### PR TITLE
fix: attest remote principals via sshd forced commands

### DIFF
--- a/packages/cli/src/commands/daemon/connect.ts
+++ b/packages/cli/src/commands/daemon/connect.ts
@@ -1,11 +1,16 @@
 import net from "node:net";
+import path from "node:path";
 import type { Readable, Writable } from "node:stream";
 import {
   daemonIdFromEnv,
   daemonUserRoot,
-  localUserDaemonEndpoint
+  encodeJsonLineFrame,
+  localUserDaemonEndpoint,
+  sshForcedCommandBootstrapFrame,
+  type SshForcedCommandBootstrapInput
 } from "../../../../daemon/src/index.ts";
 import { readOption } from "../../cli/parse-options.ts";
+import { verifyCurrentProcessHasPrivilegedSshdAncestor } from "./sshd-witness.ts";
 
 export interface DaemonConnectStreams {
   readonly input: Readable;
@@ -18,7 +23,9 @@ export async function runDaemonConnect(
   options: {
     readonly env?: NodeJS.ProcessEnv;
     readonly platform?: NodeJS.Platform;
+    readonly rootDir?: string;
     readonly streams?: DaemonConnectStreams;
+    readonly verifySshdContext?: () => boolean;
   } = {}
 ): Promise<number> {
   const streams = options.streams ?? { input: process.stdin, output: process.stdout, error: process.stderr };
@@ -32,11 +39,23 @@ export async function runDaemonConnect(
   }
 
   const env = options.env ?? process.env;
+  let authentication: SshForcedCommandBootstrapInput | undefined;
+  try {
+    authentication = resolveSshForcedCommandAuthentication({
+      args,
+      rootDir: options.rootDir,
+      env,
+      verifySshdContext: options.verifySshdContext
+    });
+  } catch (error) {
+    streams.error.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 2;
+  }
   const userRoot = readOption(args, "--user-root") ?? daemonUserRoot(env);
   const endpoint = readOption(args, "--socket")
     ?? localUserDaemonEndpoint(userRoot, daemonIdFromEnv(env), options.platform ?? process.platform);
   try {
-    await connectDaemonStdio(endpoint, streams.input, streams.output);
+    await connectDaemonStdio(endpoint, streams.input, streams.output, authentication);
     return 0;
   } catch (error) {
     streams.error.write(
@@ -46,9 +65,45 @@ export async function runDaemonConnect(
   }
 }
 
-export async function connectDaemonStdio(endpoint: string, input: Readable, output: Writable): Promise<void> {
+export async function connectDaemonStdio(
+  endpoint: string,
+  input: Readable,
+  output: Writable,
+  authentication?: SshForcedCommandBootstrapInput
+): Promise<void> {
   const socket = await openDaemonEndpoint(endpoint);
+  if (authentication) socket.write(encodeJsonLineFrame(sshForcedCommandBootstrapFrame(authentication)));
   await relayDaemonStreams(socket, input, output);
+}
+
+export function resolveSshForcedCommandAuthentication(input: {
+  readonly args: ReadonlyArray<string>;
+  readonly rootDir?: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly verifySshdContext?: () => boolean;
+}): SshForcedCommandBootstrapInput | undefined {
+  const personId = readOption(input.args, "--principal");
+  const expectedOriginalCommand = readOption(input.args, "--expect-original-command");
+  const originalCommand = nonEmpty(input.env.SSH_ORIGINAL_COMMAND);
+  const hasForcedOptions = input.args.includes("--principal") || input.args.includes("--expect-original-command");
+
+  if (!hasForcedOptions && !originalCommand) return undefined;
+  if (!personId || personId.startsWith("--") || !expectedOriginalCommand || expectedOriginalCommand.startsWith("--") || !input.rootDir) {
+    throw forcedCommandConfigurationError();
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u.test(personId)) {
+    throw new Error("SSH forced-command principal must use a stable personId containing only letters, digits, dot, underscore, colon, or dash.");
+  }
+  if (/(?:^|\s)--(?:principal|root|expect-original-command)(?:\s|=|$)/u.test(expectedOriginalCommand)) {
+    throw new Error("SSH forced-command expected original command must not contain --principal, --root, or --expect-original-command.");
+  }
+  if (originalCommand !== expectedOriginalCommand) {
+    throw new Error(`SSH_ORIGINAL_COMMAND does not match the authorized_keys forced-command expectation. Expected ${JSON.stringify(expectedOriginalCommand)}.`);
+  }
+  if (!(input.verifySshdContext ?? verifyCurrentProcessHasPrivilegedSshdAncestor)()) {
+    throw new Error("SSH forced-command principal rejected: the process does not have a root-owned sshd ancestor.");
+  }
+  return { personId, canonicalRoot: path.resolve(input.rootDir) };
 }
 
 function openDaemonEndpoint(endpoint: string): Promise<net.Socket> {
@@ -87,4 +142,16 @@ function renderDaemonConnectHelp(): string {
     "",
     "Relay stdin/stdout to an already-running local daemon without creating a runtime."
   ].join("\n");
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function forcedCommandConfigurationError(): Error {
+  return new Error([
+    "Remote SSH daemon connections require a principal and canonical root proven by an authorized_keys forced command.",
+    "Configure each key with restrict and a static command such as:",
+    "command=\"ha --root /srv/harness/team daemon connect --stdio --principal person_alice --expect-original-command 'ha daemon connect --stdio'\",restrict"
+  ].join(" "));
 }

--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -365,9 +365,9 @@ function ensurePeopleRoster(filePath: string, input: {
     ...(input.primaryEmail ? [`    primaryEmail: ${input.primaryEmail}`] : []),
     `    roles: [${input.role}]`,
     "    credentials:",
-    "      - kind: ssh-username",
-    `        issuer: host:${input.sshHost}`,
-    `        subject: ${input.sshUser}`,
+    "      - kind: ssh-forced-command-person",
+    `        issuer: host:${os.hostname()}`,
+    `        subject: ${input.personId}`,
     ...(typeof uid === "number" ? [
       "      - kind: unix-socket-owner-boundary",
       `        issuer: host:${os.hostname()}`,

--- a/packages/cli/src/commands/daemon/serve-transport.ts
+++ b/packages/cli/src/commands/daemon/serve-transport.ts
@@ -24,6 +24,7 @@ export function createDaemonLocalTransport(
     return createNamedPipeTransportServer({
       daemonId: options.daemonId,
       pipePath: options.endpoint,
+      acceptSshForcedCommand: true,
       createProtocolServer: options.createProtocolServer,
       onConnection: options.onConnection,
       onConnectionClosed: options.onConnectionClosed
@@ -32,6 +33,7 @@ export function createDaemonLocalTransport(
   return createUnixSocketTransportServer({
     daemonId: options.daemonId,
     socketPath: options.endpoint,
+    acceptSshForcedCommand: true,
     createProtocolServer: options.createProtocolServer,
     onConnection: options.onConnection,
     onConnectionClosed: options.onConnectionClosed

--- a/packages/cli/src/commands/daemon/sshd-witness.ts
+++ b/packages/cli/src/commands/daemon/sshd-witness.ts
@@ -1,0 +1,82 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+export interface ProcessWitnessRecord {
+  readonly pid: number;
+  readonly parentPid: number;
+  readonly executable: string;
+  readonly privileged: boolean;
+}
+
+export type ReadProcessWitness = (pid: number) => ProcessWitnessRecord | undefined;
+
+export function verifyCurrentProcessHasPrivilegedSshdAncestor(
+  platform: NodeJS.Platform = process.platform,
+  parentPid: number = process.ppid
+): boolean {
+  return hasPrivilegedSshdAncestor(parentPid, platform === "win32" ? readWindowsProcess : readPosixProcess);
+}
+
+export function hasPrivilegedSshdAncestor(
+  startingPid: number,
+  readProcess: ReadProcessWitness
+): boolean {
+  const visited = new Set<number>();
+  let pid = startingPid;
+  for (let depth = 0; depth < 32 && pid > 1 && !visited.has(pid); depth += 1) {
+    visited.add(pid);
+    const record = readProcess(pid);
+    if (!record) return false;
+    if (record.privileged && isSshdExecutable(record.executable)) return true;
+    pid = record.parentPid;
+  }
+  return false;
+}
+
+function readPosixProcess(pid: number): ProcessWitnessRecord | undefined {
+  try {
+    const output = execFileSync("ps", ["-o", "pid=", "-o", "ppid=", "-o", "uid=", "-o", "comm=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    }).trim();
+    const match = /^(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/u.exec(output);
+    if (!match) return undefined;
+    return {
+      pid: Number.parseInt(match[1], 10),
+      parentPid: Number.parseInt(match[2], 10),
+      executable: match[4].trim(),
+      privileged: Number.parseInt(match[3], 10) === 0
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function readWindowsProcess(pid: number): ProcessWitnessRecord | undefined {
+  const script = [
+    `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"`,
+    "if ($null -eq $p) { exit 3 }",
+    "$owner = Invoke-CimMethod -InputObject $p -MethodName GetOwnerSid",
+    "[pscustomobject]@{ pid = [int]$p.ProcessId; parentPid = [int]$p.ParentProcessId; executable = [string]$p.Name; privileged = ($owner.Sid -eq 'S-1-5-18') } | ConvertTo-Json -Compress"
+  ].join("; ");
+  try {
+    const parsed = JSON.parse(execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    })) as { readonly pid?: unknown; readonly parentPid?: unknown; readonly executable?: unknown; readonly privileged?: unknown };
+    if (typeof parsed.pid !== "number" || typeof parsed.parentPid !== "number" || typeof parsed.executable !== "string") return undefined;
+    return {
+      pid: parsed.pid,
+      parentPid: parsed.parentPid,
+      executable: parsed.executable,
+      privileged: parsed.privileged === true
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function isSshdExecutable(executable: string): boolean {
+  const basename = path.basename(executable).toLowerCase().replace(/\.exe$/u, "");
+  return basename === "sshd" || basename.startsWith("sshd:");
+}

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -146,14 +146,14 @@ async function runWithLineClient(
     await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion });
     if (isTaskHolderCommand(command)) {
       const response = await client.request(taskHolderMethod(command), {
-        repo: { repoId },
+        repo: { repoId, canonicalRoot: command.rootDir },
         payload: taskHolderPayload(command)
       });
       if (isCommandReceipt(response)) return normalizeTaskHolderReceipt(response, command.action.kind);
       throw new Error(`${taskHolderMethod(command)} did not return command-receipt/v2`);
     }
     const response = await client.request("repo.command.run", {
-      repo: { repoId },
+      repo: { repoId, canonicalRoot: command.rootDir },
       payload: commandRunPayload(command)
     });
     if (isCommandReceipt(response)) return response as unknown as CommandReceipt | CommandFailureReceipt;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -70,7 +70,9 @@ async function maybeRunDaemonCommand(argv: ReadonlyArray<string>): Promise<numbe
   const action = stripped.args[1] ?? "status";
   const layoutOverrides = stripped.authoredRoot ? { authoredRoot: stripped.authoredRoot } : undefined;
   const daemonArgs = stripped.daemonRepoId ? [...stripped.args, "--repo", stripped.daemonRepoId] : stripped.args;
-  if (action === "connect") return runDaemonConnect(stripped.args);
+  if (action === "connect") return runDaemonConnect(stripped.args, {
+    ...(readOption(argv, "--root") ? { rootDir: stripped.rootDir } : {})
+  });
   if (action === "serve") {
     if (daemonArgs.includes("--stdio")) {
       console.error("daemon serve --stdio is disabled because it creates a competing runtime; start the persistent daemon and use 'ha daemon connect --stdio'.");

--- a/packages/cli/test/daemon-connect.test.ts
+++ b/packages/cli/test/daemon-connect.test.ts
@@ -6,7 +6,9 @@ import {
   localUserDaemonEndpoint,
   localUserDaemonSocketPath
 } from "../../daemon/src/index.ts";
+import { resolveSshForcedCommandAuthentication } from "../src/commands/daemon/connect.ts";
 import { createDaemonLocalTransport } from "../src/commands/daemon/serve-transport.ts";
+import { hasPrivilegedSshdAncestor } from "../src/commands/daemon/sshd-witness.ts";
 import {
   remoteDaemonUnavailableHint,
   remoteDaemonSshArgs,
@@ -63,4 +65,63 @@ test("remote mode invokes the pure connect subcommand without a runtime or clien
   ]);
   assert.match(remoteDaemonUnavailableHint(remote), /Start the persistent daemon on daemon\.example\.test/iu);
   assert.match(remoteDaemonUnavailableHint(remote), /ha daemon start --service/iu);
+});
+
+test("forced-command principal requires an unforgeable sshd process witness", () => {
+  assert.throws(() => resolveSshForcedCommandAuthentication({
+    args: ["daemon", "connect", "--stdio", "--principal", "person_alice", "--expect-original-command", "ha daemon connect --stdio"],
+    rootDir: "/srv/canonical",
+    env: { SSH_ORIGINAL_COMMAND: "ha daemon connect --stdio", USER: "shared-harness" },
+    verifySshdContext: () => false
+  }), /root-owned sshd ancestor/iu);
+});
+
+test("forced-command principal is static argv and never comes from SSH_ORIGINAL_COMMAND or USER", () => {
+  const authentication = resolveSshForcedCommandAuthentication({
+    args: ["daemon", "connect", "--stdio", "--principal", "person_alice", "--expect-original-command", "ha daemon connect --stdio"],
+    rootDir: "/srv/canonical",
+    env: { SSH_ORIGINAL_COMMAND: "ha daemon connect --stdio", USER: "person_mallory" },
+    verifySshdContext: () => true
+  });
+
+  assert.deepEqual(authentication, { personId: "person_alice", canonicalRoot: "/srv/canonical" });
+});
+
+test("forced-command principal rejects client-controlled privileged options in the original command", () => {
+  assert.throws(() => resolveSshForcedCommandAuthentication({
+    args: ["daemon", "connect", "--stdio", "--principal", "person_alice", "--expect-original-command", "ha daemon connect --stdio"],
+    rootDir: "/srv/canonical",
+    env: { SSH_ORIGINAL_COMMAND: "ha --root /srv/other daemon connect --stdio --principal person_mallory" },
+    verifySshdContext: () => true
+  }), /does not match/iu);
+});
+
+test("SSH remote connect without a forced-command principal fails closed with configuration guidance", () => {
+  assert.throws(() => resolveSshForcedCommandAuthentication({
+    args: ["daemon", "connect", "--stdio"],
+    env: { SSH_ORIGINAL_COMMAND: "ha daemon connect --stdio" },
+    verifySshdContext: () => true
+  }), /authorized_keys/iu);
+});
+
+test("local connect without SSH context remains an owner-boundary relay", () => {
+  assert.equal(resolveSshForcedCommandAuthentication({
+    args: ["daemon", "connect", "--stdio"],
+    env: {},
+    verifySshdContext: () => false
+  }), undefined);
+});
+
+test("sshd witness requires a privileged sshd ancestor instead of a lookalike process", () => {
+  const processTable = new Map([
+    [42, { pid: 42, parentPid: 21, executable: "/bin/sh", privileged: false }],
+    [21, { pid: 21, parentPid: 1, executable: "/usr/sbin/sshd", privileged: true }]
+  ]);
+  assert.equal(hasPrivilegedSshdAncestor(42, (pid) => processTable.get(pid)), true);
+
+  const spoofedTable = new Map([
+    [42, { pid: 42, parentPid: 21, executable: "/bin/sh", privileged: false }],
+    [21, { pid: 21, parentPid: 1, executable: "/tmp/sshd", privileged: false }]
+  ]);
+  assert.equal(hasPrivilegedSshdAncestor(42, (pid) => spoofedTable.get(pid)), false);
 });

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import net from "node:net";
-import { hostname } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { JsonRpcLineClient } from "../../daemon/src/index.ts";
@@ -18,6 +17,12 @@ import {
   withTempRoot,
   withTempRootAsync
 } from "./helpers/daemon-cli.ts";
+import {
+  forcedCommandRequest,
+  receiptDataString,
+  writeForcedCommandTeamRoster,
+  writePeopleRoster
+} from "./helpers/forced-command-daemon.ts";
 
 const expectedCliVersion = readCliPackageVersion();
 const cliEntry = path.resolve("packages/cli/src/index.ts");
@@ -67,6 +72,54 @@ test("daemon connect fails closed with startup instructions when no persistent d
     assert.match(result.stderr, /No persistent daemon is listening/iu);
     assert.match(result.stderr, /ha daemon start --service/iu);
     assert.equal(existsSync(path.join(rootDir, "harness")), false);
+  });
+});
+
+test("forced-command relay attributes two shared-account members without collapsing principal or executor", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = defaultDaemonUserRoot(rootDir);
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    const aliceTask = runRawJson(rootDir, ["new-task", "--title", "Alice Forced Principal"], {
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    const bobTask = runRawJson(rootDir, ["new-task", "--title", "Bob Forced Principal"], {
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    writeForcedCommandTeamRoster(rootDir);
+
+    try {
+      runDaemonCommand(rootDir, ["daemon", "start", "--service", "--json"], { HARNESS_DAEMON_USER_ROOT: userRoot });
+      const [alice, bob] = await Promise.all([
+        forcedCommandRequest(rootDir, userRoot, "person_alice", "repo.task.claim", {
+          repo: { repoId: "canonical", canonicalRoot: rootDir },
+          payload: { taskId: receiptDataString(aliceTask, "taskId"), executor: { kind: "agent", id: "codex-alice" } }
+        }),
+        forcedCommandRequest(rootDir, userRoot, "person_bob", "repo.task.claim", {
+          repo: { repoId: "canonical", canonicalRoot: rootDir },
+          payload: { taskId: receiptDataString(bobTask, "taskId"), executor: { kind: "agent", id: "codex-bob" } }
+        })
+      ]);
+
+      assert.equal(alice.ok, true, JSON.stringify(alice));
+      assert.equal(bob.ok, true, JSON.stringify(bob));
+      const aliceHolder = (((alice.details as Record<string, unknown>).data as Record<string, unknown>).effectiveHolder as Record<string, unknown>);
+      const bobHolder = (((bob.details as Record<string, unknown>).data as Record<string, unknown>).effectiveHolder as Record<string, unknown>);
+      assert.equal((aliceHolder.principal as { personId?: string }).personId, "person_alice");
+      assert.deepEqual(aliceHolder.executor, { kind: "agent", id: "codex-alice" });
+      assert.equal((bobHolder.principal as { personId?: string }).personId, "person_bob");
+      assert.deepEqual(bobHolder.executor, { kind: "agent", id: "codex-bob" });
+
+      const wrongRoot = await forcedCommandRequest(rootDir, userRoot, "person_alice", "repo.task.holder", {
+        repo: { repoId: "canonical", canonicalRoot: path.join(rootDir, "client-selected-root") },
+        payload: { taskId: receiptDataString(aliceTask, "taskId") }
+      });
+      assert.equal(wrongRoot.ok, false);
+      assert.equal((wrongRoot.error as { code?: string }).code, "forced_command_root_mismatch");
+    } finally {
+      stopDaemonQuietly(rootDir, userRoot);
+    }
   });
 });
 
@@ -302,6 +355,7 @@ test("daemon bootstrap-server is idempotent and installs roster hooks and read-o
     assert.equal(second.ok, true);
     assert.equal(existsSync(path.join(canonicalRoot, "harness/people.yaml")), true);
     assert.match(readFileSync(path.join(canonicalRoot, "harness/people.yaml"), "utf8"), /person_alice/u);
+    assert.match(readFileSync(path.join(canonicalRoot, "harness/people.yaml"), "utf8"), /ssh-forced-command-person/u);
     assert.equal(existsSync(path.join(canonicalRoot, ".git/hooks/pre-receive")), true);
     assert.equal(existsSync(path.join(mirrorRoot, "hooks/pre-receive")), true);
     assert.equal(existsSync(reportPath), true);
@@ -555,56 +609,6 @@ function git(rootDir: string, ...args: ReadonlyArray<string>): string {
     stdio: ["ignore", "pipe", "pipe"],
     env: hermeticGitEnv(rootDir)
   }).trim();
-}
-
-function writePeopleRoster(rootDir: string, person: {
-  readonly personId: string;
-  readonly displayName: string;
-  readonly email: string;
-  readonly role: "owner" | "maintainer";
-}): void {
-  const harnessRoot = path.join(rootDir, "harness");
-  mkdirSync(harnessRoot, { recursive: true });
-  writeFileSync(path.join(harnessRoot, "people.yaml"), [
-    "schema: harness-people/v1",
-    "people:",
-    `  - personId: ${person.personId}`,
-    `    displayName: ${person.displayName}`,
-    `    primaryEmail: ${person.email}`,
-    `    roles: [${person.role}]`,
-    "    credentials:",
-    "      - kind: unix-socket-owner-boundary",
-    `        issuer: host:${hostname()}`,
-    `        subject: ${process.getuid?.() ?? 0}`,
-    "roles:",
-    "  - roleId: owner",
-    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
-    "  - roleId: maintainer",
-    "    commandClasses: [repo-write, repo-read]",
-    ""
-  ].join("\n"), "utf8");
-  commitPeopleRoster(harnessRoot);
-}
-
-function commitPeopleRoster(harnessRoot: string): void {
-  if (!existsSync(path.join(harnessRoot, ".git"))) return;
-  execFileSync("git", ["-C", harnessRoot, "add", "--", "people.yaml"], { stdio: "ignore" });
-  execFileSync("git", ["-C", harnessRoot, "commit", "-m", "chore: configure daemon people roster"], {
-    stdio: "ignore",
-    env: gitAuthorEnv(harnessRoot)
-  });
-}
-
-function gitAuthorEnv(rootDir: string): NodeJS.ProcessEnv {
-  const name = process.env.HARNESS_GIT_AUTHOR_NAME ?? "Harness Test";
-  const email = process.env.HARNESS_GIT_AUTHOR_EMAIL ?? "harness@example.test";
-  return {
-    ...hermeticGitEnv(rootDir),
-    GIT_AUTHOR_NAME: name,
-    GIT_AUTHOR_EMAIL: email,
-    GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? name,
-    GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? email
-  };
 }
 
 function hermeticGitEnv(rootDir: string): NodeJS.ProcessEnv {

--- a/packages/cli/test/helpers/forced-command-daemon.ts
+++ b/packages/cli/test/helpers/forced-command-daemon.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { hostname } from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { JsonRpcLineClient } from "../../../daemon/src/index.ts";
+import { runDaemonConnect } from "../../src/commands/daemon/connect.ts";
+
+export function writePeopleRoster(rootDir: string, person: {
+  readonly personId: string;
+  readonly displayName: string;
+  readonly email: string;
+  readonly role: "owner" | "maintainer";
+}): void {
+  const harnessRoot = path.join(rootDir, "harness");
+  mkdirSync(harnessRoot, { recursive: true });
+  writeFileSync(path.join(harnessRoot, "people.yaml"), [
+    "schema: harness-people/v1",
+    "people:",
+    `  - personId: ${person.personId}`,
+    `    displayName: ${person.displayName}`,
+    `    primaryEmail: ${person.email}`,
+    `    roles: [${person.role}]`,
+    "    credentials:",
+    "      - kind: unix-socket-owner-boundary",
+    `        issuer: host:${hostname()}`,
+    `        subject: ${process.getuid?.() ?? 0}`,
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    "  - roleId: maintainer",
+    "    commandClasses: [repo-write, repo-read]",
+    ""
+  ].join("\n"), "utf8");
+  commitPeopleRoster(harnessRoot);
+}
+
+export function writeForcedCommandTeamRoster(rootDir: string): void {
+  const harnessRoot = path.join(rootDir, "harness");
+  mkdirSync(harnessRoot, { recursive: true });
+  writeFileSync(path.join(harnessRoot, "people.yaml"), [
+    "schema: harness-people/v1",
+    "people:",
+    "  - personId: person_alice",
+    "    displayName: Alice",
+    "    primaryEmail: alice@example.test",
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: ssh-forced-command-person",
+    `        issuer: host:${hostname()}`,
+    "        subject: person_alice",
+    "      - kind: unix-socket-owner-boundary",
+    `        issuer: host:${hostname()}`,
+    `        subject: ${process.getuid?.() ?? 0}`,
+    "  - personId: person_bob",
+    "    displayName: Bob",
+    "    primaryEmail: bob@example.test",
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: ssh-forced-command-person",
+    `        issuer: host:${hostname()}`,
+    "        subject: person_bob",
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    ""
+  ].join("\n"), "utf8");
+  commitPeopleRoster(harnessRoot);
+}
+
+export async function forcedCommandRequest(
+  rootDir: string,
+  userRoot: string,
+  personId: string,
+  method: string,
+  params: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const error = new PassThrough();
+  const expectedOriginalCommand = "ha daemon connect --stdio";
+  const connect = runDaemonConnect([
+    "daemon",
+    "connect",
+    "--stdio",
+    "--principal",
+    personId,
+    "--expect-original-command",
+    expectedOriginalCommand
+  ], {
+    rootDir,
+    env: {
+      ...process.env,
+      HARNESS_DAEMON_USER_ROOT: userRoot,
+      SSH_ORIGINAL_COMMAND: expectedOriginalCommand,
+      USER: "shared-harness"
+    },
+    streams: { input, output, error },
+    verifySshdContext: () => true
+  });
+  const client = new JsonRpcLineClient(output, input);
+  try {
+    const hello = await client.request("protocol.hello", { protocolVersion: 1 });
+    assert.equal(hello.ok, true);
+    return await client.request(method, params as never) as Record<string, unknown>;
+  } finally {
+    client.close();
+    assert.equal(await connect, 0);
+  }
+}
+
+export function receiptDataString(receipt: Record<string, unknown>, key: string): string {
+  const details = receipt.details as Record<string, unknown> | undefined;
+  const data = details?.data as Record<string, unknown> | undefined;
+  assert.equal(typeof data?.[key], "string");
+  return data[key] as string;
+}
+
+function commitPeopleRoster(harnessRoot: string): void {
+  if (!existsSync(path.join(harnessRoot, ".git"))) return;
+  execFileSync("git", ["-C", harnessRoot, "add", "--", "people.yaml"], { stdio: "ignore" });
+  execFileSync("git", ["-C", harnessRoot, "commit", "-m", "chore: configure daemon people roster"], {
+    stdio: "ignore",
+    env: gitAuthorEnv(harnessRoot)
+  });
+}
+
+function gitAuthorEnv(rootDir: string): NodeJS.ProcessEnv {
+  const name = process.env.HARNESS_GIT_AUTHOR_NAME ?? "Harness Test";
+  const email = process.env.HARNESS_GIT_AUTHOR_EMAIL ?? "harness@example.test";
+  return {
+    ...process.env,
+    HOME: path.join(rootDir, ".home"),
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_AUTHOR_NAME: name,
+    GIT_AUTHOR_EMAIL: email,
+    GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? name,
+    GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? email
+  };
+}

--- a/packages/daemon/src/identity/people-roster.ts
+++ b/packages/daemon/src/identity/people-roster.ts
@@ -18,6 +18,7 @@ const credentialKinds = new Set<CredentialKind>([
   "unix-socket-owner-boundary",
   "windows-named-pipe-client",
   "ssh-username",
+  "ssh-forced-command-person",
   "ssh-tunnel-token-subject",
   "email-address",
   "password-account",

--- a/packages/daemon/src/identity/transport-derived-provider.ts
+++ b/packages/daemon/src/identity/transport-derived-provider.ts
@@ -6,6 +6,7 @@ import type { CredentialRef, IdentityProvider, IdentityProviderFailure, PeopleRo
 export interface TransportDerivedIdentityProviderOptions {
   readonly localUnixIssuer?: string;
   readonly sshExecIssuer?: string;
+  readonly sshForcedCommandIssuer?: string;
   readonly namedPipeIssuer?: string;
 }
 
@@ -34,6 +35,13 @@ function credentialFromAuthContext(
   authContext: DaemonAuthenticationContext,
   options: TransportDerivedIdentityProviderOptions
 ): CredentialRef | undefined {
+  if (authContext.sshForcedCommand?.personId) {
+    return {
+      kind: "ssh-forced-command-person",
+      issuer: options.sshForcedCommandIssuer ?? `host:${os.hostname()}`,
+      subject: authContext.sshForcedCommand.personId
+    };
+  }
   if (typeof authContext.unixSocketOwnerBoundary?.ownerUid === "number") {
     return {
       kind: "unix-socket-owner-boundary",

--- a/packages/daemon/src/identity/types.ts
+++ b/packages/daemon/src/identity/types.ts
@@ -8,6 +8,7 @@ export type CredentialKind =
   | "unix-socket-owner-boundary"
   | "windows-named-pipe-client"
   | "ssh-username"
+  | "ssh-forced-command-person"
   | "ssh-tunnel-token-subject"
   | "email-address"
   | "password-account"

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -88,9 +88,16 @@ export {
   type DaemonTransportKind,
   type NamedPipeClientContext,
   type SshExecUserContext,
+  type SshForcedCommandContext,
   type SshTunnelTokenContext,
   type UnixSocketOwnerBoundary
 } from "./transport/auth-context.ts";
+export {
+  authenticateSshForcedCommandFrame,
+  sshForcedCommandBootstrapFrame,
+  type SshForcedCommandBootstrapFrame,
+  type SshForcedCommandBootstrapInput
+} from "./transport/ssh-forced-command.ts";
 export {
   createJsonLineFrameReader,
   encodeJsonLineFrame,

--- a/packages/daemon/src/protocol/forced-command-root.ts
+++ b/packages/daemon/src/protocol/forced-command-root.ts
@@ -1,0 +1,70 @@
+import { realpathSync } from "node:fs";
+import path from "node:path";
+import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
+import type { JsonRpcMethodContract } from "./method-registry.ts";
+import { failureReceipt } from "./receipt-envelope.ts";
+import { isJsonObject, type JsonObject } from "./json-rpc-types.ts";
+
+interface RepoNamespace {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+}
+
+export function commandRootMismatch(
+  payload: JsonObject | undefined,
+  repo: RepoNamespace,
+  authContext: DaemonAuthenticationContext | undefined
+): ReturnType<typeof failureReceipt> | undefined {
+  const command = isJsonObject(payload?.command) ? payload.command : undefined;
+  const rootDir = typeof command?.rootDir === "string" ? command.rootDir : undefined;
+  if (!rootDir || sameRoot(rootDir, repo.canonicalRoot)) return undefined;
+  const forcedRoot = authContext?.sshForcedCommand?.canonicalRoot;
+  return failureReceipt("repo.command.run", forcedRoot ? "forced_command_root_mismatch" : "repo_command_root_mismatch", forcedRoot
+    ? "Client --root does not match the canonical root pinned by the SSH forced command."
+    : "payload.command.rootDir does not match params.repo.repoId.", {
+    repo: { repoId: repo.repoId, canonicalRoot: repo.canonicalRoot },
+    command: { rootDir },
+    ...(forcedRoot ? { forcedCommand: { canonicalRoot: forcedRoot } } : {})
+  });
+}
+
+export function validateForcedCommandRoot(
+  contract: JsonRpcMethodContract,
+  params: JsonObject,
+  repo: RepoNamespace | undefined,
+  authContext: DaemonAuthenticationContext | undefined
+): ReturnType<typeof failureReceipt> | undefined {
+  const forcedRoot = authContext?.sshForcedCommand?.canonicalRoot;
+  if (!contract.requiresRepo || !repo || !forcedRoot) return undefined;
+  const requestedRoot = isJsonObject(params.repo) && typeof params.repo.canonicalRoot === "string"
+    ? params.repo.canonicalRoot
+    : undefined;
+  if (!requestedRoot) {
+    return failureReceipt(contract.method, "forced_command_root_required", "SSH forced-command requests must assert the server root configured by authorized_keys.", {
+      forcedCommand: { canonicalRoot: forcedRoot }
+    });
+  }
+  if (!sameRoot(requestedRoot, forcedRoot)) {
+    return failureReceipt(contract.method, "forced_command_root_mismatch", "Client --root does not match the canonical root pinned by the SSH forced command.", {
+      requested: { canonicalRoot: requestedRoot },
+      forcedCommand: { canonicalRoot: forcedRoot }
+    });
+  }
+  if (sameRoot(forcedRoot, repo.canonicalRoot)) return undefined;
+  return failureReceipt(contract.method, "forced_command_root_mismatch", "Requested repo does not match the canonical root pinned by the SSH forced command.", {
+    repo: { repoId: repo.repoId, canonicalRoot: repo.canonicalRoot },
+    forcedCommand: { canonicalRoot: forcedRoot }
+  });
+}
+
+function sameRoot(left: string, right: string): boolean {
+  return realpathOrResolve(left) === realpathOrResolve(right);
+}
+
+function realpathOrResolve(rootDir: string): string {
+  try {
+    return realpathSync.native(rootDir);
+  } catch {
+    return path.resolve(rootDir);
+  }
+}

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -1,6 +1,4 @@
 // @slice-activation PLT-Daemon W2 protocol core exported for W3 transport adapters.
-import { realpathSync } from "node:fs";
-import path from "node:path";
 import {
   isTaskHolderError,
   runtimeEventActorFromTaskHolderPrincipal,
@@ -18,6 +16,7 @@ import { commandClassForJsonRpcRequest, currentDaemonProtocolVersion, jsonRpcMet
 import { failureReceipt, serviceResultReceipt, successReceipt } from "./receipt-envelope.ts";
 import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse, type JsonValue } from "./json-rpc-types.ts";
 import { readTaskHolderExecutor, readTaskHolderExecutorForEvent } from "./task-holder-payload.ts";
+import { commandRootMismatch, validateForcedCommandRoot } from "./forced-command-root.ts";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
 import { authorizeActorForMethod } from "../identity/authorization.ts";
 import { actorStampJson, type AuthenticatedActor, type IdentityProvider, type PeopleRoster } from "../identity/types.ts";
@@ -139,6 +138,8 @@ async function handleRequest(
   if (repoFailure) return response(failureReceipt(request.method, repoFailure.code, repoFailure.hint));
   const repo = repoForContract(contract, params, repos);
   const effectiveContract = withEffectiveCommandClass(contract, params);
+  const forcedRootFailure = validateForcedCommandRoot(effectiveContract, params, repo, options.authContext);
+  if (forcedRootFailure) return response(forcedRootFailure);
   const repoRuntimeFailure = validateRepoRuntime(effectiveContract, repo, options);
   if (repoRuntimeFailure) return response(repoRuntimeFailure);
 
@@ -255,6 +256,10 @@ async function callServiceMethod(
   repo: DaemonRepoNamespace | undefined
 ): Promise<ReturnType<typeof successReceipt> | ReturnType<typeof failureReceipt>> {
   const payload = isJsonObject(params.payload) ? params.payload : undefined;
+  if (contract.method === "repo.command.run" && repo) {
+    const rootMismatch = commandRootMismatch(payload, repo, options.authContext);
+    if (rootMismatch) return rootMismatch;
+  }
   const services = repo ? resolveServicesForRepo(contract.method, repo, options) : options.services;
   if (!services) return failureReceipt(contract.method, "repo_service_unavailable", `Repo service host is not configured for ${repo?.repoId ?? "unknown"}.`);
   if (contract.method === "repo.daemon.status") {
@@ -267,8 +272,6 @@ async function callServiceMethod(
     if (!services.CliCommandService) {
       return failureReceipt(contract.method, "cli_command_service_unavailable", "Daemon command service is not configured.");
     }
-    const rootMismatch = repo ? commandRootMismatch(payload, repo) : undefined;
-    if (rootMismatch) return rootMismatch;
     return services.CliCommandService.runCommand(payload, { actor, repo });
   }
   if (contract.method === "repo.task.claim" || contract.method === "repo.task.holder" || contract.method === "repo.task.release") {
@@ -382,25 +385,6 @@ function resolveServicesForRepo(
   return options.resolveRepoServices(repo) ?? (method === "repo.daemon.status" ? options.services : undefined);
 }
 
-function commandRootMismatch(payload: JsonObject | undefined, repo: DaemonRepoNamespace): ReturnType<typeof failureReceipt> | undefined {
-  const command = isJsonObject(payload?.command) ? payload.command : undefined;
-  const rootDir = typeof command?.rootDir === "string" ? command.rootDir : undefined;
-  if (!rootDir) return undefined;
-  if (realpathOrResolve(rootDir) === realpathOrResolve(repo.canonicalRoot)) return undefined;
-  return failureReceipt("repo.command.run", "repo_command_root_mismatch", "payload.command.rootDir does not match params.repo.repoId.", {
-    repo: { repoId: repo.repoId, canonicalRoot: repo.canonicalRoot },
-    command: { rootDir }
-  });
-}
-
-function realpathOrResolve(rootDir: string): string {
-  try {
-    return realpathSync.native(rootDir);
-  } catch {
-    return path.resolve(rootDir);
-  }
-}
-
 function withEffectiveCommandClass(contract: JsonRpcMethodContract, params: JsonObject): JsonRpcMethodContract {
   const commandClass = commandClassForJsonRpcRequest(contract, params);
   if (commandClass === contract.commandClass) return contract;
@@ -411,8 +395,17 @@ async function resolveActor(
   contract: JsonRpcMethodContract,
   options: JsonRpcServerOptions
 ): Promise<{ readonly ok: true; readonly actor: AuthenticatedActor } | Awaited<ReturnType<IdentityProvider["resolveActor"]>> | undefined> {
-  if (!options.identityProvider) return undefined;
   const authContext = options.authContext ?? { transportKind: "unix-socket" } satisfies DaemonAuthenticationContext;
+  if (!options.identityProvider) {
+    return authContext.sshForcedCommand
+      ? {
+          ok: false,
+          code: "provider_unavailable",
+          providerId: "transport-derived/v1",
+          message: "SSH forced-command authentication requires people.yaml roster validation."
+        }
+      : undefined;
+  }
   return options.identityProvider.resolveActor({
     authContext,
     command: {

--- a/packages/daemon/src/transport/auth-context.ts
+++ b/packages/daemon/src/transport/auth-context.ts
@@ -18,6 +18,12 @@ export interface SshExecUserContext {
   readonly source: "ssh-authenticated-exec";
 }
 
+export interface SshForcedCommandContext {
+  readonly personId: string;
+  readonly canonicalRoot: string;
+  readonly source: "sshd-authorized-keys-forced-command";
+}
+
 export interface AttachTokenSubject {
   readonly userId: string;
   readonly hostProfileId: string;
@@ -38,5 +44,6 @@ export interface DaemonAuthenticationContext {
   readonly unixSocketOwnerBoundary?: UnixSocketOwnerBoundary;
   readonly namedPipeClient?: NamedPipeClientContext;
   readonly sshExecUser?: SshExecUserContext;
+  readonly sshForcedCommand?: SshForcedCommandContext;
   readonly sshTunnelToken?: SshTunnelTokenContext;
 }

--- a/packages/daemon/src/transport/json-rpc-stream.ts
+++ b/packages/daemon/src/transport/json-rpc-stream.ts
@@ -15,6 +15,7 @@ export interface DaemonTransportConnection {
 export interface TransportAuthenticationSuccess {
   readonly ok: true;
   readonly authContext?: DaemonAuthenticationContext;
+  readonly forwardFrame?: boolean;
 }
 
 export interface TransportAuthenticationFailure {
@@ -92,7 +93,7 @@ export function serveJsonRpcStream(options: JsonRpcStreamOptions): DaemonTranspo
       authContext = result.authContext ?? authContext;
       server = options.createProtocolServer(authContext);
       waitingForAuthentication = false;
-      return;
+      if (!result.forwardFrame) return;
     }
 
     if (!server || !isJsonRpcRequestLike(frame)) {

--- a/packages/daemon/src/transport/named-pipe.ts
+++ b/packages/daemon/src/transport/named-pipe.ts
@@ -2,6 +2,7 @@
 import net from "node:net";
 import type { DaemonAuthenticationContext } from "./auth-context.ts";
 import { serveJsonRpcStream, type DaemonTransportConnection } from "./json-rpc-stream.ts";
+import { authenticateSshForcedCommandFrame } from "./ssh-forced-command.ts";
 import type { JsonRpcProtocolServer } from "../protocol/json-rpc-server.ts";
 
 export interface NamedPipeTransportOptions {
@@ -11,6 +12,7 @@ export interface NamedPipeTransportOptions {
   readonly createProtocolServer: (authContext: DaemonAuthenticationContext) => JsonRpcProtocolServer;
   readonly onConnection?: (connection: DaemonTransportConnection) => void;
   readonly onConnectionClosed?: (connection: DaemonTransportConnection) => void;
+  readonly acceptSshForcedCommand?: boolean;
 }
 
 export interface NamedPipeTransportServer {
@@ -54,6 +56,7 @@ export function createNamedPipeTransportServer(options: NamedPipeTransportOption
       output: socket,
       transportKind: "named-pipe",
       authContext,
+      ...(options.acceptSshForcedCommand ? { authenticateFirstFrame: authenticateSshForcedCommandFrame } : {}),
       createProtocolServer: options.createProtocolServer
     });
     options.onConnection?.(connection);

--- a/packages/daemon/src/transport/ssh-forced-command.ts
+++ b/packages/daemon/src/transport/ssh-forced-command.ts
@@ -1,0 +1,59 @@
+import type { DaemonAuthenticationContext } from "./auth-context.ts";
+import type { TransportAuthenticationResult } from "./json-rpc-stream.ts";
+
+export interface SshForcedCommandBootstrapInput {
+  readonly personId: string;
+  readonly canonicalRoot: string;
+}
+
+export interface SshForcedCommandBootstrapFrame extends SshForcedCommandBootstrapInput {
+  readonly type: "harness-daemon.ssh-forced-command/v1";
+}
+
+export function sshForcedCommandBootstrapFrame(
+  input: SshForcedCommandBootstrapInput
+): SshForcedCommandBootstrapFrame {
+  return {
+    type: "harness-daemon.ssh-forced-command/v1",
+    personId: input.personId,
+    canonicalRoot: input.canonicalRoot
+  };
+}
+
+export function authenticateSshForcedCommandFrame(
+  frame: unknown,
+  authContext: DaemonAuthenticationContext
+): TransportAuthenticationResult {
+  if (!isSshForcedCommandBootstrapFrame(frame)) {
+    if (isForcedCommandFrameType(frame)) {
+      return { ok: false, code: "forced_command_malformed", message: "Malformed SSH forced-command authentication frame." };
+    }
+    return { ok: true, authContext, forwardFrame: true };
+  }
+  return {
+    ok: true,
+    authContext: {
+      ...authContext,
+      sshForcedCommand: {
+        personId: frame.personId,
+        canonicalRoot: frame.canonicalRoot,
+        source: "sshd-authorized-keys-forced-command"
+      }
+    }
+  };
+}
+
+function isForcedCommandFrameType(value: unknown): boolean {
+  return value !== null
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && (value as { readonly type?: unknown }).type === "harness-daemon.ssh-forced-command/v1";
+}
+
+function isSshForcedCommandBootstrapFrame(value: unknown): value is SshForcedCommandBootstrapFrame {
+  return isForcedCommandFrameType(value)
+    && typeof (value as { readonly personId?: unknown }).personId === "string"
+    && (value as { readonly personId: string }).personId.length > 0
+    && typeof (value as { readonly canonicalRoot?: unknown }).canonicalRoot === "string"
+    && (value as { readonly canonicalRoot: string }).canonicalRoot.length > 0;
+}

--- a/packages/daemon/src/transport/unix-socket.ts
+++ b/packages/daemon/src/transport/unix-socket.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import type { DaemonAuthenticationContext } from "./auth-context.ts";
 import { serveJsonRpcStream, type DaemonTransportConnection } from "./json-rpc-stream.ts";
+import { authenticateSshForcedCommandFrame } from "./ssh-forced-command.ts";
 import type { JsonRpcProtocolServer } from "../protocol/json-rpc-server.ts";
 
 export interface UnixSocketTransportOptions {
@@ -13,6 +14,7 @@ export interface UnixSocketTransportOptions {
   readonly createProtocolServer: (authContext: DaemonAuthenticationContext) => JsonRpcProtocolServer;
   readonly onConnection?: (connection: DaemonTransportConnection) => void;
   readonly onConnectionClosed?: (connection: DaemonTransportConnection) => void;
+  readonly acceptSshForcedCommand?: boolean;
 }
 
 export interface UnixSocketTransportServer {
@@ -45,6 +47,7 @@ export function createUnixSocketTransportServer(options: UnixSocketTransportOpti
       output: socket,
       transportKind: "unix-socket",
       authContext,
+      ...(options.acceptSshForcedCommand ? { authenticateFirstFrame: authenticateSshForcedCommandFrame } : {}),
       createProtocolServer: options.createProtocolServer
     });
     options.onConnection?.(connection);

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -343,6 +343,34 @@ test("transport-derived provider rejects unknown credentials without anonymous f
   if (!resolved.ok) assert.equal(resolved.code, "credential_unknown");
 });
 
+test("SSH forced-command authentication fails closed when the people roster provider is unavailable", async () => {
+  const server = makeServer({
+    authContext: {
+      transportKind: "unix-socket",
+      sshForcedCommand: {
+        personId: "person_alice",
+        canonicalRoot: "/tmp/canonical",
+        source: "sshd-authorized-keys-forced-command"
+      }
+    }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const request = commandRunRequest("version", "forced-no-roster");
+  const response = await server.handle({
+    ...request,
+    params: {
+      repo: { repoId: "canonical", canonicalRoot: "/tmp/canonical" },
+      payload: { command: { rootDir: "/tmp/canonical", json: true, action: { kind: "version" } } }
+    }
+  });
+  const receipt = resultReceipt(response);
+
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.error?.code, "provider_unavailable");
+  assert.match(receipt.error?.hint ?? "", /people\.yaml roster validation/iu);
+});
+
 test("mock email provider proves provider extension without daemon call-site changes", async () => {
   const roster = sampleRoster();
   const emailProvider: IdentityProvider = {

--- a/packages/daemon/test/transport-integration.test.ts
+++ b/packages/daemon/test/transport-integration.test.ts
@@ -10,6 +10,7 @@ import type { LocalControllerService } from "../../application/src/index.ts";
 import { createInMemoryTerminalSessionService } from "../../gui/src/terminal/session-registry.ts";
 import {
   attachTokenBootstrapFrame,
+  authenticateSshForcedCommandFrame,
   createInMemoryAttachTokenStore,
   createJsonRpcProtocolServer,
   createNamedPipeTransportServer,
@@ -20,6 +21,8 @@ import {
   encodeJsonLineFrame,
   makeTransportDerivedIdentityProvider,
   peopleRosterFromDocument,
+  serveJsonRpcStream,
+  sshForcedCommandBootstrapFrame,
   serveSshExecBridge,
   serveSshTunnelTokenStream,
   windowsNamedPipeIntegrationEntry,
@@ -114,6 +117,75 @@ test("unix socket auth without an owner boundary fails explicitly", async () => 
     assert.equal(resolved.code, "credential_unavailable");
     assert.equal(resolved.message, "Transport authentication context did not expose a usable credential.");
   }
+});
+
+test("forced-command credentials keep two members distinct and ignore the shared unix owner", async () => {
+  const roster = peopleRosterFromDocument([
+    "schema: harness-people/v1",
+    "people:",
+    "  - personId: person_alice",
+    "    displayName: Alice",
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: ssh-forced-command-person",
+    "        issuer: host:team-host",
+    "        subject: person_alice",
+    "  - personId: person_bob",
+    "    displayName: Bob",
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: ssh-forced-command-person",
+    "        issuer: host:team-host",
+    "        subject: person_bob",
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    ""
+  ].join("\n"));
+  const provider = makeTransportDerivedIdentityProvider(roster, { sshForcedCommandIssuer: "host:team-host" });
+
+  const resolve = (personId: string) => provider.resolveActor({
+    authContext: {
+      transportKind: "unix-socket" as const,
+      unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" as const },
+      sshForcedCommand: { personId, canonicalRoot: "/srv/canonical", source: "sshd-authorized-keys-forced-command" as const }
+    },
+    command: { method: "repo.tasks.list", namespace: "repo", requiresRepo: true }
+  });
+  const [alice, bob, unknown] = await Promise.all([resolve("person_alice"), resolve("person_bob"), resolve("person_mallory")]);
+
+  assert.equal(alice.ok && alice.actor.personId, "person_alice");
+  assert.equal(bob.ok && bob.actor.personId, "person_bob");
+  assert.equal(unknown.ok, false);
+  if (!unknown.ok) assert.equal(unknown.code, "credential_unknown");
+});
+
+test("forced-command bootstrap is consumed before JSON-RPC and becomes authContext", async () => {
+  const clientToServer = new PassThrough();
+  const serverToClient = new PassThrough();
+  let seenAuthContext: DaemonAuthenticationContext | undefined;
+  const connection = serveJsonRpcStream({
+    input: clientToServer,
+    output: serverToClient,
+    transportKind: "unix-socket",
+    authContext: {
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" }
+    },
+    authenticateFirstFrame: authenticateSshForcedCommandFrame,
+    createProtocolServer: (authContext) => {
+      seenAuthContext = authContext;
+      return makeProtocolServerFactory()(authContext);
+    }
+  });
+  const client = frameClient(serverToClient, clientToServer);
+
+  client.send(sshForcedCommandBootstrapFrame({ personId: "person_alice", canonicalRoot: "/srv/canonical" }));
+  client.send(hello("forced-hello"));
+  assert.equal(resultReceipt(await client.read()).ok, true);
+  assert.equal(seenAuthContext?.sshForcedCommand?.personId, "person_alice");
+  assert.equal(seenAuthContext?.sshForcedCommand?.canonicalRoot, "/srv/canonical");
+  await connection.close();
 });
 
 test("people roster rejects legacy unix-uid credentials", () => {


### PR DESCRIPTION
# English

## Summary

A2 of the daemon/attribution series: remote principals are now attested by sshd via per-member authorized_keys forced commands (team model A, decision dec_mrcz2q6k), `process.env.USER` is removed from the remote attribution path (decision dec_mrdrbkp7 C4: principal sources prohibit environment variables), and the client-chosen server `--root` is closed off — the server-side root pinned in the forced command is authoritative and mismatches fail explicitly. Two team members sharing one unix account now resolve to two distinct principals; without attestation the remote entry fails closed with authorized_keys configuration guidance.

## What Changed

- Forced-command entry: `--principal`, server `--root`, and `--expect-original-command` are read only from the static authorized_keys forced command; a remote client still requests plain `ha daemon connect --stdio`.
- Mechanical anti-spoofing gate (not a convention): the entry requires a privileged sshd process ancestor (uid-0 `sshd` on POSIX; LocalSystem `sshd.exe` on Windows via CIM ownership); `SSH_ORIGINAL_COMMAND` must exactly equal the statically configured expectation, and the expectation itself is rejected if it contains privileged options — argv/env can be copied by a local process, OS process ancestry cannot.
- Principal flow: new `ssh-forced-command-person` credential kind carried via `authContext.sshForcedCommand`; the transport-derived provider resolves it against `people.yaml` with precedence over the shared socket-owner credential. `ParsedCommand` and JSON-RPC payloads still carry no actor/principal field.
- `process.env.USER` / `env.USER` removed from remote attribution; tests set `USER=person_mallory` while resolving `person_alice` from the static forced command.
- Fail-closed matrix: missing tuple → configuration guidance; principal args without privileged ancestor → rejected; original-command mismatch → rejected before the endpoint opens; unknown/disabled roster credential → existing roster failure; no identity provider → `provider_unavailable`, never anonymous.
- `ssh-tunnel-token` deliberately not enabled (sshd already attests key ownership; a token would duplicate authentication and expand scope — rationale recorded).
- Unix socket permissions 0700/0600 untouched.

## Task And Scope

- Harness task: task_01KX2GHETQZ3HKVMB8EDXCB99C
- Branch: codex/a2-forced-command
- Public scope: daemon transport/identity/protocol, CLI remote entry, tests (22 files, +697/−85)
- Private planning/evidence updated: yes (implementation report in the task package; ledger progress/facts recorded)
- Out of scope: A5 attribution-source mechanical defense (`--actor` flag, next); A4 operations documentation (after implementation alignment); attach-token lifecycle design

## Version Impact

- Version: no version change because remote team mode is pre-release surface; local single-user behavior is unchanged.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: decisions dec_mrcz2q6k (model A), dec_mrcz1kqh (persistent daemon + pure relay), dec_mrdrbkp7 C4 (no env principals), dec_mrczk07e (env cannot attest humans); task task_01KX2GHETQZ3HKVMB8EDXCB99C
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: post-merge `ha decision reckon dec_mrcz1kqh` (expected 4/4); A4 documents the authorized_keys procedure and revocation

## Verification

- Base `origin/main` SHA: 0eec448
- Branch merge-base with `origin/main`: 0eec448 (rebased onto latest main before push)
- Last `git fetch origin` time: 2026-07-10 ~10:20 UTC
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/a2-forced-command`
- Private evidence commit/path: task package impl-report for task_01KX2GHETQZ3HKVMB8EDXCB99C (private ledger)
- Reviewer evidence path: see References
- GitHub Actions `rewrite-ci` run URL: pending (runs on this PR)
- [x] `npm run check` (as `npm run check:local` fast tier: worker 16 steps, fast 275/275, contract 348/348; CEO re-run after rebase, green)
- [x] boundaries job full, CEO-run with GITHUB_TOKEN: `node tools/run-manifest-gates.mjs --workflow-job boundaries --exclude mergify-queue-metadata-edit-noop` (passed, including the two token-required context checks)
- [x] CI-shape integration shard 2 (59/59) and shard 4 (100 passed, 1 pre-existing Windows-only skip)
- [x] `git diff --check`
- [ ] `npm ci`
- [ ] `npm run typecheck` (covered by check:local fast tier and CI)
- [ ] `npm test` (integration covered by CI shards)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: live external sshd session (hermetic tests inject the witness decision and separately cover ancestor classification, original-command equality, fail-closed cases, roster resolution, and the real persistent-daemon relay); Windows sshd witness needs Windows host/CI validation (declared skip).

## Review Evidence

- Self-review: CEO's checkpoint question — "what mechanically stops a normal local invocation from using the forced-command principal parameters?" — is answered in the report's gate section (privileged ancestry + exact original-command equality + expectation string rejecting privileged flags) and covered by adversarial tests (`USER=person_mallory` vs `person_alice`; principal args without sshd ancestry rejected). Design checkpoint (pure personId + server-authoritative root, no tunnel-token) was CEO-approved before implementation.
- Reviewer subagent: implementation by Codex worker with a mid-flight design checkpoint.
- Human review: repository owner acts as merge authority via the queue.
- Blocking findings: none

## Residual Risk

- Model A's stated boundary: host/shared-account compromise is out of scope (the shared daemon account must stay shell-less/restricted); this is the decided trust model, not a regression.
- Windows sshd witness (CIM ownership) awaits Windows host validation.

## References

- Task: task_01KX2GHETQZ3HKVMB8EDXCB99C
- Evidence: decisions dec_mrcz2q6k, dec_mrcz1kqh, dec_mrdrbkp7, dec_mrczk07e
- Review: task package impl-report (private ledger)

---

# 中文

## 概要

daemon/归因系列 A2：remote principal 改由 sshd 经每成员一条 authorized_keys forced command 作证（团队模型 A，裁决 dec_mrcz2q6k）；remote 归因路径彻底移除 `process.env.USER`（裁决 dec_mrdrbkp7 C4：principal 来源禁环境变量）；收口客户端自选服务端 `--root`——forced command 钉死的服务端 root 为权威，不一致显式失败。共享同一 unix 账号的两名成员现在解析为两个不同 principal；无作证时 remote 入口 fail closed 并给出 authorized_keys 配置指引。

## 改动内容

- forced command 入口：`--principal`、服务端 `--root`、`--expect-original-command` 只从静态 authorized_keys forced command 读取；remote 客户端仍只请求裸 `ha daemon connect --stdio`。
- 机械防伪造门（非约定）：入口要求特权 sshd 进程祖先（POSIX=uid 0 的 `sshd`；Windows=LocalSystem 的 `sshd.exe`，经 CIM 属主）；`SSH_ORIGINAL_COMMAND` 必须与静态期望值精确相等，且期望值本身禁含特权选项——本地进程能抄 argv/env，伪造不了 OS 进程祖先。
- principal 流：新增 `ssh-forced-command-person` 凭证类型，经 `authContext.sshForcedCommand` 传递；transport-derived provider 对照 `people.yaml` 解析，优先级高于共享 socket 属主凭证。`ParsedCommand` 与 JSON-RPC 载荷仍无 actor/principal 字段。
- remote 归因移除 `process.env.USER`/`env.USER`；测试设 `USER=person_mallory` 时仍从静态 forced command 解析出 `person_alice`。
- fail-closed 矩阵：缺三元组→配置指引；无特权祖先的 principal 参数→拒绝；原命令不匹配→在打开 endpoint 前拒绝；roster 未知/停用→沿用既有失败语义；无身份 provider→`provider_unavailable`，绝不匿名降级。
- `ssh-tunnel-token` 有意不启用（sshd 已凭私钥完成归属证明，加 token 是重复认证且扩大范围——理由已录）。
- unix socket 权限 0700/0600 未动。

## 任务与范围

- Harness 任务：task_01KX2GHETQZ3HKVMB8EDXCB99C
- 分支：codex/a2-forced-command
- 公开范围：daemon transport/identity/protocol、CLI remote 入口、测试（22 文件，+697/−85）
- 私有计划 / 证据是否已更新：yes（任务包 impl-report；台账 progress/fact 已录）
- 范围外：A5 归因来源机械防御（`--actor` flag，下一个）；A4 运维文档（实现对齐后）；attach-token 生命周期设计

## 版本影响

- 版本：不改版本，原因是 remote team mode 属预发布面；本地单人行为不变。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：决策 dec_mrcz2q6k（模型 A）、dec_mrcz1kqh（常驻 daemon+纯中继）、dec_mrdrbkp7 C4（principal 禁 env）、dec_mrczk07e（env 不能作证人类）；任务 task_01KX2GHETQZ3HKVMB8EDXCB99C
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：合并后 `ha decision reckon dec_mrcz1kqh`（预期 4/4）；A4 文档化 authorized_keys 流程与吊销

## 验证

- `origin/main` 基准 SHA：0eec448
- 当前分支与 `origin/main` 的 merge-base：0eec448（push 前已 rebase 到最新 main）
- 最近一次 `git fetch origin` 时间：2026-07-10 约 10:20 UTC
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...codex/a2-forced-command`
- 私有证据 commit/path：task_01KX2GHETQZ3HKVMB8EDXCB99C 任务包 impl-report（私有台账）
- Reviewer 证据路径：见关联材料
- GitHub Actions `rewrite-ci` run URL：待本 PR 触发
- [x] `npm run check`（以 `npm run check:local` fast 档执行：worker 16 步、fast 275/275、contract 348/348；CEO rebase 后复跑绿）
- [x] boundaries job 全量，CEO 带 GITHUB_TOKEN 代跑：`node tools/run-manifest-gates.mjs --workflow-job boundaries --exclude mergify-queue-metadata-edit-noop`（过，含两项需 token 的 context 检查）
- [x] CI 同款 integration shard 2（59/59）与 shard 4（100 过，1 项既有 Windows-only skip）
- [x] `git diff --check`
- [ ] `npm ci`
- [ ] `npm run typecheck`（由 check:local fast 档与 CI 覆盖）
- [ ] `npm test`（integration 由 CI shards 覆盖）
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：真实外部 sshd 会话（hermetic 测试注入 witness 判定,并分别覆盖祖先分类、原命令相等、fail-closed、roster 解析与真实常驻 daemon 中继）；Windows sshd witness 待 Windows 实机/CI 验证（声明 skip）。

## 审查证据

- 自查：CEO 在 checkpoint 点名的问题——「普通本地调用凭什么用不了 forced-command principal 参数」——报告门禁一节给出机制论证（特权祖先+原命令精确相等+期望串禁特权 flag），并有对抗测试覆盖（`USER=person_mallory` vs `person_alice`；无 sshd 祖先的 principal 参数被拒）。设计 checkpoint（纯 personId+服务端权威 root、不接 tunnel-token）实现前经 CEO 批准。
- Reviewer subagent：实现由 Codex worker 完成，中途设计 checkpoint 上报。
- 人工审查：仓库所有者经队列行使合并权。
- 阻塞发现：无

## 残余风险

- 模型 A 的既定边界：宿主/共享账号被攻破不在防护范围（共享 daemon 账号必须保持无 shell/受限）——这是已裁决的信任模型，非回归。
- Windows sshd witness（CIM 属主）待 Windows 实机验证。

## 关联材料

- 任务：task_01KX2GHETQZ3HKVMB8EDXCB99C
- 证据：决策 dec_mrcz2q6k、dec_mrcz1kqh、dec_mrdrbkp7、dec_mrczk07e
- 审查：任务包 impl-report（私有台账）

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
