### PR TITLE
fix: drop stale dequeued label condition from mergify queue rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,7 +27,6 @@ pull_request_rules:
     conditions:
       - base = main
       - label = merge-queue
-      - "-label = dequeued"
     actions:
       queue:
         name: default


### PR DESCRIPTION
# English

## Summary

Remove the stale `-label = dequeued` condition from the Mergify queue rule. It is a leftover from the removed self-heal rule set and was the root cause of a live enqueue/dequeue oscillation on PR #526 (2026-07-10 06:09–06:49 UTC, ~30 cycles at ~80s period, each cycle spawning and cancelling a CI merge train).

## What Changed

- `.mergify.yml`: deleted the `-label = dequeued` condition from the `merge via queue when CI passes` pull request rule (one line).

## Task And Scope

- Harness task: task_01KX5CXS8MVGEES816HZ4YZ9GV
- Branch: fix/mergify-drop-dequeued-condition
- Public scope: `.mergify.yml` only
- Private planning/evidence updated: yes (decision dec_mrekxdgq in the private ledger)
- Out of scope: any other queue/CI configuration; requeue automation

## Version Impact

- Version: no version change because this is CI/queue configuration only, no published artifact is affected.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `.mergify.yml` merge queue rule conditions
- Authority: decision dec_mrekxdgq (accepted 2026-07-10) + harness task task_01KX5CXS8MVGEES816HZ4YZ9GV
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 7a6f25c
- Branch merge-base with `origin/main`: 7a6f25c (branched directly from origin/main)
- Last `git fetch origin` time: 2026-07-10 ~06:50 UTC
- Sync method: none needed
- Public diff command: `git diff origin/main...fix/mergify-drop-dequeued-condition`
- Private evidence commit/path: decision dec_mrekxdgq (private ledger)
- Reviewer evidence path: see References
- GitHub Actions `rewrite-ci` run URL: pending (runs on this PR)
- [x] `git diff --check`
- [ ] `npm ci`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: all npm commands — this change touches only `.mergify.yml` (queue bot configuration read by Mergify, not by any build/test path); CI on this PR is the verification.

## Review Evidence

- Self-review: root-cause dissection of the PR #526 oscillation — Mergify dequeue notifications cite `-label = dequeued` as the unsatisfied queue condition; label add/remove events are all authored by mergify[bot] (state sync); the self-heal rule bodies that consumed this condition were already removed from `.mergify.yml`, leaving the condition as a poison input fed by Mergify's own state output.
- Reviewer subagent: not used (one-line config removal)
- Human review: repository owner acts as merge authority via the queue
- Blocking findings: none

## Residual Risk

- After a genuine merge-train failure, the rule may re-queue a PR whose own checks are green (Mergify's native failure handling still applies). If unbounded retries are ever observed, add a bounded retry policy in a follow-up decision instead of reintroducing label-based conditions.

## References

- Task: task_01KX5CXS8MVGEES816HZ4YZ9GV
- Evidence: PR #526 timeline (label events 06:09–06:49 UTC, mergify[bot]); Mergify dequeue comments on PR #526
- Review: decision dec_mrekxdgq

---

# 中文

## 概要

移除 Mergify 入队规则中残留的 `-label = dequeued` 条件。它是已删除的自愈规则组的漏删残留，也是 PR #526 现场「入队→dequeue」永动振荡的根因（2026-07-10 06:09–06:49 UTC，约 30 轮、周期约 80 秒，每轮起一条 CI merge train 再取消）。

## 改动内容

- `.mergify.yml`：从 `merge via queue when CI passes` 规则的 conditions 中删除 `-label = dequeued`（一行）。

## 任务与范围

- Harness 任务：task_01KX5CXS8MVGEES816HZ4YZ9GV
- 分支：fix/mergify-drop-dequeued-condition
- 公开范围：仅 `.mergify.yml`
- 私有计划 / 证据是否已更新：yes（私有台账决策 dec_mrekxdgq）
- 范围外：其他队列 / CI 配置；requeue 自动化

## 版本影响

- 版本：不改版本，原因是仅改 CI/队列配置，不影响任何发布工件。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`.mergify.yml` 合并队列规则条件
- 依据：决策 dec_mrekxdgq（2026-07-10 已接受）+ harness 任务 task_01KX5CXS8MVGEES816HZ4YZ9GV
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：7a6f25c
- 当前分支与 `origin/main` 的 merge-base：7a6f25c（直接自 origin/main 拉出）
- 最近一次 `git fetch origin` 时间：2026-07-10 约 06:50 UTC
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...fix/mergify-drop-dequeued-condition`
- 私有证据 commit/path：决策 dec_mrekxdgq（私有台账）
- Reviewer 证据路径：见关联材料
- GitHub Actions `rewrite-ci` run URL：待本 PR 触发
- [x] `git diff --check`
- [ ] `npm ci`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：全部 npm 命令——本改动只触碰 `.mergify.yml`（Mergify 读取的队列机器人配置，不进入任何构建/测试路径）；以本 PR 的 CI 为验证。

## 审查证据

- 自查：对 PR #526 振荡做了根因解剖——Mergify dequeue 通知原文指明未满足条件为 `-label = dequeued`；标签加删事件的 actor 全部为 mergify[bot]（状态同步）；消费该条件的自愈规则体已从 `.mergify.yml` 删除，该条件成为由 Mergify 自身状态输出反哺的毒性输入。
- Reviewer subagent：未使用（一行配置删除）
- 人工审查：仓库所有者经队列行使合并权
- 阻塞发现：无

## 残余风险

- 真实 merge-train 失败后，规则可能对自身 checks 全绿的 PR 再次入队（Mergify 原生失败处理仍然生效）。若未来观察到无界重试，走后续决策加有界重试策略，而不是重新引入基于标签的条件。

## 关联材料

- 任务：task_01KX5CXS8MVGEES816HZ4YZ9GV
- 证据：PR #526 时间线（06:09–06:49 UTC 标签事件，mergify[bot]）；PR #526 上的 Mergify dequeue 评论
- 审查：决策 dec_mrekxdgq

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
