### PR TITLE
feat: add doctor command and M2 install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Harness-Anything
 
-Harness-Anything is the clean-room rewrite workspace for the next Harness kernel,
+Harness-Anything is the clean-room rewrite workspace for the Harness kernel,
 CLI, GUI, and adapter packages.
 
 This repository is a single Git monorepo. Packages under `packages/` are npm
@@ -9,8 +9,34 @@ workspace packages, not nested Git repositories.
 Private planning, architecture, and task state live in `.harness-private/`,
 which is intentionally ignored by the public repo.
 
-Public M1 operating docs are in `docs-release/m1-minimal-loop.md`. A minimal
-CLI walkthrough is in `examples/minimal-project/`.
+## Local CLI Quick Start
+
+Use Node.js 24 or newer.
+
+```bash
+npm ci
+npm run typecheck
+node packages/cli/src/index.ts --json doctor
+```
+
+For a minimal project:
+
+```bash
+node packages/cli/src/index.ts --root /path/to/project --json init
+node packages/cli/src/index.ts --root /path/to/project --json new-task --title "First task"
+node packages/cli/src/index.ts --root /path/to/project --json status
+node packages/cli/src/index.ts --root /path/to/project --json check --post-merge
+```
+
+Public operating docs:
+
+- `docs-release/m1-minimal-loop.md`
+- `docs-release/m2-coding-vertical.md`
+- `docs-release/harness-agent-skill.md`
+- `examples/minimal-project/`
+
+M2 is still before final cutover. Packages remain private and this repository
+does not claim a published package release from the P6 docs.
 
 ## License
 

--- a/docs-release/harness-agent-skill.md
+++ b/docs-release/harness-agent-skill.md
@@ -1,6 +1,6 @@
 # Harness Agent Skill
 
-Status: initial
+Status: M2 usable workflow
 
 ## Rules
 
@@ -11,5 +11,33 @@ Status: initial
 5. Use `harness task supersede` for follow-up work after `done` or `cancelled`; do not reopen terminal work.
 6. Use `harness task delete --soft` for audit-preserving removal. `--hard` is only for mistaken local packages with no archive, terminal status, or task relations.
 7. Run `harness status --json` and `harness check --post-merge` after merges before continuing authored task changes.
+8. Use `harness doctor --json` before starting work in a checkout or after installing the CLI package artifact. Treat it as diagnostic evidence only; it does not repair files.
+9. Use `harness git-diff --json` when a task needs local diff evidence. It is read-only and reports relative paths.
 
-See `docs-release/m1-minimal-loop.md` for the M1 repository model, state machine, and check report axes.
+## Standard Work Loop
+
+```bash
+harness doctor --json
+harness status --json
+harness check --post-merge --json
+```
+
+For new local work:
+
+```bash
+harness new-task --title "Task title" --json
+harness task status set <task-id> active --json
+harness task progress append <task-id> --text "Progress note" --json
+```
+
+For external read-only adoption:
+
+```bash
+harness snapshot multica <ref> --json
+harness adopt multica <ref> --task <task-id> --json
+harness check --post-merge --json
+```
+
+See `docs-release/m1-minimal-loop.md` for the repository model, state machine,
+and check report axes. See `docs-release/m2-coding-vertical.md` for install,
+doctor, migration, and troubleshooting notes.

--- a/docs-release/m2-coding-vertical.md
+++ b/docs-release/m2-coding-vertical.md
@@ -1,0 +1,108 @@
+# M2 Coding Vertical
+
+Status: M2 usable workflow, before final cutover
+
+## Install From This Repository
+
+Use Node.js 24 or newer.
+
+```bash
+npm ci
+npm run typecheck
+```
+
+Run the CLI directly during development:
+
+```bash
+node packages/cli/src/index.ts --json doctor
+```
+
+The package artifact smoke test builds and installs the private CLI package into
+a temporary consumer project:
+
+```bash
+npm run harness:smoke-cli-package
+```
+
+## Doctor
+
+`harness doctor --json` returns `harness-doctor/v1`.
+
+It checks:
+
+- Node.js major version.
+- Whether the current directory is inside a Git worktree.
+- Whether authored `harness/` state exists.
+- Whether local `.harness/` state and projection cache exist.
+- Recommended next commands.
+
+Doctor is read-only. It does not create `.harness/`, edit authored task
+packages, run repair commands, or call external services.
+
+## Minimal Project Loop
+
+```bash
+harness init --json
+harness doctor --json
+harness new-task --title "Plan the work" --json
+harness status --json
+harness check --post-merge --json
+```
+
+Task package commands:
+
+```bash
+harness task progress append <task-id> --text "Implemented first slice" --json
+harness task archive <task-id> --reason "superseded" --json
+harness task supersede <task-id> --title "Replacement task" --reason "scope changed" --json
+```
+
+## Migration And Evidence Commands
+
+Read-only or local-only evidence commands:
+
+```bash
+harness snapshot multica <ref> --json
+harness adopt multica <ref> --task <task-id> --json
+harness migrate-plan --json
+harness migrate-structure --plan --json
+harness migrate-run --plan-only --json
+harness migrate-verify <session.json> --json
+harness git-diff --json
+```
+
+`createdBy` is optional task audit metadata sourced from local Git
+`user.name`/`user.email` when available. It is not task status, package
+disposition, or review state.
+
+`git-diff` is local read-only evidence. It does not replace Git as the source of
+truth and does not write task state.
+
+## Troubleshooting
+
+If `doctor` reports no authored harness root, run:
+
+```bash
+harness init --json
+```
+
+If `status` or `check` reports generated-cache warnings, rebuild generated
+state instead of editing SQLite or journal files:
+
+```bash
+harness governance rebuild --json
+harness check --post-merge --json
+```
+
+If authored task packages have hard-fail issues, fix the markdown package and
+run the check again:
+
+```bash
+harness check --post-merge --json
+```
+
+## P7 Boundary
+
+P6 does not publish packages, change package privacy, switch default production
+paths, or claim final M2 exit. Those decisions require the final cutover packet
+with post-merge evidence.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,3 +3,17 @@
 CLI Controller package. It must call kernel services rather than own lifecycle
 state.
 
+## Doctor
+
+`harness doctor --json` emits `harness-doctor/v1` diagnostics. The command is
+read-only: it checks Node.js, Git worktree status, authored `harness/` presence,
+local `.harness/` presence, and projection cache presence without creating or
+repairing files.
+
+Use it before task work and after installing the package artifact:
+
+```bash
+harness doctor --json
+harness status --json
+harness check --post-merge --json
+```

--- a/packages/cli/src/cli/command-registry.ts
+++ b/packages/cli/src/cli/command-registry.ts
@@ -24,6 +24,7 @@ export const commandRegistry = [
   { kind: "migrate-run", primary: "harness migrate-run [--plan-only] [--out-dir folder] [--json]", resultEnvelope: "CliResult/v1" },
   { kind: "migrate-verify", primary: "harness migrate-verify <session.json> [--json]", resultEnvelope: "CliResult/v1" },
   { kind: "git-diff", primary: "harness git-diff [--base <ref>] [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "doctor", primary: "harness doctor --json", resultEnvelope: "CliResult/v1" },
   { kind: "preset-list", primary: "harness preset list [--json]", resultEnvelope: "CliResult/v1" },
   { kind: "preset-inspect", primary: "harness preset inspect <id> [--json]", resultEnvelope: "CliResult/v1" },
   { kind: "preset-check", primary: "harness preset check <id> [--json]", resultEnvelope: "CliResult/v1" },

--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -1,6 +1,7 @@
 import { isDomainStatus } from "../../../kernel/src/domain/index.ts";
 import { slugifyTaskTitle } from "../../../kernel/src/layout/index.ts";
 import { commandRegistry } from "./command-registry.ts";
+import { parseDoctorArgs } from "./parse-doctor-args.ts";
 import { parseGitDiffArgs } from "./parse-git-diff-args.ts";
 import { parseMigrationArgs } from "./parse-migration-args.ts";
 import { isCheckProfile } from "../commands/check.ts";
@@ -326,6 +327,9 @@ export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; rea
 
   const gitDiffCommand = parseGitDiffArgs(args, rootDir, json);
   if (gitDiffCommand) return { ok: true, value: gitDiffCommand };
+
+  const doctorCommand = parseDoctorArgs(args, rootDir, json);
+  if (doctorCommand) return { ok: true, value: doctorCommand };
 
   if (args[0] === "gui") {
     return {

--- a/packages/cli/src/cli/parse-doctor-args.ts
+++ b/packages/cli/src/cli/parse-doctor-args.ts
@@ -1,0 +1,14 @@
+import type { ParsedCommand } from "./types.ts";
+
+export function parseDoctorArgs(
+  args: ReadonlyArray<string>,
+  rootDir: string,
+  json: boolean
+): ParsedCommand | undefined {
+  if (args[0] !== "doctor") return undefined;
+  return {
+    rootDir,
+    json,
+    action: { kind: "doctor" }
+  };
+}

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -86,6 +86,7 @@ export interface ParsedCommand {
     | { readonly kind: "migrate-run"; readonly planOnly: boolean; readonly outDir: string }
     | { readonly kind: "migrate-verify"; readonly sessionPath: string }
     | { readonly kind: "git-diff"; readonly baseRef?: string }
+    | { readonly kind: "doctor" }
     | { readonly kind: "gui" }
     | { readonly kind: "template-list"; readonly catalogPath: string }
     | { readonly kind: "template-render"; readonly templateRef: string; readonly catalogPath: string; readonly locale: "zh-CN" | "en-US" }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,84 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { resolveHarnessLayout } from "../../../kernel/src/layout/index.ts";
+import type { CliResult } from "../cli/types.ts";
+
+export interface DoctorReport {
+  readonly schema: "harness-doctor/v1";
+  readonly readOnly: true;
+  readonly node: {
+    readonly version: string;
+    readonly requiredMajor: 24;
+    readonly ok: boolean;
+  };
+  readonly git: {
+    readonly insideWorkTree: boolean;
+  };
+  readonly harness: {
+    readonly authoredRoot: "harness";
+    readonly authoredRootExists: boolean;
+    readonly localRoot: ".harness";
+    readonly localRootExists: boolean;
+    readonly projectionCacheExists: boolean;
+  };
+  readonly cli: {
+    readonly command: "harness doctor";
+    readonly json: "CliResult/v1";
+  };
+  readonly recommendedCommands: readonly string[];
+}
+
+export function runDoctor(rootDir: string): CliResult {
+  const report = collectDoctorReport(rootDir);
+  return {
+    ok: true,
+    command: "doctor",
+    report
+  };
+}
+
+function collectDoctorReport(rootDir: string): DoctorReport {
+  const layout = resolveHarnessLayout(rootDir);
+  return {
+    schema: "harness-doctor/v1",
+    readOnly: true,
+    node: {
+      version: process.versions.node,
+      requiredMajor: 24,
+      ok: Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10) >= 24
+    },
+    git: {
+      insideWorkTree: isInsideGitWorkTree(rootDir)
+    },
+    harness: {
+      authoredRoot: "harness",
+      authoredRootExists: existsSync(layout.authoredRoot),
+      localRoot: ".harness",
+      localRootExists: existsSync(layout.localRoot),
+      projectionCacheExists: existsSync(path.join(layout.cacheRoot, "projections.sqlite"))
+    },
+    cli: {
+      command: "harness doctor",
+      json: "CliResult/v1"
+    },
+    recommendedCommands: [
+      "harness init",
+      "harness status --json",
+      "harness check --post-merge --json",
+      "harness git-diff --json"
+    ]
+  };
+}
+
+function isInsideGitWorkTree(rootDir: string): boolean {
+  try {
+    const output = execFileSync("git", ["-C", rootDir, "rev-parse", "--is-inside-work-tree"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    }).trim();
+    return output === "true";
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -11,6 +11,7 @@ import { runCheckProfile } from "./check.ts";
 import { runGovernanceRebuild } from "./governance.ts";
 import { runLessonPromote, runLessonSediment } from "./lesson.ts";
 import { runAdoptMultica, runSnapshotMultica } from "./adopt.ts";
+import { runDoctor } from "./doctor.ts";
 import { runGitDiffEvidence } from "./git-diff.ts";
 import { runMigratePlan, runMigrateRun, runMigrateStructure, runMigrateVerify } from "./migration.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
@@ -201,6 +202,10 @@ export function runCommand(
   if (command.action.kind === "git-diff") {
     const action = command.action;
     return Effect.sync(() => runGitDiffEvidence(command.rootDir, action.baseRef));
+  }
+
+  if (command.action.kind === "doctor") {
+    return Effect.sync(() => runDoctor(command.rootDir));
   }
 
   if (command.action.kind === "task-review") {

--- a/packages/cli/test/doctor-cli.test.ts
+++ b/packages/cli/test/doctor-cli.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+
+test("doctor reports read-only environment and harness diagnostics without writing local state", () => {
+  withTempRoot((rootDir) => {
+    const result = runJson(rootDir, ["doctor"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.command, "doctor");
+    assert.equal(result.report.schema, "harness-doctor/v1");
+    assert.equal(result.report.readOnly, true);
+    assert.equal(result.report.node.requiredMajor, 24);
+    assert.equal(typeof result.report.node.ok, "boolean");
+    assert.equal(result.report.harness.authoredRoot, "harness");
+    assert.equal(result.report.harness.authoredRootExists, false);
+    assert.equal(result.report.harness.localRootExists, false);
+    assert.equal(result.report.recommendedCommands.includes("harness check --post-merge --json"), true);
+    assert.equal(JSON.stringify(result).includes(rootDir), false);
+    assert.equal(existsSync(path.join(rootDir, ".harness")), false);
+  });
+});
+
+test("doctor sees initialized authored and generated harness roots without repairing them", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+
+    const result = runJson(rootDir, ["doctor"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.report.harness.authoredRootExists, true);
+    assert.equal(result.report.harness.localRootExists, true);
+    assert.equal(result.report.cli.command, "harness doctor");
+  });
+});
+
+test("status command registry includes doctor", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+
+    const result = runJson(rootDir, ["status"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.commands.some((entry: Record<string, unknown>) => entry.kind === "doctor" && entry.primary === "harness doctor --json"), true);
+  });
+});
+
+function withTempRoot<T>(fn: (rootDir: string) => T): T {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doctor-"));
+  try {
+    return fn(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
+  const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+    encoding: "utf8"
+  });
+  return JSON.parse(stdout) as Record<string, any>;
+}

--- a/tools/smoke-cli-package.mjs
+++ b/tools/smoke-cli-package.mjs
@@ -70,6 +70,11 @@ try {
     throw new Error(`unexpected check smoke output: ${JSON.stringify(check)}`);
   }
 
+  const doctor = runJson(binPath, ["--json", "doctor"], projectDir);
+  if (doctor.ok !== true || doctor.report?.schema !== "harness-doctor/v1" || doctor.report?.readOnly !== true) {
+    throw new Error(`unexpected doctor smoke output: ${JSON.stringify(doctor)}`);
+  }
+
   console.log("CLI package smoke passed.");
 } finally {
   rmSync(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add read-only `harness doctor --json` for local install and project health checks
- document the M2 source-based install, doctor, task package, and agent playbook flow
- include doctor coverage in CLI package smoke testing

## Boundary
- P6 does not publish packages, change package privacy, switch default production paths, retire old routes, or close final M2 exit
- doctor is local-only and read-only; it does not create `.harness` or write project files

## Verification
- `npm run typecheck`
- `node --test packages/cli/test/doctor-cli.test.ts`
- `npm run harness:check-cutover-readiness`
- `npm run check`
- `git diff --check`
- Opus review: no P0/P1/P2 blockers
