### PR TITLE
[codex] Add bilingual open source README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,84 @@
-# Harness-Anything
+<div align="center">
 
-Harness-Anything is the clean-room rewrite workspace for the Harness kernel,
-CLI, GUI, and adapter packages.
+# Harness Anything
 
-This repository is a single Git monorepo. Packages under `packages/` are npm
-workspace packages, not nested Git repositories.
+**An agent task harness for long-horizon software work.**
 
-Private planning, architecture, and task state live in `.harness-private/`,
-which is intentionally ignored by the public repo.
+<p>
+  <a href="#how-it-works">How it works</a> ·
+  <a href="#quick-start">Quick start</a> ·
+  <a href="#packages">Packages</a> ·
+  <a href="#contributing">Contributing</a>
+</p>
 
-## Local CLI Quick Start
+<p>
+  <a href="./LICENSE"><img alt="License: AGPL-3.0-or-later" src="https://img.shields.io/badge/license-AGPL--3.0--or--later-blue"></a>
+  <a href="https://github.com/FairladyZ625/harness-anything/actions/workflows/rewrite-ci.yml"><img alt="CI" src="https://github.com/FairladyZ625/harness-anything/actions/workflows/rewrite-ci.yml/badge.svg"></a>
+  <a href="https://github.com/FairladyZ625/harness-anything/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/FairladyZ625/harness-anything?style=flat&logo=github&color=yellow"></a>
+  <a href="https://github.com/FairladyZ625/harness-anything/issues"><img alt="Issues" src="https://img.shields.io/github/issues/FairladyZ625/harness-anything"></a>
+  <img alt="Status: early" src="https://img.shields.io/badge/status-early%20%26%20unstable-orange">
+</p>
+
+<p>
+  <a href="./README.md"><img alt="README in English" src="https://img.shields.io/badge/English-d9d9d9"></a>
+  <a href="./README.zh-CN.md"><img alt="简体中文 README" src="https://img.shields.io/badge/简体中文-d9d9d9"></a>
+</p>
+
+</div>
+
+---
+
+Harness Anything gives coding agents a durable task layer: local task packages,
+governance checks, migration evidence, and a small kernel that adapters, CLIs,
+and GUIs can build on without owning lifecycle state.
+
+Agents are getting better at changing code. They still need a reliable way to
+carry work across long sessions, split tasks, preserve review evidence, and
+prove that local state has not drifted from the repository. Harness Anything
+treats that operating layer as a first-class, inspectable artifact.
+
+## How it works
+
+Harness Anything is organized around a small core and explicit extension
+layers.
+
+| Layer | What it does | Current status |
+| --- | --- | --- |
+| **Kernel** | Owns domain types, schemas, task projection, lifecycle validation, and storage ports. | Implemented in `@harness-anything/kernel`. |
+| **CLI** | Exposes local commands for init, doctor, status, checks, task operations, migration evidence, and Git diff evidence. | Implemented in `@harness-anything/cli`. |
+| **Application layer** | Keeps controller/service orchestration out of UI and adapter code. | Implemented in `@harness-anything/application`. |
+| **GUI foundation** | Provides the Electron desktop shell and view model boundary. | Early foundation in `@harness-anything/gui`. |
+| **Adapters** | Connect external systems without taking ownership of harness state. | Adapter package layout exists; external write adapters are not the M2 claim. |
+
+The product model is intentionally composable:
+
+- **Kernel first.** The kernel stays small and conservative.
+- **Verticals add domain shape.** A vertical defines the task domain, contracts,
+  and authored package conventions.
+- **Presets add workflow choices.** Presets can add or remove templates,
+  checks, and operating assumptions for a concrete use case.
+- **Adapters stay at the edge.** Adapters collect or publish evidence; they do
+  not become the source of truth for task lifecycle state.
+
+## What this is
+
+- A local-first task harness for coding-agent work.
+- A TypeScript monorepo with kernel, CLI, GUI, application, and adapter
+  packages.
+- A governance surface for checking task packages, file complexity, import
+  boundaries, private/public boundaries, schema contracts, and cutover
+  readiness.
+- A clean-room rewrite workspace for the public Harness product surface.
+
+## What this is not
+
+- Not an agent runtime, model router, or chat UI.
+- Not a replacement for Git, GitHub, or CI.
+- Not a cloud task database.
+- Not a published npm release yet. M2 deliberately keeps packages private and
+  versions at `0.0.0`.
+
+## Quick start
 
 Use Node.js 24 or newer.
 
@@ -19,7 +88,7 @@ npm run typecheck
 node packages/cli/src/index.ts --json doctor
 ```
 
-For a minimal project:
+For a minimal project loop:
 
 ```bash
 node packages/cli/src/index.ts --root /path/to/project --json init
@@ -28,17 +97,82 @@ node packages/cli/src/index.ts --root /path/to/project --json status
 node packages/cli/src/index.ts --root /path/to/project --json check --post-merge
 ```
 
-Public operating docs:
+Run the full repository check before public commits:
 
-- `docs-release/m1-minimal-loop.md`
-- `docs-release/m2-coding-vertical.md`
-- `docs-release/harness-agent-skill.md`
-- `examples/minimal-project/`
+```bash
+npm run check
+```
 
-M2 final-cutover evidence is complete for this repository workflow. Packages
-remain private, workspace versions remain `0.0.0`, and this repository does
-not claim a published npm package release.
+## Packages
+
+This repository is a single Git monorepo. Packages under `packages/` are npm
+workspace packages, not nested Git repositories.
+
+| Package | Purpose |
+| --- | --- |
+| `@harness-anything/kernel` | Domain model, schemas, lifecycle validation, task projection, storage ports. |
+| `@harness-anything/cli` | Local command surface for project, task, migration, evidence, and check workflows. |
+| `@harness-anything/application` | Shared controller/service layer used by CLI and GUI surfaces. |
+| `@harness-anything/gui` | Electron GUI foundation and renderer boundary. |
+| `@harness-anything/adapter-github-issues` | Adapter package slot for GitHub Issues integration work. |
+
+## Documentation
+
+- [M1 minimal loop](./docs-release/m1-minimal-loop.md)
+- [M2 coding vertical](./docs-release/m2-coding-vertical.md)
+- [Harness agent skill](./docs-release/harness-agent-skill.md)
+- [Minimal example project](./examples/minimal-project/)
+
+Private planning, architecture, review state, and task ledgers live outside the
+public docs tree in `.harness-private/`, which is intentionally ignored by this
+repository.
+
+## Project status
+
+M2 final-cutover evidence is complete for this repository workflow.
+
+Current release boundary:
+
+- Packages remain `private: true`.
+- Workspace versions remain `0.0.0`.
+- No npm package release is claimed.
+- The full local gate is `npm run check`.
+
+Expect breaking changes while the public package surface stabilizes.
+
+## Roadmap
+
+**M2 - coding vertical cutover**
+
+- [x] Kernel, CLI, package layout, governance checks, behavior corpus, and
+  final-cutover evidence.
+- [x] Local smoke coverage for the full cutover and private CLI package
+  artifact.
+- [ ] npm package publication.
+
+**Next**
+
+- [ ] Public package release plan and package boundary review.
+- [ ] GUI workflow hardening beyond the current foundation.
+- [ ] External adapter implementation after the kernel/CLI contract is stable.
+- [ ] More vertical and preset examples.
+
+## Contributing
+
+The most useful contributions right now are sharp bug reports, failing test
+cases, architecture questions, and small documentation fixes.
+
+Before opening a pull request:
+
+```bash
+npm run check
+```
+
+Please keep public changes out of private harness state. Do not add
+`.harness-private/`, root-local agent instructions, or private planning docs to
+public commits.
 
 ## License
 
-Harness-Anything is licensed under AGPL-3.0-or-later. See `LICENSE`.
+[AGPL-3.0-or-later](./LICENSE). Harness Anything keeps the task harness open,
+including when someone offers it as a service.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,156 @@
+<div align="center">
+
+# Harness Anything
+
+**面向长周期软件工作的 Agent 任务 Harness。**
+
+<p>
+  <a href="#工作方式">工作方式</a> ·
+  <a href="#快速开始">快速开始</a> ·
+  <a href="#包结构">包结构</a> ·
+  <a href="#贡献">贡献</a>
+</p>
+
+<p>
+  <a href="./LICENSE"><img alt="License: AGPL-3.0-or-later" src="https://img.shields.io/badge/license-AGPL--3.0--or--later-blue"></a>
+  <a href="https://github.com/FairladyZ625/harness-anything/actions/workflows/rewrite-ci.yml"><img alt="CI" src="https://github.com/FairladyZ625/harness-anything/actions/workflows/rewrite-ci.yml/badge.svg"></a>
+  <a href="https://github.com/FairladyZ625/harness-anything/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/FairladyZ625/harness-anything?style=flat&logo=github&color=yellow"></a>
+  <a href="https://github.com/FairladyZ625/harness-anything/issues"><img alt="Issues" src="https://img.shields.io/github/issues/FairladyZ625/harness-anything"></a>
+  <img alt="Status: early" src="https://img.shields.io/badge/status-early%20%26%20unstable-orange">
+</p>
+
+<p>
+  <a href="./README.md"><img alt="README in English" src="https://img.shields.io/badge/English-d9d9d9"></a>
+  <a href="./README.zh-CN.md"><img alt="简体中文 README" src="https://img.shields.io/badge/简体中文-d9d9d9"></a>
+</p>
+
+</div>
+
+---
+
+Harness Anything 为 coding agent 提供一层持久的任务结构：本地任务包、治理检查、迁移证据，以及一个足够小的 kernel。CLI、GUI 和 adapter 都可以构建在它之上，但不拥有生命周期状态。
+
+Agent 越来越擅长改代码，但它们仍然需要一种可靠方式来跨长会话承载工作、拆分任务、保留 review 证据，并证明本地状态没有偏离仓库。Harness Anything 把这层操作系统变成一等的、可检查的工程制品。
+
+## 工作方式
+
+Harness Anything 围绕一个小内核和明确的扩展层组织。
+
+| 层 | 作用 | 当前状态 |
+| --- | --- | --- |
+| **Kernel** | 拥有领域类型、schema、任务投影、生命周期校验和存储端口。 | 已在 `@harness-anything/kernel` 中实现。 |
+| **CLI** | 暴露 init、doctor、status、check、任务操作、迁移证据和 Git diff 证据等本地命令。 | 已在 `@harness-anything/cli` 中实现。 |
+| **Application layer** | 将 controller/service 编排从 UI 和 adapter 代码中隔离出来。 | 已在 `@harness-anything/application` 中实现。 |
+| **GUI foundation** | 提供 Electron 桌面壳和 view model 边界。 | `@harness-anything/gui` 中已有早期基础。 |
+| **Adapters** | 连接外部系统，但不接管 Harness 状态。 | Adapter 包结构已存在；外部写入 adapter 不属于 M2 声明范围。 |
+
+产品模型刻意保持可组合：
+
+- **Kernel first。** Kernel 保持小而保守。
+- **Verticals add domain shape。** Vertical 定义任务领域、契约和 authored package 约定。
+- **Presets add workflow choices。** Preset 可以为具体用例添加或删除模板、检查和操作假设。
+- **Adapters stay at the edge。** Adapter 收集或发布证据，但不成为任务生命周期状态的事实来源。
+
+## 这是什么
+
+- 一个 local-first 的 coding-agent 任务 harness。
+- 一个 TypeScript monorepo，包含 kernel、CLI、GUI、application 和 adapter 包。
+- 一套治理表面，用于检查任务包、文件复杂度、import 边界、private/public 边界、schema 契约和 cutover readiness。
+- 面向公开 Harness 产品表面的 clean-room rewrite workspace。
+
+## 这不是什么
+
+- 不是 agent runtime、model router 或 chat UI。
+- 不是 Git、GitHub 或 CI 的替代品。
+- 不是云端任务数据库。
+- 还不是已发布的 npm release。M2 阶段刻意保持 packages 为 `private: true`，版本为 `0.0.0`。
+
+## 快速开始
+
+使用 Node.js 24 或更高版本。
+
+```bash
+npm ci
+npm run typecheck
+node packages/cli/src/index.ts --json doctor
+```
+
+最小项目循环：
+
+```bash
+node packages/cli/src/index.ts --root /path/to/project --json init
+node packages/cli/src/index.ts --root /path/to/project --json new-task --title "First task"
+node packages/cli/src/index.ts --root /path/to/project --json status
+node packages/cli/src/index.ts --root /path/to/project --json check --post-merge
+```
+
+公开提交前运行完整仓库检查：
+
+```bash
+npm run check
+```
+
+## 包结构
+
+这个仓库是单一 Git monorepo。`packages/` 下的包是 npm workspace package，不是嵌套 Git 仓库。
+
+| Package | Purpose |
+| --- | --- |
+| `@harness-anything/kernel` | 领域模型、schema、生命周期校验、任务投影和存储端口。 |
+| `@harness-anything/cli` | 面向 project、task、migration、evidence 和 check 工作流的本地命令表面。 |
+| `@harness-anything/application` | CLI 和 GUI 共享的 controller/service 层。 |
+| `@harness-anything/gui` | Electron GUI 基础和 renderer 边界。 |
+| `@harness-anything/adapter-github-issues` | GitHub Issues 集成工作的 adapter 包位。 |
+
+## 文档
+
+- [M1 minimal loop](./docs-release/m1-minimal-loop.md)
+- [M2 coding vertical](./docs-release/m2-coding-vertical.md)
+- [Harness agent skill](./docs-release/harness-agent-skill.md)
+- [Minimal example project](./examples/minimal-project/)
+
+Private planning、architecture、review state 和 task ledger 位于 public docs tree 之外的 `.harness-private/` 中，并且会被本仓库刻意忽略。
+
+## 项目状态
+
+这个仓库工作流的 M2 final-cutover evidence 已完成。
+
+当前 release 边界：
+
+- Packages 仍保持 `private: true`。
+- Workspace versions 仍保持 `0.0.0`。
+- 不声明任何 npm package release。
+- 完整本地 gate 是 `npm run check`。
+
+在公开 package surface 稳定前，请预期 breaking changes。
+
+## Roadmap
+
+**M2 - coding vertical cutover**
+
+- [x] Kernel、CLI、package layout、governance checks、behavior corpus 和 final-cutover evidence。
+- [x] Full cutover 和 private CLI package artifact 的本地 smoke 覆盖。
+- [ ] npm package publication。
+
+**Next**
+
+- [ ] Public package release plan 和 package boundary review。
+- [ ] 在当前基础之上继续硬化 GUI workflow。
+- [ ] 在 kernel/CLI contract 稳定后实现外部 adapter。
+- [ ] 更多 vertical 和 preset 示例。
+
+## 贡献
+
+当前最有价值的贡献是尖锐的 bug report、可复现失败测试、架构问题和小型文档修正。
+
+提交 pull request 前：
+
+```bash
+npm run check
+```
+
+请不要把 private harness state 放入公开变更。不要把 `.harness-private/`、root-local agent instructions 或 private planning docs 加入 public commit。
+
+## License
+
+[AGPL-3.0-or-later](./LICENSE)。Harness Anything 保持任务 harness 开源，包括有人将它作为服务提供时。


### PR DESCRIPTION
## Summary
- Reworked the root README into a more complete open source repository entry point.
- Added language switch badges and a full Simplified Chinese README.
- Preserved the current M2 release boundary: packages remain private, versions remain 0.0.0, and no npm release is claimed.

## Validation
- npm run check
