### PR TITLE
feat(kernel): MC-A2 list append/delta + single-value CAS for ledger writes

### DIFF
--- a/packages/application/src/decision-write-service.ts
+++ b/packages/application/src/decision-write-service.ts
@@ -126,7 +126,10 @@ export function makeDecisionWriteService(options: DecisionWriteServiceOptions): 
         ...request.current,
         relations: [...request.current.relations, request.relation]
       };
-      return writeDecision(options.coordinator, hashPayload, "decision_relate", next, request, request.current);
+      return writeDecision(options.coordinator, hashPayload, "decision_relate", next, request, request.current, {
+        kind: "append_relation",
+        relation: request.relation
+      });
     },
     retireRelation: (request) => {
       const retired = retireRelationRecord(request.current, request.relationId);
@@ -267,7 +270,8 @@ function writeDecision(
   kind: WriteOpKind,
   decision: DecisionPackage,
   request: { readonly body?: string; readonly opIdPrefix?: string; readonly taskWrites?: ReadonlyArray<DocumentWrite> },
-  previous?: DecisionPackage
+  previous?: DecisionPackage,
+  writeMode?: DecisionDocumentWriteMode
 ): Effect.Effect<DecisionWriteResult, DecisionWriteRejected | WriteError> {
   const validation = validateDecisionWrite(decision, previous);
   if (validation) return Effect.fail(validation);
@@ -277,11 +281,19 @@ function writeDecision(
     payload: {
       decision,
       ...(request.taskWrites && request.taskWrites.length > 0 ? { taskWrites: request.taskWrites } : {}),
-      ...(request.body ? { body: request.body } : {})
+      ...(request.body ? { body: request.body } : {}),
+      writeMode: writeMode ?? {
+        kind: "snapshot",
+        expectedWatermark: previous?._coordinatorWatermark ?? null
+      }
     },
     ...(request.opIdPrefix ? { opIdPrefix: request.opIdPrefix } : {})
   }).pipe(Effect.as({ decisionId: decision.decision_id, state: decision.state }));
 }
+
+type DecisionDocumentWriteMode =
+  | { readonly kind: "snapshot"; readonly expectedWatermark?: string | null }
+  | { readonly kind: "append_relation"; readonly relation: EntityRelationRecord };
 
 function validateDecisionWrite(decision: DecisionPackage, previous?: DecisionPackage): DecisionWriteRejected | null {
   if (sameActor(decision.proposedBy, decision.arbiter)) {

--- a/packages/application/src/fact-write-service.ts
+++ b/packages/application/src/fact-write-service.ts
@@ -1,14 +1,10 @@
 import { randomBytes } from "node:crypto";
-import * as fs from "node:fs";
 import { Effect, Schema } from "effect";
 import {
   FactRecordSchema,
   deriveRelationId,
   evaluateEntityDisposition,
-  formatFactFlowRecord,
-  formatRelationFlowRecord,
   isFactId,
-  parseFactFlowRecords,
   taskEntityId,
   type EntityRelationRecord,
   type FactConfidence,
@@ -22,7 +18,6 @@ import {
 } from "../../kernel/src/index.ts";
 import { harnessRuntimeRoot, resolveHarnessLayout, type HarnessLayoutInput } from "../../kernel/src/index.ts";
 import { stablePayloadHash, writeCoordinatedPayload, type PayloadHasher } from "../../kernel/src/write-coordination/write-helpers.ts";
-import { isNodeErrorCode } from "./node-errors.ts";
 import { bindCreateProvenance, type ProvenanceBindingOptions } from "./provenance-binding.ts";
 
 export interface FactWriteServiceOptions extends ProvenanceBindingOptions {
@@ -89,15 +84,9 @@ export function makeFactWriteService(options: FactWriteServiceOptions): FactWrit
   return {
     record: (request) => Effect.gen(function* () {
       const layout = resolveHarnessLayout(options.rootInput);
-      const factsPath = layout.taskFactDocumentPath(request.ownerTaskId);
-      const existingBody = yield* readExistingFactsBody(factsPath, request.ownerTaskId);
-      const existingFacts = parseFactFlowRecords(existingBody);
       const factId = request.factId ?? generateFactId();
       if (!isFactId(factId)) {
         return yield* Effect.fail(factRejection(request.ownerTaskId, `invalid fact id: ${factId}`));
-      }
-      if (existingFacts.some((record) => record.fact_id === factId)) {
-        return yield* Effect.fail(factRejection(request.ownerTaskId, `duplicate fact id: ${factId}`));
       }
       const observedAt = request.observedAt ?? timestamp();
       const provenance = yield* bindCreateProvenance(options, observedAt).pipe(
@@ -115,14 +104,16 @@ export function makeFactWriteService(options: FactWriteServiceOptions): FactWrit
       };
       const validation = validateFactRecord(request.ownerTaskId, record);
       if (validation) return yield* Effect.fail(validation);
-      const nextBody = appendFactRecord(existingBody, record);
       if (!request.dryRun) {
         yield* writeCoordinatedPayload(options.coordinator, hashPayload, {
           entityId: taskEntityId(request.ownerTaskId),
           kind: "doc_write",
           payload: {
             path: layout.factDocumentName,
-            body: nextBody
+            appendRecord: {
+              kind: "fact-record/v1",
+              record
+            }
           },
           ...(request.opIdPrefix ? { opIdPrefix: request.opIdPrefix } : {})
         });
@@ -136,9 +127,6 @@ export function makeFactWriteService(options: FactWriteServiceOptions): FactWrit
     }),
     invalidate: (request) => Effect.gen(function* () {
       const layout = resolveHarnessLayout(options.rootInput);
-      const factsPath = layout.taskFactDocumentPath(request.ownerTaskId);
-      const existingBody = yield* readExistingFactsBody(factsPath, request.ownerTaskId);
-      const existingFacts = parseFactFlowRecords(existingBody);
       if (!isFactId(request.factId)) {
         return yield* Effect.fail(factRejection(request.ownerTaskId, `invalid fact id: ${request.factId}`));
       }
@@ -151,12 +139,6 @@ export function makeFactWriteService(options: FactWriteServiceOptions): FactWrit
       if (request.rationale.trim().length === 0) {
         return yield* Effect.fail(factRejection(request.ownerTaskId, "fact invalidation requires a non-empty rationale"));
       }
-      if (!existingFacts.some((record) => record.fact_id === request.factId)) {
-        return yield* Effect.fail(factRejection(request.ownerTaskId, `fact not found: ${request.factId}`));
-      }
-      if (!existingFacts.some((record) => record.fact_id === request.invalidatedByFactId)) {
-        return yield* Effect.fail(factRejection(request.ownerTaskId, `invalidating fact not found: ${request.invalidatedByFactId}`));
-      }
       const disposition = evaluateEntityDisposition({
         rootDir: harnessRuntimeRoot(options.rootInput),
         layoutOverrides: typeof options.rootInput === "string" ? undefined : options.rootInput.layoutOverrides,
@@ -167,14 +149,17 @@ export function makeFactWriteService(options: FactWriteServiceOptions): FactWrit
         return yield* Effect.fail(factRejection(request.ownerTaskId, disposition.reason));
       }
       const relation = invalidationRelation(request);
-      const nextBody = appendFactRelation(existingBody, relation);
       if (!request.dryRun) {
         yield* writeCoordinatedPayload(options.coordinator, hashPayload, {
           entityId: taskEntityId(request.ownerTaskId),
           kind: "fact_invalidate",
           payload: {
             path: layout.factDocumentName,
-            body: nextBody
+            appendRecord: {
+              kind: "fact-relation/v1",
+              relation,
+              requiresFacts: [request.factId, request.invalidatedByFactId]
+            }
           },
           ...(request.opIdPrefix ? { opIdPrefix: request.opIdPrefix } : {})
         });
@@ -193,30 +178,6 @@ export function makeFactWriteService(options: FactWriteServiceOptions): FactWrit
 
 function existingFactProvenance(): ReadonlyArray<ProvenancePayload> {
   return [];
-}
-
-function readExistingFactsBody(factsPath: string, taskId: TaskId): Effect.Effect<string, FactWriteRejected> {
-  return Effect.tryPromise({
-    try: () => fs.promises.readFile(factsPath, "utf8").catch((error: unknown) => {
-      if (isNodeErrorCode(error, "ENOENT")) return "";
-      throw error;
-    }),
-    catch: (error) => factRejection(taskId, error instanceof Error ? error.message : "facts document read failed")
-  });
-}
-
-function appendFactRecord(existingBody: string, record: FactRecord): string {
-  const header = "# Facts\n\n";
-  const base = existingBody.trim().length === 0 ? header : ensureTrailingNewline(existingBody);
-  return `${base}${formatFactFlowRecord(record)}\n`;
-}
-
-function appendFactRelation(existingBody: string, relation: EntityRelationRecord): string {
-  const relationLine = formatRelationFlowRecord(relation);
-  if (existingBody.includes(`relation_id: ${relation.relation_id}`)) return existingBody;
-  const base = existingBody.trim().length === 0 ? "# Facts\n\n" : ensureTrailingNewline(existingBody);
-  if (/^relations:\s*$/mu.test(base)) return `${base}${relationLine}\n`;
-  return `${base}\nrelations:\n${relationLine}\n`;
 }
 
 function invalidationRelation(request: FactInvalidateRequest): EntityRelationRecord {
@@ -246,10 +207,6 @@ function validateFactRecord(taskId: TaskId, record: FactRecord): FactWriteReject
   } catch (error) {
     return factRejection(taskId, error instanceof Error ? error.message : "fact record schema validation failed");
   }
-}
-
-function ensureTrailingNewline(value: string): string {
-  return value.endsWith("\n") ? value : `${value}\n`;
 }
 
 function randomFactId(): string {

--- a/packages/application/test/decision-write-service.test.ts
+++ b/packages/application/test/decision-write-service.test.ts
@@ -121,8 +121,13 @@ test("decision write service appends relation records through relation-specific 
 
   assert.deepEqual(result, { decisionId: "dec_TEST", state: "active" });
   assert.equal(enqueued[0]?.kind, "decision_relate");
-  const payload = enqueued[0]?.payload as { readonly decision?: DecisionPackage };
+  const payload = enqueued[0]?.payload as {
+    readonly decision?: DecisionPackage;
+    readonly writeMode?: { readonly kind?: string; readonly relation?: EntityRelationRecord };
+  };
   assert.deepEqual(payload.decision?.relations, [relation]);
+  assert.equal(payload.writeMode?.kind, "append_relation");
+  assert.deepEqual(payload.writeMode?.relation, relation);
 });
 
 test("healing writes are not blocked by pre-existing illegal sibling edges", () => {

--- a/packages/application/test/fact-write-service.test.ts
+++ b/packages/application/test/fact-write-service.test.ts
@@ -4,9 +4,9 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Effect } from "effect";
-import { makeFactWriteService, type FactWriteRejected } from "../src/index.ts";
+import { makeFactWriteService, makeHumanFallbackSessionProbe } from "../src/index.ts";
 import { formatFactFlowRecord, parseEntityRef, type FactRecord, type WriteCoordinator, type WriteOp } from "../../kernel/src/index.ts";
-import { runEffect, runEffectExit } from "./effect-test-helpers.ts";
+import { runEffect } from "./effect-test-helpers.ts";
 
 test("fact write service invalidates through a relation op without rewriting fact records", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-fact-write-"));
@@ -32,35 +32,51 @@ test("fact write service invalidates through a relation op without rewriting fac
     assert.equal(result.ref, "fact/task_fact_owner/F-DEADBEEF");
     assert.equal(enqueued[0]?.kind, "fact_invalidate");
     assert.equal(enqueued[0]?.entityId, "task/task_fact_owner");
-    const payload = enqueued[0]?.payload as { readonly path?: string; readonly body?: string };
+    const payload = enqueued[0]?.payload as {
+      readonly path?: string;
+      readonly appendRecord?: { readonly kind?: string; readonly relation?: { readonly target?: string; readonly type?: string } };
+    };
     assert.equal(payload.path, "facts.md");
-    assert.match(payload.body ?? "", /relations:/u);
-    assert.match(payload.body ?? "", /type: supersedes-fact/u);
-    assert.match(payload.body ?? "", /target: fact\/task_fact_owner\/F-DEADBEEF/u);
+    assert.equal(payload.appendRecord?.kind, "fact-relation/v1");
+    assert.equal(payload.appendRecord?.relation?.type, "supersedes-fact");
+    assert.equal(payload.appendRecord?.relation?.target, "fact/task_fact_owner/F-DEADBEEF");
     assert.equal(parseEntityRef(`fact/task_fact_owner/${result.invalidatedByFactId}`)?.kind, "fact");
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
 
-test("fact write service rejects invalidation when the invalidating fact is missing", async () => {
+test("fact write service records facts as append deltas", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-fact-write-"));
+  const enqueued: WriteOp[] = [];
   try {
-    writeFacts(rootDir, "task_fact_owner", [fact("F-DEADBEEF", "Old observation.")]);
     const service = makeFactWriteService({
       rootInput: rootDir,
-      coordinator: fakeCoordinator([])
+      coordinator: fakeCoordinator(enqueued),
+      currentSessionProbe: makeHumanFallbackSessionProbe({
+        now: () => "2026-07-04T00:00:00.000Z",
+        user: () => "zeyu"
+      }),
+      now: () => "2026-07-04T00:00:00.000Z"
     });
 
-    const result = await runEffectExit(service.invalidate({
+    const result = await runEffect(service.record({
       ownerTaskId: "task_fact_owner",
-      factId: "F-DEADBEEF",
-      invalidatedByFactId: "F-FEEDFACE",
-      rationale: "Missing invalidator."
+      factId: "F-FEEDFACE",
+      statement: "New observation.",
+      source: "test",
+      confidence: "high"
     }));
 
-    assert.equal(result._tag, "Failure");
-    assert.match(failureReason(result.cause), /invalidating fact not found/u);
+    assert.equal(result.factId, "F-FEEDFACE");
+    assert.equal(enqueued[0]?.kind, "doc_write");
+    const payload = enqueued[0]?.payload as {
+      readonly path?: string;
+      readonly appendRecord?: { readonly kind?: string; readonly record?: { readonly fact_id?: string } };
+    };
+    assert.equal(payload.path, "facts.md");
+    assert.equal(payload.appendRecord?.kind, "fact-record/v1");
+    assert.equal(payload.appendRecord?.record?.fact_id, "F-FEEDFACE");
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
@@ -103,13 +119,4 @@ function fact(factId: string, statement: string): FactRecord {
       boundAt: "2026-07-04T00:00:00.000Z"
     }]
   };
-}
-
-function failureReason(cause: unknown): string {
-  return JSON.stringify(cause, (_key, value: unknown) => {
-    if (value && typeof value === "object" && "_tag" in value && (value as FactWriteRejected)._tag === "FactWriteRejected") {
-      return (value as FactWriteRejected).reason;
-    }
-    return value;
-  });
 }

--- a/packages/application/test/provenance-binding-service.test.ts
+++ b/packages/application/test/provenance-binding-service.test.ts
@@ -86,9 +86,16 @@ test("fact create service binds provenance into the single-line record and expor
       confidence: "high"
     }));
 
-    const body = (enqueued[0]?.payload as { readonly body?: string }).body ?? "";
-    assert.match(body, /memoryClass: episodic, memoryTags: \[\]/u);
-    assert.match(body, /provenance: \[\{runtime: "human", sessionId: "human-cli-1783036800000", boundAt: "2026-07-03T00:01:00\.000Z"\}\]/u);
+    const record = (enqueued[0]?.payload as {
+      readonly appendRecord?: { readonly record?: { readonly memoryClass?: string; readonly memoryTags?: ReadonlyArray<string>; readonly provenance?: unknown } };
+    }).appendRecord?.record;
+    assert.equal(record?.memoryClass, "episodic");
+    assert.deepEqual(record?.memoryTags, []);
+    assert.deepEqual(record?.provenance, [{
+      runtime: "human",
+      sessionId: "human-cli-1783036800000",
+      boundAt: "2026-07-03T00:01:00.000Z"
+    }]);
     const session = await runEffect(exporter.readById("human-cli-1783036800000"));
     assert.equal(session.path, "sessions/human-cli-1783036800000.md");
     assert.equal(session.session.runtime, "human");

--- a/packages/kernel/src/domain/decision-document.ts
+++ b/packages/kernel/src/domain/decision-document.ts
@@ -1,4 +1,6 @@
+import { readFrontmatter, readScalar } from "../markdown/frontmatter.ts";
 import type { DecisionPackage } from "../schemas/decision-package.ts";
+import type { EntityRelationRecord } from "./entity-relation.ts";
 
 export interface DecisionDocumentTaskWrite {
   readonly taskId: string;
@@ -7,10 +9,15 @@ export interface DecisionDocumentTaskWrite {
   readonly packageSlug?: string;
 }
 
+export type DecisionDocumentWriteMode =
+  | { readonly kind: "snapshot"; readonly expectedWatermark?: string | null }
+  | { readonly kind: "append_relation"; readonly relation: EntityRelationRecord };
+
 export interface DecisionDocumentPayload {
   readonly decision: DecisionPackage;
   readonly body?: string;
   readonly taskWrites?: ReadonlyArray<DecisionDocumentTaskWrite>;
+  readonly writeMode?: DecisionDocumentWriteMode;
 }
 
 export function isDecisionDocumentPayload(payload: unknown): payload is DecisionDocumentPayload {
@@ -58,6 +65,154 @@ export function serializeDecisionDocument(payload: DecisionDocumentPayload, wate
     payload.body ?? `# ${decision.title}`,
     ""
   ].join("\n");
+}
+
+export function parseDecisionDocument(documentBody: string): DecisionDocumentPayload {
+  const frontmatter = readFrontmatter(documentBody);
+  if (!frontmatter) throw new Error("decision document missing frontmatter");
+  return {
+    decision: parseDecisionFrontmatter(frontmatter),
+    body: documentBody.replace(/^---\n[\s\S]*?\n---\n?/u, "")
+  };
+}
+
+export function readDecisionWatermark(documentBody: string): string | null {
+  const frontmatter = readFrontmatter(documentBody);
+  if (!frontmatter) return null;
+  return readScalar(frontmatter, "_coordinatorWatermark") || null;
+}
+
+function parseDecisionFrontmatter(frontmatter: string): DecisionPackage {
+  const decidedAt = unquote(readScalar(frontmatter, "decidedAt"));
+  const watermark = readScalar(frontmatter, "_coordinatorWatermark");
+  return {
+    schema: "decision-package/v1",
+    decision_id: readScalar(frontmatter, "decision_id", { required: true }),
+    ...(watermark ? { _coordinatorWatermark: watermark } : {}),
+    title: unquote(readScalar(frontmatter, "title", { required: true })),
+    state: readScalar(frontmatter, "state", { required: true }) as DecisionPackage["state"],
+    riskTier: readScalar(frontmatter, "riskTier", { required: true }) as DecisionPackage["riskTier"],
+    urgency: readScalar(frontmatter, "urgency", { required: true }) as DecisionPackage["urgency"],
+    vertical: unquote(readScalar(frontmatter, "vertical", { required: true })),
+    preset: unquote(readScalar(frontmatter, "preset", { required: true })),
+    applies_to: {
+      modules: parseStringArray(readBlockScalar(frontmatter, "applies_to", "modules")),
+      productLines: parseStringArray(readBlockScalar(frontmatter, "applies_to", "productLines"))
+    },
+    proposedBy: parseFlowObject(readScalar(frontmatter, "proposedBy", { required: true })) as DecisionPackage["proposedBy"],
+    proposedAt: unquote(readScalar(frontmatter, "proposedAt", { required: true })),
+    arbiter: parseFlowObject(readScalar(frontmatter, "arbiter", { required: true })) as DecisionPackage["arbiter"],
+    ...(decidedAt ? { decidedAt } : {}),
+    provenance: parseObjectList(frontmatter, "provenance") as DecisionPackage["provenance"],
+    question: unquote(readScalar(frontmatter, "question", { required: true })),
+    chosen: parseObjectList(frontmatter, "chosen") as DecisionPackage["chosen"],
+    rejected: parseObjectList(frontmatter, "rejected") as DecisionPackage["rejected"],
+    claims: parseObjectList(frontmatter, "claims") as DecisionPackage["claims"],
+    relations: parseObjectList(frontmatter, "relations") as DecisionPackage["relations"]
+  };
+}
+
+function readBlockScalar(frontmatter: string, blockName: string, key: string): string {
+  return readIndentedBlock(frontmatter, blockName)
+    .find((line) => line.trimStart().startsWith(`${key}:`))
+    ?.replace(new RegExp(`^\\s*${key}:\\s*`, "u"), "")
+    .trim() ?? "[]";
+}
+
+function parseStringArray(value: string): string[] {
+  const parsed = JSON.parse(value) as unknown;
+  return Array.isArray(parsed) ? parsed.map((entry) => String(entry)) : [];
+}
+
+function parseObjectList(frontmatter: string, key: string): ReadonlyArray<Record<string, unknown>> {
+  const items: Record<string, unknown>[] = [];
+  let current: Record<string, unknown> | null = null;
+  for (const rawLine of readIndentedBlock(frontmatter, key)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith("- ")) {
+      if (current) items.push(current);
+      const body = line.slice(2).trim();
+      current = body.startsWith("{") ? parseFlowObject(body) : parseBlockObjectLine(body);
+      continue;
+    }
+    if (!current) continue;
+    for (const [entryKey, entryValue] of Object.entries(parseBlockObjectLine(line))) {
+      current[entryKey] = entryValue;
+    }
+  }
+  if (current) items.push(current);
+  return items;
+}
+
+function readIndentedBlock(frontmatter: string, key: string): ReadonlyArray<string> {
+  const lines = frontmatter.split("\n");
+  const start = lines.findIndex((line) => line === `${key}:`);
+  if (start === -1) return [];
+  const block: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^[A-Za-z_][A-Za-z0-9_]*:/u.test(line)) break;
+    block.push(line);
+  }
+  return block;
+}
+
+function parseFlowObject(value: string): Record<string, unknown> {
+  const body = value.trim().replace(/^\{\s*/u, "").replace(/\s*\}$/u, "");
+  const result: Record<string, unknown> = {};
+  for (const part of splitTopLevel(body)) {
+    const separator = part.indexOf(":");
+    if (separator === -1) continue;
+    const key = part.slice(0, separator).trim();
+    result[key] = parseFlowValue(part.slice(separator + 1).trim());
+  }
+  return result;
+}
+
+function parseBlockObjectLine(value: string): Record<string, unknown> {
+  const separator = value.indexOf(":");
+  if (separator === -1) return {};
+  const key = value.slice(0, separator).trim();
+  return { [key]: parseFlowValue(value.slice(separator + 1).trim()) };
+}
+
+function parseFlowValue(value: string): unknown {
+  if (value.startsWith("{")) return parseFlowObject(value);
+  if (value.startsWith("[")) return parseStringArray(value);
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return unquote(value);
+}
+
+function splitTopLevel(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let inString = false;
+  let start = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "\"" && value[index - 1] !== "\\") inString = !inString;
+    if (inString) continue;
+    if (char === "{" || char === "[") depth += 1;
+    if (char === "}" || char === "]") depth -= 1;
+    if (char === "," && depth === 0) {
+      parts.push(value.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  const tail = value.slice(start).trim();
+  return tail ? [...parts, tail] : parts;
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (!trimmed.startsWith("\"")) return trimmed;
+  try {
+    return String(JSON.parse(trimmed));
+  } catch {
+    return trimmed.replace(/^"|"$/gu, "");
+  }
 }
 
 function flowArray(values: ReadonlyArray<string>): string {

--- a/packages/kernel/src/domain/errors.ts
+++ b/packages/kernel/src/domain/errors.ts
@@ -42,7 +42,16 @@ export type TemplateLibraryError =
   | { readonly _tag: "TemplateCatalogInvalid"; readonly reason: string };
 
 export type WriteError =
-  | { readonly _tag: "WriteRejected"; readonly taskId: TaskId; readonly reason: string }
+  | {
+    readonly _tag: "WriteRejected";
+    readonly taskId?: TaskId;
+    readonly entityId?: string;
+    readonly reason: string;
+    readonly code?: string;
+    readonly currentWatermark?: string | null;
+    readonly expectedWatermark?: string | null;
+    readonly retryable?: boolean;
+  }
   | { readonly _tag: "WriteConflict"; readonly taskId: TaskId; readonly owner?: string }
   | { readonly _tag: "GlobalWriteConflict"; readonly owner?: string }
   | { readonly _tag: "JournalUnavailable"; readonly cause?: unknown };

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -533,9 +533,16 @@ function mapJournalError(
         : { _tag: "GlobalWriteConflict", owner: cause.owner };
     case "WriteRejectedError": {
       const taskId = cause.taskId ?? (context.entityId ? taskIdFromEntityId(context.entityId) ?? undefined : undefined);
-      return taskId
-        ? { _tag: "WriteRejected", taskId, reason: cause.reason }
-        : { _tag: "JournalUnavailable", cause };
+      return {
+        _tag: "WriteRejected",
+        ...(taskId ? { taskId } : {}),
+        ...(cause.entityId ?? context.entityId ? { entityId: cause.entityId ?? context.entityId } : {}),
+        reason: cause.reason,
+        ...(cause.code ? { code: cause.code } : {}),
+        ...(cause.currentWatermark !== undefined ? { currentWatermark: cause.currentWatermark } : {}),
+        ...(cause.expectedWatermark !== undefined ? { expectedWatermark: cause.expectedWatermark } : {}),
+        ...(cause.retryable !== undefined ? { retryable: cause.retryable } : {})
+      };
     }
     case "NonTaskWriteEntityError":
       return { _tag: "JournalUnavailable", cause };

--- a/packages/kernel/src/store/write-journal-decision-documents.ts
+++ b/packages/kernel/src/store/write-journal-decision-documents.ts
@@ -1,11 +1,11 @@
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { decisionIdFromEntityId } from "../domain/index.ts";
-import { isDecisionDocumentPayload, serializeDecisionDocument } from "../domain/decision-document.ts";
+import { isDecisionDocumentPayload, parseDecisionDocument, readDecisionWatermark, serializeDecisionDocument, type DecisionDocumentPayload } from "../domain/decision-document.ts";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
 import type { WriteOp } from "../ports/write-coordinator.ts";
 import { writeFileDurably } from "./write-journal-durable.ts";
-import { rejectWrite } from "./write-journal-rejection.ts";
+import { rejectCasWatermarkMismatch, rejectWrite } from "./write-journal-rejection.ts";
 
 export const decisionWriteKinds = new Set<WriteOp["kind"]>([
   "decision_propose",
@@ -25,8 +25,11 @@ export function writeDecisionDocument(rootInput: HarnessLayoutInput, op: WriteOp
   if (!isDecisionDocumentPayload(op.payload)) {
     rejectWrite(`${op.kind} op requires decision document payload: ${op.opId}`, op.entityId);
   }
+  const payload = op.payload.writeMode?.kind === "append_relation"
+    ? appendDecisionRelationPayload(targetPath, op.payload)
+    : casSnapshotPayload(targetPath, op);
   mkdirSync(path.dirname(targetPath), { recursive: true });
-  writeFileDurably(targetPath, serializeDecisionDocument(op.payload, op.opId));
+  writeFileDurably(targetPath, serializeDecisionDocument(payload, op.opId));
 }
 
 export function decisionDocumentTargetPath(rootInput: HarnessLayoutInput, op: Pick<WriteOp, "entityId" | "payload">): string {
@@ -36,4 +39,49 @@ export function decisionDocumentTargetPath(rootInput: HarnessLayoutInput, op: Pi
     rejectWrite(`decision payload id ${op.payload.decision.decision_id} does not match entity ${op.entityId}`, op.entityId);
   }
   return resolveHarnessLayout(rootInput).decisionDocumentPath(decisionId);
+}
+
+function casSnapshotPayload(targetPath: string, op: WriteOp): DecisionDocumentPayload {
+  if (!isDecisionDocumentPayload(op.payload)) {
+    rejectWrite(`${op.kind} op requires decision document payload: ${op.opId}`, op.entityId);
+  }
+  const mode = op.payload.writeMode;
+  if (mode?.kind !== "snapshot" || !("expectedWatermark" in mode)) return op.payload;
+  const currentWatermark = existsSync(targetPath) ? readDecisionWatermark(readFileSync(targetPath, "utf8")) : null;
+  if (currentWatermark !== (mode.expectedWatermark ?? null)) {
+    rejectCasWatermarkMismatch({
+      entityId: op.entityId,
+      expectedWatermark: mode.expectedWatermark ?? null,
+      currentWatermark
+    });
+  }
+  return op.payload;
+}
+
+function appendDecisionRelationPayload(
+  targetPath: string,
+  payload: DecisionDocumentPayload
+): DecisionDocumentPayload {
+  const mode = payload.writeMode;
+  if (!isDecisionDocumentPayload(payload) || mode?.kind !== "append_relation") {
+    rejectWrite("append relation payload requires decision document payload");
+  }
+  if (!existsSync(targetPath)) {
+    const relations = payload.decision.relations.some((relation) => relation.relation_id === mode.relation.relation_id)
+      ? payload.decision.relations
+      : [...payload.decision.relations, mode.relation];
+    return { ...payload, decision: { ...payload.decision, relations } };
+  }
+
+  const current = parseDecisionDocument(readFileSync(targetPath, "utf8"));
+  if (current.decision.relations.some((relation) => relation.relation_id === mode.relation.relation_id)) {
+    return current;
+  }
+  return {
+    ...current,
+    decision: {
+      ...current.decision,
+      relations: [...current.decision.relations, mode.relation]
+    }
+  };
 }

--- a/packages/kernel/src/store/write-journal-operations.ts
+++ b/packages/kernel/src/store/write-journal-operations.ts
@@ -2,8 +2,8 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import path from "node:path";
 import type { DocumentWrite } from "../ports/artifact-store-writer.ts";
 import type { WriteOp } from "../ports/write-coordinator.ts";
-import type { EntityId } from "../domain/index.ts";
-import { moduleKeyFromEntityId, taskEntityId } from "../domain/index.ts";
+import type { EntityId, EntityRelationRecord, FactRecord } from "../domain/index.ts";
+import { formatFactFlowRecord, formatRelationFlowRecord, moduleKeyFromEntityId, parseFactFlowRecords, taskEntityId } from "../domain/index.ts";
 import { isContentAddressedBlobRef, readContentAddressedTextBlob, resolveContentAddressedBlobPath, type ContentAddressedBlobRef } from "./content-addressed-blob-store.ts";
 import {
   createTaskPackagePath,
@@ -53,6 +53,9 @@ export function applyWriteOp(rootInput: HarnessLayoutInput, op: WriteOp): Docume
   if (op.kind === "progress_append" && isProgressAppendDeltaPayload(op.payload)) {
     return applyProgressAppendDelta(rootInput, op, op.payload);
   }
+  if ((op.kind === "doc_write" || op.kind === "fact_invalidate") && isDocumentAppendRecordPayload(op.payload)) {
+    return applyDocumentAppendRecord(rootInput, op, op.payload);
+  }
   if (op.kind === "doc_stage") {
     return null;
   }
@@ -100,6 +103,9 @@ export function writeOpTouchedPaths(rootInput: HarnessLayoutInput, op: WriteOp):
   if (op.kind === "progress_append" && isProgressAppendDeltaPayload(op.payload)) {
     return [documentTargetPath(rootInput, progressAppendDeltaWrite(op, op.payload))];
   }
+  if ((op.kind === "doc_write" || op.kind === "fact_invalidate") && isDocumentAppendRecordPayload(op.payload)) {
+    return [documentTargetPath(rootInput, documentAppendRecordWrite(op, op.payload))];
+  }
   if (op.kind === "doc_stage") {
     return [documentTargetPath(rootInput, documentStageWrite(op))];
   }
@@ -131,6 +137,9 @@ export function documentWritesForWriteOp(op: WriteOp): ReadonlyArray<DocumentWri
   if (op.kind === "progress_append" && isProgressAppendDeltaPayload(op.payload)) {
     return [progressAppendDeltaWrite(op, op.payload)];
   }
+  if ((op.kind === "doc_write" || op.kind === "fact_invalidate") && isDocumentAppendRecordPayload(op.payload)) {
+    return [documentAppendRecordWrite(op, op.payload)];
+  }
   if (op.kind === "doc_stage") {
     return [];
   }
@@ -151,9 +160,32 @@ export function isProgressAppendDeltaPayload(payload: unknown): payload is Progr
   return typeof candidate.path === "string" && typeof candidate.append === "string" && !("body" in candidate);
 }
 
+function isDocumentAppendRecordPayload(payload: unknown): payload is DocumentAppendRecordPayload {
+  if (!payload || typeof payload !== "object") return false;
+  const candidate = payload as { readonly path?: unknown; readonly appendRecord?: unknown; readonly body?: unknown };
+  return typeof candidate.path === "string" &&
+    !("body" in candidate) &&
+    isAppendRecord(candidate.appendRecord);
+}
+
+function isAppendRecord(value: unknown): value is DocumentAppendRecordPayload["appendRecord"] {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as { readonly kind?: unknown; readonly record?: unknown; readonly relation?: unknown };
+  return (candidate.kind === "fact-record/v1" && Boolean(candidate.record && typeof candidate.record === "object")) ||
+    (candidate.kind === "fact-relation/v1" && Boolean(candidate.relation && typeof candidate.relation === "object"));
+}
+
 interface ProgressAppendDeltaPayload {
   readonly path: string;
   readonly append: string;
+  readonly packageSlug?: string;
+}
+
+interface DocumentAppendRecordPayload {
+  readonly path: string;
+  readonly appendRecord:
+    | { readonly kind: "fact-record/v1"; readonly record: FactRecord }
+    | { readonly kind: "fact-relation/v1"; readonly relation: EntityRelationRecord; readonly requiresFacts?: ReadonlyArray<string> };
   readonly packageSlug?: string;
 }
 
@@ -212,6 +244,15 @@ function progressAppendDeltaWrite(op: WriteOp, payload: ProgressAppendDeltaPaylo
   };
 }
 
+function documentAppendRecordWrite(op: WriteOp, payload: DocumentAppendRecordPayload): DocumentWrite {
+  return {
+    taskId: taskIdForWriteOp(op),
+    path: payload.path,
+    body: "",
+    packageSlug: typeof payload.packageSlug === "string" ? payload.packageSlug : undefined
+  };
+}
+
 function applyProgressAppendDelta(rootInput: HarnessLayoutInput, op: WriteOp, payload: ProgressAppendDeltaPayload): DocumentWrite {
   const targetPath = documentTargetPath(rootInput, progressAppendDeltaWrite(op, payload));
   const existing = existsSync(targetPath) ? readFileSync(targetPath, "utf8") : "";
@@ -224,6 +265,55 @@ function applyProgressAppendDelta(rootInput: HarnessLayoutInput, op: WriteOp, pa
   };
   writeDocument(rootInput, write);
   return write;
+}
+
+function applyDocumentAppendRecord(rootInput: HarnessLayoutInput, op: WriteOp, payload: DocumentAppendRecordPayload): DocumentWrite {
+  const targetPath = documentTargetPath(rootInput, documentAppendRecordWrite(op, payload));
+  const existing = existsSync(targetPath) ? readFileSync(targetPath, "utf8") : "";
+  const body = payload.appendRecord.kind === "fact-record/v1"
+    ? appendFactRecordDelta(existing, payload.appendRecord.record, op.entityId)
+    : appendFactRelationDelta(existing, payload.appendRecord.relation, payload.appendRecord.requiresFacts ?? [], op.entityId);
+  const write: DocumentWrite = {
+    taskId: taskIdForWriteOp(op),
+    path: payload.path,
+    body,
+    packageSlug: typeof payload.packageSlug === "string" ? payload.packageSlug : undefined
+  };
+  writeDocument(rootInput, write);
+  return write;
+}
+
+function appendFactRecordDelta(existingBody: string, record: FactRecord, entityId?: EntityId): string {
+  const duplicate = parseFactFlowRecords(existingBody).find((entry) => entry.fact_id === record.fact_id);
+  if (duplicate) {
+    if (formatFactFlowRecord(duplicate) === formatFactFlowRecord(record)) return existingBody;
+    rejectWrite(`duplicate fact id: ${record.fact_id}`, entityId);
+  }
+  const base = existingBody.trim().length === 0 ? "# Facts\n\n" : ensureTrailingNewline(existingBody);
+  return `${base}${formatFactFlowRecord(record)}\n`;
+}
+
+function appendFactRelationDelta(
+  existingBody: string,
+  relation: EntityRelationRecord,
+  requiredFactIds: ReadonlyArray<string>,
+  entityId?: EntityId
+): string {
+  const existingFacts = parseFactFlowRecords(existingBody);
+  for (const factId of requiredFactIds) {
+    if (!existingFacts.some((record) => record.fact_id === factId)) {
+      rejectWrite(`fact not found for relation append: ${factId}`, entityId);
+    }
+  }
+  if (existingBody.includes(`relation_id: ${relation.relation_id}`)) return existingBody;
+  const relationLine = formatRelationFlowRecord(relation);
+  const base = existingBody.trim().length === 0 ? "# Facts\n\n" : ensureTrailingNewline(existingBody);
+  if (/^relations:\s*$/mu.test(base)) return `${base}${relationLine}\n`;
+  return `${base}\nrelations:\n${relationLine}\n`;
+}
+
+function ensureTrailingNewline(value: string): string {
+  return value.endsWith("\n") ? value : `${value}\n`;
 }
 
 function isBatchDocumentWritePayload(payload: unknown): payload is BatchDocumentWritePayload {

--- a/packages/kernel/src/store/write-journal-rejection.ts
+++ b/packages/kernel/src/store/write-journal-rejection.ts
@@ -6,13 +6,30 @@ export class WriteRejectedError extends Error {
   readonly reason: string;
   readonly entityId?: EntityId;
   readonly taskId?: TaskId;
+  readonly code?: string;
+  readonly currentWatermark?: string | null;
+  readonly expectedWatermark?: string | null;
+  readonly retryable?: boolean;
 
-  constructor(reason: string, entityId?: EntityId) {
+  constructor(
+    reason: string,
+    entityId?: EntityId,
+    options: {
+      readonly code?: string;
+      readonly currentWatermark?: string | null;
+      readonly expectedWatermark?: string | null;
+      readonly retryable?: boolean;
+    } = {}
+  ) {
     super(reason);
     this.name = "WriteRejectedError";
     this.reason = reason;
     this.entityId = entityId;
     this.taskId = entityId ? taskIdFromEntityId(entityId) ?? undefined : undefined;
+    this.code = options.code;
+    this.currentWatermark = options.currentWatermark;
+    this.expectedWatermark = options.expectedWatermark;
+    this.retryable = options.retryable;
   }
 }
 
@@ -22,4 +39,25 @@ export function rejectWrite(reason: string, entityId?: EntityId): never {
 
 export function rejectTaskWrite(reason: string, taskId: TaskId): never {
   throw new WriteRejectedError(reason, taskEntityId(taskId));
+}
+
+export function rejectCasWatermarkMismatch(input: {
+  readonly entityId?: EntityId;
+  readonly expectedWatermark?: string | null;
+  readonly currentWatermark?: string | null;
+}): never {
+  throw new WriteRejectedError(
+    `cas_watermark_mismatch: expected ${formatWatermark(input.expectedWatermark)} but current is ${formatWatermark(input.currentWatermark)}`,
+    input.entityId,
+    {
+      code: "cas_watermark_mismatch",
+      currentWatermark: input.currentWatermark ?? null,
+      expectedWatermark: input.expectedWatermark ?? null,
+      retryable: true
+    }
+  );
+}
+
+function formatWatermark(watermark: string | null | undefined): string {
+  return watermark ?? "<none>";
 }

--- a/packages/kernel/test/store/conditional-delta-writes.test.ts
+++ b/packages/kernel/test/store/conditional-delta-writes.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { Effect } from "effect";
+import {
+  decisionEntityId,
+  deriveRelationId,
+  parseFactFlowRecords,
+  taskEntityId,
+  type DecisionPackage,
+  type EntityRelationRecord,
+  type FactRecord,
+  type WriteError
+} from "../../src/domain/index.ts";
+import { parseDecisionDocument } from "../../src/domain/decision-document.ts";
+import { makeJournaledWriteCoordinator } from "../../src/store/index.ts";
+import { withTempStore } from "./helpers.ts";
+
+test("fact append deltas from the same base snapshot both survive", () => {
+  withTempStore((rootDir) => {
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(coordinator.enqueue(factAppendOp("fact-a", "task_fact_owner", fact("F-AAAA1111", "Writer A fact."))));
+    Effect.runSync(coordinator.enqueue(factAppendOp("fact-b", "task_fact_owner", fact("F-BBBB2222", "Writer B fact."))));
+
+    Effect.runSync(coordinator.flush("explicit"));
+
+    const body = readFileSync(path.join(rootDir, "harness/tasks/task_fact_owner/facts.md"), "utf8");
+    const factIds = parseFactFlowRecords(body).map((record) => record.fact_id).sort();
+    assert.deepEqual(factIds, ["F-AAAA1111", "F-BBBB2222"]);
+  });
+});
+
+test("decision relation append deltas from the same base snapshot both survive", () => {
+  withTempStore((rootDir) => {
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(coordinator.enqueue(decisionSnapshotOp("decision-base", decisionPackage({ state: "active" }), null)));
+    Effect.runSync(coordinator.flush("explicit"));
+
+    const base = decisionPackage({ state: "active", _coordinatorWatermark: "decision-base" });
+    const relationA = relationRecord("decision/dec_TEST/C1", "fact/task_fact_owner/F-AAAA1111");
+    const relationB = relationRecord("decision/dec_TEST/C1", "fact/task_fact_owner/F-BBBB2222");
+    Effect.runSync(coordinator.enqueue(decisionRelationAppendOp("relation-a", base, relationA)));
+    Effect.runSync(coordinator.enqueue(decisionRelationAppendOp("relation-b", base, relationB)));
+
+    Effect.runSync(coordinator.flush("explicit"));
+
+    const body = readFileSync(path.join(rootDir, "harness/decisions/decision-dec_TEST/decision.md"), "utf8");
+    const decision = parseDecisionDocument(body).decision;
+    assert.deepEqual(decision.relations.map((relation) => relation.relation_id).sort(), [
+      relationA.relation_id,
+      relationB.relation_id
+    ].sort());
+    assert.equal(decision._coordinatorWatermark, "relation-b");
+  });
+});
+
+test("stale decision snapshot CAS is rejected with retryable current watermark", () => {
+  withTempStore((rootDir) => {
+    const baseCoordinator = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(baseCoordinator.enqueue(decisionSnapshotOp("decision-base", decisionPackage({ state: "proposed" }), null)));
+    Effect.runSync(baseCoordinator.flush("explicit"));
+
+    const sameSnapshotWatermark = "decision-base";
+    const writerA = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(writerA.enqueue(decisionSnapshotOp(
+      "decision-writer-a",
+      decisionPackage({ state: "active", decidedAt: "2026-07-05T00:00:00.000Z", _coordinatorWatermark: sameSnapshotWatermark }),
+      sameSnapshotWatermark
+    )));
+    Effect.runSync(writerA.flush("explicit"));
+
+    const writerB = makeJournaledWriteCoordinator({ rootDir });
+    Effect.runSync(writerB.enqueue(decisionSnapshotOp(
+      "decision-writer-b",
+      decisionPackage({ state: "rejected", decidedAt: "2026-07-05T00:01:00.000Z", _coordinatorWatermark: sameSnapshotWatermark }),
+      sameSnapshotWatermark
+    )));
+    const result = Effect.runSync(Effect.either(writerB.flush("explicit")));
+
+    assert.equal(result._tag, "Left");
+    const error = result._tag === "Left" ? result.left : null;
+    assert.deepEqual(error, {
+      _tag: "WriteRejected",
+      entityId: "decision/dec_TEST",
+      reason: "cas_watermark_mismatch: expected decision-base but current is decision-writer-a",
+      code: "cas_watermark_mismatch",
+      currentWatermark: "decision-writer-a",
+      expectedWatermark: "decision-base",
+      retryable: true
+    } satisfies WriteError);
+    const body = readFileSync(path.join(rootDir, "harness/decisions/decision-dec_TEST/decision.md"), "utf8");
+    assert.match(body, /^state: active$/mu);
+    assert.match(body, /^_coordinatorWatermark: decision-writer-a$/mu);
+  });
+});
+
+function factAppendOp(opId: string, taskId: string, record: FactRecord) {
+  return {
+    opId,
+    entityId: taskEntityId(taskId),
+    kind: "doc_write" as const,
+    payload: {
+      path: "facts.md",
+      appendRecord: {
+        kind: "fact-record/v1",
+        record
+      }
+    }
+  };
+}
+
+function decisionSnapshotOp(opId: string, decision: DecisionPackage, expectedWatermark: string | null) {
+  return {
+    opId,
+    entityId: decisionEntityId(decision.decision_id),
+    kind: "decision_amend" as const,
+    payload: {
+      decision,
+      writeMode: {
+        kind: "snapshot",
+        expectedWatermark
+      }
+    }
+  };
+}
+
+function decisionRelationAppendOp(opId: string, current: DecisionPackage, relation: EntityRelationRecord) {
+  return {
+    opId,
+    entityId: decisionEntityId(current.decision_id),
+    kind: "decision_relate" as const,
+    payload: {
+      decision: {
+        ...current,
+        relations: [relation]
+      },
+      writeMode: {
+        kind: "append_relation",
+        relation
+      }
+    }
+  };
+}
+
+function fact(factId: string, statement: string): FactRecord {
+  return {
+    fact_id: factId,
+    statement,
+    source: "test",
+    observedAt: "2026-07-04T00:00:00.000Z",
+    confidence: "high",
+    memoryClass: "episodic",
+    memoryTags: [],
+    provenance: [{
+      runtime: "human",
+      sessionId: "session-1",
+      boundAt: "2026-07-04T00:00:00.000Z"
+    }]
+  };
+}
+
+function decisionPackage(overrides: Partial<DecisionPackage> = {}): DecisionPackage {
+  return {
+    schema: "decision-package/v1",
+    decision_id: "dec_TEST",
+    title: "Test decision",
+    state: "proposed",
+    riskTier: "medium",
+    urgency: "medium",
+    vertical: "software/coding",
+    preset: "architecture-decision",
+    applies_to: {
+      modules: ["kernel"],
+      productLines: []
+    },
+    proposedBy: { kind: "agent", id: "claude" },
+    proposedAt: "2026-07-02T00:00:00Z",
+    arbiter: { kind: "human", id: "ZeyuLi" },
+    provenance: [{
+      runtime: "codex",
+      sessionId: "session-1",
+      boundAt: "2026-07-02T00:00:00Z"
+    }],
+    question: "Should this test write a decision?",
+    chosen: [{ id: "CH1", text: "Write it through the coordinator." }],
+    rejected: [{ id: "RJ1", text: "Write it by hand.", why_not: "Machine-readable decision frontmatter needs a coordinator watermark." }],
+    claims: [{ id: "C1", text: "Coordinator writes are auditable." }],
+    relations: [],
+    ...overrides
+  };
+}
+
+function relationRecord(source: string, target: string): EntityRelationRecord {
+  const base = {
+    source,
+    target,
+    type: "supersedes-fact",
+    strength: "strong",
+    direction: "directed",
+    origin: "declared",
+    rationale: "The linked fact supports the decision claim.",
+    state: "active"
+  } satisfies Omit<EntityRelationRecord, "relation_id">;
+  return {
+    relation_id: deriveRelationId(base),
+    ...base
+  };
+}

--- a/packages/kernel/test/store/journal-idempotency.test.ts
+++ b/packages/kernel/test/store/journal-idempotency.test.ts
@@ -43,6 +43,7 @@ test("WriteCoordinator reports duplicate batch write conflicts on the conflictin
       assert.deepEqual(result.left, {
         _tag: "WriteRejected",
         taskId: "task-conflict",
+        entityId: "task/task-conflict",
         reason: "duplicate batch write target: INDEX.md"
       });
     }

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -39,7 +39,7 @@
         "reason": "PLT-Bedrock W2 local LockRegistry implementation for external adopt claim release; callers release through the LockRegistry lease."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-decision-documents.ts#mkdirSync@28:3",
+        "value": "packages/kernel/src/store/write-journal-decision-documents.ts#mkdirSync@31:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
@@ -224,27 +224,27 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@273:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@363:9",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@296:3",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@386:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@307:5",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@397:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@276:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@366:9",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#writeFileSync@274:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#writeFileSync@364:9",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       }

--- a/tools/gate-allowlists/check-kernel-dead-exports.json
+++ b/tools/gate-allowlists/check-kernel-dead-exports.json
@@ -394,6 +394,11 @@
         "reason": "F8a first enforcement pass preserves the existing kernel public barrel zero-consumption export baseline; future additions must show a consumer or carry new governance evidence."
       },
       {
+        "value": "formatFactFlowRecord",
+        "ref": "task_01KX19FXXB88E1VB34QQ82S26E",
+        "reason": "MC-A2 moved fact writes to delta payloads; the formatter remains part of the stable public kernel surface for fact-flow documents even when no production package consumes it directly."
+      },
+      {
         "value": "FactFieldKey",
         "ref": "task_01KWWCBRSV0V3AWTCM3ZZ1J998",
         "reason": "F8a first enforcement pass preserves the existing kernel public barrel zero-consumption export baseline; future additions must show a consumer or carry new governance evidence."

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -146,6 +146,7 @@ export const testTierManifest = {
     "packages/cli/test/worktree-cli.test.ts",
     "packages/cli/test/write-lock-retry-cli.test.ts",
     "packages/kernel/test/store/crash-before-watermark.test.ts",
+    "packages/kernel/test/store/conditional-delta-writes.test.ts",
     "packages/kernel/test/store/daemon-registry.test.ts",
     "packages/kernel/test/store/daemon-runtime.test.ts",
     "packages/kernel/test/store/entity-disposition.test.ts",


### PR DESCRIPTION
# English

## Summary

Close red line 1 of the multi-collaborator write-path ruling (MC-A2): ledger writes stop being whole-body read-modify-write. Fact writes (`record`/`invalidate`) become list-append deltas applied under journal locks; decision snapshot writes (`accept`/`amend`/`supersede`/...) carry compare-and-swap against the document's `_coordinatorWatermark`; `decision.relate` becomes relation append. Two writers appending to the same list both survive; a stale single-value write is explicitly rejected with a structured, retryable error instead of silently clobbering the other writer — the lost-update window that produced ledger scrambles is closed at the write primitive, and the error contract is the interface the upcoming claim/lease slice (MC-B1) consumes.

## What Changed

- `packages/application/src/fact-write-service.ts`: `record`/`invalidate` no longer read `facts.md`; they submit append-record payloads (`fact-record/v1`, `fact-relation/v1` with `requiresFacts`).
- `packages/application/src/decision-write-service.ts`: snapshot writes carry `writeMode: snapshot` + `expectedWatermark`; `relate` submits append-relation mode.
- `packages/kernel/src/store/write-journal-operations.ts`: fact deltas read current on-disk state under the journal lock, apply idempotent append, reject conflicting duplicates/missing required facts.
- `packages/kernel/src/store/write-journal-decision-documents.ts`: CAS enforcement against current `_coordinatorWatermark`; relation append merges only the missing relation.
- `packages/kernel/src/store/write-journal-rejection.ts` + `write-journal-coordinator.ts`: CAS mismatch maps to `WriteRejected` with `code: cas_watermark_mismatch`, `currentWatermark`, `expectedWatermark`, `retryable: true`.
- New `packages/kernel/test/store/conditional-delta-writes.test.ts`; application write-service tests updated.
- Gate allowlists: line-number re-anchoring only (reasons/refs unchanged) + one dead-export entry (`formatFactFlowRecord`) referencing this task.

## Task And Scope

- Harness task: task_01KX19FXXB88E1VB34QQ82S26E (MC-A2, red line 1 of the centralization write-path decision)
- Branch: codex/mc-a2-cas
- Public scope: 16 files, kernel store + application write services + tests
- Private planning/evidence updated: yes
- Out of scope: claim/lease (MC-B1), actor attribution (MC-A3, parallel), gate-ification of the write path (MC-A5)

## Version Impact

- Version: no version change because this is internal write-primitive hardening
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes (gate allowlist files under tools/gate-allowlists/)
- Protected surface scope: check-bypass-write-boundary.json (line-number re-anchoring of existing entries, reasons/refs unchanged), check-kernel-dead-exports.json (+1 entry with task ref)
- Authority: the accepted centralization write-path decision (red line 1: append/delta + CAS) recorded in the private ledger; task task_01KX19FXXB88E1VB34QQ82S26E
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: fold `formatFactFlowRecord` into the broader kernel public-surface cleanup when that line opens

## Verification

- Base `origin/main` SHA: latest at push time (rebased onto the merge commit of #486)
- Branch merge-base with `origin/main`: equals `origin/main` (rebased)
- Last `git fetch origin` time: 2026-07-09 (immediately before rebase and push)
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/mc-a2-cas`
- Private evidence commit/path: harness task package artifacts (report archived)
- Reviewer evidence path: harness task package review.md (private ledger)
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (via check:local fast tier, green post-rebase)
- [x] `npm test` (scoped: fast tier 220 + contract 324 green post-rebase; conditional-delta-writes suite 3/3 rerun ×3 stable; concurrency 10-run pass pre-rebase)
- [x] `npm run harness:check-import-boundaries` (via check:local, green post-rebase)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check` locally — post-rebase `check:local` (18.6s) + `check:local:gates` (9.0s, incl. supply-chain green) both green; CI is authoritative on this PR.

## Review Evidence

- Self-review: worker classified every write surface (append vs CAS table in the task report) and grep-verified no `readFile`/whole-body rewrite remains in either write service
- Reviewer subagent: post-rebase gate rerun + conditional-delta suite ×3 stability pass
- Human review: CEO semantic acceptance against the write-path ruling red line 1 (append writers both survive; stale CAS write rejected retryable with both watermarks; allowlist diff verified as pure re-anchoring)
- Blocking findings: none

## Residual Risk

- Formal contract doc for the append/CAS error contract lives in the private ledger task package (public repo carries no harness contracts by design); MC-B1 consumes it from there.
- `formatFactFlowRecord` stays on the dead-export allowlist with a task ref until the public-surface cleanup line opens.
- MC-A3 (parallel) touches the same allowlist file; serial drainage re-anchors line numbers on rebase.

## References

- Task: task_01KX19FXXB88E1VB34QQ82S26E
- Evidence: private harness ledger task package
- Review: private harness ledger task package review.md

---

# 中文

## 概要

关多协作写道裁决的红线 1(MC-A2):台账写不再是全文读改写。fact 写(`record`/`invalidate`)改为 journal 锁下应用的 list append delta;decision 快照写(`accept`/`amend`/`supersede`/…)携带对文档 `_coordinatorWatermark` 的 CAS;`decision.relate` 改为 relation append。双写者对同一列表追加两边都保留;陈旧单值写被显式拒绝并返回结构化可重试错误,而非静默覆盖对方——造成台账 scramble 的 lost-update 窗口在写原语层关闭,错误契约即将由 claim/lease 切片(MC-B1)直接消费。

## 改动内容

- `packages/application/src/fact-write-service.ts`:`record`/`invalidate` 不再读 `facts.md`,改提交 append-record 载荷(`fact-record/v1`、带 `requiresFacts` 的 `fact-relation/v1`)。
- `packages/application/src/decision-write-service.ts`:快照写携带 `writeMode: snapshot`+`expectedWatermark`;`relate` 提交 append-relation 模式。
- `packages/kernel/src/store/write-journal-operations.ts`:fact delta 在 journal 锁下读盘上现状、幂等追加,拒绝冲突重复/缺失前置 fact。
- `packages/kernel/src/store/write-journal-decision-documents.ts`:对当前 `_coordinatorWatermark` 强制 CAS;relation append 只并入缺失的边。
- `packages/kernel/src/store/write-journal-rejection.ts`+`write-journal-coordinator.ts`:CAS 失配映射为 `WriteRejected`,`code: cas_watermark_mismatch`、`currentWatermark`、`expectedWatermark`、`retryable: true`。
- 新增 `packages/kernel/test/store/conditional-delta-writes.test.ts`;application 写服务测试更新。
- gate allowlist:仅行号重锚(reason/ref 原样)+1 条 dead-export(`formatFactFlowRecord`,带本任务 ref)。

## 任务与范围

- Harness 任务:task_01KX19FXXB88E1VB34QQ82S26E(MC-A2,中心化写道裁决红线 1)
- 分支:codex/mc-a2-cas
- 公开范围:16 文件,kernel store+application 写服务+测试
- 私有计划 / 证据是否已更新:yes
- 范围外:claim/lease(MC-B1)、actor 归因(MC-A3,并行)、写道 gate 化(MC-A5)

## 版本影响

- 版本:不改版本,原因是内部写原语加固
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes(tools/gate-allowlists/ 下的 allowlist 文件)
- protected surface 范围:check-bypass-write-boundary.json(既有条目行号重锚,reason/ref 原样)、check-kernel-dead-exports.json(+1 条带 task ref)
- 依据:私有 ledger 中已 accept 的中心化写道裁决(红线 1:append/delta+CAS);task task_01KX19FXXB88E1VB34QQ82S26E
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:`formatFactFlowRecord` 待 kernel 公共面清理线开启时并入

## 验证

- `origin/main` 基准 SHA:push 时最新(rebase 到 #486 合并提交之上)
- 当前分支与 `origin/main` 的 merge-base:等于 `origin/main`(已 rebase)
- 最近一次 `git fetch origin` 时间:2026-07-09(rebase 与 push 前)
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...codex/mc-a2-cas`
- 私有证据 commit/path:harness 任务包 artifacts(报告已归档)
- Reviewer 证据路径:harness 任务包 review.md(私有 ledger)
- GitHub Actions `rewrite-ci` run URL:待本 PR 的 CI 运行后回填
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`(经 check:local fast 档,rebase 后绿)
- [x] `npm test`(范围化:rebase 后 fast 档 220+contract 档 324 绿;conditional-delta-writes 套件 3/3 复跑 ×3 稳;rebase 前并发 10 连跑绿)
- [x] `npm run harness:check-import-boundaries`(经 check:local,rebase 后绿)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地未跑全量 `npm run check`——rebase 后 `check:local`(18.6s)+`check:local:gates`(9.0s,含 supply-chain 绿)双绿;以本 PR 的 CI 为权威。

## 审查证据

- 自查:worker 对每个写面做了 append vs CAS 分类表(任务报告),并 grep 验证两写服务无 `readFile`/全文重写残留
- Reviewer subagent:rebase 后 gate 复跑+conditional-delta 套件 ×3 稳定性
- 人工审查:CEO 对写道裁决红线 1 语义验收(append 双写者都保留;陈旧 CAS 写可重试拒绝且携双 watermark;allowlist diff 核为纯重锚)
- 阻塞发现:无

## 残余风险

- append/CAS 错误契约的正式文档落私有 ledger 任务包(公共仓按设计零 harness contracts);MC-B1 从那里消费。
- `formatFactFlowRecord` 带 task ref 留在 dead-export allowlist,待公共面清理线开启。
- MC-A3(并行)碰同一 allowlist 文件;串行排水时 rebase 重锚行号。

## 关联材料

- 任务:task_01KX19FXXB88E1VB34QQ82S26E
- 证据:私有 harness ledger 任务包
- 审查:私有 harness ledger 任务包 review.md

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
