### PR TITLE
Harden Electron GUI security policy

### DIFF
--- a/packages/gui/src/index.ts
+++ b/packages/gui/src/index.ts
@@ -6,6 +6,7 @@ export * from "./daemon/remote-tunnel.ts";
 export * from "./distribution/update-policy.ts";
 export * from "./doc-renderer/sanitize.ts";
 export * from "./main/ipc-handlers.ts";
+export * from "./main/security-policy.ts";
 export * from "./main/window-config.ts";
 export * from "./preload/allowlist.ts";
 export * from "./renderer/app-model.ts";

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -3,12 +3,15 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createGuiServiceBridge } from "../api/service-bridge.ts";
 import { registerHarnessIpcHandlers } from "./ipc-handlers.ts";
-import { assertDevRendererUrl, createGuiContentSecurityPolicy, isTrustedRendererUrl } from "./window-config.ts";
+import { evaluateNavigationRequest, evaluatePermissionRequest, evaluateWindowOpenRequest } from "./security-policy.ts";
+import { assertDevRendererUrl, createGuiContentSecurityPolicy, createPackagedRendererUrl } from "./window-config.ts";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export function createMainWindow(): BrowserWindow {
   const preloadPath = path.join(dirname, "../preload/electron-preload.mjs");
+  const rendererUrl = process.env.ELECTRON_RENDERER_URL;
+  const allowDevRenderer = Boolean(rendererUrl);
   const mainWindow = new BrowserWindow({
     title: "Harness Anything",
     width: 1440,
@@ -26,11 +29,12 @@ export function createMainWindow(): BrowserWindow {
   });
 
   mainWindow.once("ready-to-show", () => mainWindow.show());
-  mainWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+  mainWindow.webContents.setWindowOpenHandler(() => ({ action: evaluateWindowOpenRequest().action }));
   mainWindow.webContents.on("will-navigate", (event, url) => {
-    if (!isTrustedRendererUrl(url)) event.preventDefault();
+    if (evaluateNavigationRequest(url, { packagedRendererUrl: createPackagedRendererUrl(), allowDevRenderer }).action === "deny") {
+      event.preventDefault();
+    }
   });
-  const rendererUrl = process.env.ELECTRON_RENDERER_URL;
   if (rendererUrl) {
     assertDevRendererUrl(rendererUrl);
     void mainWindow.loadURL(rendererUrl);
@@ -42,7 +46,7 @@ export function createMainWindow(): BrowserWindow {
 
 export function installContentSecurityPolicy(): void {
   session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => {
-    callback(false);
+    callback(evaluatePermissionRequest().action === "allow");
   });
   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
     callback({
@@ -59,11 +63,25 @@ export function installContentSecurityPolicy(): void {
 export async function startGuiApp(): Promise<void> {
   await app.whenReady();
   installContentSecurityPolicy();
-  registerHarnessIpcHandlers(ipcMain, createGuiServiceBridge(resolveGuiProjectRoot()));
-  createMainWindow();
-  app.on("activate", () => {
-    if (BrowserWindow.getAllWindows().length === 0) createMainWindow();
+  const trustedWebContentsIds = new Set<number>();
+  registerHarnessIpcHandlers(ipcMain, createGuiServiceBridge(resolveGuiProjectRoot()), {
+    isTrustedWebContentsId: (id) => trustedWebContentsIds.has(id),
+    rendererUrl: {
+      packagedRendererUrl: createPackagedRendererUrl(),
+      allowDevRenderer: Boolean(process.env.ELECTRON_RENDERER_URL)
+    }
   });
+  createTrustedMainWindow(trustedWebContentsIds);
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) createTrustedMainWindow(trustedWebContentsIds);
+  });
+}
+
+function createTrustedMainWindow(trustedWebContentsIds: Set<number>): BrowserWindow {
+  const mainWindow = createMainWindow();
+  trustedWebContentsIds.add(mainWindow.webContents.id);
+  mainWindow.once("closed", () => trustedWebContentsIds.delete(mainWindow.webContents.id));
+  return mainWindow;
 }
 
 export function resolveGuiProjectRoot(): string {

--- a/packages/gui/src/main/ipc-handlers.ts
+++ b/packages/gui/src/main/ipc-handlers.ts
@@ -1,7 +1,7 @@
 import type { IpcMainInvokeEvent } from "electron";
 import { assertPreloadPayload, preloadAllowlist } from "../preload/allowlist.ts";
 import type { GuiServiceBridge } from "../api/service-bridge.ts";
-import { isTrustedRendererUrl } from "./window-config.ts";
+import { evaluateIpcSender, type IpcSenderIdentity, type IpcWebContentsTrustPolicy } from "./security-policy.ts";
 
 export interface HarnessIpcRegistrar {
   readonly handle: (
@@ -10,20 +10,27 @@ export interface HarnessIpcRegistrar {
   ) => void;
 }
 
-export function registerHarnessIpcHandlers(registrar: HarnessIpcRegistrar, bridge: GuiServiceBridge): void {
+export function registerHarnessIpcHandlers(
+  registrar: HarnessIpcRegistrar,
+  bridge: GuiServiceBridge,
+  trustPolicy: IpcWebContentsTrustPolicy
+): void {
   for (const method of preloadAllowlist) {
     registrar.handle(`harness:${method}`, async (event, payload) => {
-      assertTrustedIpcSender(event);
+      assertTrustedIpcSender(event, trustPolicy);
       assertPreloadPayload(method, payload);
       return bridge.invoke(method, payload);
     });
   }
 }
 
-export function assertTrustedIpcSender(event: Pick<IpcMainInvokeEvent, "senderFrame">): true {
-  const senderUrl = event.senderFrame?.url;
-  if (!senderUrl || !isTrustedRendererUrl(senderUrl)) {
-    throw new Error("Rejected IPC message from untrusted renderer frame.");
+export function assertTrustedIpcSender(
+  event: IpcSenderIdentity,
+  trustPolicy: IpcWebContentsTrustPolicy
+): true {
+  const decision = evaluateIpcSender(event, trustPolicy);
+  if (decision.action === "deny") {
+    throw new Error(`Rejected IPC message: ${decision.reason}.`);
   }
   return true;
 }

--- a/packages/gui/src/main/security-policy.ts
+++ b/packages/gui/src/main/security-policy.ts
@@ -1,0 +1,93 @@
+import { isTrustedRendererUrl, type TrustedRendererUrlOptions } from "./window-config.ts";
+
+export type SecurityDecisionReason =
+  | "trusted_renderer"
+  | "untrusted_renderer_url"
+  | "untrusted_web_contents"
+  | "permission_denied_by_default"
+  | "navigation_denied"
+  | "window_open_denied"
+  | "missing_browser_preview_threat_model"
+  | "browser_preview_not_shipped";
+
+export type SecurityDecision =
+  | { readonly action: "allow"; readonly reason: SecurityDecisionReason }
+  | { readonly action: "deny"; readonly reason: SecurityDecisionReason; readonly detail?: string };
+
+export interface IpcWebContentsTrustPolicy {
+  readonly isTrustedWebContentsId: (id: number) => boolean;
+  readonly rendererUrl?: TrustedRendererUrlOptions;
+}
+
+export interface IpcSenderIdentity {
+  readonly sender: {
+    readonly id: number;
+  };
+  readonly senderFrame?: {
+    readonly url?: string;
+  } | null;
+}
+
+export interface BrowserPreviewThreatModel {
+  readonly reviewedBy: string;
+  readonly reviewedAt: string;
+  readonly allowedSchemes: ReadonlyArray<"http:" | "https:">;
+  readonly storagePartition: "ephemeral";
+  readonly userGestureRequired: true;
+}
+
+export interface BrowserPreviewOpenRequest {
+  readonly url: string;
+  readonly source: "open-target-router" | "localhost-preview" | "remote-content";
+  readonly userGesture: boolean;
+  readonly threatModel?: BrowserPreviewThreatModel;
+}
+
+export function createStaticWebContentsTrustPolicy(ids: Iterable<number>): IpcWebContentsTrustPolicy {
+  const trusted = new Set(ids);
+  return {
+    isTrustedWebContentsId: (id) => trusted.has(id)
+  };
+}
+
+export function evaluateIpcSender(
+  event: IpcSenderIdentity,
+  trustPolicy: IpcWebContentsTrustPolicy
+): SecurityDecision {
+  const senderUrl = event.senderFrame?.url;
+  if (!senderUrl || !isTrustedRendererUrl(senderUrl, trustPolicy.rendererUrl)) {
+    return { action: "deny", reason: "untrusted_renderer_url" };
+  }
+  if (!trustPolicy.isTrustedWebContentsId(event.sender.id)) {
+    return { action: "deny", reason: "untrusted_web_contents" };
+  }
+  return { action: "allow", reason: "trusted_renderer" };
+}
+
+export function evaluatePermissionRequest(): SecurityDecision {
+  return { action: "deny", reason: "permission_denied_by_default" };
+}
+
+export function evaluateNavigationRequest(url: string, options: TrustedRendererUrlOptions = {}): SecurityDecision {
+  if (isTrustedRendererUrl(url, options)) return { action: "allow", reason: "trusted_renderer" };
+  return { action: "deny", reason: "navigation_denied" };
+}
+
+export function evaluateWindowOpenRequest(): SecurityDecision {
+  return { action: "deny", reason: "window_open_denied" };
+}
+
+export function evaluateBrowserPreviewOpenRequest(request: BrowserPreviewOpenRequest): SecurityDecision {
+  if (!request.threatModel) {
+    return {
+      action: "deny",
+      reason: "missing_browser_preview_threat_model",
+      detail: request.source
+    };
+  }
+  return {
+    action: "deny",
+    reason: "browser_preview_not_shipped",
+    detail: request.url
+  };
+}

--- a/packages/gui/src/main/window-config.ts
+++ b/packages/gui/src/main/window-config.ts
@@ -20,6 +20,11 @@ export interface GuiContentSecurityPolicyOptions {
   readonly allowDevRenderer?: boolean;
 }
 
+export interface TrustedRendererUrlOptions {
+  readonly packagedRendererUrl?: string;
+  readonly allowDevRenderer?: boolean;
+}
+
 export function createGuiContentSecurityPolicy(options: GuiContentSecurityPolicyOptions = {}): string {
   const connectSrc = options.allowDevRenderer
     ? "connect-src 'self' http://127.0.0.1:5173 ws://127.0.0.1:5173"
@@ -84,10 +89,17 @@ export function assertDevRendererUrl(url: string): true {
   return true;
 }
 
-export function isTrustedRendererUrl(url: string): boolean {
+export function createPackagedRendererUrl(): string {
+  return new URL("../renderer/index.html", import.meta.url).href;
+}
+
+export function isTrustedRendererUrl(url: string, options: TrustedRendererUrlOptions = {}): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === "file:" || parsed.origin === "http://127.0.0.1:5173";
+    if (parsed.origin === "http://127.0.0.1:5173") return options.allowDevRenderer === true;
+    if (parsed.protocol !== "file:") return false;
+    const packagedRendererUrl = options.packagedRendererUrl ?? createPackagedRendererUrl();
+    return parsed.href === new URL(packagedRendererUrl).href;
   } catch {
     return false;
   }

--- a/packages/gui/test/electron-security-policy.test.ts
+++ b/packages/gui/test/electron-security-policy.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createStaticWebContentsTrustPolicy,
+  evaluateBrowserPreviewOpenRequest,
+  evaluateIpcSender,
+  evaluateNavigationRequest,
+  evaluatePermissionRequest,
+  evaluateWindowOpenRequest
+} from "../src/index.ts";
+
+test("IPC sender trust requires both renderer URL and owned webContents id", () => {
+  const packagedRendererUrl = "file:///app/renderer/index.html";
+  const trustPolicy = {
+    ...createStaticWebContentsTrustPolicy([7]),
+    rendererUrl: { packagedRendererUrl }
+  };
+
+  assert.deepEqual(
+    evaluateIpcSender({ sender: { id: 7 }, senderFrame: { url: packagedRendererUrl } }, trustPolicy),
+    { action: "allow", reason: "trusted_renderer" }
+  );
+  assert.deepEqual(
+    evaluateIpcSender({ sender: { id: 7 }, senderFrame: { url: "https://example.invalid" } }, trustPolicy),
+    { action: "deny", reason: "untrusted_renderer_url" }
+  );
+  assert.deepEqual(
+    evaluateIpcSender({ sender: { id: 9 }, senderFrame: { url: packagedRendererUrl } }, trustPolicy),
+    { action: "deny", reason: "untrusted_web_contents" }
+  );
+  assert.deepEqual(
+    evaluateIpcSender({ sender: { id: 7 }, senderFrame: null }, trustPolicy),
+    { action: "deny", reason: "untrusted_renderer_url" }
+  );
+  assert.deepEqual(
+    evaluateIpcSender({ sender: { id: 7 }, senderFrame: { url: "http://127.0.0.1:5173" } }, trustPolicy),
+    { action: "deny", reason: "untrusted_renderer_url" }
+  );
+  assert.deepEqual(
+    evaluateIpcSender({ sender: { id: 7 }, senderFrame: { url: "file:///tmp/renderer/index.html" } }, trustPolicy),
+    { action: "deny", reason: "untrusted_renderer_url" }
+  );
+  assert.deepEqual(
+    evaluateIpcSender({ sender: { id: 7 }, senderFrame: { url: "file:///app/.harness-private/task.md" } }, trustPolicy),
+    { action: "deny", reason: "untrusted_renderer_url" }
+  );
+});
+
+test("permission navigation and window-open policies are deny-by-default", () => {
+  assert.deepEqual(evaluatePermissionRequest(), {
+    action: "deny",
+    reason: "permission_denied_by_default"
+  });
+  assert.deepEqual(evaluateWindowOpenRequest(), {
+    action: "deny",
+    reason: "window_open_denied"
+  });
+  assert.deepEqual(evaluateNavigationRequest("https://example.invalid"), {
+    action: "deny",
+    reason: "navigation_denied"
+  });
+  assert.deepEqual(evaluateNavigationRequest("file:///app/renderer/index.html", { packagedRendererUrl: "file:///app/renderer/index.html" }), {
+    action: "allow",
+    reason: "trusted_renderer"
+  });
+  assert.deepEqual(evaluateNavigationRequest("file:///tmp/renderer/index.html", { packagedRendererUrl: "file:///app/renderer/index.html" }), {
+    action: "deny",
+    reason: "navigation_denied"
+  });
+  assert.deepEqual(evaluateNavigationRequest("http://127.0.0.1:5173", { packagedRendererUrl: "file:///app/renderer/index.html" }), {
+    action: "deny",
+    reason: "navigation_denied"
+  });
+  assert.deepEqual(
+    evaluateNavigationRequest("http://127.0.0.1:5173", {
+      packagedRendererUrl: "file:///app/renderer/index.html",
+      allowDevRenderer: true
+    }),
+    {
+      action: "allow",
+      reason: "trusted_renderer"
+    }
+  );
+});
+
+test("browser and preview content cannot open without a threat model and remains unshipped", () => {
+  assert.deepEqual(
+    evaluateBrowserPreviewOpenRequest({
+      url: "https://example.invalid",
+      source: "open-target-router",
+      userGesture: true
+    }),
+    {
+      action: "deny",
+      reason: "missing_browser_preview_threat_model",
+      detail: "open-target-router"
+    }
+  );
+
+  assert.deepEqual(
+    evaluateBrowserPreviewOpenRequest({
+      url: "http://127.0.0.1:3000",
+      source: "localhost-preview",
+      userGesture: true,
+      threatModel: {
+        reviewedBy: "M25GUI-P09",
+        reviewedAt: "2026-06-14",
+        allowedSchemes: ["http:"],
+        storagePartition: "ephemeral",
+        userGestureRequired: true
+      }
+    }),
+    {
+      action: "deny",
+      reason: "browser_preview_not_shipped",
+      detail: "http://127.0.0.1:3000"
+    }
+  );
+});

--- a/packages/gui/test/ipc-handler-registration.test.ts
+++ b/packages/gui/test/ipc-handler-registration.test.ts
@@ -3,10 +3,14 @@ import test from "node:test";
 import { preloadAllowlist, registerHarnessIpcHandlers, type GuiServiceBridge } from "../src/index.ts";
 
 const trustedEvent = {
+  sender: {
+    id: 1
+  },
   senderFrame: {
     url: "file:///app/renderer/index.html"
   }
 };
+const trustedRendererUrl = trustedEvent.senderFrame.url;
 
 test("main process registers one IPC handler for each preload allowlist method", async () => {
   const channels: string[] = [];
@@ -15,12 +19,16 @@ test("main process registers one IPC handler for each preload allowlist method",
   };
 
   const handlers = new Map<string, (event: typeof trustedEvent, payload: unknown) => Promise<unknown>>();
-  registerHarnessIpcHandlers({
-    handle: (channel, listener) => {
-      channels.push(channel);
-      handlers.set(channel, listener as (event: typeof trustedEvent, payload: unknown) => Promise<unknown>);
-    }
-  }, bridge);
+  registerHarnessIpcHandlers(
+    {
+      handle: (channel, listener) => {
+        channels.push(channel);
+        handlers.set(channel, listener as (event: typeof trustedEvent, payload: unknown) => Promise<unknown>);
+      }
+    },
+    bridge,
+    { isTrustedWebContentsId: (id) => id === 1, rendererUrl: { packagedRendererUrl: trustedRendererUrl } }
+  );
 
   assert.deepEqual(channels, preloadAllowlist.map((method) => `harness:${method}`));
   assert.deepEqual(await handlers.get("harness:getTasks")?.(trustedEvent, null), {
@@ -30,7 +38,11 @@ test("main process registers one IPC handler for each preload allowlist method",
   });
   await assert.rejects(() => handlers.get("harness:getTasks")?.(trustedEvent, "raw-string"), /payload must be an object/i);
   await assert.rejects(
-    () => handlers.get("harness:getTasks")?.({ senderFrame: { url: "https://example.com" } }, null),
-    /untrusted renderer frame/i
+    () => handlers.get("harness:getTasks")?.({ sender: { id: 1 }, senderFrame: { url: "https://example.com" } }, null),
+    /untrusted_renderer_url/i
+  );
+  await assert.rejects(
+    () => handlers.get("harness:getTasks")?.({ sender: { id: 2 }, senderFrame: trustedEvent.senderFrame }, null),
+    /untrusted_web_contents/i
   );
 });

--- a/packages/gui/test/window-config.test.ts
+++ b/packages/gui/test/window-config.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { assertDevRendererUrl, createGuiContentSecurityPolicy, guiContentSecurityPolicy } from "../src/index.ts";
+import { assertDevRendererUrl, createGuiContentSecurityPolicy, guiContentSecurityPolicy, isTrustedRendererUrl } from "../src/index.ts";
 
 test("dev renderer override accepts only the local Vite server", () => {
   assert.equal(assertDevRendererUrl("http://127.0.0.1:5173"), true);
@@ -14,4 +14,15 @@ test("production CSP does not allow wildcard localhost connections", () => {
   assert.doesNotMatch(guiContentSecurityPolicy, /127\.0\.0\.1:\*/);
   assert.match(createGuiContentSecurityPolicy({ allowDevRenderer: true }), /http:\/\/127\.0\.0\.1:5173/);
   assert.doesNotMatch(createGuiContentSecurityPolicy({ allowDevRenderer: true }), /127\.0\.0\.1:\*/);
+});
+
+test("trusted renderer URL accepts only explicit dev server or packaged renderer file", () => {
+  const packagedRendererUrl = "file:///app/renderer/index.html";
+
+  assert.equal(isTrustedRendererUrl(packagedRendererUrl, { packagedRendererUrl }), true);
+  assert.equal(isTrustedRendererUrl("http://127.0.0.1:5173", { packagedRendererUrl }), false);
+  assert.equal(isTrustedRendererUrl("http://127.0.0.1:5173", { packagedRendererUrl, allowDevRenderer: true }), true);
+  assert.equal(isTrustedRendererUrl("file:///tmp/renderer/index.html", { packagedRendererUrl }), false);
+  assert.equal(isTrustedRendererUrl("file:///app/.harness-private/task.md", { packagedRendererUrl }), false);
+  assert.equal(isTrustedRendererUrl("https://example.invalid", { packagedRendererUrl }), false);
 });

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -15,6 +15,7 @@ export const testTierManifest = {
   contract: [
     "packages/application/test/task-lifecycle-gates.test.ts",
     "packages/cli/test/package-surface.test.ts",
+    "packages/gui/test/electron-security-policy.test.ts",
     "packages/gui/test/ipc-handler-registration.test.ts",
     "packages/gui/test/distribution-update-policy.test.ts",
     "packages/gui/test/local-api-auth.test.ts",


### PR DESCRIPTION
## Summary

- Centralizes GUI Electron security decisions in `packages/gui/src/main/security-policy.ts`.
- Requires privileged IPC callers to have both a trusted renderer URL and an owned main-window `webContents.id`.
- Keeps permissions, navigation, and window-open deny-by-default, with explicit dev renderer trust only when `ELECTRON_RENDERER_URL` enables it.
- Adds a fail-closed browser/preview open policy so future preview work cannot silently open content without an explicit threat model.

## Review

- Reviewer: Planck (`019ec41e-5afc-7030-8e97-1e2cad01d527`).
- Findings fixed before PR:
  - P1: arbitrary `file:` renderer URLs were trusted too broadly; now only the exact packaged renderer URL is trusted.
  - P1: `http://127.0.0.1:5173` was trusted in production; now it requires `allowDevRenderer: true`.
- Final re-review: clean, no remaining P0/P1/P2/P3 findings in the Electron security policy scope.

## Test Tiering

New/modified tests under `packages/**` or `tools/**`:

- `packages/gui/test/electron-security-policy.test.ts`: new, `contract` tier. Covers IPC sender trust, deny-by-default permissions/navigation/window-open, production localhost rejection, explicit dev localhost allowance, and fail-closed browser/preview open policy.
- `packages/gui/test/ipc-handler-registration.test.ts`: modified, existing `contract` tier. Adds untrusted URL, unowned `webContents`, and invalid payload coverage around IPC handler registration.
- `packages/gui/test/window-config.test.ts`: modified, existing `contract` tier. Adds exact packaged renderer URL trust and explicit dev renderer trust coverage.
- `tools/test-tier-manifest.mjs`: updated to classify `packages/gui/test/electron-security-policy.test.ts` as `contract`.

## Verification

- `npm run typecheck`: passed.
- `npm run test:fast`: passed, 88 tests, slow-test summary had no tests at or above 1000ms.
- `npm run test:contract`: passed, 105 tests, slow-test summary had no tests at or above 1000ms.
- `npm run check:pr`: passed.
  - `test:fast`: 88 tests, no slow entries.
  - `test:contract`: 105 tests, no slow entries.
  - `test:integration`: 126 tests; slow-test summary contained existing CLI/store integration tests only.
- `npm run check`: passed.
  - Full Node test suite: 319 tests.
  - Slow-test summary contained existing CLI/store integration tests only.
  - File complexity, CLI structure, import boundary, forbidden symbol scan, private boundary, docs release map, package policy, implementation contracts, service mappability, API contract registry, schema contracts, Legacy Intake readiness, supply chain, Legacy Intake smoke, and CLI package smoke all passed.

## Slow-Test Follow-Up

No new GUI security test appears in the slow-test summaries. The slow entries are pre-existing CLI/store integration tests, so this PR does not add a new slow-test follow-up.
