### PR TITLE
Add service mappability gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "packages/adapters/*"
   ],
   "scripts": {
-    "check": "npm run typecheck && npm test && npm run harness:check-file-complexity && npm run harness:check-cli-structure && npm run harness:check-import-boundaries && npm run harness:scan-forbidden-symbols && npm run harness:check-private-boundary && npm run harness:check-package-policy && npm run harness:check-implementation-contracts && npm run harness:check-schema-contracts && npm run harness:check-legacy-intake-readiness && npm run harness:check-supply-chain && npm run harness:smoke-legacy-intake && npm run harness:smoke-cli-package",
+    "check": "npm run typecheck && npm test && npm run harness:check-file-complexity && npm run harness:check-cli-structure && npm run harness:check-import-boundaries && npm run harness:scan-forbidden-symbols && npm run harness:check-private-boundary && npm run harness:check-package-policy && npm run harness:check-implementation-contracts && npm run harness:check-service-mappability && npm run harness:check-schema-contracts && npm run harness:check-legacy-intake-readiness && npm run harness:check-supply-chain && npm run harness:smoke-legacy-intake && npm run harness:smoke-cli-package",
     "typecheck": "tsc -b --pretty false",
     "test": "node tools/run-node-tests.mjs",
     "harness:check-file-complexity": "node tools/check-file-complexity.mjs",
@@ -20,6 +20,7 @@
     "harness:check-private-boundary": "node tools/check-private-boundary.mjs",
     "harness:check-package-policy": "node tools/check-package-policy.mjs",
     "harness:check-implementation-contracts": "node tools/check-implementation-contracts.mjs",
+    "harness:check-service-mappability": "node tools/check-service-mappability.mjs",
     "harness:check-schema-contracts": "node tools/check-schema-contracts.mjs",
     "harness:check-legacy-intake-readiness": "node tools/check-legacy-intake-readiness.mjs",
     "harness:check-supply-chain": "node tools/check-supply-chain.mjs",

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import { makeLocalLifecycleEngine } from "../../adapters/local/src/index.ts";
-import type { DomainStatus } from "../../kernel/src/index.ts";
+import type { DomainStatus, ProjectionWarning, TaskProjectionRow } from "../../kernel/src/index.ts";
 import { isDomainStatus, isTerminalStatus, readTaskProjection } from "../../kernel/src/index.ts";
 import { taskDocumentPath as harnessTaskDocumentPath, validateTaskIdSyntax } from "../../kernel/src/layout/index.ts";
 export {
@@ -28,31 +28,43 @@ export interface LocalControllerSuccess {
   readonly ok: true;
 }
 
+export interface LocalControllerError {
+  readonly code: string;
+  readonly hint: string;
+}
+
 export interface LocalControllerFailure {
   readonly ok: false;
-  readonly error: {
-    readonly code: string;
-    readonly hint: string;
-  };
+  readonly error: LocalControllerError;
 }
 
 export type LocalControllerResult = LocalControllerSuccess | LocalControllerFailure;
 
-export type TaskListResult = (LocalControllerSuccess & {
-  readonly tasks: ReadonlyArray<unknown>;
-  readonly warnings: ReadonlyArray<unknown>;
-}) | LocalControllerFailure;
+export interface TaskListSuccess extends LocalControllerSuccess {
+  readonly tasks: ReadonlyArray<TaskProjectionRow>;
+  readonly warnings: ReadonlyArray<ProjectionWarning>;
+}
 
-export type TaskDetailResult = (LocalControllerSuccess & {
-  readonly task?: unknown;
-  readonly documents?: ReadonlyArray<{ readonly path: string }>;
-}) | LocalControllerFailure;
+export type TaskListResult = TaskListSuccess | LocalControllerFailure;
 
-export type TaskDocumentResult = (LocalControllerSuccess & {
+export interface TaskDocumentDescriptor {
+  readonly path: string;
+}
+
+export interface TaskDetailSuccess extends LocalControllerSuccess {
+  readonly task?: TaskProjectionRow;
+  readonly documents?: ReadonlyArray<TaskDocumentDescriptor>;
+}
+
+export type TaskDetailResult = TaskDetailSuccess | LocalControllerFailure;
+
+export interface TaskDocumentSuccess extends LocalControllerSuccess {
   readonly taskId?: string;
   readonly path?: string;
   readonly body?: string;
-}) | LocalControllerFailure;
+}
+
+export type TaskDocumentResult = TaskDocumentSuccess | LocalControllerFailure;
 
 export interface TaskIdPayload {
   readonly taskId: string;
@@ -70,6 +82,17 @@ export interface AppendTaskProgressPayload extends TaskIdPayload {
   readonly text: string;
 }
 
+export interface ShellPanelPolicy {
+  readonly displayOnly: true;
+  readonly outputCreatesTaskState: false;
+}
+
+export interface OpenShellSuccess extends LocalControllerSuccess {
+  readonly policy: ShellPanelPolicy;
+}
+
+export type OpenShellResult = OpenShellSuccess | LocalControllerFailure;
+
 export interface LocalControllerService {
   readonly getTasks: () => TaskListResult;
   readonly getTaskDetail: (payload: TaskIdPayload) => TaskDetailResult;
@@ -79,12 +102,7 @@ export interface LocalControllerService {
   readonly appendTaskProgress: (payload: AppendTaskProgressPayload) => Promise<LocalControllerResult>;
   readonly rebuildGovernance: () => TaskListResult;
   readonly archiveTask: () => LocalControllerResult;
-  readonly openShell: () => LocalControllerResult & {
-    readonly policy: {
-      readonly displayOnly: true;
-      readonly outputCreatesTaskState: false;
-    };
-  };
+  readonly openShell: () => OpenShellResult;
 }
 
 export function makeLocalControllerService(options: LocalControllerServiceOptions): LocalControllerService {

--- a/tools/check-service-mappability.mjs
+++ b/tools/check-service-mappability.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const defaultApplicationPath = "packages/application/src/index.ts";
+const allowedExternalTypeReferences = new Set([
+  "Array",
+  "Effect",
+  "Extract",
+  "Omit",
+  "Partial",
+  "Pick",
+  "Promise",
+  "Readonly",
+  "ReadonlyArray",
+  "Record"
+]);
+const allowedMappableKernelTypeReferences = new Set([
+  "DomainStatus",
+  "ProjectionWarning",
+  "TaskProjectionRow"
+]);
+
+export function evaluateServiceMappability(root = process.cwd(), options = {}) {
+  const applicationPath = options.applicationPath ?? defaultApplicationPath;
+  const absolutePath = path.join(root, applicationPath);
+  if (!existsSync(absolutePath)) {
+    return [`${applicationPath}: missing application service entrypoint`];
+  }
+
+  const sourceText = readFileSync(absolutePath, "utf8");
+  const sourceFile = ts.createSourceFile(applicationPath, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const declarations = collectDeclarations(sourceFile);
+  const serviceInterface = declarations.interfaces.get("LocalControllerService");
+  if (!serviceInterface) return [`${applicationPath}: missing LocalControllerService interface`];
+
+  const violations = [];
+  const referencedTypes = new Set();
+
+  for (const member of serviceInterface.members) {
+    if (!ts.isPropertySignature(member) || !member.type || !ts.isFunctionTypeNode(member.type) || !ts.isIdentifier(member.name)) {
+      violations.push(`${applicationPath}: LocalControllerService members must be readonly function properties`);
+      continue;
+    }
+    const methodName = member.name.text;
+    for (const parameter of member.type.parameters) {
+      if (!parameter.type) {
+        violations.push(`${applicationPath}: ${methodName} parameter ${parameter.name.getText(sourceFile)} must have an explicit named type`);
+        continue;
+      }
+      inspectTypeNode(parameter.type, {
+        sourceFile,
+        applicationPath,
+        context: `${methodName} parameter ${parameter.name.getText(sourceFile)}`,
+        referencedTypes,
+        violations
+      });
+    }
+    if (!member.type.type) {
+      violations.push(`${applicationPath}: ${methodName} must have an explicit return type`);
+      continue;
+    }
+    inspectTypeNode(member.type.type, {
+      sourceFile,
+      applicationPath,
+      context: `${methodName} return`,
+      referencedTypes,
+      violations
+    });
+  }
+
+  const checkedTypes = new Set();
+  for (const typeName of referencedTypes) {
+    inspectReferencedType(typeName, declarations, checkedTypes, {
+      sourceFile,
+      applicationPath,
+      referencedTypes,
+      violations
+    });
+  }
+
+  return violations;
+}
+
+function collectDeclarations(sourceFile) {
+  const interfaces = new Map();
+  const typeAliases = new Map();
+
+  function visit(node) {
+    if (ts.isInterfaceDeclaration(node)) interfaces.set(node.name.text, node);
+    if (ts.isTypeAliasDeclaration(node)) typeAliases.set(node.name.text, node);
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return { interfaces, typeAliases };
+}
+
+function inspectReferencedType(typeName, declarations, checkedTypes, context) {
+  if (allowedExternalTypeReferences.has(typeName) || allowedMappableKernelTypeReferences.has(typeName) || checkedTypes.has(typeName)) return;
+  checkedTypes.add(typeName);
+
+  const interfaceDeclaration = declarations.interfaces.get(typeName);
+  if (interfaceDeclaration) {
+    for (const heritage of interfaceDeclaration.heritageClauses ?? []) {
+      for (const inheritedType of heritage.types) {
+        inspectTypeNode(inheritedType, {
+          ...context,
+          context: `${typeName} extends`
+        });
+      }
+    }
+    for (const member of interfaceDeclaration.members) {
+      if (ts.isPropertySignature(member) && member.type) {
+        inspectTypeNode(member.type, {
+          ...context,
+          context: `${typeName}.${member.name.getText(context.sourceFile)}`
+        });
+      }
+    }
+    return;
+  }
+
+  const typeAlias = declarations.typeAliases.get(typeName);
+  if (typeAlias) {
+    inspectTypeNode(typeAlias.type, {
+      ...context,
+      context: typeName
+    });
+    return;
+  }
+
+  context.violations.push(`${context.applicationPath}: ${typeName} is referenced by LocalControllerService but has no local mappability declaration`);
+}
+
+function inspectTypeNode(typeNode, context) {
+  if (typeNode.kind === ts.SyntaxKind.AnyKeyword || typeNode.kind === ts.SyntaxKind.UnknownKeyword) {
+    context.violations.push(`${context.applicationPath}: ${context.context} uses ${typeNode.getText(context.sourceFile)}; Service surfaces must be mappable`);
+    return;
+  }
+  if (ts.isTypeLiteralNode(typeNode)) {
+    context.violations.push(`${context.applicationPath}: ${context.context} uses an inline object type; name the Service contract type`);
+    return;
+  }
+  if (ts.isFunctionTypeNode(typeNode)) {
+    context.violations.push(`${context.applicationPath}: ${context.context} uses an inline function type outside the Service method boundary`);
+    return;
+  }
+  if (ts.isTypeReferenceNode(typeNode)) {
+    const typeName = typeNode.typeName.getText(context.sourceFile);
+    context.referencedTypes.add(typeName);
+    for (const argument of typeNode.typeArguments ?? []) inspectTypeNode(argument, context);
+    return;
+  }
+  if (ts.isExpressionWithTypeArguments(typeNode)) {
+    const typeName = typeNode.expression.getText(context.sourceFile);
+    context.referencedTypes.add(typeName);
+    for (const argument of typeNode.typeArguments ?? []) inspectTypeNode(argument, context);
+    return;
+  }
+  if (ts.isArrayTypeNode(typeNode)) {
+    inspectTypeNode(typeNode.elementType, context);
+    return;
+  }
+  if (ts.isUnionTypeNode(typeNode) || ts.isIntersectionTypeNode(typeNode)) {
+    for (const childType of typeNode.types) inspectTypeNode(childType, context);
+    return;
+  }
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    inspectTypeNode(typeNode.type, context);
+    return;
+  }
+  if (ts.isTupleTypeNode(typeNode)) {
+    for (const element of typeNode.elements) inspectTypeNode(element, context);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const violations = evaluateServiceMappability();
+  if (violations.length > 0) {
+    console.error("Service mappability check failed:");
+    for (const violation of violations) console.error(`- ${violation}`);
+    process.exit(1);
+  }
+  console.log("Service mappability check passed.");
+}

--- a/tools/check-service-mappability.test.mjs
+++ b/tools/check-service-mappability.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { evaluateServiceMappability } from "./check-service-mappability.mjs";
+
+test("Service mappability accepts named typed LocalControllerService contracts", async () => {
+  await withFixtureRepo(async (root) => {
+    writeApplicationSource(root, [
+      "export interface TaskIdPayload { readonly taskId: string }",
+      "export interface LocalControllerSuccess { readonly ok: true }",
+      "export interface LocalControllerError { readonly code: string; readonly hint: string }",
+      "export interface LocalControllerFailure { readonly ok: false; readonly error: LocalControllerError }",
+      "export type LocalControllerResult = LocalControllerSuccess | LocalControllerFailure",
+      "export interface TaskListSuccess extends LocalControllerSuccess { readonly tasks: ReadonlyArray<TaskRow> }",
+      "export interface TaskRow { readonly taskId: string; readonly title: string }",
+      "export type TaskListResult = TaskListSuccess | LocalControllerFailure",
+      "export interface LocalControllerService {",
+      "  readonly getTasks: () => TaskListResult;",
+      "  readonly getTaskDetail: (payload: TaskIdPayload) => Promise<LocalControllerResult>;",
+      "}",
+      ""
+    ]);
+
+    assert.deepEqual(evaluateServiceMappability(root), []);
+  });
+});
+
+test("Service mappability rejects unknown in referenced Service result types", async () => {
+  await withFixtureRepo(async (root) => {
+    writeApplicationSource(root, [
+      "export interface LocalControllerSuccess { readonly ok: true }",
+      "export interface TaskListSuccess extends LocalControllerSuccess { readonly tasks: ReadonlyArray<unknown> }",
+      "export type TaskListResult = TaskListSuccess",
+      "export interface LocalControllerService {",
+      "  readonly getTasks: () => TaskListResult;",
+      "}",
+      ""
+    ]);
+
+    const violations = evaluateServiceMappability(root);
+
+    assert.equal(violations.some((violation) => violation.includes("TaskListSuccess.tasks") && violation.includes("unknown")), true);
+  });
+});
+
+test("Service mappability rejects inline object blobs in Service signatures", async () => {
+  await withFixtureRepo(async (root) => {
+    writeApplicationSource(root, [
+      "export interface LocalControllerService {",
+      "  readonly getTasks: () => { readonly ok: true };",
+      "}",
+      ""
+    ]);
+
+    const violations = evaluateServiceMappability(root);
+
+    assert.equal(violations.some((violation) => violation.includes("getTasks return") && violation.includes("inline object")), true);
+  });
+});
+
+test("Service mappability rejects unknown Service payload parameters", async () => {
+  await withFixtureRepo(async (root) => {
+    writeApplicationSource(root, [
+      "export interface LocalControllerSuccess { readonly ok: true }",
+      "export interface LocalControllerService {",
+      "  readonly getTaskDetail: (payload: unknown) => LocalControllerSuccess;",
+      "}",
+      ""
+    ]);
+
+    const violations = evaluateServiceMappability(root);
+
+    assert.equal(violations.some((violation) => violation.includes("getTaskDetail parameter payload") && violation.includes("unknown")), true);
+  });
+});
+
+test("Service mappability rejects unknown inherited through extended Service result types", async () => {
+  await withFixtureRepo(async (root) => {
+    writeApplicationSource(root, [
+      "export interface LocalControllerSuccess { readonly ok: true }",
+      "export interface UnmappableBase { readonly payload: unknown }",
+      "export interface TaskDetailSuccess extends LocalControllerSuccess, UnmappableBase { readonly taskId: string }",
+      "export interface LocalControllerService {",
+      "  readonly getTaskDetail: () => TaskDetailSuccess;",
+      "}",
+      ""
+    ]);
+
+    const violations = evaluateServiceMappability(root);
+
+    assert.equal(violations.some((violation) => violation.includes("UnmappableBase.payload") && violation.includes("unknown")), true);
+  });
+});
+
+test("Service mappability fails closed on imported Service contract types without local declaration", async () => {
+  await withFixtureRepo(async (root) => {
+    writeApplicationSource(root, [
+      "import type { ImportedResult } from './contracts.ts';",
+      "export interface LocalControllerService {",
+      "  readonly getTaskDetail: () => ImportedResult;",
+      "}",
+      ""
+    ]);
+
+    const violations = evaluateServiceMappability(root);
+
+    assert.equal(violations.some((violation) => violation.includes("ImportedResult") && violation.includes("no local mappability declaration")), true);
+  });
+});
+
+async function withFixtureRepo(fn) {
+  const root = await mkdtemp(path.join(tmpdir(), "ha-service-mappability-"));
+  try {
+    mkdirSync(path.join(root, "packages/application/src"), { recursive: true });
+    await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function writeApplicationSource(root, lines) {
+  writeFileSync(path.join(root, "packages/application/src/index.ts"), lines.join("\n"), "utf8");
+}


### PR DESCRIPTION
## Summary
- replace long-lived unknown application service result surfaces with named mappable types
- add AST-backed service mappability check for LocalControllerService contracts
- wire harness:check-service-mappability into npm run check

## Verification
- node --test tools/check-service-mappability.test.mjs
- npm run harness:check-service-mappability
- npm run typecheck
- node --test packages/application/test/local-controller-service.test.ts packages/gui/test/service-bridge.test.ts
- npm run check (263 tests plus all harness gates/smokes)

## Review
- Reviewer Dirac found 1 P2 inherited/imported type bypass; fixed and rereview reported no open P0/P1/P2.