### PR TITLE
perf: shard integration job and converge mergify queue gates

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -140,9 +140,14 @@ jobs:
       - if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' }}
         run: node tools/run-manifest-gates.mjs --workflow-job fast-contract --exclude mergify-queue-metadata-edit-noop
 
-  integration:
+  integration-shard:
     if: github.event_name == 'pull_request'
+    name: integration-shard (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - name: Accept Mergify queue metadata edit
         if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT == 'true' }}
@@ -157,7 +162,18 @@ jobs:
       - if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' }}
         run: npm ci
       - if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' }}
-        run: node tools/run-manifest-gates.mjs --workflow-job integration --exclude mergify-queue-metadata-edit-noop
+        run: npm run test:integration -- --shard ${{ matrix.shard }}
+
+  integration:
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs: [integration-shard]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: node tools/check-integration-shard-result.mjs "${{ needs.integration-shard.result }}"
 
   boundaries:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -162,7 +162,7 @@ jobs:
       - if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' }}
         run: npm ci
       - if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' }}
-        run: npm run test:integration -- --shard ${{ matrix.shard }}
+        run: node tools/run-manifest-gates.mjs --workflow-job integration-shard --shard ${{ matrix.shard }} --exclude mergify-queue-metadata-edit-noop
 
   integration:
     if: ${{ always() && github.event_name == 'pull_request' }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,78 +6,19 @@ queue_rules:
       - label = merge-queue
       - "-draft"
       - "-conflict"
-      - check-success = pr-body-lint
-    merge_conditions:
       - check-success = boundaries
       - check-success = package-policy
       - check-success = "typecheck (24)"
       - check-success = "typecheck (26)"
       - check-success = fast-contract
+      - check-success = integration
+      - check-success = supply-chain
+      - check-success = gui-build
+      - check-success = node26-compatibility
       - check-success = pr-body-lint
+    merge_conditions: []
 
 pull_request_rules:
-  - name: self-heal dequeued pull requests attempt 1
-    conditions:
-      - base = main
-      - label = merge-queue
-      - label = dequeued
-      - "-label = merge-queue-requeue-1"
-      - "-label = merge-queue-requeue-2"
-      - check-success = boundaries
-      - check-success = package-policy
-      - check-success = "typecheck (24)"
-      - check-success = "typecheck (26)"
-      - check-success = fast-contract
-      - check-success = pr-body-lint
-    actions:
-      label:
-        add:
-          - merge-queue-requeue-1
-        remove:
-          - dequeued
-      queue:
-        name: default
-
-  - name: self-heal dequeued pull requests attempt 2
-    conditions:
-      - base = main
-      - label = merge-queue
-      - label = dequeued
-      - label = merge-queue-requeue-1
-      - "-label = merge-queue-requeue-2"
-      - check-success = boundaries
-      - check-success = package-policy
-      - check-success = "typecheck (24)"
-      - check-success = "typecheck (26)"
-      - check-success = fast-contract
-      - check-success = pr-body-lint
-    actions:
-      label:
-        add:
-          - merge-queue-requeue-2
-        remove:
-          - dequeued
-      queue:
-        name: default
-
-  - name: stop self-heal after two dequeue attempts
-    conditions:
-      - base = main
-      - label = merge-queue
-      - label = dequeued
-      - label = merge-queue-requeue-2
-    actions:
-      label:
-        remove:
-          - merge-queue
-          - queued
-          - dequeued
-      comment:
-        message: |
-          Mergify stopped automatic requeue after two dequeue recovery attempts.
-
-          The `merge-queue` label was removed to prevent an unbounded queue loop. Please inspect the latest Mergify check-run output and CI runs before re-adding `merge-queue`.
-
   - name: merge via queue when CI passes
     conditions:
       - base = main

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "harness:check-duplicate-definitions": "node tools/check-duplicate-definitions.mjs",
     "harness:check-integrity-single-source": "node tools/check-integrity-single-source.mjs",
     "harness:check-private-boundary": "node tools/check-private-boundary.mjs",
+    "harness:check-integration-test-shards": "node tools/check-integration-test-shards.mjs",
     "harness:check-docs-release-map": "node tools/check-docs-release-map.mjs",
     "harness:check-docmap-fresh": "node tools/check-docmap-fresh.mjs",
     "harness:check-gate-surface": "node tools/check-gate-surface.mjs",

--- a/tools/check-gate-surface.mjs
+++ b/tools/check-gate-surface.mjs
@@ -153,7 +153,7 @@ function checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds 
         }
         continue;
       }
-      const mappedIds = commandToGateIds.get(command) ?? [];
+      const mappedIds = gateIdsForWorkflowCommand(command, commandToGateIds);
       if (mappedIds.length === 0) {
         findings.push(formatFinding("rewrite-ci", `${job.id} runs ${JSON.stringify(command)} but no manifest gate declares that command.`));
       }
@@ -312,6 +312,9 @@ function jobRunsGateCommand({ job, gate, manifest, gates }) {
   if (job.runCommands.includes(gate.command)) {
     return true;
   }
+  if (gate.id === "test-integration" && job.runCommands.some(isIntegrationShardCommand)) {
+    return true;
+  }
   if (job.runCommands.some((command) => manifestRunnerCoversGate({ command, gateId: gate.id, workflowJob: job.id, manifest, gates }))) {
     return true;
   }
@@ -358,6 +361,21 @@ function buildCommandIndex(gates) {
     commandToGateIds.set(gate.command, existing);
   }
   return commandToGateIds;
+}
+
+function gateIdsForWorkflowCommand(command, commandToGateIds) {
+  const exact = commandToGateIds.get(command);
+  if (exact) {
+    return exact;
+  }
+  if (isIntegrationShardCommand(command)) {
+    return ["test-integration"];
+  }
+  return [];
+}
+
+function isIntegrationShardCommand(command) {
+  return /^npm run test:integration -- --shard (?:\$\{\{\s*matrix\.shard\s*\}\}|[1-9][0-9]*)$/u.test(command);
 }
 
 function parseRewriteCi(text) {

--- a/tools/check-gate-surface.mjs
+++ b/tools/check-gate-surface.mjs
@@ -153,7 +153,7 @@ function checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds 
         }
         continue;
       }
-      const mappedIds = gateIdsForWorkflowCommand(command, commandToGateIds);
+      const mappedIds = commandToGateIds.get(command) ?? [];
       if (mappedIds.length === 0) {
         findings.push(formatFinding("rewrite-ci", `${job.id} runs ${JSON.stringify(command)} but no manifest gate declares that command.`));
       }
@@ -312,9 +312,6 @@ function jobRunsGateCommand({ job, gate, manifest, gates }) {
   if (job.runCommands.includes(gate.command)) {
     return true;
   }
-  if (gate.id === "test-integration" && job.runCommands.some(isIntegrationShardCommand)) {
-    return true;
-  }
   if (job.runCommands.some((command) => manifestRunnerCoversGate({ command, gateId: gate.id, workflowJob: job.id, manifest, gates }))) {
     return true;
   }
@@ -361,21 +358,6 @@ function buildCommandIndex(gates) {
     commandToGateIds.set(gate.command, existing);
   }
   return commandToGateIds;
-}
-
-function gateIdsForWorkflowCommand(command, commandToGateIds) {
-  const exact = commandToGateIds.get(command);
-  if (exact) {
-    return exact;
-  }
-  if (isIntegrationShardCommand(command)) {
-    return ["test-integration"];
-  }
-  return [];
-}
-
-function isIntegrationShardCommand(command) {
-  return /^npm run test:integration -- --shard (?:\$\{\{\s*matrix\.shard\s*\}\}|[1-9][0-9]*)$/u.test(command);
 }
 
 function parseRewriteCi(text) {
@@ -526,6 +508,10 @@ function parseManifestRunnerCommand(command) {
           invocation.exclude.add(trimmed);
         }
       }
+      index += 1;
+      continue;
+    }
+    if (arg === "--shard") {
       index += 1;
       continue;
     }

--- a/tools/check-integration-shard-result.mjs
+++ b/tools/check-integration-shard-result.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+
+export const integrationShardResults = Object.freeze(["success", "failure", "cancelled", "skipped"]);
+
+export function evaluateIntegrationShardResult(result) {
+  switch (result) {
+    case "success":
+      return { ok: true, message: "integration shards succeeded" };
+    case "failure":
+      return { ok: false, message: "integration shard matrix failed" };
+    case "cancelled":
+      return { ok: false, message: "integration shard matrix was cancelled" };
+    case "skipped":
+      return { ok: false, message: "integration shard matrix was skipped" };
+    default:
+      return { ok: false, message: `unknown integration shard result: ${String(result)}` };
+  }
+}
+
+function main(argv) {
+  const [result] = argv;
+  const evaluation = evaluateIntegrationShardResult(result);
+  const normalized = result ?? "<missing>";
+  console.log(`integration-shard result=${normalized}`);
+  console.log(evaluation.message);
+  if (!evaluation.ok) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2));
+}

--- a/tools/check-integration-test-shards.mjs
+++ b/tools/check-integration-test-shards.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+import { integrationShardSummaries, validateIntegrationTestShards } from "./integration-test-shards.mjs";
+import { testTierManifest } from "./test-tier-manifest.mjs";
+
+export function checkIntegrationTestShards() {
+  const validation = validateIntegrationTestShards(testTierManifest.integration);
+  return {
+    ok: validation.ok,
+    errors: validation.errors,
+    summaries: integrationShardSummaries(),
+    fileCount: testTierManifest.integration.length
+  };
+}
+
+function main() {
+  const result = checkIntegrationTestShards();
+  if (!result.ok) {
+    for (const error of result.errors) {
+      console.error(error);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`integration shard check passed: manifestFiles=${result.fileCount} shards=${result.summaries.length}`);
+  for (const summary of result.summaries) {
+    console.log(`shard ${summary.id}: files=${summary.files} estimatedMs=${summary.estimatedMs.toFixed(1)}`);
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/tools/check-integration-test-shards.mjs
+++ b/tools/check-integration-test-shards.mjs
@@ -1,16 +1,71 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { integrationShardSummaries, validateIntegrationTestShards } from "./integration-test-shards.mjs";
+import { integrationShardCount, integrationShardSummaries, validateIntegrationTestShards } from "./integration-test-shards.mjs";
 import { testTierManifest } from "./test-tier-manifest.mjs";
 
-export function checkIntegrationTestShards() {
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const workflowPath = path.join(repoRoot, ".github/workflows/rewrite-ci.yml");
+
+export function checkIntegrationTestShards({ workflowText = readFileSync(workflowPath, "utf8") } = {}) {
   const validation = validateIntegrationTestShards(testTierManifest.integration);
+  const workflowValidation = validateIntegrationShardWorkflowMatrix(workflowText, integrationShardCount);
+  const errors = [...validation.errors, ...workflowValidation.errors];
   return {
-    ok: validation.ok,
-    errors: validation.errors,
+    ok: errors.length === 0,
+    errors,
     summaries: integrationShardSummaries(),
-    fileCount: testTierManifest.integration.length
+    fileCount: testTierManifest.integration.length,
+    workflowShards: workflowValidation.shards
   };
+}
+
+export function validateIntegrationShardWorkflowMatrix(workflowText, shardCount = integrationShardCount) {
+  const shards = parseIntegrationShardMatrix(workflowText);
+  const expected = Array.from({ length: shardCount }, (_, index) => index + 1);
+  const errors = [];
+
+  if (shards.length === 0) {
+    errors.push("integration-shard workflow matrix shard list is missing");
+    return { shards, errors };
+  }
+  if (shards.length !== expected.length || shards.some((value, index) => value !== expected[index])) {
+    errors.push(`integration-shard workflow matrix mismatch: expected [${expected.join(", ")}], got [${shards.join(", ")}]`);
+  }
+
+  return { shards, errors };
+}
+
+function parseIntegrationShardMatrix(workflowText) {
+  const lines = workflowText.split(/\r?\n/u);
+  let inIntegrationShardJob = false;
+  let jobIndent = 0;
+
+  for (const line of lines) {
+    const jobMatch = /^(\s*)integration-shard:\s*$/u.exec(line);
+    if (jobMatch) {
+      inIntegrationShardJob = true;
+      jobIndent = jobMatch[1].length;
+      continue;
+    }
+    if (!inIntegrationShardJob) {
+      continue;
+    }
+    const nextJobMatch = /^(\s*)[A-Za-z0-9_-]+:\s*$/u.exec(line);
+    if (nextJobMatch && nextJobMatch[1].length <= jobIndent) {
+      return [];
+    }
+    const shardMatch = /^\s*shard:\s*\[(.+?)\]\s*$/u.exec(line);
+    if (shardMatch) {
+      return shardMatch[1]
+        .split(",")
+        .map((entry) => Number(entry.trim()))
+        .filter((value) => Number.isInteger(value));
+    }
+  }
+
+  return [];
 }
 
 function main() {
@@ -23,7 +78,7 @@ function main() {
     return;
   }
 
-  console.log(`integration shard check passed: manifestFiles=${result.fileCount} shards=${result.summaries.length}`);
+  console.log(`integration shard check passed: manifestFiles=${result.fileCount} shards=${result.summaries.length} workflowShards=[${result.workflowShards.join(", ")}]`);
   for (const summary of result.summaries) {
     console.log(`shard ${summary.id}: files=${summary.files} estimatedMs=${summary.estimatedMs.toFixed(1)}`);
   }

--- a/tools/check-integration-test-shards.test.mjs
+++ b/tools/check-integration-test-shards.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { checkIntegrationTestShards } from "./check-integration-test-shards.mjs";
+import { evaluateIntegrationShardResult } from "./check-integration-shard-result.mjs";
+
+test("integration shard declaration is non-overlapping and complete", () => {
+  const result = checkIntegrationTestShards();
+  assert.equal(result.ok, true, result.errors.join("\n"));
+  assert.equal(result.fileCount, 78);
+  assert.equal(result.summaries.length, 6);
+  assert.ok(result.summaries.every((summary) => summary.files > 0));
+});
+
+test("integration shard aggregate fails closed for every non-success result", () => {
+  assert.equal(evaluateIntegrationShardResult("success").ok, true);
+  assert.equal(evaluateIntegrationShardResult("failure").ok, false);
+  assert.equal(evaluateIntegrationShardResult("cancelled").ok, false);
+  assert.equal(evaluateIntegrationShardResult("skipped").ok, false);
+  assert.equal(evaluateIntegrationShardResult("unexpected").ok, false);
+});

--- a/tools/check-integration-test-shards.test.mjs
+++ b/tools/check-integration-test-shards.test.mjs
@@ -1,14 +1,46 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { checkIntegrationTestShards } from "./check-integration-test-shards.mjs";
+import { checkIntegrationTestShards, validateIntegrationShardWorkflowMatrix } from "./check-integration-test-shards.mjs";
 import { evaluateIntegrationShardResult } from "./check-integration-shard-result.mjs";
 
 test("integration shard declaration is non-overlapping and complete", () => {
   const result = checkIntegrationTestShards();
   assert.equal(result.ok, true, result.errors.join("\n"));
   assert.equal(result.fileCount, 78);
+  assert.deepEqual(result.workflowShards, [1, 2, 3, 4, 5, 6]);
   assert.equal(result.summaries.length, 6);
   assert.ok(result.summaries.every((summary) => summary.files > 0));
+});
+
+test("integration shard checker rejects workflow matrix drift", () => {
+  const workflow = [
+    "jobs:",
+    "  integration-shard:",
+    "    strategy:",
+    "      matrix:",
+    "        shard: [1, 2, 3, 4]",
+    "  integration:",
+    "    needs: [integration-shard]"
+  ].join("\n");
+
+  assert.deepEqual(validateIntegrationShardWorkflowMatrix(workflow, 6), {
+    shards: [1, 2, 3, 4],
+    errors: ["integration-shard workflow matrix mismatch: expected [1, 2, 3, 4, 5, 6], got [1, 2, 3, 4]"]
+  });
+});
+
+test("integration shard checker requires exact workflow matrix ordering", () => {
+  const workflow = [
+    "jobs:",
+    "  integration-shard:",
+    "    strategy:",
+    "      matrix:",
+    "        shard: [1, 3, 2, 4, 5, 6]"
+  ].join("\n");
+
+  assert.deepEqual(validateIntegrationShardWorkflowMatrix(workflow, 6).errors, [
+    "integration-shard workflow matrix mismatch: expected [1, 2, 3, 4, 5, 6], got [1, 3, 2, 4, 5, 6]"
+  ]);
 });
 
 test("integration shard aggregate fails closed for every non-success result", () => {

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -65,6 +65,7 @@
         "check-duplicate-definitions",
         "check-integrity-single-source",
         "check-private-boundary",
+        "check-integration-test-shards",
         "check-docs-release-map",
         "check-docmap-fresh",
         "check-gate-surface",
@@ -104,6 +105,7 @@
         "check-duplicate-definitions",
         "check-integrity-single-source",
         "check-private-boundary",
+        "check-integration-test-shards",
         "check-docs-release-map",
         "check-docmap-fresh",
         "check-gate-surface",
@@ -120,14 +122,14 @@
         "check-legacy-intake-readiness",
         "check-supply-chain"
       ],
-      "harnessLeafGateCount": 30
+      "harnessLeafGateCount": 31
     },
     "rewriteCi": {
       "pullRequestGateJobs": [
         "pr-body-lint",
         "typecheck",
         "fast-contract",
-        "integration",
+        "integration-shard",
         "boundaries",
         "package-policy",
         "supply-chain",
@@ -135,7 +137,8 @@
         "node26-compatibility"
       ],
       "helperJobsNotRegisteredAsGates": [
-        "changes"
+        "changes",
+        "integration"
       ],
       "nonPullRequestGateJobs": [
         "full-check"
@@ -433,7 +436,7 @@
           "pr-body-lint",
           "typecheck",
           "fast-contract",
-          "integration",
+          "integration-shard",
           "boundaries",
           "package-policy",
           "supply-chain",
@@ -472,7 +475,7 @@
             "pr-body-lint",
             "typecheck",
             "fast-contract",
-            "integration",
+            "integration-shard",
             "boundaries",
             "package-policy",
             "supply-chain",
@@ -848,7 +851,7 @@
           "integration"
         ],
         "workflowJobs": [
-          "integration"
+          "integration-shard"
         ],
         "nodeVersions": [
           24
@@ -877,7 +880,7 @@
         },
         "rewriteCi": {
           "pullRequestJobs": [
-            "integration"
+            "integration-shard"
           ],
           "nonPullRequestJobs": []
         },
@@ -2038,6 +2041,71 @@
           "check": true,
           "checkPr": true,
           "script": "harness:check-private-boundary"
+        },
+        "rewriteCi": {
+          "pullRequestJobs": [
+            "boundaries"
+          ],
+          "nonPullRequestJobs": [
+            "full-check"
+          ]
+        },
+        "branchProtection": {
+          "required": true,
+          "contexts": [
+            "boundaries"
+          ]
+        }
+      }
+    },
+    {
+      "id": "check-integration-test-shards",
+      "command": "npm run harness:check-integration-test-shards",
+      "category": "local-consistency",
+      "tier": "pr-required",
+      "tierReason": null,
+      "authoritySource": [
+        "tools/test-tier-manifest.mjs",
+        "tools/integration-test-shards.mjs",
+        "tools/check-integration-test-shards.mjs"
+      ],
+      "consumerScope": [
+        "integration shard declaration must cover every integration test file exactly once"
+      ],
+      "githubContext": {
+        "requiredContexts": [
+          "boundaries"
+        ],
+        "workflowJobs": [
+          "boundaries"
+        ],
+        "nodeVersions": [
+          24
+        ]
+      },
+      "allowlistPolicy": {
+        "allowed": false,
+        "location": null,
+        "adrOrDecisionRequired": false,
+        "notes": "The shard checker is fail-closed and has no allowlist."
+      },
+      "changeControl": {
+        "ordinaryImplementationMayModify": false,
+        "requiresGovernanceEvidence": true,
+        "protectedSurfaces": [
+          "tools/test-tier-manifest.mjs",
+          "tools/integration-test-shards.mjs",
+          "tools/check-integration-test-shards.mjs",
+          "package.json:scripts.harness:check-integration-test-shards",
+          "tools/gate-manifest.json"
+        ]
+      },
+      "bypassFixtureRequired": false,
+      "executionSurfaces": {
+        "packageJson": {
+          "check": true,
+          "checkPr": true,
+          "script": "harness:check-integration-test-shards"
         },
         "rewriteCi": {
           "pullRequestJobs": [

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -835,6 +835,7 @@
     {
       "id": "test-integration",
       "command": "npm run test:integration",
+      "shardable": true,
       "category": "local-consistency",
       "tier": "pr-required",
       "tierReason": null,

--- a/tools/integration-test-shards.mjs
+++ b/tools/integration-test-shards.mjs
@@ -1,0 +1,279 @@
+import { testTierManifest } from "./test-tier-manifest.mjs";
+
+export const integrationShardCount = 6;
+
+export const integrationTestFileWeightsMs = Object.freeze({
+  "packages/adapters/multica/test/multica-readonly-adopt.test.ts": 782.5,
+  "packages/application/test/local-controller-service.test.ts": 507.0,
+  "packages/cli/test/actor-attribution-cli.test.ts": 3640.4,
+  "packages/cli/test/anchor-backfill-cli.test.ts": 16962.1,
+  "packages/cli/test/attribution-diff-cli.test.ts": 4299.9,
+  "packages/cli/test/check-governance-cli.test.ts": 37788.5,
+  "packages/cli/test/conflict-preflight-cli.test.ts": 4766.7,
+  "packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts": 15469.7,
+  "packages/cli/test/daemon-thin-client-cli.test.ts": 38159.7,
+  "packages/cli/test/decision-cli.test.ts": 15299.0,
+  "packages/cli/test/decision-coverage-cli.test.ts": 26753.8,
+  "packages/cli/test/decision-task-metadata-cli.test.ts": 13473.5,
+  "packages/cli/test/diagnostics-cli.test.ts": 551.7,
+  "packages/cli/test/distill-cli.test.ts": 5975.6,
+  "packages/cli/test/docmap-cli.test.ts": 4214.7,
+  "packages/cli/test/doctor-cli.test.ts": 3606.3,
+  "packages/cli/test/extension-cli.test.ts": 7000.4,
+  "packages/cli/test/fact-cli.test.ts": 11411.7,
+  "packages/cli/test/graph-cli.test.ts": 2433.0,
+  "packages/cli/test/gui-cli.test.ts": 1187.3,
+  "packages/cli/test/init-cli.test.ts": 6346.2,
+  "packages/cli/test/local-lifecycle-cli.test.ts": 52850.8,
+  "packages/cli/test/local-lifecycle-crlf-cli.test.ts": 3951.3,
+  "packages/cli/test/migration-adopt-cli.test.ts": 21829.1,
+  "packages/cli/test/new-task-cli.test.ts": 5417.7,
+  "packages/cli/test/p16-command-parity-cli.test.ts": 10596.6,
+  "packages/cli/test/post-merge-check-cli.test.ts": 13476.9,
+  "packages/cli/test/preset-create-milestone-cli.test.ts": 4114.3,
+  "packages/cli/test/preset-create-milestone-render-html-cli.test.ts": 3185.5,
+  "packages/cli/test/preset-dogfood-utilization-cli.test.ts": 1908.3,
+  "packages/cli/test/preset-github-issue-repair-cli.test.ts": 2819.6,
+  "packages/cli/test/preset-milestone-closeout-cli.test.ts": 2414.0,
+  "packages/cli/test/preset-module-cli.test.ts": 22821.6,
+  "packages/cli/test/preset-script-cli.test.ts": 21150.1,
+  "packages/cli/test/preset-script-dossier-cli.test.ts": 3987.1,
+  "packages/cli/test/preset-script-gate-retro-cli.test.ts": 7616.4,
+  "packages/cli/test/preset-script-imports-cli.test.ts": 1132.0,
+  "packages/cli/test/preset-subtask-expansion-cli.test.ts": 17807.0,
+  "packages/cli/test/projection-freshness-cli.test.ts": 1723.3,
+  "packages/cli/test/runtime-event-cli.test.ts": 5222.8,
+  "packages/cli/test/self-host-git-boundary-cli.test.ts": 777.2,
+  "packages/cli/test/session-cli.test.ts": 3130.5,
+  "packages/cli/test/settings-cli.test.ts": 20342.2,
+  "packages/cli/test/task-archive-distill-cli.test.ts": 15682.0,
+  "packages/cli/test/task-delete-disposition-cli.test.ts": 15148.2,
+  "packages/cli/test/task-document-gates-cli.test.ts": 10050.9,
+  "packages/cli/test/task-list-cli.test.ts": 4079.4,
+  "packages/cli/test/task-show-relation-list-cli.test.ts": 9469.7,
+  "packages/cli/test/task-transition-sweep-cli.test.ts": 24335.2,
+  "packages/cli/test/task-tree-cli.test.ts": 10262.2,
+  "packages/cli/test/worktree-cli.test.ts": 2230.1,
+  "packages/cli/test/write-lock-retry-cli.test.ts": 3640.9,
+  "packages/daemon/test/transport-integration.test.ts": 413.2,
+  "packages/kernel/test/store/conditional-delta-writes.test.ts": 1083.6,
+  "packages/kernel/test/store/crash-before-watermark.test.ts": 892.2,
+  "packages/kernel/test/store/daemon-registry.test.ts": 190.1,
+  "packages/kernel/test/store/daemon-runtime.test.ts": 2829.0,
+  "packages/kernel/test/store/entity-disposition.test.ts": 487.3,
+  "packages/kernel/test/store/global-committer-lock.test.ts": 1579.8,
+  "packages/kernel/test/store/journal-idempotency.test.ts": 574.4,
+  "packages/kernel/test/store/ledger-materializer.test.ts": 1657.2,
+  "packages/kernel/test/store/payload-hash.test.ts": 493.8,
+  "packages/kernel/test/store/portable-path-collision.test.ts": 423.7,
+  "packages/kernel/test/store/progress-append-delta.test.ts": 1531.3,
+  "packages/kernel/test/store/relation-cascade-direction.test.ts": 446.4,
+  "packages/kernel/test/store/relation-graph-projection.test.ts": 850.9,
+  "packages/kernel/test/store/relation-graph-toctou.test.ts": 473.9,
+  "packages/kernel/test/store/same-task-fifo.test.ts": 7647.4,
+  "packages/kernel/test/store/sqlite-incremental-projection.test.ts": 4800.3,
+  "packages/kernel/test/store/sqlite-rebuild.test.ts": 734.2,
+  "tools/check-docs-release-map.test.mjs": 590.0,
+  "tools/check-import-boundaries.test.mjs": 1230.7,
+  "tools/check-kernel-dead-exports.test.mjs": 1909.3,
+  "tools/check-runtime-release-readiness.test.mjs": 1003.8,
+  "tools/check-supply-chain.test.mjs": 8797.4,
+  "tools/graph-panorama.test.mjs": 455.6,
+  "tools/quickstart-demo.test.mjs": 5488.9,
+  "tools/relation-weathering-spike.test.mjs": 182.9
+});
+
+export const integrationTestShards = Object.freeze([
+  Object.freeze({
+    id: 1,
+    files: Object.freeze([
+      "packages/cli/test/local-lifecycle-cli.test.ts",
+      "packages/cli/test/task-delete-disposition-cli.test.ts",
+      "packages/cli/test/task-document-gates-cli.test.ts",
+      "packages/cli/test/distill-cli.test.ts",
+      "packages/cli/test/attribution-diff-cli.test.ts",
+      "packages/cli/test/write-lock-retry-cli.test.ts",
+      "packages/cli/test/graph-cli.test.ts",
+      "packages/cli/test/projection-freshness-cli.test.ts",
+      "packages/kernel/test/store/crash-before-watermark.test.ts",
+      "packages/cli/test/self-host-git-boundary-cli.test.ts",
+      "packages/kernel/test/store/relation-cascade-direction.test.ts"
+    ])
+  }),
+  Object.freeze({
+    id: 2,
+    files: Object.freeze([
+      "packages/cli/test/daemon-thin-client-cli.test.ts",
+      "packages/cli/test/anchor-backfill-cli.test.ts",
+      "packages/cli/test/post-merge-check-cli.test.ts",
+      "packages/cli/test/task-show-relation-list-cli.test.ts",
+      "tools/quickstart-demo.test.mjs",
+      "packages/cli/test/conflict-preflight-cli.test.ts",
+      "packages/cli/test/local-lifecycle-crlf-cli.test.ts",
+      "tools/check-kernel-dead-exports.test.mjs",
+      "packages/cli/test/preset-dogfood-utilization-cli.test.ts",
+      "tools/check-runtime-release-readiness.test.mjs",
+      "tools/check-docs-release-map.test.mjs",
+      "packages/application/test/local-controller-service.test.ts",
+      "packages/kernel/test/store/portable-path-collision.test.ts"
+    ])
+  }),
+  Object.freeze({
+    id: 3,
+    files: Object.freeze([
+      "packages/cli/test/check-governance-cli.test.ts",
+      "packages/cli/test/preset-subtask-expansion-cli.test.ts",
+      "packages/cli/test/decision-task-metadata-cli.test.ts",
+      "tools/check-supply-chain.test.mjs",
+      "packages/cli/test/init-cli.test.ts",
+      "packages/cli/test/docmap-cli.test.ts",
+      "packages/cli/test/actor-attribution-cli.test.ts",
+      "packages/cli/test/preset-milestone-closeout-cli.test.ts",
+      "packages/kernel/test/store/global-committer-lock.test.ts",
+      "packages/cli/test/preset-script-imports-cli.test.ts",
+      "packages/cli/test/diagnostics-cli.test.ts",
+      "packages/kernel/test/store/entity-disposition.test.ts",
+      "packages/kernel/test/store/daemon-registry.test.ts"
+    ])
+  }),
+  Object.freeze({
+    id: 4,
+    files: Object.freeze([
+      "packages/cli/test/decision-coverage-cli.test.ts",
+      "packages/cli/test/settings-cli.test.ts",
+      "packages/cli/test/decision-cli.test.ts",
+      "packages/cli/test/task-tree-cli.test.ts",
+      "packages/cli/test/extension-cli.test.ts",
+      "packages/kernel/test/store/sqlite-incremental-projection.test.ts",
+      "packages/cli/test/preset-create-milestone-cli.test.ts",
+      "packages/cli/test/doctor-cli.test.ts",
+      "packages/cli/test/worktree-cli.test.ts",
+      "packages/kernel/test/store/ledger-materializer.test.ts",
+      "packages/kernel/test/store/conditional-delta-writes.test.ts",
+      "packages/kernel/test/store/journal-idempotency.test.ts",
+      "packages/kernel/test/store/payload-hash.test.ts",
+      "packages/daemon/test/transport-integration.test.ts"
+    ])
+  }),
+  Object.freeze({
+    id: 5,
+    files: Object.freeze([
+      "packages/cli/test/task-transition-sweep-cli.test.ts",
+      "packages/cli/test/preset-script-cli.test.ts",
+      "packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts",
+      "packages/cli/test/p16-command-parity-cli.test.ts",
+      "packages/kernel/test/store/same-task-fifo.test.ts",
+      "packages/cli/test/new-task-cli.test.ts",
+      "packages/cli/test/preset-script-dossier-cli.test.ts",
+      "packages/cli/test/preset-create-milestone-render-html-cli.test.ts",
+      "packages/kernel/test/store/daemon-runtime.test.ts",
+      "tools/check-import-boundaries.test.mjs",
+      "packages/cli/test/gui-cli.test.ts",
+      "packages/kernel/test/store/sqlite-rebuild.test.ts",
+      "packages/kernel/test/store/relation-graph-toctou.test.ts"
+    ])
+  }),
+  Object.freeze({
+    id: 6,
+    files: Object.freeze([
+      "packages/cli/test/preset-module-cli.test.ts",
+      "packages/cli/test/migration-adopt-cli.test.ts",
+      "packages/cli/test/task-archive-distill-cli.test.ts",
+      "packages/cli/test/fact-cli.test.ts",
+      "packages/cli/test/preset-script-gate-retro-cli.test.ts",
+      "packages/cli/test/runtime-event-cli.test.ts",
+      "packages/cli/test/task-list-cli.test.ts",
+      "packages/cli/test/session-cli.test.ts",
+      "packages/cli/test/preset-github-issue-repair-cli.test.ts",
+      "packages/kernel/test/store/progress-append-delta.test.ts",
+      "packages/kernel/test/store/relation-graph-projection.test.ts",
+      "packages/adapters/multica/test/multica-readonly-adopt.test.ts",
+      "tools/graph-panorama.test.mjs",
+      "tools/relation-weathering-spike.test.mjs"
+    ])
+  })
+]);
+
+export function parseIntegrationShardId(value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > integrationShardCount) {
+    throw new Error(`--shard must be an integer from 1 to ${integrationShardCount}`);
+  }
+  return parsed;
+}
+
+export function selectIntegrationShardFiles(shardValue) {
+  const validation = validateIntegrationTestShards();
+  if (!validation.ok) {
+    throw new Error(`integration shard declaration is invalid:\n${validation.errors.join("\n")}`);
+  }
+  const shardId = parseIntegrationShardId(shardValue);
+  const shard = integrationTestShards.find((candidate) => candidate.id === shardId);
+  if (!shard) {
+    throw new Error(`integration shard ${shardId} is not declared`);
+  }
+  return [...shard.files].sort();
+}
+
+export function integrationShardSummaries() {
+  return integrationTestShards.map((shard) => ({
+    id: shard.id,
+    files: shard.files.length,
+    estimatedMs: shard.files.reduce((sum, file) => sum + (integrationTestFileWeightsMs[file] ?? 0), 0)
+  }));
+}
+
+export function validateIntegrationTestShards(manifestFiles = testTierManifest.integration) {
+  const errors = [];
+  const manifestSet = new Set(manifestFiles);
+  const shardIds = new Set();
+  const seen = new Map();
+
+  for (const shard of integrationTestShards) {
+    if (!Number.isInteger(shard.id) || shard.id < 1 || shard.id > integrationShardCount) {
+      errors.push(`invalid integration shard id: ${String(shard.id)}`);
+    }
+    if (shardIds.has(shard.id)) {
+      errors.push(`duplicate integration shard id: ${shard.id}`);
+    }
+    shardIds.add(shard.id);
+    if (!Array.isArray(shard.files) || shard.files.length === 0) {
+      errors.push(`integration shard ${shard.id} is empty`);
+      continue;
+    }
+    for (const file of shard.files) {
+      if (!manifestSet.has(file)) {
+        errors.push(`integration shard ${shard.id} references non-integration file: ${file}`);
+      }
+      const previous = seen.get(file);
+      if (previous !== undefined) {
+        errors.push(`integration file appears in multiple shards: ${file} (${previous}, ${shard.id})`);
+      }
+      seen.set(file, shard.id);
+    }
+  }
+
+  for (let id = 1; id <= integrationShardCount; id += 1) {
+    if (!shardIds.has(id)) {
+      errors.push(`missing integration shard id: ${id}`);
+    }
+  }
+
+  for (const file of manifestFiles) {
+    if (!seen.has(file)) {
+      errors.push(`integration file missing from shards: ${file}`);
+    }
+    const weight = integrationTestFileWeightsMs[file];
+    if (!Number.isFinite(weight) || weight <= 0) {
+      errors.push(`integration file has no positive weight: ${file}`);
+    }
+  }
+
+  for (const file of Object.keys(integrationTestFileWeightsMs)) {
+    if (!manifestSet.has(file)) {
+      errors.push(`integration weight references non-integration file: ${file}`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}

--- a/tools/node-test-runner-lib.mjs
+++ b/tools/node-test-runner-lib.mjs
@@ -10,7 +10,8 @@ export function parseRunnerArgs(args, tierNames) {
     list: false,
     slowThresholdMs: 1000,
     slowLimit: 10,
-    concurrency: undefined
+    concurrency: undefined,
+    shard: undefined
   };
 
   for (let index = 0; index < args.length; index += 1) {
@@ -63,12 +64,26 @@ export function parseRunnerArgs(args, tierNames) {
       options.concurrency = parsePositiveInteger(arg.slice("--concurrency=".length), "--concurrency");
       continue;
     }
+    if (arg === "--shard") {
+      const value = args[index + 1];
+      if (value === undefined) throw new Error("--shard requires a value");
+      options.shard = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--shard=")) {
+      options.shard = arg.slice("--shard=".length);
+      continue;
+    }
 
     throw new Error(`unknown run-node-tests option: ${arg}`);
   }
 
   if (options.tier !== "all" && !tierNames.includes(options.tier)) {
     throw new Error(`unknown test tier: ${options.tier}; expected all, ${tierNames.join(", ")}`);
+  }
+  if (options.shard !== undefined && options.tier !== "integration") {
+    throw new Error("--shard is only supported with --tier integration");
   }
 
   return options;

--- a/tools/run-local-check.mjs
+++ b/tools/run-local-check.mjs
@@ -47,6 +47,7 @@ const FAST_STEPS = [
   ["boundaries: file-complexity", "harness:check-file-complexity"],
   ["boundaries: forbidden-symbols", "harness:scan-forbidden-symbols"],
   ["boundaries: private-boundary", "harness:check-private-boundary"],
+  ["boundaries: integration-test-shards", "harness:check-integration-test-shards"],
   ["boundaries: gate-surface", "harness:check-gate-surface"],
   ["boundaries: locale-content", "harness:check-locale-content"],
   ["boundaries: runtime-release-readiness", "harness:check-runtime-release-readiness"],

--- a/tools/run-local-check.test.mjs
+++ b/tools/run-local-check.test.mjs
@@ -32,6 +32,7 @@ test("buildSteps appends integration and gui lanes only in the full tier", () =>
 
   // Fast tier mirrors the CI boundaries + package-policy surface.
   assert.ok(fastScripts.includes("harness:check-import-boundaries"));
+  assert.ok(fastScripts.includes("harness:check-integration-test-shards"));
   assert.ok(fastScripts.includes("harness:check-gate-surface"));
   assert.ok(fastScripts.includes("harness:check-package-policy"));
 });

--- a/tools/run-manifest-gates.mjs
+++ b/tools/run-manifest-gates.mjs
@@ -19,6 +19,7 @@ export function parseManifestGateArgs(args) {
   const options = {
     packageSurface: null,
     workflowJob: null,
+    shard: null,
     exclude: new Set()
   };
 
@@ -31,6 +32,11 @@ export function parseManifestGateArgs(args) {
     }
     if (arg === "--workflow-job") {
       options.workflowJob = requireValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--shard") {
+      options.shard = parsePositiveInteger(requireValue(args, index, arg), arg);
       index += 1;
       continue;
     }
@@ -89,7 +95,7 @@ export function buildManifestGatePlan(manifest, options) {
     return gate;
   });
 
-  return collapseCompositeCoveredCommands(dedupeCommands(gates));
+  return collapseCompositeCoveredCommands(dedupeCommands(applyShardOption(gates, options.shard)));
 }
 
 function dedupeCommands(gates) {
@@ -103,6 +109,19 @@ function dedupeCommands(gates) {
     commands.push({ id: gate.id, command: gate.command });
   }
   return commands;
+}
+
+function applyShardOption(gates, shard) {
+  if (shard === null || shard === undefined) {
+    return gates.map((gate) => ({ ...gate }));
+  }
+
+  return gates.map((gate) => {
+    if (gate.shardable !== true) {
+      throw new Error(`manifest gate ${gate.id} is not shardable but --shard was provided`);
+    }
+    return { ...gate, command: `${gate.command} -- --shard ${shard}` };
+  });
 }
 
 function collapseCompositeCoveredCommands(commands) {
@@ -135,6 +154,14 @@ function requireValue(args, index, flag) {
     throw new Error(`${flag} requires a value`);
   }
   return value;
+}
+
+function parsePositiveInteger(value, flag) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
 }
 
 function readManifest() {

--- a/tools/run-manifest-gates.test.mjs
+++ b/tools/run-manifest-gates.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildManifestGatePlan, parseManifestGateArgs } from "./run-manifest-gates.mjs";
+
+test("manifest gate runner appends shard args only to shardable gates", () => {
+  const manifest = {
+    gates: [
+      {
+        id: "test-integration",
+        command: "npm run test:integration",
+        shardable: true,
+        executionSurfaces: { rewriteCi: { pullRequestJobs: ["integration-shard"] } }
+      }
+    ]
+  };
+  const options = parseManifestGateArgs(["--workflow-job", "integration-shard", "--shard", "3"]);
+
+  assert.deepEqual(buildManifestGatePlan(manifest, options), [
+    { id: "test-integration", command: "npm run test:integration -- --shard 3" }
+  ]);
+});
+
+test("manifest gate runner rejects --shard for non-shardable gates", () => {
+  const manifest = {
+    gates: [
+      {
+        id: "check-example",
+        command: "npm run harness:check-example",
+        executionSurfaces: { rewriteCi: { pullRequestJobs: ["boundaries"] } }
+      }
+    ]
+  };
+  const options = parseManifestGateArgs(["--workflow-job", "boundaries", "--shard", "1"]);
+
+  assert.throws(
+    () => buildManifestGatePlan(manifest, options),
+    /manifest gate check-example is not shardable but --shard was provided/u
+  );
+});

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -3,6 +3,7 @@
 import { spawn } from "node:child_process";
 import { availableParallelism } from "node:os";
 import { resolve } from "node:path";
+import { selectIntegrationShardFiles } from "./integration-test-shards.mjs";
 import { collectSlowTests, collectTestFiles, formatSlowTestSummary, parseRunnerArgs, resolveTestConcurrency, selectTestFiles } from "./node-test-runner-lib.mjs";
 import { testTierManifest, testTierNames } from "./test-tier-manifest.mjs";
 
@@ -35,6 +36,10 @@ if (selection.errors.length > 0) {
     console.error(error);
   }
   process.exit(1);
+}
+
+if (options.shard !== undefined) {
+  selection.files = selectIntegrationShardFiles(options.shard);
 }
 
 if (selection.files.length === 0) {

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -9,7 +9,8 @@ test("parseRunnerArgs accepts tier and slow summary options", () => {
     list: false,
     slowThresholdMs: 250,
     slowLimit: 3,
-    concurrency: undefined
+    concurrency: undefined,
+    shard: undefined
   });
 });
 
@@ -17,6 +18,12 @@ test("parseRunnerArgs accepts a concurrency cap", () => {
   assert.equal(parseRunnerArgs(["--concurrency", "4"], testTierNames).concurrency, 4);
   assert.equal(parseRunnerArgs(["--concurrency=2"], testTierNames).concurrency, 2);
   assert.throws(() => parseRunnerArgs(["--concurrency", "x"], testTierNames), /--concurrency/u);
+});
+
+test("parseRunnerArgs accepts integration shards only for the integration tier", () => {
+  assert.equal(parseRunnerArgs(["--tier", "integration", "--shard", "3"], testTierNames).shard, "3");
+  assert.equal(parseRunnerArgs(["--tier=integration", "--shard=2"], testTierNames).shard, "2");
+  assert.throws(() => parseRunnerArgs(["--tier", "fast", "--shard", "1"], testTierNames), /--shard is only supported/u);
 });
 
 test("parseRunnerArgs rejects unknown tiers and options", () => {

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -24,7 +24,8 @@ export const testTierManifest = {
     "tools/run-gui-e2e-tests.test.mjs",
     "tools/run-local-gates-check.test.mjs",
     "tools/run-local-check.test.mjs",
-    "tools/run-node-tests.test.mjs"
+    "tools/run-node-tests.test.mjs",
+    "tools/check-integration-test-shards.test.mjs"
   ],
   contract: [
     "packages/application/test/code-doc-reconciliation.test.ts",

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -25,6 +25,7 @@ export const testTierManifest = {
     "tools/run-local-gates-check.test.mjs",
     "tools/run-local-check.test.mjs",
     "tools/run-node-tests.test.mjs",
+    "tools/run-manifest-gates.test.mjs",
     "tools/check-integration-test-shards.test.mjs"
   ],
   contract: [


### PR DESCRIPTION
# English

## Summary

Shard the `integration` job across 6 parallel matrix jobs, and converge the Mergify queue gates so that in-place checks are re-enabled.

`integration` is the sole critical path of PR CI: measured on PR #505, it took **6m8s** while all ten other jobs finished within **58s** and then waited for it. Sharding it does not remove a single test — the same 78 integration test files run, distributed across 6 jobs by measured-duration bin packing.

Separately, `merge_conditions` was a proper subset of the branch-protection required contexts, which (a) made Mergify attempt merges before four required checks had reported, producing dequeue churn that two `requeue-*` self-heal rules existed only to paper over, and (b) violated one of the three conditions under which Mergify auto-enables in-place checks. The measured cost of (b) was **~2.17 extra full CI runs per merge**: every merge created a `mergify/merge-queue/*` draft PR and re-ran the entire suite against a tree that was, when `main` had not advanced, byte-identical to the one already validated.

## What Changed

**Sharding (`perf: shard integration ci job`)**

- New `integration-shard` matrix job (6 shards, `fail-fast: false`). Not a required context; its check names are `integration-shard (1..6)`.
- The job named `integration` is retained as an **aggregate** job (`needs: [integration-shard]`, `if: always() && github.event_name == 'pull_request'`). Its check name is unchanged, so **branch protection and required contexts are untouched**.
- Shard assignment is by **measured duration** (longest-processing-time bin packing), not by file count. The distribution is heavily skewed: the slowest 5 files account for ~30% of total time, the slowest 10 for ~50%, while 17 files run in under a second. Even splitting by file count would have produced a straggler shard.
- `tools/integration-test-shards.mjs` holds the static weight table and the packing.

**Aggregate verdict is fail-closed (`tools/check-integration-shard-result.mjs`)**

The aggregate job is the only check named `integration` after sharding, so it is the required status check. Its verdict is extracted into a pure, unit-tested function:

```
success   -> exit 0
failure   -> exit 1
cancelled -> exit 1
skipped   -> exit 1
default   -> exit 1   (unknown / undefined)
```

Only `"success"` passes. Anything else, including an unrecognised value, fails. A fail-open variant (`if result == 'failure' then fail`) would silently pass on `skipped`/`cancelled`, leaving a required check permanently green with nobody noticing.

**The shard count has a single source of truth (`fix:` in `tools/check-integration-test-shards.mjs`)**

`integrationShardCount` (in `integration-test-shards.mjs`) and the workflow's `matrix.shard` list are two independent declarations. If someone edited the matrix to `[1,2,3,4]` and left the script at 6, shards 5 and 6 would never run: the internal consistency check would still pass, all four shards would succeed, the aggregate would be green, and a block of tests would silently vanish from CI.

`check-integration-test-shards` now parses `.github/workflows/rewrite-ci.yml` and asserts the matrix list is exactly `1..integrationShardCount`. It also asserts the shard partition is a **cover with no overlap**: the union of all shards equals the manifest's integration tier, pairwise intersections are empty, and no shard is empty. It runs on every PR, folded into the existing `boundaries` job (`tier: pr-required`), the same pattern established by `check-cli-structure` in #505.

**Sharding stays manifest-driven (`refactor:` — `fix: keep integration shards manifest driven`)**

An earlier revision had the shard job run `npm run test:integration -- --shard N` directly, bypassing `run-manifest-gates`. That would have detached the manifest from what actually executes on the integration surface: a future gate added to that surface in the manifest would simply not run, with nothing to report it.

Instead:

- `test-integration` gains a **data field** `"shardable": true` in `tools/gate-manifest.json`.
- `run-manifest-gates.mjs` accepts `--shard <n>`. For a `shardable` gate it appends `-- --shard <n>` to the gate's command. For a **non-shardable** gate, passing `--shard` **throws** (fail-closed; it does not silently ignore the flag). Covered by a new unit test.
- The shard job runs `node tools/run-manifest-gates.mjs --workflow-job integration-shard --shard ${{ matrix.shard }} --exclude mergify-queue-metadata-edit-noop`.
- `tools/check-gate-surface.mjs` therefore needs **no special case**: its diff against `main` is 4 lines, teaching `parseManifestRunnerCommand` to consume `--shard <n>`. There is no hardcoded gate id in the checker.
- In the manifest, `test-integration.executionSurfaces.rewriteCi.pullRequestJobs` points at `integration-shard` (the job that actually executes the gate), and the aggregate `integration` job is registered under `helperJobsNotRegisteredAsGates`. The manifest states what is true.

**Mergify convergence (`fix: align mergify queue gates`)**

- `queue_conditions` now requires all **10** branch-protection required contexts: `boundaries`, `package-policy`, `typecheck (24)`, `typecheck (26)`, `fast-contract`, `integration`, `supply-chain`, `gui-build`, `node26-compatibility`, `pr-body-lint`.
- `merge_conditions: []`. Together with the repo's defaults (`max_parallel_checks == 1`, `batch_size == 1`, neither of which is set), this satisfies all three conditions under which Mergify **auto-enables in-place checks**. When the queue holds one PR whose base has not advanced, Mergify will reuse the PR's own checks instead of creating a draft PR and re-running everything.
- The `requeue-1` / `requeue-2` self-heal rules are **removed**. They existed to retry after dequeue churn, and that churn's root cause was `merge_conditions` being a strict subset of the required contexts. With the root cause gone, the self-heal rules are a patch over a fixed bug.
- `batch_size`, `max_parallel_checks` and `speculative_checks` are deliberately **not** set. This repo merges single-digit PRs per day; the queue never congests, so batching yields nothing — and `batch_size > 1` would itself re-disable in-place checks.

Not changed: no test is removed, no gate is weakened, no timeout is relaxed, no `continue-on-error` is introduced, GitHub branch protection is untouched.

## Task And Scope

- Harness task: `task_01KX2XJNEQWRWGPCYVFJ4KA97A` (CI-2) and `task_01KX2XJRZXMA0GK3MZ6QCRBGYJ` (CI-3), both under parent `task_01KX2XFTW3SJYNQ08F99SJMXVJ`
- Branch: `codex/ci-2-integration-shard`
- Public scope: `.github/workflows/rewrite-ci.yml`, `.mergify.yml`, `tools/*`, `package.json`
- Private planning/evidence updated: yes
- Out of scope: removing the redundant `typecheck (26)` matrix branch. It is a **zero wall-clock** change (that job runs in 28-32s and is not on the critical path), and removing it would delete a required status context while branch protection still demands it — the context would never report and the PR could never merge, with no CI showing red. That requires editing GitHub branch protection first, then merging the job removal: two steps across two systems, not atomically expressible in one PR. It ships separately.

## Version Impact

- Version: no version change because this PR changes CI execution topology and merge-queue configuration only; no published artifact contract changes.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `.github/workflows/rewrite-ci.yml` (job topology), `.mergify.yml` (queue gates), `tools/gate-manifest.json` (gate execution surface), `tools/check-gate-surface.mjs` (4-line parser extension, no verdict logic changed), `tools/run-manifest-gates.mjs` (new fail-closed `--shard` handling).
- Authority: decision `dec_mrd7djey` (state `active`, arbiter `human:zeyuli`), claim anchor `CH1` items 2 and 3; tasks `task_01KX2XJNEQWRWGPCYVFJ4KA97A`, `task_01KX2XJRZXMA0GK3MZ6QCRBGYJ`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: removal of the `typecheck (26)` matrix branch, gated on a prior branch-protection edit.

## Verification

- Base `origin/main` SHA: `8726f77`
- Branch merge-base with `origin/main`: `8726f77`
- Last `git fetch origin` time: immediately before opening this PR
- Sync method: rebase (fast-forward onto `8726f77`)
- Public diff command: `git diff origin/main...codex/ci-2-integration-shard`
- Private evidence commit/path: harness task packages for CI-2 and CI-3 (facts `F-VQ341RXR`, `F-J0RZVEKC`, `F-DE6Q0MF5`, `F-CZ8B169B`, `F-F7Q257AW`, `F-5484P0J0`)
- Reviewer evidence path: same task packages (`review.md`)
- GitHub Actions `rewrite-ci` run URL: see checks on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (via `npm run check:local`)
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm run check` (full) and `npm test` (full) were not run locally; the fast tier plus every gate directly affected by this change was run instead, and the full set is delegated to `rewrite-ci` on this PR. Unchecked `harness:*` boxes are covered by `check:local`'s fast tier or by the `boundaries` job on this PR; they were not each invoked individually and are therefore left unchecked rather than claimed.

**Negative controls (these are the load-bearing evidence, not the green checks):**

1. *Shard count drift is caught.* Temporarily editing the workflow matrix to `[1,2,3,4]`:
   ```
   integration-shard workflow matrix mismatch: expected [1, 2, 3, 4, 5, 6], got [1, 2, 3, 4]
   checker_exit=1
   ```
   After reverting:
   ```
   integration shard check passed: manifestFiles=78 shards=6 workflowShards=[1, 2, 3, 4, 5, 6]
   checker_exit=0
   ```
2. *A failing shard turns the required check red.* Forcing a failure in shard 6: `shard_exit=1`, `aggregate_exit=1`.
3. *The aggregate verdict is fail-closed across all four `needs.*.result` values:* `success=0`, `failure=1`, `cancelled=1`, `skipped=1`.
4. *A non-shardable gate rejects `--shard`:* unit test asserts `manifest gate check-example is not shardable but --shard was provided`.
5. *The shard partition covers the tier exactly:* union equals the 78-file integration tier, pairwise intersections empty, no empty shard.

**Other checks:** `npm run harness:check-gate-surface` green (**with the checker special cases rolled back**); `npm run check:local` green; the `.mergify.yml` `queue_conditions` list was compared item-by-item against `gh api .../branches/main/protection` (all 10 present, none extra).

**Local wall-clock, per shard:** `1:61.13s 2:53.54s 3:50.53s 4:52.89s 5:52.03s 6:53.79s` — max `61.13s`, against a full-tier local baseline of `299.21s`. On CI, `integration` measured `6m8s` on PR #505; this PR's own `integration` check is the first real measurement of the sharded topology.

**Honest boundary — in-place checks cannot be verified by this PR.** Mergify reads `.mergify.yml` from the **base** branch (`main`), so this PR is still queued under the old configuration and **will still be re-run in a `mergify/merge-queue/*` draft PR**. Whether in-place checks actually engage can only be observed on the *next* PR after this one merges: if they do, that PR will be merged without a draft PR being created. This PR does not claim to have verified it.

## Review Evidence

- Self-review: `tools/check-gate-surface.mjs` diff against `origin/main` is 4 lines and contains no gate id; `grep -c 'test-integration'` in that file returns 0. `parseManifestRunnerCommand`'s `--shard` branch was read against the `for` update expression to confirm it consumes both the flag and its value (identical shape to the existing `--workflow-job` branch). `.mergify.yml` was read in full.
- Reviewer subagent: an independent read-only recon line measured the duration distribution and the `needs.*.result` semantics, and **proposed a fail-open aggregate verdict**. The implementation line, working from an independent brief, produced a fail-closed one. The two lines disagreed on exactly the one safety-critical point in this change; the fail-closed reading was adopted.
- Human review: pending
- Blocking findings: none. Three findings raised during review (shard-count double declaration; shard job bypassing `run-manifest-gates`; hardcoded gate id in the checker) were all fixed before this PR was opened.

## Residual Risk

1. **`-label = dequeued` is now dead code.** The `requeue-1` / `requeue-2` rules that used to apply this label are removed, so nothing applies it automatically any more. The condition is retained because it is fail-closed — manually applying the label still prevents queueing, which is a useful manual brake. But a future reader should not assume automatic logic stands behind it.
2. **In-place checks are unverified until the next PR** (see the honest boundary above). If they do not engage, the queue will keep creating draft PRs, and the cause must be re-diagnosed against Mergify's three conditions rather than assumed.
3. **The shard weight table is static.** As tests are added or slow down, the packing drifts from optimal. The cover-with-no-overlap invariant is still machine-enforced (a new file missing from the table fails `check-integration-test-shards`), so drift degrades balance, never correctness.
4. **Removing `requeue-*` means a genuine dequeue is now terminal** until a human re-applies `merge-queue`. This is intentional: the churn those rules absorbed had a fixed root cause, and silently retrying a dequeue hides real signal. Fail-closed by design.

## References

- Task: `task_01KX2XJNEQWRWGPCYVFJ4KA97A`, `task_01KX2XJRZXMA0GK3MZ6QCRBGYJ`
- Evidence: facts `F-VQ341RXR`, `F-J0RZVEKC`, `F-DE6Q0MF5`, `F-CZ8B169B` (CI-2); `F-F7Q257AW`, `F-5484P0J0` (CI-3)
- Review: decision `dec_mrd7djey`

---

# 中文

## 概要

把 `integration` job 分片为 6 个并行 matrix job，并收敛 Mergify 的队列门禁，从而重新启用 in-place checks。

`integration` 是 PR CI 唯一的关键路径：在 PR #505 上实测耗时 **6m8s**，而其余十个 job 全部在 **58s** 内跑完，之后一起等它。分片不移除任何一个测试——同样的 78 个 integration 测试文件照跑，只是按实测耗时装箱分布到 6 个 job 上。

另一方面，`merge_conditions` 是分支保护 required contexts 的真子集，这导致：(a) Mergify 在四项 required check 尚未报告时就尝试合并，产生 dequeue churn，而两条 `requeue-*` 自愈规则的存在仅仅是为了掩盖它；(b) 违反了 Mergify 自动启用 in-place checks 的三个条件之一。(b) 的实测代价是**每次合并额外约 2.17 遍完整 CI**：每次合并都会创建 `mergify/merge-queue/*` 草稿 PR，对一棵在 `main` 未前进时与已验证过的树逐字节相同的代码树，重跑整套测试。

## 改动内容

**分片（`perf: shard integration ci job`）**

- 新增 `integration-shard` matrix job（6 片，`fail-fast: false`）。它不是 required context，其 check 名为 `integration-shard (1..6)`。
- 名为 `integration` 的 job 保留为**汇总（aggregate）** job（`needs: [integration-shard]`，`if: always() && github.event_name == 'pull_request'`）。其 check 名不变，因此**分支保护与 required contexts 完全未触碰**。
- 分片按**实测耗时**装箱（LPT），而非按文件数均分。耗时分布严重倾斜：最慢的 5 个文件约占总时长 30%，最慢的 10 个约占 50%，而有 17 个文件跑不到 1 秒。按文件数均分会造出一个拖后腿的分片。
- `tools/integration-test-shards.mjs` 保存静态权重表与装箱逻辑。

**汇总判定是 fail-closed（`tools/check-integration-shard-result.mjs`）**

分片之后，唯一名为 `integration` 的 check 就是这个 aggregate job，也就是那个 required status check。其判定被抽取为一个纯函数并单测覆盖：

```
success   -> exit 0
failure   -> exit 1
cancelled -> exit 1
skipped   -> exit 1
default   -> exit 1   （未知 / undefined）
```

只有 `"success"` 放行。其余任何值，包括无法识别的值，一律失败。fail-open 的写法（`若 result == 'failure' 则失败`）会在 `skipped`/`cancelled` 时静默放行，使这个 required check 永远为绿，且无人可察。

**分片数拥有单一真理源（`fix:`，位于 `tools/check-integration-test-shards.mjs`）**

`integration-test-shards.mjs` 中的 `integrationShardCount` 与 workflow 的 `matrix.shard` 列表是两处独立声明。如果有人把 matrix 改成 `[1,2,3,4]` 而脚本仍是 6，第 5、6 片的测试文件将永不执行：内部一致性检查照样通过，四个分片全部成功，aggregate 变绿，而一批测试从 CI 中静默消失。

`check-integration-test-shards` 现在会解析 `.github/workflows/rewrite-ci.yml`，断言 matrix 列表严格等于 `1..integrationShardCount`。它同时断言分片是一个**无重叠的完全覆盖**：所有分片的并集等于 manifest 的 integration tier，两两交集为空，且没有空分片。它在每个 PR 上执行，折叠进已存在的 `boundaries` job（`tier: pr-required`）——正是 #505 中 `check-cli-structure` 立下的模式。

**分片保持由 manifest 驱动（`fix: keep integration shards manifest driven`）**

早先的一版让 shard job 直接跑 `npm run test:integration -- --shard N`，绕过了 `run-manifest-gates`。那会使 manifest 与 integration 面上实际执行的内容脱钩：将来有人在 manifest 里给该面新增一道 gate，它根本不会被执行，且没有任何东西会报告这件事。

改为：

- `tools/gate-manifest.json` 中 `test-integration` 增加一个**数据字段** `"shardable": true`。
- `run-manifest-gates.mjs` 接受 `--shard <n>`。对 `shardable` 的 gate，把 `-- --shard <n>` 追加到其命令；对**非** `shardable` 的 gate 传入 `--shard` 则**抛错**（fail-closed，不静默忽略该参数）。新增单测覆盖。
- shard job 执行 `node tools/run-manifest-gates.mjs --workflow-job integration-shard --shard ${{ matrix.shard }} --exclude mergify-queue-metadata-edit-noop`。
- 因此 `tools/check-gate-surface.mjs` **无需任何特例**：它相对 `main` 的 diff 只有 4 行，即让 `parseManifestRunnerCommand` 消费 `--shard <n>`。该 checker 中没有任何硬编码的 gate id。
- manifest 中 `test-integration.executionSurfaces.rewriteCi.pullRequestJobs` 指向 `integration-shard`（真正执行该 gate 的 job），而 aggregate 的 `integration` job 登记在 `helperJobsNotRegisteredAsGates` 之下。manifest 陈述的是事实。

**Mergify 收敛（`fix: align mergify queue gates`）**

- `queue_conditions` 现在要求分支保护的全部 **10** 个 required contexts：`boundaries`、`package-policy`、`typecheck (24)`、`typecheck (26)`、`fast-contract`、`integration`、`supply-chain`、`gui-build`、`node26-compatibility`、`pr-body-lint`。
- `merge_conditions: []`。连同本仓的默认值（`max_parallel_checks == 1`、`batch_size == 1`，两者均未设置），这满足了 Mergify **自动启用 in-place checks** 的全部三个条件。当队列中只有一个 PR 且其 base 未前进时，Mergify 将复用该 PR 自身的 check 结果，而不再创建草稿 PR 重跑一切。
- **删除** `requeue-1` / `requeue-2` 两条自愈规则。它们的作用是在 dequeue churn 之后重试，而 churn 的根因正是 `merge_conditions` 是 required contexts 的真子集。根因消除之后，自愈规则就是盖在已修 bug 上的补丁。
- 刻意**不**设置 `batch_size`、`max_parallel_checks`、`speculative_checks`。本仓每日合并个位数 PR，队列从不拥塞，batching 收益为零；而且 `batch_size > 1` 本身会反向禁用 in-place checks。

未改变的部分：没有移除任何测试，没有削弱任何 gate，没有放宽任何超时，没有引入 `continue-on-error`，GitHub 分支保护未触碰。

## 任务与范围

- Harness 任务：`task_01KX2XJNEQWRWGPCYVFJ4KA97A`（CI-2）与 `task_01KX2XJRZXMA0GK3MZ6QCRBGYJ`（CI-3），同属父任务 `task_01KX2XFTW3SJYNQ08F99SJMXVJ`
- 分支：`codex/ci-2-integration-shard`
- 公开范围：`.github/workflows/rewrite-ci.yml`、`.mergify.yml`、`tools/*`、`package.json`
- 私有计划 / 证据是否已更新：yes
- 范围外：移除冗余的 `typecheck (26)` 矩阵分支。它的墙钟收益为**零**（该 job 跑 28-32s，不在关键路径上），且移除它等于删除一个 required status context，而分支保护仍然要求它——该 context 将永不报告，PR 永远无法合并，同时没有任何 CI 变红。正确做法是先修改 GitHub 分支保护、再合入删除该 job 的 PR：跨两个系统的两步操作，无法在单个 PR 内原子表达。它另行交付。

## 版本影响

- 版本：不改版本，原因是本 PR 只改变 CI 的执行拓扑与合并队列配置，不改变任何已发布工件的契约。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`.github/workflows/rewrite-ci.yml`（job 拓扑）、`.mergify.yml`（队列门禁）、`tools/gate-manifest.json`（gate 执行面）、`tools/check-gate-surface.mjs`（4 行 parser 扩展，判定逻辑未改）、`tools/run-manifest-gates.mjs`（新增 fail-closed 的 `--shard` 处理）。
- 依据：decision `dec_mrd7djey`（state `active`，arbiter `human:zeyuli`），claim anchor `CH1` 第 2、3 项；task `task_01KX2XJNEQWRWGPCYVFJ4KA97A`、`task_01KX2XJRZXMA0GK3MZ6QCRBGYJ`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：移除 `typecheck (26)` 矩阵分支，前置条件是先修改分支保护。

## 验证

- `origin/main` 基准 SHA：`8726f77`
- 当前分支与 `origin/main` 的 merge-base：`8726f77`
- 最近一次 `git fetch origin` 时间：开启本 PR 之前
- 同步方式：rebase（快进到 `8726f77`）
- 公开 diff 命令：`git diff origin/main...codex/ci-2-integration-shard`
- 私有证据 commit/path：CI-2 与 CI-3 的 harness 任务包（fact `F-VQ341RXR`、`F-J0RZVEKC`、`F-DE6Q0MF5`、`F-CZ8B169B`、`F-F7Q257AW`、`F-5484P0J0`）
- Reviewer 证据路径：同上任务包（`review.md`）
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`（经由 `npm run check:local`）
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：本地未运行 `npm run check`（全量）与 `npm test`（全量）；改为运行 fast tier 以及与本改动直接相关的全部 gate，完整集合交由本 PR 上的 `rewrite-ci` 覆盖。未勾选的 `harness:*` 项由 `check:local` 的 fast tier 或本 PR 的 `boundaries` job 覆盖；它们并未被逐条单独调用，因此如实留空而非声称已跑。

**阴性对照（这些才是承重证据，绿灯不是）：**

1. *分片数漂移会被抓住。* 临时把 workflow matrix 改成 `[1,2,3,4]`：
   ```
   integration-shard workflow matrix mismatch: expected [1, 2, 3, 4, 5, 6], got [1, 2, 3, 4]
   checker_exit=1
   ```
   还原之后：
   ```
   integration shard check passed: manifestFiles=78 shards=6 workflowShards=[1, 2, 3, 4, 5, 6]
   checker_exit=0
   ```
2. *某个分片失败会让 required check 变红。* 强制 shard 6 失败：`shard_exit=1`，`aggregate_exit=1`。
3. *汇总判定在四种 `needs.*.result` 取值上均为 fail-closed：* `success=0`、`failure=1`、`cancelled=1`、`skipped=1`。
4. *非 shardable 的 gate 会拒绝 `--shard`：* 单测断言 `manifest gate check-example is not shardable but --shard was provided`。
5. *分片是对该 tier 的精确覆盖：* 并集等于 78 个文件的 integration tier，两两交集为空，无空分片。

**其它检查：** `npm run harness:check-gate-surface` 绿（**且是在 checker 特例被回滚之后仍绿**）；`npm run check:local` 绿；`.mergify.yml` 的 `queue_conditions` 清单与 `gh api .../branches/main/protection` 逐项比对（10 项全在，无多余项）。

**本地各分片墙钟：** `1:61.13s 2:53.54s 3:50.53s 4:52.89s 5:52.03s 6:53.79s` —— 最大 `61.13s`，对照全量 tier 的本地基线 `299.21s`。在 CI 上，`integration` 于 PR #505 实测 `6m8s`；本 PR 自身的 `integration` check 就是分片拓扑的第一次真实测量。

**诚实边界——in-place checks 无法由本 PR 验证。** Mergify 读取 **base 分支（`main`）** 上的 `.mergify.yml`，因此本 PR 仍按旧配置入队，**仍会在 `mergify/merge-queue/*` 草稿 PR 中被重跑一遍**。in-place checks 是否真正生效，只能在本 PR 合入之后由**下一个** PR 观察：若生效，那个 PR 合并时不会再创建草稿 PR。本 PR 不声称已验证这一点。

## 审查证据

- 自查：`tools/check-gate-surface.mjs` 相对 `origin/main` 的 diff 仅 4 行且不含任何 gate id；对该文件 `grep -c 'test-integration'` 返回 0。`parseManifestRunnerCommand` 的 `--shard` 分支已对照 `for` 循环的 update 表达式逐字核读，确认其同时消费了参数名与参数值（与既有 `--workflow-job` 分支同构）。`.mergify.yml` 已全文通读。
- Reviewer subagent：一条独立的只读侦察线测量了耗时分布与 `needs.*.result` 语义，并**给出了 fail-open 的汇总判定骨架**；实现线基于独立的任务书，产出的是 fail-closed 版本。两条线恰好在本改动唯一的安全关键点上分歧，最终采纳 fail-closed。
- 人工审查：pending
- 阻塞发现：无。复核期间提出的三条 finding（分片数双写、shard job 绕过 `run-manifest-gates`、checker 中硬编码 gate id）在本 PR 开启之前已全部修复。

## 残余风险

1. **`-label = dequeued` 现已成为死代码。** 过去为 PR 打上该标签的 `requeue-1` / `requeue-2` 规则已被删除，因此不再有任何东西会自动打上它。保留该条件是因为它是 fail-closed 的——手动打上该标签仍可阻止入队，这是一个有用的人工刹车。但后来者不应假设它背后还有自动逻辑。
2. **in-place checks 在下一个 PR 之前未经验证**（见上文诚实边界）。若它没有生效，队列将继续创建草稿 PR，届时须对照 Mergify 的三个条件重新诊断，而不是想当然。
3. **分片权重表是静态的。** 随着测试增删或变慢，装箱会偏离最优。但「无重叠的完全覆盖」这一不变量仍由机器强制（权重表中缺失的新文件会使 `check-integration-test-shards` 失败），因此漂移只会降低均衡度，绝不会损害正确性。
4. **移除 `requeue-*` 意味着一次真实的 dequeue 现在是终局的**，直到有人重新打上 `merge-queue` 标签。这是刻意为之：那些规则吸收的 churn 有确定的根因，而静默重试一次 dequeue 会掩盖真实信号。设计上 fail-closed。

## 关联材料

- 任务：`task_01KX2XJNEQWRWGPCYVFJ4KA97A`、`task_01KX2XJRZXMA0GK3MZ6QCRBGYJ`
- 证据：fact `F-VQ341RXR`、`F-J0RZVEKC`、`F-DE6Q0MF5`、`F-CZ8B169B`（CI-2）；`F-F7Q257AW`、`F-5484P0J0`（CI-3）
- 审查：decision `dec_mrd7djey`
