### PR TITLE
[codex] Fix write journal preflight and commit scope

### DIFF
--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -48,6 +48,7 @@ export function makeJournaledWriteCoordinator(options: JournaledWriteCoordinator
     enqueue: (op) => Effect.try({
       try: (): WriteAck => {
         validateOp(rootDir, op);
+        preflightWriteOp(rootDir, op);
         const state = readDurableState(journalPath, watermarkPath, rootDir);
         if (state.applied.has(op.opId) || state.records.some((record) => record.opId === op.opId) || pending.some((item) => item.opId === op.opId)) {
           return { opId: op.opId, taskId: op.taskId, accepted: true };
@@ -94,10 +95,16 @@ function flushRecords(
 ): FlushReport {
   const touchedPaths: string[] = [];
   const committedOpIds: string[] = [];
+  const plannedRecords = records.map((record) => ({
+    record,
+    touchedPaths: recordTouchedPaths(rootDir, record)
+  }));
 
-  for (const record of records) {
+  resolveCommitPlan(rootDir, plannedRecords.flatMap((record) => record.touchedPaths));
+
+  for (const { record, touchedPaths: recordTouchedPaths } of plannedRecords) {
     applyRecord(rootDir, journalPath, record);
-    touchedPaths.push(resolveHarnessLayout(rootDir).authoredRoot);
+    touchedPaths.push(...recordTouchedPaths);
     committedOpIds.push(record.opId);
   }
 
@@ -198,6 +205,10 @@ function createJournalRecord(rootDir: string, journalPath: string, op: {
   };
 }
 
+function preflightWriteOp(rootDir: string, op: WriteOp): void {
+  resolveCommitPlan(rootDir, opTouchedPaths(rootDir, op));
+}
+
 function recordToOp(rootDir: string, record: JournalRecord): WriteOp {
   const payload = readVerifiedPayload(rootDir, record);
   return {
@@ -255,6 +266,26 @@ function writeDocumentsAtomically(rootDir: string, writes: ReadonlyArray<Documen
     }
     throw error;
   }
+}
+
+function recordTouchedPaths(rootDir: string, record: JournalRecord): ReadonlyArray<string> {
+  if (record.kind === "package_delete_hard") {
+    return [taskPackagePath(rootDir, record.taskId)];
+  }
+  return opTouchedPaths(rootDir, recordToOp(rootDir, record));
+}
+
+function opTouchedPaths(rootDir: string, op: WriteOp): ReadonlyArray<string> {
+  if ((op.kind === "package_create" || op.kind === "package_supersede") && isBatchDocumentWritePayload(op.payload)) {
+    return op.payload.writes.map((write) => documentTargetPath(rootDir, write));
+  }
+  if (op.kind === "package_delete_hard") {
+    return [taskPackagePath(rootDir, op.taskId)];
+  }
+  if (!documentWriteKinds.has(op.kind)) {
+    throw new Error(`unsupported write op kind: ${op.kind}`);
+  }
+  return [documentTargetPath(rootDir, toDocumentWrite(op))];
 }
 
 function documentTargetPath(rootDir: string, write: DocumentWrite): string {
@@ -354,16 +385,25 @@ function toDocumentWrite(op: WriteOp): DocumentWrite {
 function commitTouchedPaths(rootDir: string, touchedPaths: ReadonlyArray<string>, opIds: ReadonlyArray<string>): string {
   if (touchedPaths.length === 0) return "no-git-change";
 
+  const plan = resolveCommitPlan(rootDir, touchedPaths);
+  if (!plan) return "no-git-change";
+
+  runGit(plan.repoRoot, "add", "--", ...plan.relativePaths);
+  const staged = runGit(plan.repoRoot, "diff", "--cached", "--name-only", "--", ...plan.relativePaths).trim();
+  if (staged.length === 0) return currentGitHead(plan.repoRoot);
+
+  runGit(plan.repoRoot, "commit", "-m", `harness write ${opIds.join(",")}`);
+  return currentGitHead(plan.repoRoot);
+}
+
+function resolveCommitPlan(rootDir: string, touchedPaths: ReadonlyArray<string>): { readonly repoRoot: string; readonly relativePaths: ReadonlyArray<string> } | null {
+  if (touchedPaths.length === 0) return null;
   const target = resolveCommitTarget(rootDir, resolveHarnessLayout(rootDir).authoredRoot);
-  if (!target) return "no-git-change";
-
-  const relativePaths = unique(touchedPaths.map((filePath) => repoRelativePath(target.repoRoot, filePath)));
-  runGit(target.repoRoot, "add", "--", ...relativePaths);
-  const staged = runGit(target.repoRoot, "diff", "--cached", "--name-only").trim();
-  if (staged.length === 0) return currentGitHead(target.repoRoot);
-
-  runGit(target.repoRoot, "commit", "-m", `harness write ${opIds.join(",")}`);
-  return currentGitHead(target.repoRoot);
+  if (!target) return null;
+  return {
+    repoRoot: target.repoRoot,
+    relativePaths: unique(touchedPaths.map((filePath) => repoRelativePath(target.repoRoot, filePath)))
+  };
 }
 
 function isGitRepo(rootDir: string): boolean {
@@ -408,7 +448,18 @@ function repoRelativePath(repoRoot: string, filePath: string): string {
 }
 
 function normalizeExistingPath(inputPath: string): string {
-  return existsSync(inputPath) ? realpathSync(inputPath) : path.resolve(inputPath);
+  const resolved = path.resolve(inputPath);
+  if (existsSync(resolved)) return realpathSync.native(resolved);
+
+  const pendingSegments: string[] = [];
+  let current = resolved;
+  while (!existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) return resolved;
+    pendingSegments.unshift(path.basename(current));
+    current = parent;
+  }
+  return path.join(realpathSync.native(current), ...pendingSegments);
 }
 
 function runGit(repoRoot: string, ...args: ReadonlyArray<string>): string {
@@ -513,7 +564,14 @@ function toJournalError(cause: unknown): WriteError {
       owner: message
     };
   }
-  if (message.includes("unsupported write op kind") || message.includes("payload") || message.includes("hard delete forbidden")) {
+  if (
+    message.includes("unsupported write op kind") ||
+    message.includes("payload") ||
+    message.includes("hard delete forbidden") ||
+    message.includes("absolute paths are not allowed") ||
+    message.includes("path escapes") ||
+    message.includes("invalid document path")
+  ) {
     return {
       _tag: "WriteRejected",
       taskId: "unknown",

--- a/packages/kernel/test/store/global-committer-lock.test.ts
+++ b/packages/kernel/test/store/global-committer-lock.test.ts
@@ -15,17 +15,16 @@ test("WriteCoordinator rejects semantic writes without document payload", () => 
   withTempStore((rootDir) => {
     const coordinator = makeJournaledWriteCoordinator({ rootDir });
 
-    Effect.runSync(coordinator.enqueue({
-      opId: "op-transition",
-      taskId: "task-1",
-      kind: "transition_local",
-      payload: { to: "active" }
-    }));
-
     assert.throws(
-      () => Effect.runSync(coordinator.flush("explicit")),
+      () => Effect.runSync(coordinator.enqueue({
+        opId: "op-transition",
+        taskId: "task-1",
+        kind: "transition_local",
+        payload: { to: "active" }
+      })),
       /requires path and body payload/
     );
+    assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
   });
 });
 
@@ -33,22 +32,21 @@ test("WriteCoordinator validates supersede batch before writing any document", (
   withTempStore((rootDir) => {
     const coordinator = makeJournaledWriteCoordinator({ rootDir });
 
-    Effect.runSync(coordinator.enqueue({
-      opId: "op-supersede-batch-invalid",
-      taskId: "task-old",
-      kind: "package_supersede",
-      payload: {
-        writes: [
-          { taskId: "task-old", path: "INDEX.md", body: "old archived", packageSlug: "old" },
-          { taskId: "task-new", path: "/absolute.md", body: "new", packageSlug: "new" }
-        ]
-      }
-    }));
-
     assert.throws(
-      () => Effect.runSync(coordinator.flush("explicit")),
+      () => Effect.runSync(coordinator.enqueue({
+        opId: "op-supersede-batch-invalid",
+        taskId: "task-old",
+        kind: "package_supersede",
+        payload: {
+          writes: [
+            { taskId: "task-old", path: "INDEX.md", body: "old archived", packageSlug: "old" },
+            { taskId: "task-new", path: "/absolute.md", body: "new", packageSlug: "new" }
+          ]
+        }
+      })),
       /absolute paths are not allowed/
     );
+    assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
     assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks/task-old-old/INDEX.md")), false);
     assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks/task-new-new/absolute.md")), false);
   });
@@ -58,22 +56,21 @@ test("WriteCoordinator validates package create batch before writing any documen
   withTempStore((rootDir) => {
     const coordinator = makeJournaledWriteCoordinator({ rootDir });
 
-    Effect.runSync(coordinator.enqueue({
-      opId: "op-create-batch-invalid",
-      taskId: "task-new",
-      kind: "package_create",
-      payload: {
-        writes: [
-          { taskId: "task-new", path: "INDEX.md", body: "index", packageSlug: "new" },
-          { taskId: "task-new", path: "/absolute.md", body: "bad", packageSlug: "new" }
-        ]
-      }
-    }));
-
     assert.throws(
-      () => Effect.runSync(coordinator.flush("explicit")),
+      () => Effect.runSync(coordinator.enqueue({
+        opId: "op-create-batch-invalid",
+        taskId: "task-new",
+        kind: "package_create",
+        payload: {
+          writes: [
+            { taskId: "task-new", path: "INDEX.md", body: "index", packageSlug: "new" },
+            { taskId: "task-new", path: "/absolute.md", body: "bad", packageSlug: "new" }
+          ]
+        }
+      })),
       /absolute paths are not allowed/
     );
+    assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
     assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks/task-new-new/INDEX.md")), false);
     assert.equal(existsSync(path.join(rootDir, "harness/planning/tasks/task-new-new/absolute.md")), false);
   });

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -106,6 +106,11 @@ test("WriteCoordinator commits self-host authored writes inside ignored nested h
       "  root: harness/planning/tasks",
       ""
     ].join("\n"), "utf8");
+    mkdirSync(path.join(rootDir, "harness/notes"), { recursive: true });
+    writeFileSync(path.join(rootDir, "harness/notes/unrelated.md"), "before\n", "utf8");
+    runGit(path.join(rootDir, "harness"), "add", ".");
+    runGit(path.join(rootDir, "harness"), "commit", "-m", "seed nested harness");
+    writeFileSync(path.join(rootDir, "harness/notes/unrelated.md"), "after\n", "utf8");
 
     const coordinator = makeJournaledWriteCoordinator({ rootDir });
     Effect.runSync(coordinator.enqueue(docWrite("op-nested", "task-1", "notes.md", "nested")));
@@ -114,8 +119,45 @@ test("WriteCoordinator commits self-host authored writes inside ignored nested h
     assert.equal(report.watermark, "op-nested");
     assert.equal(readFileSync(path.join(rootDir, "harness/planning/tasks/task-1/notes.md"), "utf8"), "nested");
     assert.match(runGit(path.join(rootDir, "harness"), "log", "--oneline", "-1"), /harness write op-nested/);
+    assert.equal(runGit(path.join(rootDir, "harness"), "show", "--name-only", "--format=", "HEAD"), "planning/tasks/task-1/notes.md");
+    assert.equal(runGit(path.join(rootDir, "harness"), "status", "--short"), "M notes/unrelated.md");
     assert.equal(runGit(rootDir, "status", "--short"), "");
     assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/watermark.json")), true);
+  });
+});
+
+test("WriteCoordinator accepts non-native case root paths on case-insensitive filesystems", (t) => {
+  withTempStore((rootDir) => {
+    const variantRoot = caseVariantPath(rootDir);
+    if (!variantRoot || !existsSync(variantRoot)) {
+      t.skip("filesystem does not resolve mixed-case path aliases");
+      return;
+    }
+    initializeGitRepo(rootDir);
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    runGit(rootDir, "add", ".gitignore");
+    runGit(rootDir, "commit", "-m", "ignore private harness");
+
+    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+    initializeGitRepo(path.join(rootDir, "harness"));
+    writeFileSync(path.join(rootDir, "harness/harness.yaml"), [
+      "schema: harness-anything/v1",
+      "name: self-host-fixture",
+      "layout:",
+      "  authoredRoot: harness",
+      "  localRoot: .harness",
+      "tasks:",
+      "  root: harness/planning/tasks",
+      ""
+    ].join("\n"), "utf8");
+
+    const coordinator = makeJournaledWriteCoordinator({ rootDir: variantRoot });
+    Effect.runSync(coordinator.enqueue(docWrite("op-mixed-case", "task-1", "notes.md", "mixed")));
+    const report = Effect.runSync(coordinator.flush("explicit"));
+
+    assert.equal(report.watermark, "op-mixed-case");
+    assert.equal(readFileSync(path.join(rootDir, "harness/planning/tasks/task-1/notes.md"), "utf8"), "mixed");
+    assert.match(runGit(path.join(rootDir, "harness"), "log", "--oneline", "-1"), /harness write op-mixed-case/);
   });
 });
 
@@ -166,12 +208,12 @@ test("WriteCoordinator fails closed when ignored authored root has no nested Git
     mkdirSync(path.join(rootDir, "harness"), { recursive: true });
 
     const coordinator = makeJournaledWriteCoordinator({ rootDir });
-    Effect.runSync(coordinator.enqueue(docWrite("op-ignored", "task-1", "notes.md", "ignored")));
 
     assert.throws(
-      () => Effect.runSync(coordinator.flush("explicit")),
+      () => Effect.runSync(coordinator.enqueue(docWrite("op-ignored", "task-1", "notes.md", "ignored"))),
       /authored root is ignored by Git but is not a nested Git repository/
     );
+    assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
     assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/watermark.json")), false);
   });
 });
@@ -203,6 +245,13 @@ function indexBody(taskId: string, title: string, status: string): string {
 
 function initializeGitRepo(repoRoot: string): void {
   runGit(repoRoot, "init");
+}
+
+function caseVariantPath(inputPath: string): string | null {
+  const basename = path.basename(inputPath);
+  const toggled = basename.replace(/[A-Za-z]/u, (char) => char === char.toUpperCase() ? char.toLowerCase() : char.toUpperCase());
+  if (toggled === basename) return null;
+  return path.join(path.dirname(inputPath), toggled);
 }
 
 function runGit(repoRoot: string, ...args: ReadonlyArray<string>): string {


### PR DESCRIPTION
## Summary

- Normalize WriteCoordinator path handling with native realpaths so mixed-case macOS paths resolve to the owning repository.
- Preflight write operations before journaling so invalid commit targets or invalid document paths do not leave pending journal records.
- Limit automatic Git staging to the concrete files touched by the flushed journal records instead of staging the whole authored root.
- Extend regression coverage for mixed-case roots, ignored self-host harness roots, invalid batch payloads, and unrelated dirty files in nested harness repos.

## Root Cause

The self-host commit target used Git top-level paths with native casing while the CLI could pass a differently-cased root path. The relative-path check then treated the authored root as outside the nested Git repo. The old flush path also staged the whole authored root and only discovered commit-target failures after records were already journaled.

## Validation

- node --test packages/kernel/test/store/same-task-fifo.test.ts
- node --test packages/kernel/test/store/global-committer-lock.test.ts
- node --test packages/cli/test/self-host-git-boundary-cli.test.ts
- npm run typecheck
- npm run test:integration
- npm run check
