### PR TITLE
feat(kernel): multi-repo daemon runtime manager (W9-P2)

### DIFF
--- a/packages/kernel/src/store/daemon-runtime-queue.ts
+++ b/packages/kernel/src/store/daemon-runtime-queue.ts
@@ -1,0 +1,288 @@
+import { Effect } from "effect";
+import type { WriteError } from "../domain/index.ts";
+import type { FlushReport, WriteOp } from "../ports/write-coordinator.ts";
+import type { GitCommitAuthor, JournalActor } from "./write-journal-types.ts";
+import type { makeJournaledWriteCoordinator } from "./write-journal-coordinator.ts";
+
+export type DaemonWritePriority = "interactive" | "normal" | "background" | "maintenance";
+
+export interface InteractiveWriteRequest {
+  readonly commandId: string;
+  readonly ops: ReadonlyArray<WriteOp>;
+  readonly deadlineMs?: number;
+  readonly actor?: JournalActor;
+  readonly commitAuthor?: GitCommitAuthor;
+}
+
+export interface InteractiveWriteReceipt {
+  readonly commandId: string;
+  readonly opIds: ReadonlyArray<string>;
+  readonly durable: true;
+  readonly flush: FlushReport;
+}
+
+export interface BackgroundBatchRequest<Result = unknown> {
+  readonly source: string;
+  readonly priority?: Exclude<DaemonWritePriority, "interactive">;
+  readonly run: () => Result | Promise<Result>;
+}
+
+export interface DaemonQueueSnapshot {
+  readonly interactive: number;
+  readonly normal: number;
+  readonly background: number;
+  readonly maintenance: number;
+  readonly running: boolean;
+}
+
+interface InteractiveQueueItem {
+  readonly kind: "interactive";
+  readonly commandId: string;
+  readonly ops: ReadonlyArray<WriteOp>;
+  readonly actor?: JournalActor;
+  readonly commitAuthor?: GitCommitAuthor;
+  readonly enqueuedAt: number;
+  started: boolean;
+  timeout?: ReturnType<typeof setTimeout>;
+  readonly resolve: (receipt: InteractiveWriteReceipt) => void;
+  readonly reject: (error: WriteError) => void;
+}
+
+interface BackgroundQueueItem<Result> {
+  readonly kind: "background";
+  readonly source: string;
+  readonly priority: Exclude<DaemonWritePriority, "interactive">;
+  readonly run: () => Result | Promise<Result>;
+  readonly resolve: (result: Result) => void;
+  readonly reject: (error: unknown) => void;
+}
+
+type JournaledWriteCoordinator = ReturnType<typeof makeJournaledWriteCoordinator>;
+
+export class DaemonWriteQueue {
+  private readonly interactive: InteractiveQueueItem[] = [];
+  private readonly normal: BackgroundQueueItem<unknown>[] = [];
+  private readonly background: BackgroundQueueItem<unknown>[] = [];
+  private readonly maintenance: BackgroundQueueItem<unknown>[] = [];
+  private running = false;
+  private closed = false;
+  private idleWaiters: Array<() => void> = [];
+  private coordinatorFor: ((batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }) => JournaledWriteCoordinator) | undefined;
+  private readonly maxInteractiveOpsPerCommit: number;
+  private readonly interactiveMicroBatchMs: number;
+
+  constructor(
+    maxInteractiveOpsPerCommit: number,
+    interactiveMicroBatchMs: number
+  ) {
+    this.maxInteractiveOpsPerCommit = maxInteractiveOpsPerCommit;
+    this.interactiveMicroBatchMs = interactiveMicroBatchMs;
+  }
+
+  enqueueInteractive(
+    request: InteractiveWriteRequest,
+    coordinatorFor: (batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }) => JournaledWriteCoordinator
+  ): Promise<InteractiveWriteReceipt> {
+    if (this.closed) return Promise.reject({ _tag: "JournalUnavailable", cause: new Error("daemon write queue is closed") } satisfies WriteError);
+    this.coordinatorFor = coordinatorFor;
+    return new Promise((resolve, reject) => {
+      const item: InteractiveQueueItem = {
+        kind: "interactive",
+        commandId: request.commandId,
+        ops: request.ops,
+        ...(request.actor ? { actor: request.actor } : {}),
+        ...(request.commitAuthor ? { commitAuthor: request.commitAuthor } : {}),
+        enqueuedAt: Date.now(),
+        started: false,
+        resolve,
+        reject
+      };
+      if (request.deadlineMs !== undefined) {
+        item.timeout = setTimeout(() => {
+          if (item.started) return;
+          this.removeInteractive(item);
+          reject({ _tag: "JournalUnavailable", cause: new Error(`daemon queue wait timeout after ${request.deadlineMs}ms`) } satisfies WriteError);
+          this.resolveIdleIfNeeded();
+        }, request.deadlineMs);
+      }
+      this.interactive.push(item);
+      this.schedule();
+    });
+  }
+
+  enqueueBackground<Result>(request: BackgroundBatchRequest<Result>): Promise<Result> {
+    if (this.closed) return Promise.reject(new Error("daemon write queue is closed"));
+    return new Promise((resolve, reject) => {
+      const item: BackgroundQueueItem<Result> = {
+        kind: "background",
+        source: request.source,
+        priority: request.priority ?? "background",
+        run: request.run,
+        resolve,
+        reject
+      };
+      this.queueFor(item.priority).push(item as BackgroundQueueItem<unknown>);
+      this.schedule();
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  async idle(): Promise<void> {
+    if (this.isIdle()) return;
+    await new Promise<void>((resolve) => this.idleWaiters.push(resolve));
+  }
+
+  snapshot(): DaemonQueueSnapshot {
+    return {
+      interactive: this.interactive.length,
+      normal: this.normal.length,
+      background: this.background.length,
+      maintenance: this.maintenance.length,
+      running: this.running
+    };
+  }
+
+  private schedule(): void {
+    if (this.running) return;
+    this.running = true;
+    queueMicrotask(() => {
+      void this.drain().finally(() => {
+        this.running = false;
+        this.resolveIdleIfNeeded();
+        if (!this.isIdle()) this.schedule();
+      });
+    });
+  }
+
+  private async drain(): Promise<void> {
+    while (!this.isIdle()) {
+      if (this.interactive.length > 0) {
+        if (!this.coordinatorFor) return;
+        await this.drainInteractive(this.coordinatorFor);
+        continue;
+      }
+      const backgroundItem = this.normal.shift() ?? this.background.shift() ?? this.maintenance.shift();
+      if (!backgroundItem) return;
+      await this.runBackground(backgroundItem);
+    }
+  }
+
+  private async drainInteractive(
+    coordinatorFor: (batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }) => JournaledWriteCoordinator
+  ): Promise<void> {
+    if (this.interactiveMicroBatchMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, this.interactiveMicroBatchMs));
+    }
+    const batch: InteractiveQueueItem[] = [];
+    let opCount = 0;
+    while (this.interactive.length > 0 && opCount < this.maxInteractiveOpsPerCommit) {
+      const next = this.interactive[0]!;
+      if (batch.length > 0 && !sameAttribution(batch[0]!, next)) break;
+      const item = this.interactive.shift()!;
+      item.started = true;
+      if (item.timeout) clearTimeout(item.timeout);
+      batch.push(item);
+      opCount += item.ops.length;
+    }
+    const accepted: InteractiveQueueItem[] = [];
+    const coordinator = coordinatorFor(attributionFor(batch[0]));
+    for (const item of batch) {
+      try {
+        for (const op of item.ops) {
+          Effect.runSync(coordinator.enqueue(op));
+        }
+        accepted.push(item);
+      } catch (error) {
+        item.reject(toWriteError(error));
+      }
+    }
+    if (accepted.length === 0) return;
+    try {
+      const report = Effect.runSync(coordinator.flush("explicit"));
+      for (const item of accepted) {
+        item.resolve({
+          commandId: item.commandId,
+          opIds: item.ops.map((op) => op.opId),
+          durable: true,
+          flush: report
+        });
+      }
+    } catch (error) {
+      const writeError = toWriteError(error);
+      for (const item of accepted) item.reject(writeError);
+    }
+  }
+
+  private async runBackground(item: BackgroundQueueItem<unknown>): Promise<void> {
+    try {
+      item.resolve(await item.run());
+    } catch (error) {
+      item.reject(error);
+    }
+  }
+
+  private queueFor(priority: Exclude<DaemonWritePriority, "interactive">): BackgroundQueueItem<unknown>[] {
+    if (priority === "normal") return this.normal;
+    if (priority === "maintenance") return this.maintenance;
+    return this.background;
+  }
+
+  private removeInteractive(item: InteractiveQueueItem): void {
+    const index = this.interactive.indexOf(item);
+    if (index >= 0) this.interactive.splice(index, 1);
+  }
+
+  private isIdle(): boolean {
+    return this.interactive.length === 0
+      && this.normal.length === 0
+      && this.background.length === 0
+      && this.maintenance.length === 0
+      && !this.running;
+  }
+
+  private resolveIdleIfNeeded(): void {
+    if (!this.isIdle()) return;
+    const waiters = this.idleWaiters.splice(0, this.idleWaiters.length);
+    for (const resolve of waiters) resolve();
+  }
+}
+
+function attributionFor(item: InteractiveQueueItem | undefined): { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor } {
+  return {
+    ...(item?.actor ? { actor: item.actor } : {}),
+    ...(item?.commitAuthor ? { commitAuthor: item.commitAuthor } : {})
+  };
+}
+
+function sameAttribution(left: InteractiveQueueItem, right: InteractiveQueueItem): boolean {
+  return actorKey(left.actor) === actorKey(right.actor)
+    && authorKey(left.commitAuthor) === authorKey(right.commitAuthor);
+}
+
+function actorKey(actor: JournalActor | undefined): string {
+  return actor ? `${actor.kind}\0${actor.id}` : "";
+}
+
+function authorKey(author: GitCommitAuthor | undefined): string {
+  return author ? `${author.name}\0${author.email}` : "";
+}
+
+function toWriteError(error: unknown): WriteError {
+  if (isWriteError(error)) return error;
+  return { _tag: "JournalUnavailable", cause: error };
+}
+
+function isWriteError(error: unknown): error is WriteError {
+  return typeof error === "object"
+    && error !== null
+    && "_tag" in error
+    && (
+      error._tag === "WriteRejected"
+      || error._tag === "WriteConflict"
+      || error._tag === "GlobalWriteConflict"
+      || error._tag === "JournalUnavailable"
+    );
+}

--- a/packages/kernel/src/store/daemon-runtime.ts
+++ b/packages/kernel/src/store/daemon-runtime.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { Effect } from "effect";
-import type { FlushReport, RecoveryReport, WriteOp } from "../ports/write-coordinator.ts";
+import type { RecoveryReport } from "../ports/write-coordinator.ts";
 import type { WriteError } from "../domain/index.ts";
 import {
   createHarnessRuntimeContext,
@@ -8,9 +8,17 @@ import {
   resolveHarnessLayout
 } from "../layout/index.ts";
 import { runLedgerMaterializer, type LedgerMaterializerReport } from "./ledger-materializer.ts";
+import { DaemonWriteQueue } from "./daemon-runtime-queue.ts";
+import {
+  type BackgroundBatchRequest,
+  type DaemonQueueSnapshot,
+  type DaemonWritePriority,
+  type InteractiveWriteReceipt,
+  type InteractiveWriteRequest
+} from "./daemon-runtime-queue.ts";
 import { acquireDaemonGlobalLock, type DaemonGlobalLock } from "./write-journal-locks.ts";
 import { makeJournaledWriteCoordinator } from "./write-journal-coordinator.ts";
-import type { GitCommitAuthor, JournalActor } from "./write-journal-types.ts";
+import type { JournalActor } from "./write-journal-types.ts";
 
 const defaultDaemonActor: JournalActor = { kind: "system", id: "daemon-runtime" };
 const defaultLockTtlMs = 60_000;
@@ -18,7 +26,13 @@ const defaultInteractiveMicroBatchMs = 10;
 const defaultMaxInteractiveOpsPerCommit = 32;
 const defaultMaterializerMaxBranchesPerBatch = 1;
 
-export type DaemonWritePriority = "interactive" | "normal" | "background" | "maintenance";
+export type {
+  BackgroundBatchRequest,
+  DaemonQueueSnapshot,
+  DaemonWritePriority,
+  InteractiveWriteReceipt,
+  InteractiveWriteRequest
+};
 
 export interface DaemonRuntimeOptions {
   readonly rootDir: string;
@@ -29,35 +43,6 @@ export interface DaemonRuntimeOptions {
   readonly maxInteractiveOpsPerCommit?: number;
   readonly materializerPollMs?: number | false;
   readonly materializerMaxBranchesPerBatch?: number;
-}
-
-export interface InteractiveWriteRequest {
-  readonly commandId: string;
-  readonly ops: ReadonlyArray<WriteOp>;
-  readonly deadlineMs?: number;
-  readonly actor?: JournalActor;
-  readonly commitAuthor?: GitCommitAuthor;
-}
-
-export interface InteractiveWriteReceipt {
-  readonly commandId: string;
-  readonly opIds: ReadonlyArray<string>;
-  readonly durable: true;
-  readonly flush: FlushReport;
-}
-
-export interface BackgroundBatchRequest<Result = unknown> {
-  readonly source: string;
-  readonly priority?: Exclude<DaemonWritePriority, "interactive">;
-  readonly run: () => Result | Promise<Result>;
-}
-
-export interface DaemonQueueSnapshot {
-  readonly interactive: number;
-  readonly normal: number;
-  readonly background: number;
-  readonly maintenance: number;
-  readonly running: boolean;
 }
 
 export interface DaemonRuntimeStatus {
@@ -78,354 +63,361 @@ export interface HarnessDaemonRuntime {
   readonly enqueueMaterializerBatch: () => Promise<LedgerMaterializerReport>;
 }
 
-interface InteractiveQueueItem {
-  readonly kind: "interactive";
-  readonly commandId: string;
-  readonly ops: ReadonlyArray<WriteOp>;
-  readonly actor?: JournalActor;
-  readonly commitAuthor?: GitCommitAuthor;
-  readonly enqueuedAt: number;
-  started: boolean;
-  timeout?: ReturnType<typeof setTimeout>;
-  readonly resolve: (receipt: InteractiveWriteReceipt) => void;
-  readonly reject: (error: WriteError) => void;
+export type DaemonRepoRuntimeState = "attached" | "unavailable" | "detaching" | "detached";
+
+export interface DaemonRepoRuntimeOptions extends DaemonRuntimeOptions {
+  readonly repoId: string;
+  readonly displayName?: string;
 }
 
-interface BackgroundQueueItem<Result> {
-  readonly kind: "background";
-  readonly source: string;
-  readonly priority: Exclude<DaemonWritePriority, "interactive">;
-  readonly run: () => Result | Promise<Result>;
-  readonly resolve: (result: Result) => void;
-  readonly reject: (error: unknown) => void;
+export interface DaemonRepoRuntimeStatus extends DaemonRuntimeStatus {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+  readonly displayName?: string;
+  readonly state: DaemonRepoRuntimeState;
+  readonly lastError?: string;
+  readonly lastMaterializerError?: string;
+}
+
+export interface MultiRepoDaemonRuntimeOptions extends Omit<DaemonRuntimeOptions, "rootDir" | "layoutOverrides"> {
+  readonly repos: ReadonlyArray<DaemonRepoRuntimeOptions>;
+}
+
+export interface MultiRepoDaemonRuntimeStatus {
+  readonly started: boolean;
+  readonly repoCount: number;
+  readonly attachedCount: number;
+  readonly unavailableCount: number;
+  readonly repos: ReadonlyArray<DaemonRepoRuntimeStatus>;
+}
+
+export interface MultiRepoHarnessDaemonRuntime {
+  readonly start: () => Promise<MultiRepoDaemonRuntimeStatus>;
+  readonly stop: () => Promise<void>;
+  readonly status: () => MultiRepoDaemonRuntimeStatus;
+  readonly attachRepo: (repo: DaemonRepoRuntimeOptions) => Promise<DaemonRepoRuntimeStatus>;
+  readonly detachRepo: (repoId: string) => Promise<DaemonRepoRuntimeStatus>;
+  readonly retryUnavailableRepos: () => Promise<ReadonlyArray<DaemonRepoRuntimeStatus>>;
+  readonly getRepoRuntime: (repoId: string) => HarnessDaemonRuntime | undefined;
+  readonly enqueueInteractiveWrite: (repoId: string, request: InteractiveWriteRequest) => Promise<InteractiveWriteReceipt>;
+  readonly enqueueBackgroundBatch: <Result>(repoId: string, request: BackgroundBatchRequest<Result>) => Promise<Result>;
+  readonly enqueueMaterializerBatch: (repoId: string) => Promise<LedgerMaterializerReport>;
 }
 
 export function createDaemonRuntime(options: DaemonRuntimeOptions): HarnessDaemonRuntime {
-  const rootDir = path.resolve(options.rootDir);
-  const runtimeContext = createHarnessRuntimeContext(rootDir, options.layoutOverrides);
-  const layout = resolveHarnessLayout(runtimeContext);
-  const actor = options.actor ?? defaultDaemonActor;
-  const lockTtlMs = options.lockTtlMs ?? defaultLockTtlMs;
-  const maxInteractiveOpsPerCommit = options.maxInteractiveOpsPerCommit ?? defaultMaxInteractiveOpsPerCommit;
-  const interactiveMicroBatchMs = options.interactiveMicroBatchMs ?? defaultInteractiveMicroBatchMs;
-  const materializerMaxBranchesPerBatch = options.materializerMaxBranchesPerBatch ?? defaultMaterializerMaxBranchesPerBatch;
-  const queue = new DaemonWriteQueue(maxInteractiveOpsPerCommit, interactiveMicroBatchMs);
-  let lock: DaemonGlobalLock | undefined;
-  let coordinator: ReturnType<typeof makeJournaledWriteCoordinator> | undefined;
-  let lastRecovery: RecoveryReport | undefined;
-  let materializerTimer: ReturnType<typeof setInterval> | undefined;
-
-  const requireStarted = () => {
-    if (!lock || !coordinator) {
-      throw { _tag: "JournalUnavailable", cause: new Error("daemon runtime is not started") } satisfies WriteError;
-    }
-    return { lock, coordinator };
-  };
-
-  const enqueueMaterializerBatch = () => enqueueBackgroundBatch({
-    source: "ledger-materializer",
-    priority: "background",
-    run: () => {
-      const started = requireStarted();
-      return runLedgerMaterializer(runtimeContext, {
-        heldGlobalLock: started.lock,
-        maxBranches: materializerMaxBranchesPerBatch
-      });
-    }
-  });
-
-  const enqueueBackgroundBatch = <Result>(request: BackgroundBatchRequest<Result>): Promise<Result> => {
-    requireStarted();
-    return queue.enqueueBackground(request);
-  };
-
-  const makeStartedCoordinator = (
-    started: ReturnType<typeof requireStarted>,
-    request?: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }
-  ) => makeJournaledWriteCoordinator({
-    rootDir,
-    layoutOverrides: options.layoutOverrides,
-    actor: request?.actor ?? actor,
-    lockTtlMs,
-    heldGlobalLock: started.lock,
-    autoMaterialize: false,
-    ...(request?.commitAuthor ? { commitAuthor: request.commitAuthor } : {})
-  });
-
+  const context = new DaemonRepoRuntimeContext({ ...options, repoId: "canonical" });
   return {
+    start: async () => toDaemonRuntimeStatus(await context.attach({ failOnError: true })),
+    stop: () => context.stop(),
+    status: () => toDaemonRuntimeStatus(context.status()),
+    enqueueInteractiveWrite: (request) => context.enqueueInteractiveWrite(request),
+    enqueueBackgroundBatch: (request) => context.enqueueBackgroundBatch(request),
+    enqueueMaterializerBatch: () => context.enqueueMaterializerBatch()
+  };
+}
+
+export function createMultiRepoDaemonRuntime(options: MultiRepoDaemonRuntimeOptions): MultiRepoHarnessDaemonRuntime {
+  const contexts = new Map<string, DaemonRepoRuntimeContext>();
+  let started = false;
+
+  for (const repo of sortedRepoOptions(options.repos)) {
+    addContext(mergeRepoDefaults(repo, options));
+  }
+
+  const runtime: MultiRepoHarnessDaemonRuntime = {
     start: async () => {
-      if (lock && coordinator) return status();
-      lock = acquireDaemonGlobalLock(rootDir, runtimeContext, layout.journalPath, actor, lockTtlMs);
-      coordinator = makeJournaledWriteCoordinator({
-        rootDir,
-        layoutOverrides: options.layoutOverrides,
-        actor,
-        lockTtlMs,
-        heldGlobalLock: lock,
-        autoMaterialize: false
-      });
-      lastRecovery = Effect.runSync(coordinator.recover);
-      if (options.materializerPollMs !== false && typeof options.materializerPollMs === "number" && options.materializerPollMs > 0) {
-        materializerTimer = setInterval(() => {
-          void enqueueMaterializerBatch().catch(() => undefined);
-        }, options.materializerPollMs);
-        materializerTimer.unref();
+      started = true;
+      for (const context of sortedContexts(contexts)) {
+        await context.attach({ failOnError: false });
       }
       return status();
     },
     stop: async () => {
-      if (materializerTimer) clearInterval(materializerTimer);
-      materializerTimer = undefined;
-      queue.close();
-      await queue.idle();
-      lock?.release();
-      lock = undefined;
-      coordinator = undefined;
+      const errors: unknown[] = [];
+      for (const context of sortedContexts(contexts)) {
+        try {
+          await context.stop();
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      started = false;
+      if (errors.length > 0) throw new AggregateError(errors, "failed to stop one or more repo runtimes");
     },
     status,
-    enqueueInteractiveWrite: (request) => {
-      const started = requireStarted();
-      return queue.enqueueInteractive(request, (batch) => makeStartedCoordinator(started, batch));
+    attachRepo: async (repo) => {
+      const context = contexts.get(repo.repoId) ?? addContext(mergeRepoDefaults(repo, options));
+      started = true;
+      return context.attach({ failOnError: false });
     },
-    enqueueBackgroundBatch,
-    enqueueMaterializerBatch
+    detachRepo: async (repoId) => {
+      const context = requireContext(contexts, repoId);
+      await context.stop();
+      return context.status();
+    },
+    retryUnavailableRepos: async () => {
+      const retried: DaemonRepoRuntimeStatus[] = [];
+      for (const context of sortedContexts(contexts)) {
+        if (context.state !== "unavailable") continue;
+        retried.push(await context.attach({ failOnError: false }));
+      }
+      return retried;
+    },
+    getRepoRuntime: (repoId) => contexts.get(repoId),
+    enqueueInteractiveWrite: (repoId, request) => requireContext(contexts, repoId).enqueueInteractiveWrite(request),
+    enqueueBackgroundBatch: (repoId, request) => requireContext(contexts, repoId).enqueueBackgroundBatch(request),
+    enqueueMaterializerBatch: (repoId) => requireContext(contexts, repoId).enqueueMaterializerBatch()
   };
+  return runtime;
 
-  function status(): DaemonRuntimeStatus {
+  function status(): MultiRepoDaemonRuntimeStatus {
+    const repos = sortedContexts(contexts).map((context) => context.status());
     return {
-      started: Boolean(lock && coordinator),
-      rootDir,
-      ...(lock ? { lockPath: path.relative(rootDir, lock.path).split(path.sep).join("/"), lockOwnerToken: lock.ownerToken } : {}),
-      queue: queue.snapshot(),
-      ...(lastRecovery ? { lastRecovery } : {})
+      started,
+      repoCount: repos.length,
+      attachedCount: repos.filter((repo) => repo.state === "attached").length,
+      unavailableCount: repos.filter((repo) => repo.state === "unavailable").length,
+      repos
     };
+  }
+
+  function addContext(repo: DaemonRepoRuntimeOptions): DaemonRepoRuntimeContext {
+    if (contexts.has(repo.repoId)) throw new Error(`duplicate daemon repoId: ${repo.repoId}`);
+    const rootDir = path.resolve(repo.rootDir);
+    for (const existing of contexts.values()) {
+      if (existing.rootDir === rootDir) throw new Error(`duplicate daemon repo root: ${rootDir}`);
+    }
+    const context = new DaemonRepoRuntimeContext({ ...repo, rootDir });
+    contexts.set(repo.repoId, context);
+    return context;
   }
 }
 
-class DaemonWriteQueue {
-  private readonly interactive: InteractiveQueueItem[] = [];
-  private readonly normal: BackgroundQueueItem<unknown>[] = [];
-  private readonly background: BackgroundQueueItem<unknown>[] = [];
-  private readonly maintenance: BackgroundQueueItem<unknown>[] = [];
-  private running = false;
-  private closed = false;
-  private idleWaiters: Array<() => void> = [];
-  private coordinatorFor: ((batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }) => ReturnType<typeof makeJournaledWriteCoordinator>) | undefined;
-  private readonly maxInteractiveOpsPerCommit: number;
-  private readonly interactiveMicroBatchMs: number;
+class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
+  readonly repoId: string;
+  readonly rootDir: string;
+  readonly displayName: string | undefined;
+  state: DaemonRepoRuntimeState = "detached";
 
-  constructor(
-    maxInteractiveOpsPerCommit: number,
-    interactiveMicroBatchMs: number
-  ) {
-    this.maxInteractiveOpsPerCommit = maxInteractiveOpsPerCommit;
-    this.interactiveMicroBatchMs = interactiveMicroBatchMs;
+  private readonly runtimeContext: ReturnType<typeof createHarnessRuntimeContext>;
+  private readonly layout: ReturnType<typeof resolveHarnessLayout>;
+  private readonly actor: JournalActor;
+  private readonly lockTtlMs: number;
+  private readonly materializerMaxBranchesPerBatch: number;
+  private readonly queue: DaemonWriteQueue;
+  private readonly options: DaemonRepoRuntimeOptions;
+  private lock: DaemonGlobalLock | undefined;
+  private coordinator: ReturnType<typeof makeJournaledWriteCoordinator> | undefined;
+  private lastRecovery: RecoveryReport | undefined;
+  private lastError: string | undefined;
+  private lastMaterializerError: string | undefined;
+  private materializerTimer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(options: DaemonRepoRuntimeOptions) {
+    this.options = options;
+    this.repoId = options.repoId;
+    this.rootDir = path.resolve(options.rootDir);
+    this.displayName = options.displayName;
+    this.runtimeContext = createHarnessRuntimeContext(this.rootDir, options.layoutOverrides);
+    this.layout = resolveHarnessLayout(this.runtimeContext);
+    this.actor = options.actor ?? defaultDaemonActor;
+    this.lockTtlMs = options.lockTtlMs ?? defaultLockTtlMs;
+    this.materializerMaxBranchesPerBatch = options.materializerMaxBranchesPerBatch ?? defaultMaterializerMaxBranchesPerBatch;
+    this.queue = new DaemonWriteQueue(
+      options.maxInteractiveOpsPerCommit ?? defaultMaxInteractiveOpsPerCommit,
+      options.interactiveMicroBatchMs ?? defaultInteractiveMicroBatchMs
+    );
   }
 
-  enqueueInteractive(
-    request: InteractiveWriteRequest,
-    coordinatorFor: (batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }) => ReturnType<typeof makeJournaledWriteCoordinator>
-  ): Promise<InteractiveWriteReceipt> {
-    if (this.closed) return Promise.reject({ _tag: "JournalUnavailable", cause: new Error("daemon write queue is closed") } satisfies WriteError);
-    this.coordinatorFor = coordinatorFor;
-    return new Promise((resolve, reject) => {
-      const item: InteractiveQueueItem = {
-        kind: "interactive",
-        commandId: request.commandId,
-        ops: request.ops,
-        ...(request.actor ? { actor: request.actor } : {}),
-        ...(request.commitAuthor ? { commitAuthor: request.commitAuthor } : {}),
-        enqueuedAt: Date.now(),
-        started: false,
-        resolve,
-        reject
-      };
-      if (request.deadlineMs !== undefined) {
-        item.timeout = setTimeout(() => {
-          if (item.started) return;
-          this.removeInteractive(item);
-          reject({ _tag: "JournalUnavailable", cause: new Error(`daemon queue wait timeout after ${request.deadlineMs}ms`) } satisfies WriteError);
-          this.resolveIdleIfNeeded();
-        }, request.deadlineMs);
-      }
-      this.interactive.push(item);
-      this.schedule();
-    });
+  start(): Promise<DaemonRuntimeStatus> {
+    return this.attach({ failOnError: true });
   }
 
-  enqueueBackground<Result>(request: BackgroundBatchRequest<Result>): Promise<Result> {
-    if (this.closed) return Promise.reject(new Error("daemon write queue is closed"));
-    return new Promise((resolve, reject) => {
-      const item: BackgroundQueueItem<Result> = {
-        kind: "background",
-        source: request.source,
-        priority: request.priority ?? "background",
-        run: request.run,
-        resolve,
-        reject
-      };
-      this.queueFor(item.priority).push(item as BackgroundQueueItem<unknown>);
-      this.schedule();
-    });
+  async attach(input: { readonly failOnError: boolean }): Promise<DaemonRepoRuntimeStatus> {
+    if (this.lock && this.coordinator && this.state === "attached") return this.status();
+    try {
+      this.lock = acquireDaemonGlobalLock(this.rootDir, this.runtimeContext, this.layout.journalPath, this.actor, this.lockTtlMs);
+      this.coordinator = makeJournaledWriteCoordinator({
+        rootDir: this.rootDir,
+        layoutOverrides: this.options.layoutOverrides,
+        actor: this.actor,
+        lockTtlMs: this.lockTtlMs,
+        heldGlobalLock: this.lock,
+        autoMaterialize: false
+      });
+      this.lastRecovery = Effect.runSync(this.coordinator.recover);
+      this.lastError = undefined;
+      this.lastMaterializerError = undefined;
+      this.state = "attached";
+      this.startMaterializerTimer();
+      return this.status();
+    } catch (error) {
+      this.releaseStartedParts();
+      this.state = "unavailable";
+      this.lastError = describeError(error);
+      if (input.failOnError) throw error;
+      return this.status();
+    }
   }
 
-  close(): void {
-    this.closed = true;
+  async stop(): Promise<void> {
+    this.state = "detaching";
+    this.stopMaterializerTimer();
+    await this.queue.idle();
+    try {
+      this.lock?.release();
+      this.lastError = undefined;
+    } catch (error) {
+      this.lastError = describeError(error);
+      throw error;
+    } finally {
+      this.lock = undefined;
+      this.coordinator = undefined;
+      this.state = "detached";
+    }
   }
 
-  async idle(): Promise<void> {
-    if (this.isIdle()) return;
-    await new Promise<void>((resolve) => this.idleWaiters.push(resolve));
-  }
-
-  snapshot(): DaemonQueueSnapshot {
+  status(): DaemonRepoRuntimeStatus {
     return {
-      interactive: this.interactive.length,
-      normal: this.normal.length,
-      background: this.background.length,
-      maintenance: this.maintenance.length,
-      running: this.running
+      started: Boolean(this.lock && this.coordinator && this.state === "attached"),
+      rootDir: this.rootDir,
+      repoId: this.repoId,
+      canonicalRoot: this.rootDir,
+      ...(this.displayName ? { displayName: this.displayName } : {}),
+      state: this.state,
+      ...(this.lock ? { lockPath: path.relative(this.rootDir, this.lock.path).split(path.sep).join("/"), lockOwnerToken: this.lock.ownerToken } : {}),
+      queue: this.queue.snapshot(),
+      ...(this.lastRecovery ? { lastRecovery: this.lastRecovery } : {}),
+      ...(this.lastError ? { lastError: this.lastError } : {}),
+      ...(this.lastMaterializerError ? { lastMaterializerError: this.lastMaterializerError } : {})
     };
   }
 
-  private schedule(): void {
-    if (this.running) return;
-    this.running = true;
-    queueMicrotask(() => {
-      void this.drain().finally(() => {
-        this.running = false;
-        this.resolveIdleIfNeeded();
-        if (!this.isIdle()) this.schedule();
+  enqueueInteractiveWrite(request: InteractiveWriteRequest): Promise<InteractiveWriteReceipt> {
+    const started = this.requireAttached();
+    return this.queue.enqueueInteractive(request, (batch) => this.makeStartedCoordinator(started, batch))
+      .catch((error: unknown) => {
+        this.lastError = describeError(error);
+        throw error;
       });
-    });
   }
 
-  private async drain(): Promise<void> {
-    while (!this.isIdle()) {
-      if (this.interactive.length > 0) {
-        if (!this.coordinatorFor) return;
-        await this.drainInteractive(this.coordinatorFor);
-        continue;
-      }
-      const backgroundItem = this.normal.shift() ?? this.background.shift() ?? this.maintenance.shift();
-      if (!backgroundItem) return;
-      await this.runBackground(backgroundItem);
-    }
+  enqueueBackgroundBatch<Result>(request: BackgroundBatchRequest<Result>): Promise<Result> {
+    this.requireAttached();
+    return this.queue.enqueueBackground(request)
+      .catch((error: unknown) => {
+        this.lastError = describeError(error);
+        throw error;
+      });
   }
 
-  private async drainInteractive(
-    coordinatorFor: (batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }) => ReturnType<typeof makeJournaledWriteCoordinator>
-  ): Promise<void> {
-    if (this.interactiveMicroBatchMs > 0) {
-      await new Promise((resolve) => setTimeout(resolve, this.interactiveMicroBatchMs));
-    }
-    const batch: InteractiveQueueItem[] = [];
-    let opCount = 0;
-    while (this.interactive.length > 0 && opCount < this.maxInteractiveOpsPerCommit) {
-      const next = this.interactive[0]!;
-      if (batch.length > 0 && !sameAttribution(batch[0]!, next)) break;
-      const item = this.interactive.shift()!;
-      item.started = true;
-      if (item.timeout) clearTimeout(item.timeout);
-      batch.push(item);
-      opCount += item.ops.length;
-    }
-    const accepted: InteractiveQueueItem[] = [];
-    const coordinator = coordinatorFor(attributionFor(batch[0]));
-    for (const item of batch) {
-      try {
-        for (const op of item.ops) {
-          Effect.runSync(coordinator.enqueue(op));
-        }
-        accepted.push(item);
-      } catch (error) {
-        item.reject(toWriteError(error));
-      }
-    }
-    if (accepted.length === 0) return;
-    try {
-      const report = Effect.runSync(coordinator.flush("explicit"));
-      for (const item of accepted) {
-        item.resolve({
-          commandId: item.commandId,
-          opIds: item.ops.map((op) => op.opId),
-          durable: true,
-          flush: report
+  enqueueMaterializerBatch(): Promise<LedgerMaterializerReport> {
+    return this.enqueueBackgroundBatch({
+      source: "ledger-materializer",
+      priority: "background",
+      run: () => {
+        const started = this.requireAttached();
+        return runLedgerMaterializer(this.runtimeContext, {
+          heldGlobalLock: started.lock,
+          maxBranches: this.materializerMaxBranchesPerBatch
         });
       }
-    } catch (error) {
-      const writeError = toWriteError(error);
-      for (const item of accepted) item.reject(writeError);
-    }
+    }).catch((error: unknown) => {
+      this.lastMaterializerError = describeError(error);
+      throw error;
+    });
   }
 
-  private async runBackground(item: BackgroundQueueItem<unknown>): Promise<void> {
+  private requireAttached(): { readonly lock: DaemonGlobalLock; readonly coordinator: ReturnType<typeof makeJournaledWriteCoordinator> } {
+    if (!this.lock || !this.coordinator || this.state !== "attached") {
+      throw { _tag: "JournalUnavailable", cause: new Error(`daemon repo "${this.repoId}" is not attached`) } satisfies WriteError;
+    }
+    return { lock: this.lock, coordinator: this.coordinator };
+  }
+
+  private makeStartedCoordinator(
+    started: ReturnType<DaemonRepoRuntimeContext["requireAttached"]>,
+    request?: { readonly actor?: JournalActor; readonly commitAuthor?: InteractiveWriteRequest["commitAuthor"] }
+  ) {
+    return makeJournaledWriteCoordinator({
+      rootDir: this.rootDir,
+      layoutOverrides: this.options.layoutOverrides,
+      actor: request?.actor ?? this.actor,
+      lockTtlMs: this.lockTtlMs,
+      heldGlobalLock: started.lock,
+      autoMaterialize: false,
+      ...(request?.commitAuthor ? { commitAuthor: request.commitAuthor } : {})
+    });
+  }
+
+  private startMaterializerTimer(): void {
+    this.stopMaterializerTimer();
+    if (this.options.materializerPollMs === false || typeof this.options.materializerPollMs !== "number" || this.options.materializerPollMs <= 0) {
+      return;
+    }
+    this.materializerTimer = setInterval(() => {
+      void this.enqueueMaterializerBatch().catch(() => undefined);
+    }, this.options.materializerPollMs);
+    this.materializerTimer.unref();
+  }
+
+  private stopMaterializerTimer(): void {
+    if (this.materializerTimer) clearInterval(this.materializerTimer);
+    this.materializerTimer = undefined;
+  }
+
+  private releaseStartedParts(): void {
+    this.stopMaterializerTimer();
     try {
-      item.resolve(await item.run());
-    } catch (error) {
-      item.reject(error);
+      this.lock?.release();
+    } catch {
+      // Attach failure reporting should keep the original attach error.
     }
-  }
-
-  private queueFor(priority: Exclude<DaemonWritePriority, "interactive">): BackgroundQueueItem<unknown>[] {
-    if (priority === "normal") return this.normal;
-    if (priority === "maintenance") return this.maintenance;
-    return this.background;
-  }
-
-  private removeInteractive(item: InteractiveQueueItem): void {
-    const index = this.interactive.indexOf(item);
-    if (index >= 0) this.interactive.splice(index, 1);
-  }
-
-  private isIdle(): boolean {
-    return this.interactive.length === 0
-      && this.normal.length === 0
-      && this.background.length === 0
-      && this.maintenance.length === 0
-      && !this.running;
-  }
-
-  private resolveIdleIfNeeded(): void {
-    if (!this.isIdle()) return;
-    const waiters = this.idleWaiters.splice(0, this.idleWaiters.length);
-    for (const resolve of waiters) resolve();
+    this.lock = undefined;
+    this.coordinator = undefined;
   }
 }
 
-function attributionFor(item: InteractiveQueueItem | undefined): { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor } {
+function toDaemonRuntimeStatus(status: DaemonRepoRuntimeStatus): DaemonRuntimeStatus {
   return {
-    ...(item?.actor ? { actor: item.actor } : {}),
-    ...(item?.commitAuthor ? { commitAuthor: item.commitAuthor } : {})
+    started: status.started,
+    rootDir: status.rootDir,
+    ...(status.lockPath ? { lockPath: status.lockPath, lockOwnerToken: status.lockOwnerToken } : {}),
+    queue: status.queue,
+    ...(status.lastRecovery ? { lastRecovery: status.lastRecovery } : {})
   };
 }
 
-function sameAttribution(left: InteractiveQueueItem, right: InteractiveQueueItem): boolean {
-  return actorKey(left.actor) === actorKey(right.actor)
-    && authorKey(left.commitAuthor) === authorKey(right.commitAuthor);
+function mergeRepoDefaults(repo: DaemonRepoRuntimeOptions, options: MultiRepoDaemonRuntimeOptions): DaemonRepoRuntimeOptions {
+  return {
+    ...repo,
+    ...(repo.actor ? {} : options.actor ? { actor: options.actor } : {}),
+    ...(repo.lockTtlMs !== undefined ? {} : options.lockTtlMs !== undefined ? { lockTtlMs: options.lockTtlMs } : {}),
+    ...(repo.interactiveMicroBatchMs !== undefined ? {} : options.interactiveMicroBatchMs !== undefined ? { interactiveMicroBatchMs: options.interactiveMicroBatchMs } : {}),
+    ...(repo.maxInteractiveOpsPerCommit !== undefined ? {} : options.maxInteractiveOpsPerCommit !== undefined ? { maxInteractiveOpsPerCommit: options.maxInteractiveOpsPerCommit } : {}),
+    ...(repo.materializerPollMs !== undefined ? {} : options.materializerPollMs !== undefined ? { materializerPollMs: options.materializerPollMs } : {}),
+    ...(repo.materializerMaxBranchesPerBatch !== undefined ? {} : options.materializerMaxBranchesPerBatch !== undefined ? { materializerMaxBranchesPerBatch: options.materializerMaxBranchesPerBatch } : {})
+  };
 }
 
-function actorKey(actor: JournalActor | undefined): string {
-  return actor ? `${actor.kind}\0${actor.id}` : "";
+function sortedRepoOptions(repos: ReadonlyArray<DaemonRepoRuntimeOptions>): ReadonlyArray<DaemonRepoRuntimeOptions> {
+  return [...repos].sort((left, right) => left.repoId.localeCompare(right.repoId) || path.resolve(left.rootDir).localeCompare(path.resolve(right.rootDir)));
 }
 
-function authorKey(author: GitCommitAuthor | undefined): string {
-  return author ? `${author.name}\0${author.email}` : "";
+function sortedContexts(contexts: Map<string, DaemonRepoRuntimeContext>): ReadonlyArray<DaemonRepoRuntimeContext> {
+  return [...contexts.values()].sort((left, right) => left.repoId.localeCompare(right.repoId) || left.rootDir.localeCompare(right.rootDir));
 }
 
-function toWriteError(error: unknown): WriteError {
-  if (isWriteError(error)) return error;
-  return { _tag: "JournalUnavailable", cause: error };
+function requireContext(contexts: Map<string, DaemonRepoRuntimeContext>, repoId: string): DaemonRepoRuntimeContext {
+  const context = contexts.get(repoId);
+  if (!context) throw { _tag: "JournalUnavailable", cause: new Error(`unknown daemon repo "${repoId}"`) } satisfies WriteError;
+  return context;
 }
 
-function isWriteError(error: unknown): error is WriteError {
-  return typeof error === "object"
-    && error !== null
-    && "_tag" in error
-    && (
-      error._tag === "WriteRejected"
-      || error._tag === "WriteConflict"
-      || error._tag === "GlobalWriteConflict"
-      || error._tag === "JournalUnavailable"
-    );
+function describeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null && "cause" in error) {
+    return describeError((error as { readonly cause?: unknown }).cause);
+  }
+  return String(error);
 }

--- a/packages/kernel/test/store/daemon-runtime.test.ts
+++ b/packages/kernel/test/store/daemon-runtime.test.ts
@@ -4,8 +4,10 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
+import { createHarnessRuntimeContext, resolveHarnessLayout } from "../../src/layout/index.ts";
 import { makeJournaledWriteCoordinator } from "../../src/store/write-journal-coordinator.ts";
-import { createDaemonRuntime } from "../../src/store/daemon-runtime.ts";
+import { createDaemonRuntime, createMultiRepoDaemonRuntime } from "../../src/store/daemon-runtime.ts";
+import { acquireDaemonGlobalLock } from "../../src/store/write-journal-locks.ts";
 import { docWrite, withTempStoreAsync } from "./helpers.ts";
 
 test("daemon runtime holds global.lock, rejects direct writes before journaling, and yields background batches to P0 writes", async () => {
@@ -27,12 +29,21 @@ test("daemon runtime holds global.lock, rejects direct writes before journaling,
     assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
 
     const order: string[] = [];
+    let backgroundStarted!: () => void;
+    let releaseBackground!: () => void;
+    const backgroundStartedPromise = new Promise<void>((resolve) => {
+      backgroundStarted = resolve;
+    });
+    const releaseBackgroundPromise = new Promise<void>((resolve) => {
+      releaseBackground = resolve;
+    });
     const firstBackground = runtime.enqueueBackgroundBatch({
       source: "test-background-1",
       priority: "background",
       run: async () => {
         order.push("background-1-start");
-        await delay(25);
+        backgroundStarted();
+        await releaseBackgroundPromise;
         order.push("background-1-end");
       }
     });
@@ -40,10 +51,11 @@ test("daemon runtime holds global.lock, rejects direct writes before journaling,
       source: "test-background-2",
       priority: "background",
       run: () => {
-        order.push("background-2");
+        const interactivePath = path.join(rootDir, "harness/tasks/task-1/interactive.md");
+        order.push(existsSync(interactivePath) ? "background-2-after-interactive" : "background-2-before-interactive");
       }
     });
-    await delay(5);
+    await backgroundStartedPromise;
     const interactive = runtime.enqueueInteractiveWrite({
       commandId: "cmd-interactive",
       ops: [docWrite("op-interactive", "task-1", "interactive.md", "interactive")]
@@ -51,6 +63,7 @@ test("daemon runtime holds global.lock, rejects direct writes before journaling,
       order.push("interactive");
       return receipt;
     });
+    releaseBackground();
 
     const receipt = await interactive;
     await firstBackground;
@@ -58,7 +71,7 @@ test("daemon runtime holds global.lock, rejects direct writes before journaling,
     assert.equal(receipt.durable, true);
     assert.equal(receipt.flush.watermark, "op-interactive");
     assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-1/interactive.md"), "utf8"), "interactive");
-    assert.ok(order.indexOf("interactive") < order.indexOf("background-2"), order.join(","));
+    assert.ok(order.includes("background-2-after-interactive"), order.join(","));
     await runtime.stop();
     assert.equal(existsSync(path.join(rootDir, ".harness/locks/global.lock")), false);
   });
@@ -151,9 +164,105 @@ test("daemon interactive queue does not mix different git authors in one commit"
   });
 });
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+test("multi-repo daemon isolates attach lock failures by repo", async () => {
+  await withTempStoreAsync(async (lockedRoot) => {
+    await withTempStoreAsync(async (availableRoot) => {
+      const lockedContext = createHarnessRuntimeContext(lockedRoot);
+      const lockedLayout = resolveHarnessLayout(lockedContext);
+      const externalLock = acquireDaemonGlobalLock(
+        lockedRoot,
+        lockedContext,
+        lockedLayout.journalPath,
+        { kind: "system", id: "other-daemon" },
+        60_000
+      );
+      const runtime = createMultiRepoDaemonRuntime({
+        materializerPollMs: false,
+        interactiveMicroBatchMs: 0,
+        repos: [
+          { repoId: "locked", rootDir: lockedRoot },
+          { repoId: "available", rootDir: availableRoot }
+        ]
+      });
+
+      try {
+        const status = await runtime.start();
+        assert.equal(status.repoCount, 2);
+        assert.equal(status.attachedCount, 1);
+        assert.equal(status.unavailableCount, 1);
+        assert.equal(status.repos.find((repo) => repo.repoId === "locked")?.state, "unavailable");
+        assert.equal(status.repos.find((repo) => repo.repoId === "available")?.state, "attached");
+
+        await runtime.enqueueInteractiveWrite("available", {
+          commandId: "cmd-available",
+          ops: [docWrite("op-available", "task-available", "note.md", "available")]
+        });
+        assert.equal(readFileSync(path.join(availableRoot, "harness/tasks/task-available/note.md"), "utf8"), "available");
+
+        assert.throws(
+          () => runtime.enqueueInteractiveWrite("locked", {
+            commandId: "cmd-locked",
+            ops: [docWrite("op-locked", "task-locked", "note.md", "locked")]
+          }),
+          (error: unknown) => {
+            assert.equal(typeof error, "object");
+            assert.notEqual(error, null);
+            assert.equal((error as { readonly _tag?: string })._tag, "JournalUnavailable");
+            assert.match(String((error as { readonly cause?: unknown }).cause), /daemon repo "locked" is not attached/u);
+            return true;
+          }
+        );
+      } finally {
+        await runtime.stop();
+        externalLock.release();
+      }
+    });
+  });
+});
+
+test("multi-repo daemon detaches one repo without releasing other repo locks", async () => {
+  await withTempStoreAsync(async (firstRoot) => {
+    await withTempStoreAsync(async (secondRoot) => {
+      const runtime = createMultiRepoDaemonRuntime({
+        materializerPollMs: false,
+        interactiveMicroBatchMs: 0,
+        repos: [
+          { repoId: "first", rootDir: firstRoot },
+          { repoId: "second", rootDir: secondRoot }
+        ]
+      });
+
+      await runtime.start();
+      assert.equal(existsSync(path.join(firstRoot, ".harness/locks/global.lock")), true);
+      assert.equal(existsSync(path.join(secondRoot, ".harness/locks/global.lock")), true);
+
+      const detached = await runtime.detachRepo("first");
+      assert.equal(detached.state, "detached");
+      assert.equal(existsSync(path.join(firstRoot, ".harness/locks/global.lock")), false);
+      assert.equal(existsSync(path.join(secondRoot, ".harness/locks/global.lock")), true);
+
+      const reattached = await runtime.attachRepo({ repoId: "first", rootDir: firstRoot, materializerPollMs: false });
+      assert.equal(reattached.state, "attached");
+      assert.equal(existsSync(path.join(firstRoot, ".harness/locks/global.lock")), true);
+
+      await runtime.enqueueInteractiveWrite("first", {
+        commandId: "cmd-first",
+        ops: [docWrite("op-first", "task-first", "note.md", "first")]
+      });
+      assert.equal(readFileSync(path.join(firstRoot, "harness/tasks/task-first/note.md"), "utf8"), "first");
+
+      await runtime.enqueueInteractiveWrite("second", {
+        commandId: "cmd-second",
+        ops: [docWrite("op-second", "task-second", "note.md", "second")]
+      });
+      assert.equal(readFileSync(path.join(secondRoot, "harness/tasks/task-second/note.md"), "utf8"), "second");
+
+      await runtime.stop();
+      assert.equal(existsSync(path.join(firstRoot, ".harness/locks/global.lock")), false);
+      assert.equal(existsSync(path.join(secondRoot, ".harness/locks/global.lock")), false);
+    });
+  });
+});
 
 async function spawnJournalOnlyDaemon(rootDir: string): Promise<void> {
   const childScript = `


### PR DESCRIPTION
# English

## Summary

W9-P2 (second of five multi-repo daemon packages): the kernel daemon runtime becomes a multi-repo manager — one daemon process holds an independent lock, write queue, WriteCoordinator, and materializer per attached canonical repo, with per-repo fault isolation per design §2 and the accepted D4 refinement dec_mra8fx5h. The single-repo API is preserved as a compatibility wrapper (zero regression).

## What Changed

- **Multi-repo manager** (`packages/kernel/src/store/daemon-runtime.ts`): per-repo runtime status, `attachRepo` / `detachRepo` / `retryUnavailableRepos`, and repoId-keyed dispatch of interactive writes and materializer scheduling. Each attached repo acquires and holds its own `.harness/locks/global.lock` from attach success until detach or daemon stop; a repo whose lock/recovery fails is marked unavailable without affecting other repos.
- **Lock semantics**: non-blocking acquisition retained; no hold-and-wait (retry targets only unattached repos independently); detach releases only that repo's lock; stop drains and releases all attached repos.
- **Queue extraction** (`packages/kernel/src/store/daemon-runtime-queue.ts`): existing interactive queue moved out intact — #270's author-safe batching (`sameAttribution`) preserved verbatim with its regression test.
- **Single-repo compatibility**: `createDaemonRuntime` keeps its existing signature as a wrapper pinning `repoId="canonical"`; existing callers are unchanged.
- **Tests**: multi-repo lock failure isolation, detach/reattach lifecycle (locks verified released/reacquired on disk), per-repo write routing, stop releasing all locks, and single-repo compatibility regression.

## Task And Scope

- Harness task: task_01KWX37QN3W1WJW2EN4GGF4S08 (PLT-Daemon W9, segment 2, package 2 of 5)
- Branch: codex/w9-p2-kernel-runtime (rebased on main after #292 merged)
- Out of scope: protocol host routing (P3), CLI user-level endpoint (P4), cross-package integration verification (P5).

## Version Impact

- No version change (kernel-internal restructuring; daemon protocol and CLI behavior unchanged until P3/P4 consume the manager).

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: kernel write path (`daemon-runtime.ts`, new `daemon-runtime-queue.ts`).
- Authority: task_01KWX37QN3W1WJW2EN4GGF4S08 segment-2 design (`artifacts/multi-repo-lifecycle-design.md` §2/§6, CEO-reviewed PASS), dec_mra8fx5h (per-attached-repo lock, attach→detach lifetime, fail-closed per repo), dec_mr9sgtzr (author-safe batching preserved), dec_mr9acuxm (D4 sole write path).
- Machine-check boundary: bypass-write gate unchanged (119 governed writes, delta 0); WriteCoordinator remains the transaction boundary per repo.
- Break-glass: no

## Verification

- Base `origin/main` SHA: fda3b1f (includes #292).
- Worker's full run on identical content: typecheck, lint, full node tests 919 pass / 0 fail / 1 skip, fast 211/211, contract 295/295, integration 413 pass / 1 skip, GUI unit 5/5 (GUI Electron e2e hangs locally on this host — environmental, covered by CI runner).
- Post-rebase re-verification: typecheck, lint, daemon-runtime tests 6/6, contract suite, bypass-write-boundary (119, delta 0), import-boundaries, write-coordinator-boundary, kernel-dead-exports — all green.
- dec_mra8fx5h semantics pinned by tests: detach releases exactly that repo's lock while others stay held; reattach reacquires; stop releases all.

---

# 中文

## 摘要

W9-P2(多仓 daemon 五包之二):kernel daemon runtime 升级为多仓 manager——单 daemon 进程对每个 attached canonical 仓独立持有 lock、写队列、WriteCoordinator 与 materializer,按设计 §2 与已 accept 的 D4 修订 dec_mra8fx5h 实现每仓故障隔离。单仓 API 保留兼容 wrapper(零回退)。

## 变更内容

- **多仓 manager**(`packages/kernel/src/store/daemon-runtime.ts`):每仓 runtime status、`attachRepo`/`detachRepo`/`retryUnavailableRepos`、按 repoId 分发交互写与 materializer 调度。每个 attached 仓从 attach 成功起持有自己的 `.harness/locks/global.lock` 直到 detach 或 daemon stop;某仓 lock/recovery 失败只标该仓 unavailable,不影响其他仓。
- **锁语义**:保持非阻塞获取;无 hold-and-wait(retry 只对未 attached 仓独立重试);detach 只释放该仓锁;stop 逐仓 drain 后释放全部。
- **队列抽出**(`packages/kernel/src/store/daemon-runtime-queue.ts`):既有交互队列原样迁出——#270 的 author 安全分批(`sameAttribution`)连同回归测试原封保留。
- **单仓兼容**:`createDaemonRuntime` 签名不变,内部固定 `repoId="canonical"` 的 wrapper;现有调用方零改动。
- **测试**:多仓 lock 失败隔离、detach/reattach 生命周期(磁盘上锁释放/重取实证)、每仓写路由、stop 全量释放、单仓兼容回归。

## 任务与范围

- Harness 任务:task_01KWX37QN3W1WJW2EN4GGF4S08(PLT-Daemon W9 段二,五包之二)
- 分支:codex/w9-p2-kernel-runtime(#292 合并后已 rebase main)
- 范围外:协议 host 路由(P3)、CLI 用户级 endpoint(P4)、跨包集成验证(P5)。

## 版本影响

- 无版本变更(kernel 内部重构;P3/P4 消费 manager 前 daemon 协议与 CLI 行为不变)。

## 治理声明

- 触碰受保护面:是
- 受保护面范围:kernel 写路径(`daemon-runtime.ts`、新增 `daemon-runtime-queue.ts`)。
- 权威依据:task_01KWX37QN3W1WJW2EN4GGF4S08 段二设计(`artifacts/multi-repo-lifecycle-design.md` §2/§6,CEO 评审 PASS)、dec_mra8fx5h(每 attached repo 一把 attach 期锁,fail-closed 以 repo 为界)、dec_mr9sgtzr(author 安全分批保留)、dec_mr9acuxm(D4 唯一写路径)。
- 机器检查边界:bypass-write 门不变(119 governed writes,delta 0);WriteCoordinator 仍是每仓事务边界。
- Break-glass:否

## 验证

- 基线 `origin/main` SHA:fda3b1f(含 #292)。
- worker 在同内容上的全量验证:typecheck、lint、全量 node 测试 919 pass/0 fail/1 skip、fast 211/211、契约 295/295、集成 413 pass/1 skip、GUI 单测 5/5(GUI Electron e2e 本机挂起属环境性,交 CI runner)。
- rebase 后复验:typecheck、lint、daemon-runtime 测试 6/6、契约套件、bypass-write-boundary(119/delta 0)、import-boundaries、write-coordinator-boundary、kernel-dead-exports——全绿。
- dec_mra8fx5h 语义由测试钉住:detach 只释放该仓锁、其他仓保持;reattach 重取;stop 全释放。
