### PR TITLE
M2.5 CLI P10: add project settings defaults

### DIFF
--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -7,6 +7,7 @@ import { commandRegistry } from "../cli/command-registry.ts";
 import { relativePath } from "../cli/path.ts";
 import type { CheckProfile, CliResult } from "../cli/types.ts";
 import { isInvalidPreset, materializePresetTaskDocuments, resolvePresetEntry } from "./extensions/state.ts";
+import { readProjectHarnessSettings, settingsIssue, type ProjectHarnessSettings } from "./settings.ts";
 
 const FORCE_STATUS_AUDIT_MARKER = "FORCE_STATUS_SET_AUDIT";
 
@@ -60,10 +61,13 @@ export function runCheckProfile(
 
 function validateCheckProfile(rootDir: string, profile: CheckProfile, strict: boolean): ReadonlyArray<ProfileValidationIssue> {
   const issues: ProfileValidationIssue[] = [];
+  const settingsResult = readProjectHarnessSettings(rootDir, "check");
+  const settings = settingsResult.ok ? settingsResult.settings : undefined;
+  if (!settingsResult.ok) issues.push(settingsIssue(settingsResult));
   if (profile !== "source-package" || strict) {
     const taskDirs = listTaskIndexPaths(rootDir).map((indexPath) => path.dirname(indexPath));
     for (const taskDir of taskDirs) {
-      issues.push(...validateTaskPackageContracts(rootDir, taskDir, profile, strict));
+      issues.push(...validateTaskPackageContracts(rootDir, taskDir, profile, strict, settings));
     }
   }
 
@@ -81,7 +85,7 @@ function checkCommandName(action: { readonly profile: CheckProfile; readonly str
   return `check:${action.profile}`;
 }
 
-function validateTaskPackageContracts(rootDir: string, taskDir: string, profile: CheckProfile, strict: boolean): ReadonlyArray<ProfileValidationIssue> {
+function validateTaskPackageContracts(rootDir: string, taskDir: string, profile: CheckProfile, strict: boolean, settings?: ProjectHarnessSettings): ReadonlyArray<ProfileValidationIssue> {
   const issues: ProfileValidationIssue[] = [];
   const relativeTaskDir = relativePath(rootDir, taskDir);
   const indexPath = path.join(taskDir, "INDEX.md");
@@ -93,7 +97,7 @@ function validateTaskPackageContracts(rootDir: string, taskDir: string, profile:
   }
   const vertical = readScalar(frontmatter, "vertical");
   const metadataDriven = vertical === "software/coding";
-  issues.push(...validateMetadataDrivenTaskPackage(rootDir, taskDir, relativeTaskDir, frontmatter));
+  issues.push(...validateMetadataDrivenTaskPackage(rootDir, taskDir, relativeTaskDir, frontmatter, settings));
 
   const taskPlanPath = path.join(taskDir, "task_plan.md");
   if (!existsSync(taskPlanPath)) {
@@ -170,7 +174,8 @@ function validateMetadataDrivenTaskPackage(
   rootDir: string,
   taskDir: string,
   relativeTaskDir: string,
-  frontmatter: string
+  frontmatter: string,
+  settings?: ProjectHarnessSettings
 ): ReadonlyArray<ProfileValidationIssue> {
   const vertical = readScalar(frontmatter, "vertical");
   const presetId = readScalar(frontmatter, "preset");
@@ -215,7 +220,7 @@ function validateMetadataDrivenTaskPackage(
     ));
   }
 
-  const materialized = materializePresetTaskDocuments(preset.manifest, { profileId: profile, locale: "zh-CN" });
+  const materialized = materializePresetTaskDocuments(preset.manifest, { profileId: profile, locale: settings?.locale ?? "zh-CN" });
   const issues: ProfileValidationIssue[] = [];
   if (!materialized.ok) {
     issues.push(...materialized.issues.map((issue) => profileIssue(

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -16,6 +16,7 @@ import { runDoctor } from "./doctor.ts";
 import { runGitDiffEvidence } from "./git-diff.ts";
 import { runNewTaskFromLegacy } from "./legacy-rebuild.ts";
 import { runNewTaskWithPreset, shouldUsePresetAwareNewTask } from "./preset-task.ts";
+import { readProjectHarnessSettings, shouldUseSettingsPresetAwareNewTask } from "./settings.ts";
 import { runLegacyCopySafeDocs, runLegacyIndex, runLegacyIntakePlan, runLegacyScan, runLegacyVerify, runMigratePlan, runMigrateRun, runMigrateStructure, runMigrateVerify } from "./migration.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
 
@@ -34,8 +35,10 @@ export function runCommand(
     if (action.fromLegacyId) {
       return runNewTaskFromLegacy(command.rootDir, action);
     }
-    if (shouldUsePresetAwareNewTask(action)) {
-      return runNewTaskWithPreset(command.rootDir, action);
+    const settingsResult = readProjectHarnessSettings(command.rootDir, "new-task");
+    if (!settingsResult.ok) return Effect.succeed(settingsResult.result);
+    if (shouldUsePresetAwareNewTask(action) || shouldUseSettingsPresetAwareNewTask(settingsResult.settings)) {
+      return runNewTaskWithPreset(command.rootDir, action, settingsResult.settings);
     }
     const taskId = action.taskId ?? generateTaskId();
     return engine.createTask({
@@ -383,6 +386,13 @@ function initializeHarness(rootDir: string): CliResult {
     "tasks:",
     "  root: harness/planning/tasks",
     "  idPolicy: random-ulid",
+    "settings:",
+    "  locale: zh-CN",
+    "  defaultVertical: software/coding",
+    "  defaultPreset: standard-task",
+    "  defaultProfile: baseline",
+    "  customVerticals:",
+    "    enabled: false",
     ""
   ].join("\n"));
   writeIfMissing(path.join(layout.standardsRoot, "repo-governance.md"), [

--- a/packages/cli/src/commands/preset-task.ts
+++ b/packages/cli/src/commands/preset-task.ts
@@ -9,6 +9,7 @@ import type { EngineError, WriteError } from "../../../kernel/src/domain/index.t
 import { createTaskPackagePath, generateTaskId } from "../../../kernel/src/layout/index.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
 import { isInvalidPreset, materializePresetTaskDocuments, presetNotFound, publicPresetSummary, readModules, resolvePresetEntry } from "./extensions/state.ts";
+import type { ProjectHarnessSettings } from "./settings.ts";
 
 type NewTaskAction = Extract<ParsedCommand["action"], { readonly kind: "new-task" }>;
 
@@ -18,22 +19,23 @@ export function shouldUsePresetAwareNewTask(action: NewTaskAction): boolean {
 
 export function runNewTaskWithPreset(
   rootDir: string,
-  action: NewTaskAction
+  action: NewTaskAction,
+  settings?: ProjectHarnessSettings
 ): Effect.Effect<CliResult, EngineError | WriteError> {
   return Effect.gen(function* () {
-    const vertical = action.vertical ?? "software/coding";
+    const vertical = action.vertical ?? settings?.defaultVertical ?? "software/coding";
     if (vertical !== "software/coding") {
       return {
         ok: false,
         command: "new-task",
         error: {
           code: "custom_vertical_forbidden",
-          hint: "P08 only supports software/coding. Project custom vertical authoring is gated by P10/P11."
+          hint: "P10 only supports software/coding preset-aware task creation. Project custom vertical authoring requires P11 user authorization and remains fail-closed."
         }
       } satisfies CliResult;
     }
 
-    const presetId = action.preset ?? "standard-task";
+    const presetId = action.preset ?? settings?.defaultPreset ?? "standard-task";
     if (presetId === "module" && !action.moduleKey) {
       return {
         ok: false,
@@ -55,8 +57,8 @@ export function runNewTaskWithPreset(
     }
 
     const materialized = materializePresetTaskDocuments(preset.manifest, {
-      profileId: action.profile,
-      locale: "zh-CN"
+      profileId: action.profile ?? settings?.defaultProfile,
+      locale: settings?.locale ?? "zh-CN"
     });
     if (!materialized.ok || !materialized.profile) {
       return {

--- a/packages/cli/src/commands/settings.ts
+++ b/packages/cli/src/commands/settings.ts
@@ -1,0 +1,224 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { resolveHarnessLayout } from "../../../kernel/src/layout/index.ts";
+import type { CliResult } from "../cli/types.ts";
+
+export type HarnessLocale = "zh-CN" | "en-US";
+
+export interface ProjectHarnessSettings {
+  readonly present: boolean;
+  readonly locale?: HarnessLocale;
+  readonly defaultVertical?: string;
+  readonly defaultPreset?: string;
+  readonly defaultProfile?: string;
+  readonly customVerticalsEnabled: boolean;
+}
+
+type SettingsResult =
+  | { readonly ok: true; readonly settings: ProjectHarnessSettings }
+  | { readonly ok: false; readonly result: CliResult };
+
+type RawSettings = Record<string, unknown>;
+
+const EMPTY_SETTINGS: ProjectHarnessSettings = {
+  present: false,
+  customVerticalsEnabled: false
+};
+
+const SETTINGS_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9]*$/u;
+const SETTINGS_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9/_@.-]*$/u;
+
+export function readProjectHarnessSettings(rootDir: string, command = "settings"): SettingsResult {
+  const configPath = path.join(resolveHarnessLayout(rootDir).authoredRoot, "harness.yaml");
+  if (!existsSync(configPath)) return { ok: true, settings: EMPTY_SETTINGS };
+
+  try {
+    const body = readFileSync(configPath, "utf8");
+    const parsed = parseSettingsDocument(body);
+    if (!parsed.present) return { ok: true, settings: EMPTY_SETTINGS };
+    return validateSettings(command, parsed.settings);
+  } catch (error) {
+    return {
+      ok: false,
+      result: settingsError(command, error instanceof Error ? error.message : "Unable to read harness.yaml settings.")
+    };
+  }
+}
+
+export function shouldUseSettingsPresetAwareNewTask(settings: ProjectHarnessSettings): boolean {
+  if (!settings.present) return false;
+  if (settings.defaultVertical && settings.defaultVertical !== "default") return true;
+  if (settings.defaultPreset && settings.defaultPreset !== "default") return true;
+  return false;
+}
+
+export function settingsIssue(result: Extract<SettingsResult, { readonly ok: false }>): {
+  readonly code: string;
+  readonly source: string;
+  readonly severity: "hard-fail";
+  readonly message: string;
+  readonly repairHint: string;
+} {
+  return {
+    source: "harness-settings",
+    code: result.result.error?.code ?? "harness_settings_invalid",
+    severity: "hard-fail",
+    message: result.result.error?.hint ?? "harness/harness.yaml settings are invalid.",
+    repairHint: "Fix harness/harness.yaml settings before running metadata-driven CLI commands."
+  };
+}
+
+function parseSettingsDocument(body: string): { readonly present: boolean; readonly settings: RawSettings } {
+  const trimmed = body.trimStart();
+  if (trimmed.startsWith("{")) {
+    const decoded = JSON.parse(body) as { readonly settings?: RawSettings; readonly project?: { readonly locale?: unknown }; readonly vertical?: { readonly default?: unknown }; readonly presets?: { readonly default?: unknown } };
+    const fromSettings = decoded.settings ?? {};
+    const merged = {
+      locale: fromSettings.locale ?? decoded.project?.locale,
+      defaultVertical: fromSettings.defaultVertical ?? decoded.vertical?.default,
+      defaultPreset: fromSettings.defaultPreset ?? decoded.presets?.default,
+      defaultProfile: fromSettings.defaultProfile,
+      customVerticals: fromSettings.customVerticals
+    };
+    return {
+      present: Boolean(decoded.settings || decoded.project?.locale || decoded.vertical?.default || decoded.presets?.default),
+      settings: merged
+    };
+  }
+
+  return parseYamlSettings(body);
+}
+
+function parseYamlSettings(body: string): { readonly present: boolean; readonly settings: RawSettings } {
+  const lines = body.split(/\r?\n/u);
+  const settings: Record<string, unknown> = {};
+  let inSettings = false;
+  let inCustomVerticals = false;
+  let foundSettings = false;
+
+  for (const rawLine of lines) {
+    const withoutComment = rawLine.replace(/\s+#.*$/u, "");
+    if (!withoutComment.trim()) continue;
+
+    const topLevel = /^([A-Za-z][A-Za-z0-9]*):(?:\s*(.*))?$/u.exec(withoutComment);
+    if (topLevel) {
+      inSettings = topLevel[1] === "settings";
+      inCustomVerticals = false;
+      foundSettings ||= inSettings;
+      if (inSettings && topLevel[2]?.trim()) {
+        throw new Error("settings must be a mapping.");
+      }
+      continue;
+    }
+
+    if (!inSettings) continue;
+
+    const nested = /^  ([A-Za-z][A-Za-z0-9]*):(?:\s*(.*))?$/u.exec(withoutComment);
+    if (nested) {
+      const [, key, rawValue = ""] = nested;
+      if (!SETTINGS_KEY_PATTERN.test(key)) throw new Error(`Invalid settings key: ${key}`);
+      const value = rawValue.trim();
+      inCustomVerticals = key === "customVerticals";
+      if (inCustomVerticals) {
+        if (value) throw new Error("settings.customVerticals must be a mapping.");
+        settings.customVerticals = {};
+        continue;
+      }
+      if (!isKnownSettingsScalar(key)) throw new Error(`Unknown settings key: ${key}`);
+      if (!value) throw new Error(`settings.${key} must be a scalar value.`);
+      settings[key] = unquoteScalar(value);
+      continue;
+    }
+
+    const customNested = /^    ([A-Za-z][A-Za-z0-9]*):(?:\s*(.*))?$/u.exec(withoutComment);
+    if (inCustomVerticals && customNested) {
+      const [, key, rawValue = ""] = customNested;
+      if (key !== "enabled") throw new Error(`Unknown settings.customVerticals key: ${key}`);
+      const value = rawValue.trim();
+      if (value !== "true" && value !== "false") throw new Error("settings.customVerticals.enabled must be true or false.");
+      settings.customVerticals = { enabled: value === "true" };
+      continue;
+    }
+
+    throw new Error(`Unsupported settings YAML line: ${withoutComment.trim()}`);
+  }
+
+  return { present: foundSettings, settings };
+}
+
+function validateSettings(command: string, raw: RawSettings): SettingsResult {
+  const locale = raw.locale;
+  if (locale !== undefined && locale !== "zh-CN" && locale !== "en-US") {
+    return invalid(command, "settings.locale must be zh-CN or en-US.");
+  }
+  const defaultVertical = validateOptionalId("settings.defaultVertical", raw.defaultVertical);
+  if (!defaultVertical.ok) return invalid(command, defaultVertical.message);
+  const defaultPreset = validateOptionalId("settings.defaultPreset", raw.defaultPreset);
+  if (!defaultPreset.ok) return invalid(command, defaultPreset.message);
+  const defaultProfile = validateOptionalId("settings.defaultProfile", raw.defaultProfile);
+  if (!defaultProfile.ok) return invalid(command, defaultProfile.message);
+  const customVerticals = raw.customVerticals;
+  if (customVerticals !== undefined) {
+    if (!isRecord(customVerticals)) {
+      return invalid(command, "settings.customVerticals must be a mapping.");
+    }
+    const keys = Object.keys(customVerticals);
+    if (keys.length !== 1 || keys[0] !== "enabled" || typeof customVerticals.enabled !== "boolean") {
+      return invalid(command, "settings.customVerticals.enabled must be a boolean.");
+    }
+  }
+
+  return {
+    ok: true,
+    settings: {
+      present: true,
+      locale,
+      defaultVertical: normalizeDefaultSentinel(defaultVertical.value),
+      defaultPreset: normalizeDefaultSentinel(defaultPreset.value),
+      defaultProfile: normalizeDefaultSentinel(defaultProfile.value),
+      customVerticalsEnabled: isRecord(customVerticals) ? customVerticals.enabled === true : false
+    }
+  };
+}
+
+function validateOptionalId(name: string, value: unknown): { readonly ok: true; readonly value?: string } | { readonly ok: false; readonly message: string } {
+  if (value === undefined) return { ok: true };
+  if (typeof value !== "string" || !SETTINGS_ID_PATTERN.test(value)) {
+    return { ok: false, message: `${name} must be a non-empty identifier.` };
+  }
+  return { ok: true, value };
+}
+
+function invalid(command: string, message: string): SettingsResult {
+  return { ok: false, result: settingsError(command, message) };
+}
+
+function settingsError(command: string, hint: string): CliResult {
+  return {
+    ok: false,
+    command,
+    error: {
+      code: "harness_settings_invalid",
+      hint
+    }
+  };
+}
+
+function isKnownSettingsScalar(key: string): boolean {
+  return key === "locale" || key === "defaultVertical" || key === "defaultPreset" || key === "defaultProfile";
+}
+
+function normalizeDefaultSentinel(value: string | undefined): string | undefined {
+  return value === "default" ? undefined : value;
+}
+
+function unquoteScalar(value: string): string {
+  if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/cli/test/local-lifecycle-cli.test.ts
+++ b/packages/cli/test/local-lifecycle-cli.test.ts
@@ -14,10 +14,34 @@ test("CLI init creates shared authored harness and ignored local state root", ()
 
     assert.equal(result.ok, true);
     assert.equal(result.path, "harness/harness.yaml");
-    assert.match(readFileSync(path.join(rootDir, "harness/harness.yaml"), "utf8"), /idPolicy: random-ulid/);
+    const config = readFileSync(path.join(rootDir, "harness/harness.yaml"), "utf8");
+    assert.match(config, /idPolicy: random-ulid/);
+    assert.match(config, /defaultVertical: software\/coding/);
+    assert.match(config, /defaultPreset: standard-task/);
+    assert.match(config, /defaultProfile: baseline/);
+    assert.match(config, /locale: zh-CN/);
     assert.match(readFileSync(path.join(rootDir, "AGENTS.md"), "utf8"), /harness\/harness.yaml/);
     assert.match(readFileSync(path.join(rootDir, ".gitignore"), "utf8"), /^\.harness\/$/m);
     assert.equal(existsSync(path.join(rootDir, "harness/legacy")), false);
+  });
+});
+
+test("CLI init dogfoods coding vertical defaults for new tasks", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+
+    const result = runJson(rootDir, ["new-task", "--title", "Dogfood Task"]);
+    const taskId = assertGeneratedTaskId(result.taskId);
+    const index = readFileSync(path.join(rootDir, `harness/planning/tasks/${taskId}-dogfood-task/INDEX.md`), "utf8");
+
+    assert.equal(result.ok, true);
+    assert.equal(result.report.vertical, "software/coding");
+    assert.equal(result.report.preset, "standard-task");
+    assert.equal(result.report.profile, "baseline");
+    assert.equal(result.generated.includes("task_plan.md"), true);
+    assert.match(index, /vertical: software\/coding/);
+    assert.match(index, /preset: standard-task/);
+    assert.match(index, /profile: baseline/);
   });
 });
 

--- a/packages/cli/test/preset-module-cli.test.ts
+++ b/packages/cli/test/preset-module-cli.test.ts
@@ -105,6 +105,132 @@ test("CLI new-task wires explicit coding vertical preset and module without rela
   });
 });
 
+test("CLI new-task uses project settings defaults and explicit flag precedence", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    runJson(rootDir, ["module", "register", "billing", "--title", "Billing", "--scope", "packages/billing/**"]);
+
+    const defaulted = runJson(rootDir, ["new-task", "--title", "Default Coding Task"]);
+    assert.equal(defaulted.report.vertical, "software/coding");
+    assert.equal(defaulted.report.preset, "standard-task");
+    assert.equal(defaulted.report.profile, "baseline");
+
+    const moduleTask = runJson(rootDir, ["new-task", "--title", "Module Override", "--preset", "module", "--module", "billing"]);
+    assert.equal(moduleTask.report.vertical, "software/coding");
+    assert.equal(moduleTask.report.preset, "module");
+    assert.equal(moduleTask.module.key, "billing");
+
+    writeRawPreset(rootDir, ".harness/presets/profiled-task/preset.json", makeProfiledPreset());
+    const profiled = runJson(rootDir, ["new-task", "--title", "Profile Override", "--preset", "profiled-task", "--profile", "extra"]);
+    assert.equal(profiled.report.profile, "extra");
+    assert.equal(profiled.generated.includes("extra.md"), true);
+  });
+});
+
+test("CLI new-task keeps inert settings generic and legacy rebuild isolated", () => {
+  withTempRoot((rootDir) => {
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  locale: zh-CN",
+      "  defaultVertical: default",
+      "  defaultPreset: default",
+      "  defaultProfile: baseline",
+      "  customVerticals:",
+      "    enabled: false",
+      ""
+    ]);
+
+    const generic = runJson(rootDir, ["new-task", "--title", "Generic Task"]);
+    assert.equal(generic.report, undefined);
+    assert.match(readFileSync(path.join(rootDir, generic.packagePath, "INDEX.md"), "utf8"), /vertical: default/);
+
+    const explicitVertical = runJson(rootDir, ["new-task", "--title", "Explicit Vertical", "--vertical", "software/coding"]);
+    assert.equal(explicitVertical.report.vertical, "software/coding");
+    assert.equal(explicitVertical.report.preset, "standard-task");
+
+    const explicitPreset = runJson(rootDir, ["new-task", "--title", "Explicit Preset", "--preset", "standard-task"]);
+    assert.equal(explicitPreset.report.vertical, "software/coding");
+    assert.equal(explicitPreset.report.preset, "standard-task");
+
+    const legacy = runJson(rootDir, ["new-task", "--from-legacy", "legacy-1"], false);
+    assert.equal(legacy.error.code, "legacy_index_missing");
+  });
+});
+
+test("CLI settings fail closed for malformed and unsupported custom vertical defaults", () => {
+  withTempRoot((rootDir) => {
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  locale: fr-FR",
+      "  defaultVertical: software/coding",
+      "  defaultPreset: standard-task",
+      ""
+    ]);
+
+    const malformed = runJson(rootDir, ["new-task", "--title", "Bad Settings"], false);
+    assert.equal(malformed.error.code, "harness_settings_invalid");
+    assert.equal(malformed.command, "new-task");
+  });
+
+  withTempRoot((rootDir) => {
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  locale: zh-CN",
+      "  defaultVertical: software/coding",
+      "  defaultPreset: standard-task",
+      "  customVerticals:",
+      ""
+    ]);
+
+    const malformed = runJson(rootDir, ["new-task", "--title", "Missing Gate"], false);
+    assert.equal(malformed.error.code, "harness_settings_invalid");
+  });
+
+  withTempRoot((rootDir) => {
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  locale: zh-CN",
+      "  defaultVertical: custom/acme",
+      "  defaultPreset: standard-task",
+      "  defaultProfile: baseline",
+      "  customVerticals:",
+      "    enabled: true",
+      ""
+    ]);
+
+    const custom = runJson(rootDir, ["new-task", "--title", "Custom Vertical"], false);
+    assert.equal(custom.error.code, "custom_vertical_forbidden");
+  });
+});
+
+test("CLI settings locale controls bundled materialization and metadata check", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  locale: en-US",
+      "  defaultVertical: software/coding",
+      "  defaultPreset: standard-task",
+      "  defaultProfile: baseline",
+      "  customVerticals:",
+      "    enabled: false",
+      ""
+    ]);
+
+    const created = runJson(rootDir, ["new-task", "--title", "English Task"]);
+    const taskPlan = readFileSync(path.join(rootDir, created.packagePath, "task_plan.md"), "utf8");
+    assert.match(taskPlan, /Describe the verifiable result/);
+
+    const checked = runJson(rootDir, ["check", "--profile", "target-project", "--strict"]);
+    assert.equal(checked.ok, true);
+  });
+});
+
 test("CLI new-task fails closed on ambiguous preset and legacy/module input", () => {
   withTempRoot((rootDir) => {
     const missingModule = runJson(rootDir, ["new-task", "--title", "Module Task", "--vertical", "software/coding", "--preset", "module"], false);
@@ -394,6 +520,18 @@ function writePreset(rootDir: string, relativePath: string, overrides: {
   writeFileSync(filePath, JSON.stringify(makePreset(overrides), null, 2), "utf8");
 }
 
+function writeRawPreset(rootDir: string, relativePath: string, manifest: Record<string, unknown>): void {
+  const filePath = path.join(rootDir, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(manifest, null, 2), "utf8");
+}
+
+function writeHarnessConfig(rootDir: string, lines: ReadonlyArray<string>): void {
+  const filePath = path.join(rootDir, "harness/harness.yaml");
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, lines.join("\n"), "utf8");
+}
+
 function makePreset(overrides: {
   readonly id: string;
   readonly title: string;
@@ -417,6 +555,44 @@ function makePreset(overrides: {
       checkerProfile: "standard",
       templateSelections: overrides.templateSelections ?? []
     }],
+    defaultProfile: "baseline"
+  };
+}
+
+function makeProfiledPreset(): Record<string, unknown> {
+  return {
+    schema: "preset-manifest/v1",
+    id: "profiled-task",
+    title: "Profiled Task",
+    vertical: "software/coding",
+    version: "1.0.0",
+    kernelVersionRange: {
+      min: "1.0.0",
+      maxExclusive: "2.0.0"
+    },
+    capabilityImports: [],
+    profiles: [
+      {
+        id: "baseline",
+        title: "Baseline",
+        checkerProfile: "standard",
+        templateSelections: []
+      },
+      {
+        id: "extra",
+        title: "Extra",
+        checkerProfile: "standard",
+        templateSelections: [{
+          slot: "task.extra",
+          templateRef: "template://planning/references-index@1",
+          materializeAs: "extra.md",
+          localePolicy: {
+            prefer: "project",
+            fallback: "en-US"
+          }
+        }]
+      }
+    ],
     defaultProfile: "baseline"
   };
 }

--- a/packages/kernel/fixtures/schemas/harness-config/valid.json
+++ b/packages/kernel/fixtures/schemas/harness-config/valid.json
@@ -24,6 +24,15 @@
   "presets": {
     "default": "standard-task"
   },
+  "settings": {
+    "locale": "zh-CN",
+    "defaultVertical": "software/coding",
+    "defaultPreset": "standard-task",
+    "defaultProfile": "baseline",
+    "customVerticals": {
+      "enabled": false
+    }
+  },
   "storage": {
     "markdownRoot": "coding-agent-harness",
     "sqlitePath": ".harness/cache/projections.sqlite",

--- a/packages/kernel/schemas/json/harness-config.schema.json
+++ b/packages/kernel/schemas/json/harness-config.schema.json
@@ -11,6 +11,24 @@
     "lifecycle": { "type": "object" },
     "vertical": { "type": "object" },
     "presets": { "type": "object" },
+    "settings": {
+      "type": "object",
+      "properties": {
+        "locale": { "enum": ["zh-CN", "en-US"] },
+        "defaultVertical": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9/_@.-]*$" },
+        "defaultPreset": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9/_@.-]*$" },
+        "defaultProfile": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9/_@.-]*$" },
+        "customVerticals": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "storage": { "type": "object" }
   }
 }

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -20,6 +20,7 @@ const LegacyRootSchema = Schema.Literal("harness/legacy");
 const LegacyPathSchema = Schema.String.pipe(Schema.pattern(/^harness\/legacy\/(?!.*(?:^|\/)\.\.(?:\/|$))(?!.*\/\/)(?!.*\\).+$/u));
 const LegacyConfidenceSchema = Schema.Literal("high", "medium", "low");
 const StrictSha256Schema = Schema.String.pipe(Schema.pattern(/^sha256:[a-f0-9]{64}$/u));
+const ConfigIdentifierSchema = Schema.String.pipe(Schema.pattern(/^[A-Za-z0-9][A-Za-z0-9/_@.-]*$/u));
 
 export const ActorRefSchema = Schema.Struct({
   kind: ActorKindSchema,
@@ -50,6 +51,15 @@ export const HarnessConfigSchema = Schema.Struct({
   presets: Schema.Struct({
     default: Schema.String
   }),
+  settings: Schema.optional(Schema.Struct({
+    locale: Schema.optional(LocaleSchema),
+    defaultVertical: Schema.optional(ConfigIdentifierSchema),
+    defaultPreset: Schema.optional(ConfigIdentifierSchema),
+    defaultProfile: Schema.optional(ConfigIdentifierSchema),
+    customVerticals: Schema.optional(Schema.Struct({
+      enabled: Schema.Boolean
+    }))
+  })),
   storage: Schema.Struct({
     markdownRoot: Schema.String,
     sqlitePath: Schema.String,

--- a/tools/smoke-cli-package.mjs
+++ b/tools/smoke-cli-package.mjs
@@ -56,7 +56,7 @@ try {
   }
 
   const created = runJson(binPath, ["--json", "new-task", "--title", "Smoke Task"], projectDir);
-  if (created.ok !== true || typeof created.taskId !== "string" || !created.taskId.startsWith("task_")) {
+  if (created.ok !== true || typeof created.taskId !== "string" || !created.taskId.startsWith("task_") || created.report?.vertical !== "software/coding" || created.report?.preset !== "standard-task") {
     throw new Error(`unexpected new-task smoke output: ${JSON.stringify(created)}`);
   }
 


### PR DESCRIPTION
## Summary

- Add a public `harness/harness.yaml` settings reader for CLI project defaults.
- Make new `harness init` projects dogfood `software/coding` + `standard-task` + `baseline` + `zh-CN` by default.
- Route `new-task --title` through preset-aware creation when real dogfood settings are present, while preserving generic task creation for repos without settings or inert `default/default` settings.
- Keep explicit `--vertical`, `--preset`, and `--profile` higher precedence than settings.
- Keep `new-task --from-legacy` isolated from settings-driven preset creation.
- Keep custom vertical defaults fail-closed in P10 even when `customVerticals.enabled: true`.
- Use configured locale for bundled metadata materialization/check.

## Review Notes

- Reviewer found a P1 inert `default/default` leak and a P2 `customVerticals.enabled` parity gap.
- Both were fixed with regressions.
- Re-review confirmed no P0/P1/P2 remain.

## Verification

- `node --test packages/cli/test/preset-module-cli.test.ts packages/cli/test/local-lifecycle-cli.test.ts` passed with 47 tests.
- `npm test` passed with 195 tests.
- `npm run check` passed, including typecheck, 195 tests, file complexity, import boundaries, forbidden symbols, private boundary, package policy, implementation contracts, schema contracts, cutover readiness, supply-chain check, retired full-cutover smoke, and CLI package smoke.
