### PR TITLE
Fix application composition boundary

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,8 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
-import { makeLocalLifecycleEngine } from "../../adapters/local/src/index.ts";
-import type { DomainStatus, ProjectionWarning, TaskProjectionRow } from "../../kernel/src/index.ts";
+import type { DomainStatus, EngineError, ProjectionWarning, TaskProjectionRow, WriteError } from "../../kernel/src/index.ts";
 import { isDomainStatus, isTerminalStatus, readTaskProjection } from "../../kernel/src/index.ts";
 import { taskDocumentPath as harnessTaskDocumentPath, validateTaskIdSyntax } from "../../kernel/src/layout/index.ts";
 export {
@@ -22,6 +21,7 @@ export type {
 
 export interface LocalControllerServiceOptions {
   readonly rootDir: string;
+  readonly taskWriter: LocalControllerTaskWriter;
 }
 
 export interface LocalControllerSuccess {
@@ -82,6 +82,21 @@ export interface AppendTaskProgressPayload extends TaskIdPayload {
   readonly text: string;
 }
 
+export interface LocalControllerStatusWriteResult {
+  readonly taskId: string;
+  readonly status: DomainStatus;
+}
+
+export interface LocalControllerProgressWriteResult {
+  readonly taskId: string;
+  readonly path: string;
+}
+
+export interface LocalControllerTaskWriter {
+  readonly setStatus: (payload: SetTaskStatusPayload) => Effect.Effect<LocalControllerStatusWriteResult, EngineError | WriteError>;
+  readonly appendProgress: (payload: AppendTaskProgressPayload) => Effect.Effect<LocalControllerProgressWriteResult, EngineError | WriteError>;
+}
+
 export interface ShellPanelPolicy {
   readonly displayOnly: true;
   readonly outputCreatesTaskState: false;
@@ -107,7 +122,7 @@ export interface LocalControllerService {
 
 export function makeLocalControllerService(options: LocalControllerServiceOptions): LocalControllerService {
   const rootDir = path.resolve(options.rootDir);
-  const engine = makeLocalLifecycleEngine({ rootDir });
+  const taskWriter = options.taskWriter;
 
   return {
     getTasks: () => {
@@ -150,7 +165,7 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
           }
         };
       }
-      return Effect.runPromise(engine.setStatus({ taskId: payload.taskId, status: payload.status }).pipe(
+      return Effect.runPromise(taskWriter.setStatus({ taskId: payload.taskId, status: payload.status }).pipe(
         Effect.match({
           onFailure: (error) => ({ ok: false, error: { code: error._tag, hint: "Status update failed." } }),
           onSuccess: () => ({ ok: true })
@@ -159,7 +174,7 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
     },
     reviewTask: async (payload) => {
       validateTaskId(payload.taskId);
-      return Effect.runPromise(engine.setStatus({ taskId: payload.taskId, status: "in_review" }).pipe(
+      return Effect.runPromise(taskWriter.setStatus({ taskId: payload.taskId, status: "in_review" }).pipe(
         Effect.match({
           onFailure: (error) => ({ ok: false, error: { code: error._tag, hint: "Review transition failed." } }),
           onSuccess: () => ({ ok: true })
@@ -168,7 +183,7 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
     },
     appendTaskProgress: async (payload) => {
       validateTaskId(payload.taskId);
-      return Effect.runPromise(engine.appendProgress({ taskId: payload.taskId, text: payload.text }).pipe(
+      return Effect.runPromise(taskWriter.appendProgress({ taskId: payload.taskId, text: payload.text }).pipe(
         Effect.match({
           onFailure: (error) => ({ ok: false, error: { code: error._tag, hint: "Progress append failed." } }),
           onSuccess: () => ({ ok: true })

--- a/packages/application/test/local-controller-service.test.ts
+++ b/packages/application/test/local-controller-service.test.ts
@@ -3,13 +3,30 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { Effect } from "effect";
 import { makeLocalControllerService } from "../src/index.ts";
 
-test("local controller service reads projection and writes through local lifecycle service path", async () => {
+test("local controller service reads projection and writes through injected task writer", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-app-"));
   try {
     writeTaskIndex(rootDir, "task-1", "Task One", "planned");
-    const service = makeLocalControllerService({ rootDir });
+    const writes: string[] = [];
+    const service = makeLocalControllerService({
+      rootDir,
+      taskWriter: {
+        setStatus: (payload) => Effect.sync(() => {
+          writes.push(`status:${payload.taskId}:${payload.status}`);
+          patchTaskStatus(rootDir, payload.taskId, payload.status);
+          return { taskId: payload.taskId, status: payload.status };
+        }),
+        appendProgress: (payload) => Effect.sync(() => {
+          writes.push(`progress:${payload.taskId}:${payload.text}`);
+          const progressPath = path.join(rootDir, "harness/planning/tasks", payload.taskId, "progress.md");
+          writeFileSync(progressPath, `${payload.text}\n`, "utf8");
+          return { taskId: payload.taskId, path: "progress.md" };
+        })
+      }
+    });
 
     const list = service.getTasks();
     assert.equal(list.ok, true);
@@ -24,6 +41,7 @@ test("local controller service reads projection and writes through local lifecyc
     assert.match(document.body ?? "", /Task One/);
 
     assert.deepEqual(await service.setTaskStatus({ taskId: "task-1", status: "active" }), { ok: true });
+    assert.deepEqual(writes, ["status:task-1:active"]);
     assert.deepEqual(await service.setTaskStatus({ taskId: "task-1", status: "done" }), {
       ok: false,
       error: {
@@ -40,6 +58,7 @@ test("local controller service reads projection and writes through local lifecyc
     });
     assert.match(readFileSync(path.join(rootDir, "harness/planning/tasks/task-1/INDEX.md"), "utf8"), /status: active/);
     assert.deepEqual(await service.appendTaskProgress({ taskId: "task-1", text: "GUI update" }), { ok: true });
+    assert.deepEqual(writes, ["status:task-1:active", "progress:task-1:GUI update"]);
     assert.match(readFileSync(path.join(rootDir, "harness/planning/tasks/task-1/progress.md"), "utf8"), /GUI update/);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
@@ -68,4 +87,10 @@ function writeTaskIndex(rootDir: string, taskId: string, title: string, status: 
     "---",
     ""
   ].join("\n"), "utf8");
+}
+
+function patchTaskStatus(rootDir: string, taskId: string, status: string): void {
+  const indexPath = path.join(rootDir, "harness/planning/tasks", taskId, "INDEX.md");
+  const index = readFileSync(indexPath, "utf8");
+  writeFileSync(indexPath, index.replace(/^  status: .+$/m, `  status: ${status}`), "utf8");
 }

--- a/packages/gui/src/api/service-bridge.ts
+++ b/packages/gui/src/api/service-bridge.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import type { LocalControllerService } from "../../../application/src/index.ts";
 import {
-  makeLocalControllerService,
   readAppendProgressPayload,
   readSetStatusPayload,
   readTaskDocumentPayload,
@@ -12,10 +11,6 @@ import { validateProjectPath } from "./local-api.ts";
 
 export interface GuiServiceBridge {
   readonly invoke: (method: string, payload: unknown) => Promise<unknown>;
-}
-
-export function createGuiServiceBridge(rootDir: string): GuiServiceBridge {
-  return createGuiServiceBridgeForService(path.resolve(rootDir), makeLocalControllerService({ rootDir }));
 }
 
 export function createGuiServiceBridgeForService(rootDir: string, service: LocalControllerService): GuiServiceBridge {

--- a/packages/gui/src/index.ts
+++ b/packages/gui/src/index.ts
@@ -8,6 +8,7 @@ export * from "./distribution/runtime-release-readiness.ts";
 export * from "./distribution/supply-chain-release-readiness.ts";
 export * from "./doc-renderer/sanitize.ts";
 export * from "./main/ipc-handlers.ts";
+export * from "./main/local-composition-root.ts";
 export * from "./main/security-policy.ts";
 export * from "./main/window-config.ts";
 export * from "./preload/allowlist.ts";

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -1,8 +1,8 @@
 import { app, BrowserWindow, ipcMain, session } from "electron";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createGuiServiceBridge } from "../api/service-bridge.ts";
 import { registerHarnessIpcHandlers } from "./ipc-handlers.ts";
+import { createLocalGuiServiceBridge } from "./local-composition-root.ts";
 import { evaluateNavigationRequest, evaluatePermissionRequest, evaluateWindowOpenRequest } from "./security-policy.ts";
 import { assertDevRendererUrl, createGuiContentSecurityPolicy, createPackagedRendererUrl } from "./window-config.ts";
 
@@ -64,7 +64,7 @@ export async function startGuiApp(): Promise<void> {
   await app.whenReady();
   installContentSecurityPolicy();
   const trustedWebContentsIds = new Set<number>();
-  registerHarnessIpcHandlers(ipcMain, createGuiServiceBridge(resolveGuiProjectRoot()), {
+  registerHarnessIpcHandlers(ipcMain, createLocalGuiServiceBridge(resolveGuiProjectRoot()), {
     isTrustedWebContentsId: (id) => trustedWebContentsIds.has(id),
     rendererUrl: {
       packagedRendererUrl: createPackagedRendererUrl(),

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -1,0 +1,16 @@
+import path from "node:path";
+import { makeLocalLifecycleEngine } from "../../../adapters/local/src/index.ts";
+import { makeLocalControllerService } from "../../../application/src/index.ts";
+import { createGuiServiceBridgeForService } from "../api/service-bridge.ts";
+import type { GuiServiceBridge } from "../api/service-bridge.ts";
+
+export function createLocalGuiServiceBridge(rootDir: string): GuiServiceBridge {
+  const resolvedRootDir = path.resolve(rootDir);
+  return createGuiServiceBridgeForService(
+    resolvedRootDir,
+    makeLocalControllerService({
+      rootDir: resolvedRootDir,
+      taskWriter: makeLocalLifecycleEngine({ rootDir: resolvedRootDir })
+    })
+  );
+}

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -3,13 +3,13 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { createGuiServiceBridge } from "../src/index.ts";
+import { createLocalGuiServiceBridge } from "../src/index.ts";
 
 test("GUI service bridge reaches application service while enforcing document path guard", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-bridge-"));
   try {
     writeTaskIndex(rootDir, "task-1", "Task One", "planned");
-    const bridge = createGuiServiceBridge(rootDir);
+    const bridge = createLocalGuiServiceBridge(rootDir);
 
     const list = await bridge.invoke("getTasks", null) as { readonly ok: boolean; readonly tasks: readonly unknown[] };
     assert.equal(list.ok, true);

--- a/tools/check-implementation-contracts.mjs
+++ b/tools/check-implementation-contracts.mjs
@@ -179,7 +179,7 @@ if (hasGuiImplementation) {
   }
   for (const requiredSnippet of [
     "makeLocalControllerService",
-    "makeLocalLifecycleEngine",
+    "taskWriter",
     "readTaskProjection"
   ]) {
     if (!applicationText.includes(requiredSnippet)) record(`application service must include ${requiredSnippet}`);
@@ -203,7 +203,7 @@ if (hasGuiImplementation) {
     "preload exposes only the approved API methods",
     "main process registers one IPC handler for each preload allowlist method",
     "GUI service bridge reaches application service",
-    "local controller service reads projection and writes through local lifecycle service path",
+    "local controller service reads projection and writes through injected task writer",
     "Markdown sanitizer strips scripts",
     "local API binds localhost",
     "path guard rejects traversal",

--- a/tools/check-import-boundaries.mjs
+++ b/tools/check-import-boundaries.mjs
@@ -7,6 +7,19 @@ const sourceFile = /\.(?:ts|tsx|mts|js|jsx|mjs)$/;
 const violations = [];
 const importPattern = /\b(?:import|export)\s+(?:type\s+)?(?:[^"']*?\s+from\s+)?["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
 const oldRuntimePattern = /scripts\/(?:kernel\/task|lib\/task-)|(?:^|\/)(?:states|policies)\.mts$|TaskBinding/;
+const guiAdapterCompositionRoots = new Set([
+  "packages/gui/src/main/local-composition-root.ts"
+]);
+const cliAdapterCompositionRoots = new Set([
+  "packages/cli/src/index.ts"
+]);
+const cliAdapterKnownDebt = new Set([
+  "packages/cli/src/commands/adopt.ts",
+  "packages/cli/src/commands/git-diff.ts",
+  "packages/cli/src/commands/legacy-rebuild.ts",
+  "packages/cli/src/commands/lifecycle.ts",
+  "packages/cli/src/commands/preset-task.ts"
+]);
 
 async function walk(dir) {
   let entries;
@@ -90,7 +103,7 @@ for (const sourceRoot of sourceRoots) {
       }
     }
 
-    if (rel.startsWith("packages/kernel/src/application/")) {
+    if (rel.startsWith("packages/application/")) {
       for (const specifier of imports) {
         if (importedPathViolates(file, specifier, (target) => /packages\/kernel\/src\/store\//.test(target) || /packages\/(?:cli|gui|adapters)\//.test(target) || /^@harness-anything\/(?:cli|gui|adapter-)/.test(target))) {
           record(file, `application layer imports store/adapter/controller implementation via ${specifier}`);
@@ -100,7 +113,13 @@ for (const sourceRoot of sourceRoots) {
 
     if (rel.startsWith("packages/gui/")) {
       for (const specifier of imports) {
-        if (importedPathViolates(file, specifier, (target) => /packages\/kernel\/src\/store\//.test(target) || /packages\/adapters\//.test(target) || /^@harness-anything\/adapter-/.test(target))) {
+        if (importedPathViolates(file, specifier, (target) => {
+          if (/packages\/kernel\/src\/store\//.test(target)) return true;
+          if (/packages\/adapters\//.test(target) || /^@harness-anything\/adapter-/.test(target)) {
+            return !guiAdapterCompositionRoots.has(rel);
+          }
+          return false;
+        })) {
           record(file, `GUI imports store or external adapter implementation via ${specifier}`);
         }
       }
@@ -108,8 +127,14 @@ for (const sourceRoot of sourceRoots) {
 
     if (rel.startsWith("packages/cli/")) {
       for (const specifier of imports) {
-        if (importedPathViolates(file, specifier, (target) => /packages\/gui\//.test(target) || /^@harness-anything\/gui/.test(target))) {
-          record(file, `CLI imports GUI layer via ${specifier}`);
+        if (importedPathViolates(file, specifier, (target) => {
+          if (/packages\/gui\//.test(target) || /packages\/kernel\/src\/store\//.test(target) || /^@harness-anything\/gui/.test(target)) return true;
+          if (/packages\/adapters\//.test(target) || /^@harness-anything\/adapter-/.test(target)) {
+            return !cliAdapterCompositionRoots.has(rel) && !cliAdapterKnownDebt.has(rel);
+          }
+          return false;
+        })) {
+          record(file, `CLI imports GUI, adapter, or store implementation via ${specifier}`);
         }
       }
     }

--- a/tools/check-import-boundaries.test.mjs
+++ b/tools/check-import-boundaries.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const checkerPath = path.join(repoRoot, "tools/check-import-boundaries.mjs");
+
+test("import boundary check rejects application imports from adapters", () => {
+  const root = makeFixtureRoot();
+  try {
+    writeFileSync(path.join(root, "packages/application/src/index.ts"), [
+      "import { makeLocalLifecycleEngine } from '../../adapters/local/src/index.ts';",
+      "export const engine = makeLocalLifecycleEngine;"
+    ].join("\n"), "utf8");
+    writeFileSync(path.join(root, "packages/adapters/local/src/index.ts"), [
+      "export function makeLocalLifecycleEngine() {",
+      "  return {};",
+      "}"
+    ].join("\n"), "utf8");
+
+    const result = runChecker(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /application layer imports store\/adapter\/controller implementation/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("import boundary check allows application imports from kernel public contracts", () => {
+  const root = makeFixtureRoot();
+  try {
+    writeFileSync(path.join(root, "packages/application/src/index.ts"), [
+      "import type { DomainStatus } from '../../kernel/src/index.ts';",
+      "export const status: DomainStatus = 'planned';"
+    ].join("\n"), "utf8");
+    writeFileSync(path.join(root, "packages/kernel/src/index.ts"), [
+      "export type DomainStatus = 'planned';"
+    ].join("\n"), "utf8");
+
+    const result = runChecker(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Import boundary check passed/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("import boundary check restricts GUI adapter imports to local composition root", () => {
+  const root = makeFixtureRoot();
+  try {
+    mkdirSync(path.join(root, "packages/gui/src/api"), { recursive: true });
+    mkdirSync(path.join(root, "packages/gui/src/main"), { recursive: true });
+    writeFileSync(path.join(root, "packages/gui/src/api/service-bridge.ts"), [
+      "import { makeLocalLifecycleEngine } from '../../../adapters/local/src/index.ts';",
+      "export const bridge = makeLocalLifecycleEngine;"
+    ].join("\n"), "utf8");
+    writeFileSync(path.join(root, "packages/gui/src/main/local-composition-root.ts"), [
+      "import { makeLocalLifecycleEngine } from '../../../adapters/local/src/index.ts';",
+      "export const bridge = makeLocalLifecycleEngine;"
+    ].join("\n"), "utf8");
+    writeLocalAdapter(root);
+
+    const result = runChecker(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /packages\/gui\/src\/api\/service-bridge\.ts/);
+    assert.doesNotMatch(result.stderr, /packages\/gui\/src\/main\/local-composition-root\.ts/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("import boundary check blocks new CLI adapter imports outside allowlisted debt", () => {
+  const root = makeFixtureRoot();
+  try {
+    mkdirSync(path.join(root, "packages/cli/src/commands"), { recursive: true });
+    writeFileSync(path.join(root, "packages/cli/src/index.ts"), [
+      "import { makeLocalLifecycleEngine } from '../../adapters/local/src/index.ts';",
+      "export const engine = makeLocalLifecycleEngine;"
+    ].join("\n"), "utf8");
+    writeFileSync(path.join(root, "packages/cli/src/commands/lifecycle.ts"), [
+      "import { makeLocalLifecycleEngine } from '../../../adapters/local/src/index.ts';",
+      "export const engine = makeLocalLifecycleEngine;"
+    ].join("\n"), "utf8");
+    writeFileSync(path.join(root, "packages/cli/src/commands/new-command.ts"), [
+      "import { makeLocalLifecycleEngine } from '../../../adapters/local/src/index.ts';",
+      "export const engine = makeLocalLifecycleEngine;"
+    ].join("\n"), "utf8");
+    writeLocalAdapter(root);
+
+    const result = runChecker(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /packages\/cli\/src\/commands\/new-command\.ts/);
+    assert.doesNotMatch(result.stderr, /packages\/cli\/src\/commands\/lifecycle\.ts/);
+    assert.doesNotMatch(result.stderr, /packages\/cli\/src\/index\.ts/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function makeFixtureRoot() {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-import-boundary-"));
+  for (const dir of [
+    "packages/application/src",
+    "packages/adapters/local/src",
+    "packages/kernel/src"
+  ]) {
+    mkdirSync(path.join(root, dir), { recursive: true });
+  }
+  return root;
+}
+
+function writeLocalAdapter(root) {
+  writeFileSync(path.join(root, "packages/adapters/local/src/index.ts"), [
+    "export function makeLocalLifecycleEngine() {",
+    "  return {};",
+    "}"
+  ].join("\n"), "utf8");
+}
+
+function runChecker(cwd) {
+  return spawnSync(process.execPath, [checkerPath], {
+    cwd,
+    encoding: "utf8"
+  });
+}

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -63,6 +63,7 @@ export const testTierManifest = {
     "packages/kernel/test/store/payload-hash.test.ts",
     "packages/kernel/test/store/same-task-fifo.test.ts",
     "packages/kernel/test/store/sqlite-rebuild.test.ts",
+    "tools/check-import-boundaries.test.mjs",
     "tools/check-docs-release-map.test.mjs",
     "tools/check-runtime-release-readiness.test.mjs",
     "tools/check-supply-chain.test.mjs"


### PR DESCRIPTION
## Summary

Fixes the M2.5 architecture review P0/P1-A around Application composition boundaries.

- Removes the direct `packages/application` dependency on the local adapter by injecting a minimal `LocalControllerTaskWriter`.
- Adds an explicit GUI local composition root at `packages/gui/src/main/local-composition-root.ts`.
- Restores `packages/gui/src/api/service-bridge.ts` to bridge/dispatch behavior only.
- Updates import-boundary checks to protect the real `packages/application/` path.
- Bounds existing CLI adapter-import debt with an explicit allowlist and rejects new non-allowlisted CLI adapter imports.

## Tests and tiers

New/modified test files:

- `packages/application/test/local-controller-service.test.ts`: existing `integration`, updated to prove fake injected task writer behavior.
- `packages/gui/test/service-bridge.test.ts`: existing `contract`, updated to use the explicit local composition root.
- `tools/check-import-boundaries.test.mjs`: new `integration`, added to `tools/test-tier-manifest.mjs` because it creates fixture repos and spawns the checker.

Commands run:

- `npm install`
- `node --test tools/check-import-boundaries.test.mjs packages/application/test/local-controller-service.test.ts packages/gui/test/service-bridge.test.ts`
- `npm run typecheck`
- `npm run harness:check-import-boundaries`
- `npm run harness:check-implementation-contracts`
- `npm run test:fast`
- `npm run test:contract`
- `npm run test:integration`
- `npm run check:pr`
- `git diff --check`
- `npm run check`

Slow-test summary:

- `test:fast`: no slow entries.
- `test:contract`: no slow entries.
- `test:integration`: slow entries were existing CLI/store integration tests; new import-boundary tests were not slow.
- Final `npm run check`: 340 tests passed; slow entries were existing CLI/store integration tests only.

## Review

- Reviewer Avicenna initially found P1/P2 issues: GUI composition hidden in the API bridge, CLI adapter debt silently unenforced, and missing boundary regression coverage.
- Fixed by moving GUI composition to `main/local-composition-root.ts`, adding explicit CLI known-debt allowlist, and expanding checker regression tests.
- Avicenna re-review reported no remaining P1/P2 findings.
