### PR TITLE
[codex] fix self-host harness git boundary

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -146,9 +146,20 @@ function toCliError(error: ArtifactStoreError | EngineError | WriteError): CliRe
     return { code: "task_not_found", hint: `task not found: ${error.taskId}` };
   }
   if (error._tag === "JournalUnavailable") {
-    return { code: "journal_unavailable", hint: "Journal is unavailable." };
+    const cause = journalUnavailableCause(error.cause);
+    return { code: "journal_unavailable", hint: cause ? `Journal is unavailable: ${cause}` : "Journal is unavailable." };
   }
   return { code: error._tag, hint: "Command failed." };
+}
+
+function journalUnavailableCause(cause: unknown): string {
+  if (cause instanceof Error) return firstLine(cause.message);
+  if (typeof cause === "string") return firstLine(cause);
+  return "";
+}
+
+function firstLine(value: string): string {
+  return value.trim().split(/\r?\n/u).find((line) => line.trim().length > 0)?.trim() ?? "";
 }
 
 function emit(result: CliResult, json: boolean): void {

--- a/packages/cli/test/self-host-git-boundary-cli.test.ts
+++ b/packages/cli/test/self-host-git-boundary-cli.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+
+test("CLI reports actionable journal cause when authored root is ignored without nested Git repo", () => {
+  withTempRoot((rootDir) => {
+    runGit(rootDir, "init");
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    runGit(rootDir, "add", ".gitignore");
+    runGit(rootDir, "commit", "-m", "ignore private harness");
+    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+    writeFileSync(path.join(rootDir, "harness/harness.yaml"), [
+      "schema: harness-anything/v1",
+      "name: ignored-authored-root",
+      "layout:",
+      "  authoredRoot: harness",
+      "  localRoot: .harness",
+      "tasks:",
+      "  root: harness/planning/tasks",
+      ""
+    ].join("\n"), "utf8");
+
+    const failure = runJson(rootDir, ["new-task", "--title", "Ignored Root"], false);
+
+    assert.equal(failure.ok, false);
+    assert.equal(failure.error?.code, "journal_unavailable");
+    assert.match(failure.error?.hint, /authored root is ignored by Git but is not a nested Git repository/);
+    assert.equal(JSON.stringify(failure).includes(rootDir), false);
+  });
+});
+
+function withTempRoot<T>(fn: (rootDir: string) => T): T {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-cli-boundary-"));
+  try {
+    return fn(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, any> {
+  try {
+    const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+      encoding: "utf8"
+    });
+    return JSON.parse(stdout) as Record<string, any>;
+  } catch (error) {
+    if (expectSuccess) throw error;
+    const failure = error as { readonly stdout?: string };
+    return JSON.parse(failure.stdout ?? "{}") as Record<string, any>;
+  }
+}
+
+function runGit(rootDir: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Harness Test",
+      GIT_AUTHOR_EMAIL: "harness-test@example.invalid",
+      GIT_COMMITTER_NAME: "Harness Test",
+      GIT_COMMITTER_EMAIL: "harness-test@example.invalid"
+    }
+  }).trim();
+}

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import type { DocumentWrite } from "../ports/artifact-store-writer.ts";
@@ -351,32 +351,80 @@ function toDocumentWrite(op: WriteOp): DocumentWrite {
 }
 
 function commitTouchedPaths(rootDir: string, touchedPaths: ReadonlyArray<string>, opIds: ReadonlyArray<string>): string {
-  if (touchedPaths.length === 0 || !isGitRepo(rootDir)) return "no-git-change";
+  if (touchedPaths.length === 0) return "no-git-change";
 
-  const relativePaths = touchedPaths.map((filePath) => path.relative(rootDir, filePath));
-  execFileSync("git", ["-C", rootDir, "add", "--", ...relativePaths], { stdio: "ignore" });
-  const staged = execFileSync("git", ["-C", rootDir, "diff", "--cached", "--name-only"], { encoding: "utf8" }).trim();
+  const target = resolveCommitTarget(rootDir, resolveHarnessLayout(rootDir).authoredRoot);
+  if (!target) return "no-git-change";
+
+  const relativePaths = unique(touchedPaths.map((filePath) => repoRelativePath(target.repoRoot, filePath)));
+  runGit(target.repoRoot, "add", "--", ...relativePaths);
+  const staged = runGit(target.repoRoot, "diff", "--cached", "--name-only").trim();
   if (staged.length === 0) return currentGitHead(rootDir);
 
-  execFileSync("git", ["-C", rootDir, "commit", "-m", `harness write ${opIds.join(",")}`], {
-    stdio: "ignore",
-    env: {
-      ...process.env,
-      GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Harness Anything",
-      GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? "harness@example.invalid",
-      GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Harness Anything",
-      GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "harness@example.invalid"
-    }
-  });
-  return currentGitHead(rootDir);
+  runGit(target.repoRoot, "commit", "-m", `harness write ${opIds.join(",")}`);
+  return currentGitHead(target.repoRoot);
 }
 
 function isGitRepo(rootDir: string): boolean {
+  return gitTopLevel(rootDir) !== null;
+}
+
+function resolveCommitTarget(rootDir: string, authoredRoot: string): { readonly repoRoot: string } | null {
+  const rootRepo = gitTopLevel(rootDir);
+  const authoredRepo = gitTopLevel(authoredRoot);
+  if (!authoredRepo) return rootRepo ? { repoRoot: rootRepo } : null;
+  if (rootRepo && authoredRepo === rootRepo && isIgnoredByRepo(rootRepo, authoredRoot)) {
+    throw new Error("authored root is ignored by Git but is not a nested Git repository");
+  }
+  return { repoRoot: authoredRepo };
+}
+
+function gitTopLevel(inputPath: string): string | null {
   try {
-    execFileSync("git", ["-C", rootDir, "rev-parse", "--is-inside-work-tree"], { stdio: "ignore" });
+    return normalizeExistingPath(execFileSync("git", ["-C", inputPath, "rev-parse", "--show-toplevel"], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim());
+  } catch {
+    return null;
+  }
+}
+
+function isIgnoredByRepo(repoRoot: string, candidatePath: string): boolean {
+  const relativePath = repoRelativePath(repoRoot, candidatePath);
+  try {
+    execFileSync("git", ["-C", repoRoot, "check-ignore", "-q", "--", relativePath], { stdio: "ignore" });
     return true;
   } catch {
     return false;
+  }
+}
+
+function repoRelativePath(repoRoot: string, filePath: string): string {
+  const relativePath = path.relative(normalizeExistingPath(repoRoot), normalizeExistingPath(filePath));
+  if (relativePath.length === 0) return ".";
+  if (relativePath === ".." || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+    throw new Error("touched path is outside commit repository");
+  }
+  return relativePath.split(path.sep).join("/");
+}
+
+function normalizeExistingPath(inputPath: string): string {
+  return existsSync(inputPath) ? realpathSync(inputPath) : path.resolve(inputPath);
+}
+
+function runGit(repoRoot: string, ...args: ReadonlyArray<string>): string {
+  try {
+    return execFileSync("git", ["-C", repoRoot, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Harness Anything",
+        GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? "harness@example.invalid",
+        GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Harness Anything",
+        GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "harness@example.invalid"
+      }
+    });
+  } catch (error) {
+    throw new Error(`git ${args[0] ?? "command"} failed: ${gitErrorMessage(error)}`);
   }
 }
 
@@ -386,6 +434,21 @@ function currentGitHead(rootDir: string): string {
   } catch {
     return "no-git-head";
   }
+}
+
+function unique(values: ReadonlyArray<string>): ReadonlyArray<string> {
+  return [...new Set(values)];
+}
+
+function gitErrorMessage(error: unknown): string {
+  if (typeof error === "object" && error && "stderr" in error) {
+    const stderr = (error as { readonly stderr?: unknown }).stderr;
+    const text = Buffer.isBuffer(stderr) ? stderr.toString("utf8") : typeof stderr === "string" ? stderr : "";
+    const firstLine = text.trim().split(/\r?\n/u).find((line) => line.trim().length > 0);
+    if (firstLine) return firstLine;
+  }
+  if (error instanceof Error) return error.message.split(/\r?\n/u)[0] ?? error.message;
+  return String(error);
 }
 
 function rebuildProjectionHash(rootDir: string): string {

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import { hashTaskProjectionRows, rebuildTaskProjection } from "../../src/index.ts";
@@ -86,6 +87,57 @@ test("WriteCoordinator bounds committed op ids in watermark after successful com
   });
 });
 
+test("WriteCoordinator commits self-host authored writes inside ignored nested harness repo", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    runGit(rootDir, "add", ".gitignore");
+    runGit(rootDir, "commit", "-m", "ignore private harness");
+
+    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+    initializeGitRepo(path.join(rootDir, "harness"));
+    writeFileSync(path.join(rootDir, "harness/harness.yaml"), [
+      "schema: harness-anything/v1",
+      "name: self-host-fixture",
+      "layout:",
+      "  authoredRoot: harness",
+      "  localRoot: .harness",
+      "tasks:",
+      "  root: harness/planning/tasks",
+      ""
+    ].join("\n"), "utf8");
+
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(coordinator.enqueue(docWrite("op-nested", "task-1", "notes.md", "nested")));
+    const report = Effect.runSync(coordinator.flush("explicit"));
+
+    assert.equal(report.watermark, "op-nested");
+    assert.equal(readFileSync(path.join(rootDir, "harness/planning/tasks/task-1/notes.md"), "utf8"), "nested");
+    assert.match(runGit(path.join(rootDir, "harness"), "log", "--oneline", "-1"), /harness write op-nested/);
+    assert.equal(runGit(rootDir, "status", "--short"), "");
+    assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/watermark.json")), true);
+  });
+});
+
+test("WriteCoordinator fails closed when ignored authored root has no nested Git repo", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    runGit(rootDir, "add", ".gitignore");
+    runGit(rootDir, "commit", "-m", "ignore private harness");
+    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(coordinator.enqueue(docWrite("op-ignored", "task-1", "notes.md", "ignored")));
+
+    assert.throws(
+      () => Effect.runSync(coordinator.flush("explicit")),
+      /authored root is ignored by Git but is not a nested Git repository/
+    );
+    assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/watermark.json")), false);
+  });
+});
+
 function indexBody(taskId: string, title: string, status: string): string {
   return [
     "---",
@@ -109,4 +161,21 @@ function indexBody(taskId: string, title: string, status: string): string {
     `# ${title}`,
     ""
   ].join("\n");
+}
+
+function initializeGitRepo(repoRoot: string): void {
+  runGit(repoRoot, "init");
+}
+
+function runGit(repoRoot: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Harness Test",
+      GIT_AUTHOR_EMAIL: "harness-test@example.invalid",
+      GIT_COMMITTER_NAME: "Harness Test",
+      GIT_COMMITTER_EMAIL: "harness-test@example.invalid"
+    }
+  }).trim();
 }

--- a/tools/check-legacy-intake-readiness.mjs
+++ b/tools/check-legacy-intake-readiness.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
@@ -256,6 +257,7 @@ async function collectPublicTextFiles(root) {
       if (rel.startsWith("node_modules/") || rel.startsWith(".git/") || rel.startsWith(".harness") || rel.startsWith("dist/") || rel.startsWith("coverage/")) {
         return false;
       }
+      if (isGitIgnored(root, rel)) return false;
       // AGENTS.md / CLAUDE.md are local-only agent entries; check-private-boundary
       // enforces they stay untracked, so they are not public text.
       if (rel === "AGENTS.md" || rel === "CLAUDE.md") return false;
@@ -263,6 +265,15 @@ async function collectPublicTextFiles(root) {
       if (/(?:^|\/)(?:test|tests|fixtures|__fixtures__)\//u.test(rel)) return false;
       return rel.endsWith(".md") || rel.endsWith(".yml") || rel.endsWith(".yaml") || rel.endsWith("package.json");
     });
+}
+
+function isGitIgnored(root, rel) {
+  try {
+    execFileSync("git", ["-C", root, "check-ignore", "-q", "--", rel], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function collectFiles(directory) {

--- a/tools/check-legacy-intake-readiness.test.mjs
+++ b/tools/check-legacy-intake-readiness.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -41,6 +42,34 @@ test("Legacy Intake readiness ignores private harness files inside local worktre
     const violations = await evaluateLegacyIntakeReadiness(root);
 
     assert.deepEqual(violations, []);
+  });
+});
+
+test("Legacy Intake readiness ignores git-ignored self-host harness files", async () => {
+  await withFixtureRepo(async (root) => {
+    runGit(root, "init");
+    writeFileSync(path.join(root, ".gitignore"), "/harness/\n", "utf8");
+    mkdirSync(path.join(root, "harness/legacy/tasks/old"), { recursive: true });
+    writeFileSync(path.join(root, "harness/legacy/tasks/old/task_plan.md"), [
+      "This private legacy evidence may mention scripts/kernel/task.",
+      "It may also mention full-cutover and coding-agent-harness compatibility.",
+      ""
+    ].join("\n"));
+
+    const violations = await evaluateLegacyIntakeReadiness(root);
+
+    assert.deepEqual(violations, []);
+  });
+});
+
+test("Legacy Intake readiness still scans non-ignored harness public text", async () => {
+  await withFixtureRepo(async (root) => {
+    mkdirSync(path.join(root, "harness/planning/tasks/old"), { recursive: true });
+    writeFileSync(path.join(root, "harness/planning/tasks/old/task_plan.md"), "Use scripts/kernel/task in public docs.\n");
+
+    const violations = await evaluateLegacyIntakeReadiness(root);
+
+    assert.equal(violations.some((violation) => violation.includes("harness/planning/tasks/old/task_plan.md")), true);
   });
 });
 
@@ -345,4 +374,8 @@ function writeValidBehaviorCorpus(root) {
       { classification: "unsupported-input", summary: "npm publishing deferred" }
     ]
   }));
+}
+
+function runGit(root, ...args) {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
 }

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -61,6 +61,7 @@ export const testTierManifest = {
     "packages/cli/test/preset-module-cli.test.ts",
     "packages/cli/test/preset-script-cli.test.ts",
     "packages/cli/test/settings-cli.test.ts",
+    "packages/cli/test/self-host-git-boundary-cli.test.ts",
     "packages/cli/test/task-list-cli.test.ts",
     "packages/kernel/test/store/crash-before-watermark.test.ts",
     "packages/kernel/test/store/global-committer-lock.test.ts",


### PR DESCRIPTION
## Summary

- commit harness-authored writes in the Git repository that owns the authored root, including ignored nested self-host repos
- fail closed with an actionable journal error when an ignored authored root is not a nested Git repository
- keep legacy intake readiness from scanning private git-ignored harness worktrees as public text

## Root cause

The write journal coordinator always committed from the public repository root. When the private `harness/` authored root is git-ignored by the public repo but is itself a nested Git repository, the coordinator staged paths against the wrong repo and surfaced a generic journal failure.

## Validation

- `npm run check`
  - 388 Node tests passed
  - file complexity, CLI structure, import boundaries, private boundary, release readiness, schema contracts, legacy intake readiness, supply chain, legacy intake smoke, and CLI package smoke passed
