### PR TITLE
fix(ci): skip gui-e2e on merge-queue draft branches

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -231,7 +231,14 @@ jobs:
         run: node tools/run-manifest-gates.mjs --workflow-job gui-build --exclude mergify-queue-metadata-edit-noop
 
   gui-e2e:
-    if: github.event_name == 'pull_request'
+    # Skip on Mergify merge-queue speculative draft branches. gui-e2e is a
+    # non-required, non-merge-condition check whose Electron smoke launch still
+    # hangs headless (PRE03-R1). On merge-queue drafts the changes path-filter
+    # mis-fires gui=true even for non-gui PRs, so gui-e2e would run, hang 15m,
+    # blow past Mergify's checks timeout, and dequeue the PR — self-heal then
+    # re-queues it, spawning a new draft each cycle (a runner-saturating death
+    # spiral that stalls the whole queue). Regular PR runs still exercise it.
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'mergify/merge-queue/')
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
# English

## Summary

The Mergify merge queue was in a death spiral that stalled every queued PR (#306, #307, #308). Root cause: `gui-e2e` — a non-required, non-merge-condition check whose Electron smoke launch hangs headless (PRE03-R1) — was being triggered on Mergify's speculative merge-queue draft branches even for non-gui PRs, because the `changes` path-filter mis-fires `gui=true` on those ephemeral branches. gui-e2e then hung ~15m, exceeded Mergify's ~12m checks timeout, and the PR was dequeued. The `self-heal dequeued pull requests` rule immediately re-queued it, spawning a fresh draft each cycle (#335→#337→#346→#347→#348…), saturating GitHub Actions runners so that even the real required checks (boundaries/typecheck) could not get a runner in time — stalling the whole queue.

This PR stops gui-e2e from running on merge-queue draft branches, breaking the spiral. gui-e2e still runs on regular PR pushes, so coverage is unchanged there.

## What Changed

- `.github/workflows/rewrite-ci.yml`: the `gui-e2e` job now additionally guards `&& !startsWith(github.head_ref, 'mergify/merge-queue/')`, so it is skipped on Mergify speculative draft branches. A comment documents why.

## Task And Scope

- Harness task: GUI-V1 merge-queue stabilization (relates PRE03-R1 residual `task_01KWYFD9H0M1CA8WCW397BBNT8`)
- Branch: `codex/fix-mergequeue-guie2e`
- Public scope: `.github/workflows/rewrite-ci.yml` (single job condition)
- Private planning/evidence updated: yes (decision `dec_mrarmvp3`)
- Out of scope: fixing the gui-e2e Electron launch hang itself (PRE03-R1), the `changes` path-filter base detection on merge-queue branches, Mergify self-heal thrash guard

## Version Impact

- Version: no version change because this is a CI workflow condition only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: CI workflow `.github/workflows/rewrite-ci.yml` (gui-e2e job run condition)
- Authority: decision `dec_mrarmvp3` (accepted)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: PRE03-R1 (`task_01KWYFD9H0M1CA8WCW397BBNT8`) — fix the Electron smoke launch hang so gui-e2e can be a reliable signal

## Verification

- Base `origin/main` SHA: 87f004b
- Branch merge-base with `origin/main`: 87f004b
- Last `git fetch origin` time: immediately before branch
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/fix-mergequeue-guie2e`
- Private evidence commit/path: decision `dec_mrarmvp3`
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] YAML validity confirmed (`python3 -c "import yaml; yaml.safe_load(...)"` → valid)
- Not run: `npm run check:local` (workflow-only change, no source/test touched; CI validates the workflow)

## Review Evidence

- Self-review: diagnosis ground-truthed against live Mergify draft PRs — #348 (a docs-only #308 draft) confirmed running gui-e2e despite zero gui file changes; dequeue reasons pulled from Mergify check-run output ("checks did not pass within checks timeout"), multiple thrash drafts enumerated (#335/#337/#346/#347/#348)
- Reviewer subagent: not used (single-line CI condition, diagnosis-driven)
- Human review: CEO (in-session), user reported the stall
- Blocking findings: none

## Residual Risk

- The `self-heal dequeued` + 12m checks-timeout combo remains inherently thrash-prone: any future check that hangs >12m on a draft while the 6 merge-conditions are green could re-trigger a spiral. Durable hardening (drop auto-requeue, or a batch/timeout guard) is deferred.
- The `changes` path-filter mis-firing `gui=true` on merge-queue branches is not fixed here — only its harmful consequence (gui-e2e hang) is neutralized. gui-build still runs needlessly on drafts but completes in ~20s and is harmless.
- gui-e2e itself still hangs (PRE03-R1) on regular PRs; it is non-blocking there.

## References

- Task: `task_01KWYFD9H0M1CA8WCW397BBNT8` (PRE03-R1)
- Evidence: decision `dec_mrarmvp3`; Mergify draft thrash #335/#337/#346/#347/#348
- Review: this PR

---

# 中文

## 概要

Mergify merge queue 陷入死亡螺旋,拖死了所有排队 PR(#306、#307、#308)。根因:`gui-e2e`——一个非必需、非 merge-condition 的 check,其 Electron 冒烟启动在无头下挂死(PRE03-R1)——在 Mergify 的投机 merge-queue 草稿分支上,即便是非 gui 的 PR 也被触发,因为 `changes` 路径过滤在这些临时分支上误判 `gui=true`。gui-e2e 随即挂约 15 分钟,撞上 Mergify 约 12 分钟的 checks 超时,PR 被踢出队列。`self-heal dequeued pull requests` 规则立刻把它重新入队,每轮生成一张新草稿(#335→#337→#346→#347→#348…),把 GitHub Actions runner 榨干,连真正的必需 check(boundaries/typecheck)都排不上 runner——整个队列卡死。

本 PR 让 gui-e2e 不在 merge-queue 草稿分支上运行,打断螺旋。常规 PR push 仍会跑 gui-e2e,覆盖不变。

## 改动内容

- `.github/workflows/rewrite-ci.yml`:`gui-e2e` job 增加守卫 `&& !startsWith(github.head_ref, 'mergify/merge-queue/')`,在 Mergify 投机草稿分支上跳过。注释记录了原因。

## 任务与范围

- Harness 任务:GUI-V1 merge-queue 稳定化(关联 PRE03-R1 残留 `task_01KWYFD9H0M1CA8WCW397BBNT8`)
- 分支:`codex/fix-mergequeue-guie2e`
- 公开范围:`.github/workflows/rewrite-ci.yml`(单个 job 条件)
- 私有计划 / 证据是否已更新:yes(决策 `dec_mrarmvp3`)
- 范围外:修 gui-e2e Electron 启动挂死本体(PRE03-R1)、修 `changes` 路径过滤在 merge-queue 分支的基准检测、Mergify self-heal thrash 守卫

## 版本影响

- 版本:不改版本,原因是仅 CI workflow 条件改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:CI workflow `.github/workflows/rewrite-ci.yml`(gui-e2e job 运行条件)
- 依据:决策 `dec_mrarmvp3`(accepted)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:PRE03-R1(`task_01KWYFD9H0M1CA8WCW397BBNT8`)——修 Electron 冒烟启动挂死,让 gui-e2e 成为可靠信号

## 验证

- `origin/main` 基准 SHA:87f004b
- 当前分支与 `origin/main` 的 merge-base:87f004b
- 最近一次 `git fetch origin` 时间:建分支前
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...codex/fix-mergequeue-guie2e`
- 私有证据 commit/path:决策 `dec_mrarmvp3`
- Reviewer 证据路径:见审查证据
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- [x] YAML 合法性已确认(`python3 -c "import yaml; yaml.safe_load(...)"` → valid)
- 未运行:`npm run check:local`(仅 workflow 改动,未碰源码 / 测试;由 CI 验证 workflow)

## 审查证据

- 自查:诊断对活的 Mergify 草稿 PR 做了 ground-truth——#348(一张 docs-only 的 #308 草稿)确认在零 gui 文件改动下仍跑 gui-e2e;dequeue 原因取自 Mergify check-run 输出("checks did not pass within checks timeout"),并枚举了多张 thrash 草稿(#335/#337/#346/#347/#348)
- Reviewer subagent:未使用(单行 CI 条件,诊断驱动)
- 人工审查:CEO(会话内),用户报告了卡死
- 阻塞发现:无

## 残余风险

- `self-heal dequeued` + 12 分钟 checks 超时的组合本质上仍易 thrash:未来任何在草稿上挂 >12 分钟、而 6 个 merge-condition 又全绿的 check,都可能再触发螺旋。持久加固(去掉自动重入队,或加 batch/超时守卫)暂缓。
- `changes` 路径过滤在 merge-queue 分支误判 `gui=true` 未在此修复——只中和了它的有害后果(gui-e2e 挂死)。gui-build 仍会在草稿上多余地跑,但约 20 秒完成、无害。
- gui-e2e 本体仍挂死(PRE03-R1),但在常规 PR 上非阻塞。

## 关联材料

- 任务:`task_01KWYFD9H0M1CA8WCW397BBNT8`(PRE03-R1)
- 证据:决策 `dec_mrarmvp3`;Mergify 草稿 thrash #335/#337/#346/#347/#348
- 审查:本 PR
