### PR TITLE
fix: preserve decision bodies on implicit writes

### DIFF
--- a/packages/application/src/decision-write-service.ts
+++ b/packages/application/src/decision-write-service.ts
@@ -223,10 +223,18 @@ function transitionDecision(
     arbiter: request.arbiter,
     decidedAt: request.decidedAt ?? fallbackDecidedAt
   };
+  const judgmentOnlySection = kind === "decision_accept" ? judgmentOnlyBodySection(request) : undefined;
+  const explicitBody = request.body !== undefined && judgmentOnlySection
+    ? appendSectionToExplicitBody(request.body, judgmentOnlySection)
+    : request.body;
   return writeDecision(options.coordinator, hashPayload, kind, next, {
     ...request,
-    body: kind === "decision_accept" ? withJudgmentOnlyBody(request) : request.body
-  }, request.current);
+    body: explicitBody
+  }, request.current, {
+    kind: "snapshot",
+    expectedWatermark: request.current._coordinatorWatermark ?? null,
+    ...(request.body === undefined && judgmentOnlySection ? { appendBody: judgmentOnlySection } : {})
+  });
 }
 
 function acceptEvidenceFloor(decision: DecisionPackage, judgmentOnlyRationale?: string): DecisionWriteRejected | null {
@@ -240,11 +248,14 @@ function acceptEvidenceFloor(decision: DecisionPackage, judgmentOnlyRationale?: 
   return hasEvidence ? null : rejection(decision.decision_id, "decision_accept requires at least one evidence relation from a claim anchor, or --judgment-only <rationale>");
 }
 
-function withJudgmentOnlyBody(request: DecisionTransitionRequest): string | undefined {
+function judgmentOnlyBodySection(request: DecisionTransitionRequest): string | undefined {
   const rationale = request.judgmentOnlyRationale?.trim();
-  if (!rationale) return request.body;
-  const existing = request.body?.trimEnd() ?? "";
-  const section = `## Judgment-only acceptance\n\n${rationale}`;
+  return rationale ? `## Judgment-only acceptance\n\n${rationale}` : undefined;
+}
+
+function appendSectionToExplicitBody(body: string, section: string): string {
+  const existing = body.trimEnd();
+  if (existing.includes(section)) return body;
   return existing ? `${existing}\n\n${section}` : section;
 }
 
@@ -281,7 +292,7 @@ function writeDecision(
     payload: {
       decision,
       ...(request.taskWrites && request.taskWrites.length > 0 ? { taskWrites: request.taskWrites } : {}),
-      ...(request.body ? { body: request.body } : {}),
+      ...(request.body !== undefined ? { body: request.body } : {}),
       writeMode: writeMode ?? {
         kind: "snapshot",
         expectedWatermark: previous?._coordinatorWatermark ?? null
@@ -292,7 +303,7 @@ function writeDecision(
 }
 
 type DecisionDocumentWriteMode =
-  | { readonly kind: "snapshot"; readonly expectedWatermark?: string | null }
+  | { readonly kind: "snapshot"; readonly expectedWatermark?: string | null; readonly appendBody?: string }
   | { readonly kind: "append_relation"; readonly relation: EntityRelationRecord };
 
 function validateDecisionWrite(decision: DecisionPackage, previous?: DecisionPackage): DecisionWriteRejected | null {

--- a/packages/application/test/decision-write-service.test.ts
+++ b/packages/application/test/decision-write-service.test.ts
@@ -52,7 +52,7 @@ test("decision write service proposes and accepts through WriteCoordinator with 
   assert.equal((enqueued[1]?.payload as { decision?: DecisionPackage }).decision?.decidedAt, "2026-07-02T00:00:00Z");
 });
 
-test("decision accept permits explicit judgment-only rationale and records it in body", () => {
+test("decision accept emits an append-only body mutation for judgment-only rationale", () => {
   const enqueued: WriteOp[] = [];
   const service = makeDecisionWriteService({
     coordinator: fakeCoordinator(enqueued),
@@ -68,9 +68,13 @@ test("decision accept permits explicit judgment-only rationale and records it in
   }));
 
   assert.deepEqual(result, { decisionId: "dec_TEST", state: "active" });
-  const payload = enqueued[0]?.payload as { readonly body?: string };
-  assert.match(payload.body ?? "", /## Judgment-only acceptance/u);
-  assert.match(payload.body ?? "", /CEO accepted this as a judgment-only policy choice/u);
+  const payload = enqueued[0]?.payload as {
+    readonly body?: string;
+    readonly writeMode?: { readonly appendBody?: string };
+  };
+  assert.equal(payload.body, undefined);
+  assert.match(payload.writeMode?.appendBody ?? "", /## Judgment-only acceptance/u);
+  assert.match(payload.writeMode?.appendBody ?? "", /CEO accepted this as a judgment-only policy choice/u);
 });
 
 test("decision write service rejects invalid arbiter and unsupported transitions", () => {

--- a/packages/cli/src/cli/parsers/decision.ts
+++ b/packages/cli/src/cli/parsers/decision.ts
@@ -53,7 +53,11 @@ export function parseDecisionArgs(args: ReadonlyArray<string>, rootDir: string, 
     const arbiter = readOption(args, "--arbiter");
     if (arbiter && !isActorRef(arbiter)) return invalidActor();
     const judgmentOnlyRationale = readOption(args, "--judgment-only");
-    if (op === "accept" && args.includes("--judgment-only") && (!judgmentOnlyRationale || judgmentOnlyRationale.trim().length === 0)) {
+    if (op === "accept" && args.includes("--judgment-only") && (
+      !judgmentOnlyRationale ||
+      judgmentOnlyRationale.trim().length === 0 ||
+      judgmentOnlyRationale.trim().startsWith("--")
+    )) {
       return { ok: false, error: cliError(CliErrorCode.MissingReason, "Use decision accept <decision-id> --judgment-only <rationale>.") };
     }
     return parsedDecision(rootDir, json, {

--- a/packages/cli/test/decision-coverage-cli.test.ts
+++ b/packages/cli/test/decision-coverage-cli.test.ts
@@ -158,6 +158,173 @@ test("CLI decision accept records judgment-only rationale", () => {
   });
 });
 
+test("CLI decision judgment-only accept appends without changing existing body bytes", () => {
+  withTempRoot((rootDir) => {
+    const originalBody = "Original rationale.\n\n## Evidence\n\nLine two.\n";
+    runJson(rootDir, [
+      "decision", "propose",
+      "--id", "dec_JUDGMENT_BODY_PRESERVE",
+      "--title", "Judgment body preservation",
+      "--question", "Does judgment-only acceptance preserve the existing body?",
+      "--chosen", "Preserve then append",
+      "--rejected", "Replace the body",
+      "--why-not", "The existing rationale is an auditable asset",
+      "--body", originalBody
+    ]);
+    const decisionPath = path.join(rootDir, "harness/decisions/decision-dec_JUDGMENT_BODY_PRESERVE/decision.md");
+    const before = decisionBody(readFileSync(decisionPath, "utf8"));
+
+    const result = runJson(rootDir, [
+      "decision", "accept", "dec_JUDGMENT_BODY_PRESERVE",
+      "--arbiter", "human:ZeyuLi",
+      "--judgment-only", "The human arbiter accepts this policy choice."
+    ]);
+
+    assert.equal(result.ok, true);
+    const after = decisionBody(readFileSync(decisionPath, "utf8"));
+    assert.equal(after.slice(0, before.length), before);
+    assert.match(after.slice(before.length), /## Judgment-only acceptance\n\nThe human arbiter accepts this policy choice\./u);
+  });
+});
+
+test("CLI decision amend append leaves the existing body byte-for-byte unchanged", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, [
+      "decision", "propose",
+      "--id", "dec_AMEND_BODY_PRESERVE",
+      "--title", "Amend body preservation",
+      "--question", "Does structured append preserve the body?",
+      "--chosen", "Preserve the body",
+      "--rejected", "Rebuild the body",
+      "--why-not", "Structured amendments do not own prose",
+      "--body", "Original rationale.\n\nSecond paragraph."
+    ]);
+    const decisionPath = path.join(rootDir, "harness/decisions/decision-dec_AMEND_BODY_PRESERVE/decision.md");
+    const before = decisionBody(readFileSync(decisionPath, "utf8"));
+
+    const result = runJson(rootDir, [
+      "decision", "amend", "dec_AMEND_BODY_PRESERVE",
+      "--append", "claims:{\"text\":\"A newly structured claim\"}"
+    ]);
+
+    assert.equal(result.ok, true);
+    const after = decisionBody(readFileSync(decisionPath, "utf8"));
+    assert.equal(after, before);
+  });
+});
+
+test("CLI decision amend explicit body still replaces the existing body", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, [
+      "decision", "propose",
+      "--id", "dec_EXPLICIT_BODY_REPLACE",
+      "--title", "Explicit body replacement",
+      "--question", "Can an explicit body replace existing prose?",
+      "--chosen", "Allow explicit replacement",
+      "--rejected", "Forbid all replacement",
+      "--why-not", "The body flag is the deliberate replacement surface",
+      "--body", "Old body that should be replaced."
+    ]);
+
+    const result = runJson(rootDir, [
+      "decision", "amend", "dec_EXPLICIT_BODY_REPLACE",
+      "--body", "New body supplied explicitly."
+    ]);
+
+    assert.equal(result.ok, true);
+    const body = decisionBody(readFileSync(path.join(rootDir, "harness/decisions/decision-dec_EXPLICIT_BODY_REPLACE/decision.md"), "utf8"));
+    assert.match(body, /New body supplied explicitly\./u);
+    assert.doesNotMatch(body, /Old body that should be replaced\./u);
+  });
+});
+
+test("CLI decision accept rejects a flag-like judgment-only rationale without changing the file", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, [
+      "decision", "propose",
+      "--id", "dec_FLAG_RATIONALE",
+      "--title", "Flag rationale validation",
+      "--question", "Should flag-like rationale tokens be rejected?",
+      "--chosen", "Reject flag-like rationale",
+      "--rejected", "Store the token literally",
+      "--why-not", "A mistyped option is not a judgment rationale",
+      "--body", "Body must survive a rejected command."
+    ]);
+    const decisionPath = path.join(rootDir, "harness/decisions/decision-dec_FLAG_RATIONALE/decision.md");
+    const before = readFileSync(decisionPath, "utf8");
+
+    const result = runJson(rootDir, [
+      "decision", "accept", "dec_FLAG_RATIONALE",
+      "--arbiter", "human:ZeyuLi",
+      "--judgment-only", "--note"
+    ], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error?.code, "missing_reason");
+    assert.equal(readFileSync(decisionPath, "utf8"), before);
+  });
+});
+
+test("CLI decision accept rejects a whitespace-prefixed flag-like rationale", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, [
+      "decision", "propose",
+      "--id", "dec_SPACED_FLAG_RATIONALE",
+      "--title", "Spaced flag rationale validation",
+      "--question", "Should a trimmed flag-like rationale be rejected?",
+      "--chosen", "Reject after trimming",
+      "--rejected", "Store the trimmed token",
+      "--why-not", "Whitespace cannot turn an option into rationale",
+      "--body", "Body must survive a rejected command."
+    ]);
+    const decisionPath = path.join(rootDir, "harness/decisions/decision-dec_SPACED_FLAG_RATIONALE/decision.md");
+    const before = readFileSync(decisionPath, "utf8");
+
+    const result = runJson(rootDir, [
+      "decision", "accept", "dec_SPACED_FLAG_RATIONALE",
+      "--arbiter", "human:ZeyuLi",
+      "--judgment-only", "  --note"
+    ], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error?.code, "missing_reason");
+    assert.equal(readFileSync(decisionPath, "utf8"), before);
+  });
+});
+
+test("CLI repeated judgment-only accept keeps a single existing judgment section", () => {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, [
+      "decision", "propose",
+      "--id", "dec_REPEAT_JUDGMENT",
+      "--title", "Repeated judgment acceptance",
+      "--question", "Should repeated acceptance duplicate the judgment section?",
+      "--chosen", "Keep one section",
+      "--rejected", "Append duplicate headings",
+      "--why-not", "Repeated lifecycle writes must be body-idempotent",
+      "--body", "Original rationale."
+    ]);
+    const decisionPath = path.join(rootDir, "harness/decisions/decision-dec_REPEAT_JUDGMENT/decision.md");
+    runJson(rootDir, [
+      "decision", "accept", "dec_REPEAT_JUDGMENT",
+      "--arbiter", "human:ZeyuLi",
+      "--judgment-only", "Initial judgment rationale."
+    ]);
+    const afterFirstAccept = decisionBody(readFileSync(decisionPath, "utf8"));
+
+    const repeated = runJson(rootDir, [
+      "decision", "accept", "dec_REPEAT_JUDGMENT",
+      "--arbiter", "human:ZeyuLi",
+      "--judgment-only", "A later accept supplies different words."
+    ]);
+
+    assert.equal(repeated.ok, true);
+    const afterRepeatedAccept = decisionBody(readFileSync(decisionPath, "utf8"));
+    assert.equal(afterRepeatedAccept, afterFirstAccept);
+    assert.equal(afterRepeatedAccept.split("## Judgment-only acceptance").length - 1, 1);
+  });
+});
+
 test("CLI decision reckon fails closed on uncovered load-bearing claims", () => {
   withTempRoot((rootDir) => {
     const task = runJson(rootDir, ["task", "create", "--title", "Reckon Evidence"]);
@@ -421,6 +588,10 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
     const failure = error as { readonly stdout?: string };
     return unwrapCommandReceipt(JSON.parse(failure.stdout ?? "{}") as Record<string, any>);
   }
+}
+
+function decisionBody(document: string): string {
+  return document.replace(/^---\r?\n[\s\S]*?\r?\n---/u, "");
 }
 
 function writeFile(rootDir: string, relativePath: string, body: string): void {

--- a/packages/kernel/src/domain/decision-document.ts
+++ b/packages/kernel/src/domain/decision-document.ts
@@ -11,7 +11,7 @@ export interface DecisionDocumentTaskWrite {
 }
 
 export type DecisionDocumentWriteMode =
-  | { readonly kind: "snapshot"; readonly expectedWatermark?: string | null }
+  | { readonly kind: "snapshot"; readonly expectedWatermark?: string | null; readonly appendBody?: string }
   | { readonly kind: "append_relation"; readonly relation: EntityRelationRecord };
 
 export interface DecisionDocumentPayload {
@@ -28,11 +28,11 @@ export function isDecisionDocumentPayload(payload: unknown): payload is Decision
   return candidate.body === undefined || typeof candidate.body === "string";
 }
 
-export function serializeDecisionDocument(payload: DecisionDocumentPayload, watermark: string): string {
+export function serializeDecisionDocument(payload: DecisionDocumentPayload, watermark: string, preservedBodyTail?: string): string {
   // This per-decision marker is the authoring op id. It is distinct from the
   // global write-watermark/v1 file that records committed coordinator state.
   const decision = { ...payload.decision, _coordinatorWatermark: watermark };
-  return [
+  const frontmatter = [
     "---",
     `schema: ${decision.schema}`,
     `decision_id: ${decision.decision_id}`,
@@ -61,11 +61,10 @@ export function serializeDecisionDocument(payload: DecisionDocumentPayload, wate
     ...decision.claims.map((entry) => `  - ${flowObject(entry)}`),
     "relations:",
     ...decision.relations.map((entry) => `  - ${flowObject(entry)}`),
-    "---",
-    "",
-    payload.body ?? `# ${decision.title}`,
-    ""
+    "---"
   ].join("\n");
+  if (preservedBodyTail !== undefined) return `${frontmatter}${preservedBodyTail}`;
+  return `${frontmatter}\n\n${payload.body ?? `# ${decision.title}`}\n`;
 }
 
 export function parseDecisionDocument(documentBody: string): DecisionDocumentPayload {

--- a/packages/kernel/src/store/write-journal-decision-documents.ts
+++ b/packages/kernel/src/store/write-journal-decision-documents.ts
@@ -25,11 +25,11 @@ export function writeDecisionDocument(rootInput: HarnessLayoutInput, op: WriteOp
   if (!isDecisionDocumentPayload(op.payload)) {
     rejectWrite(`${op.kind} op requires decision document payload: ${op.opId}`, op.entityId);
   }
-  const payload = op.payload.writeMode?.kind === "append_relation"
+  const materialized = op.payload.writeMode?.kind === "append_relation"
     ? appendDecisionRelationPayload(targetPath, op.payload)
     : casSnapshotPayload(targetPath, op);
   mkdirSync(path.dirname(targetPath), { recursive: true });
-  writeFileDurably(targetPath, serializeDecisionDocument(payload, op.opId));
+  writeFileDurably(targetPath, serializeDecisionDocument(materialized.payload, op.opId, materialized.bodyTail));
 }
 
 export function decisionDocumentTargetPath(rootInput: HarnessLayoutInput, op: Pick<WriteOp, "entityId" | "payload">): string {
@@ -41,13 +41,21 @@ export function decisionDocumentTargetPath(rootInput: HarnessLayoutInput, op: Pi
   return resolveHarnessLayout(rootInput).decisionDocumentPath(decisionId);
 }
 
-function casSnapshotPayload(targetPath: string, op: WriteOp): DecisionDocumentPayload {
+interface MaterializedDecisionDocument {
+  readonly payload: DecisionDocumentPayload;
+  readonly bodyTail?: string;
+}
+
+function casSnapshotPayload(targetPath: string, op: WriteOp): MaterializedDecisionDocument {
   if (!isDecisionDocumentPayload(op.payload)) {
     rejectWrite(`${op.kind} op requires decision document payload: ${op.opId}`, op.entityId);
   }
   const mode = op.payload.writeMode;
-  if (mode?.kind !== "snapshot" || !("expectedWatermark" in mode)) return op.payload;
-  const currentWatermark = existsSync(targetPath) ? readDecisionWatermark(readFileSync(targetPath, "utf8")) : null;
+  const currentDocument = existsSync(targetPath) ? readFileSync(targetPath, "utf8") : null;
+  if (mode?.kind !== "snapshot" || !("expectedWatermark" in mode)) {
+    return bodyPreservingSnapshot(op.payload, currentDocument);
+  }
+  const currentWatermark = currentDocument === null ? null : readDecisionWatermark(currentDocument);
   if (currentWatermark !== (mode.expectedWatermark ?? null)) {
     rejectCasWatermarkMismatch({
       entityId: op.entityId,
@@ -55,13 +63,13 @@ function casSnapshotPayload(targetPath: string, op: WriteOp): DecisionDocumentPa
       currentWatermark
     });
   }
-  return op.payload;
+  return bodyPreservingSnapshot(op.payload, currentDocument);
 }
 
 function appendDecisionRelationPayload(
   targetPath: string,
   payload: DecisionDocumentPayload
-): DecisionDocumentPayload {
+): MaterializedDecisionDocument {
   const mode = payload.writeMode;
   if (!isDecisionDocumentPayload(payload) || mode?.kind !== "append_relation") {
     rejectWrite("append relation payload requires decision document payload");
@@ -70,18 +78,49 @@ function appendDecisionRelationPayload(
     const relations = payload.decision.relations.some((relation) => relation.relation_id === mode.relation.relation_id)
       ? payload.decision.relations
       : [...payload.decision.relations, mode.relation];
-    return { ...payload, decision: { ...payload.decision, relations } };
+    return { payload: { ...payload, decision: { ...payload.decision, relations } } };
   }
 
-  const current = parseDecisionDocument(readFileSync(targetPath, "utf8"));
+  const currentDocument = readFileSync(targetPath, "utf8");
+  const current = parseDecisionDocument(currentDocument);
+  const bodyTail = decisionBodyTail(currentDocument);
   if (current.decision.relations.some((relation) => relation.relation_id === mode.relation.relation_id)) {
-    return current;
+    return { payload: current, bodyTail };
   }
   return {
-    ...current,
-    decision: {
-      ...current.decision,
-      relations: [...current.decision.relations, mode.relation]
-    }
+    payload: {
+      ...current,
+      decision: {
+        ...current.decision,
+        relations: [...current.decision.relations, mode.relation]
+      }
+    },
+    bodyTail
   };
+}
+
+function bodyPreservingSnapshot(
+  payload: DecisionDocumentPayload,
+  currentDocument: string | null
+): MaterializedDecisionDocument {
+  if (payload.body !== undefined || currentDocument === null) return { payload };
+  const currentBodyTail = decisionBodyTail(currentDocument);
+  const appendBody = payload.writeMode?.kind === "snapshot" ? payload.writeMode.appendBody : undefined;
+  return {
+    payload,
+    bodyTail: appendBody ? appendBodySection(currentBodyTail, appendBody) : currentBodyTail
+  };
+}
+
+function decisionBodyTail(document: string): string {
+  const frontmatter = /^---\r?\n[\s\S]*?\r?\n---/u.exec(document)?.[0];
+  if (!frontmatter) rejectWrite("decision document missing frontmatter");
+  return document.slice(frontmatter.length);
+}
+
+function appendBodySection(currentBodyTail: string, section: string): string {
+  const heading = section.split(/\r?\n/u, 1)[0];
+  if (heading && currentBodyTail.split(/\r?\n/u).includes(heading)) return currentBodyTail;
+  const separator = currentBodyTail.endsWith("\n\n") ? "" : currentBodyTail.endsWith("\n") ? "\n" : "\n\n";
+  return `${currentBodyTail}${separator}${section}\n`;
 }

--- a/packages/kernel/test/store/conditional-delta-writes.test.ts
+++ b/packages/kernel/test/store/conditional-delta-writes.test.ts
@@ -36,6 +36,8 @@ test("decision relation append deltas from the same base snapshot both survive",
     const coordinator = makeJournaledWriteCoordinator({ rootDir });
     Effect.runSync(coordinator.enqueue(decisionSnapshotOp("decision-base", decisionPackage({ state: "active" }), null)));
     Effect.runSync(coordinator.flush("explicit"));
+    const decisionPath = path.join(rootDir, "harness/decisions/decision-dec_TEST/decision.md");
+    const bodyBeforeRelations = decisionBody(readFileSync(decisionPath, "utf8"));
 
     const base = decisionPackage({ state: "active", _coordinatorWatermark: "decision-base" });
     const relationA = relationRecord("decision/dec_TEST/C1", "fact/task_fact_owner/F-AAAA1111");
@@ -45,13 +47,14 @@ test("decision relation append deltas from the same base snapshot both survive",
 
     Effect.runSync(coordinator.flush("explicit"));
 
-    const body = readFileSync(path.join(rootDir, "harness/decisions/decision-dec_TEST/decision.md"), "utf8");
+    const body = readFileSync(decisionPath, "utf8");
     const decision = parseDecisionDocument(body).decision;
     assert.deepEqual(decision.relations.map((relation) => relation.relation_id).sort(), [
       relationA.relation_id,
       relationB.relation_id
     ].sort());
     assert.equal(decision._coordinatorWatermark, "relation-b");
+    assert.equal(decisionBody(body), bodyBeforeRelations);
   });
 });
 
@@ -95,6 +98,69 @@ test("stale decision snapshot CAS is rejected with retryable current watermark",
   });
 });
 
+test("decision snapshot without an explicit body preserves the existing body bytes", () => {
+  withTempStore((rootDir) => {
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    const originalBody = "Original rationale.\n\n## Evidence\n\nByte-stable prose.\n";
+    Effect.runSync(coordinator.enqueue(decisionSnapshotOp(
+      "decision-base",
+      decisionPackage({ state: "proposed" }),
+      null,
+      originalBody
+    )));
+    Effect.runSync(coordinator.flush("explicit"));
+    const decisionPath = path.join(rootDir, "harness/decisions/decision-dec_TEST/decision.md");
+    const before = decisionBody(readFileSync(decisionPath, "utf8"));
+
+    Effect.runSync(coordinator.enqueue(decisionSnapshotOp(
+      "decision-amend",
+      decisionPackage({ state: "proposed", title: "Amended title", _coordinatorWatermark: "decision-base" }),
+      "decision-base"
+    )));
+    Effect.runSync(coordinator.flush("explicit"));
+
+    assert.equal(decisionBody(readFileSync(decisionPath, "utf8")), before);
+  });
+});
+
+test("decision snapshot body append is idempotent by heading across different rationales", () => {
+  withTempStore((rootDir) => {
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    const section = "## Judgment-only acceptance\n\nThe arbiter accepts this policy choice.";
+    Effect.runSync(coordinator.enqueue(decisionSnapshotOp(
+      "decision-base",
+      decisionPackage({ state: "proposed" }),
+      null,
+      "Original rationale."
+    )));
+    Effect.runSync(coordinator.flush("explicit"));
+
+    Effect.runSync(coordinator.enqueue(decisionSnapshotOp(
+      "decision-accept-one",
+      decisionPackage({ state: "active", _coordinatorWatermark: "decision-base" }),
+      "decision-base",
+      undefined,
+      section
+    )));
+    Effect.runSync(coordinator.flush("explicit"));
+    const decisionPath = path.join(rootDir, "harness/decisions/decision-dec_TEST/decision.md");
+    const afterFirstAppend = decisionBody(readFileSync(decisionPath, "utf8"));
+
+    Effect.runSync(coordinator.enqueue(decisionSnapshotOp(
+      "decision-accept-two",
+      decisionPackage({ state: "active", _coordinatorWatermark: "decision-accept-one" }),
+      "decision-accept-one",
+      undefined,
+      "## Judgment-only acceptance\n\nA later acceptance uses different words."
+    )));
+    Effect.runSync(coordinator.flush("explicit"));
+    const afterSecondAppend = decisionBody(readFileSync(decisionPath, "utf8"));
+
+    assert.equal(afterSecondAppend, afterFirstAppend);
+    assert.equal(afterSecondAppend.split("## Judgment-only acceptance").length - 1, 1);
+  });
+});
+
 function factAppendOp(opId: string, taskId: string, record: FactRecord) {
   return {
     opId,
@@ -110,19 +176,31 @@ function factAppendOp(opId: string, taskId: string, record: FactRecord) {
   };
 }
 
-function decisionSnapshotOp(opId: string, decision: DecisionPackage, expectedWatermark: string | null) {
+function decisionSnapshotOp(
+  opId: string,
+  decision: DecisionPackage,
+  expectedWatermark: string | null,
+  body?: string,
+  appendBody?: string
+) {
   return {
     opId,
     entityId: decisionEntityId(decision.decision_id),
     kind: "decision_amend" as const,
     payload: {
       decision,
+      ...(body !== undefined ? { body } : {}),
       writeMode: {
         kind: "snapshot",
-        expectedWatermark
+        expectedWatermark,
+        ...(appendBody !== undefined ? { appendBody } : {})
       }
     }
   };
+}
+
+function decisionBody(document: string): string {
+  return document.replace(/^---\r?\n[\s\S]*?\r?\n---/u, "");
 }
 
 function decisionRelationAppendOp(opId: string, current: DecisionPackage, relation: EntityRelationRecord) {


### PR DESCRIPTION
# English

## Summary

Fix a P0 write-path defect (decision dec_mreaq2ge): `ha decision accept --judgment-only` and `ha decision amend --append` silently replaced the entire existing decision body with a template while returning ok. Observed four times in one day, destroying ~60 lines of ruling rationale that had to be recovered from the ledger's git history. The fix installs an invariant at the decision materialization boundary: when no explicit `--body` is provided, the existing body bytes are preserved verbatim.

## What Changed

- `packages/kernel/src/store/write-journal-decision-documents.ts`: at the single materialization boundary shared by all decision writes, distinguish "body not provided" from "explicit body"; snapshot updates and relation appends carry the current on-disk body tail byte-for-byte instead of rebuilding from the title template. Added `appendBody` semantics for judgment-only sections (appended after CAS validation).
- `packages/kernel/src/domain/decision-document.ts`: `snapshot` write mode gains `appendBody`; the serializer accepts a preserved raw body tail and only rebuilds frontmatter for that path.
- `packages/application/src/decision-write-service.ts`: judgment-only accept without explicit body emits an append mutation instead of a fake full body; explicit `--body` (including explicit empty string) remains the only legal full replacement.
- `packages/cli/src/cli/parsers/decision.ts`: a `--judgment-only` rationale that starts with `--` after trim is rejected with `missing_reason` and a non-zero exit (previously the literal flag text, e.g. `--note`, was recorded as the ruling).
- Regression tests (red-light reproduced before the fix, 3 of 4 failing): accept preserves body prefix bytes; amend append leaves body byte-identical; explicit body still replaces; flag-like rationale is rejected with the file unchanged; repeated accept is idempotent at the section-title level.

## Task And Scope

- Harness task: task_01KX4WJX3WDF15H2WF03P6272M
- Branch: fix/decision-body-preserve
- Public scope: kernel decision document store/serializer, application decision write service, CLI decision parser, regression tests
- Private planning/evidence updated: yes (task package impl report)
- Out of scope: multi-entry judgment history schema (documented tradeoff: title-level idempotency, no timestamps)

## Version Impact

- Version: no version change because this is a defect fix shipping with the next planned release
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: n/a (no gate-manifest, CI workflow, or write-road registry changes; existing decision write surface repaired in place)
- Authority: decision dec_mreaq2ge (body preservation invariant, four incidents evidenced)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: aa124bae1619e5fd6c90d93bbb735a63f537d893
- Branch merge-base with `origin/main`: aa124bae1619e5fd6c90d93bbb735a63f537d893
- Last `git fetch origin` time: 2026-07-10 (worker rebased onto the PR#521 merge commit before final gate run)
- Sync method: rebase
- Public diff command: `git diff origin/main..fix/decision-body-preserve`
- Private evidence commit/path: task package impl report (red-light reproduction, tradeoff rationale)
- Reviewer evidence path: task package `artifacts/impl-report.md`
- GitHub Actions `rewrite-ci` run URL: pending (will be linked by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (via `check:local`, 16 steps green, 31.8s)
- [x] `npm run typecheck`
- [x] `npm test` (fast 259/259, contract 335/335 via `check:local`; targeted decision coverage CLI suite 20/20)
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full integration and GUI lanes locally (CI shards cover them per local fast-tier policy dec_mr9fs0bc)

## Review Evidence

- Self-review: red-light reproduction before fix (1 passed / 3 failed on the mission regressions), then 20/20 green; independent code review pass with no Critical/Important findings
- Reviewer subagent: CEO independently re-ran `decision-coverage-cli.test.ts` in the worktree: 20/20 pass
- Human review: pending merge review
- Blocking findings: none

## Residual Risk

- Title-level idempotency: a repeated accept with a different rationale does not append a second judgment section (documented tradeoff; a multi-entry schema needs its own ruling on authoritative timestamps).
- Explicit `--body` still rebuilds the body slot under existing serializer rules (LF separators); this is the intended legal replacement path, not the byte-preservation path.

## References

- Task: task_01KX4WJX3WDF15H2WF03P6272M
- Evidence: task package `artifacts/impl-report.md`
- Review: decision dec_mreaq2ge

---

# 中文

## 概要

修复 P0 写路径缺陷（裁决 dec_mreaq2ge）：`ha decision accept --judgment-only` 与 `ha decision amend --append` 会静默把既有决策正文整体替换成模板并返回 ok。一天内四次实证，销毁约 60 行裁决理由，靠 ledger git 历史才恢复。修复在 decision 物化边界安装不变量：未显式提供 `--body` 时，既有正文 bytes 逐字节保全。

## 改动内容

- `packages/kernel/src/store/write-journal-decision-documents.ts`：在所有 decision 写入共用的物化边界统一区分「未提供 body」与「显式 body」；snapshot 更新与 relation append 逐字节携带磁盘上的原始正文尾部，不再按标题模板重建。judgment-only 节以 `appendBody` 语义在 CAS 校验后追加。
- `packages/kernel/src/domain/decision-document.ts`：snapshot 写模式新增 `appendBody`；serializer 接受已保全的原始正文尾部，该路径只重建 frontmatter。
- `packages/application/src/decision-write-service.ts`：未显式 body 的 judgment-only accept 改发 append mutation；显式 `--body`（含显式空串）仍是唯一合法整体替换。
- `packages/cli/src/cli/parsers/decision.ts`：`--judgment-only` 的 rationale 若 trim 后以 `--` 开头，报 `missing_reason` 非零退出（此前字面量如 `--note` 会被当裁决语入库）。
- 回归测试（修复前先打红灯，4 条使命回归 3 失败）：accept 保正文前缀 bytes、amend append 正文逐字节相等、显式 body 可替换、旗标样式 rationale 被拒且文件不变、重复 accept 标题级幂等。

## 任务与范围

- Harness 任务：task_01KX4WJX3WDF15H2WF03P6272M
- 分支：fix/decision-body-preserve
- 公开范围：kernel decision 文档存储/序列化、application decision 写服务、CLI decision 解析器、回归测试
- 私有计划 / 证据是否已更新：yes（任务包实施报告）
- 范围外：多条裁决语的条目化 schema（已记录取舍：标题级幂等、不引入时间戳）

## 版本影响

- 版本：不改版本，原因是缺陷修复随下一次计划发布一起出
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用（gate-manifest、CI workflow、write-road registry 零改动;原地修复既有 decision 写面）
- 依据：decision dec_mreaq2ge（正文保全不变量,四次事故实证）
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：aa124bae1619e5fd6c90d93bbb735a63f537d893
- 当前分支与 `origin/main` 的 merge-base：aa124bae1619e5fd6c90d93bbb735a63f537d893
- 最近一次 `git fetch origin` 时间：2026-07-10（worker 最终 gate 前已 rebase 到 PR#521 合并提交）
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main..fix/decision-body-preserve`
- 私有证据 commit/path：任务包实施报告（红灯复现、取舍理由）
- Reviewer 证据路径：任务包 `artifacts/impl-report.md`
- GitHub Actions `rewrite-ci` run URL：待 CI 生成后由本 PR checks 关联
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`（经 `check:local`,16 步全绿,31.8s）
- [x] `npm run typecheck`
- [x] `npm test`（fast 259/259、contract 335/335;定向 decision coverage CLI 20/20）
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：本地完整 integration/GUI lanes（按 dec_mr9fs0bc 本地 fast 档,交 CI 分片）

## 审查证据

- 自查：修复前红灯复现（使命回归 1 过 3 败）,修复后 20/20 绿;独立 code review 无 Critical/Important 遗留
- Reviewer subagent：CEO 在工作树独立复跑 decision-coverage-cli.test.ts:20/20 通过
- 人工审查：合并评审待进行
- 阻塞发现：无

## 残余风险

- 标题级幂等：换 rationale 的重复 accept 不追加第二节（已记录取舍;条目化 schema 需另裁权威时间来源）。
- 显式 `--body` 仍按既有 serializer 规则整体重建正文槽（LF 分隔）;这是有意保留的合法替换路径。

## 关联材料

- 任务：task_01KX4WJX3WDF15H2WF03P6272M
- 证据：任务包 `artifacts/impl-report.md`
- 审查：decision dec_mreaq2ge

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
