### PR TITLE
feat: apply legacy collision suffixes

### DIFF
--- a/packages/cli/src/commands/migration-collision.ts
+++ b/packages/cli/src/commands/migration-collision.ts
@@ -1,0 +1,127 @@
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { Schema } from "effect";
+import { resolveHarnessLayout } from "../../../kernel/src/layout/index.ts";
+import { LegacyCollisionReportSchema, type LegacyCollisionReport, type LegacyIndexEntry } from "../../../kernel/src/schemas/registry.ts";
+
+export interface LegacyCopyTarget {
+  readonly entry: LegacyIndexEntry;
+  readonly sourcePath: string;
+  readonly chosenPath: string;
+}
+
+export interface LegacyCopyPlan {
+  readonly targets: ReadonlyArray<LegacyCopyTarget>;
+  readonly collisionReport: LegacyCollisionReport;
+}
+
+interface OccupiedTarget {
+  readonly path: string;
+  readonly kind: "file" | "directory";
+}
+
+export function buildLegacyCopyPlan(rootDir: string, sourceRoot: string, entries: ReadonlyArray<LegacyIndexEntry>): LegacyCopyPlan {
+  const occupied: OccupiedTarget[] = [];
+  const collisionEntries: Array<LegacyCollisionReport["entries"][number]> = [];
+  const targets = [...entries].sort(compareDeepestTargetFirst).map((entry) => {
+    const sourcePath = path.resolve(rootDir, sourceRoot, entry.sourcePath);
+    const kind = statSync(sourcePath).isDirectory() ? "directory" as const : "file" as const;
+    const resolved = resolveTarget(rootDir, entry.storedPath, kind, occupied);
+    occupied.push({ path: resolved.chosenPath, kind });
+    if (resolved.suffixIndex !== null) {
+      collisionEntries.push({
+        kind,
+        sourcePath: entry.sourcePath,
+        targetPath: entry.storedPath,
+        chosenPath: resolved.chosenPath,
+        suffixIndex: resolved.suffixIndex,
+        reason: "target-exists"
+      });
+    }
+    return { entry, sourcePath, chosenPath: resolved.chosenPath };
+  });
+  return {
+    targets,
+    collisionReport: validateCollisionReport({
+      schema: "legacy-collision-report/v1",
+      legacyRoot: "harness/legacy",
+      generatedAt: new Date(0).toISOString(),
+      policy: {
+        overwriteAllowed: false,
+        directorySuffixPattern: "-legacy-import-N",
+        fileSuffixPattern: ".legacy-import-N"
+      },
+      entries: collisionEntries
+    })
+  };
+}
+
+export function writeCollisionReport(rootDir: string, report: LegacyCollisionReport): void {
+  const layout = resolveHarnessLayout(rootDir);
+  const validated = validateCollisionReport(report);
+  mkdirSync(path.dirname(layout.legacyCollisionReportPath), { recursive: true });
+  writeFileSync(layout.legacyCollisionReportPath, `${JSON.stringify(validated, null, 2)}\n`, "utf8");
+}
+
+export function readCollisionReport(rootDir: string): LegacyCollisionReport | null {
+  const layout = resolveHarnessLayout(rootDir);
+  if (!existsSync(layout.legacyCollisionReportPath)) return null;
+  return validateCollisionReport(JSON.parse(readFileSync(layout.legacyCollisionReportPath, "utf8")));
+}
+
+export function applyCollisionReport(entries: ReadonlyArray<LegacyIndexEntry>, report: LegacyCollisionReport | null): ReadonlyArray<LegacyIndexEntry> {
+  if (!report) return entries;
+  const chosenByTarget = new Map(report.entries.map((entry) => [`${entry.sourcePath}\0${entry.targetPath}`, entry.chosenPath]));
+  return entries.map((entry) => {
+    const chosenPath = chosenByTarget.get(`${entry.sourcePath}\0${entry.storedPath}`);
+    return chosenPath ? { ...entry, storedPath: chosenPath } : entry;
+  });
+}
+
+function validateCollisionReport(report: unknown): LegacyCollisionReport {
+  return Schema.decodeUnknownSync(LegacyCollisionReportSchema)(report);
+}
+
+function resolveTarget(rootDir: string, targetPath: string, kind: "file" | "directory", occupied: ReadonlyArray<OccupiedTarget>): { readonly chosenPath: string; readonly suffixIndex: number | null } {
+  if (!targetUnavailable(rootDir, targetPath, occupied)) return { chosenPath: targetPath, suffixIndex: null };
+  for (let suffixIndex = 1; suffixIndex < 10000; suffixIndex += 1) {
+    const candidate = kind === "directory" ? directoryCollisionPath(targetPath, suffixIndex) : fileCollisionPath(targetPath, suffixIndex);
+    if (!targetUnavailable(rootDir, candidate, occupied)) return { chosenPath: candidate, suffixIndex };
+  }
+  throw new Error(`unable to choose legacy collision target for ${targetPath}`);
+}
+
+function targetUnavailable(rootDir: string, targetPath: string, occupied: ReadonlyArray<OccupiedTarget>): boolean {
+  return existsSync(path.join(rootDir, targetPath)) || occupied.some((entry) => targetsOverlap(entry, targetPath));
+}
+
+function targetsOverlap(entry: OccupiedTarget, targetPath: string): boolean {
+  if (entry.path === targetPath) return true;
+  if (entry.kind === "directory" && isDescendant(targetPath, entry.path)) return true;
+  return isDescendant(entry.path, targetPath);
+}
+
+function isDescendant(candidate: string, ancestor: string): boolean {
+  return candidate.startsWith(`${ancestor}/`);
+}
+
+function compareDeepestTargetFirst(left: LegacyIndexEntry, right: LegacyIndexEntry): number {
+  return pathDepth(right.storedPath) - pathDepth(left.storedPath) || left.storedPath.localeCompare(right.storedPath);
+}
+
+function pathDepth(value: string): number {
+  return value.split("/").length;
+}
+
+function directoryCollisionPath(targetPath: string, suffixIndex: number): string {
+  return `${targetPath}-legacy-import-${suffixIndex}`;
+}
+
+function fileCollisionPath(targetPath: string, suffixIndex: number): string {
+  const directory = path.posix.dirname(targetPath);
+  const basename = path.posix.basename(targetPath);
+  const extension = path.posix.extname(basename);
+  const stem = extension ? basename.slice(0, -extension.length) : basename;
+  const suffixed = `${stem}.legacy-import-${suffixIndex}${extension}`;
+  return directory === "." ? suffixed : `${directory}/${suffixed}`;
+}

--- a/packages/cli/src/commands/migration.ts
+++ b/packages/cli/src/commands/migration.ts
@@ -5,6 +5,7 @@ import { Schema } from "effect";
 import { resolveHarnessLayout } from "../../../kernel/src/layout/index.ts";
 import { LegacyIndexSchema, type LegacyIndex, type LegacyIndexEntry } from "../../../kernel/src/schemas/registry.ts";
 import type { CliResult } from "../cli/types.ts";
+import { applyCollisionReport, buildLegacyCopyPlan, readCollisionReport, writeCollisionReport } from "./migration-collision.ts";
 import type { LegacyCopySafeDocsAction, LegacyIndexAction, LegacyIntakePlanAction, LegacyScanAction, LegacyVerifyAction, MigratePlanAction, MigrateRunAction, MigrateStructureAction, MigrateVerifyAction } from "./migration-types.ts";
 
 interface LegacyScanReport {
@@ -190,6 +191,17 @@ export function runLegacyVerify(rootDir: string, _action: LegacyVerifyAction): C
       error: { code: "legacy_index_invalid", hint: "harness/legacy/index.json does not match the runtime LegacyIndexSchema." }
     };
   }
+  let collisionReport: ReturnType<typeof readCollisionReport>;
+  try {
+    collisionReport = readCollisionReport(rootDir);
+  } catch {
+    return {
+      ok: false,
+      command: "legacy-verify",
+      report: { schema: "legacy-intake-verify-report/v1", ok: false, invalidCollisionReport: true },
+      error: { code: "legacy_collision_report_invalid", hint: "harness/legacy/collision-report.json does not match the runtime LegacyCollisionReportSchema." }
+    };
+  }
   const missingTargets = index.entries
     .map((entry) => entry.storedPath)
     .filter((storedPath) => !existsSync(path.join(rootDir, storedPath)));
@@ -204,7 +216,11 @@ export function runLegacyVerify(rootDir: string, _action: LegacyVerifyAction): C
       missingIndex: false,
       invalidIndex: false,
       missingTargets,
-      summary: index.summary
+      summary: index.summary,
+      collisionReport: collisionReport ? {
+        entryCount: collisionReport.entries.length,
+        overwriteAllowed: collisionReport.policy.overwriteAllowed
+      } : undefined
     },
     error: ok ? undefined : { code: "legacy_index_targets_missing", hint: "Legacy index references stored paths that do not exist." }
   };
@@ -310,36 +326,29 @@ function applyLegacyCopy(rootDir: string, report: LegacyScanReport): CliResult {
       }
     };
   }
-  const collisions = report.entries.filter((entry) => existsSync(path.join(rootDir, entry.storedPath)));
-  if (collisions.length > 0) {
-    return {
-      ok: false,
-      command: "legacy-copy-safe-docs",
-      migrationMode: "apply",
-      report: { ...report, collisions: collisions.map((entry) => ({ sourcePath: entry.sourcePath, targetPath: entry.storedPath })) },
-      error: {
-        code: "legacy_collision_requires_p05",
-        hint: "Legacy copy would collide with existing targets. P05 owns fixed suffix collision application; no overwrite was performed."
-      }
-    };
-  }
-  for (const entry of report.entries) {
-    const source = path.resolve(rootDir, report.sourceRoot, entry.sourcePath);
-    const target = path.join(rootDir, entry.storedPath);
-    copySource(source, target);
+  const copyPlan = buildLegacyCopyPlan(rootDir, report.sourceRoot, report.entries);
+  writeCollisionReport(rootDir, copyPlan.collisionReport);
+  for (const target of copyPlan.targets) {
+    copySource(target.sourcePath, path.join(rootDir, target.chosenPath));
   }
   return {
     ok: true,
     command: "legacy-copy-safe-docs",
     migrationMode: "apply",
     rows: report.entries.length,
-    report
+    report: {
+      ...report,
+      entries: applyCollisionReport(report.entries, copyPlan.collisionReport),
+      collisionReport: copyPlan.collisionReport
+    }
   };
 }
 
 function applyLegacyIndex(rootDir: string, report: LegacyScanReport): CliResult {
   const layout = resolveHarnessLayout(rootDir);
-  const validation = validateLegacyIndex(rootDir, report);
+  const collisionReport = readCollisionReport(rootDir);
+  const indexedReport = { ...report, entries: applyCollisionReport(report.entries, collisionReport), summary: summarize(applyCollisionReport(report.entries, collisionReport)) };
+  const validation = validateLegacyIndex(rootDir, indexedReport);
   if (!validation.ok) return validation.result;
   const index = validation.index;
   mkdirSync(path.dirname(layout.legacyIndexPath), { recursive: true });

--- a/packages/cli/test/migration-adopt-cli.test.ts
+++ b/packages/cli/test/migration-adopt-cli.test.ts
@@ -88,17 +88,63 @@ test("CLI legacy copy and index write only under harness legacy storage", () => 
   });
 });
 
-test("CLI legacy copy blocks collisions in P04 without overwrite", () => {
+test("CLI legacy copy applies fixed suffix collisions and writes report", () => {
   withTempRoot((rootDir) => {
     writeLegacyTask(rootDir, "old-task", "active");
+    writeLegacyDoc(rootDir, "11-REFERENCE/testing-standard.md", "# Testing Standard\n");
     mkdirSync(path.join(rootDir, "harness/legacy/tasks/old-task"), { recursive: true });
+    mkdirSync(path.join(rootDir, "harness/legacy/tasks/old-task-legacy-import-1"), { recursive: true });
+    mkdirSync(path.join(rootDir, "harness/legacy/docs/11-REFERENCE"), { recursive: true });
     writeFileSync(path.join(rootDir, "harness/legacy/tasks/old-task/sentinel.txt"), "keep", "utf8");
+    writeFileSync(path.join(rootDir, "harness/legacy/docs/11-REFERENCE/testing-standard.md"), "keep", "utf8");
+    writeFileSync(path.join(rootDir, "harness/legacy/docs/11-REFERENCE/testing-standard.legacy-import-1.md"), "keep-1", "utf8");
 
-    const conflict = runJson(rootDir, ["legacy", "copy-safe-docs", ".", "--apply"], false);
+    const copied = runJson(rootDir, ["legacy", "copy-safe-docs", ".", "--apply"]);
+    const indexed = runJson(rootDir, ["legacy", "index", ".", "--apply"]);
+    const verified = runJson(rootDir, ["legacy", "verify"]);
+    const collisionReport = JSON.parse(readFileSync(path.join(rootDir, "harness/legacy/collision-report.json"), "utf8"));
+    const index = JSON.parse(readFileSync(path.join(rootDir, "harness/legacy/index.json"), "utf8"));
 
-    assert.equal(conflict.ok, false);
-    assert.equal(conflict.error.code, "legacy_collision_requires_p05");
+    assert.equal(copied.ok, true);
+    assert.equal(indexed.ok, true);
+    assert.equal(verified.ok, true);
+    assert.equal(verified.report.collisionReport.entryCount, 2);
+    assert.equal(verified.report.collisionReport.overwriteAllowed, false);
     assert.equal(readFileSync(path.join(rootDir, "harness/legacy/tasks/old-task/sentinel.txt"), "utf8"), "keep");
+    assert.equal(readFileSync(path.join(rootDir, "harness/legacy/docs/11-REFERENCE/testing-standard.md"), "utf8"), "keep");
+    assert.equal(existsSync(path.join(rootDir, "harness/legacy/tasks/old-task-legacy-import-2/task_plan.md")), true);
+    assert.equal(readFileSync(path.join(rootDir, "harness/legacy/docs/11-REFERENCE/testing-standard.legacy-import-2.md"), "utf8"), "# Testing Standard\n");
+    assert.equal(collisionReport.schema, "legacy-collision-report/v1");
+    assert.equal(collisionReport.policy.overwriteAllowed, false);
+    assert.equal(collisionReport.entries.length, 2);
+    assert.equal(collisionReport.entries.some((entry: Record<string, unknown>) => entry.kind === "directory" && entry.chosenPath === "harness/legacy/tasks/old-task-legacy-import-2" && entry.suffixIndex === 2), true);
+    assert.equal(collisionReport.entries.some((entry: Record<string, unknown>) => entry.kind === "file" && entry.chosenPath === "harness/legacy/docs/11-REFERENCE/testing-standard.legacy-import-2.md" && entry.suffixIndex === 2), true);
+    assert.equal(index.entries.some((entry: Record<string, unknown>) => entry.storedPath === "harness/legacy/tasks/old-task-legacy-import-2"), true);
+    assert.equal(index.entries.some((entry: Record<string, unknown>) => entry.storedPath === "harness/legacy/docs/11-REFERENCE/testing-standard.legacy-import-2.md"), true);
+  });
+});
+
+test("CLI legacy copy suffixes planned parent directories before they can overwrite planned children", () => {
+  withTempRoot((rootDir) => {
+    writeLegacyTask(rootDir, "modules", "active");
+    writeLegacyModuleTask(rootDir, "auth", "module-task", "active");
+    mkdirSync(path.join(rootDir, "docs/09-PLANNING/TASKS/modules/auth/module-task"), { recursive: true });
+    writeFileSync(path.join(rootDir, "docs/09-PLANNING/TASKS/modules/auth/module-task/task_plan.md"), "root nested plan\n", "utf8");
+
+    runJson(rootDir, ["legacy", "copy-safe-docs", ".", "--apply"]);
+    runJson(rootDir, ["legacy", "index", ".", "--apply"]);
+    const verified = runJson(rootDir, ["legacy", "verify"]);
+    const collisionReport = JSON.parse(readFileSync(path.join(rootDir, "harness/legacy/collision-report.json"), "utf8"));
+    const index = JSON.parse(readFileSync(path.join(rootDir, "harness/legacy/index.json"), "utf8"));
+
+    assert.equal(verified.ok, true);
+    assert.equal(readFileSync(path.join(rootDir, "harness/legacy/tasks/modules/auth/module-task/task_plan.md"), "utf8"), "# module-task\n\nTask Contract: harness-task/v1\n");
+    assert.equal(readFileSync(path.join(rootDir, "harness/legacy/tasks/modules-legacy-import-1/auth/module-task/task_plan.md"), "utf8"), "root nested plan\n");
+    assert.equal(collisionReport.entries.length, 1);
+    assert.equal(collisionReport.entries[0].targetPath, "harness/legacy/tasks/modules");
+    assert.equal(collisionReport.entries[0].chosenPath, "harness/legacy/tasks/modules-legacy-import-1");
+    assert.equal(collisionReport.entries[0].suffixIndex, 1);
+    assert.equal(index.entries.some((entry: Record<string, unknown>) => entry.sourcePath === "docs/09-PLANNING/TASKS/modules" && entry.storedPath === "harness/legacy/tasks/modules-legacy-import-1"), true);
   });
 });
 
@@ -134,6 +180,7 @@ test("CLI migrate aliases now emit Legacy Intake semantics and retire full cutov
     assert.equal(plan.report.schema, "legacy-intake-scan/v1");
     assert.equal(plan.warnings[0].code, "migration_alias_legacy_intake");
     assert.equal(structure.ok, true);
+    assert.equal(JSON.parse(readFileSync(path.join(rootDir, "harness/legacy/collision-report.json"), "utf8")).entries.length, 0);
     assert.equal(existsSync(path.join(rootDir, "harness/legacy/tasks/old-task/task_plan.md")), true);
     assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks/old-task")), false);
     assert.equal(run.report.schema, "legacy-intake-session/v1");


### PR DESCRIPTION
## Summary

- Add fixed Legacy Intake collision target planning for copy apply.
- Directory collisions use `-legacy-import-N`; file collisions use `.legacy-import-N` before the extension.
- Write runtime-validated `harness/legacy/collision-report.json`.
- Remap legacy index entries to chosen collision paths so `legacy verify` follows the actual copied files.
- Keep old tasks under `harness/legacy/**`; no active task tree rewrite.

## Verification

- `npm run typecheck`
- `node --test packages/cli/test/migration-adopt-cli.test.ts` (8 tests)
- `node tools/smoke-full-cutover.mjs`
- `npm run harness:check-file-complexity`
- `npm run harness:check-schema-contracts`
- `git diff --check`
- `npm run check` (167 tests plus full gates)

## Review

Read-only reviewer Hubble initially found one P1: planned nested copy targets could overwrite during the same copy apply without collision report.

Fixed by:

- sorting planned targets deepest-first;
- tracking planned occupied targets with kind metadata;
- treating exact overlap, occupied directory ancestors, and planned descendant overlaps as unavailable;
- adding a regression where root task `modules` and module task `modules/auth/module-task` preserve both file bodies and report the parent collision.

Reviewer recheck confirmed the P1 is closed and no P0/P1/P2 remain.

P3 residual:

- `copySource` still uses normal `writeFileSync`; planner covers same-apply overwrite paths, while exclusive writes could harden external filesystem races later.
