### PR TITLE
Fix EntityRef scanner false positives

### DIFF
--- a/packages/kernel/src/domain/entity-ref.ts
+++ b/packages/kernel/src/domain/entity-ref.ts
@@ -9,13 +9,18 @@ export interface ParsedEntityRef {
 }
 
 const entityRefPattern = /^(?:(?<alias>[A-Za-z][A-Za-z0-9_-]*):)?(?<kind>task)\/(?<id>[A-Za-z0-9_-]+)$/u;
-const entityRefSearchPattern = /\b(?:(?<alias>[A-Za-z][A-Za-z0-9_-]*):)?(?<kind>task)\/(?<id>[A-Za-z0-9_-]+)\b/gu;
+const entityRefSearchPattern = /(?<![A-Za-z0-9_/-])(?:(?<alias>[A-Za-z][A-Za-z0-9_-]*):)?(?<kind>task)\/(?<id>[A-Za-z0-9_-]+)\b(?!\/)/gu;
+
+function isPlausibleTaskRefId(id: string): boolean {
+  return id.startsWith("task_") || id.includes("-");
+}
 
 export function parseEntityRef(value: string): ParsedEntityRef | null {
   const match = value.match(entityRefPattern);
   const kind = match?.groups?.kind;
   const id = match?.groups?.id;
   if (kind !== "task" || !id) return null;
+  if (!isPlausibleTaskRefId(id)) return null;
   const harnessAlias = match.groups?.alias;
   return {
     raw: value,

--- a/packages/kernel/test/domain/entity-ref.test.ts
+++ b/packages/kernel/test/domain/entity-ref.test.ts
@@ -17,6 +17,8 @@ test("EntityRef parser accepts local and prefixed task references", () => {
     externalHarness: true
   });
   assert.equal(parseEntityRef("issue/123"), null);
+  assert.equal(parseEntityRef("task/v1"), null);
+  assert.equal(parseEntityRef("task/doc"), null);
 });
 
 test("EntityRef scanner preserves external harness prefixes without resolving them", () => {
@@ -26,4 +28,15 @@ test("EntityRef scanner preserves external harness prefixes without resolving th
     ["task/local-task", false],
     ["other-harness:task/remote-task", true]
   ]);
+});
+
+test("EntityRef scanner ignores task-like prose, package markers, and paths", () => {
+  const refs = findEntityRefs([
+    "Task Contract: harness-task/v1",
+    "workspace has task/doc/terminal panes",
+    "path scripts/domain/task/task-subjects.mts",
+    "real refs task/local-task and team-a:task/remote-task remain"
+  ].join("\n"));
+
+  assert.deepEqual(refs.map((ref) => ref.raw), ["task/local-task", "team-a:task/remote-task"]);
 });


### PR DESCRIPTION
## Summary
- prevent EntityRef scanning from matching task-like substrings inside package markers, prose lists, and paths
- keep real local and cross-harness task refs working
- add fast-tier coverage for harness-task/v1, task/doc, and domain/task paths

## Verification
- npm run test:fast
- npm run check
- NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/harness-anything check --profile private-harness .harness-private --json

M2.5 closeout note: this fixes a checker false-positive found during parent closeout. It is not a new P16b/P17 task package.