### PR TITLE
perf: inline gui paths filter

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -46,38 +46,6 @@ jobs:
           PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login || '' }}
         run: node tools/run-manifest-gates.mjs --workflow-job pr-body-lint --exclude mergify-queue-metadata-edit-noop
 
-  # Detect what a PR touched so heavy, package-scoped jobs can no-op their
-  # expensive steps. The jobs still run and report green, so required-check
-  # branch protection never deadlocks on a skipped context.
-  changes:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    outputs:
-      gui: ${{ steps.filter.outputs.gui }}
-    steps:
-      - name: Accept Mergify queue metadata edit
-        if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT == 'true' }}
-        run: echo "Mergify queue metadata edit does not change the source under test."
-      - uses: actions/checkout@v4
-        if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' }}
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: dorny/paths-filter@v4
-        if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' }}
-        id: filter
-        with:
-          # Force git-based comparison so Mergify merge-queue draft PRs use the
-          # event's explicit base/head SHAs instead of the synthetic PR file list.
-          token: ""
-          base: ${{ github.event.pull_request.base.sha }}
-          filters: |
-            gui:
-              - 'packages/gui/**'
-              - 'package.json'
-              - 'package-lock.json'
-              - 'tsconfig*.json'
-
   full-check:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -234,7 +202,6 @@ jobs:
 
   gui-build:
     if: github.event_name == 'pull_request'
-    needs: changes
     runs-on: ubuntu-latest
     steps:
       - name: Accept Mergify queue metadata edit
@@ -242,15 +209,31 @@ jobs:
         run: echo "Mergify queue metadata edit does not change the source under test."
       - uses: actions/checkout@v4
         if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' }}
-      - uses: actions/setup-node@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v4
         if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' }}
+        id: filter
+        with:
+          # Force git-based comparison so Mergify merge-queue draft PRs use the
+          # event's explicit base/head SHAs instead of the synthetic PR file list.
+          token: ""
+          base: ${{ github.event.pull_request.base.sha }}
+          filters: |
+            gui:
+              - 'packages/gui/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig*.json'
+      - uses: actions/setup-node@v4
+        if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' && steps.filter.outputs.gui == 'true' }}
         with:
           node-version: 24
           cache: npm
       # Skip the GUI build/test when a PR touches no GUI or shared-root files.
-      - if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' && needs.changes.outputs.gui == 'true' }}
+      - if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' && steps.filter.outputs.gui == 'true' }}
         run: npm ci
-      - if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' && needs.changes.outputs.gui == 'true' }}
+      - if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' && steps.filter.outputs.gui == 'true' }}
         run: node tools/run-manifest-gates.mjs --workflow-job gui-build --exclude mergify-queue-metadata-edit-noop
   node26-compatibility:
     if: github.event_name == 'pull_request'

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -137,7 +137,6 @@
         "node26-compatibility"
       ],
       "helperJobsNotRegisteredAsGates": [
-        "changes",
         "integration"
       ],
       "nonPullRequestGateJobs": [


### PR DESCRIPTION
# English

## Summary

Delete the `changes` job and inline `dorny/paths-filter` into `gui-build`, so that `gui-build` no longer has a `needs` edge.

The `changes` job executes in **5 seconds**. Its only consumer is `gui-build`. But because `gui-build` declares `needs: changes`, GitHub schedules it in a **second scheduling wave**, and that wave is expensive: measured `queued` durations for `gui-build` across recent runs were `303s / 304s / 607s / 3s / 4s`.

On PR #505 this was the actual end-to-end determinant. `integration` — the job everyone was watching, and the one #507 sharded — ran 368s and finished at **t=373s**. `gui-build` ran 26s and finished at **t=621s**, because it spent 608s queued waiting for a 5-second dependency to release it. The run took 632s. **The critical path was a dependency edge nobody was looking at, not the conspicuous slow job.**

Removing the edge lets `gui-build` schedule in the same wave as the other nine PR jobs.

## What Changed

**`.github/workflows/rewrite-ci.yml`**

- The `changes` job is deleted in full.
- `gui-build` loses `needs: changes`. Its `runs-on`, its job id, and therefore its **check name are byte-identical** — `gui-build` is one of the 10 branch-protection required contexts, and renaming it would leave that context permanently unreported.
- `dorny/paths-filter@v4` moves into `gui-build` as `id: filter`, carrying `token: ""`, `base: ${{ github.event.pull_request.base.sha }}`, its filter list, and the comment explaining why `token` is forced empty, verbatim.
- `gui-build`'s `checkout` gains `fetch-depth: 0` (paths-filter's `ensureRefAvailable(base)` needs history). It gains **nothing else** — see below.
- Three step conditions change from `needs.changes.outputs.gui == 'true'` to `steps.filter.outputs.gui == 'true'`. `setup-node` and `npm ci` are now also gated on that condition: when a PR touches no GUI or shared-root file, the job runs `checkout` + `filter`, skips the rest, and reports `success`.

**`tools/gate-manifest.json`**

- `surfaces.rewriteCi.helperJobsNotRegisteredAsGates` drops the `changes` entry. `integration` (the CI-2 aggregate) remains.

The skip logic is unchanged in behaviour: GUI paths changed → `test:gui` and the GUI build run; unchanged → they are skipped. No test is removed, no gate weakened, no timeout relaxed, no `continue-on-error` added. Branch protection and `.mergify.yml` are untouched.

## Review Finding Caught Before Merge: `ref: head.sha`

The first implementation moved the `changes` job's checkout **wholesale**, including `ref: ${{ github.event.pull_request.head.sha }}`.

On `changes` that line was inert — the job computed a filter and built nothing. On `gui-build` it decides **which tree gets compiled**. With it, `gui-build` became the only job in the workflow that builds the PR head rather than the merge ref (`refs/pull/N/merge`, the `actions/checkout` default on `pull_request`); the other nine still build the merge result. Nothing about the line changed. Everything about what it does changed.

It also compounds with #507: with in-place checks enabled, Mergify no longer rebuilds in a draft PR. Had `gui-build` also stopped testing the merge ref, no run anywhere would have compiled `main + PR` until Mergify updated the branch.

The line is removed. `grep -n 'ref:' .github/workflows/rewrite-ci.yml` now returns nothing.

**Why the fix is a deletion and not a substitution.** The obvious repair — pass `ref` to `paths-filter` instead of to `checkout` — does not work, and the action's source says so:

- `action.yml`: `inputs.ref` — *"This option is ignored if action is triggered by pull_request event."*
- `src/main.ts`, `case 'pull_request'`: emits `core.warning("'ref' input parameter is ignored")`, and with `token: ""` calls `git.getChanges(base, await git.getCurrentRef())` — i.e. the head is **whatever `checkout` left on disk**.
- `src/git.ts` `getChanges()` uses a **two-dot** diff, `base..head`. The three-dot form lives only in `getChangesSinceMergeBase()`, which this path never reaches.

Two-dot semantics make the default checkout **more** precise, not less. Because `base.sha` is the merge commit's first parent, `base..merge_ref` is exactly the PR's net contribution. By contrast `base..head.sha` is the PR's changes **unioned with the inverse of everything `main` did since the fork**. Reproduced in a scratch repo — `main` touched `packages/gui`, the PR touched only `packages/cli`:

```
git diff --name-status base..head_sha     git diff --name-status base..merge_ref
M  packages/cli/main.ts                   M  packages/cli/main.ts
M  packages/gui/app.ts   <- false positive
```

So the deleted line was making `gui-build` run more often than necessary, inside the PR whose purpose is to make CI faster. Both forms are fail-safe (they over-run, never under-run); only the merge ref is precise.

## Task And Scope

- Harness task: `task_01KX34TSDQANHS46J7PA62CD26` (CI-4), under parent `task_01KX2XFTW3SJYNQ08F99SJMXVJ`
- Branch: `codex/ci-4-inline-paths-filter`
- Public scope: `.github/workflows/rewrite-ci.yml`, `tools/gate-manifest.json`
- Private planning/evidence updated: yes
- Out of scope: removing the aggregate `integration` job's `needs: [integration-shard]` edge. That edge pays the same second-wave scheduling tax, but removing it means promoting the 6 shards to required status contexts, which requires editing GitHub branch protection first. It is deferred and will be combined with the pending removal of the redundant `typecheck (26)` matrix branch into a single branch-protection change.

## Version Impact

- Version: no version change because this touches CI topology only, no published package source.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `.github/workflows/rewrite-ci.yml` (CI topology), `tools/gate-manifest.json` (gate execution surface)
- Authority: decision `dec_mrdbyvyd` (state=active, arbiter=human:zeyuli); task `task_01KX34TSDQANHS46J7PA62CD26`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: branch-protection edit combining `typecheck (26)` removal and the `integration` aggregate decision

## Verification

- Base `origin/main` SHA: `8f7784e2bf4bb679cb0e5c069659b981a3bac011`
- Branch merge-base with `origin/main`: `8f7784e2bf4bb679cb0e5c069659b981a3bac011`
- Last `git fetch origin` time: 2026-07-09T10:16:55Z
- Sync method: none needed (0 behind, 1 ahead)
- Public diff command: `git diff 8f7784e..da47a8e -- .github/workflows/rewrite-ci.yml tools/gate-manifest.json`
- Private evidence commit/path: task package `facts.md` and `artifacts/orchestration/` under the CI-4 task
- Reviewer evidence path: task package `review.md` (to be written after this run reports)
- GitHub Actions `rewrite-ci` run URL: pending — linked after the first run on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: the individual `harness:*` gates and `npm test` were not invoked one by one. Locally run instead: `npm run check:local` (fast tier, passed in 18.6s) and `npm run harness:check-gate-surface` (passed, 48 manifest gates, 0 drift findings), plus a YAML parse of the workflow. The full gate set is what `rewrite-ci` executes on this PR; the boxes above are left unchecked rather than claimed.
- Cannot be verified locally (no real `pull_request` event context): the existence and content of `refs/pull/N/merge`, the runtime value of `github.event.pull_request.base.sha`, `paths-filter` behaviour on a Mergify draft PR, and the `gui-build` `queued`-time improvement. These are asserted only against this PR's actual run.

## Review Evidence

- Self-review: CEO ground-truthed the worker's report against the file rather than the report text. Caught the `ref: head.sha` regression via a file-wide `grep -n 'ref:'` (a diff review would not surface it — the diff shows the line arriving, not that it becomes the only one of its kind among ten jobs). Ran a positive control to confirm the grep was live before trusting its silence.
- Reviewer subagent: implementation by `agent:codex`; it independently reproduced the two-dot scratch-repo control and refused an earlier CEO-proposed fix, falsifying it from `action.yml` and `src/git.ts` rather than complying.
- Human review: pending
- Blocking findings: 1 (the `ref: head.sha` regression), fixed before merge by amending the commit; no intermediate state carrying it exists in history.

## Residual Risk

- `paths-filter`'s behaviour on Mergify merge-queue draft PRs is unverifiable locally. The `token: ""` guard that protects it is carried over unchanged, but the guard's effect is only observable on a real queued run.
- Two-dot diff semantics mean that if the merge ref is recomputed against a `main` newer than the event's `base.sha`, the filter may report `gui=true` when the PR did not touch GUI paths. This over-runs `gui-build` — fail-safe, never fail-open.
- If a future change makes `checkout` conditional or removes it, `getCurrentRef()` would resolve against an unexpected tree. Nothing currently guards that invariant mechanically.
- **This PR must go through the Mergify queue and must not be merged by hand.** It is the only instrument that can observe whether #507 actually enabled in-place checks: if a `mergify/merge-queue/*` draft PR is created, in-place did not take effect. Merging it manually destroys that observation.

## References

- Task: `task_01KX34TSDQANHS46J7PA62CD26`; parent `task_01KX2XFTW3SJYNQ08F99SJMXVJ`
- Evidence: decision `dec_mrdbyvyd`; facts recorded on the CI-4 task covering the `needs` scheduling tax, the `ref: head.sha` regression, and `paths-filter` v4 diff semantics
- Review: `dorny/paths-filter@v4` `action.yml`, `src/main.ts`, `src/git.ts`

---

# 中文

## 概要

删除 `changes` job，把 `dorny/paths-filter` 内联进 `gui-build`，使 `gui-build` 不再带 `needs` 边。

`changes` job 自身只跑 **5 秒**，唯一消费者是 `gui-build`。但因为 `gui-build` 声明了 `needs: changes`，GitHub 会把它排进**第二轮调度**，而这一轮很贵：近期 run 中 `gui-build` 的 `queued` 实测为 `303s / 304s / 607s / 3s / 4s`。

在 PR #505 上，这就是端到端时长的真正决定者。所有人盯着看、并且被 #507 分片的那个 `integration`，执行 368s、在 **t=373s** 完成；`gui-build` 执行仅 26s，却在 **t=621s** 完成——它花了 608s 排队，等一个 5 秒的依赖放行。整个 run 632s。**关键路径是一条没人看的依赖边，不是那个显眼的慢 job。**

移除该边后，`gui-build` 与其余九个 PR job 同批调度。

## 改动内容

**`.github/workflows/rewrite-ci.yml`**

- 整个 `changes` job 删除。
- `gui-build` 去掉 `needs: changes`。其 job id 与 **check 名逐字未变**——`gui-build` 是分支保护 10 个 required contexts 之一，改名会让该 context 永不报告。
- `dorny/paths-filter@v4` 内联进 `gui-build`，`id: filter`，`token: ""`、`base: ${{ github.event.pull_request.base.sha }}`、filter 列表，以及解释 `token` 为何置空的那条注释，**一字不落**地搬迁。
- `gui-build` 的 `checkout` 增加 `fetch-depth: 0`（paths-filter 的 `ensureRefAvailable(base)` 需要历史）。**只增加这一项**，理由见下。
- 三处步骤条件从 `needs.changes.outputs.gui == 'true'` 改为 `steps.filter.outputs.gui == 'true'`。`setup-node` 与 `npm ci` 也纳入该条件：PR 未触碰 GUI 或共享根文件时，job 只跑 `checkout` + `filter`，其余跳过，并报 `success`。

**`tools/gate-manifest.json`**

- `surfaces.rewriteCi.helperJobsNotRegisteredAsGates` 移除 `changes` 条目，`integration`（CI-2 的 aggregate）保留。

跳过逻辑行为不变：GUI 路径变更 → `test:gui` 与 GUI build 执行；未变 → 跳过。不砍任何测试、不放宽任何门禁与超时、不引入 `continue-on-error`。分支保护与 `.mergify.yml` 未触碰。

## 合并前拦下的复核发现：`ref: head.sha`

首版实现把 `changes` job 的 checkout **整块**搬了过来，其中包括 `ref: ${{ github.event.pull_request.head.sha }}`。

这一行在 `changes` 上是惰性的——那个 job 只算 filter，什么都不构建。搬到 `gui-build` 上，它决定**哪棵树被编译**。带上它，`gui-build` 就成了本 workflow 中唯一构建 PR head 而非 merge ref（`refs/pull/N/merge`，`pull_request` 事件下 `actions/checkout` 的默认值）的 job，其余九个仍构建合并结果。这一行本身没有任何改变，它做的事情全变了。

它还与 #507 叠加：in-place checks 启用后，Mergify 不再在草稿 PR 里重建。若 `gui-build` 同时不再测试 merge ref，那么在 Mergify 更新分支之前，**没有任何一次 run 编译过 `main + PR` 的合并树**。

该行已删除。`grep -n 'ref:' .github/workflows/rewrite-ci.yml` 现在无任何命中。

**为什么正解是「删一行」而不是「换个地方加」。** 看似显然的修法——把 `ref` 传给 `paths-filter` 而不是 `checkout`——**不成立**，action 源码自陈：

- `action.yml`：`inputs.ref` —— *"This option is ignored if action is triggered by pull_request event."*
- `src/main.ts` 的 `case 'pull_request'`：发出 `core.warning("'ref' input parameter is ignored")`，且在 `token: ""` 时调用 `git.getChanges(base, await git.getCurrentRef())`——head 就是**磁盘上 `checkout` 留下的那棵树**。
- `src/git.ts` 的 `getChanges()` 用的是**两点** diff `base..head`；三点形式只存在于 `getChangesSinceMergeBase()`，本路径永不经过。

两点语义使默认 checkout **更精确**，而非更差。因为 `base.sha` 是 merge commit 的第一父提交，`base..merge_ref` 恰好等于 PR 的净贡献；而 `base..head.sha` 等于「PR 的改动 ∪ `main` 自分叉以来所有改动的**逆向**」。scratch 仓复现——`main` 改了 `packages/gui`，PR 只改了 `packages/cli`：

```
git diff --name-status base..head_sha     git diff --name-status base..merge_ref
M  packages/cli/main.ts                   M  packages/cli/main.ts
M  packages/gui/app.ts   <- 假阳性
```

也就是说，那行被删掉的代码，正在让 `gui-build` 跑得比必要更频繁——就在这个以「让 CI 更快」为目的的 PR 里。两种形式都是 fail-safe（只会多跑，不会漏跑）；但只有 merge ref 是精确的。

## 任务与范围

- Harness 任务：`task_01KX34TSDQANHS46J7PA62CD26`（CI-4），父任务 `task_01KX2XFTW3SJYNQ08F99SJMXVJ`
- 分支：`codex/ci-4-inline-paths-filter`
- 公开范围：`.github/workflows/rewrite-ci.yml`、`tools/gate-manifest.json`
- 私有计划 / 证据是否已更新：yes
- 范围外：移除 aggregate `integration` job 的 `needs: [integration-shard]` 边。该边同样要付第二轮调度税，但移除它意味着把 6 个 shard 提升为 required status contexts，需先改 GitHub 分支保护。已延后，将与待办的 `typecheck (26)` 冗余矩阵分支移除合并为**同一次**分支保护修改。

## 版本影响

- 版本：不改版本，原因是本 PR 只触碰 CI 拓扑，不涉及任何已发布包的源码。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`.github/workflows/rewrite-ci.yml`（CI 拓扑）、`tools/gate-manifest.json`（gate 执行面）
- 依据：decision `dec_mrdbyvyd`（state=active，arbiter=human:zeyuli）；task `task_01KX34TSDQANHS46J7PA62CD26`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：合并 `typecheck (26)` 移除与 `integration` aggregate 裁决的那一次分支保护修改

## 验证

- `origin/main` 基准 SHA：`8f7784e2bf4bb679cb0e5c069659b981a3bac011`
- 当前分支与 `origin/main` 的 merge-base：`8f7784e2bf4bb679cb0e5c069659b981a3bac011`
- 最近一次 `git fetch origin` 时间：2026-07-09T10:16:55Z
- 同步方式：不需要（落后 0，领先 1）
- 公开 diff 命令：`git diff 8f7784e..da47a8e -- .github/workflows/rewrite-ci.yml tools/gate-manifest.json`
- 私有证据 commit/path：CI-4 任务包下的 `facts.md` 与 `artifacts/orchestration/`
- Reviewer 证据路径：任务包 `review.md`（本 run 出结果后补写）
- GitHub Actions `rewrite-ci` run URL：待定——本 PR 首次 run 后回填
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：上列 `harness:*` 各 gate 与 `npm test` 未逐条单独调用。本地实际跑的是 `npm run check:local`（fast 档，18.6s 通过）与 `npm run harness:check-gate-surface`（通过，48 个 manifest gate，0 drift），外加 workflow 的 YAML 解析。完整 gate 集由本 PR 上的 `rewrite-ci` 执行；上面的框宁可留空，也不谎称已跑。
- 本地无法验证（无真实 `pull_request` 事件上下文）：`refs/pull/N/merge` 的存在与内容、`github.event.pull_request.base.sha` 的运行时取值、`paths-filter` 在 Mergify 草稿 PR 上的行为、`gui-build` 的 `queued` 时间改善。这些只在本 PR 的实际 run 上断言。

## 审查证据

- 自查：CEO 以文件为准 ground-truth worker 的汇报，而非以汇报文本为准。通过全文 `grep -n 'ref:'` 抓出 `ref: head.sha` 回归——**diff 复核抓不到它**：diff 只显示这一行到达了，不显示它成为十个 job 中唯一的一处。在信任 grep 的沉默之前先跑了阳性对照，确认 grep 本身是活的。
- Reviewer subagent：实现由 `agent:codex` 完成；它独立复现了两点语义的 scratch 仓对照，并**拒绝执行** CEO 提出的一个错误修法，用 `action.yml` 与 `src/git.ts` 原文证伪之，而不是照做。
- 人工审查：待进行
- 阻塞发现：1 条（`ref: head.sha` 回归），合并前以 amend 修复；历史中不存在携带该回归的中间提交。

## 残余风险

- `paths-filter` 在 Mergify 草稿 PR 上的行为本地不可验证。保护它的 `token: ""` 已原样搬迁，但该保护的效果只能在真实入队 run 上观察到。
- 两点 diff 语义意味着：若 merge ref 是基于比事件 `base.sha` 更新的 `main` 重算的，filter 可能在 PR 未触碰 GUI 时报 `gui=true`。这会让 `gui-build` 多跑一次——fail-safe，绝不 fail-open。
- 若将来有人把 `checkout` 改成条件式或删除它，`getCurrentRef()` 会解析到一棵预期之外的树。目前**没有任何机制**守住这条不变量。
- **本 PR 必须走 Mergify 队列，禁止手动合并。** 它是唯一能观察 #507 是否真的启用了 in-place checks 的仪器：若出现 `mergify/merge-queue/*` 草稿 PR，说明 in-place 未生效。手动合并将摧毁这次观察。

## 关联材料

- 任务：`task_01KX34TSDQANHS46J7PA62CD26`；父任务 `task_01KX2XFTW3SJYNQ08F99SJMXVJ`
- 证据：decision `dec_mrdbyvyd`；CI-4 任务上记录的 facts，覆盖 `needs` 调度税、`ref: head.sha` 回归、`paths-filter` v4 的 diff 语义
- 审查：`dorny/paths-filter@v4` 的 `action.yml`、`src/main.ts`、`src/git.ts`
