### PR TITLE
[codex] mark M2 cutover evidence historical

### DIFF
--- a/docs-release/m2-coding-vertical.md
+++ b/docs-release/m2-coding-vertical.md
@@ -1,6 +1,6 @@
 # M2 Coding Vertical
 
-Status: M2 final-cutover evidence complete, package release deferred
+Status: M2 complete, package release deferred; final-cutover evidence is historical and deprecated for future strategy
 
 ## Install From This Repository
 
@@ -57,7 +57,7 @@ harness task archive <task-id> --reason "superseded" --json
 harness task supersede <task-id> --title "Replacement task" --reason "scope changed" --json
 ```
 
-## Migration And Evidence Commands
+## Legacy Intake And Evidence Commands
 
 Read-only or local-only evidence commands:
 
@@ -68,9 +68,13 @@ harness migrate-plan --json
 harness migrate-structure --plan --json
 harness migrate-run --plan-only --json
 harness migrate-verify <session.json> --json
-harness migrate-verify <session.json> --full-cutover --json
 harness git-diff --json
 ```
+
+M2 shipped migration evidence commands, but the project strategy changed after
+M2: future releases should treat old task packages as legacy evidence, not as
+input for automatic task-package conversion. Use Legacy Intake and rebuild
+unfinished work as new tasks with provenance.
 
 `createdBy` is optional task audit metadata sourced from local Git
 `user.name`/`user.email` when available. It is not task status, package
@@ -102,15 +106,13 @@ run the check again:
 harness check --post-merge --json
 ```
 
-## Final Cutover Evidence
+## Historical Final Cutover Evidence
 
-M2-P7 activates `migrate-verify --full-cutover` as the final repository gate.
-The gate verifies the migration session, package release decision, package
-surface, and behavior corpus report before returning success.
-The behavior corpus must contain at least 15 classified items and zero
-`needs-decision` entries.
+M2-P7 used `migrate-verify --full-cutover` as historical completion evidence.
+That strategy is now deprecated. Future work should not use full cutover as an
+exit gate or dogfood prerequisite.
 
-Local final-cutover checks:
+Historical M2 checks were:
 
 ```bash
 harness migrate-run --json
@@ -119,6 +121,8 @@ npm run harness:check-cutover-readiness
 npm run harness:smoke-full-cutover
 npm run check
 ```
+
+M2.5 will replace these with Legacy Intake readiness and smoke checks.
 
 Package release decision:
 


### PR DESCRIPTION
## Summary

Marks M2 full-cutover evidence as historical/deprecated in the public M2 Coding Vertical docs.

## What Changed

- Renamed the migration/evidence section to Legacy Intake and evidence wording.
- Removed `migrate-verify --full-cutover` from the active command list.
- Moved full-cutover commands into a historical evidence section.
- Clarified that M2.5 will replace those historical checks with Legacy Intake readiness and smoke checks.

## Task And Scope

- Harness task: `coding-agent-harness/planning/modules/m2-5-cli/tasks/2026-06-14-m2-5-cli-p01-strategy-docs-gate-retirement/`
- Branch: `codex/m2-5-cli-p01-strategy-docs-gate-retirement`
- Public scope: `docs-release/m2-coding-vertical.md`
- Private planning/evidence updated: yes
- Out of scope: Legacy Intake command implementation, completion gate, package script replacement, GUI/daemon work, M3 relation/tree work

## Version Impact

- Version: no version change because this is docs-only strategy wording.
- Publish impact: no publish.

## Verification

- Base `origin/main` SHA: `d79db4265fe83f2a43e98ec77110d6510c250ddb`
- Branch merge-base with `origin/main`: `d79db4265fe83f2a43e98ec77110d6510c250ddb`
- Last `git fetch origin` time: 2026-06-13T17:26:26Z
- Sync method: none needed
- Public diff command: `git diff -- docs-release/m2-coding-vertical.md`
- Private evidence commit/path: private task path listed above
- Reviewer evidence path: `review.md` in the private task path listed above
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-cutover-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` because `npm install` was used to initialize the fresh worktree before running full `npm run check`.

## Review Evidence

- Self-review: confirmed scoped diff is only `docs-release/m2-coding-vertical.md` and does not claim Legacy Intake/check replacement is implemented.
- Reviewer subagent: no open P0/P1/P2; P3 wording risk fixed by changing present tense to future tense.
- Human review: not yet requested for this PR.
- Blocking findings: none.

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [ ] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear: merge after green CI, then delete branch, remove worktree, sync local main, and update private progress.

## Residual Risk

- Current `npm run check` still runs historical cutover readiness and full-cutover smoke. This is expected for P01; M25CLI-P13 owns package script replacement.
- `npm install` reported existing high severity audit findings. P01 does not change dependencies.

## References

- Task: `coding-agent-harness/planning/modules/m2-5-cli/tasks/2026-06-14-m2-5-cli-p01-strategy-docs-gate-retirement/`
- Evidence: `progress.md` in the task path above
- Review: `review.md` in the task path above

---

## 摘要

将公开 M2 Coding Vertical 文档中的 M2 full-cutover 口径标为历史证据 / 未来策略废弃。

## 改动内容

- 将 migration/evidence 章节改为 Legacy Intake 相关口径。
- 从 active command list 移除 `migrate-verify --full-cutover`。
- 将 full-cutover 命令移动到 historical evidence 章节。
- 明确 M2.5 未来会用 Legacy Intake readiness/smoke 替代这些历史检查。

## 任务与范围

- Harness 任务：`coding-agent-harness/planning/modules/m2-5-cli/tasks/2026-06-14-m2-5-cli-p01-strategy-docs-gate-retirement/`
- 分支：`codex/m2-5-cli-p01-strategy-docs-gate-retirement`
- 公开范围：`docs-release/m2-coding-vertical.md`
- 私有计划 / 证据是否已更新：yes
- 范围外：Legacy Intake 命令实现、completion gate、package script replacement、GUI/daemon、M3 relation/tree

## 版本影响

- 版本：不改版本，原因是 docs-only strategy wording。
- 发布影响：不发布。

## 验证

- `origin/main` 基准 SHA：`d79db4265fe83f2a43e98ec77110d6510c250ddb`
- 当前分支与 `origin/main` 的 merge-base：`d79db4265fe83f2a43e98ec77110d6510c250ddb`
- 最近一次 `git fetch origin` 时间：2026-06-13T17:26:26Z
- 同步方式：不需要
- 公开 diff 命令：`git diff -- docs-release/m2-coding-vertical.md`
- 私有证据 commit/path：见上方 private task path
- Reviewer 证据路径：见上方 private task path 下的 `review.md`
- GitHub Actions `rewrite-ci` run URL：pending
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-cutover-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci`，因为 fresh worktree 中使用 `npm install` 安装依赖后已运行完整 `npm run check`。

## 审查证据

- 自查：确认公开 diff 只有 `docs-release/m2-coding-vertical.md`，且没有声称 Legacy Intake/check replacement 已实现。
- Reviewer subagent：无 open P0/P1/P2；P3 时态风险已修复。
- 人工审查：本 PR 尚未请求。
- 阻塞发现：无。

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [ ] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚：CI 绿后合并，删除分支，清理 worktree，同步本地 main，更新 private progress。

## 残余风险

- 当前 `npm run check` 仍运行 historical cutover readiness/full-cutover smoke；这是 P01 的预期状态，M25CLI-P13 负责替换 package scripts。
- `npm install` 报告现有 high severity audit findings；P01 不改依赖。

## 关联材料

- 任务：`coding-agent-harness/planning/modules/m2-5-cli/tasks/2026-06-14-m2-5-cli-p01-strategy-docs-gate-retirement/`
- 证据：上述任务路径下的 `progress.md`
- 审查：上述任务路径下的 `review.md`
