### PR TITLE
ci: enforce squash merge in queue and drop dead auto-queue rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
   - name: default
+    merge_method: squash
     merge_conditions:
       - check-success = boundaries
       - check-success = package-policy
@@ -13,20 +14,6 @@ pull_request_rules:
     conditions:
       - base = main
       - label = merge-queue
-    actions:
-      queue:
-        name: default
-
-  - name: auto-queue approved PRs
-    conditions:
-      - base = main
-      - "#approved-reviews-by >= 1"
-      - check-success = boundaries
-      - check-success = package-policy
-      - check-success = "typecheck (24)"
-      - check-success = "typecheck (26)"
-      - check-success = fast-contract
-      - check-success = pr-body-lint
     actions:
       queue:
         name: default


### PR DESCRIPTION
# English

## Summary

Tune the Mergify merge-queue configuration now that the queue is proven end-to-end (PR #209 was merged by the queue): enforce the repository's squash-merge convention inside the queue, and remove a dead automation rule that can never fire under the current branch-protection settings.

## What Changed

- `queue_rules.default` now sets `merge_method: squash`. PR #209 was merged by the queue as a two-parent merge commit, which deviates from the repository convention where every mainline change lands as a single squashed commit (see #213, #214). This makes the queue follow the same convention.
- Removed the `auto-queue approved PRs` rule. Its condition `#approved-reviews-by >= 1` can never be satisfied in practice: branch protection now requires 0 approving reviews and this repository's PRs are not reviewed via GitHub approvals. The `merge-queue` label rule remains the single, explicit entry point into the queue, which also keeps merge authority as a deliberate action instead of auto-merging any green PR.

## Task And Scope

- Harness task: task_01KWTNJDVMG2YT0B500JDENFVA (enable merge queue to eliminate PR rebase races)
- Branch: `chore/mergify-queue-tuning`
- Public scope: `.mergify.yml` only
- Private planning/evidence updated: yes (task progress log)
- Out of scope: CI workflow changes, branch-protection changes, any gate/checker changes

## Version Impact

- Version: no version change because this is repository automation configuration only, no published artifact is affected
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: 21fb023
- Branch merge-base with `origin/main`: 21fb023 (branched from latest main)
- Last `git fetch origin` time: immediately before branching
- Sync method: none needed
- Public diff command: `git diff origin/main...chore/mergify-queue-tuning`
- Private evidence commit/path: harness task package progress log for task_01KWTNJDVMG2YT0B500JDENFVA
- Reviewer evidence path: not applicable (config-only diff, reviewed inline)
- GitHub Actions `rewrite-ci` run URL: will be attached by CI on this PR
- [x] `git diff --check`
- [ ] `npm ci`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: npm-based commands and node tests — the diff touches only `.mergify.yml`, which no npm script consumes; `rewrite-ci` on this PR is the authoritative verification.

## Review Evidence

- Self-review: full diff read; confirmed only two semantic changes (add `merge_method: squash`, delete the dead rule) and no change to `merge_conditions`.
- Reviewer subagent: not applicable (10-line config diff)
- Human review: queue behavior change was requested and approved in session by ZeyuLi (all merges go through the Mergify queue)
- Blocking findings: none

## Residual Risk

- Mergify evaluates configuration from the default branch, so this change takes effect only after merge; the PR itself is still merged under the previous configuration (merge commit instead of squash) unless Mergify applies the new config first. Worst case is one more merge-commit-style landing, then squash for all subsequent queue merges.

## References

- Task: task_01KWTNJDVMG2YT0B500JDENFVA
- Evidence: PR #209 merged by app/mergify via queue (queue proven end-to-end); `git log` shows #209 landed as a two-parent merge commit while #213/#214 are squashed
- Review: this PR body, Review Evidence section

---

# 中文

## 概要

Mergify 合并队列已被端到端证明可用（PR #209 由队列成功合并），本 PR 对队列配置做两处收敛：让队列遵守仓库的 squash 合并惯例，并删除一条在当前分支保护配置下永远不会触发的死规则。

## 改动内容

- `queue_rules.default` 显式设置 `merge_method: squash`。PR #209 被队列以双 parent 的 merge commit 方式合入，偏离了仓库"主干每个变更一条压缩提交"的惯例（见 #213、#214）。本改动让队列合并遵循同一惯例。
- 删除 `auto-queue approved PRs` 规则。其条件 `#approved-reviews-by >= 1` 在现实中永远不满足：分支保护现在要求 0 个 approving review，本仓库的 PR 也不走 GitHub approval 流程。`merge-queue` 标签规则保留为进入队列的唯一显式入口，同时保证"合并"仍是一个显式动作而不是任何绿灯 PR 自动合入。

## 任务与范围

- Harness 任务：task_01KWTNJDVMG2YT0B500JDENFVA（启用 merge queue 消除 PR rebase 竞态）
- 分支：`chore/mergify-queue-tuning`
- 公开范围：仅 `.mergify.yml`
- 私有计划 / 证据是否已更新：yes（任务 progress 日志）
- 范围外：CI workflow、分支保护、任何 gate/checker 改动

## 版本影响

- 版本：不改版本，原因是本改动仅为仓库自动化配置，不影响任何发布产物
- 发布影响：不发布

## 验证

- `origin/main` 基准 SHA：21fb023
- 当前分支与 `origin/main` 的 merge-base：21fb023（自最新 main 切出）
- 最近一次 `git fetch origin` 时间：切分支前刚执行
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...chore/mergify-queue-tuning`
- 私有证据 commit/path：task_01KWTNJDVMG2YT0B500JDENFVA 任务包 progress 日志
- Reviewer 证据路径：不适用（纯配置 diff，已内联审阅）
- GitHub Actions `rewrite-ci` run URL：由本 PR 的 CI 附上
- [x] `git diff --check`
- [ ] `npm ci`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：npm 系列命令与 node 测试——diff 仅涉及 `.mergify.yml`，无任何 npm 脚本消费该文件；以本 PR 的 `rewrite-ci` 为权威验证。

## 审查证据

- 自查：通读全部 diff；确认仅两处语义变化（新增 `merge_method: squash`、删除死规则），`merge_conditions` 未动。
- Reviewer subagent：不适用（10 行配置 diff）
- 人工审查：队列行为变更由泽宇在会话中提出并批准（所有合并统一走 Mergify 队列）
- 阻塞发现：无

## 残余风险

- Mergify 从默认分支读取配置，本改动合并后才生效；本 PR 自身仍可能按旧配置（merge commit 而非 squash）合入。最坏情况是再多一条 merge commit 风格的合入，其后所有队列合并均为 squash。

## 关联材料

- 任务：task_01KWTNJDVMG2YT0B500JDENFVA
- 证据：PR #209 由 app/mergify 经队列合并（队列端到端证明）；`git log` 显示 #209 为双 parent merge commit 而 #213/#214 为 squash
- 审查：本 PR body 审查证据一节

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
