### PR TITLE
fix: enforce relation post-merge invariants

### DIFF
--- a/packages/kernel/schemas/json/harness-check-report.schema.json
+++ b/packages/kernel/schemas/json/harness-check-report.schema.json
@@ -34,6 +34,12 @@
                 "binding_tampered",
                 "conflict_marker_present",
                 "dangling_entity_ref",
+                "invalid_relation_endpoint",
+                "relation_host_source_mismatch",
+                "relation_provenance_inheritance_mismatch",
+                "relation_id_mismatch",
+                "duplicate_relation_id",
+                "relation_rationale_missing",
                 "relation_cycle_detected"
               ]
             }

--- a/packages/kernel/src/projection/post-merge-checks.ts
+++ b/packages/kernel/src/projection/post-merge-checks.ts
@@ -6,7 +6,7 @@ import { stablePayloadHash } from "../integrity/stable-hash.ts";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import { readFrontmatter, readScalar } from "../markdown/frontmatter.ts";
-import { buildRelationGraphProjection, detectRelationGraphCycles } from "./relation-graph-projection.ts";
+import { buildRelationGraphProjection, detectRelationGraphCycles, validateRelationGraphRecords } from "./relation-graph-projection.ts";
 import type { ProjectionCheckAxisReport, ProjectionCheckReport, ProjectionWarning, ProjectionWarningCode, ProjectionWarningSource } from "./types.ts";
 import { readMarkdownSource, sourcePath, type TaskSourceEntry } from "./sqlite-task-source.ts";
 
@@ -21,6 +21,7 @@ export function runPostMergeChecks(rootInput: HarnessLayoutInput): ReadonlyArray
   warnings.push(...findConflictMarkerWarnings(rootInput));
   warnings.push(...findDecisionWatermarkIssues(rootInput));
   warnings.push(...findDanglingEntityRefs(rootInput, source.entries));
+  warnings.push(...findRelationRecordIssues(rootInput));
   warnings.push(...findRelationCycles(rootInput));
   return warnings;
 }
@@ -277,6 +278,31 @@ function findRelationCycles(rootInput: HarnessLayoutInput): ReadonlyArray<Projec
     `Entity relation cycle detected: ${cycle.join(" -> ")}.`,
     "Break the cyclic typed relation records before merging authored planning docs."
   )];
+}
+
+function findRelationRecordIssues(rootInput: HarnessLayoutInput): ReadonlyArray<ProjectionWarning> {
+  return validateRelationGraphRecords(rootInput).map(({ entry, issue }) => hardFail(
+    "source-package",
+    issue.code,
+    `${issue.message} (${entry.sourcePath}:${entry.recordIndex + 1}).`,
+    relationRepairHint(issue.code)
+  ));
+}
+
+function relationRepairHint(code: ProjectionWarningCode): string {
+  if (code === "relation_host_source_mismatch" || code === "relation_provenance_inheritance_mismatch") {
+    return "Move the relation record into the metadata for its source entity so provenance is inherited from the correct host.";
+  }
+  if (code === "relation_id_mismatch") {
+    return "Recompute relation_id from source, target, type, and direction; relation_id is deterministic and must not be hand-assigned.";
+  }
+  if (code === "duplicate_relation_id") {
+    return "Keep one byte-identical duplicate relation record, or manually arbitrate divergent attributes for the same canonical edge before merging.";
+  }
+  if (code === "relation_rationale_missing") {
+    return "Add a non-blank rationale for strong or gate-bearing relation records.";
+  }
+  return "Restore a valid typed relation endpoint before rebuilding the relation graph projection.";
 }
 
 export function buildCheckReport(

--- a/packages/kernel/src/projection/relation-graph-projection.ts
+++ b/packages/kernel/src/projection/relation-graph-projection.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
-import { parseFactFlowRecords, parseEntityRef, validateRelationRecordsForHost } from "../domain/index.ts";
-import type { EntityRelationRecord } from "../domain/index.ts";
+import { formatRelationFlowRecord, parseFactFlowRecords, parseEntityRef, validateRelationRecordsForHost } from "../domain/index.ts";
+import type { EntityRelationRecord, EntityRelationValidationIssue } from "../domain/index.ts";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import { readFrontmatter, readScalar } from "../markdown/frontmatter.ts";
@@ -50,14 +50,36 @@ interface GraphRefIndex {
   readonly factRefs: ReadonlySet<string>;
 }
 
+export interface RelationRecordEntry {
+  readonly hostRef: string;
+  readonly ownerRef: string;
+  readonly record: EntityRelationRecord;
+  readonly sourcePath: string;
+  readonly recordIndex: number;
+}
+
+export interface RelationRecordValidationIssue {
+  readonly entry: RelationRecordEntry;
+  readonly issue: EntityRelationValidationIssue | {
+    readonly code: "relation_provenance_inheritance_mismatch";
+    readonly relationId?: string;
+    readonly message: string;
+  };
+}
+
 export function buildRelationGraphProjection(rootInput: HarnessLayoutInput): RelationGraphProjection {
   const decisions = readDecisionSources(rootInput);
   const refIndex = buildGraphRefIndex(rootInput, decisions);
-  const edges = collectRelationEdges(rootInput, decisions, refIndex);
+  const entries = collectRelationRecordEntries(rootInput, decisions);
+  const edges = relationEntriesToEdges(entries, refIndex);
   return {
     edges,
     coverageRows: buildCoverageRows(decisions.filter((decision) => decision.visible), edges, refIndex)
   };
+}
+
+export function validateRelationGraphRecords(rootInput: HarnessLayoutInput): ReadonlyArray<RelationRecordValidationIssue> {
+  return validateRelationRecordEntries(collectRelationRecordEntries(rootInput, readDecisionSources(rootInput)));
 }
 
 export function detectRelationGraphCycles(edges: ReadonlyArray<RelationGraphEdgeRow>): ReadonlyArray<ReadonlyArray<string>> {
@@ -102,15 +124,13 @@ export function detectRelationGraphCycles(edges: ReadonlyArray<RelationGraphEdge
   return cycles;
 }
 
-function collectRelationEdges(
+function collectRelationRecordEntries(
   rootInput: HarnessLayoutInput,
-  decisions: ReadonlyArray<DecisionSource>,
-  refIndex: GraphRefIndex
-): ReadonlyArray<RelationGraphEdgeRow> {
+  decisions: ReadonlyArray<DecisionSource>
+): ReadonlyArray<RelationRecordEntry> {
   const layout = resolveHarnessLayout(rootInput);
   const rootDir = layout.rootDir;
-  const edges: RelationGraphEdgeRow[] = [];
-  const seen = new Set<string>();
+  const entries: RelationRecordEntry[] = [];
 
   for (const taskDir of listTaskDirs(layout.tasksRoot)) {
     const taskId = readTaskPackageId(taskDir);
@@ -118,14 +138,12 @@ function collectRelationEdges(
     if (existsSync(indexPath)) {
       const frontmatter = readFrontmatter(readFileSync(indexPath, "utf8"));
       if (frontmatter) {
-        edges.push(...recordsToEdges({
+        entries.push(...recordsToEntries({
           hostRef: `task/${taskId}`,
           ownerRef: `task/${taskId}`,
           records: parseRelationFlowRecords(frontmatter),
           sourceFile: indexPath,
-          rootDir,
-          refIndex,
-          seen
+          rootDir
         }));
       }
     }
@@ -133,65 +151,131 @@ function collectRelationEdges(
     const factsPath = path.join(taskDir, layout.factDocumentName);
     if (existsSync(factsPath)) {
       const factsBody = readFileSync(factsPath, "utf8");
-      edges.push(...recordsToEdges({
+      entries.push(...recordsToEntries({
+        hostRefForRecord: (record) => factRelationHostRef(taskId, record),
         ownerRef: `task/${taskId}`,
         records: parseRelationFlowRecords(factsBody),
         sourceFile: factsPath,
-        rootDir,
-        refIndex,
-        seen
+        rootDir
       }));
     }
   }
 
   for (const decision of decisions) {
     if (!decision.visible) continue;
-    edges.push(...recordsToEdges({
+    entries.push(...recordsToEntries({
       hostRef: decision.decisionRef,
       ownerRef: decision.decisionRef,
       records: parseRelationFlowRecords(decision.frontmatter),
       sourceFile: decision.filePath,
-      rootDir,
-      refIndex,
-      seen
+      rootDir
     }));
   }
 
-  return edges.sort(compareEdges);
+  return entries.sort(compareRelationRecordEntries);
 }
 
-function recordsToEdges(input: {
+function recordsToEntries(input: {
   readonly hostRef?: string;
+  readonly hostRefForRecord?: (record: EntityRelationRecord) => string;
   readonly ownerRef: string;
   readonly records: ReadonlyArray<EntityRelationRecord>;
   readonly sourceFile: string;
   readonly rootDir: string;
-  readonly refIndex: GraphRefIndex;
-  readonly seen: Set<string>;
-}): ReadonlyArray<RelationGraphEdgeRow> {
-  const edges: RelationGraphEdgeRow[] = [];
+}): ReadonlyArray<RelationRecordEntry> {
+  const entries: RelationRecordEntry[] = [];
   for (const [index, record] of input.records.entries()) {
-    const hostRef = input.hostRef ?? record.source;
-    if (validateRelationRecordsForHost(hostRef, [record]).length > 0) continue;
-    if (!isKnownLocalEndpoint(record.source, input.refIndex) || !isKnownLocalEndpoint(record.target, input.refIndex)) continue;
-    if (input.seen.has(record.relation_id)) continue;
-    input.seen.add(record.relation_id);
-    edges.push({
-      relationId: record.relation_id,
-      sourceRef: record.source,
-      targetRef: record.target,
-      relationType: record.type,
-      direction: record.direction,
-      strength: record.strength,
-      origin: record.origin,
-      state: record.state,
-      rationale: record.rationale,
+    entries.push({
+      hostRef: input.hostRefForRecord?.(record) ?? input.hostRef ?? input.ownerRef,
       ownerRef: input.ownerRef,
       sourcePath: sourcePath(input.rootDir, input.sourceFile),
+      record,
       recordIndex: index
     });
   }
-  return edges;
+  return entries;
+}
+
+function factRelationHostRef(taskId: string, record: EntityRelationRecord): string {
+  const source = parseEntityRef(record.source);
+  if (source?.kind === "fact") return `fact/${taskId}/${source.id}`;
+  return `task/${taskId}`;
+}
+
+function relationEntriesToEdges(
+  entries: ReadonlyArray<RelationRecordEntry>,
+  refIndex: GraphRefIndex
+): ReadonlyArray<RelationGraphEdgeRow> {
+  const edges: RelationGraphEdgeRow[] = [];
+  const seen = new Map<string, string>();
+  for (const entry of entries) {
+    if (validateRelationRecordsForHost(entry.hostRef, [entry.record]).length > 0) continue;
+    if (!isKnownLocalEndpoint(entry.record.source, refIndex) || !isKnownLocalEndpoint(entry.record.target, refIndex)) continue;
+
+    const canonicalRecord = canonicalRelationRecord(entry.record);
+    const previous = seen.get(entry.record.relation_id);
+    if (previous) {
+      if (previous === canonicalRecord) continue;
+      continue;
+    }
+    seen.set(entry.record.relation_id, canonicalRecord);
+    edges.push({
+      relationId: entry.record.relation_id,
+      sourceRef: entry.record.source,
+      targetRef: entry.record.target,
+      relationType: entry.record.type,
+      direction: entry.record.direction,
+      strength: entry.record.strength,
+      origin: entry.record.origin,
+      state: entry.record.state,
+      rationale: entry.record.rationale,
+      ownerRef: entry.ownerRef,
+      sourcePath: entry.sourcePath,
+      recordIndex: entry.recordIndex
+    });
+  }
+  return edges.sort(compareEdges);
+}
+
+function validateRelationRecordEntries(entries: ReadonlyArray<RelationRecordEntry>): ReadonlyArray<RelationRecordValidationIssue> {
+  const issues: RelationRecordValidationIssue[] = [];
+  const seen = new Map<string, { readonly canonicalRecord: string; readonly entry: RelationRecordEntry }>();
+  for (const entry of entries) {
+    for (const issue of validateRelationRecordsForHost(entry.hostRef, [entry.record])) {
+      issues.push({ entry, issue });
+      if (issue.code === "relation_host_source_mismatch") {
+        issues.push({
+          entry,
+          issue: {
+            code: "relation_provenance_inheritance_mismatch",
+            relationId: entry.record.relation_id,
+            message: `Relation ${entry.record.relation_id} cannot inherit provenance from ${entry.hostRef} because its source is ${entry.record.source}`
+          }
+        });
+      }
+    }
+
+    const canonicalRecord = canonicalRelationRecord(entry.record);
+    const previous = seen.get(entry.record.relation_id);
+    if (!previous) {
+      seen.set(entry.record.relation_id, { canonicalRecord, entry });
+      continue;
+    }
+    if (previous.canonicalRecord === canonicalRecord) continue;
+    issues.push({
+      entry,
+      issue: {
+        code: "duplicate_relation_id",
+        relationId: entry.record.relation_id,
+        message: `Duplicate relation_id ${entry.record.relation_id} in ${previous.entry.sourcePath} and ${entry.sourcePath}`
+      }
+    });
+  }
+  return issues;
+}
+
+function canonicalRelationRecord(record: EntityRelationRecord): string {
+  return formatRelationFlowRecord(record);
 }
 
 function buildCoverageRows(
@@ -461,6 +545,10 @@ function isRelationGraphTextLikePath(filePath: string): boolean {
 
 function compareEdges(a: RelationGraphEdgeRow, b: RelationGraphEdgeRow): number {
   return `${a.sourceRef}\0${a.targetRef}\0${a.relationId}`.localeCompare(`${b.sourceRef}\0${b.targetRef}\0${b.relationId}`);
+}
+
+function compareRelationRecordEntries(a: RelationRecordEntry, b: RelationRecordEntry): number {
+  return `${a.sourcePath}\0${a.recordIndex}`.localeCompare(`${b.sourcePath}\0${b.recordIndex}`);
 }
 
 function isRelationType(value: string): value is EntityRelationRecord["type"] {

--- a/packages/kernel/src/projection/types.ts
+++ b/packages/kernel/src/projection/types.ts
@@ -20,6 +20,12 @@ export type ProjectionWarningCode =
   | "decision_watermark_missing"
   | "decision_watermark_duplicate"
   | "dangling_entity_ref"
+  | "invalid_relation_endpoint"
+  | "relation_host_source_mismatch"
+  | "relation_provenance_inheritance_mismatch"
+  | "relation_id_mismatch"
+  | "duplicate_relation_id"
+  | "relation_rationale_missing"
   | "relation_cycle_detected";
 
 export interface TaskCreatedBy {

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -391,6 +391,12 @@ export const ProjectionWarningCodeSchema = Schema.Literal(
   "decision_watermark_missing",
   "decision_watermark_duplicate",
   "dangling_entity_ref",
+  "invalid_relation_endpoint",
+  "relation_host_source_mismatch",
+  "relation_provenance_inheritance_mismatch",
+  "relation_id_mismatch",
+  "duplicate_relation_id",
+  "relation_rationale_missing",
   "relation_cycle_detected"
 );
 

--- a/packages/kernel/test/store/relation-graph-projection.test.ts
+++ b/packages/kernel/test/store/relation-graph-projection.test.ts
@@ -233,6 +233,115 @@ test("post-merge typed relation cycle detection terminates across decision and f
   });
 });
 
+test("post-merge relation validation rejects facts.md host drift and provenance inheritance mismatch", () => {
+  withTempStore((rootDir) => {
+    writeIndex(rootDir, "task-owner", "Task Owner");
+    writeFacts(rootDir, "task-owner", [{
+      fact_id: "F-DEADBEEF",
+      statement: "The owner fact is local to task-owner.",
+      source: "test",
+      observedAt: "2026-07-03T00:00:00.000Z",
+      confidence: "high"
+    }], [
+      relationRecord({
+        source: "fact/task-other/F-DEADBEEF",
+        target: "task/task-owner",
+        type: "relates"
+      })
+    ]);
+    writeIndex(rootDir, "task-other", "Task Other");
+    writeFacts(rootDir, "task-other", [{
+      fact_id: "F-DEADBEEF",
+      statement: "The source fact belongs to a different task.",
+      source: "test",
+      observedAt: "2026-07-03T00:00:00.000Z",
+      confidence: "high"
+    }]);
+
+    const result = checkTaskProjection({ rootDir, postMerge: true });
+    const codes = result.warnings.map((warning) => warning.code);
+
+    assert.equal(result.ok, false);
+    assert.equal(codes.includes("relation_host_source_mismatch"), true);
+    assert.equal(codes.includes("relation_provenance_inheritance_mismatch"), true);
+  });
+});
+
+test("post-merge relation validation rejects relation_id mismatches", () => {
+  withTempStore((rootDir) => {
+    writeIndex(rootDir, "task-bad-id", "Task Bad Id");
+    writeFacts(rootDir, "task-bad-id", [{
+      fact_id: "F-DEADBEEF",
+      statement: "The fact supports a decision with a bad relation id.",
+      source: "test",
+      observedAt: "2026-07-03T00:00:00.000Z",
+      confidence: "high"
+    }]);
+    writeDecisionRelationLines(rootDir, "dec_BAD_ID", "wm-bad-id", [
+      "- {relation_id: rel_0000000000000000, source: decision/dec_BAD_ID/C1, target: fact/task-bad-id/F-DEADBEEF, type: supports, strength: strong, direction: directed, origin: declared, rationale: \"Fixture relation\", state: active}"
+    ]);
+
+    const result = checkTaskProjection({ rootDir, postMerge: true });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.warnings.some((warning) => warning.code === "relation_id_mismatch"), true);
+  });
+});
+
+test("post-merge relation validation rejects divergent duplicate relation_id records", () => {
+  withTempStore((rootDir) => {
+    writeIndex(rootDir, "task-duplicate-relation", "Task Duplicate Relation");
+    writeFacts(rootDir, "task-duplicate-relation", [{
+      fact_id: "F-DEADBEEF",
+      statement: "The fact is targeted by divergent duplicate relation records.",
+      source: "test",
+      observedAt: "2026-07-03T00:00:00.000Z",
+      confidence: "high"
+    }]);
+    const relation = relationRecord({
+      source: "decision/dec_DUP_REL/C1",
+      target: "fact/task-duplicate-relation/F-DEADBEEF",
+      type: "supports"
+    });
+    writeDecision(rootDir, "dec_DUP_REL", "wm-dup-rel", [
+      relation,
+      { ...relation, strength: "weak", rationale: "Divergent attributes for the same canonical edge." }
+    ]);
+
+    const result = checkTaskProjection({ rootDir, postMerge: true });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.warnings.some((warning) => warning.code === "duplicate_relation_id"), true);
+  });
+});
+
+test("post-merge relation validation allows byte-identical duplicate records to converge", () => {
+  withTempStore((rootDir) => {
+    writeIndex(rootDir, "task-identical-relation", "Task Identical Relation");
+    writeFacts(rootDir, "task-identical-relation", [{
+      fact_id: "F-DEADBEEF",
+      statement: "The fact is targeted by identical duplicate relation records.",
+      source: "test",
+      observedAt: "2026-07-03T00:00:00.000Z",
+      confidence: "high"
+    }]);
+    const relation = relationRecord({
+      source: "decision/dec_IDENTICAL_REL/C1",
+      target: "fact/task-identical-relation/F-DEADBEEF",
+      type: "supports"
+    });
+    writeDecision(rootDir, "dec_IDENTICAL_REL", "wm-identical-rel", [relation, relation]);
+
+    const result = checkTaskProjection({ rootDir, postMerge: true });
+    rebuildTaskProjection({ rootDir });
+    const graph = readRelationGraphProjection({ rootDir });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.warnings.some((warning) => warning.code === "duplicate_relation_id"), false);
+    assert.equal(graph.edges.filter((edge) => edge.relationId === relation.relation_id).length, 1);
+  });
+});
+
 function writeIndex(rootDir: string, taskDirName: string, title: string, taskId = taskDirName): void {
   const taskRoot = path.join(rootDir, "harness/tasks", taskDirName);
   mkdirSync(taskRoot, { recursive: true });
@@ -249,7 +358,7 @@ function writeIndex(rootDir: string, taskDirName: string, title: string, taskId 
     `  titleSnapshot: ${title}`,
     "  url: ",
     "  bindingCreatedAt: 2026-07-03T00:00:00.000Z",
-    "  bindingFingerprint: sha256:fixture",
+    "  bindingFingerprint: ",
     "packageDisposition: active",
     "vertical: default",
     "preset: default",
@@ -282,6 +391,10 @@ function writeFacts(rootDir: string, taskId: string, facts: ReadonlyArray<FactFi
 }
 
 function writeDecision(rootDir: string, decisionId: string, watermark: string, relations: ReadonlyArray<EntityRelationRecord>): void {
+  writeDecisionRelationLines(rootDir, decisionId, watermark, relations.map(formatRelationFlowRecord));
+}
+
+function writeDecisionRelationLines(rootDir: string, decisionId: string, watermark: string, relationLines: ReadonlyArray<string>): void {
   const decisionRoot = path.join(rootDir, "harness/decisions", `decision-${decisionId}`);
   mkdirSync(decisionRoot, { recursive: true });
   writeFileSync(path.join(decisionRoot, "decision.md"), [
@@ -311,7 +424,7 @@ function writeDecision(rootDir: string, decisionId: string, watermark: string, r
     "claims:",
     "  - { id: \"C1\", statement: \"Fixture claim\", required: true }",
     "relations:",
-    ...relations.map(formatRelationFlowRecord),
+    ...relationLines,
     "---",
     "",
     `# ${decisionId}`,


### PR DESCRIPTION
## Summary

Enforces M3 relation post-merge invariants as hard-fail projection warnings.

## What Changed

- Added relation warning codes for host/source mismatch, relation id mismatch, duplicate relation ids, and provenance inheritance violations.
- Wired relation validation into post-merge checks and projection ingestion.
- Changed duplicate handling so byte-identical relation records converge while divergent records hard-fail.
- Fixed facts.md relation host propagation so fact edge host/source validation is meaningful.
- Added coverage for host/source mismatch, divergent duplicate relation ids, identical duplicate convergence, and provenance inheritance violations.

## Task And Scope

- Harness task: `task_01KWJV5V1T2W79P0TS1FQY7M3E`
- Branch: `codex/m3-rmd-r1`
- Public scope: kernel relation projection, post-merge checks, schema warning codes, relation projection tests
- Private planning/evidence updated: yes
- Out of scope: schema redesign, migration/backfill, npm release

## Version Impact

- Version: no version change because this is pre-release remediation.
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: `fe36e206ebebd0b7fa883f87d09c6d4a336c50f1`
- Branch merge-base with `origin/main`: `fe36e206ebebd0b7fa883f87d09c6d4a336c50f1`
- Last `git fetch origin` time: `2026-07-03T02:40:45Z`
- Sync method: none needed
- Public diff command: `git diff --stat origin/main..HEAD`
- Private evidence commit/path: private harness task `task_01KWJV5V1T2W79P0TS1FQY7M3E`
- Reviewer evidence path: subagent Pascal findings plus Commander verification
- GitHub Actions `rewrite-ci` run URL: pending; see Checks tab
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` (local workspace already installed; `npm run check` and package smoke exercised the gate). `npm run check` initially reached an npm audit TLS disconnect, then `npm run harness:check-supply-chain && npm run harness:smoke-legacy-intake && npm run harness:smoke-cli-package` passed on retry.

## Review Evidence

- Self-review: verified relation hard-fail semantics, duplicate convergence behavior, and fact host propagation against R1 acceptance criteria.
- Reviewer subagent: Pascal
- Human review: pending CEO review
- Blocking findings: none open

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear.

## Residual Risk

- CI `rewrite-ci` is pending at PR creation.
- Merge method: squash or normal merge per repository policy; after merge delete remote branch `codex/m3-rmd-r1` and remove the local worktree.

## References

- Task: `task_01KWJV5V1T2W79P0TS1FQY7M3E`
- Evidence: local `npm run check`, `git diff --check`, focused relation projection tests
- Review: Pascal subagent + Commander self-review

---

## 摘要

将 M3 relation post-merge 不变量接成 hard-fail projection warning。

## 改动内容

- 新增 host/source mismatch、relation id mismatch、duplicate relation id、provenance inheritance violation 等 relation warning code。
- 将 relation validation 接入 post-merge checks 与 projection ingestion。
- 重复 relation 处理改为：字节一致自动收敛，属性分歧 hard-fail。
- 修正 facts.md relation host 传递，让 fact 边 host/source 校验真实生效。
- 补充 host/source mismatch、重复 relation_id 分歧、完全一致重复收敛、provenance 继承违例测试。

## 任务与范围

- Harness 任务：`task_01KWJV5V1T2W79P0TS1FQY7M3E`
- 分支：`codex/m3-rmd-r1`
- 公开范围：kernel relation projection、post-merge checks、schema warning code、relation projection 测试
- 私有计划 / 证据是否已更新：yes
- 范围外：schema 重新设计、迁移/回填、npm 发布

## 版本影响

- 版本：不改版本，原因是 pre-release remediation。
- 发布影响：不发布

## 验证

- `origin/main` 基准 SHA：`fe36e206ebebd0b7fa883f87d09c6d4a336c50f1`
- 当前分支与 `origin/main` 的 merge-base：`fe36e206ebebd0b7fa883f87d09c6d4a336c50f1`
- 最近一次 `git fetch origin` 时间：`2026-07-03T02:40:45Z`
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main..HEAD`
- 私有证据 commit/path：private harness task `task_01KWJV5V1T2W79P0TS1FQY7M3E`
- Reviewer 证据路径：subagent Pascal findings plus Commander verification
- GitHub Actions `rewrite-ci` run URL：pending; see Checks tab
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci`（本地 workspace 已安装；`npm run check` 和 package smoke 已覆盖 gate）。`npm run check` 初次到 npm audit TLS 断连，随后 `npm run harness:check-supply-chain && npm run harness:smoke-legacy-intake && npm run harness:smoke-cli-package` 重跑通过。

## 审查证据

- 自查：按 R1 验收核对 relation hard-fail、重复收敛语义与 fact host 传递。
- Reviewer subagent：Pascal
- 人工审查：等待 CEO 复核
- 阻塞发现：无

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚。

## 残余风险

- PR 创建时 CI `rewrite-ci` 尚未完成。
- 合并方式：按仓库策略 squash 或 normal merge；合并后删除远端分支 `codex/m3-rmd-r1` 并移除本地 worktree。

## 关联材料

- 任务：`task_01KWJV5V1T2W79P0TS1FQY7M3E`
- 证据：本地 `npm run check`、`git diff --check`、focused relation projection tests
- 审查：Pascal subagent + Commander self-review
