### PR TITLE
feat(gui): route GUI main through daemon, drop better-sqlite3 from Electron

### DIFF
--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -1,34 +1,35 @@
-import { createHash } from "node:crypto";
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import net from "node:net";
-import os from "node:os";
+import { spawn } from "node:child_process";
 import path from "node:path";
-import { createInterface } from "node:readline";
-import type { Readable, Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import {
-  readDaemonRegistry,
-  registerDaemonRepo,
-  resolveDaemonRepoByRoot,
-  type DaemonRegistry,
-  type DaemonRegistryRepo
-} from "../../../kernel/src/index.ts";
-import {
+  daemonIdFromEnv,
+  daemonUserRoot,
+  defaultDaemonAutostartTimeoutMs,
+  defaultDaemonIdleExitMs,
+  JsonRpcLineClient,
   currentDaemonProtocolVersion,
-  defaultUnixSocketPath,
-  encodeJsonLineFrame,
+  requestLocalDaemonJsonRpcForTarget,
+  resolveLocalDaemonTarget,
   type JsonObject,
-  type JsonRpcRequest,
-  type JsonRpcResponse
+  type LocalDaemonTarget
 } from "../../../daemon/src/index.ts";
 import { CliErrorCode, cliError } from "../cli/error-codes.ts";
 import type { CommandFailureReceipt, CommandReceipt } from "../cli/receipt.ts";
 import { toCommandReceipt } from "../cli/receipt.ts";
 import type { ParsedCommand } from "../cli/types.ts";
-import { isPlainRecord, parsePositiveIntegerOr } from "../cli/value-utils.ts";
+import { parsePositiveIntegerOr } from "../cli/value-utils.ts";
 
-const defaultAutostartTimeoutMs = 6_000;
-const defaultIdleExitMs = 750;
+export {
+  daemonIdForRoot,
+  daemonIdForUserRoot,
+  daemonIdFromEnv,
+  daemonUserRoot,
+  localDaemonSocketPath,
+  localUserDaemonSocketPath,
+  requestLocalDaemonJsonRpc,
+  resolveLocalDaemonTarget,
+  type LocalDaemonTarget
+} from "../../../daemon/src/index.ts";
 
 export type DaemonClientMode = "direct" | "local" | "remote";
 
@@ -48,23 +49,13 @@ export interface RemoteDaemonConfig {
   readonly repoId: string;
 }
 
-export interface LocalDaemonTarget {
-  readonly repoId: string;
-  readonly canonicalRoot: string;
-  readonly userRoot: string;
-  readonly daemonId: string;
-  readonly socketPath: string;
-  readonly legacySocketPath: string;
-  readonly registered: boolean;
-}
-
 export function readDaemonClientConfig(env: NodeJS.ProcessEnv = process.env): DaemonClientConfig {
   const mode = readMode(env.HARNESS_DAEMON_MODE);
   const userRoot = daemonUserRoot(env);
   return {
     mode,
-    idleExitMs: parsePositiveIntegerOr(env.HARNESS_DAEMON_IDLE_MS, defaultIdleExitMs),
-    autostartTimeoutMs: parsePositiveIntegerOr(env.HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS, defaultAutostartTimeoutMs),
+    idleExitMs: parsePositiveIntegerOr(env.HARNESS_DAEMON_IDLE_MS, defaultDaemonIdleExitMs),
+    autostartTimeoutMs: parsePositiveIntegerOr(env.HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS, defaultDaemonAutostartTimeoutMs),
     userRoot,
     daemonId: daemonIdFromEnv(env),
     ...(mode === "remote" ? { remote: readRemoteConfig(env) } : {})
@@ -85,126 +76,6 @@ export async function runCommandThroughDaemon(
   }
 }
 
-export function daemonIdForRoot(rootDir: string): string {
-  return `repo-${createHash("sha256").update(rootDir).digest("hex").slice(0, 16)}`;
-}
-
-export function daemonIdForUserRoot(userRoot: string, daemonId = "default"): string {
-  return `u-${createHash("sha256").update(`${path.resolve(userRoot)}\0${daemonId}`).digest("hex").slice(0, 16)}`;
-}
-
-export function localDaemonSocketPath(rootDir: string): string {
-  return defaultUnixSocketPath(daemonIdForRoot(rootDir));
-}
-
-export function localUserDaemonSocketPath(userRoot = daemonUserRoot(), daemonId = daemonIdFromEnv()): string {
-  return defaultUnixSocketPath(daemonIdForUserRoot(userRoot, daemonId));
-}
-
-export function daemonUserRoot(env: NodeJS.ProcessEnv = process.env): string {
-  return path.resolve(readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_USER_ROOT") ?? path.join(os.homedir(), ".harness"));
-}
-
-export function daemonIdFromEnv(env: NodeJS.ProcessEnv = process.env): string {
-  return readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_ID") ?? "default";
-}
-
-export function resolveLocalDaemonTarget(input: {
-  readonly rootDir: string;
-  readonly repoIdOverride?: string;
-  readonly userRoot?: string;
-  readonly daemonId?: string;
-  readonly autoRegisterSingleRepo?: boolean;
-  readonly env?: NodeJS.ProcessEnv;
-}): LocalDaemonTarget {
-  const env = input.env ?? process.env;
-  const userRoot = path.resolve(input.userRoot ?? daemonUserRoot(env));
-  const daemonId = input.daemonId ?? daemonIdFromEnv(env);
-  const repoIdOverride = input.repoIdOverride ?? readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_REPO_ID");
-  const registry = readDaemonRegistry({ userRoot });
-  const legacySocketPath = localDaemonSocketPath(input.rootDir);
-  const socketPath = localUserDaemonSocketPath(userRoot, daemonId);
-
-  if (repoIdOverride) {
-    const registered = registry.repos.find((repo) => repo.repoId === repoIdOverride && repo.state === "enabled");
-    return daemonTarget({
-      repoId: repoIdOverride,
-      canonicalRoot: registered?.canonicalRoot ?? path.resolve(input.rootDir),
-      userRoot,
-      daemonId,
-      socketPath,
-      legacySocketPath,
-      registered: Boolean(registered)
-    });
-  }
-
-  const matchingRepo = resolveRegistryRepoByRoot(input.rootDir, registry, userRoot);
-  if (matchingRepo?.state === "enabled") {
-    return daemonTarget({
-      repoId: matchingRepo.repoId,
-      canonicalRoot: matchingRepo.canonicalRoot,
-      userRoot,
-      daemonId,
-      socketPath,
-      legacySocketPath,
-      registered: true
-    });
-  }
-
-  const enabledRepos = registry.repos.filter((repo) => repo.state === "enabled");
-  if (enabledRepos.length === 0) {
-    if (input.autoRegisterSingleRepo) {
-      const registered = tryRegisterCanonicalRepo(input.rootDir, userRoot);
-      if (registered) {
-        return daemonTarget({
-          repoId: registered.repoId,
-          canonicalRoot: registered.canonicalRoot,
-          userRoot,
-          daemonId,
-          socketPath,
-          legacySocketPath,
-          registered: true
-        });
-      }
-    }
-    return daemonTarget({
-      repoId: "canonical",
-      canonicalRoot: path.resolve(input.rootDir),
-      userRoot,
-      daemonId,
-      socketPath,
-      legacySocketPath,
-      registered: false
-    });
-  }
-
-  throw new Error(`current root is not registered with the user daemon registry. Run: ha daemon repo register --repo-id <id> --root ${JSON.stringify(path.resolve(input.rootDir))}`);
-}
-
-export async function requestLocalDaemonJsonRpc(
-  rootDir: string,
-  method: string,
-  params: JsonObject,
-  timeoutMs = 1_000,
-  options: {
-    readonly userRoot?: string;
-    readonly daemonId?: string;
-    readonly socketPath?: string;
-    readonly allowLegacySocket?: boolean;
-  } = {}
-): Promise<JsonObject> {
-  const userRoot = path.resolve(options.userRoot ?? daemonUserRoot());
-  const socketPath = options.socketPath ?? localUserDaemonSocketPath(userRoot, options.daemonId ?? daemonIdFromEnv());
-  const socket = await connectUnixSocketWithLegacyFallback(socketPath, options.allowLegacySocket === false ? undefined : localDaemonSocketPath(rootDir), timeoutMs);
-  const client = new JsonRpcLineClient(socket, socket);
-  try {
-    await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion });
-    return await client.request(method, params);
-  } finally {
-    client.close();
-  }
-}
-
 async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfig): Promise<CommandReceipt | CommandFailureReceipt> {
   const target = resolveLocalDaemonTarget({
     rootDir: command.rootDir,
@@ -213,24 +84,17 @@ async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfi
     daemonId: config.daemonId,
     autoRegisterSingleRepo: true
   });
-  const endpoint = target.socketPath;
-  const deadline = Date.now() + config.autostartTimeoutMs;
-  let nextSpawnAt = 0;
-  let lastError: unknown;
-  while (Date.now() <= deadline) {
-    try {
-      const socket = await connectUnixSocket(endpoint, 200);
-      return await runWithLineClient(new JsonRpcLineClient(socket, socket), commandForTarget(command, target), target.repoId);
-    } catch (error) {
-      lastError = error;
-      if (Date.now() >= nextSpawnAt) {
-        spawnLocalDaemon(commandForTarget(command, target), target, config.idleExitMs);
-        nextSpawnAt = Date.now() + 500;
-      }
-      await delay(100);
-    }
-  }
-  throw lastError ?? new Error("local daemon did not become reachable");
+  const response = await requestLocalDaemonJsonRpcForTarget(target, "repo.command.run", {
+    repo: { repoId: target.repoId },
+    payload: { command: commandForTarget(command, target) as unknown as JsonObject }
+  }, 200, {
+    entryPath: cliEntrypointPath(),
+    idleExitMs: config.idleExitMs,
+    timeoutMs: config.autostartTimeoutMs,
+    layoutOverrides: command.layoutOverrides
+  });
+  if (isCommandReceipt(response)) return response as unknown as CommandReceipt | CommandFailureReceipt;
+  throw new Error("daemon command.run did not return command-receipt/v2");
 }
 
 async function runRemoteCommand(command: ParsedCommand, remote: RemoteDaemonConfig): Promise<CommandReceipt | CommandFailureReceipt> {
@@ -272,101 +136,6 @@ async function runWithLineClient(
   }
 }
 
-function spawnLocalDaemon(command: ParsedCommand, target: LocalDaemonTarget, idleExitMs: number): void {
-  const child = spawn(process.execPath, [
-    ...process.execArgv,
-    fileURLToPath(import.meta.url).replace(/\/daemon\/client\.(ts|js)$/u, "/index.$1"),
-    "--root",
-    target.canonicalRoot,
-    ...(command.layoutOverrides?.authoredRoot ? ["--authored-root", command.layoutOverrides.authoredRoot] : []),
-    "daemon",
-    "serve",
-    "--repo",
-    target.repoId,
-    "--socket",
-    target.socketPath,
-    "--idle-ms",
-    String(idleExitMs)
-  ], {
-    detached: true,
-    stdio: "ignore",
-    env: {
-      ...process.env,
-      HARNESS_DAEMON_MODE: "direct",
-      HARNESS_DAEMON_USER_ROOT: target.userRoot,
-      HARNESS_DAEMON_ID: target.daemonId
-    }
-  });
-  child.unref();
-}
-
-function connectUnixSocket(socketPath: string, timeoutMs: number): Promise<net.Socket> {
-  return new Promise((resolve, reject) => {
-    const socket = net.createConnection(socketPath);
-    const timer = setTimeout(() => {
-      socket.destroy();
-      reject(new Error(`timed out connecting to daemon socket: ${socketPath}`));
-    }, timeoutMs);
-    socket.once("connect", () => {
-      clearTimeout(timer);
-      resolve(socket);
-    });
-    socket.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-  });
-}
-
-async function connectUnixSocketWithLegacyFallback(socketPath: string, legacySocketPath: string | undefined, timeoutMs: number): Promise<net.Socket> {
-  try {
-    return await connectUnixSocket(socketPath, timeoutMs);
-  } catch (error) {
-    if (!legacySocketPath || legacySocketPath === socketPath) throw error;
-    return connectUnixSocket(legacySocketPath, timeoutMs);
-  }
-}
-
-class JsonRpcLineClient {
-  private nextId = 1;
-  private readonly input: Readable;
-  private readonly output: Writable;
-  private readonly owner?: ChildProcessWithoutNullStreams;
-
-  constructor(input: Readable, output: Writable, owner?: ChildProcessWithoutNullStreams) {
-    this.input = input;
-    this.output = output;
-    this.owner = owner;
-  }
-
-  async request(method: string, params: JsonObject): Promise<JsonObject> {
-    const id = this.nextId++;
-    const responsePromise = this.readResponse(id);
-    const request = { jsonrpc: "2.0", id, method, params } satisfies JsonRpcRequest;
-    this.output.write(encodeJsonLineFrame(request));
-    const response = await responsePromise;
-    if ("error" in response) throw new Error(response.error.message);
-    if (!isPlainRecord(response.result)) throw new Error(`daemon returned non-object result for ${method}`);
-    return response.result as JsonObject;
-  }
-
-  close(): void {
-    this.output.end();
-    this.owner?.kill("SIGTERM");
-  }
-
-  private async readResponse(id: number): Promise<JsonRpcResponse> {
-    const lines = createInterface({ input: this.input });
-    const iterator = lines[Symbol.asyncIterator]();
-    while (true) {
-      const next = await iterator.next();
-      if (next.done) throw new Error(`daemon closed before JSON-RPC response ${id}`);
-      const response = JSON.parse(next.value) as JsonRpcResponse;
-      if (response.id === id) return response;
-    }
-  }
-}
-
 function daemonUnavailableReceipt(command: ParsedCommand, error: unknown): CommandFailureReceipt {
   const receipt = toCommandReceipt({
     ok: false,
@@ -385,40 +154,14 @@ function readMode(value: string | undefined): DaemonClientMode {
   return "direct";
 }
 
-function readNonEmptyDaemonEnv(env: NodeJS.ProcessEnv, name: string): string | undefined {
-  const value = env[name];
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function resolveRegistryRepoByRoot(rootDir: string, registry: DaemonRegistry, userRoot: string): DaemonRegistryRepo | undefined {
-  try {
-    return resolveDaemonRepoByRoot(rootDir, { userRoot });
-  } catch {
-    const resolvedRoot = path.resolve(rootDir);
-    return registry.repos.find((repo) => path.resolve(repo.canonicalRoot) === resolvedRoot);
-  }
-}
-
-function tryRegisterCanonicalRepo(rootDir: string, userRoot: string): DaemonRegistryRepo | undefined {
-  try {
-    return registerDaemonRepo({
-      userRoot,
-      canonicalRoot: rootDir,
-      repoId: "canonical"
-    }).repo;
-  } catch {
-    return undefined;
-  }
-}
-
 function commandForTarget(command: ParsedCommand, target: LocalDaemonTarget): ParsedCommand {
   return path.resolve(command.rootDir) === path.resolve(target.canonicalRoot)
     ? command
     : { ...command, rootDir: target.canonicalRoot };
 }
 
-function daemonTarget(input: LocalDaemonTarget): LocalDaemonTarget {
-  return input;
+function cliEntrypointPath(): string {
+  return fileURLToPath(import.meta.url).replace(/\/daemon\/client\.(ts|js)$/u, "/index.$1");
 }
 
 function readRemoteConfig(env: NodeJS.ProcessEnv): RemoteDaemonConfig {
@@ -438,8 +181,4 @@ function requiredEnv(env: NodeJS.ProcessEnv, name: string): string {
 
 function isCommandReceipt(value: JsonObject): boolean {
   return value.schema === "command-receipt/v2" && typeof value.ok === "boolean" && typeof value.command === "string";
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -1,0 +1,363 @@
+import { createHash } from "node:crypto";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import type { Readable, Writable } from "node:stream";
+// eslint-disable-next-line no-restricted-imports -- The daemon client must not import the kernel barrel because GUI dynamically loads this module and the barrel exports sqlite projection code.
+import {
+  readDaemonRegistry,
+  registerDaemonRepo,
+  resolveDaemonRepoByRoot,
+  type DaemonRegistry,
+  type DaemonRegistryRepo
+} from "../../../kernel/src/daemon/registry.ts";
+import { currentDaemonProtocolVersion } from "../protocol/method-registry.ts";
+import { type JsonObject, type JsonRpcRequest, type JsonRpcResponse } from "../protocol/json-rpc-types.ts";
+import { encodeJsonLineFrame } from "../transport/frame-codec.ts";
+import { defaultUnixSocketPath } from "../transport/unix-socket.ts";
+
+export const defaultDaemonAutostartTimeoutMs = 6_000;
+export const defaultDaemonIdleExitMs = 750;
+
+export interface LocalDaemonTarget {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+  readonly userRoot: string;
+  readonly daemonId: string;
+  readonly socketPath: string;
+  readonly legacySocketPath: string;
+  readonly registered: boolean;
+}
+
+interface HarnessLayoutOverrides {
+  readonly authoredRoot?: string;
+}
+
+export interface LocalDaemonAutostartOptions {
+  readonly entryPath: string;
+  readonly idleExitMs?: number;
+  readonly timeoutMs?: number;
+  readonly layoutOverrides?: HarnessLayoutOverrides;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly execPath?: string;
+  readonly execArgv?: ReadonlyArray<string>;
+}
+
+export interface LocalDaemonJsonRpcOptions {
+  readonly userRoot?: string;
+  readonly daemonId?: string;
+  readonly socketPath?: string;
+  readonly repoIdOverride?: string;
+  readonly autoRegisterSingleRepo?: boolean;
+  readonly allowLegacySocket?: boolean;
+  readonly autostart?: LocalDaemonAutostartOptions;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+export function daemonIdForRoot(rootDir: string): string {
+  return `repo-${createHash("sha256").update(rootDir).digest("hex").slice(0, 16)}`;
+}
+
+export function daemonIdForUserRoot(userRoot: string, daemonId = "default"): string {
+  return `u-${createHash("sha256").update(`${path.resolve(userRoot)}\0${daemonId}`).digest("hex").slice(0, 16)}`;
+}
+
+export function localDaemonSocketPath(rootDir: string): string {
+  return defaultUnixSocketPath(daemonIdForRoot(rootDir));
+}
+
+export function localUserDaemonSocketPath(userRoot = daemonUserRoot(), daemonId = daemonIdFromEnv()): string {
+  return defaultUnixSocketPath(daemonIdForUserRoot(userRoot, daemonId));
+}
+
+export function daemonUserRoot(env: NodeJS.ProcessEnv = process.env): string {
+  return path.resolve(readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_USER_ROOT") ?? path.join(os.homedir(), ".harness"));
+}
+
+export function daemonIdFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  return readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_ID") ?? "default";
+}
+
+export function resolveLocalDaemonTarget(input: {
+  readonly rootDir: string;
+  readonly repoIdOverride?: string;
+  readonly userRoot?: string;
+  readonly daemonId?: string;
+  readonly autoRegisterSingleRepo?: boolean;
+  readonly env?: NodeJS.ProcessEnv;
+}): LocalDaemonTarget {
+  const env = input.env ?? process.env;
+  const userRoot = path.resolve(input.userRoot ?? daemonUserRoot(env));
+  const daemonId = input.daemonId ?? daemonIdFromEnv(env);
+  const repoIdOverride = input.repoIdOverride ?? readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_REPO_ID");
+  const registry = readDaemonRegistry({ userRoot });
+  const legacySocketPath = localDaemonSocketPath(input.rootDir);
+  const socketPath = localUserDaemonSocketPath(userRoot, daemonId);
+
+  if (repoIdOverride) {
+    const registered = registry.repos.find((repo) => repo.repoId === repoIdOverride && repo.state === "enabled");
+    return daemonTarget({
+      repoId: repoIdOverride,
+      canonicalRoot: registered?.canonicalRoot ?? path.resolve(input.rootDir),
+      userRoot,
+      daemonId,
+      socketPath,
+      legacySocketPath,
+      registered: Boolean(registered)
+    });
+  }
+
+  const matchingRepo = resolveRegistryRepoByRoot(input.rootDir, registry, userRoot);
+  if (matchingRepo?.state === "enabled") {
+    return daemonTarget({
+      repoId: matchingRepo.repoId,
+      canonicalRoot: matchingRepo.canonicalRoot,
+      userRoot,
+      daemonId,
+      socketPath,
+      legacySocketPath,
+      registered: true
+    });
+  }
+
+  const enabledRepos = registry.repos.filter((repo) => repo.state === "enabled");
+  if (enabledRepos.length === 0) {
+    if (input.autoRegisterSingleRepo) {
+      const registered = tryRegisterCanonicalRepo(input.rootDir, userRoot);
+      if (registered) {
+        return daemonTarget({
+          repoId: registered.repoId,
+          canonicalRoot: registered.canonicalRoot,
+          userRoot,
+          daemonId,
+          socketPath,
+          legacySocketPath,
+          registered: true
+        });
+      }
+    }
+    return daemonTarget({
+      repoId: "canonical",
+      canonicalRoot: path.resolve(input.rootDir),
+      userRoot,
+      daemonId,
+      socketPath,
+      legacySocketPath,
+      registered: false
+    });
+  }
+
+  throw new Error(`current root is not registered with the user daemon registry. Run: ha daemon repo register --repo-id <id> --root ${JSON.stringify(path.resolve(input.rootDir))}`);
+}
+
+export async function requestLocalDaemonJsonRpc(
+  rootDir: string,
+  method: string,
+  params: JsonObject,
+  timeoutMs = 1_000,
+  options: LocalDaemonJsonRpcOptions = {}
+): Promise<JsonObject> {
+  if (options.autostart) {
+    const target = resolveLocalDaemonTarget({
+      rootDir,
+      repoIdOverride: options.repoIdOverride,
+      userRoot: options.userRoot,
+      daemonId: options.daemonId,
+      autoRegisterSingleRepo: options.autoRegisterSingleRepo ?? true,
+      env: options.env
+    });
+    return requestLocalDaemonJsonRpcWithAutostart(target, method, params, timeoutMs, options.autostart);
+  }
+
+  const userRoot = path.resolve(options.userRoot ?? daemonUserRoot(options.env));
+  const socketPath = options.socketPath ?? localUserDaemonSocketPath(userRoot, options.daemonId ?? daemonIdFromEnv(options.env));
+  const socket = await connectUnixSocketWithLegacyFallback(socketPath, options.allowLegacySocket === false ? undefined : localDaemonSocketPath(rootDir), timeoutMs);
+  return requestWithSocket(socket, method, params);
+}
+
+export async function requestLocalDaemonJsonRpcForTarget(
+  target: LocalDaemonTarget,
+  method: string,
+  params: JsonObject,
+  timeoutMs = 1_000,
+  autostart?: LocalDaemonAutostartOptions
+): Promise<JsonObject> {
+  if (!autostart) {
+    const socket = await connectUnixSocketWithLegacyFallback(target.socketPath, target.legacySocketPath, timeoutMs);
+    return requestWithSocket(socket, method, params);
+  }
+  return requestLocalDaemonJsonRpcWithAutostart(target, method, params, timeoutMs, autostart);
+}
+
+export function spawnLocalDaemon(target: LocalDaemonTarget, options: LocalDaemonAutostartOptions): void {
+  const child = spawn(options.execPath ?? process.execPath, [
+    ...(options.execArgv ?? process.execArgv),
+    options.entryPath,
+    "--root",
+    target.canonicalRoot,
+    ...(options.layoutOverrides?.authoredRoot ? ["--authored-root", options.layoutOverrides.authoredRoot] : []),
+    "daemon",
+    "serve",
+    "--repo",
+    target.repoId,
+    "--socket",
+    target.socketPath,
+    "--user-root",
+    target.userRoot,
+    "--idle-ms",
+    String(options.idleExitMs ?? defaultDaemonIdleExitMs)
+  ], {
+    detached: true,
+    stdio: "ignore",
+    env: {
+      ...(options.env ?? process.env),
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DAEMON_USER_ROOT: target.userRoot,
+      HARNESS_DAEMON_ID: target.daemonId
+    }
+  });
+  child.unref();
+}
+
+export class JsonRpcLineClient {
+  private nextId = 1;
+  private readonly input: Readable;
+  private readonly output: Writable;
+  private readonly owner?: ChildProcessWithoutNullStreams;
+
+  constructor(input: Readable, output: Writable, owner?: ChildProcessWithoutNullStreams) {
+    this.input = input;
+    this.output = output;
+    this.owner = owner;
+  }
+
+  async request(method: string, params: JsonObject): Promise<JsonObject> {
+    const id = this.nextId++;
+    const responsePromise = this.readResponse(id);
+    const request = { jsonrpc: "2.0", id, method, params } satisfies JsonRpcRequest;
+    this.output.write(encodeJsonLineFrame(request));
+    const response = await responsePromise;
+    if ("error" in response) throw new Error(response.error.message);
+    if (!isPlainRecord(response.result)) throw new Error(`daemon returned non-object result for ${method}`);
+    return response.result as JsonObject;
+  }
+
+  close(): void {
+    this.output.end();
+    this.owner?.kill("SIGTERM");
+  }
+
+  private async readResponse(id: number): Promise<JsonRpcResponse> {
+    const lines = createInterface({ input: this.input });
+    const iterator = lines[Symbol.asyncIterator]();
+    while (true) {
+      const next = await iterator.next();
+      if (next.done) throw new Error(`daemon closed before JSON-RPC response ${id}`);
+      const response = JSON.parse(next.value) as JsonRpcResponse;
+      if (response.id === id) return response;
+    }
+  }
+}
+
+async function requestLocalDaemonJsonRpcWithAutostart(
+  target: LocalDaemonTarget,
+  method: string,
+  params: JsonObject,
+  connectTimeoutMs: number,
+  autostart: LocalDaemonAutostartOptions
+): Promise<JsonObject> {
+  const deadline = Date.now() + (autostart.timeoutMs ?? defaultDaemonAutostartTimeoutMs);
+  let nextSpawnAt = 0;
+  let lastError: unknown;
+  while (Date.now() <= deadline) {
+    try {
+      const socket = await connectUnixSocket(target.socketPath, connectTimeoutMs);
+      return await requestWithSocket(socket, method, params);
+    } catch (error) {
+      lastError = error;
+      if (Date.now() >= nextSpawnAt) {
+        spawnLocalDaemon(target, autostart);
+        nextSpawnAt = Date.now() + 500;
+      }
+      await delay(100);
+    }
+  }
+  throw lastError ?? new Error("local daemon did not become reachable");
+}
+
+async function requestWithSocket(socket: net.Socket, method: string, params: JsonObject): Promise<JsonObject> {
+  const client = new JsonRpcLineClient(socket, socket);
+  try {
+    await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion });
+    return await client.request(method, params);
+  } finally {
+    client.close();
+  }
+}
+
+function connectUnixSocket(socketPath: string, timeoutMs: number): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`timed out connecting to daemon socket: ${socketPath}`));
+    }, timeoutMs);
+    socket.once("connect", () => {
+      clearTimeout(timer);
+      resolve(socket);
+    });
+    socket.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+async function connectUnixSocketWithLegacyFallback(socketPath: string, legacySocketPath: string | undefined, timeoutMs: number): Promise<net.Socket> {
+  try {
+    return await connectUnixSocket(socketPath, timeoutMs);
+  } catch (error) {
+    if (!legacySocketPath || legacySocketPath === socketPath) throw error;
+    return connectUnixSocket(legacySocketPath, timeoutMs);
+  }
+}
+
+function readNonEmptyDaemonEnv(env: NodeJS.ProcessEnv | undefined, name: string): string | undefined {
+  const value = env?.[name];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function resolveRegistryRepoByRoot(rootDir: string, registry: DaemonRegistry, userRoot: string): DaemonRegistryRepo | undefined {
+  try {
+    return resolveDaemonRepoByRoot(rootDir, { userRoot });
+  } catch {
+    const resolvedRoot = path.resolve(rootDir);
+    return registry.repos.find((repo) => path.resolve(repo.canonicalRoot) === resolvedRoot);
+  }
+}
+
+function tryRegisterCanonicalRepo(rootDir: string, userRoot: string): DaemonRegistryRepo | undefined {
+  try {
+    return registerDaemonRepo({
+      userRoot,
+      canonicalRoot: rootDir,
+      repoId: "canonical"
+    }).repo;
+  } catch {
+    return undefined;
+  }
+}
+
+function daemonTarget(input: LocalDaemonTarget): LocalDaemonTarget {
+  return input;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,4 +1,22 @@
 export {
+  daemonIdForRoot,
+  daemonIdForUserRoot,
+  daemonIdFromEnv,
+  daemonUserRoot,
+  defaultDaemonAutostartTimeoutMs,
+  defaultDaemonIdleExitMs,
+  JsonRpcLineClient,
+  localDaemonSocketPath,
+  localUserDaemonSocketPath,
+  requestLocalDaemonJsonRpc,
+  requestLocalDaemonJsonRpcForTarget,
+  resolveLocalDaemonTarget,
+  spawnLocalDaemon,
+  type LocalDaemonAutostartOptions,
+  type LocalDaemonJsonRpcOptions,
+  type LocalDaemonTarget
+} from "./client/local-json-rpc-client.ts";
+export {
   actorGitCommitAuthor,
   actorStamp,
   actorStampJson,

--- a/packages/gui/src/api/service-bridge.ts
+++ b/packages/gui/src/api/service-bridge.ts
@@ -148,8 +148,78 @@ async function invokeDaemonGuiRoute(
       }
     };
   }
-  const receipt = await request(route, payload);
+  const validation = validateGuiRoutePayload(route, payload);
+  if (!validation.ok) return validation.failure;
+  const receipt = await request(route, validation.payload);
   return unwrapDaemonReceipt(receipt);
+}
+
+type PayloadValidation = { readonly ok: true; readonly payload: unknown } | { readonly ok: false; readonly failure: JsonObject };
+const domainStatuses = new Set(["planned", "active", "blocked", "in_review", "done", "cancelled"]);
+
+export function validateGuiRoutePayload(route: ApiRouteContract, payload: unknown): PayloadValidation {
+  switch (route.inputSchemaId) {
+    case "gui.empty/v1":
+      return payload === undefined || payload === null || isRecord(payload)
+        ? { ok: true, payload }
+        : invalidPayload("empty payload is required.");
+    case "application.task-id-payload/v1":
+      return validateTaskIdPayload(payload);
+    case "application.task-document-payload/v1":
+      return validateTaskDocumentPayload(payload);
+    case "application.set-task-status-payload/v1":
+      return validateSetStatusPayload(payload);
+    case "application.append-task-progress-payload/v1":
+      return validateAppendProgressPayload(payload);
+    default:
+      return { ok: true, payload };
+  }
+}
+
+function validateTaskIdPayload(payload: unknown): PayloadValidation {
+  if (!isRecord(payload) || typeof payload.taskId !== "string") return invalidPayload("taskId is required.");
+  if (!isValidTaskId(payload.taskId)) return invalidPayload("taskId is invalid.");
+  return { ok: true, payload };
+}
+
+function validateTaskDocumentPayload(payload: unknown): PayloadValidation {
+  const taskPayload = validateTaskIdPayload(payload);
+  if (!taskPayload.ok) return taskPayload;
+  if (!isRecord(payload) || typeof payload.path !== "string") return invalidPayload("path is required.");
+  return { ok: true, payload };
+}
+
+function validateSetStatusPayload(payload: unknown): PayloadValidation {
+  const taskPayload = validateTaskIdPayload(payload);
+  if (!taskPayload.ok) return taskPayload;
+  if (!isRecord(payload) || typeof payload.status !== "string" || !domainStatuses.has(payload.status)) {
+    return invalidPayload("valid status is required.");
+  }
+  return { ok: true, payload };
+}
+
+function validateAppendProgressPayload(payload: unknown): PayloadValidation {
+  const taskPayload = validateTaskIdPayload(payload);
+  if (!taskPayload.ok) return taskPayload;
+  if (!isRecord(payload) || typeof payload.text !== "string" || payload.text.length === 0) return invalidPayload("text is required.");
+  return { ok: true, payload };
+}
+
+function invalidPayload(hint: string): PayloadValidation {
+  return {
+    ok: false,
+    failure: {
+      ok: false,
+      error: {
+        code: "invalid_payload",
+        hint
+      }
+    }
+  };
+}
+
+function isValidTaskId(taskId: string): boolean {
+  return taskId.length > 0 && !taskId.includes("/") && !taskId.includes("..");
 }
 
 function unwrapDaemonReceipt(receipt: JsonObject): unknown {

--- a/packages/gui/src/api/service-bridge.ts
+++ b/packages/gui/src/api/service-bridge.ts
@@ -1,33 +1,43 @@
-import path from "node:path";
-import type { LocalControllerService } from "../../../application/src/index.ts";
-import {
-  readAppendProgressPayload,
-  readSetStatusPayload,
-  readTaskDocumentPayload,
-  readTaskIdPayload
-} from "../../../application/src/index.ts";
-import type { HarnessLayoutInput, HarnessLayoutOverrides } from "../../../kernel/src/index.ts";
-import { createHarnessRuntimeContext, normalizeRelativeDocumentPath, resolveHarnessRuntimeContext, taskDocumentPath } from "../../../kernel/src/index.ts";
 import type { PreloadApiMethod } from "../preload/allowlist.ts";
-import { apiRouteContracts, deferredGuiBridgeContracts } from "./api-contract-registry.ts";
-import { validateProjectPath } from "./local-api.ts";
+import { apiRouteContracts, deferredGuiBridgeContracts, type ApiRouteContract } from "./api-contract-registry.ts";
 
+// Contract anchor: document path normalization remains owned by the daemon-side
+// LocalControllerService via kernel normalizeRelativeDocumentPath. GUI main must
+// not import that kernel barrel because it would reintroduce the sqlite ABI path.
 export interface GuiServiceBridge {
   readonly invoke: (method: string, payload: unknown) => Promise<unknown>;
 }
 
+type JsonObject = { readonly [key: string]: JsonValue };
+type JsonValue = string | number | boolean | null | JsonObject | ReadonlyArray<JsonValue>;
 type ShippedGuiBridgeRoute = Extract<(typeof apiRouteContracts)[number], { readonly guiBridgeMethod: PreloadApiMethod }>;
 type ShippedGuiBridgeMethod = ShippedGuiBridgeRoute["guiBridgeMethod"];
+type LocalControllerGuiMethod =
+  | "getTasks"
+  | "getTaskDetail"
+  | "getTaskDocument"
+  | "setTaskStatus"
+  | "reviewTask"
+  | "appendTaskProgress"
+  | "rebuildGovernance";
+
+interface GuiBridgeServiceProxy {
+  readonly getTasks: () => Promise<unknown> | unknown;
+  readonly getTaskDetail: (payload: unknown) => Promise<unknown> | unknown;
+  readonly getTaskDocument: (payload: unknown) => Promise<unknown> | unknown;
+  readonly setTaskStatus: (payload: unknown) => Promise<unknown> | unknown;
+  readonly reviewTask: (payload: unknown) => Promise<unknown> | unknown;
+  readonly appendTaskProgress: (payload: unknown) => Promise<unknown> | unknown;
+  readonly rebuildGovernance: () => Promise<unknown> | unknown;
+}
 
 interface GuiBridgeHandlerContext {
-  readonly rootDir: string;
-  readonly layoutInput: HarnessLayoutInput;
-  readonly service: LocalControllerService;
+  readonly service: GuiBridgeServiceProxy;
   readonly payload: unknown;
 }
 
 interface GuiBridgeHandlerImplementation {
-  readonly serviceMethod: keyof LocalControllerService;
+  readonly serviceMethod: LocalControllerGuiMethod;
   readonly invoke: (context: GuiBridgeHandlerContext) => Promise<unknown> | unknown;
 }
 
@@ -38,45 +48,23 @@ export const guiBridgeHandlerImplementations = {
   },
   getTaskDetail: {
     serviceMethod: "getTaskDetail",
-    invoke: ({ service, payload }) => {
-      const parsed = readTaskIdPayload(payload);
-      if (!parsed.ok) return parsed;
-      return service.getTaskDetail(parsed);
-    }
+    invoke: ({ service, payload }) => service.getTaskDetail(payload)
   },
   getTaskDocument: {
     serviceMethod: "getTaskDocument",
-    invoke: ({ rootDir, layoutInput, service, payload }) => {
-      const pathDecision = validateTaskDocumentPayloadPath(rootDir, layoutInput, payload);
-      if (!pathDecision.ok) return pathDecision;
-      const parsed = readTaskDocumentPayload(payload);
-      if (!parsed.ok) return parsed;
-      return service.getTaskDocument(parsed);
-    }
+    invoke: ({ service, payload }) => service.getTaskDocument(payload)
   },
   setTaskStatus: {
     serviceMethod: "setTaskStatus",
-    invoke: ({ service, payload }) => {
-      const parsed = readSetStatusPayload(payload);
-      if (!parsed.ok) return parsed;
-      return service.setTaskStatus(parsed);
-    }
+    invoke: ({ service, payload }) => service.setTaskStatus(payload)
   },
   reviewTask: {
     serviceMethod: "reviewTask",
-    invoke: ({ service, payload }) => {
-      const parsed = readTaskIdPayload(payload);
-      if (!parsed.ok) return parsed;
-      return service.reviewTask(parsed);
-    }
+    invoke: ({ service, payload }) => service.reviewTask(payload)
   },
   appendTaskProgress: {
     serviceMethod: "appendTaskProgress",
-    invoke: ({ service, payload }) => {
-      const parsed = readAppendProgressPayload(payload);
-      if (!parsed.ok) return parsed;
-      return service.appendTaskProgress(parsed);
-    }
+    invoke: ({ service, payload }) => service.appendTaskProgress(payload)
   },
   rebuildGovernance: {
     serviceMethod: "rebuildGovernance",
@@ -84,36 +72,35 @@ export const guiBridgeHandlerImplementations = {
   }
 } as const satisfies Record<ShippedGuiBridgeMethod, GuiBridgeHandlerImplementation>;
 
+export type GuiDaemonRequester = (route: ApiRouteContract, payload: unknown) => Promise<JsonObject>;
+
 export function getShippedGuiBridgeMethods(): ReadonlyArray<ShippedGuiBridgeMethod> {
   return apiRouteContracts.flatMap((route) => "guiBridgeMethod" in route && route.guiBridgeMethod ? [route.guiBridgeMethod] : []) as ReadonlyArray<ShippedGuiBridgeMethod>;
 }
 
 const shippedGuiBridgeMethods = new Set<PreloadApiMethod>(getShippedGuiBridgeMethods());
+const routeByGuiMethod = new Map<PreloadApiMethod, ApiRouteContract>(
+  apiRouteContracts.flatMap((route) => "guiBridgeMethod" in route && route.guiBridgeMethod ? [[route.guiBridgeMethod as PreloadApiMethod, route]] : [])
+);
 const deferredGuiBridgeReasons = new Map<PreloadApiMethod, string>(
   deferredGuiBridgeContracts.map((entry) => [entry.guiBridgeMethod, entry.reason])
 );
 
-export function createGuiServiceBridgeForService(
-  rootDir: string,
-  service: LocalControllerService,
-  layoutOverrides?: HarnessLayoutOverrides
-): GuiServiceBridge {
-  const layoutInput = resolveHarnessRuntimeContext(createHarnessRuntimeContext(rootDir, layoutOverrides));
+export function createGuiServiceBridgeForDaemon(request: GuiDaemonRequester): GuiServiceBridge {
+  const service = createDaemonServiceProxy(request);
   return {
-    invoke: async (method, payload) => dispatchGuiServiceMethod(layoutInput.rootDir, layoutInput, service, method, payload)
+    invoke: async (method, payload) => dispatchGuiServiceMethod(service, method, payload)
   };
 }
 
 export async function dispatchGuiServiceMethod(
-  rootDir: string,
-  layoutInput: HarnessLayoutInput,
-  service: LocalControllerService,
+  service: GuiBridgeServiceProxy,
   method: string,
   payload: unknown
 ): Promise<unknown> {
   if (shippedGuiBridgeMethods.has(method as PreloadApiMethod)) {
     const handler = guiBridgeHandlerImplementations[method as ShippedGuiBridgeMethod];
-    return handler.invoke({ rootDir, layoutInput, service, payload });
+    return handler.invoke({ service, payload });
   }
   const deferredReason = deferredGuiBridgeReasons.get(method as PreloadApiMethod);
   if (deferredReason) {
@@ -134,39 +121,54 @@ export async function dispatchGuiServiceMethod(
   };
 }
 
-function validateTaskDocumentPayloadPath(
-  rootDir: string,
-  layoutInput: HarnessLayoutInput,
+function createDaemonServiceProxy(request: GuiDaemonRequester): GuiBridgeServiceProxy {
+  return {
+    getTasks: () => invokeDaemonGuiRoute(request, "getTasks", undefined),
+    getTaskDetail: (payload) => invokeDaemonGuiRoute(request, "getTaskDetail", payload),
+    getTaskDocument: (payload) => invokeDaemonGuiRoute(request, "getTaskDocument", payload),
+    setTaskStatus: (payload) => invokeDaemonGuiRoute(request, "setTaskStatus", payload),
+    reviewTask: (payload) => invokeDaemonGuiRoute(request, "reviewTask", payload),
+    appendTaskProgress: (payload) => invokeDaemonGuiRoute(request, "appendTaskProgress", payload),
+    rebuildGovernance: () => invokeDaemonGuiRoute(request, "rebuildGovernance", undefined)
+  };
+}
+
+async function invokeDaemonGuiRoute(
+  request: GuiDaemonRequester,
+  method: PreloadApiMethod,
   payload: unknown
-): { readonly ok: true } | { readonly ok: false; readonly error: { readonly code: string; readonly hint: string } } {
-  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
-    return { ok: false, error: { code: "invalid_payload", hint: "taskId and path are required." } };
-  }
-  const record = payload as Record<string, unknown>;
-  if (typeof record.taskId !== "string" || typeof record.path !== "string") {
-    return { ok: false, error: { code: "invalid_payload", hint: "taskId and path are required." } };
-  }
-  let documentPath: string;
-  try {
-    documentPath = normalizeRelativeDocumentPath(record.path);
-  } catch {
-    return { ok: false, error: { code: "invalid_payload", hint: "Portable document path is required." } };
-  }
-  let relativeDocumentPath: string;
-  try {
-    relativeDocumentPath = path.relative(rootDir, taskDocumentPath(layoutInput, record.taskId, documentPath));
-  } catch {
-    return { ok: false, error: { code: "invalid_payload", hint: "taskId is invalid." } };
-  }
-  const decision = validateProjectPath(rootDir, relativeDocumentPath);
-  if (!decision.ok) {
+): Promise<unknown> {
+  const route = routeByGuiMethod.get(method);
+  if (!route) {
     return {
       ok: false,
       error: {
-        code: decision.reason ?? "path_rejected",
-        hint: "Requested document path is outside the public task package."
+        code: "method_not_allowed",
+        hint: `Unsupported GUI service method: ${method}`
+      }
+    };
+  }
+  const receipt = await request(route, payload);
+  return unwrapDaemonReceipt(receipt);
+}
+
+function unwrapDaemonReceipt(receipt: JsonObject): unknown {
+  const details = isRecord(receipt.details) ? receipt.details : undefined;
+  const data = isRecord(details?.data) ? details.data : undefined;
+  if (data) return data;
+  if (receipt.ok === false) {
+    const error = isRecord(receipt.error) ? receipt.error : {};
+    return {
+      ok: false,
+      error: {
+        code: typeof error.code === "string" ? error.code : "daemon_error",
+        hint: typeof error.hint === "string" ? error.hint : "Daemon request failed."
       }
     };
   }
   return { ok: true };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -56,15 +57,21 @@ interface LocalDaemonClientModule {
 
 let daemonClientModulePromise: Promise<LocalDaemonClientModule> | undefined;
 
+interface GuiDaemonBridgeState {
+  layoutOverrideDaemonStarted: boolean;
+}
+
 export function createLocalGuiServiceBridge(rootDir: string, layoutOverrides?: HarnessLayoutOverrides): GuiServiceBridge {
   const resolvedRootDir = path.resolve(rootDir);
   validateProjectPath(resolvedRootDir, ".");
-  return createGuiServiceBridgeForDaemon(async (route, payload) => requestGuiRouteViaDaemon(resolvedRootDir, layoutOverrides, route, payload));
+  const state: GuiDaemonBridgeState = { layoutOverrideDaemonStarted: false };
+  return createGuiServiceBridgeForDaemon(async (route, payload) => requestGuiRouteViaDaemon(resolvedRootDir, layoutOverrides, state, route, payload));
 }
 
 async function requestGuiRouteViaDaemon(
   rootDir: string,
   layoutOverrides: HarnessLayoutOverrides | undefined,
+  state: GuiDaemonBridgeState,
   route: ApiRouteContract,
   payload: unknown
 ): Promise<JsonObject> {
@@ -79,15 +86,31 @@ async function requestGuiRouteViaDaemon(
       daemonId,
       autoRegisterSingleRepo: true
     });
-    return await daemonClient.requestLocalDaemonJsonRpcForTarget(target, `repo.${route.id}`, {
+    const customLayout = hasLayoutOverride(layoutOverrides);
+    if (customLayout && !state.layoutOverrideDaemonStarted && await daemonAlreadyRunning(daemonClient, target)) {
+      return {
+        ok: false,
+        error: {
+          code: "daemon_layout_conflict",
+          hint: "A Harness daemon is already running for this repo without a verifiable matching authored layout. Stop the daemon or restart the GUI without HARNESS_AUTHORED_ROOT."
+        }
+      };
+    }
+    const nodeRuntime = resolveGuiDaemonNodeRuntime();
+    const receipt = await daemonClient.requestLocalDaemonJsonRpcForTarget(target, `repo.${route.id}`, {
       repo: { repoId: target.repoId },
       ...(isRecord(payload) ? { payload: payload as JsonObject } : {})
     }, 200, {
       entryPath: cliEntrypointPath(),
       idleExitMs: daemonIdleExitMs(),
       timeoutMs: daemonAutostartTimeoutMs(),
+      execPath: nodeRuntime.execPath,
+      execArgv: nodeRuntime.execArgv,
+      env: nodeRuntime.env,
       ...(layoutOverrides ? { layoutOverrides } : {})
     });
+    if (customLayout) state.layoutOverrideDaemonStarted = true;
+    return receipt;
   } catch (error) {
     return {
       ok: false,
@@ -97,6 +120,52 @@ async function requestGuiRouteViaDaemon(
       }
     };
   }
+}
+
+export interface GuiDaemonNodeRuntime {
+  readonly execPath: string;
+  readonly execArgv: ReadonlyArray<string>;
+  readonly env: NodeJS.ProcessEnv;
+}
+
+export function resolveGuiDaemonNodeRuntime(input: {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly execPath?: string;
+  readonly platform?: NodeJS.Platform;
+  readonly lookupNodeOnPath?: (env: NodeJS.ProcessEnv, platform: NodeJS.Platform) => string | undefined;
+} = {}): GuiDaemonNodeRuntime {
+  const env = input.env ?? process.env;
+  const currentExecPath = input.execPath ?? process.execPath;
+  const explicit = nonEmptyEnv(env, "HARNESS_NODE_BIN");
+  if (explicit) return guiDaemonNodeRuntime(explicit, env);
+  const npmNode = nonEmptyEnv(env, "npm_node_execpath");
+  if (npmNode && !sameExecutable(npmNode, currentExecPath)) return guiDaemonNodeRuntime(npmNode, env);
+  const pathNode = (input.lookupNodeOnPath ?? lookupNodeOnPath)(env, input.platform ?? process.platform);
+  if (pathNode) return guiDaemonNodeRuntime(pathNode, env);
+  throw new Error("System Node runtime not found; set HARNESS_NODE_BIN to a Node executable.");
+}
+
+function guiDaemonNodeRuntime(execPath: string, env: NodeJS.ProcessEnv): GuiDaemonNodeRuntime {
+  return {
+    execPath,
+    execArgv: [],
+    env: daemonAutostartEnv(env)
+  };
+}
+
+async function daemonAlreadyRunning(daemonClient: LocalDaemonClientModule, target: LocalDaemonTarget): Promise<boolean> {
+  try {
+    await daemonClient.requestLocalDaemonJsonRpcForTarget(target, "repo.daemon.status", {
+      repo: { repoId: target.repoId }
+    }, 200);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasLayoutOverride(layoutOverrides: HarnessLayoutOverrides | undefined): boolean {
+  return Boolean(layoutOverrides?.authoredRoot);
 }
 
 async function loadDaemonClientModule(): Promise<LocalDaemonClientModule> {
@@ -124,6 +193,40 @@ function daemonIdleExitMs(): number {
 
 function daemonAutostartTimeoutMs(): number {
   return positiveIntegerOr(process.env.HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS, defaultDaemonAutostartTimeoutMs);
+}
+
+function daemonAutostartEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const next = { ...env };
+  delete next.ELECTRON_RUN_AS_NODE;
+  return next;
+}
+
+function lookupNodeOnPath(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string | undefined {
+  const command = platform === "win32" ? "where" : "which";
+  const result = spawnSync(command, ["node"], {
+    encoding: "utf8",
+    env,
+    windowsHide: true
+  });
+  if (result.status !== 0 || !result.stdout) return undefined;
+  return result.stdout.split(/\r?\n/u).map((line) => line.trim()).find(Boolean);
+}
+
+function nonEmptyEnv(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const value = env[name];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function sameExecutable(left: string, right: string): boolean {
+  return normalizeExecutablePath(left) === normalizeExecutablePath(right);
+}
+
+function normalizeExecutablePath(value: string): string {
+  try {
+    return realpathSync.native(value);
+  } catch {
+    return path.resolve(value);
+  }
 }
 
 function positiveIntegerOr(value: string | undefined, fallback: number): number {

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -1,22 +1,137 @@
+import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
-import { makeLocalLifecycleEngine } from "../../../adapters/local/src/index.ts";
-import { makeLocalControllerService } from "../../../application/src/index.ts";
-import type { HarnessLayoutOverrides } from "../../../kernel/src/index.ts";
-import { createHarnessRuntimeContext, makeMarkdownArtifactStore, resolveHarnessRuntimeContext } from "../../../kernel/src/index.ts";
-import { createGuiServiceBridgeForService } from "../api/service-bridge.ts";
+import { fileURLToPath } from "node:url";
+import { validateProjectPath } from "../api/local-api.ts";
+import { createGuiServiceBridgeForDaemon } from "../api/service-bridge.ts";
+import type { ApiRouteContract } from "../api/api-contract-registry.ts";
 import type { GuiServiceBridge } from "../api/service-bridge.ts";
 
+const defaultDaemonAutostartTimeoutMs = 6_000;
+const defaultDaemonIdleExitMs = 750;
+
+type JsonObject = { readonly [key: string]: JsonValue };
+type JsonValue = string | number | boolean | null | JsonObject | ReadonlyArray<JsonValue>;
+
+interface LocalDaemonTarget {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+  readonly userRoot: string;
+  readonly daemonId: string;
+  readonly socketPath: string;
+  readonly legacySocketPath: string;
+  readonly registered: boolean;
+}
+
+interface HarnessLayoutOverrides {
+  readonly authoredRoot?: string;
+}
+
+interface LocalDaemonClientModule {
+  readonly daemonUserRoot: (env?: NodeJS.ProcessEnv) => string;
+  readonly daemonIdFromEnv: (env?: NodeJS.ProcessEnv) => string;
+  readonly resolveLocalDaemonTarget: (input: {
+    readonly rootDir: string;
+    readonly repoIdOverride?: string;
+    readonly userRoot?: string;
+    readonly daemonId?: string;
+    readonly autoRegisterSingleRepo?: boolean;
+    readonly env?: NodeJS.ProcessEnv;
+  }) => LocalDaemonTarget;
+  readonly requestLocalDaemonJsonRpcForTarget: (
+    target: LocalDaemonTarget,
+    method: string,
+    params: JsonObject,
+    timeoutMs?: number,
+    autostart?: {
+      readonly entryPath: string;
+      readonly idleExitMs?: number;
+      readonly timeoutMs?: number;
+      readonly layoutOverrides?: HarnessLayoutOverrides;
+      readonly env?: NodeJS.ProcessEnv;
+      readonly execPath?: string;
+      readonly execArgv?: ReadonlyArray<string>;
+    }
+  ) => Promise<JsonObject>;
+}
+
+let daemonClientModulePromise: Promise<LocalDaemonClientModule> | undefined;
+
 export function createLocalGuiServiceBridge(rootDir: string, layoutOverrides?: HarnessLayoutOverrides): GuiServiceBridge {
-  const runtimeContext = resolveHarnessRuntimeContext(createHarnessRuntimeContext(path.resolve(rootDir), layoutOverrides));
-  const resolvedRootDir = runtimeContext.rootDir;
-  return createGuiServiceBridgeForService(
-    resolvedRootDir,
-    makeLocalControllerService({
-      rootDir: resolvedRootDir,
-      layoutOverrides,
-      taskWriter: makeLocalLifecycleEngine({ rootDir: resolvedRootDir, layoutOverrides }),
-      artifactStore: makeMarkdownArtifactStore({ rootDir: resolvedRootDir, layoutOverrides })
-    }),
-    layoutOverrides
-  );
+  const resolvedRootDir = path.resolve(rootDir);
+  validateProjectPath(resolvedRootDir, ".");
+  return createGuiServiceBridgeForDaemon(async (route, payload) => requestGuiRouteViaDaemon(resolvedRootDir, layoutOverrides, route, payload));
+}
+
+async function requestGuiRouteViaDaemon(
+  rootDir: string,
+  layoutOverrides: HarnessLayoutOverrides | undefined,
+  route: ApiRouteContract,
+  payload: unknown
+): Promise<JsonObject> {
+  try {
+    const daemonClient = await loadDaemonClientModule();
+    const userRoot = daemonClient.daemonUserRoot();
+    const daemonId = daemonClient.daemonIdFromEnv();
+    const target = daemonClient.resolveLocalDaemonTarget({
+      rootDir,
+      repoIdOverride: process.env.HARNESS_DAEMON_REPO_ID,
+      userRoot,
+      daemonId,
+      autoRegisterSingleRepo: true
+    });
+    return await daemonClient.requestLocalDaemonJsonRpcForTarget(target, `repo.${route.id}`, {
+      repo: { repoId: target.repoId },
+      ...(isRecord(payload) ? { payload: payload as JsonObject } : {})
+    }, 200, {
+      entryPath: cliEntrypointPath(),
+      idleExitMs: daemonIdleExitMs(),
+      timeoutMs: daemonAutostartTimeoutMs(),
+      ...(layoutOverrides ? { layoutOverrides } : {})
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        code: "daemon_unavailable",
+        hint: `Harness daemon is unavailable: ${error instanceof Error ? error.message : String(error)}`
+      }
+    };
+  }
+}
+
+async function loadDaemonClientModule(): Promise<LocalDaemonClientModule> {
+  daemonClientModulePromise ??= import(daemonClientModuleUrl()) as Promise<LocalDaemonClientModule>;
+  return daemonClientModulePromise;
+}
+
+function daemonClientModuleUrl(): string {
+  return new URL("../../../daemon/src/client/local-json-rpc-client.ts", import.meta.url).href;
+}
+
+function cliEntrypointPath(): string {
+  const candidates = [
+    fileURLToPath(new URL("../../../cli/src/index.ts", import.meta.url)),
+    fileURLToPath(new URL("../../../cli/dist/cli/src/index.js", import.meta.url))
+  ];
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (!found) throw new Error(`Harness CLI entrypoint not found; checked ${candidates.join(", ")}`);
+  return realpathSync(found);
+}
+
+function daemonIdleExitMs(): number {
+  return positiveIntegerOr(process.env.HARNESS_DAEMON_IDLE_MS, defaultDaemonIdleExitMs);
+}
+
+function daemonAutostartTimeoutMs(): number {
+  return positiveIntegerOr(process.env.HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS, defaultDaemonAutostartTimeoutMs);
+}
+
+function positiveIntegerOr(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -1,9 +1,66 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { apiRouteContracts, createLocalGuiServiceBridge, getShippedGuiBridgeMethods } from "../src/index.ts";
+import {
+  apiRouteContracts,
+  createGuiServiceBridgeForDaemon,
+  createLocalGuiServiceBridge,
+  getShippedGuiBridgeMethods,
+  resolveGuiDaemonNodeRuntime
+} from "../src/index.ts";
+
+test("GUI daemon autostart resolves system Node instead of Electron runtime", () => {
+  const electronExecPath = "/Applications/Harness Anything.app/Contents/MacOS/Harness Anything";
+  const systemNode = "/opt/homebrew/bin/node";
+  const runtime = resolveGuiDaemonNodeRuntime({
+    execPath: electronExecPath,
+    env: {
+      npm_node_execpath: electronExecPath,
+      ELECTRON_RUN_AS_NODE: "1"
+    },
+    lookupNodeOnPath: () => systemNode
+  });
+
+  assert.equal(runtime.execPath, systemNode);
+  assert.notEqual(runtime.execPath, electronExecPath);
+  assert.deepEqual(runtime.execArgv, []);
+  assert.equal(runtime.env.ELECTRON_RUN_AS_NODE, undefined);
+});
+
+test("GUI daemon autostart honors HARNESS_NODE_BIN before other Node candidates", () => {
+  const runtime = resolveGuiDaemonNodeRuntime({
+    execPath: "/Applications/Electron.app/Contents/MacOS/Electron",
+    env: {
+      HARNESS_NODE_BIN: "/custom/bin/node",
+      npm_node_execpath: "/npm/bin/node"
+    },
+    lookupNodeOnPath: () => "/path/bin/node"
+  });
+
+  assert.equal(runtime.execPath, "/custom/bin/node");
+});
+
+test("GUI daemon bridge rejects malformed payload contracts before request dispatch", async () => {
+  let requests = 0;
+  const bridge = createGuiServiceBridgeForDaemon(async () => {
+    requests += 1;
+    return { ok: true };
+  });
+
+  const nonRecord = await bridge.invoke("getTaskDetail", "task-1") as { readonly ok: boolean; readonly error?: { readonly code: string; readonly hint: string } };
+  assert.equal(nonRecord.ok, false);
+  assert.equal(nonRecord.error?.code, "invalid_payload");
+  assert.match(nonRecord.error?.hint ?? "", /taskId is required/u);
+
+  const malformedRecord = await bridge.invoke("setTaskStatus", { taskId: "task-1", status: "unknown-status" }) as { readonly ok: boolean; readonly error?: { readonly code: string; readonly hint: string } };
+  assert.equal(malformedRecord.ok, false);
+  assert.equal(malformedRecord.error?.code, "invalid_payload");
+  assert.match(malformedRecord.error?.hint ?? "", /valid status/u);
+
+  assert.equal(requests, 0);
+});
 
 test("GUI service bridge reaches application service through the daemon client", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-daemon-"));
@@ -82,7 +139,9 @@ test("GUI service bridge resolves project root before daemon routing", async () 
   try {
     mkdirSync(path.join(rootDir, "workspace", "nested"), { recursive: true });
     writeTaskIndex(rootDir, "task-1", "Subdir GUI Task", "planned");
-    const bridge = createLocalGuiServiceBridge(path.join(rootDir, "workspace", "nested"));
+    const nestedRoot = path.join(rootDir, "workspace", "nested");
+    const canonicalRoot = realpathSync.native(rootDir);
+    const bridge = createLocalGuiServiceBridge(nestedRoot);
 
     const document = await withGuiDaemonEnv(rootDir, () =>
       bridge.invoke("getTaskDocument", { taskId: "task-1", path: "INDEX.md" })
@@ -91,6 +150,32 @@ test("GUI service bridge resolves project root before daemon routing", async () 
     assert.equal(document.ok, true);
     assert.match(document.body ?? "", /Subdir GUI Task/);
     assert.notEqual(document.error?.code, "path_outside_project");
+    const registry = JSON.parse(readFileSync(path.join(rootDir, "user-daemon", "registry.json"), "utf8")) as { readonly repos: ReadonlyArray<{ readonly canonicalRoot: string }> };
+    assert.equal(registry.repos[0]?.canonicalRoot, canonicalRoot);
+    assert.notEqual(registry.repos[0]?.canonicalRoot, path.resolve(nestedRoot));
+  } finally {
+    await waitForDaemonIdle();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("GUI service bridge refuses custom authored root when an existing daemon layout cannot be verified", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-bridge-"));
+  try {
+    writeTaskIndex(rootDir, "task-1", "Default GUI Task", "planned");
+    const defaultBridge = createLocalGuiServiceBridge(rootDir);
+    const defaultList = await withGuiDaemonEnv(rootDir, () =>
+      defaultBridge.invoke("getTasks", null)
+    ) as { readonly ok: boolean };
+    assert.equal(defaultList.ok, true);
+
+    const customBridge = createLocalGuiServiceBridge(rootDir, { authoredRoot: ".custom-harness" });
+    const customList = await withGuiDaemonEnv(rootDir, () =>
+      customBridge.invoke("getTasks", null)
+    ) as { readonly ok: boolean; readonly error?: { readonly code: string; readonly hint: string } };
+    assert.equal(customList.ok, false);
+    assert.equal(customList.error?.code, "daemon_layout_conflict");
+    assert.match(customList.error?.hint ?? "", /layout/u);
   } finally {
     await waitForDaemonIdle();
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -1,94 +1,116 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { apiRouteContracts, createLocalGuiServiceBridge, getShippedGuiBridgeMethods } from "../src/index.ts";
 
-test("GUI service bridge reaches application service while enforcing document path guard", async () => {
+test("GUI service bridge reaches application service through the daemon client", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-daemon-"));
+  try {
+    writeTaskIndex(rootDir, "task-1", "Task One", "planned");
+    const list = await withGuiDaemonEnv(rootDir, async () => {
+      const bridge = createLocalGuiServiceBridge(rootDir);
+      return bridge.invoke("getTasks", null) as Promise<{ readonly ok: boolean; readonly tasks: readonly unknown[] }>;
+    });
+
+    assert.equal(list.ok, true);
+    assert.equal(list.tasks.length, 1);
+    assert.equal(existsSync(path.join(rootDir, "user-daemon", "registry.json")), true);
+    assert.match(readFileSync(path.join(rootDir, "user-daemon", "registry.json"), "utf8"), /"repoId": "canonical"/u);
+  } finally {
+    await waitForDaemonIdle();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("GUI service bridge preserves document results and daemon-side validation shape", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-bridge-"));
   try {
     writeTaskIndex(rootDir, "task-1", "Task One", "planned");
     const bridge = createLocalGuiServiceBridge(rootDir);
 
-    const list = await bridge.invoke("getTasks", null) as { readonly ok: boolean; readonly tasks: readonly unknown[] };
-    assert.equal(list.ok, true);
-    assert.equal(list.tasks.length, 1);
-
-    const document = await bridge.invoke("getTaskDocument", { taskId: "task-1", path: "INDEX.md" }) as { readonly ok: boolean; readonly body?: string };
+    const document = await withGuiDaemonEnv(rootDir, () =>
+      bridge.invoke("getTaskDocument", { taskId: "task-1", path: "INDEX.md" })
+    ) as { readonly ok: boolean; readonly body?: string };
     assert.equal(document.ok, true);
     assert.match(document.body ?? "", /Task One/);
 
-    const rejected = await bridge.invoke("getTaskDocument", { taskId: "task-1", path: "../../../../.harness-private/review.md" }) as { readonly ok: boolean; readonly error?: { readonly code: string } };
+    const rejected = await withGuiDaemonEnv(rootDir, () =>
+      bridge.invoke("getTaskDocument", { taskId: "task-1", path: "../../../../.harness-private/review.md" })
+    ) as { readonly ok: boolean; readonly error?: { readonly code: string } };
     assert.equal(rejected.ok, false);
     assert.equal(rejected.error?.code, "invalid_payload");
 
-    const windowsPath = await bridge.invoke("getTaskDocument", { taskId: "task-1", path: "C:\\Users\\name\\secret.md" }) as { readonly ok: boolean; readonly error?: { readonly code: string } };
+    const windowsPath = await withGuiDaemonEnv(rootDir, () =>
+      bridge.invoke("getTaskDocument", { taskId: "task-1", path: "C:\\Users\\name\\secret.md" })
+    ) as { readonly ok: boolean; readonly error?: { readonly code: string } };
     assert.equal(windowsPath.ok, false);
     assert.equal(windowsPath.error?.code, "invalid_payload");
   } finally {
+    await waitForDaemonIdle();
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
 
-test("GUI service bridge honors explicit authored root context", async () => {
+test("GUI service bridge honors explicit authored root context through daemon", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-bridge-"));
   try {
     writeTaskIndex(rootDir, "task-1", "Custom GUI Task", "planned", ".custom-harness");
     const bridge = createLocalGuiServiceBridge(rootDir, { authoredRoot: ".custom-harness" });
 
-    const list = await bridge.invoke("getTasks", null) as { readonly ok: boolean; readonly tasks: readonly unknown[] };
+    const list = await withGuiDaemonEnv(rootDir, () =>
+      bridge.invoke("getTasks", null)
+    ) as { readonly ok: boolean; readonly tasks: readonly unknown[] };
     assert.equal(list.ok, true);
     assert.equal(list.tasks.length, 1);
 
-    const document = await bridge.invoke("getTaskDocument", { taskId: "task-1", path: "INDEX.md" }) as { readonly ok: boolean; readonly body?: string };
+    const document = await withGuiDaemonEnv(rootDir, () =>
+      bridge.invoke("getTaskDocument", { taskId: "task-1", path: "INDEX.md" })
+    ) as { readonly ok: boolean; readonly body?: string };
     assert.equal(document.ok, true);
     assert.match(document.body ?? "", /Custom GUI Task/);
     assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-1/INDEX.md")), false);
   } finally {
+    await waitForDaemonIdle();
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
 
-test("GUI service bridge resolves project root before guarding task documents", async () => {
+test("GUI service bridge resolves project root before daemon routing", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-bridge-"));
   try {
     mkdirSync(path.join(rootDir, "workspace", "nested"), { recursive: true });
-    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
-    writeFileSync(path.join(rootDir, "harness", "harness.yaml"), [
-      "schema: harness-anything/v1",
-      "name: gui-subdir",
-      "layout:",
-      "  authoredRoot: harness",
-      "  localRoot: .harness",
-      ""
-    ].join("\n"), "utf8");
     writeTaskIndex(rootDir, "task-1", "Subdir GUI Task", "planned");
     const bridge = createLocalGuiServiceBridge(path.join(rootDir, "workspace", "nested"));
 
-    const document = await bridge.invoke("getTaskDocument", { taskId: "task-1", path: "INDEX.md" }) as { readonly ok: boolean; readonly body?: string; readonly error?: { readonly code: string } };
+    const document = await withGuiDaemonEnv(rootDir, () =>
+      bridge.invoke("getTaskDocument", { taskId: "task-1", path: "INDEX.md" })
+    ) as { readonly ok: boolean; readonly body?: string; readonly error?: { readonly code: string } };
 
     assert.equal(document.ok, true);
     assert.match(document.body ?? "", /Subdir GUI Task/);
     assert.notEqual(document.error?.code, "path_outside_project");
   } finally {
+    await waitForDaemonIdle();
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
 
 test("GUI service bridge shipped methods are registry-driven and deferred methods return explicit errors", async () => {
+  const activeGuiMethods = apiRouteContracts
+    .map((route) => "guiBridgeMethod" in route ? route.guiBridgeMethod : undefined)
+    .filter((method): method is string => typeof method === "string");
+
+  assert.deepEqual(getShippedGuiBridgeMethods(), activeGuiMethods);
+  const shippedMethods = new Set<string>(getShippedGuiBridgeMethods());
+  assert.equal(shippedMethods.has("archiveTask"), false);
+  assert.equal(shippedMethods.has("openShell"), false);
+
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-bridge-"));
   try {
+    writeHarnessConfig(rootDir);
     const bridge = createLocalGuiServiceBridge(rootDir);
-    const activeGuiMethods = apiRouteContracts
-      .map((route) => "guiBridgeMethod" in route ? route.guiBridgeMethod : undefined)
-      .filter((method): method is string => typeof method === "string");
-
-    assert.deepEqual(getShippedGuiBridgeMethods(), activeGuiMethods);
-    const shippedMethods = new Set<string>(getShippedGuiBridgeMethods());
-    assert.equal(shippedMethods.has("archiveTask"), false);
-    assert.equal(shippedMethods.has("openShell"), false);
-
     const archive = await bridge.invoke("archiveTask", null) as { readonly ok: boolean; readonly error?: { readonly code: string; readonly hint: string } };
     assert.equal(archive.ok, false);
     assert.equal(archive.error?.code, "method_deferred");
@@ -103,7 +125,21 @@ test("GUI service bridge shipped methods are registry-driven and deferred method
   }
 });
 
+async function withGuiDaemonEnv<T>(rootDir: string, run: () => Promise<T>): Promise<T> {
+  const previousUserRoot = process.env.HARNESS_DAEMON_USER_ROOT;
+  const previousIdleMs = process.env.HARNESS_DAEMON_IDLE_MS;
+  process.env.HARNESS_DAEMON_USER_ROOT = path.join(rootDir, "user-daemon");
+  process.env.HARNESS_DAEMON_IDLE_MS = "250";
+  try {
+    return await run();
+  } finally {
+    restoreEnv("HARNESS_DAEMON_USER_ROOT", previousUserRoot);
+    restoreEnv("HARNESS_DAEMON_IDLE_MS", previousIdleMs);
+  }
+}
+
 function writeTaskIndex(rootDir: string, taskId: string, title: string, status: string, authoredRoot = "harness"): void {
+  writeHarnessConfig(rootDir, authoredRoot);
   mkdirSync(path.join(rootDir, authoredRoot, "tasks", taskId), { recursive: true });
   writeFileSync(path.join(rootDir, authoredRoot, "tasks", taskId, "INDEX.md"), [
     "---",
@@ -125,4 +161,28 @@ function writeTaskIndex(rootDir: string, taskId: string, title: string, status: 
     "---",
     ""
   ].join("\n"), "utf8");
+}
+
+function writeHarnessConfig(rootDir: string, authoredRoot = "harness"): void {
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  writeFileSync(path.join(rootDir, "harness", "harness.yaml"), [
+    "schema: harness-anything/v1",
+    "name: gui-bridge-test",
+    "layout:",
+    `  authoredRoot: ${authoredRoot}`,
+    "  localRoot: .harness",
+    ""
+  ].join("\n"), "utf8");
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+function waitForDaemonIdle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 700));
 }

--- a/packages/kernel/src/daemon/registry.ts
+++ b/packages/kernel/src/daemon/registry.ts
@@ -175,10 +175,10 @@ function writeDaemonRegistry(registry: DaemonRegistry, options: DaemonRegistryOp
 function canonicalHarnessRoot(rootDir: string): string {
   const realRoot = existsSync(path.resolve(rootDir)) ? realpathSync.native(path.resolve(rootDir)) : invalidCanonicalRoot(rootDir);
   const layout = resolveHarnessLayout(realRoot);
-  if (layout.rootDir !== realRoot || !layout.configPath || !existsSync(layout.configPath)) {
+  if (!layout.configPath || !existsSync(layout.configPath)) {
     throw new Error(`canonicalRoot must be an initialized harness repository: ${rootDir}`);
   }
-  return realRoot;
+  return realpathSync.native(layout.rootDir);
 }
 
 function generateRepoId(displayName: string, canonicalRoot: string, repos: ReadonlyArray<DaemonRegistryRepo>): string {

--- a/packages/kernel/src/layout/index.ts
+++ b/packages/kernel/src/layout/index.ts
@@ -103,11 +103,6 @@ export function createHarnessRuntimeContext(
   };
 }
 
-export function resolveHarnessRuntimeContext(input: HarnessLayoutInput): HarnessRuntimeContext {
-  const layout = resolveHarnessLayout(input);
-  return createHarnessRuntimeContext(layout.rootDir, layoutInputOverrides(input));
-}
-
 export function harnessRuntimeRoot(input: HarnessLayoutInput): string {
   return typeof input === "string" ? path.resolve(input) : input.rootDir;
 }

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -174,7 +174,6 @@ const publicRuntimeSurface = [
   "resolveDaemonRepoByRoot",
   "resolveEntityRoot",
   "resolveHarnessLayout",
-  "resolveHarnessRuntimeContext",
   "resolveTaskSchema",
   "reviewArtifactStatuses",
   "runPostMergeChecks",


### PR DESCRIPTION
# English

## Summary

Routes the Electron GUI main process through the local daemon (JSON-RPC over the user socket) instead of opening its own direct SQLite connection. This unifies GUI with the CLI, which already became a thin daemon client in W9-P4 (#304), and removes `better-sqlite3` from the Electron bundle — eliminating the dual-ABI conflict (Electron ABI 146 vs system Node ABI 141) at its root, since the Electron process no longer loads any native module.

## What Changed

- `packages/daemon/src/client/local-json-rpc-client.ts`: extracted the shared thin-client layer (user-level daemon target/registry/auto-register, socket JSON-RPC, hello handshake, D1 autostart) so both CLI and GUI reuse one connection stack.
- `packages/cli/src/daemon/client.ts`: CLI local mode now consumes the shared client; remote/receipt behavior preserved.
- `packages/gui/src/main/local-composition-root.ts`: GUI service bridge sends `repo.${route.id}` requests through the daemon with autostart (auto-launch when absent), auto-registering a single repo; on autostart failure it returns a readable `daemon_unavailable` error.
- `packages/gui/src/api/service-bridge.ts`: bridge handler keeps the registry-lock shape (contract lock unchanged) but its service is now a daemon proxy with receipt unwrapping; payload validation stays on the daemon-side LocalControllerService.
- `packages/gui/test/service-bridge.test.ts`: new/updated tests covering GUI-main-via-daemon fetch and single-repo auto-registration.
- `packages/kernel/src/layout/index.ts` + `packages/kernel/test/contracts/public-surface.test.ts`: removed the now-dead `resolveHarnessRuntimeContext` export (its only two non-test consumers were the GUI direct-SQLite path, both replaced by the daemon route here) and its public-surface contract entry. Underlying primitives (`resolveHarnessLayout`, `createHarnessRuntimeContext`) are retained and still consumed. Removed rather than allowlisted — allowlisting a genuinely-dead export would weaken the `check-kernel-dead-exports` signal.

Follow-up commits address the automated Codex review findings (all four triaged by CEO, see Review Evidence):

- P1 (confirmed): GUI autostart now explicitly resolves a **system Node runtime** (`HARNESS_NODE_BIN` → `npm_node_execpath` if not Electron itself → `node` on PATH) and passes `execPath`/`execArgv` to `spawnLocalDaemon`, stripping `ELECTRON_RUN_AS_NODE` from the child env. Without this, the daemon spawned from Electron main would inherit the Electron binary and reintroduce the ABI conflict through the autostart back door. Resolution fails with a readable error instead of silently falling back.
- P2: GUI bridge validates payloads against the route contract before daemon dispatch, returning a contract-shaped `invalid_payload` rejection (parity with the old direct path).
- P2: daemon registry `canonicalHarnessRoot` now normalizes sub-directory launches upward to the initialized project root instead of rejecting them (prevents spurious per-subdirectory daemons/registry entries).
- P2: a GUI launched with custom `layoutOverrides` against an already-running daemon whose layout cannot be verified returns a readable `daemon_layout_conflict` error instead of silently reading the wrong layout; a custom-layout daemon started by this bridge is reused.

renderer / preload / API contract shapes are unchanged.

## Task And Scope

- Harness task: `task_01KWYXYFSXWRK0A3Z2NJMPTRZ4` (GUI/CLI better-sqlite3 dual-ABI resolution)
- Branch: `gui-via-daemon`
- Public scope: GUI main data layer, shared daemon thin client, CLI local-mode client wiring, removal of one dead kernel export (`resolveHarnessRuntimeContext`)
- Private planning/evidence updated: yes
- Out of scope: renderer/preload/contract shapes; daemon JSON-RPC protocol surface (unchanged — existing methods covered all GUI reads)

## Version Impact

- Version: no version change because this is an internal data-layer rewiring with no public CLI surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable (no CI/mergify/branch-protection/import-boundary allowlist changes)
- Authority: decision `dec_mrb9fkif` ("GUI data layer goes through daemon; direct SQLite retires to a no-daemon degradation path") derives task `task_01KWYXYFSXWRK0A3Z2NJMPTRZ4`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `16426f63bcef52f6038bc0340526bb8ffc0d8fbf`
- Branch merge-base with `origin/main`: `16426f63bcef52f6038bc0340526bb8ffc0d8fbf` (no drift)
- Last `git fetch origin` time: 2026-07-08, immediately before push
- Sync method: none needed
- Public diff command: `git diff origin/main...gui-via-daemon`
- Private evidence commit/path: `harness/tasks/task_01KWYPMZD74BQ0NTR7YT1TA9F4-*/artifacts/orchestration/codex-guidaemon.log`
- Reviewer evidence path: same log tail (architecture landing + esbuild metafile + test runs)
- GitHub Actions `rewrite-ci` run URL: pending CI
- better-sqlite3 removal evidence: esbuild metafile on `electron-main.ts` bundle (9 inputs) and daemon-client bundle (14 inputs) — grep for `better-sqlite3|@effect/sql-sqlite-node|sqlite projection|adapters/local|local-controller` returns `[]` hits in both.
- Local tests: `node --test packages/gui/test/service-bridge.test.ts packages/gui/test/ipc-handler-registration.test.ts` 8/8; `node --test packages/cli/test/daemon-thin-client-cli.test.ts packages/daemon/test/json-rpc-protocol.test.ts` 33/33; `npm run test:gui` 5/5; `npm run check:local` passed fast tier 18.4s.
- Not run: `npm run check:local --full`, `npm run test:gui:e2e`, cloud CI (delegated to GitHub Actions on this PR).

## Review Evidence

- Self-review: CEO semantic acceptance — verified GUI route goes through daemon with D1 autostart (not degraded to error), contract shapes unchanged, better-sqlite3 absent from Electron bundle via metafile, tests green. Confirms alignment with dec_mrb9fkif.
- Automated review triage (chatgpt-codex-connector, reviewed `f0b40b1`): 4 findings, each ground-truthed by CEO before merge. P1 "daemon spawned with Electron runtime" — CONFIRMED against `local-json-rpc-client.ts` spawn fallback and fixed (system-Node resolution). P2 payload validation — confirmed, fixed with contract-shaped rejection. P2 subdirectory root resolution — confirmed, fixed via registry root normalization. P2 layoutOverrides vs running daemon — confirmed, fixed with readable conflict error (no daemon protocol expansion). None dismissed.
- Reviewer subagent: not applicable (mechanical + semantic done inline)
- Human review: pending
- Blocking findings: none open (P1 fixed pre-merge)

## Residual Risk

- E2E (`test:gui:e2e`) and full-tier check not run locally; relying on cloud CI to cover them.
- Headful dual-runtime usage proof (GUI + CLI simultaneously against one daemon) is performed at task closeout, post-merge.

## References

- Task: `task_01KWYXYFSXWRK0A3Z2NJMPTRZ4`
- Decision: `dec_mrb9fkif`
- Evidence: `codex-guidaemon.log`

---

# 中文

## 摘要

把 Electron GUI 主进程从"自己直连 SQLite"改为经本地 daemon(用户 socket 上的 JSON-RPC)取数,与 W9-P4(#304)已成为 daemon 瘦客户端的 CLI 统一。同时把 `better-sqlite3` 从 Electron bundle 中移除——从根上消除双 ABI 冲突(Electron ABI 146 vs 系统 Node ABI 141),因为 Electron 进程不再加载任何原生模块。

## 改动内容

- `packages/daemon/src/client/local-json-rpc-client.ts`:抽出共享瘦客户端层(用户级 daemon target/registry/自动注册、socket JSON-RPC、hello 握手、D1 自动拉起),CLI 与 GUI 复用同一套连接栈。
- `packages/cli/src/daemon/client.ts`:CLI local 模式改用共享 client,远程/receipt 行为保留。
- `packages/gui/src/main/local-composition-root.ts`:GUI service bridge 以 `repo.${route.id}` 经 daemon 请求,带自动拉起(daemon 缺失即拉起)、单仓自动注册;拉起失败返回可读的 `daemon_unavailable` 错误。
- `packages/gui/src/api/service-bridge.ts`:bridge handler 保持 registry 锁形状(契约锁不变),service 改为 daemon 代理 + receipt 解包;payload 校验留在 daemon 侧 LocalControllerService。
- `packages/gui/test/service-bridge.test.ts`:新增/改造 GUI-main 经 daemon 取数与单仓自动注册测试。
- `packages/kernel/src/layout/index.ts` + `packages/kernel/test/contracts/public-surface.test.ts`:删除已成死导出的 `resolveHarnessRuntimeContext`(其仅有的两个非测试消费者=GUI 直连 SQLite 路径,本 PR 均已改走 daemon)及其公共面契约项。底层原语(`resolveHarnessLayout`、`createHarnessRuntimeContext`)保留且仍被消费。选择删除而非 allowlist——给真死导出加豁免会削弱 `check-kernel-dead-exports` 门信号。

后续 commit 处理了自动 Codex review 的 4 条 findings(CEO 逐条 ground-truth 后裁断,见复核证据节):

- P1(已确认):GUI 自动拉起现在显式解析**系统 Node 运行时**(`HARNESS_NODE_BIN` → 非 Electron 自身的 `npm_node_execpath` → PATH 上的 `node`),将 `execPath`/`execArgv` 传给 `spawnLocalDaemon`,并从子进程 env 去除 `ELECTRON_RUN_AS_NODE`。不修的话,Electron main 拉起的 daemon 会继承 Electron 二进制,把 ABI 冲突从自动拉起后门带回来。解析失败返回可读错误,绝不静默 fallback。
- P2:GUI bridge 在发往 daemon 前按 route 契约校验 payload,失败返回契约形状的 `invalid_payload`(与旧直连路径对齐)。
- P2:daemon registry 的 `canonicalHarnessRoot` 对子目录启动向上归一到已初始化项目根,不再拒绝(防止按子目录误拉多余 daemon/注册项)。
- P2:带自定义 `layoutOverrides` 的 GUI 连到已运行且布局无法核对的 daemon 时,返回可读的 `daemon_layout_conflict` 错误而非静默读错布局;本 bridge 自己拉起的自定义布局 daemon 可复用。

renderer / preload / API 契约形状均未改。

## 任务与范围

- Harness 任务:`task_01KWYXYFSXWRK0A3Z2NJMPTRZ4`(GUI/CLI better-sqlite3 双 ABI 收敛)
- 分支:`gui-via-daemon`
- 公共范围:GUI 主进程数据层、共享 daemon 瘦客户端、CLI local 模式接线、删除一个 kernel 死导出(`resolveHarnessRuntimeContext`)
- 私有规划/证据已更新:是
- 不在范围:renderer/preload/契约形状;daemon JSON-RPC 协议面(未改——现有方法已覆盖 GUI 所有读路径)

## 版本影响

- 版本:无变更,因为这是内部数据层改接线、无公共 CLI 面变化
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:不适用(无 CI/mergify/分支保护/import 边界 allowlist 改动)
- 授权:决策 `dec_mrb9fkif`("GUI 数据层走 daemon;直连 SQLite 退役为无 daemon 降级路径")派生任务 `task_01KWYXYFSXWRK0A3Z2NJMPTRZ4`
- 机器检查边界:本 PR 只断言声明存在;是否真实充分由复核者判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- Base `origin/main` SHA:`16426f63bcef52f6038bc0340526bb8ffc0d8fbf`
- 分支与 `origin/main` 的 merge-base:`16426f63bcef52f6038bc0340526bb8ffc0d8fbf`(无漂移)
- 最后一次 `git fetch origin`:2026-07-08,push 前
- 同步方式:无需同步
- 公共 diff 命令:`git diff origin/main...gui-via-daemon`
- 私有证据 commit/路径:`harness/tasks/task_01KWYPMZD74BQ0NTR7YT1TA9F4-*/artifacts/orchestration/codex-guidaemon.log`
- 复核证据路径:同上日志尾部(架构落点 + esbuild metafile + 测试记录)
- GitHub Actions `rewrite-ci` run URL:待 CI
- better-sqlite3 移除证据:对 `electron-main.ts` bundle(9 inputs)与 daemon-client bundle(14 inputs)跑 esbuild metafile,grep `better-sqlite3|@effect/sql-sqlite-node|sqlite projection|adapters/local|local-controller` 两侧命中均为 `[]`。
- 本地测试:`node --test packages/gui/test/service-bridge.test.ts packages/gui/test/ipc-handler-registration.test.ts` 8/8;`node --test packages/cli/test/daemon-thin-client-cli.test.ts packages/daemon/test/json-rpc-protocol.test.ts` 33/33;`npm run test:gui` 5/5;`npm run check:local` fast tier 18.4s 通过。
- 未跑:`npm run check:local --full`、`npm run test:gui:e2e`、云端 CI(交本 PR 的 GitHub Actions 覆盖)。

## 复核证据

- 自审:CEO 语义验收——确认 GUI route 经 daemon 且带 D1 自动拉起(非降级为报错)、契约形状不变、esbuild metafile 证明 better-sqlite3 不在 Electron bundle、测试全绿。符合 dec_mrb9fkif。
- 自动 review triage(chatgpt-codex-connector,复核 `f0b40b1`):4 条 findings,CEO 合并前逐条 ground-truth。P1"daemon 以 Electron 运行时拉起"——对照 `local-json-rpc-client.ts` 的 spawn fallback 确认为真并修复(系统 Node 解析)。P2 payload 校验——成立,已修(契约形状拒绝)。P2 子目录根解析——成立,已修(registry 根归一)。P2 layoutOverrides 与在跑 daemon——成立,已修(可读冲突错误,未扩 daemon 协议)。无驳回项。
- 复核子代理:不适用(机械 + 语义已内联完成)
- 人工复核:待
- 阻断性发现:无未闭合项(P1 已在合并前修复)

## 残余风险

- E2E(`test:gui:e2e`)与 full-tier check 本地未跑,依赖云端 CI 覆盖。
- Headful 双运行时使用证明(GUI + CLI 同时对一个 daemon)在任务收口(合并后)执行。

## 参考

- 任务:`task_01KWYXYFSXWRK0A3Z2NJMPTRZ4`
- 决策:`dec_mrb9fkif`
- 证据:`codex-guidaemon.log`
