### PR TITLE
Consolidate task lifecycle contracts

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -2,15 +2,20 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import type { DomainStatus, EngineError, ProjectionWarning, TaskProjectionRow, WriteError } from "../../kernel/src/index.ts";
-import { isDomainStatus, isTerminalStatus, readTaskProjection } from "../../kernel/src/index.ts";
+import { isDomainStatus, readTaskProjection } from "../../kernel/src/index.ts";
 import type { HarnessLayoutInput, HarnessLayoutOverrides } from "../../kernel/src/layout/index.ts";
 import { createHarnessRuntimeContext, normalizeRelativeDocumentPath, taskDocumentPath as harnessTaskDocumentPath, validateTaskIdSyntax } from "../../kernel/src/layout/index.ts";
+import { makeTaskLifecycleOrchestrator } from "./task-lifecycle-orchestrator.ts";
 export {
   evaluateCompletionGate,
   evaluateReviewGate,
   parseReviewMarkdown,
   validatePhaseRows
 } from "./task-lifecycle-gates.ts";
+export {
+  makeTaskLifecycleOrchestrator,
+  readTaskLifecyclePolicy
+} from "./task-lifecycle-orchestrator.ts";
 export type {
   CompletionGateInput,
   PhaseRow,
@@ -19,6 +24,18 @@ export type {
   ReviewGateResult,
   VerifierBackedReviewContract
 } from "./task-lifecycle-gates.ts";
+export type {
+  TaskLifecycleError,
+  TaskLifecycleFailure,
+  TaskLifecycleOrchestrator,
+  TaskLifecycleOrchestratorOptions,
+  TaskLifecyclePolicy,
+  TaskLifecycleProgressWriteResult,
+  TaskLifecycleResult,
+  TaskLifecycleStatusWriteResult,
+  TaskLifecycleSuccess,
+  TaskLifecycleWriter
+} from "./task-lifecycle-orchestrator.ts";
 
 export interface LocalControllerServiceOptions {
   readonly rootDir: string;
@@ -126,6 +143,11 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
   const rootDir = path.resolve(options.rootDir);
   const layoutInput = createHarnessRuntimeContext(rootDir, options.layoutOverrides);
   const taskWriter = options.taskWriter;
+  const lifecycleOrchestrator = makeTaskLifecycleOrchestrator({
+    rootDir,
+    layoutOverrides: options.layoutOverrides,
+    taskWriter
+  });
 
   return {
     getTasks: () => {
@@ -158,32 +180,11 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
     },
     setTaskStatus: async (payload) => {
       validateTaskId(payload.taskId);
-      if (isTerminalStatus(payload.status)) {
-        return {
-          ok: false,
-          error: {
-            code: "terminal_status_requires_task_complete",
-            hint: payload.status === "done"
-              ? "Use task-complete after review, CI, and closeout gates pass."
-              : "Terminal cancellation requires an audited recovery path."
-          }
-        };
-      }
-      return Effect.runPromise(taskWriter.setStatus({ taskId: payload.taskId, status: payload.status }).pipe(
-        Effect.match({
-          onFailure: (error) => ({ ok: false, error: { code: error._tag, hint: "Status update failed." } }),
-          onSuccess: () => ({ ok: true })
-        })
-      ));
+      return Effect.runPromise(lifecycleOrchestrator.setTaskStatus(payload).pipe(Effect.map(toLocalControllerResult)));
     },
     reviewTask: async (payload) => {
       validateTaskId(payload.taskId);
-      return Effect.runPromise(taskWriter.setStatus({ taskId: payload.taskId, status: "in_review" }).pipe(
-        Effect.match({
-          onFailure: (error) => ({ ok: false, error: { code: error._tag, hint: "Review transition failed." } }),
-          onSuccess: () => ({ ok: true })
-        })
-      ));
+      return Effect.runPromise(lifecycleOrchestrator.startTaskReview(payload).pipe(Effect.map(toLocalControllerResult)));
     },
     appendTaskProgress: async (payload) => {
       validateTaskId(payload.taskId);
@@ -279,6 +280,10 @@ function invalidPayload(hint: string): LocalControllerFailure {
 
 function taskNotFound(taskId: string): LocalControllerFailure {
   return { ok: false, error: { code: "task_not_found", hint: `task not found: ${taskId}` } };
+}
+
+function toLocalControllerResult(result: { readonly ok: true } | { readonly ok: false; readonly error: LocalControllerError }): LocalControllerResult {
+  return result.ok ? { ok: true } : { ok: false, error: result.error };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/application/src/task-lifecycle-orchestrator.ts
+++ b/packages/application/src/task-lifecycle-orchestrator.ts
@@ -1,0 +1,227 @@
+import { existsSync, readFileSync } from "node:fs";
+import { Effect } from "effect";
+import type { DomainStatus, EngineError, WriteError } from "../../kernel/src/index.ts";
+import { isDomainStatus, isTerminalStatus, readTaskProjection } from "../../kernel/src/index.ts";
+import type { HarnessLayoutInput, HarnessLayoutOverrides } from "../../kernel/src/layout/index.ts";
+import { createHarnessRuntimeContext, readFrontmatter, readScalar, taskDocumentPath } from "../../kernel/src/layout/index.ts";
+import { evaluateCompletionGate, evaluateReviewGate, parseReviewMarkdown } from "./task-lifecycle-gates.ts";
+import type { VerifierBackedReviewContract } from "./task-lifecycle-gates.ts";
+
+type CompletionGateResult = ReturnType<typeof evaluateCompletionGate>;
+
+export interface TaskLifecycleStatusWriteResult {
+  readonly taskId: string;
+  readonly status: DomainStatus;
+}
+
+export interface TaskLifecycleProgressWriteResult {
+  readonly taskId: string;
+  readonly path: string;
+}
+
+export interface TaskLifecycleWriter {
+  readonly setStatus: (payload: { readonly taskId: string; readonly status: DomainStatus }) => Effect.Effect<TaskLifecycleStatusWriteResult, EngineError | WriteError>;
+  readonly appendProgress: (payload: { readonly taskId: string; readonly text: string }) => Effect.Effect<TaskLifecycleProgressWriteResult, EngineError | WriteError>;
+}
+
+export interface TaskLifecycleOrchestratorOptions {
+  readonly rootDir: string;
+  readonly layoutOverrides?: HarnessLayoutOverrides;
+  readonly taskWriter: TaskLifecycleWriter;
+  readonly now?: () => string;
+}
+
+export interface TaskLifecycleError {
+  readonly code: string;
+  readonly hint: string;
+}
+
+export interface TaskLifecycleFailure {
+  readonly ok: false;
+  readonly taskId: string;
+  readonly error: TaskLifecycleError;
+  readonly report?: unknown;
+  readonly issues?: ReadonlyArray<unknown>;
+  readonly completionGate?: CompletionGateResult;
+}
+
+export interface TaskLifecycleSuccess {
+  readonly ok: true;
+  readonly taskId: string;
+  readonly status?: DomainStatus;
+  readonly path?: string;
+  readonly report?: unknown;
+  readonly reviewContract?: VerifierBackedReviewContract;
+  readonly completionGate?: CompletionGateResult;
+}
+
+export type TaskLifecycleResult = TaskLifecycleSuccess | TaskLifecycleFailure;
+
+export interface TaskLifecycleOrchestrator {
+  readonly setTaskStatus: (payload: { readonly taskId: string; readonly status: DomainStatus }) => Effect.Effect<TaskLifecycleResult>;
+  readonly startTaskReview: (payload: { readonly taskId: string }) => Effect.Effect<TaskLifecycleResult>;
+  readonly reviewTask: (payload: { readonly taskId: string; readonly reviewerId: string }) => Effect.Effect<TaskLifecycleResult>;
+  readonly completeTask: (payload: { readonly taskId: string; readonly reviewerId: string; readonly ciGate: "passed" | "failed" }) => Effect.Effect<TaskLifecycleResult>;
+}
+
+export interface TaskLifecyclePolicy {
+  readonly engine: string;
+  readonly status: DomainStatus | null;
+}
+
+export function makeTaskLifecycleOrchestrator(options: TaskLifecycleOrchestratorOptions): TaskLifecycleOrchestrator {
+  const layoutInput = createHarnessRuntimeContext(options.rootDir, options.layoutOverrides);
+
+  return {
+    setTaskStatus: (payload) => {
+      if (isTerminalStatus(payload.status)) {
+        return Effect.succeed(terminalStatusFailure(payload.taskId, payload.status));
+      }
+      return options.taskWriter.setStatus(payload).pipe(
+        Effect.match({
+          onFailure: (error): TaskLifecycleResult => writeFailure(payload.taskId, error, "Status update failed."),
+          onSuccess: (result): TaskLifecycleResult => ({ ok: true, taskId: result.taskId, status: result.status })
+        })
+      );
+    },
+    startTaskReview: (payload) => options.taskWriter.setStatus({ taskId: payload.taskId, status: "in_review" }).pipe(
+      Effect.match({
+        onFailure: (error): TaskLifecycleResult => writeFailure(payload.taskId, error, "Review transition failed."),
+        onSuccess: (result): TaskLifecycleResult => ({ ok: true, taskId: result.taskId, status: result.status })
+      })
+    ),
+    reviewTask: (payload) => Effect.sync(() => reviewTask(layoutInput, payload.taskId, payload.reviewerId, options.now)),
+    completeTask: (payload) => Effect.gen(function* () {
+      const review = yield* Effect.sync(() => reviewTask(layoutInput, payload.taskId, payload.reviewerId, options.now));
+      if (!review.ok) {
+        return {
+          ok: false,
+          taskId: payload.taskId,
+          report: review.report,
+          issues: review.issues,
+          error: {
+            code: "review_not_passed",
+            hint: "Task completion requires a passed task-review gate."
+          }
+        } satisfies TaskLifecycleResult;
+      }
+
+      const projection = readTaskProjection({ rootDir: options.rootDir, layoutOverrides: options.layoutOverrides });
+      const row = projection.rows.find((item) => item.taskId === payload.taskId);
+      if (!row) return taskFailure(payload.taskId, "task_not_found", `task not found: ${payload.taskId}`);
+
+      const completionGate = evaluateCompletionGate({
+        taskId: payload.taskId,
+        coordinationStatus: row.coordinationStatus,
+        packageDisposition: row.packageDisposition,
+        closeoutReadiness: row.closeoutReadiness,
+        reviewGate: "passed",
+        ciGate: payload.ciGate
+      });
+      if (!completionGate.ok) {
+        return {
+          ok: false,
+          taskId: payload.taskId,
+          completionGate,
+          issues: completionGate.issues,
+          error: {
+            code: completionGateErrorCode(completionGate.issues),
+            hint: "Task completion gate failed."
+          }
+        } satisfies TaskLifecycleResult;
+      }
+
+      const status = yield* options.taskWriter.setStatus({ taskId: payload.taskId, status: "done" }).pipe(
+        Effect.match({
+          onFailure: (error): TaskLifecycleResult => writeFailure(payload.taskId, error, "Completion status update failed."),
+          onSuccess: (result): TaskLifecycleResult => ({ ok: true, taskId: result.taskId, status: result.status })
+        })
+      );
+      if (!status.ok) return status;
+      return {
+        ok: true,
+        taskId: payload.taskId,
+        status: status.status,
+        completionGate,
+        reviewContract: review.reviewContract
+      } satisfies TaskLifecycleResult;
+    })
+  };
+}
+
+export function readTaskLifecyclePolicy(rootInput: HarnessLayoutInput, taskId: string): TaskLifecyclePolicy | null {
+  const indexPath = taskDocumentPath(rootInput, taskId, "INDEX.md");
+  if (!existsSync(indexPath)) return null;
+  const frontmatter = readFrontmatter(readFileSync(indexPath, "utf8"));
+  if (!frontmatter) return null;
+  const status = readScalar(frontmatter, "  status");
+  return { engine: readScalar(frontmatter, "  engine") || "", status: isDomainStatus(status) ? status : null };
+}
+
+function reviewTask(
+  rootInput: HarnessLayoutInput,
+  taskId: string,
+  reviewerId: string,
+  now: (() => string) | undefined
+): TaskLifecycleResult {
+  const reviewPath = taskDocumentPath(rootInput, taskId, "review.md");
+  if (!existsSync(reviewPath)) {
+    return taskFailure(taskId, "review_document_missing", "Task review requires review.md in the task package.");
+  }
+
+  const parsed = parseReviewMarkdown(readFileSync(reviewPath, "utf8"));
+  if (parsed.issues.length > 0) {
+    return {
+      ok: false,
+      taskId,
+      issues: parsed.issues,
+      error: {
+        code: "review_schema_invalid",
+        hint: "review.md material findings table failed validation."
+      }
+    };
+  }
+
+  const gate = evaluateReviewGate({
+    taskId,
+    reviewerId,
+    submittedAt: now ? now() : new Date().toISOString(),
+    findings: parsed.findings
+  });
+  if (!gate.ok) {
+    return {
+      ok: false,
+      taskId,
+      report: gate,
+      issues: gate.issues,
+      error: {
+        code: "release_blocking_findings",
+        hint: "Open release-blocking findings must be closed before review passes."
+      }
+    };
+  }
+
+  return { ok: true, taskId, report: gate, reviewContract: gate.contract };
+}
+
+function terminalStatusFailure(taskId: string, status: DomainStatus): TaskLifecycleFailure {
+  return taskFailure(
+    taskId,
+    "terminal_status_requires_task_complete",
+    status === "done"
+      ? "Use task-complete after review, CI, and closeout gates pass."
+      : "Terminal cancellation requires an audited recovery path."
+  );
+}
+
+function taskFailure(taskId: string, code: string, hint: string): TaskLifecycleFailure {
+  return { ok: false, taskId, error: { code, hint } };
+}
+
+function writeFailure(taskId: string, error: EngineError | WriteError, fallbackHint: string): TaskLifecycleFailure {
+  return taskFailure(taskId, error._tag, fallbackHint);
+}
+
+function completionGateErrorCode(issues: ReadonlyArray<{ readonly code: string }>): string {
+  return issues[0]?.code ?? "completion_gate_failed";
+}

--- a/packages/cli/src/cli/command-registry.ts
+++ b/packages/cli/src/cli/command-registry.ts
@@ -39,6 +39,11 @@ export interface CommandUsage {
   readonly aliases?: ReadonlyArray<string>;
 }
 
+export interface CommandReceiptContract {
+  readonly data: ReadonlyArray<string>;
+  readonly paths: ReadonlyArray<string>;
+}
+
 const commandUsages = [
   { kind: "help", usage: "help", aliases: ["--help", "-h"] },
   { kind: "version", usage: "version", aliases: ["--version", "-v"] },
@@ -311,11 +316,66 @@ const commandExamples = {
   "gui": [`${cliCommandName} gui`]
 } satisfies Record<CommandKind, ReadonlyArray<string>>;
 
+const commandReceiptContractsByKind = {
+  "help": { data: ["commands", "report"], paths: [] },
+  "version": { data: ["version"], paths: [] },
+  "init": { data: ["generated"], paths: ["primary", "config"] },
+  "new-task": { data: ["taskId", "slug", "status", "preset", "module", "generated", "report"], paths: ["package"] },
+  "status-set": { data: ["taskId", "status", "forced", "forceAudit"], paths: ["forceAudit"] },
+  "progress-append": { data: ["taskId", "report"], paths: ["primary", "progress"] },
+  "task-archive": { data: ["taskId", "status", "report"], paths: [] },
+  "task-supersede": { data: ["taskId", "status", "report"], paths: ["primary", "package"] },
+  "task-delete": { data: ["taskId", "mode", "report"], paths: [] },
+  "task-reopen": { data: ["taskId", "status", "report"], paths: [] },
+  "task-review": { data: ["taskId", "reviewContract", "report"], paths: [] },
+  "task-complete": { data: ["taskId", "status", "completionGate", "report"], paths: [] },
+  "template-list": { data: ["templates"], paths: [] },
+  "template-render": { data: ["document"], paths: [] },
+  "task-list": { data: ["tasks", "rows"], paths: [] },
+  "status": { data: ["rows", "summary", "report", "commands"], paths: ["projection"] },
+  "check": { data: ["profile", "rows", "summary", "report"], paths: ["projection"] },
+  "governance-rebuild": { data: ["mode", "rows", "generated", "report"], paths: ["projection"] },
+  "lesson-promote": { data: ["taskId", "mode", "report"], paths: [] },
+  "lesson-sediment": { data: ["taskId", "mode", "report"], paths: [] },
+  "adopt-multica": { data: ["taskId", "status", "report"], paths: [] },
+  "snapshot-multica": { data: ["report"], paths: [] },
+  "migrate-plan": { data: ["rows", "report"], paths: [] },
+  "migrate-structure": { data: ["mode", "report"], paths: [] },
+  "migrate-run": { data: ["migrationMode", "report"], paths: ["primary", "session"] },
+  "migrate-verify": { data: ["report"], paths: [] },
+  "legacy-scan": { data: ["report"], paths: [] },
+  "legacy-intake-plan": { data: ["report"], paths: ["primary", "plan"] },
+  "legacy-copy-safe-docs": { data: ["report"], paths: [] },
+  "legacy-index": { data: ["summary", "report"], paths: ["primary", "index"] },
+  "legacy-verify": { data: ["report"], paths: [] },
+  "git-diff": { data: ["report"], paths: [] },
+  "doctor": { data: ["report"], paths: [] },
+  "preset-validate": { data: ["preset", "report"], paths: [] },
+  "preset-list": { data: ["presets"], paths: [] },
+  "preset-inspect": { data: ["preset"], paths: [] },
+  "preset-check": { data: ["preset", "report"], paths: [] },
+  "preset-install": { data: ["preset", "report"], paths: [] },
+  "preset-seed": { data: ["presets", "report"], paths: [] },
+  "preset-audit": { data: ["presets", "report"], paths: [] },
+  "preset-uninstall": { data: ["preset", "report"], paths: [] },
+  "preset-run": { data: ["taskId", "preset", "generated", "report"], paths: [] },
+  "preset-action": { data: ["taskId", "preset", "generated", "report"], paths: [] },
+  "module-list": { data: ["modules"], paths: [] },
+  "module-inspect": { data: ["module"], paths: [] },
+  "module-register": { data: ["module"], paths: [] },
+  "module-scaffold": { data: ["module"], paths: ["primary", "modulePlan"] },
+  "module-unregister": { data: ["module"], paths: [] },
+  "module-step": { data: ["module"], paths: [] },
+  "vertical-validate": { data: ["report"], paths: [] },
+  "gui": { data: ["launchPlan"], paths: [] }
+} satisfies Record<CommandKind, CommandReceiptContract>;
+
 export interface CommandDescriptor extends CommandUsage {
   readonly parserId: CommandParserId;
   readonly runnerId: CommandRunnerId;
   readonly summary: string;
   readonly examples: ReadonlyArray<string>;
+  readonly receiptContract: CommandReceiptContract;
 }
 
 export const commandDescriptors = commandUsages.map((entry) => ({
@@ -323,8 +383,14 @@ export const commandDescriptors = commandUsages.map((entry) => ({
   parserId: commandParserIds[entry.kind],
   runnerId: commandRunnerIds[entry.kind],
   summary: commandSummaries[entry.kind],
-  examples: commandExamples[entry.kind]
+  examples: commandExamples[entry.kind],
+  receiptContract: commandReceiptContractsByKind[entry.kind]
 })) satisfies ReadonlyArray<CommandDescriptor>;
+
+export const commandReceiptContracts = commandDescriptors.map((entry) => ({
+  kind: entry.kind,
+  ...entry.receiptContract
+}));
 
 export const commandRegistry = commandDescriptors.map((entry) => {
   const shortAliases = "aliases" in entry ? entry.aliases : [];

--- a/packages/cli/src/cli/error-codes.ts
+++ b/packages/cli/src/cli/error-codes.ts
@@ -118,6 +118,40 @@ export const CliErrorCode = {
 export type CliErrorCode = (typeof CliErrorCode)[keyof typeof CliErrorCode];
 
 export type CliErrorCategory = "parse" | "command" | "domain" | "settings" | "extension" | "migration";
+export type CliErrorFamily = "kernel-mapped" | "command-local";
+
+export const cliKernelMappedErrorCodes = new Set<CliErrorCode>([
+  CliErrorCode.ArchivedHardDeleteForbidden,
+  CliErrorCode.ArtifactReadFailed,
+  CliErrorCode.ArtifactWriteRejected,
+  CliErrorCode.DuplicateAdoptClaim,
+  CliErrorCode.DuplicateExternalBinding,
+  CliErrorCode.EngineOwnsStatus,
+  CliErrorCode.GeneratedTaskIdRequired,
+  CliErrorCode.InvalidTransition,
+  CliErrorCode.JournalUnavailable,
+  CliErrorCode.MalformedSnapshot,
+  CliErrorCode.RelatedTaskHardDeleteForbidden,
+  CliErrorCode.StaleSnapshotRefused,
+  CliErrorCode.TaskAlreadyExists,
+  CliErrorCode.TaskNotFound,
+  CliErrorCode.TerminalHardDeleteForbidden,
+  CliErrorCode.TerminalReopenRequiresSupersede,
+  CliErrorCode.WriteConflict,
+  CliErrorCode.WriteRejected,
+  CliErrorCode.EngineNotEnabled,
+  CliErrorCode.AdapterUnavailable,
+  CliErrorCode.AuthMissing,
+  CliErrorCode.RefNotFound,
+  CliErrorCode.StatusUnmapped,
+  CliErrorCode.RateLimited,
+  CliErrorCode.EngineUnreachable,
+  CliErrorCode.Timeout
+]);
+
+export const cliCommandLocalErrorCodes = new Set<CliErrorCode>(
+  Object.values(CliErrorCode).filter((code): code is CliErrorCode => !cliKernelMappedErrorCodes.has(code as CliErrorCode))
+);
 
 export interface CliError {
   readonly code: CliErrorCode;
@@ -252,6 +286,10 @@ export function cliError(code: CliErrorCode, hint?: string): CliError {
 
 export function isCliErrorCode(value: unknown): value is CliErrorCode {
   return typeof value === "string" && Object.hasOwn(cliErrorCodeRegistry, value);
+}
+
+export function cliErrorFamily(code: CliErrorCode): CliErrorFamily {
+  return cliKernelMappedErrorCodes.has(code) ? "kernel-mapped" : "command-local";
 }
 
 export function missingRequiredOptionErrorCode(name: string): CliErrorCode {

--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -20,66 +20,6 @@ export interface CommandReceiptWrite {
   readonly paths?: ReadonlyArray<string>;
 }
 
-interface CommandReceiptContract {
-  readonly kind: string;
-  readonly data: ReadonlyArray<string>;
-  readonly paths: ReadonlyArray<string>;
-}
-
-export const commandReceiptContracts = [
-  { kind: "help", data: ["commands", "report"], paths: [] },
-  { kind: "init", data: ["generated"], paths: ["primary", "config"] },
-  { kind: "new-task", data: ["taskId", "slug", "status", "preset", "module", "generated", "report"], paths: ["package"] },
-  { kind: "status-set", data: ["taskId", "status", "forced", "forceAudit"], paths: ["forceAudit"] },
-  { kind: "progress-append", data: ["taskId", "report"], paths: ["primary", "progress"] },
-  { kind: "task-archive", data: ["taskId", "status", "report"], paths: [] },
-  { kind: "task-supersede", data: ["taskId", "status", "report"], paths: ["primary", "package"] },
-  { kind: "task-delete", data: ["taskId", "mode", "report"], paths: [] },
-  { kind: "task-reopen", data: ["taskId", "status", "report"], paths: [] },
-  { kind: "task-review", data: ["taskId", "reviewContract", "report"], paths: [] },
-  { kind: "task-complete", data: ["taskId", "status", "completionGate", "report"], paths: [] },
-  { kind: "template-list", data: ["templates"], paths: [] },
-  { kind: "template-render", data: ["document"], paths: [] },
-  { kind: "task-list", data: ["tasks", "rows"], paths: [] },
-  { kind: "status", data: ["rows", "summary", "report", "commands"], paths: ["projection"] },
-  { kind: "check", data: ["profile", "rows", "summary", "report"], paths: ["projection"] },
-  { kind: "governance-rebuild", data: ["mode", "rows", "generated", "report"], paths: ["projection"] },
-  { kind: "lesson-promote", data: ["taskId", "mode", "report"], paths: [] },
-  { kind: "lesson-sediment", data: ["taskId", "mode", "report"], paths: [] },
-  { kind: "adopt-multica", data: ["taskId", "status", "report"], paths: [] },
-  { kind: "snapshot-multica", data: ["report"], paths: [] },
-  { kind: "migrate-plan", data: ["rows", "report"], paths: [] },
-  { kind: "migrate-structure", data: ["mode", "report"], paths: [] },
-  { kind: "migrate-run", data: ["migrationMode", "report"], paths: ["primary", "session"] },
-  { kind: "migrate-verify", data: ["report"], paths: [] },
-  { kind: "legacy-scan", data: ["report"], paths: [] },
-  { kind: "legacy-intake-plan", data: ["report"], paths: ["primary", "plan"] },
-  { kind: "legacy-copy-safe-docs", data: ["report"], paths: [] },
-  { kind: "legacy-index", data: ["summary", "report"], paths: ["primary", "index"] },
-  { kind: "legacy-verify", data: ["report"], paths: [] },
-  { kind: "git-diff", data: ["report"], paths: [] },
-  { kind: "doctor", data: ["report"], paths: [] },
-  { kind: "preset-validate", data: ["preset", "report"], paths: [] },
-  { kind: "preset-list", data: ["presets"], paths: [] },
-  { kind: "preset-inspect", data: ["preset"], paths: [] },
-  { kind: "preset-check", data: ["preset", "report"], paths: [] },
-  { kind: "preset-install", data: ["preset", "report"], paths: [] },
-  { kind: "preset-seed", data: ["presets", "report"], paths: [] },
-  { kind: "preset-audit", data: ["presets", "report"], paths: [] },
-  { kind: "preset-uninstall", data: ["preset", "report"], paths: [] },
-  { kind: "preset-run", data: ["taskId", "preset", "generated", "report"], paths: [] },
-  { kind: "preset-action", data: ["taskId", "preset", "generated", "report"], paths: [] },
-  { kind: "module-list", data: ["modules"], paths: [] },
-  { kind: "module-inspect", data: ["module"], paths: [] },
-  { kind: "module-register", data: ["module"], paths: [] },
-  { kind: "module-scaffold", data: ["module"], paths: ["primary", "modulePlan"] },
-  { kind: "module-unregister", data: ["module"], paths: [] },
-  { kind: "module-step", data: ["module"], paths: [] },
-  { kind: "vertical-validate", data: ["report"], paths: [] },
-  { kind: "gui", data: ["launchPlan"], paths: [] },
-  { kind: "version", data: ["version"], paths: [] }
-] as const satisfies ReadonlyArray<CommandReceiptContract>;
-
 const baseResultKeys = new Set(["ok", "command", "error", "path", "packagePath", "projectionPath", "warnings"]);
 
 type CliFailureResult = CliResult & { readonly ok: false };

--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -1,116 +1,52 @@
-import { existsSync, readFileSync } from "node:fs";
 import { Effect } from "effect";
-import { evaluateCompletionGate, evaluateReviewGate, parseReviewMarkdown } from "../../../../application/src/index.ts";
-import { taskDocumentPath } from "../../../../kernel/src/layout/index.ts";
-import { readTaskProjection } from "../../../../kernel/src/index.ts";
+import { makeTaskLifecycleOrchestrator, type TaskLifecycleResult } from "../../../../application/src/index.ts";
 import { cliError, CliErrorCode, isCliErrorCode, type CliErrorCode as CliErrorCodeValue } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
-import type { CommandRunner, CommandRunnerContext } from "../../cli/runner-registry.ts";
+import type { CommandRunner } from "../../cli/runner-registry.ts";
 
 type TaskGateAction = Extract<Parameters<CommandRunner>[1]["action"], { readonly kind: "task-review" | "task-complete" }>;
 
 export const runTaskGatesCommand: CommandRunner = (context, command) => {
   const action = command.action as TaskGateAction;
-  if (action.kind === "task-review") {
-    return Effect.sync(() => runTaskReview(context, action.taskId, action.reviewerId));
-  }
-  return Effect.gen(function* () {
-    const gate = runTaskComplete(context, action.taskId, action.reviewerId, action.ciGate);
-    if (!gate.ok) return gate;
-    const result = yield* context.engine.setStatus({ taskId: action.taskId, status: "done" });
-    return { ...gate, status: result.status } satisfies CliResult;
+  const orchestrator = makeTaskLifecycleOrchestrator({
+    rootDir: context.rootDir,
+    layoutOverrides: context.layoutOverrides,
+    taskWriter: context.engine
   });
+  if (action.kind === "task-review") {
+    return orchestrator.reviewTask({ taskId: action.taskId, reviewerId: action.reviewerId }).pipe(
+      Effect.map((result): CliResult => taskLifecycleResultToCliResult("task-review", result))
+    );
+  }
+  return orchestrator.completeTask({ taskId: action.taskId, reviewerId: action.reviewerId, ciGate: action.ciGate }).pipe(
+    Effect.map((result): CliResult => taskLifecycleResultToCliResult("task-complete", result))
+  );
 };
 
-function runTaskReview(context: CommandRunnerContext, taskId: string, reviewerId: string): CliResult {
-  const reviewPath = taskDocumentPath(context.layoutInput, taskId, "review.md");
-  if (!existsSync(reviewPath)) {
+function taskLifecycleResultToCliResult(command: "task-review" | "task-complete", result: TaskLifecycleResult): CliResult {
+  if (result.ok) {
     return {
-      ok: false,
-      command: "task-review",
-      taskId,
-      error: cliError(CliErrorCode.ReviewDocumentMissing, "Task review requires review.md in the task package.")
+      ok: true,
+      command,
+      taskId: result.taskId,
+      status: result.status,
+      report: result.report,
+      reviewContract: result.reviewContract,
+      completionGate: result.completionGate
     };
   }
-
-  const parsed = parseReviewMarkdown(readFileSync(reviewPath, "utf8"));
-  if (parsed.issues.length > 0) {
-    return {
-      ok: false,
-      command: "task-review",
-      taskId,
-      issues: parsed.issues,
-      error: cliError(CliErrorCode.ReviewSchemaInvalid, "review.md material findings table failed validation.")
-    };
-  }
-
-  const gate = evaluateReviewGate({
-    taskId,
-    reviewerId,
-    submittedAt: new Date().toISOString(),
-    findings: parsed.findings
-  });
-  if (!gate.ok) {
-    return {
-      ok: false,
-      command: "task-review",
-      taskId,
-      report: gate,
-      issues: gate.issues,
-      error: cliError(CliErrorCode.ReleaseBlockingFindings, "Open release-blocking findings must be closed before review passes.")
-    };
-  }
-
-  return { ok: true, command: "task-review", taskId, report: gate, reviewContract: gate.contract };
+  return {
+    ok: false,
+    command,
+    taskId: result.taskId,
+    report: result.report,
+    issues: result.issues,
+    completionGate: result.completionGate,
+    error: cliError(cliErrorCode(result.error.code), result.error.hint)
+  };
 }
 
-function runTaskComplete(context: CommandRunnerContext, taskId: string, reviewerId: string, ciGate: "passed" | "failed"): CliResult {
-  const review = runTaskReview(context, taskId, reviewerId);
-  if (!review.ok) {
-    return {
-      ok: false,
-      command: "task-complete",
-      taskId,
-      report: review.report,
-      issues: review.issues,
-      error: cliError(CliErrorCode.ReviewNotPassed, "Task completion requires a passed task-review gate.")
-    };
-  }
-
-  const projection = readTaskProjection({ rootDir: context.rootDir, layoutOverrides: context.layoutOverrides });
-  const row = projection.rows.find((item) => item.taskId === taskId);
-  if (!row) {
-    return {
-      ok: false,
-      command: "task-complete",
-      taskId,
-      error: cliError(CliErrorCode.TaskNotFound, `task not found: ${taskId}`)
-    };
-  }
-
-  const completionGate = evaluateCompletionGate({
-    taskId,
-    coordinationStatus: row.coordinationStatus,
-    packageDisposition: row.packageDisposition,
-    closeoutReadiness: row.closeoutReadiness,
-    reviewGate: "passed",
-    ciGate
-  });
-  if (!completionGate.ok) {
-    return {
-      ok: false,
-      command: "task-complete",
-      taskId,
-      completionGate,
-      issues: completionGate.issues,
-      error: cliError(completionGateErrorCode(completionGate.issues), "Task completion gate failed.")
-    };
-  }
-
-  return { ok: true, command: "task-complete", taskId, completionGate, reviewContract: review.reviewContract };
-}
-
-function completionGateErrorCode(issues: ReadonlyArray<{ readonly code: string }>): CliErrorCodeValue {
-  const code = issues[0]?.code;
-  return isCliErrorCode(code) ? code : CliErrorCode.CompletionGateFailed;
+function cliErrorCode(code: string): CliErrorCodeValue {
+  if (isCliErrorCode(code)) return code;
+  return CliErrorCode.CompletionGateFailed;
 }

--- a/packages/cli/src/commands/core/task-lifecycle.ts
+++ b/packages/cli/src/commands/core/task-lifecycle.ts
@@ -1,8 +1,7 @@
-import { existsSync, readFileSync } from "node:fs";
 import { Effect } from "effect";
+import { readTaskLifecyclePolicy } from "../../../../application/src/index.ts";
 import type { DomainStatus, EngineError, WriteError } from "../../../../kernel/src/domain/index.ts";
-import { explainStatusTransition, isDomainStatus, isTerminalStatus } from "../../../../kernel/src/domain/index.ts";
-import { readFrontmatter, readScalar, taskDocumentPath } from "../../../../kernel/src/layout/index.ts";
+import { explainStatusTransition, isTerminalStatus } from "../../../../kernel/src/domain/index.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
 import type { CommandRunner, CommandRunnerContext } from "../../cli/runner-registry.ts";
@@ -82,7 +81,7 @@ function runStatusSet(
     })));
   }
 
-  const taskPolicy = readTaskStatusPolicy(context, taskId);
+  const taskPolicy = readTaskLifecyclePolicy(context.layoutInput, taskId);
   if (taskPolicy?.engine !== "local") {
     return context.engine.setStatus({ taskId, status }).pipe(Effect.map((result): CliResult => ({
       ok: true,
@@ -165,15 +164,6 @@ function runTaskDelete(
     path: result.mode,
     report: action.deletedBy ? { schema: "task-delete-report/v1", deletedBy: action.deletedBy } : undefined
   })));
-}
-
-function readTaskStatusPolicy(context: CommandRunnerContext, taskId: string): { readonly engine: string; readonly status: DomainStatus | null } | null {
-  const indexPath = taskDocumentPath(context.layoutInput, taskId, "INDEX.md");
-  if (!existsSync(indexPath)) return null;
-  const frontmatter = readFrontmatter(readFileSync(indexPath, "utf8"));
-  if (!frontmatter) return null;
-  const status = readScalar(frontmatter, "  status");
-  return { engine: readScalar(frontmatter, "  engine") || "", status: isDomainStatus(status) ? status : null };
 }
 
 function renderForceStatusAudit(status: string, reason: string): string {

--- a/tools/check-cli-error-codes.mjs
+++ b/tools/check-cli-error-codes.mjs
@@ -15,6 +15,7 @@ export function findCliErrorCodeViolations(rootDir = process.cwd()) {
   const registrySource = readFileSync(path.join(rootDir, registryPath), "utf8");
   const codeEntries = cliErrorCodeEntries(registrySource);
   const codeNames = new Set(codeEntries.map((entry) => entry.name));
+  const kernelMappedNames = cliErrorFamilyNames(registrySource, "cliKernelMappedErrorCodes");
   const codeValues = new Map();
   const duplicateValues = new Set();
 
@@ -38,6 +39,22 @@ export function findCliErrorCodeViolations(rootDir = process.cwd()) {
       violations.push(`${registryPath} must export ${exportedName}`);
     }
   }
+  for (const exportedName of ["cliKernelMappedErrorCodes", "cliCommandLocalErrorCodes", "cliErrorFamily"]) {
+    if (!registrySource.includes(`export const ${exportedName}`) && !registrySource.includes(`export function ${exportedName}`)) {
+      violations.push(`${registryPath} must export ${exportedName}`);
+    }
+  }
+  for (const name of kernelMappedNames) {
+    if (!codeNames.has(name)) violations.push(`cliKernelMappedErrorCodes has stale CliErrorCode.${name}`);
+  }
+  for (const entry of codeEntries) {
+    if (/^[A-Z][A-Za-z0-9]+$/u.test(entry.value) && !kernelMappedNames.has(entry.name)) {
+      violations.push(`PascalCase kernel adapter code CliErrorCode.${entry.name} must be in cliKernelMappedErrorCodes`);
+    }
+  }
+  if (!/cliCommandLocalErrorCodes\s*=\s*new Set<\s*CliErrorCode\s*>\s*\(\s*Object\.values\(CliErrorCode\)\.filter/u.test(registrySource)) {
+    violations.push("cliCommandLocalErrorCodes must be derived from CliErrorCode minus cliKernelMappedErrorCodes");
+  }
 
   for (const file of walkFiles(path.join(rootDir, sourceRoot))) {
     const relative = path.relative(rootDir, file);
@@ -58,6 +75,24 @@ function cliErrorCodeEntries(source) {
 function cliErrorRegistryNames(source) {
   const registrySource = extractAssignedLiteral(source, "cliErrorCodeRegistry");
   return new Set([...registrySource.matchAll(/\[\s*CliErrorCode\.([A-Za-z0-9]+)\s*\]\s*:/gmu)].map((match) => match[1]));
+}
+
+function cliErrorFamilyNames(source, constName) {
+  const start = source.indexOf(`export const ${constName}`);
+  if (start < 0) return new Set();
+  const bodyStart = source.indexOf("[", start);
+  if (bodyStart < 0) return new Set();
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "[") depth += 1;
+    if (char === "]") depth -= 1;
+    if (depth === 0) {
+      const body = source.slice(bodyStart, index + 1);
+      return new Set([...body.matchAll(/CliErrorCode\.([A-Za-z0-9]+)/gmu)].map((match) => match[1]));
+    }
+  }
+  return new Set();
 }
 
 function inlineCliResultErrorViolations(relativePath, source) {

--- a/tools/check-cli-error-codes.test.mjs
+++ b/tools/check-cli-error-codes.test.mjs
@@ -13,6 +13,10 @@ test("CLI error code gate rejects missing registry metadata and inline CliResult
         UnknownCommand: "unknown_command"
       } as const;
       export type CliErrorCode = typeof CliErrorCode[keyof typeof CliErrorCode];
+      export const cliKernelMappedErrorCodes = new Set<CliErrorCode>([]);
+      export const cliCommandLocalErrorCodes = new Set<CliErrorCode>(
+        Object.values(CliErrorCode).filter((code): code is CliErrorCode => !cliKernelMappedErrorCodes.has(code as CliErrorCode))
+      );
       export const cliErrorCodeRegistry = {
         [CliErrorCode.UnknownCommand]: { category: "parse", defaultHint: "Unknown command." }
       };
@@ -21,6 +25,9 @@ test("CLI error code gate rejects missing registry metadata and inline CliResult
       }
       export function isCliErrorCode(value: string): value is CliErrorCode {
         return Object.values(CliErrorCode).includes(value as CliErrorCode);
+      }
+      export function cliErrorFamily(code: CliErrorCode) {
+        return cliKernelMappedErrorCodes.has(code) ? "kernel-mapped" : "command-local";
       }
     `);
     writeFile(rootDir, "packages/cli/src/commands/new-task.ts", `
@@ -47,6 +54,10 @@ test("CLI error code gate accepts registry helpers and validation issue codes", 
         UnknownCommand: "unknown_command"
       } as const;
       export type CliErrorCode = typeof CliErrorCode[keyof typeof CliErrorCode];
+      export const cliKernelMappedErrorCodes = new Set<CliErrorCode>([]);
+      export const cliCommandLocalErrorCodes = new Set<CliErrorCode>(
+        Object.values(CliErrorCode).filter((code): code is CliErrorCode => !cliKernelMappedErrorCodes.has(code as CliErrorCode))
+      );
       export const cliErrorCodeRegistry = {
         [CliErrorCode.MissingTitle]: { category: "parse", defaultHint: "Use --title." },
         [CliErrorCode.UnknownCommand]: { category: "parse", defaultHint: "Unknown command." }
@@ -56,6 +67,9 @@ test("CLI error code gate accepts registry helpers and validation issue codes", 
       }
       export function isCliErrorCode(value: string): value is CliErrorCode {
         return Object.values(CliErrorCode).includes(value as CliErrorCode);
+      }
+      export function cliErrorFamily(code: CliErrorCode) {
+        return cliKernelMappedErrorCodes.has(code) ? "kernel-mapped" : "command-local";
       }
     `);
     writeFile(rootDir, "packages/cli/src/commands/new-task.ts", `
@@ -67,6 +81,40 @@ test("CLI error code gate accepts registry helpers and validation issue codes", 
     `);
 
     assert.deepEqual(findCliErrorCodeViolations(rootDir), []);
+  });
+});
+
+test("CLI error code gate rejects PascalCase adapter codes outside the kernel mapped family", () => {
+  withTempRoot((rootDir) => {
+    writeFile(rootDir, "packages/cli/src/cli/error-codes.ts", `
+      export const CliErrorCode = {
+        EngineUnreachable: "EngineUnreachable",
+        UnknownCommand: "unknown_command"
+      } as const;
+      export type CliErrorCode = typeof CliErrorCode[keyof typeof CliErrorCode];
+      export const cliKernelMappedErrorCodes = new Set<CliErrorCode>([]);
+      export const cliCommandLocalErrorCodes = new Set<CliErrorCode>(
+        Object.values(CliErrorCode).filter((code): code is CliErrorCode => !cliKernelMappedErrorCodes.has(code as CliErrorCode))
+      );
+      export const cliErrorCodeRegistry = {
+        [CliErrorCode.EngineUnreachable]: { category: "domain", defaultHint: "Engine unreachable." },
+        [CliErrorCode.UnknownCommand]: { category: "parse", defaultHint: "Unknown command." }
+      };
+      export function cliError(code: CliErrorCode, hint?: string) {
+        return { code, hint: hint ?? cliErrorCodeRegistry[code].defaultHint };
+      }
+      export function isCliErrorCode(value: string): value is CliErrorCode {
+        return Object.values(CliErrorCode).includes(value as CliErrorCode);
+      }
+      export function cliErrorFamily(code: CliErrorCode) {
+        return cliKernelMappedErrorCodes.has(code) ? "kernel-mapped" : "command-local";
+      }
+    `);
+
+    assert.equal(
+      findCliErrorCodeViolations(rootDir).includes("PascalCase kernel adapter code CliErrorCode.EngineUnreachable must be in cliKernelMappedErrorCodes"),
+      true
+    );
   });
 });
 

--- a/tools/check-cli-help-contract.mjs
+++ b/tools/check-cli-help-contract.mjs
@@ -14,12 +14,12 @@ export function findCliHelpContractViolations(rootDir = process.cwd()) {
   const summarySource = extractAssignedLiteral(source, "commandSummaries");
   const exampleSource = extractAssignedLiteral(source, "commandExamples");
   const descriptionSource = extractAssignedLiteral(source, "descriptions");
-  const receiptContractSource = extractAssignedLiteral(receiptSource, "commandReceiptContracts");
+  const receiptContractSource = extractAssignedLiteral(source, "commandReceiptContractsByKind");
   const violations = [];
 
   const commandKinds = [...commandUsageSource.matchAll(/\{\s*kind:\s*"([^"]+)"/gu)].map((match) => match[1]);
-  const receiptKinds = [...receiptContractSource.matchAll(/\{\s*kind:\s*"([^"]+)"/gu)].map((match) => match[1]);
-  const expectedReceiptKinds = [...commandKinds, "version"];
+  const receiptKinds = objectKeys(receiptContractSource);
+  const expectedReceiptKinds = commandKinds;
   const usageByKind = commandUsageByKind(commandUsageSource);
   const summaryKinds = objectKeys(summarySource);
   const exampleKinds = objectKeys(exampleSource);
@@ -38,7 +38,7 @@ export function findCliHelpContractViolations(rootDir = process.cwd()) {
     if (!commandKinds.includes(kind)) violations.push(`commandExamples has stale command ${kind}`);
   }
   for (const kind of expectedReceiptKinds) {
-    if (!receiptKinds.includes(kind)) violations.push(`command ${kind} is missing commandReceiptContracts entry`);
+    if (!receiptKinds.has(kind)) violations.push(`command ${kind} is missing command descriptor receipt contract`);
   }
   for (const kind of receiptKinds) {
     if (!expectedReceiptKinds.includes(kind)) violations.push(`commandReceiptContracts has stale command ${kind}`);

--- a/tools/check-cli-help-contract.test.mjs
+++ b/tools/check-cli-help-contract.test.mjs
@@ -13,6 +13,7 @@ test("CLI help contract gate rejects missing command help metadata", () => {
       ] as const;
       const commandSummaries = {} satisfies Record<CommandKind, string>;
       const commandExamples = {} satisfies Record<CommandKind, ReadonlyArray<string>>;
+      const commandReceiptContractsByKind = { "new-task": { data: ["taskId"], paths: ["package"] } } satisfies Record<CommandKind, CommandReceiptContract>;
       function optionDescription(flag: string): string {
         const descriptions: Record<string, string> = { "--json": "Emit JSON." };
         return descriptions[flag] ?? "Set this command option.";
@@ -36,6 +37,7 @@ test("CLI help contract gate accepts complete help metadata", () => {
       ] as const;
       const commandSummaries = { "new-task": "Create a task." } satisfies Record<CommandKind, string>;
       const commandExamples = { "new-task": ["harness-anything new-task --title Example"] } satisfies Record<CommandKind, ReadonlyArray<string>>;
+      const commandReceiptContractsByKind = { "new-task": { data: ["taskId"], paths: ["package"] } } satisfies Record<CommandKind, CommandReceiptContract>;
       function optionDescription(flag: string): string {
         const descriptions: Record<string, string> = { "--title": "Set the task title.", "--json": "Emit JSON." };
         return descriptions[flag]!;
@@ -54,17 +56,14 @@ test("CLI help contract gate rejects missing receipt contracts", () => {
       ] as const;
       const commandSummaries = { "new-task": "Create a task." } satisfies Record<CommandKind, string>;
       const commandExamples = { "new-task": ["harness-anything new-task --title Example"] } satisfies Record<CommandKind, ReadonlyArray<string>>;
+      const commandReceiptContractsByKind = {} satisfies Record<CommandKind, CommandReceiptContract>;
       function optionDescription(flag: string): string {
         const descriptions: Record<string, string> = { "--title": "Set the task title.", "--json": "Emit JSON." };
         return descriptions[flag]!;
       }
-    `, `
-      export const commandReceiptContracts = [
-        { kind: "version", data: ["version"], paths: [] }
-      ] as const;
     `);
 
-    assert.equal(findCliHelpContractViolations(rootDir).includes("command new-task is missing commandReceiptContracts entry"), true);
+    assert.equal(findCliHelpContractViolations(rootDir).includes("command new-task is missing command descriptor receipt contract"), true);
   });
 });
 
@@ -76,6 +75,7 @@ test("CLI help contract gate rejects examples with undocumented flags", () => {
       ] as const;
       const commandSummaries = { "new-task": "Create a task." } satisfies Record<CommandKind, string>;
       const commandExamples = { "new-task": ["harness-anything new-task --title Example --module billing"] } satisfies Record<CommandKind, ReadonlyArray<string>>;
+      const commandReceiptContractsByKind = { "new-task": { data: ["taskId"], paths: ["package"] } } satisfies Record<CommandKind, CommandReceiptContract>;
       function optionDescription(flag: string): string {
         const descriptions: Record<string, string> = { "--title": "Set the task title." };
         return descriptions[flag]!;
@@ -86,12 +86,7 @@ test("CLI help contract gate rejects examples with undocumented flags", () => {
   });
 });
 
-function writeRegistry(rootDir, body, receiptBody = `
-  export const commandReceiptContracts = [
-    { kind: "new-task", data: ["taskId"], paths: ["package"] },
-    { kind: "version", data: ["version"], paths: [] }
-  ] as const;
-`) {
+function writeRegistry(rootDir, body, receiptBody = "") {
   const dir = path.join(rootDir, "packages/cli/src/cli");
   mkdirSync(dir, { recursive: true });
   writeFileSync(path.join(dir, "command-registry.ts"), body);


### PR DESCRIPTION
## Summary

Consolidates local task lifecycle gate orchestration and CLI command contracts for T4b.

## What Changed

- Added an application-layer `TaskLifecycleOrchestrator` for shared `task-review` / `task-complete` gate evaluation and local controller terminal-status guard behavior.
- Moved CLI receipt contract declarations into command descriptors, keeping normalized `CommandReceipt/v1` output derived from the command registry.
- Split CLI error codes into explicit `kernel-mapped` and `command-local` families, with a gate that rejects unmapped PascalCase adapter codes.
- Kept forced terminal-status recovery in the CLI audit path, while sharing readonly lifecycle policy parsing from application code.

## Task And Scope

- Harness task: `task_01KWGNGVEWBEZ7E9JVTH5PY33A`
- Branch: `codex/t4b-lifecycle-contracts`
- Public scope: `packages/application`, `packages/cli`, and CLI contract checker tests under `tools/`.
- Private planning/evidence updated: yes, private harness commit `97534bb`.
- Out of scope: M4 `LifecycleEngine` rename/narrow, relation read-model design implementation, provider-backed external adapter work.

## Version Impact

- Version: no version change because this is an internal architecture and contract consolidation.
- Publish impact: no publish.

## Verification

- Base `origin/main` SHA: `1dfb41e29e896776c7f7da0c5dcdf6af9f52700a`
- Branch merge-base with `origin/main`: `1dfb41e29e896776c7f7da0c5dcdf6af9f52700a`
- Last `git fetch origin` time: `2026-07-02T06:04:50Z`
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: `97534bb`, `planning/tasks/task_01KWGNGVEWBEZ7E9JVTH5PY33A-t4b-shared-lifecycle-orchestrator-and-cli-contract-consolidation/`
- Reviewer evidence path: same task package `review.md`
- GitHub Actions `rewrite-ci` run URL: `https://github.com/FairladyZ625/harness-anything/actions/runs/28569267829`
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: none for local gate. Full `npm run check` passed in a non-hidden validation checkout after `npm ci`; the hidden `.worktrees` checkout is not suitable for ESLint because it ignores dot-directory paths.

## Review Evidence

- Self-review: passed; no release-blocking findings in private task `review.md`.
- Reviewer subagent: not used for this final T4b implementation; T5/T6 design workers were separate design-only tasks.
- Human review: not performed before orchestrator merge.
- Blocking findings: none known.
- Admin bypass: may be used for `REVIEW_REQUIRED`; user authorized orchestrator takeover and merge, GitHub Actions passed, missing normal gate is human review.

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear: merge after CI using admin bypass if review remains required, then delete remote branch and remove local validation/worktree checkouts.

## Residual Risk

- `TaskLifecycleOrchestrator` now owns review/complete gate sequencing; future terminal recovery behavior should continue to stay explicit in the CLI audit path unless a separate recovery contract is designed.
- Receipt contracts are descriptor-driven, so future command additions must update descriptor metadata rather than adding separate receipt tables.

## References

- Task: `task_01KWGNGVEWBEZ7E9JVTH5PY33A`
- Evidence: private harness commit `97534bb`
- Review: private task `review.md`
