### PR TITLE
chore: auto-rebuild CLI dist on commit and checkout via git hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "harness:check-legacy-intake-readiness": "node tools/check-legacy-intake-readiness.mjs",
     "harness:check-supply-chain": "node tools/check-supply-chain.mjs",
     "harness:smoke-legacy-intake": "node tools/smoke-legacy-intake.mjs",
-    "harness:smoke-cli-package": "node tools/smoke-cli-package.mjs"
+    "harness:smoke-cli-package": "node tools/smoke-cli-package.mjs",
+    "hooks:install": "git config core.hooksPath tools/git-hooks"
   },
   "engines": {
     "node": ">=24"

--- a/tools/git-hooks/post-checkout
+++ b/tools/git-hooks/post-checkout
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+set -eu
+
+# Installed by pointing git at this directory:
+#   git config core.hooksPath tools/git-hooks   (or: npm run hooks:install)
+#
+# Rebuilds CLI dist after a BRANCH checkout that changed CLI source or bundled
+# assets, so local `ha` reflects the branch you switched to.
+# Args (git-provided): $1 = previous HEAD, $2 = new HEAD, $3 = 1 for branch
+# checkout / 0 for file checkout.
+
+prev_head=$1
+new_head=$2
+branch_checkout=$3
+
+# Only branch checkouts matter; ignore per-file checkouts.
+[ "$branch_checkout" = "1" ] || exit 0
+# No-op when HEAD did not actually move.
+[ "$prev_head" != "$new_head" ] || exit 0
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+# Fresh clone / unborn prev ref: cannot diff, so rebuild conservatively.
+if ! git rev-parse --verify --quiet "$prev_head^{commit}" >/dev/null 2>&1; then
+  echo "post-checkout: initial checkout; rebuilding CLI conservatively."
+  npm run build -w @harness-anything/cli
+  exit 0
+fi
+
+changed_paths=$(git diff --name-only "$prev_head" "$new_head" -- \
+  package-lock.json \
+  package.json \
+  packages/cli/package.json \
+  packages/cli/tsconfig.build.json \
+  packages/cli/scripts/copy-assets.mjs \
+  packages/cli/src)
+
+if [ -z "$changed_paths" ]; then
+  echo "post-checkout: no CLI source or asset changes; skipping CLI build."
+  exit 0
+fi
+
+echo "post-checkout: CLI source or assets changed; rebuilding @harness-anything/cli."
+npm run build -w @harness-anything/cli

--- a/tools/git-hooks/post-commit
+++ b/tools/git-hooks/post-commit
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+set -eu
+
+# Installed by pointing git at this directory:
+#   git config core.hooksPath tools/git-hooks   (or: npm run hooks:install)
+#
+# Keeps the workspace CLI dist fresh after LOCAL commits that changed CLI source
+# or bundled assets, so local `ha` shims that point at dist do not go stale.
+# post-commit cannot abort the commit; a failed build only prints, never blocks.
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+# Merge commits are handled by post-merge; skip here to avoid a double build.
+if git rev-parse --verify --quiet HEAD^2 >/dev/null 2>&1; then
+  exit 0
+fi
+
+parent=$(git rev-parse --verify --quiet HEAD~1 || true)
+if [ -z "$parent" ]; then
+  echo "post-commit: root commit; rebuilding CLI conservatively."
+  npm run build -w @harness-anything/cli
+  exit 0
+fi
+
+changed_paths=$(git diff --name-only "$parent" HEAD -- \
+  package-lock.json \
+  package.json \
+  packages/cli/package.json \
+  packages/cli/tsconfig.build.json \
+  packages/cli/scripts/copy-assets.mjs \
+  packages/cli/src)
+
+if [ -z "$changed_paths" ]; then
+  echo "post-commit: no CLI source or asset changes; skipping CLI build."
+  exit 0
+fi
+
+echo "post-commit: CLI source or assets changed; rebuilding @harness-anything/cli."
+npm run build -w @harness-anything/cli

--- a/tools/git-hooks/post-merge
+++ b/tools/git-hooks/post-merge
@@ -1,9 +1,8 @@
 #!/usr/bin/env sh
 set -eu
 
-# Install from repo root:
-#   mkdir -p "$(dirname "$(git rev-parse --git-path hooks/post-merge)")"
-#   ln -sf "$(pwd)/tools/git-hooks/post-merge" "$(git rev-parse --git-path hooks/post-merge)"
+# Installed by pointing git at this directory:
+#   git config core.hooksPath tools/git-hooks   (or: npm run hooks:install)
 #
 # Keeps the workspace CLI dist fresh after merges that changed CLI source or
 # bundled assets, so local `ha` shims that point at dist do not go stale.


### PR DESCRIPTION
# English

## What
Add `post-commit` and `post-checkout` git hooks that keep the locally
`npm link`-ed `ha` CLI fresh by rebuilding `@harness-anything/cli` dist
whenever a commit or branch checkout touches CLI source or bundled assets.
They mirror the existing `post-merge` hook's change-detection, so a build
only runs when it is actually needed.

## Why
The global `ha` shim resolves through the workspace `dist`, so local commits
and branch switches could otherwise leave it stale until the next merge.
`post-commit` skips merge commits (already handled by `post-merge`) to avoid
double builds; `post-checkout` reacts only to branch checkouts, not file
checkouts.

## How
Switch to `core.hooksPath=tools/git-hooks` so every hook is versioned in one
place, and add `npm run hooks:install` to wire a fresh clone in one command.
The `post-commit` rebuild was exercised live by this very commit.

---

# 中文

## 做了什么
新增 `post-commit` 与 `post-checkout` 两个 git 钩子,让本地 `npm link` 的 `ha`
在提交或切分支动到 CLI 源码/资产时,自动重建 `@harness-anything/cli` 的 dist;
复用现有 `post-merge` 的变更检测,只在真正需要时才构建。

## 为什么
全局 `ha` shim 走 workspace 的 dist,本地提交和切分支本会让它停在旧版本,直到下次
合并才刷新。`post-commit` 跳过 merge 提交(已由 `post-merge` 处理)以避免双重构建;
`post-checkout` 只响应切分支、不管切单个文件。

## 怎么做
改用 `core.hooksPath=tools/git-hooks` 把所有钩子版本化统一管理,并加
`npm run hooks:install` 让新 clone 一键接入。本次提交已当场触发并验证 post-commit 构建。
