### PR TITLE
fix(gui): make Electron shell actually launchable end to end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ tmp/
 # release tarballs (npm pack output)
 *.tgz
 .gstack/
+
+# Electron preload bundle (built by packages/gui build:preload)
+packages/gui/dist-electron/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -129,6 +129,7 @@ export default tseslint.config(
       "harness/",
       "node_modules/",
       "packages/**/dist/",
+      "packages/**/dist-electron/",
       "tmp/"
     ]
   },

--- a/packages/gui/e2e/electron-smoke.e2e.mjs
+++ b/packages/gui/e2e/electron-smoke.e2e.mjs
@@ -38,6 +38,11 @@ test("Electron shell opens its first BrowserWindow", { timeout: 45_000 }, async 
 
   const windowCount = await electronApp.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length);
   assert.equal(windowCount, 1);
+
+  // The window opening is not enough: the sandboxed preload must have loaded
+  // and exposed the IPC bridge, otherwise the shell is a hollow window.
+  const bridgeType = await page.evaluate(() => typeof globalThis.harness);
+  assert.equal(bridgeType, "object", "preload bridge (window.harness) failed to load");
 });
 
 function startRendererServer() {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -6,10 +6,12 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
+    "dev:electron": "node scripts/dev-electron.mjs",
     "build": "vite build",
+    "build:preload": "vite build --config vite.preload.config.ts",
     "preview": "vite preview --host 127.0.0.1",
     "test:gui": "vitest run --config vitest.config.ts",
-    "test:e2e": "node --test e2e/*.e2e.mjs"
+    "test:e2e": "npm run build:preload && node --test e2e/*.e2e.mjs"
   },
   "exports": {
     ".": "./src/index.ts"

--- a/packages/gui/scripts/dev-electron.mjs
+++ b/packages/gui/scripts/dev-electron.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Human-facing GUI launcher: builds the preload bundle, starts the Vite dev
+// renderer on the origin the security contract pins (http://127.0.0.1:5173),
+// then launches the Electron shell against it. Ctrl+C or closing the window
+// tears everything down. Zero dependencies beyond what the package already has.
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const guiRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(guiRoot, "../..");
+const rendererUrl = "http://127.0.0.1:5173";
+const electronPath = require("electron");
+
+function log(message) {
+  console.log(`[dev-electron] ${message}`);
+}
+
+log("building preload bundle...");
+const preloadBuild = spawnSync("npx", ["vite", "build", "--config", "vite.preload.config.ts"], {
+  cwd: guiRoot,
+  stdio: "inherit"
+});
+if (preloadBuild.status !== 0) {
+  console.error("[dev-electron] preload build failed");
+  process.exit(preloadBuild.status ?? 1);
+}
+
+log(`starting renderer dev server at ${rendererUrl} ...`);
+const vite = spawn("npx", ["vite", "--host", "127.0.0.1", "--port", "5173", "--strictPort"], {
+  cwd: guiRoot,
+  env: { ...process.env, BROWSER: "none" },
+  stdio: ["ignore", "pipe", "pipe"]
+});
+vite.stderr.on("data", (chunk) => process.stderr.write(chunk));
+
+async function waitForRenderer() {
+  const deadline = Date.now() + 30_000;
+  let lastError;
+  while (Date.now() < deadline) {
+    if (vite.exitCode !== null) {
+      throw new Error(`renderer dev server exited early with code ${vite.exitCode} (is port 5173 busy?)`);
+    }
+    try {
+      const response = await fetch(rendererUrl);
+      if (response.ok) return;
+      lastError = new Error(`renderer returned HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 250));
+  }
+  throw new Error(`renderer dev server not ready at ${rendererUrl}: ${lastError?.message ?? "timeout"}`);
+}
+
+async function stopVite() {
+  if (vite.exitCode !== null || vite.signalCode !== null) return;
+  vite.kill("SIGTERM");
+  const closed = once(vite, "close");
+  const timedOut = new Promise((resolveSleep) => setTimeout(() => resolveSleep("timeout"), 5_000));
+  if (await Promise.race([closed, timedOut]) === "timeout") {
+    vite.kill("SIGKILL");
+    await once(vite, "close").catch(() => undefined);
+  }
+}
+
+try {
+  await waitForRenderer();
+} catch (error) {
+  console.error(`[dev-electron] ${error.message}`);
+  await stopVite();
+  process.exit(1);
+}
+
+log("launching Electron shell...");
+const electron = spawn(electronPath, [path.join(guiRoot, "src/main/electron-main.ts")], {
+  cwd: repoRoot,
+  env: {
+    ...process.env,
+    ELECTRON_RENDERER_URL: rendererUrl,
+    HARNESS_GUI_ROOT: process.env.HARNESS_GUI_ROOT ?? repoRoot
+  },
+  stdio: "inherit"
+});
+
+const shutdown = async (code) => {
+  await stopVite();
+  process.exit(code);
+};
+electron.on("close", (code) => void shutdown(code ?? 0));
+process.on("SIGINT", () => {
+  electron.kill("SIGTERM");
+});
+process.on("SIGTERM", () => {
+  electron.kill("SIGTERM");
+});

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -10,7 +10,7 @@ import { assertDevRendererUrl, createGuiContentSecurityPolicy, createPackagedRen
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export function createMainWindow(): BrowserWindow {
-  const preloadPath = path.join(dirname, "../preload/electron-preload.mjs");
+  const preloadPath = path.join(dirname, "../../dist-electron/electron-preload.cjs");
   const rendererUrl = process.env.ELECTRON_RENDERER_URL;
   const allowDevRenderer = Boolean(rendererUrl);
   const mainWindow = new BrowserWindow({
@@ -80,8 +80,11 @@ export async function startGuiApp(): Promise<void> {
 
 function createTrustedMainWindow(trustedWebContentsIds: Set<number>): BrowserWindow {
   const mainWindow = createMainWindow();
-  trustedWebContentsIds.add(mainWindow.webContents.id);
-  mainWindow.once("closed", () => trustedWebContentsIds.delete(mainWindow.webContents.id));
+  // Capture the id now: by the time "closed" fires the native window is
+  // destroyed and reading mainWindow.webContents throws "Object has been destroyed".
+  const webContentsId = mainWindow.webContents.id;
+  trustedWebContentsIds.add(webContentsId);
+  mainWindow.once("closed", () => trustedWebContentsIds.delete(webContentsId));
   return mainWindow;
 }
 

--- a/packages/gui/src/main/window-config.ts
+++ b/packages/gui/src/main/window-config.ts
@@ -29,10 +29,14 @@ export function createGuiContentSecurityPolicy(options: GuiContentSecurityPolicy
   const connectSrc = options.allowDevRenderer
     ? "connect-src 'self' http://127.0.0.1:5173 ws://127.0.0.1:5173"
     : "connect-src 'self'";
+  // Dev only: the Vite dev server injects the react-refresh preamble as an
+  // inline script and styles as inline <style> tags. Production stays strict.
+  const scriptSrc = options.allowDevRenderer ? "script-src 'self' 'unsafe-inline'" : "script-src 'self'";
+  const styleSrc = options.allowDevRenderer ? "style-src 'self' 'unsafe-inline'" : "style-src 'self'";
   return [
     "default-src 'self'",
-    "script-src 'self'",
-    "style-src 'self'",
+    scriptSrc,
+    styleSrc,
     "img-src 'self' data:",
     "font-src 'self'",
     connectSrc,

--- a/packages/gui/test/window-config.test.ts
+++ b/packages/gui/test/window-config.test.ts
@@ -16,6 +16,14 @@ test("production CSP does not allow wildcard localhost connections", () => {
   assert.doesNotMatch(createGuiContentSecurityPolicy({ allowDevRenderer: true }), /127\.0\.0\.1:\*/);
 });
 
+test("inline script/style relaxation is dev-only; production CSP stays strict", () => {
+  assert.doesNotMatch(guiContentSecurityPolicy, /unsafe-inline/);
+  assert.doesNotMatch(createGuiContentSecurityPolicy(), /unsafe-inline/);
+  const devCsp = createGuiContentSecurityPolicy({ allowDevRenderer: true });
+  assert.match(devCsp, /script-src 'self' 'unsafe-inline'/);
+  assert.match(devCsp, /style-src 'self' 'unsafe-inline'/);
+});
+
 test("trusted renderer URL accepts only explicit dev server or packaged renderer file", () => {
   const packagedRendererUrl = "file:///app/renderer/index.html";
 

--- a/packages/gui/vite.preload.config.ts
+++ b/packages/gui/vite.preload.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vite";
+
+// Bundles the sandboxed preload (and its allowlist imports) into a single
+// CommonJS file. Sandboxed Electron preloads cannot load ESM or resolve
+// bare/multi-file imports, so this build step is required before launch.
+export default defineConfig({
+  build: {
+    lib: {
+      entry: "src/preload/electron-preload.ts",
+      formats: ["cjs"],
+      fileName: () => "electron-preload.cjs"
+    },
+    outDir: "dist-electron",
+    emptyOutDir: true,
+    target: "node20",
+    minify: false,
+    rollupOptions: {
+      external: ["electron"]
+    }
+  }
+});


### PR DESCRIPTION
# English

## Summary

The Electron GUI shell could not actually be launched or used by a human: the referenced preload file was never built (hollow window, no IPC bridge), the app crashed on window close, there was no launch entrypoint, and the CSP blocked the Vite dev renderer. This PR fixes all launch-path defects end to end and hardens the e2e smoke so the regression class is caught.

## What Changed

- Bundle the sandboxed preload to CJS via a dedicated Vite lib-mode config (`vite.preload.config.ts` -> `dist-electron/electron-preload.cjs`); the previously referenced `electron-preload.mjs` was never built or committed, so windows opened without `window.harness`.
- Fix crash on window close in `electron-main.ts`: capture `webContents.id` before the `closed` event fires (the native object is already destroyed at that point, reading it threw "Object has been destroyed").
- CSP: allow `'unsafe-inline'` script/style only when the dev renderer is enabled (Vite injects the react-refresh preamble inline). Production CSP stays strict, now locked by a dedicated test.
- Add `scripts/dev-electron.mjs` human launcher and the `dev:electron` npm script: builds the preload, starts Vite, waits for readiness, launches Electron, tears down on exit.
- Extend the e2e smoke to assert `typeof window.harness === "object"`, closing the hollow-window blind spot; `test:e2e` now builds the preload first.
- Ignore `packages/gui/dist-electron/` in git and ESLint (build artifact).

## Task And Scope

- Harness task: GUI-V1 launchability fix (follow-up to the PRE-03 smoke lane, PR #273)
- Branch: `codex/gui-launchable`
- Public scope: `packages/gui/**`, `.gitignore`, `eslint.config.mjs`
- Private planning/evidence updated: yes (harness ledger records for the GUI-V1 line)
- Out of scope: renderer consuming the bridge (still a static shell), CI gui-e2e lane stabilization on headless Linux (known hang, tracked separately)

## Version Impact

- Version: no version change because the GUI package is private and unpublished
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: ADR-0025 (Playwright Electron e2e driver); GUI-V1 re-charter decision line
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 66c4963
- Branch merge-base with `origin/main`: 66c4963 (branch is exactly one commit ahead)
- Last `git fetch origin` time: immediately before push
- Sync method: none needed (already on tip)
- Public diff command: `git diff origin/main...codex/gui-launchable`
- Private evidence commit/path: harness ledger (GUI-V1 line)
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `npm run check:local` (fast tier, passed in 19.6s: lint, typecheck, tests, boundaries, package-policy)
- [x] `npm run test:e2e -w @harness-anything/gui` (Electron smoke incl. bridge assertion, passed locally)
- [x] Manual headful launch via `npm run dev:electron -w @harness-anything/gui`: window renders, `window.harness` bridge live, clean close without crash
- Not run: full `npm run check` / integration tier (covered by cloud CI per repo policy)

## Review Evidence

- Self-review: full diff re-read after gate pass; CSP relaxation verified dev-only via new locking test
- Reviewer subagent: not used (single-author fix line, verified by runtime probe)
- Human review: CEO acceptance in-session; user confirmed the GUI now launches
- Blocking findings: none open

## Residual Risk

- The CI `gui-e2e` lane hangs on headless Linux (pre-existing, PRE03-R1); it is not part of the merge queue's conditions so it does not block this PR, but needs a follow-up.
- Renderer is still a static shell; consuming `window.harness` is the next slice.

## References

- Task: GUI-V1 re-charter line (dec_mr9z0b7m)
- Evidence: local e2e output + headful launch session
- Review: this PR discussion

---

# 中文

## 概要

Electron GUI 外壳此前根本无法被人启动使用：引用的 preload 文件从未被构建（空壳窗口、无 IPC 桥）、关窗即崩溃、没有启动入口、CSP 还挡掉了 Vite 开发渲染器。本 PR 端到端修复全部启动链缺陷，并加固 e2e 冒烟以捕获这类回归。

## 改动内容

- 用独立的 Vite lib 模式配置把沙箱 preload 打包为 CJS（`vite.preload.config.ts` -> `dist-electron/electron-preload.cjs`）；此前引用的 `electron-preload.mjs` 从未被构建或提交，窗口打开后没有 `window.harness`。
- 修复 `electron-main.ts` 关窗崩溃：在 `closed` 事件触发前捕获 `webContents.id`（事件触发时原生对象已销毁，读取会抛 "Object has been destroyed"）。
- CSP：仅在启用 dev 渲染器时放行 `'unsafe-inline'` script/style（Vite 以内联方式注入 react-refresh preamble）；生产 CSP 保持严格，并新增测试锁定。
- 新增 `scripts/dev-electron.mjs` 人工启动器与 `dev:electron` npm 脚本：构建 preload、起 Vite、等就绪、拉起 Electron、退出时清理。
- e2e 冒烟增加 `typeof window.harness === "object"` 断言，堵住空壳窗口盲区；`test:e2e` 先构建 preload。
- git 与 ESLint 忽略 `packages/gui/dist-electron/`（构建产物）。

## 任务与范围

- Harness 任务：GUI-V1 可启动性修复（PRE-03 冒烟通道即 PR #273 的后续）
- 分支：`codex/gui-launchable`
- 公开范围：`packages/gui/**`、`.gitignore`、`eslint.config.mjs`
- 私有计划 / 证据是否已更新：yes（GUI-V1 线的 harness 台账记录）
- 范围外：渲染器消费桥接（仍是静态外壳）、headless Linux 上 CI gui-e2e 通道挂死的治理（已知问题，另行跟踪）

## 版本影响

- 版本：不改版本，原因是 GUI 包为 private 未发布
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：ADR-0025（Playwright Electron e2e driver）；GUI-V1 re-charter 决策线
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：66c4963
- 当前分支与 `origin/main` 的 merge-base：66c4963（分支恰好领先一个提交）
- 最近一次 `git fetch origin` 时间：推送前
- 同步方式：不需要（已在最新 tip 上）
- 公开 diff 命令：`git diff origin/main...codex/gui-launchable`
- 私有证据 commit/path：harness 台账（GUI-V1 线）
- Reviewer 证据路径：见审查证据
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `npm run check:local`（fast tier，19.6s 全绿：lint、typecheck、tests、boundaries、package-policy）
- [x] `npm run test:e2e -w @harness-anything/gui`（含桥接断言的 Electron 冒烟，本地通过）
- [x] 通过 `npm run dev:electron -w @harness-anything/gui` 人工有头启动：窗口渲染、`window.harness` 桥在线、关窗无崩溃
- 未运行：完整 `npm run check` / integration 层（按仓库政策由云端 CI 覆盖）

## 审查证据

- 自查：gate 通过后完整重读 diff；CSP 放宽经新增锁定测试验证为仅 dev
- Reviewer subagent：未使用（单作者修复线，以运行时探针验证）
- 人工审查：会话内 CEO 验收；用户已确认 GUI 可启动
- 阻塞发现：无

## 残余风险

- CI `gui-e2e` 通道在 headless Linux 上挂死（既有问题，PRE03-R1）；不在 merge queue 条件内故不阻塞本 PR，但需后续处理。
- 渲染器仍是静态外壳；消费 `window.harness` 是下一切片。

## 关联材料

- 任务：GUI-V1 re-charter 线（dec_mr9z0b7m）
- 证据：本地 e2e 输出 + 有头启动会话
- 审查：本 PR 讨论

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
