### PR TITLE
fix: ignore local worktrees in cutover check

### DIFF
--- a/tools/check-cutover-readiness.mjs
+++ b/tools/check-cutover-readiness.mjs
@@ -222,7 +222,7 @@ async function collectFiles(directory) {
   for (const entry of entries) {
     const full = path.join(directory, entry.name);
     if (entry.isDirectory()) {
-      if (["node_modules", "dist", "out", "coverage"].includes(entry.name)) continue;
+      if (ignoredDirectoryNames.has(entry.name)) continue;
       files.push(...await collectFiles(full));
     } else if (entry.isFile() && (sourceFilePattern.test(entry.name) || entry.name.endsWith(".md") || entry.name.endsWith(".yml") || entry.name.endsWith(".yaml") || entry.name === "package.json")) {
       files.push(full);
@@ -230,6 +230,17 @@ async function collectFiles(directory) {
   }
   return files;
 }
+
+const ignoredDirectoryNames = new Set([
+  ".git",
+  ".harness",
+  ".harness-private",
+  ".worktrees",
+  "coverage",
+  "dist",
+  "node_modules",
+  "out"
+]);
 
 function readJson(root, rel) {
   return JSON.parse(readFileSync(path.join(root, rel), "utf8"));

--- a/tools/check-cutover-readiness.test.mjs
+++ b/tools/check-cutover-readiness.test.mjs
@@ -28,6 +28,22 @@ test("cutover readiness allows old runtime references in tests and behavior repo
   });
 });
 
+test("cutover readiness ignores private harness files inside local worktrees", async () => {
+  await withFixtureRepo(async (root) => {
+    mkdirSync(path.join(root, ".worktrees/gui-prototype-private-context/.harness-private"), { recursive: true });
+    writeFileSync(path.join(root, ".worktrees/gui-prototype-private-context/.harness-private/AGENTS.md"), [
+      "Local-only harness note.",
+      "It may mention scripts/kernel/task and requestTransition because it is not public surface.",
+      "It may also mention coding-agent-harness compatibility.",
+      ""
+    ].join("\n"));
+
+    const violations = await evaluateCutoverReadiness(root);
+
+    assert.deepEqual(violations, []);
+  });
+});
+
 test("cutover readiness requires the harness-anything CLI package artifact bin surface", async () => {
   await withFixtureRepo(async (root) => {
     writeFileSync(path.join(root, "packages/cli/package.json"), JSON.stringify({


### PR DESCRIPTION
## Summary
- ignore local/private worktree directories when collecting cutover readiness public text files
- add a regression test for .worktrees/**/.harness-private content containing retired runtime references

## Verification
- node --test tools/check-cutover-readiness.test.mjs
- node tools/check-cutover-readiness.mjs
- npm run check