### PR TITLE
feat(daemon): command-level RBAC derivation + per-request git author (D2 completion)

### DIFF
--- a/packages/cli/src/daemon/command-service.ts
+++ b/packages/cli/src/daemon/command-service.ts
@@ -1,4 +1,4 @@
-import type { JsonObject } from "../../../daemon/src/index.ts";
+import { actorGitCommitAuthor, type AuthenticatedActor, type JsonObject } from "../../../daemon/src/index.ts";
 import { toCommandReceipt, type CommandFailureReceipt, type CommandReceipt } from "../cli/receipt.ts";
 import type { ParsedCommand } from "../cli/types.ts";
 import { isPlainRecord } from "../cli/value-utils.ts";
@@ -6,7 +6,7 @@ import { runRegisteredCommandWithCliComposition } from "../composition/command-e
 import { makeDaemonQueuedWriteCoordinator, type CliDaemonRuntime } from "./queued-write-coordinator.ts";
 
 export interface CliCommandService {
-  readonly runCommand: (payload?: JsonObject) => Promise<CommandReceipt | CommandFailureReceipt>;
+  readonly runCommand: (payload?: JsonObject, context?: { readonly actor?: AuthenticatedActor }) => Promise<CommandReceipt | CommandFailureReceipt>;
 }
 
 export interface CliCommandServiceOptions {
@@ -16,14 +16,21 @@ export interface CliCommandServiceOptions {
 
 export function createCliCommandService(runtime: CliDaemonRuntime, options: CliCommandServiceOptions = {}): CliCommandService {
   return {
-    runCommand: async (payload) => {
+    runCommand: async (payload, context) => {
       options.onCommandStart?.();
       const command = readParsedCommandPayload(payload);
+      const daemonActor = context?.actor;
       try {
         const result = await runRegisteredCommandWithCliComposition(command, {
           makeWriteCoordinator: (actor) => makeDaemonQueuedWriteCoordinator(
             runtime,
-            `${command.action.kind}:${actor.kind}:${actor.id}`
+            `${command.action.kind}:${actor.kind}:${actor.id}`,
+            daemonActor
+              ? {
+                actor: { kind: "human", id: daemonActor.personId },
+                commitAuthor: actorGitCommitAuthor(daemonActor, "harness@example.invalid")
+              }
+              : undefined
           )
         });
         return toCommandReceipt(result);

--- a/packages/cli/src/daemon/queued-write-coordinator.ts
+++ b/packages/cli/src/daemon/queued-write-coordinator.ts
@@ -2,11 +2,21 @@ import { Effect } from "effect";
 import type { FlushReport, RecoveryReport, WriteCoordinator, WriteError } from "../../../kernel/src/index.ts";
 
 type QueuedWriteOp = Parameters<WriteCoordinator["enqueue"]>[0];
+interface QueuedJournalActor {
+  readonly kind: "agent" | "human" | "system";
+  readonly id: string;
+}
+interface QueuedGitCommitAuthor {
+  readonly name: string;
+  readonly email: string;
+}
 
 export interface CliDaemonRuntime {
   readonly enqueueInteractiveWrite: (request: {
     readonly commandId: string;
     readonly ops: ReadonlyArray<QueuedWriteOp>;
+    readonly actor?: QueuedJournalActor;
+    readonly commitAuthor?: QueuedGitCommitAuthor;
   }) => Promise<{
     readonly flush: FlushReport;
   }>;
@@ -17,7 +27,8 @@ export interface CliDaemonRuntime {
 
 export function makeDaemonQueuedWriteCoordinator(
   runtime: CliDaemonRuntime,
-  commandId: string
+  commandId: string,
+  options: { readonly actor?: QueuedJournalActor; readonly commitAuthor?: QueuedGitCommitAuthor } = {}
 ): WriteCoordinator {
   const pending: Array<QueuedWriteOp> = [];
   return {
@@ -33,7 +44,9 @@ export function makeDaemonQueuedWriteCoordinator(
         const ops = pending.splice(0, pending.length);
         const receipt = await runtime.enqueueInteractiveWrite({
           commandId,
-          ops
+          ops,
+          ...(options.actor ? { actor: options.actor } : {}),
+          ...(options.commitAuthor ? { commitAuthor: options.commitAuthor } : {})
         });
         return receipt.flush;
       },

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile, execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
@@ -31,6 +31,59 @@ test("daemon client auto-starts, durably writes, and exits after idle", () => {
     sleep(700);
     const status = runDaemonCommand(rootDir, ["daemon", "status", "--json"]);
     assert.equal(status.started, false);
+  });
+});
+
+test("daemon client applies command-level RBAC to inner CLI commands", () => {
+  withTempRoot((rootDir) => {
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
+    writePeopleRoster(rootDir, {
+      personId: "person_maint",
+      displayName: "Maintainer User",
+      email: "maintainer@example.test",
+      role: "maintainer"
+    });
+
+    const read = runRawJson(rootDir, ["version"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "250" });
+    assert.equal(read.ok, true);
+
+    const write = runRawJson(rootDir, ["new-task", "--title", "Maintainer Daemon Write"], {
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_IDLE_MS: "250"
+    });
+    assert.equal(write.ok, true);
+
+    const arbiter = runRawJsonMaybeFail(rootDir, ["decision", "accept", "dec_missing", "--judgment-only", "manual arbiter probe"], {
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_IDLE_MS: "250"
+    });
+    assert.notEqual(arbiter.status, 0);
+    assert.equal(arbiter.receipt.ok, false);
+    assert.deepEqual((arbiter.receipt.error as { code?: string }).code, "rbac_forbidden");
+    assert.equal(((arbiter.receipt.details as Record<string, unknown>).actor as { personId?: string }).personId, "person_maint");
+    assert.equal((arbiter.receipt.details as Record<string, unknown>).commandClass, "arbiter");
+  });
+});
+
+test("daemon client writes git commits with the resolved actor author", () => {
+  withTempRoot((rootDir) => {
+    initGitRepo(rootDir);
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
+    writePeopleRoster(rootDir, {
+      personId: "person_owner",
+      displayName: "Owner User",
+      email: "owner@example.test",
+      role: "owner"
+    });
+
+    const receipt = runRawJson(rootDir, ["new-task", "--title", "Owner Author Attribution"], {
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_IDLE_MS: "250"
+    });
+
+    assert.equal(receipt.ok, true);
+    assert.equal(((receipt.details as Record<string, unknown>).actor as { personId?: string }).personId, "person_owner");
+    assert.equal(git(rootDir, "log", "-1", "--pretty=format:%an <%ae>"), "Owner User <owner@example.test>");
   });
 });
 
@@ -176,6 +229,22 @@ function runRawJson(rootDir: string, args: ReadonlyArray<string>, env: Readonly<
   return JSON.parse(stdout) as Record<string, unknown>;
 }
 
+function runRawJsonMaybeFail(
+  rootDir: string,
+  args: ReadonlyArray<string>,
+  env: Readonly<Record<string, string>> = {}
+): { readonly status: number | null; readonly receipt: Record<string, unknown> } {
+  const result = spawnSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...env }
+  });
+  assert.equal(result.stderr, "");
+  return {
+    status: result.status,
+    receipt: JSON.parse(result.stdout) as Record<string, unknown>
+  };
+}
+
 async function runRawJsonAsync(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Promise<Record<string, unknown>> {
   const { stdout } = await execFileAsync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
@@ -203,6 +272,47 @@ function normalizeVolatileReceipt(receipt: Record<string, unknown>): Record<stri
 
 function sleep(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function initGitRepo(rootDir: string): void {
+  execFileSync("git", ["-C", rootDir, "init", "-b", "master"], { stdio: "ignore" });
+  execFileSync("git", ["-C", rootDir, "config", "user.name", "Harness Test"], { stdio: "ignore" });
+  execFileSync("git", ["-C", rootDir, "config", "user.email", "harness@example.test"], { stdio: "ignore" });
+}
+
+function git(rootDir: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+function writePeopleRoster(rootDir: string, person: {
+  readonly personId: string;
+  readonly displayName: string;
+  readonly email: string;
+  readonly role: "owner" | "maintainer";
+}): void {
+  const harnessRoot = path.join(rootDir, "harness");
+  mkdirSync(harnessRoot, { recursive: true });
+  writeFileSync(path.join(harnessRoot, "people.yaml"), [
+    "schema: harness-people/v1",
+    "people:",
+    `  - personId: ${person.personId}`,
+    `    displayName: ${person.displayName}`,
+    `    primaryEmail: ${person.email}`,
+    `    roles: [${person.role}]`,
+    "    credentials:",
+    "      - kind: unix-uid",
+    `        issuer: host:${hostname()}`,
+    `        subject: ${process.getuid?.() ?? 0}`,
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    "  - roleId: maintainer",
+    "    commandClasses: [repo-write, repo-read]",
+    ""
+  ].join("\n"), "utf8");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -36,9 +36,12 @@ export {
 export {
   currentDaemonProtocolVersion,
   commandClassForApiRoute,
+  commandClassForCliCommandPayload,
+  commandClassForJsonRpcRequest,
   deriveJsonRpcServiceMethodContracts,
   jsonRpcMethodContracts,
   jsonRpcServiceMethodContracts,
+  repoCommandRunClassifiedActionKinds,
   type DaemonCommandClass as JsonRpcDaemonCommandClass,
   type JsonRpcMethodContract,
   type JsonRpcMethodMode

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -2,7 +2,7 @@
 import type { CommandFailureReceipt, CommandReceipt, LocalControllerService } from "../../../application/src/index.ts";
 import type { RuntimeEventAppendInput } from "../../../application/src/runtime-event-ledger-service.ts";
 import type { TerminalSessionService } from "../../../gui/src/terminal/session-registry.ts";
-import { currentDaemonProtocolVersion, jsonRpcMethodContracts, type JsonRpcMethodContract } from "./method-registry.ts";
+import { commandClassForJsonRpcRequest, currentDaemonProtocolVersion, jsonRpcMethodContracts, type JsonRpcMethodContract } from "./method-registry.ts";
 import { failureReceipt, serviceResultReceipt, successReceipt } from "./receipt-envelope.ts";
 import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse, type JsonValue } from "./json-rpc-types.ts";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
@@ -21,7 +21,7 @@ export interface DaemonServiceHost {
     readonly getStatus: () => JsonObject | Promise<JsonObject>;
   };
   readonly CliCommandService?: {
-    readonly runCommand: (payload?: JsonObject) => Promise<CommandReceipt | CommandFailureReceipt>;
+    readonly runCommand: (payload?: JsonObject, context?: { readonly actor?: AuthenticatedActor }) => Promise<CommandReceipt | CommandFailureReceipt>;
   };
 }
 
@@ -88,26 +88,28 @@ async function handleRequest(
     return response(failureReceipt(request.method, "method_reserved", `Method namespace is reserved for future admin API: ${request.method}.`));
   }
 
-  const repoFailure = validateRepoNamespace(contract, request.params ?? {}, repos);
+  const params = request.params ?? {};
+  const repoFailure = validateRepoNamespace(contract, params, repos);
   if (repoFailure) return response(failureReceipt(request.method, repoFailure.code, repoFailure.hint));
+  const effectiveContract = withEffectiveCommandClass(contract, params);
 
-  const actorResult = await resolveActor(contract, options);
+  const actorResult = await resolveActor(effectiveContract, options);
   if (actorResult && !actorResult.ok) {
     const receipt = failureReceipt(request.method, actorResult.code, actorResult.message, {
       providerId: actorResult.providerId,
       ...(actorResult.credential ? { credential: credentialJson(actorResult.credential) } : {})
     });
-    await appendCommandEvent(options, request.params ?? {}, contract, "failed", actorResult.message, actorResult.code);
+    await appendCommandEvent(options, params, effectiveContract, "failed", actorResult.message, actorResult.code);
     return response(receipt);
   }
   const actor = actorResult?.actor;
   if (actor && options.peopleRoster) {
-    const authz = authorizeActorForMethod(actor, contract, options.peopleRoster);
+    const authz = authorizeActorForMethod(actor, effectiveContract, options.peopleRoster);
     if (!authz.ok) {
-      await appendCommandEvent(options, request.params ?? {}, contract, "failed", authz.message, authz.code, actor);
+      await appendCommandEvent(options, params, effectiveContract, "failed", authz.message, authz.code, actor);
       return response(stampReceipt(failureReceipt(request.method, authz.code, authz.message, {
         actor: actorStampJson(actor),
-        commandClass: contract.commandClass ?? null
+        commandClass: effectiveContract.commandClass ?? null
       }), actor));
     }
   }
@@ -121,13 +123,13 @@ async function handleRequest(
   if (contract.namespace === "admin") {
     const result = handleAdminMethod(contract, options);
     const receipt = stampReceipt(result, actor);
-    await appendWriteEventIfNeeded(options, request.params ?? {}, contract, receipt.ok ? "succeeded" : "failed", receipt.summary, receipt.ok ? undefined : receipt.error?.code, actor);
+    await appendWriteEventIfNeeded(options, params, effectiveContract, receipt.ok ? "succeeded" : "failed", receipt.summary, receipt.ok ? undefined : receipt.error?.code, actor);
     return response(receipt);
   }
 
-  const result = await callServiceMethod(contract, request.params ?? {}, options.services);
+  const result = await callServiceMethod(effectiveContract, params, options.services, actor);
   const receipt = stampReceipt(result, actor);
-  await appendWriteEventIfNeeded(options, request.params ?? {}, contract, receipt.ok ? "succeeded" : "failed", receipt.summary, receipt.ok ? undefined : receipt.error?.code, actor);
+  await appendWriteEventIfNeeded(options, params, effectiveContract, receipt.ok ? "succeeded" : "failed", receipt.summary, receipt.ok ? undefined : receipt.error?.code, actor);
   return response(receipt);
 }
 
@@ -174,7 +176,8 @@ function validateRepoNamespace(
 async function callServiceMethod(
   contract: JsonRpcMethodContract,
   params: JsonObject,
-  services: DaemonServiceHost
+  services: DaemonServiceHost,
+  actor: AuthenticatedActor | undefined
 ): Promise<ReturnType<typeof successReceipt> | ReturnType<typeof failureReceipt>> {
   const payload = isJsonObject(params.payload) ? params.payload : undefined;
   if (contract.method === "repo.daemon.status") {
@@ -187,7 +190,7 @@ async function callServiceMethod(
     if (!services.CliCommandService) {
       return failureReceipt(contract.method, "cli_command_service_unavailable", "Daemon command service is not configured.");
     }
-    return services.CliCommandService.runCommand(payload);
+    return services.CliCommandService.runCommand(payload, { actor });
   }
   const result = contract.service === "TerminalSessionService"
     ? await invokeServiceMethod(services.TerminalSessionService, String(contract.serviceMethod), payload)
@@ -195,6 +198,12 @@ async function callServiceMethod(
   return isJsonObject(result)
     ? serviceResultReceipt(contract.method, result)
     : successReceipt(contract.method, `completed ${contract.method}`, { value: toJsonValue(result) });
+}
+
+function withEffectiveCommandClass(contract: JsonRpcMethodContract, params: JsonObject): JsonRpcMethodContract {
+  const commandClass = commandClassForJsonRpcRequest(contract, params);
+  if (commandClass === contract.commandClass) return contract;
+  return commandClass ? { ...contract, commandClass } : { ...contract };
 }
 
 async function resolveActor(

--- a/packages/daemon/src/protocol/method-registry.ts
+++ b/packages/daemon/src/protocol/method-registry.ts
@@ -19,6 +19,7 @@ export interface JsonRpcMethodContract {
   readonly auth: ApiRouteContract["auth"];
   readonly requiresRepo: boolean;
   readonly commandClass?: DaemonCommandClass;
+  readonly commandClassDerivation?: "repo-command-run-action";
 }
 
 const protocolMethodContracts = [
@@ -44,7 +45,7 @@ const cliCommandContracts = [
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
     requiresRepo: true,
-    commandClass: "arbiter"
+    commandClassDerivation: "repo-command-run-action"
   }
 ] as const satisfies ReadonlyArray<JsonRpcMethodContract>;
 
@@ -137,6 +138,137 @@ export function commandClassForApiRoute(contract: ApiRouteContract): DaemonComma
   if (arbiterApiRouteIds.has(contract.id)) return "arbiter";
   if (contract.method === "GET" || contract.method === "WS") return "repo-read";
   return "repo-write";
+}
+
+const repoReadCliActionKinds = new Set<string>([
+  "capabilities",
+  "check",
+  "decision-list",
+  "decision-show",
+  "doc-list",
+  "doc-map",
+  "doctor",
+  "entity-list",
+  "fact-list",
+  "fact-show",
+  "help",
+  "legacy-scan",
+  "legacy-verify",
+  "migrate-plan",
+  "migrate-verify",
+  "module-inspect",
+  "module-list",
+  "preset-audit",
+  "preset-check",
+  "preset-inspect",
+  "preset-list",
+  "preset-validate",
+  "runtime-event-list",
+  "script-inspect",
+  "script-list",
+  "snapshot-multica",
+  "status",
+  "task-list",
+  "task-tree",
+  "template-list",
+  "template-render",
+  "vertical-validate",
+  "version"
+]);
+
+const repoWriteCliActionKinds = new Set<string>([
+  "adopt-multica",
+  "decision-amend",
+  "decision-propose",
+  "decision-reckon",
+  "decision-relate",
+  "decision-relation-replace",
+  "decision-relation-retire",
+  "distill-candidate",
+  "distill-commit",
+  "doc-generate",
+  "fact-invalidate",
+  "git-diff",
+  "governance-rebuild",
+  "graph",
+  "gui",
+  "init",
+  "legacy-copy-safe-docs",
+  "legacy-index",
+  "legacy-intake-plan",
+  "lesson-promote",
+  "lesson-sediment",
+  "materializer-run",
+  "migrate-anchors",
+  "migrate-provenance",
+  "migrate-run",
+  "migrate-structure",
+  "module-register",
+  "module-scaffold",
+  "module-step",
+  "module-unregister",
+  "new-task",
+  "preset-action",
+  "preset-install",
+  "preset-run",
+  "preset-seed",
+  "preset-uninstall",
+  "progress-append",
+  "record-fact",
+  "runtime-event-append",
+  "script-run",
+  "session-backfill",
+  "session-export",
+  "session-sync",
+  "task-amend",
+  "task-archive",
+  "task-delete",
+  "task-relate",
+  "task-reopen",
+  "task-supersede"
+]);
+
+const arbiterCliActionKinds = new Set<string>([
+  "decision-accept",
+  "decision-defer",
+  "decision-reject",
+  "decision-retire",
+  "decision-supersede",
+  "status-set",
+  "task-complete",
+  "task-review"
+]);
+
+export const repoCommandRunClassifiedActionKinds = [
+  ...repoReadCliActionKinds,
+  ...repoWriteCliActionKinds,
+  ...arbiterCliActionKinds
+].sort();
+
+export function commandClassForJsonRpcRequest(
+  contract: JsonRpcMethodContract,
+  params: unknown
+): DaemonCommandClass | undefined {
+  if (contract.commandClassDerivation === "repo-command-run-action") {
+    return commandClassForCliCommandPayload(params);
+  }
+  return contract.commandClass;
+}
+
+export function commandClassForCliCommandPayload(params: unknown): DaemonCommandClass | undefined {
+  const payload = isRecord(params) ? params.payload : undefined;
+  const command = isRecord(payload) ? payload.command : undefined;
+  const action = isRecord(command) ? command.action : undefined;
+  const kind = isRecord(action) && typeof action.kind === "string" ? action.kind : undefined;
+  if (!kind) return undefined;
+  if (repoReadCliActionKinds.has(kind)) return "repo-read";
+  if (repoWriteCliActionKinds.has(kind)) return "repo-write";
+  if (arbiterCliActionKinds.has(kind)) return "arbiter";
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 export const jsonRpcServiceMethodContracts = deriveJsonRpcServiceMethodContracts();

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -8,11 +8,13 @@ import type { LocalControllerService } from "../../application/src/index.ts";
 import { makeRuntimeEventAppendPromise, makeRuntimeEventLedgerService } from "../../application/src/index.ts";
 import { apiRouteContracts } from "../../gui/src/api/api-contract-registry.ts";
 import { createInMemoryTerminalSessionService } from "../../gui/src/terminal/session-registry.ts";
+import { commandSpecs } from "../../cli/src/cli/command-spec/index.ts";
 import {
   createJsonRpcProtocolServer,
   currentDaemonProtocolVersion,
   jsonRpcServiceMethodContracts,
   jsonRpcMethodContracts,
+  repoCommandRunClassifiedActionKinds,
   makeTransportDerivedIdentityProvider,
   peopleRosterFromDocument,
   type IdentityProvider,
@@ -48,8 +50,18 @@ test("daemon method registry classifies every non-hello method exactly once", ()
       assert.equal(contract.commandClass, undefined);
       continue;
     }
-    assert.match(contract.commandClass ?? "", /^(admin|repo-write|repo-read|arbiter)$/u, contract.method);
+    const hasStaticClass = typeof contract.commandClass === "string";
+    const hasDerivedClass = contract.commandClassDerivation === "repo-command-run-action";
+    assert.equal(Number(hasStaticClass) + Number(hasDerivedClass), 1, contract.method);
+    if (hasStaticClass) assert.match(contract.commandClass ?? "", /^(admin|repo-write|repo-read|arbiter)$/u, contract.method);
   }
+});
+
+test("repo.command.run classification covers every parsed CLI action kind", () => {
+  assert.deepEqual(
+    repoCommandRunClassifiedActionKinds,
+    commandSpecs.map((spec) => spec.kind).sort()
+  );
 });
 
 test("protocol.hello accepts the current daemon protocol version", async () => {
@@ -150,7 +162,7 @@ test("admin people list returns roster data and stamps receipt actor", async () 
   const receipt = resultReceipt(response);
 
   assert.equal(receipt.ok, true);
-  assert.equal(receipt.items?.length, 3);
+  assert.equal(receipt.items?.length, 4);
   assert.equal((receipt.details.actor as { readonly personId?: string }).personId, "person_alice");
 });
 
@@ -251,8 +263,67 @@ test("RBAC rejects non-arbiter methods and records a runtime event with actor", 
   }
 });
 
+test("repo.command.run derives RBAC from the inner CLI command", async () => {
+  const roster = sampleRoster();
+  const calls: string[] = [];
+  const server = makeServer({
+    peopleRoster: roster,
+    identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),
+    authContext: {
+      transportKind: "ssh-exec",
+      sshExecUser: { username: "maint", host: "team-host", source: "ssh-authenticated-exec" }
+    },
+    services: {
+      LocalControllerService: emptyLocalController(),
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" }),
+      CliCommandService: {
+        runCommand: async (payload) => {
+          const kind = (((payload?.command as Record<string, unknown> | undefined)?.action as Record<string, unknown> | undefined)?.kind);
+          calls.push(String(kind));
+          return {
+            ok: true,
+            schema: "command-receipt/v2",
+            command: String(kind),
+            action: String(kind),
+            summary: `completed ${String(kind)}`,
+            details: {},
+            meta: {
+              generatedAt: "2026-07-07T00:00:00.000Z",
+              compatibility: { legacyReceipt: "CommandReceipt/v1" }
+            }
+          };
+        }
+      }
+    }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const readReceipt = resultReceipt(await server.handle(commandRunRequest("version", "rbac-read")));
+  assert.equal(readReceipt.ok, true);
+  const writeReceipt = resultReceipt(await server.handle(commandRunRequest("new-task", "rbac-write")));
+  assert.equal(writeReceipt.ok, true);
+
+  const arbiterReceipt = resultReceipt(await server.handle(commandRunRequest("decision-accept", "rbac-arbiter")));
+  assert.equal(arbiterReceipt.ok, false);
+  assert.equal(arbiterReceipt.error?.code, "rbac_forbidden");
+  assert.equal(arbiterReceipt.details.commandClass, "arbiter");
+  assert.deepEqual(calls, ["version", "new-task"]);
+});
+
 function makeServer(overrides: Partial<Parameters<typeof createJsonRpcProtocolServer>[0]> = {}) {
-  const localController: LocalControllerService = {
+  return createJsonRpcProtocolServer({
+    daemonId: "daemon-test",
+    repos: [{ repoId: "canonical", canonicalRoot: "/tmp/canonical" }],
+    services: {
+      LocalControllerService: emptyLocalController(),
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" })
+    },
+    ...overrides
+  });
+}
+
+function emptyLocalController(): LocalControllerService {
+  return {
     getTasks: () => ({ ok: true, tasks: [], warnings: [] }),
     getTaskDetail: () => ({ ok: true }),
     getTaskDocument: () => ({ ok: true }),
@@ -263,16 +334,24 @@ function makeServer(overrides: Partial<Parameters<typeof createJsonRpcProtocolSe
     archiveTask: () => ({ ok: true }),
     openShell: () => ({ ok: true, policy: { displayOnly: true, outputCreatesTaskState: false } })
   };
+}
 
-  return createJsonRpcProtocolServer({
-    daemonId: "daemon-test",
-    repos: [{ repoId: "canonical", canonicalRoot: "/tmp/canonical" }],
-    services: {
-      LocalControllerService: localController,
-      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" })
-    },
-    ...overrides
-  });
+function commandRunRequest(actionKind: string, id: string): JsonRpcRequest {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "repo.command.run",
+    params: {
+      repo: { repoId: "canonical" },
+      payload: {
+        command: {
+          rootDir: "/tmp/canonical",
+          json: true,
+          action: { kind: actionKind }
+        }
+      }
+    }
+  };
 }
 
 function readFixture(name: string): JsonRpcRequest {
@@ -327,6 +406,14 @@ function sampleRoster(): PeopleRoster {
     "      - kind: ssh-username",
     "        issuer: host:team-host",
     "        subject: viewer",
+    "  - personId: person_maint",
+    "    displayName: Mina Maintainer",
+    "    primaryEmail: maint@example.com",
+    "    roles: [maintainer]",
+    "    credentials:",
+    "      - kind: ssh-username",
+    "        issuer: host:team-host",
+    "        subject: maint",
     "  - personId: person_arbiter",
     "    displayName: Ari Arbiter",
     "    primaryEmail: ari@example.com",
@@ -340,6 +427,8 @@ function sampleRoster(): PeopleRoster {
     "    commandClasses: [admin, repo-write, repo-read, arbiter]",
     "  - roleId: observer",
     "    commandClasses: [repo-read]",
+    "  - roleId: maintainer",
+    "    commandClasses: [repo-write, repo-read]",
     "  - roleId: arbiter",
     "    commandClasses: [arbiter, repo-write, repo-read]",
     ""

--- a/packages/kernel/src/store/daemon-runtime.ts
+++ b/packages/kernel/src/store/daemon-runtime.ts
@@ -10,7 +10,7 @@ import {
 import { runLedgerMaterializer, type LedgerMaterializerReport } from "./ledger-materializer.ts";
 import { acquireDaemonGlobalLock, type DaemonGlobalLock } from "./write-journal-locks.ts";
 import { makeJournaledWriteCoordinator } from "./write-journal-coordinator.ts";
-import type { JournalActor } from "./write-journal-types.ts";
+import type { GitCommitAuthor, JournalActor } from "./write-journal-types.ts";
 
 const defaultDaemonActor: JournalActor = { kind: "system", id: "daemon-runtime" };
 const defaultLockTtlMs = 60_000;
@@ -35,6 +35,8 @@ export interface InteractiveWriteRequest {
   readonly commandId: string;
   readonly ops: ReadonlyArray<WriteOp>;
   readonly deadlineMs?: number;
+  readonly actor?: JournalActor;
+  readonly commitAuthor?: GitCommitAuthor;
 }
 
 export interface InteractiveWriteReceipt {
@@ -80,6 +82,8 @@ interface InteractiveQueueItem {
   readonly kind: "interactive";
   readonly commandId: string;
   readonly ops: ReadonlyArray<WriteOp>;
+  readonly actor?: JournalActor;
+  readonly commitAuthor?: GitCommitAuthor;
   readonly enqueuedAt: number;
   started: boolean;
   timeout?: ReturnType<typeof setTimeout>;
@@ -135,6 +139,19 @@ export function createDaemonRuntime(options: DaemonRuntimeOptions): HarnessDaemo
     return queue.enqueueBackground(request);
   };
 
+  const makeStartedCoordinator = (
+    started: ReturnType<typeof requireStarted>,
+    request?: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }
+  ) => makeJournaledWriteCoordinator({
+    rootDir,
+    layoutOverrides: options.layoutOverrides,
+    actor: request?.actor ?? actor,
+    lockTtlMs,
+    heldGlobalLock: started.lock,
+    autoMaterialize: false,
+    ...(request?.commitAuthor ? { commitAuthor: request.commitAuthor } : {})
+  });
+
   return {
     start: async () => {
       if (lock && coordinator) return status();
@@ -168,7 +185,7 @@ export function createDaemonRuntime(options: DaemonRuntimeOptions): HarnessDaemo
     status,
     enqueueInteractiveWrite: (request) => {
       const started = requireStarted();
-      return queue.enqueueInteractive(request, started.coordinator);
+      return queue.enqueueInteractive(request, (batch) => makeStartedCoordinator(started, batch));
     },
     enqueueBackgroundBatch,
     enqueueMaterializerBatch
@@ -193,7 +210,7 @@ class DaemonWriteQueue {
   private running = false;
   private closed = false;
   private idleWaiters: Array<() => void> = [];
-  private coordinator: ReturnType<typeof makeJournaledWriteCoordinator> | undefined;
+  private coordinatorFor: ((batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }) => ReturnType<typeof makeJournaledWriteCoordinator>) | undefined;
   private readonly maxInteractiveOpsPerCommit: number;
   private readonly interactiveMicroBatchMs: number;
 
@@ -205,14 +222,19 @@ class DaemonWriteQueue {
     this.interactiveMicroBatchMs = interactiveMicroBatchMs;
   }
 
-  enqueueInteractive(request: InteractiveWriteRequest, coordinator: ReturnType<typeof makeJournaledWriteCoordinator>): Promise<InteractiveWriteReceipt> {
+  enqueueInteractive(
+    request: InteractiveWriteRequest,
+    coordinatorFor: (batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }) => ReturnType<typeof makeJournaledWriteCoordinator>
+  ): Promise<InteractiveWriteReceipt> {
     if (this.closed) return Promise.reject({ _tag: "JournalUnavailable", cause: new Error("daemon write queue is closed") } satisfies WriteError);
-    this.coordinator = coordinator;
+    this.coordinatorFor = coordinatorFor;
     return new Promise((resolve, reject) => {
       const item: InteractiveQueueItem = {
         kind: "interactive",
         commandId: request.commandId,
         ops: request.ops,
+        ...(request.actor ? { actor: request.actor } : {}),
+        ...(request.commitAuthor ? { commitAuthor: request.commitAuthor } : {}),
         enqueuedAt: Date.now(),
         started: false,
         resolve,
@@ -281,8 +303,8 @@ class DaemonWriteQueue {
   private async drain(): Promise<void> {
     while (!this.isIdle()) {
       if (this.interactive.length > 0) {
-        if (!this.coordinator) return;
-        await this.drainInteractive(this.coordinator);
+        if (!this.coordinatorFor) return;
+        await this.drainInteractive(this.coordinatorFor);
         continue;
       }
       const backgroundItem = this.normal.shift() ?? this.background.shift() ?? this.maintenance.shift();
@@ -291,13 +313,17 @@ class DaemonWriteQueue {
     }
   }
 
-  private async drainInteractive(coordinator: ReturnType<typeof makeJournaledWriteCoordinator>): Promise<void> {
+  private async drainInteractive(
+    coordinatorFor: (batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }) => ReturnType<typeof makeJournaledWriteCoordinator>
+  ): Promise<void> {
     if (this.interactiveMicroBatchMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, this.interactiveMicroBatchMs));
     }
     const batch: InteractiveQueueItem[] = [];
     let opCount = 0;
     while (this.interactive.length > 0 && opCount < this.maxInteractiveOpsPerCommit) {
+      const next = this.interactive[0]!;
+      if (batch.length > 0 && !sameAttribution(batch[0]!, next)) break;
       const item = this.interactive.shift()!;
       item.started = true;
       if (item.timeout) clearTimeout(item.timeout);
@@ -305,6 +331,7 @@ class DaemonWriteQueue {
       opCount += item.ops.length;
     }
     const accepted: InteractiveQueueItem[] = [];
+    const coordinator = coordinatorFor(attributionFor(batch[0]));
     for (const item of batch) {
       try {
         for (const op of item.ops) {
@@ -364,6 +391,26 @@ class DaemonWriteQueue {
     const waiters = this.idleWaiters.splice(0, this.idleWaiters.length);
     for (const resolve of waiters) resolve();
   }
+}
+
+function attributionFor(item: InteractiveQueueItem | undefined): { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor } {
+  return {
+    ...(item?.actor ? { actor: item.actor } : {}),
+    ...(item?.commitAuthor ? { commitAuthor: item.commitAuthor } : {})
+  };
+}
+
+function sameAttribution(left: InteractiveQueueItem, right: InteractiveQueueItem): boolean {
+  return actorKey(left.actor) === actorKey(right.actor)
+    && authorKey(left.commitAuthor) === authorKey(right.commitAuthor);
+}
+
+function actorKey(actor: JournalActor | undefined): string {
+  return actor ? `${actor.kind}\0${actor.id}` : "";
+}
+
+function authorKey(author: GitCommitAuthor | undefined): string {
+  return author ? `${author.name}\0${author.email}` : "";
 }
 
 function toWriteError(error: unknown): WriteError {

--- a/packages/kernel/test/store/daemon-runtime.test.ts
+++ b/packages/kernel/test/store/daemon-runtime.test.ts
@@ -113,6 +113,44 @@ test("daemon materializer producer runs bounded batches under the lifetime globa
   });
 });
 
+test("daemon interactive queue does not mix different git authors in one commit", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: false,
+      interactiveMicroBatchMs: 20
+    });
+    await runtime.start();
+
+    const alice = runtime.enqueueInteractiveWrite({
+      commandId: "cmd-alice",
+      actor: { kind: "human", id: "person_alice" },
+      commitAuthor: { name: "Alice Owner", email: "alice@example.test" },
+      ops: [docWrite("op-author-alice", "task-author-a", "note.md", "alice\n")]
+    });
+    const bob = runtime.enqueueInteractiveWrite({
+      commandId: "cmd-bob",
+      actor: { kind: "human", id: "person_bob" },
+      commitAuthor: { name: "Bob Owner", email: "bob@example.test" },
+      ops: [docWrite("op-author-bob", "task-author-b", "note.md", "bob\n")]
+    });
+
+    const [aliceReceipt, bobReceipt] = await Promise.all([alice, bob]);
+    assert.equal(aliceReceipt.flush.opCount, 1);
+    assert.equal(bobReceipt.flush.opCount, 1);
+    assert.deepEqual(
+      git(rootDir, "log", "-2", "--format=%an <%ae>|%s").split(/\r?\n/u),
+      [
+        "Bob Owner <bob@example.test>|task(doc): task-author-b note.md [op-author-bob]",
+        "Alice Owner <alice@example.test>|task(doc): task-author-a note.md [op-author-alice]"
+      ]
+    );
+
+    await runtime.stop();
+  });
+});
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
# English

## Summary

Completes the D2 identity integration end-to-end (dec_mr9ac5ca): command-level RBAC derivation for `repo.command.run`, and per-request git-author propagation through the daemon write queue. These were the two team-mode blockers surfaced by W7's live drill; single-user mode was unaffected and stays behavior-equivalent.

## What Changed

- **Command-level RBAC**: `repo.command.run` no longer carries a static `arbiter` class. The registry marks it `commandClassDerivation: "repo-command-run-action"`, and JSON-RPC authorization derives the effective class from `payload.command.action.kind` — e.g. `version`/`decision-show`→repo-read, `new-task`/`decision-propose`→repo-write, `decision-accept`/`decision-supersede`→arbiter. Non-arbiter roles can now run read/write commands; arbiter operations remain restricted.
- **Fail-closed classifier**: the action classifier lives in the same W4 method-registry surface; a contract test pins its classified action set against the CLI command spec, so any future unclassified command fails closed until explicitly classified.
- **Per-request git author**: the JSON-RPC server passes the resolved transport actor into `CliCommandService.runCommand`; the daemon command service stamps write-journal actor `{kind:"human", id: personId}` and git author `displayName <primaryEmail>`.
- **Author-safe batching (dec_mr9sgtzr)**: the kernel interactive queue batches only adjacent writes with the same journal actor AND git author; different actors flush as separate commits, preserving the W0 queue-as-scheduler / WriteCoordinator-as-transaction boundary.

## Task And Scope

- Harness task: task_01KWX3WWZJ5J333BW431J7VA8N
- Branch: codex/gap-rbac-author
- Out of scope: multi-repo runtime (W9 task_01KWX37QN3); no changes to `rewrite-ci.yml`, docs, or projection.

## Version Impact

- No version change (daemon identity/RBAC internal completion).

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: daemon protocol RBAC (`packages/daemon/src/protocol/method-registry.ts`, `json-rpc-server.ts`), kernel write path (`packages/kernel/src/store/daemon-runtime.ts`), daemon CLI command/queue services.
- Authority: task_01KWX3WWZJ5J333BW431J7VA8N, dec_mr9ac5ca (D2 command-level RBAC + 4 stamp points), dec_mr9sgtzr (queue batch / durable receipt — author-safe batching), dec_mr9acuxm (D4 sole write path).
- Machine-check boundary: the contract test asserts the classifier stays pinned to the CLI spec; reviewers decide whether each action's class assignment is correct.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 82b149e2e75086bb4d91ad306977d9a5557387a0 (final rebase).
- `npm run check` passed after final rebase. typecheck + lint passed. Contract 287/287, integration 398 passed / 1 skipped.
- Acceptance evidence: (1) protocol + CLI tests prove `repo.command.run` maps version→read, new-task→write, decision-accept→arbiter; maintainer runs read/write, rejected for arbiter with `rbac_forbidden`; (2) owner write through daemon → `git log` author = `Owner User <owner@example.test>`; (3) two concurrent writes (Alice/Bob) → two separate commits, each `opCount === 1`.

---

# 中文

## 摘要

端到端补全 D2 身份集成(dec_mr9ac5ca):`repo.command.run` 命令级 RBAC 派生 + per-request git author 传播过 daemon 写队列。二者是 W7 真机演练暴露的团队模式 blocker;单人模式不受影响、行为等价。

## 变更内容

- **命令级 RBAC**:`repo.command.run` 不再静态 `arbiter`。registry 标 `commandClassDerivation: "repo-command-run-action"`,JSON-RPC 授权从 `payload.command.action.kind` 派生有效 class——`version`/`decision-show`→repo-read、`new-task`/`decision-propose`→repo-write、`decision-accept`/`decision-supersede`→arbiter。非 arbiter 角色现在能跑读写命令;arbiter 操作仍受限。
- **fail-closed 分类器**:分类器落在 W4 method-registry 同一面;契约测试把分类动作集钉在 CLI 命令 spec 上,未来未分类命令 fail closed 直到显式分类。
- **per-request git author**:JSON-RPC server 把解析出的传输 actor 传进 `CliCommandService.runCommand`;daemon 命令服务盖章 write-journal actor `{kind:"human", id: personId}` + git author `displayName <primaryEmail>`。
- **author 安全分批(dec_mr9sgtzr)**:kernel 交互队列只合批相邻的同 journal actor + 同 git author 的写;不同 author 分开成独立 commit,保留 W0 队列=调度器 / WriteCoordinator=事务的边界。

## 任务与范围

- Harness 任务:task_01KWX3WWZJ5J333BW431J7VA8N
- 分支:codex/gap-rbac-author
- 范围外:多仓 runtime(W9 task_01KWX37QN3);未碰 rewrite-ci.yml / 文档 / projection。

## 版本影响

- 无版本变更(daemon 身份/RBAC 内部补全)。

## 治理声明

- 触碰受保护面:是
- 受保护面范围:daemon 协议 RBAC(method-registry.ts / json-rpc-server.ts)、kernel 写路径(daemon-runtime.ts)、daemon CLI 命令/队列服务。
- 权威依据:task_01KWX3WWZJ5J333BW431J7VA8N、dec_mr9ac5ca(D2 命令级 RBAC + 盖章四落点)、dec_mr9sgtzr(队列分批/durable receipt——author 安全分批)、dec_mr9acuxm(D4 唯一写路径)。
- 机器检查边界:契约测试断言分类器钉在 CLI spec 上;每个动作的 class 归属是否正确由复核者判定。
- Break-glass:否

## 验证

- 基线 `origin/main` SHA:82b149e(最终 rebase)。
- 最终 rebase 后 `npm run check` 通过。typecheck + lint 通过。契约 287/287,集成 398 passed / 1 skipped。
- 验收证据:(1) 协议 + CLI 测试证明 `repo.command.run` version→读 / new-task→写 / decision-accept→arbiter;maintainer 跑读写、arbiter 被 `rbac_forbidden` 拒;(2) owner 经 daemon 写入 → `git log` author = `Owner User <owner@example.test>`;(3) 两并发写(Alice/Bob)→ 两独立 commit,各 `opCount === 1`。
