### PR TITLE
Close out M2.5 public CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The product model is intentionally composable:
 - A TypeScript monorepo with kernel, CLI, GUI, application, and adapter
   packages.
 - A governance surface for checking task packages, file complexity, import
-  boundaries, private/public boundaries, schema contracts, and cutover
+  boundaries, private/public boundaries, schema contracts, and Legacy Intake
   readiness.
 - A supply-chain release gate for high-severity npm advisories and CycloneDX
   SBOM generation.
@@ -110,6 +110,21 @@ node packages/cli/src/index.ts --root /path/to/project --json init
 node packages/cli/src/index.ts --root /path/to/project --json new-task --title "First task"
 node packages/cli/src/index.ts --root /path/to/project --json status
 node packages/cli/src/index.ts --root /path/to/project --json check --post-merge
+```
+
+For current coding-agent dogfood, create new work with the coding vertical and
+preset surface, then complete it through the review/CI closeout gate:
+
+```bash
+node packages/cli/src/index.ts --root /path/to/project --json new-task --title "Implement slice" --vertical software/coding --preset standard-task
+node packages/cli/src/index.ts --root /path/to/project --json task-complete <task-id> --ci passed --reviewer <reviewer-id>
+```
+
+Unfinished old task state is treated as Legacy Intake evidence. Rebuild it into
+a new Harness task with provenance instead of expecting bulk conversion:
+
+```bash
+node packages/cli/src/index.ts --root /path/to/project --json new-task --from-legacy <legacy-id>
 ```
 
 Run the full repository check before public commits:
@@ -158,7 +173,7 @@ Expect breaking changes while the public package surface stabilizes.
 
 ## Roadmap
 
-**M2 - coding vertical cutover**
+**M2 - coding vertical workflow**
 
 - [x] Kernel, CLI, package layout, governance checks, behavior corpus, and
   Legacy Intake readiness evidence.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -84,6 +84,21 @@ node packages/cli/src/index.ts --root /path/to/project --json status
 node packages/cli/src/index.ts --root /path/to/project --json check --post-merge
 ```
 
+当前 coding-agent dogfood 使用 coding vertical 和 preset surface 创建新任务，
+再通过 review/CI closeout gate 完成任务：
+
+```bash
+node packages/cli/src/index.ts --root /path/to/project --json new-task --title "Implement slice" --vertical software/coding --preset standard-task
+node packages/cli/src/index.ts --root /path/to/project --json task-complete <task-id> --ci passed --reviewer <reviewer-id>
+```
+
+未完成的旧任务状态只作为 Legacy Intake 证据处理。把它带 provenance
+重建成新的 Harness 任务，不承诺自动批量转换：
+
+```bash
+node packages/cli/src/index.ts --root /path/to/project --json new-task --from-legacy <legacy-id>
+```
+
 公开提交前运行完整仓库检查：
 
 ```bash
@@ -126,7 +141,7 @@ Private planning、architecture、review state 和 task ledger 位于 public doc
 
 ## Roadmap
 
-**M2 - coding vertical cutover**
+**M2 - coding vertical workflow**
 
 - [x] Kernel、CLI、package layout、governance checks、behavior corpus 和 Legacy Intake readiness evidence。
 - [x] Legacy Intake 和 private CLI package artifact 的本地 smoke 覆盖。

--- a/docs-release/harness-agent-skill.md
+++ b/docs-release/harness-agent-skill.md
@@ -1,11 +1,11 @@
 # Harness Agent Skill
 
-Status: M2 usable workflow
+Status: M2.5 usable workflow
 
 ## Rules
 
 1. Read `harness/harness.yaml` and the task `INDEX.md` before changing task state.
-2. Local task state is owned by Harness commands. Use `harness task status set`, `harness task progress append`, `harness task archive`, `harness task supersede`, `harness task delete`, and `harness task reopen`.
+2. Local task state is owned by Harness commands. Use `harness task progress append`, `harness task archive`, `harness task supersede`, `harness task delete`, `harness task reopen`, and `harness task-complete`.
 3. External engine task state is read-only in Harness. Change status in the owning engine, then use `harness check` locally.
 4. Do not edit `task_id`, `lifecycle.binding*`, or generated `.harness/` files by hand.
 5. Use `harness task supersede` for follow-up work after `done` or `cancelled`; do not reopen terminal work.
@@ -25,9 +25,26 @@ harness check --post-merge --json
 For new local work:
 
 ```bash
-harness new-task --title "Task title" --json
-harness task status set <task-id> active --json
+harness new-task --title "Task title" --vertical software/coding --preset standard-task --json
 harness task progress append <task-id> --text "Progress note" --json
+harness task-complete <task-id> --ci passed --reviewer <reviewer-id> --json
+```
+
+For module-scoped coding work:
+
+```bash
+harness new-task --title "Module task" --vertical software/coding --preset module --module <module-key> --json
+```
+
+For unfinished legacy work, keep the legacy state as evidence and rebuild a new
+Harness task with provenance:
+
+```bash
+harness legacy scan <legacy-root> --json
+harness legacy copy-safe-docs <legacy-root> --apply --json
+harness legacy index <legacy-root> --apply --json
+harness legacy verify --json
+harness new-task --from-legacy <legacy-id> --json
 ```
 
 For external read-only adoption:

--- a/docs-release/m2-coding-vertical.md
+++ b/docs-release/m2-coding-vertical.md
@@ -1,6 +1,6 @@
 # M2 Coding Vertical
 
-Status: M2 complete, package release deferred; final-cutover evidence is historical and deprecated for future strategy
+Status: M2 complete, package release deferred; the former `--full-cutover` flag is retired historical evidence only
 
 ## Install From This Repository
 
@@ -49,6 +49,23 @@ harness status --json
 harness check --post-merge --json
 ```
 
+For coding vertical dogfood, create new work through the vertical/preset surface:
+
+```bash
+harness new-task --title "Implement slice" --vertical software/coding --preset standard-task --json
+harness new-task --title "Implement module slice" --vertical software/coding --preset module --module billing --json
+```
+
+Project defaults can provide the same coding vertical and preset choices, but
+the explicit flags above are the portable command surface for agents and tests.
+
+Complete ordinary work through the terminal closeout command after review, CI,
+and local checks are ready:
+
+```bash
+harness task-complete <task-id> --ci passed --reviewer <reviewer-id> --json
+```
+
 Task package commands:
 
 ```bash
@@ -74,7 +91,15 @@ harness git-diff --json
 M2 shipped migration evidence commands, but the project strategy changed after
 M2: future releases should treat old task packages as legacy evidence, not as
 input for automatic task-package conversion. Use Legacy Intake and rebuild
-unfinished work as new tasks with provenance.
+unfinished work as new tasks with provenance:
+
+```bash
+harness legacy scan <legacy-root> --json
+harness legacy copy-safe-docs <legacy-root> --apply --json
+harness legacy index <legacy-root> --apply --json
+harness legacy verify --json
+harness new-task --from-legacy <legacy-id> --json
+```
 
 `createdBy` is optional task audit metadata sourced from local Git
 `user.name`/`user.email` when available. It is not task status, package

--- a/tools/check-legacy-intake-readiness.mjs
+++ b/tools/check-legacy-intake-readiness.mjs
@@ -31,6 +31,13 @@ const publicCompatibilityPatterns = [
   /\bautomatic migration\b/u,
   /\bauto-migration\b/u
 ];
+const activeCutoverGuidancePatterns = [
+  /\bcoding vertical cutover\b/iu,
+  /\bcutover readiness\b/iu
+];
+const fullCutoverMentionPattern = /(?:--full-cutover|\bfull[- ]cutover\b|\bfinal[- ]cutover\b)/iu;
+const allowedHistoricalCutoverContextPattern =
+  /\b(?:historical|deprecated|retired|former|rejection path|not active|should not use|not use|not as an active)\b/iu;
 const retiredPackageScriptGatePatterns = [
   /\bcheck-cutover-readiness\b/u,
   /\bsmoke-full-cutover\b/u,
@@ -144,6 +151,25 @@ async function checkPublicText(root, violations) {
         break;
       }
     }
+    for (const pattern of activeCutoverGuidancePatterns) {
+      if (pattern.test(text)) {
+        violations.push(`${rel}: public text appears to present cutover as active guidance`);
+        break;
+      }
+    }
+    checkFullCutoverPublicGuidance(rel, text, violations);
+  }
+}
+
+function checkFullCutoverPublicGuidance(rel, text, violations) {
+  const lines = text.split(/\r?\n/u);
+  for (const [index, line] of lines.entries()) {
+    if (!fullCutoverMentionPattern.test(line)) continue;
+    const contextStart = Math.max(0, index - 5);
+    const contextEnd = Math.min(lines.length, index + 2);
+    const context = lines.slice(contextStart, contextEnd).join("\n");
+    if (allowedHistoricalCutoverContextPattern.test(context)) continue;
+    violations.push(`${rel}:${index + 1}: public text mentions full cutover without historical/deprecated context`);
   }
 }
 

--- a/tools/check-legacy-intake-readiness.test.mjs
+++ b/tools/check-legacy-intake-readiness.test.mjs
@@ -117,6 +117,45 @@ test("Legacy Intake readiness rejects forbidden runtime APIs in public markdown"
   });
 });
 
+test("Legacy Intake readiness rejects active cutover guidance in public markdown", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFileSync(path.join(root, "README.md"), [
+      "## Roadmap",
+      "",
+      "M2 - coding vertical cutover",
+      "",
+      "Run harness migrate-verify session.json --full-cutover --json as the release gate.",
+      ""
+    ].join("\n"));
+
+    const violations = await evaluateLegacyIntakeReadiness(root);
+
+    assert.equal(violations.some((violation) => violation.includes("README.md") && violation.includes("active guidance")), true);
+    assert.equal(violations.some((violation) => violation.includes("README.md:5") && violation.includes("without historical/deprecated context")), true);
+  });
+});
+
+test("Legacy Intake readiness allows explicitly historical full-cutover evidence in public markdown", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFileSync(path.join(root, "README.md"), [
+      "# Historical Final Cutover Evidence",
+      "",
+      "Historical M2 evidence used the now-retired full-cutover flag:",
+      "",
+      "```bash",
+      "harness migrate-verify session.json --full-cutover --json",
+      "```",
+      "",
+      "Future work should not use full cutover as an exit gate.",
+      ""
+    ].join("\n"));
+
+    const violations = await evaluateLegacyIntakeReadiness(root);
+
+    assert.deepEqual(violations, []);
+  });
+});
+
 test("Legacy Intake readiness rejects retired runtime paths in GitHub workflow config", async () => {
   await withFixtureRepo(async (root) => {
     mkdirSync(path.join(root, ".github/workflows"), { recursive: true });


### PR DESCRIPTION
## Summary
- update public README docs with M2.5 coding vertical/preset dogfood, task-complete closeout, and Legacy Intake rebuild provenance
- update the public agent guide with the same forward-only flow
- add Legacy Intake readiness coverage that rejects active full-cutover public guidance while allowing explicitly historical/deprecated evidence

## Verification
- node --test tools/check-legacy-intake-readiness.test.mjs
- npm run harness:check-legacy-intake-readiness
- npm run check (257 tests plus all harness gates/smokes)

## Review
- Reviewer Pascal found 3 P2s; fixed all and rereview reported no open P0/P1/P2, no P3/nits.