### PR TITLE
refactor: drop brittle README magic-string asserts from governance checkers

### DIFF
--- a/tools/check-docs-release-map.mjs
+++ b/tools/check-docs-release-map.mjs
@@ -35,8 +35,6 @@ const negativeOrFuture = /\b(no|not|never|without|unshipped|planned|future|later
 
 for (const docPath of expectedDocs) {
   if (!existsSync(docPath)) errors.push(`Missing expected docs-release page: ${docPath}`);
-  const readmeLink = `./${docPath}`;
-  if (!readme.includes(readmeLink)) errors.push(`README.md does not link ${readmeLink}`);
 }
 
 const productLinePath = "docs-release/release-posture.md";
@@ -58,13 +56,6 @@ for (const docPath of listMarkdown("docs-release")) {
   if (content.includes(".harness-private/")) errors.push(`${docPath} exposes private harness path`);
 }
 validateReadmePrivateBoundary(readme, errors);
-
-if (!readme.includes("M2.5 GUI/daemon foundation")) {
-  errors.push("README.md must expose the M2.5 GUI/daemon foundation status");
-}
-if (!readme.includes("docs-release/release-posture.md")) {
-  errors.push("README.md must link the public release-posture page");
-}
 
 if (errors.length > 0) {
   console.error("Docs release map check failed:");

--- a/tools/check-docs-release-map.test.mjs
+++ b/tools/check-docs-release-map.test.mjs
@@ -72,8 +72,7 @@ async function withFixtureRepo(fn) {
 function writeValidDocsMap(root, options = {}) {
   writeFile(root, "README.md", [
     "# Harness Anything",
-    "- [Release posture](./docs-release/release-posture.md)",
-    "M2.5 GUI/daemon foundation is foundation-only.",
+    "The accountability layer for AI agents.",
     "Private planning lives in `.harness-private/`.",
     "Do not add `.harness-private/` to public commits.",
     options.readmeSuffix ?? ""

--- a/tools/check-runtime-release-readiness.mjs
+++ b/tools/check-runtime-release-readiness.mjs
@@ -93,15 +93,6 @@ for (const docPath of expectedDocs) {
   if (!existsSync(path.join(root, docPath))) record(`Missing runtime/release documentation: ${docPath}`);
 }
 
-requireIncludes("README.md", "Use Node.js 24 or newer", "Node 24 minimum");
-requireIncludes("README.md", commandBySurface.get("source-run")?.command ?? "", "source-run command");
-requireIncludes("README.md", commandBySurface.get("full-check")?.command ?? "", "full check command");
-requireIncludes("README.md", "Node 24 and Node 26", "Node 24/26 CI coverage");
-requireIncludes("README.md", "package smoke", "package smoke validation");
-requireIncludes("README.md", "docs-release/release-posture.md", "release posture doc link");
-requireIncludes("README.md", "No signed desktop installer, notarized build, or auto-update capability is\n  claimed", "non-shipped desktop release boundary");
-requireIncludes("README.md", "No npm package release is claimed", "non-shipped npm release boundary");
-
 requireIncludes("docs-release/release-posture.md", "Status: source checkout and package smoke only", "runtime status");
 requireIncludes("docs-release/release-posture.md", "Node 24 and Node 26", "Node 24/26 coverage");
 requireIncludes("docs-release/release-posture.md", commandBySurface.get("source-run")?.command ?? "", "source-run command");

--- a/tools/check-runtime-release-readiness.test.mjs
+++ b/tools/check-runtime-release-readiness.test.mjs
@@ -122,14 +122,7 @@ function writeValidRuntimeReleaseFixture(root, options = {}) {
 
   writeFile(root, "README.md", [
     "# Harness Anything",
-    "Use Node.js 24 or newer.",
-    "Run npm run check.",
-    "rewrite-ci covers Node 24 and Node 26 plus package smoke.",
-    "Run node packages/cli/src/index.ts --json doctor.",
-    "- [Release posture](./docs-release/release-posture.md)",
-    "No signed desktop installer, notarized build, or auto-update capability is",
-    "  claimed.",
-    "No npm package release is claimed."
+    "The accountability layer for AI agents."
   ].join("\n"));
   writeFile(root, "docs-release/release-posture.md", options.runtimeDocBody ?? validRuntimeDoc());
   writeFile(root, ".github/workflows/rewrite-ci.yml", options.workflowBody ?? validWorkflow());

--- a/tools/check-supply-chain.mjs
+++ b/tools/check-supply-chain.mjs
@@ -173,10 +173,6 @@ function validateDocsAndWorkflow() {
     requireIncludes(supplyDoc, "release artifacts are not published", "non-shipped release artifact boundary");
   }
 
-  requireIncludes("README.md", "docs-release/release-posture.md", "release posture doc link");
-  requireIncludes("README.md", "OSV readiness", "OSV readiness");
-  requireIncludes("README.md", "AGPL network-service release-note checklist", "AGPL release checklist");
-
   const workflow = read(".github/workflows/rewrite-ci.yml");
   if (!workflow.includes("npm run harness:check-supply-chain")) {
     record(".github/workflows/rewrite-ci.yml must run npm run harness:check-supply-chain");

--- a/tools/check-supply-chain.test.mjs
+++ b/tools/check-supply-chain.test.mjs
@@ -232,9 +232,7 @@ function writeValidSupplyChainFixture(root, options = {}) {
 function validReadme() {
   return [
     "# Harness Anything",
-    "Read [Release posture](./docs-release/release-posture.md).",
-    "This covers OSV readiness.",
-    "This includes the AGPL network-service release-note checklist."
+    "The accountability layer for AI agents."
   ].join("\n");
 }
 


### PR DESCRIPTION
# English

## Summary

Remove the brittle "the README prose must contain literal string X" assertions from three governance checkers. These positive `requireIncludes(README.md, ...)` checks coupled marketing/status copy to checker internals: they broke on every doc rewrite (the accountability-layer README rewrite was blocked three times in a row, once per checker), duplicated the same enforcement across three files (the release-posture link was required by all three), and verified string *presence* rather than claim *truth* — the same string in a code comment would satisfy them. This is a direct instance of the ADR-0022 gate-defense root cause (regex guarding an invariant it cannot actually check + a diverging enforcement surface).

The reverse honesty guards are kept and untouched: the overclaim scan (`collectOverclaims` / `collectReleaseOverclaims`, which flags sentences that claim shipped + risky-subject without a negative qualifier), the private-path leakage scan, and the absolute-path scan. All assertions on the authoritative `docs-release/release-posture.md` source-of-truth document are also kept — the deletion is scoped to README marketing prose only.

## What Changed

- `tools/check-docs-release-map.mjs` — drop the README→release-posture link assertion and the "README must expose M2.5 GUI/daemon foundation" assertion. Keep the release-posture-file-existence check, the product-line phrase checks on `release-posture.md`, the overclaim scan, the absolute-path scan, and `validateReadmePrivateBoundary`.
- `tools/check-runtime-release-readiness.mjs` — drop all eight README `requireIncludes` (Node 24 minimum, source-run command, full-check command, Node 24/26 coverage, package-smoke, release-posture link, non-shipped desktop sentence, non-shipped npm sentence). Keep every `requireIncludes` on `release-posture.md`, the source-run smoke, the CI-workflow assertions, package/version/private policy, and the reverse overclaim scan.
- `tools/check-supply-chain.mjs` — drop the three README `requireIncludes` (release-posture link, "OSV readiness", AGPL checklist). Keep every assertion on `release-posture.md` (OSV commands, AGPL checklist items, SBOM boundary) and the reverse overclaim scan.
- `tools/check-docs-release-map.test.mjs`, `tools/check-runtime-release-readiness.test.mjs`, `tools/check-supply-chain.test.mjs` — trim the now-dead magic strings out of the README fixtures so the tests honestly reflect the reduced contract. The private-boundary lines in the docs-map fixture are kept (that check is retained). No test assertion was removed; the negative tests (overclaim, private subpath, CI drift, missing OSV doc, missing AGPL checklist item) are all retained and still pass.

## Task And Scope

- Harness task: `task_01KWVYSBKJG8KYQBVMZBXJ3B83`, implementing decision `dec_README_CHECKER_MAGIC_STRING_CLEANUP` (which derives from `dec_GATE_DEFENSE_ROOT_CAUSE` / ADR-0022)
- Branch: `refactor/drop-readme-magic-string-checks`
- Public scope: three governance checkers under `tools/` and their test fixtures
- Private planning/evidence updated: yes (decision + task in the private harness ledger)
- Out of scope: the reverse overclaim/private/absolute-path invariants (kept), all `release-posture.md` assertions (kept), any README content change (that is PR #203), any runtime/kernel code

## Version Impact

- Version: no version change; tooling only, all packages remain `private: true` at `0.0.0`
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: 6bc8b3888d2150a847e49faba6c6ff1476d9ef76
- Branch merge-base with `origin/main`: 6bc8b3888d2150a847e49faba6c6ff1476d9ef76
- Last `git fetch origin` time: 2026-07-06 (this session)
- Sync method: none needed (branch tip is at current origin/main)
- Public diff command: `git diff origin/main...refactor/drop-readme-magic-string-checks`
- Private evidence commit/path: private harness ledger — decision `dec_README_CHECKER_MAGIC_STRING_CLEANUP`, task `task_01KWVYSBKJG8KYQBVMZBXJ3B83`
- Reviewer evidence path: authoring-session review; the three checkers run clean and their 16 tests pass
- GitHub Actions `rewrite-ci` run URL: triggered by this PR — see the Checks tab (rewrite-ci)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck` (via `npm run check`)
- [x] `npm test` (via `npm run check`)
- [x] three checkers run clean against the real repo (`check-docs-release-map`, `check-runtime-release-readiness`, `check-supply-chain`)
- [x] `node --test` on the three checker test files: 16 pass, 0 fail
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: none

## Review Evidence

- Self-review: full diff reviewed; confirmed no dead variables/functions left after deletion (`readme`, `commandBySurface`, `requireIncludes` all still used by retained checks)
- Reviewer subagent: not run (small, self-contained deletion; the retained/removed boundary is explicitly scoped by the decision and covered by the existing test suite)
- Human review: direction approved by ZeyuLi in session on 2026-07-06 ("直接删掉好了 这种完全没用的 check 不需要存在"); arbiter of `dec_README_CHECKER_MAGIC_STRING_CLEANUP`
- Blocking findings: none

## Residual Risk

- The README can now drift on release-boundary wording without a checker catching it. This is intentional: truth is guarded by the retained reverse overclaim scan (which fails on unqualified shipped-claims) and by the authoritative `release-posture.md` assertions, not by requiring specific disclaimer strings to be present in marketing copy.
- If a future policy genuinely needs the README to always disclose a specific boundary, the durable fix is to generate that section from the `runtime-release-readiness` contract, not to reintroduce a literal-string `requireIncludes`.

## References

- Task: `task_01KWVYSBKJG8KYQBVMZBXJ3B83` (private harness ledger)
- Decision: `dec_README_CHECKER_MAGIC_STRING_CLEANUP` → derives from `dec_GATE_DEFENSE_ROOT_CAUSE` (ADR-0022)
- Evidence: three checkers clean + 16 checker tests pass

---

# 中文

## 概要

删掉三个治理 checker 里"README 正文必须包含字面串 X"这类脆弱的正向断言。这些 `requireIncludes(README.md, ...)` 把营销/状态文案耦合进了 checker 内部：每次文档重写都会挂（问责层 README 重写被三个 checker 连续拦了三次，一人一次），同一执法在三个文件里重复（release-posture 链接被三个都要求一遍），而且只验证字符串"在不在"、不验证声称"是否为真"——同一句话放进代码注释里也能过。这正是 ADR-0022 门禁根因的活标本（regex 守它守不住的不变量 + 执法面发散）。

反向的诚实防线全部保留、原封不动：过度声称扫描（`collectOverclaims` / `collectReleaseOverclaims`，揪出"声称 shipped + 高风险主语却无否定限定"的句子）、私有路径泄漏扫描、绝对路径扫描。对权威单一真源文档 `docs-release/release-posture.md` 的全部断言也保留——本次删除只针对 README 营销正文。

## 改动内容

- `tools/check-docs-release-map.mjs` — 删掉 README→release-posture 链接断言、以及"README 必须暴露 M2.5 GUI/daemon foundation"断言。保留 release-posture 文件存在检查、对 `release-posture.md` 的 product-line 短语检查、过度声称扫描、绝对路径扫描、`validateReadmePrivateBoundary`。
- `tools/check-runtime-release-readiness.mjs` — 删掉全部 8 条 README `requireIncludes`（Node 24 下限、source-run 命令、full-check 命令、Node 24/26 覆盖、package-smoke、release-posture 链接、非交付桌面句、非交付 npm 句）。保留对 `release-posture.md` 的全部 `requireIncludes`、source-run smoke、CI workflow 断言、package/version/private 策略、以及反向过度声称扫描。
- `tools/check-supply-chain.mjs` — 删掉 3 条 README `requireIncludes`（release-posture 链接、"OSV readiness"、AGPL 清单）。保留对 `release-posture.md` 的全部断言（OSV 命令、AGPL 清单项、SBOM 边界）与反向过度声称扫描。
- `tools/check-docs-release-map.test.mjs`、`tools/check-runtime-release-readiness.test.mjs`、`tools/check-supply-chain.test.mjs` — 把 README fixture 里已死的魔法串清掉，让测试诚实反映收缩后的契约。docs-map fixture 里的私有边界行保留（该检查仍在）。没有删除任何测试断言；负向测试（过度声称、私有子路径、CI drift、缺 OSV 文档、缺 AGPL 清单项）全部保留且仍通过。

## 任务与范围

- Harness 任务：`task_01KWVYSBKJG8KYQBVMZBXJ3B83`，实现决策 `dec_README_CHECKER_MAGIC_STRING_CLEANUP`（derives 自 `dec_GATE_DEFENSE_ROOT_CAUSE` / ADR-0022）
- 分支：`refactor/drop-readme-magic-string-checks`
- 公开范围：`tools/` 下三个治理 checker 及其测试 fixture
- 私有计划 / 证据是否已更新：yes（decision + task 已落私有台账）
- 范围外：反向 overclaim/私有路径/绝对路径不变量（保留）、全部 `release-posture.md` 断言（保留）、任何 README 内容改动（那是 PR #203）、任何运行时/内核代码

## 版本影响

- 版本：不改版本；仅工具，所有包保持 `private: true` @ `0.0.0`
- 发布影响：不发布

## 验证

- `origin/main` 基准 SHA：6bc8b3888d2150a847e49faba6c6ff1476d9ef76
- 当前分支与 `origin/main` 的 merge-base：6bc8b3888d2150a847e49faba6c6ff1476d9ef76
- 最近一次 `git fetch origin` 时间：2026-07-06（本会话）
- 同步方式：不需要（分支尖端即当前 origin/main）
- 公开 diff 命令：`git diff origin/main...refactor/drop-readme-magic-string-checks`
- 私有证据 commit/path：私有 harness 台账——decision `dec_README_CHECKER_MAGIC_STRING_CLEANUP`、task `task_01KWVYSBKJG8KYQBVMZBXJ3B83`
- Reviewer 证据路径：主笔会话审查；三个 checker 直跑通过，其 16 个测试通过
- GitHub Actions `rewrite-ci` run URL：triggered by this PR — see the Checks tab (rewrite-ci)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`（含于 `npm run check`）
- [x] `npm test`（含于 `npm run check`）
- [x] 三个 checker 对真实仓库直跑通过（`check-docs-release-map`、`check-runtime-release-readiness`、`check-supply-chain`）
- [x] 三个 checker 测试文件 `node --test`：16 pass，0 fail
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：无

## 审查证据

- 自查：完整审查 diff；确认删除后无死变量/死函数（`readme`、`commandBySurface`、`requireIncludes` 均仍被保留的检查使用）
- Reviewer subagent：未跑（小而自洽的删除；保留/删除的边界由 decision 明确划定并被既有测试套件覆盖）
- 人工审查：方向由泽宇于 2026-07-06 会话内批准（"直接删掉好了 这种完全没用的 check 不需要存在"）；`dec_README_CHECKER_MAGIC_STRING_CLEANUP` 的 arbiter
- 阻塞发现：无

## 残余风险

- README 现在可以在发布边界措辞上漂移而不被 checker 抓。这是有意的：真实性由保留的反向过度声称扫描（对无限定的 shipped 声称报错）和权威的 `release-posture.md` 断言守住，而不是靠要求营销文案里必须出现某些免责字符串。
- 若未来某条策略确实需要 README 始终披露某个边界，持久的修法是从 `runtime-release-readiness` contract 生成那一段，而不是重新引入字面串 `requireIncludes`。

## 关联材料

- 任务：`task_01KWVYSBKJG8KYQBVMZBXJ3B83`（私有 harness 台账）
- 决策：`dec_README_CHECKER_MAGIC_STRING_CLEANUP` → derives 自 `dec_GATE_DEFENSE_ROOT_CAUSE`（ADR-0022）
- 证据：三个 checker 直跑干净 + 16 个 checker 测试通过

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear: merge queue (Mergify) after 1 approving review, delete branch after merge. / 合并方式：1 个 approve 后走 merge queue（Mergify），合并后删除分支。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
