### PR TITLE
fix: harden M2 final cutover evidence

### DIFF
--- a/docs-release/m2-coding-vertical.md
+++ b/docs-release/m2-coding-vertical.md
@@ -107,6 +107,8 @@ harness check --post-merge --json
 M2-P7 activates `migrate-verify --full-cutover` as the final repository gate.
 The gate verifies the migration session, package release decision, package
 surface, and behavior corpus report before returning success.
+The behavior corpus must contain at least 15 classified items and zero
+`needs-decision` entries.
 
 Local final-cutover checks:
 
@@ -114,6 +116,7 @@ Local final-cutover checks:
 harness migrate-run --json
 harness migrate-verify <session.json> --full-cutover --json
 npm run harness:check-cutover-readiness
+npm run harness:smoke-full-cutover
 npm run check
 ```
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "packages/adapters/*"
   ],
   "scripts": {
-    "check": "npm run typecheck && npm test && npm run harness:check-file-complexity && npm run harness:check-import-boundaries && npm run harness:scan-forbidden-symbols && npm run harness:check-private-boundary && npm run harness:check-package-policy && npm run harness:check-implementation-contracts && npm run harness:check-schema-contracts && npm run harness:check-cutover-readiness && npm run harness:smoke-cli-package",
+    "check": "npm run typecheck && npm test && npm run harness:check-file-complexity && npm run harness:check-import-boundaries && npm run harness:scan-forbidden-symbols && npm run harness:check-private-boundary && npm run harness:check-package-policy && npm run harness:check-implementation-contracts && npm run harness:check-schema-contracts && npm run harness:check-cutover-readiness && npm run harness:smoke-full-cutover && npm run harness:smoke-cli-package",
     "typecheck": "tsc -b --pretty false",
     "test": "node tools/run-node-tests.mjs",
     "harness:check-file-complexity": "node tools/check-file-complexity.mjs",
@@ -20,6 +20,7 @@
     "harness:check-implementation-contracts": "node tools/check-implementation-contracts.mjs",
     "harness:check-schema-contracts": "node tools/check-schema-contracts.mjs",
     "harness:check-cutover-readiness": "node tools/check-cutover-readiness.mjs",
+    "harness:smoke-full-cutover": "node tools/smoke-full-cutover.mjs",
     "harness:smoke-cli-package": "node tools/smoke-cli-package.mjs"
   },
   "engines": {

--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -1,120 +1,52 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
-import type { DomainStatus, EngineError, PackageDisposition, TaskId, WriteError } from "../../../kernel/src/domain/index.ts";
-import { findEntityRefs, isDomainStatus, isPackageDisposition, isTerminalStatus } from "../../../kernel/src/domain/index.ts";
+import type { DomainStatus, EngineError, TaskId, WriteError } from "../../../kernel/src/domain/index.ts";
+import { isTerminalStatus } from "../../../kernel/src/domain/index.ts";
 import type { WriteCoordinator } from "../../../kernel/src/ports/index.ts";
-import type { WriteOpKind } from "../../../kernel/src/ports/write-coordinator.ts";
-import { makeJournaledWriteCoordinator, type JournalActor } from "../../../kernel/src/store/index.ts";
+import { makeJournaledWriteCoordinator } from "../../../kernel/src/store/index.ts";
 import { stablePayloadHash } from "../../../kernel/src/store/hash.ts";
-import { isGeneratedTaskId, resolveHarnessLayout, taskDocumentPath as harnessTaskDocumentPath, taskPackagePath, validateTaskIdSyntax } from "../../../kernel/src/layout/index.ts";
-import { resolveTaskCreatedBy, type TaskCreatedBy } from "./created-by.ts";
+import { resolveTaskCreatedBy } from "./created-by.ts";
+import { hasTaskRelations, renderSupersedesRelation } from "./task-relations.ts";
+import { indexPath, makeIndex, readIndexEffect, renderIndex, taskDocumentPath, validateGeneratedTaskId, validateTaskId } from "./task-index.ts";
+import { deleteTaskPackage, writeSupersedeTaskDocuments, writeTaskDocument } from "./task-writes.ts";
+import type {
+  AppendProgressInput,
+  CreateLocalTaskInput,
+  DeleteTaskInput,
+  LocalDeleteResult,
+  LocalLifecycleEngine,
+  LocalLifecycleOptions,
+  LocalProgressResult,
+  LocalSupersedeResult,
+  LocalTaskResult,
+  LocalWriteCoordinatorOptions,
+  SetLocalStatusInput,
+  SupersedeTaskInput,
+  TaskReasonInput
+} from "./types.ts";
 
 export { collectGitDiffEvidence } from "./git-diff-evidence.ts";
 export type { GitDiffEvidenceFile, GitDiffEvidenceOptions, GitDiffEvidenceReport } from "./git-diff-evidence.ts";
-
-export interface LocalLifecycleOptions {
-  readonly rootDir: string;
-  readonly coordinator?: WriteCoordinator;
-  readonly clock?: () => Date;
-}
-
-export interface LocalWriteCoordinatorOptions {
-  readonly rootDir: string;
-  readonly actor?: JournalActor;
-}
-
-export interface CreateLocalTaskInput {
-  readonly taskId: TaskId;
-  readonly title: string;
-  readonly allowManualId?: boolean;
-  readonly slug?: string;
-  readonly vertical?: string;
-  readonly preset?: string;
-  readonly createdBy?: TaskCreatedBy;
-}
-
-export interface SetLocalStatusInput {
-  readonly taskId: TaskId;
-  readonly status: DomainStatus;
-}
-
-export interface AppendProgressInput {
-  readonly taskId: TaskId;
-  readonly text: string;
-}
-
-export interface TaskReasonInput {
-  readonly taskId: TaskId;
-  readonly reason: string;
-}
-
-export interface SupersedeTaskInput {
-  readonly oldTaskId: TaskId;
-  readonly newTaskId: TaskId;
-  readonly title: string;
-  readonly slug: string;
-  readonly reason: string;
-}
-
-export type DeleteMode = "soft" | "hard";
-
-export interface DeleteTaskInput extends TaskReasonInput {
-  readonly mode: DeleteMode;
-}
-
-export interface LocalTaskResult {
-  readonly taskId: TaskId;
-  readonly status: DomainStatus;
-  readonly engine: "local";
-  readonly packageDisposition?: PackageDisposition;
-}
-
-export interface LocalProgressResult {
-  readonly taskId: TaskId;
-  readonly path: "progress.md";
-}
-
-export interface LocalSupersedeResult {
-  readonly oldTaskId: TaskId;
-  readonly newTaskId: TaskId;
-  readonly packageDisposition: "archived";
-}
-
-export interface LocalDeleteResult {
-  readonly taskId: TaskId;
-  readonly mode: DeleteMode;
-  readonly packageDisposition?: "tombstoned";
-}
-
-export interface LocalLifecycleEngine {
-  readonly createTask: (input: CreateLocalTaskInput) => Effect.Effect<LocalTaskResult, EngineError | WriteError>;
-  readonly setStatus: (input: SetLocalStatusInput) => Effect.Effect<LocalTaskResult, EngineError | WriteError>;
-  readonly appendProgress: (input: AppendProgressInput) => Effect.Effect<LocalProgressResult, EngineError | WriteError>;
-  readonly archiveTask: (input: TaskReasonInput) => Effect.Effect<LocalTaskResult, EngineError | WriteError>;
-  readonly supersedeTask: (input: SupersedeTaskInput) => Effect.Effect<LocalSupersedeResult, EngineError | WriteError>;
-  readonly deleteTask: (input: DeleteTaskInput) => Effect.Effect<LocalDeleteResult, EngineError | WriteError>;
-  readonly reopenTask: (input: TaskReasonInput) => Effect.Effect<LocalTaskResult, EngineError | WriteError>;
-}
+export type {
+  AppendProgressInput,
+  CreateLocalTaskInput,
+  DeleteMode,
+  DeleteTaskInput,
+  LocalDeleteResult,
+  LocalLifecycleEngine,
+  LocalLifecycleOptions,
+  LocalProgressResult,
+  LocalSupersedeResult,
+  LocalTaskResult,
+  LocalWriteCoordinatorOptions,
+  SetLocalStatusInput,
+  SupersedeTaskInput,
+  TaskReasonInput
+} from "./types.ts";
 
 export function makeLocalWriteCoordinator(options: LocalWriteCoordinatorOptions): WriteCoordinator {
   return makeJournaledWriteCoordinator(options);
-}
-
-interface LocalTaskIndex {
-  readonly taskId: TaskId;
-  readonly title: string;
-  readonly engine: string;
-  readonly status: DomainStatus;
-  readonly ref: string | null;
-  readonly titleSnapshot: string | null;
-  readonly url: string | null;
-  readonly bindingCreatedAt: string;
-  readonly bindingFingerprint: string;
-  readonly packageDisposition: "active" | "archived" | "tombstoned";
-  readonly vertical: string;
-  readonly preset: string;
-  readonly createdBy?: TaskCreatedBy;
 }
 
 export function makeLocalLifecycleEngine(options: LocalLifecycleOptions): LocalLifecycleEngine {
@@ -123,343 +55,170 @@ export function makeLocalLifecycleEngine(options: LocalLifecycleOptions): LocalL
   const clock = options.clock ?? (() => new Date());
 
   return {
-    createTask: (input) => Effect.gen(function* () {
+    createTask: (input) => createTask(rootDir, coordinator, clock, input),
+    setStatus: (input) => setStatus(rootDir, coordinator, input),
+    appendProgress: (input) => appendProgress(rootDir, coordinator, input),
+    archiveTask: (input) => archiveTask(rootDir, coordinator, input),
+    supersedeTask: (input) => supersedeTask(rootDir, coordinator, clock, input),
+    deleteTask: (input) => deleteTask(rootDir, coordinator, input),
+    reopenTask: (input) => reopenTask(rootDir, coordinator, input)
+  };
+}
+
+function createTask(
+  rootDir: string,
+  coordinator: WriteCoordinator,
+  clock: () => Date,
+  input: CreateLocalTaskInput
+): Effect.Effect<LocalTaskResult, EngineError | WriteError> {
+  return Effect.gen(function* () {
+    if (!input.allowManualId) {
+      const error = validateGeneratedTaskId(input.taskId);
+      if (error) return yield* Effect.fail(error);
+    } else {
       validateTaskId(input.taskId);
-      if (!input.allowManualId && !isGeneratedTaskId(input.taskId)) {
-        return yield* Effect.fail({ _tag: "MalformedSnapshot", raw: `task id must be generated: ${input.taskId}` } satisfies EngineError);
-      }
-      if (existsSync(indexPath(rootDir, input.taskId))) {
-        return yield* Effect.fail({ _tag: "MalformedSnapshot", raw: `task already exists: ${input.taskId}` } satisfies EngineError);
-      }
-      const bindingCreatedAt = clock().toISOString();
-      const createdBy = resolveTaskCreatedBy(rootDir, input.createdBy);
-      const index = makeIndex({
-        taskId: input.taskId,
-        title: input.title,
-        status: "planned",
-        bindingCreatedAt,
-        vertical: input.vertical ?? "default",
-        preset: input.preset ?? "default",
-        createdBy
-      });
-      yield* writeTaskDocument(coordinator, input.taskId, "INDEX.md", renderIndex(index), {
-        kind: "package_create",
-        slug: input.slug
-      });
-      return { taskId: input.taskId, status: "planned", engine: "local" } satisfies LocalTaskResult;
-    }),
-    setStatus: (input) => Effect.gen(function* () {
-      const index = yield* readIndexEffect(rootDir, input.taskId);
-      if (index.engine !== "local") {
-        return yield* Effect.fail({
-          _tag: "EngineOwnsStatus",
-          engine: index.engine,
-          ref: index.ref ?? input.taskId
-        } satisfies EngineError);
-      }
-      if (!canTransition(index.status, input.status)) {
-        return yield* Effect.fail({
-          _tag: "MalformedSnapshot",
-          raw: `invalid transition: ${index.status} -> ${input.status}`
-        } satisfies EngineError);
-      }
-      const next = { ...index, status: input.status };
-      yield* writeTaskDocument(coordinator, input.taskId, "INDEX.md", renderIndex(next), { kind: "transition_local" });
-      return { taskId: input.taskId, status: input.status, engine: "local" } satisfies LocalTaskResult;
-    }),
-    appendProgress: (input) => Effect.gen(function* () {
-      yield* readIndexEffect(rootDir, input.taskId);
-      const existing = existsSync(taskDocumentPath(rootDir, input.taskId, "progress.md"))
-        ? readFileSync(taskDocumentPath(rootDir, input.taskId, "progress.md"), "utf8")
-        : "";
-      const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
-      const body = `${existing}${separator}${input.text}\n`;
-      yield* writeTaskDocument(coordinator, input.taskId, "progress.md", body, { kind: "progress_append" });
-      return { taskId: input.taskId, path: "progress.md" } satisfies LocalProgressResult;
-    }),
-    archiveTask: (input) => Effect.gen(function* () {
-      const index = yield* readIndexEffect(rootDir, input.taskId);
-      const next = { ...index, packageDisposition: "archived" as const };
-      yield* writeTaskDocument(coordinator, input.taskId, "INDEX.md", renderIndex(next, input.reason), { kind: "package_archive" });
-      return { taskId: input.taskId, status: index.status, engine: "local", packageDisposition: "archived" } satisfies LocalTaskResult;
-    }),
-    supersedeTask: (input) => Effect.gen(function* () {
-      validateTaskId(input.newTaskId);
-      if (!isGeneratedTaskId(input.newTaskId)) {
-        return yield* Effect.fail({ _tag: "MalformedSnapshot", raw: `task id must be generated: ${input.newTaskId}` } satisfies EngineError);
-      }
-      if (existsSync(indexPath(rootDir, input.newTaskId))) {
-        return yield* Effect.fail({ _tag: "MalformedSnapshot", raw: `task already exists: ${input.newTaskId}` } satisfies EngineError);
-      }
-      const oldIndex = yield* readIndexEffect(rootDir, input.oldTaskId);
-      const bindingCreatedAt = clock().toISOString();
-      const createdBy = resolveTaskCreatedBy(rootDir);
-      const newIndex = makeIndex({
-        taskId: input.newTaskId,
-        title: input.title,
-        status: "planned",
-        bindingCreatedAt,
-        vertical: oldIndex.vertical,
-        preset: oldIndex.preset,
-        createdBy
-      });
-      const archivedOld = { ...oldIndex, packageDisposition: "archived" as const };
-      const relationBody = renderSupersedesRelation(input.newTaskId, input.oldTaskId, input.reason);
-      yield* writeSupersedeTaskDocuments(coordinator, [
-        { taskId: input.oldTaskId, path: "INDEX.md", body: renderIndex(archivedOld, input.reason) },
-        { taskId: input.newTaskId, path: "INDEX.md", body: renderIndex(newIndex), packageSlug: input.slug },
-        { taskId: input.newTaskId, path: "relations.md", body: relationBody, packageSlug: input.slug }
-      ]);
-      return { oldTaskId: input.oldTaskId, newTaskId: input.newTaskId, packageDisposition: "archived" } satisfies LocalSupersedeResult;
-    }),
-    deleteTask: (input) => Effect.gen(function* () {
-      const index = yield* readIndexEffect(rootDir, input.taskId);
-      if (input.mode === "soft") {
-        const next = { ...index, packageDisposition: "tombstoned" as const };
-        yield* writeTaskDocument(coordinator, input.taskId, "INDEX.md", renderIndex(next, input.reason), { kind: "package_tombstone" });
-        return { taskId: input.taskId, mode: "soft", packageDisposition: "tombstoned" } satisfies LocalDeleteResult;
-      }
-      if (index.packageDisposition === "archived") {
-        return yield* Effect.fail({ _tag: "ArchivedHardDeleteForbidden", taskId: input.taskId } satisfies EngineError);
-      }
-      if (isTerminalStatus(index.status)) {
-        return yield* Effect.fail({ _tag: "TerminalHardDeleteForbidden", taskId: input.taskId, status: index.status } satisfies EngineError);
-      }
-      if (hasTaskRelations(rootDir, input.taskId)) {
-        return yield* Effect.fail({ _tag: "RelatedTaskHardDeleteForbidden", taskId: input.taskId } satisfies EngineError);
-      }
-      yield* deleteTaskPackage(coordinator, input.taskId, input.reason);
-      return { taskId: input.taskId, mode: "hard" } satisfies LocalDeleteResult;
-    }),
-    reopenTask: (input) => Effect.gen(function* () {
-      const index = yield* readIndexEffect(rootDir, input.taskId);
-      if (isTerminalStatus(index.status)) {
-        return yield* Effect.fail({ _tag: "TerminalReopenRequiresSupersede", taskId: input.taskId, status: index.status } satisfies EngineError);
-      }
-      const next = { ...index, packageDisposition: "active" as const };
-      yield* writeTaskDocument(coordinator, input.taskId, "INDEX.md", renderIndex(next, input.reason), { kind: "package_reopen" });
-      return { taskId: input.taskId, status: index.status, engine: "local", packageDisposition: "active" } satisfies LocalTaskResult;
-    })
-  };
-}
-
-interface TaskDocumentWrite {
-  readonly taskId: TaskId;
-  readonly path: string;
-  readonly body: string;
-  readonly kind: WriteOpKind;
-  readonly packageSlug?: string;
-}
-
-interface SupersedeDocumentWrite {
-  readonly taskId: TaskId;
-  readonly path: string;
-  readonly body: string;
-  readonly packageSlug?: string;
-}
-
-function writeTaskDocument(
-  coordinator: WriteCoordinator,
-  taskId: TaskId,
-  documentPath: string,
-  body: string,
-  options: {
-    readonly kind?: WriteOpKind;
-    readonly slug?: string;
-  } = {}
-): Effect.Effect<void, WriteError> {
-  return writeTaskDocuments(coordinator, [{
-    taskId,
-    path: documentPath,
-    body,
-    kind: options.kind ?? "doc_write",
-    packageSlug: options.slug
-  }]);
-}
-
-function writeTaskDocuments(
-  coordinator: WriteCoordinator,
-  writes: ReadonlyArray<TaskDocumentWrite>
-): Effect.Effect<void, WriteError> {
-  return Effect.gen(function* () {
-    for (const write of writes) {
-      const opId = `${Date.now()}-${stablePayloadHash(write).slice(0, 16)}`;
-      yield* coordinator.enqueue({
-        opId,
-        taskId: write.taskId,
-        kind: write.kind,
-        payload: {
-          path: write.path,
-          body: write.body,
-          ...(write.packageSlug ? { packageSlug: write.packageSlug } : {})
-        }
-      });
     }
-    yield* coordinator.flush("explicit");
-  });
-}
-
-function writeSupersedeTaskDocuments(
-  coordinator: WriteCoordinator,
-  writes: ReadonlyArray<SupersedeDocumentWrite>
-): Effect.Effect<void, WriteError> {
-  return Effect.gen(function* () {
-    const opId = `${Date.now()}-${stablePayloadHash({ kind: "package_supersede", writes }).slice(0, 16)}`;
-    yield* coordinator.enqueue({
-      opId,
-      taskId: writes[0]?.taskId ?? "unknown",
-      kind: "package_supersede",
-      payload: { writes }
+    if (existsSync(indexPath(rootDir, input.taskId))) {
+      return yield* Effect.fail({ _tag: "MalformedSnapshot", raw: `task already exists: ${input.taskId}` } satisfies EngineError);
+    }
+    const index = makeIndex({
+      taskId: input.taskId,
+      title: input.title,
+      status: "planned",
+      bindingCreatedAt: clock().toISOString(),
+      vertical: input.vertical ?? "default",
+      preset: input.preset ?? "default",
+      createdBy: resolveTaskCreatedBy(rootDir, input.createdBy)
+    }, stablePayloadHash);
+    yield* writeTaskDocument(coordinator, stablePayloadHash, input.taskId, "INDEX.md", renderIndex(index), {
+      kind: "package_create",
+      slug: input.slug
     });
-    yield* coordinator.flush("explicit");
+    return { taskId: input.taskId, status: "planned", engine: "local" } satisfies LocalTaskResult;
   });
 }
 
-function deleteTaskPackage(
+function setStatus(
+  rootDir: string,
   coordinator: WriteCoordinator,
-  taskId: TaskId,
-  reason: string
-): Effect.Effect<void, WriteError> {
+  input: SetLocalStatusInput
+): Effect.Effect<LocalTaskResult, EngineError | WriteError> {
   return Effect.gen(function* () {
-    const opId = `${Date.now()}-${stablePayloadHash({ taskId, reason, kind: "package_delete_hard" }).slice(0, 16)}`;
-    yield* coordinator.enqueue({
-      opId,
-      taskId,
-      kind: "package_delete_hard",
-      payload: { reason }
-    });
-    yield* coordinator.flush("explicit");
+    const index = yield* readIndexEffect(rootDir, input.taskId);
+    if (index.engine !== "local") {
+      return yield* Effect.fail({
+        _tag: "EngineOwnsStatus",
+        engine: index.engine,
+        ref: index.ref ?? input.taskId
+      } satisfies EngineError);
+    }
+    if (!canTransition(index.status, input.status)) {
+      return yield* Effect.fail({
+        _tag: "MalformedSnapshot",
+        raw: `invalid transition: ${index.status} -> ${input.status}`
+      } satisfies EngineError);
+    }
+    yield* writeTaskDocument(coordinator, stablePayloadHash, input.taskId, "INDEX.md", renderIndex({ ...index, status: input.status }), { kind: "transition_local" });
+    return { taskId: input.taskId, status: input.status, engine: "local" } satisfies LocalTaskResult;
   });
 }
 
-function makeIndex(input: {
-  readonly taskId: TaskId;
-  readonly title: string;
-  readonly status: DomainStatus;
-  readonly bindingCreatedAt: string;
-  readonly vertical: string;
-  readonly preset: string;
-  readonly createdBy?: TaskCreatedBy;
-}): LocalTaskIndex {
-  const fingerprint = stablePayloadHash({
-    engine: "local",
-    ref: null,
-    bindingCreatedAt: input.bindingCreatedAt
-  });
-  return {
-    taskId: input.taskId,
-    title: input.title,
-    engine: "local",
-    status: input.status,
-    ref: null,
-    titleSnapshot: input.title,
-    url: null,
-    bindingCreatedAt: input.bindingCreatedAt,
-    bindingFingerprint: `sha256:${fingerprint}`,
-    packageDisposition: "active",
-    vertical: input.vertical,
-    preset: input.preset,
-    ...(input.createdBy ? { createdBy: input.createdBy } : {})
-  };
-}
-
-function renderIndex(index: LocalTaskIndex, reason?: string): string {
-  const lines = [
-    "---",
-    "schema: task-package/v2",
-    `task_id: ${index.taskId}`,
-    `title: ${index.title}`,
-    "lifecycle:",
-    "  bindingSchema: lifecycle-binding/v1",
-    `  engine: ${index.engine}`,
-    `  status: ${index.status}`,
-    `  ref: ${index.ref ?? ""}`,
-    `  titleSnapshot: ${index.titleSnapshot ?? ""}`,
-    `  url: ${index.url ?? ""}`,
-    `  bindingCreatedAt: ${index.bindingCreatedAt}`,
-    `  bindingFingerprint: ${index.bindingFingerprint}`,
-    `packageDisposition: ${index.packageDisposition}`,
-    `vertical: ${index.vertical}`,
-    `preset: ${index.preset}`,
-    ...(index.createdBy ? [
-      "createdBy:",
-      `  name: ${index.createdBy.name}`,
-      `  email: ${index.createdBy.email}`
-    ] : []),
-    "---",
-    "",
-    `# ${index.title}`,
-    ""
-  ];
-  if (reason && reason.length > 0) {
-    lines.push("## Lifecycle Note", "", reason, "");
-  }
-  return lines.join("\n");
-}
-
-function readIndexEffect(rootDir: string, taskId: TaskId): Effect.Effect<LocalTaskIndex, EngineError> {
-  return Effect.try({
-    try: () => readIndex(rootDir, taskId),
-    catch: (cause): EngineError => ({
-      _tag: "MalformedSnapshot",
-      raw: isNodeErrorCode(cause, "ENOENT") ? `task not found: ${taskId}` : sanitizeReadError(cause)
-    })
+function appendProgress(
+  rootDir: string,
+  coordinator: WriteCoordinator,
+  input: AppendProgressInput
+): Effect.Effect<LocalProgressResult, EngineError | WriteError> {
+  return Effect.gen(function* () {
+    yield* readIndexEffect(rootDir, input.taskId);
+    const existingPath = taskDocumentPath(rootDir, input.taskId, "progress.md");
+    const existing = existsSync(existingPath) ? readFileSync(existingPath, "utf8") : "";
+    const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+    yield* writeTaskDocument(coordinator, stablePayloadHash, input.taskId, "progress.md", `${existing}${separator}${input.text}\n`, { kind: "progress_append" });
+    return { taskId: input.taskId, path: "progress.md" } satisfies LocalProgressResult;
   });
 }
 
-function readIndex(rootDir: string, taskId: TaskId): LocalTaskIndex {
-  validateTaskId(taskId);
-  const body = readFileSync(indexPath(rootDir, taskId), "utf8");
-  const frontmatter = body.match(/^---\n([\s\S]*?)\n---/u)?.[1];
-  if (!frontmatter) throw new Error(`INDEX.md missing frontmatter: ${taskId}`);
-
-  const status = readScalar(frontmatter, "  status");
-  if (!isDomainStatus(status)) throw new Error(`invalid local status: ${status}`);
-
-  return {
-    taskId: readScalar(frontmatter, "task_id"),
-    title: readScalar(frontmatter, "title"),
-    engine: readScalar(frontmatter, "  engine"),
-    status,
-    ref: nullIfEmpty(readScalar(frontmatter, "  ref")),
-    titleSnapshot: nullIfEmpty(readScalar(frontmatter, "  titleSnapshot")),
-    url: nullIfEmpty(readScalar(frontmatter, "  url")),
-    bindingCreatedAt: readScalar(frontmatter, "  bindingCreatedAt"),
-    bindingFingerprint: readScalar(frontmatter, "  bindingFingerprint"),
-    packageDisposition: readPackageDisposition(frontmatter),
-    vertical: readScalar(frontmatter, "vertical"),
-    preset: readScalar(frontmatter, "preset"),
-    ...readCreatedBy(frontmatter)
-  };
+function archiveTask(
+  rootDir: string,
+  coordinator: WriteCoordinator,
+  input: TaskReasonInput
+): Effect.Effect<LocalTaskResult, EngineError | WriteError> {
+  return Effect.gen(function* () {
+    const index = yield* readIndexEffect(rootDir, input.taskId);
+    yield* writeTaskDocument(coordinator, stablePayloadHash, input.taskId, "INDEX.md", renderIndex({ ...index, packageDisposition: "archived" }, input.reason), { kind: "package_archive" });
+    return { taskId: input.taskId, status: index.status, engine: "local", packageDisposition: "archived" } satisfies LocalTaskResult;
+  });
 }
 
-function readScalar(frontmatter: string, key: string): string {
-  const escaped = key.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-  const value = frontmatter.match(new RegExp(`^${escaped}:[ \\t]*(.*)$`, "mu"))?.[1];
-  if (value === undefined) throw new Error(`frontmatter missing ${key.trim()}`);
-  return value.trim();
+function supersedeTask(
+  rootDir: string,
+  coordinator: WriteCoordinator,
+  clock: () => Date,
+  input: SupersedeTaskInput
+): Effect.Effect<LocalSupersedeResult, EngineError | WriteError> {
+  return Effect.gen(function* () {
+    const error = validateGeneratedTaskId(input.newTaskId);
+    if (error) return yield* Effect.fail(error);
+    if (existsSync(indexPath(rootDir, input.newTaskId))) {
+      return yield* Effect.fail({ _tag: "MalformedSnapshot", raw: `task already exists: ${input.newTaskId}` } satisfies EngineError);
+    }
+    const oldIndex = yield* readIndexEffect(rootDir, input.oldTaskId);
+    const newIndex = makeIndex({
+      taskId: input.newTaskId,
+      title: input.title,
+      status: "planned",
+      bindingCreatedAt: clock().toISOString(),
+      vertical: oldIndex.vertical,
+      preset: oldIndex.preset,
+      createdBy: resolveTaskCreatedBy(rootDir)
+    }, stablePayloadHash);
+    yield* writeSupersedeTaskDocuments(coordinator, stablePayloadHash, [
+      { taskId: input.oldTaskId, path: "INDEX.md", body: renderIndex({ ...oldIndex, packageDisposition: "archived" }, input.reason) },
+      { taskId: input.newTaskId, path: "INDEX.md", body: renderIndex(newIndex), packageSlug: input.slug },
+      { taskId: input.newTaskId, path: "relations.md", body: renderSupersedesRelation(input.newTaskId, input.oldTaskId, input.reason), packageSlug: input.slug }
+    ]);
+    return { oldTaskId: input.oldTaskId, newTaskId: input.newTaskId, packageDisposition: "archived" } satisfies LocalSupersedeResult;
+  });
 }
 
-function nullIfEmpty(value: string): string | null {
-  return value.length === 0 ? null : value;
+function deleteTask(
+  rootDir: string,
+  coordinator: WriteCoordinator,
+  input: DeleteTaskInput
+): Effect.Effect<LocalDeleteResult, EngineError | WriteError> {
+  return Effect.gen(function* () {
+    const index = yield* readIndexEffect(rootDir, input.taskId);
+    if (input.mode === "soft") {
+      yield* writeTaskDocument(coordinator, stablePayloadHash, input.taskId, "INDEX.md", renderIndex({ ...index, packageDisposition: "tombstoned" }, input.reason), { kind: "package_tombstone" });
+      return { taskId: input.taskId, mode: "soft", packageDisposition: "tombstoned" } satisfies LocalDeleteResult;
+    }
+    if (index.packageDisposition === "archived") {
+      return yield* Effect.fail({ _tag: "ArchivedHardDeleteForbidden", taskId: input.taskId } satisfies EngineError);
+    }
+    if (isTerminalStatus(index.status)) {
+      return yield* Effect.fail({ _tag: "TerminalHardDeleteForbidden", taskId: input.taskId, status: index.status } satisfies EngineError);
+    }
+    if (hasTaskRelations(rootDir, input.taskId)) {
+      return yield* Effect.fail({ _tag: "RelatedTaskHardDeleteForbidden", taskId: input.taskId } satisfies EngineError);
+    }
+    yield* deleteTaskPackage(coordinator, stablePayloadHash, input.taskId, input.reason);
+    return { taskId: input.taskId, mode: "hard" } satisfies LocalDeleteResult;
+  });
 }
 
-function readCreatedBy(frontmatter: string): { readonly createdBy?: TaskCreatedBy } {
-  const block = frontmatter.match(/^createdBy:\n((?:[ \t]+[^\n]*\n?)*)/mu)?.[1];
-  if (!block) return {};
-  const name = readOptionalNestedScalar(block, "name");
-  const email = readOptionalNestedScalar(block, "email");
-  return name && email ? { createdBy: { name, email } } : {};
-}
-
-function readOptionalNestedScalar(block: string, key: string): string {
-  const escaped = key.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-  return block.match(new RegExp(`^[ \\t]+${escaped}:[ \\t]*(.*)$`, "mu"))?.[1]?.trim() ?? "";
-}
-
-function readPackageDisposition(frontmatter: string): LocalTaskIndex["packageDisposition"] {
-  const value = readScalar(frontmatter, "packageDisposition");
-  return isPackageDisposition(value) ? value : "active";
+function reopenTask(
+  rootDir: string,
+  coordinator: WriteCoordinator,
+  input: TaskReasonInput
+): Effect.Effect<LocalTaskResult, EngineError | WriteError> {
+  return Effect.gen(function* () {
+    const index = yield* readIndexEffect(rootDir, input.taskId);
+    if (isTerminalStatus(index.status)) {
+      return yield* Effect.fail({ _tag: "TerminalReopenRequiresSupersede", taskId: input.taskId, status: index.status } satisfies EngineError);
+    }
+    yield* writeTaskDocument(coordinator, stablePayloadHash, input.taskId, "INDEX.md", renderIndex({ ...index, packageDisposition: "active" }, input.reason), { kind: "package_reopen" });
+    return { taskId: input.taskId, status: index.status, engine: "local", packageDisposition: "active" } satisfies LocalTaskResult;
+  });
 }
 
 function canTransition(from: DomainStatus, to: DomainStatus): boolean {
@@ -470,74 +229,4 @@ function canTransition(from: DomainStatus, to: DomainStatus): boolean {
   if (from === "blocked") return to === "active" || to === "cancelled";
   if (from === "in_review") return to === "active" || to === "blocked" || to === "done" || to === "cancelled";
   return false;
-}
-
-function validateTaskId(taskId: TaskId): void {
-  validateTaskIdSyntax(taskId);
-}
-
-function renderSupersedesRelation(newTaskId: TaskId, oldTaskId: TaskId, reason: string): string {
-  return [
-    "---",
-    "schema: task-relations/v1",
-    `source: task/${newTaskId}`,
-    `target: task/${oldTaskId}`,
-    "type: supersedes",
-    "strength: strong",
-    "direction: directed",
-    "provenance: declared",
-    "state: active",
-    "---",
-    "",
-    "# Supersedes",
-    "",
-    `task/${newTaskId} supersedes task/${oldTaskId}.`,
-    "",
-    "## Reason",
-    "",
-    reason,
-    ""
-  ].join("\n");
-}
-
-function hasTaskRelations(rootDir: string, taskId: TaskId): boolean {
-  const layout = resolveHarnessLayout(rootDir);
-  const ownPackage = taskPackagePath(rootDir, taskId);
-  for (const filePath of listTextFiles(layout.authoredRoot)) {
-    const body = readFileSync(filePath, "utf8");
-    const refs = findEntityRefs(body);
-    if (refs.some((ref) => !ref.externalHarness && ref.id === taskId)) return true;
-    if (filePath.startsWith(ownPackage) && refs.some((ref) => !ref.externalHarness && ref.id !== taskId)) return true;
-  }
-  return false;
-}
-
-function listTextFiles(inputPath: string): ReadonlyArray<string> {
-  if (!existsSync(inputPath)) return [];
-  const files: string[] = [];
-  for (const entry of readdirSync(inputPath, { withFileTypes: true })) {
-    const fullPath = path.join(inputPath, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...listTextFiles(fullPath));
-      continue;
-    }
-    if (/\.(md|markdown|txt|ya?ml|json)$/iu.test(entry.name)) files.push(fullPath);
-  }
-  return files;
-}
-
-function indexPath(rootDir: string, taskId: TaskId): string {
-  return taskDocumentPath(rootDir, taskId, "INDEX.md");
-}
-
-function taskDocumentPath(rootDir: string, taskId: TaskId, documentPath: string): string {
-  return harnessTaskDocumentPath(rootDir, taskId, documentPath);
-}
-
-function isNodeErrorCode(error: unknown, code: string): boolean {
-  return typeof error === "object" && error !== null && "code" in error && error.code === code;
-}
-
-function sanitizeReadError(error: unknown): string {
-  return error instanceof Error ? error.message.replace(/'[^']*'/gu, "[path]") : "malformed task package";
 }

--- a/packages/adapters/local/src/task-index.ts
+++ b/packages/adapters/local/src/task-index.ts
@@ -1,0 +1,166 @@
+import { readFileSync } from "node:fs";
+import { Effect } from "effect";
+import type { DomainStatus, EngineError, TaskId } from "../../../kernel/src/domain/index.ts";
+import { isDomainStatus, isPackageDisposition } from "../../../kernel/src/domain/index.ts";
+import { isGeneratedTaskId, taskDocumentPath as harnessTaskDocumentPath, validateTaskIdSyntax } from "../../../kernel/src/layout/index.ts";
+import type { TaskCreatedBy } from "./created-by.ts";
+import type { LocalTaskIndex } from "./types.ts";
+
+export type HashPayload = (value: unknown) => string;
+
+export function validateTaskId(taskId: TaskId): void {
+  validateTaskIdSyntax(taskId);
+}
+
+export function validateGeneratedTaskId(taskId: TaskId): EngineError | undefined {
+  validateTaskId(taskId);
+  return isGeneratedTaskId(taskId)
+    ? undefined
+    : { _tag: "MalformedSnapshot", raw: `task id must be generated: ${taskId}` };
+}
+
+export function makeIndex(input: {
+  readonly taskId: TaskId;
+  readonly title: string;
+  readonly status: DomainStatus;
+  readonly bindingCreatedAt: string;
+  readonly vertical: string;
+  readonly preset: string;
+  readonly createdBy?: TaskCreatedBy;
+}, hashPayload: HashPayload): LocalTaskIndex {
+  const fingerprint = hashPayload({
+    engine: "local",
+    ref: null,
+    bindingCreatedAt: input.bindingCreatedAt
+  });
+  return {
+    taskId: input.taskId,
+    title: input.title,
+    engine: "local",
+    status: input.status,
+    ref: null,
+    titleSnapshot: input.title,
+    url: null,
+    bindingCreatedAt: input.bindingCreatedAt,
+    bindingFingerprint: `sha256:${fingerprint}`,
+    packageDisposition: "active",
+    vertical: input.vertical,
+    preset: input.preset,
+    ...(input.createdBy ? { createdBy: input.createdBy } : {})
+  };
+}
+
+export function renderIndex(index: LocalTaskIndex, reason?: string): string {
+  const lines = [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${index.taskId}`,
+    `title: ${index.title}`,
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    `  engine: ${index.engine}`,
+    `  status: ${index.status}`,
+    `  ref: ${index.ref ?? ""}`,
+    `  titleSnapshot: ${index.titleSnapshot ?? ""}`,
+    `  url: ${index.url ?? ""}`,
+    `  bindingCreatedAt: ${index.bindingCreatedAt}`,
+    `  bindingFingerprint: ${index.bindingFingerprint}`,
+    `packageDisposition: ${index.packageDisposition}`,
+    `vertical: ${index.vertical}`,
+    `preset: ${index.preset}`,
+    ...(index.createdBy ? [
+      "createdBy:",
+      `  name: ${index.createdBy.name}`,
+      `  email: ${index.createdBy.email}`
+    ] : []),
+    "---",
+    "",
+    `# ${index.title}`,
+    ""
+  ];
+  if (reason && reason.length > 0) {
+    lines.push("## Lifecycle Note", "", reason, "");
+  }
+  return lines.join("\n");
+}
+
+export function readIndexEffect(rootDir: string, taskId: TaskId): Effect.Effect<LocalTaskIndex, EngineError> {
+  return Effect.try({
+    try: () => readIndex(rootDir, taskId),
+    catch: (cause): EngineError => ({
+      _tag: "MalformedSnapshot",
+      raw: isNodeErrorCode(cause, "ENOENT") ? `task not found: ${taskId}` : sanitizeReadError(cause)
+    })
+  });
+}
+
+export function readIndex(rootDir: string, taskId: TaskId): LocalTaskIndex {
+  validateTaskId(taskId);
+  const body = readFileSync(indexPath(rootDir, taskId), "utf8");
+  const frontmatter = body.match(/^---\n([\s\S]*?)\n---/u)?.[1];
+  if (!frontmatter) throw new Error(`INDEX.md missing frontmatter: ${taskId}`);
+
+  const status = readScalar(frontmatter, "  status");
+  if (!isDomainStatus(status)) throw new Error(`invalid local status: ${status}`);
+
+  return {
+    taskId: readScalar(frontmatter, "task_id"),
+    title: readScalar(frontmatter, "title"),
+    engine: readScalar(frontmatter, "  engine"),
+    status,
+    ref: nullIfEmpty(readScalar(frontmatter, "  ref")),
+    titleSnapshot: nullIfEmpty(readScalar(frontmatter, "  titleSnapshot")),
+    url: nullIfEmpty(readScalar(frontmatter, "  url")),
+    bindingCreatedAt: readScalar(frontmatter, "  bindingCreatedAt"),
+    bindingFingerprint: readScalar(frontmatter, "  bindingFingerprint"),
+    packageDisposition: readPackageDisposition(frontmatter),
+    vertical: readScalar(frontmatter, "vertical"),
+    preset: readScalar(frontmatter, "preset"),
+    ...readCreatedBy(frontmatter)
+  };
+}
+
+export function indexPath(rootDir: string, taskId: TaskId): string {
+  return taskDocumentPath(rootDir, taskId, "INDEX.md");
+}
+
+export function taskDocumentPath(rootDir: string, taskId: TaskId, documentPath: string): string {
+  return harnessTaskDocumentPath(rootDir, taskId, documentPath);
+}
+
+function readScalar(frontmatter: string, key: string): string {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  const value = frontmatter.match(new RegExp(`^${escaped}:[ \\t]*(.*)$`, "mu"))?.[1];
+  if (value === undefined) throw new Error(`frontmatter missing ${key.trim()}`);
+  return value.trim();
+}
+
+function nullIfEmpty(value: string): string | null {
+  return value.length === 0 ? null : value;
+}
+
+function readCreatedBy(frontmatter: string): { readonly createdBy?: TaskCreatedBy } {
+  const block = frontmatter.match(/^createdBy:\n((?:[ \t]+[^\n]*\n?)*)/mu)?.[1];
+  if (!block) return {};
+  const name = readOptionalNestedScalar(block, "name");
+  const email = readOptionalNestedScalar(block, "email");
+  return name && email ? { createdBy: { name, email } } : {};
+}
+
+function readOptionalNestedScalar(block: string, key: string): string {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return block.match(new RegExp(`^[ \\t]+${escaped}:[ \\t]*(.*)$`, "mu"))?.[1]?.trim() ?? "";
+}
+
+function readPackageDisposition(frontmatter: string): LocalTaskIndex["packageDisposition"] {
+  const value = readScalar(frontmatter, "packageDisposition");
+  return isPackageDisposition(value) ? value : "active";
+}
+
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
+}
+
+function sanitizeReadError(error: unknown): string {
+  return error instanceof Error ? error.message.replace(/'[^']*'/gu, "[path]") : "malformed task package";
+}

--- a/packages/adapters/local/src/task-relations.ts
+++ b/packages/adapters/local/src/task-relations.ts
@@ -1,0 +1,55 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import type { TaskId } from "../../../kernel/src/domain/index.ts";
+import { findEntityRefs } from "../../../kernel/src/domain/index.ts";
+import { resolveHarnessLayout, taskPackagePath } from "../../../kernel/src/layout/index.ts";
+
+export function renderSupersedesRelation(newTaskId: TaskId, oldTaskId: TaskId, reason: string): string {
+  return [
+    "---",
+    "schema: task-relations/v1",
+    `source: task/${newTaskId}`,
+    `target: task/${oldTaskId}`,
+    "type: supersedes",
+    "strength: strong",
+    "direction: directed",
+    "provenance: declared",
+    "state: active",
+    "---",
+    "",
+    "# Supersedes",
+    "",
+    `task/${newTaskId} supersedes task/${oldTaskId}.`,
+    "",
+    "## Reason",
+    "",
+    reason,
+    ""
+  ].join("\n");
+}
+
+export function hasTaskRelations(rootDir: string, taskId: TaskId): boolean {
+  const layout = resolveHarnessLayout(rootDir);
+  const ownPackage = taskPackagePath(rootDir, taskId);
+  for (const filePath of listTextFiles(layout.authoredRoot)) {
+    const body = readFileSync(filePath, "utf8");
+    const refs = findEntityRefs(body);
+    if (refs.some((ref) => !ref.externalHarness && ref.id === taskId)) return true;
+    if (filePath.startsWith(ownPackage) && refs.some((ref) => !ref.externalHarness && ref.id !== taskId)) return true;
+  }
+  return false;
+}
+
+function listTextFiles(inputPath: string): ReadonlyArray<string> {
+  if (!existsSync(inputPath)) return [];
+  const files: string[] = [];
+  for (const entry of readdirSync(inputPath, { withFileTypes: true })) {
+    const fullPath = path.join(inputPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listTextFiles(fullPath));
+      continue;
+    }
+    if (/\.(md|markdown|txt|ya?ml|json)$/iu.test(entry.name)) files.push(fullPath);
+  }
+  return files;
+}

--- a/packages/adapters/local/src/task-writes.ts
+++ b/packages/adapters/local/src/task-writes.ts
@@ -1,0 +1,98 @@
+import { Effect } from "effect";
+import type { TaskId, WriteError } from "../../../kernel/src/domain/index.ts";
+import type { WriteCoordinator } from "../../../kernel/src/ports/index.ts";
+import type { WriteOpKind } from "../../../kernel/src/ports/write-coordinator.ts";
+import type { HashPayload } from "./task-index.ts";
+
+export interface TaskDocumentWrite {
+  readonly taskId: TaskId;
+  readonly path: string;
+  readonly body: string;
+  readonly kind: WriteOpKind;
+  readonly packageSlug?: string;
+}
+
+export interface SupersedeDocumentWrite {
+  readonly taskId: TaskId;
+  readonly path: string;
+  readonly body: string;
+  readonly packageSlug?: string;
+}
+
+export function writeTaskDocument(
+  coordinator: WriteCoordinator,
+  hashPayload: HashPayload,
+  taskId: TaskId,
+  documentPath: string,
+  body: string,
+  options: {
+    readonly kind?: WriteOpKind;
+    readonly slug?: string;
+  } = {}
+): Effect.Effect<void, WriteError> {
+  return writeTaskDocuments(coordinator, hashPayload, [{
+    taskId,
+    path: documentPath,
+    body,
+    kind: options.kind ?? "doc_write",
+    packageSlug: options.slug
+  }]);
+}
+
+export function writeTaskDocuments(
+  coordinator: WriteCoordinator,
+  hashPayload: HashPayload,
+  writes: ReadonlyArray<TaskDocumentWrite>
+): Effect.Effect<void, WriteError> {
+  return Effect.gen(function* () {
+    for (const write of writes) {
+      const opId = `${Date.now()}-${hashPayload(write).slice(0, 16)}`;
+      yield* coordinator.enqueue({
+        opId,
+        taskId: write.taskId,
+        kind: write.kind,
+        payload: {
+          path: write.path,
+          body: write.body,
+          ...(write.packageSlug ? { packageSlug: write.packageSlug } : {})
+        }
+      });
+    }
+    yield* coordinator.flush("explicit");
+  });
+}
+
+export function writeSupersedeTaskDocuments(
+  coordinator: WriteCoordinator,
+  hashPayload: HashPayload,
+  writes: ReadonlyArray<SupersedeDocumentWrite>
+): Effect.Effect<void, WriteError> {
+  return Effect.gen(function* () {
+    const opId = `${Date.now()}-${hashPayload({ kind: "package_supersede", writes }).slice(0, 16)}`;
+    yield* coordinator.enqueue({
+      opId,
+      taskId: writes[0]?.taskId ?? "unknown",
+      kind: "package_supersede",
+      payload: { writes }
+    });
+    yield* coordinator.flush("explicit");
+  });
+}
+
+export function deleteTaskPackage(
+  coordinator: WriteCoordinator,
+  hashPayload: HashPayload,
+  taskId: TaskId,
+  reason: string
+): Effect.Effect<void, WriteError> {
+  return Effect.gen(function* () {
+    const opId = `${Date.now()}-${hashPayload({ taskId, reason, kind: "package_delete_hard" }).slice(0, 16)}`;
+    yield* coordinator.enqueue({
+      opId,
+      taskId,
+      kind: "package_delete_hard",
+      payload: { reason }
+    });
+    yield* coordinator.flush("explicit");
+  });
+}

--- a/packages/adapters/local/src/types.ts
+++ b/packages/adapters/local/src/types.ts
@@ -1,0 +1,109 @@
+import type { Effect } from "effect";
+import type { DomainStatus, EngineError, PackageDisposition, TaskId, WriteError } from "../../../kernel/src/domain/index.ts";
+import type { WriteCoordinator } from "../../../kernel/src/ports/index.ts";
+import type { TaskCreatedBy } from "./created-by.ts";
+
+export interface LocalJournalActor {
+  readonly kind: "agent" | "human" | "system";
+  readonly id: string;
+}
+
+export interface LocalLifecycleOptions {
+  readonly rootDir: string;
+  readonly coordinator?: WriteCoordinator;
+  readonly clock?: () => Date;
+}
+
+export interface LocalWriteCoordinatorOptions {
+  readonly rootDir: string;
+  readonly actor?: LocalJournalActor;
+}
+
+export interface CreateLocalTaskInput {
+  readonly taskId: TaskId;
+  readonly title: string;
+  readonly allowManualId?: boolean;
+  readonly slug?: string;
+  readonly vertical?: string;
+  readonly preset?: string;
+  readonly createdBy?: TaskCreatedBy;
+}
+
+export interface SetLocalStatusInput {
+  readonly taskId: TaskId;
+  readonly status: DomainStatus;
+}
+
+export interface AppendProgressInput {
+  readonly taskId: TaskId;
+  readonly text: string;
+}
+
+export interface TaskReasonInput {
+  readonly taskId: TaskId;
+  readonly reason: string;
+}
+
+export interface SupersedeTaskInput {
+  readonly oldTaskId: TaskId;
+  readonly newTaskId: TaskId;
+  readonly title: string;
+  readonly slug: string;
+  readonly reason: string;
+}
+
+export type DeleteMode = "soft" | "hard";
+
+export interface DeleteTaskInput extends TaskReasonInput {
+  readonly mode: DeleteMode;
+}
+
+export interface LocalTaskResult {
+  readonly taskId: TaskId;
+  readonly status: DomainStatus;
+  readonly engine: "local";
+  readonly packageDisposition?: PackageDisposition;
+}
+
+export interface LocalProgressResult {
+  readonly taskId: TaskId;
+  readonly path: "progress.md";
+}
+
+export interface LocalSupersedeResult {
+  readonly oldTaskId: TaskId;
+  readonly newTaskId: TaskId;
+  readonly packageDisposition: "archived";
+}
+
+export interface LocalDeleteResult {
+  readonly taskId: TaskId;
+  readonly mode: DeleteMode;
+  readonly packageDisposition?: "tombstoned";
+}
+
+export interface LocalLifecycleEngine {
+  readonly createTask: (input: CreateLocalTaskInput) => Effect.Effect<LocalTaskResult, EngineError | WriteError>;
+  readonly setStatus: (input: SetLocalStatusInput) => Effect.Effect<LocalTaskResult, EngineError | WriteError>;
+  readonly appendProgress: (input: AppendProgressInput) => Effect.Effect<LocalProgressResult, EngineError | WriteError>;
+  readonly archiveTask: (input: TaskReasonInput) => Effect.Effect<LocalTaskResult, EngineError | WriteError>;
+  readonly supersedeTask: (input: SupersedeTaskInput) => Effect.Effect<LocalSupersedeResult, EngineError | WriteError>;
+  readonly deleteTask: (input: DeleteTaskInput) => Effect.Effect<LocalDeleteResult, EngineError | WriteError>;
+  readonly reopenTask: (input: TaskReasonInput) => Effect.Effect<LocalTaskResult, EngineError | WriteError>;
+}
+
+export interface LocalTaskIndex {
+  readonly taskId: TaskId;
+  readonly title: string;
+  readonly engine: string;
+  readonly status: DomainStatus;
+  readonly ref: string | null;
+  readonly titleSnapshot: string | null;
+  readonly url: string | null;
+  readonly bindingCreatedAt: string;
+  readonly bindingFingerprint: string;
+  readonly packageDisposition: "active" | "archived" | "tombstoned";
+  readonly vertical: string;
+  readonly preset: string;
+  readonly createdBy?: TaskCreatedBy;
+}

--- a/packages/cli/src/commands/full-cutover.ts
+++ b/packages/cli/src/commands/full-cutover.ts
@@ -18,6 +18,8 @@ export interface FullCutoverEvidence {
   readonly violations: ReadonlyArray<string>;
 }
 
+const minBehaviorCorpusItems = 15;
+
 export function evaluateFullCutoverEvidence(rootDir: string): FullCutoverEvidence {
   const violations: string[] = [];
   checkPackageDecision(rootDir, violations);
@@ -108,6 +110,9 @@ function checkBehaviorCorpus(rootDir: string, violations: string[]): FullCutover
     if (counts[category] !== expected) {
       violations.push(`${dataPath}: category ${category} count ${expected} does not match ${counts[category]} item(s)`);
     }
+  }
+  if (items.length < minBehaviorCorpusItems) {
+    violations.push(`${dataPath}: behavior corpus must include at least ${minBehaviorCorpusItems} classified items`);
   }
 
   return { dataPath, reportPath, needsDecision, itemCount: items.length };

--- a/packages/cli/test/migration-adopt-cli.test.ts
+++ b/packages/cli/test/migration-adopt-cli.test.ts
@@ -148,17 +148,18 @@ function writeCutoverReadySurface(rootDir: string): void {
     scope: "M2 final cutover",
     publishState: "not-published",
     categories: {
-      preserve: 0,
-      "intentional-change": 1,
-      "old-bug": 0,
-      "unsupported-input": 0,
+      preserve: 7,
+      "intentional-change": 5,
+      "old-bug": 1,
+      "unsupported-input": 2,
       "needs-decision": 0
     },
     items: [
-      {
-        classification: "intentional-change",
-        summary: "Package release remains not-published while cutover evidence is complete."
-      }
+      ...Array.from({ length: 7 }, (_, index) => ({ classification: "preserve", summary: `preserve ${index}` })),
+      ...Array.from({ length: 5 }, (_, index) => ({ classification: "intentional-change", summary: `intentional ${index}` })),
+      { classification: "old-bug", summary: "old compatibility promise" },
+      { classification: "unsupported-input", summary: "conflicting legacy tree" },
+      { classification: "unsupported-input", summary: "npm publishing deferred" }
     ]
   }), "utf8");
   writeFileSync(path.join(cutoverDir, "behavior-corpus-classification.md"), "# Behavior Corpus Classification\n", "utf8");

--- a/tools/check-cutover-readiness.mjs
+++ b/tools/check-cutover-readiness.mjs
@@ -31,6 +31,7 @@ const publicCompatibilityPatterns = [
   /\bautomatic migration\b/u,
   /\bauto-migration\b/u
 ];
+const minBehaviorCorpusItems = 15;
 
 export async function evaluateCutoverReadiness(root = process.cwd()) {
   const violations = [];
@@ -155,6 +156,9 @@ function checkBehaviorCorpusReport(root, violations) {
       if (actualCounts[category] !== expectedCount) {
         violations.push(`tools/cutover/behavior-corpus-classification.json: category ${category} count ${expectedCount} does not match ${actualCounts[category]} item(s)`);
       }
+    }
+    if (data.items.length < minBehaviorCorpusItems) {
+      violations.push(`tools/cutover/behavior-corpus-classification.json: behavior corpus must include at least ${minBehaviorCorpusItems} classified items`);
     }
   } else {
     violations.push("tools/cutover/behavior-corpus-classification.json: missing items array");

--- a/tools/check-cutover-readiness.test.mjs
+++ b/tools/check-cutover-readiness.test.mjs
@@ -153,6 +153,41 @@ test("cutover readiness requires behavior item counts to match categories", asyn
   });
 });
 
+test("cutover readiness requires a non-trivial behavior corpus", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.md"), [
+      "# Behavior Corpus Classification",
+      "",
+      "Machine-checkable source: `behavior-corpus-classification.json`.",
+      "",
+      "| Classification | Count | Notes |",
+      "| --- | ---: | --- |",
+      "| preserve | 1 | too small |",
+      "| intentional-change | 0 | none |",
+      "| old-bug | 0 | none |",
+      "| unsupported-input | 0 | none |",
+      "| needs-decision | 0 | none |",
+      ""
+    ].join("\n"));
+    writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.json"), JSON.stringify({
+      categories: {
+        preserve: 1,
+        "intentional-change": 0,
+        "old-bug": 0,
+        "unsupported-input": 0,
+        "needs-decision": 0
+      },
+      items: [
+        { classification: "preserve", summary: "too small" }
+      ]
+    }));
+
+    const violations = await evaluateCutoverReadiness(root);
+
+    assert.equal(violations.some((violation) => violation.includes("at least 15 classified items")), true);
+  });
+});
+
 test("cutover readiness requires Markdown counts to match JSON categories", async () => {
   await withFixtureRepo(async (root) => {
     writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.md"), [
@@ -212,33 +247,43 @@ async function withFixtureRepo(fn) {
       }
     }));
     writeFileSync(path.join(root, "README.md"), "# Harness Anything\n");
-    writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.md"), [
-      "# Behavior Corpus Classification",
-      "",
-      "Machine-checkable source: `behavior-corpus-classification.json`.",
-      "",
-      "| Classification | Count | Notes |",
-      "| --- | ---: | --- |",
-      "| preserve | 0 | none |",
-      "| intentional-change | 0 | none |",
-      "| old-bug | 0 | none |",
-      "| unsupported-input | 0 | none |",
-      "| needs-decision | 0 | none |",
-      ""
-    ].join("\n"));
-    writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.json"), JSON.stringify({
-      categories: {
-        preserve: 0,
-        "intentional-change": 0,
-        "old-bug": 0,
-        "unsupported-input": 0,
-        "needs-decision": 0
-      },
-      items: []
-    }));
+    writeValidBehaviorCorpus(root);
 
     await fn(root);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+}
+
+function writeValidBehaviorCorpus(root) {
+  writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.md"), [
+    "# Behavior Corpus Classification",
+    "",
+    "Machine-checkable source: `behavior-corpus-classification.json`.",
+    "",
+    "| Classification | Count | Notes |",
+    "| --- | ---: | --- |",
+    "| preserve | 7 | preserved behavior |",
+    "| intentional-change | 5 | intentional differences |",
+    "| old-bug | 1 | old bug |",
+    "| unsupported-input | 2 | unsupported inputs |",
+    "| needs-decision | 0 | none |",
+    ""
+  ].join("\n"));
+  writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.json"), JSON.stringify({
+    categories: {
+      preserve: 7,
+      "intentional-change": 5,
+      "old-bug": 1,
+      "unsupported-input": 2,
+      "needs-decision": 0
+    },
+    items: [
+      ...Array.from({ length: 7 }, (_, index) => ({ classification: "preserve", summary: `preserve ${index}` })),
+      ...Array.from({ length: 5 }, (_, index) => ({ classification: "intentional-change", summary: `intentional ${index}` })),
+      { classification: "old-bug", summary: "old compatibility promise" },
+      { classification: "unsupported-input", summary: "conflicting legacy tree" },
+      { classification: "unsupported-input", summary: "npm publishing deferred" }
+    ]
+  }));
 }

--- a/tools/cutover/behavior-corpus-classification.json
+++ b/tools/cutover/behavior-corpus-classification.json
@@ -2,11 +2,12 @@
   "schema": "harness-anything-behavior-corpus-classification/v1",
   "scope": "M2 final cutover",
   "publishState": "not-published",
+  "minimumItems": 15,
   "categories": {
-    "preserve": 0,
-    "intentional-change": 2,
-    "old-bug": 0,
-    "unsupported-input": 1,
+    "preserve": 7,
+    "intentional-change": 5,
+    "old-bug": 1,
+    "unsupported-input": 2,
     "needs-decision": 0
   },
   "evidence": [
@@ -21,6 +22,11 @@
       "result": "passed"
     },
     {
+      "id": "EV-FULL-CUTOVER-SMOKE",
+      "command": "npm run harness:smoke-full-cutover",
+      "result": "passed"
+    },
+    {
       "id": "EV-FULL-CUTOVER-VERIFY",
       "command": "harness migrate-verify <session.json> --full-cutover --json",
       "result": "passed"
@@ -28,16 +34,64 @@
   ],
   "items": [
     {
-      "classification": "intentional-change",
-      "summary": "Package identity uses harness-anything rather than old package names."
+      "classification": "preserve",
+      "summary": "Local task packages remain authored Markdown under harness/planning/tasks."
+    },
+    {
+      "classification": "preserve",
+      "summary": "Local lifecycle writes continue to go through the WriteCoordinator journal before authored files are mutated."
+    },
+    {
+      "classification": "preserve",
+      "summary": "Generated task IDs remain the default identity policy; manual IDs stay limited to controlled migration mode."
+    },
+    {
+      "classification": "preserve",
+      "summary": "Six-state lifecycle vocabulary remains planned, active, blocked, in_review, done, and cancelled."
+    },
+    {
+      "classification": "preserve",
+      "summary": "External engine bindings remain immutable local references rather than agent-owned external status writes."
+    },
+    {
+      "classification": "preserve",
+      "summary": "SQLite projection is rebuildable generated cache, not the source of task truth."
+    },
+    {
+      "classification": "preserve",
+      "summary": "createdBy remains optional audit metadata sourced from local Git user configuration when available."
     },
     {
       "classification": "intentional-change",
-      "summary": "Default CLI package artifact bin is harness-anything; external npm publish remains out of scope."
+      "summary": "Root package identity uses harness-anything rather than the previous repository-level product name."
+    },
+    {
+      "classification": "intentional-change",
+      "summary": "CLI package identity uses @harness-anything/cli and exposes the harness-anything binary."
+    },
+    {
+      "classification": "intentional-change",
+      "summary": "Package release remains private and not-published during M2 final cutover."
+    },
+    {
+      "classification": "intentional-change",
+      "summary": "The old scripts-refactor and SR implementation route is blocked from production source and public docs."
+    },
+    {
+      "classification": "intentional-change",
+      "summary": "Migration is explicit evidence through migrate-run and migrate-verify rather than automatic legacy compatibility."
+    },
+    {
+      "classification": "old-bug",
+      "summary": "Old broad public compatibility promises are rejected because they hid unsupported legacy behavior."
     },
     {
       "classification": "unsupported-input",
-      "summary": "Prior task files are handled through explicit migration evidence, not by preserving previous public interfaces."
+      "summary": "Malformed or conflicting legacy task trees require migration preflight failure rather than best-effort conversion."
+    },
+    {
+      "classification": "unsupported-input",
+      "summary": "npm registry scope reservation and public publishing are outside M2 and remain deferred release work."
     }
   ]
 }

--- a/tools/cutover/behavior-corpus-classification.md
+++ b/tools/cutover/behavior-corpus-classification.md
@@ -1,19 +1,48 @@
 # Behavior Corpus Classification
 
-M2 final cutover uses this report as a behavior corpus and negative evidence
-source. Migration intake is represented by explicit evidence files and
-`migrate-verify --full-cutover`, while the default package and CLI surface stay
-on the Harness-Anything implementation.
+M2 final cutover uses this report as the human-readable mirror of the
+machine-checkable behavior corpus. Migration intake is represented by explicit
+evidence files and `migrate-verify --full-cutover`; the public package and CLI
+surface stay on the Harness-Anything implementation.
 
 Machine-checkable source: `behavior-corpus-classification.json`.
 
 | Classification | Count | Notes |
 | --- | ---: | --- |
-| preserve | 0 | No old behavior has been selected for preservation in this cutover slice. |
-| intentional-change | 2 | Package name and workspace CLI bin use `harness-anything`; old package/API names are not preserved. |
-| old-bug | 0 | No old bug classification was needed for this cutover slice. |
-| unsupported-input | 1 | Prior task files require explicit migration evidence. |
+| preserve | 7 | Core task package, lifecycle, projection, external-binding, and attribution behavior is preserved. |
+| intentional-change | 5 | Package identity, CLI bin, private release state, old-runtime blocking, and explicit migration evidence are intentional changes. |
+| old-bug | 1 | Broad old-compatibility promises are treated as a bug because they hid unsupported behavior. |
+| unsupported-input | 2 | Conflicting legacy trees and npm registry publishing are outside M2 automatic cutover. |
 | needs-decision | 0 | No unclassified behavior differences remain. |
+
+## Classified Items
+
+### Preserve
+
+- Local task packages remain authored Markdown under `harness/planning/tasks`.
+- Local lifecycle writes continue to go through the `WriteCoordinator` journal before authored files are mutated.
+- Generated task IDs remain the default identity policy; manual IDs stay limited to controlled migration mode.
+- Six-state lifecycle vocabulary remains `planned`, `active`, `blocked`, `in_review`, `done`, and `cancelled`.
+- External engine bindings remain immutable local references rather than agent-owned external status writes.
+- SQLite projection is rebuildable generated cache, not the source of task truth.
+- `createdBy` remains optional audit metadata sourced from local Git user configuration when available.
+
+### Intentional Change
+
+- Root package identity uses `harness-anything` rather than the previous repository-level product name.
+- CLI package identity uses `@harness-anything/cli` and exposes the `harness-anything` binary.
+- Package release remains private and `not-published` during M2 final cutover.
+- The retired SR implementation route is blocked from production source and public docs.
+- Migration is explicit evidence through `migrate-run` and `migrate-verify` rather than automatic legacy compatibility.
+
+### Old Bug
+
+- Old broad public compatibility promises are rejected because they hid unsupported legacy behavior.
+
+### Unsupported Input
+
+- Malformed or conflicting legacy task trees require migration preflight failure rather than best-effort conversion.
+- npm registry scope reservation and public publishing are outside M2 and remain deferred release work.
 
 ## Cutover Evidence Notes
 
@@ -22,4 +51,5 @@ Machine-checkable source: `behavior-corpus-classification.json`.
 - The default CLI package artifact bin is `harness-anything`; external npm publish is intentionally out of scope.
 - Retired old runtime paths are blocked by `harness:check-cutover-readiness`.
 - Full cutover verification is active through `migrate-verify --full-cutover`.
+- Real repository full-cutover smoke is covered by `harness:smoke-full-cutover`.
 - Package artifact executability is verified by `harness:smoke-cli-package`, which builds, packs, installs into a temporary consumer, and runs `harness-anything --json gui` with GUI dry-run enabled.

--- a/tools/smoke-full-cutover.mjs
+++ b/tools/smoke-full-cutover.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const cli = path.join(root, "packages/cli/src/index.ts");
+const outDir = ".harness/generated/full-cutover-smoke";
+
+function runJson(args) {
+  const output = execFileSync(process.execPath, [cli, ...args, "--root", root, "--json"], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  return JSON.parse(output);
+}
+
+try {
+  rmSync(path.join(root, outDir), { recursive: true, force: true });
+  const run = runJson(["migrate-run", "--plan-only", "--out-dir", outDir]);
+  if (run.ok !== true || run.report?.schema !== "harness-migration-session/v1") {
+    throw new Error("migrate-run did not produce a migration session");
+  }
+
+  const verify = runJson(["migrate-verify", run.path, "--full-cutover"]);
+  if (verify.ok !== true || verify.report?.fullCutoverEvidence?.ok !== true) {
+    throw new Error("full-cutover verify did not accept real repository evidence");
+  }
+
+  const itemCount = verify.report.fullCutoverEvidence.behaviorCorpus.itemCount;
+  if (itemCount < 15) throw new Error(`behavior corpus too small: ${itemCount}`);
+
+  console.log(`Full cutover smoke passed with ${itemCount} behavior corpus items.`);
+} finally {
+  rmSync(path.join(root, outDir), { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- split the local adapter lifecycle implementation by responsibility instead of keeping the 543-line orchestration file
- expand the M2 behavior corpus to 15 classified items and enforce that minimum in cutover checks
- add a real repository `harness:smoke-full-cutover` gate and wire it into `npm run check`

## Verification
- npm run check
