### PR TITLE
fix: align journal guard with harness isolation

### DIFF
--- a/packages/cli/src/cli/error-mapper.ts
+++ b/packages/cli/src/cli/error-mapper.ts
@@ -32,7 +32,7 @@ const cliErrorMappers = {
   Timeout: () => cliError(CliErrorCode.Timeout, "Command failed."),
   WriteConflict: (error) => cliError(CliErrorCode.WriteConflict, error.owner ?? "Write lock is held."),
   GlobalWriteConflict: (error) => cliError(CliErrorCode.WriteConflict, error.owner ? `Global write lock is held: ${error.owner}` : "Global write lock is held."),
-  WriteRejected: (error) => error.reason === "authored root is ignored by Git but is not a nested Git repository"
+  WriteRejected: (error) => error.reason.includes("authored root is not isolated from the outer code repository")
     ? cliError(CliErrorCode.JournalUnavailable, `Journal is unavailable: ${error.reason}`)
     : cliError(CliErrorCode.WriteRejected, error.reason),
   ArtifactReadFailed: () => cliError(CliErrorCode.ArtifactReadFailed, "Artifact read failed."),

--- a/packages/cli/test/attribution-diff-cli.test.ts
+++ b/packages/cli/test/attribution-diff-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -13,6 +14,7 @@ test("new-task records optional createdBy from local git user config and project
   withTempRoot((rootDir) => {
     initGit(rootDir);
     configureGitUser(rootDir, "M2 Commander", "m2@example.com");
+    initializeNestedHarnessRepo(rootDir, { writeOuterGitignore: true });
 
     const created = runJson(rootDir, ["new-task", "--title", "Attribution Task"]);
     const taskId = assertGeneratedTaskId(created.taskId);
@@ -31,6 +33,7 @@ test("new-task records optional createdBy from local git user config and project
 test("new-task omits createdBy deterministically when git user config is unavailable", () => {
   withTempRoot((rootDir) => {
     initGit(rootDir);
+    initializeNestedHarnessRepo(rootDir, { writeOuterGitignore: true });
     mkdirSync(path.join(rootDir, "home"), { recursive: true });
 
     const created = runJson(rootDir, ["new-task", "--title", "Anonymous Task"], true, {

--- a/packages/cli/test/helpers/git-fixtures.ts
+++ b/packages/cli/test/helpers/git-fixtures.ts
@@ -1,0 +1,20 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export function initializeNestedHarnessRepo(rootDir: string, options: { readonly writeOuterGitignore?: boolean } = {}): void {
+  if (options.writeOuterGitignore) {
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+  }
+
+  const harnessRoot = path.join(rootDir, "harness");
+  mkdirSync(harnessRoot, { recursive: true });
+  if (existsSync(path.join(harnessRoot, ".git"))) return;
+
+  execFileSync("git", ["-C", harnessRoot, "init", "-q"]);
+  execFileSync("git", ["-C", harnessRoot, "config", "user.email", "harness@example.test"]);
+  execFileSync("git", ["-C", harnessRoot, "config", "user.name", "Harness Test"]);
+  writeFileSync(path.join(harnessRoot, ".gitignore"), "*.log\n", "utf8");
+  execFileSync("git", ["-C", harnessRoot, "add", ".gitignore"]);
+  execFileSync("git", ["-C", harnessRoot, "commit", "-m", "seed harness repo"]);
+}

--- a/packages/cli/test/local-lifecycle-cli.test.ts
+++ b/packages/cli/test/local-lifecycle-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
@@ -527,6 +528,7 @@ test("CLI task-review fails closed on open release-blocking findings and emits p
 
 test("CLI task-complete evaluates review, CI, and closeout readiness before setting status done", () => {
   withTempRoot((rootDir) => {
+    initializeNestedHarnessRepo(rootDir);
     writeIndex(rootDir, "task-1", "Complete Task", "in_review");
     writeFact(rootDir, "task-1");
     writeReview(rootDir, "task-1", []);

--- a/packages/cli/test/preset-module-cli.test.ts
+++ b/packages/cli/test/preset-module-cli.test.ts
@@ -441,16 +441,20 @@ test("CLI preset run rejects undeclared v2 actions instead of succeeding as no-o
 test("CLI module CRUD maintains generated module view and module-step state", () => {
   withTempRoot((rootDir) => {
     initializeGitRepo(rootDir);
-    writeFile(rootDir, ".gitignore", ".harness/\n");
+    writeFile(rootDir, ".gitignore", "/harness/\n/.harness/\n");
     runGit(rootDir, "add", ".gitignore");
     runGit(rootDir, "commit", "-m", "seed ignore");
+    initializeGitRepo(path.join(rootDir, "harness"));
+    writeFile(rootDir, "harness/.gitignore", "*.log\n");
+    runGit(path.join(rootDir, "harness"), "add", ".gitignore");
+    runGit(path.join(rootDir, "harness"), "commit", "-m", "seed harness repo");
 
     const registered = runJson(rootDir, ["module", "register", "billing", "--title", "Billing", "--scope", "packages/billing/**"]);
     assert.equal(registered.ok, true);
     assert.equal(registered.command, "module-register");
     assert.equal(registered.module.key, "billing");
-    assert.equal(runGit(rootDir, "status", "--short"), "");
-    assert.match(runGit(rootDir, "log", "--oneline", "--all"), /module\(registry\): billing register/);
+    assert.equal(runGit(path.join(rootDir, "harness"), "status", "--short"), "");
+    assert.match(runGit(path.join(rootDir, "harness"), "log", "--oneline", "--all"), /module\(registry\): billing register/);
 
     const listed = runJson(rootDir, ["module", "list"]);
     assert.equal(listed.ok, true);
@@ -464,14 +468,14 @@ test("CLI module CRUD maintains generated module view and module-step state", ()
     const scaffolded = runJson(rootDir, ["module", "scaffold", "billing"]);
     assert.equal(scaffolded.ok, true);
     assert.equal(scaffolded.path, "harness/modules/billing/module_plan.md");
-    assert.equal(runGit(rootDir, "status", "--short"), "");
-    assert.match(runGit(rootDir, "log", "--oneline", "--all"), /module\(scaffold\): billing scaffold/);
+    assert.equal(runGit(path.join(rootDir, "harness"), "status", "--short"), "");
+    assert.match(runGit(path.join(rootDir, "harness"), "log", "--oneline", "--all"), /module\(scaffold\): billing scaffold/);
 
     const stepped = runJson(rootDir, ["module-step", "billing", "BILL-01", "--state", "done"]);
     assert.equal(stepped.ok, true);
     assert.equal(stepped.module.steps[0].state, "done");
-    assert.equal(runGit(rootDir, "status", "--short"), "");
-    assert.match(runGit(rootDir, "log", "--oneline", "--all"), /module\(registry\): billing step/);
+    assert.equal(runGit(path.join(rootDir, "harness"), "status", "--short"), "");
+    assert.match(runGit(path.join(rootDir, "harness"), "log", "--oneline", "--all"), /module\(registry\): billing step/);
 
     const registry = readFileSync(path.join(rootDir, ".harness/generated/Module-Registry.md"), "utf8");
     assert.match(registry, /\| billing \| Billing \| active \|/);
@@ -511,6 +515,7 @@ function writeFile(rootDir: string, relativePath: string, body: string): void {
 }
 
 function initializeGitRepo(rootDir: string): void {
+  mkdirSync(rootDir, { recursive: true });
   runGit(rootDir, "init");
   runGit(rootDir, "config", "user.email", "test@example.com");
   runGit(rootDir, "config", "user.name", "Test User");

--- a/packages/cli/test/self-host-git-boundary-cli.test.ts
+++ b/packages/cli/test/self-host-git-boundary-cli.test.ts
@@ -8,29 +8,44 @@ import test from "node:test";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
+test("CLI reports doctor-aligned journal cause when authored root is tracked by the outer repo", () => {
+  withTempRoot((rootDir) => {
+    runGit(rootDir, "init");
+    writeFileSync(path.join(rootDir, ".gitignore"), "/.harness/\n", "utf8");
+    runGit(rootDir, "add", ".gitignore");
+    runGit(rootDir, "commit", "-m", "seed outer repo");
+    writeHarnessConfig(rootDir, "outer-managed-authored-root");
+
+    const failure = runJson(rootDir, ["new-task", "--title", "Outer Managed"], false);
+    const doctor = runJson(rootDir, ["doctor"]);
+
+    assert.equal(failure.ok, false);
+    assert.equal(failure.error?.code, "journal_unavailable");
+    assert.match(failure.error?.hint, /authored root is not isolated from the outer code repository/);
+    assert.match(failure.error?.hint, /independent Git repository/u);
+    assert.match(failure.error?.hint, /harness-anything init/u);
+    assert.equal(JSON.stringify(failure).includes(rootDir), false);
+    assert.equal(doctor.report.harness.isolation.ok, false);
+    assert.equal(doctor.report.harness.isolation.findings.some((finding: Record<string, unknown>) => finding.code === "harness_git_missing"), true);
+    assert.equal(doctor.report.harness.isolation.findings.some((finding: Record<string, unknown>) => finding.code === "outer_gitignore_missing"), true);
+  });
+});
+
 test("CLI reports actionable journal cause when authored root is ignored without nested Git repo", () => {
   withTempRoot((rootDir) => {
     runGit(rootDir, "init");
     writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
     runGit(rootDir, "add", ".gitignore");
     runGit(rootDir, "commit", "-m", "ignore private harness");
-    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
-    writeFileSync(path.join(rootDir, "harness/harness.yaml"), [
-      "schema: harness-anything/v1",
-      "name: ignored-authored-root",
-      "layout:",
-      "  authoredRoot: harness",
-      "  localRoot: .harness",
-      "tasks:",
-      "  root: harness/tasks",
-      ""
-    ].join("\n"), "utf8");
+    writeHarnessConfig(rootDir, "ignored-authored-root");
 
     const failure = runJson(rootDir, ["new-task", "--title", "Ignored Root"], false);
 
     assert.equal(failure.ok, false);
     assert.equal(failure.error?.code, "journal_unavailable");
-    assert.match(failure.error?.hint, /authored root is ignored by Git but is not a nested Git repository/);
+    assert.match(failure.error?.hint, /authored root is not isolated from the outer code repository/);
+    assert.match(failure.error?.hint, /independent Git repository/u);
+    assert.match(failure.error?.hint, /harness-anything init/u);
     assert.equal(JSON.stringify(failure).includes(rootDir), false);
   });
 });
@@ -68,4 +83,18 @@ function runGit(rootDir: string, ...args: ReadonlyArray<string>): string {
       GIT_COMMITTER_EMAIL: "harness-test@example.invalid"
     }
   }).trim();
+}
+
+function writeHarnessConfig(rootDir: string, name: string): void {
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  writeFileSync(path.join(rootDir, "harness/harness.yaml"), [
+    "schema: harness-anything/v1",
+    `name: ${name}`,
+    "layout:",
+    "  authoredRoot: harness",
+    "  localRoot: .harness",
+    "tasks:",
+    "  root: harness/tasks",
+    ""
+  ].join("\n"), "utf8");
 }

--- a/packages/cli/test/task-document-gates-cli.test.ts
+++ b/packages/cli/test/task-document-gates-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -179,30 +180,33 @@ test("CLI task-review accepts a task with a real fact", () => {
 
 test("CLI task-review and task-complete stage reviewed artifacts through WriteCoordinator", () => {
   withTempRoot((rootDir) => {
+    const harnessRepo = path.join(rootDir, "harness");
     initializeGitRepo(rootDir);
-    writeFileSync(path.join(rootDir, ".gitignore"), ".harness/\n", "utf8");
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
     writeIndex(rootDir, "task-1", "Review Task", "in_review");
     writeFact(rootDir, "task-1");
-    runGit(rootDir, "add", ".gitignore", "harness/tasks/task-1/INDEX.md", "harness/tasks/task-1/facts.md");
+    runGit(rootDir, "add", ".gitignore");
     runGit(rootDir, "commit", "-m", "seed task");
+    runGit(harnessRepo, "add", "tasks/task-1/INDEX.md", "tasks/task-1/facts.md");
+    runGit(harnessRepo, "commit", "-m", "seed task");
 
     writeReview(rootDir, "task-1");
-    assert.match(runGit(rootDir, "status", "--short"), /review\.md/);
+    assert.match(runGit(harnessRepo, "status", "--short"), /review\.md/);
 
     const reviewed = runJson(rootDir, ["task-review", "task-1", "--reviewer", "reviewer-a"]);
     assert.equal(reviewed.ok, true);
-    assert.equal(runGit(rootDir, "status", "--short"), "");
-    assert.match(runGit(rootDir, "log", "--oneline", "--all"), /task\(task-tree-stage\): task-1 task package/);
+    assert.equal(runGit(harnessRepo, "status", "--short"), "");
+    assert.match(runGit(harnessRepo, "log", "--oneline", "--all"), /task\(task-tree-stage\): task-1 task package/);
 
     writeRealCloseout(rootDir, "task-1");
-    assert.match(runGit(rootDir, "status", "--short"), /closeout\.md/);
+    assert.match(runGit(harnessRepo, "status", "--short"), /closeout\.md/);
 
     const completed = runJson(rootDir, ["task-complete", "task-1", "--reviewer", "reviewer-a", "--ci", "passed"]);
     assert.equal(completed.ok, true);
     assert.equal(completed.data?.status ?? completed.status, "done");
-    assert.equal(runGit(rootDir, "status", "--short"), "");
-    assert.match(runGit(rootDir, "log", "--oneline", "--all"), /task\(transition\): task-1/);
-    assert.match(runGit(rootDir, "log", "--oneline", "--all"), /task\(task-tree-stage\): task-1 task package/);
+    assert.equal(runGit(harnessRepo, "status", "--short"), "");
+    assert.match(runGit(harnessRepo, "log", "--oneline", "--all"), /task\(transition\): task-1/);
+    assert.match(runGit(harnessRepo, "log", "--oneline", "--all"), /task\(task-tree-stage\): task-1 task package/);
   });
 });
 
@@ -328,6 +332,7 @@ function writeCodeDocAnchors(rootDir: string, directoryName: string, sha = ensur
 function withTempRoot<T>(fn: (rootDir: string) => T): T {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-cli-task-doc-gates-"));
   try {
+    initializeNestedHarnessRepo(rootDir);
     return fn(rootDir);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
@@ -335,7 +340,8 @@ function withTempRoot<T>(fn: (rootDir: string) => T): T {
 }
 
 function initializeGitRepo(rootDir: string): void {
-  if (pathExists(path.join(rootDir, ".git"))) return;
+  if (existsSync(path.join(rootDir, ".git"))) return;
+  mkdirSync(rootDir, { recursive: true });
   runGit(rootDir, "init");
   runGit(rootDir, "config", "user.email", "test@example.com");
   runGit(rootDir, "config", "user.name", "Test User");
@@ -348,10 +354,6 @@ function ensureAnchorCommit(rootDir: string): string {
   runGit(rootDir, "add", "evidence/code-doc-anchor.txt");
   runGit(rootDir, "commit", "-m", "seed code-doc anchor");
   return runGit(rootDir, "rev-parse", "HEAD");
-}
-
-function pathExists(filePath: string): boolean {
-  return existsSync(filePath);
 }
 
 function runGit(rootDir: string, ...args: ReadonlyArray<string>): string {

--- a/packages/cli/test/task-transition-sweep-cli.test.ts
+++ b/packages/cli/test/task-transition-sweep-cli.test.ts
@@ -126,11 +126,19 @@ test("CLI task complete blocks when the task tree is dirty after the sweep", () 
 
 function withGitTempRoot<T>(fn: (rootDir: string) => T): T {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-transition-sweep-"));
+  const harnessRoot = path.join(rootDir, "harness");
   try {
     execFileSync("git", ["-C", rootDir, "init", "-q"]);
     execFileSync("git", ["-C", rootDir, "config", "user.email", "test@example.com"]);
     execFileSync("git", ["-C", rootDir, "config", "user.name", "Test User"]);
-    writeFileSync(path.join(rootDir, ".gitignore"), "*.log\n", "utf8");
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    mkdirSync(harnessRoot, { recursive: true });
+    execFileSync("git", ["-C", harnessRoot, "init", "-q"]);
+    execFileSync("git", ["-C", harnessRoot, "config", "user.email", "test@example.com"]);
+    execFileSync("git", ["-C", harnessRoot, "config", "user.name", "Test User"]);
+    writeFileSync(path.join(harnessRoot, ".gitignore"), "*.log\n", "utf8");
+    execFileSync("git", ["-C", harnessRoot, "add", ".gitignore"]);
+    execFileSync("git", ["-C", harnessRoot, "commit", "-m", "seed harness gitignore"]);
     return fn(rootDir);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
@@ -192,25 +200,31 @@ function ensureAnchorCommit(rootDir: string): string {
 }
 
 function installPostCommitDirtyHook(rootDir: string, taskPath: string): void {
-  const hookPath = path.join(rootDir, ".git/hooks/post-commit");
+  const hookPath = path.join(rootDir, "harness/.git/hooks/post-commit");
   writeFileSync(hookPath, [
     "#!/bin/sh",
-    `printf 'dirty after sweep\\n' >> "${taskPath}/post-commit-dirty.md"`,
+    `printf 'dirty after sweep\\n' >> "${authoredRelativePath(taskPath)}/post-commit-dirty.md"`,
     ""
   ].join("\n"), "utf8");
   chmodSync(hookPath, 0o755);
 }
 
 function gitStatus(rootDir: string, taskPath: string): string {
-  return execFileSync("git", ["-C", rootDir, "status", "--porcelain", "-uall", "--", taskPath], {
+  return execFileSync("git", ["-C", path.join(rootDir, "harness"), "status", "--porcelain", "-uall", "--", authoredRelativePath(taskPath)], {
     encoding: "utf8"
   }).trim();
 }
 
 function gitLsFiles(rootDir: string, filePath: string): string {
-  return execFileSync("git", ["-C", rootDir, "ls-files", "--", filePath], {
+  const relativePath = authoredRelativePath(filePath);
+  const trackedPath = execFileSync("git", ["-C", path.join(rootDir, "harness"), "ls-files", "--", relativePath], {
     encoding: "utf8"
   }).trim();
+  return trackedPath.length === 0 ? "" : `harness/${trackedPath}`;
+}
+
+function authoredRelativePath(filePath: string): string {
+  return filePath.startsWith("harness/") ? filePath.slice("harness/".length) : filePath;
 }
 
 function assertGeneratedTaskId(value: unknown): string {

--- a/packages/kernel/src/store/write-journal-git.ts
+++ b/packages/kernel/src/store/write-journal-git.ts
@@ -6,6 +6,7 @@ import { makeLocalVersionControlSystem } from "./local-version-control-system.ts
 import type { GitCommitAuthor } from "./write-journal-types.ts";
 
 const defaultVersionControlSystem = makeLocalVersionControlSystem();
+const authoredRootNotIsolatedMessage = "authored root is not isolated from the outer code repository; run harness-anything init so the authored root is an independent Git repository and the outer .gitignore isolates it";
 
 export function commitTouchedPaths(
   rootDir: string,
@@ -94,13 +95,10 @@ function resolveCommitTarget(rootDir: string, authoredRoot: string, touchedPaths
   if (!touchedPaths.every((filePath) => isPathInside(authoredRoot, filePath, vcs))) return null;
   if (!authoredRepo) {
     if (!rootRepo || !isPathInsideRepo(rootRepo, authoredRoot, vcs)) return null;
-    if (isIgnoredByRepo(rootRepo, authoredRoot, vcs)) {
-      throw new Error("authored root is ignored by Git but is not a nested Git repository");
-    }
-    return { repoRoot: rootRepo };
+    throw new Error(authoredRootNotIsolatedMessage);
   }
-  if (rootRepo && authoredRepo === rootRepo && isIgnoredByRepo(rootRepo, authoredRoot, vcs)) {
-    throw new Error("authored root is ignored by Git but is not a nested Git repository");
+  if (rootRepo && authoredRepo === rootRepo && !isSamePath(rootRepo, authoredRoot, vcs)) {
+    throw new Error(authoredRootNotIsolatedMessage);
   }
   return { repoRoot: authoredRepo };
 }
@@ -170,12 +168,6 @@ export function refExists(repoRoot: string, ref: string, versionControlSystem: V
   return versionControlSystem.refExists(repoRoot, ref);
 }
 
-function isIgnoredByRepo(repoRoot: string, candidatePath: string, vcs: VersionControlSystem): boolean {
-  const relativePath = repoRelativePath(repoRoot, candidatePath, vcs);
-  const directoryPath = relativePath.endsWith("/") ? relativePath : `${relativePath}/`;
-  return vcs.isIgnored(repoRoot, relativePath) || vcs.isIgnored(repoRoot, directoryPath);
-}
-
 function resolveForceAddSet(
   rootDir: string,
   forceAddPaths: ReadonlyArray<string>,
@@ -198,6 +190,10 @@ function isPathInside(rootPath: string, filePath: string, vcs: VersionControlSys
 function isPathInsideRepo(repoRoot: string, filePath: string, vcs: VersionControlSystem): boolean {
   const relativePath = path.relative(vcs.normalizePath(repoRoot), vcs.normalizePath(filePath));
   return relativePath.length === 0 || (relativePath !== ".." && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath));
+}
+
+function isSamePath(left: string, right: string, vcs: VersionControlSystem): boolean {
+  return vcs.normalizePath(left) === vcs.normalizePath(right);
 }
 
 function repoRelativePath(repoRoot: string, filePath: string, vcs: VersionControlSystem): string {

--- a/packages/kernel/test/store/global-committer-lock.test.ts
+++ b/packages/kernel/test/store/global-committer-lock.test.ts
@@ -408,12 +408,13 @@ function runWriteFailure<A>(effect: Effect.Effect<A, WriteError>): WriteError {
 
 function fakeVersionControlSystem(repoRoot: string): VersionControlSystem {
   let commitCount = 0;
+  const harnessRoot = path.join(repoRoot, "harness");
   return {
     normalizePath: (inputPath) => path.resolve(inputPath),
-    topLevel: () => repoRoot,
+    topLevel: (inputPath) => path.resolve(inputPath).startsWith(`${harnessRoot}${path.sep}`) || path.resolve(inputPath) === harnessRoot ? harnessRoot : repoRoot,
     isIgnored: () => false,
     add: () => undefined,
-    stagedFiles: () => "harness/tasks/task-1/notes.md\n",
+    stagedFiles: () => "tasks/task-1/notes.md\n",
     commit: () => {
       commitCount += 1;
     },

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -26,7 +26,7 @@ test("WriteCoordinator flushes same-task writes in FIFO order", () => {
 test("WriteCoordinator journals actor person and uses explicit git authors", () => {
   withTempStore((rootDir) => {
     initializeGitRepo(rootDir);
-    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+    const harnessRoot = initializeNestedHarnessRepo(rootDir);
     const alice = makeJournaledWriteCoordinator({
       rootDir,
       actor: { kind: "human", id: "person_alice" },
@@ -49,7 +49,7 @@ test("WriteCoordinator journals actor person and uses explicit git authors", () 
     Effect.runSync(bob.flush("explicit"));
 
     assert.deepEqual(
-      runGit(rootDir, "log", "-2", "--format=%an <%ae>").split(/\r?\n/u),
+      runGit(harnessRoot, "log", "-2", "--format=%an <%ae>").split(/\r?\n/u),
       ["Bob Builder <bob@example.com>", "Alice Admin <alice@example.com>"]
     );
   });
@@ -99,10 +99,11 @@ test("WriteCoordinator records real projection hash and compacts watermark-cover
 test("WriteCoordinator stages hard-deleted task packages and clears replay journal", () => {
   withTempStore((rootDir) => {
     initializeGitRepo(rootDir);
-    mkdirSync(path.join(rootDir, "harness/tasks/task-1"), { recursive: true });
-    writeFileSync(path.join(rootDir, "harness/tasks/task-1/INDEX.md"), indexBody("task-1", "Task One", "planned"), "utf8");
-    runGit(rootDir, "add", ".");
-    runGit(rootDir, "commit", "-m", "seed task");
+    const harnessRoot = initializeNestedHarnessRepo(rootDir);
+    mkdirSync(path.join(harnessRoot, "tasks/task-1"), { recursive: true });
+    writeFileSync(path.join(harnessRoot, "tasks/task-1/INDEX.md"), indexBody("task-1", "Task One", "planned"), "utf8");
+    runGit(harnessRoot, "add", ".");
+    runGit(harnessRoot, "commit", "-m", "seed task");
 
     const coordinator = makeJournaledWriteCoordinator({
       rootDir,
@@ -124,7 +125,7 @@ test("WriteCoordinator stages hard-deleted task packages and clears replay journ
     assert.doesNotMatch(journalBody, /"schema":"write-journal\/v1"/);
     assert.match(journalBody, /"schema":"delete-audit\/v1"/);
     assert.match(readFileSync(path.join(rootDir, ".harness/write-journal/watermark.json"), "utf8"), /op-hard-delete/);
-    assert.match(runGit(rootDir, "show", "--name-status", "--format=", "HEAD"), /D\s+harness\/tasks\/task-1\/INDEX.md/);
+    assert.match(runGit(harnessRoot, "show", "--name-status", "--format=", "HEAD"), /D\s+tasks\/task-1\/INDEX.md/);
 
     const recovered = Effect.runSync(makeJournaledWriteCoordinator({ rootDir }).recover);
     assert.equal(recovered.replayedOps, 0);
@@ -170,11 +171,11 @@ test("WriteCoordinator rejects hard delete for task packages with anchored facts
 test("WriteCoordinator rejects ignored authored paths instead of reporting success", () => {
   withTempStore((rootDir) => {
     initializeGitRepo(rootDir);
-    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
-    writeFileSync(path.join(rootDir, ".gitignore"), "artifacts/\n", "utf8");
-    runGit(rootDir, "add", ".gitignore");
-    runGit(rootDir, "commit", "-m", "ignore artifacts");
-    const beforeHead = runGit(rootDir, "rev-parse", "HEAD");
+    const harnessRoot = initializeNestedHarnessRepo(rootDir);
+    writeFileSync(path.join(harnessRoot, ".gitignore"), "artifacts/\n", "utf8");
+    runGit(harnessRoot, "add", ".gitignore");
+    runGit(harnessRoot, "commit", "-m", "ignore artifacts");
+    const beforeHead = runGit(harnessRoot, "rev-parse", "HEAD");
 
     const coordinator = makeJournaledWriteCoordinator({
       rootDir,
@@ -182,25 +183,26 @@ test("WriteCoordinator rejects ignored authored paths instead of reporting succe
     });
     assert.throws(
       () => Effect.runSync(coordinator.enqueue(docWrite("op-ignored-artifact", "task-1", "artifacts/.gitkeep", ""))),
-      /gitignored authored path requires explicit forceAddPaths: harness\/tasks\/task-1\/artifacts\/\.gitkeep/u
+      /gitignored authored path requires explicit forceAddPaths: tasks\/task-1\/artifacts\/\.gitkeep/u
     );
 
     assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-1/artifacts/.gitkeep")), false);
     assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
-    assert.equal(runGit(rootDir, "rev-parse", "HEAD"), beforeHead);
+    assert.equal(runGit(harnessRoot, "rev-parse", "HEAD"), beforeHead);
   });
 });
 
 test("WriteCoordinator rejects tracked files that are now matched by gitignore", () => {
   withTempStore((rootDir) => {
     initializeGitRepo(rootDir);
-    mkdirSync(path.join(rootDir, "harness/tasks/task-1/artifacts"), { recursive: true });
-    writeFileSync(path.join(rootDir, ".gitignore"), "artifacts/\n", "utf8");
-    writeFileSync(path.join(rootDir, "harness/tasks/task-1/artifacts/tracked.md"), "before\n", "utf8");
-    runGit(rootDir, "add", ".gitignore");
-    runGit(rootDir, "add", "-f", "harness/tasks/task-1/artifacts/tracked.md");
-    runGit(rootDir, "commit", "-m", "seed tracked ignored authored path");
-    const beforeHead = runGit(rootDir, "rev-parse", "HEAD");
+    const harnessRoot = initializeNestedHarnessRepo(rootDir);
+    mkdirSync(path.join(harnessRoot, "tasks/task-1/artifacts"), { recursive: true });
+    writeFileSync(path.join(harnessRoot, ".gitignore"), "artifacts/\n", "utf8");
+    writeFileSync(path.join(harnessRoot, "tasks/task-1/artifacts/tracked.md"), "before\n", "utf8");
+    runGit(harnessRoot, "add", ".gitignore");
+    runGit(harnessRoot, "add", "-f", "tasks/task-1/artifacts/tracked.md");
+    runGit(harnessRoot, "commit", "-m", "seed tracked ignored authored path");
+    const beforeHead = runGit(harnessRoot, "rev-parse", "HEAD");
 
     const coordinator = makeJournaledWriteCoordinator({
       rootDir,
@@ -209,11 +211,11 @@ test("WriteCoordinator rejects tracked files that are now matched by gitignore",
 
     assert.throws(
       () => Effect.runSync(coordinator.enqueue(docWrite("op-tracked-ignored-artifact", "task-1", "artifacts/tracked.md", "after\n"))),
-      /gitignored authored path requires explicit forceAddPaths: harness\/tasks\/task-1\/artifacts\/tracked\.md/u
+      /gitignored authored path requires explicit forceAddPaths: tasks\/task-1\/artifacts\/tracked\.md/u
     );
     assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-1/artifacts/tracked.md"), "utf8"), "before\n");
     assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
-    assert.equal(runGit(rootDir, "rev-parse", "HEAD"), beforeHead);
+    assert.equal(runGit(harnessRoot, "rev-parse", "HEAD"), beforeHead);
   });
 });
 
@@ -268,7 +270,7 @@ test("WriteCoordinator excludes localRoot machine artifacts from every git repo"
   });
 });
 
-test("WriteCoordinator creates missing unignored authored root in root repo", () => {
+test("WriteCoordinator refuses to create missing authored root inside the outer repo", () => {
   withTempStore((rootDir) => {
     initializeGitRepo(rootDir);
     writeFileSync(path.join(rootDir, ".gitignore"), "/.harness/\n", "utf8");
@@ -280,18 +282,18 @@ test("WriteCoordinator creates missing unignored authored root in root repo", ()
       rootDir,
       commitAuthor: testCommitAuthor
     });
-    Effect.runSync(coordinator.enqueue(docWrite("op-create-authored-root", "task-1", "notes.md", "first write")));
-    const report = Effect.runSync(coordinator.flush("explicit"));
 
-    assert.equal(report.watermark, "op-create-authored-root");
-    assert.notEqual(runGit(rootDir, "rev-parse", "HEAD"), beforeHead);
-    assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-1/notes.md"), "utf8"), "first write");
-    assert.equal(runGit(rootDir, "ls-files", "--", "harness/tasks/task-1/notes.md"), "harness/tasks/task-1/notes.md");
+    assert.throws(
+      () => Effect.runSync(coordinator.enqueue(docWrite("op-create-authored-root", "task-1", "notes.md", "first write"))),
+      /authored root is not isolated from the outer code repository/u
+    );
+    assert.equal(runGit(rootDir, "rev-parse", "HEAD"), beforeHead);
+    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-1/notes.md")), false);
     assert.equal(runGit(rootDir, "branch", "--list", "sessions/*"), "");
   });
 });
 
-test("resolveCommitPlan fails closed when missing authored root is ignored by root repo", () => {
+test("resolveCommitPlan fails closed when missing authored root is inside the outer repo", () => {
   withTempStore((rootDir) => {
     initializeGitRepo(rootDir);
     writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
@@ -301,7 +303,7 @@ test("resolveCommitPlan fails closed when missing authored root is ignored by ro
 
     assert.throws(
       () => resolveCommitPlan(rootDir, [path.join(rootDir, "harness/tasks/task-1/notes.md")], rootDir),
-      /authored root is ignored by Git but is not a nested Git repository/u
+      /authored root is not isolated from the outer code repository/u
     );
     assert.equal(runGit(rootDir, "rev-parse", "HEAD"), beforeHead);
     assert.equal(runGit(rootDir, "branch", "--list", "sessions/*"), "");
@@ -448,19 +450,19 @@ test("WriteCoordinator records nested harness HEAD when self-host flush has no s
   });
 });
 
-test("WriteCoordinator fails closed when ignored authored root has no nested Git repo", () => {
+test("WriteCoordinator fails closed when authored root is not an independent nested Git repo", () => {
   withTempStore((rootDir) => {
     initializeGitRepo(rootDir);
-    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    writeFileSync(path.join(rootDir, ".gitignore"), "/.harness/\n", "utf8");
     runGit(rootDir, "add", ".gitignore");
-    runGit(rootDir, "commit", "-m", "ignore private harness");
+    runGit(rootDir, "commit", "-m", "seed outer repo");
     mkdirSync(path.join(rootDir, "harness"), { recursive: true });
 
     const coordinator = makeJournaledWriteCoordinator({ rootDir });
 
     assert.throws(
-      () => Effect.runSync(coordinator.enqueue(docWrite("op-ignored", "task-1", "notes.md", "ignored"))),
-      /authored root is ignored by Git but is not a nested Git repository/
+      () => Effect.runSync(coordinator.enqueue(docWrite("op-unisolated", "task-1", "notes.md", "unisolated"))),
+      /authored root is not isolated from the outer code repository/
     );
     assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
     assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/watermark.json")), false);
@@ -481,7 +483,7 @@ test("WriteCoordinator still fails closed when ignored authored root was force-t
 
     assert.throws(
       () => Effect.runSync(coordinator.enqueue(docWrite("op-force-tracked-ignored", "task-1", "notes.md", "ignored"))),
-      /authored root is ignored by Git but is not a nested Git repository/
+      /authored root is not isolated from the outer code repository/
     );
     assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")), false);
   });
@@ -514,6 +516,13 @@ function indexBody(taskId: string, title: string, status: string): string {
 
 function initializeGitRepo(repoRoot: string): void {
   runGit(repoRoot, "init");
+}
+
+function initializeNestedHarnessRepo(rootDir: string): string {
+  const harnessRoot = path.join(rootDir, "harness");
+  mkdirSync(harnessRoot, { recursive: true });
+  initializeGitRepo(harnessRoot);
+  return harnessRoot;
 }
 
 const testCommitAuthor = {


### PR DESCRIPTION
# English

## Summary

Align the journal write guard with the repository isolation design for self-hosted harness roots. If `authoredRoot: harness` is inside an outer code repository but is not its own nested Git repository, write commands now fail with the same isolation cause that `ha doctor` reports instead of claiming that the authored root is Git-ignored.

## What Changed

- Changed journal commit target resolution to require an independent authored Git repository when `authoredRoot` is a subdirectory of the outer repo.
- Updated CLI error mapping so this isolation failure remains `journal_unavailable` with an actionable `harness-anything init` hint.
- Added CLI coverage for the issue #508 shape where `.gitignore` only excludes `.harness/`, `harness/` is not ignored, and `harness/` is not a nested repo.
- Updated write-journal tests so valid authored writes use a nested `harness/.git`, while outer-managed `harness/` fails closed.

## Task And Scope

- Harness task: not created; public issue fix for #508
- Branch: `codex/issue-508-harness-isolation`
- Public scope: journal Git target selection, CLI error classification, and regression tests
- Private planning/evidence updated: not applicable
- Out of scope: supporting `harness/` as a normal tracked directory in the outer code repository; changing `ha doctor` findings; version or release changes

## Version Impact

- Version: no version change because this is a bug fix for CLI behavior and tests
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `b177188d7d908c193daef58ac67f98b92ddf93f1`
- Branch merge-base with `origin/main`: `b177188d7d908c193daef58ac67f98b92ddf93f1`
- Last `git fetch origin` time: `2026-07-09T13:35:07Z`
- Sync method: rebase onto latest `origin/main`
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: not applicable
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci`, `npm run check`, `npm test`, and `npm run harness:smoke-cli-package` were not run as standalone commands; `npm run check:local` passed and covered typecheck, lint, fast and contract tests, package policy, and the listed boundary gates. Full integration and GUI coverage are left to CI.

## Review Evidence

- Self-review: checked the diff after rebase and verified that the failure now follows the isolation contract rather than Git-ignore status
- Reviewer subagent: not run
- Human review: pending
- Blocking findings: none known

## Residual Risk

- The remaining risk is wording precision: the fix intentionally rejects outer-managed `harness/` rather than supporting it, matching the project design requirement.

## References

- Task: #508
- Evidence: `git diff --check`; `HARNESS_ACTOR=agent:harness-test node --test packages/cli/test/self-host-git-boundary-cli.test.ts packages/cli/test/doctor-cli.test.ts packages/kernel/test/store/same-task-fifo.test.ts`; `npm run check:local`
- Review: pending

---

# 中文

## 概要

把 journal 写入 guard 和 self-host harness root 的仓库隔离设计对齐。当 `authoredRoot: harness` 位于外层代码仓库内部、但不是独立 nested Git 仓库时，写命令现在会返回和 `ha doctor` 一致的 isolation 原因，而不是误报 authored root 被 Git ignore。

## 改动内容

- 调整 journal commit target 解析：如果 `authoredRoot` 是外层仓库子目录，必须是独立 authored Git 仓库。
- 更新 CLI 错误映射，让该 isolation 失败继续表现为 `journal_unavailable`，并给出 `harness-anything init` 修复建议。
- 增加 issue #508 形态的 CLI 回归测试：`.gitignore` 只忽略 `.harness/`，`harness/` 未被 ignore，且 `harness/` 不是 nested repo。
- 更新 write-journal 测试：合法 authored 写入使用 nested `harness/.git`，外层仓库托管的 `harness/` fail closed。

## 任务与范围

- Harness 任务：未创建；公开 issue #508 修复
- 分支：`codex/issue-508-harness-isolation`
- 公开范围：journal Git target 选择、CLI 错误分类、回归测试
- 私有计划 / 证据是否已更新：not applicable
- 范围外：支持把 `harness/` 当作外层代码仓库的普通 tracked 目录；修改 `ha doctor` findings；版本或发布改动

## 版本影响

- 版本：不改版本，原因是这是 CLI 行为和测试层面的 bug fix
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`b177188d7d908c193daef58ac67f98b92ddf93f1`
- 当前分支与 `origin/main` 的 merge-base：`b177188d7d908c193daef58ac67f98b92ddf93f1`
- 最近一次 `git fetch origin` 时间：`2026-07-09T13:35:07Z`
- 同步方式：rebase 到最新 `origin/main`
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：不适用
- Reviewer 证据路径：不适用
- GitHub Actions `rewrite-ci` run URL：pending
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：未单独运行 `npm ci`、`npm run check`、`npm test` 和 `npm run harness:smoke-cli-package`；已运行并通过 `npm run check:local`，覆盖 typecheck、lint、fast/contract tests、package policy 和上面勾选的 boundary gates。完整 integration 和 GUI 覆盖交给 CI。

## 审查证据

- 自查：rebase 后复查 diff，并确认失败语义现在跟 isolation contract 对齐，而不是依赖 Git-ignore 状态
- Reviewer subagent：未运行
- 人工审查：pending
- 阻塞发现：目前未知

## 残余风险

- 剩余风险主要是提示文案精度：本修复按项目设计要求拒绝 outer-managed `harness/`，而不是支持它。

## 关联材料

- 任务：#508
- 证据：`git diff --check`；`HARNESS_ACTOR=agent:harness-test node --test packages/cli/test/self-host-git-boundary-cli.test.ts packages/cli/test/doctor-cli.test.ts packages/kernel/test/store/same-task-fifo.test.ts`；`npm run check:local`
- 审查：pending

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。