### PR TITLE
fix: materialize supersede replacement scaffold

### DIFF
--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -329,6 +329,12 @@ function supersedeTask(
     yield* writeSupersedeTaskDocuments(coordinator, stablePayloadHash, input.oldTaskId, [
       { taskId: input.oldTaskId, path: "INDEX.md", body: renderIndex({ ...oldIndex, packageDisposition: "archived" }, input.reason) },
       { taskId: input.newTaskId, path: "INDEX.md", body: renderIndex(newIndex), packageSlug: input.slug },
+      ...(input.scaffoldDocuments ?? []).map((document) => ({
+        taskId: input.newTaskId,
+        path: document.path,
+        body: document.body,
+        packageSlug: input.slug
+      })),
       { taskId: input.newTaskId, path: "relations.md", body: renderSupersedesRelation(input.newTaskId, input.oldTaskId, input.reason), packageSlug: input.slug }
     ]);
     return { oldTaskId: input.oldTaskId, newTaskId: input.newTaskId, packageDisposition: "archived" } satisfies LocalSupersedeResult;

--- a/packages/adapters/local/src/types.ts
+++ b/packages/adapters/local/src/types.ts
@@ -83,6 +83,10 @@ export interface SupersedeTaskInput {
   readonly title: string;
   readonly slug: string;
   readonly reason: string;
+  readonly scaffoldDocuments?: ReadonlyArray<{
+    readonly path: string;
+    readonly body: string;
+  }>;
 }
 
 export type DeleteMode = "soft" | "hard";

--- a/packages/cli/src/cli/runner-registry.ts
+++ b/packages/cli/src/cli/runner-registry.ts
@@ -91,6 +91,7 @@ export interface CommandRunnerEngine {
     readonly title: string;
     readonly slug: string;
     readonly reason: string;
+    readonly scaffoldDocuments?: ReadonlyArray<{ readonly path: string; readonly body: string }>;
   }) => EngineEffect<{ readonly oldTaskId: string; readonly newTaskId: string }>;
   readonly deleteTask: (input: {
     readonly taskId: string;

--- a/packages/cli/src/commands/core/task-supersede.ts
+++ b/packages/cli/src/commands/core/task-supersede.ts
@@ -1,11 +1,13 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import type { EngineError, WriteError } from "../../../../kernel/src/index.ts";
-import { createTaskPackagePath, generateTaskId, taskDocumentPath } from "../../../../kernel/src/index.ts";
+import { createTaskPackagePath, generateTaskId, readFrontmatter, readScalar, taskDocumentPath } from "../../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
 import type { CommandRunner, CommandRunnerContext } from "../../cli/runner-registry.ts";
+import { materializePresetTaskScaffold, renderTemplateBody } from "../preset-task.ts";
+import { readProjectHarnessSettings } from "../settings.ts";
 import { lifecycleReason } from "./task-lifecycle-shared.ts";
 
 type TaskSupersedeAction = Extract<Parameters<CommandRunner>[1]["action"], { readonly kind: "task-supersede" }>;
@@ -67,20 +69,67 @@ function createReplacementTask(
 ): Effect.Effect<CliResult, EngineError | WriteError> {
   const newTaskId = generateTaskId();
   const slug = action.slug ?? "replacement-task";
-  return context.engine.supersedeTask({
-    oldTaskId: action.oldTaskId,
-    newTaskId,
-    title: action.title ?? "Replacement Task",
-    slug,
-    reason: lifecycleReason(action.reason, {
-      deletedBy: action.deletedBy,
-      allowOpenFindings: action.allowOpenFindings ? "true" : undefined
-    })
-  }).pipe(Effect.map((result): CliResult => ({
-    ok: true,
-    command: "task-supersede",
-    taskId: result.oldTaskId,
-    path: `task/${result.newTaskId}`,
-    packagePath: path.relative(context.rootDir, createTaskPackagePath(context.layoutInput, result.newTaskId, slug)).split(path.sep).join("/")
-  })));
+  const title = action.title ?? "Replacement Task";
+  return Effect.gen(function* () {
+    const scaffoldSource = readSupersededTaskScaffoldSource(context, action.oldTaskId);
+    if (!scaffoldSource.ok) return yield* Effect.fail(scaffoldSource.error);
+    const settingsResult = readProjectHarnessSettings(context.layoutInput, "task-supersede");
+    if (!settingsResult.ok) return settingsResult.result;
+    const scaffold = scaffoldSource.vertical === "software/coding"
+      ? materializePresetTaskScaffold(context.layoutInput, {
+        command: "task-supersede",
+        vertical: scaffoldSource.vertical,
+        presetId: scaffoldSource.preset,
+        profileId: scaffoldSource.profile ?? settingsResult.settings.defaultProfile,
+        locale: settingsResult.settings.locale ?? "zh-CN"
+      }, settingsResult.settings)
+      : { ok: true as const, materialized: { documents: [] } };
+    if (!scaffold.ok) return scaffold.result;
+    return yield* context.engine.supersedeTask({
+      oldTaskId: action.oldTaskId,
+      newTaskId,
+      title,
+      slug,
+      reason: lifecycleReason(action.reason, {
+        deletedBy: action.deletedBy,
+        allowOpenFindings: action.allowOpenFindings ? "true" : undefined
+      }),
+      scaffoldDocuments: scaffold.materialized.documents.map((document) => ({
+        path: document.materializeAs,
+        body: renderTemplateBody(document.body, title)
+      }))
+    }).pipe(Effect.map((result): CliResult => ({
+      ok: true,
+      command: "task-supersede",
+      taskId: result.oldTaskId,
+      path: `task/${result.newTaskId}`,
+      packagePath: path.relative(context.rootDir, createTaskPackagePath(context.layoutInput, result.newTaskId, slug)).split(path.sep).join("/")
+    })));
+  });
+}
+
+function readSupersededTaskScaffoldSource(
+  context: CommandRunnerContext,
+  taskId: string
+): { readonly ok: true; readonly vertical: string; readonly preset: string; readonly profile?: string } | { readonly ok: false; readonly error: EngineError } {
+  try {
+    const body = readFileSync(taskDocumentPath(context.layoutInput, taskId, "INDEX.md"), "utf8");
+    const frontmatter = readFrontmatter(body);
+    if (!frontmatter) return { ok: false, error: { _tag: "MalformedSnapshot", raw: "INDEX.md missing frontmatter" } };
+    const profile = frontmatter.match(/^profile:[ \t]*(.*)$/mu)?.[1]?.trim() ?? "";
+    return {
+      ok: true,
+      vertical: readScalar(frontmatter, "vertical", { required: true }),
+      preset: readScalar(frontmatter, "preset", { required: true }),
+      ...(profile ? { profile } : {})
+    };
+  } catch (cause) {
+    return isNodeErrorCode(cause, "ENOENT")
+      ? { ok: false, error: { _tag: "TaskNotFound", taskId } }
+      : { ok: false, error: { _tag: "MalformedSnapshot", raw: cause instanceof Error ? cause.message.replace(/'[^']*'/gu, "[path]") : "malformed task package" } };
+  }
+}
+
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
 }

--- a/packages/cli/src/commands/preset-task.ts
+++ b/packages/cli/src/commands/preset-task.ts
@@ -5,17 +5,45 @@ import { makeLocalWriteCoordinator } from "../../../adapters/local/src/index.ts"
 import { resolveTaskCreatedBy } from "../../../adapters/local/src/created-by.ts";
 import { assertValidParentBinding, indexPath, makeIndex, renderIndex, validateGeneratedTaskId, validateTaskId } from "../../../adapters/local/src/task-index.ts";
 import { bindCreateProvenance, type ProvenanceBindingOptions } from "../../../application/src/index.ts";
-import { taskEntityId, type EngineError, type WriteError } from "../../../kernel/src/index.ts";
-import { stablePayloadHash } from "../../../kernel/src/index.ts";
-import type { HarnessLayoutInput, HarnessLayoutOverrides } from "../../../kernel/src/index.ts";
-import { createTaskPackagePath, generateTaskId, resolveHarnessLayout } from "../../../kernel/src/index.ts";
+import {
+  createTaskPackagePath,
+  generateTaskId,
+  resolveHarnessLayout,
+  stablePayloadHash,
+  taskEntityId,
+  type EngineError,
+  type ExtensionValidationIssue,
+  type HarnessLayoutInput,
+  type HarnessLayoutOverrides,
+  type MaterializedTemplatePlan,
+  type WriteError
+} from "../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../cli/error-codes.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
 import { buildDerivedDocmapReadSet, renderDocmapReadSetMarkdown } from "./core/docmap-generate.ts";
-import { isInvalidPreset, materializePresetTaskDocuments, presetNotFound, publicPresetSummary, readModules, resolvePresetEntry, writeModulesCoordinated } from "./extensions/state.ts";
+import { isInvalidPreset, materializePresetTaskDocuments, presetNotFound, publicPresetSummary, readModules, resolvePresetEntry, writeModulesCoordinated, type ResolvedPreset } from "./extensions/state.ts";
 import { customVerticalGateResult, type ProjectHarnessSettings } from "./settings.ts";
 
 type NewTaskAction = Extract<ParsedCommand["action"], { readonly kind: "new-task" }>;
+
+interface PresetTaskMaterializationInput {
+  readonly command: string;
+  readonly vertical: string;
+  readonly presetId: string;
+  readonly profileId?: string;
+  readonly locale: "zh-CN" | "en-US";
+}
+
+interface PresetTaskMaterializationResult {
+  readonly vertical: string;
+  readonly preset: ResolvedPreset;
+  readonly materialized: {
+    readonly ok: true;
+    readonly profile: NonNullable<ReturnType<typeof materializePresetTaskDocuments>["profile"]>;
+    readonly documents: ReadonlyArray<MaterializedTemplatePlan>;
+    readonly issues: ReadonlyArray<ExtensionValidationIssue>;
+  };
+}
 
 export function shouldUsePresetAwareNewTask(action: NewTaskAction): boolean {
   return Boolean(action.vertical || action.preset || action.profile || action.moduleKey || action.registerModule || action.longRunning || action.dryRun || action.locale);
@@ -30,9 +58,6 @@ export function runNewTaskWithPreset(
   return Effect.gen(function* () {
     const rootDir = resolveHarnessLayout(rootInput).rootDir;
     const vertical = action.vertical ?? settings?.defaultVertical ?? "software/coding";
-    if (vertical !== "software/coding") {
-      return customVerticalGateResult(rootInput, "new-task", settings);
-    }
 
     let presetId = action.preset ?? settings?.defaultPreset ?? "standard-task";
     if (action.longRunning) presetId = "long-running-task";
@@ -44,31 +69,15 @@ export function runNewTaskWithPreset(
         error: cliError(CliErrorCode.MissingModule, "Use task create --preset module --module <key>.")
       } satisfies CliResult;
     }
-    const preset = resolvePresetEntry(rootInput, presetId);
-    if (!preset) return presetNotFound("new-task", presetId);
-    if (isInvalidPreset(preset)) {
-      return {
-        ok: false,
-        command: "new-task",
-        preset: { id: preset.id, layer: preset.layer, valid: false },
-        issues: preset.issues,
-        error: cliError(CliErrorCode.PresetManifestInvalid, "Preset manifest failed validation.")
-      } satisfies CliResult;
-    }
-
-    const materialized = materializePresetTaskDocuments(preset.manifest, {
+    const scaffold = materializePresetTaskScaffold(rootInput, {
+      command: "new-task",
+      vertical,
+      presetId,
       profileId: action.profile ?? settings?.defaultProfile,
       locale: action.locale ?? settings?.locale ?? "zh-CN"
-    });
-    if (!materialized.ok || !materialized.profile) {
-      return {
-        ok: false,
-        command: "new-task",
-        preset: publicPresetSummary(preset),
-        issues: materialized.issues,
-        error: cliError(CliErrorCode.PresetMaterializationFailed, "Preset-selected templates could not be materialized.")
-      } satisfies CliResult;
-    }
+    }, settings);
+    if (!scaffold.ok) return scaffold.result;
+    const { materialized, preset } = scaffold;
 
     const registeredModule = action.registerModule
       ? {
@@ -251,6 +260,59 @@ export function runNewTaskWithPreset(
   });
 }
 
+export function materializePresetTaskScaffold(
+  rootInput: HarnessLayoutInput,
+  input: PresetTaskMaterializationInput,
+  settings?: ProjectHarnessSettings
+): { readonly ok: true } & PresetTaskMaterializationResult | { readonly ok: false; readonly result: CliResult } {
+  if (input.vertical !== "software/coding") {
+    return { ok: false, result: customVerticalGateResult(rootInput, input.command, settings) };
+  }
+  const preset = resolvePresetEntry(rootInput, input.presetId);
+  if (!preset) return { ok: false, result: presetNotFound(input.command, input.presetId) };
+  if (isInvalidPreset(preset)) {
+    return {
+      ok: false,
+      result: {
+        ok: false,
+        command: input.command,
+        preset: { id: preset.id, layer: preset.layer, valid: false },
+        issues: preset.issues,
+        error: cliError(CliErrorCode.PresetManifestInvalid, "Preset manifest failed validation.")
+      } satisfies CliResult
+    };
+  }
+
+  const materialized = materializePresetTaskDocuments(preset.manifest, {
+    profileId: input.profileId,
+    locale: input.locale
+  });
+  if (!materialized.ok || !materialized.profile) {
+    return {
+      ok: false,
+      result: {
+        ok: false,
+        command: input.command,
+        preset: publicPresetSummary(preset),
+        issues: materialized.issues,
+        error: cliError(CliErrorCode.PresetMaterializationFailed, "Preset-selected templates could not be materialized.")
+      } satisfies CliResult
+    };
+  }
+
+  return {
+    ok: true,
+    vertical: input.vertical,
+    preset,
+    materialized: {
+      ok: true,
+      profile: materialized.profile,
+      documents: materialized.documents,
+      issues: materialized.issues
+    }
+  };
+}
+
 function resolveTaskReadSet(
   rootInput: HarnessLayoutInput,
   moduleKey: string | undefined
@@ -278,6 +340,6 @@ function renderModuleSelection(module: { readonly key: string; readonly title: s
   ].join("\n");
 }
 
-function renderTemplateBody(body: string, title: string): string {
+export function renderTemplateBody(body: string, title: string): string {
   return body.replace(/\{\{title\}\}/gu, title);
 }

--- a/packages/cli/test/check-governance-cli.test.ts
+++ b/packages/cli/test/check-governance-cli.test.ts
@@ -106,6 +106,15 @@ test("CLI task supersede preserves selected preset profile metadata", () => {
     assert.match(index, /vertical: software\/coding/);
     assert.match(index, /preset: profiled-task/);
     assert.match(index, /profile: extra/);
+    for (const documentPath of ["task_plan.md", "progress.md", "facts.md", "review.md", "closeout.md", "artifacts/.gitkeep", "references/.gitkeep", "extra.md"]) {
+      assert.equal(existsSync(path.join(rootDir, superseded.packagePath, documentPath)), true, documentPath);
+    }
+
+    const checked = runJson(rootDir, ["check", "--profile", "target-project", "--strict"]);
+    assert.equal(checked.ok, true);
+    assert.equal(checked.report.summary.hardFailCount, 0);
+    assert.equal(checked.warnings.some((warning: Record<string, unknown>) => warning.code === "metadata_document_missing"), false);
+    assert.equal(checked.warnings.some((warning: Record<string, unknown>) => warning.code === "task_plan_missing"), false);
   });
 });
 

--- a/packages/cli/test/settings-cli.test.ts
+++ b/packages/cli/test/settings-cli.test.ts
@@ -332,6 +332,10 @@ test("CLI settings locale controls bundled materialization and metadata check", 
     const taskPlan = readFileSync(path.join(rootDir, created.packagePath, "task_plan.md"), "utf8");
     assert.match(taskPlan, /Describe the verifiable result/);
 
+    const superseded = runJson(rootDir, ["task", "supersede", created.taskId, "--title", "English Replacement", "--reason", "scope changed"]);
+    const replacementTaskPlan = readFileSync(path.join(rootDir, superseded.packagePath, "task_plan.md"), "utf8");
+    assert.match(replacementTaskPlan, /Describe the verifiable result/);
+
     const checked = runJson(rootDir, ["check", "--profile", "target-project", "--strict"]);
     assert.equal(checked.ok, true);
   });


### PR DESCRIPTION
# English

## Summary

Fixes `ha task supersede <old> --title <t>` so replacement task packages materialize the same preset-selected scaffold documents as `ha task create`.

## What Changed

- Extracted the preset task scaffold materialization path used by task creation into a reusable helper.
- Updated the supersede replacement path to read the old task's vertical, preset, profile, and project locale, then pass rendered scaffold documents through the existing supersede write batch.
- Added regression coverage for successor document materialization, hard-fail-free structural checks, profile-selected extra documents, and project locale fallback.

## Task And Scope

- Harness task: `task_01KWVZD4WBZA41AJKTDFDV655N`
- Branch: `codex/fix-supersede-scaffold`
- Public scope: CLI supersede replacement scaffolding, local adapter supersede input/write batch, and focused CLI regression tests.
- Private planning/evidence updated: yes
- Out of scope: supersede relation semantics, lifecycle binding semantics, template body changes, compatibility shims, releases, and merge.

## Version Impact

- Version: no version change because this is a CLI behavior fix before a release task.
- Publish impact: publish readiness only.

## Verification

- Base `origin/main` SHA: `7c3a74f4809de2606e6eb803858b26192e0d988d`
- Branch merge-base with `origin/main`: `7c3a74f4809de2606e6eb803858b26192e0d988d`
- Last `git fetch origin` time: `2026-07-06T15:35:04Z`
- Sync method: rebase
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: harness task progress and fact records under `harness/tasks/task_01KWVZD4WBZA41AJKTDFDV655N-ha-task-supersede-standard-task/`
- Reviewer evidence path: not applicable; CEO semantic and architecture review is pending on this PR.
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/workflows/rewrite-ci.yml?query=branch%3Acodex%2Ffix-supersede-scaffold (latest run is visible there; PR body edits retrigger this workflow).
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: GitHub Actions cannot pass locally; it is expected to run after PR creation.

## Review Evidence

- Self-review: completed after rebase; public diff is limited to the supersede scaffold fix and tests.
- Reviewer subagent: not run; this is a narrow root-cause fix with local gate coverage.
- Human review: pending CEO review.
- Blocking findings: none known.

## Residual Risk

- `private-harness --strict` is not used directly on a freshly scaffolded template task because placeholder template text is intentionally hard-failed by that profile. The regression instead asserts all successor scaffold documents exist and that the structurally equivalent target-project check reports zero hard-fails and no missing-document warnings.

## References

- Task: `task_01KWVZD4WBZA41AJKTDFDV655N`
- Evidence: local gate log captured during validation; harness progress records under the task package.
- Review: this PR.

---

# 中文

## 概要

修复 `ha task supersede <old> --title <t>`：replacement task package 现在会物化与 `ha task create` 相同的 preset scaffold 文档。

## 改动内容

- 将 task create 使用的 preset task scaffold 物化路径提取为可复用 helper。
- 让 supersede replacement 路径读取旧任务的 vertical、preset、profile 与项目 locale，并通过既有 supersede write batch 写入渲染后的 scaffold 文档。
- 增加回归测试，覆盖 successor 文档物化、结构检查 0 hard-fail、profile 额外文档、项目 locale fallback。

## 任务与范围

- Harness 任务：`task_01KWVZD4WBZA41AJKTDFDV655N`
- 分支：`codex/fix-supersede-scaffold`
- 公开范围：CLI supersede replacement scaffold、本地 adapter supersede 输入 / 写入 batch、聚焦 CLI 回归测试。
- 私有计划 / 证据是否已更新：yes
- 范围外：supersede relation 语义、lifecycle binding 语义、模板正文、兼容 shim、发布、合并。

## 版本影响

- 版本：不改版本，原因是这是 release task 之前的 CLI 行为修复。
- 发布影响：只做发布准备。

## 验证

- `origin/main` 基准 SHA：`7c3a74f4809de2606e6eb803858b26192e0d988d`
- 当前分支与 `origin/main` 的 merge-base：`7c3a74f4809de2606e6eb803858b26192e0d988d`
- 最近一次 `git fetch origin` 时间：`2026-07-06T15:35:04Z`
- 同步方式：rebase
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：`harness/tasks/task_01KWVZD4WBZA41AJKTDFDV655N-ha-task-supersede-standard-task/` 下的 harness task progress 与 fact 记录
- Reviewer 证据路径：不适用；CEO 语义与架构审查等待本 PR。
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/workflows/rewrite-ci.yml?query=branch%3Acodex%2Ffix-supersede-scaffold（最新 run 在此可见；PR body 编辑会重新触发该 workflow）。
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：GitHub Actions 无法在本地通过；预期 PR 创建后运行。

## 审查证据

- 自查：rebase 后已完成；公开 diff 限于 supersede scaffold 修复和测试。
- Reviewer subagent：未运行；本次是窄范围根因修复，本地 gate 已覆盖。
- 人工审查：等待 CEO 审查。
- 阻塞发现：无已知阻塞。

## 残余风险

- 没有直接对新 scaffold 模板任务运行 `private-harness --strict`，因为该 profile 会有意 hard-fail 模板 placeholder 文本。回归测试改为断言 successor scaffold 文档完整存在，并用结构等价的 target-project check 验证 0 hard-fail 且无 missing-document warning。

## 关联材料

- 任务：`task_01KWVZD4WBZA41AJKTDFDV655N`
- 证据：验证期间捕获的本地 gate 日志；任务包下的 harness progress 记录。
- 审查：本 PR。

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear: CEO-owned squash or merge; delete `codex/fix-supersede-scaffold` after merge. / 合并方式和合并后分支清理计划清楚：CEO 负责 squash 或 merge；合并后删除 `codex/fix-supersede-scaffold`。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
