### PR TITLE
feat: gate terminal task completion

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { Effect } from "effect";
 import { makeLocalLifecycleEngine } from "../../adapters/local/src/index.ts";
 import type { DomainStatus } from "../../kernel/src/index.ts";
-import { isDomainStatus, readTaskProjection } from "../../kernel/src/index.ts";
+import { isDomainStatus, isTerminalStatus, readTaskProjection } from "../../kernel/src/index.ts";
 import { taskDocumentPath as harnessTaskDocumentPath, validateTaskIdSyntax } from "../../kernel/src/layout/index.ts";
 export {
   evaluateCompletionGate,
@@ -107,6 +107,17 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
     setTaskStatus: async (payload) => {
       const parsed = readSetStatusPayload(payload);
       if (!parsed.ok) return parsed;
+      if (isTerminalStatus(parsed.status)) {
+        return {
+          ok: false,
+          error: {
+            code: "terminal_status_requires_task_complete",
+            hint: parsed.status === "done"
+              ? "Use task-complete after review, CI, and closeout gates pass."
+              : "Terminal cancellation requires an audited recovery path."
+          }
+        };
+      }
       return Effect.runPromise(engine.setStatus({ taskId: parsed.taskId, status: parsed.status }).pipe(
         Effect.match({
           onFailure: (error) => ({ ok: false, error: { code: error._tag, hint: "Status update failed." } }),

--- a/packages/application/test/local-controller-service.test.ts
+++ b/packages/application/test/local-controller-service.test.ts
@@ -24,6 +24,21 @@ test("local controller service reads projection and writes through local lifecyc
     assert.match(document.body ?? "", /Task One/);
 
     assert.deepEqual(await service.setTaskStatus({ taskId: "task-1", status: "active" }), { ok: true });
+    assert.deepEqual(await service.setTaskStatus({ taskId: "task-1", status: "done" }), {
+      ok: false,
+      error: {
+        code: "terminal_status_requires_task_complete",
+        hint: "Use task-complete after review, CI, and closeout gates pass."
+      }
+    });
+    assert.deepEqual(await service.setTaskStatus({ taskId: "task-1", status: "cancelled" }), {
+      ok: false,
+      error: {
+        code: "terminal_status_requires_task_complete",
+        hint: "Terminal cancellation requires an audited recovery path."
+      }
+    });
+    assert.match(readFileSync(path.join(rootDir, "harness/planning/tasks/task-1/INDEX.md"), "utf8"), /status: active/);
     assert.deepEqual(await service.appendTaskProgress({ taskId: "task-1", text: "GUI update" }), { ok: true });
     assert.match(readFileSync(path.join(rootDir, "harness/planning/tasks/task-1/progress.md"), "utf8"), /GUI update/);
   } finally {

--- a/packages/cli/src/cli/command-registry.ts
+++ b/packages/cli/src/cli/command-registry.ts
@@ -3,7 +3,7 @@ import type { CommandRegistryEntry } from "./types.ts";
 export const commandRegistry = [
   { kind: "init", primary: "harness init", resultEnvelope: "CliResult/v1" },
   { kind: "new-task", primary: "harness new-task --title <title> [--json]", resultEnvelope: "CliResult/v1" },
-  { kind: "status-set", primary: "harness task status set <id> <status>", resultEnvelope: "CliResult/v1" },
+  { kind: "status-set", primary: "harness task status set <id> <status> [--force --reason <reason>]", resultEnvelope: "CliResult/v1" },
   { kind: "progress-append", primary: "harness task progress append <id> --text <text>", resultEnvelope: "CliResult/v1" },
   { kind: "task-archive", primary: "harness task archive <id> --reason <reason>", resultEnvelope: "CliResult/v1" },
   { kind: "task-supersede", primary: "harness task supersede <old-id> --title <title> [--slug <slug>]", resultEnvelope: "CliResult/v1" },

--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -59,6 +59,11 @@ export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; rea
     if (!isDomainStatus(args[4])) {
       return { ok: false, error: { code: "invalid_status", hint: `Unknown status: ${args[4]}` } };
     }
+    const force = args.includes("--force");
+    const reason = readOption(args, "--reason");
+    if (force && !reason) {
+      return { ok: false, error: { code: "missing_force_reason", hint: "Forced terminal status changes require --reason for audit evidence." } };
+    }
     return {
       ok: true,
       value: {
@@ -67,7 +72,9 @@ export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; rea
         action: {
           kind: "status-set",
           taskId: args[3],
-          status: args[4]
+          status: args[4],
+          force,
+          reason
         }
       }
     };

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -32,6 +32,11 @@ export interface CliResult {
   readonly generated?: ReadonlyArray<string>;
   readonly reviewContract?: unknown;
   readonly completionGate?: unknown;
+  readonly forced?: boolean;
+  readonly forceAudit?: {
+    readonly path: string;
+    readonly marker: string;
+  };
   readonly summary?: {
     readonly taskCount: number;
     readonly byPackageDisposition: Record<string, number>;
@@ -65,7 +70,7 @@ export interface ParsedCommand {
   readonly action:
     | { readonly kind: "init" }
     | { readonly kind: "new-task"; readonly taskId?: string; readonly title: string; readonly slug: string; readonly allowManualId: boolean }
-    | { readonly kind: "status-set"; readonly taskId: string; readonly status: DomainStatus }
+    | { readonly kind: "status-set"; readonly taskId: string; readonly status: DomainStatus; readonly force: boolean; readonly reason?: string }
     | { readonly kind: "progress-append"; readonly taskId: string; readonly text: string }
     | { readonly kind: "task-archive"; readonly taskId: string; readonly reason: string }
     | { readonly kind: "task-supersede"; readonly oldTaskId: string; readonly title: string; readonly slug: string; readonly reason: string }

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -7,6 +7,8 @@ import { commandRegistry } from "../cli/command-registry.ts";
 import { relativePath } from "../cli/path.ts";
 import type { CheckProfile, CliResult } from "../cli/types.ts";
 
+const FORCE_STATUS_AUDIT_MARKER = "FORCE_STATUS_SET_AUDIT";
+
 interface ProfileValidationIssue {
   readonly code: string;
   readonly source: string;
@@ -100,6 +102,17 @@ function validateTaskPackageContracts(rootDir: string, taskDir: string, profile:
     if (hasTemplatePlaceholder(taskPlanBody)) {
       issues.push(profileIssue("task-plan-contract", "task_plan_placeholder", "hard-fail", `${relativeTaskDir}/task_plan.md still contains template placeholders.`, "Replace scaffold placeholders before treating the task package as implementation-ready."));
     }
+  }
+
+  const progressPath = path.join(taskDir, "progress.md");
+  if (existsSync(progressPath) && readFileSync(progressPath, "utf8").includes(FORCE_STATUS_AUDIT_MARKER)) {
+    issues.push(profileIssue(
+      "completion-policy",
+      "forced_terminal_status_set",
+      "warning",
+      `${relativeTaskDir}/progress.md contains forced terminal status audit evidence.`,
+      "Review FORCE_STATUS_SET_AUDIT before treating this terminal state as normal completion."
+    ));
   }
 
   const reviewPath = path.join(taskDir, "review.md");

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -3,8 +3,9 @@ import path from "node:path";
 import { Effect } from "effect";
 import { makeLocalLifecycleEngine } from "../../../adapters/local/src/index.ts";
 import { evaluateCompletionGate, evaluateReviewGate, parseReviewMarkdown } from "../../../application/src/index.ts";
-import type { ArtifactStoreError, EngineError, WriteError } from "../../../kernel/src/domain/index.ts";
-import { createTaskPackagePath, generateTaskId, resolveHarnessLayout, taskDocumentPath } from "../../../kernel/src/layout/index.ts";
+import type { ArtifactStoreError, DomainStatus, EngineError, WriteError } from "../../../kernel/src/domain/index.ts";
+import { isDomainStatus, isTerminalStatus } from "../../../kernel/src/domain/index.ts";
+import { createTaskPackagePath, generateTaskId, readFrontmatter, readScalar, resolveHarnessLayout, taskDocumentPath } from "../../../kernel/src/layout/index.ts";
 import { checkTaskProjection, readTaskProjection } from "../../../kernel/src/index.ts";
 import { commandRegistry } from "../cli/command-registry.ts";
 import { runCheckProfile } from "./check.ts";
@@ -15,6 +16,8 @@ import { runDoctor } from "./doctor.ts";
 import { runGitDiffEvidence } from "./git-diff.ts";
 import { runMigratePlan, runMigrateRun, runMigrateStructure, runMigrateVerify } from "./migration.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
+
+export const FORCE_STATUS_AUDIT_MARKER = "FORCE_STATUS_SET_AUDIT";
 
 export function runCommand(
   engine: ReturnType<typeof makeLocalLifecycleEngine>,
@@ -43,15 +46,8 @@ export function runCommand(
   }
 
   if (command.action.kind === "status-set") {
-    return engine.setStatus({
-      taskId: command.action.taskId,
-      status: command.action.status
-    }).pipe(Effect.map((result): CliResult => ({
-      ok: true,
-      command: "status-set",
-      taskId: result.taskId,
-      status: result.status
-    })));
+    const action = command.action;
+    return runStatusSet(engine, command.rootDir, action.taskId, action.status, action.force, action.reason);
   }
 
   if (command.action.kind === "progress-append") {
@@ -215,12 +211,120 @@ export function runCommand(
 
   if (command.action.kind === "task-complete") {
     const action = command.action;
-    return Effect.sync(() => runTaskComplete(command.rootDir, action.taskId, action.reviewerId, action.ciGate));
+    return Effect.gen(function* () {
+      const gate = runTaskComplete(command.rootDir, action.taskId, action.reviewerId, action.ciGate);
+      if (!gate.ok) return gate;
+      const result = yield* engine.setStatus({ taskId: action.taskId, status: "done" });
+      return {
+        ...gate,
+        status: result.status
+      } satisfies CliResult;
+    });
   }
 
   return Effect.sync(() => runCheckProfile(command.rootDir, command.action.kind === "check"
     ? command.action
     : { kind: "check", profile: "source-package", strict: false, postMerge: false }));
+}
+
+function runStatusSet(
+  engine: ReturnType<typeof makeLocalLifecycleEngine>,
+  rootDir: string,
+  taskId: string,
+  status: DomainStatus,
+  force: boolean,
+  reason?: string
+): Effect.Effect<CliResult, EngineError | WriteError> {
+  if (!isTerminalStatus(status)) {
+    return engine.setStatus({ taskId, status }).pipe(Effect.map((result): CliResult => ({
+      ok: true,
+      command: "status-set",
+      taskId: result.taskId,
+      status: result.status
+    })));
+  }
+
+  const taskPolicy = readTaskStatusPolicy(rootDir, taskId);
+  if (taskPolicy?.engine === "local") {
+    if (!force) {
+      return Effect.sync(() => ({
+        ok: false,
+        command: "status-set",
+        taskId,
+        status,
+        error: {
+          code: "terminal_status_requires_task_complete",
+          hint: status === "done"
+            ? "Use task-complete after review, CI, and closeout gates pass. Use --force --reason only for recovery."
+            : "Terminal cancellation must be audited. Use --force --reason only for recovery."
+        }
+      } satisfies CliResult));
+    }
+
+    if (taskPolicy.status && !canStructurallyTransition(taskPolicy.status, status)) {
+      return Effect.sync(() => ({
+        ok: false,
+        command: "status-set",
+        taskId,
+        status,
+        error: {
+          code: "invalid_transition",
+          hint: `invalid transition: ${taskPolicy.status} -> ${status}`
+        }
+      } satisfies CliResult));
+    }
+
+    const auditText = renderForceStatusAudit(status, reason ?? "unspecified");
+    return Effect.gen(function* () {
+      const audit = yield* engine.appendProgress({ taskId, text: auditText });
+      const result = yield* engine.setStatus({ taskId, status });
+      return {
+        ok: true,
+        command: "status-set",
+        taskId: result.taskId,
+        status: result.status,
+        path: audit.path,
+        forced: true,
+        forceAudit: {
+          path: audit.path,
+          marker: FORCE_STATUS_AUDIT_MARKER
+        }
+      } satisfies CliResult;
+    });
+  }
+
+  return engine.setStatus({ taskId, status }).pipe(Effect.map((result): CliResult => ({
+    ok: true,
+    command: "status-set",
+    taskId: result.taskId,
+    status: result.status
+  })));
+}
+
+function readTaskStatusPolicy(rootDir: string, taskId: string): { readonly engine: string; readonly status: DomainStatus | null } | null {
+  const indexPath = taskDocumentPath(rootDir, taskId, "INDEX.md");
+  if (!existsSync(indexPath)) return null;
+  const frontmatter = readFrontmatter(readFileSync(indexPath, "utf8"));
+  if (!frontmatter) return null;
+  const status = readScalar(frontmatter, "  status");
+  return {
+    engine: readScalar(frontmatter, "  engine") || "",
+    status: isDomainStatus(status) ? status : null
+  };
+}
+
+function renderForceStatusAudit(status: string, reason: string): string {
+  return `${FORCE_STATUS_AUDIT_MARKER}: forced terminal status=${status}; reason=${reason}; recordedAt=${new Date().toISOString()}`;
+}
+
+function canStructurallyTransition(from: DomainStatus, to: DomainStatus): boolean {
+  if (from === to) return true;
+  if (isTerminalStatus(from)) return false;
+  if (from === "planned") return to === "active" || to === "blocked" || to === "cancelled";
+  if (from === "active") return to === "blocked" || to === "in_review" || to === "done" || to === "cancelled";
+  if (from === "blocked") return to === "active" || to === "cancelled";
+  if (from === "in_review") return to === "active" || to === "blocked" || to === "done" || to === "cancelled";
+  return false;
 }
 
 function initializeHarness(rootDir: string): CliResult {

--- a/packages/cli/test/local-lifecycle-cli.test.ts
+++ b/packages/cli/test/local-lifecycle-cli.test.ts
@@ -75,10 +75,47 @@ test("CLI rejects invalid local lifecycle transitions with a stable error code",
   withTempRoot((rootDir) => {
     const created = runJson(rootDir, ["new-task", "--title", "Task One"]);
     const taskId = assertGeneratedTaskId(created.taskId);
-    const failure = runJson(rootDir, ["task", "status", "set", taskId, "done"], false);
+    const failure = runJson(rootDir, ["task", "status", "set", taskId, "in_review"], false);
 
     assert.equal(failure.ok, false);
     assert.equal(failure.error?.code, "invalid_transition");
+  });
+});
+
+test("CLI blocks ordinary terminal status-set and requires audited force for recovery", () => {
+  withTempRoot((rootDir) => {
+    const created = runJson(rootDir, ["new-task", "--title", "Task One"]);
+    const taskId = assertGeneratedTaskId(created.taskId);
+
+    const invalidForce = runJson(rootDir, ["task", "status", "set", taskId, "done", "--force", "--reason", "invalid recovery"], false);
+    assert.equal(invalidForce.ok, false);
+    assert.equal(invalidForce.error?.code, "invalid_transition");
+    assert.equal(existsSync(path.join(rootDir, `harness/planning/tasks/${taskId}-task-one/progress.md`)), false);
+
+    runJson(rootDir, ["task", "status", "set", taskId, "active"]);
+
+    const doneFailure = runJson(rootDir, ["task", "status", "set", taskId, "done"], false);
+    assert.equal(doneFailure.ok, false);
+    assert.equal(doneFailure.error?.code, "terminal_status_requires_task_complete");
+
+    const cancelFailure = runJson(rootDir, ["task", "status", "set", taskId, "cancelled"], false);
+    assert.equal(cancelFailure.ok, false);
+    assert.equal(cancelFailure.error?.code, "terminal_status_requires_task_complete");
+
+    const missingReason = runJson(rootDir, ["task", "status", "set", taskId, "done", "--force"], false);
+    assert.equal(missingReason.ok, false);
+    assert.equal(missingReason.error?.code, "missing_force_reason");
+
+    const forced = runJson(rootDir, ["task", "status", "set", taskId, "done", "--force", "--reason", "fixture recovery"]);
+    assert.equal(forced.ok, true);
+    assert.equal(forced.status, "done");
+    assert.equal(forced.forced, true);
+    assert.equal(forced.forceAudit.marker, "FORCE_STATUS_SET_AUDIT");
+    const progressBody = readFileSync(path.join(rootDir, `harness/planning/tasks/${taskId}-task-one/progress.md`), "utf8");
+    assert.match(progressBody, /FORCE_STATUS_SET_AUDIT: forced terminal status=done; reason=fixture recovery/);
+
+    const check = runJson(rootDir, ["check", "--profile", "target-project"], false);
+    assert.equal(check.warnings.some((warning: Record<string, unknown>) => warning.code === "forced_terminal_status_set" && warning.severity === "warning"), true);
   });
 });
 
@@ -199,7 +236,7 @@ test("CLI task delete soft tombstones and hard delete rejects archived terminal 
     const terminal = runJson(rootDir, ["new-task", "--title", "Done Delete"]);
     const terminalTaskId = assertGeneratedTaskId(terminal.taskId);
     runJson(rootDir, ["task", "status", "set", terminalTaskId, "active"]);
-    runJson(rootDir, ["task", "status", "set", terminalTaskId, "done"]);
+    runJson(rootDir, ["task", "status", "set", terminalTaskId, "done", "--force", "--reason", "terminal fixture"]);
     const terminalFailure = runJson(rootDir, ["task", "delete", "--hard", terminalTaskId, "--reason", "remove"], false);
     assert.equal(terminalFailure.ok, false);
     assert.equal(terminalFailure.error?.code, "terminal_hard_delete_forbidden");
@@ -237,7 +274,7 @@ test("CLI task reopen restores only non-terminal package disposition", () => {
     assert.match(readFileSync(path.join(rootDir, `harness/planning/tasks/${taskId}-reopenable/INDEX.md`), "utf8"), /packageDisposition: active/);
 
     runJson(rootDir, ["task", "status", "set", taskId, "active"]);
-    runJson(rootDir, ["task", "status", "set", taskId, "done"]);
+    runJson(rootDir, ["task", "status", "set", taskId, "done", "--force", "--reason", "terminal fixture"]);
     const failure = runJson(rootDir, ["task", "reopen", taskId, "--reason", "more work"], false);
     assert.equal(failure.ok, false);
     assert.equal(failure.error?.code, "terminal_reopen_requires_supersede");
@@ -477,7 +514,7 @@ test("CLI task-review fails closed on open release-blocking findings and emits p
   });
 });
 
-test("CLI task-complete evaluates review, CI, and closeout readiness without mutating lifecycle axes", () => {
+test("CLI task-complete evaluates review, CI, and closeout readiness before setting status done", () => {
   withTempRoot((rootDir) => {
     writeIndex(rootDir, "task-1", "Complete Task", "in_review");
     writeReview(rootDir, "task-1", []);
@@ -490,6 +527,8 @@ test("CLI task-complete evaluates review, CI, and closeout readiness without mut
       packageDisposition: "active",
       closeoutReadiness: "ready"
     });
+    assert.equal(passed.status, "done");
+    assert.match(readFileSync(path.join(rootDir, "harness/planning/tasks/task-1/INDEX.md"), "utf8"), /status: done/);
 
     const failed = runJson(rootDir, ["task-complete", "task-1", "--ci", "failed"], false);
     assert.equal(failed.ok, false);


### PR DESCRIPTION
## Summary

- Block ordinary local `task status set <id> done|cancelled` and route completion through `task-complete`.
- Add audited `--force --reason` recovery for terminal status updates and surface `forced_terminal_status_set` in check profiles.
- Prevent application/GUI service calls from bypassing the terminal completion gate.

## Verification

- `node --test packages/cli/test/local-lifecycle-cli.test.ts`
- `node --test packages/application/test/local-controller-service.test.ts`
- `npm run check`

## Review

Reviewer subagent Heisenberg (`019ec212-c050-7b83-98b4-7611ac2f51fb`) found one P1 and one P2. Both were fixed and re-reviewed. Final reviewer verdict: no open P0/P1/P2.

## Harness Task

M25CLI-P02 completion command gate.
