### PR TITLE
fix: anchor layout at git boundary and canonicalize legacy source guards

### DIFF
--- a/packages/cli/src/commands/migration-scan.ts
+++ b/packages/cli/src/commands/migration-scan.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { sha256Text } from "../../../kernel/src/integrity/stable-hash.ts";
 import type { HarnessLayoutInput } from "../../../kernel/src/layout/index.ts";
@@ -263,12 +263,29 @@ function isSafeRelativePath(relativePath: string): boolean {
 }
 
 function isPathInside(parent: string, candidate: string): boolean {
-  const relativePath = path.relative(parent, candidate);
+  const relativePath = path.relative(canonicalPath(parent), canonicalPath(candidate));
   return relativePath === "" || isSafeRelativePath(relativePath);
 }
 
 function isSamePath(left: string, right: string): boolean {
-  return path.resolve(left) === path.resolve(right);
+  return canonicalPath(left) === canonicalPath(right);
+}
+
+export function canonicalPath(target: string): string {
+  const resolved = path.resolve(target);
+  let current = resolved;
+  let suffix = "";
+  while (true) {
+    try {
+      const real = realpathSync(current);
+      return suffix ? path.join(real, suffix) : real;
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) return resolved;
+      suffix = suffix ? path.join(path.basename(current), suffix) : path.basename(current);
+      current = parent;
+    }
+  }
 }
 
 export function copySource(source: string, target: string): void {

--- a/packages/cli/src/commands/migration.ts
+++ b/packages/cli/src/commands/migration.ts
@@ -9,7 +9,7 @@ import { cliError, CliErrorCode } from "../cli/error-codes.ts";
 import type { CliResult } from "../cli/types.ts";
 import { applyCollisionReport, buildLegacyCopyPlan, readCollisionReport, writeCollisionReport } from "./migration-collision.ts";
 import { collectLegacyProvenanceWarnings } from "./legacy-provenance-verify.ts";
-import { buildScanReport, copyForwardDocs, copySource, renderIntakePlan, stripScanOnlyFields, summarize, type LegacyScanReport } from "./migration-scan.ts";
+import { buildScanReport, canonicalPath, copyForwardDocs, copySource, renderIntakePlan, stripScanOnlyFields, summarize, type LegacyScanReport } from "./migration-scan.ts";
 import type { LegacyCopySafeDocsAction, LegacyIndexAction, LegacyIntakePlanAction, LegacyScanAction, LegacyVerifyAction, MigratePlanAction, MigrateRunAction, MigrateStructureAction, MigrateVerifyAction } from "./migration-types.ts";
 
 interface LegacyIntakeSession {
@@ -416,11 +416,11 @@ function isUnsafeLegacySourcePath(sourcePath: string): boolean {
 }
 
 function isSamePath(left: string, right: string): boolean {
-  return path.resolve(left) === path.resolve(right);
+  return canonicalPath(left) === canonicalPath(right);
 }
 
 function isPathInside(parent: string, candidate: string): boolean {
-  const relativePath = path.relative(parent, candidate);
+  const relativePath = path.relative(canonicalPath(parent), canonicalPath(candidate));
   return relativePath.length > 0 && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
 }
 

--- a/packages/cli/test/migration-adopt-cli.test.ts
+++ b/packages/cli/test/migration-adopt-cli.test.ts
@@ -229,6 +229,24 @@ test("CLI legacy apply refuses the active authored harness root as source", () =
   });
 });
 
+test("CLI legacy apply refuses a symlink alias of the active authored harness root", () => {
+  withTempRoot((rootDir) => {
+    writeFile(rootDir, "harness/harness.yaml", "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n");
+    writeFile(rootDir, "harness/docs/architecture/self-host.md", "# Self Host\n");
+    symlinkSync(path.join(rootDir, "harness"), path.join(rootDir, "link-harness"), "dir");
+
+    const copied = runJson(rootDir, ["legacy", "copy-safe-docs", "link-harness", "--apply"], false);
+    const indexed = runJson(rootDir, ["legacy", "index", "link-harness", "--apply"], false);
+
+    assert.equal(copied.ok, false);
+    assert.equal(copied.error.code, "legacy_unsafe_source");
+    assert.equal(indexed.ok, false);
+    assert.equal(indexed.error.code, "legacy_unsafe_source");
+    assert.equal(existsSync(path.join(rootDir, "harness/legacy/docs/architecture/self-host.md")), false);
+    assert.equal(existsSync(path.join(rootDir, "harness/legacy/index.json")), false);
+  });
+});
+
 test("CLI legacy copy suffixes planned parent directories before they can overwrite planned children", () => {
   withTempRoot((rootDir) => {
     writeLegacyTask(rootDir, "modules", "active");

--- a/packages/kernel/src/layout/index.ts
+++ b/packages/kernel/src/layout/index.ts
@@ -170,29 +170,50 @@ function resolveProjectRootAndConfig(rootDir: string): {
   readonly config: HarnessLayoutConfig;
 } {
   const startingRoot = path.resolve(rootDir);
-  const configLocation = findHarnessConfigLocation(startingRoot);
-  if (!configLocation) return { projectRoot: startingRoot, config: {} };
+  const discovery = findHarnessConfigLocation(startingRoot);
+  if (!discovery.location) return { projectRoot: discovery.boundaryRoot ?? startingRoot, config: {} };
   return {
-    projectRoot: configLocation.projectRoot,
-    config: readLayoutConfig(configLocation)
+    projectRoot: discovery.location.projectRoot,
+    config: readLayoutConfig(discovery.location)
   };
 }
 
-function findHarnessConfigLocation(startingRoot: string): HarnessConfigLocation | undefined {
+interface HarnessConfigDiscovery {
+  readonly location?: HarnessConfigLocation;
+  readonly boundaryRoot?: string;
+}
+
+function findHarnessConfigLocation(startingRoot: string): HarnessConfigDiscovery {
   let current = startingRoot;
   while (true) {
     const publicCandidate = path.join(current, defaultAuthoredRoot, "harness.yaml");
-    if (existsSync(publicCandidate)) return { path: publicCandidate, projectRoot: current };
+    if (existsSync(publicCandidate)) return { location: { path: publicCandidate, projectRoot: current } };
     const privateRoot = path.join(current, ".harness-private");
     const privateCandidate = path.join(privateRoot, "coding-agent-harness", "harness.yaml");
     if (existsSync(privateCandidate)) {
-      return { path: privateCandidate, projectRoot: current, structureBase: ".harness-private" };
+      return { location: { path: privateCandidate, projectRoot: current, structureBase: ".harness-private" } };
     }
-    if (existsSync(path.join(current, ".git"))) return undefined;
+    const selfHostLocation = findSelfHostConfigLocation(current);
+    if (selfHostLocation) return { location: selfHostLocation };
+    if (existsSync(path.join(current, ".git"))) return { boundaryRoot: current };
     const parent = path.dirname(current);
-    if (parent === current) return undefined;
+    if (parent === current) return {};
     current = parent;
   }
+}
+
+function findSelfHostConfigLocation(current: string): HarnessConfigLocation | undefined {
+  const configPath = path.join(current, "harness.yaml");
+  if (!existsSync(configPath)) return undefined;
+  const parent = path.dirname(current);
+  if (parent === current) return undefined;
+  if (path.basename(current) === defaultAuthoredRoot) {
+    return { path: configPath, projectRoot: parent };
+  }
+  if (path.basename(current) === "coding-agent-harness" && path.basename(parent) === ".harness-private") {
+    return { path: configPath, projectRoot: path.dirname(parent), structureBase: ".harness-private" };
+  }
+  return undefined;
 }
 
 function readLayoutConfig(location: HarnessConfigLocation): HarnessLayoutConfig {

--- a/packages/kernel/test/contracts/legacy-intake-schema.test.ts
+++ b/packages/kernel/test/contracts/legacy-intake-schema.test.ts
@@ -98,6 +98,38 @@ test("layout resolver does not cross a git worktree boundary to borrow parent ha
   });
 });
 
+test("layout resolver anchors at the worktree root when invoked from a subdirectory", () => {
+  withTempRoot((rootDir) => {
+    const parentConfigPath = path.join(rootDir, "harness", "harness.yaml");
+    mkdirSync(path.dirname(parentConfigPath), { recursive: true });
+    writeFileSync(parentConfigPath, "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n", "utf8");
+    const worktreeRoot = path.join(rootDir, ".worktrees", "feature");
+    const nestedRoot = path.join(worktreeRoot, "packages", "cli");
+    mkdirSync(nestedRoot, { recursive: true });
+    writeFileSync(path.join(worktreeRoot, ".git"), "gitdir: ../../.git/worktrees/feature\n", "utf8");
+
+    const layout = resolveHarnessLayout(nestedRoot);
+
+    assert.equal(layout.rootDir, worktreeRoot);
+    assert.equal(layout.authoredRoot, path.join(worktreeRoot, "harness"));
+  });
+});
+
+test("layout resolver finds the outer project config from inside a self-hosted nested harness repo", () => {
+  withTempRoot((rootDir) => {
+    const authoredRoot = path.join(rootDir, "harness");
+    mkdirSync(path.join(authoredRoot, ".git"), { recursive: true });
+    writeFileSync(path.join(authoredRoot, "harness.yaml"), "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n", "utf8");
+    const nestedCwd = path.join(authoredRoot, "planning", "tasks");
+    mkdirSync(nestedCwd, { recursive: true });
+
+    const layout = resolveHarnessLayout(nestedCwd);
+
+    assert.equal(layout.rootDir, rootDir);
+    assert.equal(layout.authoredRoot, authoredRoot);
+  });
+});
+
 test("legacy index schema decodes and encodes valid fixture", async () => {
   const fixture = JSON.parse(await readFile(legacyIndexValidUrl, "utf8")) as unknown;
   const decoded = Schema.decodeUnknownSync(LegacyIndexSchema)(fixture);


### PR DESCRIPTION
## Summary

Fixes two defects found in review of #92's self-host write guard: layout resolution mis-anchoring at a `.git` boundary, and legacy self-import guards that a symlink alias could bypass.

## What Changed

- `findHarnessConfigLocation` now returns the `.git` boundary as the project root instead of bare `undefined`, and recognizes a self-hosted nested `harness/` (or `.harness-private/coding-agent-harness`) repo whose own directory carries `harness.yaml` as the config location.
- `isSamePath`/`isPathInside` in `migration.ts` and `migration-scan.ts` canonicalize paths through `realpath` before comparing, closing the symlink-alias bypass.
- Added regression tests for subdirectory-anchored resolution, self-hosted nested-repo resolution, and symlink-alias source rejection.

## Task And Scope

- Harness task: legacy pollution recurrence follow-up (private task tracked)
- Branch: `codex/layout-boundary-fallback`
- Public scope: `packages/kernel/src/layout`, `packages/cli/src/commands` legacy intake path guards + tests
- Private planning/evidence updated: not applicable
- Out of scope: cleanup of already-generated legacy pollution files

## Version Impact

- Version: no version change because this is an internal bug fix with no CLI surface change
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: `f84b2cb8747afb3b05766b3a652cd3a8be0cc211`
- Branch merge-base with `origin/main`: `f84b2cb8747afb3b05766b3a652cd3a8be0cc211`
- Last `git fetch origin` time: 2026-07-02 (this session)
- Sync method: none needed (branched from latest `origin/main`)
- Public diff command: `git diff origin/main...codex/layout-boundary-fallback`
- Private evidence commit/path: not applicable
- Reviewer evidence path: Claude multi-agent review on #92
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28589064519
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (all lanes pass; `npm audit` lane failed locally on network TLS only)
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: none (local `npm audit` failed on network only; CI will run it with network)

## Review Evidence

- Self-review: done
- Reviewer subagent: Claude 5-agent review of #92 surfaced these two findings
- Human review: pending
- Blocking findings: none open

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained (https://github.com/FairladyZ625/harness-anything/actions/runs/28589064519).
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear.

## Residual Risk

- Low. Path canonicalization adds `realpath` calls on non-existent paths, handled by walking up to the nearest existing ancestor; behavior for normal absolute paths is unchanged.

## References

- Task: legacy pollution recurrence follow-up
- Evidence: local `npm run check` in worktree
- Review: #92

---

## 摘要

修复评审 #92 self-host 写入防护时发现的两个缺陷：布局解析在 `.git` 边界错误锚定，以及 legacy 自导入防护可被符号链接别名绕过。

## 改动内容

- `findHarnessConfigLocation` 命中 `.git` 边界时返回该边界作为 project root，而非裸 `undefined`；并识别自托管的嵌套 `harness/`（或 `.harness-private/coding-agent-harness`）——其自身目录带有 `harness.yaml` 时作为配置位置。
- `migration.ts` 与 `migration-scan.ts` 中的 `isSamePath`/`isPathInside` 在比较前通过 `realpath` 归一化路径，堵住符号链接别名绕过。
- 新增回归测试：子目录锚定解析、自托管嵌套仓库解析、符号链接别名源拒绝。

## 任务与范围

- Harness 任务：legacy 污染复发跟进（私有 task 跟踪）
- 分支：`codex/layout-boundary-fallback`
- 公开范围：`packages/kernel/src/layout`、`packages/cli/src/commands` legacy intake 路径防护 + 测试
- 私有计划 / 证据是否已更新：not applicable
- 范围外：清理已生成的 legacy 污染文件

## 版本影响

- 版本：不改版本，原因是内部 bug 修复、无 CLI 接口变化
- 发布影响：不发布

## 验证

- `origin/main` 基准 SHA：`f84b2cb8747afb3b05766b3a652cd3a8be0cc211`
- 当前分支与 `origin/main` 的 merge-base：`f84b2cb8747afb3b05766b3a652cd3a8be0cc211`
- 最近一次 `git fetch origin` 时间：2026-07-02（本会话）
- 同步方式：不需要（基于最新 `origin/main` 建分支）
- 公开 diff 命令：`git diff origin/main...codex/layout-boundary-fallback`
- 私有证据 commit/path：not applicable
- Reviewer 证据路径：Claude 对 #92 的多代理评审
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28589064519
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`（所有通道通过；仅 `npm audit` 通道因本地网络 TLS 失败）
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：无（本地 `npm audit` 仅因网络失败；CI 有网络会运行）

## 审查证据

- 自查：已完成
- Reviewer subagent：Claude 对 #92 的 5 代理评审发现这两个问题
- 人工审查：pending
- 阻塞发现：无 open

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明（https://github.com/FairladyZ625/harness-anything/actions/runs/28589064519）。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚。

## 残余风险

- 低。路径归一化对不存在的路径新增 `realpath` 调用，通过向上回退到最近存在的祖先处理；普通绝对路径行为不变。

## 关联材料

- 任务：legacy 污染复发跟进
- 证据：worktree 内本地 `npm run check`
- 审查：#92
