### PR TITLE
[codex] Slim AGENTS entry templates

### DIFF
--- a/packages/cli/src/commands/extensions/assets/software-coding/template-catalog.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/template-catalog.json
@@ -605,27 +605,33 @@
       "materializeAs": "AGENTS.md",
       "frontmatterSchema": "none",
       "requiredAnchors": [
+        "## Context loading",
+        "## Worktree discipline",
         "## Kernel Workflow (triadic)",
-        "## WriteCoordinator discipline",
-        "## Task reading matrix"
+        "## Relation edge rules",
+        "## WriteCoordinator discipline"
       ],
       "fallbackLocale": "en-US",
       "locales": [
         {
           "locale": "zh-CN",
           "anchors": [
+            "## Context loading",
+            "## Worktree discipline",
             "## Kernel Workflow (triadic)",
-            "## WriteCoordinator discipline",
-            "## Task reading matrix"
+            "## Relation edge rules",
+            "## WriteCoordinator discipline"
           ],
           "bodyPath": "templates/repository.agent.base/zh-CN.md"
         },
         {
           "locale": "en-US",
           "anchors": [
+            "## Context loading",
+            "## Worktree discipline",
             "## Kernel Workflow (triadic)",
-            "## WriteCoordinator discipline",
-            "## Task reading matrix"
+            "## Relation edge rules",
+            "## WriteCoordinator discipline"
           ],
           "bodyPath": "templates/repository.agent.base/en-US.md"
         }

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.agent.base/en-US.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.agent.base/en-US.md
@@ -1,24 +1,36 @@
 # Harness Agent Entry
 
-Read `harness/harness.yaml` and `harness/standards/repo-governance.md` before changing task state.
+This entry holds stable operating rules only. Current milestone context, roadmap state, temporary read sets, and task-specific background belong in the active task package or docmap, not in AGENTS.md.
+
+## Context loading
+
+- Read `harness/harness.yaml`.
+- If a task is assigned, read that task package first: `task_plan.md`, `read_set.md`, and any files explicitly named there.
+- Route from the task to the smallest relevant standard or folder README. Do not preload the full ADR, decision, milestone, or standards tree.
+
+## Worktree discipline
+
+- Background/parallel workers, and any public implementation or public docs PR, start from latest `origin/main` in `.worktrees/<slug>` on branch `codex/<slug>`.
+- Do not edit `packages/**`, `tools/**`, `docs-release/**`, or root public config from the shared repository root. Keep the shared root for coordination, private harness writes, local ignored entry files, and final sync.
+- Leave unrelated dirty files in their original checkout. After merge, delete the remote PR branch, clean the local worktree/branch, and record any residual cleanup.
 
 ## Kernel Workflow (triadic)
 
-The required workflow is triadic — do not skip a leg:
+- `task` is the work unit and status timeline.
+- `fact` is a task-local, append-only, verifiable observation. Every task reaching review/complete needs at least one real fact.
+- `decision` is the load-bearing why: choices, reversals, long-lived boundaries, and downstream work-spawning judgments.
+- Prose mentions do not replace facts, decisions, or relations.
 
-- Task progress is a work-state timeline: `ha task transition <id> active`, then `ha task progress append <id> --text "<note>" --evidence type:PATH:summary`. Progress is a timeline, not a fact ledger.
-- Facts are load-bearing observations, task-local and append-only: `ha fact record --task <id> --statement "<verifiable observation>" --source "<source>" --confidence high`. Every task reaching review/complete needs at least one real fact (fails closed otherwise).
-- Decisions are load-bearing choices, reversals, and long-lived boundaries: `ha decision propose --title ... --question ... --chosen ... --rejected ... --why-not ...`. A verdict is not a decision unless it exposes a strategic question.
-- Relations link cross-entity dependencies: `ha decision relate <id> --anchor <CH1|C1|RJ1> --type supports|supersedes|refines|narrows|relates --target <entity-ref> --rationale "..."`. Isolated entities are audit findings.
+## Relation edge rules
+
+- Write relations with canonical ids. Legacy `E<n>` selectors are projection-read conveniences for commands such as `ha decision show`; do not assume write commands accept them.
+- Decision-to-task edges use `derives` when the decision spawned the task and `relates` when the task was later found connected.
+- `refines` is for decision-to-decision revision, not for target `task/...`.
 
 ## WriteCoordinator discipline
 
-- Writes that go through the harness CLI are auto-committed when the harness root is inside a git repository, with semantic messages such as `task(progress-append): <id>` or `decision(relate): <id>`. Do not add a second commit for coordinator-owned writes. Hand-edited prose, standards, templates, artifact indexes, or source files must be committed by the agent that changed them: check `git status --short`, stage only paths touched in the task, and leave unrelated dirty files alone.
-- Boundary: machine-read fields and relations must be written through CLI commands. Human-read prose may be edited directly, but it does not replace facts, decisions, or relations.
-- Disposition: do not physically delete decisions; supersede or retire them. Facts are append-only; invalidate stale facts instead of rewriting them. Check relation cascade impact before deleting or archiving anything.
-
-## Task reading matrix
-
-Load only what the current task needs: this file, the `harness/standards/` files the action routes to, and the task-package directory. Do not preload the whole repository.
+- Writes through the harness CLI are auto-committed when the harness root is inside a Git repository. Do not add a second commit for coordinator-owned writes.
+- Hand-edited prose, standards, templates, artifact indexes, or source files must be committed by the agent that changed them: check `git status --short`, stage only paths touched in the task, and leave unrelated dirty files alone.
+- Machine-read fields and relations must be written through CLI commands. Human-read prose may be edited directly, but it does not create graph state.
 
 Generated state under `.harness/` is local-only and must not be committed.

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.agent.base/zh-CN.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.agent.base/zh-CN.md
@@ -1,24 +1,36 @@
 # Harness Agent Entry
 
-在改变任务状态前，先读 `harness/harness.yaml` 与 `harness/standards/repo-governance.md`。
+本入口只放稳定运行规则。当前里程碑、roadmap 状态、临时读集和任务背景属于当前任务包或 docmap，不放进 AGENTS.md。
+
+## Context loading
+
+- 读取 `harness/harness.yaml`。
+- 如果已有 task，先读该 task 的 `task_plan.md`、`read_set.md`，以及其中明确列出的文件。
+- 从任务路由到最小必要的标准或文件夹 README。不要预载整个 ADR、decision、milestone 或 standards 树。
+
+## Worktree discipline
+
+- 后台/并行 worker，以及任何 public implementation 或 public docs PR，都从最新 `origin/main` 在 `.worktrees/<slug>` 创建 `codex/<slug>` 分支。
+- 不要在共享仓库根工作树里改 `packages/**`、`tools/**`、`docs-release/**` 或公开根配置。共享 root 只做 coordinator、私有 harness、local ignored entry 文件和最终同步。
+- 已有无关脏文件留在原 checkout。合并后删除远端 PR 分支，清理本地 worktree/branch，并记录无法清理的 residual。
 
 ## Kernel Workflow (triadic)
 
-三元语工作流是强制的，任何一条都不能跳过：
+- `task` 是工作单元和状态时间线。
+- `fact` 是 task-local、append-only、可复核观察。进入 review/complete 的 task 必须至少有一条真实 fact。
+- `decision` 是承重 why：选路、推翻、长期边界，以及派生后续工作的判断。
+- prose 提及不能替代 fact、decision 或 relation。
 
-- 任务进展是工作状态的时间线：`ha task transition <id> active`，随后 `ha task progress append <id> --text "<记录>" --evidence type:PATH:summary`。进展是时间线，不是事实账本。
-- 事实是承重观察，任务本地、只追加：`ha fact record --task <id> --statement "<可复核观察>" --source "<来源>" --confidence high`。任何进入 review/complete 的任务至少要有一条真实事实，否则 fail closed。
-- 决策是承重选择、反转与长效边界：`ha decision propose --title ... --question ... --chosen ... --rejected ... --why-not ...`。裁决暴露出战略问题时才算决策。
-- 关系连接跨实体依赖：`ha decision relate <id> --anchor <CH1|C1|RJ1> --type supports|supersedes|refines|narrows|relates --target <entity-ref> --rationale "..."`。孤立实体是审计发现。
+## Relation edge rules
+
+- relation 写入使用 canonical id。legacy `E<n>` selector 只是 `ha decision show` 等投影读便利；不要假设写命令接受。
+- decision 到 task 的边：decision 直接派生 task 时用 `derives`；task 后来发现有关联时用 `relates`。
+- `refines` 是 decision 到 decision 的修订关系，不用于 target `task/...`。
 
 ## WriteCoordinator discipline
 
-- 经 harness CLI 的写入，在 harness 根位于 git 仓库内时会自动提交，提交信息带语义，如 `task(progress-append): <id>` 或 `decision(relate): <id>`。不要为协调器所有的写入再补一次提交。手改的散文、标准、模板、artifact 索引或源码由执行 Agent 在结束前检查 `git status --short`，只 stage 自己触碰的路径并提交；已有无关脏文件保持原状。
-- 边界：机读字段与关系必须走 CLI 命令写入。人读散文可以直接编辑，但不替代事实、决策与关系。
-- 处置：不要物理删除决策，用 supersede 或 retire；事实只追加，用失效而非改写；删除或归档前先检查关系级联影响。
-
-## Task reading matrix
-
-只加载当前任务需要的内容：本文件、动作路由到的 `harness/standards/` 文件、以及任务包目录。不要预载整个仓库。
+- 经 harness CLI 的写入在 harness root 位于 Git 仓内时会自动提交。不要为 coordinator-owned 写入补第二个提交。
+- 手工编辑 prose、标准、模板、artifact 索引或源码后，执行 agent 必须检查 `git status --short`，只 stage 本任务触碰的路径并提交；无关脏文件保持原状。
+- 机读字段和 relation 必须通过 CLI 写入。人读 prose 可以直接编辑，但不会创建 graph state。
 
 `.harness/` 下的生成态仅本地有效，不得提交。

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.agent.entry/en-US.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.agent.entry/en-US.md
@@ -1,21 +1,37 @@
 # Harness Agent Entry
 
-Read `harness/harness.yaml` and `harness/standards/repo-governance.md` before changing task state.
+This standalone entry is kept for compatibility. Current milestone context and temporary read sets belong in the active task package, not in AGENTS.md.
+
+## Context loading
+
+- Read `harness/harness.yaml`.
+- If a task is assigned, read `task_plan.md`, `read_set.md`, and the files explicitly named there.
+- Load only the standards or folder README files relevant to the task.
+
+## Worktree discipline
+
+- Public implementation, public docs PRs, and background/parallel workers use `.worktrees/<slug>` on `codex/<slug>` from latest `origin/main`.
+- Do not edit public source, public docs, or root public config from the shared repository root.
 
 ## Harness CLI
 
-- Invoke via `ha <command>` or `npx harness-anything <command>`. Create task packages with `ha task create --title "<title>"`; never hand-scaffold directories under the tasks root.
-- Choose the preset before creating a task. Use `standard-task` for ordinary implementation or document repair, `milestone-closeout` for milestone closeout, `legacy-migration` for legacy migration, `module` for module scaffolding, `long-running-task` for long-running work, `lesson-sedimentation` for lesson capture, `version-upgrade` for version upgrades, and `publish-standard` / `release-closeout` for release work. If operating docs lag active decisions or ADRs, use `doc-canon-sync` and run `ha preset action doc-canon-sync check --task <id> --allow-scripts` to produce `artifacts/doc-canon-drift.json`. If unsure, run `ha preset list`; do not default everything to `standard-task`.
-- Prefer command self-description before composing writes: `ha <command> --help`, preset manifests, and capabilities metadata. When a command supports JSON / `--from-file`, use structured input instead of shell-escaped long text; when it does not, use the current flags. During command-renaming transition, document the current runnable name and treat old aliases as compatibility only.
-- Task progress: `ha task transition <id> active`, then `ha task progress append <id> --text "<note>" --evidence type:PATH:summary`. Progress is a timeline, not a fact ledger.
-- Fact gate: every task that reaches review/complete must have at least one real fact. Record load-bearing observations with `ha fact record --task <id> --statement "<verifiable observation>" --source "<source>" --confidence high`.
-- Review and completion: move the task into review with `ha task transition <id> in_review`, replace placeholder review/closeout content with real evidence, run `ha task review <id>`, then `ha task complete <id> --ci passed|failed`. These commands produce a task verdict (PASS/FAIL). Missing facts, placeholder review, or placeholder closeout fail closed.
-- Decisions: route choices, reversals, long-lived boundaries, and choices that derive follow-up work use `ha decision propose --title ... --question ... --chosen ... --rejected ... --why-not ...`. A verdict is not a decision unless it exposes a strategic question.
-- Relations: connect supporting facts and downstream decisions/tasks with `ha decision relate <id> --anchor <CH1|C1|RJ1> --type supports|supersedes|refines|narrows|relates --target <entity-ref> --rationale "..."`. Isolated entities are audit findings.
-- Query through projections: `ha decision list --state active --module <key> --compact`, `ha decision show <id|E<n>>`, and `ha task list --module <key>`.
-- Disposition: do not physically delete decisions; supersede or retire them. Facts are append-only; invalidate stale facts instead of rewriting them. Check relation cascade impact before deleting or archiving anything.
-- Writes that go through the harness CLI are auto-committed when the harness root is inside a git repository, with semantic messages such as `task(progress-append): <id>` or `decision(relate): <id>`. Do not add a second commit for coordinator-owned writes. Hand-edited prose, standards, templates, artifact indexes, or source files must be committed by the agent that changed them: check `git status --short`, stage only paths touched in the task, and leave unrelated dirty files alone.
-- Boundary: machine-read fields and relations must be written through CLI commands. Human-read prose may be edited directly, but it does not replace facts, decisions, or relations.
-- Template assets are part of the operating surface. When AGENTS/task/governance workflow text changes, update the seeded templates too so new scaffolds do not teach stale behavior.
+- Invoke via `ha <command>` or `npx harness-anything <command>`.
+- Create task packages with `ha task create --title "<title>" --vertical software/coding --preset <id>`; never hand-scaffold directories under the tasks root.
+- Choose the preset before creating a task. If unsure, run `ha preset list`.
+- Prefer `ha <command> --help`, preset manifests, and capabilities metadata before composing writes.
+- Record load-bearing observations with `ha fact record --task <id> --statement "<verifiable observation>" --source "<source>" --confidence high`.
+- Query through projections with `ha decision list --state active --module <key> --compact`, `ha decision show <id|E<n>>`, and `ha task list --module <key>`.
+
+## Relation edge rules
+
+- Use canonical decision ids for relation writes. Legacy `E<n>` selectors are projection-read conveniences; do not assume write commands accept them.
+- Decision-to-task edges use `derives` when the decision spawned the task and `relates` when the task was later found connected.
+- `refines` is for decision-to-decision revision, not for target `task/...`.
+
+## Write discipline
+
+- Harness CLI writes are auto-committed when the harness root is inside a Git repository. Do not add a second commit for coordinator-owned writes.
+- Hand-edited prose, standards, templates, artifact indexes, or source files must be committed by the agent that changed them, staging only task-touched paths.
+- Template assets are operating surface. When AGENTS/task/governance workflow text changes, update the seeded templates too.
 
 Generated state under `.harness/` is local-only and must not be committed.

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.agent.entry/zh-CN.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.agent.entry/zh-CN.md
@@ -1,21 +1,37 @@
 # Harness Agent Entry
 
-Read `harness/harness.yaml` and `harness/standards/repo-governance.md` before changing task state.
+这个 standalone 入口只为兼容保留。当前里程碑和临时读集属于当前任务包，不放进 AGENTS.md。
+
+## Context loading
+
+- 读取 `harness/harness.yaml`。
+- 如果已有 task，读取 `task_plan.md`、`read_set.md`，以及其中明确列出的文件。
+- 只加载当前任务相关的标准或文件夹 README。
+
+## Worktree discipline
+
+- public implementation、public docs PR 和后台/并行 worker 都从最新 `origin/main` 在 `.worktrees/<slug>` 使用 `codex/<slug>`。
+- 不要在共享仓库根工作树里改公开源码、公开文档或公开根配置。
 
 ## Harness CLI
 
-- Invoke via `ha <command>` or `npx harness-anything <command>`. Create task packages with `ha task create --title "<title>"`; never hand-scaffold directories under the tasks root.
-- Choose the preset before creating a task. Use `standard-task` for ordinary implementation or document repair, `milestone-closeout` for milestone closeout, `legacy-migration` for legacy migration, `module` for module scaffolding, `long-running-task` for long-running work, `lesson-sedimentation` for lesson capture, `version-upgrade` for version upgrades, and `publish-standard` / `release-closeout` for release work. If operating docs lag active decisions or ADRs, use `doc-canon-sync` and run `ha preset action doc-canon-sync check --task <id> --allow-scripts` to produce `artifacts/doc-canon-drift.json`. If unsure, run `ha preset list`; do not default everything to `standard-task`.
-- Prefer command self-description before composing writes: `ha <command> --help`, preset manifests, and capabilities metadata. When a command supports JSON / `--from-file`, use structured input instead of shell-escaped long text; when it does not, use the current flags. During command-renaming transition, document the current runnable name and treat old aliases as compatibility only.
-- Task progress: `ha task transition <id> active`, then `ha task progress append <id> --text "<记录>" --evidence type:PATH:summary`. Progress is a timeline, not a fact ledger.
-- Fact gate: every task that reaches review/complete must have at least one real fact. Record load-bearing observations with `ha fact record --task <id> --statement "<可复核观察>" --source "<来源>" --confidence high`.
-- Review and completion: move the task into review with `ha task transition <id> in_review`, replace placeholder review/closeout content with real evidence, run `ha task review <id>`, then `ha task complete <id> --ci passed|failed`. These commands produce a task verdict (PASS/FAIL). Missing facts, placeholder review, or placeholder closeout fail closed.
-- Decisions: route choices, reversals, long-lived boundaries, and choices that derive follow-up work use `ha decision propose --title ... --question ... --chosen ... --rejected ... --why-not ...`. A verdict is not a decision unless it exposes a strategic question.
-- Relations: connect supporting facts and downstream decisions/tasks with `ha decision relate <id> --anchor <CH1|C1|RJ1> --type supports|supersedes|refines|narrows|relates --target <entity-ref> --rationale "..."`. Isolated entities are audit findings.
-- Query through projections: `ha decision list --state active --module <key> --compact`, `ha decision show <id|E<n>>`, and `ha task list --module <key>`.
-- Disposition: do not physically delete decisions; supersede or retire them. Facts are append-only; invalidate stale facts instead of rewriting them. Check relation cascade impact before deleting or archiving anything.
-- Writes that go through the harness CLI are auto-committed when the harness root is inside a git repository, with semantic messages such as `task(progress-append): <id>` or `decision(relate): <id>`. Do not add a second commit for coordinator-owned writes. Hand-edited prose, standards, templates, artifact indexes, or source files must be committed by the agent that changed them: check `git status --short`, stage only paths touched in the task, and leave unrelated dirty files alone.
-- Boundary: machine-read fields and relations must be written through CLI commands. Human-read prose may be edited directly, but it does not replace facts, decisions, or relations.
-- Template assets are part of the operating surface. When AGENTS/task/governance workflow text changes, update the seeded templates too so new scaffolds do not teach stale behavior.
+- 通过 `ha <command>` 或 `npx harness-anything <command>` 调用。
+- 用 `ha task create --title "<title>" --vertical software/coding --preset <id>` 创建任务包；不要手写 tasks 目录。
+- 创建任务前先选 preset。拿不准就运行 `ha preset list`。
+- 组装写入前先看 `ha <command> --help`、preset manifest 和 capabilities。
+- 用 `ha fact record --task <id> --statement "<可复核观察>" --source "<来源>" --confidence high` 记录承重观察。
+- 通过投影查询：`ha decision list --state active --module <key> --compact`、`ha decision show <id|E<n>>`、`ha task list --module <key>`。
 
-Generated state under `.harness/` is local-only and must not be committed.
+## Relation edge rules
+
+- relation 写入使用 canonical decision id。legacy `E<n>` selector 是投影读便利；不要假设写命令接受。
+- decision 到 task 的边：decision 直接派生 task 时用 `derives`；task 后来发现有关联时用 `relates`。
+- `refines` 是 decision 到 decision 的修订关系，不用于 target `task/...`。
+
+## Write discipline
+
+- harness CLI 写入在 harness root 位于 Git 仓内时会自动提交。不要为 coordinator-owned 写入补第二个提交。
+- 手工编辑 prose、标准、模板、artifact 索引或源码后，执行 agent 必须提交自己触碰的路径，不纳入无关脏文件。
+- 模板资产是操作面。AGENTS/task/governance 工作流文本变化时，同步更新 seeded templates。
+
+`.harness/` 下的生成态仅本地有效，不得提交。

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.agent.overlay/en-US.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.agent.overlay/en-US.md
@@ -21,3 +21,4 @@ Each scaffold folder owns the single source of truth for its own usage. This ent
 
 - PR / branch / merge / admin bypass → `harness/standards/repo-governance.md` and `.github/pull_request_template.md`
 - CI / required checks / release gates → `harness/standards/ci-cd-standard.md`
+- Testing tier / evidence depth / new test files → `harness/standards/testing-standard.md`

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.agent.overlay/zh-CN.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.agent.overlay/zh-CN.md
@@ -21,3 +21,4 @@
 
 - PR / 分支 / 合并 / admin bypass → `harness/standards/repo-governance.md` 与 `.github/pull_request_template.md`
 - CI / required checks / 发布门禁 → `harness/standards/ci-cd-standard.md`
+- 测试 tier / 证据深度 / 新测试文件 → `harness/standards/testing-standard.md`

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.governance/en-US.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.governance/en-US.md
@@ -5,3 +5,5 @@
 - Kernel primitives: `task` is the work unit, `fact` is a task-local immutable observation in `facts.md`, and `decision` is the load-bearing why in `decisions/`.
 - Use relation records to connect fact -> decision, decision -> task, and decision -> decision. Do not rely on prose-only ledgers for load-bearing links.
 - Task identities use random `task_<ULID>` values; titles and slugs are display metadata.
+- Public implementation work, including small docs/template PRs, starts from latest `origin/main` in `.worktrees/<slug>` on a `codex/<slug>` branch. Treat the shared repository root as coordinator-only; do not edit public source, docs, or root config there.
+- Background/parallel workers must use their own `.worktrees/<slug>` checkout and leave coordinator-owned global state to the coordinator through handoff notes and evidence.

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.governance/zh-CN.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.governance/zh-CN.md
@@ -5,3 +5,5 @@
 - Kernel primitives: `task` is the work unit, `fact` is a task-local immutable observation in `facts.md`, and `decision` is the load-bearing why in `decisions/`.
 - Use relation records to connect fact -> decision, decision -> task, and decision -> decision. Do not rely on prose-only ledgers for load-bearing links.
 - Task identities use random `task_<ULID>` values; titles and slugs are display metadata.
+- Public implementation work, including small docs/template PRs, starts from latest `origin/main` in `.worktrees/<slug>` on a `codex/<slug>` branch. Treat the shared repository root as coordinator-only; do not edit public source, docs, or root config there.
+- Background/parallel workers must use their own `.worktrees/<slug>` checkout and leave coordinator-owned global state to the coordinator through handoff notes and evidence.

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.standards.readme/en-US.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.standards.readme/en-US.md
@@ -6,7 +6,7 @@ This folder holds **repository-level standards**: governance conventions, coding
 
 ## 怎么用 (How to use)
 
-- Each standard is a standalone `.md` (e.g. `repo-governance.md`). Before starting, an agent follows the task-reading matrix in `AGENTS.md` and loads only the standards relevant to the current task — never load them all.
+- Each standard is a standalone `.md` (e.g. `repo-governance.md`). Before starting, an agent follows the context-loading and governance-routing rules in `AGENTS.md` and loads only the standards relevant to the current task — never load them all.
 - Standards are the "how we do things" ruleset; they are not decision records (load-bearing choices → `../decisions/`) nor architecture facts (system structure → `../context/architecture/`).
 - Adding/changing a standard must preserve a single source of truth: define a rule in one place only; do not keep a copy in both `AGENTS.md` and here (ADR-0021 D3 anti-drift principle).
 

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.standards.readme/zh-CN.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/repository.standards.readme/zh-CN.md
@@ -6,7 +6,7 @@
 
 ## 怎么用
 
-- 每份标准是一个独立 `.md`（如 `repo-governance.md`）。Agent 在动手前按 `AGENTS.md` 的任务阅读矩阵，只加载当前任务相关的标准，不要全量灌。
+- 每份标准是一个独立 `.md`（如 `repo-governance.md`）。Agent 在动手前按 `AGENTS.md` 的 context loading 与 governance routing，只加载当前任务相关的标准，不要全量灌。
 - 标准是"怎么做事"的规则集；它不是决策记录（承重选择 → `../decisions/`），也不是架构事实（系统结构 → `../context/architecture/`）。
 - 新增/修改标准应保持单一事实源：一条规则只在一处定义，别在 `AGENTS.md` 和这里各存一份（ADR-0021 D3 反漂移原则）。
 

--- a/packages/cli/test/extension-cli.test.ts
+++ b/packages/cli/test/extension-cli.test.ts
@@ -80,6 +80,22 @@ test("CLI bundled template render fails closed on missing template refs", () => 
   assert.equal(result.issues.some((issue) => issue.code === "missing_template"), true);
 });
 
+test("CLI bundled AGENTS templates surface public worktree discipline", () => {
+  const agentEn = runJson(["template", "render", "template://repository/agent-base@1", "--locale", "en-US"]);
+  const agentZh = runJson(["template", "render", "template://repository/agent-base@1", "--locale", "zh-CN"]);
+  const governance = runJson(["template", "render", "template://repository/repo-governance@1", "--locale", "en-US"]);
+
+  assert.match(agentEn.document.body, /## Worktree discipline/u);
+  assert.match(agentEn.document.body, /\.worktrees\/<slug>/u);
+  assert.match(agentEn.document.body, /Do not edit `packages\/\*\*`.*shared repository root/u);
+  assert.match(agentEn.document.body, /## Relation edge rules/u);
+  assert.match(agentEn.document.body, /`refines` is for decision-to-decision revision, not for target `task\/\.\.\.`/u);
+  assert.match(agentZh.document.body, /后台\/并行 worker/u);
+  assert.match(agentZh.document.body, /\.worktrees\/<slug>/u);
+  assert.match(agentZh.document.body, /`refines` 是 decision 到 decision 的修订关系，不用于 target `task\/\.\.\.`/u);
+  assert.match(governance.document.body, /Public implementation work.*\.worktrees\/<slug>/u);
+});
+
 test("CLI preset validate reports kernel version incompatibility as stable JSON", () => {
   const result = runJson(["preset", "validate", presetFixture, "--kernel-version", "0.9.0"], false);
 

--- a/packages/cli/test/init-cli.test.ts
+++ b/packages/cli/test/init-cli.test.ts
@@ -23,9 +23,11 @@ test("CLI init defaults harness project name from the target root basename", () 
     // empty L3 `## Repository Specifics` anchor reserved (ADR-0021 D2).
     const agents = readFileSync(path.join(rootDir, "AGENTS.md"), "utf8");
     assert.match(agents, /Harness Agent Entry/u);
+    assert.match(agents, /## Context loading/u);
+    assert.match(agents, /## Worktree discipline/u);
     assert.match(agents, /## Kernel Workflow \(triadic\)/u);
+    assert.match(agents, /## Relation edge rules/u);
     assert.match(agents, /## WriteCoordinator discipline/u);
-    assert.match(agents, /## Task reading matrix/u);
     assert.match(agents, /## Harness CLI \(software\/coding\)/u);
     assert.match(agents, /## Scaffold folders/u);
     assert.match(agents, /## Governance routing \(near-field hard gates\)/u);


### PR DESCRIPTION
# English

## Summary

Slims the generated AGENTS entry surface so it remains an operating entry point instead of becoming a catch-all context dump. The templates now keep milestone and temporary read-set context out of AGENTS.md, preserve the public worktree rule, and document the relation edge boundary that caused confusion: relation writes use canonical decision ids, decision-to-task edges use `derives` or `relates`, and `refines` is decision-to-decision only.

## What Changed

- Rewrote bundled AGENTS base/entry templates to remove static current-milestone style context and replace the old task-reading matrix wording with context-loading rules.
- Added explicit relation edge rules for canonical ids, `derives`/`relates` decision-to-task links, and `refines` as decision-to-decision only.
- Kept public implementation worktree discipline visible in generated AGENTS templates.
- Updated standards README templates so new scaffolds no longer refer to an AGENTS task-reading matrix.
- Updated template catalog required anchors plus extension/init CLI regression coverage.

## Task And Scope

- Harness task: `task_01KWS8ZZ7EMFJB32GA83GK3V3W`
- Branch: `codex/agents-worktree-discipline`
- Public scope: seeded AGENTS/governance/standards templates and template regression coverage.
- Private planning/evidence updated: yes, private harness entry docs were committed separately in the nested harness repository.
- Out of scope: changing task graph semantics or including private harness files in the public commit.

## Version Impact

- Version: no version change because this is documentation/template behavior only.
- Publish impact: no publish.

## Verification

- Base `origin/main` SHA: `fadeb1a43b80e3233b3b08efe61548a8d1559e78`
- Branch merge-base with `origin/main`: `fadeb1a43b80e3233b3b08efe61548a8d1559e78`
- Sync method: rebase after PR #188 merged, amend, then `git push --force-with-lease`.
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: nested harness commit `9cdbf14` in the private harness repository; public PR includes no private files.
- Reviewer evidence path: self-review of rendered templates and diff.
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28744516284
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck` via `npm run check`
- [x] `npm test` via `npm run check`
- [x] Scoped regression: `node --test packages/cli/test/extension-cli.test.ts`
- [x] Scoped regression: `node --test packages/cli/test/init-cli.test.ts`
- [x] `npm run build -w @harness-anything/cli`
- [x] `npm run harness:check-import-boundaries` via `npm run check`
- [x] `npm run harness:scan-forbidden-symbols` via `npm run check`
- [x] `npm run harness:check-private-boundary` via `npm run check`
- [x] `npm run harness:check-package-policy` via `npm run check`
- [x] `npm run harness:check-implementation-contracts` via `npm run check`
- [x] `npm run harness:check-schema-contracts` via `npm run check`
- [x] `npm run harness:check-legacy-intake-readiness` via `npm run check`
- [x] `npm run harness:smoke-cli-package` via `npm run check`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci`; dependency graph was unchanged.

## Review Evidence

- Self-review: confirmed generated AGENTS base/entry templates no longer contain the old task-reading matrix, legacy milestone readset, or `decision-id-or-E<n>` write selector wording.
- Reviewer subagent: not run.
- Human review: owner direction was to slim AGENTS.md and remove current milestone/context pollution.
- Blocking findings: none after local `npm run check` and remote `rewrite-ci`.

## Residual Risk

- Generated AGENTS remains intentionally terse, so task packages and standards must carry task-specific context correctly.
- Existing repos that already materialized AGENTS.md need separate local/private updates; this PR fixes seeded assets for future scaffolds.

## References

- Task: `task_01KWS8ZZ7EMFJB32GA83GK3V3W`
- Evidence: local `npm run check`, scoped template regressions, CLI build, `git diff --check`, and GitHub Actions `rewrite-ci` run `28744516284`.
- Merge plan: convert draft to ready, squash merge, delete the remote branch, and remove the local public worktree after merge.
- Admin bypass: owner approved admin merge in the coordinating thread. The missing normal gate is GitHub `REVIEW_REQUIRED`; CI is green and local `npm run check` passed.

---

# 中文

## 概要

收缩生成版 AGENTS 入口，避免它继续变成“所有上下文都往里塞”的总汇。模板现在明确不把当前里程碑、临时读集和任务背景放进 AGENTS.md，同时保留 public worktree 纪律，并修正这次引发困惑的 relation 边界：写 relation 用 canonical decision id，decision 到 task 用 `derives` 或 `relates`，`refines` 只用于 decision 到 decision。

## 改动内容

- 重写 bundled AGENTS base/entry 模板，移除静态 current-milestone 类上下文，并把旧任务阅读矩阵口径改成 context-loading 规则。
- 明确 relation edge rules：canonical id、decision-to-task 的 `derives`/`relates`、以及 `refines` 只用于 decision-to-decision。
- 保留 generated AGENTS 里的 public implementation worktree discipline。
- 更新 standards README 模板，避免新 scaffold 继续引用 AGENTS task-reading matrix。
- 更新 template catalog required anchors，并补 extension/init CLI 回归测试。

## 任务与范围

- Harness 任务：`task_01KWS8ZZ7EMFJB32GA83GK3V3W`
- 分支：`codex/agents-worktree-discipline`
- 公开范围：seeded AGENTS / governance / standards 模板，以及模板回归测试。
- 私有计划 / 证据是否已更新：yes，私有 harness 入口文档已在 nested harness 仓单独提交。
- 范围外：改变 task graph 语义，或把私有 harness 文件放进公开提交。

## 版本影响

- 版本：不改版本，原因是这里只改变文档/模板行为。
- 发布影响：不发布。

## 验证

- `origin/main` 基准 SHA：`fadeb1a43b80e3233b3b08efe61548a8d1559e78`
- 当前分支与 `origin/main` 的 merge-base：`fadeb1a43b80e3233b3b08efe61548a8d1559e78`
- 同步方式：PR #188 合入后 rebase，amend，然后 `git push --force-with-lease`。
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：private harness 仓中的 nested commit `9cdbf14`；公开 PR 不包含私有文件。
- Reviewer 证据路径：渲染模板和 diff 自查。
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28744516284
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`，通过 `npm run check` 覆盖
- [x] `npm test`，通过 `npm run check` 覆盖
- [x] scoped regression：`node --test packages/cli/test/extension-cli.test.ts`
- [x] scoped regression：`node --test packages/cli/test/init-cli.test.ts`
- [x] `npm run build -w @harness-anything/cli`
- [x] `npm run harness:check-import-boundaries`，通过 `npm run check` 覆盖
- [x] `npm run harness:scan-forbidden-symbols`，通过 `npm run check` 覆盖
- [x] `npm run harness:check-private-boundary`，通过 `npm run check` 覆盖
- [x] `npm run harness:check-package-policy`，通过 `npm run check` 覆盖
- [x] `npm run harness:check-implementation-contracts`，通过 `npm run check` 覆盖
- [x] `npm run harness:check-schema-contracts`，通过 `npm run check` 覆盖
- [x] `npm run harness:check-legacy-intake-readiness`，通过 `npm run check` 覆盖
- [x] `npm run harness:smoke-cli-package`，通过 `npm run check` 覆盖
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci`；本 PR 未改依赖图。

## 审查证据

- 自查：确认 generated AGENTS base/entry 模板不再包含旧任务阅读矩阵、legacy milestone 读集或 `decision-id-or-E<n>` 写 selector 口径。
- Reviewer subagent：未运行。
- 人工审查：owner 明确要求收缩 AGENTS.md，并删除 current milestone / context pollution。
- 阻塞发现：本地 `npm run check` 和远端 `rewrite-ci` 后无阻塞。

## 残余风险

- generated AGENTS 会保持克制，因此 task package 和 standards 必须正确承载任务上下文。
- 已经物化过 AGENTS.md 的现有仓库需要单独 local/private 更新；本 PR 修的是未来 scaffold 的 seeded assets。

## 关联材料

- 任务：`task_01KWS8ZZ7EMFJB32GA83GK3V3W`
- 证据：本地 `npm run check`、scoped template regressions、CLI build、`git diff --check`、GitHub Actions `rewrite-ci` run `28744516284`。
- 合并计划：转 ready，squash merge，删除远端分支，合入后移除本地 public worktree。
- Admin bypass：owner 在协调线程中已批准 admin merge。缺失的普通门禁是 GitHub `REVIEW_REQUIRED`；CI 已绿，本地 `npm run check` 已通过。

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] Admin bypass is approved and recorded for `REVIEW_REQUIRED`. / `REVIEW_REQUIRED` 的 admin bypass 已获批准并记录。
