### PR TITLE
fix: connect remote clients to persistent daemon via pure stdio relay

### DIFF
--- a/packages/cli/src/commands/daemon/connect.ts
+++ b/packages/cli/src/commands/daemon/connect.ts
@@ -1,0 +1,90 @@
+import net from "node:net";
+import type { Readable, Writable } from "node:stream";
+import {
+  daemonIdFromEnv,
+  daemonUserRoot,
+  localUserDaemonEndpoint
+} from "../../../../daemon/src/index.ts";
+import { readOption } from "../../cli/parse-options.ts";
+
+export interface DaemonConnectStreams {
+  readonly input: Readable;
+  readonly output: Writable;
+  readonly error: Writable;
+}
+
+export async function runDaemonConnect(
+  args: ReadonlyArray<string>,
+  options: {
+    readonly env?: NodeJS.ProcessEnv;
+    readonly platform?: NodeJS.Platform;
+    readonly streams?: DaemonConnectStreams;
+  } = {}
+): Promise<number> {
+  const streams = options.streams ?? { input: process.stdin, output: process.stdout, error: process.stderr };
+  if (args.includes("--help") || args.includes("-h")) {
+    streams.output.write(`${renderDaemonConnectHelp()}\n`);
+    return 0;
+  }
+  if (!args.includes("--stdio")) {
+    streams.error.write("daemon connect requires --stdio; stdout is reserved for relayed daemon bytes.\n");
+    return 2;
+  }
+
+  const env = options.env ?? process.env;
+  const userRoot = readOption(args, "--user-root") ?? daemonUserRoot(env);
+  const endpoint = readOption(args, "--socket")
+    ?? localUserDaemonEndpoint(userRoot, daemonIdFromEnv(env), options.platform ?? process.platform);
+  try {
+    await connectDaemonStdio(endpoint, streams.input, streams.output);
+    return 0;
+  } catch (error) {
+    streams.error.write(
+      `No persistent daemon is listening at ${endpoint}. Start it with 'ha daemon start --service' and verify 'ha daemon status'. Cause: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    return 1;
+  }
+}
+
+export async function connectDaemonStdio(endpoint: string, input: Readable, output: Writable): Promise<void> {
+  const socket = await openDaemonEndpoint(endpoint);
+  await relayDaemonStreams(socket, input, output);
+}
+
+function openDaemonEndpoint(endpoint: string): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(endpoint);
+    const fail = (error: Error) => reject(error);
+    socket.once("error", fail);
+    socket.once("connect", () => {
+      socket.off("error", fail);
+      resolve(socket);
+    });
+  });
+}
+
+function relayDaemonStreams(socket: net.Socket, input: Readable, output: Writable): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const fail = (error: Error) => {
+      socket.destroy();
+      reject(error);
+    };
+    socket.once("error", fail);
+    input.once("error", fail);
+    output.once("error", fail);
+    socket.once("close", () => resolve());
+    input.pipe(socket);
+    socket.pipe(output, { end: false });
+  }).finally(() => {
+    input.unpipe(socket);
+    socket.unpipe(output);
+  });
+}
+
+function renderDaemonConnectHelp(): string {
+  return [
+    "Usage: ha daemon connect --stdio [--socket <endpoint>] [--user-root <path>]",
+    "",
+    "Relay stdin/stdout to an already-running local daemon without creating a runtime."
+  ].join("\n");
+}

--- a/packages/cli/src/commands/daemon/help.ts
+++ b/packages/cli/src/commands/daemon/help.ts
@@ -1,6 +1,6 @@
 export function renderDaemonHelp(): string {
   return [
-    "Usage: harness-anything daemon <start|status|stop|bootstrap-server|install-templates> [options]",
+    "Usage: harness-anything daemon <start|status|stop|connect|bootstrap-server|install-templates> [options]",
     "Alias: ha daemon <subcommand> [options]",
     "",
     "Commands:",
@@ -8,6 +8,7 @@ export function renderDaemonHelp(): string {
     "  start --foreground           Run the daemon service in the foreground.",
     "  status --json                Show lock holder, queue depth, connections, and version.",
     "  stop [--timeout-ms <ms>]     Signal the daemon and wait for queue drain and lock release.",
+    "  connect --stdio              Relay stdin/stdout to an already-running daemon.",
     "  repo <subcommand>            Register, list, or unregister daemon repositories.",
     "  bootstrap-server             Initialize a canonical team server repository.",
     "  install-templates --out DIR  Copy systemd, launchd, and Windows Service templates."

--- a/packages/cli/src/commands/daemon/serve-transport.ts
+++ b/packages/cli/src/commands/daemon/serve-transport.ts
@@ -1,0 +1,39 @@
+import {
+  createNamedPipeTransportServer,
+  createUnixSocketTransportServer,
+  type DaemonAuthenticationContext,
+  type DaemonTransportConnection,
+  type JsonRpcProtocolServer,
+  type NamedPipeTransportServer,
+  type UnixSocketTransportServer
+} from "../../../../daemon/src/index.ts";
+
+export interface DaemonLocalTransportOptions {
+  readonly daemonId: string;
+  readonly endpoint: string;
+  readonly platform?: NodeJS.Platform;
+  readonly createProtocolServer: (authContext: DaemonAuthenticationContext) => JsonRpcProtocolServer;
+  readonly onConnection?: (connection: DaemonTransportConnection) => void;
+  readonly onConnectionClosed?: (connection: DaemonTransportConnection) => void;
+}
+
+export function createDaemonLocalTransport(
+  options: DaemonLocalTransportOptions
+): UnixSocketTransportServer | NamedPipeTransportServer {
+  if ((options.platform ?? process.platform) === "win32") {
+    return createNamedPipeTransportServer({
+      daemonId: options.daemonId,
+      pipePath: options.endpoint,
+      createProtocolServer: options.createProtocolServer,
+      onConnection: options.onConnection,
+      onConnectionClosed: options.onConnectionClosed
+    });
+  }
+  return createUnixSocketTransportServer({
+    daemonId: options.daemonId,
+    socketPath: options.endpoint,
+    createProtocolServer: options.createProtocolServer,
+    onConnection: options.onConnection,
+    onConnectionClosed: options.onConnectionClosed
+  });
+}

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -30,6 +30,7 @@ export {
   daemonIdFromEnv,
   daemonUserRoot,
   localDaemonSocketPath,
+  localUserDaemonEndpoint,
   localUserDaemonSocketPath,
   requestLocalDaemonJsonRpc,
   resolveLocalDaemonTarget,
@@ -87,7 +88,7 @@ export async function runCommandThroughDaemon(
     if (error instanceof CliActorAttributionError) {
       return daemonActorAttributionReceipt(command, error);
     }
-    return daemonUnavailableReceipt(command, error);
+    return daemonUnavailableReceipt(command, error, config.mode === "remote" ? config.remote : undefined);
   }
 }
 
@@ -126,17 +127,7 @@ async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfi
 }
 
 async function runRemoteCommand(command: ParsedCommand, remote: RemoteDaemonConfig): Promise<CommandReceipt | CommandFailureReceipt> {
-  const child = spawn("ssh", [
-    remote.host,
-    remote.remoteHaPath,
-    "daemon",
-    "serve",
-    "--stdio",
-    "--repo",
-    remote.repoId,
-    "--root",
-    remote.remoteRoot
-  ], {
+  const child = spawn("ssh", remoteDaemonSshArgs(remote), {
     stdio: ["pipe", "pipe", "pipe"]
   });
   const remoteCommand = {
@@ -172,13 +163,16 @@ async function runWithLineClient(
   }
 }
 
-function daemonUnavailableReceipt(command: ParsedCommand, error: unknown): CommandFailureReceipt {
+function daemonUnavailableReceipt(command: ParsedCommand, error: unknown, remote?: RemoteDaemonConfig): CommandFailureReceipt {
+  const unavailableHint = remote
+    ? remoteDaemonUnavailableHint(remote)
+    : "Daemon unavailable. Start the daemon with 'ha daemon start --service' or check 'ha daemon status'.";
   const receipt = toCommandReceipt({
     ok: false,
     command: command.action.kind,
     error: cliError(
       CliErrorCode.JournalUnavailable,
-      `Daemon unavailable. Start the daemon with 'ha daemon start' or check 'ha daemon status'. Cause: ${error instanceof Error ? error.message : String(error)}`
+      `${unavailableHint} Cause: ${error instanceof Error ? error.message : String(error)}`
     )
   });
   if (receipt.ok) throw new Error("daemon unavailable receipt unexpectedly succeeded");
@@ -198,6 +192,14 @@ function daemonActorAttributionReceipt(command: ParsedCommand, error: CliActorAt
 function readMode(value: string | undefined): DaemonClientMode {
   if (value === "direct" || value === "local" || value === "remote") return value;
   return "direct";
+}
+
+export function remoteDaemonSshArgs(remote: RemoteDaemonConfig): ReadonlyArray<string> {
+  return [remote.host, remote.remoteHaPath, "daemon", "connect", "--stdio"];
+}
+
+export function remoteDaemonUnavailableHint(remote: RemoteDaemonConfig): string {
+  return `Remote daemon unavailable. Start the persistent daemon on ${remote.host} with '${remote.remoteHaPath} daemon start --service' and verify '${remote.remoteHaPath} daemon status'.`;
 }
 
 function commandForTarget(command: ParsedCommand, target: LocalDaemonTarget): ParsedCommand {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,8 +13,6 @@ import { makeLocalControllerService, makeRuntimeEventAppendPromise, makeRuntimeE
 import { appendParseFailureRuntimeEvent } from "./cli/parse-failure-runtime-event.ts";
 import {
   createJsonRpcProtocolServer,
-  createUnixSocketTransportServer,
-  serveSshExecBridge,
   type DaemonRepoAvailabilityFailure,
   type DaemonRepoNamespace,
   type DaemonAuthenticationContext
@@ -29,9 +27,11 @@ import {
   type DaemonConnectionStats,
   type DaemonServeHooks
 } from "./commands/daemon/productization.ts";
+import { runDaemonConnect } from "./commands/daemon/connect.ts";
+import { createDaemonLocalTransport } from "./commands/daemon/serve-transport.ts";
 import { runRegisteredCommandWithCliComposition } from "./composition/command-executor.ts";
 import { selectCliAdapterProvider } from "./composition/adapter-registry.ts";
-import { daemonIdFromEnv, daemonUserRoot, localUserDaemonSocketPath, runCommandThroughDaemon } from "./daemon/client.ts";
+import { daemonIdFromEnv, daemonUserRoot, localUserDaemonEndpoint, runCommandThroughDaemon } from "./daemon/client.ts";
 import { createCliCommandService } from "./daemon/command-service.ts";
 import { makeDocSyncService } from "./daemon/doc-sync-service.ts";
 import { makeDaemonQueuedWriteCoordinator } from "./daemon/queued-write-coordinator.ts";
@@ -69,7 +69,12 @@ async function maybeRunDaemonCommand(argv: ReadonlyArray<string>): Promise<numbe
   const action = stripped.args[1] ?? "status";
   const layoutOverrides = stripped.authoredRoot ? { authoredRoot: stripped.authoredRoot } : undefined;
   const daemonArgs = stripped.daemonRepoId ? [...stripped.args, "--repo", stripped.daemonRepoId] : stripped.args;
+  if (action === "connect") return runDaemonConnect(stripped.args);
   if (action === "serve") {
+    if (daemonArgs.includes("--stdio")) {
+      console.error("daemon serve --stdio is disabled because it creates a competing runtime; start the persistent daemon and use 'ha daemon connect --stdio'.");
+      return 2;
+    }
     await runDaemonServe(stripped.rootDir, layoutOverrides, daemonArgs);
     return 0;
   }
@@ -106,30 +111,13 @@ async function runDaemonServe(
     throw new Error(`daemon did not attach any registered repo: ${startStatus.repos.map((repo) => `${repo.repoId}:${repo.lastError ?? repo.state}`).join("; ")}`);
   }
   const idleMs = parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true });
-  const stdio = args.includes("--stdio");
-  const socketPath = readOption(args, "--socket") ?? localUserDaemonSocketPath(userRoot, daemonIdFromEnv());
-  const endpoint = stdio ? "stdio" : socketPath;
+  const endpoint = readOption(args, "--socket") ?? localUserDaemonEndpoint(userRoot, daemonIdFromEnv());
   const connections: DaemonConnectionStats = { active: 0, total: 0 };
   const serviceHost = createDaemonServiceHost(runtime, serveRepos, defaultRepoId, layoutOverrides, idleMs, endpoint, connections);
   serviceHost.startRegistryReconcile(userRoot);
-  if (stdio) {
-    connections.active += 1;
-    connections.total += 1;
-    hooks.onStarted?.(serviceHost.status());
-    serveSshExecBridge({
-      username: process.env.USER,
-      host: process.env.HOSTNAME,
-      createProtocolServer: serviceHost.createProtocolServer
-    });
-    await waitForInputEnd();
-    connections.active = Math.max(0, connections.active - 1);
-    await serviceHost.stop();
-    return;
-  }
-
-  const transport = createUnixSocketTransportServer({
+  const transport = createDaemonLocalTransport({
     daemonId: serviceHost.daemonId,
-    socketPath,
+    endpoint,
     createProtocolServer: serviceHost.createProtocolServer,
     onConnection: () => {
       connections.active += 1;
@@ -436,17 +424,6 @@ async function waitForStopSignal(): Promise<void> {
     };
     process.on("SIGINT", stop);
     process.on("SIGTERM", stop);
-  });
-}
-
-async function waitForInputEnd(): Promise<void> {
-  await new Promise<void>((resolve) => {
-    if (process.stdin.destroyed) {
-      resolve();
-      return;
-    }
-    process.stdin.once("end", resolve);
-    process.stdin.once("close", resolve);
   });
 }
 

--- a/packages/cli/test/daemon-connect.test.ts
+++ b/packages/cli/test/daemon-connect.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  daemonIdForUserRoot,
+  defaultNamedPipePath,
+  localUserDaemonEndpoint,
+  localUserDaemonSocketPath
+} from "../../daemon/src/index.ts";
+import { createDaemonLocalTransport } from "../src/commands/daemon/serve-transport.ts";
+import {
+  remoteDaemonUnavailableHint,
+  remoteDaemonSshArgs,
+  type RemoteDaemonConfig
+} from "../src/daemon/client.ts";
+
+test("daemon endpoint selection uses a named pipe on Windows and a unix socket on POSIX", () => {
+  const userRoot = "/srv/harness-user";
+  const daemonId = "team";
+  assert.equal(
+    localUserDaemonEndpoint(userRoot, daemonId, "win32"),
+    defaultNamedPipePath(daemonIdForUserRoot(userRoot, daemonId))
+  );
+  assert.equal(localUserDaemonEndpoint(userRoot, daemonId, "linux"), localUserDaemonSocketPath(userRoot, daemonId));
+});
+
+test("daemon serve transport wires the selected endpoint to the platform adapter", () => {
+  const createProtocolServer = () => {
+    throw new Error("not used by adapter selection test");
+  };
+  const windows = createDaemonLocalTransport({
+    daemonId: "daemon-test",
+    endpoint: "\\\\.\\pipe\\daemon-test",
+    platform: "win32",
+    createProtocolServer
+  });
+  const posix = createDaemonLocalTransport({
+    daemonId: "daemon-test",
+    endpoint: "/tmp/daemon-test.sock",
+    platform: "linux",
+    createProtocolServer
+  });
+
+  assert.equal(windows.kind, "named-pipe");
+  assert.equal(windows.endpoint, "\\\\.\\pipe\\daemon-test");
+  assert.equal(posix.kind, "unix-socket");
+  assert.equal(posix.endpoint, "/tmp/daemon-test.sock");
+});
+
+test("remote mode invokes the pure connect subcommand without a runtime or client-selected root", () => {
+  const remote: RemoteDaemonConfig = {
+    host: "daemon.example.test",
+    remoteHaPath: "/opt/harness/bin/ha",
+    remoteRoot: "/srv/canonical",
+    repoId: "canonical"
+  };
+
+  assert.deepEqual(remoteDaemonSshArgs(remote), [
+    "daemon.example.test",
+    "/opt/harness/bin/ha",
+    "daemon",
+    "connect",
+    "--stdio"
+  ]);
+  assert.match(remoteDaemonUnavailableHint(remote), /Start the persistent daemon on daemon\.example\.test/iu);
+  assert.match(remoteDaemonUnavailableHint(remote), /ha daemon start --service/iu);
+});

--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, 
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -152,6 +153,7 @@ function setupRegisteredRepos(workspaceRoot: string): {
   const betaRoot = path.join(workspaceRoot, "beta");
   for (const rootDir of [alphaRoot, betaRoot]) {
     mkdirSync(rootDir, { recursive: true });
+    ensureTestHarnessIdentity(rootDir);
     runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
     writePeopleRoster(rootDir);
   }
@@ -170,8 +172,8 @@ function writePeopleRoster(rootDir: string): void {
   writeFileSync(path.join(harnessRoot, "people.yaml"), [
     "schema: harness-people/v1",
     "people:",
-    "  - personId: person_daemon_tester",
-    "    displayName: Daemon Tester",
+    "  - personId: person_test",
+    "    displayName: Harness Test",
     "    primaryEmail: daemon-tester@example.test",
     "    roles: [owner]",
     "    credentials:",
@@ -187,16 +189,18 @@ function writePeopleRoster(rootDir: string): void {
     execFileSync("git", ["-C", harnessRoot, "add", "--", "people.yaml"], { stdio: "ignore" });
     execFileSync("git", ["-C", harnessRoot, "commit", "-m", "chore: configure daemon people roster"], {
       stdio: "ignore",
-      env: gitAuthorEnv()
+      env: gitAuthorEnv(rootDir)
     });
   }
 }
 
-function gitAuthorEnv(): NodeJS.ProcessEnv {
+function gitAuthorEnv(rootDir: string): NodeJS.ProcessEnv {
   const name = process.env.HARNESS_GIT_AUTHOR_NAME ?? "Harness Test";
   const email = process.env.HARNESS_GIT_AUTHOR_EMAIL ?? "harness@example.test";
   return {
     ...process.env,
+    HOME: path.join(rootDir, ".home"),
+    GIT_CONFIG_GLOBAL: "/dev/null",
     GIT_AUTHOR_NAME: name,
     GIT_AUTHOR_EMAIL: email,
     GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? name,
@@ -239,6 +243,8 @@ function runDaemonCommand(rootDir: string, args: ReadonlyArray<string>, env: Rea
 function daemonTestEnv(rootDir: string, env: Readonly<Record<string, string>>): NodeJS.ProcessEnv {
   return {
     ...process.env,
+    HOME: path.join(rootDir, ".home"),
+    GIT_CONFIG_GLOBAL: "/dev/null",
     HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user"),
     ...env
   };

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import net from "node:net";
 import { hostname } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { JsonRpcLineClient } from "../../daemon/src/index.ts";
 import {
   defaultDaemonUserRoot,
   delay,
@@ -18,6 +20,65 @@ import {
 } from "./helpers/daemon-cli.ts";
 
 const expectedCliVersion = readCliPackageVersion();
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+
+test("daemon connect relays opaque bytes without creating repository runtime state", { skip: process.platform === "win32" }, async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const endpoint = path.join(rootDir, "relay.sock");
+    const server = net.createServer((socket) => socket.pipe(socket));
+    await listen(server, endpoint);
+    try {
+      const result = await runDaemonCliProcess(rootDir, ["daemon", "connect", "--stdio", "--socket", endpoint], "opaque request\nsecond frame\n");
+      assert.equal(result.code, 0, result.stderr);
+      assert.equal(result.stdout, "opaque request\nsecond frame\n");
+      assert.equal(existsSync(path.join(rootDir, "harness")), false);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});
+
+test("daemon connect reaches the already-running daemon instance", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const startStatus = runDaemonCommand(rootDir, ["daemon", "start", "--service", "--json"]);
+    const child = spawnDaemonCli(rootDir, ["daemon", "connect", "--stdio"]);
+    const client = new JsonRpcLineClient(child.stdout, child.stdin, child);
+    const hello = await client.request("protocol.hello", { protocolVersion: 1 });
+    const status = await client.request("repo.daemon.status", { repo: { repoId: "canonical" } });
+    client.close();
+
+    assert.equal(hello.ok, true);
+    const details = status.details as Record<string, unknown>;
+    const data = details.data as Record<string, unknown>;
+    assert.equal(data.daemonId, startStatus.daemonId);
+    assert.equal(data.started, true);
+  });
+});
+
+test("daemon connect fails closed with startup instructions when no persistent daemon exists", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const endpoint = process.platform === "win32"
+      ? `\\\\.\\pipe\\ha-connect-missing-${process.pid}-${Date.now()}`
+      : path.join(rootDir, "missing.sock");
+    const result = await runDaemonCliProcess(rootDir, ["daemon", "connect", "--stdio", "--socket", endpoint]);
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    assert.match(result.stderr, /No persistent daemon is listening/iu);
+    assert.match(result.stderr, /ha daemon start --service/iu);
+    assert.equal(existsSync(path.join(rootDir, "harness")), false);
+  });
+});
+
+test("daemon serve --stdio is rejected before runtime attachment", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const result = await runDaemonCliProcess(rootDir, ["daemon", "serve", "--stdio"]);
+
+    assert.equal(result.code, 2);
+    assert.match(result.stderr, /daemon connect --stdio/iu);
+    assert.equal(existsSync(path.join(rootDir, "harness")), false);
+  });
+});
 
 test("daemon client mode preserves command receipt output shape against direct mode", () => {
   withTempRoot((rootDir) => {
@@ -472,15 +533,17 @@ function daemonStatusRepos(rootDir: string, userRoot: string, repoId: string): R
 }
 
 function initGitRepo(rootDir: string): void {
-  execFileSync("git", ["-C", rootDir, "init", "-b", "master"], { stdio: "ignore" });
-  execFileSync("git", ["-C", rootDir, "config", "user.name", "Harness Test"], { stdio: "ignore" });
-  execFileSync("git", ["-C", rootDir, "config", "user.email", "harness@example.test"], { stdio: "ignore" });
+  const env = hermeticGitEnv(rootDir);
+  execFileSync("git", ["-C", rootDir, "init", "-b", "master"], { stdio: "ignore", env });
+  execFileSync("git", ["-C", rootDir, "config", "user.name", "Harness Test"], { stdio: "ignore", env });
+  execFileSync("git", ["-C", rootDir, "config", "user.email", "harness@example.test"], { stdio: "ignore", env });
 }
 
 function git(rootDir: string, ...args: ReadonlyArray<string>): string {
   return execFileSync("git", ["-C", rootDir, ...args], {
     encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
+    stdio: ["ignore", "pipe", "pipe"],
+    env: hermeticGitEnv(rootDir)
   }).trim();
 }
 
@@ -518,20 +581,75 @@ function commitPeopleRoster(harnessRoot: string): void {
   execFileSync("git", ["-C", harnessRoot, "add", "--", "people.yaml"], { stdio: "ignore" });
   execFileSync("git", ["-C", harnessRoot, "commit", "-m", "chore: configure daemon people roster"], {
     stdio: "ignore",
-    env: gitAuthorEnv()
+    env: gitAuthorEnv(harnessRoot)
   });
 }
 
-function gitAuthorEnv(): NodeJS.ProcessEnv {
+function gitAuthorEnv(rootDir: string): NodeJS.ProcessEnv {
   const name = process.env.HARNESS_GIT_AUTHOR_NAME ?? "Harness Test";
   const email = process.env.HARNESS_GIT_AUTHOR_EMAIL ?? "harness@example.test";
   return {
-    ...process.env,
+    ...hermeticGitEnv(rootDir),
     GIT_AUTHOR_NAME: name,
     GIT_AUTHOR_EMAIL: email,
     GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? name,
     GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? email
   };
+}
+
+function hermeticGitEnv(rootDir: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    HOME: path.join(rootDir, ".home"),
+    GIT_CONFIG_GLOBAL: "/dev/null"
+  };
+}
+
+function spawnDaemonCli(rootDir: string, args: ReadonlyArray<string>) {
+  return spawn(process.execPath, [cliEntry, "--root", rootDir, ...args], {
+    env: {
+      ...process.env,
+      HOME: path.join(rootDir, ".home"),
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DAEMON_USER_ROOT: defaultDaemonUserRoot(rootDir)
+    },
+    stdio: ["pipe", "pipe", "pipe"]
+  });
+}
+
+function runDaemonCliProcess(
+  rootDir: string,
+  args: ReadonlyArray<string>,
+  stdin = ""
+): Promise<{ readonly code: number | null; readonly stdout: string; readonly stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawnDaemonCli(rootDir, args);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk: string) => { stdout += chunk; });
+    child.stderr.setEncoding("utf8").on("data", (chunk: string) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, stdout, stderr }));
+    child.stdin.end(stdin);
+  });
+}
+
+function listen(server: net.Server, endpoint: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(endpoint, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function closeServer(server: net.Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/test/helpers/daemon-cli.ts
+++ b/packages/cli/test/helpers/daemon-cli.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { ensureTestHarnessIdentity } from "./git-fixtures.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const execFileAsync = promisify(execFile);
@@ -28,6 +29,7 @@ export async function withTempRootAsync<T>(fn: (rootDir: string) => Promise<T>):
 }
 
 export function runRawJson(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Record<string, unknown> {
+  if (args[0] === "init") ensureTestHarnessIdentity(rootDir);
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
     env: daemonTestEnv(rootDir, env)
@@ -168,6 +170,8 @@ function removeTempRootSync(rootDir: string): void {
 function daemonTestEnv(rootDir: string, env: Readonly<Record<string, string>>): NodeJS.ProcessEnv {
   return {
     ...process.env,
+    HOME: path.join(rootDir, ".home"),
+    GIT_CONFIG_GLOBAL: "/dev/null",
     HARNESS_DAEMON_USER_ROOT: defaultDaemonUserRoot(rootDir),
     ...env
   };

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -16,6 +16,7 @@ import {
 import { currentDaemonProtocolVersion } from "../protocol/method-registry.ts";
 import { type JsonObject, type JsonRpcRequest, type JsonRpcResponse } from "../protocol/json-rpc-types.ts";
 import { encodeJsonLineFrame } from "../transport/frame-codec.ts";
+import { defaultNamedPipePath } from "../transport/named-pipe.ts";
 import { defaultUnixSocketPath } from "../transport/unix-socket.ts";
 
 export const defaultDaemonAutostartTimeoutMs = 6_000;
@@ -83,6 +84,15 @@ export function localUserDaemonSocketPath(userRoot = daemonUserRoot(), daemonId 
   return defaultUnixSocketPath(daemonIdForUserRoot(userRoot, daemonId));
 }
 
+export function localUserDaemonEndpoint(
+  userRoot = daemonUserRoot(),
+  daemonId = daemonIdFromEnv(),
+  platform: NodeJS.Platform = process.platform
+): string {
+  const endpointId = daemonIdForUserRoot(userRoot, daemonId);
+  return platform === "win32" ? defaultNamedPipePath(endpointId) : defaultUnixSocketPath(endpointId);
+}
+
 export function daemonUserRoot(env: NodeJS.ProcessEnv = process.env): string {
   return path.resolve(readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_USER_ROOT") ?? path.join(os.homedir(), ".harness"));
 }
@@ -104,8 +114,8 @@ export function resolveLocalDaemonTarget(input: {
   const daemonId = input.daemonId ?? daemonIdFromEnv(env);
   const repoIdOverride = input.repoIdOverride ?? readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_REPO_ID");
   const registry = readDaemonRegistry({ userRoot });
-  const legacySocketPath = localDaemonSocketPath(input.rootDir);
-  const socketPath = localUserDaemonSocketPath(userRoot, daemonId);
+  const socketPath = localUserDaemonEndpoint(userRoot, daemonId);
+  const legacySocketPath = process.platform === "win32" ? socketPath : localDaemonSocketPath(input.rootDir);
 
   if (repoIdOverride) {
     const registered = registry.repos.find((repo) => repo.repoId === repoIdOverride && repo.state === "enabled");
@@ -183,8 +193,9 @@ export async function requestLocalDaemonJsonRpc(
   }
 
   const userRoot = path.resolve(options.userRoot ?? daemonUserRoot(options.env));
-  const socketPath = options.socketPath ?? localUserDaemonSocketPath(userRoot, options.daemonId ?? daemonIdFromEnv(options.env));
-  const socket = await connectUnixSocketWithLegacyFallback(socketPath, options.allowLegacySocket === false ? undefined : localDaemonSocketPath(rootDir), timeoutMs);
+  const socketPath = options.socketPath ?? localUserDaemonEndpoint(userRoot, options.daemonId ?? daemonIdFromEnv(options.env));
+  const legacySocketPath = process.platform === "win32" ? undefined : localDaemonSocketPath(rootDir);
+  const socket = await connectUnixSocketWithLegacyFallback(socketPath, options.allowLegacySocket === false ? undefined : legacySocketPath, timeoutMs);
   return requestWithSocket(socket, method, params);
 }
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -7,6 +7,7 @@ export {
   defaultDaemonIdleExitMs,
   JsonRpcLineClient,
   localDaemonSocketPath,
+  localUserDaemonEndpoint,
   localUserDaemonSocketPath,
   requestLocalDaemonJsonRpc,
   requestLocalDaemonJsonRpcForTarget,

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -2,6 +2,7 @@ export const testTierManifest = {
   fast: [
     "packages/adapters/local/test/task-writes.test.ts",
     "packages/cli/test/doc-sync-service.test.ts",
+    "packages/cli/test/daemon-connect.test.ts",
     "packages/cli/test/parse-args.test.ts",
     "packages/cli/test/path-utils.test.ts",
     "packages/daemon/test/local-json-rpc-client.test.ts",


### PR DESCRIPTION
# English

## Summary

A1 of the daemon remote/attribution line (decision dec_mrcz1kqh): remote mode now connects to the persistent daemon instead of spawning a competing one. New `ha daemon connect --stdio` is a pure relay — it dials the resident daemon's local endpoint and pipes bytes, building no runtime, attaching no repo, touching no lock. When no persistent daemon is running, both connect and the remote client fail closed with startup instructions instead of silently spawning a second writer.

## What Changed

- New `packages/cli/src/commands/daemon/connect.ts`: pure relay (Node `net` + stdio pipes only); dispatched before `parseArgs`/CLI composition so no runtime path is reachable.
- Remote SSH argv in `packages/cli/src/daemon/client.ts` changed from `daemon serve --stdio` to `daemon connect --stdio`; a fast test locks the argv shape (no `serve`, no `--root`, no `--repo`) so it stays forced-command constrainable (groundwork for A2).
- `daemon serve --stdio` runtime branch deleted; the flag now rejects with exit 2 pointing to `daemon connect --stdio`. The ssh-exec transport adapter is retained (no runtime; reusable seam for A2).
- Fail-closed: connect exits 1 on connection failure with `ha daemon start --service` / `ha daemon status` guidance; the remote receipt names the remote host explicitly.
- Cross-platform endpoint selection: single `localUserDaemonEndpoint(...)` (unix socket on POSIX, named pipe on Windows); `serve-transport.ts` wires the previously-unwired `createNamedPipeTransportServer` for win32. Unix socket permissions (0700/0600) untouched.

## Task And Scope

- Harness task: task_01KX2GHBWWWT51MXY8JRFTR3Z1
- Branch: codex/a1-daemon-connect
- Public scope: CLI daemon connect/serve dispatch, remote client argv, daemon endpoint/transport selection, tests
- Private planning/evidence updated: yes (task package impl report)
- Out of scope: A2 forced-command principal injection, A3 peer-credential truthfulness, A5 attribution defense, A4 docs sync; client `--root` behavior unchanged (C4 belongs to A2)

## Version Impact

- Version: no version change because this ships with the next planned release
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: n/a (no gate-manifest/CI/socket-permission changes; unix-socket.ts untouched per the A3-first red line)
- Authority: decision dec_mrcz1kqh (remote must connect to persistent daemon; stdio is transport only)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: A2 (task_01KX2GHETQZ3HKVMB8EDXCB99C), A3, A4, A5 per the parent line

## Verification

- Base `origin/main` SHA: bb11695b52cb3ba461ee9e3a08459d88b7d353d3
- Branch merge-base with `origin/main`: bb11695b52cb3ba461ee9e3a08459d88b7d353d3
- Last `git fetch origin` time: 2026-07-10 (before dispatch; base is current main)
- Sync method: none needed
- Public diff command: `git diff origin/main..codex/a1-daemon-connect`
- Private evidence commit/path: task package impl report
- Reviewer evidence path: task package `artifacts/impl-report.md`
- GitHub Actions `rewrite-ci` run URL: pending (will be linked by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (aggregate ran; see Residual Risk for a pre-existing failure reproduced on unmodified main)
- [x] `npm run typecheck`
- [x] `npm test` (fast 265/265, contract 344/344; focused daemon suites 7/7, 2/2, 19/19 with red-green reproduction; full Node suite 1099 pass / 1 Windows platform skip)
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: real SSH end-to-end and Windows-host E2E (named-pipe covered at unit level; Windows E2E remains platform-skipped locally). CI-shape gates run locally: boundaries 21/21, integration shard 2 (58/58) and shard 5 (84/84).

## Review Evidence

- Self-review: red-green reproduction (new tests failed with ERR_MODULE_NOT_FOUND before implementation); serve --stdio consumer inventory with per-consumer disposition
- Reviewer subagent: CEO verified the report's load-bearing negative control — `check-duplicate-definitions` fails identically on unmodified main (3 pre-existing duplicates in files not in this diff)
- Human review: pending merge review
- Blocking findings: none

## Residual Risk

- `check-duplicate-definitions` (not part of PR-required jobs) is red on main itself: `application/isRecord`, `cli/visit`, `cli/snapshotFiles` — pre-existing debt from earlier merges, tracked as a separate cleanup task (task_01KX566DD6WP6NJ8TD01Z2Z3WP), untouched here.
- Windows named-pipe path has unit-level coverage only until a Windows runner E2E exists.
- Public operations docs still describe the old `daemon serve --stdio` remote path; that sync is A4's charter.

## References

- Task: task_01KX2GHBWWWT51MXY8JRFTR3Z1
- Evidence: task package `artifacts/impl-report.md`
- Review: decision dec_mrcz1kqh

---

# 中文

## 概要

daemon 远程/归属线的 A1（裁决 dec_mrcz1kqh）：remote 模式改为连接常驻 daemon，不再拉起竞争写入者。新增 `ha daemon connect --stdio` 纯中继——dial 常驻 daemon 的本地 endpoint 并双向 pipe 字节流，不建 runtime、不 attach、不碰锁。远端无常驻 daemon 时 connect 与 remote 客户端均 fail-closed 并给出启动指引，绝不静默 spawn。

## 改动内容

- 新增 `packages/cli/src/commands/daemon/connect.ts`：纯中继（仅 Node `net`+stdio pipe）；在 `parseArgs`/CLI composition 之前分流执行，无任何可达的 runtime 路径。
- `packages/cli/src/daemon/client.ts` 的 remote SSH argv 由 `daemon serve --stdio` 改为 `daemon connect --stdio`；fast 测试锁死 argv 形态（无 `serve`/`--root`/`--repo`），保持可被 forced command 约束（A2 的地基）。
- 删除 `daemon serve --stdio` 的 runtime 分支；该 flag 现以 exit 2 拒绝并指向 connect。ssh-exec transport adapter 保留（无 runtime,是 A2 可复用 seam）。
- fail-closed：连接失败 exit 1,stderr 给出 `ha daemon start --service` / `ha daemon status` 指引;remote 回执明确点名远端 host。
- 跨平台 endpoint 选择：统一 `localUserDaemonEndpoint(...)`（POSIX=unix socket,Windows=命名管道）;`serve-transport.ts` 接上此前未接线的 `createNamedPipeTransportServer`。unix socket 权限（0700/0600）一个 bit 未动。

## 任务与范围

- Harness 任务：task_01KX2GHBWWWT51MXY8JRFTR3Z1
- 分支：codex/a1-daemon-connect
- 公开范围：CLI daemon connect/serve 分流、remote 客户端 argv、daemon endpoint/transport 选择、测试
- 私有计划 / 证据是否已更新：yes（任务包实施报告）
- 范围外：A2 forced-command principal 注入、A3 peer credential、A5 归属防御、A4 文档同步;客户端 `--root` 行为维持现状（C4 归 A2）

## 版本影响

- 版本：不改版本，原因是随下一次计划发布一起出
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用（gate-manifest/CI/socket 权限零改动;unix-socket.ts 按 A3 先行红线未动）
- 依据：decision dec_mrcz1kqh（remote 必须连常驻 daemon;stdio 只做传输）
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：A2（task_01KX2GHETQZ3HKVMB8EDXCB99C）、A3、A4、A5

## 验证

- `origin/main` 基准 SHA：bb11695b52cb3ba461ee9e3a08459d88b7d353d3
- 当前分支与 `origin/main` 的 merge-base：bb11695b52cb3ba461ee9e3a08459d88b7d353d3
- 最近一次 `git fetch origin` 时间：2026-07-10（派工前;基线即当前 main）
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main..codex/a1-daemon-connect`
- 私有证据 commit/path：任务包实施报告
- Reviewer 证据路径：任务包 `artifacts/impl-report.md`
- GitHub Actions `rewrite-ci` run URL：待 CI 生成后由本 PR checks 关联
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`（聚合层含一处存量红,阴性对照见残余风险）
- [x] `npm run typecheck`
- [x] `npm test`（fast 265/265、contract 344/344;定向 daemon 套件红绿法;全量 Node 1099 过/1 Windows skip）
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：真实 SSH 端到端与 Windows 主机 E2E（named-pipe 有单元级覆盖,Windows E2E 本地 platform skip）。CI 同款门本地已跑：boundaries 21/21、integration shard 2（58/58）、shard 5（84/84）。

## 审查证据

- 自查：红绿法（新测试实现前以 ERR_MODULE_NOT_FOUND 打红）;serve --stdio 消费点逐条清单与处置
- Reviewer subagent：CEO 亲验报告的承重阴性对照——`check-duplicate-definitions` 在未改动的 main 上同样失败（3 处存量重复,均不在本 diff）
- 人工审查：合并评审待进行
- 阻塞发现：无

## 残余风险

- `check-duplicate-definitions`（不在 PR 必跑 jobs）在 main 本身即红：三处存量重复定义,已登记独立清债任务（task_01KX566DD6WP6NJ8TD01Z2Z3WP）,本 PR 不触碰。
- Windows named-pipe 在有 Windows runner E2E 前仅单元级覆盖。
- 公开运维文档仍描述旧 `daemon serve --stdio` 路径,同步归 A4。

## 关联材料

- 任务：task_01KX2GHBWWWT51MXY8JRFTR3Z1
- 证据：任务包 `artifacts/impl-report.md`
- 审查：decision dec_mrcz1kqh

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
