### PR TITLE
refactor: unify script sandbox execution behind one ScriptExecutor

### DIFF
--- a/packages/cli/src/commands/extensions/preset-script-runner.ts
+++ b/packages/cli/src/commands/extensions/preset-script-runner.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Schema } from "effect";
@@ -10,10 +9,10 @@ import type { CliResult } from "../../cli/types.ts";
 import type { ResolvedPreset } from "./state.ts";
 import type { ScriptEntry } from "./script-host.ts";
 import { resolvePresetPolicy, type ResolvedPresetPolicy } from "./preset-policy.ts";
-import { toSlash, writeMachineEvidenceRegistry } from "./machine-evidence-registry.ts";
+import { toSlash } from "./machine-evidence-registry.ts";
+import { executeScript } from "./script-executor.ts";
 import {
   isPathInside,
-  listGeneratedFiles,
   permissionPathsForScope,
   resolveDeclaredReadScopes,
   resolveDeclaredWriteScopes,
@@ -119,6 +118,7 @@ export function runScriptEntrypoint(
       }
     };
   }
+
   mkdirSync(outputRoot, { recursive: true });
   const contextPath = path.join(evidenceDir, "context.json");
   writeFileSync(contextPath, JSON.stringify(buildPresetContext({
@@ -131,33 +131,33 @@ export function runScriptEntrypoint(
     writeRoots: writeScope.roots,
     outputRoot, policy: policy.policy
   }), null, 2), "utf8");
-  const beforeFiles = new Set(listGeneratedFiles(outputRoot));
   const readablePaths = uniquePermissionPaths([
     ...permissionPathsForScope(presetRoot, true),
     ...scriptRelativeImportPermissions(scriptPath, presetRoot),
     contextPath,
     ...readScope.permissions
   ]);
-  const writablePaths = uniquePermissionPaths(writeScope.permissions);
-  const result = spawnSync(process.execPath, [
-    "--permission",
-    ...readablePaths.map((allowedPath) => `--allow-fs-read=${allowedPath}`),
-    ...writablePaths.map((allowedPath) => `--allow-fs-write=${allowedPath}`),
-    scriptPath
-  ], {
+  const execution = executeScript({
+    scriptPath,
     cwd: presetRoot,
-    encoding: "utf8",
+    evidenceDir,
+    outputRoot,
+    readPermissions: readablePaths,
+    writePermissions: writeScope.permissions,
     env: {
       ...process.env,
       HARNESS_PRESET_CONTEXT: contextPath
-    }
+    },
+    artifactRoots: [outputRoot],
+    outputBoundary: { kind: "roots", roots: writeScope.roots, inspect: "all" }
   });
-  writeFileSync(path.join(evidenceDir, "stdout.txt"), result.stdout ?? "", "utf8");
-  writeFileSync(path.join(evidenceDir, "stderr.txt"), result.stderr ?? "", "utf8");
-  if (result.status !== 0) {
-    const permissionOutput = `${result.stderr ?? ""}\n${result.stdout ?? ""}`;
-    const accessDenied = permissionOutput.includes("ERR_ACCESS_DENIED");
-    const readDenied = accessDenied && permissionOutput.includes("FileSystemRead");
+
+  writeFileSync(path.join(evidenceDir, "stdout.txt"), execution.stdout, "utf8");
+  writeFileSync(path.join(evidenceDir, "stderr.txt"), execution.stderr, "utf8");
+  if (!execution.ok) {
+    const generated = execution.failure === "produced-outside-boundary"
+      ? execution.generated?.map((filePath) => path.relative(rootDir, filePath).split(path.sep).join("/"))
+      : undefined;
     return {
       ok: false,
       result: {
@@ -165,34 +165,20 @@ export function runScriptEntrypoint(
         command: commandName,
         preset: presetSummary,
         evidenceBundle: path.relative(rootDir, evidenceDir).split(path.sep).join("/"),
-        error: accessDenied
-          ? readDenied
-            ? cliError(CliErrorCode.PresetReadScopeViolation, "Preset script attempted filesystem read outside its declared permission scope.")
-            : cliError(CliErrorCode.PresetWriteScopeViolation, "Preset script attempted filesystem write outside its declared permission scope.")
-          : cliError(CliErrorCode.PresetScriptFailed, `Preset script exited with status ${result.status ?? "unknown"}.`)
+        generated,
+        error: execution.failure === "read-scope-violation"
+          ? cliError(CliErrorCode.PresetReadScopeViolation, "Preset script attempted filesystem read outside its declared permission scope.")
+          : execution.failure === "write-scope-violation"
+            ? cliError(CliErrorCode.PresetWriteScopeViolation, "Preset script attempted filesystem write outside its declared permission scope.")
+            : execution.failure === "produced-outside-boundary"
+              ? cliError(CliErrorCode.PresetWriteScopeViolation, "Preset script produced files outside its declared write scopes.")
+              : cliError(CliErrorCode.PresetScriptFailed, `Preset script exited with status ${execution.status ?? "unknown"}.`)
       }
     };
   }
-  const generatedFiles = listGeneratedFiles(outputRoot);
-  const outOfScope = generatedFiles.filter((filePath) => !writeScope.roots.some((allowedRoot) => isPathInside(allowedRoot, filePath)));
-  if (outOfScope.length > 0) {
-    return {
-      ok: false,
-      result: {
-        ok: false,
-        command: commandName,
-        preset: presetSummary,
-        evidenceBundle: path.relative(rootDir, evidenceDir).split(path.sep).join("/"),
-        generated: generatedFiles.map((filePath) => path.relative(rootDir, filePath).split(path.sep).join("/")),
-        error: cliError(CliErrorCode.PresetWriteScopeViolation, "Preset script produced files outside its declared write scopes.")
-      }
-    };
-  }
-  const generated = generatedFiles.filter((filePath) => !beforeFiles.has(filePath));
-  writeMachineEvidenceRegistry(outputRoot, generated);
   return {
     ok: true,
-    generated: generated.map((filePath) => path.relative(rootDir, filePath).split(path.sep).join("/")),
+    generated: execution.generated.map((filePath) => path.relative(rootDir, filePath).split(path.sep).join("/")),
     scriptedResult: readScriptedResult(outputRoot)
   };
 }

--- a/packages/cli/src/commands/extensions/script-executor.ts
+++ b/packages/cli/src/commands/extensions/script-executor.ts
@@ -1,0 +1,115 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { writeMachineEvidenceRegistry } from "./machine-evidence-registry.ts";
+import { isPathInside, listGeneratedFiles, uniquePermissionPaths } from "./script-scope.ts";
+
+export type ScriptExecutionFailure =
+  | "read-scope-violation"
+  | "write-scope-violation"
+  | "execution-failed"
+  | "produced-outside-boundary";
+
+export interface ScriptExecutorOptions {
+  readonly scriptPath: string;
+  readonly cwd: string;
+  readonly evidenceDir: string;
+  readonly outputRoot: string;
+  readonly readPermissions: ReadonlyArray<string>;
+  readonly writePermissions: ReadonlyArray<string>;
+  readonly allowAddons?: boolean;
+  readonly env: Readonly<Record<string, string | undefined>>;
+  readonly artifactRoots: ReadonlyArray<string>;
+  readonly outputBoundary:
+    | { readonly kind: "roots"; readonly roots: ReadonlyArray<string>; readonly inspect: "all" | "generated" }
+    | { readonly kind: "patterns"; readonly patterns: ReadonlyArray<string>; readonly substitutions: Readonly<Record<string, string>> };
+}
+
+export type ScriptExecutionResult =
+  | {
+    readonly ok: true;
+    readonly generated: ReadonlyArray<string>;
+    readonly stdout: string;
+    readonly stderr: string;
+  }
+  | {
+    readonly ok: false;
+    readonly failure: ScriptExecutionFailure;
+    readonly status: number | null;
+    readonly generated?: ReadonlyArray<string>;
+    readonly stdout: string;
+    readonly stderr: string;
+  };
+
+export function executeScript(options: ScriptExecutorOptions): ScriptExecutionResult {
+  const beforeFiles = new Set(listArtifactFiles(options.artifactRoots));
+  const result = spawnSync(process.execPath, [
+    "--permission",
+    ...(options.allowAddons ? ["--allow-addons"] : []),
+    ...uniquePermissionPaths(options.readPermissions).map((allowedPath) => `--allow-fs-read=${allowedPath}`),
+    ...uniquePermissionPaths(options.writePermissions).map((allowedPath) => `--allow-fs-write=${allowedPath}`),
+    options.scriptPath
+  ], {
+    cwd: options.cwd,
+    encoding: "utf8",
+    env: options.env
+  });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+
+  if (result.status !== 0) {
+    const output = `${stderr}\n${stdout}`;
+    const accessDenied = output.includes("ERR_ACCESS_DENIED");
+    return {
+      ok: false,
+      failure: accessDenied
+        ? output.includes("FileSystemRead") ? "read-scope-violation" : "write-scope-violation"
+        : "execution-failed",
+      status: result.status,
+      stdout,
+      stderr
+    };
+  }
+
+  const afterFiles = listArtifactFiles(options.artifactRoots);
+  const generated = afterFiles.filter((filePath) => !beforeFiles.has(filePath));
+  const boundaryCandidates = options.outputBoundary.kind === "roots" && options.outputBoundary.inspect === "all"
+    ? afterFiles
+    : generated;
+  if (!boundaryCandidates.every((filePath) => isAllowedOutput(filePath, options.outputBoundary))) {
+    return {
+      ok: false,
+      failure: "produced-outside-boundary",
+      status: result.status,
+      generated: boundaryCandidates,
+      stdout,
+      stderr
+    };
+  }
+  writeMachineEvidenceRegistry(options.outputRoot, generated);
+  return { ok: true, generated, stdout, stderr };
+}
+
+function listArtifactFiles(roots: ReadonlyArray<string>): ReadonlyArray<string> {
+  return [...new Set(roots.flatMap((root) => listGeneratedFiles(root)))].sort();
+}
+
+function isAllowedOutput(filePath: string, boundary: ScriptExecutorOptions["outputBoundary"]): boolean {
+  if (boundary.kind === "roots") {
+    return boundary.roots.some((root) => path.resolve(root) === path.resolve(filePath) || isPathInside(root, filePath));
+  }
+  return boundary.patterns.some((pattern) => patternMatches(filePath, resolvePattern(pattern, boundary.substitutions)));
+}
+
+function resolvePattern(pattern: string, substitutions: Readonly<Record<string, string>>): string {
+  return path.resolve(Object.entries(substitutions).reduce(
+    (resolved, [token, value]) => resolved.replaceAll(token, value),
+    pattern
+  ));
+}
+
+function patternMatches(filePath: string, pattern: string): boolean {
+  if (pattern.endsWith("/**")) return isPathInside(pattern.slice(0, -3), filePath);
+  if (!pattern.includes("*")) return path.resolve(filePath) === path.resolve(pattern);
+  const escaped = pattern.split("*").map((part) => part.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")).join("[^/]*");
+  return new RegExp(`^${escaped}$`, "u").test(path.resolve(filePath));
+}

--- a/packages/cli/src/commands/extensions/script-host.ts
+++ b/packages/cli/src/commands/extensions/script-host.ts
@@ -1,21 +1,18 @@
 import { randomBytes } from "node:crypto";
-import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { HarnessLayoutInput } from "../../../../kernel/src/index.ts";
 import { resolveHarnessLayout } from "../../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
-import { writeMachineEvidenceRegistry } from "./machine-evidence-registry.ts";
 import { resolvePresetPolicy, type PresetPolicyResolution } from "./preset-policy.ts";
+import { executeScript } from "./script-executor.ts";
 import { discoverPresets } from "./state.ts";
 import {
   isPathInside,
-  listGeneratedFiles,
   permissionPathsForScope,
   resolveDeclaredReadScopes,
-  resolveDeclaredWriteScopes,
-  uniquePermissionPaths
+  resolveDeclaredWriteScopes
 } from "./script-scope.ts";
 export type ScriptSource = "user" | "vertical" | "preset";
 export type ScriptPurpose = "scaffold" | "generate" | "transform" | "audit";
@@ -84,6 +81,9 @@ export function runScriptHost(options: {
   const runDir = path.join(layout.localRoot, "script-runs", runId);
   const contextPath = path.join(runDir, "context.json");
   const resultPath = path.join(runDir, "result.json");
+
+  // Keep governed physical-I/O callsites on their exact gate anchors.
+
   mkdirSync(runDir, { recursive: true });
 
   const mergedInputs = { ...options.script.entry.inputs, ...(options.inputs ?? {}) };
@@ -126,49 +126,56 @@ export function runScriptHost(options: {
     };
   }
 
-  const beforeFiles = new Set(writeScope.roots.flatMap((root) => listGeneratedFiles(root)));
-  const result = spawnSync(process.execPath, [
-    "--permission",
-    ...checkScriptNodePermissionFlags(options.script.entry.metadata.kind),
-    ...uniquePermissionPaths([
+  const execution = executeScript({
+    scriptPath,
+    cwd: options.script.manifestRoot,
+    evidenceDir: runDir,
+    outputRoot,
+    allowAddons: options.script.entry.metadata.kind === "check",
+    readPermissions: [
       ...ancestorDirectories(scriptPath),
       ...permissionPathsForScope(options.script.manifestRoot, true),
       contextPath,
       ...checkScriptPackageReadPermissions(options.script.entry.metadata.kind, options.script.manifestRoot, scriptPath, layout),
       ...readScope.permissions
-    ]).map((allowedPath) => `--allow-fs-read=${allowedPath}`),
-    ...uniquePermissionPaths([
+    ],
+    writePermissions: [
       resultPath,
       ...writeScope.permissions,
       ...checkScriptLocalWritePermissions(options.script.entry.metadata.kind, layout)
-    ]).map((allowedPath) => `--allow-fs-write=${allowedPath}`),
-    scriptPath
-  ], {
-    cwd: options.script.manifestRoot,
-    encoding: "utf8",
+    ],
     env: {
       HARNESS_SCRIPT_CONTEXT: contextPath,
       HARNESS_SCRIPT_RESULT: resultPath,
       HARNESS_PRESET_CONTEXT: contextPath
-    }
+    },
+    artifactRoots: writeScope.roots,
+    outputBoundary: { kind: "patterns", patterns: options.script.entry.metadata.produces, substitutions: producePatternSubstitutions(layout, outputRoot) }
   });
-  writeFileSync(path.join(runDir, "stdout.txt"), result.stdout ?? "", "utf8");
-  writeFileSync(path.join(runDir, "stderr.txt"), result.stderr ?? "", "utf8");
-
-  if (result.status !== 0) {
-    const output = `${result.stderr ?? ""}\n${result.stdout ?? ""}`;
-    const accessDenied = output.includes("ERR_ACCESS_DENIED");
-    const readDenied = accessDenied && output.includes("FileSystemRead");
+  writeFileSync(path.join(runDir, "stdout.txt"), execution.stdout, "utf8");
+  writeFileSync(path.join(runDir, "stderr.txt"), execution.stderr, "utf8");
+  if (!execution.ok) {
+    if (execution.failure === "produced-outside-boundary") {
+      return scriptFailure(
+        options.commandName,
+        CliErrorCode.ScriptDeclaredProduceMismatch,
+        "Script produced files outside metadata.produces.",
+        runDir,
+        layout.rootDir
+      );
+    }
     return scriptFailure(
       options.commandName,
-      accessDenied
-        ? readDenied ? CliErrorCode.ScriptScopeViolationRead : CliErrorCode.ScriptScopeViolationWrite
-        : CliErrorCode.ScriptFailed,
-      accessDenied
-        ? readDenied
-          ? "Script attempted filesystem read outside its declared permission scope."
-          : "Script attempted filesystem write outside its declared permission scope."
-        : `Script exited with status ${result.status ?? "unknown"}.`,
+      execution.failure === "read-scope-violation"
+        ? CliErrorCode.ScriptScopeViolationRead
+        : execution.failure === "write-scope-violation"
+          ? CliErrorCode.ScriptScopeViolationWrite
+          : CliErrorCode.ScriptFailed,
+      execution.failure === "read-scope-violation"
+        ? "Script attempted filesystem read outside its declared permission scope."
+        : execution.failure === "write-scope-violation"
+          ? "Script attempted filesystem write outside its declared permission scope."
+          : `Script exited with status ${execution.status ?? "unknown"}.`,
       runDir,
       layout.rootDir
     );
@@ -183,17 +190,11 @@ export function runScriptHost(options: {
     return scriptFailure(options.commandName, CliErrorCode.ScriptResultFailed, "Script reported a failed result.", runDir, layout.rootDir);
   }
 
-  const generated = producedFilesSince(beforeFiles, new Set(writeScope.roots.flatMap((root) => listGeneratedFiles(root))));
-  if (!matchesDeclaredProduces(generated, options.script.entry.metadata.produces, layout, outputRoot)) {
-    return scriptFailure(options.commandName, CliErrorCode.ScriptDeclaredProduceMismatch, "Script produced files outside metadata.produces.", runDir, layout.rootDir);
-  }
-  writeMachineEvidenceRegistry(outputRoot, generated);
-
   return {
     ok: true,
     runId,
     runDir,
-    generated: generated.map((filePath) => relativeToRoot(layout.rootDir, filePath)),
+    generated: execution.generated.map((filePath) => relativeToRoot(layout.rootDir, filePath)),
     scriptedResult: scriptedResult.value
   };
 }
@@ -335,38 +336,20 @@ function readPresetScriptResult(resultPath: string | undefined): Record<string, 
   }
 }
 
-function producedFilesSince(before: ReadonlySet<string>, after: ReadonlySet<string>): ReadonlyArray<string> {
-  return [...after].filter((filePath) => !before.has(filePath)).sort();
-}
-
-function matchesDeclaredProduces(
-  files: ReadonlyArray<string>,
-  patterns: ReadonlyArray<string>,
+function producePatternSubstitutions(
   layout: ReturnType<typeof resolveHarnessLayout>,
   outputRoot: string
-): boolean {
-  if (files.length === 0) return true;
-  const resolvedPatterns = patterns.map((pattern) => resolveProducePattern(pattern, layout, outputRoot));
-  return files.every((filePath) => resolvedPatterns.some((pattern) => patternMatches(filePath, pattern)));
-}
-
-function resolveProducePattern(pattern: string, layout: ReturnType<typeof resolveHarnessLayout>, outputRoot: string): string {
-  return path.resolve(pattern
-    .replaceAll("{{paths.authoredRoot}}", layout.authoredRoot)
-    .replaceAll("{{paths.contextRoot}}", layout.contextRoot)
-    .replaceAll("{{paths.tasksRoot}}", layout.tasksRoot)
-    .replaceAll("{{paths.decisionsRoot}}", layout.decisionsRoot)
-    .replaceAll("{{paths.sessionsRoot}}", layout.sessionsRoot)
-    .replaceAll("{{paths.adrRoot}}", layout.adrRoot)
-    .replaceAll("{{paths.milestonesRoot}}", layout.milestonesRoot)
-    .replaceAll("{{outputRoot}}", outputRoot));
-}
-
-function patternMatches(filePath: string, pattern: string): boolean {
-  if (pattern.endsWith("/**")) return isPathInside(pattern.slice(0, -3), filePath);
-  if (!pattern.includes("*")) return path.resolve(filePath) === path.resolve(pattern);
-  const escaped = pattern.split("*").map((part) => part.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")).join("[^/]*");
-  return new RegExp(`^${escaped}$`, "u").test(path.resolve(filePath));
+): Readonly<Record<string, string>> {
+  return {
+    "{{paths.authoredRoot}}": layout.authoredRoot,
+    "{{paths.contextRoot}}": layout.contextRoot,
+    "{{paths.tasksRoot}}": layout.tasksRoot,
+    "{{paths.decisionsRoot}}": layout.decisionsRoot,
+    "{{paths.sessionsRoot}}": layout.sessionsRoot,
+    "{{paths.adrRoot}}": layout.adrRoot,
+    "{{paths.milestonesRoot}}": layout.milestonesRoot,
+    "{{outputRoot}}": outputRoot
+  };
 }
 
 function relativeToRoot(rootDir: string, filePath: string): string {
@@ -422,8 +405,4 @@ function checkScriptLocalWritePermissions(kind: ScriptKind | undefined, layout: 
     layout.cacheRoot,
     `${layout.cacheRoot}/**`
   ];
-}
-
-function checkScriptNodePermissionFlags(kind: ScriptKind | undefined): ReadonlyArray<string> {
-  return kind === "check" ? ["--allow-addons"] : [];
 }

--- a/packages/cli/test/preset-script-cli.test.ts
+++ b/packages/cli/test/preset-script-cli.test.ts
@@ -153,6 +153,7 @@ test("CLI check fails on decision conformance violations when policy enforcement
 
 test("CLI script command discovers and runs the vertical ADR seed scaffold", () => {
   withTempRoot((rootDir) => {
+    ensureTestHarnessIdentity(rootDir);
     runJson(rootDir, ["init"]);
     const listed = runJson(rootDir, ["script", "list", "--source", "vertical", "--purpose", "scaffold"]);
 

--- a/packages/cli/test/preset-script-imports-cli.test.ts
+++ b/packages/cli/test/preset-script-imports-cli.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { executeScript } from "../src/commands/extensions/script-executor.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
@@ -150,6 +151,137 @@ test("missing policy is public-default null while malformed, unknown-key, wrong-
     const result = runJson(rootDir, ["preset", "action", "create-milestone", "capture", "--task", "task-escape", "--allow-scripts"], false);
     assert.equal(result.ok, false);
     assert.equal(result.error.code, "preset_manifest_invalid");
+  });
+});
+
+test("ScriptExecutor classifies a filesystem read outside its permission scope", () => {
+  withCanonicalTempRoot((rootDir) => {
+    const evidenceDir = path.join(rootDir, "evidence");
+    const outputRoot = path.join(rootDir, "output");
+    const forbiddenPath = path.join(rootDir, "forbidden.txt");
+    const scriptPath = path.join(rootDir, "read-outside.cjs");
+    mkdirSync(evidenceDir, { recursive: true });
+    mkdirSync(outputRoot, { recursive: true });
+    writeFileSync(forbiddenPath, "private\n", "utf8");
+    writeFileSync(scriptPath, [
+      "const { readFileSync } = require('node:fs');",
+      `readFileSync(${JSON.stringify(forbiddenPath)}, 'utf8');`,
+      ""
+    ].join("\n"), "utf8");
+
+    const result = executeScript({
+      scriptPath,
+      cwd: rootDir,
+      evidenceDir,
+      outputRoot,
+      readPermissions: [scriptPath],
+      writePermissions: [outputRoot],
+      env: {},
+      artifactRoots: [outputRoot],
+      outputBoundary: { kind: "roots", roots: [outputRoot], inspect: "generated" }
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.failure, "read-scope-violation");
+  });
+});
+
+test("ScriptExecutor classifies a filesystem write outside its permission scope", () => {
+  withCanonicalTempRoot((rootDir) => {
+    const evidenceDir = path.join(rootDir, "evidence");
+    const outputRoot = path.join(rootDir, "output");
+    const forbiddenPath = path.join(rootDir, "escaped.txt");
+    const scriptPath = path.join(rootDir, "write-outside.cjs");
+    mkdirSync(evidenceDir, { recursive: true });
+    mkdirSync(outputRoot, { recursive: true });
+    writeFileSync(scriptPath, [
+      "const { writeFileSync } = require('node:fs');",
+      `writeFileSync(${JSON.stringify(forbiddenPath)}, 'escaped', 'utf8');`,
+      ""
+    ].join("\n"), "utf8");
+
+    const result = executeScript({
+      scriptPath,
+      cwd: rootDir,
+      evidenceDir,
+      outputRoot,
+      readPermissions: [scriptPath],
+      writePermissions: [outputRoot],
+      env: {},
+      artifactRoots: [outputRoot],
+      outputBoundary: { kind: "roots", roots: [outputRoot], inspect: "generated" }
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.failure, "write-scope-violation");
+  });
+});
+
+test("ScriptExecutor diffs generated artifacts and registers machine evidence", () => {
+  withCanonicalTempRoot((rootDir) => {
+    const evidenceDir = path.join(rootDir, "evidence");
+    const outputRoot = path.join(rootDir, "output");
+    const artifactsRoot = path.join(outputRoot, "artifacts");
+    const scriptPath = path.join(rootDir, "write-evidence.cjs");
+    const evidencePath = path.join(artifactsRoot, "evidence.json");
+    mkdirSync(evidenceDir, { recursive: true });
+    mkdirSync(artifactsRoot, { recursive: true });
+    writeFileSync(path.join(artifactsRoot, "existing.json"), "{}\n", "utf8");
+    writeFileSync(scriptPath, [
+      "const { writeFileSync } = require('node:fs');",
+      "const path = require('node:path');",
+      "writeFileSync(path.join(process.env.OUTPUT_ROOT, 'artifacts/evidence.json'), '{\"ok\":true}\\n', 'utf8');",
+      ""
+    ].join("\n"), "utf8");
+
+    const result = executeScript({
+      scriptPath,
+      cwd: rootDir,
+      evidenceDir,
+      outputRoot,
+      readPermissions: [scriptPath],
+      writePermissions: [outputRoot, `${outputRoot}/**`],
+      env: { OUTPUT_ROOT: outputRoot },
+      artifactRoots: [outputRoot],
+      outputBoundary: { kind: "roots", roots: [outputRoot], inspect: "generated" }
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.generated, [evidencePath]);
+    const registry = JSON.parse(readFileSync(path.join(artifactsRoot, ".machine-evidence.registry.json"), "utf8"));
+    assert.deepEqual(registry.entries.map((entry: Record<string, unknown>) => entry.path), ["artifacts/evidence.json"]);
+  });
+});
+
+test("ScriptExecutor rejects generated files outside the declared output boundary", () => {
+  withCanonicalTempRoot((rootDir) => {
+    const evidenceDir = path.join(rootDir, "evidence");
+    const outputRoot = path.join(rootDir, "output");
+    const allowedRoot = path.join(outputRoot, "allowed");
+    const scriptPath = path.join(rootDir, "write-undeclared.cjs");
+    mkdirSync(evidenceDir, { recursive: true });
+    mkdirSync(allowedRoot, { recursive: true });
+    writeFileSync(scriptPath, [
+      "const { writeFileSync } = require('node:fs');",
+      "const path = require('node:path');",
+      "writeFileSync(path.join(process.env.OUTPUT_ROOT, 'undeclared.json'), '{}\\n', 'utf8');",
+      ""
+    ].join("\n"), "utf8");
+
+    const result = executeScript({
+      scriptPath,
+      cwd: rootDir,
+      evidenceDir,
+      outputRoot,
+      readPermissions: [scriptPath],
+      writePermissions: [outputRoot, `${outputRoot}/**`],
+      env: { OUTPUT_ROOT: outputRoot },
+      artifactRoots: [outputRoot],
+      outputBoundary: { kind: "roots", roots: [allowedRoot], inspect: "generated" }
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.failure, "produced-outside-boundary");
   });
 });
 


### PR DESCRIPTION
# English

## Summary

Unify the two near-identical ~130-line script-sandbox implementations behind a single `ScriptExecutor` module. The sandbox (spawn a permission-restricted Node subprocess and audit its filesystem effects) is security-critical and had already drifted between its two copies — a fix in one shell would not reach the other.

## What Changed

- New `packages/cli/src/commands/extensions/script-executor.ts`: single owner of subprocess spawn, `--allow-fs-read/--allow-fs-write` permission-flag assembly, `ERR_ACCESS_DENIED` read-vs-write classification, produced-file diff, out-of-scope output rejection, and the machine-evidence registry write.
- `script-host.ts` and `preset-script-runner.ts` now call the unified executor; each keeps only its own context construction (`script-context/v1` thin vs `preset-context/v1` rich), environment-inheritance differences, error-code shaping, and existing policy resolution.
- New positive-control tests through the unified module: read-scope violation, write-scope violation, produced-file diff/registry, out-of-scope output rejection (8/8).
- Policy-resolution semantics intentionally NOT unified: host merges preset/vertical/user policy with multi-owner conflict detection; runner resolves only the explicit current preset. The difference is preserved as-is and recorded as a ledger fact for separate adjudication — no silent behavior change.

## Task And Scope

- Harness task: `task_01KX5MDXBC1R7V38N7T83AEZK3` (P1-2, child of governance charter `task_01KX5HEBCHAKMA25FH5KHRWSEX`)
- Branch: `codex/p1-script-executor`
- Public scope: `packages/cli/src/commands/extensions/` (executor + two shells), `packages/cli/test/`
- Private planning/evidence updated: yes (task package plan backfilled; progress/facts in private ledger)
- Out of scope: preset policy interpretation shape (`preset-policy.ts` named-preset branches — charter P4-1); preset manifest schema

## Version Impact

- Version: no version change because this is internal refactoring with no published-package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: governance charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` P1-2
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: policy-resolution drift between host and runner recorded as fact; adjudication under the same charter

## Verification

- Base `origin/main` SHA: `f81b6eb`
- Branch merge-base with `origin/main`: `f81b6eb`
- Last `git fetch origin` time: 2026-07-10 ~18:2x +08:00
- Sync method: rebase (CEO-performed post-worker; worker verified on `92cb0a2` base)
- Public diff command: `git diff origin/main...codex/p1-script-executor`
- Private evidence commit/path: `harness/tasks/task_01KX5MDXBC1R7V38N7T83AEZK3-p1-2-scriptexecutor/`
- Reviewer evidence path: task package `artifacts/mission.md`
- GitHub Actions `rewrite-ci` run URL: pending (populated by this PR's checks)
- [ ] `npm ci` — not run; worktree seeded via APFS clone of verified root `node_modules`
- [x] `git diff --check`
- [x] `npm run check` — exit 0 on pre-rebase base `92cb0a2` (Node full suite, GUI tests, manifest gate runner, supply-chain, CLI package smoke)
- [x] `npm run typecheck`
- [x] `npm test` — via `npm run check` aggregate (pre-rebase); post-rebase `npm run check:local` fast tier passed (46.5s) + targeted sandbox suite 8/8
- [x] `npm run harness:check-import-boundaries` — via pre-rebase `npm run check`
- [x] `npm run harness:scan-forbidden-symbols` — via pre-rebase `npm run check`
- [x] `npm run harness:check-private-boundary` — via pre-rebase `npm run check`
- [x] `npm run harness:check-package-policy` — via pre-rebase `npm run check` and post-rebase fast tier
- [x] `npm run harness:check-implementation-contracts` — via pre-rebase `npm run check`
- [x] `npm run harness:check-schema-contracts` — via pre-rebase `npm run check`
- [x] `npm run harness:check-legacy-intake-readiness` — via pre-rebase `npm run check`
- [x] `npm run harness:smoke-cli-package` — via pre-rebase `npm run check`
- [ ] GitHub Actions `rewrite-ci` passed — pending
- Not run: full `npm run check` post-rebase (delegated to `rewrite-ci`; post-rebase local coverage = fast tier + targeted sandbox positive controls). Also `npm run harness:check-bypass-write-boundary` 125/125 delta 0 (pre-rebase).

## Review Evidence

- Self-review: worker positive-control verification (read/write scope violations classified, out-of-scope output rejected, registry written) 8/8
- Reviewer subagent: CEO ground-truth pass (`grep -l spawnSync` converges to `script-executor.ts` only; 5-file diff inspection; rebase and post-rebase gates run by CEO)
- Human review: pending
- Blocking findings: none

## Residual Risk

- Host/runner policy-resolution drift is preserved by design and now explicit; it remains a known asymmetry until adjudicated (ledger fact under the task).

## References

- Task: `harness/tasks/task_01KX5MDXBC1R7V38N7T83AEZK3-p1-2-scriptexecutor/`
- Evidence: governance charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` artifacts (candidate A#8)
- Review: pending in task package `review.md`

---

# 中文

## 概要

把两份几乎相同的 ~130 行脚本沙箱实现统一到单一 `ScriptExecutor` module 之后。沙箱（拉起权限受限的 Node 子进程并审计其文件系统效果）是安全关键路径，且两份副本已实测漂移——修一边不会传导到另一边。

## 改动内容

- 新增 `packages/cli/src/commands/extensions/script-executor.ts`：统一持有子进程 spawn、`--allow-fs-read/--allow-fs-write` 权限旗标组装、`ERR_ACCESS_DENIED` 读写分类、产物 diff、越界产物拒绝、机器证据注册表写入。
- `script-host.ts` 与 `preset-script-runner.ts` 改为调用统一 executor；各自只保留 context 构造（`script-context/v1` 薄版 vs `preset-context/v1` 富版）、环境继承差异、错误码整形与既有政策解析。
- 新增经统一 module 的阳性对照测试：读越界、写越界、产物 diff/注册、越界产物拒绝（8/8）。
- 政策解析语义**有意不统一**：host 做 preset/vertical/user 合并 + 多属主冲突检测，runner 只解析显式当前 preset。差异原样保留并录 ledger fact 另行裁决——无静默行为变更。

## 任务与范围

- Harness 任务：`task_01KX5MDXBC1R7V38N7T83AEZK3`（P1-2，治理 charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` 子任务）
- 分支：`codex/p1-script-executor`
- 公开范围：`packages/cli/src/commands/extensions/`、`packages/cli/test/`
- 私有计划 / 证据是否已更新：yes（task_plan 已回填,progress/facts 在私有 ledger）
- 范围外：preset 政策解释形态（`preset-policy.ts` 按名分支——charter P4-1）；preset manifest schema

## 版本影响

- 版本：不改版本，原因是内部重构，无已发布包面变更
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：治理 charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` P1-2
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：host/runner 政策解析漂移已录 fact，同 charter 下另行裁决

## 验证

- `origin/main` 基准 SHA：`f81b6eb`
- 当前分支与 `origin/main` 的 merge-base：`f81b6eb`
- 最近一次 `git fetch origin` 时间：2026-07-10 ~18:2x +08:00
- 同步方式：rebase（worker 在 `92cb0a2` 基线验证,CEO rebase 后复跑）
- 公开 diff 命令：`git diff origin/main...codex/p1-script-executor`
- 私有证据 commit / 路径：`harness/tasks/task_01KX5MDXBC1R7V38N7T83AEZK3-p1-2-scriptexecutor/`
- Reviewer 证据路径：任务包 `artifacts/mission.md`
- GitHub Actions `rewrite-ci` run URL：待本 PR checks 产生
- 勾选情况与英文块一致：rebase 前基线 `npm run check` 全量 exit 0（含 bypass-write-boundary 125/125 delta 0）；rebase 后 `check:local` fast tier passed（46.5s）+ 定向沙箱阳性对照 8/8 + `git diff --check` 干净；全量 check 复跑交由 `rewrite-ci`
- 未运行：rebase 后全量 `npm run check`（交 CI）

## Review Evidence

- 自审：worker 阳性对照 8/8（读/写越界分类、越界产物拒绝、注册表写入）
- Reviewer subagent：CEO ground-truth（spawnSync 收敛 grep、5 文件 diff 检视、rebase 与 rebase 后 gate 由 CEO 亲跑）
- 人工 review：待定
- 阻塞发现：无

## 残余风险

- host/runner 政策解析漂移按设计保留并显式化；裁决前是已知不对称（fact 在任务 ledger）。

## 参考

- 任务：`harness/tasks/task_01KX5MDXBC1R7V38N7T83AEZK3-p1-2-scriptexecutor/`
- 证据：charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` artifacts（候选 A#8）
- Review：待回填任务包 `review.md`
