### PR TITLE
feat(cli): task complete auto-queues distill candidate

### DIFF
--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -1,8 +1,11 @@
+import path from "node:path";
 import { Effect } from "effect";
 import { makeTaskLifecycleOrchestrator, type TaskLifecycleResult } from "../../../../application/src/index.ts";
+import { taskDocumentPath } from "../../../../kernel/src/index.ts";
 import { cliError, CliErrorCode, isCliErrorCode, type CliErrorCode as CliErrorCodeValue } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
 import type { CommandRunner } from "../../cli/runner-registry.ts";
+import { runDistillCommand } from "./distill.ts";
 import { bundledTaskDocumentPlaceholderPolicy } from "./task-document-placeholders.ts";
 import { taskTreeSoftGateWarnings } from "./task-lifecycle.ts";
 
@@ -26,7 +29,8 @@ export const runTaskGatesCommand: CommandRunner = (context, command) => {
       const output = taskLifecycleResultToCliResult("task-complete", result);
       if (!output.ok) return output;
       return { ...output, warnings: taskTreeSoftGateWarnings(context, action.taskId) };
-    })
+    }),
+    Effect.flatMap((output) => output.ok ? queueCloseoutDistillCandidate(context, command, action, output) : Effect.succeed(output))
   );
 };
 
@@ -51,6 +55,72 @@ function taskLifecycleResultToCliResult(command: "task-review" | "task-complete"
     completionGate: result.completionGate,
     error: cliError(cliErrorCode(result.error.code), taskGateHint(result.error.code, result.error.hint, result.taskId))
   };
+}
+
+function queueCloseoutDistillCandidate(
+  context: Parameters<CommandRunner>[0],
+  command: Parameters<CommandRunner>[1],
+  action: Extract<TaskGateAction, { readonly kind: "task-complete" }>,
+  output: CliResult
+): ReturnType<CommandRunner> {
+  const inputPath = taskCloseoutInputPath(context, action.taskId);
+  return runDistillCommand(context, {
+    ...command,
+    action: {
+      kind: "distill-candidate",
+      taskId: action.taskId,
+      inputPath
+    }
+  }).pipe(
+    Effect.match({
+      onFailure: (error): CliResult => withDistillCandidateWarning(output, `distill candidate write failed: ${JSON.stringify(error)}`),
+      onSuccess: (candidate): CliResult => candidate.ok
+        ? withDistillCandidateReport(output, candidate)
+        : withDistillCandidateWarning(output, candidate.error?.hint ?? "distill candidate was not queued")
+    })
+  );
+}
+
+function taskCloseoutInputPath(context: Parameters<CommandRunner>[0], taskId: string): string {
+  return path.relative(context.rootDir, taskDocumentPath(context.layoutInput, taskId, "closeout.md")).split(path.sep).join("/");
+}
+
+function withDistillCandidateReport(output: CliResult, candidate: CliResult): CliResult {
+  return {
+    ...output,
+    report: {
+      ...(isCliReportRecord(output.report) ? output.report : { schema: "task-complete-report/v1" }),
+      distillCandidate: {
+        queued: true,
+        path: candidate.path,
+        report: candidate.report
+      }
+    }
+  };
+}
+
+function withDistillCandidateWarning(output: CliResult, reason: string): CliResult {
+  return {
+    ...output,
+    report: {
+      ...(isCliReportRecord(output.report) ? output.report : { schema: "task-complete-report/v1" }),
+      distillCandidate: {
+        queued: false,
+        reason
+      }
+    },
+    warnings: [
+      ...(output.warnings ?? []),
+      {
+        code: "distill_candidate_not_queued",
+        message: reason
+      }
+    ]
+  };
+}
+
+function isCliReportRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function taskGateHint(code: string, hint: string, taskId: string): string {

--- a/packages/cli/test/task-transition-sweep-cli.test.ts
+++ b/packages/cli/test/task-transition-sweep-cli.test.ts
@@ -37,6 +37,49 @@ test("CLI in_review and complete sweeps commit hand-edited closeout.md", () => {
   });
 });
 
+for (const preset of ["milestone-closeout", "lesson-sedimentation"] as const) {
+  test(`CLI task complete queues a distill candidate for ${preset}`, () => {
+    withGitTempRoot((rootDir) => {
+      const created = runJson(rootDir, [
+        "new-task",
+        "--title",
+        `Closeout Candidate ${preset}`,
+        "--vertical",
+        "software/coding",
+        "--preset",
+        preset
+      ]);
+      const taskId = assertGeneratedTaskId(created.taskId);
+      const taskPath = String(created.packagePath);
+      const closeoutPath = path.join(rootDir, taskPath, "closeout.md");
+      const factsPath = path.join(rootDir, taskPath, "facts.md");
+
+      runJson(rootDir, ["task", "transition", taskId, "active"]);
+      runJson(rootDir, ["task", "transition", taskId, "in_review"]);
+      writeFact(rootDir, taskPath);
+      writeReview(rootDir, taskPath);
+      writeFileSync(closeoutPath, `# Closeout\n\n${preset} generated a closeout candidate source.\n`, "utf8");
+      const factsBefore = readFileSync(factsPath, "utf8");
+
+      const completed = runJson(rootDir, ["task", "complete", taskId, "--reviewer", "reviewer-a", "--ci", "passed"]);
+
+      assert.equal(completed.ok, true);
+      assert.equal(completed.status, "done");
+      assert.equal(completed.report.distillCandidate.queued, true);
+      assert.equal(completed.report.distillCandidate.report.factWrite, false);
+      const candidatePath = String(completed.report.distillCandidate.path);
+      assert.match(candidatePath, new RegExp(`^\\.harness/generated/distill/${taskId}/distill_[^/]+\\.json$`, "u"));
+      const artifact = JSON.parse(readFileSync(path.join(rootDir, candidatePath), "utf8")) as Record<string, unknown>;
+      assert.equal(artifact.schema, "distill-candidate/v1");
+      assert.equal(artifact.taskId, taskId);
+      assert.equal(artifact.command, "ha distill candidate");
+      assert.equal(artifact.factState, "candidate");
+      assert.equal(artifact.inputPath, `${taskPath}/closeout.md`);
+      assert.equal(readFileSync(factsPath, "utf8"), factsBefore);
+    });
+  });
+}
+
 test("CLI transition sweep commits orchestration markdown but never commits logs", () => {
   withGitTempRoot((rootDir) => {
     const created = runJson(rootDir, ["new-task", "--title", "Sweep Logs"]);


### PR DESCRIPTION
# English

## Summary

Task completion now queues a distill candidate from the completed task closeout evidence without promoting or recording a fact automatically.

## What Changed

- Reused the existing `ha distill candidate` runner after successful `ha task complete`.
- Uses the completed task package `closeout.md` as the candidate input and returns the queued candidate in `report.distillCandidate`.
- Added coverage for `milestone-closeout` and `lesson-sedimentation` preset tasks to prove completion produces a `distill-candidate/v1` artifact while leaving `facts.md` unchanged.

## Task And Scope

- Harness task: `task_01KWWYZATPY8DWRTGWFXCM6Y6X`
- Branch: `m6-d1-closeout-distill`
- Public scope: CLI task completion hook and task completion regression tests.
- Private planning/evidence updated: not applicable; the requested task package path is not present in this checkout.
- Out of scope: daemon write paths, distill promotion, fact recording, new distill pipeline creation.

## Version Impact

- Version: no version change because this is an unreleased CLI behavior change.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01KWWYZATPY8DWRTGWFXCM6Y6X`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `1d37144b63230040c9f12853459b94148e51677b`
- Branch merge-base with `origin/main`: `1d37144b63230040c9f12853459b94148e51677b`
- Last `git fetch origin` time: `2026-07-07T08:06:31Z`
- Sync method: rebase
- Public diff command: `git diff origin/main...HEAD --stat`
- Private evidence commit/path: not applicable
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: pending after PR creation
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Additional run: `node --test packages/cli/test/task-transition-sweep-cli.test.ts` passed.
- Additional run: `npm run lint` passed.
- Additional run: `npm run test:fast` passed.
- Additional run: `npm run check:pr` passed before the final rebase; after rebasing, it passed through typecheck, lint, fast, contract, integration, and GUI Vitest, then `npm run test:gui:e2e` hung and was interrupted. The post-E2E policy segment from `check:pr` was rerun separately and passed.
- Not run: `npm ci` because `npm install` was used to restore missing locked GUI dependencies locally; `npm run check` because `npm run check:pr` and its component lanes were used; `npm test` because the tiered node test lanes from `check:pr` were used; `npm run harness:smoke-cli-package` was not run separately; final rebased `npm run test:gui:e2e` did not complete because `e2e/electron-smoke.e2e.mjs` hung with Electron running.

## Review Evidence

- Self-review: verified the hook only runs after successful task completion and calls the existing candidate runner; no `distill promote` or fact write is invoked.
- Reviewer subagent: not run.
- Human review: pending.
- Blocking findings: none known in the CLI distill change; GUI E2E hang remains an unrelated local verification gap.

## Residual Risk

- If candidate generation fails after task completion, the task completion result remains successful with a warning and `report.distillCandidate.queued=false`; this avoids rolling back an already-completed task while making the queue failure visible.

## References

- Task: `task_01KWWYZATPY8DWRTGWFXCM6Y6X`
- Evidence: `node --test packages/cli/test/task-transition-sweep-cli.test.ts`; `npm run check:pr` component runs described above.
- Review: pending.

---

# 中文

## 概要

任务完成现在会基于已完成任务的 closeout 证据排队一个 distill candidate，不会自动 promote，也不会自动写入 fact。

## 改动内容

- 在 `ha task complete` 成功后复用既有 `ha distill candidate` runner。
- 使用已完成任务包的 `closeout.md` 作为 candidate 输入，并在 `report.distillCandidate` 返回排队结果。
- 增加 `milestone-closeout` 和 `lesson-sedimentation` preset 任务的覆盖，证明完成任务会产生 `distill-candidate/v1` artifact，同时不改写 `facts.md`。

## 任务与范围

- Harness 任务：`task_01KWWYZATPY8DWRTGWFXCM6Y6X`
- 分支：`m6-d1-closeout-distill`
- 公开范围：CLI task complete hook 与 task complete 回归测试。
- 私有计划 / 证据是否已更新：not applicable；本 checkout 中不存在请求的任务包路径。
- 范围外：daemon 写路径、distill promote、fact 自动写入、新建 distill 管道。

## 版本影响

- 版本：不改版本，原因是这是未发布 CLI 行为改动。
- 发布影响：不发布。

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：任务 `task_01KWWYZATPY8DWRTGWFXCM6Y6X`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`1d37144b63230040c9f12853459b94148e51677b`
- 当前分支与 `origin/main` 的 merge-base：`1d37144b63230040c9f12853459b94148e51677b`
- 最近一次 `git fetch origin` 时间：`2026-07-07T08:06:31Z`
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...HEAD --stat`
- 私有证据 commit/path：不适用
- Reviewer 证据路径：不适用
- GitHub Actions `rewrite-ci` run URL：PR 创建后等待
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 额外运行：`node --test packages/cli/test/task-transition-sweep-cli.test.ts` 通过。
- 额外运行：`npm run lint` 通过。
- 额外运行：`npm run test:fast` 通过。
- 额外运行：`npm run check:pr` 在最终 rebase 前完整通过；最终 rebase 后，它已通过 typecheck、lint、fast、contract、integration 与 GUI Vitest，随后 `npm run test:gui:e2e` 挂起并被中断。`check:pr` 中 E2E 之后的 policy 段已单独重跑并通过。
- 未运行：`npm ci`，因为本地用 `npm install` 恢复缺失但已锁定的 GUI 依赖；`npm run check`，因为使用了 `npm run check:pr` 与其组件 lane；`npm test`，因为使用了 `check:pr` 的分层 node test lane；`npm run harness:smoke-cli-package` 未单独运行；最终 rebase 后的 `npm run test:gui:e2e` 未完成，因为 `e2e/electron-smoke.e2e.mjs` 在 Electron 已运行时挂起。

## 审查证据

- 自查：确认 hook 只在 task complete 成功后运行，并调用既有 candidate runner；没有调用 `distill promote`，也没有写 fact。
- Reviewer subagent：未运行。
- 人工审查：待完成。
- 阻塞发现：CLI distill 改动无已知阻塞；GUI E2E 挂起是本地验证缺口。

## 残余风险

- 如果 candidate 生成在 task completion 之后失败，task complete 结果仍保持成功，但会带 warning 并返回 `report.distillCandidate.queued=false`；这样避免回滚已经完成的任务，同时显式暴露排队失败。

## 关联材料

- 任务：`task_01KWWYZATPY8DWRTGWFXCM6Y6X`
- 证据：`node --test packages/cli/test/task-transition-sweep-cli.test.ts`；以及上文列出的 `npm run check:pr` 组件运行。
- 审查：待完成。

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，then `# 中文` 在下。
- [ ] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
