### PR TITLE
feat: rebuild tasks from legacy index

### DIFF
--- a/packages/cli/src/cli/command-registry.ts
+++ b/packages/cli/src/cli/command-registry.ts
@@ -2,7 +2,7 @@ import type { CommandRegistryEntry } from "./types.ts";
 
 export const commandRegistry = [
   { kind: "init", primary: "harness init", resultEnvelope: "CliResult/v1" },
-  { kind: "new-task", primary: "harness new-task --title <title> [--json]", resultEnvelope: "CliResult/v1" },
+  { kind: "new-task", primary: "harness new-task --title <title> [--from-legacy <legacy-id>] [--json]", resultEnvelope: "CliResult/v1" },
   { kind: "status-set", primary: "harness task status set <id> <status> [--force --reason <reason>]", resultEnvelope: "CliResult/v1" },
   { kind: "progress-append", primary: "harness task progress append <id> --text <text>", resultEnvelope: "CliResult/v1" },
   { kind: "task-archive", primary: "harness task archive <id> --reason <reason>", resultEnvelope: "CliResult/v1" },

--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -28,7 +28,26 @@ export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; rea
 
   if (args[0] === "new-task") {
     const migrationMode = args.includes("--migration") || args.includes("--import") || args.includes("--admin");
+    const fromLegacyId = readOption(args, "--from-legacy");
+    if (args.includes("--from-legacy") && (!fromLegacyId || fromLegacyId.startsWith("--"))) {
+      return {
+        ok: false,
+        error: {
+          code: "missing_legacy_id",
+          hint: "Use new-task --from-legacy <legacy-id> with an id from harness/legacy/index.json."
+        }
+      };
+    }
     const manualId = readOption(args, "--id") ?? (args[1]?.startsWith("--") ? undefined : args[1]);
+    if (fromLegacyId && manualId) {
+      return {
+        ok: false,
+        error: {
+          code: "legacy_rebuild_manual_id_forbidden",
+          hint: "new-task --from-legacy creates a fresh generated task id and cannot also use a manual id."
+        }
+      };
+    }
     if (manualId && !migrationMode) {
       return {
         ok: false,
@@ -38,7 +57,9 @@ export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; rea
         }
       };
     }
-    const title = readOption(args, "--title") ?? manualId ?? "Untitled task";
+    const explicitTitle = readOption(args, "--title");
+    const title = explicitTitle ?? manualId ?? "Untitled task";
+    const explicitSlug = readOption(args, "--slug");
     return {
       ok: true,
       value: {
@@ -48,8 +69,11 @@ export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; rea
           kind: "new-task",
           taskId: manualId,
           title,
-          slug: readOption(args, "--slug") ?? slugifyTaskTitle(title),
-          allowManualId: migrationMode
+          slug: explicitSlug ?? slugifyTaskTitle(title),
+          allowManualId: migrationMode,
+          fromLegacyId,
+          titleProvided: Boolean(explicitTitle),
+          slugProvided: Boolean(explicitSlug)
         }
       }
     };

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -69,7 +69,7 @@ export interface ParsedCommand {
   readonly json: boolean;
   readonly action:
     | { readonly kind: "init" }
-    | { readonly kind: "new-task"; readonly taskId?: string; readonly title: string; readonly slug: string; readonly allowManualId: boolean }
+    | { readonly kind: "new-task"; readonly taskId?: string; readonly title: string; readonly slug: string; readonly allowManualId: boolean; readonly fromLegacyId?: string; readonly titleProvided: boolean; readonly slugProvided: boolean }
     | { readonly kind: "status-set"; readonly taskId: string; readonly status: DomainStatus; readonly force: boolean; readonly reason?: string }
     | { readonly kind: "progress-append"; readonly taskId: string; readonly text: string }
     | { readonly kind: "task-archive"; readonly taskId: string; readonly reason: string }

--- a/packages/cli/src/commands/legacy-provenance-verify.ts
+++ b/packages/cli/src/commands/legacy-provenance-verify.ts
@@ -1,0 +1,51 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { resolveHarnessLayout } from "../../../kernel/src/layout/index.ts";
+
+export function collectLegacyProvenanceWarnings(rootDir: string): ReadonlyArray<Record<string, string>> {
+  const layout = resolveHarnessLayout(rootDir);
+  if (!existsSync(layout.tasksRoot)) return [];
+  return readdirSync(layout.tasksRoot, { withFileTypes: true }).flatMap((entry) => {
+    if (!entry.isDirectory()) return [];
+    const provenancePath = path.join(layout.tasksRoot, entry.name, "legacy-provenance.json");
+    if (!existsSync(provenancePath)) return [];
+    const taskPackage = normalizeSlashes(path.relative(rootDir, path.dirname(provenancePath)));
+    try {
+      const provenance = parseLegacyProvenance(JSON.parse(readFileSync(provenancePath, "utf8")));
+      if (!isLegacyStoredPath(provenance.storedPath)) {
+        return [legacyProvenanceWarning("legacy_provenance_invalid", taskPackage, provenance.legacyId, provenance.storedPath)];
+      }
+      if (existsSync(path.join(rootDir, provenance.storedPath))) return [];
+      return [legacyProvenanceWarning("legacy_provenance_target_missing", taskPackage, provenance.legacyId, provenance.storedPath)];
+    } catch {
+      return [legacyProvenanceWarning("legacy_provenance_invalid", taskPackage, "", "")];
+    }
+  }).sort((left, right) => `${left.taskPackage}:${left.code}`.localeCompare(`${right.taskPackage}:${right.code}`));
+}
+
+function parseLegacyProvenance(value: unknown): { readonly legacyId: string; readonly storedPath: string } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid legacy provenance");
+  const candidate = value as { readonly schema?: unknown; readonly legacyId?: unknown; readonly storedPath?: unknown };
+  if (candidate.schema !== "legacy-rebuild-provenance/v1") throw new Error("invalid legacy provenance schema");
+  if (typeof candidate.legacyId !== "string" || candidate.legacyId.length === 0) throw new Error("invalid legacy provenance id");
+  if (typeof candidate.storedPath !== "string" || candidate.storedPath.length === 0) throw new Error("invalid legacy provenance storedPath");
+  return { legacyId: candidate.legacyId, storedPath: candidate.storedPath };
+}
+
+function isLegacyStoredPath(value: string): boolean {
+  return value.startsWith("harness/legacy/") && !value.includes("..") && !value.includes("\\") && !path.isAbsolute(value);
+}
+
+function legacyProvenanceWarning(code: string, taskPackage: string, legacyId: string, storedPath: string): Record<string, string> {
+  return {
+    code,
+    severity: "warning",
+    taskPackage,
+    legacyId,
+    storedPath
+  };
+}
+
+function normalizeSlashes(value: string): string {
+  return value.split(path.sep).join("/");
+}

--- a/packages/cli/src/commands/legacy-rebuild.ts
+++ b/packages/cli/src/commands/legacy-rebuild.ts
@@ -1,0 +1,186 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { Effect, Schema } from "effect";
+import { makeLocalWriteCoordinator } from "../../../adapters/local/src/index.ts";
+import { resolveTaskCreatedBy } from "../../../adapters/local/src/created-by.ts";
+import { indexPath, makeIndex, renderIndex } from "../../../adapters/local/src/task-index.ts";
+import type { EngineError, WriteError } from "../../../kernel/src/domain/index.ts";
+import { createTaskPackagePath, generateTaskId, resolveHarnessLayout, slugifyTaskTitle } from "../../../kernel/src/layout/index.ts";
+import { LegacyIndexSchema, type LegacyIndexEntry } from "../../../kernel/src/schemas/registry.ts";
+import type { CliResult, ParsedCommand } from "../cli/types.ts";
+
+type NewTaskAction = Extract<ParsedCommand["action"], { readonly kind: "new-task" }>;
+
+type LegacyRebuildSource =
+  | { readonly ok: true; readonly entry: LegacyIndexEntry }
+  | { readonly ok: false; readonly result: CliResult };
+
+interface LegacyProvenance {
+  readonly schema: "legacy-rebuild-provenance/v1";
+  readonly legacyId: string;
+  readonly legacyIndexPath: "harness/legacy/index.json";
+  readonly sourcePath: string;
+  readonly storedPath: string;
+  readonly sourceDigest: string;
+  readonly title?: string;
+  readonly category: "task" | "doc";
+  readonly detectedStatus?: LegacyIndexEntry["detectedStatus"];
+  readonly recommendedTreatment: LegacyIndexEntry["recommendedTreatment"];
+  readonly humanReviewRequired: boolean;
+  readonly evidencePointers: LegacyIndexEntry["evidencePointers"];
+  readonly rebuiltAt: string;
+}
+
+export function runNewTaskFromLegacy(
+  rootDir: string,
+  action: NewTaskAction
+): Effect.Effect<CliResult, EngineError | WriteError> {
+  if (!action.fromLegacyId) {
+    throw new Error("runNewTaskFromLegacy requires fromLegacyId");
+  }
+  const fromLegacyId = action.fromLegacyId;
+  return Effect.sync(() => readLegacyRebuildSource(rootDir, fromLegacyId)).pipe(
+    Effect.flatMap((legacySource): Effect.Effect<CliResult, EngineError | WriteError> => {
+      if (!legacySource.ok) return Effect.succeed(legacySource.result);
+      const title = action.titleProvided ? action.title : legacySource.entry.title ?? legacySource.entry.id;
+      const slug = action.slugProvided ? action.slug : slugifyTaskTitle(title);
+      const taskId = generateTaskId();
+      if (existsSync(indexPath(rootDir, taskId))) {
+        return Effect.fail({ _tag: "MalformedSnapshot", raw: `task already exists: ${taskId}` } satisfies EngineError);
+      }
+      const createdAt = new Date().toISOString();
+      const index = makeIndex({
+        taskId,
+        title,
+        status: "planned",
+        bindingCreatedAt: createdAt,
+        vertical: "default",
+        preset: "default",
+        createdBy: resolveTaskCreatedBy(rootDir)
+      }, hashPayload);
+      const packagePath = createTaskPackagePath(rootDir, taskId, slug);
+      const provenance = buildLegacyProvenance(legacySource.entry, createdAt);
+      const provenanceMd = renderLegacyProvenanceMarkdown(rootDir, packagePath, legacySource.entry);
+      const coordinator = makeLocalWriteCoordinator({ rootDir, actor: { kind: "agent", id: "local-lifecycle" } });
+      const writes = [
+        { taskId, path: "INDEX.md", body: renderIndex(index), packageSlug: slug },
+        { taskId, path: "legacy-provenance.json", body: `${JSON.stringify(provenance, null, 2)}\n`, packageSlug: slug },
+        { taskId, path: "legacy-provenance.md", body: provenanceMd, packageSlug: slug }
+      ];
+      const opId = `${Date.now()}-${hashPayload({ kind: "package_create", writes }).slice(0, 16)}`;
+      return coordinator.enqueue({
+        opId,
+        taskId,
+        kind: "package_create",
+        payload: { writes }
+      }).pipe(
+        Effect.flatMap(() => coordinator.flush("explicit")),
+        Effect.map((): CliResult => {
+          return {
+            ok: true,
+            command: "new-task",
+            taskId,
+            slug,
+            status: "planned",
+            packagePath: path.relative(rootDir, packagePath).split(path.sep).join("/"),
+            report: {
+              schema: "legacy-rebuild-report/v1",
+              source: provenance,
+              inheritedTaskId: false,
+              inheritedStatus: false
+            }
+          };
+        })
+      );
+    })
+  );
+}
+
+function hashPayload(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function readLegacyRebuildSource(rootDir: string, legacyId: string): LegacyRebuildSource {
+  const layout = resolveHarnessLayout(rootDir);
+  if (!existsSync(layout.legacyIndexPath)) {
+    return {
+      ok: false,
+      result: {
+        ok: false,
+        command: "new-task",
+        error: { code: "legacy_index_missing", hint: "harness/legacy/index.json is missing. Run legacy index <path> --apply before rebuilding from legacy." }
+      }
+    };
+  }
+  try {
+    const index = Schema.decodeUnknownSync(LegacyIndexSchema)(JSON.parse(readFileSync(layout.legacyIndexPath, "utf8")));
+    const entry = index.entries.find((candidate) => candidate.id === legacyId);
+    if (!entry) {
+      return {
+        ok: false,
+        result: {
+          ok: false,
+          command: "new-task",
+          error: { code: "legacy_entry_not_found", hint: `No legacy index entry found for id: ${legacyId}` }
+        }
+      };
+    }
+    if (!existsSync(path.join(rootDir, entry.storedPath))) {
+      return {
+        ok: false,
+        result: {
+          ok: false,
+          command: "new-task",
+          error: { code: "legacy_stored_path_missing", hint: `Legacy stored path is missing: ${entry.storedPath}` }
+        }
+      };
+    }
+    return { ok: true, entry };
+  } catch {
+    return {
+      ok: false,
+      result: {
+        ok: false,
+        command: "new-task",
+        error: { code: "legacy_index_invalid", hint: "harness/legacy/index.json does not match the runtime LegacyIndexSchema." }
+      }
+    };
+  }
+}
+
+function buildLegacyProvenance(entry: LegacyIndexEntry, rebuiltAt: string): LegacyProvenance {
+  return {
+    schema: "legacy-rebuild-provenance/v1",
+    legacyId: entry.id,
+    legacyIndexPath: "harness/legacy/index.json",
+    sourcePath: entry.sourcePath,
+    storedPath: entry.storedPath,
+    sourceDigest: entry.sourceDigest,
+    title: entry.title,
+    category: entry.category,
+    detectedStatus: entry.detectedStatus,
+    recommendedTreatment: entry.recommendedTreatment,
+    humanReviewRequired: entry.humanReviewRequired,
+    evidencePointers: entry.evidencePointers,
+    rebuiltAt
+  };
+}
+
+function renderLegacyProvenanceMarkdown(rootDir: string, packagePath: string, entry: LegacyIndexEntry): string {
+  const relativePath = path.relative(rootDir, packagePath).split(path.sep).join("/");
+  return [
+    "# Legacy Rebuild Provenance",
+    "",
+    `Task package: ${relativePath}`,
+    `Legacy id: ${entry.id}`,
+    `Legacy source path: ${entry.sourcePath}`,
+    `Legacy stored path: ${entry.storedPath}`,
+    `Source digest: ${entry.sourceDigest}`,
+    `Recommended treatment: ${entry.recommendedTreatment}`,
+    `Human review required: ${entry.humanReviewRequired ? "yes" : "no"}`,
+    "",
+    "This task was rebuilt as a fresh Harness Anything task. It does not inherit the legacy task id, lifecycle status, or package identity.",
+    ""
+  ].join("\n");
+}

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -14,6 +14,7 @@ import { runLessonPromote, runLessonSediment } from "./lesson.ts";
 import { runAdoptMultica, runSnapshotMultica } from "./adopt.ts";
 import { runDoctor } from "./doctor.ts";
 import { runGitDiffEvidence } from "./git-diff.ts";
+import { runNewTaskFromLegacy } from "./legacy-rebuild.ts";
 import { runLegacyCopySafeDocs, runLegacyIndex, runLegacyIntakePlan, runLegacyScan, runLegacyVerify, runMigratePlan, runMigrateRun, runMigrateStructure, runMigrateVerify } from "./migration.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
 
@@ -29,6 +30,9 @@ export function runCommand(
 
   if (command.action.kind === "new-task") {
     const action = command.action;
+    if (action.fromLegacyId) {
+      return runNewTaskFromLegacy(command.rootDir, action);
+    }
     const taskId = action.taskId ?? generateTaskId();
     return engine.createTask({
       taskId,

--- a/packages/cli/src/commands/migration.ts
+++ b/packages/cli/src/commands/migration.ts
@@ -6,6 +6,7 @@ import { resolveHarnessLayout } from "../../../kernel/src/layout/index.ts";
 import { LegacyIndexSchema, type LegacyIndex, type LegacyIndexEntry } from "../../../kernel/src/schemas/registry.ts";
 import type { CliResult } from "../cli/types.ts";
 import { applyCollisionReport, buildLegacyCopyPlan, readCollisionReport, writeCollisionReport } from "./migration-collision.ts";
+import { collectLegacyProvenanceWarnings } from "./legacy-provenance-verify.ts";
 import type { LegacyCopySafeDocsAction, LegacyIndexAction, LegacyIntakePlanAction, LegacyScanAction, LegacyVerifyAction, MigratePlanAction, MigrateRunAction, MigrateStructureAction, MigrateVerifyAction } from "./migration-types.ts";
 
 interface LegacyScanReport {
@@ -206,16 +207,19 @@ export function runLegacyVerify(rootDir: string, _action: LegacyVerifyAction): C
     .map((entry) => entry.storedPath)
     .filter((storedPath) => !existsSync(path.join(rootDir, storedPath)));
   const ok = missingTargets.length === 0;
+  const provenanceWarnings = collectLegacyProvenanceWarnings(rootDir);
   return {
     ok,
     command: "legacy-verify",
     rows: index.entries.length,
+    warnings: provenanceWarnings.length > 0 ? provenanceWarnings : undefined,
     report: {
       schema: "legacy-intake-verify-report/v1",
       ok,
       missingIndex: false,
       invalidIndex: false,
       missingTargets,
+      provenanceWarnings,
       summary: index.summary,
       collisionReport: collisionReport ? {
         entryCount: collisionReport.entries.length,

--- a/packages/cli/test/migration-adopt-cli.test.ts
+++ b/packages/cli/test/migration-adopt-cli.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
+const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
 
 test("CLI exposes Multica snapshot as readonly JSON evidence", () => {
   withTempRoot((rootDir) => {
@@ -165,6 +166,69 @@ test("CLI legacy verify detects missing, invalid, and valid index states", () =>
     const valid = runJson(rootDir, ["legacy", "verify"]);
     assert.equal(valid.ok, true);
     assert.equal(valid.report.summary.taskCount, 1);
+  });
+});
+
+test("CLI rebuilds a fresh local task from a legacy index entry with provenance", () => {
+  withTempRoot((rootDir) => {
+    const missingLegacyId = runJson(rootDir, ["new-task", "--from-legacy"], false);
+    assert.equal(missingLegacyId.error.code, "missing_legacy_id");
+
+    const manualId = runJson(rootDir, ["new-task", "legacy-old-task", "--from-legacy", "legacy_missing"], false);
+    assert.equal(manualId.error.code, "legacy_rebuild_manual_id_forbidden");
+
+    const missing = runJson(rootDir, ["new-task", "--from-legacy", "legacy_missing"], false);
+    assert.equal(missing.error.code, "legacy_index_missing");
+
+    mkdirSync(path.join(rootDir, "harness/legacy"), { recursive: true });
+    writeFileSync(path.join(rootDir, "harness/legacy/index.json"), "{\"schema\":\"wrong\"}\n", "utf8");
+    const invalid = runJson(rootDir, ["new-task", "--from-legacy", "legacy_missing"], false);
+    assert.equal(invalid.error.code, "legacy_index_invalid");
+
+    rmSync(path.join(rootDir, "harness"), { recursive: true, force: true });
+    writeLegacyTask(rootDir, "old-task", "active");
+    runJson(rootDir, ["legacy", "copy-safe-docs", ".", "--apply"]);
+    runJson(rootDir, ["legacy", "index", ".", "--apply"]);
+    const index = JSON.parse(readFileSync(path.join(rootDir, "harness/legacy/index.json"), "utf8"));
+    const legacyEntry = index.entries.find((entry: Record<string, unknown>) => entry.category === "task");
+
+    const unknown = runJson(rootDir, ["new-task", "--from-legacy", "legacy_unknown"], false);
+    assert.equal(unknown.error.code, "legacy_entry_not_found");
+
+    const rebuilt = runJson(rootDir, ["new-task", "--from-legacy", legacyEntry.id]);
+    assert.match(rebuilt.taskId, taskIdPattern);
+    assert.notEqual(rebuilt.taskId, legacyEntry.id);
+    assert.equal(rebuilt.status, "planned");
+    assert.equal(rebuilt.slug, "old-task");
+    assert.equal(rebuilt.report.inheritedTaskId, false);
+    assert.equal(rebuilt.report.inheritedStatus, false);
+    assert.equal(rebuilt.report.source.legacyId, legacyEntry.id);
+    assert.equal(rebuilt.report.source.storedPath, legacyEntry.storedPath);
+
+    const taskDir = path.join(rootDir, rebuilt.packagePath);
+    const indexBody = readFileSync(path.join(taskDir, "INDEX.md"), "utf8");
+    const provenance = JSON.parse(readFileSync(path.join(taskDir, "legacy-provenance.json"), "utf8"));
+    assert.match(indexBody, /status: planned/);
+    assert.doesNotMatch(indexBody, /status: active/);
+    assert.equal(provenance.schema, "legacy-rebuild-provenance/v1");
+    assert.equal(provenance.legacyId, legacyEntry.id);
+    assert.equal(provenance.storedPath, legacyEntry.storedPath);
+    assert.equal(provenance.detectedStatus.raw, "active");
+    assert.match(provenance.rebuiltAt, /^\d{4}-\d{2}-\d{2}T/u);
+    assert.notEqual(provenance.rebuiltAt, "1970-01-01T00:00:00.000Z");
+    assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks", legacyEntry.id)), false);
+    assert.equal(existsSync(path.join(rootDir, legacyEntry.storedPath)), true);
+
+    writeFileSync(path.join(taskDir, "legacy-provenance.json"), "{\"schema\":\"legacy-rebuild-provenance/v1\",\"legacyId\":\"legacy_bad\"}\n", "utf8");
+    const invalidProvenance = runJson(rootDir, ["legacy", "verify"]);
+    assert.equal(invalidProvenance.ok, true);
+    assert.equal(invalidProvenance.warnings.some((warning: Record<string, unknown>) => warning.code === "legacy_provenance_invalid"), true);
+
+    provenance.storedPath = "harness/legacy/tasks/missing-rebuild-source";
+    writeFileSync(path.join(taskDir, "legacy-provenance.json"), `${JSON.stringify(provenance, null, 2)}\n`, "utf8");
+    const verified = runJson(rootDir, ["legacy", "verify"]);
+    assert.equal(verified.ok, true);
+    assert.equal(verified.warnings.some((warning: Record<string, unknown>) => warning.code === "legacy_provenance_target_missing" && warning.legacyId === legacyEntry.id), true);
   });
 });
 

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -152,7 +152,7 @@ function applyRecord(rootDir: string, journalPath: string, record: JournalRecord
 }
 
 function applyOp(rootDir: string, op: WriteOp): DocumentWrite | null {
-  if (op.kind === "package_supersede" && isBatchDocumentWritePayload(op.payload)) {
+  if ((op.kind === "package_create" || op.kind === "package_supersede") && isBatchDocumentWritePayload(op.payload)) {
     writeDocumentsAtomically(rootDir, op.payload.writes);
     return null;
   }

--- a/packages/kernel/test/store/global-committer-lock.test.ts
+++ b/packages/kernel/test/store/global-committer-lock.test.ts
@@ -54,6 +54,31 @@ test("WriteCoordinator validates supersede batch before writing any document", (
   });
 });
 
+test("WriteCoordinator validates package create batch before writing any document", () => {
+  withTempStore((rootDir) => {
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+
+    Effect.runSync(coordinator.enqueue({
+      opId: "op-create-batch-invalid",
+      taskId: "task-new",
+      kind: "package_create",
+      payload: {
+        writes: [
+          { taskId: "task-new", path: "INDEX.md", body: "index", packageSlug: "new" },
+          { taskId: "task-new", path: "/absolute.md", body: "bad", packageSlug: "new" }
+        ]
+      }
+    }));
+
+    assert.throws(
+      () => Effect.runSync(coordinator.flush("explicit")),
+      /absolute paths are not allowed/
+    );
+    assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks/task-new-new/INDEX.md")), false);
+    assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks/task-new-new/absolute.md")), false);
+  });
+});
+
 test("WriteCoordinator rejects hard delete before journaling when policy payload or disposition is invalid", () => {
   withTempStore((rootDir) => {
     const coordinator = makeJournaledWriteCoordinator({ rootDir });


### PR DESCRIPTION
## Summary
- add `new-task --from-legacy <legacy-id>` to rebuild legacy index entries as fresh generated-id local tasks
- write rebuild provenance in the new task package through a WriteCoordinator package-create batch
- warn from `legacy verify` when rebuild provenance is invalid or points to a missing legacy stored path

## Verification
- `npm run check`

## Review
- Turing initial review found P2 issues around epoch timestamps, post-create provenance writes, and invalid provenance warnings; all fixed.
- Pasteur re-review found missing `--from-legacy` value created an ordinary task; fixed with `missing_legacy_id` regression.
