### PR TITLE
Make process presets script-declared

### DIFF
--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/index.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/index.json
@@ -3,6 +3,7 @@
     "standard-task",
     "module",
     "legacy-migration",
+    "milestone-closeout",
     "lesson-sedimentation",
     "version-upgrade",
     "publish-standard",

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/legacy-migration/preset.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/legacy-migration/preset.json
@@ -1,14 +1,26 @@
 {
   "schema": "preset-manifest/v2",
   "id": "legacy-migration",
-  "title": "Legacy Migration Capability Smoke",
+  "title": "Legacy Migration",
   "vertical": "software/coding",
   "version": "1.0.0",
   "kind": "process-action",
   "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
   "capabilityImports": [{ "id": "legacy-migration-command", "kind": "command", "version": "1", "required": false }],
   "entrypoints": {
-    "plan": { "type": "script", "command": "scripts/preset-action.mjs", "writes": ["{{outputRoot}}/**"] }
+    "plan": {
+      "type": "script",
+      "command": "scripts/preset-action.mjs",
+      "reads": [
+        "{{paths.rootDir}}/docs/**",
+        "{{paths.rootDir}}/harness/**",
+        "{{paths.rootDir}}/.harness-private/**",
+        "{{paths.rootDir}}/*/docs/**",
+        "{{paths.rootDir}}/*/harness/**",
+        "{{paths.rootDir}}/*/.harness-private/**"
+      ],
+      "writes": ["{{outputRoot}}/**"]
+    }
   },
   "profiles": [{ "id": "baseline", "title": "Baseline", "checkerProfile": "standard", "templateSelections": [] }],
   "defaultProfile": "baseline"

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/legacy-migration/scripts/preset-action.mjs
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/legacy-migration/scripts/preset-action.mjs
@@ -1,10 +1,292 @@
 #!/usr/bin/env node
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 const contextPath = process.env.HARNESS_PRESET_CONTEXT;
 if (!contextPath) throw new Error("HARNESS_PRESET_CONTEXT is required");
 const context = JSON.parse(readFileSync(contextPath, "utf8"));
-const outputDir = path.join(context.outputRoot, "artifacts");
-mkdirSync(outputDir, { recursive: true });
-writeFileSync(path.join(outputDir, "evidence.json"), JSON.stringify({ schema: "preset-script-output/v1", mode: "capability-smoke", presetId: context.presetId, entrypoint: context.entrypoint, taskId: context.taskId }, null, 2), "utf8");
+const artifactsDir = path.join(context.outputRoot, "artifacts");
+mkdirSync(artifactsDir, { recursive: true });
+
+const scan = selectScan(context.paths.rootDir);
+const report = {
+  schema: "legacy-migration-preset-plan/v1",
+  taskId: context.taskId,
+  scan,
+  guidance: [
+    "Legacy Intake preserves old evidence under harness/legacy.",
+    "Safe authored context and standards may be forwarded into the active harness tree.",
+    "Active task packages are rebuilt by explicit follow-up tasks; the plan does not promise unattended conversion."
+  ]
+};
+writeFileSync(path.join(artifactsDir, "legacy-migration-plan.json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
+writeFileSync(path.join(artifactsDir, "legacy-migration-plan.md"), renderPlan(scan), "utf8");
+writeFileSync(path.join(artifactsDir, "preset-result.json"), `${JSON.stringify({ ok: true, rows: scan.entries.length, report }, null, 2)}\n`, "utf8");
+
+function selectScan(rootDir) {
+  const rootScan = buildScan(rootDir, ".");
+  if (rootScan.entries.length > 0) return rootScan;
+  const childScan = listCandidateRoots(rootDir)
+    .map((sourcePath) => buildScan(rootDir, sourcePath))
+    .find((scan) => scan.entries.length > 0);
+  return childScan ?? rootScan;
+}
+
+function buildScan(rootDir, sourcePath) {
+  const sourceRoot = path.resolve(rootDir, sourcePath);
+  const entries = uniqueEntries([
+    ...collectOldTasks(sourceRoot),
+    ...collectV2Tasks(sourceRoot),
+    ...collectDocs(rootDir, sourceRoot)
+  ]);
+  return {
+    schema: "legacy-intake-scan/v1",
+    strategy: "legacy-intake",
+    legacyRoot: "harness/legacy",
+    sourceRoot: toSlash(path.relative(rootDir, sourceRoot) || "."),
+    entries,
+    summary: summarize(entries),
+    deprecatedAliases: ["migrate-plan", "migrate-structure", "migrate-run", "migrate-verify"]
+  };
+}
+
+function collectOldTasks(sourceRoot) {
+  const rootTasks = listDirectories(path.join(sourceRoot, "docs/09-PLANNING/TASKS"))
+    .filter((name) => !name.startsWith("_"))
+    .map((name) => taskEntry(sourceRoot, `docs/09-PLANNING/TASKS/${name}`, `harness/legacy/tasks/${name}`));
+  const moduleTasksRoot = path.join(sourceRoot, "docs/09-PLANNING/MODULES");
+  const moduleTasks = listDirectories(moduleTasksRoot).flatMap((moduleKey) => {
+    if (moduleKey.startsWith("_")) return [];
+    return listDirectories(path.join(moduleTasksRoot, moduleKey, "TASKS"))
+      .filter((name) => !name.startsWith("_"))
+      .map((name) => taskEntry(sourceRoot, `docs/09-PLANNING/MODULES/${moduleKey}/TASKS/${name}`, `harness/legacy/tasks/modules/${moduleKey}/${name}`));
+  });
+  return [...rootTasks, ...moduleTasks];
+}
+
+function collectV2Tasks(sourceRoot) {
+  const privateRoot = path.join(sourceRoot, ".harness-private/coding-agent-harness");
+  const publicRoot = path.join(sourceRoot, "harness");
+  const authoredRoot = existsSync(path.join(privateRoot, "harness.yaml")) ? privateRoot : existsSync(path.join(publicRoot, "harness.yaml")) ? publicRoot : undefined;
+  if (!authoredRoot) return [];
+  const tasksRoot = path.join(authoredRoot, "planning/tasks");
+  const moduleRoot = path.join(authoredRoot, "planning/modules");
+  const rootTasks = listDirectories(tasksRoot)
+    .filter((name) => !name.startsWith("_"))
+    .map((name) => taskEntry(sourceRoot, toSlash(path.relative(sourceRoot, path.join(tasksRoot, name))), `harness/legacy/tasks/${name}`));
+  const moduleTasks = listDirectories(moduleRoot).flatMap((moduleKey) => {
+    if (moduleKey.startsWith("_")) return [];
+    const moduleTasksRoot = path.join(moduleRoot, moduleKey, "tasks");
+    return listDirectories(moduleTasksRoot)
+      .filter((name) => !name.startsWith("_"))
+      .map((name) => taskEntry(sourceRoot, toSlash(path.relative(sourceRoot, path.join(moduleTasksRoot, name))), `harness/legacy/tasks/modules/${moduleKey}/${name}`));
+  });
+  return [...rootTasks, ...moduleTasks];
+}
+
+function collectDocs(rootDir, sourceRoot) {
+  const docsEntries = walkFiles(path.join(sourceRoot, "docs"))
+    .map((filePath) => toSlash(path.relative(sourceRoot, filePath)))
+    .filter((relativePath) => isSafeDocPath(relativePath, true))
+    .map((relativePath) => docEntry(sourceRoot, relativePath, `harness/legacy/docs/${relativePath.replace(/^docs\//u, "")}`, forwardPathForOldDoc(relativePath)));
+  const privateRoot = path.join(sourceRoot, ".harness-private/coding-agent-harness");
+  const publicRoot = path.join(sourceRoot, "harness");
+  const authoredRoot = existsSync(path.join(privateRoot, "harness.yaml")) ? privateRoot : existsSync(path.join(publicRoot, "harness.yaml")) ? publicRoot : undefined;
+  if (!authoredRoot) return docsEntries;
+  const authoredDocs = [
+    ...collectAuthoredDocs(rootDir, sourceRoot, path.join(authoredRoot, "context"), "harness/context"),
+    ...collectAuthoredDocs(rootDir, sourceRoot, path.join(authoredRoot, "standards"), "harness/standards")
+  ];
+  return uniqueEntries([...docsEntries, ...authoredDocs]);
+}
+
+function collectAuthoredDocs(rootDir, sourceRoot, sourceDocRoot, forwardRoot) {
+  return walkFiles(sourceDocRoot)
+    .map((filePath) => toSlash(path.relative(sourceRoot, filePath)))
+    .filter((relativePath) => isSafeDocPath(relativePath, false))
+    .map((relativePath) => {
+      const relWithinRoot = toSlash(path.relative(sourceDocRoot, path.join(sourceRoot, relativePath)));
+      return docEntry(sourceRoot, relativePath, `harness/legacy/docs/${relativePath}`, `${forwardRoot}/${relWithinRoot}`);
+    });
+}
+
+function taskEntry(sourceRoot, sourcePath, storedPath) {
+  const fullPath = path.join(sourceRoot, sourcePath);
+  const status = readDetectedStatus(fullPath);
+  return {
+    id: legacyId(sourcePath),
+    category: "task",
+    sourcePath,
+    storedPath,
+    sourceDigest: digestPath(fullPath),
+    title: readTitle(fullPath) ?? path.basename(sourcePath),
+    detectedStatus: status ? { raw: status, confidence: "medium" } : { raw: "unknown", confidence: "low" },
+    evidencePointers: evidencePointers(fullPath, storedPath),
+    recommendedTreatment: status === "done" || status === "cancelled" ? "preserve" : "rebuild-required",
+    humanReviewRequired: true
+  };
+}
+
+function docEntry(sourceRoot, sourcePath, storedPath, forwardPath) {
+  return {
+    id: legacyId(sourcePath),
+    category: "doc",
+    sourcePath,
+    storedPath,
+    sourceDigest: digestPath(path.join(sourceRoot, sourcePath)),
+    title: path.basename(sourcePath),
+    evidencePointers: [],
+    recommendedTreatment: "preserve",
+    humanReviewRequired: false,
+    forwardPath
+  };
+}
+
+function renderPlan(scan) {
+  return [
+    "# Legacy Intake Plan",
+    "",
+    `Source root: ${scan.sourceRoot}`,
+    `Entries: ${scan.summary.entryCount}`,
+    "",
+    "| ID | Title | Category | Source | Stored | Forward | Treatment |",
+    "| --- | --- | --- | --- | --- | --- | --- |",
+    ...scan.entries.map((entry) => `| ${entry.id} | ${escapeCell(entry.title ?? "")} | ${entry.category} | ${entry.sourcePath} | ${entry.storedPath} | ${entry.forwardPath ?? ""} | ${entry.recommendedTreatment} |`),
+    ""
+  ].join("\n");
+}
+
+function forwardPathForOldDoc(relativePath) {
+  const mappings = [
+    [/^docs\/11-REFERENCE\/(.+)$/u, "harness/standards"],
+    [/^docs\/10-ARCHITECTURE\/(.+)$/u, "harness/context/architecture"],
+    [/^docs\/context\/(.+)$/u, "harness/context"],
+    [/^docs\/architecture\/(.+)$/u, "harness/context/architecture"]
+  ];
+  for (const [pattern, targetRoot] of mappings) {
+    const match = pattern.exec(relativePath);
+    if (match) return `${targetRoot}/${match[1]}`;
+  }
+  return undefined;
+}
+
+function evidencePointers(fullPath, storedPath) {
+  if (!statSync(fullPath).isDirectory()) return [];
+  return ["progress.md", "review.md", "walkthrough.md"]
+    .filter((fileName) => existsSync(path.join(fullPath, fileName)))
+    .map((fileName) => ({
+      kind: fileName === "review.md" ? "review" : fileName === "walkthrough.md" ? "walkthrough" : "progress",
+      path: `${storedPath}/${fileName}`,
+      label: fileName
+    }));
+}
+
+function listCandidateRoots(rootDir) {
+  const roots = new Set();
+  for (const readScope of context.readScopes ?? []) {
+    const candidate = candidateRootFromReadScope(rootDir, readScope);
+    if (candidate && candidate !== ".") roots.add(candidate);
+  }
+  return [...roots]
+    .sort()
+    .filter((sourcePath) => existsSync(path.join(rootDir, sourcePath, "docs"))
+      || existsSync(path.join(rootDir, sourcePath, "harness/harness.yaml"))
+      || existsSync(path.join(rootDir, sourcePath, ".harness-private/coding-agent-harness/harness.yaml")));
+}
+
+function candidateRootFromReadScope(rootDir, readScope) {
+  const relativePath = toSlash(path.relative(rootDir, readScope));
+  if (!relativePath || relativePath.startsWith("../")) return ".";
+  const segments = relativePath.split("/");
+  const markerIndex = segments.findIndex((segment) => segment === "docs" || segment === "harness" || segment === ".harness-private");
+  if (markerIndex <= 0) return ".";
+  return segments.slice(0, markerIndex).join("/");
+}
+
+function isSafeDocPath(relativePath, requireDocsPrefix) {
+  if (requireDocsPrefix && !relativePath.startsWith("docs/")) return false;
+  if (!/\.(?:md|mdx|txt|json|ya?ml)$/u.test(relativePath)) return false;
+  if (/^docs\/09-PLANNING\/TASKS\//u.test(relativePath)) return false;
+  if (/^docs\/09-PLANNING\/MODULES\/[^/]+\/TASKS\//u.test(relativePath)) return false;
+  return true;
+}
+
+function summarize(entries) {
+  return {
+    entryCount: entries.length,
+    taskCount: entries.filter((entry) => entry.category === "task").length,
+    docCount: entries.filter((entry) => entry.category === "doc").length,
+    rebuildRequiredCount: entries.filter((entry) => entry.recommendedTreatment === "rebuild-required").length
+  };
+}
+
+function uniqueEntries(entries) {
+  const seen = new Set();
+  return entries.filter((entry) => {
+    const key = `${entry.category}:${entry.sourcePath}:${entry.storedPath}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function walkFiles(directory) {
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isSymbolicLink()) return [];
+    if (entry.isDirectory()) return walkFiles(entryPath);
+    if (!entry.isFile()) return [];
+    return [entryPath];
+  }).sort();
+}
+
+function listDirectories(directory) {
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory, { withFileTypes: true }).filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+}
+
+function readTitle(directory) {
+  const indexPath = path.join(directory, "INDEX.md");
+  const taskPlanPath = path.join(directory, "task_plan.md");
+  const body = existsSync(indexPath) ? readFileSync(indexPath, "utf8") : existsSync(taskPlanPath) ? readFileSync(taskPlanPath, "utf8") : "";
+  return body.match(/^title:\s*(.+)$/mu)?.[1]?.trim() ?? body.match(/^#\s+(.+)$/mu)?.[1]?.trim();
+}
+
+function readDetectedStatus(directory) {
+  const indexPath = path.join(directory, "INDEX.md");
+  if (!existsSync(indexPath)) return undefined;
+  return readFileSync(indexPath, "utf8").match(/^status:\s*(.+)$/mu)?.[1]?.trim();
+}
+
+function digestPath(targetPath) {
+  if (lstatSync(targetPath).isSymbolicLink()) {
+    return `sha256:${createHash("sha256").update("symlink-skipped").digest("hex")}`;
+  }
+  const hash = createHash("sha256");
+  const stats = statSync(targetPath);
+  if (stats.isDirectory()) {
+    for (const filePath of walkFiles(targetPath)) {
+      hash.update(toSlash(path.relative(targetPath, filePath)));
+      hash.update("\0");
+      hash.update(readFileSync(filePath));
+      hash.update("\0");
+    }
+  } else {
+    hash.update(readFileSync(targetPath));
+  }
+  return `sha256:${hash.digest("hex")}`;
+}
+
+function legacyId(sourcePath) {
+  return `legacy_${createHash("sha256").update(sourcePath).digest("hex").slice(0, 12)}`;
+}
+
+function escapeCell(value) {
+  return value.replace(/\|/gu, "\\|");
+}
+
+function toSlash(value) {
+  return value.split(path.sep).join("/");
+}

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/milestone-closeout/preset.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/milestone-closeout/preset.json
@@ -1,0 +1,23 @@
+{
+  "schema": "preset-manifest/v2",
+  "id": "milestone-closeout",
+  "title": "Milestone Closeout",
+  "vertical": "software/coding",
+  "version": "1.0.0",
+  "kind": "process-action",
+  "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
+  "capabilityImports": [{ "id": "milestone-closeout-parity", "kind": "command", "version": "1", "required": false }],
+  "entrypoints": {
+    "check": {
+      "type": "script",
+      "command": "scripts/preset-action.mjs",
+      "reads": ["{{outputRoot}}/**", "{{paths.authoredRoot}}/planning/milestones/**"],
+      "writes": ["{{outputRoot}}/**"],
+      "inputs": {
+        "milestoneCriteriaRoots": "{{paths.authoredRoot}}/planning/milestones"
+      }
+    }
+  },
+  "profiles": [{ "id": "baseline", "title": "Baseline", "checkerProfile": "standard", "templateSelections": [] }],
+  "defaultProfile": "baseline"
+}

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/milestone-closeout/scripts/preset-action.mjs
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/milestone-closeout/scripts/preset-action.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const contextPath = process.env.HARNESS_PRESET_CONTEXT;
+if (!contextPath) throw new Error("HARNESS_PRESET_CONTEXT is required");
+const context = JSON.parse(readFileSync(contextPath, "utf8"));
+const taskRoot = context.outputRoot;
+const artifactsDir = path.join(taskRoot, "artifacts");
+mkdirSync(artifactsDir, { recursive: true });
+
+const criteriaRoots = [
+  path.join(context.paths.authoredRoot, "planning", "milestones")
+];
+const criteria = criteriaRoots
+  .flatMap((root) => walkMarkdown(root))
+  .filter((filePath) => /(?:^|\/)(?:feature-breakdown|milestone-closeout|exit-criteria)\.md$/u.test(toSlash(filePath)))
+  .flatMap((filePath) => readCriteria(filePath, "milestone"));
+const taskEvidence = walkMarkdown(taskRoot)
+  .filter((filePath) => !toSlash(path.relative(taskRoot, filePath)).startsWith("artifacts/"))
+  .map((filePath) => ({
+    sourcePath: relative(context.paths.rootDir, filePath),
+    body: readFileSync(filePath, "utf8")
+  }));
+const items = criteria.length > 0
+  ? criteria.map((criterion) => evaluateCriterion(criterion, taskEvidence))
+  : [{
+    status: "red",
+    reason: "no_milestone_criteria",
+    sourcePath: relative(context.paths.rootDir, context.paths.authoredRoot),
+    line: 0,
+    text: "No milestone feature-breakdown or exit-criteria markdown was found."
+  }];
+const summary = {
+  green: items.filter((item) => item.status === "green").length,
+  yellow: 0,
+  red: items.filter((item) => item.status === "red").length,
+  total: items.length
+};
+const report = {
+  schema: "milestone-closeout-parity/v1",
+  taskId: context.taskId,
+  status: summary.red === 0 ? "passed" : "blocked",
+  summary,
+  criteriaSource: "milestone-feature-breakdown",
+  items
+};
+writeFileSync(path.join(artifactsDir, "milestone-closeout-report.json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
+writeFileSync(path.join(artifactsDir, "preset-result.json"), `${JSON.stringify({
+  ok: summary.red === 0,
+  report,
+  error: summary.red === 0 ? undefined : {
+    code: "milestone_closeout_blocked",
+    hint: "Milestone closeout parity found red items."
+  }
+}, null, 2)}\n`, "utf8");
+
+function evaluateCriterion(criterion, taskEvidence) {
+  if (!criterion.checked) return { ...criterion, status: "red", reason: "milestone_criterion_unchecked" };
+  if (hasStubMarker(criterion.text)) return { ...criterion, status: "red", reason: "milestone_criterion_stub_or_placeholder" };
+  const needle = normalize(criterion.text);
+  const matchedEvidence = taskEvidence.find((evidence) => normalize(evidence.body).includes(needle) && hasCheckedLine(evidence.body, criterion.text));
+  if (!matchedEvidence) {
+    return { ...criterion, status: "red", reason: "missing_task_evidence_for_milestone_criterion" };
+  }
+  return { ...criterion, status: "green", reason: "task_evidence_matches_milestone_criterion", evidencePath: matchedEvidence.sourcePath };
+}
+
+function readCriteria(filePath) {
+  const relativePath = relative(context.paths.rootDir, filePath);
+  return readFileSync(filePath, "utf8").split(/\r?\n/u).flatMap((line, index) => {
+    const match = /^\s*[-*]\s+\[([ xX])\]\s+(.+)$/u.exec(line);
+    if (!match) return [];
+    return [{
+      status: "red",
+      reason: "unclassified",
+      sourcePath: relativePath,
+      line: index + 1,
+      checked: match[1] !== " ",
+      text: match[2].trim()
+    }];
+  });
+}
+
+function hasCheckedLine(body, text) {
+  const expected = normalize(text);
+  return body.split(/\r?\n/u).some((line) => {
+    const match = /^\s*[-*]\s+\[[xX]\]\s+(.+)$/u.exec(line);
+    return Boolean(match) && normalize(match[1]).includes(expected) && !hasStubMarker(match[1]);
+  });
+}
+
+function hasStubMarker(value) {
+  return /\b(?:stub|skeleton|todo|placeholder|pending)\b/iu.test(value);
+}
+
+function normalize(value) {
+  return value.toLowerCase().replace(/[`*_~[\]()#.,:;!"']/gu, "").replace(/\s+/gu, " ").trim();
+}
+
+function walkMarkdown(directory) {
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isSymbolicLink()) return [];
+    if (entry.isDirectory()) return walkMarkdown(entryPath);
+    if (!entry.isFile() || !entry.name.endsWith(".md")) return [];
+    return [entryPath];
+  }).sort();
+}
+
+function relative(rootDir, targetPath) {
+  return toSlash(path.relative(rootDir, targetPath));
+}
+
+function toSlash(value) {
+  return value.split(path.sep).join("/");
+}

--- a/packages/cli/src/commands/extensions/preset-script-runner.ts
+++ b/packages/cli/src/commands/extensions/preset-script-runner.ts
@@ -1,0 +1,205 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { Schema } from "effect";
+import { PresetManifestSchema } from "../../../../kernel/src/index.ts";
+import { resolveHarnessLayout, taskPackagePath } from "../../../../kernel/src/layout/index.ts";
+import type { CliResult } from "../../cli/types.ts";
+import type { ResolvedPreset } from "./state.ts";
+import {
+  isPathInside,
+  listGeneratedFiles,
+  permissionPathsForScope,
+  resolveDeclaredReadScopes,
+  resolveDeclaredWriteScopes,
+  uniquePermissionPaths
+} from "./script-scope.ts";
+
+type PresetManifest = Schema.Schema.Type<typeof PresetManifestSchema>;
+type ScriptEntrypoint = Extract<NonNullable<PresetManifest["entrypoints"]>[string], { readonly type: "script" }>;
+
+export function runScriptEntrypoint(
+  rootDir: string,
+  preset: ResolvedPreset,
+  presetSummary: unknown,
+  entrypoint: ScriptEntrypoint,
+  entrypointName: string,
+  taskId: string,
+  evidenceDir: string,
+  commandName: "preset-run" | "preset-action"
+): { readonly ok: true; readonly generated: ReadonlyArray<string>; readonly scriptedResult?: Record<string, unknown> } | { readonly ok: false; readonly result: CliResult } {
+  const presetRoot = path.dirname(preset.sourcePath);
+  const scriptPath = path.resolve(presetRoot, entrypoint.command);
+  if (!isPathInside(presetRoot, scriptPath) || !existsSync(scriptPath)) {
+    return {
+      ok: false,
+      result: {
+        ok: false,
+        command: commandName,
+        preset: presetSummary,
+        error: { code: "preset_script_not_found", hint: "Preset script entrypoint was not found inside the preset package." }
+      }
+    };
+  }
+  const layout = resolveHarnessLayout(rootDir);
+  const outputRoot = taskPackagePath(rootDir, taskId);
+  const writeScope = resolveDeclaredWriteScopes(entrypoint.writes, layout, outputRoot);
+  const readScope = entrypoint.reads
+    ? resolveDeclaredReadScopes(entrypoint.reads, layout, outputRoot)
+    : { ok: true as const, roots: [], permissions: [] };
+  if (!readScope.ok) {
+    return {
+      ok: false,
+      result: {
+        ok: false,
+        command: commandName,
+        preset: presetSummary,
+        error: { code: "preset_read_scope_invalid", hint: "Preset script reads must declare supported project-local scopes." }
+      }
+    };
+  }
+  if (!writeScope.ok || !writeScope.roots.some((allowedRoot) => isPathInside(allowedRoot, outputRoot))) {
+    return {
+      ok: false,
+      result: {
+        ok: false,
+        command: commandName,
+        preset: presetSummary,
+        error: { code: "preset_write_scope_invalid", hint: "Preset script writes must declare a supported scope that covers the generated output root." }
+      }
+    };
+  }
+  mkdirSync(outputRoot, { recursive: true });
+  const contextPath = path.join(evidenceDir, "context.json");
+  writeFileSync(contextPath, JSON.stringify({
+    schema: "preset-context/v1",
+    presetId: preset.manifest.id,
+    presetTitle: preset.manifest.title,
+    entrypoint: entrypointName,
+    taskId,
+    paths: {
+      rootDir: layout.rootDir,
+      authoredRoot: layout.authoredRoot,
+      tasksRoot: layout.tasksRoot,
+      generatedRoot: layout.generatedRoot,
+      localRoot: layout.localRoot
+    },
+    inputs: entrypoint.inputs ?? {},
+    readScopes: readScope.roots,
+    writeScopes: writeScope.roots,
+    outputRoot
+  }, null, 2), "utf8");
+  const beforeFiles = new Set(listGeneratedFiles(outputRoot));
+  const readablePaths = uniquePermissionPaths([
+    ...permissionPathsForScope(presetRoot, true),
+    contextPath,
+    ...readScope.permissions
+  ]);
+  const writablePaths = uniquePermissionPaths(writeScope.permissions);
+  const result = spawnSync(process.execPath, [
+    "--permission",
+    ...readablePaths.map((allowedPath) => `--allow-fs-read=${allowedPath}`),
+    ...writablePaths.map((allowedPath) => `--allow-fs-write=${allowedPath}`),
+    scriptPath
+  ], {
+    cwd: presetRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HARNESS_PRESET_CONTEXT: contextPath
+    }
+  });
+  writeFileSync(path.join(evidenceDir, "stdout.txt"), result.stdout ?? "", "utf8");
+  writeFileSync(path.join(evidenceDir, "stderr.txt"), result.stderr ?? "", "utf8");
+  if (result.status !== 0) {
+    const permissionOutput = `${result.stderr ?? ""}\n${result.stdout ?? ""}`;
+    const accessDenied = permissionOutput.includes("ERR_ACCESS_DENIED");
+    const readDenied = accessDenied && permissionOutput.includes("FileSystemRead");
+    return {
+      ok: false,
+      result: {
+        ok: false,
+        command: commandName,
+        preset: presetSummary,
+        evidenceBundle: path.relative(rootDir, evidenceDir).split(path.sep).join("/"),
+        error: accessDenied
+          ? readDenied
+            ? { code: "preset_read_scope_violation", hint: "Preset script attempted filesystem read outside its declared permission scope." }
+            : { code: "preset_write_scope_violation", hint: "Preset script attempted filesystem write outside its declared permission scope." }
+          : { code: "preset_script_failed", hint: `Preset script exited with status ${result.status ?? "unknown"}.` }
+      }
+    };
+  }
+  const generatedFiles = listGeneratedFiles(outputRoot);
+  const outOfScope = generatedFiles.filter((filePath) => !writeScope.roots.some((allowedRoot) => isPathInside(allowedRoot, filePath)));
+  if (outOfScope.length > 0) {
+    return {
+      ok: false,
+      result: {
+        ok: false,
+        command: commandName,
+        preset: presetSummary,
+        evidenceBundle: path.relative(rootDir, evidenceDir).split(path.sep).join("/"),
+        generated: generatedFiles.map((filePath) => path.relative(rootDir, filePath).split(path.sep).join("/")),
+        error: { code: "preset_write_scope_violation", hint: "Preset script produced files outside its declared write scopes." }
+      }
+    };
+  }
+  return {
+    ok: true,
+    generated: generatedFiles
+      .filter((filePath) => !beforeFiles.has(filePath))
+      .map((filePath) => path.relative(rootDir, filePath).split(path.sep).join("/")),
+    scriptedResult: readScriptedResult(outputRoot)
+  };
+}
+
+export function scriptCliResult(options: {
+  readonly rootDir: string;
+  readonly evidenceDir: string;
+  readonly commandName: "preset-run" | "preset-action";
+  readonly preset: unknown;
+  readonly generated: ReadonlyArray<string>;
+  readonly scriptedResult: Record<string, unknown>;
+}): CliResult {
+  const ok = options.scriptedResult.ok === true;
+  const report = options.scriptedResult.report ?? options.scriptedResult;
+  return {
+    ok,
+    command: options.commandName,
+    preset: options.preset,
+    evidenceBundle: path.relative(options.rootDir, options.evidenceDir).split(path.sep).join("/"),
+    generated: options.generated,
+    warnings: Array.isArray(options.scriptedResult.warnings) ? options.scriptedResult.warnings : undefined,
+    rows: typeof options.scriptedResult.rows === "number" ? options.scriptedResult.rows : undefined,
+    report,
+    error: ok ? undefined : scriptError(options.scriptedResult.error)
+  };
+}
+
+function scriptError(value: unknown): CliResult["error"] {
+  if (value && typeof value === "object" && "code" in value && "hint" in value) {
+    const error = value as { readonly code?: unknown; readonly hint?: unknown };
+    if (typeof error.code === "string" && typeof error.hint === "string") {
+      return { code: error.code, hint: error.hint };
+    }
+  }
+  return { code: "preset_script_result_failed", hint: "Preset script reported a failed result." };
+}
+
+function readScriptedResult(outputRoot: string): Record<string, unknown> | undefined {
+  const resultPath = path.join(outputRoot, "artifacts", "preset-result.json");
+  if (!existsSync(resultPath)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(resultPath, "utf8")) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : undefined;
+  } catch {
+    return {
+      ok: false,
+      error: {
+        code: "preset_script_result_invalid",
+        hint: "Preset script wrote invalid artifacts/preset-result.json."
+      }
+    };
+  }
+}

--- a/packages/cli/src/commands/extensions/script-scope.ts
+++ b/packages/cli/src/commands/extensions/script-scope.ts
@@ -1,6 +1,11 @@
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, realpathSync, readdirSync } from "node:fs";
 import path from "node:path";
 import type { resolveHarnessLayout } from "../../../../kernel/src/layout/index.ts";
+
+export interface ResolvedScopeSet {
+  readonly roots: ReadonlyArray<string>;
+  readonly permissions: ReadonlyArray<string>;
+}
 
 export function listGeneratedFiles(rootDir: string): ReadonlyArray<string> {
   if (!existsSync(rootDir)) return [];
@@ -16,21 +21,52 @@ export function resolveDeclaredWriteScopes(
   scopes: ReadonlyArray<string>,
   layout: ReturnType<typeof resolveHarnessLayout>,
   outputRoot: string
-): { readonly ok: true; readonly roots: ReadonlyArray<string> } | { readonly ok: false } {
+): { readonly ok: true } & ResolvedScopeSet | { readonly ok: false } {
+  return resolveDeclaredScopes(scopes, layout, outputRoot, false);
+}
+
+export function resolveDeclaredReadScopes(
+  scopes: ReadonlyArray<string>,
+  layout: ReturnType<typeof resolveHarnessLayout>,
+  outputRoot: string
+): { readonly ok: true } & ResolvedScopeSet | { readonly ok: false } {
+  return resolveDeclaredScopes(scopes, layout, outputRoot, true);
+}
+
+function resolveDeclaredScopes(
+  scopes: ReadonlyArray<string>,
+  layout: ReturnType<typeof resolveHarnessLayout>,
+  outputRoot: string,
+  allowRootRead: boolean
+): { readonly ok: true } & ResolvedScopeSet | { readonly ok: false } {
   const roots: string[] = [];
+  const permissions: string[] = [];
   for (const scope of scopes) {
-    const root = scope.endsWith("/**") ? scope.slice(0, -3) : scope;
-    const resolved = root
+    const recursive = scope.endsWith("/**");
+    const root = recursive ? scope.slice(0, -3) : scope;
+    let resolved = root
       .replaceAll("{{paths.generatedRoot}}", layout.generatedRoot)
       .replaceAll("{{paths.localRoot}}", layout.localRoot)
       .replaceAll("{{paths.authoredRoot}}", layout.authoredRoot)
+      .replaceAll("{{paths.tasksRoot}}", layout.tasksRoot)
       .replaceAll("{{outputRoot}}", outputRoot);
+    if (allowRootRead) {
+      resolved = resolved.replaceAll("{{paths.rootDir}}", layout.rootDir);
+    }
     if (resolved.includes("{{") || resolved.includes("}}")) return { ok: false };
-    const absolute = path.resolve(resolved);
-    if (!isPathInside(layout.rootDir, absolute)) return { ok: false };
-    roots.push(absolute);
+    for (const expanded of expandScopeRoot(resolved)) {
+      const absolute = path.resolve(expanded);
+      if (!isPathInside(layout.rootDir, absolute)) return { ok: false };
+      if (recursive && absolute === path.resolve(layout.rootDir)) return { ok: false };
+      roots.push(absolute);
+      permissions.push(...permissionPathsForScope(absolute, recursive));
+    }
   }
-  return roots.length > 0 ? { ok: true, roots } : { ok: false };
+  return roots.length > 0 ? {
+    ok: true,
+    roots: uniquePermissionPaths(roots),
+    permissions: uniquePermissionPaths(permissions)
+  } : { ok: false };
 }
 
 export function isPathInside(parent: string, candidate: string): boolean {
@@ -40,4 +76,30 @@ export function isPathInside(parent: string, candidate: string): boolean {
 
 export function uniquePermissionPaths(paths: ReadonlyArray<string>): ReadonlyArray<string> {
   return [...new Set(paths.map((candidate) => path.resolve(candidate)))];
+}
+
+export function permissionPathsForScope(root: string, recursive: boolean): ReadonlyArray<string> {
+  const paths = recursive ? [root, `${root}/**`] : [root];
+  if (!existsSync(root)) return paths;
+  const real = realpathSync(root);
+  return real === path.resolve(root)
+    ? paths
+    : [...paths, ...(recursive ? [real, `${real}/**`] : [real])];
+}
+
+function expandScopeRoot(root: string): ReadonlyArray<string> {
+  const parts = root.split(path.sep);
+  if (!parts.includes("*")) return [root];
+  let candidates = [parts[0] === "" ? path.sep : parts[0]];
+  const remaining = parts[0] === "" ? parts.slice(1) : parts.slice(1);
+  for (const part of remaining) {
+    candidates = candidates.flatMap((candidate) => {
+      if (part !== "*") return [path.join(candidate, part)];
+      if (!existsSync(candidate)) return [];
+      return readdirSync(candidate, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => path.join(candidate, entry.name));
+    });
+  }
+  return candidates;
 }

--- a/packages/cli/src/commands/extensions/state.ts
+++ b/packages/cli/src/commands/extensions/state.ts
@@ -1,5 +1,4 @@
-import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Schema } from "effect";
 import {
@@ -10,7 +9,7 @@ import {
   type ExtensionValidationIssue,
   type MaterializedTemplatePlan
 } from "../../../../kernel/src/index.ts";
-import { normalizeRelativeDocumentPath, resolveHarnessLayout, taskPackagePath } from "../../../../kernel/src/layout/index.ts";
+import { normalizeRelativeDocumentPath, resolveHarnessLayout } from "../../../../kernel/src/layout/index.ts";
 import type { CliResult } from "../../cli/types.ts";
 import {
   bundledTemplateCatalog,
@@ -19,7 +18,7 @@ import {
 } from "./bundled.ts";
 import { writeModuleRegistryView } from "./module-registry-view.ts";
 import { presetScriptAuthorizationRequiredResult } from "./preset-evidence.ts";
-import { isPathInside, listGeneratedFiles, resolveDeclaredWriteScopes, uniquePermissionPaths } from "./script-scope.ts";
+import { runScriptEntrypoint, scriptCliResult } from "./preset-script-runner.ts";
 
 type PresetManifest = Schema.Schema.Type<typeof PresetManifestSchema>;
 
@@ -315,9 +314,20 @@ export function runPresetEntrypoint(
         entrypoint
       });
     }
-    const scriptResult = runScriptEntrypoint(rootDir, preset, declaredEntrypoint, entrypoint, taskId, evidenceDir, commandName);
+    const presetSummary = publicPresetSummary(preset);
+    const scriptResult = runScriptEntrypoint(rootDir, preset, presetSummary, declaredEntrypoint, entrypoint, taskId, evidenceDir, commandName);
     if (!scriptResult.ok) return scriptResult.result;
     generated.push(...scriptResult.generated);
+    if (scriptResult.scriptedResult) {
+      return scriptCliResult({
+        rootDir,
+        evidenceDir,
+        commandName,
+        preset: presetSummary,
+        generated,
+        scriptedResult: scriptResult.scriptedResult
+      });
+    }
   } else if (preset.manifest.schema === "preset-manifest/v1" && entrypoint === "scaffold") {
     const outputPath = path.join(resolveHarnessLayout(rootDir).generatedRoot, "preset-scaffold", taskId, `${presetId}.md`);
     mkdirSync(path.dirname(outputPath), { recursive: true });
@@ -349,114 +359,6 @@ export function runPresetEntrypoint(
     evidenceBundle: path.relative(rootDir, evidenceDir).split(path.sep).join("/"),
     generated,
     report: evidence
-  };
-}
-
-function runScriptEntrypoint(
-  rootDir: string,
-  preset: ResolvedPreset,
-  entrypoint: Extract<NonNullable<PresetManifest["entrypoints"]>[string], { readonly type: "script" }>,
-  entrypointName: string,
-  taskId: string,
-  evidenceDir: string,
-  commandName: "preset-run" | "preset-action"
-): { readonly ok: true; readonly generated: ReadonlyArray<string> } | { readonly ok: false; readonly result: CliResult } {
-  const presetRoot = path.dirname(preset.sourcePath);
-  const scriptPath = path.resolve(presetRoot, entrypoint.command);
-  if (!isPathInside(presetRoot, scriptPath) || !existsSync(scriptPath)) {
-    return {
-      ok: false,
-      result: {
-        ok: false,
-        command: commandName,
-        preset: publicPresetSummary(preset),
-        error: { code: "preset_script_not_found", hint: "Preset script entrypoint was not found inside the preset package." }
-      }
-    };
-  }
-  const layout = resolveHarnessLayout(rootDir);
-  const outputRoot = taskPackagePath(rootDir, taskId);
-  const writeScope = resolveDeclaredWriteScopes(entrypoint.writes, layout, outputRoot);
-  if (!writeScope.ok || !writeScope.roots.some((allowedRoot) => isPathInside(allowedRoot, outputRoot))) {
-    return {
-      ok: false,
-      result: {
-        ok: false,
-        command: commandName,
-        preset: publicPresetSummary(preset),
-        error: { code: "preset_write_scope_invalid", hint: "Preset script writes must declare a supported scope that covers the generated output root." }
-      }
-    };
-  }
-  mkdirSync(outputRoot, { recursive: true });
-  const contextPath = path.join(evidenceDir, "context.json");
-  writeFileSync(contextPath, JSON.stringify({
-    schema: "preset-context/v1",
-    presetId: preset.manifest.id,
-    presetTitle: preset.manifest.title,
-    entrypoint: entrypointName,
-    taskId,
-    paths: {
-      rootDir: layout.rootDir,
-      authoredRoot: layout.authoredRoot,
-      tasksRoot: layout.tasksRoot,
-      generatedRoot: layout.generatedRoot,
-      localRoot: layout.localRoot
-    },
-    writeScopes: writeScope.roots,
-    outputRoot
-  }, null, 2), "utf8");
-  const beforeFiles = new Set(listGeneratedFiles(outputRoot));
-  const result = spawnSync(process.execPath, [
-    "--permission",
-    ...uniquePermissionPaths([presetRoot, realpathSync(presetRoot), contextPath, realpathSync(contextPath)]).map((allowedPath) => `--allow-fs-read=${allowedPath}`),
-    ...uniquePermissionPaths([...writeScope.roots, ...writeScope.roots.map((allowedPath) => realpathSync(allowedPath))]).map((allowedPath) => `--allow-fs-write=${allowedPath}`),
-    scriptPath
-  ], {
-    cwd: presetRoot,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      HARNESS_PRESET_CONTEXT: contextPath
-    }
-  });
-  writeFileSync(path.join(evidenceDir, "stdout.txt"), result.stdout ?? "", "utf8");
-  writeFileSync(path.join(evidenceDir, "stderr.txt"), result.stderr ?? "", "utf8");
-  if (result.status !== 0) {
-    const accessDenied = `${result.stderr ?? ""}\n${result.stdout ?? ""}`.includes("ERR_ACCESS_DENIED");
-    return {
-      ok: false,
-      result: {
-        ok: false,
-        command: commandName,
-        preset: publicPresetSummary(preset),
-        evidenceBundle: path.relative(rootDir, evidenceDir).split(path.sep).join("/"),
-        error: accessDenied
-          ? { code: "preset_write_scope_violation", hint: "Preset script attempted filesystem access outside its declared permission scope." }
-          : { code: "preset_script_failed", hint: `Preset script exited with status ${result.status ?? "unknown"}.` }
-      }
-    };
-  }
-  const generatedFiles = listGeneratedFiles(outputRoot);
-  const outOfScope = generatedFiles.filter((filePath) => !writeScope.roots.some((allowedRoot) => isPathInside(allowedRoot, filePath)));
-  if (outOfScope.length > 0) {
-    return {
-      ok: false,
-      result: {
-        ok: false,
-        command: commandName,
-        preset: publicPresetSummary(preset),
-        evidenceBundle: path.relative(rootDir, evidenceDir).split(path.sep).join("/"),
-        generated: generatedFiles.map((filePath) => path.relative(rootDir, filePath).split(path.sep).join("/")),
-        error: { code: "preset_write_scope_violation", hint: "Preset script produced files outside its declared write scopes." }
-      }
-    };
-  }
-  return {
-    ok: true,
-    generated: generatedFiles
-      .filter((filePath) => !beforeFiles.has(filePath))
-      .map((filePath) => path.relative(rootDir, filePath).split(path.sep).join("/"))
   };
 }
 

--- a/packages/cli/src/commands/migration-scan.ts
+++ b/packages/cli/src/commands/migration-scan.ts
@@ -1,0 +1,334 @@
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { resolveHarnessLayout } from "../../../kernel/src/layout/index.ts";
+import type { LegacyIndex, LegacyIndexEntry } from "../../../kernel/src/schemas/registry.ts";
+
+export interface LegacyScanEntry extends LegacyIndexEntry {
+  readonly forwardPath?: string;
+}
+
+export interface LegacyScanReport {
+  readonly schema: "legacy-intake-scan/v1";
+  readonly strategy: "legacy-intake";
+  readonly legacyRoot: "harness/legacy";
+  readonly sourceRoot: string;
+  readonly entries: ReadonlyArray<LegacyScanEntry>;
+  readonly summary: LegacyIndex["summary"];
+  readonly deprecatedAliases: ReadonlyArray<string>;
+}
+
+export function buildScanReport(rootDir: string, sourcePath: string): LegacyScanReport {
+  const sourceRoot = path.resolve(rootDir, sourcePath);
+  const entries = [
+    ...collectLegacyTasks(sourceRoot),
+    ...collectLegacyDocs(rootDir, sourceRoot)
+  ];
+  const summary = summarize(entries);
+  return {
+    schema: "legacy-intake-scan/v1",
+    strategy: "legacy-intake",
+    legacyRoot: "harness/legacy",
+    sourceRoot: normalizeSlashes(path.relative(rootDir, sourceRoot) || "."),
+    entries,
+    summary,
+    deprecatedAliases: ["migrate-plan", "migrate-structure", "migrate-run", "migrate-verify"]
+  };
+}
+
+export function renderIntakePlan(report: LegacyScanReport): string {
+  const lines = [
+    "# Legacy Intake Plan",
+    "",
+    `Source root: ${report.sourceRoot}`,
+    `Entries: ${report.summary.entryCount}`,
+    "",
+    "| ID | Title | Category | Source | Stored | Forward | Treatment |",
+    "| --- | --- | --- | --- | --- | --- | --- |",
+    ...report.entries.map((entry) => `| ${entry.id} | ${escapeMarkdownTableCell(entry.title ?? "")} | ${entry.category} | ${entry.sourcePath} | ${entry.storedPath} | ${entry.forwardPath ?? ""} | ${entry.recommendedTreatment} |`),
+    ""
+  ];
+  return lines.join("\n");
+}
+
+export function summarize(entries: ReadonlyArray<LegacyIndexEntry>): LegacyIndex["summary"] {
+  return {
+    entryCount: entries.length,
+    taskCount: entries.filter((entry) => entry.category === "task").length,
+    docCount: entries.filter((entry) => entry.category === "doc").length,
+    rebuildRequiredCount: entries.filter((entry) => entry.recommendedTreatment === "rebuild-required").length
+  };
+}
+
+export function stripScanOnlyFields(entry: LegacyScanEntry): LegacyIndexEntry {
+  const { forwardPath: _forwardPath, ...legacyEntry } = entry;
+  return legacyEntry;
+}
+
+export function copyForwardDocs(rootDir: string, report: LegacyScanReport): void {
+  const sourceRoot = path.resolve(rootDir, report.sourceRoot);
+  for (const entry of report.entries) {
+    if (!entry.forwardPath) continue;
+    if (!isSafeRelativePath(entry.forwardPath)) continue;
+    const source = path.join(sourceRoot, entry.sourcePath);
+    const target = path.resolve(rootDir, entry.forwardPath);
+    if (!isPathInside(rootDir, target) || existsSync(target)) continue;
+    copySource(source, target);
+  }
+}
+
+function collectLegacyTasks(sourceRoot: string): ReadonlyArray<LegacyScanEntry> {
+  const rootTasks = listDirectories(path.join(sourceRoot, "docs/09-PLANNING/TASKS"))
+    .filter((name) => !name.startsWith("_"))
+    .map((name) => taskEntry(sourceRoot, `docs/09-PLANNING/TASKS/${name}`, `harness/legacy/tasks/${name}`));
+  const moduleTasksRoot = path.join(sourceRoot, "docs/09-PLANNING/MODULES");
+  const moduleTasks = listDirectories(moduleTasksRoot).flatMap((moduleKey) => {
+    if (moduleKey.startsWith("_")) return [];
+    return listDirectories(path.join(moduleTasksRoot, moduleKey, "TASKS"))
+      .filter((name) => !name.startsWith("_"))
+      .map((name) => taskEntry(sourceRoot, `docs/09-PLANNING/MODULES/${moduleKey}/TASKS/${name}`, `harness/legacy/tasks/modules/${moduleKey}/${name}`));
+  });
+  const v2 = collectV2Tasks(sourceRoot);
+  return uniqueEntries([...rootTasks, ...moduleTasks, ...v2]);
+}
+
+function collectV2Tasks(sourceRoot: string): ReadonlyArray<LegacyScanEntry> {
+  if (!hasExplicitHarnessConfig(sourceRoot)) return [];
+  let layout: ReturnType<typeof resolveHarnessLayout>;
+  try {
+    layout = resolveHarnessLayout(sourceRoot);
+  } catch {
+    return [];
+  }
+  const entries: LegacyScanEntry[] = [];
+  if (isPathInside(sourceRoot, layout.tasksRoot)) {
+    entries.push(...listDirectories(layout.tasksRoot)
+      .filter((name) => !name.startsWith("_"))
+      .map((name) => taskEntry(sourceRoot, normalizeSlashes(path.relative(sourceRoot, path.join(layout.tasksRoot, name))), `harness/legacy/tasks/${name}`)));
+  }
+  const modulesRoot = path.join(layout.planningRoot, "modules");
+  if (isPathInside(sourceRoot, modulesRoot)) {
+    for (const moduleKey of listDirectories(modulesRoot)) {
+      if (moduleKey.startsWith("_")) continue;
+      const moduleTasksRoot = path.join(modulesRoot, moduleKey, "tasks");
+      entries.push(...listDirectories(moduleTasksRoot)
+        .filter((name) => !name.startsWith("_"))
+        .map((name) => taskEntry(sourceRoot, normalizeSlashes(path.relative(sourceRoot, path.join(moduleTasksRoot, name))), `harness/legacy/tasks/modules/${moduleKey}/${name}`)));
+    }
+  }
+  return entries;
+}
+
+function collectLegacyDocs(rootDir: string, sourceRoot: string): ReadonlyArray<LegacyScanEntry> {
+  const docsRoot = path.join(sourceRoot, "docs");
+  const docsEntries = walkFiles(docsRoot)
+    .map((filePath) => normalizeSlashes(path.relative(sourceRoot, filePath)))
+    .flatMap((relativePath) => safeDocEntry(rootDir, sourceRoot, relativePath));
+  if (!hasExplicitHarnessConfig(sourceRoot)) return docsEntries;
+  let layout: ReturnType<typeof resolveHarnessLayout>;
+  try {
+    layout = resolveHarnessLayout(sourceRoot);
+  } catch {
+    return docsEntries;
+  }
+  const authoredDocRoots = [
+    { root: layout.contextRoot, forwardRoot: resolveHarnessLayout(rootDir).contextRoot },
+    { root: layout.standardsRoot, forwardRoot: resolveHarnessLayout(rootDir).standardsRoot }
+  ];
+  const authoredEntries = authoredDocRoots.flatMap(({ root, forwardRoot }) => {
+    if (!isPathInside(sourceRoot, root)) return [];
+    return walkFiles(root)
+      .map((filePath) => normalizeSlashes(path.relative(sourceRoot, filePath)))
+      .flatMap((relativePath) => safeAuthoredDocEntry(rootDir, sourceRoot, relativePath, forwardRoot, root));
+  });
+  return uniqueEntries([...docsEntries, ...authoredEntries]);
+}
+
+function taskEntry(sourceRoot: string, sourcePath: string, storedPath: string): LegacyIndexEntry {
+  const fullPath = path.join(sourceRoot, sourcePath);
+  const title = readTitle(fullPath) ?? path.basename(sourcePath);
+  const status = readDetectedStatus(fullPath);
+  return {
+    id: legacyId(sourcePath),
+    category: "task",
+    sourcePath,
+    storedPath,
+    sourceDigest: digestPath(fullPath),
+    title,
+    detectedStatus: status ? { raw: status, confidence: "medium" } : { raw: "unknown", confidence: "low" },
+    evidencePointers: evidencePointers(fullPath, storedPath),
+    recommendedTreatment: status === "done" || status === "cancelled" ? "preserve" : "rebuild-required",
+    humanReviewRequired: true
+  };
+}
+
+function docEntry(sourceRoot: string, sourcePath: string, storedPath: string, forwardPath?: string): LegacyScanEntry {
+  const fullPath = path.join(sourceRoot, sourcePath);
+  return {
+    id: legacyId(sourcePath),
+    category: "doc",
+    sourcePath,
+    storedPath,
+    sourceDigest: digestPath(fullPath),
+    title: path.basename(sourcePath),
+    evidencePointers: [],
+    recommendedTreatment: "preserve",
+    humanReviewRequired: false,
+    forwardPath
+  };
+}
+
+function evidencePointers(fullPath: string, storedPath: string): LegacyIndexEntry["evidencePointers"] {
+  if (!statSync(fullPath).isDirectory()) return [];
+  return ["progress.md", "review.md", "walkthrough.md"]
+    .filter((fileName) => existsSync(path.join(fullPath, fileName)))
+    .map((fileName) => ({
+      kind: fileName === "review.md" ? "review" as const : fileName === "walkthrough.md" ? "walkthrough" as const : "progress" as const,
+      path: `${storedPath}/${fileName}`,
+      label: fileName
+    }));
+}
+
+function safeDocEntry(rootDir: string, sourceRoot: string, relativePath: string): ReadonlyArray<LegacyScanEntry> {
+  if (!isSafeDocPath(relativePath)) return [];
+  const targetLayout = resolveHarnessLayout(rootDir);
+  const forwardPath = forwardPathForDocsPath(rootDir, targetLayout, relativePath);
+  return [docEntry(sourceRoot, relativePath, `harness/legacy/docs/${relativePath.replace(/^docs\//u, "")}`, forwardPath)];
+}
+
+function safeAuthoredDocEntry(
+  rootDir: string,
+  sourceRoot: string,
+  relativePath: string,
+  forwardRoot: string,
+  sourceAuthoredRoot: string
+): ReadonlyArray<LegacyScanEntry> {
+  if (!isSafeDocPath(relativePath, false)) return [];
+  const relWithinAuthoredRoot = normalizeSlashes(path.relative(sourceAuthoredRoot, path.join(sourceRoot, relativePath)));
+  const forwardPath = normalizeSlashes(path.relative(rootDir, path.join(forwardRoot, relWithinAuthoredRoot)));
+  return [docEntry(sourceRoot, relativePath, `harness/legacy/docs/${relativePath}`, forwardPath.startsWith("..") ? undefined : forwardPath)];
+}
+
+function isSafeDocPath(relativePath: string, requireDocsPrefix = true): boolean {
+  if (requireDocsPrefix && !relativePath.startsWith("docs/")) return false;
+  if (!/\.(?:md|mdx|txt|json|ya?ml)$/u.test(relativePath)) return false;
+  if (/^docs\/09-PLANNING\/TASKS\//u.test(relativePath)) return false;
+  if (/^docs\/09-PLANNING\/MODULES\/[^/]+\/TASKS\//u.test(relativePath)) return false;
+  return true;
+}
+
+function forwardPathForDocsPath(rootDir: string, targetLayout: ReturnType<typeof resolveHarnessLayout>, relativePath: string): string | undefined {
+  const mappings: ReadonlyArray<readonly [RegExp, string]> = [
+    [/^docs\/11-REFERENCE\/(.+)$/u, targetLayout.standardsRoot],
+    [/^docs\/10-ARCHITECTURE\/(.+)$/u, path.join(targetLayout.contextRoot, "architecture")],
+    [/^docs\/context\/(.+)$/u, targetLayout.contextRoot],
+    [/^docs\/architecture\/(.+)$/u, path.join(targetLayout.contextRoot, "architecture")]
+  ];
+  for (const [pattern, targetRoot] of mappings) {
+    const match = pattern.exec(relativePath);
+    if (!match) continue;
+    const forwardPath = normalizeSlashes(path.relative(rootDir, path.join(targetRoot, match[1])));
+    return forwardPath.startsWith("..") ? undefined : forwardPath;
+  }
+  return undefined;
+}
+
+function hasExplicitHarnessConfig(sourceRoot: string): boolean {
+  return existsSync(path.join(sourceRoot, "harness", "harness.yaml"))
+    || existsSync(path.join(sourceRoot, ".harness-private", "coding-agent-harness", "harness.yaml"));
+}
+
+function escapeMarkdownTableCell(value: string): string {
+  return value.replace(/\|/gu, "\\|");
+}
+
+function uniqueEntries(entries: ReadonlyArray<LegacyScanEntry>): ReadonlyArray<LegacyScanEntry> {
+  const seen = new Set<string>();
+  return entries.filter((entry) => {
+    const key = `${entry.category}:${entry.sourcePath}:${entry.storedPath}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function isSafeRelativePath(relativePath: string): boolean {
+  return relativePath.length > 0 && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
+}
+
+function isPathInside(parent: string, candidate: string): boolean {
+  const relativePath = path.relative(parent, candidate);
+  return relativePath === "" || isSafeRelativePath(relativePath);
+}
+
+export function copySource(source: string, target: string): void {
+  const linkStats = lstatSync(source);
+  if (linkStats.isSymbolicLink()) return;
+  const stats = statSync(source);
+  if (stats.isDirectory()) {
+    mkdirSync(target, { recursive: true });
+    for (const entry of readdirSync(source, { withFileTypes: true })) {
+      copySource(path.join(source, entry.name), path.join(target, entry.name));
+    }
+    return;
+  }
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, readFileSync(source));
+}
+
+function walkFiles(directory: string): ReadonlyArray<string> {
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isSymbolicLink()) return [];
+    if (entry.isDirectory()) return walkFiles(entryPath);
+    return [entryPath];
+  }).sort();
+}
+
+function listDirectories(directory: string): ReadonlyArray<string> {
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function readTitle(directory: string): string | undefined {
+  const indexPath = path.join(directory, "INDEX.md");
+  const taskPlanPath = path.join(directory, "task_plan.md");
+  const body = existsSync(indexPath) ? readFileSync(indexPath, "utf8") : existsSync(taskPlanPath) ? readFileSync(taskPlanPath, "utf8") : "";
+  return body.match(/^title:\s*(.+)$/mu)?.[1]?.trim() ?? body.match(/^#\s+(.+)$/mu)?.[1]?.trim();
+}
+
+function readDetectedStatus(directory: string): string | undefined {
+  const indexPath = path.join(directory, "INDEX.md");
+  if (!existsSync(indexPath)) return undefined;
+  const body = readFileSync(indexPath, "utf8");
+  return body.match(/^status:\s*(.+)$/mu)?.[1]?.trim();
+}
+
+function digestPath(targetPath: string): `sha256:${string}` {
+  const hash = createHash("sha256");
+  const stats = statSync(targetPath);
+  if (stats.isDirectory()) {
+    for (const filePath of walkFiles(targetPath)) {
+      hash.update(normalizeSlashes(path.relative(targetPath, filePath)));
+      hash.update("\0");
+      hash.update(readFileSync(filePath));
+      hash.update("\0");
+    }
+  } else {
+    hash.update(readFileSync(targetPath));
+  }
+  return `sha256:${hash.digest("hex")}`;
+}
+
+function legacyId(sourcePath: string): string {
+  const digest = createHash("sha256").update(sourcePath).digest("hex").slice(0, 12);
+  return `legacy_${digest}`;
+}
+
+function normalizeSlashes(value: string): string {
+  return value.split(path.sep).join("/");
+}

--- a/packages/cli/src/commands/migration.ts
+++ b/packages/cli/src/commands/migration.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Schema } from "effect";
 import { resolveHarnessLayout } from "../../../kernel/src/layout/index.ts";
@@ -7,17 +7,8 @@ import { LegacyIndexSchema, type LegacyIndex, type LegacyIndexEntry } from "../.
 import type { CliResult } from "../cli/types.ts";
 import { applyCollisionReport, buildLegacyCopyPlan, readCollisionReport, writeCollisionReport } from "./migration-collision.ts";
 import { collectLegacyProvenanceWarnings } from "./legacy-provenance-verify.ts";
+import { buildScanReport, copyForwardDocs, copySource, renderIntakePlan, stripScanOnlyFields, summarize, type LegacyScanReport } from "./migration-scan.ts";
 import type { LegacyCopySafeDocsAction, LegacyIndexAction, LegacyIntakePlanAction, LegacyScanAction, LegacyVerifyAction, MigratePlanAction, MigrateRunAction, MigrateStructureAction, MigrateVerifyAction } from "./migration-types.ts";
-
-interface LegacyScanReport {
-  readonly schema: "legacy-intake-scan/v1";
-  readonly strategy: "legacy-intake";
-  readonly legacyRoot: "harness/legacy";
-  readonly sourceRoot: string;
-  readonly entries: ReadonlyArray<LegacyIndexEntry>;
-  readonly summary: LegacyIndex["summary"];
-  readonly deprecatedAliases: ReadonlyArray<string>;
-}
 
 interface LegacyIntakeSession {
   readonly schema: "legacy-intake-session/v1";
@@ -242,90 +233,6 @@ export function runLegacyVerify(rootDir: string, _action: LegacyVerifyAction): C
   };
 }
 
-function buildScanReport(rootDir: string, sourcePath: string): LegacyScanReport {
-  const sourceRoot = path.resolve(rootDir, sourcePath);
-  const entries = [
-    ...collectLegacyTasks(sourceRoot),
-    ...collectLegacyDocs(sourceRoot)
-  ];
-  const summary = summarize(entries);
-  return {
-    schema: "legacy-intake-scan/v1",
-    strategy: "legacy-intake",
-    legacyRoot: "harness/legacy",
-    sourceRoot: normalizeSlashes(path.relative(rootDir, sourceRoot) || "."),
-    entries,
-    summary,
-    deprecatedAliases: ["migrate-plan", "migrate-structure", "migrate-run", "migrate-verify"]
-  };
-}
-
-function collectLegacyTasks(sourceRoot: string): ReadonlyArray<LegacyIndexEntry> {
-  const rootTasks = listDirectories(path.join(sourceRoot, "docs/09-PLANNING/TASKS"))
-    .filter((name) => !name.startsWith("_"))
-    .map((name) => taskEntry(sourceRoot, `docs/09-PLANNING/TASKS/${name}`, `harness/legacy/tasks/${name}`));
-  const moduleTasksRoot = path.join(sourceRoot, "docs/09-PLANNING/MODULES");
-  const moduleTasks = listDirectories(moduleTasksRoot).flatMap((moduleKey) => {
-    if (moduleKey.startsWith("_")) return [];
-    return listDirectories(path.join(moduleTasksRoot, moduleKey, "TASKS"))
-      .filter((name) => !name.startsWith("_"))
-      .map((name) => taskEntry(sourceRoot, `docs/09-PLANNING/MODULES/${moduleKey}/TASKS/${name}`, `harness/legacy/tasks/modules/${moduleKey}/${name}`));
-  });
-  return [...rootTasks, ...moduleTasks];
-}
-
-function collectLegacyDocs(sourceRoot: string): ReadonlyArray<LegacyIndexEntry> {
-  const docsRoot = path.join(sourceRoot, "docs");
-  return walkFiles(docsRoot)
-    .map((filePath) => normalizeSlashes(path.relative(sourceRoot, filePath)))
-    .filter((relativePath) => isSafeDocPath(relativePath))
-    .map((relativePath) => docEntry(sourceRoot, relativePath, `harness/legacy/docs/${relativePath.replace(/^docs\//u, "")}`));
-}
-
-function taskEntry(sourceRoot: string, sourcePath: string, storedPath: string): LegacyIndexEntry {
-  const fullPath = path.join(sourceRoot, sourcePath);
-  const title = readTitle(fullPath) ?? path.basename(sourcePath);
-  const status = readDetectedStatus(fullPath);
-  return {
-    id: legacyId(sourcePath),
-    category: "task",
-    sourcePath,
-    storedPath,
-    sourceDigest: digestPath(fullPath),
-    title,
-    detectedStatus: status ? { raw: status, confidence: "medium" } : { raw: "unknown", confidence: "low" },
-    evidencePointers: evidencePointers(fullPath, storedPath),
-    recommendedTreatment: status === "done" || status === "cancelled" ? "preserve" : "rebuild-required",
-    humanReviewRequired: true
-  };
-}
-
-function docEntry(sourceRoot: string, sourcePath: string, storedPath: string): LegacyIndexEntry {
-  const fullPath = path.join(sourceRoot, sourcePath);
-  return {
-    id: legacyId(sourcePath),
-    category: "doc",
-    sourcePath,
-    storedPath,
-    sourceDigest: digestPath(fullPath),
-    title: path.basename(sourcePath),
-    evidencePointers: [],
-    recommendedTreatment: "preserve",
-    humanReviewRequired: false
-  };
-}
-
-function evidencePointers(fullPath: string, storedPath: string): LegacyIndexEntry["evidencePointers"] {
-  if (!statSync(fullPath).isDirectory()) return [];
-  return ["progress.md", "review.md", "walkthrough.md"]
-    .filter((fileName) => existsSync(path.join(fullPath, fileName)))
-    .map((fileName) => ({
-      kind: fileName === "review.md" ? "review" as const : fileName === "walkthrough.md" ? "walkthrough" as const : "progress" as const,
-      path: `${storedPath}/${fileName}`,
-      label: fileName
-    }));
-}
-
 function applyLegacyCopy(rootDir: string, report: LegacyScanReport): CliResult {
   const validation = validateLegacyIndex(rootDir, report);
   if (!validation.ok) return validation.result;
@@ -347,6 +254,7 @@ function applyLegacyCopy(rootDir: string, report: LegacyScanReport): CliResult {
   for (const target of copyPlan.targets) {
     copySource(target.sourcePath, path.join(rootDir, target.chosenPath));
   }
+  copyForwardDocs(rootDir, report);
   return {
     ok: true,
     command: "legacy-copy-safe-docs",
@@ -404,24 +312,9 @@ function toLegacyIndex(rootDir: string, report: LegacyScanReport): LegacyIndex {
     legacyRoot: "harness/legacy",
     generatedAt: new Date(0).toISOString(),
     sourceRoot: report.sourceRoot,
-    entries: report.entries,
+    entries: report.entries.map(stripScanOnlyFields),
     summary: summarize(report.entries)
   };
-}
-
-function renderIntakePlan(report: LegacyScanReport): string {
-  const lines = [
-    "# Legacy Intake Plan",
-    "",
-    `Source root: ${report.sourceRoot}`,
-    `Entries: ${report.summary.entryCount}`,
-    "",
-    "| ID | Category | Source | Stored | Treatment |",
-    "| --- | --- | --- | --- | --- |",
-    ...report.entries.map((entry) => `| ${entry.id} | ${entry.category} | ${entry.sourcePath} | ${entry.storedPath} | ${entry.recommendedTreatment} |`),
-    ""
-  ];
-  return lines.join("\n");
 }
 
 function aliasResult(command: string, report: LegacyScanReport, meta: { readonly aliasOf: string; readonly hint: string; readonly migrationMode?: "plan" | "apply" }): CliResult {
@@ -460,27 +353,10 @@ function retiredMigrationWarning(command: string, aliasOf: string): Record<strin
   };
 }
 
-function summarize(entries: ReadonlyArray<LegacyIndexEntry>): LegacyIndex["summary"] {
-  return {
-    entryCount: entries.length,
-    taskCount: entries.filter((entry) => entry.category === "task").length,
-    docCount: entries.filter((entry) => entry.category === "doc").length,
-    rebuildRequiredCount: entries.filter((entry) => entry.recommendedTreatment === "rebuild-required").length
-  };
-}
-
 function limitReport(report: LegacyScanReport, limit: number): LegacyScanReport {
   if (!Number.isFinite(limit)) return report;
   const entries = report.entries.slice(0, Math.max(0, limit));
   return { ...report, entries, summary: summarize(entries) };
-}
-
-function isSafeDocPath(relativePath: string): boolean {
-  if (!relativePath.startsWith("docs/")) return false;
-  if (!/\.(?:md|mdx|txt|json|ya?ml)$/u.test(relativePath)) return false;
-  if (/^docs\/09-PLANNING\/TASKS\//u.test(relativePath)) return false;
-  if (/^docs\/09-PLANNING\/MODULES\/[^/]+\/TASKS\//u.test(relativePath)) return false;
-  return true;
 }
 
 function firstDuplicate(values: ReadonlyArray<string>): string | undefined {
@@ -490,71 +366,6 @@ function firstDuplicate(values: ReadonlyArray<string>): string | undefined {
     seen.add(value);
   }
   return undefined;
-}
-
-function copySource(source: string, target: string): void {
-  const stats = statSync(source);
-  if (stats.isDirectory()) {
-    mkdirSync(target, { recursive: true });
-    for (const entry of readdirSync(source, { withFileTypes: true })) {
-      copySource(path.join(source, entry.name), path.join(target, entry.name));
-    }
-    return;
-  }
-  mkdirSync(path.dirname(target), { recursive: true });
-  writeFileSync(target, readFileSync(source));
-}
-
-function walkFiles(directory: string): ReadonlyArray<string> {
-  if (!existsSync(directory)) return [];
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const entryPath = path.join(directory, entry.name);
-    if (entry.isDirectory()) return walkFiles(entryPath);
-    return [entryPath];
-  }).sort();
-}
-
-function listDirectories(directory: string): ReadonlyArray<string> {
-  if (!existsSync(directory)) return [];
-  return readdirSync(directory, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .sort();
-}
-
-function readTitle(directory: string): string | undefined {
-  const indexPath = path.join(directory, "INDEX.md");
-  const taskPlanPath = path.join(directory, "task_plan.md");
-  const body = existsSync(indexPath) ? readFileSync(indexPath, "utf8") : existsSync(taskPlanPath) ? readFileSync(taskPlanPath, "utf8") : "";
-  return body.match(/^title:\s*(.+)$/mu)?.[1]?.trim() ?? body.match(/^#\s+(.+)$/mu)?.[1]?.trim();
-}
-
-function readDetectedStatus(directory: string): string | undefined {
-  const indexPath = path.join(directory, "INDEX.md");
-  if (!existsSync(indexPath)) return undefined;
-  const body = readFileSync(indexPath, "utf8");
-  return body.match(/^status:\s*(.+)$/mu)?.[1]?.trim();
-}
-
-function digestPath(targetPath: string): `sha256:${string}` {
-  const hash = createHash("sha256");
-  const stats = statSync(targetPath);
-  if (stats.isDirectory()) {
-    for (const filePath of walkFiles(targetPath)) {
-      hash.update(normalizeSlashes(path.relative(targetPath, filePath)));
-      hash.update("\0");
-      hash.update(readFileSync(filePath));
-      hash.update("\0");
-    }
-  } else {
-    hash.update(readFileSync(targetPath));
-  }
-  return `sha256:${hash.digest("hex")}`;
-}
-
-function legacyId(sourcePath: string): string {
-  const digest = createHash("sha256").update(sourcePath).digest("hex").slice(0, 12);
-  return `legacy_${digest}`;
 }
 
 function digestJson(value: unknown): `sha256:${string}` {

--- a/packages/cli/test/migration-adopt-cli.test.ts
+++ b/packages/cli/test/migration-adopt-cli.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -58,7 +58,7 @@ test("CLI legacy scan and intake-plan are readonly intake evidence", () => {
   });
 });
 
-test("CLI legacy copy and index write only under harness legacy storage", () => {
+test("CLI legacy copy preserves legacy evidence and forwards safe authored docs", () => {
   withTempRoot((rootDir) => {
     writeLegacyTask(rootDir, "done-task", "done");
     writeLegacyModuleTask(rootDir, "auth", "module-task", "active");
@@ -79,6 +79,7 @@ test("CLI legacy copy and index write only under harness legacy storage", () => 
     assert.equal(existsSync(path.join(rootDir, "harness/legacy/tasks/done-task/task_plan.md")), true);
     assert.equal(existsSync(path.join(rootDir, "harness/legacy/tasks/modules/auth/module-task/task_plan.md")), true);
     assert.equal(existsSync(path.join(rootDir, "harness/legacy/docs/11-REFERENCE/testing-standard.md")), true);
+    assert.equal(existsSync(path.join(rootDir, "harness/standards/testing-standard.md")), true);
     assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks/done-task")), false);
     assert.equal(existsSync(path.join(rootDir, "harness/planning/modules/auth/tasks/module-task")), false);
     const index = JSON.parse(readFileSync(path.join(rootDir, "harness/legacy/index.json"), "utf8"));
@@ -122,6 +123,40 @@ test("CLI legacy copy applies fixed suffix collisions and writes report", () => 
     assert.equal(collisionReport.entries.some((entry: Record<string, unknown>) => entry.kind === "file" && entry.chosenPath === "harness/legacy/docs/11-REFERENCE/testing-standard.legacy-import-2.md" && entry.suffixIndex === 2), true);
     assert.equal(index.entries.some((entry: Record<string, unknown>) => entry.storedPath === "harness/legacy/tasks/old-task-legacy-import-2"), true);
     assert.equal(index.entries.some((entry: Record<string, unknown>) => entry.storedPath === "harness/legacy/docs/11-REFERENCE/testing-standard.legacy-import-2.md"), true);
+  });
+});
+
+test("CLI legacy scan discovers V2 layout tasks and forwards private harness context", () => {
+  withTempRoot((rootDir) => {
+    writeFile(rootDir, "old/.harness-private/coding-agent-harness/harness.yaml", [
+      "version: 2",
+      "structure:",
+      "  harnessRoot: coding-agent-harness",
+      "  planningRoot: coding-agent-harness/planning",
+      "  tasksRoot: coding-agent-harness/planning/tasks",
+      ""
+    ].join("\n"));
+    writeFile(rootDir, "old/.harness-private/coding-agent-harness/planning/tasks/v2-task/INDEX.md", "---\ntitle: V2 Task\nstatus: active\n---\n# V2 Task\n");
+    writeFile(rootDir, "old/.harness-private/coding-agent-harness/planning/tasks/v2-task/progress.md", "progress\n");
+    writeFile(rootDir, "old/.harness-private/coding-agent-harness/context/architecture/overview.md", "# Architecture\n");
+    writeFile(rootDir, "outside-secret.md", "# Secret\n");
+    symlinkSync(path.join(rootDir, "outside-secret.md"), path.join(rootDir, "old/.harness-private/coding-agent-harness/context/architecture/leak.md"));
+
+    const scan = runJson(rootDir, ["legacy", "scan", "old"]);
+    assert.equal(scan.report.summary.taskCount, 1);
+    assert.equal(scan.report.summary.docCount, 1);
+    assert.equal(scan.report.entries.some((entry: Record<string, unknown>) => entry.sourcePath === ".harness-private/coding-agent-harness/planning/tasks/v2-task"), true);
+    assert.equal(scan.report.entries.some((entry: Record<string, unknown>) => entry.sourcePath === ".harness-private/coding-agent-harness/context/architecture/leak.md"), false);
+    const contextEntry = scan.report.entries.find((entry: Record<string, unknown>) => entry.sourcePath === ".harness-private/coding-agent-harness/context/architecture/overview.md");
+    assert.equal(contextEntry.forwardPath, "harness/context/architecture/overview.md");
+
+    runJson(rootDir, ["legacy", "copy-safe-docs", "old", "--apply"]);
+    runJson(rootDir, ["legacy", "index", "old", "--apply"]);
+
+    assert.equal(existsSync(path.join(rootDir, "harness/legacy/tasks/v2-task/INDEX.md")), true);
+    assert.equal(existsSync(path.join(rootDir, "harness/context/architecture/overview.md")), true);
+    assert.equal(existsSync(path.join(rootDir, "harness/context/architecture/leak.md")), false);
+    assert.equal(existsSync(path.join(rootDir, "harness/legacy/docs/.harness-private/coding-agent-harness/context/architecture/overview.md")), true);
   });
 });
 
@@ -272,6 +307,12 @@ function writeTaskPackage(taskDir: string, id: string, status: string): void {
 
 function writeLegacyDoc(rootDir: string, relativePath: string, body: string): void {
   const fullPath = path.join(rootDir, "docs", relativePath);
+  mkdirSync(path.dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, body, "utf8");
+}
+
+function writeFile(rootDir: string, relativePath: string, body: string): void {
+  const fullPath = path.join(rootDir, relativePath);
   mkdirSync(path.dirname(fullPath), { recursive: true });
   writeFileSync(fullPath, body, "utf8");
 }

--- a/packages/cli/test/package-surface.test.ts
+++ b/packages/cli/test/package-surface.test.ts
@@ -41,7 +41,8 @@ test("bundled software coding assets have consistent template and process-preset
   };
   const catalogIds = new Set(catalog.documents.map((document) => document.id));
   const selectedMaterializedPaths = new Set<string>();
-  const processPresetIds = new Set(["legacy-migration", "lesson-sedimentation", "publish-standard", "release-closeout", "version-upgrade"]);
+  const processPresetIds = new Set(["legacy-migration", "lesson-sedimentation", "milestone-closeout", "publish-standard", "release-closeout", "version-upgrade"]);
+  const implementedProcessPresetIds = new Set(["legacy-migration", "milestone-closeout"]);
 
   for (const selection of vertical.templateSelections) {
     assertKnownTemplateRef(catalogIds, selection.templateRef);
@@ -61,8 +62,15 @@ test("bundled software coding assets have consistent template and process-preset
     }
     if (processPresetIds.has(presetId)) {
       assert.equal(manifest.kind, "process-action");
-      assert.match(manifest.title, /Capability Smoke/u);
+      if (!implementedProcessPresetIds.has(presetId)) {
+        assert.match(manifest.title, /Capability Smoke/u);
+      }
       assert.notEqual(Object.keys(manifest.entrypoints ?? {}).length, 0);
+      for (const entrypoint of Object.values(manifest.entrypoints ?? {})) {
+        const scriptEntrypoint = entrypoint as { readonly reads?: ReadonlyArray<string>; readonly writes?: ReadonlyArray<string> };
+        assert.equal(scriptEntrypoint.reads?.includes("{{paths.rootDir}}/**") ?? false, false, `${presetId} declares repo-wide recursive reads`);
+        assert.equal(scriptEntrypoint.writes?.includes("{{paths.rootDir}}/**") ?? false, false, `${presetId} declares repo-wide recursive writes`);
+      }
     }
   }
 });

--- a/packages/cli/test/preset-module-cli.test.ts
+++ b/packages/cli/test/preset-module-cli.test.ts
@@ -55,7 +55,7 @@ test("CLI preset CRUD validates, installs, audits, and removes project presets",
 
     const audit = runJson(rootDir, ["preset", "audit"]);
     assert.equal(audit.ok, true);
-    assert.equal(audit.report.totalResolved, 8);
+    assert.equal(audit.report.totalResolved, 9);
 
     const removed = runJson(rootDir, ["preset", "uninstall", "custom-task", "--project"]);
     assert.equal(removed.ok, true);

--- a/packages/cli/test/preset-script-cli.test.ts
+++ b/packages/cli/test/preset-script-cli.test.ts
@@ -76,6 +76,75 @@ test("CLI process preset script entrypoint rejects undeclared output write scope
   });
 });
 
+test("CLI process preset script entrypoint rejects repository-wide declared write scope", () => {
+  withTempRoot((rootDir) => {
+    writeFile(rootDir, ".harness/presets/root-writer/preset.json", JSON.stringify({
+      schema: "preset-manifest/v2",
+      id: "root-writer",
+      title: "Root Writer",
+      vertical: "software/coding",
+      version: "1.0.0",
+      kind: "process-action",
+      kernelVersionRange: { min: "1.0.0", maxExclusive: "2.0.0" },
+      capabilityImports: [],
+      entrypoints: {
+        scaffold: { type: "script", command: "scripts/preset-action.mjs", writes: ["{{paths.rootDir}}/**"] }
+      },
+      profiles: [{
+        id: "baseline",
+        title: "Baseline",
+        checkerProfile: "standard",
+        templateSelections: []
+      }],
+      defaultProfile: "baseline"
+    }, null, 2));
+    writeFile(rootDir, ".harness/presets/root-writer/scripts/preset-action.mjs", "console.log('should not execute');\n");
+
+    const result = runJson(rootDir, ["preset", "action", "root-writer", "scaffold", "--task", "task-1", "--allow-scripts"], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "preset_write_scope_invalid");
+    assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks/task-1")), false);
+  });
+});
+
+test("CLI process preset script entrypoint rejects repository-wide recursive read scope", () => {
+  withTempRoot((rootDir) => {
+    writeFile(rootDir, ".harness/presets/root-reader/preset.json", JSON.stringify({
+      schema: "preset-manifest/v2",
+      id: "root-reader",
+      title: "Root Reader",
+      vertical: "software/coding",
+      version: "1.0.0",
+      kind: "process-action",
+      kernelVersionRange: { min: "1.0.0", maxExclusive: "2.0.0" },
+      capabilityImports: [],
+      entrypoints: {
+        scaffold: {
+          type: "script",
+          command: "scripts/preset-action.mjs",
+          reads: ["{{paths.rootDir}}/**"],
+          writes: ["{{outputRoot}}/**"]
+        }
+      },
+      profiles: [{
+        id: "baseline",
+        title: "Baseline",
+        checkerProfile: "standard",
+        templateSelections: []
+      }],
+      defaultProfile: "baseline"
+    }, null, 2));
+    writeFile(rootDir, ".harness/presets/root-reader/scripts/preset-action.mjs", "console.log('should not execute');\n");
+
+    const result = runJson(rootDir, ["preset", "action", "root-reader", "scaffold", "--task", "task-1", "--allow-scripts"], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "preset_read_scope_invalid");
+    assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks/task-1")), false);
+  });
+});
+
 test("CLI process preset script entrypoint blocks out-of-scope filesystem writes", () => {
   withTempRoot((rootDir) => {
     writeFile(rootDir, ".harness/presets/escape-script/preset.json", JSON.stringify({
@@ -112,8 +181,104 @@ test("CLI process preset script entrypoint blocks out-of-scope filesystem writes
     const result = runJson(rootDir, ["preset", "action", "escape-script", "scaffold", "--task", "task-1", "--allow-scripts"], false);
 
     assert.equal(result.ok, false);
-    assert.equal(result.error.code, "preset_write_scope_violation");
+    assert.match(result.error.code, /^preset_(read|write)_scope_violation$/u);
     assert.equal(existsSync(path.join(rootDir, "escaped.txt")), false);
+  });
+});
+
+test("CLI milestone-closeout preset script red-blocks task evidence missing milestone criteria and passes after mapped evidence is complete", () => {
+  withTempRoot((rootDir) => {
+    writeFile(rootDir, "harness/planning/milestones/m2-5/feature-breakdown.md", [
+      "# M2.5 Feature Breakdown",
+      "",
+      "## Exit Criteria",
+      "",
+      "- [x] Implemented behavior has source evidence.",
+      "- [x] Stub criterion still pending.",
+      ""
+    ].join("\n"));
+    writeFile(rootDir, "harness/planning/tasks/task-closeout/INDEX.md", [
+      "---",
+      "schema: task-package/v2",
+      "task_id: task-closeout",
+      "title: Closeout fixture",
+      "---",
+      "# Closeout fixture",
+      ""
+    ].join("\n"));
+    writeFile(rootDir, "harness/planning/tasks/task-closeout/task_plan.md", [
+      "# Plan",
+      "",
+      "## Task Evidence",
+      "",
+      "- [x] Implemented behavior has source evidence.",
+      ""
+    ].join("\n"));
+
+    const unauthorized = runJson(rootDir, ["preset", "action", "milestone-closeout", "check", "--task", "task-closeout"], false);
+    assert.equal(unauthorized.error.code, "preset_script_authorization_required");
+
+    const blocked = runJson(rootDir, ["preset", "action", "milestone-closeout", "check", "--task", "task-closeout", "--allow-scripts"], false);
+
+    assert.equal(blocked.ok, false);
+    assert.equal(blocked.error.code, "milestone_closeout_blocked");
+    assert.equal(blocked.report.status, "blocked");
+    assert.equal(blocked.report.criteriaSource, "milestone-feature-breakdown");
+    assert.equal(blocked.report.items.some((item: Record<string, unknown>) => item.status === "red" && item.reason === "milestone_criterion_stub_or_placeholder"), true);
+    assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks/task-closeout/artifacts/milestone-closeout-report.json")), true);
+
+    writeFile(rootDir, "harness/planning/milestones/m2-5/feature-breakdown.md", [
+      "# M2.5 Feature Breakdown",
+      "",
+      "## Exit Criteria",
+      "",
+      "- [x] Implemented behavior has source evidence.",
+      "- [x] Former open criterion now has source evidence.",
+      ""
+    ].join("\n"));
+    writeFile(rootDir, "harness/planning/tasks/task-closeout/task_plan.md", [
+      "# Plan",
+      "",
+      "## Task Evidence",
+      "",
+      "- [x] Implemented behavior has source evidence.",
+      "- [x] Former open criterion now has source evidence.",
+      ""
+    ].join("\n"));
+
+    const passed = runJson(rootDir, ["preset", "action", "milestone-closeout", "check", "--task", "task-closeout", "--allow-scripts"]);
+
+    assert.equal(passed.ok, true);
+    assert.equal(passed.report.status, "passed");
+    assert.equal(passed.report.summary.red, 0);
+    assert.equal(passed.report.summary.green, 2);
+  });
+});
+
+test("CLI legacy-migration preset action plans V2 task discovery and context forward evidence", () => {
+  withTempRoot((rootDir) => {
+    writeFile(rootDir, "old/.harness-private/coding-agent-harness/harness.yaml", [
+      "version: 2",
+      "structure:",
+      "  harnessRoot: coding-agent-harness",
+      "  planningRoot: coding-agent-harness/planning",
+      "  tasksRoot: coding-agent-harness/planning/tasks",
+      ""
+    ].join("\n"));
+    writeFile(rootDir, "old/.harness-private/coding-agent-harness/planning/tasks/v2-task/INDEX.md", "---\ntitle: V2 Task\nstatus: active\n---\n# V2 Task\n");
+    writeFile(rootDir, "old/.harness-private/coding-agent-harness/planning/tasks/v2-task/progress.md", "progress\n");
+    writeFile(rootDir, "old/.harness-private/coding-agent-harness/context/architecture/overview.md", "# Architecture\n");
+
+    const result = runJson(rootDir, ["preset", "action", "legacy-migration", "plan", "--task", "task-migration", "--allow-scripts"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.command, "preset-action");
+    assert.equal(result.report.scan.summary.taskCount, 1);
+    assert.equal(result.report.scan.entries.some((entry: Record<string, unknown>) => entry.sourcePath === ".harness-private/coding-agent-harness/planning/tasks/v2-task"), true);
+    const contextEntry = result.report.scan.entries.find((entry: Record<string, unknown>) => entry.sourcePath === ".harness-private/coding-agent-harness/context/architecture/overview.md");
+    assert.equal(contextEntry.forwardPath, "harness/context/architecture/overview.md");
+    assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks/task-migration/artifacts/legacy-migration-plan.json")), true);
+    assert.match(readFileSync(path.join(rootDir, "harness/planning/tasks/task-migration/artifacts/legacy-migration-plan.md"), "utf8"), /V2 Task/u);
   });
 });
 

--- a/packages/kernel/schemas/json/preset-manifest.schema.json
+++ b/packages/kernel/schemas/json/preset-manifest.schema.json
@@ -120,6 +120,7 @@
           "properties": {
             "type": { "const": "script" },
             "command": { "type": "string" },
+            "reads": { "type": "array", "items": { "type": "string" } },
             "writes": { "type": "array", "items": { "type": "string" } },
             "inputs": {
               "type": "object",

--- a/packages/kernel/src/domain/extension-model.ts
+++ b/packages/kernel/src/domain/extension-model.ts
@@ -317,7 +317,7 @@ function validatePresetEntrypointsShape(input: unknown, path: string, issues: Ex
     const entrypointPath = `${path}.${entrypointName}`;
     if (!isRecord(entrypoint)) continue;
     if (entrypoint.type === "script") {
-      validateObjectKeys(entrypoint, entrypointPath, ["type", "command", "writes", "inputs"], issues);
+      validateObjectKeys(entrypoint, entrypointPath, ["type", "command", "reads", "writes", "inputs"], issues);
       continue;
     }
     if (entrypoint.type === "template") {

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -234,6 +234,7 @@ export const PresetEntrypointSchema = Schema.Union(
   Schema.Struct({
     type: Schema.Literal("script"),
     command: Schema.String,
+    reads: Schema.optional(Schema.Array(Schema.String)),
     writes: Schema.Array(Schema.String),
     inputs: Schema.optional(Schema.Record({
       key: Schema.String,

--- a/skills/preset-creator/SKILL.md
+++ b/skills/preset-creator/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: preset-creator
+description: Create, review, or update Harness Anything presets. Use when designing preset-manifest JSON, preset script entrypoints, reads/writes scopes, preset profiles, process-action presets, or preset tests for Harness Anything. Enforces declaration-first presets and forbids hardcoding preset-specific behavior in CLI core TypeScript.
+---
+
+# Preset Creator
+
+## Core Rule
+
+Keep presets declaration-first. A preset is a manifest plus optional package-local scripts/templates. Do not add `presetId` or action-specific branches to CLI core code.
+
+The CLI may provide only generic infrastructure:
+
+- Manifest/schema validation.
+- Layer resolution: builtin, user, project.
+- Generic script execution.
+- Declared `reads`/`writes` permission handling.
+- Generic result envelope collection.
+
+Preset behavior belongs in the preset package:
+
+- `preset.json`
+- `scripts/*`
+- profile/template selections
+- declared inputs, reads, and writes
+
+## Workflow
+
+1. Define the preset's job in one sentence.
+2. Decide whether it is `template-content` or `process-action`.
+3. Write or update `preset.json` with explicit `entrypoints`.
+4. For script entrypoints, declare the narrowest possible `reads` and `writes`.
+5. Put all preset-specific action logic in `scripts/`, not CLI command dispatch.
+6. If a script needs to return rich command output, write `artifacts/preset-result.json`.
+7. Add tests in the correct tier and update `tools/test-tier-manifest.mjs` when adding new test files.
+
+## Manifest Pattern
+
+Use `reads` for input permissions and `writes` for output permissions:
+
+```json
+{
+  "schema": "preset-manifest/v2",
+  "id": "example-process",
+  "title": "Example Process",
+  "vertical": "software/coding",
+  "version": "1.0.0",
+  "kind": "process-action",
+  "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
+  "capabilityImports": [],
+  "entrypoints": {
+    "plan": {
+      "type": "script",
+      "command": "scripts/preset-action.mjs",
+      "reads": ["{{outputRoot}}/**"],
+      "writes": ["{{outputRoot}}/**"],
+      "inputs": {}
+    }
+  },
+  "profiles": [{ "id": "baseline", "title": "Baseline", "checkerProfile": "standard", "templateSelections": [] }],
+  "defaultProfile": "baseline"
+}
+```
+
+## Script Pattern
+
+Scripts should read `process.env.HARNESS_PRESET_CONTEXT`, use only declared paths, and write outputs under `context.outputRoot`.
+
+If the CLI should surface a domain result, write:
+
+```json
+{
+  "ok": true,
+  "rows": 1,
+  "report": { "schema": "example-report/v1" }
+}
+```
+
+to `artifacts/preset-result.json`.
+
+## Review Checklist
+
+- No CLI core branch checks `presetId`, preset title, or action name for behavior.
+- No preset script requires permissions not declared in `preset.json`.
+- `writes` never grants repo-root write access.
+- Any repo-wide read is deliberate and justified by the preset's job.
+- Process-action presets are not left as capability-smoke placeholders.
+- Tests prove unauthorized script runs fail and authorized runs produce expected artifacts.

--- a/skills/preset-creator/agents/openai.yaml
+++ b/skills/preset-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Preset Creator"
+  short_description: "Design Harness Anything presets"
+  default_prompt: "Design or update a Harness Anything preset using declaration-first manifest and script patterns."

--- a/skills/vertical-creator/SKILL.md
+++ b/skills/vertical-creator/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: vertical-creator
+description: Create, review, or update Harness Anything verticals. Use when designing vertical-definition JSON, vertical template catalogs, entity kinds, package scaffolds, checker profiles, projection schemas, and preset layering for a new Harness Anything domain such as coding, QA, docs, design, or operations.
+---
+
+# Vertical Creator
+
+## Core Rule
+
+Keep verticals declarative. A vertical defines domain shape, templates, defaults, and applicable presets. It must not require CLI core branches for a specific domain.
+
+The CLI may provide only generic vertical infrastructure:
+
+- Schema validation.
+- Template catalog loading.
+- Template materialization.
+- Settings/dev-mode gating.
+- Generic preset and profile selection.
+
+Vertical-specific behavior belongs in vertical assets, template catalogs, presets, and process scripts.
+
+## Workflow
+
+1. Name the domain and list its entity kinds.
+2. Decide which entities become task packages and which are metadata-only.
+3. Define required task documents as template selections.
+4. Choose the checker profile and projection schemas.
+5. Define applicable presets separately; do not bury preset behavior in the vertical.
+6. Add validation tests for schema shape, materialized paths, and default profile behavior.
+7. Add integration tests only for real CLI/filesystem behavior.
+
+## Vertical Definition Pattern
+
+```json
+{
+  "schema": "vertical-definition/v1",
+  "id": "software/coding",
+  "title": "Software Coding",
+  "version": "1.0.0",
+  "entityKinds": [
+    { "id": "task", "packageKind": "task", "contractEntity": true }
+  ],
+  "contractEntityKinds": ["task"],
+  "packageScaffolds": [],
+  "templateSelections": [],
+  "checkerProfile": "standard",
+  "projectionSchemas": []
+}
+```
+
+## Design Rules
+
+- Use templates for document structure, not ad hoc file writes.
+- Use presets for optional process or content overlays.
+- Keep project/user overrides additive and fail closed on invalid active overrides.
+- Do not promise unattended conversion when the system supports Legacy Intake plus explicit rebuild only.
+- Keep private harness operating state out of public docs unless explicitly designing public product documentation.
+
+## Review Checklist
+
+- The vertical works without CLI branches keyed by vertical id.
+- Template refs exist in the catalog and materialize to stable paths.
+- Default preset/profile behavior is explicit.
+- Custom verticals remain gated by user dev mode and project settings.
+- Tests are placed in the proper tier manifest when new test files are added.

--- a/skills/vertical-creator/agents/openai.yaml
+++ b/skills/vertical-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vertical Creator"
+  short_description: "Design Harness Anything verticals"
+  default_prompt: "Design or update a Harness Anything vertical using declaration-first schemas, templates, and preset layering."


### PR DESCRIPTION
## Summary

- Keep process presets declaration-first by moving action behavior into preset-local scripts and adding a generic script runner.
- Add declared read scopes, generic preset-result envelopes, and milestone-closeout task-vs-milestone evidence checking.
- Move legacy-migration planning into the preset package and add project-local Preset Creator / Vertical Creator skills.

## Verification

- `npm run check:pr`
- `npm run check`
- `python3 /Users/lizeyu/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/preset-creator`
- `python3 /Users/lizeyu/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/vertical-creator`

## Test tiers

- Modified `packages/cli/test/package-surface.test.ts` in `contract`.
- Modified `packages/cli/test/migration-adopt-cli.test.ts`, `packages/cli/test/preset-module-cli.test.ts`, and `packages/cli/test/preset-script-cli.test.ts` in `integration`.
- No new `packages/**` or `tools/**` test files were added, so `tools/test-tier-manifest.mjs` did not need changes.

## Slow-test note

The slow-test summary remains led by existing integration tests such as `P16 lifecycle provenance flags write auditable task notes` and `CLI task delete soft tombstones and hard delete rejects archived terminal or related tasks`.