### PR TITLE
fix: collapse main to a single required-check enforcement surface and machine-check it

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -34,16 +34,14 @@ manual workflow dispatch. It remains the release-grade gate and still covers
 typecheck, all node tests, boundaries, package policy, schema/API/service gates,
 supply-chain, Legacy Intake smoke, and CLI package smoke.
 
-GitHub repository rulesets for `main` should require pull requests, the
-`rewrite-ci` status checks, deletion blocking, and non-fast-forward/force-push
-blocking with no bypass actors. Classic branch protection keeps the same
-required status checks with `required_status_checks.strict = false`, approval
-count `0`, and required conversation resolution disabled. Mergify owns the
-up-to-date guarantee by testing queued pull requests against the predicted
-merge state.
+The active GitHub repository ruleset is the sole enforcement surface for
+`main`. It requires pull requests, the `rewrite-ci` status checks, deletion
+blocking, and non-fast-forward/force-push blocking with no bypass actors. The
+`check-github-required-contexts` gate verifies the hosted branch rules against
+the structured gate manifest. Mergify owns the up-to-date guarantee by testing
+queued pull requests against the predicted merge state.
 
-The current GitHub branch-protection configuration for `main` has administrator
-enforcement disabled and requires these status contexts:
+The active GitHub ruleset enforcement for `main` requires these status contexts:
 
 - boundaries
 - package-policy
@@ -107,15 +105,11 @@ contexts, not through a slower aggregate `integration` context.
 GUI Electron E2E is an explicit local closeout gate for GUI-related tasks and
 must be recorded as task evidence instead of running in GitHub CI.
 
-This repository may leave classic administrator enforcement disabled so a
-single-owner/admin-agent workflow can merge after recorded local review
-evidence. The active ruleset still blocks force pushes, deletion, missing
-required checks, and non-PR updates to `main`.
-
 ## Admin Bypass
 
-Administrator merge is the normal autonomous path after local task evidence
-records:
+The active repository ruleset has no bypass actors. Repository administrators
+cannot bypass required checks for `main`; merges still require recorded task
+evidence, including:
 
 - verification commands
 - self-review
@@ -123,4 +117,4 @@ records:
 - residual risks
 - the latest `origin/main` sync state
 
-Bypass does not make checks, conflict resolution, or review evidence optional.
+Required checks, conflict resolution, and review evidence are not optional.

--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -134,6 +134,8 @@ jobs:
 
   boundaries:
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Accept Mergify queue metadata edit
@@ -149,6 +151,8 @@ jobs:
       - if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' }}
         run: npm ci
       - if: ${{ env.MERGIFY_QUEUE_METADATA_EDIT != 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: node tools/run-manifest-gates.mjs --workflow-job boundaries --exclude mergify-queue-metadata-edit-noop
 
   package-policy:

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "harness:check-private-boundary": "node tools/check-private-boundary.mjs",
     "harness:check-integration-test-shards": "node tools/check-integration-test-shards.mjs",
     "harness:check-mergify-queue-contexts": "node tools/check-mergify-queue-contexts.mjs",
+    "harness:check-github-required-contexts": "node tools/check-github-required-contexts.mjs",
     "harness:check-docs-release-map": "node tools/check-docs-release-map.mjs",
     "harness:check-docmap-fresh": "node tools/check-docmap-fresh.mjs",
     "harness:check-gate-surface": "node tools/check-gate-surface.mjs",

--- a/tools/check-github-required-contexts.mjs
+++ b/tools/check-github-required-contexts.mjs
@@ -74,12 +74,22 @@ export function extractGitHubRequiredStatusCheckContexts(branchRules) {
   return { hasRequiredStatusCheckRule, contexts };
 }
 
+// Retry only what a retry can fix: transport faults, rate limiting, and 5xx.
+// A 4xx is a permission or configuration answer -- repeating it just delays a
+// red that must stay red.
+function isRetryableStatus(status) {
+  return status === 429 || status >= 500;
+}
+
 export async function fetchGitHubBranchRules({
   repo,
   branch = DEFAULT_BRANCH,
   token = process.env.GITHUB_TOKEN,
   apiBase = DEFAULT_API_BASE,
-  fetchImpl = globalThis.fetch
+  fetchImpl = globalThis.fetch,
+  attempts = 3,
+  backoffMs = 500,
+  sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 }) {
   if (!repo || !/^[^/\s]+\/[^/\s]+$/u.test(repo)) {
     throw new Error("repository must be provided as owner/name");
@@ -92,22 +102,40 @@ export async function fetchGitHubBranchRules({
   }
 
   const url = `${apiBase.replace(/\/+$/u, "")}/repos/${repo}/rules/branches/${encodeURIComponent(branch)}`;
-  const response = await fetchImpl(url, {
-    headers: {
-      "Accept": "application/vnd.github+json",
-      "Authorization": `Bearer ${token}`,
-      "X-GitHub-Api-Version": "2022-11-28",
-      "User-Agent": "harness-anything-required-context-check"
-    }
-  });
+  let lastError;
 
-  if (!response.ok) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    let response;
+    try {
+      response = await fetchImpl(url, {
+        headers: {
+          "Accept": "application/vnd.github+json",
+          "Authorization": `Bearer ${token}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+          "User-Agent": "harness-anything-required-context-check"
+        }
+      });
+    } catch (error) {
+      lastError = new Error(`GitHub branch rules request failed: ${error.message}`);
+      if (attempt === attempts) break;
+      await sleepImpl(backoffMs * attempt);
+      continue;
+    }
+
+    if (response.ok) {
+      return response.json();
+    }
+
     const body = await response.text();
     const detail = body.trim() ? `: ${body.slice(0, 500)}` : "";
-    throw new Error(`GitHub branch rules request failed (${response.status} ${response.statusText})${detail}`);
+    lastError = new Error(
+      `GitHub branch rules request failed (${response.status} ${response.statusText})${detail}`
+    );
+    if (!isRetryableStatus(response.status) || attempt === attempts) break;
+    await sleepImpl(backoffMs * attempt);
   }
 
-  return response.json();
+  throw lastError;
 }
 
 function parseArgs(argv) {

--- a/tools/check-github-required-contexts.mjs
+++ b/tools/check-github-required-contexts.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseManifestBranchProtectionContexts } from "./check-mergify-queue-contexts.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const gateManifestPath = path.join(repoRoot, "tools/gate-manifest.json");
+const DEFAULT_BRANCH = "main";
+const DEFAULT_API_BASE = "https://api.github.com";
+
+export function checkGithubRequiredContexts({
+  branchRules,
+  gateManifestText = readFileSync(gateManifestPath, "utf8")
+}) {
+  const apiResult = extractGitHubRequiredStatusCheckContexts(branchRules);
+  const apiContexts = apiResult.contexts;
+  const requiredContexts = parseManifestBranchProtectionContexts(gateManifestText);
+  const errors = [];
+  const missing = requiredContexts.filter((context) => !apiContexts.includes(context));
+  const extra = apiContexts.filter((context) => !requiredContexts.includes(context));
+
+  if (requiredContexts.length === 0) {
+    errors.push("gate manifest declares no branch-protection contexts");
+  }
+  if (!apiResult.hasRequiredStatusCheckRule) {
+    errors.push("GitHub branch rules include no required_status_checks rule");
+  }
+  if (apiContexts.length === 0) {
+    errors.push("GitHub branch rules declare no required status check contexts");
+  }
+
+  if (missing.length > 0) {
+    errors.push(`missing required contexts in GitHub branch rules: ${missing.join(", ")}`);
+  }
+  if (extra.length > 0) {
+    errors.push(`extra GitHub branch-rule contexts not declared by gate manifest: ${extra.join(", ")}`);
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    apiContexts,
+    requiredContexts
+  };
+}
+
+export function extractGitHubRequiredStatusCheckContexts(branchRules) {
+  if (!Array.isArray(branchRules)) {
+    throw new TypeError("GitHub branch rules response must be an array");
+  }
+
+  const contexts = [];
+  const seen = new Set();
+  let hasRequiredStatusCheckRule = false;
+
+  for (const rule of branchRules) {
+    if (rule?.type !== "required_status_checks") {
+      continue;
+    }
+    hasRequiredStatusCheckRule = true;
+    for (const entry of rule.parameters?.required_status_checks ?? []) {
+      const context = typeof entry === "string" ? entry : entry?.context;
+      if (typeof context !== "string" || context.trim() === "") {
+        continue;
+      }
+      if (!seen.has(context)) {
+        seen.add(context);
+        contexts.push(context);
+      }
+    }
+  }
+
+  return { hasRequiredStatusCheckRule, contexts };
+}
+
+export async function fetchGitHubBranchRules({
+  repo,
+  branch = DEFAULT_BRANCH,
+  token = process.env.GITHUB_TOKEN,
+  apiBase = DEFAULT_API_BASE,
+  fetchImpl = globalThis.fetch
+}) {
+  if (!repo || !/^[^/\s]+\/[^/\s]+$/u.test(repo)) {
+    throw new Error("repository must be provided as owner/name");
+  }
+  if (!token) {
+    throw new Error("GITHUB_TOKEN is required to read GitHub branch rules");
+  }
+  if (typeof fetchImpl !== "function") {
+    throw new Error("global fetch is unavailable");
+  }
+
+  const url = `${apiBase.replace(/\/+$/u, "")}/repos/${repo}/rules/branches/${encodeURIComponent(branch)}`;
+  const response = await fetchImpl(url, {
+    headers: {
+      "Accept": "application/vnd.github+json",
+      "Authorization": `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "harness-anything-required-context-check"
+    }
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    const detail = body.trim() ? `: ${body.slice(0, 500)}` : "";
+    throw new Error(`GitHub branch rules request failed (${response.status} ${response.statusText})${detail}`);
+  }
+
+  return response.json();
+}
+
+function parseArgs(argv) {
+  const options = {
+    repo: process.env.GITHUB_REPOSITORY ?? null,
+    branch: process.env.GITHUB_REF_NAME === DEFAULT_BRANCH ? process.env.GITHUB_REF_NAME : DEFAULT_BRANCH
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--repo") {
+      options.repo = requireValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--branch") {
+      options.branch = requireValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown check-github-required-contexts option: ${arg}`);
+  }
+
+  return options;
+}
+
+function requireValue(args, index, flag) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+async function main(argv) {
+  const options = parseArgs(argv);
+  const branchRules = await fetchGitHubBranchRules(options);
+  const result = checkGithubRequiredContexts({ branchRules });
+  if (!result.ok) {
+    for (const error of result.errors) {
+      console.error(error);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`GitHub required context check passed (${result.apiContexts.length} contexts).`);
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/tools/check-github-required-contexts.test.mjs
+++ b/tools/check-github-required-contexts.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  checkGithubRequiredContexts,
+  extractGitHubRequiredStatusCheckContexts
+} from "./check-github-required-contexts.mjs";
+
+function manifestWithContexts(contexts) {
+  return JSON.stringify({
+    gates: [
+      {
+        id: "fixture",
+        executionSurfaces: {
+          branchProtection: {
+            contexts
+          }
+        }
+      }
+    ]
+  });
+}
+
+function requiredStatusCheckRule(contexts) {
+  return {
+    type: "required_status_checks",
+    parameters: {
+      required_status_checks: contexts.map((context) => ({ context }))
+    }
+  };
+}
+
+test("github required context check accepts matching context sets", () => {
+  const result = checkGithubRequiredContexts({
+    branchRules: [requiredStatusCheckRule(["boundaries", "integration-shard (1)"])],
+    gateManifestText: manifestWithContexts(["boundaries", "integration-shard (1)"])
+  });
+
+  assert.equal(result.ok, true, result.errors.join("\n"));
+});
+
+test("github required context check rejects missing and extra contexts", () => {
+  const result = checkGithubRequiredContexts({
+    branchRules: [requiredStatusCheckRule(["boundaries", "nonexistent-job"])],
+    gateManifestText: manifestWithContexts(["boundaries", "integration-shard (3)"])
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /missing required contexts.*integration-shard \(3\)/u);
+  assert.match(result.errors.join("\n"), /extra GitHub branch-rule contexts.*nonexistent-job/u);
+});
+
+test("github required context check rejects dual empty context sets", () => {
+  const result = checkGithubRequiredContexts({
+    branchRules: [requiredStatusCheckRule([])],
+    gateManifestText: manifestWithContexts([])
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.errors, [
+    "gate manifest declares no branch-protection contexts",
+    "GitHub branch rules declare no required status check contexts"
+  ]);
+});
+
+test("github required context check rejects missing required_status_checks rule", () => {
+  const result = checkGithubRequiredContexts({
+    branchRules: [{ type: "pull_request" }],
+    gateManifestText: manifestWithContexts(["boundaries"])
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /include no required_status_checks rule/u);
+  assert.match(result.errors.join("\n"), /declare no required status check contexts/u);
+});
+
+test("github required context parser unions contexts across multiple rulesets", () => {
+  assert.deepEqual(extractGitHubRequiredStatusCheckContexts([
+    requiredStatusCheckRule(["boundaries", "typecheck (24)"]),
+    { type: "deletion" },
+    requiredStatusCheckRule(["typecheck (24)", "integration-shard (6)"])
+  ]), {
+    hasRequiredStatusCheckRule: true,
+    contexts: ["boundaries", "typecheck (24)", "integration-shard (6)"]
+  });
+});

--- a/tools/check-github-required-contexts.test.mjs
+++ b/tools/check-github-required-contexts.test.mjs
@@ -2,8 +2,21 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   checkGithubRequiredContexts,
-  extractGitHubRequiredStatusCheckContexts
+  extractGitHubRequiredStatusCheckContexts,
+  fetchGitHubBranchRules
 } from "./check-github-required-contexts.mjs";
+
+const FETCH_OPTIONS = { repo: "o/r", token: "t", backoffMs: 0, sleepImpl: async () => {} };
+
+function response(status, payload) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: String(status),
+    json: async () => payload,
+    text: async () => JSON.stringify(payload)
+  };
+}
 
 function manifestWithContexts(contexts) {
   return JSON.stringify({
@@ -82,4 +95,70 @@ test("github required context parser unions contexts across multiple rulesets", 
     hasRequiredStatusCheckRule: true,
     contexts: ["boundaries", "typecheck (24)", "integration-shard (6)"]
   });
+});
+
+test("branch-rules fetch retries a transport fault and then succeeds", async () => {
+  let calls = 0;
+  const rules = await fetchGitHubBranchRules({
+    ...FETCH_OPTIONS,
+    fetchImpl: async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("socket hang up");
+      return response(200, [{ type: "deletion" }]);
+    }
+  });
+  assert.equal(calls, 2);
+  assert.deepEqual(rules, [{ type: "deletion" }]);
+});
+
+test("branch-rules fetch retries 5xx and 429 but not 403", async () => {
+  let serverErrorCalls = 0;
+  await fetchGitHubBranchRules({
+    ...FETCH_OPTIONS,
+    fetchImpl: async () => {
+      serverErrorCalls += 1;
+      return serverErrorCalls < 3 ? response(503, {}) : response(200, []);
+    }
+  });
+  assert.equal(serverErrorCalls, 3);
+
+  let rateLimitedCalls = 0;
+  await fetchGitHubBranchRules({
+    ...FETCH_OPTIONS,
+    fetchImpl: async () => {
+      rateLimitedCalls += 1;
+      return rateLimitedCalls === 1 ? response(429, {}) : response(200, []);
+    }
+  });
+  assert.equal(rateLimitedCalls, 2);
+
+  // A 403 is an answer, not a fault: it must fail on the first attempt so a
+  // missing token permission stays red instead of being retried into silence.
+  let forbiddenCalls = 0;
+  await assert.rejects(
+    fetchGitHubBranchRules({
+      ...FETCH_OPTIONS,
+      fetchImpl: async () => {
+        forbiddenCalls += 1;
+        return response(403, { message: "Resource not accessible by integration" });
+      }
+    }),
+    /403/u
+  );
+  assert.equal(forbiddenCalls, 1);
+});
+
+test("branch-rules fetch stays fail-closed after exhausting retries", async () => {
+  let calls = 0;
+  await assert.rejects(
+    fetchGitHubBranchRules({
+      ...FETCH_OPTIONS,
+      fetchImpl: async () => {
+        calls += 1;
+        throw new Error("EOF");
+      }
+    }),
+    /EOF/u
+  );
+  assert.equal(calls, 3);
 });

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -2211,6 +2211,69 @@
       }
     },
     {
+      "id": "check-github-required-contexts",
+      "command": "npm run harness:check-github-required-contexts",
+      "category": "meta-governance",
+      "tier": "pr-required",
+      "tierReason": null,
+      "authoritySource": [
+        "GET /repos/{owner}/{repo}/rules/branches/main",
+        "tools/gate-manifest.json",
+        "decision:dec_mrdk63q3"
+      ],
+      "consumerScope": [
+        "GitHub branch rules must require exactly the same contexts as the gate manifest branch-protection surface"
+      ],
+      "githubContext": {
+        "requiredContexts": [
+          "boundaries"
+        ],
+        "workflowJobs": [
+          "boundaries"
+        ],
+        "nodeVersions": [
+          24
+        ]
+      },
+      "allowlistPolicy": {
+        "allowed": false,
+        "location": null,
+        "adrOrDecisionRequired": false,
+        "notes": "GitHub required-context reconciliation is fail-closed and has no allowlist or local skip branch."
+      },
+      "changeControl": {
+        "ordinaryImplementationMayModify": false,
+        "requiresGovernanceEvidence": true,
+        "protectedSurfaces": [
+          "tools/check-github-required-contexts.mjs",
+          "package.json:scripts.harness:check-github-required-contexts",
+          ".github/workflows/rewrite-ci.yml:jobs.boundaries",
+          "tools/gate-manifest.json",
+          "decision:dec_mrdk63q3"
+        ]
+      },
+      "bypassFixtureRequired": false,
+      "executionSurfaces": {
+        "packageJson": {
+          "check": false,
+          "checkPr": false,
+          "script": "harness:check-github-required-contexts"
+        },
+        "rewriteCi": {
+          "pullRequestJobs": [
+            "boundaries"
+          ],
+          "nonPullRequestJobs": []
+        },
+        "branchProtection": {
+          "required": true,
+          "contexts": [
+            "boundaries"
+          ]
+        }
+      }
+    },
+    {
       "id": "check-docs-release-map",
       "command": "npm run harness:check-docs-release-map",
       "category": "local-consistency",

--- a/tools/pr-doctor.mjs
+++ b/tools/pr-doctor.mjs
@@ -1,23 +1,8 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-
-const REQUIRED_CHECKS_FALLBACK = [
-  "boundaries",
-  "package-policy",
-  "typecheck (24)",
-  "fast-contract",
-  "integration-shard (1)",
-  "integration-shard (2)",
-  "integration-shard (3)",
-  "integration-shard (4)",
-  "integration-shard (5)",
-  "integration-shard (6)",
-  "supply-chain",
-  "gui-build",
-  "node26-compatibility",
-  "pr-body-lint"
-];
+import { extractGitHubRequiredStatusCheckContexts } from "./check-github-required-contexts.mjs";
+import { parseMergifyQueueCheckSuccessContexts } from "./check-mergify-queue-contexts.mjs";
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
@@ -41,7 +26,27 @@ function runJson(command, args, fallback) {
 }
 
 function repoNameWithOwner() {
+  const envRepo = process.env.GITHUB_REPOSITORY;
+  if (isValidNameWithOwner(envRepo)) {
+    return envRepo;
+  }
+
+  const remote = run("git", ["config", "--get", "remote.origin.url"]);
+  const parsedRemote = parseGitHubRemote(remote);
+  if (parsedRemote) {
+    return parsedRemote;
+  }
+
   return runJson("gh", ["repo", "view", "--json", "nameWithOwner"], {}).nameWithOwner;
+}
+
+function parseGitHubRemote(remote) {
+  const match = /github\.com[:/]([^/\s]+\/[^/\s]+?)(?:\.git)?$/u.exec(remote.trim());
+  return isValidNameWithOwner(match?.[1]) ? match[1] : null;
+}
+
+function isValidNameWithOwner(value) {
+  return typeof value === "string" && /^[^/\s]+\/[^/\s]+$/u.test(value);
 }
 
 function latestChecks(statusCheckRollup = []) {
@@ -117,46 +122,23 @@ function summarizeChecks(pr) {
     .join(", ");
 }
 
-function branchProtectionRequired(repo) {
-  try {
-    return runJson("gh", [
-      "api",
-      `repos/${repo}/branches/main/protection/required_status_checks`,
-      "--jq",
-      ".contexts"
-    ], []);
-  } catch (_error) {
-    return REQUIRED_CHECKS_FALLBACK;
+function githubRulesRequired(repo) {
+  const rules = runJson("gh", [
+    "api",
+    `repos/${repo}/rules/branches/main`
+  ], []);
+  const result = extractGitHubRequiredStatusCheckContexts(rules);
+  if (!result.hasRequiredStatusCheckRule) {
+    throw new Error("GitHub branch rules include no required_status_checks rule for main");
   }
+  if (result.contexts.length === 0) {
+    throw new Error("GitHub branch rules declare no required status check contexts for main");
+  }
+  return result.contexts;
 }
 
-function mergifyMergeConditions() {
-  const text = readFileSync(".mergify.yml", "utf8");
-  const lines = text.split(/\r?\n/u);
-  const checks = new Set();
-  let inDefaultQueue = false;
-  let inMergeConditions = false;
-  for (const line of lines) {
-    if (/^  - name: default\s*$/u.test(line)) {
-      inDefaultQueue = true;
-      continue;
-    }
-    if (inDefaultQueue && /^pull_request_rules:\s*$/u.test(line)) {
-      break;
-    }
-    if (!inDefaultQueue) continue;
-    if (/^    merge_conditions:\s*$/u.test(line)) {
-      inMergeConditions = true;
-      continue;
-    }
-    if (inMergeConditions && /^    [A-Za-z_]+/u.test(line)) {
-      inMergeConditions = false;
-    }
-    if (!inMergeConditions) continue;
-    const match = /^\s+- check-success = "?([^"]+?)"?\s*$/u.exec(line);
-    if (match) checks.add(match[1]);
-  }
-  return [...checks].sort();
+function mergifyQueueConditions() {
+  return parseMergifyQueueCheckSuccessContexts(readFileSync(".mergify.yml", "utf8"));
 }
 
 function diffSets(left, right) {
@@ -248,7 +230,7 @@ function printSection(title, lines) {
 
 function main() {
   const repo = repoNameWithOwner();
-  const requiredChecks = branchProtectionRequired(repo);
+  const requiredChecks = githubRulesRequired(repo);
   const prs = runJson("gh", [
     "pr",
     "list",
@@ -275,8 +257,8 @@ function main() {
 
   printSection("Recent Dequeue Events", recentDequeueEvents(repo, prs));
 
-  const mergifyChecks = mergifyMergeConditions();
-  printSection("Branch Protection vs Mergify", [
+  const mergifyChecks = mergifyQueueConditions();
+  printSection("GitHub Branch Rules vs Mergify", [
     `required-only: ${diffSets(requiredChecks, mergifyChecks).join(", ") || "none"}`,
     `mergify-only: ${diffSets(mergifyChecks, requiredChecks).join(", ") || "none"}`
   ]);

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -28,6 +28,7 @@ export const testTierManifest = {
     "tools/run-node-tests.test.mjs",
     "tools/run-manifest-gates.test.mjs",
     "tools/check-integration-test-shards.test.mjs",
+    "tools/check-github-required-contexts.test.mjs",
     "tools/check-mergify-queue-contexts.test.mjs"
   ],
   contract: [


### PR DESCRIPTION
# English

## Summary

Collapse `main` to a single required-status-checks enforcement surface, then machine-check it. Previously the constraint lived in two places at once — classic branch protection and repository ruleset `18576233` — and GitHub enforces the **union**. Updating one and forgetting the other does not turn CI red; it leaves the pull request pending forever on a check that will never report.

## What Changed

- Add `tools/check-github-required-contexts.mjs` (+ tests, `tier: pr-required`, wired to the `boundaries` job). It asserts that the `required_status_checks` contexts returned by `GET /repos/{owner}/{repo}/rules/branches/main` equal `gate-manifest.json`'s `executionSurfaces.branchProtection.contexts`, in both directions. Empty manifest set, empty API set, and a missing `required_status_checks` rule are all fail-closed.
- Retry only transport faults, `429`, and `5xx` with linear backoff. A `4xx` is an answer, not a fault: a missing token permission fails on the first attempt and stays red. Exhausting the attempt budget still throws.
- Repair `tools/pr-doctor.mjs`. It read `branches/main/protection` inside a `try/catch` that silently returned a hardcoded, pre-sharding context list on failure — so deleting classic branch protection would have made the queue-triage tool report stale data without telling anyone. It also parsed `.mergify.yml`'s `merge_conditions`, which has been `[]` since in-place checks were enabled. It now reads the branch-rules endpoint, fails loudly, and reuses `parseMergifyQueueCheckSuccessContexts` to read `queue_conditions`.
- Correct `.github/branch-protection.md`: the "Admin Bypass" section described a capability that does not exist (the ruleset has `bypass_actors: []` and `current_user_can_bypass: "never"`, so repository administrators cannot bypass required checks either).

This PR does **not** delete classic branch protection. That is the final step, performed after merge, deliberately in this order: `pr-doctor` must already point at the ruleset, otherwise there is a window in which the triage tool silently uses its stale fallback.

## Task And Scope

- Task: `task_01KX3J28AT309V2G9XFHJFVKT1` (CI-7)
- In scope: the new checker, its wiring, `pr-doctor` repair, documentation correction.
- Out of scope: the `contexts` lists themselves (the 14 entries are correct and unchanged); deleting classic branch protection (CEO action, post-merge).

## Version Impact

No published artifact changes. `tools/` and CI configuration only.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `.github/workflows/rewrite-ci.yml` (adds a required-tier gate to the `boundaries` job), `tools/gate-manifest.json`, `.github/branch-protection.md`
- Authority: `dec_mrdk63q3` (accepted, arbiter `human:zeyuli`), derived task `task_01KX3J28AT309V2G9XFHJFVKT1`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: delete classic branch protection after this merges (`dec_mrdk63q3`, CEO action)

## Verification

- Base `origin/main` SHA: `16babfa`
- Branch merge-base with `origin/main`: `16babfa`
- `npm run check:local` green on the rebased baseline (33.9s).
- Fail-closed without a token: `env -u GITHUB_TOKEN node tools/check-github-required-contexts.mjs …` → exit `1`. It does not skip.
- Against the live endpoint with a token: `GitHub required context check passed (14 contexts).` → exit `0`.
- **Positive control (tampered manifest)**: renaming one context to `integration-shard (7)` produces both `missing …` and `extra …` and exits `1`. Measured without a pipe — `$?` after `| head` reports `head`'s status, not node's, and did initially read as a false `0`.
- **Positive control (retry)**: forcing `attempts = 1` turns 3 of the new tests red; making `403` retryable turns 1 red. Restoring the code returns all 8 to green. The tests fail when the behaviour is removed, so their green is evidence.
- `tools/gate-manifest.json` confirmed byte-identical to its committed state after the tampering experiment.

## Review Evidence

- Self-review: CEO read the full diff of `check-github-required-contexts.mjs` and `pr-doctor.mjs` rather than the worker's report. The worker claimed it had verified `GITHUB_TOKEN` can read the branch-rules endpoint; it had actually used `gh auth token` (an OAuth token with `repo` scope), which is **not** the Actions `GITHUB_TOKEN`. That claim is retracted — see Residual Risk.
- Reviewer subagent: not used.
- Human review: pending.
- Blocking findings: one. The required check hard-depended on a single network call with no retry, on an API that returned transient `EOF` twice during this session's work. Fixed in `7fef10c` before opening this PR.

## Residual Risk

- **The load-bearing unknown is unverified until this PR's own CI runs.** Whether the Actions `GITHUB_TOKEN` with `permissions: contents: read` can read `GET /repos/{o}/{r}/rules/branches/main` has not been demonstrated. Documentation says repo read suffices. If it cannot, the `boundaries` job goes red on this PR — which is the correct, fail-closed outcome, and this PR becomes its own positive control. It must not be "fixed" by skipping the check.
- Every PR now depends on one GitHub API call in a required job. Retries cover transient faults; a sustained API outage will block merges. That is the intended trade for making enforcement-surface drift impossible to miss.
- Classic branch protection still exists, so `main` still has two enforcement surfaces until the post-merge CEO action. They are currently in agreement (14 contexts each, verified by reading both).
- `check-gate-surface.mjs` still validates the manifest against a local Markdown document that the same PR can rewrite. Unchanged by this PR.

## References

- Task: `task_01KX3J28AT309V2G9XFHJFVKT1`
- Evidence: fact `F-2F2E3WT8` (two enforcement surfaces, ruleset drift, `#512` `BLOCKED` → `CLEAN`)
- Review: `dec_mrdk63q3`

---

# 中文

## 概要

把 `main` 收敛为**单一**的 required-status-checks 执法面，然后用机器校验它。此前这条约束同时住在两个地方——classic branch protection 与 repository ruleset `18576233`——而 GitHub 对二者取**并集**。只改其中一个而漏掉另一个，**不会让 CI 变红**，只会让 PR 永远停在一个再也不会报告的 check 上。

## 改动内容

- 新增 `tools/check-github-required-contexts.mjs`（含测试，`tier: pr-required`，挂在 `boundaries` job）。它断言 `GET /repos/{owner}/{repo}/rules/branches/main` 返回的 `required_status_checks` contexts 与 `gate-manifest.json` 的 `executionSurfaces.branchProtection.contexts` 双向相等。manifest 侧为空、API 侧为空、以及端点里根本没有 `required_status_checks` 规则，三种情况全部 fail-closed。
- 只重试重试能修的东西：传输层故障、`429`、`5xx`，线性退避。`4xx` 是一个**答案**而不是故障——token 权限不足必须第一次尝试就失败并保持红色，不能被重试成沉默。重试预算耗尽仍然抛错。
- 修复 `tools/pr-doctor.mjs`。它此前在 `try/catch` 里读 `branches/main/protection`，失败时**静默返回一份写死的、分片之前的旧 context 清单**——也就是说，一旦删掉 classic branch protection，这个排查队列故障的工具就会拿着陈旧数据继续汇报，且不告诉任何人。它还在解析 `.mergify.yml` 的 `merge_conditions`，而该字段自 in-place checks 启用起就是 `[]`。现改为读 branch-rules 端点、取数失败大声失败、并复用 `parseMergifyQueueCheckSuccessContexts` 读 `queue_conditions`。
- 更正 `.github/branch-protection.md`：其 "Admin Bypass" 段描述了一个**不存在**的能力（ruleset 的 `bypass_actors: []` 且 `current_user_can_bypass: "never"`，仓库管理员同样无法绕过 required checks）。

本 PR **不**删除 classic branch protection。那是合入之后的最后一步，顺序是刻意的：`pr-doctor` 必须先指向 ruleset，否则中间会存在一个"排障工具静默使用陈旧 fallback"的窗口。

## 任务与范围

- 任务：`task_01KX3J28AT309V2G9XFHJFVKT1`（CI-7）
- 范围内：新 checker 及其接线、`pr-doctor` 修复、文档更正。
- 范围外：contexts 清单本身（14 项是对的，未改动）；删除 classic branch protection（CEO 动作，合入后执行）。

## 版本影响

无发布产物变化，仅 `tools/` 与 CI 配置。

## 治理声明

- 触碰 protected surface：是
- 范围：`.github/workflows/rewrite-ci.yml`（向 `boundaries` job 新增 required 层门）、`tools/gate-manifest.json`、`.github/branch-protection.md`
- 授权：`dec_mrdk63q3`（accepted，arbiter `human:zeyuli`），派生任务 `task_01KX3J28AT309V2G9XFHJFVKT1`
- 机器校验边界：本 PR 只断言声明存在；声明是否为真、是否充分由复核者判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：本 PR 合入后删除 classic branch protection（`dec_mrdk63q3`，CEO 动作）

## 验证

- 基线 `origin/main` SHA：`16babfa`
- 分支与 `origin/main` 的 merge-base：`16babfa`
- rebase 到新基线后 `npm run check:local` 全绿（33.9s）。
- 无 token 时 fail-closed：`env -u GITHUB_TOKEN node tools/check-github-required-contexts.mjs …` → exit `1`。它不会跳过。
- 带 token 打真实端点：`GitHub required context check passed (14 contexts).` → exit `0`。
- **阳性对照（篡改 manifest）**：把某个 context 改名为 `integration-shard (7)`，同时报出 `missing …` 与 `extra …`，exit `1`。该测量未经管道——`| head` 之后的 `$?` 取的是 `head` 的退出码而非 node 的，最初正是因此读出了一个假的 `0`。
- **阳性对照（重试）**：强制 `attempts = 1` 使 3 条新测试变红；让 `403` 也可重试使 1 条变红；恢复代码后 8 条全绿。测试在行为被移除时会失败，因此它们的绿色才算证据。
- 篡改实验之后，确认 `tools/gate-manifest.json` 与其已提交状态逐字节一致。

## 审查证据

- 自审：CEO 读的是 `check-github-required-contexts.mjs` 与 `pr-doctor.mjs` 的完整 diff，而不是 worker 的汇报。worker 声称已验证 `GITHUB_TOKEN` 能读 branch-rules 端点；它实际用的是 `gh auth token`（scope 为 `repo` 的 OAuth token），**那不是** Actions 的 `GITHUB_TOKEN`。该断言已撤回，见残余风险。
- 复核 subagent：未使用。
- 人类复核：待办。
- 阻塞性发现：一处。该 required check 曾硬依赖单次网络调用且零重试，而这个 API 在本次工作期间两次返回瞬时 `EOF`。已在 `7fef10c` 中于开 PR 前修复。

## 残余风险

- **本任务唯一承重的未知，在本 PR 自己的 CI 跑起来之前仍未验证。** Actions 的 `GITHUB_TOKEN` 配 `permissions: contents: read` 能否读 `GET /repos/{o}/{r}/rules/branches/main`，尚无实证。文档称 repo read 即可。若不能，`boundaries` 会在本 PR 上变红——那正是正确的 fail-closed 结果，本 PR 也就成了它自己的阳性对照。**不得**用"跳过这个 check"来"修好"它。
- 此后每个 PR 的 required job 都依赖一次 GitHub API 调用。重试覆盖瞬时故障；持续性 API 故障会阻塞合并。这是为"让执法面漂移无法被忽视"付出的、有意为之的代价。
- classic branch protection 目前仍然存在，因此在合入后的 CEO 动作之前，`main` 仍有两个执法面。二者当前一致（各 14 项，已逐面读取确认）。
- `check-gate-surface.mjs` 仍以本地 Markdown 文档为权威校验 manifest，而该文档可被同一个 PR 改写。本 PR 未改变这一点。

## 关联材料

- 任务：`task_01KX3J28AT309V2G9XFHJFVKT1`
- 证据：fact `F-2F2E3WT8`（双执法面、ruleset 漂移、`#512` 由 `BLOCKED` 转 `CLEAN`）
- 复核：`dec_mrdk63q3`
