### PR TITLE
fix(git): raise status buffer for large worktrees

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1128,9 +1128,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/packages/adapters/local/src/git-diff-evidence.ts
+++ b/packages/adapters/local/src/git-diff-evidence.ts
@@ -1,5 +1,7 @@
 import { execFileSync } from "node:child_process";
 
+const gitMaxBuffer = 256 * 1024 * 1024;
+
 export interface GitDiffEvidenceOptions {
   readonly rootDir: string;
   readonly baseRef?: string;
@@ -131,10 +133,19 @@ function readGit(rootDir: string, args: ReadonlyArray<string>): { readonly ok: t
       ok: true,
       stdout: execFileSync("git", ["-C", rootDir, ...args], {
         encoding: "utf8",
+        maxBuffer: gitMaxBuffer,
         stdio: ["ignore", "pipe", "ignore"]
       })
     };
-  } catch {
-    return { ok: false, error: "git command unavailable for this repository" };
+  } catch (error) {
+    return { ok: false, error: gitErrorMessage(error) };
   }
+}
+
+function gitErrorMessage(error: unknown): string {
+  if (typeof error === "object" && error && "code" in error && typeof (error as { readonly code?: unknown }).code === "string") {
+    const code = (error as { readonly code: string }).code;
+    if (code.length > 0) return `git command failed: ${code}`;
+  }
+  return "git command unavailable for this repository";
 }

--- a/packages/cli/test/attribution-diff-cli.test.ts
+++ b/packages/cli/test/attribution-diff-cli.test.ts
@@ -71,6 +71,30 @@ test("git-diff emits stable read-only evidence without creating harness state or
   });
 });
 
+test("git-diff handles status output larger than Node's default exec buffer", () => {
+  withTempRoot((rootDir) => {
+    initGit(rootDir);
+    configureGitUser(rootDir, "Diff User", "diff@example.com");
+    writeFileSync(path.join(rootDir, "README.md"), "baseline\n", "utf8");
+    execFileSync("git", ["add", "README.md"], { cwd: rootDir, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "init"], { cwd: rootDir, stdio: "ignore" });
+
+    const segment = "nested-status-output-" + "x".repeat(150);
+    const deepDir = path.join(rootDir, segment, segment, segment, segment);
+    mkdirSync(deepDir, { recursive: true });
+    for (let index = 0; index < 1600; index += 1) {
+      writeFileSync(path.join(deepDir, `untracked-${String(index).padStart(4, "0")}.txt`), "status\n", "utf8");
+    }
+
+    const result = runJson(rootDir, ["git-diff"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.report.schema, "git-diff-evidence/v1");
+    assert.equal(result.report.fileCount, 1600);
+    assert.equal(result.report.files.every((file: Record<string, unknown>) => file.status === "untracked"), true);
+  });
+});
+
 function initGit(rootDir: string): void {
   execFileSync("git", ["init"], { cwd: rootDir, stdio: "ignore" });
 }
@@ -99,6 +123,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
+      maxBuffer: 256 * 1024 * 1024,
       env: { ...process.env, ...env }
     });
     return JSON.parse(stdout) as Record<string, any>;

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -33,6 +33,7 @@ const defaultActor: JournalActor = { kind: "agent", id: "local" };
 // Flush writes the full op-id set before compaction for recovery safety, then
 // trims to a bounded recent-id window only after journal compaction succeeds.
 const maxWatermarkCommittedOpIds = 128;
+const gitMaxBuffer = 256 * 1024 * 1024;
 
 export function makeJournaledWriteCoordinator(options: JournaledWriteCoordinatorOptions): WriteCoordinator {
   const rootDir = path.resolve(options.rootDir);
@@ -354,11 +355,12 @@ function commitTouchedPaths(rootDir: string, touchedPaths: ReadonlyArray<string>
   if (touchedPaths.length === 0 || !isGitRepo(rootDir)) return "no-git-change";
 
   const relativePaths = touchedPaths.map((filePath) => path.relative(rootDir, filePath));
-  execFileSync("git", ["-C", rootDir, "add", "--", ...relativePaths], { stdio: "ignore" });
-  const staged = execFileSync("git", ["-C", rootDir, "diff", "--cached", "--name-only"], { encoding: "utf8" }).trim();
+  execFileSync("git", ["-C", rootDir, "add", "--", ...relativePaths], { maxBuffer: gitMaxBuffer, stdio: "ignore" });
+  const staged = execFileSync("git", ["-C", rootDir, "diff", "--cached", "--name-only"], { encoding: "utf8", maxBuffer: gitMaxBuffer }).trim();
   if (staged.length === 0) return currentGitHead(rootDir);
 
   execFileSync("git", ["-C", rootDir, "commit", "-m", `harness write ${opIds.join(",")}`], {
+    maxBuffer: gitMaxBuffer,
     stdio: "ignore",
     env: {
       ...process.env,
@@ -373,7 +375,7 @@ function commitTouchedPaths(rootDir: string, touchedPaths: ReadonlyArray<string>
 
 function isGitRepo(rootDir: string): boolean {
   try {
-    execFileSync("git", ["-C", rootDir, "rev-parse", "--is-inside-work-tree"], { stdio: "ignore" });
+    execFileSync("git", ["-C", rootDir, "rev-parse", "--is-inside-work-tree"], { maxBuffer: gitMaxBuffer, stdio: "ignore" });
     return true;
   } catch {
     return false;
@@ -382,7 +384,7 @@ function isGitRepo(rootDir: string): boolean {
 
 function currentGitHead(rootDir: string): string {
   try {
-    return execFileSync("git", ["-C", rootDir, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    return execFileSync("git", ["-C", rootDir, "rev-parse", "HEAD"], { encoding: "utf8", maxBuffer: gitMaxBuffer }).trim();
   } catch {
     return "no-git-head";
   }


### PR DESCRIPTION
## Summary

Raises Git command buffers on the new runtime paths that can inspect large worktrees, refreshes the vulnerable `undici` lockfile entry, and adds regression coverage for large `git status --porcelain -z` output.

## What Changed

- Added a 256MB Git exec buffer to local `git-diff` evidence collection.
- Preserved Git exec error codes such as `ENOBUFS` in the local adapter error text.
- Added matching buffer coverage to the kernel write coordinator Git exec calls.
- Added a CLI regression test with large untracked status output.
- Updated the lockfile-selected optional `undici` package from `7.27.2` to `7.28.0` to clear the supply-chain audit advisory.

## Task And Scope

- Harness task: `2026-06-29-transaction-git-status-enobufs`
- Branch: `codex/transaction-git-status-enobufs`
- Public scope: local adapter git-diff evidence, kernel write coordinator Git exec calls, CLI attribution/diff test, package-lock supply-chain refresh.
- Private planning/evidence updated: not applicable in this public PR.
- Out of scope: package publishing, unrelated preset/lifecycle changes.

## Version Impact

- Version: no version change because this is a runtime robustness bug fix for a later release task.
- Publish impact: publish intended in a separate release task.

## Verification

- Base `origin/main` SHA: `597e929e3cc0a54b337b0a78a59045ec4b3a2876`
- Branch merge-base with `origin/main`: `597e929e3cc0a54b337b0a78a59045ec4b3a2876`
- Last `git fetch origin` time: `2026-06-29T13:59:41Z`
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: not applicable
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28379083021
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` as a standalone verification command; `npm ci --ignore-scripts` was run locally before re-running supply-chain to populate workspace dependencies for SBOM generation.

## Review Evidence

- Self-review: committed from a clean worktree based on latest `origin/main`; diff limited to scoped public files and package-lock refresh.
- Reviewer subagent: none.
- Human review: pending.
- Blocking findings: none.

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear.

## Residual Risk

- This PR increases buffers but does not stream Git output. That is acceptable for the current CLI evidence paths; a future change can switch large evidence collectors to streaming if memory pressure appears.

## References

- Task: `2026-06-29-transaction-git-status-enobufs`
- Evidence: `node --test packages/cli/test/attribution-diff-cli.test.ts`; `npm run typecheck`; `git diff --check`; `npm run harness:check-supply-chain`; `npm run check`; GitHub Actions run above.
- Review: pending human review.

---

## 摘要

提高新版运行时中会检查大工作树的 Git 命令 buffer，刷新 vulnerable `undici` lockfile 记录，并补充大 `git status --porcelain -z` 输出的回归测试。

## 改动内容

- local `git-diff` evidence 采集增加 256MB Git exec buffer。
- local adapter 错误文本保留 `ENOBUFS` 等 Git exec 错误码。
- kernel write coordinator 的 Git exec 调用增加同等 buffer。
- 增加 CLI 大量 untracked status 输出回归测试。
- 将 lockfile 中 optional `undici` 从 `7.27.2` 更新到 `7.28.0`，解除 supply-chain audit advisory。

## 任务与范围

- Harness 任务：`2026-06-29-transaction-git-status-enobufs`
- 分支：`codex/transaction-git-status-enobufs`
- 公开范围：local adapter git-diff evidence、kernel write coordinator Git exec、CLI attribution/diff test、package-lock supply-chain refresh。
- 私有计划 / 证据是否已更新：not applicable
- 范围外：npm 发布、无关 preset/lifecycle 改动。

## 版本影响

- 版本：不改版本，原因是此 PR 是进入后续 release task 的运行时健壮性修复。
- 发布影响：发布放到独立 release task。

## 验证

- `origin/main` 基准 SHA：`597e929e3cc0a54b337b0a78a59045ec4b3a2876`
- 当前分支与 `origin/main` 的 merge-base：`597e929e3cc0a54b337b0a78a59045ec4b3a2876`
- 最近一次 `git fetch origin` 时间：`2026-06-29T13:59:41Z`
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：not applicable
- Reviewer 证据路径：not applicable
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28379083021
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：单独的 `npm ci` 验证命令；本地曾运行 `npm ci --ignore-scripts` 以安装 workspace deps，随后重新跑 supply-chain/SBOM gate。

## 审查证据

- 自查：从 latest `origin/main` 干净 worktree 提交；diff 限定在任务范围公开文件和 package-lock refresh。
- Reviewer subagent：无。
- 人工审查：pending。
- 阻塞发现：无。

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚。

## 残余风险

- 本 PR 增大 buffer，但没有把 Git 输出改为 streaming。对当前 CLI evidence 路径可接受；若后续出现内存压力，可单独把大 evidence collector 改为 streaming。

## 关联材料

- 任务：`2026-06-29-transaction-git-status-enobufs`
- 证据：`node --test packages/cli/test/attribution-diff-cli.test.ts`；`npm run typecheck`；`git diff --check`；`npm run harness:check-supply-chain`；`npm run check`；GitHub Actions run 见上文。
- 审查：pending human review。
