### PR TITLE
feat(kernel): add SQLite task projection

### DIFF
--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -57,7 +57,7 @@ interface LocalTaskIndex {
   readonly url: string | null;
   readonly bindingCreatedAt: string;
   readonly bindingFingerprint: string;
-  readonly packageDisposition: "active" | "archived" | "deleted";
+  readonly packageDisposition: "active" | "archived" | "tombstoned";
   readonly vertical: string;
   readonly preset: string;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect";
 import { makeLocalLifecycleEngine } from "../../adapters/local/src/index.ts";
 import type { DomainStatus, EngineError, WriteError } from "../../kernel/src/domain/index.ts";
 import { isDomainStatus } from "../../kernel/src/domain/index.ts";
+import { checkTaskProjection, readTaskProjection } from "../../kernel/src/index.ts";
 
 export interface CliResult {
   readonly ok: boolean;
@@ -9,6 +10,9 @@ export interface CliResult {
   readonly taskId?: string;
   readonly status?: DomainStatus;
   readonly path?: string;
+  readonly tasks?: ReadonlyArray<unknown>;
+  readonly rows?: number;
+  readonly warnings?: ReadonlyArray<unknown>;
   readonly error?: {
     readonly code: string;
     readonly hint: string;
@@ -21,7 +25,9 @@ interface ParsedCommand {
   readonly action:
     | { readonly kind: "new-task"; readonly taskId: string; readonly title: string }
     | { readonly kind: "status-set"; readonly taskId: string; readonly status: DomainStatus }
-    | { readonly kind: "progress-append"; readonly taskId: string; readonly text: string };
+    | { readonly kind: "progress-append"; readonly taskId: string; readonly text: string }
+    | { readonly kind: "task-list" }
+    | { readonly kind: "check" };
 }
 
 export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)): Promise<number> {
@@ -37,7 +43,7 @@ export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)):
       onFailure: (error): CliResult => ({
         ok: false,
         command: parsed.value.action.kind,
-        taskId: parsed.value.action.taskId,
+        taskId: actionTaskId(parsed.value.action),
         error: toCliError(error)
       }),
       onSuccess: (value) => value
@@ -76,15 +82,43 @@ function runCommand(
     })));
   }
 
-  return engine.appendProgress({
-    taskId: command.action.taskId,
-    text: command.action.text
-  }).pipe(Effect.map((result): CliResult => ({
-    ok: true,
-    command: "progress-append",
-    taskId: result.taskId,
-    path: result.path
-  })));
+  if (command.action.kind === "progress-append") {
+    return engine.appendProgress({
+      taskId: command.action.taskId,
+      text: command.action.text
+    }).pipe(Effect.map((result): CliResult => ({
+      ok: true,
+      command: "progress-append",
+      taskId: result.taskId,
+      path: result.path
+    })));
+  }
+
+  if (command.action.kind === "task-list") {
+    return Effect.sync(() => {
+      const result = readTaskProjection({ rootDir: command.rootDir });
+      return {
+        ok: true,
+        command: "task-list",
+        tasks: result.rows,
+        warnings: result.warnings
+      } satisfies CliResult;
+    });
+  }
+
+  return Effect.sync(() => {
+    const result = checkTaskProjection({ rootDir: command.rootDir });
+    return {
+      ok: result.ok,
+      command: "check",
+      rows: result.rows.length,
+      warnings: result.warnings,
+      error: result.ok ? undefined : {
+        code: "projection_check_failed",
+        hint: "Projection cache or markdown source has contract warnings."
+      }
+    } satisfies CliResult;
+  });
 }
 
 function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] } {
@@ -147,11 +181,37 @@ function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; readonly v
     };
   }
 
+  if (args[0] === "task" && args[1] === "list") {
+    return {
+      ok: true,
+      value: {
+        rootDir,
+        json,
+        action: {
+          kind: "task-list"
+        }
+      }
+    };
+  }
+
+  if (args[0] === "check") {
+    return {
+      ok: true,
+      value: {
+        rootDir,
+        json,
+        action: {
+          kind: "check"
+        }
+      }
+    };
+  }
+
   return {
     ok: false,
     error: {
       code: "unknown_command",
-      hint: "Supported commands: new-task, task status set, task progress append."
+      hint: "Supported commands: new-task, task status set, task progress append, task list, check."
     }
   };
 }
@@ -159,6 +219,10 @@ function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; readonly v
 function readOption(argv: ReadonlyArray<string>, name: string): string | undefined {
   const index = argv.indexOf(name);
   return index >= 0 ? argv[index + 1] : undefined;
+}
+
+function actionTaskId(action: ParsedCommand["action"]): string | undefined {
+  return "taskId" in action ? action.taskId : undefined;
 }
 
 function toCliError(error: EngineError | WriteError): CliResult["error"] {
@@ -194,7 +258,7 @@ function emit(result: CliResult, json: boolean): void {
   }
 
   if (result.ok) {
-    const suffix = result.status ? ` status=${result.status}` : result.path ? ` path=${result.path}` : "";
+    const suffix = result.status ? ` status=${result.status}` : result.path ? ` path=${result.path}` : result.rows !== undefined ? ` rows=${result.rows}` : "";
     console.log(`ok command=${result.command} task=${result.taskId ?? ""}${suffix}`);
     return;
   }

--- a/packages/cli/test/local-lifecycle-cli.test.ts
+++ b/packages/cli/test/local-lifecycle-cli.test.ts
@@ -103,6 +103,90 @@ test("CLI appends progress through the write journal", () => {
   });
 });
 
+test("CLI task list reads from rebuildable SQLite projection", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["new-task", "task-1", "--title", "Task One"]);
+    rmSync(path.join(rootDir, ".projection.sqlite"), { force: true });
+
+    const result = runJson(rootDir, ["task", "list"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(Array.isArray(result.tasks), true);
+    assert.equal(result.tasks[0].taskId, "task-1");
+    assert.equal(result.tasks[0].canonicalStatus, "planned");
+    assert.equal(result.tasks[0].sourcePath, "tasks/task-1/INDEX.md");
+    assert.equal(readFileSync(path.join(rootDir, "tasks/task-1/INDEX.md"), "utf8").includes(".projection.sqlite"), false);
+  });
+});
+
+test("CLI check reports projection tampering as a stable JSON error", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["new-task", "task-1", "--title", "Task One"]);
+    runJson(rootDir, ["task", "list"]);
+    const projectionPath = path.join(rootDir, ".projection.sqlite");
+    execFileSync(process.execPath, ["--input-type=module", "-e", [
+      "import { DatabaseSync } from 'node:sqlite';",
+      `const db = new DatabaseSync(${JSON.stringify(projectionPath)});`,
+      "const row = JSON.parse(db.prepare('SELECT row_json FROM task_projection WHERE task_id = ?').get('task-1').row_json);",
+      "row.title = 'Projection Edit';",
+      "db.prepare('UPDATE task_projection SET row_json = ? WHERE task_id = ?').run(JSON.stringify(row), 'task-1');",
+      "db.close();"
+    ].join("\n")]);
+
+    const result = runJson(rootDir, ["check"], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error?.code, "projection_check_failed");
+    assert.equal(result.warnings.some((warning) => warning.code === "projection_tampered"), true);
+    assert.equal(JSON.stringify(result).includes("Projection Edit"), false);
+    assert.equal(JSON.stringify(result).includes(rootDir), false);
+  });
+});
+
+test("CLI task list does not emit tampered SQLite row content as task truth", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["new-task", "task-1", "--title", "Task One"]);
+    runJson(rootDir, ["task", "list"]);
+    const projectionPath = path.join(rootDir, ".projection.sqlite");
+    execFileSync(process.execPath, ["--input-type=module", "-e", [
+      "import { DatabaseSync } from 'node:sqlite';",
+      `const db = new DatabaseSync(${JSON.stringify(projectionPath)});`,
+      "const row = JSON.parse(db.prepare('SELECT row_json FROM task_projection WHERE task_id = ?').get('task-1').row_json);",
+      "row.title = 'SQLite Lie';",
+      "db.prepare('UPDATE task_projection SET row_json = ? WHERE task_id = ?').run(JSON.stringify(row), 'task-1');",
+      "db.close();"
+    ].join("\n")]);
+
+    const result = runJson(rootDir, ["task", "list"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.tasks[0].title, "Task One");
+    assert.equal(result.warnings.some((warning) => warning.code === "projection_tampered"), true);
+    assert.equal(JSON.stringify(result).includes("SQLite Lie"), false);
+  });
+});
+
+test("CLI check reports corrupted projection without crashing or leaking root", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["new-task", "task-1", "--title", "Task One"]);
+    runJson(rootDir, ["task", "list"]);
+    const projectionPath = path.join(rootDir, ".projection.sqlite");
+    execFileSync(process.execPath, ["--input-type=module", "-e", [
+      "import { DatabaseSync } from 'node:sqlite';",
+      `const db = new DatabaseSync(${JSON.stringify(projectionPath)});`,
+      "db.prepare('UPDATE task_projection SET row_json = ? WHERE task_id = ?').run('{bad-json', 'task-1');",
+      "db.close();"
+    ].join("\n")]);
+
+    const result = runJson(rootDir, ["check"], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error?.code, "projection_check_failed");
+    assert.equal(result.warnings.some((warning) => warning.code === "projection_tampered"), true);
+    assert.equal(JSON.stringify(result).includes(rootDir), false);
+  });
+});
+
 function withTempRoot<T>(fn: (rootDir: string) => T): T {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-cli-"));
   try {

--- a/packages/kernel/fixtures/schemas/sqlite-task-row/invalid.json
+++ b/packages/kernel/fixtures/schemas/sqlite-task-row/invalid.json
@@ -3,9 +3,13 @@
   "taskId": "2026-06-11-kr-01-harness-infrastructure",
   "title": "Harness infrastructure baseline",
   "canonicalStatus": "paused",
+  "coordinationStatus": "open",
+  "rawStatus": "paused",
   "packageDisposition": "active",
+  "closeoutReadiness": "not_required",
   "lifecycleEngine": "local",
   "freshness": "fresh",
   "updatedAt": "2026-06-11T00:03:00.000Z",
+  "source": "local-document",
   "sourcePath": "planning/modules/kernel-rewrite/tasks/2026-06-11-kr-01-harness-infrastructure/task_plan.md"
 }

--- a/packages/kernel/fixtures/schemas/sqlite-task-row/valid.json
+++ b/packages/kernel/fixtures/schemas/sqlite-task-row/valid.json
@@ -3,9 +3,13 @@
   "taskId": "2026-06-11-kr-01-harness-infrastructure",
   "title": "Harness infrastructure baseline",
   "canonicalStatus": "active",
+  "coordinationStatus": "open",
+  "rawStatus": "active",
   "packageDisposition": "active",
+  "closeoutReadiness": "not_required",
   "lifecycleEngine": "local",
   "freshness": "fresh",
   "updatedAt": "2026-06-11T00:03:00.000Z",
+  "source": "local-document",
   "sourcePath": "planning/modules/kernel-rewrite/tasks/2026-06-11-kr-01-harness-infrastructure/task_plan.md"
 }

--- a/packages/kernel/schemas/json/sqlite-task-row.schema.json
+++ b/packages/kernel/schemas/json/sqlite-task-row.schema.json
@@ -4,16 +4,20 @@
   "x-harness-schema-id": "sqlite-task-row",
   "title": "SQLite Task Row",
   "type": "object",
-  "required": ["schema", "taskId", "title", "canonicalStatus", "packageDisposition", "lifecycleEngine", "freshness", "updatedAt", "sourcePath"],
+  "required": ["schema", "taskId", "title", "canonicalStatus", "coordinationStatus", "rawStatus", "packageDisposition", "closeoutReadiness", "lifecycleEngine", "freshness", "updatedAt", "source", "sourcePath"],
   "properties": {
     "schema": { "const": "sqlite-task-row/v1" },
     "taskId": { "type": "string" },
     "title": { "type": "string" },
     "canonicalStatus": { "enum": ["planned", "active", "blocked", "in_review", "done", "cancelled", "unknown"] },
+    "coordinationStatus": { "enum": ["open", "blocked", "in_review", "terminal", "unknown"] },
+    "rawStatus": { "type": "string" },
     "packageDisposition": { "enum": ["active", "archived", "tombstoned"] },
+    "closeoutReadiness": { "enum": ["not_required", "missing", "incomplete", "ready", "passed", "failed"] },
     "lifecycleEngine": { "type": "string" },
     "freshness": { "enum": ["fresh", "stale-but-usable", "unavailable-no-cache"] },
     "updatedAt": { "type": "string" },
+    "source": { "enum": ["local-document", "external-engine", "snapshot-cache"] },
     "sourcePath": { "type": "string" }
   }
 }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./domain/index.ts";
 export * from "./ports/index.ts";
+export * from "./projection/sqlite-task-projection.ts";
 export * from "./schemas/registry.ts";

--- a/packages/kernel/src/projection/sqlite-task-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-projection.ts
@@ -1,0 +1,301 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import path from "node:path";
+import type { CloseoutReadiness, DomainStatus, PackageDisposition } from "../domain/index.ts";
+import { isDomainStatus, isPackageDisposition, isTerminalStatus } from "../domain/index.ts";
+
+export type ProjectionFreshness = "fresh" | "stale-but-usable" | "unavailable-no-cache";
+export type ProjectionSource = "local-document" | "external-engine" | "snapshot-cache";
+export type ProjectionCanonicalStatus = DomainStatus | "unknown";
+export type CoordinationStatus = "open" | "blocked" | "in_review" | "terminal" | "unknown";
+export type ProjectionWarningCode = "projection_missing" | "projection_stale" | "projection_tampered" | "source_malformed";
+
+export interface TaskProjectionRow {
+  readonly schema: "sqlite-task-row/v1";
+  readonly taskId: string;
+  readonly title: string;
+  readonly canonicalStatus: ProjectionCanonicalStatus;
+  readonly coordinationStatus: CoordinationStatus;
+  readonly rawStatus: string;
+  readonly packageDisposition: PackageDisposition;
+  readonly closeoutReadiness: CloseoutReadiness;
+  readonly lifecycleEngine: string;
+  readonly freshness: ProjectionFreshness;
+  readonly updatedAt: string;
+  readonly source: ProjectionSource;
+  readonly sourcePath: string;
+}
+
+export interface ProjectionWarning {
+  readonly code: ProjectionWarningCode;
+  readonly message: string;
+}
+
+export interface ProjectionReadResult {
+  readonly rows: ReadonlyArray<TaskProjectionRow>;
+  readonly warnings: ReadonlyArray<ProjectionWarning>;
+}
+
+export interface ProjectionCheckResult extends ProjectionReadResult {
+  readonly ok: boolean;
+  readonly projectionPath: string;
+}
+
+export interface TaskProjectionOptions {
+  readonly rootDir: string;
+  readonly projectionPath?: string;
+}
+
+interface ProjectionMeta {
+  readonly sourceHash: string;
+  readonly rowsHash: string;
+}
+
+const projectionVersion = "task-projection/v1";
+
+export function defaultTaskProjectionPath(rootDir: string): string {
+  return path.join(path.resolve(rootDir), ".projection.sqlite");
+}
+
+export function rebuildTaskProjection(options: TaskProjectionOptions): ProjectionReadResult {
+  const rootDir = path.resolve(options.rootDir);
+  const projectionPath = options.projectionPath ? path.resolve(options.projectionPath) : defaultTaskProjectionPath(rootDir);
+  const source = readMarkdownSource(rootDir);
+  const rows = source.entries.map((entry) => taskEntryToRow(rootDir, entry)).sort(compareRows);
+  const rowsHash = hashRows(rows);
+  writeProjectionDatabase(projectionPath, rows, {
+    sourceHash: source.hash,
+    rowsHash
+  });
+  return {
+    rows,
+    warnings: source.warnings
+  };
+}
+
+export function readTaskProjection(options: TaskProjectionOptions): ProjectionReadResult {
+  const rootDir = path.resolve(options.rootDir);
+  const projectionPath = options.projectionPath ? path.resolve(options.projectionPath) : defaultTaskProjectionPath(rootDir);
+  const source = readMarkdownSource(rootDir);
+  const warnings = [...source.warnings];
+
+  if (!existsSync(projectionPath)) {
+    warnings.push({ code: "projection_missing", message: "Projection cache was missing and has been rebuilt." });
+    const rebuilt = rebuildTaskProjection({ rootDir, projectionPath });
+    return { rows: rebuilt.rows, warnings };
+  }
+
+  const existing = tryReadProjectionDatabase(projectionPath);
+  if (!existing.ok) {
+    warnings.push({ code: "projection_tampered", message: "Projection cache could not be read and has been rebuilt from markdown." });
+    const rebuilt = rebuildTaskProjection({ rootDir, projectionPath });
+    return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
+  }
+
+  if (existing.meta.sourceHash !== source.hash) {
+    warnings.push({ code: "projection_stale", message: "Projection cache was stale and has been rebuilt from markdown." });
+    const rebuilt = rebuildTaskProjection({ rootDir, projectionPath });
+    return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
+  }
+
+  const actualRowsHash = hashRows(existing.rows);
+  if (existing.meta.rowsHash !== actualRowsHash) {
+    warnings.push({ code: "projection_tampered", message: "Projection rows no longer match their recorded hash." });
+    const rebuilt = rebuildTaskProjection({ rootDir, projectionPath });
+    return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
+  }
+
+  return {
+    rows: [...existing.rows].sort(compareRows),
+    warnings
+  };
+}
+
+export function checkTaskProjection(options: TaskProjectionOptions): ProjectionCheckResult {
+  const rootDir = path.resolve(options.rootDir);
+  const projectionPath = options.projectionPath ? path.resolve(options.projectionPath) : defaultTaskProjectionPath(rootDir);
+  const result = readTaskProjection({ rootDir, projectionPath });
+  return {
+    ok: result.warnings.every((warning) => warning.code !== "projection_tampered" && warning.code !== "source_malformed"),
+    projectionPath,
+    rows: result.rows,
+    warnings: result.warnings
+  };
+}
+
+function writeProjectionDatabase(projectionPath: string, rows: ReadonlyArray<TaskProjectionRow>, meta: ProjectionMeta): void {
+  mkdirSync(path.dirname(projectionPath), { recursive: true });
+  const tempPath = `${projectionPath}.${process.pid}.${Date.now()}.tmp`;
+  rmSync(tempPath, { force: true });
+  const db = new DatabaseSync(tempPath);
+  try {
+    db.exec([
+      "PRAGMA journal_mode = DELETE",
+      "CREATE TABLE projection_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+      [
+        "CREATE TABLE task_projection (",
+        "  task_id TEXT PRIMARY KEY,",
+        "  row_json TEXT NOT NULL",
+        ")"
+      ].join("\n")
+    ].join(";\n"));
+    const insertMeta = db.prepare("INSERT INTO projection_meta (key, value) VALUES (?, ?)");
+    insertMeta.run("version", projectionVersion);
+    insertMeta.run("sourceHash", meta.sourceHash);
+    insertMeta.run("rowsHash", meta.rowsHash);
+    const insertRow = db.prepare("INSERT INTO task_projection (task_id, row_json) VALUES (?, ?)");
+    for (const row of rows) {
+      insertRow.run(row.taskId, JSON.stringify(row));
+    }
+  } finally {
+    db.close();
+  }
+  renameSync(tempPath, projectionPath);
+}
+
+function readProjectionDatabase(projectionPath: string): { readonly rows: ReadonlyArray<TaskProjectionRow>; readonly meta: ProjectionMeta } {
+  const db = new DatabaseSync(projectionPath, { readOnly: true });
+  try {
+    const metaRows = db.prepare("SELECT key, value FROM projection_meta").all() as unknown as ReadonlyArray<{ key: string; value: string }>;
+    const meta = new Map(metaRows.map((row) => [row.key, row.value]));
+    const rowRecords = db.prepare("SELECT row_json FROM task_projection ORDER BY task_id").all() as unknown as ReadonlyArray<{ row_json: string }>;
+    return {
+      meta: {
+        sourceHash: meta.get("sourceHash") ?? "",
+        rowsHash: meta.get("rowsHash") ?? ""
+      },
+      rows: rowRecords.map((record) => JSON.parse(record.row_json) as TaskProjectionRow)
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function tryReadProjectionDatabase(
+  projectionPath: string
+): { readonly ok: true; readonly rows: ReadonlyArray<TaskProjectionRow>; readonly meta: ProjectionMeta } | { readonly ok: false } {
+  try {
+    return {
+      ok: true,
+      ...readProjectionDatabase(projectionPath)
+    };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readMarkdownSource(rootDir: string): {
+  readonly entries: ReadonlyArray<TaskSourceEntry>;
+  readonly hash: string;
+  readonly warnings: ReadonlyArray<ProjectionWarning>;
+} {
+  const tasksDir = path.join(rootDir, "tasks");
+  if (!existsSync(tasksDir)) {
+    return { entries: [], hash: hashText("[]"), warnings: [] };
+  }
+
+  const warnings: ProjectionWarning[] = [];
+  const entries: TaskSourceEntry[] = [];
+  for (const name of readdirSync(tasksDir).sort()) {
+    const indexPath = path.join(tasksDir, name, "INDEX.md");
+    if (!existsSync(indexPath)) continue;
+    const body = readFileSync(indexPath, "utf8");
+    try {
+      entries.push({
+        taskId: name,
+        indexPath,
+        body,
+        frontmatter: parseFrontmatter(body)
+      });
+    } catch (error) {
+      warnings.push({
+        code: "source_malformed",
+        message: error instanceof Error ? error.message : `Malformed task package: ${name}`
+      });
+    }
+  }
+
+  return {
+    entries,
+    hash: hashText(JSON.stringify(entries.map((entry) => ({
+      taskId: entry.taskId,
+      sourcePath: sourcePath(rootDir, entry.indexPath),
+      body: entry.body
+    })))),
+    warnings
+  };
+}
+
+interface TaskSourceEntry {
+  readonly taskId: string;
+  readonly indexPath: string;
+  readonly body: string;
+  readonly frontmatter: string;
+}
+
+function taskEntryToRow(rootDir: string, entry: TaskSourceEntry): TaskProjectionRow {
+  const rawStatus = readScalar(entry.frontmatter, "  status") || "unknown";
+  const canonicalStatus = isDomainStatus(rawStatus) ? rawStatus : "unknown";
+  const rawDisposition = readScalar(entry.frontmatter, "packageDisposition") || "active";
+  const packageDisposition = isPackageDisposition(rawDisposition) ? rawDisposition : "active";
+  const lifecycleEngine = readScalar(entry.frontmatter, "  engine") || "local";
+  const source = sourcePath(rootDir, entry.indexPath);
+  return {
+    schema: "sqlite-task-row/v1",
+    taskId: readScalar(entry.frontmatter, "task_id") || entry.taskId,
+    title: readScalar(entry.frontmatter, "title") || entry.taskId,
+    canonicalStatus,
+    coordinationStatus: coordinationStatus(canonicalStatus),
+    rawStatus,
+    packageDisposition,
+    closeoutReadiness: closeoutReadiness(rootDir, entry.taskId, canonicalStatus),
+    lifecycleEngine,
+    freshness: canonicalStatus === "unknown" || !isPackageDisposition(rawDisposition) ? "stale-but-usable" : "fresh",
+    updatedAt: statSync(entry.indexPath).mtime.toISOString(),
+    source: lifecycleEngine === "local" ? "local-document" : "external-engine",
+    sourcePath: source
+  };
+}
+
+function parseFrontmatter(body: string): string {
+  const frontmatter = body.match(/^---\n([\s\S]*?)\n---/u)?.[1];
+  if (!frontmatter) throw new Error("INDEX.md missing frontmatter");
+  return frontmatter;
+}
+
+function readScalar(frontmatter: string, key: string): string {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return frontmatter.match(new RegExp(`^${escaped}:\\s*(.*)$`, "mu"))?.[1]?.trim() ?? "";
+}
+
+function coordinationStatus(status: ProjectionCanonicalStatus): CoordinationStatus {
+  if (status === "unknown") return "unknown";
+  if (status === "blocked") return "blocked";
+  if (status === "in_review") return "in_review";
+  return isTerminalStatus(status) ? "terminal" : "open";
+}
+
+function closeoutReadiness(rootDir: string, taskId: string, status: ProjectionCanonicalStatus): CloseoutReadiness {
+  if (status === "unknown") return "missing";
+  if (!isTerminalStatus(status) && status !== "in_review") return "not_required";
+  const taskDir = path.join(rootDir, "tasks", taskId);
+  if (existsSync(path.join(taskDir, "walkthrough.md")) || existsSync(path.join(taskDir, "closeout.md"))) return "ready";
+  return "missing";
+}
+
+function sourcePath(rootDir: string, filePath: string): string {
+  return path.relative(rootDir, filePath).split(path.sep).join("/");
+}
+
+function hashRows(rows: ReadonlyArray<TaskProjectionRow>): string {
+  return hashText(JSON.stringify([...rows].sort(compareRows)));
+}
+
+function hashText(text: string): string {
+  return `sha256:${createHash("sha256").update(text).digest("hex")}`;
+}
+
+function compareRows(a: TaskProjectionRow, b: TaskProjectionRow): number {
+  return a.taskId.localeCompare(b.taskId);
+}

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -158,10 +158,14 @@ export const SqliteTaskRowSchema = Schema.Struct({
   taskId: Schema.String,
   title: Schema.String,
   canonicalStatus: SnapshotStatusSchema,
+  coordinationStatus: Schema.Literal("open", "blocked", "in_review", "terminal", "unknown"),
+  rawStatus: Schema.String,
   packageDisposition: Schema.Literal(...packageDispositions),
+  closeoutReadiness: Schema.Literal("not_required", "missing", "incomplete", "ready", "passed", "failed"),
   lifecycleEngine: Schema.String,
   freshness: FreshnessSchema,
   updatedAt: Schema.String,
+  source: Schema.Literal("local-document", "external-engine", "snapshot-cache"),
   sourcePath: Schema.String
 });
 

--- a/packages/kernel/test/store/sqlite-rebuild.test.ts
+++ b/packages/kernel/test/store/sqlite-rebuild.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { rmSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { Effect } from "effect";
+import { checkTaskProjection, readTaskProjection, rebuildTaskProjection } from "../../src/index.ts";
 import { makeJournaledWriteCoordinator, makeMarkdownArtifactStore } from "../../src/store/index.ts";
 import { docWrite, withTempStore } from "./helpers.ts";
 
@@ -22,3 +24,116 @@ test("markdown artifact store remains the rebuildable source of truth without SQ
     assert.equal(taskPackage.documents[0]?.body, "# Task");
   });
 });
+
+test("SQLite task projection rebuild is deterministic after cache deletion", () => {
+  withTempStore((rootDir) => {
+    writeIndex(rootDir, "task-1", "Task One", "active");
+    writeIndex(rootDir, "task-2", "Task Two", "done");
+    writeFileSync(path.join(rootDir, "tasks/task-2/walkthrough.md"), "# Closeout\n");
+
+    const first = rebuildTaskProjection({ rootDir }).rows;
+    rmSync(path.join(rootDir, ".projection.sqlite"), { force: true });
+    const second = rebuildTaskProjection({ rootDir }).rows;
+
+    assert.deepEqual(second, first);
+    assert.equal(second[0]?.sourcePath, "tasks/task-1/INDEX.md");
+    assert.equal(second[0]?.source, "local-document");
+    assert.equal(second[1]?.closeoutReadiness, "ready");
+  });
+});
+
+test("task projection auto-rebuilds when markdown source changes", () => {
+  withTempStore((rootDir) => {
+    writeIndex(rootDir, "task-1", "Task One", "planned");
+    rebuildTaskProjection({ rootDir });
+    writeIndex(rootDir, "task-1", "Task One", "active");
+
+    const result = readTaskProjection({ rootDir });
+
+    assert.equal(result.rows[0]?.canonicalStatus, "active");
+    assert.equal(result.warnings.some((warning) => warning.code === "projection_stale"), true);
+  });
+});
+
+test("generated SQLite edits are reported and rebuilt from markdown truth", () => {
+  withTempStore((rootDir) => {
+    writeIndex(rootDir, "task-1", "Task One", "active");
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".projection.sqlite");
+    const db = new DatabaseSync(projectionPath);
+    try {
+      const row = JSON.parse(db.prepare("SELECT row_json FROM task_projection WHERE task_id = ?").get("task-1").row_json as string) as Record<string, unknown>;
+      row.title = "Edited In Projection";
+      db.prepare("UPDATE task_projection SET row_json = ? WHERE task_id = ?").run(JSON.stringify(row), "task-1");
+    } finally {
+      db.close();
+    }
+
+    const result = checkTaskProjection({ rootDir });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.rows[0]?.title, "Task One");
+    assert.equal(result.warnings.some((warning) => warning.code === "projection_tampered"), true);
+    assert.equal(readFileSync(path.join(rootDir, "tasks/task-1/INDEX.md"), "utf8").includes("Edited In Projection"), false);
+  });
+});
+
+test("corrupted SQLite projection is reported with a stable warning and rebuilt from markdown", () => {
+  withTempStore((rootDir) => {
+    writeIndex(rootDir, "task-1", "Task One", "active");
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".projection.sqlite");
+    const db = new DatabaseSync(projectionPath);
+    try {
+      db.prepare("UPDATE task_projection SET row_json = ? WHERE task_id = ?").run("{bad-json", "task-1");
+    } finally {
+      db.close();
+    }
+
+    const result = checkTaskProjection({ rootDir });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.rows[0]?.title, "Task One");
+    assert.equal(result.warnings.some((warning) => warning.code === "projection_tampered"), true);
+  });
+});
+
+test("malformed task source is a checker error and not authored by projection reads", () => {
+  withTempStore((rootDir) => {
+    mkdirSync(path.join(rootDir, "tasks/bad-task"), { recursive: true });
+    writeFileSync(path.join(rootDir, "tasks/bad-task/INDEX.md"), "# Missing frontmatter\n");
+
+    const result = checkTaskProjection({ rootDir });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.rows.length, 0);
+    assert.equal(result.warnings.some((warning) => warning.code === "source_malformed"), true);
+    assert.equal(readFileSync(path.join(rootDir, "tasks/bad-task/INDEX.md"), "utf8"), "# Missing frontmatter\n");
+  });
+});
+
+function writeIndex(rootDir: string, taskId: string, title: string, status: string): void {
+  mkdirSync(path.join(rootDir, "tasks", taskId), { recursive: true });
+  writeFileSync(path.join(rootDir, "tasks", taskId, "INDEX.md"), [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    `title: ${title}`,
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    `  status: ${status}`,
+    "  ref: ",
+    `  titleSnapshot: ${title}`,
+    "  url: ",
+    "  bindingCreatedAt: 2026-06-12T00:00:00.000Z",
+    "  bindingFingerprint: sha256:fixture",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "---",
+    "",
+    `# ${title}`,
+    ""
+  ].join("\n"));
+}

--- a/tools/check-implementation-contracts.mjs
+++ b/tools/check-implementation-contracts.mjs
@@ -125,6 +125,7 @@ const hasStoreImplementation = files.some((file) => /packages\/kernel\/src\/stor
 const hasPublishImplementation = files.some((file) => /packages\/(?:kernel|cli|gui)\/src\/.*publish/i.test(relative(file)));
 const hasLocalLifecycleImplementation = files.some((file) => relative(file) === "packages/adapters/local/src/index.ts")
   && !readFileSync(path.join(root, "packages/adapters/local/src/index.ts"), "utf8").trim().startsWith("export {}");
+const hasTaskProjectionImplementation = files.some((file) => relative(file) === "packages/kernel/src/projection/sqlite-task-projection.ts");
 for (const [kind, active] of Object.entries({ gui: hasGuiImplementation, store: hasStoreImplementation, publish: hasPublishImplementation })) {
   if (!active) continue;
   for (const requiredPath of expectedRuntimeTestFiles[kind]) {
@@ -192,6 +193,37 @@ if (hasLocalLifecycleImplementation) {
   const cliTestText = existsSync(path.join(root, cliTestPath)) ? readFileSync(path.join(root, cliTestPath), "utf8") : "";
   if (!/missing task errors do not leak local root paths|includes\(rootDir\)/.test(cliTestText)) {
     record("local lifecycle CLI tests must prove missing task errors do not leak local root paths");
+  }
+}
+
+if (hasTaskProjectionImplementation) {
+  const projectionText = readFileSync(path.join(root, "packages/kernel/src/projection/sqlite-task-projection.ts"), "utf8");
+  const rebuildTestText = readFileSync(path.join(root, "packages/kernel/test/store/sqlite-rebuild.test.ts"), "utf8");
+  const cliTestText = readFileSync(path.join(root, "packages/cli/test/local-lifecycle-cli.test.ts"), "utf8");
+  for (const requiredSnippet of [
+    "DatabaseSync",
+    "rebuildTaskProjection",
+    "projection_tampered",
+    "sourceHash",
+    "rowsHash",
+    "closeoutReadiness",
+    "coordinationStatus"
+  ]) {
+    if (!projectionText.includes(requiredSnippet)) {
+      record(`task projection implementation must include ${requiredSnippet}`);
+    }
+  }
+  if (!/SQLite task projection rebuild is deterministic after cache deletion|rmSync\(path\.join\(rootDir, "\.projection\.sqlite"\)/.test(rebuildTestText)) {
+    record("task projection tests must prove deleting SQLite and rebuilding preserves read output");
+  }
+  if (!/generated SQLite edits are reported and rebuilt from markdown truth|projection_tampered/.test(rebuildTestText)) {
+    record("task projection tests must prove hand-edited generated projection is reported");
+  }
+  if (!/CLI task list reads from rebuildable SQLite projection|CLI check reports projection tampering|CLI task list does not emit tampered SQLite row content as task truth/.test(cliTestText)) {
+    record("CLI tests must cover task list and check over the SQLite projection");
+  }
+  if (/writeFileSync\s*\([^)]*tasks\//s.test(projectionText) || /renameSync\s*\([^)]*tasks\//s.test(projectionText)) {
+    record("task projection must not write authored task documents");
   }
 }
 


### PR DESCRIPTION
## Summary

Add KR-05 SQLite task projection and CLI read/check surfaces. Markdown task packages remain the authored source of truth; `.projection.sqlite` is a generated read model that can be deleted, rebuilt, and checked for tampering.

## What Changed

- Added Node `node:sqlite` backed task projection rebuild/read/check API.
- Added projection source/row hashes, stale rebuild, and tamper rebuild behavior.
- Added CLI `task list` and `check` commands over the projection.
- Expanded SQLite task row schema with lifecycleStatus dashboard fields.
- Added kernel and CLI regression coverage for rebuild, stale source, tamper, corrupted projection, malformed source, and no authored writes.
- Added implementation contract checks for KR-05 projection requirements.

## Task And Scope

- Harness task: KR-05 SQLite projection / check / list
- Branch: `codex/kr-05-sqlite-projection`
- Public scope: kernel projection, CLI read/check commands, schema fixtures, contract tests
- Private planning/evidence updated: yes
- Out of scope: GUI rendering, external adapter adoption/write, publishNote, npm publish

## Version Impact

- Version: no version change because this is pre-release rewrite work
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: `ebfe1391f3383f28bb1419f08c8f957021ea2e95`
- Branch merge-base with `origin/main`: `ebfe1391f3383f28bb1419f08c8f957021ea2e95`
- Last `git fetch origin` time: `2026-06-11T17:59:59Z`
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: pending private closeout; `planning/modules/kernel-rewrite/tasks/2026-06-12-kr-05-sqlite-projection-check-list/artifacts/local-check-2026-06-12.txt`
- Reviewer evidence path: `planning/modules/kernel-rewrite/tasks/2026-06-12-kr-05-sqlite-projection-check-list/artifacts/reviewer-goodall-kr05-2026-06-12.txt`
- GitHub Actions `rewrite-ci` run URL: pending PR CI
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` was not rerun because package dependencies and lockfile were unchanged; package policy gate passed.

## Review Evidence

- Self-review: fixed corrupted projection handling before reviewer closeout; full check passed with 46 tests.
- Reviewer subagent: Goodall found KR05-R1 P1; fixed and re-reviewed closed. No remaining P0/P1/P2.
- Human review: pending.
- Blocking findings: none open.

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [ ] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear: squash merge after CI, then delete remote branch and remove local worktree.

## Residual Risk

- `node:sqlite` is used from the required Node >=24 runtime; CI verifies availability.
- Projection check warns on missing/stale/tampered cache; only tampered/malformed source makes `check` fail.

## References

- Task: KR-05 SQLite projection / check / list
- Evidence: private KR-05 local-check artifact
- Review: private Goodall KR-05 reviewer artifact

---

## 摘要

新增 KR-05 SQLite task projection 以及 CLI 读模型 / 检查入口。Markdown task package 仍然是 authored SSoT；`.projection.sqlite` 只是可删除、可重建、可检查篡改的生成读模型。

## 改动内容

- 新增基于 Node `node:sqlite` 的 task projection rebuild/read/check API。
- 新增 source/row hash、stale rebuild、tamper rebuild 行为。
- 新增 CLI `task list` 和 `check`。
- 扩展 SQLite task row schema，包含 lifecycleStatus dashboard 字段。
- 增加 rebuild、stale、tamper、corrupt、malformed source、no authored write 回归测试。
- 增加 KR-05 projection 实现合同检查。

## 任务与范围

- Harness 任务：KR-05 SQLite projection / check / list
- 分支：`codex/kr-05-sqlite-projection`
- 公开范围：kernel projection、CLI read/check、schema fixtures、contract tests
- 私有计划 / 证据是否已更新：yes
- 范围外：GUI rendering、external adapter adoption/write、publishNote、npm publish

## 版本影响

- 版本：不改版本，原因是 pre-release rewrite work
- 发布影响：不发布

## 验证

- `origin/main` 基准 SHA：`ebfe1391f3383f28bb1419f08c8f957021ea2e95`
- 当前分支与 `origin/main` 的 merge-base：`ebfe1391f3383f28bb1419f08c8f957021ea2e95`
- 最近一次 `git fetch origin` 时间：`2026-06-11T17:59:59Z`
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：pending private closeout；`planning/modules/kernel-rewrite/tasks/2026-06-12-kr-05-sqlite-projection-check-list/artifacts/local-check-2026-06-12.txt`
- Reviewer 证据路径：`planning/modules/kernel-rewrite/tasks/2026-06-12-kr-05-sqlite-projection-check-list/artifacts/reviewer-goodall-kr05-2026-06-12.txt`
- GitHub Actions `rewrite-ci` run URL：pending PR CI
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci`，原因是依赖和 lockfile 未变；package policy gate 已通过。

## 审查证据

- 自查：补上 corrupted projection 稳定错误处理，full check 46 tests passed。
- Reviewer subagent：Goodall 发现 KR05-R1 P1；修复后复审关闭。无剩余 P0/P1/P2。
- 人工审查：pending。
- 阻塞发现：无 open blocker。

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [ ] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚：CI 通过后 squash merge，删除远端分支并移除本地 worktree。

## 残余风险

- 使用要求 Node >=24 的 `node:sqlite`，由 CI 验证可用性。
- Projection check 对 missing/stale/tampered cache 产出 warning；只有 tampered/malformed source 使 `check` fail。

## 关联材料

- 任务：KR-05 SQLite projection / check / list
- 证据：private KR-05 local-check artifact
- 审查：private Goodall KR-05 reviewer artifact
