### PR TITLE
fix: represent unix socket owner boundary honestly

### DIFF
--- a/MC-B1-PHASE2-REPORT.md
+++ b/MC-B1-PHASE2-REPORT.md
@@ -35,7 +35,7 @@ Runtime state path: `.harness/task-holders/<taskId>.json` under `layout.localRoo
     "primaryEmail": "person@example.com",
     "providerId": "transport-derived",
     "credential": {
-      "kind": "unix-uid",
+      "kind": "unix-socket-owner-boundary",
       "issuer": "local",
       "subject": "501"
     }

--- a/docs-release/operations-server-daemon.md
+++ b/docs-release/operations-server-daemon.md
@@ -134,9 +134,12 @@ the same `global.lock`.
 The local Unix socket is the real access boundary. The daemon creates the socket
 directory as `0700` and the socket file as `0600`.
 
-The Unix transport does not perform kernel peer credential validation such as
-`SO_PEERCRED`. The recorded peer credential is derived from the daemon process
-owner (`process.getuid()` / `process.getgid()`), not from the connecting client.
+The Unix transport does not inspect the connected process identity. It records
+`unix-socket-owner-boundary`, whose subject is the socket file owner's
+`stat.uid`. Every accepted client is attributed to that owner solely because
+the `0700` directory and `0600` socket permit only the owner to connect. Widening
+either permission invalidates this boundary and requires a different identity
+source.
 
 `harness/people.yaml` enables roster-based authorization when it exists. Without
 that roster, local connections are trusted by the transport boundary.

--- a/docs-release/operations-server-daemon.zh-CN.md
+++ b/docs-release/operations-server-daemon.zh-CN.md
@@ -119,9 +119,10 @@ id 时，设置 `HARNESS_DAEMON_REPO_ID`。
 本地 Unix socket 才是真实访问边界。daemon 会用 `0700` 创建 socket 目录，并把
 socket 文件设为 `0600`。
 
-Unix transport 没有做 `SO_PEERCRED` 这类内核 peer credential 校验。记录的 peer
-credential 来自 daemon 进程所有者（`process.getuid()` / `process.getgid()`），不是
-连接进来的客户端。
+Unix transport 不读取连接进程的身份。它记录
+`unix-socket-owner-boundary`，subject 是 socket 文件属主的 `stat.uid`。每个成功连接
+的客户端之所以归属该 owner，只因为 `0700` 目录与 `0600` socket 仅允许 owner
+连接。放宽任一权限都会使这个边界失效，届时必须改用其他身份来源。
 
 存在 `harness/people.yaml` 时会启用基于 roster 的授权。没有这份 roster 时，本地连接
 完全信任 transport 边界。

--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -369,7 +369,7 @@ function ensurePeopleRoster(filePath: string, input: {
     `        issuer: host:${input.sshHost}`,
     `        subject: ${input.sshUser}`,
     ...(typeof uid === "number" ? [
-      "      - kind: unix-uid",
+      "      - kind: unix-socket-owner-boundary",
       `        issuer: host:${os.hostname()}`,
       `        subject: ${uid}`
     ] : []),

--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -177,7 +177,7 @@ function writePeopleRoster(rootDir: string): void {
     "    primaryEmail: daemon-tester@example.test",
     "    roles: [owner]",
     "    credentials:",
-    "      - kind: unix-uid",
+    "      - kind: unix-socket-owner-boundary",
     `        issuer: host:${hostname()}`,
     `        subject: ${process.getuid?.() ?? 0}`,
     "roles:",

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -563,7 +563,7 @@ function writePeopleRoster(rootDir: string, person: {
     `    primaryEmail: ${person.email}`,
     `    roles: [${person.role}]`,
     "    credentials:",
-    "      - kind: unix-uid",
+    "      - kind: unix-socket-owner-boundary",
     `        issuer: host:${hostname()}`,
     `        subject: ${process.getuid?.() ?? 0}`,
     "roles:",

--- a/packages/daemon/src/identity/people-roster.ts
+++ b/packages/daemon/src/identity/people-roster.ts
@@ -5,6 +5,7 @@ import { resolveHarnessLayout, type HarnessLayoutInput } from "../../../kernel/s
 import {
   credentialKey,
   type CredentialRef,
+  type CredentialKind,
   type DaemonCommandClass,
   type IdentityProviderFailure,
   type PeopleRoster,
@@ -13,6 +14,16 @@ import {
 } from "./types.ts";
 
 const commandClasses = new Set<DaemonCommandClass>(["admin", "repo-write", "repo-read", "arbiter"]);
+const credentialKinds = new Set<CredentialKind>([
+  "unix-socket-owner-boundary",
+  "windows-named-pipe-client",
+  "ssh-username",
+  "ssh-tunnel-token-subject",
+  "email-address",
+  "password-account",
+  "oauth-subject",
+  "api-token"
+]);
 
 export function loadPeopleRoster(rootInput: HarnessLayoutInput): PeopleRoster {
   const layout = resolveHarnessLayout(rootInput);
@@ -87,6 +98,7 @@ function validateRoster(people: ReadonlyArray<PersonProfile>, roles: ReadonlyArr
       if (!roleIds.has(roleId)) throw new Error(`person ${person.personId} references unknown role ${roleId}`);
     }
     for (const credential of person.credentials) {
+      if (!credentialKinds.has(credential.kind)) throw new Error(`unknown credential kind: ${credential.kind}`);
       const key = credentialKey(credential);
       if (credentialKeys.has(key)) throw new Error(`duplicate credential binding: ${credential.kind}:${credential.issuer}:${credential.subject}`);
       credentialKeys.add(key);

--- a/packages/daemon/src/identity/transport-derived-provider.ts
+++ b/packages/daemon/src/identity/transport-derived-provider.ts
@@ -34,11 +34,11 @@ function credentialFromAuthContext(
   authContext: DaemonAuthenticationContext,
   options: TransportDerivedIdentityProviderOptions
 ): CredentialRef | undefined {
-  if (typeof authContext.unixPeerCredential?.uid === "number") {
+  if (typeof authContext.unixSocketOwnerBoundary?.ownerUid === "number") {
     return {
-      kind: "unix-uid",
+      kind: "unix-socket-owner-boundary",
       issuer: options.localUnixIssuer ?? `host:${os.hostname()}`,
-      subject: String(authContext.unixPeerCredential.uid)
+      subject: String(authContext.unixSocketOwnerBoundary.ownerUid)
     };
   }
   if (authContext.sshExecUser?.username) {

--- a/packages/daemon/src/identity/types.ts
+++ b/packages/daemon/src/identity/types.ts
@@ -5,7 +5,7 @@ export type PersonId = string;
 export type RoleId = string;
 
 export type CredentialKind =
-  | "unix-uid"
+  | "unix-socket-owner-boundary"
   | "windows-named-pipe-client"
   | "ssh-username"
   | "ssh-tunnel-token-subject"

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -83,14 +83,13 @@ export type {
   JsonRpcSuccessResponse
 } from "./protocol/json-rpc-types.ts";
 export {
-  localUnixPeerCredential,
   type AttachTokenSubject,
   type DaemonAuthenticationContext,
   type DaemonTransportKind,
   type NamedPipeClientContext,
   type SshExecUserContext,
   type SshTunnelTokenContext,
-  type UnixPeerCredential
+  type UnixSocketOwnerBoundary
 } from "./transport/auth-context.ts";
 export {
   createJsonLineFrameReader,

--- a/packages/daemon/src/transport/auth-context.ts
+++ b/packages/daemon/src/transport/auth-context.ts
@@ -2,11 +2,9 @@ import type { JsonObject } from "../protocol/json-rpc-types.ts";
 
 export type DaemonTransportKind = "unix-socket" | "named-pipe" | "ssh-exec" | "ssh-tunnel";
 
-export interface UnixPeerCredential {
-  readonly uid?: number;
-  readonly gid?: number;
-  readonly pid?: number;
-  readonly source: "node-process-owner" | "platform-peercred-unavailable";
+export interface UnixSocketOwnerBoundary {
+  readonly ownerUid: number;
+  readonly source: "unix-socket-filesystem-owner-boundary";
 }
 
 export interface NamedPipeClientContext {
@@ -37,16 +35,8 @@ export interface SshTunnelTokenContext {
 export interface DaemonAuthenticationContext {
   readonly transportKind: DaemonTransportKind;
   readonly endpoint?: string;
-  readonly unixPeerCredential?: UnixPeerCredential;
+  readonly unixSocketOwnerBoundary?: UnixSocketOwnerBoundary;
   readonly namedPipeClient?: NamedPipeClientContext;
   readonly sshExecUser?: SshExecUserContext;
   readonly sshTunnelToken?: SshTunnelTokenContext;
-}
-
-export function localUnixPeerCredential(): UnixPeerCredential {
-  return {
-    uid: process.getuid?.(),
-    gid: process.getgid?.(),
-    source: process.getuid || process.getgid ? "node-process-owner" : "platform-peercred-unavailable"
-  };
 }

--- a/packages/daemon/src/transport/unix-socket.ts
+++ b/packages/daemon/src/transport/unix-socket.ts
@@ -1,10 +1,9 @@
 // @slice-activation PLT-Daemon W3 transport adapters exported for daemon composition roots.
-import { mkdirSync, rmSync, chmodSync } from "node:fs";
+import { mkdirSync, rmSync, chmodSync, statSync } from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import type { DaemonAuthenticationContext } from "./auth-context.ts";
-import { localUnixPeerCredential } from "./auth-context.ts";
 import { serveJsonRpcStream, type DaemonTransportConnection } from "./json-rpc-stream.ts";
 import type { JsonRpcProtocolServer } from "../protocol/json-rpc-server.ts";
 
@@ -30,10 +29,16 @@ export function defaultUnixSocketPath(daemonId: string, uid = process.getuid?.()
 export function createUnixSocketTransportServer(options: UnixSocketTransportOptions): UnixSocketTransportServer {
   const endpoint = options.socketPath ?? defaultUnixSocketPath(options.daemonId);
   const server = net.createServer((socket) => {
+    const ownerUid = statSync(endpoint).uid;
     const authContext: DaemonAuthenticationContext = {
       transportKind: "unix-socket",
       endpoint,
-      unixPeerCredential: localUnixPeerCredential()
+      // 0700 parent + 0600 socket authorize only this filesystem owner. This
+      // identifies that access boundary; it does not observe the client process.
+      unixSocketOwnerBoundary: {
+        ownerUid,
+        source: "unix-socket-filesystem-owner-boundary"
+      }
     };
     const connection = serveJsonRpcStream({
       input: socket,

--- a/packages/daemon/test/transport-integration.test.ts
+++ b/packages/daemon/test/transport-integration.test.ts
@@ -18,13 +18,16 @@ import {
   defaultNamedPipePath,
   defaultUnixSocketPath,
   encodeJsonLineFrame,
+  makeTransportDerivedIdentityProvider,
+  peopleRosterFromDocument,
   serveSshExecBridge,
   serveSshTunnelTokenStream,
   windowsNamedPipeIntegrationEntry,
   type DaemonAuthenticationContext,
   type JsonRpcProtocolServer,
   type JsonRpcRequest,
-  type JsonRpcResponse
+  type JsonRpcResponse,
+  type PeopleRoster
 } from "../src/index.ts";
 
 test("unix socket transport uses single-user path and permissions on POSIX", async (t) => {
@@ -43,18 +46,92 @@ test("unix socket transport uses single-user path and permissions on POSIX", asy
   });
 
   await transport.start();
+  const directoryMode = statSync(path.dirname(socketPath)).mode & 0o777;
   const mode = statSync(socketPath).mode & 0o777;
+  assert.equal(directoryMode, 0o700);
   assert.equal(mode, 0o600);
   assert.equal(defaultUnixSocketPath("daemon test").includes(`daemon-${process.getuid?.() ?? 0}-daemon-test.sock`), true);
 
   const socket = net.createConnection(socketPath);
+  t.after(() => socket.destroy());
   const client = frameClient(socket, socket);
   client.send(hello("unix-hello"));
   const response = await client.read();
   assert.equal(resultReceipt(response).ok, true);
   assert.equal(seenAuthContexts[0]?.transportKind, "unix-socket");
-  assert.equal(seenAuthContexts[0]?.unixPeerCredential?.uid, process.getuid?.());
+  assert.equal(seenAuthContexts[0]?.unixSocketOwnerBoundary?.ownerUid, process.getuid?.());
+  assert.equal(
+    seenAuthContexts[0]?.unixSocketOwnerBoundary?.source,
+    "unix-socket-filesystem-owner-boundary"
+  );
   socket.end();
+});
+
+test("unix socket owner boundary credential resolves to its roster person", async () => {
+  const provider = makeTransportDerivedIdentityProvider(localBoundaryRoster(), { localUnixIssuer: "host:team-host" });
+  const resolved = await provider.resolveActor({
+    authContext: {
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" }
+    },
+    command: { method: "repo.tasks.list", namespace: "repo", requiresRepo: true }
+  });
+
+  assert.equal(resolved.ok, true);
+  if (resolved.ok) {
+    assert.equal(resolved.actor.personId, "person_socket_owner");
+    assert.equal(resolved.actor.resolvedCredential.kind, "unix-socket-owner-boundary");
+    assert.equal(resolved.actor.resolvedCredential.subject, "501");
+  }
+});
+
+test("legacy unix peer-shaped auth context cannot mint a transport credential", async () => {
+  const provider = makeTransportDerivedIdentityProvider(localBoundaryRoster());
+  const resolved = await provider.resolveActor({
+    authContext: {
+      transportKind: "unix-socket",
+      unixPeerCredential: { uid: 501, gid: 20, source: "node-process-owner" }
+    } as unknown as DaemonAuthenticationContext,
+    command: { method: "repo.tasks.list", namespace: "repo", requiresRepo: true }
+  });
+
+  assert.equal(resolved.ok, false);
+  if (!resolved.ok) {
+    assert.equal(resolved.code, "credential_unavailable");
+    assert.equal(resolved.message, "Transport authentication context did not expose a usable credential.");
+  }
+});
+
+test("unix socket auth without an owner boundary fails explicitly", async () => {
+  const provider = makeTransportDerivedIdentityProvider(localBoundaryRoster());
+  const resolved = await provider.resolveActor({
+    authContext: { transportKind: "unix-socket" },
+    command: { method: "repo.tasks.list", namespace: "repo", requiresRepo: true }
+  });
+
+  assert.equal(resolved.ok, false);
+  if (!resolved.ok) {
+    assert.equal(resolved.code, "credential_unavailable");
+    assert.equal(resolved.message, "Transport authentication context did not expose a usable credential.");
+  }
+});
+
+test("people roster rejects legacy unix-uid credentials", () => {
+  assert.throws(() => peopleRosterFromDocument([
+    "schema: harness-people/v1",
+    "people:",
+    "  - personId: person_legacy",
+    "    displayName: Legacy Owner",
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: unix-uid",
+    "        issuer: host:team-host",
+    "        subject: 501",
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin]",
+    ""
+  ].join("\n")), /unknown credential kind: unix-uid/u);
 });
 
 test("Windows named pipe transport path and local test entry are declared", () => {
@@ -305,4 +382,22 @@ function sequenceId(): (prefix: string) => string {
 
 function fixedTime(value: string): () => string {
   return () => value;
+}
+
+function localBoundaryRoster(): PeopleRoster {
+  return peopleRosterFromDocument([
+    "schema: harness-people/v1",
+    "people:",
+    "  - personId: person_socket_owner",
+    "    displayName: Socket Owner",
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: unix-socket-owner-boundary",
+    "        issuer: host:team-host",
+    "        subject: 501",
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    ""
+  ].join("\n"));
 }


### PR DESCRIPTION
# English

## Summary

A3 of the daemon remote/attribution line: stop the local Unix credential from lying. `localUnixPeerCredential()` claimed to expose the connected peer's credential while actually returning the daemon process's own uid; the identity provider then minted it as a `unix-uid` credential — semantically "the peer is this person". Today's 0700/0600 socket permissions make the value coincidentally correct; any future permission widening would silently attribute every client as the daemon owner. This PR renames the mechanism to what it actually is — a filesystem owner boundary — and makes the legacy shape fail loudly.

## What Changed

- `packages/daemon/src/transport/auth-context.ts`: `UnixPeerCredential`/`unixPeerCredential` replaced by `UnixSocketOwnerBoundary`/`unixSocketOwnerBoundary` with `ownerUid` and source `unix-socket-filesystem-owner-boundary`; no client uid/gid/pid, no peer-oriented naming.
- `packages/daemon/src/transport/unix-socket.ts`: the boundary is read from `statSync(endpoint).uid` (the socket file's owner — the actual enforcement subject), not from the daemon process; comments state that 0700 dir + 0600 socket are the authorization mechanism and that no client process is observed. Permissions unchanged (verified byte-level against HEAD).
- `packages/daemon/src/identity/transport-derived-provider.ts`: mints only `kind: unix-socket-owner-boundary`; a constructed legacy `unixPeerCredential` shape is ignored and falls through to the existing explicit "did not expose a usable credential" failure.
- `packages/daemon/src/identity/people-roster.ts`: the removed `unix-uid` kind is rejected at roster load — no compatibility alias that could silently preserve the old identity claim. Migration is a one-line kind change (issuer/subject unchanged); CLI daemon bootstrap emits the new kind.
- `docs-release/operations-server-daemon.md` (en + zh-CN): now describe the filesystem owner boundary and state that widening either permission invalidates this identity source.
- Tests: red-first controls (honest resolution, legacy-shape rejection, legacy-kind rejection all failed against the old implementation); real-socket integration coverage of auth context, person resolution, both permission modes.

## Task And Scope

- Harness task: task_01KX2GHHVP1EQ13C3M68SPW0PJ
- Branch: codex/a3-honest-credential
- Public scope: daemon transport auth context, unix socket transport, transport-derived identity provider, people roster kind validation, daemon barrel exports, operations docs, tests
- Private planning/evidence updated: yes (task package impl report)
- Out of scope: implementing real platform peercred (rejected by dec_mrcz2q6k — Node exposes none of the three platform mechanisms), A2 forced-command principal injection, A5 attribution defense, any socket permission change

## Version Impact

- Version: no version change because this ships with the next planned release
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: n/a (socket permissions 0700/0600 byte-identical to HEAD; no gate-manifest/CI changes)
- Authority: decision dec_mrcz2q6k (team principal attested by sshd; model B peercred rejected) and the parent-line red line "A3 must land before any socket permission widening"
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: A2 (task_01KX2GHETQZ3HKVMB8EDXCB99C), A5, A4

## Verification

- Base `origin/main` SHA: 204666c7033e7def3b6f317a3053b62e2e99b664
- Branch merge-base with `origin/main`: 204666c7033e7def3b6f317a3053b62e2e99b664
- Last `git fetch origin` time: 2026-07-10 (based on the PR#524 merge commit)
- Sync method: none needed
- Public diff command: `git diff origin/main..codex/a3-honest-credential`
- Private evidence commit/path: task package impl report
- Reviewer evidence path: task package `artifacts/impl-report.md`
- GitHub Actions `rewrite-ci` run URL: pending (will be linked by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (via hermetic `check:local`, 16 steps green)
- [x] `npm run typecheck`
- [x] `npm test` (fast 265/265, contract 344/344; hermetic targeted daemon/CLI suite 52 pass / 1 Windows skip)
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: shards other than 2/4/5 locally (CI covers; shards run with the CI command shape: shard 2 58/58, shard 4 94/94 + 1 Windows skip, shard 5 84/84; boundaries 21/21)

## Review Evidence

- Self-review: red-first controls; full-tree grep with positive control (legacy symbols remain only in the deliberate rejection tests); permission byte-comparison against HEAD
- Reviewer subagent: CEO independently re-ran the grep controls in the worktree (production source zero hits, test-file positive control 4 hits) and verified 0700/0600 lines unchanged
- Human review: pending merge review
- Blocking findings: none

## Residual Risk

- The identity assertion is valid only while 0700/0600 hold; permission widening requires a separately implemented platform-authenticated identity source (that is the A2/A5 line, and the enforced red-line ordering exists precisely for this).
- Deployments with existing `kind: unix-uid` roster entries need the documented one-line migration before roster load succeeds (this repository has no people.yaml; no live migration needed).

## References

- Task: task_01KX2GHHVP1EQ13C3M68SPW0PJ
- Evidence: task package `artifacts/impl-report.md`
- Review: decision dec_mrcz2q6k

---

# 中文

## 概要

daemon 远程/归属线 A3：终结本地 Unix 凭据的谎言。`localUnixPeerCredential()` 自称暴露对端凭据,实际返回 daemon 进程自己的 uid;身份层再把它铸成 `unix-uid` 凭据——语义上宣称「对端就是这个人」。今天 0700/0600 权限让值碰巧正确;未来任何权限放宽都会把所有客户端静默归属为 daemon 属主。本 PR 把机制改名为它实际所是——文件系统属主边界——并让旧形态大声失败。

## 改动内容

- `packages/daemon/src/transport/auth-context.ts`：`UnixPeerCredential`/`unixPeerCredential` 替换为 `UnixSocketOwnerBoundary`/`unixSocketOwnerBoundary`,携带 `ownerUid` 与来源 `unix-socket-filesystem-owner-boundary`;无客户端 uid/gid/pid,无 peer 命名。
- `packages/daemon/src/transport/unix-socket.ts`：边界值取自 `statSync(endpoint).uid`(socket 文件属主——真正的执法主体),非 daemon 进程;注释明言 0700 目录+0600 socket 是授权机制、未观测任何客户端进程。权限与 HEAD 逐字节一致。
- `packages/daemon/src/identity/transport-derived-provider.ts`：只铸 `kind: unix-socket-owner-boundary`;构造的旧 `unixPeerCredential` 形态被忽略,落入既有「did not expose a usable credential」显式失败。
- `packages/daemon/src/identity/people-roster.ts`：已移除的 `unix-uid` kind 在 roster 加载时拒绝——无兼容别名,不许旧身份声明静默存活。迁移=一行 kind 改名(issuer/subject 不变);CLI daemon bootstrap 产出新 kind。
- `docs-release/operations-server-daemon.md`(中英)：如实描述文件系统属主边界,并声明放宽任一权限即令此身份来源失效。
- 测试：红灯先行(诚实解析/旧形态拒绝/旧 kind 拒绝在旧实现上全部打红);真实 socket 集成覆盖 auth context、person 解析、双权限模式。

## 任务与范围

- Harness 任务：task_01KX2GHHVP1EQ13C3M68SPW0PJ
- 分支：codex/a3-honest-credential
- 公开范围：daemon transport auth context、unix socket transport、transport 派生身份 provider、roster kind 校验、barrel 导出、运维文档、测试
- 私有计划 / 证据是否已更新：yes（任务包实施报告）
- 范围外：实现真实平台 peercred（dec_mrcz2q6k 已否——Node 不暴露三平台机制）、A2 forced-command、A5 归属防御、任何 socket 权限改动

## 版本影响

- 版本：不改版本，原因是随下一次计划发布一起出
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用（socket 权限与 HEAD 逐字节一致;gate-manifest/CI 零改动）
- 依据：decision dec_mrcz2q6k（团队 principal 由 sshd 作证;peercred 模型 B 被否）与父线红线「A3 先于任何 socket 权限放宽」
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：A2（task_01KX2GHETQZ3HKVMB8EDXCB99C）、A5、A4

## 验证

- `origin/main` 基准 SHA：204666c7033e7def3b6f317a3053b62e2e99b664
- 当前分支与 `origin/main` 的 merge-base：204666c7033e7def3b6f317a3053b62e2e99b664
- 最近一次 `git fetch origin` 时间：2026-07-10（基线即 PR#524 合并提交）
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main..codex/a3-honest-credential`
- 私有证据 commit/path：任务包实施报告
- Reviewer 证据路径：任务包 `artifacts/impl-report.md`
- GitHub Actions `rewrite-ci` run URL：待 CI 生成后由本 PR checks 关联
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`（hermetic `check:local`,16 步全绿）
- [x] `npm run typecheck`
- [x] `npm test`（fast 265/265、contract 344/344;hermetic 定向 daemon/CLI 52 过/1 Windows skip）
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：shard 2/4/5 之外的分片（CI 覆盖;本地分片用 CI 同款命令:shard2 58/58、shard4 94/94+1 skip、shard5 84/84;boundaries 21/21）

## 审查证据

- 自查：红灯先行;全库 grep 带阳性对照（旧符号仅存于刻意的拒绝测试）;权限与 HEAD 逐字节比对
- Reviewer subagent：CEO 在工作树独立复跑 grep 对照（生产源零命中,测试文件阳性对照 4 命中）并核实 0700/0600 行未动
- 人工审查：合并评审待进行
- 阻塞发现：无

## 残余风险

- 该身份断言仅在 0700/0600 成立时有效;放宽权限必须先有独立实现的平台鉴别身份来源（即 A2/A5 线,红线顺序正为此而设）。
- 存量 `kind: unix-uid` roster 条目需一行迁移后才能加载（本仓无 people.yaml,无实际迁移需求）。

## 关联材料

- 任务：task_01KX2GHHVP1EQ13C3M68SPW0PJ
- 证据：任务包 `artifacts/impl-report.md`
- 审查：decision dec_mrcz2q6k

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
