### PR TITLE
fix: enforce check-cli-structure on pull requests via boundaries job

### DIFF
--- a/packages/cli/src/cli/parsers/decision-propose-inputs.ts
+++ b/packages/cli/src/cli/parsers/decision-propose-inputs.ts
@@ -1,0 +1,131 @@
+import { cliError, CliErrorCode } from "../error-codes.ts";
+import { readRepeatedRawOption } from "../parse-options.ts";
+import type { CliResult, DecisionChoiceInput, DecisionClaimInput, DecisionRejectedInput } from "../types.ts";
+
+export function parseChoiceInputs(args: ReadonlyArray<string>):
+  | { readonly ok: true; readonly value: ReadonlyArray<DecisionChoiceInput> }
+  | { readonly ok: false; readonly error: CliResult["error"] } {
+  const values = readRepeatedRawOption(args, "--chosen");
+  if (values.length === 0) return { ok: false, error: cliError(CliErrorCode.MissingDecisionChoice, "Use decision propose --chosen <text>.") };
+  const choices: DecisionChoiceInput[] = [];
+  for (const value of values) {
+    const parsed = parseChoiceInput(value);
+    if (!parsed.ok) return parsed;
+    choices.push(parsed.value);
+  }
+  return { ok: true, value: choices };
+}
+
+function parseChoiceInput(raw: string | undefined):
+  | { readonly ok: true; readonly value: DecisionChoiceInput }
+  | { readonly ok: false; readonly error: CliResult["error"] } {
+  if (!raw || raw.startsWith("--")) {
+    return { ok: false, error: cliError(CliErrorCode.MissingDecisionChoice, "Use decision propose --chosen <text> or --chosen <json-object>.") };
+  }
+  if (!raw.trim().startsWith("{")) return { ok: true, value: { text: raw } };
+  try {
+    const parsed = parseJsonObject(raw, "chosen JSON must be an object");
+    const text = typeof parsed.text === "string" ? parsed.text : "";
+    if (!text.trim()) throw new Error("chosen JSON requires text");
+    return {
+      ok: true,
+      value: {
+        ...(typeof parsed.id === "string" && parsed.id.trim() ? { id: parsed.id } : {}),
+        text,
+        ...(typeof parsed.load_bearing === "boolean" ? { load_bearing: parsed.load_bearing } : {})
+      }
+    };
+  } catch (error) {
+    return { ok: false, error: cliError(CliErrorCode.InvalidDecisionAmendPatch, `Invalid --chosen JSON: ${error instanceof Error ? error.message : String(error)}`) };
+  }
+}
+
+export function parseRejectedInputs(args: ReadonlyArray<string>, fallbackWhyNot: string | undefined):
+  | { readonly ok: true; readonly value: ReadonlyArray<DecisionRejectedInput> }
+  | { readonly ok: false; readonly error: CliResult["error"] } {
+  const values = readRepeatedRawOption(args, "--rejected");
+  if (values.length === 0) {
+    return { ok: false, error: cliError(CliErrorCode.MissingDecisionRejected, "Use decision propose --rejected <text> --why-not <text>.") };
+  }
+  const rejected: DecisionRejectedInput[] = [];
+  for (const value of values) {
+    const parsed = parseRejectedInput(value, fallbackWhyNot);
+    if (!parsed.ok) return parsed;
+    rejected.push(parsed.value);
+  }
+  return { ok: true, value: rejected };
+}
+
+function parseRejectedInput(raw: string | undefined, fallbackWhyNot: string | undefined):
+  | { readonly ok: true; readonly value: DecisionRejectedInput }
+  | { readonly ok: false; readonly error: CliResult["error"] } {
+  if (!raw || raw.startsWith("--")) {
+    return { ok: false, error: cliError(CliErrorCode.MissingDecisionRejected, "Use decision propose --rejected <text> --why-not <text>.") };
+  }
+  if (!raw.trim().startsWith("{")) {
+    if (!fallbackWhyNot) return { ok: false, error: cliError(CliErrorCode.MissingDecisionRejected, "Use decision propose --rejected <text> --why-not <text>.") };
+    return { ok: true, value: { text: raw, why_not: fallbackWhyNot } };
+  }
+  try {
+    const parsed = parseJsonObject(raw, "rejected JSON must be an object");
+    const text = typeof parsed.text === "string" ? parsed.text : "";
+    const whyNot = typeof parsed.why_not === "string"
+      ? parsed.why_not
+      : typeof parsed.whyNot === "string"
+        ? parsed.whyNot
+        : fallbackWhyNot ?? "";
+    if (!text.trim()) throw new Error("rejected JSON requires text");
+    if (!whyNot.trim()) throw new Error("rejected JSON requires why_not");
+    return {
+      ok: true,
+      value: {
+        ...(typeof parsed.id === "string" && parsed.id.trim() ? { id: parsed.id } : {}),
+        text,
+        why_not: whyNot
+      }
+    };
+  } catch (error) {
+    return { ok: false, error: cliError(CliErrorCode.InvalidDecisionAmendPatch, `Invalid --rejected JSON: ${error instanceof Error ? error.message : String(error)}`) };
+  }
+}
+
+export function parseClaimInputs(args: ReadonlyArray<string>, defaultLoadBearing: boolean):
+  | { readonly ok: true; readonly value: ReadonlyArray<DecisionClaimInput> }
+  | { readonly ok: false; readonly error: CliResult["error"] } {
+  const claims: DecisionClaimInput[] = [];
+  for (const raw of readRepeatedRawOption(args, "--claim")) {
+    const parsed = parseClaimInput(raw, defaultLoadBearing);
+    if (!parsed.ok) return parsed;
+    claims.push(parsed.value);
+  }
+  return { ok: true, value: claims };
+}
+
+function parseClaimInput(raw: string | undefined, defaultLoadBearing: boolean):
+  | { readonly ok: true; readonly value: DecisionClaimInput }
+  | { readonly ok: false; readonly error: CliResult["error"] } {
+  if (!raw || raw.startsWith("--")) {
+    return { ok: false, error: cliError(CliErrorCode.InvalidDecisionAmendPatch, "Use --claim <text> or --claim <json-object>.") };
+  }
+  if (!raw.trim().startsWith("{")) return { ok: true, value: { text: raw, ...(defaultLoadBearing ? {} : { load_bearing: false }) } };
+  try {
+    const object = parseJsonObject(raw, "claim JSON must be an object");
+    if (typeof object.text !== "string" || object.text.trim().length === 0) throw new Error("claim JSON requires text");
+    return {
+      ok: true,
+      value: {
+        ...(typeof object.id === "string" && object.id.trim() ? { id: object.id } : {}),
+        text: object.text,
+        ...(typeof object.load_bearing === "boolean" ? { load_bearing: object.load_bearing } : defaultLoadBearing ? {} : { load_bearing: false })
+      }
+    };
+  } catch (error) {
+    return { ok: false, error: cliError(CliErrorCode.InvalidDecisionAmendPatch, `Invalid --claim JSON: ${error instanceof Error ? error.message : String(error)}`) };
+  }
+}
+
+function parseJsonObject(raw: string, objectError: string): Record<string, unknown> {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error(objectError);
+  return parsed as Record<string, unknown>;
+}

--- a/packages/cli/src/cli/parsers/decision.ts
+++ b/packages/cli/src/cli/parsers/decision.ts
@@ -5,8 +5,9 @@ import {
 } from "../../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../error-codes.ts";
 import { readOption, readRepeatedRawOption } from "../parse-options.ts";
-import type { CliResult, DecisionChoiceInput, DecisionClaimInput, DecisionEvidenceRelationInput, DecisionRejectedInput, ParsedCommand } from "../types.ts";
+import type { CliResult, DecisionEvidenceRelationInput, ParsedCommand } from "../types.ts";
 import { parseDecisionAmendPatches } from "./decision-amend.ts";
+import { parseChoiceInputs, parseClaimInputs, parseRejectedInputs } from "./decision-propose-inputs.ts";
 import { parseDecisionRelationOp } from "./decision-relation.ts";
 
 type ParseResult = { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] };
@@ -123,134 +124,6 @@ function parseDecisionPropose(args: ReadonlyArray<string>, rootDir: string, json
     body: readOption(args, "--body"),
     dryRun: args.includes("--dry-run")
   });
-}
-
-function parseChoiceInputs(args: ReadonlyArray<string>):
-  | { readonly ok: true; readonly value: ReadonlyArray<DecisionChoiceInput> }
-  | { readonly ok: false; readonly error: CliResult["error"] } {
-  const values = readRepeatedRawOption(args, "--chosen");
-  if (values.length === 0) return { ok: false, error: cliError(CliErrorCode.MissingDecisionChoice, "Use decision propose --chosen <text>.") };
-  const choices: DecisionChoiceInput[] = [];
-  for (const value of values) {
-    const parsed = parseChoiceInput(value);
-    if (!parsed.ok) return parsed;
-    choices.push(parsed.value);
-  }
-  return { ok: true, value: choices };
-}
-
-function parseChoiceInput(raw: string | undefined):
-  | { readonly ok: true; readonly value: DecisionChoiceInput }
-  | { readonly ok: false; readonly error: CliResult["error"] } {
-  if (!raw || raw.startsWith("--")) {
-    return { ok: false, error: cliError(CliErrorCode.MissingDecisionChoice, "Use decision propose --chosen <text> or --chosen <json-object>.") };
-  }
-  if (!raw.trim().startsWith("{")) return { ok: true, value: { text: raw } };
-  try {
-    const parsed = parseJsonObject(raw, "chosen JSON must be an object");
-    const text = typeof parsed.text === "string" ? parsed.text : "";
-    if (!text.trim()) throw new Error("chosen JSON requires text");
-    return {
-      ok: true,
-      value: {
-        ...(typeof parsed.id === "string" && parsed.id.trim() ? { id: parsed.id } : {}),
-        text,
-        ...(typeof parsed.load_bearing === "boolean" ? { load_bearing: parsed.load_bearing } : {})
-      }
-    };
-  } catch (error) {
-    return { ok: false, error: cliError(CliErrorCode.InvalidDecisionAmendPatch, `Invalid --chosen JSON: ${error instanceof Error ? error.message : String(error)}`) };
-  }
-}
-
-function parseRejectedInputs(args: ReadonlyArray<string>, fallbackWhyNot: string | undefined):
-  | { readonly ok: true; readonly value: ReadonlyArray<DecisionRejectedInput> }
-  | { readonly ok: false; readonly error: CliResult["error"] } {
-  const values = readRepeatedRawOption(args, "--rejected");
-  if (values.length === 0) {
-    return { ok: false, error: cliError(CliErrorCode.MissingDecisionRejected, "Use decision propose --rejected <text> --why-not <text>.") };
-  }
-  const rejected: DecisionRejectedInput[] = [];
-  for (const value of values) {
-    const parsed = parseRejectedInput(value, fallbackWhyNot);
-    if (!parsed.ok) return parsed;
-    rejected.push(parsed.value);
-  }
-  return { ok: true, value: rejected };
-}
-
-function parseRejectedInput(raw: string | undefined, fallbackWhyNot: string | undefined):
-  | { readonly ok: true; readonly value: DecisionRejectedInput }
-  | { readonly ok: false; readonly error: CliResult["error"] } {
-  if (!raw || raw.startsWith("--")) {
-    return { ok: false, error: cliError(CliErrorCode.MissingDecisionRejected, "Use decision propose --rejected <text> --why-not <text>.") };
-  }
-  if (!raw.trim().startsWith("{")) {
-    if (!fallbackWhyNot) return { ok: false, error: cliError(CliErrorCode.MissingDecisionRejected, "Use decision propose --rejected <text> --why-not <text>.") };
-    return { ok: true, value: { text: raw, why_not: fallbackWhyNot } };
-  }
-  try {
-    const parsed = parseJsonObject(raw, "rejected JSON must be an object");
-    const text = typeof parsed.text === "string" ? parsed.text : "";
-    const whyNot = typeof parsed.why_not === "string"
-      ? parsed.why_not
-      : typeof parsed.whyNot === "string"
-        ? parsed.whyNot
-        : fallbackWhyNot ?? "";
-    if (!text.trim()) throw new Error("rejected JSON requires text");
-    if (!whyNot.trim()) throw new Error("rejected JSON requires why_not");
-    return {
-      ok: true,
-      value: {
-        ...(typeof parsed.id === "string" && parsed.id.trim() ? { id: parsed.id } : {}),
-        text,
-        why_not: whyNot
-      }
-    };
-  } catch (error) {
-    return { ok: false, error: cliError(CliErrorCode.InvalidDecisionAmendPatch, `Invalid --rejected JSON: ${error instanceof Error ? error.message : String(error)}`) };
-  }
-}
-
-function parseClaimInputs(args: ReadonlyArray<string>, defaultLoadBearing: boolean):
-  | { readonly ok: true; readonly value: ReadonlyArray<DecisionClaimInput> }
-  | { readonly ok: false; readonly error: CliResult["error"] } {
-  const claims: DecisionClaimInput[] = [];
-  for (const raw of readRepeatedRawOption(args, "--claim")) {
-    const parsed = parseClaimInput(raw, defaultLoadBearing);
-    if (!parsed.ok) return parsed;
-    claims.push(parsed.value);
-  }
-  return { ok: true, value: claims };
-}
-
-function parseClaimInput(raw: string | undefined, defaultLoadBearing: boolean):
-  | { readonly ok: true; readonly value: DecisionClaimInput }
-  | { readonly ok: false; readonly error: CliResult["error"] } {
-  if (!raw || raw.startsWith("--")) {
-    return { ok: false, error: cliError(CliErrorCode.InvalidDecisionAmendPatch, "Use --claim <text> or --claim <json-object>.") };
-  }
-  if (!raw.trim().startsWith("{")) return { ok: true, value: { text: raw, ...(defaultLoadBearing ? {} : { load_bearing: false }) } };
-  try {
-    const object = parseJsonObject(raw, "claim JSON must be an object");
-    if (typeof object.text !== "string" || object.text.trim().length === 0) throw new Error("claim JSON requires text");
-    return {
-      ok: true,
-      value: {
-        ...(typeof object.id === "string" && object.id.trim() ? { id: object.id } : {}),
-        text: object.text,
-        ...(typeof object.load_bearing === "boolean" ? { load_bearing: object.load_bearing } : defaultLoadBearing ? {} : { load_bearing: false })
-      }
-    };
-  } catch (error) {
-    return { ok: false, error: cliError(CliErrorCode.InvalidDecisionAmendPatch, `Invalid --claim JSON: ${error instanceof Error ? error.message : String(error)}`) };
-  }
-}
-
-function parseJsonObject(raw: string, objectError: string): Record<string, unknown> {
-  const parsed = JSON.parse(raw) as unknown;
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error(objectError);
-  return parsed as Record<string, unknown>;
 }
 
 function parseDecisionRelate(args: ReadonlyArray<string>, rootDir: string, json: boolean): ParseResult {

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -1197,8 +1197,8 @@
       "id": "check-cli-structure",
       "command": "npm run harness:check-cli-structure",
       "category": "local-consistency",
-      "tier": "main-only",
-      "tierReason": "Registered in package.json check/check:pr but not executed by a pull_request rewrite-ci job; full-check runs it on main/schedule/manual.",
+      "tier": "pr-required",
+      "tierReason": null,
       "authoritySource": [
         "packages/cli/src",
         "tools/check-cli-structure.mjs"
@@ -1207,8 +1207,11 @@
         "CLI source structure"
       ],
       "githubContext": {
-        "requiredContexts": [],
+        "requiredContexts": [
+          "boundaries"
+        ],
         "workflowJobs": [
+          "boundaries",
           "full-check"
         ],
         "nodeVersions": [
@@ -1239,14 +1242,18 @@
           "script": "harness:check-cli-structure"
         },
         "rewriteCi": {
-          "pullRequestJobs": [],
+          "pullRequestJobs": [
+            "boundaries"
+          ],
           "nonPullRequestJobs": [
             "full-check"
           ]
         },
         "branchProtection": {
-          "required": false,
-          "contexts": []
+          "required": true,
+          "contexts": [
+            "boundaries"
+          ]
         }
       }
     },


### PR DESCRIPTION
# English

## Summary

Enforce the `check-cli-structure` gate on pull requests by folding it into the existing `boundaries` job, and split the oversized CLI parser file that currently violates it on `main`.

The gate previously ran only on `push: main`. Violating changes passed all 10 required contexts, merged, and only then turned `main` red. This has now recurred twice. This PR closes the enforcement gap without adding a workflow job, a required status check, or any change to branch protection / Mergify.

## What Changed

- `refactor:` moved `decision propose` raw option parsing (chosen / rejected / claim) out of `packages/cli/src/cli/parsers/decision.ts` into a new `packages/cli/src/cli/parsers/decision-propose-inputs.ts`. Pure move plus re-export; no CLI behaviour change, no test assertion changed. `decision.ts` 340 -> 213 lines (checker count); new file 132 lines. Both are under the 250-line CLI parser limit.
- `fix:` `tools/gate-manifest.json` — `check-cli-structure` moves from `tier: "main-only"` to `tier: "pr-required"`; `executionSurfaces.rewriteCi.pullRequestJobs` `[]` -> `["boundaries"]`; `githubContext.workflowJobs` / `requiredContexts` and `executionSurfaces.branchProtection` now reference the **already-existing** `boundaries` context.
- No new workflow job. No new required status check. `.github/workflows/rewrite-ci.yml`, `.mergify.yml` and branch protection are untouched — `tools/run-manifest-gates.mjs` selects gates by `pullRequestJobs`, so the manifest change alone wires the gate into the existing `boundaries` job.

Why this shape: the gate runs in ~0.34s and `boundaries` already performs `npm ci`. Opening a dedicated job would spend 30-60s of checkout + install to carry a 0.34s check, and would require registering a new required context in two separate lists (branch protection and Mergify). `integration` (~6.5 min) remains the sole critical path; wall-clock cost of this change is ~0.3s.

Root cause of the gap: `run-manifest-gates.mjs` selects gates whose `executionSurfaces.rewriteCi.pullRequestJobs` contains the current `--workflow-job`. That list was empty for this gate, so no pull-request job ever executed it, while `executionSurfaces.packageJson.checkPr: true` meant a local `npm run check:pr` did. Local surface enforced; CI pull-request surface did not.

Observed recurrences: `820425a` pushed `task-query.ts` 126 -> 301 lines (red streak of ~28 `main` runs, incidentally fixed by an unrelated PR); `2817892` pushed `parsers/decision.ts` 249 -> 339 lines and merged as #502, which is why `main` is red at `acdef93` right now. This PR also turns `main` green again.

## Task And Scope

- Harness task: `task_01KX2XJHXEAHGFHTXPZQHSQFCK` (parent `task_01KX2XFTW3SJYNQ08F99SJMXVJ`)
- Branch: `codex/ci-1-cli-structure-pr-gate`
- Public scope: `tools/gate-manifest.json`, `packages/cli/src/cli/parsers/decision.ts`, `packages/cli/src/cli/parsers/decision-propose-inputs.ts`
- Private planning/evidence updated: yes
- Out of scope: `integration` job sharding (follow-up task CI-2); Mergify `merge_conditions` / `queue_conditions` convergence and the `typecheck` node-26 matrix branch (follow-up task CI-3). Splitting the three near-limit files (`worktree.ts` 240, `preset.ts` 236, `decision-relate.ts` 230) is deliberately excluded to keep this diff minimal.

## Version Impact

- Version: no version change because this PR changes gate execution surface and internal file layout only; no published artifact contract changes.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-manifest.json` (gate execution surface / tier). This change **tightens** enforcement: the gate is added to a pull-request job. No gate is weakened, skipped, exempted, or given a longer timeout.
- Authority: decision `dec_mrd7djey` (state `active`, arbiter `human:zeyuli`), claim anchor `CH1` item 1; task `task_01KX2XJHXEAHGFHTXPZQHSQFCK`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: CI-3 (`task_01KX2XJRZXMA0GK3MZ6QCRBGYJ`) will converge Mergify `merge_conditions` with branch-protection required contexts.

## Verification

- Base `origin/main` SHA: `acdef93`
- Branch merge-base with `origin/main`: `acdef93`
- Last `git fetch origin` time: immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/ci-1-cli-structure-pr-gate`
- Private evidence commit/path: harness task package `task_01KX2XJHXEAHGFHTXPZQHSQFCK` (facts `F-2MXT62CC`, `F-NN9SN4ZF`, `F-K94WEJ6F`, `F-1K3PJ7P4`)
- Reviewer evidence path: same task package (`review.md`)
- GitHub Actions `rewrite-ci` run URL: see checks on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (via `npm run check:local`)
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm run check` (full) and `npm test` (full) were not run locally; the fast tier plus the gates directly affected by this change were run instead, and the full set is delegated to `rewrite-ci` on this PR. Unchecked `harness:*` boxes above are covered either by `check:local`'s fast tier or by the `boundaries` job on this PR; they were not each invoked individually and are therefore left unchecked rather than claimed.

Commands actually run locally, in an isolated worktree:

- `npm run harness:check-cli-structure` -> `CLI structure check passed.`
- `node tools/run-manifest-gates.mjs --workflow-job boundaries` -> passed, and `check-cli-structure` is now selected and executed by that job
- `npm run harness:check-gate-surface` -> `47 manifest gates, 0 drift findings`
- `npm run check:local` -> pass
- decision / parser unit tests -> pass
- **Negative control** (proves the gate is genuinely wired, not merely declared): the new parser file was temporarily padded to 252 lines, then `boundaries` failed with `packages/cli/src/cli/parsers/decision-propose-inputs.ts: 252 lines exceeds CLI parser file max 250` and exit 1; after reverting the padding, `boundaries` passed again. The padding was never committed.

Note that this PR is self-verifying: because the manifest change is in the diff, this PR's own `boundaries` job executes the newly-wired gate against this PR's own tree.

## Review Evidence

- Self-review: diff is 131 insertions / 131 deletions across the two parser files (symmetric, consistent with a pure move) plus 19 lines in the manifest; `git diff --name-only` confirms no workflow, Mergify or branch-protection file is touched.
- Reviewer subagent: an independent read-only diagnosis established the root cause and the recurrence timeline; a separate adversarial verification pass adjudicated the redundancy claims and refuted an earlier over-broad claim that `node26-compatibility` was fully redundant (its `test:fast` / `test:contract` runs are intentional cross-version coverage; only its `typecheck` is redundant).
- Human review: pending
- Blocking findings: none

## Residual Risk

- Three files now sit close to the 250-line limit: `packages/cli/src/commands/core/worktree.ts` (240), `packages/cli/src/commands/extensions/preset.ts` (236), `packages/cli/src/commands/core/decision-relate.ts` (230). Once this gate runs on pull requests, the next change that pushes any of them over 250 will fail its PR. That is the gate working as intended, but authors should expect it. A follow-up task will split them proactively.
- `tools/check-gate-surface.mjs` validates `executionSurfaces.branchProtection` against the local `.github/branch-protection.md` (it states this honest boundary in its own header comment), not against the live GitHub branch-protection API. A drift between that document and GitHub's actual settings would not be caught. This is pre-existing and is in scope for CI-3.
- The `check-cli-structure` line counter uses `.split(/\r?\n/)`, which reports one more line than `wc -l` for files with a trailing newline. Line numbers quoted in this PR use the checker's count.

## References

- Task: `task_01KX2XJHXEAHGFHTXPZQHSQFCK`
- Evidence: facts `F-2MXT62CC`, `F-NN9SN4ZF`, `F-K94WEJ6F`, `F-1K3PJ7P4` in that task package
- Review: decision `dec_mrd7djey`

---

# 中文

## 概要

把 `check-cli-structure` 这个 gate 折叠进已存在的 `boundaries` job，使它在每个 pull request 上执行；并拆分当前在 `main` 上违反该 gate 的超长 CLI parser 文件。

此前该 gate 只在 `push: main` 上运行。违规改动能通过全部 10 个 required context 合入，落 `main` 之后才变红。该情形已复发两次。本 PR 关闭这一执法面缺口，且不新增 workflow job、不新增 required status check、不改动分支保护与 Mergify。

## 改动内容

- `refactor:` 把 `decision propose` 的 chosen / rejected / claim 原始选项解析从 `packages/cli/src/cli/parsers/decision.ts` 移入新文件 `packages/cli/src/cli/parsers/decision-propose-inputs.ts`。纯移动加重导出；不改变任何 CLI 行为，不改动任何测试断言。`decision.ts` 340 -> 213 行（checker 口径），新文件 132 行，均低于 250 行的 CLI parser 上限。
- `fix:` `tools/gate-manifest.json` — `check-cli-structure` 由 `tier: "main-only"` 改为 `tier: "pr-required"`；`executionSurfaces.rewriteCi.pullRequestJobs` 由 `[]` 改为 `["boundaries"]`；`githubContext.workflowJobs` / `requiredContexts` 与 `executionSurfaces.branchProtection` 改为引用**已存在的** `boundaries` context。
- 不新增 workflow job，不新增 required status check。`.github/workflows/rewrite-ci.yml`、`.mergify.yml` 与分支保护均未触碰——`tools/run-manifest-gates.mjs` 依据 `pullRequestJobs` 选取 gate，因此仅改 manifest 即可把该 gate 接入现有的 `boundaries` job。

为何采用这个形状：该 gate 本体约 0.34s，而 `boundaries` 已经执行过 `npm ci`。若另开独立 job，需付出 30-60s 的 checkout 与依赖安装去承载一个 0.34s 的检查，并且要在两份彼此独立的清单（分支保护与 Mergify）中登记一个新的 required context。`integration`（约 6.5 分钟）仍是唯一的关键路径；本改动的墙钟代价约 0.3s。

缺口的根因：`run-manifest-gates.mjs` 只选取 `executionSurfaces.rewriteCi.pullRequestJobs` 包含当前 `--workflow-job` 的 gate。该 gate 的这个列表为空，因此任何 pull-request job 都不会执行它；与此同时它的 `executionSurfaces.packageJson.checkPr: true` 又意味着本地 `npm run check:pr` 会执行它。本地面执法，CI 的 pull-request 面不执法。

已观测到的两次复发：`820425a` 将 `task-query.ts` 从 126 行推至 301 行（导致约 28 个 `main` run 连续变红，最后由一个不相干的 PR 顺带修复）；`2817892` 将 `parsers/decision.ts` 从 249 行推至 339 行并经 #502 合入，这正是 `main` 目前在 `acdef93` 上挂红的原因。本 PR 同时也使 `main` 恢复绿灯。

## 任务与范围

- Harness 任务：`task_01KX2XJHXEAHGFHTXPZQHSQFCK`（父任务 `task_01KX2XFTW3SJYNQ08F99SJMXVJ`）
- 分支：`codex/ci-1-cli-structure-pr-gate`
- 公开范围：`tools/gate-manifest.json`、`packages/cli/src/cli/parsers/decision.ts`、`packages/cli/src/cli/parsers/decision-propose-inputs.ts`
- 私有计划 / 证据是否已更新：yes
- 范围外：`integration` job 分片（后续任务 CI-2）；Mergify `merge_conditions` / `queue_conditions` 收敛与 `typecheck` node-26 矩阵分支（后续任务 CI-3）。三个逼近上限的文件（`worktree.ts` 240、`preset.ts` 236、`decision-relate.ts` 230）刻意不在本 PR 内拆分，以保持 diff 最小。

## 版本影响

- 版本：不改版本，原因是本 PR 只改变 gate 的执行面与内部文件布局，不改变任何已发布工件的契约。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/gate-manifest.json`（gate 执行面 / tier）。本改动是**加严**：把该 gate 加入一个 pull-request job。没有任何 gate 被削弱、跳过、豁免或放宽超时。
- 依据：decision `dec_mrd7djey`（state `active`，arbiter `human:zeyuli`），claim anchor `CH1` 第 1 项；task `task_01KX2XJHXEAHGFHTXPZQHSQFCK`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：CI-3（`task_01KX2XJRZXMA0GK3MZ6QCRBGYJ`）将把 Mergify `merge_conditions` 与分支保护 required contexts 收敛为一致。

## 验证

- `origin/main` 基准 SHA：`acdef93`
- 当前分支与 `origin/main` 的 merge-base：`acdef93`
- 最近一次 `git fetch origin` 时间：开启本 PR 之前
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...codex/ci-1-cli-structure-pr-gate`
- 私有证据 commit/path：harness 任务包 `task_01KX2XJHXEAHGFHTXPZQHSQFCK`（fact `F-2MXT62CC`、`F-NN9SN4ZF`、`F-K94WEJ6F`、`F-1K3PJ7P4`）
- Reviewer 证据路径：同一任务包（`review.md`）
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`（经由 `npm run check:local`）
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：本地未运行 `npm run check`（全量）与 `npm test`（全量）；改为运行 fast tier 以及与本改动直接相关的 gate，完整集合交由本 PR 上的 `rewrite-ci` 覆盖。上面未勾选的 `harness:*` 项，或由 `check:local` 的 fast tier 覆盖，或由本 PR 的 `boundaries` job 覆盖；它们并未被逐条单独调用，因此如实留空而不是声称已跑。

本地在隔离 worktree 中实际执行的命令：

- `npm run harness:check-cli-structure` -> `CLI structure check passed.`
- `node tools/run-manifest-gates.mjs --workflow-job boundaries` -> 通过，且 `check-cli-structure` 已被该 job 选中并执行
- `npm run harness:check-gate-surface` -> `47 manifest gates, 0 drift findings`
- `npm run check:local` -> 通过
- decision / parser 相关单测 -> 通过
- **阴性对照**（证明该 gate 是真的接上了，而不只是在 manifest 里声明了）：把新 parser 文件临时填充至 252 行，`boundaries` 随即以 `packages/cli/src/cli/parsers/decision-propose-inputs.ts: 252 lines exceeds CLI parser file max 250` 失败并 exit 1；撤销填充后 `boundaries` 重新通过。该填充从未被提交。

另需注意：本 PR 自带验证性——manifest 的改动就在 diff 里，因此本 PR 自己的 `boundaries` job 会用这份新接上的 gate 检查本 PR 自己的代码树。

## 审查证据

- 自查：两个 parser 文件的 diff 为 131 增 / 131 删（对称，符合纯移动），另加 manifest 的 19 行；`git diff --name-only` 确认未触碰任何 workflow、Mergify 或分支保护文件。
- Reviewer subagent：一条独立的只读诊断线确立了根因与复发时间线；另一条对抗验证线裁决了各项冗余断言，并推翻了此前「`node26-compatibility` 完全冗余」这一过宽结论——该 job 的 `test:fast` / `test:contract` 是有意的跨 node 版本覆盖，只有其中的 `typecheck` 才是冗余。
- 人工审查：pending
- 阻塞发现：无

## 残余风险

- 现有三个文件逼近 250 行上限：`packages/cli/src/commands/core/worktree.ts`（240）、`packages/cli/src/commands/extensions/preset.ts`（236）、`packages/cli/src/commands/core/decision-relate.ts`（230）。该 gate 开始在 pull request 上运行之后，下一个把它们中任意一个推过 250 行的改动都会让其 PR 变红。这正是 gate 应有的行为，但作者需要预期到。后续任务将主动拆分它们。
- `tools/check-gate-surface.mjs` 是拿 `executionSurfaces.branchProtection` 与本地的 `.github/branch-protection.md` 比对（它在自己的头部注释里如实标注了这一 honest boundary），而非与 GitHub 上真实的分支保护 API 比对。该文档与 GitHub 实际设置之间的漂移不会被捕获。此问题先于本 PR 存在，并已纳入 CI-3 的范围。
- `check-cli-structure` 的行数统计使用 `.split(/\r?\n/)`，对以换行结尾的文件会比 `wc -l` 多算一行。本 PR 中引用的行数均采用 checker 的口径。

## 关联材料

- 任务：`task_01KX2XJHXEAHGFHTXPZQHSQFCK`
- 证据：该任务包中的 fact `F-2MXT62CC`、`F-NN9SN4ZF`、`F-K94WEJ6F`、`F-1K3PJ7P4`
- 审查：decision `dec_mrd7djey`
