### PR TITLE
test: hard fail task document placeholders

### DIFF
--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -190,9 +190,9 @@ function validateDoneTaskDocumentPlaceholders(rootInput: HarnessLayoutInput): Re
       issues.push(profileIssue(
         "completion-consistency",
         "closeout_placeholder",
-        "warning",
+        "hard-fail",
         `${relativeTaskDir}/closeout.md still contains template placeholder text.`,
-        "Replace closeout.md placeholders with Summary, Verification, and Residual Risk evidence; this warning is intended to become a hard-fail after existing packages are backfilled."
+        "Replace closeout.md placeholders with Summary, Verification, and Residual Risk evidence before treating the task as done."
       ));
     }
 
@@ -201,9 +201,9 @@ function validateDoneTaskDocumentPlaceholders(rootInput: HarnessLayoutInput): Re
       issues.push(profileIssue(
         "completion-consistency",
         "review_placeholder",
-        "warning",
+        "hard-fail",
         `${relativeTaskDir}/review.md is still the initial not-started review with no findings.`,
-        "Record the actual review result before treating the task as complete; this warning is intended to become a hard-fail after existing packages are backfilled."
+        "Record the actual review result before treating the task as done."
       ));
     }
   }

--- a/packages/cli/test/post-merge-check-cli.test.ts
+++ b/packages/cli/test/post-merge-check-cli.test.ts
@@ -83,7 +83,7 @@ test("CLI check --post-merge visibly fails hand-written decision watermarks", ()
   });
 });
 
-test("CLI check --post-merge reports done task document placeholders as visible warnings", () => {
+test("CLI check --post-merge reports done task document placeholders as hard-fails", () => {
   withTempRoot((rootDir) => {
     writeIndex(rootDir, "task-a", "A", "done");
     writeFileSync(path.join(rootDir, "harness/tasks/task-a/closeout.md"), [
@@ -119,19 +119,21 @@ test("CLI check --post-merge reports done task document placeholders as visible 
       ""
     ].join("\n"), "utf8");
 
-    const result = runJson(rootDir, ["check", "--post-merge"]);
+    const result = runJson(rootDir, ["check", "--post-merge"], false);
 
-    assert.equal(result.ok, true);
+    assert.equal(result.ok, false);
+    assert.equal(result.error?.code, "check_profile_failed");
     const closeout = result.warnings.find((warning: any) => warning.code === "closeout_placeholder");
     const review = result.warnings.find((warning: any) => warning.code === "review_placeholder");
     assert.ok(closeout);
-    assert.equal(closeout.severity, "warning");
+    assert.equal(closeout.severity, "hard-fail");
     assert.match(closeout.message, /harness\/tasks\/task-a\/closeout\.md/);
-    assert.match(closeout.repairHint, /hard-fail/);
+    assert.match(closeout.repairHint, /Summary, Verification, and Residual Risk evidence/);
     assert.ok(review);
-    assert.equal(review.severity, "warning");
+    assert.equal(review.severity, "hard-fail");
     assert.match(review.message, /harness\/tasks\/task-a\/review\.md/);
-    assert.match(review.repairHint, /hard-fail/);
+    assert.match(review.repairHint, /actual review result/);
+    assert.equal(result.warnings.filter((warning: any) => warning.severity === "hard-fail").length >= 2, true);
   });
 });
 


### PR DESCRIPTION
## Summary

Promote the done-task document placeholder checks introduced in #119 from visible warnings to hard-fails after the private backfill cleared existing debt.

## What Changed

- `check --post-merge` now reports `closeout_placeholder` as `hard-fail` for done tasks that still contain bundled closeout template fingerprints.
- `check --post-merge` now reports `review_placeholder` as `hard-fail` for done tasks whose review is still the initial not-started review with no findings.
- Updated the post-merge CLI test to assert a failing receipt, `check_profile_failed`, and hard-fail severities.

## Task And Scope

- Harness task: M3 final task document gate hardening, following #119 and private backfill commit `37c4bf6`.
- Branch: `codex/task-doc-gates-strict`
- Public scope: CLI check severity and test expectation only.
- Private planning/evidence updated: yes, parent M3 progress ledger records the private backfill.
- Out of scope: template wording, task-complete gate behavior, historical task package prose, and unrelated lifecycle semantics.

## Version Impact

- Version: no version change because this is a pre-release governance gate hardening.
- Publish impact: no publish.

## Verification

- Base `origin/main` SHA: `6b9c10b`
- Branch merge-base with `origin/main`: `6b9c10b`
- Last `git fetch origin` time: `2026-07-02T23:50:44Z`
- Sync method: rebase, branch already up to date.
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: `37c4bf6` backfilled closeout/review evidence; parent M3 progress ledger updated.
- Reviewer evidence path: pending CEO/Sonnet review.
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28628944771.
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` not run; this worktree used `npm install` to materialize missing GUI dev dependencies, then `npm run check` ran the full local gate.

## Review Evidence

- Self-review: confirmed diff is limited to `packages/cli/src/commands/check.ts` and `packages/cli/test/post-merge-check-cli.test.ts`; no private files included.
- Reviewer subagent: not run; this is a narrow severity promotion after #119 review.
- Human review: pending.
- Blocking findings: none known.

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear: CEO review, squash merge, then delete remote branch and remove worktree.

## Residual Risk

- This makes future done-task placeholder debt fail hard. Existing private task debt was cleared first and verified with `npx ha check --post-merge --json` returning 0 placeholder issues.

## References

- Task: M3 final closeout / task document gate hardening.
- Evidence: #119 staged the warning gate; private backfill commit `37c4bf6`; local `npm run check` passed.
- Review: pending.

---

## 摘要

在私有存量任务文档回填清零后，把 #119 引入的 done 任务 closeout/review 占位检查从 warning 升为 hard-fail。

## 改动内容

- `check --post-merge` 对 done 任务中仍含 closeout 模板指纹的 `closeout_placeholder` 报 `hard-fail`。
- `check --post-merge` 对 done 任务中仍是初始 not-started 空 findings 的 `review_placeholder` 报 `hard-fail`。
- 更新 post-merge CLI 测试，断言失败 receipt、`check_profile_failed` 和 hard-fail severity。

## 任务与范围

- Harness 任务：M3 最终任务文档 gate 加固，接 #119 与私有回填提交 `37c4bf6`。
- 分支：`codex/task-doc-gates-strict`
- 公开范围：CLI check severity 与对应测试预期。
- 私有计划 / 证据是否已更新：yes，M3 父任务 progress 已记录私有回填。
- 范围外：模板文案、task-complete gate 行为、历史任务包正文、无关 lifecycle 语义。

## 版本影响

- 版本：不改版本，原因是预发布治理 gate 加固。
- 发布影响：不发布。

## 验证

- `origin/main` 基准 SHA：`6b9c10b`
- 当前分支与 `origin/main` 的 merge-base：`6b9c10b`
- 最近一次 `git fetch origin` 时间：`2026-07-02T23:50:44Z`
- 同步方式：rebase，分支已是最新。
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：`37c4bf6` 回填 closeout/review 证据；M3 父任务 progress 已更新。
- Reviewer 证据路径：待 CEO/Sonnet 复核。
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28628944771。
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci` 未运行；本 worktree 用 `npm install` 补齐缺失 GUI dev dependency 后跑完整 `npm run check`。

## 审查证据

- 自查：diff 只包含 `packages/cli/src/commands/check.ts` 与 `packages/cli/test/post-merge-check-cli.test.ts`，无私有文件。
- Reviewer subagent：未运行；本 PR 是 #119 复核后预告的窄范围 severity 升级。
- 人工审查：待复核。
- 阻塞发现：当前无。

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚：CEO 复核后 squash merge，随后删除远端分支并移除 worktree。

## 残余风险

- 未来 done 任务文档占位会 hard-fail；现有私有任务债已先回填，并用 `npx ha check --post-merge --json` 验证 0 placeholder issue。

## 关联材料

- 任务：M3 final closeout / task document gate hardening。
- 证据：#119 先落 warning gate；私有回填 commit `37c4bf6`；本地 `npm run check` passed。
- 审查：待复核。

