### PR TITLE
feat: add milestone dossier preset

### DIFF
--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { isCloseoutPlaceholderMarkdown, isReviewPlaceholderMarkdown, parseReviewMarkdown } from "../../../application/src/index.ts";
+import { findEntityRefs, parseFactFlowRecords } from "../../../kernel/src/domain/index.ts";
 import { checkTaskProjection } from "../../../kernel/src/index.ts";
 import type { HarnessLayoutInput, HarnessLayoutOverrides } from "../../../kernel/src/layout/index.ts";
 import { listTaskIndexPaths, normalizeRelativeDocumentPath, resolveHarnessLayout } from "../../../kernel/src/layout/index.ts";
@@ -79,6 +80,7 @@ function validateCheckProfile(rootInput: HarnessLayoutInput, profile: CheckProfi
     for (const taskDir of taskDirs) {
       issues.push(...validateTaskPackageContracts(rootInput, taskDir, profile, strict, settings));
     }
+    issues.push(...validateMilestoneDossierGate(rootInput, taskDirs));
   }
 
   if (profile === "private-harness" || profile === "target-project") {
@@ -357,6 +359,124 @@ function validateGovernanceGeneratedViews(rootInput: HarnessLayoutInput, strict:
     issues.push(profileIssue("governance-boundary", "module_registry_projection_missing", strictSeverity(strict), ".harness/generated/Module-Registry.md is missing for authored modules.json.", "Run harness-anything module scaffold/register or governance rebuild to regenerate local views."));
   }
   return issues;
+}
+
+function validateMilestoneDossierGate(rootInput: HarnessLayoutInput, taskDirs: ReadonlyArray<string>): ReadonlyArray<ProfileValidationIssue> {
+  const layout = resolveHarnessLayout(rootInput);
+  const rootDir = layout.rootDir;
+  const index = buildResolvableEntityIndex(rootInput);
+  const issues: ProfileValidationIssue[] = [];
+  for (const taskDir of taskDirs) {
+    const relativeTaskDir = relativePath(rootDir, taskDir);
+    const indexPath = path.join(taskDir, "INDEX.md");
+    if (!existsSync(indexPath)) continue;
+    const frontmatter = readFrontmatter(readFileSync(indexPath, "utf8"));
+    if (!frontmatter || readScalar(frontmatter, "preset") !== "milestone-dossier") continue;
+
+    const dossierPath = path.join(taskDir, "artifacts", "dossier.html");
+    if (!existsSync(dossierPath)) {
+      issues.push(profileIssue(
+        "dossier-gate-checker",
+        "dossier_html_missing",
+        "hard-fail",
+        `${relativeTaskDir}/artifacts/dossier.html is required by preset milestone-dossier.`,
+        "Run the milestone-dossier gather entrypoint, write the understanding dossier by hand, and keep it under the coordination task artifacts directory."
+      ));
+      continue;
+    }
+
+    let body: string;
+    try {
+      body = readFileSync(dossierPath, "utf8");
+    } catch {
+      issues.push(profileIssue(
+        "dossier-gate-checker",
+        "dossier_html_unreadable",
+        "hard-fail",
+        `${relativeTaskDir}/artifacts/dossier.html could not be read as UTF-8 text.`,
+        "Restore a readable HTML dossier artifact."
+      ));
+      continue;
+    }
+
+    const unresolved = [...new Set(findEntityRefs(body)
+      .filter((ref) => !ref.externalHarness)
+      .map((ref) => ref.raw))]
+      .filter((ref) => !index.refs.has(ref));
+    for (const ref of unresolved) {
+      issues.push(profileIssue(
+        "dossier-gate-checker",
+        "dossier_entity_ref_unresolved",
+        "hard-fail",
+        `${relativeTaskDir}/artifacts/dossier.html references unresolved entity ${ref}.`,
+        "Replace bubble references with real task, decision, or fact refs from authored Harness packages."
+      ));
+    }
+  }
+  return issues;
+}
+
+function buildResolvableEntityIndex(rootInput: HarnessLayoutInput): { readonly refs: ReadonlySet<string> } {
+  const layout = resolveHarnessLayout(rootInput);
+  const refs = new Set<string>();
+  for (const indexPath of listTaskIndexPaths(rootInput)) {
+    const taskDir = path.dirname(indexPath);
+    const frontmatter = readFrontmatter(readFileSync(indexPath, "utf8"));
+    const taskId = frontmatter ? readScalar(frontmatter, "task_id") || path.basename(taskDir) : path.basename(taskDir);
+    refs.add(`task/${taskId}`);
+    const factsPath = path.join(taskDir, layout.factDocumentName);
+    if (existsSync(factsPath)) {
+      for (const fact of parseFactFlowRecords(readFileSync(factsPath, "utf8"))) {
+        refs.add(`fact/${taskId}/${fact.fact_id}`);
+      }
+    }
+  }
+
+  for (const decisionPath of listDecisionDocuments(layout.decisionsRoot)) {
+    const body = readFileSync(decisionPath, "utf8");
+    const frontmatter = readFrontmatter(body);
+    if (!frontmatter || readScalar(frontmatter, "schema") !== "decision-package/v1") continue;
+    const decisionId = readScalar(frontmatter, "decision_id") || path.basename(path.dirname(decisionPath));
+    refs.add(`decision/${decisionId}`);
+    for (const anchor of readDecisionEndpointAnchors(frontmatter)) {
+      refs.add(`decision/${decisionId}/${anchor}`);
+    }
+  }
+  return { refs };
+}
+
+function listDecisionDocuments(inputPath: string): ReadonlyArray<string> {
+  if (!existsSync(inputPath)) return [];
+  return readdirSync(inputPath, { withFileTypes: true }).flatMap((entry): ReadonlyArray<string> => {
+    const entryPath = path.join(inputPath, entry.name);
+    if (entry.isDirectory()) return listDecisionDocuments(entryPath);
+    if (entry.isFile() && entry.name === "decision.md") return [entryPath];
+    return [];
+  }).sort();
+}
+
+function readDecisionEndpointAnchors(frontmatter: string): ReadonlyArray<string> {
+  return ["claims", "chosen", "rejected"].flatMap((key) => readDecisionAnchorBlock(frontmatter, key));
+}
+
+function readDecisionAnchorBlock(frontmatter: string, key: string): ReadonlyArray<string> {
+  const lines = frontmatter.split(/\r?\n/u);
+  const output: string[] = [];
+  let inBlock = false;
+  for (const line of lines) {
+    if (line === `${key}:`) {
+      inBlock = true;
+      continue;
+    }
+    if (!inBlock) continue;
+    if (/^\s*-\s*\{/u.test(line)) {
+      const match = /^\s*-\s*\{\s*id:\s*"?([A-Za-z][A-Za-z0-9_-]*)"?/u.exec(line);
+      if (match?.[1]) output.push(match[1]);
+      continue;
+    }
+    if (/^\S/u.test(line)) break;
+  }
+  return output;
 }
 
 function layoutOverridesFromInput(rootInput: HarnessLayoutInput): HarnessLayoutOverrides | undefined {

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/index.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/index.json
@@ -6,6 +6,7 @@
     "doc-canon-sync",
     "milestone-closeout",
     "lesson-sedimentation",
+    "milestone-dossier",
     "version-upgrade",
     "publish-standard",
     "release-closeout",

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/milestone-dossier/preset.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/milestone-dossier/preset.json
@@ -1,0 +1,45 @@
+{
+  "schema": "preset-manifest/v2",
+  "id": "milestone-dossier",
+  "title": "Aggregation-Boundary Understanding Dossier",
+  "vertical": "software/coding",
+  "version": "1.0.0",
+  "kind": "process-action",
+  "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
+  "capabilityImports": [
+    { "id": "relation-graph-projection", "kind": "projection", "version": "1", "required": true },
+    { "id": "dossier-gate-checker", "kind": "checker", "version": "1", "required": true }
+  ],
+  "entrypoints": {
+    "gather": {
+      "type": "script",
+      "command": "scripts/dossier-data.mjs",
+      "reads": [
+        "{{paths.tasksRoot}}/**",
+        "{{paths.decisionsRoot}}/**",
+        "{{paths.localRoot}}/**"
+      ],
+      "writes": [
+        "{{outputRoot}}/artifacts/**"
+      ],
+      "inputs": {
+        "coordinationTaskId": "{{taskId}}",
+        "decisionId": ""
+      }
+    }
+  },
+  "profiles": [{
+    "id": "baseline",
+    "title": "Baseline",
+    "checkerProfile": "software-coding-standard",
+    "templateSelections": [
+      {
+        "slot": "dossier-shell",
+        "templateRef": "template://dossier/editorial-shell@1",
+        "materializeAs": "artifacts/dossier.scaffold.html",
+        "localePolicy": { "prefer": "project", "fallback": "zh-CN" }
+      }
+    ]
+  }],
+  "defaultProfile": "baseline"
+}

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/milestone-dossier/scripts/dossier-data.mjs
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/milestone-dossier/scripts/dossier-data.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import path from "node:path";
+
+const contextPath = process.env.HARNESS_SCRIPT_CONTEXT ?? process.env.HARNESS_PRESET_CONTEXT;
+if (!contextPath) throw new Error("HARNESS_SCRIPT_CONTEXT or HARNESS_PRESET_CONTEXT is required");
+
+const context = JSON.parse(readFileSync(contextPath, "utf8"));
+const paths = context.paths ?? {};
+const inputs = context.inputs ?? {};
+const outputRoot = context.outputRoot;
+const coordinationTaskId = inputs.coordinationTaskId && inputs.coordinationTaskId !== "{{taskId}}"
+  ? inputs.coordinationTaskId
+  : context.taskId;
+const decisionId = inputs.decisionId || undefined;
+
+if (!outputRoot) throw new Error("context.outputRoot is required");
+if (!coordinationTaskId) throw new Error("coordinationTaskId input or task context is required");
+
+const artifactsDir = path.join(outputRoot, "artifacts");
+mkdirSync(artifactsDir, { recursive: true });
+
+const projectionPath = path.join(paths.localRoot ?? ".harness", "cache", "projections.sqlite");
+if (!existsSync(projectionPath)) {
+  throw new Error(`Relation graph projection database not found: ${projectionPath}`);
+}
+
+const projection = readProjection(projectionPath);
+const focusDecisionRef = decisionId ? `decision/${decisionId}` : undefined;
+const selectedCoverage = focusDecisionRef
+  ? projection.coverageRows.filter((row) => row.decisionRef === focusDecisionRef)
+  : projection.coverageRows;
+const selectedDecisionRefs = new Set(selectedCoverage.map((row) => row.decisionRef));
+if (focusDecisionRef) selectedDecisionRefs.add(focusDecisionRef);
+
+const relationIds = new Set(selectedCoverage.flatMap((row) => Array.isArray(row.relationPath) ? row.relationPath : []));
+const selectedEdges = projection.relationEdges.filter((edge) =>
+  relationIds.has(edge.relationId) ||
+  selectedDecisionRefs.has(baseDecisionRef(edge.sourceRef)) ||
+  selectedDecisionRefs.has(baseDecisionRef(edge.targetRef))
+);
+
+const selectedRefs = new Set();
+for (const row of selectedCoverage) {
+  selectedRefs.add(row.decisionRef);
+  selectedRefs.add(row.claimRef);
+  if (row.coveringFactRef) selectedRefs.add(row.coveringFactRef);
+}
+for (const edge of selectedEdges) {
+  selectedRefs.add(edge.sourceRef);
+  selectedRefs.add(edge.targetRef);
+  selectedRefs.add(edge.ownerRef);
+}
+
+const tasks = projection.tasks.filter((task) => selectedRefs.has(`task/${task.taskId}`));
+const decisions = projection.decisions.filter((decision) => selectedDecisionRefs.has(`decision/${decision.decisionId}`));
+const facts = projection.factAnchors.filter((fact) => selectedRefs.has(fact.factRef));
+
+const data = {
+  schema: "milestone-dossier-data/v1",
+  generatedAt: new Date().toISOString(),
+  presetId: context.presetId ?? "milestone-dossier",
+  entrypoint: context.entrypoint ?? "gather",
+  coordinationTaskId,
+  decisionId: decisionId ?? null,
+  output: {
+    dossierHtml: "artifacts/dossier.html",
+    dossierScaffoldHtml: "artifacts/dossier.scaffold.html",
+    dataJson: "artifacts/dossier.data.json"
+  },
+  projection: {
+    path: projectionPath,
+    tables: ["task_projection", "decision_projection", "relation_edges", "relation_coverage", "task_fact_anchors"]
+  },
+  summary: {
+    decisions: decisions.length,
+    tasks: tasks.length,
+    facts: facts.length,
+    relationEdges: selectedEdges.length,
+    coverageRows: selectedCoverage.length,
+    uncoveredClaims: selectedCoverage.filter((row) => row.status !== "covered").length
+  },
+  decisions,
+  tasks,
+  facts,
+  relationEdges: selectedEdges,
+  coverageRows: selectedCoverage,
+  provenanceRefs: [...selectedRefs].sort()
+};
+
+const dataPath = path.join(artifactsDir, "dossier.data.json");
+writeFileSync(dataPath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+writeFileSync(path.join(artifactsDir, "preset-result.json"), `${JSON.stringify({
+  schema: "script-result/v1",
+  ok: true,
+  rows: data.summary.coverageRows,
+  report: {
+    schema: "milestone-dossier-gather-report/v1",
+    coordinationTaskId,
+    decisionId: decisionId ?? null,
+    dataPath: path.relative(paths.rootDir ?? process.cwd(), dataPath).split(path.sep).join("/"),
+    summary: data.summary
+  },
+  produced: ["artifacts/dossier.data.json"]
+}, null, 2)}\n`, "utf8");
+
+function readProjection(filename) {
+  const db = new DatabaseSync(filename, { readOnly: true });
+  try {
+    return {
+      tasks: safeAll(db, "SELECT task_id, title, canonical_status, coordination_status, source_path, vertical, preset, profile FROM task_projection ORDER BY task_id")
+        .map((row) => ({
+          taskId: String(row.task_id ?? ""),
+          title: String(row.title ?? ""),
+          canonicalStatus: String(row.canonical_status ?? ""),
+          coordinationStatus: String(row.coordination_status ?? ""),
+          sourcePath: String(row.source_path ?? ""),
+          vertical: nullableString(row.vertical),
+          preset: nullableString(row.preset),
+          profile: nullableString(row.profile)
+        })),
+      decisions: safeAll(db, "SELECT decision_id, title, state, question, path, chosen_json, rejected_json, decided_at FROM decision_projection ORDER BY decision_id")
+        .map((row) => ({
+          decisionId: String(row.decision_id ?? ""),
+          title: String(row.title ?? ""),
+          state: String(row.state ?? ""),
+          question: String(row.question ?? ""),
+          path: String(row.path ?? ""),
+          chosen: parseJson(row.chosen_json, []),
+          rejected: parseJson(row.rejected_json, []),
+          decidedAt: nullableString(row.decided_at)
+        })),
+      relationEdges: safeJsonRows(db, "SELECT row_json FROM relation_edges ORDER BY source_ref, target_ref, relation_id"),
+      coverageRows: safeJsonRows(db, "SELECT row_json FROM relation_coverage ORDER BY claim_ref"),
+      factAnchors: safeJsonRows(db, "SELECT row_json FROM task_fact_anchors ORDER BY fact_ref")
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function safeAll(db, sql) {
+  try {
+    return db.prepare(sql).all();
+  } catch {
+    return [];
+  }
+}
+
+function safeJsonRows(db, sql) {
+  return safeAll(db, sql).map((row) => parseJson(row.row_json, {}));
+}
+
+function parseJson(value, fallback) {
+  try {
+    return JSON.parse(String(value ?? ""));
+  } catch {
+    return fallback;
+  }
+}
+
+function nullableString(value) {
+  return value === null || value === undefined ? null : String(value);
+}
+
+function baseDecisionRef(ref) {
+  const match = /^decision\/[A-Za-z0-9_-]+/u.exec(String(ref ?? ""));
+  return match ? match[0] : "";
+}

--- a/packages/cli/src/commands/extensions/assets/software-coding/template-catalog.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/template-catalog.json
@@ -201,6 +201,43 @@
       ]
     },
     {
+      "id": "dossier/editorial-shell",
+      "version": "1",
+      "documentKind": "milestone-dossier-shell",
+      "slot": "dossier-shell",
+      "materializeAs": "artifacts/dossier.scaffold.html",
+      "frontmatterSchema": "task-package/v2",
+      "requiredAnchors": [
+        "data-dossier-section=\"brief\"",
+        "data-dossier-section=\"boundary\"",
+        "data-dossier-section=\"evidence\"",
+        "data-dossier-section=\"provenance\""
+      ],
+      "fallbackLocale": "zh-CN",
+      "locales": [
+        {
+          "locale": "zh-CN",
+          "anchors": [
+            "data-dossier-section=\"brief\"",
+            "data-dossier-section=\"boundary\"",
+            "data-dossier-section=\"evidence\"",
+            "data-dossier-section=\"provenance\""
+          ],
+          "bodyPath": "templates/dossier.editorial.shell/zh-CN.md"
+        },
+        {
+          "locale": "en-US",
+          "anchors": [
+            "data-dossier-section=\"brief\"",
+            "data-dossier-section=\"boundary\"",
+            "data-dossier-section=\"evidence\"",
+            "data-dossier-section=\"provenance\""
+          ],
+          "bodyPath": "templates/dossier.editorial.shell/en-US.md"
+        }
+      ]
+    },
+    {
       "id": "planning/brief",
       "version": "1",
       "documentKind": "brief",

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/dossier.editorial.shell/en-US.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/dossier.editorial.shell/en-US.md
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Milestone Dossier</title>
+<style>
+:root { --bg:#0b0d12; --bg-2:#11141c; --panel:#161a24; --panel-2:#1c2230; --ink:#e8eaf0; --ink-dim:#9aa3b4; --ink-faint:#5c6478; --line:#262d3d; --line-soft:#1f2433; --amber:#f0a830; --teal:#3fb8af; --rose:#e5484d; --violet:#a78bfa; --lime:#a3e635; }
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body { margin: 0; background: var(--bg); color: var(--ink); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; font-size: 15px; line-height: 1.62; letter-spacing: 0; -webkit-font-smoothing: antialiased; }
+.serif { font-family: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, "Times New Roman", serif; }
+.mono { font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, "Liberation Mono", monospace; }
+.wrap { width: min(1180px, calc(100vw - 40px)); margin: 0 auto; }
+.topbar { position: sticky; top: 0; z-index: 10; background: rgba(11, 13, 18, .86); backdrop-filter: blur(12px); border-bottom: 1px solid var(--line); }
+.topbar .row { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 13px 0; }
+.brand { display: flex; align-items: center; gap: 11px; font-weight: 650; font-size: 14px; }
+.brand .dot { width: 10px; height: 10px; border-radius: 3px; background: linear-gradient(135deg, var(--violet), var(--teal), var(--rose)); }
+nav { display: flex; gap: 4px; flex-wrap: wrap; justify-content: flex-end; }
+nav a { color: var(--ink-dim); text-decoration: none; font-size: 12px; padding: 5px 9px; border-radius: 6px; }
+nav a:hover { color: var(--ink); background: var(--panel); }
+.hero { padding: 82px 0 54px; border-bottom: 1px solid var(--line); }
+.eyebrow { color: var(--violet); font-size: 12px; letter-spacing: .1em; text-transform: uppercase; margin-bottom: 20px; }
+h1 { margin: 0; font-family: "Iowan Old Style", Palatino, Georgia, serif; font-size: clamp(38px, 5.4vw, 68px); line-height: 1.06; font-weight: 400; letter-spacing: 0; }
+.lede { margin: 24px 0 0; max-width: 820px; color: var(--ink-dim); font-family: "Iowan Old Style", Palatino, Georgia, serif; font-size: 19px; line-height: 1.56; }
+.meta-grid { display: grid; grid-template-columns: repeat(4, 1fr); border: 1px solid var(--line); border-radius: 12px; overflow: hidden; margin-top: 44px; }
+.meta-cell { padding: 18px 20px; background: var(--panel); border-right: 1px solid var(--line); }
+.meta-cell:last-child { border-right: 0; }
+.k { color: var(--ink-faint); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
+.v { margin-top: 7px; font-size: 21px; font-weight: 650; }
+section { padding: 64px 0; border-bottom: 1px solid var(--line); }
+.section-head { margin-bottom: 30px; }
+.section-num { color: var(--ink-faint); font-size: 12px; letter-spacing: .13em; text-transform: uppercase; }
+h2 { margin: 8px 0 0; font-family: "Iowan Old Style", Palatino, Georgia, serif; font-weight: 400; font-size: clamp(28px, 3.4vw, 42px); line-height: 1.12; letter-spacing: 0; }
+.takeaway { margin-top: 14px; max-width: 860px; border-left: 3px solid var(--violet); padding-left: 16px; color: var(--ink); }
+.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+.card { border: 1px solid var(--line); border-radius: 8px; background: var(--panel); padding: 22px; }
+.card h3 { margin: 0 0 10px; font-size: 17px; }
+.card p, .card li { color: var(--ink-dim); }
+.placeholder { min-height: 90px; border: 1px dashed var(--line); border-radius: 8px; background: var(--bg-2); color: var(--ink-faint); padding: 16px; }
+table { width: 100%; border-collapse: collapse; table-layout: fixed; font-size: 13px; background: var(--panel); }
+th, td { border: 1px solid var(--line); padding: 10px 12px; text-align: left; vertical-align: top; overflow-wrap: anywhere; }
+th { color: var(--ink-faint); background: var(--bg-2); font-size: 11px; text-transform: uppercase; letter-spacing: .06em; }
+code { color: var(--teal); background: var(--bg-2); border: 1px solid var(--line-soft); border-radius: 4px; padding: 1px 5px; }
+footer { padding: 34px 0 48px; color: var(--ink-faint); }
+@media (max-width: 760px) { .topbar .row, .grid-2 { display: block; } nav { justify-content: flex-start; margin-top: 10px; } .meta-grid { grid-template-columns: 1fr 1fr; } .meta-cell { border-bottom: 1px solid var(--line); } }
+</style>
+</head>
+<body>
+<header class="topbar"><div class="wrap row"><div class="brand"><span class="dot"></span><span>milestone dossier</span></div><nav><a href="#brief">brief</a><a href="#boundary">boundary</a><a href="#evidence">evidence</a><a href="#provenance">provenance</a></nav></div></header>
+<main>
+  <div class="hero"><div class="wrap"><div class="eyebrow mono">aggregation boundary</div><h1>Write the milestone close boundary as an auditable understanding dossier</h1><p class="lede">This file is only the editorial shell. Use <code>artifacts/dossier.data.json</code> and the original source documents to write the final human interpretation by hand.</p><div class="meta-grid"><div class="meta-cell"><div class="k mono">coordination task</div><div class="v">task/...</div></div><div class="meta-cell"><div class="k mono">boundary decision</div><div class="v">decision/...</div></div><div class="meta-cell"><div class="k mono">coverage</div><div class="v">0 / 0</div></div><div class="meta-cell"><div class="k mono">status</div><div class="v">draft</div></div></div></div></div>
+  <section id="brief" data-dossier-section="brief"><div class="wrap"><div class="section-head"><div class="section-num mono">01 / brief</div><h2>Closeout Brief</h2><p class="takeaway">Explain the milestone objective, the boundary that is complete, and the risks still worth carrying forward.</p></div><div class="placeholder">Agent-authored narrative goes here.</div></div></section>
+  <section id="boundary" data-dossier-section="boundary"><div class="wrap"><div class="section-head"><div class="section-num mono">02 / boundary</div><h2>Aggregation Boundary</h2><p class="takeaway">State which tasks, decisions, and facts form the close boundary, and why this is the correct stopping point.</p></div><div class="grid-2"><div class="card"><h3>Included</h3><div class="placeholder">Task and decision groups.</div></div><div class="card"><h3>Excluded</h3><div class="placeholder">Deferred or out-of-bound work.</div></div></div></div></section>
+  <section id="evidence" data-dossier-section="evidence"><div class="wrap"><div class="section-head"><div class="section-num mono">03 / evidence</div><h2>Evidence And Coverage</h2><p class="takeaway">Translate coverage rows, facts, and relation paths into a reviewable evidence story.</p></div><table><thead><tr><th>Claim</th><th>Evidence</th><th>Interpretation</th></tr></thead><tbody><tr><td>decision/.../C1</td><td>fact/.../F-...</td><td>Replace with authored reading.</td></tr></tbody></table></div></section>
+  <section id="provenance" data-dossier-section="provenance"><div class="wrap"><div class="section-head"><div class="section-num mono">04 / provenance</div><h2>Resolvable References</h2><p class="takeaway">List the real entity refs used by this dossier. The checker verifies resolution only, not writing quality.</p></div><div class="placeholder">task/..., decision/..., fact/.../F-...</div></div></section>
+</main>
+<footer><div class="wrap mono">Generated from template://dossier/editorial-shell@1. Write final content to artifacts/dossier.html.</div></footer>
+</body>
+</html>

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/dossier.editorial.shell/zh-CN.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/dossier.editorial.shell/zh-CN.md
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Milestone Dossier</title>
+<style>
+:root {
+  --bg: #0b0d12;
+  --bg-2: #11141c;
+  --panel: #161a24;
+  --panel-2: #1c2230;
+  --ink: #e8eaf0;
+  --ink-dim: #9aa3b4;
+  --ink-faint: #5c6478;
+  --line: #262d3d;
+  --line-soft: #1f2433;
+  --amber: #f0a830;
+  --teal: #3fb8af;
+  --rose: #e5484d;
+  --violet: #a78bfa;
+  --lime: #a3e635;
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  font-size: 15px;
+  line-height: 1.62;
+  letter-spacing: 0;
+  -webkit-font-smoothing: antialiased;
+}
+.serif { font-family: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", "Songti SC", Georgia, "Times New Roman", serif; }
+.mono { font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, "Liberation Mono", monospace; }
+.wrap { width: min(1180px, calc(100vw - 40px)); margin: 0 auto; }
+.topbar { position: sticky; top: 0; z-index: 10; background: rgba(11, 13, 18, .86); backdrop-filter: blur(12px); border-bottom: 1px solid var(--line); }
+.topbar .row { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 13px 0; }
+.brand { display: flex; align-items: center; gap: 11px; font-weight: 650; font-size: 14px; }
+.brand .dot { width: 10px; height: 10px; border-radius: 3px; background: linear-gradient(135deg, var(--violet), var(--teal), var(--rose)); }
+nav { display: flex; gap: 4px; flex-wrap: wrap; justify-content: flex-end; }
+nav a { color: var(--ink-dim); text-decoration: none; font-size: 12px; padding: 5px 9px; border-radius: 6px; }
+nav a:hover { color: var(--ink); background: var(--panel); }
+.hero { padding: 82px 0 54px; border-bottom: 1px solid var(--line); }
+.eyebrow { color: var(--violet); font-size: 12px; letter-spacing: .1em; text-transform: uppercase; margin-bottom: 20px; }
+h1 { margin: 0; font-family: "Iowan Old Style", Palatino, "Songti SC", Georgia, serif; font-size: clamp(38px, 5.4vw, 68px); line-height: 1.06; font-weight: 400; letter-spacing: 0; }
+.lede { margin: 24px 0 0; max-width: 820px; color: var(--ink-dim); font-family: "Iowan Old Style", Palatino, "Songti SC", Georgia, serif; font-size: 19px; line-height: 1.56; }
+.meta-grid { display: grid; grid-template-columns: repeat(4, 1fr); border: 1px solid var(--line); border-radius: 12px; overflow: hidden; margin-top: 44px; }
+.meta-cell { padding: 18px 20px; background: var(--panel); border-right: 1px solid var(--line); }
+.meta-cell:last-child { border-right: 0; }
+.k { color: var(--ink-faint); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
+.v { margin-top: 7px; font-size: 21px; font-weight: 650; }
+section { padding: 64px 0; border-bottom: 1px solid var(--line); }
+.section-head { margin-bottom: 30px; }
+.section-num { color: var(--ink-faint); font-size: 12px; letter-spacing: .13em; text-transform: uppercase; }
+h2 { margin: 8px 0 0; font-family: "Iowan Old Style", Palatino, "Songti SC", Georgia, serif; font-weight: 400; font-size: clamp(28px, 3.4vw, 42px); line-height: 1.12; letter-spacing: 0; }
+.takeaway { margin-top: 14px; max-width: 860px; border-left: 3px solid var(--violet); padding-left: 16px; color: var(--ink); }
+.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+.card { border: 1px solid var(--line); border-radius: 8px; background: var(--panel); padding: 22px; }
+.card h3 { margin: 0 0 10px; font-size: 17px; }
+.card p, .card li { color: var(--ink-dim); }
+.placeholder { min-height: 90px; border: 1px dashed var(--line); border-radius: 8px; background: var(--bg-2); color: var(--ink-faint); padding: 16px; }
+table { width: 100%; border-collapse: collapse; table-layout: fixed; font-size: 13px; background: var(--panel); }
+th, td { border: 1px solid var(--line); padding: 10px 12px; text-align: left; vertical-align: top; overflow-wrap: anywhere; }
+th { color: var(--ink-faint); background: var(--bg-2); font-size: 11px; text-transform: uppercase; letter-spacing: .06em; }
+code { color: var(--teal); background: var(--bg-2); border: 1px solid var(--line-soft); border-radius: 4px; padding: 1px 5px; }
+footer { padding: 34px 0 48px; color: var(--ink-faint); }
+@media (max-width: 760px) {
+  .topbar .row, .grid-2 { display: block; }
+  nav { justify-content: flex-start; margin-top: 10px; }
+  .meta-grid { grid-template-columns: 1fr 1fr; }
+  .meta-cell { border-bottom: 1px solid var(--line); }
+}
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="wrap row">
+    <div class="brand"><span class="dot"></span><span>milestone dossier</span></div>
+    <nav>
+      <a href="#brief">brief</a>
+      <a href="#boundary">boundary</a>
+      <a href="#evidence">evidence</a>
+      <a href="#provenance">provenance</a>
+    </nav>
+  </div>
+</header>
+<main>
+  <div class="hero">
+    <div class="wrap">
+      <div class="eyebrow mono">aggregation boundary</div>
+      <h1>把这个里程碑为什么能收口,写成可审计的理解档案</h1>
+      <p class="lede">这里保留编辑级排版骨架。请基于 <code>artifacts/dossier.data.json</code> 与真实原文,亲手写出综合判断、证据取舍和边界结论。</p>
+      <div class="meta-grid">
+        <div class="meta-cell"><div class="k mono">coordination task</div><div class="v">task/...</div></div>
+        <div class="meta-cell"><div class="k mono">boundary decision</div><div class="v">decision/...</div></div>
+        <div class="meta-cell"><div class="k mono">coverage</div><div class="v">0 / 0</div></div>
+        <div class="meta-cell"><div class="k mono">status</div><div class="v">draft</div></div>
+      </div>
+    </div>
+  </div>
+  <section id="brief" data-dossier-section="brief">
+    <div class="wrap">
+      <div class="section-head"><div class="section-num mono">01 / brief</div><h2>收口摘要</h2><p class="takeaway">用少量判断讲清里程碑的目标、已经完成的边界、仍需保留的风险。</p></div>
+      <div class="placeholder">Agent-authored narrative goes here.</div>
+    </div>
+  </section>
+  <section id="boundary" data-dossier-section="boundary">
+    <div class="wrap">
+      <div class="section-head"><div class="section-num mono">02 / boundary</div><h2>聚合边界裁决</h2><p class="takeaway">解释哪些任务、决策和事实构成了本次收口的边界,以及为什么可以在这里停下。</p></div>
+      <div class="grid-2"><div class="card"><h3>Included</h3><div class="placeholder">Task and decision groups.</div></div><div class="card"><h3>Excluded</h3><div class="placeholder">Deferred or out-of-bound work.</div></div></div>
+    </div>
+  </section>
+  <section id="evidence" data-dossier-section="evidence">
+    <div class="wrap">
+      <div class="section-head"><div class="section-num mono">03 / evidence</div><h2>证据与覆盖</h2><p class="takeaway">把 coverage rows、facts、关键关系链翻译成人能复核的证据故事。</p></div>
+      <table><thead><tr><th>Claim</th><th>Evidence</th><th>Interpretation</th></tr></thead><tbody><tr><td>decision/.../C1</td><td>fact/.../F-...</td><td>Replace with authored reading.</td></tr></tbody></table>
+    </div>
+  </section>
+  <section id="provenance" data-dossier-section="provenance">
+    <div class="wrap">
+      <div class="section-head"><div class="section-num mono">04 / provenance</div><h2>可追溯引用</h2><p class="takeaway">列出 dossier 中使用的真实 entity refs。checker 只验证这些引用能解析,不评价文字质量。</p></div>
+      <div class="placeholder">task/..., decision/..., fact/.../F-...</div>
+    </div>
+  </section>
+</main>
+<footer><div class="wrap mono">Generated from template://dossier/editorial-shell@1. Write final content to artifacts/dossier.html.</div></footer>
+</body>
+</html>

--- a/packages/cli/test/check-governance-cli.test.ts
+++ b/packages/cli/test/check-governance-cli.test.ts
@@ -132,6 +132,62 @@ test("CLI metadata check fails closed on missing preset-selected document and an
   });
 });
 
+test("CLI metadata check enforces milestone dossier artifact and resolvable provenance refs", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    const created = runJson(rootDir, ["new-task", "--title", "Milestone Dossier", "--vertical", "software/coding", "--preset", "milestone-dossier"]);
+    assert.equal(existsSync(path.join(rootDir, created.packagePath, "artifacts", "dossier.scaffold.html")), true);
+
+    const missing = runJson(rootDir, ["check", "--profile", "target-project", "--strict"], false);
+    assert.equal(missing.ok, false);
+    assert.equal(missing.warnings.some((warning: Record<string, unknown>) => warning.source === "dossier-gate-checker" && warning.code === "dossier_html_missing"), true);
+
+    const artifactsDir = path.join(rootDir, created.packagePath, "artifacts");
+    mkdirSync(artifactsDir, { recursive: true });
+    writeFileSync(path.join(artifactsDir, "dossier.html"), "<!doctype html><p>Unresolved decision/dec_MISSING.</p>\n", "utf8");
+    const unresolved = runJson(rootDir, ["check", "--profile", "target-project", "--strict"], false);
+    assert.equal(unresolved.ok, false);
+    assert.equal(unresolved.warnings.some((warning: Record<string, unknown>) => warning.code === "dossier_entity_ref_unresolved" && warning.message.includes("decision/dec_MISSING")), true);
+
+    writeFileSync(path.join(rootDir, created.packagePath, "facts.md"), [
+      "# Facts",
+      "",
+      "- {fact_id: F-DEADBEEF, statement: \"Milestone dossier has anchored evidence.\", source: \"test fixture\", observedAt: \"2026-07-04T00:00:00.000Z\", confidence: high, memoryClass: episodic, memoryTags: [], provenance: [{runtime: \"human\", sessionId: \"human-cli-1783036800000\", boundAt: \"2026-07-04T00:00:00.000Z\"}]}",
+      ""
+    ].join("\n"), "utf8");
+    runJson(rootDir, [
+      "decision",
+      "propose",
+      "--id",
+      "dec_DOSSIER",
+      "--title",
+      "Dossier Boundary",
+      "--question",
+      "Should the milestone close?",
+      "--chosen",
+      "Close with dossier evidence",
+      "--rejected",
+      "Close without dossier",
+      "--why-not",
+      "Boundary understanding must be reviewable"
+    ]);
+
+    writeFileSync(path.join(artifactsDir, "dossier.html"), [
+      "<!doctype html>",
+      "<html><body>",
+      `<p>Resolved task/${created.taskId}.</p>`,
+      "<p>Resolved decision/dec_DOSSIER and decision/dec_DOSSIER/CH1.</p>",
+      `<p>Resolved fact/${created.taskId}/F-DEADBEEF.</p>`,
+      "</body></html>",
+      ""
+    ].join("\n"), "utf8");
+
+    const passed = runJson(rootDir, ["check", "--profile", "target-project", "--strict"]);
+    assert.equal(passed.ok, true);
+    assert.equal(passed.warnings.some((warning: Record<string, unknown>) => warning.source === "dossier-gate-checker"), false);
+  });
+});
+
 test("CLI metadata check does not resolve preset overrides for default tasks", () => {
   withTempRoot((rootDir) => {
     runJson(rootDir, ["init"]);

--- a/packages/cli/test/extension-cli.test.ts
+++ b/packages/cli/test/extension-cli.test.ts
@@ -52,10 +52,11 @@ test("CLI template commands use bundled software coding catalog by default", () 
 
   assert.equal(listed.ok, true);
   assert.equal(listed.command, "template-list");
-  assert.equal(listed.templates.length, 28);
+  assert.equal(listed.templates.length, 29);
   assert.equal(listed.templates.some((template) => template.templateRef === "template://planning/task-plan@1" && template.materializeAs === "task_plan.md"), true);
   assert.equal(listed.templates.some((template) => template.templateRef === "template://planning/brief@1" && template.materializeAs === "brief.md"), true);
   assert.equal(listed.templates.some((template) => template.templateRef === "template://planning/module-plan@1" && template.materializeAs === "module_plan.md"), true);
+  assert.equal(listed.templates.some((template) => template.templateRef === "template://dossier/editorial-shell@1" && template.materializeAs === "artifacts/dossier.scaffold.html"), true);
   assert.equal(listed.templates.some((template) => template.templateRef === "template://repository/repo-governance@1" && template.materializeAs === "harness/standards/repo-governance.md"), true);
   assert.equal(listed.templates.some((template) => template.templateRef === "template://repository/adr-template@1" && template.materializeAs === "adr/0000-template.md"), true);
   assert.equal(listed.templates.some((template) => template.templateRef === "template://repository/decisions-readme@1" && template.materializeAs === "harness/decisions/README.md"), true);

--- a/packages/cli/test/preset-script-dossier-cli.test.ts
+++ b/packages/cli/test/preset-script-dossier-cli.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+
+test("CLI milestone-dossier gather script writes focused dossier data from relation graph projection", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    const created = runJson(rootDir, ["new-task", "--title", "Milestone Dossier", "--vertical", "software/coding", "--preset", "milestone-dossier"]);
+    writeFile(rootDir, `${created.packagePath}/facts.md`, [
+      "# Facts",
+      "",
+      "- {fact_id: F-DEADBEEF, statement: \"Gather has anchored coverage.\", source: \"test fixture\", observedAt: \"2026-07-04T00:00:00.000Z\", confidence: high, memoryClass: episodic, memoryTags: [], provenance: [{runtime: \"human\", sessionId: \"human-cli-1783036800000\", boundAt: \"2026-07-04T00:00:00.000Z\"}]}",
+      ""
+    ].join("\n"));
+    runJson(rootDir, [
+      "decision",
+      "propose",
+      "--id",
+      "dec_GATHER",
+      "--title",
+      "Gather Decision",
+      "--question",
+      "Should gather read relation coverage?",
+      "--chosen",
+      "Read relation coverage",
+      "--rejected",
+      "Rebuild a separate graph",
+      "--why-not",
+      "The relation graph projection is already the source of truth",
+      "--evidence-relation",
+      `C1:supports:fact/${created.taskId}/F-DEADBEEF:Fact F-DEADBEEF supports gather claim`
+    ]);
+    runJson(rootDir, ["task", "list"]);
+
+    const result = runJson(rootDir, ["script", "run", "preset:milestone-dossier:gather", "--task", created.taskId, "--input", "decisionId=dec_GATHER"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.script.id, "preset:milestone-dossier:gather");
+    assert.equal(result.generated.some((filePath: string) => filePath.endsWith("artifacts/dossier.data.json")), true);
+    const data = JSON.parse(readFileSync(path.join(rootDir, created.packagePath, "artifacts", "dossier.data.json"), "utf8"));
+    assert.equal(data.schema, "milestone-dossier-data/v1");
+    assert.equal(data.coordinationTaskId, created.taskId);
+    assert.equal(data.decisionId, "dec_GATHER");
+    assert.equal(data.coverageRows.some((row: Record<string, unknown>) => row.claimRef === "decision/dec_GATHER/C1" && row.status === "covered"), true);
+    assert.equal(data.facts.some((fact: Record<string, unknown>) => fact.factRef === `fact/${created.taskId}/F-DEADBEEF`), true);
+  });
+});
+
+function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, any> {
+  try {
+    const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+      encoding: "utf8"
+    });
+    const parsed = JSON.parse(output) as Record<string, any>;
+    if (expectSuccess) assert.equal(parsed.ok, true, output);
+    return unwrapCommandReceipt(parsed);
+  } catch (error) {
+    if (expectSuccess) throw error;
+    const failure = error as { readonly stdout?: string };
+    return unwrapCommandReceipt(JSON.parse(failure.stdout ?? "{}") as Record<string, any>);
+  }
+}
+
+function withTempRoot<T>(fn: (rootDir: string) => T): T {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "harness-preset-script-dossier-"));
+  try {
+    return fn(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function writeFile(rootDir: string, relativePath: string, body: string): void {
+  const target = path.join(rootDir, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, body, "utf8");
+}

--- a/packages/cli/test/runtime-event-cli.test.ts
+++ b/packages/cli/test/runtime-event-cli.test.ts
@@ -7,6 +7,14 @@ import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
+const cleanRuntimeEnv = {
+  CLAUDE_CODE_SESSION_ID: "",
+  CLAUDE_SESSION_ID: "",
+  CODEX_SESSION_ID: "",
+  CODEX_THREAD_ID: "",
+  ZCODE_SESSION_ID: "",
+  ANTIGRAVITY_SESSION_ID: ""
+} as const;
 
 test("CLI authored write commands append a current-session result event", () => {
   withTempRoot((rootDir) => {
@@ -157,7 +165,7 @@ function runJson(
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...env }
+      env: { ...process.env, ...cleanRuntimeEnv, ...env }
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/session-cli.test.ts
+++ b/packages/cli/test/session-cli.test.ts
@@ -7,6 +7,14 @@ import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
+const cleanRuntimeEnv = {
+  CLAUDE_CODE_SESSION_ID: "",
+  CLAUDE_SESSION_ID: "",
+  CODEX_SESSION_ID: "",
+  CODEX_THREAD_ID: "",
+  ZCODE_SESSION_ID: "",
+  ANTIGRAVITY_SESSION_ID: ""
+} as const;
 
 test("CLI session export binds CODEX_THREAD_ID and commits managed session markdown", () => {
   withTempRoot((rootDir) => {
@@ -101,7 +109,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...env }
+      env: { ...process.env, ...cleanRuntimeEnv, ...env }
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -100,6 +100,7 @@ export const testTierManifest = {
     "packages/cli/test/projection-freshness-cli.test.ts",
     "packages/cli/test/preset-module-cli.test.ts",
     "packages/cli/test/preset-script-cli.test.ts",
+    "packages/cli/test/preset-script-dossier-cli.test.ts",
     "packages/cli/test/runtime-event-cli.test.ts",
     "packages/cli/test/session-cli.test.ts",
     "packages/cli/test/settings-cli.test.ts",


### PR DESCRIPTION
# English

## Summary

Adds the milestone-dossier process-action preset to the bundled software-coding preset set. The preset provides a relation-graph gather script, an editorial HTML shell template, and a fail-closed dossier gate that requires a coordination task artifact at `artifacts/dossier.html` with locally resolvable task, decision, and fact references.

## Verification

- `npm run typecheck`
- `npm run lint`
- `node --test packages/cli/test/preset-script-cli.test.ts`
- `node --test packages/cli/test/check-governance-cli.test.ts`
- `node packages/cli/src/index.ts --json preset inspect milestone-dossier`
- `node packages/cli/src/index.ts --json script inspect preset:milestone-dossier:gather`
- `node packages/cli/src/index.ts --json template render template://dossier/editorial-shell@1 --locale zh-CN`
- `npm run check:pr` reached the final supply-chain gate after all local code, test, GUI, structure, schema, and contract checks passed; the final `npm audit` request intermittently failed locally with a registry TLS disconnect. A standalone supply-chain retry passed once before later retries hit the same registry network failure.

## Notes

The generic D4 collection path for kind=check scripts is not present yet, so this change wires the required dossier checker through the existing metadata check profile. The preset still preserves the intended human-authored dossier boundary: it gathers data and scaffolds the shell, but it does not generate final dossier content.

---

# 中文

## 摘要

新增 bundled software-coding 的 `milestone-dossier` process-action preset。它包含 relation-graph gather 脚本、编辑级 HTML 骨架模板，以及 fail-closed 的 dossier gate：协调任务必须有 `artifacts/dossier.html`，且文内本地 task、decision、fact 引用必须能解析。

## 验证

- `npm run typecheck`
- `npm run lint`
- `node --test packages/cli/test/preset-script-cli.test.ts`
- `node --test packages/cli/test/check-governance-cli.test.ts`
- `node packages/cli/src/index.ts --json preset inspect milestone-dossier`
- `node packages/cli/src/index.ts --json script inspect preset:milestone-dossier:gather`
- `node packages/cli/src/index.ts --json template render template://dossier/editorial-shell@1 --locale zh-CN`
- `npm run check:pr` 已通过本地代码、测试、GUI、结构、schema、contract 等阶段，最后 supply-chain 的 `npm audit` 在本机多次遇到 registry TLS 连接中断；单独重跑 supply-chain 曾通过一次，后续失败仍是同类网络错误。

## 备注

D4 的通用 kind=check 收集接线目前还不存在，因此本 PR 按现有 metadata check profile 直接接入 dossier checker。preset 只负责供料、脚手架和门禁，不替代后续手写 `dossier.html` 的理解型内容。
