### PR TITLE
Clarify deferred GUI preload capabilities

### DIFF
--- a/packages/gui/src/preload/allowlist.ts
+++ b/packages/gui/src/preload/allowlist.ts
@@ -13,11 +13,44 @@ export const allowedPreloadApi = {
 } as const;
 
 export type PreloadApiMethod = keyof typeof allowedPreloadApi;
+export type PreloadApiCapabilityStatus = "shipped" | "deferred";
+
+export interface PreloadApiCapability {
+  readonly method: PreloadApiMethod;
+  readonly status: PreloadApiCapabilityStatus;
+  readonly reason?: string;
+}
+
+export const preloadApiCapabilities = {
+  getTasks: { method: "getTasks", status: "shipped" },
+  getTaskDetail: { method: "getTaskDetail", status: "shipped" },
+  getTaskDocument: { method: "getTaskDocument", status: "shipped" },
+  setTaskStatus: { method: "setTaskStatus", status: "shipped" },
+  reviewTask: { method: "reviewTask", status: "shipped" },
+  archiveTask: {
+    method: "archiveTask",
+    status: "deferred",
+    reason: "Archive is a disabled placeholder until closeout/archive route ownership is implemented."
+  },
+  appendTaskProgress: { method: "appendTaskProgress", status: "shipped" },
+  rebuildGovernance: { method: "rebuildGovernance", status: "shipped" },
+  openShell: {
+    method: "openShell",
+    status: "deferred",
+    reason: "Legacy openShell is display-only; shipped terminal lifecycle uses terminal session APIs."
+  }
+} as const satisfies Record<PreloadApiMethod, PreloadApiCapability>;
 
 export const preloadAllowlist = Object.freeze(Object.keys(allowedPreloadApi) as ReadonlyArray<PreloadApiMethod>);
+export const shippedPreloadMethods = Object.freeze(preloadAllowlist.filter((method) => preloadApiCapabilities[method].status === "shipped"));
+export const deferredPreloadMethods = Object.freeze(preloadAllowlist.filter((method) => preloadApiCapabilities[method].status === "deferred"));
 
 export function isAllowedPreloadApiMethod(method: string): method is PreloadApiMethod {
   return preloadAllowlist.includes(method as PreloadApiMethod);
+}
+
+export function getPreloadApiCapability(method: PreloadApiMethod): PreloadApiCapability {
+  return preloadApiCapabilities[method];
 }
 
 export function assertPreloadPayload(method: string, payload: unknown): true {

--- a/packages/gui/src/preload/electron-preload.ts
+++ b/packages/gui/src/preload/electron-preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from "electron";
 import {
   HARNESS_PRELOAD_API,
   assertPreloadPayload,
+  preloadApiCapabilities,
   preloadAllowlist,
   type PreloadApiMethod
 } from "./allowlist.ts";
@@ -14,4 +15,9 @@ const exposedApi = Object.fromEntries(preloadAllowlist.map((method) => [
   }
 ])) as Record<PreloadApiMethod, (payload?: unknown) => Promise<unknown>>;
 
-contextBridge.exposeInMainWorld(HARNESS_PRELOAD_API, exposedApi);
+const exposedHarnessApi = {
+  ...exposedApi,
+  capabilities: preloadApiCapabilities
+};
+
+contextBridge.exposeInMainWorld(HARNESS_PRELOAD_API, exposedHarnessApi);

--- a/packages/gui/test/ipc-handler-registration.test.ts
+++ b/packages/gui/test/ipc-handler-registration.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { preloadAllowlist, registerHarnessIpcHandlers, type GuiServiceBridge } from "../src/index.ts";
+import { preloadApiCapabilities, preloadAllowlist, registerHarnessIpcHandlers, type GuiServiceBridge } from "../src/index.ts";
 
 const trustedEvent = {
   sender: {
@@ -45,4 +45,6 @@ test("main process registers one IPC handler for each preload allowlist method",
     () => handlers.get("harness:getTasks")?.({ sender: { id: 2 }, senderFrame: trustedEvent.senderFrame }, null),
     /untrusted_web_contents/i
   );
+  assert.equal(handlers.has("harness:capabilities"), false);
+  assert.equal(preloadApiCapabilities.archiveTask.status, "deferred");
 });

--- a/packages/gui/test/preload-allowlist.test.ts
+++ b/packages/gui/test/preload-allowlist.test.ts
@@ -3,8 +3,11 @@ import test from "node:test";
 import {
   HARNESS_PRELOAD_API,
   assertPreloadPayload,
+  deferredPreloadMethods,
+  getPreloadApiCapability,
   isAllowedPreloadApiMethod,
-  preloadAllowlist
+  preloadAllowlist,
+  shippedPreloadMethods
 } from "../src/index.ts";
 
 test("preload exposes only the approved API methods", () => {
@@ -24,4 +27,22 @@ test("preload exposes only the approved API methods", () => {
   assert.equal(isAllowedPreloadApiMethod("readFile"), false);
   assert.throws(() => assertPreloadPayload("readFile", {}), /not allowed/);
   assert.throws(() => assertPreloadPayload("getTasks", []), /object or null/);
+});
+
+test("preload capabilities distinguish shipped methods from deferred placeholders", () => {
+  assert.deepEqual(shippedPreloadMethods, [
+    "getTasks",
+    "getTaskDetail",
+    "getTaskDocument",
+    "setTaskStatus",
+    "reviewTask",
+    "appendTaskProgress",
+    "rebuildGovernance"
+  ]);
+  assert.deepEqual(deferredPreloadMethods, ["archiveTask", "openShell"]);
+  assert.equal(getPreloadApiCapability("getTasks").status, "shipped");
+  assert.equal(getPreloadApiCapability("archiveTask").status, "deferred");
+  assert.match(getPreloadApiCapability("archiveTask").reason ?? "", /placeholder/);
+  assert.equal(getPreloadApiCapability("openShell").status, "deferred");
+  assert.match(getPreloadApiCapability("openShell").reason ?? "", /display-only/);
 });

--- a/tools/check-api-contract-registry.mjs
+++ b/tools/check-api-contract-registry.mjs
@@ -42,6 +42,7 @@ export function evaluateApiContractRegistry(root = process.cwd(), options = {}) 
   const schemaContracts = collectApiSchemaContracts(root, paths.registryPath, violations);
   const deferredContracts = collectDeferredGuiBridgeContracts(root, paths.registryPath, violations);
   const preloadMethods = collectPreloadMethods(root, paths.allowlistPath, violations);
+  const preloadCapabilities = collectPreloadCapabilities(root, paths.allowlistPath, violations);
   const dispatchBranches = collectDispatchBranches(root, paths.bridgePath, violations);
   const applicationDeclarations = collectTypeDeclarations(root, paths.applicationPath, violations);
   const registryDeclarations = collectTypeDeclarations(root, paths.registryPath, violations);
@@ -59,10 +60,16 @@ export function evaluateApiContractRegistry(root = process.cwd(), options = {}) 
     ...deferredContracts.map((entry) => entry.guiBridgeMethod).filter(Boolean)
   ]);
 
+  compareSets(preloadMethods, new Set(preloadCapabilities.keys()), {
+    leftName: "preload allowlist",
+    rightName: "preload capability metadata",
+    filePath: paths.allowlistPath,
+    violations
+  });
   inspectSchemaContracts(schemaContracts, applicationDeclarations, guiDeclarations, paths.registryPath, violations);
-  inspectRegistryEntries(registry, schemaContracts, serviceMethods, preloadMethods, paths.registryPath, violations);
+  inspectRegistryEntries(registry, schemaContracts, serviceMethods, preloadMethods, preloadCapabilities, paths.registryPath, violations);
   inspectRequiredTerminalRoutes(registry, paths.registryPath, violations);
-  inspectDeferredContracts(deferredContracts, registry, localControllerMethods, preloadMethods, paths.registryPath, violations);
+  inspectDeferredContracts(deferredContracts, registry, localControllerMethods, preloadMethods, preloadCapabilities, paths.registryPath, violations);
   inspectDispatchBranches([...registry, ...deferredContracts], dispatchBranches, paths.bridgePath, violations);
   compareSets(preloadMethods, coveredBridgeMethods, {
     leftName: "preload allowlist",
@@ -143,6 +150,36 @@ function collectPreloadMethods(root, relativePath, violations) {
   return new Set(stripAsExpression(initializer).properties.map((property) => propertyName(property.name, source.file)).filter(Boolean));
 }
 
+function collectPreloadCapabilities(root, relativePath, violations) {
+  const source = readSource(root, relativePath, violations);
+  if (!source) return new Map();
+  const initializer = findVariableInitializer(source.file, "preloadApiCapabilities");
+  if (!initializer || !ts.isObjectLiteralExpression(stripAsExpression(initializer))) {
+    violations.push(`${relativePath}: missing preloadApiCapabilities object literal`);
+    return new Map();
+  }
+  const capabilities = new Map();
+  for (const property of stripAsExpression(initializer).properties) {
+    const method = propertyName(property.name, source.file);
+    if (!method || !ts.isPropertyAssignment(property) || !ts.isObjectLiteralExpression(stripAsExpression(property.initializer))) {
+      violations.push(`${relativePath}: preloadApiCapabilities entries must be object literals`);
+      continue;
+    }
+    const capability = readStringObject(stripAsExpression(property.initializer), source.file);
+    capabilities.set(method, capability);
+    if (capability.method !== method) {
+      violations.push(`${relativePath}: preload capability ${method} method must equal ${method}`);
+    }
+    if (!["shipped", "deferred"].includes(capability.status)) {
+      violations.push(`${relativePath}: preload capability ${method} status must be shipped or deferred`);
+    }
+    if (capability.status === "deferred" && !capability.reason) {
+      violations.push(`${relativePath}: preload capability ${method} deferred status requires reason`);
+    }
+  }
+  return capabilities;
+}
+
 function collectDispatchBranches(root, relativePath, violations) {
   const source = readSource(root, relativePath, violations);
   if (!source) return new Map();
@@ -215,7 +252,7 @@ function inspectSchemaContracts(schemaContracts, applicationDeclarations, regist
   }
 }
 
-function inspectRegistryEntries(entries, schemaContracts, serviceMethods, preloadMethods, relativePath, violations) {
+function inspectRegistryEntries(entries, schemaContracts, serviceMethods, preloadMethods, preloadCapabilities, relativePath, violations) {
   const ids = new Set();
   const methodPaths = new Set();
   const schemaIds = new Set(schemaContracts.map((entry) => entry.id));
@@ -254,10 +291,13 @@ function inspectRegistryEntries(entries, schemaContracts, serviceMethods, preloa
     if (entry.guiBridgeMethod && !preloadMethods.has(entry.guiBridgeMethod)) {
       violations.push(`${relativePath}: ${label} guiBridgeMethod ${entry.guiBridgeMethod} is not in preload allowlist`);
     }
+    if (entry.guiBridgeMethod && preloadCapabilities.get(entry.guiBridgeMethod)?.status !== "shipped") {
+      violations.push(`${relativePath}: ${label} guiBridgeMethod ${entry.guiBridgeMethod} must be marked shipped in preload capabilities`);
+    }
   }
 }
 
-function inspectDeferredContracts(deferredContracts, routeContracts, serviceMethods, preloadMethods, relativePath, violations) {
+function inspectDeferredContracts(deferredContracts, routeContracts, serviceMethods, preloadMethods, preloadCapabilities, relativePath, violations) {
   const activeMethods = new Set(routeContracts.map((entry) => entry.guiBridgeMethod));
   const deferredMethods = new Set();
   for (const entry of deferredContracts) {
@@ -280,6 +320,9 @@ function inspectDeferredContracts(deferredContracts, routeContracts, serviceMeth
     }
     if (entry.guiBridgeMethod && !preloadMethods.has(entry.guiBridgeMethod)) {
       violations.push(`${relativePath}: ${label} is not in preload allowlist`);
+    }
+    if (entry.guiBridgeMethod && preloadCapabilities.get(entry.guiBridgeMethod)?.status !== "deferred") {
+      violations.push(`${relativePath}: ${label} must be marked deferred in preload capabilities`);
     }
   }
 }

--- a/tools/check-api-contract-registry.test.mjs
+++ b/tools/check-api-contract-registry.test.mjs
@@ -143,6 +143,95 @@ test("API contract registry covers deferred GUI bridge methods without active ro
   });
 });
 
+test("API contract registry rejects active route methods marked as deferred capabilities", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks"],
+      preloadCapabilities: {
+        getTasks: { method: "getTasks", status: "deferred", reason: "wrongly deferred" }
+      },
+      dispatchMethods: ["getTasks"],
+      serviceMethods: ["getTasks"],
+      registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })]
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("getTasks must be marked shipped")), true);
+  });
+});
+
+test("API contract registry rejects deferred bridge methods marked as shipped capabilities", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks", "archiveTask"],
+      preloadCapabilities: {
+        getTasks: { method: "getTasks", status: "shipped" },
+        archiveTask: { method: "archiveTask", status: "shipped" }
+      },
+      dispatchMethods: ["getTasks", "archiveTask"],
+      serviceMethods: ["getTasks", "archiveTask"],
+      registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
+      deferredEntries: [{
+        guiBridgeMethod: "archiveTask",
+        service: "LocalControllerService",
+        serviceMethod: "archiveTask",
+        reason: "Archive is disabled until route ownership lands."
+      }]
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("deferred archiveTask must be marked deferred")), true);
+  });
+});
+
+test("API contract registry rejects preload methods without capability metadata", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks", "getTaskDetail"],
+      preloadCapabilities: {
+        getTasks: { method: "getTasks", status: "shipped" }
+      },
+      dispatchMethods: ["getTasks", "getTaskDetail"],
+      serviceMethods: ["getTasks", "getTaskDetail"],
+      registryEntries: [
+        route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" }),
+        route({ id: "tasks.detail", guiBridgeMethod: "getTaskDetail", serviceMethod: "getTaskDetail" })
+      ]
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("getTaskDetail") && violation.includes("preload capability metadata")), true);
+  });
+});
+
+test("API contract registry rejects deferred capability without reason", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks", "archiveTask"],
+      preloadCapabilities: {
+        getTasks: { method: "getTasks", status: "shipped" },
+        archiveTask: { method: "archiveTask", status: "deferred" }
+      },
+      dispatchMethods: ["getTasks", "archiveTask"],
+      serviceMethods: ["getTasks", "archiveTask"],
+      registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
+      deferredEntries: [{
+        guiBridgeMethod: "archiveTask",
+        service: "LocalControllerService",
+        serviceMethod: "archiveTask",
+        reason: "Archive is disabled until route ownership lands."
+      }]
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("archiveTask deferred status requires reason")), true);
+  });
+});
+
 test("API contract registry accepts terminal service routes without preload dispatch", async () => {
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
@@ -237,6 +326,13 @@ function writeFixture(root, options) {
     { id: "terminal.session-list-result/v1", owner: "gui", typeName: "TerminalSessionListResult" }
   ];
   const deferredEntries = options.deferredEntries ?? [];
+  const deferredMethods = new Set(deferredEntries.map((entry) => entry.guiBridgeMethod));
+  const preloadCapabilities = options.preloadCapabilities ?? Object.fromEntries(options.preloadMethods.map((method) => [
+    method,
+    deferredMethods.has(method)
+      ? { method, status: "deferred", reason: `${method} is deferred in this fixture.` }
+      : { method, status: "shipped" }
+  ]));
   const dispatchBranches = options.dispatchBranches
     ?? options.dispatchMethods.map((method) => ({ method, serviceMethod: method }));
   const terminalRoutes = options.terminalRoutes ?? requiredTerminalRoutes();
@@ -258,6 +354,9 @@ function writeFixture(root, options) {
   writeFileSync(path.join(root, "packages/gui/src/preload/allowlist.ts"), [
     "export const allowedPreloadApi = {",
     ...options.preloadMethods.map((method) => `  ${method}: ${JSON.stringify(method)},`),
+    "} as const;",
+    "export const preloadApiCapabilities = {",
+    ...Object.entries(preloadCapabilities).map(([method, capability]) => `  ${method}: ${JSON.stringify(capability)},`),
     "} as const;",
     ""
   ].join("\n"), "utf8");


### PR DESCRIPTION
## Summary

- Add machine-readable preload capability metadata for every GUI preload method.
- Mark active GUI bridge methods as `shipped`, and mark `archiveTask` / legacy `openShell` as `deferred` with explicit reason text.
- Expose static capability metadata through the preload object without adding a new IPC handler.
- Extend the API contract registry checker so shipped/deferred drift fails closed.

## Tests and tiers

Modified existing contract-tier tests only; no new test files were added, so `tools/test-tier-manifest.mjs` did not need a change.

- `packages/gui/test/preload-allowlist.test.ts` — contract
- `packages/gui/test/ipc-handler-registration.test.ts` — contract
- `tools/check-api-contract-registry.test.mjs` — contract

Commands run:

- `npm install`
- `node --test packages/gui/test/preload-allowlist.test.ts packages/gui/test/ipc-handler-registration.test.ts tools/check-api-contract-registry.test.mjs`
- `npm run typecheck`
- `npm run harness:check-api-contract-registry`
- `npm run test:contract`
- `npm run check:pr`
- `npm run check`

Slow-test summary:

- No P12-specific slow tests were introduced.
- Slow entries remain existing full-suite/integration CLI/store behavior, including CLI task delete, project settings defaults, preset CRUD, legacy rebuild, terminal status-set recovery, WriteCoordinator compaction, and metadata checks.

## Review

Reviewer subagent Hooke reported no P0/P1/P2 findings and recommended merge-ready after normal gates.

Residual follow-up for future handler generation: generated handlers must treat `deferred` as excluded or explicit not-implemented behavior, never as shipped.
