### PR TITLE
fix: make task-holder lease claims atomic across processes

### DIFF
--- a/packages/application/test/fixtures/task-holder-claim-worker.ts
+++ b/packages/application/test/fixtures/task-holder-claim-worker.ts
@@ -1,0 +1,28 @@
+import { createInterface } from "node:readline";
+import { makeTaskHolderService, taskHolderActor } from "../../src/index.ts";
+
+const [rootDir, personId] = process.argv.slice(2);
+if (!rootDir || !personId) throw new Error("task-holder claim worker requires rootDir and personId");
+
+const service = makeTaskHolderService({
+  rootInput: rootDir,
+  now: () => new Date("2026-07-10T00:00:00.000Z")
+});
+const principal = taskHolderActor({ personId }, null);
+const lines = createInterface({ input: process.stdin, crlfDelay: Number.POSITIVE_INFINITY });
+
+process.stdout.write(`${JSON.stringify({ ready: true })}\n`);
+
+for await (const line of lines) {
+  const input = JSON.parse(line) as { readonly taskId: string };
+  try {
+    await service.claim({ taskId: input.taskId, principal, ttlMs: 60_000 });
+    process.stdout.write(`${JSON.stringify({ taskId: input.taskId, ok: true })}\n`);
+  } catch (error) {
+    process.stdout.write(`${JSON.stringify({
+      taskId: input.taskId,
+      ok: false,
+      code: error instanceof Error && "code" in error ? error.code : "unknown"
+    })}\n`);
+  }
+}

--- a/packages/application/test/task-holder-service.test.ts
+++ b/packages/application/test/task-holder-service.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { createInterface, type Interface } from "node:readline";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   TaskClaimCollisionError,
   TaskLeaseRequiredError,
@@ -17,6 +20,32 @@ const alice = taskHolderActor({ personId: "alice", displayName: "Alice" }, null)
 const aliceCodex = taskHolderActor({ personId: "alice", displayName: "Alice" }, { kind: "agent", id: "codex" }) satisfies TaskHolderPrincipal;
 const aliceClaude = taskHolderActor({ personId: "alice", displayName: "Alice" }, { kind: "agent", id: "claude-code" }) satisfies TaskHolderPrincipal;
 const bob = taskHolderActor({ personId: "bob", displayName: "Bob" }, null) satisfies TaskHolderPrincipal;
+
+test("independent task holder services atomically claim the same task", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-holder-race-"));
+  const aliceWorker = startClaimWorker(rootDir, "alice");
+  const bobWorker = startClaimWorker(rootDir, "bob");
+  try {
+    await Promise.all([aliceWorker.next(), bobWorker.next()]);
+    const suffixes = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+    for (const suffix of suffixes) {
+      const racedTaskId = `task_01KX19GEKWMEJNGSMRT6JJH6H${suffix}`;
+      aliceWorker.send(racedTaskId);
+      bobWorker.send(racedTaskId);
+      const results = await Promise.all([aliceWorker.next(), bobWorker.next()]);
+
+      assert.equal(results.filter((result) => result.ok).length, 1, JSON.stringify(results));
+      assert.deepEqual(
+        results.filter((result) => !result.ok).map((result) => result.code),
+        ["task_claim_collision"]
+      );
+    }
+  } finally {
+    aliceWorker.close();
+    bobWorker.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
 
 test("claim collision exposes current holder and lease expiry", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-holder-"));
@@ -148,3 +177,40 @@ test("holder record stays in local runtime state with acquiredVia claim", async 
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
+
+interface ClaimWorkerMessage {
+  readonly ready?: boolean;
+  readonly taskId?: string;
+  readonly ok?: boolean;
+  readonly code?: string;
+}
+
+function startClaimWorker(rootDir: string, personId: string): {
+  readonly send: (taskId: string) => void;
+  readonly next: () => Promise<ClaimWorkerMessage>;
+  readonly close: () => void;
+} {
+  const workerPath = fileURLToPath(new URL("./fixtures/task-holder-claim-worker.ts", import.meta.url));
+  const child = spawn(process.execPath, [workerPath, rootDir, personId], {
+    stdio: ["pipe", "pipe", "pipe"]
+  });
+  const lines = createInterface({ input: child.stdout, crlfDelay: Number.POSITIVE_INFINITY });
+  const iterator = lines[Symbol.asyncIterator]();
+  return {
+    send: (taskId) => child.stdin.write(`${JSON.stringify({ taskId })}\n`),
+    next: async () => {
+      const result = await iterator.next();
+      if (!result.done) return JSON.parse(result.value) as ClaimWorkerMessage;
+      throw workerExitError(child, lines);
+    },
+    close: () => {
+      lines.close();
+      child.kill();
+    }
+  };
+}
+
+function workerExitError(process: ChildProcessWithoutNullStreams, lines: Interface): Error {
+  lines.close();
+  return new Error(`task-holder claim worker exited before responding (exitCode=${process.exitCode ?? "running"})`);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -374,10 +374,7 @@ function createRepoServiceBinding(
     taskWriter,
     artifactStore: makeMarkdownArtifactStore({ rootDir, layoutOverrides })
   });
-  const taskHolderService = makeTaskHolderService({
-    rootInput: { rootDir, layoutOverrides },
-    mutate: ({ source, run }) => runtime.enqueueBackgroundBatch({ source, priority: "normal", run })
-  });
+  const taskHolderService = makeTaskHolderService({ rootInput: { rootDir, layoutOverrides } });
   const cliCommandService = createCliCommandService(runtime, commandOptions);
   const docSyncService = makeDocSyncService({ rootDir, layoutOverrides });
   const appendRuntimeEvent = makeRuntimeEventAppendPromise(makeRuntimeEventLedgerService({

--- a/packages/kernel/src/local/local-layout-file-system.ts
+++ b/packages/kernel/src/local/local-layout-file-system.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import type { LayoutFileSystem } from "../layout/file-system.ts";
 
 export const localLayoutFileSystem: LayoutFileSystem = {
@@ -8,9 +8,30 @@ export const localLayoutFileSystem: LayoutFileSystem = {
 };
 
 export const localRuntimeStateFileSystem = {
+  createExclusiveText: (inputPath: string, value: string): boolean => {
+    let descriptor: number;
+    try {
+      descriptor = openSync(inputPath, "wx");
+    } catch (error) {
+      if (isExclusiveCreateConflict(error)) return false;
+      throw error;
+    }
+    try {
+      writeFileSync(descriptor, value, "utf8");
+      return true;
+    } finally {
+      closeSync(descriptor);
+    }
+  },
   exists: (inputPath: string) => existsSync(inputPath),
   mkdirp: (inputPath: string) => mkdirSync(inputPath, { recursive: true }),
+  modifiedAtMs: (inputPath: string) => statSync(inputPath).mtimeMs,
   readText: (inputPath: string) => readFileSync(inputPath, "utf8"),
   rename: (fromPath: string, toPath: string) => renameSync(fromPath, toPath),
+  remove: (inputPath: string) => rmSync(inputPath, { force: true }),
   writeText: (inputPath: string, value: string) => writeFileSync(inputPath, value, "utf8")
 };
+
+function isExclusiveCreateConflict(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
+}

--- a/packages/kernel/src/local/task-holder-state.ts
+++ b/packages/kernel/src/local/task-holder-state.ts
@@ -1,5 +1,6 @@
 // @slice-activation MC-B1 exposes task holder lease runtime state over localRoot for daemon and CLI writer gates.
 import { randomBytes } from "node:crypto";
+import { hostname } from "node:os";
 import path from "node:path";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
 import { localRuntimeStateFileSystem } from "./local-layout-file-system.ts";
@@ -141,7 +142,6 @@ export interface TaskHolderServiceOptions {
   readonly rootInput: HarnessLayoutInput;
   readonly now?: () => Date;
   readonly defaultTtlMs?: number;
-  readonly mutate?: <Result>(input: { readonly source: string; readonly run: () => Result }) => Promise<Result>;
 }
 
 export interface TaskHolderService {
@@ -156,11 +156,9 @@ const defaultTtlMs = 30 * 60 * 1_000;
 export function makeTaskHolderService(options: TaskHolderServiceOptions): TaskHolderService {
   const now = () => options.now?.() ?? new Date();
   const ttl = (ttlMs: number | undefined) => normalizeTtlMs(ttlMs ?? options.defaultTtlMs ?? defaultTtlMs);
-  const runMutation = async <Result>(source: string, run: () => Result): Promise<Result> =>
-    options.mutate ? options.mutate({ source, run }) : run();
 
   return {
-    claim: (input) => runMutation("task-holder.claim", () => {
+    claim: (input) => withTaskHolderMutationLock(options.rootInput, input.taskId, () => {
       const at = now();
       const current = readHolderRecord(options.rootInput, input.taskId);
       const snapshot = holderSnapshot(input.taskId, current, at);
@@ -192,7 +190,7 @@ export function makeTaskHolderService(options: TaskHolderServiceOptions): TaskHo
       } satisfies TaskHolderClaimResult;
     }),
     holder: async (input) => holderSnapshot(input.taskId, readHolderRecord(options.rootInput, input.taskId), now()),
-    release: (input) => runMutation("task-holder.release", () => {
+    release: (input) => withTaskHolderMutationLock(options.rootInput, input.taskId, () => {
       const at = now();
       const current = readHolderRecord(options.rootInput, input.taskId);
       const snapshot = holderSnapshot(input.taskId, current, at);
@@ -323,6 +321,110 @@ function writeHolderRecord(rootInput: HarnessLayoutInput, record: TaskHolderReco
   const tempPath = `${filePath}.${process.pid}.${randomBytes(4).toString("hex")}.tmp`;
   localRuntimeStateFileSystem.writeText(tempPath, `${JSON.stringify(record, null, 2)}\n`);
   localRuntimeStateFileSystem.rename(tempPath, filePath);
+}
+
+interface TaskHolderMutationLockRecord {
+  readonly schema: "task-holder-mutation-lock/v1";
+  readonly pid: number;
+  readonly hostname: string;
+  readonly acquiredAt: string;
+  readonly ownerToken: string;
+}
+
+const mutationLockRetryMs = 5;
+const mutationLockWaitMs = 5_000;
+const mutationLockStaleMs = 30_000;
+
+async function withTaskHolderMutationLock<Result>(
+  rootInput: HarnessLayoutInput,
+  taskId: string,
+  run: () => Result
+): Promise<Result> {
+  const lockPath = `${holderRecordPath(rootInput, taskId)}.lock`;
+  const ownerToken = await acquireTaskHolderMutationLock(lockPath, taskId);
+  try {
+    return run();
+  } finally {
+    releaseTaskHolderMutationLock(lockPath, ownerToken);
+  }
+}
+
+async function acquireTaskHolderMutationLock(lockPath: string, taskId: string): Promise<string> {
+  const ownerToken = randomBytes(12).toString("hex");
+  const startedAt = Date.now();
+  localRuntimeStateFileSystem.mkdirp(path.dirname(lockPath));
+  while (Date.now() - startedAt <= mutationLockWaitMs) {
+    const record: TaskHolderMutationLockRecord = {
+      schema: "task-holder-mutation-lock/v1",
+      pid: process.pid,
+      hostname: hostname(),
+      acquiredAt: new Date().toISOString(),
+      ownerToken
+    };
+    if (localRuntimeStateFileSystem.createExclusiveText(lockPath, JSON.stringify(record))) return ownerToken;
+    recoverAbandonedTaskHolderMutationLock(lockPath);
+    await new Promise<void>((resolve) => setTimeout(resolve, mutationLockRetryMs));
+  }
+  throw new Error(`timed out waiting for task holder mutation lock: ${taskId}`);
+}
+
+function recoverAbandonedTaskHolderMutationLock(lockPath: string): void {
+  if (!localRuntimeStateFileSystem.exists(lockPath)) return;
+  const record = readTaskHolderMutationLock(lockPath);
+  const ageMs = Date.now() - (record ? Date.parse(record.acquiredAt) : localRuntimeStateFileSystem.modifiedAtMs(lockPath));
+  const abandoned = record?.hostname === hostname()
+    ? !processIsAlive(record.pid)
+    : Number.isFinite(ageMs) && ageMs > mutationLockStaleMs;
+  if (!abandoned) return;
+  const quarantinePath = `${lockPath}.stale.${randomBytes(6).toString("hex")}`;
+  try {
+    localRuntimeStateFileSystem.rename(lockPath, quarantinePath);
+    localRuntimeStateFileSystem.remove(quarantinePath);
+  } catch (error) {
+    if (!isMissingFileError(error)) throw error;
+  }
+}
+
+function releaseTaskHolderMutationLock(lockPath: string, ownerToken: string): void {
+  const record = readTaskHolderMutationLock(lockPath);
+  if (record?.ownerToken === ownerToken) localRuntimeStateFileSystem.remove(lockPath);
+}
+
+function readTaskHolderMutationLock(lockPath: string): TaskHolderMutationLockRecord | null {
+  try {
+    const parsed = JSON.parse(localRuntimeStateFileSystem.readText(lockPath)) as Partial<TaskHolderMutationLockRecord>;
+    return parsed.schema === "task-holder-mutation-lock/v1" &&
+      typeof parsed.pid === "number" &&
+      typeof parsed.hostname === "string" &&
+      typeof parsed.acquiredAt === "string" &&
+      typeof parsed.ownerToken === "string"
+      ? parsed as TaskHolderMutationLockRecord
+      : null;
+  } catch (error) {
+    if (isMissingFileError(error) || error instanceof SyntaxError) return null;
+    throw error;
+  }
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !isMissingProcessError(error);
+  }
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return isNodeErrorCode(error, "ENOENT");
+}
+
+function isMissingProcessError(error: unknown): boolean {
+  return isNodeErrorCode(error, "ESRCH");
+}
+
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
 }
 
 function holderRecordPath(rootInput: HarnessLayoutInput, taskId: string): string {


### PR DESCRIPTION
# English

## Summary

Make task-holder lease claim/release atomic inside the lease module itself, instead of depending on callers to inject serialization. Before this change, two direct-CLI processes could both successfully claim the same task (read–decide–write with no mutual exclusion); the daemon path was only safe by coincidence of its background queue.

## What Changed

- `packages/kernel/src/local/task-holder-state.ts`: removed the optional caller-supplied `mutate` callback; `claim`/`release` now acquire a task-keyed cross-process file lock (exclusive create, owner token, same-host PID liveness check, stale-lock quarantine recovery); the read–decide–rename sequence runs entirely inside the critical section.
- `packages/kernel/src/local/local-layout-file-system.ts`: added exclusive-create, mtime, and safe-delete capabilities used by the lock.
- `packages/cli/src/index.ts`: daemon no longer injects its background-queue mutation into the task-holder service — the queue reverts to scheduling policy, not a correctness prerequisite.
- New cross-process race test: two independent Node processes claim 32 tasks concurrently through the public service interface; exactly one wins each round. Positive control: the old implementation fails this test (both processes returned `ok:true`).

## Task And Scope

- Harness task: `task_01KX5MDSACJ67S739ZT2ZW2YNR` (P1-1-A, child of governance charter `task_01KX5HEBCHAKMA25FH5KHRWSEX`)
- Branch: `codex/p1-lease-route`
- Public scope: `packages/kernel/src/local/`, `packages/cli/src/index.ts` (queue-injection removal), `packages/application/test/`
- Private planning/evidence updated: yes (task package progress/facts in private harness ledger)
- Out of scope: task write-route policy single authority (P1-1-B) — saved on `codex/p1-lease-route-b-wip`, blocked on checker-discovery decision `dec_mreqd1zg`

## Version Impact

- Version: no version change because this is an internal correctness fix with no published-package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: governance charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` P1-1; lease mechanism introduced in PR#523
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: P1-1-B route policy continues under the same task after `dec_mreqd1zg` is adjudicated

## Verification

- Base `origin/main` SHA: `60f8902`
- Branch merge-base with `origin/main`: `60f8902`
- Last `git fetch origin` time: 2026-07-10 ~18:0x +08:00 (during worker finalization)
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/p1-lease-route`
- Private evidence commit/path: `harness/tasks/task_01KX5MDSACJ67S739ZT2ZW2YNR-p1-1-task-holder-lease-task/` (mission, resume mission, progress, facts F-2WG0BKNR/F-AYNRRY5M/F-4V8GR5T4)
- Reviewer evidence path: task package `artifacts/mission.md`, `artifacts/mission-resume-1.md`
- GitHub Actions `rewrite-ci` run URL: pending (populated by this PR's checks)
- [ ] `npm ci` — not run as such; worktree deps synced to lockfile during gate run (electron-builder@26.15.3 restored, no tracked diff)
- [x] `git diff --check`
- [x] `npm run check` — exit 0: typecheck+lint pass, Node 1121 pass/0 fail/1 platform skip, GUI 40/40, 34/34 manifest gates (incl. write-road, duplicate-definitions, supply-chain)
- [x] `npm run typecheck`
- [x] `npm test` — via `npm run check` aggregate
- [x] `npm run harness:check-import-boundaries` — via `npm run check`
- [x] `npm run harness:scan-forbidden-symbols` — via `npm run check`
- [x] `npm run harness:check-private-boundary` — via `npm run check`
- [x] `npm run harness:check-package-policy` — via `npm run check`
- [x] `npm run harness:check-implementation-contracts` — via `npm run check`
- [x] `npm run harness:check-schema-contracts` — via `npm run check`
- [x] `npm run harness:check-legacy-intake-readiness` — via `npm run check`
- [x] `npm run harness:smoke-cli-package` — via `npm run check`
- [ ] GitHub Actions `rewrite-ci` passed — pending
- Not run: none beyond `npm ci` note above. Additionally: post-commit hermetic re-run (`HOME=<empty> GIT_CONFIG_GLOBAL=/dev/null node --test ...`) 17/17 incl. cross-process race and identity tests

## Review Evidence

- Self-review: worker positive-control verification (old implementation red `2 !== 1`, new implementation green across 32-task rounds)
- Reviewer subagent: CEO ground-truth pass (mutate fully removed — 0 grep hits; race fixture present; 5-file diff inspection; B changes confirmed absent from this branch)
- Human review: pending
- Blocking findings: none

## Residual Risk

- Crash-recovery and lock-timeout long-tail paths are covered by stale-lock quarantine logic but not by dedicated fault-injection tests; flagged for the architecture-rot registry rather than blocking this correctness fix.

## References

- Task: `harness/tasks/task_01KX5MDSACJ67S739ZT2ZW2YNR-p1-1-task-holder-lease-task/`
- Evidence: governance charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` artifacts (candidate A#6 / B#03)
- Review: pending in task package `review.md`

---

# 中文

## 概要

把 task-holder lease 的 claim/release 原子性收进 lease module 本体，不再依赖调用方注入串行化。改动前，两个 CLI 直连进程可以同时 claim 成功同一个 task（read–decide–write 全程无互斥）；daemon 路径只是靠后台队列碰巧安全。

## 改动内容

- `packages/kernel/src/local/task-holder-state.ts`：删除可选的调用方 `mutate` 回调；`claim`/`release` 在 module 内获取 task 级跨进程文件锁（排他创建、owner token、同机 PID 存活检查、遗留锁隔离恢复）；read–decide–rename 全部在临界区内。
- `packages/kernel/src/local/local-layout-file-system.ts`：新增锁所需的排他创建、mtime、安全删除能力。
- `packages/cli/src/index.ts`：daemon 不再向 task-holder 注入后台队列 mutation——队列退回纯调度策略，不再是正确性前提。
- 新增跨进程竞态测试：两个独立 Node 进程经公开 service interface 并发 claim 32 个 task，每轮恰一个成功。阳性对照：旧实现在该测试上失败（两进程都返回 `ok:true`）。

## 任务与范围

- Harness 任务：`task_01KX5MDSACJ67S739ZT2ZW2YNR`（P1-1-A，治理 charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` 子任务）
- 分支：`codex/p1-lease-route`
- 公开范围：`packages/kernel/src/local/`、`packages/cli/src/index.ts`（去队列注入）、`packages/application/test/`
- 私有计划 / 证据是否已更新：yes（任务包 progress/facts 在私有 ledger）
- 范围外：Task 写路由单一权威（P1-1-B）——存于 `codex/p1-lease-route-b-wip`，等 checker 发现模型裁决 `dec_mreqd1zg`

## 版本影响

- 版本：不改版本，原因是内部正确性修复，无已发布包面变更
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：治理 charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` P1-1；lease 机制来自 PR#523
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：P1-1-B 在 `dec_mreqd1zg` 裁决后于同一任务继续

## 验证

- `origin/main` 基准 SHA：`60f8902`
- 当前分支与 `origin/main` 的 merge-base：`60f8902`
- 最近一次 `git fetch origin` 时间：2026-07-10 ~18:0x +08:00
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...codex/p1-lease-route`
- 私有证据 commit / 路径：`harness/tasks/task_01KX5MDSACJ67S739ZT2ZW2YNR-p1-1-task-holder-lease-task/`（facts F-2WG0BKNR/F-AYNRRY5M/F-4V8GR5T4）
- Reviewer 证据路径：任务包 `artifacts/mission.md`、`artifacts/mission-resume-1.md`
- GitHub Actions `rewrite-ci` run URL：待本 PR checks 产生
- 勾选情况与英文块一致：`npm run check` 全量 exit 0（Node 1121 pass、GUI 40/40、34/34 manifest gates）；另有 commit 后 hermetic 复跑 17/17（含跨进程竞态与身份类测试）；`npm ci` 未单独跑（gate 过程中已按 lockfile 同步依赖且无 tracked diff）
- 未运行：除上述 `npm ci` 说明外无

## Review Evidence

- 自审：worker 阳性对照验证（旧实现红 `2 !== 1`，新实现 32 任务轮次全绿）
- Reviewer subagent：CEO ground-truth（mutate 零残留、竞态夹具在位、5 文件 diff 检视、确认 B 面改动不在本分支）
- 人工 review：待定
- 阻塞发现：无

## 残余风险

- 崩溃恢复与锁超时长尾路径由遗留锁隔离逻辑覆盖，但无专门故障注入测试；已标记进架构腐烂 registry 候选，不阻塞本正确性修复。

## 参考

- 任务：`harness/tasks/task_01KX5MDSACJ67S739ZT2ZW2YNR-p1-1-task-holder-lease-task/`
- 证据：charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` artifacts（候选 A#6 / B#03）
- Review：待回填任务包 `review.md`
