### PR TITLE
M2.5 CLI P09: enforce metadata-driven task checks

### DIFF
--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -170,6 +170,7 @@ function supersedeTask(
       bindingCreatedAt: clock().toISOString(),
       vertical: oldIndex.vertical,
       preset: oldIndex.preset,
+      profile: oldIndex.profile,
       createdBy: resolveTaskCreatedBy(rootDir)
     }, stablePayloadHash);
     yield* writeSupersedeTaskDocuments(coordinator, stablePayloadHash, [

--- a/packages/adapters/local/src/task-index.ts
+++ b/packages/adapters/local/src/task-index.ts
@@ -26,6 +26,7 @@ export function makeIndex(input: {
   readonly bindingCreatedAt: string;
   readonly vertical: string;
   readonly preset: string;
+  readonly profile?: string;
   readonly createdBy?: TaskCreatedBy;
 }, hashPayload: HashPayload): LocalTaskIndex {
   const fingerprint = hashPayload({
@@ -46,6 +47,7 @@ export function makeIndex(input: {
     packageDisposition: "active",
     vertical: input.vertical,
     preset: input.preset,
+    ...(input.profile ? { profile: input.profile } : {}),
     ...(input.createdBy ? { createdBy: input.createdBy } : {})
   };
 }
@@ -68,6 +70,7 @@ export function renderIndex(index: LocalTaskIndex, reason?: string): string {
     `packageDisposition: ${index.packageDisposition}`,
     `vertical: ${index.vertical}`,
     `preset: ${index.preset}`,
+    ...(index.profile ? [`profile: ${index.profile}`] : []),
     ...(index.createdBy ? [
       "createdBy:",
       `  name: ${index.createdBy.name}`,
@@ -116,6 +119,7 @@ export function readIndex(rootDir: string, taskId: TaskId): LocalTaskIndex {
     packageDisposition: readPackageDisposition(frontmatter),
     vertical: readScalar(frontmatter, "vertical"),
     preset: readScalar(frontmatter, "preset"),
+    ...readProfile(frontmatter),
     ...readCreatedBy(frontmatter)
   };
 }
@@ -155,6 +159,11 @@ function readOptionalNestedScalar(block: string, key: string): string {
 function readPackageDisposition(frontmatter: string): LocalTaskIndex["packageDisposition"] {
   const value = readScalar(frontmatter, "packageDisposition");
   return isPackageDisposition(value) ? value : "active";
+}
+
+function readProfile(frontmatter: string): { readonly profile?: string } {
+  const profile = frontmatter.match(/^profile:[ \t]*(.*)$/mu)?.[1]?.trim() ?? "";
+  return profile ? { profile } : {};
 }
 
 function isNodeErrorCode(error: unknown, code: string): boolean {

--- a/packages/adapters/local/src/types.ts
+++ b/packages/adapters/local/src/types.ts
@@ -105,5 +105,6 @@ export interface LocalTaskIndex {
   readonly packageDisposition: "active" | "archived" | "tombstoned";
   readonly vertical: string;
   readonly preset: string;
+  readonly profile?: string;
   readonly createdBy?: TaskCreatedBy;
 }

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -2,10 +2,11 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { parseReviewMarkdown } from "../../../application/src/index.ts";
 import { checkTaskProjection } from "../../../kernel/src/index.ts";
-import { listTaskIndexPaths, readFrontmatter, readScalar, resolveHarnessLayout } from "../../../kernel/src/layout/index.ts";
+import { listTaskIndexPaths, normalizeRelativeDocumentPath, readFrontmatter, readScalar, resolveHarnessLayout } from "../../../kernel/src/layout/index.ts";
 import { commandRegistry } from "../cli/command-registry.ts";
 import { relativePath } from "../cli/path.ts";
 import type { CheckProfile, CliResult } from "../cli/types.ts";
+import { isInvalidPreset, materializePresetTaskDocuments, resolvePresetEntry } from "./extensions/state.ts";
 
 const FORCE_STATUS_AUDIT_MARKER = "FORCE_STATUS_SET_AUDIT";
 
@@ -90,6 +91,9 @@ function validateTaskPackageContracts(rootDir: string, taskDir: string, profile:
     issues.push(profileIssue("task-plan-contract", "task_index_frontmatter_missing", "hard-fail", `${relativeTaskDir}/INDEX.md is missing frontmatter.`, "Restore task package frontmatter before running check profiles."));
     return issues;
   }
+  const vertical = readScalar(frontmatter, "vertical");
+  const metadataDriven = vertical === "software/coding";
+  issues.push(...validateMetadataDrivenTaskPackage(rootDir, taskDir, relativeTaskDir, frontmatter));
 
   const taskPlanPath = path.join(taskDir, "task_plan.md");
   if (!existsSync(taskPlanPath)) {
@@ -134,7 +138,7 @@ function validateTaskPackageContracts(rootDir: string, taskDir: string, profile:
     if (hasTemplatePlaceholder(visualBody)) {
       issues.push(profileIssue("visual-map", "visual_map_placeholder", "hard-fail", `${relativeTaskDir}/visual_map.md still contains template placeholders.`, "Replace scaffold placeholders in the visual map."));
     }
-  } else if (profile !== "source-package") {
+  } else if (profile !== "source-package" && !metadataDriven) {
     issues.push(profileIssue("visual-map", "visual_map_missing", strictSeverity(strict), `${relativeTaskDir}/visual_map.md is missing.`, "Add visual_map.md or record why this task is exempt."));
   }
 
@@ -157,6 +161,132 @@ function validateTaskPackageContracts(rootDir: string, taskDir: string, profile:
   const status = readScalar(frontmatter, "  status");
   if ((status === "done" || status === "in_review") && !existsSync(path.join(taskDir, "walkthrough.md")) && !existsSync(path.join(taskDir, "closeout.md"))) {
     issues.push(profileIssue("completion-consistency", "closeout_missing", strictSeverity(strict), `${relativeTaskDir} is ${status} without closeout evidence.`, "Add walkthrough.md/closeout.md before claiming completion."));
+  }
+
+  return issues;
+}
+
+function validateMetadataDrivenTaskPackage(
+  rootDir: string,
+  taskDir: string,
+  relativeTaskDir: string,
+  frontmatter: string
+): ReadonlyArray<ProfileValidationIssue> {
+  const vertical = readScalar(frontmatter, "vertical");
+  const presetId = readScalar(frontmatter, "preset");
+  if (!vertical || vertical === "default") return [];
+  if (vertical !== "software/coding") {
+    return [profileIssue(
+      "metadata-contract",
+      "unsupported_vertical_metadata",
+      "hard-fail",
+      `${relativeTaskDir}/INDEX.md records unsupported vertical ${vertical}.`,
+      "Use software/coding until project custom vertical checks are enabled by P10/P11."
+    )];
+  }
+  if (!presetId || presetId === "default") {
+    return [profileIssue(
+      "metadata-contract",
+      "metadata_preset_missing",
+      "hard-fail",
+      `${relativeTaskDir}/INDEX.md records software/coding without a concrete preset.`,
+      "Record the selected preset in task frontmatter or rebuild the task package."
+    )];
+  }
+  const profile = readScalar(frontmatter, "profile") || undefined;
+
+  const preset = resolvePresetEntry(rootDir, presetId);
+  if (!preset) {
+    return [profileIssue(
+      "metadata-preset",
+      "metadata_preset_not_found",
+      "hard-fail",
+      `${relativeTaskDir}/INDEX.md references unknown preset ${presetId}.`,
+      "Install the preset or update the task frontmatter to a valid preset id."
+    )];
+  }
+  if (isInvalidPreset(preset)) {
+    return preset.issues.map((issue) => profileIssue(
+      "metadata-preset",
+      issue.code,
+      "hard-fail",
+      `${relativeTaskDir}/INDEX.md preset ${presetId} is blocked by active ${preset.layer} preset validation: ${issue.message}`,
+      "Fix or remove the active preset override before running check."
+    ));
+  }
+
+  const materialized = materializePresetTaskDocuments(preset.manifest, { profileId: profile, locale: "zh-CN" });
+  const issues: ProfileValidationIssue[] = [];
+  if (!materialized.ok) {
+    issues.push(...materialized.issues.map((issue) => profileIssue(
+      "metadata-template",
+      issue.code,
+      "hard-fail",
+      `${relativeTaskDir}/INDEX.md preset ${presetId} cannot materialize required template metadata: ${issue.message}`,
+      "Fix the preset/template metadata before running check."
+    )));
+    return issues;
+  }
+
+  for (const document of materialized.documents) {
+    let safeDocumentPath: string;
+    try {
+      safeDocumentPath = normalizeRelativeDocumentPath(document.materializeAs);
+    } catch (error) {
+      issues.push(profileIssue(
+        "metadata-template",
+        "invalid_materialized_path",
+        "hard-fail",
+        `${relativeTaskDir}/INDEX.md preset ${presetId} has invalid materialized path ${document.materializeAs}: ${error instanceof Error ? error.message : "invalid path"}.`,
+        "Fix the preset/template metadata before running check."
+      ));
+      continue;
+    }
+    const documentPath = path.join(taskDir, safeDocumentPath);
+    const relativeDocumentPath = `${relativeTaskDir}/${document.materializeAs}`;
+    if (!existsSync(documentPath)) {
+      issues.push(profileIssue(
+        "metadata-template",
+        "metadata_document_missing",
+        "hard-fail",
+        `${relativeDocumentPath} is required by vertical ${vertical} preset ${presetId}.`,
+        "Restore the required materialized document or rebuild the task package from the preset."
+      ));
+      continue;
+    }
+    let body: string;
+    try {
+      body = readFileSync(documentPath, "utf8");
+    } catch {
+      issues.push(profileIssue(
+        "metadata-template",
+        "metadata_document_unreadable",
+        "hard-fail",
+        `${relativeDocumentPath} could not be read as a file.`,
+        "Restore the required materialized document as a readable file."
+      ));
+      continue;
+    }
+    for (const anchor of document.requiredAnchors) {
+      if (!body.includes(anchor)) {
+        issues.push(profileIssue(
+          "metadata-template",
+          "metadata_required_anchor_missing",
+          "hard-fail",
+          `${relativeDocumentPath} is missing required anchor ${anchor}.`,
+          "Restore the required anchor or rebuild the document from the selected template."
+        ));
+      }
+    }
+    if (document.fallbackUsed) {
+      issues.push(profileIssue(
+        "metadata-template",
+        "metadata_locale_fallback_used",
+        "warning",
+        `${relativeDocumentPath} used locale fallback ${document.locale}.`,
+        "Review locale settings once project default locale is configured."
+      ));
+    }
   }
 
   return issues;

--- a/packages/cli/src/commands/extensions/bundled.ts
+++ b/packages/cli/src/commands/extensions/bundled.ts
@@ -6,6 +6,8 @@ type VerticalDefinition = Schema.Schema.Type<typeof VerticalDefinitionSchema>;
 
 const taskPlanZh = `# {{title}}
 
+Task Contract: harness-task v1
+
 ## Goal
 
 说明本任务要完成的可验证结果。
@@ -26,6 +28,8 @@ const taskPlanZh = `# {{title}}
 `;
 
 const taskPlanEn = `# {{title}}
+
+Task Contract: harness-task v1
 
 ## Goal
 
@@ -69,8 +73,8 @@ Status: not-started
 
 ## Findings
 
-| Severity | File | Finding | Status |
-| --- | --- | --- | --- |
+| ID | Severity | Finding | Evidence Checked | Required Action | Open | Disposition | Blocks Release | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
 `;
 
 const closeoutBody = `# Closeout

--- a/packages/cli/src/commands/extensions/state.ts
+++ b/packages/cli/src/commands/extensions/state.ts
@@ -9,7 +9,7 @@ import {
   type ExtensionValidationIssue,
   type MaterializedTemplatePlan
 } from "../../../../kernel/src/index.ts";
-import { resolveHarnessLayout } from "../../../../kernel/src/layout/index.ts";
+import { normalizeRelativeDocumentPath, resolveHarnessLayout } from "../../../../kernel/src/layout/index.ts";
 import type { CliResult } from "../../cli/types.ts";
 import {
   bundledSoftwareCodingTemplateCatalog,
@@ -439,6 +439,11 @@ function validateAdditiveSoftwareCodingPreset(manifest: PresetManifest): Readonl
 
     for (const [selectionIndex, selection] of profile.templateSelections.entries()) {
       const path = `profiles[${profileIndex}].templateSelections[${selectionIndex}]`;
+      try {
+        normalizeRelativeDocumentPath(selection.materializeAs);
+      } catch (error) {
+        issues.push(extensionIssue("invalid_materialized_path", error instanceof Error ? error.message : `Invalid materialized path ${selection.materializeAs}.`, path));
+      }
       if (reservedMaterializedPaths.has(selection.materializeAs)) {
         issues.push(extensionIssue("reserved_materialized_path", `Preset ${manifest.id} cannot materialize reserved task package path ${selection.materializeAs}.`, path));
       }

--- a/packages/cli/src/commands/preset-task.ts
+++ b/packages/cli/src/commands/preset-task.ts
@@ -100,8 +100,9 @@ export function runNewTaskWithPreset(
       bindingCreatedAt: createdAt,
       vertical,
       preset: preset.manifest.id,
+      profile: materialized.profile.id,
       createdBy: resolveTaskCreatedBy(rootDir)
-    }, hashPayload);
+    }, stablePayloadHash);
     const writes = [
       { taskId, path: "INDEX.md", body: renderIndex(index), packageSlug: action.slug },
       ...materialized.documents.map((document) => ({
@@ -118,7 +119,7 @@ export function runNewTaskWithPreset(
       }] : [])
     ];
     const coordinator = makeLocalWriteCoordinator({ rootDir, actor: { kind: "agent", id: "local-lifecycle" } });
-    const opId = `${Date.now()}-${hashPayload({ kind: "package_create", writes }).slice(0, 16)}`;
+    const opId = `${Date.now()}-${stablePayloadHash({ kind: "package_create", writes }).slice(0, 16)}`;
     yield* coordinator.enqueue({
       opId,
       taskId,
@@ -169,6 +170,17 @@ function renderTemplateBody(body: string, title: string): string {
   return body.replace(/\{\{title\}\}/gu, title);
 }
 
-function hashPayload(value: unknown): string {
-  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+function stablePayloadHash(value: unknown): string {
+  return createHash("sha256").update(stableStringify(value), "utf8").digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .join(",")}}`;
 }

--- a/packages/cli/test/check-governance-cli.test.ts
+++ b/packages/cli/test/check-governance-cli.test.ts
@@ -57,6 +57,161 @@ test("CLI target-project check profile passes valid task material contracts", ()
   });
 });
 
+test("CLI metadata check validates software coding preset task documents", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    const created = runJson(rootDir, ["new-task", "--title", "Coding Task", "--vertical", "software/coding", "--preset", "standard-task"]);
+
+    const result = runJson(rootDir, ["check", "--profile", "target-project", "--strict"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.report.summary.hardFailCount, 0);
+    assert.equal(result.warnings.some((warning: Record<string, unknown>) => warning.code === "visual_map_missing"), false);
+    assert.equal(readFileSync(path.join(rootDir, created.packagePath, "task_plan.md"), "utf8").includes("Task Contract: harness-task v1"), true);
+  });
+});
+
+test("CLI metadata check uses the selected persisted preset profile", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    writeRawPreset(rootDir, ".harness/presets/profiled-task/preset.json", makeMultiProfilePreset());
+    const created = runJson(rootDir, ["new-task", "--title", "Profiled Task", "--vertical", "software/coding", "--preset", "profiled-task", "--profile", "extra"]);
+
+    assert.equal(created.report.profile, "extra");
+    assert.equal(created.generated.includes("extra.md"), true);
+    const index = readFileSync(path.join(rootDir, created.packagePath, "INDEX.md"), "utf8");
+    assert.match(index, /profile: extra/);
+
+    const passed = runJson(rootDir, ["check", "--profile", "target-project", "--strict"]);
+    assert.equal(passed.ok, true);
+
+    rmSync(path.join(rootDir, created.packagePath, "extra.md"));
+    const failed = runJson(rootDir, ["check", "--profile", "target-project", "--strict"], false);
+    assert.equal(failed.ok, false);
+    assert.equal(failed.warnings.some((warning: Record<string, unknown>) => warning.code === "metadata_document_missing" && warning.message.includes("extra.md")), true);
+  });
+});
+
+test("CLI task supersede preserves selected preset profile metadata", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    writeRawPreset(rootDir, ".harness/presets/profiled-task/preset.json", makeMultiProfilePreset());
+    const created = runJson(rootDir, ["new-task", "--title", "Profiled Task", "--vertical", "software/coding", "--preset", "profiled-task", "--profile", "extra"]);
+    const superseded = runJson(rootDir, ["task", "supersede", created.taskId, "--title", "Replacement Profiled Task", "--reason", "scope changed"]);
+
+    assert.equal(superseded.ok, true);
+    const index = readFileSync(path.join(rootDir, superseded.packagePath, "INDEX.md"), "utf8");
+    assert.match(index, /vertical: software\/coding/);
+    assert.match(index, /preset: profiled-task/);
+    assert.match(index, /profile: extra/);
+  });
+});
+
+test("CLI metadata check fails closed on missing preset-selected document and anchor", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    const created = runJson(rootDir, ["new-task", "--title", "Coding Task", "--vertical", "software/coding", "--preset", "standard-task"]);
+    rmSync(path.join(rootDir, created.packagePath, "progress.md"));
+
+    const missingDocument = runJson(rootDir, ["check", "--profile", "target-project", "--strict"], false);
+
+    assert.equal(missingDocument.ok, false);
+    assert.equal(missingDocument.error.code, "check_profile_failed");
+    assert.equal(missingDocument.warnings.some((warning: Record<string, unknown>) => warning.code === "metadata_document_missing" && warning.severity === "hard-fail"), true);
+
+    const recreated = runJson(rootDir, ["new-task", "--title", "Anchor Task", "--vertical", "software/coding", "--preset", "standard-task"]);
+    const taskPlanPath = path.join(rootDir, recreated.packagePath, "task_plan.md");
+    writeFileSync(taskPlanPath, readFileSync(taskPlanPath, "utf8").replace("## Context", "## Notes"), "utf8");
+
+    const missingAnchor = runJson(rootDir, ["check", "--profile", "target-project", "--strict"], false);
+
+    assert.equal(missingAnchor.ok, false);
+    assert.equal(missingAnchor.warnings.some((warning: Record<string, unknown>) => warning.code === "metadata_required_anchor_missing" && warning.message.includes("task_plan.md")), true);
+  });
+});
+
+test("CLI metadata check does not resolve preset overrides for default tasks", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    writeTaskPackage(rootDir, "task-1", {
+      taskPlan: validTaskPlan(),
+      review: validReview(),
+      visual: validVisualMap(),
+      execution: validExecutionStrategy(),
+      lessons: validLessonCandidates()
+    });
+    writePreset(rootDir, ".harness/presets/module/preset.json", {
+      id: "module",
+      title: "Bad Module",
+      version: "9.0.0",
+      templateSelections: [conflictingTaskPlanSelection()]
+    });
+
+    const result = runJson(rootDir, ["check", "--profile", "target-project", "--strict"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.warnings.some((warning: Record<string, unknown>) => warning.source === "metadata-preset"), false);
+  });
+});
+
+test("CLI metadata check blocks invalid active preset overrides without bundled fallback", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    runJson(rootDir, ["new-task", "--title", "Coding Task", "--vertical", "software/coding", "--preset", "standard-task"]);
+    writePreset(rootDir, ".harness/presets/standard-task/preset.json", {
+      id: "standard-task",
+      title: "Bad Standard Task",
+      version: "9.0.0",
+      templateSelections: [conflictingTaskPlanSelection()]
+    });
+
+    const result = runJson(rootDir, ["check", "--profile", "target-project", "--strict"], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "check_profile_failed");
+    assert.equal(result.warnings.some((warning: Record<string, unknown>) => warning.code === "preset_required_template_conflict"), true);
+  });
+});
+
+test("CLI metadata check reports invalid materialized paths instead of crashing", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    runJson(rootDir, ["new-task", "--title", "Coding Task", "--vertical", "software/coding", "--preset", "standard-task"]);
+    writePreset(rootDir, ".harness/presets/standard-task/preset.json", {
+      id: "standard-task",
+      title: "Bad Path Standard Task",
+      version: "9.0.0",
+      templateSelections: [invalidPathSelection()]
+    });
+
+    const result = runJson(rootDir, ["check", "--profile", "target-project", "--strict"], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "check_profile_failed");
+    assert.equal(result.warnings.some((warning: Record<string, unknown>) => warning.code === "invalid_materialized_path"), true);
+  });
+});
+
+test("CLI metadata check rejects unsupported non-default verticals", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    writeTaskPackage(rootDir, "task-1", {
+      vertical: "custom/coding",
+      preset: "standard-task",
+      taskPlan: validTaskPlan(),
+      review: validReview(),
+      visual: validVisualMap(),
+      execution: validExecutionStrategy(),
+      lessons: validLessonCandidates()
+    });
+
+    const result = runJson(rootDir, ["check", "--profile", "target-project", "--strict"], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.warnings.some((warning: Record<string, unknown>) => warning.code === "unsupported_vertical_metadata"), true);
+  });
+});
+
 test("CLI governance rebuild supports dry-run, apply, and archive modes", () => {
   withTempRoot((rootDir) => {
     runJson(rootDir, ["init"]);
@@ -123,6 +278,8 @@ function writeTaskPackage(
   rootDir: string,
   taskId: string,
   files: {
+    readonly vertical?: string;
+    readonly preset?: string;
     readonly taskPlan: string;
     readonly review: string;
     readonly visual: string;
@@ -147,8 +304,8 @@ function writeTaskPackage(
     "  bindingCreatedAt: 2026-06-12T00:00:00.000Z",
     "  bindingFingerprint: sha256:4d1771ef6e83619eb8a82f1593bf118383084665fc58f634072d379178d525d7",
     "packageDisposition: active",
-    "vertical: default",
-    "preset: module",
+    `vertical: ${files.vertical ?? "default"}`,
+    `preset: ${files.preset ?? "module"}`,
     "---",
     "",
     "# Governance Task",
@@ -159,6 +316,112 @@ function writeTaskPackage(
   writeFileSync(path.join(taskDir, "visual_map.md"), files.visual, "utf8");
   writeFileSync(path.join(taskDir, "execution_strategy.md"), files.execution, "utf8");
   writeFileSync(path.join(taskDir, "lesson_candidates.md"), files.lessons, "utf8");
+}
+
+function writePreset(rootDir: string, relativePath: string, overrides: {
+  readonly id: string;
+  readonly title: string;
+  readonly version: string;
+  readonly templateSelections?: ReadonlyArray<Record<string, unknown>>;
+}): void {
+  const filePath = path.join(rootDir, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(makePreset(overrides), null, 2), "utf8");
+}
+
+function writeRawPreset(rootDir: string, relativePath: string, manifest: Record<string, unknown>): void {
+  const filePath = path.join(rootDir, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(manifest, null, 2), "utf8");
+}
+
+function makePreset(overrides: {
+  readonly id: string;
+  readonly title: string;
+  readonly version: string;
+  readonly templateSelections?: ReadonlyArray<Record<string, unknown>>;
+}): Record<string, unknown> {
+  return {
+    schema: "preset-manifest/v1",
+    id: overrides.id,
+    title: overrides.title,
+    vertical: "software/coding",
+    version: overrides.version,
+    kernelVersionRange: {
+      min: "1.0.0",
+      maxExclusive: "2.0.0"
+    },
+    capabilityImports: [],
+    profiles: [{
+      id: "baseline",
+      title: "Baseline",
+      checkerProfile: "standard",
+      templateSelections: overrides.templateSelections ?? []
+    }],
+    defaultProfile: "baseline"
+  };
+}
+
+function conflictingTaskPlanSelection(): Record<string, unknown> {
+  return {
+    slot: "task.plan",
+    templateRef: "template://planning/progress@1",
+    materializeAs: "task_plan.md",
+    localePolicy: {
+      prefer: "project",
+      fallback: "en-US"
+    }
+  };
+}
+
+function invalidPathSelection(): Record<string, unknown> {
+  return {
+    slot: "task.extra",
+    templateRef: "template://planning/references-index@1",
+    materializeAs: ".",
+    localePolicy: {
+      prefer: "project",
+      fallback: "en-US"
+    }
+  };
+}
+
+function makeMultiProfilePreset(): Record<string, unknown> {
+  return {
+    schema: "preset-manifest/v1",
+    id: "profiled-task",
+    title: "Profiled Task",
+    vertical: "software/coding",
+    version: "1.0.0",
+    kernelVersionRange: {
+      min: "1.0.0",
+      maxExclusive: "2.0.0"
+    },
+    capabilityImports: [],
+    profiles: [
+      {
+        id: "baseline",
+        title: "Baseline",
+        checkerProfile: "standard",
+        templateSelections: []
+      },
+      {
+        id: "extra",
+        title: "Extra",
+        checkerProfile: "standard",
+        templateSelections: [{
+          slot: "task.extra",
+          templateRef: "template://planning/references-index@1",
+          materializeAs: "extra.md",
+          localePolicy: {
+            prefer: "project",
+            fallback: "en-US"
+          }
+        }]
+      }
+    ],
+    defaultProfile: "baseline"
+  };
 }
 
 function validTaskPlan(): string {

--- a/packages/kernel/fixtures/schemas/task-frontmatter/valid.json
+++ b/packages/kernel/fixtures/schemas/task-frontmatter/valid.json
@@ -15,6 +15,7 @@
   "packageDisposition": "active",
   "vertical": "software/coding",
   "preset": "standard-task",
+  "profile": "baseline",
   "createdBy": {
     "name": "Harness User",
     "email": "harness@example.com"

--- a/packages/kernel/schemas/json/task-frontmatter.schema.json
+++ b/packages/kernel/schemas/json/task-frontmatter.schema.json
@@ -91,6 +91,9 @@
     "preset": {
       "type": "string"
     },
+    "profile": {
+      "type": "string"
+    },
     "createdBy": {
       "type": "object",
       "required": [

--- a/packages/kernel/src/domain/extension-model.ts
+++ b/packages/kernel/src/domain/extension-model.ts
@@ -16,6 +16,7 @@ export interface ExtensionValidationIssue {
     | "missing_template"
     | "custom_vertical_forbidden"
     | "duplicate_materialized_path"
+    | "invalid_materialized_path"
     | "preset_required_template_conflict"
     | "preset_path_id_mismatch"
     | "reserved_materialized_path"

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -91,6 +91,7 @@ export const TaskFrontmatterSchema = Schema.Struct({
   packageDisposition: Schema.Literal(...packageDispositions),
   vertical: Schema.String,
   preset: Schema.String,
+  profile: Schema.optional(Schema.String),
   createdBy: Schema.optional(CreatedBySchema)
 });
 


### PR DESCRIPTION
## Summary
- enforce metadata-driven checks for software/coding tasks from frontmatter vertical/preset/profile metadata
- persist selected preset profile in task frontmatter and preserve it through supersede
- fail closed on invalid active preset overrides, missing materialized docs/anchors, unsupported custom vertical metadata, and invalid materialized paths
- update bundled coding templates so generated tasks pass task contract/review checks without dangling task refs

## Review
- Anscombe planning review found P1/P2 gaps around profile persistence, activation predicate, and locale fallback scope; contract and implementation were adjusted.
- Carson code review found P1 invalid materialized path crash/escape and P2 supersede profile loss; both fixed with regressions.

## Verification
- baseline npm test passed before implementation with 182 tests
- targeted: node --test packages/cli/test/check-governance-cli.test.ts packages/cli/test/preset-module-cli.test.ts packages/kernel/test/contracts/extension-model.test.ts
- npm run typecheck
- npm run harness:check-import-boundaries && npm run harness:check-schema-contracts && npm run harness:check-implementation-contracts
- npm run check passed post-review with 190 tests, all harness gates, supply-chain check, retired full-cutover smoke, and CLI package smoke
