### PR TITLE
feat(cli): add --version and distribution/docs DX hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ tmp/
 *.log
 *.tsbuildinfo
 .harness/
+
+# release tarballs (npm pack output)
+*.tgz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,12 @@ Harness Anything is a repo-native harness. Public code and docs live in this rep
 3. Add or update tests for behavior changes.
 4. Run `npm run check` before requesting review.
 5. In the PR, list the verification commands and any deferred work.
+6. If you changed CLI code and use the built bin (`npx ha`), rebuild the
+   workspace dist (`npm run build -w @harness-anything/cli`); running from
+   source (`node packages/cli/src/index.ts`) is always fresh. Refresh a global
+   install only when cutting a version. Local distribution and release steps
+   live in the private harness `ci-cd-standard.md`; there is no public npm
+   publish yet.
 
 ## Review Expectations
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,8 @@
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node scripts/copy-assets.mjs"
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-assets.mjs",
+    "prepack": "npm run build"
   },
   "bin": {
     "harness-anything": "./dist/cli/src/index.js",

--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -12,6 +12,10 @@ export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; rea
   const help = parseHelpRequest(args, rootDir, json);
   if (help) return help;
 
+  if (args[0] === "version" || args.includes("--version") || args.includes("-v")) {
+    return { ok: true, value: { rootDir, json, action: { kind: "version" } } };
+  }
+
   const parsed = parseRegisteredCommand(args, rootDir, json);
   if (parsed) return parsed;
   return {

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -46,6 +46,7 @@ export interface CliResult {
   readonly issues?: ReadonlyArray<unknown>;
   readonly rows?: number;
   readonly warnings?: ReadonlyArray<unknown>;
+  readonly version?: string;
   readonly report?: unknown;
   readonly snapshot?: unknown;
   readonly profile?: CheckProfile;
@@ -107,6 +108,7 @@ export interface ParsedCommand {
     | { readonly kind: "task-complete"; readonly taskId: string; readonly ciGate: "passed" | "failed"; readonly reviewerId: string }
     | { readonly kind: "task-list"; readonly filters: TaskListFilters }
     | { readonly kind: "status" }
+    | { readonly kind: "version" }
     | { readonly kind: "check"; readonly profile: CheckProfile; readonly strict: boolean; readonly postMerge: boolean }
     | { readonly kind: "governance-rebuild"; readonly mode: GovernanceRebuildMode }
     | { readonly kind: "lesson-promote"; readonly taskId: string; readonly candidateId: string; readonly mode: LessonCommandMode }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -37,6 +37,12 @@ export function initializeHarness(rootDir: string, addNpmScripts = false, projec
     "",
     "Read `harness/harness.yaml` and `harness/standards/repo-governance.md` before changing task state.",
     "",
+    "## Harness CLI",
+    "",
+    "- Invoke via `npx harness-anything <command>` (alias: `ha`). Create task packages with `new-task`; never hand-scaffold directories under the tasks root.",
+    "- Task lifecycle: `task status set <id> <planned|active|blocked|in_review|done|cancelled>`, `task progress append <id> --text <text> [--evidence type:PATH:summary]`, `task-review <id>`, `task-complete <id> --ci passed|failed`. Completion is gated on review + closeout; setting `done` directly is rejected.",
+    "- Writes that go through the harness CLI (new-task, status set, progress append, review, complete) are auto-committed as `harness write <opId>` when the harness root is inside a git repository. A clean `git status` right after these commands is expected: do not re-verify, re-commit, or treat it as data loss. Only hand-edited files need manual commits.",
+    "",
     "Generated state under `.harness/` is local-only and must not be committed.",
     ""
   ].join("\n"));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isExtensionAction, runExtensionCommand } from "./commands/extensions/index.ts";
@@ -28,6 +28,11 @@ export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)):
   if (parsed.value.action.kind === "gui") {
     const result = launchGui(parsed.value.rootDir);
     emit(result, parsed.value.json);
+    return 0;
+  }
+
+  if (parsed.value.action.kind === "version") {
+    emit({ ok: true, command: "version", version: resolveCliVersion() }, parsed.value.json);
     return 0;
   }
 
@@ -99,6 +104,10 @@ function emit(result: CliResult, json: boolean): void {
   }
 
   if (result.ok) {
+    if (result.command === "version") {
+      console.log(`harness-anything ${result.version ?? "unknown"}`);
+      return;
+    }
     if (result.command === "help" && result.commands) {
       console.log(renderHelp(result));
       return;
@@ -156,6 +165,28 @@ function helpReport(report: unknown): { readonly kind: "global" | "command" | "p
   if (candidate.schema !== "cli-help-report/v1") return undefined;
   if (candidate.kind !== "global" && candidate.kind !== "command" && candidate.kind !== "prefix") return undefined;
   return { kind: candidate.kind, prefix: candidate.prefix };
+}
+
+function resolveCliVersion(): string {
+  // Walk up from this module to the @harness-anything/cli package.json. Robust
+  // across layouts: src (packages/cli/src), built dist (packages/cli/dist/cli/src),
+  // and installed (node_modules/@harness-anything/cli/dist/cli/src).
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let depth = 0; depth < 8; depth += 1) {
+    const candidate = path.join(dir, "package.json");
+    if (existsSync(candidate)) {
+      try {
+        const pkg = JSON.parse(readFileSync(candidate, "utf8")) as { readonly name?: unknown; readonly version?: unknown };
+        if (pkg.name === "@harness-anything/cli" && typeof pkg.version === "string") return pkg.version;
+      } catch {
+        // malformed package.json: keep walking
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return "0.0.0";
 }
 
 function isCliEntrypoint(): boolean {

--- a/packages/cli/test/parse-args.test.ts
+++ b/packages/cli/test/parse-args.test.ts
@@ -125,6 +125,14 @@ test("parseArgs has characterization coverage for every command registry kind", 
   assert.deepEqual(covered, registered);
 });
 
+test("parseArgs recognizes version as a global flag, short flag, and bare command", () => {
+  for (const argv of [["--version"], ["-v"], ["version"], ["status", "--version"]]) {
+    const parsed = parseArgs(argv);
+    assert.equal(parsed.ok, true, argv.join(" "));
+    assert.equal(parsed.ok && parsed.value.action.kind, "version", argv.join(" "));
+  }
+});
+
 test("parseArgs strips explicit authored root global override", () => {
   const parsed = parseArgs(["--root", rootDir, "--authored-root", ".custom-harness", "doctor"]);
 


### PR DESCRIPTION
## Summary

Add a `--version` flag to the CLI and small distribution/docs DX hardening discovered while dogfooding the harness on itself.

## What Changed

- `feat(cli)`: `--version` / `-v` / `version` print the CLI's own version (`harness-anything <v>`; `--json` emits `{ok,command:version,version}`). Implemented as a global flag intercepted before the command registry (not a registered subcommand). `resolveCliVersion()` walks up from `import.meta.url` to the `@harness-anything/cli` package.json, so it resolves across source, built dist, and installed-package layouts. Adds a dedicated parse-args test.
- `chore(cli)`: `prepack` build hook so `npm pack` / local-install always ships fresh dist; `.gitignore` release tarballs (`*.tgz`).
- `docs`: expand the `init`-generated `AGENTS.md` template with the CLI command surface, lifecycle/status vocabulary, completion gate, and coordinator auto-commit semantics; `CONTRIBUTING` gains a rebuild-dist-after-CLI-change note.

## Task And Scope

- Harness task: `task_01KWFSWYWWAP1CJKSBK7NWMPK4` (CLI --version), status `done` (private harness repo).
- Branch: `feat/cli-version-and-dx`.
- Public scope: `packages/cli/**`, `.gitignore`, `CONTRIBUTING.md`.
- Private planning/evidence updated: yes (task plan/review/closeout in the private harness repo).
- Out of scope: no public npm publish (release boundary unchanged; repo packages stay private + 0.0.0).

## Version Impact

- Version: `0.0.0` -> `0.0.0` (no change; repo stays behind the release boundary).
- Publish impact: no publish. The global install used for local dogfooding is a self-chosen snapshot label and does not change the repo version or the release-boundary contract.

## Verification

- Base `origin/main` SHA: `cd59984ac3c3981fef4a7a4a285e45d23f20638d`
- Branch merge-base with `origin/main`: `cd59984ac3c3` (rebased; linear)
- Last `git fetch origin` time: 2026-07-02 ~05:55 CST
- Sync method: rebase onto `origin/main`
- Public diff command: `git diff origin/main...feat/cli-version-and-dx`
- Private evidence commit/path: harness task `task_01KWFSWYWWAP1CJKSBK7NWMPK4` (plan/review/closeout) in the private harness repo
- Reviewer evidence path: `review.md` in the same private task package (Status: passed, no open blocking findings)
- GitHub Actions `rewrite-ci` run URL: _pending — see checks on this PR_
- [x] `npm ci` — not run; used existing workspace install (see Not run)
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck` (via `npm run check`)
- [x] `npm test` (via `npm run check`)
- [x] `npm run harness:check-import-boundaries` (via `npm run check`)
- [x] `npm run harness:scan-forbidden-symbols` (via `npm run check`)
- [x] `npm run harness:check-private-boundary` (via `npm run check`)
- [x] `npm run harness:check-package-policy` (via `npm run check`)
- [x] `npm run harness:check-implementation-contracts` (via `npm run check`)
- [x] `npm run harness:check-schema-contracts` (via `npm run check`)
- [x] `npm run harness:check-legacy-intake-readiness` (via `npm run check`)
- [x] `npm run harness:smoke-cli-package` (via `npm run check`)
- [ ] GitHub Actions `rewrite-ci` passed — pending remote run
- Not run: `npm ci` (kept the existing installed workspace; `npm run check` ran against it and passed, and CI runs `npm ci` from clean).

## Review Evidence

- Self-review: implemented as a global flag (not a registry command) to avoid parser-registry coupling; version read from the package's own package.json for layout-robustness; regression-checked help and unknown-command paths.
- Reviewer subagent: n/a (small, well-scoped change).
- Human review: requested via this PR.
- Blocking findings: none (two info-level notes recorded in the private task `review.md`).

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
