### PR TITLE
chore(mergify): switch queue merge_method from squash to merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,6 @@
 queue_rules:
   - name: default
-    merge_method: squash
+    merge_method: merge
     queue_conditions:
       - base = main
       - label = merge-queue


### PR DESCRIPTION
# English

## Summary
Switch the Mergify default queue from squash-merge to merge-commit. squash breaks `git branch --merged` / `git worktree prune` cleanup signals, so merged worker worktrees pile up (19 stacked on 2026-07-07, only 6 active). merge-commit keeps the branch tip in main history so cleanup is scriptable, and avoids the Mergify squash+rebase conflict-cache deadlock.

## What Changed
- `.mergify.yml`: `merge_method: squash` -> `merge_method: merge` (1 line)

## Task And Scope
- Harness task: none (process decision)
- Branch: codex/switch-to-merge-commit
- Public scope: .mergify.yml only
- Private planning/evidence updated: yes (decision dec_mras7lmq in harness ledger)
- Out of scope: GitHub repo `allow_merge_commit` setting (done via gh api, not in diff); inner ledger

## Version Impact
- Version: no version change (CI/governance config, not a shipped artifact)
- Publish impact: no publish

## Governance Declaration
- Protected surface touched: yes (.mergify.yml is merge-governance config)
- Protected surface scope: .mergify.yml queue_rules.default.merge_method
- Authority: decision dec_mras7lmq (accepted, arbiter human:ZeyuLi, 2026-07-07)
- Machine-check boundary: declaration only; reviewer verifies the decision id exists and authorizes this surface.
- Break-glass: no

## Verification
- Base origin/main SHA: 87f004b
- Branch merge-base with origin/main: 87f004b (1 commit ahead)
- Sync method: none needed (branched from current main)
- Public diff command: `git diff main..codex/switch-to-merge-commit -- .mergify.yml`
- [x] `git diff --check` (1-line config, no whitespace issues)
- Not run: npm ci / typecheck / test — this PR touches only .mergify.yml (zero code/asset surface); CI still runs on the PR.
- GitHub Actions rewrite-ci: pending (link once running)

## Review Evidence
- Self-review: 1-line config flip, verified `merge_method: merge` in worktree
- Reviewer subagent: none
- Human review: CEO ZeyuLi approved the decision directly (dec_mras7lmq arbiter)
- Blocking findings: none

## Residual Risk
- This PR merges itself via the OLD squash method (main is still squash at queue time); after it lands, main becomes merge. Self-consistent.
- 5 in-flight OPEN PRs (#345/#307/#308/#320/#306) will merge via merge-commit once this lands; their commit history is preserved.

## References
- Decision: dec_mras7lmq
- Worktree cleanup root cause: 2026-07-07 audit (19 worktrees; squash broke --merged signal)

---

# 中文

## 概要
将 Mergify 默认队列从 squash-merge 切到 merge-commit。squash 会破坏 `git branch --merged` / `git worktree prune` 的清理信号,导致已合并 worker worktree 堆积(2026-07-07 实测 19 个,仅 6 个活跃)。merge-commit 保留分支 tip 在 main 历史,清理可脚本化,且避开 Mergify squash+rebase 冲突缓存卡死。

## 改动内容
- `.mergify.yml`:`merge_method: squash` -> `merge_method: merge`(1 行)

## 任务与范围
- Harness 任务:无(process 决策)
- 分支:codex/switch-to-merge-commit
- 公开范围:仅 .mergify.yml
- 私有计划/证据已更新:yes(harness ledger 决策 dec_mras7lmq)
- 范围外:GitHub repo `allow_merge_commit` 设置(已用 gh api 改,不在 diff 内);内层 ledger

## 版本影响
- 版本:不改版本(CI/治理配置,非发布工件)
- 发布影响:不发布

## 治理声明
- 是否触碰 protected surface:yes(.mergify.yml 是合并治理配置)
- protected surface 范围:.mergify.yml queue_rules.default.merge_method
- 依据:决策 dec_mras7lmq(已 accepted,arbiter human:ZeyuLi,2026-07-07)
- 机器检查边界:本 PR 只声明依据存在;reviewer 核验决策 id 存在且授权该 surface。
- Break-glass:no

## 验证
- origin/main 基准 SHA:87f004b
- 与 origin/main 的 merge-base:87f004b(领先 1 commit)
- 同步方式:不需要(从当前 main 分出)
- 公开 diff 命令:`git diff main..codex/switch-to-merge-commit -- .mergify.yml`
- [x] `git diff --check`(1 行配置,无空白问题)
- 未运行:npm ci / typecheck / test——本 PR 只动 .mergify.yml(零代码/asset 面);CI 仍会在 PR 上跑。
- GitHub Actions rewrite-ci:待跑(跑后补链接)

## 审查证据
- 自查:1 行配置翻转,worktree 内已确认 `merge_method: merge`
- Reviewer subagent:无
- 人工审查:CEO 泽宇已直接拍板该决策(dec_mras7lmq arbiter)
- 阻塞发现:无

## 残余风险
- 本 PR 自身用「旧的 squash 方式」合并(main 在入队时仍是 squash);合并后 main 变 merge。自洽。
- 5 个在途 OPEN PR(#345/#307/#308/#320/#306)在本 PR 落地后将用 merge-commit 合并,其 commit 历史会被保留。

## 关联材料
- 决策:dec_mras7lmq
- worktree 清理根因:2026-07-07 排查(19 个 worktree;squash 破坏 --merged 信号)
