### PR TITLE
Add durable terminal backend policy

### DIFF
--- a/packages/gui/src/index.ts
+++ b/packages/gui/src/index.ts
@@ -7,5 +7,6 @@ export * from "./main/ipc-handlers.ts";
 export * from "./main/window-config.ts";
 export * from "./preload/allowlist.ts";
 export * from "./renderer/app-model.ts";
+export * from "./terminal/backend-policy.ts";
 export * from "./terminal/boundary.ts";
 export * from "./terminal/session-registry.ts";

--- a/packages/gui/src/terminal/backend-policy.ts
+++ b/packages/gui/src/terminal/backend-policy.ts
@@ -1,0 +1,258 @@
+import type { TerminalBackend, TerminalSessionInfo } from "./session-registry.ts";
+
+export type TerminalBackendDurability = "none" | "daemon-restart" | "remote-owned";
+export type TerminalBackendEvidence = "always-available" | "probe" | "not-installed" | "remote-owned" | "disabled";
+
+export interface TerminalBackendCapability {
+  readonly backend: TerminalBackend;
+  readonly available: boolean;
+  readonly durability: TerminalBackendDurability;
+  readonly evidence: TerminalBackendEvidence;
+  readonly version?: string;
+  readonly reason?: string;
+}
+
+export interface TerminalBackendWarning {
+  readonly code: "terminal_backend_downgraded_non_durable";
+  readonly requestedBackend: TerminalBackend;
+  readonly selectedBackend: TerminalBackend;
+  readonly hint: string;
+}
+
+export interface TerminalBackendSelectionSuccess {
+  readonly ok: true;
+  readonly backend: TerminalBackend;
+  readonly capability: TerminalBackendCapability;
+  readonly durableAcrossDaemonRestart: boolean;
+  readonly warnings: ReadonlyArray<TerminalBackendWarning>;
+}
+
+export interface TerminalBackendFailure {
+  readonly ok: false;
+  readonly error: {
+    readonly code:
+      | "terminal_backend_mismatch"
+      | "terminal_backend_unavailable"
+      | "terminal_backend_not_registered"
+      | "terminal_backend_resource_closed";
+    readonly hint: string;
+  };
+}
+
+export type TerminalBackendSelectionResult = TerminalBackendSelectionSuccess | TerminalBackendFailure;
+
+export interface SelectTerminalBackendInput {
+  readonly requestedBackend?: TerminalBackend;
+  readonly defaultBackend?: TerminalBackend;
+  readonly capabilities: ReadonlyArray<TerminalBackendCapability>;
+  readonly allowDirectPtyFallback?: boolean;
+}
+
+export interface TerminalBackendNamespaceInput {
+  readonly sessionId: string;
+  readonly hostProfileId?: string;
+  readonly projectId?: string;
+  readonly taskId?: string;
+  readonly cwd?: string;
+}
+
+export interface TerminalBackendNamespace {
+  readonly namespace: string;
+  readonly material: string;
+}
+
+export type TerminalBackendResourceStatus = "attached" | "detached" | "closed";
+
+export interface TerminalBackendResource {
+  readonly resourceId: string;
+  readonly sessionId: string;
+  readonly backend: TerminalBackend;
+  readonly namespace: string;
+  readonly durability: TerminalBackendDurability;
+  readonly status: TerminalBackendResourceStatus;
+  readonly closeReason?: string;
+}
+
+export interface TerminalBackendResourceInput {
+  readonly session: TerminalSessionInfo;
+  readonly selection: TerminalBackendSelectionSuccess;
+  readonly namespace: TerminalBackendNamespace;
+}
+
+export interface TerminalBackendResourceSuccess {
+  readonly ok: true;
+  readonly resource: TerminalBackendResource;
+}
+
+export type TerminalBackendResourceResult = TerminalBackendResourceSuccess | TerminalBackendFailure;
+
+export interface InMemoryTerminalBackendController {
+  readonly createResource: (input: TerminalBackendResourceInput) => TerminalBackendResourceResult;
+  readonly detachResourceView: (sessionId: string) => TerminalBackendResourceResult;
+  readonly resumeResource: (sessionId: string) => TerminalBackendResourceResult;
+  readonly closeResource: (sessionId: string) => TerminalBackendResourceResult;
+  readonly simulateDaemonRestart: () => void;
+  readonly listResources: () => ReadonlyArray<TerminalBackendResource>;
+}
+
+export function directPtyCapability(): TerminalBackendCapability {
+  return {
+    backend: "direct-pty",
+    available: true,
+    durability: "none",
+    evidence: "always-available",
+    reason: "direct-pty sessions are development/degrade sessions and do not survive daemon restart."
+  };
+}
+
+export function tmuxCapability(input: { readonly available: boolean; readonly version?: string; readonly reason?: string }): TerminalBackendCapability {
+  return {
+    backend: "tmux",
+    available: input.available,
+    durability: "daemon-restart",
+    evidence: input.available ? "probe" : "not-installed",
+    version: input.version,
+    reason: input.reason
+  };
+}
+
+export function remoteCapability(input: { readonly available: boolean; readonly reason?: string }): TerminalBackendCapability {
+  return {
+    backend: "remote",
+    available: input.available,
+    durability: "remote-owned",
+    evidence: input.available ? "remote-owned" : "disabled",
+    reason: input.reason
+  };
+}
+
+export function selectTerminalBackend(input: SelectTerminalBackendInput): TerminalBackendSelectionResult {
+  const targetBackend = input.requestedBackend ?? input.defaultBackend ?? "direct-pty";
+  const target = findCapability(input.capabilities, targetBackend);
+  if (!target) return backendFailure("terminal_backend_not_registered", `Terminal backend is not registered: ${targetBackend}`);
+  if (target.available) return backendSelection(target, []);
+  if (targetBackend === "tmux" && input.allowDirectPtyFallback !== false) {
+    const fallback = findCapability(input.capabilities, "direct-pty");
+    if (fallback?.available) {
+      return backendSelection(fallback, [
+        {
+          code: "terminal_backend_downgraded_non_durable",
+          requestedBackend: "tmux",
+          selectedBackend: "direct-pty",
+          hint: target.reason ?? "tmux is unavailable; selected direct-pty. This session will not survive daemon restart."
+        }
+      ]);
+    }
+  }
+  return backendFailure("terminal_backend_unavailable", target.reason ?? `Terminal backend is unavailable: ${targetBackend}`);
+}
+
+export function createTerminalBackendNamespace(input: TerminalBackendNamespaceInput): TerminalBackendNamespace {
+  const material = [
+    `host=${input.hostProfileId ?? "local"}`,
+    `project=${input.projectId ?? "none"}`,
+    `task=${input.taskId ?? "none"}`,
+    `cwd=${input.cwd ?? "none"}`,
+    `session=${input.sessionId}`
+  ].join("|");
+  return {
+    namespace: `ha-${stableHash(material)}-${sanitizeNamespacePart(input.sessionId)}`,
+    material
+  };
+}
+
+export function createInMemoryTerminalBackendController(): InMemoryTerminalBackendController {
+  const resources = new Map<string, TerminalBackendResource>();
+
+  function save(resource: TerminalBackendResource): TerminalBackendResource {
+    resources.set(resource.sessionId, resource);
+    return resource;
+  }
+
+  function existing(sessionId: string): TerminalBackendResourceResult {
+    const resource = resources.get(sessionId);
+    if (!resource) return backendFailure("terminal_backend_unavailable", `No backend resource exists for terminal session: ${sessionId}`);
+    if (resource.status === "closed") {
+      return backendFailure("terminal_backend_resource_closed", resource.closeReason ?? "Terminal backend resource is closed.");
+    }
+    return { ok: true, resource };
+  }
+
+  return {
+    createResource: (input) => {
+      if (input.session.backend !== input.selection.backend) {
+        return backendFailure(
+          "terminal_backend_mismatch",
+          `Terminal session backend ${input.session.backend} does not match selected backend ${input.selection.backend}.`
+        );
+      }
+      const resource: TerminalBackendResource = {
+        resourceId: `${input.namespace.namespace}:${input.session.sessionId}`,
+        sessionId: input.session.sessionId,
+        backend: input.selection.backend,
+        namespace: input.namespace.namespace,
+        durability: input.selection.capability.durability,
+        status: "attached"
+      };
+      return { ok: true, resource: save(resource) };
+    },
+    detachResourceView: (sessionId) => {
+      const resource = existing(sessionId);
+      if (!resource.ok) return resource;
+      return { ok: true, resource: save({ ...resource.resource, status: "detached" }) };
+    },
+    resumeResource: (sessionId) => {
+      const resource = existing(sessionId);
+      if (!resource.ok) return resource;
+      return { ok: true, resource: save({ ...resource.resource, status: "attached" }) };
+    },
+    closeResource: (sessionId) => {
+      const resource = resources.get(sessionId);
+      if (!resource) return backendFailure("terminal_backend_unavailable", `No backend resource exists for terminal session: ${sessionId}`);
+      return { ok: true, resource: save({ ...resource, status: "closed", closeReason: "explicit-close" }) };
+    },
+    simulateDaemonRestart: () => {
+      for (const resource of resources.values()) {
+        if (resource.status === "closed") continue;
+        if (resource.durability === "none") {
+          save({ ...resource, status: "closed", closeReason: "daemon-restart-non-durable-backend" });
+        } else {
+          save({ ...resource, status: "detached" });
+        }
+      }
+    },
+    listResources: () => [...resources.values()].sort((left, right) => left.resourceId.localeCompare(right.resourceId))
+  };
+}
+
+function backendSelection(capability: TerminalBackendCapability, warnings: ReadonlyArray<TerminalBackendWarning>): TerminalBackendSelectionSuccess {
+  return {
+    ok: true,
+    backend: capability.backend,
+    capability,
+    durableAcrossDaemonRestart: capability.durability !== "none",
+    warnings
+  };
+}
+
+function backendFailure(code: TerminalBackendFailure["error"]["code"], hint: string): TerminalBackendFailure {
+  return { ok: false, error: { code, hint } };
+}
+
+function findCapability(capabilities: ReadonlyArray<TerminalBackendCapability>, backend: TerminalBackend): TerminalBackendCapability | undefined {
+  return capabilities.find((capability) => capability.backend === backend);
+}
+
+function sanitizeNamespacePart(value: string): string {
+  const sanitized = value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return sanitized || "terminal";
+}
+
+function stableHash(value: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}

--- a/packages/gui/test/terminal-backend-policy.test.ts
+++ b/packages/gui/test/terminal-backend-policy.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createInMemoryTerminalBackendController,
+  createTerminalBackendNamespace,
+  directPtyCapability,
+  remoteCapability,
+  selectTerminalBackend,
+  tmuxCapability
+} from "../src/index.ts";
+import type { TerminalSessionInfo } from "../src/index.ts";
+
+test("terminal backend selection uses tmux only with capability evidence", () => {
+  const selected = selectTerminalBackend({
+    requestedBackend: "tmux",
+    capabilities: [directPtyCapability(), tmuxCapability({ available: true, version: "tmux 3.4" })]
+  });
+
+  assert.equal(selected.ok, true);
+  if (!selected.ok) return;
+  assert.equal(selected.backend, "tmux");
+  assert.equal(selected.capability.version, "tmux 3.4");
+  assert.equal(selected.durableAcrossDaemonRestart, true);
+  assert.deepEqual(selected.warnings, []);
+});
+
+test("terminal backend selection downgrades unavailable tmux with explicit non-durable warning", () => {
+  const selected = selectTerminalBackend({
+    requestedBackend: "tmux",
+    capabilities: [directPtyCapability(), tmuxCapability({ available: false, reason: "tmux binary not found" })]
+  });
+
+  assert.equal(selected.ok, true);
+  if (!selected.ok) return;
+  assert.equal(selected.backend, "direct-pty");
+  assert.equal(selected.durableAcrossDaemonRestart, false);
+  assert.deepEqual(selected.warnings, [
+    {
+      code: "terminal_backend_downgraded_non_durable",
+      requestedBackend: "tmux",
+      selectedBackend: "direct-pty",
+      hint: "tmux binary not found"
+    }
+  ]);
+});
+
+test("terminal backend selection does not silently fallback remote ownership", () => {
+  const selected = selectTerminalBackend({
+    requestedBackend: "remote",
+    capabilities: [directPtyCapability(), remoteCapability({ available: false, reason: "remote daemon is not connected" })]
+  });
+
+  assert.deepEqual(selected, {
+    ok: false,
+    error: {
+      code: "terminal_backend_unavailable",
+      hint: "remote daemon is not connected"
+    }
+  });
+});
+
+test("terminal backend namespace is deterministic and separates project task contexts", () => {
+  const left = createTerminalBackendNamespace({
+    sessionId: "Term 01",
+    hostProfileId: "local",
+    projectId: "project-a",
+    taskId: "task-1",
+    cwd: "/workspace"
+  });
+  const same = createTerminalBackendNamespace({
+    sessionId: "Term 01",
+    hostProfileId: "local",
+    projectId: "project-a",
+    taskId: "task-1",
+    cwd: "/workspace"
+  });
+  const right = createTerminalBackendNamespace({
+    sessionId: "Term 01",
+    hostProfileId: "local",
+    projectId: "project-a",
+    taskId: "task-2",
+    cwd: "/workspace"
+  });
+
+  assert.deepEqual(left, same);
+  assert.notEqual(left.namespace, right.namespace);
+  assert.match(left.namespace, /^ha-[a-z0-9]+-term-01$/);
+});
+
+test("tmux backend resources detach and resume across daemon restart", () => {
+  const controller = createInMemoryTerminalBackendController();
+  const selection = selectTerminalBackend({
+    requestedBackend: "tmux",
+    capabilities: [directPtyCapability(), tmuxCapability({ available: true })]
+  });
+  assert.equal(selection.ok, true);
+  if (!selection.ok) return;
+
+  const created = controller.createResource({
+    session: session({ sessionId: "term-1", backend: "tmux" }),
+    selection,
+    namespace: createTerminalBackendNamespace({ sessionId: "term-1", projectId: "project-a", taskId: "task-1" })
+  });
+  assert.equal(created.ok, true);
+  if (!created.ok) return;
+
+  const detached = controller.detachResourceView("term-1");
+  assert.equal(detached.ok, true);
+  if (!detached.ok) return;
+  assert.equal(detached.resource.status, "detached");
+
+  controller.simulateDaemonRestart();
+
+  const resumed = controller.resumeResource("term-1");
+  assert.equal(resumed.ok, true);
+  if (!resumed.ok) return;
+  assert.equal(resumed.resource.resourceId, created.resource.resourceId);
+  assert.equal(resumed.resource.status, "attached");
+  assert.equal(resumed.resource.durability, "daemon-restart");
+});
+
+test("backend resources reject session and selection backend drift", () => {
+  const controller = createInMemoryTerminalBackendController();
+  const selection = selectTerminalBackend({
+    requestedBackend: "tmux",
+    capabilities: [directPtyCapability(), tmuxCapability({ available: true })]
+  });
+  assert.equal(selection.ok, true);
+  if (!selection.ok) return;
+
+  assert.deepEqual(
+    controller.createResource({
+      session: session({ sessionId: "term-mismatch", backend: "direct-pty" }),
+      selection,
+      namespace: createTerminalBackendNamespace({ sessionId: "term-mismatch", projectId: "project-a" })
+    }),
+    {
+      ok: false,
+      error: {
+        code: "terminal_backend_mismatch",
+        hint: "Terminal session backend direct-pty does not match selected backend tmux."
+      }
+    }
+  );
+});
+
+test("direct-pty backend resources are explicitly non-durable across daemon restart", () => {
+  const controller = createInMemoryTerminalBackendController();
+  const selection = selectTerminalBackend({
+    requestedBackend: "direct-pty",
+    capabilities: [directPtyCapability()]
+  });
+  assert.equal(selection.ok, true);
+  if (!selection.ok) return;
+
+  const created = controller.createResource({
+    session: session({ sessionId: "term-2", backend: "direct-pty" }),
+    selection,
+    namespace: createTerminalBackendNamespace({ sessionId: "term-2", projectId: "project-a" })
+  });
+  assert.equal(created.ok, true);
+
+  controller.simulateDaemonRestart();
+
+  assert.deepEqual(controller.resumeResource("term-2"), {
+    ok: false,
+    error: {
+      code: "terminal_backend_resource_closed",
+      hint: "daemon-restart-non-durable-backend"
+    }
+  });
+});
+
+test("explicit close releases durable backend resource while pane detach does not", () => {
+  const controller = createInMemoryTerminalBackendController();
+  const selection = selectTerminalBackend({
+    requestedBackend: "tmux",
+    capabilities: [directPtyCapability(), tmuxCapability({ available: true })]
+  });
+  assert.equal(selection.ok, true);
+  if (!selection.ok) return;
+
+  controller.createResource({
+    session: session({ sessionId: "term-3", backend: "tmux" }),
+    selection,
+    namespace: createTerminalBackendNamespace({ sessionId: "term-3", projectId: "project-a" })
+  });
+  assert.equal(controller.detachResourceView("term-3").ok, true);
+  assert.equal(controller.resumeResource("term-3").ok, true);
+
+  const closed = controller.closeResource("term-3");
+  assert.equal(closed.ok, true);
+  if (!closed.ok) return;
+  assert.equal(closed.resource.status, "closed");
+  assert.equal(controller.resumeResource("term-3").ok, false);
+});
+
+function session(overrides: Pick<TerminalSessionInfo, "sessionId" | "backend">): TerminalSessionInfo {
+  return {
+    sessionId: overrides.sessionId,
+    name: "Task shell",
+    backend: overrides.backend,
+    status: "active",
+    hostLabel: "local",
+    projectId: "project-a",
+    taskId: "task-1",
+    cwd: "/workspace",
+    shell: "/bin/zsh",
+    createdAt: "2026-06-14T00:00:00.000Z",
+    lastActivityAt: "2026-06-14T00:00:00.000Z"
+  };
+}


### PR DESCRIPTION
## Summary
- add a typed terminal backend policy surface for direct-pty, tmux, and remote backend ownership
- add deterministic backend selection, explicit non-durable tmux downgrade warnings, and backend namespace generation
- add an in-memory backend controller proving durable detach/resume semantics, explicit close cleanup, non-durable direct-pty daemon-restart loss, and session/selection backend drift rejection

## Review
- Dalton read-only review found one P2: backend resource creation could combine a tmux selection with a direct-pty session, creating conflicting control-plane truth.
- Fixed with `terminal_backend_mismatch` and regression coverage.
- Dalton rereview reported no open P0/P1/P2.
- Residual P3: the in-memory controller assumes `TerminalBackendSelectionSuccess` came from `selectTerminalBackend`; a forged structural object could make `selection.backend` and `selection.capability.durability` disagree. This is hardening, not a blocker for this control-plane spike.

## Verification
- `npm install` in the P04 worktree to create local workspace package links
- `npm run check` baseline passed with 280 tests and all gates/smokes
- `node --test packages/gui/test/terminal-backend-policy.test.ts packages/gui/test/terminal-session-registry.test.ts` passed 12/12 after review fix
- `npm run typecheck` passed
- `npm run harness:check-api-contract-registry` passed
- `npm run harness:check-implementation-contracts` passed
- `npm run check` passed with 288 tests and all gates/smokes after review fix
