### PR TITLE
Gate GUI bridge handlers from API registry

### DIFF
--- a/packages/gui/src/api/service-bridge.ts
+++ b/packages/gui/src/api/service-bridge.ts
@@ -6,12 +6,89 @@ import {
   readTaskDocumentPayload,
   readTaskIdPayload
 } from "../../../application/src/index.ts";
-import { classifyShellOutput } from "../terminal/boundary.ts";
+import type { PreloadApiMethod } from "../preload/allowlist.ts";
+import { apiRouteContracts, deferredGuiBridgeContracts } from "./api-contract-registry.ts";
 import { validateProjectPath } from "./local-api.ts";
 
 export interface GuiServiceBridge {
   readonly invoke: (method: string, payload: unknown) => Promise<unknown>;
 }
+
+type ShippedGuiBridgeRoute = Extract<(typeof apiRouteContracts)[number], { readonly guiBridgeMethod: PreloadApiMethod }>;
+type ShippedGuiBridgeMethod = ShippedGuiBridgeRoute["guiBridgeMethod"];
+
+interface GuiBridgeHandlerContext {
+  readonly rootDir: string;
+  readonly service: LocalControllerService;
+  readonly payload: unknown;
+}
+
+interface GuiBridgeHandlerImplementation {
+  readonly serviceMethod: keyof LocalControllerService;
+  readonly invoke: (context: GuiBridgeHandlerContext) => Promise<unknown> | unknown;
+}
+
+export const guiBridgeHandlerImplementations = {
+  getTasks: {
+    serviceMethod: "getTasks",
+    invoke: ({ service }) => service.getTasks()
+  },
+  getTaskDetail: {
+    serviceMethod: "getTaskDetail",
+    invoke: ({ service, payload }) => {
+      const parsed = readTaskIdPayload(payload);
+      if (!parsed.ok) return parsed;
+      return service.getTaskDetail(parsed);
+    }
+  },
+  getTaskDocument: {
+    serviceMethod: "getTaskDocument",
+    invoke: ({ rootDir, service, payload }) => {
+      const pathDecision = validateTaskDocumentPayloadPath(rootDir, payload);
+      if (!pathDecision.ok) return pathDecision;
+      const parsed = readTaskDocumentPayload(payload);
+      if (!parsed.ok) return parsed;
+      return service.getTaskDocument(parsed);
+    }
+  },
+  setTaskStatus: {
+    serviceMethod: "setTaskStatus",
+    invoke: ({ service, payload }) => {
+      const parsed = readSetStatusPayload(payload);
+      if (!parsed.ok) return parsed;
+      return service.setTaskStatus(parsed);
+    }
+  },
+  reviewTask: {
+    serviceMethod: "reviewTask",
+    invoke: ({ service, payload }) => {
+      const parsed = readTaskIdPayload(payload);
+      if (!parsed.ok) return parsed;
+      return service.reviewTask(parsed);
+    }
+  },
+  appendTaskProgress: {
+    serviceMethod: "appendTaskProgress",
+    invoke: ({ service, payload }) => {
+      const parsed = readAppendProgressPayload(payload);
+      if (!parsed.ok) return parsed;
+      return service.appendTaskProgress(parsed);
+    }
+  },
+  rebuildGovernance: {
+    serviceMethod: "rebuildGovernance",
+    invoke: ({ service }) => service.rebuildGovernance()
+  }
+} as const satisfies Record<ShippedGuiBridgeMethod, GuiBridgeHandlerImplementation>;
+
+export function getShippedGuiBridgeMethods(): ReadonlyArray<ShippedGuiBridgeMethod> {
+  return apiRouteContracts.flatMap((route) => "guiBridgeMethod" in route && route.guiBridgeMethod ? [route.guiBridgeMethod] : []) as ReadonlyArray<ShippedGuiBridgeMethod>;
+}
+
+const shippedGuiBridgeMethods = new Set<PreloadApiMethod>(getShippedGuiBridgeMethods());
+const deferredGuiBridgeReasons = new Map<PreloadApiMethod, string>(
+  deferredGuiBridgeContracts.map((entry) => [entry.guiBridgeMethod, entry.reason])
+);
 
 export function createGuiServiceBridgeForService(rootDir: string, service: LocalControllerService): GuiServiceBridge {
   return {
@@ -25,40 +102,18 @@ export async function dispatchGuiServiceMethod(
   method: string,
   payload: unknown
 ): Promise<unknown> {
-  if (method === "getTasks") return service.getTasks();
-  if (method === "getTaskDetail") {
-    const parsed = readTaskIdPayload(payload);
-    if (!parsed.ok) return parsed;
-    return service.getTaskDetail(parsed);
+  if (shippedGuiBridgeMethods.has(method as PreloadApiMethod)) {
+    const handler = guiBridgeHandlerImplementations[method as ShippedGuiBridgeMethod];
+    return handler.invoke({ rootDir, service, payload });
   }
-  if (method === "getTaskDocument") {
-    const pathDecision = validateTaskDocumentPayloadPath(rootDir, payload);
-    if (!pathDecision.ok) return pathDecision;
-    const parsed = readTaskDocumentPayload(payload);
-    if (!parsed.ok) return parsed;
-    return service.getTaskDocument(parsed);
-  }
-  if (method === "setTaskStatus") {
-    const parsed = readSetStatusPayload(payload);
-    if (!parsed.ok) return parsed;
-    return service.setTaskStatus(parsed);
-  }
-  if (method === "reviewTask") {
-    const parsed = readTaskIdPayload(payload);
-    if (!parsed.ok) return parsed;
-    return service.reviewTask(parsed);
-  }
-  if (method === "archiveTask") return service.archiveTask();
-  if (method === "appendTaskProgress") {
-    const parsed = readAppendProgressPayload(payload);
-    if (!parsed.ok) return parsed;
-    return service.appendTaskProgress(parsed);
-  }
-  if (method === "rebuildGovernance") return service.rebuildGovernance();
-  if (method === "openShell") {
+  const deferredReason = deferredGuiBridgeReasons.get(method as PreloadApiMethod);
+  if (deferredReason) {
     return {
-      ...service.openShell(),
-      sampleClassification: classifyShellOutput("")
+      ok: false,
+      error: {
+        code: "method_deferred",
+        hint: deferredReason
+      }
     };
   }
   return {

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { createLocalGuiServiceBridge } from "../src/index.ts";
+import { apiRouteContracts, createLocalGuiServiceBridge, getShippedGuiBridgeMethods } from "../src/index.ts";
 
 test("GUI service bridge reaches application service while enforcing document path guard", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-bridge-"));
@@ -22,6 +22,33 @@ test("GUI service bridge reaches application service while enforcing document pa
     const rejected = await bridge.invoke("getTaskDocument", { taskId: "task-1", path: "../../../../.harness-private/review.md" }) as { readonly ok: boolean; readonly error?: { readonly code: string } };
     assert.equal(rejected.ok, false);
     assert.equal(rejected.error?.code, "path_is_private");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("GUI service bridge shipped methods are registry-driven and deferred methods return explicit errors", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-bridge-"));
+  try {
+    const bridge = createLocalGuiServiceBridge(rootDir);
+    const activeGuiMethods = apiRouteContracts
+      .map((route) => "guiBridgeMethod" in route ? route.guiBridgeMethod : undefined)
+      .filter((method): method is string => typeof method === "string");
+
+    assert.deepEqual(getShippedGuiBridgeMethods(), activeGuiMethods);
+    const shippedMethods = new Set<string>(getShippedGuiBridgeMethods());
+    assert.equal(shippedMethods.has("archiveTask"), false);
+    assert.equal(shippedMethods.has("openShell"), false);
+
+    const archive = await bridge.invoke("archiveTask", null) as { readonly ok: boolean; readonly error?: { readonly code: string; readonly hint: string } };
+    assert.equal(archive.ok, false);
+    assert.equal(archive.error?.code, "method_deferred");
+    assert.match(archive.error?.hint ?? "", /Archive/);
+
+    const shell = await bridge.invoke("openShell", null) as { readonly ok: boolean; readonly error?: { readonly code: string; readonly hint: string } };
+    assert.equal(shell.ok, false);
+    assert.equal(shell.error?.code, "method_deferred");
+    assert.match(shell.error?.hint ?? "", /terminal sessions/i);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }

--- a/tools/check-api-contract-registry.mjs
+++ b/tools/check-api-contract-registry.mjs
@@ -43,7 +43,7 @@ export function evaluateApiContractRegistry(root = process.cwd(), options = {}) 
   const deferredContracts = collectDeferredGuiBridgeContracts(root, paths.registryPath, violations);
   const preloadMethods = collectPreloadMethods(root, paths.allowlistPath, violations);
   const preloadCapabilities = collectPreloadCapabilities(root, paths.allowlistPath, violations);
-  const dispatchBranches = collectDispatchBranches(root, paths.bridgePath, violations);
+  const bridgeHandlers = collectGuiBridgeHandlerImplementations(root, paths.bridgePath, violations);
   const applicationDeclarations = collectTypeDeclarations(root, paths.applicationPath, violations);
   const registryDeclarations = collectTypeDeclarations(root, paths.registryPath, violations);
   const terminalDeclarations = collectTypeDeclarations(root, paths.terminalPath, violations);
@@ -70,19 +70,20 @@ export function evaluateApiContractRegistry(root = process.cwd(), options = {}) 
   inspectRegistryEntries(registry, schemaContracts, serviceMethods, preloadMethods, preloadCapabilities, paths.registryPath, violations);
   inspectRequiredTerminalRoutes(registry, paths.registryPath, violations);
   inspectDeferredContracts(deferredContracts, registry, localControllerMethods, preloadMethods, preloadCapabilities, paths.registryPath, violations);
-  inspectDispatchBranches([...registry, ...deferredContracts], dispatchBranches, paths.bridgePath, violations);
+  inspectBridgeHandlers(registry, bridgeHandlers, paths.bridgePath, violations);
   compareSets(preloadMethods, coveredBridgeMethods, {
     leftName: "preload allowlist",
     rightName: "API registry or deferred GUI bridge contract",
     filePath: paths.registryPath,
     violations
   });
-  compareSets(new Set(dispatchBranches.keys()), coveredBridgeMethods, {
-    leftName: "GUI service dispatch",
-    rightName: "API registry or deferred GUI bridge contract",
-    filePath: paths.registryPath,
+  compareSets(new Set(bridgeHandlers.keys()), new Set(registry.map((entry) => entry.guiBridgeMethod).filter(Boolean)), {
+    leftName: "GUI shipped bridge handler implementations",
+    rightName: "active API registry GUI bridge methods",
+    filePath: paths.bridgePath,
     violations
   });
+  inspectDeferredMethodsExcludedFromBridgeHandlers(deferredContracts, bridgeHandlers, paths.bridgePath, violations);
 
   return violations;
 }
@@ -180,24 +181,33 @@ function collectPreloadCapabilities(root, relativePath, violations) {
   return capabilities;
 }
 
-function collectDispatchBranches(root, relativePath, violations) {
+function collectGuiBridgeHandlerImplementations(root, relativePath, violations) {
   const source = readSource(root, relativePath, violations);
   if (!source) return new Map();
-  const branches = new Map();
-  let foundDispatcher = false;
-
-  function visit(node) {
-    if (ts.isFunctionDeclaration(node) && node.name?.text === "dispatchGuiServiceMethod") {
-      foundDispatcher = true;
-      collectMethodBranches(node, source.file, branches, relativePath, violations);
-      return;
-    }
-    ts.forEachChild(node, visit);
+  const initializer = findVariableInitializer(source.file, "guiBridgeHandlerImplementations");
+  if (!initializer || !ts.isObjectLiteralExpression(stripAsExpression(initializer))) {
+    violations.push(`${relativePath}: missing guiBridgeHandlerImplementations object literal`);
+    return new Map();
   }
-
-  visit(source.file);
-  if (!foundDispatcher) violations.push(`${relativePath}: missing dispatchGuiServiceMethod`);
-  return branches;
+  const handlers = new Map();
+  for (const property of stripAsExpression(initializer).properties) {
+    const method = propertyName(property.name, source.file);
+    if (!method || !ts.isPropertyAssignment(property) || !ts.isObjectLiteralExpression(stripAsExpression(property.initializer))) {
+      violations.push(`${relativePath}: guiBridgeHandlerImplementations entries must be object literals`);
+      continue;
+    }
+    if (handlers.has(method)) {
+      violations.push(`${relativePath}: duplicate GUI bridge handler implementation for ${method}`);
+      continue;
+    }
+    const handler = stripAsExpression(property.initializer);
+    const metadata = readStringObject(handler, source.file);
+    handlers.set(method, {
+      serviceMethod: metadata.serviceMethod,
+      serviceCalls: collectServiceCalls(handler, source.file)
+    });
+  }
+  return handlers;
 }
 
 function collectTypeDeclarations(root, relativePath, violations) {
@@ -327,21 +337,32 @@ function inspectDeferredContracts(deferredContracts, routeContracts, serviceMeth
   }
 }
 
-function inspectDispatchBranches(contracts, dispatchBranches, relativePath, violations) {
+function inspectBridgeHandlers(contracts, bridgeHandlers, relativePath, violations) {
   for (const entry of contracts) {
     if (!entry.guiBridgeMethod || !entry.serviceMethod) continue;
-    const serviceCalls = dispatchBranches.get(entry.guiBridgeMethod);
-    if (!serviceCalls) {
-      violations.push(`${relativePath}: ${entry.guiBridgeMethod} is registered but has no dispatch branch`);
+    const handler = bridgeHandlers.get(entry.guiBridgeMethod);
+    if (!handler) {
+      violations.push(`${relativePath}: ${entry.guiBridgeMethod} is registered as active but has no shipped bridge handler implementation`);
       continue;
     }
-    if (!serviceCalls.has(entry.serviceMethod)) {
-      violations.push(`${relativePath}: ${entry.guiBridgeMethod} dispatch does not call LocalControllerService.${entry.serviceMethod}`);
+    if (handler.serviceMethod !== entry.serviceMethod) {
+      violations.push(`${relativePath}: ${entry.guiBridgeMethod} shipped bridge handler declares ${handler.serviceMethod ?? "<missing>"} but registry requires LocalControllerService.${entry.serviceMethod}`);
     }
-    for (const serviceCall of serviceCalls) {
+    if (!handler.serviceCalls.has(entry.serviceMethod)) {
+      violations.push(`${relativePath}: ${entry.guiBridgeMethod} shipped bridge handler does not call LocalControllerService.${entry.serviceMethod}`);
+    }
+    for (const serviceCall of handler.serviceCalls) {
       if (serviceCall !== entry.serviceMethod) {
-        violations.push(`${relativePath}: ${entry.guiBridgeMethod} dispatch calls unexpected LocalControllerService.${serviceCall}`);
+        violations.push(`${relativePath}: ${entry.guiBridgeMethod} shipped bridge handler calls unexpected LocalControllerService.${serviceCall}`);
       }
+    }
+  }
+}
+
+function inspectDeferredMethodsExcludedFromBridgeHandlers(deferredContracts, bridgeHandlers, relativePath, violations) {
+  for (const entry of deferredContracts) {
+    if (entry.guiBridgeMethod && bridgeHandlers.has(entry.guiBridgeMethod)) {
+      violations.push(`${relativePath}: deferred ${entry.guiBridgeMethod} must not appear in GUI shipped bridge handler implementations`);
     }
   }
 }
@@ -353,35 +374,6 @@ function compareSets(left, right, context) {
   for (const value of right) {
     if (!left.has(value)) context.violations.push(`${context.filePath}: ${value} is in ${context.rightName} but missing from ${context.leftName}`);
   }
-}
-
-function collectMethodBranches(node, sourceFile, branches, relativePath, violations) {
-  function visit(child) {
-    if (ts.isIfStatement(child)) {
-      const methodName = readMethodEquality(child.expression, sourceFile);
-      if (methodName) {
-        if (branches.has(methodName)) {
-          violations.push(`${relativePath}: duplicate dispatch branch for ${methodName}`);
-        } else {
-          branches.set(methodName, collectServiceCalls(child.thenStatement, sourceFile));
-        }
-        if (child.elseStatement) visit(child.elseStatement);
-        return;
-      }
-    }
-    ts.forEachChild(child, visit);
-  }
-
-  visit(node);
-}
-
-function readMethodEquality(expression, sourceFile) {
-  if (!ts.isBinaryExpression(expression) || expression.operatorToken.kind !== ts.SyntaxKind.EqualsEqualsEqualsToken) return undefined;
-  const left = expression.left.getText(sourceFile);
-  const right = expression.right.getText(sourceFile);
-  if (left === "method" && ts.isStringLiteral(expression.right)) return expression.right.text;
-  if (right === "method" && ts.isStringLiteral(expression.left)) return expression.left.text;
-  return undefined;
 }
 
 function collectServiceCalls(node, sourceFile) {

--- a/tools/check-api-contract-registry.test.mjs
+++ b/tools/check-api-contract-registry.test.mjs
@@ -14,7 +14,7 @@ test("API contract registry rejects preload methods missing from registry", asyn
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
       preloadMethods: ["getTasks", "getTaskDetail"],
-      dispatchMethods: ["getTasks", "getTaskDetail"],
+      handlerMethods: ["getTasks", "getTaskDetail"],
       serviceMethods: ["getTasks", "getTaskDetail"],
       registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })]
     });
@@ -29,7 +29,7 @@ test("API contract registry rejects routes pointing at missing service methods",
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
       preloadMethods: ["getTasks"],
-      dispatchMethods: ["getTasks"],
+      handlerMethods: ["getTasks"],
       serviceMethods: ["getTasks"],
       registryEntries: [route({ serviceMethod: "missingMethod" })]
     });
@@ -44,7 +44,7 @@ test("API contract registry rejects duplicate method and path pairs", async () =
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
       preloadMethods: ["getTasks", "getTaskDetail"],
-      dispatchMethods: ["getTasks", "getTaskDetail"],
+      handlerMethods: ["getTasks", "getTaskDetail"],
       serviceMethods: ["getTasks", "getTaskDetail"],
       registryEntries: [
         route({ id: "tasks.list", guiBridgeMethod: "getTasks", serviceMethod: "getTasks" }),
@@ -58,11 +58,11 @@ test("API contract registry rejects duplicate method and path pairs", async () =
   });
 });
 
-test("API contract registry rejects malformed schema ids and undispatched bridge methods", async () => {
+test("API contract registry rejects malformed schema ids and unimplemented bridge methods", async () => {
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
       preloadMethods: ["getTasks"],
-      dispatchMethods: [],
+      handlerMethods: [],
       serviceMethods: ["getTasks"],
       registryEntries: [route({ inputSchemaId: "TaskListResult", guiBridgeMethod: "getTasks" })]
     });
@@ -70,7 +70,7 @@ test("API contract registry rejects malformed schema ids and undispatched bridge
     const violations = evaluateApiContractRegistry(root);
 
     assert.equal(violations.some((violation) => violation.includes("malformed inputSchemaId")), true);
-    assert.equal(violations.some((violation) => violation.includes("GUI service dispatch")), true);
+    assert.equal(violations.some((violation) => violation.includes("active API registry GUI bridge methods")), true);
   });
 });
 
@@ -78,7 +78,7 @@ test("API contract registry rejects valid-looking but unregistered schema ids", 
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
       preloadMethods: ["getTasks"],
-      dispatchMethods: ["getTasks"],
+      handlerMethods: ["getTasks"],
       serviceMethods: ["getTasks"],
       registryEntries: [route({ inputSchemaId: "application.not-real/v1" })]
     });
@@ -89,27 +89,28 @@ test("API contract registry rejects valid-looking but unregistered schema ids", 
   });
 });
 
-test("API contract registry rejects dispatch branches calling the wrong service method", async () => {
+test("API contract registry rejects bridge handler implementations calling the wrong service method", async () => {
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
       preloadMethods: ["getTasks"],
-      dispatchBranches: [{ method: "getTasks", serviceMethod: "getTaskDetail" }],
+      handlerImplementations: [{ method: "getTasks", serviceMethod: "getTaskDetail" }],
       serviceMethods: ["getTasks", "getTaskDetail"],
       registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })]
     });
 
     const violations = evaluateApiContractRegistry(root);
 
-    assert.equal(violations.some((violation) => violation.includes("getTasks dispatch does not call LocalControllerService.getTasks")), true);
-    assert.equal(violations.some((violation) => violation.includes("getTasks dispatch calls unexpected LocalControllerService.getTaskDetail")), true);
+    assert.equal(violations.some((violation) => violation.includes("getTasks shipped bridge handler declares getTaskDetail")), true);
+    assert.equal(violations.some((violation) => violation.includes("getTasks shipped bridge handler does not call LocalControllerService.getTasks")), true);
+    assert.equal(violations.some((violation) => violation.includes("getTasks shipped bridge handler calls unexpected LocalControllerService.getTaskDetail")), true);
   });
 });
 
-test("API contract registry rejects duplicate dispatch branches", async () => {
+test("API contract registry rejects duplicate bridge handler implementations", async () => {
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
       preloadMethods: ["getTasks"],
-      dispatchBranches: [
+      handlerImplementations: [
         { method: "getTasks", serviceMethod: "getTaskDetail" },
         { method: "getTasks", serviceMethod: "getTasks" }
       ],
@@ -119,8 +120,8 @@ test("API contract registry rejects duplicate dispatch branches", async () => {
 
     const violations = evaluateApiContractRegistry(root);
 
-    assert.equal(violations.some((violation) => violation.includes("duplicate dispatch branch for getTasks")), true);
-    assert.equal(violations.some((violation) => violation.includes("getTasks dispatch does not call LocalControllerService.getTasks")), true);
+    assert.equal(violations.some((violation) => violation.includes("duplicate GUI bridge handler implementation for getTasks")), true);
+    assert.equal(violations.some((violation) => violation.includes("getTasks shipped bridge handler does not call LocalControllerService.getTasks")), true);
   });
 });
 
@@ -128,7 +129,7 @@ test("API contract registry covers deferred GUI bridge methods without active ro
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
       preloadMethods: ["getTasks", "archiveTask"],
-      dispatchMethods: ["getTasks", "archiveTask"],
+      handlerMethods: ["getTasks"],
       serviceMethods: ["getTasks", "archiveTask"],
       registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
       deferredEntries: [{
@@ -150,7 +151,7 @@ test("API contract registry rejects active route methods marked as deferred capa
       preloadCapabilities: {
         getTasks: { method: "getTasks", status: "deferred", reason: "wrongly deferred" }
       },
-      dispatchMethods: ["getTasks"],
+      handlerMethods: ["getTasks"],
       serviceMethods: ["getTasks"],
       registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })]
     });
@@ -169,7 +170,7 @@ test("API contract registry rejects deferred bridge methods marked as shipped ca
         getTasks: { method: "getTasks", status: "shipped" },
         archiveTask: { method: "archiveTask", status: "shipped" }
       },
-      dispatchMethods: ["getTasks", "archiveTask"],
+      handlerMethods: ["getTasks"],
       serviceMethods: ["getTasks", "archiveTask"],
       registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
       deferredEntries: [{
@@ -193,7 +194,7 @@ test("API contract registry rejects preload methods without capability metadata"
       preloadCapabilities: {
         getTasks: { method: "getTasks", status: "shipped" }
       },
-      dispatchMethods: ["getTasks", "getTaskDetail"],
+      handlerMethods: ["getTasks", "getTaskDetail"],
       serviceMethods: ["getTasks", "getTaskDetail"],
       registryEntries: [
         route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" }),
@@ -215,7 +216,7 @@ test("API contract registry rejects deferred capability without reason", async (
         getTasks: { method: "getTasks", status: "shipped" },
         archiveTask: { method: "archiveTask", status: "deferred" }
       },
-      dispatchMethods: ["getTasks", "archiveTask"],
+      handlerMethods: ["getTasks"],
       serviceMethods: ["getTasks", "archiveTask"],
       registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
       deferredEntries: [{
@@ -232,11 +233,32 @@ test("API contract registry rejects deferred capability without reason", async (
   });
 });
 
+test("API contract registry rejects deferred bridge methods in shipped handler implementations", async () => {
+  await withFixtureRepo(async (root) => {
+    writeFixture(root, {
+      preloadMethods: ["getTasks", "archiveTask"],
+      handlerMethods: ["getTasks", "archiveTask"],
+      serviceMethods: ["getTasks", "archiveTask"],
+      registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
+      deferredEntries: [{
+        guiBridgeMethod: "archiveTask",
+        service: "LocalControllerService",
+        serviceMethod: "archiveTask",
+        reason: "Archive is disabled until route ownership lands."
+      }]
+    });
+
+    const violations = evaluateApiContractRegistry(root);
+
+    assert.equal(violations.some((violation) => violation.includes("deferred archiveTask must not appear in GUI shipped bridge handler implementations")), true);
+  });
+});
+
 test("API contract registry accepts terminal service routes without preload dispatch", async () => {
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
       preloadMethods: ["getTasks"],
-      dispatchMethods: ["getTasks"],
+      handlerMethods: ["getTasks"],
       serviceMethods: ["getTasks"],
       registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
       terminalRoutes: requiredTerminalRoutes()
@@ -250,7 +272,7 @@ test("API contract registry rejects terminal routes pointing at missing terminal
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
       preloadMethods: ["getTasks"],
-      dispatchMethods: ["getTasks"],
+      handlerMethods: ["getTasks"],
       serviceMethods: ["getTasks"],
       terminalMethods: ["createSession", "listSessions", "getSession", "attachSession", "resizeSession", "closeSession"],
       registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
@@ -269,7 +291,7 @@ test("API contract registry rejects missing required terminal routes", async () 
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
       preloadMethods: ["getTasks"],
-      dispatchMethods: ["getTasks"],
+      handlerMethods: ["getTasks"],
       serviceMethods: ["getTasks"],
       registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
       terminalRoutes: requiredTerminalRoutes().filter((entry) => entry.id !== "terminal.sessions.attach")
@@ -285,7 +307,7 @@ test("API contract registry rejects required terminal route path drift", async (
   await withFixtureRepo(async (root) => {
     writeFixture(root, {
       preloadMethods: ["getTasks"],
-      dispatchMethods: ["getTasks"],
+      handlerMethods: ["getTasks"],
       serviceMethods: ["getTasks"],
       registryEntries: [route({ guiBridgeMethod: "getTasks", serviceMethod: "getTasks" })],
       terminalRoutes: requiredTerminalRoutes().map((entry) => entry.id === "terminal.sessions.get"
@@ -333,8 +355,8 @@ function writeFixture(root, options) {
       ? { method, status: "deferred", reason: `${method} is deferred in this fixture.` }
       : { method, status: "shipped" }
   ]));
-  const dispatchBranches = options.dispatchBranches
-    ?? options.dispatchMethods.map((method) => ({ method, serviceMethod: method }));
+  const handlerImplementations = options.handlerImplementations
+    ?? options.handlerMethods.map((method) => ({ method, serviceMethod: method }));
   const terminalRoutes = options.terminalRoutes ?? requiredTerminalRoutes();
   const terminalMethods = options.terminalMethods ?? [...new Set(terminalRoutes.map((entry) => entry.serviceMethod))];
   writeFileSync(path.join(root, "packages/gui/src/api/api-contract-registry.ts"), [
@@ -361,10 +383,9 @@ function writeFixture(root, options) {
     ""
   ].join("\n"), "utf8");
   writeFileSync(path.join(root, "packages/gui/src/api/service-bridge.ts"), [
-    "export function dispatchGuiServiceMethod(method: string): unknown {",
-    ...dispatchBranches.map((branch) => `  if (method === ${JSON.stringify(branch.method)}) return service.${branch.serviceMethod}();`),
-    "  return {};",
-    "}",
+    "export const guiBridgeHandlerImplementations = {",
+    ...handlerImplementations.map((handler) => `  ${handler.method}: { serviceMethod: ${JSON.stringify(handler.serviceMethod)}, invoke: () => service.${handler.serviceMethod}() },`),
+    "} as const;",
     ""
   ].join("\n"), "utf8");
   writeFileSync(path.join(root, "packages/application/src/index.ts"), [


### PR DESCRIPTION
## Summary

- Derive shipped GUI bridge method membership from `apiRouteContracts`.
- Replace the unstructured `if (method === ...)` bridge surface with `guiBridgeHandlerImplementations` that declares each shipped handler's service method and invoke function.
- Return explicit `method_deferred` errors for deferred preload methods (`archiveTask`, legacy `openShell`) instead of treating them as shipped service handlers.
- Extend `harness:check-api-contract-registry` so active registry GUI bridge methods and shipped handler implementations cannot drift, and deferred methods cannot enter shipped handlers.

This is a GUI bridge lint/gate layer for M2.5 G-01. It does not implement daemon REST/WS handlers.

## Tests and tiers

Modified existing contract-tier tests only; no new test files were added, so `tools/test-tier-manifest.mjs` did not need a change.

- `packages/gui/test/service-bridge.test.ts` — contract
- `tools/check-api-contract-registry.test.mjs` — contract

Commands run:

- `npm install`
- `npm run typecheck`
- `node --test packages/gui/test/service-bridge.test.ts tools/check-api-contract-registry.test.mjs`
- `npm run harness:check-api-contract-registry`
- `npm run test:contract`
- `npm run harness:check-supply-chain`
- `npm run check:pr`
- `npm run check`

Slow-test summary:

- No P14-specific slow tests were introduced.
- Slow entries remain existing full-suite/integration CLI/store behavior, including CLI task delete, settings defaults, legacy rebuild, preset CRUD, terminal status-set recovery, WriteCoordinator compaction, and metadata/check tests.

## Review

Reviewer subagent Lorentz reported no P0/P1/P2 findings and recommended merge-ready.
