### PR TITLE
feat: decision to ADR render flow (ADR-0020 D4)

### DIFF
--- a/packages/cli/src/commands/extensions/assets/software-coding/scripts/adr-render.mjs
+++ b/packages/cli/src/commands/extensions/assets/software-coding/scripts/adr-render.mjs
@@ -1,0 +1,410 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const contextPath = process.env.HARNESS_SCRIPT_CONTEXT;
+const resultPath = process.env.HARNESS_SCRIPT_RESULT;
+if (!contextPath || !resultPath) {
+  throw new Error("script context and result paths are required");
+}
+
+const context = JSON.parse(readFileSync(contextPath, "utf8"));
+const decisionId = String(context.inputs?.decisionId ?? "").trim();
+if (!decisionId) {
+  fail("adr-render requires --input decisionId=<id>");
+}
+
+const decisionsRoot = context.paths.decisionsRoot;
+const adrRoot = context.paths.adrRoot;
+const decisionDocumentPath = path.join(decisionsRoot, `decision-${decisionId}`, "decision.md");
+if (!existsSync(decisionDocumentPath)) {
+  fail(`decision document not found for ${decisionId} at ${decisionDocumentPath}`);
+}
+
+const decision = readDecisionSourceFields(readFrontmatter(readFileSync(decisionDocumentPath, "utf8")));
+if (decision.decision_id && decision.decision_id !== decisionId) {
+  fail(`decision_id mismatch: input ${decisionId} vs frontmatter ${decision.decision_id}`);
+}
+
+const existingAdrs = listAdrFiles(adrRoot);
+const anchored = existingAdrs.find((entry) => machineAnchorDecisionId(entry.body) === decisionId);
+const adrNumber = anchored ? anchored.number : nextAdrNumber(existingAdrs);
+const slug = kebabCase(decision.title || decisionId);
+const adrFileName = anchored ? anchored.fileName : `ADR-${adrNumber}-${slug}.md`;
+const adrPath = path.join(adrRoot, adrFileName);
+
+const humanBlock = anchored ? extractHumanBlock(anchored.body) : defaultHumanBlock();
+const machineBlock = renderMachineBlock(decision, adrNumber);
+const rendered = `${machineBlock}\n\n${humanBlock}\n`;
+
+mkdirSync(adrRoot, { recursive: true });
+writeFileSync(adrPath, rendered, "utf8");
+
+writeFileSync(resultPath, JSON.stringify({
+  schema: "script-result/v1",
+  ok: true,
+  report: {
+    scriptId: context.scriptId,
+    source: context.source,
+    verticalId: context.verticalId,
+    decisionId,
+    adrNumber,
+    adrPath: path.relative(context.paths.rootDir, adrPath).split(path.sep).join("/"),
+    reused: Boolean(anchored),
+    watermark: decision._coordinatorWatermark ?? null
+  },
+  produced: [path.relative(context.paths.rootDir, adrPath).split(path.sep).join("/")]
+}, null, 2), "utf8");
+
+function fail(hint) {
+  const target = process.env.HARNESS_SCRIPT_RESULT;
+  if (target) {
+    writeFileSync(target, JSON.stringify({
+      schema: "script-result/v1",
+      ok: false,
+      report: { error: hint },
+      produced: []
+    }, null, 2), "utf8");
+  }
+  process.stderr.write(`${hint}\n`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Rendering (§1 field mapping, §3.2 sentinel partitions)
+// ---------------------------------------------------------------------------
+
+function renderMachineBlock(decision, adrNumber) {
+  const title = decision.title || decision.decision_id;
+  const watermark = decision._coordinatorWatermark
+    ? ` @ ${decision._coordinatorWatermark}`
+    : "";
+  const lines = [];
+  lines.push(`<!-- adr-render:begin machine (decision ${decision.decision_id}${watermark}) -->`);
+  lines.push(`# ADR-${adrNumber} · ${title}`);
+  lines.push("");
+  lines.push(...renderStatus(decision));
+  lines.push("");
+  lines.push(...renderContext(decision));
+  lines.push("");
+  lines.push(...renderDecision(decision));
+  lines.push("");
+  lines.push(...renderConsequences(decision));
+  const provenance = renderProvenance(decision);
+  if (provenance.length > 0) {
+    lines.push("");
+    lines.push(...provenance);
+  }
+  lines.push("<!-- adr-render:end machine -->");
+  return lines.join("\n");
+}
+
+function renderStatus(decision) {
+  const lines = ["## Status", ""];
+  lines.push(statusLine(decision));
+  lines.push("");
+  lines.push(`- Decision 锚：\`${decision.decision_id}\`（${decision.state}）`);
+  if (decision.arbiter && decision.arbiter.kind) {
+    lines.push(`- Arbiter：${decision.arbiter.kind}/${decision.arbiter.id ?? ""}`);
+  }
+  return lines;
+}
+
+function statusLine(decision) {
+  switch (decision.state) {
+    case "active":
+      return decision.decidedAt ? `Accepted ${decision.decidedAt}` : "Accepted";
+    case "proposed":
+      return "Proposed";
+    case "rejected":
+      return "Rejected";
+    case "deferred":
+      return "Deferred";
+    case "retired":
+    case "superseded":
+      return "Superseded";
+    default:
+      return decision.state || "Unknown";
+  }
+}
+
+function renderContext(decision) {
+  const lines = ["## Context", ""];
+  lines.push(`本 ADR 回答：${decision.question}`);
+  const scope = [];
+  if (decision.riskTier) scope.push(`riskTier=${decision.riskTier}`);
+  if (decision.urgency) scope.push(`urgency=${decision.urgency}`);
+  const modules = decision.applies_to?.modules ?? [];
+  if (modules.length > 0) scope.push(`modules=${modules.join(", ")}`);
+  if (scope.length > 0) {
+    lines.push("");
+    lines.push(`范围：${scope.join("；")}`);
+  }
+  return lines;
+}
+
+function renderDecision(decision) {
+  const lines = ["## Decision", ""];
+  for (const chosen of decision.chosen ?? []) {
+    lines.push(`### ${chosen.id} · ${chosen.text}`);
+    lines.push("");
+  }
+  const rejected = decision.rejected ?? [];
+  if (rejected.length > 0) {
+    lines.push("被否选项：");
+    lines.push("");
+    for (const entry of rejected) {
+      lines.push(`- ✗ ${entry.text} — 否决理由：${entry.why_not}`);
+    }
+  }
+  return trimTrailingBlank(lines);
+}
+
+function renderConsequences(decision) {
+  const lines = ["## Consequences", ""];
+  const claims = decision.claims ?? [];
+  for (const claim of claims) {
+    lines.push(`- ${claim.id}：${claim.text}`);
+  }
+  const relations = decision.relations ?? [];
+  if (relations.length > 0) {
+    lines.push("");
+    lines.push("关联：");
+    lines.push("");
+    for (const relation of relations) {
+      const rationale = relation.rationale ? `（${relation.rationale}）` : "";
+      lines.push(`- ${relation.type} → ${relation.target}${rationale}`);
+    }
+  }
+  return trimTrailingBlank(lines);
+}
+
+function renderProvenance(decision) {
+  const provenance = decision.provenance ?? [];
+  const proposedBy = decision.proposedBy;
+  if (provenance.length === 0 && !proposedBy) return [];
+  const first = provenance[0] ?? {};
+  const proposer = proposedBy ? `${proposedBy.id ?? proposedBy.kind ?? ""}` : "unknown";
+  const runtime = first.runtime ? `runtime=${first.runtime}` : "";
+  const session = first.sessionId ? `session=${first.sessionId}` : "";
+  const provenanceTail = [runtime, session].filter(Boolean).join("；");
+  const proposedAt = decision.proposedAt ? ` 于 ${decision.proposedAt}` : "";
+  const suffix = provenanceTail ? `；${provenanceTail}` : "";
+  return [`> 由 ${proposer}${proposedAt} propose${suffix}。`];
+}
+
+function defaultHumanBlock() {
+  return [
+    "<!-- adr-render:human -->",
+    "## Context（人工补充）",
+    "",
+    "此处人工补充：长文叙事、Refines/Supersedes 关系行、跨 ADR 论证。",
+    "机器段（上方 machine 区）每次重渲染整块覆盖，此人工区永久保留。"
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// ADR numbering & idempotency (§3.1)
+// ---------------------------------------------------------------------------
+
+function listAdrFiles(adrRoot) {
+  if (!existsSync(adrRoot)) return [];
+  return readdirSync(adrRoot, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => {
+      const number = adrNumberFromFileName(entry.name);
+      return number === undefined ? undefined : {
+        fileName: entry.name,
+        number,
+        body: readFileSync(path.join(adrRoot, entry.name), "utf8")
+      };
+    })
+    .filter((entry) => entry !== undefined);
+}
+
+function adrNumberFromFileName(fileName) {
+  const match = /^ADR-(\d{4})/u.exec(fileName) ?? /^(\d{4})-/u.exec(fileName);
+  return match ? match[1] : undefined;
+}
+
+function nextAdrNumber(existingAdrs) {
+  const max = existingAdrs.reduce((acc, entry) => Math.max(acc, Number(entry.number)), -1);
+  return String(max + 1).padStart(4, "0");
+}
+
+function machineAnchorDecisionId(body) {
+  const match = /<!--\s*adr-render:begin machine \(decision ([A-Za-z0-9_-]+)/u.exec(body);
+  return match ? match[1] : undefined;
+}
+
+function extractHumanBlock(body) {
+  const index = body.indexOf("<!-- adr-render:human -->");
+  if (index === -1) return defaultHumanBlock();
+  return body.slice(index).replace(/\n+$/u, "");
+}
+
+function kebabCase(value) {
+  return value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/gu, "")
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .slice(0, 60)
+    .replace(/-+$/u, "") || "decision";
+}
+
+function trimTrailingBlank(lines) {
+  const copy = [...lines];
+  while (copy.length > 0 && copy[copy.length - 1] === "") copy.pop();
+  return copy;
+}
+
+// ---------------------------------------------------------------------------
+// Inlined decision frontmatter parser (ported from sqlite-decision-source.ts)
+// Kept self-contained: sandboxed script cannot import kernel sources at runtime.
+// ---------------------------------------------------------------------------
+
+function readFrontmatter(body) {
+  const match = body.match(/^---\n([\s\S]*?)\n---/u);
+  return match ? match[1] : "";
+}
+
+function readDecisionSourceFields(frontmatter) {
+  return {
+    decision_id: readScalar(frontmatter, "decision_id"),
+    _coordinatorWatermark: optional(unquote(readScalar(frontmatter, "_coordinatorWatermark"))),
+    title: unquote(readScalar(frontmatter, "title")),
+    state: readScalar(frontmatter, "state") || "unknown",
+    riskTier: readScalar(frontmatter, "riskTier"),
+    urgency: readScalar(frontmatter, "urgency"),
+    applies_to: {
+      modules: parseStringArray(readBlockScalar(frontmatter, "applies_to", "modules")),
+      productLines: parseStringArray(readBlockScalar(frontmatter, "applies_to", "productLines"))
+    },
+    proposedBy: parseFlowObject(readScalar(frontmatter, "proposedBy")),
+    proposedAt: unquote(readScalar(frontmatter, "proposedAt")),
+    arbiter: parseFlowObject(readScalar(frontmatter, "arbiter")),
+    decidedAt: optional(unquote(readScalar(frontmatter, "decidedAt"))),
+    provenance: parseObjectList(frontmatter, "provenance"),
+    question: unquote(readScalar(frontmatter, "question")),
+    chosen: parseObjectList(frontmatter, "chosen"),
+    rejected: parseObjectList(frontmatter, "rejected"),
+    claims: parseObjectList(frontmatter, "claims"),
+    relations: parseObjectList(frontmatter, "relations")
+  };
+}
+
+function readScalar(frontmatter, key) {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  const match = frontmatter.match(new RegExp(`^${escaped}:[ \\t]*(.*)$`, "mu"));
+  return match ? match[1].trim() : "";
+}
+
+function readBlockScalar(frontmatter, blockName, key) {
+  return readIndentedBlock(frontmatter, blockName)
+    .find((line) => line.trimStart().startsWith(`${key}:`))
+    ?.replace(new RegExp(`^\\s*${key}:\\s*`, "u"), "")
+    .trim() ?? "[]";
+}
+
+function parseObjectList(frontmatter, key) {
+  const items = [];
+  let current = null;
+  for (const rawLine of readIndentedBlock(frontmatter, key)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith("- ")) {
+      if (current) items.push(current);
+      const body = line.slice(2).trim();
+      current = body.startsWith("{") ? parseFlowObject(body) : parseBlockObjectLine(body);
+      continue;
+    }
+    if (!current) continue;
+    for (const [entryKey, entryValue] of Object.entries(parseBlockObjectLine(line))) {
+      current[entryKey] = entryValue;
+    }
+  }
+  if (current) items.push(current);
+  return items;
+}
+
+function readIndentedBlock(frontmatter, key) {
+  const lines = frontmatter.split("\n");
+  const start = lines.findIndex((line) => line === `${key}:`);
+  if (start === -1) return [];
+  const block = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^[A-Za-z_][A-Za-z0-9_]*:/u.test(line)) break;
+    block.push(line);
+  }
+  return block;
+}
+
+function parseFlowObject(value) {
+  const body = value.trim().replace(/^\{\s*/u, "").replace(/\s*\}$/u, "");
+  const result = {};
+  for (const part of splitTopLevel(body)) {
+    const separator = part.indexOf(":");
+    if (separator === -1) continue;
+    const key = part.slice(0, separator).trim();
+    result[key] = parseDecisionScalar(part.slice(separator + 1).trim());
+  }
+  return result;
+}
+
+function parseBlockObjectLine(value) {
+  const separator = value.indexOf(":");
+  if (separator === -1) return {};
+  const key = value.slice(0, separator).trim();
+  return { [key]: parseDecisionScalar(value.slice(separator + 1).trim()) };
+}
+
+function parseDecisionScalar(value) {
+  if (value.startsWith("{")) return parseFlowObject(value);
+  if (value.startsWith("[")) return parseStringArray(value);
+  return unquote(value);
+}
+
+function splitTopLevel(value) {
+  const parts = [];
+  let depth = 0;
+  let inString = false;
+  let start = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    const previous = value[index - 1];
+    if (char === "\"" && previous !== "\\") inString = !inString;
+    if (!inString && (char === "{" || char === "[")) depth += 1;
+    if (!inString && (char === "}" || char === "]")) depth -= 1;
+    if (!inString && depth === 0 && char === ",") {
+      parts.push(value.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  const tail = value.slice(start).trim();
+  if (tail) parts.push(tail);
+  return parts;
+}
+
+function parseStringArray(value) {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.map((entry) => String(entry)) : [];
+  } catch {
+    return [];
+  }
+}
+
+function unquote(value) {
+  if (!value) return "";
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function optional(value) {
+  return value ? value : undefined;
+}

--- a/packages/cli/src/commands/extensions/assets/software-coding/vertical.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/vertical.json
@@ -261,6 +261,29 @@
           "{{paths.adrRoot}}/0000-template.md"
         ]
       }
+    },
+    {
+      "id": "vertical:software-coding:adr-render",
+      "type": "script",
+      "command": "scripts/adr-render.mjs",
+      "reads": [
+        "{{paths.decisionsRoot}}/**",
+        "{{paths.adrRoot}}/**"
+      ],
+      "writes": [
+        "{{paths.adrRoot}}/**"
+      ],
+      "inputs": {
+        "locale": "en-US"
+      },
+      "metadata": {
+        "description": "Render an ADR document from a decision entity (decision is SoT).",
+        "purpose": "generate",
+        "contractVersion": "script-entry/v1",
+        "produces": [
+          "{{paths.adrRoot}}/*.md"
+        ]
+      }
     }
   ],
   "templateSelections": [],

--- a/packages/cli/test/preset-script-cli.test.ts
+++ b/packages/cli/test/preset-script-cli.test.ts
@@ -124,6 +124,102 @@ test("CLI script command discovers and runs the vertical ADR seed scaffold", () 
   });
 });
 
+test("CLI script command renders an ADR from a decision entity, reuses the number, and preserves the human block", () => {
+  withTempRoot((rootDir) => {
+    writeDecisionFixture(rootDir, "dec_ADR_RENDER_FIXTURE");
+
+    const inspected = runJson(rootDir, ["script", "inspect", "vertical:software-coding:adr-render"]);
+    assert.equal(inspected.ok, true);
+    assert.equal(inspected.script.source, "vertical");
+    assert.equal(inspected.script.purpose, "generate");
+    assert.deepEqual(inspected.script.reads, ["{{paths.decisionsRoot}}/**", "{{paths.adrRoot}}/**"]);
+    assert.deepEqual(inspected.script.writes, ["{{paths.adrRoot}}/**"]);
+
+    const listed = runJson(rootDir, ["script", "list", "--source", "vertical", "--purpose", "generate"]);
+    assert.equal(listed.scripts.some((script: Record<string, unknown>) => script.id === "vertical:software-coding:adr-render"), true);
+
+    const result = runJson(rootDir, ["script", "run", "vertical:software-coding:adr-render", "--input", "decisionId=dec_ADR_RENDER_FIXTURE"]);
+    assert.equal(result.ok, true);
+    assert.equal(result.report.decisionId, "dec_ADR_RENDER_FIXTURE");
+    assert.equal(result.report.reused, false);
+    assert.equal(result.report.watermark, "wm-1");
+    const adrRelPath = result.report.adrPath as string;
+    assert.match(adrRelPath, /^harness\/adr\/ADR-0000-/u);
+
+    const adrPath = path.join(rootDir, adrRelPath);
+    const rendered = readFileSync(adrPath, "utf8");
+    // D8: never writes decisionsRoot; only adrRoot.
+    assert.equal(result.generated.every((filePath: string) => filePath.startsWith("harness/adr/")), true);
+    // Machine sentinel carries decision id + watermark.
+    assert.match(rendered, /<!-- adr-render:begin machine \(decision dec_ADR_RENDER_FIXTURE @ wm-1\) -->/u);
+    // Status ← state + decidedAt + decision anchor.
+    assert.match(rendered, /Accepted 2026-07-04T00:00:00\.000Z/u);
+    assert.match(rendered, /Decision 锚：`dec_ADR_RENDER_FIXTURE`（active）/u);
+    // Decision ← chosen + rejected.why_not.
+    assert.match(rendered, /### CH1 · chosen anchor text/u);
+    assert.match(rendered, /否决理由：rejected because drift/u);
+    // Consequences ← claims + relations.
+    assert.match(rendered, /- C1：claim anchor text/u);
+    assert.match(rendered, /derives → task\/task_FIXTURE/u);
+    // Human block present.
+    assert.match(rendered, /<!-- adr-render:human -->/u);
+
+    // Inject manual narrative, rerun: number reused, machine block byte-stable, human preserved.
+    const machineBefore = sliceMachineBlock(rendered);
+    writeFileSync(adrPath, rendered.replace("此处人工补充", "MANUAL-NARRATIVE-SENTINEL"), "utf8");
+    const rerun = runJson(rootDir, ["script", "run", "vertical:software-coding:adr-render", "--input", "decisionId=dec_ADR_RENDER_FIXTURE"]);
+    assert.equal(rerun.report.reused, true);
+    assert.equal((rerun.report.adrPath as string), adrRelPath);
+    const rerendered = readFileSync(adrPath, "utf8");
+    assert.equal(sliceMachineBlock(rerendered), machineBefore);
+    assert.match(rerendered, /MANUAL-NARRATIVE-SENTINEL/u);
+  });
+});
+
+function writeDecisionFixture(rootDir: string, decisionId: string): void {
+  writeFile(rootDir, `harness/decisions/decision-${decisionId}/decision.md`, [
+    "---",
+    "schema: decision-package/v1",
+    `decision_id: ${decisionId}`,
+    "_coordinatorWatermark: wm-1",
+    "title: \"Fixture decision for ADR render\"",
+    "state: active",
+    "riskTier: medium",
+    "urgency: medium",
+    "vertical: \"software/coding\"",
+    "preset: \"architecture-decision\"",
+    "applies_to:",
+    "  modules: []",
+    "  productLines: []",
+    "proposedBy: { kind: \"agent\", id: \"claude-opus\" }",
+    "proposedAt: \"2026-07-04T00:00:00.000Z\"",
+    "arbiter: { kind: \"human\", id: \"zeyuli\" }",
+    "decidedAt: \"2026-07-04T00:00:00.000Z\"",
+    "provenance:",
+    "  - { runtime: \"claude-code\", sessionId: \"session-fixture\", boundAt: \"2026-07-04T00:00:00.000Z\" }",
+    "question: \"what is the fixture question?\"",
+    "chosen:",
+    "  - { id: \"CH1\", text: \"chosen anchor text\" }",
+    "rejected:",
+    "  - { id: \"RJ1\", text: \"rejected anchor text\", why_not: \"rejected because drift\" }",
+    "claims:",
+    "  - { id: \"C1\", text: \"claim anchor text\" }",
+    "relations:",
+    "  - { relation_id: \"rel_0000000000000000\", source: \"decision/dec_ADR_RENDER_FIXTURE/CH1\", target: \"task/task_FIXTURE\", type: \"derives\", strength: \"strong\", direction: \"directed\", origin: \"declared\", rationale: \"fixture relation\", state: \"active\" }",
+    "---",
+    "",
+    "# Fixture decision for ADR render",
+    ""
+  ].join("\n"));
+}
+
+function sliceMachineBlock(body: string): string {
+  const begin = body.indexOf("<!-- adr-render:begin machine");
+  const endMarker = "<!-- adr-render:end machine -->";
+  const end = body.indexOf(endMarker);
+  return body.slice(begin, end + endMarker.length);
+}
+
 test("CLI script command runs with an explicit environment allowlist", () => {
   withTempRoot((rootDir) => {
     writeFile(rootDir, ".harness/presets/env-check/preset.json", JSON.stringify({


### PR DESCRIPTION
# English

## Summary

Add a `decision -> ADR` render flow so ADRs become a projection of decision entities rather than a hand-maintained parallel record. Implements ADR-0020 D4 via a D8 ScriptHost consumer script (kernel unchanged).

## What Changed

- New `adr-render.mjs` script under the `software-coding` vertical assets, isomorphic to `adr-seed.mjs`: reads `HARNESS_SCRIPT_CONTEXT` -> reads a decision -> fills an ADR template -> writes `adrRoot` -> emits `script-result/v1`.
- Register the script in `vertical.json` (`reads: [decisionsRoot/**, adrRoot/**]`, `writes: [adrRoot/**]`); invoke via `ha script run vertical:software-coding:adr-render --input decisionId=<id>`.
- Field-level mapping decision -> ADR (question -> Context, chosen/rejected -> Decision, claims/relations -> Consequences, state/decidedAt -> Status).
- Machine/human sentinel partitions: `<!-- adr-render:begin/end machine -->` is regenerated; the human region is preserved. Numbering is max+1 with idempotent number reuse for already-anchored ADRs.
- Integration tests in `preset-script-cli`.

## Task And Scope

- Harness task: `task_01KWPPYWS992PQJEZXK86BECEZ`
- Branch: `feat/adr-render-flow`
- Public scope: `packages/cli` (vertical script asset + registration + tests)
- Private planning/evidence updated: yes (harness task artifacts/plan/04)
- Out of scope: a freshness checker consuming the watermark (interface written, checker not built); backfilling render over all existing ADRs

## Version Impact

- Version: no version change (`0.0.0` workspaces)
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: `2f30672`
- Branch merge-base with `origin/main`: `2f30672`
- Sync method: none needed (branch cut from current `origin/main`)
- Public diff command: `git diff origin/main...feat/adr-render-flow`
- Dogfood: rendered `dec_ADR_DECISION_BOUNDARY` and verified the machine region is field-level consistent with hand-written ADR-0020 (human region divergence is by design); output written to a throwaway dir, never the live ADR root
- Local checks run in worktree: `npm run build -w @harness-anything/cli`; `preset-script-cli` 15/15, `package-surface` green; typecheck / lint / `check-template-command-surface` / `check-cli-structure` / `check-file-complexity` / `check-schema-field-coverage` exit 0
- D8 boundary verified: generated write scope is `adrRoot` only; `decisionsRoot` is in `forbiddenWriteRoots`
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- Not run locally in one pass: full `npm run check` — delegated to `rewrite-ci`.

## Review Evidence

- Self-review: subagent report + orchestrator verification of dogfood parity and D8 write-scope
- Human review: pending
- Blocking findings: none

## Residual Risk

- The script adds `adrRoot/**` to `reads` (beyond the plan's draft) so numbering/idempotency can scan existing ADRs; reads-only, write boundary unchanged.
- CJK titles kebab to ASCII-stripped slugs (e.g. `ADR-NNNN-decision-adr.md`); acceptable, revisit if slugs need CJK transliteration.

## References

- Task: `task_01KWPPYWS992PQJEZXK86BECEZ`
- Decision anchor: `dec_ADR_DECISION_BOUNDARY` (ADR-0020 D4)

---

# 中文

## 概要

新增 `decision -> ADR` 渲染流，让 ADR 成为 decision 实体的投影，而非手维护的平行账。以 D8 ScriptHost 消费者脚本落地 ADR-0020 D4（内核零改）。

## 改动内容

- 在 `software-coding` vertical assets 下新增 `adr-render.mjs`，与 `adr-seed.mjs` 同构：读 `HARNESS_SCRIPT_CONTEXT` -> 读 decision -> 填 ADR 模板 -> 写 `adrRoot` -> 输出 `script-result/v1`。
- 在 `vertical.json` 注册脚本（`reads: [decisionsRoot/**, adrRoot/**]`、`writes: [adrRoot/**]`）；用 `ha script run vertical:software-coding:adr-render --input decisionId=<id>` 调用。
- 字段级映射 decision -> ADR（question -> Context、chosen/rejected -> Decision、claims/relations -> Consequences、state/decidedAt -> Status）。
- machine/human 哨兵分区：`<!-- adr-render:begin/end machine -->` 覆盖重渲染，human 区保留。编号 max+1，已锚 ADR 幂等复用号。
- `preset-script-cli` 集成测试。

## 任务与范围

- Harness 任务：`task_01KWPPYWS992PQJEZXK86BECEZ`
- 分支：`feat/adr-render-flow`
- 公开范围：`packages/cli`（vertical 脚本 asset + 注册 + 测试）
- 私有计划 / 证据是否已更新：yes（harness task artifacts/plan/04）
- 范围外：消费 watermark 的 freshness checker（接口已写，checker 未建）；对全部现存 ADR 的渲染回填

## 版本影响

- 版本：不改版本（`0.0.0` workspaces）
- 发布影响：不发布

## 验证

- `origin/main` 基准 SHA：`2f30672`
- 当前分支与 `origin/main` 的 merge-base：`2f30672`
- 同步方式：不需要（分支从当前 `origin/main` 切出）
- 公开 diff 命令：`git diff origin/main...feat/adr-render-flow`
- Dogfood：渲染 `dec_ADR_DECISION_BOUNDARY`，machine 段与手写 ADR-0020 字段级一致（human 区差异属设计），输出写抛弃目录、不碰 live ADR 根
- worktree 内本地检查：`npm run build -w @harness-anything/cli`；`preset-script-cli` 15/15、`package-surface` 绿；typecheck / lint / `check-template-command-surface` / `check-cli-structure` / `check-file-complexity` / `check-schema-field-coverage` exit 0
- D8 边界验证：生成的写授权仅 `adrRoot`；`decisionsRoot` 在 `forbiddenWriteRoots` 内
- GitHub Actions `rewrite-ci` run URL：本 PR 触发，待跑
- 未运行：本地未一次性跑全量 `npm run check`，交 `rewrite-ci`。

## 审查证据

- 自查：子代理回报 + 编排者对 dogfood 一致性与 D8 写边界的验证
- 人工审查：待
- 阻塞发现：无

## 残余风险

- 脚本把 `adrRoot/**` 加进 `reads`（超出计划草案），以便编号/幂等扫描现存 ADR；仅扩读，写边界不变。
- CJK 标题 kebab 后被剥成 ASCII slug（如 `ADR-NNNN-decision-adr.md`）；可接受，若需 CJK 转写再议。

## 关联材料

- 任务：`task_01KWPPYWS992PQJEZXK86BECEZ`
- 决策锚：`dec_ADR_DECISION_BOUNDARY`（ADR-0020 D4）

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。（rewrite-ci 待跑）
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。（squash merge 后删分支 + 清 worktree）
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
