### PR TITLE
refactor: make sessions a base-level scaffold instead of vertical-gated

### DIFF
--- a/packages/cli/src/commands/extensions/assets/software-coding/vertical.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/vertical.json
@@ -139,10 +139,6 @@
       {
         "path": "{{paths.milestonesRoot}}",
         "create": "init"
-      },
-      {
-        "path": "{{paths.sessionsRoot}}",
-        "create": "lazy"
       }
     ],
     "seededDocs": [

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -19,7 +19,11 @@ export function initializeHarness(rootInput: HarnessLayoutInput, addNpmScripts =
     layout.cacheRoot,
     layout.writeJournalRoot,
     layout.payloadsRoot,
-    layout.locksRoot
+    layout.locksRoot,
+    // sessions is base infrastructure, not vertical-specific: every scenario gets it
+    // regardless of the active vertical, so it is created unconditionally here rather
+    // than via the vertical's repositoryScaffold.
+    layout.sessionsRoot
   ]) {
     mkdirSync(directory, { recursive: true });
   }

--- a/packages/cli/test/init-cli.test.ts
+++ b/packages/cli/test/init-cli.test.ts
@@ -18,7 +18,7 @@ test("CLI init defaults harness project name from the target root basename", () 
     assert.match(config, new RegExp(`^name: ${path.basename(rootDir)}$`, "m"));
     assert.equal(existsSync(path.join(rootDir, "harness/tasks")), true);
     assert.equal(existsSync(path.join(rootDir, "harness/decisions")), false);
-    assert.equal(existsSync(path.join(rootDir, "harness/sessions")), false);
+    assert.equal(existsSync(path.join(rootDir, "harness/sessions")), true);
     assert.equal(existsSync(path.join(rootDir, "harness/adr")), true);
     assert.equal(existsSync(path.join(rootDir, "harness/adr/README.md")), false);
     assert.match(readFileSync(path.join(rootDir, "harness/standards/repo-governance.md"), "utf8"), /Repository Governance/u);


### PR DESCRIPTION
# English

## Summary

Move `harness/sessions` creation from the `software/coding` vertical to the unconditional base scaffold in `init.ts`, so sessions is treated as essential base infrastructure that every scenario gets regardless of the active vertical.

## What Changed

- `packages/cli/src/commands/init.ts`: add `layout.sessionsRoot` to the unconditional base directory-creation block that runs on every `init`, with a comment explaining the base-vs-vertical rationale.
- `packages/cli/src/commands/extensions/assets/software-coding/vertical.json`: drop the `sessionsRoot` entry (previously `create: lazy`) from the vertical's `repositoryScaffold.dirs`.
- `packages/cli/test/init-cli.test.ts`: flip the assertion so `harness/sessions` now exists after init.

## Task And Scope

- Harness task: `task_01KWPQN2ARN1Z53AXMB4WB47NT` (derives from decision `dec_mr6g0cfi`, route A)
- Branch: `refactor/sessions-base-scaffold`
- Public scope: CLI init scaffold layer only (3 files)
- Private planning/evidence updated: yes (decision `dec_mr6g0cfi` accepted/active, task active, decision-derives-task relation recorded in the inner harness ledger)
- Out of scope: session read/write logic in application/CLI layers, kernel `sessionsRoot` path definition (already base-level, unchanged)

## Version Impact

- Version: no version change because this is a scaffold-layer behavior correction, not a published surface change.
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: `2f30672c2a79125dc7b2cde9c13fd3d5da526266`
- Branch merge-base with `origin/main`: `2f30672c2a79125dc7b2cde9c13fd3d5da526266` (branch is directly based on latest main)
- Last `git fetch origin` time: 2026-07-04, immediately before pushing this branch
- Sync method: none needed
- Public diff command: `git diff 2f30672...refactor/sessions-base-scaffold`
- Private evidence commit/path: inner harness ledger — `harness/decisions/decision-dec_mr6g0cfi/decision.md`, task `task_01KWPQN2ARN1Z53AXMB4WB47NT`
- Reviewer evidence path: pending human review
- GitHub Actions `rewrite-ci` run URL: pending (triggered by this PR)
- [ ] `npm ci`
- [x] `git diff --check` (clean)
- [ ] `npm run check`
- [x] `npm run typecheck` (passed)
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local gate suite — deferred to GitHub Actions `rewrite-ci`. Locally ran the affected tests `init-cli.test.ts` + `package-surface.test.ts` (8/8 pass) and `npm run typecheck` (pass).

## Review Evidence

- Self-review: done — confirmed no scaffold-contract snapshot enumerates `dirs` (package-surface only reads `seededDocs`), and empty committed `harness/sessions` matches the existing `adr`/`milestones` convention (no `.gitkeep` needed).
- Reviewer subagent: not run
- Human review: pending
- Blocking findings: none

## Residual Risk

- Low: `harness/sessions` is created empty at init; git does not track empty directories, identical to the existing `adr`/`milestones` behavior, so it materializes on first session write in a fresh clone.

## References

- Task: `task_01KWPQN2ARN1Z53AXMB4WB47NT`
- Evidence: decision `dec_mr6g0cfi` (accepted/active)
- Review: self-review recorded above

---

# 中文

## 概要

将 `harness/sessions` 的创建从 `software/coding` vertical 迁到 `init.ts` 的无条件 base scaffold，使 sessions 成为任何场景都具备的本质 base 基础设施，不再受当前 vertical 条件约束。

## 改动内容

- `packages/cli/src/commands/init.ts`：把 `layout.sessionsRoot` 加进每次 `init` 都执行的无条件 base 目录创建块，并加注释说明 base 与 vertical 的归属理由。
- `packages/cli/src/commands/extensions/assets/software-coding/vertical.json`：从 vertical 的 `repositoryScaffold.dirs` 中删除 `sessionsRoot` 条目（原为 `create: lazy`）。
- `packages/cli/test/init-cli.test.ts`：翻转断言，`harness/sessions` 现在 init 后即存在。

## 任务与范围

- Harness 任务：`task_01KWPQN2ARN1Z53AXMB4WB47NT`（派生自决策 `dec_mr6g0cfi`，路线 A）
- 分支：`refactor/sessions-base-scaffold`
- 公开范围：仅 CLI init scaffold 层（3 个文件）
- 私有计划 / 证据是否已更新：yes（决策 `dec_mr6g0cfi` 已 accept/active，task 已 active，decision-derives-task 关联已记录在内层 harness 账本）
- 范围外：application/CLI 层的 session 读写逻辑、kernel 的 `sessionsRoot` 路径定义（本就在 base 层，未改动）

## 版本影响

- 版本：不改版本，原因是这是 scaffold 层的行为修正，不涉及已发布表面变更。
- 发布影响：不发布

## 验证

- `origin/main` 基准 SHA：`2f30672c2a79125dc7b2cde9c13fd3d5da526266`
- 当前分支与 `origin/main` 的 merge-base：`2f30672c2a79125dc7b2cde9c13fd3d5da526266`（分支直接基于最新 main）
- 最近一次 `git fetch origin` 时间：2026-07-04，push 本分支前刚执行
- 同步方式：不需要
- 公开 diff 命令：`git diff 2f30672...refactor/sessions-base-scaffold`
- 私有证据 commit/path：内层 harness 账本 —— `harness/decisions/decision-dec_mr6g0cfi/decision.md`，task `task_01KWPQN2ARN1Z53AXMB4WB47NT`
- Reviewer 证据路径：待人工审查
- GitHub Actions `rewrite-ci` run URL：待生成（由本 PR 触发）
- [ ] `npm ci`
- [x] `git diff --check`（clean）
- [ ] `npm run check`
- [x] `npm run typecheck`（通过）
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：本地完整门禁套件 —— 延后到 GitHub Actions `rewrite-ci`。本地已跑受影响的 `init-cli.test.ts` + `package-surface.test.ts`（8/8 通过）与 `npm run typecheck`（通过）。

## 审查证据

- 自查：已完成 —— 确认没有 scaffold 契约快照枚举 `dirs`（package-surface 只读 `seededDocs`），且空提交目录 `harness/sessions` 与既有 `adr`/`milestones` 约定一致（无需 `.gitkeep`）。
- Reviewer subagent：未运行
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 低：`harness/sessions` 在 init 时创建为空目录；git 不追踪空目录，与既有 `adr`/`milestones` 行为一致，新克隆下会在首次写 session 时物化。

## 关联材料

- 任务：`task_01KWPQN2ARN1Z53AXMB4WB47NT`
- 证据：决策 `dec_mr6g0cfi`（accepted/active）
- 审查：见上方自查记录

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
