### PR TITLE
docs: add contributing guide path

### DIFF
--- a/docs-release/README.md
+++ b/docs-release/README.md
@@ -20,6 +20,14 @@ Install it, run one real loop, watch the structure grow, and see what it does fo
 
 → **[start/](start/en/00-what-is-this.md)**
 
+## Contribute without bypassing the gates
+
+Want to help build Harness Anything, or point an agent at the repo? Start with
+the contribution path: local setup, change flow, CI evidence, PR review, merge
+authority, and agent-specific rules.
+
+→ **[contributing/](contributing/en/00-overview.md)**
+
 ## Understand why it's built this way
 
 The design is deliberate, and every choice has a reason. This path walks through the primitive kernel, the decision and adjudication mechanics, the gates, the extension model, and the methodology.

--- a/docs-release/README.zh-CN.md
+++ b/docs-release/README.zh-CN.md
@@ -20,6 +20,12 @@ Harness Anything 是 AI agent 的问责层（accountability layer）：agent 产
 
 → **[start/](start/zh/00-what-is-this.md)**
 
+## 贡献时不要绕过门禁
+
+想帮忙构建 Harness Anything，或把 agent 指向这个仓库？先读贡献路径：本地准备、改动流程、CI 证据、PR 审查、合入权限，以及 agent 专用规则。
+
+→ **[contributing/](contributing/zh/00-overview.md)**
+
 ## 理解为什么这样设计
 
 设计是深思熟虑的，每个选择都有理由。这条路径讲解原语内核、决策和裁决机制、守门人(gate)、扩展模型和方法论。

--- a/docs-release/contributing/en/00-overview.md
+++ b/docs-release/contributing/en/00-overview.md
@@ -1,0 +1,61 @@
+# Contributing overview
+
+Harness Anything is built for agent-shaped work, but contributions still move
+through ordinary git review, CI, and maintainer authority. A good contribution is
+not just a patch that works locally. It is a patch with a clear scope, recorded
+evidence, a reviewable PR, and no private context leaking into the public repo.
+
+This path is the contribution contract for this repository. Read it before
+opening a PR, and give it to any coding agent that helps you.
+
+## The contribution path
+
+1. Prepare a source checkout and use a branch or worktree.
+2. Keep the change inside one reviewable scope.
+3. Run the checks that match the scope.
+4. Open a PR with the full bilingual template.
+5. Triage review comments and CI failures.
+6. Wait for maintainer-controlled merge.
+
+The last step matters: external contributors and their agents may propose
+changes, but they do not merge them into `main`. Merge authority stays with the
+maintainers, the repository owner, or a maintainer-authorized admin agent after
+the required gates pass.
+
+## What this path covers
+
+- [Local setup](01-local-setup.md): runtime, install posture, branch discipline,
+  and public/private file boundaries.
+- [Change flow](02-change-flow.md): how to shape a contribution so it can be
+  reviewed and tested.
+- [CI and evidence](03-ci-and-evidence.md): local commands, CI lanes, test
+  tiers, and what must be recorded in the PR.
+- [PR, review, and merge](04-pr-review-and-merge.md): the PR template, review
+  evidence, bot comment triage, and merge authority.
+- [Agent contributors](05-agent-contributors.md): rules for coding agents that
+  work on this repository.
+
+## Public scope only
+
+Public contributions belong in the public monorepo: `packages/`, `tools/`,
+`.github/`, root configuration, root README files, package README files, and
+`docs-release/`.
+
+Do not include local planning records, private evidence folders, generated
+caches, local agent entry files, credentials, absolute filesystem paths, or
+machine-specific state. If a private note helped you make a change, summarize
+the public reasoning in the PR instead of copying the private note.
+
+## Release posture
+
+The current public release posture is source checkout and package smoke, not a
+published npm package or signed desktop artifact. Before changing install,
+packaging, or release wording, read [Release Posture](../../release-posture.md)
+and keep the docs honest about what is shipped, foundation-only, and planned.
+
+## The short version
+
+Make the smallest coherent change, prove it with the right checks, fill the PR
+template honestly, and leave merge control to maintainers. If your agent cannot
+explain the scope, the verification, and the merge boundary, it is not ready to
+open the PR.

--- a/docs-release/contributing/en/01-local-setup.md
+++ b/docs-release/contributing/en/01-local-setup.md
@@ -1,0 +1,91 @@
+# Local setup
+
+## Prerequisites
+
+Use the same baseline as the public docs:
+
+- Node.js 24 or newer. CI covers Node 24 and Node 26.
+- git.
+- A clean source checkout of this repository.
+
+From the repository root:
+
+```bash
+npm ci
+```
+
+There is no public npm package release yet. For product usage and local
+development from source, follow the install path in
+[start/install](../../start/en/01-install.md). For repository contribution, work
+from the checkout and use the workspace scripts.
+
+## Use a branch or worktree
+
+Do not edit shared `main` directly. Start from the latest upstream state:
+
+```bash
+git fetch origin
+git switch -c <branch-name> origin/main
+```
+
+Agent-authored implementation branches should use the repository convention:
+
+```bash
+git switch -c codex/<short-scope> origin/main
+```
+
+When running multiple agents or keeping local coordination separate from public
+implementation, prefer a git worktree:
+
+```bash
+git worktree add .worktrees/<short-scope> -b codex/<short-scope> origin/main
+```
+
+Each concurrent agent gets its own branch or worktree. Two agents editing the
+same working tree is treated as a coordination failure, not as a merge strategy.
+
+## Keep public and local files separate
+
+Public PRs may include repository code, tools, CI files, public docs, and
+fixtures. They must not include:
+
+- local agent entry files such as root `AGENTS.md` or `CLAUDE.md`;
+- local harness or planning records that were not intentionally made public;
+- generated cache directories;
+- editor, Finder, OS, or machine-local files;
+- secrets, tokens, private URLs, or absolute local paths.
+
+Run `git status --short` before staging. Stage only the paths that belong to the
+contribution.
+
+## Command names
+
+Use the current CLI command names:
+
+```bash
+ha <command>
+npx harness-anything <command>
+```
+
+Do not use the stale `harness` / `npx harness` command surface for this checkout.
+
+If you edit `packages/cli/src`, rebuild the workspace CLI before relying on the
+workspace bin:
+
+```bash
+npm run build -w @harness-anything/cli
+```
+
+While iterating on CLI behavior, running the source entrypoint directly is also
+valid:
+
+```bash
+node packages/cli/src/index.ts --json doctor
+```
+
+## Before you start coding
+
+Write down the scope in one sentence. If you cannot state what files or behavior
+the PR is allowed to change, narrow the work before editing. Contributions that
+mix implementation, release posture, unrelated cleanup, and docs rewrites are
+hard to review and likely to be sent back.

--- a/docs-release/contributing/en/02-change-flow.md
+++ b/docs-release/contributing/en/02-change-flow.md
@@ -1,0 +1,74 @@
+# Change flow
+
+## Start with one reviewable scope
+
+A contribution should answer:
+
+- What problem does this solve?
+- What files or surfaces may change?
+- What is explicitly out of scope?
+- What evidence will prove the change?
+
+Keep unrelated cleanup out of the PR. If you find a neighboring bug, either fix
+it only when it blocks the current change or open a separate issue/PR.
+
+## Respect the architecture boundary
+
+Harness Anything treats Markdown in git as authored source of truth and derived
+stores as rebuildable projections. Do not introduce a second source of truth for
+tasks, decisions, facts, or relations. Do not bypass the write path for
+load-bearing authored records.
+
+When changing application behavior, prefer existing package boundaries and
+public surfaces. Avoid deep imports across packages unless the current public
+surface cannot express the change and the PR explicitly explains why.
+
+## Use the existing command surface
+
+CLI changes should go through registered commands, descriptors, help text,
+receipt shapes, error codes, and tests together. A command that works but cannot
+be discovered by `--help`, cannot emit structured output, or returns an
+unregistered error shape is not finished.
+
+When you add or change tests under `packages/**` or `tools/**`, update
+`tools/test-tier-manifest.mjs`. Unclassified tests are expected to fail closed.
+
+## Docs changes
+
+Public user-facing docs live in `docs-release/`, root README files, and package
+README files. The root `docs/` directory is not the public release channel for
+this repository.
+
+Docs should describe the current release posture honestly. Do not claim a
+published npm package, signed installer, notarized build, hosted service, or
+finished GUI product unless the release posture and gates have changed first.
+
+For docs-only PRs, still treat private-boundary and path leakage checks as real
+gates. Public docs must not reveal private planning paths, local filesystem
+paths, or unpublished operating state.
+
+## Dependency and package changes
+
+Dependency, package, and release-adjacent changes have a higher review burden.
+They must preserve the current package policy unless the PR is explicitly a
+release-boundary task:
+
+- workspace packages remain private before an explicit publish task;
+- version and publish impact must be stated in the PR;
+- package smoke and supply-chain checks may be required even when the code diff
+  looks small.
+
+## Commit discipline
+
+Commit messages stay concise and English by convention. The PR body carries the
+full bilingual explanation.
+
+Before committing:
+
+```bash
+git status --short
+git diff --check
+```
+
+Only stage files that belong to the stated scope. Do not reset, reformat, or
+stage someone else's unrelated local changes.

--- a/docs-release/contributing/en/03-ci-and-evidence.md
+++ b/docs-release/contributing/en/03-ci-and-evidence.md
@@ -1,0 +1,89 @@
+# CI and evidence
+
+Every contribution needs evidence. Evidence is not confidence language; it is a
+command, test result, CI run, diff, review note, or reasoned "not run" entry that
+a reviewer can inspect.
+
+## Local checks
+
+The smallest useful pre-PR loop is:
+
+```bash
+git diff --check
+```
+
+For public docs changes, also run:
+
+```bash
+npm run harness:check-private-boundary
+npm run harness:check-docs-release-map
+```
+
+For package, CLI, kernel, tool, GUI, or contract changes, run the PR-sized gate:
+
+```bash
+npm run check:pr
+```
+
+Before claiming implementation readiness for broad public changes, run:
+
+```bash
+npm run check
+```
+
+If a command is not run, the PR must say exactly which command was skipped and
+why. "Not needed" is not enough; name the scope reason.
+
+## Test tiers
+
+The repository uses tiered test lanes:
+
+| Command | Use |
+| --- | --- |
+| `npm run test:fast` | Pure or near-pure behavior tests. |
+| `npm run test:contract` | Public API, schema, and cross-package contracts. |
+| `npm run test:integration` | CLI, filesystem, store, migration, and slower behavior. |
+| `npm test` | Full Node test suite. |
+| `npm run test:gui` | GUI test lane. |
+
+New `packages/**` or `tools/**` tests must be registered in
+`tools/test-tier-manifest.mjs`; the runner is designed to reject unclassified
+tests.
+
+## CI lanes
+
+Pull requests run the `rewrite-ci` workflow. Required PR signals include the
+typecheck, fast/contract, integration, boundary, package-policy, GUI build,
+Node 26 compatibility, supply-chain, and PR body lint lanes as configured by the
+repository.
+
+The full aggregate `npm run check` lane is reserved for `main`, scheduled runs,
+and manual dispatch. Do not treat a pull-request skip of the full-check job as a
+failure when the PR lanes passed by design.
+
+## Evidence in the PR
+
+The PR template asks for:
+
+- base `origin/main` SHA and merge-base;
+- last fetch time and sync method;
+- public diff command;
+- local verification commands;
+- GitHub Actions `rewrite-ci` run URL;
+- reviewer evidence and blocking findings;
+- residual risk.
+
+Fill these fields honestly. Empty verification sections slow review down because
+maintainers must reconstruct the evidence from scratch.
+
+## Failing checks
+
+When a check fails:
+
+1. Read the failure, not just the job name.
+2. Fix the PR branch.
+3. Re-run the smallest local command that proves the fix.
+4. Push normally and wait for CI again.
+
+Do not force-push or direct-push to `main` to escape a failure. A failing gate is
+part of the contribution, and resolving it is part of the work.

--- a/docs-release/contributing/en/04-pr-review-and-merge.md
+++ b/docs-release/contributing/en/04-pr-review-and-merge.md
@@ -1,0 +1,83 @@
+# PR, review, and merge
+
+## PR body format
+
+Every public PR uses the repository template at `.github/pull_request_template.md`.
+The body must contain two complete language blocks:
+
+1. `# English`
+2. `# 中文`
+
+Do not write alternating paragraph-by-paragraph translations. The English block
+is complete on its own; the Chinese block is complete on its own. The gate also
+checks the PR gate checklist.
+
+## Required PR content
+
+Fill in:
+
+- Summary.
+- What Changed.
+- Task And Scope.
+- Version Impact.
+- Verification.
+- Review Evidence.
+- Residual Risk.
+- References.
+- PR Gate Checklist.
+
+If a section does not apply, say why. Do not delete template sections to make the
+PR look shorter.
+
+## Review evidence
+
+Review evidence includes self-review, maintainer review, human review, reviewer
+subagent output, and concrete bot comments on the PR. Treat review comments as
+inputs that must be triaged, not as automatic truth and not as noise.
+
+Any open P0/P1/P2 finding must be in one of these states before merge:
+
+- fixed;
+- explicitly false-positive with rationale;
+- deferred with owner and reason;
+- blocking.
+
+Do not merge with an untriaged release-blocking finding.
+
+## Bot comments
+
+If Codex Connect Bot, ChatGPT Codex Connector, or another review bot leaves a
+specific comment, include it in review triage. The bot is not the merge
+authority, and the bot is not a substitute for CI. It is evidence to evaluate.
+
+## Merge authority
+
+External contributors and their agents do not merge PRs into `main`.
+
+A PR may be merged only by a maintainer, the repository owner, or a
+maintainer-authorized admin agent after:
+
+- the branch is based on current `origin/main` or has been synchronized;
+- required `rewrite-ci` PR lanes are green;
+- the PR has no merge conflict;
+- the PR body and checklist are complete;
+- review evidence has been triaged;
+- no open release-blocking P0/P1/P2 finding remains.
+
+Maintainer-authorized admin merge is not a way to skip CI or review triage. It
+is a controlled merge path after the gates are satisfied.
+
+## Conflict handling
+
+If the PR has a merge conflict, fix the PR branch by merging or rebasing from
+`origin/main`, resolve the conflict, run the relevant checks again, and let CI
+rerun.
+
+Do not solve conflicts by force-pushing over `main`, direct-pushing to `main`, or
+asking an agent to bypass branch protection.
+
+## After merge
+
+Branch cleanup is maintainer-owned unless a maintainer explicitly asks the
+contributor to help. Public contribution is complete when the PR is merged or
+closed with a clear reason, not when local code happens to work.

--- a/docs-release/contributing/en/05-agent-contributors.md
+++ b/docs-release/contributing/en/05-agent-contributors.md
@@ -1,0 +1,81 @@
+# Agent contributors
+
+Coding agents are welcome as implementation assistants, but they must follow the
+same public contribution contract as humans. An agent that can edit files but
+cannot respect scope, evidence, and merge authority is not ready to work on this
+repository.
+
+## Give the agent this read set
+
+At minimum, point the agent to:
+
+- this contributing path;
+- the root README and `docs-release/`;
+- `.github/pull_request_template.md`;
+- the specific files named by the task or issue;
+- package scripts in `package.json`;
+- relevant tests next to the changed code.
+
+For code involving a library, framework, SDK, CLI, or cloud service, the agent
+should consult current official docs rather than relying on memory.
+
+## Agent ground rules
+
+The agent must:
+
+- state the task scope before editing;
+- work on a branch or worktree, not shared `main`;
+- inspect current code before proposing abstractions;
+- keep edits inside the stated scope;
+- use existing package boundaries and helpers;
+- run relevant checks and report exact results;
+- preserve unrelated local changes;
+- stage only files it changed for the task;
+- keep private notes, local paths, and credentials out of public diffs.
+
+The agent must not:
+
+- add compatibility shims for hypothetical users before the release boundary
+  asks for them;
+- rewrite unrelated files for style;
+- bypass generated gates or remove failing tests to make CI green;
+- open a PR with an empty verification section;
+- merge, force-push, or direct-push to `main` unless a maintainer explicitly
+  grants that authority for that exact operation.
+
+## Agent-created tasks and evidence
+
+If a maintainer asks the agent to use Harness Anything task records, the agent
+should use the current CLI:
+
+```bash
+ha task create --title "<title>" --vertical software/coding --preset standard-task
+ha task progress append <task-id> --text "<progress>"
+ha fact record --task <task-id> --statement "<observed fact>" --source "<source>" --confidence high
+```
+
+Do not hand-scaffold task directories. If the CLI cannot create or update the
+task package, stop and report the blocker.
+
+## Agent PR handoff
+
+Before asking for review, the agent should leave a compact handoff:
+
+- what changed;
+- what did not change;
+- commands run;
+- commands not run and why;
+- known residual risk;
+- files that need human attention.
+
+This handoff belongs in the PR body or review comment, not in private local
+notes that reviewers cannot see.
+
+## Merge boundary for agents
+
+An external contributor's agent has proposal authority only. It can create a
+branch, make commits, run checks, and open or update a PR. It cannot decide that
+the PR is allowed into `main`.
+
+Only maintainers, the owner, or a maintainer-authorized admin agent may merge,
+and only after the CI and review gates described in this path are satisfied.

--- a/docs-release/contributing/zh/00-overview.md
+++ b/docs-release/contributing/zh/00-overview.md
@@ -1,0 +1,49 @@
+# 贡献概览
+
+Harness Anything 是为 agent 形态的工作流设计的，但贡献仍然必须经过普通的 git
+review、CI 和 maintainer 权限。一份好的贡献不只是“本地能跑”的补丁，而是范围清楚、有
+证据、PR 可审查、并且没有把私有上下文泄漏进公开仓库的补丁。
+
+这条路径是本仓库的贡献合同。开 PR 前先读它；让任何帮你开发的 coding agent 也先读它。
+
+## 贡献路径
+
+1. 准备源码 checkout，并使用 branch 或 worktree。
+2. 把改动控制在一个可审查的范围内。
+3. 运行与范围匹配的检查。
+4. 用完整双语模板开 PR。
+5. 处理 review comment 和 CI 失败。
+6. 等 maintainer 控制的合入路径。
+
+最后一步很重要：外部贡献者和他们的 agent 可以提出改动，但不能把改动合入 `main`。
+合入权属于 maintainer、仓库 owner，或 maintainer 授权的 admin agent，并且必须在
+required gates 通过之后执行。
+
+## 这条路径覆盖什么
+
+- [本地准备](01-local-setup.md)：运行时、安装姿态、branch 纪律、公开/私有文件边界。
+- [改动流程](02-change-flow.md)：如何把贡献做成可审查、可测试的形状。
+- [CI 与证据](03-ci-and-evidence.md)：本地命令、CI lane、测试分层、PR 证据。
+- [PR、审查与合入](04-pr-review-and-merge.md)：PR 模板、review evidence、bot
+  comment triage、合入权限。
+- [Agent 贡献者](05-agent-contributors.md)：参与本仓开发的 coding agent 必须遵守的规则。
+
+## 只进入公开范围
+
+公开贡献应该落在公开 monorepo：`packages/`、`tools/`、`.github/`、根配置、根
+README、package README，以及 `docs-release/`。
+
+不要提交本地计划记录、私有证据目录、生成缓存、本地 agent 入口文件、凭证、绝对文件系统路径，
+或机器特有状态。如果某条私有笔记帮你做了判断，请把可公开的推理摘要写进 PR，而不是复制私有笔记。
+
+## Release 姿态
+
+当前公开 release 姿态是源码 checkout 和 package smoke，不是已发布 npm 包，也不是已签名的
+桌面产物。修改安装、打包、发布措辞前，先读
+[Release Posture](../../release-posture.md)，确保文档诚实区分 shipped、
+foundation-only 和 planned。
+
+## 简短版
+
+做一个最小且完整的改动，用正确检查证明它，如实填 PR 模板，把合入控制权留给 maintainer。
+如果你的 agent 讲不清范围、验证和合入边界，它还没准备好开 PR。

--- a/docs-release/contributing/zh/01-local-setup.md
+++ b/docs-release/contributing/zh/01-local-setup.md
@@ -1,0 +1,83 @@
+# 本地准备
+
+## 前置条件
+
+使用公开文档里的同一条基线：
+
+- Node.js 24 或更新版本。CI 覆盖 Node 24 和 Node 26。
+- git。
+- 本仓库的干净源码 checkout。
+
+从仓库根目录运行：
+
+```bash
+npm ci
+```
+
+目前还没有公开 npm package release。产品使用和本地源码运行见
+[start/install](../../start/zh/01-install.md)。贡献本仓代码时，从 checkout 工作并使用
+workspace scripts。
+
+## 使用 branch 或 worktree
+
+不要直接编辑共享 `main`。先基于最新 upstream：
+
+```bash
+git fetch origin
+git switch -c <branch-name> origin/main
+```
+
+Agent 写的实现分支应使用本仓约定：
+
+```bash
+git switch -c codex/<short-scope> origin/main
+```
+
+如果有多个 agent 并行，或需要把本地协调和公开实现隔离开，优先使用 git worktree：
+
+```bash
+git worktree add .worktrees/<short-scope> -b codex/<short-scope> origin/main
+```
+
+每个并发 agent 使用自己的 branch 或 worktree。两个 agent 编辑同一个 working tree 是协调
+失败，不是 merge 策略。
+
+## 分开公开文件和本地文件
+
+公开 PR 可以包含仓库代码、工具、CI 文件、公开文档和 fixture。不得包含：
+
+- 根目录本地 agent 入口文件，例如 `AGENTS.md` 或 `CLAUDE.md`；
+- 未刻意公开的本地 harness 或计划记录；
+- 生成缓存目录；
+- 编辑器、Finder、操作系统或机器本地文件；
+- secret、token、私有 URL 或本机绝对路径。
+
+stage 前先运行 `git status --short`。只 stage 属于本次贡献的路径。
+
+## 命令名
+
+使用当前 CLI 命令面：
+
+```bash
+ha <command>
+npx harness-anything <command>
+```
+
+不要在这个 checkout 里使用 stale 的 `harness` / `npx harness` 命令面。
+
+如果改了 `packages/cli/src`，在依赖 workspace bin 前先重建 CLI：
+
+```bash
+npm run build -w @harness-anything/cli
+```
+
+迭代 CLI 行为时，也可以直接跑源码入口：
+
+```bash
+node packages/cli/src/index.ts --json doctor
+```
+
+## 开始编码前
+
+用一句话写清 scope。如果你说不清 PR 允许改哪些文件或行为，先收窄再动手。把实现、release
+姿态、无关清理和 docs 重写混在一起的贡献很难 review，也更容易被退回。

--- a/docs-release/contributing/zh/02-change-flow.md
+++ b/docs-release/contributing/zh/02-change-flow.md
@@ -1,0 +1,62 @@
+# 改动流程
+
+## 从一个可审查范围开始
+
+一份贡献应该能回答：
+
+- 它解决什么问题？
+- 哪些文件或 surface 可以改变？
+- 哪些明确不在范围内？
+- 什么证据能证明它成立？
+
+把无关清理留在 PR 外。如果你发现旁边还有一个 bug，只有当它阻塞当前改动时才一起修；否则开独立
+issue/PR。
+
+## 尊重架构边界
+
+Harness Anything 把 git 里的 Markdown 当成 authored source of truth，把派生存储当成可重建投影。
+不要为 task、decision、fact 或 relation 引入第二个 source of truth。不要绕过承重 authored
+record 的写入路径。
+
+改应用行为时，优先使用现有 package boundary 和 public surface。除非现有 public surface 无法表达本次改动，
+且 PR 明确解释原因，否则避免跨 package deep import。
+
+## 使用现有命令面
+
+CLI 改动要同时经过已注册 command、descriptor、help 文本、receipt shape、error code 和测试。
+一个命令即使能跑，如果不能通过 `--help` 被发现、不能输出结构化结果，或返回未注册错误形态，都还没完成。
+
+如果在 `packages/**` 或 `tools/**` 下新增或修改测试，同步更新 `tools/test-tier-manifest.mjs`。
+未分类测试预期会 fail closed。
+
+## 文档改动
+
+公开用户文档放在 `docs-release/`、根 README 和 package README。根 `docs/` 不是这个仓库的公开 release
+渠道。
+
+文档必须诚实描述当前 release 姿态。除非 release posture 和 gates 已先改变，否则不要声称已经有公开 npm 包、签名
+installer、notarized build、hosted service 或完整 GUI 产品。
+
+docs-only PR 也必须把 private-boundary 和路径泄漏检查当成真实 gate。公开文档不得暴露私有计划路径、本机文件系统路径或未发布的运行状态。
+
+## 依赖和 package 改动
+
+依赖、package 和 release-adjacent 改动的 review 负担更高。除非 PR 明确是 release-boundary 任务，
+否则必须保持当前 package policy：
+
+- 在明确 publish task 前，workspace packages 保持 private；
+- PR 必须说明 version 与 publish impact；
+- 即使代码 diff 很小，也可能需要 package smoke 和 supply-chain 检查。
+
+## Commit 纪律
+
+commit message 按约定保持简洁英文。完整双语解释放在 PR body。
+
+commit 前：
+
+```bash
+git status --short
+git diff --check
+```
+
+只 stage 属于本次 scope 的文件。不要 reset、重排格式或 stage 别人的无关本地改动。

--- a/docs-release/contributing/zh/03-ci-and-evidence.md
+++ b/docs-release/contributing/zh/03-ci-and-evidence.md
@@ -1,0 +1,81 @@
+# CI 与证据
+
+每份贡献都需要证据。证据不是“我觉得可以”，而是 reviewer 能检查的命令、测试结果、CI run、diff、review
+note，或有理由的 “not run” 记录。
+
+## 本地检查
+
+最小有用的 pre-PR loop 是：
+
+```bash
+git diff --check
+```
+
+公开 docs 改动还要运行：
+
+```bash
+npm run harness:check-private-boundary
+npm run harness:check-docs-release-map
+```
+
+package、CLI、kernel、tool、GUI 或 contract 改动，运行 PR-sized gate：
+
+```bash
+npm run check:pr
+```
+
+对范围较大的公开改动声明 implementation readiness 前，运行：
+
+```bash
+npm run check
+```
+
+如果某条命令没跑，PR 必须写清哪条命令跳过、为什么跳过。“不需要”不够；要写明 scope 原因。
+
+## 测试分层
+
+仓库使用分层测试 lane：
+
+| 命令 | 用途 |
+| --- | --- |
+| `npm run test:fast` | 纯或近纯行为测试。 |
+| `npm run test:contract` | public API、schema、跨 package contract。 |
+| `npm run test:integration` | CLI、filesystem、store、migration 和较慢行为。 |
+| `npm test` | 全量 Node test suite。 |
+| `npm run test:gui` | GUI 测试 lane。 |
+
+新增 `packages/**` 或 `tools/**` 测试必须登记到 `tools/test-tier-manifest.mjs`；
+runner 设计上会拒绝未分类测试。
+
+## CI lanes
+
+Pull request 运行 `rewrite-ci` workflow。Required PR signals 包括仓库配置里的 typecheck、fast/contract、
+integration、boundary、package-policy、GUI build、Node 26 compatibility、supply-chain 和 PR body lint lanes。
+
+完整聚合 `npm run check` lane 保留给 `main`、scheduled run 和 manual dispatch。pull request 上 full-check
+job 按设计 skipped 时，不要把它当失败。
+
+## PR 里的证据
+
+PR 模板要求填写：
+
+- base `origin/main` SHA 和 merge-base；
+- 最近一次 fetch 时间和同步方式；
+- public diff command；
+- 本地验证命令；
+- GitHub Actions `rewrite-ci` run URL；
+- reviewer evidence 和 blocking findings；
+- residual risk。
+
+如实填写这些字段。空 verification section 会拖慢 review，因为 maintainer 必须从零重建证据。
+
+## 检查失败时
+
+检查失败时：
+
+1. 读失败内容，不只看 job 名字。
+2. 修 PR branch。
+3. 重跑能证明修复成立的最小本地命令。
+4. 正常 push，等待 CI 重跑。
+
+不要 force-push 或 direct-push 到 `main` 来逃避失败。失败的 gate 是贡献的一部分，解决它也是工作的一部分。

--- a/docs-release/contributing/zh/04-pr-review-and-merge.md
+++ b/docs-release/contributing/zh/04-pr-review-and-merge.md
@@ -1,0 +1,72 @@
+# PR、审查与合入
+
+## PR body 格式
+
+每个公开 PR 都使用 `.github/pull_request_template.md`。正文必须包含两个完整语言块：
+
+1. `# English`
+2. `# 中文`
+
+不要逐段交错翻译。英文块本身完整；中文块本身完整。gate 也会检查 PR gate checklist。
+
+## PR 必填内容
+
+填写：
+
+- Summary。
+- What Changed。
+- Task And Scope。
+- Version Impact。
+- Verification。
+- Review Evidence。
+- Residual Risk。
+- References。
+- PR Gate Checklist。
+
+如果某段不适用，说明原因。不要为了让 PR 看起来更短而删除模板 section。
+
+## Review evidence
+
+Review evidence 包括自查、maintainer review、human review、reviewer subagent 输出，以及 PR 上具体的
+bot comments。把 review comments 当成必须 triage 的输入；它们既不是自动真理，也不是噪音。
+
+任何 open P0/P1/P2 finding 在合入前必须处于以下状态之一：
+
+- 已修复；
+- 明确是 false-positive，并说明理由；
+- 带 owner 和理由延后；
+- 阻塞。
+
+不要在未 triage release-blocking finding 的情况下合入。
+
+## Bot comments
+
+如果 Codex Connect Bot、ChatGPT Codex Connector 或其他 review bot 留下具体 comment，要纳入 review
+triage。bot 不是合入权威，也不能替代 CI。它是需要评估的证据。
+
+## 合入权限
+
+外部贡献者和他们的 agent 不得把 PR 合入 `main`。
+
+只有 maintainer、仓库 owner 或 maintainer 授权的 admin agent 可以合入，并且必须满足：
+
+- 分支基于当前 `origin/main`，或已经同步；
+- required `rewrite-ci` PR lanes 全绿；
+- PR 没有 merge conflict；
+- PR body 和 checklist 完整；
+- review evidence 已 triage；
+- 没有 open release-blocking P0/P1/P2 finding。
+
+maintainer 授权的 admin merge 不是跳过 CI 或 review triage 的方式。它是在 gates 满足后的受控合入路径。
+
+## 冲突处理
+
+如果 PR 有 merge conflict，在 PR branch 上 merge 或 rebase `origin/main`，解决冲突，重新运行相关检查，
+再等 CI 重跑。
+
+不要通过 force-push 覆盖 `main`、direct-push 到 `main`，或要求 agent 绕过 branch protection 来解决冲突。
+
+## 合入之后
+
+branch cleanup 归 maintainer 负责，除非 maintainer 明确要求贡献者协助。公开贡献在 PR 被合入或被清楚说明原因关闭时完成，
+不是在本地代码能跑时完成。

--- a/docs-release/contributing/zh/05-agent-contributors.md
+++ b/docs-release/contributing/zh/05-agent-contributors.md
@@ -1,0 +1,71 @@
+# Agent 贡献者
+
+欢迎把 coding agent 当成实现助手，但 agent 必须遵守和人类一样的公开贡献合同。一个能改文件却不能遵守 scope、
+evidence 和合入权限的 agent，还没准备好在这个仓库工作。
+
+## 给 agent 的最小读集
+
+至少把这些材料交给 agent：
+
+- 这套 contributing 文档；
+- root README 和 `docs-release/`；
+- `.github/pull_request_template.md`；
+- task 或 issue 点名的具体文件；
+- `package.json` 里的 package scripts；
+- changed code 旁边的相关测试。
+
+如果代码涉及 library、framework、SDK、CLI 或 cloud service，agent 应查阅当前官方文档，而不是只依赖记忆。
+
+## Agent 基本规则
+
+agent 必须：
+
+- 编辑前说明 task scope；
+- 在 branch 或 worktree 上工作，不在共享 `main` 上工作；
+- 提抽象前先读当前代码；
+- 把编辑控制在声明范围内；
+- 使用现有 package boundary 和 helper；
+- 运行相关检查并报告精确结果；
+- 保留无关本地改动；
+- 只 stage 本任务修改的文件；
+- 不把私有笔记、本地路径或凭证放进公开 diff。
+
+agent 不得：
+
+- 在 release boundary 要求前，为假想用户加兼容 shim；
+- 为了风格重写无关文件；
+- 绕过 generated gates，或删除失败测试来让 CI 变绿；
+- 用空 verification section 开 PR；
+- merge、force-push 或 direct-push 到 `main`，除非 maintainer 对该具体操作明确授权。
+
+## Agent 创建 task 与证据
+
+如果 maintainer 要求 agent 使用 Harness Anything task records，agent 应使用当前 CLI：
+
+```bash
+ha task create --title "<title>" --vertical software/coding --preset standard-task
+ha task progress append <task-id> --text "<progress>"
+ha fact record --task <task-id> --statement "<observed fact>" --source "<source>" --confidence high
+```
+
+不要手工 scaffold task 目录。如果 CLI 不能创建或更新 task package，停下来报告 blocker。
+
+## Agent PR handoff
+
+请求 review 前，agent 应留下紧凑 handoff：
+
+- 改了什么；
+- 没改什么；
+- 跑了哪些命令；
+- 哪些命令没跑，为什么；
+- 已知 residual risk；
+- 需要人重点看的文件。
+
+这份 handoff 应放进 PR body 或 review comment，而不是放在 reviewer 看不到的私有本地笔记里。
+
+## Agent 的合入边界
+
+外部贡献者的 agent 只有 proposal authority。它可以建 branch、commit、跑检查、开或更新 PR。它不能决定
+PR 是否允许进入 `main`。
+
+只有 maintainer、owner 或 maintainer 授权的 admin agent 可以合入，并且必须满足这套文档里的 CI 与 review gates。


### PR DESCRIPTION
# English

## Summary

Add a full public contributing documentation path for Harness Anything release docs. The new path explains how external contributors and their coding agents should prepare work, run CI evidence, open PRs, handle review, and respect maintainer-only merge authority.

## What Changed

- Added `docs-release/contributing/en/` with overview, local setup, change flow, CI/evidence, PR/review/merge, and agent contributor pages.
- Added the matching `docs-release/contributing/zh/` Chinese guide set.
- Linked the contributing path from both release docs README entrypoints.

## Task And Scope

- Harness task: `task_01KWW0NPTD3JP3BFHDZFTPG1VC`
- Branch: `codex/contributing-docs`
- Public scope: release documentation only under `docs-release/`.
- Private planning/evidence updated: yes, in the local private harness task package.
- Out of scope: CI workflow changes, checker changes, branch protection changes, package policy changes, release artifact claims, pushing private harness files.

## Version Impact

- Version: no version change because this is documentation-only.
- Publish impact: no publish.

## Verification

- Base `origin/main` SHA: `141b028d3c070dbdd5cbc65b1f9edbaa88cf8a09`
- Branch merge-base with `origin/main`: `141b028d3c070dbdd5cbc65b1f9edbaa88cf8a09`
- Last `git fetch origin` time: `2026-07-06T16:02:52Z`
- Sync method: rebase
- Public diff command: `git diff --name-only origin/main...HEAD`
- Private evidence commit/path: local private harness task `task_01KWW0NPTD3JP3BFHDZFTPG1VC`
- Reviewer evidence path: local private harness task review for `task_01KWW0NPTD3JP3BFHDZFTPG1VC`
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28805537776
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: standalone `npm ci` after the rebase because dependencies were already installed in this worktree; the full `npm run check` passed after the rebase.

## Review Evidence

- Self-review: passed. The diff is limited to public release docs and bilingual index links.
- Reviewer subagent: not used for this docs-only change.
- Human review: pending PR review.
- Blocking findings: none known. Local task review passed with zero open blocking findings.

## Residual Risk

- No release-blocking residual risk remains after `rewrite-ci` passed.
- The documentation describes the current maintainer-controlled merge policy; it does not change GitHub branch protection or CI configuration.

## References

- Task: `task_01KWW0NPTD3JP3BFHDZFTPG1VC`
- Evidence: public commit `4f5445aba5c0f39445e90d2abb2ff42fc17ee153`; local `npm run check` passed after rebase.
- Review: local private harness review for `task_01KWW0NPTD3JP3BFHDZFTPG1VC`

---

# 中文

## 概要

为 Harness Anything 的 release docs 增加完整公开 contributing 文档路径。新文档说明外部贡献者及其 coding agent 应如何准备开发、运行 CI 证据、开 PR、处理 review，并遵守 maintainer-only 的合入权限边界。

## 改动内容

- 新增 `docs-release/contributing/en/`：概览、本地准备、改动流程、CI/证据、PR/审查/合入、agent 贡献者规则。
- 新增对应的 `docs-release/contributing/zh/` 中文文档集。
- 在英文和中文 release docs README 入口接入 contributing 路径。

## 任务与范围

- Harness 任务：`task_01KWW0NPTD3JP3BFHDZFTPG1VC`
- 分支：`codex/contributing-docs`
- 公开范围：只改 `docs-release/` 下的 release 文档。
- 私有计划 / 证据是否已更新：yes，已记录在本地私有 harness task package。
- 范围外：不改 CI workflow、不改 checker、不改 branch protection、不改 package policy、不声明新的 release artifact、不推送私有 harness 文件。

## 版本影响

- 版本：不改版本，原因是本 PR 只改文档。
- 发布影响：不发布。

## 验证

- `origin/main` 基准 SHA：`141b028d3c070dbdd5cbc65b1f9edbaa88cf8a09`
- 当前分支与 `origin/main` 的 merge-base：`141b028d3c070dbdd5cbc65b1f9edbaa88cf8a09`
- 最近一次 `git fetch origin` 时间：`2026-07-06T16:02:52Z`
- 同步方式：rebase
- 公开 diff 命令：`git diff --name-only origin/main...HEAD`
- 私有证据 commit/path：本地私有 harness 任务 `task_01KWW0NPTD3JP3BFHDZFTPG1VC`
- Reviewer 证据路径：本地私有 harness 任务 `task_01KWW0NPTD3JP3BFHDZFTPG1VC` 的 review
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28805537776
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：rebase 后未单独重跑 `npm ci`，因为该 worktree 依赖已经安装；rebase 后完整 `npm run check` 已通过。

## 审查证据

- 自查：通过。公开 diff 限于 release docs 和双语入口链接。
- Reviewer subagent：docs-only 改动未使用。
- 人工审查：等待 PR review。
- 阻塞发现：无已知阻塞；本地 task review 已通过且没有 open blocking finding。

## 残余风险

- `rewrite-ci` 已通过；无剩余 release-blocking 风险。
- 本 PR 只描述当前 maintainer-controlled merge policy，不改变 GitHub branch protection 或 CI 配置。

## 关联材料

- 任务：`task_01KWW0NPTD3JP3BFHDZFTPG1VC`
- 证据：公开提交 `4f5445aba5c0f39445e90d2abb2ff42fc17ee153`；rebase 后本地 `npm run check` 通过。
- 审查：本地私有 harness task review：`task_01KWW0NPTD3JP3BFHDZFTPG1VC`

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
