### PR TITLE
Standardize CLI command receipts

### DIFF
--- a/packages/cli/src/cli/command-registry.ts
+++ b/packages/cli/src/cli/command-registry.ts
@@ -1,4 +1,5 @@
 import type { CommandRegistryEntry, ParsedCommand } from "./types.ts";
+import { commandReceiptEnvelope } from "./receipt.ts";
 
 export const cliCommandName = "harness-anything";
 export const cliCommandAlias = "ha";
@@ -327,7 +328,7 @@ export const commandRegistry = commandDescriptors.map((entry) => {
     summary: entry.summary,
     options: optionsFromUsage(entry.usage),
     examples: entry.examples,
-    resultEnvelope: "CliResult/v1"
+    resultEnvelope: commandReceiptEnvelope
   };
 }) satisfies ReadonlyArray<CommandRegistryEntry>;
 
@@ -419,7 +420,7 @@ function optionDescription(flag: string): string {
     "--hard": "Hard-delete the selected task.",
     "--help": "Show help output.",
     "--include-archived": "Include archived task packages.",
-    "--json": "Emit CliResult/v1 JSON.",
+    "--json": "Emit CommandReceipt/v1 JSON.",
     "--kernel-version": "Validate against a kernel version.",
     "--lesson": "Filter by lesson state.",
     "--limit": "Limit the number of planned items.",

--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -1,0 +1,183 @@
+import type { CliResult } from "./types.ts";
+
+export const commandReceiptEnvelope = "CommandReceipt/v1" as const;
+
+export interface CommandReceipt<Command extends string = string> {
+  readonly ok: true;
+  readonly receipt: typeof commandReceiptEnvelope;
+  readonly command: Command;
+  readonly summary: string;
+  readonly data?: Record<string, unknown>;
+  readonly paths?: Record<string, string>;
+  readonly write?: CommandReceiptWrite;
+  readonly warnings?: ReadonlyArray<unknown>;
+  readonly next?: ReadonlyArray<string>;
+}
+
+export interface CommandReceiptWrite {
+  readonly opId?: string;
+  readonly committed?: boolean;
+  readonly paths?: ReadonlyArray<string>;
+}
+
+interface CommandReceiptContract {
+  readonly kind: string;
+  readonly data: ReadonlyArray<string>;
+  readonly paths: ReadonlyArray<string>;
+}
+
+export const commandReceiptContracts = [
+  { kind: "help", data: ["commands", "report"], paths: [] },
+  { kind: "init", data: ["generated"], paths: ["primary", "config"] },
+  { kind: "new-task", data: ["taskId", "slug", "status", "preset", "module", "generated", "report"], paths: ["package"] },
+  { kind: "status-set", data: ["taskId", "status", "forced", "forceAudit"], paths: ["forceAudit"] },
+  { kind: "progress-append", data: ["taskId", "report"], paths: ["primary", "progress"] },
+  { kind: "task-archive", data: ["taskId", "status", "report"], paths: [] },
+  { kind: "task-supersede", data: ["taskId", "status", "report"], paths: ["primary", "package"] },
+  { kind: "task-delete", data: ["taskId", "mode", "report"], paths: [] },
+  { kind: "task-reopen", data: ["taskId", "status", "report"], paths: [] },
+  { kind: "task-review", data: ["taskId", "reviewContract", "report"], paths: [] },
+  { kind: "task-complete", data: ["taskId", "status", "completionGate", "report"], paths: [] },
+  { kind: "template-list", data: ["templates"], paths: [] },
+  { kind: "template-render", data: ["document"], paths: [] },
+  { kind: "task-list", data: ["tasks", "rows"], paths: [] },
+  { kind: "status", data: ["rows", "summary", "report", "commands"], paths: ["projection"] },
+  { kind: "check", data: ["profile", "rows", "summary", "report"], paths: ["projection"] },
+  { kind: "governance-rebuild", data: ["mode", "rows", "generated", "report"], paths: ["projection"] },
+  { kind: "lesson-promote", data: ["taskId", "mode", "report"], paths: [] },
+  { kind: "lesson-sediment", data: ["taskId", "mode", "report"], paths: [] },
+  { kind: "adopt-multica", data: ["taskId", "status", "report"], paths: [] },
+  { kind: "snapshot-multica", data: ["report"], paths: [] },
+  { kind: "migrate-plan", data: ["rows", "report"], paths: [] },
+  { kind: "migrate-structure", data: ["mode", "report"], paths: [] },
+  { kind: "migrate-run", data: ["migrationMode", "report"], paths: ["primary", "session"] },
+  { kind: "migrate-verify", data: ["report"], paths: [] },
+  { kind: "legacy-scan", data: ["report"], paths: [] },
+  { kind: "legacy-intake-plan", data: ["report"], paths: ["primary", "plan"] },
+  { kind: "legacy-copy-safe-docs", data: ["report"], paths: [] },
+  { kind: "legacy-index", data: ["summary", "report"], paths: ["primary", "index"] },
+  { kind: "legacy-verify", data: ["report"], paths: [] },
+  { kind: "git-diff", data: ["report"], paths: [] },
+  { kind: "doctor", data: ["report"], paths: [] },
+  { kind: "preset-validate", data: ["preset", "report"], paths: [] },
+  { kind: "preset-list", data: ["presets"], paths: [] },
+  { kind: "preset-inspect", data: ["preset"], paths: [] },
+  { kind: "preset-check", data: ["preset", "report"], paths: [] },
+  { kind: "preset-install", data: ["preset", "report"], paths: [] },
+  { kind: "preset-seed", data: ["presets", "report"], paths: [] },
+  { kind: "preset-audit", data: ["presets", "report"], paths: [] },
+  { kind: "preset-uninstall", data: ["preset", "report"], paths: [] },
+  { kind: "preset-run", data: ["taskId", "preset", "generated", "report"], paths: [] },
+  { kind: "preset-action", data: ["taskId", "preset", "generated", "report"], paths: [] },
+  { kind: "module-list", data: ["modules"], paths: [] },
+  { kind: "module-inspect", data: ["module"], paths: [] },
+  { kind: "module-register", data: ["module"], paths: [] },
+  { kind: "module-scaffold", data: ["module"], paths: ["primary", "modulePlan"] },
+  { kind: "module-unregister", data: ["module"], paths: [] },
+  { kind: "module-step", data: ["module"], paths: [] },
+  { kind: "vertical-validate", data: ["report"], paths: [] },
+  { kind: "gui", data: ["launchPlan"], paths: [] },
+  { kind: "version", data: ["version"], paths: [] }
+] as const satisfies ReadonlyArray<CommandReceiptContract>;
+
+const baseResultKeys = new Set(["ok", "command", "error", "path", "packagePath", "projectionPath", "warnings"]);
+
+type CliFailureResult = CliResult & { readonly ok: false };
+
+export function toCommandReceipt(result: CliResult): CommandReceipt | CliFailureResult {
+  if (!result.ok) return result as CliFailureResult;
+
+  const raw = result as unknown as Record<string, unknown>;
+  const data: Record<string, unknown> = {};
+  const paths: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(raw)) {
+    if (baseResultKeys.has(key) || value === undefined) continue;
+    data[key] = value;
+  }
+
+  setPath(paths, "primary", raw.path);
+  setPath(paths, "package", raw.packagePath);
+  setPath(paths, "projection", raw.projectionPath);
+  classifyPrimaryPath(result.command, paths, raw.path);
+  const forceAudit = raw.forceAudit;
+  if (forceAudit && typeof forceAudit === "object" && typeof (forceAudit as { path?: unknown }).path === "string") {
+    setPath(paths, "forceAudit", (forceAudit as { path: string }).path);
+  }
+
+  return {
+    ok: true,
+    receipt: commandReceiptEnvelope,
+    command: result.command,
+    summary: summarizeResult(raw),
+    ...(Object.keys(data).length > 0 ? { data } : {}),
+    ...(Object.keys(paths).length > 0 ? { paths } : {}),
+    ...(result.warnings && result.warnings.length > 0 ? { warnings: result.warnings } : {})
+  };
+}
+
+export function renderReceiptText(receipt: CommandReceipt): string {
+  const parts = [`ok`, `command=${formatToken(receipt.command)}`];
+  const taskId = receipt.data?.taskId;
+  if (typeof taskId === "string") parts.push(`task=${formatToken(taskId)}`);
+  const status = receipt.data?.status;
+  if (typeof status === "string") parts.push(`status=${formatToken(status)}`);
+  const primaryPath = receipt.paths?.package ?? receipt.paths?.primary ?? receipt.paths?.projection;
+  if (primaryPath) parts.push(`path=${formatToken(primaryPath)}`);
+  const rows = receipt.data?.rows;
+  if (typeof rows === "number") parts.push(`rows=${rows}`);
+  const mode = launchMode(receipt.data?.launchPlan);
+  if (mode) parts.push(`mode=${formatToken(mode.mode)}`, `package=${formatToken(mode.packageName)}`);
+  parts.push(`summary=${formatToken(receipt.summary)}`);
+  return parts.join(" ");
+}
+
+function setPath(paths: Record<string, string>, key: string, value: unknown): void {
+  if (typeof value === "string" && value.length > 0) paths[key] = value;
+}
+
+function classifyPrimaryPath(command: string, paths: Record<string, string>, value: unknown): void {
+  if (typeof value !== "string" || value.length === 0) return;
+  const keyByCommand: Record<string, string> = {
+    init: "config",
+    "progress-append": "progress",
+    "task-supersede": "replacement",
+    "migrate-run": "session",
+    "legacy-intake-plan": "plan",
+    "legacy-index": "index",
+    "module-scaffold": "modulePlan"
+  };
+  const key = keyByCommand[command];
+  if (key) paths[key] = value;
+}
+
+function summarizeResult(raw: Record<string, unknown>): string {
+  const command = typeof raw.command === "string" ? raw.command : "unknown";
+  const taskId = typeof raw.taskId === "string" ? raw.taskId : undefined;
+  const status = typeof raw.status === "string" ? raw.status : undefined;
+  const packagePath = typeof raw.packagePath === "string" ? raw.packagePath : undefined;
+  const path = typeof raw.path === "string" ? raw.path : undefined;
+  const rows = typeof raw.rows === "number" ? raw.rows : undefined;
+  const version = typeof raw.version === "string" ? raw.version : undefined;
+
+  if (command === "new-task" && taskId && packagePath) return `created task ${taskId} at ${packagePath}`;
+  if (command === "status-set" && taskId && status) return `set task ${taskId} to ${status}`;
+  if (command === "progress-append" && taskId) return `appended progress for ${taskId}`;
+  if (command === "init" && path) return `initialized harness at ${path}`;
+  if (command === "version" && version) return `resolved CLI version ${version}`;
+  if (command === "help") return "rendered CLI help";
+  if (rows !== undefined) return `completed ${command} with ${rows} row${rows === 1 ? "" : "s"}`;
+  if (taskId) return `completed ${command} for ${taskId}`;
+  return `completed ${command}`;
+}
+
+function launchMode(value: unknown): { readonly mode: string; readonly packageName: string } | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const candidate = value as { readonly mode?: unknown; readonly packageName?: unknown };
+  if (typeof candidate.mode !== "string" || typeof candidate.packageName !== "string") return undefined;
+  return { mode: candidate.mode, packageName: candidate.packageName };
+}
+
+function formatToken(value: string): string {
+  return /^[A-Za-z0-9_./:@-]+$/u.test(value) ? value : JSON.stringify(value);
+}

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -76,6 +76,8 @@ export interface CliResult {
   readonly error?: CliError;
 }
 
+export type CommandReceiptEnvelope = "CommandReceipt/v1";
+
 export interface CommandRegistryEntry {
   readonly kind: string;
   readonly primary: string;
@@ -84,7 +86,7 @@ export interface CommandRegistryEntry {
   readonly summary: string;
   readonly options: ReadonlyArray<CommandHelpOption>;
   readonly examples: ReadonlyArray<string>;
-  readonly resultEnvelope: "CliResult/v1";
+  readonly resultEnvelope: CommandReceiptEnvelope;
 }
 
 export interface CommandHelpOption {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -24,7 +24,7 @@ export interface DoctorReport {
   };
   readonly cli: {
     readonly command: "harness-anything doctor";
-    readonly json: "CliResult/v1";
+    readonly json: "CommandReceipt/v1";
   };
   readonly recommendedCommands: readonly string[];
 }
@@ -60,7 +60,7 @@ function collectDoctorReport(rootDir: string): DoctorReport {
     },
     cli: {
       command: "harness-anything doctor",
-      json: "CliResult/v1"
+      json: "CommandReceipt/v1"
     },
     recommendedCommands: [
       "harness-anything init",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import { actionTaskId, parseArgs } from "./cli/parse-args.ts";
 import { Effect } from "effect";
 import { makeLocalLifecycleEngine } from "../../adapters/local/src/index.ts";
 import { runCommand } from "./commands/lifecycle.ts";
+import { renderReceiptText, toCommandReceipt } from "./cli/receipt.ts";
 import type { CliResult, CommandRegistryEntry } from "./cli/types.ts";
 
 export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)): Promise<number> {
@@ -100,30 +101,30 @@ function launchGui(rootDir: string): CliResult {
 }
 
 function emit(result: CliResult, json: boolean): void {
+  const output = toCommandReceipt(result);
   if (json) {
-    console.log(JSON.stringify(result));
+    console.log(JSON.stringify(output));
     return;
   }
 
-  if (result.ok) {
-    if (result.command === "version") {
-      console.log(`harness-anything ${result.version ?? "unknown"}`);
+  if (output.ok) {
+    if (output.command === "version") {
+      console.log(`harness-anything ${String(output.data?.version ?? "unknown")}`);
       return;
     }
-    if (result.command === "help" && result.commands) {
-      console.log(renderHelp(result));
+    if (output.command === "help" && Array.isArray(output.data?.commands)) {
+      console.log(renderHelp(output.data));
       return;
     }
-    const suffix = result.status ? ` status=${result.status}` : result.path ? ` path=${result.path}` : result.rows !== undefined ? ` rows=${result.rows}` : result.launchPlan ? ` mode=${result.launchPlan.mode} package=${result.launchPlan.packageName}` : "";
-    console.log(`ok command=${result.command} task=${result.taskId ?? ""}${suffix}`);
+    console.log(renderReceiptText(output));
     return;
   }
 
-  console.error(`error code=${result.error?.code ?? "unknown"} hint=${result.error?.hint ?? "Command failed."}`);
+  console.error(`error code=${output.error?.code ?? "unknown"} hint=${output.error?.hint ?? "Command failed."}`);
 }
 
-function renderHelp(result: CliResult): string {
-  const commands = result.commands ?? [];
+function renderHelp(result: Record<string, unknown>): string {
+  const commands = Array.isArray(result.commands) ? result.commands as ReadonlyArray<CommandRegistryEntry> : [];
   const report = helpReport(result.report);
   if (report?.kind === "command" && commands.length === 1) {
     return renderCommandHelp(commands[0]!);

--- a/packages/cli/test/attribution-diff-cli.test.ts
+++ b/packages/cli/test/attribution-diff-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -126,7 +127,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
       maxBuffer: 256 * 1024 * 1024,
       env: { ...process.env, ...env }
     });
-    return JSON.parse(stdout) as Record<string, any>;
+    return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
     if (expectSuccess) throw error;
     const failure = error as { readonly stdout?: string };

--- a/packages/cli/test/check-governance-cli.test.ts
+++ b/packages/cli/test/check-governance-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -486,7 +487,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8"
     });
-    return JSON.parse(stdout) as Record<string, any>;
+    return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
     if (expectSuccess) throw error;
     const failure = error as { readonly stdout?: string };

--- a/packages/cli/test/doctor-cli.test.ts
+++ b/packages/cli/test/doctor-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -92,5 +93,5 @@ function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, a
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8"
   });
-  return JSON.parse(stdout) as Record<string, any>;
+  return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
 }

--- a/packages/cli/test/extension-cli.test.ts
+++ b/packages/cli/test/extension-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -132,7 +133,7 @@ function runJson(args: ReadonlyArray<string>, expectSuccess = true): Record<stri
     const stdout = execFileSync(process.execPath, [cliEntry, "--json", ...args], {
       encoding: "utf8"
     });
-    return JSON.parse(stdout) as Record<string, any>;
+    return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
     if (expectSuccess) throw error;
     const failure = error as { readonly stdout?: string };

--- a/packages/cli/test/helpers/receipt.ts
+++ b/packages/cli/test/helpers/receipt.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+
+const disallowedSuccessTopLevel = [
+  "taskId",
+  "slug",
+  "status",
+  "path",
+  "packagePath",
+  "projectionPath",
+  "mode",
+  "migrationMode",
+  "tasks",
+  "templates",
+  "presets",
+  "preset",
+  "modules",
+  "module",
+  "document",
+  "evidenceBundle",
+  "issues",
+  "rows",
+  "version",
+  "report",
+  "snapshot",
+  "profile",
+  "generated",
+  "reviewContract",
+  "completionGate",
+  "forced",
+  "forceAudit",
+  "commands",
+  "launchPlan"
+] as const;
+
+export function unwrapCommandReceipt(value: Record<string, any>): Record<string, any> {
+  assert.equal(value.ok, true);
+  assert.equal(value.receipt, "CommandReceipt/v1");
+  assert.equal(typeof value.command, "string");
+  assert.equal(typeof value.summary, "string");
+
+  for (const key of disallowedSuccessTopLevel) {
+    assert.equal(Object.prototype.hasOwnProperty.call(value, key), false, `receipt leaked old top-level field ${key}`);
+  }
+
+  const data = isRecord(value.data) ? value.data : {};
+  const paths = isRecord(value.paths) ? value.paths : {};
+  return {
+    ...data,
+    ok: value.ok,
+    command: value.command,
+    receipt: value.receipt,
+    receiptSummary: value.summary,
+    paths,
+    warnings: Array.isArray(value.warnings) ? value.warnings : [],
+    path: paths.primary,
+    packagePath: paths.package,
+    projectionPath: paths.projection
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/cli/test/init-cli.test.ts
+++ b/packages/cli/test/init-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -82,5 +83,5 @@ function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, a
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8"
   });
-  return JSON.parse(stdout) as Record<string, any>;
+  return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
 }

--- a/packages/cli/test/local-lifecycle-cli.test.ts
+++ b/packages/cli/test/local-lifecycle-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -55,8 +56,10 @@ test("CLI creates a local task with generated identity and stable JSON output", 
     assert.equal(result.slug, "task-one");
     assert.equal(result.status, "planned");
     assert.equal(result.packagePath, `harness/planning/tasks/${taskId}-task-one`);
+    assert.equal(result.paths.package, result.packagePath);
     assert.match(readFileSync(path.join(rootDir, `harness/planning/tasks/${taskId}-task-one/INDEX.md`), "utf8"), /engine: local/);
     assert.match(readFileSync(path.join(rootDir, ".harness/write-journal/watermark.json"), "utf8"), /"projectionHash":"sha256:/);
+    assert.match(runText(rootDir, ["new-task", "--title", "Text Path"]), /ok command=new-task task=task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26} status=planned path=harness\/planning\/tasks\/task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}-text-path summary=/u);
   });
 });
 
@@ -356,7 +359,7 @@ test("CLI status --json returns local projection health envelope", () => {
     assert.equal(result.report.axes.some((axis: Record<string, unknown>) => axis.axis === "generated-cache" && axis.warningCount === 0), true);
     assert.equal(result.report.axes.some((axis: Record<string, unknown>) => axis.axis === "collaboration-gate" && axis.warningCount === 0), true);
     assert.equal(result.warnings.length, 0);
-    assert.equal(result.commands.some((entry: Record<string, unknown>) => entry.kind === "task-supersede" && entry.resultEnvelope === "CliResult/v1"), true);
+    assert.equal(result.commands.some((entry: Record<string, unknown>) => entry.kind === "task-supersede" && entry.resultEnvelope === "CommandReceipt/v1"), true);
     assert.equal(result.commands.some((entry: Record<string, unknown>) => entry.kind === "preset-validate" && entry.primary === "harness-anything preset validate <manifest> [--kernel-version <version>] [--json]"), true);
   });
 });
@@ -583,17 +586,15 @@ test("CLI task-complete evaluates review, CI, and closeout readiness before sett
 test("CLI gui command delegates to the local desktop controller without importing GUI", () => {
   const result = runJson(process.cwd(), ["gui"], true, { HARNESS_GUI_DRY_RUN: "1" });
 
-  assert.deepEqual(result, {
-    ok: true,
-    command: "gui",
-    launchPlan: {
-      packageName: "@harness-anything/gui",
-      mode: "local-desktop-controller",
-      apiHost: "127.0.0.1",
-      delegated: true,
-      dryRun: true,
-      command: ["npm", "--workspace", "@harness-anything/gui", "run", "dev"]
-    }
+  assert.equal(result.ok, true);
+  assert.equal(result.command, "gui");
+  assert.deepEqual(result.launchPlan, {
+    packageName: "@harness-anything/gui",
+    mode: "local-desktop-controller",
+    apiHost: "127.0.0.1",
+    delegated: true,
+    dryRun: true,
+    command: ["npm", "--workspace", "@harness-anything/gui", "run", "dev"]
   });
 });
 
@@ -674,7 +675,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
       encoding: "utf8",
       env: { ...process.env, ...env }
     });
-    return JSON.parse(stdout) as Record<string, any>;
+    return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
     if (expectSuccess) throw error;
     const failure = error as { readonly stdout?: string };

--- a/packages/cli/test/migration-adopt-cli.test.ts
+++ b/packages/cli/test/migration-adopt-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -323,7 +324,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
     const output = execFileSync(process.execPath, command, { encoding: "utf8" });
     const parsed = JSON.parse(output);
     if (expectSuccess) assert.equal(parsed.ok, true, output);
-    return parsed;
+    return unwrapCommandReceipt(parsed);
   } catch (error) {
     const failure = error as { readonly stdout?: string; readonly stderr?: string };
     const body = failure.stdout && failure.stdout.trim().length > 0 ? failure.stdout : failure.stderr ?? "";

--- a/packages/cli/test/p16-command-parity-cli.test.ts
+++ b/packages/cli/test/p16-command-parity-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -122,7 +123,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8"
     });
-    return JSON.parse(stdout) as Record<string, any>;
+    return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
     if (expectSuccess) throw error;
     const failure = error as { readonly stdout?: string };

--- a/packages/cli/test/parse-args.test.ts
+++ b/packages/cli/test/parse-args.test.ts
@@ -159,7 +159,7 @@ test("command registry exposes help metadata for every command", () => {
   for (const entry of commandRegistry) {
     assert.equal(entry.commandPath.length > 0, true, entry.kind);
     assert.equal(entry.summary.length > 0, true, entry.kind);
-    assert.equal(entry.resultEnvelope, "CliResult/v1", entry.kind);
+    assert.equal(entry.resultEnvelope, "CommandReceipt/v1", entry.kind);
   }
 });
 

--- a/packages/cli/test/preset-module-cli.test.ts
+++ b/packages/cli/test/preset-module-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -442,7 +443,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8"
     });
-    return JSON.parse(stdout) as Record<string, any>;
+    return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
     if (expectSuccess) throw error;
     const failure = error as { readonly stdout?: string };

--- a/packages/cli/test/preset-script-cli.test.ts
+++ b/packages/cli/test/preset-script-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -289,7 +290,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
     });
     const parsed = JSON.parse(output) as Record<string, any>;
     if (expectSuccess) assert.equal(parsed.ok, true, output);
-    return parsed;
+    return unwrapCommandReceipt(parsed);
   } catch (error) {
     if (expectSuccess) throw error;
     const failure = error as { readonly stdout?: string };

--- a/packages/cli/test/self-host-git-boundary-cli.test.ts
+++ b/packages/cli/test/self-host-git-boundary-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -48,7 +49,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8"
     });
-    return JSON.parse(stdout) as Record<string, any>;
+    return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
     if (expectSuccess) throw error;
     const failure = error as { readonly stdout?: string };

--- a/packages/cli/test/settings-cli.test.ts
+++ b/packages/cli/test/settings-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -341,7 +342,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8"
     });
-    return JSON.parse(stdout) as Record<string, any>;
+    return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
     if (expectSuccess) throw error;
     const failure = error as { readonly stdout?: string };

--- a/packages/cli/test/task-list-cli.test.ts
+++ b/packages/cli/test/task-list-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -109,7 +110,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, a
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8"
   });
-  return JSON.parse(stdout) as Record<string, any>;
+  return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
 }
 
 function withTempRoot<T>(fn: (rootDir: string) => T): T {

--- a/tools/check-cli-help-contract.mjs
+++ b/tools/check-cli-help-contract.mjs
@@ -3,16 +3,23 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const registryPath = "packages/cli/src/cli/command-registry.ts";
+const receiptPath = "packages/cli/src/cli/receipt.ts";
+const entrypointPath = "packages/cli/src/index.ts";
 
 export function findCliHelpContractViolations(rootDir = process.cwd()) {
   const source = readFileSync(path.join(rootDir, registryPath), "utf8");
+  const receiptSource = readFileSync(path.join(rootDir, receiptPath), "utf8");
+  const entrypointSource = readFileSync(path.join(rootDir, entrypointPath), "utf8");
   const commandUsageSource = extractAssignedLiteral(source, "commandUsages");
   const summarySource = extractAssignedLiteral(source, "commandSummaries");
   const exampleSource = extractAssignedLiteral(source, "commandExamples");
   const descriptionSource = extractAssignedLiteral(source, "descriptions");
+  const receiptContractSource = extractAssignedLiteral(receiptSource, "commandReceiptContracts");
   const violations = [];
 
   const commandKinds = [...commandUsageSource.matchAll(/\{\s*kind:\s*"([^"]+)"/gu)].map((match) => match[1]);
+  const receiptKinds = [...receiptContractSource.matchAll(/\{\s*kind:\s*"([^"]+)"/gu)].map((match) => match[1]);
+  const expectedReceiptKinds = [...commandKinds, "version"];
   const usageByKind = commandUsageByKind(commandUsageSource);
   const summaryKinds = objectKeys(summarySource);
   const exampleKinds = objectKeys(exampleSource);
@@ -30,6 +37,12 @@ export function findCliHelpContractViolations(rootDir = process.cwd()) {
   for (const kind of exampleKinds) {
     if (!commandKinds.includes(kind)) violations.push(`commandExamples has stale command ${kind}`);
   }
+  for (const kind of expectedReceiptKinds) {
+    if (!receiptKinds.includes(kind)) violations.push(`command ${kind} is missing commandReceiptContracts entry`);
+  }
+  for (const kind of receiptKinds) {
+    if (!expectedReceiptKinds.includes(kind)) violations.push(`commandReceiptContracts has stale command ${kind}`);
+  }
   for (const flag of usageFlags) {
     if (!descriptionFlags.has(flag)) violations.push(`option ${flag} is missing help description`);
   }
@@ -43,6 +56,12 @@ export function findCliHelpContractViolations(rootDir = process.cwd()) {
   }
   if (/humanizeKind|Set this command option/u.test(source)) {
     violations.push("command help must not use generic summary or option-description fallback text");
+  }
+  if (/CliResult\/v1/u.test(source) || /CliResult\/v1/u.test(receiptSource) || /CliResult\/v1/u.test(entrypointSource)) {
+    violations.push("CLI success output must use CommandReceipt/v1, not CliResult/v1");
+  }
+  if (/JSON\.stringify\(result\)/u.test(entrypointSource)) {
+    violations.push("CLI entrypoint must serialize normalized CommandReceipt output, not raw CliResult");
   }
   return violations;
 }

--- a/tools/check-cli-help-contract.test.mjs
+++ b/tools/check-cli-help-contract.test.mjs
@@ -46,6 +46,28 @@ test("CLI help contract gate accepts complete help metadata", () => {
   });
 });
 
+test("CLI help contract gate rejects missing receipt contracts", () => {
+  withTempRoot((rootDir) => {
+    writeRegistry(rootDir, `
+      const commandUsages = [
+        { kind: "new-task", usage: "new-task --title <title> --json" }
+      ] as const;
+      const commandSummaries = { "new-task": "Create a task." } satisfies Record<CommandKind, string>;
+      const commandExamples = { "new-task": ["harness-anything new-task --title Example"] } satisfies Record<CommandKind, ReadonlyArray<string>>;
+      function optionDescription(flag: string): string {
+        const descriptions: Record<string, string> = { "--title": "Set the task title.", "--json": "Emit JSON." };
+        return descriptions[flag]!;
+      }
+    `, `
+      export const commandReceiptContracts = [
+        { kind: "version", data: ["version"], paths: [] }
+      ] as const;
+    `);
+
+    assert.equal(findCliHelpContractViolations(rootDir).includes("command new-task is missing commandReceiptContracts entry"), true);
+  });
+});
+
 test("CLI help contract gate rejects examples with undocumented flags", () => {
   withTempRoot((rootDir) => {
     writeRegistry(rootDir, `
@@ -64,10 +86,17 @@ test("CLI help contract gate rejects examples with undocumented flags", () => {
   });
 });
 
-function writeRegistry(rootDir, body) {
+function writeRegistry(rootDir, body, receiptBody = `
+  export const commandReceiptContracts = [
+    { kind: "new-task", data: ["taskId"], paths: ["package"] },
+    { kind: "version", data: ["version"], paths: [] }
+  ] as const;
+`) {
   const dir = path.join(rootDir, "packages/cli/src/cli");
   mkdirSync(dir, { recursive: true });
   writeFileSync(path.join(dir, "command-registry.ts"), body);
+  writeFileSync(path.join(dir, "receipt.ts"), receiptBody);
+  writeFileSync(path.join(rootDir, "packages/cli/src/index.ts"), "console.log(JSON.stringify(output));\n");
 }
 
 function withTempRoot(fn) {

--- a/tools/check-runtime-release-readiness.mjs
+++ b/tools/check-runtime-release-readiness.mjs
@@ -151,7 +151,7 @@ function executeSourceRunSmoke() {
   try {
     const stdout = execFileSync(executable, args, { cwd: root, encoding: "utf8" });
     const result = JSON.parse(stdout);
-    if (result.ok !== true || result.command !== "doctor" || result.report?.readOnly !== true) {
+    if (result.ok !== true || result.receipt !== "CommandReceipt/v1" || result.command !== "doctor" || result.data?.report?.readOnly !== true) {
       record(`source-run command returned unexpected output: ${stdout}`);
     }
   } catch (error) {

--- a/tools/check-runtime-release-readiness.test.mjs
+++ b/tools/check-runtime-release-readiness.test.mjs
@@ -134,7 +134,7 @@ function writeValidRuntimeReleaseFixture(root, options = {}) {
   writeFile(root, "docs-release/m2-5-runtime-release.md", options.runtimeDocBody ?? validRuntimeDoc());
   writeFile(root, "docs-release/m2-5-gui-distribution.md", "# Distribution\n");
   writeFile(root, ".github/workflows/rewrite-ci.yml", options.workflowBody ?? validWorkflow());
-  writeFile(root, "packages/cli/src/index.ts", "console.log(JSON.stringify({ ok: true, command: \"doctor\", report: { readOnly: true } }));\n");
+  writeFile(root, "packages/cli/src/index.ts", "console.log(JSON.stringify({ ok: true, receipt: \"CommandReceipt/v1\", command: \"doctor\", summary: \"completed doctor\", data: { report: { readOnly: true } } }));\n");
 }
 
 function validRuntimeDoc() {

--- a/tools/smoke-cli-package.mjs
+++ b/tools/smoke-cli-package.mjs
@@ -39,7 +39,7 @@ try {
       HARNESS_GUI_DRY_RUN: "1"
     }
   });
-  const result = JSON.parse(stdout);
+  const result = unwrapReceipt(JSON.parse(stdout));
   if (result.ok !== true || result.command !== "gui" || result.launchPlan?.packageName !== "@harness-anything/gui") {
     throw new Error(`unexpected CLI smoke output: ${stdout}`);
   }
@@ -47,7 +47,7 @@ try {
     cwd: consumerDir,
     encoding: "utf8"
   });
-  const aliasResult = JSON.parse(aliasOutput);
+  const aliasResult = unwrapReceipt(JSON.parse(aliasOutput));
   if (aliasResult.ok !== true || aliasResult.command !== "doctor" || aliasResult.report?.schema !== "harness-doctor/v1") {
     throw new Error(`unexpected CLI alias smoke output: ${aliasOutput}`);
   }
@@ -90,5 +90,31 @@ try {
 }
 
 function runJson(binPath, args, cwd) {
-  return JSON.parse(execFileSync(binPath, args, { cwd, encoding: "utf8" }));
+  return unwrapReceipt(JSON.parse(execFileSync(binPath, args, { cwd, encoding: "utf8" })));
+}
+
+function unwrapReceipt(value) {
+  const oldTopLevel = ["taskId", "path", "packagePath", "projectionPath", "report", "summary", "launchPlan", "document"];
+  if (value.ok !== true || value.receipt !== "CommandReceipt/v1" || typeof value.command !== "string") {
+    throw new Error(`unexpected CommandReceipt/v1 output: ${JSON.stringify(value)}`);
+  }
+  for (const key of oldTopLevel) {
+    if (Object.prototype.hasOwnProperty.call(value, key) && key !== "summary") {
+      throw new Error(`receipt leaked old top-level field ${key}: ${JSON.stringify(value)}`);
+    }
+  }
+  const data = value.data && typeof value.data === "object" ? value.data : {};
+  const paths = value.paths && typeof value.paths === "object" ? value.paths : {};
+  return {
+    ...data,
+    ok: value.ok,
+    command: value.command,
+    receipt: value.receipt,
+    receiptSummary: value.summary,
+    paths,
+    path: paths.primary,
+    packagePath: paths.package,
+    projectionPath: paths.projection,
+    warnings: Array.isArray(value.warnings) ? value.warnings : []
+  };
 }

--- a/tools/smoke-legacy-intake.mjs
+++ b/tools/smoke-legacy-intake.mjs
@@ -16,7 +16,7 @@ function runJson(args) {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"]
     });
-    return JSON.parse(output);
+    return unwrapReceipt(JSON.parse(output));
   } catch (error) {
     const failure = error;
     const body = failure.stdout && failure.stdout.toString().trim().length > 0
@@ -55,4 +55,23 @@ try {
   console.log(`Legacy Intake smoke passed with ${legacyVerify.report.summary.entryCount} entries.`);
 } finally {
   rmSync(smokeRoot, { recursive: true, force: true });
+}
+
+function unwrapReceipt(value) {
+  if (value.ok !== true) return value;
+  if (value.receipt !== "CommandReceipt/v1") {
+    throw new Error(`unexpected CommandReceipt/v1 output: ${JSON.stringify(value)}`);
+  }
+  const data = value.data && typeof value.data === "object" ? value.data : {};
+  const paths = value.paths && typeof value.paths === "object" ? value.paths : {};
+  return {
+    ...data,
+    ok: value.ok,
+    command: value.command,
+    receipt: value.receipt,
+    path: paths.primary,
+    packagePath: paths.package,
+    projectionPath: paths.projection,
+    warnings: Array.isArray(value.warnings) ? value.warnings : []
+  };
 }


### PR DESCRIPTION
## Summary

Standardize successful CLI JSON output around `CommandReceipt/v1` and expose task/package paths through `paths` instead of old command-specific top-level fields.

## What Changed

- Added `packages/cli/src/cli/receipt.ts` with `CommandReceipt/v1`, command receipt contracts, result normalization, and text rendering.
- Changed CLI JSON success output to serialize normalized receipts; non-JSON `new-task` output now includes `path=...`.
- Updated command registry `resultEnvelope` to `CommandReceipt/v1` and extended the CLI help contract gate to require receipt contracts for every command.
- Updated tests and package/runtime/legacy smoke scripts to validate receipt output without product-side compatibility fields.

## Task And Scope

- Harness task: `task_01KWFZ8JKRPCKBJCBPN672P3Z7`
- Branch: `codex/cli-command-receipt`
- Public scope: CLI success output envelope, CLI command registry contract, CLI tests, and smoke/check tooling that consumes CLI JSON.
- Private planning/evidence updated: yes, private harness task progress commits `b13a50b` and `d5c768c`.
- Out of scope: error envelope redesign and Markdown WriteCoordinator scope changes.

## Version Impact

- Version: no version change because this is a pre-release CLI contract change.
- Publish impact: no publish.

## Verification

- Base `origin/main` SHA: `fdc1dd11f31ad4fa5c380e835cb8d3a5a998d9ca`
- Branch merge-base with `origin/main`: `fdc1dd11f31ad4fa5c380e835cb8d3a5a998d9ca`
- Last `git fetch origin` time: `2026-07-01T23:38:16Z`
- Sync method: rebase onto `origin/main`
- Public diff command: `git diff --name-only origin/main...HEAD`
- Private evidence commit/path: `d5c768c` / `harness/planning/tasks/task_01KWFZ8JKRPCKBJCBPN672P3Z7-cli-command-receipt/progress.md`
- Reviewer evidence path: not applicable; self-review only for this scoped CLI contract change.
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28555016567
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` was not run separately; existing workspace install was used, and `npm run check` plus package smoke passed after rebase.

## Review Evidence

- Self-review: Checked the receipt normalization boundary, command registry envelope, receipt contract gate, smoke consumers, and that no private harness files are included.
- Reviewer subagent: Not run; scoped CLI contract change with full local gate coverage.
- Human review: User explicitly requested merge on 2026-07-02; admin bypass used for REVIEW_REQUIRED after local `npm run check` and `rewrite-ci` passed.
- Blocking findings: none known.

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear: admin squash merge after `rewrite-ci` passed; delete remote branch and remove local worktree after merge.

## Residual Risk

- Admin bypass will be used only for the branch protection review requirement, because the user explicitly requested merge and both local `npm run check` and GitHub Actions `rewrite-ci` passed.
- Existing command handlers still build internal `CliResult`; the public output boundary normalizes success results to `CommandReceipt/v1`. This keeps the implementation scoped while enforcing the external contract through tests and gates.
- GitHub Actions `rewrite-ci` passed; `full-check` was skipped by workflow design.

## References

- Task: `task_01KWFZ8JKRPCKBJCBPN672P3Z7`
- Evidence: `npm run check` passed locally after rebase; private harness progress commit `d5c768c`.
- Review: self-review, no blocking findings.

---

## 摘要

统一 CLI 成功 JSON 输出为 `CommandReceipt/v1`，并通过 `paths` 暴露 task/package 路径，不再使用旧的命令专属顶层字段。

## 改动内容

- 新增 `packages/cli/src/cli/receipt.ts`，定义 `CommandReceipt/v1`、命令 receipt contract、结果归一化和文本渲染。
- CLI 成功 JSON 输出改为序列化归一化 receipt；非 JSON 的 `new-task` 输出现在包含 `path=...`。
- command registry 的 `resultEnvelope` 更新为 `CommandReceipt/v1`，并扩展 CLI help contract gate，要求每个命令都有 receipt contract。
- 更新测试与 package/runtime/legacy smoke 脚本，验证 receipt 输出，同时不在产品输出中保留旧顶层兼容字段。

## 任务与范围

- Harness 任务：`task_01KWFZ8JKRPCKBJCBPN672P3Z7`
- 分支：`codex/cli-command-receipt`
- 公开范围：CLI 成功输出 envelope、CLI command registry contract、CLI 测试，以及消费 CLI JSON 的 smoke/check 工具。
- 私有计划 / 证据是否已更新：yes，私有 harness task progress commits `b13a50b` 和 `d5c768c`。
- 范围外：error envelope 重设计、Markdown WriteCoordinator 范围调整。

## 版本影响

- 版本：不改版本，原因是这是 pre-release CLI contract change。
- 发布影响：不发布。

## 验证

- `origin/main` 基准 SHA：`fdc1dd11f31ad4fa5c380e835cb8d3a5a998d9ca`
- 当前分支与 `origin/main` 的 merge-base：`fdc1dd11f31ad4fa5c380e835cb8d3a5a998d9ca`
- 最近一次 `git fetch origin` 时间：`2026-07-01T23:38:16Z`
- 同步方式：rebase onto `origin/main`
- 公开 diff 命令：`git diff --name-only origin/main...HEAD`
- 私有证据 commit/path：`d5c768c` / `harness/planning/tasks/task_01KWFZ8JKRPCKBJCBPN672P3Z7-cli-command-receipt/progress.md`
- Reviewer 证据路径：not applicable；本次为 scoped CLI contract change，仅做 self-review。
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28555016567
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci` 未单独运行；使用现有 workspace install，rebase 后 `npm run check` 和 package smoke 已通过。

## 审查证据

- 自查：检查了 receipt normalization boundary、command registry envelope、receipt contract gate、smoke consumers，以及 public diff 不包含 private harness 文件。
- Reviewer subagent：未运行；本次是范围明确的 CLI contract change，已有完整本地 gate 覆盖。
- 人工审查：用户在 2026-07-02 明确要求合入；在本地 `npm run check` 和 `rewrite-ci` 通过后，对 REVIEW_REQUIRED 使用 admin bypass。
- 阻塞发现：none known。

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚：`rewrite-ci` 通过后 admin squash merge；合并后删除远端分支并移除本地 worktree。

## 残余风险

- 本次仅针对 branch protection 的 review requirement 使用 admin bypass，原因是用户明确要求合入，且本地 `npm run check` 和 GitHub Actions `rewrite-ci` 均已通过。
- 现有 command handlers 内部仍构造 `CliResult`；公开输出边界会把成功结果归一化为 `CommandReceipt/v1`。这样保持实现范围可控，同时通过测试和 gate 强制外部契约。
- GitHub Actions `rewrite-ci` 已通过；`full-check` 是 workflow 设计上的 skipped。

## 关联材料

- 任务：`task_01KWFZ8JKRPCKBJCBPN672P3Z7`
- 证据：rebase 后本地 `npm run check` 通过；私有 harness progress commit `d5c768c`。
- 审查：self-review，无阻塞发现。


