### PR TITLE
feat(kernel): add publish safety projection

### DIFF
--- a/packages/kernel/fixtures/schemas/publishable-projection/invalid.json
+++ b/packages/kernel/fixtures/schemas/publishable-projection/invalid.json
@@ -1,8 +1,15 @@
 {
   "visibility": "private",
+  "sourceTaskId": "2026-06-12-invalid",
   "title": "Invalid projection",
   "summary": "This should not decode.",
   "links": [],
+  "readiness": {
+    "closeoutReadiness": "missing",
+    "reviewGate": "missing",
+    "ciGate": "missing",
+    "evidenceLinks": []
+  },
   "redactionReport": {
     "scannerVersion": "redaction-fixture/v1",
     "findings": [],

--- a/packages/kernel/fixtures/schemas/publishable-projection/valid.json
+++ b/packages/kernel/fixtures/schemas/publishable-projection/valid.json
@@ -1,5 +1,6 @@
 {
   "visibility": "public-safe",
+  "sourceTaskId": "2026-06-12-kr-01-harness-infrastructure",
   "title": "Harness infrastructure baseline",
   "summary": "Public-safe summary of the baseline gates and remaining residuals.",
   "links": [
@@ -9,6 +10,18 @@
       "kind": "commit"
     }
   ],
+  "readiness": {
+    "closeoutReadiness": "passed",
+    "reviewGate": "passed",
+    "ciGate": "passed",
+    "evidenceLinks": [
+      {
+        "label": "Review evidence",
+        "href": "https://example.invalid/pull/1",
+        "kind": "review"
+      }
+    ]
+  },
   "redactionReport": {
     "scannerVersion": "redaction-fixture/v1",
     "findings": [],

--- a/packages/kernel/schemas/json/publishable-projection.schema.json
+++ b/packages/kernel/schemas/json/publishable-projection.schema.json
@@ -4,13 +4,73 @@
   "x-harness-schema-id": "publishable-projection",
   "title": "Publishable Projection",
   "type": "object",
-  "required": ["visibility", "title", "summary", "links", "redactionReport", "idempotencyKey"],
+  "additionalProperties": false,
+  "required": ["visibility", "sourceTaskId", "title", "summary", "links", "readiness", "redactionReport", "idempotencyKey"],
   "properties": {
     "visibility": { "const": "public-safe" },
+    "sourceTaskId": { "type": "string" },
     "title": { "type": "string" },
     "summary": { "type": "string" },
-    "links": { "type": "array" },
-    "redactionReport": { "type": "object" },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["label", "href", "kind"],
+        "properties": {
+          "label": { "type": "string" },
+          "href": { "type": "string" },
+          "kind": { "enum": ["artifact", "commit", "review"] }
+        }
+      }
+    },
+    "readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["closeoutReadiness", "reviewGate", "ciGate", "evidenceLinks"],
+      "properties": {
+        "closeoutReadiness": { "const": "passed" },
+        "reviewGate": { "const": "passed" },
+        "ciGate": { "const": "passed" },
+        "evidenceLinks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["label", "href", "kind"],
+            "properties": {
+              "label": { "type": "string" },
+              "href": { "type": "string" },
+              "kind": { "enum": ["artifact", "commit", "review"] }
+            }
+          }
+        }
+      }
+    },
+    "redactionReport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scannerVersion", "findings", "passed"],
+      "properties": {
+        "scannerVersion": { "type": "string" },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["ruleId", "severity", "message"],
+            "properties": {
+              "ruleId": { "type": "string" },
+              "severity": { "enum": ["info", "warning", "error"] },
+              "message": { "type": "string" },
+              "path": { "type": "string" }
+            }
+          }
+        },
+        "passed": { "const": true }
+      }
+    },
     "idempotencyKey": { "type": "string" }
   }
 }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./domain/index.ts";
 export * from "./ports/index.ts";
+export * from "./publish/index.ts";
 export * from "./projection/sqlite-task-projection.ts";
 export * from "./schemas/registry.ts";

--- a/packages/kernel/src/publish/index.ts
+++ b/packages/kernel/src/publish/index.ts
@@ -1,0 +1,1 @@
+export * from "./publish-safety.ts";

--- a/packages/kernel/src/publish/publish-safety.ts
+++ b/packages/kernel/src/publish/publish-safety.ts
@@ -1,0 +1,259 @@
+import { createHash } from "node:crypto";
+import type { PublishableProjection } from "../schemas/registry.ts";
+
+export type PublishProjectionRejectionCode =
+  | "redaction_failed"
+  | "closeout_not_ready"
+  | "duplicate_publish";
+
+export interface PublishableLink {
+  readonly label: string;
+  readonly href: string;
+  readonly kind: "artifact" | "commit" | "review";
+}
+
+export interface PublishReadinessEvidence {
+  readonly closeoutReadiness: "passed" | "ready" | "missing" | "incomplete" | "failed";
+  readonly reviewGate: "passed" | "missing" | "failed";
+  readonly ciGate: "passed" | "missing" | "failed";
+  readonly evidenceLinks: ReadonlyArray<PublishableLink>;
+}
+
+export interface PublishProjectionInput {
+  readonly sourceTaskId: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly links: ReadonlyArray<PublishableLink>;
+  readonly readiness: PublishReadinessEvidence;
+}
+
+export interface PublishProjectionRejection {
+  readonly ok: false;
+  readonly code: PublishProjectionRejectionCode;
+  readonly findings: ReadonlyArray<PublishRedactionFinding>;
+}
+
+export interface PublishProjectionSuccess {
+  readonly ok: true;
+  readonly projection: PublishableProjection;
+}
+
+export type PublishProjectionResult = PublishProjectionSuccess | PublishProjectionRejection;
+
+export interface PublishIdempotencyLedger {
+  readonly has: (key: string) => boolean;
+  readonly record: (key: string) => void;
+}
+
+export interface PublishRedactionFinding {
+  readonly ruleId: string;
+  readonly severity: "info" | "warning" | "error";
+  readonly message: string;
+  readonly path?: string;
+}
+
+const scannerVersion = "publish-redaction/v1";
+
+const privateTextPatterns: ReadonlyArray<{
+  readonly ruleId: string;
+  readonly pattern: RegExp;
+  readonly message: string;
+}> = [
+  {
+    ruleId: "private-harness-path",
+    pattern: /\.harness-private/u,
+    message: "Private harness paths are not publishable."
+  },
+  {
+    ruleId: "absolute-local-path",
+    pattern: /(?:^|[\s(["'=])\/(?:Users|Volumes|tmp|var|private|home|root|opt|etc)(?:\/|$)[^\s)"']*/u,
+    message: "Absolute local filesystem paths are not publishable."
+  },
+  {
+    ruleId: "file-uri-local-path",
+    pattern: /\bfile:\/\/\/[^\s)"']+/u,
+    message: "Local file URIs are not publishable."
+  },
+  {
+    ruleId: "windows-local-path",
+    pattern: /(?:^|[\s(["'=])[A-Za-z]:\\[^\s)"']+/u,
+    message: "Windows local filesystem paths are not publishable."
+  },
+  {
+    ruleId: "private-evidence-marker",
+    pattern: /\bPRIVATE:/u,
+    message: "Private evidence markers must not leave the private harness."
+  },
+  {
+    ruleId: "secret-token-marker",
+    pattern: /\b(?:token|secret|password|api[_-]?key|access[_-]?token|auth(?:orization)?)\s*[:=]/iu,
+    message: "Secret-like key/value text is not publishable."
+  },
+  {
+    ruleId: "bearer-token-marker",
+    pattern: /\bBearer\s+[A-Za-z0-9._~+/-]{6,}/u,
+    message: "Bearer tokens are not publishable."
+  },
+  {
+    ruleId: "private-key-marker",
+    pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/u,
+    message: "Private key material is not publishable."
+  },
+  {
+    ruleId: "env-secret-marker",
+    pattern: /\b[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|ACCESS_KEY)[A-Z0-9_]*\s*=/u,
+    message: "Secret-like environment variables are not publishable."
+  }
+];
+
+export function buildPublishableProjection(input: PublishProjectionInput): PublishProjectionResult {
+  const findings = scanPublishInput(input);
+  if (findings.some((finding) => finding.severity === "error")) {
+    return {
+      ok: false,
+      code: "redaction_failed",
+      findings
+    };
+  }
+
+  if (!readinessPassed(input.readiness)) {
+    return {
+      ok: false,
+      code: "closeout_not_ready",
+      findings: [
+        {
+          ruleId: "publish-readiness",
+          severity: "error",
+          message: "Publishable output requires passed closeout, review, and CI gates."
+        }
+      ]
+    };
+  }
+
+  const links = [...input.links, ...input.readiness.evidenceLinks].sort(compareLinks);
+  const readiness = {
+    closeoutReadiness: "passed" as const,
+    reviewGate: "passed" as const,
+    ciGate: "passed" as const,
+    evidenceLinks: [...input.readiness.evidenceLinks].sort(compareLinks)
+  };
+  const idempotencyPayload = {
+    sourceTaskId: input.sourceTaskId,
+    title: input.title,
+    summary: input.summary,
+    links,
+    readiness
+  };
+
+  return {
+    ok: true,
+    projection: {
+      visibility: "public-safe",
+      sourceTaskId: input.sourceTaskId,
+      title: input.title,
+      summary: input.summary,
+      links,
+      readiness,
+      redactionReport: {
+        scannerVersion,
+        findings,
+        passed: true
+      },
+      idempotencyKey: `sha256:${stablePayloadHash(idempotencyPayload)}`
+    }
+  };
+}
+
+export function createInMemoryPublishIdempotencyLedger(): PublishIdempotencyLedger {
+  const keys = new Set<string>();
+  return {
+    has: (key) => keys.has(key),
+    record: (key) => {
+      keys.add(key);
+    }
+  };
+}
+
+export function reservePublishIdempotencyKey(
+  projection: PublishableProjection,
+  ledger: PublishIdempotencyLedger
+): PublishProjectionResult {
+  if (ledger.has(projection.idempotencyKey)) {
+    return {
+      ok: false,
+      code: "duplicate_publish",
+      findings: [
+        {
+          ruleId: "publish-idempotency",
+          severity: "error",
+          message: "Publishable projection idempotency key has already been reserved."
+        }
+      ]
+    };
+  }
+
+  ledger.record(projection.idempotencyKey);
+  return {
+    ok: true,
+    projection
+  };
+}
+
+function readinessPassed(readiness: PublishReadinessEvidence): boolean {
+  return readiness.closeoutReadiness === "passed"
+    && readiness.reviewGate === "passed"
+    && readiness.ciGate === "passed"
+    && readiness.evidenceLinks.length > 0;
+}
+
+function scanPublishInput(input: PublishProjectionInput): ReadonlyArray<PublishRedactionFinding> {
+  const findings: PublishRedactionFinding[] = [];
+  scanText(input.sourceTaskId, "sourceTaskId", findings);
+  scanText(input.title, "title", findings);
+  scanText(input.summary, "summary", findings);
+  scanLinks(input.links, "links", findings);
+  scanLinks(input.readiness.evidenceLinks, "readiness.evidenceLinks", findings);
+  return findings;
+}
+
+function scanLinks(
+  links: ReadonlyArray<PublishableLink>,
+  prefix: string,
+  findings: PublishRedactionFinding[]
+): void {
+  links.forEach((link, index) => {
+    scanText(link.label, `${prefix}.${index}.label`, findings);
+    scanText(link.href, `${prefix}.${index}.href`, findings);
+  });
+}
+
+function scanText(text: string, path: string, findings: PublishRedactionFinding[]): void {
+  for (const rule of privateTextPatterns) {
+    if (!rule.pattern.test(text)) continue;
+    findings.push({
+      ruleId: rule.ruleId,
+      severity: "error",
+      message: rule.message,
+      path
+    });
+  }
+}
+
+function compareLinks(a: PublishableLink, b: PublishableLink): number {
+  return `${a.kind}\0${a.href}\0${a.label}`.localeCompare(`${b.kind}\0${b.href}\0${b.label}`);
+}
+
+function stablePayloadHash(value: unknown): string {
+  return createHash("sha256").update(stableStringify(value), "utf8").digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .join(",")}}`;
+}

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -112,15 +112,24 @@ export const RedactionFindingSchema = Schema.Struct({
   path: OptionalString
 });
 
+const PublishableLinkSchema = Schema.Struct({
+  label: Schema.String,
+  href: Schema.String,
+  kind: LinkKindSchema
+});
+
 export const PublishableProjectionSchema = Schema.Struct({
   visibility: Schema.Literal("public-safe"),
+  sourceTaskId: Schema.String,
   title: Schema.String,
   summary: Schema.String,
-  links: Schema.Array(Schema.Struct({
-    label: Schema.String,
-    href: Schema.String,
-    kind: LinkKindSchema
-  })),
+  links: Schema.Array(PublishableLinkSchema),
+  readiness: Schema.Struct({
+    closeoutReadiness: Schema.Literal("passed"),
+    reviewGate: Schema.Literal("passed"),
+    ciGate: Schema.Literal("passed"),
+    evidenceLinks: Schema.Array(PublishableLinkSchema).pipe(Schema.minItems(1))
+  }),
   redactionReport: Schema.Struct({
     scannerVersion: Schema.String,
     findings: Schema.Array(RedactionFindingSchema),

--- a/packages/kernel/test/publish/idempotency.test.ts
+++ b/packages/kernel/test/publish/idempotency.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildPublishableProjection,
+  createInMemoryPublishIdempotencyLedger,
+  reservePublishIdempotencyKey
+} from "../../src/index.ts";
+
+test("publish idempotency key is stable for equivalent sorted inputs", () => {
+  const first = buildPublishableProjection(validInput([
+    { label: "Review", href: "https://example.invalid/pull/7", kind: "review" },
+    { label: "Commit", href: "https://example.invalid/commit/abc123", kind: "commit" }
+  ]));
+  const second = buildPublishableProjection(validInput([
+    { label: "Commit", href: "https://example.invalid/commit/abc123", kind: "commit" },
+    { label: "Review", href: "https://example.invalid/pull/7", kind: "review" }
+  ]));
+
+  assert.equal(first.ok, true);
+  assert.equal(second.ok, true);
+  assert.equal(first.projection.idempotencyKey, second.projection.idempotencyKey);
+});
+
+test("publish idempotency ledger rejects duplicate publish attempts", () => {
+  const built = buildPublishableProjection(validInput([]));
+  assert.equal(built.ok, true);
+  const ledger = createInMemoryPublishIdempotencyLedger();
+
+  const first = reservePublishIdempotencyKey(built.projection, ledger);
+  const second = reservePublishIdempotencyKey(built.projection, ledger);
+
+  assert.equal(first.ok, true);
+  assert.equal(second.ok, false);
+  assert.equal(second.code, "duplicate_publish");
+});
+
+function validInput(extraLinks: ReadonlyArray<{ readonly label: string; readonly href: string; readonly kind: "artifact" | "commit" | "review" }>) {
+  return {
+    sourceTaskId: "kr-07",
+    title: "Public closeout",
+    summary: "Review, CI, and closeout evidence passed.",
+    links: extraLinks,
+    readiness: {
+      closeoutReadiness: "passed" as const,
+      reviewGate: "passed" as const,
+      ciGate: "passed" as const,
+      evidenceLinks: [
+        {
+          label: "Review evidence",
+          href: "https://example.invalid/pull/7",
+          kind: "review" as const
+        }
+      ]
+    }
+  };
+}

--- a/packages/kernel/test/publish/private-evidence-rejection.test.ts
+++ b/packages/kernel/test/publish/private-evidence-rejection.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildPublishableProjection } from "../../src/index.ts";
+
+test("publishable projection rejects missing closeout evidence", () => {
+  const result = buildPublishableProjection({
+    sourceTaskId: "kr-07",
+    title: "Public closeout",
+    summary: "Review evidence is not complete yet.",
+    links: [],
+    readiness: {
+      closeoutReadiness: "ready",
+      reviewGate: "passed",
+      ciGate: "passed",
+      evidenceLinks: [
+        {
+          label: "Review",
+          href: "https://example.invalid/pull/7",
+          kind: "review"
+        }
+      ]
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "closeout_not_ready");
+  assert.equal(result.findings.some((finding) => finding.ruleId === "publish-readiness"), true);
+});
+
+test("publishable projection rejects missing review or CI evidence", () => {
+  const result = buildPublishableProjection({
+    sourceTaskId: "kr-07",
+    title: "Public closeout",
+    summary: "Closeout exists but review and CI are incomplete.",
+    links: [],
+    readiness: {
+      closeoutReadiness: "passed",
+      reviewGate: "missing",
+      ciGate: "failed",
+      evidenceLinks: []
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "closeout_not_ready");
+});

--- a/packages/kernel/test/publish/redaction.test.ts
+++ b/packages/kernel/test/publish/redaction.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildPublishableProjection } from "../../src/index.ts";
+
+test("publishable projection rejects unsafe payloads before producing public output", () => {
+  const result = buildPublishableProjection({
+    sourceTaskId: "PRIVATE:kr-07",
+    title: "Public closeout",
+    summary: "Evidence lives at /Users/example/project/.harness-private/review.md",
+    links: [
+      {
+        label: "Private artifact",
+        href: "PRIVATE:coding-agent-harness/planning/tasks/kr-07/review.md",
+        kind: "artifact"
+      }
+    ],
+    readiness: {
+      closeoutReadiness: "passed",
+      reviewGate: "passed",
+      ciGate: "passed",
+      evidenceLinks: [
+        {
+          label: "PR",
+          href: "https://example.invalid/pull/7",
+          kind: "review"
+        }
+      ]
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "redaction_failed");
+  assert.equal(result.findings.some((finding) => finding.ruleId === "absolute-local-path"), true);
+  assert.equal(result.findings.some((finding) => finding.ruleId === "private-harness-path"), true);
+  assert.equal(result.findings.some((finding) => finding.ruleId === "private-evidence-marker"), true);
+  assert.equal(result.findings.some((finding) => finding.path === "sourceTaskId"), true);
+});
+
+test("publishable projection rejects local path bypass variants", () => {
+  for (const unsafeText of [
+    "/tmp/private-review.md",
+    "/Volumes/Secret/review.md",
+    "file:///Users/example/secret.md",
+    "C:\\Users\\example\\secret.md"
+  ]) {
+    const result = buildPublishableProjection({
+      sourceTaskId: "kr-07",
+      title: "Public closeout",
+      summary: `Unsafe evidence ${unsafeText}`,
+      links: [],
+      readiness: passedReadiness()
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "redaction_failed");
+  }
+});
+
+test("publishable projection rejects secret marker bypass variants", () => {
+  for (const unsafeText of [
+    "api_key=abc123",
+    "Authorization: Bearer abc123",
+    "ACCESS_TOKEN=abc123",
+    "-----BEGIN PRIVATE KEY-----"
+  ]) {
+    const result = buildPublishableProjection({
+      sourceTaskId: "kr-07",
+      title: "Public closeout",
+      summary: unsafeText,
+      links: [],
+      readiness: passedReadiness()
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "redaction_failed");
+  }
+});
+
+test("publishable projection emits public-safe redaction report for clean payloads", () => {
+  const result = buildPublishableProjection({
+    sourceTaskId: "kr-07",
+    title: "Public closeout",
+    summary: "Review, CI, and closeout evidence passed.",
+    links: [
+      {
+        label: "Merge commit",
+        href: "https://example.invalid/commit/abc123",
+        kind: "commit"
+      }
+    ],
+    readiness: {
+      closeoutReadiness: "passed",
+      reviewGate: "passed",
+      ciGate: "passed",
+      evidenceLinks: [
+      {
+        label: "Review evidence",
+        href: "https://example.invalid/pull/7",
+        kind: "review"
+      }
+      ]
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.projection.visibility, "public-safe");
+  assert.equal(result.projection.redactionReport.passed, true);
+  assert.deepEqual(result.projection.redactionReport.findings, []);
+});
+
+function passedReadiness() {
+  return {
+    closeoutReadiness: "passed" as const,
+    reviewGate: "passed" as const,
+    ciGate: "passed" as const,
+    evidenceLinks: [
+      {
+        label: "Review evidence",
+        href: "https://example.invalid/pull/7",
+        kind: "review" as const
+      }
+    ]
+  };
+}

--- a/packages/kernel/test/publish/schema-lockdown.test.ts
+++ b/packages/kernel/test/publish/schema-lockdown.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { Schema } from "effect";
+import { PublishableProjectionSchema } from "../../src/index.ts";
+
+test("publishable projection JSON schema rejects extra private/local-only fields", () => {
+  const schema = JSON.parse(readFileSync("packages/kernel/schemas/json/publishable-projection.schema.json", "utf8")) as {
+    readonly additionalProperties?: boolean;
+    readonly properties: Record<string, {
+      readonly additionalProperties?: boolean;
+      readonly minItems?: number;
+      readonly items?: { readonly additionalProperties?: boolean };
+      readonly properties?: Record<string, {
+        readonly additionalProperties?: boolean;
+        readonly minItems?: number;
+        readonly items?: { readonly additionalProperties?: boolean };
+      }>;
+    }>;
+  };
+
+  assert.equal(schema.additionalProperties, false);
+  assert.equal(schema.properties.links.items?.additionalProperties, false);
+  assert.equal(schema.properties.readiness.additionalProperties, false);
+  assert.equal(schema.properties.readiness.properties?.evidenceLinks.minItems, 1);
+  assert.equal(schema.properties.readiness.properties?.evidenceLinks.items?.additionalProperties, false);
+  assert.equal(schema.properties.redactionReport.additionalProperties, false);
+  assert.equal(schema.properties.redactionReport.properties?.findings.items?.additionalProperties, false);
+});
+
+test("publishable projection runtime schema rejects empty readiness evidence", () => {
+  const projection = {
+    visibility: "public-safe",
+    sourceTaskId: "kr-07",
+    title: "Public closeout",
+    summary: "Missing evidence links should fail schema decode.",
+    links: [],
+    readiness: {
+      closeoutReadiness: "passed",
+      reviewGate: "passed",
+      ciGate: "passed",
+      evidenceLinks: []
+    },
+    redactionReport: {
+      scannerVersion: "publish-redaction/v1",
+      findings: [],
+      passed: true
+    },
+    idempotencyKey: "sha256:empty-evidence"
+  };
+
+  assert.throws(() => Schema.decodeUnknownSync(PublishableProjectionSchema)(projection));
+});


### PR DESCRIPTION
## Summary

Add KR-07 publish safety primitives for public-safe projection generation before any real external publish path is enabled.

## What Changed

- Added a kernel publish safety module that builds `PublishableProjection` only after redaction and readiness gates pass.
- Added local idempotency key reservation helpers for the no-real-publish slice.
- Extended the publishable projection schema with `sourceTaskId` and required readiness evidence.
- Added publish contract tests for redaction bypasses, duplicate publish attempts, private evidence rejection, JSON schema lockdown, and runtime schema readiness alignment.

## Task And Scope

- Harness task: KR-07 publishNote safety + closeout completeness
- Branch: `codex/kr-07-publish-note-safety`
- Public scope: kernel publish safety projection, schema, fixtures, and tests
- Private planning/evidence updated: pending after PR merge
- Out of scope: real external publish, adapter `publishNote` implementation, GUI, npm publish

## Version Impact

- Version: no version change because this is publish readiness only
- Publish impact: publish readiness only; no external publish path is enabled

## Verification

- Base `origin/main` SHA: `75bc5810b1fe54b61d6829dafc8fa0d3ffaa497d`
- Branch merge-base with `origin/main`: `75bc5810b1fe54b61d6829dafc8fa0d3ffaa497d`
- Last `git fetch origin` time: before PR creation
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: task evidence pending closeout after PR merge
- Reviewer evidence path: KR-07 reviewer evidence recorded in task review notes after PR merge
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` not rerun because dependencies did not change and the local install already supports the workspace checks

## Review Evidence

- Self-review: completed against publish safety, schema, idempotency, and external-write boundaries
- Reviewer subagent: Goodall closed KR07-R1/R2/R3/R4; no open P0/P1/P2 blockers
- Human review: admin merge may be used after CI if project owner accepts the recorded evidence
- Blocking findings: none open

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses the full repository template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [ ] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear.

## Residual Risk

- Duplicate suppression is in-memory for this no-real-publish slice. A future real publish adapter must use a durable ledger or remote marker scan keyed by `idempotencyKey`.

## References

- Task: KR-07 publishNote safety + closeout completeness
- Evidence: local `npm run check` passed with 64 tests
- Review: Goodall adversarial review closed all P0/P1/P2 findings

---

## 摘要

新增 KR-07 发布安全基础能力，在任何真实 external publish 开启之前，先建立 public-safe projection、脱敏、幂等和 closeout readiness 门禁。

## 改动内容

- 新增 kernel publish safety 模块，只有 redaction 和 readiness gate 通过后才生成 `PublishableProjection`。
- 新增本地 idempotency key reservation helper，服务于当前不真实发布的切片。
- 扩展 publishable projection schema，加入 `sourceTaskId` 和必需 readiness evidence。
- 新增 redaction bypass、重复发布、private evidence rejection、JSON schema lockdown、runtime schema readiness 对齐测试。

## 任务与范围

- Harness 任务：KR-07 publishNote safety + closeout completeness
- 分支：`codex/kr-07-publish-note-safety`
- 公开范围：kernel publish safety projection、schema、fixtures、tests
- 私有计划 / 证据是否已更新：PR merge 后收口
- 范围外：真实 external publish、adapter `publishNote` 实现、GUI、npm publish

## 版本影响

- 版本：不改版本，原因是只做发布准备
- 发布影响：只做发布准备；不启用 external publish path

## 验证

- `origin/main` 基准 SHA：`75bc5810b1fe54b61d6829dafc8fa0d3ffaa497d`
- 当前分支与 `origin/main` 的 merge-base：`75bc5810b1fe54b61d6829dafc8fa0d3ffaa497d`
- 最近一次 `git fetch origin` 时间：PR 创建前
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：PR merge 后收口
- Reviewer 证据路径：PR merge 后写入 KR-07 review notes
- GitHub Actions `rewrite-ci` run URL：pending
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci` 未重跑；依赖未变化，本地 install 已支持 workspace checks

## 审查证据

- 自查：已覆盖 publish safety、schema、idempotency、external-write boundary
- Reviewer subagent：Goodall 已关闭 KR07-R1/R2/R3/R4；无 open P0/P1/P2 blockers
- 人工审查：CI 通过后，如项目 owner 接受已记录证据，可使用 admin merge
- 阻塞发现：无 open blocking findings

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用仓库模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [ ] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚。

## 残余风险

- 当前切片的 duplicate suppression 是 in-memory。未来真实 publish adapter 必须使用 durable ledger 或 remote marker scan，并以 `idempotencyKey` 为键。

## 关联材料

- 任务：KR-07 publishNote safety + closeout completeness
- 证据：本地 `npm run check` 通过，64 tests
- 审查：Goodall 对抗性审查关闭全部 P0/P1/P2 findings
