### PR TITLE
feat: add task attribution and git diff evidence

### DIFF
--- a/packages/adapters/local/src/created-by.ts
+++ b/packages/adapters/local/src/created-by.ts
@@ -1,0 +1,35 @@
+import { execFileSync } from "node:child_process";
+
+export interface TaskCreatedBy {
+  readonly name: string;
+  readonly email: string;
+}
+
+export function resolveTaskCreatedBy(rootDir: string, explicit?: TaskCreatedBy): TaskCreatedBy | undefined {
+  if (explicit) return normalizeTaskCreatedBy(explicit);
+  const name = readGitConfig(rootDir, "user.name");
+  const email = readGitConfig(rootDir, "user.email");
+  if (!name || !email) return undefined;
+  return { name, email };
+}
+
+function normalizeTaskCreatedBy(input: TaskCreatedBy): TaskCreatedBy | undefined {
+  const name = cleanScalar(input.name);
+  const email = cleanScalar(input.email);
+  return name && email ? { name, email } : undefined;
+}
+
+function readGitConfig(rootDir: string, key: "user.name" | "user.email"): string | undefined {
+  try {
+    return cleanScalar(execFileSync("git", ["-C", rootDir, "config", "--get", key], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    }));
+  } catch {
+    return undefined;
+  }
+}
+
+function cleanScalar(value: string): string {
+  return value.replace(/[\r\n]/gu, " ").trim();
+}

--- a/packages/adapters/local/src/git-diff-evidence.ts
+++ b/packages/adapters/local/src/git-diff-evidence.ts
@@ -1,0 +1,140 @@
+import { execFileSync } from "node:child_process";
+
+export interface GitDiffEvidenceOptions {
+  readonly rootDir: string;
+  readonly baseRef?: string;
+}
+
+export interface GitDiffEvidenceFile {
+  readonly path: string;
+  readonly status: "added" | "modified" | "deleted" | "renamed" | "copied" | "untracked" | "unknown";
+  readonly indexStatus: string;
+  readonly worktreeStatus: string;
+}
+
+export interface GitDiffEvidenceReport {
+  readonly schema: "git-diff-evidence/v1";
+  readonly ok: boolean;
+  readonly baseRef?: string;
+  readonly head: string | null;
+  readonly dirty: boolean;
+  readonly readOnly: true;
+  readonly fileCount: number;
+  readonly files: ReadonlyArray<GitDiffEvidenceFile>;
+  readonly error?: string;
+}
+
+export function collectGitDiffEvidence(options: GitDiffEvidenceOptions): GitDiffEvidenceReport {
+  const head = readGit(options.rootDir, ["rev-parse", "--verify", "HEAD"]);
+  if (!head.ok) return unavailable(head.error);
+
+  const status = readGit(options.rootDir, [
+    "-c",
+    "status.renames=false",
+    "status",
+    "--porcelain=v1",
+    "-z",
+    "--untracked-files=all"
+  ]);
+  if (!status.ok) return unavailable(status.error, head.stdout);
+
+  const statusFiles = parsePorcelainStatus(status.stdout);
+  const baseFiles = options.baseRef ? readBaseDiff(options.rootDir, options.baseRef) : [];
+  const files = mergeFiles([...baseFiles, ...statusFiles]);
+
+  return {
+    schema: "git-diff-evidence/v1",
+    ok: true,
+    ...(options.baseRef ? { baseRef: options.baseRef } : {}),
+    head: head.stdout.trim(),
+    dirty: files.length > 0,
+    readOnly: true,
+    fileCount: files.length,
+    files
+  };
+}
+
+function readBaseDiff(rootDir: string, baseRef: string): ReadonlyArray<GitDiffEvidenceFile> {
+  const result = readGit(rootDir, ["-c", "diff.renames=false", "diff", "--name-status", "-z", baseRef, "--"]);
+  return result.ok ? parseNameStatus(result.stdout) : [];
+}
+
+function parsePorcelainStatus(output: string): ReadonlyArray<GitDiffEvidenceFile> {
+  return output.split("\0")
+    .filter((entry) => entry.length > 0)
+    .map((entry) => {
+      const indexStatus = entry.slice(0, 1);
+      const worktreeStatus = entry.slice(1, 2);
+      const filePath = entry.slice(3);
+      return makeFile(filePath, indexStatus, worktreeStatus);
+    })
+    .filter(isRelativePath);
+}
+
+function parseNameStatus(output: string): ReadonlyArray<GitDiffEvidenceFile> {
+  const parts = output.split("\0").filter((part) => part.length > 0);
+  const files: GitDiffEvidenceFile[] = [];
+  for (let index = 0; index < parts.length; index += 2) {
+    const status = parts[index] ?? "";
+    const filePath = parts[index + 1] ?? "";
+    files.push(makeFile(filePath, status.slice(0, 1), " "));
+  }
+  return files.filter(isRelativePath);
+}
+
+function makeFile(filePath: string, indexStatus: string, worktreeStatus: string): GitDiffEvidenceFile {
+  return {
+    path: filePath,
+    status: classifyStatus(indexStatus, worktreeStatus),
+    indexStatus,
+    worktreeStatus
+  };
+}
+
+function classifyStatus(indexStatus: string, worktreeStatus: string): GitDiffEvidenceFile["status"] {
+  const status = indexStatus === " " || indexStatus === "?" ? worktreeStatus : indexStatus;
+  if (indexStatus === "?" && worktreeStatus === "?") return "untracked";
+  if (status === "A") return "added";
+  if (status === "M") return "modified";
+  if (status === "D") return "deleted";
+  if (status === "R") return "renamed";
+  if (status === "C") return "copied";
+  return "unknown";
+}
+
+function mergeFiles(files: ReadonlyArray<GitDiffEvidenceFile>): ReadonlyArray<GitDiffEvidenceFile> {
+  const byPath = new Map<string, GitDiffEvidenceFile>();
+  for (const file of files) byPath.set(file.path, file);
+  return [...byPath.values()].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function isRelativePath(file: GitDiffEvidenceFile): boolean {
+  return !file.path.startsWith("/") && !file.path.split("/").includes("..");
+}
+
+function unavailable(error: string, head: string | null = null): GitDiffEvidenceReport {
+  return {
+    schema: "git-diff-evidence/v1",
+    ok: false,
+    head: head?.trim() ?? null,
+    dirty: false,
+    readOnly: true,
+    fileCount: 0,
+    files: [],
+    error
+  };
+}
+
+function readGit(rootDir: string, args: ReadonlyArray<string>): { readonly ok: true; readonly stdout: string } | { readonly ok: false; readonly error: string } {
+  try {
+    return {
+      ok: true,
+      stdout: execFileSync("git", ["-C", rootDir, ...args], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"]
+      })
+    };
+  } catch {
+    return { ok: false, error: "git command unavailable for this repository" };
+  }
+}

--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -8,6 +8,10 @@ import type { WriteOpKind } from "../../../kernel/src/ports/write-coordinator.ts
 import { makeJournaledWriteCoordinator, type JournalActor } from "../../../kernel/src/store/index.ts";
 import { stablePayloadHash } from "../../../kernel/src/store/hash.ts";
 import { isGeneratedTaskId, resolveHarnessLayout, taskDocumentPath as harnessTaskDocumentPath, taskPackagePath, validateTaskIdSyntax } from "../../../kernel/src/layout/index.ts";
+import { resolveTaskCreatedBy, type TaskCreatedBy } from "./created-by.ts";
+
+export { collectGitDiffEvidence } from "./git-diff-evidence.ts";
+export type { GitDiffEvidenceFile, GitDiffEvidenceOptions, GitDiffEvidenceReport } from "./git-diff-evidence.ts";
 
 export interface LocalLifecycleOptions {
   readonly rootDir: string;
@@ -27,6 +31,7 @@ export interface CreateLocalTaskInput {
   readonly slug?: string;
   readonly vertical?: string;
   readonly preset?: string;
+  readonly createdBy?: TaskCreatedBy;
 }
 
 export interface SetLocalStatusInput {
@@ -109,6 +114,7 @@ interface LocalTaskIndex {
   readonly packageDisposition: "active" | "archived" | "tombstoned";
   readonly vertical: string;
   readonly preset: string;
+  readonly createdBy?: TaskCreatedBy;
 }
 
 export function makeLocalLifecycleEngine(options: LocalLifecycleOptions): LocalLifecycleEngine {
@@ -126,13 +132,15 @@ export function makeLocalLifecycleEngine(options: LocalLifecycleOptions): LocalL
         return yield* Effect.fail({ _tag: "MalformedSnapshot", raw: `task already exists: ${input.taskId}` } satisfies EngineError);
       }
       const bindingCreatedAt = clock().toISOString();
+      const createdBy = resolveTaskCreatedBy(rootDir, input.createdBy);
       const index = makeIndex({
         taskId: input.taskId,
         title: input.title,
         status: "planned",
         bindingCreatedAt,
         vertical: input.vertical ?? "default",
-        preset: input.preset ?? "default"
+        preset: input.preset ?? "default",
+        createdBy
       });
       yield* writeTaskDocument(coordinator, input.taskId, "INDEX.md", renderIndex(index), {
         kind: "package_create",
@@ -185,13 +193,15 @@ export function makeLocalLifecycleEngine(options: LocalLifecycleOptions): LocalL
       }
       const oldIndex = yield* readIndexEffect(rootDir, input.oldTaskId);
       const bindingCreatedAt = clock().toISOString();
+      const createdBy = resolveTaskCreatedBy(rootDir);
       const newIndex = makeIndex({
         taskId: input.newTaskId,
         title: input.title,
         status: "planned",
         bindingCreatedAt,
         vertical: oldIndex.vertical,
-        preset: oldIndex.preset
+        preset: oldIndex.preset,
+        createdBy
       });
       const archivedOld = { ...oldIndex, packageDisposition: "archived" as const };
       const relationBody = renderSupersedesRelation(input.newTaskId, input.oldTaskId, input.reason);
@@ -329,6 +339,7 @@ function makeIndex(input: {
   readonly bindingCreatedAt: string;
   readonly vertical: string;
   readonly preset: string;
+  readonly createdBy?: TaskCreatedBy;
 }): LocalTaskIndex {
   const fingerprint = stablePayloadHash({
     engine: "local",
@@ -347,7 +358,8 @@ function makeIndex(input: {
     bindingFingerprint: `sha256:${fingerprint}`,
     packageDisposition: "active",
     vertical: input.vertical,
-    preset: input.preset
+    preset: input.preset,
+    ...(input.createdBy ? { createdBy: input.createdBy } : {})
   };
 }
 
@@ -369,6 +381,11 @@ function renderIndex(index: LocalTaskIndex, reason?: string): string {
     `packageDisposition: ${index.packageDisposition}`,
     `vertical: ${index.vertical}`,
     `preset: ${index.preset}`,
+    ...(index.createdBy ? [
+      "createdBy:",
+      `  name: ${index.createdBy.name}`,
+      `  email: ${index.createdBy.email}`
+    ] : []),
     "---",
     "",
     `# ${index.title}`,
@@ -411,7 +428,8 @@ function readIndex(rootDir: string, taskId: TaskId): LocalTaskIndex {
     bindingFingerprint: readScalar(frontmatter, "  bindingFingerprint"),
     packageDisposition: readPackageDisposition(frontmatter),
     vertical: readScalar(frontmatter, "vertical"),
-    preset: readScalar(frontmatter, "preset")
+    preset: readScalar(frontmatter, "preset"),
+    ...readCreatedBy(frontmatter)
   };
 }
 
@@ -424,6 +442,19 @@ function readScalar(frontmatter: string, key: string): string {
 
 function nullIfEmpty(value: string): string | null {
   return value.length === 0 ? null : value;
+}
+
+function readCreatedBy(frontmatter: string): { readonly createdBy?: TaskCreatedBy } {
+  const block = frontmatter.match(/^createdBy:\n((?:[ \t]+[^\n]*\n?)*)/mu)?.[1];
+  if (!block) return {};
+  const name = readOptionalNestedScalar(block, "name");
+  const email = readOptionalNestedScalar(block, "email");
+  return name && email ? { createdBy: { name, email } } : {};
+}
+
+function readOptionalNestedScalar(block: string, key: string): string {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return block.match(new RegExp(`^[ \\t]+${escaped}:[ \\t]*(.*)$`, "mu"))?.[1]?.trim() ?? "";
 }
 
 function readPackageDisposition(frontmatter: string): LocalTaskIndex["packageDisposition"] {

--- a/packages/cli/src/cli/command-registry.ts
+++ b/packages/cli/src/cli/command-registry.ts
@@ -23,6 +23,7 @@ export const commandRegistry = [
   { kind: "migrate-structure", primary: "harness migrate-structure (--plan|--apply --confirm-plan) [--json]", resultEnvelope: "CliResult/v1" },
   { kind: "migrate-run", primary: "harness migrate-run [--plan-only] [--out-dir folder] [--json]", resultEnvelope: "CliResult/v1" },
   { kind: "migrate-verify", primary: "harness migrate-verify <session.json> [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "git-diff", primary: "harness git-diff [--base <ref>] [--json]", resultEnvelope: "CliResult/v1" },
   { kind: "preset-list", primary: "harness preset list [--json]", resultEnvelope: "CliResult/v1" },
   { kind: "preset-inspect", primary: "harness preset inspect <id> [--json]", resultEnvelope: "CliResult/v1" },
   { kind: "preset-check", primary: "harness preset check <id> [--json]", resultEnvelope: "CliResult/v1" },

--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -1,6 +1,7 @@
 import { isDomainStatus } from "../../../kernel/src/domain/index.ts";
 import { slugifyTaskTitle } from "../../../kernel/src/layout/index.ts";
 import { commandRegistry } from "./command-registry.ts";
+import { parseGitDiffArgs } from "./parse-git-diff-args.ts";
 import { parseMigrationArgs } from "./parse-migration-args.ts";
 import { isCheckProfile } from "../commands/check.ts";
 import type { CliResult, ParsedCommand } from "./types.ts";
@@ -322,6 +323,9 @@ export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; rea
 
   const migrationCommand = parseMigrationArgs(args, rootDir, json);
   if (migrationCommand) return migrationCommand;
+
+  const gitDiffCommand = parseGitDiffArgs(args, rootDir, json);
+  if (gitDiffCommand) return { ok: true, value: gitDiffCommand };
 
   if (args[0] === "gui") {
     return {

--- a/packages/cli/src/cli/parse-git-diff-args.ts
+++ b/packages/cli/src/cli/parse-git-diff-args.ts
@@ -1,0 +1,22 @@
+import type { ParsedCommand } from "./types.ts";
+
+export function parseGitDiffArgs(
+  args: ReadonlyArray<string>,
+  rootDir: string,
+  json: boolean
+): ParsedCommand | undefined {
+  if (args[0] !== "git-diff") return undefined;
+  return {
+    rootDir,
+    json,
+    action: {
+      kind: "git-diff",
+      baseRef: readOption(args, "--base")
+    }
+  };
+}
+
+function readOption(argv: ReadonlyArray<string>, name: string): string | undefined {
+  const index = argv.indexOf(name);
+  return index >= 0 ? argv[index + 1] : undefined;
+}

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -85,6 +85,7 @@ export interface ParsedCommand {
     | { readonly kind: "migrate-structure"; readonly mode: "plan" | "apply"; readonly confirmPlan: boolean }
     | { readonly kind: "migrate-run"; readonly planOnly: boolean; readonly outDir: string }
     | { readonly kind: "migrate-verify"; readonly sessionPath: string }
+    | { readonly kind: "git-diff"; readonly baseRef?: string }
     | { readonly kind: "gui" }
     | { readonly kind: "template-list"; readonly catalogPath: string }
     | { readonly kind: "template-render"; readonly templateRef: string; readonly catalogPath: string; readonly locale: "zh-CN" | "en-US" }

--- a/packages/cli/src/commands/git-diff.ts
+++ b/packages/cli/src/commands/git-diff.ts
@@ -1,0 +1,15 @@
+import { collectGitDiffEvidence } from "../../../adapters/local/src/index.ts";
+import type { CliResult } from "../cli/types.ts";
+
+export function runGitDiffEvidence(rootDir: string, baseRef?: string): CliResult {
+  const report = collectGitDiffEvidence({ rootDir, baseRef });
+  return {
+    ok: report.ok,
+    command: "git-diff",
+    report,
+    error: report.ok ? undefined : {
+      code: "git_diff_unavailable",
+      hint: report.error ?? "Git diff evidence is unavailable for this repository."
+    }
+  };
+}

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -11,6 +11,7 @@ import { runCheckProfile } from "./check.ts";
 import { runGovernanceRebuild } from "./governance.ts";
 import { runLessonPromote, runLessonSediment } from "./lesson.ts";
 import { runAdoptMultica, runSnapshotMultica } from "./adopt.ts";
+import { runGitDiffEvidence } from "./git-diff.ts";
 import { runMigratePlan, runMigrateRun, runMigrateStructure, runMigrateVerify } from "./migration.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
 
@@ -195,6 +196,11 @@ export function runCommand(
   if (command.action.kind === "migrate-verify") {
     const action = command.action;
     return Effect.sync(() => runMigrateVerify(command.rootDir, action));
+  }
+
+  if (command.action.kind === "git-diff") {
+    const action = command.action;
+    return Effect.sync(() => runGitDiffEvidence(command.rootDir, action.baseRef));
   }
 
   if (command.action.kind === "task-review") {

--- a/packages/cli/test/attribution-diff-cli.test.ts
+++ b/packages/cli/test/attribution-diff-cli.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
+
+test("new-task records optional createdBy from local git user config and projects it", () => {
+  withTempRoot((rootDir) => {
+    initGit(rootDir);
+    configureGitUser(rootDir, "M2 Commander", "m2@example.com");
+
+    const created = runJson(rootDir, ["new-task", "--title", "Attribution Task"]);
+    const taskId = assertGeneratedTaskId(created.taskId);
+    const indexBody = readFileSync(path.join(rootDir, `harness/planning/tasks/${taskId}-attribution-task/INDEX.md`), "utf8");
+
+    assert.match(indexBody, /createdBy:\n  name: M2 Commander\n  email: m2@example\.com/);
+
+    const listed = runJson(rootDir, ["task", "list"]);
+    assert.equal(listed.tasks[0].createdBy.name, "M2 Commander");
+    assert.equal(listed.tasks[0].createdBy.email, "m2@example.com");
+    assert.equal(listed.tasks[0].canonicalStatus, "planned");
+    assert.equal(listed.tasks[0].packageDisposition, "active");
+  });
+});
+
+test("new-task omits createdBy deterministically when git user config is unavailable", () => {
+  withTempRoot((rootDir) => {
+    initGit(rootDir);
+    mkdirSync(path.join(rootDir, "home"), { recursive: true });
+
+    const created = runJson(rootDir, ["new-task", "--title", "Anonymous Task"], true, {
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_NOSYSTEM: "1",
+      HOME: path.join(rootDir, "home")
+    });
+    const taskId = assertGeneratedTaskId(created.taskId);
+    const indexBody = readFileSync(path.join(rootDir, `harness/planning/tasks/${taskId}-anonymous-task/INDEX.md`), "utf8");
+
+    assert.equal(indexBody.includes("createdBy:"), false);
+  });
+});
+
+test("git-diff emits stable read-only evidence without creating harness state or leaking root paths", () => {
+  withTempRoot((rootDir) => {
+    initGit(rootDir);
+    configureGitUser(rootDir, "Diff User", "diff@example.com");
+    writeFileSync(path.join(rootDir, "README.md"), "before\n", "utf8");
+    execFileSync("git", ["add", "README.md"], { cwd: rootDir, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "init"], { cwd: rootDir, stdio: "ignore" });
+
+    writeFileSync(path.join(rootDir, "README.md"), "after\n", "utf8");
+    writeFileSync(path.join(rootDir, "notes.md"), "untracked\n", "utf8");
+
+    const result = runJson(rootDir, ["git-diff"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.command, "git-diff");
+    assert.equal(result.report.schema, "git-diff-evidence/v1");
+    assert.equal(result.report.readOnly, true);
+    assert.equal(result.report.dirty, true);
+    assert.equal(result.report.fileCount, 2);
+    assert.deepEqual(new Set(result.report.files.map((file: Record<string, unknown>) => file.path)), new Set(["README.md", "notes.md"]));
+    assert.equal(result.report.files.some((file: Record<string, unknown>) => file.status === "modified"), true);
+    assert.equal(result.report.files.some((file: Record<string, unknown>) => file.status === "untracked"), true);
+    assert.equal(JSON.stringify(result).includes(rootDir), false);
+    assert.equal(existsSync(path.join(rootDir, ".harness")), false);
+  });
+});
+
+function initGit(rootDir: string): void {
+  execFileSync("git", ["init"], { cwd: rootDir, stdio: "ignore" });
+}
+
+function configureGitUser(rootDir: string, name: string, email: string): void {
+  execFileSync("git", ["config", "user.name", name], { cwd: rootDir, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", email], { cwd: rootDir, stdio: "ignore" });
+}
+
+function assertGeneratedTaskId(value: unknown): string {
+  assert.equal(typeof value, "string");
+  assert.match(value, taskIdPattern);
+  return value;
+}
+
+function withTempRoot<T>(fn: (rootDir: string) => T): T {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-p5-"));
+  try {
+    return fn(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true, env: Readonly<Record<string, string>> = {}): Record<string, any> {
+  try {
+    const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+      encoding: "utf8",
+      env: { ...process.env, ...env }
+    });
+    return JSON.parse(stdout) as Record<string, any>;
+  } catch (error) {
+    if (expectSuccess) throw error;
+    const failure = error as { readonly stdout?: string };
+    return JSON.parse(failure.stdout ?? "{}") as Record<string, any>;
+  }
+}

--- a/packages/kernel/fixtures/schemas/sqlite-task-row/valid.json
+++ b/packages/kernel/fixtures/schemas/sqlite-task-row/valid.json
@@ -11,5 +11,9 @@
   "freshness": "fresh",
   "updatedAt": "2026-06-11T00:03:00.000Z",
   "source": "local-document",
-  "sourcePath": "planning/modules/kernel-rewrite/tasks/2026-06-11-kr-01-harness-infrastructure/task_plan.md"
+  "sourcePath": "planning/modules/kernel-rewrite/tasks/2026-06-11-kr-01-harness-infrastructure/task_plan.md",
+  "createdBy": {
+    "name": "Harness User",
+    "email": "harness@example.com"
+  }
 }

--- a/packages/kernel/fixtures/schemas/task-frontmatter/valid.json
+++ b/packages/kernel/fixtures/schemas/task-frontmatter/valid.json
@@ -14,5 +14,9 @@
   },
   "packageDisposition": "active",
   "vertical": "software/coding",
-  "preset": "standard-task"
+  "preset": "standard-task",
+  "createdBy": {
+    "name": "Harness User",
+    "email": "harness@example.com"
+  }
 }

--- a/packages/kernel/schemas/json/sqlite-task-row.schema.json
+++ b/packages/kernel/schemas/json/sqlite-task-row.schema.json
@@ -18,6 +18,15 @@
     "freshness": { "enum": ["fresh", "stale-but-usable", "unavailable-no-cache"] },
     "updatedAt": { "type": "string" },
     "source": { "enum": ["local-document", "external-engine", "snapshot-cache"] },
-    "sourcePath": { "type": "string" }
+    "sourcePath": { "type": "string" },
+    "createdBy": {
+      "type": "object",
+      "required": ["name", "email"],
+      "properties": {
+        "name": { "type": "string" },
+        "email": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
   }
 }

--- a/packages/kernel/schemas/json/task-frontmatter.schema.json
+++ b/packages/kernel/schemas/json/task-frontmatter.schema.json
@@ -90,6 +90,22 @@
     },
     "preset": {
       "type": "string"
+    },
+    "createdBy": {
+      "type": "object",
+      "required": [
+        "name",
+        "email"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/packages/kernel/src/projection/sqlite-task-source.ts
+++ b/packages/kernel/src/projection/sqlite-task-source.ts
@@ -78,7 +78,8 @@ export function taskEntryToRow(rootDir: string, entry: TaskSourceEntry): TaskPro
     freshness: canonicalStatus === "unknown" || !isPackageDisposition(rawDisposition) ? "stale-but-usable" : "fresh",
     updatedAt: statSync(entry.indexPath).mtime.toISOString(),
     source: lifecycleEngine === "local" ? "local-document" : "external-engine",
-    sourcePath: source
+    sourcePath: source,
+    ...readCreatedBy(entry.frontmatter)
   };
 }
 
@@ -91,6 +92,19 @@ function parseFrontmatter(body: string): string {
 export function readScalar(frontmatter: string, key: string): string {
   const escaped = key.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
   return frontmatter.match(new RegExp(`^${escaped}:[ \\t]*(.*)$`, "mu"))?.[1]?.trim() ?? "";
+}
+
+function readCreatedBy(frontmatter: string): { readonly createdBy?: { readonly name: string; readonly email: string } } {
+  const block = frontmatter.match(/^createdBy:\n((?:[ \t]+[^\n]*\n?)*)/mu)?.[1];
+  if (!block) return {};
+  const name = readNestedScalar(block, "name");
+  const email = readNestedScalar(block, "email");
+  return name && email ? { createdBy: { name, email } } : {};
+}
+
+function readNestedScalar(block: string, key: string): string {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return block.match(new RegExp(`^[ \\t]+${escaped}:[ \\t]*(.*)$`, "mu"))?.[1]?.trim() ?? "";
 }
 
 function coordinationStatus(status: ProjectionCanonicalStatus): CoordinationStatus {

--- a/packages/kernel/src/projection/types.ts
+++ b/packages/kernel/src/projection/types.ts
@@ -19,6 +19,11 @@ export type ProjectionWarningCode =
   | "dangling_entity_ref"
   | "relation_cycle_detected";
 
+export interface TaskCreatedBy {
+  readonly name: string;
+  readonly email: string;
+}
+
 export interface TaskProjectionRow {
   readonly schema: "sqlite-task-row/v1";
   readonly taskId: string;
@@ -33,6 +38,7 @@ export interface TaskProjectionRow {
   readonly updatedAt: string;
   readonly source: ProjectionSource;
   readonly sourcePath: string;
+  readonly createdBy?: TaskCreatedBy;
 }
 
 export interface ProjectionWarning {

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -74,6 +74,11 @@ type LifecycleBindingDecoded = Schema.Schema.Type<typeof LifecycleBindingSchema>
 true satisfies MutuallyAssignable<LifecycleBindingDecoded, LifecycleBinding>;
 true satisfies MutuallyAssignable<keyof LifecycleBindingDecoded, keyof LifecycleBinding>;
 
+const CreatedBySchema = Schema.Struct({
+  name: Schema.String,
+  email: Schema.String
+});
+
 export const TaskFrontmatterSchema = Schema.Struct({
   schema: Schema.Literal("task-package/v2"),
   task_id: Schema.String,
@@ -81,7 +86,8 @@ export const TaskFrontmatterSchema = Schema.Struct({
   lifecycle: LifecycleBindingSchema,
   packageDisposition: Schema.Literal(...packageDispositions),
   vertical: Schema.String,
-  preset: Schema.String
+  preset: Schema.String,
+  createdBy: Schema.optional(CreatedBySchema)
 });
 
 export const WriteJournalOpSchema = Schema.Struct({
@@ -258,7 +264,8 @@ export const SqliteTaskRowSchema = Schema.Struct({
   freshness: FreshnessSchema,
   updatedAt: Schema.String,
   source: Schema.Literal("local-document", "external-engine", "snapshot-cache"),
-  sourcePath: Schema.String
+  sourcePath: Schema.String,
+  createdBy: Schema.optional(CreatedBySchema)
 });
 
 export const ProjectionWarningSourceSchema = Schema.Literal("source-package", "generated-cache", "collaboration-gate");


### PR DESCRIPTION
## Summary
- add optional createdBy audit metadata to task package frontmatter and projection rows
- default local task creation/supersede attribution from git user.name/user.email when available
- add read-only harness git-diff JSON evidence helper with relative paths only
- cover attribution, missing git config, and read-only diff evidence in CLI tests

## Verification
- npm run typecheck
- node --test packages/cli/test/attribution-diff-cli.test.ts packages/kernel/test/contracts/schema-frontmatter.test.ts
- npm run check

## M2 Contract Notes
- createdBy is audit metadata only; it does not become lifecycle, status, or packageDisposition truth
- git-diff evidence uses local git read commands only and does not write harness state or call external APIs
