### PR TITLE
fix: surface real writer error code on task-complete

### DIFF
--- a/packages/application/src/task-lifecycle-orchestrator.ts
+++ b/packages/application/src/task-lifecycle-orchestrator.ts
@@ -248,26 +248,42 @@ function completionGateErrorCode(issues: ReadonlyArray<{ readonly code: string }
   return issues[0]?.code ?? "completion_gate_failed";
 }
 
+// Canonical kernel-tag -> CLI error-code mapping. Kept exhaustive by the mapped
+// type: adding or removing an EngineError/WriteError tag breaks compilation until
+// this table is updated, so a writer failure can never leak an unregistered code
+// that the CLI would coerce into a misleading completion_gate_failed. Values must
+// stay in lockstep with the CLI error-code registry (packages/cli/src/cli/error-codes.ts);
+// the application layer cannot import that registry across the package boundary.
+const writeFailureCodeByTag: Readonly<Record<(EngineError | WriteError)["_tag"], string>> = {
+  EngineNotEnabled: "EngineNotEnabled",
+  AdapterUnavailable: "AdapterUnavailable",
+  AuthMissing: "AuthMissing",
+  RefNotFound: "RefNotFound",
+  TaskAlreadyExists: "task_already_exists",
+  TaskNotFound: "task_not_found",
+  InvalidTransition: "invalid_transition",
+  DuplicateExternalBinding: "duplicate_external_binding",
+  DuplicateAdoptClaim: "duplicate_adopt_claim",
+  StaleSnapshotRefused: "stale_snapshot_refused",
+  GeneratedTaskIdRequired: "generated_task_id_required",
+  MalformedSnapshot: "malformed_snapshot",
+  StatusUnmapped: "StatusUnmapped",
+  EngineOwnsStatus: "engine_owns_status",
+  TerminalReopenRequiresSupersede: "terminal_reopen_requires_supersede",
+  ArchivedHardDeleteForbidden: "archived_hard_delete_forbidden",
+  TerminalHardDeleteForbidden: "terminal_hard_delete_forbidden",
+  RelatedTaskHardDeleteForbidden: "related_task_hard_delete_forbidden",
+  RateLimited: "RateLimited",
+  EngineUnreachable: "EngineUnreachable",
+  Timeout: "Timeout",
+  WriteRejected: "write_rejected",
+  WriteConflict: "write_conflict",
+  GlobalWriteConflict: "write_conflict",
+  JournalUnavailable: "journal_unavailable"
+};
+
 function writeFailureCode(error: EngineError | WriteError): string {
-  switch (error._tag) {
-    case "MalformedSnapshot":
-      return "malformed_snapshot";
-    case "TaskNotFound":
-      return "task_not_found";
-    case "InvalidTransition":
-      return "invalid_transition";
-    case "EngineOwnsStatus":
-      return "engine_owns_status";
-    case "WriteRejected":
-      return "write_rejected";
-    case "WriteConflict":
-    case "GlobalWriteConflict":
-      return "write_conflict";
-    case "JournalUnavailable":
-      return "journal_unavailable";
-    default:
-      return error._tag;
-  }
+  return writeFailureCodeByTag[error._tag];
 }
 
 function writeFailureCauseHint(error: EngineError | WriteError): string {

--- a/packages/application/test/task-lifecycle-write-failure.test.ts
+++ b/packages/application/test/task-lifecycle-write-failure.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import type { EngineError, WriteError } from "../../kernel/src/index.ts";
+import { makeTaskLifecycleOrchestrator, type TaskLifecycleWriter } from "../src/task-lifecycle-orchestrator.ts";
+
+// Regression: task-complete must surface the underlying kernel writer error code
+// rather than the misleading completion_gate_failed. A stub writer forces setStatus
+// to fail after every gate passes, covering the kernel tags whose registered CLI
+// error code is NOT their raw PascalCase _tag (previously leaked by the default
+// branch and then coerced to completion_gate_failed by cliErrorCode).
+const writeFailureCases: ReadonlyArray<{ readonly name: string; readonly error: EngineError | WriteError; readonly code: string }> = [
+  {
+    name: "TerminalReopenRequiresSupersede",
+    error: { _tag: "TerminalReopenRequiresSupersede", taskId: "task-1", status: "done" },
+    code: "terminal_reopen_requires_supersede"
+  },
+  {
+    name: "StaleSnapshotRefused",
+    error: { _tag: "StaleSnapshotRefused", engine: "local", ref: "local:task-1" },
+    code: "stale_snapshot_refused"
+  },
+  {
+    name: "GeneratedTaskIdRequired",
+    error: { _tag: "GeneratedTaskIdRequired", taskId: "task-1" },
+    code: "generated_task_id_required"
+  },
+  {
+    name: "WriteRejected",
+    error: { _tag: "WriteRejected", taskId: "task-1", reason: "provenance minItems(1)" },
+    code: "write_rejected"
+  },
+  {
+    name: "GlobalWriteConflict",
+    error: { _tag: "GlobalWriteConflict", owner: "other-session" },
+    code: "write_conflict"
+  }
+];
+
+for (const { name, error, code } of writeFailureCases) {
+  test(`completeTask surfaces the real writer error code for ${name}`, () => {
+    withTempRoot((rootDir) => {
+      writeTaskPackage(rootDir, "task-1", "Complete Task");
+      const orchestrator = makeTaskLifecycleOrchestrator({
+        rootDir,
+        taskWriter: failingWriter(error),
+        now: () => "2026-06-13T00:00:00.000Z"
+      });
+
+      const result = Effect.runSync(orchestrator.completeTask({ taskId: "task-1", reviewerId: "reviewer-a", ciGate: "passed" }));
+
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.error.code, code);
+      assert.notEqual(result.error.code, "completion_gate_failed");
+      assert.match(result.error.hint, /Completion status update failed\./);
+    });
+  });
+}
+
+function failingWriter(error: EngineError | WriteError): TaskLifecycleWriter {
+  return {
+    setStatus: () => Effect.fail(error),
+    appendProgress: () => Effect.fail(error)
+  };
+}
+
+function writeTaskPackage(rootDir: string, directoryName: string, title: string): void {
+  mkdirSync(path.join(rootDir, "harness/tasks", directoryName), { recursive: true });
+  writeFileSync(path.join(rootDir, "harness/tasks", directoryName, "INDEX.md"), [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${directoryName}`,
+    `title: ${title}`,
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    "  status: in_review",
+    "  ref: ",
+    `  titleSnapshot: ${title}`,
+    "  url: ",
+    "  bindingCreatedAt: 2026-06-12T00:00:00.000Z",
+    "  bindingFingerprint: sha256:4d1771ef6e83619eb8a82f1593bf118383084665fc58f634072d379178d525d7",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "provenance:",
+    "  - {runtime: \"human\", sessionId: \"human-cli-1783036800000\", boundAt: \"2026-06-12T00:00:00.000Z\"}",
+    "---",
+    "",
+    `# ${title}`,
+    ""
+  ].join("\n"), "utf8");
+  writeFileSync(path.join(rootDir, "harness/tasks", directoryName, "review.md"), [
+    "# Review",
+    "",
+    "| ID | Severity | Finding | Evidence Checked | Required Action | Open | Disposition | Blocks Release | Follow-up |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ""
+  ].join("\n"), "utf8");
+  writeFileSync(path.join(rootDir, "harness/tasks", directoryName, "closeout.md"), [
+    "# Closeout",
+    "",
+    "## Summary",
+    "",
+    "Implemented the task lifecycle write-failure passthrough.",
+    "",
+    "## Verification",
+    "",
+    "npm run check passed.",
+    "",
+    "## Residual Risk",
+    "",
+    "No residual risk accepted.",
+    ""
+  ].join("\n"), "utf8");
+}
+
+function withTempRoot<T>(fn: (rootDir: string) => T): T {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-write-failure-"));
+  try {
+    return fn(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}

--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -49,6 +49,11 @@ function taskLifecycleResultToCliResult(command: "task-review" | "task-complete"
 }
 
 function cliErrorCode(code: string): CliErrorCodeValue {
+  // The orchestrator's writeFailureCode maps every kernel writer/engine error to a
+  // registered CLI error code, so a real write failure (e.g. malformed_snapshot,
+  // write_rejected) passes through untouched and surfaces its true cause. The
+  // CompletionGateFailed fallback is a defensive guard for an unexpected unregistered
+  // code, not the normal path — it must not mask a recognized writer error code.
   if (isCliErrorCode(code)) return code;
   return CliErrorCode.CompletionGateFailed;
 }

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -28,6 +28,7 @@ export const testTierManifest = {
     "packages/application/test/provenance-session-exporter.test.ts",
     "packages/application/test/runtime-event-ledger-service.test.ts",
     "packages/application/test/task-lifecycle-gates.test.ts",
+    "packages/application/test/task-lifecycle-write-failure.test.ts",
     "packages/cli/test/package-surface.test.ts",
     "packages/cli/test/receipt-contracts.test.ts",
     "packages/gui/test/electron-security-policy.test.ts",


### PR DESCRIPTION
## 问题

`task-complete` 写入失败时，CLI 只暴露 `completion_gate_failed`，真实原因（如 `stale_snapshot_refused`/`write_rejected` 等 writer 错误）被掩盖。

根因：`writeFailureCode()` 的 `default: return error._tag` 会对映射表未覆盖的内核错误漏出原始 PascalCase `_tag`；这些 tag 不在 CLI error-codes 注册表里，随后被 `cliErrorCode()` 统一压成 `completion_gate_failed`。

（注：上游 #129 已修好 `malformed_snapshot` 这一具体症状；本 PR 关闭剩余的结构性隐患。）

## 改动

- `writeFailureCode` 改为**编译期穷尽**的 `kernel-tag -> CLI error-code` 映射表（mapped type 强制），删除会泄漏原始 tag 的 `default` 分支。任何新增/删除 `EngineError`/`WriteError` tag 都会直接编译失败，逼迫补映射，而非静默掩盖。
- `cliErrorCode` 补注释：`CompletionGateFailed` 仅为防御性兜底，不得掩盖已识别的 writer 错误码。
- 新增回归测试 `task-lifecycle-write-failure.test.ts`：stub writer 让 `completeTask` 过闸门后在 `setStatus` 失败，覆盖 5 个 writer tag（含 3 个原先被掩盖的），断言暴露真实注册码且不等于 `completion_gate_failed`。

## 验证

- `tsc -b`、eslint 通过
- `check-cli-error-codes` / `check-error-classification` / `check-duplicate-definitions` / `check-file-complexity` 全 PASS
- 相关测试全绿；已实测穷尽保证：去掉任一 tag 会触发 `error TS2741`