### PR TITLE
feat: source task lease enforcement from workspace settings

### DIFF
--- a/packages/cli/src/commands/settings.ts
+++ b/packages/cli/src/commands/settings.ts
@@ -12,6 +12,10 @@ export interface ProjectHarnessIdentity {
   readonly displayName?: string;
 }
 
+export interface ProjectHarnessTaskSettings {
+  readonly leaseEnforcement: boolean;
+}
+
 export interface ProjectHarnessSettings {
   readonly present: boolean;
   readonly locale?: HarnessLocale;
@@ -19,6 +23,7 @@ export interface ProjectHarnessSettings {
   readonly defaultPreset?: string;
   readonly defaultProfile?: string;
   readonly identity?: ProjectHarnessIdentity;
+  readonly tasks: ProjectHarnessTaskSettings;
   readonly customVerticalsEnabled: boolean;
 }
 
@@ -39,6 +44,7 @@ type RawSettings = Record<string, unknown>;
 
 const EMPTY_SETTINGS: ProjectHarnessSettings = {
   present: false,
+  tasks: { leaseEnforcement: false },
   customVerticalsEnabled: false
 };
 
@@ -99,6 +105,21 @@ export function readUserHarnessSettings(rootInput: HarnessLayoutInput, command =
       result: userSettingsError(command, error instanceof Error ? error.message : "Unable to read .harness/user-settings.json.")
     };
   }
+}
+
+/**
+ * Resolves the lease gate for one workspace. The environment is an explicit
+ * operational override; absent that override, the workspace ledger owns the
+ * policy and new or temporary roots remain unenforced by default.
+ */
+export function leaseEnforcementEnabled(
+  rootInput: HarnessLayoutInput,
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  const envOverride = parseLeaseEnforcementEnv(env.HARNESS_TASK_LEASE_ENFORCEMENT);
+  if (envOverride !== undefined) return envOverride;
+  const settings = readProjectHarnessSettings(rootInput, "lease-enforcement");
+  return settings.ok && settings.settings.tasks.leaseEnforcement;
 }
 
 export function customVerticalGateResult(
@@ -166,6 +187,7 @@ function parseSettingsDocument(body: string): { readonly present: boolean; reado
       defaultPreset: fromSettings.defaultPreset ?? decoded.presets?.default,
       defaultProfile: fromSettings.defaultProfile,
       identity: fromSettings.identity,
+      tasks: fromSettings.tasks,
       customVerticals: fromSettings.customVerticals
     };
     return {
@@ -183,6 +205,7 @@ function parseYamlSettings(body: string): { readonly present: boolean; readonly 
   let inSettings = false;
   let inCustomVerticals = false;
   let inIdentity = false;
+  let inTasks = false;
   let foundSettings = false;
 
   for (const rawLine of lines) {
@@ -194,6 +217,7 @@ function parseYamlSettings(body: string): { readonly present: boolean; readonly 
       inSettings = topLevel[1] === "settings";
       inCustomVerticals = false;
       inIdentity = false;
+      inTasks = false;
       foundSettings ||= inSettings;
       if (inSettings && topLevel[2]?.trim()) {
         throw new Error("settings must be a mapping.");
@@ -210,6 +234,7 @@ function parseYamlSettings(body: string): { readonly present: boolean; readonly 
       const value = rawValue.trim();
       inCustomVerticals = key === "customVerticals";
       inIdentity = key === "identity";
+      inTasks = key === "tasks";
       if (inCustomVerticals) {
         if (value) throw new Error("settings.customVerticals must be a mapping.");
         settings.customVerticals = {};
@@ -218,6 +243,11 @@ function parseYamlSettings(body: string): { readonly present: boolean; readonly 
       if (inIdentity) {
         if (value) throw new Error("settings.identity must be a mapping.");
         settings.identity = {};
+        continue;
+      }
+      if (inTasks) {
+        if (value) throw new Error("settings.tasks must be a mapping.");
+        settings.tasks = {};
         continue;
       }
       if (!isKnownSettingsScalar(key)) throw new Error(`Unknown settings key: ${key}`);
@@ -243,6 +273,14 @@ function parseYamlSettings(body: string): { readonly present: boolean; readonly 
       settings.identity = { ...(isRecord(settings.identity) ? settings.identity : {}), [key]: unquoteScalar(value) };
       continue;
     }
+    if (inTasks && customNested) {
+      const [, key, rawValue = ""] = customNested;
+      if (key !== "leaseEnforcement") throw new Error(`Unknown settings.tasks key: ${key}`);
+      const value = rawValue.trim();
+      if (value !== "true" && value !== "false") throw new Error("settings.tasks.leaseEnforcement must be true or false.");
+      settings.tasks = { leaseEnforcement: value === "true" };
+      continue;
+    }
 
     throw new Error(`Unsupported settings YAML line: ${withoutComment.trim()}`);
   }
@@ -263,6 +301,14 @@ function validateSettings(command: string, raw: RawSettings): SettingsResult {
   if (!defaultProfile.ok) return invalid(command, defaultProfile.message);
   const identity = validateIdentity(command, raw.identity);
   if (!identity.ok) return identity;
+  const tasks = raw.tasks;
+  if (tasks !== undefined) {
+    if (!isRecord(tasks)) return invalid(command, "settings.tasks must be a mapping.");
+    const keys = Object.keys(tasks);
+    if (keys.length !== 1 || keys[0] !== "leaseEnforcement" || typeof tasks.leaseEnforcement !== "boolean") {
+      return invalid(command, "settings.tasks.leaseEnforcement must be a boolean.");
+    }
+  }
   const customVerticals = raw.customVerticals;
   if (customVerticals !== undefined) {
     if (!isRecord(customVerticals)) {
@@ -283,6 +329,7 @@ function validateSettings(command: string, raw: RawSettings): SettingsResult {
       defaultPreset: normalizeDefaultSentinel(defaultPreset.value),
       defaultProfile: normalizeDefaultSentinel(defaultProfile.value),
       ...(identity.value ? { identity: identity.value } : {}),
+      tasks: { leaseEnforcement: isRecord(tasks) && tasks.leaseEnforcement === true },
       customVerticalsEnabled: isRecord(customVerticals) ? customVerticals.enabled === true : false
     }
   };
@@ -342,6 +389,19 @@ function userSettingsError(command: string, hint: string): CliResult {
 
 function isKnownSettingsScalar(key: string): boolean {
   return key === "locale" || key === "defaultVertical" || key === "defaultPreset" || key === "defaultProfile";
+}
+
+function parseLeaseEnforcementEnv(value: string | undefined): boolean | undefined {
+  switch (value?.trim().toLowerCase()) {
+    case "1":
+    case "true":
+      return true;
+    case "0":
+    case "false":
+      return false;
+    default:
+      return undefined;
+  }
 }
 
 function hasExactKeys(value: Record<string, unknown>, expected: ReadonlyArray<string>): boolean {

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -43,7 +43,15 @@ export async function runRegisteredCommandWithCliComposition(
     rootDir: command.rootDir,
     layoutOverrides: command.layoutOverrides
   };
-  const enforceTaskLease = leaseEnforcementEnabled(layoutInput);
+  let enforceTaskLeaseResolved = false;
+  let enforceTaskLeaseValue = false;
+  const enforceTaskLease = () => {
+    if (!enforceTaskLeaseResolved) {
+      enforceTaskLeaseValue = leaseEnforcementEnabled(layoutInput);
+      enforceTaskLeaseResolved = true;
+    }
+    return enforceTaskLeaseValue;
+  };
   let currentSessionProbe: ReturnType<typeof makeEnvironmentCurrentSessionProbe> | undefined;
   const getCurrentSessionProbe = () => {
     currentSessionProbe ??= makeEnvironmentCurrentSessionProbe();
@@ -140,7 +148,7 @@ export async function runRegisteredCommandWithCliComposition(
       provenanceSessionExporter: makeSessionExporter(),
       syncExportedSession
     }, boundAt)
-  }), enforceTaskLease, makeTaskHolder, getTaskHolderPrincipal), makeArtifactStore, getCurrentSessionProbe, makeSessionExporter, syncExportedSession, makeWriteCoordinator, getActorAttribution, getTaskHolderPrincipal, () => makeDecisionWriteService({
+  }), enforceTaskLease(), makeTaskHolder, getTaskHolderPrincipal), makeArtifactStore, getCurrentSessionProbe, makeSessionExporter, syncExportedSession, makeWriteCoordinator, getActorAttribution, getTaskHolderPrincipal, () => makeDecisionWriteService({
     rootInput: layoutInput,
     coordinator: makeWriteCoordinator({ kind: "agent", id: "decision-cli" }),
     currentSessionProbe: getCurrentSessionProbe(),
@@ -152,7 +160,7 @@ export async function runRegisteredCommandWithCliComposition(
     currentSessionProbe: getCurrentSessionProbe(),
     provenanceSessionExporter: makeSessionExporter(),
     syncExportedSession
-  }), enforceTaskLease, makeTaskHolder, getTaskHolderPrincipal), makeTaskHolder, () => makeRuntimeEventLedgerService({
+  }), enforceTaskLease(), makeTaskHolder, getTaskHolderPrincipal), makeTaskHolder, () => makeRuntimeEventLedgerService({
     rootInput: layoutInput,
     coordinator: makeWriteCoordinator({ kind: "agent", id: "runtime-event-cli" })
   }), provider.runLedgerMaterializer).pipe(

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -18,6 +18,7 @@ import { toCliError } from "../cli/error-mapper.ts";
 import { actionTaskId } from "../cli/parse-args.ts";
 import { requiresConflictMarkerPreflight, runRegisteredCommand } from "../cli/runner-registry.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
+import { leaseEnforcementEnabled } from "../commands/settings.ts";
 import { CliActorAttributionError, resolveLocalCliActorAttribution, type CliActorAttribution } from "./actor-attribution.ts";
 import { CliPrincipalResolutionError, readConfiguredLocalPrincipal, resolveCliTaskHolderPrincipal } from "./local-principal.ts";
 import {
@@ -42,6 +43,7 @@ export async function runRegisteredCommandWithCliComposition(
     rootDir: command.rootDir,
     layoutOverrides: command.layoutOverrides
   };
+  const enforceTaskLease = leaseEnforcementEnabled(layoutInput);
   let currentSessionProbe: ReturnType<typeof makeEnvironmentCurrentSessionProbe> | undefined;
   const getCurrentSessionProbe = () => {
     currentSessionProbe ??= makeEnvironmentCurrentSessionProbe();
@@ -138,7 +140,7 @@ export async function runRegisteredCommandWithCliComposition(
       provenanceSessionExporter: makeSessionExporter(),
       syncExportedSession
     }, boundAt)
-  }), makeTaskHolder, getTaskHolderPrincipal), makeArtifactStore, getCurrentSessionProbe, makeSessionExporter, syncExportedSession, makeWriteCoordinator, getActorAttribution, getTaskHolderPrincipal, () => makeDecisionWriteService({
+  }), enforceTaskLease, makeTaskHolder, getTaskHolderPrincipal), makeArtifactStore, getCurrentSessionProbe, makeSessionExporter, syncExportedSession, makeWriteCoordinator, getActorAttribution, getTaskHolderPrincipal, () => makeDecisionWriteService({
     rootInput: layoutInput,
     coordinator: makeWriteCoordinator({ kind: "agent", id: "decision-cli" }),
     currentSessionProbe: getCurrentSessionProbe(),
@@ -150,7 +152,7 @@ export async function runRegisteredCommandWithCliComposition(
     currentSessionProbe: getCurrentSessionProbe(),
     provenanceSessionExporter: makeSessionExporter(),
     syncExportedSession
-  }), makeTaskHolder, getTaskHolderPrincipal), makeTaskHolder, () => makeRuntimeEventLedgerService({
+  }), enforceTaskLease, makeTaskHolder, getTaskHolderPrincipal), makeTaskHolder, () => makeRuntimeEventLedgerService({
     rootInput: layoutInput,
     coordinator: makeWriteCoordinator({ kind: "agent", id: "runtime-event-cli" })
   }), provider.runLedgerMaterializer).pipe(
@@ -177,10 +179,11 @@ type TaskHolderPrincipalFactory = () => TaskHolderPrincipal;
 
 function withOptionalLeaseGuard(
   engine: LifecycleEngine,
+  enabled: boolean,
   makeTaskHolder: TaskHolderServiceFactory,
   getTaskHolderPrincipal: TaskHolderPrincipalFactory
 ): LifecycleEngine {
-  if (!leaseEnforcementEnabled()) return engine;
+  if (!enabled) return engine;
   const guard = (taskId: string) => assertTaskLease(taskId, makeTaskHolder, getTaskHolderPrincipal);
   return {
     ...engine,
@@ -195,10 +198,11 @@ function withOptionalLeaseGuard(
 
 function withOptionalFactLeaseGuard(
   service: FactWriteService,
+  enabled: boolean,
   makeTaskHolder: TaskHolderServiceFactory,
   getTaskHolderPrincipal: TaskHolderPrincipalFactory
 ): FactWriteService {
-  if (!leaseEnforcementEnabled()) return service;
+  if (!enabled) return service;
   const guard = (taskId: string) => assertTaskLease(taskId, makeTaskHolder, getTaskHolderPrincipal);
   return {
     ...service,
@@ -240,11 +244,6 @@ function taskLeaseWriteError(error: unknown): WriteError {
     };
   }
   return { _tag: "JournalUnavailable", cause: error };
-}
-
-function leaseEnforcementEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  const value = env.HARNESS_TASK_LEASE_ENFORCEMENT?.trim().toLowerCase();
-  return value === "1" || value === "true";
 }
 
 function withConflictMarkerFlushRecheck(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,6 +35,7 @@ import { daemonIdFromEnv, daemonUserRoot, localUserDaemonEndpoint, runCommandThr
 import { createCliCommandService } from "./daemon/command-service.ts";
 import { makeDocSyncService } from "./daemon/doc-sync-service.ts";
 import { makeDaemonQueuedWriteCoordinator } from "./daemon/queued-write-coordinator.ts";
+import { leaseEnforcementEnabled } from "./commands/settings.ts";
 import { makeMarkdownArtifactStore } from "../../kernel/src/index.ts";
 
 const runRegisteredCommand = runRegisteredCommandWithCliComposition;
@@ -266,6 +267,7 @@ function createDaemonServiceHost(
       services: defaultRepoBinding().services,
       resolveRepoServices: (repo) => repoBindings.get(repo.repoId)?.services,
       resolveRepoAvailability: (repo) => repoAvailabilityFailure(runtime, repo),
+      leaseEnforcementEnabled: (repo) => leaseEnforcementEnabled({ rootDir: repo.canonicalRoot, layoutOverrides }),
       authContext,
       ...(defaultRepoBinding().identity.identityProvider ? { identityProvider: defaultRepoBinding().identity.identityProvider } : {}),
       ...(defaultRepoBinding().identity.peopleRoster ? { peopleRoster: defaultRepoBinding().identity.peopleRoster } : {}),

--- a/packages/cli/test/task-lease-cli.test.ts
+++ b/packages/cli/test/task-lease-cli.test.ts
@@ -9,22 +9,58 @@ import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
 
-test("task lease enforcement defaults off and rejects progress writes when enabled without a lease", () => {
+test("task lease enforcement defaults off without configuration or environment", () => {
   withTempRoot((rootDir) => {
-    writeHarnessIdentity(rootDir, "person_tester", "Harness Tester");
     const created = runJson(rootDir, ["new-task", "--title", "Task One"]);
     const taskId = assertGeneratedTaskId(created.taskId);
 
-    const defaultOff = runJson(rootDir, ["task", "progress", "append", taskId, "--text", "discipline period write"]);
-    assert.equal(defaultOff.ok, true);
-    assert.match(readFileSync(path.join(rootDir, `harness/tasks/${taskId}-task-one/progress.md`), "utf8"), /discipline period write/u);
+    const write = runJson(rootDir, ["task", "progress", "append", taskId, "--text", "default off write"]);
+    assert.equal(write.ok, true);
+    assert.match(readFileSync(path.join(rootDir, `harness/tasks/${taskId}-task-one/progress.md`), "utf8"), /default off write/u);
+  });
+});
 
-    const rejected = runJson(rootDir, ["task", "progress", "append", taskId, "--text", "guarded write"], false, {
+test("workspace lease configuration rejects unclaimed writes and permits the claimed writer", () => {
+  withTempRoot((rootDir) => {
+    writeHarnessLeaseEnforcement(rootDir, true);
+    const created = runJson(rootDir, ["new-task", "--title", "Configured Lease"]);
+    const taskId = assertGeneratedTaskId(created.taskId);
+
+    const rejected = runJson(rootDir, ["task", "progress", "append", taskId, "--text", "unclaimed write"], false);
+    assert.equal(rejected.ok, false);
+    assert.equal(rejected.error?.code, "write_rejected");
+    assert.match(rejected.error?.hint ?? "", /requires an active lease/u);
+
+    const claimed = runJson(rootDir, ["task", "claim", taskId]);
+    assert.equal(claimed.ok, true);
+    const accepted = runJson(rootDir, ["task", "progress", "append", taskId, "--text", "claimed write"]);
+    assert.equal(accepted.ok, true);
+  });
+});
+
+test("explicit false environment override disables configured lease enforcement", () => {
+  withTempRoot((rootDir) => {
+    writeHarnessLeaseEnforcement(rootDir, true);
+    const created = runJson(rootDir, ["new-task", "--title", "Environment Disabled Lease"]);
+    const taskId = assertGeneratedTaskId(created.taskId);
+
+    const write = runJson(rootDir, ["task", "progress", "append", taskId, "--text", "env disabled write"], true, {
+      HARNESS_TASK_LEASE_ENFORCEMENT: "0"
+    });
+    assert.equal(write.ok, true);
+  });
+});
+
+test("explicit true environment override enables lease enforcement without configuration", () => {
+  withTempRoot((rootDir) => {
+    const created = runJson(rootDir, ["new-task", "--title", "Environment Enabled Lease"]);
+    const taskId = assertGeneratedTaskId(created.taskId);
+
+    const rejected = runJson(rootDir, ["task", "progress", "append", taskId, "--text", "env enabled write"], false, {
       HARNESS_TASK_LEASE_ENFORCEMENT: "1"
     });
     assert.equal(rejected.ok, false);
     assert.equal(rejected.error?.code, "write_rejected");
-    assert.match(rejected.error?.hint ?? "", /requires an active lease/u);
   });
 });
 
@@ -151,6 +187,17 @@ function writeHarnessIdentity(rootDir: string, personId: string, displayName: st
   ]);
 }
 
+function writeHarnessLeaseEnforcement(rootDir: string, enabled: boolean): void {
+  writeHarnessConfig(rootDir, [
+    "settings:",
+    "  identity:",
+    "    personId: person_tester",
+    "    displayName: Harness Tester",
+    "  tasks:",
+    `    leaseEnforcement: ${enabled}`
+  ]);
+}
+
 function writeHarnessConfig(rootDir: string, extraLines: ReadonlyArray<string> = []): void {
   const harnessRoot = path.join(rootDir, "harness");
   mkdirSync(harnessRoot, { recursive: true });
@@ -182,15 +229,20 @@ function writePeopleRoster(rootDir: string, personId: string, displayName: strin
 
 function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true, env: Readonly<Record<string, string>> = {}): Record<string, any> {
   try {
+    const childEnv = {
+      ...process.env,
+      HARNESS_ACTOR: "human:tester",
+      HARNESS_GIT_AUTHOR_NAME: "Harness Tester",
+      HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test",
+      ...env
+    };
+    delete childEnv.HARNESS_TASK_LEASE_ENFORCEMENT;
+    if (env.HARNESS_TASK_LEASE_ENFORCEMENT !== undefined) {
+      childEnv.HARNESS_TASK_LEASE_ENFORCEMENT = env.HARNESS_TASK_LEASE_ENFORCEMENT;
+    }
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_ACTOR: "human:tester",
-        HARNESS_GIT_AUTHOR_NAME: "Harness Tester",
-        HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test",
-        ...env
-      }
+      env: childEnv
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -73,6 +73,8 @@ export interface JsonRpcServerOptions {
   readonly services: DaemonServiceHost;
   readonly resolveRepoServices?: (repo: DaemonRepoNamespace) => DaemonServiceHost | undefined;
   readonly resolveRepoAvailability?: (repo: DaemonRepoNamespace) => DaemonRepoAvailabilityFailure | undefined;
+  /** Workspace policy resolver supplied by the CLI composition root. */
+  readonly leaseEnforcementEnabled?: (repo: DaemonRepoNamespace) => boolean;
   readonly authContext?: DaemonAuthenticationContext;
   readonly identityProvider?: IdentityProvider;
   readonly peopleRoster?: PeopleRoster;
@@ -281,7 +283,7 @@ async function callServiceMethod(
       ? successReceipt(contract.method, `completed ${contract.method}`, result as unknown as JsonObject)
       : failureReceipt(contract.method, result.code, result.reason, { data: result as unknown as JsonObject });
   }
-  const taskLeaseFailure = await validateTaskLeaseForServiceWrite(contract, payload, services, actor);
+  const taskLeaseFailure = await validateTaskLeaseForServiceWrite(contract, payload, services, actor, repo, options);
   if (taskLeaseFailure) return taskLeaseFailure;
   const result = contract.service === "TerminalSessionService"
     ? await invokeServiceMethod(services.TerminalSessionService, String(contract.serviceMethod), payload)
@@ -344,9 +346,11 @@ async function validateTaskLeaseForServiceWrite(
   contract: JsonRpcMethodContract,
   payload: JsonObject | undefined,
   services: DaemonServiceHost,
-  actor: AuthenticatedActor | undefined
+  actor: AuthenticatedActor | undefined,
+  repo: DaemonRepoNamespace | undefined,
+  options: JsonRpcServerOptions
 ): Promise<ReturnType<typeof failureReceipt> | undefined> {
-  if (!taskLeaseEnforcementEnabled() || !taskLeaseGuardedRouteIds.has(contract.routeId ?? "")) return undefined;
+  if (!repo || !options.leaseEnforcementEnabled?.(repo) || !taskLeaseGuardedRouteIds.has(contract.routeId ?? "")) return undefined;
   const taskId = typeof payload?.taskId === "string" ? payload.taskId : undefined;
   if (!taskId) return failureReceipt(contract.method, "task_id_required", "Task lease enforcement requires payload.taskId.");
   if (!services.TaskHolderService) {
@@ -368,11 +372,6 @@ const taskLeaseGuardedRouteIds = new Set<string>([
   "tasks.status.set",
   "tasks.progress.append"
 ]);
-
-function taskLeaseEnforcementEnabled(): boolean {
-  const value = process.env.HARNESS_TASK_LEASE_ENFORCEMENT?.toLowerCase();
-  return value === "1" || value === "true";
-}
 
 function resolveServicesForRepo(
   method: string,

--- a/packages/daemon/test/task-holder-rpc.test.ts
+++ b/packages/daemon/test/task-holder-rpc.test.ts
@@ -14,6 +14,7 @@ import {
   type JsonRpcResponse,
   type PeopleRoster
 } from "../src/index.ts";
+import { leaseEnforcementEnabled } from "../../cli/src/commands/settings.ts";
 
 test("task holder RPC claims, reports collisions with holder and expiry, and releases", async () => {
   const rootDir = createHarnessRoot();
@@ -83,11 +84,11 @@ test("task holder RPC records asserted executor and responsible human in holder 
   }
 });
 
-test("task lease enforcement guards daemon task progress API writes when enabled", async () => {
+test("task lease enforcement guards daemon task progress API writes when enabled by workspace configuration", async () => {
   const previous = process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
-  const rootDir = createHarnessRoot();
+  const rootDir = createHarnessRoot(["settings:", "  tasks:", "    leaseEnforcement: true"]);
   try {
-    process.env.HARNESS_TASK_LEASE_ENFORCEMENT = "1";
+    delete process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
     let progressWrites = 0;
     const { alice, maint } = makeActorServers(rootDir, {
       ...emptyLocalController(),
@@ -117,6 +118,42 @@ test("task lease enforcement guards daemon task progress API writes when enabled
     assert.equal(denied.details.holder.principal.personId, "person_alice");
     assert.equal(denied.details.leaseExpiresAt, "2026-07-10T00:01:00.000Z");
     assert.equal(progressWrites, 0);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
+    } else {
+      process.env.HARNESS_TASK_LEASE_ENFORCEMENT = previous;
+    }
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("daemon lease enforcement accepts explicit environment disable over workspace configuration", async () => {
+  const previous = process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
+  const rootDir = createHarnessRoot(["settings:", "  tasks:", "    leaseEnforcement: true"]);
+  try {
+    process.env.HARNESS_TASK_LEASE_ENFORCEMENT = "0";
+    let progressWrites = 0;
+    const { maint } = makeActorServers(rootDir, {
+      ...emptyLocalController(),
+      appendTaskProgress: async () => {
+        progressWrites += 1;
+        return { ok: true };
+      }
+    });
+    await hello(maint);
+
+    const result = resultReceipt(await maint.handle({
+      jsonrpc: "2.0",
+      id: "progress-lease-env-disabled",
+      method: "repo.tasks.progress.append",
+      params: {
+        repo: { repoId: "canonical" },
+        payload: { taskId: "task_01KX19GEKWMEJNGSMRT6JJH6HY", text: "allowed by env" }
+      }
+    }));
+    assert.equal(result.ok, true);
+    assert.equal(progressWrites, 1);
   } finally {
     if (previous === undefined) {
       delete process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
@@ -165,6 +202,7 @@ function createActorServer(
       sshExecUser: { username, host: "team-host", source: "ssh-authenticated-exec" }
     },
     services,
+    leaseEnforcementEnabled: (repo) => leaseEnforcementEnabled(repo.canonicalRoot),
     appendRuntimeEvent
   });
 }
@@ -254,9 +292,9 @@ function sampleRoster(): PeopleRoster {
   ].join("\n"));
 }
 
-function createHarnessRoot(): string {
+function createHarnessRoot(settings: ReadonlyArray<string> = []): string {
   const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-task-holder-rpc-"));
   mkdirSync(path.join(rootDir, "harness"), { recursive: true });
-  writeFileSync(path.join(rootDir, "harness/harness.yaml"), "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n", "utf8");
+  writeFileSync(path.join(rootDir, "harness/harness.yaml"), ["schema: harness-anything/v1", "layout:", "  authoredRoot: harness", ...settings, ""].join("\n"), "utf8");
   return rootDir;
 }

--- a/packages/kernel/fixtures/schemas/harness-config/valid.json
+++ b/packages/kernel/fixtures/schemas/harness-config/valid.json
@@ -33,6 +33,9 @@
       "personId": "person_zeyu",
       "displayName": "Zeyu Li"
     },
+    "tasks": {
+      "leaseEnforcement": true
+    },
     "customVerticals": {
       "enabled": false
     }

--- a/packages/kernel/schemas/json/harness-config.schema.json
+++ b/packages/kernel/schemas/json/harness-config.schema.json
@@ -27,6 +27,14 @@
           },
           "additionalProperties": false
         },
+        "tasks": {
+          "type": "object",
+          "required": ["leaseEnforcement"],
+          "properties": {
+            "leaseEnforcement": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        },
         "customVerticals": {
           "type": "object",
           "required": ["enabled"],

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -86,6 +86,9 @@ export const HarnessConfigSchema = Schema.Struct({
       personId: ConfigIdentifierSchema,
       displayName: Schema.optional(Schema.String)
     })),
+    tasks: Schema.optional(Schema.Struct({
+      leaseEnforcement: Schema.Boolean
+    })),
     customVerticals: Schema.optional(Schema.Struct({
       enabled: Schema.Boolean
     }))


### PR DESCRIPTION
# English

## Summary

Source task lease enforcement from workspace settings instead of a bare environment variable. Decision dec_mregis82 C2 ruled the env switch (`HARNESS_TASK_LEASE_ENFORCEMENT`) a bootstrap, not the terminal state: an unset process equals no gate, and the env gate is root-agnostic — setting it shell-wide poisons every hermetic temp-root integration test (proven live on 2026-07-10 when a shell-wide export turned shard 3 red). The gate must travel with the workspace it governs, like `settings.identity` and the preset policy seam.

## What Changed

- `settings.tasks.leaseEnforcement: boolean` added to the harness config across all three schema surfaces: Effect schema (`packages/kernel/src/schemas/registry.ts`), JSON schema (`packages/kernel/schemas/json/harness-config.schema.json`), and the settings reader.
- Single resolver `leaseEnforcementEnabled(rootInput, env)` replaces the env-only check in `packages/cli/src/composition/command-executor.ts`. Priority: explicit env override wins both ways (`"1"/"true"` force-on, `"0"/"false"` force-off) > workspace config > default **off**. Temp/new workspaces without config stay gateless, so hermetic tests are unaffected.
- Daemon RPC path converges on the same resolver: `packages/daemon/src/transport/json-rpc-server.ts` no longer reads the env itself; composition injects the resolver per canonical root.
- Enforcement boundaries unchanged: lifecycle/progress/fact writer guards neither widened nor narrowed.
- Five hermetic test groups cover the priority matrix (no config no env → off; config true → lease required, claim passes; config true + env "0" → off; no config + env "1" → on; RPC path 14/14).

## Task And Scope

- Harness task: task_01KX561PZJ6R1SQ88JXBCBRQ3N
- Branch: codex/lease-config-enforcement
- Public scope: kernel config schemas, settings reader, CLI composition resolver, daemon RPC wiring, tests (9 files, +200/−36)
- Private planning/evidence updated: yes (decision dec_mregis82 and task package in the private ledger)
- Out of scope: flipping the real workspace config (CEO does that in the private ledger after this merges); changing enforcement boundaries

## Version Impact

- Version: no version change because the config field is optional and backward compatible; default behavior without config or env is unchanged (gate off).
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: decision dec_mregis82 (accepted; C2 env-is-bootstrap ruling), task task_01KX561PZJ6R1SQ88JXBCBRQ3N
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: CEO flips `settings.tasks.leaseEnforcement: true` in the canonical workspace after merge

## Verification

- Base `origin/main` SHA: 13e720b
- Branch merge-base with `origin/main`: 13e720b (rebased onto latest main before push)
- Last `git fetch origin` time: 2026-07-10 ~07:27 UTC
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/lease-config-enforcement`
- Private evidence commit/path: task package impl-report for task_01KX561PZJ6R1SQ88JXBCBRQ3N (private ledger)
- Reviewer evidence path: see References
- GitHub Actions `rewrite-ci` run URL: pending (runs on this PR)
- [x] `npm run check` (as `npm run check:local` fast tier, 44.2s, green after rebase)
- [x] `npm run harness:check-schema-contracts` (within check:local)
- [x] boundaries job: `node tools/run-manifest-gates.mjs --workflow-job boundaries --exclude mergify-queue-metadata-edit-noop` with GitHub token (green, pre-rebase; rebase brought preset-seam and Mergify-config changes, no boundary overlap)
- [x] Affected integration shard, CI-shape: `node tools/run-manifest-gates.mjs --workflow-job integration-shard --shard N --exclude mergify-queue-metadata-edit-noop` (green, pre-rebase)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run typecheck` (covered by check:local fast tier and CI)
- [ ] `npm test` (integration covered by CI shards)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: remaining checklist items individually — covered by the manifest-driven gate runner above and by CI on this PR.

## Review Evidence

- Self-review: CEO verified the resolver priority matrix against dec_mregis82 C2 (default off, env explicit override both directions, config as workspace-carried terminal state) and confirmed the daemon RPC path no longer reads env directly. A live incident (shell-wide env export poisoning temp-root tests) validated the design premise the same day.
- Reviewer subagent: implementation authored by Codex worker; CEO completed the final boundaries verification and commit.
- Human review: repository owner acts as merge authority via the queue.
- Blocking findings: none

## Residual Risk

- The settings reader validates keys strictly: flipping the workspace config before this change is deployed breaks ha write commands with `harness_settings_invalid` (observed live). Mitigation: flip only after merge and dist rebuild.
- Enforcement remains off by default everywhere until a workspace opts in — intentional per C2.

## References

- Task: task_01KX561PZJ6R1SQ88JXBCBRQ3N
- Evidence: decision dec_mregis82 (claim/lease gate opening, C2)
- Review: task package impl-report (private ledger)

---

# 中文

## 概要

任务 lease 执法开关从裸环境变量改为 workspace 配置承载。裁决 dec_mregis82 C2 认定 env 开关（`HARNESS_TASK_LEASE_ENFORCEMENT`）是 bootstrap 而非终态：未设变量的进程等于无门，且 env 门是 root 无关的——shell 级导出会毒化全部 hermetic 临时根集成测试（2026-07-10 当天实证：全局 export 导致 shard 3 假红）。门必须跟着它治理的 workspace 走，与 `settings.identity`、preset policy 接缝同一哲学。

## 改动内容

- harness 配置三处 schema 面同步新增 `settings.tasks.leaseEnforcement: boolean`：Effect schema（`packages/kernel/src/schemas/registry.ts`）、JSON schema（`packages/kernel/schemas/json/harness-config.schema.json`）、settings reader。
- 单一 resolver `leaseEnforcementEnabled(rootInput, env)` 取代 `packages/cli/src/composition/command-executor.ts` 中只读 env 的实现。优先级：显式 env 双向覆盖（`"1"/"true"` 强制开，`"0"/"false"` 强制关）> workspace 配置 > 代码默认 **off**。无配置的临时/新工作区保持无门，hermetic 测试不受影响。
- daemon RPC 路径收敛到同一 resolver：`packages/daemon/src/transport/json-rpc-server.ts` 不再自读 env，由 composition 按 canonical root 注入。
- 执法边界不动：lifecycle/progress/fact 三 writer 守卫不扩不缩。
- 五组 hermetic 测试覆盖优先级矩阵（无配置无 env → 关；配置 true → 需 lease，claim 后通过；配置 true + env "0" → 关；无配置 + env "1" → 开；RPC 路径 14/14）。

## 任务与范围

- Harness 任务：task_01KX561PZJ6R1SQ88JXBCBRQ3N
- 分支：codex/lease-config-enforcement
- 公开范围：kernel 配置 schema、settings reader、CLI composition resolver、daemon RPC 接线、测试（9 文件，+200/−36）
- 私有计划 / 证据是否已更新：yes（私有台账中的决策 dec_mregis82 与任务包）
- 范围外：真实 workspace 配置的翻转（合并后由 CEO 在私有台账落）；执法边界变更

## 版本影响

- 版本：不改版本，原因是配置字段可选且向后兼容；无配置无 env 时默认行为不变（门关）。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：决策 dec_mregis82（已接受；C2「env 是 bootstrap」裁定）、任务 task_01KX561PZJ6R1SQ88JXBCBRQ3N
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：合并后 CEO 在 canonical workspace 落 `settings.tasks.leaseEnforcement: true`

## 验证

- `origin/main` 基准 SHA：13e720b
- 当前分支与 `origin/main` 的 merge-base：13e720b（push 前已 rebase 到最新 main）
- 最近一次 `git fetch origin` 时间：2026-07-10 约 07:27 UTC
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...codex/lease-config-enforcement`
- 私有证据 commit/path：task_01KX561PZJ6R1SQ88JXBCBRQ3N 任务包 impl-report（私有台账）
- Reviewer 证据路径：见关联材料
- GitHub Actions `rewrite-ci` run URL：待本 PR 触发
- [x] `npm run check`（以 `npm run check:local` fast 档执行，44.2s，rebase 后绿）
- [x] `npm run harness:check-schema-contracts`（含于 check:local）
- [x] boundaries job：`node tools/run-manifest-gates.mjs --workflow-job boundaries --exclude mergify-queue-metadata-edit-noop` 带 GitHub token（绿，rebase 前；rebase 仅引入 preset 接缝与 Mergify 配置改动，与边界面无交集）
- [x] 受影响 integration shard，CI 同款命令：`node tools/run-manifest-gates.mjs --workflow-job integration-shard --shard N --exclude mergify-queue-metadata-edit-noop`（绿，rebase 前）
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run typecheck`（由 check:local fast 档与 CI 覆盖）
- [ ] `npm test`（integration 由 CI shards 覆盖）
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：其余清单项未单独执行——由上述 manifest 驱动 gate runner 与本 PR 的 CI 覆盖。

## 审查证据

- 自查：CEO 按 dec_mregis82 C2 核验 resolver 优先级矩阵（默认 off、env 双向显式覆盖、配置作为跟随 workspace 的终态），并确认 daemon RPC 路径不再直读 env。同日的现场事故（shell 级 env 导出毒化临时根测试）反向验证了设计前提。
- Reviewer subagent：实现由 Codex worker 完成；CEO 补跑最后的 boundaries 验证并完成 commit。
- 人工审查：仓库所有者经队列行使合并权。
- 阻塞发现：无

## 残余风险

- settings reader 严格校验键名：在本改动部署前提前落 workspace 配置会使 ha 写命令报 `harness_settings_invalid`（已现场观察到）。缓解：合并且 dist 重建后再落。
- 在任何 workspace 显式开启前，执法默认全局关闭——C2 的设计意图。

## 关联材料

- 任务：task_01KX561PZJ6R1SQ88JXBCBRQ3N
- 证据：决策 dec_mregis82（claim/lease 开门，C2）
- 审查：任务包 impl-report（私有台账）

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
