### PR TITLE
fix: enforce E79 delete containment semantics

### DIFF
--- a/packages/cli/src/cli/command-registry.ts
+++ b/packages/cli/src/cli/command-registry.ts
@@ -319,7 +319,7 @@ const commandSummaries = {
   "progress-append": "Append the provided text as-is to a task package, with optional evidence; no Markdown formatting or normalization is applied.",
   "task-archive": "Archive a task package while preserving its audit trail.",
   "task-supersede": "Archive old work and optionally create or link replacement work.",
-  "task-delete": "Soft-delete or guarded hard-delete a task package.",
+  "task-delete": "Soft-delete or guarded hard-delete a task package. E79 makes hard delete rare: anchored facts or incoming relations block it; use task archive after distilling evidence into an anchor task.",
   "task-reopen": "Reopen a non-terminal archived or tombstoned task package.",
   "task-review": "Evaluate the review gate for a task package.",
   "task-complete": "Evaluate the completion gate after CI has passed or failed. To make closeoutReadiness ready/passed, run task transition <id> in_review, replace closeout.md placeholder content, record a real fact, run task review, then run task complete --ci passed.",

--- a/packages/cli/src/commands/core/capabilities.ts
+++ b/packages/cli/src/commands/core/capabilities.ts
@@ -116,6 +116,12 @@ function descriptionForEntity(kind: string): string {
 
 function dispositionForEntity(kind: string): ReadonlyArray<Record<string, unknown>> {
   if (kind === "decision") return [{ level: "D1", name: "semantic-retire", commands: ["ha decision retire <id>"], soTCheckRequired: true }];
-  if (kind === "task") return [{ level: "D1", name: "archive-or-delete", commands: ["ha task archive <id>", "ha task delete --soft <id>"], soTCheckRequired: true }];
+  if (kind === "task") return [{
+    level: "D2",
+    name: "archive",
+    commands: ["ha task archive <id> --reason <reason>"],
+    soTCheckRequired: true,
+    description: "E79 daily containment path: distill evidence into an anchor task, reconnect relations, then archive the original task. Hard delete is blocked when anchored facts or active incoming relations exist."
+  }];
   return [];
 }

--- a/packages/cli/test/task-delete-disposition-cli.test.ts
+++ b/packages/cli/test/task-delete-disposition-cli.test.ts
@@ -47,13 +47,41 @@ test("CLI task delete hard path is guarded by F5 disposition semantics", () => {
     assert.equal(terminalFailure.ok, false);
     assert.equal(terminalFailure.error?.code, "terminal_hard_delete_forbidden");
 
+    const anchored = runJson(rootDir, ["new-task", "--title", "Anchored Fact Delete"]);
+    const anchoredTaskId = assertGeneratedTaskId(anchored.taskId);
+    const anchoredPackagePath = path.join(rootDir, `harness/tasks/${anchoredTaskId}-anchored-fact-delete`);
+    runJson(rootDir, [
+      "fact",
+      "record",
+      "--task",
+      anchoredTaskId,
+      "--statement",
+      "Anchored fact must survive stage containment.",
+      "--source",
+      "delete semantics test",
+      "--confidence",
+      "high"
+    ]);
+    const anchoredFailure = runJson(rootDir, ["task", "delete", "--hard", anchoredTaskId, "--reason", "remove", "--confirm", anchoredTaskId], false);
+    assert.equal(anchoredFailure.ok, false);
+    assert.equal(anchoredFailure.error?.code, "related_task_hard_delete_forbidden");
+    assert.match(anchoredFailure.error?.hint ?? "", /1 anchored fact\(s\) and 0 active incoming relation\(s\)/u);
+    assert.match(anchoredFailure.error?.hint ?? "", /distill evidence into an anchor task/u);
+    assert.match(anchoredFailure.error?.hint ?? "", /ha task archive/u);
+    assert.equal(existsSync(anchoredPackagePath), true);
+
+    const archivedAnchored = runJson(rootDir, ["task", "archive", anchoredTaskId, "--reason", "stage contained by anchor task"]);
+    assert.equal(archivedAnchored.ok, true);
+    assert.match(readFileSync(path.join(anchoredPackagePath, "INDEX.md"), "utf8"), /packageDisposition: archived/);
+
     const related = runJson(rootDir, ["new-task", "--title", "Related Delete"]);
     const relatedTaskId = assertGeneratedTaskId(related.taskId);
     writeDecisionRelation(rootDir, "dec_DELETE_BLOCKER", `task/${relatedTaskId}`, "active");
     const relatedFailure = runJson(rootDir, ["task", "delete", "--hard", relatedTaskId, "--reason", "remove", "--confirm", relatedTaskId], false);
     assert.equal(relatedFailure.ok, false);
     assert.equal(relatedFailure.error?.code, "related_task_hard_delete_forbidden");
-    assert.match(relatedFailure.error?.hint ?? "", /active incoming relation/u);
+    assert.match(relatedFailure.error?.hint ?? "", /0 anchored fact\(s\) and 1 active incoming relation\(s\)/u);
+    assert.match(relatedFailure.error?.hint ?? "", /ha task archive/u);
 
     const deprecated = runJson(rootDir, ["new-task", "--title", "Deprecated Relation Delete"]);
     const deprecatedTaskId = assertGeneratedTaskId(deprecated.taskId);

--- a/packages/kernel/src/entity/disposition.ts
+++ b/packages/kernel/src/entity/disposition.ts
@@ -1,7 +1,7 @@
 /** @slice-activation M5 F5 entity CRUD framework exposes disposition evaluation for application services and W7 cascade graph consumers. */
 import type { HarnessLayoutOverrides } from "../layout/index.ts";
 import { parseEntityRef } from "../domain/entity-ref.ts";
-import type { RelationGraphEdgeRow } from "../projection/relation-graph-projection.ts";
+import type { FactAnchorRow, RelationGraphEdgeRow } from "../projection/relation-graph-projection.ts";
 import { readRelationGraphProjection } from "../projection/sqlite-task-projection.ts";
 import { entityRegistry, type DispositionAction, type DispositionLevel, type KernelEntityKind } from "./registry.ts";
 
@@ -20,6 +20,7 @@ export interface EntityCascadeImpact {
   readonly entityRef: string;
   readonly incoming: ReadonlyArray<RelationGraphEdgeRow>;
   readonly outgoing: ReadonlyArray<RelationGraphEdgeRow>;
+  readonly anchoredFacts: ReadonlyArray<FactAnchorRow>;
   readonly impactedRefs: ReadonlyArray<string>;
 }
 
@@ -33,6 +34,7 @@ export interface EntityDispositionEvaluation {
   readonly writeOpKinds: ReadonlyArray<string>;
   readonly lowerBound: {
     readonly activeIncomingCount: number;
+    readonly activeAnchoredFactCount: number;
     readonly blocksDestructiveDisposition: boolean;
   };
   readonly cascade: EntityCascadeImpact;
@@ -54,20 +56,23 @@ export function evaluateEntityDisposition(request: EntityDispositionRequest): En
   const registration = entityRegistry[entityKind];
   const matrixEntry = registration.dispositionMatrix.entries[request.action];
   const graph = readRelationGraphProjection(request);
-  const cascade = cascadeImpactFromEdges(request.entityRef, graph.edges);
+  const cascade = cascadeImpactFromProjection(request.entityRef, graph.edges, graph.factAnchors);
   const destructive = matrixEntry.level === "D3" || matrixEntry.level === "D4";
-  const blockedByIncoming = destructive && cascade.incoming.length > 0;
+  const blockedByLowerBound = destructive && (cascade.incoming.length > 0 || cascade.anchoredFacts.length > 0);
   if (!matrixEntry.supported) {
     return evaluation(request.entityRef, entityKind, request.action, matrixEntry.level, false, matrixEntry.reason, matrixEntry.writeOpKinds, cascade);
   }
-  if (blockedByIncoming) {
+  if (blockedByLowerBound) {
     return evaluation(
       request.entityRef,
       entityKind,
       request.action,
       matrixEntry.level,
       false,
-      `${request.entityRef} has ${cascade.incoming.length} active incoming relation(s); D3/D4 disposition is blocked by the lower-bound rule`,
+      [
+        `${request.entityRef} has ${cascade.anchoredFacts.length} anchored fact(s) and ${cascade.incoming.length} active incoming relation(s); D3/D4 disposition is blocked by the lower-bound rule.`,
+        "E79 defines delete as stage containment: distill evidence into an anchor task, reconnect facts/decisions to that anchor, then run ha task archive <id> --reason <reason>; hard delete has no --cascade escape hatch."
+      ].join(" "),
       matrixEntry.writeOpKinds,
       cascade
     );
@@ -77,7 +82,7 @@ export function evaluateEntityDisposition(request: EntityDispositionRequest): En
 
 export function readEntityCascadeImpact(options: EntityDispositionOptions & { readonly entityRef: string }): EntityCascadeImpact {
   const projection = readRelationGraphProjection(options);
-  return cascadeImpactFromEdges(options.entityRef, projection.edges);
+  return cascadeImpactFromProjection(options.entityRef, projection.edges, projection.factAnchors);
 }
 
 export function evaluateImplicitDispositionRecommendations(
@@ -120,21 +125,39 @@ function evaluation(
     writeOpKinds,
     lowerBound: {
       activeIncomingCount: cascade.incoming.length,
-      blocksDestructiveDisposition: cascade.incoming.length > 0
+      activeAnchoredFactCount: cascade.anchoredFacts.length,
+      blocksDestructiveDisposition: cascade.incoming.length > 0 || cascade.anchoredFacts.length > 0
     },
     cascade
   };
 }
 
-function cascadeImpactFromEdges(entityRef: string, edges: ReadonlyArray<RelationGraphEdgeRow>): EntityCascadeImpact {
+function cascadeImpactFromProjection(
+  entityRef: string,
+  edges: ReadonlyArray<RelationGraphEdgeRow>,
+  factAnchors: ReadonlyArray<FactAnchorRow>
+): EntityCascadeImpact {
   const incoming = activeSorted(edges.filter((edge) => edgeHasIncomingToEntity(edge, entityRef)));
   const outgoing = activeSorted(edges.filter((edge) => edgeHasOutgoingFromEntity(edge, entityRef)));
+  const anchoredFacts = activeAnchoredFacts(entityRef, factAnchors);
   return {
     entityRef,
     incoming,
     outgoing,
-    impactedRefs: uniqueSorted([...incoming, ...outgoing].flatMap((edge) => otherEndpointRefs(edge, entityRef)))
+    anchoredFacts,
+    impactedRefs: uniqueSorted([
+      ...anchoredFacts.map((fact) => fact.factRef),
+      ...[...incoming, ...outgoing].flatMap((edge) => otherEndpointRefs(edge, entityRef))
+    ])
   };
+}
+
+function activeAnchoredFacts(entityRef: string, factAnchors: ReadonlyArray<FactAnchorRow>): ReadonlyArray<FactAnchorRow> {
+  const entity = parseEntityRef(entityRef);
+  if (!entity || entity.externalHarness || entity.kind !== "task") return [];
+  return factAnchors
+    .filter((fact) => fact.taskId === entity.id)
+    .sort((left, right) => left.factRef.localeCompare(right.factRef));
 }
 
 function activeSorted(edges: ReadonlyArray<RelationGraphEdgeRow>): ReadonlyArray<RelationGraphEdgeRow> {

--- a/packages/kernel/src/projection/relation-graph-projection.ts
+++ b/packages/kernel/src/projection/relation-graph-projection.ts
@@ -31,9 +31,17 @@ export interface RelationCoverageRow {
   readonly relationPath: ReadonlyArray<string>;
 }
 
+export interface FactAnchorRow {
+  readonly factRef: string;
+  readonly taskId: string;
+  readonly factId: string;
+  readonly sourcePath: string;
+}
+
 export interface RelationGraphProjection {
   readonly edges: ReadonlyArray<RelationGraphEdgeRow>;
   readonly coverageRows: ReadonlyArray<RelationCoverageRow>;
+  readonly factAnchors: ReadonlyArray<FactAnchorRow>;
 }
 
 interface DecisionSource {
@@ -49,6 +57,7 @@ interface GraphRefIndex {
   readonly decisionIds: ReadonlySet<string>;
   readonly decisionAnchors: ReadonlySet<string>;
   readonly factRefs: ReadonlySet<string>;
+  readonly factAnchors: ReadonlyArray<FactAnchorRow>;
 }
 
 export interface RelationRecordEntry {
@@ -79,7 +88,8 @@ export function buildRelationGraphProjection(rootInput: HarnessLayoutInput): Rel
   const edges = relationEntriesToEdges(entries, refIndex);
   return {
     edges,
-    coverageRows: buildCoverageRows(decisions.filter((decision) => decision.visible), edges, refIndex)
+    coverageRows: buildCoverageRows(decisions.filter((decision) => decision.visible), edges, refIndex),
+    factAnchors: refIndex.factAnchors
   };
 }
 
@@ -400,13 +410,21 @@ function buildGraphRefIndex(rootInput: HarnessLayoutInput, decisions: ReadonlyAr
   const layout = resolveHarnessLayout(rootInput);
   const taskIds = new Set<string>();
   const factRefs = new Set<string>();
+  const factAnchors: FactAnchorRow[] = [];
   for (const taskDir of listTaskDirs(layout.tasksRoot)) {
     const taskId = readTaskPackageId(taskDir);
     taskIds.add(taskId);
     const factsPath = path.join(taskDir, layout.factDocumentName);
     if (!existsSync(factsPath)) continue;
     for (const record of parseFactFlowRecords(readFileSync(factsPath, "utf8"))) {
-      factRefs.add(`${taskId}/${record.fact_id}`);
+      const factKey = `${taskId}/${record.fact_id}`;
+      factRefs.add(factKey);
+      factAnchors.push({
+        factRef: `fact/${factKey}`,
+        taskId,
+        factId: record.fact_id,
+        sourcePath: sourcePath(layout.rootDir, factsPath)
+      });
     }
   }
 
@@ -419,7 +437,7 @@ function buildGraphRefIndex(rootInput: HarnessLayoutInput, decisions: ReadonlyAr
       decisionAnchors.add(`${decision.decisionId}/${anchor}`);
     }
   }
-  return { taskIds, decisionIds, decisionAnchors, factRefs };
+  return { taskIds, decisionIds, decisionAnchors, factRefs, factAnchors: factAnchors.sort((a, b) => a.factRef.localeCompare(b.factRef)) };
 }
 
 function isKnownLocalEndpoint(refText: string, refIndex: GraphRefIndex): boolean {

--- a/packages/kernel/src/projection/sqlite-projection-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-store.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { SqlClient } from "@effect/sql";
 import { SqliteClient } from "@effect/sql-sqlite-node";
 import { Effect } from "effect";
-import type { RelationCoverageRow, RelationGraphEdgeRow } from "./relation-graph-projection.ts";
+import type { FactAnchorRow, RelationCoverageRow, RelationGraphEdgeRow } from "./relation-graph-projection.ts";
 import type {
   DecisionProjectionQueryFilters,
   DecisionProjectionRow,
@@ -17,6 +17,7 @@ const projectionVersion = "entity-projection/d4-v1";
 export interface ProjectionGraphRows {
   readonly relationEdges: ReadonlyArray<RelationGraphEdgeRow>;
   readonly coverageRows: ReadonlyArray<RelationCoverageRow>;
+  readonly factAnchors: ReadonlyArray<FactAnchorRow>;
 }
 
 export function writeProjectionDatabase(
@@ -24,7 +25,7 @@ export function writeProjectionDatabase(
   rows: ReadonlyArray<TaskProjectionRow>,
   decisionRows: ReadonlyArray<DecisionProjectionRow>,
   meta: ProjectionMeta,
-  graphRows: ProjectionGraphRows = { relationEdges: [], coverageRows: [] }
+  graphRows: ProjectionGraphRows = { relationEdges: [], coverageRows: [], factAnchors: [] }
 ): void {
   mkdirSync(path.dirname(projectionPath), { recursive: true });
   const tempPath = `${projectionPath}.${process.pid}.${Date.now()}.tmp`;
@@ -92,6 +93,15 @@ export function writeProjectionDatabase(
         row_json TEXT NOT NULL
       )
     `;
+    yield* sql`
+      CREATE TABLE task_fact_anchors (
+        fact_ref TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        fact_id TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        row_json TEXT NOT NULL
+      )
+    `;
     yield* insertMeta(sql, "version", projectionVersion);
     yield* insertMeta(sql, "sourceHash", meta.sourceHash);
     yield* insertMeta(sql, "rowsHash", meta.rowsHash);
@@ -100,6 +110,7 @@ export function writeProjectionDatabase(
     for (const row of decisionRows) yield* insertDecisionRow(sql, row);
     for (const edge of graphRows.relationEdges) yield* insertRelationEdge(sql, edge);
     for (const row of graphRows.coverageRows) yield* insertCoverageRow(sql, row);
+    for (const row of graphRows.factAnchors) yield* insertFactAnchor(sql, row);
     yield* sql`CREATE INDEX task_projection_status ON task_projection (canonical_status, coordination_status)`;
     yield* sql`CREATE INDEX task_projection_module_key ON task_projection (module_key)`;
     yield* sql`CREATE INDEX decision_projection_legacy_number ON decision_projection (legacy_number)`;
@@ -107,6 +118,7 @@ export function writeProjectionDatabase(
     yield* sql`CREATE INDEX relation_edges_source_ref ON relation_edges (source_ref)`;
     yield* sql`CREATE INDEX relation_edges_target_ref ON relation_edges (target_ref)`;
     yield* sql`CREATE INDEX relation_coverage_decision_ref ON relation_coverage (decision_ref)`;
+    yield* sql`CREATE INDEX task_fact_anchors_task_id ON task_fact_anchors (task_id)`;
   }));
   renameSync(tempPath, projectionPath);
 }
@@ -147,9 +159,11 @@ export function readRelationGraphRows(projectionPath: string): ProjectionGraphRo
     const sql = yield* SqlClient.SqlClient;
     const edgeRecords = yield* sql`SELECT row_json FROM relation_edges ORDER BY source_ref, target_ref, relation_id`;
     const coverageRecords = yield* sql`SELECT row_json FROM relation_coverage ORDER BY claim_ref`;
+    const factAnchorRecords = yield* sql`SELECT row_json FROM task_fact_anchors ORDER BY fact_ref`;
     return {
       relationEdges: edgeRecords.map((record) => JSON.parse(String(record.row_json)) as RelationGraphEdgeRow),
-      coverageRows: coverageRecords.map((record) => JSON.parse(String(record.row_json)) as RelationCoverageRow)
+      coverageRows: coverageRecords.map((record) => JSON.parse(String(record.row_json)) as RelationCoverageRow),
+      factAnchors: factAnchorRecords.map((record) => JSON.parse(String(record.row_json)) as FactAnchorRow)
     };
   }));
 }
@@ -226,6 +240,13 @@ function insertCoverageRow(sql: SqlClient.SqlClient, row: RelationCoverageRow): 
   return sql`
     INSERT OR REPLACE INTO relation_coverage (claim_ref, decision_ref, status, covering_fact_ref, row_json)
     VALUES (${row.claimRef}, ${row.decisionRef}, ${row.status}, ${row.coveringFactRef ?? null}, ${JSON.stringify(row)})
+  `;
+}
+
+function insertFactAnchor(sql: SqlClient.SqlClient, row: FactAnchorRow): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT OR REPLACE INTO task_fact_anchors (fact_ref, task_id, fact_id, source_path, row_json)
+    VALUES (${row.factRef}, ${row.taskId}, ${row.factId}, ${row.sourcePath}, ${JSON.stringify(row)})
   `;
 }
 

--- a/packages/kernel/src/projection/sqlite-task-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-projection.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { createHarnessRuntimeContext } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import { buildCheckReport, hardFail, runPostMergeChecks, warning } from "./post-merge-checks.ts";
-import type { RelationCoverageRow, RelationGraphEdgeRow } from "./relation-graph-projection.ts";
+import type { FactAnchorRow, RelationCoverageRow, RelationGraphEdgeRow } from "./relation-graph-projection.ts";
 import { buildRelationGraphProjection } from "./relation-graph-projection.ts";
 import { queryDecisionProjectionRows, queryTaskProjectionRows, readRelationGraphRows, writeProjectionDatabase, tryReadProjectionDatabase } from "./sqlite-projection-store.ts";
 import { compareDecisionRows, hashDecisionProjectionRows, readDecisionProjectionRows } from "./sqlite-decision-source.ts";
@@ -57,7 +57,8 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
     decisionRowsHash
   }, {
     relationEdges: relationGraph.edges,
-    coverageRows: relationGraph.coverageRows
+    coverageRows: relationGraph.coverageRows,
+    factAnchors: relationGraph.factAnchors
   });
   return {
     rows,
@@ -169,6 +170,7 @@ export function queryDecisionProjection(options: TaskProjectionOptions & { reado
 export function readRelationGraphProjection(options: TaskProjectionOptions): {
   readonly edges: ReadonlyArray<RelationGraphEdgeRow>;
   readonly coverageRows: ReadonlyArray<RelationCoverageRow>;
+  readonly factAnchors: ReadonlyArray<FactAnchorRow>;
   readonly warnings: ProjectionReadResult["warnings"];
 } {
   const rootDir = path.resolve(options.rootDir);
@@ -180,6 +182,7 @@ export function readRelationGraphProjection(options: TaskProjectionOptions): {
     return {
       edges: graphRows.relationEdges,
       coverageRows: graphRows.coverageRows,
+      factAnchors: graphRows.factAnchors,
       warnings: taskProjection.warnings
     };
   } catch {
@@ -188,6 +191,7 @@ export function readRelationGraphProjection(options: TaskProjectionOptions): {
     return {
       edges: graphRows.relationEdges,
       coverageRows: graphRows.coverageRows,
+      factAnchors: graphRows.factAnchors,
       warnings: [...taskProjection.warnings, ...rebuilt.warnings]
     };
   }

--- a/packages/kernel/test/store/entity-disposition.test.ts
+++ b/packages/kernel/test/store/entity-disposition.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import {
+  evaluateEntityDisposition,
+  formatFactFlowRecord,
+  readEntityCascadeImpact
+} from "../../src/index.ts";
+import { withTempStore } from "./helpers.ts";
+
+test("entity disposition lower-bound blocks D3 and D4 when task owns anchored facts", () => {
+  withTempStore((rootDir) => {
+    writeIndex(rootDir, "task-fact-anchored", "Task Fact Anchored");
+    writeFacts(rootDir, "task-fact-anchored", [{
+      fact_id: "F-DEADBEEF",
+      statement: "This anchored fact makes hard delete unsafe.",
+      source: "test",
+      observedAt: "2026-07-04T00:00:00.000Z",
+      confidence: "high"
+    }]);
+
+    const hardDelete = evaluateEntityDisposition({
+      rootDir,
+      entityRef: "task/task-fact-anchored",
+      action: "hard-delete"
+    });
+    const tombstone = evaluateEntityDisposition({
+      rootDir,
+      entityRef: "task/task-fact-anchored",
+      action: "tombstone"
+    });
+    const archive = evaluateEntityDisposition({
+      rootDir,
+      entityRef: "task/task-fact-anchored",
+      action: "archive"
+    });
+    const impact = readEntityCascadeImpact({ rootDir, entityRef: "task/task-fact-anchored" });
+
+    assert.equal(hardDelete.allowed, false);
+    assert.equal(tombstone.allowed, false);
+    assert.equal(archive.allowed, true);
+    assert.equal(hardDelete.lowerBound.activeAnchoredFactCount, 1);
+    assert.equal(hardDelete.lowerBound.activeIncomingCount, 0);
+    assert.match(hardDelete.reason, /1 anchored fact\(s\) and 0 active incoming relation\(s\)/u);
+    assert.match(hardDelete.reason, /distill evidence into an anchor task/u);
+    assert.deepEqual(impact.anchoredFacts.map((fact) => fact.factRef), ["fact/task-fact-anchored/F-DEADBEEF"]);
+    assert.deepEqual(impact.impactedRefs, ["fact/task-fact-anchored/F-DEADBEEF"]);
+  });
+});
+
+function writeIndex(rootDir: string, taskId: string, title: string): void {
+  const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+  mkdirSync(taskRoot, { recursive: true });
+  writeFileSync(path.join(taskRoot, "INDEX.md"), [
+    "---",
+    "schema: task-package/v1",
+    `task_id: ${taskId}`,
+    `title: ${JSON.stringify(title)}`,
+    "status: in_progress",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "---",
+    "",
+    `# ${title}`,
+    ""
+  ].join("\n"));
+}
+
+function writeFacts(
+  rootDir: string,
+  taskId: string,
+  facts: ReadonlyArray<{
+    readonly fact_id: string;
+    readonly statement: string;
+    readonly source: string;
+    readonly observedAt: string;
+    readonly confidence: "low" | "medium" | "high";
+  }>
+): void {
+  const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+  mkdirSync(taskRoot, { recursive: true });
+  writeFileSync(path.join(taskRoot, "facts.md"), [
+    "# Facts",
+    "",
+    ...facts.map((fact) => formatFactFlowRecord({
+      ...fact,
+      memoryClass: "episodic",
+      memoryTags: [],
+      provenance: [{
+        runtime: "human",
+        sessionId: "human-cli-1783036800000",
+        boundAt: "2026-07-04T00:00:00.000Z"
+      }]
+    })),
+    ""
+  ].join("\n"));
+}

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -95,6 +95,39 @@ test("WriteCoordinator stages hard-deleted task packages and clears replay journ
   });
 });
 
+test("WriteCoordinator rejects hard delete for task packages with anchored facts", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    const taskDir = path.join(rootDir, "harness/tasks/task-anchored");
+    mkdirSync(taskDir, { recursive: true });
+    writeFileSync(path.join(taskDir, "INDEX.md"), indexBody("task-anchored", "Task Anchored", "planned"), "utf8");
+    writeFileSync(path.join(taskDir, "facts.md"), [
+      "# Facts",
+      "",
+      "- {fact_id: F-DEADBEEF, statement: \"Anchored fact blocks hard delete.\", source: \"test\", observedAt: \"2026-07-04T00:00:00.000Z\", confidence: high, memoryClass: episodic, memoryTags: [], provenance: [{runtime: \"human\", sessionId: \"human-cli-1783036800000\", boundAt: \"2026-07-04T00:00:00.000Z\"}]}",
+      ""
+    ].join("\n"), "utf8");
+    runGit(rootDir, "add", ".");
+    runGit(rootDir, "commit", "-m", "seed anchored task");
+
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+
+    assert.throws(
+      () => Effect.runSync(coordinator.enqueue({
+        opId: "op-hard-delete-anchored",
+        entityId: taskEntityId("task-anchored"),
+        kind: "package_delete_hard",
+        payload: {
+          reason: "mistaken anchored package"
+        }
+      })),
+      /1 anchored fact\(s\) and 0 active incoming relation\(s\).*ha task archive/u
+    );
+    assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
+    assert.equal(existsSync(taskDir), true);
+  });
+});
+
 test("WriteCoordinator force-adds explicit harness paths ignored by target repo patterns", () => {
   withTempStore((rootDir) => {
     initializeGitRepo(rootDir);

--- a/tools/graph-panorama.test.mjs
+++ b/tools/graph-panorama.test.mjs
@@ -65,6 +65,7 @@ function writeProjectionFixture(projectionPath) {
     db.exec([
       "CREATE TABLE relation_edges (relation_id TEXT PRIMARY KEY, source_ref TEXT NOT NULL, target_ref TEXT NOT NULL, relation_type TEXT NOT NULL, direction TEXT NOT NULL, state TEXT NOT NULL, row_json TEXT NOT NULL)",
       "CREATE TABLE relation_coverage (claim_ref TEXT PRIMARY KEY, decision_ref TEXT NOT NULL, status TEXT NOT NULL, covering_fact_ref TEXT, row_json TEXT NOT NULL)",
+      "CREATE TABLE task_fact_anchors (fact_ref TEXT PRIMARY KEY, task_id TEXT NOT NULL, fact_id TEXT NOT NULL, source_path TEXT NOT NULL, row_json TEXT NOT NULL)",
       "CREATE TABLE task_projection (task_id TEXT PRIMARY KEY, title TEXT NOT NULL, canonical_status TEXT NOT NULL)",
       "CREATE TABLE decision_projection (decision_id TEXT PRIMARY KEY, title TEXT NOT NULL, state TEXT NOT NULL)"
     ].join(";\n"));

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -108,6 +108,7 @@ export const testTierManifest = {
     "packages/cli/test/task-document-gates-cli.test.ts",
     "packages/cli/test/task-list-cli.test.ts",
     "packages/kernel/test/store/crash-before-watermark.test.ts",
+    "packages/kernel/test/store/entity-disposition.test.ts",
     "packages/kernel/test/store/global-committer-lock.test.ts",
     "packages/kernel/test/store/journal-idempotency.test.ts",
     "packages/kernel/test/store/payload-hash.test.ts",


### PR DESCRIPTION
# English

## Summary

Implements E79 delete semantics for the M5 exit blocker. Hard task deletion now fails closed when the task owns anchored facts as well as when it has active incoming relation edges, and the failure hint teaches the distill plus archive containment path instead of offering cascade deletion.

## What Changed

- Added task fact anchors to the relation graph projection and persisted them in the SQLite projection as `task_fact_anchors`.
- Updated `evaluateEntityDisposition` and `readEntityCascadeImpact` to consume projected fact anchors, include them in cascade impact, and block D3/D4 destructive disposition when anchored facts exist.
- Kept archive as the supported daily D2 path and updated CLI summary/capabilities text to make the E79 containment route discoverable.
- Added CLI and WriteCoordinator coverage proving hard delete is blocked for anchored facts, inbound relation blocking still works, archive succeeds, and decision/fact disposition rules do not regress.

## Task And Scope

- Harness task: `task_01KWMC7H04ZRY0VZ5MRR6M4XVQ`
- Branch: `m5-exit-2b`
- Public scope: kernel disposition/projection, local delete guard consumers, CLI discoverability text, and tests.
- Private planning/evidence updated: yes, progress was appended and fact `fact/task_01KWMC7H04ZRY0VZ5MRR6M4XVQ/F-ZNBPSRSM` was recorded.
- Out of scope: no cascade delete, no real harness task deletion/archive, no changes to public docs or template assets.

## Version Impact

- Version: no version change because this is an exit remediation before public release.
- Publish impact: no publish; publish readiness only.

## Verification

- Base `origin/main` SHA: `efa0f7ff85a275a29417237a2c97b10e3b8b48a9`
- Branch merge-base with `origin/main`: `efa0f7ff85a275a29417237a2c97b10e3b8b48a9`
- Last `git fetch origin` time: `2026-07-04T10:07:49Z`
- Sync method: none needed, branch head was already based on latest fetched `origin/main`.
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: M5 parent task progress plus fact `fact/task_01KWMC7H04ZRY0VZ5MRR6M4XVQ/F-ZNBPSRSM`
- Reviewer evidence path: self-review only; CEO review pending.
- GitHub Actions `rewrite-ci` run URL: pending after PR creation.
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci`, because the worktree used the repository lockfile with `npm install` to satisfy workspace GUI dev dependencies before the full local gate.

## Review Evidence

- Self-review: inspected public diff and reran targeted E79 tests plus full `npm run check`.
- Reviewer subagent: not used.
- Human review: pending CEO review.
- Blocking findings: none known; CI is pending.

## Residual Risk

- The projection now contains a new `task_fact_anchors` table. Existing stale projection databases rebuild through the existing projection read path when the schema read fails, and tests cover the real CLI delete path.
- The implementation treats every real task-local `F-` fact as an active anchored fact because facts are append-only; invalidation changes fact truth value but does not remove the task anchor.

## References

- Task: `task_01KWMC7H04ZRY0VZ5MRR6M4XVQ`
- Evidence: `fact/task_01KWMC7H04ZRY0VZ5MRR6M4XVQ/F-ZNBPSRSM`, `npm run check`
- Review: E79 `dec_M5_E79_DELETE_SEMANTICS`

---

# 中文

## 概要

落实 E79 的 delete 语义，修复 M5 exit blocker。task hard-delete 现在不仅看活跃入边，也会看 task 自身 facts.md 里的锚定事实；存在锚 fact 或入边时 fail-closed，并在错误提示里教 agent 走 distill + archive 的阶段收纳路径，不提供 cascade 删除逃生口。

## 改动内容

- relation graph 投影新增 task fact anchor，并持久化到 SQLite `task_fact_anchors` 表。
- `evaluateEntityDisposition` / `readEntityCascadeImpact` 消费投影里的 fact anchor，把锚 fact 纳入级联影响和 D3/D4 lower-bound 阻断。
- 保持 archive 作为日常 D2 路径，并更新 CLI summary / capabilities，让 E79 收纳路径可发现。
- 增加 CLI 与 WriteCoordinator 覆盖：锚 fact 阻断 hard-delete、入边阻断不回归、archive 对同 fixture 放行、decision / fact 处置矩阵不回归。

## 任务与范围

- Harness 任务：`task_01KWMC7H04ZRY0VZ5MRR6M4XVQ`
- 分支：`m5-exit-2b`
- 公开范围：kernel disposition/projection、本地 delete guard 消费点、CLI 可发现文案、测试。
- 私有计划 / 证据是否已更新：yes，已追加 M5 父任务 progress，并记录 fact `fact/task_01KWMC7H04ZRY0VZ5MRR6M4XVQ/F-ZNBPSRSM`。
- 范围外：不做 cascade delete，不对真实 harness task 做删除/归档，不改公开文档或模板资产。

## 版本影响

- 版本：不改版本，原因是这是公开发布前的 exit remediation。
- 发布影响：不发布，只做发布准备。

## 验证

- `origin/main` 基准 SHA：`efa0f7ff85a275a29417237a2c97b10e3b8b48a9`
- 当前分支与 `origin/main` 的 merge-base：`efa0f7ff85a275a29417237a2c97b10e3b8b48a9`
- 最近一次 `git fetch origin` 时间：`2026-07-04T10:07:49Z`
- 同步方式：不需要，分支 head 已基于最新 fetch 到的 `origin/main`。
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：M5 父任务 progress 与 fact `fact/task_01KWMC7H04ZRY0VZ5MRR6M4XVQ/F-ZNBPSRSM`
- Reviewer 证据路径：仅自查；等待 CEO review。
- GitHub Actions `rewrite-ci` run URL：PR 创建后待运行。
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci`，本 worktree 使用仓库 lockfile 执行 `npm install` 补齐 workspace GUI dev 依赖后跑完整本地 gate。

## 审查证据

- 自查：检查 public diff，并重跑 E79 目标测试与完整 `npm run check`。
- Reviewer subagent：未使用。
- 人工审查：等待 CEO review。
- 阻塞发现：目前无已知阻塞；CI 待运行。

## 残余风险

- 投影新增 `task_fact_anchors` 表；旧缓存若缺表会通过既有读路径触发重建，真实 CLI delete 路径已有测试覆盖。
- 实现把 task-local 的真实 `F-` fact 都视为活跃锚 fact，因为 fact append-only；invalidation 改变事实真值，但不移除 task anchor。

## 关联材料

- 任务：`task_01KWMC7H04ZRY0VZ5MRR6M4XVQ`
- 证据：`fact/task_01KWMC7H04ZRY0VZ5MRR6M4XVQ/F-ZNBPSRSM`，`npm run check`
- 审查：E79 `dec_M5_E79_DELETE_SEMANTICS`

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
