### PR TITLE
Add GUI API contract registry gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "packages/adapters/*"
   ],
   "scripts": {
-    "check": "npm run typecheck && npm test && npm run harness:check-file-complexity && npm run harness:check-cli-structure && npm run harness:check-import-boundaries && npm run harness:scan-forbidden-symbols && npm run harness:check-private-boundary && npm run harness:check-package-policy && npm run harness:check-implementation-contracts && npm run harness:check-service-mappability && npm run harness:check-schema-contracts && npm run harness:check-legacy-intake-readiness && npm run harness:check-supply-chain && npm run harness:smoke-legacy-intake && npm run harness:smoke-cli-package",
+    "check": "npm run typecheck && npm test && npm run harness:check-file-complexity && npm run harness:check-cli-structure && npm run harness:check-import-boundaries && npm run harness:scan-forbidden-symbols && npm run harness:check-private-boundary && npm run harness:check-package-policy && npm run harness:check-implementation-contracts && npm run harness:check-service-mappability && npm run harness:check-api-contract-registry && npm run harness:check-schema-contracts && npm run harness:check-legacy-intake-readiness && npm run harness:check-supply-chain && npm run harness:smoke-legacy-intake && npm run harness:smoke-cli-package",
     "typecheck": "tsc -b --pretty false",
     "test": "node tools/run-node-tests.mjs",
     "harness:check-file-complexity": "node tools/check-file-complexity.mjs",
@@ -21,6 +21,7 @@
     "harness:check-package-policy": "node tools/check-package-policy.mjs",
     "harness:check-implementation-contracts": "node tools/check-implementation-contracts.mjs",
     "harness:check-service-mappability": "node tools/check-service-mappability.mjs",
+    "harness:check-api-contract-registry": "node tools/check-api-contract-registry.mjs",
     "harness:check-schema-contracts": "node tools/check-schema-contracts.mjs",
     "harness:check-legacy-intake-readiness": "node tools/check-legacy-intake-readiness.mjs",
     "harness:check-supply-chain": "node tools/check-supply-chain.mjs",

--- a/packages/gui/src/api/api-contract-registry.ts
+++ b/packages/gui/src/api/api-contract-registry.ts
@@ -1,0 +1,150 @@
+import type { LocalControllerService } from "../../../application/src/index.ts";
+import type { PreloadApiMethod } from "../preload/allowlist.ts";
+
+export type ApiRouteMethod = "GET" | "POST" | "PUT" | "DELETE" | "WS";
+export type ApiRouteAuth = "local-session-token" | "ssh-tunnel-local-token" | "none";
+
+export interface ApiRouteContract {
+  readonly id: string;
+  readonly method: ApiRouteMethod;
+  readonly path: string;
+  readonly inputSchemaId: string;
+  readonly outputSchemaId?: string;
+  readonly errorSchemaId: string;
+  readonly service: "LocalControllerService";
+  readonly serviceMethod: keyof LocalControllerService;
+  readonly auth: ApiRouteAuth;
+  readonly guiBridgeMethod: PreloadApiMethod;
+}
+
+export interface ApiSchemaContract {
+  readonly id: string;
+  readonly owner: "application" | "gui";
+  readonly typeName: string;
+}
+
+export interface DeferredGuiBridgeContract {
+  readonly guiBridgeMethod: PreloadApiMethod;
+  readonly service: "LocalControllerService";
+  readonly serviceMethod: keyof LocalControllerService;
+  readonly reason: string;
+}
+
+export interface EmptyGuiPayload {
+  readonly kind?: "empty";
+}
+
+export const apiSchemaContracts = [
+  { id: "gui.empty/v1", owner: "gui", typeName: "EmptyGuiPayload" },
+  { id: "application.append-task-progress-payload/v1", owner: "application", typeName: "AppendTaskProgressPayload" },
+  { id: "application.local-controller-error/v1", owner: "application", typeName: "LocalControllerError" },
+  { id: "application.local-controller-result/v1", owner: "application", typeName: "LocalControllerResult" },
+  { id: "application.set-task-status-payload/v1", owner: "application", typeName: "SetTaskStatusPayload" },
+  { id: "application.task-detail-result/v1", owner: "application", typeName: "TaskDetailResult" },
+  { id: "application.task-document-payload/v1", owner: "application", typeName: "TaskDocumentPayload" },
+  { id: "application.task-document-result/v1", owner: "application", typeName: "TaskDocumentResult" },
+  { id: "application.task-id-payload/v1", owner: "application", typeName: "TaskIdPayload" },
+  { id: "application.task-list-result/v1", owner: "application", typeName: "TaskListResult" }
+] as const satisfies ReadonlyArray<ApiSchemaContract>;
+
+export const apiRouteContracts = [
+  {
+    id: "tasks.list",
+    method: "GET",
+    path: "/api/tasks",
+    inputSchemaId: "gui.empty/v1",
+    outputSchemaId: "application.task-list-result/v1",
+    errorSchemaId: "application.local-controller-error/v1",
+    service: "LocalControllerService",
+    serviceMethod: "getTasks",
+    auth: "local-session-token",
+    guiBridgeMethod: "getTasks"
+  },
+  {
+    id: "tasks.detail",
+    method: "GET",
+    path: "/api/tasks/:taskId",
+    inputSchemaId: "application.task-id-payload/v1",
+    outputSchemaId: "application.task-detail-result/v1",
+    errorSchemaId: "application.local-controller-error/v1",
+    service: "LocalControllerService",
+    serviceMethod: "getTaskDetail",
+    auth: "local-session-token",
+    guiBridgeMethod: "getTaskDetail"
+  },
+  {
+    id: "tasks.document.read",
+    method: "GET",
+    path: "/api/tasks/:taskId/documents/:path",
+    inputSchemaId: "application.task-document-payload/v1",
+    outputSchemaId: "application.task-document-result/v1",
+    errorSchemaId: "application.local-controller-error/v1",
+    service: "LocalControllerService",
+    serviceMethod: "getTaskDocument",
+    auth: "local-session-token",
+    guiBridgeMethod: "getTaskDocument"
+  },
+  {
+    id: "tasks.status.set",
+    method: "POST",
+    path: "/api/tasks/:taskId/status",
+    inputSchemaId: "application.set-task-status-payload/v1",
+    outputSchemaId: "application.local-controller-result/v1",
+    errorSchemaId: "application.local-controller-error/v1",
+    service: "LocalControllerService",
+    serviceMethod: "setTaskStatus",
+    auth: "local-session-token",
+    guiBridgeMethod: "setTaskStatus"
+  },
+  {
+    id: "tasks.review",
+    method: "POST",
+    path: "/api/tasks/:taskId/review",
+    inputSchemaId: "application.task-id-payload/v1",
+    outputSchemaId: "application.local-controller-result/v1",
+    errorSchemaId: "application.local-controller-error/v1",
+    service: "LocalControllerService",
+    serviceMethod: "reviewTask",
+    auth: "local-session-token",
+    guiBridgeMethod: "reviewTask"
+  },
+  {
+    id: "tasks.progress.append",
+    method: "POST",
+    path: "/api/tasks/:taskId/progress",
+    inputSchemaId: "application.append-task-progress-payload/v1",
+    outputSchemaId: "application.local-controller-result/v1",
+    errorSchemaId: "application.local-controller-error/v1",
+    service: "LocalControllerService",
+    serviceMethod: "appendTaskProgress",
+    auth: "local-session-token",
+    guiBridgeMethod: "appendTaskProgress"
+  },
+  {
+    id: "governance.rebuild",
+    method: "POST",
+    path: "/api/governance/rebuild",
+    inputSchemaId: "gui.empty/v1",
+    outputSchemaId: "application.task-list-result/v1",
+    errorSchemaId: "application.local-controller-error/v1",
+    service: "LocalControllerService",
+    serviceMethod: "rebuildGovernance",
+    auth: "local-session-token",
+    guiBridgeMethod: "rebuildGovernance"
+  }
+] as const satisfies ReadonlyArray<ApiRouteContract>;
+
+export const deferredGuiBridgeContracts = [
+  {
+    guiBridgeMethod: "archiveTask",
+    service: "LocalControllerService",
+    serviceMethod: "archiveTask",
+    reason: "Archive is exposed in the preload allowlist as a disabled placeholder until the closeout/archive route contract is implemented."
+  },
+  {
+    guiBridgeMethod: "openShell",
+    service: "LocalControllerService",
+    serviceMethod: "openShell",
+    reason: "Shell opening is display-only GUI policy until M25GUI-P03 defines terminal session routes and metadata."
+  }
+] as const satisfies ReadonlyArray<DeferredGuiBridgeContract>;

--- a/packages/gui/src/index.ts
+++ b/packages/gui/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./api/local-api.ts";
+export * from "./api/api-contract-registry.ts";
 export * from "./api/service-bridge.ts";
 export * from "./api/view-model.ts";
 export * from "./doc-renderer/sanitize.ts";

--- a/tools/check-api-contract-registry.mjs
+++ b/tools/check-api-contract-registry.mjs
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const defaults = {
+  registryPath: "packages/gui/src/api/api-contract-registry.ts",
+  allowlistPath: "packages/gui/src/preload/allowlist.ts",
+  bridgePath: "packages/gui/src/api/service-bridge.ts",
+  applicationPath: "packages/application/src/index.ts"
+};
+const validMethods = new Set(["GET", "POST", "PUT", "DELETE", "WS"]);
+const validAuthModes = new Set(["local-session-token", "ssh-tunnel-local-token", "none"]);
+const requiredFields = [
+  "id",
+  "method",
+  "path",
+  "inputSchemaId",
+  "errorSchemaId",
+  "service",
+  "serviceMethod",
+  "auth",
+  "guiBridgeMethod"
+];
+const schemaIdPattern = /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*\/v[1-9][0-9]*$/u;
+
+export function evaluateApiContractRegistry(root = process.cwd(), options = {}) {
+  const paths = { ...defaults, ...options };
+  const violations = [];
+  const registry = collectApiRouteContracts(root, paths.registryPath, violations);
+  const schemaContracts = collectApiSchemaContracts(root, paths.registryPath, violations);
+  const deferredContracts = collectDeferredGuiBridgeContracts(root, paths.registryPath, violations);
+  const preloadMethods = collectPreloadMethods(root, paths.allowlistPath, violations);
+  const dispatchBranches = collectDispatchBranches(root, paths.bridgePath, violations);
+  const applicationDeclarations = collectTypeDeclarations(root, paths.applicationPath, violations);
+  const registryDeclarations = collectTypeDeclarations(root, paths.registryPath, violations);
+  const serviceMethods = collectLocalControllerServiceMethods(root, paths.applicationPath, violations);
+  const coveredBridgeMethods = new Set([
+    ...registry.map((entry) => entry.guiBridgeMethod).filter(Boolean),
+    ...deferredContracts.map((entry) => entry.guiBridgeMethod).filter(Boolean)
+  ]);
+
+  inspectSchemaContracts(schemaContracts, applicationDeclarations, registryDeclarations, paths.registryPath, violations);
+  inspectRegistryEntries(registry, schemaContracts, serviceMethods, preloadMethods, paths.registryPath, violations);
+  inspectDeferredContracts(deferredContracts, registry, serviceMethods, preloadMethods, paths.registryPath, violations);
+  inspectDispatchBranches([...registry, ...deferredContracts], dispatchBranches, paths.bridgePath, violations);
+  compareSets(preloadMethods, coveredBridgeMethods, {
+    leftName: "preload allowlist",
+    rightName: "API registry or deferred GUI bridge contract",
+    filePath: paths.registryPath,
+    violations
+  });
+  compareSets(new Set(dispatchBranches.keys()), coveredBridgeMethods, {
+    leftName: "GUI service dispatch",
+    rightName: "API registry or deferred GUI bridge contract",
+    filePath: paths.registryPath,
+    violations
+  });
+
+  return violations;
+}
+
+function collectApiSchemaContracts(root, relativePath, violations) {
+  return collectStringObjectArray(root, relativePath, "apiSchemaContracts", violations);
+}
+
+function collectDeferredGuiBridgeContracts(root, relativePath, violations) {
+  return collectStringObjectArray(root, relativePath, "deferredGuiBridgeContracts", violations);
+}
+
+function collectApiRouteContracts(root, relativePath, violations) {
+  return collectStringObjectArray(root, relativePath, "apiRouteContracts", violations);
+}
+
+function collectStringObjectArray(root, relativePath, variableName, violations) {
+  const source = readSource(root, relativePath, violations);
+  if (!source) return [];
+  const registryNode = findVariableInitializer(source.file, variableName);
+  if (!registryNode || !ts.isArrayLiteralExpression(stripAsExpression(registryNode))) {
+    violations.push(`${relativePath}: missing ${variableName} array literal`);
+    return [];
+  }
+
+  const entries = [];
+  const arrayNode = stripAsExpression(registryNode);
+  for (const element of arrayNode.elements) {
+    if (!ts.isObjectLiteralExpression(element)) {
+      violations.push(`${relativePath}: ${variableName} entries must be object literals`);
+      continue;
+    }
+    entries.push(readStringObject(element, source.file));
+  }
+  return entries;
+}
+
+function collectPreloadMethods(root, relativePath, violations) {
+  const source = readSource(root, relativePath, violations);
+  if (!source) return new Set();
+  const initializer = findVariableInitializer(source.file, "allowedPreloadApi");
+  if (!initializer || !ts.isObjectLiteralExpression(stripAsExpression(initializer))) {
+    violations.push(`${relativePath}: missing allowedPreloadApi object literal`);
+    return new Set();
+  }
+  return new Set(stripAsExpression(initializer).properties.map((property) => propertyName(property.name, source.file)).filter(Boolean));
+}
+
+function collectDispatchBranches(root, relativePath, violations) {
+  const source = readSource(root, relativePath, violations);
+  if (!source) return new Map();
+  const branches = new Map();
+  let foundDispatcher = false;
+
+  function visit(node) {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === "dispatchGuiServiceMethod") {
+      foundDispatcher = true;
+      collectMethodBranches(node, source.file, branches, relativePath, violations);
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source.file);
+  if (!foundDispatcher) violations.push(`${relativePath}: missing dispatchGuiServiceMethod`);
+  return branches;
+}
+
+function collectTypeDeclarations(root, relativePath, violations) {
+  const source = readSource(root, relativePath, violations);
+  if (!source) return new Set();
+  const declarations = new Set();
+
+  function visit(node) {
+    if (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) declarations.add(node.name.text);
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source.file);
+  return declarations;
+}
+
+function collectLocalControllerServiceMethods(root, relativePath, violations) {
+  const source = readSource(root, relativePath, violations);
+  if (!source) return new Set();
+  const methods = new Set();
+
+  function visit(node) {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === "LocalControllerService") {
+      for (const member of node.members) {
+        if (ts.isPropertySignature(member) && ts.isIdentifier(member.name)) methods.add(member.name.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source.file);
+  if (methods.size === 0) violations.push(`${relativePath}: missing LocalControllerService methods`);
+  return methods;
+}
+
+function inspectSchemaContracts(schemaContracts, applicationDeclarations, registryDeclarations, relativePath, violations) {
+  const ids = new Set();
+  for (const entry of schemaContracts) {
+    const label = entry.id ? `schema ${entry.id}` : "schema <missing id>";
+    for (const field of ["id", "owner", "typeName"]) {
+      if (!entry[field]) violations.push(`${relativePath}: ${label} missing ${field}`);
+    }
+    if (entry.id && ids.has(entry.id)) violations.push(`${relativePath}: duplicate schema id ${entry.id}`);
+    if (entry.id) ids.add(entry.id);
+    if (entry.id && !schemaIdPattern.test(entry.id)) violations.push(`${relativePath}: ${label} has malformed id`);
+    if (entry.owner && !["application", "gui"].includes(entry.owner)) violations.push(`${relativePath}: ${label} has invalid owner ${entry.owner}`);
+    if (entry.owner === "application" && entry.typeName && !applicationDeclarations.has(entry.typeName)) {
+      violations.push(`${relativePath}: ${label} points to missing application type ${entry.typeName}`);
+    }
+    if (entry.owner === "gui" && entry.typeName && !registryDeclarations.has(entry.typeName)) {
+      violations.push(`${relativePath}: ${label} points to missing GUI contract type ${entry.typeName}`);
+    }
+  }
+}
+
+function inspectRegistryEntries(entries, schemaContracts, serviceMethods, preloadMethods, relativePath, violations) {
+  const ids = new Set();
+  const methodPaths = new Set();
+  const schemaIds = new Set(schemaContracts.map((entry) => entry.id));
+
+  for (const entry of entries) {
+    const label = entry.id ? `route ${entry.id}` : "route <missing id>";
+    for (const field of requiredFields) {
+      if (!entry[field]) violations.push(`${relativePath}: ${label} missing ${field}`);
+    }
+    if (entry.outputSchemaId === "") violations.push(`${relativePath}: ${label} has an empty outputSchemaId`);
+    if (entry.id && ids.has(entry.id)) violations.push(`${relativePath}: duplicate route id ${entry.id}`);
+    if (entry.id) ids.add(entry.id);
+    const methodPath = `${entry.method ?? ""} ${entry.path ?? ""}`;
+    if (entry.method && entry.path && methodPaths.has(methodPath)) violations.push(`${relativePath}: duplicate route method/path ${methodPath}`);
+    if (entry.method && entry.path) methodPaths.add(methodPath);
+    if (entry.method && !validMethods.has(entry.method)) violations.push(`${relativePath}: ${label} has invalid method ${entry.method}`);
+    if (entry.auth && !validAuthModes.has(entry.auth)) violations.push(`${relativePath}: ${label} has invalid auth ${entry.auth}`);
+    if (entry.path && !entry.path.startsWith("/api/")) violations.push(`${relativePath}: ${label} path must start with /api/`);
+    for (const field of ["inputSchemaId", "outputSchemaId", "errorSchemaId"]) {
+      if (entry[field] && !schemaIdPattern.test(entry[field])) violations.push(`${relativePath}: ${label} has malformed ${field} ${entry[field]}`);
+      if (entry[field] && !schemaIds.has(entry[field])) violations.push(`${relativePath}: ${label} ${field} ${entry[field]} is not registered in apiSchemaContracts`);
+    }
+    if (entry.service && entry.service !== "LocalControllerService") {
+      violations.push(`${relativePath}: ${label} unsupported service ${entry.service}`);
+    }
+    if (entry.serviceMethod && !serviceMethods.has(entry.serviceMethod)) {
+      violations.push(`${relativePath}: ${label} points to missing LocalControllerService.${entry.serviceMethod}`);
+    }
+    if (entry.guiBridgeMethod && !preloadMethods.has(entry.guiBridgeMethod)) {
+      violations.push(`${relativePath}: ${label} guiBridgeMethod ${entry.guiBridgeMethod} is not in preload allowlist`);
+    }
+  }
+}
+
+function inspectDeferredContracts(deferredContracts, routeContracts, serviceMethods, preloadMethods, relativePath, violations) {
+  const activeMethods = new Set(routeContracts.map((entry) => entry.guiBridgeMethod));
+  const deferredMethods = new Set();
+  for (const entry of deferredContracts) {
+    const label = entry.guiBridgeMethod ? `deferred ${entry.guiBridgeMethod}` : "deferred <missing guiBridgeMethod>";
+    for (const field of ["guiBridgeMethod", "service", "serviceMethod", "reason"]) {
+      if (!entry[field]) violations.push(`${relativePath}: ${label} missing ${field}`);
+    }
+    if (entry.guiBridgeMethod && deferredMethods.has(entry.guiBridgeMethod)) {
+      violations.push(`${relativePath}: duplicate deferred guiBridgeMethod ${entry.guiBridgeMethod}`);
+    }
+    if (entry.guiBridgeMethod) deferredMethods.add(entry.guiBridgeMethod);
+    if (entry.guiBridgeMethod && activeMethods.has(entry.guiBridgeMethod)) {
+      violations.push(`${relativePath}: ${entry.guiBridgeMethod} cannot be both an API route and a deferred GUI bridge contract`);
+    }
+    if (entry.service && entry.service !== "LocalControllerService") {
+      violations.push(`${relativePath}: ${label} unsupported service ${entry.service}`);
+    }
+    if (entry.serviceMethod && !serviceMethods.has(entry.serviceMethod)) {
+      violations.push(`${relativePath}: ${label} points to missing LocalControllerService.${entry.serviceMethod}`);
+    }
+    if (entry.guiBridgeMethod && !preloadMethods.has(entry.guiBridgeMethod)) {
+      violations.push(`${relativePath}: ${label} is not in preload allowlist`);
+    }
+  }
+}
+
+function inspectDispatchBranches(contracts, dispatchBranches, relativePath, violations) {
+  for (const entry of contracts) {
+    if (!entry.guiBridgeMethod || !entry.serviceMethod) continue;
+    const serviceCalls = dispatchBranches.get(entry.guiBridgeMethod);
+    if (!serviceCalls) {
+      violations.push(`${relativePath}: ${entry.guiBridgeMethod} is registered but has no dispatch branch`);
+      continue;
+    }
+    if (!serviceCalls.has(entry.serviceMethod)) {
+      violations.push(`${relativePath}: ${entry.guiBridgeMethod} dispatch does not call LocalControllerService.${entry.serviceMethod}`);
+    }
+    for (const serviceCall of serviceCalls) {
+      if (serviceCall !== entry.serviceMethod) {
+        violations.push(`${relativePath}: ${entry.guiBridgeMethod} dispatch calls unexpected LocalControllerService.${serviceCall}`);
+      }
+    }
+  }
+}
+
+function compareSets(left, right, context) {
+  for (const value of left) {
+    if (!right.has(value)) context.violations.push(`${context.filePath}: ${value} is in ${context.leftName} but missing from ${context.rightName}`);
+  }
+  for (const value of right) {
+    if (!left.has(value)) context.violations.push(`${context.filePath}: ${value} is in ${context.rightName} but missing from ${context.leftName}`);
+  }
+}
+
+function collectMethodBranches(node, sourceFile, branches, relativePath, violations) {
+  function visit(child) {
+    if (ts.isIfStatement(child)) {
+      const methodName = readMethodEquality(child.expression, sourceFile);
+      if (methodName) {
+        if (branches.has(methodName)) {
+          violations.push(`${relativePath}: duplicate dispatch branch for ${methodName}`);
+        } else {
+          branches.set(methodName, collectServiceCalls(child.thenStatement, sourceFile));
+        }
+        if (child.elseStatement) visit(child.elseStatement);
+        return;
+      }
+    }
+    ts.forEachChild(child, visit);
+  }
+
+  visit(node);
+}
+
+function readMethodEquality(expression, sourceFile) {
+  if (!ts.isBinaryExpression(expression) || expression.operatorToken.kind !== ts.SyntaxKind.EqualsEqualsEqualsToken) return undefined;
+  const left = expression.left.getText(sourceFile);
+  const right = expression.right.getText(sourceFile);
+  if (left === "method" && ts.isStringLiteral(expression.right)) return expression.right.text;
+  if (right === "method" && ts.isStringLiteral(expression.left)) return expression.left.text;
+  return undefined;
+}
+
+function collectServiceCalls(node, sourceFile) {
+  const serviceCalls = new Set();
+  function visit(child) {
+    if (ts.isCallExpression(child) && ts.isPropertyAccessExpression(child.expression)) {
+      const receiver = child.expression.expression.getText(sourceFile);
+      if (receiver === "service") serviceCalls.add(child.expression.name.text);
+    }
+    ts.forEachChild(child, visit);
+  }
+  visit(node);
+  return serviceCalls;
+}
+
+function readStringObject(objectNode, sourceFile) {
+  const record = {};
+  for (const property of objectNode.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name = propertyName(property.name, sourceFile);
+    const value = stripAsExpression(property.initializer);
+    if (name && ts.isStringLiteralLike(value)) record[name] = value.text;
+  }
+  return record;
+}
+
+function findVariableInitializer(sourceFile, variableName) {
+  let initializer;
+  function visit(node) {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === variableName) {
+      initializer = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return initializer;
+}
+
+function propertyName(name, sourceFile) {
+  if (!name) return undefined;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text;
+  return name.getText(sourceFile);
+}
+
+function stripAsExpression(node) {
+  let current = node;
+  while (ts.isAsExpression(current) || ts.isSatisfiesExpression(current)) current = current.expression;
+  return current;
+}
+
+function readSource(root, relativePath, violations) {
+  const absolutePath = path.join(root, relativePath);
+  if (!existsSync(absolutePath)) {
+    violations.push(`${relativePath}: missing file`);
+    return undefined;
+  }
+  const text = readFileSync(absolutePath, "utf8");
+  return {
+    text,
+    file: ts.createSourceFile(relativePath, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+  };
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const violations = evaluateApiContractRegistry();
+  if (violations.length > 0) {
+    console.error("API contract registry check failed:");
+    for (const violation of violations) console.error(`- ${violation}`);
+    process.exit(1);
+  }
+  console.log("API contract registry check passed.");
+}

--- a/tools/check-api-contract-registry.test.mjs
+++ b/tools/check-api-contract-registry.test.mjs
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { evaluateApiContractRegistry } from "./check-api-contract-registry.mjs";
+
+test("API contract registry accepts the repository route registry", () => {
+  assert.deepEqual(evaluateApiContractRegistry(), []);
+});
+
+test("API contract registry rejects preload methods missing from registry", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks", "getTaskDetail"],
+      dispatchMethods: ["getTasks", "getTaskDetail"],
+      serviceMethods: ["getTasks", "getTaskDetail"],
+      registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })]
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("getTaskDetail") && violation.includes("preload allowlist")), true);
+  });
+});
+
+test("API contract registry rejects routes pointing at missing service methods", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks"],
+      dispatchMethods: ["getTasks"],
+      serviceMethods: ["getTasks"],
+      registryEntries: [route({ serviceMethod: "missingMethod" })]
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("missing LocalControllerService.missingMethod")), true);
+  });
+});
+
+test("API contract registry rejects duplicate method and path pairs", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks", "getTaskDetail"],
+      dispatchMethods: ["getTasks", "getTaskDetail"],
+      serviceMethods: ["getTasks", "getTaskDetail"],
+      registryEntries: [
+        route({ id: "tasks.list", guiBridgeMethod: "getTasks", serviceMethod: "getTasks" }),
+        route({ id: "tasks.detail", guiBridgeMethod: "getTaskDetail", serviceMethod: "getTaskDetail" })
+      ]
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("duplicate route method/path GET /api/tasks")), true);
+  });
+});
+
+test("API contract registry rejects malformed schema ids and undispatched bridge methods", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks"],
+      dispatchMethods: [],
+      serviceMethods: ["getTasks"],
+      registryEntries: [route({ inputSchemaId: "TaskListResult", guiBridgeMethod: "getTasks" })]
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("malformed inputSchemaId")), true);
+    assert.equal(violations.some((violation) => violation.includes("GUI service dispatch")), true);
+  });
+});
+
+test("API contract registry rejects valid-looking but unregistered schema ids", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks"],
+      dispatchMethods: ["getTasks"],
+      serviceMethods: ["getTasks"],
+      registryEntries: [route({ inputSchemaId: "application.not-real/v1" })]
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("application.not-real/v1") && violation.includes("not registered")), true);
+  });
+});
+
+test("API contract registry rejects dispatch branches calling the wrong service method", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks"],
+      dispatchBranches: [{ method: "getTasks", serviceMethod: "getTaskDetail" }],
+      serviceMethods: ["getTasks", "getTaskDetail"],
+      registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })]
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("getTasks dispatch does not call LocalControllerService.getTasks")), true);
+    assert.equal(violations.some((violation) => violation.includes("getTasks dispatch calls unexpected LocalControllerService.getTaskDetail")), true);
+  });
+});
+
+test("API contract registry rejects duplicate dispatch branches", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks"],
+      dispatchBranches: [
+        { method: "getTasks", serviceMethod: "getTaskDetail" },
+        { method: "getTasks", serviceMethod: "getTasks" }
+      ],
+      serviceMethods: ["getTasks", "getTaskDetail"],
+      registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })]
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("duplicate dispatch branch for getTasks")), true);
+    assert.equal(violations.some((violation) => violation.includes("getTasks dispatch does not call LocalControllerService.getTasks")), true);
+  });
+});
+
+test("API contract registry covers deferred GUI bridge methods without active routes", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks", "archiveTask"],
+      dispatchMethods: ["getTasks", "archiveTask"],
+      serviceMethods: ["getTasks", "archiveTask"],
+      registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
+      deferredEntries: [{
+        guiBridgeMethod: "archiveTask",
+        service: "LocalControllerService",
+        serviceMethod: "archiveTask",
+        reason: "Archive is disabled until route ownership lands."
+      }]
+    });
+
+    assert.deepEqual(evaluateApiContractRegistry(root), []);
+  });
+});
+
+async function withFixtureRepo(fn) {
+  const root = await mkdtemp(path.join(tmpdir(), "ha-api-registry-"));
+  try {
+    mkdirSync(path.join(root, "packages/gui/src/api"), { recursive: true });
+    mkdirSync(path.join(root, "packages/gui/src/preload"), { recursive: true });
+    mkdirSync(path.join(root, "packages/application/src"), { recursive: true });
+    await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function writeFixture(root, options) {
+  const schemaContracts = options.schemaContracts ?? [
+    { id: "gui.empty/v1", owner: "gui", typeName: "EmptyGuiPayload" },
+    { id: "application.local-controller-error/v1", owner: "application", typeName: "LocalControllerError" },
+    { id: "application.task-list-result/v1", owner: "application", typeName: "TaskListResult" }
+  ];
+  const deferredEntries = options.deferredEntries ?? [];
+  const dispatchBranches = options.dispatchBranches
+    ?? options.dispatchMethods.map((method) => ({ method, serviceMethod: method }));
+  writeFileSync(path.join(root, "packages/gui/src/api/api-contract-registry.ts"), [
+    "export interface EmptyGuiPayload {}",
+    "export const apiSchemaContracts = [",
+    ...schemaContracts.map((entry) => `  ${JSON.stringify(entry)},`),
+    "] as const;",
+    "export const apiRouteContracts = [",
+    ...options.registryEntries.map((entry) => `  ${JSON.stringify(entry)},`),
+    "] as const;",
+    "export const deferredGuiBridgeContracts = [",
+    ...deferredEntries.map((entry) => `  ${JSON.stringify(entry)},`),
+    "] as const;",
+    ""
+  ].join("\n"), "utf8");
+  writeFileSync(path.join(root, "packages/gui/src/preload/allowlist.ts"), [
+    "export const allowedPreloadApi = {",
+    ...options.preloadMethods.map((method) => `  ${method}: ${JSON.stringify(method)},`),
+    "} as const;",
+    ""
+  ].join("\n"), "utf8");
+  writeFileSync(path.join(root, "packages/gui/src/api/service-bridge.ts"), [
+    "export function dispatchGuiServiceMethod(method: string): unknown {",
+    ...dispatchBranches.map((branch) => `  if (method === ${JSON.stringify(branch.method)}) return service.${branch.serviceMethod}();`),
+    "  return {};",
+    "}",
+    ""
+  ].join("\n"), "utf8");
+  writeFileSync(path.join(root, "packages/application/src/index.ts"), [
+    ...schemaContracts
+      .filter((entry) => entry.owner === "application")
+      .map((entry) => `export interface ${entry.typeName} {}`),
+    "export interface LocalControllerService {",
+    ...options.serviceMethods.map((method) => `  readonly ${method}: () => unknown;`),
+    "}",
+    ""
+  ].join("\n"), "utf8");
+}
+
+function route(overrides = {}) {
+  return {
+    id: "tasks.list",
+    method: "GET",
+    path: "/api/tasks",
+    inputSchemaId: "gui.empty/v1",
+    outputSchemaId: "application.task-list-result/v1",
+    errorSchemaId: "application.local-controller-error/v1",
+    service: "LocalControllerService",
+    serviceMethod: "getTasks",
+    auth: "local-session-token",
+    guiBridgeMethod: "getTasks",
+    ...overrides
+  };
+}


### PR DESCRIPTION
## Summary

- Add a typed GUI API contract registry for active daemon-compatible GUI bridge routes.
- Add deferred GUI bridge contracts for exposed placeholders so they stay covered without becoming active daemon route commitments.
- Add an API contract registry gate that compares registry/deferred coverage with preload allowlist, GUI dispatch branches, LocalControllerService methods, and schema contract ids.
- Wire the gate into npm run check.

## Review fixes

- Verify dispatch branches call the declared LocalControllerService method.
- Move archiveTask/openShell out of active route contracts.
- Require route schema ids to exist in apiSchemaContracts and point at existing TS contract types.
- Reject duplicate dispatch branches instead of letting later unreachable branches mask the runtime branch.

## Verification

- node --test tools/check-api-contract-registry.test.mjs passed 9/9
- npm run harness:check-api-contract-registry passed
- npm run typecheck passed
- npm run check passed with 272 tests and all gates/smokes
- Reviewer Noether final rereview: no open P0/P1/P2
