### PR TITLE
fix: progress_append delta semantics (ADR-0016 D2/D5)

### DIFF
--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import type { EngineError, WriteError } from "../../../kernel/src/domain/index.ts";
@@ -10,8 +10,8 @@ import type { WriteCoordinator } from "../../../kernel/src/ports/index.ts";
 import { makeJournaledWriteCoordinator } from "../../../kernel/src/store/index.ts";
 import { resolveTaskCreatedBy } from "./created-by.ts";
 import { hasTaskRelations, renderSupersedesRelation } from "./task-relations.ts";
-import { indexPath, makeIndex, readIndexEffect, renderIndex, taskDocumentPath, validateGeneratedTaskId, validateTaskId } from "./task-index.ts";
-import { deleteTaskPackage, writeSupersedeTaskDocuments, writeTaskDocument } from "./task-writes.ts";
+import { indexPath, makeIndex, readIndexEffect, renderIndex, validateGeneratedTaskId, validateTaskId } from "./task-index.ts";
+import { appendProgressDelta, deleteTaskPackage, writeSupersedeTaskDocuments, writeTaskDocument } from "./task-writes.ts";
 import type {
   AppendProgressInput,
   CreateLocalTaskInput,
@@ -140,10 +140,10 @@ function appendProgress(
 ): Effect.Effect<LocalProgressResult, EngineError | WriteError> {
   return Effect.gen(function* () {
     yield* readIndexEffect(rootInput, input.taskId);
-    const existingPath = taskDocumentPath(rootInput, input.taskId, "progress.md");
-    const existing = existsSync(existingPath) ? readFileSync(existingPath, "utf8") : "";
-    const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
-    yield* writeTaskDocument(coordinator, stablePayloadHash, input.taskId, "progress.md", `${existing}${separator}${input.text}\n`, { kind: "progress_append" });
+    // ADR-0016 D2: journal only stores the append delta. flush/replay reads the
+    // on-disk progress.md at apply time and appends, so crash recovery no longer
+    // rolls back hand-edits with a stale full-file snapshot.
+    yield* appendProgressDelta(coordinator, stablePayloadHash, input.taskId, input.text);
     return { taskId: input.taskId, path: "progress.md" } satisfies LocalProgressResult;
   });
 }

--- a/packages/adapters/local/src/task-writes.ts
+++ b/packages/adapters/local/src/task-writes.ts
@@ -48,6 +48,21 @@ export function writeTaskDocuments(
   return writeCoordinatedTaskDocuments(coordinator, hashPayload, writes);
 }
 
+export const PROGRESS_DOCUMENT_PATH = "progress.md";
+
+export function appendProgressDelta(
+  coordinator: WriteCoordinator,
+  hashPayload: HashPayload,
+  taskId: TaskId,
+  text: string
+): Effect.Effect<void, WriteError> {
+  return writeCoordinatedPayload(coordinator, hashPayload, {
+    taskId,
+    kind: "progress_append",
+    payload: { path: PROGRESS_DOCUMENT_PATH, append: text }
+  });
+}
+
 export function writeSupersedeTaskDocuments(
   coordinator: WriteCoordinator,
   hashPayload: HashPayload,

--- a/packages/cli/src/cli/command-registry.ts
+++ b/packages/cli/src/cli/command-registry.ts
@@ -210,7 +210,7 @@ const commandSummaries = {
   "init": "Create the harness directory layout and optional npm shortcuts.",
   "new-task": "Create a new task package, optionally through a vertical or preset.",
   "status-set": "Move a local task to a new lifecycle status.",
-  "progress-append": "Append progress text, with optional evidence, to a task package.",
+  "progress-append": "Append the provided text as-is to a task package, with optional evidence; no Markdown formatting or normalization is applied.",
   "task-archive": "Archive a task package while preserving its audit trail.",
   "task-supersede": "Archive old work and optionally create or link replacement work.",
   "task-delete": "Soft-delete or guarded hard-delete a task package.",
@@ -477,7 +477,7 @@ function optionDescription(flag: string): string {
     "--status": "Set the external or module status.",
     "--strict": "Run strict checks.",
     "--task": "Set the task id.",
-    "--text": "Set appended progress text.",
+    "--text": "Progress text appended as-is (no Markdown formatting or normalization).",
     "--title": "Set the required task title used for generated package metadata and slug.",
     "--vertical": "Select a vertical definition; new-task defaults to software/coding.",
     "--version": "Print the installed CLI version."

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -46,6 +46,7 @@ export function initializeHarness(rootInput: HarnessLayoutInput, addNpmScripts =
     "- Invoke via `npx harness-anything <command>` (alias: `ha`). Create task packages with `new-task`; never hand-scaffold directories under the tasks root.",
     "- Task lifecycle: `task status set <id> <planned|active|blocked|in_review|done|cancelled>`, `task progress append <id> --text <text> [--evidence type:PATH:summary]`, `task-review <id>`, `task-complete <id> --ci passed|failed`. Completion is gated on review + closeout; setting `done` directly is rejected.",
     "- Writes that go through the harness CLI (new-task, status set, progress append, review, complete) are auto-committed as `harness write <opId>` when the harness root is inside a git repository. A clean `git status` right after these commands is expected: do not re-verify, re-commit, or treat it as data loss. Only hand-edited files need manual commits.",
+    "- Boundary (ADR-0016 D1): machine-read fields (INDEX.md frontmatter — status, engine, binding, packageDisposition — and relations) must be written through the CLI commands above; never hand-edit them. Human-read prose (`progress.md`, `task_plan.md` bodies) may be edited directly, but then commit those files yourself.",
     "",
     "Generated state under `.harness/` is local-only and must not be committed.",
     ""

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -27,7 +27,7 @@ import { hashTaskProjectionRows, rebuildTaskProjection } from "../projection/sql
 import { appendJsonLineDurably, readDurableState, readPayloadRef, writePayloadRef, writeWatermarkDurably, writeFileDurably } from "./write-journal-durable.ts";
 import { commitTouchedPaths, resolveCommitPlan } from "./write-journal-git.ts";
 import { withRepoLocks, WriteLockHeldError } from "./write-journal-locks.ts";
-import type { DeleteAuditRecord, JournalActor, JournalRecord, JournalRecordKind, JournaledWriteCoordinatorOptions, LockTakeoverRecord, WriteWatermark } from "./write-journal-types.ts";
+import type { ApplyMarkerRecord, DeleteAuditRecord, JournalActor, JournalRecord, JournalRecordKind, JournaledWriteCoordinatorOptions, LockTakeoverRecord, WriteWatermark } from "./write-journal-types.ts";
 export type { JournalActor, JournaledWriteCoordinatorOptions } from "./write-journal-types.ts";
 
 const defaultActor: JournalActor = { kind: "agent", id: "local" };
@@ -82,7 +82,7 @@ export function makeJournaledWriteCoordinator(options: JournaledWriteCoordinator
         const state = readDurableState(journalPath, watermarkPath, rootDir);
         pending.splice(0, pending.length);
         const pendingRecords = state.records.filter((record) => !state.applied.has(record.opId));
-        return flushRecords(reason, rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords);
+        return flushRecords(reason, rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied);
       }),
       catch: (cause): WriteError => toJournalError(cause)
     }),
@@ -90,7 +90,7 @@ export function makeJournaledWriteCoordinator(options: JournaledWriteCoordinator
       try: (): RecoveryReport => withRepoLocks(rootDir, runtimeContext, journalPath, actor, lockTtlMs, [], () => {
         const state = readDurableState(journalPath, watermarkPath, rootDir);
         const pendingRecords = state.records.filter((record) => !state.applied.has(record.opId));
-        const report = flushRecords("recovery", rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords);
+        const report = flushRecords("recovery", rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied);
         return {
           replayedOps: report.opCount,
           recoveredWatermark: report.watermark
@@ -108,7 +108,8 @@ function flushRecords(
   journalPath: string,
   watermarkPath: string,
   previousWatermark: WriteWatermark | null,
-  records: ReadonlyArray<JournalRecord>
+  records: ReadonlyArray<JournalRecord>,
+  fileApplied: ReadonlySet<string>
 ): FlushReport {
   const touchedPaths: string[] = [];
   const committedOpIds: string[] = [];
@@ -120,7 +121,11 @@ function flushRecords(
   resolveCommitPlan(rootDir, plannedRecords.flatMap((record) => record.touchedPaths), rootInput);
 
   for (const { record, touchedPaths: recordTouchedPaths } of plannedRecords) {
-    applyRecord(rootDir, rootInput, journalPath, record);
+    // Ops with a durable apply marker already mutated their file before a crash;
+    // skip the (non-idempotent) file write but still commit and watermark them.
+    if (!fileApplied.has(record.opId)) {
+      applyRecord(rootDir, rootInput, journalPath, record);
+    }
     touchedPaths.push(...recordTouchedPaths);
     committedOpIds.push(record.opId);
   }
@@ -173,7 +178,19 @@ function applyRecord(rootDir: string, rootInput: HarnessLayoutInput, journalPath
     });
     return;
   }
-  applyOp(rootInput, recordToOp(rootDir, record));
+  const op = recordToOp(rootDir, record);
+  applyOp(rootInput, op);
+  // Delta appends are not idempotent: replaying one after a crash between apply and
+  // watermark would duplicate the text. Mark the file mutation durably so replay
+  // skips the write while still committing and watermarking the op (ADR-0016 D2).
+  if (op.kind === "progress_append" && isProgressAppendDeltaPayload(op.payload)) {
+    appendJsonLineDurably(journalPath, {
+      schema: "apply-marker/v1",
+      opId: record.opId,
+      taskId: record.taskId,
+      at: new Date().toISOString()
+    });
+  }
 }
 
 function applyOp(rootInput: HarnessLayoutInput, op: WriteOp): DocumentWrite | null {
@@ -204,7 +221,9 @@ interface ProgressAppendDeltaPayload {
 function isProgressAppendDeltaPayload(payload: unknown): payload is ProgressAppendDeltaPayload {
   if (!payload || typeof payload !== "object") return false;
   const candidate = payload as { readonly path?: unknown; readonly append?: unknown };
-  return typeof candidate.path === "string" && typeof candidate.append === "string";
+  // An ambiguous payload carrying both `append` and `body` falls through to the
+  // legacy snapshot path instead of silently ignoring `body` here.
+  return typeof candidate.path === "string" && typeof candidate.append === "string" && !("body" in candidate);
 }
 
 function progressAppendDeltaWrite(op: WriteOp, payload: ProgressAppendDeltaPayload): DocumentWrite {
@@ -361,6 +380,9 @@ function documentWritesForOp(op: WriteOp): ReadonlyArray<DocumentWrite> {
   if (op.kind === "package_delete_hard") {
     return [];
   }
+  if (op.kind === "progress_append" && isProgressAppendDeltaPayload(op.payload)) {
+    return [progressAppendDeltaWrite(op, op.payload)];
+  }
   if (!documentWriteKinds.has(op.kind)) {
     rejectWrite(`unsupported write op kind: ${op.kind}`);
   }
@@ -451,7 +473,7 @@ function listTextFiles(inputPath: string): ReadonlyArray<string> {
 function toDocumentWrite(op: WriteOp): DocumentWrite {
   const payload = op.payload as Partial<DocumentWrite> | undefined;
   if (!payload || typeof payload.path !== "string" || typeof payload.body !== "string") {
-    rejectWrite(`doc_write op requires path and body payload: ${op.opId}`, op.taskId);
+    rejectWrite(`${op.kind} op requires path and body payload: ${op.opId}`, op.taskId);
   }
   return {
     taskId: op.taskId,
@@ -490,8 +512,8 @@ function compactJournalDurably(journalPath: string, coveredOpIds: ReadonlySet<st
     .split("\n")
     .filter((line) => line.trim().length > 0)
     .filter((line) => {
-      const parsed = JSON.parse(line) as Partial<JournalRecord | LockTakeoverRecord | DeleteAuditRecord>;
-      if (parsed.schema !== "write-journal/v1") return true;
+      const parsed = JSON.parse(line) as Partial<JournalRecord | LockTakeoverRecord | DeleteAuditRecord | ApplyMarkerRecord>;
+      if (parsed.schema !== "write-journal/v1" && parsed.schema !== "apply-marker/v1") return true;
       return typeof parsed.opId !== "string" || !coveredOpIds.has(parsed.opId);
     });
   writeFileDurably(journalPath, retained.length === 0 ? "" : `${retained.join("\n")}\n`);

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -181,10 +181,51 @@ function applyOp(rootInput: HarnessLayoutInput, op: WriteOp): DocumentWrite | nu
     writeDocumentsAtomically(rootInput, op.payload.writes, op.taskId);
     return null;
   }
+  // ADR-0016 D2: delta-shaped progress_append reads the current on-disk file and
+  // appends. Legacy full-snapshot progress_append ops fall through to the overwrite
+  // path below (backward compatibility, discriminated by payload shape).
+  if (op.kind === "progress_append" && isProgressAppendDeltaPayload(op.payload)) {
+    return applyProgressAppendDelta(rootInput, op, op.payload);
+  }
   if (!documentWriteKinds.has(op.kind)) {
     rejectWrite(`unsupported write op kind: ${op.kind}`, op.taskId);
   }
   const write = toDocumentWrite(op);
+  writeDocument(rootInput, write);
+  return write;
+}
+
+interface ProgressAppendDeltaPayload {
+  readonly path: string;
+  readonly append: string;
+  readonly packageSlug?: string;
+}
+
+function isProgressAppendDeltaPayload(payload: unknown): payload is ProgressAppendDeltaPayload {
+  if (!payload || typeof payload !== "object") return false;
+  const candidate = payload as { readonly path?: unknown; readonly append?: unknown };
+  return typeof candidate.path === "string" && typeof candidate.append === "string";
+}
+
+function progressAppendDeltaWrite(op: WriteOp, payload: ProgressAppendDeltaPayload): DocumentWrite {
+  return {
+    taskId: op.taskId,
+    path: payload.path,
+    body: "",
+    packageSlug: typeof payload.packageSlug === "string" ? payload.packageSlug : undefined
+  };
+}
+
+function applyProgressAppendDelta(rootInput: HarnessLayoutInput, op: WriteOp, payload: ProgressAppendDeltaPayload): DocumentWrite {
+  const targetPath = documentTargetPath(rootInput, progressAppendDeltaWrite(op, payload));
+  const existing = existsSync(targetPath) ? readFileSync(targetPath, "utf8") : "";
+  const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+  const write: DocumentWrite = {
+    taskId: op.taskId,
+    path: payload.path,
+    body: `${existing}${separator}${payload.append}\n`,
+    packageSlug: typeof payload.packageSlug === "string" ? payload.packageSlug : undefined
+  };
   writeDocument(rootInput, write);
   return write;
 }
@@ -303,6 +344,9 @@ function opTouchedPaths(rootInput: HarnessLayoutInput, op: WriteOp): ReadonlyArr
   }
   if (op.kind === "package_delete_hard") {
     return [taskPackagePath(rootInput, op.taskId)];
+  }
+  if (op.kind === "progress_append" && isProgressAppendDeltaPayload(op.payload)) {
+    return [documentTargetPath(rootInput, progressAppendDeltaWrite(op, op.payload))];
   }
   if (!documentWriteKinds.has(op.kind)) {
     rejectWrite(`unsupported write op kind: ${op.kind}`);

--- a/packages/kernel/src/store/write-journal-durable.ts
+++ b/packages/kernel/src/store/write-journal-durable.ts
@@ -1,20 +1,40 @@
 import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, writeSync } from "node:fs";
 import path from "node:path";
 import { sha256Text } from "../integrity/stable-hash.ts";
-import type { DeleteAuditRecord, JournalRecord, LockTakeoverRecord, PayloadRef, WriteWatermark } from "./write-journal-types.ts";
+import type { ApplyMarkerRecord, DeleteAuditRecord, JournalRecord, LockTakeoverRecord, PayloadRef, WriteWatermark } from "./write-journal-types.ts";
 
 export function readDurableState(journalPath: string, watermarkPath: string, rootDir: string): {
   readonly records: ReadonlyArray<JournalRecord>;
   readonly watermark: WriteWatermark | null;
   readonly applied: ReadonlySet<string>;
+  readonly fileApplied: ReadonlySet<string>;
 } {
   const watermark = readWatermark(watermarkPath);
   const records = readJournal(journalPath, rootDir);
   return {
     records,
     watermark,
-    applied: new Set(watermark?.lastCommittedOpIds ?? [])
+    applied: new Set(watermark?.lastCommittedOpIds ?? []),
+    fileApplied: readApplyMarkers(journalPath)
   };
+}
+
+// Op ids whose file mutation already happened (apply-marker/v1 lines). Replay must
+// not re-run these non-idempotent writes even though the watermark does not cover
+// them yet.
+export function readApplyMarkers(journalPath: string): ReadonlySet<string> {
+  if (!existsSync(journalPath)) return new Set();
+  const body = readFileSync(journalPath, "utf8").trim();
+  if (body.length === 0) return new Set();
+
+  const markers = new Set<string>();
+  for (const line of body.split("\n")) {
+    const parsed = JSON.parse(line) as Partial<ApplyMarkerRecord>;
+    if (parsed.schema === "apply-marker/v1" && typeof parsed.opId === "string") {
+      markers.add(parsed.opId);
+    }
+  }
+  return markers;
 }
 
 export function readJournal(journalPath: string, rootDir: string): ReadonlyArray<JournalRecord> {
@@ -24,9 +44,10 @@ export function readJournal(journalPath: string, rootDir: string): ReadonlyArray
 
   const records: JournalRecord[] = [];
   for (const line of body.split("\n")) {
-    const parsed = JSON.parse(line) as Partial<JournalRecord | LockTakeoverRecord | DeleteAuditRecord>;
+    const parsed = JSON.parse(line) as Partial<JournalRecord | LockTakeoverRecord | DeleteAuditRecord | ApplyMarkerRecord>;
     if (parsed.schema === "lock-takeover/v1") continue;
     if (parsed.schema === "delete-audit/v1") continue;
+    if (parsed.schema === "apply-marker/v1") continue;
     if (parsed.schema !== "write-journal/v1") {
       throw new Error("malformed journal record: unsupported schema");
     }
@@ -84,7 +105,7 @@ export function readPayloadRef(rootDir: string, record: JournalRecord): Record<s
   return JSON.parse(body) as Record<string, unknown>;
 }
 
-export function appendJsonLineDurably(filePath: string, value: JournalRecord | LockTakeoverRecord | DeleteAuditRecord): void {
+export function appendJsonLineDurably(filePath: string, value: JournalRecord | LockTakeoverRecord | DeleteAuditRecord | ApplyMarkerRecord): void {
   mkdirSync(path.dirname(filePath), { recursive: true });
   const fd = openSync(filePath, "a");
   try {

--- a/packages/kernel/src/store/write-journal-types.ts
+++ b/packages/kernel/src/store/write-journal-types.ts
@@ -53,6 +53,17 @@ export interface DeleteAuditRecord {
   readonly reason: string;
 }
 
+// Durable mark that a non-idempotent op (delta progress_append) already mutated
+// the target file. Replay skips the file write for marked ops but still commits
+// and watermarks them, so a crash between apply and watermark cannot append the
+// same delta twice (ADR-0016 D2).
+export interface ApplyMarkerRecord {
+  readonly schema: "apply-marker/v1";
+  readonly opId: string;
+  readonly taskId: TaskId;
+  readonly at: string;
+}
+
 export interface WriteWatermark {
   readonly schema: "write-watermark/v1";
   readonly lastCommittedOpIds: ReadonlyArray<string>;

--- a/packages/kernel/src/write-coordination/write-helpers.ts
+++ b/packages/kernel/src/write-coordination/write-helpers.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { Effect } from "effect";
 import type { TaskId, WriteError } from "../domain/index.ts";
 import { stablePayloadHash } from "../integrity/stable-hash.ts";
@@ -48,7 +49,13 @@ export function writeCoordinatedPayload(
   options: { readonly flush?: boolean } = {}
 ): Effect.Effect<void, WriteError> {
   return Effect.gen(function* () {
-    const opId = `${input.opIdPrefix ?? Date.now()}-${hashPayload({
+    // Default op ids carry random entropy: delta-shaped payloads (e.g. progress_append)
+    // are constant for identical text, so timestamp+hash alone would collide within one
+    // millisecond and silently dedupe a legitimate second append. Callers that pass an
+    // explicit opIdPrefix opt into deterministic ids for intentional idempotency. The
+    // hash still folds in taskId/kind so distinct ops never share a payload hash.
+    const prefix = input.opIdPrefix ?? `${Date.now()}-${randomBytes(4).toString("hex")}`;
+    const opId = `${prefix}-${hashPayload({
       taskId: input.taskId,
       kind: input.kind,
       payload: input.payload

--- a/packages/kernel/test/store/helpers.ts
+++ b/packages/kernel/test/store/helpers.ts
@@ -32,3 +32,29 @@ export function docWrite(opId: string, taskId: string, documentPath: string, bod
     }
   };
 }
+
+// ADR-0016 D2: delta-shaped progress_append op (journal stores only the append text).
+export function progressAppendDelta(opId: string, taskId: string, text: string): WriteOp {
+  return {
+    opId,
+    taskId,
+    kind: "progress_append",
+    payload: {
+      path: "progress.md",
+      append: text
+    }
+  };
+}
+
+// Legacy full-snapshot progress_append op (pre-ADR-0016 payload shape).
+export function progressAppendSnapshot(opId: string, taskId: string, body: string): WriteOp {
+  return {
+    opId,
+    taskId,
+    kind: "progress_append",
+    payload: {
+      path: "progress.md",
+      body
+    }
+  };
+}

--- a/packages/kernel/test/store/progress-append-delta.test.ts
+++ b/packages/kernel/test/store/progress-append-delta.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { Effect } from "effect";
+import { makeJournaledWriteCoordinator } from "../../src/store/index.ts";
+import { progressAppendDelta, progressAppendSnapshot, withTempStore } from "./helpers.ts";
+
+// ADR-0016 D2 / 37-write-coordination-contract §10.2 focused tests.
+
+function progressPath(rootDir: string, taskId: string): string {
+  return path.join(rootDir, `harness/planning/tasks/${taskId}/progress.md`);
+}
+
+test("progress_append delta accumulates appends with correct separators", () => {
+  withTempStore((rootDir) => {
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+
+    Effect.runSync(coordinator.enqueue(progressAppendDelta("op-1", "task-1", "line one")));
+    Effect.runSync(coordinator.flush("explicit"));
+    Effect.runSync(coordinator.enqueue(progressAppendDelta("op-2", "task-1", "line two")));
+    Effect.runSync(coordinator.flush("explicit"));
+    Effect.runSync(coordinator.enqueue(progressAppendDelta("op-3", "task-1", "line three")));
+    Effect.runSync(coordinator.flush("explicit"));
+
+    assert.equal(
+      readFileSync(progressPath(rootDir, "task-1"), "utf8"),
+      "line one\nline two\nline three\n"
+    );
+  });
+});
+
+test("progress_append delta replay preserves hand edits made after enqueue", () => {
+  withTempStore((rootDir) => {
+    // Seed the file through the coordinator so it exists on disk.
+    const seeder = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(seeder.enqueue(progressAppendDelta("op-seed", "task-1", "seed")));
+    Effect.runSync(seeder.flush("explicit"));
+
+    // Enqueue a delta op but crash before flushing it (journal has the pending record).
+    const crashed = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(crashed.enqueue(progressAppendDelta("op-pending", "task-1", "from journal")));
+
+    // Simulate a direct hand edit of progress.md while the op is unflushed.
+    const filePath = progressPath(rootDir, "task-1");
+    writeFileSync(filePath, "seed\nMANUAL EDIT", "utf8");
+
+    // Recovery replays the pending delta against the CURRENT on-disk contents.
+    const recovered = makeJournaledWriteCoordinator({ rootDir });
+    const report = Effect.runSync(recovered.recover);
+    assert.equal(report.replayedOps, 1);
+
+    const body = readFileSync(filePath, "utf8");
+    assert.equal(body, "seed\nMANUAL EDIT\nfrom journal\n");
+    assert.match(body, /MANUAL EDIT/); // hand edit survived; no stale snapshot rollback
+  });
+});
+
+test("legacy full-snapshot progress_append op still overwrites on replay", () => {
+  withTempStore((rootDir) => {
+    const seeder = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(seeder.enqueue(progressAppendDelta("op-seed", "task-1", "old seed")));
+    Effect.runSync(seeder.flush("explicit"));
+
+    // Enqueue a pre-ADR-0016 snapshot-shaped op (payload carries the full new file body).
+    const crashed = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(crashed.enqueue(progressAppendSnapshot("op-legacy", "task-1", "FULL SNAPSHOT REPLACEMENT\n")));
+
+    // A hand edit before replay is intentionally overwritten by the legacy op (old semantics).
+    const filePath = progressPath(rootDir, "task-1");
+    writeFileSync(filePath, "tampered", "utf8");
+
+    const recovered = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(recovered.recover);
+
+    assert.equal(readFileSync(filePath, "utf8"), "FULL SNAPSHOT REPLACEMENT\n");
+  });
+});
+
+test("progress_append delta appends text verbatim without formatting or normalization", () => {
+  withTempStore((rootDir) => {
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    // Markdown-ish content with leading/trailing spaces and blank lines must pass through unchanged.
+    const raw = "  * not-a-bullet\n\n#tag   with trailing spaces   ";
+
+    assert.equal(existsSync(progressPath(rootDir, "task-1")), false);
+    Effect.runSync(coordinator.enqueue(progressAppendDelta("op-1", "task-1", raw)));
+    Effect.runSync(coordinator.flush("explicit"));
+
+    // Only a single trailing newline is added; every other byte is preserved as-is.
+    assert.equal(readFileSync(progressPath(rootDir, "task-1"), "utf8"), `${raw}\n`);
+  });
+});

--- a/packages/kernel/test/store/progress-append-delta.test.ts
+++ b/packages/kernel/test/store/progress-append-delta.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import { makeJournaledWriteCoordinator } from "../../src/store/index.ts";
@@ -89,5 +89,66 @@ test("progress_append delta appends text verbatim without formatting or normaliz
 
     // Only a single trailing newline is added; every other byte is preserved as-is.
     assert.equal(readFileSync(progressPath(rootDir, "task-1"), "utf8"), `${raw}\n`);
+  });
+});
+
+test("recovery applies multiple pending deltas from separate writers in journal order", () => {
+  withTempStore((rootDir) => {
+    // Two writers enqueue deltas and both crash before flushing.
+    const writerA = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(writerA.enqueue(progressAppendDelta("op-1", "task-1", "first")));
+    const writerB = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(writerB.enqueue(progressAppendDelta("op-2", "task-1", "second")));
+
+    // A single recovery batch replays both deltas, accumulating in journal order.
+    const recovered = makeJournaledWriteCoordinator({ rootDir });
+    const report = Effect.runSync(recovered.recover);
+
+    assert.equal(report.replayedOps, 2);
+    assert.equal(readFileSync(progressPath(rootDir, "task-1"), "utf8"), "first\nsecond\n");
+  });
+});
+
+test("recover after successful flush does not re-append a committed delta", () => {
+  withTempStore((rootDir) => {
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(coordinator.enqueue(progressAppendDelta("op-1", "task-1", "once only")));
+    Effect.runSync(coordinator.flush("explicit"));
+
+    // Watermark covers op-1: recovery must be a no-op for the file.
+    const recovered = makeJournaledWriteCoordinator({ rootDir });
+    const report = Effect.runSync(recovered.recover);
+
+    assert.equal(report.replayedOps, 0);
+    assert.equal(readFileSync(progressPath(rootDir, "task-1"), "utf8"), "once only\n");
+  });
+});
+
+test("crash between delta apply and watermark does not duplicate the append", () => {
+  withTempStore((rootDir) => {
+    // Enqueue a delta, then simulate a crash mid-flush: the file write and the
+    // durable apply marker landed, but the watermark was never written.
+    const crashed = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(crashed.enqueue(progressAppendDelta("op-1", "task-1", "applied once")));
+
+    const filePath = progressPath(rootDir, "task-1");
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, "applied once\n", "utf8");
+    appendFileSync(
+      path.join(rootDir, ".harness/write-journal/writes.jsonl"),
+      `${JSON.stringify({ schema: "apply-marker/v1", opId: "op-1", taskId: "task-1", at: "2026-07-02T00:00:00.000Z" })}\n`,
+      "utf8"
+    );
+
+    // Replay must skip the file write (marker) yet still watermark the op.
+    const recovered = makeJournaledWriteCoordinator({ rootDir });
+    const report = Effect.runSync(recovered.recover);
+
+    assert.equal(report.recoveredWatermark, "op-1");
+    assert.equal(readFileSync(filePath, "utf8"), "applied once\n");
+
+    // A second recovery is a full no-op.
+    Effect.runSync(makeJournaledWriteCoordinator({ rootDir }).recover);
+    assert.equal(readFileSync(filePath, "utf8"), "applied once\n");
   });
 });

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -83,6 +83,7 @@ export const testTierManifest = {
     "packages/kernel/test/store/journal-idempotency.test.ts",
     "packages/kernel/test/store/payload-hash.test.ts",
     "packages/kernel/test/store/portable-path-collision.test.ts",
+    "packages/kernel/test/store/progress-append-delta.test.ts",
     "packages/kernel/test/store/same-task-fifo.test.ts",
     "packages/kernel/test/store/sqlite-rebuild.test.ts",
     "tools/check-import-boundaries.test.mjs",


### PR DESCRIPTION
## 背景

实现 ADR-0016 D2/D5 的代码变更集：`task progress append` 从"入队时读全文件、journal 存完整快照、replay 整体覆盖"改为**增量语义**——修掉崩溃恢复用旧快照覆盖手工编辑的丢失更新坑，同时消除 journal 随文件线性膨胀。

## 改动

**D2 · 增量语义**
- `appendProgress` 只入队追加增量（payload `{ path, append }`）；apply 时读**当时**磁盘上的 progress.md，处理末尾换行后追加写回
- 向后兼容：存量全量快照式 op（`{ path, body }`）仍按旧语义整体覆盖 replay，靠 payload 形状区分；opId watermark 去重不变

**D1/D5 · 边界与文案**
- `task progress append` help 与 `--text` 说明补"按原样追加，不做 Markdown 格式化/规范化"
- init 生成的 AGENTS.md 模板补 D1 边界：机器读字段走 CLI，prose 可直接编辑后手动 commit

**Review 加固（对抗式评审后追加）**
- delta 应用非幂等，崩溃在 apply 与 watermark 之间会重复追加：新增 `apply-marker/v1` durable 标记，replay 见 marker 即跳过文件写但照常 commit/watermark，窗口收窄至单次 fsync 粒度
- 默认 opId 加随机熵：delta payload 对相同文本是常量，同毫秒两次相同追加会被静默去重丢弃
- 形状判别拒绝歧义 `{path, body, append}`（回落旧快照语义）

## 测试

新增 `progress-append-delta.test.ts` 7 项：增量正确性、崩溃恢复保留手工编辑、旧格式兼容 replay、无格式化契约守护、多写者恢复批次顺序、flush 后不重复追加、apply-marker 崩溃窗口。

`npm run check` 全绿：typecheck / lint / **491 node 测试** / test:gui / 全部 20 harness checker（含 supply-chain SBOM、cli-package smoke）。

> 注：ADR-0016 / 37 §10.2 的配套文档标注（把"追加不会重复"收窄为无 crash 路径承诺 + 记录 apply-marker 机制）已提交进本地 harness 权威库（gitignored，不在本 PR diff 内）。