### PR TITLE
ci: configure Mergify merge queue

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -7,9 +7,9 @@ This repository accepts work through pull requests against `main`.
 1. Create a `codex/` branch from the latest `origin/main`.
 2. Keep public implementation and private planning evidence separated.
 3. Open a pull request with the full repository PR template.
-4. Wait for the `rewrite-ci` workflow to pass.
+4. Wait for the fast `rewrite-ci` gate to pass.
 5. Resolve or explicitly route open P0/P1/P2 findings before merge.
-6. Delete the merged PR branch after merge.
+6. Let Mergify merge through the queue, then delete the merged PR branch.
 
 ## Required Checks
 
@@ -33,10 +33,30 @@ typecheck, all node tests, boundaries, package policy, schema/API/service gates,
 supply-chain, Legacy Intake smoke, and CLI package smoke.
 
 GitHub branch protection for `main` should require pull request review and the
-`rewrite-ci` status checks. This repository may leave administrator enforcement
-disabled so a single-owner repository can still merge after recorded local
-review evidence. Any admin bypass must be explicit in the task evidence and PR
-body.
+`rewrite-ci` status checks, with `required_status_checks.strict = false`.
+Mergify owns the up-to-date guarantee by testing queued pull requests against
+the predicted merge state.
+
+The Mergify GitHub App must be installed from
+https://github.com/marketplace/mergify before maintainers rely on the queue.
+The queue rules live in `.mergify.yml`.
+
+Mergify blocks queue merges on the fast gate:
+
+- boundaries
+- package-policy
+- typecheck (24)
+- typecheck (26)
+- fast-contract
+- pr-body-lint
+
+The slower `integration`, `supply-chain`, `gui-build`, and
+`node26-compatibility` checks still run for visibility, but they do not block
+the Mergify queue merge.
+
+This repository may leave administrator enforcement disabled so a single-owner
+repository can still merge after recorded local review evidence. Any admin
+bypass must be explicit in the task evidence and PR body.
 
 ## Admin Bypass
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,32 @@
+queue_rules:
+  - name: default
+    merge_conditions:
+      - check-success = boundaries
+      - check-success = package-policy
+      - check-success = "typecheck (24)"
+      - check-success = "typecheck (26)"
+      - check-success = fast-contract
+      - check-success = pr-body-lint
+
+pull_request_rules:
+  - name: merge via queue when CI passes
+    conditions:
+      - base = main
+      - label = merge-queue
+    actions:
+      queue:
+        name: default
+
+  - name: auto-queue approved PRs
+    conditions:
+      - base = main
+      - "#approved-reviews-by >= 1"
+      - check-success = boundaries
+      - check-success = package-policy
+      - check-success = "typecheck (24)"
+      - check-success = "typecheck (26)"
+      - check-success = fast-contract
+      - check-success = pr-body-lint
+    actions:
+      queue:
+        name: default


### PR DESCRIPTION
# English

## Summary

Configure Mergify as the merge queue for `main` because GitHub native merge queue is unavailable for this personal-account repository.

## What Changed

- Added `.mergify.yml` with a default queue and auto-queue rules for approved `main` pull requests.
- Configured Mergify queue merge conditions to block on the fast gate only: `boundaries`, `package-policy`, `typecheck (24)`, `typecheck (26)`, `fast-contract`, and `pr-body-lint`.
- Updated `.github/branch-protection.md` to document `required_status_checks.strict = false`, the Mergify prerequisite, contributor queue flow, and the fast/slow check split.
- Set GitHub branch protection `required_status_checks.strict` to `false` by API while preserving all 10 existing required check contexts and the 1-review requirement.

## Task And Scope

- Harness task: `task_01KWTNJDVMG2YT0B500JDENFVA`
- Branch: `feat/merge-queue`
- Public scope: Mergify queue configuration and public branch-protection documentation.
- Private planning/evidence updated: yes, completion fact will be recorded after PR creation.
- Out of scope: package source code, workflow job logic, removing required GitHub status checks, and publishing root `docs/` artifacts.

## Version Impact

- Version: no version change because this is CI governance configuration only.
- Publish impact: no publish.

## Verification

- Base `origin/main` SHA: `970eafa660737912083c1645f4224014095b26c6`
- Branch merge-base with `origin/main`: `970eafa660737912083c1645f4224014095b26c6`
- Last `git fetch origin` time: `2026-07-06T03:47:01Z`
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD -- .mergify.yml .github/branch-protection.md`
- Private evidence commit/path: fact `F-JGXMWV73` in task `task_01KWTNJDVMG2YT0B500JDENFVA`
- Reviewer evidence path: not applicable yet
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28766453340
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: individual subcommands were not run standalone because `npm run check` completed successfully and includes typecheck, lint, node tests, GUI tests, boundary checks, package policy, implementation/schema contracts, supply-chain, Legacy Intake smoke, and CLI package smoke. Mergify App installation could not be verified with the user-token `gh api repos/FairladyZ625/harness-anything/installation` probe because that endpoint requires GitHub App authentication.

## Review Evidence

- Self-review: checked `.mergify.yml` against the requested fast gate list and verified branch protection `strict=false` with all 10 required contexts preserved.
- Reviewer subagent: not run.
- Human review: CEO decision to use Mergify after GitHub native merge queue was blocked for a personal repository.
- Blocking findings: Mergify GitHub App installation remains a prerequisite before relying on queue automation.

## Residual Risk

- Prerequisite: install Mergify GitHub App at https://github.com/marketplace/mergify.
- Root `docs/` is ignored by repository policy, so `docs/ci-merge-queue.md` and the local config snapshot were created locally but are not part of this public PR.
- Slow checks still run in GitHub Actions and remain required GitHub status contexts, but Mergify queue rules only block on the fast gate by configuration.

## References

- Task: `task_01KWTNJDVMG2YT0B500JDENFVA`
- Evidence: `gh api repos/FairladyZ625/harness-anything/branches/main/protection | jq '.required_status_checks.strict'` returned `false`.
- Review: ADR-0022 / ADR-0023 gate split and CI authority context.

---

# 中文

## 概要

为 `main` 配置 Mergify merge queue。由于本仓库属于个人账号，GitHub 原生 merge queue 不可用，因此改用 Mergify 达到队列合并和预测合并态验证的目标。

## 改动内容

- 新增 `.mergify.yml`，包含默认队列和面向 `main` 已批准 PR 的自动入队规则。
- Mergify 队列合并条件只阻塞快速门禁：`boundaries`、`package-policy`、`typecheck (24)`、`typecheck (26)`、`fast-contract` 和 `pr-body-lint`。
- 更新 `.github/branch-protection.md`，记录 `required_status_checks.strict = false`、Mergify 安装前置条件、贡献者入队方式，以及快慢检查拆分。
- 已通过 GitHub API 将分支保护 `required_status_checks.strict` 设为 `false`，同时保留全部 10 个原 required check context 和 1 人 review 要求。

## 任务与范围

- Harness 任务：`task_01KWTNJDVMG2YT0B500JDENFVA`
- 分支：`feat/merge-queue`
- 公开范围：Mergify 队列配置和公开分支保护文档。
- 私有计划 / 证据是否已更新：yes，PR 创建后记录 completion fact。
- 范围外：packages 源码、workflow job 逻辑、移除 required GitHub status checks、发布 root `docs/` 资料。

## 版本影响

- 版本：不改版本，原因是本次仅修改 CI 治理配置。
- 发布影响：不发布。

## 验证

- `origin/main` 基准 SHA：`970eafa660737912083c1645f4224014095b26c6`
- 当前分支与 `origin/main` 的 merge-base：`970eafa660737912083c1645f4224014095b26c6`
- 最近一次 `git fetch origin` 时间：`2026-07-06T03:47:01Z`
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...HEAD -- .mergify.yml .github/branch-protection.md`
- 私有证据 commit/path：task `task_01KWTNJDVMG2YT0B500JDENFVA` 中的 fact `F-JGXMWV73`
- Reviewer 证据路径：暂不适用
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28766453340
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：未单独运行各个子命令，因为 `npm run check` 已完整通过，且包含 typecheck、lint、node tests、GUI tests、boundary checks、package policy、implementation/schema contracts、supply-chain、Legacy Intake smoke 和 CLI package smoke。无法用当前 user-token 的 `gh api repos/FairladyZ625/harness-anything/installation` 可靠验证 Mergify App 安装，因为该 endpoint 需要 GitHub App 身份认证。

## 审查证据

- 自查：核对 `.mergify.yml` 使用了指定快速门禁列表，并确认分支保护 `strict=false` 且全部 10 个 required contexts 保留。
- Reviewer subagent：未运行。
- 人工审查：CEO 已裁决在 GitHub 原生 merge queue 因个人仓库限制不可用后改用 Mergify。
- 阻塞发现：依赖项是先安装 Mergify GitHub App，之后才能依赖队列自动化。

## 残余风险

- 前置条件：安装 Mergify GitHub App，地址 https://github.com/marketplace/mergify。
- root `docs/` 被仓库策略忽略，因此 `docs/ci-merge-queue.md` 和本地配置快照已在本地创建，但不进入本公开 PR。
- 慢检查仍在 GitHub Actions 中运行，并仍保留为 GitHub required status contexts；但 Mergify 队列规则只按快速门禁阻塞合并。

## 关联材料

- 任务：`task_01KWTNJDVMG2YT0B500JDENFVA`
- 证据：`gh api repos/FairladyZ625/harness-anything/branches/main/protection | jq '.required_status_checks.strict'` 返回 `false`。
- 审查：ADR-0022 / ADR-0023 gate split 和 CI authority 背景。

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
