### PR TITLE
fix: render runtime session jsonl exports

### DIFF
--- a/packages/application/src/provenance-session-exporter.ts
+++ b/packages/application/src/provenance-session-exporter.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import type { CurrentSessionProbePort, CurrentSessionRef, CurrentSessionRuntime, CurrentSessionSource } from "../../kernel/src/index.ts";
@@ -8,6 +8,8 @@ export interface ProvenanceSessionExporterOptions {
   readonly rootInput: HarnessLayoutInput;
   readonly currentSessionProbe: CurrentSessionProbePort;
   readonly now?: () => string;
+  readonly homeDir?: string;
+  readonly runtimeLogRoots?: Partial<Record<CurrentSessionRuntime, ReadonlyArray<string>>>;
 }
 
 export interface ProvenanceSessionDocument {
@@ -39,10 +41,25 @@ export interface ProvenanceSessionExporter {
 
 const sessionSchema = "provenance-session/v1";
 const safeSessionIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
+const maxRuntimeLogSearchDepth = 8;
+
+interface RuntimeConversationMessage {
+  readonly role: "user" | "assistant" | "summary";
+  readonly text: string;
+  readonly timestamp?: string;
+}
+
+interface RuntimeConversation {
+  readonly logPath?: string;
+  readonly messages: ReadonlyArray<RuntimeConversationMessage>;
+  readonly warnings: ReadonlyArray<string>;
+}
+
+type JsonObject = Record<string, unknown>;
 
 export function makeProvenanceSessionExporter(options: ProvenanceSessionExporterOptions): ProvenanceSessionExporter {
   const timestamp = () => options.now?.() ?? new Date().toISOString();
-  const exportSession = (session: CurrentSessionRef) => writeSessionDocument(options.rootInput, toSessionDocument(session, timestamp()));
+  const exportSession = (session: CurrentSessionRef) => writeSessionDocument(options.rootInput, options, toSessionDocument(session, timestamp()));
   return {
     exportSession,
     exportCurrentSession: () => options.currentSessionProbe.currentSession.pipe(
@@ -66,6 +83,7 @@ function toSessionDocument(session: CurrentSessionRef, exportedAt: string): Prov
 
 function writeSessionDocument(
   rootInput: HarnessLayoutInput,
+  options: ProvenanceSessionExporterOptions,
   session: ProvenanceSessionDocument
 ): Effect.Effect<ProvenanceSessionExportResult, ProvenanceSessionExporterRejected> {
   return Effect.try({
@@ -73,7 +91,7 @@ function writeSessionDocument(
       const target = resolveSessionPath(rootInput, session.sessionId);
       mkdirSync(path.dirname(target.absolutePath), { recursive: true });
       const tmpPath = `${target.absolutePath}.${process.pid}.${Date.now()}.tmp`;
-      writeFileSync(tmpPath, renderSessionMarkdown(session), "utf8");
+      writeFileSync(tmpPath, renderSessionMarkdown(session, resolveRuntimeConversation(session, options)), "utf8");
       renameSync(tmpPath, target.absolutePath);
       return {
         session,
@@ -138,7 +156,7 @@ function parseSessionMarkdown(body: string, expectedSessionId: string): Provenan
   };
 }
 
-function renderSessionMarkdown(session: ProvenanceSessionDocument): string {
+function renderSessionMarkdown(session: ProvenanceSessionDocument, conversation: RuntimeConversation): string {
   return [
     "---",
     `schema: ${session.schema}`,
@@ -157,8 +175,319 @@ function renderSessionMarkdown(session: ProvenanceSessionDocument): string {
     `Detected at: ${session.detectedAt}`,
     `Exported at: ${session.exportedAt}`,
     ...(session.user ? [`User: ${sanitizeScalar(session.user)}`] : []),
+    ...(conversation.logPath ? [`Runtime log: ${displayRuntimePath(conversation.logPath)}`] : []),
+    "",
+    ...renderWarnings(conversation.warnings),
+    "## Conversation",
+    "",
+    ...renderConversationMessages(conversation.messages),
     ""
   ].join("\n");
+}
+
+function resolveRuntimeConversation(
+  session: ProvenanceSessionDocument,
+  options: ProvenanceSessionExporterOptions
+): RuntimeConversation {
+  const warnings: string[] = [];
+  if (session.runtime === "human") {
+    warnings.push("No runtime JSONL log is expected for human fallback sessions.");
+    return { messages: [], warnings };
+  }
+
+  const logPath = findRuntimeLogPath(session, options, warnings);
+  if (!logPath) {
+    warnings.push(`No runtime JSONL log found for ${session.runtime} session ${session.sessionId}.`);
+    return { messages: [], warnings };
+  }
+
+  if (session.runtime === "zcode" || session.runtime === "antigravity") {
+    warnings.push(`${session.runtime} runtime JSONL rendering is a progressive stub for M3.`);
+    return { logPath, messages: [], warnings };
+  }
+
+  try {
+    const body = readFileSync(logPath, "utf8");
+    const messages = session.runtime === "claude-code"
+      ? parseClaudeRuntimeJsonl(body, warnings)
+      : parseCodexRuntimeJsonl(body, warnings);
+    if (messages.length === 0) warnings.push(`No conversation text could be extracted from ${displayRuntimePath(logPath)}.`);
+    return { logPath, messages, warnings };
+  } catch (error) {
+    warnings.push(`Failed to read runtime JSONL log ${displayRuntimePath(logPath)}: ${errorMessage(error)}.`);
+    return { logPath, messages: [], warnings };
+  }
+}
+
+function findRuntimeLogPath(
+  session: ProvenanceSessionDocument,
+  options: ProvenanceSessionExporterOptions,
+  warnings: string[]
+): string | undefined {
+  const configuredRoots = options.runtimeLogRoots?.[session.runtime];
+  const roots = configuredRoots ?? defaultRuntimeLogRoots(session.runtime, options.homeDir);
+  if (roots.length === 0) {
+    warnings.push(`No JSONL log roots are configured for ${session.runtime}.`);
+    return undefined;
+  }
+
+  for (const root of roots) {
+    const match = findMatchingJsonl(root, session.sessionId, configuredRoots !== undefined, warnings);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+function defaultRuntimeLogRoots(runtime: CurrentSessionRuntime, homeDir = process.env.HOME): ReadonlyArray<string> {
+  if (!homeDir) return [];
+  if (runtime === "claude-code") return [path.join(homeDir, ".claude", "projects")];
+  if (runtime === "codex") {
+    return [
+      path.join(homeDir, ".codex", "sessions"),
+      path.join(homeDir, ".codex", "archived_sessions")
+    ];
+  }
+  return [];
+}
+
+function findMatchingJsonl(
+  root: string,
+  sessionId: string,
+  allowExplicitFileRoot: boolean,
+  warnings: string[]
+): string | undefined {
+  let rootStat;
+  try {
+    rootStat = statSync(root);
+  } catch (error) {
+    if (allowExplicitFileRoot) warnings.push(`Configured runtime log root is not readable: ${root} (${errorMessage(error)}).`);
+    return undefined;
+  }
+
+  if (rootStat.isFile()) {
+    if (path.extname(root) === ".jsonl" && (allowExplicitFileRoot || fileNameMatchesSession(root, sessionId))) return root;
+    return undefined;
+  }
+  if (!rootStat.isDirectory()) return undefined;
+  return findMatchingJsonlInDirectory(root, sessionId, maxRuntimeLogSearchDepth);
+}
+
+function findMatchingJsonlInDirectory(root: string, sessionId: string, depth: number): string | undefined {
+  if (depth < 0) return undefined;
+  let entries;
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  const sorted = entries.toSorted((left, right) => left.name.localeCompare(right.name));
+  for (const entry of sorted) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isFile() && path.extname(entry.name) === ".jsonl" && fileNameMatchesSession(entry.name, sessionId)) {
+      return fullPath;
+    }
+  }
+  for (const entry of sorted) {
+    if (!entry.isDirectory()) continue;
+    const match = findMatchingJsonlInDirectory(path.join(root, entry.name), sessionId, depth - 1);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+function fileNameMatchesSession(filePath: string, sessionId: string): boolean {
+  const basename = path.basename(filePath, ".jsonl");
+  return basename === sessionId || basename.endsWith(`-${sessionId}`) || basename.includes(sessionId);
+}
+
+function parseClaudeRuntimeJsonl(body: string, warnings: string[]): ReadonlyArray<RuntimeConversationMessage> {
+  const messages: RuntimeConversationMessage[] = [];
+  for (const line of body.split(/\r?\n/u)) {
+    const record = parseJsonlRecord(line, warnings);
+    if (!record) continue;
+    const type = readString(record, "type");
+    const message = readRecord(record, "message");
+    if (!message) continue;
+    const role = readString(message, "role");
+    const timestamp = readString(record, "timestamp");
+    if (type === "user" && role === "user") appendMessage(messages, "user", extractTextContent(message.content, "user"), timestamp);
+    if (type === "assistant" && role === "assistant") appendMessage(messages, "assistant", extractTextContent(message.content, "assistant"), timestamp);
+  }
+  return messages;
+}
+
+function parseCodexRuntimeJsonl(body: string, warnings: string[]): ReadonlyArray<RuntimeConversationMessage> {
+  const streamMessages: RuntimeConversationMessage[] = [];
+  const compactedSnapshots: Array<{ readonly timestamp?: string; readonly messages: ReadonlyArray<RuntimeConversationMessage> }> = [];
+
+  for (const line of body.split(/\r?\n/u)) {
+    const record = parseJsonlRecord(line, warnings);
+    if (!record) continue;
+    const type = readString(record, "type");
+    const timestamp = readString(record, "timestamp");
+    const payload = readRecord(record, "payload");
+    if (!payload) continue;
+
+    if (type === "compacted") {
+      const replacementHistory = readArray(payload, "replacement_history");
+      if (replacementHistory.length > 0) {
+        compactedSnapshots.push({ timestamp, messages: extractCodexReplacementHistory(replacementHistory, timestamp) });
+      }
+      continue;
+    }
+
+    if (type === "event_msg" && readString(payload, "type") === "user_message") {
+      appendMessage(streamMessages, "user", readString(payload, "message") ?? "", timestamp);
+      continue;
+    }
+
+    if (type !== "response_item") continue;
+    const payloadType = readString(payload, "type");
+    const role = readString(payload, "role");
+    if (payloadType === "message" && role === "assistant") {
+      appendMessage(streamMessages, "assistant", extractTextContent(payload.content, "assistant"), timestamp);
+    } else if (payloadType === "message" && role === "user" && !streamMessages.some((message) => message.role === "user")) {
+      appendMessage(streamMessages, "user", extractTextContent(payload.content, "user"), timestamp);
+    }
+  }
+
+  const lastSnapshot = compactedSnapshots.at(-1);
+  if (!lastSnapshot) return streamMessages;
+  const streamAfterSnapshot = lastSnapshot.timestamp
+    ? streamMessages.filter((message) => (message.timestamp ?? "") > lastSnapshot.timestamp!)
+    : [];
+  const recentSnapshotTexts = new Set(lastSnapshot.messages.slice(-6).map((message) => message.text));
+  return [
+    ...lastSnapshot.messages,
+    ...streamAfterSnapshot.filter((message) => !recentSnapshotTexts.has(message.text))
+  ];
+}
+
+function extractCodexReplacementHistory(
+  replacementHistory: ReadonlyArray<unknown>,
+  timestamp?: string
+): ReadonlyArray<RuntimeConversationMessage> {
+  const messages: RuntimeConversationMessage[] = [];
+  for (const item of replacementHistory) {
+    if (!isJsonObject(item)) continue;
+    const role = readString(item, "role");
+    if (role !== "user" && role !== "assistant") continue;
+    appendMessage(messages, role, extractTextContent(item.content, role), timestamp);
+  }
+  return messages;
+}
+
+function extractTextContent(content: unknown, role: "user" | "assistant"): string {
+  if (typeof content === "string") return cleanRuntimeText(content);
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const item of content) {
+    if (typeof item === "string") {
+      parts.push(item);
+      continue;
+    }
+    if (!isJsonObject(item)) continue;
+    const type = readString(item, "type");
+    const text = readString(item, "text");
+    if (text && (type === "text" || type === "input_text" || type === "output_text")) parts.push(text);
+    if (role === "user" && type === "image") parts.push("[image]");
+  }
+  return cleanRuntimeText(parts.join("\n\n"));
+}
+
+function appendMessage(
+  messages: RuntimeConversationMessage[],
+  role: RuntimeConversationMessage["role"],
+  rawText: string,
+  timestamp?: string
+): void {
+  const text = cleanRuntimeText(rawText);
+  if (!text || isSystemNoise(text)) return;
+  messages.push({ role, text, ...(timestamp ? { timestamp } : {}) });
+}
+
+function cleanRuntimeText(text: string): string {
+  return text
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/gu, "")
+    .replace(/<command-message>[\s\S]*?<\/command-message>/gu, "")
+    .replace(/<command-name>[\s\S]*?<\/command-name>/gu, "")
+    .replace(/<command-args>[\s\S]*?<\/command-args>/gu, "")
+    .replace(/<local-command-caveat>[\s\S]*?<\/local-command-caveat>/gu, "")
+    .replace(/<task-notification>[\s\S]*?<\/task-notification>/gu, "")
+    .replace(/\n{4,}/gu, "\n\n\n")
+    .trim();
+}
+
+function isSystemNoise(text: string): boolean {
+  return [
+    "<environment",
+    "<environment_context>",
+    "<INSTRUCTIONS>",
+    "<permissions",
+    "<developer>",
+    "# AGENTS.md",
+    "## Apps\n",
+    "Base directory for this skill:"
+  ].some((prefix) => text.startsWith(prefix));
+}
+
+function parseJsonlRecord(line: string, warnings: string[]): JsonObject | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (isJsonObject(parsed)) return parsed;
+    warnings.push("Skipped non-object JSONL record.");
+  } catch {
+    warnings.push("Skipped malformed JSONL record.");
+  }
+  return undefined;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readRecord(record: JsonObject, key: string): JsonObject | undefined {
+  const value = record[key];
+  return isJsonObject(value) ? value : undefined;
+}
+
+function readString(record: JsonObject, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function readArray(record: JsonObject, key: string): ReadonlyArray<unknown> {
+  const value = record[key];
+  return Array.isArray(value) ? value : [];
+}
+
+function renderWarnings(warnings: ReadonlyArray<string>): ReadonlyArray<string> {
+  if (warnings.length === 0) return [];
+  return [
+    "## Export Warnings",
+    "",
+    ...warnings.map((warning) => `- ${warning}`),
+    ""
+  ];
+}
+
+function renderConversationMessages(messages: ReadonlyArray<RuntimeConversationMessage>): ReadonlyArray<string> {
+  if (messages.length === 0) return ["_No conversation text extracted._", ""];
+  return messages.flatMap((message) => [
+    `### ${renderRole(message.role)}${message.timestamp ? ` (${message.timestamp})` : ""}`,
+    "",
+    message.text,
+    ""
+  ]);
+}
+
+function renderRole(role: RuntimeConversationMessage["role"]): string {
+  if (role === "user") return "User";
+  if (role === "assistant") return "Assistant";
+  return "Summary";
 }
 
 function assertSafeSessionId(sessionId: string): void {
@@ -175,8 +504,20 @@ function assertSource(value: string): asserts value is CurrentSessionSource {
   if (value !== "runtime" && value !== "manual") throw new Error(`invalid session source: ${value}`);
 }
 
+function displayRuntimePath(logPath: string): string {
+  const homeDir = process.env.HOME;
+  if (homeDir && logPath.startsWith(`${homeDir}${path.sep}`)) {
+    return `~/${path.relative(homeDir, logPath).split(path.sep).join("/")}`;
+  }
+  return logPath.split(path.sep).join("/");
+}
+
 function sanitizeScalar(value: string): string {
   return value.replace(/[\r\n]+/gu, " ").trim();
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function sessionRejection(sessionId: string, reason: string): ProvenanceSessionExporterRejected {

--- a/packages/application/test/provenance-session-exporter.test.ts
+++ b/packages/application/test/provenance-session-exporter.test.ts
@@ -5,6 +5,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { Effect } from "effect";
 import { makeHumanFallbackSessionProbe, makeProvenanceSessionExporter } from "../src/index.ts";
+import type { CurrentSessionRef } from "../../kernel/src/index.ts";
 
 test("provenance session exporter writes human fallback markdown and reads it by id", () => {
   const rootDir = createHarnessRoot();
@@ -45,6 +46,115 @@ test("provenance session exporter writes human fallback markdown and reads it by
   }
 });
 
+test("provenance session exporter renders Claude Code JSONL conversation text", () => {
+  const rootDir = createHarnessRoot();
+  try {
+    const logsRoot = path.join(rootDir, "runtime-logs", "claude", "project-a");
+    mkdirSync(logsRoot, { recursive: true });
+    writeFileSync(path.join(logsRoot, "claude-session-1.jsonl"), [
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-03T00:00:01.000Z",
+        message: { role: "user", content: [{ type: "text", text: "Claude user original line" }] }
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-03T00:00:02.000Z",
+        message: { role: "assistant", content: [{ type: "text", text: "Claude assistant original line" }] }
+      })
+    ].join("\n"), "utf8");
+
+    const exporter = makeProvenanceSessionExporter({
+      rootInput: rootDir,
+      currentSessionProbe: fixedSessionProbe({
+        runtime: "claude-code",
+        sessionId: "claude-session-1",
+        source: "runtime",
+        detectedAt: "2026-07-03T00:00:00.000Z"
+      }),
+      runtimeLogRoots: { "claude-code": [path.join(rootDir, "runtime-logs", "claude")] },
+      now: () => "2026-07-03T00:01:00.000Z"
+    });
+
+    const exported = Effect.runSync(exporter.exportCurrentSession());
+    const body = readFileSync(path.join(rootDir, "harness", exported.path), "utf8");
+    assert.match(body, /## Conversation/u);
+    assert.match(body, /Claude user original line/u);
+    assert.match(body, /Claude assistant original line/u);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("provenance session exporter renders Codex JSONL conversation text", () => {
+  const rootDir = createHarnessRoot();
+  try {
+    const logsRoot = path.join(rootDir, "runtime-logs", "codex");
+    mkdirSync(logsRoot, { recursive: true });
+    writeFileSync(path.join(logsRoot, "rollout-2026-07-03T00-00-00-codex-session-1.jsonl"), [
+      JSON.stringify({
+        timestamp: "2026-07-03T00:00:01.000Z",
+        type: "event_msg",
+        payload: { type: "user_message", message: "Codex user original line" }
+      }),
+      JSON.stringify({
+        timestamp: "2026-07-03T00:00:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Codex assistant original line" }]
+        }
+      })
+    ].join("\n"), "utf8");
+
+    const exporter = makeProvenanceSessionExporter({
+      rootInput: rootDir,
+      currentSessionProbe: fixedSessionProbe({
+        runtime: "codex",
+        sessionId: "codex-session-1",
+        source: "runtime",
+        detectedAt: "2026-07-03T00:00:00.000Z"
+      }),
+      runtimeLogRoots: { codex: [logsRoot] },
+      now: () => "2026-07-03T00:01:00.000Z"
+    });
+
+    const exported = Effect.runSync(exporter.exportCurrentSession());
+    const body = readFileSync(path.join(rootDir, "harness", exported.path), "utf8");
+    assert.match(body, /## Conversation/u);
+    assert.match(body, /Codex user original line/u);
+    assert.match(body, /Codex assistant original line/u);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("provenance session exporter writes visible warning when runtime log is missing", () => {
+  const rootDir = createHarnessRoot();
+  try {
+    const exporter = makeProvenanceSessionExporter({
+      rootInput: rootDir,
+      currentSessionProbe: fixedSessionProbe({
+        runtime: "codex",
+        sessionId: "missing-codex-session",
+        source: "runtime",
+        detectedAt: "2026-07-03T00:00:00.000Z"
+      }),
+      runtimeLogRoots: { codex: [path.join(rootDir, "missing-runtime-logs")] },
+      now: () => "2026-07-03T00:01:00.000Z"
+    });
+
+    const exported = Effect.runSync(exporter.exportCurrentSession());
+    const body = readFileSync(path.join(rootDir, "harness", exported.path), "utf8");
+    assert.match(body, /## Export Warnings/u);
+    assert.match(body, /No runtime JSONL log found for codex session missing-codex-session/u);
+    assert.match(body, /_No conversation text extracted\._/u);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("provenance session exporter fails visibly for missing or unsafe session ids", () => {
   const rootDir = createHarnessRoot();
   try {
@@ -64,6 +174,12 @@ test("provenance session exporter fails visibly for missing or unsafe session id
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
+
+function fixedSessionProbe(session: CurrentSessionRef) {
+  return {
+    currentSession: Effect.succeed(session)
+  };
+}
 
 function createHarnessRoot(): string {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-provenance-session-"));


### PR DESCRIPTION
## Summary

Adds JSONL-backed session markdown rendering for Claude Code and Codex provenance exports.

## What Changed

- Added runtime log lookup and JSONL parsing for Claude Code and Codex session exports.
- Rendered user/assistant/tool conversation text into session markdown.
- Preserved visible missing-log warnings without crashing export.
- Left zcode and antigravity as explicit progressive stubs.
- Added fixture tests for Claude Code, Codex, and missing-log behavior.

## Task And Scope

- Harness task: `task_01KWJV6WC3FFRBFYQS8J4JWRTR`
- Branch: `codex/m3-rmd-r4`
- Public scope: application provenance session exporter and tests
- Private planning/evidence updated: yes
- Out of scope: I/O proxy, structured summaries/sections, zcode/antigravity full parsers, release publishing

## Version Impact

- Version: no version change because this is pre-release remediation.
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: `fe36e206ebebd0b7fa883f87d09c6d4a336c50f1`
- Branch merge-base with `origin/main`: `fe36e206ebebd0b7fa883f87d09c6d4a336c50f1`
- Last `git fetch origin` time: `2026-07-03T02:40:45Z`
- Sync method: none needed
- Public diff command: `git diff --stat origin/main..HEAD`
- Private evidence commit/path: private harness task `task_01KWJV6WC3FFRBFYQS8J4JWRTR`
- Reviewer evidence path: subagent Sartre findings plus Commander verification
- GitHub Actions `rewrite-ci` run URL: pending; see Checks tab
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` (local workspace install used). `npm run check` initially reached an npm audit TLS disconnect, then `npm run harness:check-supply-chain && npm run harness:smoke-legacy-intake && npm run harness:smoke-cli-package` passed on retry.

## Review Evidence

- Self-review: checked fixture-backed Claude/Codex rendering, visible missing-log warning, and scoped stubs for runtimes left progressive.
- Reviewer subagent: Sartre
- Human review: pending CEO review
- Blocking findings: none open

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear.

## Residual Risk

- CI `rewrite-ci` is pending at PR creation.
- Runtime disk-log formats may drift; this PR delivers the fixture-backed minimum viable parser for Claude Code and Codex, with zcode/antigravity intentionally deferred.
- Merge method: squash or normal merge per repository policy; after merge delete remote branch `codex/m3-rmd-r4` and remove the local worktree.

## References

- Task: `task_01KWJV6WC3FFRBFYQS8J4JWRTR`
- Evidence: local `npm run check`, `git diff --check`, provenance-session-exporter fixture tests
- Review: Sartre subagent + Commander self-review

---

## 摘要

为 Claude Code 与 Codex provenance session export 增加 JSONL 到 markdown 的正文渲染。

## 改动内容

- 增加 Claude Code 与 Codex runtime log 定位和 JSONL 解析。
- 将 user/assistant/tool 对话正文渲染进 session markdown。
- 缺日志时输出可见 warning，不崩溃。
- zcode 与 antigravity 保留显式渐进 stub。
- 增加 Claude Code、Codex、缺日志 fixture 测试。

## 任务与范围

- Harness 任务：`task_01KWJV6WC3FFRBFYQS8J4JWRTR`
- 分支：`codex/m3-rmd-r4`
- 公开范围：application provenance session exporter 与测试
- 私有计划 / 证据是否已更新：yes
- 范围外：I/O proxy、结构化摘要/分段、zcode/antigravity 完整解析器、发布

## 版本影响

- 版本：不改版本，原因是 pre-release remediation。
- 发布影响：不发布

## 验证

- `origin/main` 基准 SHA：`fe36e206ebebd0b7fa883f87d09c6d4a336c50f1`
- 当前分支与 `origin/main` 的 merge-base：`fe36e206ebebd0b7fa883f87d09c6d4a336c50f1`
- 最近一次 `git fetch origin` 时间：`2026-07-03T02:40:45Z`
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main..HEAD`
- 私有证据 commit/path：private harness task `task_01KWJV6WC3FFRBFYQS8J4JWRTR`
- Reviewer 证据路径：subagent Sartre findings plus Commander verification
- GitHub Actions `rewrite-ci` run URL：pending; see Checks tab
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci`（使用本地 workspace install）。`npm run check` 初次到 npm audit TLS 断连，随后 `npm run harness:check-supply-chain && npm run harness:smoke-legacy-intake && npm run harness:smoke-cli-package` 重跑通过。

## 审查证据

- 自查：核对 Claude/Codex fixture 渲染、缺日志 warning、渐进 runtime stub 边界。
- Reviewer subagent：Sartre
- 人工审查：等待 CEO 复核
- 阻塞发现：无

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚。

## 残余风险

- PR 创建时 CI `rewrite-ci` 尚未完成。
- runtime 磁盘日志格式可能漂移；本 PR 交付 Claude Code 与 Codex 的 fixture-backed 最小可用解析，zcode/antigravity 明确延后。
- 合并方式：按仓库策略 squash 或 normal merge；合并后删除远端分支 `codex/m3-rmd-r4` 并移除本地 worktree。

## 关联材料

- 任务：`task_01KWJV6WC3FFRBFYQS8J4JWRTR`
- 证据：本地 `npm run check`、`git diff --check`、provenance-session-exporter fixture tests
- 审查：Sartre subagent + Commander self-review
