### PR TITLE
fix: align mergify required contexts

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -60,13 +60,23 @@ The Mergify GitHub App must be installed from
 https://github.com/marketplace/mergify before maintainers rely on the queue.
 The queue rules live in `.mergify.yml`.
 
-Mergify queue rules track the fast gate subset:
+Mergify queue rules track the same required contexts as GitHub branch
+protection. `merge_conditions` stays empty so Mergify can run in-place checks
+against the queued pull request's predicted merge state.
 
 - boundaries
 - package-policy
 - typecheck (24)
-- typecheck (26)
 - fast-contract
+- integration-shard (1)
+- integration-shard (2)
+- integration-shard (3)
+- integration-shard (4)
+- integration-shard (5)
+- integration-shard (6)
+- supply-chain
+- gui-build
+- node26-compatibility
 - pr-body-lint
 
 The `pr-body-lint` job checks human-authored pull request bodies against the
@@ -87,9 +97,6 @@ fast no-op success. That keeps queue bookkeeping edits from launching another
 full CI pass while preserving normal `edited` body validation for
 human-authored pull requests.
 
-The slower `integration`, `supply-chain`, `gui-build`, and
-`node26-compatibility` contexts remain GitHub branch-protection required
-contexts even though they are outside the Mergify fast-gate subset.
 GUI Electron E2E is an explicit local closeout gate for GUI-related tasks and
 must be recorded as task evidence instead of running in GitHub CI.
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,9 +9,13 @@ queue_rules:
       - check-success = boundaries
       - check-success = package-policy
       - check-success = "typecheck (24)"
-      - check-success = "typecheck (26)"
       - check-success = fast-contract
-      - check-success = integration
+      - check-success = "integration-shard (1)"
+      - check-success = "integration-shard (2)"
+      - check-success = "integration-shard (3)"
+      - check-success = "integration-shard (4)"
+      - check-success = "integration-shard (5)"
+      - check-success = "integration-shard (6)"
       - check-success = supply-chain
       - check-success = gui-build
       - check-success = node26-compatibility


### PR DESCRIPTION
# English

## Summary

Align `.mergify.yml` queue conditions with the branch-protection required contexts that were changed out-of-band. **This PR changes configuration only. It deletes no job.** That is deliberate, and it is the entire reason CI-5 ships as two pull requests.

Branch protection for `main` was updated ahead of this PR (recorded as a fact on `task_01KX36XVJ6ZS7ZS7HP2BDNM8GB`, with a rollback snapshot): required contexts went from 10 to 14 — `integration` and `typecheck (26)` removed, `integration-shard (1)` through `integration-shard (6)` added. Both removed jobs still exist and still report, so nothing is deadlocked right now.

## What Changed

**`.mergify.yml`**

- `queue_conditions` now lists the 14 current branch-protection required contexts. `check-success = integration` and `check-success = "typecheck (26)"` are removed; the six `integration-shard (N)` contexts are added.
- `merge_conditions: []` is **unchanged**. Together with the repo defaults (`max_parallel_checks == 1`, `batch_size == 1`, neither set), this keeps Mergify's in-place checks enabled — confirmed working on PR #509 and again on PR #503, neither of which created a `mergify/merge-queue/*` draft PR.
- `batch_size`, `max_parallel_checks`, `speculative_checks` remain deliberately unset; `batch_size > 1` would re-disable in-place checks.
- `pull_request_rules` untouched.

**`.github/branch-protection.md`**

- The "Mergify queue rules track the fast gate subset" section was **stale since CI-3** (PR #507), which widened `queue_conditions` to every required context and emptied `merge_conditions`. The doc still described a 6-check subset. It now describes reality.
- The paragraph claiming `integration`, `supply-chain`, `gui-build`, and `node26-compatibility` sit "outside the Mergify fast-gate subset" is removed — there is no subset any more.

Nothing else. No test removed, no gate weakened, no timeout relaxed, no `continue-on-error`. The workflow is untouched.

## Why This Cannot Be One Pull Request

Mergify evaluates a pull request against the `.mergify.yml` on the **base branch**, not the one in the PR.

A single PR that both deleted the `integration` job and dropped it from `queue_conditions` would be judged by `main`'s current rules, which still require `check-success = integration`. That check would never report, because the same PR deleted the job producing it. The PR would never enter the queue, and **no CI would turn red** — the symptom is indistinguishable from a frozen queue.

This is the same cross-system deadlock CI-3 identified for `typecheck (26)` (fact `F-F7Q257AW`) and correctly refused to attempt. It applies to `integration` for identical reasons.

Hence: branch protection first (both jobs still report → safe), then this PR (config only, no job deleted → still enqueues under the old rules), then a follow-up PR that deletes the jobs (by which time `main` no longer asks for them).

## Task And Scope

- Harness task: `task_01KX36XVJ6ZS7ZS7HP2BDNM8GB` (CI-5)
- Branch: `codex/ci-5a-mergify-contexts`
- Public scope: `.mergify.yml`, `.github/branch-protection.md`
- Private planning/evidence updated: yes
- Out of scope: deleting the aggregate `integration` job and the `typecheck` matrix `26` branch, plus the matching `tools/gate-manifest.json` and branch-protection required-contexts list updates. Those ship in the follow-up PR for the ordering reason above.

## Version Impact

- Version: no version change because this touches merge-queue configuration and governance documentation only.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `.mergify.yml` (merge queue gate), `.github/branch-protection.md` (governance documentation). GitHub branch protection itself was changed out-of-band before this PR.
- Authority: decision `dec_mrdg4m6l` (state=active, arbiter=human:zeyuli); task `task_01KX36XVJ6ZS7ZS7HP2BDNM8GB`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: the second CI-5 pull request, which deletes the jobs and syncs `tools/gate-manifest.json`

## Verification

- Base `origin/main` SHA: `aee10c43c33b7ec82f09a0d51ddccda7f6aa212c`
- Branch merge-base with `origin/main`: `aee10c43c33b7ec82f09a0d51ddccda7f6aa212c`
- Last `git fetch origin` time: 2026-07-09T12:0xZ (immediately before opening this PR)
- Sync method: none needed (0 behind, 1 ahead)
- Public diff command: `git diff aee10c4..185baec -- .mergify.yml .github/branch-protection.md`
- Private evidence commit/path: `facts.md` and `artifacts/orchestration/` under the CI-5 task
- Reviewer evidence path: task package `review.md` (written after this run reports)
- GitHub Actions `rewrite-ci` run URL: pending — linked after the first run on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: the individual `harness:*` gates and `npm test` were not invoked one by one. Locally run instead: `npm run harness:check-gate-surface` (passed, 48 manifest gates, 0 drift findings) and `npm run check:local` (fast tier, passed in 23.9s), plus a YAML parse of `.mergify.yml`. The full gate set is what `rewrite-ci` runs on this PR; the boxes above are left unchecked rather than claimed.
- Cannot be verified locally: Mergify's actual enqueue behaviour under the base-branch config, and whether the six `integration-shard (N)` contexts satisfy the new branch protection on a real merge. This PR is the first to be gated by the 14-context configuration.

## Review Evidence

- Self-review: CEO diffed both files against `origin/main` and confirmed the machine-checked contexts list in `.github/branch-protection.md` is **not** touched by this PR — it must move together with `tools/gate-manifest.json`, or `check-gate-surface` goes red. CEO also rewrote both commits' author identity, which the worker had recorded as `lizeyu@example.com` despite correct repo and global git config; commit trees are byte-identical before and after (verified by comparing tree hashes).
- Reviewer subagent: implementation by `agent:codex`. It independently discovered that `origin/main` had advanced to `aee10c43` (PR #503 merged mid-flight) and rebased onto it rather than using the stale SHA in its mission brief.
- Human review: pending
- Blocking findings: none in this PR.

## Residual Risk

- **Known transient inconsistency, one PR wide.** After this PR merges, `.github/branch-protection.md` will describe Mergify's contexts correctly while its own "requires these status contexts" list still names `integration` and `typecheck (26)`, which are no longer required on GitHub. `check-gate-surface` validates that list against `tools/gate-manifest.json`, not against the GitHub API, so it stays green while being wrong. This is the honest boundary already recorded as C3-5. The follow-up PR closes it.
- Nothing in this repository validates `.mergify.yml` against the manifest. `check-gate-surface` never reads it (`grep -c mergify` on that checker returns 0). This is exactly the blind spot that let CI-3's root cause — `merge_conditions` being a strict subset of the required contexts — persist unnoticed at a measured cost of ~2.17 full CI runs per merge. A checker closing this gap ships in the follow-up PR.
- The shard count is now baked into GitHub branch protection. Changing it requires a manual protection edit, which no repository checker can observe.

## References

- Task: `task_01KX36XVJ6ZS7ZS7HP2BDNM8GB`
- Evidence: decision `dec_mrdg4m6l`; facts on the CI-5 task recording the branch-protection change and its rollback snapshot; fact `F-F7Q257AW` on the CI-3 task recording the cross-system deadlock
- Review: PR #507 (CI-3, in-place checks), PR #509 (CI-4, first merge with no draft PR)

---

# 中文

## 概要

把 `.mergify.yml` 的 queue 条件对齐到已在带外修改的分支保护 required contexts。**本 PR 只改配置，不删除任何 job。** 这是刻意为之，也正是 CI-5 必须拆成两个 PR 的全部原因。

`main` 的分支保护已在本 PR 之前修改（作为 fact 记录在 `task_01KX36XVJ6ZS7ZS7HP2BDNM8GB` 上，并保留了回滚快照）：required contexts 由 10 个变为 14 个——移除 `integration` 与 `typecheck (26)`，新增 `integration-shard (1)` 至 `integration-shard (6)`。被移除的两个 job 仍然存在、仍然上报，因此当前没有任何死锁。

## 改动内容

**`.mergify.yml`**

- `queue_conditions` 现在列出当前分支保护的全部 14 个 required contexts。删除 `check-success = integration` 与 `check-success = "typecheck (26)"`，加入六个 `integration-shard (N)`。
- `merge_conditions: []` **保持不变**。连同本仓的默认值（`max_parallel_checks == 1`、`batch_size == 1`，两者均未设置），这使 Mergify 的 in-place checks 保持启用——已在 PR #509 与 PR #503 上各证实一次，两者均未创建 `mergify/merge-queue/*` 草稿 PR。
- `batch_size` / `max_parallel_checks` / `speculative_checks` 仍刻意不设置；`batch_size > 1` 会反向禁用 in-place checks。
- `pull_request_rules` 未触碰。

**`.github/branch-protection.md`**

- 「Mergify queue rules track the fast gate subset」那一段**自 CI-3（PR #507）起就已陈旧**——CI-3 把 `queue_conditions` 补齐成全部 required contexts 并清空了 `merge_conditions`，而该文档仍在描述一个 6 项的子集。现改为如实描述。
- 声称 `integration`、`supply-chain`、`gui-build`、`node26-compatibility` 位于「Mergify fast-gate 子集之外」的那一段被删除——现在已经不存在什么子集了。

除此之外一无改动。不砍任何测试、不放宽任何门禁与超时、不引入 `continue-on-error`。workflow 未触碰。

## 为什么这件事不能放在一个 PR 里做

Mergify 读取的是 **base 分支** 上的 `.mergify.yml`，不是 PR 里的那份。

若一个 PR 既删除 `integration` job、又把它从 `queue_conditions` 中移除，那么它会被 `main` 上的**现行**规则评估——而现行规则仍要求 `check-success = integration`。这个 check 永远不会上报，因为产生它的 job 恰好被同一个 PR 删掉了。该 PR 将永远无法进入队列，**且没有任何 CI 变红**——表征与队列冻结无法区分。

这与 CI-3 为 `typecheck (26)` 识别出的跨系统死锁（fact `F-F7Q257AW`）是同一个，当时 CI-3 正确地拒绝了尝试。对 `integration` 而言，理由完全相同。

因此顺序是：先改分支保护（两个 job 仍上报 → 安全），再合本 PR（只改配置、不删 job → 在旧规则下仍可入队），最后由后续 PR 删除这两个 job（那时 `main` 已不再要求它们）。

## 任务与范围

- Harness 任务：`task_01KX36XVJ6ZS7ZS7HP2BDNM8GB`（CI-5）
- 分支：`codex/ci-5a-mergify-contexts`
- 公开范围：`.mergify.yml`、`.github/branch-protection.md`
- 私有计划 / 证据是否已更新：yes
- 范围外：删除 aggregate `integration` job 与 `typecheck` 矩阵的 `26` 分支，以及配套的 `tools/gate-manifest.json` 与 branch-protection 的 required contexts 清单更新。基于上述顺序原因，它们在后续 PR 中交付。

## 版本影响

- 版本：不改版本，原因是本 PR 只触碰合并队列配置与治理文档。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`.mergify.yml`（合并队列门禁）、`.github/branch-protection.md`（治理文档）。GitHub 分支保护本身已在本 PR 之前带外修改。
- 依据：decision `dec_mrdg4m6l`（state=active，arbiter=human:zeyuli）；task `task_01KX36XVJ6ZS7ZS7HP2BDNM8GB`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：CI-5 的第二个 PR，删除 job 并同步 `tools/gate-manifest.json`

## 验证

- `origin/main` 基准 SHA：`aee10c43c33b7ec82f09a0d51ddccda7f6aa212c`
- 当前分支与 `origin/main` 的 merge-base：`aee10c43c33b7ec82f09a0d51ddccda7f6aa212c`
- 最近一次 `git fetch origin` 时间：2026-07-09T12:0xZ（开 PR 前）
- 同步方式：不需要（落后 0，领先 1）
- 公开 diff 命令：`git diff aee10c4..185baec -- .mergify.yml .github/branch-protection.md`
- 私有证据 commit/path：CI-5 任务包下的 `facts.md` 与 `artifacts/orchestration/`
- Reviewer 证据路径：任务包 `review.md`（本 run 出结果后补写）
- GitHub Actions `rewrite-ci` run URL：待定——本 PR 首次 run 后回填
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：上列 `harness:*` 各 gate 与 `npm test` 未逐条单独调用。本地实际跑的是 `npm run harness:check-gate-surface`（通过，48 个 manifest gate，0 drift）与 `npm run check:local`（fast 档，23.9s 通过），外加 `.mergify.yml` 的 YAML 解析。完整 gate 集由本 PR 上的 `rewrite-ci` 执行；上面的框宁可留空，也不谎称已跑。
- 本地无法验证：Mergify 在 base 分支配置下的实际入队行为，以及六个 `integration-shard (N)` context 是否能在真实合并中满足新的分支保护。**本 PR 是第一个被 14-context 配置门控的 PR。**

## 审查证据

- 自查：CEO 逐文件与 `origin/main` 比对，确认本 PR **未触碰** `.github/branch-protection.md` 中那份被机器校验的 contexts 清单——它必须与 `tools/gate-manifest.json` 同步移动，否则 `check-gate-surface` 会红。CEO 另重写了两个 commit 的作者身份：worker 在仓库与全局 git config 均正确的情况下把作者记成了 `lizeyu@example.com`；重写前后 commit tree 哈希逐字节相同（已比对）。
- Reviewer subagent：实现由 `agent:codex` 完成。它独立发现 `origin/main` 已前进到 `aee10c43`（PR #503 中途合入）并据此改基，而非沿用 mission 中过期的 SHA。
- 人工审查：待进行
- 阻塞发现：本 PR 无。

## 残余风险

- **已知的暂态不一致，宽度为一个 PR。** 本 PR 合入后，`.github/branch-protection.md` 会正确描述 Mergify 的 contexts，而它自己那份「requires these status contexts」清单仍列着 `integration` 与 `typecheck (26)`——这两项在 GitHub 上已不再是 required。`check-gate-surface` 校验的是该清单与 `tools/gate-manifest.json` 的一致性，而不是与 GitHub API 的一致性，因此它会**绿着，同时是错的**。这正是已登记的诚实边界 C3-5。后续 PR 关闭它。
- **本仓没有任何东西校验 `.mergify.yml` 与 manifest 的一致性。** `check-gate-surface` 根本不读它（对该 checker `grep -c mergify` 返回 0）。这恰恰是让 CI-3 的根因——`merge_conditions` 是 required contexts 的真子集——长期无人察觉的盲区，实测代价为每次合并约 2.17 遍完整 CI。关闭该盲区的 checker 在后续 PR 中交付。
- 分片数现已固化进 GitHub 分支保护。改变它需要人工修改保护设置，而仓内任何 checker 都观察不到这件事。

## 关联材料

- 任务：`task_01KX36XVJ6ZS7ZS7HP2BDNM8GB`
- 证据：decision `dec_mrdg4m6l`；CI-5 任务上记录分支保护改动与回滚快照的 facts；CI-3 任务上记录跨系统死锁的 fact `F-F7Q257AW`
- 审查：PR #507（CI-3，in-place checks）、PR #509（CI-4，首个无草稿 PR 的合并）
