### PR TITLE
fix: route session ledger commits through the write journal

### DIFF
--- a/packages/cli/src/cli/command-spec/command-spec-runtime-docs.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-runtime-docs.ts
@@ -86,7 +86,7 @@ export const runtimeDocsCommandSpecs = defineCommandSpecs([
   {
     "kind": "session-sync",
     "usage": "session sync [--json]",
-    "summary": "Commit existing managed session markdown files under harness/sessions.",
+    "summary": "Synchronize existing managed session markdown files under harness/sessions through the write journal.",
     "examples": ["harness-anything session sync --json"],
     "parserId": "session",
     "runnerId": "session",

--- a/packages/cli/src/commands/core/authored-git.ts
+++ b/packages/cli/src/commands/core/authored-git.ts
@@ -4,43 +4,9 @@ import path from "node:path";
 import { normalizeSlashes } from "../../cli/path.ts";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../../../../kernel/src/index.ts";
 
-export interface AuthoredGitCommitResult {
-  readonly attempted: boolean;
-  readonly committed: boolean;
-  readonly paths: ReadonlyArray<string>;
-  readonly reason?: string;
-}
-
-export function commitAuthoredPaths(
-  rootInput: HarnessLayoutInput,
-  relativePaths: ReadonlyArray<string>,
-  message: string
-): AuthoredGitCommitResult {
-  const layout = resolveHarnessLayout(rootInput);
-  const paths = validateAuthoredRelativePaths(layout.rootDir, layout.authoredRoot, relativePaths);
-  if (paths.length === 0) return { attempted: false, committed: false, paths, reason: "no_paths" };
-  const rootRepo = gitTopLevel(layout.rootDir);
-  const authoredRepo = gitTopLevel(layout.authoredRoot);
-  if (!authoredRepo) return { attempted: false, committed: false, paths, reason: "authored_root_not_git" };
-  if (rootRepo && authoredRepo === rootRepo && isIgnoredByRepo(rootRepo, layout.authoredRoot)) {
-    throw new Error("authored root is ignored by Git but is not a nested Git repository");
-  }
-
-  execFileSync("git", ["-C", layout.authoredRoot, "add", "--force", "--", ...paths], { stdio: "ignore" });
-  const staged = execFileSync("git", ["-C", layout.authoredRoot, "diff", "--cached", "--name-only", "--", ...paths], { encoding: "utf8" })
-    .split(/\r?\n/u)
-    .map((entry) => entry.trim())
-    .filter(Boolean);
-  if (staged.length === 0) return { attempted: true, committed: false, paths, reason: "no_changes" };
-  // materializer-exempt: authored metadata helpers commit directly because they
-  // are outside the WriteCoordinator journal stream.
-  execFileSync("git", ["-C", layout.authoredRoot, "commit", "-m", message], { stdio: "ignore", env: authoredGitEnv() });
-  return { attempted: true, committed: true, paths: staged.map((entry) => normalizeSlashes(entry)) };
-}
-
 export function authoredRelativePath(rootInput: HarnessLayoutInput, absolutePath: string): string {
   const layout = resolveHarnessLayout(rootInput);
-  return normalizeSlashes(path.relative(layout.authoredRoot, absolutePath));
+  return validateAuthoredRelativePaths(layout.rootDir, layout.authoredRoot, [normalizeSlashes(path.relative(layout.authoredRoot, absolutePath))])[0] ?? "";
 }
 
 function validateAuthoredRelativePaths(
@@ -77,16 +43,6 @@ export function gitTopLevel(inputPath: string): string | null {
   }
 }
 
-function isIgnoredByRepo(repoRoot: string, candidatePath: string): boolean {
-  const relativePath = normalizeSlashes(path.relative(normalizeExistingPath(repoRoot), normalizeExistingPath(candidatePath)));
-  try {
-    execFileSync("git", ["-C", repoRoot, "check-ignore", "-q", "--", relativePath], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function normalizeExistingPath(inputPath: string): string {
   const resolved = path.resolve(inputPath);
   if (existsSync(resolved)) return realpathSync.native(resolved);
@@ -100,14 +56,4 @@ function normalizeExistingPath(inputPath: string): string {
     current = parent;
   }
   return path.join(realpathSync.native(current), ...pendingSegments);
-}
-
-function authoredGitEnv(): NodeJS.ProcessEnv {
-  return {
-    ...process.env,
-    GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Harness Anything",
-    GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? "harness@example.invalid",
-    GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Harness Anything",
-    GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "harness@example.invalid"
-  };
 }

--- a/packages/cli/src/commands/core/session.ts
+++ b/packages/cli/src/commands/core/session.ts
@@ -1,12 +1,13 @@
-import { readdirSync, statSync } from "node:fs";
+import { readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import type { CurrentSessionRef } from "../../../../kernel/src/index.ts";
-import { resolveHarnessLayout } from "../../../../kernel/src/index.ts";
+import { moduleEntityId, resolveHarnessLayout, stablePayloadHash, writeContentAddressedBlob, writeCoordinatedPayload } from "../../../../kernel/src/index.ts";
+import type { FlushReport, WriteError } from "../../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult, SessionExportRuntime, SessionExportSource } from "../../cli/types.ts";
 import type { CommandRunner } from "../../cli/runner-registry.ts";
-import { authoredRelativePath, commitAuthoredPaths } from "./authored-git.ts";
+import { authoredRelativePath } from "./authored-git.ts";
 
 type SessionAction = Extract<Parameters<CommandRunner>[1]["action"], {
   readonly kind: "session-export" | "session-backfill" | "session-sync";
@@ -14,7 +15,7 @@ type SessionAction = Extract<Parameters<CommandRunner>[1]["action"], {
 
 export const runSessionCommand: CommandRunner = (context, command) => {
   const action = command.action as SessionAction;
-  if (action.kind === "session-sync") return runSessionSync(context.layoutInput);
+  if (action.kind === "session-sync") return runSessionSync(context);
   if (action.kind === "session-backfill") {
     return context.provenanceSessionExporter.backfillRuntimeSessions({
       ...(action.runtime ? { runtime: action.runtime } : {}),
@@ -22,18 +23,18 @@ export const runSessionCommand: CommandRunner = (context, command) => {
     }).pipe(
       Effect.map((result) => {
         const paths = result.exported.map((entry) => entry.path);
-      const git = acknowledgeCoordinatorCommit(commitAuthoredPaths(context.layoutInput, paths, `session(backfill): ${paths.length} sessions`));
-      const displayPaths = paths.map((entry) => rootRelativeSessionPath(context.layoutInput, entry));
-      return {
-        ok: true,
-        command: "session-backfill",
-        rows: result.exported.length,
-        path: displayPaths[0],
-        warnings: result.warnings,
-        report: {
-          schema: "session-backfill-report/v1",
-          runtime: action.runtime,
-          limit: action.limit,
+        const git = journalGitReport(paths.length > 0, paths, paths.length > 0);
+        const displayPaths = paths.map((entry) => rootRelativeSessionPath(context.layoutInput, entry));
+        return {
+          ok: true,
+          command: "session-backfill",
+          rows: result.exported.length,
+          path: displayPaths[0],
+          warnings: result.warnings,
+          report: {
+            schema: "session-backfill-report/v1",
+            runtime: action.runtime,
+            limit: action.limit,
             exported: result.exported,
             git
           }
@@ -57,7 +58,7 @@ function runSessionExport(
     : context.provenanceSessionExporter.exportCurrentSession();
   return exportEffect.pipe(
     Effect.map((result) => {
-      const git = acknowledgeCoordinatorCommit(commitAuthoredPaths(context.layoutInput, [result.path], `session(export): ${result.session.sessionId}`));
+      const git = journalGitReport(true, [result.path], true);
       const displayPath = rootRelativeSessionPath(context.layoutInput, result.path);
       return {
         ok: true,
@@ -76,11 +77,14 @@ function runSessionExport(
   );
 }
 
-function runSessionSync(rootInput: Parameters<CommandRunner>[0]["layoutInput"]) {
-  return Effect.sync(() => {
-    const paths = listSessionMarkdownPaths(rootInput);
-    const displayPaths = paths.map((entry) => rootRelativeSessionPath(rootInput, entry));
-    const git = commitAuthoredPaths(rootInput, paths, `session(sync): ${paths.length} sessions`);
+function runSessionSync(context: Parameters<CommandRunner>[0]) {
+  return Effect.gen(function* () {
+    const paths = listSessionMarkdownPaths(context.layoutInput);
+    const displayPaths = paths.map((entry) => rootRelativeSessionPath(context.layoutInput, entry));
+    const flush = paths.length === 0
+      ? undefined
+      : yield* writeExistingSessionDocuments(context, paths);
+    const git = journalGitReport(paths.length > 0, paths, flush?.committed ?? false, flush);
     return {
       ok: true,
       command: "session-sync",
@@ -96,15 +100,58 @@ function runSessionSync(rootInput: Parameters<CommandRunner>[0]["layoutInput"]) 
   });
 }
 
-function acknowledgeCoordinatorCommit(git: ReturnType<typeof commitAuthoredPaths>): ReturnType<typeof commitAuthoredPaths> {
-  return git.attempted && git.reason === "no_changes"
-    ? { ...git, committed: true, reason: "already_committed" }
-    : git;
-}
-
 function rootRelativeSessionPath(rootInput: Parameters<CommandRunner>[0]["layoutInput"], authoredRelative: string): string {
   const layout = resolveHarnessLayout(rootInput);
   return path.relative(layout.rootDir, path.join(layout.authoredRoot, authoredRelative)).split(path.sep).join("/");
+}
+
+function writeExistingSessionDocuments(
+  context: Parameters<CommandRunner>[0],
+  paths: ReadonlyArray<string>
+): Effect.Effect<FlushReport, WriteError> {
+  const coordinator = context.makeWriteCoordinator({ kind: "agent", id: "session-sync" });
+  return Effect.gen(function* () {
+    for (const [index, authoredRelativePath] of paths.entries()) {
+      const rootRelativePath = rootRelativeSessionPath(context.layoutInput, authoredRelativePath);
+      const absolutePath = path.join(resolveHarnessLayout(context.layoutInput).rootDir, rootRelativePath);
+      const body = readFileSync(absolutePath, "utf8");
+      const bodyRef = writeContentAddressedBlob(context.layoutInput, body, "text/markdown; charset=utf-8");
+      yield* writeCoordinatedPayload(coordinator, stablePayloadHash, {
+        entityId: moduleEntityId("provenance-session"),
+        kind: "machine_artifact_write",
+        opIdPrefix: `session-sync-${index}`,
+        payload: {
+          boundary: "provenance-session",
+          path: rootRelativePath,
+          bodyRef
+        }
+      }, { flush: false });
+    }
+    return yield* coordinator.flush("explicit");
+  });
+}
+
+function journalGitReport(
+  attempted: boolean,
+  paths: ReadonlyArray<string>,
+  committed: boolean,
+  flush?: FlushReport
+): {
+  readonly attempted: boolean;
+  readonly committed: boolean;
+  readonly coordinator: "write-journal";
+  readonly paths: ReadonlyArray<string>;
+  readonly reason?: string;
+  readonly flush?: FlushReport;
+} {
+  return {
+    attempted,
+    committed,
+    coordinator: "write-journal",
+    paths,
+    ...(!attempted ? { reason: "no_paths" } : {}),
+    ...(flush ? { flush } : {})
+  };
 }
 
 function toExplicitSession(action: Extract<SessionAction, { readonly kind: "session-export" }>): CurrentSessionRef {

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -6,7 +6,6 @@ import {
   makeFactWriteService,
   makeProvenanceSessionExporter,
   makeRuntimeEventLedgerService,
-  type ProvenanceSessionExporterRejected,
   type ProvenanceSessionExportResult
 } from "../../../application/src/index.ts";
 import type { WriteCoordinator } from "../../../kernel/src/index.ts";
@@ -15,7 +14,6 @@ import { toCliError } from "../cli/error-mapper.ts";
 import { actionTaskId } from "../cli/parse-args.ts";
 import { requiresConflictMarkerPreflight, runRegisteredCommand } from "../cli/runner-registry.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
-import { commitAuthoredPaths } from "../commands/core/authored-git.ts";
 import {
   defaultCliAdapterProvider,
   type CliCompositionAdapterProvider
@@ -50,21 +48,7 @@ export async function runRegisteredCommandWithCliComposition(
     }
     return sessionBranchId;
   };
-  const syncExportedSession = (result: ProvenanceSessionExportResult): Effect.Effect<void, ProvenanceSessionExporterRejected> => Effect.try({
-    try: () => {
-      try {
-        commitAuthoredPaths(layoutInput, [result.path], `session(export): ${result.session.sessionId}`);
-      } catch (error) {
-        if (error instanceof Error && error.message === "authored root is ignored by Git but is not a nested Git repository") return;
-        throw error;
-      }
-    },
-    catch: (error) => ({
-      _tag: "ProvenanceSessionExporterRejected" as const,
-      sessionId: result.session.sessionId,
-      reason: error instanceof Error ? error.message : "session git commit failed"
-    })
-  }).pipe(Effect.asVoid);
+  const syncExportedSession = (_result: ProvenanceSessionExportResult): Effect.Effect<void, never> => Effect.void;
 
   const rawMakeWriteCoordinator = options.makeWriteCoordinator ?? ((actor: { readonly kind: "agent" | "human" | "system"; readonly id: string }) =>
     provider.createWriteCoordinator({

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -142,7 +142,7 @@ function daemonUnavailableReceipt(command: ParsedCommand, error: unknown): Comma
     command: command.action.kind,
     error: cliError(
       CliErrorCode.JournalUnavailable,
-      `Daemon unavailable. Use HARNESS_DAEMON_MODE=direct to bypass local client mode, or check 'ha daemon status'. Cause: ${error instanceof Error ? error.message : String(error)}`
+      `Daemon unavailable. Start the daemon with 'ha daemon start' or check 'ha daemon status'. Cause: ${error instanceof Error ? error.message : String(error)}`
     )
   });
   if (receipt.ok) throw new Error("daemon unavailable receipt unexpectedly succeeded");

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -105,6 +105,29 @@ test("concurrent daemon client startup converges on one lock owner and both clie
   });
 });
 
+test("concurrent daemon client writes serialize into linear git history", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    initGitRepo(rootDir);
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
+    const harnessRoot = path.join(rootDir, "harness");
+    const beforeCount = Number(git(harnessRoot, "rev-list", "--count", "HEAD"));
+
+    const [left, right] = await Promise.all([
+      runRawJsonAsync(rootDir, ["new-task", "--title", "Concurrent Daemon Write Left"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "1500" }),
+      runRawJsonAsync(rootDir, ["new-task", "--title", "Concurrent Daemon Write Right"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "1500" })
+    ]);
+
+    assert.equal(left.ok, true);
+    assert.equal(right.ok, true);
+    assert.equal(Number(git(harnessRoot, "rev-list", "--count", "HEAD")), beforeCount + 2);
+    const parentCounts = git(harnessRoot, "log", "--format=%P")
+      .split(/\r?\n/u)
+      .map((line) => line.trim().length === 0 ? 0 : line.trim().split(/\s+/u).length);
+    assert.equal(parentCounts.every((count) => count <= 1), true);
+    assert.equal(git(harnessRoot, "status", "--short"), "");
+  });
+});
+
 test("daemon start service status and stop expose productized status contract", () => {
   withTempRoot((rootDir) => {
     try {

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -408,7 +408,7 @@ function withTempRoot<T>(fn: (rootDir: string) => T): T {
   try {
     return fn(rootDir);
   } finally {
-    rmSync(rootDir, { recursive: true, force: true });
+    removeTempRootSync(rootDir);
   }
 }
 
@@ -417,8 +417,99 @@ async function withTempRootAsync<T>(fn: (rootDir: string) => Promise<T>): Promis
   try {
     return await fn(rootDir);
   } finally {
-    rmSync(rootDir, { recursive: true, force: true });
+    await stopDaemonForRoot(rootDir);
+    await removeTempRoot(rootDir);
   }
+}
+
+async function stopDaemonForRoot(rootDir: string): Promise<void> {
+  const pid = daemonPidFromStatus(rootDir);
+  if (!pid) return;
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch (error) {
+    if (isNoSuchProcess(error)) return;
+    throw error;
+  }
+  await waitForProcessExit(pid, 3_000);
+}
+
+function daemonPidFromStatus(rootDir: string): number | undefined {
+  let status: Record<string, unknown>;
+  try {
+    status = runDaemonCommand(rootDir, ["daemon", "status", "--json"]);
+  } catch {
+    return undefined;
+  }
+  if (typeof status.pid === "number" && Number.isSafeInteger(status.pid) && status.pid > 0) return status.pid;
+  const daemonId = status.daemonId;
+  if (typeof daemonId !== "string") return undefined;
+  const match = /^ha-(\d+)$/u.exec(daemonId);
+  if (!match) return undefined;
+  const pid = Number.parseInt(match[1]!, 10);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
+}
+
+function waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      try {
+        process.kill(pid, 0);
+      } catch (error) {
+        if (isNoSuchProcess(error)) {
+          resolve();
+          return;
+        }
+        reject(error);
+        return;
+      }
+      if (Date.now() >= deadline) {
+        reject(new Error(`daemon process ${pid} did not exit within ${timeoutMs}ms`));
+        return;
+      }
+      setTimeout(check, 25);
+    };
+    check();
+  });
+}
+
+async function removeTempRoot(rootDir: string): Promise<void> {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    try {
+      rmSync(rootDir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (!isRetriableRemoveError(error) || attempt === 7) throw error;
+      await delay(25 * (attempt + 1));
+    }
+  }
+}
+
+function removeTempRootSync(rootDir: string): void {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    try {
+      rmSync(rootDir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (!isRetriableRemoveError(error) || attempt === 7) throw error;
+      sleep(25 * (attempt + 1));
+    }
+  }
+}
+
+function isRetriableRemoveError(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && ["ENOTEMPTY", "EBUSY", "EPERM"].includes(String((error as { readonly code?: unknown }).code));
+}
+
+function isNoSuchProcess(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && (error as { readonly code?: unknown }).code === "ESRCH";
 }
 
 function runRawJson(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Record<string, unknown> {
@@ -492,11 +583,15 @@ function sleep(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function waitForCondition(check: () => boolean, timeoutMs = 4_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
     if (check()) return;
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await delay(100);
   }
   assert.equal(check(), true);
 }

--- a/packages/cli/test/session-cli.test.ts
+++ b/packages/cli/test/session-cli.test.ts
@@ -16,7 +16,7 @@ const cleanRuntimeEnv = {
   ANTIGRAVITY_SESSION_ID: ""
 } as const;
 
-test("CLI session export binds CODEX_THREAD_ID and commits managed session markdown", () => {
+test("CLI session export binds CODEX_THREAD_ID and writes managed session markdown through the journal", () => {
   withTempRoot((rootDir) => {
     const harnessRoot = path.join(rootDir, "harness");
     mkdirSync(harnessRoot, { recursive: true });
@@ -32,12 +32,15 @@ test("CLI session export binds CODEX_THREAD_ID and commits managed session markd
     assert.equal(exported.paths.primary, "harness/sessions/019f28de-f7f6-7223-a2a8-b2968686fe21.md");
     assert.equal(exported.report.session.sessionId, "019f28de-f7f6-7223-a2a8-b2968686fe21");
     assert.equal(exported.report.git.committed, true);
+    assert.equal(exported.report.git.coordinator, "write-journal");
     assert.match(readFileSync(path.join(rootDir, exported.paths.primary), "utf8"), /sessionId: 019f28de-f7f6-7223-a2a8-b2968686fe21/u);
+    assert.match(writeWatermarkBody(rootDir), /"schema":"write-watermark\/v1"/u);
+    assert.match(writeWatermarkBody(rootDir), /session-export-019f28de-f7f6-7223-a2a8-b2968686fe21/u);
     assert.equal(gitStatus(harnessRoot), "");
   });
 });
 
-test("CLI session sync commits existing untracked session exports", () => {
+test("CLI session sync writes existing untracked session exports through the journal", () => {
   withTempRoot((rootDir) => {
     const harnessRoot = path.join(rootDir, "harness");
     mkdirSync(path.join(harnessRoot, "sessions"), { recursive: true });
@@ -62,11 +65,14 @@ test("CLI session sync commits existing untracked session exports", () => {
     assert.equal(synced.command, "session-sync");
     assert.equal(synced.rows, 1);
     assert.equal(synced.report.git.committed, true);
+    assert.equal(synced.report.git.coordinator, "write-journal");
+    assert.match(writeWatermarkBody(rootDir), /"schema":"write-watermark\/v1"/u);
+    assert.match(writeWatermarkBody(rootDir), /session-sync-0/u);
     assert.equal(gitStatus(harnessRoot), "");
   });
 });
 
-test("CLI session backfill discovers Codex runtime logs and commits exports", () => {
+test("CLI session backfill discovers Codex runtime logs and writes exports through the journal", () => {
   withTempRoot((rootDir) => {
     const harnessRoot = path.join(rootDir, "harness");
     const homeDir = path.join(rootDir, "home");
@@ -91,12 +97,15 @@ test("CLI session backfill discovers Codex runtime logs and commits exports", ()
     assert.equal(backfilled.rows, 1);
     assert.equal(backfilled.report.exported[0].session.sessionId, "codex-thread-backfill");
     assert.equal(backfilled.report.git.committed, true);
+    assert.equal(backfilled.report.git.coordinator, "write-journal");
     assert.match(readFileSync(path.join(harnessRoot, "sessions", "codex-thread-backfill.md"), "utf8"), /Backfill this Codex thread/u);
+    assert.match(writeWatermarkBody(rootDir), /"schema":"write-watermark\/v1"/u);
+    assert.match(writeWatermarkBody(rootDir), /session-export-codex-thread-backfill/u);
     assert.equal(gitStatus(harnessRoot), "");
   });
 });
 
-test("CLI session backfill discovers ZCode runtime logs and commits exports", () => {
+test("CLI session backfill discovers ZCode runtime logs and writes exports through the journal", () => {
   withTempRoot((rootDir) => {
     const harnessRoot = path.join(rootDir, "harness");
     const homeDir = path.join(rootDir, "home");
@@ -123,8 +132,11 @@ test("CLI session backfill discovers ZCode runtime logs and commits exports", ()
     assert.equal(backfilled.rows, 1);
     assert.equal(backfilled.report.exported[0].session.sessionId, "sess_zcode-thread-backfill");
     assert.equal(backfilled.report.git.committed, true);
+    assert.equal(backfilled.report.git.coordinator, "write-journal");
     assert.match(readFileSync(path.join(harnessRoot, "sessions", "sess_zcode-thread-backfill.md"), "utf8"), /Backfill this ZCode thread/u);
     assert.match(readFileSync(path.join(harnessRoot, "sessions", "sess_zcode-thread-backfill.md"), "utf8"), /ZCode backfill response/u);
+    assert.match(writeWatermarkBody(rootDir), /"schema":"write-watermark\/v1"/u);
+    assert.match(writeWatermarkBody(rootDir), /session-export-sess_zcode-thread-backfill/u);
     assert.equal(gitStatus(harnessRoot), "");
   });
 });
@@ -163,4 +175,8 @@ function initHarnessGit(harnessRoot: string): void {
 
 function gitStatus(harnessRoot: string): string {
   return execFileSync("git", ["-C", harnessRoot, "status", "--short"], { encoding: "utf8" }).trim();
+}
+
+function writeWatermarkBody(rootDir: string): string {
+  return readFileSync(path.join(rootDir, ".harness", "write-journal", "watermark.json"), "utf8");
 }


### PR DESCRIPTION
# English

## Summary

Eliminate the ledger's bypass git-commit path: `commitAuthoredPaths` (a direct `git add --force` + `git commit`, marked materializer-exempt) is removed, and session export/backfill/sync now route through the write journal into the single-writer coordinator. This closes the write-safety gap where session artifacts were committed to git outside the daemon's serialized write path — the same family of machinery that recently mis-committed ledger artifacts onto a feature branch. With this change, two concurrent writers land linear git history through the coordinator.

## What Changed

- `packages/cli/src/commands/core/authored-git.ts`: `commitAuthoredPaths` direct-git path deleted.
- `packages/cli/src/composition/command-executor.ts`: post-export compensating commit removed.
- `session export/backfill/sync`: no longer use the authored-git helper; `session sync` emits `machine_artifact_write` with `bodyRef` (claim-check descriptor from #476) and flushes via the WriteCoordinator.
- Daemon-unavailable UX: error now instructs starting/checking the daemon instead of suggesting `HARNESS_DAEMON_MODE=direct` as a bypass.
- Tests: concurrent-writer serialization test (two writers, linear history), session CLI + daemon thin-client suites updated (19 passing).

## Task And Scope

- Harness task: task_01KX19FTJKGRV3JJF5NF5G2DEM (MC-A1, derived from decision dec_mrc9cx0d: single-writer ledger, all writes through the daemon path)
- Branch: codex/mc-a1-git-commit-ledger
- Public scope: CLI/composition write-path changes + tests
- Private planning/evidence updated: yes
- Out of scope: changing the global daemon default (explicit `HARNESS_DAEMON_MODE=direct` bootstrap path retained), claim/lease mechanics (MC-B1), CAS primitives (MC-A2)

## Version Impact

- Version: no version change because this is an internal write-path consolidation
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: decision dec_mrc9cx0d; task task_01KX19FTJKGRV3JJF5NF5G2DEM
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: latest (branch is up to date with origin/main at push time)
- Branch merge-base with `origin/main`: equals `origin/main`
- Last `git fetch origin` time: 2026-07-09 (immediately before push)
- Sync method: none needed (based on current main)
- Public diff command: `git diff origin/main...codex/mc-a1-git-commit-ledger`
- Private evidence commit/path: harness task package artifacts (report archived)
- Reviewer evidence path: harness task package review.md (private ledger)
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (scoped: session-cli + daemon-thin-client suites, 19/19 pass, incl. concurrent-writer linear-history test)
- [x] `npm run harness:check-import-boundaries` (via check:local + check:local:gates, green)
- [x] `npm run harness:scan-forbidden-symbols` (via check:local:gates)
- [x] `npm run harness:check-private-boundary` (via check:local:gates)
- [x] `npm run harness:check-package-policy` (via check:local:gates)
- [x] `npm run harness:check-implementation-contracts` (via check:local:gates)
- [x] `npm run harness:check-schema-contracts` (via check:local:gates)
- [x] `npm run harness:check-legacy-intake-readiness` (via check:local:gates)
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check` locally — `check:local` (18.5s) and `check:local:gates` green; remaining tiers covered by `rewrite-ci`.
- Bypass elimination proof: repo-wide grep for `commitAuthoredPaths` / `materializer-exempt` / `git add --force` (session path) / "set HARNESS_DAEMON_MODE=direct to bypass" returns zero hits.

## Review Evidence

- Self-review: worker verified linear history under two concurrent writers and zero bypass-grep hits before commit
- Reviewer subagent: not used (write-path consolidation with dedicated tests; CI covers full tiers)
- Human review: CEO semantic acceptance against dec_mrc9cx0d (single-writer invariant: no remaining session-side direct git commit; daemon-unavailable UX no longer advertises a bypass)
- Blocking findings: none

## Residual Risk

- The explicit `HARNESS_DAEMON_MODE=direct` bootstrap/productization path remains (out of scope here); narrowing it is a separate decision.
- `session export/backfill` reports keep the compatible `git.committed=true` shape, now sourced from `coordinator: "write-journal"` — downstream readers unaffected but the field semantics are now coordinator-backed.

## References

- Task: task_01KX19FTJKGRV3JJF5NF5G2DEM
- Evidence: private harness ledger task package
- Review: private harness ledger task package review.md

---

# 中文

## 概要

消除 ledger 的旁路 git commit:删除 `commitAuthoredPaths`(直连 `git add --force`+`git commit`,标记 materializer-exempt),session export/backfill/sync 改走 write journal 进单写者 coordinator。补上"session 产物绕过 daemon 串行写道直接 commit git"的写安全缺口——近期把 ledger 产物误提交到功能分支的正是这一族机械。改后两个并发 writer 经 coordinator 落出线性 git 历史。

## 改动内容

- `packages/cli/src/commands/core/authored-git.ts`:删除 `commitAuthoredPaths` 直连 git 路径。
- `packages/cli/src/composition/command-executor.ts`:移除导出后的补偿 commit。
- `session export/backfill/sync`:不再用 authored-git helper;`session sync` 发 `machine_artifact_write` 携带 `bodyRef`(#476 的 claim-check 描述符),经 WriteCoordinator flush。
- daemon 不可用体验:报错改为指引启动/检查 daemon,不再建议 `HARNESS_DAEMON_MODE=direct` 绕行。
- 测试:并发双 writer 串行化测试(历史线性)、session CLI+daemon thin-client 套件更新(19 过)。

## 任务与范围

- Harness 任务:task_01KX19FTJKGRV3JJF5NF5G2DEM(MC-A1,derives 自 decision dec_mrc9cx0d:ledger 单写者,一切写过 daemon 道)
- 分支:codex/mc-a1-git-commit-ledger
- 公开范围:CLI/composition 写路径变更+测试
- 私有计划 / 证据是否已更新:yes
- 范围外:改全局 daemon 默认(显式 `HARNESS_DAEMON_MODE=direct` bootstrap 路径保留)、claim/lease(MC-B1)、CAS 原语(MC-A2)

## 版本影响

- 版本:不改版本,原因是内部写路径收敛
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:无
- 依据:decision dec_mrc9cx0d;task task_01KX19FTJKGRV3JJF5NF5G2DEM
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- `origin/main` 基准 SHA:push 时最新(分支与 origin/main 同基)
- 当前分支与 `origin/main` 的 merge-base:等于 `origin/main`
- 最近一次 `git fetch origin` 时间:2026-07-09(push 前)
- 同步方式:不需要(基于当前 main)
- 公开 diff 命令:`git diff origin/main...codex/mc-a1-git-commit-ledger`
- 私有证据 commit/path:harness 任务包 artifacts(报告已归档)
- Reviewer 证据路径:harness 任务包 review.md(私有 ledger)
- GitHub Actions `rewrite-ci` run URL:待本 PR 的 CI 运行后回填
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(范围化:session-cli+daemon-thin-client 套件 19/19,含并发 writer 线性历史测试)
- [x] `npm run harness:check-import-boundaries`(经 check:local+check:local:gates,绿)
- [x] `npm run harness:scan-forbidden-symbols`(经 check:local:gates)
- [x] `npm run harness:check-private-boundary`(经 check:local:gates)
- [x] `npm run harness:check-package-policy`(经 check:local:gates)
- [x] `npm run harness:check-implementation-contracts`(经 check:local:gates)
- [x] `npm run harness:check-schema-contracts`(经 check:local:gates)
- [x] `npm run harness:check-legacy-intake-readiness`(经 check:local:gates)
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地未跑全量 `npm run check`——`check:local`(18.5s)与 `check:local:gates` 绿;其余档由 `rewrite-ci` 覆盖。
- 旁路消除证明:全仓 grep `commitAuthoredPaths`/`materializer-exempt`/session 路径 `git add --force`/"HARNESS_DAEMON_MODE=direct to bypass" 零命中。

## 审查证据

- 自查:worker 提交前验证并发双 writer 线性历史与旁路 grep 零命中
- Reviewer subagent:未使用(写路径收敛带专项测试;CI 覆盖全量档)
- 人工审查:CEO 对 dec_mrc9cx0d 语义验收(单写者不变量:session 侧无残留直连 git commit;daemon 不可用体验不再宣传绕行)
- 阻塞发现:无

## 残余风险

- 显式 `HARNESS_DAEMON_MODE=direct` bootstrap/产品化路径保留(不在本包);收窄它另起 decision。
- `session export/backfill` 报告保留兼容形 `git.committed=true`,来源改标 `coordinator: "write-journal"`——下游读端不受影响,字段语义已 coordinator 化。

## 关联材料

- 任务:task_01KX19FTJKGRV3JJF5NF5G2DEM
- 证据:私有 harness ledger 任务包
- 审查:私有 harness ledger 任务包 review.md

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
