### PR TITLE
fix: resolve relation graph fact refs by task id

### DIFF
--- a/packages/kernel/src/projection/relation-graph-projection.ts
+++ b/packages/kernel/src/projection/relation-graph-projection.ts
@@ -113,7 +113,7 @@ function collectRelationEdges(
   const seen = new Set<string>();
 
   for (const taskDir of listTaskDirs(layout.tasksRoot)) {
-    const taskId = path.basename(taskDir);
+    const taskId = readTaskPackageId(taskDir);
     const indexPath = path.join(taskDir, "INDEX.md");
     if (existsSync(indexPath)) {
       const frontmatter = readFrontmatter(readFileSync(indexPath, "utf8"));
@@ -285,7 +285,7 @@ function buildGraphRefIndex(rootInput: HarnessLayoutInput, decisions: ReadonlyAr
   const taskIds = new Set<string>();
   const factRefs = new Set<string>();
   for (const taskDir of listTaskDirs(layout.tasksRoot)) {
-    const taskId = path.basename(taskDir);
+    const taskId = readTaskPackageId(taskDir);
     taskIds.add(taskId);
     const factsPath = path.join(taskDir, "facts.md");
     if (!existsSync(factsPath)) continue;
@@ -427,6 +427,13 @@ function readFlowObjectBlock(frontmatter: string, key: string): string {
     if (/^\S/u.test(line)) break;
   }
   return output.join("\n");
+}
+
+function readTaskPackageId(taskDir: string): string {
+  const indexPath = path.join(taskDir, "INDEX.md");
+  if (!existsSync(indexPath)) return path.basename(taskDir);
+  const frontmatter = readFrontmatter(readFileSync(indexPath, "utf8"));
+  return (frontmatter ? readScalar(frontmatter, "task_id") : "") || path.basename(taskDir);
 }
 
 function listTaskDirs(tasksRoot: string): ReadonlyArray<string> {

--- a/packages/kernel/test/store/relation-graph-projection.test.ts
+++ b/packages/kernel/test/store/relation-graph-projection.test.ts
@@ -36,6 +36,40 @@ test("relation graph projection stores decision claim to live fact coverage in S
   });
 });
 
+test("relation graph projection resolves facts by task_id when task directory has a slug suffix", () => {
+  withTempStore((rootDir) => {
+    const taskId = "task-slugged";
+    const taskDirName = "task-slugged-real-title";
+    writeIndex(rootDir, taskDirName, "Task Slugged Real Title", taskId);
+    writeFacts(rootDir, taskDirName, [{
+      fact_id: "F-DEADBEEF",
+      statement: "The live fact is owned by the task_id, not the package directory slug.",
+      source: "test",
+      observedAt: "2026-07-03T00:00:00.000Z",
+      confidence: "high"
+    }]);
+    const relation = relationRecord({
+      source: "decision/dec_SLUGGED/C1",
+      target: `fact/${taskId}/F-DEADBEEF`,
+      type: "supports"
+    });
+    writeDecision(rootDir, "dec_SLUGGED", "wm-slugged", [relation]);
+
+    rebuildTaskProjection({ rootDir });
+    const graph = readRelationGraphProjection({ rootDir });
+    const coverage = readDecisionFactCoverage({ rootDir, decisionId: "dec_SLUGGED" });
+
+    assert.equal(graph.edges.some((edge) => edge.targetRef === `fact/${taskId}/F-DEADBEEF`), true);
+    assert.deepEqual(coverage.rows, [{
+      decisionRef: "decision/dec_SLUGGED",
+      claimRef: "decision/dec_SLUGGED/C1",
+      status: "covered",
+      coveringFactRef: `fact/${taskId}/F-DEADBEEF`,
+      relationPath: [relation.relation_id]
+    }]);
+  });
+});
+
 test("relation graph coverage treats invalidated facts as not live", () => {
   withTempStore((rootDir) => {
     writeIndex(rootDir, "task-invalidated", "Task Invalidated");
@@ -199,8 +233,8 @@ test("post-merge typed relation cycle detection terminates across decision and f
   });
 });
 
-function writeIndex(rootDir: string, taskId: string, title: string): void {
-  const taskRoot = path.join(rootDir, "harness/planning/tasks", taskId);
+function writeIndex(rootDir: string, taskDirName: string, title: string, taskId = taskDirName): void {
+  const taskRoot = path.join(rootDir, "harness/planning/tasks", taskDirName);
   mkdirSync(taskRoot, { recursive: true });
   writeFileSync(path.join(taskRoot, "INDEX.md"), [
     "---",


### PR DESCRIPTION
## Summary

Fix relation graph projection so fact refs are resolved by `INDEX.md` `task_id`, not the task package directory slug.

## What Changed

- Relation graph task/fact indexes now use the canonical task id from task package frontmatter.
- Added a regression test where the task package directory has a slug suffix but the relation target uses the canonical `fact/<task_id>/<F-id>` ref.

## Task And Scope

- Harness task: TP-M3-12b Self-host evidence validation follow-up
- Branch: `codex/tp-12b-relation-projection-task-id`
- Public scope: kernel relation graph projection and its store test
- Private planning/evidence updated: yes, in the private harness ledger only; no private files are part of this PR
- Out of scope: TP-12b private self-host data completion, relation schema changes, layout contract changes, and legacy compatibility

## Version Impact

- Version: no version change because this is a pre-release projection correctness fix
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: `8e7a06cb3c3f1a9d94c0a96bc71648d6251a8f92`
- Branch merge-base with `origin/main`: `8e7a06cb3c3f1a9d94c0a96bc71648d6251a8f92`
- Last `git fetch origin` time: before branch creation for this PR
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: private harness TP-12b task ledger records the dogfood failure that exposed this projection gap
- Reviewer evidence path: pending CEO/Sonnet review
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28624472769
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` was not run; this worktree used `npm install` to materialize missing workspace dependencies before the full `npm run check` gate.

## Review Evidence

- Self-review: verified the projection now uses canonical task ids from task frontmatter and preserves directory fallback for malformed or non-package directories.
- Reviewer subagent: pending.
- Human review: pending.
- Blocking findings: none known.

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear: CEO will review and merge; after merge, delete remote branch and remove the worktree.

## Residual Risk

- Low. The change is restricted to relation projection task identity resolution and covered by a slugged task package regression test plus the full local check gate.

## References

- Task: TP-M3-12b Self-host evidence validation
- Evidence: `packages/kernel/test/store/relation-graph-projection.test.ts`
- Review: pending

---

## 摘要

修复 relation graph projection：fact ref 解析使用 `INDEX.md` 的 canonical `task_id`，不再误用带 slug 的任务包目录名。

## 改动内容

- relation graph 的 task/fact index 改为从任务 frontmatter 读取 canonical task id。
- 新增回归测试：任务目录带 slug 后缀，但 relation target 使用 `fact/<task_id>/<F-id>` 时 coverage 必须 covered。

## 任务与范围

- Harness 任务：TP-M3-12b Self-host evidence validation follow-up
- 分支：`codex/tp-12b-relation-projection-task-id`
- 公开范围：kernel relation graph projection 与对应 store test
- 私有计划 / 证据是否已更新：yes，仅在私有 harness ledger；本 PR 不包含私有文件
- 范围外：TP-12b 私有 self-host 数据收尾、relation schema 变更、layout 契约变更、旧格式兼容

## 版本影响

- 版本：不改版本，原因是预发布 projection correctness fix
- 发布影响：不发布

## 验证

- `origin/main` 基准 SHA：`8e7a06cb3c3f1a9d94c0a96bc71648d6251a8f92`
- 当前分支与 `origin/main` 的 merge-base：`8e7a06cb3c3f1a9d94c0a96bc71648d6251a8f92`
- 最近一次 `git fetch origin` 时间：创建本 PR 分支前
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：私有 harness TP-12b task ledger 记录了 dogfood 暴露的 projection 缺口
- Reviewer 证据路径：待 CEO/Sonnet review
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28624472769
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci` 未运行；本 worktree 用 `npm install` 补齐缺失 workspace 依赖后执行完整 `npm run check`。

## 审查证据

- 自查：确认 projection 改为 frontmatter canonical task id，并保留目录名 fallback。
- Reviewer subagent：待执行。
- 人工审查：待执行。
- 阻塞发现：当前无。

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚：CEO review 后合并；合并后删除远端分支并移除 worktree。

## 残余风险

- 低。改动局限在 relation projection 的 task identity 解析，并有 slugged task package 回归测试和完整本地 check 覆盖。

## 关联材料

- 任务：TP-M3-12b Self-host evidence validation
- 证据：`packages/kernel/test/store/relation-graph-projection.test.ts`
- 审查：待执行
