### PR TITLE
test: enforce projection source and receipt contracts

### DIFF
--- a/packages/cli/src/cli/receipt-contracts.ts
+++ b/packages/cli/src/cli/receipt-contracts.ts
@@ -3,6 +3,8 @@ import type { ParsedCommand } from "./types.ts";
 export interface CommandReceiptContract {
   readonly data: ReadonlyArray<string>;
   readonly paths: ReadonlyArray<string>;
+  readonly optionalData?: Readonly<Record<string, string>>;
+  readonly optionalPaths?: Readonly<Record<string, string>>;
 }
 
 export type CommandKind = ParsedCommand["action"]["kind"];

--- a/packages/cli/src/cli/receipt-contracts.ts
+++ b/packages/cli/src/cli/receipt-contracts.ts
@@ -15,16 +15,69 @@ export const commandReceiptContractsByKind = {
   "entity-list": { data: ["rows", "report"], paths: [] },
   "capabilities": { data: ["rows", "report"], paths: [] },
   "init": { data: ["generated"], paths: ["primary", "config"] },
-  "new-task": { data: ["taskId", "slug", "status", "preset", "module", "generated", "report"], paths: ["package"] },
-  "status-set": { data: ["taskId", "status", "forced", "forceAudit"], paths: ["primary", "forceAudit"] },
-  "progress-append": { data: ["taskId", "report"], paths: ["primary", "progress"] },
+  "new-task": {
+    data: ["taskId", "slug", "status"],
+    optionalData: {
+      preset: "Only emitted when task creation runs through a selected preset.",
+      module: "Only emitted when --module is supplied or preset/module routing materializes module metadata.",
+      generated: "Only emitted when preset or template materialization produces generated files.",
+      report: "Only emitted when the creation path produces a structured creation report."
+    },
+    paths: ["package"]
+  },
+  "status-set": {
+    data: ["taskId", "status"],
+    optionalData: {
+      forced: "Only emitted for audited terminal recovery transitions invoked with --force.",
+      forceAudit: "Only emitted for audited terminal recovery transitions that append force audit evidence."
+    },
+    paths: [],
+    optionalPaths: {
+      primary: "Only emitted for audited terminal recovery transitions where the audit progress path is returned as the primary path.",
+      forceAudit: "Only emitted for audited terminal recovery transitions that append force audit evidence."
+    }
+  },
+  "progress-append": {
+    data: ["taskId"],
+    optionalData: {
+      report: "Only emitted when --evidence is supplied and the receipt includes the appended evidence payload."
+    },
+    paths: ["primary", "progress"]
+  },
   "task-amend": { data: ["taskId", "report"], paths: ["primary"] },
   "task-archive": { data: ["taskId", "status", "report"], paths: [] },
-  "task-supersede": { data: ["taskId", "status", "report"], paths: ["primary", "package", "replacement"] },
-  "task-delete": { data: ["taskId", "mode", "report"], paths: [] },
-  "task-reopen": { data: ["taskId", "status", "report"], paths: ["primary"] },
-  "task-review": { data: ["taskId", "reviewContract", "completionGate", "report"], paths: [] },
-  "task-complete": { data: ["taskId", "status", "reviewContract", "completionGate", "report"], paths: [] },
+  "task-supersede": {
+    data: ["taskId"],
+    optionalData: {
+      report: "Only emitted when superseding by an existing replacement task via --by."
+    },
+    paths: ["primary", "replacement"],
+    optionalPaths: {
+      package: "Only emitted when supersede creates a new replacement task package."
+    }
+  },
+  "task-delete": {
+    data: ["taskId", "mode"],
+    optionalData: {
+      report: "Only emitted when delete attribution such as --deleted-by is supplied."
+    },
+    paths: []
+  },
+  "task-reopen": { data: ["taskId", "status"], paths: ["primary"] },
+  "task-review": {
+    data: ["taskId", "reviewContract", "report"],
+    optionalData: {
+      completionGate: "Only emitted by completion-oriented task gate results; ordinary task review emits the review contract only."
+    },
+    paths: []
+  },
+  "task-complete": {
+    data: ["taskId", "status", "reviewContract", "completionGate"],
+    optionalData: {
+      report: "Only emitted for completion paths that surface a review or gate report; clean completion emits reviewContract and completionGate."
+    },
+    paths: []
+  },
   "task-tree": { data: ["taskId", "tasks", "report"], paths: [] },
   "task-relate": { data: ["taskId", "report"], paths: ["primary"] },
   "decision-list": { data: ["rows", "report"], paths: [] },
@@ -50,31 +103,37 @@ export const commandReceiptContractsByKind = {
   "runtime-event-list": { data: ["rows", "report"], paths: ["primary"] },
   "materializer-run": { data: ["rows", "warnings", "report"], paths: [] },
   "session-export": { data: ["rows", "report"], paths: ["primary"] },
-  "session-backfill": { data: ["rows", "warnings", "report"], paths: ["primary"] },
+  "session-backfill": { data: ["rows", "report"], paths: ["primary"] },
   "session-sync": { data: ["rows", "report"], paths: ["primary"] },
   "doc-list": { data: ["rows", "report"], paths: ["primary"] },
   "doc-map": { data: ["rows", "report"], paths: ["primary"] },
   "doc-generate": { data: ["rows", "report"], paths: ["primary"] },
   "template-list": { data: ["templates", "issues"], paths: [] },
   "template-render": { data: ["document", "issues"], paths: [] },
-  "task-list": { data: ["tasks", "rows"], paths: [] },
+  "task-list": { data: ["tasks"], paths: [] },
   "status": { data: ["rows", "summary", "report", "commands"], paths: ["projection"] },
-  "check": { data: ["profile", "rows", "summary", "report", "commands"], paths: ["projection"] },
-  "governance-rebuild": { data: ["mode", "rows", "generated", "report"], paths: ["projection"] },
+  "check": { data: ["profile", "rows", "report", "commands"], paths: [] },
+  "governance-rebuild": {
+    data: ["mode", "rows", "report"],
+    optionalData: {
+      generated: "Only emitted for apply/archive rebuild modes that write generated governance views."
+    },
+    paths: ["projection"]
+  },
   "lesson-promote": { data: ["taskId", "mode", "generated", "report"], paths: [] },
   "lesson-sediment": { data: ["taskId", "mode", "generated", "report"], paths: [] },
-  "adopt-multica": { data: ["taskId", "status", "report"], paths: ["primary"] },
+  "adopt-multica": { data: ["taskId", "report"], paths: ["primary"] },
   "snapshot-multica": { data: ["report"], paths: [] },
   "migrate-plan": { data: ["rows", "report"], paths: [] },
   "migrate-structure": { data: ["migrationMode", "rows", "report"], paths: [] },
   "migrate-anchors": { data: ["migrationMode", "rows", "report"], paths: [] },
   "migrate-provenance": { data: ["migrationMode", "rows", "report"], paths: [] },
-  "migrate-run": { data: ["migrationMode", "rows", "report"], paths: ["primary", "session"] },
+  "migrate-run": { data: ["rows", "report"], paths: ["primary", "session"] },
   "migrate-verify": { data: ["report"], paths: [] },
   "legacy-scan": { data: ["rows", "report"], paths: [] },
   "legacy-intake-plan": { data: ["rows", "report"], paths: ["primary", "plan"] },
   "legacy-copy-safe-docs": { data: ["migrationMode", "rows", "report"], paths: [] },
-  "legacy-index": { data: ["migrationMode", "rows", "summary", "report"], paths: ["primary", "index"] },
+  "legacy-index": { data: ["migrationMode", "rows", "report"], paths: ["primary", "index"] },
   "legacy-verify": { data: ["rows", "report"], paths: [] },
   "git-diff": { data: ["report"], paths: [] },
   "doctor": { data: ["report"], paths: [] },
@@ -83,15 +142,28 @@ export const commandReceiptContractsByKind = {
   "preset-list": { data: ["presets", "issues"], paths: [] },
   "preset-inspect": { data: ["preset", "issues"], paths: [] },
   "preset-check": { data: ["preset", "issues"], paths: [] },
-  "preset-install": { data: ["preset", "report"], paths: [] },
+  "preset-install": { data: ["preset"], paths: [] },
   "preset-seed": { data: ["presets", "report"], paths: [] },
   "preset-audit": { data: ["presets", "issues", "report"], paths: [] },
   "preset-uninstall": { data: ["preset"], paths: [] },
   "preset-run": { data: ["taskId", "preset", "evidenceBundle", "generated", "rows", "report"], paths: [] },
-  "preset-action": { data: ["taskId", "preset", "evidenceBundle", "generated", "rows", "report"], paths: [] },
+  "preset-action": {
+    data: ["preset", "evidenceBundle", "generated", "report"],
+    optionalData: {
+      taskId: "Only emitted by scripted preset actions that echo the task id in their script result.",
+      rows: "Only emitted when a scripted preset action writes a numeric rows value in its result."
+    },
+    paths: []
+  },
   "script-list": { data: ["scripts", "rows"], paths: [] },
   "script-inspect": { data: ["script"], paths: [] },
-  "script-run": { data: ["script", "runId", "evidenceBundle", "generated", "rows", "report"], paths: [] },
+  "script-run": {
+    data: ["script", "runId", "evidenceBundle", "generated", "report"],
+    optionalData: {
+      rows: "Only emitted when a script writes a numeric rows value in its script-result/v1 payload."
+    },
+    paths: []
+  },
   "module-list": { data: ["modules"], paths: [] },
   "module-inspect": { data: ["module"], paths: [] },
   "module-register": { data: ["module"], paths: [] },

--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -1,6 +1,6 @@
 import type { CliResult } from "./types.ts";
 import { cliError, CliErrorCode } from "./error-codes.ts";
-import { commandReceiptContractsByKind } from "./receipt-contracts.ts";
+import { commandReceiptContractsByKind, type CommandReceiptContract } from "./receipt-contracts.ts";
 
 export const commandReceiptEnvelope = "command-receipt/v2" as const;
 const legacyReceiptEnvelope = "CommandReceipt/v1" as const;
@@ -189,20 +189,29 @@ function setPath(paths: Record<string, string>, key: string, value: unknown): vo
 }
 
 function validateReceiptContract(receipt: LegacyCommandReceipt): string | undefined {
-  const contract = commandReceiptContractsByKind[receipt.command as keyof typeof commandReceiptContractsByKind];
+  const contract: CommandReceiptContract | undefined = commandReceiptContractsByKind[receipt.command as keyof typeof commandReceiptContractsByKind];
   if (!contract) return `missing receipt contract for command ${receipt.command}`;
-  const allowedData: ReadonlySet<string> = new Set(contract.data);
-  const allowedPaths: ReadonlySet<string> = new Set(contract.paths);
+  const allowedData: ReadonlySet<string> = new Set([...contract.data, ...Object.keys(contract.optionalData ?? {})]);
+  const allowedPaths: ReadonlySet<string> = new Set([...contract.paths, ...Object.keys(contract.optionalPaths ?? {})]);
   const dataKeys = Object.keys(receipt.data ?? {});
   const pathKeys = Object.keys(receipt.paths ?? {});
   const unexpectedData = dataKeys.filter((key) => !allowedData.has(key));
   const unexpectedPaths = pathKeys.filter((key) => !allowedPaths.has(key));
-  const violations = [
+  const missingData = contract.data.filter((key) => !dataKeys.includes(key));
+  const missingPaths = contract.paths.filter((key) => !pathKeys.includes(key));
+  const unexpectedViolations = [
     ...unexpectedData.map((key) => `data.${key}`),
     ...unexpectedPaths.map((key) => `paths.${key}`)
   ];
-  return violations.length > 0
-    ? `receipt for command ${receipt.command} emitted undeclared fields: ${violations.join(", ")}`
+  if (unexpectedViolations.length > 0) {
+    return `receipt for command ${receipt.command} emitted undeclared fields: ${unexpectedViolations.join(", ")}`;
+  }
+  const missingViolations = [
+    ...missingData.map((key) => `data.${key}`),
+    ...missingPaths.map((key) => `paths.${key}`)
+  ];
+  return missingViolations.length > 0
+    ? `receipt for command ${receipt.command} missed declared fields: ${missingViolations.join(", ")}`
     : undefined;
 }
 

--- a/packages/cli/test/receipt-contracts.test.ts
+++ b/packages/cli/test/receipt-contracts.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { commandReceiptContractsByKind } from "../src/cli/receipt-contracts.ts";
 import { toCommandReceipt } from "../src/cli/receipt.ts";
 
 test("command receipts fail closed on undeclared path fields", () => {
@@ -8,7 +9,6 @@ test("command receipts fail closed on undeclared path fields", () => {
     command: "task-delete",
     taskId: "task_1",
     mode: "soft",
-    report: { schema: "task-delete-report/v1" },
     path: "soft"
   });
 
@@ -76,6 +76,124 @@ test("command receipts fail closed on missing declared paths", () => {
     assert.equal(receipt.error?.code, "command_receipt_contract_mismatch");
     assert.match(receipt.error?.hint ?? "", /paths\.primary/u);
   }
+});
+
+test("command receipts allow explicitly optional declared data to be absent", () => {
+  const receipt = toCommandReceipt({
+    ok: true,
+    command: "new-task",
+    taskId: "task_1",
+    slug: "task-1",
+    status: "active",
+    packagePath: "harness/tasks/task_1"
+  });
+
+  assert.equal(receipt.ok, true);
+  if (!receipt.ok) return;
+  assert.equal(receipt.entity?.id, "task_1");
+  assert.equal(receipt.paths?.some((entry) => entry.role === "package"), true);
+});
+
+test("command receipts accept explicitly optional declared data when present", () => {
+  const receipt = toCommandReceipt({
+    ok: true,
+    command: "new-task",
+    taskId: "task_1",
+    slug: "task-1",
+    status: "active",
+    preset: "standard-task",
+    module: "kernel",
+    generated: ["task_plan.md"],
+    report: { schema: "new-task-report/v1" },
+    packagePath: "harness/tasks/task_1"
+  });
+
+  assert.equal(receipt.ok, true);
+  if (!receipt.ok) return;
+  assert.equal(receipt.details?.data && typeof receipt.details.data === "object" && "preset" in receipt.details.data, true);
+});
+
+test("optional receipt contract fields carry non-empty absence reasons", () => {
+  const optionalEntries = Object.entries(commandReceiptContractsByKind)
+    .flatMap(([command, contract]) => [
+      ...Object.entries(contract.optionalData ?? {}).map(([field, reason]) => ({ command, field: `data.${field}`, reason })),
+      ...Object.entries(contract.optionalPaths ?? {}).map(([field, reason]) => ({ command, field: `paths.${field}`, reason }))
+    ]);
+
+  assert.deepEqual(optionalEntries, [{
+    command: "new-task",
+    field: "data.preset",
+    reason: "Only emitted when task creation runs through a selected preset."
+  }, {
+    command: "new-task",
+    field: "data.module",
+    reason: "Only emitted when --module is supplied or preset/module routing materializes module metadata."
+  }, {
+    command: "new-task",
+    field: "data.generated",
+    reason: "Only emitted when preset or template materialization produces generated files."
+  }, {
+    command: "new-task",
+    field: "data.report",
+    reason: "Only emitted when the creation path produces a structured creation report."
+  }, {
+    command: "status-set",
+    field: "data.forced",
+    reason: "Only emitted for audited terminal recovery transitions invoked with --force."
+  }, {
+    command: "status-set",
+    field: "data.forceAudit",
+    reason: "Only emitted for audited terminal recovery transitions that append force audit evidence."
+  }, {
+    command: "status-set",
+    field: "paths.primary",
+    reason: "Only emitted for audited terminal recovery transitions where the audit progress path is returned as the primary path."
+  }, {
+    command: "status-set",
+    field: "paths.forceAudit",
+    reason: "Only emitted for audited terminal recovery transitions that append force audit evidence."
+  }, {
+    command: "progress-append",
+    field: "data.report",
+    reason: "Only emitted when --evidence is supplied and the receipt includes the appended evidence payload."
+  }, {
+    command: "task-supersede",
+    field: "data.report",
+    reason: "Only emitted when superseding by an existing replacement task via --by."
+  }, {
+    command: "task-supersede",
+    field: "paths.package",
+    reason: "Only emitted when supersede creates a new replacement task package."
+  }, {
+    command: "task-delete",
+    field: "data.report",
+    reason: "Only emitted when delete attribution such as --deleted-by is supplied."
+  }, {
+    command: "task-review",
+    field: "data.completionGate",
+    reason: "Only emitted by completion-oriented task gate results; ordinary task review emits the review contract only."
+  }, {
+    command: "task-complete",
+    field: "data.report",
+    reason: "Only emitted for completion paths that surface a review or gate report; clean completion emits reviewContract and completionGate."
+  }, {
+    command: "governance-rebuild",
+    field: "data.generated",
+    reason: "Only emitted for apply/archive rebuild modes that write generated governance views."
+  }, {
+    command: "preset-action",
+    field: "data.taskId",
+    reason: "Only emitted by scripted preset actions that echo the task id in their script result."
+  }, {
+    command: "preset-action",
+    field: "data.rows",
+    reason: "Only emitted when a scripted preset action writes a numeric rows value in its result."
+  }, {
+    command: "script-run",
+    field: "data.rows",
+    reason: "Only emitted when a script writes a numeric rows value in its script-result/v1 payload."
+  }]);
+  assert.equal(optionalEntries.every((entry) => entry.reason.trim().length > 0), true);
 });
 
 test("command receipts accept declared success data and paths", () => {

--- a/packages/cli/test/receipt-contracts.test.ts
+++ b/packages/cli/test/receipt-contracts.test.ts
@@ -8,6 +8,7 @@ test("command receipts fail closed on undeclared path fields", () => {
     command: "task-delete",
     taskId: "task_1",
     mode: "soft",
+    report: { schema: "task-delete-report/v1" },
     path: "soft"
   });
 
@@ -47,12 +48,43 @@ test("command receipts fail closed on undeclared success data", () => {
   }
 });
 
+test("command receipts fail closed on missing declared success data", () => {
+  const receipt = toCommandReceipt({
+    ok: true,
+    command: "task-archive",
+    taskId: "task_1",
+    status: "cancelled"
+  });
+
+  assert.equal(receipt.ok, false);
+  if (!receipt.ok) {
+    assert.equal(receipt.error?.code, "command_receipt_contract_mismatch");
+    assert.match(receipt.error?.hint ?? "", /data\.report/u);
+  }
+});
+
+test("command receipts fail closed on missing declared paths", () => {
+  const receipt = toCommandReceipt({
+    ok: true,
+    command: "decision-show",
+    decisionId: "dec_MISSING_PATH",
+    report: { schema: "decision-show-report/v1" }
+  });
+
+  assert.equal(receipt.ok, false);
+  if (!receipt.ok) {
+    assert.equal(receipt.error?.code, "command_receipt_contract_mismatch");
+    assert.match(receipt.error?.hint ?? "", /paths\.primary/u);
+  }
+});
+
 test("command receipts accept declared success data and paths", () => {
   const deleteReceipt = toCommandReceipt({
     ok: true,
     command: "task-delete",
     taskId: "task_1",
-    mode: "soft"
+    mode: "soft",
+    report: { schema: "task-delete-report/v1" }
   });
   const presetReceipt = toCommandReceipt({
     ok: true,
@@ -70,6 +102,7 @@ test("command receipts expose v2 shallow fields and user-facing command names", 
     ok: true,
     command: "runtime-event-list",
     rows: 1,
+    path: "harness/events/runtime-events.jsonl",
     report: {
       schema: "runtime-event-ledger-cli-report/v1",
       items: [{ eventId: "evt_1", kind: "interrupt" }]

--- a/packages/kernel/src/projection/relation-graph-projection.ts
+++ b/packages/kernel/src/projection/relation-graph-projection.ts
@@ -63,6 +63,7 @@ interface GraphRefIndex {
 export interface RelationRecordEntry {
   readonly hostRef: string;
   readonly ownerRef: string;
+  readonly sourceKind: "task-index" | "task-facts" | "decision-document";
   readonly record: EntityRelationRecord;
   readonly sourcePath: string;
   readonly recordIndex: number;
@@ -99,6 +100,11 @@ export function validateRelationGraphRecords(rootInput: HarnessLayoutInput): Rea
     collectRelationRecordEntries(rootInput, decisions),
     buildGraphRefIndex(rootInput, decisions)
   );
+}
+
+export function readRelationGraphAuthoredSourceKinds(rootInput: HarnessLayoutInput): ReadonlyArray<RelationRecordEntry["sourceKind"]> {
+  const decisions = readDecisionSources(rootInput);
+  return [...new Set(collectRelationRecordEntries(rootInput, decisions).map((entry) => entry.sourceKind))].sort();
 }
 
 export function detectRelationGraphCycles(edges: ReadonlyArray<RelationGraphEdgeRow>): ReadonlyArray<ReadonlyArray<string>> {
@@ -160,6 +166,7 @@ function collectRelationRecordEntries(
         entries.push(...recordsToEntries({
           hostRef: `task/${taskId}`,
           ownerRef: `task/${taskId}`,
+          sourceKind: "task-index",
           records: parseRelationFlowRecords(frontmatter),
           sourceFile: indexPath,
           rootDir
@@ -173,6 +180,7 @@ function collectRelationRecordEntries(
       entries.push(...recordsToEntries({
         hostRefForRecord: (record) => factRelationHostRef(taskId, record),
         ownerRef: `task/${taskId}`,
+        sourceKind: "task-facts",
         records: parseRelationFlowRecords(factsBody),
         sourceFile: factsPath,
         rootDir
@@ -185,6 +193,7 @@ function collectRelationRecordEntries(
     entries.push(...recordsToEntries({
       hostRef: decision.decisionRef,
       ownerRef: decision.decisionRef,
+      sourceKind: "decision-document",
       records: parseRelationFlowRecords(decision.frontmatter),
       sourceFile: decision.filePath,
       rootDir
@@ -198,6 +207,7 @@ function recordsToEntries(input: {
   readonly hostRef?: string;
   readonly hostRefForRecord?: (record: EntityRelationRecord) => string;
   readonly ownerRef: string;
+  readonly sourceKind: RelationRecordEntry["sourceKind"];
   readonly records: ReadonlyArray<EntityRelationRecord>;
   readonly sourceFile: string;
   readonly rootDir: string;
@@ -207,6 +217,7 @@ function recordsToEntries(input: {
     entries.push({
       hostRef: input.hostRefForRecord?.(record) ?? input.hostRef ?? input.ownerRef,
       ownerRef: input.ownerRef,
+      sourceKind: input.sourceKind,
       sourcePath: sourcePath(input.rootDir, input.sourceFile),
       record,
       recordIndex: index

--- a/packages/kernel/src/projection/sqlite-task-source.ts
+++ b/packages/kernel/src/projection/sqlite-task-source.ts
@@ -13,11 +13,28 @@ export function readMarkdownSource(rootInput: HarnessLayoutInput): {
   readonly hash: string;
   readonly warnings: ReadonlyArray<ProjectionWarning>;
 } {
+  const source = readTaskProjectionSource(rootInput);
+  return {
+    entries: source.entries,
+    hash: hashText(JSON.stringify(source.sourceInputs)),
+    warnings: source.warnings
+  };
+}
+
+export function readTaskProjectionSourceHashInputs(rootInput: HarnessLayoutInput): ReadonlyArray<TaskProjectionSourceHashInput> {
+  return readTaskProjectionSource(rootInput).sourceInputs;
+}
+
+function readTaskProjectionSource(rootInput: HarnessLayoutInput): {
+  readonly entries: ReadonlyArray<TaskSourceEntry>;
+  readonly sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>;
+  readonly warnings: ReadonlyArray<ProjectionWarning>;
+} {
   const layout = resolveHarnessLayout(rootInput);
   const rootDir = layout.rootDir;
   const tasksDir = layout.tasksRoot;
   if (!existsSync(tasksDir)) {
-    return { entries: [], hash: hashText("[]"), warnings: [] };
+    return { entries: [], sourceInputs: [], warnings: [] };
   }
 
   const warnings: ProjectionWarning[] = [];
@@ -46,7 +63,7 @@ export function readMarkdownSource(rootInput: HarnessLayoutInput): {
 
   return {
     entries,
-    hash: hashText(JSON.stringify([
+    sourceInputs: [
       ...entries.map((entry) => ({
         kind: "task-index",
         taskId: entry.taskId,
@@ -54,7 +71,7 @@ export function readMarkdownSource(rootInput: HarnessLayoutInput): {
         body: entry.body
       })),
       ...readRelationGraphSourceInputs(rootDir, layout, entries)
-    ])),
+    ],
     warnings
   };
 }
@@ -64,6 +81,12 @@ export interface TaskSourceEntry {
   readonly indexPath: string;
   readonly body: string;
   readonly frontmatter: string;
+}
+
+export interface TaskProjectionSourceHashInput {
+  readonly kind: string;
+  readonly sourcePath: string;
+  readonly body: string;
 }
 
 export function taskEntryToRow(

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -149,6 +149,7 @@ const publicRuntimeSurface = [
   "readEntityCascadeImpact",
   "readFrontmatter",
   "readNestedScalar",
+  "readRelationGraphAuthoredSourceKinds",
   "readRelationGraphProjection",
   "readScalar",
   "readTaskProjection",

--- a/packages/kernel/test/contracts/relation-source-hash-inputs.test.ts
+++ b/packages/kernel/test/contracts/relation-source-hash-inputs.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { deriveRelationId, formatFactFlowRecord, formatRelationFlowRecord } from "../../src/index.ts";
+import type { EntityRelationRecord, FactRecord } from "../../src/index.ts";
+import { readRelationGraphAuthoredSourceKinds } from "../../src/projection/relation-graph-projection.ts";
+import { readTaskProjectionSourceHashInputs } from "../../src/projection/sqlite-task-source.ts";
+import { withTempStore } from "../store/helpers.ts";
+
+test("relation authored source kinds are covered by task projection sourceHash inputs", () => {
+  withTempStore((rootDir) => {
+    writeIndex(rootDir, "task-source", "Task Source", [
+      relationRecord({
+        source: "task/task-source",
+        target: "task/task-target",
+        type: "relates"
+      })
+    ]);
+    writeIndex(rootDir, "task-target", "Task Target");
+    writeIndex(rootDir, "task-fact-owner", "Task Fact Owner");
+    writeFacts(rootDir, "task-fact-owner", [{
+      fact_id: "F-DEADBEEF",
+      statement: "The fact supports the decision.",
+      source: "fixture",
+      observedAt: "2026-07-06T00:00:00.000Z",
+      confidence: "high",
+      memoryClass: "semantic",
+      memoryTags: ["abstract_rule"],
+      provenance: [{
+        runtime: "codex",
+        sessionId: "fixture-session",
+        boundAt: "2026-07-06T00:00:00.000Z"
+      }]
+    }], [
+      relationRecord({
+        source: "fact/task-fact-owner/F-DEADBEEF",
+        target: "decision/dec_SOURCE/C1",
+        type: "supports"
+      })
+    ]);
+    writeDecision(rootDir, "dec_SOURCE", [
+      relationRecord({
+        source: "decision/dec_SOURCE/C1",
+        target: "task/task-target",
+        type: "derives"
+      })
+    ]);
+
+    const authoredKinds = readRelationGraphAuthoredSourceKinds({ rootDir });
+    const sourceHashKinds = new Set(readTaskProjectionSourceHashInputs({ rootDir }).map((input) => input.kind));
+    const missingKinds = authoredKinds.filter((kind) => !sourceHashKinds.has(kind));
+
+    assert.deepEqual(authoredKinds, ["decision-document", "task-facts", "task-index"]);
+    assert.deepEqual(missingKinds, []);
+  });
+});
+
+function writeIndex(rootDir: string, taskId: string, title: string, relations: ReadonlyArray<EntityRelationRecord> = []): void {
+  const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+  mkdirSync(taskRoot, { recursive: true });
+  writeFileSync(path.join(taskRoot, "INDEX.md"), [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    `title: ${JSON.stringify(title)}`,
+    "status: active",
+    "packageDisposition: active",
+    "lifecycle:",
+    "  engine: local",
+    ...(relations.length > 0 ? ["relations:", ...relations.map(formatRelationFlowRecord)] : []),
+    "---",
+    "",
+    `# ${title}`,
+    ""
+  ].join("\n"));
+}
+
+function writeFacts(
+  rootDir: string,
+  taskId: string,
+  facts: ReadonlyArray<FactRecord>,
+  relations: ReadonlyArray<EntityRelationRecord> = []
+): void {
+  const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+  mkdirSync(taskRoot, { recursive: true });
+  writeFileSync(path.join(taskRoot, "facts.md"), [
+    "# Facts",
+    "",
+    ...facts.map(formatFactFlowRecord),
+    ...(relations.length > 0 ? ["", "relations:", ...relations.map(formatRelationFlowRecord)] : []),
+    ""
+  ].join("\n"));
+}
+
+function writeDecision(rootDir: string, decisionId: string, relations: ReadonlyArray<EntityRelationRecord>): void {
+  const decisionRoot = path.join(rootDir, "harness/decisions", `decision-${decisionId}`);
+  mkdirSync(decisionRoot, { recursive: true });
+  writeFileSync(path.join(decisionRoot, "decision.md"), [
+    "---",
+    "schema: decision-package/v1",
+    `decision_id: ${decisionId}`,
+    "_coordinatorWatermark: wm-source-contract",
+    `title: ${decisionId}`,
+    "state: active",
+    "riskTier: low",
+    "urgency: medium",
+    "vertical: test",
+    "preset: default",
+    "applies_to:",
+    "  modules: [\"test\"]",
+    "  productLines: []",
+    "proposedBy: { kind: \"human\", id: \"tester\" }",
+    "proposedAt: \"2026-07-06T00:00:00.000Z\"",
+    "arbiter: { kind: \"human\", id: \"arbiter\" }",
+    "provenance:",
+    "  - { runtime: \"cli\", actor: { kind: \"human\", id: \"tester\" }, capturedAt: \"2026-07-06T00:00:00.000Z\" }",
+    `question: ${JSON.stringify(decisionId)}`,
+    "chosen:",
+    "  - { id: \"O1\", title: \"Chosen\", rationale: \"Fixture\" }",
+    "rejected:",
+    "  - { id: \"O2\", title: \"Rejected\", rationale: \"Fixture\" }",
+    "claims:",
+    "  - { id: \"C1\", statement: \"Fixture claim\", required: true }",
+    "relations:",
+    ...relations.map(formatRelationFlowRecord),
+    "---",
+    "",
+    `# ${decisionId}`,
+    ""
+  ].join("\n"));
+}
+
+function relationRecord(input: {
+  readonly source: string;
+  readonly target: string;
+  readonly type: EntityRelationRecord["type"];
+}): EntityRelationRecord {
+  const base = {
+    source: input.source,
+    target: input.target,
+    type: input.type,
+    direction: "directed" as const
+  };
+  return {
+    relation_id: deriveRelationId(base),
+    ...base,
+    strength: "strong",
+    origin: "declared",
+    rationale: "Fixture relation",
+    state: "active"
+  };
+}

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -56,6 +56,7 @@ export const testTierManifest = {
     "packages/kernel/test/contracts/lifecycle-engine-contract.test.ts",
     "packages/kernel/test/contracts/port-registry.test.ts",
     "packages/kernel/test/contracts/public-surface.test.ts",
+    "packages/kernel/test/contracts/relation-source-hash-inputs.test.ts",
     "packages/kernel/test/contracts/schema-domain-vocabulary-alignment.test.ts",
     "packages/kernel/test/contracts/schema-frontmatter.test.ts",
     "packages/kernel/test/publish/private-evidence-rejection.test.ts",


### PR DESCRIPTION
# English

## Summary

This PR completes Harness task `task_01KWVTQGWN3P7RFFC9A9V8Z5M2` for ADR-0022 F1/F7/D8. It adds a contract test that keeps relation authored source kinds covered by the task projection source-hash input list, and it makes command receipt validation bidirectional for missing required fields and undeclared emitted fields.

It also applies the CEO follow-up ruling for receipt contracts: fields are required by default, conditional fields must be explicitly optional with an absence reason, dead declarations are removed, and field-name drift is corrected to match actual command output.

## What Changed

- Added `readTaskProjectionSourceHashInputs` and a relation source-kind contract test covering `task-index`, `task-facts`, and `decision-document` authored relation sources.
- Added `sourceKind` tagging for relation records without changing persisted projection rows or delete semantics.
- Updated `validateReceiptContract` to fail on missing required `data.*` and `paths.*`, while allowing explicitly declared optional fields when absent or present.
- Added optional receipt declarations with reason strings, removed dead receipt declarations, and corrected `task-list` from `rows` to actual `tasks` output.

## Task And Scope

- Harness task: `task_01KWVTQGWN3P7RFFC9A9V8Z5M2`
- Branch: `codex/g8-projection-receipt`
- Public scope: `packages/kernel` projection contract helpers/tests, `packages/cli` receipt contracts/validation/tests, and `tools/test-tier-manifest.mjs`.
- Private planning/evidence updated: yes, task progress/facts and G8 orchestration report are maintained in the private harness workspace.
- Out of scope: projection behavior changes, deletion semantics, new gates, product behavior rewrites, versioning, and publishing.

## Optional Receipt Fields And Reasons

- `new-task.data.preset`: only emitted when task creation runs through a selected preset.
- `new-task.data.module`: only emitted when `--module` is supplied or preset/module routing materializes module metadata.
- `new-task.data.generated`: only emitted when preset or template materialization produces generated files.
- `new-task.data.report`: only emitted when the creation path produces a structured creation report.
- `status-set.data.forced`: only emitted for audited terminal recovery transitions invoked with `--force`.
- `status-set.data.forceAudit`: only emitted for audited terminal recovery transitions that append force audit evidence.
- `status-set.paths.primary`: only emitted for audited terminal recovery transitions where the audit progress path is returned as the primary path.
- `status-set.paths.forceAudit`: only emitted for audited terminal recovery transitions that append force audit evidence.
- `progress-append.data.report`: only emitted when `--evidence` is supplied and the receipt includes the appended evidence payload.
- `task-supersede.data.report`: only emitted when superseding by an existing replacement task via `--by`.
- `task-supersede.paths.package`: only emitted when supersede creates a new replacement task package.
- `task-delete.data.report`: only emitted when delete attribution such as `--deleted-by` is supplied.
- `task-review.data.completionGate`: only emitted by completion-oriented task gate results; ordinary task review emits the review contract only.
- `task-complete.data.report`: only emitted for completion paths that surface a review or gate report; clean completion emits `reviewContract` and `completionGate`.
- `governance-rebuild.data.generated`: only emitted for apply/archive rebuild modes that write generated governance views.
- `preset-action.data.taskId`: only emitted by scripted preset actions that echo the task id in their script result.
- `preset-action.data.rows`: only emitted when a scripted preset action writes a numeric rows value in its result.
- `script-run.data.rows`: only emitted when a script writes a numeric rows value in its `script-result/v1` payload.

## Classification Evidence Table

| Field | Command | Contract Declaration | Actual Output Condition | Class | Action |
| --- | --- | --- | --- | --- | --- |
| `forced`, `forceAudit`, `paths.primary`, `paths.forceAudit` | `status-set` | required | emitted only by audited force recovery paths in task lifecycle receipts | A | made optional with reasons |
| `report` | `progress-append` | required | `packages/cli/src/commands/core/task-lifecycle.ts:57` emits report only when evidence is supplied | A | made optional with reason |
| `report` | `task-delete` | required | delete attribution report is conditional on delete attribution path | A | made optional with reason |
| `completionGate` | `task-review` | required | ordinary review emits `reviewContract`/`report`; completion gate is completion-oriented | A | made optional with reason |
| `report` | `task-complete` | required | clean completion emits `reviewContract` and `completionGate`; report is not universal | A | made optional with reason |
| `report` | `task-supersede` | required | `packages/cli/src/commands/core/task-supersede.ts:49` emits report for `--by`; `:79` create-replacement path does not | A | made optional with reason |
| `paths.package` | `task-supersede` | required | `packages/cli/src/commands/core/task-supersede.ts:84` emits package path only when creating a replacement package | A | made optional with reason |
| `generated` | `governance-rebuild` | required | `packages/cli/src/commands/governance.ts:13` dry-run lacks generated; `:31` apply/archive writes it | A | made optional with reason |
| `taskId`, `rows` | `preset-action` | required | `packages/cli/src/commands/extensions/state.ts:321` scripted results may add rows/task id; default evidence path at `:355` does not | A | made optional with reasons |
| `rows` | `script-run` | required | `packages/cli/src/commands/extensions/script-host.ts:205` emits rows only when script result has numeric rows | A | made optional with reason |
| `warnings` | `session-backfill` | required | warnings are top-level receipt warnings, not `details.data.warnings` | B | removed from contract |
| `summary`, `paths.projection` | `check` | required | check profile returns profile, rows, report, commands; projection path belongs to status | B | removed from contract |
| `report` | `task-reopen` | required | `packages/cli/src/commands/core/task-lifecycle.ts:45` emits taskId, status, and path only | B | removed from contract |
| `status` | `task-supersede` | required | both supersede branches return taskId/path data, no status field | B | removed from contract |
| `status` | `adopt-multica` | required | `packages/cli/src/commands/adopt.ts:45` emits taskId, path, and report only | B | removed from contract |
| `migrationMode` | `migrate-run` | required | `packages/cli/src/commands/migration.ts:94` returns rows/path/report; plan/apply lives in the session report | B | removed from contract |
| `summary` | `legacy-index` | required | `packages/cli/src/commands/migration.ts:300` returns migrationMode/path/rows/report; summary is inside report | B | removed from contract |
| `report` | `preset-install` | required | `packages/cli/src/commands/extensions/preset.ts:159` returns preset only on success | B | removed from contract |
| `rows` | `task-list` | required | `packages/cli/src/commands/core/task-query.ts:22` emits `tasks: result.rows` | C | changed contract to `tasks` |
| none | all reviewed red fields | n/a | no D implementation leak found; all fields classified as A/B/C | D | no implementation fix needed |

## Version Impact

- Version: no version change because this is a contract/test validation correction without package release intent.
- Publish impact: no publish.

## Verification

- Base `origin/main` SHA: `6bc8b3888d2150a847e49faba6c6ff1476d9ef76`
- Branch merge-base with `origin/main`: `6bc8b3888d2150a847e49faba6c6ff1476d9ef76`
- Last `git fetch origin` time: `2026-07-06T15:00:50Z`
- Sync method: rebase
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: private harness task package for `task_01KWVTQGWN3P7RFFC9A9V8Z5M2`; G8 report path `harness/tasks/task_01KWVTP2JC42P9W9ZW1080EPCP-ci-gate-gate-adr-0022-adr-0023/artifacts/orchestration/report-g8.md`
- Reviewer evidence path: not applicable; self-review only for this worker PR.
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28801348547
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Additional local verification: `npm run test:contract` passed 244 tests; `npm run test:integration` passed 360 tests.
- Not run: `npm ci`; used `npm install` only to hydrate the isolated worktree after the declared GUI dependency was missing locally, and git status remained clean.

## Review Evidence

- Self-review: verified public diff stays inside F1/F7 scope, does not alter projection behavior or delete semantics, and keeps optional fields explicit with reasons.
- Reviewer subagent: not run.
- Human review: CEO provided the required optional-field and A/B/C/D classification rulings in task thread; no further product ambiguity remained.
- Blocking findings: none open.

## Residual Risk

- Optional-field ratio is now visible in the contract and should be watched as a governance trend signal.
- Remote CI passed in `rewrite-ci` run 28801348547; local gates listed above passed after rebase.

## References

- Task: `task_01KWVTQGWN3P7RFFC9A9V8Z5M2`
- Evidence: F1 red proof fact, F7 missing-field red proof fact, optional-field fact, and final integration result recorded in private harness facts/progress.
- Review: ADR-0022 F1/F7/D8 and the CEO optional/A-B-C-D receipt contract rulings from this mission thread.

---

# 中文

## 概要

本 PR 完成 Harness 任务 `task_01KWVTQGWN3P7RFFC9A9V8Z5M2` 中 ADR-0022 F1/F7/D8 的要求：新增 relation authored 来源类型必须被 task projection source-hash 输入清单覆盖的契约测试，并把 command receipt 校验补成双向校验：既拒绝未声明输出，也拒绝缺少 required 字段。

同时按 CEO 后续裁决收敛 receipt 契约：字段默认 required，条件字段必须显式 optional 并带缺席理由，死声明删除，字段名漂移按实现实际输出修正。

## 改动内容

- 新增 `readTaskProjectionSourceHashInputs`，并新增 relation 来源清单同源契约测试，覆盖 `task-index`、`task-facts`、`decision-document` 三类 authored relation 来源。
- 给 relation record collection 增加非持久化 `sourceKind` 标记，不改变投影持久化行，也不改变删除语义。
- 更新 `validateReceiptContract`：缺 required `data.*` / `paths.*` 会红；显式 optional 字段缺席或出现都合法。
- 增加 optional receipt 声明及 reason，删除死声明，并把 `task-list` 从声明的 `rows` 修正为实现实际输出的 `tasks`。

## 任务与范围

- Harness 任务：`task_01KWVTQGWN3P7RFFC9A9V8Z5M2`
- 分支：`codex/g8-projection-receipt`
- 公开范围：`packages/kernel` 投影契约 helper / 测试、`packages/cli` receipt 契约 / 校验 / 测试、`tools/test-tier-manifest.mjs`。
- 私有计划 / 证据是否已更新：yes，任务 progress/fact 与 G8 orchestration report 维护在私有 harness workspace。
- 范围外：投影行为变更、删除语义、新 gate、产品行为重写、版本变更、发布。

## Optional 字段清单与理由

- `new-task.data.preset`：仅任务创建走选定 preset 时产出。
- `new-task.data.module`：仅提供 `--module` 或 preset/module routing 物化 module metadata 时产出。
- `new-task.data.generated`：仅 preset 或 template materialization 产生 generated files 时产出。
- `new-task.data.report`：仅创建路径产生结构化 creation report 时产出。
- `status-set.data.forced`：仅 `--force` 触发 audited terminal recovery transition 时产出。
- `status-set.data.forceAudit`：仅 audited terminal recovery transition 追加 force audit evidence 时产出。
- `status-set.paths.primary`：仅 audited terminal recovery transition 返回 audit progress path 作为 primary 时产出。
- `status-set.paths.forceAudit`：仅 audited terminal recovery transition 追加 force audit evidence 时产出。
- `progress-append.data.report`：仅提供 `--evidence` 且 receipt 包含 appended evidence payload 时产出。
- `task-supersede.data.report`：仅通过 `--by` 使用已有 replacement task supersede 时产出。
- `task-supersede.paths.package`：仅 supersede 创建新的 replacement task package 时产出。
- `task-delete.data.report`：仅提供 `--deleted-by` 等 delete attribution 时产出。
- `task-review.data.completionGate`：仅 completion-oriented task gate result 产出；普通 task review 只产出 review contract。
- `task-complete.data.report`：仅 completion path surface review 或 gate report 时产出；clean completion 产出 `reviewContract` 和 `completionGate`。
- `governance-rebuild.data.generated`：仅 apply/archive rebuild mode 写 generated governance views 时产出。
- `preset-action.data.taskId`：仅 scripted preset action 在 script result 中 echo task id 时产出。
- `preset-action.data.rows`：仅 scripted preset action 写出 numeric rows 时产出。
- `script-run.data.rows`：仅 script 在 `script-result/v1` payload 中写出 numeric rows 时产出。

## 归类证据表

| 字段 | 命令 | 契约声明 | 实际产出条件 | 归类 | 动作 |
| --- | --- | --- | --- | --- | --- |
| `forced`, `forceAudit`, `paths.primary`, `paths.forceAudit` | `status-set` | required | 仅 task lifecycle 的 audited force recovery receipt 产出 | A | 改为 optional 并写 reason |
| `report` | `progress-append` | required | `packages/cli/src/commands/core/task-lifecycle.ts:57` 仅 evidence 路径产出 report | A | 改为 optional 并写 reason |
| `report` | `task-delete` | required | delete attribution report 只在 delete attribution 路径产出 | A | 改为 optional 并写 reason |
| `completionGate` | `task-review` | required | ordinary review 产出 `reviewContract` / `report`；completion gate 只属于 completion-oriented 路径 | A | 改为 optional 并写 reason |
| `report` | `task-complete` | required | clean completion 产出 `reviewContract` 和 `completionGate`；report 非全路径字段 | A | 改为 optional 并写 reason |
| `report` | `task-supersede` | required | `packages/cli/src/commands/core/task-supersede.ts:49` 的 `--by` 分支产出 report；`:79` 的 create-replacement 分支不产出 | A | 改为 optional 并写 reason |
| `paths.package` | `task-supersede` | required | `packages/cli/src/commands/core/task-supersede.ts:84` 仅创建 replacement package 时产出 package path | A | 改为 optional 并写 reason |
| `generated` | `governance-rebuild` | required | `packages/cli/src/commands/governance.ts:13` dry-run 不产出；`:31` apply/archive 写出 generated | A | 改为 optional 并写 reason |
| `taskId`, `rows` | `preset-action` | required | `packages/cli/src/commands/extensions/state.ts:321` scripted result 可带 rows/task id；`:355` 默认 evidence 路径不带 | A | 改为 optional 并写 reason |
| `rows` | `script-run` | required | `packages/cli/src/commands/extensions/script-host.ts:205` 仅 script result 有 numeric rows 时产出 | A | 改为 optional 并写 reason |
| `warnings` | `session-backfill` | required | warnings 是顶层 receipt warnings，不是 `details.data.warnings` | B | 从契约删除 |
| `summary`, `paths.projection` | `check` | required | check profile 返回 profile、rows、report、commands；projection path 属于 status | B | 从契约删除 |
| `report` | `task-reopen` | required | `packages/cli/src/commands/core/task-lifecycle.ts:45` 只产出 taskId、status、path | B | 从契约删除 |
| `status` | `task-supersede` | required | 两个 supersede 分支都只返回 taskId/path 类数据，不返回 status | B | 从契约删除 |
| `status` | `adopt-multica` | required | `packages/cli/src/commands/adopt.ts:45` 只产出 taskId、path、report | B | 从契约删除 |
| `migrationMode` | `migrate-run` | required | `packages/cli/src/commands/migration.ts:94` 返回 rows/path/report；plan/apply 信息在 session report 内 | B | 从契约删除 |
| `summary` | `legacy-index` | required | `packages/cli/src/commands/migration.ts:300` 返回 migrationMode/path/rows/report；summary 在 report 内 | B | 从契约删除 |
| `report` | `preset-install` | required | `packages/cli/src/commands/extensions/preset.ts:159` 成功路径只返回 preset | B | 从契约删除 |
| `rows` | `task-list` | required | `packages/cli/src/commands/core/task-query.ts:22` 实际输出 `tasks: result.rows` | C | 契约改为 `tasks` |
| 无 | 所有已审红字段 | n/a | 未发现 D 类实现漏产；全部字段归入 A/B/C | D | 无实现修复 |

## 版本影响

- 版本：不改版本，原因是本次是契约 / 测试校验修正，没有 package release 意图。
- 发布影响：不发布。

## 验证

- `origin/main` 基准 SHA：`6bc8b3888d2150a847e49faba6c6ff1476d9ef76`
- 当前分支与 `origin/main` 的 merge-base：`6bc8b3888d2150a847e49faba6c6ff1476d9ef76`
- 最近一次 `git fetch origin` 时间：`2026-07-06T15:00:50Z`
- 同步方式：rebase
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：私有 harness task package `task_01KWVTQGWN3P7RFFC9A9V8Z5M2`；G8 report path `harness/tasks/task_01KWVTP2JC42P9W9ZW1080EPCP-ci-gate-gate-adr-0022-adr-0023/artifacts/orchestration/report-g8.md`
- Reviewer 证据路径：不适用；本 worker PR 仅做自查。
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28801348547
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 额外本地验证：`npm run test:contract` 通过 244 项；`npm run test:integration` 通过 360 项。
- 未运行：`npm ci`；仅用 `npm install` 补齐 isolated worktree 中缺失的已声明 GUI dependency，且 git status 保持干净。

## 审查证据

- 自查：确认公开 diff 限于 F1/F7 范围，不改变投影行为或删除语义，并保证 optional 字段显式声明且带 reason。
- Reviewer subagent：未运行。
- 人工审查：CEO 已在任务线程给出 optional 字段与 A/B/C/D 归类裁决；本轮没有剩余产品语义歧义。
- 阻塞发现：无 open blocking finding。

## 残余风险

- optional 字段比例现在已显性化，应作为治理趋势信号继续观察。
- 远端 CI 已在 `rewrite-ci` run 28801348547 通过；本地 rebase 后 gate 已按上文通过。

## 关联材料

- 任务：`task_01KWVTQGWN3P7RFFC9A9V8Z5M2`
- 证据：F1 红证明 fact、F7 missing-field 红证明 fact、optional 字段 fact、最终 integration 结果均记录在私有 harness facts/progress。
- 审查：ADR-0022 F1/F7/D8，以及本 mission 线程中的 CEO optional / A-B-C-D receipt 契约裁决。

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
