### PR TITLE
feat: declare decision and fact entity kinds

### DIFF
--- a/packages/cli/src/commands/extensions/assets/software-coding/vertical.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/vertical.json
@@ -4,10 +4,11 @@
   "title": "Software Coding",
   "version": "1.0.0",
   "entityKinds": [
-    { "id": "task", "packageKind": "task-package/v2", "contractEntity": true },
-    { "id": "decision-record", "packageKind": "document/v1", "contractEntity": false }
+    { "id": "task", "entityType": "lifecycle", "packageKind": "task-package/v2", "contractEntity": true },
+    { "id": "decision", "entityType": "lifecycle", "packageKind": "decision-package/v1", "contractEntity": true },
+    { "id": "fact", "entityType": "schema", "schemaRef": "schema://fact-record", "contractEntity": true }
   ],
-  "contractEntityKinds": ["task"],
+  "contractEntityKinds": ["task", "decision", "fact"],
   "packageScaffolds": [
     {
       "entityKind": "task",
@@ -19,18 +20,17 @@
         { "slot": "task.artifacts.keep", "templateRef": "template://planning/keep-file@1", "materializeAs": "artifacts/.gitkeep", "localePolicy": { "prefer": "project", "fallback": "en-US" } },
         { "slot": "task.references.keep", "templateRef": "template://planning/keep-file@1", "materializeAs": "references/.gitkeep", "localePolicy": { "prefer": "project", "fallback": "en-US" } }
       ]
+    },
+    {
+      "entityKind": "decision",
+      "templateSelections": []
     }
   ],
-  "templateSelections": [
-    { "slot": "task.plan", "templateRef": "template://planning/task-plan@1", "materializeAs": "task_plan.md", "localePolicy": { "prefer": "project", "fallback": "en-US" } },
-    { "slot": "task.progress", "templateRef": "template://planning/progress@1", "materializeAs": "progress.md", "localePolicy": { "prefer": "project", "fallback": "en-US" } },
-    { "slot": "task.review", "templateRef": "template://planning/review@1", "materializeAs": "review.md", "localePolicy": { "prefer": "project", "fallback": "en-US" } },
-    { "slot": "task.closeout", "templateRef": "template://planning/closeout@1", "materializeAs": "closeout.md", "localePolicy": { "prefer": "project", "fallback": "en-US" } },
-    { "slot": "task.artifacts.keep", "templateRef": "template://planning/keep-file@1", "materializeAs": "artifacts/.gitkeep", "localePolicy": { "prefer": "project", "fallback": "en-US" } },
-    { "slot": "task.references.keep", "templateRef": "template://planning/keep-file@1", "materializeAs": "references/.gitkeep", "localePolicy": { "prefer": "project", "fallback": "en-US" } }
-  ],
+  "templateSelections": [],
   "checkerProfile": "software-coding-standard",
   "projectionSchemas": [
-    { "id": "task-frontmatter", "schemaRef": "schema://task-frontmatter" }
+    { "id": "task-frontmatter", "schemaRef": "schema://task-frontmatter" },
+    { "id": "decision-frontmatter", "schemaRef": "schema://decision-frontmatter" },
+    { "id": "fact-record", "schemaRef": "schema://fact-record" }
   ]
 }

--- a/packages/cli/src/commands/extensions/bundled.ts
+++ b/packages/cli/src/commands/extensions/bundled.ts
@@ -41,7 +41,10 @@ export function loadBundledPresetManifestEntries(): ReadonlyArray<BundledPresetM
 }
 
 export function bundledTaskTemplateSelections(): VerticalDefinition["templateSelections"] {
-  return bundledVerticalDefinition()?.templateSelections ?? [];
+  const vertical = bundledVerticalDefinition();
+  return vertical?.packageScaffolds.find((scaffold) => scaffold.entityKind === "task")?.templateSelections
+    ?? vertical?.templateSelections
+    ?? [];
 }
 
 function readBundledJson<A, I>(relativePath: string, schema: Schema.Schema<A, I, never>): A {

--- a/packages/cli/src/commands/extensions/state.ts
+++ b/packages/cli/src/commands/extensions/state.ts
@@ -422,8 +422,9 @@ function validateAdditiveSoftwareCodingPreset(manifest: PresetManifest): Readonl
     issues.push(extensionIssue("custom_vertical_forbidden", "P08 only allows software/coding preset overrides; custom vertical exposure is gated by P10/P11.", "vertical"));
   }
 
-  const requiredBySlot = new Map(vertical.templateSelections.map((selection) => [selection.slot, selection]));
-  const requiredByPath = new Map(vertical.templateSelections.map((selection) => [selection.materializeAs, selection]));
+  const requiredSelections = verticalTaskTemplateSelections(vertical);
+  const requiredBySlot = new Map(requiredSelections.map((selection) => [selection.slot, selection]));
+  const requiredByPath = new Map(requiredSelections.map((selection) => [selection.materializeAs, selection]));
 
   for (const [profileIndex, profile] of manifest.profiles.entries()) {
     const materializedPaths = new Set<string>();
@@ -466,7 +467,7 @@ function combineVerticalAndPresetSelections(
   presetSelections: ReadonlyArray<PresetManifest["profiles"][number]["templateSelections"][number]>
 ): PresetManifest["profiles"][number]["templateSelections"] {
   const byPath = new Map<string, PresetManifest["profiles"][number]["templateSelections"][number]>();
-  for (const selection of requireBundledVerticalDefinition().templateSelections) {
+  for (const selection of verticalTaskTemplateSelections(requireBundledVerticalDefinition())) {
     byPath.set(selection.materializeAs, selection);
   }
   for (const selection of presetSelections) {
@@ -475,6 +476,12 @@ function combineVerticalAndPresetSelections(
     byPath.set(selection.materializeAs, selection);
   }
   return [...byPath.values()];
+}
+
+function verticalTaskTemplateSelections(
+  vertical: ReturnType<typeof requireBundledVerticalDefinition>
+): PresetManifest["profiles"][number]["templateSelections"] {
+  return vertical.packageScaffolds.find((scaffold) => scaffold.entityKind === "task")?.templateSelections ?? vertical.templateSelections;
 }
 
 function requireBundledTemplateCatalog() {

--- a/packages/cli/test/extension-cli.test.ts
+++ b/packages/cli/test/extension-cli.test.ts
@@ -124,6 +124,27 @@ test("CLI vertical validate fails closed on unknown lifecycle mapping fields", (
   });
 });
 
+test("CLI vertical validate fails closed when fact declares a package scaffold", () => {
+  withTempFile("vertical.json", () => {
+    const vertical = JSON.parse(readFileSync(verticalFixture, "utf8")) as Record<string, any>;
+    vertical.packageScaffolds = [
+      ...vertical.packageScaffolds,
+      {
+        entityKind: "fact",
+        templateSelections: []
+      }
+    ];
+    return JSON.stringify(vertical);
+  }, (filePath) => {
+    const result = runJson(["vertical", "validate", filePath], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error?.code, "vertical_definition_invalid");
+    assert.equal(result.issues.some((issue) => issue.code === "vertical_schema_scaffold_forbidden"), true);
+    assert.equal(JSON.stringify(result).includes(filePath), false);
+  });
+});
+
 test("CLI preset validate fails closed on budget fields before they can become task entities", () => {
   withTempFile("preset.json", () => {
     const preset = JSON.parse(readFileSync(presetFixture, "utf8")) as Record<string, any>;

--- a/packages/cli/test/package-surface.test.ts
+++ b/packages/cli/test/package-surface.test.ts
@@ -36,6 +36,10 @@ test("bundled software coding assets have consistent template and process-preset
   };
   const vertical = JSON.parse(readFileSync(path.join(assetRoot, "vertical.json"), "utf8")) as {
     readonly templateSelections: ReadonlyArray<TemplateSelection>;
+    readonly packageScaffolds: ReadonlyArray<{
+      readonly entityKind: string;
+      readonly templateSelections: ReadonlyArray<TemplateSelection>;
+    }>;
   };
   const index = JSON.parse(readFileSync(path.join(assetRoot, "presets/index.json"), "utf8")) as {
     readonly presets: ReadonlyArray<string>;
@@ -45,7 +49,10 @@ test("bundled software coding assets have consistent template and process-preset
   const processPresetIds = new Set(["legacy-migration", "lesson-sedimentation", "milestone-closeout", "publish-standard", "release-closeout", "version-upgrade"]);
   const implementedProcessPresetIds = new Set(["legacy-migration", "milestone-closeout"]);
 
-  for (const selection of vertical.templateSelections) {
+  assert.equal(vertical.templateSelections.length, 0, "vertical top-level templateSelections stay deduplicated");
+  const taskScaffoldSelections = vertical.packageScaffolds.find((scaffold) => scaffold.entityKind === "task")?.templateSelections ?? [];
+
+  for (const selection of taskScaffoldSelections) {
     assertKnownTemplateRef(catalogIds, selection.templateRef);
     assert.equal(selectedMaterializedPaths.has(selection.materializeAs), false, `duplicate materialized path ${selection.materializeAs}`);
     selectedMaterializedPaths.add(selection.materializeAs);

--- a/packages/kernel/fixtures/schemas/vertical-definition/valid.json
+++ b/packages/kernel/fixtures/schemas/vertical-definition/valid.json
@@ -6,16 +6,24 @@
   "entityKinds": [
     {
       "id": "task",
+      "entityType": "lifecycle",
       "packageKind": "task-package/v2",
       "contractEntity": true
     },
     {
-      "id": "decision-record",
-      "packageKind": "document/v1",
-      "contractEntity": false
+      "id": "decision",
+      "entityType": "lifecycle",
+      "packageKind": "decision-package/v1",
+      "contractEntity": true
+    },
+    {
+      "id": "fact",
+      "entityType": "schema",
+      "schemaRef": "schema://fact-record",
+      "contractEntity": true
     }
   ],
-  "contractEntityKinds": ["task"],
+  "contractEntityKinds": ["task", "decision", "fact"],
   "packageScaffolds": [
     {
       "entityKind": "task",
@@ -33,24 +41,26 @@
           }
         }
       ]
-    }
-  ],
-  "templateSelections": [
+    },
     {
-      "slot": "task.flow",
-      "templateRef": "template://planning/task-flow@1",
-      "materializeAs": "task_flow.md",
-      "localePolicy": {
-        "prefer": "project",
-        "fallback": "en-US"
-      }
+      "entityKind": "decision",
+      "templateSelections": []
     }
   ],
+  "templateSelections": [],
   "checkerProfile": "software-coding-standard",
   "projectionSchemas": [
     {
       "id": "task-frontmatter",
       "schemaRef": "schema://task-frontmatter"
+    },
+    {
+      "id": "decision-frontmatter",
+      "schemaRef": "schema://decision-frontmatter"
+    },
+    {
+      "id": "fact-record",
+      "schemaRef": "schema://fact-record"
     }
   ]
 }

--- a/packages/kernel/schemas/json/vertical-definition.schema.json
+++ b/packages/kernel/schemas/json/vertical-definition.schema.json
@@ -15,14 +15,30 @@
       "type": "array",
       "minItems": 1,
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["id", "packageKind", "contractEntity"],
-        "properties": {
-          "id": { "type": "string" },
-          "packageKind": { "type": "string" },
-          "contractEntity": { "type": "boolean" }
-        }
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "entityType", "packageKind", "contractEntity"],
+            "properties": {
+              "id": { "type": "string" },
+              "entityType": { "const": "lifecycle" },
+              "packageKind": { "type": "string" },
+              "contractEntity": { "type": "boolean" }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "entityType", "schemaRef", "contractEntity"],
+            "properties": {
+              "id": { "type": "string" },
+              "entityType": { "const": "schema" },
+              "schemaRef": { "type": "string" },
+              "contractEntity": { "type": "boolean" }
+            }
+          }
+        ]
       }
     },
     "contractEntityKinds": {

--- a/packages/kernel/src/domain/extension-model.ts
+++ b/packages/kernel/src/domain/extension-model.ts
@@ -24,7 +24,11 @@ export interface ExtensionValidationIssue {
     | "status_mapping_forbidden"
     | "template_locale_structure_mismatch"
     | "unknown_extension_field"
-    | "vertical_contract_entity_missing";
+    | "vertical_contract_entity_disabled"
+    | "vertical_contract_entity_missing"
+    | "vertical_lifecycle_scaffold_missing"
+    | "vertical_scaffold_entity_missing"
+    | "vertical_schema_scaffold_forbidden";
   readonly message: string;
   readonly path: string;
 }
@@ -150,18 +154,42 @@ export function validatePresetManifests(
 
 export function validateVerticalDefinition(vertical: VerticalDefinition): ExtensionValidationResult {
   const issues: ExtensionValidationIssue[] = [];
-  const entityIds = new Set<string>();
+  const entityById = new Map<string, VerticalDefinition["entityKinds"][number]>();
+  const scaffoldEntityKinds = new Set<string>();
 
   for (const [entityIndex, entity] of vertical.entityKinds.entries()) {
-    if (entityIds.has(entity.id)) {
+    if (entityById.has(entity.id)) {
       issues.push(issue("duplicate_vertical_entity", `Duplicate vertical entity kind ${entity.id}.`, `entityKinds[${entityIndex}].id`));
     }
-    entityIds.add(entity.id);
+    entityById.set(entity.id, entity);
   }
 
   for (const [contractIndex, entityKind] of vertical.contractEntityKinds.entries()) {
-    if (!entityIds.has(entityKind)) {
+    const entity = entityById.get(entityKind);
+    if (!entity) {
       issues.push(issue("vertical_contract_entity_missing", `Contract entity ${entityKind} is not declared in entityKinds.`, `contractEntityKinds[${contractIndex}]`));
+      continue;
+    }
+    if (!entity.contractEntity) {
+      issues.push(issue("vertical_contract_entity_disabled", `Contract entity ${entityKind} must be marked contractEntity: true.`, `contractEntityKinds[${contractIndex}]`));
+    }
+  }
+
+  for (const [scaffoldIndex, scaffold] of vertical.packageScaffolds.entries()) {
+    scaffoldEntityKinds.add(scaffold.entityKind);
+    const entity = entityById.get(scaffold.entityKind);
+    if (!entity) {
+      issues.push(issue("vertical_scaffold_entity_missing", `Package scaffold entity ${scaffold.entityKind} is not declared in entityKinds.`, `packageScaffolds[${scaffoldIndex}].entityKind`));
+      continue;
+    }
+    if (entity.entityType === "schema") {
+      issues.push(issue("vertical_schema_scaffold_forbidden", `Schema entity ${scaffold.entityKind} must not declare a package scaffold.`, `packageScaffolds[${scaffoldIndex}].entityKind`));
+    }
+  }
+
+  for (const [entityIndex, entity] of vertical.entityKinds.entries()) {
+    if (entity.entityType === "lifecycle" && !scaffoldEntityKinds.has(entity.id)) {
+      issues.push(issue("vertical_lifecycle_scaffold_missing", `Lifecycle entity ${entity.id} must declare a package scaffold.`, `entityKinds[${entityIndex}].id`));
     }
   }
 
@@ -333,7 +361,7 @@ function validateVerticalDefinitionShape(input: unknown, path: string, issues: E
   if (!isRecord(input)) return;
   if (Array.isArray(input.entityKinds)) {
     for (const [index, entity] of input.entityKinds.entries()) {
-      validateObjectKeys(entity, `${path}.entityKinds[${index}]`, ["id", "packageKind", "contractEntity"], issues);
+      validateObjectKeys(entity, `${path}.entityKinds[${index}]`, ["id", "entityType", "packageKind", "schemaRef", "contractEntity"], issues);
     }
   }
   if (Array.isArray(input.packageScaffolds)) {

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -274,11 +274,20 @@ export const VerticalDefinitionSchema = Schema.Struct({
   id: Schema.String,
   title: Schema.String,
   version: Schema.String,
-  entityKinds: Schema.Array(Schema.Struct({
-    id: Schema.String,
-    packageKind: Schema.String,
-    contractEntity: Schema.Boolean
-  })).pipe(Schema.minItems(1)),
+  entityKinds: Schema.Array(Schema.Union(
+    Schema.Struct({
+      id: Schema.String,
+      entityType: Schema.Literal("lifecycle"),
+      packageKind: Schema.String,
+      contractEntity: Schema.Boolean
+    }),
+    Schema.Struct({
+      id: Schema.String,
+      entityType: Schema.Literal("schema"),
+      schemaRef: Schema.String,
+      contractEntity: Schema.Boolean
+    })
+  )).pipe(Schema.minItems(1)),
   contractEntityKinds: StringArray,
   packageScaffolds: Schema.Array(Schema.Struct({
     entityKind: Schema.String,

--- a/packages/kernel/test/contracts/extension-model.test.ts
+++ b/packages/kernel/test/contracts/extension-model.test.ts
@@ -123,6 +123,73 @@ test("vertical validation rejects lifecycle status mapping ownership", async () 
   assert.equal(result.issues.some((issue) => issue.code === "status_mapping_forbidden"), true);
 });
 
+test("vertical validation accepts decision lifecycle and fact schema entity kinds", async () => {
+  const vertical = Schema.decodeUnknownSync(VerticalDefinitionSchema)(await readFixture(verticalDefinitionUrl));
+  const byId = new Map(vertical.entityKinds.map((entity) => [entity.id, entity]));
+
+  assert.deepEqual([...byId.keys()], ["task", "decision", "fact"]);
+  assert.equal(byId.get("decision")?.entityType, "lifecycle");
+  assert.equal(byId.get("fact")?.entityType, "schema");
+  assert.deepEqual(vertical.contractEntityKinds, ["task", "decision", "fact"]);
+  assert.equal(validateVerticalDefinition(vertical).ok, true);
+});
+
+test("vertical schema rejects composite entity kinds in M3", async () => {
+  const vertical = await readFixture(verticalDefinitionUrl) as Record<string, any>;
+  vertical.entityKinds = [
+    ...vertical.entityKinds,
+    {
+      id: "milestone",
+      entityType: "composite",
+      contractEntity: true
+    }
+  ];
+
+  assert.throws(() => Schema.decodeUnknownSync(VerticalDefinitionSchema)(vertical));
+});
+
+test("vertical validation rejects schema entity package scaffolds", async () => {
+  const vertical = Schema.decodeUnknownSync(VerticalDefinitionSchema)(await readFixture(verticalDefinitionUrl));
+  const contaminated: VerticalDefinition = {
+    ...vertical,
+    packageScaffolds: [
+      ...vertical.packageScaffolds,
+      {
+        entityKind: "fact",
+        templateSelections: []
+      }
+    ]
+  };
+  const result = validateVerticalDefinition(contaminated);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.issues.some((issue) => issue.code === "vertical_schema_scaffold_forbidden"), true);
+});
+
+test("vertical validation rejects lifecycle entities without package scaffolds", async () => {
+  const vertical = Schema.decodeUnknownSync(VerticalDefinitionSchema)(await readFixture(verticalDefinitionUrl));
+  const contaminated: VerticalDefinition = {
+    ...vertical,
+    packageScaffolds: vertical.packageScaffolds.filter((scaffold) => scaffold.entityKind !== "decision")
+  };
+  const result = validateVerticalDefinition(contaminated);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.issues.some((issue) => issue.code === "vertical_lifecycle_scaffold_missing"), true);
+});
+
+test("vertical validation rejects contract entity declarations that are not contract-bearing", async () => {
+  const vertical = Schema.decodeUnknownSync(VerticalDefinitionSchema)(await readFixture(verticalDefinitionUrl));
+  const contaminated: VerticalDefinition = {
+    ...vertical,
+    entityKinds: vertical.entityKinds.map((entity) => entity.id === "decision" ? { ...entity, contractEntity: false } : entity)
+  };
+  const result = validateVerticalDefinition(contaminated);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.issues.some((issue) => issue.code === "vertical_contract_entity_disabled"), true);
+});
+
 async function readFixture(url: URL): Promise<unknown> {
   return JSON.parse(await readFile(url, "utf8")) as unknown;
 }


### PR DESCRIPTION
## Summary

Declare coding vertical entity kinds for M3 decision/fact support and make vertical validation distinguish lifecycle entities from schema entities.

## What Changed

- Added lifecycle/schema entity kind variants to the vertical definition Effect schema and published JSON Schema.
- Updated software/coding vertical fixtures and bundled assets to declare `task`, `decision`, and `fact`, with `fact` as a schema entity and `decision` as a lifecycle entity.
- Moved bundled task template selection reads to `packageScaffolds[entityKind=task]` so top-level `templateSelections` stays deduplicated.
- Added validation and CLI tests for decision/fact declarations, composite rejection, schema scaffold rejection, missing lifecycle scaffold rejection, and disabled contract entity declarations.

## Task And Scope

- Harness task: `task_01KWFQ216YF9A3TXNWYGHJN41R` TP-M3-00b EntityKinds add decision and fact.
- Branch: `codex/tp-00b-entity-kinds`.
- Public scope: vertical definition schema/validation, bundled software/coding vertical asset, fixtures, and existing contract/CLI tests.
- Private planning/evidence updated: pending parent ledger entry after PR creation.
- Out of scope: decision package write path, relation schema, EntityKind registry/repositoryScaffold, composite/milestone support, legacy vertical compatibility.

## Version Impact

- Version: no version change because this is an internal pre-release schema/fixture contract change.
- Publish impact: no publish.

## Verification

- Base `origin/main` SHA: `e67ac48`.
- Branch merge-base with `origin/main`: `e67ac48`.
- Last `git fetch origin` time: `2026-07-02 23:59:41 CST`.
- Sync method: rebase, no-op because branch was already based on latest `origin/main`.
- Public diff command: `git diff --name-only origin/main...HEAD`.
- Private evidence commit/path: pending parent progress ledger entry after PR creation.
- Reviewer evidence path: pending CEO/Sonnet review.
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28603925907.
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck` via `npm run check`
- [x] `npm test` via `npm run check`
- [x] `npm run harness:check-import-boundaries` via `npm run check`
- [x] `npm run harness:scan-forbidden-symbols` via `npm run check`
- [x] `npm run harness:check-private-boundary` via `npm run check`
- [x] `npm run harness:check-package-policy` via `npm run check`
- [x] `npm run harness:check-implementation-contracts` via `npm run check`
- [x] `npm run harness:check-schema-contracts` via `npm run check`
- [x] `npm run harness:check-legacy-intake-readiness` via `npm run check`
- [x] `npm run harness:smoke-cli-package` via `npm run check`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` was not run separately; dependencies were installed in this worktree and the full local `npm run check` gate passed. The first `npm run check` attempt hit a transient `npm audit` TLS error in supply-chain; `npm run harness:check-supply-chain` then passed, and a second full `npm run check` passed.

## Review Evidence

- Self-review: checked public diff scope, no private harness files, no local agent entry files, no absolute local paths in this PR body.
- Reviewer subagent: pending.
- Human review: pending.
- Blocking findings: none known before remote review.

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear: CEO side will review, wait for `rewrite-ci`, admin-squash-merge if approved, delete remote branch, and remove the worktree.

## Residual Risk

- `vertical-definition/v1` keeps the top-level `templateSelections` field for the current schema shape, but bundled software/coding now leaves it empty and reads task scaffold templates from `packageScaffolds[entityKind=task]`; full schema version cleanup remains outside TP-00b.
- Decision package authoring and relation schema behavior are intentionally left to TP-01 and TP-02.

## References

- Task: `task_01KWFQ216YF9A3TXNWYGHJN41R`.
- Evidence: local `npm run check` passed on branch `codex/tp-00b-entity-kinds`.
- Review: pending.

---

## 摘要

为 M3 decision/fact 支持声明 coding vertical 的实体类型，并让 vertical validation 区分 lifecycle 实体与 schema 实体。

## 改动内容

- vertical definition 的 Effect Schema 与发布 JSON Schema 增加 lifecycle/schema entity kind 形态。
- software/coding vertical fixture 与 bundled asset 声明 `task`、`decision`、`fact`；`decision` 是 lifecycle 实体，`fact` 是 schema 实体。
- bundled task 模板读取改为走 `packageScaffolds[entityKind=task]`，顶层 `templateSelections` 保持去重为空。
- 增加 contract/CLI 测试，覆盖 decision/fact 正例、composite 拒绝、schema entity scaffold 拒绝、lifecycle 缺 scaffold 拒绝、contractEntityKinds 指向非承重实体拒绝。

## 任务与范围

- Harness 任务：`task_01KWFQ216YF9A3TXNWYGHJN41R` TP-M3-00b EntityKinds add decision and fact。
- 分支：`codex/tp-00b-entity-kinds`。
- 公开范围：vertical definition schema/validation、bundled software/coding vertical asset、fixtures、既有 contract/CLI tests。
- 私有计划 / 证据是否已更新：PR 创建后补父任务 progress ledger。
- 范围外：decision package 写路径、relation schema、EntityKind registry/repositoryScaffold、composite/milestone、旧 vertical 兼容读取。

## 版本影响

- 版本：不改版本，原因是内部预发布 schema/fixture contract 变更。
- 发布影响：不发布。

## 验证

- `origin/main` 基准 SHA：`e67ac48`。
- 当前分支与 `origin/main` 的 merge-base：`e67ac48`。
- 最近一次 `git fetch origin` 时间：`2026-07-02 23:59:41 CST`。
- 同步方式：rebase，no-op。
- 公开 diff 命令：`git diff --name-only origin/main...HEAD`。
- 私有证据 commit/path：PR 创建后补父任务 progress ledger。
- Reviewer 证据路径：待 CEO/Sonnet review。
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28603925907。
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck` via `npm run check`
- [x] `npm test` via `npm run check`
- [x] `npm run harness:check-import-boundaries` via `npm run check`
- [x] `npm run harness:scan-forbidden-symbols` via `npm run check`
- [x] `npm run harness:check-private-boundary` via `npm run check`
- [x] `npm run harness:check-package-policy` via `npm run check`
- [x] `npm run harness:check-implementation-contracts` via `npm run check`
- [x] `npm run harness:check-schema-contracts` via `npm run check`
- [x] `npm run harness:check-legacy-intake-readiness` via `npm run check`
- [x] `npm run harness:smoke-cli-package` via `npm run check`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：未单独运行 `npm ci`；本 worktree 已安装依赖并通过完整 `npm run check`。首次 `npm run check` 在 supply-chain 的 `npm audit` 处遇到网络 TLS 瞬断；随后单独 `npm run harness:check-supply-chain` 通过，第二次完整 `npm run check` 通过。

## 审查证据

- 自查：已确认公开 diff 范围，不包含私有 harness、本地 agent 入口文件，PR body 不含本机绝对路径。
- Reviewer subagent：待补。
- 人工审查：待补。
- 阻塞发现：远端审查前暂无。

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚：CEO 侧 review，等待 `rewrite-ci`，通过后 admin-squash-merge，删除远端分支并清理 worktree。

## 残余风险

- `vertical-definition/v1` 当前仍保留顶层 `templateSelections` 字段，但 bundled software/coding 已置空并改从 `packageScaffolds[entityKind=task]` 读取；完整 schema version 清理不属于 TP-00b。
- Decision package authoring 与 relation schema 行为留给 TP-01/TP-02。

## 关联材料

- 任务：`task_01KWFQ216YF9A3TXNWYGHJN41R`。
- 证据：`codex/tp-00b-entity-kinds` 分支本地 `npm run check` 通过。
- 审查：待补。

