### PR TITLE
Add remote daemon tunnel control plane

### DIFF
--- a/packages/gui/src/daemon/remote-tunnel.ts
+++ b/packages/gui/src/daemon/remote-tunnel.ts
@@ -1,0 +1,473 @@
+import type { ApiRouteAuth, ApiRouteContract } from "../api/api-contract-registry.ts";
+import type { TerminalSessionInfo } from "../terminal/session-registry.ts";
+
+export type DaemonTransport =
+  | { readonly kind: "local-ipc"; readonly endpoint: string }
+  | { readonly kind: "local-loopback"; readonly host: "127.0.0.1"; readonly port: number }
+  | { readonly kind: "ssh-tunnel"; readonly tunnelId: string; readonly localHost: "127.0.0.1"; readonly localPort: number };
+
+export type TunnelConnectionStatus =
+  | "initiating"
+  | "authenticating"
+  | "established"
+  | "degraded"
+  | "reconnecting"
+  | "failed"
+  | "closed";
+
+export interface TunnelConnectionInfo {
+  readonly tunnelId: string;
+  readonly hostProfileId: string;
+  readonly status: TunnelConnectionStatus;
+  readonly localHost: "127.0.0.1";
+  readonly localPort: number;
+  readonly remoteDaemonId?: string;
+  readonly startedAt: string;
+  readonly lastHeartbeatAt?: string;
+  readonly errorCode?: string;
+  readonly errorMessage?: string;
+}
+
+export interface RemoteHostProfile {
+  readonly hostProfileId: string;
+  readonly label: string;
+  readonly sshConfigHost: string;
+  readonly revokedAt?: string;
+}
+
+export interface RemoteDaemonAttachTokenMetadata {
+  readonly tokenId: string;
+  readonly daemonInstanceId: string;
+  readonly userId: string;
+  readonly hostProfileId: string;
+  readonly tunnelNonce: string;
+  readonly issuedAt: string;
+  readonly expiresAt: string;
+  readonly revokedAt?: string;
+}
+
+export interface RemoteDaemonAttachSecret {
+  readonly tokenId: string;
+  readonly value: string;
+}
+
+export interface RemoteDaemonAttachTokenSuccess {
+  readonly ok: true;
+  readonly metadata: RemoteDaemonAttachTokenMetadata;
+  readonly secret: RemoteDaemonAttachSecret;
+}
+
+export interface RemoteTunnelFailure {
+  readonly ok: false;
+  readonly error: {
+    readonly code:
+      | "host_profile_not_found"
+      | "host_profile_revoked"
+      | "invalid_tunnel_port"
+      | "invalid_tunnel_state"
+      | "token_already_used"
+      | "token_daemon_mismatch"
+      | "token_expired"
+      | "token_host_mismatch"
+      | "token_nonce_mismatch"
+      | "token_not_found"
+      | "token_revoked"
+      | "token_secret_mismatch"
+      | "tunnel_not_found";
+    readonly hint: string;
+  };
+}
+
+export type RemoteDaemonAttachTokenResult = RemoteDaemonAttachTokenSuccess | RemoteTunnelFailure;
+
+export interface RequestAttachTokenInput {
+  readonly hostProfileId: string;
+  readonly daemonInstanceId: string;
+  readonly userId: string;
+  readonly ttlMillis: number;
+  readonly tunnelNonce?: string;
+}
+
+export interface StartTunnelInput {
+  readonly hostProfileId: string;
+  readonly tokenId: string;
+  readonly tokenSecret: string;
+  readonly tunnelNonce: string;
+  readonly localPort: number;
+  readonly remoteDaemonId: string;
+}
+
+export interface InitiateTunnelInput {
+  readonly hostProfileId: string;
+  readonly localPort: number;
+}
+
+export interface AuthenticateTunnelInput {
+  readonly tunnelId: string;
+  readonly tokenId: string;
+  readonly tokenSecret: string;
+  readonly tunnelNonce: string;
+  readonly remoteDaemonId: string;
+}
+
+export interface TunnelConnectionSuccess {
+  readonly ok: true;
+  readonly tunnel: TunnelConnectionInfo;
+}
+
+export type TunnelConnectionResult = TunnelConnectionSuccess | RemoteTunnelFailure;
+
+export interface BoundApiRouteForTransport {
+  readonly id: string;
+  readonly method: ApiRouteContract["method"];
+  readonly path: string;
+  readonly service: ApiRouteContract["service"];
+  readonly serviceMethod: ApiRouteContract["serviceMethod"];
+  readonly auth: ApiRouteAuth;
+  readonly transport: DaemonTransport["kind"];
+}
+
+export interface RemoteTerminalSurfaceState {
+  readonly sessionId: string;
+  readonly terminalStatus: TerminalSessionInfo["status"];
+  readonly surfaceStatus: "attached" | "detached" | "degraded" | "closed";
+  readonly reason?: string;
+}
+
+export interface RemoteDaemonTunnelController {
+  readonly requestAttachToken: (input: RequestAttachTokenInput) => RemoteDaemonAttachTokenResult;
+  readonly initiateTunnel: (input: InitiateTunnelInput) => TunnelConnectionResult;
+  readonly authenticateTunnel: (input: AuthenticateTunnelInput) => TunnelConnectionResult;
+  readonly establishTunnel: (tunnelId: string) => TunnelConnectionResult;
+  readonly startTunnel: (input: StartTunnelInput) => TunnelConnectionResult;
+  readonly markDegraded: (tunnelId: string, errorCode: string, errorMessage: string) => TunnelConnectionResult;
+  readonly beginReconnect: (tunnelId: string) => TunnelConnectionResult;
+  readonly completeReconnect: (tunnelId: string) => TunnelConnectionResult;
+  readonly failTunnel: (tunnelId: string, errorCode: string, errorMessage: string) => TunnelConnectionResult;
+  readonly closeTunnel: (tunnelId: string) => TunnelConnectionResult;
+  readonly revokeHostProfile: (hostProfileId: string) => void;
+  readonly listTunnels: () => ReadonlyArray<TunnelConnectionInfo>;
+  readonly listTokenMetadata: () => ReadonlyArray<RemoteDaemonAttachTokenMetadata>;
+}
+
+export interface RemoteDaemonTunnelControllerOptions {
+  readonly hostProfiles: ReadonlyArray<RemoteHostProfile>;
+  readonly createId?: (prefix: string) => string;
+  readonly now?: () => string;
+}
+
+export function bindApiRoutesToDaemonTransport(
+  routes: ReadonlyArray<ApiRouteContract>,
+  transport: DaemonTransport
+): ReadonlyArray<BoundApiRouteForTransport> {
+  return routes.map((route) => ({
+    id: route.id,
+    method: route.method,
+    path: route.path,
+    service: route.service,
+    serviceMethod: route.serviceMethod,
+    auth: transport.kind === "ssh-tunnel" ? "ssh-tunnel-local-token" : route.auth,
+    transport: transport.kind
+  }));
+}
+
+export function createRemoteDaemonTunnelController(options: RemoteDaemonTunnelControllerOptions): RemoteDaemonTunnelController {
+  const hostProfiles = new Map(options.hostProfiles.map((profile) => [profile.hostProfileId, profile]));
+  const tokens = new Map<string, RemoteDaemonAttachTokenMetadata>();
+  const tokenSecrets = new Map<string, string>();
+  const consumedTokenIds = new Set<string>();
+  const tunnels = new Map<string, TunnelConnectionInfo>();
+  const createId = options.createId ?? randomId;
+  const now = options.now ?? (() => new Date().toISOString());
+
+  function hostProfile(hostProfileId: string): RemoteHostProfile | RemoteTunnelFailure {
+    const profile = hostProfiles.get(hostProfileId);
+    if (!profile) return failure("host_profile_not_found", `Remote host profile not found: ${hostProfileId}`);
+    if (profile.revokedAt) return failure("host_profile_revoked", `Remote host profile is revoked: ${hostProfileId}`);
+    return profile;
+  }
+
+  function validateToken(input: {
+    readonly tokenId: string;
+    readonly tokenSecret: string;
+    readonly hostProfileId: string;
+    readonly remoteDaemonId: string;
+    readonly tunnelNonce: string;
+  }): RemoteDaemonAttachTokenMetadata | RemoteTunnelFailure {
+    const tokenId = input.tokenId;
+    const token = tokens.get(tokenId);
+    if (!token) return failure("token_not_found", `Remote daemon attach token not found: ${tokenId}`);
+    if (token.hostProfileId !== input.hostProfileId) {
+      return failure("token_host_mismatch", "Remote daemon attach token is bound to a different host profile.");
+    }
+    if (token.daemonInstanceId !== input.remoteDaemonId) {
+      return failure("token_daemon_mismatch", "Remote daemon attach token is bound to a different daemon instance.");
+    }
+    if (token.tunnelNonce !== input.tunnelNonce) {
+      return failure("token_nonce_mismatch", "Remote daemon attach token is bound to a different tunnel nonce.");
+    }
+    if (tokenSecrets.get(tokenId) !== input.tokenSecret) {
+      return failure("token_secret_mismatch", "Remote daemon attach token secret is invalid.");
+    }
+    if (consumedTokenIds.has(tokenId)) return failure("token_already_used", "Remote daemon attach token has already been used.");
+    if (token.revokedAt) return failure("token_revoked", "Remote daemon attach token has been revoked.");
+    if (Date.parse(token.expiresAt) <= Date.parse(now())) return failure("token_expired", "Remote daemon attach token has expired.");
+    return token;
+  }
+
+  function existingTunnel(tunnelId: string): TunnelConnectionInfo | RemoteTunnelFailure {
+    const tunnel = tunnels.get(tunnelId);
+    if (!tunnel) return failure("tunnel_not_found", `Tunnel not found: ${tunnelId}`);
+    return tunnel;
+  }
+
+  function save(tunnel: TunnelConnectionInfo): TunnelConnectionInfo {
+    tunnels.set(tunnel.tunnelId, tunnel);
+    return tunnel;
+  }
+
+  const controller: RemoteDaemonTunnelController = {
+    requestAttachToken: (input) => {
+      const profile = hostProfile(input.hostProfileId);
+      if (!isRemoteHostProfile(profile)) return profile;
+      const issuedAt = now();
+      const tokenId = createId("token");
+      const metadata: RemoteDaemonAttachTokenMetadata = {
+        tokenId,
+        daemonInstanceId: input.daemonInstanceId,
+        userId: input.userId,
+        hostProfileId: input.hostProfileId,
+        tunnelNonce: input.tunnelNonce ?? createId("nonce"),
+        issuedAt,
+        expiresAt: new Date(Date.parse(issuedAt) + input.ttlMillis).toISOString()
+      };
+      tokens.set(tokenId, metadata);
+      const secret = createId("secret");
+      tokenSecrets.set(tokenId, secret);
+      return {
+        ok: true,
+        metadata,
+        secret: {
+          tokenId,
+          value: secret
+        }
+      };
+    },
+    initiateTunnel: (input) => {
+      const profile = hostProfile(input.hostProfileId);
+      if (!isRemoteHostProfile(profile)) return profile;
+      if (!Number.isInteger(input.localPort) || input.localPort <= 0 || input.localPort > 65535) {
+        return failure("invalid_tunnel_port", "SSH tunnel local port must be a valid TCP port.");
+      }
+      const timestamp = now();
+      return {
+        ok: true,
+        tunnel: save({
+          tunnelId: createId("tunnel"),
+          hostProfileId: input.hostProfileId,
+          status: "initiating",
+          localHost: "127.0.0.1",
+          localPort: input.localPort,
+          startedAt: timestamp
+        })
+      };
+    },
+    authenticateTunnel: (input) => {
+      const tunnel = existingTunnel(input.tunnelId);
+      if (!isTunnelConnectionInfo(tunnel)) return tunnel;
+      if (tunnel.status !== "initiating" && tunnel.status !== "reconnecting") {
+        return failure("invalid_tunnel_state", `Tunnel cannot authenticate from status: ${tunnel.status}`);
+      }
+      const profile = hostProfile(tunnel.hostProfileId);
+      if (!isRemoteHostProfile(profile)) return profile;
+      const token = validateToken({
+        tokenId: input.tokenId,
+        tokenSecret: input.tokenSecret,
+        hostProfileId: tunnel.hostProfileId,
+        remoteDaemonId: input.remoteDaemonId,
+        tunnelNonce: input.tunnelNonce
+      });
+      if (!isRemoteDaemonAttachTokenMetadata(token)) return token;
+      consumedTokenIds.add(input.tokenId);
+      return {
+        ok: true,
+        tunnel: save({
+          ...tunnel,
+          status: "authenticating",
+          remoteDaemonId: input.remoteDaemonId,
+          lastHeartbeatAt: now()
+        })
+      };
+    },
+    establishTunnel: (tunnelId) => {
+      const tunnel = existingTunnel(tunnelId);
+      if (!isTunnelConnectionInfo(tunnel)) return tunnel;
+      if (tunnel.status !== "authenticating") {
+        return failure("invalid_tunnel_state", `Tunnel cannot be established from status: ${tunnel.status}`);
+      }
+      return { ok: true, tunnel: save({ ...tunnel, status: "established", lastHeartbeatAt: now() }) };
+    },
+    startTunnel: (input) => {
+      const profile = hostProfile(input.hostProfileId);
+      if (!isRemoteHostProfile(profile)) return profile;
+      const token = validateToken({
+        tokenId: input.tokenId,
+        tokenSecret: input.tokenSecret,
+        hostProfileId: input.hostProfileId,
+        remoteDaemonId: input.remoteDaemonId,
+        tunnelNonce: input.tunnelNonce
+      });
+      if (!isRemoteDaemonAttachTokenMetadata(token)) return token;
+      if (!Number.isInteger(input.localPort) || input.localPort <= 0 || input.localPort > 65535) {
+        return failure("invalid_tunnel_port", "SSH tunnel local port must be a valid TCP port.");
+      }
+      consumedTokenIds.add(input.tokenId);
+      const timestamp = now();
+      return {
+        ok: true,
+        tunnel: save({
+          tunnelId: createId("tunnel"),
+          hostProfileId: input.hostProfileId,
+          status: "established",
+          localHost: "127.0.0.1",
+          localPort: input.localPort,
+          remoteDaemonId: input.remoteDaemonId,
+          startedAt: timestamp,
+          lastHeartbeatAt: timestamp
+        })
+      };
+    },
+    markDegraded: (tunnelId, errorCode, errorMessage) => {
+      const tunnel = existingTunnel(tunnelId);
+      if (!isTunnelConnectionInfo(tunnel)) return tunnel;
+      if (tunnel.status === "closed") return failure("invalid_tunnel_state", "Closed tunnels cannot be marked degraded.");
+      return {
+        ok: true,
+        tunnel: save({ ...tunnel, status: "degraded", errorCode, errorMessage, lastHeartbeatAt: now() })
+      };
+    },
+    beginReconnect: (tunnelId) => {
+      const tunnel = existingTunnel(tunnelId);
+      if (!isTunnelConnectionInfo(tunnel)) return tunnel;
+      if (tunnel.status !== "degraded" && tunnel.status !== "failed") {
+        return failure("invalid_tunnel_state", `Tunnel cannot reconnect from status: ${tunnel.status}`);
+      }
+      const profile = hostProfile(tunnel.hostProfileId);
+      if (!isRemoteHostProfile(profile)) return profile;
+      return { ok: true, tunnel: save({ ...tunnel, status: "reconnecting", lastHeartbeatAt: now() }) };
+    },
+    completeReconnect: (tunnelId) => {
+      const tunnel = existingTunnel(tunnelId);
+      if (!isTunnelConnectionInfo(tunnel)) return tunnel;
+      if (tunnel.status !== "reconnecting") {
+        return failure("invalid_tunnel_state", `Tunnel cannot complete reconnect from status: ${tunnel.status}`);
+      }
+      const profile = hostProfile(tunnel.hostProfileId);
+      if (!isRemoteHostProfile(profile)) return profile;
+      return {
+        ok: true,
+        tunnel: save({
+          ...tunnel,
+          status: "established",
+          lastHeartbeatAt: now(),
+          errorCode: undefined,
+          errorMessage: undefined
+        })
+      };
+    },
+    failTunnel: (tunnelId, errorCode, errorMessage) => {
+      const tunnel = existingTunnel(tunnelId);
+      if (!isTunnelConnectionInfo(tunnel)) return tunnel;
+      if (tunnel.status === "closed") return failure("invalid_tunnel_state", "Closed tunnels cannot be marked failed.");
+      return { ok: true, tunnel: save({ ...tunnel, status: "failed", errorCode, errorMessage, lastHeartbeatAt: now() }) };
+    },
+    closeTunnel: (tunnelId) => {
+      const tunnel = existingTunnel(tunnelId);
+      if (!isTunnelConnectionInfo(tunnel)) return tunnel;
+      return { ok: true, tunnel: save({ ...tunnel, status: "closed", lastHeartbeatAt: now() }) };
+    },
+    revokeHostProfile: (hostProfileId) => {
+      const timestamp = now();
+      const profile = hostProfiles.get(hostProfileId);
+      if (profile) hostProfiles.set(hostProfileId, { ...profile, revokedAt: timestamp });
+      for (const token of tokens.values()) {
+        if (token.hostProfileId === hostProfileId && !token.revokedAt) tokens.set(token.tokenId, { ...token, revokedAt: timestamp });
+      }
+      for (const tunnel of tunnels.values()) {
+        if (tunnel.hostProfileId === hostProfileId && tunnel.status !== "closed") {
+          save({
+            ...tunnel,
+            status: "closed",
+            lastHeartbeatAt: timestamp,
+            errorCode: "host_profile_revoked",
+            errorMessage: "Remote host profile was revoked."
+          });
+        }
+      }
+    },
+    listTunnels: () => [...tunnels.values()].sort((left, right) => left.tunnelId.localeCompare(right.tunnelId)),
+    listTokenMetadata: () => [...tokens.values()].sort((left, right) => left.tokenId.localeCompare(right.tokenId))
+  };
+  return controller;
+}
+
+export function deriveRemoteTerminalSurfaceState(
+  session: TerminalSessionInfo,
+  tunnel: TunnelConnectionInfo
+): RemoteTerminalSurfaceState {
+  if (session.status === "exited") {
+    return {
+      sessionId: session.sessionId,
+      terminalStatus: "exited",
+      surfaceStatus: "closed",
+      reason: "terminal-session-exited"
+    };
+  }
+  if (tunnel.status === "established") {
+    return {
+      sessionId: session.sessionId,
+      terminalStatus: session.status,
+      surfaceStatus: "attached"
+    };
+  }
+  if (tunnel.status === "closed") {
+    return {
+      sessionId: session.sessionId,
+      terminalStatus: session.status,
+      surfaceStatus: "detached",
+      reason: tunnel.errorCode ?? "tunnel-closed"
+    };
+  }
+  return {
+    sessionId: session.sessionId,
+    terminalStatus: session.status,
+    surfaceStatus: "degraded",
+    reason: tunnel.errorCode ?? `tunnel-${tunnel.status}`
+  };
+}
+
+export function publicTokenMetadata(metadata: RemoteDaemonAttachTokenMetadata): RemoteDaemonAttachTokenMetadata {
+  return { ...metadata };
+}
+
+function failure(code: RemoteTunnelFailure["error"]["code"], hint: string): RemoteTunnelFailure {
+  return { ok: false, error: { code, hint } };
+}
+
+function isRemoteHostProfile(value: RemoteHostProfile | RemoteTunnelFailure): value is RemoteHostProfile {
+  return !("ok" in value);
+}
+
+function isRemoteDaemonAttachTokenMetadata(
+  value: RemoteDaemonAttachTokenMetadata | RemoteTunnelFailure
+): value is RemoteDaemonAttachTokenMetadata {
+  return !("ok" in value);
+}
+
+function isTunnelConnectionInfo(value: TunnelConnectionInfo | RemoteTunnelFailure): value is TunnelConnectionInfo {
+  return !("ok" in value);
+}
+
+function randomId(prefix: string): string {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/packages/gui/src/index.ts
+++ b/packages/gui/src/index.ts
@@ -2,6 +2,7 @@ export * from "./api/local-api.ts";
 export * from "./api/api-contract-registry.ts";
 export * from "./api/service-bridge.ts";
 export * from "./api/view-model.ts";
+export * from "./daemon/remote-tunnel.ts";
 export * from "./doc-renderer/sanitize.ts";
 export * from "./main/ipc-handlers.ts";
 export * from "./main/window-config.ts";

--- a/packages/gui/test/remote-tunnel.test.ts
+++ b/packages/gui/test/remote-tunnel.test.ts
@@ -1,0 +1,440 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  apiRouteContracts,
+  bindApiRoutesToDaemonTransport,
+  createRemoteDaemonTunnelController,
+  deriveRemoteTerminalSurfaceState,
+  publicTokenMetadata
+} from "../src/index.ts";
+import type { RemoteHostProfile, TerminalSessionInfo } from "../src/index.ts";
+
+test("ssh tunnel transport reuses daemon API route semantics with tunnel auth only", () => {
+  const local = bindApiRoutesToDaemonTransport(apiRouteContracts, {
+    kind: "local-loopback",
+    host: "127.0.0.1",
+    port: 4873
+  });
+  const remote = bindApiRoutesToDaemonTransport(apiRouteContracts, {
+    kind: "ssh-tunnel",
+    tunnelId: "tunnel-1",
+    localHost: "127.0.0.1",
+    localPort: 65001
+  });
+
+  assert.deepEqual(
+    remote.map(({ id, method, path, service, serviceMethod }) => ({ id, method, path, service, serviceMethod })),
+    local.map(({ id, method, path, service, serviceMethod }) => ({ id, method, path, service, serviceMethod }))
+  );
+  assert.equal(remote.every((route) => route.auth === "ssh-tunnel-local-token"), true);
+  assert.equal(remote.some((route) => route.id.includes("remote")), false);
+});
+
+test("remote daemon token bootstrap stores metadata separately from the one-time secret", () => {
+  const controller = createRemoteDaemonTunnelController({
+    hostProfiles: [hostProfile("host-a")],
+    createId: sequenceId(),
+    now: sequenceTime("2026-06-14T00:00:00.000Z")
+  });
+
+  const issued = controller.requestAttachToken({
+    hostProfileId: "host-a",
+    daemonInstanceId: "daemon-a",
+    userId: "user-a",
+    ttlMillis: 60_000,
+    tunnelNonce: "nonce-a"
+  });
+
+  assert.equal(issued.ok, true);
+  if (!issued.ok) return;
+  assert.equal(issued.secret.value, "secret-2");
+  assert.deepEqual(publicTokenMetadata(issued.metadata), {
+    tokenId: "token-1",
+    daemonInstanceId: "daemon-a",
+    userId: "user-a",
+    hostProfileId: "host-a",
+    tunnelNonce: "nonce-a",
+    issuedAt: "2026-06-14T00:00:00.000Z",
+    expiresAt: "2026-06-14T00:01:00.000Z"
+  });
+  assert.deepEqual(controller.listTokenMetadata(), [issued.metadata]);
+  assert.equal(JSON.stringify(controller.listTokenMetadata()).includes("secret-2"), false);
+});
+
+test("remote daemon tunnel lifecycle distinguishes degraded reconnect failed and closed", () => {
+  const controller = createRemoteDaemonTunnelController({
+    hostProfiles: [hostProfile("host-a")],
+    createId: sequenceId(),
+    now: sequenceTime("2026-06-14T01:00:00.000Z")
+  });
+  const token = controller.requestAttachToken({
+    hostProfileId: "host-a",
+    daemonInstanceId: "daemon-a",
+    userId: "user-a",
+    ttlMillis: 60_000
+  });
+  assert.equal(token.ok, true);
+  if (!token.ok) return;
+
+  const initiated = controller.initiateTunnel({
+    hostProfileId: "host-a",
+    localPort: 65001
+  });
+  assert.equal(initiated.ok, true);
+  if (!initiated.ok) return;
+  assert.equal(initiated.tunnel.status, "initiating");
+
+  const authenticating = controller.authenticateTunnel({
+    tunnelId: initiated.tunnel.tunnelId,
+    tokenId: token.metadata.tokenId,
+    tokenSecret: token.secret.value,
+    tunnelNonce: token.metadata.tunnelNonce,
+    remoteDaemonId: "daemon-a"
+  });
+  assert.equal(authenticating.ok, true);
+  if (!authenticating.ok) return;
+  assert.equal(authenticating.tunnel.status, "authenticating");
+
+  const started = controller.establishTunnel(authenticating.tunnel.tunnelId);
+  assert.equal(started.ok, true);
+  if (!started.ok) return;
+  assert.equal(started.tunnel.status, "established");
+  assert.deepEqual(
+    controller.authenticateTunnel({
+      tunnelId: started.tunnel.tunnelId,
+      tokenId: token.metadata.tokenId,
+      tokenSecret: token.secret.value,
+      tunnelNonce: token.metadata.tunnelNonce,
+      remoteDaemonId: "daemon-a"
+    }),
+    {
+      ok: false,
+      error: {
+        code: "invalid_tunnel_state",
+        hint: "Tunnel cannot authenticate from status: established"
+      }
+    }
+  );
+
+  const degraded = controller.markDegraded(started.tunnel.tunnelId, "remote_daemon_unreachable", "heartbeat missed");
+  assert.equal(degraded.ok, true);
+  if (!degraded.ok) return;
+  assert.equal(degraded.tunnel.status, "degraded");
+  assert.equal(degraded.tunnel.errorCode, "remote_daemon_unreachable");
+
+  const reconnecting = controller.beginReconnect(started.tunnel.tunnelId);
+  assert.equal(reconnecting.ok, true);
+  if (!reconnecting.ok) return;
+  assert.equal(reconnecting.tunnel.status, "reconnecting");
+
+  const reconnected = controller.completeReconnect(started.tunnel.tunnelId);
+  assert.equal(reconnected.ok, true);
+  if (!reconnected.ok) return;
+  assert.equal(reconnected.tunnel.status, "established");
+  assert.equal(reconnected.tunnel.errorCode, undefined);
+
+  const failed = controller.failTunnel(started.tunnel.tunnelId, "ssh_tunnel_closed", "ssh process exited");
+  assert.equal(failed.ok, true);
+  if (!failed.ok) return;
+  assert.equal(failed.tunnel.status, "failed");
+
+  const closed = controller.closeTunnel(started.tunnel.tunnelId);
+  assert.equal(closed.ok, true);
+  if (!closed.ok) return;
+  assert.equal(closed.tunnel.status, "closed");
+});
+
+test("token expiry and host revoke block new tunnel use without requiring network", () => {
+  const controller = createRemoteDaemonTunnelController({
+    hostProfiles: [hostProfile("host-a"), hostProfile("host-b")],
+    createId: sequenceId(),
+    now: sequenceTime("2026-06-14T02:00:00.000Z", 61_000)
+  });
+  const expired = controller.requestAttachToken({
+    hostProfileId: "host-a",
+    daemonInstanceId: "daemon-a",
+    userId: "user-a",
+    ttlMillis: 60_000
+  });
+  assert.equal(expired.ok, true);
+  if (!expired.ok) return;
+
+  assert.deepEqual(
+    controller.startTunnel({
+      hostProfileId: "host-a",
+      tokenId: expired.metadata.tokenId,
+      tokenSecret: expired.secret.value,
+      tunnelNonce: expired.metadata.tunnelNonce,
+      localPort: 65001,
+      remoteDaemonId: "daemon-a"
+    }),
+    {
+      ok: false,
+      error: {
+        code: "token_expired",
+        hint: "Remote daemon attach token has expired."
+      }
+    }
+  );
+
+  const revoked = controller.requestAttachToken({
+    hostProfileId: "host-b",
+    daemonInstanceId: "daemon-b",
+    userId: "user-a",
+    ttlMillis: 120_000
+  });
+  assert.equal(revoked.ok, true);
+  if (!revoked.ok) return;
+  controller.revokeHostProfile("host-b");
+
+  assert.deepEqual(
+    controller.startTunnel({
+      hostProfileId: "host-b",
+      tokenId: revoked.metadata.tokenId,
+      tokenSecret: revoked.secret.value,
+      tunnelNonce: revoked.metadata.tunnelNonce,
+      localPort: 65002,
+      remoteDaemonId: "daemon-b"
+    }),
+    {
+      ok: false,
+      error: {
+        code: "host_profile_revoked",
+        hint: "Remote host profile is revoked: host-b"
+      }
+    }
+  );
+});
+
+test("token id metadata alone cannot authenticate and attach tokens are one-time daemon nonce bound", () => {
+  const controller = createRemoteDaemonTunnelController({
+    hostProfiles: [hostProfile("host-a")],
+    createId: sequenceId(),
+    now: sequenceTime("2026-06-14T02:30:00.000Z")
+  });
+  const issued = controller.requestAttachToken({
+    hostProfileId: "host-a",
+    daemonInstanceId: "daemon-a",
+    userId: "user-a",
+    ttlMillis: 60_000,
+    tunnelNonce: "nonce-a"
+  });
+  assert.equal(issued.ok, true);
+  if (!issued.ok) return;
+
+  assert.deepEqual(
+    controller.startTunnel({
+      hostProfileId: "host-a",
+      tokenId: issued.metadata.tokenId,
+      tokenSecret: "not-the-secret",
+      tunnelNonce: "nonce-a",
+      localPort: 65001,
+      remoteDaemonId: "daemon-a"
+    }),
+    {
+      ok: false,
+      error: {
+        code: "token_secret_mismatch",
+        hint: "Remote daemon attach token secret is invalid."
+      }
+    }
+  );
+  assert.deepEqual(
+    controller.startTunnel({
+      hostProfileId: "host-a",
+      tokenId: issued.metadata.tokenId,
+      tokenSecret: issued.secret.value,
+      tunnelNonce: "wrong-nonce",
+      localPort: 65001,
+      remoteDaemonId: "daemon-a"
+    }),
+    {
+      ok: false,
+      error: {
+        code: "token_nonce_mismatch",
+        hint: "Remote daemon attach token is bound to a different tunnel nonce."
+      }
+    }
+  );
+  assert.deepEqual(
+    controller.startTunnel({
+      hostProfileId: "host-a",
+      tokenId: issued.metadata.tokenId,
+      tokenSecret: issued.secret.value,
+      tunnelNonce: "nonce-a",
+      localPort: 65001,
+      remoteDaemonId: "daemon-b"
+    }),
+    {
+      ok: false,
+      error: {
+        code: "token_daemon_mismatch",
+        hint: "Remote daemon attach token is bound to a different daemon instance."
+      }
+    }
+  );
+
+  const started = controller.startTunnel({
+    hostProfileId: "host-a",
+    tokenId: issued.metadata.tokenId,
+    tokenSecret: issued.secret.value,
+    tunnelNonce: "nonce-a",
+    localPort: 65001,
+    remoteDaemonId: "daemon-a"
+  });
+  assert.equal(started.ok, true);
+  if (!started.ok) return;
+
+  assert.deepEqual(
+    controller.startTunnel({
+      hostProfileId: "host-a",
+      tokenId: issued.metadata.tokenId,
+      tokenSecret: issued.secret.value,
+      tunnelNonce: "nonce-a",
+      localPort: 65002,
+      remoteDaemonId: "daemon-a"
+    }),
+    {
+      ok: false,
+      error: {
+        code: "token_already_used",
+        hint: "Remote daemon attach token has already been used."
+      }
+    }
+  );
+});
+
+test("closed or revoked tunnels cannot be reconnected back to established", () => {
+  const controller = createRemoteDaemonTunnelController({
+    hostProfiles: [hostProfile("host-a")],
+    createId: sequenceId(),
+    now: sequenceTime("2026-06-14T02:45:00.000Z")
+  });
+  const token = controller.requestAttachToken({
+    hostProfileId: "host-a",
+    daemonInstanceId: "daemon-a",
+    userId: "user-a",
+    ttlMillis: 60_000
+  });
+  assert.equal(token.ok, true);
+  if (!token.ok) return;
+  const started = controller.startTunnel({
+    hostProfileId: "host-a",
+    tokenId: token.metadata.tokenId,
+    tokenSecret: token.secret.value,
+    tunnelNonce: token.metadata.tunnelNonce,
+    localPort: 65001,
+    remoteDaemonId: "daemon-a"
+  });
+  assert.equal(started.ok, true);
+  if (!started.ok) return;
+
+  assert.deepEqual(controller.beginReconnect(started.tunnel.tunnelId), {
+    ok: false,
+    error: {
+      code: "invalid_tunnel_state",
+      hint: "Tunnel cannot reconnect from status: established"
+    }
+  });
+  controller.revokeHostProfile("host-a");
+  assert.deepEqual(controller.completeReconnect(started.tunnel.tunnelId), {
+    ok: false,
+    error: {
+      code: "invalid_tunnel_state",
+      hint: "Tunnel cannot complete reconnect from status: closed"
+    }
+  });
+  assert.deepEqual(controller.markDegraded(started.tunnel.tunnelId, "stale_heartbeat", "late stale event"), {
+    ok: false,
+    error: {
+      code: "invalid_tunnel_state",
+      hint: "Closed tunnels cannot be marked degraded."
+    }
+  });
+  assert.deepEqual(controller.failTunnel(started.tunnel.tunnelId, "stale_ssh_close", "late stale event"), {
+    ok: false,
+    error: {
+      code: "invalid_tunnel_state",
+      hint: "Closed tunnels cannot be marked failed."
+    }
+  });
+});
+
+test("tunnel disconnect and host revoke degrade remote terminal surfaces instead of exiting sessions", () => {
+  const activeSession = remoteSession("term-1", "active");
+  const exitedSession = remoteSession("term-2", "exited");
+  const degradedTunnel = {
+    tunnelId: "tunnel-1",
+    hostProfileId: "host-a",
+    status: "degraded" as const,
+    localHost: "127.0.0.1" as const,
+    localPort: 65001,
+    startedAt: "2026-06-14T03:00:00.000Z",
+    errorCode: "ssh_tunnel_closed",
+    errorMessage: "ssh process exited"
+  };
+  const closedRevokedTunnel = {
+    ...degradedTunnel,
+    status: "closed" as const,
+    errorCode: "host_profile_revoked",
+    errorMessage: "Remote host profile was revoked."
+  };
+
+  assert.deepEqual(deriveRemoteTerminalSurfaceState(activeSession, degradedTunnel), {
+    sessionId: "term-1",
+    terminalStatus: "active",
+    surfaceStatus: "degraded",
+    reason: "ssh_tunnel_closed"
+  });
+  assert.deepEqual(deriveRemoteTerminalSurfaceState(activeSession, closedRevokedTunnel), {
+    sessionId: "term-1",
+    terminalStatus: "active",
+    surfaceStatus: "detached",
+    reason: "host_profile_revoked"
+  });
+  assert.deepEqual(deriveRemoteTerminalSurfaceState(exitedSession, degradedTunnel), {
+    sessionId: "term-2",
+    terminalStatus: "exited",
+    surfaceStatus: "closed",
+    reason: "terminal-session-exited"
+  });
+});
+
+function hostProfile(hostProfileId: string): RemoteHostProfile {
+  return {
+    hostProfileId,
+    label: hostProfileId,
+    sshConfigHost: hostProfileId
+  };
+}
+
+function remoteSession(sessionId: string, status: TerminalSessionInfo["status"]): TerminalSessionInfo {
+  return {
+    sessionId,
+    name: "Remote shell",
+    backend: "remote",
+    status,
+    hostProfileId: "host-a",
+    hostLabel: "remote-a",
+    projectId: "project-a",
+    taskId: "task-a",
+    cwd: "/workspace",
+    shell: "/bin/zsh",
+    createdAt: "2026-06-14T03:00:00.000Z",
+    lastActivityAt: "2026-06-14T03:00:00.000Z"
+  };
+}
+
+function sequenceId(): (prefix: string) => string {
+  let value = 0;
+  return (prefix) => `${prefix}-${++value}`;
+}
+
+function sequenceTime(start: string, stepMs = 1000): () => string {
+  let value = Date.parse(start);
+  return () => {
+    const current = new Date(value).toISOString();
+    value += stepMs;
+    return current;
+  };
+}


### PR DESCRIPTION
## Summary

Adds the M25GUI-P05 remote daemon over SSH tunnel control-plane model. This is deterministic GUI/daemon contract work only: no real SSH execution, no production daemon server, and no workspace shell UI.

## What Changed

- Added typed daemon transport and tunnel lifecycle contracts for local IPC, local loopback, and SSH tunnel transports.
- Added an in-memory remote tunnel controller with host profiles, one-time attach token secrets, daemon/nonce/expiry/revoke validation, reconnect/degraded/failed/closed transitions, and remote terminal surface derivation.
- Added regression coverage for route semantic reuse, token secrecy, one-time token binding, host revoke, stale event rejection after closed/revoked tunnels, and terminal detach/degrade behavior.

## Task And Scope

- Harness task: M25GUI-P05 Remote daemon over SSH tunnel
- Branch: `codex/m2-5-gui-p05-remote-daemon-ssh-tunnel`
- Public scope: `packages/gui/src/daemon/remote-tunnel.ts`, `packages/gui/src/index.ts`, `packages/gui/test/remote-tunnel.test.ts`
- Private planning/evidence updated: yes
- Out of scope: real SSH execution, production daemon server, WebSocket transport, workspace shell UI/docking, browser pane remote content, full terminal streaming, kernel lifecycle/preset/migration changes

## Version Impact

- Version: no version change because this is a pre-release internal contract slice
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: `82a6a38cbde164c1dc4aabb1ae01757a6ebe7728`
- Branch merge-base with `origin/main`: `82a6a38cbde164c1dc4aabb1ae01757a6ebe7728`
- Last `git fetch origin` time: `2026-06-14 09:28:24 CST`
- Sync method: none needed; branch merge-base equals latest `origin/main`
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: private commit `2e349f5`; `planning/modules/m2-5-gui/tasks/2026-06-14-m2-5-gui-p05-remote-daemon-ssh-tunnel/`
- Reviewer evidence path: same private task `review.md`; Archimedes final rereview reported no P0/P1/P2
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/27484748796
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` was not run in this worktree; dependencies were already installed and `npm run check` passed end-to-end.

## Review Evidence

- Self-review: verified public diff scope, no real SSH/network execution calls, no private files, and no remote-only API route ids/service methods.
- Reviewer subagent: Archimedes final rereview found no P0/P1/P2; prior stale-event P2 closed by rejecting degraded/failed writes to closed tunnels.
- Human review: pending PR review if required
- Blocking findings: none open

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear: merge after green CI, then delete local and remote branch, remove worktree, sync local main, and run post-merge `npm run check`.

## Residual Risk

- This is a control-plane model only. Later GUI packets still need actual workspace shell UI, daemon process integration, and browser remote trust handling.

## References

- Task: `planning/modules/m2-5-gui/tasks/2026-06-14-m2-5-gui-p05-remote-daemon-ssh-tunnel/task_plan.md`
- Evidence: `planning/modules/m2-5-gui/tasks/2026-06-14-m2-5-gui-p05-remote-daemon-ssh-tunnel/progress.md`
- Review: `planning/modules/m2-5-gui/tasks/2026-06-14-m2-5-gui-p05-remote-daemon-ssh-tunnel/review.md`

---

## 摘要

新增 M25GUI-P05 remote daemon over SSH tunnel control-plane model。该 PR 只做确定性的 GUI/daemon contract 建模，不执行真实 SSH，不实现 production daemon server，也不做 workspace shell UI。

## 改动内容

- 新增 local IPC、local loopback、SSH tunnel 三类 daemon transport 与 tunnel lifecycle 类型。
- 新增 in-memory remote tunnel controller，覆盖 host profile、一次性 attach token secret、daemon/nonce/expiry/revoke 校验、reconnect/degraded/failed/closed 状态，以及 remote terminal surface 推导。
- 新增回归测试，覆盖 route semantic reuse、token secrecy、一次性 token 绑定、host revoke、closed/revoked 后 stale event 拒绝，以及 terminal detach/degrade 行为。

## 任务与范围

- Harness 任务：M25GUI-P05 Remote daemon over SSH tunnel
- 分支：`codex/m2-5-gui-p05-remote-daemon-ssh-tunnel`
- 公开范围：`packages/gui/src/daemon/remote-tunnel.ts`, `packages/gui/src/index.ts`, `packages/gui/test/remote-tunnel.test.ts`
- 私有计划 / 证据是否已更新：yes
- 范围外：真实 SSH、production daemon server、WebSocket transport、workspace shell UI/docking、browser pane remote content、full terminal streaming、kernel lifecycle/preset/migration changes

## 版本影响

- 版本：不改版本，原因是 pre-release internal contract slice
- 发布影响：不发布

## 验证

- `origin/main` 基准 SHA：`82a6a38cbde164c1dc4aabb1ae01757a6ebe7728`
- 当前分支与 `origin/main` 的 merge-base：`82a6a38cbde164c1dc4aabb1ae01757a6ebe7728`
- 最近一次 `git fetch origin` 时间：`2026-06-14 09:28:24 CST`
- 同步方式：不需要；merge-base 等于最新 `origin/main`
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：private commit `2e349f5`; `planning/modules/m2-5-gui/tasks/2026-06-14-m2-5-gui-p05-remote-daemon-ssh-tunnel/`
- Reviewer 证据路径：同一 private task `review.md`; Archimedes final rereview 无 P0/P1/P2
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/27484748796
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci` 未在该 worktree 单独运行；依赖已安装且 `npm run check` 已完整通过。

## 审查证据

- 自查：确认 public diff 范围、无真实 SSH/network execution call、无 private 文件、无 remote-only API route id/service method。
- Reviewer subagent：Archimedes final rereview 无 P0/P1/P2；此前 stale-event P2 已通过 closed tunnel 拒绝 degraded/failed 写入关闭。
- 人工审查：如需要则在 PR 中等待
- 阻塞发现：无 open blocking findings

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚：green CI 后 merge，删除 local/remote branch，移除 worktree，同步 local main，并运行 post-merge `npm run check`。

## 残余风险

- 当前仅为 control-plane model。后续 GUI packets 仍需实现 actual workspace shell UI、daemon process integration 和 browser remote trust handling。

## 关联材料

- 任务：`planning/modules/m2-5-gui/tasks/2026-06-14-m2-5-gui-p05-remote-daemon-ssh-tunnel/task_plan.md`
- 证据：`planning/modules/m2-5-gui/tasks/2026-06-14-m2-5-gui-p05-remote-daemon-ssh-tunnel/progress.md`
- 审查：`planning/modules/m2-5-gui/tasks/2026-06-14-m2-5-gui-p05-remote-daemon-ssh-tunnel/review.md`
