### PR TITLE
fix(attribution): MC-A3 require real actor attribution for ledger writes

### DIFF
--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -79,6 +79,9 @@ export const localAdapterProviderMetadata = {
 } as const satisfies AdapterProviderMetadata;
 
 export function makeLocalWriteCoordinator(options: LocalWriteCoordinatorOptions): WriteCoordinator {
+  if (!options.actor) {
+    throw new Error("Local write coordinator requires explicit actor attribution.");
+  }
   return makeJournaledWriteCoordinator({
     ...options,
     lockConflictRetry: localLockConflictRetry
@@ -91,7 +94,7 @@ export function makeLocalLifecycleEngine(options: LocalLifecycleOptions): LocalL
   const coordinator = options.coordinator ?? makeLocalWriteCoordinator({
     rootDir,
     layoutOverrides: options.layoutOverrides,
-    actor: { kind: "agent", id: "local-lifecycle" }
+    actor: options.actor
   });
   const clock = options.clock ?? (() => new Date());
 

--- a/packages/adapters/local/src/types.ts
+++ b/packages/adapters/local/src/types.ts
@@ -13,6 +13,7 @@ export interface LocalLifecycleOptions {
   readonly rootDir: string;
   readonly layoutOverrides?: HarnessLayoutOverrides;
   readonly coordinator?: WriteCoordinator;
+  readonly actor?: LocalJournalActor;
   readonly clock?: () => Date;
   readonly bindCreateProvenance?: (boundAt: string) => Effect.Effect<ProvenancePayload | undefined, CreateProvenanceRejected>;
 }
@@ -27,6 +28,10 @@ export interface LocalWriteCoordinatorOptions {
   readonly actor?: LocalJournalActor;
   readonly sessionId?: string;
   readonly autoMaterialize?: boolean;
+  readonly commitAuthor?: {
+    readonly name: string;
+    readonly email: string;
+  };
 }
 
 export interface AdapterProviderMetadata {

--- a/packages/cli/src/cli/runner-registry.ts
+++ b/packages/cli/src/cli/runner-registry.ts
@@ -14,6 +14,7 @@ import { toCliError } from "./error-mapper.ts";
 import { actionTaskId } from "./parse-args.ts";
 import { appendCommandRuntimeEvent } from "./command-runtime-events.ts";
 import type { CliResult, MaterializerCommandReport, ParsedCommand } from "./types.ts";
+import type { CliActorAttribution } from "../composition/actor-attribution.ts";
 import {
   runDiagnosticsCommand,
   runCapabilitiesCommand,
@@ -49,6 +50,7 @@ export interface CommandRunnerContext {
   readonly syncExportedSession: (result: ProvenanceSessionExportResult) => Effect.Effect<void, ProvenanceSessionExporterRejected>;
   readonly runtimeEventLedgerService: RuntimeEventLedgerService;
   readonly makeWriteCoordinator: (actor: { readonly kind: "agent" | "human" | "system"; readonly id: string }) => WriteCoordinator;
+  readonly actorAttribution: () => CliActorAttribution;
   readonly decisionWriteService: DecisionWriteService;
   readonly factWriteService: FactWriteService;
   readonly runLedgerMaterializer: (options: { readonly dryRun?: boolean }) => MaterializerCommandReport;
@@ -145,6 +147,7 @@ export function runRegisteredCommand(
   makeProvenanceSessionExporter: () => ProvenanceSessionExporter,
   syncExportedSession: (result: ProvenanceSessionExportResult) => Effect.Effect<void, ProvenanceSessionExporterRejected>,
   makeWriteCoordinator: (actor: { readonly kind: "agent" | "human" | "system"; readonly id: string }) => WriteCoordinator,
+  actorAttribution: () => CliActorAttribution,
   makeDecisionWriteService: () => DecisionWriteService,
   makeFactWriteService: () => FactWriteService,
   makeRuntimeEventLedgerService: () => RuntimeEventLedgerService,
@@ -193,6 +196,7 @@ export function runRegisteredCommand(
     },
     syncExportedSession,
     makeWriteCoordinator,
+    actorAttribution,
     get decisionWriteService() {
       decisionWriteService ??= makeDecisionWriteService();
       return decisionWriteService;

--- a/packages/cli/src/commands/core/init.ts
+++ b/packages/cli/src/commands/core/init.ts
@@ -12,7 +12,17 @@ const initSmokeSlug = "harness-onboarding-smoke";
 
 export const runInitCommand: CommandRunner = (context, command) => {
   const action = command.action as Extract<typeof command.action, { readonly kind: "init" }>;
-  return Effect.sync(() => initializeHarness(context.layoutInput, action.addNpmScripts, action.projectName))
+  return Effect.sync(() => {
+    try {
+      return initializeHarness(context.layoutInput, action.addNpmScripts, action.projectName, context.actorAttribution().commitAuthor);
+    } catch (error) {
+      return {
+        ok: false,
+        command: "init",
+        error: cliError(CliErrorCode.AuthMissing, error instanceof Error ? error.message : String(error))
+      } satisfies CliResult;
+    }
+  })
     .pipe(Effect.flatMap((result) => runConfigureVerifySmoke(context, result)));
 };
 
@@ -20,6 +30,7 @@ function runConfigureVerifySmoke(
   context: Parameters<CommandRunner>[0],
   result: CliResult
 ): ReturnType<CommandRunner> {
+  if (!result.ok) return Effect.succeed(result);
   return Effect.sync(() => {
     const layout = resolveHarnessLayout(context.layoutInput);
     const smokeTaskId = generateTaskId();

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,13 +2,14 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { HarnessLayoutInput } from "../../../kernel/src/index.ts";
+import type { CliGitCommitAuthor } from "../composition/actor-attribution.ts";
 import { resolveHarnessLayout } from "../../../kernel/src/index.ts";
 import { normalizeSlashes } from "../cli/path.ts";
 import type { CliResult } from "../cli/types.ts";
 import { bundledVerticalDefinition } from "./extensions/bundled.ts";
 import { materializeRepositoryScaffold } from "./extensions/repository-scaffold.ts";
 
-export function initializeHarness(rootInput: HarnessLayoutInput, addNpmScripts = false, projectName?: string): CliResult {
+export function initializeHarness(rootInput: HarnessLayoutInput, addNpmScripts = false, projectName?: string, commitAuthor?: CliGitCommitAuthor): CliResult {
   const layout = resolveHarnessLayout(rootInput);
   const rootDir = layout.rootDir;
   const warnings: unknown[] = [];
@@ -33,7 +34,7 @@ export function initializeHarness(rootInput: HarnessLayoutInput, addNpmScripts =
   const harnessConfigPath = layout.configPath ?? path.join(layout.authoredRoot, "harness.yaml");
   writeHarnessYaml(harnessConfigPath, resolvedProjectName, projectName !== undefined);
   materializeRepositoryScaffold(rootInput, vertical);
-  const isolation = ensureHarnessRepositoryIsolation(rootDir, layout.authoredRoot);
+  const isolation = ensureHarnessRepositoryIsolation(rootDir, layout.authoredRoot, commitAuthor);
   warnings.push(...isolation.warnings);
   const packagePath = path.join(layout.rootDir, "package.json");
   if (addNpmScripts) {
@@ -92,14 +93,14 @@ interface HarnessIsolationReport {
   readonly nextSteps: readonly string[];
 }
 
-function ensureHarnessRepositoryIsolation(rootDir: string, authoredRoot: string): HarnessIsolationResult {
+function ensureHarnessRepositoryIsolation(rootDir: string, authoredRoot: string, commitAuthor?: CliGitCommitAuthor): HarnessIsolationResult {
   const warnings: unknown[] = [];
   const authoredRootRelative = initRelativeLayoutPath(rootDir, authoredRoot);
   const innerGitDir = path.join(authoredRoot, ".git");
   const outerGit = isInsideInitGitWorkTree(rootDir);
   const gitignore = ensureOuterGitignoreIsolation(rootDir, outerGit, authoredRootRelative);
   warnings.push(...gitignore.warnings);
-  const innerRepository = ensureInnerGitRepository(authoredRoot, innerGitDir);
+  const innerRepository = ensureInnerGitRepository(authoredRoot, innerGitDir, commitAuthor);
   warnings.push(...innerRepository.warnings);
 
   return {
@@ -163,7 +164,7 @@ function ensureOuterGitignoreIsolation(rootDir: string, outerGit: boolean, autho
   }
 }
 
-function ensureInnerGitRepository(authoredRoot: string, innerGitDir: string): {
+function ensureInnerGitRepository(authoredRoot: string, innerGitDir: string, commitAuthor?: CliGitCommitAuthor): {
   readonly report: HarnessIsolationReport["innerRepository"];
   readonly warnings: ReadonlyArray<unknown>;
 } {
@@ -182,13 +183,13 @@ function ensureInnerGitRepository(authoredRoot: string, innerGitDir: string): {
 
   try {
     try {
-      runInitGit(authoredRoot, ["init", "--initial-branch=master"]);
+      runInitGit(authoredRoot, ["init", "--initial-branch=master"], commitAuthor);
     } catch {
-      runInitGit(authoredRoot, ["init"]);
-      runInitGit(authoredRoot, ["symbolic-ref", "HEAD", "refs/heads/master"]);
+      runInitGit(authoredRoot, ["init"], commitAuthor);
+      runInitGit(authoredRoot, ["symbolic-ref", "HEAD", "refs/heads/master"], commitAuthor);
     }
-    runInitGit(authoredRoot, ["add", "."]);
-    runInitGit(authoredRoot, ["commit", "-m", "chore: initialize harness ledger"]);
+    runInitGit(authoredRoot, ["add", "."], commitAuthor);
+    runInitGit(authoredRoot, ["commit", "-m", "chore: initialize harness ledger"], commitAuthor);
     return {
       warnings: [],
       report: {
@@ -233,16 +234,18 @@ function readGitText(rootDir: string, args: ReadonlyArray<string>): string | und
   }
 }
 
-function runInitGit(rootDir: string, args: ReadonlyArray<string>): void {
+function runInitGit(rootDir: string, args: ReadonlyArray<string>, author?: CliGitCommitAuthor): void {
   execFileSync("git", ["-C", rootDir, ...args], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     env: {
       ...process.env,
-      GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Harness Anything",
-      GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? "harness-anything@example.invalid",
-      GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Harness Anything",
-      GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "harness-anything@example.invalid"
+      ...(author ? {
+        GIT_AUTHOR_NAME: author.name,
+        GIT_AUTHOR_EMAIL: author.email,
+        GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? author.name,
+        GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? author.email
+      } : {})
     }
   });
 }

--- a/packages/cli/src/commands/legacy-rebuild.ts
+++ b/packages/cli/src/commands/legacy-rebuild.ts
@@ -71,7 +71,7 @@ export function runNewTaskFromLegacy(
       const packagePath = createTaskPackagePath(rootInput, taskId, slug);
       const provenance = buildLegacyProvenance(legacySource.entry, createdAt);
       const provenanceMd = renderLegacyProvenanceMarkdown(rootDir, packagePath, legacySource.entry);
-      const coordinator = makeWriteCoordinator({ kind: "agent", id: "local-lifecycle" });
+      const coordinator = makeWriteCoordinator({ kind: "agent", id: "legacy-rebuild" });
       const writes = [
         { taskId, path: "INDEX.md", body: renderIndex(index), packageSlug: slug },
         { taskId, path: "legacy-provenance.json", body: `${JSON.stringify(provenance, null, 2)}\n`, packageSlug: slug },

--- a/packages/cli/src/commands/preset-task.ts
+++ b/packages/cli/src/commands/preset-task.ts
@@ -205,7 +205,7 @@ export function runNewTaskWithPreset(
       }] : []),
       ...readSetWrite
     ];
-    const coordinator = makeWriteCoordinator?.({ kind: "agent", id: "local-lifecycle" });
+    const coordinator = makeWriteCoordinator?.({ kind: "agent", id: "preset-task" });
     if (!coordinator) return yield* Effect.fail({ _tag: "JournalUnavailable", cause: new Error("write coordinator factory is required") } satisfies WriteError);
     const opId = `${Date.now()}-${stablePayloadHash({ kind: "package_create", writes }).slice(0, 16)}`;
     yield* coordinator.enqueue({

--- a/packages/cli/src/composition/actor-attribution.ts
+++ b/packages/cli/src/composition/actor-attribution.ts
@@ -1,0 +1,84 @@
+import type { AuthenticatedActor } from "../../../daemon/src/index.ts";
+
+export interface CliJournalActor {
+  readonly kind: "agent" | "human" | "system";
+  readonly id: string;
+}
+
+export interface CliGitCommitAuthor {
+  readonly name: string;
+  readonly email: string;
+}
+
+export interface CliActorAttribution {
+  readonly actor: CliJournalActor;
+  readonly commitAuthor: CliGitCommitAuthor;
+  readonly source: "env" | "daemon";
+}
+
+export class CliActorAttributionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CliActorAttributionError";
+  }
+}
+
+export function resolveLocalCliActorAttribution(env: NodeJS.ProcessEnv = process.env): CliActorAttribution {
+  const actor = readEnvActor(env);
+  const name = readEnv(env, "HARNESS_GIT_AUTHOR_NAME") ?? readEnv(env, "GIT_AUTHOR_NAME");
+  const email = readEnv(env, "HARNESS_GIT_AUTHOR_EMAIL") ?? readEnv(env, "GIT_AUTHOR_EMAIL");
+  const missing = [
+    actor ? undefined : "HARNESS_ACTOR=kind:id",
+    name ? undefined : "HARNESS_GIT_AUTHOR_NAME",
+    email ? undefined : "HARNESS_GIT_AUTHOR_EMAIL"
+  ].filter((value): value is string => Boolean(value));
+  if (missing.length > 0) {
+    throw new CliActorAttributionError(
+      `Local CLI writes require explicit actor attribution; set ${missing.join(", ")}. ` +
+      "Daemon writes should use harness/people.yaml identity resolution."
+    );
+  }
+  if (!actor || !name || !email) {
+    throw new CliActorAttributionError("Local CLI writes require explicit actor attribution.");
+  }
+  return {
+    actor,
+    commitAuthor: { name, email },
+    source: "env"
+  };
+}
+
+export function daemonActorAttribution(actor: AuthenticatedActor): CliActorAttribution {
+  const email = actor.primaryEmail?.trim();
+  if (!email) {
+    throw new CliActorAttributionError(`Daemon actor ${actor.personId} requires primaryEmail for git author attribution.`);
+  }
+  return {
+    actor: { kind: "human", id: actor.personId },
+    commitAuthor: { name: actor.displayName, email },
+    source: "daemon"
+  };
+}
+
+function readEnvActor(env: NodeJS.ProcessEnv): CliJournalActor | undefined {
+  const raw = readEnv(env, "HARNESS_ACTOR");
+  if (!raw) return undefined;
+  const separator = raw.indexOf(":");
+  if (separator <= 0 || separator === raw.length - 1) {
+    throw new CliActorAttributionError("HARNESS_ACTOR must use kind:id form, for example human:lizeyu.");
+  }
+  const kind = raw.slice(0, separator);
+  const id = raw.slice(separator + 1);
+  if (kind !== "agent" && kind !== "human" && kind !== "system") {
+    throw new CliActorAttributionError("HARNESS_ACTOR kind must be one of: agent, human, system.");
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u.test(id)) {
+    throw new CliActorAttributionError("HARNESS_ACTOR id must start with an alphanumeric character and contain only A-Z, a-z, 0-9, dot, underscore, colon, or dash.");
+  }
+  return { kind, id };
+}
+
+function readEnv(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const value = env[name]?.trim();
+  return value && value.length > 0 ? value : undefined;
+}

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -14,6 +14,7 @@ import { toCliError } from "../cli/error-mapper.ts";
 import { actionTaskId } from "../cli/parse-args.ts";
 import { requiresConflictMarkerPreflight, runRegisteredCommand } from "../cli/runner-registry.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
+import { CliActorAttributionError, resolveLocalCliActorAttribution, type CliActorAttribution } from "./actor-attribution.ts";
 import {
   defaultCliAdapterProvider,
   type CliCompositionAdapterProvider
@@ -22,6 +23,9 @@ import {
 export interface ParsedCommandExecutionOptions {
   readonly provider?: CliCompositionAdapterProvider;
   readonly makeWriteCoordinator?: (actor: { readonly kind: "agent" | "human" | "system"; readonly id: string }) => WriteCoordinator;
+  readonly actorAttribution?: CliActorAttribution;
+  readonly missingActorAttributionMessage?: string;
+  readonly requireProvidedActorAttribution?: boolean;
 }
 
 export async function runRegisteredCommandWithCliComposition(
@@ -49,23 +53,48 @@ export async function runRegisteredCommandWithCliComposition(
     return sessionBranchId;
   };
   const syncExportedSession = (_result: ProvenanceSessionExportResult): Effect.Effect<void, never> => Effect.void;
+  let actorAttributionResolved = false;
+  let actorAttribution: CliActorAttribution | undefined;
+  let actorAttributionError: CliActorAttributionError | undefined;
+  const getActorAttribution = () => {
+    if (!actorAttributionResolved) {
+      actorAttributionResolved = true;
+      try {
+        if (options.actorAttribution) {
+          actorAttribution = options.actorAttribution;
+        } else if (options.requireProvidedActorAttribution) {
+          throw new CliActorAttributionError(options.missingActorAttributionMessage ?? "Actor attribution is required.");
+        } else {
+          actorAttribution = resolveLocalCliActorAttribution();
+        }
+      } catch (error) {
+        actorAttributionError = error instanceof CliActorAttributionError
+          ? error
+          : new CliActorAttributionError(error instanceof Error ? error.message : String(error));
+      }
+    }
+    if (actorAttributionError) throw actorAttributionError;
+    return actorAttribution!;
+  };
 
   const rawMakeWriteCoordinator = options.makeWriteCoordinator ?? ((actor: { readonly kind: "agent" | "human" | "system"; readonly id: string }) =>
-    provider.createWriteCoordinator({
+    makeAttributedWriteCoordinator(() => provider.createWriteCoordinator({
       rootDir: command.rootDir,
       layoutOverrides: command.layoutOverrides,
-      actor,
+      actor: getActorAttribution().actor,
+      commitAuthor: getActorAttribution().commitAuthor,
       sessionId: getSessionBranchId()
-    }));
+    }), getActorAttribution, options.missingActorAttributionMessage, actor));
   const makeWriteCoordinator = requiresConflictMarkerPreflight(command.action)
     ? (actor: { readonly kind: "agent" | "human" | "system"; readonly id: string }) => withConflictMarkerFlushRecheck(rawMakeWriteCoordinator(actor), layoutInput)
     : rawMakeWriteCoordinator;
   const rawMakeSessionWriteCoordinator = options.makeWriteCoordinator ?? ((actor: { readonly kind: "agent" | "human" | "system"; readonly id: string }) =>
-    provider.createWriteCoordinator({
+    makeAttributedWriteCoordinator(() => provider.createWriteCoordinator({
       rootDir: command.rootDir,
       layoutOverrides: command.layoutOverrides,
-      actor
-    }));
+      actor: getActorAttribution().actor,
+      commitAuthor: getActorAttribution().commitAuthor
+    }), getActorAttribution, options.missingActorAttributionMessage, actor));
   const makeSessionWriteCoordinator = requiresConflictMarkerPreflight(command.action)
     ? (actor: { readonly kind: "agent" | "human" | "system"; readonly id: string }) => withConflictMarkerFlushRecheck(rawMakeSessionWriteCoordinator(actor), layoutInput)
     : rawMakeSessionWriteCoordinator;
@@ -84,13 +113,13 @@ export async function runRegisteredCommandWithCliComposition(
   return Effect.runPromise(runRegisteredCommand(command, () => provider.createLifecycleEngine({
     rootDir: command.rootDir,
     layoutOverrides: command.layoutOverrides,
-    coordinator: makeWriteCoordinator({ kind: "agent", id: "local-lifecycle" }),
+    coordinator: makeWriteCoordinator({ kind: "agent", id: "task-lifecycle" }),
     bindCreateProvenance: (boundAt) => bindCreateProvenance({
       currentSessionProbe: getCurrentSessionProbe(),
       provenanceSessionExporter: makeSessionExporter(),
       syncExportedSession
     }, boundAt)
-  }), makeArtifactStore, getCurrentSessionProbe, makeSessionExporter, syncExportedSession, makeWriteCoordinator, () => makeDecisionWriteService({
+  }), makeArtifactStore, getCurrentSessionProbe, makeSessionExporter, syncExportedSession, makeWriteCoordinator, getActorAttribution, () => makeDecisionWriteService({
     rootInput: layoutInput,
     coordinator: makeWriteCoordinator({ kind: "agent", id: "decision-cli" }),
     currentSessionProbe: getCurrentSessionProbe(),
@@ -141,5 +170,35 @@ function withConflictMarkerFlushRecheck(
         })
         : coordinator.flush(reason))
     )
+  };
+}
+
+function makeAttributedWriteCoordinator(
+  create: () => WriteCoordinator,
+  getActorAttribution: () => CliActorAttribution,
+  missingMessage: string | undefined,
+  requestedActor: { readonly kind: "agent" | "human" | "system"; readonly id: string }
+): WriteCoordinator {
+  try {
+    getActorAttribution();
+    return create();
+  } catch (error) {
+    const message = missingMessage ?? (error instanceof Error ? error.message : String(error));
+    return failingWriteCoordinator(message, requestedActor);
+  }
+}
+
+function failingWriteCoordinator(
+  message: string,
+  requestedActor: { readonly kind: "agent" | "human" | "system"; readonly id: string }
+): WriteCoordinator {
+  const fail = () => Effect.fail({
+    _tag: "JournalUnavailable" as const,
+    cause: new Error(`${message} Requested writer: ${requestedActor.kind}:${requestedActor.id}.`)
+  });
+  return {
+    enqueue: () => fail(),
+    flush: () => fail(),
+    recover: fail()
   };
 }

--- a/packages/cli/src/daemon/command-service.ts
+++ b/packages/cli/src/daemon/command-service.ts
@@ -1,7 +1,11 @@
-import { actorGitCommitAuthor, type AuthenticatedActor, type JsonObject } from "../../../daemon/src/index.ts";
+import { Effect } from "effect";
+import type { AuthenticatedActor, JsonObject } from "../../../daemon/src/index.ts";
+import type { WriteCoordinator } from "../../../kernel/src/index.ts";
+import { cliError, CliErrorCode } from "../cli/error-codes.ts";
 import { toCommandReceipt, type CommandFailureReceipt, type CommandReceipt } from "../cli/receipt.ts";
 import type { ParsedCommand } from "../cli/types.ts";
 import { isPlainRecord } from "../cli/value-utils.ts";
+import { CliActorAttributionError, daemonActorAttribution } from "../composition/actor-attribution.ts";
 import { runRegisteredCommandWithCliComposition } from "../composition/command-executor.ts";
 import { makeDaemonQueuedWriteCoordinator, type CliDaemonRuntime } from "./queued-write-coordinator.ts";
 
@@ -21,23 +25,49 @@ export function createCliCommandService(runtime: CliDaemonRuntime, options: CliC
       const command = readParsedCommandPayload(payload);
       const daemonActor = context?.actor;
       try {
+        const attribution = daemonActor ? daemonActorAttribution(daemonActor) : undefined;
         const result = await runRegisteredCommandWithCliComposition(command, {
-          makeWriteCoordinator: (actor) => makeDaemonQueuedWriteCoordinator(
-            runtime,
-            `${command.action.kind}:${actor.kind}:${actor.id}`,
-            daemonActor
-              ? {
-                actor: { kind: "human", id: daemonActor.personId },
-                commitAuthor: actorGitCommitAuthor(daemonActor, "harness@example.invalid")
-              }
-              : undefined
-          )
+          requireProvidedActorAttribution: true,
+          ...(attribution ? { actorAttribution: attribution } : {
+            missingActorAttributionMessage: "Daemon writes require a per-request authenticated actor from harness/people.yaml."
+          }),
+          makeWriteCoordinator: (actor) => attribution
+            ? makeDaemonQueuedWriteCoordinator(
+              runtime,
+              `${command.action.kind}:${actor.kind}:${actor.id}`,
+              { actor: attribution.actor, commitAuthor: attribution.commitAuthor }
+            )
+            : missingDaemonActorCoordinator(command.action.kind, actor)
         });
         return toCommandReceipt(result);
+      } catch (error) {
+        if (error instanceof CliActorAttributionError) {
+          return toCommandReceipt({
+            ok: false,
+            command: command.action.kind,
+            error: cliError(CliErrorCode.AuthMissing, error.message)
+          });
+        }
+        throw error;
       } finally {
         options.onCommandSettled?.();
       }
     }
+  };
+}
+
+function missingDaemonActorCoordinator(
+  commandKind: string,
+  requestedActor: { readonly kind: "agent" | "human" | "system"; readonly id: string }
+): WriteCoordinator {
+  const fail = () => Effect.fail({
+    _tag: "JournalUnavailable" as const,
+    cause: new Error(`Daemon command ${commandKind} requires a per-request authenticated actor from harness/people.yaml. Requested writer: ${requestedActor.kind}:${requestedActor.id}.`)
+  });
+  return {
+    enqueue: () => fail(),
+    flush: () => fail(),
+    recover: fail()
   };
 }
 

--- a/packages/cli/test/actor-attribution-cli.test.ts
+++ b/packages/cli/test/actor-attribution-cli.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
+
+test("CLI write commands require explicit local actor attribution", () => {
+  withTempRoot((rootDir) => {
+    const result = runJson(rootDir, ["new-task", "--title", "No Actor"], false, withoutActorAttributionEnv());
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error?.code, "write_rejected");
+    assert.match(result.error?.hint ?? "", /Local CLI writes require explicit actor attribution/u);
+    assert.equal(existsSync(path.join(rootDir, "harness/tasks")), false);
+  });
+});
+
+test("CLI local writes preserve distinct git authors for distinct actors", () => {
+  withTempRoot((rootDir) => {
+    const aliceEnv = actorEnv("human:person_alice", "Alice Owner", "alice@example.test");
+    const bobEnv = actorEnv("human:person_bob", "Bob Builder", "bob@example.test");
+    runJson(rootDir, ["init"], true, aliceEnv);
+    const alice = runJson(rootDir, ["new-task", "--title", "Alice Authored"], true, aliceEnv);
+    const bob = runJson(rootDir, ["new-task", "--title", "Bob Authored"], true, bobEnv);
+
+    assertGeneratedTaskId(alice.taskId);
+    assertGeneratedTaskId(bob.taskId);
+    const authors = git(path.join(rootDir, "harness"), ["log", "--format=%an <%ae>"]).split(/\r?\n/u);
+    assert.equal(authors.includes("Alice Owner <alice@example.test>"), true);
+    assert.equal(authors.includes("Bob Builder <bob@example.test>"), true);
+  });
+});
+
+function assertGeneratedTaskId(value: unknown): string {
+  assert.equal(typeof value, "string");
+  assert.match(value, taskIdPattern);
+  return value;
+}
+
+function withTempRoot<T>(fn: (rootDir: string) => T): T {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-cli-"));
+  try {
+    return fn(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true, env: Readonly<Record<string, string>> = {}): Record<string, any> {
+  try {
+    const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+      encoding: "utf8",
+      env: { ...process.env, ...env }
+    });
+    return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
+  } catch (error) {
+    if (expectSuccess) throw error;
+    const failure = error as { readonly stdout?: string };
+    return unwrapCommandReceipt(JSON.parse(failure.stdout ?? "{}") as Record<string, any>);
+  }
+}
+
+function actorEnv(actor: string, name: string, email: string): Readonly<Record<string, string>> {
+  return {
+    HARNESS_ACTOR: actor,
+    HARNESS_GIT_AUTHOR_NAME: name,
+    HARNESS_GIT_AUTHOR_EMAIL: email
+  };
+}
+
+function withoutActorAttributionEnv(): Readonly<Record<string, string>> {
+  return {
+    HARNESS_ACTOR: "",
+    HARNESS_GIT_AUTHOR_NAME: "",
+    HARNESS_GIT_AUTHOR_EMAIL: "",
+    GIT_AUTHOR_NAME: "",
+    GIT_AUTHOR_EMAIL: ""
+  };
+}
+
+function git(rootDir: string, args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}

--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -153,6 +153,7 @@ function setupRegisteredRepos(workspaceRoot: string): {
   for (const rootDir of [alphaRoot, betaRoot]) {
     mkdirSync(rootDir, { recursive: true });
     runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    writePeopleRoster(rootDir);
   }
   runDaemonCommand(alphaRoot, ["daemon", "repo", "register", "--repo-id", "alpha", "--root", alphaRoot, "--user-root", userRoot, "--no-link", "--json"], {
     HARNESS_DAEMON_USER_ROOT: userRoot
@@ -161,6 +162,46 @@ function setupRegisteredRepos(workspaceRoot: string): {
     HARNESS_DAEMON_USER_ROOT: userRoot
   });
   return { userRoot, alphaRoot, betaRoot };
+}
+
+function writePeopleRoster(rootDir: string): void {
+  const harnessRoot = path.join(rootDir, "harness");
+  mkdirSync(harnessRoot, { recursive: true });
+  writeFileSync(path.join(harnessRoot, "people.yaml"), [
+    "schema: harness-people/v1",
+    "people:",
+    "  - personId: person_daemon_tester",
+    "    displayName: Daemon Tester",
+    "    primaryEmail: daemon-tester@example.test",
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: unix-uid",
+    `        issuer: host:${hostname()}`,
+    `        subject: ${process.getuid?.() ?? 0}`,
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    ""
+  ].join("\n"), "utf8");
+  if (existsSync(path.join(harnessRoot, ".git"))) {
+    execFileSync("git", ["-C", harnessRoot, "add", "--", "people.yaml"], { stdio: "ignore" });
+    execFileSync("git", ["-C", harnessRoot, "commit", "-m", "chore: configure daemon people roster"], {
+      stdio: "ignore",
+      env: gitAuthorEnv()
+    });
+  }
+}
+
+function gitAuthorEnv(): NodeJS.ProcessEnv {
+  const name = process.env.HARNESS_GIT_AUTHOR_NAME ?? "Harness Test";
+  const email = process.env.HARNESS_GIT_AUTHOR_EMAIL ?? "harness@example.test";
+  return {
+    ...process.env,
+    GIT_AUTHOR_NAME: name,
+    GIT_AUTHOR_EMAIL: email,
+    GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? name,
+    GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? email
+  };
 }
 
 function runRawJson(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Record<string, unknown> {

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -99,8 +99,8 @@ test("concurrent daemon client startup converges on one lock owner and both clie
     runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
 
     const [left, right] = await Promise.all([
-      runRawJsonAsync(rootDir, ["task", "list"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "1500" }),
-      runRawJsonAsync(rootDir, ["task", "list"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "1500" })
+      runRawJsonAsync(rootDir, ["task", "list"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "10000" }),
+      runRawJsonAsync(rootDir, ["task", "list"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "10000" })
     ]);
 
     assert.equal(left.ok, true);

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -21,7 +21,13 @@ test("daemon client mode preserves command receipt output shape against direct m
 
 test("daemon client auto-starts, durably writes, and exits after idle", () => {
   withTempRoot((rootDir) => {
-    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "250" });
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
+    writePeopleRoster(rootDir, {
+      personId: "person_auto",
+      displayName: "Auto User",
+      email: "auto@example.test",
+      role: "owner"
+    });
     const created = runRawJson(rootDir, ["new-task", "--title", "Daemon Client Write"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "250" });
 
     assert.equal(created.ok, true);
@@ -90,7 +96,7 @@ test("daemon client writes git commits with the resolved actor author", () => {
 
 test("concurrent daemon client startup converges on one lock owner and both clients continue", async () => {
   await withTempRootAsync(async (rootDir) => {
-    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "1500" });
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
 
     const [left, right] = await Promise.all([
       runRawJsonAsync(rootDir, ["task", "list"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "1500" }),
@@ -109,6 +115,12 @@ test("concurrent daemon client writes serialize into linear git history", async 
   await withTempRootAsync(async (rootDir) => {
     initGitRepo(rootDir);
     runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
+    writePeopleRoster(rootDir, {
+      personId: "person_concurrent",
+      displayName: "Concurrent User",
+      email: "concurrent@example.test",
+      role: "owner"
+    });
     const harnessRoot = path.join(rootDir, "harness");
     const beforeCount = Number(git(harnessRoot, "rev-list", "--count", "HEAD"));
 
@@ -258,6 +270,12 @@ test("daemon client resolves an existing single-repo registry without requiring 
   withTempRoot((rootDir) => {
     const userRoot = path.join(rootDir, "user-daemon");
     runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    writePeopleRoster(rootDir, {
+      personId: "person_registered",
+      displayName: "Registered User",
+      email: "registered@example.test",
+      role: "owner"
+    });
     const registered = runDaemonCommand(rootDir, ["daemon", "repo", "register", "--repo-id", "canonical", "--user-root", userRoot, "--no-link", "--json"], {
       HARNESS_DAEMON_USER_ROOT: userRoot
     });
@@ -646,6 +664,28 @@ function writePeopleRoster(rootDir: string, person: {
     "    commandClasses: [repo-write, repo-read]",
     ""
   ].join("\n"), "utf8");
+  commitPeopleRoster(harnessRoot);
+}
+
+function commitPeopleRoster(harnessRoot: string): void {
+  if (!existsSync(path.join(harnessRoot, ".git"))) return;
+  execFileSync("git", ["-C", harnessRoot, "add", "--", "people.yaml"], { stdio: "ignore" });
+  execFileSync("git", ["-C", harnessRoot, "commit", "-m", "chore: configure daemon people roster"], {
+    stdio: "ignore",
+    env: gitAuthorEnv()
+  });
+}
+
+function gitAuthorEnv(): NodeJS.ProcessEnv {
+  const name = process.env.HARNESS_GIT_AUTHOR_NAME ?? "Harness Test";
+  const email = process.env.HARNESS_GIT_AUTHOR_EMAIL ?? "harness@example.test";
+  return {
+    ...process.env,
+    GIT_AUTHOR_NAME: name,
+    GIT_AUTHOR_EMAIL: email,
+    GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? name,
+    GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? email
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/daemon/src/identity/types.ts
+++ b/packages/daemon/src/identity/types.ts
@@ -129,9 +129,11 @@ export function actorStampJson(actor: AuthenticatedActor): JsonObject {
   };
 }
 
-export function actorGitCommitAuthor(actor: AuthenticatedActor, fallbackEmail: string): GitCommitAuthor {
+export function actorGitCommitAuthor(actor: AuthenticatedActor): GitCommitAuthor {
+  const email = actor.primaryEmail?.trim();
+  if (!email) throw new Error(`Actor ${actor.personId} requires primaryEmail for git author attribution.`);
   return {
     name: actor.displayName,
-    email: actor.primaryEmail?.trim() || fallbackEmail
+    email
   };
 }

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -131,10 +131,12 @@ function runGitAs(repoRoot: string, author: VcsCommitAuthor | undefined, ...args
       stdio: ["ignore", "pipe", "pipe"],
       env: {
         ...process.env,
-        GIT_AUTHOR_NAME: author?.name ?? process.env.GIT_AUTHOR_NAME ?? "Harness Anything",
-        GIT_AUTHOR_EMAIL: author?.email ?? process.env.GIT_AUTHOR_EMAIL ?? "harness@example.invalid",
-        GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Harness Anything",
-        GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "harness@example.invalid"
+        ...(author ? {
+          GIT_AUTHOR_NAME: author.name,
+          GIT_AUTHOR_EMAIL: author.email,
+          GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? author.name,
+          GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? author.email
+        } : {})
       }
     });
   } catch (error) {

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -102,7 +102,10 @@ test("WriteCoordinator stages hard-deleted task packages and clears replay journ
     runGit(rootDir, "add", ".");
     runGit(rootDir, "commit", "-m", "seed task");
 
-    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    const coordinator = makeJournaledWriteCoordinator({
+      rootDir,
+      commitAuthor: testCommitAuthor
+    });
     Effect.runSync(coordinator.enqueue({
       opId: "op-hard-delete",
       entityId: taskEntityId("task-1"),
@@ -141,7 +144,10 @@ test("WriteCoordinator rejects hard delete for task packages with anchored facts
     runGit(rootDir, "add", ".");
     runGit(rootDir, "commit", "-m", "seed anchored task");
 
-    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    const coordinator = makeJournaledWriteCoordinator({
+      rootDir,
+      commitAuthor: testCommitAuthor
+    });
 
     assert.throws(
       () => Effect.runSync(coordinator.enqueue({
@@ -166,7 +172,10 @@ test("WriteCoordinator force-adds explicit harness paths ignored by target repo 
     runGit(rootDir, "add", ".gitignore");
     runGit(rootDir, "commit", "-m", "ignore artifacts");
 
-    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    const coordinator = makeJournaledWriteCoordinator({
+      rootDir,
+      commitAuthor: testCommitAuthor
+    });
     Effect.runSync(coordinator.enqueue(docWrite("op-ignored-artifact", "task-1", "artifacts/.gitkeep", "")));
     const report = Effect.runSync(coordinator.flush("explicit"));
 
@@ -226,7 +235,10 @@ test("WriteCoordinator commits self-host authored writes inside ignored nested h
     runGit(path.join(rootDir, "harness"), "commit", "-m", "seed nested harness");
     writeFileSync(path.join(rootDir, "harness/notes/unrelated.md"), "after\n", "utf8");
 
-    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    const coordinator = makeJournaledWriteCoordinator({
+      rootDir,
+      commitAuthor: testCommitAuthor
+    });
     Effect.runSync(coordinator.enqueue(docWrite("op-nested", "task-1", "notes.md", "nested")));
     const report = Effect.runSync(coordinator.flush("explicit"));
 
@@ -360,6 +372,11 @@ function indexBody(taskId: string, title: string, status: string): string {
 function initializeGitRepo(repoRoot: string): void {
   runGit(repoRoot, "init");
 }
+
+const testCommitAuthor = {
+  name: "Harness Test",
+  email: "harness@example.test"
+};
 
 function caseVariantPath(inputPath: string): string | null {
   const basename = path.basename(inputPath);

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -33,7 +33,7 @@ test("WriteCoordinator journals actor person and uses explicit git authors", () 
     const bob = makeJournaledWriteCoordinator({
       rootDir,
       actor: { kind: "human", id: "person_bob" },
-      commitAuthor: { name: "Bob Builder", email: "team-fallback@example.invalid" }
+      commitAuthor: { name: "Bob Builder", email: "bob@example.com" }
     });
 
     Effect.runSync(alice.enqueue(docWrite("op-alice", "task-1", "alice.md", "alice")));
@@ -42,11 +42,13 @@ test("WriteCoordinator journals actor person and uses explicit git authors", () 
     Effect.runSync(alice.flush("explicit"));
 
     Effect.runSync(bob.enqueue(docWrite("op-bob", "task-1", "bob.md", "bob")));
+    const bobJournalBody = readFileSync(path.join(rootDir, ".harness/write-journal/writes.jsonl"), "utf8");
+    assert.match(bobJournalBody, /"actor":\{"kind":"human","id":"person_bob"\}/u);
     Effect.runSync(bob.flush("explicit"));
 
     assert.deepEqual(
       runGit(rootDir, "log", "-2", "--format=%an <%ae>").split(/\r?\n/u),
-      ["Bob Builder <team-fallback@example.invalid>", "Alice Admin <alice@example.com>"]
+      ["Bob Builder <bob@example.com>", "Alice Admin <alice@example.com>"]
     );
   });
 });

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -251,22 +251,22 @@
     ],
     "exemptHumanOrBootstrap": [
       {
-        "value": "packages/cli/src/commands/core/init.ts#mkdirSync@97:3",
+        "value": "packages/cli/src/commands/core/init.ts#mkdirSync@108:3",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init Configure-Verify smoke package bootstrap write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/core/init.ts#rmSync@31:7",
+        "value": "packages/cli/src/commands/core/init.ts#rmSync@42:7",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/core/init.ts#rmSync@39:7",
+        "value": "packages/cli/src/commands/core/init.ts#rmSync@50:7",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/core/init.ts#writeFileSync@98:3",
+        "value": "packages/cli/src/commands/core/init.ts#writeFileSync@109:3",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init Configure-Verify smoke package bootstrap write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
@@ -476,32 +476,32 @@
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/init.ts#mkdirSync@30:5",
+        "value": "packages/cli/src/commands/init.ts#mkdirSync@31:5",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init local directory bootstrap write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/init.ts#mkdirSync@286:5",
+        "value": "packages/cli/src/commands/init.ts#mkdirSync@289:5",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init harness.yaml bootstrap write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/init.ts#writeFileSync@52:5",
+        "value": "packages/cli/src/commands/init.ts#writeFileSync@53:5",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init optional package.json script bootstrap write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/init.ts#writeFileSync@287:5",
+        "value": "packages/cli/src/commands/init.ts#writeFileSync@290:5",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init harness.yaml bootstrap write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/init.ts#writeFileSync@296:3",
+        "value": "packages/cli/src/commands/init.ts#writeFileSync@299:3",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init harness.yaml name update write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/init.ts#writeFileSync@303:3",
+        "value": "packages/cli/src/commands/init.ts#writeFileSync@306:3",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init outer .gitignore bootstrap isolation write; governed by dec_mraja5we task scope and not a machine projection authority."
       },

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -15,6 +15,9 @@ const roots = ["packages", "tools"];
 // env, so the cache is shared. Lives under node_modules/.cache (already
 // git-ignored).
 process.env.NODE_COMPILE_CACHE ||= resolve(repoRoot, "node_modules/.cache/harness-node-compile");
+process.env.HARNESS_ACTOR ||= "human:harness-test";
+process.env.HARNESS_GIT_AUTHOR_NAME ||= "Harness Test";
+process.env.HARNESS_GIT_AUTHOR_EMAIL ||= "harness@example.test";
 
 let options;
 try {

--- a/tools/smoke-cli-package.mjs
+++ b/tools/smoke-cli-package.mjs
@@ -113,7 +113,21 @@ export function buildCliPackageArtifact(root, options = {}) {
 }
 
 function runJson(command, args, cwd) {
-  return unwrapReceipt(JSON.parse(execFileSync(command.file, [...command.argsPrefix, ...args], { cwd, encoding: "utf8" })));
+  return unwrapReceipt(JSON.parse(execFileSync(command.file, [...command.argsPrefix, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: smokeCliWriteEnv()
+  })));
+}
+
+function smokeCliWriteEnv() {
+  return {
+    ...process.env,
+    // Test-only actor attribution for package smoke writes; real env wins.
+    HARNESS_ACTOR: process.env.HARNESS_ACTOR || "human:harness-smoke",
+    HARNESS_GIT_AUTHOR_NAME: process.env.HARNESS_GIT_AUTHOR_NAME || "Harness Smoke",
+    HARNESS_GIT_AUTHOR_EMAIL: process.env.HARNESS_GIT_AUTHOR_EMAIL || "harness-smoke@example.test"
+  };
 }
 
 function resolveBinCommand(consumerDir, name) {

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -98,6 +98,7 @@ export const testTierManifest = {
     "packages/adapters/multica/test/multica-readonly-adopt.test.ts",
     "packages/application/test/local-controller-service.test.ts",
     "packages/daemon/test/transport-integration.test.ts",
+    "packages/cli/test/actor-attribution-cli.test.ts",
     "packages/cli/test/anchor-backfill-cli.test.ts",
     "packages/cli/test/attribution-diff-cli.test.ts",
     "packages/cli/test/check-governance-cli.test.ts",


### PR DESCRIPTION
# English

## Summary

Close red line 3 of the multi-collaborator write-path ruling (MC-A3): every ledger write is attributed to a real actor. The `agent:local-lifecycle` placeholder and the hardcoded `Harness Anything <harness@example.invalid>` git author family — the same author that signed the machine commits in the recent ledger-leak incident — are eliminated from all production write paths. Daemon writes resolve the per-request authenticated actor from `harness/people.yaml` to a `human:<personId>` journal actor and a real git author; local direct CLI writes require explicit `HARNESS_ACTOR=kind:id` (+ git author env) and fail with a configuration error instead of falling back to a placeholder. The `kind:id` actor shape is the seam the future principal design plugs into.

## What Changed

- Local lifecycle composition and preset/legacy task write labels: `agent:local-lifecycle` removed; actor comes from explicit configuration.
- Local VCS + `init` git commits: product-identity author fallbacks removed; `init` uses the resolved commit author.
- Daemon command writes: requests without a resolved actor no longer enqueue; command service maps `AuthenticatedActor` → journal actor + git author, failing explicitly when `primaryEmail` is missing.
- Test runner (`tools/run-node-tests.mjs`): provides default test-identity env via `||=` (real env always wins) so the explicit-fail paths stay testable without weakening production behavior.
- New `packages/cli/test/actor-attribution-cli.test.ts`; dual-identity coverage in `same-task-fifo.test.ts` (Alice/Bob distinct journal actors and git authors) and daemon thin-client attribution assertions.
- Gate allowlist `check-bypass-write-boundary.json`: line-number re-anchoring only (reasons/refs unchanged).

## Task And Scope

- Harness task: task_01KX19G18XCB2788X243S7QJS4 (MC-A3, red line 3 of the centralization write-path decision; principal seam per the actor-attribution ruling)
- Branch: codex/mc-a3-actor-attribution
- Public scope: 19 files, cli/daemon/kernel attribution surfaces + tests
- Private planning/evidence updated: yes
- Out of scope: principal implementation (future B4 line), write primitives (MC-A2, merged), claim/lease (MC-B1)

## Version Impact

- Version: no version change because this is internal attribution hardening
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes (gate allowlist under tools/gate-allowlists/; test runner tools/run-node-tests.mjs)
- Protected surface scope: check-bypass-write-boundary.json (line-number re-anchoring of existing entries, reasons/refs unchanged); run-node-tests.mjs adds default test-identity env only (`||=`, no assertion or gate behavior change)
- Authority: the accepted centralization write-path decision (red line 3: real actor attribution) and the accepted principal-seam ruling recorded in the private ledger; task task_01KX19G18XCB2788X243S7QJS4
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: audit remaining daemon service surfaces using LocalControllerService for per-request actor plumbing (recorded as residual risk)

## Verification

- Base `origin/main` SHA: latest at push time (rebased onto the merge commit of #488)
- Branch merge-base with `origin/main`: equals `origin/main` (rebased)
- Last `git fetch origin` time: 2026-07-09 (immediately before rebase and push)
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/mc-a3-actor-attribution`
- Private evidence commit/path: harness task package artifacts (report archived)
- Reviewer evidence path: harness task package review.md (private ledger)
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (via check:local fast tier, green post-rebase)
- [x] `npm test` (scoped: fast tier 220 + contract 324 green pre-rebase; post-rebase check:local green; dual-identity attribution suites 14/14 post-rebase, 29/29 pre-rebase incl. daemon thin-client)
- [x] `npm run harness:check-import-boundaries` (via check:local, green post-rebase)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check` locally — post-rebase `check:local` (21.4s) + `check:local:gates` (8.9s) both green with zero allowlist drift; CI is authoritative on this PR.

## Review Evidence

- Self-review: worker grep-verified zero placeholder hits across cli/adapters/kernel/daemon production sources (`local-lifecycle|harness@example.invalid|...` → no matches)
- Reviewer subagent: post-rebase gate rerun + dual-identity suite rerun (14/14), confirmed zero anchor drift and single ZeyuLi commit
- Human review: CEO semantic acceptance against write-path ruling red line 3 + principal-seam ruling (kind:id shape; explicit-fail chain daemon/local both forms; run-node-tests env verified as test-only `||=` defaults, not a production fallback)
- Blocking findings: none

## Residual Risk

- Other daemon service surfaces using `LocalControllerService` deserve a follow-up audit before claiming every GUI/service-originated write carries per-request actor plumbing.
- Journal compaction can leave `writes.jsonl` empty after flush; attribution is asserted at enqueue/coordinator level and via git author after flush.
- No manual smoke of the remote daemon SSH path beyond existing test coverage.

## References

- Task: task_01KX19G18XCB2788X243S7QJS4
- Evidence: private harness ledger task package
- Review: private harness ledger task package review.md

---

# 中文

## 概要

关多协作写道裁决的红线 3(MC-A3):每笔台账写归因到真实 actor。`agent:local-lifecycle` 占位与硬编码 git 作者族 `Harness Anything <harness@example.invalid>`——正是近期台账泄漏事故中机器提交的签名作者——从全部生产写路径消除。daemon 写从 `harness/people.yaml` 解析每请求认证 actor,映射为 `human:<personId>` journal actor+真实 git author;本地直连 CLI 写要求显式 `HARNESS_ACTOR=kind:id`(+git author env),缺配置报配置错误而非回落占位。`kind:id` 形态即未来 principal 设计的接缝。

## 改动内容

- 本地生命周期组合与 preset/legacy task 写标签:`agent:local-lifecycle` 移除,actor 来自显式配置。
- 本地 VCS 与 `init` 的 git 提交:产品身份作者回落移除;`init` 使用解析出的提交作者。
- daemon 命令写:未解析出 actor 的请求不再入队;command service 把 `AuthenticatedActor` 映射为 journal actor+git author,缺 `primaryEmail` 显式失败。
- 测试运行器(`tools/run-node-tests.mjs`):以 `||=` 提供默认测试身份 env(真实 env 永远优先),保证显式失败路径可测,不弱化生产行为。
- 新增 `packages/cli/test/actor-attribution-cli.test.ts`;`same-task-fifo.test.ts` 双身份覆盖(Alice/Bob journal actor 与 git author 可区分)+ daemon thin-client 归因断言。
- gate allowlist `check-bypass-write-boundary.json`:仅行号重锚(reason/ref 原样)。

## 任务与范围

- Harness 任务:task_01KX19G18XCB2788X243S7QJS4(MC-A3,中心化写道裁决红线 3;principal 接缝按归因裁决)
- 分支:codex/mc-a3-actor-attribution
- 公开范围:19 文件,cli/daemon/kernel 归因面+测试
- 私有计划 / 证据是否已更新:yes
- 范围外:principal 实现(未来 B4 线)、写原语(MC-A2,已合)、claim/lease(MC-B1)

## 版本影响

- 版本:不改版本,原因是内部归因加固
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes(tools/gate-allowlists/ 下 allowlist;测试运行器 tools/run-node-tests.mjs)
- protected surface 范围:check-bypass-write-boundary.json(既有条目行号重锚,reason/ref 原样);run-node-tests.mjs 仅加默认测试身份 env(`||=`,不改断言与 gate 行为)
- 依据:私有 ledger 中已 accept 的中心化写道裁决(红线 3:真实 actor 归因)与 principal 接缝裁决;task task_01KX19G18XCB2788X243S7QJS4
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:审计其余经 LocalControllerService 的 daemon 服务面的每请求 actor 贯通(已记残余风险)

## 验证

- `origin/main` 基准 SHA:push 时最新(rebase 到 #488 合并提交之上)
- 当前分支与 `origin/main` 的 merge-base:等于 `origin/main`(已 rebase)
- 最近一次 `git fetch origin` 时间:2026-07-09(rebase 与 push 前)
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...codex/mc-a3-actor-attribution`
- 私有证据 commit/path:harness 任务包 artifacts(报告已归档)
- Reviewer 证据路径:harness 任务包 review.md(私有 ledger)
- GitHub Actions `rewrite-ci` run URL:待本 PR 的 CI 运行后回填
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`(经 check:local fast 档,rebase 后绿)
- [x] `npm test`(范围化:rebase 前 fast 档 220+contract 档 324 绿;rebase 后 check:local 绿;双身份归因套件 rebase 后 14/14、rebase 前 29/29 含 daemon thin-client)
- [x] `npm run harness:check-import-boundaries`(经 check:local,rebase 后绿)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地未跑全量 `npm run check`——rebase 后 `check:local`(21.4s)+`check:local:gates`(8.9s)双绿且 allowlist 零漂移;以本 PR 的 CI 为权威。

## 审查证据

- 自查:worker grep 验证 cli/adapters/kernel/daemon 生产源占位零命中
- Reviewer subagent:rebase 后 gate 复跑+双身份套件复跑(14/14),确认零锚点漂移、单 ZeyuLi 提交
- 人工审查:CEO 对写道裁决红线 3+principal 接缝裁决语义验收(kind:id 形态;daemon/本地双形态显式失败链;run-node-tests env 核为仅测试默认值非生产回落)
- 阻塞发现:无

## 残余风险

- 其余经 `LocalControllerService` 的 daemon 服务面待后续审计,才能宣称所有 GUI/服务发起的写都有每请求 actor 贯通。
- journal 压实后 `writes.jsonl` 可能为空;归因在入队/coordinator 层断言+flush 后以 git author 断言。
- 远程 daemon SSH 路径无既有测试覆盖之外的手工冒烟。

## 关联材料

- 任务:task_01KX19G18XCB2788X243S7QJS4
- 证据:私有 harness ledger 任务包
- 审查:私有 harness ledger 任务包 review.md

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
