### PR TITLE
feat: reskin milestone-dossier editorial shell to calm day/night style

### DIFF
--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/dossier.editorial.shell/en-US.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/dossier.editorial.shell/en-US.md
@@ -5,56 +5,326 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Milestone Dossier</title>
 <style>
-:root { --bg:#0b0d12; --bg-2:#11141c; --panel:#161a24; --panel-2:#1c2230; --ink:#e8eaf0; --ink-dim:#9aa3b4; --ink-faint:#5c6478; --line:#262d3d; --line-soft:#1f2433; --amber:#f0a830; --teal:#3fb8af; --rose:#e5484d; --violet:#a78bfa; --lime:#a3e635; }
-* { box-sizing: border-box; }
+/* ============================================================
+   Editorial shell — calm, readable, day/night.
+   LIGHT (default): warm off-white, near-black ink, newspaper calm.
+   DARK: soft muted charcoal, never pure black, never neon.
+   One low-saturation slate-indigo accent; muted sage/clay/brick
+   reserved for done / risk / rejected once an agent fills content.
+   ============================================================ */
+:root {
+  /* light (default) */
+  --bg:#faf9f6;
+  --panel:#ffffff;
+  --panel-2:#f5f2ec;
+  --ink:#1f1d1a;
+  --ink-dim:#57534a;
+  --ink-faint:#8a8478;
+  --line:#e7e3db;
+  --line-soft:#efece5;
+  --accent:#5b6b8c;          /* muted slate-indigo */
+  --accent-soft:#e8ebf2;
+  --done:#5f7a55;            /* muted sage */
+  --done-soft:#eef1ea;
+  --defer:#a07238;           /* muted clay/amber */
+  --defer-soft:#f4ecdc;
+  --reject:#9a4a3f;          /* muted brick */
+  --reject-soft:#f3e3df;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,"Times New Roman",serif;
+  --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  --mono:"SF Mono",SFMono-Regular,ui-monospace,"JetBrains Mono","Cascadia Code",Menlo,Consolas,"Liberation Mono",monospace;
+}
+:root[data-theme="dark"] {
+  --bg:#1b1d21;
+  --panel:#23262c;
+  --panel-2:#2a2e35;
+  --ink:#e6e3dd;
+  --ink-dim:#a9a39a;
+  --ink-faint:#7d776c;
+  --line:#373b43;
+  --line-soft:#2e3138;
+  --accent:#8896b5;
+  --accent-soft:#2c3142;
+  --done:#9bb089;
+  --done-soft:#2c352b;
+  --defer:#c89a5e;
+  --defer-soft:#38301f;
+  --reject:#bf8074;
+  --reject-soft:#3a2622;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
 html { scroll-behavior: smooth; }
-body { margin: 0; background: var(--bg); color: var(--ink); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; font-size: 15px; line-height: 1.62; letter-spacing: 0; -webkit-font-smoothing: antialiased; }
-.serif { font-family: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, "Times New Roman", serif; }
-.mono { font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, "Liberation Mono", monospace; }
-.wrap { width: min(1180px, calc(100vw - 40px)); margin: 0 auto; }
-.topbar { position: sticky; top: 0; z-index: 10; background: rgba(11, 13, 18, .86); backdrop-filter: blur(12px); border-bottom: 1px solid var(--line); }
-.topbar .row { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 13px 0; }
-.brand { display: flex; align-items: center; gap: 11px; font-weight: 650; font-size: 14px; }
-.brand .dot { width: 10px; height: 10px; border-radius: 3px; background: linear-gradient(135deg, var(--violet), var(--teal), var(--rose)); }
-nav { display: flex; gap: 4px; flex-wrap: wrap; justify-content: flex-end; }
-nav a { color: var(--ink-dim); text-decoration: none; font-size: 12px; padding: 5px 9px; border-radius: 6px; }
-nav a:hover { color: var(--ink); background: var(--panel); }
-.hero { padding: 82px 0 54px; border-bottom: 1px solid var(--line); }
-.eyebrow { color: var(--violet); font-size: 12px; letter-spacing: .1em; text-transform: uppercase; margin-bottom: 20px; }
-h1 { margin: 0; font-family: "Iowan Old Style", Palatino, Georgia, serif; font-size: clamp(38px, 5.4vw, 68px); line-height: 1.06; font-weight: 400; letter-spacing: 0; }
-.lede { margin: 24px 0 0; max-width: 820px; color: var(--ink-dim); font-family: "Iowan Old Style", Palatino, Georgia, serif; font-size: 19px; line-height: 1.56; }
-.meta-grid { display: grid; grid-template-columns: repeat(4, 1fr); border: 1px solid var(--line); border-radius: 12px; overflow: hidden; margin-top: 44px; }
-.meta-cell { padding: 18px 20px; background: var(--panel); border-right: 1px solid var(--line); }
-.meta-cell:last-child { border-right: 0; }
-.k { color: var(--ink-faint); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
-.v { margin-top: 7px; font-size: 21px; font-weight: 650; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+  text-wrap: pretty;
+  transition: background-color .25s ease, color .25s ease;
+}
+.serif { font-family: var(--serif); }
+.mono { font-family: var(--mono); }
+.wrap { max-width: 1080px; margin: 0 auto; padding: 0 32px; }
+
+/* ===== topbar ===== */
+.topbar {
+  position: sticky; top: 0; z-index: 50;
+  background: color-mix(in srgb, var(--bg) 92%, transparent);
+  backdrop-filter: saturate(140%) blur(10px);
+  border-bottom: 1px solid var(--line);
+}
+.topbar .row { display: flex; align-items: center; justify-content: space-between; padding: 14px 0; gap: 16px; }
+.brand { display: flex; align-items: center; gap: 10px; font-weight: 500; font-size: 14px; letter-spacing: -.005em; color: var(--ink); flex-shrink: 0; }
+.brand .dot { width: 8px; height: 8px; border-radius: 2px; background: var(--accent); }
+nav { display: flex; align-items: center; gap: 2px; flex-wrap: wrap; justify-content: flex-end; }
+nav a { color: var(--ink-dim); text-decoration: none; font-size: 13px; padding: 5px 11px; border-radius: 5px; transition: .15s; white-space: nowrap; }
+nav a:hover { color: var(--ink); background: var(--panel-2); }
+.theme-toggle {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 34px; height: 34px; border-radius: 6px; border: 1px solid var(--line);
+  background: var(--panel); color: var(--ink-dim); cursor: pointer; transition: .2s; margin-left: 6px;
+}
+.theme-toggle:hover { color: var(--accent); border-color: var(--accent); background: var(--panel-2); }
+.theme-toggle svg { width: 17px; height: 17px; display: block; }
+.theme-toggle .moon { display: none; }
+:root[data-theme="dark"] .theme-toggle .sun { display: none; }
+:root[data-theme="dark"] .theme-toggle .moon { display: block; }
+
+/* ===== hero ===== */
+.hero { padding: 72px 0 52px; border-bottom: 1px solid var(--line); }
+.eyebrow {
+  font-family: var(--mono); font-size: 11.5px; color: var(--accent);
+  letter-spacing: .1em; text-transform: uppercase; margin-bottom: 22px;
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.eyebrow::before { content: ""; width: 22px; height: 1px; background: var(--accent); }
+h1 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: clamp(34px, 5vw, 56px); line-height: 1.08; letter-spacing: -.015em;
+  margin-bottom: 24px; max-width: 20em; color: var(--ink);
+}
+.lede { font-size: 18px; color: var(--ink-dim); max-width: 68ch; line-height: 1.6; font-family: var(--serif); margin-top: 4px; }
+.lede code, code {
+  font-family: var(--mono); font-size: .85em;
+  background: var(--panel-2); padding: 1px 5px; border-radius: 3px; color: var(--accent);
+  border: 1px solid var(--line); white-space: nowrap;
+}
+.hero-figure {
+  margin-top: 40px; border: 1px solid var(--line); border-radius: 8px;
+  background: var(--panel); padding: 24px 24px 16px;
+}
+.hero-figure .figtitle {
+  font-family: var(--mono); font-size: 11px; color: var(--ink-faint);
+  letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px;
+}
+.hero-figure svg { display: block; width: 100%; height: auto; overflow: visible; }
+.hero-figure figcaption { margin-top: 12px; font-size: 12.5px; color: var(--ink-dim); line-height: 1.55; font-family: var(--serif); }
+.meta-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+  margin-top: 28px; border: 1px solid var(--line); border-radius: 8px; overflow: hidden;
+}
+.meta-cell { padding: 18px 22px; border-right: 1px solid var(--line); background: var(--panel); }
+.meta-cell:last-child { border-right: none; }
+.meta-cell .k { font-family: var(--mono); font-size: 10.5px; color: var(--ink-faint); letter-spacing: .07em; text-transform: uppercase; margin-bottom: 6px; }
+.meta-cell .v { font-size: 19px; font-weight: 500; letter-spacing: -.005em; line-height: 1.25; color: var(--ink); }
+
+/* ===== section ===== */
 section { padding: 64px 0; border-bottom: 1px solid var(--line); }
-.section-head { margin-bottom: 30px; }
-.section-num { color: var(--ink-faint); font-size: 12px; letter-spacing: .13em; text-transform: uppercase; }
-h2 { margin: 8px 0 0; font-family: "Iowan Old Style", Palatino, Georgia, serif; font-weight: 400; font-size: clamp(28px, 3.4vw, 42px); line-height: 1.12; letter-spacing: 0; }
-.takeaway { margin-top: 14px; max-width: 860px; border-left: 3px solid var(--violet); padding-left: 16px; color: var(--ink); }
-.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+.section-head { margin-bottom: 30px; max-width: 68ch; }
+.section-num { font-family: var(--mono); font-size: 11.5px; color: var(--ink-faint); letter-spacing: .12em; text-transform: uppercase; margin-bottom: 10px; }
+h2 { font-family: var(--serif); font-weight: 400; font-size: clamp(26px, 3.4vw, 38px); line-height: 1.16; letter-spacing: -.015em; margin-bottom: 14px; color: var(--ink); }
+.takeaway { color: var(--ink-dim); font-size: 16px; line-height: 1.62; border-left: 2px solid var(--accent); padding-left: 14px; }
+.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; align-items: start; }
 .card { border: 1px solid var(--line); border-radius: 8px; background: var(--panel); padding: 22px; }
-.card h3 { margin: 0 0 10px; font-size: 17px; }
+.card h3 { margin-bottom: 10px; font-family: var(--serif); font-weight: 400; font-size: 18px; color: var(--ink); }
 .card p, .card li { color: var(--ink-dim); }
-.placeholder { min-height: 90px; border: 1px dashed var(--line); border-radius: 8px; background: var(--bg-2); color: var(--ink-faint); padding: 16px; }
-table { width: 100%; border-collapse: collapse; table-layout: fixed; font-size: 13px; background: var(--panel); }
-th, td { border: 1px solid var(--line); padding: 10px 12px; text-align: left; vertical-align: top; overflow-wrap: anywhere; }
-th { color: var(--ink-faint); background: var(--bg-2); font-size: 11px; text-transform: uppercase; letter-spacing: .06em; }
-code { color: var(--teal); background: var(--bg-2); border: 1px solid var(--line-soft); border-radius: 4px; padding: 1px 5px; }
-footer { padding: 34px 0 48px; color: var(--ink-faint); }
-@media (max-width: 760px) { .topbar .row, .grid-2 { display: block; } nav { justify-content: flex-start; margin-top: 10px; } .meta-grid { grid-template-columns: 1fr 1fr; } .meta-cell { border-bottom: 1px solid var(--line); } }
+
+/* placeholder + empty diagram slot (agent replaces both) */
+.placeholder {
+  min-height: 90px; border: 1px dashed var(--line); border-radius: 8px;
+  background: var(--panel-2); color: var(--ink-faint); padding: 16px; font-size: 14px;
+}
+.diagram-slot {
+  margin-top: 22px; border: 1px dashed var(--line); border-radius: 8px;
+  background: var(--panel-2); padding: 20px; text-align: center;
+  color: var(--ink-faint); font-family: var(--mono); font-size: 11px;
+  letter-spacing: .05em; text-transform: uppercase;
+}
+
+/* ===== evidence table ===== */
+.scroll-x { overflow-x: auto; border-radius: 8px; border: 1px solid var(--line); -webkit-overflow-scrolling: touch; }
+table { width: 100%; border-collapse: collapse; font-size: 13px; background: var(--panel); min-width: 640px; }
+thead { background: var(--panel-2); }
+th { text-align: left; padding: 13px 16px; font-family: var(--mono); font-size: 10.5px; color: var(--ink-faint); letter-spacing: .06em; text-transform: uppercase; border-bottom: 1px solid var(--line); font-weight: 500; white-space: nowrap; }
+td { padding: 14px 16px; border-bottom: 1px solid var(--line-soft); vertical-align: top; line-height: 1.55; color: var(--ink-dim); overflow-wrap: anywhere; }
+tr:last-child td { border-bottom: none; }
+td code { white-space: normal; }
+
+/* ===== footer ===== */
+footer { padding: 44px 0 64px; color: var(--ink-faint); }
+footer .src { font-family: var(--mono); font-size: 11px; color: var(--ink-faint); line-height: 1.75; }
+
+/* ===== responsive ===== */
+@media (max-width: 760px) {
+  .wrap { padding: 0 22px; }
+  .hero { padding: 48px 0 36px; }
+  nav { justify-content: flex-start; }
+  .grid-2 { grid-template-columns: 1fr; }
+  .meta-grid { grid-template-columns: 1fr; }
+  .meta-cell { border-right: none; border-bottom: 1px solid var(--line); }
+  .meta-cell:last-child { border-bottom: none; }
+  section { padding: 46px 0; }
+}
 </style>
 </head>
 <body>
-<header class="topbar"><div class="wrap row"><div class="brand"><span class="dot"></span><span>milestone dossier</span></div><nav><a href="#brief">brief</a><a href="#boundary">boundary</a><a href="#evidence">evidence</a><a href="#provenance">provenance</a></nav></div></header>
+
+<!-- theme bootstrap: apply persisted / prefers-color-scheme choice before first paint -->
+<script>
+(function () {
+  try {
+    var saved = localStorage.getItem('ha-dossier-theme');
+    var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', saved || (prefersDark ? 'dark' : 'light'));
+  } catch (e) {
+    document.documentElement.setAttribute('data-theme', 'light');
+  }
+})();
+</script>
+
+<header class="topbar">
+  <div class="wrap row">
+    <div class="brand"><span class="dot"></span><span>milestone dossier</span></div>
+    <nav>
+      <a href="#brief">brief</a>
+      <a href="#boundary">boundary</a>
+      <a href="#evidence">evidence</a>
+      <a href="#provenance">provenance</a>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle day / night theme" title="Toggle day / night theme">
+        <!-- sun (shown in light) -->
+        <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="4"/>
+          <line x1="12" y1="2" x2="12" y2="4"/><line x1="12" y1="20" x2="12" y2="22"/>
+          <line x1="2" y1="12" x2="4" y2="12"/><line x1="20" y1="12" x2="22" y2="12"/>
+          <line x1="4.5" y1="4.5" x2="6" y2="6"/><line x1="18" y1="18" x2="19.5" y2="19.5"/>
+          <line x1="4.5" y1="19.5" x2="6" y2="18"/><line x1="18" y1="6" x2="19.5" y2="4.5"/>
+        </svg>
+        <!-- moon (shown in dark) -->
+        <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/>
+        </svg>
+      </button>
+    </nav>
+  </div>
+</header>
+
+<script>
+document.getElementById('themeToggle').addEventListener('click', function () {
+  var cur = document.documentElement.getAttribute('data-theme') || 'light';
+  var next = cur === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  try { localStorage.setItem('ha-dossier-theme', next); } catch (e) {}
+});
+</script>
+
 <main>
-  <div class="hero"><div class="wrap"><div class="eyebrow mono">aggregation boundary</div><h1>Write the milestone close boundary as an auditable understanding dossier</h1><p class="lede">This file is only the editorial shell. Use <code>artifacts/dossier.data.json</code> and the original source documents to write the final human interpretation by hand.</p><div class="meta-grid"><div class="meta-cell"><div class="k mono">coordination task</div><div class="v">task/...</div></div><div class="meta-cell"><div class="k mono">boundary decision</div><div class="v">decision/...</div></div><div class="meta-cell"><div class="k mono">coverage</div><div class="v">0 / 0</div></div><div class="meta-cell"><div class="k mono">status</div><div class="v">draft</div></div></div></div></div>
-  <section id="brief" data-dossier-section="brief"><div class="wrap"><div class="section-head"><div class="section-num mono">01 / brief</div><h2>Closeout Brief</h2><p class="takeaway">Explain the milestone objective, the boundary that is complete, and the risks still worth carrying forward.</p></div><div class="placeholder">Agent-authored narrative goes here.</div></div></section>
-  <section id="boundary" data-dossier-section="boundary"><div class="wrap"><div class="section-head"><div class="section-num mono">02 / boundary</div><h2>Aggregation Boundary</h2><p class="takeaway">State which tasks, decisions, and facts form the close boundary, and why this is the correct stopping point.</p></div><div class="grid-2"><div class="card"><h3>Included</h3><div class="placeholder">Task and decision groups.</div></div><div class="card"><h3>Excluded</h3><div class="placeholder">Deferred or out-of-bound work.</div></div></div></div></section>
-  <section id="evidence" data-dossier-section="evidence"><div class="wrap"><div class="section-head"><div class="section-num mono">03 / evidence</div><h2>Evidence And Coverage</h2><p class="takeaway">Translate coverage rows, facts, and relation paths into a reviewable evidence story.</p></div><table><thead><tr><th>Claim</th><th>Evidence</th><th>Interpretation</th></tr></thead><tbody><tr><td>decision/.../C1</td><td>fact/.../F-...</td><td>Replace with authored reading.</td></tr></tbody></table></div></section>
-  <section id="provenance" data-dossier-section="provenance"><div class="wrap"><div class="section-head"><div class="section-num mono">04 / provenance</div><h2>Resolvable References</h2><p class="takeaway">List the real entity refs used by this dossier. The checker verifies resolution only, not writing quality.</p></div><div class="placeholder">task/..., decision/..., fact/.../F-...</div></div></section>
+  <div class="hero">
+    <div class="wrap">
+      <div class="eyebrow">aggregation boundary</div>
+      <h1>Write the milestone close boundary as an auditable understanding dossier</h1>
+      <p class="lede">This file is only the editorial shell. Use <code>artifacts/dossier.data.json</code> and the original source documents to write the final human interpretation by hand.</p>
+
+      <!-- Theme-aware inline-SVG placeholder. It uses CSS vars (var(--line), var(--accent), var(--done))
+           and currentColor, so it repaints correctly in both light and dark. Replace with a real
+           diagram (timeline / boundary set / coverage) drawn from artifacts/dossier.data.json.
+           PATTERN for filling agents — draw diagrams inline like this, no external images:
+             <svg viewBox="0 0 W H" role="img" aria-label="...">
+               <line ... stroke="var(--line)"/>          quiet structure
+               <circle ... fill="var(--done)"/>          done / covered
+               <rect ... stroke="var(--accent)"/>        highlighted / in-scope
+               <text ... fill="var(--ink)">label</text>  theme-aware text
+             </svg>
+           Never hardcode hex colors; always reference the CSS custom properties above. -->
+      <figure class="hero-figure">
+        <div class="figtitle">FIG · placeholder diagram · replace with real coverage / boundary art</div>
+        <svg viewBox="0 0 880 120" role="img" aria-label="Placeholder milestone rail: an empty progress track awaiting real packet data">
+          <line x1="30" y1="60" x2="850" y2="60" stroke="var(--line)" stroke-width="1"/>
+          <g font-family="var(--mono)" font-size="10" text-anchor="middle" fill="var(--ink-faint)">
+            <g transform="translate(30,60)"><circle r="6" fill="var(--panel)" stroke="var(--line)" stroke-width="1.2"/><text y="22">start</text></g>
+            <g transform="translate(300,60)"><circle r="5" fill="var(--panel)" stroke="var(--line)" stroke-width="1.2"/></g>
+            <g transform="translate(570,60)"><circle r="5" fill="var(--panel)" stroke="var(--line)" stroke-width="1.2"/></g>
+            <g transform="translate(850,60)"><circle r="6.5" fill="var(--panel)" stroke="var(--accent)" stroke-width="1.2"/><text y="22" fill="var(--accent)">close</text></g>
+          </g>
+        </svg>
+        <figcaption>Placeholder only. Replace with a theme-aware diagram of the real coverage or boundary once data is in hand.</figcaption>
+      </figure>
+
+      <div class="meta-grid">
+        <div class="meta-cell"><div class="k mono">coordination task</div><div class="v">task/...</div></div>
+        <div class="meta-cell"><div class="k mono">boundary decision</div><div class="v">decision/...</div></div>
+        <div class="meta-cell"><div class="k mono">coverage</div><div class="v">0 / 0</div></div>
+        <div class="meta-cell"><div class="k mono">status</div><div class="v">draft</div></div>
+      </div>
+    </div>
+  </div>
+
+  <section id="brief" data-dossier-section="brief">
+    <div class="wrap">
+      <div class="section-head">
+        <div class="section-num">01 / brief</div>
+        <h2>Closeout Brief</h2>
+        <p class="takeaway">Explain the milestone objective, the boundary that is complete, and the risks still worth carrying forward.</p>
+      </div>
+      <div class="placeholder">Agent-authored narrative goes here.</div>
+      <div class="diagram-slot">empty diagram slot — draw a theme-aware inline SVG here</div>
+    </div>
+  </section>
+
+  <section id="boundary" data-dossier-section="boundary">
+    <div class="wrap">
+      <div class="section-head">
+        <div class="section-num">02 / boundary</div>
+        <h2>Aggregation Boundary</h2>
+        <p class="takeaway">State which tasks, decisions, and facts form the close boundary, and why this is the correct stopping point.</p>
+      </div>
+      <div class="grid-2">
+        <div class="card"><h3>Included</h3><div class="placeholder">Task and decision groups.</div></div>
+        <div class="card"><h3>Excluded</h3><div class="placeholder">Deferred or out-of-bound work.</div></div>
+      </div>
+      <div class="diagram-slot">empty diagram slot — draw an included / excluded set diagram here</div>
+    </div>
+  </section>
+
+  <section id="evidence" data-dossier-section="evidence">
+    <div class="wrap">
+      <div class="section-head">
+        <div class="section-num">03 / evidence</div>
+        <h2>Evidence And Coverage</h2>
+        <p class="takeaway">Translate coverage rows, facts, and relation paths into a reviewable evidence story.</p>
+      </div>
+      <div class="scroll-x">
+        <table>
+          <thead><tr><th>Claim</th><th>Evidence</th><th>Interpretation</th></tr></thead>
+          <tbody><tr><td><code>decision/.../C1</code></td><td><code>fact/.../F-...</code></td><td>Replace with authored reading.</td></tr></tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <section id="provenance" data-dossier-section="provenance">
+    <div class="wrap">
+      <div class="section-head">
+        <div class="section-num">04 / provenance</div>
+        <h2>Resolvable References</h2>
+        <p class="takeaway">List the real entity refs used by this dossier. The checker verifies resolution only, not writing quality.</p>
+      </div>
+      <div class="placeholder mono">task/..., decision/..., fact/.../F-...</div>
+    </div>
+  </section>
 </main>
-<footer><div class="wrap mono">Generated from template://dossier/editorial-shell@1. Write final content to artifacts/dossier.html.</div></footer>
+
+<footer><div class="wrap src">Generated from template://dossier/editorial-shell@1. Write final content to artifacts/dossier.html.</div></footer>
 </body>
 </html>

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/dossier.editorial.shell/zh-CN.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/dossier.editorial.shell/zh-CN.md
@@ -5,77 +5,195 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Milestone Dossier</title>
 <style>
+/* ============================================================
+   Editorial shell — calm, readable, day/night.
+   LIGHT (default): warm off-white, near-black ink, newspaper calm.
+   DARK: soft muted charcoal, never pure black, never neon.
+   One low-saturation slate-indigo accent; muted sage/clay/brick
+   reserved for done / risk / rejected once an agent fills content.
+   ============================================================ */
 :root {
-  --bg: #0b0d12;
-  --bg-2: #11141c;
-  --panel: #161a24;
-  --panel-2: #1c2230;
-  --ink: #e8eaf0;
-  --ink-dim: #9aa3b4;
-  --ink-faint: #5c6478;
-  --line: #262d3d;
-  --line-soft: #1f2433;
-  --amber: #f0a830;
-  --teal: #3fb8af;
-  --rose: #e5484d;
-  --violet: #a78bfa;
-  --lime: #a3e635;
+  /* light (default) */
+  --bg:#faf9f6;
+  --panel:#ffffff;
+  --panel-2:#f5f2ec;
+  --ink:#1f1d1a;
+  --ink-dim:#57534a;
+  --ink-faint:#8a8478;
+  --line:#e7e3db;
+  --line-soft:#efece5;
+  --accent:#5b6b8c;          /* muted slate-indigo */
+  --accent-soft:#e8ebf2;
+  --done:#5f7a55;            /* muted sage */
+  --done-soft:#eef1ea;
+  --defer:#a07238;           /* muted clay/amber */
+  --defer-soft:#f4ecdc;
+  --reject:#9a4a3f;          /* muted brick */
+  --reject-soft:#f3e3df;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua","Songti SC",Georgia,"Times New Roman",serif;
+  --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif;
+  --mono:"SF Mono",SFMono-Regular,ui-monospace,"JetBrains Mono","Cascadia Code",Menlo,Consolas,"Liberation Mono",monospace;
 }
-* { box-sizing: border-box; }
+:root[data-theme="dark"] {
+  --bg:#1b1d21;
+  --panel:#23262c;
+  --panel-2:#2a2e35;
+  --ink:#e6e3dd;
+  --ink-dim:#a9a39a;
+  --ink-faint:#7d776c;
+  --line:#373b43;
+  --line-soft:#2e3138;
+  --accent:#8896b5;
+  --accent-soft:#2c3142;
+  --done:#9bb089;
+  --done-soft:#2c352b;
+  --defer:#c89a5e;
+  --defer-soft:#38301f;
+  --reject:#bf8074;
+  --reject-soft:#3a2622;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
 html { scroll-behavior: smooth; }
 body {
-  margin: 0;
   background: var(--bg);
   color: var(--ink);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
-  font-size: 15px;
-  line-height: 1.62;
-  letter-spacing: 0;
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.7;
   -webkit-font-smoothing: antialiased;
+  text-wrap: pretty;
+  transition: background-color .25s ease, color .25s ease;
 }
-.serif { font-family: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", "Songti SC", Georgia, "Times New Roman", serif; }
-.mono { font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, "Liberation Mono", monospace; }
-.wrap { width: min(1180px, calc(100vw - 40px)); margin: 0 auto; }
-.topbar { position: sticky; top: 0; z-index: 10; background: rgba(11, 13, 18, .86); backdrop-filter: blur(12px); border-bottom: 1px solid var(--line); }
-.topbar .row { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 13px 0; }
-.brand { display: flex; align-items: center; gap: 11px; font-weight: 650; font-size: 14px; }
-.brand .dot { width: 10px; height: 10px; border-radius: 3px; background: linear-gradient(135deg, var(--violet), var(--teal), var(--rose)); }
-nav { display: flex; gap: 4px; flex-wrap: wrap; justify-content: flex-end; }
-nav a { color: var(--ink-dim); text-decoration: none; font-size: 12px; padding: 5px 9px; border-radius: 6px; }
-nav a:hover { color: var(--ink); background: var(--panel); }
-.hero { padding: 82px 0 54px; border-bottom: 1px solid var(--line); }
-.eyebrow { color: var(--violet); font-size: 12px; letter-spacing: .1em; text-transform: uppercase; margin-bottom: 20px; }
-h1 { margin: 0; font-family: "Iowan Old Style", Palatino, "Songti SC", Georgia, serif; font-size: clamp(38px, 5.4vw, 68px); line-height: 1.06; font-weight: 400; letter-spacing: 0; }
-.lede { margin: 24px 0 0; max-width: 820px; color: var(--ink-dim); font-family: "Iowan Old Style", Palatino, "Songti SC", Georgia, serif; font-size: 19px; line-height: 1.56; }
-.meta-grid { display: grid; grid-template-columns: repeat(4, 1fr); border: 1px solid var(--line); border-radius: 12px; overflow: hidden; margin-top: 44px; }
-.meta-cell { padding: 18px 20px; background: var(--panel); border-right: 1px solid var(--line); }
-.meta-cell:last-child { border-right: 0; }
-.k { color: var(--ink-faint); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
-.v { margin-top: 7px; font-size: 21px; font-weight: 650; }
+.serif { font-family: var(--serif); }
+.mono { font-family: var(--mono); }
+.wrap { max-width: 1080px; margin: 0 auto; padding: 0 32px; }
+
+/* ===== topbar ===== */
+.topbar {
+  position: sticky; top: 0; z-index: 50;
+  background: color-mix(in srgb, var(--bg) 92%, transparent);
+  backdrop-filter: saturate(140%) blur(10px);
+  border-bottom: 1px solid var(--line);
+}
+.topbar .row { display: flex; align-items: center; justify-content: space-between; padding: 14px 0; gap: 16px; }
+.brand { display: flex; align-items: center; gap: 10px; font-weight: 500; font-size: 14px; letter-spacing: -.005em; color: var(--ink); flex-shrink: 0; }
+.brand .dot { width: 8px; height: 8px; border-radius: 2px; background: var(--accent); }
+nav { display: flex; align-items: center; gap: 2px; flex-wrap: wrap; justify-content: flex-end; }
+nav a { color: var(--ink-dim); text-decoration: none; font-size: 13px; padding: 5px 11px; border-radius: 5px; transition: .15s; white-space: nowrap; }
+nav a:hover { color: var(--ink); background: var(--panel-2); }
+.theme-toggle {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 34px; height: 34px; border-radius: 6px; border: 1px solid var(--line);
+  background: var(--panel); color: var(--ink-dim); cursor: pointer; transition: .2s; margin-left: 6px;
+}
+.theme-toggle:hover { color: var(--accent); border-color: var(--accent); background: var(--panel-2); }
+.theme-toggle svg { width: 17px; height: 17px; display: block; }
+.theme-toggle .moon { display: none; }
+:root[data-theme="dark"] .theme-toggle .sun { display: none; }
+:root[data-theme="dark"] .theme-toggle .moon { display: block; }
+
+/* ===== hero ===== */
+.hero { padding: 72px 0 52px; border-bottom: 1px solid var(--line); }
+.eyebrow {
+  font-family: var(--mono); font-size: 11.5px; color: var(--accent);
+  letter-spacing: .1em; text-transform: uppercase; margin-bottom: 22px;
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.eyebrow::before { content: ""; width: 22px; height: 1px; background: var(--accent); }
+h1 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: clamp(30px, 4.6vw, 50px); line-height: 1.14; letter-spacing: 0;
+  margin-bottom: 24px; max-width: 22em; color: var(--ink);
+}
+.lede { font-size: 18px; color: var(--ink-dim); max-width: 46em; line-height: 1.66; font-family: var(--serif); margin-top: 4px; }
+.lede code, code {
+  font-family: var(--mono); font-size: .85em;
+  background: var(--panel-2); padding: 1px 5px; border-radius: 3px; color: var(--accent);
+  border: 1px solid var(--line); white-space: nowrap;
+}
+.hero-figure {
+  margin-top: 40px; border: 1px solid var(--line); border-radius: 8px;
+  background: var(--panel); padding: 24px 24px 16px;
+}
+.hero-figure .figtitle {
+  font-family: var(--mono); font-size: 11px; color: var(--ink-faint);
+  letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px;
+}
+.hero-figure svg { display: block; width: 100%; height: auto; overflow: visible; }
+.hero-figure figcaption { margin-top: 12px; font-size: 12.5px; color: var(--ink-dim); line-height: 1.6; font-family: var(--serif); }
+.meta-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+  margin-top: 28px; border: 1px solid var(--line); border-radius: 8px; overflow: hidden;
+}
+.meta-cell { padding: 18px 22px; border-right: 1px solid var(--line); background: var(--panel); }
+.meta-cell:last-child { border-right: none; }
+.meta-cell .k { font-family: var(--mono); font-size: 10.5px; color: var(--ink-faint); letter-spacing: .07em; text-transform: uppercase; margin-bottom: 6px; }
+.meta-cell .v { font-size: 19px; font-weight: 500; letter-spacing: -.005em; line-height: 1.25; color: var(--ink); }
+
+/* ===== section ===== */
 section { padding: 64px 0; border-bottom: 1px solid var(--line); }
-.section-head { margin-bottom: 30px; }
-.section-num { color: var(--ink-faint); font-size: 12px; letter-spacing: .13em; text-transform: uppercase; }
-h2 { margin: 8px 0 0; font-family: "Iowan Old Style", Palatino, "Songti SC", Georgia, serif; font-weight: 400; font-size: clamp(28px, 3.4vw, 42px); line-height: 1.12; letter-spacing: 0; }
-.takeaway { margin-top: 14px; max-width: 860px; border-left: 3px solid var(--violet); padding-left: 16px; color: var(--ink); }
-.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+.section-head { margin-bottom: 30px; max-width: 46em; }
+.section-num { font-family: var(--mono); font-size: 11.5px; color: var(--ink-faint); letter-spacing: .12em; text-transform: uppercase; margin-bottom: 10px; }
+h2 { font-family: var(--serif); font-weight: 400; font-size: clamp(24px, 3.2vw, 34px); line-height: 1.24; letter-spacing: 0; margin-bottom: 14px; color: var(--ink); }
+.takeaway { color: var(--ink-dim); font-size: 16px; line-height: 1.7; border-left: 2px solid var(--accent); padding-left: 14px; }
+.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; align-items: start; }
 .card { border: 1px solid var(--line); border-radius: 8px; background: var(--panel); padding: 22px; }
-.card h3 { margin: 0 0 10px; font-size: 17px; }
+.card h3 { margin-bottom: 10px; font-family: var(--serif); font-weight: 400; font-size: 18px; color: var(--ink); }
 .card p, .card li { color: var(--ink-dim); }
-.placeholder { min-height: 90px; border: 1px dashed var(--line); border-radius: 8px; background: var(--bg-2); color: var(--ink-faint); padding: 16px; }
-table { width: 100%; border-collapse: collapse; table-layout: fixed; font-size: 13px; background: var(--panel); }
-th, td { border: 1px solid var(--line); padding: 10px 12px; text-align: left; vertical-align: top; overflow-wrap: anywhere; }
-th { color: var(--ink-faint); background: var(--bg-2); font-size: 11px; text-transform: uppercase; letter-spacing: .06em; }
-code { color: var(--teal); background: var(--bg-2); border: 1px solid var(--line-soft); border-radius: 4px; padding: 1px 5px; }
-footer { padding: 34px 0 48px; color: var(--ink-faint); }
+
+/* placeholder + empty diagram slot (agent replaces both) */
+.placeholder {
+  min-height: 90px; border: 1px dashed var(--line); border-radius: 8px;
+  background: var(--panel-2); color: var(--ink-faint); padding: 16px; font-size: 14px;
+}
+.diagram-slot {
+  margin-top: 22px; border: 1px dashed var(--line); border-radius: 8px;
+  background: var(--panel-2); padding: 20px; text-align: center;
+  color: var(--ink-faint); font-family: var(--mono); font-size: 11px;
+  letter-spacing: .05em; text-transform: uppercase;
+}
+
+/* ===== evidence table ===== */
+.scroll-x { overflow-x: auto; border-radius: 8px; border: 1px solid var(--line); -webkit-overflow-scrolling: touch; }
+table { width: 100%; border-collapse: collapse; font-size: 13px; background: var(--panel); min-width: 640px; }
+thead { background: var(--panel-2); }
+th { text-align: left; padding: 13px 16px; font-family: var(--mono); font-size: 10.5px; color: var(--ink-faint); letter-spacing: .06em; text-transform: uppercase; border-bottom: 1px solid var(--line); font-weight: 500; white-space: nowrap; }
+td { padding: 14px 16px; border-bottom: 1px solid var(--line-soft); vertical-align: top; line-height: 1.6; color: var(--ink-dim); overflow-wrap: anywhere; }
+tr:last-child td { border-bottom: none; }
+td code { white-space: normal; }
+
+/* ===== footer ===== */
+footer { padding: 44px 0 64px; color: var(--ink-faint); }
+footer .src { font-family: var(--mono); font-size: 11px; color: var(--ink-faint); line-height: 1.75; }
+
+/* ===== responsive ===== */
 @media (max-width: 760px) {
-  .topbar .row, .grid-2 { display: block; }
-  nav { justify-content: flex-start; margin-top: 10px; }
-  .meta-grid { grid-template-columns: 1fr 1fr; }
-  .meta-cell { border-bottom: 1px solid var(--line); }
+  .wrap { padding: 0 22px; }
+  .hero { padding: 48px 0 36px; }
+  nav { justify-content: flex-start; }
+  .grid-2 { grid-template-columns: 1fr; }
+  .meta-grid { grid-template-columns: 1fr; }
+  .meta-cell { border-right: none; border-bottom: 1px solid var(--line); }
+  .meta-cell:last-child { border-bottom: none; }
+  section { padding: 46px 0; }
 }
 </style>
 </head>
 <body>
+
+<!-- theme bootstrap: apply persisted / prefers-color-scheme choice before first paint -->
+<script>
+(function () {
+  try {
+    var saved = localStorage.getItem('ha-dossier-theme');
+    var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', saved || (prefersDark ? 'dark' : 'light'));
+  } catch (e) {
+    document.documentElement.setAttribute('data-theme', 'light');
+  }
+})();
+</script>
+
 <header class="topbar">
   <div class="wrap row">
     <div class="brand"><span class="dot"></span><span>milestone dossier</span></div>
@@ -84,15 +202,65 @@ footer { padding: 34px 0 48px; color: var(--ink-faint); }
       <a href="#boundary">boundary</a>
       <a href="#evidence">evidence</a>
       <a href="#provenance">provenance</a>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="切换日 / 夜主题" title="切换日 / 夜主题">
+        <!-- sun (shown in light) -->
+        <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="4"/>
+          <line x1="12" y1="2" x2="12" y2="4"/><line x1="12" y1="20" x2="12" y2="22"/>
+          <line x1="2" y1="12" x2="4" y2="12"/><line x1="20" y1="12" x2="22" y2="12"/>
+          <line x1="4.5" y1="4.5" x2="6" y2="6"/><line x1="18" y1="18" x2="19.5" y2="19.5"/>
+          <line x1="4.5" y1="19.5" x2="6" y2="18"/><line x1="18" y1="6" x2="19.5" y2="4.5"/>
+        </svg>
+        <!-- moon (shown in dark) -->
+        <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/>
+        </svg>
+      </button>
     </nav>
   </div>
 </header>
+
+<script>
+document.getElementById('themeToggle').addEventListener('click', function () {
+  var cur = document.documentElement.getAttribute('data-theme') || 'light';
+  var next = cur === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  try { localStorage.setItem('ha-dossier-theme', next); } catch (e) {}
+});
+</script>
+
 <main>
   <div class="hero">
     <div class="wrap">
-      <div class="eyebrow mono">aggregation boundary</div>
+      <div class="eyebrow">aggregation boundary</div>
       <h1>把这个里程碑为什么能收口,写成可审计的理解档案</h1>
       <p class="lede">这里保留编辑级排版骨架。请基于 <code>artifacts/dossier.data.json</code> 与真实原文,亲手写出综合判断、证据取舍和边界结论。</p>
+
+      <!-- 主题感知的内联 SVG 占位。它使用 CSS 变量(var(--line)、var(--accent)、var(--done))与
+           currentColor,因此在日 / 夜模式下都会正确重绘。填档 agent 请用真实的
+           timeline / boundary / coverage 图替换,数据取自 artifacts/dossier.data.json。
+           内联绘图模式(不要外链图片):
+             <svg viewBox="0 0 W H" role="img" aria-label="...">
+               <line ... stroke="var(--line)"/>          安静的结构线
+               <circle ... fill="var(--done)"/>          done / covered
+               <rect ... stroke="var(--accent)"/>        高亮 / in-scope
+               <text ... fill="var(--ink)">标签</text>   主题感知文字
+             </svg>
+           永远不要写死 hex 颜色,一律引用上面的 CSS 自定义属性。 -->
+      <figure class="hero-figure">
+        <div class="figtitle">FIG · 占位示意图 · 请替换为真实的覆盖 / 边界图</div>
+        <svg viewBox="0 0 880 120" role="img" aria-label="占位里程碑轨道:一条尚待填入真实 packet 数据的空进度轨">
+          <line x1="30" y1="60" x2="850" y2="60" stroke="var(--line)" stroke-width="1"/>
+          <g font-family="var(--mono)" font-size="10" text-anchor="middle" fill="var(--ink-faint)">
+            <g transform="translate(30,60)"><circle r="6" fill="var(--panel)" stroke="var(--line)" stroke-width="1.2"/><text y="22">start</text></g>
+            <g transform="translate(300,60)"><circle r="5" fill="var(--panel)" stroke="var(--line)" stroke-width="1.2"/></g>
+            <g transform="translate(570,60)"><circle r="5" fill="var(--panel)" stroke="var(--line)" stroke-width="1.2"/></g>
+            <g transform="translate(850,60)"><circle r="6.5" fill="var(--panel)" stroke="var(--accent)" stroke-width="1.2"/><text y="22" fill="var(--accent)">close</text></g>
+          </g>
+        </svg>
+        <figcaption>仅为占位。拿到真实数据后,请替换为主题感知的覆盖或边界示意图。</figcaption>
+      </figure>
+
       <div class="meta-grid">
         <div class="meta-cell"><div class="k mono">coordination task</div><div class="v">task/...</div></div>
         <div class="meta-cell"><div class="k mono">boundary decision</div><div class="v">decision/...</div></div>
@@ -101,31 +269,62 @@ footer { padding: 34px 0 48px; color: var(--ink-faint); }
       </div>
     </div>
   </div>
+
   <section id="brief" data-dossier-section="brief">
     <div class="wrap">
-      <div class="section-head"><div class="section-num mono">01 / brief</div><h2>收口摘要</h2><p class="takeaway">用少量判断讲清里程碑的目标、已经完成的边界、仍需保留的风险。</p></div>
+      <div class="section-head">
+        <div class="section-num">01 / brief</div>
+        <h2>收口摘要</h2>
+        <p class="takeaway">用少量判断讲清里程碑的目标、已经完成的边界、仍需保留的风险。</p>
+      </div>
       <div class="placeholder">Agent-authored narrative goes here.</div>
+      <div class="diagram-slot">空图槽 — 在此绘制主题感知的内联 SVG</div>
     </div>
   </section>
+
   <section id="boundary" data-dossier-section="boundary">
     <div class="wrap">
-      <div class="section-head"><div class="section-num mono">02 / boundary</div><h2>聚合边界裁决</h2><p class="takeaway">解释哪些任务、决策和事实构成了本次收口的边界,以及为什么可以在这里停下。</p></div>
-      <div class="grid-2"><div class="card"><h3>Included</h3><div class="placeholder">Task and decision groups.</div></div><div class="card"><h3>Excluded</h3><div class="placeholder">Deferred or out-of-bound work.</div></div></div>
+      <div class="section-head">
+        <div class="section-num">02 / boundary</div>
+        <h2>聚合边界裁决</h2>
+        <p class="takeaway">解释哪些任务、决策和事实构成了本次收口的边界,以及为什么可以在这里停下。</p>
+      </div>
+      <div class="grid-2">
+        <div class="card"><h3>Included</h3><div class="placeholder">Task and decision groups.</div></div>
+        <div class="card"><h3>Excluded</h3><div class="placeholder">Deferred or out-of-bound work.</div></div>
+      </div>
+      <div class="diagram-slot">空图槽 — 在此绘制 included / excluded 集合示意图</div>
     </div>
   </section>
+
   <section id="evidence" data-dossier-section="evidence">
     <div class="wrap">
-      <div class="section-head"><div class="section-num mono">03 / evidence</div><h2>证据与覆盖</h2><p class="takeaway">把 coverage rows、facts、关键关系链翻译成人能复核的证据故事。</p></div>
-      <table><thead><tr><th>Claim</th><th>Evidence</th><th>Interpretation</th></tr></thead><tbody><tr><td>decision/.../C1</td><td>fact/.../F-...</td><td>Replace with authored reading.</td></tr></tbody></table>
+      <div class="section-head">
+        <div class="section-num">03 / evidence</div>
+        <h2>证据与覆盖</h2>
+        <p class="takeaway">把 coverage rows、facts、关键关系链翻译成人能复核的证据故事。</p>
+      </div>
+      <div class="scroll-x">
+        <table>
+          <thead><tr><th>Claim</th><th>Evidence</th><th>Interpretation</th></tr></thead>
+          <tbody><tr><td><code>decision/.../C1</code></td><td><code>fact/.../F-...</code></td><td>Replace with authored reading.</td></tr></tbody>
+        </table>
+      </div>
     </div>
   </section>
+
   <section id="provenance" data-dossier-section="provenance">
     <div class="wrap">
-      <div class="section-head"><div class="section-num mono">04 / provenance</div><h2>可追溯引用</h2><p class="takeaway">列出 dossier 中使用的真实 entity refs。checker 只验证这些引用能解析,不评价文字质量。</p></div>
-      <div class="placeholder">task/..., decision/..., fact/.../F-...</div>
+      <div class="section-head">
+        <div class="section-num">04 / provenance</div>
+        <h2>可追溯引用</h2>
+        <p class="takeaway">列出 dossier 中使用的真实 entity refs。checker 只验证这些引用能解析,不评价文字质量。</p>
+      </div>
+      <div class="placeholder mono">task/..., decision/..., fact/.../F-...</div>
     </div>
   </section>
 </main>
-<footer><div class="wrap mono">Generated from template://dossier/editorial-shell@1. Write final content to artifacts/dossier.html.</div></footer>
+
+<footer><div class="wrap src">Generated from template://dossier/editorial-shell@1. Write final content to artifacts/dossier.html.</div></footer>
 </body>
 </html>


### PR DESCRIPTION
# English

## Summary

Reskin the milestone-dossier editorial shell template from its cyberpunk neon-on-black look to a calm, readable day/night editorial style, implementing accepted decision `dec_mr7re23p` ("self-generated understanding HTML aesthetics: restrained and easy on the eyes, day/night toggle, use SVG generously"). This is a template-only visual change: both locale shells keep every placeholder and structural anchor untouched.

## What Changed

- Rewrote the two blank shell files `templates/dossier.editorial.shell/en-US.md` and `zh-CN.md` (raw HTML despite the `.md` extension).
- New theme system: light default is warm off-white (`#faf9f6`) with near-black ink; dark is soft muted charcoal (`#1b1d21`), never pure black, never neon. Colors swap via CSS custom properties on `:root[data-theme="light|dark"]`.
- Added a sun/moon inline-SVG day/night toggle that follows `prefers-color-scheme`, lets a click override, persists in `localStorage`, and applies the theme before first paint via a small inline script.
- Low-saturation palette: one quiet slate-indigo accent, with muted sage/clay/brick reserved for done/risk/rejected once an agent fills content. Serif headings and lede, system sans body, mono for refs and code.
- Added one theme-aware inline SVG placeholder in the hero plus a documented inline-SVG pattern comment and per-section empty diagram slots, honoring "use SVG generously" as guidance for the filling agent without inventing fake data.
- Preserved template semantics: the four `data-dossier-section="brief|boundary|evidence|provenance"` anchors, hero meta-grid placeholders (`task/...`, `decision/...`, `0 / 0`, `draft`), the evidence table placeholder row, the provenance refs line, the eyebrow/section-number editorial structure, and the footer note about `template://dossier/editorial-shell` writing to `artifacts/dossier.html`.
- No M2.5 data (no packet ids, PR numbers, or merge hashes) is hardcoded. Each file is a single self-contained HTML document with all CSS/JS/SVG inline and zero external fonts, scripts, or images.

## Task And Scope

- Harness task: reskin milestone-dossier editorial shell per decision `dec_mr7re23p`.
- Branch: `feat/dossier-editorial-v2`.
- Public scope: two template asset files only.
- Private planning/evidence updated: not applicable.
- Out of scope: the ledger, other presets, gather/check scripts, GUI, and any filled dossier document.

## Version Impact

- Version: no version change because this is a template asset reskin with no CLI surface or schema change.
- Publish impact: no publish.

## Verification

- Base `origin/main` SHA: `33906ec15d5be0c9d059bb12abff19a7edf8f007`
- Branch merge-base with `origin/main`: `33906ec15d5be0c9d059bb12abff19a7edf8f007`
- Last `git fetch origin` time: at the start of this task.
- Sync method: none needed (branched directly from latest `origin/main`).
- Public diff command: `git diff origin/main -- packages/cli/src/commands/extensions/assets/software-coding/templates/dossier.editorial.shell/`
- Private evidence commit/path: not applicable.
- Reviewer evidence path: not applicable.
- GitHub Actions `rewrite-ci` run URL: pending on this PR.
- [x] `node --test packages/cli/test/preset-script-dossier-cli.test.ts` — pass (1/1)
- [x] `node --test packages/cli/test/extension-cli.test.ts` — pass (13/13)
- [x] `node tools/check-template-command-surface.mjs` — pass (exit 0)
- [x] `node --test packages/cli/test/{package-surface,preset-script-cli,init-cli}.test.ts` — pass (23/23)
- [x] `git diff --check` — clean
- Not run: `npm run test:gui` — the git worktree has no local `node_modules`, so vitest cannot resolve `@vitejs/plugin-react`; this is an environment limitation, and the change touches zero GUI/JS code (HTML template assets only), so GUI behavior cannot be affected.

## Review Evidence

- Self-review: verified the four `data-dossier-section` anchors, hero placeholders, evidence placeholder row, provenance refs, and footer all survive; verified zero `http(s)://`, `<link>`, external `<script src>`, or `<img>` references; verified the theme toggle, `prefers-color-scheme`, and `localStorage` persistence are present in both locales.
- Reviewer subagent: not run.
- Human review: pending CEO.
- Blocking findings: none.

## Residual Risk

- None functional. The template body is validated only for the presence of the four required anchors, which are preserved; there are no HTML snapshots or checksums over the shell, so no test needed updating.

## References

- Task: reskin milestone-dossier editorial shell (`dec_mr7re23p`).
- Evidence: tests and checks listed above.
- Review: this PR.

---

# 中文

## 概要

把 milestone-dossier 编辑级排版骨架从赛博朋克霓虹黑底风格,改为克制、护眼的日夜编辑风格,落实已裁决决策 `dec_mr7re23p`(「自生成理解型 HTML 的美学:克制护眼、日夜切换、多用 SVG」)。这是一次纯模板视觉改动:两个 locale 骨架的占位符与结构锚点全部原样保留。

## 改动内容

- 重写两个空骨架文件 `templates/dossier.editorial.shell/en-US.md` 与 `zh-CN.md`(虽然是 `.md` 后缀,内容其实是原始 HTML)。
- 新主题系统:浅色默认为暖调米白(`#faf9f6`)配近黑墨色;深色为柔和的哑光炭灰(`#1b1d21`),既非纯黑也非霓虹。颜色通过 `:root[data-theme="light|dark"]` 上的 CSS 自定义属性切换。
- 新增日 / 夜切换按钮(内联 sun/moon SVG):跟随 `prefers-color-scheme`,点击可覆盖,状态写入 `localStorage`,并通过一段内联脚本在首屏绘制前应用主题。
- 低饱和度配色:一个安静的板岩靛蓝 accent,done/risk/rejected 保留哑光鼠尾草绿 / 陶土色 / 砖红,供 agent 填内容时使用。标题与 lede 用衬线,正文用系统无衬线,引用与代码用等宽。
- 在 hero 加入一个主题感知的内联 SVG 占位,并附内联 SVG 绘图模式注释,每个小节留空图槽,以「多用 SVG」为填档 agent 的指引,同时不编造假数据。
- 保留模板语义:四个 `data-dossier-section="brief|boundary|evidence|provenance"` 锚点、hero meta-grid 占位(`task/...`、`decision/...`、`0 / 0`、`draft`)、证据表占位行、provenance 引用行、eyebrow / section-number 编辑结构,以及关于 `template://dossier/editorial-shell` 写入 `artifacts/dossier.html` 的 footer 说明。
- 没有写死任何 M2.5 数据(不含 packet id、PR 编号、merge hash)。每个文件都是自包含单页 HTML,所有 CSS/JS/SVG 内联,零外部字体、脚本或图片。

## 任务与范围

- Harness 任务:按决策 `dec_mr7re23p` reskin milestone-dossier 编辑骨架。
- 分支:`feat/dossier-editorial-v2`。
- 公开范围:仅两个模板资产文件。
- 私有计划 / 证据是否已更新:not applicable。
- 范围外:ledger、其他 preset、gather/check 脚本、GUI,以及任何已填充的 dossier 文档。

## 版本影响

- 版本:不改版本,因为这是模板资产 reskin,没有 CLI 面或 schema 变化。
- 发布影响:不发布。

## 验证

- `origin/main` 基准 SHA:`33906ec15d5be0c9d059bb12abff19a7edf8f007`
- 当前分支与 `origin/main` 的 merge-base:`33906ec15d5be0c9d059bb12abff19a7edf8f007`
- 最近一次 `git fetch origin` 时间:本任务开始时。
- 同步方式:不需要(直接基于最新 `origin/main` 开分支)。
- 公开 diff 命令:`git diff origin/main -- packages/cli/src/commands/extensions/assets/software-coding/templates/dossier.editorial.shell/`
- 私有证据 commit/path:not applicable。
- Reviewer 证据路径:not applicable。
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑。
- [x] `node --test packages/cli/test/preset-script-dossier-cli.test.ts` — 通过(1/1)
- [x] `node --test packages/cli/test/extension-cli.test.ts` — 通过(13/13)
- [x] `node tools/check-template-command-surface.mjs` — 通过(exit 0)
- [x] `node --test packages/cli/test/{package-surface,preset-script-cli,init-cli}.test.ts` — 通过(23/23)
- [x] `git diff --check` — 干净
- 未运行:`npm run test:gui` — git worktree 没有本地 `node_modules`,vitest 无法解析 `@vitejs/plugin-react`,这是环境限制;本改动只动 HTML 模板资产、不碰任何 GUI/JS 代码,不会影响 GUI 行为。

## 审查证据

- 自查:核对四个 `data-dossier-section` 锚点、hero 占位、证据占位行、provenance 引用、footer 全部保留;核对零 `http(s)://`、`<link>`、外部 `<script src>` 或 `<img>` 引用;核对日夜切换、`prefers-color-scheme`、`localStorage` 持久化在两个 locale 中都存在。
- Reviewer subagent:未运行。
- 人工审查:待 CEO。
- 阻塞发现:无。

## 残余风险

- 无功能风险。模板正文只校验四个必需锚点是否存在,而这些锚点均已保留;骨架没有 HTML 快照或校验和,因此无需更新任何测试。

## 关联材料

- 任务:reskin milestone-dossier 编辑骨架(`dec_mr7re23p`)。
- 证据:上述测试与检查。
- 审查:本 PR。
