### PR TITLE
Add terminal session registry contracts

### DIFF
--- a/packages/gui/src/api/api-contract-registry.ts
+++ b/packages/gui/src/api/api-contract-registry.ts
@@ -1,8 +1,11 @@
 import type { LocalControllerService } from "../../../application/src/index.ts";
 import type { PreloadApiMethod } from "../preload/allowlist.ts";
+import type { TerminalSessionService } from "../terminal/session-registry.ts";
 
 export type ApiRouteMethod = "GET" | "POST" | "PUT" | "DELETE" | "WS";
 export type ApiRouteAuth = "local-session-token" | "ssh-tunnel-local-token" | "none";
+export type ApiServiceName = "LocalControllerService" | "TerminalSessionService";
+export type ApiServiceMethod = keyof LocalControllerService | keyof TerminalSessionService;
 
 export interface ApiRouteContract {
   readonly id: string;
@@ -11,10 +14,10 @@ export interface ApiRouteContract {
   readonly inputSchemaId: string;
   readonly outputSchemaId?: string;
   readonly errorSchemaId: string;
-  readonly service: "LocalControllerService";
-  readonly serviceMethod: keyof LocalControllerService;
+  readonly service: ApiServiceName;
+  readonly serviceMethod: ApiServiceMethod;
   readonly auth: ApiRouteAuth;
-  readonly guiBridgeMethod: PreloadApiMethod;
+  readonly guiBridgeMethod?: PreloadApiMethod;
 }
 
 export interface ApiSchemaContract {
@@ -44,7 +47,14 @@ export const apiSchemaContracts = [
   { id: "application.task-document-payload/v1", owner: "application", typeName: "TaskDocumentPayload" },
   { id: "application.task-document-result/v1", owner: "application", typeName: "TaskDocumentResult" },
   { id: "application.task-id-payload/v1", owner: "application", typeName: "TaskIdPayload" },
-  { id: "application.task-list-result/v1", owner: "application", typeName: "TaskListResult" }
+  { id: "application.task-list-result/v1", owner: "application", typeName: "TaskListResult" },
+  { id: "terminal.attach-policy-result/v1", owner: "gui", typeName: "TerminalAttachPolicyResult" },
+  { id: "terminal.create-session-payload/v1", owner: "gui", typeName: "CreateTerminalSessionPayload" },
+  { id: "terminal.resize-session-payload/v1", owner: "gui", typeName: "ResizeTerminalSessionPayload" },
+  { id: "terminal.session-detail-result/v1", owner: "gui", typeName: "TerminalSessionDetailResult" },
+  { id: "terminal.session-error/v1", owner: "gui", typeName: "TerminalSessionFailure" },
+  { id: "terminal.session-id-payload/v1", owner: "gui", typeName: "TerminalSessionIdPayload" },
+  { id: "terminal.session-list-result/v1", owner: "gui", typeName: "TerminalSessionListResult" }
 ] as const satisfies ReadonlyArray<ApiSchemaContract>;
 
 export const apiRouteContracts = [
@@ -131,6 +141,72 @@ export const apiRouteContracts = [
     serviceMethod: "rebuildGovernance",
     auth: "local-session-token",
     guiBridgeMethod: "rebuildGovernance"
+  },
+  {
+    id: "terminal.sessions.create",
+    method: "POST",
+    path: "/api/terminal/sessions",
+    inputSchemaId: "terminal.create-session-payload/v1",
+    outputSchemaId: "terminal.session-detail-result/v1",
+    errorSchemaId: "terminal.session-error/v1",
+    service: "TerminalSessionService",
+    serviceMethod: "createSession",
+    auth: "local-session-token"
+  },
+  {
+    id: "terminal.sessions.list",
+    method: "GET",
+    path: "/api/terminal/sessions",
+    inputSchemaId: "gui.empty/v1",
+    outputSchemaId: "terminal.session-list-result/v1",
+    errorSchemaId: "terminal.session-error/v1",
+    service: "TerminalSessionService",
+    serviceMethod: "listSessions",
+    auth: "local-session-token"
+  },
+  {
+    id: "terminal.sessions.get",
+    method: "GET",
+    path: "/api/terminal/sessions/:id",
+    inputSchemaId: "terminal.session-id-payload/v1",
+    outputSchemaId: "terminal.session-detail-result/v1",
+    errorSchemaId: "terminal.session-error/v1",
+    service: "TerminalSessionService",
+    serviceMethod: "getSession",
+    auth: "local-session-token"
+  },
+  {
+    id: "terminal.sessions.attach",
+    method: "WS",
+    path: "/api/terminal/sessions/:id/attach",
+    inputSchemaId: "terminal.session-id-payload/v1",
+    outputSchemaId: "terminal.attach-policy-result/v1",
+    errorSchemaId: "terminal.session-error/v1",
+    service: "TerminalSessionService",
+    serviceMethod: "attachSession",
+    auth: "local-session-token"
+  },
+  {
+    id: "terminal.sessions.resize",
+    method: "POST",
+    path: "/api/terminal/sessions/:id/resize",
+    inputSchemaId: "terminal.resize-session-payload/v1",
+    outputSchemaId: "terminal.session-detail-result/v1",
+    errorSchemaId: "terminal.session-error/v1",
+    service: "TerminalSessionService",
+    serviceMethod: "resizeSession",
+    auth: "local-session-token"
+  },
+  {
+    id: "terminal.sessions.close",
+    method: "DELETE",
+    path: "/api/terminal/sessions/:id",
+    inputSchemaId: "terminal.session-id-payload/v1",
+    outputSchemaId: "terminal.session-detail-result/v1",
+    errorSchemaId: "terminal.session-error/v1",
+    service: "TerminalSessionService",
+    serviceMethod: "closeSession",
+    auth: "local-session-token"
   }
 ] as const satisfies ReadonlyArray<ApiRouteContract>;
 
@@ -145,6 +221,6 @@ export const deferredGuiBridgeContracts = [
     guiBridgeMethod: "openShell",
     service: "LocalControllerService",
     serviceMethod: "openShell",
-    reason: "Shell opening is display-only GUI policy until M25GUI-P03 defines terminal session routes and metadata."
+    reason: "Legacy shell button remains a display-only GUI policy placeholder; terminal sessions use explicit terminal route contracts."
   }
 ] as const satisfies ReadonlyArray<DeferredGuiBridgeContract>;

--- a/packages/gui/src/index.ts
+++ b/packages/gui/src/index.ts
@@ -8,3 +8,4 @@ export * from "./main/window-config.ts";
 export * from "./preload/allowlist.ts";
 export * from "./renderer/app-model.ts";
 export * from "./terminal/boundary.ts";
+export * from "./terminal/session-registry.ts";

--- a/packages/gui/src/terminal/session-registry.ts
+++ b/packages/gui/src/terminal/session-registry.ts
@@ -1,0 +1,235 @@
+export type TerminalBackend = "direct-pty" | "tmux" | "remote";
+export type TerminalSessionStatus = "active" | "idle" | "exited";
+
+export interface TerminalSessionInfo {
+  readonly sessionId: string;
+  readonly name: string;
+  readonly backend: TerminalBackend;
+  readonly status: TerminalSessionStatus;
+  readonly hostProfileId?: string;
+  readonly hostLabel: string;
+  readonly projectId?: string;
+  readonly taskId?: string;
+  readonly cwd?: string;
+  readonly shell?: string;
+  readonly createdAt: string;
+  readonly lastActivityAt?: string;
+  readonly exitCode?: number;
+}
+
+export interface ScrollbackConfig {
+  readonly maxBytes: number;
+  readonly replayMaxBytes: number;
+  readonly eviction: "drop-oldest";
+}
+
+export interface TerminalSessionFailure {
+  readonly ok: false;
+  readonly error: {
+    readonly code: string;
+    readonly hint: string;
+  };
+}
+
+export interface TerminalSessionIdPayload {
+  readonly sessionId: string;
+}
+
+export interface CreateTerminalSessionPayload {
+  readonly name?: string;
+  readonly backend?: TerminalBackend;
+  readonly hostProfileId?: string;
+  readonly hostLabel?: string;
+  readonly projectId?: string;
+  readonly taskId?: string;
+  readonly cwd?: string;
+  readonly shell?: string;
+  readonly reopenOfSessionId?: string;
+}
+
+export interface ResizeTerminalSessionPayload extends TerminalSessionIdPayload {
+  readonly columns: number;
+  readonly rows: number;
+}
+
+export interface TerminalSessionDetailSuccess {
+  readonly ok: true;
+  readonly session: TerminalSessionInfo;
+}
+
+export type TerminalSessionDetailResult = TerminalSessionDetailSuccess | TerminalSessionFailure;
+
+export interface TerminalSessionListSuccess {
+  readonly ok: true;
+  readonly sessions: ReadonlyArray<TerminalSessionInfo>;
+}
+
+export type TerminalSessionListResult = TerminalSessionListSuccess | TerminalSessionFailure;
+
+export interface TerminalAttachPolicy {
+  readonly displayOnly: true;
+  readonly outputCreatesTaskState: false;
+  readonly inputAccepted: true;
+  readonly replayMaxBytes: number;
+}
+
+export interface TerminalAttachPolicySuccess {
+  readonly ok: true;
+  readonly session: TerminalSessionInfo;
+  readonly policy: TerminalAttachPolicy;
+}
+
+export type TerminalAttachPolicyResult = TerminalAttachPolicySuccess | TerminalSessionFailure;
+
+export interface TerminalSessionService {
+  readonly createSession: (payload: CreateTerminalSessionPayload) => TerminalSessionDetailResult;
+  readonly listSessions: () => TerminalSessionListResult;
+  readonly getSession: (payload: TerminalSessionIdPayload) => TerminalSessionDetailResult;
+  readonly attachSession: (payload: TerminalSessionIdPayload) => TerminalAttachPolicyResult;
+  readonly resizeSession: (payload: ResizeTerminalSessionPayload) => TerminalSessionDetailResult;
+  readonly closeSession: (payload: TerminalSessionIdPayload) => TerminalSessionDetailResult;
+}
+
+export interface InMemoryTerminalSessionService extends TerminalSessionService {
+  readonly detachSessionView: (payload: TerminalSessionIdPayload) => TerminalSessionDetailResult;
+}
+
+export interface TerminalSessionRegistryOptions {
+  readonly createId?: () => string;
+  readonly now?: () => string;
+  readonly defaultBackend?: TerminalBackend;
+  readonly defaultHostLabel?: string;
+  readonly scrollback?: ScrollbackConfig;
+}
+
+const defaultScrollback: ScrollbackConfig = {
+  maxBytes: 1_048_576,
+  replayMaxBytes: 262_144,
+  eviction: "drop-oldest"
+};
+
+export function createInMemoryTerminalSessionService(options: TerminalSessionRegistryOptions = {}): InMemoryTerminalSessionService {
+  const sessions = new Map<string, TerminalSessionInfo>();
+  const createId = options.createId ?? randomSessionId;
+  const now = options.now ?? (() => new Date().toISOString());
+  const defaultBackend = options.defaultBackend ?? "direct-pty";
+  const defaultHostLabel = options.defaultHostLabel ?? "local";
+  const scrollback = options.scrollback ?? defaultScrollback;
+
+  function getExistingSession(sessionId: string): TerminalSessionInfo | TerminalSessionFailure {
+    const session = sessions.get(sessionId);
+    if (!session) return failure("terminal_session_not_found", `Terminal session not found: ${sessionId}`);
+    return session;
+  }
+
+  function save(session: TerminalSessionInfo): TerminalSessionInfo {
+    sessions.set(session.sessionId, session);
+    return session;
+  }
+
+  return {
+    createSession: (payload) => {
+      const timestamp = now();
+      if (payload.reopenOfSessionId) {
+        const source = getExistingSession(payload.reopenOfSessionId);
+        if (!isTerminalSessionInfo(source)) return source;
+        if (source.status !== "exited") {
+          return failure("terminal_session_not_exited", "Only exited terminal sessions can be reopened.");
+        }
+        return {
+          ok: true,
+          session: save({
+            sessionId: createId(),
+            name: payload.name ?? source.name,
+            backend: payload.backend ?? source.backend,
+            hostProfileId: payload.hostProfileId ?? source.hostProfileId,
+            hostLabel: payload.hostLabel ?? source.hostLabel,
+            projectId: payload.projectId ?? source.projectId,
+            taskId: payload.taskId ?? source.taskId,
+            cwd: payload.cwd ?? source.cwd,
+            shell: payload.shell ?? source.shell,
+            status: "active",
+            createdAt: timestamp,
+            lastActivityAt: timestamp
+          })
+        };
+      }
+
+      return {
+        ok: true,
+        session: save({
+          sessionId: createId(),
+          name: payload.name ?? "Terminal",
+          backend: payload.backend ?? defaultBackend,
+          status: "active",
+          hostProfileId: payload.hostProfileId,
+          hostLabel: payload.hostLabel ?? defaultHostLabel,
+          projectId: payload.projectId,
+          taskId: payload.taskId,
+          cwd: payload.cwd,
+          shell: payload.shell,
+          createdAt: timestamp,
+          lastActivityAt: timestamp
+        })
+      };
+    },
+    listSessions: () => ({
+      ok: true,
+      sessions: [...sessions.values()].sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+    }),
+    getSession: (payload) => {
+      const session = getExistingSession(payload.sessionId);
+      if (!isTerminalSessionInfo(session)) return session;
+      return { ok: true, session };
+    },
+    attachSession: (payload) => {
+      const session = getExistingSession(payload.sessionId);
+      if (!isTerminalSessionInfo(session)) return session;
+      if (session.status === "exited") return failure("terminal_session_exited", "Reopen exited terminal sessions before attaching.");
+      const attached = save({ ...session, status: "active", lastActivityAt: now() });
+      return {
+        ok: true,
+        session: attached,
+        policy: {
+          displayOnly: true,
+          outputCreatesTaskState: false,
+          inputAccepted: true,
+          replayMaxBytes: scrollback.replayMaxBytes
+        }
+      };
+    },
+    resizeSession: (payload) => {
+      if (!Number.isInteger(payload.columns) || payload.columns <= 0 || !Number.isInteger(payload.rows) || payload.rows <= 0) {
+        return failure("invalid_terminal_size", "Terminal rows and columns must be positive integers.");
+      }
+      const session = getExistingSession(payload.sessionId);
+      if (!isTerminalSessionInfo(session)) return session;
+      if (session.status === "exited") return failure("terminal_session_exited", "Exited terminal sessions cannot be resized.");
+      return { ok: true, session: save({ ...session, lastActivityAt: now() }) };
+    },
+    closeSession: (payload) => {
+      const session = getExistingSession(payload.sessionId);
+      if (!isTerminalSessionInfo(session)) return session;
+      if (session.status === "exited") return { ok: true, session };
+      return { ok: true, session: save({ ...session, status: "exited", lastActivityAt: now(), exitCode: session.exitCode ?? 0 }) };
+    },
+    detachSessionView: (payload) => {
+      const session = getExistingSession(payload.sessionId);
+      if (!isTerminalSessionInfo(session)) return session;
+      if (session.status === "exited") return { ok: true, session };
+      return { ok: true, session: save({ ...session, status: "idle", lastActivityAt: now() }) };
+    }
+  };
+}
+
+function failure(code: string, hint: string): TerminalSessionFailure {
+  return { ok: false, error: { code, hint } };
+}
+
+function isTerminalSessionInfo(value: TerminalSessionInfo | TerminalSessionFailure): value is TerminalSessionInfo {
+  return !("ok" in value);
+}
+
+function randomSessionId(): string {
+  return `term-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/packages/gui/test/terminal-session-registry.test.ts
+++ b/packages/gui/test/terminal-session-registry.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { classifyShellOutput, createInMemoryTerminalSessionService } from "../src/index.ts";
+
+test("terminal session registry creates lists gets attaches resizes and closes runtime metadata", () => {
+  const service = createInMemoryTerminalSessionService({
+    createId: sequence("term"),
+    now: sequenceTime("2026-06-14T00:00:00.000Z"),
+    scrollback: {
+      maxBytes: 4096,
+      replayMaxBytes: 1024,
+      eviction: "drop-oldest"
+    }
+  });
+
+  const created = service.createSession({
+    name: "Task shell",
+    backend: "direct-pty",
+    hostLabel: "local",
+    projectId: "project-a",
+    taskId: "task-1",
+    cwd: "/workspace",
+    shell: "/bin/zsh"
+  });
+  assert.equal(created.ok, true);
+  if (!created.ok) return;
+  assert.equal(created.session.sessionId, "term-1");
+  assert.equal(created.session.status, "active");
+
+  assert.deepEqual(service.listSessions(), { ok: true, sessions: [created.session] });
+  assert.deepEqual(service.getSession({ sessionId: "term-1" }), { ok: true, session: created.session });
+
+  const attached = service.attachSession({ sessionId: "term-1" });
+  assert.equal(attached.ok, true);
+  if (!attached.ok) return;
+  assert.equal(attached.policy.displayOnly, true);
+  assert.equal(attached.policy.outputCreatesTaskState, false);
+  assert.equal(attached.policy.replayMaxBytes, 1024);
+
+  const resized = service.resizeSession({ sessionId: "term-1", columns: 120, rows: 40 });
+  assert.equal(resized.ok, true);
+  if (!resized.ok) return;
+  assert.equal(resized.session.status, "active");
+
+  const closed = service.closeSession({ sessionId: "term-1" });
+  assert.equal(closed.ok, true);
+  if (!closed.ok) return;
+  assert.equal(closed.session.status, "exited");
+  assert.equal(closed.session.exitCode, 0);
+  assert.equal(service.attachSession({ sessionId: "term-1" }).ok, false);
+});
+
+test("terminal session detach is distinct from explicit close", () => {
+  const service = createInMemoryTerminalSessionService({
+    createId: sequence("term"),
+    now: sequenceTime("2026-06-14T01:00:00.000Z")
+  });
+
+  const created = service.createSession({ name: "Detach test" });
+  assert.equal(created.ok, true);
+  if (!created.ok) return;
+
+  const detached = service.detachSessionView({ sessionId: created.session.sessionId });
+  assert.equal(detached.ok, true);
+  if (!detached.ok) return;
+  assert.equal(detached.session.status, "idle");
+  assert.equal(detached.session.exitCode, undefined);
+
+  const attached = service.attachSession({ sessionId: created.session.sessionId });
+  assert.equal(attached.ok, true);
+  if (!attached.ok) return;
+  assert.equal(attached.session.status, "active");
+});
+
+test("terminal session reopen creates a new session with inherited metadata", () => {
+  const service = createInMemoryTerminalSessionService({
+    createId: sequence("term"),
+    now: sequenceTime("2026-06-14T02:00:00.000Z")
+  });
+  const created = service.createSession({
+    name: "Reusable shell",
+    backend: "direct-pty",
+    hostLabel: "local",
+    projectId: "project-a",
+    taskId: "task-1",
+    cwd: "/workspace",
+    shell: "/bin/zsh"
+  });
+  assert.equal(created.ok, true);
+  if (!created.ok) return;
+
+  assert.equal(service.createSession({ reopenOfSessionId: created.session.sessionId }).ok, false);
+  const closed = service.closeSession({ sessionId: created.session.sessionId });
+  assert.equal(closed.ok, true);
+  if (!closed.ok) return;
+
+  const reopened = service.createSession({ reopenOfSessionId: created.session.sessionId });
+  assert.equal(reopened.ok, true);
+  if (!reopened.ok) return;
+  assert.equal(reopened.session.sessionId, "term-2");
+  assert.equal(reopened.session.name, "Reusable shell");
+  assert.equal(reopened.session.cwd, "/workspace");
+  assert.equal(reopened.session.taskId, "task-1");
+  assert.equal(reopened.session.status, "active");
+  assert.equal(reopened.session.exitCode, undefined);
+});
+
+test("shell chunks remain display-only", () => {
+  const chunk = classifyShellOutput("task status done");
+
+  assert.deepEqual(chunk, {
+    displayOnly: true,
+    stateChange: false
+  });
+});
+
+function sequence(prefix: string): () => string {
+  let value = 0;
+  return () => `${prefix}-${++value}`;
+}
+
+function sequenceTime(start: string): () => string {
+  let value = Date.parse(start);
+  return () => {
+    const current = new Date(value).toISOString();
+    value += 1000;
+    return current;
+  };
+}

--- a/tools/check-api-contract-registry.mjs
+++ b/tools/check-api-contract-registry.mjs
@@ -9,8 +9,18 @@ const defaults = {
   registryPath: "packages/gui/src/api/api-contract-registry.ts",
   allowlistPath: "packages/gui/src/preload/allowlist.ts",
   bridgePath: "packages/gui/src/api/service-bridge.ts",
-  applicationPath: "packages/application/src/index.ts"
+  applicationPath: "packages/application/src/index.ts",
+  terminalPath: "packages/gui/src/terminal/session-registry.ts"
 };
+const supportedServices = new Set(["LocalControllerService", "TerminalSessionService"]);
+const requiredTerminalRoutes = [
+  { id: "terminal.sessions.create", method: "POST", path: "/api/terminal/sessions", serviceMethod: "createSession" },
+  { id: "terminal.sessions.list", method: "GET", path: "/api/terminal/sessions", serviceMethod: "listSessions" },
+  { id: "terminal.sessions.get", method: "GET", path: "/api/terminal/sessions/:id", serviceMethod: "getSession" },
+  { id: "terminal.sessions.attach", method: "WS", path: "/api/terminal/sessions/:id/attach", serviceMethod: "attachSession" },
+  { id: "terminal.sessions.resize", method: "POST", path: "/api/terminal/sessions/:id/resize", serviceMethod: "resizeSession" },
+  { id: "terminal.sessions.close", method: "DELETE", path: "/api/terminal/sessions/:id", serviceMethod: "closeSession" }
+];
 const validMethods = new Set(["GET", "POST", "PUT", "DELETE", "WS"]);
 const validAuthModes = new Set(["local-session-token", "ssh-tunnel-local-token", "none"]);
 const requiredFields = [
@@ -21,8 +31,7 @@ const requiredFields = [
   "errorSchemaId",
   "service",
   "serviceMethod",
-  "auth",
-  "guiBridgeMethod"
+  "auth"
 ];
 const schemaIdPattern = /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*\/v[1-9][0-9]*$/u;
 
@@ -36,15 +45,24 @@ export function evaluateApiContractRegistry(root = process.cwd(), options = {}) 
   const dispatchBranches = collectDispatchBranches(root, paths.bridgePath, violations);
   const applicationDeclarations = collectTypeDeclarations(root, paths.applicationPath, violations);
   const registryDeclarations = collectTypeDeclarations(root, paths.registryPath, violations);
-  const serviceMethods = collectLocalControllerServiceMethods(root, paths.applicationPath, violations);
+  const terminalDeclarations = collectTypeDeclarations(root, paths.terminalPath, violations);
+  const guiDeclarations = new Set([...registryDeclarations, ...terminalDeclarations]);
+  const localControllerMethods = collectInterfaceMethods(root, paths.applicationPath, "LocalControllerService", violations);
+  const terminalSessionMethods = collectInterfaceMethods(root, paths.terminalPath, "TerminalSessionService", violations);
+  const serviceMethods = new Map([
+    ["LocalControllerService", localControllerMethods],
+    ["TerminalSessionService", terminalSessionMethods]
+  ]);
+  if (localControllerMethods.size === 0) violations.push(`${paths.applicationPath}: missing LocalControllerService methods`);
   const coveredBridgeMethods = new Set([
     ...registry.map((entry) => entry.guiBridgeMethod).filter(Boolean),
     ...deferredContracts.map((entry) => entry.guiBridgeMethod).filter(Boolean)
   ]);
 
-  inspectSchemaContracts(schemaContracts, applicationDeclarations, registryDeclarations, paths.registryPath, violations);
+  inspectSchemaContracts(schemaContracts, applicationDeclarations, guiDeclarations, paths.registryPath, violations);
   inspectRegistryEntries(registry, schemaContracts, serviceMethods, preloadMethods, paths.registryPath, violations);
-  inspectDeferredContracts(deferredContracts, registry, serviceMethods, preloadMethods, paths.registryPath, violations);
+  inspectRequiredTerminalRoutes(registry, paths.registryPath, violations);
+  inspectDeferredContracts(deferredContracts, registry, localControllerMethods, preloadMethods, paths.registryPath, violations);
   inspectDispatchBranches([...registry, ...deferredContracts], dispatchBranches, paths.bridgePath, violations);
   compareSets(preloadMethods, coveredBridgeMethods, {
     leftName: "preload allowlist",
@@ -60,6 +78,25 @@ export function evaluateApiContractRegistry(root = process.cwd(), options = {}) 
   });
 
   return violations;
+}
+
+function inspectRequiredTerminalRoutes(entries, relativePath, violations) {
+  const byId = new Map(entries.map((entry) => [entry.id, entry]));
+  for (const required of requiredTerminalRoutes) {
+    const entry = byId.get(required.id);
+    if (!entry) {
+      violations.push(`${relativePath}: missing required terminal route ${required.id}`);
+      continue;
+    }
+    for (const field of ["method", "path", "serviceMethod"]) {
+      if (entry[field] !== required[field]) {
+        violations.push(`${relativePath}: terminal route ${required.id} ${field} must be ${required[field]}`);
+      }
+    }
+    if (entry.service !== "TerminalSessionService") {
+      violations.push(`${relativePath}: terminal route ${required.id} service must be TerminalSessionService`);
+    }
+  }
 }
 
 function collectApiSchemaContracts(root, relativePath, violations) {
@@ -140,13 +177,13 @@ function collectTypeDeclarations(root, relativePath, violations) {
   return declarations;
 }
 
-function collectLocalControllerServiceMethods(root, relativePath, violations) {
+function collectInterfaceMethods(root, relativePath, interfaceName, violations) {
   const source = readSource(root, relativePath, violations);
   if (!source) return new Set();
   const methods = new Set();
 
   function visit(node) {
-    if (ts.isInterfaceDeclaration(node) && node.name.text === "LocalControllerService") {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === interfaceName) {
       for (const member of node.members) {
         if (ts.isPropertySignature(member) && ts.isIdentifier(member.name)) methods.add(member.name.text);
       }
@@ -155,7 +192,6 @@ function collectLocalControllerServiceMethods(root, relativePath, violations) {
   }
 
   visit(source.file);
-  if (methods.size === 0) violations.push(`${relativePath}: missing LocalControllerService methods`);
   return methods;
 }
 
@@ -202,11 +238,18 @@ function inspectRegistryEntries(entries, schemaContracts, serviceMethods, preloa
       if (entry[field] && !schemaIdPattern.test(entry[field])) violations.push(`${relativePath}: ${label} has malformed ${field} ${entry[field]}`);
       if (entry[field] && !schemaIds.has(entry[field])) violations.push(`${relativePath}: ${label} ${field} ${entry[field]} is not registered in apiSchemaContracts`);
     }
-    if (entry.service && entry.service !== "LocalControllerService") {
+    if (entry.service && !supportedServices.has(entry.service)) {
       violations.push(`${relativePath}: ${label} unsupported service ${entry.service}`);
     }
-    if (entry.serviceMethod && !serviceMethods.has(entry.serviceMethod)) {
-      violations.push(`${relativePath}: ${label} points to missing LocalControllerService.${entry.serviceMethod}`);
+    const methodSet = serviceMethods.get(entry.service);
+    if (entry.service && entry.serviceMethod && (!methodSet || !methodSet.has(entry.serviceMethod))) {
+      violations.push(`${relativePath}: ${label} points to missing ${entry.service}.${entry.serviceMethod}`);
+    }
+    if (entry.service === "LocalControllerService" && !entry.guiBridgeMethod) {
+      violations.push(`${relativePath}: ${label} LocalControllerService route missing guiBridgeMethod`);
+    }
+    if (entry.service === "TerminalSessionService" && entry.guiBridgeMethod) {
+      violations.push(`${relativePath}: ${label} TerminalSessionService route must not declare guiBridgeMethod`);
     }
     if (entry.guiBridgeMethod && !preloadMethods.has(entry.guiBridgeMethod)) {
       violations.push(`${relativePath}: ${label} guiBridgeMethod ${entry.guiBridgeMethod} is not in preload allowlist`);

--- a/tools/check-api-contract-registry.test.mjs
+++ b/tools/check-api-contract-registry.test.mjs
@@ -143,11 +143,79 @@ test("API contract registry covers deferred GUI bridge methods without active ro
   });
 });
 
+test("API contract registry accepts terminal service routes without preload dispatch", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks"],
+      dispatchMethods: ["getTasks"],
+      serviceMethods: ["getTasks"],
+      registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
+      terminalRoutes: requiredTerminalRoutes()
+    });
+
+    assert.deepEqual(evaluateApiContractRegistry(root), []);
+  });
+});
+
+test("API contract registry rejects terminal routes pointing at missing terminal service methods", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks"],
+      dispatchMethods: ["getTasks"],
+      serviceMethods: ["getTasks"],
+      terminalMethods: ["createSession", "listSessions", "getSession", "attachSession", "resizeSession", "closeSession"],
+      registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
+      terminalRoutes: requiredTerminalRoutes().map((entry) => entry.id === "terminal.sessions.list"
+        ? { ...entry, serviceMethod: "missingTerminalMethod" }
+        : entry)
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("missing TerminalSessionService.missingTerminalMethod")), true);
+  });
+});
+
+test("API contract registry rejects missing required terminal routes", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks"],
+      dispatchMethods: ["getTasks"],
+      serviceMethods: ["getTasks"],
+      registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
+      terminalRoutes: requiredTerminalRoutes().filter((entry) => entry.id !== "terminal.sessions.attach")
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("missing required terminal route terminal.sessions.attach")), true);
+  });
+});
+
+test("API contract registry rejects required terminal route path drift", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks"],
+      dispatchMethods: ["getTasks"],
+      serviceMethods: ["getTasks"],
+      registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
+      terminalRoutes: requiredTerminalRoutes().map((entry) => entry.id === "terminal.sessions.get"
+        ? { ...entry, path: "/api/terminal/sessions/:sessionId" }
+        : entry)
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("terminal route terminal.sessions.get path must be /api/terminal/sessions/:id")), true);
+  });
+});
+
 async function withFixtureRepo(fn) {
   const root = await mkdtemp(path.join(tmpdir(), "ha-api-registry-"));
   try {
     mkdirSync(path.join(root, "packages/gui/src/api"), { recursive: true });
     mkdirSync(path.join(root, "packages/gui/src/preload"), { recursive: true });
+    mkdirSync(path.join(root, "packages/gui/src/terminal"), { recursive: true });
     mkdirSync(path.join(root, "packages/application/src"), { recursive: true });
     await fn(root);
   } finally {
@@ -159,11 +227,20 @@ function writeFixture(root, options) {
   const schemaContracts = options.schemaContracts ?? [
     { id: "gui.empty/v1", owner: "gui", typeName: "EmptyGuiPayload" },
     { id: "application.local-controller-error/v1", owner: "application", typeName: "LocalControllerError" },
-    { id: "application.task-list-result/v1", owner: "application", typeName: "TaskListResult" }
+    { id: "application.task-list-result/v1", owner: "application", typeName: "TaskListResult" },
+    { id: "terminal.attach-policy-result/v1", owner: "gui", typeName: "TerminalAttachPolicyResult" },
+    { id: "terminal.create-session-payload/v1", owner: "gui", typeName: "CreateTerminalSessionPayload" },
+    { id: "terminal.resize-session-payload/v1", owner: "gui", typeName: "ResizeTerminalSessionPayload" },
+    { id: "terminal.session-detail-result/v1", owner: "gui", typeName: "TerminalSessionDetailResult" },
+    { id: "terminal.session-error/v1", owner: "gui", typeName: "TerminalSessionFailure" },
+    { id: "terminal.session-id-payload/v1", owner: "gui", typeName: "TerminalSessionIdPayload" },
+    { id: "terminal.session-list-result/v1", owner: "gui", typeName: "TerminalSessionListResult" }
   ];
   const deferredEntries = options.deferredEntries ?? [];
   const dispatchBranches = options.dispatchBranches
     ?? options.dispatchMethods.map((method) => ({ method, serviceMethod: method }));
+  const terminalRoutes = options.terminalRoutes ?? requiredTerminalRoutes();
+  const terminalMethods = options.terminalMethods ?? [...new Set(terminalRoutes.map((entry) => entry.serviceMethod))];
   writeFileSync(path.join(root, "packages/gui/src/api/api-contract-registry.ts"), [
     "export interface EmptyGuiPayload {}",
     "export const apiSchemaContracts = [",
@@ -171,6 +248,7 @@ function writeFixture(root, options) {
     "] as const;",
     "export const apiRouteContracts = [",
     ...options.registryEntries.map((entry) => `  ${JSON.stringify(entry)},`),
+    ...terminalRoutes.map((entry) => `  ${JSON.stringify(entry)},`),
     "] as const;",
     "export const deferredGuiBridgeContracts = [",
     ...deferredEntries.map((entry) => `  ${JSON.stringify(entry)},`),
@@ -199,6 +277,15 @@ function writeFixture(root, options) {
     "}",
     ""
   ].join("\n"), "utf8");
+  writeFileSync(path.join(root, "packages/gui/src/terminal/session-registry.ts"), [
+    ...schemaContracts
+      .filter((entry) => entry.owner === "gui" && entry.typeName !== "EmptyGuiPayload")
+      .map((entry) => `export interface ${entry.typeName} {}`),
+    "export interface TerminalSessionService {",
+    ...terminalMethods.map((method) => `  readonly ${method}: () => unknown;`),
+    "}",
+    ""
+  ].join("\n"), "utf8");
 }
 
 function route(overrides = {}) {
@@ -215,4 +302,72 @@ function route(overrides = {}) {
     guiBridgeMethod: "getTasks",
     ...overrides
   };
+}
+
+function terminalRoute(overrides = {}) {
+  return {
+    id: "terminal.sessions.list",
+    method: "GET",
+    path: "/api/terminal/sessions",
+    inputSchemaId: "gui.empty/v1",
+    outputSchemaId: "terminal.session-list-result/v1",
+    errorSchemaId: "terminal.session-error/v1",
+    service: "TerminalSessionService",
+    serviceMethod: "listSessions",
+    auth: "local-session-token",
+    ...overrides
+  };
+}
+
+function requiredTerminalRoutes() {
+  return [
+    terminalRoute({
+      id: "terminal.sessions.create",
+      method: "POST",
+      path: "/api/terminal/sessions",
+      inputSchemaId: "terminal.create-session-payload/v1",
+      outputSchemaId: "terminal.session-detail-result/v1",
+      serviceMethod: "createSession"
+    }),
+    terminalRoute({
+      id: "terminal.sessions.list",
+      method: "GET",
+      path: "/api/terminal/sessions",
+      inputSchemaId: "gui.empty/v1",
+      outputSchemaId: "terminal.session-list-result/v1",
+      serviceMethod: "listSessions"
+    }),
+    terminalRoute({
+      id: "terminal.sessions.get",
+      method: "GET",
+      path: "/api/terminal/sessions/:id",
+      inputSchemaId: "terminal.session-id-payload/v1",
+      outputSchemaId: "terminal.session-detail-result/v1",
+      serviceMethod: "getSession"
+    }),
+    terminalRoute({
+      id: "terminal.sessions.attach",
+      method: "WS",
+      path: "/api/terminal/sessions/:id/attach",
+      inputSchemaId: "terminal.session-id-payload/v1",
+      outputSchemaId: "terminal.attach-policy-result/v1",
+      serviceMethod: "attachSession"
+    }),
+    terminalRoute({
+      id: "terminal.sessions.resize",
+      method: "POST",
+      path: "/api/terminal/sessions/:id/resize",
+      inputSchemaId: "terminal.resize-session-payload/v1",
+      outputSchemaId: "terminal.session-detail-result/v1",
+      serviceMethod: "resizeSession"
+    }),
+    terminalRoute({
+      id: "terminal.sessions.close",
+      method: "DELETE",
+      path: "/api/terminal/sessions/:id",
+      inputSchemaId: "terminal.session-id-payload/v1",
+      outputSchemaId: "terminal.session-detail-result/v1",
+      serviceMethod: "closeSession"
+    })
+  ];
 }


### PR DESCRIPTION
## Summary

- Add terminal session metadata types and an in-memory runtime registry service.
- Register the six contract-39 terminal API routes in the GUI API contract registry.
- Extend the API registry gate to support TerminalSessionService route ownership and pin the required terminal route matrix.
- Add lifecycle tests for create/list/get/attach-policy/resize/close/reopen, detach-vs-close, and display-only shell chunks.

## Review fixes

- Required route matrix now pins all six terminal route contracts.
- Terminal paths use the contract-39 `:id` form.
- ScrollbackConfig matches contract 39: maxBytes 1 MiB, replayMaxBytes 256 KiB, eviction drop-oldest.

## Verification

- node --test tools/check-api-contract-registry.test.mjs packages/gui/test/terminal-session-registry.test.ts passed 17/17
- npm run harness:check-api-contract-registry passed
- npm run typecheck passed
- npm run check passed with 280 tests and all gates/smokes
- Reviewer Hilbert final rereview: no open P0/P1/P2
