### PR TITLE
feat(gui): scaffold secure local desktop controller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,790 @@
         "node": ">=24"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
+      "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.2.tgz",
+      "integrity": "sha512-VJuNETNPEhrmQEZezeTZO5TZMV+dobBRyJ7zHjGJWIhMS7m7W1UeClt69u4hkUxv9ZZVxuli/E9Yvc4gDNHGsg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@harness-anything/adapter-github-issues": {
       "resolved": "packages/adapters/github-issues",
       "link": true
@@ -36,6 +820,10 @@
       "resolved": "packages/adapters/multica",
       "link": true
     },
+    "node_modules/@harness-anything/application": {
+      "resolved": "packages/application",
+      "link": true
+    },
     "node_modules/@harness-anything/cli": {
       "resolved": "packages/cli",
       "link": true
@@ -48,10 +836,508 @@
       "resolved": "packages/kernel",
       "link": true
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -64,6 +1350,157 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.36",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.36.tgz",
+      "integrity": "sha512-lVq/Df7LXlO79MVaaUHztSwWiG9oXoWHlgvNS51v8Dpd4+G4/VIy6qYePTw31nAVls33nUtnfezYeLkYAak9dg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/effect": {
       "version": "3.21.2",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.2.tgz",
@@ -72,6 +1509,127 @@
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
+      }
+    },
+    "node_modules/electron": {
+      "version": "42.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.4.0.tgz",
+      "integrity": "sha512-OXXqh9LD9KxXPv2Fe25EfU9N9AvWTuV6V81sfhQaNvTAXCd9ONA+Q4OWvMe+CmYD6xIwjFxGGtG/ZphDYYC5OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/electron-vite": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/electron-vite/-/electron-vite-5.0.0.tgz",
+      "integrity": "sha512-OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.4",
+        "@babel/plugin-transform-arrow-functions": "^7.27.1",
+        "cac": "^6.7.14",
+        "esbuild": "^0.25.11",
+        "magic-string": "^0.30.19",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "electron-vite": "bin/electron-vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@swc/core": "^1.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/fast-check": {
@@ -96,6 +1654,204 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -112,6 +1868,138 @@
       ],
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -126,12 +2014,620 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "packages/adapters/github-issues": {
       "name": "@harness-anything/adapter-github-issues",
@@ -149,13 +2645,29 @@
       "name": "@harness-anything/adapter-multica",
       "version": "0.0.0"
     },
+    "packages/application": {
+      "name": "@harness-anything/application",
+      "version": "0.0.0"
+    },
     "packages/cli": {
       "name": "@harness-anything/cli",
       "version": "0.0.0"
     },
     "packages/gui": {
       "name": "@harness-anything/gui",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "19.2.7",
+        "react-dom": "19.2.7"
+      },
+      "devDependencies": {
+        "@types/react": "19.2.17",
+        "@types/react-dom": "19.2.3",
+        "@vitejs/plugin-react": "5.2.0",
+        "electron": "42.4.0",
+        "electron-vite": "5.0.0",
+        "vite": "7.3.5"
+      }
     },
     "packages/kernel": {
       "name": "@harness-anything/kernel",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@harness-anything/application",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,0 +1,213 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { Effect } from "effect";
+import { makeLocalLifecycleEngine } from "../../adapters/local/src/index.ts";
+import type { DomainStatus } from "../../kernel/src/index.ts";
+import { isDomainStatus, readTaskProjection } from "../../kernel/src/index.ts";
+
+export interface LocalControllerServiceOptions {
+  readonly rootDir: string;
+}
+
+export interface LocalControllerSuccess {
+  readonly ok: true;
+}
+
+export interface LocalControllerFailure {
+  readonly ok: false;
+  readonly error: {
+    readonly code: string;
+    readonly hint: string;
+  };
+}
+
+export type LocalControllerResult = LocalControllerSuccess | LocalControllerFailure;
+
+export type TaskListResult = (LocalControllerSuccess & {
+  readonly tasks: ReadonlyArray<unknown>;
+  readonly warnings: ReadonlyArray<unknown>;
+}) | LocalControllerFailure;
+
+export type TaskDetailResult = (LocalControllerSuccess & {
+  readonly task?: unknown;
+  readonly documents?: ReadonlyArray<{ readonly path: string }>;
+}) | LocalControllerFailure;
+
+export type TaskDocumentResult = (LocalControllerSuccess & {
+  readonly taskId?: string;
+  readonly path?: string;
+  readonly body?: string;
+}) | LocalControllerFailure;
+
+export interface LocalControllerService {
+  readonly getTasks: () => TaskListResult;
+  readonly getTaskDetail: (payload: unknown) => TaskDetailResult;
+  readonly getTaskDocument: (payload: unknown) => TaskDocumentResult;
+  readonly setTaskStatus: (payload: unknown) => Promise<LocalControllerResult>;
+  readonly reviewTask: (payload: unknown) => Promise<LocalControllerResult>;
+  readonly appendTaskProgress: (payload: unknown) => Promise<LocalControllerResult>;
+  readonly rebuildGovernance: () => TaskListResult;
+  readonly archiveTask: () => LocalControllerResult;
+  readonly openShell: () => LocalControllerResult & {
+    readonly policy: {
+      readonly displayOnly: true;
+      readonly outputCreatesTaskState: false;
+    };
+  };
+}
+
+export function makeLocalControllerService(options: LocalControllerServiceOptions): LocalControllerService {
+  const rootDir = path.resolve(options.rootDir);
+  const engine = makeLocalLifecycleEngine({ rootDir });
+
+  return {
+    getTasks: () => {
+      const result = readTaskProjection({ rootDir });
+      return { ok: true, tasks: result.rows, warnings: result.warnings };
+    },
+    getTaskDetail: (payload) => {
+      const parsed = readTaskIdPayload(payload);
+      if (!parsed.ok) return parsed;
+      const projection = readTaskProjection({ rootDir });
+      const task = projection.rows.find((row) => row.taskId === parsed.taskId);
+      if (!task) return taskNotFound(parsed.taskId);
+      return {
+        ok: true,
+        task,
+        documents: listKnownTaskDocuments(rootDir, parsed.taskId)
+      };
+    },
+    getTaskDocument: (payload) => {
+      const parsed = readTaskDocumentPayload(payload);
+      if (!parsed.ok) return parsed;
+      const documentPath = taskDocumentPath(rootDir, parsed.taskId, parsed.path);
+      if (!existsSync(documentPath)) return { ok: false, error: { code: "document_not_found", hint: parsed.path } };
+      return {
+        ok: true,
+        taskId: parsed.taskId,
+        path: parsed.path,
+        body: readFileSync(documentPath, "utf8")
+      };
+    },
+    setTaskStatus: async (payload) => {
+      const parsed = readSetStatusPayload(payload);
+      if (!parsed.ok) return parsed;
+      return Effect.runPromise(engine.setStatus({ taskId: parsed.taskId, status: parsed.status }).pipe(
+        Effect.match({
+          onFailure: (error) => ({ ok: false, error: { code: error._tag, hint: "Status update failed." } }),
+          onSuccess: () => ({ ok: true })
+        })
+      ));
+    },
+    reviewTask: async (payload) => {
+      const parsed = readTaskIdPayload(payload);
+      if (!parsed.ok) return parsed;
+      return Effect.runPromise(engine.setStatus({ taskId: parsed.taskId, status: "in_review" }).pipe(
+        Effect.match({
+          onFailure: (error) => ({ ok: false, error: { code: error._tag, hint: "Review transition failed." } }),
+          onSuccess: () => ({ ok: true })
+        })
+      ));
+    },
+    appendTaskProgress: async (payload) => {
+      const parsed = readAppendProgressPayload(payload);
+      if (!parsed.ok) return parsed;
+      return Effect.runPromise(engine.appendProgress({ taskId: parsed.taskId, text: parsed.text }).pipe(
+        Effect.match({
+          onFailure: (error) => ({ ok: false, error: { code: error._tag, hint: "Progress append failed." } }),
+          onSuccess: () => ({ ok: true })
+        })
+      ));
+    },
+    rebuildGovernance: () => {
+      const result = readTaskProjection({ rootDir });
+      return { ok: true, tasks: result.rows, warnings: result.warnings };
+    },
+    archiveTask: () => ({
+      ok: false,
+      error: {
+        code: "unsupported_in_kr09",
+        hint: "Archive mutation is reserved for the closeout workflow task."
+      }
+    }),
+    openShell: () => ({
+      ok: true,
+      policy: {
+        displayOnly: true,
+        outputCreatesTaskState: false
+      }
+    })
+  };
+}
+
+function listKnownTaskDocuments(rootDir: string, taskId: string): ReadonlyArray<{ readonly path: string }> {
+  return ["INDEX.md", "progress.md", "review.md", "findings.md"]
+    .filter((documentPath) => existsSync(taskDocumentPath(rootDir, taskId, documentPath)))
+    .map((documentPath) => ({ path: documentPath }));
+}
+
+function taskDocumentPath(rootDir: string, taskId: string, documentPath: string): string {
+  validateTaskId(taskId);
+  validateRelativeDocumentPath(documentPath);
+  return path.join(rootDir, "tasks", taskId, documentPath);
+}
+
+function readTaskIdPayload(payload: unknown): { readonly ok: true; readonly taskId: string } | LocalControllerFailure {
+  if (!isRecord(payload) || typeof payload.taskId !== "string") {
+    return invalidPayload("taskId is required.");
+  }
+  validateTaskId(payload.taskId);
+  return { ok: true, taskId: payload.taskId };
+}
+
+function readTaskDocumentPayload(payload: unknown): { readonly ok: true; readonly taskId: string; readonly path: string } | LocalControllerFailure {
+  const taskPayload = readTaskIdPayload(payload);
+  if (!taskPayload.ok) return taskPayload;
+  if (!isRecord(payload) || typeof payload.path !== "string") {
+    return invalidPayload("path is required.");
+  }
+  validateRelativeDocumentPath(payload.path);
+  return { ok: true, taskId: taskPayload.taskId, path: payload.path };
+}
+
+function readSetStatusPayload(payload: unknown): { readonly ok: true; readonly taskId: string; readonly status: DomainStatus } | LocalControllerFailure {
+  const taskPayload = readTaskIdPayload(payload);
+  if (!taskPayload.ok) return taskPayload;
+  if (!isRecord(payload) || typeof payload.status !== "string" || !isDomainStatus(payload.status)) {
+    return invalidPayload("valid status is required.");
+  }
+  return { ok: true, taskId: taskPayload.taskId, status: payload.status };
+}
+
+function readAppendProgressPayload(payload: unknown): { readonly ok: true; readonly taskId: string; readonly text: string } | LocalControllerFailure {
+  const taskPayload = readTaskIdPayload(payload);
+  if (!taskPayload.ok) return taskPayload;
+  if (!isRecord(payload) || typeof payload.text !== "string" || payload.text.length === 0) {
+    return invalidPayload("text is required.");
+  }
+  return { ok: true, taskId: taskPayload.taskId, text: payload.text };
+}
+
+function validateTaskId(taskId: string): void {
+  if (taskId.length === 0 || taskId.includes("/") || taskId.includes("..")) {
+    throw new Error(`invalid task id: ${taskId}`);
+  }
+}
+
+function validateRelativeDocumentPath(documentPath: string): void {
+  if (path.isAbsolute(documentPath)) throw new Error("absolute document paths are not allowed");
+  const normalized = path.normalize(documentPath);
+  if (normalized === "." || normalized.startsWith("..")) throw new Error("document path must stay inside the task package");
+}
+
+function invalidPayload(hint: string): LocalControllerFailure {
+  return { ok: false, error: { code: "invalid_payload", hint } };
+}
+
+function taskNotFound(taskId: string): LocalControllerFailure {
+  return { ok: false, error: { code: "task_not_found", hint: `task not found: ${taskId}` } };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/application/test/local-controller-service.test.ts
+++ b/packages/application/test/local-controller-service.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeLocalControllerService } from "../src/index.ts";
+
+test("local controller service reads projection and writes through local lifecycle service path", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-app-"));
+  try {
+    writeTaskIndex(rootDir, "task-1", "Task One", "planned");
+    const service = makeLocalControllerService({ rootDir });
+
+    const list = service.getTasks();
+    assert.equal(list.ok, true);
+    assert.equal(list.tasks.length, 1);
+
+    const detail = service.getTaskDetail({ taskId: "task-1" });
+    assert.equal(detail.ok, true);
+    assert.deepEqual(detail.documents, [{ path: "INDEX.md" }]);
+
+    const document = service.getTaskDocument({ taskId: "task-1", path: "INDEX.md" });
+    assert.equal(document.ok, true);
+    assert.match(document.body ?? "", /Task One/);
+
+    assert.deepEqual(await service.setTaskStatus({ taskId: "task-1", status: "active" }), { ok: true });
+    assert.deepEqual(await service.appendTaskProgress({ taskId: "task-1", text: "GUI update" }), { ok: true });
+    assert.match(readFileSync(path.join(rootDir, "tasks/task-1/progress.md"), "utf8"), /GUI update/);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function writeTaskIndex(rootDir: string, taskId: string, title: string, status: string): void {
+  mkdirSync(path.join(rootDir, "tasks", taskId), { recursive: true });
+  writeFileSync(path.join(rootDir, "tasks", taskId, "INDEX.md"), [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    `title: ${title}`,
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    `  status: ${status}`,
+    "  ref: ",
+    `  titleSnapshot: ${title}`,
+    "  url: ",
+    "  bindingCreatedAt: 2026-06-12T00:00:00.000Z",
+    "  bindingFingerprint: sha256:test",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "---",
+    ""
+  ].join("\n"), "utf8");
+}

--- a/packages/application/tsconfig.json
+++ b/packages/application/tsconfig.json
@@ -9,14 +9,13 @@
     "strict": true,
     "skipLibCheck": true,
     "allowImportingTsExtensions": true,
-    "erasableSyntaxOnly": true,
-    "jsx": "react-jsx"
+    "erasableSyntaxOnly": true
   },
   "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx"
+    "src/**/*.ts"
   ],
   "references": [
-    { "path": "../application" }
+    { "path": "../kernel" },
+    { "path": "../adapters/local" }
   ]
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
@@ -30,6 +31,15 @@ export interface CliResult {
   readonly issues?: ReadonlyArray<unknown>;
   readonly rows?: number;
   readonly warnings?: ReadonlyArray<unknown>;
+  readonly launchPlan?: {
+    readonly packageName: "@harness-anything/gui";
+    readonly mode: "local-desktop-controller";
+    readonly apiHost: "127.0.0.1";
+    readonly delegated: true;
+    readonly dryRun: boolean;
+    readonly command: readonly string[];
+    readonly pid?: number;
+  };
   readonly error?: {
     readonly code: string;
     readonly hint: string;
@@ -45,6 +55,7 @@ interface ParsedCommand {
     | { readonly kind: "progress-append"; readonly taskId: string; readonly text: string }
     | { readonly kind: "task-list" }
     | { readonly kind: "check" }
+    | { readonly kind: "gui" }
     | { readonly kind: "template-list"; readonly catalogPath: string }
     | { readonly kind: "template-render"; readonly templateRef: string; readonly catalogPath: string; readonly locale: "zh-CN" | "en-US" }
     | { readonly kind: "preset-validate"; readonly manifestPath: string; readonly kernelVersion: string }
@@ -62,6 +73,12 @@ export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)):
     const result = runExtensionCommand(parsed.value);
     emit(result, parsed.value.json);
     return result.ok ? 0 : 1;
+  }
+
+  if (parsed.value.action.kind === "gui") {
+    const result = launchGui(parsed.value.rootDir);
+    emit(result, parsed.value.json);
+    return 0;
   }
 
   const engine = makeLocalLifecycleEngine({ rootDir: parsed.value.rootDir });
@@ -146,6 +163,50 @@ function runCommand(
       }
     } satisfies CliResult;
   });
+}
+
+function launchGui(rootDir: string): CliResult {
+  const command = ["npm", "--workspace", "@harness-anything/gui", "run", "dev"] as const;
+  const dryRun = process.env.HARNESS_GUI_DRY_RUN === "1";
+  if (dryRun) {
+    return {
+      ok: true,
+      command: "gui",
+      launchPlan: {
+        packageName: "@harness-anything/gui",
+        mode: "local-desktop-controller",
+        apiHost: "127.0.0.1",
+        delegated: true,
+        dryRun,
+        command
+      }
+    };
+  }
+
+  const child = spawn(command[0], command.slice(1), {
+    cwd: process.cwd(),
+    detached: true,
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      HARNESS_GUI_ROOT: path.resolve(rootDir)
+    }
+  });
+  child.unref();
+
+  return {
+    ok: true,
+    command: "gui",
+    launchPlan: {
+      packageName: "@harness-anything/gui",
+      mode: "local-desktop-controller",
+      apiHost: "127.0.0.1",
+      delegated: true,
+      dryRun,
+      command,
+      pid: child.pid
+    }
+  };
 }
 
 function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] } {
@@ -234,6 +295,19 @@ function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; readonly v
     };
   }
 
+  if (args[0] === "gui") {
+    return {
+      ok: true,
+      value: {
+        rootDir,
+        json,
+        action: {
+          kind: "gui"
+        }
+      }
+    };
+  }
+
   if (args[0] === "template" && args[1] === "list") {
     const catalogPath = readOption(args, "--catalog");
     if (!catalogPath) {
@@ -309,7 +383,7 @@ function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; readonly v
     ok: false,
     error: {
       code: "unknown_command",
-      hint: "Supported commands: new-task, task status set, task progress append, task list, check, template list, template render, preset validate, vertical validate."
+      hint: "Supported commands: new-task, task status set, task progress append, task list, check, gui, template list, template render, preset validate, vertical validate."
     }
   };
 }
@@ -500,7 +574,7 @@ function emit(result: CliResult, json: boolean): void {
   }
 
   if (result.ok) {
-    const suffix = result.status ? ` status=${result.status}` : result.path ? ` path=${result.path}` : result.rows !== undefined ? ` rows=${result.rows}` : "";
+    const suffix = result.status ? ` status=${result.status}` : result.path ? ` path=${result.path}` : result.rows !== undefined ? ` rows=${result.rows}` : result.launchPlan ? ` mode=${result.launchPlan.mode} package=${result.launchPlan.packageName}` : "";
     console.log(`ok command=${result.command} task=${result.taskId ?? ""}${suffix}`);
     return;
   }

--- a/packages/cli/test/local-lifecycle-cli.test.ts
+++ b/packages/cli/test/local-lifecycle-cli.test.ts
@@ -22,6 +22,23 @@ test("CLI creates a local task with stable JSON output", () => {
   });
 });
 
+test("CLI gui command delegates to the local desktop controller without importing GUI", () => {
+  const result = runJson(process.cwd(), ["gui"], true, { HARNESS_GUI_DRY_RUN: "1" });
+
+  assert.deepEqual(result, {
+    ok: true,
+    command: "gui",
+    launchPlan: {
+      packageName: "@harness-anything/gui",
+      mode: "local-desktop-controller",
+      apiHost: "127.0.0.1",
+      delegated: true,
+      dryRun: true,
+      command: ["npm", "--workspace", "@harness-anything/gui", "run", "dev"]
+    }
+  });
+});
+
 test("CLI status set mutates local task state through the write journal", () => {
   withTempRoot((rootDir) => {
     runJson(rootDir, ["new-task", "task-1", "--title", "Task One"]);
@@ -196,10 +213,11 @@ function withTempRoot<T>(fn: (rootDir: string) => T): T {
   }
 }
 
-function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, unknown> {
+function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true, env: Readonly<Record<string, string>> = {}): Record<string, unknown> {
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
-      encoding: "utf8"
+      encoding: "utf8",
+      env: { ...process.env, ...env }
     });
     return JSON.parse(stdout) as Record<string, unknown>;
   } catch (error) {

--- a/packages/gui/README.md
+++ b/packages/gui/README.md
@@ -1,5 +1,13 @@
 # @harness-anything/gui
 
+Harness Anything GUI foundation package.
+
+This package is the local desktop controller surface for KR-09. It defines the
+Electron window security contract, preload API allowlist, localhost API guards,
+renderer view model, document sanitization, and shell panel boundary.
+
+The GUI is not an agent runtime control plane. Shell output is display-only and
+never becomes task state implicitly.
+
 Electron Harness client package. GUI and CLI share the same Controller/Service
 layer; GUI does not parse or control agent runtime sessions.
-

--- a/packages/gui/electron.vite.config.ts
+++ b/packages/gui/electron.vite.config.ts
@@ -1,0 +1,28 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "electron-vite";
+
+export default defineConfig({
+  main: {
+    build: {
+      lib: {
+        entry: "src/main/electron-main.ts"
+      }
+    }
+  },
+  preload: {
+    build: {
+      lib: {
+        entry: "src/preload/electron-preload.ts"
+      }
+    }
+  },
+  renderer: {
+    root: ".",
+    plugins: [react()],
+    build: {
+      rollupOptions: {
+        input: "index.html"
+      }
+    }
+  }
+});

--- a/packages/gui/index.html
+++ b/packages/gui/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self' http://127.0.0.1:*; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Harness Anything</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/renderer/main.tsx"></script>
+  </body>
+</html>

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -2,6 +2,25 @@
   "name": "@harness-anything/gui",
   "version": "0.0.0",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "dev": "electron-vite dev",
+    "build": "electron-vite build",
+    "preview": "electron-vite preview"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "react": "19.2.7",
+    "react-dom": "19.2.7"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "5.2.0",
+    "electron": "42.4.0",
+    "electron-vite": "5.0.0",
+    "vite": "7.3.5"
+  }
 }
-

--- a/packages/gui/src/api/local-api.ts
+++ b/packages/gui/src/api/local-api.ts
@@ -1,0 +1,86 @@
+import { randomBytes } from "node:crypto";
+import { existsSync, lstatSync, realpathSync } from "node:fs";
+import path from "node:path";
+
+export const localApiBindHost = "127.0.0.1";
+export const localApiMaxBodyBytes = 256 * 1024;
+
+export interface LocalApiSession {
+  readonly bindHost: "127.0.0.1";
+  readonly sessionToken: string;
+  readonly corsAllowedOrigins: readonly [];
+  readonly maxBodyBytes: number;
+}
+
+export interface LocalApiRequest {
+  readonly headers: Readonly<Record<string, string | undefined>>;
+  readonly bodyBytes: number;
+}
+
+export interface ProjectPathDecision {
+  readonly ok: boolean;
+  readonly normalizedPath: string;
+  readonly reason?: "path_outside_project" | "path_is_private" | "body_too_large";
+}
+
+export function createLocalApiSession(): LocalApiSession {
+  return {
+    bindHost: localApiBindHost,
+    sessionToken: randomBytes(32).toString("base64url"),
+    corsAllowedOrigins: [],
+    maxBodyBytes: localApiMaxBodyBytes
+  };
+}
+
+export function authorizeLocalApiRequest(session: LocalApiSession, request: LocalApiRequest): boolean {
+  if (request.bodyBytes > session.maxBodyBytes) return false;
+  return request.headers.authorization === `Bearer ${session.sessionToken}`;
+}
+
+export function validateProjectPath(projectRoot: string, candidatePath: string): ProjectPathDecision {
+  const root = normalizeExistingPath(projectRoot);
+  const candidate = normalizePossiblyMissingPath(root, candidatePath);
+  if (!isInside(root, candidate)) {
+    return { ok: false, normalizedPath: candidate, reason: "path_outside_project" };
+  }
+  if (isPrivateHarnessPath(root, candidate)) {
+    return { ok: false, normalizedPath: candidate, reason: "path_is_private" };
+  }
+  return { ok: true, normalizedPath: candidate };
+}
+
+export function isPrivateHarnessPath(projectRoot: string, candidatePath: string): boolean {
+  const root = normalizeExistingPath(projectRoot);
+  const relativePath = path.relative(root, candidatePath).split(path.sep).join("/");
+  return relativePath === ".harness-private" || relativePath.startsWith(".harness-private/");
+}
+
+function normalizeExistingPath(inputPath: string): string {
+  return realpathSync(path.resolve(inputPath));
+}
+
+function normalizePossiblyMissingPath(root: string, inputPath: string): string {
+  const resolved = path.isAbsolute(inputPath) ? path.resolve(inputPath) : path.resolve(root, inputPath);
+  if (existsSync(resolved)) {
+    const stat = lstatSync(resolved);
+    if (stat.isSymbolicLink()) return realpathSync(resolved);
+    return realpathSync(resolved);
+  }
+
+  const missingSegments: string[] = [];
+  let nearestExistingParent = resolved;
+  while (!existsSync(nearestExistingParent)) {
+    const nextParent = path.dirname(nearestExistingParent);
+    if (nextParent === nearestExistingParent) break;
+    missingSegments.unshift(path.basename(nearestExistingParent));
+    nearestExistingParent = nextParent;
+  }
+
+  const realParent = realpathSync(nearestExistingParent);
+  return path.resolve(realParent, ...missingSegments);
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const relativePath = path.relative(root, candidate);
+  return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+}

--- a/packages/gui/src/api/service-bridge.ts
+++ b/packages/gui/src/api/service-bridge.ts
@@ -1,0 +1,73 @@
+import path from "node:path";
+import type { LocalControllerService } from "../../../application/src/index.ts";
+import { makeLocalControllerService } from "../../../application/src/index.ts";
+import { classifyShellOutput } from "../terminal/boundary.ts";
+import { validateProjectPath } from "./local-api.ts";
+
+export interface GuiServiceBridge {
+  readonly invoke: (method: string, payload: unknown) => Promise<unknown>;
+}
+
+export function createGuiServiceBridge(rootDir: string): GuiServiceBridge {
+  return createGuiServiceBridgeForService(path.resolve(rootDir), makeLocalControllerService({ rootDir }));
+}
+
+export function createGuiServiceBridgeForService(rootDir: string, service: LocalControllerService): GuiServiceBridge {
+  return {
+    invoke: async (method, payload) => dispatchGuiServiceMethod(rootDir, service, method, payload)
+  };
+}
+
+export async function dispatchGuiServiceMethod(
+  rootDir: string,
+  service: LocalControllerService,
+  method: string,
+  payload: unknown
+): Promise<unknown> {
+  if (method === "getTasks") return service.getTasks();
+  if (method === "getTaskDetail") return service.getTaskDetail(payload);
+  if (method === "getTaskDocument") {
+    const pathDecision = validateTaskDocumentPayloadPath(rootDir, payload);
+    if (!pathDecision.ok) return pathDecision;
+    return service.getTaskDocument(payload);
+  }
+  if (method === "setTaskStatus") return service.setTaskStatus(payload);
+  if (method === "reviewTask") return service.reviewTask(payload);
+  if (method === "archiveTask") return service.archiveTask();
+  if (method === "appendTaskProgress") return service.appendTaskProgress(payload);
+  if (method === "rebuildGovernance") return service.rebuildGovernance();
+  if (method === "openShell") {
+    return {
+      ...service.openShell(),
+      sampleClassification: classifyShellOutput("")
+    };
+  }
+  return {
+    ok: false,
+    error: {
+      code: "method_not_allowed",
+      hint: `Unsupported GUI service method: ${method}`
+    }
+  };
+}
+
+function validateTaskDocumentPayloadPath(rootDir: string, payload: unknown): { readonly ok: true } | { readonly ok: false; readonly error: { readonly code: string; readonly hint: string } } {
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+    return { ok: false, error: { code: "invalid_payload", hint: "taskId and path are required." } };
+  }
+  const record = payload as Record<string, unknown>;
+  if (typeof record.taskId !== "string" || typeof record.path !== "string") {
+    return { ok: false, error: { code: "invalid_payload", hint: "taskId and path are required." } };
+  }
+  const decision = validateProjectPath(rootDir, path.join("tasks", record.taskId, record.path));
+  if (!decision.ok) {
+    return {
+      ok: false,
+      error: {
+        code: decision.reason ?? "path_rejected",
+        hint: "Requested document path is outside the public task package."
+      }
+    };
+  }
+  return { ok: true };
+}

--- a/packages/gui/src/api/view-model.ts
+++ b/packages/gui/src/api/view-model.ts
@@ -1,0 +1,45 @@
+export type GuiViewId = "board" | "list" | "detail" | "doc-viewer" | "review-queue" | "graph";
+export type GuiCoordinationStatus = "open" | "blocked" | "in_review" | "terminal" | "unknown";
+
+export interface GuiTaskRow {
+  readonly taskId: string;
+  readonly title: string;
+  readonly coordinationStatus: GuiCoordinationStatus;
+  readonly closeoutReadiness: string;
+}
+
+export interface GuiBoardColumn {
+  readonly id: GuiCoordinationStatus;
+  readonly taskIds: readonly string[];
+}
+
+export interface GuiViewModel {
+  readonly views: readonly GuiViewId[];
+  readonly board: readonly GuiBoardColumn[];
+  readonly list: readonly GuiTaskRow[];
+  readonly reviewQueue: readonly GuiTaskRow[];
+  readonly graph: {
+    readonly nodes: readonly { readonly id: string; readonly title: string }[];
+    readonly edges: readonly { readonly from: string; readonly to: string; readonly kind: "child" | "related" }[];
+  };
+}
+
+const viewOrder: readonly GuiViewId[] = ["board", "list", "detail", "doc-viewer", "review-queue", "graph"];
+const boardOrder: readonly GuiCoordinationStatus[] = ["open", "blocked", "in_review", "terminal", "unknown"];
+
+export function buildGuiViewModel(rows: readonly GuiTaskRow[]): GuiViewModel {
+  const sortedRows = [...rows].sort((left, right) => left.taskId.localeCompare(right.taskId));
+  return {
+    views: viewOrder,
+    board: boardOrder.map((status) => ({
+      id: status,
+      taskIds: sortedRows.filter((row) => row.coordinationStatus === status).map((row) => row.taskId)
+    })),
+    list: sortedRows,
+    reviewQueue: sortedRows.filter((row) => row.closeoutReadiness === "ready"),
+    graph: {
+      nodes: sortedRows.map((row) => ({ id: row.taskId, title: row.title })),
+      edges: []
+    }
+  };
+}

--- a/packages/gui/src/doc-renderer/sanitize.ts
+++ b/packages/gui/src/doc-renderer/sanitize.ts
@@ -1,0 +1,51 @@
+export interface SanitizedDocument {
+  readonly html: string;
+  readonly strippedReasons: readonly string[];
+}
+
+const unsafePatterns: ReadonlyArray<readonly [RegExp, string]> = [
+  [/<script\b[\s\S]*?<\/script>/giu, "script-tag"],
+  [/\son[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/giu, "event-handler"],
+  [/(?:\/Users|\/tmp|\/private\/var|\/var\/folders)\/[^\s"'<>]+/gu, "absolute-local-path"],
+  [/\.harness-private(?:\/[^\s"'<>]*)?/gu, "private-harness-path"],
+  [/\bauthorization\s*:\s*bearer\s+[^\s"'<>]+/giu, "secret-marker"],
+  [/\b(?:api[_-]?key|access[_-]?token|token)\s*[:=]\s*[^\s"'<>]+/giu, "secret-marker"]
+];
+
+const urlAttributePattern = /\s(?:src|href|srcset|poster|data|action|formaction)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/giu;
+
+export function sanitizeMarkdownHtml(input: string): SanitizedDocument {
+  let html = input;
+  const strippedReasons = new Set<string>();
+  for (const [pattern, reason] of unsafePatterns) {
+    html = html.replace(pattern, () => {
+      strippedReasons.add(reason);
+      return "";
+    });
+  }
+  html = html.replace(urlAttributePattern, (attribute) => {
+    const normalized = attribute.toLowerCase();
+    const value = normalized.replace(/^[^=]+=\s*/, "").trim().replace(/^["']|["']$/g, "");
+    if (value.startsWith("javascript:")) {
+      strippedReasons.add("script-url");
+      return "";
+    }
+    if (value.startsWith("data:")) {
+      strippedReasons.add("data-embed");
+      return "";
+    }
+    if (value.startsWith("file:")) {
+      strippedReasons.add("file-embed");
+      return "";
+    }
+    if (/(^|[\s,])(https?:|\/\/)/u.test(value)) {
+      strippedReasons.add("remote-embed");
+      return "";
+    }
+    return attribute;
+  });
+  return {
+    html,
+    strippedReasons: [...strippedReasons].sort()
+  };
+}

--- a/packages/gui/src/index.ts
+++ b/packages/gui/src/index.ts
@@ -1,2 +1,9 @@
-export {};
-
+export * from "./api/local-api.ts";
+export * from "./api/service-bridge.ts";
+export * from "./api/view-model.ts";
+export * from "./doc-renderer/sanitize.ts";
+export * from "./main/ipc-handlers.ts";
+export * from "./main/window-config.ts";
+export * from "./preload/allowlist.ts";
+export * from "./renderer/app-model.ts";
+export * from "./terminal/boundary.ts";

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -1,0 +1,70 @@
+import { app, BrowserWindow, ipcMain, session } from "electron";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createGuiServiceBridge } from "../api/service-bridge.ts";
+import { registerHarnessIpcHandlers } from "./ipc-handlers.ts";
+import { assertDevRendererUrl, guiContentSecurityPolicy } from "./window-config.ts";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export function createMainWindow(): BrowserWindow {
+  const preloadPath = path.join(dirname, "../preload/electron-preload.mjs");
+  const mainWindow = new BrowserWindow({
+    title: "Harness Anything",
+    width: 1440,
+    height: 920,
+    minWidth: 1120,
+    minHeight: 720,
+    show: false,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      webSecurity: true,
+      preload: preloadPath
+    }
+  });
+
+  mainWindow.once("ready-to-show", () => mainWindow.show());
+  const rendererUrl = process.env.ELECTRON_RENDERER_URL;
+  if (rendererUrl) {
+    assertDevRendererUrl(rendererUrl);
+    void mainWindow.loadURL(rendererUrl);
+  } else {
+    void mainWindow.loadFile(path.join(dirname, "../renderer/index.html"));
+  }
+  return mainWindow;
+}
+
+export function installContentSecurityPolicy(): void {
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        "Content-Security-Policy": [guiContentSecurityPolicy]
+      }
+    });
+  });
+}
+
+export async function startGuiApp(): Promise<void> {
+  await app.whenReady();
+  installContentSecurityPolicy();
+  registerHarnessIpcHandlers(ipcMain, createGuiServiceBridge(resolveGuiProjectRoot()));
+  createMainWindow();
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) createMainWindow();
+  });
+}
+
+export function resolveGuiProjectRoot(): string {
+  return path.resolve(process.env.HARNESS_GUI_ROOT ?? process.cwd());
+}
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") app.quit();
+});
+
+if (process.argv[1]?.endsWith("electron-main.js")) {
+  void startGuiApp();
+}

--- a/packages/gui/src/main/ipc-handlers.ts
+++ b/packages/gui/src/main/ipc-handlers.ts
@@ -1,0 +1,19 @@
+import type { IpcMainInvokeEvent } from "electron";
+import { assertPreloadPayload, preloadAllowlist } from "../preload/allowlist.ts";
+import type { GuiServiceBridge } from "../api/service-bridge.ts";
+
+export interface HarnessIpcRegistrar {
+  readonly handle: (
+    channel: string,
+    listener: (event: IpcMainInvokeEvent, payload: unknown) => Promise<unknown>
+  ) => void;
+}
+
+export function registerHarnessIpcHandlers(registrar: HarnessIpcRegistrar, bridge: GuiServiceBridge): void {
+  for (const method of preloadAllowlist) {
+    registrar.handle(`harness:${method}`, async (_event, payload) => {
+      assertPreloadPayload(method, payload);
+      return bridge.invoke(method, payload);
+    });
+  }
+}

--- a/packages/gui/src/main/window-config.ts
+++ b/packages/gui/src/main/window-config.ts
@@ -1,0 +1,55 @@
+export interface GuiWebPreferences {
+  readonly nodeIntegration: false;
+  readonly contextIsolation: true;
+  readonly sandbox: true;
+  readonly webSecurity: true;
+  readonly preload: string;
+}
+
+export interface GuiWindowOptions {
+  readonly title: "Harness Anything";
+  readonly width: number;
+  readonly height: number;
+  readonly minWidth: number;
+  readonly minHeight: number;
+  readonly show: false;
+  readonly webPreferences: GuiWebPreferences;
+}
+
+export const guiContentSecurityPolicy = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self' http://127.0.0.1:*",
+  "object-src 'none'",
+  "base-uri 'none'",
+  "frame-ancestors 'none'"
+].join("; ");
+
+export function createGuiWindowOptions(preloadPath: string): GuiWindowOptions {
+  return {
+    title: "Harness Anything",
+    width: 1440,
+    height: 920,
+    minWidth: 1120,
+    minHeight: 720,
+    show: false,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      webSecurity: true,
+      preload: preloadPath
+    }
+  };
+}
+
+export function assertDevRendererUrl(url: string): true {
+  const parsed = new URL(url);
+  if (parsed.origin !== "http://127.0.0.1:5173") {
+    throw new Error("GUI V1 may load only the local dev renderer server.");
+  }
+  return true;
+}

--- a/packages/gui/src/preload/allowlist.ts
+++ b/packages/gui/src/preload/allowlist.ts
@@ -1,0 +1,31 @@
+export const HARNESS_PRELOAD_API = "harness";
+
+export const allowedPreloadApi = {
+  getTasks: "getTasks",
+  getTaskDetail: "getTaskDetail",
+  getTaskDocument: "getTaskDocument",
+  setTaskStatus: "setTaskStatus",
+  reviewTask: "reviewTask",
+  archiveTask: "archiveTask",
+  appendTaskProgress: "appendTaskProgress",
+  rebuildGovernance: "rebuildGovernance",
+  openShell: "openShell"
+} as const;
+
+export type PreloadApiMethod = keyof typeof allowedPreloadApi;
+
+export const preloadAllowlist = Object.freeze(Object.keys(allowedPreloadApi) as ReadonlyArray<PreloadApiMethod>);
+
+export function isAllowedPreloadApiMethod(method: string): method is PreloadApiMethod {
+  return preloadAllowlist.includes(method as PreloadApiMethod);
+}
+
+export function assertPreloadPayload(method: string, payload: unknown): true {
+  if (!isAllowedPreloadApiMethod(method)) {
+    throw new Error(`Preload method is not allowed: ${method}`);
+  }
+  if (payload !== null && (typeof payload !== "object" || Array.isArray(payload))) {
+    throw new Error("Preload payload must be an object or null.");
+  }
+  return true;
+}

--- a/packages/gui/src/preload/electron-preload.ts
+++ b/packages/gui/src/preload/electron-preload.ts
@@ -1,0 +1,17 @@
+import { contextBridge, ipcRenderer } from "electron";
+import {
+  HARNESS_PRELOAD_API,
+  assertPreloadPayload,
+  preloadAllowlist,
+  type PreloadApiMethod
+} from "./allowlist.ts";
+
+const exposedApi = Object.fromEntries(preloadAllowlist.map((method) => [
+  method,
+  (payload: unknown = null) => {
+    assertPreloadPayload(method, payload);
+    return ipcRenderer.invoke(`harness:${method}`, payload);
+  }
+])) as Record<PreloadApiMethod, (payload?: unknown) => Promise<unknown>>;
+
+contextBridge.exposeInMainWorld(HARNESS_PRELOAD_API, exposedApi);

--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement } from "react";
+import { rendererNavigation } from "./app-model.ts";
+
+export function App(): ReactElement {
+  return (
+    <main className="ha-shell">
+      <aside className="ha-sidebar" aria-label="Harness views">
+        <div className="ha-brand">Harness Anything</div>
+        <nav>
+          {rendererNavigation.map((item) => (
+            <button key={item.id} type="button" className="ha-nav-item">
+              {item.label}
+            </button>
+          ))}
+        </nav>
+      </aside>
+      <section className="ha-workspace" aria-label="Task board">
+        <header className="ha-header">
+          <h1>Board</h1>
+          <p>Local desktop controller foundation</p>
+        </header>
+        <div className="ha-columns">
+          {["Open", "Blocked", "In Review", "Terminal", "Unknown"].map((column) => (
+            <section key={column} className="ha-column">
+              <h2>{column}</h2>
+            </section>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/packages/gui/src/renderer/app-model.ts
+++ b/packages/gui/src/renderer/app-model.ts
@@ -1,0 +1,25 @@
+export interface RendererCapabilityModel {
+  readonly nodeGlobalsAvailable: false;
+  readonly privilegedModulesAvailable: false;
+  readonly receivesOnlyPreloadData: true;
+}
+
+export const rendererCapabilityModel: RendererCapabilityModel = {
+  nodeGlobalsAvailable: false,
+  privilegedModulesAvailable: false,
+  receivesOnlyPreloadData: true
+};
+
+export interface RendererNavigationItem {
+  readonly id: "board" | "list" | "detail" | "doc-viewer" | "review-queue" | "graph";
+  readonly label: string;
+}
+
+export const rendererNavigation: readonly RendererNavigationItem[] = [
+  { id: "board", label: "Board" },
+  { id: "list", label: "List" },
+  { id: "detail", label: "Detail" },
+  { id: "doc-viewer", label: "Docs" },
+  { id: "review-queue", label: "Review" },
+  { id: "graph", label: "Graph" }
+];

--- a/packages/gui/src/renderer/main.tsx
+++ b/packages/gui/src/renderer/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Renderer root was not found.");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/packages/gui/src/renderer/styles.css
+++ b/packages/gui/src/renderer/styles.css
@@ -1,0 +1,73 @@
+:root {
+  color: #14171a;
+  background: #f6f7f8;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+}
+
+button {
+  font: inherit;
+}
+
+.ha-shell {
+  display: grid;
+  min-height: 100vh;
+  grid-template-columns: 248px 1fr;
+}
+
+.ha-sidebar {
+  border-right: 1px solid #d8dde3;
+  background: #ffffff;
+  padding: 20px;
+}
+
+.ha-brand {
+  font-size: 14px;
+  font-weight: 700;
+  margin-bottom: 24px;
+}
+
+.ha-nav-item {
+  display: block;
+  width: 100%;
+  padding: 10px 12px;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  color: #30363d;
+}
+
+.ha-workspace {
+  padding: 28px;
+}
+
+.ha-header h1 {
+  margin: 0;
+  font-size: 28px;
+}
+
+.ha-header p {
+  margin: 6px 0 24px;
+  color: #68717d;
+}
+
+.ha-columns {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.ha-column {
+  min-height: 360px;
+  border: 1px solid #d8dde3;
+  background: #ffffff;
+  padding: 12px;
+}
+
+.ha-column h2 {
+  margin: 0;
+  font-size: 13px;
+}

--- a/packages/gui/src/terminal/boundary.ts
+++ b/packages/gui/src/terminal/boundary.ts
@@ -1,0 +1,20 @@
+export interface ShellPanelPolicy {
+  readonly spawnRequiresUserAction: true;
+  readonly hiddenCommandInjectionAllowed: false;
+  readonly outputCreatesTaskState: false;
+  readonly outputCreatesEvidence: false;
+}
+
+export const shellPanelPolicy: ShellPanelPolicy = {
+  spawnRequiresUserAction: true,
+  hiddenCommandInjectionAllowed: false,
+  outputCreatesTaskState: false,
+  outputCreatesEvidence: false
+};
+
+export function classifyShellOutput(_chunk: string): { readonly displayOnly: true; readonly stateChange: false } {
+  return {
+    displayOnly: true,
+    stateChange: false
+  };
+}

--- a/packages/gui/test/ipc-handler-registration.test.ts
+++ b/packages/gui/test/ipc-handler-registration.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { preloadAllowlist, registerHarnessIpcHandlers, type GuiServiceBridge } from "../src/index.ts";
+
+test("main process registers one IPC handler for each preload allowlist method", async () => {
+  const channels: string[] = [];
+  const bridge: GuiServiceBridge = {
+    invoke: async (method, payload) => ({ ok: true, method, payload })
+  };
+
+  const handlers = new Map<string, (event: never, payload: unknown) => Promise<unknown>>();
+  registerHarnessIpcHandlers({
+    handle: (channel, listener) => {
+      channels.push(channel);
+      handlers.set(channel, listener as (event: never, payload: unknown) => Promise<unknown>);
+    }
+  }, bridge);
+
+  assert.deepEqual(channels, preloadAllowlist.map((method) => `harness:${method}`));
+  assert.deepEqual(await handlers.get("harness:getTasks")?.(undefined as never, null), {
+    ok: true,
+    method: "getTasks",
+    payload: null
+  });
+  await assert.rejects(() => handlers.get("harness:getTasks")?.(undefined as never, "raw-string"), /payload must be an object/i);
+});

--- a/packages/gui/test/local-api-auth.test.ts
+++ b/packages/gui/test/local-api-auth.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  authorizeLocalApiRequest,
+  createLocalApiSession,
+  localApiBindHost,
+  localApiMaxBodyBytes
+} from "../src/index.ts";
+
+test("local API binds localhost and rejects missing or wrong authorization", () => {
+  const session = createLocalApiSession();
+
+  assert.equal(localApiBindHost, "127.0.0.1");
+  assert.equal(session.bindHost, "127.0.0.1");
+  assert.deepEqual(session.corsAllowedOrigins, []);
+  assert.equal(authorizeLocalApiRequest(session, { headers: {}, bodyBytes: 0 }), false);
+  assert.equal(authorizeLocalApiRequest(session, { headers: { authorization: "Bearer wrong" }, bodyBytes: 0 }), false);
+  assert.equal(authorizeLocalApiRequest(session, { headers: { authorization: `Bearer ${session.sessionToken}` }, bodyBytes: 0 }), true);
+  assert.equal(authorizeLocalApiRequest(session, { headers: { authorization: `Bearer ${session.sessionToken}` }, bodyBytes: localApiMaxBodyBytes + 1 }), false);
+});

--- a/packages/gui/test/markdown-sanitize.test.ts
+++ b/packages/gui/test/markdown-sanitize.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { sanitizeMarkdownHtml } from "../src/index.ts";
+
+test("Markdown sanitizer strips scripts, handlers, file embeds, remote embeds and private markers", () => {
+  const result = sanitizeMarkdownHtml([
+    "<h1>Task</h1>",
+    "<script>alert(1)</script>",
+    "<img src=\"file:///Users/example/secret.png\" onerror=\"steal()\">",
+    "<img src=\"https://example.invalid/remote.png\">",
+    "<a href=\"javascript:alert(1)\">bad</a>",
+    "<iframe src=\"data:text/html,<script>alert(1)</script>\"></iframe>",
+    "<img src=\"//example.invalid/protocol-relative.png\">",
+    "<img srcset=\"local.png 1x, https://example.invalid/remote-2x.png 2x\">",
+    "<a href=\".harness-private/review.md\">private</a>",
+    "api_key=abc123",
+    "Authorization: Bearer abc123",
+    "token=abc123",
+    "/tmp/harness-secret.txt",
+    "/private/var/tmp/harness-secret.txt"
+  ].join("\n"));
+
+  assert.equal(result.html.includes("<script"), false);
+  assert.equal(result.html.includes("onerror"), false);
+  assert.equal(result.html.includes("file://"), false);
+  assert.equal(result.html.includes("https://example.invalid"), false);
+  assert.equal(result.html.includes("javascript:"), false);
+  assert.equal(result.html.includes("data:text/html"), false);
+  assert.equal(result.html.includes("//example.invalid"), false);
+  assert.equal(result.html.includes("srcset="), false);
+  assert.equal(result.html.includes(".harness-private"), false);
+  assert.equal(result.html.includes("api_key"), false);
+  assert.equal(result.html.includes("Bearer abc123"), false);
+  assert.equal(result.html.includes("token=abc123"), false);
+  assert.equal(result.html.includes("/tmp/harness-secret.txt"), false);
+  assert.equal(result.html.includes("/private/var/tmp/harness-secret.txt"), false);
+  assert.deepEqual(result.strippedReasons, [
+    "absolute-local-path",
+    "data-embed",
+    "event-handler",
+    "file-embed",
+    "private-harness-path",
+    "remote-embed",
+    "script-tag",
+    "script-url",
+    "secret-marker"
+  ]);
+});

--- a/packages/gui/test/path-traversal.test.ts
+++ b/packages/gui/test/path-traversal.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { validateProjectPath } from "../src/index.ts";
+
+test("path guard rejects traversal, private folder access, absolute escape and file symlink escape", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-gui-root-"));
+  const outside = mkdtempSync(path.join(tmpdir(), "ha-gui-outside-"));
+  try {
+    mkdirSync(path.join(root, "tasks/task-1"), { recursive: true });
+    mkdirSync(path.join(root, ".harness-private"), { recursive: true });
+    writeFileSync(path.join(outside, "secret.md"), "secret");
+    symlinkSync(path.join(outside, "secret.md"), path.join(root, "tasks/task-1/link.md"));
+
+    assert.equal(validateProjectPath(root, "tasks/task-1/INDEX.md").ok, true);
+    assert.equal(validateProjectPath(root, "../outside.md").reason, "path_outside_project");
+    assert.equal(validateProjectPath(root, path.join(outside, "secret.md")).reason, "path_outside_project");
+    assert.equal(validateProjectPath(root, ".harness-private/review.md").reason, "path_is_private");
+    assert.equal(validateProjectPath(root, "tasks/task-1/link.md").reason, "path_outside_project");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test("path guard rejects missing files under symlinked parent directories", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-gui-root-"));
+  const outside = mkdtempSync(path.join(tmpdir(), "ha-gui-outside-"));
+  try {
+    mkdirSync(path.join(root, "tasks"), { recursive: true });
+    symlinkSync(outside, path.join(root, "tasks/outdir"));
+
+    assert.equal(
+      validateProjectPath(root, "tasks/outdir/new.md").reason,
+      "path_outside_project"
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});

--- a/packages/gui/test/preload-allowlist.test.ts
+++ b/packages/gui/test/preload-allowlist.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  HARNESS_PRELOAD_API,
+  assertPreloadPayload,
+  isAllowedPreloadApiMethod,
+  preloadAllowlist
+} from "../src/index.ts";
+
+test("preload exposes only the approved API methods", () => {
+  assert.equal(HARNESS_PRELOAD_API, "harness");
+  assert.deepEqual(preloadAllowlist, [
+    "getTasks",
+    "getTaskDetail",
+    "getTaskDocument",
+    "setTaskStatus",
+    "reviewTask",
+    "archiveTask",
+    "appendTaskProgress",
+    "rebuildGovernance",
+    "openShell"
+  ]);
+  assert.equal(isAllowedPreloadApiMethod("getTasks"), true);
+  assert.equal(isAllowedPreloadApiMethod("readFile"), false);
+  assert.throws(() => assertPreloadPayload("readFile", {}), /not allowed/);
+  assert.throws(() => assertPreloadPayload("getTasks", []), /object or null/);
+});

--- a/packages/gui/test/renderer-no-node.test.ts
+++ b/packages/gui/test/renderer-no-node.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { rendererCapabilityModel, rendererNavigation } from "../src/index.ts";
+
+test("renderer model has no Node or Electron privileged surface", () => {
+  assert.equal(rendererCapabilityModel.nodeGlobalsAvailable, false);
+  assert.equal(rendererCapabilityModel.privilegedModulesAvailable, false);
+  assert.equal(rendererCapabilityModel.receivesOnlyPreloadData, true);
+  assert.deepEqual(rendererNavigation.map((item) => item.id), [
+    "board",
+    "list",
+    "detail",
+    "doc-viewer",
+    "review-queue",
+    "graph"
+  ]);
+});
+
+test("renderer source does not import privileged modules", () => {
+  const source = readFileSync("packages/gui/src/renderer/app-model.ts", "utf8");
+
+  assert.equal(/\bfrom\s+["'](?:node:)?(?:fs|child_process|process|path|os|electron)["']/.test(source), false);
+});

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createGuiServiceBridge } from "../src/index.ts";
+
+test("GUI service bridge reaches application service while enforcing document path guard", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-bridge-"));
+  try {
+    writeTaskIndex(rootDir, "task-1", "Task One", "planned");
+    const bridge = createGuiServiceBridge(rootDir);
+
+    const list = await bridge.invoke("getTasks", null) as { readonly ok: boolean; readonly tasks: readonly unknown[] };
+    assert.equal(list.ok, true);
+    assert.equal(list.tasks.length, 1);
+
+    const document = await bridge.invoke("getTaskDocument", { taskId: "task-1", path: "INDEX.md" }) as { readonly ok: boolean; readonly body?: string };
+    assert.equal(document.ok, true);
+    assert.match(document.body ?? "", /Task One/);
+
+    const rejected = await bridge.invoke("getTaskDocument", { taskId: "task-1", path: "../../.harness-private/review.md" }) as { readonly ok: boolean; readonly error?: { readonly code: string } };
+    assert.equal(rejected.ok, false);
+    assert.equal(rejected.error?.code, "path_is_private");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function writeTaskIndex(rootDir: string, taskId: string, title: string, status: string): void {
+  mkdirSync(path.join(rootDir, "tasks", taskId), { recursive: true });
+  writeFileSync(path.join(rootDir, "tasks", taskId, "INDEX.md"), [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    `title: ${title}`,
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    `  status: ${status}`,
+    "  ref: ",
+    `  titleSnapshot: ${title}`,
+    "  url: ",
+    "  bindingCreatedAt: 2026-06-12T00:00:00.000Z",
+    "  bindingFingerprint: sha256:test",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "---",
+    ""
+  ].join("\n"), "utf8");
+}

--- a/packages/gui/test/terminal-no-ingestion.test.ts
+++ b/packages/gui/test/terminal-no-ingestion.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { classifyShellOutput, shellPanelPolicy } from "../src/index.ts";
+
+test("PTY output stays display-only and cannot create task state", () => {
+  assert.equal(shellPanelPolicy.spawnRequiresUserAction, true);
+  assert.equal(shellPanelPolicy.hiddenCommandInjectionAllowed, false);
+  assert.equal(shellPanelPolicy.outputCreatesTaskState, false);
+  assert.equal(shellPanelPolicy.outputCreatesEvidence, false);
+  assert.deepEqual(classifyShellOutput("status: done"), {
+    displayOnly: true,
+    stateChange: false
+  });
+});

--- a/packages/gui/test/window-config.test.ts
+++ b/packages/gui/test/window-config.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assertDevRendererUrl } from "../src/index.ts";
+
+test("dev renderer override accepts only the local Vite server", () => {
+  assert.equal(assertDevRendererUrl("http://127.0.0.1:5173"), true);
+  assert.throws(() => assertDevRendererUrl("file:///tmp/renderer/index.html"), /local dev renderer/);
+  assert.throws(() => assertDevRendererUrl("http://localhost:5173"), /local dev renderer/);
+  assert.throws(() => assertDevRendererUrl("https://example.invalid"), /local dev renderer/);
+});

--- a/tools/check-implementation-contracts.mjs
+++ b/tools/check-implementation-contracts.mjs
@@ -10,10 +10,13 @@ const expectedRuntimeTestFiles = {
   gui: [
     "packages/gui/test/renderer-no-node.test.ts",
     "packages/gui/test/preload-allowlist.test.ts",
+    "packages/gui/test/ipc-handler-registration.test.ts",
+    "packages/gui/test/service-bridge.test.ts",
     "packages/gui/test/markdown-sanitize.test.ts",
     "packages/gui/test/local-api-auth.test.ts",
     "packages/gui/test/path-traversal.test.ts",
-    "packages/gui/test/terminal-no-ingestion.test.ts"
+    "packages/gui/test/terminal-no-ingestion.test.ts",
+    "packages/application/test/local-controller-service.test.ts"
   ],
   store: [
     "packages/kernel/test/store/journal-idempotency.test.ts",
@@ -55,7 +58,7 @@ async function walk(dir) {
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "out") continue;
       files.push(...await walk(full));
     } else if (sourceFile.test(entry.name) && !entry.name.endsWith(".d.ts")) {
       files.push(full);
@@ -92,6 +95,7 @@ const expectedWorkspaceTsconfigs = [
   "packages/adapters/linear/tsconfig.json",
   "packages/adapters/local/tsconfig.json",
   "packages/adapters/multica/tsconfig.json",
+  "packages/application/tsconfig.json",
   "packages/cli/tsconfig.json",
   "packages/gui/tsconfig.json",
   "packages/kernel/tsconfig.json"
@@ -133,6 +137,69 @@ for (const [kind, active] of Object.entries({ gui: hasGuiImplementation, store: 
   if (!active) continue;
   for (const requiredPath of expectedRuntimeTestFiles[kind]) {
     if (!existsSync(path.join(root, requiredPath))) record(`${kind} implementation requires contract test: ${requiredPath}`);
+  }
+}
+
+if (hasGuiImplementation) {
+  const guiText = files
+    .filter((file) => relative(file).startsWith("packages/gui/"))
+    .map((file) => readFileSync(file, "utf8"))
+    .join("\n");
+  const applicationText = files
+    .filter((file) => relative(file).startsWith("packages/application/"))
+    .map((file) => readFileSync(file, "utf8"))
+    .join("\n");
+  const cliText = readFileSync(path.join(root, "packages/cli/src/index.ts"), "utf8");
+  for (const requiredSnippet of [
+    "nodeIntegration: false",
+    "contextIsolation: true",
+    "sandbox: true",
+    "webSecurity: true",
+    "guiContentSecurityPolicy",
+    "HARNESS_PRELOAD_API",
+    "allowedPreloadApi",
+    "localApiBindHost = \"127.0.0.1\"",
+    "createLocalApiSession",
+    "authorizeLocalApiRequest",
+    "validateProjectPath",
+    "sanitizeMarkdownHtml",
+    "registerHarnessIpcHandlers",
+    "createGuiServiceBridge",
+    "shellPanelPolicy",
+    "outputCreatesTaskState: false",
+    "buildGuiViewModel"
+  ]) {
+    if (!guiText.includes(requiredSnippet)) record(`GUI implementation must include ${requiredSnippet}`);
+  }
+  for (const requiredSnippet of [
+    "makeLocalControllerService",
+    "makeLocalLifecycleEngine",
+    "readTaskProjection"
+  ]) {
+    if (!applicationText.includes(requiredSnippet)) record(`application service must include ${requiredSnippet}`);
+  }
+  if (
+    !cliText.includes("command: \"gui\"")
+    || !cliText.includes("@harness-anything/gui")
+    || !cliText.includes("spawn(command[0]")
+    || !cliText.includes("HARNESS_GUI_ROOT")
+    || /from\s+["'][^"']*(?:packages\/gui|@harness-anything\/gui)/.test(cliText)
+  ) {
+    record("CLI must delegate a gui launch command without importing the GUI package");
+  }
+  const guiSecurityTests = expectedRuntimeTestFiles.gui.map((testPath) => readFileSync(path.join(root, testPath), "utf8")).join("\n");
+  for (const requiredEvidence of [
+    "renderer model has no Node or Electron privileged surface",
+    "preload exposes only the approved API methods",
+    "main process registers one IPC handler for each preload allowlist method",
+    "GUI service bridge reaches application service",
+    "local controller service reads projection and writes through local lifecycle service path",
+    "Markdown sanitizer strips scripts",
+    "local API binds localhost",
+    "path guard rejects traversal",
+    "PTY output stays display-only"
+  ]) {
+    if (!guiSecurityTests.includes(requiredEvidence)) record(`GUI security tests must prove: ${requiredEvidence}`);
   }
 }
 
@@ -333,8 +400,8 @@ for (const file of files) {
     }
   }
 
-  if (!rel.startsWith("packages/cli/src/") && /\b(?:Effect|E|Fx)\.runPromise\w*\s*\(|\brunPromise\w*\s*\(/.test(text)) {
-    record(`${rel}: Effect.runPromise* is only allowed at CLI composition roots`);
+  if (!rel.startsWith("packages/cli/src/") && !rel.startsWith("packages/application/src/") && /\b(?:Effect|E|Fx)\.runPromise\w*\s*\(|\brunPromise\w*\s*\(/.test(text)) {
+    record(`${rel}: Effect.runPromise* is only allowed at controller composition roots`);
   }
 
   if (rel.startsWith("packages/kernel/src/store/") && /\bfrom\s+["'][^"']*(?:packages\/adapters|@harness-anything\/adapter-)[^"']*["']/.test(text)) {

--- a/tools/check-import-boundaries.mjs
+++ b/tools/check-import-boundaries.mjs
@@ -21,7 +21,7 @@ async function walk(dir) {
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "out") continue;
       files.push(...await walk(full));
     } else if (sourceFile.test(entry.name)) {
       files.push(full);

--- a/tools/check-package-policy.mjs
+++ b/tools/check-package-policy.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 const root = process.cwd();
 const expectedPackages = new Map([
   ["packages/kernel/package.json", "@harness-anything/kernel"],
+  ["packages/application/package.json", "@harness-anything/application"],
   ["packages/cli/package.json", "@harness-anything/cli"],
   ["packages/gui/package.json", "@harness-anything/gui"],
   ["packages/adapters/local/package.json", "@harness-anything/adapter-local"],
@@ -39,6 +40,7 @@ for (const [relativePath, expectedName] of expectedPackages.entries()) {
 
 for (const relativePath of [
   "packages/kernel/.git",
+  "packages/application/.git",
   "packages/cli/.git",
   "packages/gui/.git",
   "packages/adapters/local/.git",

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -7,7 +7,7 @@ import { spawn } from "node:child_process";
 const repoRoot = resolve(import.meta.dirname, "..");
 const roots = ["packages", "tools"];
 const testFilePattern = /\.(test|spec)\.(?:mjs|js|ts)$/u;
-const ignoredDirectoryNames = new Set(["node_modules", "dist", "coverage", ".git"]);
+const ignoredDirectoryNames = new Set(["node_modules", "dist", "out", "coverage", ".git"]);
 
 async function collectTestFiles(directory) {
   const entries = await readdir(directory, { withFileTypes: true });

--- a/tools/scan-forbidden-symbols.mjs
+++ b/tools/scan-forbidden-symbols.mjs
@@ -24,7 +24,7 @@ async function walk(dir) {
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "out") continue;
       files.push(...await walk(full));
     } else if (sourceFile.test(entry.name)) {
       files.push(full);
@@ -55,4 +55,3 @@ if (violations.length > 0) {
 }
 
 console.log("Forbidden symbol scan passed.");
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./packages/kernel" },
+    { "path": "./packages/application" },
     { "path": "./packages/cli" },
     { "path": "./packages/gui" },
     { "path": "./packages/adapters/local" },
@@ -10,4 +11,3 @@
     { "path": "./packages/adapters/linear" }
   ]
 }
-


### PR DESCRIPTION
## Summary

- scaffold the KR-09 Electron/React GUI foundation with secure BrowserWindow defaults, CSP, preload allowlist, renderer no-Node boundary, and local desktop controller UI
- add `@harness-anything/application` as the GUI/controller composition path over kernel projection reads and local lifecycle writes
- add `harness gui` delegation to `@harness-anything/gui` without importing GUI code into the CLI
- strengthen GUI security gates for IPC handler registration, service bridge path guards, sanitizer coverage, symlink escape rejection, terminal display-only behavior, and implementation contracts

## Clean-Room Boundary

- no legacy runtime/schema/npm API compatibility
- no `scripts-refactor` route
- no GitHub/Linear adapter implementation
- no npm publish config
- GUI is not an agent runtime control plane; terminal output remains display-only and cannot create task/evidence state

## Review / Fix Loop

- Goodall review found P1/P2 issues around `harness gui` delegation, missing IPC/service bridge, preload `.mjs` path, and sanitizer coverage; fixed
- GUI/security review found P1/P2 issues around symlink-parent path escape and weak boundary tests; fixed
- follow-up P3 hardening for array payload rejection and broader local-path stripping also fixed

## Verification

- `npm run --workspace @harness-anything/gui build`
- `npm run check` (89 node tests plus import boundary, forbidden symbol scan, private boundary, package policy, implementation contracts, schema contracts)
