### PR TITLE
feat(daemon): repo-aware protocol host routing (W9-P3)

### DIFF
--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -9,7 +9,7 @@ import { stablePayloadHash } from "../../../kernel/src/index.ts";
 import type { HarnessLayoutInput } from "../../../kernel/src/index.ts";
 import { createHarnessRuntimeContext, harnessRuntimeRoot, taskPackagePath } from "../../../kernel/src/index.ts";
 import type { WriteCoordinator } from "../../../kernel/src/index.ts";
-import { createDaemonRuntime, makeJournaledWriteCoordinator, runLedgerMaterializer } from "../../../kernel/src/store/index.ts";
+import { createDaemonRuntime, createMultiRepoDaemonRuntime, makeJournaledWriteCoordinator, runLedgerMaterializer } from "../../../kernel/src/store/index.ts";
 import { resolveTaskCreatedBy } from "./created-by.ts";
 import { renderSupersedesRelation } from "./task-relations.ts";
 import { assertValidParentBinding, indexPath, makeIndex, readIndexEffect, renderIndex, validateGeneratedTaskId, validateTaskId } from "./task-index.ts";
@@ -38,7 +38,7 @@ import type { AdapterProviderMetadata } from "./types.ts";
 export { collectGitDiffEvidence } from "./git-diff-evidence.ts";
 export type { GitDiffEvidenceFile, GitDiffEvidenceOptions, GitDiffEvidenceReport } from "./git-diff-evidence.ts";
 export { runLedgerMaterializer };
-export { createDaemonRuntime };
+export { createDaemonRuntime, createMultiRepoDaemonRuntime };
 export type {
   AdapterProviderMetadata,
   AppendProgressInput,

--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -45,6 +45,26 @@ export interface DaemonConnectionStats {
   total: number;
 }
 
+export interface DaemonStatusRuntimeRepo {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+  readonly state: string;
+  readonly lockPath?: string;
+  readonly lockOwnerToken?: string;
+  readonly queue: {
+    readonly interactive: number;
+    readonly normal: number;
+    readonly background: number;
+    readonly maintenance: number;
+    readonly running: boolean;
+  };
+  readonly lastRecovery?: unknown;
+  readonly lastError?: string;
+  readonly lastMaterializerError?: string;
+}
+
+const emptyDaemonQueue = { interactive: 0, normal: 0, background: 0, maintenance: 0, running: false } as const;
+
 export async function runDaemonProductCommand(input: DaemonCommandInput): Promise<number> {
   const action = input.args[1] ?? "status";
   if (action === "--help" || action === "-h" || input.args.includes("--help") || input.args.includes("-h")) {
@@ -75,7 +95,7 @@ export function daemonStatusPayload(input: {
     readonly started: boolean;
     readonly lockPath?: string;
     readonly lockOwnerToken?: string;
-    readonly queue: {
+    readonly queue?: {
       readonly interactive: number;
       readonly normal: number;
       readonly background: number;
@@ -83,33 +103,54 @@ export function daemonStatusPayload(input: {
       readonly running: boolean;
     };
     readonly lastRecovery?: unknown;
+    readonly repos?: ReadonlyArray<DaemonStatusRuntimeRepo>;
   };
   readonly connections: DaemonConnectionStats;
 }): JsonObject {
-  const queueDepth = input.runtimeStatus.queue.interactive
-    + input.runtimeStatus.queue.normal
-    + input.runtimeStatus.queue.background
-    + input.runtimeStatus.queue.maintenance;
+  const selectedRepo = input.runtimeStatus.repos?.find((repo) => repo.repoId === input.repoId) ?? input.runtimeStatus.repos?.[0];
+  const queue = selectedRepo?.queue ?? input.runtimeStatus.queue ?? emptyDaemonQueue;
+  const lockPath = selectedRepo?.lockPath ?? input.runtimeStatus.lockPath;
+  const lockOwnerToken = selectedRepo?.lockOwnerToken ?? input.runtimeStatus.lockOwnerToken;
+  const lastRecovery = selectedRepo?.lastRecovery ?? input.runtimeStatus.lastRecovery ?? null;
+  const rootDir = selectedRepo?.canonicalRoot ?? input.rootDir;
+  const repoId = selectedRepo?.repoId ?? input.repoId;
+  const queueDepth = queue.interactive
+    + queue.normal
+    + queue.background
+    + queue.maintenance;
   return {
     schema: "daemon-status/v1",
     started: input.runtimeStatus.started,
     daemonId: input.daemonId,
-    rootDir: input.rootDir,
-    repoId: input.repoId,
+    rootDir,
+    repoId,
     endpoint: input.endpoint,
     version: resolveCliVersion(),
     protocolVersion: currentDaemonProtocolVersion,
     lock: {
-      path: input.runtimeStatus.lockPath ?? null,
-      ownerToken: input.runtimeStatus.lockOwnerToken ?? null
+      path: lockPath ?? null,
+      ownerToken: lockOwnerToken ?? null
     },
-    queue: input.runtimeStatus.queue,
+    queue,
     queueDepth,
     connections: {
       active: input.connections.active,
       total: input.connections.total
     },
-    lastRecovery: toJsonValue(input.runtimeStatus.lastRecovery ?? null)
+    lastRecovery: toJsonValue(lastRecovery),
+    ...(input.runtimeStatus.repos ? {
+      repos: input.runtimeStatus.repos.map((repo) => ({
+        repoId: repo.repoId,
+        canonicalRoot: repo.canonicalRoot,
+        state: repo.state,
+        lockPath: repo.lockPath ?? null,
+        lockOwnerToken: repo.lockOwnerToken ?? null,
+        queue: repo.queue,
+        lastRecovery: toJsonValue(repo.lastRecovery ?? null),
+        lastError: repo.lastError ?? null,
+        lastMaterializerError: repo.lastMaterializerError ?? null
+      }))
+    } : {})
   };
 }
 

--- a/packages/cli/src/composition/adapter-registry.ts
+++ b/packages/cli/src/composition/adapter-registry.ts
@@ -1,6 +1,7 @@
 import {
   localAdapterProviderMetadata,
   createDaemonRuntime,
+  createMultiRepoDaemonRuntime,
   makeLocalLifecycleEngine,
   makeLocalWriteCoordinator,
   runLedgerMaterializer
@@ -37,6 +38,7 @@ export interface CliCompositionAdapterProvider {
   readonly createLifecycleEngine: typeof makeLocalLifecycleEngine;
   readonly createWriteCoordinator: typeof makeLocalWriteCoordinator;
   readonly createDaemonRuntime: typeof createDaemonRuntime;
+  readonly createMultiRepoDaemonRuntime: typeof createMultiRepoDaemonRuntime;
   readonly runLedgerMaterializer: (rootInput: HarnessLayoutInput, options: { readonly dryRun?: boolean }) => MaterializerCommandReport;
 }
 
@@ -45,6 +47,7 @@ const localProvider = {
   createLifecycleEngine: (options: LocalLifecycleOptions) => makeLocalLifecycleEngine(options),
   createWriteCoordinator: (options: LocalWriteCoordinatorOptions) => makeLocalWriteCoordinator(options),
   createDaemonRuntime: (options) => createDaemonRuntime(options),
+  createMultiRepoDaemonRuntime: (options) => createMultiRepoDaemonRuntime(options),
   runLedgerMaterializer
 } satisfies CliCompositionAdapterProvider;
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,8 @@ import {
   createJsonRpcProtocolServer,
   createUnixSocketTransportServer,
   serveSshExecBridge,
+  type DaemonRepoAvailabilityFailure,
+  type DaemonRepoNamespace,
   type DaemonAuthenticationContext
 } from "../../daemon/src/index.ts";
 import { receiptDetailsData, renderReceiptText, toCommandReceipt, type CommandFailureReceipt, type CommandReceipt } from "./cli/receipt.ts";
@@ -28,9 +30,11 @@ import { localDaemonSocketPath, runCommandThroughDaemon } from "./daemon/client.
 import { createCliCommandService } from "./daemon/command-service.ts";
 import { makeDaemonQueuedWriteCoordinator } from "./daemon/queued-write-coordinator.ts";
 
-type HarnessDaemonRuntime = ReturnType<typeof createDaemonRuntime>;
 const runRegisteredCommand = runRegisteredCommandWithCliComposition;
-const createDaemonRuntime = selectCliAdapterProvider("daemon.runtime").createDaemonRuntime;
+const daemonRuntimeProvider = selectCliAdapterProvider("daemon.runtime");
+type HarnessDaemonRuntime = ReturnType<typeof daemonRuntimeProvider.createDaemonRuntime>;
+type MultiRepoHarnessDaemonRuntime = ReturnType<typeof daemonRuntimeProvider.createMultiRepoDaemonRuntime>;
+const createMultiRepoDaemonRuntime = daemonRuntimeProvider.createMultiRepoDaemonRuntime;
 
 export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)): Promise<number> {
   const daemonExit = await maybeRunDaemonCommand(argv);
@@ -73,19 +77,21 @@ async function runDaemonServe(
   args: ReadonlyArray<string>,
   hooks: DaemonServeHooks = {}
 ): Promise<void> {
-  const runtime = createDaemonRuntime({
-    rootDir,
-    layoutOverrides,
-    materializerPollMs: 5_000
-  });
-  await runtime.start();
   const repoId = readOption(args, "--repo") ?? "canonical";
+  const runtime = createMultiRepoDaemonRuntime({
+    materializerPollMs: 5_000,
+    repos: [{ repoId, rootDir, ...(layoutOverrides ? { layoutOverrides } : {}) }]
+  });
+  const startStatus = await runtime.start();
+  if (startStatus.repoCount > 0 && startStatus.attachedCount === 0 && startStatus.unavailableCount > 0) {
+    throw new Error(`daemon did not attach any registered repo: ${startStatus.repos.map((repo) => `${repo.repoId}:${repo.lastError ?? repo.state}`).join("; ")}`);
+  }
   const idleMs = parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true });
   const stdio = args.includes("--stdio");
   const socketPath = readOption(args, "--socket") ?? localDaemonSocketPath(rootDir);
   const endpoint = stdio ? "stdio" : socketPath;
   const connections: DaemonConnectionStats = { active: 0, total: 0 };
-  const serviceHost = createDaemonServiceHost(runtime, rootDir, layoutOverrides, repoId, idleMs, endpoint, connections);
+  const serviceHost = createDaemonServiceHost(runtime, [{ repoId, canonicalRoot: rootDir }], repoId, layoutOverrides, idleMs, endpoint, connections);
   if (stdio) {
     connections.active += 1;
     connections.total += 1;
@@ -123,11 +129,44 @@ async function runDaemonServe(
   await serviceHost.stop();
 }
 
+function repoAvailabilityFailure(
+  runtime: MultiRepoHarnessDaemonRuntime,
+  repo: DaemonRepoNamespace
+): DaemonRepoAvailabilityFailure | undefined {
+  const status = runtime.status().repos.find((candidate) => candidate.repoId === repo.repoId);
+  if (!status) {
+    return {
+      code: "repo_unavailable",
+      repo: {
+        repoId: repo.repoId,
+        canonicalRoot: repo.canonicalRoot,
+        state: "unavailable",
+        lockPath: null,
+        lockOwnerToken: null,
+        lastError: "runtime context not found"
+      }
+    };
+  }
+  if (status.state === "attached") return undefined;
+  const lockHeld = typeof status.lastError === "string" && /lock already held|global\.lock/u.test(status.lastError);
+  return {
+    code: lockHeld ? "repo_lock_held" : "repo_unavailable",
+    repo: {
+      repoId: repo.repoId,
+      canonicalRoot: repo.canonicalRoot,
+      state: status.state,
+      lockPath: status.lockPath ?? null,
+      lockOwnerToken: status.lockOwnerToken ?? null,
+      lastError: status.lastError ?? null
+    }
+  };
+}
+
 function createDaemonServiceHost(
-  runtime: HarnessDaemonRuntime,
-  rootDir: string,
+  runtime: MultiRepoHarnessDaemonRuntime,
+  repos: ReadonlyArray<DaemonRepoNamespace>,
+  defaultRepoId: string,
   layoutOverrides: { readonly authoredRoot?: string } | undefined,
-  repoId: string,
   idleMs: number,
   endpoint: string,
   connections: DaemonConnectionStats
@@ -141,7 +180,6 @@ function createDaemonServiceHost(
   readonly stop: () => Promise<void>;
 } {
   const daemonId = `ha-${process.pid}`;
-  const identity = loadDaemonIdentity(rootDir, layoutOverrides);
   const stopHandlers: Array<() => Promise<void>> = [];
   let requestStop: (() => void) | undefined;
   const stopRequested = new Promise<void>((resolve) => {
@@ -166,55 +204,36 @@ function createDaemonServiceHost(
     }, idleMs);
     idleTimer.unref();
   };
-  const taskWriter = selectCliAdapterProvider("task.lifecycle").createLifecycleEngine({
-    rootDir,
-    layoutOverrides,
-    coordinator: makeDaemonQueuedWriteCoordinator(runtime, "local-controller")
-  });
-  const localController = makeLocalControllerService({
-    rootDir,
-    layoutOverrides,
-    taskWriter
-  });
-  const cliCommandService = createCliCommandService(runtime, {
-    onCommandStart: () => {
-      if (idleTimer) clearTimeout(idleTimer);
-    },
-    onCommandSettled: scheduleIdleExit
-  });
-  const appendRuntimeEvent = makeRuntimeEventAppendPromise(makeRuntimeEventLedgerService({
-    rootInput: { rootDir, layoutOverrides },
-    coordinator: makeDaemonQueuedWriteCoordinator(runtime, "runtime-event-protocol")
+  const repoBindings = new Map(repos.map((repo) => {
+    const repoRuntime = runtime.getRepoRuntime(repo.repoId);
+    if (!repoRuntime) throw new Error(`daemon runtime missing repo context: ${repo.repoId}`);
+    return [repo.repoId, createRepoServiceBinding(repo, repoRuntime, runtime, layoutOverrides, {
+      onCommandStart: () => {
+        if (idleTimer) clearTimeout(idleTimer);
+      },
+      onCommandSettled: scheduleIdleExit
+    }, { daemonId, endpoint, connections })] as const;
   }));
   return {
     daemonId,
     createProtocolServer: (authContext) => createJsonRpcProtocolServer({
       daemonId,
-      repos: [{ repoId, canonicalRoot: rootDir }],
-      services: {
-        LocalControllerService: localController,
-        TerminalSessionService: makeUnavailableTerminalSessionService(),
-        DaemonStatusService: {
-          getStatus: () => daemonStatusPayload({
-            daemonId,
-            rootDir,
-            repoId,
-            endpoint,
-            runtimeStatus: runtime.status(),
-            connections
-          })
-        },
-        CliCommandService: cliCommandService
-      },
+      repos,
+      services: repoBindings.get(defaultRepoId)!.services,
+      resolveRepoServices: (repo) => repoBindings.get(repo.repoId)?.services,
+      resolveRepoAvailability: (repo) => repoAvailabilityFailure(runtime, repo),
       authContext,
-      ...(identity.identityProvider ? { identityProvider: identity.identityProvider } : {}),
-      ...(identity.peopleRoster ? { peopleRoster: identity.peopleRoster } : {}),
-      appendRuntimeEvent
+      ...(repoBindings.get(defaultRepoId)?.identity.identityProvider ? { identityProvider: repoBindings.get(defaultRepoId)!.identity.identityProvider } : {}),
+      ...(repoBindings.get(defaultRepoId)?.identity.peopleRoster ? { peopleRoster: repoBindings.get(defaultRepoId)!.identity.peopleRoster } : {}),
+      appendRuntimeEvent: (input, context) => {
+        const targetRepoId = context?.repo.repoId ?? defaultRepoId;
+        return repoBindings.get(targetRepoId)?.appendRuntimeEvent(input) ?? Promise.resolve();
+      }
     }),
     status: () => daemonStatusPayload({
       daemonId,
-      rootDir,
-      repoId,
+      rootDir: repoBindings.get(defaultRepoId)!.repo.canonicalRoot,
+      repoId: defaultRepoId,
       endpoint,
       runtimeStatus: runtime.status(),
       connections
@@ -225,6 +244,61 @@ function createDaemonServiceHost(
       stopHandlers.push(handler);
     },
     stop
+  };
+}
+
+function createRepoServiceBinding(
+  repo: DaemonRepoNamespace,
+  runtime: HarnessDaemonRuntime,
+  managerRuntime: MultiRepoHarnessDaemonRuntime,
+  layoutOverrides: { readonly authoredRoot?: string } | undefined,
+  commandOptions: { readonly onCommandStart: () => void; readonly onCommandSettled: () => void },
+  statusOptions?: { readonly daemonId?: string; readonly endpoint?: string; readonly connections?: DaemonConnectionStats }
+): {
+  readonly repo: DaemonRepoNamespace;
+  readonly identity: ReturnType<typeof loadDaemonIdentity>;
+  readonly services: Parameters<typeof createJsonRpcProtocolServer>[0]["services"];
+  readonly appendRuntimeEvent: ReturnType<typeof makeRuntimeEventAppendPromise>;
+} {
+  const rootDir = repo.canonicalRoot;
+  const identity = loadDaemonIdentity(rootDir, layoutOverrides);
+  const taskWriter = selectCliAdapterProvider("task.lifecycle").createLifecycleEngine({
+    rootDir,
+    layoutOverrides,
+    coordinator: makeDaemonQueuedWriteCoordinator(runtime, "local-controller")
+  });
+  const localController = makeLocalControllerService({
+    rootDir,
+    layoutOverrides,
+    taskWriter
+  });
+  const cliCommandService = createCliCommandService(runtime, commandOptions);
+  const appendRuntimeEvent = makeRuntimeEventAppendPromise(makeRuntimeEventLedgerService({
+    rootInput: { rootDir, layoutOverrides },
+    coordinator: makeDaemonQueuedWriteCoordinator(runtime, "runtime-event-protocol")
+  }));
+  return {
+    repo,
+    identity,
+    services: {
+      LocalControllerService: localController,
+      TerminalSessionService: makeUnavailableTerminalSessionService(),
+      DaemonStatusService: {
+        getStatus: (context) => {
+          const targetRepo = context?.repo ?? repo;
+          return daemonStatusPayload({
+            daemonId: statusOptions?.daemonId ?? `ha-${process.pid}`,
+            rootDir: targetRepo.canonicalRoot,
+            repoId: targetRepo.repoId,
+            endpoint: statusOptions?.endpoint ?? "repo-router",
+            runtimeStatus: managerRuntime.status(),
+            connections: statusOptions?.connections ?? { active: 0, total: 0 }
+          });
+        }
+      },
+      CliCommandService: cliCommandService
+    },
+    appendRuntimeEvent
   };
 }
 

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -122,6 +122,9 @@ test("daemon start service status and stop expose productized status contract", 
       assert.equal(typeof status.queueDepth, "number");
       assert.equal(isRecord(status.queue), true);
       assert.equal(isRecord(status.connections), true);
+      assert.equal(Array.isArray(status.repos), true);
+      assert.equal((status.repos as Array<{ repoId?: string; state?: string }>)[0]?.repoId, "canonical");
+      assert.equal((status.repos as Array<{ repoId?: string; state?: string }>)[0]?.state, "attached");
 
       const stop = runDaemonCommand(rootDir, ["daemon", "stop", "--timeout-ms", "5000", "--json"]);
       assert.equal(stop.signaled, true);

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -48,6 +48,7 @@ export {
 } from "./protocol/method-registry.ts";
 export {
   createJsonRpcProtocolServer,
+  type DaemonRepoAvailabilityFailure,
   type DaemonRepoNamespace,
   type DaemonServiceHost,
   type JsonRpcProtocolServer,

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -1,4 +1,5 @@
 // @slice-activation PLT-Daemon W2 protocol core exported for W3 transport adapters.
+import path from "node:path";
 import type { CommandFailureReceipt, CommandReceipt, LocalControllerService } from "../../../application/src/index.ts";
 import type { RuntimeEventAppendInput } from "../../../application/src/runtime-event-ledger-service.ts";
 import type { TerminalSessionService } from "../../../gui/src/terminal/session-registry.ts";
@@ -14,14 +15,39 @@ export interface DaemonRepoNamespace {
   readonly canonicalRoot: string;
 }
 
+export interface DaemonRepoRuntimeSnapshot {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+  readonly state: "attached" | "unavailable" | "detaching" | "detached";
+  readonly lockPath?: string;
+  readonly lockOwnerToken?: string;
+  readonly lastError?: string;
+}
+
+export interface DaemonRepoAvailabilityFailure {
+  readonly code: "repo_lock_held" | "repo_unavailable";
+  readonly repo: {
+    readonly repoId: string;
+    readonly canonicalRoot: string;
+    readonly state: string;
+    readonly lockPath: string | null;
+    readonly lockOwnerToken: string | null;
+    readonly lastError: string | null;
+  };
+}
+
+export interface DaemonRepoServiceContext {
+  readonly repo: DaemonRepoNamespace;
+}
+
 export interface DaemonServiceHost {
   readonly LocalControllerService: LocalControllerService;
   readonly TerminalSessionService: TerminalSessionService;
   readonly DaemonStatusService?: {
-    readonly getStatus: () => JsonObject | Promise<JsonObject>;
+    readonly getStatus: (context?: DaemonRepoServiceContext) => JsonObject | Promise<JsonObject>;
   };
   readonly CliCommandService?: {
-    readonly runCommand: (payload?: JsonObject, context?: { readonly actor?: AuthenticatedActor }) => Promise<CommandReceipt | CommandFailureReceipt>;
+    readonly runCommand: (payload?: JsonObject, context?: { readonly actor?: AuthenticatedActor; readonly repo?: DaemonRepoNamespace }) => Promise<CommandReceipt | CommandFailureReceipt>;
   };
 }
 
@@ -29,10 +55,12 @@ export interface JsonRpcServerOptions {
   readonly daemonId: string;
   readonly repos: ReadonlyArray<DaemonRepoNamespace>;
   readonly services: DaemonServiceHost;
+  readonly resolveRepoServices?: (repo: DaemonRepoNamespace) => DaemonServiceHost | undefined;
+  readonly resolveRepoAvailability?: (repo: DaemonRepoNamespace) => DaemonRepoAvailabilityFailure | undefined;
   readonly authContext?: DaemonAuthenticationContext;
   readonly identityProvider?: IdentityProvider;
   readonly peopleRoster?: PeopleRoster;
-  readonly appendRuntimeEvent?: (input: RuntimeEventAppendInput) => Promise<void>;
+  readonly appendRuntimeEvent?: (input: RuntimeEventAppendInput, context?: DaemonRepoServiceContext) => Promise<void>;
 }
 
 export interface JsonRpcProtocolServer {
@@ -91,7 +119,10 @@ async function handleRequest(
   const params = request.params ?? {};
   const repoFailure = validateRepoNamespace(contract, params, repos);
   if (repoFailure) return response(failureReceipt(request.method, repoFailure.code, repoFailure.hint));
+  const repo = repoForContract(contract, params, repos);
   const effectiveContract = withEffectiveCommandClass(contract, params);
+  const repoRuntimeFailure = validateRepoRuntime(effectiveContract, repo, options);
+  if (repoRuntimeFailure) return response(repoRuntimeFailure);
 
   const actorResult = await resolveActor(effectiveContract, options);
   if (actorResult && !actorResult.ok) {
@@ -99,14 +130,14 @@ async function handleRequest(
       providerId: actorResult.providerId,
       ...(actorResult.credential ? { credential: credentialJson(actorResult.credential) } : {})
     });
-    await appendCommandEvent(options, params, effectiveContract, "failed", actorResult.message, actorResult.code);
+    await appendCommandEvent(options, params, effectiveContract, "failed", actorResult.message, actorResult.code, undefined, repo);
     return response(receipt);
   }
   const actor = actorResult?.actor;
   if (actor && options.peopleRoster) {
     const authz = authorizeActorForMethod(actor, effectiveContract, options.peopleRoster);
     if (!authz.ok) {
-      await appendCommandEvent(options, params, effectiveContract, "failed", authz.message, authz.code, actor);
+      await appendCommandEvent(options, params, effectiveContract, "failed", authz.message, authz.code, actor, repo);
       return response(stampReceipt(failureReceipt(request.method, authz.code, authz.message, {
         actor: actorStampJson(actor),
         commandClass: effectiveContract.commandClass ?? null
@@ -123,13 +154,13 @@ async function handleRequest(
   if (contract.namespace === "admin") {
     const result = handleAdminMethod(contract, options);
     const receipt = stampReceipt(result, actor);
-    await appendWriteEventIfNeeded(options, params, effectiveContract, receipt.ok ? "succeeded" : "failed", receipt.summary, receipt.ok ? undefined : receipt.error?.code, actor);
+    await appendWriteEventIfNeeded(options, params, effectiveContract, receipt.ok ? "succeeded" : "failed", receipt.summary, receipt.ok ? undefined : receipt.error?.code, actor, repo);
     return response(receipt);
   }
 
-  const result = await callServiceMethod(effectiveContract, params, options.services, actor);
+  const result = await callServiceMethod(effectiveContract, params, options, actor, repo);
   const receipt = stampReceipt(result, actor);
-  await appendWriteEventIfNeeded(options, params, effectiveContract, receipt.ok ? "succeeded" : "failed", receipt.summary, receipt.ok ? undefined : receipt.error?.code, actor);
+  await appendWriteEventIfNeeded(options, params, effectiveContract, receipt.ok ? "succeeded" : "failed", receipt.summary, receipt.ok ? undefined : receipt.error?.code, actor, repo);
   return response(receipt);
 }
 
@@ -173,24 +204,54 @@ function validateRepoNamespace(
   return undefined;
 }
 
+function repoForContract(
+  contract: JsonRpcMethodContract,
+  params: JsonObject,
+  repos: ReadonlyMap<string, DaemonRepoNamespace>
+): DaemonRepoNamespace | undefined {
+  if (!contract.requiresRepo) return undefined;
+  const repo = isJsonObject(params.repo) && typeof params.repo.repoId === "string" ? repos.get(params.repo.repoId) : undefined;
+  return repo;
+}
+
+function validateRepoRuntime(
+  contract: JsonRpcMethodContract,
+  repo: DaemonRepoNamespace | undefined,
+  options: JsonRpcServerOptions
+): ReturnType<typeof failureReceipt> | undefined {
+  if (!repo || !contract.requiresRepo || !options.resolveRepoAvailability || doesNotRequireAttachedRepo(contract)) return undefined;
+  const failure = options.resolveRepoAvailability(repo);
+  if (!failure) return undefined;
+  return failureReceipt(contract.method, failure.code, `Repo ${repo.repoId} is not attached to this daemon.`, { repo: failure.repo });
+}
+
+function doesNotRequireAttachedRepo(contract: JsonRpcMethodContract): boolean {
+  return contract.method === "repo.daemon.status" || contract.mode === "notification-stub";
+}
+
 async function callServiceMethod(
   contract: JsonRpcMethodContract,
   params: JsonObject,
-  services: DaemonServiceHost,
-  actor: AuthenticatedActor | undefined
+  options: JsonRpcServerOptions,
+  actor: AuthenticatedActor | undefined,
+  repo: DaemonRepoNamespace | undefined
 ): Promise<ReturnType<typeof successReceipt> | ReturnType<typeof failureReceipt>> {
   const payload = isJsonObject(params.payload) ? params.payload : undefined;
+  const services = repo ? resolveServicesForRepo(contract.method, repo, options) : options.services;
+  if (!services) return failureReceipt(contract.method, "repo_service_unavailable", `Repo service host is not configured for ${repo?.repoId ?? "unknown"}.`);
   if (contract.method === "repo.daemon.status") {
     if (!services.DaemonStatusService) {
       return failureReceipt(contract.method, "daemon_status_service_unavailable", "Daemon status service is not configured.");
     }
-    return successReceipt(contract.method, "read daemon status", await services.DaemonStatusService.getStatus());
+    return successReceipt(contract.method, "read daemon status", await services.DaemonStatusService.getStatus(repo ? { repo } : undefined));
   }
   if (contract.method === "repo.command.run") {
     if (!services.CliCommandService) {
       return failureReceipt(contract.method, "cli_command_service_unavailable", "Daemon command service is not configured.");
     }
-    return services.CliCommandService.runCommand(payload, { actor });
+    const rootMismatch = repo ? commandRootMismatch(payload, repo) : undefined;
+    if (rootMismatch) return rootMismatch;
+    return services.CliCommandService.runCommand(payload, { actor, repo });
   }
   const result = contract.service === "TerminalSessionService"
     ? await invokeServiceMethod(services.TerminalSessionService, String(contract.serviceMethod), payload)
@@ -198,6 +259,26 @@ async function callServiceMethod(
   return isJsonObject(result)
     ? serviceResultReceipt(contract.method, result)
     : successReceipt(contract.method, `completed ${contract.method}`, { value: toJsonValue(result) });
+}
+
+function resolveServicesForRepo(
+  method: string,
+  repo: DaemonRepoNamespace,
+  options: JsonRpcServerOptions
+): DaemonServiceHost | undefined {
+  if (!options.resolveRepoServices) return options.services;
+  return options.resolveRepoServices(repo) ?? (method === "repo.daemon.status" ? options.services : undefined);
+}
+
+function commandRootMismatch(payload: JsonObject | undefined, repo: DaemonRepoNamespace): ReturnType<typeof failureReceipt> | undefined {
+  const command = isJsonObject(payload?.command) ? payload.command : undefined;
+  const rootDir = typeof command?.rootDir === "string" ? command.rootDir : undefined;
+  if (!rootDir) return undefined;
+  if (path.resolve(rootDir) === path.resolve(repo.canonicalRoot)) return undefined;
+  return failureReceipt("repo.command.run", "repo_command_root_mismatch", "payload.command.rootDir does not match params.repo.repoId.", {
+    repo: { repoId: repo.repoId, canonicalRoot: repo.canonicalRoot },
+    command: { rootDir }
+  });
 }
 
 function withEffectiveCommandClass(contract: JsonRpcMethodContract, params: JsonObject): JsonRpcMethodContract {
@@ -270,10 +351,11 @@ async function appendWriteEventIfNeeded(
   status: "succeeded" | "failed",
   summary: string,
   errorCode: string | undefined,
-  actor: AuthenticatedActor | undefined
+  actor: AuthenticatedActor | undefined,
+  repo: DaemonRepoNamespace | undefined
 ): Promise<void> {
   if (contract.commandClass === "repo-read") return;
-  await appendCommandEvent(options, params, contract, status, summary, errorCode, actor);
+  await appendCommandEvent(options, params, contract, status, summary, errorCode, actor, repo);
 }
 
 async function appendCommandEvent(
@@ -283,7 +365,8 @@ async function appendCommandEvent(
   status: "succeeded" | "failed",
   summary: string,
   errorCode?: string,
-  actor?: AuthenticatedActor
+  actor?: AuthenticatedActor,
+  repo?: DaemonRepoNamespace
 ): Promise<void> {
   if (!options.appendRuntimeEvent) return;
   const session = runtimeSession(params, options.daemonId);
@@ -300,7 +383,7 @@ async function appendCommandEvent(
       ...(errorCode ? { errorCode } : {})
     },
     ...(actor ? { actor: actorStamp(actor) } : {})
-  }).catch(() => undefined);
+  }, repo ? { repo } : undefined).catch(() => undefined);
 }
 
 function runtimeSession(params: JsonObject, daemonId: string): { readonly sessionId: string; readonly runtime: "human" | "claude-code" | "codex" | "zcode" | "antigravity" | "unknown" } {

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -132,6 +132,168 @@ test("repo namespace rejects unknown canonical repositories", async () => {
   assert.equal(receipt.error.code, "repo_namespace_unknown");
 });
 
+test("repo methods fail closed when the repo runtime is unavailable", async () => {
+  let serviceCalls = 0;
+  const server = makeServer({
+    repos: [
+      { repoId: "canonical", canonicalRoot: "/tmp/canonical" },
+      { repoId: "locked", canonicalRoot: "/tmp/locked" }
+    ],
+    resolveRepoAvailability: (repo) => repo.repoId === "locked"
+      ? {
+          code: "repo_lock_held",
+          repo: {
+            repoId: repo.repoId,
+            canonicalRoot: repo.canonicalRoot,
+            state: "unavailable",
+            lockPath: ".harness/locks/global.lock",
+            lockOwnerToken: null,
+            lastError: "lock already held: daemon owner"
+          }
+        }
+      : undefined,
+    services: {
+      LocalControllerService: {
+        ...emptyLocalController(),
+        getTasks: () => {
+          serviceCalls += 1;
+          return { ok: true, tasks: [], warnings: [] };
+        }
+      },
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" })
+    }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const response = await server.handle({
+    ...readFixture("repo-request.json"),
+    params: { repo: { repoId: "locked" }, payload: {} }
+  });
+  const receipt = resultReceipt(response);
+
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.error?.code, "repo_lock_held");
+  assert.equal((receipt.details.repo as { state?: string }).state, "unavailable");
+  assert.equal(serviceCalls, 0);
+});
+
+test("repo methods fail closed when the repo runtime context is missing", async () => {
+  let serviceCalls = 0;
+  const server = makeServer({
+    resolveRepoAvailability: (repo) => ({
+      code: "repo_unavailable",
+      repo: {
+        repoId: repo.repoId,
+        canonicalRoot: repo.canonicalRoot,
+        state: "unavailable",
+        lockPath: null,
+        lockOwnerToken: null,
+        lastError: "runtime context not found"
+      }
+    }),
+    services: {
+      LocalControllerService: {
+        ...emptyLocalController(),
+        getTasks: () => {
+          serviceCalls += 1;
+          return { ok: true, tasks: [], warnings: [] };
+        }
+      },
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" })
+    }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const response = await server.handle(readFixture("repo-request.json"));
+  const receipt = resultReceipt(response);
+
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.error?.code, "repo_unavailable");
+  assert.equal((receipt.details.repo as { lastError?: string }).lastError, "runtime context not found");
+  assert.equal(serviceCalls, 0);
+});
+
+test("repo.daemon.status remains available for unavailable repos", async () => {
+  const server = makeServer({
+    repos: [
+      { repoId: "canonical", canonicalRoot: "/tmp/canonical" },
+      { repoId: "locked", canonicalRoot: "/tmp/locked" }
+    ],
+    resolveRepoAvailability: (repo) => repo.repoId === "locked"
+      ? {
+          code: "repo_unavailable",
+          repo: {
+            repoId: repo.repoId,
+            canonicalRoot: repo.canonicalRoot,
+            state: "unavailable",
+            lockPath: null,
+            lockOwnerToken: null,
+            lastError: "recovery failed"
+          }
+        }
+      : undefined,
+    services: {
+      LocalControllerService: emptyLocalController(),
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" }),
+      DaemonStatusService: {
+        getStatus: (context) => ({
+          schema: "daemon-status/v1",
+          requestedRepoId: context?.repo.repoId ?? null,
+          repos: [
+            { repoId: "canonical", canonicalRoot: "/tmp/canonical", state: "attached" },
+            { repoId: "locked", canonicalRoot: "/tmp/locked", state: "unavailable", lastError: "recovery failed" }
+          ]
+        })
+      }
+    }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const response = await server.handle({
+    jsonrpc: "2.0",
+    id: "status-locked",
+    method: "repo.daemon.status",
+    params: { repo: { repoId: "locked" } }
+  });
+  const receipt = resultReceipt(response);
+
+  assert.equal(receipt.ok, true);
+  assert.equal(receipt.details.data.requestedRepoId, "locked");
+  assert.equal((receipt.details.data.repos as ReadonlyArray<{ state: string }>)[1]?.state, "unavailable");
+});
+
+test("repo.command.run rejects payload rootDir that does not match the repo namespace", async () => {
+  const calls: string[] = [];
+  const server = makeServer({
+    services: {
+      LocalControllerService: emptyLocalController(),
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" }),
+      CliCommandService: {
+        runCommand: async () => {
+          calls.push("called");
+          return {
+            ok: true,
+            schema: "command-receipt/v2",
+            command: "version",
+            action: "version",
+            summary: "version",
+            details: {},
+            meta: { generatedAt: "2026-07-07T00:00:00.000Z", compatibility: { legacyReceipt: "CommandReceipt/v1" } }
+          };
+        }
+      }
+    }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const response = await server.handle(commandRunRequest("version", "root-mismatch", "/tmp/other"));
+  const receipt = resultReceipt(response);
+
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.error?.code, "repo_command_root_mismatch");
+  assert.deepEqual(calls, []);
+});
+
 test("notification subscribe is a no-op socket and respects JSON-RPC notification semantics", async () => {
   const server = makeServer();
   await server.handle(readFixture("hello-compatible.json"));
@@ -263,6 +425,37 @@ test("RBAC rejects non-arbiter methods and records a runtime event with actor", 
   }
 });
 
+test("runtime event append receives the validated repo namespace", async () => {
+  const eventRepos: string[] = [];
+  const server = makeServer({
+    appendRuntimeEvent: async (_input, context) => {
+      eventRepos.push(context?.repo.repoId ?? "none");
+    },
+    services: {
+      LocalControllerService: emptyLocalController(),
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" }),
+      CliCommandService: {
+        runCommand: async (_payload, context) => ({
+          ok: true,
+          schema: "command-receipt/v2",
+          command: context?.repo?.repoId ?? "missing",
+          action: "new-task",
+          summary: "created task",
+          details: {},
+          meta: { generatedAt: "2026-07-07T00:00:00.000Z", compatibility: { legacyReceipt: "CommandReceipt/v1" } }
+        })
+      }
+    }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const response = await server.handle(commandRunRequest("new-task", "repo-event"));
+  const receipt = resultReceipt(response);
+
+  assert.equal(receipt.ok, true);
+  assert.deepEqual(eventRepos, ["canonical"]);
+});
+
 test("repo.command.run derives RBAC from the inner CLI command", async () => {
   const roster = sampleRoster();
   const calls: string[] = [];
@@ -336,7 +529,7 @@ function emptyLocalController(): LocalControllerService {
   };
 }
 
-function commandRunRequest(actionKind: string, id: string): JsonRpcRequest {
+function commandRunRequest(actionKind: string, id: string, rootDir = "/tmp/canonical"): JsonRpcRequest {
   return {
     jsonrpc: "2.0",
     id,
@@ -345,7 +538,7 @@ function commandRunRequest(actionKind: string, id: string): JsonRpcRequest {
       repo: { repoId: "canonical" },
       payload: {
         command: {
-          rootDir: "/tmp/canonical",
+          rootDir,
           json: true,
           action: { kind: actionKind }
         }

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -251,77 +251,77 @@
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@214:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@255:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@215:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@256:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@213:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@254:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@212:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@253:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@263:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@304:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@270:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@311:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@283:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@324:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@316:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@357:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@319:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@360:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@328:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@369:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@264:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@305:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@285:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@326:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@321:5",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@362:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@323:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@364:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@337:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@378:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },


### PR DESCRIPTION
# English

## Summary

W9-P3 (third of five multi-repo daemon packages): the daemon protocol host becomes repo-aware — JSON-RPC requests are routed by validated `repoId` to the per-repo runtime context introduced in P2 (#294), with fail-closed structured receipts for unavailable repos and a multi-repo `repo.daemon.status`. Doc 39A §6.4 was revised per the design's seven-point checklist (inner harness ledger commit f2adbfd1).

## What Changed

- **Repo-aware routing** (`packages/daemon/src/protocol/json-rpc-server.ts`): after W2's existing `validateRepoNamespace` (unchanged), requests resolve `repoId -> RepoRuntimeContext` through a runtime/service router — no global variables. Missing/unattached repo contexts return a structured `repo_unavailable` failure receipt (with per-repo `lastError`) instead of reaching service methods; `repo.daemon.status` remains readable for unavailable repos.
- **rootDir compatibility check**: `payload.command.rootDir` is never a routing authority; it is validated for consistency against the repo namespace (mismatch fails closed).
- **Runtime events per repo**: runtime event append flows through the validated repo context — never the daemon's incidental startup root.
- **CLI daemon serve** (`packages/cli/src/index.ts`): switches to `createMultiRepoDaemonRuntime` with per-repo service bindings; single-repo behavior preserved via the `canonical` wrapper from P2.
- **Status surface** (`packages/cli/src/commands/daemon/productization.ts`): `repo.daemon.status` returns process-level status plus `repos[]` (repoId, canonicalRoot, state, lockPath, queue, lastRecovery, lastError) per design §2.
- **`protocol.hello` untouched**; #270's commandClassDerivation RBAC surface untouched.
- **Allowlist renumbering only**: 15 productization.ts anchors renumbered positionally (same functions, same order); gate passes at 119 governed writes, delta 0 — no new exemptions.
- **Doc 39A §6.4**: seven-point revision (user-level default instance, multi-repo vs multi-instance, user-root registry, per-repo isolation keys, user-root endpoint derivation, overlap arbitration by repo global.lock, stop/detach semantics) landed in the inner harness ledger (f2adbfd1).

## Task And Scope

- Harness task: task_01KWX37QN3W1WJW2EN4GGF4S08 (PLT-Daemon W9, segment 2, package 3 of 5)
- Branch: codex/w9-p3-protocol-host (rebased on main after #294 merged)
- Out of scope: CLI user-level endpoint and target resolution (P4), cross-package verification (P5).

## Version Impact

- No version change (protocol host internal wiring; request/response shapes unchanged, `repo.daemon.status` gains additive `repos[]`).

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: daemon protocol host (`json-rpc-server.ts`), CLI daemon composition (`index.ts`, `productization.ts`, adapter registry), `tools/gate-allowlists/check-bypass-write-boundary.json` (renumbering only).
- Authority: task_01KWX37QN3W1WJW2EN4GGF4S08 segment-2 design (`artifacts/multi-repo-lifecycle-design.md` §2/§4, CEO-reviewed PASS), dec_mra8fx5h (per-repo fail-closed boundary), dec_mr9acscw (D3 protocol: receipt/v2, repo namespace), dec_mr9ac5ca (D2 RBAC surface preserved).
- Machine-check boundary: bypass-write gate stays at 119 governed writes (delta 0); success receipts remain gated on per-repo durable authored state.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 66c4963 (includes #292, #294).
- Post-rebase: typecheck, lint, test:fast (211), test:contract (300), json-rpc-protocol tests 19/19, daemon-runtime tests 6/6, bypass-write-boundary (119, delta 0), import-boundaries, write-coordinator-boundary, kernel-dead-exports — all green. GUI Electron e2e skipped locally (environmental hang on this host; covered by CI runner).
- Worker verification on pre-rebase content additionally: thin-client CLI tests 9/9, transport integration 5 pass/1 Windows-skip, CLI build.

---

# 中文

## 摘要

W9-P3(多仓 daemon 五包之三):daemon 协议 host 升级为 repo-aware——JSON-RPC 请求经已验证的 `repoId` 路由到 P2(#294)引入的每仓 runtime context,不可用仓返回 fail-closed 结构化 receipt,`repo.daemon.status` 支持多仓输出。Doc 39A §6.4 按设计七条清单修订(内层账本 f2adbfd1)。

## 变更内容

- **repo-aware 路由**(`packages/daemon/src/protocol/json-rpc-server.ts`):W2 既有 `validateRepoNamespace` 之后(该层不动),请求经 runtime/service router 解析 `repoId -> RepoRuntimeContext`——不塞全局变量。缺失/未 attached 的仓返回结构化 `repo_unavailable` 失败 receipt(带每仓 `lastError`),不触达 service 方法;`repo.daemon.status` 对不可用仓保持可读。
- **rootDir 兼容校验**:`payload.command.rootDir` 永不作为路由权威;只校验与 repo namespace 一致性(不匹配 fail closed)。
- **runtime event 走对应仓**:runtime event append 经已验证的 repo context——绝不落 daemon 启动时的偶然仓。
- **CLI daemon serve**(`packages/cli/src/index.ts`):切换到 `createMultiRepoDaemonRuntime` + 每仓 service bindings;单仓行为经 P2 的 `canonical` wrapper 保持。
- **状态面**(`productization.ts`):`repo.daemon.status` 返回进程级 status + `repos[]`(repoId/canonicalRoot/state/lockPath/queue/lastRecovery/lastError,按设计 §2)。
- **`protocol.hello` 不动**;#270 的 commandClassDerivation RBAC 面不动。
- **allowlist 仅重编号**:productization.ts 15 条锚点按序对位重编号(同函数同序);门通过 119 governed writes,delta 0——无新增豁免。
- **Doc 39A §6.4**:七条修订(用户级默认实例、多仓 vs 多实例、用户根 registry、每仓隔离 key、用户根 endpoint 派生、重叠仲裁归仓 global.lock、stop/detach 语义)已落内层账本(f2adbfd1)。

## 任务与范围

- Harness 任务:task_01KWX37QN3W1WJW2EN4GGF4S08(PLT-Daemon W9 段二,五包之三)
- 分支:codex/w9-p3-protocol-host(#294 合并后已 rebase main)
- 范围外:CLI 用户级 endpoint 与 target resolution(P4)、跨包验证(P5)。

## 版本影响

- 无版本变更(协议 host 内部接线;请求/响应形态不变,`repo.daemon.status` 增量新增 `repos[]`)。

## 治理声明

- 触碰受保护面:是
- 受保护面范围:daemon 协议 host(`json-rpc-server.ts`)、CLI daemon 组装(`index.ts`/`productization.ts`/adapter registry)、`check-bypass-write-boundary.json`(仅重编号)。
- 权威依据:task_01KWX37QN3W1WJW2EN4GGF4S08 段二设计(`artifacts/multi-repo-lifecycle-design.md` §2/§4,CEO 评审 PASS)、dec_mra8fx5h(fail-closed 以 repo 为界)、dec_mr9acscw(D3 协议:receipt/v2、repo namespace)、dec_mr9ac5ca(D2 RBAC 面保持)。
- 机器检查边界:bypass-write 门保持 119 governed writes(delta 0);success receipt 仍以每仓 durable authored state 为门。
- Break-glass:否

## 验证

- 基线 `origin/main` SHA:66c4963(含 #292、#294)。
- rebase 后:typecheck、lint、test:fast(211)、test:contract(300)、json-rpc-protocol 19/19、daemon-runtime 6/6、bypass-write-boundary(119/delta 0)、import-boundaries、write-coordinator-boundary、kernel-dead-exports——全绿。GUI Electron e2e 本地跳过(本机环境性挂起,交 CI runner)。
- worker 在 rebase 前内容上另验:thin-client CLI 9/9、transport 集成 5 pass/1 Windows skip、CLI build。
