### PR TITLE
W6: incrementally update SQLite projection flushes

### DIFF
--- a/packages/kernel/src/projection/sqlite-decision-source.ts
+++ b/packages/kernel/src/projection/sqlite-decision-source.ts
@@ -14,6 +14,17 @@ export function readDecisionProjectionRows(rootInput: HarnessLayoutInput): Reado
     .sort(compareDecisionRows);
 }
 
+export function readDecisionProjectionRowsForPaths(
+  rootInput: HarnessLayoutInput,
+  documentPaths: ReadonlyArray<string>
+): ReadonlyArray<DecisionProjectionRow> {
+  const layout = resolveHarnessLayout(rootInput);
+  return uniqueDecisionDocumentPaths(documentPaths.map((documentPath) => path.resolve(documentPath)))
+    .filter((documentPath) => existsSync(documentPath) && path.basename(documentPath) === "decision.md")
+    .map((documentPath) => decisionDocumentToProjectionRow(layout.rootDir, documentPath))
+    .sort(compareDecisionRows);
+}
+
 export function hashDecisionProjectionRows(rows: ReadonlyArray<DecisionProjectionRow>): string {
   return `sha256:${sha256Text(JSON.stringify([...rows].sort(compareDecisionRows).map(canonicalDecisionProjectionRow)))}`;
 }
@@ -224,6 +235,10 @@ function legacyNumber(value: string): number | undefined {
   if (!match) return undefined;
   const parsed = Number(match[1]);
   return Number.isInteger(parsed) ? parsed : undefined;
+}
+
+function uniqueDecisionDocumentPaths(values: ReadonlyArray<string>): ReadonlyArray<string> {
+  return [...new Set(values)];
 }
 
 function canonicalDecisionProjectionRow(row: DecisionProjectionRow): DecisionProjectionRow {

--- a/packages/kernel/src/projection/sqlite-projection-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-store.ts
@@ -263,7 +263,7 @@ function readProjectionDatabase(
   }));
 }
 
-function runSqlite<A>(filename: string, effect: Effect.Effect<A, unknown, SqlClient.SqlClient>): A {
+export function runSqlite<A>(filename: string, effect: Effect.Effect<A, unknown, SqlClient.SqlClient>): A {
   return Effect.runSync(Effect.provide(effect, SqliteClient.layer({ filename })));
 }
 
@@ -275,7 +275,7 @@ function addTaskProjectionColumn(sql: SqlClient.SqlClient, column: string): Effe
   return sql.unsafe(`ALTER TABLE task_projection ADD COLUMN ${quoteIdentifier(column)} TEXT`);
 }
 
-function insertTaskRow(
+export function insertTaskRow(
   sql: SqlClient.SqlClient,
   row: TaskProjectionRow,
   taskFieldExtensions: ReadonlyArray<TaskFieldExtensionProjection>
@@ -314,7 +314,7 @@ function insertTaskRow(
   );
 }
 
-function insertDecisionRow(sql: SqlClient.SqlClient, row: DecisionProjectionRow): Effect.Effect<unknown, unknown> {
+export function insertDecisionRow(sql: SqlClient.SqlClient, row: DecisionProjectionRow): Effect.Effect<unknown, unknown> {
   return sql`
     INSERT OR REPLACE INTO decision_projection (
       decision_id, legacy_id, legacy_number, state, title, question, chosen_json,
@@ -327,21 +327,21 @@ function insertDecisionRow(sql: SqlClient.SqlClient, row: DecisionProjectionRow)
   `;
 }
 
-function insertRelationEdge(sql: SqlClient.SqlClient, edge: RelationGraphEdgeRow): Effect.Effect<unknown, unknown> {
+export function insertRelationEdge(sql: SqlClient.SqlClient, edge: RelationGraphEdgeRow): Effect.Effect<unknown, unknown> {
   return sql`
     INSERT OR REPLACE INTO relation_edges (relation_id, source_ref, target_ref, relation_type, direction, state, row_json)
     VALUES (${edge.relationId}, ${edge.sourceRef}, ${edge.targetRef}, ${edge.relationType}, ${edge.direction}, ${edge.state}, ${JSON.stringify(edge)})
   `;
 }
 
-function insertCoverageRow(sql: SqlClient.SqlClient, row: RelationCoverageRow): Effect.Effect<unknown, unknown> {
+export function insertCoverageRow(sql: SqlClient.SqlClient, row: RelationCoverageRow): Effect.Effect<unknown, unknown> {
   return sql`
     INSERT OR REPLACE INTO relation_coverage (claim_ref, decision_ref, status, covering_fact_ref, row_json)
     VALUES (${row.claimRef}, ${row.decisionRef}, ${row.status}, ${row.coveringFactRef ?? null}, ${JSON.stringify(row)})
   `;
 }
 
-function insertFactAnchor(sql: SqlClient.SqlClient, row: FactAnchorRow): Effect.Effect<unknown, unknown> {
+export function insertFactAnchor(sql: SqlClient.SqlClient, row: FactAnchorRow): Effect.Effect<unknown, unknown> {
   return sql`
     INSERT OR REPLACE INTO task_fact_anchors (fact_ref, task_id, fact_id, source_path, row_json)
     VALUES (${row.factRef}, ${row.taskId}, ${row.factId}, ${row.sourcePath}, ${JSON.stringify(row)})
@@ -533,7 +533,7 @@ function legacyNumberFromLabel(value: string): number | undefined {
   return Number.isInteger(parsed) ? parsed : undefined;
 }
 
-function queryableTaskFieldExtensions(
+export function queryableTaskFieldExtensions(
   extensions: ReadonlyArray<TaskFieldExtensionProjection>
 ): ReadonlyArray<TaskFieldExtensionProjection> {
   const seen = new Set<string>(baseTaskProjectionColumns);

--- a/packages/kernel/src/projection/sqlite-projection-update-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-update-store.ts
@@ -1,0 +1,67 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+import type { ProjectionMeta, TaskFieldExtensionProjection, TaskProjectionRow, DecisionProjectionRow } from "./types.ts";
+import type { ProjectionGraphRows } from "./sqlite-projection-store.ts";
+import {
+  insertCoverageRow,
+  insertDecisionRow,
+  insertFactAnchor,
+  insertRelationEdge,
+  insertTaskRow,
+  queryableTaskFieldExtensions,
+  runSqlite
+} from "./sqlite-projection-store.ts";
+
+export function updateProjectionDatabase(
+  projectionPath: string,
+  change: {
+    readonly deleteTaskIds: ReadonlyArray<string>;
+    readonly upsertTaskRows: ReadonlyArray<TaskProjectionRow>;
+    readonly deleteDecisionIds: ReadonlyArray<string>;
+    readonly upsertDecisionRows: ReadonlyArray<DecisionProjectionRow>;
+    readonly meta: ProjectionMeta;
+    readonly graphRows: ProjectionGraphRows;
+    readonly taskFieldExtensions?: ReadonlyArray<TaskFieldExtensionProjection>;
+  }
+): void {
+  runSqlite(projectionPath, Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const projectedTaskFieldExtensions = queryableTaskFieldExtensions(change.taskFieldExtensions ?? []);
+    yield* sql`BEGIN IMMEDIATE`;
+    try {
+      for (const taskId of uniqueProjectionIds(change.deleteTaskIds)) {
+        yield* sql`DELETE FROM task_projection WHERE task_id = ${taskId}`;
+      }
+      for (const row of change.upsertTaskRows) {
+        yield* insertTaskRow(sql, row, projectedTaskFieldExtensions);
+      }
+      for (const decisionId of uniqueProjectionIds(change.deleteDecisionIds)) {
+        yield* sql`DELETE FROM decision_projection WHERE decision_id = ${decisionId}`;
+      }
+      for (const row of change.upsertDecisionRows) {
+        yield* insertDecisionRow(sql, row);
+      }
+      yield* sql`DELETE FROM relation_edges`;
+      yield* sql`DELETE FROM relation_coverage`;
+      yield* sql`DELETE FROM task_fact_anchors`;
+      for (const edge of change.graphRows.relationEdges) yield* insertRelationEdge(sql, edge);
+      for (const row of change.graphRows.coverageRows) yield* insertCoverageRow(sql, row);
+      for (const row of change.graphRows.factAnchors) yield* insertFactAnchor(sql, row);
+      yield* upsertMeta(sql, "sourceHash", change.meta.sourceHash);
+      yield* upsertMeta(sql, "rowsHash", change.meta.rowsHash);
+      yield* upsertMeta(sql, "decisionRowsHash", change.meta.decisionRowsHash ?? "");
+      yield* sql`COMMIT`;
+    } catch (error) {
+      yield* sql`ROLLBACK`;
+      throw error;
+    }
+  }));
+}
+
+function upsertMeta(sql: SqlClient.SqlClient, key: string, value: string): Effect.Effect<unknown, unknown> {
+  return sql`INSERT OR REPLACE INTO projection_meta (key, value) VALUES (${key}, ${value})`;
+}
+
+function uniqueProjectionIds(values: ReadonlyArray<string>): ReadonlyArray<string> {
+  return [...new Set(values)];
+}

--- a/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
@@ -1,0 +1,250 @@
+import { existsSync, realpathSync } from "node:fs";
+import path from "node:path";
+import { createHarnessRuntimeContext, resolveHarnessLayout } from "../layout/index.ts";
+import { readScalar } from "../markdown/frontmatter.ts";
+import type { RelationGraphEdgeRow } from "./relation-graph-projection.ts";
+import { buildRelationGraphProjection } from "./relation-graph-projection.ts";
+import { compareDecisionRows, hashDecisionProjectionRows, readDecisionProjectionRowsForPaths } from "./sqlite-decision-source.ts";
+import { readRelationGraphRows, tryReadProjectionDatabase } from "./sqlite-projection-store.ts";
+import { updateProjectionDatabase } from "./sqlite-projection-update-store.ts";
+import { compareRows, hashExactRows, readMarkdownSource, sourcePath, taskEntryToRow } from "./sqlite-task-source.ts";
+import { rebuildTaskProjection } from "./sqlite-task-projection.ts";
+import type { DecisionProjectionRow, ProjectionReadResult, TaskProjectionOptions, TaskProjectionRow } from "./types.ts";
+
+export function updateTaskProjectionIncrementally(options: TaskProjectionOptions & {
+  readonly touchedPaths: ReadonlyArray<string>;
+  readonly previousSourceHash?: string;
+}): ProjectionReadResult & { readonly mode: "incremental" | "rebuild" | "unchanged" } {
+  const rootDir = path.resolve(options.rootDir);
+  const runtimeContext = createHarnessRuntimeContext(rootDir, options.layoutOverrides);
+  const projectionPath = options.projectionPath ? path.resolve(options.projectionPath) : resolveHarnessLayout(runtimeContext).projectionPath;
+  const source = readMarkdownSource(runtimeContext);
+
+  if (!existsSync(projectionPath)) {
+    return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+  }
+
+  const existing = tryReadProjectionDatabase(projectionPath, options.taskFieldExtensions);
+  if (!existing.ok || !projectionRowsMatchMeta(existing)) {
+    return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+  }
+
+  const oldGraph = safeReadRelationGraphRows(projectionPath);
+  const newGraph = buildRelationGraphProjection(runtimeContext);
+  const affected = affectedProjectionEntities({
+    rootDir,
+    rootInput: runtimeContext,
+    touchedPaths: options.touchedPaths,
+    sourceEntries: source.entries,
+    existingRows: existing.rows,
+    existingDecisionRows: existing.decisionRows,
+    oldEdges: oldGraph.relationEdges,
+    newEdges: newGraph.edges
+  });
+
+  if (existing.meta.sourceHash === source.hash && !hasAffectedProjectionEntities(affected)) {
+    return {
+      rows: [...existing.rows].sort(compareRows),
+      warnings: source.warnings,
+      mode: "unchanged"
+    };
+  }
+
+  if (existing.meta.sourceHash !== source.hash && options.previousSourceHash && existing.meta.sourceHash !== options.previousSourceHash) {
+    return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+  }
+
+  const taskChange = incrementalTaskRows(runtimeContext, source.entries, existing.rows, affected.taskIds, options.taskFieldExtensions);
+  const decisionChange = incrementalDecisionRows(runtimeContext, existing.decisionRows, affected.decisionIds, affected.decisionPaths);
+  const rowsHash = hashExactRows(taskChange.rows);
+  const decisionRowsHash = hashDecisionProjectionRows(decisionChange.rows);
+
+  updateProjectionDatabase(projectionPath, {
+    deleteTaskIds: [...taskChange.deleteIds],
+    upsertTaskRows: taskChange.currentRows,
+    deleteDecisionIds: [...decisionChange.deleteIds],
+    upsertDecisionRows: decisionChange.currentRows,
+    meta: {
+      sourceHash: source.hash,
+      rowsHash,
+      decisionRowsHash
+    },
+    graphRows: {
+      relationEdges: newGraph.edges,
+      coverageRows: newGraph.coverageRows,
+      factAnchors: newGraph.factAnchors
+    },
+    taskFieldExtensions: options.taskFieldExtensions
+  });
+
+  return {
+    rows: taskChange.rows,
+    warnings: source.warnings,
+    mode: "incremental"
+  };
+}
+
+function hasAffectedProjectionEntities(affected: {
+  readonly taskIds: ReadonlySet<string>;
+  readonly decisionIds: ReadonlySet<string>;
+  readonly decisionPaths: ReadonlySet<string>;
+}): boolean {
+  return affected.taskIds.size > 0 || affected.decisionIds.size > 0 || affected.decisionPaths.size > 0;
+}
+
+function projectionRowsMatchMeta(existing: {
+  readonly rows: ReadonlyArray<TaskProjectionRow>;
+  readonly decisionRows: ReadonlyArray<DecisionProjectionRow>;
+  readonly meta: { readonly rowsHash: string; readonly decisionRowsHash?: string };
+}): boolean {
+  return existing.meta.rowsHash === hashExactRows(existing.rows) &&
+    (existing.meta.decisionRowsHash ?? "") === hashDecisionProjectionRows(existing.decisionRows);
+}
+
+function safeReadRelationGraphRows(projectionPath: string): {
+  readonly relationEdges: ReadonlyArray<RelationGraphEdgeRow>;
+} {
+  try {
+    return readRelationGraphRows(projectionPath);
+  } catch {
+    return { relationEdges: [] };
+  }
+}
+
+function incrementalTaskRows(
+  rootInput: Parameters<typeof taskEntryToRow>[0],
+  entries: ReturnType<typeof readMarkdownSource>["entries"],
+  existingRows: ReadonlyArray<TaskProjectionRow>,
+  affectedTaskIds: ReadonlySet<string>,
+  taskFieldExtensions: TaskProjectionOptions["taskFieldExtensions"]
+): {
+  readonly rows: ReadonlyArray<TaskProjectionRow>;
+  readonly currentRows: ReadonlyArray<TaskProjectionRow>;
+  readonly deleteIds: ReadonlySet<string>;
+} {
+  const currentRows = entries
+    .filter((entry) => affectedTaskIds.has(entry.taskId) || affectedTaskIds.has(readScalar(entry.frontmatter, "task_id") || entry.taskId))
+    .map((entry) => taskEntryToRow(rootInput, entry, taskFieldExtensions));
+  const deleteIds = new Set([...affectedTaskIds, ...currentRows.map((row) => row.taskId)]);
+  return {
+    rows: [
+      ...existingRows.filter((row) => !deleteIds.has(row.taskId)),
+      ...currentRows
+    ].sort(compareRows),
+    currentRows,
+    deleteIds
+  };
+}
+
+function incrementalDecisionRows(
+  rootInput: Parameters<typeof readDecisionProjectionRowsForPaths>[0],
+  existingRows: ReadonlyArray<DecisionProjectionRow>,
+  affectedDecisionIds: ReadonlySet<string>,
+  affectedDecisionPaths: ReadonlySet<string>
+): {
+  readonly rows: ReadonlyArray<DecisionProjectionRow>;
+  readonly currentRows: ReadonlyArray<DecisionProjectionRow>;
+  readonly deleteIds: ReadonlySet<string>;
+} {
+  const currentRows = readDecisionProjectionRowsForPaths(rootInput, [...affectedDecisionPaths]);
+  const deleteIds = new Set([...affectedDecisionIds, ...currentRows.map((row) => row.decisionId)]);
+  return {
+    rows: [
+      ...existingRows.filter((row) => !deleteIds.has(row.decisionId)),
+      ...currentRows
+    ].sort(compareDecisionRows),
+    currentRows,
+    deleteIds
+  };
+}
+
+function affectedProjectionEntities(input: {
+  readonly rootDir: string;
+  readonly rootInput: Parameters<typeof resolveHarnessLayout>[0];
+  readonly touchedPaths: ReadonlyArray<string>;
+  readonly sourceEntries: ReturnType<typeof readMarkdownSource>["entries"];
+  readonly existingRows: ReadonlyArray<TaskProjectionRow>;
+  readonly existingDecisionRows: ReadonlyArray<DecisionProjectionRow>;
+  readonly oldEdges: ReadonlyArray<RelationGraphEdgeRow>;
+  readonly newEdges: ReadonlyArray<RelationGraphEdgeRow>;
+}): {
+  readonly taskIds: ReadonlySet<string>;
+  readonly decisionIds: ReadonlySet<string>;
+  readonly decisionPaths: ReadonlySet<string>;
+} {
+  const layout = resolveHarnessLayout(input.rootInput);
+  const rootDir = realPathIfExists(input.rootDir);
+  const tasksRoot = realPathIfExists(layout.tasksRoot);
+  const decisionsRoot = realPathIfExists(layout.decisionsRoot);
+  const taskIds = new Set<string>();
+  const decisionIds = new Set<string>();
+  const decisionPaths = new Set<string>();
+  const touchedRelativePaths = new Set(input.touchedPaths.map((filePath) => sourcePath(rootDir, realPathIfExists(filePath))));
+
+  for (const filePath of input.touchedPaths) {
+    const resolved = realPathIfExists(filePath);
+    const taskSlug = taskSlugForPath(tasksRoot, resolved);
+    if (taskSlug) taskIds.add(taskSlug);
+    if (path.basename(resolved) === "decision.md" && isPathWithin(decisionsRoot, resolved)) {
+      decisionPaths.add(path.join(input.rootDir, sourcePath(rootDir, resolved)));
+    }
+  }
+
+  for (const entry of input.sourceEntries) {
+    const entrySourcePath = sourcePath(rootDir, realPathIfExists(entry.indexPath));
+    if ([...touchedRelativePaths].some((relativePath) => relativePath === entrySourcePath || relativePath.startsWith(`${path.posix.dirname(entrySourcePath)}/`))) {
+      taskIds.add(entry.taskId);
+    }
+  }
+
+  for (const row of input.existingRows) {
+    if ([...touchedRelativePaths].some((relativePath) => relativePath === row.sourcePath || relativePath.startsWith(`${path.posix.dirname(row.sourcePath)}/`))) {
+      taskIds.add(row.taskId);
+    }
+  }
+
+  for (const row of input.existingDecisionRows) {
+    if (touchedRelativePaths.has(row.path)) {
+      decisionIds.add(row.decisionId);
+      decisionPaths.add(path.join(input.rootDir, row.path));
+    }
+  }
+
+  for (const edge of [...input.oldEdges, ...input.newEdges]) {
+    if (!touchedRelativePaths.has(edge.sourcePath)) continue;
+    addEntityRef(edge.sourceRef, taskIds, decisionIds);
+    addEntityRef(edge.targetRef, taskIds, decisionIds);
+  }
+
+  return { taskIds, decisionIds, decisionPaths };
+}
+
+function taskSlugForPath(tasksRoot: string, filePath: string): string | undefined {
+  if (!isPathWithin(tasksRoot, filePath)) return undefined;
+  const relative = path.relative(tasksRoot, filePath);
+  const [slug] = relative.split(path.sep);
+  return slug && slug.length > 0 ? slug : undefined;
+}
+
+function isPathWithin(parent: string, child: string): boolean {
+  const relative = path.relative(realPathIfExists(parent), realPathIfExists(child));
+  return relative.length === 0 || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function realPathIfExists(filePath: string): string {
+  try {
+    return realpathSync.native(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
+function addEntityRef(ref: string, taskIds: Set<string>, decisionIds: Set<string>): void {
+  const [kind, id] = ref.split("/");
+  if (kind === "task" && id) taskIds.add(id);
+  if (kind === "decision" && id) decisionIds.add(id);
+  if (kind === "fact") {
+    const ownerTaskId = ref.split("/")[1];
+    if (ownerTaskId) taskIds.add(ownerTaskId);
+  }
+}

--- a/packages/kernel/src/store/ledger-materializer.ts
+++ b/packages/kernel/src/store/ledger-materializer.ts
@@ -1,7 +1,9 @@
+import path from "node:path";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
-import { rebuildTaskProjection } from "../projection/sqlite-task-projection.ts";
-import { abortMerge, checkoutMaster, commitsNotInMaster, deleteBranch, ledgerGitTopLevel, mergeNoFf, refExists, sessionBranches } from "./write-journal-git.ts";
+import { updateTaskProjectionIncrementally } from "../projection/sqlite-task-incremental-projection.ts";
+import { readMarkdownSource } from "../projection/sqlite-task-source.ts";
+import { abortMerge, changedFilesBetween, checkoutMaster, commitsNotInMaster, currentGitHead, deleteBranch, ledgerGitTopLevel, mergeNoFf, refExists, sessionBranches } from "./write-journal-git.ts";
 import { withRepoLocks } from "./write-journal-locks.ts";
 import type { OwnedLock } from "./write-journal-types.ts";
 
@@ -52,6 +54,8 @@ function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dr
   const warnings: string[] = [];
   let merged = 0;
   let processed = 0;
+  const projectionSourceHashBeforeMerge = readMarkdownSource(rootInput).hash;
+  const touchedPaths = new Set<string>();
 
   if (!refExists(repoRoot, "master")) {
     return {
@@ -80,7 +84,12 @@ function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dr
 
     checkoutMaster(repoRoot);
     try {
+      const beforeMergeHead = currentGitHead(repoRoot);
       mergeNoFf(repoRoot, branch, `materializer: merge session ${branch.slice("sessions/".length)}`);
+      const afterMergeHead = currentGitHead(repoRoot);
+      for (const relativePath of changedFilesBetween(repoRoot, beforeMergeHead, afterMergeHead)) {
+        touchedPaths.add(path.join(repoRoot, relativePath));
+      }
       deleteBranch(repoRoot, branch);
       merged += 1;
       reports.push({ branch, commitCount: commits.length, status: "merged", commits });
@@ -100,9 +109,11 @@ function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dr
 
   if (merged > 0) {
     const layout = resolveHarnessLayout(rootInput);
-    rebuildTaskProjection({
+    updateTaskProjectionIncrementally({
       rootDir: layout.rootDir,
-      ...(typeof rootInput === "object" && rootInput.layoutOverrides ? { layoutOverrides: rootInput.layoutOverrides } : {})
+      ...(typeof rootInput === "object" && rootInput.layoutOverrides ? { layoutOverrides: rootInput.layoutOverrides } : {}),
+      touchedPaths: [...touchedPaths],
+      previousSourceHash: projectionSourceHashBeforeMerge
     });
   }
 

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -26,7 +26,9 @@ import {
   resolveHarnessLayout,
   taskPackagePath
 } from "../layout/index.ts";
-import { hashTaskProjectionRows, rebuildTaskProjection } from "../projection/sqlite-task-projection.ts";
+import { updateTaskProjectionIncrementally } from "../projection/sqlite-task-incremental-projection.ts";
+import { hashTaskProjectionRows } from "../projection/sqlite-task-projection.ts";
+import { readMarkdownSource } from "../projection/sqlite-task-source.ts";
 import { appendJsonLineDurably, readDurableState, readPayloadRef, writePayloadRef, writeWatermarkDurably, writeFileDurably } from "./write-journal-durable.ts";
 import { commitTouchedPaths, resolveCommitPlan } from "./write-journal-git.ts";
 import { runLedgerMaterializer } from "./ledger-materializer.ts";
@@ -183,6 +185,7 @@ function flushRecords(
   }));
 
   resolveCommitPlan(rootDir, plannedRecords.flatMap((record) => record.touchedPaths), rootInput);
+  const previousProjectionSourceHash = records.length > 0 ? readMarkdownSource(rootInput).hash : undefined;
 
   for (const { record, touchedPaths: recordTouchedPaths } of plannedRecords) {
     // Ops with a durable apply marker already mutated their file before a crash;
@@ -203,7 +206,9 @@ function flushRecords(
     sessionId,
     { respectGitignorePaths: plannedRecords.filter((entry) => entry.record.kind === "task_tree_stage").flatMap((entry) => entry.touchedPaths) }
   );
-  const projectionHash = committedOpIds.length > 0 ? rebuildProjectionHash(rootDir, rootInput) : previousWatermark?.projectionHash ?? "no-projection-change";
+  const projectionHash = committedOpIds.length > 0
+    ? rebuildProjectionHash(rootDir, rootInput, touchedPaths, previousProjectionSourceHash)
+    : previousWatermark?.projectionHash ?? "no-projection-change";
   const allCommitted = [...(previousWatermark?.lastCommittedOpIds ?? []), ...committedOpIds];
   const recentCommitted = recentOpIds(allCommitted);
   const watermark = committedOpIds.at(-1);
@@ -427,9 +432,19 @@ function assertHardDeleteAllowed(
   }
 }
 
-function rebuildProjectionHash(rootDir: string, rootInput: HarnessLayoutInput): string {
+function rebuildProjectionHash(
+  rootDir: string,
+  rootInput: HarnessLayoutInput,
+  touchedPaths: ReadonlyArray<string>,
+  previousSourceHash: string | undefined
+): string {
   const layoutOverrides = typeof rootInput === "string" ? undefined : rootInput.layoutOverrides;
-  return hashTaskProjectionRows(rebuildTaskProjection({ rootDir, layoutOverrides }).rows);
+  return hashTaskProjectionRows(updateTaskProjectionIncrementally({
+    rootDir,
+    layoutOverrides,
+    touchedPaths,
+    previousSourceHash
+  }).rows);
 }
 
 function recentOpIds(opIds: ReadonlyArray<string>): ReadonlyArray<string> {

--- a/packages/kernel/src/store/write-journal-git.ts
+++ b/packages/kernel/src/store/write-journal-git.ts
@@ -93,6 +93,22 @@ export function commitsNotInMaster(repoRoot: string, branch: string): ReadonlyAr
     .filter(Boolean);
 }
 
+export function currentGitHead(repoRoot: string): string {
+  try {
+    return runGit(repoRoot, "rev-parse", "HEAD").trim();
+  } catch {
+    return "no-git-head";
+  }
+}
+
+export function changedFilesBetween(repoRoot: string, before: string, after: string): ReadonlyArray<string> {
+  if (before === after) return [];
+  return runGit(repoRoot, "diff", "--name-only", before, after)
+    .split(/\r?\n/u)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
 export function refExists(repoRoot: string, ref: string): boolean {
   try {
     runGit(repoRoot, "rev-parse", "--verify", "--quiet", ref);
@@ -200,14 +216,6 @@ function sessionBranchName(sessionId: string | undefined): string | undefined {
     throw new Error(`invalid session id for git branch: ${safeSessionId}`);
   }
   return `sessions/${safeSessionId}`;
-}
-
-function currentGitHead(rootDir: string): string {
-  try {
-    return runGit(rootDir, "rev-parse", "HEAD").trim();
-  } catch {
-    return "no-git-head";
-  }
 }
 
 function unique(values: ReadonlyArray<string>): ReadonlyArray<string> {

--- a/packages/kernel/test/store/sqlite-incremental-projection.test.ts
+++ b/packages/kernel/test/store/sqlite-incremental-projection.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { deriveRelationId, formatRelationFlowRecord } from "../../src/domain/index.ts";
+import type { EntityRelationRecord } from "../../src/domain/index.ts";
+import {
+  queryDecisionProjection,
+  readRelationGraphProjection,
+  readTaskProjection,
+  rebuildTaskProjection
+} from "../../src/projection/sqlite-task-projection.ts";
+import { updateTaskProjectionIncrementally } from "../../src/projection/sqlite-task-incremental-projection.ts";
+import { readMarkdownSource } from "../../src/projection/sqlite-task-source.ts";
+
+test("incremental projection matches full rebuild across deterministic random write sequences", () => {
+  for (const seed of [7, 19, 43, 71]) {
+    withProjectionPair((incrementalRoot, rebuildRoot) => {
+      seedHarness(incrementalRoot);
+      seedHarness(rebuildRoot);
+      rebuildTaskProjection({ rootDir: incrementalRoot });
+      rebuildTaskProjection({ rootDir: rebuildRoot });
+
+      const random = mulberry32(seed);
+      for (let step = 0; step < 36; step += 1) {
+        const operation = Math.floor(random() * 5);
+        const taskId = ["task-a", "task-b", "task-c"][Math.floor(random() * 3)] ?? "task-a";
+        const previousSourceHash = readMarkdownSource(incrementalRoot).hash;
+        const touchedPaths = applyRandomProjectionWrite(incrementalRoot, operation, taskId, step, seed);
+        applyRandomProjectionWrite(rebuildRoot, operation, taskId, step, seed);
+
+        updateTaskProjectionIncrementally({
+          rootDir: incrementalRoot,
+          touchedPaths,
+          previousSourceHash
+        });
+        rebuildTaskProjection({ rootDir: rebuildRoot });
+
+        assert.deepEqual(snapshotProjection(incrementalRoot, `incremental seed ${seed} step ${step}`), snapshotProjection(rebuildRoot, `rebuild seed ${seed} step ${step}`), `seed ${seed} step ${step}`);
+      }
+    });
+  }
+});
+
+test("incremental projection upserts task rows when package slug differs from task_id", () => {
+  withProjectionPair((incrementalRoot, rebuildRoot) => {
+    const slug = "task_01ABC-readable-slug";
+    const taskId = "task_01ABC";
+    writeIndex(incrementalRoot, taskId, "Slugged Task", "active", [], slug);
+    writeIndex(rebuildRoot, taskId, "Slugged Task", "active", [], slug);
+    rebuildTaskProjection({ rootDir: incrementalRoot });
+    rebuildTaskProjection({ rootDir: rebuildRoot });
+
+    const previousSourceHash = readMarkdownSource(incrementalRoot).hash;
+    const touchedPath = writeIndex(incrementalRoot, taskId, "Slugged Task Updated", "done", [], slug);
+    writeIndex(rebuildRoot, taskId, "Slugged Task Updated", "done", [], slug);
+
+    updateTaskProjectionIncrementally({
+      rootDir: incrementalRoot,
+      touchedPaths: [touchedPath],
+      previousSourceHash
+    });
+    rebuildTaskProjection({ rootDir: rebuildRoot });
+
+    assert.deepEqual(snapshotProjection(incrementalRoot, "incremental slug mismatch"), snapshotProjection(rebuildRoot, "rebuild slug mismatch"));
+  });
+});
+
+function withProjectionPair(fn: (incrementalRoot: string, rebuildRoot: string) => void): void {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-incremental-projection-"));
+  try {
+    fn(path.join(rootDir, "incremental"), path.join(rootDir, "rebuild"));
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function seedHarness(rootDir: string): void {
+  for (const taskId of ["task-a", "task-b", "task-c"]) {
+    writeIndex(rootDir, taskId, `Task ${taskId}`, "active", []);
+  }
+  writeFacts(rootDir, "task-a", true);
+  writeDecision(rootDir, false);
+}
+
+function applyRandomProjectionWrite(rootDir: string, operation: number, taskId: string, step: number, seed: number): ReadonlyArray<string> {
+  switch (operation) {
+    case 0: {
+      const target = taskId === "task-c" ? "task-a" : "task-c";
+      const relations = step % 2 === 0 ? [relation(`task/${taskId}`, `task/${target}`, "depends-on", `step ${step}`)] : [];
+      return [writeIndex(rootDir, taskId, `Task ${taskId} ${seed}-${step}`, statusFor(step), relations)];
+    }
+    case 1:
+      return [writeModule(rootDir, taskId, `module-${seed % 5}`, `Module ${step}`)];
+    case 2:
+      return [writeCloseout(rootDir, taskId, step % 2 === 0)];
+    case 3:
+      return [writeFacts(rootDir, taskId, step % 3 !== 0)];
+    default:
+      return [writeDecision(rootDir, step % 2 === 0)];
+  }
+}
+
+function snapshotProjection(rootDir: string, label: string): unknown {
+  const tasks = readTaskProjection({ rootDir });
+  const decisions = queryDecisionProjection({ rootDir, filters: {} });
+  const graph = readRelationGraphProjection({ rootDir });
+  assert.equal(tasks.warnings.every((warning) => warning.severity !== "hard-fail"), true, `${label} ${rootDir}: ${JSON.stringify(tasks.warnings)}`);
+  assert.equal(decisions.warnings.every((warning) => warning.severity !== "hard-fail"), true, `${label} ${rootDir}: ${JSON.stringify(decisions.warnings)}`);
+  assert.equal(graph.warnings.every((warning) => warning.severity !== "hard-fail"), true, `${label} ${rootDir}: ${JSON.stringify(graph.warnings)}`);
+  return {
+    tasks: tasks.rows,
+    decisions: decisions.rows,
+    edges: graph.edges,
+    coverageRows: graph.coverageRows,
+    factAnchors: graph.factAnchors
+  };
+}
+
+function writeIndex(
+  rootDir: string,
+  taskId: string,
+  title: string,
+  status: string,
+  relations: ReadonlyArray<EntityRelationRecord>,
+  packageSlug = taskId
+): string {
+  const taskDir = path.join(rootDir, "harness/tasks", packageSlug);
+  mkdirSync(taskDir, { recursive: true });
+  const indexPath = path.join(taskDir, "INDEX.md");
+  writeFileSync(indexPath, [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    `title: ${title}`,
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    `  status: ${status}`,
+    "  ref: ",
+    `  titleSnapshot: ${title}`,
+    "  url: ",
+    "  bindingCreatedAt: 2026-07-07T00:00:00.000Z",
+    "  bindingFingerprint: sha256:fixture",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    ...(relations.length > 0 ? ["relations:", ...relations.map(formatRelationFlowRecord)] : []),
+    "---",
+    "",
+    `# ${title}`,
+    ""
+  ].join("\n"));
+  stamp(indexPath);
+  return indexPath;
+}
+
+function writeModule(rootDir: string, taskId: string, moduleKey: string, moduleTitle: string): string {
+  const modulePath = path.join(rootDir, "harness/tasks", taskId, "module.md");
+  mkdirSync(path.dirname(modulePath), { recursive: true });
+  writeFileSync(modulePath, [`Module key: ${moduleKey}`, `Module title: ${moduleTitle}`, ""].join("\n"));
+  stamp(modulePath);
+  return modulePath;
+}
+
+function writeCloseout(rootDir: string, taskId: string, present: boolean): string {
+  const closeoutPath = path.join(rootDir, "harness/tasks", taskId, "closeout.md");
+  if (present) {
+    mkdirSync(path.dirname(closeoutPath), { recursive: true });
+    writeFileSync(closeoutPath, `# Closeout ${taskId}\n`);
+    stamp(closeoutPath);
+  } else {
+    rmSync(closeoutPath, { force: true });
+  }
+  return closeoutPath;
+}
+
+function writeFacts(rootDir: string, taskId: string, includeRelation: boolean): string {
+  const factsPath = path.join(rootDir, "harness/tasks", taskId, "facts.md");
+  mkdirSync(path.dirname(factsPath), { recursive: true });
+  const factRef = `fact/${taskId}/F-DEADBEEF`;
+  writeFileSync(factsPath, [
+    "# Facts",
+    "",
+    "- {fact_id: F-DEADBEEF, statement: \"Incremental projection fact.\", source: \"test\", observedAt: \"2026-07-07T00:00:00.000Z\", confidence: high, memoryClass: episodic, memoryTags: [], provenance: [{runtime: \"node-test\", sessionId: \"sqlite-incremental\", boundAt: \"2026-07-07T00:00:00.000Z\"}]}",
+    ...(includeRelation ? [
+      "",
+      "relations:",
+      formatRelationFlowRecord(relation(factRef, "decision/dec_W6_INCREMENTAL/CH1", "supports", `fact ${taskId} supports decision`))
+    ] : []),
+    ""
+  ].join("\n"));
+  stamp(factsPath);
+  return factsPath;
+}
+
+function writeDecision(rootDir: string, includeRelation: boolean): string {
+  const decisionDir = path.join(rootDir, "harness/decisions/decision-dec_W6_INCREMENTAL");
+  mkdirSync(decisionDir, { recursive: true });
+  const decisionPath = path.join(decisionDir, "decision.md");
+  writeFileSync(decisionPath, [
+    "---",
+    "schema: decision-package/v1",
+    "decision_id: dec_W6_INCREMENTAL",
+    "_coordinatorWatermark: wm-w6-incremental",
+    "title: W6 incremental projection decision",
+    "state: active",
+    "riskTier: medium",
+    "urgency: medium",
+    "vertical: \"software/coding\"",
+    "preset: \"architecture-decision\"",
+    "applies_to:",
+    "  modules: [\"projection\"]",
+    "  productLines: []",
+    "proposedBy: { kind: \"agent\", id: \"test\" }",
+    "proposedAt: \"2026-07-07T00:00:00.000Z\"",
+    "arbiter: { kind: \"human\", id: \"test\" }",
+    "decidedAt: \"2026-07-07T00:00:00.000Z\"",
+    "provenance:",
+    "  - { runtime: \"node-test\", sessionId: \"sqlite-incremental\", boundAt: \"2026-07-07T00:00:00.000Z\" }",
+    "question: \"Should incremental projection match full rebuild?\"",
+    "chosen:",
+    "  - { id: \"CH1\", text: \"Use incremental projection\" }",
+    "rejected:",
+    "  - { id: \"RJ1\", text: \"Trust stale cache\", why_not: \"SQLite is derived\" }",
+    "claims:",
+    "  - { id: \"C1\", text: \"Incremental equals rebuild\" }",
+    "relations:",
+    ...(includeRelation ? [
+      formatRelationFlowRecord(relation("decision/dec_W6_INCREMENTAL/CH1", "fact/task-a/F-DEADBEEF", "evidenced-by", "decision evidence edge"))
+    ] : []),
+    "---",
+    "",
+    "# W6 incremental projection decision",
+    ""
+  ].join("\n"));
+  stamp(decisionPath);
+  return decisionPath;
+}
+
+function relation(source: string, target: string, type: EntityRelationRecord["type"], rationale: string): EntityRelationRecord {
+  const base = {
+    source,
+    target,
+    type,
+    direction: "directed" as const
+  };
+  return {
+    relation_id: deriveRelationId(base),
+    ...base,
+    strength: "strong",
+    origin: "declared",
+    rationale,
+    state: "active"
+  };
+}
+
+function statusFor(step: number): string {
+  return ["planned", "active", "blocked", "in_review", "done"][step % 5] ?? "active";
+}
+
+function mulberry32(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state += 0x6D2B79F5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function stamp(filePath: string): void {
+  const fixed = new Date("2026-07-07T00:00:00.000Z");
+  utimesSync(filePath, fixed, fixed);
+}

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -141,6 +141,7 @@ export const testTierManifest = {
     "packages/kernel/test/store/relation-cascade-direction.test.ts",
     "packages/kernel/test/store/relation-graph-projection.test.ts",
     "packages/kernel/test/store/same-task-fifo.test.ts",
+    "packages/kernel/test/store/sqlite-incremental-projection.test.ts",
     "packages/kernel/test/store/sqlite-rebuild.test.ts",
     "tools/check-docs-release-map.test.mjs",
     "tools/check-import-boundaries.test.mjs",


### PR DESCRIPTION
# English

## Summary

W6 replaces the per-flush full SQLite projection rebuild with an incremental projection update path while keeping full rebuild as the benchmark and recovery tool. The change updates only affected task and decision rows after authored writes, conservatively refreshes relation-derived projection tables through the canonical relation graph projection, and wires the path into WriteCoordinator flushes plus ledger materializer merges.

## What Changed

- Added `updateTaskProjectionIncrementally` and a SQLite update transaction for targeted task and decision row upserts, affected-row deletion, projection metadata refresh, and relation/fact-anchor derived table replacement.
- Kept `rebuildTaskProjection` as the authoritative full rebuild baseline and fallback when the projection database is missing, tampered, or stale before the incremental write.
- Added decision-row reads by changed document paths and exported existing SQLite row helpers for the incremental update store.
- Wired incremental projection hashing into `write-journal-coordinator.ts` and ledger materializer merge refreshes without changing projection schema semantics.
- Added an integration-tier equivalence/property test that compares incremental and full rebuild terminal projections after deterministic random authored write sequences, and registered it in the test-tier manifest.

## Task And Scope

- Harness task: `task_01KWW57Z6EHBRBJGAXHQB4D6NN`
- Branch: `codex/w6-projection-incremental`
- Public scope: `packages/kernel/src/projection/**`, kernel store flush/materializer trigger points, and `tools/test-tier-manifest.mjs` test registration.
- Private planning/evidence updated: yes, task progress/facts and benchmark artifacts under the W6 task package.
- Out of scope: daemon transport files, `packages/daemon/**`, `tools/check-*`, projection schema semantic changes, and any second source of truth for ledger state.

## Version Impact

- Version: no version change because this is an internal kernel projection/runtime behavior change with no package release task in scope.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: WriteCoordinator flush projection freshness path, ledger materializer projection refresh hook, and test-tier manifest registration.
- Authority: `task_01KWW57Z6EHBRBJGAXHQB4D6NN` authorizes W6 projection incrementalization; `dec_LEDGER_E51` keeps SQLite as a rebuildable derived read layer rather than a second fact source.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `654144892a3dad852d0858a387818f6ae74e1641`
- Branch merge-base with `origin/main`: `654144892a3dad852d0858a387818f6ae74e1641`
- Last `git fetch origin` time: not run in this continuation; user-provided continuation baseline stated `6541448` is current `origin/main`.
- Sync method: none needed.
- Public diff command: `git diff --stat origin/main...HEAD` and `git diff --check origin/main...HEAD`
- Private evidence commit/path: W6 task facts/progress plus `artifacts/benchmarks/w6-projection-benchmark-summary.md` in the private task package.
- Reviewer evidence path: W6 task package `artifacts/benchmarks/` raw before/after JSON and benchmark summary.
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28832732248
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: local `npm ci` was not rerun in this continuation; dependency files are unchanged. CI `npm ci` completed successfully in the workflow run above.

## Review Evidence

- Self-review: diff was reviewed against W6 constraints; no `packages/daemon/**` or `tools/check-*` changes; relation cycle substrate gate still passes with `relation-graph-projection.ts` as canonical detector.
- Reviewer subagent: not run.
- Human review: pending CEO/reviewers.
- Blocking findings: none known locally.

## Residual Risk

- Local read p95 measurements are noisy on repeated runs. W6 does not alter read query functions; raw benchmark artifacts and the summary record both stable and noisy readings.
- Relation-derived tables are conservatively replaced during incremental updates rather than minimally patched, trading some write work for lower missed-propagation risk.
- Corrupted or stale projection state intentionally recovers by full rebuild rather than projection-level repair.

## References

- Task: `task_01KWW57Z6EHBRBJGAXHQB4D6NN`
- Evidence: `F-W6EQV001`, `F-W6BENCH1`, `artifacts/benchmarks/w6-projection-benchmark-summary.md`
- Review: pending

---

# 中文

## 概要

W6 将每次 flush 后全量重建 SQLite 投影改为增量更新，同时保留全量重建作为基准和恢复工具。实现只重算本次 authored 写入影响的 task / decision 行，并通过 canonical relation graph projection 保守刷新 relation 派生表；接入点覆盖 WriteCoordinator flush 和 ledger materializer 合并后的投影刷新。

## 改动内容

- 新增 `updateTaskProjectionIncrementally` 与 SQLite update transaction，用于定向 upsert task / decision 行、删除受影响旧行、刷新 projection metadata，并替换 relation/fact-anchor 派生表。
- 保留 `rebuildTaskProjection` 作为权威全量基准；当投影库缺失、被篡改或写前 freshness 不匹配时，增量路径回退到全量重建。
- 增加按 changed document path 读取 decision rows 的能力，并复用现有 SQLite row helper。
- 在 `write-journal-coordinator.ts` 和 ledger materializer merge 刷新点接入增量投影 hash，未改变投影 schema 语义。
- 新增 integration-tier 等价性属性测试：确定性随机 authored 写序列中，每一步比较增量路径与全量 rebuild 终态投影，并加入 test-tier manifest。

## 任务与范围

- Harness 任务：`task_01KWW57Z6EHBRBJGAXHQB4D6NN`
- 分支：`codex/w6-projection-incremental`
- 公开范围：`packages/kernel/src/projection/**`、kernel store flush/materializer 触发点、`tools/test-tier-manifest.mjs` 测试登记。
- 私有计划 / 证据是否已更新：yes，W6 task package 中已有 progress/facts 和 benchmark artifacts。
- 范围外：daemon transport 文件、`packages/daemon/**`、`tools/check-*`、投影 schema 语义变更，以及把 SQLite 变成第二事实源。

## 版本影响

- 版本：不改版本，原因是本 PR 是内部 kernel 投影/runtime 行为变更，未包含 package release task。
- 发布影响：不发布。

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：WriteCoordinator flush 投影 freshness 路径、ledger materializer 投影刷新钩子、test-tier manifest 登记。
- 依据：`task_01KWW57Z6EHBRBJGAXHQB4D6NN` 授权 W6 投影增量化；`dec_LEDGER_E51` 规定 SQLite 仍是可重建派生读层，不是第二事实源。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`654144892a3dad852d0858a387818f6ae74e1641`
- 当前分支与 `origin/main` 的 merge-base：`654144892a3dad852d0858a387818f6ae74e1641`
- 最近一次 `git fetch origin` 时间：本轮续跑未执行；用户给定续跑基线为当前 `origin/main` 的 `6541448`。
- 同步方式：不需要。
- 公开 diff 命令：`git diff --stat origin/main...HEAD` 与 `git diff --check origin/main...HEAD`
- 私有证据 commit/path：W6 task facts/progress，以及私有 task package 下的 `artifacts/benchmarks/w6-projection-benchmark-summary.md`。
- Reviewer 证据路径：W6 task package `artifacts/benchmarks/` before/after 原始 JSON 和 benchmark summary。
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28832732248
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：本轮续跑未在本地重新执行 `npm ci`，依赖文件未改变。CI workflow 中的 `npm ci` 已成功完成。

## 审查证据

- 自查：已按 W6 constraints 检查 diff；未改 `packages/daemon/**` 或 `tools/check-*`；relation cycle substrate gate 仍确认 `relation-graph-projection.ts` 是 canonical detector。
- Reviewer subagent：未运行。
- 人工审查：等待 CEO/reviewer。
- 阻塞发现：本地未知。

## 残余风险

- 本地 read p95 多轮测量噪声较大。W6 未改 read query 函数；原始 benchmark artifacts 与 summary 同时保留稳定读数和噪声说明。
- relation 派生表在增量更新中采用保守替换而不是最小 patch，用更多写侧工作换取不漏传播。
- 投影损坏或写前 freshness 不匹配时，恢复动作按约束回退全量 rebuild，不做投影级修复。

## 关联材料

- 任务：`task_01KWW57Z6EHBRBJGAXHQB4D6NN`
- 证据：`F-W6EQV001`、`F-W6BENCH1`、`artifacts/benchmarks/w6-projection-benchmark-summary.md`
- 审查：等待中
