### PR TITLE
fix: coalesce daemon autostart spawn

### DIFF
--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -16,12 +16,12 @@ test("daemon client routes writes for two registered repos through one user-leve
       const alphaCreated = runRawJson(alphaRoot, ["new-task", "--title", "Alpha Routed Write"], {
         HARNESS_DAEMON_MODE: "local",
         HARNESS_DAEMON_USER_ROOT: userRoot,
-        HARNESS_DAEMON_IDLE_MS: "5000"
+        HARNESS_DAEMON_IDLE_MS: "60000"
       });
       const betaCreated = runRawJson(betaRoot, ["new-task", "--title", "Beta Routed Write"], {
         HARNESS_DAEMON_MODE: "local",
         HARNESS_DAEMON_USER_ROOT: userRoot,
-        HARNESS_DAEMON_IDLE_MS: "5000"
+        HARNESS_DAEMON_IDLE_MS: "60000"
       });
 
       assert.equal(alphaCreated.ok, true);

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -1,13 +1,22 @@
 import assert from "node:assert/strict";
-import { execFile, execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import { hostname, tmpdir } from "node:os";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { hostname } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { promisify } from "node:util";
+import {
+  defaultDaemonUserRoot,
+  delay,
+  runDaemonCommand,
+  runRawJson,
+  runRawJsonAsync,
+  runRawJsonMaybeFail,
+  sleep,
+  stopDaemonQuietly,
+  withTempRoot,
+  withTempRootAsync
+} from "./helpers/daemon-cli.ts";
 
-const cliEntry = path.resolve("packages/cli/src/index.ts");
-const execFileAsync = promisify(execFile);
 const expectedCliVersion = readCliPackageVersion();
 
 test("daemon client mode preserves command receipt output shape against direct mode", () => {
@@ -247,22 +256,26 @@ test("daemon bootstrap-server is idempotent and installs roster hooks and read-o
 test("daemon client auto-registers initialized single repo on first local command", () => {
   withTempRoot((rootDir) => {
     const userRoot = path.join(rootDir, "user-daemon");
-    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    try {
+      runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
 
-    const listed = runRawJson(rootDir, ["task", "list"], {
-      HARNESS_DAEMON_MODE: "local",
-      HARNESS_DAEMON_USER_ROOT: userRoot,
-      HARNESS_DAEMON_IDLE_MS: "1500"
-    });
+      const listed = runRawJson(rootDir, ["task", "list"], {
+        HARNESS_DAEMON_MODE: "local",
+        HARNESS_DAEMON_USER_ROOT: userRoot,
+        HARNESS_DAEMON_IDLE_MS: "60000"
+      });
 
-    assert.equal(listed.ok, true);
-    const registry = JSON.parse(readFileSync(path.join(userRoot, "registry.json"), "utf8")) as { repos: Array<{ repoId: string; canonicalRoot: string; state: string }> };
-    assert.deepEqual(registry.repos.map((repo) => [repo.repoId, repo.canonicalRoot, repo.state]), [["canonical", realpathSync.native(rootDir), "enabled"]]);
+      assert.equal(listed.ok, true);
+      const registry = JSON.parse(readFileSync(path.join(userRoot, "registry.json"), "utf8")) as { repos: Array<{ repoId: string; canonicalRoot: string; state: string }> };
+      assert.deepEqual(registry.repos.map((repo) => [repo.repoId, repo.canonicalRoot, repo.state]), [["canonical", realpathSync.native(rootDir), "enabled"]]);
 
-    const status = runDaemonCommand(rootDir, ["daemon", "status", "--user-root", userRoot, "--json"], { HARNESS_DAEMON_USER_ROOT: userRoot });
-    assert.equal(status.started, true);
-    assert.equal(status.repoId, "canonical");
-    assert.equal(status.rootDir, realpathSync.native(rootDir));
+      const status = runDaemonCommand(rootDir, ["daemon", "status", "--user-root", userRoot, "--json"], { HARNESS_DAEMON_USER_ROOT: userRoot });
+      assert.equal(status.started, true);
+      assert.equal(status.repoId, "canonical");
+      assert.equal(status.rootDir, realpathSync.native(rootDir));
+    } finally {
+      stopDaemonQuietly(rootDir, userRoot);
+    }
   });
 });
 
@@ -325,32 +338,34 @@ test("daemon client --repo override targets a registered repo from a different c
     const userRoot = path.join(workspaceRoot, "user-daemon");
     const alphaRoot = path.join(workspaceRoot, "alpha");
     const betaRoot = path.join(workspaceRoot, "beta");
-    for (const rootDir of [alphaRoot, betaRoot]) {
-      mkdirSync(rootDir, { recursive: true });
-      runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    try {
+      for (const rootDir of [alphaRoot, betaRoot]) {
+        mkdirSync(rootDir, { recursive: true });
+        runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+      }
+      runDaemonCommand(alphaRoot, ["daemon", "repo", "register", "--repo-id", "alpha", "--root", alphaRoot, "--user-root", userRoot, "--no-link", "--json"], {
+        HARNESS_DAEMON_USER_ROOT: userRoot
+      });
+      runDaemonCommand(betaRoot, ["daemon", "repo", "register", "--repo-id", "beta", "--root", betaRoot, "--user-root", userRoot, "--no-link", "--json"], {
+        HARNESS_DAEMON_USER_ROOT: userRoot
+      });
+
+      const listed = runRawJson(betaRoot, ["--repo", "alpha", "task", "list"], {
+        HARNESS_DAEMON_MODE: "local",
+        HARNESS_DAEMON_USER_ROOT: userRoot,
+        HARNESS_DAEMON_IDLE_MS: "60000"
+      });
+      assert.equal(listed.ok, true);
+
+      const status = runDaemonCommand(betaRoot, ["--repo", "alpha", "daemon", "status", "--user-root", userRoot, "--json"], {
+        HARNESS_DAEMON_USER_ROOT: userRoot
+      });
+      assert.equal(status.repoId, "alpha");
+      assert.equal(status.rootDir, realpathSync.native(alphaRoot));
+      assert.deepEqual((status.repos as Array<{ repoId: string }>).map((repo) => repo.repoId), ["alpha", "beta"]);
+    } finally {
+      stopDaemonQuietly(betaRoot, userRoot);
     }
-    runDaemonCommand(alphaRoot, ["daemon", "repo", "register", "--repo-id", "alpha", "--root", alphaRoot, "--user-root", userRoot, "--no-link", "--json"], {
-      HARNESS_DAEMON_USER_ROOT: userRoot
-    });
-    runDaemonCommand(betaRoot, ["daemon", "repo", "register", "--repo-id", "beta", "--root", betaRoot, "--user-root", userRoot, "--no-link", "--json"], {
-      HARNESS_DAEMON_USER_ROOT: userRoot
-    });
-
-    const listed = runRawJson(betaRoot, ["--repo", "alpha", "task", "list"], {
-      HARNESS_DAEMON_MODE: "local",
-      HARNESS_DAEMON_USER_ROOT: userRoot,
-      // Long idle keeps the daemon alive for the status probe below; a short
-      // idle races daemon exit now that reconcile no longer delays it.
-      HARNESS_DAEMON_IDLE_MS: "5000"
-    });
-    assert.equal(listed.ok, true);
-
-    const status = runDaemonCommand(betaRoot, ["--repo", "alpha", "daemon", "status", "--user-root", userRoot, "--json"], {
-      HARNESS_DAEMON_USER_ROOT: userRoot
-    });
-    assert.equal(status.repoId, "alpha");
-    assert.equal(status.rootDir, realpathSync.native(alphaRoot));
-    assert.deepEqual((status.repos as Array<{ repoId: string }>).map((repo) => repo.repoId), ["alpha", "beta"]);
   });
 });
 
@@ -421,167 +436,6 @@ test("daemon repo commands register list and unregister the user-level registry"
   });
 });
 
-function withTempRoot<T>(fn: (rootDir: string) => T): T {
-  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-cli-daemon-"));
-  try {
-    return fn(rootDir);
-  } finally {
-    removeTempRootSync(rootDir);
-  }
-}
-
-async function withTempRootAsync<T>(fn: (rootDir: string) => Promise<T>): Promise<T> {
-  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-cli-daemon-"));
-  try {
-    return await fn(rootDir);
-  } finally {
-    await stopDaemonForRoot(rootDir);
-    await removeTempRoot(rootDir);
-  }
-}
-
-async function stopDaemonForRoot(rootDir: string): Promise<void> {
-  const pid = daemonPidFromStatus(rootDir);
-  if (!pid) return;
-  try {
-    process.kill(pid, "SIGTERM");
-  } catch (error) {
-    if (isNoSuchProcess(error)) return;
-    throw error;
-  }
-  await waitForProcessExit(pid, 3_000);
-}
-
-function daemonPidFromStatus(rootDir: string): number | undefined {
-  let status: Record<string, unknown>;
-  try {
-    status = runDaemonCommand(rootDir, ["daemon", "status", "--json"]);
-  } catch {
-    return undefined;
-  }
-  if (typeof status.pid === "number" && Number.isSafeInteger(status.pid) && status.pid > 0) return status.pid;
-  const daemonId = status.daemonId;
-  if (typeof daemonId !== "string") return undefined;
-  const match = /^ha-(\d+)$/u.exec(daemonId);
-  if (!match) return undefined;
-  const pid = Number.parseInt(match[1]!, 10);
-  return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
-}
-
-function waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  return new Promise((resolve, reject) => {
-    const check = () => {
-      try {
-        process.kill(pid, 0);
-      } catch (error) {
-        if (isNoSuchProcess(error)) {
-          resolve();
-          return;
-        }
-        reject(error);
-        return;
-      }
-      if (Date.now() >= deadline) {
-        reject(new Error(`daemon process ${pid} did not exit within ${timeoutMs}ms`));
-        return;
-      }
-      setTimeout(check, 25);
-    };
-    check();
-  });
-}
-
-async function removeTempRoot(rootDir: string): Promise<void> {
-  for (let attempt = 0; attempt < 8; attempt += 1) {
-    try {
-      rmSync(rootDir, { recursive: true, force: true });
-      return;
-    } catch (error) {
-      if (!isRetriableRemoveError(error) || attempt === 7) throw error;
-      await delay(25 * (attempt + 1));
-    }
-  }
-}
-
-function removeTempRootSync(rootDir: string): void {
-  for (let attempt = 0; attempt < 8; attempt += 1) {
-    try {
-      rmSync(rootDir, { recursive: true, force: true });
-      return;
-    } catch (error) {
-      if (!isRetriableRemoveError(error) || attempt === 7) throw error;
-      sleep(25 * (attempt + 1));
-    }
-  }
-}
-
-function isRetriableRemoveError(error: unknown): boolean {
-  return typeof error === "object"
-    && error !== null
-    && "code" in error
-    && ["ENOTEMPTY", "EBUSY", "EPERM"].includes(String((error as { readonly code?: unknown }).code));
-}
-
-function isNoSuchProcess(error: unknown): boolean {
-  return typeof error === "object"
-    && error !== null
-    && "code" in error
-    && (error as { readonly code?: unknown }).code === "ESRCH";
-}
-
-function runRawJson(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Record<string, unknown> {
-  const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
-    encoding: "utf8",
-    env: daemonTestEnv(rootDir, env)
-  });
-  return JSON.parse(stdout) as Record<string, unknown>;
-}
-
-function runRawJsonMaybeFail(
-  rootDir: string,
-  args: ReadonlyArray<string>,
-  env: Readonly<Record<string, string>> = {}
-): { readonly status: number | null; readonly receipt: Record<string, unknown> } {
-  const result = spawnSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
-    encoding: "utf8",
-    env: daemonTestEnv(rootDir, env)
-  });
-  assert.equal(result.stderr, "");
-  return {
-    status: result.status,
-    receipt: JSON.parse(result.stdout) as Record<string, unknown>
-  };
-}
-
-async function runRawJsonAsync(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Promise<Record<string, unknown>> {
-  const { stdout } = await execFileAsync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
-    encoding: "utf8",
-    env: daemonTestEnv(rootDir, env)
-  });
-  return JSON.parse(stdout) as Record<string, unknown>;
-}
-
-function runDaemonCommand(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Record<string, unknown> {
-  const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, ...args], {
-    encoding: "utf8",
-    env: daemonTestEnv(rootDir, { HARNESS_DAEMON_MODE: "direct", ...env })
-  });
-  return JSON.parse(stdout) as Record<string, unknown>;
-}
-
-function daemonTestEnv(rootDir: string, env: Readonly<Record<string, string>>): NodeJS.ProcessEnv {
-  return {
-    ...process.env,
-    HARNESS_DAEMON_USER_ROOT: defaultDaemonUserRoot(rootDir),
-    ...env
-  };
-}
-
-function defaultDaemonUserRoot(rootDir: string): string {
-  return path.join(rootDir, ".daemon-user");
-}
-
 function readCliPackageVersion(): string {
   const pkg = JSON.parse(readFileSync(path.resolve("packages/cli/package.json"), "utf8")) as { readonly version?: unknown };
   assert.equal(typeof pkg.version, "string");
@@ -595,14 +449,6 @@ function normalizeVolatileReceipt(receipt: Record<string, unknown>): Record<stri
     ...receipt,
     ...(meta ? { meta } : {})
   };
-}
-
-function sleep(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function waitForCondition(check: () => boolean, timeoutMs = 4_000): Promise<void> {

--- a/packages/cli/test/helpers/daemon-cli.ts
+++ b/packages/cli/test/helpers/daemon-cli.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { execFile, execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+const execFileAsync = promisify(execFile);
+
+export function withTempRoot<T>(fn: (rootDir: string) => T): T {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-cli-daemon-"));
+  try {
+    return fn(rootDir);
+  } finally {
+    removeTempRootSync(rootDir);
+  }
+}
+
+export async function withTempRootAsync<T>(fn: (rootDir: string) => Promise<T>): Promise<T> {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-cli-daemon-"));
+  try {
+    return await fn(rootDir);
+  } finally {
+    await stopDaemonForRoot(rootDir);
+    await removeTempRoot(rootDir);
+  }
+}
+
+export function runRawJson(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Record<string, unknown> {
+  const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+    encoding: "utf8",
+    env: daemonTestEnv(rootDir, env)
+  });
+  return JSON.parse(stdout) as Record<string, unknown>;
+}
+
+export function runRawJsonMaybeFail(
+  rootDir: string,
+  args: ReadonlyArray<string>,
+  env: Readonly<Record<string, string>> = {}
+): { readonly status: number | null; readonly receipt: Record<string, unknown> } {
+  const result = spawnSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+    encoding: "utf8",
+    env: daemonTestEnv(rootDir, env)
+  });
+  assert.equal(result.stderr, "");
+  return {
+    status: result.status,
+    receipt: JSON.parse(result.stdout) as Record<string, unknown>
+  };
+}
+
+export async function runRawJsonAsync(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Promise<Record<string, unknown>> {
+  const { stdout } = await execFileAsync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+    encoding: "utf8",
+    env: daemonTestEnv(rootDir, env)
+  });
+  return JSON.parse(stdout) as Record<string, unknown>;
+}
+
+export function runDaemonCommand(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Record<string, unknown> {
+  const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, ...args], {
+    encoding: "utf8",
+    env: daemonTestEnv(rootDir, { HARNESS_DAEMON_MODE: "direct", ...env })
+  });
+  return JSON.parse(stdout) as Record<string, unknown>;
+}
+
+export function stopDaemonQuietly(rootDir: string, userRoot: string): void {
+  try {
+    runDaemonCommand(rootDir, ["daemon", "stop", "--timeout-ms", "1000", "--user-root", userRoot, "--json"], {
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+  } catch {
+    // Best-effort cleanup for assertions that keep the daemon alive.
+  }
+}
+
+export function defaultDaemonUserRoot(rootDir: string): string {
+  return path.join(rootDir, ".daemon-user");
+}
+
+export function sleep(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function stopDaemonForRoot(rootDir: string): Promise<void> {
+  const pid = daemonPidFromStatus(rootDir);
+  if (!pid) return;
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch (error) {
+    if (isNoSuchProcess(error)) return;
+    throw error;
+  }
+  await waitForProcessExit(pid, 3_000);
+}
+
+function daemonPidFromStatus(rootDir: string): number | undefined {
+  let status: Record<string, unknown>;
+  try {
+    status = runDaemonCommand(rootDir, ["daemon", "status", "--json"]);
+  } catch {
+    return undefined;
+  }
+  if (typeof status.pid === "number" && Number.isSafeInteger(status.pid) && status.pid > 0) return status.pid;
+  const daemonId = status.daemonId;
+  if (typeof daemonId !== "string") return undefined;
+  const match = /^ha-(\d+)$/u.exec(daemonId);
+  if (!match) return undefined;
+  const pid = Number.parseInt(match[1]!, 10);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
+}
+
+function waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      try {
+        process.kill(pid, 0);
+      } catch (error) {
+        if (isNoSuchProcess(error)) {
+          resolve();
+          return;
+        }
+        reject(error);
+        return;
+      }
+      if (Date.now() >= deadline) {
+        reject(new Error(`daemon process ${pid} did not exit within ${timeoutMs}ms`));
+        return;
+      }
+      setTimeout(check, 25);
+    };
+    check();
+  });
+}
+
+async function removeTempRoot(rootDir: string): Promise<void> {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    try {
+      rmSync(rootDir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (!isRetriableRemoveError(error) || attempt === 7) throw error;
+      await delay(25 * (attempt + 1));
+    }
+  }
+}
+
+function removeTempRootSync(rootDir: string): void {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    try {
+      rmSync(rootDir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (!isRetriableRemoveError(error) || attempt === 7) throw error;
+      sleep(25 * (attempt + 1));
+    }
+  }
+}
+
+function daemonTestEnv(rootDir: string, env: Readonly<Record<string, string>>): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    HARNESS_DAEMON_USER_ROOT: defaultDaemonUserRoot(rootDir),
+    ...env
+  };
+}
+
+function isRetriableRemoveError(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && ["ENOTEMPTY", "EBUSY", "EPERM"].includes(String((error as { readonly code?: unknown }).code));
+}
+
+function isNoSuchProcess(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && (error as { readonly code?: unknown }).code === "ESRCH";
+}

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -56,6 +56,17 @@ export interface LocalDaemonJsonRpcOptions {
   readonly env?: NodeJS.ProcessEnv;
 }
 
+type SpawnLocalDaemon = (target: LocalDaemonTarget, options: LocalDaemonAutostartOptions) => void;
+
+interface DaemonStartupFlight {
+  deadline: number;
+  lastError: unknown;
+  promise: Promise<void>;
+}
+
+const daemonStartupFlights = new Map<string, DaemonStartupFlight>();
+let spawnLocalDaemonImplementation: SpawnLocalDaemon = spawnLocalDaemonProcess;
+
 export function daemonIdForRoot(rootDir: string): string {
   return `repo-${createHash("sha256").update(rootDir).digest("hex").slice(0, 16)}`;
 }
@@ -192,6 +203,18 @@ export async function requestLocalDaemonJsonRpcForTarget(
 }
 
 export function spawnLocalDaemon(target: LocalDaemonTarget, options: LocalDaemonAutostartOptions): void {
+  spawnLocalDaemonImplementation(target, options);
+}
+
+export function replaceSpawnLocalDaemonForTest(replacement: SpawnLocalDaemon): () => void {
+  const previous = spawnLocalDaemonImplementation;
+  spawnLocalDaemonImplementation = replacement;
+  return () => {
+    spawnLocalDaemonImplementation = previous;
+  };
+}
+
+function spawnLocalDaemonProcess(target: LocalDaemonTarget, options: LocalDaemonAutostartOptions): void {
   const child = spawn(options.execPath ?? process.execPath, [
     ...(options.execArgv ?? process.execArgv),
     options.entryPath,
@@ -269,22 +292,103 @@ async function requestLocalDaemonJsonRpcWithAutostart(
   autostart: LocalDaemonAutostartOptions
 ): Promise<JsonObject> {
   const deadline = Date.now() + (autostart.timeoutMs ?? defaultDaemonAutostartTimeoutMs);
-  let nextSpawnAt = 0;
   let lastError: unknown;
   while (Date.now() <= deadline) {
+    let socket: net.Socket;
     try {
-      const socket = await connectUnixSocket(target.socketPath, connectTimeoutMs);
+      socket = await connectUnixSocket(target.socketPath, boundedConnectTimeout(connectTimeoutMs, deadline));
+    } catch (error) {
+      lastError = error;
+      await ensureLocalDaemonStarted(target, autostart, connectTimeoutMs, deadline);
+      continue;
+    }
+    try {
       return await requestWithSocket(socket, method, params);
     } catch (error) {
       lastError = error;
-      if (Date.now() >= nextSpawnAt) {
-        spawnLocalDaemon(target, autostart);
-        nextSpawnAt = Date.now() + 500;
-      }
-      await delay(100);
+      await delay(Math.min(100, Math.max(1, deadline - Date.now())));
     }
   }
   throw lastError ?? new Error("local daemon did not become reachable");
+}
+
+async function ensureLocalDaemonStarted(
+  target: LocalDaemonTarget,
+  autostart: LocalDaemonAutostartOptions,
+  connectTimeoutMs: number,
+  deadline: number
+): Promise<void> {
+  const existing = daemonStartupFlights.get(target.socketPath);
+  if (existing) {
+    if (Date.now() >= existing.deadline) {
+      daemonStartupFlights.delete(target.socketPath);
+    } else {
+      existing.deadline = Math.max(existing.deadline, deadline);
+      return waitForDaemonStartupFlight(target.socketPath, existing, deadline);
+    }
+  }
+
+  const flight: DaemonStartupFlight = {
+    deadline,
+    lastError: undefined,
+    promise: Promise.resolve()
+  };
+  flight.promise = spawnAndWaitForLocalDaemon(target, autostart, connectTimeoutMs, flight);
+  daemonStartupFlights.set(target.socketPath, flight);
+  flight.promise.then(
+    () => clearDaemonStartupFlight(target.socketPath, flight),
+    () => clearDaemonStartupFlight(target.socketPath, flight)
+  );
+  return waitForDaemonStartupFlight(target.socketPath, flight, deadline);
+}
+
+async function spawnAndWaitForLocalDaemon(
+  target: LocalDaemonTarget,
+  autostart: LocalDaemonAutostartOptions,
+  connectTimeoutMs: number,
+  flight: DaemonStartupFlight
+): Promise<void> {
+  spawnLocalDaemon(target, autostart);
+  while (Date.now() <= flight.deadline) {
+    try {
+      await probeLocalDaemonReady(target.socketPath, boundedConnectTimeout(connectTimeoutMs, flight.deadline));
+      return;
+    } catch (error) {
+      flight.lastError = error;
+      const retryDelayMs = Math.min(100, flight.deadline - Date.now());
+      if (retryDelayMs > 0) await delay(retryDelayMs);
+    }
+  }
+  throw flight.lastError ?? new Error("local daemon did not become reachable");
+}
+
+async function waitForDaemonStartupFlight(socketPath: string, flight: DaemonStartupFlight, deadline: number): Promise<void> {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) {
+    if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
+    throw flight.lastError ?? new Error("local daemon did not become reachable");
+  }
+  return Promise.race([
+    flight.promise,
+    delay(remainingMs).then(() => {
+      if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
+      throw flight.lastError ?? new Error("local daemon did not become reachable");
+    })
+  ]);
+}
+
+function clearDaemonStartupFlight(socketPath: string, flight: DaemonStartupFlight): void {
+  if (daemonStartupFlights.get(socketPath) === flight) daemonStartupFlights.delete(socketPath);
+}
+
+async function probeLocalDaemonReady(socketPath: string, timeoutMs: number): Promise<void> {
+  const socket = await connectUnixSocket(socketPath, timeoutMs);
+  const client = new JsonRpcLineClient(socket, socket);
+  try {
+    await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion });
+  } finally {
+    client.close();
+  }
 }
 
 async function requestWithSocket(socket: net.Socket, method: string, params: JsonObject): Promise<JsonObject> {
@@ -360,4 +464,8 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function boundedConnectTimeout(timeoutMs: number, deadline: number): number {
+  return Math.max(1, Math.min(timeoutMs, deadline - Date.now()));
 }

--- a/packages/daemon/test/local-json-rpc-client.test.ts
+++ b/packages/daemon/test/local-json-rpc-client.test.ts
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import { rmSync } from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import test from "node:test";
+import {
+  replaceSpawnLocalDaemonForTest,
+  requestLocalDaemonJsonRpcForTarget,
+  type LocalDaemonTarget
+} from "../src/client/local-json-rpc-client.ts";
+import { encodeJsonLineFrame, type JsonObject, type JsonRpcRequest } from "../src/index.ts";
+
+test("autostart coalesces concurrent requests to one spawn per socket path", async (t) => {
+  if (process.platform === "win32") return;
+  const socketPath = uniqueSocketPath("ha-daemon-singleflight");
+  const target = makeTarget(socketPath);
+  let spawnCalls = 0;
+  let server: net.Server | undefined;
+  const restoreSpawn = replaceSpawnLocalDaemonForTest(() => {
+    spawnCalls += 1;
+    setTimeout(() => {
+      void startJsonRpcServer(socketPath).then((started) => {
+        server = started;
+      });
+    }, 50);
+  });
+  t.after(async () => {
+    restoreSpawn();
+    await closeServer(server);
+    rmSync(socketPath, { force: true });
+  });
+
+  const requests = Array.from({ length: 32 }, (_, index) =>
+    requestLocalDaemonJsonRpcForTarget(
+      target,
+      "repo.tasks.list",
+      { request: index },
+      20,
+      { entryPath: "/unused", timeoutMs: 1_000 }
+    )
+  );
+
+  const results = await Promise.all(requests);
+
+  assert.equal(spawnCalls, 1);
+  assert.equal(results.length, 32);
+  assert.deepEqual(results[0], { ok: true, method: "repo.tasks.list" });
+});
+
+test("autostart clears failed single-flight so a later request can spawn again", async (t) => {
+  if (process.platform === "win32") return;
+  const socketPath = uniqueSocketPath("ha-daemon-singleflight-retry");
+  const target = makeTarget(socketPath);
+  let spawnCalls = 0;
+  let server: net.Server | undefined;
+  let shouldStartServer = false;
+  const restoreSpawn = replaceSpawnLocalDaemonForTest(() => {
+    spawnCalls += 1;
+    if (!shouldStartServer) return;
+    setTimeout(() => {
+      void startJsonRpcServer(socketPath).then((started) => {
+        server = started;
+      });
+    }, 20);
+  });
+  t.after(async () => {
+    restoreSpawn();
+    await closeServer(server);
+    rmSync(socketPath, { force: true });
+  });
+
+  const failedRequests = Array.from({ length: 8 }, () =>
+    requestLocalDaemonJsonRpcForTarget(
+      target,
+      "repo.tasks.list",
+      {},
+      20,
+      { entryPath: "/unused", timeoutMs: 180 }
+    )
+  );
+
+  await Promise.all(failedRequests.map((request) => assert.rejects(request)));
+  assert.equal(spawnCalls, 1);
+
+  shouldStartServer = true;
+  const result = await requestLocalDaemonJsonRpcForTarget(
+    target,
+    "repo.tasks.list",
+    {},
+    20,
+    { entryPath: "/unused", timeoutMs: 1_000 }
+  );
+
+  assert.equal(spawnCalls, 2);
+  assert.deepEqual(result, { ok: true, method: "repo.tasks.list" });
+});
+
+test("autostart keeps the shared spawn alive when an early caller times out", async (t) => {
+  if (process.platform === "win32") return;
+  const socketPath = uniqueSocketPath("ha-daemon-singleflight-deadline");
+  const target = makeTarget(socketPath);
+  let spawnCalls = 0;
+  let server: net.Server | undefined;
+  const restoreSpawn = replaceSpawnLocalDaemonForTest(() => {
+    spawnCalls += 1;
+    setTimeout(() => {
+      void startJsonRpcServer(socketPath).then((started) => {
+        server = started;
+      });
+    }, 220);
+  });
+  t.after(async () => {
+    restoreSpawn();
+    await closeServer(server);
+    rmSync(socketPath, { force: true });
+  });
+
+  const shortDeadlineRequest = requestLocalDaemonJsonRpcForTarget(
+    target,
+    "repo.tasks.list",
+    {},
+    20,
+    { entryPath: "/unused", timeoutMs: 90 }
+  );
+  await delay(10);
+  const longDeadlineRequest = requestLocalDaemonJsonRpcForTarget(
+    target,
+    "repo.tasks.list",
+    {},
+    20,
+    { entryPath: "/unused", timeoutMs: 1_000 }
+  );
+
+  await assert.rejects(shortDeadlineRequest);
+  assert.deepEqual(await longDeadlineRequest, { ok: true, method: "repo.tasks.list" });
+  assert.equal(spawnCalls, 1);
+});
+
+test("autostart retries when the socket accepts before JSON-RPC is ready", async (t) => {
+  if (process.platform === "win32") return;
+  const socketPath = uniqueSocketPath("ha-daemon-singleflight-handshake");
+  const target = makeTarget(socketPath);
+  let spawnCalls = 0;
+  let server: net.Server | undefined;
+  const restoreSpawn = replaceSpawnLocalDaemonForTest(() => {
+    spawnCalls += 1;
+    setTimeout(() => {
+      void startJsonRpcServer(socketPath, { closeFirstConnections: 2 }).then((started) => {
+        server = started;
+      });
+    }, 30);
+  });
+  t.after(async () => {
+    restoreSpawn();
+    await closeServer(server);
+    rmSync(socketPath, { force: true });
+  });
+
+  const result = await requestLocalDaemonJsonRpcForTarget(
+    target,
+    "repo.tasks.list",
+    {},
+    20,
+    { entryPath: "/unused", timeoutMs: 1_000 }
+  );
+
+  assert.equal(spawnCalls, 1);
+  assert.deepEqual(result, { ok: true, method: "repo.tasks.list" });
+});
+
+function makeTarget(socketPath: string): LocalDaemonTarget {
+  return {
+    repoId: "canonical",
+    canonicalRoot: "/tmp/canonical",
+    userRoot: "/tmp/ha-user-root",
+    daemonId: "default",
+    socketPath,
+    legacySocketPath: `${socketPath}.legacy`,
+    registered: true
+  };
+}
+
+function uniqueSocketPath(prefix: string): string {
+  return path.join("/tmp", `${prefix}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}.sock`);
+}
+
+async function startJsonRpcServer(socketPath: string, options: { readonly closeFirstConnections?: number } = {}): Promise<net.Server> {
+  rmSync(socketPath, { force: true });
+  let closeConnections = options.closeFirstConnections ?? 0;
+  const server = net.createServer((socket) => {
+    if (closeConnections > 0) {
+      closeConnections -= 1;
+      socket.destroy();
+      return;
+    }
+    const lines = createInterface({ input: socket });
+    lines.on("line", (line) => {
+      const request = JSON.parse(line) as JsonRpcRequest;
+      const result: JsonObject = request.method === "protocol.hello"
+        ? { ok: true }
+        : { ok: true, method: request.method };
+      socket.write(encodeJsonLineFrame({
+        jsonrpc: "2.0",
+        id: request.id ?? null,
+        result
+      }));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return server;
+}
+
+function closeServer(server: net.Server | undefined): Promise<void> {
+  if (!server?.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -3,6 +3,7 @@ export const testTierManifest = {
     "packages/adapters/local/test/task-writes.test.ts",
     "packages/cli/test/parse-args.test.ts",
     "packages/cli/test/path-utils.test.ts",
+    "packages/daemon/test/local-json-rpc-client.test.ts",
     "packages/gui/test/markdown-sanitize.test.ts",
     "packages/gui/test/terminal-backend-policy.test.ts",
     "packages/gui/test/terminal-no-ingestion.test.ts",


### PR DESCRIPTION
# English

## Summary

Fix daemon autostart spawn amplification by coalescing concurrent local JSON-RPC client autostart attempts per socket path. This keeps a cold or slow daemon from being spawned repeatedly by many simultaneous GUI/CLI requests.

## What Changed

- Added a module-level single-flight map around daemon autostart spawning, keyed by socket path.
- Kept failed or timed-out spawn attempts recoverable so later requests can retry cleanly.
- Added daemon client regression tests for concurrent coalescing, failed-spawn cleanup, early-caller timeout behavior, and socket-ready-before-RPC-ready retry behavior.
- Registered the new daemon test file in the fast test tier manifest.

## Task And Scope

- Harness task: `task_01KX27SK05DNF90GES57E4N5Y6`
- Branch: `codex/p0a-daemon-spawn-singleflight`
- Public scope: daemon local JSON-RPC client autostart single-flight behavior and focused tests.
- Private planning/evidence updated: not applicable for this public PR body; task evidence is tracked privately.
- Out of scope: GUI query fan-out changes, connect timeout tuning, broader performance budgets, daemon protocol changes, and release/version publishing.

## Version Impact

- Version: no version change because this is an internal runtime bug fix with no package release in this PR.
- Publish impact: no publish; publish readiness and release remain separate tasks.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/test-tier-manifest.mjs` only, to classify the new daemon test file.
- Authority: `task_01KX27SK05DNF90GES57E4N5Y6` required a regression test for daemon autostart single-flight behavior; repository testing policy requires new `packages/**` test files to be registered in `tools/test-tier-manifest.mjs`.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `a8dd146dec7013c0853f2cd837e43359b896038d`
- Branch merge-base with `origin/main`: `a8dd146dec7013c0853f2cd837e43359b896038d`
- Last `git fetch origin` time: 2026-07-09T14:17:55Z before the second rebase to `origin/main`
- Sync method: rebase
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: `task_01KX27SK05DNF90GES57E4N5Y6` private task package
- Reviewer evidence path: not yet available
- GitHub Actions `rewrite-ci` run URL: pending after the force-with-lease update
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Additional local verification: `npm run test:fast` passed with 241 tests, 0 failures before the CI fix; `npm run harness:check-gate-surface` passed with 49 manifest gates and 0 drift findings; `node --test packages/daemon/test/local-json-rpc-client.test.ts` passed with 4 tests, 0 failures; `npm run test:integration -- --shard 2` passed with 55 tests, 0 failures; `npm run test:integration -- --shard 5` passed with 88 tests, 0 failures.
- Not run: `npm ci`, `npm run check`, full `npm test`, and the listed individual harness gates were not run locally before opening this draft PR to keep turnaround focused; remote CI is pending.

## Review Evidence

- Self-review: inspected diff scope after rebase; public changes are limited to daemon client single-flight behavior, daemon client tests, and test tier registration.
- Reviewer subagent: not run.
- Human review: pending.
- Blocking findings: none known at PR creation time.

## Residual Risk

- This reduces daemon spawn amplification at the client autostart layer, but it does not address GUI request fan-out or the 200ms connection timeout feedback loop. Those remain separate P0 follow-up lines.
- CI is pending again after the CI-fix force-with-lease update; reviewer evidence is still pending.

## References

- Task: `task_01KX27SK05DNF90GES57E4N5Y6`
- Evidence: local verification commands listed above
- Review: pending

---

# 中文

## 概要

修复 daemon autostart 的 spawn 放大问题：本地 JSON-RPC client 现在按 socket path 合并并发自动拉起请求，避免冷启动或慢启动 daemon 时被大量 GUI/CLI 并发请求重复拉起。

## 改动内容

- 在 daemon autostart spawn 外增加 module 级 single-flight map，按 socket path 分组。
- 保持失败或超时的 spawn 可清理、可重试，避免一次失败污染后续请求。
- 增加 daemon client 回归测试，覆盖并发合并、失败清理、早到调用方超时、socket 先 ready 但 JSON-RPC 尚未 ready 的重试行为。
- 将新增 daemon 测试登记到 fast test tier manifest。

## 任务与范围

- Harness 任务：`task_01KX27SK05DNF90GES57E4N5Y6`
- 分支：`codex/p0a-daemon-spawn-singleflight`
- 公开范围：daemon 本地 JSON-RPC client 的 autostart single-flight 行为与聚焦测试。
- 私有计划 / 证据是否已更新：not applicable for this public PR body；任务证据在私有任务包中维护。
- 范围外：GUI query fan-out、连接超时调参、更广的性能预算、daemon 协议变更、版本发布。

## 版本影响

- 版本：不改版本，原因是本 PR 是内部 runtime bug fix，不在本 PR 发布包。
- 发布影响：不发布；发布准备与正式 release 放到独立任务。

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：仅 `tools/test-tier-manifest.mjs`，用于登记新增 daemon 测试文件。
- 依据：`task_01KX27SK05DNF90GES57E4N5Y6` 要求为 daemon autostart single-flight 行为补回归测试；仓库测试政策要求新增 `packages/**` 测试文件必须登记到 `tools/test-tier-manifest.mjs`。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`a8dd146dec7013c0853f2cd837e43359b896038d`
- 当前分支与 `origin/main` 的 merge-base：`a8dd146dec7013c0853f2cd837e43359b896038d`
- 最近一次 `git fetch origin` 时间：2026-07-09T14:17:55Z，第二次 rebase 到 `origin/main` 前
- 同步方式：rebase
- 公开 diff 命令：`git diff --stat origin/main...HEAD`
- 私有证据 commit/path：`task_01KX27SK05DNF90GES57E4N5Y6` 私有任务包
- Reviewer 证据路径：暂未生成
- GitHub Actions `rewrite-ci` run URL：force-with-lease 更新后等待生成
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 额外本地验证：CI 修复前 `npm run test:fast` 通过，241 tests、0 failures；`npm run harness:check-gate-surface` 通过，49 个 manifest gates、0 drift findings；`node --test packages/daemon/test/local-json-rpc-client.test.ts` 通过，4 tests、0 failures；`npm run test:integration -- --shard 2` 通过，55 tests、0 failures；`npm run test:integration -- --shard 5` 通过，88 tests、0 failures。
- 未运行：`npm ci`、`npm run check`、完整 `npm test` 和上面列出的单项 harness gates 尚未在本地运行；本 PR 先作为 draft 推出，等待远端 CI。

## 审查证据

- 自查：rebase 后检查 diff 范围；公开改动限于 daemon client single-flight 行为、daemon client 测试和 test tier 登记。
- Reviewer subagent：未运行。
- 人工审查：等待。
- 阻塞发现：创建 PR 时暂无已知阻塞项。

## 残余风险

- 本 PR 降低的是 client autostart 层的 daemon spawn 放大；不处理 GUI request fan-out 或 200ms 连接超时正反馈，这些属于独立 P0 后续线。
- CI 修复 force-with-lease 更新后，新一轮 CI 仍在等待；reviewer 证据仍待补齐。

## 关联材料

- 任务：`task_01KX27SK05DNF90GES57E4N5Y6`
- 证据：见上方本地验证命令
- 审查：等待

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [ ] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [ ] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。


