### PR TITLE
P13: Replace full-cutover gates with Legacy Intake checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,7 +39,7 @@
 - [ ] `npm run harness:check-package-policy`
 - [ ] `npm run harness:check-implementation-contracts`
 - [ ] `npm run harness:check-schema-contracts`
-- [ ] `npm run harness:check-cutover-readiness`
+- [ ] `npm run harness:check-legacy-intake-readiness`
 - [ ] `npm run harness:smoke-cli-package`
 - [ ] GitHub Actions `rewrite-ci` passed
 - Not run: [command and reason]
@@ -115,7 +115,7 @@
 - [ ] `npm run harness:check-package-policy`
 - [ ] `npm run harness:check-implementation-contracts`
 - [ ] `npm run harness:check-schema-contracts`
-- [ ] `npm run harness:check-cutover-readiness`
+- [ ] `npm run harness:check-legacy-intake-readiness`
 - [ ] `npm run harness:smoke-cli-package`
 - [ ] GitHub Actions `rewrite-ci` passed
 - 未运行：[命令和原因]

--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -72,7 +72,7 @@ jobs:
       - run: npm run harness:check-private-boundary
       - run: npm run harness:check-implementation-contracts
       - run: npm run harness:check-schema-contracts
-      - run: npm run harness:check-cutover-readiness
+      - run: npm run harness:check-legacy-intake-readiness
 
   package-policy:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ repository.
 
 ## Project status
 
-M2 final-cutover evidence is complete for this repository workflow.
+M2 Legacy Intake readiness evidence is complete for this repository workflow.
 
 Current release boundary:
 
@@ -161,8 +161,8 @@ Expect breaking changes while the public package surface stabilizes.
 **M2 - coding vertical cutover**
 
 - [x] Kernel, CLI, package layout, governance checks, behavior corpus, and
-  final-cutover evidence.
-- [x] Local smoke coverage for the full cutover and private CLI package
+  Legacy Intake readiness evidence.
+- [x] Local smoke coverage for the Legacy Intake and private CLI package
   artifact.
 - [ ] npm package publication.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,7 +55,7 @@ Harness Anything 围绕一个小内核和明确的扩展层组织。
 
 - 一个 local-first 的 coding-agent 任务 harness。
 - 一个 TypeScript monorepo，包含 kernel、CLI、GUI、application 和 adapter 包。
-- 一套治理表面，用于检查任务包、文件复杂度、import 边界、private/public 边界、schema 契约和 cutover readiness。
+- 一套治理表面，用于检查任务包、文件复杂度、import 边界、private/public 边界、schema 契约和 Legacy Intake readiness。
 - 面向公开 Harness 产品表面的 clean-room rewrite workspace。
 
 ## 这不是什么
@@ -113,7 +113,7 @@ Private planning、architecture、review state 和 task ledger 位于 public doc
 
 ## 项目状态
 
-这个仓库工作流的 M2 final-cutover evidence 已完成。
+这个仓库工作流的 M2 Legacy Intake readiness evidence 已完成。
 
 当前 release 边界：
 
@@ -128,8 +128,8 @@ Private planning、architecture、review state 和 task ledger 位于 public doc
 
 **M2 - coding vertical cutover**
 
-- [x] Kernel、CLI、package layout、governance checks、behavior corpus 和 final-cutover evidence。
-- [x] Full cutover 和 private CLI package artifact 的本地 smoke 覆盖。
+- [x] Kernel、CLI、package layout、governance checks、behavior corpus 和 Legacy Intake readiness evidence。
+- [x] Legacy Intake 和 private CLI package artifact 的本地 smoke 覆盖。
 - [ ] npm package publication。
 
 **Next**

--- a/docs-release/m2-coding-vertical.md
+++ b/docs-release/m2-coding-vertical.md
@@ -112,17 +112,22 @@ M2-P7 used `migrate-verify --full-cutover` as historical completion evidence.
 That strategy is now deprecated. Future work should not use full cutover as an
 exit gate or dogfood prerequisite.
 
-Historical M2 checks were:
+Historical M2 evidence used the now-retired full-cutover flag:
 
 ```bash
 harness migrate-run --json
 harness migrate-verify <session.json> --full-cutover --json
-npm run harness:check-cutover-readiness
-npm run harness:smoke-full-cutover
+```
+
+Current M2.5 replacements are:
+
+```bash
+npm run harness:check-legacy-intake-readiness
+npm run harness:smoke-legacy-intake
 npm run check
 ```
 
-M2.5 will replace these with Legacy Intake readiness and smoke checks.
+M2.5 replaces the active gate names with Legacy Intake readiness and smoke checks.
 
 Package release decision:
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "packages/adapters/*"
   ],
   "scripts": {
-    "check": "npm run typecheck && npm test && npm run harness:check-file-complexity && npm run harness:check-cli-structure && npm run harness:check-import-boundaries && npm run harness:scan-forbidden-symbols && npm run harness:check-private-boundary && npm run harness:check-package-policy && npm run harness:check-implementation-contracts && npm run harness:check-schema-contracts && npm run harness:check-cutover-readiness && npm run harness:check-supply-chain && npm run harness:smoke-full-cutover && npm run harness:smoke-cli-package",
+    "check": "npm run typecheck && npm test && npm run harness:check-file-complexity && npm run harness:check-cli-structure && npm run harness:check-import-boundaries && npm run harness:scan-forbidden-symbols && npm run harness:check-private-boundary && npm run harness:check-package-policy && npm run harness:check-implementation-contracts && npm run harness:check-schema-contracts && npm run harness:check-legacy-intake-readiness && npm run harness:check-supply-chain && npm run harness:smoke-legacy-intake && npm run harness:smoke-cli-package",
     "typecheck": "tsc -b --pretty false",
     "test": "node tools/run-node-tests.mjs",
     "harness:check-file-complexity": "node tools/check-file-complexity.mjs",
@@ -21,9 +21,9 @@
     "harness:check-package-policy": "node tools/check-package-policy.mjs",
     "harness:check-implementation-contracts": "node tools/check-implementation-contracts.mjs",
     "harness:check-schema-contracts": "node tools/check-schema-contracts.mjs",
-    "harness:check-cutover-readiness": "node tools/check-cutover-readiness.mjs",
+    "harness:check-legacy-intake-readiness": "node tools/check-legacy-intake-readiness.mjs",
     "harness:check-supply-chain": "node tools/check-supply-chain.mjs",
-    "harness:smoke-full-cutover": "node tools/smoke-full-cutover.mjs",
+    "harness:smoke-legacy-intake": "node tools/smoke-legacy-intake.mjs",
     "harness:smoke-cli-package": "node tools/smoke-cli-package.mjs"
   },
   "engines": {

--- a/packages/cli/src/commands/legacy-intake-readiness.ts
+++ b/packages/cli/src/commands/legacy-intake-readiness.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
-export interface FullCutoverEvidence {
-  readonly schema: "harness-full-cutover-evidence/v1";
+export interface LegacyIntakeReadinessEvidence {
+  readonly schema: "harness-legacy-intake-readiness-evidence/v1";
   readonly ok: boolean;
   readonly packageReleaseDecision: {
     readonly publishState: "not-published";
@@ -20,13 +20,13 @@ export interface FullCutoverEvidence {
 
 const minBehaviorCorpusItems = 15;
 
-export function evaluateFullCutoverEvidence(rootDir: string): FullCutoverEvidence {
+export function evaluateLegacyIntakeReadinessEvidence(rootDir: string): LegacyIntakeReadinessEvidence {
   const violations: string[] = [];
   checkPackageDecision(rootDir, violations);
   const behaviorCorpus = checkBehaviorCorpus(rootDir, violations);
 
   return {
-    schema: "harness-full-cutover-evidence/v1",
+    schema: "harness-legacy-intake-readiness-evidence/v1",
     ok: violations.length === 0,
     packageReleaseDecision: {
       publishState: "not-published",
@@ -53,7 +53,7 @@ function checkPackageDecision(rootDir: string, violations: string[]): void {
 
   for (const packagePath of packages) {
     const json = readJsonObject(rootDir, packagePath, violations);
-    if (json.private !== true) violations.push(`${packagePath}: package must remain private for M2 final cutover`);
+    if (json.private !== true) violations.push(`${packagePath}: package must remain private for M2 Legacy Intake readiness`);
     if (packagePath !== "package.json" && json.version !== "0.0.0") {
       violations.push(`${packagePath}: version must remain 0.0.0 before publish planning`);
     }
@@ -71,9 +71,9 @@ function checkPackageDecision(rootDir: string, violations: string[]): void {
   }
 }
 
-function checkBehaviorCorpus(rootDir: string, violations: string[]): FullCutoverEvidence["behaviorCorpus"] {
-  const dataPath = "tools/cutover/behavior-corpus-classification.json";
-  const reportPath = "tools/cutover/behavior-corpus-classification.md";
+function checkBehaviorCorpus(rootDir: string, violations: string[]): LegacyIntakeReadinessEvidence["behaviorCorpus"] {
+  const dataPath = "tools/legacy-intake/behavior-corpus-classification.json";
+  const reportPath = "tools/legacy-intake/behavior-corpus-classification.md";
   const dataFullPath = path.join(rootDir, dataPath);
   const reportFullPath = path.join(rootDir, reportPath);
 
@@ -89,7 +89,7 @@ function checkBehaviorCorpus(rootDir: string, violations: string[]): FullCutover
   const needsDecision = categories["needs-decision"] ?? -1;
 
   if (data.publishState !== "not-published") {
-    violations.push(`${dataPath}: publishState must remain not-published for M2 final cutover`);
+    violations.push(`${dataPath}: publishState must remain not-published for M2 Legacy Intake readiness`);
   }
   for (const category of ["preserve", "intentional-change", "old-bug", "unsupported-input", "needs-decision"]) {
     if (!Number.isInteger(categories[category]) || categories[category] < 0) {
@@ -121,7 +121,7 @@ function checkBehaviorCorpus(rootDir: string, violations: string[]): FullCutover
 function readJsonObject(rootDir: string, relativePath: string, violations: string[]): Record<string, unknown> {
   const fullPath = path.join(rootDir, relativePath);
   if (!existsSync(fullPath)) {
-    violations.push(`${relativePath}: missing required full-cutover evidence file`);
+    violations.push(`${relativePath}: missing required Legacy Intake readiness evidence file`);
     return {};
   }
   try {

--- a/tools/check-legacy-intake-readiness.mjs
+++ b/tools/check-legacy-intake-readiness.mjs
@@ -31,9 +31,15 @@ const publicCompatibilityPatterns = [
   /\bautomatic migration\b/u,
   /\bauto-migration\b/u
 ];
+const retiredPackageScriptGatePatterns = [
+  /\bcheck-cutover-readiness\b/u,
+  /\bsmoke-full-cutover\b/u,
+  /\bcutover-readiness\b/u,
+  /\bfull-cutover\b/u
+];
 const minBehaviorCorpusItems = 15;
 
-export async function evaluateCutoverReadiness(root = process.cwd()) {
+export async function evaluateLegacyIntakeReadiness(root = process.cwd()) {
   const violations = [];
 
   checkPackageSurface(root, violations);
@@ -52,6 +58,7 @@ function checkPackageSurface(root, violations) {
   if (rootPackage.private !== true) {
     violations.push("package.json: root package must stay private until explicit publish approval");
   }
+  checkRootPackageScripts(rootPackage, violations);
 
   const cliPackage = readJson(root, "packages/cli/package.json");
   if (cliPackage.name !== "@harness-anything/cli") {
@@ -74,6 +81,20 @@ function checkPackageSurface(root, violations) {
   }
   if (cliPackage.publishConfig) {
     violations.push("packages/cli/package.json: publishConfig is not allowed before explicit publish approval");
+  }
+}
+
+function checkRootPackageScripts(rootPackage, violations) {
+  const scripts = rootPackage.scripts;
+  if (!scripts || typeof scripts !== "object") return;
+  for (const [name, command] of Object.entries(scripts)) {
+    const scriptText = `${name} ${String(command)}`;
+    for (const pattern of retiredPackageScriptGatePatterns) {
+      if (pattern.test(scriptText)) {
+        violations.push(`package.json: script ${name} exposes retired full-cutover/cutover readiness gate name`);
+        break;
+      }
+    }
   }
 }
 
@@ -127,20 +148,20 @@ async function checkPublicText(root, violations) {
 }
 
 function checkBehaviorCorpusReport(root, violations) {
-  const dataPath = path.join(root, "tools/cutover/behavior-corpus-classification.json");
+  const dataPath = path.join(root, "tools/legacy-intake/behavior-corpus-classification.json");
   if (!existsSync(dataPath)) {
-    violations.push("tools/cutover/behavior-corpus-classification.json: missing machine-checkable behavior corpus classification input");
+    violations.push("tools/legacy-intake/behavior-corpus-classification.json: missing machine-checkable behavior corpus classification input");
     return;
   }
   const data = JSON.parse(readFileSync(dataPath, "utf8"));
   const categories = data?.categories;
   if (!categories || typeof categories !== "object") {
-    violations.push("tools/cutover/behavior-corpus-classification.json: missing categories object");
+    violations.push("tools/legacy-intake/behavior-corpus-classification.json: missing categories object");
     return;
   }
   for (const required of ["preserve", "intentional-change", "old-bug", "unsupported-input", "needs-decision"]) {
     if (!Number.isInteger(categories[required]) || categories[required] < 0) {
-      violations.push(`tools/cutover/behavior-corpus-classification.json: missing non-negative integer category ${required}`);
+      violations.push(`tools/legacy-intake/behavior-corpus-classification.json: missing non-negative integer category ${required}`);
     }
   }
   if (Array.isArray(data?.items)) {
@@ -149,50 +170,50 @@ function checkBehaviorCorpusReport(root, violations) {
       if (typeof item?.classification === "string" && item.classification in actualCounts) {
         actualCounts[item.classification] += 1;
       } else {
-        violations.push("tools/cutover/behavior-corpus-classification.json: item has unknown classification");
+        violations.push("tools/legacy-intake/behavior-corpus-classification.json: item has unknown classification");
       }
     }
     for (const [category, expectedCount] of Object.entries(categories)) {
       if (actualCounts[category] !== expectedCount) {
-        violations.push(`tools/cutover/behavior-corpus-classification.json: category ${category} count ${expectedCount} does not match ${actualCounts[category]} item(s)`);
+        violations.push(`tools/legacy-intake/behavior-corpus-classification.json: category ${category} count ${expectedCount} does not match ${actualCounts[category]} item(s)`);
       }
     }
     if (data.items.length < minBehaviorCorpusItems) {
-      violations.push(`tools/cutover/behavior-corpus-classification.json: behavior corpus must include at least ${minBehaviorCorpusItems} classified items`);
+      violations.push(`tools/legacy-intake/behavior-corpus-classification.json: behavior corpus must include at least ${minBehaviorCorpusItems} classified items`);
     }
   } else {
-    violations.push("tools/cutover/behavior-corpus-classification.json: missing items array");
+    violations.push("tools/legacy-intake/behavior-corpus-classification.json: missing items array");
   }
   if (categories["needs-decision"] !== 0) {
-    violations.push("tools/cutover/behavior-corpus-classification.json: unresolved needs-decision differences remain");
+    violations.push("tools/legacy-intake/behavior-corpus-classification.json: unresolved needs-decision differences remain");
   }
 
-  const reportPath = path.join(root, "tools/cutover/behavior-corpus-classification.md");
+  const reportPath = path.join(root, "tools/legacy-intake/behavior-corpus-classification.md");
   if (!existsSync(reportPath)) {
-    violations.push("tools/cutover/behavior-corpus-classification.md: missing behavior corpus classification report");
+    violations.push("tools/legacy-intake/behavior-corpus-classification.md: missing behavior corpus classification report");
     return;
   }
 
   const text = readFileSync(reportPath, "utf8");
   if (!text.includes("behavior-corpus-classification.json")) {
-    violations.push("tools/cutover/behavior-corpus-classification.md: report must reference machine-checkable JSON input");
+    violations.push("tools/legacy-intake/behavior-corpus-classification.md: report must reference machine-checkable JSON input");
   }
   for (const required of ["preserve", "intentional-change", "old-bug", "unsupported-input"]) {
     if (!text.includes(required)) {
-      violations.push(`tools/cutover/behavior-corpus-classification.md: missing ${required} classification category`);
+      violations.push(`tools/legacy-intake/behavior-corpus-classification.md: missing ${required} classification category`);
     }
   }
   for (const [category, expectedCount] of Object.entries(categories)) {
     const row = text.split(/\r?\n/u).find((line) => new RegExp(`^\\|\\s*${escapeRegExp(category)}\\s*\\|`, "u").test(line));
     const markdownCount = row?.split("|")[2]?.trim();
     if (markdownCount !== String(expectedCount)) {
-      violations.push(`tools/cutover/behavior-corpus-classification.md: Markdown category ${category} count must match JSON count ${expectedCount}`);
+      violations.push(`tools/legacy-intake/behavior-corpus-classification.md: Markdown category ${category} count must match JSON count ${expectedCount}`);
     }
   }
   const needsDecisionLine = text.split(/\r?\n/u).find((line) => /^\|\s*needs-decision\s*\|/u.test(line));
   const needsDecisionCount = needsDecisionLine?.split("|")[2]?.trim();
   if (needsDecisionCount !== "0") {
-    violations.push("tools/cutover/behavior-corpus-classification.md: unresolved needs-decision differences remain");
+    violations.push("tools/legacy-intake/behavior-corpus-classification.md: unresolved needs-decision differences remain");
   }
 }
 
@@ -265,11 +286,11 @@ function escapeRegExp(input) {
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  const violations = await evaluateCutoverReadiness();
+  const violations = await evaluateLegacyIntakeReadiness();
   if (violations.length > 0) {
-    console.error("Cutover readiness check failed:");
+    console.error("Legacy Intake readiness check failed:");
     for (const violation of violations) console.error(`- ${violation}`);
     process.exit(1);
   }
-  console.log("Cutover readiness check passed.");
+  console.log("Legacy Intake readiness check passed.");
 }

--- a/tools/check-legacy-intake-readiness.test.mjs
+++ b/tools/check-legacy-intake-readiness.test.mjs
@@ -4,31 +4,31 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { evaluateCutoverReadiness } from "./check-cutover-readiness.mjs";
+import { evaluateLegacyIntakeReadiness } from "./check-legacy-intake-readiness.mjs";
 
-test("cutover readiness rejects old runtime production references", async () => {
+test("Legacy Intake readiness rejects old runtime production references", async () => {
   await withFixtureRepo(async (root) => {
     writeFileSync(path.join(root, "packages/kernel/src/index.ts"), "export const oldPath = 'scripts/kernel/task';\n");
 
-    const violations = await evaluateCutoverReadiness(root);
+    const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.equal(violations.some((violation) => violation.includes("retired old runtime")), true);
   });
 });
 
-test("cutover readiness allows old runtime references in tests and behavior report", async () => {
+test("Legacy Intake readiness allows old runtime references in tests and behavior report", async () => {
   await withFixtureRepo(async (root) => {
     mkdirSync(path.join(root, "packages/kernel/test"), { recursive: true });
     writeFileSync(path.join(root, "packages/kernel/src/index.ts"), "export const ok = true;\n");
     writeFileSync(path.join(root, "packages/kernel/test/legacy.test.ts"), "const oldPath = 'scripts/kernel/task';\n");
 
-    const violations = await evaluateCutoverReadiness(root);
+    const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.deepEqual(violations, []);
   });
 });
 
-test("cutover readiness ignores private harness files inside local worktrees", async () => {
+test("Legacy Intake readiness ignores private harness files inside local worktrees", async () => {
   await withFixtureRepo(async (root) => {
     mkdirSync(path.join(root, ".worktrees/gui-prototype-private-context/.harness-private"), { recursive: true });
     writeFileSync(path.join(root, ".worktrees/gui-prototype-private-context/.harness-private/AGENTS.md"), [
@@ -38,13 +38,13 @@ test("cutover readiness ignores private harness files inside local worktrees", a
       ""
     ].join("\n"));
 
-    const violations = await evaluateCutoverReadiness(root);
+    const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.deepEqual(violations, []);
   });
 });
 
-test("cutover readiness requires the harness-anything CLI package artifact bin surface", async () => {
+test("Legacy Intake readiness requires the harness-anything CLI package artifact bin surface", async () => {
   await withFixtureRepo(async (root) => {
     writeFileSync(path.join(root, "packages/cli/package.json"), JSON.stringify({
       name: "@harness-anything/cli",
@@ -52,23 +52,23 @@ test("cutover readiness requires the harness-anything CLI package artifact bin s
       type: "module"
     }));
 
-    const violations = await evaluateCutoverReadiness(root);
+    const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.equal(violations.some((violation) => violation.includes("bin.harness-anything")), true);
   });
 });
 
-test("cutover readiness dynamically rejects public legacy compatibility promises", async () => {
+test("Legacy Intake readiness dynamically rejects public legacy compatibility promises", async () => {
   await withFixtureRepo(async (root) => {
     writeFileSync(path.join(root, "PUBLIC-COMPAT.md"), "This promises coding-agent-harness compatibility.\n");
 
-    const violations = await evaluateCutoverReadiness(root);
+    const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.equal(violations.some((violation) => violation.includes("PUBLIC-COMPAT.md")), true);
   });
 });
 
-test("cutover readiness rejects retired runtime paths in root package scripts", async () => {
+test("Legacy Intake readiness rejects retired runtime paths in root package scripts", async () => {
   await withFixtureRepo(async (root) => {
     writeFileSync(path.join(root, "package.json"), JSON.stringify({
       name: "harness-anything",
@@ -81,23 +81,43 @@ test("cutover readiness rejects retired runtime paths in root package scripts", 
       }
     }));
 
-    const violations = await evaluateCutoverReadiness(root);
+    const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.equal(violations.some((violation) => violation.includes("package.json") && violation.includes("retired old runtime")), true);
   });
 });
 
-test("cutover readiness rejects forbidden runtime APIs in public markdown", async () => {
+test("Legacy Intake readiness rejects retired full-cutover package script gate names", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFileSync(path.join(root, "package.json"), JSON.stringify({
+      name: "harness-anything",
+      private: true,
+      scripts: {
+        "harness:smoke-full-cutover": "node tools/smoke-full-cutover.mjs",
+        "harness:check-cutover-readiness": "node tools/check-cutover-readiness.mjs"
+      },
+      dependencies: {
+        effect: "3.21.2"
+      }
+    }));
+
+    const violations = await evaluateLegacyIntakeReadiness(root);
+
+    assert.equal(violations.some((violation) => violation.includes("smoke-full-cutover") || violation.includes("check-cutover-readiness")), true);
+  });
+});
+
+test("Legacy Intake readiness rejects forbidden runtime APIs in public markdown", async () => {
   await withFixtureRepo(async (root) => {
     writeFileSync(path.join(root, "README.md"), "Use requestTransition for lifecycle control.\n");
 
-    const violations = await evaluateCutoverReadiness(root);
+    const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.equal(violations.some((violation) => violation.includes("README.md") && violation.includes("forbidden runtime-control")), true);
   });
 });
 
-test("cutover readiness rejects retired runtime paths in GitHub workflow config", async () => {
+test("Legacy Intake readiness rejects retired runtime paths in GitHub workflow config", async () => {
   await withFixtureRepo(async (root) => {
     mkdirSync(path.join(root, ".github/workflows"), { recursive: true });
     writeFileSync(path.join(root, ".github/workflows/rewrite-ci.yml"), [
@@ -110,15 +130,15 @@ test("cutover readiness rejects retired runtime paths in GitHub workflow config"
       ""
     ].join("\n"));
 
-    const violations = await evaluateCutoverReadiness(root);
+    const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.equal(violations.some((violation) => violation.includes(".github/workflows/rewrite-ci.yml") && violation.includes("retired old runtime")), true);
   });
 });
 
-test("cutover readiness requires machine-checkable behavior corpus input", async () => {
+test("Legacy Intake readiness requires machine-checkable behavior corpus input", async () => {
   await withFixtureRepo(async (root) => {
-    writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.json"), JSON.stringify({
+    writeFileSync(path.join(root, "tools/legacy-intake/behavior-corpus-classification.json"), JSON.stringify({
       categories: {
         preserve: 0,
         "intentional-change": 0,
@@ -128,15 +148,15 @@ test("cutover readiness requires machine-checkable behavior corpus input", async
       }
     }));
 
-    const violations = await evaluateCutoverReadiness(root);
+    const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.equal(violations.some((violation) => violation.includes("needs-decision")), true);
   });
 });
 
-test("cutover readiness requires behavior item counts to match categories", async () => {
+test("Legacy Intake readiness requires behavior item counts to match categories", async () => {
   await withFixtureRepo(async (root) => {
-    writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.json"), JSON.stringify({
+    writeFileSync(path.join(root, "tools/legacy-intake/behavior-corpus-classification.json"), JSON.stringify({
       categories: {
         preserve: 1,
         "intentional-change": 0,
@@ -147,15 +167,15 @@ test("cutover readiness requires behavior item counts to match categories", asyn
       items: []
     }));
 
-    const violations = await evaluateCutoverReadiness(root);
+    const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.equal(violations.some((violation) => violation.includes("does not match")), true);
   });
 });
 
-test("cutover readiness requires a non-trivial behavior corpus", async () => {
+test("Legacy Intake readiness requires a non-trivial behavior corpus", async () => {
   await withFixtureRepo(async (root) => {
-    writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.md"), [
+    writeFileSync(path.join(root, "tools/legacy-intake/behavior-corpus-classification.md"), [
       "# Behavior Corpus Classification",
       "",
       "Machine-checkable source: `behavior-corpus-classification.json`.",
@@ -169,7 +189,7 @@ test("cutover readiness requires a non-trivial behavior corpus", async () => {
       "| needs-decision | 0 | none |",
       ""
     ].join("\n"));
-    writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.json"), JSON.stringify({
+    writeFileSync(path.join(root, "tools/legacy-intake/behavior-corpus-classification.json"), JSON.stringify({
       categories: {
         preserve: 1,
         "intentional-change": 0,
@@ -182,15 +202,15 @@ test("cutover readiness requires a non-trivial behavior corpus", async () => {
       ]
     }));
 
-    const violations = await evaluateCutoverReadiness(root);
+    const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.equal(violations.some((violation) => violation.includes("at least 15 classified items")), true);
   });
 });
 
-test("cutover readiness requires Markdown counts to match JSON categories", async () => {
+test("Legacy Intake readiness requires Markdown counts to match JSON categories", async () => {
   await withFixtureRepo(async (root) => {
-    writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.md"), [
+    writeFileSync(path.join(root, "tools/legacy-intake/behavior-corpus-classification.md"), [
       "# Behavior Corpus Classification",
       "",
       "Machine-checkable source: `behavior-corpus-classification.json`.",
@@ -205,7 +225,7 @@ test("cutover readiness requires Markdown counts to match JSON categories", asyn
       ""
     ].join("\n"));
 
-    const violations = await evaluateCutoverReadiness(root);
+    const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.equal(violations.some((violation) => violation.includes("category preserve count")), true);
   });
@@ -216,7 +236,7 @@ async function withFixtureRepo(fn) {
   try {
     mkdirSync(path.join(root, "packages/kernel/src"), { recursive: true });
     mkdirSync(path.join(root, "packages/cli"), { recursive: true });
-    mkdirSync(path.join(root, "tools/cutover"), { recursive: true });
+    mkdirSync(path.join(root, "tools/legacy-intake"), { recursive: true });
     writeFileSync(path.join(root, "package.json"), JSON.stringify({
       name: "harness-anything",
       private: true,
@@ -256,7 +276,7 @@ async function withFixtureRepo(fn) {
 }
 
 function writeValidBehaviorCorpus(root) {
-  writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.md"), [
+  writeFileSync(path.join(root, "tools/legacy-intake/behavior-corpus-classification.md"), [
     "# Behavior Corpus Classification",
     "",
     "Machine-checkable source: `behavior-corpus-classification.json`.",
@@ -270,7 +290,7 @@ function writeValidBehaviorCorpus(root) {
     "| needs-decision | 0 | none |",
     ""
   ].join("\n"));
-  writeFileSync(path.join(root, "tools/cutover/behavior-corpus-classification.json"), JSON.stringify({
+  writeFileSync(path.join(root, "tools/legacy-intake/behavior-corpus-classification.json"), JSON.stringify({
     categories: {
       preserve: 7,
       "intentional-change": 5,

--- a/tools/legacy-intake/behavior-corpus-classification.json
+++ b/tools/legacy-intake/behavior-corpus-classification.json
@@ -1,6 +1,6 @@
 {
   "schema": "harness-anything-behavior-corpus-classification/v1",
-  "scope": "M2 final cutover",
+  "scope": "M2 Legacy Intake readiness",
   "publishState": "not-published",
   "minimumItems": 15,
   "categories": {
@@ -12,8 +12,8 @@
   },
   "evidence": [
     {
-      "id": "EV-CUTOVER-READINESS",
-      "command": "npm run harness:check-cutover-readiness",
+      "id": "EV-LEGACY-INTAKE-READINESS",
+      "command": "npm run harness:check-legacy-intake-readiness",
       "result": "passed"
     },
     {
@@ -22,14 +22,14 @@
       "result": "passed"
     },
     {
-      "id": "EV-FULL-CUTOVER-SMOKE",
-      "command": "npm run harness:smoke-full-cutover",
+      "id": "EV-LEGACY-INTAKE-SMOKE",
+      "command": "npm run harness:smoke-legacy-intake",
       "result": "passed"
     },
     {
-      "id": "EV-FULL-CUTOVER-VERIFY",
+      "id": "EV-RETIRED-FULL-CUTOVER-FLAG",
       "command": "harness migrate-verify <session.json> --full-cutover --json",
-      "result": "passed"
+      "result": "rejected with full_cutover_retired"
     }
   ],
   "items": [
@@ -71,7 +71,7 @@
     },
     {
       "classification": "intentional-change",
-      "summary": "Package release remains private and not-published during M2 final cutover."
+      "summary": "Package release remains private and not-published during M2 Legacy Intake readiness."
     },
     {
       "classification": "intentional-change",

--- a/tools/legacy-intake/behavior-corpus-classification.md
+++ b/tools/legacy-intake/behavior-corpus-classification.md
@@ -1,9 +1,9 @@
 # Behavior Corpus Classification
 
-M2 final cutover uses this report as the human-readable mirror of the
+M2 Legacy Intake readiness uses this report as the human-readable mirror of the
 machine-checkable behavior corpus. Migration intake is represented by explicit
-evidence files and `migrate-verify --full-cutover`; the public package and CLI
-surface stay on the Harness-Anything implementation.
+Legacy Intake evidence files; the public package and CLI surface stay on the
+Harness-Anything implementation.
 
 Machine-checkable source: `behavior-corpus-classification.json`.
 
@@ -31,7 +31,7 @@ Machine-checkable source: `behavior-corpus-classification.json`.
 
 - Root package identity uses `harness-anything` rather than the previous repository-level product name.
 - CLI package identity uses `@harness-anything/cli` and exposes the `harness-anything` binary.
-- Package release remains private and `not-published` during M2 final cutover.
+- Package release remains private and `not-published` during M2 Legacy Intake readiness.
 - The retired SR implementation route is blocked from production source and public docs.
 - Migration is explicit evidence through `migrate-run` and `migrate-verify` rather than automatic legacy compatibility.
 
@@ -44,12 +44,13 @@ Machine-checkable source: `behavior-corpus-classification.json`.
 - Malformed or conflicting legacy task trees require migration preflight failure rather than best-effort conversion.
 - npm registry scope reservation and public publishing are outside M2 and remain deferred release work.
 
-## Cutover Evidence Notes
+## Legacy Intake Evidence Notes
 
 - Default package identity is `harness-anything`.
 - CLI package identity is `@harness-anything/cli`.
 - The default CLI package artifact bin is `harness-anything`; external npm publish is intentionally out of scope.
-- Retired old runtime paths are blocked by `harness:check-cutover-readiness`.
-- Full cutover verification is active through `migrate-verify --full-cutover`.
-- Real repository full-cutover smoke is covered by `harness:smoke-full-cutover`.
+- Retired old runtime paths are blocked by `harness:check-legacy-intake-readiness`.
+- Legacy Intake verification is active through `legacy verify`.
+- The retired `migrate-verify --full-cutover` flag is covered as a rejection path, not as an active future gate.
+- Real repository Legacy Intake smoke is covered by `harness:smoke-legacy-intake`.
 - Package artifact executability is verified by `harness:smoke-cli-package`, which builds, packs, installs into a temporary consumer, and runs `harness-anything --json gui` with GUI dry-run enabled.

--- a/tools/smoke-legacy-intake.mjs
+++ b/tools/smoke-legacy-intake.mjs
@@ -6,8 +6,8 @@ import path from "node:path";
 
 const root = process.cwd();
 const cli = path.join(root, "packages/cli/src/index.ts");
-const smokeRoot = path.join(root, ".harness/generated/full-cutover-smoke-root");
-const outDir = ".harness/generated/full-cutover-smoke";
+const smokeRoot = path.join(root, ".harness/generated/legacy-intake-smoke-root");
+const outDir = ".harness/generated/legacy-intake-smoke";
 
 function runJson(args) {
   try {
@@ -52,7 +52,7 @@ try {
     throw new Error("legacy verify did not accept current Legacy Intake index");
   }
 
-  console.log(`Full cutover smoke retired; Legacy Intake verify passed with ${legacyVerify.report.summary.entryCount} entries.`);
+  console.log(`Legacy Intake smoke passed with ${legacyVerify.report.summary.entryCount} entries.`);
 } finally {
   rmSync(smokeRoot, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- Replaced active `npm run check` full-cutover/cutover readiness gate names with Legacy Intake readiness and smoke names.
- Renamed readiness/smoke tools and active behavior corpus path from `tools/cutover/**` to `tools/legacy-intake/**`.
- Preserved readiness coverage for old runtime refs, forbidden APIs, public compatibility promises, package artifact surface, behavior corpus counts/min-size/needs-decision, and retired package script names.
- Preserved smoke coverage for Legacy Intake plan/copy/index/verify and kept `migrate-verify --full-cutover` as a rejection-path regression only.

## Verification
- `node --test tools/check-legacy-intake-readiness.test.mjs packages/cli/test/migration-adopt-cli.test.ts`
- `npm run harness:check-legacy-intake-readiness`
- `npm run harness:smoke-legacy-intake`
- `npm run typecheck`
- `npm run check` (255 tests, all gates/smokes passed)

## Review
- Reviewer Aquinas found no open P0/P1/P2.
- Reviewer confirmed active package scripts, workflow, PR template, readiness coverage, smoke coverage, and `tools/legacy-intake/**` consistency.