### PR TITLE
fix: allow decision→fact supports evidence relation in whitelist

### DIFF
--- a/packages/kernel/src/domain/entity-relation.ts
+++ b/packages/kernel/src/domain/entity-relation.ts
@@ -146,7 +146,12 @@ export function isAllowedRelationKindTriple(
     return type === "supersedes" || type === "refines" || type === "narrows" || type === "relates" || type === "blocks";
   }
   if (sourceKind === "decision" && targetKind === "task") return type === "derives";
-  if (sourceKind === "decision" && targetKind === "fact") return type === "supersedes-fact";
+  // decision->fact is the physical storage direction: the relation is hosted in the
+  // decision's frontmatter and points at the fact. "supports" is the standard evidence
+  // relation (the decision's claim is supported by the fact), authored from the decision
+  // side via `decision relate ... --type supports --target fact/...`. It reads
+  // semantically as fact->decision but is stored decision->fact, so it must be allowed here.
+  if (sourceKind === "decision" && targetKind === "fact") return type === "supersedes-fact" || type === "supports";
   if (sourceKind === "task" && targetKind === "decision") return type === "implements";
   if (sourceKind === "task" && targetKind === "task") return type === "blocks" || type === "relates";
   if (sourceKind === "task" && targetKind === "fact") return type === "produces" || type === "evidences";

--- a/packages/kernel/test/domain/entity-ref.test.ts
+++ b/packages/kernel/test/domain/entity-ref.test.ts
@@ -4,6 +4,7 @@ import { findEntityRefs, parseEntityRef } from "../../src/domain/entity-ref.ts";
 import {
   deriveRelationId,
   formatRelationFlowRecord,
+  isAllowedRelationKindTriple,
   validateRelationRecordsForHost
 } from "../../src/domain/entity-relation.ts";
 import type { EntityRelationRecord } from "../../src/domain/entity-relation.ts";
@@ -118,6 +119,18 @@ test("relation validator rejects host drift, duplicates, missing rationale, and 
       .map((issue) => issue.code),
     ["invalid_relation_endpoint"]
   );
+});
+
+test("decision->fact allows both supersedes-fact and the supports evidence relation", () => {
+  // Evidence relations are physically stored decision->fact (hosted in the decision,
+  // pointing at its supporting fact), authored via `decision relate ... --type supports`.
+  assert.equal(isAllowedRelationKindTriple("decision", "supports", "fact"), true);
+  assert.equal(isAllowedRelationKindTriple("decision", "supersedes-fact", "fact"), true);
+  // Direction remains enforced elsewhere: decision->task stays derives (not implements),
+  // and an unrelated type on decision->fact is still rejected.
+  assert.equal(isAllowedRelationKindTriple("decision", "derives", "task"), true);
+  assert.equal(isAllowedRelationKindTriple("decision", "implements", "task"), false);
+  assert.equal(isAllowedRelationKindTriple("decision", "blocks", "fact"), false);
 });
 
 test("relation flow formatter emits one flow-style line per record", () => {


### PR DESCRIPTION
# English

## Summary

Fix a whitelist over-rejection introduced by #179. The relation-kind whitelist rejected the standard evidence relation `decision->fact supports`, tripping the fail-closed check on 17 existing edges and blocking relation retire/replace on their host decisions.

## What Changed

- `packages/kernel/src/domain/entity-relation.ts`: `decision->fact` now allows `{ supersedes-fact, supports }` (was `supersedes-fact` only).
- Added a focused test asserting the decision->fact evidence relation is allowed while direction enforcement elsewhere is unchanged.

## Root Cause

Relations are physically stored in the source entity's frontmatter. An evidence relation ("a fact supports a decision") is authored from the decision side and stored `decision->fact`, even though it reads semantically as `fact->decision`. The draft matrix keyed `supports` only under `fact->decision` (semantic direction), so the physically `decision->fact` evidence edges hit the restricted row and were rejected.

## Task And Scope

- Harness task: follow-up to `task_01KWR2BE5EX09VK9GKN97SY2C9` / decision `dec_mr74sbka`
- Branch: `fix/relation-whitelist-evidence`
- Public scope: one kernel whitelist rule + test (2 files)
- Private planning/evidence updated: yes (`dec_mr74sbka` amended with the matrix correction)
- Out of scope: 8 wrong-direction `implements` edges and ambiguous triples — held for the matrix discussion, not migrated here.

## Version Impact

- Version: no version change because this is a whitelist correction, not a published surface change.
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: `cfc1a9f40` (after #179)
- Sync method: none needed (branched from latest main)
- Public diff command: `git diff cfc1a9f...fix/relation-whitelist-evidence`
- Private evidence: `dec_mr74sbka` amended body (matrix correction, physical vs semantic direction)
- [x] `node --test` affected suites (entity-ref, decision-cli, decision-write-service, relation-graph-projection): exit 0, 0 failures
- [x] `npm run typecheck` (passed)
- [ ] full `npm run check` / `npm test`: deferred to GitHub Actions `rewrite-ci`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run locally: full gate suite deferred to CI; ran the affected test suites + typecheck locally.

## Review Evidence

- Self-review: root cause confirmed against a real edge (`dec_F2_ACCEPT_RECKON/C1 -> F-HKPMAP7K`, an evidence relation) and the whitelist function keying on physical source/target kind. New test green.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Only the clearly-legitimate evidence relation is widened. Other rejected triples (wrong-direction implements, ambiguous relates/derives) stay blocked by design until the matrix is ratified — no active regression on normal writes (amend/accept/retire/relate all pass).

## References

- Task: `task_01KWR2BE5EX09VK9GKN97SY2C9`
- Evidence: `dec_mr74sbka` (active, amended)
- Prior: #179 (introduced the whitelist)

---

# 中文

## 概要

修 #179 引入的白名单误拒。relation 类型白名单拒绝了标准证据关系 `decision->fact supports`,导致 17 条存量边触发 fail-closed 校验,阻塞了这些宿主决策上的 relation retire/replace。

## 改动内容

- `packages/kernel/src/domain/entity-relation.ts`:`decision->fact` 现允许 `{ supersedes-fact, supports }`(原只有 supersedes-fact)。
- 加一个聚焦测试:断言 decision->fact 证据关系被允许,且别处方向约束不变。

## 根因

relation 物理上寄居在源实体的 frontmatter。证据关系("fact 支撑 decision")是从决策侧写的、物理存为 `decision->fact`,尽管语义读作 `fact->decision`。矩阵草案把 `supports` 只放在 `fact->decision`(语义方向)那格,于是物理为 `decision->fact` 的证据边撞进被限死的格子、遭拒。

## 任务与范围

- Harness 任务:`task_01KWR2BE5EX09VK9GKN97SY2C9` / 决策 `dec_mr74sbka` 的后续
- 分支:`fix/relation-whitelist-evidence`
- 公开范围:一条 kernel 白名单规则 + 测试(2 文件)
- 私有计划 / 证据是否已更新:yes(`dec_mr74sbka` 已 amend 记录矩阵修正)
- 范围外:8 条错向 `implements` 边与存疑三元组——留给矩阵讨论,本 PR 不迁移。

## 版本影响

- 版本:不改版本,这是白名单修正,非已发布表面变更。
- 发布影响:不发布

## 验证

- `origin/main` 基准 SHA:`cfc1a9f40`(在 #179 之后)
- 同步方式:不需要(基于最新 main 建分支)
- 公开 diff 命令:`git diff cfc1a9f...fix/relation-whitelist-evidence`
- 私有证据:`dec_mr74sbka` amend 正文(矩阵修正、物理 vs 语义方向)
- [x] `node --test` 受影响套件(entity-ref、decision-cli、decision-write-service、relation-graph-projection):exit 0,0 失败
- [x] `npm run typecheck`(通过)
- [ ] 完整 `npm run check` / `npm test`:延后到 GitHub Actions `rewrite-ci`
- [ ] GitHub Actions `rewrite-ci` passed
- 未本地运行:完整门禁套件延后到 CI;本地跑了受影响测试套件 + typecheck。

## 审查证据

- 自查:根因已对照一条真实边(`dec_F2_ACCEPT_RECKON/C1 -> F-HKPMAP7K`,证据关系)+ 白名单函数按物理 source/target kind 查证实;新测试通过。
- 人工审查:待进行
- 阻塞发现:无

## 残余风险

- 只放宽了明确合法的证据关系。其余被拒三元组(错向 implements、存疑 relates/derives)按设计仍拦,待矩阵拍板——对普通写(amend/accept/retire/relate 全过)无 active regression。

## 关联材料

- 任务:`task_01KWR2BE5EX09VK9GKN97SY2C9`
- 证据:`dec_mr74sbka`(active,已 amend)
- 前序:#179(引入白名单)

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
