### PR TITLE
speed up low-risk check paths

### DIFF
--- a/tools/check-legacy-intake-readiness.mjs
+++ b/tools/check-legacy-intake-readiness.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
@@ -254,13 +254,12 @@ function checkBehaviorCorpusReport(root, violations) {
 
 async function collectPublicTextFiles(root) {
   const files = await collectFiles(root);
-  return files
+  const candidates = files
     .map((file) => relative(root, file))
     .filter((rel) => {
       if (rel.startsWith("node_modules/") || rel.startsWith(".git/") || rel.startsWith(".harness") || rel.startsWith("dist/") || rel.startsWith("coverage/")) {
         return false;
       }
-      if (isGitIgnored(root, rel)) return false;
       // AGENTS.md / CLAUDE.md are local-only agent entries; check-private-boundary
       // enforces they stay untracked, so they are not public text.
       if (rel === "AGENTS.md" || rel === "CLAUDE.md") return false;
@@ -268,15 +267,22 @@ async function collectPublicTextFiles(root) {
       if (/(?:^|\/)(?:test|tests|fixtures|__fixtures__)\//u.test(rel)) return false;
       return rel.endsWith(".md") || rel.endsWith(".yml") || rel.endsWith(".yaml") || rel.endsWith("package.json");
     });
+
+  const ignoredFiles = collectGitIgnoredFiles(root, candidates);
+  return candidates.filter((rel) => !ignoredFiles.has(rel));
 }
 
-function isGitIgnored(root, rel) {
-  try {
-    execFileSync("git", ["-C", root, "check-ignore", "-q", "--", rel], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
+function collectGitIgnoredFiles(root, files) {
+  if (files.length === 0) return new Set();
+
+  const result = spawnSync("git", ["-C", root, "check-ignore", "-z", "--stdin"], {
+    encoding: "utf8",
+    input: `${files.join("\0")}\0`,
+    stdio: ["pipe", "pipe", "ignore"]
+  });
+  if (result.status !== 0) return new Set();
+
+  return new Set(result.stdout.split("\0").filter(Boolean));
 }
 
 async function collectFiles(directory) {

--- a/tools/smoke-cli-package.mjs
+++ b/tools/smoke-cli-package.mjs
@@ -14,11 +14,6 @@ try {
   mkdirSync(packDir, { recursive: true });
   mkdirSync(consumerDir, { recursive: true });
 
-  execFileSync("npm", ["--workspace", "@harness-anything/cli", "run", "build"], {
-    cwd: root,
-    stdio: "inherit"
-  });
-
   const packOutput = execFileSync("npm", ["pack", "--workspace", "@harness-anything/cli", "--pack-destination", packDir, "--json"], {
     cwd: root,
     encoding: "utf8"


### PR DESCRIPTION
## Summary

Speed up two low-risk `npm run check` paths without reducing validation coverage.

## What Changed

- Batched `git check-ignore` calls in the Legacy Intake readiness checker.
- Removed the duplicate explicit CLI build from the package smoke; `npm pack` still runs `prepack`, builds the package, installs the tarball in a temporary consumer, and verifies both CLI bins.

## Task And Scope

- Harness task: `task_01KWFXQC6DR22V4X3Z3NS48WFH`
- Branch: `codex/check-speed-low-risk`
- Public scope: `tools/check-legacy-intake-readiness.mjs`, `tools/smoke-cli-package.mjs`
- Private planning/evidence updated: yes, private harness commit `77d63c4`
- Out of scope: integration test restructuring, CLI result contract design, structured progress document APIs

## Version Impact

- Version: no version change because this only changes checker/smoke implementation internals.
- Publish impact: no publish.

## Verification

- Base `origin/main` SHA: `6fd259212d52c09e5c12d18207b8b204f6e6c9f3`
- Branch merge-base with `origin/main`: `6fd259212d52c09e5c12d18207b8b204f6e6c9f3`
- Last `git fetch origin` time: `2026-07-01T22:54:38Z`
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD -- tools/check-legacy-intake-readiness.mjs tools/smoke-cli-package.mjs`
- Private evidence commit/path: private harness commit `77d63c4`, task `task_01KWFXQC6DR22V4X3Z3NS48WFH`
- Reviewer evidence path: self-review only for this narrow checker/smoke change
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28553178296
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` not rerun locally because dependencies were already installed and this PR does not change dependencies; individual harness gates not checked here are covered by `npm run check` and remote `rewrite-ci`.

## Review Evidence

- Self-review: inspected staged diff; scope is limited to batching equivalent git ignore queries and removing one duplicate prepack build.
- Reviewer subagent: not used; narrow tool-only change with full local check.
- Human review: requested by user through PR flow.
- Blocking findings: none known.
- Admin bypass: user explicitly requested immediate merge after `rewrite-ci` passed; missing normal gate: platform policy did not allow ordinary merge without admin/auto path.

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear.

## Residual Risk

- `npm run check` wall-clock remains dominated by integration tests and package install variance. This PR removes one deterministic Legacy Intake bottleneck and one duplicate build, but does not redesign the integration lane.
- The CLI result contract and structured progress-write product issues discovered during use are intentionally left for a separate design/task.

## References

- Task: `task_01KWFXQC6DR22V4X3Z3NS48WFH`
- Evidence: `npm run check` passed locally in 133.81s; Legacy Intake readiness checker passed in 1.11s.
- Review: self-review of two-file diff.

---

## 摘要

加速两个低风险 `npm run check` 路径，不降低验证覆盖。

## 改动内容

- Legacy Intake readiness checker 的 `git check-ignore` 改为批量查询。
- CLI package smoke 删除重复显式 build；`npm pack` 仍通过 `prepack` build package，并在临时 consumer 中安装 tarball、验证两个 CLI bin。

## 任务与范围

- Harness 任务：`task_01KWFXQC6DR22V4X3Z3NS48WFH`
- 分支：`codex/check-speed-low-risk`
- 公开范围：`tools/check-legacy-intake-readiness.mjs`、`tools/smoke-cli-package.mjs`
- 私有计划 / 证据是否已更新：yes，私有 harness commit `77d63c4`
- 范围外：integration 测试重构、CLI 返回值契约设计、结构化 progress 写入 API

## 版本影响

- 版本：不改版本，原因是只改 checker/smoke 内部实现。
- 发布影响：不发布。

## 验证

- `origin/main` 基准 SHA：`6fd259212d52c09e5c12d18207b8b204f6e6c9f3`
- 当前分支与 `origin/main` 的 merge-base：`6fd259212d52c09e5c12d18207b8b204f6e6c9f3`
- 最近一次 `git fetch origin` 时间：`2026-07-01T22:54:38Z`
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...HEAD -- tools/check-legacy-intake-readiness.mjs tools/smoke-cli-package.mjs`
- 私有证据 commit/path：私有 harness commit `77d63c4`，任务 `task_01KWFXQC6DR22V4X3Z3NS48WFH`
- Reviewer 证据路径：本窄范围 checker/smoke 变更仅做 self-review
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28553178296
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci` 未本地重跑，因为依赖已安装且本 PR 不改依赖；未单独勾选的 harness gates 由 `npm run check` 和远端 `rewrite-ci` 覆盖。

## 审查证据

- 自查：已检查 staged diff；范围仅限等价批量 git ignore 查询与删除重复 prepack build。
- Reviewer subagent：未使用；窄范围工具变更，已有 full local check。
- 人工审查：按用户要求走 PR flow。
- 阻塞发现：无已知。
- Admin bypass：用户在 `rewrite-ci` 通过后明确要求立即合入；缺失的正常门：平台策略不允许普通 merge，只能走 admin/auto path。

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚。

## 残余风险

- `npm run check` 总墙钟仍主要由 integration tests 和 package install 波动主导。本 PR 去掉确定性的 Legacy Intake bottleneck 和一次重复 build，但不重构 integration lane。
- 本次使用中暴露的 CLI 返回值契约和结构化 progress 写入产品问题，刻意留给独立设计 / task。

## 关联材料

- 任务：`task_01KWFXQC6DR22V4X3Z3NS48WFH`
- 证据：`npm run check` 本地 133.81s 通过；Legacy Intake readiness checker 1.11s 通过。
- 审查：两文件 diff self-review。


