### PR TITLE
feat(daemon): user-level multi-repo cli client (W9-P4)

### DIFF
--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -7,17 +7,17 @@ import type { HarnessLayoutOverrides } from "../../../kernel/src/index.ts";
 import type { CliResult, ParsedCommand } from "./types.ts";
 
 export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] } {
-  const { rootDir, authoredRoot, json, args: rawArgs } = stripGlobalOptions(argv);
+  const { rootDir, authoredRoot, daemonRepoId, json, args: rawArgs } = stripGlobalOptions(argv);
   const jsonInput = applyJsonInputLayer(rawArgs, process.cwd());
   if (!jsonInput.ok) return { ok: false, error: jsonInput.error };
   const args = jsonInput.args;
   const layoutOverrides = authoredRoot ? { authoredRoot } : undefined;
 
   const help = parseHelpRequest(args, rootDir, json, layoutOverrides);
-  if (help) return help;
+  if (help) return attachDaemonRepoId(help, daemonRepoId);
 
   const parsed = parseRegisteredCommand(args, rootDir, json);
-  if (parsed) return attachLayoutOverrides(parsed, layoutOverrides);
+  if (parsed) return attachDaemonRepoId(attachLayoutOverrides(parsed, layoutOverrides), daemonRepoId);
   return {
     ok: false,
     error: cliError(CliErrorCode.UnknownCommand, `Supported commands: ${commandRegistry.map((entry) => entry.primary).join("; ")}, template list, template render, preset validate, vertical validate.`)
@@ -64,6 +64,14 @@ function attachLayoutOverrides(
 ): { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] } {
   if (!parsed.ok) return parsed;
   return { ok: true, value: commandWithLayoutOverrides(parsed.value, layoutOverrides) };
+}
+
+function attachDaemonRepoId(
+  parsed: { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] },
+  daemonRepoId: string | undefined
+): { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] } {
+  if (!parsed.ok || !daemonRepoId) return parsed;
+  return { ok: true, value: { ...parsed.value, daemonRepoId } };
 }
 
 function commandWithLayoutOverrides(command: ParsedCommand, layoutOverrides?: HarnessLayoutOverrides): ParsedCommand {

--- a/packages/cli/src/cli/parse-options.ts
+++ b/packages/cli/src/cli/parse-options.ts
@@ -4,6 +4,7 @@ import type { CliResult } from "./types.ts";
 export interface GlobalParseOptions {
   readonly rootDir: string;
   readonly authoredRoot?: string;
+  readonly daemonRepoId?: string;
   readonly json: boolean;
   readonly args: ReadonlyArray<string>;
 }
@@ -11,6 +12,7 @@ export interface GlobalParseOptions {
 export function stripGlobalOptions(argv: ReadonlyArray<string>, cwd = process.cwd()): GlobalParseOptions {
   const rootDir = readOption(argv, "--root") ?? cwd;
   const authoredRoot = readOption(argv, "--authored-root") ?? nonEmptyEnv("HARNESS_AUTHORED_ROOT");
+  const daemonRepoId = readOption(argv, "--repo") ?? nonEmptyEnv("HARNESS_DAEMON_REPO_ID");
   const json = argv.includes("--json");
   const args = argv.filter((arg, index) => {
     const previous = argv[index - 1];
@@ -18,9 +20,11 @@ export function stripGlobalOptions(argv: ReadonlyArray<string>, cwd = process.cw
       && arg !== "--root"
       && previous !== "--root"
       && arg !== "--authored-root"
-      && previous !== "--authored-root";
+      && previous !== "--authored-root"
+      && arg !== "--repo"
+      && previous !== "--repo";
   });
-  return { rootDir, authoredRoot, json, args };
+  return { rootDir, authoredRoot, daemonRepoId, json, args };
 }
 
 function nonEmptyEnv(name: string): string | undefined {

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -159,6 +159,7 @@ export interface CommandHelpOption {
 export interface ParsedCommand {
   readonly rootDir: string;
   readonly layoutOverrides?: HarnessLayoutOverrides;
+  readonly daemonRepoId?: string;
   readonly json: boolean;
   readonly action:
     | { readonly kind: "init"; readonly addNpmScripts: boolean; readonly projectName?: string }

--- a/packages/cli/src/commands/daemon/help.ts
+++ b/packages/cli/src/commands/daemon/help.ts
@@ -1,0 +1,15 @@
+export function renderDaemonHelp(): string {
+  return [
+    "Usage: harness-anything daemon <start|status|stop|bootstrap-server|install-templates> [options]",
+    "Alias: ha daemon <subcommand> [options]",
+    "",
+    "Commands:",
+    "  start --service              Start a detached local daemon service (default).",
+    "  start --foreground           Run the daemon service in the foreground.",
+    "  status --json                Show lock holder, queue depth, connections, and version.",
+    "  stop [--timeout-ms <ms>]     Signal the daemon and wait for queue drain and lock release.",
+    "  repo <subcommand>            Register, list, or unregister daemon repositories.",
+    "  bootstrap-server             Initialize a canonical team server repository.",
+    "  install-templates --out DIR  Copy systemd, launchd, and Windows Service templates."
+  ].join("\n");
+}

--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   createHarnessRuntimeContext,
+  registerDaemonRepo,
   resolveHarnessLayout,
 } from "../../../../kernel/src/index.ts";
 import {
@@ -20,7 +21,7 @@ import { initializeHarness } from "../init.ts";
 import { resolveCliVersion } from "../core/version.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import { readOption } from "../../cli/parse-options.ts";
-import { localDaemonSocketPath, requestLocalDaemonJsonRpc } from "../../daemon/client.ts";
+import { resolveLocalDaemonTarget, requestLocalDaemonJsonRpc, type LocalDaemonTarget } from "../../daemon/client.ts";
 import { runDaemonRepoCommand } from "./repo-registry.ts";
 
 export interface DaemonCommandInput {
@@ -178,9 +179,14 @@ export function loadDaemonIdentity(rootDir: string, layoutOverrides: { readonly 
 async function startDaemon(input: DaemonCommandInput): Promise<number> {
   const foreground = input.args.includes("--foreground");
   const service = input.args.includes("--service") || !foreground;
-  const socketPath = readOption(input.args, "--socket") ?? localDaemonSocketPath(input.rootDir);
+  const target = resolveLocalDaemonTarget({
+    rootDir: input.rootDir,
+    repoIdOverride: daemonRepoIdOverride(input.args),
+    autoRegisterSingleRepo: true
+  });
+  const socketPath = readOption(input.args, "--socket") ?? target.socketPath;
   if (foreground) {
-    await input.runServe(input.rootDir, input.layoutOverrides, ["daemon", "serve", "--socket", socketPath, "--idle-ms", "0"], {
+    await input.runServe(target.canonicalRoot, input.layoutOverrides, ["daemon", "serve", "--repo", target.repoId, "--socket", socketPath, "--user-root", target.userRoot, "--idle-ms", "0"], {
       onStarted: (status) => emitDaemonResult("daemon-start", { ...status, mode: "foreground" }, input.json)
     });
     return 0;
@@ -190,21 +196,25 @@ async function startDaemon(input: DaemonCommandInput): Promise<number> {
       ...process.execArgv,
       cliEntrypointPath(),
       "--root",
-      input.rootDir,
+      target.canonicalRoot,
       ...(input.layoutOverrides?.authoredRoot ? ["--authored-root", input.layoutOverrides.authoredRoot] : []),
       "daemon",
       "serve",
+      "--repo",
+      target.repoId,
       "--socket",
       socketPath,
+      "--user-root",
+      target.userRoot,
       "--idle-ms",
       "0"
     ], {
       detached: true,
       stdio: "ignore",
-      env: { ...process.env, HARNESS_DAEMON_MODE: "direct" }
+      env: { ...process.env, HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: target.userRoot, HARNESS_DAEMON_ID: target.daemonId }
     });
     child.unref();
-    const status = await waitForReachableStatus(input.rootDir, 6_000);
+    const status = await waitForReachableStatus(target, 6_000);
     emitDaemonResult("daemon-start", { ...status, mode: "service", socketPath }, input.json);
     return 0;
   }
@@ -212,9 +222,14 @@ async function startDaemon(input: DaemonCommandInput): Promise<number> {
 }
 
 async function statusDaemon(input: DaemonCommandInput): Promise<number> {
-  const layout = resolveHarnessLayout(createHarnessRuntimeContext(input.rootDir, input.layoutOverrides));
+  const target = resolveLocalDaemonTarget({
+    rootDir: input.rootDir,
+    repoIdOverride: daemonRepoIdOverride(input.args),
+    autoRegisterSingleRepo: false
+  });
+  const layout = resolveHarnessLayout(createHarnessRuntimeContext(target.canonicalRoot, input.layoutOverrides));
   const lockStatus = readDaemonLock(path.join(layout.locksRoot, "global.lock"));
-  const rpcStatus = await readReachableDaemonStatus(input.rootDir);
+  const rpcStatus = await readReachableDaemonStatus(target);
   emitDaemonResult("daemon-status", {
     ...lockStatus,
     reachable: Boolean(rpcStatus),
@@ -231,7 +246,12 @@ async function statusDaemon(input: DaemonCommandInput): Promise<number> {
 
 async function stopDaemon(input: DaemonCommandInput): Promise<number> {
   const timeoutMs = Number.parseInt(readOption(input.args, "--timeout-ms") ?? "5000", 10);
-  const layout = resolveHarnessLayout(createHarnessRuntimeContext(input.rootDir, input.layoutOverrides));
+  const target = resolveLocalDaemonTarget({
+    rootDir: input.rootDir,
+    repoIdOverride: daemonRepoIdOverride(input.args),
+    autoRegisterSingleRepo: false
+  });
+  const layout = resolveHarnessLayout(createHarnessRuntimeContext(target.canonicalRoot, input.layoutOverrides));
   const lockPath = path.join(layout.locksRoot, "global.lock");
   const before = readDaemonLock(lockPath);
   if (before.started && typeof before.pid === "number") {
@@ -277,9 +297,16 @@ async function bootstrapServer(input: DaemonCommandInput): Promise<number> {
   const reportPath = readOption(input.args, "--report") ?? path.join(canonicalRoot, ".harness", "generated", "daemon-bootstrap-report.json");
   const skipSshCheck = input.args.includes("--skip-ssh-check");
   const noStart = input.args.includes("--no-start");
+  const registryRepoId = readOption(input.args, "--repo-id") ?? "canonical";
 
   ensureCanonicalRepo(canonicalRoot);
   initializeHarness({ rootDir: canonicalRoot }, false, path.basename(canonicalRoot));
+  const registryUserRoot = daemonUserRoot(input.args);
+  const registry = registerDaemonRepo({
+    ...(registryUserRoot ? { userRoot: registryUserRoot } : {}),
+    canonicalRoot,
+    repoId: registryRepoId
+  });
   const layout = resolveHarnessLayout({ rootDir: canonicalRoot });
   const peoplePath = path.join(layout.authoredRoot, "people.yaml");
   ensurePeopleRoster(peoplePath, { personId, displayName, primaryEmail, role, sshUser, sshHost });
@@ -287,13 +314,19 @@ async function bootstrapServer(input: DaemonCommandInput): Promise<number> {
   const mirrorReport = readonlyMirror ? ensureReadonlyMirror(canonicalRoot, path.resolve(readonlyMirror)) : undefined;
   const daemon = noStart
     ? { started: false, reason: "no-start" }
-    : await startBootstrapDaemon(canonicalRoot);
+    : await startBootstrapDaemon(canonicalRoot, registry.repo.repoId, registry.registryPath);
   const ssh = skipSshCheck ? { checked: false, reason: "skip-ssh-check" } : await checkSshReachability(sshHost, sshUser, canonicalRoot);
   const report = {
     schema: "daemon-bootstrap-report/v1",
     canonicalRoot,
     peoplePath,
     daemon,
+    registry: {
+      path: registry.registryPath,
+      repoId: registry.repo.repoId,
+      changed: registry.changed,
+      warnings: registry.warnings
+    },
     ssh,
     gitHook: {
       path: path.join(canonicalRoot, ".git/hooks/pre-receive"),
@@ -380,7 +413,14 @@ function ensureReadonlyMirror(canonicalRoot: string, mirrorRoot: string): Record
   return { path: mirrorRoot, sync: "git fetch", hookPath };
 }
 
-async function startBootstrapDaemon(rootDir: string): Promise<Record<string, unknown>> {
+async function startBootstrapDaemon(rootDir: string, repoId: string, registryPath: string): Promise<Record<string, unknown>> {
+  const userRoot = path.dirname(registryPath);
+  const target = resolveLocalDaemonTarget({
+    rootDir,
+    repoIdOverride: repoId,
+    userRoot,
+    autoRegisterSingleRepo: false
+  });
   const child = spawn(process.execPath, [
     ...process.execArgv,
     cliEntrypointPath(),
@@ -388,17 +428,21 @@ async function startBootstrapDaemon(rootDir: string): Promise<Record<string, unk
     rootDir,
     "daemon",
     "serve",
+    "--repo",
+    target.repoId,
     "--socket",
-    localDaemonSocketPath(rootDir),
+    target.socketPath,
+    "--user-root",
+    target.userRoot,
     "--idle-ms",
     "0"
   ], {
     detached: true,
     stdio: "ignore",
-    env: { ...process.env, HARNESS_DAEMON_MODE: "direct" }
+    env: { ...process.env, HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: target.userRoot, HARNESS_DAEMON_ID: target.daemonId }
   });
   child.unref();
-  return waitForReachableStatus(rootDir, 6_000);
+  return waitForReachableStatus(target, 6_000);
 }
 
 async function checkSshReachability(host: string, user: string, canonicalRoot: string): Promise<Record<string, unknown>> {
@@ -435,9 +479,14 @@ function readDaemonLock(lockPath: string): Record<string, unknown> {
   };
 }
 
-async function readReachableDaemonStatus(rootDir: string): Promise<Record<string, unknown> | undefined> {
+async function readReachableDaemonStatus(target: LocalDaemonTarget): Promise<Record<string, unknown> | undefined> {
   try {
-    const receipt = await requestLocalDaemonJsonRpc(rootDir, "repo.daemon.status", { repo: { repoId: "canonical" } });
+    const receipt = await requestLocalDaemonJsonRpc(target.canonicalRoot, "repo.daemon.status", { repo: { repoId: target.repoId } }, 1_000, {
+      userRoot: target.userRoot,
+      daemonId: target.daemonId,
+      socketPath: target.socketPath,
+      allowLegacySocket: true
+    });
     const details = isDaemonRecord(receipt.details) ? receipt.details : {};
     const data = isDaemonRecord(details.data) ? details.data : undefined;
     return receipt.ok === true && data ? data : { rpcError: receipt };
@@ -446,10 +495,10 @@ async function readReachableDaemonStatus(rootDir: string): Promise<Record<string
   }
 }
 
-async function waitForReachableStatus(rootDir: string, timeoutMs: number): Promise<Record<string, unknown>> {
+async function waitForReachableStatus(target: LocalDaemonTarget, timeoutMs: number): Promise<Record<string, unknown>> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
-    const status = await readReachableDaemonStatus(rootDir);
+    const status = await readReachableDaemonStatus(target);
     if (status) return status;
     await waitDaemonPollInterval(100);
   }
@@ -484,6 +533,14 @@ function emitDaemonError(message: string, json: boolean): void {
     return;
   }
   console.error(`error code=${CliErrorCode.JournalUnavailable} hint=${message}`);
+}
+
+function daemonRepoIdOverride(args: ReadonlyArray<string>): string | undefined {
+  return readOption(args, "--repo") ?? process.env.HARNESS_DAEMON_REPO_ID;
+}
+
+function daemonUserRoot(args: ReadonlyArray<string>): string | undefined {
+  return readOption(args, "--user-root") ?? process.env.HARNESS_DAEMON_USER_ROOT;
 }
 
 function renderDaemonHelp(): string {

--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -22,6 +22,7 @@ import { resolveCliVersion } from "../core/version.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import { readOption } from "../../cli/parse-options.ts";
 import { resolveLocalDaemonTarget, requestLocalDaemonJsonRpc, type LocalDaemonTarget } from "../../daemon/client.ts";
+import { renderDaemonHelp } from "./help.ts";
 import { runDaemonRepoCommand } from "./repo-registry.ts";
 
 export interface DaemonCommandInput {
@@ -541,22 +542,6 @@ function daemonRepoIdOverride(args: ReadonlyArray<string>): string | undefined {
 
 function daemonUserRoot(args: ReadonlyArray<string>): string | undefined {
   return readOption(args, "--user-root") ?? process.env.HARNESS_DAEMON_USER_ROOT;
-}
-
-function renderDaemonHelp(): string {
-  return [
-    "Usage: harness-anything daemon <start|status|stop|bootstrap-server|install-templates> [options]",
-    "Alias: ha daemon <subcommand> [options]",
-    "",
-    "Commands:",
-    "  start --service              Start a detached local daemon service (default).",
-    "  start --foreground           Run the daemon service in the foreground.",
-    "  status --json                Show lock holder, queue depth, connections, and version.",
-    "  stop [--timeout-ms <ms>]     Signal the daemon and wait for queue drain and lock release.",
-    "  repo <subcommand>            Register, list, or unregister daemon repositories.",
-    "  bootstrap-server             Initialize a canonical team server repository.",
-    "  install-templates --out DIR  Copy systemd, launchd, and Windows Service templates."
-  ].join("\n");
 }
 
 function requiredOption(args: ReadonlyArray<string>, name: string): string {

--- a/packages/cli/src/commands/daemon/repo-registry.ts
+++ b/packages/cli/src/commands/daemon/repo-registry.ts
@@ -27,7 +27,7 @@ export function runDaemonRepoCommand(input: DaemonRepoCommandInput): number {
   };
   try {
     if (action === "register") {
-      const canonicalRoot = readOption(input.args, "--canonical-root") ?? input.rootDir;
+      const canonicalRoot = readOption(input.args, "--canonical-root") ?? readOption(input.args, "--root") ?? input.rootDir;
       const result = registerDaemonRepo({
         ...options,
         canonicalRoot,

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -1,9 +1,18 @@
 import { createHash } from "node:crypto";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import net from "node:net";
+import os from "node:os";
+import path from "node:path";
 import { createInterface } from "node:readline";
 import type { Readable, Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
+import {
+  readDaemonRegistry,
+  registerDaemonRepo,
+  resolveDaemonRepoByRoot,
+  type DaemonRegistry,
+  type DaemonRegistryRepo
+} from "../../../kernel/src/index.ts";
 import {
   currentDaemonProtocolVersion,
   defaultUnixSocketPath,
@@ -27,6 +36,8 @@ export interface DaemonClientConfig {
   readonly mode: DaemonClientMode;
   readonly idleExitMs: number;
   readonly autostartTimeoutMs: number;
+  readonly userRoot: string;
+  readonly daemonId: string;
   readonly remote?: RemoteDaemonConfig;
 }
 
@@ -37,12 +48,25 @@ export interface RemoteDaemonConfig {
   readonly repoId: string;
 }
 
+export interface LocalDaemonTarget {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+  readonly userRoot: string;
+  readonly daemonId: string;
+  readonly socketPath: string;
+  readonly legacySocketPath: string;
+  readonly registered: boolean;
+}
+
 export function readDaemonClientConfig(env: NodeJS.ProcessEnv = process.env): DaemonClientConfig {
   const mode = readMode(env.HARNESS_DAEMON_MODE);
+  const userRoot = daemonUserRoot(env);
   return {
     mode,
     idleExitMs: parsePositiveIntegerOr(env.HARNESS_DAEMON_IDLE_MS, defaultIdleExitMs),
     autostartTimeoutMs: parsePositiveIntegerOr(env.HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS, defaultAutostartTimeoutMs),
+    userRoot,
+    daemonId: daemonIdFromEnv(env),
     ...(mode === "remote" ? { remote: readRemoteConfig(env) } : {})
   };
 }
@@ -65,17 +89,113 @@ export function daemonIdForRoot(rootDir: string): string {
   return `repo-${createHash("sha256").update(rootDir).digest("hex").slice(0, 16)}`;
 }
 
+export function daemonIdForUserRoot(userRoot: string, daemonId = "default"): string {
+  return `u-${createHash("sha256").update(`${path.resolve(userRoot)}\0${daemonId}`).digest("hex").slice(0, 16)}`;
+}
+
 export function localDaemonSocketPath(rootDir: string): string {
   return defaultUnixSocketPath(daemonIdForRoot(rootDir));
+}
+
+export function localUserDaemonSocketPath(userRoot = daemonUserRoot(), daemonId = daemonIdFromEnv()): string {
+  return defaultUnixSocketPath(daemonIdForUserRoot(userRoot, daemonId));
+}
+
+export function daemonUserRoot(env: NodeJS.ProcessEnv = process.env): string {
+  return path.resolve(nonEmptyEnv(env, "HARNESS_DAEMON_USER_ROOT") ?? path.join(os.homedir(), ".harness"));
+}
+
+export function daemonIdFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  return nonEmptyEnv(env, "HARNESS_DAEMON_ID") ?? "default";
+}
+
+export function resolveLocalDaemonTarget(input: {
+  readonly rootDir: string;
+  readonly repoIdOverride?: string;
+  readonly userRoot?: string;
+  readonly daemonId?: string;
+  readonly autoRegisterSingleRepo?: boolean;
+  readonly env?: NodeJS.ProcessEnv;
+}): LocalDaemonTarget {
+  const env = input.env ?? process.env;
+  const userRoot = path.resolve(input.userRoot ?? daemonUserRoot(env));
+  const daemonId = input.daemonId ?? daemonIdFromEnv(env);
+  const repoIdOverride = input.repoIdOverride ?? nonEmptyEnv(env, "HARNESS_DAEMON_REPO_ID");
+  const registry = readDaemonRegistry({ userRoot });
+  const legacySocketPath = localDaemonSocketPath(input.rootDir);
+  const socketPath = localUserDaemonSocketPath(userRoot, daemonId);
+
+  if (repoIdOverride) {
+    const registered = registry.repos.find((repo) => repo.repoId === repoIdOverride && repo.state === "enabled");
+    return daemonTarget({
+      repoId: repoIdOverride,
+      canonicalRoot: registered?.canonicalRoot ?? path.resolve(input.rootDir),
+      userRoot,
+      daemonId,
+      socketPath,
+      legacySocketPath,
+      registered: Boolean(registered)
+    });
+  }
+
+  const matchingRepo = resolveRegistryRepoByRoot(input.rootDir, registry, userRoot);
+  if (matchingRepo?.state === "enabled") {
+    return daemonTarget({
+      repoId: matchingRepo.repoId,
+      canonicalRoot: matchingRepo.canonicalRoot,
+      userRoot,
+      daemonId,
+      socketPath,
+      legacySocketPath,
+      registered: true
+    });
+  }
+
+  const enabledRepos = registry.repos.filter((repo) => repo.state === "enabled");
+  if (enabledRepos.length === 0) {
+    if (input.autoRegisterSingleRepo) {
+      const registered = tryRegisterCanonicalRepo(input.rootDir, userRoot);
+      if (registered) {
+        return daemonTarget({
+          repoId: registered.repoId,
+          canonicalRoot: registered.canonicalRoot,
+          userRoot,
+          daemonId,
+          socketPath,
+          legacySocketPath,
+          registered: true
+        });
+      }
+    }
+    return daemonTarget({
+      repoId: "canonical",
+      canonicalRoot: path.resolve(input.rootDir),
+      userRoot,
+      daemonId,
+      socketPath,
+      legacySocketPath,
+      registered: false
+    });
+  }
+
+  throw new Error(`current root is not registered with the user daemon registry. Run: ha daemon repo register --repo-id <id> --root ${JSON.stringify(path.resolve(input.rootDir))}`);
 }
 
 export async function requestLocalDaemonJsonRpc(
   rootDir: string,
   method: string,
   params: JsonObject,
-  timeoutMs = 1_000
+  timeoutMs = 1_000,
+  options: {
+    readonly userRoot?: string;
+    readonly daemonId?: string;
+    readonly socketPath?: string;
+    readonly allowLegacySocket?: boolean;
+  } = {}
 ): Promise<JsonObject> {
-  const socket = await connectUnixSocket(localDaemonSocketPath(rootDir), timeoutMs);
+  const userRoot = path.resolve(options.userRoot ?? daemonUserRoot());
+  const socketPath = options.socketPath ?? localUserDaemonSocketPath(userRoot, options.daemonId ?? daemonIdFromEnv());
+  const socket = await connectUnixSocketWithLegacyFallback(socketPath, options.allowLegacySocket === false ? undefined : localDaemonSocketPath(rootDir), timeoutMs);
   const client = new JsonRpcLineClient(socket, socket);
   try {
     await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion });
@@ -86,18 +206,25 @@ export async function requestLocalDaemonJsonRpc(
 }
 
 async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfig): Promise<CommandReceipt | CommandFailureReceipt> {
-  const endpoint = localDaemonSocketPath(command.rootDir);
+  const target = resolveLocalDaemonTarget({
+    rootDir: command.rootDir,
+    repoIdOverride: command.daemonRepoId,
+    userRoot: config.userRoot,
+    daemonId: config.daemonId,
+    autoRegisterSingleRepo: true
+  });
+  const endpoint = target.socketPath;
   const deadline = Date.now() + config.autostartTimeoutMs;
   let nextSpawnAt = 0;
   let lastError: unknown;
   while (Date.now() <= deadline) {
     try {
       const socket = await connectUnixSocket(endpoint, 200);
-      return await runWithLineClient(new JsonRpcLineClient(socket, socket), command, "canonical");
+      return await runWithLineClient(new JsonRpcLineClient(socket, socket), commandForTarget(command, target), target.repoId);
     } catch (error) {
       lastError = error;
       if (Date.now() >= nextSpawnAt) {
-        spawnLocalDaemon(command, endpoint, config.idleExitMs);
+        spawnLocalDaemon(commandForTarget(command, target), target, config.idleExitMs);
         nextSpawnAt = Date.now() + 500;
       }
       await delay(100);
@@ -145,17 +272,19 @@ async function runWithLineClient(
   }
 }
 
-function spawnLocalDaemon(command: ParsedCommand, socketPath: string, idleExitMs: number): void {
+function spawnLocalDaemon(command: ParsedCommand, target: LocalDaemonTarget, idleExitMs: number): void {
   const child = spawn(process.execPath, [
     ...process.execArgv,
     fileURLToPath(import.meta.url).replace(/\/daemon\/client\.(ts|js)$/u, "/index.$1"),
     "--root",
-    command.rootDir,
+    target.canonicalRoot,
     ...(command.layoutOverrides?.authoredRoot ? ["--authored-root", command.layoutOverrides.authoredRoot] : []),
     "daemon",
     "serve",
+    "--repo",
+    target.repoId,
     "--socket",
-    socketPath,
+    target.socketPath,
     "--idle-ms",
     String(idleExitMs)
   ], {
@@ -163,7 +292,9 @@ function spawnLocalDaemon(command: ParsedCommand, socketPath: string, idleExitMs
     stdio: "ignore",
     env: {
       ...process.env,
-      HARNESS_DAEMON_MODE: "direct"
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DAEMON_USER_ROOT: target.userRoot,
+      HARNESS_DAEMON_ID: target.daemonId
     }
   });
   child.unref();
@@ -185,6 +316,15 @@ function connectUnixSocket(socketPath: string, timeoutMs: number): Promise<net.S
       reject(error);
     });
   });
+}
+
+async function connectUnixSocketWithLegacyFallback(socketPath: string, legacySocketPath: string | undefined, timeoutMs: number): Promise<net.Socket> {
+  try {
+    return await connectUnixSocket(socketPath, timeoutMs);
+  } catch (error) {
+    if (!legacySocketPath || legacySocketPath === socketPath) throw error;
+    return connectUnixSocket(legacySocketPath, timeoutMs);
+  }
 }
 
 class JsonRpcLineClient {
@@ -243,6 +383,42 @@ function daemonUnavailableReceipt(command: ParsedCommand, error: unknown): Comma
 function readMode(value: string | undefined): DaemonClientMode {
   if (value === "direct" || value === "local" || value === "remote") return value;
   return "direct";
+}
+
+function nonEmptyEnv(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const value = env[name];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function resolveRegistryRepoByRoot(rootDir: string, registry: DaemonRegistry, userRoot: string): DaemonRegistryRepo | undefined {
+  try {
+    return resolveDaemonRepoByRoot(rootDir, { userRoot });
+  } catch {
+    const resolvedRoot = path.resolve(rootDir);
+    return registry.repos.find((repo) => path.resolve(repo.canonicalRoot) === resolvedRoot);
+  }
+}
+
+function tryRegisterCanonicalRepo(rootDir: string, userRoot: string): DaemonRegistryRepo | undefined {
+  try {
+    return registerDaemonRepo({
+      userRoot,
+      canonicalRoot: rootDir,
+      repoId: "canonical"
+    }).repo;
+  } catch {
+    return undefined;
+  }
+}
+
+function commandForTarget(command: ParsedCommand, target: LocalDaemonTarget): ParsedCommand {
+  return path.resolve(command.rootDir) === path.resolve(target.canonicalRoot)
+    ? command
+    : { ...command, rootDir: target.canonicalRoot };
+}
+
+function daemonTarget(input: LocalDaemonTarget): LocalDaemonTarget {
+  return input;
 }
 
 function readRemoteConfig(env: NodeJS.ProcessEnv): RemoteDaemonConfig {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -350,6 +350,7 @@ function createDaemonServiceHost(
       reposById.delete(repoId);
       if (runtime.getRepoRuntime(repoId)) await runtime.detachRepo(repoId);
     }
+    await runtime.retryUnavailableRepos();
   }
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,10 @@
 
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import {
+  readDaemonRegistry,
+  type DaemonRegistryRepo
+} from "../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "./cli/error-codes.ts";
 import { parseArgs } from "./cli/parse-args.ts";
 import { readOption, stripGlobalOptions } from "./cli/parse-options.ts";
@@ -26,7 +30,7 @@ import {
 } from "./commands/daemon/productization.ts";
 import { runRegisteredCommandWithCliComposition } from "./composition/command-executor.ts";
 import { selectCliAdapterProvider } from "./composition/adapter-registry.ts";
-import { localDaemonSocketPath, runCommandThroughDaemon } from "./daemon/client.ts";
+import { daemonIdFromEnv, daemonUserRoot, localUserDaemonSocketPath, runCommandThroughDaemon } from "./daemon/client.ts";
 import { createCliCommandService } from "./daemon/command-service.ts";
 import { makeDaemonQueuedWriteCoordinator } from "./daemon/queued-write-coordinator.ts";
 
@@ -34,6 +38,8 @@ const runRegisteredCommand = runRegisteredCommandWithCliComposition;
 const daemonRuntimeProvider = selectCliAdapterProvider("daemon.runtime");
 type HarnessDaemonRuntime = ReturnType<typeof daemonRuntimeProvider.createDaemonRuntime>;
 type MultiRepoHarnessDaemonRuntime = ReturnType<typeof daemonRuntimeProvider.createMultiRepoDaemonRuntime>;
+type RepoServiceBinding = ReturnType<typeof createRepoServiceBinding>;
+type DaemonServeRepo = DaemonRepoNamespace & Pick<DaemonRegistryRepo, "displayName">;
 const createMultiRepoDaemonRuntime = daemonRuntimeProvider.createMultiRepoDaemonRuntime;
 
 export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)): Promise<number> {
@@ -58,15 +64,16 @@ async function maybeRunDaemonCommand(argv: ReadonlyArray<string>): Promise<numbe
   if (stripped.args[0] !== "daemon") return undefined;
   const action = stripped.args[1] ?? "status";
   const layoutOverrides = stripped.authoredRoot ? { authoredRoot: stripped.authoredRoot } : undefined;
+  const daemonArgs = stripped.daemonRepoId ? [...stripped.args, "--repo", stripped.daemonRepoId] : stripped.args;
   if (action === "serve") {
-    await runDaemonServe(stripped.rootDir, layoutOverrides, stripped.args);
+    await runDaemonServe(stripped.rootDir, layoutOverrides, daemonArgs);
     return 0;
   }
   return runDaemonProductCommand({
     rootDir: stripped.rootDir,
     layoutOverrides,
     json: stripped.json,
-    args: stripped.args,
+    args: daemonArgs,
     runServe: runDaemonServe
   });
 }
@@ -77,10 +84,18 @@ async function runDaemonServe(
   args: ReadonlyArray<string>,
   hooks: DaemonServeHooks = {}
 ): Promise<void> {
-  const repoId = readOption(args, "--repo") ?? "canonical";
+  const requestedRepoId = readOption(args, "--repo") ?? process.env.HARNESS_DAEMON_REPO_ID ?? "canonical";
+  const userRoot = readOption(args, "--user-root") ?? daemonUserRoot();
+  const serveRepos = daemonServeRepos(rootDir, layoutOverrides, requestedRepoId, userRoot);
+  const defaultRepoId = defaultDaemonServeRepoId(serveRepos, rootDir, requestedRepoId);
   const runtime = createMultiRepoDaemonRuntime({
     materializerPollMs: 5_000,
-    repos: [{ repoId, rootDir, ...(layoutOverrides ? { layoutOverrides } : {}) }]
+    repos: serveRepos.map((repo) => ({
+      repoId: repo.repoId,
+      rootDir: repo.canonicalRoot,
+      displayName: repo.displayName,
+      ...(layoutOverrides ? { layoutOverrides } : {})
+    }))
   });
   const startStatus = await runtime.start();
   if (startStatus.repoCount > 0 && startStatus.attachedCount === 0 && startStatus.unavailableCount > 0) {
@@ -88,10 +103,11 @@ async function runDaemonServe(
   }
   const idleMs = parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true });
   const stdio = args.includes("--stdio");
-  const socketPath = readOption(args, "--socket") ?? localDaemonSocketPath(rootDir);
+  const socketPath = readOption(args, "--socket") ?? localUserDaemonSocketPath(userRoot, daemonIdFromEnv());
   const endpoint = stdio ? "stdio" : socketPath;
   const connections: DaemonConnectionStats = { active: 0, total: 0 };
-  const serviceHost = createDaemonServiceHost(runtime, [{ repoId, canonicalRoot: rootDir }], repoId, layoutOverrides, idleMs, endpoint, connections);
+  const serviceHost = createDaemonServiceHost(runtime, serveRepos, defaultRepoId, layoutOverrides, idleMs, endpoint, connections);
+  serviceHost.startRegistryReconcile(userRoot);
   if (stdio) {
     connections.active += 1;
     connections.total += 1;
@@ -162,6 +178,37 @@ function repoAvailabilityFailure(
   };
 }
 
+function daemonServeRepos(
+  rootDir: string,
+  layoutOverrides: { readonly authoredRoot?: string } | undefined,
+  requestedRepoId: string,
+  userRoot: string
+): ReadonlyArray<DaemonServeRepo> {
+  const enabledRepos = readDaemonRegistry({ userRoot }).repos.filter((repo) => repo.state === "enabled");
+  if (enabledRepos.length > 0) {
+    return enabledRepos.map((repo) => ({
+      repoId: repo.repoId,
+      canonicalRoot: repo.canonicalRoot,
+      displayName: repo.displayName
+    }));
+  }
+  return [{
+    repoId: requestedRepoId,
+    canonicalRoot: rootDir,
+    displayName: layoutOverrides?.authoredRoot ?? requestedRepoId
+  }];
+}
+
+function defaultDaemonServeRepoId(repos: ReadonlyArray<DaemonServeRepo>, rootDir: string, requestedRepoId: string): string {
+  if (repos.some((repo) => repo.repoId === requestedRepoId)) return requestedRepoId;
+  const matchingRoot = repos.find((repo) => realpathOrResolve(repo.canonicalRoot) === realpathOrResolve(rootDir));
+  return matchingRoot?.repoId ?? repos[0]?.repoId ?? requestedRepoId;
+}
+
+function sortedDaemonRepos(repos: ReadonlyArray<DaemonRepoNamespace>): ReadonlyArray<DaemonRepoNamespace> {
+  return [...repos].sort((left, right) => left.repoId.localeCompare(right.repoId) || left.canonicalRoot.localeCompare(right.canonicalRoot));
+}
+
 function createDaemonServiceHost(
   runtime: MultiRepoHarnessDaemonRuntime,
   repos: ReadonlyArray<DaemonRepoNamespace>,
@@ -177,20 +224,25 @@ function createDaemonServiceHost(
   readonly scheduleIdleExit: () => void;
   readonly waitForStopRequest: () => Promise<void>;
   readonly onStop: (handler: () => Promise<void>) => void;
+  readonly startRegistryReconcile: (userRoot: string) => void;
   readonly stop: () => Promise<void>;
 } {
   const daemonId = `ha-${process.pid}`;
   const stopHandlers: Array<() => Promise<void>> = [];
+  const reposById = new Map(repos.map((repo) => [repo.repoId, repo]));
   let requestStop: (() => void) | undefined;
   const stopRequested = new Promise<void>((resolve) => {
     requestStop = resolve;
   });
   let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let reconcileTimer: ReturnType<typeof setInterval> | undefined;
+  let reconciling = false;
   let stopping = false;
   const stop = async () => {
     if (stopping) return;
     stopping = true;
     if (idleTimer) clearTimeout(idleTimer);
+    if (reconcileTimer) clearInterval(reconcileTimer);
     for (const handler of stopHandlers.splice(0, stopHandlers.length)) {
       await handler();
     }
@@ -218,13 +270,13 @@ function createDaemonServiceHost(
     daemonId,
     createProtocolServer: (authContext) => createJsonRpcProtocolServer({
       daemonId,
-      repos,
-      services: repoBindings.get(defaultRepoId)!.services,
+      repos: sortedDaemonRepos([...reposById.values()]),
+      services: defaultRepoBinding().services,
       resolveRepoServices: (repo) => repoBindings.get(repo.repoId)?.services,
       resolveRepoAvailability: (repo) => repoAvailabilityFailure(runtime, repo),
       authContext,
-      ...(repoBindings.get(defaultRepoId)?.identity.identityProvider ? { identityProvider: repoBindings.get(defaultRepoId)!.identity.identityProvider } : {}),
-      ...(repoBindings.get(defaultRepoId)?.identity.peopleRoster ? { peopleRoster: repoBindings.get(defaultRepoId)!.identity.peopleRoster } : {}),
+      ...(defaultRepoBinding().identity.identityProvider ? { identityProvider: defaultRepoBinding().identity.identityProvider } : {}),
+      ...(defaultRepoBinding().identity.peopleRoster ? { peopleRoster: defaultRepoBinding().identity.peopleRoster } : {}),
       appendRuntimeEvent: (input, context) => {
         const targetRepoId = context?.repo.repoId ?? defaultRepoId;
         return repoBindings.get(targetRepoId)?.appendRuntimeEvent(input) ?? Promise.resolve();
@@ -232,8 +284,8 @@ function createDaemonServiceHost(
     }),
     status: () => daemonStatusPayload({
       daemonId,
-      rootDir: repoBindings.get(defaultRepoId)!.repo.canonicalRoot,
-      repoId: defaultRepoId,
+      rootDir: defaultRepoBinding().repo.canonicalRoot,
+      repoId: defaultRepoBinding().repo.repoId,
       endpoint,
       runtimeStatus: runtime.status(),
       connections
@@ -243,8 +295,62 @@ function createDaemonServiceHost(
     onStop: (handler) => {
       stopHandlers.push(handler);
     },
+    startRegistryReconcile: (userRoot) => {
+      if (reconcileTimer || stopping) return;
+      const reconcile = async () => {
+        if (reconciling || stopping) return;
+        reconciling = true;
+        try {
+          await reconcileDaemonRepos(userRoot);
+        } finally {
+          reconciling = false;
+        }
+      };
+      reconcileTimer = setInterval(() => {
+        void reconcile().catch(() => undefined);
+      }, 1_000);
+      reconcileTimer.unref();
+    },
     stop
   };
+
+  function defaultRepoBinding(): RepoServiceBinding {
+    const binding = repoBindings.get(defaultRepoId) ?? repoBindings.values().next().value;
+    if (!binding) throw new Error("daemon service host has no repo bindings");
+    return binding;
+  }
+
+  async function reconcileDaemonRepos(userRoot: string): Promise<void> {
+    const desiredRepos = readDaemonRegistry({ userRoot }).repos.filter((repo) => repo.state === "enabled");
+    if (desiredRepos.length === 0) return;
+    const desiredIds = new Set(desiredRepos.map((repo) => repo.repoId));
+    for (const repo of desiredRepos) {
+      if (!reposById.has(repo.repoId)) {
+        const namespace = { repoId: repo.repoId, canonicalRoot: repo.canonicalRoot } satisfies DaemonRepoNamespace;
+        reposById.set(repo.repoId, namespace);
+      }
+      if (!runtime.getRepoRuntime(repo.repoId)) {
+        await runtime.attachRepo({ repoId: repo.repoId, rootDir: repo.canonicalRoot, displayName: repo.displayName, ...(layoutOverrides ? { layoutOverrides } : {}) });
+      }
+      if (!repoBindings.has(repo.repoId)) {
+        const repoRuntime = runtime.getRepoRuntime(repo.repoId);
+        if (repoRuntime) {
+          repoBindings.set(repo.repoId, createRepoServiceBinding(reposById.get(repo.repoId)!, repoRuntime, runtime, layoutOverrides, {
+            onCommandStart: () => {
+              if (idleTimer) clearTimeout(idleTimer);
+            },
+            onCommandSettled: scheduleIdleExit
+          }, { daemonId, endpoint, connections }));
+        }
+      }
+    }
+    for (const repoId of [...reposById.keys()]) {
+      if (desiredIds.has(repoId)) continue;
+      repoBindings.delete(repoId);
+      reposById.delete(repoId);
+      if (runtime.getRepoRuntime(repoId)) await runtime.detachRepo(repoId);
+    }
+  }
 }
 
 function createRepoServiceBinding(
@@ -435,6 +541,14 @@ function makeUnavailableTerminalSessionService() {
     resizeSession: () => failure,
     closeSession: () => failure
   };
+}
+
+function realpathOrResolve(rootDir: string): string {
+  try {
+    return realpathSync(rootDir);
+  } catch {
+    return rootDir;
+  }
 }
 
 function isCliEntrypoint(): boolean {

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile, execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -189,6 +189,8 @@ test("daemon bootstrap-server is idempotent and installs roster hooks and read-o
     assert.equal(existsSync(path.join(canonicalRoot, ".git/hooks/pre-receive")), true);
     assert.equal(existsSync(path.join(mirrorRoot, "hooks/pre-receive")), true);
     assert.equal(existsSync(reportPath), true);
+    assert.equal(first.registry && typeof first.registry === "object" && (first.registry as { repoId?: string }).repoId, "canonical");
+    assert.equal(existsSync(path.join(defaultDaemonUserRoot(rootDir), "registry.json")), true);
 
     const canonicalHook = spawnSync(path.join(canonicalRoot, ".git/hooks/pre-receive"), {
       cwd: canonicalRoot,
@@ -203,6 +205,141 @@ test("daemon bootstrap-server is idempotent and installs roster hooks and read-o
     });
     assert.notEqual(mirrorHook.status, 0);
     assert.match(mirrorHook.stderr, /read-only mirror/u);
+  });
+});
+
+test("daemon client auto-registers initialized single repo on first local command", () => {
+  withTempRoot((rootDir) => {
+    const userRoot = path.join(rootDir, "user-daemon");
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+
+    const listed = runRawJson(rootDir, ["task", "list"], {
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_USER_ROOT: userRoot,
+      HARNESS_DAEMON_IDLE_MS: "1500"
+    });
+
+    assert.equal(listed.ok, true);
+    const registry = JSON.parse(readFileSync(path.join(userRoot, "registry.json"), "utf8")) as { repos: Array<{ repoId: string; canonicalRoot: string; state: string }> };
+    assert.deepEqual(registry.repos.map((repo) => [repo.repoId, repo.canonicalRoot, repo.state]), [["canonical", realpathSync.native(rootDir), "enabled"]]);
+
+    const status = runDaemonCommand(rootDir, ["daemon", "status", "--user-root", userRoot, "--json"], { HARNESS_DAEMON_USER_ROOT: userRoot });
+    assert.equal(status.started, true);
+    assert.equal(status.repoId, "canonical");
+    assert.equal(status.rootDir, realpathSync.native(rootDir));
+  });
+});
+
+test("daemon client resolves an existing single-repo registry without requiring repo input", () => {
+  withTempRoot((rootDir) => {
+    const userRoot = path.join(rootDir, "user-daemon");
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    const registered = runDaemonCommand(rootDir, ["daemon", "repo", "register", "--repo-id", "canonical", "--user-root", userRoot, "--no-link", "--json"], {
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    assert.equal(registered.ok, true);
+
+    const created = runRawJson(rootDir, ["new-task", "--title", "Registered Single Repo"], {
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_USER_ROOT: userRoot,
+      HARNESS_DAEMON_IDLE_MS: "250"
+    });
+
+    assert.equal(created.ok, true);
+    assert.equal(existsSync(path.join(rootDir, "harness/tasks")), true);
+  });
+});
+
+test("daemon client fails unregistered cwd in multi-repo registry with register hint", () => {
+  withTempRoot((workspaceRoot) => {
+    const userRoot = path.join(workspaceRoot, "user-daemon");
+    const alphaRoot = path.join(workspaceRoot, "alpha");
+    const betaRoot = path.join(workspaceRoot, "beta");
+    const outsiderRoot = path.join(workspaceRoot, "outsider");
+    for (const rootDir of [alphaRoot, betaRoot, outsiderRoot]) {
+      mkdirSync(rootDir, { recursive: true });
+      runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    }
+    runDaemonCommand(alphaRoot, ["daemon", "repo", "register", "--repo-id", "alpha", "--root", alphaRoot, "--user-root", userRoot, "--no-link", "--json"], {
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    runDaemonCommand(betaRoot, ["daemon", "repo", "register", "--repo-id", "beta", "--root", betaRoot, "--user-root", userRoot, "--no-link", "--json"], {
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+
+    const failed = runRawJsonMaybeFail(outsiderRoot, ["task", "list"], {
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+
+    assert.notEqual(failed.status, 0);
+    assert.equal(failed.receipt.ok, false);
+    assert.match(((failed.receipt.error as Record<string, unknown>).hint as string), /ha daemon repo register --repo-id <id> --root/u);
+  });
+});
+
+test("daemon client --repo override targets a registered repo from a different cwd", () => {
+  withTempRoot((workspaceRoot) => {
+    const userRoot = path.join(workspaceRoot, "user-daemon");
+    const alphaRoot = path.join(workspaceRoot, "alpha");
+    const betaRoot = path.join(workspaceRoot, "beta");
+    for (const rootDir of [alphaRoot, betaRoot]) {
+      mkdirSync(rootDir, { recursive: true });
+      runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    }
+    runDaemonCommand(alphaRoot, ["daemon", "repo", "register", "--repo-id", "alpha", "--root", alphaRoot, "--user-root", userRoot, "--no-link", "--json"], {
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    runDaemonCommand(betaRoot, ["daemon", "repo", "register", "--repo-id", "beta", "--root", betaRoot, "--user-root", userRoot, "--no-link", "--json"], {
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+
+    const listed = runRawJson(betaRoot, ["--repo", "alpha", "task", "list"], {
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_USER_ROOT: userRoot,
+      HARNESS_DAEMON_IDLE_MS: "250"
+    });
+    assert.equal(listed.ok, true);
+
+    const status = runDaemonCommand(betaRoot, ["--repo", "alpha", "daemon", "status", "--user-root", userRoot, "--json"], {
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    assert.equal(status.repoId, "alpha");
+    assert.equal(status.rootDir, realpathSync.native(alphaRoot));
+    assert.deepEqual((status.repos as Array<{ repoId: string }>).map((repo) => repo.repoId), ["alpha", "beta"]);
+  });
+});
+
+test("daemon service reconciles registry register and unregister changes", async () => {
+  await withTempRootAsync(async (workspaceRoot) => {
+    const userRoot = path.join(workspaceRoot, "user-daemon");
+    const alphaRoot = path.join(workspaceRoot, "alpha");
+    const betaRoot = path.join(workspaceRoot, "beta");
+    for (const rootDir of [alphaRoot, betaRoot]) {
+      mkdirSync(rootDir, { recursive: true });
+      runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    }
+    runDaemonCommand(alphaRoot, ["daemon", "repo", "register", "--repo-id", "alpha", "--root", alphaRoot, "--user-root", userRoot, "--no-link", "--json"], {
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+
+    const listed = runRawJson(alphaRoot, ["task", "list"], {
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_USER_ROOT: userRoot,
+      HARNESS_DAEMON_IDLE_MS: "15000"
+    });
+    assert.equal(listed.ok, true);
+    assert.deepEqual(daemonStatusRepoIds(alphaRoot, userRoot, "alpha"), ["alpha"]);
+
+    runDaemonCommand(betaRoot, ["daemon", "repo", "register", "--repo-id", "beta", "--root", betaRoot, "--user-root", userRoot, "--no-link", "--json"], {
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    await waitForCondition(() => daemonStatusRepoIds(alphaRoot, userRoot, "alpha").includes("beta"));
+
+    runDaemonCommand(betaRoot, ["daemon", "repo", "unregister", "--repo-id", "beta", "--user-root", userRoot, "--no-link", "--json"], {
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    await waitForCondition(() => daemonStatusRepos(alphaRoot, userRoot, "alpha").find((repo) => repo.repoId === "beta")?.state === "detached");
   });
 });
 
@@ -261,7 +398,7 @@ async function withTempRootAsync<T>(fn: (rootDir: string) => Promise<T>): Promis
 function runRawJson(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Record<string, unknown> {
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: { ...process.env, ...env }
+    env: daemonTestEnv(rootDir, env)
   });
   return JSON.parse(stdout) as Record<string, unknown>;
 }
@@ -273,7 +410,7 @@ function runRawJsonMaybeFail(
 ): { readonly status: number | null; readonly receipt: Record<string, unknown> } {
   const result = spawnSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: { ...process.env, ...env }
+    env: daemonTestEnv(rootDir, env)
   });
   assert.equal(result.stderr, "");
   return {
@@ -285,17 +422,29 @@ function runRawJsonMaybeFail(
 async function runRawJsonAsync(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Promise<Record<string, unknown>> {
   const { stdout } = await execFileAsync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: { ...process.env, ...env }
+    env: daemonTestEnv(rootDir, env)
   });
   return JSON.parse(stdout) as Record<string, unknown>;
 }
 
-function runDaemonCommand(rootDir: string, args: ReadonlyArray<string>): Record<string, unknown> {
+function runDaemonCommand(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Record<string, unknown> {
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, ...args], {
     encoding: "utf8",
-    env: { ...process.env, HARNESS_DAEMON_MODE: "direct" }
+    env: daemonTestEnv(rootDir, { HARNESS_DAEMON_MODE: "direct", ...env })
   });
   return JSON.parse(stdout) as Record<string, unknown>;
+}
+
+function daemonTestEnv(rootDir: string, env: Readonly<Record<string, string>>): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    HARNESS_DAEMON_USER_ROOT: defaultDaemonUserRoot(rootDir),
+    ...env
+  };
+}
+
+function defaultDaemonUserRoot(rootDir: string): string {
+  return path.join(rootDir, ".daemon-user");
 }
 
 function normalizeVolatileReceipt(receipt: Record<string, unknown>): Record<string, unknown> {
@@ -309,6 +458,26 @@ function normalizeVolatileReceipt(receipt: Record<string, unknown>): Record<stri
 
 function sleep(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+async function waitForCondition(check: () => boolean, timeoutMs = 4_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.equal(check(), true);
+}
+
+function daemonStatusRepoIds(rootDir: string, userRoot: string, repoId: string): ReadonlyArray<string> {
+  return daemonStatusRepos(rootDir, userRoot, repoId).map((repo) => repo.repoId);
+}
+
+function daemonStatusRepos(rootDir: string, userRoot: string, repoId: string): ReadonlyArray<{ readonly repoId: string; readonly state?: string }> {
+  const status = runDaemonCommand(rootDir, ["--repo", repoId, "daemon", "status", "--user-root", userRoot, "--json"], {
+    HARNESS_DAEMON_USER_ROOT: userRoot
+  });
+  return Array.isArray(status.repos) ? status.repos as Array<{ repoId: string; state?: string }> : [];
 }
 
 function initGitRepo(rootDir: string): void {

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -297,7 +297,9 @@ test("daemon client --repo override targets a registered repo from a different c
     const listed = runRawJson(betaRoot, ["--repo", "alpha", "task", "list"], {
       HARNESS_DAEMON_MODE: "local",
       HARNESS_DAEMON_USER_ROOT: userRoot,
-      HARNESS_DAEMON_IDLE_MS: "250"
+      // Long idle keeps the daemon alive for the status probe below; a short
+      // idle races daemon exit now that reconcile no longer delays it.
+      HARNESS_DAEMON_IDLE_MS: "5000"
     });
     assert.equal(listed.ok, true);
 

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -1,4 +1,5 @@
 // @slice-activation PLT-Daemon W2 protocol core exported for W3 transport adapters.
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import type { CommandFailureReceipt, CommandReceipt, LocalControllerService } from "../../../application/src/index.ts";
 import type { RuntimeEventAppendInput } from "../../../application/src/runtime-event-ledger-service.ts";
@@ -274,11 +275,19 @@ function commandRootMismatch(payload: JsonObject | undefined, repo: DaemonRepoNa
   const command = isJsonObject(payload?.command) ? payload.command : undefined;
   const rootDir = typeof command?.rootDir === "string" ? command.rootDir : undefined;
   if (!rootDir) return undefined;
-  if (path.resolve(rootDir) === path.resolve(repo.canonicalRoot)) return undefined;
+  if (realpathOrResolve(rootDir) === realpathOrResolve(repo.canonicalRoot)) return undefined;
   return failureReceipt("repo.command.run", "repo_command_root_mismatch", "payload.command.rootDir does not match params.repo.repoId.", {
     repo: { repoId: repo.repoId, canonicalRoot: repo.canonicalRoot },
     command: { rootDir }
   });
+}
+
+function realpathOrResolve(rootDir: string): string {
+  try {
+    return realpathSync.native(rootDir);
+  } catch {
+    return path.resolve(rootDir);
+  }
 }
 
 function withEffectiveCommandClass(contract: JsonRpcMethodContract, params: JsonObject): JsonRpcMethodContract {

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -20,7 +20,8 @@ export * from "./schemas/docmap.ts";
 export * from "./schemas/task-schema-resolver.ts";
 export {
   readDaemonRegistry,
+  resolveDaemonRepoByRoot,
   registerDaemonRepo,
   unregisterDaemonRepo
 } from "./daemon/registry.ts";
-export type { DaemonRegistryRepo } from "./daemon/registry.ts";
+export type { DaemonRegistry, DaemonRegistryRepo } from "./daemon/registry.ts";

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -164,6 +164,7 @@ const publicRuntimeSurface = [
   "relationTypes",
   "requiredSchemaIds",
   "reservePublishIdempotencyKey",
+  "resolveDaemonRepoByRoot",
   "resolveEntityRoot",
   "resolveHarnessLayout",
   "resolveHarnessRuntimeContext",

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -251,77 +251,77 @@
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@255:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@275:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@256:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@276:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@254:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@277:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@253:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@274:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@304:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@338:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@311:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@345:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@324:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@358:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@357:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@391:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@360:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@394:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@369:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@403:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@305:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@339:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@326:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@360:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@362:5",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@396:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@364:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@398:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@378:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@412:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },


### PR DESCRIPTION
# English

## Summary

Productizes the W9-P4 daemon CLI client path on top of the merged P1/P2/P3 mainline.

## What Changed

- Added user-level daemon endpoint selection from the daemon user root and daemon id, while keeping legacy repo-root socket fallback for existing local daemons.
- Added registry-backed CLI target resolution: current root -> repo id, empty-registry single-repo auto-registration as `canonical`, multi-repo fail-closed guidance, and `--repo` / `HARNESS_DAEMON_REPO_ID` overrides.
- Wired daemon start/status/stop/bootstrap-server through the user registry, including canonical-root registration and runtime reconcile attach/detach behavior.
- Preserved the merged P3 `resolveRepoAvailability` protocol shape and added CLI-side availability formatting for unavailable/locked repos.
- Fixed the P5-discovered reconcile defect: unavailable repos are retried after external lock release by calling the kernel runtime's `retryUnavailableRepos()` at the end of reconcile.
- Re-anchored the daemon productization write-boundary allowlist after the rebase onto the gate-manifest mainline.

## Task And Scope

- Harness task: `task_01KWX37QN3W1WJW2EN4GGF4S08`
- Branch: `codex/w9-p4-cli-client`
- Public scope: CLI daemon client/productization/composition, daemon protocol availability adapter, kernel public export snapshot, and gate allowlist anchor refresh.
- Private planning/evidence updated: yes.
- Out of scope: GUI e2e, merge queue labeling, post-merge cleanup, P5 end-to-end verification package.

## Version Impact

- Version: no version change because this is a pre-release daemon behavior change.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: yes.
- Protected surface scope: `tools/gate-allowlists/check-bypass-write-boundary.json` anchor refresh only; CLI daemon client/composition behavior changed; no kernel runtime protected behavior change in this PR.
- Authority: task `task_01KWX37QN3W1WJW2EN4GGF4S08`, decision `dec_mra8fx5h`, and W9 multi-repo lifecycle design sections 1, 5, and 6.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no.
- Break-glass reason: not applicable.
- Break-glass scope: not applicable.
- Follow-up governance task: not applicable.

## Verification

- Base `origin/main` SHA: `a821ca02c2e590c6a042eb75f8968bba4cd9364a`
- Branch merge-base with `origin/main`: `a821ca02c2e590c6a042eb75f8968bba4cd9364a`
- Last `git fetch origin` time: `2026-07-07T11:49:38Z`
- Sync method: rebase.
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: task progress appended with PR evidence.
- Reviewer evidence path: not applicable.
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28864326420
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Additional commands run:
  - `npm run lint`
  - `npm run test:fast` (211/211)
  - `npm run test:contract` (301/301)
  - `node --test packages/cli/test/daemon-thin-client-cli.test.ts` (14/14)
  - `node --test packages/daemon/test/json-rpc-protocol.test.ts` (19/19)
  - `node --test packages/kernel/test/store/daemon-registry.test.ts` (6/6)
  - `npm run harness:check-bypass-write-boundary` (`current=119 previous=119 delta=0`)
  - `npm run harness:check-file-complexity`
  - `node --test --test-name-pattern="concurrent daemon client startup converges" packages/cli/test/daemon-thin-client-cli.test.ts` (3 runs, 1/1 each)
- Not run: `npm run check` because it includes `test:gui:e2e`, which this W9-P4 kickoff explicitly says not to run locally; GUI e2e is left to CI. `npm ci` was not run because dependencies were already installed in the existing workspace. `npm test` was not run because the requested local evidence was the fast/contract tiers plus targeted daemon/kernel suites.

## Review Evidence

- Self-review: conflict resolution checked against merged P3 shape; `resolveRepoAvailability` and `repoAvailabilityFailure` retained; daemon protocol package keeps pure availability formatting without daemon-side state interpretation.
- Reviewer subagent: not run.
- Human review: pending CEO review.
- Blocking findings: none known.

## Residual Risk

- GUI e2e was intentionally not run locally per kickoff.

## References

- Task: `task_01KWX37QN3W1WJW2EN4GGF4S08`
- Evidence: local verification commands listed above.
- Review: pending.

---

# 中文

## 概要

在已合并的 P1/P2/P3 mainline 上收口 W9-P4 daemon CLI client/productization。

## 改动内容

- 新增用户级 daemon endpoint：由 daemon user root 和 daemon id 派生，同时保留旧 repo-root socket 作为 legacy fallback。
- 新增 registry 驱动的 CLI 目标解析：当前 root 反查 repo id、空 registry 单仓自动注册为 `canonical`、多仓未注册 fail-closed 并提示 register、支持 `--repo` / `HARNESS_DAEMON_REPO_ID` 覆盖。
- 将 daemon start/status/stop/bootstrap-server 接到用户 registry，包括 canonical-root 注册和 runtime reconcile attach/detach。
- 保留已合并 P3 的 `resolveRepoAvailability` 协议形态，并在 CLI 侧格式化 unavailable/locked repo。
- 修复 P5 对抗验证发现的 reconcile 缺陷：外部 lock 释放后 unavailable 仓此前不会恢复；现在 reconcile 末尾调用 kernel runtime 已有的 `retryUnavailableRepos()`。
- rebase 后重锚 daemon productization 写边界 allowlist。

## 任务与范围

- Harness 任务：`task_01KWX37QN3W1WJW2EN4GGF4S08`
- 分支：`codex/w9-p4-cli-client`
- 公开范围：CLI daemon client/productization/composition、daemon protocol availability adapter、kernel public export snapshot、gate allowlist anchor refresh。
- 私有计划 / 证据是否已更新：yes。
- 范围外：GUI e2e、merge queue 标签、合并后清理、P5 端到端验证包。

## 版本影响

- 版本：不改版本，原因是本 PR 是 pre-release daemon 行为变更。
- 发布影响：不发布。

## 治理声明

- 是否触碰 protected surface：yes。
- protected surface 范围：仅重锚 `tools/gate-allowlists/check-bypass-write-boundary.json`；本 PR 改 CLI daemon client/composition 行为；无 kernel runtime protected behavior 变更。
- 依据：task `task_01KWX37QN3W1WJW2EN4GGF4S08`、decision `dec_mra8fx5h`、W9 multi-repo lifecycle design §1/§5/§6。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no。
- Break-glass 原因：不适用。
- Break-glass 范围：不适用。
- 后续治理任务：不适用。

## 验证

- `origin/main` 基准 SHA：`a821ca02c2e590c6a042eb75f8968bba4cd9364a`
- 当前分支与 `origin/main` 的 merge-base：`a821ca02c2e590c6a042eb75f8968bba4cd9364a`
- 最近一次 `git fetch origin` 时间：`2026-07-07T11:49:38Z`
- 同步方式：rebase。
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：已追加 task progress，证据指向本 PR。
- Reviewer 证据路径：不适用。
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28864326420
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 额外已运行：
  - `npm run lint`
  - `npm run test:fast` (211/211)
  - `npm run test:contract` (301/301)
  - `node --test packages/cli/test/daemon-thin-client-cli.test.ts` (14/14)
  - `node --test packages/daemon/test/json-rpc-protocol.test.ts` (19/19)
  - `node --test packages/kernel/test/store/daemon-registry.test.ts` (6/6)
  - `npm run harness:check-bypass-write-boundary` (`current=119 previous=119 delta=0`)
  - `npm run harness:check-file-complexity`
  - `node --test --test-name-pattern="concurrent daemon client startup converges" packages/cli/test/daemon-thin-client-cli.test.ts`（3 次，每次 1/1）
- 未运行：`npm run check`，因为它包含 `test:gui:e2e`，本次 W9-P4 kickoff 明确要求本机不跑 GUI e2e；GUI e2e 交给 CI。`npm ci` 未运行，因为当前 workspace 依赖已安装。`npm test` 未运行，因为本次要求的本地证据是 fast/contract tiers 加 daemon/kernel targeted suites。

## 审查证据

- 自查：按已合并 P3 形态检查冲突解决；保留 `resolveRepoAvailability` 与 `repoAvailabilityFailure`；daemon protocol 包仅做纯 availability formatting，不把状态判读回收到 daemon 包。
- Reviewer subagent：未运行。
- 人工审查：等待 CEO review。
- 阻塞发现：无已知。

## 残余风险

- GUI e2e 按 kickoff 要求未在本机运行。

## 关联材料

- 任务：`task_01KWX37QN3W1WJW2EN4GGF4S08`
- 证据：见上方本地验证命令。
- 审查：等待。

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
