### PR TITLE
daemon: add identity rbac actor stamping

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -8,7 +8,7 @@ export { bindCreateProvenance } from "./provenance-binding.ts";
 export { makeDecisionWriteService } from "./decision-write-service.ts";
 export { makeFactWriteService } from "./fact-write-service.ts";
 export { makeProvenanceSessionExporter } from "./provenance-session-exporter.ts";
-export { makeRuntimeEventLedgerService } from "./runtime-event-ledger-service.ts";
+export { makeRuntimeEventAppendPromise, makeRuntimeEventLedgerService } from "./runtime-event-ledger-service.ts";
 export { listDecisionDocuments, readDecisionDocument } from "./decision-document-reader.ts";
 export type { EnvironmentCurrentSessionProbeOptions, HumanFallbackSessionProbeOptions, RuntimeSessionEnvCandidate } from "./current-session-probe.ts";
 export type { ProvenanceBindingOptions } from "./provenance-binding.ts";

--- a/packages/application/src/runtime-event-ledger-service.ts
+++ b/packages/application/src/runtime-event-ledger-service.ts
@@ -23,6 +23,7 @@ export interface RuntimeEventAppendInput {
   readonly eventId?: string;
   readonly recordedAt?: string;
   readonly kind: RuntimeEventKind;
+  readonly actor?: RuntimeEventRecord["actor"];
   readonly session: {
     readonly sessionId: string;
     readonly runtime?: RuntimeEventRuntime | "unknown";
@@ -77,6 +78,14 @@ export interface RuntimeEventLedgerService {
   readonly readSession: (sessionId: string) => Effect.Effect<RuntimeEventLedgerReadResult, RuntimeEventLedgerRejected>;
 }
 
+export function makeRuntimeEventAppendPromise(
+  service: RuntimeEventLedgerService
+): (input: RuntimeEventAppendInput) => Promise<void> {
+  return async (input) => {
+    await Effect.runPromise(service.append(input));
+  };
+}
+
 export function makeRuntimeEventLedgerService(options: RuntimeEventLedgerServiceOptions): RuntimeEventLedgerService {
   const timestamp = () => options.now?.() ?? new Date().toISOString();
   const eventId = () => options.makeEventId?.() ?? makeRuntimeEventId(timestamp());
@@ -97,6 +106,7 @@ function toRuntimeEventRecord(
     eventId: id,
     recordedAt: input.recordedAt ?? timestamp(),
     kind: input.kind,
+    ...(input.actor ? { actor: input.actor } : {}),
     session: {
       sessionId: input.session.sessionId,
       runtime: input.session.runtime ?? "unknown",

--- a/packages/application/test/runtime-event-ledger-service.test.ts
+++ b/packages/application/test/runtime-event-ledger-service.test.ts
@@ -22,6 +22,17 @@ test("runtime event ledger appends fsynced JSONL and reads schema-validated reco
         runtime: "codex",
         taskId: "task_01KWK8Z8V1YF1N0V0H2F6R1AYW"
       },
+      actor: {
+        personId: "person_zeyu",
+        displayName: "ZeYu Li",
+        primaryEmail: "zeyu@example.com",
+        providerId: "transport-derived/v1",
+        credential: {
+          kind: "ssh-username",
+          issuer: "host:team-daemon-01",
+          subject: "zeyu"
+        }
+      },
       interrupt: {
         action: "append",
         reason: "task-level steering"
@@ -41,6 +52,37 @@ test("runtime event ledger appends fsynced JSONL and reads schema-validated reco
     const readBack = Effect.runSync(ledger.readSession("codex-session-1"));
     assert.equal(readBack.events.length, 1);
     assert.deepEqual(readBack.events[0], appended.event);
+    assert.equal(readBack.events[0]?.actor?.personId, "person_zeyu");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("runtime event ledger reads legacy v1 rows without actor", () => {
+  const rootDir = createHarnessRoot();
+  try {
+    const ledger = makeRuntimeEventLedgerService({ rootInput: rootDir });
+    const ledgerDir = path.join(rootDir, ".harness/generated/runtime-events");
+    mkdirSync(ledgerDir, { recursive: true });
+    writeFileSync(path.join(ledgerDir, "codex-session-1.jsonl"), `${JSON.stringify({
+      schema: "runtime-event/v1",
+      eventId: "evt_20260703_000001",
+      recordedAt: "2026-07-03T00:00:00.000Z",
+      kind: "result",
+      session: { sessionId: "codex-session-1", runtime: "codex" },
+      turn: null,
+      step: null,
+      tool: null,
+      approval: null,
+      interrupt: null,
+      result: { status: "succeeded" },
+      cost: null
+    })}\n`, "utf8");
+
+    const readBack = Effect.runSync(ledger.readSession("codex-session-1"));
+
+    assert.equal(readBack.events.length, 1);
+    assert.equal(readBack.events[0]?.actor, undefined);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }

--- a/packages/daemon/src/identity/authorization.ts
+++ b/packages/daemon/src/identity/authorization.ts
@@ -1,0 +1,28 @@
+import type { JsonRpcMethodContract } from "../protocol/method-registry.ts";
+import type { AuthenticatedActor, PeopleRoster } from "./types.ts";
+
+export interface AuthorizationFailure {
+  readonly ok: false;
+  readonly code: "rbac_forbidden" | "command_class_missing";
+  readonly message: string;
+}
+
+export interface AuthorizationSuccess {
+  readonly ok: true;
+}
+
+export function authorizeActorForMethod(
+  actor: AuthenticatedActor,
+  contract: JsonRpcMethodContract,
+  roster: PeopleRoster
+): AuthorizationSuccess | AuthorizationFailure {
+  if (!contract.commandClass) {
+    return { ok: false, code: "command_class_missing", message: `Method is missing commandClass: ${contract.method}` };
+  }
+  if (actor.roles.some((roleId) => roster.roleAllows(roleId, contract.commandClass!))) return { ok: true };
+  return {
+    ok: false,
+    code: "rbac_forbidden",
+    message: `Person ${actor.personId} is not authorized for ${contract.commandClass} method ${contract.method}.`
+  };
+}

--- a/packages/daemon/src/identity/people-roster.ts
+++ b/packages/daemon/src/identity/people-roster.ts
@@ -1,0 +1,212 @@
+// @slice-activation PLT-Daemon W4 identity/RBAC roster exported for daemon composition and W7 team server wiring.
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { resolveHarnessLayout, type HarnessLayoutInput } from "../../../kernel/src/index.ts";
+import {
+  credentialKey,
+  type CredentialRef,
+  type DaemonCommandClass,
+  type IdentityProviderFailure,
+  type PeopleRoster,
+  type PersonProfile,
+  type RolePolicy
+} from "./types.ts";
+
+const commandClasses = new Set<DaemonCommandClass>(["admin", "repo-write", "repo-read", "arbiter"]);
+
+export function loadPeopleRoster(rootInput: HarnessLayoutInput): PeopleRoster {
+  const layout = resolveHarnessLayout(rootInput);
+  const filePath = path.join(layout.authoredRoot, "people.yaml");
+  if (!existsSync(filePath)) {
+    throw new Error(`people.yaml not found: ${path.relative(layout.rootDir, filePath)}`);
+  }
+  return peopleRosterFromDocument(readFileSync(filePath, "utf8"));
+}
+
+export function peopleRosterFromDocument(body: string): PeopleRoster {
+  const raw = parsePeopleYaml(body);
+  if (raw.schema !== "harness-people/v1") throw new Error("people.yaml schema must be harness-people/v1");
+  validateRoster(raw.people, raw.roles);
+  const peopleByCredential = new Map<string, PersonProfile>();
+  for (const person of raw.people) {
+    for (const credential of person.credentials) {
+      peopleByCredential.set(credentialKey(credential), person);
+    }
+  }
+  const rolesById = new Map(raw.roles.map((role) => [role.roleId, role]));
+  return {
+    schema: "harness-people/v1",
+    people: raw.people,
+    roles: raw.roles,
+    resolveCredential: (credential, providerId) => {
+      const person = peopleByCredential.get(credentialKey(credential));
+      if (!person) return credentialResolutionFailure(providerId, "credential_unknown", "Credential is not bound to a person.", credential);
+      if (person.disabled) return credentialResolutionFailure(providerId, "person_disabled", `Person is disabled: ${person.personId}`, credential);
+      return {
+        ok: true,
+        actor: {
+          personId: person.personId,
+          displayName: person.displayName,
+          ...(person.primaryEmail ? { primaryEmail: person.primaryEmail } : {}),
+          roles: person.roles,
+          resolvedCredential: credential,
+          providerId
+        }
+      };
+    },
+    roleAllows: (roleId, commandClass) => rolesById.get(roleId)?.commandClasses.includes(commandClass) ?? false
+  };
+}
+
+function credentialResolutionFailure(
+  providerId: string,
+  code: IdentityProviderFailure["code"],
+  message: string,
+  credential?: CredentialRef
+): IdentityProviderFailure {
+  return { ok: false, code, providerId, message, ...(credential ? { credential } : {}) };
+}
+
+function validateRoster(people: ReadonlyArray<PersonProfile>, roles: ReadonlyArray<RolePolicy>): void {
+  const personIds = new Set<string>();
+  const credentialKeys = new Set<string>();
+  const roleIds = new Set(roles.map((role) => role.roleId));
+  for (const role of roles) {
+    if (!role.roleId) throw new Error("roleId is required");
+    if (role.commandClasses.length === 0) throw new Error(`role ${role.roleId} must allow at least one command class`);
+    for (const commandClass of role.commandClasses) {
+      if (!commandClasses.has(commandClass)) throw new Error(`unknown command class: ${commandClass}`);
+    }
+  }
+  for (const person of people) {
+    if (!person.personId) throw new Error("personId is required");
+    if (personIds.has(person.personId)) throw new Error(`duplicate personId: ${person.personId}`);
+    personIds.add(person.personId);
+    if (!person.displayName) throw new Error(`displayName is required for ${person.personId}`);
+    for (const roleId of person.roles) {
+      if (!roleIds.has(roleId)) throw new Error(`person ${person.personId} references unknown role ${roleId}`);
+    }
+    for (const credential of person.credentials) {
+      const key = credentialKey(credential);
+      if (credentialKeys.has(key)) throw new Error(`duplicate credential binding: ${credential.kind}:${credential.issuer}:${credential.subject}`);
+      credentialKeys.add(key);
+    }
+  }
+}
+
+function parsePeopleYaml(body: string): { readonly schema: string; readonly people: PersonProfile[]; readonly roles: RolePolicy[] } {
+  const trimmed = body.trimStart();
+  if (trimmed.startsWith("{")) return JSON.parse(body) as { readonly schema: string; readonly people: PersonProfile[]; readonly roles: RolePolicy[] };
+
+  let schema = "";
+  let section: "people" | "roles" | undefined;
+  let currentPerson: MutablePerson | undefined;
+  let currentCredential: MutableCredential | undefined;
+  let currentRole: MutableRole | undefined;
+  const people: MutablePerson[] = [];
+  const roles: MutableRole[] = [];
+
+  for (const rawLine of body.split(/\r?\n/u)) {
+    const line = rawLine.replace(/\s+#.*$/u, "");
+    if (!line.trim()) continue;
+    const topLevel = /^([A-Za-z][A-Za-z0-9_-]*):(?:\s*(.*))?$/u.exec(line);
+    if (topLevel) {
+      const [, key, value = ""] = topLevel;
+      if (key === "schema") schema = unquote(value.trim());
+      else if (key === "people") section = "people";
+      else if (key === "roles") section = "roles";
+      else throw new Error(`Unsupported people.yaml key: ${key}`);
+      currentPerson = undefined;
+      currentCredential = undefined;
+      currentRole = undefined;
+      continue;
+    }
+    if (section === "people") {
+      const started = /^  - personId:\s*(.+)$/u.exec(line);
+      if (started) {
+        currentPerson = { personId: unquote(started[1]), displayName: "", roles: [], credentials: [] };
+        people.push(currentPerson);
+        currentCredential = undefined;
+        continue;
+      }
+      if (!currentPerson) throw new Error(`people entry must start with personId: ${line.trim()}`);
+      const scalar = /^    ([A-Za-z][A-Za-z0-9_-]*):(?:\s*(.*))?$/u.exec(line);
+      if (scalar) {
+        const [, key, value = ""] = scalar;
+        assignPersonScalar(currentPerson, key, value.trim());
+        currentCredential = undefined;
+        continue;
+      }
+      const credentialStart = /^      - kind:\s*(.+)$/u.exec(line);
+      if (credentialStart) {
+        currentCredential = { kind: unquote(credentialStart[1]), issuer: "", subject: "" };
+        currentPerson.credentials.push(currentCredential);
+        continue;
+      }
+      const credentialScalar = /^        (issuer|subject):\s*(.+)$/u.exec(line);
+      if (credentialScalar && currentCredential) {
+        currentCredential[credentialScalar[1] as "issuer" | "subject"] = unquote(credentialScalar[2]);
+        continue;
+      }
+    }
+    if (section === "roles") {
+      const started = /^  - roleId:\s*(.+)$/u.exec(line);
+      if (started) {
+        currentRole = { roleId: unquote(started[1]), commandClasses: [] };
+        roles.push(currentRole);
+        continue;
+      }
+      const commandClassesLine = /^    commandClasses:\s*(.+)$/u.exec(line);
+      if (commandClassesLine && currentRole) {
+        currentRole.commandClasses = parseInlineArray(commandClassesLine[1]) as DaemonCommandClass[];
+        continue;
+      }
+    }
+    throw new Error(`Unsupported people.yaml line: ${line.trim()}`);
+  }
+  return { schema, people: people as PersonProfile[], roles: roles as RolePolicy[] };
+}
+
+function assignPersonScalar(person: MutablePerson, key: string, rawValue: string): void {
+  if (key === "displayName") person.displayName = unquote(rawValue);
+  else if (key === "primaryEmail") person.primaryEmail = unquote(rawValue);
+  else if (key === "roles") person.roles = parseInlineArray(rawValue);
+  else if (key === "disabled") person.disabled = rawValue === "true";
+  else if (key !== "credentials") throw new Error(`Unsupported person key: ${key}`);
+}
+
+function parseInlineArray(rawValue: string): string[] {
+  const trimmed = rawValue.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) throw new Error(`Expected inline array: ${rawValue}`);
+  const inner = trimmed.slice(1, -1).trim();
+  if (!inner) return [];
+  return inner.split(",").map((item) => unquote(item.trim()));
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith("\"") && trimmed.endsWith("\"")) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+interface MutableCredential {
+  kind: string;
+  issuer: string;
+  subject: string;
+}
+
+interface MutablePerson {
+  personId: string;
+  displayName: string;
+  primaryEmail?: string;
+  roles: string[];
+  credentials: MutableCredential[];
+  disabled?: boolean;
+}
+
+interface MutableRole {
+  roleId: string;
+  commandClasses: DaemonCommandClass[];
+}

--- a/packages/daemon/src/identity/transport-derived-provider.ts
+++ b/packages/daemon/src/identity/transport-derived-provider.ts
@@ -1,0 +1,74 @@
+// @slice-activation PLT-Daemon W4 transport-derived identity provider exported for daemon composition and W7 team server wiring.
+import os from "node:os";
+import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
+import type { CredentialRef, IdentityProvider, IdentityProviderFailure, PeopleRoster } from "./types.ts";
+
+export interface TransportDerivedIdentityProviderOptions {
+  readonly localUnixIssuer?: string;
+  readonly sshExecIssuer?: string;
+  readonly namedPipeIssuer?: string;
+}
+
+export function makeTransportDerivedIdentityProvider(
+  roster: PeopleRoster,
+  options: TransportDerivedIdentityProviderOptions = {}
+): IdentityProvider {
+  const providerId = "transport-derived/v1";
+  return {
+    providerId,
+    resolveActor: async ({ authContext }) => {
+      const credential = credentialFromAuthContext(authContext, options);
+      if (!credential) {
+        return unavailableTransportCredentialFailure(
+          providerId,
+          "credential_unavailable",
+          "Transport authentication context did not expose a usable credential."
+        );
+      }
+      return roster.resolveCredential(credential, providerId);
+    }
+  };
+}
+
+function credentialFromAuthContext(
+  authContext: DaemonAuthenticationContext,
+  options: TransportDerivedIdentityProviderOptions
+): CredentialRef | undefined {
+  if (typeof authContext.unixPeerCredential?.uid === "number") {
+    return {
+      kind: "unix-uid",
+      issuer: options.localUnixIssuer ?? `host:${os.hostname()}`,
+      subject: String(authContext.unixPeerCredential.uid)
+    };
+  }
+  if (authContext.sshExecUser?.username) {
+    return {
+      kind: "ssh-username",
+      issuer: options.sshExecIssuer ?? `host:${authContext.sshExecUser.host ?? "unknown"}`,
+      subject: authContext.sshExecUser.username
+    };
+  }
+  if (authContext.sshTunnelToken?.subject.userId) {
+    return {
+      kind: "ssh-tunnel-token-subject",
+      issuer: `host-profile:${authContext.sshTunnelToken.subject.hostProfileId}`,
+      subject: authContext.sshTunnelToken.subject.userId
+    };
+  }
+  if (authContext.namedPipeClient?.endpoint) {
+    return {
+      kind: "windows-named-pipe-client",
+      issuer: options.namedPipeIssuer ?? "host:windows-named-pipe",
+      subject: authContext.namedPipeClient.endpoint
+    };
+  }
+  return undefined;
+}
+
+function unavailableTransportCredentialFailure(
+  providerId: string,
+  code: IdentityProviderFailure["code"],
+  message: string
+): IdentityProviderFailure {
+  return { ok: false, code, providerId, message };
+}

--- a/packages/daemon/src/identity/types.ts
+++ b/packages/daemon/src/identity/types.ts
@@ -1,0 +1,137 @@
+import type { JsonObject } from "../protocol/json-rpc-types.ts";
+import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
+
+export type PersonId = string;
+export type RoleId = string;
+
+export type CredentialKind =
+  | "unix-uid"
+  | "windows-named-pipe-client"
+  | "ssh-username"
+  | "ssh-tunnel-token-subject"
+  | "email-address"
+  | "password-account"
+  | "oauth-subject"
+  | "api-token";
+
+export type DaemonCommandClass = "admin" | "repo-write" | "repo-read" | "arbiter";
+
+export interface CredentialRef {
+  readonly kind: CredentialKind;
+  readonly issuer: string;
+  readonly subject: string;
+}
+
+export interface PersonProfile {
+  readonly personId: PersonId;
+  readonly displayName: string;
+  readonly primaryEmail?: string;
+  readonly roles: ReadonlyArray<RoleId>;
+  readonly credentials: ReadonlyArray<CredentialRef>;
+  readonly disabled?: boolean;
+}
+
+export interface RolePolicy {
+  readonly roleId: RoleId;
+  readonly commandClasses: ReadonlyArray<DaemonCommandClass>;
+}
+
+export interface PeopleRoster {
+  readonly schema: "harness-people/v1";
+  readonly people: ReadonlyArray<PersonProfile>;
+  readonly roles: ReadonlyArray<RolePolicy>;
+  readonly resolveCredential: (credential: CredentialRef, providerId: string) => IdentityProviderSuccess | IdentityProviderFailure;
+  readonly roleAllows: (roleId: RoleId, commandClass: DaemonCommandClass) => boolean;
+}
+
+export interface AuthenticatedActor {
+  readonly personId: PersonId;
+  readonly displayName: string;
+  readonly primaryEmail?: string;
+  readonly roles: ReadonlyArray<RoleId>;
+  readonly resolvedCredential: CredentialRef;
+  readonly providerId: string;
+}
+
+export interface ActorStamp {
+  readonly personId: PersonId;
+  readonly displayName: string;
+  readonly primaryEmail?: string;
+  readonly providerId: string;
+  readonly credential: CredentialRef;
+}
+
+export interface IdentityProviderResolveInput {
+  readonly authContext: DaemonAuthenticationContext;
+  readonly command: {
+    readonly method: string;
+    readonly namespace: "protocol" | "repo" | "admin";
+    readonly requiresRepo: boolean;
+  };
+}
+
+export type IdentityProviderFailureCode =
+  | "credential_unavailable"
+  | "credential_unknown"
+  | "person_disabled"
+  | "provider_unavailable"
+  | "malformed_credential";
+
+export interface IdentityProviderFailure {
+  readonly ok: false;
+  readonly code: IdentityProviderFailureCode;
+  readonly providerId: string;
+  readonly message: string;
+  readonly credential?: CredentialRef;
+}
+
+export interface IdentityProviderSuccess {
+  readonly ok: true;
+  readonly actor: AuthenticatedActor;
+}
+
+export interface IdentityProvider {
+  readonly providerId: string;
+  readonly resolveActor: (input: IdentityProviderResolveInput) => Promise<IdentityProviderSuccess | IdentityProviderFailure>;
+}
+
+export interface GitCommitAuthor {
+  readonly name: string;
+  readonly email: string;
+}
+
+export function credentialKey(credential: CredentialRef): string {
+  return `${credential.kind}\0${credential.issuer}\0${credential.subject}`;
+}
+
+export function actorStamp(actor: AuthenticatedActor): ActorStamp {
+  return {
+    personId: actor.personId,
+    displayName: actor.displayName,
+    ...(actor.primaryEmail ? { primaryEmail: actor.primaryEmail } : {}),
+    providerId: actor.providerId,
+    credential: actor.resolvedCredential
+  };
+}
+
+export function actorStampJson(actor: AuthenticatedActor): JsonObject {
+  const stamp = actorStamp(actor);
+  return {
+    personId: stamp.personId,
+    displayName: stamp.displayName,
+    ...(stamp.primaryEmail ? { primaryEmail: stamp.primaryEmail } : {}),
+    providerId: stamp.providerId,
+    credential: {
+      kind: stamp.credential.kind,
+      issuer: stamp.credential.issuer,
+      subject: stamp.credential.subject
+    }
+  };
+}
+
+export function actorGitCommitAuthor(actor: AuthenticatedActor, fallbackEmail: string): GitCommitAuthor {
+  return {
+    name: actor.displayName,
+    email: actor.primaryEmail?.trim() || fallbackEmail
+  };
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,8 +1,45 @@
 export {
+  actorGitCommitAuthor,
+  actorStamp,
+  actorStampJson,
+  credentialKey,
+  type ActorStamp,
+  type AuthenticatedActor,
+  type CredentialKind,
+  type CredentialRef,
+  type DaemonCommandClass,
+  type GitCommitAuthor,
+  type IdentityProvider,
+  type IdentityProviderFailure,
+  type IdentityProviderFailureCode,
+  type IdentityProviderResolveInput,
+  type IdentityProviderSuccess,
+  type PeopleRoster,
+  type PersonId,
+  type PersonProfile,
+  type RoleId,
+  type RolePolicy
+} from "./identity/types.ts";
+export {
+  loadPeopleRoster,
+  peopleRosterFromDocument
+} from "./identity/people-roster.ts";
+export {
+  makeTransportDerivedIdentityProvider,
+  type TransportDerivedIdentityProviderOptions
+} from "./identity/transport-derived-provider.ts";
+export {
+  authorizeActorForMethod,
+  type AuthorizationFailure,
+  type AuthorizationSuccess
+} from "./identity/authorization.ts";
+export {
   currentDaemonProtocolVersion,
+  commandClassForApiRoute,
   deriveJsonRpcServiceMethodContracts,
   jsonRpcMethodContracts,
   jsonRpcServiceMethodContracts,
+  type DaemonCommandClass as JsonRpcDaemonCommandClass,
   type JsonRpcMethodContract,
   type JsonRpcMethodMode
 } from "./protocol/method-registry.ts";

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -1,9 +1,13 @@
 // @slice-activation PLT-Daemon W2 protocol core exported for W3 transport adapters.
 import type { LocalControllerService } from "../../../application/src/index.ts";
+import type { RuntimeEventAppendInput } from "../../../application/src/runtime-event-ledger-service.ts";
 import type { TerminalSessionService } from "../../../gui/src/terminal/session-registry.ts";
 import { currentDaemonProtocolVersion, jsonRpcMethodContracts, type JsonRpcMethodContract } from "./method-registry.ts";
 import { failureReceipt, serviceResultReceipt, successReceipt } from "./receipt-envelope.ts";
 import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse, type JsonValue } from "./json-rpc-types.ts";
+import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
+import { authorizeActorForMethod } from "../identity/authorization.ts";
+import { actorStamp, actorStampJson, type AuthenticatedActor, type IdentityProvider, type PeopleRoster } from "../identity/types.ts";
 
 export interface DaemonRepoNamespace {
   readonly repoId: string;
@@ -19,6 +23,10 @@ export interface JsonRpcServerOptions {
   readonly daemonId: string;
   readonly repos: ReadonlyArray<DaemonRepoNamespace>;
   readonly services: DaemonServiceHost;
+  readonly authContext?: DaemonAuthenticationContext;
+  readonly identityProvider?: IdentityProvider;
+  readonly peopleRoster?: PeopleRoster;
+  readonly appendRuntimeEvent?: (input: RuntimeEventAppendInput) => Promise<void>;
 }
 
 export interface JsonRpcProtocolServer {
@@ -30,7 +38,7 @@ interface ProtocolSession {
   handshaken: boolean;
 }
 
-const methodByName = new Map(jsonRpcMethodContracts.map((contract) => [contract.method, contract]));
+const methodByName: ReadonlyMap<string, JsonRpcMethodContract> = new Map(jsonRpcMethodContracts.map((contract) => [contract.method, contract]));
 
 export function createJsonRpcProtocolServer(options: JsonRpcServerOptions): JsonRpcProtocolServer {
   const session: ProtocolSession = { handshaken: false };
@@ -77,13 +85,44 @@ async function handleRequest(
   const repoFailure = validateRepoNamespace(contract, request.params ?? {}, repos);
   if (repoFailure) return response(failureReceipt(request.method, repoFailure.code, repoFailure.hint));
 
-  if (contract.mode === "notification-stub") {
-    return response(successReceipt(request.method, `registered no-op notification stub for ${request.method}`, {
-      subscription: "noop"
-    }));
+  const actorResult = await resolveActor(contract, options);
+  if (actorResult && !actorResult.ok) {
+    const receipt = failureReceipt(request.method, actorResult.code, actorResult.message, {
+      providerId: actorResult.providerId,
+      ...(actorResult.credential ? { credential: credentialJson(actorResult.credential) } : {})
+    });
+    await appendCommandEvent(options, request.params ?? {}, contract, "failed", actorResult.message, actorResult.code);
+    return response(receipt);
+  }
+  const actor = actorResult?.actor;
+  if (actor && options.peopleRoster) {
+    const authz = authorizeActorForMethod(actor, contract, options.peopleRoster);
+    if (!authz.ok) {
+      await appendCommandEvent(options, request.params ?? {}, contract, "failed", authz.message, authz.code, actor);
+      return response(stampReceipt(failureReceipt(request.method, authz.code, authz.message, {
+        actor: actorStampJson(actor),
+        commandClass: contract.commandClass ?? null
+      }), actor));
+    }
   }
 
-  return response(await callServiceMethod(contract, request.params ?? {}, options.services));
+  if (contract.mode === "notification-stub") {
+    return response(stampReceipt(successReceipt(request.method, `registered no-op notification stub for ${request.method}`, {
+      subscription: "noop"
+    }), actor));
+  }
+
+  if (contract.namespace === "admin") {
+    const result = handleAdminMethod(contract, options);
+    const receipt = stampReceipt(result, actor);
+    await appendWriteEventIfNeeded(options, request.params ?? {}, contract, receipt.ok ? "succeeded" : "failed", receipt.summary, receipt.ok ? undefined : receipt.error?.code, actor);
+    return response(receipt);
+  }
+
+  const result = await callServiceMethod(contract, request.params ?? {}, options.services);
+  const receipt = stampReceipt(result, actor);
+  await appendWriteEventIfNeeded(options, request.params ?? {}, contract, receipt.ok ? "succeeded" : "failed", receipt.summary, receipt.ok ? undefined : receipt.error?.code, actor);
+  return response(receipt);
 }
 
 function handleHello(
@@ -130,7 +169,7 @@ async function callServiceMethod(
   contract: JsonRpcMethodContract,
   params: JsonObject,
   services: DaemonServiceHost
-): Promise<unknown> {
+): Promise<ReturnType<typeof successReceipt> | ReturnType<typeof failureReceipt>> {
   const payload = isJsonObject(params.payload) ? params.payload : undefined;
   const result = contract.service === "TerminalSessionService"
     ? await invokeServiceMethod(services.TerminalSessionService, String(contract.serviceMethod), payload)
@@ -138,6 +177,122 @@ async function callServiceMethod(
   return isJsonObject(result)
     ? serviceResultReceipt(contract.method, result)
     : successReceipt(contract.method, `completed ${contract.method}`, { value: toJsonValue(result) });
+}
+
+async function resolveActor(
+  contract: JsonRpcMethodContract,
+  options: JsonRpcServerOptions
+): Promise<{ readonly ok: true; readonly actor: AuthenticatedActor } | Awaited<ReturnType<IdentityProvider["resolveActor"]>> | undefined> {
+  if (!options.identityProvider) return undefined;
+  const authContext = options.authContext ?? { transportKind: "unix-socket" } satisfies DaemonAuthenticationContext;
+  return options.identityProvider.resolveActor({
+    authContext,
+    command: {
+      method: contract.method,
+      namespace: contract.namespace,
+      requiresRepo: contract.requiresRepo
+    }
+  });
+}
+
+function handleAdminMethod(
+  contract: JsonRpcMethodContract,
+  options: JsonRpcServerOptions
+): ReturnType<typeof successReceipt> | ReturnType<typeof failureReceipt> {
+  if (!options.peopleRoster) {
+    return failureReceipt(contract.method, "people_roster_unavailable", "Admin identity methods require a loaded people roster.");
+  }
+  if (contract.method === "admin.people.list") {
+    return successReceipt(contract.method, "listed people", {
+      items: options.peopleRoster.people.map((person) => ({
+        personId: person.personId,
+        displayName: person.displayName,
+        ...(person.primaryEmail ? { primaryEmail: person.primaryEmail } : {}),
+        roles: [...person.roles],
+        disabled: person.disabled ?? false,
+        credentials: person.credentials.map(credentialJson)
+      }))
+    });
+  }
+  if (contract.method === "admin.rbac.roles.list") {
+    return successReceipt(contract.method, "listed RBAC roles", {
+      items: options.peopleRoster.roles.map((role) => ({
+        roleId: role.roleId,
+        commandClasses: [...role.commandClasses]
+      }))
+    });
+  }
+  return failureReceipt(contract.method, "method_not_implemented", `Admin method is not implemented: ${contract.method}`);
+}
+
+function stampReceipt<T extends ReturnType<typeof successReceipt> | ReturnType<typeof failureReceipt>>(receipt: T, actor?: AuthenticatedActor): T {
+  if (!actor) return receipt;
+  return {
+    ...receipt,
+    details: {
+      ...(receipt.details ?? {}),
+      actor: actorStampJson(actor)
+    }
+  };
+}
+
+async function appendWriteEventIfNeeded(
+  options: JsonRpcServerOptions,
+  params: JsonObject,
+  contract: JsonRpcMethodContract,
+  status: "succeeded" | "failed",
+  summary: string,
+  errorCode: string | undefined,
+  actor: AuthenticatedActor | undefined
+): Promise<void> {
+  if (contract.commandClass === "repo-read") return;
+  await appendCommandEvent(options, params, contract, status, summary, errorCode, actor);
+}
+
+async function appendCommandEvent(
+  options: JsonRpcServerOptions,
+  params: JsonObject,
+  contract: JsonRpcMethodContract,
+  status: "succeeded" | "failed",
+  summary: string,
+  errorCode?: string,
+  actor?: AuthenticatedActor
+): Promise<void> {
+  if (!options.appendRuntimeEvent) return;
+  const session = runtimeSession(params, options.daemonId);
+  await options.appendRuntimeEvent({
+    kind: "result",
+    session,
+    tool: {
+      toolName: contract.method,
+      ...(errorCode ? { errorCode } : {})
+    },
+    result: {
+      status,
+      summary,
+      ...(errorCode ? { errorCode } : {})
+    },
+    ...(actor ? { actor: actorStamp(actor) } : {})
+  }).catch(() => undefined);
+}
+
+function runtimeSession(params: JsonObject, daemonId: string): { readonly sessionId: string; readonly runtime: "human" | "claude-code" | "codex" | "zcode" | "antigravity" | "unknown" } {
+  const session = isJsonObject(params.session) ? params.session : {};
+  const runtime = typeof session.runtime === "string" && ["human", "claude-code", "codex", "zcode", "antigravity"].includes(session.runtime)
+    ? session.runtime as "human" | "claude-code" | "codex" | "zcode" | "antigravity"
+    : "unknown";
+  return {
+    sessionId: typeof session.sessionId === "string" && session.sessionId.trim() ? session.sessionId : `daemon-${daemonId}`,
+    runtime
+  };
+}
+
+function credentialJson(credential: { readonly kind: string; readonly issuer: string; readonly subject: string }): JsonObject {
+  return {
+    kind: credential.kind,
+    issuer: credential.issuer,
+    subject: credential.subject
+  };
 }
 
 async function invokeServiceMethod(

--- a/packages/daemon/src/protocol/method-registry.ts
+++ b/packages/daemon/src/protocol/method-registry.ts
@@ -1,8 +1,10 @@
 import { apiRouteContracts, type ApiRouteContract } from "../../../gui/src/api/api-contract-registry.ts";
+import type { DaemonCommandClass } from "../identity/types.ts";
 
 export const currentDaemonProtocolVersion = 1 as const;
 
 export type JsonRpcMethodMode = "active" | "notification-stub" | "reserved";
+export type { DaemonCommandClass };
 
 export interface JsonRpcMethodContract {
   readonly method: string;
@@ -16,6 +18,7 @@ export interface JsonRpcMethodContract {
   readonly routeId?: ApiRouteContract["id"];
   readonly auth: ApiRouteContract["auth"];
   readonly requiresRepo: boolean;
+  readonly commandClass?: DaemonCommandClass;
 }
 
 const protocolMethodContracts = [
@@ -40,7 +43,8 @@ const notificationStubContracts = [
     outputSchemaId: "daemon.notification-subscription-result/v1",
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
-    requiresRepo: true
+    requiresRepo: true,
+    commandClass: "repo-read"
   },
   {
     method: "repo.notifications.unsubscribe",
@@ -50,32 +54,37 @@ const notificationStubContracts = [
     outputSchemaId: "daemon.notification-subscription-result/v1",
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
-    requiresRepo: true
+    requiresRepo: true,
+    commandClass: "repo-read"
   }
 ] as const satisfies ReadonlyArray<JsonRpcMethodContract>;
 
 const adminReservedContracts = [
   {
     method: "admin.people.list",
-    mode: "reserved",
+    mode: "active",
     namespace: "admin",
     inputSchemaId: "daemon.admin-empty/v1",
     outputSchemaId: "daemon.admin-people-list/v1",
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
-    requiresRepo: false
+    requiresRepo: false,
+    commandClass: "admin"
   },
   {
     method: "admin.rbac.roles.list",
-    mode: "reserved",
+    mode: "active",
     namespace: "admin",
     inputSchemaId: "daemon.admin-empty/v1",
     outputSchemaId: "daemon.admin-rbac-roles-list/v1",
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
-    requiresRepo: false
+    requiresRepo: false,
+    commandClass: "admin"
   }
 ] as const satisfies ReadonlyArray<JsonRpcMethodContract>;
+
+const arbiterApiRouteIds = new Set<string>(["tasks.status.set", "tasks.review"]);
 
 export function deriveJsonRpcServiceMethodContracts(
   contracts: ReadonlyArray<ApiRouteContract> = apiRouteContracts
@@ -91,8 +100,15 @@ export function deriveJsonRpcServiceMethodContracts(
     serviceMethod: contract.serviceMethod,
     routeId: contract.id,
     auth: contract.auth,
-    requiresRepo: true
+    requiresRepo: true,
+    commandClass: commandClassForApiRoute(contract)
   }));
+}
+
+export function commandClassForApiRoute(contract: ApiRouteContract): DaemonCommandClass {
+  if (arbiterApiRouteIds.has(contract.id)) return "arbiter";
+  if (contract.method === "GET" || contract.method === "WS") return "repo-read";
+  return "repo-write";
 }
 
 export const jsonRpcServiceMethodContracts = deriveJsonRpcServiceMethodContracts();

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -1,15 +1,22 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import type { LocalControllerService } from "../../application/src/index.ts";
+import { makeRuntimeEventAppendPromise, makeRuntimeEventLedgerService } from "../../application/src/index.ts";
 import { apiRouteContracts } from "../../gui/src/api/api-contract-registry.ts";
 import { createInMemoryTerminalSessionService } from "../../gui/src/terminal/session-registry.ts";
 import {
   createJsonRpcProtocolServer,
   currentDaemonProtocolVersion,
   jsonRpcServiceMethodContracts,
+  jsonRpcMethodContracts,
+  makeTransportDerivedIdentityProvider,
+  peopleRosterFromDocument,
+  type IdentityProvider,
+  type PeopleRoster,
   type JsonRpcRequest,
   type JsonRpcResponse
 } from "../src/index.ts";
@@ -33,6 +40,16 @@ test("daemon JSON-RPC service method registry is derived from the API contract r
       outputSchemaId: contract.outputSchemaId
     }))
   );
+});
+
+test("daemon method registry classifies every non-hello method exactly once", () => {
+  for (const contract of jsonRpcMethodContracts) {
+    if (contract.method === "protocol.hello") {
+      assert.equal(contract.commandClass, undefined);
+      continue;
+    }
+    assert.match(contract.commandClass ?? "", /^(admin|repo-write|repo-read|arbiter)$/u, contract.method);
+  }
 });
 
 test("protocol.hello accepts the current daemon protocol version", async () => {
@@ -112,8 +129,16 @@ test("notification subscribe is a no-op socket and respects JSON-RPC notificatio
   assert.equal(response, undefined);
 });
 
-test("admin namespace is reserved and explicitly rejected until W4 owns it", async () => {
-  const server = makeServer();
+test("admin people list returns roster data and stamps receipt actor", async () => {
+  const roster = sampleRoster();
+  const server = makeServer({
+    peopleRoster: roster,
+    identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),
+    authContext: {
+      transportKind: "ssh-exec",
+      sshExecUser: { username: "alice", host: "team-host", source: "ssh-authenticated-exec" }
+    }
+  });
   await server.handle(readFixture("hello-compatible.json"));
 
   const response = await server.handle({
@@ -124,11 +149,109 @@ test("admin namespace is reserved and explicitly rejected until W4 owns it", asy
   });
   const receipt = resultReceipt(response);
 
-  assert.equal(receipt.ok, false);
-  assert.equal(receipt.error.code, "method_reserved");
+  assert.equal(receipt.ok, true);
+  assert.equal(receipt.items?.length, 3);
+  assert.equal((receipt.details.actor as { readonly personId?: string }).personId, "person_alice");
 });
 
-function makeServer() {
+test("transport-derived provider rejects unknown credentials without anonymous fallback", async () => {
+  const roster = sampleRoster();
+  const provider = makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" });
+  const resolved = await provider.resolveActor({
+    authContext: {
+      transportKind: "ssh-exec",
+      sshExecUser: { username: "mallory", host: "team-host", source: "ssh-authenticated-exec" }
+    },
+    command: { method: "repo.tasks.list", namespace: "repo", requiresRepo: true }
+  });
+
+  assert.equal(resolved.ok, false);
+  if (!resolved.ok) assert.equal(resolved.code, "credential_unknown");
+});
+
+test("mock email provider proves provider extension without daemon call-site changes", async () => {
+  const roster = sampleRoster();
+  const emailProvider: IdentityProvider = {
+    providerId: "email-session/v1",
+    resolveActor: async ({ authContext }) => {
+      const claims = authContext.sshTunnelToken?.subject.claims;
+      const email = claims && typeof claims.email === "string" ? claims.email.toLowerCase() : "";
+      return roster.resolveCredential({ kind: "email-address", issuer: "email:primary", subject: email }, "email-session/v1");
+    }
+  };
+
+  const resolved = await emailProvider.resolveActor({
+    authContext: {
+      transportKind: "ssh-tunnel",
+      sshTunnelToken: {
+        tokenId: "token-1",
+        tunnelNonce: "nonce-1",
+        subject: {
+          userId: "session-user",
+          hostProfileId: "host-profile",
+          daemonInstanceId: "daemon-test",
+          claims: { email: "ALICE@EXAMPLE.COM" }
+        }
+      }
+    },
+    command: { method: "repo.tasks.list", namespace: "repo", requiresRepo: true }
+  });
+
+  assert.equal(resolved.ok, true);
+  if (resolved.ok) {
+    assert.equal(resolved.actor.personId, "person_alice");
+    assert.equal(resolved.actor.providerId, "email-session/v1");
+  }
+});
+
+test("RBAC rejects non-arbiter methods and records a runtime event with actor", async () => {
+  const rootDir = createHarnessRoot();
+  try {
+    const roster = sampleRoster();
+    const server = makeServer({
+      peopleRoster: roster,
+      identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),
+      authContext: {
+        transportKind: "ssh-exec",
+        sshExecUser: { username: "viewer", host: "team-host", source: "ssh-authenticated-exec" }
+      },
+      appendRuntimeEvent: makeRuntimeEventAppendPromise(makeRuntimeEventLedgerService({
+        rootInput: rootDir,
+        now: () => "2026-07-07T00:00:00.000Z",
+        makeEventId: () => "evt_20260707_rbacdeny"
+      }))
+    });
+    await server.handle(readFixture("hello-compatible.json"));
+
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: "rbac-1",
+      method: "repo.tasks.review",
+      params: {
+        repo: { repoId: "canonical" },
+        session: { sessionId: "codex-session-rbac", runtime: "codex" },
+        payload: { taskId: "task-1" }
+      }
+    });
+    const receipt = resultReceipt(response);
+
+    assert.equal(receipt.ok, false);
+    assert.equal(receipt.error?.code, "rbac_forbidden");
+    assert.equal((receipt.details.actor as { readonly personId?: string }).personId, "person_viewer");
+    const event = JSON.parse(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/codex-session-rbac.jsonl"), "utf8")) as {
+      readonly actor?: { readonly personId?: string };
+      readonly result?: { readonly errorCode?: string };
+      readonly tool?: { readonly toolName?: string };
+    };
+    assert.equal(event.actor?.personId, "person_viewer");
+    assert.equal(event.result?.errorCode, "rbac_forbidden");
+    assert.equal(event.tool?.toolName, "repo.tasks.review");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function makeServer(overrides: Partial<Parameters<typeof createJsonRpcProtocolServer>[0]> = {}) {
   const localController: LocalControllerService = {
     getTasks: () => ({ ok: true, tasks: [], warnings: [] }),
     getTaskDetail: () => ({ ok: true }),
@@ -147,7 +270,8 @@ function makeServer() {
     services: {
       LocalControllerService: localController,
       TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" })
-    }
+    },
+    ...overrides
   });
 }
 
@@ -166,7 +290,7 @@ function resultReceipt(response: JsonRpcResponse | ReadonlyArray<JsonRpcResponse
   readonly action?: string;
   readonly error?: { readonly code?: string };
   readonly items?: ReadonlyArray<unknown>;
-  readonly details: Record<string, Record<string, unknown>>;
+  readonly details: Record<string, any>;
 } {
   assert.ok(response && !Array.isArray(response));
   assert.equal("result" in response, true);
@@ -177,6 +301,54 @@ function resultReceipt(response: JsonRpcResponse | ReadonlyArray<JsonRpcResponse
     readonly action?: string;
     readonly error?: { readonly code?: string };
     readonly items?: ReadonlyArray<unknown>;
-    readonly details: Record<string, Record<string, unknown>>;
+    readonly details: Record<string, any>;
   };
+}
+
+function sampleRoster(): PeopleRoster {
+  return peopleRosterFromDocument([
+    "schema: harness-people/v1",
+    "people:",
+    "  - personId: person_alice",
+    "    displayName: Alice Admin",
+    "    primaryEmail: alice@example.com",
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: ssh-username",
+    "        issuer: host:team-host",
+    "        subject: alice",
+    "      - kind: email-address",
+    "        issuer: email:primary",
+    "        subject: alice@example.com",
+    "  - personId: person_viewer",
+    "    displayName: Victor Viewer",
+    "    roles: [observer]",
+    "    credentials:",
+    "      - kind: ssh-username",
+    "        issuer: host:team-host",
+    "        subject: viewer",
+    "  - personId: person_arbiter",
+    "    displayName: Ari Arbiter",
+    "    primaryEmail: ari@example.com",
+    "    roles: [arbiter]",
+    "    credentials:",
+    "      - kind: ssh-username",
+    "        issuer: host:team-host",
+    "        subject: ari",
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    "  - roleId: observer",
+    "    commandClasses: [repo-read]",
+    "  - roleId: arbiter",
+    "    commandClasses: [arbiter, repo-write, repo-read]",
+    ""
+  ].join("\n"));
+}
+
+function createHarnessRoot(): string {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-rbac-"));
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  writeFileSync(path.join(rootDir, "harness/harness.yaml"), "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n", "utf8");
+  return rootDir;
 }

--- a/packages/kernel/schemas/json/runtime-event-record.schema.json
+++ b/packages/kernel/schemas/json/runtime-event-record.schema.json
@@ -28,6 +28,27 @@
     "kind": {
       "enum": ["session", "turn", "step", "tool", "approval", "interrupt", "result", "cost"]
     },
+    "actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["personId", "displayName", "providerId", "credential"],
+      "properties": {
+        "personId": { "type": "string" },
+        "displayName": { "type": "string" },
+        "primaryEmail": { "type": "string" },
+        "providerId": { "type": "string" },
+        "credential": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "issuer", "subject"],
+          "properties": {
+            "kind": { "type": "string" },
+            "issuer": { "type": "string" },
+            "subject": { "type": "string" }
+          }
+        }
+      }
+    },
     "session": {
       "type": "object",
       "additionalProperties": false,

--- a/packages/kernel/src/domain/runtime-event.ts
+++ b/packages/kernel/src/domain/runtime-event.ts
@@ -10,11 +10,26 @@ export type RuntimeEventResultStatus = typeof runtimeEventResultStatuses[number]
 export type RuntimeEventApprovalDecision = typeof runtimeEventApprovalDecisions[number];
 export type RuntimeEventInterruptAction = typeof runtimeEventInterruptActions[number];
 
+export interface RuntimeEventActorCredential {
+  readonly kind: string;
+  readonly issuer: string;
+  readonly subject: string;
+}
+
+export interface RuntimeEventActor {
+  readonly personId: string;
+  readonly displayName: string;
+  readonly primaryEmail?: string;
+  readonly providerId: string;
+  readonly credential: RuntimeEventActorCredential;
+}
+
 export interface RuntimeEventRecord {
   readonly schema: "runtime-event/v1";
   readonly eventId: string;
   readonly recordedAt: string;
   readonly kind: RuntimeEventKind;
+  readonly actor?: RuntimeEventActor;
   readonly session: {
     readonly sessionId: string;
     readonly runtime: RuntimeEventRuntime | "unknown";

--- a/packages/kernel/src/schemas/runtime-event.ts
+++ b/packages/kernel/src/schemas/runtime-event.ts
@@ -10,11 +10,24 @@ import {
 const OptionalString = Schema.optional(Schema.String);
 const OptionalNumber = Schema.optional(Schema.Number);
 
+const RuntimeEventActorSchema = Schema.Struct({
+  personId: Schema.String,
+  displayName: Schema.String,
+  primaryEmail: OptionalString,
+  providerId: Schema.String,
+  credential: Schema.Struct({
+    kind: Schema.String,
+    issuer: Schema.String,
+    subject: Schema.String
+  })
+});
+
 export const RuntimeEventRecordSchema = Schema.Struct({
   schema: Schema.Literal("runtime-event/v1"),
   eventId: Schema.String.pipe(Schema.pattern(/^evt_[A-Za-z0-9._-]{8,96}$/u)),
   recordedAt: Schema.String,
   kind: Schema.Literal(...runtimeEventKinds),
+  actor: Schema.optional(RuntimeEventActorSchema),
   session: Schema.Struct({
     sessionId: Schema.String,
     runtime: Schema.Union(CurrentSessionRuntimeSchema, Schema.Literal("unknown")),

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -40,8 +40,8 @@ import {
   isProgressAppendDeltaPayload,
   writeOpTouchedPaths
 } from "./write-journal-operations.ts";
-import type { ApplyMarkerRecord, DeleteAuditRecord, JournalActor, JournalRecord, JournalRecordKind, JournaledWriteCoordinatorOptions, LockConflictRetryOptions, LockTakeoverRecord, WriteWatermark } from "./write-journal-types.ts";
-export type { JournalActor, JournaledWriteCoordinatorOptions, LockConflictRetryOptions } from "./write-journal-types.ts";
+import type { ApplyMarkerRecord, DeleteAuditRecord, GitCommitAuthor, JournalActor, JournalRecord, JournalRecordKind, JournaledWriteCoordinatorOptions, LockConflictRetryOptions, LockTakeoverRecord, WriteWatermark } from "./write-journal-types.ts";
+export type { GitCommitAuthor, JournalActor, JournaledWriteCoordinatorOptions, LockConflictRetryOptions } from "./write-journal-types.ts";
 
 const defaultActor: JournalActor = { kind: "agent", id: "local" };
 // Flush writes the full op-id set before compaction for recovery safety, then
@@ -62,6 +62,7 @@ export function makeJournaledWriteCoordinator(options: JournaledWriteCoordinator
   const lockTtlMs = options.lockTtlMs ?? 60_000;
   const lockConflictRetry = options.lockConflictRetry;
   const heldGlobalLock = options.heldGlobalLock;
+  const commitAuthor = options.commitAuthor;
   const sessionId = cleanSessionId(options.sessionId);
   const autoMaterialize = options.autoMaterialize ?? true;
   const pending: WriteOp[] = [];
@@ -70,7 +71,7 @@ export function makeJournaledWriteCoordinator(options: JournaledWriteCoordinator
       const state = readDurableState(journalPath, watermarkPath, rootDir);
       pending.splice(0, pending.length);
       const pendingRecords = state.records.filter((record) => !state.applied.has(record.opId));
-      return flushRecords(reason, rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId);
+      return flushRecords(reason, rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor);
     }, { heldGlobalLock }),
     catch: (cause): WriteError => toJournalError(cause)
   });
@@ -101,7 +102,7 @@ export function makeJournaledWriteCoordinator(options: JournaledWriteCoordinator
       try: (): RecoveryReport => withRepoLocks(rootDir, runtimeContext, journalPath, actor, lockTtlMs, [], () => {
         const state = readDurableState(journalPath, watermarkPath, rootDir);
         const pendingRecords = state.records.filter((record) => !state.applied.has(record.opId));
-        const report = flushRecords("recovery", rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId);
+        const report = flushRecords("recovery", rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor);
         return {
           replayedOps: report.opCount,
           recoveredWatermark: report.watermark
@@ -173,7 +174,8 @@ function flushRecords(
   previousWatermark: WriteWatermark | null,
   records: ReadonlyArray<JournalRecord>,
   fileApplied: ReadonlySet<string>,
-  sessionId?: string
+  sessionId?: string,
+  commitAuthor?: GitCommitAuthor
 ): FlushReport {
   const touchedPaths: string[] = [];
   const committedOpIds: string[] = [];
@@ -201,7 +203,7 @@ function flushRecords(
     rootInput,
     semanticCommitMessage(rootDir, plannedRecords.map((entry) => entry.record)),
     sessionId,
-    { respectGitignorePaths: plannedRecords.filter((entry) => entry.record.kind === "task_tree_stage").flatMap((entry) => entry.touchedPaths) }
+    { respectGitignorePaths: plannedRecords.filter((entry) => entry.record.kind === "task_tree_stage").flatMap((entry) => entry.touchedPaths), author: commitAuthor }
   );
   const projectionHash = committedOpIds.length > 0 ? rebuildProjectionHash(rootDir, rootInput) : previousWatermark?.projectionHash ?? "no-projection-change";
   const allCommitted = [...(previousWatermark?.lastCommittedOpIds ?? []), ...committedOpIds];

--- a/packages/kernel/src/store/write-journal-git.ts
+++ b/packages/kernel/src/store/write-journal-git.ts
@@ -3,6 +3,7 @@ import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
+import type { GitCommitAuthor } from "./write-journal-types.ts";
 
 const gitMaxBuffer = 256 * 1024 * 1024;
 
@@ -13,7 +14,7 @@ export function commitTouchedPaths(
   layoutInput: HarnessLayoutInput = rootDir,
   message?: string,
   sessionId?: string,
-  options: { readonly respectGitignorePaths?: ReadonlyArray<string> } = {}
+  options: { readonly respectGitignorePaths?: ReadonlyArray<string>; readonly author?: GitCommitAuthor } = {}
 ): string {
   if (touchedPaths.length === 0) return "no-git-change";
 
@@ -32,7 +33,7 @@ export function commitTouchedPaths(
     const staged = runGit(plan.repoRoot, "diff", "--cached", "--name-only", "--", ...plan.relativePaths).trim();
     if (staged.length === 0) return currentGitHead(plan.repoRoot);
 
-    runGit(plan.repoRoot, "commit", "-m", message ?? `harness write ${opIds.join(",")}`);
+    runGitAs(plan.repoRoot, options.author, "commit", "-m", message ?? `harness write ${opIds.join(",")}`);
     return currentGitHead(plan.repoRoot);
   } finally {
     if (sessionBranch) runGit(plan.repoRoot, "checkout", "master");
@@ -145,6 +146,10 @@ function normalizeExistingPath(inputPath: string): string {
 }
 
 function runGit(repoRoot: string, ...args: ReadonlyArray<string>): string {
+  return runGitAs(repoRoot, undefined, ...args);
+}
+
+function runGitAs(repoRoot: string, author: GitCommitAuthor | undefined, ...args: ReadonlyArray<string>): string {
   try {
     return execFileSync("git", ["-C", repoRoot, ...args], {
       encoding: "utf8",
@@ -152,8 +157,8 @@ function runGit(repoRoot: string, ...args: ReadonlyArray<string>): string {
       stdio: ["ignore", "pipe", "pipe"],
       env: {
         ...process.env,
-        GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Harness Anything",
-        GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? "harness@example.invalid",
+        GIT_AUTHOR_NAME: author?.name ?? process.env.GIT_AUTHOR_NAME ?? "Harness Anything",
+        GIT_AUTHOR_EMAIL: author?.email ?? process.env.GIT_AUTHOR_EMAIL ?? "harness@example.invalid",
         GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Harness Anything",
         GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "harness@example.invalid"
       }

--- a/packages/kernel/src/store/write-journal-types.ts
+++ b/packages/kernel/src/store/write-journal-types.ts
@@ -13,6 +13,7 @@ export interface JournaledWriteCoordinatorOptions {
   readonly heldGlobalLock?: OwnedLock;
   readonly sessionId?: string;
   readonly autoMaterialize?: boolean;
+  readonly commitAuthor?: GitCommitAuthor;
 }
 
 export interface LockConflictRetryOptions {
@@ -24,6 +25,11 @@ export interface LockConflictRetryOptions {
 export interface JournalActor {
   readonly kind: "agent" | "human" | "system";
   readonly id: string;
+}
+
+export interface GitCommitAuthor {
+  readonly name: string;
+  readonly email: string;
 }
 
 export interface PayloadRef {

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -22,6 +22,35 @@ test("WriteCoordinator flushes same-task writes in FIFO order", () => {
   });
 });
 
+test("WriteCoordinator journals actor person and uses explicit git authors", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    const alice = makeJournaledWriteCoordinator({
+      rootDir,
+      actor: { kind: "human", id: "person_alice" },
+      commitAuthor: { name: "Alice Admin", email: "alice@example.com" }
+    });
+    const bob = makeJournaledWriteCoordinator({
+      rootDir,
+      actor: { kind: "human", id: "person_bob" },
+      commitAuthor: { name: "Bob Builder", email: "team-fallback@example.invalid" }
+    });
+
+    Effect.runSync(alice.enqueue(docWrite("op-alice", "task-1", "alice.md", "alice")));
+    const journalBody = readFileSync(path.join(rootDir, ".harness/write-journal/writes.jsonl"), "utf8");
+    assert.match(journalBody, /"actor":\{"kind":"human","id":"person_alice"\}/u);
+    Effect.runSync(alice.flush("explicit"));
+
+    Effect.runSync(bob.enqueue(docWrite("op-bob", "task-1", "bob.md", "bob")));
+    Effect.runSync(bob.flush("explicit"));
+
+    assert.deepEqual(
+      runGit(rootDir, "log", "-2", "--format=%an <%ae>").split(/\r?\n/u),
+      ["Bob Builder <team-fallback@example.invalid>", "Alice Admin <alice@example.com>"]
+    );
+  });
+});
+
 test("WriteCoordinator preserves same-task FIFO across two coordinators", () => {
   withTempStore((rootDir) => {
     const firstCoordinator = makeJournaledWriteCoordinator({ rootDir });


### PR DESCRIPTION
# English

## Summary

Add the W4 identity and RBAC slice for the daemon: a pluggable identity provider contract, `people.yaml` roster loading, transport-derived actor resolution, role-to-command-class authorization, and actor stamping across daemon receipts, runtime events, journal metadata, and git author attribution.

## What Changed

- Added daemon identity modules for stable person ids, credential tuple matching, roster parsing/validation, transport-derived provider `transport-derived/v1`, and RBAC checks.
- Added `commandClass` metadata to the daemon method registry, with `admin`, `repo-write`, `repo-read`, and `arbiter` classes.
- Activated the minimal admin methods `admin.people.list` and `admin.rbac.roles.list`.
- Added optional `actor` to `runtime-event/v1` without a version bump; legacy rows without actor still decode.
- Reused the existing write-journal actor field and added explicit git author injection using primary email or deterministic fallback email.
- Stamped daemon command receipts through `details.actor` and recorded RBAC/authn denial events through the runtime event ledger appender.
- Added executable tests for the mock email provider extension path, unknown credentials, RBAC denial events, runtime-event compatibility, journal actor stamping, and git author attribution.

Arbiter command-class list for CEO confirmation:

- `repo.tasks.status.set`
- `repo.tasks.review`

Future decision accept/reject/defer/supersede/retire daemon methods should be classified as `arbiter` when those methods are introduced.

## Task And Scope

- Harness task: `task_01KWW57HKT7ZMB3REKQ8PM3SYJ`
- Branch: `codex/w4-identity-rbac`
- Public scope: `packages/application`, `packages/daemon`, and approved `packages/kernel` runtime-event/write-journal stamping surfaces.
- Private planning/evidence updated: yes, private harness commit `caec204` records the W4 report and migration-path artifact.
- Out of scope: `packages/cli/**`, `packages/adapters/local`, `packages/kernel/src/projection/**`, `tools/check-*`, W5 thin client work, W6 projection incrementality work, password/session/token storage, and Windows peer SID hardening.

## Version Impact

- Version: no version change because this is an unreleased daemon capability slice.
- Publish impact: no publish; publish readiness only.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: daemon method registry command classification, `runtime-event/v1` optional actor schema, write-journal actor/git author stamping path.
- Authority: task `task_01KWW57HKT7ZMB3REKQ8PM3SYJ`; decision `dec_mr9ac5ca`; CEO checkpoint approvals for optional runtime-event actor and method-registry `commandClass`.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: Windows named-pipe peer SID hardening remains with W7 three-platform validation.

## Verification

- Base `origin/main` SHA: `654144892a3dad852d0858a387818f6ae74e1641`
- Branch merge-base with `origin/main`: `654144892a3dad852d0858a387818f6ae74e1641`
- Last `git fetch origin` time: `2026-07-07T00:16:16Z`
- Sync method: rebase, already up to date with `origin/main`
- Public diff command: `git diff origin/main...HEAD --stat`
- Private evidence commit/path: private harness commit `caec204`; W4 report artifact and migration-path artifact
- Reviewer evidence path: private W4 report artifact
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28832369729
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` was not run locally; lockfile and dependency manifests were unchanged.

## Review Evidence

- Self-review: checked public diff scope, W5/W6 red lines, schema compatibility, command-class coverage, actor stamping tests, and `npm run check` output.
- Reviewer subagent: not run.
- Human review: CEO approved the IdentityProvider interface gate and both implementation checkpoints in the task progress ledger.
- Blocking findings: none known locally.

## Residual Risk

- Named pipe v1 remains endpoint-level and does not carry Windows peer SID. CEO approved this limit for W4; W7 owns three-platform peer identity hardening.
- The daemon protocol now accepts a promise-based runtime event appender. W5/W7 composition must wire the appender from the application runtime event ledger when enabling team-server daemon flows.
- The arbiter list reflects today’s daemon command surface; future decision lifecycle daemon methods must be explicitly classified as `arbiter`.

## References

- Task: `task_01KWW57HKT7ZMB3REKQ8PM3SYJ`
- Decision: `dec_mr9ac5ca`
- Evidence: private facts `F-7CC58FF1`, `F-S9VTXGB0`, `F-FF9TW7BQ`; private harness commit `caec204`
- Review: CEO approvals recorded in task progress ledger

---

# 中文

## 概要

实现 W4 daemon 身份与 RBAC 切片：可插拔 IdentityProvider 契约、`people.yaml` 花名册加载、由传输认证上下文解析 actor、角色到命令类的白名单授权，以及 daemon receipt、runtime event、journal 元数据、git author 四类盖章。

## 改动内容

- 新增 daemon identity 模块，覆盖稳定 person id、credential 三元组匹配、花名册解析与校验、`transport-derived/v1` provider、RBAC 检查。
- daemon method registry 新增 `commandClass` 元数据，v1 命令类为 `admin`、`repo-write`、`repo-read`、`arbiter`。
- 挂载最小 admin 命令面：`admin.people.list` 与 `admin.rbac.roles.list`。
- `runtime-event/v1` 增加 optional `actor`，不升 v2；旧行无 actor 仍可解码。
- 复用既有 write journal actor 字段，并支持显式 git author，优先 primary email，缺失时用确定性 fallback email。
- daemon command receipt 通过 `details.actor` 盖章，认证 / RBAC 拒绝事件通过 runtime event ledger appender 记录。
- 增加 mock email provider 可执行接口测试、未知 credential 拒绝、RBAC 拒绝事件、runtime-event 兼容性、journal actor 盖章、git author 归属测试。

供 CEO 确认的 arbiter 命令类清单：

- `repo.tasks.status.set`
- `repo.tasks.review`

未来新增 decision accept/reject/defer/supersede/retire daemon 方法时，应显式归类为 `arbiter`。

## 任务与范围

- Harness 任务：`task_01KWW57HKT7ZMB3REKQ8PM3SYJ`
- 分支：`codex/w4-identity-rbac`
- 公开范围：`packages/application`、`packages/daemon`，以及已批准的 `packages/kernel` runtime-event / write-journal 盖章面。
- 私有计划 / 证据是否已更新：yes，私有 harness commit `caec204` 记录 W4 report 与迁移路径 artifact。
- 范围外：`packages/cli/**`、`packages/adapters/local`、`packages/kernel/src/projection/**`、`tools/check-*`、W5 薄客户端、W6 投影增量化、密码 / session / token 存储、Windows peer SID 加固。

## 版本影响

- 版本：不改版本，原因是本 PR 是尚未发布的 daemon 能力切片。
- 发布影响：不发布 / 只做发布准备。

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：daemon method registry 命令分类、`runtime-event/v1` optional actor schema、write-journal actor / git author 盖章路径。
- 依据：task `task_01KWW57HKT7ZMB3REKQ8PM3SYJ`；decision `dec_mr9ac5ca`；CEO 对 optional runtime-event actor 与 method-registry `commandClass` checkpoint 的批准。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：Windows named-pipe peer SID 加固归 W7 三平台验收。

## 验证

- `origin/main` 基准 SHA：`654144892a3dad852d0858a387818f6ae74e1641`
- 当前分支与 `origin/main` 的 merge-base：`654144892a3dad852d0858a387818f6ae74e1641`
- 最近一次 `git fetch origin` 时间：`2026-07-07T00:16:16Z`
- 同步方式：rebase，且已与 `origin/main` 对齐
- 公开 diff 命令：`git diff origin/main...HEAD --stat`
- 私有证据 commit/path：私有 harness commit `caec204`；W4 report artifact 与迁移路径 artifact
- Reviewer 证据路径：私有 W4 report artifact
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28832369729
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：本地未运行 `npm ci`；lockfile 与依赖 manifest 未变化。

## 审查证据

- 自查：已检查 public diff 范围、W5/W6 红线、schema 兼容、命令类覆盖、actor 盖章测试、`npm run check` 输出。
- Reviewer subagent：未运行。
- 人工审查：CEO 已在 task progress 台账批准 IdentityProvider 接口门与两个实现 checkpoint。
- 阻塞发现：本地未发现。

## 残余风险

- named pipe v1 保持 endpoint 级身份，不携带 Windows peer SID。CEO 已批准 W4 保持该限制；W7 负责三平台 peer 身份加固。
- daemon protocol 现在接收 promise 形式的 runtime event appender。W5/W7 组合层启用团队服务器 daemon flow 时，需要从 application runtime event ledger 接入 appender。
- arbiter 清单反映当前 daemon 命令面；未来 decision 生命周期 daemon 方法必须显式归类为 `arbiter`。

## 关联材料

- 任务：`task_01KWW57HKT7ZMB3REKQ8PM3SYJ`
- 决策：`dec_mr9ac5ca`
- 证据：私有 facts `F-7CC58FF1`、`F-S9VTXGB0`、`F-FF9TW7BQ`；私有 harness commit `caec204`
- 审查：CEO 批准已记录在 task progress 台账

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
