### PR TITLE
feat: add decision skills

### DIFF
--- a/skills/decision/SKILL.md
+++ b/skills/decision/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: decision
+description: Capture a single consequential decision from the current conversation. Use when a user asks to record, propose, accept, reject, defer, amend, supersede, or retire one decision in Harness Anything. Thin trigger only: it must call the Harness Anything decision CLI and must not edit markdown directly.
+---
+
+# Decision
+
+## Core Rule
+
+This skill is a thin trigger over the Harness Anything CLI. All authored entity changes must go through `npx ha decision ...` or the installed `harness-anything decision ...` command.
+
+Do not edit, create, patch, append, or rewrite decision markdown directly. Do not create frontmatter by hand. The CLI writes through the application service and WriteCoordinator, adds coordinator watermarks, and binds provenance.
+
+## When To Use
+
+Use this skill for one decision at a time:
+
+- Turn an important conversation outcome into a proposed decision.
+- Accept, reject, defer, supersede, amend, or retire an existing decision.
+- Convert a user's explicit choice into a durable decision record.
+
+## Workflow
+
+1. Identify the decision question in one sentence.
+2. Confirm the chosen option and at least one rejected alternative with a clear `why_not`.
+3. Capture any claim that must later be supported by facts or relations.
+4. Run the CLI with `--json` and inspect the receipt before reporting success.
+5. If the user wants the decision finalized, run the appropriate state command through the CLI.
+
+## Propose Pattern
+
+For source checkouts, prefer `npx ha`:
+
+```bash
+npx ha decision propose \
+  --title "Adopt decision loop" \
+  --question "Should this work be recorded as a decision?" \
+  --chosen "Record it" \
+  --rejected "Leave it in chat only" \
+  --why-not "Chat-only reasoning is not durable or queryable" \
+  --claim "The decision is consequential enough to preserve" \
+  --json
+```
+
+For installed package use, the equivalent command is:
+
+```bash
+harness-anything decision propose --title "..." --question "..." --chosen "..." --rejected "..." --why-not "..." --json
+```
+
+## State Commands
+
+Use only CLI state operations:
+
+```bash
+npx ha decision accept <decision-id> --arbiter human:<id> --json
+npx ha decision reject <decision-id> --arbiter human:<id> --json
+npx ha decision defer <decision-id> --arbiter human:<id> --json
+npx ha decision supersede <decision-id> --arbiter human:<id> --json
+npx ha decision amend <decision-id> --title "Updated title" --json
+npx ha decision retire <decision-id> --arbiter human:<id> --json
+```
+
+## Guardrails
+
+- Never bypass the CLI to mutate decision files.
+- Never invent an arbiter; ask the user when it is not clear.
+- Never omit the rejected alternative and `why_not` when proposing.
+- Never claim a decision was recorded until the CLI command returns `ok: true`.
+- If a CLI capability is missing, stop and report the missing command instead of hand-writing the record.

--- a/skills/decision/agents/openai.yaml
+++ b/skills/decision/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Decision"
+  short_description: "Record one consequential decision through the CLI"
+  default_prompt: "Capture one consequential decision by using the Harness Anything decision CLI. Do not edit markdown directly."

--- a/skills/decisions/SKILL.md
+++ b/skills/decisions/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: decisions
+description: Drive a conversational decision queue for Harness Anything. Use when a user wants to review multiple pending decisions, walk through decision candidates, or finalize several decisions. Thin trigger only: it must call the Harness Anything decision CLI and must not edit markdown directly.
+---
+
+# Decisions
+
+## Core Rule
+
+This skill coordinates a decision review loop. It does not own persistence. All changes must be executed through `npx ha decision ...` or the installed `harness-anything decision ...` command.
+
+Do not edit, create, patch, append, or rewrite decision, task, fact, relation, or session markdown directly. The CLI path is responsible for WriteCoordinator, provenance binding, and watermark checks.
+
+## When To Use
+
+Use this skill when there is more than one decision candidate or when the user wants to process a queue conversationally:
+
+- Review proposed decision candidates one by one.
+- Turn a conversation backlog into proposed decisions.
+- Accept, reject, defer, supersede, amend, or retire existing decisions.
+
+## Queue Loop
+
+1. Ask the user for the next candidate or existing decision id.
+2. For a new candidate, collect `title`, `question`, `chosen`, `rejected`, `why_not`, and optional `claim`.
+3. For an existing decision, ask for the intended outcome: accept, reject, defer, supersede, amend, or retire.
+4. Run exactly one CLI command for the current item and inspect the JSON receipt.
+5. Summarize the result, then ask whether to continue to the next item.
+
+## CLI Patterns
+
+Propose:
+
+```bash
+npx ha decision propose \
+  --title "Adopt decision loop" \
+  --question "Should this work be recorded as a decision?" \
+  --chosen "Record it" \
+  --rejected "Leave it in chat only" \
+  --why-not "Chat-only reasoning is not durable or queryable" \
+  --claim "The decision is consequential enough to preserve" \
+  --json
+```
+
+Finalize:
+
+```bash
+npx ha decision accept <decision-id> --arbiter human:<id> --json
+npx ha decision reject <decision-id> --arbiter human:<id> --json
+npx ha decision defer <decision-id> --arbiter human:<id> --json
+npx ha decision supersede <decision-id> --arbiter human:<id> --json
+npx ha decision amend <decision-id> --title "Updated title" --json
+npx ha decision retire <decision-id> --arbiter human:<id> --json
+```
+
+For installed package use, replace `npx ha` with `harness-anything`.
+
+## Guardrails
+
+- Process one item at a time; do not batch-write multiple decisions blindly.
+- Never bypass the CLI to mutate authored markdown.
+- Never silently choose an arbiter or a rejected alternative.
+- Never report queue progress as durable until the CLI returns `ok: true`.
+- If no candidate or id is available, ask the user for the next item instead of scanning and editing files.

--- a/skills/decisions/agents/openai.yaml
+++ b/skills/decisions/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Decisions"
+  short_description: "Review a conversational decision queue through the CLI"
+  default_prompt: "Walk through decision candidates one at a time by using the Harness Anything decision CLI. Do not edit markdown directly."

--- a/tools/skill-contracts.test.mjs
+++ b/tools/skill-contracts.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const skillsRoot = path.join(repoRoot, "skills");
+
+test("repository decision skills are discoverable with agent metadata", () => {
+  const skillNames = readdirSync(skillsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+
+  assert.deepEqual(skillNames, ["decision", "decisions", "preset-creator", "vertical-creator"]);
+  for (const skillName of ["decision", "decisions"]) {
+    assert.equal(existsSync(path.join(skillsRoot, skillName, "SKILL.md")), true, skillName);
+    assert.equal(existsSync(path.join(skillsRoot, skillName, "agents", "openai.yaml")), true, skillName);
+  }
+});
+
+test("decision skills are thin CLI triggers and do not instruct direct markdown writes", () => {
+  for (const skillName of ["decision", "decisions"]) {
+    const body = readFileSync(path.join(skillsRoot, skillName, "SKILL.md"), "utf8");
+
+    assert.match(body, new RegExp(`name: ${skillName}`, "u"), skillName);
+    assert.match(body, /npx ha decision propose/u, skillName);
+    assert.match(body, /npx ha decision accept/u, skillName);
+    assert.match(body, /WriteCoordinator/u, skillName);
+    assert.match(body, /Do not edit, create, patch, append, or rewrite/u, skillName);
+    assert.doesNotMatch(body, /\bwriteFileSync\b|\bfs\.write|\bapply_patch\b|cat\s*>\s*.+decision\.md|tee\s+.+decision\.md/u, skillName);
+  }
+});

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -65,6 +65,7 @@ export const testTierManifest = {
     "tools/check-integrity-single-source.test.mjs",
     "tools/check-legacy-intake-readiness.test.mjs",
     "tools/check-service-mappability.test.mjs",
+    "tools/skill-contracts.test.mjs",
     "tools/smoke-cli-package.test.mjs",
     "tools/scan-forbidden-symbols.test.mjs"
   ],


### PR DESCRIPTION
## Summary

Adds the planned TP-M3-09 decision skills: `decision` and `decisions`.

## What Changed

- Added `skills/decision/SKILL.md` and OpenAI agent metadata for recording one consequential decision through the CLI.
- Added `skills/decisions/SKILL.md` and OpenAI agent metadata for conversationally processing multiple decision candidates one at a time.
- Added a contract test that proves the repository skill list includes both decision skills and that the decision skills are thin CLI triggers, not direct markdown writers.
- Registered the new test in the contract tier manifest.

## Task And Scope

- Harness task: `task_01KWJBFTNH4ETY5CYX45YCSGCH`
- Branch: `codex/tp-09-decision-skills`
- Public scope: planned decision skill files, OpenAI skill metadata, and contract tests.
- Private planning/evidence updated: yes, private evidence commit `f4c16fc`.
- Out of scope: new CLI commands, new ports, plugin packaging, daemon behavior, GUI changes, or additional skills beyond `decision` and `decisions`.

## Version Impact

- Version: no version change because this adds source skills and tests only.
- Publish impact: no publish.

## Verification

- Base `origin/main` SHA: `a01cb56c6af3f2c0d9cc10a5d5874f80c273562c`
- Branch merge-base with `origin/main`: `a01cb56c6af3f2c0d9cc10a5d5874f80c273562c`
- Last `git fetch origin` time: `2026-07-03T05:29:20+08:00`
- Sync method: rebase; branch was already up to date with `origin/main`.
- Public diff command: `git diff --name-only origin/main..HEAD`
- Private evidence commit/path: private evidence commit `f4c16fc`.
- Reviewer evidence path: pending CEO/Sonnet review.
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28622809604
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` (package lock unchanged; `npm install` was used for worktree setup and `npm run check` passed).

## Review Evidence

- Self-review: checked skill wording against TP-M3-09 boundaries; both skills instruct CLI-only persistence and explicitly forbid direct markdown mutation.
- Reviewer subagent: pending.
- Human review: pending.
- Blocking findings: none known.

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear: CEO review, squash merge, delete branch, remove worktree.

## Residual Risk

- The skills are thin textual triggers. They do not add a decision queue/list command; when no existing decision id or candidate is available, the skill asks the user for the next item instead of scanning and mutating files.

## References

- Task: `task_01KWJBFTNH4ETY5CYX45YCSGCH`
- Evidence: local `npm run check`; focused `node --test tools/skill-contracts.test.mjs`; contract tier `npm run test:contract -- --concurrency 4`; rewrite-ci run `28622809604`.
- Review: pending CEO/Sonnet review.

---

## 摘要

新增计划内 TP-M3-09 decision skills：`decision` 与 `decisions`。

## 改动内容

- 新增 `skills/decision/SKILL.md` 与 OpenAI agent metadata，用于通过 CLI 记录单个承重 decision。
- 新增 `skills/decisions/SKILL.md` 与 OpenAI agent metadata，用于逐条对话式处理多个 decision candidate。
- 新增 contract 测试，证明仓库 skill 清单包含两个 decision skill，且它们是 CLI 薄触发器，不直接写 markdown。
- 新测试登记到 contract tier manifest。

## 任务与范围

- Harness 任务：`task_01KWJBFTNH4ETY5CYX45YCSGCH`
- 分支：`codex/tp-09-decision-skills`
- 公开范围：计划内 decision skill、OpenAI skill metadata、contract tests。
- 私有计划 / 证据是否已更新：yes，私有证据 commit `f4c16fc`。
- 范围外：新 CLI 命令、新 port、plugin packaging、daemon、GUI、或 `decision` / `decisions` 以外的新 skill。

## 版本影响

- 版本：不改版本，原因是只新增 source skill 与测试。
- 发布影响：不发布。

## 验证

- `origin/main` 基准 SHA：`a01cb56c6af3f2c0d9cc10a5d5874f80c273562c`
- 当前分支与 `origin/main` 的 merge-base：`a01cb56c6af3f2c0d9cc10a5d5874f80c273562c`
- 最近一次 `git fetch origin` 时间：`2026-07-03T05:29:20+08:00`
- 同步方式：rebase；分支已与 `origin/main` 对齐。
- 公开 diff 命令：`git diff --name-only origin/main..HEAD`
- 私有证据 commit/path：私有证据 commit `f4c16fc`。
- Reviewer 证据路径：待 CEO/Sonnet 复核。
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28622809604
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci`（lockfile 未变；worktree setup 使用 `npm install`，且 `npm run check` 已通过）。

## 审查证据

- 自查：按 TP-M3-09 边界审查 skill 文案；两个 skill 都只指向 CLI 持久化路径，并明确禁止直接修改 markdown。
- Reviewer subagent：待复核。
- 人工审查：待复核。
- 阻塞发现：暂无。

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚：CEO 复核、squash merge、删除分支、移除 worktree。

## 残余风险

- 两个 skill 是薄文本触发器，不新增 decision queue/list 命令；当没有现成 decision id 或 candidate 时，skill 会向用户询问下一项，而不是扫描并修改文件。

## 关联材料

- 任务：`task_01KWJBFTNH4ETY5CYX45YCSGCH`
- 证据：本地 `npm run check`；聚焦 `node --test tools/skill-contracts.test.mjs`；contract tier `npm run test:contract -- --concurrency 4`；rewrite-ci run `28622809604`。
- 审查：待 CEO/Sonnet 复核。
