### PR TITLE
feat(kernel,gui): hide archived entities from default graph and GUI read surfaces

### DIFF
--- a/packages/application/src/local-controller-service.ts
+++ b/packages/application/src/local-controller-service.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { Effect } from "effect";
 import type { ArtifactStore, EngineError, WriteError } from "../../kernel/src/index.ts";
-import { readTaskProjection } from "../../kernel/src/index.ts";
+import { queryTaskProjection, readTaskProjection } from "../../kernel/src/index.ts";
 import {
   readTaskDocumentPayload,
   validateLocalControllerTaskId
@@ -27,7 +27,7 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
 
   return {
     getTasks: () => {
-      const result = readTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides });
+      const result = queryTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, filters: {} });
       return { ok: true, tasks: result.rows, warnings: result.warnings };
     },
     getTaskDetail: async (payload) => {
@@ -65,7 +65,7 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
       ));
     },
     rebuildGovernance: () => {
-      const result = readTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides });
+      const result = queryTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, filters: {} });
       return { ok: true, tasks: result.rows, warnings: result.warnings };
     },
     archiveTask: () => ({

--- a/packages/application/test/local-controller-service.test.ts
+++ b/packages/application/test/local-controller-service.test.ts
@@ -11,6 +11,7 @@ test("local controller service reads projection and writes through injected task
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-app-"));
   try {
     writeTaskIndex(rootDir, "task-1", "Task One", "planned");
+    writeTaskIndex(rootDir, "task-archived", "Archived Task", "done", "harness", "archived");
     const writes: string[] = [];
     const service = makeLocalControllerService({
       rootDir,
@@ -33,6 +34,7 @@ test("local controller service reads projection and writes through injected task
     const list = service.getTasks();
     assert.equal(list.ok, true);
     assert.equal(list.tasks.length, 1);
+    assert.deepEqual(list.tasks.map((task) => task.taskId), ["task-1"]);
 
     const detail = await service.getTaskDetail({ taskId: "task-1" });
     assert.equal(detail.ok, true);
@@ -113,7 +115,7 @@ test("local controller service honors explicit authored root for reads and write
   }
 });
 
-function writeTaskIndex(rootDir: string, taskId: string, title: string, status: string, authoredRoot = "harness"): void {
+function writeTaskIndex(rootDir: string, taskId: string, title: string, status: string, authoredRoot = "harness", packageDisposition = "active"): void {
   mkdirSync(path.join(rootDir, authoredRoot, "tasks", taskId), { recursive: true });
   writeFileSync(path.join(rootDir, authoredRoot, "tasks", taskId, "INDEX.md"), [
     "---",
@@ -129,7 +131,7 @@ function writeTaskIndex(rootDir: string, taskId: string, title: string, status: 
     "  url: ",
     "  bindingCreatedAt: 2026-06-12T00:00:00.000Z",
     "  bindingFingerprint: sha256:test",
-    "packageDisposition: active",
+    `packageDisposition: ${packageDisposition}`,
     "vertical: default",
     "preset: default",
     "---",

--- a/packages/cli/src/cli/command-spec/command-spec-migration-diagnostics.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-migration-diagnostics.ts
@@ -300,7 +300,7 @@ export const migrationDiagnosticsCommandSpecs = defineCommandSpecs([
   },
   {
     "kind": "graph",
-    "usage": "graph [--out <path>] [--focus <entity-ref>] [--projection <path>] [--json]",
+    "usage": "graph [--out <path>] [--focus <entity-ref>] [--projection <path>] [--include-archived] [--json]",
     "summary": "Generate a self-contained relation graph HTML panorama from the SQLite projection, with optional F5 cascade focus.",
     "examples": ["harness-anything graph --focus decision/dec_LEDGER_E51 --out .harness/generated/graph-panorama/index.html --json"],
     "parserId": "graph",

--- a/packages/cli/src/cli/parsers/graph.ts
+++ b/packages/cli/src/cli/parsers/graph.ts
@@ -14,7 +14,8 @@ export function parseGraphArgs(args: ReadonlyArray<string>, rootDir: string, jso
         kind: "graph",
         outputPath: readOption(args, "--out"),
         focus: readOption(args, "--focus"),
-        projectionPath: readOption(args, "--projection")
+        projectionPath: readOption(args, "--projection"),
+        includeArchived: args.includes("--include-archived")
       }
     }
   };

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -234,7 +234,7 @@ export interface ParsedCommand {
     | { readonly kind: "diagnostics-command-usage" }
     | { readonly kind: "worktree-create"; readonly taskId: string; readonly agent?: string; readonly branchPrefix?: string; readonly baseRef?: string; readonly worktreePath?: string }
     | { readonly kind: "worktree-status"; readonly taskId: string }
-    | { readonly kind: "graph"; readonly outputPath?: string; readonly focus?: string; readonly projectionPath?: string }
+    | { readonly kind: "graph"; readonly outputPath?: string; readonly focus?: string; readonly projectionPath?: string; readonly includeArchived: boolean }
     | { readonly kind: "help"; readonly commandKind?: string; readonly commandPrefix?: ReadonlyArray<string> }
     | { readonly kind: "entity-list" }
     | { readonly kind: "capabilities"; readonly entityKind?: string }

--- a/packages/cli/src/commands/graph-panorama.ts
+++ b/packages/cli/src/commands/graph-panorama.ts
@@ -33,6 +33,9 @@ export function generateGraphPanorama(input: GenerateGraphPanoramaInput = {}): R
   const rootDir = path.resolve(input.rootDir ?? process.cwd());
   const projectionPath = path.resolve(rootDir, input.projectionPath ?? defaultProjectionPath);
   const outputPath = path.resolve(rootDir, input.outputPath ?? defaultOutputPath);
+  if (!existsSync(projectionPath)) {
+    throw new Error(`Projection database not found: ${projectionPath}`);
+  }
   const includeArchived = input.includeArchived === true;
   const visibility = readGraphVisibility(projectionPath, includeArchived);
   const graphRows = applyGraphVisibility(
@@ -94,6 +97,9 @@ function readGraphVisibility(projectionPath: string, includeArchived: boolean): 
   if (includeArchived) return { includeArchived, archivedTaskIds: new Set() };
   const db = new DatabaseSync(projectionPath, { readOnly: true });
   try {
+    if (!hasColumn(db, "task_projection", "package_disposition")) {
+      return { includeArchived, archivedTaskIds: new Set() };
+    }
     return {
       includeArchived,
       archivedTaskIds: new Set(safeAll(db, "SELECT task_id FROM task_projection WHERE package_disposition != 'active' ORDER BY task_id")
@@ -111,8 +117,12 @@ function readProjectedEntities(
 ): ReadonlyArray<ProjectedEntity> {
   const db = new DatabaseSync(projectionPath, { readOnly: true });
   try {
-    const taskWhere = visibility.includeArchived ? "" : "WHERE package_disposition = 'active'";
-    const tasks = safeAll(db, `SELECT task_id, title, canonical_status AS state, package_disposition FROM task_projection ${taskWhere} ORDER BY task_id`)
+    const hasPackageDisposition = hasColumn(db, "task_projection", "package_disposition");
+    const taskWhere = visibility.includeArchived || !hasPackageDisposition ? "" : "WHERE package_disposition = 'active'";
+    const taskColumns = hasPackageDisposition
+      ? "task_id, title, canonical_status AS state, package_disposition"
+      : "task_id, title, canonical_status AS state, 'active' AS package_disposition";
+    const tasks = safeAll(db, `SELECT ${taskColumns} FROM task_projection ${taskWhere} ORDER BY task_id`)
       .map((row) => ({
         kind: "task",
         ref: `task/${String(row.task_id ?? "")}`,
@@ -134,6 +144,11 @@ function safeAll(db: DatabaseSync, sql: string): ReadonlyArray<Record<string, un
   } catch {
     return [];
   }
+}
+
+function hasColumn(db: DatabaseSync, tableName: string, columnName: string): boolean {
+  return safeAll(db, `PRAGMA table_info(${tableName})`)
+    .some((row) => row.name === columnName);
 }
 
 function applyGraphVisibility(

--- a/packages/cli/src/commands/graph-panorama.ts
+++ b/packages/cli/src/commands/graph-panorama.ts
@@ -12,21 +12,36 @@ interface GenerateGraphPanoramaInput {
   readonly projectionPath?: string;
   readonly outputPath?: string;
   readonly focus?: string;
+  readonly includeArchived?: boolean;
 }
 
 interface GraphRows {
   readonly relationEdges: ReadonlyArray<Record<string, any>>;
   readonly coverageRows: ReadonlyArray<Record<string, any>>;
+  readonly factAnchors: ReadonlyArray<Record<string, any>>;
+}
+
+interface ProjectedEntity {
+  readonly kind: string;
+  readonly ref: string;
+  readonly title: string;
+  readonly state: string;
+  readonly packageDisposition?: string;
 }
 
 export function generateGraphPanorama(input: GenerateGraphPanoramaInput = {}): Record<string, any> {
   const rootDir = path.resolve(input.rootDir ?? process.cwd());
   const projectionPath = path.resolve(rootDir, input.projectionPath ?? defaultProjectionPath);
   const outputPath = path.resolve(rootDir, input.outputPath ?? defaultOutputPath);
-  const graphRows = readFreshGraphRows({ rootDir, projectionPath, usesDefaultProjection: !input.projectionPath });
-  const projectedEntities = readProjectedEntities(projectionPath);
+  const includeArchived = input.includeArchived === true;
+  const visibility = readGraphVisibility(projectionPath, includeArchived);
+  const graphRows = applyGraphVisibility(
+    readFreshGraphRows({ rootDir, projectionPath, usesDefaultProjection: !input.projectionPath }),
+    visibility
+  );
+  const projectedEntities = readProjectedEntities(projectionPath, visibility);
   const cascade = input.focus ? readEntityCascadeImpact({ rootDir, projectionPath, entityRef: input.focus }) : undefined;
-  const model = buildPanoramaModel(graphRows, projectedEntities, { focus: input.focus, cascade });
+  const model = buildPanoramaModel(graphRows, projectedEntities, { focus: input.focus, cascade, visibility });
 
   mkdirSync(path.dirname(outputPath), { recursive: true });
   writeFileSync(outputPath, renderPanoramaHtml(model), "utf8");
@@ -49,7 +64,8 @@ function readFreshGraphRows(input: { readonly rootDir: string; readonly projecti
   const projection = readRelationGraphProjection({ rootDir: input.rootDir, projectionPath: input.projectionPath });
   return {
     relationEdges: projection.edges,
-    coverageRows: projection.coverageRows
+    coverageRows: projection.coverageRows,
+    factAnchors: projection.factAnchors
   };
 }
 
@@ -64,17 +80,46 @@ function readGraphRows(projectionPath: string): GraphRows {
       .prepare("SELECT row_json FROM relation_coverage ORDER BY claim_ref")
       .all()
       .map((record) => JSON.parse(String((record as { row_json: unknown }).row_json)) as Record<string, any>);
-    return { relationEdges, coverageRows };
+    const factAnchors = db
+      .prepare("SELECT row_json FROM task_fact_anchors ORDER BY fact_ref")
+      .all()
+      .map((record) => JSON.parse(String((record as { row_json: unknown }).row_json)) as Record<string, any>);
+    return { relationEdges, coverageRows, factAnchors };
   } finally {
     db.close();
   }
 }
 
-function readProjectedEntities(projectionPath: string): ReadonlyArray<Record<string, string>> {
+function readGraphVisibility(projectionPath: string, includeArchived: boolean): { readonly includeArchived: boolean; readonly archivedTaskIds: ReadonlySet<string> } {
+  if (includeArchived) return { includeArchived, archivedTaskIds: new Set() };
   const db = new DatabaseSync(projectionPath, { readOnly: true });
   try {
-    const tasks = safeAll(db, "SELECT task_id, title, canonical_status AS state FROM task_projection ORDER BY task_id")
-      .map((row) => ({ kind: "task", ref: `task/${String(row.task_id ?? "")}`, title: String(row.title ?? ""), state: String(row.state ?? "") }));
+    return {
+      includeArchived,
+      archivedTaskIds: new Set(safeAll(db, "SELECT task_id FROM task_projection WHERE package_disposition != 'active' ORDER BY task_id")
+        .map((row) => String(row.task_id ?? ""))
+        .filter((taskId) => taskId.length > 0))
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function readProjectedEntities(
+  projectionPath: string,
+  visibility: { readonly includeArchived: boolean }
+): ReadonlyArray<ProjectedEntity> {
+  const db = new DatabaseSync(projectionPath, { readOnly: true });
+  try {
+    const taskWhere = visibility.includeArchived ? "" : "WHERE package_disposition = 'active'";
+    const tasks = safeAll(db, `SELECT task_id, title, canonical_status AS state, package_disposition FROM task_projection ${taskWhere} ORDER BY task_id`)
+      .map((row) => ({
+        kind: "task",
+        ref: `task/${String(row.task_id ?? "")}`,
+        title: String(row.title ?? ""),
+        state: String(row.state ?? ""),
+        packageDisposition: String(row.package_disposition ?? "")
+      }));
     const decisions = safeAll(db, "SELECT decision_id, title, state FROM decision_projection ORDER BY decision_id")
       .map((row) => ({ kind: "decision", ref: `decision/${String(row.decision_id ?? "")}`, title: String(row.title ?? ""), state: String(row.state ?? "") }));
     return [...tasks, ...decisions];
@@ -91,7 +136,29 @@ function safeAll(db: DatabaseSync, sql: string): ReadonlyArray<Record<string, un
   }
 }
 
-function buildPanoramaModel(rows: GraphRows, projectedEntities: ReadonlyArray<Record<string, string>>, options: { readonly focus?: string; readonly cascade?: any }): Record<string, any> {
+function applyGraphVisibility(
+  rows: GraphRows,
+  visibility: { readonly includeArchived: boolean; readonly archivedTaskIds: ReadonlySet<string> }
+): GraphRows {
+  if (visibility.includeArchived || visibility.archivedTaskIds.size === 0) return rows;
+  const relationEdges = rows.relationEdges.filter((edge) => isVisibleEdge(edge, visibility));
+  const factAnchors = rows.factAnchors.filter((anchor) => isVisibleRef(String(anchor.factRef ?? ""), visibility));
+  return {
+    relationEdges,
+    coverageRows: rebuildCoverageRows(rows.coverageRows, relationEdges, factAnchors),
+    factAnchors
+  };
+}
+
+function buildPanoramaModel(
+  rows: GraphRows,
+  projectedEntities: ReadonlyArray<ProjectedEntity>,
+  options: {
+    readonly focus?: string;
+    readonly cascade?: any;
+    readonly visibility: { readonly includeArchived: boolean; readonly archivedTaskIds: ReadonlySet<string> };
+  }
+): Record<string, any> {
   const refs = new Map<string, { readonly ref: string; readonly roles: Set<string> }>();
   for (const edge of rows.relationEdges) {
     addRef(refs, String(edge.sourceRef), "source");
@@ -115,9 +182,9 @@ function buildPanoramaModel(rows: GraphRows, projectedEntities: ReadonlyArray<Re
   const islands = collectIslands(projectedEntities, activeEdges);
   const focus = options.focus ? {
     entityRef: options.focus,
-    incoming: options.cascade?.incoming ?? [],
-    outgoing: options.cascade?.outgoing ?? [],
-    impactedRefs: options.cascade?.impactedRefs ?? []
+    incoming: filterCascadeEdges(options.cascade?.incoming ?? [], options.visibility),
+    outgoing: filterCascadeEdges(options.cascade?.outgoing ?? [], options.visibility),
+    impactedRefs: (options.cascade?.impactedRefs ?? []).filter((ref: unknown) => isVisibleRef(String(ref), options.visibility))
   } : undefined;
   return {
     generatedAt: new Date().toISOString(),
@@ -150,6 +217,91 @@ function addRef(refs: Map<string, { readonly ref: string; readonly roles: Set<st
     return;
   }
   refs.set(ref, { ref, roles: new Set([role]) });
+}
+
+function rebuildCoverageRows(
+  coverageRows: ReadonlyArray<Record<string, any>>,
+  relationEdges: ReadonlyArray<Record<string, any>>,
+  factAnchors: ReadonlyArray<Record<string, any>>
+): ReadonlyArray<Record<string, any>> {
+  const activeEdges = relationEdges.filter((edge) => edge.state === "active");
+  const graph = new Map<string, Record<string, any>[]>();
+  const liveFactRefs = new Set(factAnchors.map((anchor) => String(anchor.factRef ?? "")));
+  const invalidatedFactRefs = new Set(
+    activeEdges
+      .filter((edge) => {
+        const type = String(edge.relationType ?? "");
+        return String(edge.sourceRef ?? "").startsWith("fact/")
+          && String(edge.targetRef ?? "").startsWith("fact/")
+          && (type === "invalidated-by" || type === "supersedes-fact");
+      })
+      .map((edge) => String(edge.targetRef ?? ""))
+  );
+  for (const edge of activeEdges) {
+    const sourceRef = String(edge.sourceRef ?? "");
+    graph.set(sourceRef, [...(graph.get(sourceRef) ?? []), edge]);
+  }
+  return coverageRows.map((row) => {
+    const reachable = firstReachableLiveFact(String(row.claimRef ?? ""), graph, liveFactRefs, invalidatedFactRefs);
+    return reachable
+      ? { ...row, status: "covered", coveringFactRef: reachable.factRef, relationPath: reachable.path }
+      : withoutCoverage(row);
+  });
+}
+
+function firstReachableLiveFact(
+  startRef: string,
+  graph: ReadonlyMap<string, ReadonlyArray<Record<string, any>>>,
+  liveFactRefs: ReadonlySet<string>,
+  invalidatedFactRefs: ReadonlySet<string>
+): { readonly factRef: string; readonly path: ReadonlyArray<string> } | null {
+  const visited = new Set<string>();
+  const queue: Array<{ readonly ref: string; readonly path: ReadonlyArray<string> }> = [{ ref: startRef, path: [] }];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || visited.has(current.ref)) continue;
+    visited.add(current.ref);
+    if (liveFactRefs.has(current.ref) && !invalidatedFactRefs.has(current.ref)) {
+      return { factRef: current.ref, path: current.path };
+    }
+    for (const edge of graph.get(current.ref) ?? []) {
+      const targetRef = String(edge.targetRef ?? "");
+      if (!visited.has(targetRef)) queue.push({ ref: targetRef, path: current.path.concat(String(edge.relationId ?? "")) });
+    }
+  }
+  return null;
+}
+
+function withoutCoverage(row: Record<string, any>): Record<string, any> {
+  const { coveringFactRef: _coveringFactRef, ...rest } = row;
+  return { ...rest, status: "uncovered", relationPath: [] };
+}
+
+function filterCascadeEdges(
+  edges: ReadonlyArray<Record<string, any>>,
+  visibility: { readonly includeArchived: boolean; readonly archivedTaskIds: ReadonlySet<string> }
+): ReadonlyArray<Record<string, any>> {
+  return edges.filter((edge) => isVisibleEdge(edge, visibility));
+}
+
+function isVisibleEdge(
+  edge: Record<string, any>,
+  visibility: { readonly includeArchived: boolean; readonly archivedTaskIds: ReadonlySet<string> }
+): boolean {
+  return isVisibleRef(String(edge.sourceRef ?? ""), visibility)
+    && isVisibleRef(String(edge.targetRef ?? ""), visibility)
+    && isVisibleRef(String(edge.ownerRef ?? ""), visibility);
+}
+
+function isVisibleRef(
+  ref: string,
+  visibility: { readonly includeArchived: boolean; readonly archivedTaskIds: ReadonlySet<string> }
+): boolean {
+  if (visibility.includeArchived) return true;
+  const parts = ref.split("/");
+  if (parts[0] === "task" && parts[1]) return !visibility.archivedTaskIds.has(parts[1]);
+  if (parts[0] === "fact" && parts[1]) return !visibility.archivedTaskIds.has(parts[1]);
+  return true;
 }
 
 function renderPanoramaHtml(model: Record<string, any>): string {
@@ -247,7 +399,7 @@ function renderFocus(focus: Record<string, any>): string {
   ].join("\n");
 }
 
-function collectIslands(projectedEntities: ReadonlyArray<Record<string, string>>, activeEdges: ReadonlyArray<Record<string, any>>): ReadonlyArray<Record<string, string>> {
+function collectIslands(projectedEntities: ReadonlyArray<ProjectedEntity>, activeEdges: ReadonlyArray<Record<string, any>>): ReadonlyArray<ProjectedEntity> {
   const incident = new Set<string>();
   for (const edge of activeEdges) {
     incident.add(baseEntityRef(String(edge.sourceRef ?? "")));

--- a/packages/cli/src/commands/graph.ts
+++ b/packages/cli/src/commands/graph.ts
@@ -36,7 +36,8 @@ export function runGraphCommand(rootDir: string, action: GraphAction): CliResult
       rootDir,
       outputPath: action.outputPath,
       focus: action.focus,
-      projectionPath: action.projectionPath
+      projectionPath: action.projectionPath,
+      includeArchived: action.includeArchived
     }) as GraphToolReport);
     return {
       ok: true,

--- a/packages/cli/test/graph-cli.test.ts
+++ b/packages/cli/test/graph-cli.test.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { deriveRelationId } from "../../kernel/src/index.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
@@ -37,7 +38,52 @@ test("CLI graph writes relation graph HTML from projection and embeds F5 cascade
   });
 });
 
-function writeTask(rootDir: string, taskId: string, title: string): void {
+test("CLI graph hides archived task refs by default and can include them explicitly", () => {
+  withTempRoot((rootDir) => {
+    writeTask(rootDir, "task-active", "Active", {
+      relations: [
+        relationLine("task/task-active", "task/task-connected", "active edge"),
+        relationLine("task/task-active", "task/task-archived", "archived edge")
+      ]
+    });
+    writeTask(rootDir, "task-connected", "Connected");
+    writeTask(rootDir, "task-active-island", "Active Island");
+    writeTask(rootDir, "task-archived", "Archived", { packageDisposition: "archived" });
+    writeTask(rootDir, "task-archived-island", "Archived Island", { packageDisposition: "archived" });
+    runJson(rootDir, ["task", "list"]);
+
+    const visible = runJson(rootDir, ["graph", "--out", ".harness/generated/graph-panorama/active.html"]);
+    const visibleHtml = readFileSync(path.join(rootDir, ".harness/generated/graph-panorama/active.html"), "utf8");
+
+    assert.equal(visible.ok, true);
+    assert.equal(visible.rows, 1);
+    assert.equal(visible.report.summary.islands, 1);
+    assert.match(visibleHtml, /task\/task-active-island/u);
+    assert.doesNotMatch(visibleHtml, /task\/task-archived/u);
+    assert.doesNotMatch(visibleHtml, /task\/task-archived-island/u);
+
+    const withArchived = runJson(rootDir, ["graph", "--include-archived", "--out", ".harness/generated/graph-panorama/all.html"]);
+    const withArchivedHtml = readFileSync(path.join(rootDir, ".harness/generated/graph-panorama/all.html"), "utf8");
+
+    assert.equal(withArchived.ok, true);
+    assert.equal(withArchived.rows, 2);
+    assert.equal(withArchived.report.summary.islands, 2);
+    assert.match(withArchivedHtml, /task\/task-archived/u);
+    assert.match(withArchivedHtml, /task\/task-archived-island/u);
+  });
+});
+
+function relationLine(source: string, target: string, rationale: string): string {
+  const relation = { source, target, type: "relates" as const, direction: "directed" as const };
+  return `- {relation_id: ${deriveRelationId(relation)}, source: ${source}, target: ${target}, type: relates, strength: weak, direction: directed, origin: declared, rationale: "${rationale}", state: active}`;
+}
+
+function writeTask(
+  rootDir: string,
+  taskId: string,
+  title: string,
+  options: { readonly packageDisposition?: string; readonly relations?: ReadonlyArray<string> } = {}
+): void {
   const taskDir = path.join(rootDir, "harness/tasks", `${taskId}-fixture`);
   mkdirSync(taskDir, { recursive: true });
   writeFileSync(path.join(taskDir, "INDEX.md"), [
@@ -54,9 +100,10 @@ function writeTask(rootDir: string, taskId: string, title: string): void {
     "  url: ",
     "  bindingCreatedAt: 2026-07-04T00:00:00.000Z",
     "  bindingFingerprint: sha256:4d1771ef6e83619eb8a82f1593bf118383084665fc58f634072d379178d525d7",
-    "packageDisposition: active",
+    `packageDisposition: ${options.packageDisposition ?? "active"}`,
     "vertical: software/coding",
     "preset: standard-task",
+    ...(options.relations ? ["relations:", ...options.relations.map((relation) => `  ${relation}`)] : []),
     "---",
     "",
     `# ${title}`,

--- a/packages/gui/src/api/view-model.ts
+++ b/packages/gui/src/api/view-model.ts
@@ -77,7 +77,8 @@ export const guiTaskProjectionFields = [
   "title",
   "parentTaskId",
   "coordinationStatus",
-  "closeoutReadiness"
+  "closeoutReadiness",
+  "packageDisposition"
 ] as const satisfies ReadonlyArray<keyof TaskProjectionRow>;
 
 const viewOrder: readonly GuiViewId[] = ["board", "list", "detail", "doc-viewer", "review-queue", "graph"];
@@ -105,7 +106,7 @@ export function buildGuiViewModel(rows: readonly GuiTaskRow[]): GuiViewModel {
 }
 
 export function buildGuiViewModelFromTaskProjection(rows: readonly TaskProjectionRow[]): GuiViewModel {
-  return buildGuiViewModel(rows.map(toGuiTaskRow));
+  return buildGuiViewModel(rows.filter((row) => row.packageDisposition === "active").map(toGuiTaskRow));
 }
 
 export function readGuiTaskListResult(result: unknown): GuiTaskListReadResult {
@@ -118,6 +119,7 @@ export function readGuiTaskListResult(result: unknown): GuiTaskListReadResult {
   for (const task of result.tasks) {
     const row = readGuiTaskRow(task);
     if (!row.ok) return row;
+    if ((task as TaskProjectionRow).packageDisposition !== "active") continue;
     rows.push(row.row);
   }
   return {
@@ -232,6 +234,7 @@ function isSqliteTaskProjectionRow(value: unknown): value is TaskProjectionRow {
     && typeof value.title === "string"
     && typeof value.coordinationStatus === "string"
     && typeof value.closeoutReadiness === "string"
+    && typeof value.packageDisposition === "string"
     && (value.parentTaskId === undefined || typeof value.parentTaskId === "string");
 }
 

--- a/packages/gui/test/renderer-app-model.vitest.ts
+++ b/packages/gui/test/renderer-app-model.vitest.ts
@@ -33,7 +33,8 @@ describe("renderer app model", () => {
   it("builds task shell views from sqlite-task-row/v1 fields only", () => {
     const rows = [
       taskRow({ taskId: "task-child", title: "Child", parentTaskId: "task-parent", coordinationStatus: "blocked" }),
-      taskRow({ taskId: "task-parent", title: "Parent", closeoutReadiness: "ready" })
+      taskRow({ taskId: "task-parent", title: "Parent", closeoutReadiness: "ready" }),
+      taskRow({ taskId: "task-archived", title: "Archived", packageDisposition: "archived" })
     ];
 
     const model = buildGuiViewModelFromTaskProjection(rows);
@@ -53,7 +54,10 @@ describe("renderer app model", () => {
   it("reads task route results defensively without depending on optional route fields", () => {
     const list = readGuiTaskListResult({
       ok: true,
-      tasks: [taskRow({ taskId: "task-1", title: "One" })]
+      tasks: [
+        taskRow({ taskId: "task-1", title: "One" }),
+        taskRow({ taskId: "task-archived", title: "Archived", packageDisposition: "archived" })
+      ]
     });
     const detail = readGuiTaskDetailResult({
       ok: true,
@@ -65,6 +69,7 @@ describe("renderer app model", () => {
 
     expect(list).toMatchObject({ ok: true, warnings: [] });
     expect(list.ok && list.rows[0]).toMatchObject({ taskId: "task-1", title: "One" });
+    expect(list.ok && list.rows.map((row) => row.taskId)).toEqual(["task-1"]);
     expect(detail.ok && detail.documents).toEqual([{ path: "INDEX.md" }]);
     expect(document).toEqual({ ok: true, taskId: "task-1", path: "INDEX.md", body: "" });
     expect(invalid).toEqual({

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -461,12 +461,12 @@
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/graph-panorama.ts#mkdirSync@31:3",
+        "value": "packages/cli/src/commands/graph-panorama.ts#mkdirSync@49:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/graph-panorama.ts#writeFileSync@32:3",
+        "value": "packages/cli/src/commands/graph-panorama.ts#writeFileSync@50:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },


### PR DESCRIPTION
# English

## Summary

First step of the "retire means soft-delete" semantics: archived entities now disappear from default read surfaces while remaining fully readable on explicit request. `ha graph` gains `--include-archived`; its default output now excludes archived task/fact refs from edges, islands, focus cascade, and coverage. The GUI data bridge inherits the same active-only defaults. Background: after D3 archived 118 terminal task islands, `ha graph` island counts did not move at all (245 before and after) because the graph still included archived refs — archiving that changes nothing on the monitoring surface defeats its purpose.

## What Changed

- `packages/cli/src/commands/graph.ts` / `graph-panorama.ts` / `parsers/graph.ts`: default graph excludes archived task refs, archived task-owned fact refs, edges touching them, island entities, and focus cascade refs; coverage recomputed over the filtered graph; new `--include-archived` flag reads back the full projection.
- `packages/application/src/local-controller-service.ts`: GUI data bridge `getTasks()` and `rebuildGovernance()` switch to `queryTaskProjection` with default filters (active-only) instead of raw projection reads.
- `packages/gui/src/api/view-model.ts`: renderer model defensively drops archived rows if a backend ever returns them.
- Tests: graph CLI and controller-service coverage extended with archived-row fixtures asserting default exclusion and explicit readback.
- Verified as already correct (no change needed): `ha task list` default excludes archived via `taskWhereClause`; legacy in-memory filter ditto.

## Task And Scope

- Harness task: task_01KX0KKMQSCGFSP4S63XKGHGJ0 (retire visibility step 1)
- Branch: codex/retire-visibility
- Public scope: graph CLI read surface, GUI data bridge defaults, renderer defensive filter, tests
- Private planning/evidence updated: yes
- Out of scope: physical deletion (never), task show / relation list surfaces (parallel lane, merged as #460), decision read semantics.

## Version Impact

- Version: no version change because this adjusts unpublished CLI/GUI read defaults only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_01KX0KKMQSCGFSP4S63XKGHGJ0, scheduling decision dec_mrbx9jhc (Wave-1 lane 4)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: f55e439 (merge of #460)
- Branch merge-base with `origin/main`: f55e439 (rebased after #460 merged)
- Last `git fetch origin` time: 2026-07-08 (this tick)
- Sync method: rebase
- Public diff command: `git diff origin/main..codex/retire-visibility`
- Private evidence commit/path: harness ledger task package (task_plan/closeout salvaged to canonical; progress recorded by CEO due to worktree ledger-resolution gap)
- Reviewer evidence path: task package closeout.md / review.md
- GitHub Actions `rewrite-ci` run URL: pending (will run on this PR)
- [x] `npm run check` (via `npm run check:local` post-rebase, 15/15 steps, fast tier, 22.0s)
- [x] `npm run typecheck` (standalone pass + within check:local)
- [x] `npm test` (fast+contract tiers within check:local; targeted `node --test` on controller-service and graph-cli suites passed; integration tier delegated to cloud CI)
- [ ] `npm ci` — not run locally; worktree seeded from verified root node_modules
- [x] `npm run harness:check-import-boundaries` (within check:local)
- [x] `npm run harness:scan-forbidden-symbols` (within check:local)
- [x] `npm run harness:check-private-boundary` (within check:local)
- [x] `npm run harness:check-package-policy` (within check:local)
- [x] `npm run harness:check-implementation-contracts` (within check:local)
- [x] `npm run harness:check-schema-contracts` (within check:local)
- [x] `npm run harness:check-legacy-intake-readiness` (within check:local)
- [x] `npm run harness:smoke-cli-package` (within check:local)
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR
- Not run: full local integration suite (delegated to cloud CI per local-check throttling policy)

## Review Evidence

- Self-review: worker inventoried every read surface (task list / graph / GUI bridge / renderer) and recorded which already excluded archived vs which needed the fix
- Reviewer subagent: not used this round; Codex review bot findings will be ground-truthed on this PR
- Human review: CEO semantic acceptance — soft-delete invariant preserved (no physical deletion; `--include-archived` full readback), scope boundaries respected; CEO also amended the branch to remove task-package files accidentally committed to the public repo (workers cannot write the private ledger from worktrees — root cause recorded as a fact on the task)
- Blocking findings: none

## Residual Risk

- Island-count reduction under the new semantics is verified against worktree fixtures; the canonical-ledger before/after comparison will be recorded as a fact after merge (old-semantics baseline already recorded: 245 → 241 after CEO edge backfill).
- GUI renderer filter is defensive only; authoritative filtering lives in the data bridge.

## References

- Task: task_01KX0KKMQSCGFSP4S63XKGHGJ0
- Evidence: task package closeout (read-surface inventory, verification transcript), root-cause fact on ledger-resolution gap
- Review: task package review.md

---

# 中文

## 概要

「retire=假删除」语义第一步:归档实体从默认读面主动消失,显式请求仍完整可读。`ha graph` 新增 `--include-archived`;默认输出从边、孤岛、focus 级联、coverage 中排除 archived task/fact refs。GUI 数据桥继承同样的 active-only 默认。背景:D3 归档 118 个终态任务孤岛后,`ha graph` 的孤岛计数纹丝不动(前后都是 245),因为图仍纳入 archived refs——归档了监测面却不变,归档等于白做。

## 改动内容

- `packages/cli/src/commands/graph.ts` / `graph-panorama.ts` / `parsers/graph.ts`:默认图排除 archived task refs、archived task 名下 fact refs、触及它们的边、孤岛实体、focus 级联;coverage 按过滤后图重算;新增 `--include-archived` 读回全量投影。
- `packages/application/src/local-controller-service.ts`:GUI 数据桥 `getTasks()` 与 `rebuildGovernance()` 改走 `queryTaskProjection` 默认过滤(active-only),不再裸读投影。
- `packages/gui/src/api/view-model.ts`:渲染器模型防御性丢弃 archived 行。
- 测试:graph CLI 与 controller-service 用 archived 行 fixture 断言默认排除+显式读回。
- 核实无需改动:`ha task list` 经 `taskWhereClause` 本就默认排除 archived;legacy 内存过滤同。

## 任务与范围

- Harness 任务:task_01KX0KKMQSCGFSP4S63XKGHGJ0(retire 消失语义第一步)
- 分支:codex/retire-visibility
- 公开范围:graph CLI 读面、GUI 数据桥默认、渲染器防御过滤、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:物理删除(永不)、task show / relation list 读面(并行线,已作为 #460 合入)、decision 读语义。

## 版本影响

- 版本:不改版本,原因是仅调整未发布的 CLI/GUI 读默认
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:task_01KX0KKMQSCGFSP4S63XKGHGJ0、排期决策 dec_mrbx9jhc(Wave-1 第④线)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:f55e439(#460 合并提交)
- 当前分支与 `origin/main` 的 merge-base:f55e439(#460 合入后已 rebase)
- 最近一次 `git fetch origin` 时间:2026-07-08(本 tick)
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main..codex/retire-visibility`
- 私有证据 commit/path:内层 ledger 任务包(task_plan/closeout 已抢救回 canonical;progress 因 worktree 台账解析缺口由 CEO 代录)
- Reviewer 证据路径:任务包 closeout.md / review.md
- GitHub Actions `rewrite-ci` run URL:待本 PR CI 跑出后补
- [x] `npm run check`(rebase 后经 `npm run check:local`,15/15 步,fast 档,22.0s)
- [x] `npm run typecheck`(独立跑过 + 含于 check:local)
- [x] `npm test`(fast+contract 档含于 check:local;controller-service 与 graph-cli 套件定向 `node --test` 通过;integration 档交云端 CI)
- [ ] `npm ci` —— 本地未跑;worktree 依赖从已验证的仓库根播种
- [x] `npm run harness:check-import-boundaries`(含于 check:local)
- [x] `npm run harness:scan-forbidden-symbols`(含于 check:local)
- [x] `npm run harness:check-private-boundary`(含于 check:local)
- [x] `npm run harness:check-package-policy`(含于 check:local)
- [x] `npm run harness:check-implementation-contracts`(含于 check:local)
- [x] `npm run harness:check-schema-contracts`(含于 check:local)
- [x] `npm run harness:check-legacy-intake-readiness`(含于 check:local)
- [x] `npm run harness:smoke-cli-package`(含于 check:local)
- [ ] GitHub Actions `rewrite-ci` passed —— 本 PR 待跑
- 未运行:完整本地 integration 套件(按本地检查限流政策交云端 CI)

## 审查证据

- 自查:worker 逐面盘点全部读面(task list / graph / GUI 桥 / 渲染器),记录哪些本就排除、哪些需修
- Reviewer subagent:本轮未用;Codex review bot 的 findings 将在本 PR 上逐条 ground-truth
- 人工审查:CEO 语义验收——假删除不变量守住(无物理删除;`--include-archived` 全量读回),分工边界守住;CEO 另 amend 剥除了误 commit 进公开仓的任务包文件(worker 无法从 worktree 写私有 ledger,根因已落 fact)
- 阻塞发现:无

## 残余风险

- 新语义下孤岛数下降在 worktree fixture 层验证;canonical 台账的前后对比在合并后落 fact(旧语义基线已记:245→CEO 补边后 241)。
- 渲染器过滤仅为防御;权威过滤在数据桥层。

## 关联材料

- 任务:task_01KX0KKMQSCGFSP4S63XKGHGJ0
- 证据:任务包 closeout(读面盘点、验证记录)、台账解析缺口根因 fact
- 审查:任务包 review.md

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
