### PR TITLE
chore: ignore local harness entrypoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,17 @@
-.harness-private/
-.harness/
-.worktrees/
-AGENTS.md
-CLAUDE.md
-docs/
+# Local-only agent entrypoints for developing this source repository.
+# They route agents into .harness-private/ and must not be published.
+/AGENTS.md
+/CLAUDE.md
+/docs/
+
+# Private self-hosted harness for this source repository.
+# This directory is versioned by its own local/private git repository and must not be
+# published with the open-source package.
+/.harness-private/
+/.harness/
+/.worktrees/
+/.gstack/
+
 node_modules/
 dist/
 coverage/


### PR DESCRIPTION
## Summary
- tighten root .gitignore entries for local-only harness entrypoints
- keep AGENTS.md, CLAUDE.md, docs/, .harness-private/, .harness/, worktrees, and gstack local-only at repository root

## Verification
- npm run check

## Notes
- No private harness files are included in this PR; this only protects local paths from accidental publication.