### PR TITLE
feat: claim-check blob channel for session exports

### DIFF
--- a/A6-REPORT.md
+++ b/A6-REPORT.md
@@ -1,0 +1,97 @@
+# MC-A6 Claim-Check Blob Channel Report
+
+## 设计定稿
+
+CEO裁决后继续采用 v0 git-tracked `harness/objects/sha256/<2>/<62>` 布局。
+
+### 存储布局
+
+- v0 object root: `harness/objects/`
+- digest namespace: `harness/objects/sha256/`
+- object path: `harness/objects/sha256/<first-2-hex>/<remaining-62-hex>`
+- ref format: repo-root-relative portable path, for example `harness/objects/sha256/ab/cdef...`
+- write semantics: immutable content addressing. Writer computes sha256 over exact bytes, writes durably, verifies bytes after rename, and never overwrites an existing object with different content.
+- dedupe semantics: same bytes map to the same object path; repeated writes return the same ref and do not create another object.
+- v0 explicitly does not implement GC, chunking, remote backend, or migration of old records.
+
+### Journal payload schema
+
+For `machine_artifact_write`, keep the existing `boundary` and materialized `path`, but replace inline `body` with a generic claim-check descriptor:
+
+```json
+{
+  "boundary": "provenance-session",
+  "path": "harness/sessions/<sessionId>.md",
+  "bodyRef": {
+    "ref": "harness/objects/sha256/<aa>/<62-hex>",
+    "sha256": "<64-hex>",
+    "size": 12345,
+    "mediaType": "text/markdown; charset=utf-8"
+  }
+}
+```
+
+Compatibility rule: `machine_artifact_write` apply/read paths continue accepting legacy `{ "body": "..." }` payloads. New session exporter payloads use `bodyRef` only; no duplicate body or excerpt is written into the journal payload.
+
+### Generic primitive shape
+
+The store layer exposes a generic content-addressed blob primitive, not a session-specific helper:
+
+- `writeContentAddressedBlob(rootInput, body, mediaType) -> { ref, sha256, size, mediaType }`
+- `readContentAddressedBlob(rootInput, descriptor) -> bytes after sha256 + size verification`
+- `readContentAddressedTextBlob(rootInput, descriptor) -> UTF-8 text after sha256 + size verification`
+- `machine_artifact_write` can materialize any text artifact from a descriptor once future callers adopt it.
+
+## 测试证据
+
+Verification run:
+
+- `npm run typecheck` -> pass.
+- `node --test --experimental-strip-types packages/application/test/provenance-session-exporter.test.ts packages/kernel/test/store/crash-before-watermark.test.ts` -> 15 tests pass.
+- `node --test --experimental-strip-types packages/application/test/provenance-session-exporter.test.ts` -> 10 tests pass after final test import cleanup.
+- `npm run check:local` -> pass after rebase to latest `origin/main`, fast tier, 15 steps, 18.6s.
+- `node tools/check-bypass-write-boundary.mjs` -> pass after allowlist line update for durable bytes write, current=125 previous=124 delta=1.
+- `node tools/check-duplicate-definitions.mjs` -> pass.
+- `node tools/check-kernel-dead-exports.mjs` -> pass.
+
+Covered behaviors:
+
+- session exporter journal payload stores `bodyRef` and does not contain inline transcript text.
+- blob ref can be read back and matches the materialized session markdown.
+- identical export content dedupes to one object path.
+- corrupted blob read fails on sha256 mismatch.
+- legacy inline `body` machine artifact recovery remains compatible.
+
+Broad `tools/check-*.mjs` loop was also run. It exposed the three task-related static failures above, all fixed and rerun green. The same broad loop also hit non-task/precondition failures: `check-pr-body-bilingual.mjs` needs a PR body, `check-pr-governance.mjs` needs changed-file inputs, `check-supply-chain.mjs` failed on npm registry/socket and existing GUI dependency state, and `check-cli-structure.mjs` reported the pre-existing `packages/cli/src/commands/core/task-query.ts` line-count issue (origin/main has 301 lines). Those were not changed in this task.
+
+## 体积数据
+
+Pre-implementation runtime source-log samples:
+
+- Recent Codex runtime JSONL samples under `~/.codex/sessions`, last 50 files: largest observed files were 7.05 MB, 7.32 MB, 10.96 MB, 13.39 MB, 13.53 MB, and 15.17 MB.
+- Recent Claude JSONL samples under `~/.claude/projects`, last 50 files: largest observed files were 0.77 MB, 0.80 MB, 1.00 MB, 1.86 MB, and 5.31 MB.
+- This worktree had no pre-existing `harness/sessions/*.md` samples.
+
+Post-implementation real export measurement, using a real Codex runtime log source and a temporary harness root:
+
+- exported session: `490b91f6-8b2c-466c-aa56-1d21f50bc6c8`
+- rendered markdown size: 682 bytes
+- blob size: 682 bytes
+- bodyRef: `harness/objects/sha256/0c/a22a9811820a61a0c01cd1c818af7e5e008f0711219075a5aad456324cca42`
+
+This is a single measured export, not an upper-bound claim.
+
+## 残留风险
+
+CEO裁决理由,原样引用:
+
+1. 内层 ledger 是 master 单副本、无 remote、永不 clone/fetch——git 历史膨胀的代价≈本地磁盘,当前可接受;git 化换来持久性(ledger 的备份面=这个 git 仓)。
+2. 内容寻址天然去重,增长有界于「不同内容的导出数」。
+3. ledger 远程化(fleet 阶段)本来就是既定的后端重裁点:届时 blob 换外部/远程存储,接口(四元组 {ref,sha256,size,mediaType})不变,旧 blob 留在本地历史不迁移。
+4. 你采样的 15MB 是 runtime JSONL 源日志,不是渲染后的 markdown 导出体积——若实现后能顺手跑一次真实导出,把实际体积记进 residual risk;跑不了就标 unverified。
+
+Remaining risks:
+
+- No GC in v0; orphaned content-addressed objects can accumulate.
+- No chunking or remote backend in v0; very large unique exports still become single git-tracked blobs.
+- Existing inline journal records are not migrated; compatibility is read/apply only.

--- a/packages/application/src/provenance-session-exporter.ts
+++ b/packages/application/src/provenance-session-exporter.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { Effect } from "effect";
 import type { ArtifactStore, CurrentSessionProbePort, CurrentSessionRef, CurrentSessionRuntime, CurrentSessionSource, WriteCoordinator, WriteError } from "../../kernel/src/index.ts";
-import { moduleEntityId, readFrontmatter, readScalar, resolveHarnessLayout, stablePayloadHash, writeCoordinatedPayload, type HarnessLayoutInput } from "../../kernel/src/index.ts";
+import { moduleEntityId, readFrontmatter, readScalar, resolveHarnessLayout, stablePayloadHash, writeContentAddressedBlob, writeCoordinatedPayload, type HarnessLayoutInput } from "../../kernel/src/index.ts";
 import { discoverRuntimeSessions, displayRuntimePath, resolveRuntimeConversation, type RuntimeConversation, type RuntimeConversationMessage } from "./runtime-session-logs.ts";
 
 export interface ProvenanceSessionExporterOptions {
@@ -54,6 +54,7 @@ export interface ProvenanceSessionExporter {
 }
 
 const sessionSchema = "provenance-session/v1";
+const sessionMediaType = "text/markdown; charset=utf-8";
 const safeSessionIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
 
 export function makeProvenanceSessionExporter(options: ProvenanceSessionExporterOptions): ProvenanceSessionExporter {
@@ -89,6 +90,11 @@ function writeSessionDocument(
   return Effect.gen(function* () {
     const target = resolveSessionPath(rootInput, session.sessionId);
     const conversation = yield* resolveRuntimeConversation(session, options);
+    const body = renderSessionMarkdown(session, conversation);
+    const bodyRef = yield* Effect.try({
+      try: () => writeContentAddressedBlob(rootInput, body, sessionMediaType),
+      catch: (cause) => sessionRejection(session.sessionId, cause instanceof Error ? cause.message : String(cause))
+    });
     return yield* writeCoordinatedPayload(options.coordinator, stablePayloadHash, {
       entityId: moduleEntityId("provenance-session"),
       kind: "machine_artifact_write",
@@ -96,7 +102,7 @@ function writeSessionDocument(
       payload: {
         boundary: "provenance-session",
         path: target.rootRelativePath,
-        body: renderSessionMarkdown(session, conversation)
+        bodyRef
       }
     }).pipe(
       Effect.map(() => ({

--- a/packages/application/test/provenance-session-exporter.test.ts
+++ b/packages/application/test/provenance-session-exporter.test.ts
@@ -1,11 +1,11 @@
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import assert from "node:assert/strict";
 import test from "node:test";
 import { Effect } from "effect";
 import { makeHumanFallbackSessionProbe, makeProvenanceSessionExporter } from "../src/index.ts";
-import { makeJournaledWriteCoordinator, makeMarkdownArtifactStore, type CurrentSessionRef, type WriteCoordinator, type WriteError } from "../../kernel/src/index.ts";
+import { makeJournaledWriteCoordinator, makeMarkdownArtifactStore, moduleEntityId, type CurrentSessionRef, type WriteCoordinator, type WriteError } from "../../kernel/src/index.ts";
 import type { ProvenanceSessionExporterOptions } from "../src/index.ts";
 import { runEffect, runEffectExit } from "./effect-test-helpers.ts";
 
@@ -124,6 +124,72 @@ test("provenance session exporter renders Codex JSONL conversation text", async 
     assert.match(body, /## Conversation/u);
     assert.match(body, /Codex user original line/u);
     assert.match(body, /Codex assistant original line/u);
+
+    const payload = readOnlyJournalPayload(rootDir);
+    assert.equal(payload.boundary, "provenance-session");
+    assert.equal(payload.path, "harness/sessions/codex-session-1.md");
+    assert.equal("body" in payload, false);
+    assert.equal(JSON.stringify(payload).includes("Codex user original line"), false);
+    const bodyRef = assertContentAddressedBlobRef(payload.bodyRef);
+    assert.equal(bodyRef.mediaType, "text/markdown; charset=utf-8");
+    assert.equal(readFileSync(path.join(rootDir, bodyRef.ref), "utf8"), body);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("provenance session exporter dedupes identical claim-check blobs and verifies corruption", async () => {
+  const rootDir = createHarnessRoot();
+  try {
+    const logsRoot = path.join(rootDir, "runtime-logs", "codex");
+    mkdirSync(logsRoot, { recursive: true });
+    writeFileSync(path.join(logsRoot, "rollout-2026-07-03T00-00-00-codex-session-1.jsonl"), [
+      JSON.stringify({
+        timestamp: "2026-07-03T00:00:01.000Z",
+        type: "event_msg",
+        payload: { type: "user_message", message: "Deduped Codex user line" }
+      })
+    ].join("\n"), "utf8");
+
+    const exporter = makeTestProvenanceSessionExporter(rootDir, {
+      currentSessionProbe: fixedSessionProbe({
+        runtime: "codex",
+        sessionId: "codex-session-1",
+        source: "runtime",
+        detectedAt: "2026-07-03T00:00:00.000Z"
+      }),
+      runtimeLogRoots: { codex: [logsRoot] },
+      now: () => "2026-07-03T00:01:00.000Z"
+    });
+
+    await runEffect(exporter.exportCurrentSession());
+    await runEffect(exporter.exportCurrentSession());
+
+    const payload = readOnlyJournalPayload(rootDir);
+    const bodyRef = assertContentAddressedBlobRef(payload.bodyRef);
+    assert.deepEqual(listObjectFiles(rootDir), [bodyRef.ref]);
+    assert.match(readFileSync(path.join(rootDir, bodyRef.ref), "utf8"), /Deduped Codex user line/u);
+
+    writeFileSync(path.join(rootDir, bodyRef.ref), "corrupted blob", "utf8");
+    const corruptCoordinator = makeJournaledWriteCoordinator({ rootDir });
+    const corruptResult = await runEffect(Effect.either(Effect.gen(function* () {
+      yield* corruptCoordinator.enqueue({
+        opId: "session-export-corrupt-blob",
+        entityId: moduleEntityId("provenance-session"),
+        kind: "machine_artifact_write",
+        payload: {
+          boundary: "provenance-session",
+          path: "harness/sessions/corrupt.md",
+          bodyRef
+        }
+      });
+      yield* corruptCoordinator.flush("explicit");
+    })));
+    assert.equal(corruptResult._tag, "Left");
+    if (corruptResult._tag === "Left") {
+      assert.equal(corruptResult.left._tag, "JournalUnavailable");
+      assert.match(corruptResult.left.cause instanceof Error ? corruptResult.left.cause.message : String(corruptResult.left.cause), /content-addressed blob sha256 mismatch/u);
+    }
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
@@ -373,4 +439,47 @@ function createHarnessRoot(): string {
   mkdirSync(path.join(rootDir, "harness"), { recursive: true });
   writeFileSync(path.join(rootDir, "harness", "harness.yaml"), "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n", "utf8");
   return rootDir;
+}
+
+function readOnlyJournalPayload(rootDir: string): Record<string, unknown> {
+  const payloadRoot = path.join(rootDir, ".harness", "write-journal", "payloads");
+  const payloadFiles = readdirSync(payloadRoot).filter((entry) => entry.endsWith(".json"));
+  assert.equal(payloadFiles.length, 1);
+  return JSON.parse(readFileSync(path.join(payloadRoot, payloadFiles[0]!), "utf8")) as Record<string, unknown>;
+}
+
+interface TestContentAddressedBlobRef {
+  readonly ref: string;
+  readonly sha256: string;
+  readonly size: number;
+  readonly mediaType: string;
+}
+
+function assertContentAddressedBlobRef(value: unknown): TestContentAddressedBlobRef {
+  assert.equal(Boolean(value && typeof value === "object"), true);
+  const candidate = value as Partial<TestContentAddressedBlobRef>;
+  assert.equal(typeof candidate.ref, "string");
+  assert.equal(typeof candidate.sha256, "string");
+  assert.equal(typeof candidate.size, "number");
+  assert.equal(typeof candidate.mediaType, "string");
+  assert.match(candidate.sha256!, /^[0-9a-f]{64}$/u);
+  assert.equal(candidate.ref, `harness/objects/sha256/${candidate.sha256!.slice(0, 2)}/${candidate.sha256!.slice(2)}`);
+  return candidate as TestContentAddressedBlobRef;
+}
+
+function listObjectFiles(rootDir: string): ReadonlyArray<string> {
+  const objectRoot = path.join(rootDir, "harness", "objects");
+  const files: string[] = [];
+  function visit(current: string): void {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath);
+      } else {
+        files.push(path.relative(rootDir, fullPath).split(path.sep).join("/"));
+      }
+    }
+  }
+  visit(objectRoot);
+  return files.sort();
 }

--- a/packages/kernel/src/composition/index.ts
+++ b/packages/kernel/src/composition/index.ts
@@ -1,5 +1,6 @@
 // @slice-activation PLT-Bedrock W1 exposes local kernel implementation factories
 // for application composition roots without making store internals public.
+export { writeContentAddressedBlob } from "../store/content-addressed-blob-store.ts";
 export { makeMarkdownArtifactStore } from "../store/markdown-artifact-store.ts";
 export { makeJournaledWriteCoordinator } from "../store/write-journal-coordinator.ts";
 export { makeLocalLockRegistry } from "../store/local-lock-registry.ts";

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -4,7 +4,7 @@ export * from "./docmap/docmap-unique.ts";
 export * from "./entity/disposition.ts";
 export * from "./entity/field-contracts.ts";
 export * from "./entity/registry.ts";
-export * from "./integrity/stable-hash.ts";
+export { sha256Text, stablePayloadHash, stableStringify } from "./integrity/stable-hash.ts";
 export * from "./layout/index.ts";
 export * from "./markdown/frontmatter.ts";
 export * from "./ports/artifact-store-writer.ts";
@@ -18,7 +18,13 @@ export * from "./schemas/registry.ts";
 export * from "./schemas/common.ts";
 export * from "./schemas/docmap.ts";
 export * from "./schemas/task-schema-resolver.ts";
-export { makeJournaledWriteCoordinator, makeLocalLockRegistry, makeLocalVersionControlSystem, makeMarkdownArtifactStore } from "./composition/index.ts";
+export {
+  makeJournaledWriteCoordinator,
+  makeLocalLockRegistry,
+  makeLocalVersionControlSystem,
+  makeMarkdownArtifactStore,
+  writeContentAddressedBlob
+} from "./composition/index.ts";
 export { writeCoordinatedPayload, writeCoordinatedTaskDocuments } from "./write-coordination/write-helpers.ts";
 export {
   readDaemonRegistry,

--- a/packages/kernel/src/integrity/stable-hash.ts
+++ b/packages/kernel/src/integrity/stable-hash.ts
@@ -4,6 +4,10 @@ export function sha256Text(text: string): string {
   return createHash("sha256").update(text, "utf8").digest("hex");
 }
 
+export function sha256Bytes(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
 export function stablePayloadHash(value: unknown): string {
   return sha256Text(stableStringify(value));
 }

--- a/packages/kernel/src/store/content-addressed-blob-store.ts
+++ b/packages/kernel/src/store/content-addressed-blob-store.ts
@@ -1,0 +1,110 @@
+import path from "node:path";
+import { sha256Bytes } from "../integrity/stable-hash.ts";
+import { type HarnessLayoutInput, resolveHarnessLayout } from "../layout/index.ts";
+import { durableFileExists, readFileBytes, writeFileDurably } from "./write-journal-durable.ts";
+
+export interface ContentAddressedBlobRef {
+  readonly ref: string;
+  readonly sha256: string;
+  readonly size: number;
+  readonly mediaType: string;
+}
+
+const sha256Pattern = /^[0-9a-f]{64}$/u;
+
+export function writeContentAddressedBlob(
+  rootInput: HarnessLayoutInput,
+  body: string | Uint8Array,
+  mediaType: string
+): ContentAddressedBlobRef {
+  const bytes = typeof body === "string" ? Buffer.from(body, "utf8") : Buffer.from(body);
+  const sha256 = sha256Bytes(bytes);
+  const descriptor = descriptorForDigest(rootInput, sha256, bytes.byteLength, mediaType);
+  const targetPath = resolveContentAddressedBlobPath(rootInput, descriptor);
+
+  if (durableFileExists(targetPath)) {
+    verifyBlobBytes(readFileBytes(targetPath), descriptor);
+    return descriptor;
+  }
+
+  writeFileDurably(targetPath, bytes);
+  verifyBlobBytes(readFileBytes(targetPath), descriptor);
+  return descriptor;
+}
+
+export function readContentAddressedBlob(rootInput: HarnessLayoutInput, descriptor: ContentAddressedBlobRef): Uint8Array {
+  const targetPath = resolveContentAddressedBlobPath(rootInput, descriptor);
+  const bytes = readFileBytes(targetPath);
+  verifyBlobBytes(bytes, descriptor);
+  return bytes;
+}
+
+export function readContentAddressedTextBlob(rootInput: HarnessLayoutInput, descriptor: ContentAddressedBlobRef): string {
+  return Buffer.from(readContentAddressedBlob(rootInput, descriptor)).toString("utf8");
+}
+
+export function resolveContentAddressedBlobPath(rootInput: HarnessLayoutInput, descriptor: ContentAddressedBlobRef): string {
+  assertBlobRef(descriptor);
+  const layout = resolveHarnessLayout(rootInput);
+  const expectedRef = descriptorRef(layout.rootDir, blobPathForDigest(layout.authoredRoot, descriptor.sha256));
+  if (descriptor.ref !== expectedRef) {
+    throw new Error(`content-addressed blob ref does not match sha256 layout: ${descriptor.ref}`);
+  }
+  const targetPath = path.resolve(layout.rootDir, descriptor.ref);
+  if (!isPathInsideRoot(layout.rootDir, targetPath)) {
+    throw new Error(`content-addressed blob ref escapes root: ${descriptor.ref}`);
+  }
+  return targetPath;
+}
+
+export function isContentAddressedBlobRef(value: unknown): value is ContentAddressedBlobRef {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<ContentAddressedBlobRef>;
+  return typeof candidate.ref === "string" &&
+    typeof candidate.sha256 === "string" &&
+    typeof candidate.size === "number" &&
+    typeof candidate.mediaType === "string" &&
+    Number.isSafeInteger(candidate.size) &&
+    candidate.size >= 0 &&
+    sha256Pattern.test(candidate.sha256) &&
+    candidate.mediaType.trim().length > 0;
+}
+
+function descriptorForDigest(rootInput: HarnessLayoutInput, sha256: string, size: number, mediaType: string): ContentAddressedBlobRef {
+  if (mediaType.trim().length === 0) throw new Error("content-addressed blob mediaType is required");
+  const layout = resolveHarnessLayout(rootInput);
+  return {
+    ref: descriptorRef(layout.rootDir, blobPathForDigest(layout.authoredRoot, sha256)),
+    sha256,
+    size,
+    mediaType
+  };
+}
+
+function blobPathForDigest(authoredRoot: string, sha256: string): string {
+  assertSha256(sha256);
+  return path.join(authoredRoot, "objects", "sha256", sha256.slice(0, 2), sha256.slice(2));
+}
+
+function descriptorRef(rootDir: string, absolutePath: string): string {
+  return path.relative(rootDir, absolutePath).split(path.sep).join("/");
+}
+
+function assertBlobRef(descriptor: ContentAddressedBlobRef): void {
+  if (!isContentAddressedBlobRef(descriptor)) throw new Error("invalid content-addressed blob ref");
+}
+
+function assertSha256(value: string): void {
+  if (!sha256Pattern.test(value)) throw new Error(`invalid sha256 digest: ${value}`);
+}
+
+function verifyBlobBytes(bytes: Uint8Array, descriptor: ContentAddressedBlobRef): void {
+  const actualSha = sha256Bytes(bytes);
+  if (actualSha !== descriptor.sha256) throw new Error(`content-addressed blob sha256 mismatch: ${descriptor.ref}`);
+  if (bytes.byteLength !== descriptor.size) throw new Error(`content-addressed blob size mismatch: ${descriptor.ref}`);
+}
+
+function isPathInsideRoot(rootPath: string, targetPath: string): boolean {
+  const relative = path.relative(rootPath, targetPath);
+  return relative.length === 0 || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -1,3 +1,4 @@
+export * from "./content-addressed-blob-store.ts";
 export * from "../integrity/stable-hash.ts";
 export * from "./daemon-runtime.ts";
 export * from "./ledger-materializer.ts";

--- a/packages/kernel/src/store/write-journal-durable.ts
+++ b/packages/kernel/src/store/write-journal-durable.ts
@@ -120,12 +120,25 @@ export function writeWatermarkDurably(filePath: string, watermark: WriteWatermar
   writeFileDurably(filePath, JSON.stringify(watermark));
 }
 
-export function writeFileDurably(filePath: string, body: string): void {
+export function durableFileExists(filePath: string): boolean {
+  return existsSync(filePath);
+}
+
+export function readFileBytes(filePath: string): Uint8Array {
+  return readFileSync(filePath);
+}
+
+export function writeFileDurably(filePath: string, body: string | Uint8Array): void {
   mkdirSync(path.dirname(filePath), { recursive: true });
   const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
   const fd = openSync(tempPath, "w");
   try {
-    writeSync(fd, body, null, "utf8");
+    if (typeof body === "string") {
+      writeSync(fd, body, null, "utf8");
+    } else {
+      const buffer = Buffer.from(body);
+      writeSync(fd, buffer, 0, buffer.byteLength, 0);
+    }
     fsyncSync(fd);
   } finally {
     closeSync(fd);

--- a/packages/kernel/src/store/write-journal-operations.ts
+++ b/packages/kernel/src/store/write-journal-operations.ts
@@ -4,6 +4,7 @@ import type { DocumentWrite } from "../ports/artifact-store-writer.ts";
 import type { WriteOp } from "../ports/write-coordinator.ts";
 import type { EntityId } from "../domain/index.ts";
 import { moduleKeyFromEntityId, taskEntityId } from "../domain/index.ts";
+import { isContentAddressedBlobRef, readContentAddressedTextBlob, resolveContentAddressedBlobPath, type ContentAddressedBlobRef } from "./content-addressed-blob-store.ts";
 import {
   createTaskPackagePath,
   type HarnessLayoutInput,
@@ -80,7 +81,11 @@ export function writeOpTouchedPaths(rootInput: HarnessLayoutInput, op: WriteOp):
     return moduleScaffoldWrites(rootInput, op).map((write) => write.targetPath);
   }
   if (op.kind === "machine_artifact_write") {
-    return [machineArtifactWrite(rootInput, op).targetPath];
+    const artifact = machineArtifactWrite(rootInput, op);
+    return [
+      artifact.targetPath,
+      ...(artifact.bodyRef ? [resolveContentAddressedBlobPath(rootInput, artifact.bodyRef)] : [])
+    ];
   }
   if (op.kind === "machine_artifact_append_jsonl") {
     const artifact = machineArtifactJsonlAppend(rootInput, op);
@@ -167,7 +172,8 @@ interface ModuleScaffoldWritePayload {
 interface MachineArtifactWritePayload {
   readonly boundary: MachineArtifactBoundary;
   readonly path: string;
-  readonly body: string;
+  readonly body?: string;
+  readonly bodyRef?: ContentAddressedBlobRef;
 }
 
 interface MachineArtifactAppendJsonlPayload {
@@ -303,14 +309,15 @@ function writeModuleScaffold(rootInput: HarnessLayoutInput, op: WriteOp): void {
   }
 }
 
-function machineArtifactWrite(rootInput: HarnessLayoutInput, op: WriteOp): { readonly targetPath: string; readonly body: string } {
+function machineArtifactWrite(rootInput: HarnessLayoutInput, op: WriteOp): { readonly targetPath: string; readonly body: string; readonly bodyRef?: ContentAddressedBlobRef } {
   const payload = op.payload;
   if (!isMachineArtifactWritePayload(payload)) {
-    rejectWrite(`${op.kind} op requires boundary, path, and body payload: ${op.opId}`, op.entityId);
+    rejectWrite(`${op.kind} op requires boundary, path, and exactly one of body/bodyRef payload: ${op.opId}`, op.entityId);
   }
   return {
     targetPath: resolveMachineArtifactPath(rootInput, payload.boundary, payload.path, op.entityId),
-    body: payload.body
+    body: payload.body ?? readContentAddressedTextBlob(rootInput, payload.bodyRef!),
+    ...(payload.bodyRef ? { bodyRef: payload.bodyRef } : {})
   };
 }
 
@@ -327,13 +334,13 @@ function machineArtifactJsonlAppend(rootInput: HarnessLayoutInput, op: WriteOp):
 }
 
 function isMachineArtifactWritePayload(payload: unknown): payload is MachineArtifactWritePayload {
-  return Boolean(
-    payload &&
-    typeof payload === "object" &&
-    isMachineArtifactBoundary((payload as { readonly boundary?: unknown }).boundary) &&
-    typeof (payload as { readonly path?: unknown }).path === "string" &&
-    typeof (payload as { readonly body?: unknown }).body === "string"
-  );
+  if (!payload || typeof payload !== "object") return false;
+  const candidate = payload as { readonly boundary?: unknown; readonly path?: unknown; readonly body?: unknown; readonly bodyRef?: unknown };
+  const hasBody = typeof candidate.body === "string";
+  const hasBodyRef = isContentAddressedBlobRef(candidate.bodyRef);
+  return isMachineArtifactBoundary(candidate.boundary) &&
+    typeof candidate.path === "string" &&
+    hasBody !== hasBodyRef;
 }
 
 function isMachineArtifactAppendJsonlPayload(payload: unknown): payload is MachineArtifactAppendJsonlPayload & { readonly value: Record<string, unknown> } {

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -204,6 +204,7 @@ const publicRuntimeSurface = [
   "validateTemplateCatalog",
   "validateVerticalDefinition",
   "warning",
+  "writeContentAddressedBlob",
   "writeCoordinatedPayload",
   "writeCoordinatedTaskDocuments"
 ];

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -49,12 +49,12 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#closeSync@131:5",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#closeSync@144:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#closeSync@143:5",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#closeSync@156:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
@@ -64,12 +64,12 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#fsyncSync@129:5",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#fsyncSync@142:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#fsyncSync@141:5",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#fsyncSync@154:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
@@ -79,7 +79,7 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#mkdirSync@124:3",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#mkdirSync@132:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
@@ -89,17 +89,17 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@126:14",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@134:14",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@139:14",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@152:14",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#renameSync@133:3",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#renameSync@146:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
@@ -109,7 +109,12 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#writeSync@128:5",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#writeSync@137:7",
+        "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
+        "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
+      },
+      {
+        "value": "packages/kernel/src/store/write-journal-durable.ts#writeSync@140:7",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
@@ -219,27 +224,27 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@267:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@273:9",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@290:3",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@296:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@301:5",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@307:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@270:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@276:9",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#writeFileSync@268:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#writeFileSync@274:9",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       }


### PR DESCRIPTION
# English

## Summary

Introduce a claim-check channel for large ledger payloads: session exports no longer inline the full transcript body into the write-journal payload. Blobs are written to a content-addressed store (sha256-addressed, git-style fan-out layout) and the journal records only a `{ref, sha256, size, mediaType}` descriptor. This stops journal bloat that is already happening on single-machine use today, and establishes the generic large-artifact write primitive that the remote-ledger document-submission design will reuse.

## What Changed

- `packages/kernel/src/store/content-addressed-blob-store.ts` (new): generic content-addressed blob store, `objects/sha256/<2>/<62>` layout, write-then-verify, immutable blobs, natural dedup for identical content.
- `packages/application/src/provenance-session-exporter.ts`: exporter writes the transcript blob first, then emits a journal payload carrying `bodyRef` instead of an inline `body`.
- `machine_artifact_write` apply path: accepts both legacy inline `{body}` payloads and new `{bodyRef}` descriptors — full backward compatibility with existing journal records, no retroactive migration.
- Bypass-write boundary manifest: line-anchor refresh for the moved durable-journal write sites plus one new anchor for the durable path's internal write (reason recorded in the manifest entry, same style as existing entries). No enforcement removed.
- Tests: exporter payload shape, blob retrieval + sha verification, duplicate-content dedup, corrupt-blob sha-mismatch error, legacy inline-record recovery.

## Task And Scope

- Harness task: task_01KX19GB647G7G9XT5CWHKX5SQ (MC-A6, derived from decision dec_mrc9ef3g CH1-(a))
- Branch: codex/mc-a6-blob-claim-check
- Public scope: kernel blob store + exporter + journal apply path + tests
- Private planning/evidence updated: yes
- Out of scope: GC/retention, chunked upload, remote blob backend (fleet phase), retroactive migration of existing inline records

## Version Impact

- Version: no version change because this is an internal storage-path change with backward-compatible reads
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no (bypass-write manifest changes are line-anchor maintenance plus one documented internal-write registration; no checker semantics or CI configuration modified)
- Protected surface scope: none
- Authority: decision dec_mrc9ef3g (CH1-(a) claim-check for large artifacts, adjudicated 2026-07-09 as immediately actionable); task task_01KX19GB647G7G9XT5CWHKX5SQ
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: latest at push time (rebased onto the merge commit of #474)
- Branch merge-base with `origin/main`: equals `origin/main` (rebased)
- Last `git fetch origin` time: 2026-07-09 (immediately before rebase and push)
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/mc-a6-blob-claim-check`
- Private evidence commit/path: harness task package artifacts (design/report archived)
- Reviewer evidence path: harness task package review.md (private ledger)
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test` (scoped: exporter + legacy recovery suites, 15/15 pass; targeted exporter tests 10/10)
- [x] `npm run harness:check-import-boundaries` (via check:local, green post-rebase)
- [x] `npm run harness:scan-forbidden-symbols` (via check:local:gates static set)
- [x] `npm run harness:check-private-boundary` (via check:local:gates static set)
- [x] `npm run harness:check-package-policy` (via check:local:gates static set)
- [x] `npm run harness:check-implementation-contracts` (via check:local:gates static set)
- [x] `npm run harness:check-schema-contracts` (via check:local:gates static set)
- [x] `npm run harness:check-legacy-intake-readiness` (via check:local:gates static set)
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check`/`typecheck` locally; local `check:local:gates` stopped at `check-supply-chain` on an npm-registry network transient (known flaky offline; every static checker before it passed) — CI's supply-chain job is authoritative on this PR. `check:local` fast tier green (16.5s).

## Review Evidence

- Self-review: worker verified blob write-then-verify, dedup, corrupt-blob rejection, and legacy-record recovery before commit
- Reviewer subagent: not used; CEO reviewed the bypass-write manifest diff line-by-line (anchor moves + one documented registration, no enforcement removal)
- Human review: CEO semantic acceptance against dec_mrc9ef3g (journal carries refs only; storage tension over blob-in-git was escalated mid-task with real size data and adjudicated: v0 keeps the git-tracked object store, backend swap re-decided at fleet phase)
- Blocking findings: none

## Residual Risk

- No GC in v0 (explicit residual; content addressing bounds growth to distinct-content count).
- Large unique exports still become git-tracked blobs in the private ledger repo; acceptable for the no-remote single-copy ledger today, backend swap is the designated fleet-phase re-decision.
- No chunking/remote backend yet; the descriptor interface is designed to survive that swap unchanged.

## References

- Task: task_01KX19GB647G7G9XT5CWHKX5SQ
- Evidence: private harness ledger task package
- Review: private harness ledger task package review.md

---

# 中文

## 概要

为 ledger 大产物引入 claim-check 通道:session 导出不再把完整 transcript 正文内联进 write-journal payload。blob 写入内容寻址存储(sha256 寻址,git 式扇出布局),journal 只记 `{ref, sha256, size, mediaType}` 描述符。根治单机今天就在发生的 journal 膨胀,并立起远程 ledger 文档提交设计将复用的通用大产物写原语。

## 改动内容

- `packages/kernel/src/store/content-addressed-blob-store.ts`(新增):通用内容寻址 blob store,`objects/sha256/<2>/<62>` 布局,写后校验,blob 不可变,同内容天然去重。
- `packages/application/src/provenance-session-exporter.ts`:导出先写 blob,journal payload 携带 `bodyRef` 替代内联 `body`。
- `machine_artifact_write` apply 路径:同时接受旧 `{body}` 与新 `{bodyRef}`——对存量 journal 记录完全向后兼容,不做追溯迁移。
- bypass-write boundary manifest:durable journal 写点的行号锚随代码位移刷新+durable 路径内部新写点按既有格式登记(条目内写明 reason)。未移除任何执法。
- 测试:导出 payload 形态、blob 取回+sha 校验、同内容去重、损坏 blob 报 sha mismatch、旧内联记录恢复。

## 任务与范围

- Harness 任务:task_01KX19GB647G7G9XT5CWHKX5SQ(MC-A6,derives 自 decision dec_mrc9ef3g CH1-(a))
- 分支:codex/mc-a6-blob-claim-check
- 公开范围:kernel blob store+导出器+journal apply 路径+测试
- 私有计划 / 证据是否已更新:yes
- 范围外:GC/retention、分块上传、远程 blob 后端(fleet 阶段)、存量内联记录追溯迁移

## 版本影响

- 版本:不改版本,原因是内部存储路径变更且读路径向后兼容
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no(bypass-write manifest 变更为行号锚维护+一处内部写点登记并记录理由;未修改 checker 语义或 CI 配置)
- protected surface 范围:无
- 依据:decision dec_mrc9ef3g(CH1-(a) 大产物 claim-check,2026-07-09 裁决提前为立即可做);task task_01KX19GB647G7G9XT5CWHKX5SQ
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- `origin/main` 基准 SHA:push 时最新(rebase 到 #474 合并提交之上)
- 当前分支与 `origin/main` 的 merge-base:等于 `origin/main`(已 rebase)
- 最近一次 `git fetch origin` 时间:2026-07-09(rebase 与 push 前)
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...codex/mc-a6-blob-claim-check`
- 私有证据 commit/path:harness 任务包 artifacts(设计与报告已归档)
- Reviewer 证据路径:harness 任务包 review.md(私有 ledger)
- GitHub Actions `rewrite-ci` run URL:待本 PR 的 CI 运行后回填
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test`(范围化:导出器+旧记录恢复套件 15/15;导出器定向测试 10/10)
- [x] `npm run harness:check-import-boundaries`(经 check:local,rebase 后绿)
- [x] `npm run harness:scan-forbidden-symbols`(经 check:local:gates 静态集)
- [x] `npm run harness:check-private-boundary`(经 check:local:gates 静态集)
- [x] `npm run harness:check-package-policy`(经 check:local:gates 静态集)
- [x] `npm run harness:check-implementation-contracts`(经 check:local:gates 静态集)
- [x] `npm run harness:check-schema-contracts`(经 check:local:gates 静态集)
- [x] `npm run harness:check-legacy-intake-readiness`(经 check:local:gates 静态集)
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地未跑全量 `npm run check`/`typecheck`;本地 `check:local:gates` 在 `check-supply-chain` 处因 npm registry 网络抖动停止(已知离线不稳;其前全部静态 checker 通过)——以本 PR CI 的 supply-chain job 为权威。`check:local` fast 档绿(16.5s)。

## 审查证据

- 自查:worker 提交前验证了 blob 写后校验、去重、损坏拒收与旧记录恢复
- Reviewer subagent:未使用;CEO 逐行审了 bypass-write manifest diff(锚位移+一处登记,无执法移除)
- 人工审查:CEO 对 dec_mrc9ef3g 语义验收(journal 只存 ref;blob 进 git 的存储张力任务中带真实体积数据上报并裁决:v0 维持 git-tracked 对象存储,后端更换为 fleet 阶段既定重裁点)
- 阻塞发现:无

## 残余风险

- v0 无 GC(显式残留;内容寻址使增长有界于不同内容数)。
- 大体积唯一导出仍会成为私有 ledger 仓的 git-tracked blob;对当前无 remote 单副本 ledger 可接受,后端更换是 fleet 阶段既定重裁点。
- 暂无分块/远程后端;描述符接口设计为后端更换时不变。

## 关联材料

- 任务:task_01KX19GB647G7G9XT5CWHKX5SQ
- 证据:私有 harness ledger 任务包
- 审查:私有 harness ledger 任务包 review.md

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
