### PR TITLE
fix: close low-risk triadic remediation gaps

### DIFF
--- a/packages/application/src/decision-document-reader.ts
+++ b/packages/application/src/decision-document-reader.ts
@@ -73,10 +73,24 @@ function parseActor(value: string): DecisionPackage["arbiter"] {
 }
 
 function parseObjectList(frontmatter: string, key: string): ReadonlyArray<Record<string, unknown>> {
-  return readIndentedBlock(frontmatter, key)
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith("- "))
-    .map((line) => parseFlowObject(line.slice(2).trim()));
+  const items: Record<string, unknown>[] = [];
+  let current: Record<string, unknown> | null = null;
+  for (const rawLine of readIndentedBlock(frontmatter, key)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith("- ")) {
+      if (current) items.push(current);
+      const body = line.slice(2).trim();
+      current = body.startsWith("{") ? parseFlowObject(body) : parseBlockObjectLine(body);
+      continue;
+    }
+    if (!current) continue;
+    for (const [entryKey, entryValue] of Object.entries(parseBlockObjectLine(line))) {
+      current[entryKey] = entryValue;
+    }
+  }
+  if (current) items.push(current);
+  return items;
 }
 
 function readIndentedBlock(frontmatter: string, key: string): ReadonlyArray<string> {
@@ -101,6 +115,13 @@ function parseFlowObject(value: string): Record<string, unknown> {
     result[key] = parseFlowValue(part.slice(separator + 1).trim());
   }
   return result;
+}
+
+function parseBlockObjectLine(value: string): Record<string, unknown> {
+  const separator = value.indexOf(":");
+  if (separator === -1) return {};
+  const key = value.slice(0, separator).trim();
+  return { [key]: parseFlowValue(value.slice(separator + 1).trim()) };
 }
 
 function parseFlowValue(value: string): unknown {

--- a/packages/application/test/decision-write-service.test.ts
+++ b/packages/application/test/decision-write-service.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { Effect } from "effect";
-import { makeDecisionWriteService, type DecisionWriteRejected } from "../src/index.ts";
+import { makeDecisionWriteService, readDecisionDocument, type DecisionWriteRejected } from "../src/index.ts";
 import { deriveRelationId, type DecisionPackage, type EntityRelationRecord, type WriteCoordinator, type WriteOp } from "../../kernel/src/index.ts";
 
 test("decision write service proposes and accepts through WriteCoordinator", () => {
@@ -75,6 +78,32 @@ test("decision write service rejects relation records not hosted by the decision
   assert.match(failureReason(result.cause), /hosted by decision\/dec_TEST/u);
 });
 
+test("decision document reader accepts block-list frontmatter and rejects unknown provenance runtime", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-decision-reader-"));
+  try {
+    writeDecisionMarkdown(rootDir, "dec_BLOCK", "codex");
+
+    const read = readDecisionDocument(rootDir, "dec_BLOCK");
+
+    assert.equal(read.decision.decision_id, "dec_BLOCK");
+    assert.deepEqual(read.decision.provenance, [{
+      runtime: "codex",
+      sessionId: "session-1",
+      boundAt: "2026-07-03T00:00:00.000Z"
+    }]);
+    assert.deepEqual(read.decision.rejected, [{
+      id: "RJ1",
+      text: "Keep flow-only parser compatibility.",
+      why_not: "Block-list YAML is the contract shape humans copy from design docs."
+    }]);
+
+    writeDecisionMarkdown(rootDir, "dec_BLOCK", "other-runtime");
+    assert.throws(() => readDecisionDocument(rootDir, "dec_BLOCK"));
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function fakeCoordinator(enqueued: WriteOp[]): WriteCoordinator {
   return {
     enqueue: (op) => Effect.sync(() => {
@@ -84,6 +113,50 @@ function fakeCoordinator(enqueued: WriteOp[]): WriteCoordinator {
     flush: () => Effect.succeed({ reason: "explicit", opCount: enqueued.length, committed: true }),
     recover: Effect.succeed({ replayedOps: 0 })
   };
+}
+
+function writeDecisionMarkdown(rootDir: string, decisionId: string, runtime: string): void {
+  const decisionRoot = path.join(rootDir, "harness/decisions", `decision-${decisionId}`);
+  mkdirSync(decisionRoot, { recursive: true });
+  writeFileSync(path.join(decisionRoot, "decision.md"), [
+    "---",
+    "schema: decision-package/v1",
+    `decision_id: ${decisionId}`,
+    "_coordinatorWatermark: wm-block",
+    "title: Block frontmatter decision",
+    "state: active",
+    "riskTier: medium",
+    "urgency: medium",
+    "vertical: software/coding",
+    "preset: architecture-decision",
+    "applies_to:",
+    "  modules: [\"kernel\"]",
+    "  productLines: []",
+    "proposedBy: { kind: agent, id: writer }",
+    "proposedAt: 2026-07-03T00:00:00.000Z",
+    "arbiter: { kind: human, id: writer }",
+    "decidedAt: 2026-07-03T00:01:00.000Z",
+    "provenance:",
+    `  - runtime: ${runtime}`,
+    "    sessionId: session-1",
+    "    boundAt: 2026-07-03T00:00:00.000Z",
+    "question: Should the reader accept contract-shaped blocks?",
+    "chosen:",
+    "  - id: CH1",
+    "    text: Parse block-list YAML.",
+    "rejected:",
+    "  - id: RJ1",
+    "    text: Keep flow-only parser compatibility.",
+    "    why_not: Block-list YAML is the contract shape humans copy from design docs.",
+    "claims:",
+    "  - id: C1",
+    "    text: Reader compatibility belongs at the read boundary.",
+    "relations:",
+    "---",
+    "",
+    "# Block frontmatter decision",
+    ""
+  ].join("\n"), "utf8");
 }
 
 function decisionPackage(overrides: Partial<DecisionPackage> = {}): DecisionPackage {

--- a/packages/cli/test/post-merge-check-cli.test.ts
+++ b/packages/cli/test/post-merge-check-cli.test.ts
@@ -83,6 +83,23 @@ test("CLI check --post-merge visibly fails hand-written decision watermarks", ()
   });
 });
 
+test("CLI check --post-merge hard-fails a relation to a missing decision", () => {
+  withTempRoot((rootDir) => {
+    writeIndex(rootDir, "task-a", "A", "planned", {
+      relations: [relationRecord("task/task-a", "decision/dec_MISSING/C1")]
+    });
+
+    const result = runJson(rootDir, ["check", "--post-merge"], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error?.code, "projection_check_failed");
+    const dangling = result.warnings.find((warning: any) => warning.code === "dangling_entity_ref");
+    assert.ok(dangling);
+    assert.equal(dangling.severity, "hard-fail");
+    assert.match(dangling.message, /decision\/dec_MISSING\/C1/);
+  });
+});
+
 test("CLI check --post-merge reports done task document placeholders as hard-fails", () => {
   withTempRoot((rootDir) => {
     writeIndex(rootDir, "task-a", "A", "done");

--- a/packages/cli/test/preset-script-cli.test.ts
+++ b/packages/cli/test/preset-script-cli.test.ts
@@ -239,6 +239,38 @@ test("CLI process preset script entrypoint rejects undeclared output write scope
   });
 });
 
+test("CLI process preset script entrypoint directly rejects localRoot write scope", () => {
+  withTempRoot((rootDir) => {
+    writeFile(rootDir, ".harness/presets/local-root-writer/preset.json", JSON.stringify({
+      schema: "preset-manifest/v2",
+      id: "local-root-writer",
+      title: "Local Root Writer",
+      vertical: "software/coding",
+      version: "1.0.0",
+      kind: "process-action",
+      kernelVersionRange: { min: "1.0.0", maxExclusive: "2.0.0" },
+      capabilityImports: [],
+      entrypoints: {
+        scaffold: { type: "script", command: "scripts/preset-action.mjs", writes: ["{{paths.localRoot}}"] }
+      },
+      profiles: [{
+        id: "baseline",
+        title: "Baseline",
+        checkerProfile: "standard",
+        templateSelections: []
+      }],
+      defaultProfile: "baseline"
+    }, null, 2));
+    writeFile(rootDir, ".harness/presets/local-root-writer/scripts/preset-action.mjs", "console.log('should not execute');\n");
+
+    const result = runJson(rootDir, ["preset", "action", "local-root-writer", "scaffold", "--task", "task-1", "--allow-scripts"], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "preset_write_scope_invalid");
+    assert.equal(existsSync(path.join(rootDir, ".harness/preset-scripts")), false);
+  });
+});
+
 test("CLI process preset script entrypoint rejects repository-wide declared write scope", () => {
   withTempRoot((rootDir) => {
     writeFile(rootDir, ".harness/presets/root-writer/preset.json", JSON.stringify({

--- a/packages/kernel/src/domain/fact-record.ts
+++ b/packages/kernel/src/domain/fact-record.ts
@@ -1,6 +1,7 @@
 export const factConfidenceLevels = ["low", "medium", "high"] as const;
 
 export type FactConfidence = typeof factConfidenceLevels[number];
+type FactProvenanceRuntime = "human" | "claude-code" | "codex" | "zcode" | "antigravity";
 
 export interface FactRecord {
   readonly fact_id: string;
@@ -9,7 +10,7 @@ export interface FactRecord {
   readonly observedAt: string;
   readonly confidence: FactConfidence;
   readonly provenance: ReadonlyArray<{
-    readonly runtime: string;
+    readonly runtime: FactProvenanceRuntime;
     readonly sessionId: string;
     readonly boundAt: string;
   }>;
@@ -79,12 +80,16 @@ function parseFactProvenanceEntry(value: string): FactRecord["provenance"][numbe
     const key = part.slice(0, separator).trim();
     values[key] = parseFlowScalar(part.slice(separator + 1).trim());
   }
-  if (!values.runtime || !values.sessionId || !values.boundAt) return null;
+  if (!values.runtime || !isFactProvenanceRuntime(values.runtime) || !values.sessionId || !values.boundAt) return null;
   return {
     runtime: values.runtime,
     sessionId: values.sessionId,
     boundAt: values.boundAt
   };
+}
+
+function isFactProvenanceRuntime(value: string): value is FactProvenanceRuntime {
+  return value === "human" || value === "claude-code" || value === "codex" || value === "zcode" || value === "antigravity";
 }
 
 function isConfidence(value: string): value is FactConfidence {

--- a/packages/kernel/src/schemas/decision-package.ts
+++ b/packages/kernel/src/schemas/decision-package.ts
@@ -49,6 +49,6 @@ export const DecisionPackageSchema = Schema.Struct({
   rejected: Schema.Array(RejectedDecisionAnchorSchema).pipe(Schema.minItems(1)),
   claims: Schema.Array(DecisionAnchorSchema).pipe(Schema.minItems(1)),
   relations: Schema.Array(EntityRelationRecordSchema)
-}).pipe(Schema.filter((decision) => decision.proposedBy.id !== decision.arbiter.id));
+}).pipe(Schema.filter((decision) => decision.proposedBy.kind !== decision.arbiter.kind || decision.proposedBy.id !== decision.arbiter.id));
 
 export type DecisionPackage = Schema.Schema.Type<typeof DecisionPackageSchema>;


### PR DESCRIPTION
## Summary

Closes the ride-along R6-R10 triadic remediation gaps.

## What Changed

- Added independent decision-dangling coverage.
- Made decision frontmatter reader accept block-list relation shapes instead of rewriting private examples.
- Aligned arbiter/proposedBy validation to compare actor kind and id.
- Rejected one-layer `{{paths.localRoot}}` script scope declarations.
- Added runtime enum validation for provenance persisted through schemas and ports.

## Task And Scope

- Harness task: `task_01KWJV68HCVR27MEP3ASB1P45A`
- Branch: `codex/m3-rmd-r6-r10`
- Public scope: decision reader/schema validation, script-scope tests, post-merge dangling coverage, provenance runtime validation
- Private planning/evidence updated: yes
- Out of scope: private architecture doc edits, release publishing

## Version Impact

- Version: no version change because this is pre-release remediation.
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: `fe36e206ebebd0b7fa883f87d09c6d4a336c50f1`
- Branch merge-base with `origin/main`: `fe36e206ebebd0b7fa883f87d09c6d4a336c50f1`
- Last `git fetch origin` time: `2026-07-03T02:40:45Z`
- Sync method: none needed
- Public diff command: `git diff --stat origin/main..HEAD`
- Private evidence commit/path: private harness task `task_01KWJV68HCVR27MEP3ASB1P45A`
- Reviewer evidence path: subagent Ampere findings plus Commander verification
- GitHub Actions `rewrite-ci` run URL: pending; see Checks tab
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` (local workspace install used). `npm run check` initially reached an npm audit TLS disconnect, then `npm run harness:check-supply-chain && npm run harness:smoke-legacy-intake && npm run harness:smoke-cli-package` passed on retry.

## Review Evidence

- Self-review: checked each R6-R10 acceptance point and chose reader compatibility for R7 to keep public runtime tolerant of both relation list shapes.
- Reviewer subagent: Ampere
- Human review: pending CEO review
- Blocking findings: none open

## PR Gate Checklist

- [x] Branch is based on latest `origin/main`.
- [x] PR body uses this full template.
- [x] No private harness files are included.
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] CI results are linked or explained.
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked.
- [x] Merge method and post-merge branch cleanup plan are clear.

## Residual Risk

- CI `rewrite-ci` is pending at PR creation.
- R7 was handled by reader compatibility rather than private doc rewrite, so both existing block-list and flow-object relation frontmatter forms decode.
- Merge method: squash or normal merge per repository policy; after merge delete remote branch `codex/m3-rmd-r6-r10` and remove the local worktree.

## References

- Task: `task_01KWJV68HCVR27MEP3ASB1P45A`
- Evidence: local `npm run check`, `git diff --check`, focused decision/script/schema tests
- Review: Ampere subagent + Commander self-review

---

## 摘要

收敛 R6-R10 ride-along 三元语 remediation 缺口。

## 改动内容

- 补充 decision-dangling 独立测试。
- `decision-document-reader` 兼容 block-list relation frontmatter，而不是改私有示例文档。
- arbiter/proposedBy 校验对齐到 actor kind + id。
- 一层直接拒绝 `{{paths.localRoot}}` script scope 声明。
- 为 schema 和 ports 落盘 provenance 增加 runtime 枚举校验。

## 任务与范围

- Harness 任务：`task_01KWJV68HCVR27MEP3ASB1P45A`
- 分支：`codex/m3-rmd-r6-r10`
- 公开范围：decision reader/schema validation、script-scope tests、post-merge dangling coverage、provenance runtime validation
- 私有计划 / 证据是否已更新：yes
- 范围外：私有架构文档编辑、发布

## 版本影响

- 版本：不改版本，原因是 pre-release remediation。
- 发布影响：不发布

## 验证

- `origin/main` 基准 SHA：`fe36e206ebebd0b7fa883f87d09c6d4a336c50f1`
- 当前分支与 `origin/main` 的 merge-base：`fe36e206ebebd0b7fa883f87d09c6d4a336c50f1`
- 最近一次 `git fetch origin` 时间：`2026-07-03T02:40:45Z`
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main..HEAD`
- 私有证据 commit/path：private harness task `task_01KWJV68HCVR27MEP3ASB1P45A`
- Reviewer 证据路径：subagent Ampere findings plus Commander verification
- GitHub Actions `rewrite-ci` run URL：pending; see Checks tab
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci`（使用本地 workspace install）。`npm run check` 初次到 npm audit TLS 断连，随后 `npm run harness:check-supply-chain && npm run harness:smoke-legacy-intake && npm run harness:smoke-cli-package` 重跑通过。

## 审查证据

- 自查：逐项核对 R6-R10 验收；R7 选择 reader compatibility，使 block-list 与 flow-object relation frontmatter 都可解码。
- Reviewer subagent：Ampere
- 人工审查：等待 CEO 复核
- 阻塞发现：无

## PR 门禁清单

- [x] 分支基于最新 `origin/main`。
- [x] PR 描述使用本模板完整结构。
- [x] 不包含私有 harness 文件。
- [x] 不包含被忽略的本地 agent 入口文件。
- [x] 本公开 PR 描述不包含本机绝对路径。
- [x] CI 结果已链接或说明。
- [x] open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] 合并方式和合并后分支清理计划清楚。

## 残余风险

- PR 创建时 CI `rewrite-ci` 尚未完成。
- R7 采用 reader compatibility，而非私有文档回写，因此现存 block-list 与 flow-object relation frontmatter 都能解码。
- 合并方式：按仓库策略 squash 或 normal merge；合并后删除远端分支 `codex/m3-rmd-r6-r10` 并移除本地 worktree。

## 关联材料

- 任务：`task_01KWJV68HCVR27MEP3ASB1P45A`
- 证据：本地 `npm run check`、`git diff --check`、focused decision/script/schema tests
- 审查：Ampere subagent + Commander self-review
