### PR TITLE
chore(gui): refresh Electron to 42.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -530,9 +530,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.4.0.tgz",
-      "integrity": "sha512-OXXqh9LD9KxXPv2Fe25EfU9N9AvWTuV6V81sfhQaNvTAXCd9ONA+Q4OWvMe+CmYD6xIwjFxGGtG/ZphDYYC5OQ==",
+      "version": "42.5.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.5.1.tgz",
+      "integrity": "sha512-2VFNJcHHbrhIpGsJHdkLoi/nWPZPxN3GHVPe+9At3Oz3/TJRwpr+7JL97ddBDbKyLmHGx3GfI2jvzcEQL28uFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1193,7 +1193,7 @@
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.2",
-        "electron": "42.4.0",
+        "electron": "42.5.1",
         "vite": "8.0.16"
       }
     },

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -20,7 +20,7 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",
-    "electron": "42.4.0",
+    "electron": "42.5.1",
     "vite": "8.0.16"
   }
 }


### PR DESCRIPTION
## Summary

- refresh @harness-anything/gui Electron dev dependency from 42.4.0 to 42.5.1
- update root package-lock metadata for the Electron tarball

## Verification

- npm --workspace @harness-anything/gui run build
- npm run harness:check-package-policy
- npm run harness:check-supply-chain
- npm run check:pr

## Notes

The self-host Git boundary part of the stale PR consolidation task is already present on main via PR #71. Effect and @types/node remain intentionally pinned by implementation contracts.