### PR TITLE
fix: harden windows validation paths

### DIFF
--- a/packages/adapters/local/src/git-diff-evidence.ts
+++ b/packages/adapters/local/src/git-diff-evidence.ts
@@ -131,7 +131,7 @@ function readGit(rootDir: string, args: ReadonlyArray<string>): { readonly ok: t
   try {
     return {
       ok: true,
-      stdout: execFileSync("git", ["-C", rootDir, ...args], {
+      stdout: execFileSync("git", ["-C", rootDir, "-c", "core.longpaths=true", ...args], {
         encoding: "utf8",
         maxBuffer: gitMaxBuffer,
         stdio: ["ignore", "pipe", "ignore"]

--- a/packages/cli/src/commands/extensions/script-scope.ts
+++ b/packages/cli/src/commands/extensions/script-scope.ts
@@ -123,10 +123,12 @@ export function permissionPathsForScope(root: string, recursive: boolean): Reado
 }
 
 function expandScopeRoot(root: string): ReadonlyArray<string> {
-  const parts = root.split(path.sep);
+  const parsed = path.parse(path.resolve(root));
+  const relativeParts = path.relative(parsed.root, path.resolve(root)).split(path.sep).filter((part) => part.length > 0);
+  const parts = [parsed.root, ...relativeParts];
   if (!parts.includes("*")) return [root];
-  let candidates = [parts[0] === "" ? path.sep : parts[0]];
-  const remaining = parts[0] === "" ? parts.slice(1) : parts.slice(1);
+  let candidates = [parts[0]];
+  const remaining = parts.slice(1);
   for (const part of remaining) {
     candidates = candidates.flatMap((candidate) => {
       if (part !== "*") return [path.join(candidate, part)];

--- a/packages/cli/test/migration-adopt-cli.test.ts
+++ b/packages/cli/test/migration-adopt-cli.test.ts
@@ -169,7 +169,7 @@ test("CLI legacy scan discovers V2 layout tasks and forwards private harness con
     writeFile(rootDir, "old/.harness-private/coding-agent-harness/tasks/v2-task/progress.md", "progress\n");
     writeFile(rootDir, "old/.harness-private/coding-agent-harness/context/architecture/overview.md", "# Architecture\n");
     writeFile(rootDir, "outside-secret.md", "# Secret\n");
-    symlinkSync(path.join(rootDir, "outside-secret.md"), path.join(rootDir, "old/.harness-private/coding-agent-harness/context/architecture/leak.md"));
+    trySymlink(path.join(rootDir, "outside-secret.md"), path.join(rootDir, "old/.harness-private/coding-agent-harness/context/architecture/leak.md"));
 
     const scan = runJson(rootDir, ["legacy", "scan", "old"]);
     assert.equal(scan.report.summary.taskCount, 1);
@@ -247,7 +247,7 @@ test("CLI legacy apply refuses a symlink alias of the active authored harness ro
   withTempRoot((rootDir) => {
     writeFile(rootDir, "harness/harness.yaml", "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n");
     writeFile(rootDir, "harness/docs/architecture/self-host.md", "# Self Host\n");
-    symlinkSync(path.join(rootDir, "harness"), path.join(rootDir, "link-harness"), "dir");
+    if (!trySymlink(path.join(rootDir, "harness"), path.join(rootDir, "link-harness"), "junction")) return;
 
     const copied = runJson(rootDir, ["legacy", "copy-safe-docs", "link-harness", "--apply"], false);
     const indexed = runJson(rootDir, ["legacy", "index", "link-harness", "--apply"], false);
@@ -463,6 +463,24 @@ function writeFile(rootDir: string, relativePath: string, body: string): void {
   const fullPath = path.join(rootDir, relativePath);
   mkdirSync(path.dirname(fullPath), { recursive: true });
   writeFileSync(fullPath, body, "utf8");
+}
+
+function trySymlink(target: string, linkPath: string, type?: "file" | "dir" | "junction"): boolean {
+  try {
+    symlinkSync(target, linkPath, type);
+    return true;
+  } catch (error) {
+    if (isWindowsSymlinkPermissionError(error)) return false;
+    throw error;
+  }
+}
+
+function isWindowsSymlinkPermissionError(error: unknown): boolean {
+  return process.platform === "win32" &&
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "EPERM";
 }
 
 function writeCurrentTaskPackage(

--- a/packages/cli/test/package-surface.test.ts
+++ b/packages/cli/test/package-surface.test.ts
@@ -26,7 +26,9 @@ test("CLI package exposes the harness-anything package artifact surface without 
   assert.equal(cliPackage.dependencies?.effect, "3.21.2");
   const cliEntry = path.resolve("packages/cli/src/index.ts");
   assert.equal(readFileSync(cliEntry, "utf8").startsWith("#!/usr/bin/env node"), true);
-  assert.equal((statSync(cliEntry).mode & 0o111) !== 0, true);
+  if (process.platform !== "win32") {
+    assert.equal((statSync(cliEntry).mode & 0o111) !== 0, true);
+  }
 });
 
 test("bundled software coding assets have consistent template and process-preset surfaces", () => {

--- a/packages/cli/test/path-utils.test.ts
+++ b/packages/cli/test/path-utils.test.ts
@@ -42,7 +42,25 @@ test("CLI path helpers resolve symlinks before inside checks", async () => {
   mkdirSync(root, { recursive: true });
   mkdirSync(outside, { recursive: true });
   writeFileSync(path.join(outside, "escape.txt"), "outside\n", "utf8");
-  symlinkSync(outside, path.join(root, "linked-outside"));
+  if (!trySymlink(outside, path.join(root, "linked-outside"), "junction")) return;
 
   assert.equal(isPathInside(root, path.join(root, "linked-outside", "escape.txt")), false);
 });
+
+function trySymlink(target: string, linkPath: string, type?: "file" | "dir" | "junction"): boolean {
+  try {
+    symlinkSync(target, linkPath, type);
+    return true;
+  } catch (error) {
+    if (isWindowsSymlinkPermissionError(error)) return false;
+    throw error;
+  }
+}
+
+function isWindowsSymlinkPermissionError(error: unknown): boolean {
+  return process.platform === "win32" &&
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "EPERM";
+}

--- a/packages/cli/test/preset-script-cli.test.ts
+++ b/packages/cli/test/preset-script-cli.test.ts
@@ -164,10 +164,26 @@ test("CLI script command runs with an explicit environment allowlist", () => {
     assert.equal(result.report.envKeys.includes("HARNESS_PRESET_CONTEXT"), true);
     assert.equal(result.report.envKeys.includes("HARNESS_SCRIPT_CONTEXT"), true);
     assert.equal(result.report.envKeys.includes("HARNESS_SCRIPT_RESULT"), true);
-    assert.equal(result.report.hasHome, false);
-    assert.equal(result.report.envKeys.includes("PATH"), false);
+    if (process.platform !== "win32") assert.equal(result.report.hasHome, false);
+    if (process.platform !== "win32") assert.equal(result.report.envKeys.includes("PATH"), false);
     assert.equal(result.report.envKeys.includes("USER"), false);
-    assert.equal(result.report.envKeys.every((key: string) => key.startsWith("HARNESS_") || key === "__CF_USER_TEXT_ENCODING"), true);
+    assert.equal(result.report.envKeys.every((key: string) =>
+      key.startsWith("HARNESS_") ||
+      key === "__CF_USER_TEXT_ENCODING" ||
+      (process.platform === "win32" && [
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "LOGONSERVER",
+        "PATH",
+        "SYSTEMDRIVE",
+        "SYSTEMROOT",
+        "TEMP",
+        "USERDOMAIN",
+        "USERNAME",
+        "USERPROFILE",
+        "WINDIR"
+      ].includes(key.toUpperCase()))
+    ), true);
   });
 });
 

--- a/packages/gui/test/path-traversal.test.ts
+++ b/packages/gui/test/path-traversal.test.ts
@@ -12,7 +12,7 @@ test("path guard rejects traversal, private folder access, absolute escape and f
     mkdirSync(path.join(root, "harness/tasks/task-1"), { recursive: true });
     mkdirSync(path.join(root, ".harness-private"), { recursive: true });
     writeFileSync(path.join(outside, "secret.md"), "secret");
-    symlinkSync(path.join(outside, "secret.md"), path.join(root, "harness/tasks/task-1/link.md"));
+    if (!trySymlink(path.join(outside, "secret.md"), path.join(root, "harness/tasks/task-1/link.md"))) return;
 
     assert.equal(validateProjectPath(root, "harness/tasks/task-1/INDEX.md").ok, true);
     assert.equal(validateProjectPath(root, "../outside.md").reason, "path_outside_project");
@@ -32,7 +32,7 @@ test("path guard rejects missing files under symlinked parent directories", () =
   const outside = mkdtempSync(path.join(tmpdir(), "ha-gui-outside-"));
   try {
     mkdirSync(path.join(root, "harness/tasks"), { recursive: true });
-    symlinkSync(outside, path.join(root, "harness/tasks/outdir"));
+    if (!trySymlink(outside, path.join(root, "harness/tasks/outdir"), "junction")) return;
 
     assert.equal(
       validateProjectPath(root, "harness/tasks/outdir/new.md").reason,
@@ -43,3 +43,21 @@ test("path guard rejects missing files under symlinked parent directories", () =
     rmSync(outside, { recursive: true, force: true });
   }
 });
+
+function trySymlink(target: string, path: string, type?: "file" | "dir" | "junction"): boolean {
+  try {
+    symlinkSync(target, path, type);
+    return true;
+  } catch (error) {
+    if (isWindowsSymlinkPermissionError(error)) return false;
+    throw error;
+  }
+}
+
+function isWindowsSymlinkPermissionError(error: unknown): boolean {
+  return process.platform === "win32" &&
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "EPERM";
+}

--- a/packages/kernel/src/store/write-journal-durable.ts
+++ b/packages/kernel/src/store/write-journal-durable.ts
@@ -135,6 +135,7 @@ export function writeFileDurably(filePath: string, body: string): void {
 }
 
 export function fsyncDirectory(dirPath: string): void {
+  if (process.platform === "win32") return;
   const fd = openSync(dirPath, "r");
   try {
     fsyncSync(fd);

--- a/packages/kernel/src/store/write-journal-git.ts
+++ b/packages/kernel/src/store/write-journal-git.ts
@@ -12,7 +12,7 @@ export function commitTouchedPaths(rootDir: string, touchedPaths: ReadonlyArray<
   const plan = resolveCommitPlan(rootDir, touchedPaths, layoutInput);
   if (!plan) return "no-git-change";
 
-  runGit(plan.repoRoot, "add", "--", ...plan.relativePaths);
+  runGit(plan.repoRoot, "add", "-A", "-f", "--", ...plan.relativePaths);
   const staged = runGit(plan.repoRoot, "diff", "--cached", "--name-only", "--", ...plan.relativePaths).trim();
   if (staged.length === 0) return currentGitHead(plan.repoRoot);
 

--- a/packages/kernel/test/contracts/legacy-intake-schema.test.ts
+++ b/packages/kernel/test/contracts/legacy-intake-schema.test.ts
@@ -17,22 +17,23 @@ const collisionValidUrl = new URL("../../fixtures/schemas/legacy-collision-repor
 const collisionInvalidUrl = new URL("../../fixtures/schemas/legacy-collision-report/invalid.json", import.meta.url);
 
 test("legacy storage layout is inside authored harness root", () => {
-  const layout = resolveHarnessLayout("/repo");
+  const rootDir = path.resolve(path.parse(process.cwd()).root, "repo");
+  const layout = resolveHarnessLayout(rootDir);
 
-  assert.equal(layout.tasksRoot, path.join("/repo", "harness", "tasks"));
-  assert.equal(layout.decisionsRoot, path.join("/repo", "harness", "decisions"));
-  assert.equal(layout.sessionsRoot, path.join("/repo", "harness", "sessions"));
-  assert.equal(layout.adrRoot, path.join("/repo", "harness", "adr"));
-  assert.equal(layout.milestonesRoot, path.join("/repo", "harness", "milestones"));
-  assert.equal(layout.legacyRoot, path.join("/repo", "harness", "legacy"));
+  assert.equal(layout.tasksRoot, path.join(rootDir, "harness", "tasks"));
+  assert.equal(layout.decisionsRoot, path.join(rootDir, "harness", "decisions"));
+  assert.equal(layout.sessionsRoot, path.join(rootDir, "harness", "sessions"));
+  assert.equal(layout.adrRoot, path.join(rootDir, "harness", "adr"));
+  assert.equal(layout.milestonesRoot, path.join(rootDir, "harness", "milestones"));
+  assert.equal(layout.legacyRoot, path.join(rootDir, "harness", "legacy"));
   assert.equal(layout.legacyTasksRoot, path.join(layout.legacyRoot, "tasks"));
   assert.equal(layout.legacyDocsRoot, path.join(layout.legacyRoot, "docs"));
   assert.equal(layout.legacyIndexPath, path.join(layout.legacyRoot, "index.json"));
   assert.equal(layout.legacyCollisionReportPath, path.join(layout.legacyRoot, "collision-report.json"));
   assert.equal(layout.legacyRebuildGuidePath, path.join(layout.legacyRoot, "rebuild-guide.md"));
-  assert.equal(layout.taskPackagePath("task_1"), taskPackagePath("/repo", "task_1"));
-  assert.equal(layout.createTaskPackagePath("task_1", "Layout Task"), createTaskPackagePath("/repo", "task_1", "Layout Task"));
-  assert.equal(layout.taskDocumentPath("task_1", "task_plan.md"), taskDocumentPath("/repo", "task_1", "task_plan.md"));
+  assert.equal(layout.taskPackagePath("task_1"), taskPackagePath(rootDir, "task_1"));
+  assert.equal(layout.createTaskPackagePath("task_1", "Layout Task"), createTaskPackagePath(rootDir, "task_1", "Layout Task"));
+  assert.equal(layout.taskDocumentPath("task_1", "task_plan.md"), taskDocumentPath(rootDir, "task_1", "task_plan.md"));
 });
 
 test("layout resolver honors harness.yaml layout roots and upward discovery", () => {

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { Effect } from "effect";
 import { hashTaskProjectionRows, rebuildTaskProjection } from "../../src/index.ts";
 import { makeJournaledWriteCoordinator } from "../../src/store/index.ts";
+import { taskEntityId } from "../../src/domain/index.ts";
 import { docWrite, withTempStore } from "./helpers.ts";
 
 test("WriteCoordinator flushes same-task writes in FIFO order", () => {
@@ -59,6 +60,55 @@ test("WriteCoordinator records real projection hash and compacts watermark-cover
     const recovered = Effect.runSync(makeJournaledWriteCoordinator({ rootDir }).recover);
     assert.equal(recovered.replayedOps, 0);
     assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-1/INDEX.md"), "utf8"), indexBody("task-1", "Task One", "planned"));
+  });
+});
+
+test("WriteCoordinator stages hard-deleted task packages and clears replay journal", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    mkdirSync(path.join(rootDir, "harness/tasks/task-1"), { recursive: true });
+    writeFileSync(path.join(rootDir, "harness/tasks/task-1/INDEX.md"), indexBody("task-1", "Task One", "planned"), "utf8");
+    runGit(rootDir, "add", ".");
+    runGit(rootDir, "commit", "-m", "seed task");
+
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(coordinator.enqueue({
+      opId: "op-hard-delete",
+      entityId: taskEntityId("task-1"),
+      kind: "package_delete_hard",
+      payload: {
+        reason: "mistaken local package"
+      }
+    }));
+    const report = Effect.runSync(coordinator.flush("explicit"));
+
+    assert.equal(report.watermark, "op-hard-delete");
+    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-1")), false);
+    const journalBody = readFileSync(path.join(rootDir, ".harness/write-journal/writes.jsonl"), "utf8");
+    assert.doesNotMatch(journalBody, /"schema":"write-journal\/v1"/);
+    assert.match(journalBody, /"schema":"delete-audit\/v1"/);
+    assert.match(readFileSync(path.join(rootDir, ".harness/write-journal/watermark.json"), "utf8"), /op-hard-delete/);
+    assert.match(runGit(rootDir, "show", "--name-status", "--format=", "HEAD"), /D\s+harness\/tasks\/task-1\/INDEX.md/);
+
+    const recovered = Effect.runSync(makeJournaledWriteCoordinator({ rootDir }).recover);
+    assert.equal(recovered.replayedOps, 0);
+  });
+});
+
+test("WriteCoordinator force-adds explicit harness paths ignored by target repo patterns", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    writeFileSync(path.join(rootDir, ".gitignore"), "artifacts/\n", "utf8");
+    runGit(rootDir, "add", ".gitignore");
+    runGit(rootDir, "commit", "-m", "ignore artifacts");
+
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(coordinator.enqueue(docWrite("op-ignored-artifact", "task-1", "artifacts/.gitkeep", "")));
+    const report = Effect.runSync(coordinator.flush("explicit"));
+
+    assert.equal(report.watermark, "op-ignored-artifact");
+    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-1/artifacts/.gitkeep")), true);
+    assert.match(runGit(rootDir, "show", "--name-only", "--format=", "HEAD"), /harness\/tasks\/task-1\/artifacts\/\.gitkeep/);
   });
 });
 

--- a/tools/check-cli-error-codes.mjs
+++ b/tools/check-cli-error-codes.mjs
@@ -74,7 +74,7 @@ function cliErrorCodeEntries(source) {
 
 function cliErrorRegistryNames(source) {
   const registrySource = extractAssignedLiteral(source, "cliErrorCodeRegistry");
-  return new Set([...registrySource.matchAll(/\[\s*CliErrorCode\.([A-Za-z0-9]+)\s*\]\s*:/gmu)].map((match) => match[1]));
+  return new Set([...registrySource.matchAll(/^\s*\[\s*CliErrorCode\.([A-Za-z0-9]+)\s*\]\s*:/gmu)].map((match) => match[1]));
 }
 
 function cliErrorFamilyNames(source, constName) {

--- a/tools/check-cli-error-codes.test.mjs
+++ b/tools/check-cli-error-codes.test.mjs
@@ -39,10 +39,10 @@ test("CLI error code gate rejects missing registry metadata and inline CliResult
     const violations = findCliErrorCodeViolations(rootDir);
 
     assert.equal(violations.includes("CliErrorCode.MissingTitle is missing cliErrorCodeRegistry metadata"), true);
-    assert.equal(
-      violations.includes(`packages/cli/src/commands/new-task.ts:3 uses inline CliResult error code "missing_title"; use cliError(CliErrorCode.*)`),
-      true
-    );
+    assert.equal(violations.some((violation) =>
+      violation.replaceAll("\\", "/").startsWith("packages/cli/src/commands/new-task.ts:") &&
+      violation.includes(`uses inline CliResult error code "missing_title"; use cliError(CliErrorCode.*)`)
+    ), true);
   });
 });
 

--- a/tools/check-private-boundary.mjs
+++ b/tools/check-private-boundary.mjs
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import path from "node:path";
 
 function git(args, options = {}) {
   return execFileSync("git", args, {
@@ -24,8 +25,9 @@ function record(message) {
   violations.push(message);
 }
 
-const topLevel = git(["rev-parse", "--show-toplevel"]).trim();
-if (topLevel !== process.cwd()) {
+const topLevel = normalizePath(git(["rev-parse", "--show-toplevel"]).trim());
+const cwd = normalizePath(process.cwd());
+if (topLevel !== cwd) {
   record(`run from repository root: expected ${topLevel}, got ${process.cwd()}`);
 }
 
@@ -85,3 +87,7 @@ if (violations.length > 0) {
 }
 
 console.log("Private boundary check passed.");
+
+function normalizePath(value) {
+  return path.resolve(value).split(path.sep).join("/");
+}

--- a/tools/check-runtime-release-readiness.mjs
+++ b/tools/check-runtime-release-readiness.mjs
@@ -39,7 +39,7 @@ function record(message) {
 }
 
 function requireIncludes(file, text, description = text) {
-  const body = read(file);
+  const body = read(file).replaceAll("\r\n", "\n");
   if (!body.includes(text)) record(`${file} must mention ${description}`);
 }
 

--- a/tools/run-gui-tests.mjs
+++ b/tools/run-gui-tests.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { collectGuiVitestFiles, validateGuiVitestManifest } from "./gui-test-runner-lib.mjs";
 import { guiVitestManifest } from "./gui-test-manifest.mjs";
@@ -36,8 +37,13 @@ if (guiVitestManifest.length === 0) {
   process.exit(0);
 }
 
-const npmBin = process.platform === "win32" ? "npm.cmd" : "npm";
-const child = spawn(npmBin, ["run", "test:gui", "-w", "@harness-anything/gui"], {
+const npmCli = resolveNpmCli();
+const child = npmCli
+  ? spawn(process.execPath, [npmCli, "run", "test:gui", "-w", "@harness-anything/gui"], {
+    cwd: repoRoot,
+    stdio: "inherit"
+  })
+  : spawn("npm", ["run", "test:gui", "-w", "@harness-anything/gui"], {
   cwd: repoRoot,
   stdio: "inherit"
 });
@@ -54,3 +60,11 @@ child.on("close", (code, signal) => {
   }
   process.exit(code ?? 1);
 });
+
+function resolveNpmCli() {
+  if (process.env.npm_execpath && existsSync(process.env.npm_execpath)) {
+    return process.env.npm_execpath;
+  }
+  const candidate = resolve(process.execPath, "..", "node_modules", "npm", "bin", "npm-cli.js");
+  return existsSync(candidate) ? candidate : undefined;
+}

--- a/tools/smoke-cli-package.mjs
+++ b/tools/smoke-cli-package.mjs
@@ -34,9 +34,9 @@ export function runCliPackageSmoke(root = process.cwd()) {
       stdio: "inherit"
     });
 
-    const binPath = path.join(consumerDir, "node_modules/.bin/harness-anything");
-    const aliasBinPath = path.join(consumerDir, "node_modules/.bin/ha");
-    const stdout = execFileSync(binPath, ["--json", "gui"], {
+    const binPath = resolveBinCommand(consumerDir, "harness-anything");
+    const aliasBinPath = resolveBinCommand(consumerDir, "ha");
+    const stdout = execFileSync(binPath.file, [...binPath.argsPrefix, "--json", "gui"], {
       cwd: consumerDir,
       encoding: "utf8",
       env: {
@@ -48,7 +48,7 @@ export function runCliPackageSmoke(root = process.cwd()) {
     if (result.ok !== true || result.command !== "gui" || result.launchPlan?.packageName !== "@harness-anything/gui") {
       throw new Error(`unexpected CLI smoke output: ${stdout}`);
     }
-    const aliasOutput = execFileSync(aliasBinPath, ["--json", "doctor"], {
+    const aliasOutput = execFileSync(aliasBinPath.file, [...aliasBinPath.argsPrefix, "--json", "doctor"], {
       cwd: consumerDir,
       encoding: "utf8"
     });
@@ -112,8 +112,24 @@ export function buildCliPackageArtifact(root, options = {}) {
   }
 }
 
-function runJson(binPath, args, cwd) {
-  return unwrapReceipt(JSON.parse(execFileSync(binPath, args, { cwd, encoding: "utf8" })));
+function runJson(command, args, cwd) {
+  return unwrapReceipt(JSON.parse(execFileSync(command.file, [...command.argsPrefix, ...args], { cwd, encoding: "utf8" })));
+}
+
+function resolveBinCommand(consumerDir, name) {
+  const packageEntry = path.join(consumerDir, "node_modules", "@harness-anything", "cli", "dist", "cli", "src", "index.js");
+  if (process.platform === "win32" && existsSync(packageEntry)) {
+    return { file: process.execPath, argsPrefix: [packageEntry] };
+  }
+  const binRoot = path.join(consumerDir, "node_modules", ".bin");
+  const candidates = process.platform === "win32"
+    ? [`${name}.cmd`, `${name}.ps1`, name]
+    : [name];
+  for (const candidate of candidates) {
+    const binPath = path.join(binRoot, candidate);
+    if (existsSync(binPath)) return { file: binPath, argsPrefix: [] };
+  }
+  return { file: path.join(binRoot, name), argsPrefix: [] };
 }
 
 function unwrapReceipt(value) {


### PR DESCRIPTION
## Summary
- Harden Windows path handling for script scope glob expansion, git diff evidence, private boundary checks, runtime release text checks, GUI test npm invocation, and CLI package smoke bin execution.
- Make Windows-specific filesystem behavior explicit in tests for symlink permissions, executable bits, root path assertions, and environment allowlists.
- Ensure hard-deleted task packages and ignored explicit harness paths are staged correctly by the write journal git commit path.

## Verification
- `npm install` in clean worktree `D:\IdeaProjects\harness-research-pr-clean`
- `npm run check:pr` in clean worktree passed through typecheck, lint, fast/contract/integration/GUI tests, and harness gates.
- `npm run harness:smoke-legacy-intake` passed.
- `npm run harness:smoke-cli-package` passed.

Note: the original working tree contains local untracked directories `.idea/` and `AI-KTY-WEB-copy/`. Running broad checks from that dirty tree fails because `eslint .` and legacy-intake scanning include `AI-KTY-WEB-copy/`; the clean worktree verification avoids that local-only pollution.