### PR TITLE
feat: productize daemon server mode

### DIFF
--- a/docs-release/README.md
+++ b/docs-release/README.md
@@ -39,3 +39,10 @@ The design is deliberate, and every choice has a reason. This path walks through
 Finished `learn/` and wondering *how the system delivers on those claims*? This path is the mechanism: the layered architecture, how the three entities live on disk, the single write path, the rebuildable SQLite projection, the gates, and the vertical engine.
 
 → **[architecture/](architecture/en/00-overview.md)**
+
+## Run a team daemon server
+
+Deploy a canonical repository behind a long-lived daemon, install service
+templates, reject direct pushes, and expose a read-only mirror for bulk fetches.
+
+→ **[operations-server-daemon.md](operations-server-daemon.md)**

--- a/docs-release/README.zh-CN.md
+++ b/docs-release/README.zh-CN.md
@@ -37,3 +37,9 @@ Harness Anything 是 AI agent 的问责层（accountability layer）：agent 产
 读完 `learn/`，好奇*系统到底如何兑现那些主张*？这条路径讲机制：分层架构、三个实体如何落在磁盘上、单一写入路径、可重建的 SQLite 投影、守门人(gate)以及 vertical 引擎。
 
 → **[architecture/](architecture/zh/00-overview.md)**
+
+## 运行团队 daemon 服务器
+
+把 canonical 仓库放到常驻 daemon 后面，安装服务模板，拒绝直推，并暴露只读镜像用于批量 fetch。
+
+→ **[operations-server-daemon.zh-CN.md](operations-server-daemon.zh-CN.md)**

--- a/docs-release/operations-server-daemon.md
+++ b/docs-release/operations-server-daemon.md
@@ -1,0 +1,83 @@
+# Server Daemon Operations
+
+Harness Anything team mode runs one canonical repository behind one long-lived daemon.
+Clients reach it over SSH; no public TCP port is required.
+
+## Prerequisites
+
+- Node.js that satisfies the package engine policy.
+- `ha` available on the server user's `PATH`.
+- Git available on the server.
+- SSH access for each team member.
+- A canonical repository path writable by the daemon user.
+
+## Bootstrap
+
+Run the server bootstrap once, then rerun it safely whenever you need to verify
+the layout:
+
+```bash
+ha daemon bootstrap-server \
+  --canonical-root /srv/harness/team \
+  --ssh-host team-host \
+  --ssh-user alice \
+  --person-id person_alice \
+  --display-name "Alice Admin" \
+  --email alice@example.com \
+  --readonly-mirror /srv/harness/team-readonly.git
+```
+
+The command initializes the canonical repository, ensures `harness/people.yaml`,
+installs the canonical pre-receive hook, optionally creates a read-only mirror,
+starts the local daemon service, verifies SSH reachability, and writes a
+`daemon-bootstrap-report/v1` JSON report.
+
+Use `--skip-ssh-check` for offline preparation and `--no-start` when a service
+manager will start the daemon later.
+
+## Service Templates
+
+Copy platform templates from the CLI package:
+
+```bash
+ha daemon install-templates --out ./daemon-service-templates
+```
+
+Templates are intentionally package-manager neutral:
+
+- `harness-anything-daemon.service` for systemd.
+- `com.harness-anything.daemon.plist` for launchd.
+- `install-harness-anything-daemon.ps1` for Windows Service registration.
+
+Replace `{{HA_BIN}}`, `{{CANONICAL_ROOT}}`, `{{USER}}`, and log placeholders for
+your host before installing them.
+
+## Direct Push Hook
+
+The canonical repository hook rejects non-daemon pushes and tells users to use
+the daemon-backed `ha` path. It is a server-side accident guard, not content
+review. It fails closed unless a future daemon-managed push path supplies the
+server-local daemon token.
+
+## Read-Only Mirror
+
+The mirror is for bulk context reads:
+
+```bash
+git fetch ssh://team-host/srv/harness/team-readonly.git
+```
+
+Mirror synchronization is ordinary Git fetch from the canonical repository. It
+does not require daemon push logic. The mirror has its own pre-receive hook that
+rejects writes and points users back to the canonical daemon path.
+
+## Status And Stop
+
+```bash
+ha --root /srv/harness/team daemon status --json
+ha --root /srv/harness/team daemon stop --timeout-ms 5000 --json
+```
+
+Status reports the lock holder, queue depth, active and total connections,
+daemon version, and protocol version. Stop sends `SIGTERM` and waits for the
+daemon runtime to drain queued writes and release the global lock.

--- a/docs-release/operations-server-daemon.zh-CN.md
+++ b/docs-release/operations-server-daemon.zh-CN.md
@@ -1,0 +1,76 @@
+# 服务器 Daemon 运维
+
+Harness Anything 团队模式使用一个常驻 daemon 托管一份 canonical 仓库。客户端
+只通过 SSH 到达服务器，不需要打开公网 TCP 端口。
+
+## 前置条件
+
+- Node.js 满足当前 package engine 策略。
+- 服务器用户的 `PATH` 上有 `ha`。
+- 服务器安装 Git。
+- 每位团队成员有 SSH 访问权限。
+- daemon 用户可写 canonical 仓库路径。
+
+## 引导
+
+首次部署时运行一次；之后重复执行也应保持幂等：
+
+```bash
+ha daemon bootstrap-server \
+  --canonical-root /srv/harness/team \
+  --ssh-host team-host \
+  --ssh-user alice \
+  --person-id person_alice \
+  --display-name "Alice Admin" \
+  --email alice@example.com \
+  --readonly-mirror /srv/harness/team-readonly.git
+```
+
+该命令会初始化 canonical 仓库，确保 `harness/people.yaml`，安装 canonical
+pre-receive hook，可选创建只读镜像，启动本地 daemon service，验证 SSH 可达，并写出
+`daemon-bootstrap-report/v1` JSON 报告。
+
+离线准备时使用 `--skip-ssh-check`；准备交给服务管理器启动时使用 `--no-start`。
+
+## 服务模板
+
+从 CLI 包复制三平台模板：
+
+```bash
+ha daemon install-templates --out ./daemon-service-templates
+```
+
+模板不绑定发行版包管理器：
+
+- `harness-anything-daemon.service`：systemd。
+- `com.harness-anything.daemon.plist`：launchd。
+- `install-harness-anything-daemon.ps1`：Windows Service 注册脚本。
+
+安装前替换 `{{HA_BIN}}`、`{{CANONICAL_ROOT}}`、`{{USER}}` 和日志路径占位符。
+
+## 拒绝直推 Hook
+
+canonical 仓库 hook 会拒绝非 daemon push，并提示用户走 daemon-backed `ha` 路径。
+它是服务器侧防误操作护栏，不做内容审查。除非未来 daemon 管理的 push 路径提供
+服务器本地 token，否则默认 fail-closed。
+
+## 只读镜像
+
+镜像只承担批量上下文读取：
+
+```bash
+git fetch ssh://team-host/srv/harness/team-readonly.git
+```
+
+镜像同步是普通 Git fetch，从 canonical 仓库拉取，不需要 daemon 新增推送逻辑。
+镜像自身也安装 pre-receive hook，拒绝写入并提示回到 canonical daemon 路径。
+
+## Status 与 Stop
+
+```bash
+ha --root /srv/harness/team daemon status --json
+ha --root /srv/harness/team daemon stop --timeout-ms 5000 --json
+```
+
+status 报告锁持有者、队列深度、当前/累计连接数、daemon 版本和协议版本。stop 发送
+`SIGTERM`，并等待 daemon runtime 排空队列、释放全局锁。

--- a/packages/cli/scripts/copy-assets.mjs
+++ b/packages/cli/scripts/copy-assets.mjs
@@ -3,11 +3,21 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const source = path.join(packageRoot, "src/commands/extensions/assets");
-const target = path.join(packageRoot, "dist/cli/src/commands/extensions/assets");
+const copies = [
+  {
+    source: path.join(packageRoot, "src/commands/extensions/assets"),
+    target: path.join(packageRoot, "dist/cli/src/commands/extensions/assets")
+  },
+  {
+    source: path.join(packageRoot, "src/commands/daemon/assets"),
+    target: path.join(packageRoot, "dist/cli/src/commands/daemon/assets")
+  }
+];
 
-if (existsSync(target)) {
-  rmSync(target, { recursive: true, force: true });
+for (const { source, target } of copies) {
+  if (existsSync(target)) {
+    rmSync(target, { recursive: true, force: true });
+  }
+  mkdirSync(path.dirname(target), { recursive: true });
+  cpSync(source, target, { recursive: true });
 }
-mkdirSync(path.dirname(target), { recursive: true });
-cpSync(source, target, { recursive: true });

--- a/packages/cli/src/commands/core/version.ts
+++ b/packages/cli/src/commands/core/version.ts
@@ -7,7 +7,7 @@ import type { CommandRunner } from "../../cli/runner-registry.ts";
 export const runVersionCommand: CommandRunner = () =>
   Effect.sync(() => ({ ok: true, command: "version", version: resolveCliVersion() }));
 
-function resolveCliVersion(): string {
+export function resolveCliVersion(): string {
   // Walk up from this module to the @harness-anything/cli package.json. Robust
   // across layouts: src, built dist, and installed package layouts.
   let dir = path.dirname(fileURLToPath(import.meta.url));

--- a/packages/cli/src/commands/daemon/assets/git-hooks/pre-receive-daemon-only.sh
+++ b/packages/cli/src/commands/daemon/assets/git-hooks/pre-receive-daemon-only.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+token_file="$repo_root/.harness/server/daemon-push-token"
+
+if [ "${HARNESS_DAEMON_GIT_PUSH:-}" = "1" ] && [ -f "$token_file" ]; then
+  expected="$(cat "$token_file")"
+  if [ "${HARNESS_DAEMON_GIT_TOKEN:-}" = "$expected" ]; then
+    exit 0
+  fi
+fi
+
+cat >&2 <<'MSG'
+Harness Anything rejected this direct push.
+
+This canonical repository is daemon-owned. Submit writes through the daemon-backed
+ha client/API over SSH instead of pushing authored state directly.
+
+Use:
+  HARNESS_DAEMON_MODE=remote ha <command>
+
+Server policy: fail closed for non-daemon write paths; this hook does not inspect
+commit contents.
+MSG
+exit 1

--- a/packages/cli/src/commands/daemon/assets/git-hooks/pre-receive-readonly-mirror.sh
+++ b/packages/cli/src/commands/daemon/assets/git-hooks/pre-receive-readonly-mirror.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -eu
+
+cat >&2 <<'MSG'
+Harness Anything rejected this push.
+
+This repository is a read-only mirror for git fetch/context reads. Fetch from it,
+but send all writes to the canonical daemon-backed ha path.
+MSG
+exit 1

--- a/packages/cli/src/commands/daemon/assets/launchd/com.harness-anything.daemon.plist
+++ b/packages/cli/src/commands/daemon/assets/launchd/com.harness-anything.daemon.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.harness-anything.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>{{HA_BIN}}</string>
+    <string>--root</string>
+    <string>{{CANONICAL_ROOT}}</string>
+    <string>daemon</string>
+    <string>start</string>
+    <string>--foreground</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HARNESS_DAEMON_MODE</key>
+    <string>direct</string>
+  </dict>
+  <key>WorkingDirectory</key>
+  <string>{{CANONICAL_ROOT}}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>{{LOG_DIR}}/harness-anything-daemon.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{LOG_DIR}}/harness-anything-daemon.err.log</string>
+</dict>
+</plist>

--- a/packages/cli/src/commands/daemon/assets/systemd/harness-anything-daemon.service
+++ b/packages/cli/src/commands/daemon/assets/systemd/harness-anything-daemon.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Harness Anything daemon
+Documentation=https://github.com/FairladyZ625/harness-anything
+After=network.target
+
+[Service]
+Type=simple
+User={{USER}}
+WorkingDirectory={{CANONICAL_ROOT}}
+Environment=HARNESS_DAEMON_MODE=direct
+ExecStart={{HA_BIN}} --root {{CANONICAL_ROOT}} daemon start --foreground
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/cli/src/commands/daemon/assets/windows/install-harness-anything-daemon.ps1
+++ b/packages/cli/src/commands/daemon/assets/windows/install-harness-anything-daemon.ps1
@@ -1,0 +1,18 @@
+param(
+  [Parameter(Mandatory=$true)][string]$CanonicalRoot,
+  [string]$HaBin = "ha",
+  [string]$ServiceName = "HarnessAnythingDaemon"
+)
+
+$ErrorActionPreference = "Stop"
+
+$command = "`"$HaBin`" --root `"$CanonicalRoot`" daemon start --foreground"
+if (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue) {
+  sc.exe config $ServiceName binPath= $command | Out-Null
+} else {
+  New-Service -Name $ServiceName -BinaryPathName $command -DisplayName "Harness Anything Daemon" -StartupType Automatic | Out-Null
+}
+
+Write-Host "Service registered: $ServiceName"
+Write-Host "Start with: Start-Service $ServiceName"
+Write-Host "Verify with: ha --root `"$CanonicalRoot`" daemon status --json"

--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -1,0 +1,506 @@
+import { execFileSync, spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync, chmodSync, cpSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createHarnessRuntimeContext,
+  resolveHarnessLayout,
+} from "../../../../kernel/src/index.ts";
+import {
+  currentDaemonProtocolVersion,
+  loadPeopleRoster,
+  makeTransportDerivedIdentityProvider,
+  type JsonObject,
+  type JsonValue
+} from "../../../../daemon/src/index.ts";
+import { makeRuntimeEventAppendPromise, makeRuntimeEventLedgerService } from "../../../../application/src/index.ts";
+import { initializeHarness } from "../init.ts";
+import { resolveCliVersion } from "../core/version.ts";
+import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
+import { readOption } from "../../cli/parse-options.ts";
+import { localDaemonSocketPath, requestLocalDaemonJsonRpc } from "../../daemon/client.ts";
+
+export interface DaemonCommandInput {
+  readonly rootDir: string;
+  readonly layoutOverrides?: { readonly authoredRoot?: string };
+  readonly json: boolean;
+  readonly args: ReadonlyArray<string>;
+  readonly runServe: (
+    rootDir: string,
+    layoutOverrides: { readonly authoredRoot?: string } | undefined,
+    args: ReadonlyArray<string>,
+    hooks?: DaemonServeHooks
+  ) => Promise<void>;
+}
+
+export interface DaemonServeHooks {
+  readonly onStarted?: (status: Record<string, unknown>) => void;
+}
+
+export interface DaemonConnectionStats {
+  active: number;
+  total: number;
+}
+
+export async function runDaemonProductCommand(input: DaemonCommandInput): Promise<number> {
+  const action = input.args[1] ?? "status";
+  if (action === "--help" || action === "-h" || input.args.includes("--help") || input.args.includes("-h")) {
+    console.log(renderDaemonHelp());
+    return 0;
+  }
+  try {
+    if (action === "start") return await startDaemon(input);
+    if (action === "status") return await statusDaemon(input);
+    if (action === "stop") return await stopDaemon(input);
+    if (action === "bootstrap-server") return await bootstrapServer(input);
+    if (action === "install-templates") return installTemplates(input);
+    emitDaemonError(`unknown daemon command: ${action}`, input.json);
+    return 2;
+  } catch (error) {
+    emitDaemonError(error instanceof Error ? error.message : String(error), input.json);
+    return 1;
+  }
+}
+
+export function daemonStatusPayload(input: {
+  readonly daemonId: string;
+  readonly rootDir: string;
+  readonly repoId: string;
+  readonly endpoint: string;
+  readonly runtimeStatus: {
+    readonly started: boolean;
+    readonly lockPath?: string;
+    readonly lockOwnerToken?: string;
+    readonly queue: {
+      readonly interactive: number;
+      readonly normal: number;
+      readonly background: number;
+      readonly maintenance: number;
+      readonly running: boolean;
+    };
+    readonly lastRecovery?: unknown;
+  };
+  readonly connections: DaemonConnectionStats;
+}): JsonObject {
+  const queueDepth = input.runtimeStatus.queue.interactive
+    + input.runtimeStatus.queue.normal
+    + input.runtimeStatus.queue.background
+    + input.runtimeStatus.queue.maintenance;
+  return {
+    schema: "daemon-status/v1",
+    started: input.runtimeStatus.started,
+    daemonId: input.daemonId,
+    rootDir: input.rootDir,
+    repoId: input.repoId,
+    endpoint: input.endpoint,
+    version: resolveCliVersion(),
+    protocolVersion: currentDaemonProtocolVersion,
+    lock: {
+      path: input.runtimeStatus.lockPath ?? null,
+      ownerToken: input.runtimeStatus.lockOwnerToken ?? null
+    },
+    queue: input.runtimeStatus.queue,
+    queueDepth,
+    connections: {
+      active: input.connections.active,
+      total: input.connections.total
+    },
+    lastRecovery: toJsonValue(input.runtimeStatus.lastRecovery ?? null)
+  };
+}
+
+export function loadDaemonIdentity(rootDir: string, layoutOverrides: { readonly authoredRoot?: string } | undefined): {
+  readonly peopleRoster?: ReturnType<typeof loadPeopleRoster>;
+  readonly identityProvider?: ReturnType<typeof makeTransportDerivedIdentityProvider>;
+  readonly appendRuntimeEvent?: ReturnType<typeof makeRuntimeEventAppendPromise>;
+} {
+  const runtimeContext = createHarnessRuntimeContext(rootDir, layoutOverrides);
+  const layout = resolveHarnessLayout(runtimeContext);
+  const peoplePath = path.join(layout.authoredRoot, "people.yaml");
+  if (!existsSync(peoplePath)) return {};
+  const peopleRoster = loadPeopleRoster(runtimeContext);
+  return {
+    peopleRoster,
+    identityProvider: makeTransportDerivedIdentityProvider(peopleRoster, {
+      localUnixIssuer: `host:${os.hostname()}`,
+      sshExecIssuer: `host:${os.hostname()}`,
+      namedPipeIssuer: `host:${os.hostname()}:named-pipe`
+    }),
+    appendRuntimeEvent: makeRuntimeEventAppendPromise(makeRuntimeEventLedgerService({ rootInput: runtimeContext }))
+  };
+}
+
+async function startDaemon(input: DaemonCommandInput): Promise<number> {
+  const foreground = input.args.includes("--foreground");
+  const service = input.args.includes("--service") || !foreground;
+  const socketPath = readOption(input.args, "--socket") ?? localDaemonSocketPath(input.rootDir);
+  if (foreground) {
+    await input.runServe(input.rootDir, input.layoutOverrides, ["daemon", "serve", "--socket", socketPath, "--idle-ms", "0"], {
+      onStarted: (status) => emitDaemonResult("daemon-start", { ...status, mode: "foreground" }, input.json)
+    });
+    return 0;
+  }
+  if (service) {
+    const child = spawn(process.execPath, [
+      ...process.execArgv,
+      cliEntrypointPath(),
+      "--root",
+      input.rootDir,
+      ...(input.layoutOverrides?.authoredRoot ? ["--authored-root", input.layoutOverrides.authoredRoot] : []),
+      "daemon",
+      "serve",
+      "--socket",
+      socketPath,
+      "--idle-ms",
+      "0"
+    ], {
+      detached: true,
+      stdio: "ignore",
+      env: { ...process.env, HARNESS_DAEMON_MODE: "direct" }
+    });
+    child.unref();
+    const status = await waitForReachableStatus(input.rootDir, 6_000);
+    emitDaemonResult("daemon-start", { ...status, mode: "service", socketPath }, input.json);
+    return 0;
+  }
+  return 0;
+}
+
+async function statusDaemon(input: DaemonCommandInput): Promise<number> {
+  const layout = resolveHarnessLayout(createHarnessRuntimeContext(input.rootDir, input.layoutOverrides));
+  const lockStatus = readDaemonLock(path.join(layout.locksRoot, "global.lock"));
+  const rpcStatus = await readReachableDaemonStatus(input.rootDir);
+  emitDaemonResult("daemon-status", {
+    ...lockStatus,
+    reachable: Boolean(rpcStatus),
+    ...(rpcStatus ?? {
+      version: resolveCliVersion(),
+      protocolVersion: currentDaemonProtocolVersion,
+      queueDepth: 0,
+      queue: { interactive: 0, normal: 0, background: 0, maintenance: 0, running: false },
+      connections: { active: 0, total: 0 }
+    })
+  }, input.json);
+  return 0;
+}
+
+async function stopDaemon(input: DaemonCommandInput): Promise<number> {
+  const timeoutMs = Number.parseInt(readOption(input.args, "--timeout-ms") ?? "5000", 10);
+  const layout = resolveHarnessLayout(createHarnessRuntimeContext(input.rootDir, input.layoutOverrides));
+  const lockPath = path.join(layout.locksRoot, "global.lock");
+  const before = readDaemonLock(lockPath);
+  if (before.started && typeof before.pid === "number") {
+    process.kill(before.pid, "SIGTERM");
+  }
+  const stopped = before.started ? await waitForStopped(lockPath, timeoutMs) : true;
+  emitDaemonResult("daemon-stop", {
+    ...before,
+    signaled: before.started,
+    drained: stopped,
+    stopped
+  }, input.json);
+  return stopped ? 0 : 1;
+}
+
+function installTemplates(input: DaemonCommandInput): number {
+  const outDir = readOption(input.args, "--out");
+  if (!outDir) throw new Error("Use ha daemon install-templates --out <directory>.");
+  mkdirSync(outDir, { recursive: true });
+  cpSync(daemonAssetPath("systemd/harness-anything-daemon.service"), path.join(outDir, "harness-anything-daemon.service"));
+  cpSync(daemonAssetPath("launchd/com.harness-anything.daemon.plist"), path.join(outDir, "com.harness-anything.daemon.plist"));
+  cpSync(daemonAssetPath("windows/install-harness-anything-daemon.ps1"), path.join(outDir, "install-harness-anything-daemon.ps1"));
+  emitDaemonResult("daemon-install-templates", {
+    outputDir: outDir,
+    files: [
+      "harness-anything-daemon.service",
+      "com.harness-anything.daemon.plist",
+      "install-harness-anything-daemon.ps1"
+    ]
+  }, input.json);
+  return 0;
+}
+
+async function bootstrapServer(input: DaemonCommandInput): Promise<number> {
+  const canonicalRoot = path.resolve(requiredOption(input.args, "--canonical-root"));
+  const sshHost = requiredOption(input.args, "--ssh-host");
+  const sshUser = readOption(input.args, "--ssh-user") ?? os.userInfo().username;
+  const personId = readOption(input.args, "--person-id") ?? `person_${safeId(sshUser)}`;
+  const displayName = readOption(input.args, "--display-name") ?? sshUser;
+  const primaryEmail = readOption(input.args, "--email");
+  const role = readOption(input.args, "--role") ?? "owner";
+  const readonlyMirror = readOption(input.args, "--readonly-mirror");
+  const reportPath = readOption(input.args, "--report") ?? path.join(canonicalRoot, ".harness", "generated", "daemon-bootstrap-report.json");
+  const skipSshCheck = input.args.includes("--skip-ssh-check");
+  const noStart = input.args.includes("--no-start");
+
+  ensureCanonicalRepo(canonicalRoot);
+  initializeHarness({ rootDir: canonicalRoot }, false, path.basename(canonicalRoot));
+  const layout = resolveHarnessLayout({ rootDir: canonicalRoot });
+  const peoplePath = path.join(layout.authoredRoot, "people.yaml");
+  ensurePeopleRoster(peoplePath, { personId, displayName, primaryEmail, role, sshUser, sshHost });
+  installCanonicalPreReceiveHook(canonicalRoot);
+  const mirrorReport = readonlyMirror ? ensureReadonlyMirror(canonicalRoot, path.resolve(readonlyMirror)) : undefined;
+  const daemon = noStart
+    ? { started: false, reason: "no-start" }
+    : await startBootstrapDaemon(canonicalRoot);
+  const ssh = skipSshCheck ? { checked: false, reason: "skip-ssh-check" } : await checkSshReachability(sshHost, sshUser, canonicalRoot);
+  const report = {
+    schema: "daemon-bootstrap-report/v1",
+    canonicalRoot,
+    peoplePath,
+    daemon,
+    ssh,
+    gitHook: {
+      path: path.join(canonicalRoot, ".git/hooks/pre-receive"),
+      policy: "reject non-daemon direct push"
+    },
+    readonlyMirror: mirrorReport ?? null
+  };
+  mkdirSync(path.dirname(reportPath), { recursive: true });
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  emitDaemonResult("daemon-bootstrap-server", { reportPath, ...report }, input.json);
+  return 0;
+}
+
+function ensureCanonicalRepo(rootDir: string): void {
+  mkdirSync(rootDir, { recursive: true });
+  if (!existsSync(path.join(rootDir, ".git"))) runGit(rootDir, ["init"]);
+}
+
+function ensurePeopleRoster(filePath: string, input: {
+  readonly personId: string;
+  readonly displayName: string;
+  readonly primaryEmail?: string;
+  readonly role: string;
+  readonly sshUser: string;
+  readonly sshHost: string;
+}): void {
+  if (existsSync(filePath)) return;
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const uid = process.getuid?.();
+  writeFileSync(filePath, [
+    "schema: harness-people/v1",
+    "people:",
+    `  - personId: ${input.personId}`,
+    `    displayName: ${input.displayName}`,
+    ...(input.primaryEmail ? [`    primaryEmail: ${input.primaryEmail}`] : []),
+    `    roles: [${input.role}]`,
+    "    credentials:",
+    "      - kind: ssh-username",
+    `        issuer: host:${input.sshHost}`,
+    `        subject: ${input.sshUser}`,
+    ...(typeof uid === "number" ? [
+      "      - kind: unix-uid",
+      `        issuer: host:${os.hostname()}`,
+      `        subject: ${uid}`
+    ] : []),
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    "  - roleId: maintainer",
+    "    commandClasses: [repo-write, repo-read]",
+    "  - roleId: observer",
+    "    commandClasses: [repo-read]",
+    "  - roleId: arbiter",
+    "    commandClasses: [arbiter, repo-write, repo-read]",
+    ""
+  ].join("\n"), "utf8");
+}
+
+function installCanonicalPreReceiveHook(rootDir: string): void {
+  const hookPath = path.join(rootDir, ".git/hooks/pre-receive");
+  mkdirSync(path.dirname(hookPath), { recursive: true });
+  const tokenDir = path.join(rootDir, ".harness/server");
+  const tokenPath = path.join(tokenDir, "daemon-push-token");
+  mkdirSync(tokenDir, { recursive: true, mode: 0o700 });
+  if (!existsSync(tokenPath)) {
+    writeFileSync(tokenPath, `${randomBytes(24).toString("hex")}\n`, { encoding: "utf8", mode: 0o600 });
+  }
+  writeFileSync(hookPath, readFileSync(daemonAssetPath("git-hooks/pre-receive-daemon-only.sh"), "utf8"), { encoding: "utf8", mode: 0o755 });
+  chmodSync(hookPath, 0o755);
+}
+
+function ensureReadonlyMirror(canonicalRoot: string, mirrorRoot: string): Record<string, unknown> {
+  mkdirSync(path.dirname(mirrorRoot), { recursive: true });
+  if (!existsSync(mirrorRoot)) {
+    runGit(path.dirname(mirrorRoot), ["clone", "--mirror", canonicalRoot, mirrorRoot]);
+  } else if (!existsSync(path.join(mirrorRoot, "HEAD"))) {
+    throw new Error(`readonly mirror path exists but is not a bare git repository: ${mirrorRoot}`);
+  } else {
+    runGit(mirrorRoot, ["fetch", "--prune", canonicalRoot, "+refs/heads/*:refs/heads/*"]);
+  }
+  const hookPath = path.join(mirrorRoot, "hooks/pre-receive");
+  writeFileSync(hookPath, readFileSync(daemonAssetPath("git-hooks/pre-receive-readonly-mirror.sh"), "utf8"), { encoding: "utf8", mode: 0o755 });
+  chmodSync(hookPath, 0o755);
+  return { path: mirrorRoot, sync: "git fetch", hookPath };
+}
+
+async function startBootstrapDaemon(rootDir: string): Promise<Record<string, unknown>> {
+  const child = spawn(process.execPath, [
+    ...process.execArgv,
+    cliEntrypointPath(),
+    "--root",
+    rootDir,
+    "daemon",
+    "serve",
+    "--socket",
+    localDaemonSocketPath(rootDir),
+    "--idle-ms",
+    "0"
+  ], {
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env, HARNESS_DAEMON_MODE: "direct" }
+  });
+  child.unref();
+  return waitForReachableStatus(rootDir, 6_000);
+}
+
+async function checkSshReachability(host: string, user: string, canonicalRoot: string): Promise<Record<string, unknown>> {
+  const target = host.includes("@") ? host : `${user}@${host}`;
+  const child = spawn("ssh", [
+    "-o",
+    "BatchMode=yes",
+    target,
+    "test",
+    "-d",
+    canonicalRoot
+  ], { stdio: "ignore" });
+  const exitCode = await new Promise<number | null>((resolve) => child.once("exit", resolve));
+  return { checked: true, ok: exitCode === 0, target, exitCode };
+}
+
+function readDaemonLock(lockPath: string): Record<string, unknown> {
+  if (!existsSync(lockPath)) return { started: false, lockPath };
+  const lock = JSON.parse(readFileSync(lockPath, "utf8")) as {
+    readonly pid?: unknown;
+    readonly hostname?: unknown;
+    readonly heartbeatAt?: unknown;
+    readonly ownerKind?: unknown;
+    readonly ownerToken?: unknown;
+  };
+  return {
+    started: lock.ownerKind === "daemon",
+    lockPath,
+    pid: lock.pid,
+    hostname: lock.hostname,
+    heartbeatAt: lock.heartbeatAt,
+    ownerKind: lock.ownerKind,
+    ownerToken: lock.ownerToken
+  };
+}
+
+async function readReachableDaemonStatus(rootDir: string): Promise<Record<string, unknown> | undefined> {
+  try {
+    const receipt = await requestLocalDaemonJsonRpc(rootDir, "repo.daemon.status", { repo: { repoId: "canonical" } });
+    const details = isDaemonRecord(receipt.details) ? receipt.details : {};
+    const data = isDaemonRecord(details.data) ? details.data : undefined;
+    return receipt.ok === true && data ? data : { rpcError: receipt };
+  } catch {
+    return undefined;
+  }
+}
+
+async function waitForReachableStatus(rootDir: string, timeoutMs: number): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    const status = await readReachableDaemonStatus(rootDir);
+    if (status) return status;
+    await waitDaemonPollInterval(100);
+  }
+  throw new Error("daemon service did not become reachable before timeout");
+}
+
+async function waitForStopped(lockPath: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (!readDaemonLock(lockPath).started) return true;
+    await waitDaemonPollInterval(100);
+  }
+  return !readDaemonLock(lockPath).started;
+}
+
+function emitDaemonResult(command: string, result: Record<string, unknown>, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify({ ok: true, schema: "daemon-command/v1", command, ...result }));
+    return;
+  }
+  const parts = [`ok`, `command=${command}`];
+  for (const key of ["started", "reachable", "mode", "queueDepth", "version", "protocolVersion", "pid", "drained", "stopped", "reportPath", "outputDir"] as const) {
+    if (result[key] !== undefined) parts.push(`${key}=${JSON.stringify(result[key])}`);
+  }
+  if (typeof result.lockPath === "string") parts.push(`lock=${result.lockPath}`);
+  console.log(parts.join(" "));
+}
+
+function emitDaemonError(message: string, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify({ ok: false, schema: "daemon-command/v1", command: "daemon", error: cliError(CliErrorCode.JournalUnavailable, message) }));
+    return;
+  }
+  console.error(`error code=${CliErrorCode.JournalUnavailable} hint=${message}`);
+}
+
+function renderDaemonHelp(): string {
+  return [
+    "Usage: harness-anything daemon <start|status|stop|bootstrap-server|install-templates> [options]",
+    "Alias: ha daemon <subcommand> [options]",
+    "",
+    "Commands:",
+    "  start --service              Start a detached local daemon service (default).",
+    "  start --foreground           Run the daemon service in the foreground.",
+    "  status --json                Show lock holder, queue depth, connections, and version.",
+    "  stop [--timeout-ms <ms>]     Signal the daemon and wait for queue drain and lock release.",
+    "  bootstrap-server             Initialize a canonical team server repository.",
+    "  install-templates --out DIR  Copy systemd, launchd, and Windows Service templates."
+  ].join("\n");
+}
+
+function requiredOption(args: ReadonlyArray<string>, name: string): string {
+  const value = readOption(args, name);
+  if (!value || value.startsWith("--")) throw new Error(`Use ${name} <value>.`);
+  return value;
+}
+
+function runGit(cwd: string, args: ReadonlyArray<string>): void {
+  try {
+    execFileSync("git", [...args], { cwd, stdio: "ignore" });
+  } catch {
+    throw new Error(`git ${args.join(" ")} failed in ${cwd}`);
+  }
+}
+
+function cliEntrypointPath(): string {
+  return realpathSync(fileURLToPath(new URL("../../index.ts", import.meta.url)));
+}
+
+function daemonAssetPath(relativePath: string): string {
+  const candidates = [
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), "assets", relativePath),
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../daemon/assets", relativePath)
+  ];
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (!found) throw new Error(`daemon asset not found: ${relativePath}`);
+  return found;
+}
+
+function safeId(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/gu, "_").replace(/^_+|_+$/gu, "") || "user";
+}
+
+function waitDaemonPollInterval(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isDaemonRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function toJsonValue(value: unknown): JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.map(toJsonValue);
+  if (!isDaemonRecord(value)) return String(value);
+  return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, toJsonValue(entry)])) as JsonObject;
+}

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -69,6 +69,22 @@ export function localDaemonSocketPath(rootDir: string): string {
   return defaultUnixSocketPath(daemonIdForRoot(rootDir));
 }
 
+export async function requestLocalDaemonJsonRpc(
+  rootDir: string,
+  method: string,
+  params: JsonObject,
+  timeoutMs = 1_000
+): Promise<JsonObject> {
+  const socket = await connectUnixSocket(localDaemonSocketPath(rootDir), timeoutMs);
+  const client = new JsonRpcLineClient(socket, socket);
+  try {
+    await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion });
+    return await client.request(method, params);
+  } finally {
+    client.close();
+  }
+}
+
 async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfig): Promise<CommandReceipt | CommandFailureReceipt> {
   const endpoint = localDaemonSocketPath(command.rootDir);
   const deadline = Date.now() + config.autostartTimeoutMs;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, readFileSync, realpathSync } from "node:fs";
-import path from "node:path";
+import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { cliError, CliErrorCode } from "./cli/error-codes.ts";
 import { parseArgs } from "./cli/parse-args.ts";
@@ -13,13 +12,19 @@ import {
   serveSshExecBridge,
   type DaemonAuthenticationContext
 } from "../../daemon/src/index.ts";
-import { createHarnessRuntimeContext, resolveHarnessLayout } from "../../kernel/src/index.ts";
 import { receiptDetailsData, renderReceiptText, toCommandReceipt, type CommandFailureReceipt, type CommandReceipt } from "./cli/receipt.ts";
 import type { CommandRegistryEntry } from "./cli/types.ts";
 import { parsePositiveIntegerOr } from "./cli/value-utils.ts";
+import {
+  daemonStatusPayload,
+  loadDaemonIdentity,
+  runDaemonProductCommand,
+  type DaemonConnectionStats,
+  type DaemonServeHooks
+} from "./commands/daemon/productization.ts";
 import { runRegisteredCommandWithCliComposition } from "./composition/command-executor.ts";
 import { selectCliAdapterProvider } from "./composition/adapter-registry.ts";
-import { runCommandThroughDaemon } from "./daemon/client.ts";
+import { localDaemonSocketPath, runCommandThroughDaemon } from "./daemon/client.ts";
 import { createCliCommandService } from "./daemon/command-service.ts";
 import { makeDaemonQueuedWriteCoordinator } from "./daemon/queued-write-coordinator.ts";
 
@@ -49,87 +54,67 @@ async function maybeRunDaemonCommand(argv: ReadonlyArray<string>): Promise<numbe
   if (stripped.args[0] !== "daemon") return undefined;
   const action = stripped.args[1] ?? "status";
   const layoutOverrides = stripped.authoredRoot ? { authoredRoot: stripped.authoredRoot } : undefined;
-  const runtimeContext = createHarnessRuntimeContext(stripped.rootDir, layoutOverrides);
-  const layout = resolveHarnessLayout(runtimeContext);
-  const lockPath = path.join(layout.locksRoot, "global.lock");
-  try {
-    if (action === "serve") {
-      await runDaemonServe(stripped.rootDir, layoutOverrides, stripped.args);
-      return 0;
-    }
-    if (action === "start") {
-      const foreground = stripped.args.includes("--foreground");
-      const runtime = createDaemonRuntime({
-        rootDir: stripped.rootDir,
-        layoutOverrides,
-        materializerPollMs: foreground ? 5_000 : false
-      });
-      const status = await runtime.start();
-      emitDaemonResult("daemon-start", {
-        ...status,
-        mode: foreground ? "foreground" : "oneshot",
-        guidance: "submit writes through the daemon-backed ha client/API; legacy direct WriteCoordinator writes fail closed while this lock is held"
-      }, stripped.json);
-      if (!foreground) {
-        await runtime.stop();
-        return 0;
-      }
-      await waitForStopSignal();
-      await runtime.stop();
-      return 0;
-    }
-    if (action === "status") {
-      emitDaemonResult("daemon-status", readDaemonLock(lockPath), stripped.json);
-      return 0;
-    }
-    if (action === "stop") {
-      const status = readDaemonLock(lockPath);
-      if (status.started && typeof status.pid === "number") {
-        process.kill(status.pid, "SIGTERM");
-      }
-      emitDaemonResult("daemon-stop", { ...status, signaled: status.started }, stripped.json);
-      return 0;
-    }
-    emitDaemonError(`unknown daemon command: ${action}`, stripped.json, CliErrorCode.UnknownCommand);
-    return 2;
-  } catch (error) {
-    emitDaemonError(error instanceof Error ? error.message : String(error), stripped.json, CliErrorCode.JournalUnavailable);
-    return 1;
+  if (action === "serve") {
+    await runDaemonServe(stripped.rootDir, layoutOverrides, stripped.args);
+    return 0;
   }
+  return runDaemonProductCommand({
+    rootDir: stripped.rootDir,
+    layoutOverrides,
+    json: stripped.json,
+    args: stripped.args,
+    runServe: runDaemonServe
+  });
 }
 
 async function runDaemonServe(
   rootDir: string,
   layoutOverrides: { readonly authoredRoot?: string } | undefined,
-  args: ReadonlyArray<string>
+  args: ReadonlyArray<string>,
+  hooks: DaemonServeHooks = {}
 ): Promise<void> {
   const runtime = createDaemonRuntime({
     rootDir,
     layoutOverrides,
-    materializerPollMs: false
+    materializerPollMs: 5_000
   });
   await runtime.start();
   const repoId = readOption(args, "--repo") ?? "canonical";
   const idleMs = parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true });
-  const serviceHost = createDaemonServiceHost(runtime, rootDir, layoutOverrides, repoId, idleMs);
-  if (args.includes("--stdio")) {
+  const stdio = args.includes("--stdio");
+  const socketPath = readOption(args, "--socket") ?? localDaemonSocketPath(rootDir);
+  const endpoint = stdio ? "stdio" : socketPath;
+  const connections: DaemonConnectionStats = { active: 0, total: 0 };
+  const serviceHost = createDaemonServiceHost(runtime, rootDir, layoutOverrides, repoId, idleMs, endpoint, connections);
+  if (stdio) {
+    connections.active += 1;
+    connections.total += 1;
+    hooks.onStarted?.(serviceHost.status());
     serveSshExecBridge({
       username: process.env.USER,
       host: process.env.HOSTNAME,
       createProtocolServer: serviceHost.createProtocolServer
     });
     await waitForInputEnd();
+    connections.active = Math.max(0, connections.active - 1);
     await serviceHost.stop();
     return;
   }
 
-  const socketPath = readOption(args, "--socket");
   const transport = createUnixSocketTransportServer({
     daemonId: serviceHost.daemonId,
-    ...(socketPath ? { socketPath } : {}),
-    createProtocolServer: serviceHost.createProtocolServer
+    socketPath,
+    createProtocolServer: serviceHost.createProtocolServer,
+    onConnection: () => {
+      connections.active += 1;
+      connections.total += 1;
+    },
+    onConnectionClosed: () => {
+      connections.active = Math.max(0, connections.active - 1);
+    }
   });
   await transport.start();
+  hooks.onStarted?.(serviceHost.status());
   serviceHost.onStop(async () => {
     await transport.stop();
   });
@@ -143,16 +128,20 @@ function createDaemonServiceHost(
   rootDir: string,
   layoutOverrides: { readonly authoredRoot?: string } | undefined,
   repoId: string,
-  idleMs: number
+  idleMs: number,
+  endpoint: string,
+  connections: DaemonConnectionStats
 ): {
   readonly daemonId: string;
   readonly createProtocolServer: (authContext: DaemonAuthenticationContext) => ReturnType<typeof createJsonRpcProtocolServer>;
+  readonly status: () => Record<string, unknown>;
   readonly scheduleIdleExit: () => void;
   readonly waitForStopRequest: () => Promise<void>;
   readonly onStop: (handler: () => Promise<void>) => void;
   readonly stop: () => Promise<void>;
 } {
   const daemonId = `ha-${process.pid}`;
+  const identity = loadDaemonIdentity(rootDir, layoutOverrides);
   const stopHandlers: Array<() => Promise<void>> = [];
   let requestStop: (() => void) | undefined;
   const stopRequested = new Promise<void>((resolve) => {
@@ -195,14 +184,36 @@ function createDaemonServiceHost(
   });
   return {
     daemonId,
-    createProtocolServer: (_authContext) => createJsonRpcProtocolServer({
+    createProtocolServer: (authContext) => createJsonRpcProtocolServer({
       daemonId,
       repos: [{ repoId, canonicalRoot: rootDir }],
       services: {
         LocalControllerService: localController,
         TerminalSessionService: makeUnavailableTerminalSessionService(),
+        DaemonStatusService: {
+          getStatus: () => daemonStatusPayload({
+            daemonId,
+            rootDir,
+            repoId,
+            endpoint,
+            runtimeStatus: runtime.status(),
+            connections
+          })
+        },
         CliCommandService: cliCommandService
-      }
+      },
+      authContext,
+      ...(identity.identityProvider ? { identityProvider: identity.identityProvider } : {}),
+      ...(identity.peopleRoster ? { peopleRoster: identity.peopleRoster } : {}),
+      ...(identity.appendRuntimeEvent ? { appendRuntimeEvent: identity.appendRuntimeEvent } : {})
+    }),
+    status: () => daemonStatusPayload({
+      daemonId,
+      rootDir,
+      repoId,
+      endpoint,
+      runtimeStatus: runtime.status(),
+      connections
     }),
     scheduleIdleExit,
     waitForStopRequest: () => stopRequested,
@@ -211,48 +222,6 @@ function createDaemonServiceHost(
     },
     stop
   };
-}
-
-function readDaemonLock(lockPath: string): Record<string, unknown> {
-  if (!existsSync(lockPath)) {
-    return { started: false, lockPath };
-  }
-  const lock = JSON.parse(readFileSync(lockPath, "utf8")) as {
-    readonly pid?: unknown;
-    readonly hostname?: unknown;
-    readonly heartbeatAt?: unknown;
-    readonly ownerKind?: unknown;
-  };
-  return {
-    started: lock.ownerKind === "daemon",
-    lockPath,
-    pid: lock.pid,
-    hostname: lock.hostname,
-    heartbeatAt: lock.heartbeatAt,
-    ownerKind: lock.ownerKind
-  };
-}
-
-function emitDaemonResult(command: string, result: Record<string, unknown>, json: boolean): void {
-  if (json) {
-    console.log(JSON.stringify({ ok: true, schema: "daemon-command/v1", command, ...result }));
-    return;
-  }
-  const parts = [`ok`, `command=${command}`];
-  if (typeof result.started === "boolean") parts.push(`started=${String(result.started)}`);
-  if (typeof result.mode === "string") parts.push(`mode=${result.mode}`);
-  if (typeof result.lockPath === "string") parts.push(`lock=${result.lockPath}`);
-  if (typeof result.pid === "number") parts.push(`pid=${String(result.pid)}`);
-  if (typeof result.guidance === "string") parts.push(`guidance=${JSON.stringify(result.guidance)}`);
-  console.log(parts.join(" "));
-}
-
-function emitDaemonError(message: string, json: boolean, code: CliErrorCode): void {
-  if (json) {
-    console.log(JSON.stringify({ ok: false, schema: "daemon-command/v1", command: "daemon", error: { code, hint: message } }));
-    return;
-  }
-  console.error(`error code=${code} hint=${message}`);
 }
 
 async function waitForStopSignal(): Promise<void> {

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFile, execFileSync } from "node:child_process";
+import { execFile, execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -48,6 +48,105 @@ test("concurrent daemon client startup converges on one lock owner and both clie
     const status = runDaemonCommand(rootDir, ["daemon", "status", "--json"]);
     assert.equal(status.started, true);
     assert.equal(typeof status.pid, "number");
+  });
+});
+
+test("daemon start service status and stop expose productized status contract", () => {
+  withTempRoot((rootDir) => {
+    try {
+      const start = runDaemonCommand(rootDir, ["daemon", "start", "--service", "--json"]);
+      assert.equal(start.started, true);
+      assert.equal(start.mode, "service");
+      assert.equal(start.version, "0.0.0");
+      assert.equal(typeof start.queueDepth, "number");
+
+      const status = runDaemonCommand(rootDir, ["daemon", "status", "--json"]);
+      assert.equal(status.started, true);
+      assert.equal(status.reachable, true);
+      assert.equal(typeof status.pid, "number");
+      assert.equal(status.version, "0.0.0");
+      assert.equal(status.protocolVersion, 1);
+      assert.equal(typeof status.queueDepth, "number");
+      assert.equal(isRecord(status.queue), true);
+      assert.equal(isRecord(status.connections), true);
+
+      const stop = runDaemonCommand(rootDir, ["daemon", "stop", "--timeout-ms", "5000", "--json"]);
+      assert.equal(stop.signaled, true);
+      assert.equal(stop.drained, true);
+      assert.equal(stop.stopped, true);
+    } finally {
+      try {
+        runDaemonCommand(rootDir, ["daemon", "stop", "--timeout-ms", "1000", "--json"]);
+      } catch {
+        // best-effort cleanup for failed assertions
+      }
+    }
+  });
+});
+
+test("daemon install-templates distributes three platform service templates", () => {
+  withTempRoot((rootDir) => {
+    const outDir = path.join(rootDir, "templates");
+    const result = runDaemonCommand(rootDir, ["daemon", "install-templates", "--out", outDir, "--json"]);
+    assert.equal(result.ok, true);
+    assert.equal(existsSync(path.join(outDir, "harness-anything-daemon.service")), true);
+    assert.equal(existsSync(path.join(outDir, "com.harness-anything.daemon.plist")), true);
+    assert.equal(existsSync(path.join(outDir, "install-harness-anything-daemon.ps1")), true);
+  });
+});
+
+test("daemon bootstrap-server is idempotent and installs roster hooks and read-only mirror", () => {
+  withTempRoot((rootDir) => {
+    const canonicalRoot = path.join(rootDir, "canonical");
+    const mirrorRoot = path.join(rootDir, "readonly.git");
+    const reportPath = path.join(rootDir, "bootstrap-report.json");
+    const args = [
+      "daemon",
+      "bootstrap-server",
+      "--canonical-root",
+      canonicalRoot,
+      "--ssh-host",
+      "team-host",
+      "--ssh-user",
+      "alice",
+      "--person-id",
+      "person_alice",
+      "--display-name",
+      "Alice Admin",
+      "--email",
+      "alice@example.com",
+      "--readonly-mirror",
+      mirrorRoot,
+      "--report",
+      reportPath,
+      "--skip-ssh-check",
+      "--no-start",
+      "--json"
+    ];
+    const first = runDaemonCommand(rootDir, args);
+    const second = runDaemonCommand(rootDir, args);
+
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+    assert.equal(existsSync(path.join(canonicalRoot, "harness/people.yaml")), true);
+    assert.match(readFileSync(path.join(canonicalRoot, "harness/people.yaml"), "utf8"), /person_alice/u);
+    assert.equal(existsSync(path.join(canonicalRoot, ".git/hooks/pre-receive")), true);
+    assert.equal(existsSync(path.join(mirrorRoot, "hooks/pre-receive")), true);
+    assert.equal(existsSync(reportPath), true);
+
+    const canonicalHook = spawnSync(path.join(canonicalRoot, ".git/hooks/pre-receive"), {
+      cwd: canonicalRoot,
+      encoding: "utf8"
+    });
+    assert.notEqual(canonicalHook.status, 0);
+    assert.match(canonicalHook.stderr, /rejected this direct push/u);
+
+    const mirrorHook = spawnSync(path.join(mirrorRoot, "hooks/pre-receive"), {
+      cwd: mirrorRoot,
+      encoding: "utf8"
+    });
+    assert.notEqual(mirrorHook.status, 0);
+    assert.match(mirrorHook.stderr, /read-only mirror/u);
   });
 });
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -54,6 +54,7 @@ export type {
   JsonRpcErrorObject,
   JsonRpcId,
   JsonObject,
+  JsonValue,
   JsonRpcRequest,
   JsonRpcResponse,
   JsonRpcSuccessResponse

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -17,6 +17,9 @@ export interface DaemonRepoNamespace {
 export interface DaemonServiceHost {
   readonly LocalControllerService: LocalControllerService;
   readonly TerminalSessionService: TerminalSessionService;
+  readonly DaemonStatusService?: {
+    readonly getStatus: () => JsonObject | Promise<JsonObject>;
+  };
   readonly CliCommandService?: {
     readonly runCommand: (payload?: JsonObject) => Promise<CommandReceipt | CommandFailureReceipt>;
   };
@@ -174,6 +177,12 @@ async function callServiceMethod(
   services: DaemonServiceHost
 ): Promise<ReturnType<typeof successReceipt> | ReturnType<typeof failureReceipt>> {
   const payload = isJsonObject(params.payload) ? params.payload : undefined;
+  if (contract.method === "repo.daemon.status") {
+    if (!services.DaemonStatusService) {
+      return failureReceipt(contract.method, "daemon_status_service_unavailable", "Daemon status service is not configured.");
+    }
+    return successReceipt(contract.method, "read daemon status", await services.DaemonStatusService.getStatus());
+  }
   if (contract.method === "repo.command.run") {
     if (!services.CliCommandService) {
       return failureReceipt(contract.method, "cli_command_service_unavailable", "Daemon command service is not configured.");

--- a/packages/daemon/src/protocol/method-registry.ts
+++ b/packages/daemon/src/protocol/method-registry.ts
@@ -48,6 +48,20 @@ const cliCommandContracts = [
   }
 ] as const satisfies ReadonlyArray<JsonRpcMethodContract>;
 
+const daemonStatusContracts = [
+  {
+    method: "repo.daemon.status",
+    mode: "active",
+    namespace: "repo",
+    inputSchemaId: "daemon.status-request/v1",
+    outputSchemaId: "daemon.status-result/v1",
+    errorSchemaId: "daemon.protocol-error/v1",
+    auth: "local-session-token",
+    requiresRepo: true,
+    commandClass: "repo-read"
+  }
+] as const satisfies ReadonlyArray<JsonRpcMethodContract>;
+
 const notificationStubContracts = [
   {
     method: "repo.notifications.subscribe",
@@ -130,6 +144,7 @@ export const jsonRpcServiceMethodContracts = deriveJsonRpcServiceMethodContracts
 export const jsonRpcMethodContracts = [
   ...protocolMethodContracts,
   ...cliCommandContracts,
+  ...daemonStatusContracts,
   ...jsonRpcServiceMethodContracts,
   ...notificationStubContracts,
   ...adminReservedContracts

--- a/packages/daemon/src/transport/named-pipe.ts
+++ b/packages/daemon/src/transport/named-pipe.ts
@@ -10,6 +10,7 @@ export interface NamedPipeTransportOptions {
   readonly platform?: NodeJS.Platform;
   readonly createProtocolServer: (authContext: DaemonAuthenticationContext) => JsonRpcProtocolServer;
   readonly onConnection?: (connection: DaemonTransportConnection) => void;
+  readonly onConnectionClosed?: (connection: DaemonTransportConnection) => void;
 }
 
 export interface NamedPipeTransportServer {
@@ -56,6 +57,7 @@ export function createNamedPipeTransportServer(options: NamedPipeTransportOption
       createProtocolServer: options.createProtocolServer
     });
     options.onConnection?.(connection);
+    socket.once("close", () => options.onConnectionClosed?.(connection));
   });
 
   return {

--- a/packages/daemon/src/transport/unix-socket.ts
+++ b/packages/daemon/src/transport/unix-socket.ts
@@ -13,6 +13,7 @@ export interface UnixSocketTransportOptions {
   readonly socketPath?: string;
   readonly createProtocolServer: (authContext: DaemonAuthenticationContext) => JsonRpcProtocolServer;
   readonly onConnection?: (connection: DaemonTransportConnection) => void;
+  readonly onConnectionClosed?: (connection: DaemonTransportConnection) => void;
 }
 
 export interface UnixSocketTransportServer {
@@ -42,6 +43,7 @@ export function createUnixSocketTransportServer(options: UnixSocketTransportOpti
       createProtocolServer: options.createProtocolServer
     });
     options.onConnection?.(connection);
+    socket.once("close", () => options.onConnectionClosed?.(connection));
   });
 
   return {


### PR DESCRIPTION
# English

## Summary

Productizes the daemon server mode for W7. This PR adds the service-oriented `ha daemon` lifecycle, server bootstrap, three platform service templates, daemon-only git push hooks, read-only mirror support, and public operations docs.

## What Changed

- Added `ha daemon start/status/stop` product behavior: detached service start, foreground service start, registry-derived daemon status, and stop with drain/lock-release waiting.
- Added `repo.daemon.status` as a `repo-read` JSON-RPC registry method; no separate query channel was introduced.
- Added CLI-distributed service templates for systemd, launchd, and Windows Service registration.
- Added `ha daemon bootstrap-server` for canonical repository setup, initial `people.yaml`, daemon service start, optional SSH reachability check, daemon-only pre-receive hook, optional read-only mirror, and a verifiable bootstrap report.
- Added canonical and mirror pre-receive hooks: canonical rejects non-daemon direct pushes with correct path guidance; mirror rejects all writes while allowing ordinary `git fetch` reads.
- Added English and Chinese `docs-release` operations documentation and tests covering the daemon lifecycle, template install, bootstrap idempotency, and mirror/hook behavior.

## Task And Scope

- Harness task: `task_01KWW581A5B2F6TERVA08R951N`
- Branch: `codex/w7-server-productization`
- Public scope: `packages/cli/src/commands/daemon/**`, daemon protocol registry/status service wiring, service/git-hook assets, daemon operations docs, focused CLI tests.
- Private planning/evidence updated: yes, in `harness/tasks/task_01KWW581A5B2F6TERVA08R951N-plt-daemon-w7-daemon-git-hook/artifacts/orchestration/report-w7.md`.
- Out of scope: kernel daemon runtime author propagation, command-level RBAC derivation inside `repo.command.run`, kernel projection read paths, `runner-registry.ts`, CI workflow/gate tooling.

## Version Impact

- Version: no version change because this is productization of the existing unpublished CLI/package surface for W7.
- Publish impact: publish readiness only; release remains a separate release task.

## Governance Declaration

- Protected surface touched: no manifest-derived protected surface was changed.
- Protected surface scope: not applicable.
- Authority: `task_01KWW581A5B2F6TERVA08R951N`, `dec_mr9acuxm` fail-closed server write surface, and `dec_mr9acscw` SSH-only transport boundary.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no.
- Break-glass reason: not applicable.
- Break-glass scope: not applicable.
- Follow-up governance task: `task_01KWX3WWZJ5J333BW431J7VA8N` for daemon identity integration completion.

## Verification

- Base `origin/main` SHA: `da699d9ed14a381b9e6d42da188af1c8e2888926`
- Branch merge-base with `origin/main`: `da699d9ed14a381b9e6d42da188af1c8e2888926`
- Last `git fetch origin` time: `2026-07-07T02:37:10Z`
- Sync method: rebase onto `origin/main` before final check.
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: harness private commit `edfe9335`; `harness/tasks/task_01KWW581A5B2F6TERVA08R951N-plt-daemon-w7-daemon-git-hook/artifacts/orchestration/report-w7.md`
- Reviewer evidence path: `harness/tasks/task_01KWW581A5B2F6TERVA08R951N-plt-daemon-w7-daemon-git-hook/artifacts/orchestration/report-w7.md`
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28837533618
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` after the final rebase; dependencies were unchanged, and `npm run check` including package smoke passed after rebase.

## Review Evidence

- Self-review: completed against task boundaries and redlines; public diff does not touch `packages/kernel/src/store/**`, `packages/kernel/src/projection/**`, `packages/cli/src/cli/runner-registry.ts`, `tools/check-*`, or CI workflow files.
- Reviewer subagent: not run.
- Human review: pending CEO/reviewer review.
- Blocking findings: none for the W7 productization scope.

## Known Follow-Up Gaps

- RBAC granularity is intentionally not fixed in this PR. Evidence is in `report-w7.md` section `RBAC Checkpoint`: a maintainer with `[repo-write, repo-read]` cannot use ordinary CLI commands over `repo.command.run` because the channel is currently `arbiter`. CEO moved this to follow-up task `task_01KWX3WWZJ5J333BW431J7VA8N`.
- Git author propagation is intentionally not fixed in this PR. Evidence is in `report-w7.md` section `Git Author Attribution Gap`: daemon receipts carry the actor, but the git commit author remains the default Harness author. CEO moved per-request actor propagation and batching semantics to follow-up task `task_01KWX3WWZJ5J333BW431J7VA8N`.

## Arbiter Method List For CEO Confirmation

- JSON-RPC method with `commandClass: arbiter`: `repo.command.run`.
- API route ids derived as `arbiter`: `tasks.status.set`, `tasks.review`.
- New W7 status method is not arbiter: `repo.daemon.status` is `repo-read`.

## Residual Risk

- Windows Service template is shipped with a local PowerShell verification entry, but there is no Windows CI lane for installing/running it.
- SSH remains the only intended remote transport; this PR opens no public daemon port.
- The two identity gaps above are explicit follow-up work, not hidden completion claims.

## References

- Task: `task_01KWW581A5B2F6TERVA08R951N`
- Decisions: `dec_mr9abn9x`, `dec_mr9acuxm`, `dec_mr9acscw`
- Follow-up: `task_01KWX3WWZJ5J333BW431J7VA8N`
- Evidence: `report-w7.md` sections `Daemon Status And Stop`, `Direct Push Rejection`, `RBAC Checkpoint`, and `Git Author Attribution Gap`.

---

# 中文

## 概要

本 PR 完成 W7 daemon 服务器模式产品化：补齐服务态 `ha daemon` 生命周期、服务器引导、三平台服务模板、daemon-only git hook、只读镜像能力，以及公开运维文档。

## 改动内容

- 增加 `ha daemon start/status/stop` 产品行为：后台服务启动、前台服务启动、由 registry 派生的 daemon status、以及等待排空和锁释放的 stop。
- 增加 `repo.daemon.status`，命令类别为 `repo-read`，走既有 JSON-RPC registry；未新增独立查询通道。
- 增加随 CLI 分发的 systemd、launchd、Windows Service 模板。
- 增加 `ha daemon bootstrap-server`，完成 canonical 仓初始化、初始 `people.yaml`、daemon 常驻、可选 SSH 可达性验证、daemon-only pre-receive hook、可选只读镜像，以及可核对的 bootstrap report。
- 增加 canonical 与 mirror 两类 pre-receive hook：canonical 拒绝非 daemon 直推并给出正确路径指引；mirror 拒绝所有写入，但允许普通 `git fetch` 读取。
- 增加中英文 `docs-release` 运维文档，并用测试覆盖 daemon 生命周期、模板安装、bootstrap 幂等、镜像和 hook 行为。

## 任务与范围

- Harness 任务：`task_01KWW581A5B2F6TERVA08R951N`
- 分支：`codex/w7-server-productization`
- 公开范围：`packages/cli/src/commands/daemon/**`、daemon protocol registry/status service wiring、服务和 git hook assets、daemon 运维文档、聚焦 CLI 测试。
- 私有计划 / 证据是否已更新：yes，见 `harness/tasks/task_01KWW581A5B2F6TERVA08R951N-plt-daemon-w7-daemon-git-hook/artifacts/orchestration/report-w7.md`。
- 范围外：kernel daemon runtime author 传播、`repo.command.run` 内部按命令派生 RBAC、kernel projection 读路径、`runner-registry.ts`、CI workflow/gate tooling。

## 版本影响

- 版本：不改版本，因为这是对现有未公开 CLI/package surface 的 W7 产品化补齐。
- 发布影响：只做发布准备；正式发布仍应放到独立 release task。

## 治理声明

- 是否触碰 protected surface：no，未修改 manifest 派生 protected surface。
- protected surface 范围：不适用。
- 依据：`task_01KWW581A5B2F6TERVA08R951N`、`dec_mr9acuxm` fail-closed server write surface、`dec_mr9acscw` 仅 SSH 传输边界。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no。
- Break-glass 原因：不适用。
- Break-glass 范围：不适用。
- 后续治理任务：`task_01KWX3WWZJ5J333BW431J7VA8N`，用于 daemon 身份集成补全。

## 验证

- `origin/main` 基准 SHA：`da699d9ed14a381b9e6d42da188af1c8e2888926`
- 当前分支与 `origin/main` 的 merge-base：`da699d9ed14a381b9e6d42da188af1c8e2888926`
- 最近一次 `git fetch origin` 时间：`2026-07-07T02:37:10Z`
- 同步方式：最终检查前已 rebase 到 `origin/main`。
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：harness private commit `edfe9335`；`harness/tasks/task_01KWW581A5B2F6TERVA08R951N-plt-daemon-w7-daemon-git-hook/artifacts/orchestration/report-w7.md`
- Reviewer 证据路径：`harness/tasks/task_01KWW581A5B2F6TERVA08R951N-plt-daemon-w7-daemon-git-hook/artifacts/orchestration/report-w7.md`
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28837533618
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 未运行：最终 rebase 后未单独运行 `npm ci`；依赖未变，且 rebase 后 `npm run check` 包含 package smoke 已通过。

## 审查证据

- 自查：已按任务边界和红线检查；public diff 未触碰 `packages/kernel/src/store/**`、`packages/kernel/src/projection/**`、`packages/cli/src/cli/runner-registry.ts`、`tools/check-*` 或 CI workflow。
- Reviewer subagent：未运行。
- 人工审查：等待 CEO / reviewer 审查。
- 阻塞发现：W7 产品化范围内无阻塞发现。

## 已知后续 gap

- RBAC 粒度本 PR 不修。证据见 `report-w7.md` 的 `RBAC Checkpoint` 节：具备 `[repo-write, repo-read]` 的 maintainer 通过 `repo.command.run` 使用普通 CLI 命令会被拒绝，因为该通道当前是 `arbiter`。CEO 已将修复移动到 follow-up 任务 `task_01KWX3WWZJ5J333BW431J7VA8N`。
- Git author 传播本 PR 不修。证据见 `report-w7.md` 的 `Git Author Attribution Gap` 节：daemon receipt 已携带 actor，但 git commit author 仍是默认 Harness author。CEO 已将 per-request actor 传播和批处理 author 语义移动到 follow-up 任务 `task_01KWX3WWZJ5J333BW431J7VA8N`。

## Arbiter 方法清单，供 CEO 确认

- `commandClass: arbiter` 的 JSON-RPC method：`repo.command.run`。
- 派生为 `arbiter` 的 API route id：`tasks.status.set`、`tasks.review`。
- W7 新增 status 方法不是 arbiter：`repo.daemon.status` 是 `repo-read`。

## 残余风险

- Windows Service 模板提供本地 PowerShell 验证入口，但当前没有 Windows CI lane 安装并运行它。
- SSH 仍是唯一预期远程传输；本 PR 不开放公网 daemon 端口。
- 上述两个身份 gap 是明确 follow-up，不作为本 PR 完成声明隐藏。

## 关联材料

- 任务：`task_01KWW581A5B2F6TERVA08R951N`
- 裁决：`dec_mr9abn9x`、`dec_mr9acuxm`、`dec_mr9acscw`
- Follow-up：`task_01KWX3WWZJ5J333BW431J7VA8N`
- 证据：`report-w7.md` 的 `Daemon Status And Stop`、`Direct Push Rejection`、`RBAC Checkpoint`、`Git Author Attribution Gap` 各节。



