### PR TITLE
feat: add preset and module CLI runtime

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1297,7 +1297,7 @@ function runExtensionCommand(command: ParsedCommand): CliResult {
     }
 
     if (command.action.kind === "preset-run") {
-      return runPresetEntrypoint(command.rootDir, command.action.presetId, command.action.entrypoint, command.action.taskId);
+      return runPresetEntrypoint(command.rootDir, command.action.presetId, command.action.entrypoint, command.action.taskId, "preset-run");
     }
 
     if (command.action.kind === "preset-action") {
@@ -1309,7 +1309,7 @@ function runExtensionCommand(command: ParsedCommand): CliResult {
           error: { code: "preset_action_forbidden", hint: `Preset action ${command.action.actionName} is not declared.` }
         };
       }
-      return runPresetEntrypoint(command.rootDir, command.action.presetId, command.action.actionName, command.action.taskId);
+      return runPresetEntrypoint(command.rootDir, command.action.presetId, command.action.actionName, command.action.taskId, "preset-action");
     }
 
     if (command.action.kind === "module-list") {
@@ -1417,6 +1417,17 @@ function runExtensionCommand(command: ParsedCommand): CliResult {
       }
     };
   } catch (error) {
+    if (error instanceof Error && error.message.startsWith("invalid_registry_key:")) {
+      const label = error.message.split(":")[1] ?? "registry";
+      return {
+        ok: false,
+        command: command.action.kind,
+        error: {
+          code: "invalid_registry_key",
+          hint: `Invalid ${label} key.`
+        }
+      };
+    }
     return {
       ok: false,
       command: command.action.kind,
@@ -1561,7 +1572,13 @@ function presetManifestPath(rootDir: string, layer: "project" | "user", presetId
   return path.join(presetLayerRoot(rootDir, layer), presetId, "preset.json");
 }
 
-function runPresetEntrypoint(rootDir: string, presetId: string, entrypoint: "plan" | "scaffold" | "check", taskId: string): CliResult {
+function runPresetEntrypoint(
+  rootDir: string,
+  presetId: string,
+  entrypoint: "plan" | "scaffold" | "check",
+  taskId: string,
+  commandName: "preset-run" | "preset-action"
+): CliResult {
   const preset = resolvePreset(rootDir, presetId);
   if (!preset) return presetNotFound("preset-run", presetId);
   validateRegistryKey(taskId, "task");
@@ -1586,7 +1603,7 @@ function runPresetEntrypoint(rootDir: string, presetId: string, entrypoint: "pla
   writeFileSync(path.join(evidenceDir, "evidence.json"), JSON.stringify(evidence, null, 2), "utf8");
   return {
     ok: true,
-    command: "preset-run",
+    command: commandName,
     preset: publicPresetSummary(preset),
     evidenceBundle: path.relative(rootDir, evidenceDir).split(path.sep).join("/"),
     report: evidence
@@ -1647,7 +1664,7 @@ function moduleNotFound(command: string, moduleKey: string): CliResult {
 
 function validateRegistryKey(value: string, label: string): void {
   if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/u.test(value)) {
-    throw new Error(`invalid ${label} key`);
+    throw new Error(`invalid_registry_key:${label}`);
   }
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, realpathSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Effect } from "effect";
@@ -26,6 +26,8 @@ import {
   validateVerticalDefinition
 } from "../../kernel/src/index.ts";
 
+type PresetManifest = Schema.Schema.Type<typeof PresetManifestSchema>;
+
 export interface CliResult {
   readonly ok: boolean;
   readonly command: string;
@@ -38,7 +40,12 @@ export interface CliResult {
   readonly mode?: "soft" | "hard";
   readonly tasks?: ReadonlyArray<unknown>;
   readonly templates?: ReadonlyArray<unknown>;
+  readonly presets?: ReadonlyArray<unknown>;
+  readonly preset?: unknown;
+  readonly modules?: ReadonlyArray<unknown>;
+  readonly module?: unknown;
   readonly document?: unknown;
+  readonly evidenceBundle?: string;
   readonly issues?: ReadonlyArray<unknown>;
   readonly rows?: number;
   readonly warnings?: ReadonlyArray<unknown>;
@@ -87,6 +94,21 @@ const commandRegistry = [
   { kind: "status", primary: "harness status --json", resultEnvelope: "CliResult/v1" },
   { kind: "check", primary: "harness check [--post-merge] [--json]", resultEnvelope: "CliResult/v1" },
   { kind: "governance-rebuild", primary: "harness governance rebuild [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "preset-list", primary: "harness preset list [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "preset-inspect", primary: "harness preset inspect <id> [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "preset-check", primary: "harness preset check <id> [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "preset-install", primary: "harness preset install <folder> [--project] [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "preset-seed", primary: "harness preset seed [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "preset-audit", primary: "harness preset audit [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "preset-uninstall", primary: "harness preset uninstall <id> [--project] [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "preset-run", primary: "harness preset run <id> <plan|scaffold|check> --task <id> [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "preset-action", primary: "harness preset action <id> <action> --task <id> [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "module-list", primary: "harness module list [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "module-inspect", primary: "harness module inspect <key> [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "module-register", primary: "harness module register <key> --title <title> --scope <path> [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "module-scaffold", primary: "harness module scaffold <key> [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "module-unregister", primary: "harness module unregister <key> [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "module-step", primary: "harness module-step <key> <step> --state <state> [--json]", resultEnvelope: "CliResult/v1" },
   { kind: "gui", primary: "harness gui", resultEnvelope: "CliResult/v1" }
 ] as const satisfies ReadonlyArray<CommandRegistryEntry>;
 
@@ -112,6 +134,21 @@ interface ParsedCommand {
     | { readonly kind: "template-list"; readonly catalogPath: string }
     | { readonly kind: "template-render"; readonly templateRef: string; readonly catalogPath: string; readonly locale: "zh-CN" | "en-US" }
     | { readonly kind: "preset-validate"; readonly manifestPath: string; readonly kernelVersion: string }
+    | { readonly kind: "preset-list" }
+    | { readonly kind: "preset-inspect"; readonly presetId: string }
+    | { readonly kind: "preset-check"; readonly presetId: string }
+    | { readonly kind: "preset-install"; readonly sourcePath: string; readonly layer: "project" | "user" }
+    | { readonly kind: "preset-seed" }
+    | { readonly kind: "preset-audit" }
+    | { readonly kind: "preset-uninstall"; readonly presetId: string; readonly layer: "project" | "user" }
+    | { readonly kind: "preset-run"; readonly presetId: string; readonly entrypoint: "plan" | "scaffold" | "check"; readonly taskId: string }
+    | { readonly kind: "preset-action"; readonly presetId: string; readonly actionName: string; readonly taskId: string }
+    | { readonly kind: "module-list" }
+    | { readonly kind: "module-inspect"; readonly moduleKey: string }
+    | { readonly kind: "module-register"; readonly moduleKey: string; readonly title: string; readonly scope: string }
+    | { readonly kind: "module-scaffold"; readonly moduleKey: string }
+    | { readonly kind: "module-unregister"; readonly moduleKey: string }
+    | { readonly kind: "module-step"; readonly moduleKey: string; readonly stepId: string; readonly state: "planned" | "in-progress" | "blocked" | "done" }
     | { readonly kind: "vertical-validate"; readonly definitionPath: string };
 }
 
@@ -921,6 +958,80 @@ function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; readonly v
     };
   }
 
+  if (args[0] === "preset" && args[1] === "list") {
+    return { ok: true, value: { rootDir, json, action: { kind: "preset-list" } } };
+  }
+
+  if (args[0] === "preset" && args[1] === "inspect" && args[2]) {
+    return { ok: true, value: { rootDir, json, action: { kind: "preset-inspect", presetId: args[2] } } };
+  }
+
+  if (args[0] === "preset" && args[1] === "check" && args[2]) {
+    return { ok: true, value: { rootDir, json, action: { kind: "preset-check", presetId: args[2] } } };
+  }
+
+  if (args[0] === "preset" && args[1] === "install" && args[2]) {
+    return { ok: true, value: { rootDir, json, action: { kind: "preset-install", sourcePath: args[2], layer: args.includes("--project") ? "project" : "user" } } };
+  }
+
+  if (args[0] === "preset" && args[1] === "seed") {
+    return { ok: true, value: { rootDir, json, action: { kind: "preset-seed" } } };
+  }
+
+  if (args[0] === "preset" && args[1] === "audit") {
+    return { ok: true, value: { rootDir, json, action: { kind: "preset-audit" } } };
+  }
+
+  if (args[0] === "preset" && args[1] === "uninstall" && args[2]) {
+    return { ok: true, value: { rootDir, json, action: { kind: "preset-uninstall", presetId: args[2], layer: args.includes("--project") ? "project" : "user" } } };
+  }
+
+  if (args[0] === "preset" && args[1] === "run" && args[2] && args[3]) {
+    const taskId = readOption(args, "--task");
+    if (!taskId) return { ok: false, error: { code: "missing_task", hint: "preset run requires --task <id>." } };
+    if (args[3] !== "plan" && args[3] !== "scaffold" && args[3] !== "check") {
+      return { ok: false, error: { code: "invalid_entrypoint", hint: `Unknown preset entrypoint: ${args[3]}` } };
+    }
+    return { ok: true, value: { rootDir, json, action: { kind: "preset-run", presetId: args[2], entrypoint: args[3], taskId } } };
+  }
+
+  if (args[0] === "preset" && args[1] === "action" && args[2] && args[3]) {
+    const taskId = readOption(args, "--task");
+    if (!taskId) return { ok: false, error: { code: "missing_task", hint: "preset action requires --task <id>." } };
+    return { ok: true, value: { rootDir, json, action: { kind: "preset-action", presetId: args[2], actionName: args[3], taskId } } };
+  }
+
+  if (args[0] === "module" && args[1] === "list") {
+    return { ok: true, value: { rootDir, json, action: { kind: "module-list" } } };
+  }
+
+  if (args[0] === "module" && args[1] === "inspect" && args[2]) {
+    return { ok: true, value: { rootDir, json, action: { kind: "module-inspect", moduleKey: args[2] } } };
+  }
+
+  if (args[0] === "module" && args[1] === "register" && args[2]) {
+    const title = readOption(args, "--title");
+    const scope = readOption(args, "--scope");
+    if (!title || !scope) return { ok: false, error: { code: "missing_module_fields", hint: "module register requires --title and --scope." } };
+    return { ok: true, value: { rootDir, json, action: { kind: "module-register", moduleKey: args[2], title, scope } } };
+  }
+
+  if (args[0] === "module" && args[1] === "scaffold" && args[2]) {
+    return { ok: true, value: { rootDir, json, action: { kind: "module-scaffold", moduleKey: args[2] } } };
+  }
+
+  if (args[0] === "module" && args[1] === "unregister" && args[2]) {
+    return { ok: true, value: { rootDir, json, action: { kind: "module-unregister", moduleKey: args[2] } } };
+  }
+
+  if (args[0] === "module-step" && args[1] && args[2]) {
+    const state = readOption(args, "--state") ?? "in-progress";
+    if (state !== "planned" && state !== "in-progress" && state !== "blocked" && state !== "done") {
+      return { ok: false, error: { code: "invalid_module_step_state", hint: `Unknown module step state: ${state}` } };
+    }
+    return { ok: true, value: { rootDir, json, action: { kind: "module-step", moduleKey: args[1], stepId: args[2], state } } };
+  }
+
   if (args[0] === "vertical" && args[1] === "validate" && args[2]) {
     return {
       ok: true,
@@ -954,8 +1065,49 @@ function actionTaskId(action: ParsedCommand["action"]): string | undefined {
   return "taskId" in action ? action.taskId : undefined;
 }
 
-function isExtensionAction(action: ParsedCommand["action"]): action is Extract<ParsedCommand["action"], { readonly kind: "template-list" | "template-render" | "preset-validate" | "vertical-validate" }> {
-  return action.kind === "template-list" || action.kind === "template-render" || action.kind === "preset-validate" || action.kind === "vertical-validate";
+function isExtensionAction(action: ParsedCommand["action"]): action is Extract<ParsedCommand["action"], {
+  readonly kind:
+    | "template-list"
+    | "template-render"
+    | "preset-validate"
+    | "preset-list"
+    | "preset-inspect"
+    | "preset-check"
+    | "preset-install"
+    | "preset-seed"
+    | "preset-audit"
+    | "preset-uninstall"
+    | "preset-run"
+    | "preset-action"
+    | "module-list"
+    | "module-inspect"
+    | "module-register"
+    | "module-scaffold"
+    | "module-unregister"
+    | "module-step"
+    | "vertical-validate"
+}> {
+  return [
+    "template-list",
+    "template-render",
+    "preset-validate",
+    "preset-list",
+    "preset-inspect",
+    "preset-check",
+    "preset-install",
+    "preset-seed",
+    "preset-audit",
+    "preset-uninstall",
+    "preset-run",
+    "preset-action",
+    "module-list",
+    "module-inspect",
+    "module-register",
+    "module-scaffold",
+    "module-unregister",
+    "module-step",
+    "vertical-validate"
+  ].includes(action.kind);
 }
 
 function runExtensionCommand(command: ParsedCommand): CliResult {
@@ -1034,6 +1186,210 @@ function runExtensionCommand(command: ParsedCommand): CliResult {
       };
     }
 
+    if (command.action.kind === "preset-list") {
+      return {
+        ok: true,
+        command: "preset-list",
+        presets: discoverPresets(command.rootDir).map(publicPresetSummary)
+      };
+    }
+
+    if (command.action.kind === "preset-inspect") {
+      const preset = resolvePreset(command.rootDir, command.action.presetId);
+      if (!preset) return presetNotFound("preset-inspect", command.action.presetId);
+      return {
+        ok: true,
+        command: "preset-inspect",
+        preset: {
+          ...publicPresetSummary(preset),
+          manifest: preset.manifest
+        }
+      };
+    }
+
+    if (command.action.kind === "preset-check") {
+      const preset = resolvePreset(command.rootDir, command.action.presetId);
+      if (!preset) return presetNotFound("preset-check", command.action.presetId);
+      const validation = validatePresetManifests([preset.manifest], { kernelVersion: "1.0.0" });
+      return {
+        ok: validation.ok,
+        command: "preset-check",
+        preset: publicPresetSummary(preset),
+        issues: validation.issues,
+        error: validation.ok ? undefined : {
+          code: "preset_manifest_invalid",
+          hint: "Preset manifest failed validation."
+        }
+      };
+    }
+
+    if (command.action.kind === "preset-install") {
+      const manifest = readPresetManifestFromSource(command.action.sourcePath);
+      const validation = validatePresetManifests([manifest], { kernelVersion: "1.0.0" });
+      if (!validation.ok) {
+        return {
+          ok: false,
+          command: "preset-install",
+          preset: { id: manifest.id },
+          issues: validation.issues,
+          error: { code: "preset_manifest_invalid", hint: "Preset manifest failed validation." }
+        };
+      }
+      const target = presetManifestPath(command.rootDir, command.action.layer, manifest.id);
+      mkdirSync(path.dirname(target), { recursive: true });
+      writeFileSync(target, JSON.stringify(manifest, null, 2), "utf8");
+      return {
+        ok: true,
+        command: "preset-install",
+        preset: publicPresetSummary({ manifest, layer: command.action.layer, sourcePath: target })
+      };
+    }
+
+    if (command.action.kind === "preset-seed") {
+      for (const manifest of bundledPresetManifests()) {
+        const target = presetManifestPath(command.rootDir, "user", manifest.id);
+        if (!existsSync(target)) {
+          mkdirSync(path.dirname(target), { recursive: true });
+          writeFileSync(target, JSON.stringify(manifest, null, 2), "utf8");
+        }
+      }
+      return {
+        ok: true,
+        command: "preset-seed",
+        presets: discoverPresets(command.rootDir).filter((preset) => preset.layer === "user").map(publicPresetSummary)
+      };
+    }
+
+    if (command.action.kind === "preset-audit") {
+      const resolved = discoverPresets(command.rootDir);
+      const bundledById = new Map(bundledPresetManifests().map((manifest) => [manifest.id, manifest.version]));
+      const drift = resolved
+        .filter((preset) => preset.layer !== "builtin" && bundledById.has(preset.manifest.id) && bundledById.get(preset.manifest.id) !== preset.manifest.version)
+        .map((preset) => ({
+          id: preset.manifest.id,
+          layer: preset.layer,
+          installedVersion: preset.manifest.version,
+          bundledVersion: bundledById.get(preset.manifest.id)
+        }));
+      return {
+        ok: true,
+        command: "preset-audit",
+        presets: resolved.map(publicPresetSummary),
+        report: {
+          totalResolved: resolved.length,
+          drift
+        }
+      };
+    }
+
+    if (command.action.kind === "preset-uninstall") {
+      const target = presetManifestPath(command.rootDir, command.action.layer, command.action.presetId);
+      if (!existsSync(target)) return presetNotFound("preset-uninstall", command.action.presetId);
+      rmSync(path.dirname(target), { recursive: true, force: true });
+      return {
+        ok: true,
+        command: "preset-uninstall",
+        preset: {
+          id: command.action.presetId,
+          layer: command.action.layer
+        }
+      };
+    }
+
+    if (command.action.kind === "preset-run") {
+      return runPresetEntrypoint(command.rootDir, command.action.presetId, command.action.entrypoint, command.action.taskId);
+    }
+
+    if (command.action.kind === "preset-action") {
+      if (command.action.actionName !== "plan" && command.action.actionName !== "scaffold" && command.action.actionName !== "check") {
+        return {
+          ok: false,
+          command: "preset-action",
+          preset: { id: command.action.presetId },
+          error: { code: "preset_action_forbidden", hint: `Preset action ${command.action.actionName} is not declared.` }
+        };
+      }
+      return runPresetEntrypoint(command.rootDir, command.action.presetId, command.action.actionName, command.action.taskId);
+    }
+
+    if (command.action.kind === "module-list") {
+      return {
+        ok: true,
+        command: "module-list",
+        modules: readModules(command.rootDir).modules.filter((module) => module.status !== "unregistered")
+      };
+    }
+
+    if (command.action.kind === "module-inspect") {
+      const action = command.action;
+      const module = readModules(command.rootDir).modules.find((candidate) => candidate.key === action.moduleKey);
+      if (!module || module.status === "unregistered") return moduleNotFound("module-inspect", action.moduleKey);
+      return { ok: true, command: "module-inspect", module };
+    }
+
+    if (command.action.kind === "module-register") {
+      const action = command.action;
+      const registry = readModules(command.rootDir);
+      const existing = registry.modules.find((module) => module.key === action.moduleKey);
+      const module = {
+        key: action.moduleKey,
+        title: action.title,
+        status: "active",
+        scopes: [action.scope],
+        steps: [] as Array<{ readonly id: string; readonly state: string }>
+      };
+      const modules = existing
+        ? registry.modules.map((candidate) => candidate.key === action.moduleKey ? module : candidate)
+        : [...registry.modules, module];
+      writeModules(command.rootDir, { modules });
+      return { ok: true, command: "module-register", module };
+    }
+
+    if (command.action.kind === "module-scaffold") {
+      const action = command.action;
+      const registry = readModules(command.rootDir);
+      const module = registry.modules.find((candidate) => candidate.key === action.moduleKey);
+      if (!module || module.status === "unregistered") return moduleNotFound("module-scaffold", action.moduleKey);
+      const moduleRoot = path.join(resolveHarnessLayout(command.rootDir).planningRoot, "modules", module.key);
+      mkdirSync(moduleRoot, { recursive: true });
+      writeIfMissing(path.join(moduleRoot, "brief.md"), `# ${module.title}\n\nModule key: ${module.key}\n`);
+      writeIfMissing(path.join(moduleRoot, "module_plan.md"), `# ${module.title} Module Plan\n\n| Step | State |\n| --- | --- |\n`);
+      return {
+        ok: true,
+        command: "module-scaffold",
+        module,
+        path: path.relative(command.rootDir, path.join(moduleRoot, "module_plan.md")).split(path.sep).join("/")
+      };
+    }
+
+    if (command.action.kind === "module-unregister") {
+      const action = command.action;
+      const registry = readModules(command.rootDir);
+      const module = registry.modules.find((candidate) => candidate.key === action.moduleKey);
+      if (!module || module.status === "unregistered") return moduleNotFound("module-unregister", action.moduleKey);
+      const next = { ...module, status: "unregistered" };
+      writeModules(command.rootDir, {
+        modules: registry.modules.map((candidate) => candidate.key === module.key ? next : candidate)
+      });
+      return { ok: true, command: "module-unregister", module: next };
+    }
+
+    if (command.action.kind === "module-step") {
+      const action = command.action;
+      const registry = readModules(command.rootDir);
+      const module = registry.modules.find((candidate) => candidate.key === action.moduleKey);
+      if (!module || module.status === "unregistered") return moduleNotFound("module-step", action.moduleKey);
+      const step = { id: action.stepId, state: action.state };
+      const steps = module.steps.some((candidate) => candidate.id === step.id)
+        ? module.steps.map((candidate) => candidate.id === step.id ? step : candidate)
+        : [...module.steps, step];
+      const next = { ...module, steps };
+      writeModules(command.rootDir, {
+        modules: registry.modules.map((candidate) => candidate.key === module.key ? next : candidate)
+      });
+      return { ok: true, command: "module-step", module: next };
+    }
+
     if (command.action.kind === "vertical-validate") {
       const decoded = decodeExtensionJsonFile("vertical-definition", command.action.definitionPath, VerticalDefinitionSchema);
       if (!decoded.ok) {
@@ -1070,6 +1426,233 @@ function runExtensionCommand(command: ParsedCommand): CliResult {
       }
     };
   }
+}
+
+interface ResolvedPreset {
+  readonly manifest: PresetManifest;
+  readonly layer: "project" | "user" | "builtin";
+  readonly sourcePath: string;
+}
+
+interface ModuleRegistry {
+  readonly modules: ReadonlyArray<ModuleRecord>;
+}
+
+interface ModuleRecord {
+  readonly key: string;
+  readonly title: string;
+  readonly status: string;
+  readonly scopes: ReadonlyArray<string>;
+  readonly steps: ReadonlyArray<{ readonly id: string; readonly state: string }>;
+}
+
+const bundledPresetIds = [
+  "standard-task",
+  "module",
+  "legacy-migration",
+  "lesson-sedimentation",
+  "version-upgrade",
+  "publish-standard",
+  "release-closeout"
+] as const;
+
+function discoverPresets(rootDir: string): ReadonlyArray<ResolvedPreset> {
+  const byId = new Map<string, ResolvedPreset>();
+  for (const manifest of bundledPresetManifests()) {
+    byId.set(manifest.id, { manifest, layer: "builtin", sourcePath: `builtin:${manifest.id}` });
+  }
+  for (const layer of ["user", "project"] as const) {
+    for (const preset of readLayerPresets(rootDir, layer)) {
+      byId.set(preset.manifest.id, preset);
+    }
+  }
+  return [...byId.values()].sort((left, right) => left.manifest.id.localeCompare(right.manifest.id));
+}
+
+function resolvePreset(rootDir: string, presetId: string): ResolvedPreset | undefined {
+  return discoverPresets(rootDir).find((preset) => preset.manifest.id === presetId);
+}
+
+function publicPresetSummary(preset: ResolvedPreset): Record<string, unknown> {
+  return {
+    id: preset.manifest.id,
+    title: preset.manifest.title,
+    version: preset.manifest.version,
+    vertical: preset.manifest.vertical,
+    defaultProfile: preset.manifest.defaultProfile,
+    layer: preset.layer,
+    sourcePath: safePresetSourcePath(preset.sourcePath)
+  };
+}
+
+function safePresetSourcePath(sourcePath: string): string {
+  return sourcePath.startsWith("builtin:") ? sourcePath : sourcePath.split(path.sep).slice(-3).join("/");
+}
+
+function readLayerPresets(rootDir: string, layer: "project" | "user"): ReadonlyArray<ResolvedPreset> {
+  const layerRoot = presetLayerRoot(rootDir, layer);
+  if (!existsSync(layerRoot)) return [];
+  return readdirSync(layerRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(layerRoot, entry.name, "preset.json"))
+    .filter((presetPath) => existsSync(presetPath))
+    .map((presetPath) => ({
+      manifest: decodePresetManifestFile(presetPath),
+      layer,
+      sourcePath: presetPath
+    }));
+}
+
+function bundledPresetManifests(): ReadonlyArray<PresetManifest> {
+  return bundledPresetIds.map((id): PresetManifest => ({
+    schema: "preset-manifest/v1",
+    id,
+    title: titleizePresetId(id),
+    vertical: "software/coding",
+    version: "1.0.0",
+    kernelVersionRange: {
+      min: "1.0.0",
+      maxExclusive: "2.0.0"
+    },
+    capabilityImports: [{
+      id: `${id}-check`,
+      kind: "checker",
+      version: "1",
+      required: false
+    }],
+    profiles: [{
+      id: "baseline",
+      title: "Baseline",
+      checkerProfile: "standard",
+      templateSelections: []
+    }],
+    defaultProfile: "baseline"
+  }));
+}
+
+function titleizePresetId(id: string): string {
+  return id.split("-").map((part) => part.length > 0 ? `${part[0]?.toUpperCase()}${part.slice(1)}` : part).join(" ");
+}
+
+function readPresetManifestFromSource(sourcePath: string): PresetManifest {
+  const resolved = path.resolve(sourcePath);
+  const presetPath = existsSync(path.join(resolved, "preset.json")) ? path.join(resolved, "preset.json") : resolved;
+  return decodePresetManifestFile(presetPath);
+}
+
+function decodePresetManifestFile(presetPath: string): PresetManifest {
+  const raw = JSON.parse(readFileSync(presetPath, "utf8")) as unknown;
+  const shape = validateExtensionInputShape("preset-manifest", raw);
+  if (!shape.ok) {
+    throw new Error("preset manifest shape invalid");
+  }
+  return Schema.decodeUnknownSync(PresetManifestSchema)(raw);
+}
+
+function presetLayerRoot(rootDir: string, layer: "project" | "user"): string {
+  const layout = resolveHarnessLayout(rootDir);
+  return layer === "project"
+    ? path.join(layout.localRoot, "presets")
+    : path.join(layout.localRoot, "user-presets");
+}
+
+function presetManifestPath(rootDir: string, layer: "project" | "user", presetId: string): string {
+  validateRegistryKey(presetId, "preset");
+  return path.join(presetLayerRoot(rootDir, layer), presetId, "preset.json");
+}
+
+function runPresetEntrypoint(rootDir: string, presetId: string, entrypoint: "plan" | "scaffold" | "check", taskId: string): CliResult {
+  const preset = resolvePreset(rootDir, presetId);
+  if (!preset) return presetNotFound("preset-run", presetId);
+  validateRegistryKey(taskId, "task");
+  const evidenceDir = path.join(resolveHarnessLayout(rootDir).localRoot, "evidence", "presets", presetId, timestampForPath());
+  mkdirSync(evidenceDir, { recursive: true });
+  const generated: string[] = [];
+  if (entrypoint === "scaffold") {
+    const outputPath = path.join(resolveHarnessLayout(rootDir).generatedRoot, "preset-scaffold", taskId, `${presetId}.md`);
+    mkdirSync(path.dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, `# ${preset.manifest.title}\n\nTask: ${taskId}\n`, "utf8");
+    generated.push(path.relative(rootDir, outputPath).split(path.sep).join("/"));
+  }
+  const evidence = {
+    schema: "preset-evidence/v1",
+    presetId,
+    layer: preset.layer,
+    taskId,
+    entrypoint,
+    generated,
+    ok: true
+  };
+  writeFileSync(path.join(evidenceDir, "evidence.json"), JSON.stringify(evidence, null, 2), "utf8");
+  return {
+    ok: true,
+    command: "preset-run",
+    preset: publicPresetSummary(preset),
+    evidenceBundle: path.relative(rootDir, evidenceDir).split(path.sep).join("/"),
+    report: evidence
+  };
+}
+
+function readModules(rootDir: string): ModuleRegistry {
+  const registryPath = modulesRegistryPath(rootDir);
+  if (!existsSync(registryPath)) return { modules: [] };
+  const parsed = JSON.parse(readFileSync(registryPath, "utf8")) as { readonly modules?: ReadonlyArray<ModuleRecord> };
+  return { modules: parsed.modules ?? [] };
+}
+
+function writeModules(rootDir: string, registry: ModuleRegistry): void {
+  const registryPath = modulesRegistryPath(rootDir);
+  mkdirSync(path.dirname(registryPath), { recursive: true });
+  writeFileSync(registryPath, JSON.stringify({ schema: "module-registry/v1", modules: registry.modules }, null, 2), "utf8");
+  writeModuleRegistryView(rootDir, registry);
+}
+
+function modulesRegistryPath(rootDir: string): string {
+  return path.join(resolveHarnessLayout(rootDir).authoredRoot, "modules.json");
+}
+
+function writeModuleRegistryView(rootDir: string, registry: ModuleRegistry): void {
+  const outputPath = path.join(resolveHarnessLayout(rootDir).generatedRoot, "Module-Registry.md");
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  const rows = registry.modules
+    .map((module) => `| ${module.key} | ${module.title} | ${module.status} | ${module.scopes.join("<br>")} | ${module.steps.map((step) => `${step.id}:${step.state}`).join(", ")} |`)
+    .join("\n");
+  writeFileSync(outputPath, [
+    "# Module Registry",
+    "",
+    "| Key | Title | Status | Scopes | Steps |",
+    "| --- | --- | --- | --- | --- |",
+    rows,
+    ""
+  ].join("\n"), "utf8");
+}
+
+function presetNotFound(command: string, presetId: string): CliResult {
+  return {
+    ok: false,
+    command,
+    preset: { id: presetId },
+    error: { code: "preset_not_found", hint: `Preset ${presetId} was not found.` }
+  };
+}
+
+function moduleNotFound(command: string, moduleKey: string): CliResult {
+  return {
+    ok: false,
+    command,
+    module: { key: moduleKey },
+    error: { code: "module_not_found", hint: `Module ${moduleKey} was not found.` }
+  };
+}
+
+function validateRegistryKey(value: string, label: string): void {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/u.test(value)) {
+    throw new Error(`invalid ${label} key`);
+  }
+}
+
+function timestampForPath(now: Date = new Date()): string {
+  return now.toISOString().replace(/[:.]/gu, "-");
 }
 
 function decodeExtensionJsonFile<A, I>(

--- a/packages/cli/test/preset-module-cli.test.ts
+++ b/packages/cli/test/preset-module-cli.test.ts
@@ -81,6 +81,14 @@ test("CLI preset run writes scoped evidence bundles and rejects unknown actions"
     const rejected = runJson(rootDir, ["preset", "action", "module", "deploy", "--task", "task-1"], false);
     assert.equal(rejected.ok, false);
     assert.equal(rejected.error.code, "preset_action_forbidden");
+
+    const action = runJson(rootDir, ["preset", "action", "module", "check", "--task", "task-1"]);
+    assert.equal(action.ok, true);
+    assert.equal(action.command, "preset-action");
+
+    const invalidTask = runJson(rootDir, ["preset", "run", "module", "check", "--task", "../task"], false);
+    assert.equal(invalidTask.ok, false);
+    assert.equal(invalidTask.error.code, "invalid_registry_key");
   });
 });
 

--- a/packages/cli/test/preset-module-cli.test.ts
+++ b/packages/cli/test/preset-module-cli.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+
+test("CLI preset discovery honors project over user over bundled presets", () => {
+  withTempRoot((rootDir) => {
+    writePreset(rootDir, ".harness/user-presets/standard-task/preset.json", {
+      id: "standard-task",
+      title: "User Standard Task",
+      version: "1.0.0"
+    });
+    writePreset(rootDir, ".harness/presets/standard-task/preset.json", {
+      id: "standard-task",
+      title: "Project Standard Task",
+      version: "2.0.0"
+    });
+
+    const result = runJson(rootDir, ["preset", "list"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.command, "preset-list");
+    const standard = result.presets.find((preset: Record<string, unknown>) => preset.id === "standard-task");
+    assert.equal(standard.title, "Project Standard Task");
+    assert.equal(standard.layer, "project");
+    assert.equal(result.presets.some((preset: Record<string, unknown>) => preset.id === "module"), true);
+  });
+});
+
+test("CLI preset CRUD validates, installs, audits, and removes project presets", () => {
+  withTempRoot((rootDir) => {
+    const sourceDir = path.join(rootDir, "source-preset");
+    writePreset(sourceDir, "preset.json", {
+      id: "custom-task",
+      title: "Custom Task",
+      version: "1.0.0"
+    });
+
+    const installed = runJson(rootDir, ["preset", "install", sourceDir, "--project"]);
+    assert.equal(installed.ok, true);
+    assert.equal(installed.command, "preset-install");
+    assert.equal(installed.preset.id, "custom-task");
+
+    const inspected = runJson(rootDir, ["preset", "inspect", "custom-task"]);
+    assert.equal(inspected.ok, true);
+    assert.equal(inspected.preset.layer, "project");
+
+    const checked = runJson(rootDir, ["preset", "check", "custom-task"]);
+    assert.equal(checked.ok, true);
+    assert.deepEqual(checked.issues, []);
+
+    const audit = runJson(rootDir, ["preset", "audit"]);
+    assert.equal(audit.ok, true);
+    assert.equal(audit.report.totalResolved, 8);
+
+    const removed = runJson(rootDir, ["preset", "uninstall", "custom-task", "--project"]);
+    assert.equal(removed.ok, true);
+    assert.equal(removed.command, "preset-uninstall");
+
+    const missing = runJson(rootDir, ["preset", "inspect", "custom-task"], false);
+    assert.equal(missing.ok, false);
+    assert.equal(missing.error.code, "preset_not_found");
+  });
+});
+
+test("CLI preset run writes scoped evidence bundles and rejects unknown actions", () => {
+  withTempRoot((rootDir) => {
+    const result = runJson(rootDir, ["preset", "run", "module", "check", "--task", "task-1"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.command, "preset-run");
+    assert.equal(result.evidenceBundle.startsWith(".harness/evidence/presets/module/"), true);
+    const evidence = JSON.parse(readFileSync(path.join(rootDir, result.evidenceBundle, "evidence.json"), "utf8"));
+    assert.equal(evidence.presetId, "module");
+    assert.equal(evidence.entrypoint, "check");
+
+    const rejected = runJson(rootDir, ["preset", "action", "module", "deploy", "--task", "task-1"], false);
+    assert.equal(rejected.ok, false);
+    assert.equal(rejected.error.code, "preset_action_forbidden");
+  });
+});
+
+test("CLI module CRUD maintains generated module view and module-step state", () => {
+  withTempRoot((rootDir) => {
+    const registered = runJson(rootDir, ["module", "register", "billing", "--title", "Billing", "--scope", "packages/billing/**"]);
+    assert.equal(registered.ok, true);
+    assert.equal(registered.command, "module-register");
+    assert.equal(registered.module.key, "billing");
+
+    const listed = runJson(rootDir, ["module", "list"]);
+    assert.equal(listed.ok, true);
+    assert.equal(listed.modules.length, 1);
+    assert.equal(listed.modules[0].key, "billing");
+
+    const inspected = runJson(rootDir, ["module", "inspect", "billing"]);
+    assert.equal(inspected.ok, true);
+    assert.deepEqual(inspected.module.scopes, ["packages/billing/**"]);
+
+    const scaffolded = runJson(rootDir, ["module", "scaffold", "billing"]);
+    assert.equal(scaffolded.ok, true);
+    assert.equal(scaffolded.path, "harness/planning/modules/billing/module_plan.md");
+
+    const stepped = runJson(rootDir, ["module-step", "billing", "BILL-01", "--state", "done"]);
+    assert.equal(stepped.ok, true);
+    assert.equal(stepped.module.steps[0].state, "done");
+
+    const registry = readFileSync(path.join(rootDir, ".harness/generated/Module-Registry.md"), "utf8");
+    assert.match(registry, /\| billing \| Billing \| active \|/);
+
+    const removed = runJson(rootDir, ["module", "unregister", "billing"]);
+    assert.equal(removed.ok, true);
+    assert.equal(removed.module.status, "unregistered");
+  });
+});
+
+function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, any> {
+  try {
+    const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+      encoding: "utf8"
+    });
+    return JSON.parse(stdout) as Record<string, any>;
+  } catch (error) {
+    if (expectSuccess) throw error;
+    const failure = error as { readonly stdout?: string };
+    return JSON.parse(failure.stdout ?? "{}") as Record<string, any>;
+  }
+}
+
+function withTempRoot<T>(fn: (rootDir: string) => T): T {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-p2-cli-"));
+  try {
+    return fn(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function writePreset(rootDir: string, relativePath: string, overrides: { readonly id: string; readonly title: string; readonly version: string }): void {
+  const filePath = path.join(rootDir, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(makePreset(overrides), null, 2), "utf8");
+}
+
+function makePreset(overrides: { readonly id: string; readonly title: string; readonly version: string }): Record<string, unknown> {
+  return {
+    schema: "preset-manifest/v1",
+    id: overrides.id,
+    title: overrides.title,
+    vertical: "software/coding",
+    version: overrides.version,
+    kernelVersionRange: {
+      min: "1.0.0",
+      maxExclusive: "2.0.0"
+    },
+    capabilityImports: [],
+    profiles: [{
+      id: "baseline",
+      title: "Baseline",
+      checkerProfile: "standard",
+      templateSelections: []
+    }],
+    defaultProfile: "baseline"
+  };
+}


### PR DESCRIPTION
## Summary

Adds the M2-P2 local preset and module runtime surface to the Harness Anything CLI.

## What Changed

- Added preset discovery with project -> user -> bundled precedence.
- Added preset CRUD/check/run/action JSON commands with scoped local evidence bundles.
- Added module register/list/inspect/scaffold/unregister/module-step commands with an authored local registry and generated module view.
- Added focused CLI contract tests for preset discovery, CRUD, run evidence, structured invalid-key errors, and module CRUD.
- Addressed reviewer P3 notes for `preset-action` command identity and malformed key structured errors.

## Task And Scope

- Harness task: M2-P2 preset schema, engine, bundled presets, module CRUD
- Branch: `codex/m2-p2-preset-schema-engine-module-crud`
- Public scope: CLI runtime contracts for preset and module local filesystem behavior
- Private planning/evidence updated: yes, P2 task packet and scope lock recorded; final closeout evidence pending after merge
- Out of scope: migration/adopt execution flow, createdBy attribution, Git Diff Adapter, install/docs/playbooks, final cutover/default path switch, external write adapters, kernel-level Lite/Full

## Version Impact

- Version: no version change because this is an internal M2 implementation slice
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: `4362e5a0a7905d7f4c3e91db3e3b424a09cf89b1`
- Branch merge-base with `origin/main`: `4362e5a0a7905d7f4c3e91db3e3b424a09cf89b1`
- Last `git fetch origin` time: `2026-06-13 12:04 CST`
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: private harness commit `11cc33e`; task package `m2-coding-vertical/tasks/2026-06-13-m2-p2-preset-schema-engine-module-crud/`
- Reviewer evidence path: tmux reviewer `m2-claude-loop:1.1`, captured `2026-06-13`, P0/P1/P2 none; P3 command identity and invalid key notes addressed in `4ff5f78`; P3 module upsert created/updated signal deferred as non-blocking
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/27456118234
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-cutover-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` locally; dependencies were already installed in the worktree and PR CI covered the clean runner path.

## Review Evidence

- Self-review: completed locally; no open P0/P1/P2 found
- Reviewer subagent: Claude Opus reviewer reported On Track, P0/P1/P2 None, Merge Recommendation yes
- Human review: Commander admin review for this internal implementation slice
- Blocking findings: none

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear: squash merge after CI/review, then delete remote branch and remove local worktree.

## Residual Risk

- This is the M2-P2 local runtime surface. Later packets still own migration/adopt, attribution/evidence helpers, install/docs/playbooks, and final cutover.
- Module register currently has upsert behavior without a created/updated discriminator. Reviewer classified this as P3 and non-blocking for M2 internal use.

## References

- Task: M2-P2 preset schema, engine, bundled presets, module CRUD
- Evidence: local targeted tests, full `npm run check`, and GitHub Actions run `27456118234`
- Review: Claude Opus reviewer P0/P1/P2 none; merge yes

---

## 摘要

为 Harness Anything CLI 新增 M2-P2 本地 preset/module runtime surface。

## 改动内容

- 新增 project -> user -> bundled 优先级的 preset discovery。
- 新增 preset CRUD/check/run/action JSON 命令和本地 evidence bundle。
- 新增 module register/list/inspect/scaffold/unregister/module-step 命令，维护 authored registry 和 generated module view。
- 新增 preset/module CLI contract tests。
- 处理 reviewer P3：`preset-action` command identity 和 malformed key structured error。

## 任务与范围

- Harness 任务：M2-P2 preset schema, engine, bundled presets, module CRUD
- 分支：`codex/m2-p2-preset-schema-engine-module-crud`
- 公开范围：preset/module 本地文件系统 CLI runtime contracts
- 私有计划 / 证据是否已更新：yes；P2 task packet 和 scope lock 已记录，最终 closeout 证据等待 merge 后补齐
- 范围外：migration/adopt execution flow、createdBy、Git Diff Adapter、install/docs/playbooks、final cutover/default path switch、external write adapters、kernel-level Lite/Full

## 版本影响

- 版本：不改版本，原因是这是 M2 内部实现切片
- 发布影响：不发布

## 验证

- `origin/main` 基准 SHA：`4362e5a0a7905d7f4c3e91db3e3b424a09cf89b1`
- 当前分支与 `origin/main` 的 merge-base：`4362e5a0a7905d7f4c3e91db3e3b424a09cf89b1`
- 最近一次 `git fetch origin` 时间：`2026-06-13 12:04 CST`
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：private harness commit `11cc33e`；task package `m2-coding-vertical/tasks/2026-06-13-m2-p2-preset-schema-engine-module-crud/`
- Reviewer 证据路径：tmux reviewer `m2-claude-loop:1.1`，`2026-06-13` capture，P0/P1/P2 none；P3 command identity 与 invalid key notes 已在 `4ff5f78` 处理；P3 module upsert created/updated signal 非阻塞延后
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/27456118234
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-cutover-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：本地未单独运行 `npm ci`；worktree 已有依赖，PR CI 覆盖 clean runner 路径。

## 审查证据

- 自查：本地已完成，无 open P0/P1/P2
- Reviewer subagent：Claude Opus reviewer 结论 On Track，P0/P1/P2 None，Merge Recommendation yes
- 人工审查：Commander admin review for this internal implementation slice
- 阻塞发现：无

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚：CI/review 通过后 squash merge，删除远端分支并清理本地 worktree。

## 残余风险

- 本 PR 是 M2-P2 本地 runtime surface。后续 packet 仍需完成 migration/adopt、attribution/evidence helper、install/docs/playbooks 和 final cutover。
- module register 当前是 upsert 行为，没有 created/updated discriminator。Reviewer 判定为 P3，对 M2 内部使用不阻塞。

## 关联材料

- 任务：M2-P2 preset schema, engine, bundled presets, module CRUD
- 证据：本地定向测试、完整 `npm run check`、GitHub Actions run `27456118234`
- 审查：Claude Opus reviewer P0/P1/P2 none；merge yes
