### PR TITLE
perf: speed up node test suite via compile cache and concurrency cap

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -9,7 +9,33 @@ on:
   schedule:
     - cron: "17 19 * * *"
 
+# Cancel superseded PR runs (e.g. after a force-push). Never cancel main/nightly
+# full-check runs — those must always complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  # Detect what a PR touched so heavy, package-scoped jobs can no-op their
+  # expensive steps. The jobs still run and report green, so required-check
+  # branch protection never deadlocks on a skipped context.
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      gui: ${{ steps.filter.outputs.gui }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            gui:
+              - 'packages/gui/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig*.json'
+
   full-check:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -115,6 +141,7 @@ jobs:
 
   gui-build:
     if: github.event_name == 'pull_request'
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -122,9 +149,13 @@ jobs:
         with:
           node-version: 24
           cache: npm
-      - run: npm ci
-      - run: npm run test:gui
-      - run: npm run -w @harness-anything/gui build
+      # Skip the GUI build/test when a PR touches no GUI or shared-root files.
+      - if: needs.changes.outputs.gui == 'true'
+        run: npm ci
+      - if: needs.changes.outputs.gui == 'true'
+        run: npm run test:gui
+      - if: needs.changes.outputs.gui == 'true'
+        run: npm run -w @harness-anything/gui build
 
   node26-compatibility:
     if: github.event_name == 'pull_request'

--- a/tools/node-test-runner-lib.mjs
+++ b/tools/node-test-runner-lib.mjs
@@ -9,7 +9,8 @@ export function parseRunnerArgs(args, tierNames) {
     tier: "all",
     list: false,
     slowThresholdMs: 1000,
-    slowLimit: 10
+    slowLimit: 10,
+    concurrency: undefined
   };
 
   for (let index = 0; index < args.length; index += 1) {
@@ -49,6 +50,17 @@ export function parseRunnerArgs(args, tierNames) {
     }
     if (arg.startsWith("--slow-limit=")) {
       options.slowLimit = parsePositiveInteger(arg.slice("--slow-limit=".length), "--slow-limit");
+      continue;
+    }
+    if (arg === "--concurrency") {
+      const value = args[index + 1];
+      if (value === undefined) throw new Error("--concurrency requires a value");
+      options.concurrency = parsePositiveInteger(value, "--concurrency");
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--concurrency=")) {
+      options.concurrency = parsePositiveInteger(arg.slice("--concurrency=".length), "--concurrency");
       continue;
     }
 

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -8,6 +8,13 @@ import { testTierManifest, testTierNames } from "./test-tier-manifest.mjs";
 const repoRoot = resolve(import.meta.dirname, "..");
 const roots = ["packages", "tools"];
 
+// Reuse type-strip/compile output across the test host and every CLI
+// subprocess it spawns (integration tests cold-start `node src/index.ts` per
+// assertion). Native Node compile cache — no build step. Children inherit the
+// env, so the cache is shared. Lives under node_modules/.cache (already
+// git-ignored).
+process.env.NODE_COMPILE_CACHE ||= resolve(repoRoot, "node_modules/.cache/harness-node-compile");
+
 let options;
 try {
   options = parseRunnerArgs(process.argv.slice(2), testTierNames);
@@ -38,7 +45,14 @@ if (options.list) {
   process.exit(0);
 }
 
-const child = spawn(process.execPath, ["--test", ...selection.files], {
+// Cap process fan-out so full runs don't exhaust memory on developer laptops.
+// --concurrency wins; else HARNESS_TEST_CONCURRENCY; else node's default (cores-1).
+const envConcurrency = process.env.HARNESS_TEST_CONCURRENCY;
+const concurrency = options.concurrency ?? (envConcurrency ? Number.parseInt(envConcurrency, 10) : undefined);
+const concurrencyArgs =
+  concurrency && Number.isInteger(concurrency) && concurrency > 0 ? [`--test-concurrency=${concurrency}`] : [];
+
+const child = spawn(process.execPath, ["--test", ...concurrencyArgs, ...selection.files], {
   cwd: repoRoot,
   stdio: ["inherit", "pipe", "pipe"]
 });

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -8,8 +8,15 @@ test("parseRunnerArgs accepts tier and slow summary options", () => {
     tier: "fast",
     list: false,
     slowThresholdMs: 250,
-    slowLimit: 3
+    slowLimit: 3,
+    concurrency: undefined
   });
+});
+
+test("parseRunnerArgs accepts a concurrency cap", () => {
+  assert.equal(parseRunnerArgs(["--concurrency", "4"], testTierNames).concurrency, 4);
+  assert.equal(parseRunnerArgs(["--concurrency=2"], testTierNames).concurrency, 2);
+  assert.throws(() => parseRunnerArgs(["--concurrency", "x"], testTierNames), /--concurrency/u);
 });
 
 test("parseRunnerArgs rejects unknown tiers and options", () => {


### PR DESCRIPTION
## Summary
The node test suite was dominated by CLI integration tests that each `execFileSync(node, ["packages/cli/src/index.ts", ...])` per assertion — every spawn cold-starts node and re-strips the entire CLI import graph.

- **Compile cache (main win):** runner sets `NODE_COMPILE_CACHE` (under `node_modules/.cache/`) so type-strip/compile output is reused across the test host and every CLI spawn. Integration tier **~173s → ~60s locally (~2.9×)**, measured on a single cold run — the win lands within one run because the first spawn warms the cache and dozens of later spawns reuse it, so CI benefits too.
- **Concurrency cap:** `--concurrency <n>` flag + `HARNESS_TEST_CONCURRENCY` env cap `node --test` process fan-out on resource-constrained machines (default at `cores-1` could exhaust laptop memory).
- **CI:** `cancel-in-progress` for superseded PR runs (never for main/nightly full-check); `gui-build` heavy steps gated behind a `changes` (dorny/paths-filter) detector so PRs untouching `packages/gui/**` no-op the Electron build. The job still runs and reports green, so required-check branch protection never deadlocks.

## Scope
Test runner + CI workflow only. No product code touched.

## Verification
- `test:fast` 125✔, runner unit test 7✔, lint clean.
- Integration tier timed: 172.9s (no cache) → 58.7s (cold single run, cache on).
- Workflow YAML validated.

## Residual Risk
`dorny/paths-filter@v3` may need `pull-requests: read` in permission-restricted repos; default `GITHUB_TOKEN` is sufficient here. Watch the first PR run.