### PR TITLE
fix(kernel): convert listTextFiles to iterative DFS to fix stack overflow

### DIFF
--- a/packages/kernel/src/projection/post-merge-checks.ts
+++ b/packages/kernel/src/projection/post-merge-checks.ts
@@ -412,16 +412,27 @@ export function buildCheckReport(
 
 function listTextFiles(inputPath: string): ReadonlyArray<string> {
   if (!existsSync(inputPath)) return [];
-  const stat = statPathIfPresent(inputPath);
-  if (stat === null) return [];
-  if (stat.isFile()) return isTextLikePath(inputPath) ? [inputPath] : [];
-  if (!stat.isDirectory()) return [];
+  const rootStat = statPathIfPresent(inputPath);
+  if (rootStat === null) return [];
+  if (rootStat.isFile()) return isTextLikePath(inputPath) ? [inputPath] : [];
+  if (!rootStat.isDirectory()) return [];
   const files: string[] = [];
-  const entries = readDirIfPresent(inputPath);
-  if (entries === null) return [];
-  for (const entry of entries) {
-    if (entry.name === ".git" || entry.name === "node_modules") continue;
-    files.push(...listTextFiles(path.join(inputPath, entry.name)));
+  const dirQueue: string[] = [inputPath];
+  while (dirQueue.length > 0) {
+    const dir = dirQueue.pop()!;
+    const entries = readDirIfPresent(dir);
+    if (entries === null) continue;
+    for (const entry of entries) {
+      if (entry.name === ".git" || entry.name === "node_modules") continue;
+      const childPath = path.join(dir, entry.name);
+      const childStat = statPathIfPresent(childPath);
+      if (childStat === null) continue;
+      if (childStat.isDirectory()) {
+        dirQueue.push(childPath);
+      } else if (childStat.isFile() && isTextLikePath(childPath)) {
+        files.push(childPath);
+      }
+    }
   }
   return files;
 }


### PR DESCRIPTION
# English

## Summary

Fixes the conflict-marker preflight stack overflow by changing the authored text file scan from recursive DFS to iterative DFS with an explicit stack.

## What Changed

- Replaced `listTextFiles` recursion in `packages/kernel/src/projection/post-merge-checks.ts` with an iterative directory stack.
- Preserved the existing file filtering, ignored directory names, and transient read behavior.

## Task And Scope

- Harness task: Hotfix request, no task id provided
- Branch: `codex/hotfix-listtextfiles-iterative-dfs`
- Public scope: `packages/kernel/src/projection/post-merge-checks.ts`
- Private planning/evidence updated: not applicable
- Out of scope: CLI command behavior, package metadata, test runner configuration, public docs

## Version Impact

- Version: no version change because this is an internal hotfix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: hotfix request
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `339570858b128a9399fc31b26af663e9132b1652`
- Branch merge-base with `origin/main`: `339570858b128a9399fc31b26af663e9132b1652`
- Last `git fetch origin` time: `2026-07-08T03:00:00Z`
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: not applicable
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/28914316855
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Additional verification run:
  - `npx tsc -p packages/kernel/tsconfig.json --noEmit --pretty false` passed.
  - `node --test packages/cli/test/conflict-preflight-cli.test.ts` passed: 5 tests, 0 failed.
  - `npm run test:fast` passed: 216 tests, 0 failed.
  - `npm run test:contract` passed: 313 tests, 0 failed.
  - `npm run test:integration` passed: 445 passed, 1 skipped, 0 failed.
  - Worktree source CLI `task list` passed with `ok command="task list" summary="completed task list"`.
- Not run:
  - `npm run build -w packages/kernel`: current kernel workspace has no `build` script, so npm exits with `Missing script: "build"`.
  - `npx vitest run --project kernel --reporter verbose 2>&1 | tail -20`: current Vitest configuration has no `kernel` project.
  - `npx vitest run --reporter verbose --project cli -t "conflict"`: current Vitest configuration has no `cli` project.
  - Full aggregate gates such as `npm run check`, because this hotfix was limited to the requested build/test scope plus fast, contract, and integration coverage.

## Review Evidence

- Self-review: public diff is one function only; it removes recursive self-calls and keeps text-file filtering behavior unchanged.
- Reviewer subagent: not run.
- Human review: pending.
- Blocking findings: none known.

## Residual Risk

- Traversal order remains depth-first but may differ from the previous recursive order for sibling directories because the explicit stack uses `pop`. The preflight checks membership for conflict markers rather than relying on sorted output.

## References

- Task: Hotfix request for conflict preflight stack overflow in `listTextFiles`
- Evidence: local command outputs listed above
- Review: pending

---

# 中文

## 概要

修复 conflict marker preflight 的栈溢出：把 authored text file 扫描从递归 DFS 改为显式栈的迭代 DFS。

## 改动内容

- 将 `packages/kernel/src/projection/post-merge-checks.ts` 中的 `listTextFiles` 递归遍历替换为目录栈遍历。
- 保持原有文本文件过滤、忽略目录和瞬时读取容错逻辑不变。

## 任务与范围

- Harness 任务：Hotfix 请求，未提供 task id
- 分支：`codex/hotfix-listtextfiles-iterative-dfs`
- 公开范围：`packages/kernel/src/projection/post-merge-checks.ts`
- 私有计划 / 证据是否已更新：not applicable
- 范围外：CLI 命令行为、package metadata、test runner 配置、公开文档

## 版本影响

- 版本：不改版本，原因是本次为内部 hotfix
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：hotfix 请求
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`339570858b128a9399fc31b26af663e9132b1652`
- 当前分支与 `origin/main` 的 merge-base：`339570858b128a9399fc31b26af663e9132b1652`
- 最近一次 `git fetch origin` 时间：`2026-07-08T03:00:00Z`
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：不适用
- Reviewer 证据路径：不适用
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/28914316855
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 额外已运行验证：
  - `npx tsc -p packages/kernel/tsconfig.json --noEmit --pretty false` 通过。
  - `node --test packages/cli/test/conflict-preflight-cli.test.ts` 通过：5 tests，0 failed。
  - `npm run test:fast` 通过：216 tests，0 failed。
  - `npm run test:contract` 通过：313 tests，0 failed。
  - `npm run test:integration` 通过：445 passed，1 skipped，0 failed。
  - worktree source CLI `task list` 通过，输出 `ok command="task list" summary="completed task list"`。
- 未运行：
  - `npm run build -w packages/kernel`：当前 kernel workspace 没有 `build` script，npm 返回 `Missing script: "build"`。
  - `npx vitest run --project kernel --reporter verbose 2>&1 | tail -20`：当前 Vitest 配置没有 `kernel` project。
  - `npx vitest run --reporter verbose --project cli -t "conflict"`：当前 Vitest 配置没有 `cli` project。
  - `npm run check` 等全量聚合 gate：本 hotfix 按请求范围执行，并额外覆盖 fast、contract、integration。

## 审查证据

- 自查：公开 diff 仅限一个函数；移除递归自调用，保持文本文件过滤行为不变。
- Reviewer subagent：未运行。
- 人工审查：pending。
- 阻塞发现：暂无已知阻塞。

## 残余风险

- 遍历仍是 DFS，但显式栈 `pop` 对兄弟目录的访问顺序可能不同于旧递归顺序；preflight 只检查 conflict marker 存在性，不依赖排序输出。

## 关联材料

- 任务：`listTextFiles` conflict preflight 栈溢出 hotfix 请求
- 证据：上方本地命令输出
- 审查：pending

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
