### PR TITLE
fix: stop local ledger artifacts entering git; outer repo never a commit target

### DIFF
--- a/packages/cli/src/daemon/command-service.ts
+++ b/packages/cli/src/daemon/command-service.ts
@@ -24,6 +24,7 @@ export function createCliCommandService(runtime: CliDaemonRuntime, options: CliC
       options.onCommandStart?.();
       const command = readParsedCommandPayload(payload);
       const daemonActor = context?.actor;
+      const sessionId = readSessionId(payload);
       try {
         const attribution = daemonActor ? daemonActorAttribution(daemonActor) : undefined;
         const result = await runRegisteredCommandWithCliComposition(command, {
@@ -35,7 +36,7 @@ export function createCliCommandService(runtime: CliDaemonRuntime, options: CliC
             ? makeDaemonQueuedWriteCoordinator(
               runtime,
               `${command.action.kind}:${actor.kind}:${actor.id}`,
-              { actor: attribution.actor, commitAuthor: attribution.commitAuthor }
+              { actor: attribution.actor, commitAuthor: attribution.commitAuthor, ...(sessionId ? { sessionId } : {}) }
             )
             : missingDaemonActorCoordinator(command.action.kind, actor)
         });
@@ -69,6 +70,13 @@ function missingDaemonActorCoordinator(
     flush: () => fail(),
     recover: fail()
   };
+}
+
+function readSessionId(payload: JsonObject | undefined): string | undefined {
+  const session = payload?.session;
+  if (!isPlainRecord(session) || typeof session.sessionId !== "string") return undefined;
+  const trimmed = session.sessionId.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function readParsedCommandPayload(payload: JsonObject | undefined): ParsedCommand {

--- a/packages/cli/src/daemon/queued-write-coordinator.ts
+++ b/packages/cli/src/daemon/queued-write-coordinator.ts
@@ -17,6 +17,7 @@ export interface CliDaemonRuntime {
     readonly ops: ReadonlyArray<QueuedWriteOp>;
     readonly actor?: QueuedJournalActor;
     readonly commitAuthor?: QueuedGitCommitAuthor;
+    readonly sessionId?: string;
   }) => Promise<{
     readonly flush: FlushReport;
   }>;
@@ -28,7 +29,7 @@ export interface CliDaemonRuntime {
 export function makeDaemonQueuedWriteCoordinator(
   runtime: CliDaemonRuntime,
   commandId: string,
-  options: { readonly actor?: QueuedJournalActor; readonly commitAuthor?: QueuedGitCommitAuthor } = {}
+  options: { readonly actor?: QueuedJournalActor; readonly commitAuthor?: QueuedGitCommitAuthor; readonly sessionId?: string } = {}
 ): WriteCoordinator {
   const pending: Array<QueuedWriteOp> = [];
   return {
@@ -46,7 +47,8 @@ export function makeDaemonQueuedWriteCoordinator(
           commandId,
           ops,
           ...(options.actor ? { actor: options.actor } : {}),
-          ...(options.commitAuthor ? { commitAuthor: options.commitAuthor } : {})
+          ...(options.commitAuthor ? { commitAuthor: options.commitAuthor } : {}),
+          ...(options.sessionId ? { sessionId: options.sessionId } : {})
         });
         return receipt.flush;
       },

--- a/packages/kernel/src/store/daemon-runtime-queue.ts
+++ b/packages/kernel/src/store/daemon-runtime-queue.ts
@@ -12,6 +12,7 @@ export interface InteractiveWriteRequest {
   readonly deadlineMs?: number;
   readonly actor?: JournalActor;
   readonly commitAuthor?: GitCommitAuthor;
+  readonly sessionId?: string;
 }
 
 export interface InteractiveWriteReceipt {
@@ -41,6 +42,7 @@ interface InteractiveQueueItem {
   readonly ops: ReadonlyArray<WriteOp>;
   readonly actor?: JournalActor;
   readonly commitAuthor?: GitCommitAuthor;
+  readonly sessionId?: string;
   readonly enqueuedAt: number;
   started: boolean;
   timeout?: ReturnType<typeof setTimeout>;
@@ -67,7 +69,7 @@ export class DaemonWriteQueue {
   private running = false;
   private closed = false;
   private idleWaiters: Array<() => void> = [];
-  private coordinatorFor: ((batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }) => JournaledWriteCoordinator) | undefined;
+  private coordinatorFor: ((batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor; readonly sessionId?: string }) => JournaledWriteCoordinator) | undefined;
   private readonly maxInteractiveOpsPerCommit: number;
   private readonly interactiveMicroBatchMs: number;
 
@@ -81,7 +83,7 @@ export class DaemonWriteQueue {
 
   enqueueInteractive(
     request: InteractiveWriteRequest,
-    coordinatorFor: (batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }) => JournaledWriteCoordinator
+    coordinatorFor: (batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor; readonly sessionId?: string }) => JournaledWriteCoordinator
   ): Promise<InteractiveWriteReceipt> {
     if (this.closed) return Promise.reject({ _tag: "JournalUnavailable", cause: new Error("daemon write queue is closed") } satisfies WriteError);
     this.coordinatorFor = coordinatorFor;
@@ -92,6 +94,7 @@ export class DaemonWriteQueue {
         ops: request.ops,
         ...(request.actor ? { actor: request.actor } : {}),
         ...(request.commitAuthor ? { commitAuthor: request.commitAuthor } : {}),
+        ...(request.sessionId ? { sessionId: request.sessionId } : {}),
         enqueuedAt: Date.now(),
         started: false,
         resolve,
@@ -171,7 +174,7 @@ export class DaemonWriteQueue {
   }
 
   private async drainInteractive(
-    coordinatorFor: (batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor }) => JournaledWriteCoordinator
+    coordinatorFor: (batch: { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor; readonly sessionId?: string }) => JournaledWriteCoordinator
   ): Promise<void> {
     if (this.interactiveMicroBatchMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, this.interactiveMicroBatchMs));
@@ -250,16 +253,18 @@ export class DaemonWriteQueue {
   }
 }
 
-function attributionFor(item: InteractiveQueueItem | undefined): { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor } {
+function attributionFor(item: InteractiveQueueItem | undefined): { readonly actor?: JournalActor; readonly commitAuthor?: GitCommitAuthor; readonly sessionId?: string } {
   return {
     ...(item?.actor ? { actor: item.actor } : {}),
-    ...(item?.commitAuthor ? { commitAuthor: item.commitAuthor } : {})
+    ...(item?.commitAuthor ? { commitAuthor: item.commitAuthor } : {}),
+    ...(item?.sessionId ? { sessionId: item.sessionId } : {})
   };
 }
 
 function sameAttribution(left: InteractiveQueueItem, right: InteractiveQueueItem): boolean {
   return actorKey(left.actor) === actorKey(right.actor)
-    && authorKey(left.commitAuthor) === authorKey(right.commitAuthor);
+    && authorKey(left.commitAuthor) === authorKey(right.commitAuthor)
+    && sessionKey(left.sessionId) === sessionKey(right.sessionId);
 }
 
 function actorKey(actor: JournalActor | undefined): string {
@@ -268,6 +273,10 @@ function actorKey(actor: JournalActor | undefined): string {
 
 function authorKey(author: GitCommitAuthor | undefined): string {
   return author ? `${author.name}\0${author.email}` : "";
+}
+
+function sessionKey(sessionId: string | undefined): string {
+  return sessionId?.trim() ?? "";
 }
 
 function toWriteError(error: unknown): WriteError {

--- a/packages/kernel/src/store/daemon-runtime.ts
+++ b/packages/kernel/src/store/daemon-runtime.ts
@@ -337,7 +337,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
 
   private makeStartedCoordinator(
     started: ReturnType<DaemonRepoRuntimeContext["requireAttached"]>,
-    request?: { readonly actor?: JournalActor; readonly commitAuthor?: InteractiveWriteRequest["commitAuthor"] }
+    request?: { readonly actor?: JournalActor; readonly commitAuthor?: InteractiveWriteRequest["commitAuthor"]; readonly sessionId?: string }
   ) {
     return makeJournaledWriteCoordinator({
       rootDir: this.rootDir,
@@ -346,6 +346,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       lockTtlMs: this.lockTtlMs,
       heldGlobalLock: started.lock,
       autoMaterialize: false,
+      ...(request?.sessionId ? { sessionId: request.sessionId } : {}),
       ...(request?.commitAuthor ? { commitAuthor: request.commitAuthor } : {})
     });
   }

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -12,7 +12,7 @@ export function makeLocalVersionControlSystem(): VersionControlSystem {
     topLevel: gitTopLevel,
     isIgnored: (repoRoot, relativePath) => {
       try {
-        runGit(repoRoot, "check-ignore", "-q", "--", relativePath);
+        runGit(repoRoot, "check-ignore", "--no-index", "-q", "--", relativePath);
         return true;
       } catch {
         return false;

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -31,7 +31,7 @@ import { updateTaskProjectionIncrementally } from "../projection/sqlite-task-inc
 import { hashTaskProjectionRows } from "../projection/sqlite-task-projection.ts";
 import { readMarkdownSource } from "../projection/sqlite-task-source.ts";
 import { appendJsonLineDurably, readDurableState, readPayloadRef, writePayloadRef, writeWatermarkDurably, writeFileDurably } from "./write-journal-durable.ts";
-import { commitTouchedPaths, resolveCommitPlan } from "./write-journal-git.ts";
+import { assertCommitPlanAddable, commitTouchedPaths } from "./write-journal-git.ts";
 import { runLedgerMaterializer } from "./ledger-materializer.ts";
 import { assertDirectWriteAllowed, withRepoLocks, WriteLockHeldError } from "./write-journal-locks.ts";
 import { NonTaskWriteEntityError, taskIdForJournalRecord, taskIdForWriteOp } from "./write-journal-entity.ts";
@@ -190,7 +190,7 @@ function flushRecords(
     touchedPaths: recordTouchedPaths(rootDir, rootInput, record)
   }));
 
-  resolveCommitPlan(rootDir, plannedRecords.flatMap((record) => record.touchedPaths), rootInput, versionControlSystem);
+  assertCommitPlanAddable(rootDir, plannedRecords.flatMap((record) => record.touchedPaths), rootInput, { versionControlSystem });
   const previousProjectionSourceHash = records.length > 0 ? readMarkdownSource(rootInput).hash : undefined;
 
   for (const { record, touchedPaths: recordTouchedPaths } of plannedRecords) {
@@ -211,7 +211,6 @@ function flushRecords(
     semanticCommitMessage(rootDir, plannedRecords.map((entry) => entry.record)),
     sessionId,
     {
-      respectGitignorePaths: plannedRecords.filter((entry) => entry.record.kind === "task_tree_stage").flatMap((entry) => entry.touchedPaths),
       author: commitAuthor,
       versionControlSystem
     }
@@ -304,7 +303,7 @@ function createJournalRecord(rootDir: string, journalPath: string, op: {
 }
 
 function preflightWriteOp(rootDir: string, rootInput: HarnessLayoutInput, op: WriteOp, versionControlSystem?: VersionControlSystem): void {
-  resolveCommitPlan(rootDir, writeOpTouchedPaths(rootInput, op), rootInput, versionControlSystem);
+  assertCommitPlanAddable(rootDir, writeOpTouchedPaths(rootInput, op), rootInput, { versionControlSystem });
   try {
     assertDocumentWritePathsDoNotCollide(rootInput, documentWritesForWriteOp(op));
   } catch (error) {

--- a/packages/kernel/src/store/write-journal-git.ts
+++ b/packages/kernel/src/store/write-journal-git.ts
@@ -15,7 +15,7 @@ export function commitTouchedPaths(
   message?: string,
   sessionId?: string,
   options: {
-    readonly respectGitignorePaths?: ReadonlyArray<string>;
+    readonly forceAddPaths?: ReadonlyArray<string>;
     readonly author?: GitCommitAuthor;
     readonly versionControlSystem?: VersionControlSystem;
   } = {}
@@ -23,11 +23,14 @@ export function commitTouchedPaths(
   if (touchedPaths.length === 0) return "no-git-change";
   const vcs = options.versionControlSystem ?? defaultVersionControlSystem;
 
-  const plan = resolveCommitPlan(rootDir, touchedPaths, layoutInput, vcs);
+  const plan = assertCommitPlanAddable(rootDir, touchedPaths, layoutInput, {
+    forceAddPaths: options.forceAddPaths,
+    versionControlSystem: vcs
+  });
   if (!plan) return "no-git-change";
-  const respectGitignore = new Set(resolveCommitPlan(rootDir, options.respectGitignorePaths ?? [], layoutInput, vcs)?.relativePaths ?? []);
-  const forcedPaths = plan.relativePaths.filter((relativePath) => !respectGitignore.has(relativePath));
-  const unforcedPaths = plan.relativePaths.filter((relativePath) => respectGitignore.has(relativePath));
+  const forceAdd = resolveForceAddSet(rootDir, options.forceAddPaths ?? [], layoutInput, vcs);
+  const forcedPaths = plan.relativePaths.filter((relativePath) => forceAdd.has(relativePath));
+  const unforcedPaths = plan.relativePaths.filter((relativePath) => !forceAdd.has(relativePath));
   const sessionBranch = sessionBranchName(sessionId);
   // Resolve the trunk branch while HEAD still points at it, before checkoutSessionBranch
   // moves us onto the session branch; the finally must return to the same trunk.
@@ -54,27 +57,50 @@ export function resolveCommitPlan(
   layoutInput: HarnessLayoutInput = rootDir,
   versionControlSystem: VersionControlSystem = defaultVersionControlSystem
 ): { readonly repoRoot: string; readonly relativePaths: ReadonlyArray<string> } | null {
-  if (touchedPaths.length === 0) return null;
-  const target = resolveCommitTarget(rootDir, resolveHarnessLayout(layoutInput).authoredRoot, touchedPaths, versionControlSystem);
+  const layout = resolveHarnessLayout(layoutInput);
+  const committablePaths = excludeLocalRootPaths(layout.localRoot, touchedPaths, versionControlSystem);
+  if (committablePaths.length === 0) return null;
+  const target = resolveCommitTarget(rootDir, layout.authoredRoot, committablePaths, versionControlSystem);
   if (!target) return null;
   return {
     repoRoot: target.repoRoot,
-    relativePaths: unique(touchedPaths.map((filePath) => repoRelativePath(target.repoRoot, filePath, versionControlSystem)))
+    relativePaths: unique(committablePaths.map((filePath) => repoRelativePath(target.repoRoot, filePath, versionControlSystem)))
   };
+}
+
+export function assertCommitPlanAddable(
+  rootDir: string,
+  touchedPaths: ReadonlyArray<string>,
+  layoutInput: HarnessLayoutInput = rootDir,
+  options: {
+    readonly forceAddPaths?: ReadonlyArray<string>;
+    readonly versionControlSystem?: VersionControlSystem;
+  } = {}
+): { readonly repoRoot: string; readonly relativePaths: ReadonlyArray<string> } | null {
+  const vcs = options.versionControlSystem ?? defaultVersionControlSystem;
+  const plan = resolveCommitPlan(rootDir, touchedPaths, layoutInput, vcs);
+  if (!plan) return null;
+  const forceAdd = resolveForceAddSet(rootDir, options.forceAddPaths ?? [], layoutInput, vcs);
+  const ignoredPaths = plan.relativePaths.filter((relativePath) => !forceAdd.has(relativePath) && vcs.isIgnored(plan.repoRoot, relativePath));
+  if (ignoredPaths.length > 0) {
+    throw new Error(`gitignored authored path requires explicit forceAddPaths: ${ignoredPaths.join(", ")}`);
+  }
+  return plan;
 }
 
 function resolveCommitTarget(rootDir: string, authoredRoot: string, touchedPaths: ReadonlyArray<string>, vcs: VersionControlSystem): { readonly repoRoot: string } | null {
   const rootRepo = vcs.topLevel(rootDir);
   const authoredRepo = vcs.topLevel(authoredRoot);
-  if (!authoredRepo) return rootRepo ? { repoRoot: rootRepo } : null;
+  if (!touchedPaths.every((filePath) => isPathInside(authoredRoot, filePath, vcs))) return null;
+  if (!authoredRepo) {
+    if (!rootRepo || !isPathInsideRepo(rootRepo, authoredRoot, vcs)) return null;
+    if (isIgnoredByRepo(rootRepo, authoredRoot, vcs)) {
+      throw new Error("authored root is ignored by Git but is not a nested Git repository");
+    }
+    return { repoRoot: rootRepo };
+  }
   if (rootRepo && authoredRepo === rootRepo && isIgnoredByRepo(rootRepo, authoredRoot, vcs)) {
     throw new Error("authored root is ignored by Git but is not a nested Git repository");
-  }
-  if (touchedPaths.every((filePath) => isPathInsideRepo(authoredRepo, filePath, vcs))) {
-    return { repoRoot: authoredRepo };
-  }
-  if (rootRepo && touchedPaths.every((filePath) => isPathInsideRepo(rootRepo, filePath, vcs))) {
-    return { repoRoot: rootRepo };
   }
   return { repoRoot: authoredRepo };
 }
@@ -146,7 +172,27 @@ export function refExists(repoRoot: string, ref: string, versionControlSystem: V
 
 function isIgnoredByRepo(repoRoot: string, candidatePath: string, vcs: VersionControlSystem): boolean {
   const relativePath = repoRelativePath(repoRoot, candidatePath, vcs);
-  return vcs.isIgnored(repoRoot, relativePath);
+  const directoryPath = relativePath.endsWith("/") ? relativePath : `${relativePath}/`;
+  return vcs.isIgnored(repoRoot, relativePath) || vcs.isIgnored(repoRoot, directoryPath);
+}
+
+function resolveForceAddSet(
+  rootDir: string,
+  forceAddPaths: ReadonlyArray<string>,
+  layoutInput: HarnessLayoutInput,
+  vcs: VersionControlSystem
+): ReadonlySet<string> {
+  if (forceAddPaths.length === 0) return new Set<string>();
+  return new Set(resolveCommitPlan(rootDir, forceAddPaths, layoutInput, vcs)?.relativePaths ?? []);
+}
+
+function excludeLocalRootPaths(localRoot: string, touchedPaths: ReadonlyArray<string>, vcs: VersionControlSystem): ReadonlyArray<string> {
+  return touchedPaths.filter((filePath) => !isPathInside(localRoot, filePath, vcs));
+}
+
+function isPathInside(rootPath: string, filePath: string, vcs: VersionControlSystem): boolean {
+  const relativePath = path.relative(vcs.normalizePath(rootPath), vcs.normalizePath(filePath));
+  return relativePath.length === 0 || (relativePath !== ".." && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath));
 }
 
 function isPathInsideRepo(repoRoot: string, filePath: string, vcs: VersionControlSystem): boolean {

--- a/packages/kernel/test/store/daemon-runtime.test.ts
+++ b/packages/kernel/test/store/daemon-runtime.test.ts
@@ -126,6 +126,32 @@ test("daemon materializer producer runs bounded batches under the lifetime globa
   });
 });
 
+test("daemon interactive writes route sessionId commits to authored session branches", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: false,
+      interactiveMicroBatchMs: 0
+    });
+    await runtime.start();
+
+    const receipt = await runtime.enqueueInteractiveWrite({
+      commandId: "cmd-session-routed",
+      sessionId: "daemon-session-1",
+      ops: [docWrite("op-daemon-session", "task-daemon-session", "note.md", "session routed\n")]
+    });
+
+    assert.equal(receipt.flush.watermark, "op-daemon-session");
+    assert.equal(git(rootDir, "rev-parse", "--abbrev-ref", "HEAD"), "master");
+    assert.equal(git(rootDir, "branch", "--list", "sessions/daemon-session-1"), "sessions/daemon-session-1");
+    assert.match(git(rootDir, "log", "master..sessions/daemon-session-1", "--oneline"), /op-daemon-session/u);
+    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-daemon-session/note.md")), false);
+
+    await runtime.stop();
+  });
+});
+
 test("daemon interactive queue does not mix different git authors in one commit", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initAuthoredGit(rootDir);

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -6,7 +6,8 @@ import path from "node:path";
 import { Effect } from "effect";
 import { hashTaskProjectionRows, rebuildTaskProjection } from "../../src/index.ts";
 import { makeJournaledWriteCoordinator } from "../../src/store/index.ts";
-import { taskEntityId } from "../../src/domain/index.ts";
+import { resolveCommitPlan } from "../../src/store/write-journal-git.ts";
+import { moduleEntityId, taskEntityId } from "../../src/domain/index.ts";
 import { docWrite, withTempStore } from "./helpers.ts";
 
 test("WriteCoordinator flushes same-task writes in FIFO order", () => {
@@ -25,6 +26,7 @@ test("WriteCoordinator flushes same-task writes in FIFO order", () => {
 test("WriteCoordinator journals actor person and uses explicit git authors", () => {
   withTempStore((rootDir) => {
     initializeGitRepo(rootDir);
+    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
     const alice = makeJournaledWriteCoordinator({
       rootDir,
       actor: { kind: "human", id: "person_alice" },
@@ -165,23 +167,144 @@ test("WriteCoordinator rejects hard delete for task packages with anchored facts
   });
 });
 
-test("WriteCoordinator force-adds explicit harness paths ignored by target repo patterns", () => {
+test("WriteCoordinator rejects ignored authored paths instead of reporting success", () => {
   withTempStore((rootDir) => {
     initializeGitRepo(rootDir);
+    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
     writeFileSync(path.join(rootDir, ".gitignore"), "artifacts/\n", "utf8");
     runGit(rootDir, "add", ".gitignore");
     runGit(rootDir, "commit", "-m", "ignore artifacts");
+    const beforeHead = runGit(rootDir, "rev-parse", "HEAD");
 
     const coordinator = makeJournaledWriteCoordinator({
       rootDir,
       commitAuthor: testCommitAuthor
     });
-    Effect.runSync(coordinator.enqueue(docWrite("op-ignored-artifact", "task-1", "artifacts/.gitkeep", "")));
+    assert.throws(
+      () => Effect.runSync(coordinator.enqueue(docWrite("op-ignored-artifact", "task-1", "artifacts/.gitkeep", ""))),
+      /gitignored authored path requires explicit forceAddPaths: harness\/tasks\/task-1\/artifacts\/\.gitkeep/u
+    );
+
+    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-1/artifacts/.gitkeep")), false);
+    assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
+    assert.equal(runGit(rootDir, "rev-parse", "HEAD"), beforeHead);
+  });
+});
+
+test("WriteCoordinator rejects tracked files that are now matched by gitignore", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    mkdirSync(path.join(rootDir, "harness/tasks/task-1/artifacts"), { recursive: true });
+    writeFileSync(path.join(rootDir, ".gitignore"), "artifacts/\n", "utf8");
+    writeFileSync(path.join(rootDir, "harness/tasks/task-1/artifacts/tracked.md"), "before\n", "utf8");
+    runGit(rootDir, "add", ".gitignore");
+    runGit(rootDir, "add", "-f", "harness/tasks/task-1/artifacts/tracked.md");
+    runGit(rootDir, "commit", "-m", "seed tracked ignored authored path");
+    const beforeHead = runGit(rootDir, "rev-parse", "HEAD");
+
+    const coordinator = makeJournaledWriteCoordinator({
+      rootDir,
+      commitAuthor: testCommitAuthor
+    });
+
+    assert.throws(
+      () => Effect.runSync(coordinator.enqueue(docWrite("op-tracked-ignored-artifact", "task-1", "artifacts/tracked.md", "after\n"))),
+      /gitignored authored path requires explicit forceAddPaths: harness\/tasks\/task-1\/artifacts\/tracked\.md/u
+    );
+    assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-1/artifacts/tracked.md"), "utf8"), "before\n");
+    assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
+    assert.equal(runGit(rootDir, "rev-parse", "HEAD"), beforeHead);
+  });
+});
+
+test("WriteCoordinator excludes localRoot machine artifacts from every git repo", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    runGit(rootDir, "add", ".gitignore");
+    runGit(rootDir, "commit", "-m", "ignore private harness");
+    const outerHead = runGit(rootDir, "rev-parse", "HEAD");
+
+    const harnessRoot = path.join(rootDir, "harness");
+    mkdirSync(harnessRoot, { recursive: true });
+    initializeGitRepo(harnessRoot);
+    writeFileSync(path.join(harnessRoot, "harness.yaml"), [
+      "schema: harness-anything/v1",
+      "name: self-host-fixture",
+      "layout:",
+      "  authoredRoot: harness",
+      "  localRoot: .harness",
+      ""
+    ].join("\n"), "utf8");
+    runGit(harnessRoot, "add", "harness.yaml");
+    runGit(harnessRoot, "commit", "-m", "seed nested harness");
+    const innerHead = runGit(harnessRoot, "rev-parse", "HEAD");
+
+    const coordinator = makeJournaledWriteCoordinator({
+      rootDir,
+      sessionId: "codex-distill-leak",
+      autoMaterialize: false,
+      commitAuthor: testCommitAuthor
+    });
+    Effect.runSync(coordinator.enqueue({
+      opId: "op-distill-candidate",
+      entityId: moduleEntityId("distill-candidate"),
+      kind: "machine_artifact_write",
+      payload: {
+        boundary: "distill-candidate",
+        path: ".harness/generated/distill/task-1/distill_fixture.json",
+        body: "{\"schema\":\"distill-candidate/v1\"}\n"
+      }
+    }));
     const report = Effect.runSync(coordinator.flush("explicit"));
 
-    assert.equal(report.watermark, "op-ignored-artifact");
-    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-1/artifacts/.gitkeep")), true);
-    assert.match(runGit(rootDir, "show", "--name-only", "--format=", "HEAD"), /harness\/tasks\/task-1\/artifacts\/\.gitkeep/);
+    assert.equal(report.watermark, "op-distill-candidate");
+    assert.equal(readFileSync(path.join(rootDir, ".harness/generated/distill/task-1/distill_fixture.json"), "utf8"), "{\"schema\":\"distill-candidate/v1\"}\n");
+    assert.equal(runGit(rootDir, "rev-parse", "HEAD"), outerHead);
+    assert.equal(runGit(rootDir, "branch", "--list", "sessions/*"), "");
+    assert.equal(runGit(rootDir, "ls-files", "--", "harness", ".harness"), "");
+    assert.equal(runGit(harnessRoot, "rev-parse", "HEAD"), innerHead);
+    assert.equal(runGit(harnessRoot, "branch", "--list", "sessions/*"), "");
+  });
+});
+
+test("WriteCoordinator creates missing unignored authored root in root repo", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    writeFileSync(path.join(rootDir, ".gitignore"), "/.harness/\n", "utf8");
+    runGit(rootDir, "add", ".gitignore");
+    runGit(rootDir, "commit", "-m", "seed outer repo");
+    const beforeHead = runGit(rootDir, "rev-parse", "HEAD");
+
+    const coordinator = makeJournaledWriteCoordinator({
+      rootDir,
+      commitAuthor: testCommitAuthor
+    });
+    Effect.runSync(coordinator.enqueue(docWrite("op-create-authored-root", "task-1", "notes.md", "first write")));
+    const report = Effect.runSync(coordinator.flush("explicit"));
+
+    assert.equal(report.watermark, "op-create-authored-root");
+    assert.notEqual(runGit(rootDir, "rev-parse", "HEAD"), beforeHead);
+    assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-1/notes.md"), "utf8"), "first write");
+    assert.equal(runGit(rootDir, "ls-files", "--", "harness/tasks/task-1/notes.md"), "harness/tasks/task-1/notes.md");
+    assert.equal(runGit(rootDir, "branch", "--list", "sessions/*"), "");
+  });
+});
+
+test("resolveCommitPlan fails closed when missing authored root is ignored by root repo", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    runGit(rootDir, "add", ".gitignore");
+    runGit(rootDir, "commit", "-m", "ignore private harness");
+    const beforeHead = runGit(rootDir, "rev-parse", "HEAD");
+
+    assert.throws(
+      () => resolveCommitPlan(rootDir, [path.join(rootDir, "harness/tasks/task-1/notes.md")], rootDir),
+      /authored root is ignored by Git but is not a nested Git repository/u
+    );
+    assert.equal(runGit(rootDir, "rev-parse", "HEAD"), beforeHead);
+    assert.equal(runGit(rootDir, "branch", "--list", "sessions/*"), "");
   });
 });
 
@@ -341,6 +464,26 @@ test("WriteCoordinator fails closed when ignored authored root has no nested Git
     );
     assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
     assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/watermark.json")), false);
+  });
+});
+
+test("WriteCoordinator still fails closed when ignored authored root was force-tracked", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+    writeFileSync(path.join(rootDir, "harness/tracked.md"), "tracked despite ignore\n", "utf8");
+    runGit(rootDir, "add", ".gitignore");
+    runGit(rootDir, "add", "-f", "harness/tracked.md");
+    runGit(rootDir, "commit", "-m", "seed force tracked harness");
+
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+
+    assert.throws(
+      () => Effect.runSync(coordinator.enqueue(docWrite("op-force-tracked-ignored", "task-1", "notes.md", "ignored"))),
+      /authored root is ignored by Git but is not a nested Git repository/
+    );
+    assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
   });
 });
 

--- a/tools/check-private-boundary.mjs
+++ b/tools/check-private-boundary.mjs
@@ -32,16 +32,18 @@ if (topLevel !== cwd) {
   record(`run from repository root: expected ${topLevel}, got ${process.cwd()}`);
 }
 
-try {
-  // Probe a phantom child path: works even when .harness-private does not
-  // exist on disk (CI clean checkout), while still failing if the ignore
-  // rule is missing from .gitignore.
-  gitStatus(["check-ignore", "-q", ".harness-private/__boundary_probe__"]);
-} catch {
-  record(".harness-private is not ignored by git");
+for (const privateRoot of [".harness-private", "harness", ".harness"]) {
+  try {
+    // Probe a phantom child path: works even when the private root does not
+    // exist on disk (CI clean checkout), while still failing if the ignore
+    // rule is missing from .gitignore.
+    gitStatus(["check-ignore", "--no-index", "-q", `${privateRoot}/__boundary_probe__`]);
+  } catch {
+    record(`${privateRoot} is not ignored by git`);
+  }
 }
 
-const explicitlyForbidden = git(["ls-files", "--", ".harness-private", "AGENTS.md"])
+const explicitlyForbidden = git(["ls-files", "--", ".harness-private", "harness", ".harness", "AGENTS.md"])
   .trim()
   .split(/\r?\n/)
   .filter(Boolean);
@@ -58,11 +60,25 @@ const allowlist = loadGateAllowlist("check-private-boundary", {
 });
 const privateContentMarkers = entryJoinedValues(allowlist.privateContentMarkers);
 
+const sessionBranches = git(["branch", "--list", "sessions/*"])
+  .trim()
+  .split(/\r?\n/u)
+  .map((entry) => entry.replace(/^\*\s*/u, "").trim())
+  .filter(Boolean);
+
+for (const branch of sessionBranches) {
+  record(`forbidden session branch in public repo: ${branch}`);
+}
+
 for (const trackedPath of allTracked) {
   if (
     trackedPath === "AGENTS.md" ||
     trackedPath === ".harness-private" ||
     trackedPath.startsWith(".harness-private/") ||
+    trackedPath === "harness" ||
+    trackedPath.startsWith("harness/") ||
+    trackedPath === ".harness" ||
+    trackedPath.startsWith(".harness/") ||
     trackedPath.startsWith(".codex/attachments/")
   ) {
     record(`private path tracked in public repo: ${trackedPath}`);

--- a/tools/check-private-boundary.test.mjs
+++ b/tools/check-private-boundary.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const checkerPath = path.join(repoRoot, "tools/check-private-boundary.mjs");
+
+test("private boundary check passes when private roots are ignored and untracked", () => {
+  withBoundaryRepo((root) => {
+    const result = runChecker(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Private boundary check passed/u);
+  });
+});
+
+test("private boundary check rejects tracked harness roots", () => {
+  withBoundaryRepo((root) => {
+    mkdirSync(path.join(root, "harness"), { recursive: true });
+    writeFileSync(path.join(root, "harness/leak.md"), "private ledger\n", "utf8");
+    git(root, "add", "-f", "harness/leak.md");
+    git(root, "commit", "-m", "track harness leak");
+
+    const result = runChecker(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /private path tracked in public repo: harness\/leak\.md/u);
+  });
+});
+
+test("private boundary check rejects outer session branches", () => {
+  withBoundaryRepo((root) => {
+    git(root, "branch", "sessions/leak");
+
+    const result = runChecker(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /forbidden session branch in public repo: sessions\/leak/u);
+  });
+});
+
+function withBoundaryRepo(fn) {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-private-boundary-"));
+  try {
+    git(root, "init");
+    writeFileSync(path.join(root, ".gitignore"), [
+      "/.harness-private/",
+      "/harness/",
+      "/.harness/",
+      ""
+    ].join("\n"), "utf8");
+    git(root, "add", ".gitignore");
+    git(root, "commit", "-m", "seed boundary ignores");
+    fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function runChecker(root) {
+  return spawnSync(process.execPath, [checkerPath], {
+    cwd: root,
+    encoding: "utf8"
+  });
+}
+
+function git(root, ...args) {
+  return execFileSync("git", ["-C", root, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Harness Test",
+      GIT_AUTHOR_EMAIL: "harness-test@example.invalid",
+      GIT_COMMITTER_NAME: "Harness Test",
+      GIT_COMMITTER_EMAIL: "harness-test@example.invalid"
+    },
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -19,7 +19,7 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-coordinator.ts#rmSync@257:5",
+        "value": "packages/kernel/src/store/write-journal-coordinator.ts#rmSync@256:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -84,6 +84,7 @@ export const testTierManifest = {
     "tools/check-locale-content.test.mjs",
     "tools/check-pr-body-bilingual.test.mjs",
     "tools/check-pr-governance.test.mjs",
+    "tools/check-private-boundary.test.mjs",
     "tools/check-relation-cycle-substrate.test.mjs",
     "tools/check-service-mappability.test.mjs",
     "tools/check-schema-field-coverage.test.mjs",


### PR DESCRIPTION
# English

## Summary

Stops machine-generated ledger artifacts (`.harness/**`) from ever entering any git repository, and stops the outer public repository from ever becoming a commit target for paths it does not own. Root-cause fix for a real, reproduced private-ledger leak: `ha task complete` writes `.harness/generated/distill/*.json`, which falls outside `authoredRoot`, so `resolveCommitTarget` fell back to the outer repo, created a `sessions/<id>` branch there and force-added private files — and branch checkout then deleted real ledger files from the working tree.

## What Changed

- `localRoot` is excluded before the commit flow (not via gitignore): `resolveCommitPlan` filters any `.harness/**` path out of the commit plan before `git add` / session-branch logic runs. gitignore is not trusted as backstop — a first `force-add` permanently disarms it (`check-ignore` is index-aware).
- The leak guard is now stated as a mechanism, not as a repo comparison: `resolveCommitTarget` returns `null` unless **every** touched path lies inside `authoredRoot`. The outer repo can never receive a path it does not own. It may still legitimately *be* the commit target when `authoredRoot` lives inside it and is not ignored (the standalone, non-nested layout).
- Fail-closed where the layout is ambiguous: if `authoredRoot` is ignored by the repo that would own it — whether or not the directory exists yet — the write throws instead of falling back. That is the canonical `harness-anything` shape with a missing nested repo, and it must never land in the public repo.
- Force semantics reversed: was "force-add by default, respect an allowlist"; now "respect gitignore by default, force only an explicit `forceAddPaths` allowlist" (zero callers added). An authored path blocked by gitignore is now a hard failure before journal append or file mutation (`assertCommitPlanAddable`), never a silent drop.
- `check-ignore --no-index` so an ignore rule is honoured even for a path that was previously force-tracked.
- Inner `session-branch + materializer` model unchanged — only the misroute to the outer repo is removed; `sessionId` is threaded through the daemon/RPC/CLI queue purely for inner session-branch correctness.
- Defense in depth: `tools/check-private-boundary.mjs` (already the PR-required `boundaries` check) now also rejects tracked `harness/` / `.harness/` and any outer `sessions/*` branch, with red-fixture tests.

## Task And Scope

- Harness task: task_01KX227DQQMSKAP5PGZ1RQBZXJ (re-chartered from four point-patches to a write-path refactor)
- Branch: codex/ledger-refactor
- Public scope: kernel write-path (`packages/kernel/src/store/*`), daemon queue passthrough (`packages/cli/src/daemon/*`, `packages/kernel/src/store/daemon-runtime*`), boundary gate (`tools/check-private-boundary.mjs` + test), gate allowlist line re-anchor, test-tier manifest
- Private planning/evidence updated: yes
- Out of scope: rewriting existing public history (declined by prior decision); the `.harness/` ghost directory on disk (destructive, not touched)

## Version Impact

- Version: no version change because this is an internal write-path correctness/security fix with no published-surface API change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/check-private-boundary.mjs` (the `boundaries` required check — assertions added, none relaxed) + `tools/gate-allowlists/check-bypass-write-boundary.json` (single line-number re-anchor of an existing entry, reason/ref unchanged) + `tools/test-tier-manifest.mjs` (registers the new boundary test)
- Authority: the accepted decision to stop machine-artifact auto-commit and refactor the write-path landing point (refines the accept-existing-public-history decision), and task task_01KX227DQQMSKAP5PGZ1RQBZXJ, recorded in the private ledger
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Follow-up governance task: layout-governance enforcement that `harness/` is a nested repo or ignored (residual risk below)

## Verification

- Base `origin/main` SHA: 04e74bf
- Branch merge-base with `origin/main`: 04e74bf
- Last `git fetch origin` time: 2026-07-09T03:40:00Z
- Sync method: rebase onto `04e74bf` (no conflicts), single commit `3899fa5`
- Public diff command: `git diff origin/main...codex/ledger-refactor` (13 files, +376/-46)
- Private evidence commit/path: harness task package artifacts under the task's `artifacts/orchestration/` (private ledger)
- Reviewer evidence path: this PR description + task package review (private ledger)
- GitHub Actions `rewrite-ci` run URL: see this PR's Checks tab (`boundaries` job)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (local: `check:local` 15/15 + `check:local:gates` 17/17 green, post-rebase)
- [x] `npm run typecheck`
- [x] `npm test` (`--tier integration --concurrency=1`: 467 pass / 0 fail / 1 skipped, exit 0)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary` (`current=3 previous=3 delta=0`, passed)
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Leak gates on the branch: `git ls-files harness/ .harness/` = 0 entries; `git branch --list 'sessions/*'` = empty.
- Regression suite: `packages/cli/test/preset-module-cli.test.ts` 17 pass / 0 fail under the CI identity environment; negative control on `origin/main` also 17/0.
- Not run: the unchecked harness:* commands are covered by the CI `boundaries`/`fast-contract` jobs on this PR; the security-critical `check-private-boundary` was run locally alongside the full integration tier.

## Review Evidence

- Self-review: CEO read the full diff and required three follow-up fixes (a `return rootRepo` branch proven reachable; silent-drop of gitignored authored paths made a hard failure; boundary gate confirmed PR-required with red fixtures).
- **Correction on the record:** the first of those three instructions was wrong. The CEO asked for the `authoredRepo`-unresolved branch to be deleted outright, conflating "outer repo is the commit target" with "outer repo receives a foreign path". That branch is the legitimate first-write path when `authoredRoot` does not exist yet, and deleting it broke `ha module register` in every non-nested layout — caught by CI `integration`, initially misdiagnosed as a pre-existing flake because the reproduction command omitted the identity environment the test runner injects (`tools/run-node-tests.mjs`), turning both sides red. The invariant is now stated as a mechanism (every touched path inside `authoredRoot`) rather than as a forbidden line of code, and the leak guard is strictly stronger than before.
- Reviewer subagent: `codex review` + `adversarial-review` requested on the implementation.
- Human review: pending.
- Blocking findings: none open; all CEO findings resolved with tests.

## Residual Risk

- If `harness/` is neither a nested git repo nor ignored by the outer repo, `authoredRepo === rootRepo` and authored writes target the outer repo — indistinguishable in code from a standalone `authoredRoot: '.'` layout, so it must be enforced by `ha init` / layout governance, not here. Registered as a follow-up fact.
- `forceAddPaths` remains as an explicit escape hatch with zero callers; any future force use must come with a targeted test and governance evidence.
- Boundary errors still lose their underlying cause at the journal edge (a git-layout throw surfaced as `decode_failed`), which amplified the misdiagnosis above. Fixing that is registered as a separate task and is out of scope here.

## References

- Task: task_01KX227DQQMSKAP5PGZ1RQBZXJ
- Evidence: private ledger task package (blood-test outputs, boundary outputs, integration tier log)
- Review: this PR + task review.md (private ledger)

---

# 中文

## 概要

彻底堵住机器产物(`.harness/**`)进入任何 git 仓,并让外层公开仓永不成为「它不拥有的路径」的 commit target。一次真实复现过的私有账本泄漏的根因修复:`ha task complete` 生成的 `.harness/generated/distill/*.json` 落在 `authoredRoot` 之外,导致 `resolveCommitTarget` 回落到外层公开仓、在那里建 `sessions/<id>` 分支并 force-add 私有文件——切分支时又把真实账本文件从工作树删除。

## 改动内容

- `localRoot` 在进入 commit 流之前被剔除(不靠 gitignore):`resolveCommitPlan` 在 `git add` / session 分支逻辑之前,把 `.harness/**` 路径全部滤出提交计划。gitignore 不作兜底——首次 `force-add` 会永久解除它(`check-ignore` 默认查 index)。
- 泄漏守卫按**机制**表述,不按仓库比较表述:`resolveCommitTarget` 仅当**每一条** touched path 都落在 `authoredRoot` 之内时才返回目标,否则返回 `null`。外层仓永不接收不属于它的路径;但当 `authoredRoot` 就住在它里面且未被 ignore 时(独立、非嵌套布局),它仍可以合法地**是**那个 commit target。
- 布局歧义处 fail-closed:若 `authoredRoot` 被本该拥有它的那个仓 ignore——无论该目录是否已存在——写入直接抛错,绝不回落。这正是 canonical `harness-anything` 在嵌套仓缺失时的形状,它绝不能落进公开仓。
- force 语义反转:此前"默认 force-add + 白名单豁免",现在"默认尊重 gitignore + 仅白名单 `forceAddPaths` 强制"(零新增 caller)。被 gitignore 挡住的 authored 路径现在是进 journal / 改文件之前的硬失败(`assertCommitPlanAddable`),不再静默丢弃。
- `check-ignore --no-index`:即使某路径此前被 force-tracked,ignore 规则也照常生效。
- 内层 `session-branch + materializer` 模型保持不动——只移除通往外层仓的误路由;`sessionId` 只为内层 session 分支正确性透传。
- 防御纵深:`tools/check-private-boundary.mjs`(已是 PR-required 的 `boundaries` 门)现在还拒绝 tracked 的 `harness/` / `.harness/` 与任何外层 `sessions/*` 分支,带红线 fixture 测试。

## 任务与范围

- Harness 任务:task_01KX227DQQMSKAP5PGZ1RQBZXJ(从四条点状修补 re-charter 为写路径重构)
- 分支:codex/ledger-refactor
- 公开范围:kernel 写路径(`packages/kernel/src/store/*`)、daemon 队列透传(`packages/cli/src/daemon/*`、`packages/kernel/src/store/daemon-runtime*`)、边界门(`tools/check-private-boundary.mjs` + 测试)、gate allowlist 行号重锚、test-tier manifest
- 私有计划 / 证据是否已更新:yes
- 范围外:重写既有公共历史(前序裁决已否);磁盘上的 `.harness/` 幽灵目录(破坏性,未碰)

## 版本影响

- 版本:不改版本,原因是这是内部写路径正确性 / 安全修复,不改已发布面 API
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:`tools/check-private-boundary.mjs`(`boundaries` required check——只加断言、不放宽)+ `tools/gate-allowlists/check-bypass-write-boundary.json`(既有条目单行号重锚,reason/ref 原样)+ `tools/test-tier-manifest.mjs`(注册新边界测试)
- 依据:私有 ledger 中已 accept 的"停用机器产物自动入 git、重构写路径落点"裁决(refines 接受既有公共历史的裁决),及 task task_01KX227DQQMSKAP5PGZ1RQBZXJ
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- 后续治理任务:布局治理强制 `harness/` 为嵌套仓或被 ignore(见残余风险)

## 验证

- `origin/main` 基准 SHA:04e74bf
- 当前分支与 `origin/main` 的 merge-base:04e74bf
- 最近一次 `git fetch origin` 时间:2026-07-09T03:40:00Z
- 同步方式:rebase 到 `04e74bf`(无冲突),单 commit `3899fa5`
- 公开 diff 命令:`git diff origin/main...codex/ledger-refactor`(13 文件,+376/-46)
- 私有证据 commit/path:该 task 包 `artifacts/orchestration/` 下的 artifacts(私有 ledger)
- Reviewer 证据路径:本 PR 描述 + task 包 review(私有 ledger)
- GitHub Actions `rewrite-ci` run URL:见本 PR Checks 页(`boundaries` job)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`(本地:`check:local` 15/15 + `check:local:gates` 17/17 绿,rebase 后复跑)
- [x] `npm run typecheck`
- [x] `npm test`(`--tier integration --concurrency=1`:467 pass / 0 fail / 1 skipped,退出码 0)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`(`current=3 previous=3 delta=0`,passed)
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 分支上的泄漏门:`git ls-files harness/ .harness/` = 0 条;`git branch --list 'sessions/*'` = 空。
- 回归套件:`packages/cli/test/preset-module-cli.test.ts` 在 CI 身份环境下 17 pass / 0 fail;`origin/main` 侧阴性对照同为 17/0。
- 未运行:未勾选的 harness:* 命令由本 PR 的 CI `boundaries`/`fast-contract` job 覆盖;安全关键的 `check-private-boundary` 与完整 integration tier 均已本地跑过。

## 审查证据

- 自查:CEO 通读全 diff,要求三处后续修复(一条 `return rootRepo` 分支被证实可达;被 gitignore 挡住的 authored 路径静默丢弃改为硬失败;确认边界门为 PR-required 且带红线 fixture)。
- **更正备案:** 上述三条里的第一条是错的。CEO 要求直接删掉 `authoredRepo` 解析失败的那条分支,把"外层仓成为 commit target"与"外层仓收到不属于它的路径"混为一谈。那条分支的真实语义是 `authoredRoot` 尚不存在时的首次写入,删掉它会打死所有非嵌套布局下的 `ha module register`——由 CI `integration` 抓到,起初被误判为存量 flake,因为复现命令漏了测试 runner(`tools/run-node-tests.mjs`)注入的身份环境,导致改动前后两侧都红。现在不变量按**机制**表述(每条 touched path 都在 `authoredRoot` 内),而非"某行代码不许出现",且泄漏守卫严格强于此前。
- Reviewer subagent:对实现请求了 `codex review` + `adversarial-review`。
- 人工审查:pending。
- 阻塞发现:无 open;CEO 的全部发现均已带测试解决。

## 残余风险

- 若 `harness/` 既非嵌套 git 仓、又未被外层仓 ignore,则 `authoredRepo === rootRepo`,authored 写入落外层仓——代码层面与 standalone `authoredRoot: '.'` 布局不可区分,须由 `ha init` / 布局治理保证,不在本 PR。已登记为后续 fact。
- `forceAddPaths` 作为显式逃生口保留、零 caller;未来任何 force 使用须带针对性测试与治理证据。
- 边界错误仍会在 journal 边缘丢失底层 cause(git 布局抛错被呈现为 `decode_failed`),这放大了上述误诊。修复已登记为独立任务,不在本 PR 范围。

## 关联材料

- 任务:task_01KX227DQQMSKAP5PGZ1RQBZXJ
- 证据:私有 ledger 任务包(血泪测试输出、边界输出、integration tier 日志)
- 审查:本 PR + task review.md(私有 ledger)
