### PR TITLE
fix: restore main full-check gates broken by unsynced sources

### DIFF
--- a/packages/gui/src/renderer/model/fact-triage.ts
+++ b/packages/gui/src/renderer/model/fact-triage.ts
@@ -41,7 +41,7 @@ export const SIGNAL_LABEL: Record<FactTriageSignalKind, string> = {
   SUPERSEDED: "已被取代",
 };
 
-function normalizeDecisionId(ref: string): string | undefined {
+function decisionIdFromRef(ref: string): string | undefined {
   if (!ref.startsWith("decision/")) return undefined;
   return ref.split("/")[1];
 }
@@ -78,7 +78,7 @@ export function computeFactTriageSignals(
           (row) =>
             row.status === "covered" && row.coveringFactRef === factRef,
         )
-        .map((row) => normalizeDecisionId(row.decisionRef))
+        .map((row) => decisionIdFromRef(row.decisionRef))
         .filter((id): id is string => Boolean(id)),
   );
   for (const relation of relations) {
@@ -89,7 +89,7 @@ export function computeFactTriageSignals(
           ? relation.to
           : undefined;
     const decisionId = decisionRef
-      ? normalizeDecisionId(decisionRef)
+      ? decisionIdFromRef(decisionRef)
       : undefined;
     if (decisionId) citingDecisionIdSet.add(decisionId);
   }

--- a/tools/check-cli-help-contract.mjs
+++ b/tools/check-cli-help-contract.mjs
@@ -1,67 +1,67 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const registryPath = "packages/cli/src/cli/command-registry.ts";
-const optionDescriptionsPath = "packages/cli/src/cli/command-option-descriptions.ts";
+const commandSpecDirPath = "packages/cli/src/cli/command-spec";
 const receiptPath = "packages/cli/src/cli/receipt.ts";
-const receiptContractsPath = "packages/cli/src/cli/receipt-contracts.ts";
 const entrypointPath = "packages/cli/src/index.ts";
+const defaultMinimumCommands = 20;
 
-export function findCliHelpContractViolations(rootDir = process.cwd()) {
-  const source = readFileSync(path.join(rootDir, registryPath), "utf8");
-  const optionDescriptionsSource = readFileSync(path.join(rootDir, optionDescriptionsPath), "utf8");
+export function findCliHelpContractViolations(rootDir = process.cwd(), options = {}) {
+  const minimumCommands = options.minimumCommands ?? defaultMinimumCommands;
+  const registrySource = readFileSync(path.join(rootDir, registryPath), "utf8");
   const receiptSource = readFileSync(path.join(rootDir, receiptPath), "utf8");
-  const receiptContractsSource = readFileSync(path.join(rootDir, receiptContractsPath), "utf8");
   const entrypointSource = readFileSync(path.join(rootDir, entrypointPath), "utf8");
-  const commandUsageSource = extractAssignedLiteral(source, "commandUsages");
-  const summarySource = extractAssignedLiteral(source, "commandSummaries");
-  const exampleSource = extractAssignedLiteral(source, "commandExamples");
-  const descriptionSource = extractAssignedLiteral(optionDescriptionsSource, "descriptions");
-  const receiptContractSource = extractAssignedLiteral(receiptContractsSource, "commandReceiptContractsByKind");
+  const specSources = readdirSync(path.join(rootDir, commandSpecDirPath))
+    .filter((name) => name.startsWith("command-spec-") && name.endsWith(".ts"))
+    .sort()
+    .map((name) => readFileSync(path.join(rootDir, commandSpecDirPath, name), "utf8"));
+
+  const entries = specSources.flatMap(extractSpecEntries);
   const violations = [];
 
-  const commandKinds = [...commandUsageSource.matchAll(/\{\s*kind:\s*"([^"]+)"/gu)].map((match) => match[1]);
-  const receiptKinds = objectKeys(receiptContractSource);
-  const expectedReceiptKinds = commandKinds;
-  const usageByKind = commandUsageByKind(commandUsageSource);
-  const summaryKinds = objectKeys(summarySource);
-  const exampleKinds = objectKeys(exampleSource);
-  const examplesByKind = objectArrayEntries(exampleSource);
-  const descriptionFlags = objectKeys(descriptionSource);
-  const usageFlags = [...new Set([...commandUsageSource.matchAll(/--[a-z0-9-]+/gu)].map((match) => match[0]))];
+  if (entries.length < minimumCommands) {
+    violations.push(
+      `checker parsed only ${entries.length} command specs (< ${minimumCommands}); the command-spec source shape changed — update tools/check-cli-help-contract.mjs instead of accepting a vacuous pass`
+    );
+  }
 
-  for (const kind of commandKinds) {
-    if (!summaryKinds.has(kind)) violations.push(`command ${kind} is missing commandSummaries entry`);
-    if (!exampleKinds.has(kind)) violations.push(`command ${kind} is missing commandExamples entry`);
+  const kinds = entries.map((entry) => entry.kind);
+  for (const kind of new Set(kinds.filter((kind, index) => kinds.indexOf(kind) !== index))) {
+    violations.push(`command ${kind} is declared more than once across command-spec files`);
   }
-  for (const kind of summaryKinds) {
-    if (!commandKinds.includes(kind)) violations.push(`commandSummaries has stale command ${kind}`);
-  }
-  for (const kind of exampleKinds) {
-    if (!commandKinds.includes(kind)) violations.push(`commandExamples has stale command ${kind}`);
-  }
-  for (const kind of expectedReceiptKinds) {
-    if (!receiptKinds.has(kind)) violations.push(`command ${kind} is missing command descriptor receipt contract`);
-  }
-  for (const kind of receiptKinds) {
-    if (!expectedReceiptKinds.includes(kind)) violations.push(`commandReceiptContracts has stale command ${kind}`);
-  }
-  for (const flag of usageFlags) {
-    if (!descriptionFlags.has(flag)) violations.push(`option ${flag} is missing help description`);
-  }
-  for (const [kind, exampleBody] of examplesByKind) {
-    const usageFlagSet = new Set(flagsFromText(usageByKind.get(kind) ?? ""));
-    for (const flag of flagsFromText(exampleBody)) {
-      if (!usageFlagSet.has(flag)) {
-        violations.push(`command ${kind} example uses ${flag} but usage does not list it`);
+
+  for (const entry of entries) {
+    if (!entry.usage) violations.push(`command ${entry.kind} is missing usage`);
+    if (!entry.summary) violations.push(`command ${entry.kind} is missing summary`);
+    if (entry.examples.length === 0) violations.push(`command ${entry.kind} is missing examples`);
+    if (!entry.hasReceiptContract) violations.push(`command ${entry.kind} is missing command descriptor receipt contract`);
+    const descriptionByFlag = new Map(entry.options.map((option) => [option.flag, option.description]));
+    const usageFlags = flagsFromText(entry.usage);
+    for (const flag of usageFlags) {
+      const description = descriptionByFlag.get(flag);
+      if (description === undefined) {
+        violations.push(`command ${entry.kind} option ${flag} is missing an options declaration`);
+      } else if (description.trim().length === 0) {
+        violations.push(`command ${entry.kind} option ${flag} has an empty description`);
+      }
+    }
+    const usageFlagSet = new Set(usageFlags);
+    for (const example of entry.examples) {
+      for (const flag of flagsFromText(example)) {
+        if (!usageFlagSet.has(flag)) {
+          violations.push(`command ${entry.kind} example uses ${flag} but usage does not list it`);
+        }
       }
     }
   }
-  if (/humanizeKind|Set this command option/u.test(`${source}\n${optionDescriptionsSource}`)) {
+
+  const specJoined = specSources.join("\n");
+  if (/humanizeKind|Set this command option/u.test(`${registrySource}\n${specJoined}`)) {
     violations.push("command help must not use generic summary or option-description fallback text");
   }
-  if (/CliResult\/v1/u.test(source) || /CliResult\/v1/u.test(receiptSource) || /CliResult\/v1/u.test(entrypointSource)) {
+  if (/CliResult\/v1/u.test(registrySource) || /CliResult\/v1/u.test(receiptSource) || /CliResult\/v1/u.test(entrypointSource)) {
     violations.push("CLI success output must use command-receipt/v2, not CliResult/v1");
   }
   if (/JSON\.stringify\(result\)/u.test(entrypointSource)) {
@@ -70,22 +70,49 @@ export function findCliHelpContractViolations(rootDir = process.cwd()) {
   return violations;
 }
 
-function extractAssignedLiteral(source, constName) {
-  const declaration = new RegExp(`\\bconst\\s+${constName}\\b[^=]*=`, "u").exec(source);
-  if (!declaration?.index) {
-    if (declaration?.index !== 0) throw new Error(`missing ${constName}`);
-  }
-  const start = declaration.index + declaration[0].length;
-  const objectStart = source.indexOf("{", start);
-  const arrayStart = source.indexOf("[", start);
-  const bodyStart = objectStart >= 0 && (arrayStart < 0 || objectStart < arrayStart) ? objectStart : arrayStart;
-  if (bodyStart < 0) throw new Error(`missing ${constName} literal`);
-  const open = source[bodyStart];
-  const close = open === "{" ? "}" : "]";
+function extractSpecEntries(source) {
+  const kindMatches = [...source.matchAll(/"kind":\s*"([^"]+)"/gu)];
+  return kindMatches.map((match, index) => {
+    const sliceStart = match.index ?? 0;
+    const sliceEnd = index + 1 < kindMatches.length ? kindMatches[index + 1].index : source.length;
+    const slice = source.slice(sliceStart, sliceEnd);
+    return {
+      kind: match[1],
+      usage: quotedField(slice, "usage"),
+      summary: quotedField(slice, "summary"),
+      examples: stringArrayField(slice, "examples"),
+      options: optionEntries(slice),
+      hasReceiptContract: /"receiptContract":\s*\{/u.test(slice)
+    };
+  });
+}
+
+function quotedField(slice, fieldName) {
+  const match = new RegExp(`"${fieldName}":\\s*"((?:[^"\\\\]|\\\\.)*)"`, "u").exec(slice);
+  return match ? match[1] : "";
+}
+
+function stringArrayField(slice, fieldName) {
+  const start = new RegExp(`"${fieldName}":\\s*\\[`, "u").exec(slice);
+  if (!start || start.index === undefined) return [];
+  const body = balancedSlice(slice, start.index + start[0].length - 1, "[", "]");
+  return [...body.matchAll(/"((?:[^"\\]|\\.)*)"/gu)].map((entry) => entry[1]);
+}
+
+function optionEntries(slice) {
+  const start = /"options":\s*\[/u.exec(slice);
+  if (!start || start.index === undefined) return [];
+  const body = balancedSlice(slice, start.index + start[0].length - 1, "[", "]");
+  return [...body.matchAll(/\{\s*"flag":\s*"([^"]+)"\s*,\s*"description":\s*"((?:[^"\\]|\\.)*)"\s*\}/gu)].map(
+    (entry) => ({ flag: entry[1], description: entry[2] })
+  );
+}
+
+function balancedSlice(source, openIndex, open, close) {
   let depth = 0;
   let quote = "";
   let escaped = false;
-  for (let index = bodyStart; index < source.length; index += 1) {
+  for (let index = openIndex; index < source.length; index += 1) {
     const char = source[index];
     if (quote) {
       if (escaped) {
@@ -99,27 +126,15 @@ function extractAssignedLiteral(source, constName) {
       if (char === quote) quote = "";
       continue;
     }
-    if (char === "\"" || char === "'" || char === "`") {
+    if (char === '"' || char === "'" || char === "`") {
       quote = char;
       continue;
     }
     if (char === open) depth += 1;
     if (char === close) depth -= 1;
-    if (depth === 0) return source.slice(bodyStart, index + 1);
+    if (depth === 0) return source.slice(openIndex, index + 1);
   }
-  throw new Error(`unterminated ${constName}`);
-}
-
-function objectKeys(source) {
-  return new Set([...source.matchAll(/"([^"]+)"\s*:/gu)].map((match) => match[1]));
-}
-
-function commandUsageByKind(source) {
-  return new Map([...source.matchAll(/\{\s*kind:\s*"([^"]+)"\s*,\s*usage:\s*"([^"]+)"/gu)].map((match) => [match[1], match[2]]));
-}
-
-function objectArrayEntries(source) {
-  return new Map([...source.matchAll(/"([^"]+)"\s*:\s*\[([\s\S]*?)\]\s*(?:,|\})/gu)].map((match) => [match[1], match[2]]));
+  throw new Error(`unterminated ${open}${close} literal`);
 }
 
 function flagsFromText(source) {

--- a/tools/check-cli-help-contract.test.mjs
+++ b/tools/check-cli-help-contract.test.mjs
@@ -1,106 +1,88 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { findCliHelpContractViolations } from "./check-cli-help-contract.mjs";
 
-test("CLI help contract gate rejects missing command help metadata", () => {
-  withTempRoot((rootDir) => {
-    writeRegistry(rootDir, `
-      const commandUsages = [
-        { kind: "new-task", usage: "new-task --title <title> --json" }
-      ] as const;
-      const commandSummaries = {} satisfies Record<CommandKind, string>;
-      const commandExamples = {} satisfies Record<CommandKind, ReadonlyArray<string>>;
-      const commandReceiptContractsByKind = { "new-task": { data: ["taskId"], paths: ["package"] } } satisfies Record<CommandKind, CommandReceiptContract>;
-      function optionDescription(flag: string): string {
-        const descriptions: Record<string, string> = { "--json": "Emit JSON." };
-        return descriptions[flag] ?? "Set this command option.";
-      }
-    `);
-
-    const violations = findCliHelpContractViolations(rootDir);
-
-    assert.equal(violations.includes("command new-task is missing commandSummaries entry"), true);
-    assert.equal(violations.includes("command new-task is missing commandExamples entry"), true);
-    assert.equal(violations.includes("option --title is missing help description"), true);
-    assert.equal(violations.includes("command help must not use generic summary or option-description fallback text"), true);
-  });
-});
-
-test("CLI help contract gate accepts complete help metadata", () => {
-  withTempRoot((rootDir) => {
-    writeRegistry(rootDir, `
-      const commandUsages = [
-        { kind: "new-task", usage: "new-task --title <title> --json" }
-      ] as const;
-      const commandSummaries = { "new-task": "Create a task." } satisfies Record<CommandKind, string>;
-      const commandExamples = { "new-task": ["harness-anything new-task --title Example"] } satisfies Record<CommandKind, ReadonlyArray<string>>;
-      const commandReceiptContractsByKind = { "new-task": { data: ["taskId"], paths: ["package"] } } satisfies Record<CommandKind, CommandReceiptContract>;
-      function optionDescription(flag: string): string {
-        const descriptions: Record<string, string> = { "--title": "Set the task title.", "--json": "Emit JSON." };
-        return descriptions[flag]!;
-      }
-    `);
-
-    assert.deepEqual(findCliHelpContractViolations(rootDir), []);
-  });
-});
-
-test("CLI help contract gate rejects missing receipt contracts", () => {
-  withTempRoot((rootDir) => {
-    writeRegistry(rootDir, `
-      const commandUsages = [
-        { kind: "new-task", usage: "new-task --title <title> --json" }
-      ] as const;
-      const commandSummaries = { "new-task": "Create a task." } satisfies Record<CommandKind, string>;
-      const commandExamples = { "new-task": ["harness-anything new-task --title Example"] } satisfies Record<CommandKind, ReadonlyArray<string>>;
-      const commandReceiptContractsByKind = {} satisfies Record<CommandKind, CommandReceiptContract>;
-      function optionDescription(flag: string): string {
-        const descriptions: Record<string, string> = { "--title": "Set the task title.", "--json": "Emit JSON." };
-        return descriptions[flag]!;
-      }
-    `);
-
-    assert.equal(findCliHelpContractViolations(rootDir).includes("command new-task is missing command descriptor receipt contract"), true);
-  });
-});
-
-test("CLI help contract gate rejects examples with undocumented flags", () => {
-  withTempRoot((rootDir) => {
-    writeRegistry(rootDir, `
-      const commandUsages = [
-        { kind: "new-task", usage: "new-task --title <title>" }
-      ] as const;
-      const commandSummaries = { "new-task": "Create a task." } satisfies Record<CommandKind, string>;
-      const commandExamples = { "new-task": ["harness-anything new-task --title Example --module billing"] } satisfies Record<CommandKind, ReadonlyArray<string>>;
-      const commandReceiptContractsByKind = { "new-task": { data: ["taskId"], paths: ["package"] } } satisfies Record<CommandKind, CommandReceiptContract>;
-      function optionDescription(flag: string): string {
-        const descriptions: Record<string, string> = { "--title": "Set the task title." };
-        return descriptions[flag]!;
-      }
-    `);
-
-    assert.equal(findCliHelpContractViolations(rootDir).includes("command new-task example uses --module but usage does not list it"), true);
-  });
-});
-
-function writeRegistry(rootDir, body, receiptBody = "") {
-  const dir = path.join(rootDir, "packages/cli/src/cli");
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(path.join(dir, "command-registry.ts"), body);
-  writeFileSync(path.join(dir, "command-option-descriptions.ts"), body);
-  writeFileSync(path.join(dir, "receipt.ts"), receiptBody);
-  writeFileSync(path.join(dir, "receipt-contracts.ts"), body);
-  writeFileSync(path.join(rootDir, "packages/cli/src/index.ts"), "console.log(JSON.stringify(output));\n");
+function writeFixture(specEntrySource) {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "cli-help-contract-"));
+  mkdirSync(path.join(rootDir, "packages/cli/src/cli/command-spec"), { recursive: true });
+  writeFileSync(path.join(rootDir, "packages/cli/src/cli/command-registry.ts"), "const derived = commandSpecs.map((entry) => entry);\n");
+  writeFileSync(path.join(rootDir, "packages/cli/src/cli/receipt.ts"), "export const receipt = 1;\n");
+  writeFileSync(path.join(rootDir, "packages/cli/src/index.ts"), "export const cli = 1;\n");
+  writeFileSync(path.join(rootDir, "packages/cli/src/cli/command-spec/command-spec-fixture.ts"), specEntrySource);
+  return rootDir;
 }
 
-function withTempRoot(fn) {
-  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-help-gate-"));
-  try {
-    fn(rootDir);
-  } finally {
-    rmSync(rootDir, { recursive: true, force: true });
+const validEntry = `export const specs = [
+  {
+    "kind": "fixture-list",
+    "usage": "fixture list [--state <state>] [--json]",
+    "options": [{"flag":"--state","description":"Filter fixtures by state."},{"flag":"--json","description":"Emit JSON."}],
+    "summary": "List fixtures.",
+    "examples": ["harness-anything fixture list --state active --json"],
+    "receiptContract": { "data": ["rows"], "paths": [] }
   }
-}
+];
+`;
+
+test("clean fixture passes with no violations", () => {
+  const rootDir = writeFixture(validEntry);
+  assert.deepEqual(findCliHelpContractViolations(rootDir, { minimumCommands: 1 }), []);
+});
+
+test("usage flag without an options declaration is a violation", () => {
+  const rootDir = writeFixture(validEntry.replace(
+    `{"flag":"--state","description":"Filter fixtures by state."},`,
+    ""
+  ));
+  const violations = findCliHelpContractViolations(rootDir, { minimumCommands: 1 });
+  assert.ok(violations.some((entry) => entry.includes("option --state is missing an options declaration")), violations.join("\n"));
+});
+
+test("empty option description is a violation", () => {
+  const rootDir = writeFixture(validEntry.replace("Filter fixtures by state.", " "));
+  const violations = findCliHelpContractViolations(rootDir, { minimumCommands: 1 });
+  assert.ok(violations.some((entry) => entry.includes("option --state has an empty description")), violations.join("\n"));
+});
+
+test("missing summary, examples, and receipt contract are violations", () => {
+  const stripped = validEntry
+    .replace(`"summary": "List fixtures.",`, "")
+    .replace(`"examples": ["harness-anything fixture list --state active --json"],`, "")
+    .replace(`"receiptContract": { "data": ["rows"], "paths": [] }`, `"other": 1`);
+  const rootDir = writeFixture(stripped);
+  const violations = findCliHelpContractViolations(rootDir, { minimumCommands: 1 });
+  assert.ok(violations.some((entry) => entry.includes("missing summary")), violations.join("\n"));
+  assert.ok(violations.some((entry) => entry.includes("missing examples")), violations.join("\n"));
+  assert.ok(violations.some((entry) => entry.includes("missing command descriptor receipt contract")), violations.join("\n"));
+});
+
+test("example flag not present in usage is a violation", () => {
+  const rootDir = writeFixture(validEntry.replace("--state active --json", "--state active --unknown"));
+  const violations = findCliHelpContractViolations(rootDir, { minimumCommands: 1 });
+  assert.ok(violations.some((entry) => entry.includes("example uses --unknown")), violations.join("\n"));
+});
+
+test("duplicate command kinds across spec files are violations", () => {
+  const rootDir = writeFixture(validEntry);
+  writeFileSync(
+    path.join(rootDir, "packages/cli/src/cli/command-spec/command-spec-second.ts"),
+    validEntry
+  );
+  const violations = findCliHelpContractViolations(rootDir, { minimumCommands: 1 });
+  assert.ok(violations.some((entry) => entry.includes("declared more than once")), violations.join("\n"));
+});
+
+test("generic fallback text in spec sources is a violation", () => {
+  const rootDir = writeFixture(validEntry.replace("Emit JSON.", "Set this command option."));
+  const violations = findCliHelpContractViolations(rootDir, { minimumCommands: 1 });
+  assert.ok(violations.some((entry) => entry.includes("must not use generic summary or option-description fallback text")), violations.join("\n"));
+});
+
+test("vacuous parse is rejected instead of passing", () => {
+  const rootDir = writeFixture("export const specs = [];\n");
+  const violations = findCliHelpContractViolations(rootDir);
+  assert.ok(violations.some((entry) => entry.includes("vacuous")), violations.join("\n"));
+});


### PR DESCRIPTION
# English

## Summary

Break-glass fix restoring main's full-check to green. Main currently has two deterministic full-check failures that no PR-seam context runs: (1) `check-cli-help-contract` crashes with ENOENT reading the global option dictionary deleted by PR#583, and (2) `check-duplicate-definitions` fails on `gui/normalizeDecisionId` defined in two renderer modules since PR#587. Post-merge main runs for #583/#584/#586 are red — a live recurrence of the admission gap adjudication `dec_mrepu7h7` addresses.

## What Changed

- `tools/check-cli-help-contract.mjs`: re-sourced from the current authority. The old checker regex-parsed `commandUsages`/`commandSummaries`/`commandExamples` object literals in `command-registry.ts` and the deleted dictionary; since the registry became spec-derived, those extractions matched zero commands and every kind/flag check passed vacuously — the gate was dead before it crashed. The rewritten checker parses `command-spec/*.ts` entries (kind/usage/summary/examples/options/receiptContract) and asserts per command: usage flags declared in options with non-empty descriptions, summary/examples/receiptContract present, example flags ⊆ usage flags, no duplicate kinds, no generic fallback text. **Anti-vacuous floor**: parsing fewer than 20 commands is itself a failure, so a future source-shape change can never silently pass again. Dropped the receipt-contracts cross-check — `commandReceiptContractsByKind` is now spec-derived with `satisfies Record<CommandKind, …>`, so the compiler already enforces it.
- `tools/check-cli-help-contract.test.mjs`: replaced fixtures of the retired source shape with positive controls for the new contract (8 tests: missing declaration, empty description, missing summary/examples/receiptContract, stale example flag, duplicate kind, fallback text, vacuous-parse rejection).
- `packages/gui/src/renderer/model/fact-triage.ts`: renamed the local `normalizeDecisionId` to `decisionIdFromRef`. The two same-named functions have different semantics (triadic's always returns a string; this one returns `undefined` for non-decision refs as a filter guard), so deduping into one implementation would change behavior — the correct fix is the distinct name. Call sites updated; no behavior change.

## Task And Scope

- Harness task: `task_01KX5HEBCHAKMA25FH5KHRWSEX` (governance charter; break-glass under its P0 item)
- Branch: `fix/cli-help-contract-spec-source`
- Public scope: `tools/check-cli-help-contract.{mjs,test.mjs}`, `packages/gui/src/renderer/model/fact-triage.ts`
- Private planning/evidence updated: yes (charter progress/facts in private ledger)
- Out of scope: front-loading these gates to the PR seam (that is `dec_mrepu7h7`, pending adjudication); W4's descriptor migration (separate branch)

## Version Impact

- Version: no version change because this is gate tooling + an internal rename
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/check-cli-help-contract.mjs` (gate-manifest entry `check-cli-help-contract`) judgment logic re-sourced; gate strength strictly increased (per-command assertions + anti-vacuous floor vs. previously vacuous checks)
- Authority: break-glass (main red now) + governance charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` P0 scope; ADR-0012 D2 defines the descriptor as the help authority this checker now reads
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: yes
- Break-glass reason: main full-check red since PR#583 merged (runs for #583/#584/#586 all failed); two deterministic causes identified and fixed
- Break-glass scope: limited to restoring the two failing gates to green without weakening either (help-contract gains assertions; duplicate-definitions untouched, violation resolved by rename)
- Follow-up governance task: task_01KX5HEBCHAKMA25FH5KHRWSEX (governance charter P0; adjudication dec_mrepu7h7 front-loads deterministic gates to the PR seam — this incident is its third recorded evidence)

## Verification

- Base `origin/main` SHA: `d512c3b`
- Branch merge-base with `origin/main`: `d512c3b`
- Last `git fetch origin` time: 2026-07-10 ~18:45 +08:00
- Sync method: rebase
- Public diff command: `git diff origin/main...fix/cli-help-contract-spec-source`
- Private evidence commit/path: charter task package progress/facts
- Reviewer evidence path: this PR body + `tools/check-cli-help-contract.test.mjs`
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci` — not run; worktree deps synced to lockfile (`npm install`, no lockfile diff)
- [x] `git diff --check`
- [x] `npm run check` — exit 0 end-to-end (manifest gate runner passed), including the two previously failing gates
- [x] `npm run typecheck` — via `npm run check`
- [x] `npm test` — via `npm run check`
- [x] `npm run harness:check-import-boundaries` — via `npm run check`
- [x] `npm run harness:scan-forbidden-symbols` — via `npm run check`
- [x] `npm run harness:check-private-boundary` — via `npm run check`
- [x] `npm run harness:check-package-policy` — via `npm run check`
- [x] `npm run harness:check-implementation-contracts` — via `npm run check`
- [x] `npm run harness:check-schema-contracts` — via `npm run check`
- [x] `npm run harness:check-legacy-intake-readiness` — via `npm run check`
- [x] `npm run harness:smoke-cli-package` — via `npm run check`
- [ ] GitHub Actions `rewrite-ci` passed — pending
- Not run: none. Positive controls: 8/8 checker tests; clean-tree `node tools/check-cli-help-contract.mjs` exit 0; `node tools/check-duplicate-definitions.mjs` passes post-rename

## Review Evidence

- Self-review: CEO-authored; both root causes reproduced from main CI logs (ENOENT at check-cli-help-contract.mjs:13) and local runs before fixing
- Reviewer subagent: none (break-glass); Codex connector review findings on this PR will be ground-truthed post-open
- Human review: pending
- Blocking findings: none

## Residual Risk

- The checker remains regex-on-source by design (minimal break-glass change); the deeper AST-based descriptor gate lands with the P2-2 branch. The anti-vacuous floor bounds the failure mode that killed the old checker.

## References

- Task: `harness/tasks/task_01KX5HEBCHAKMA25FH5KHRWSEX-architecture-governance-charter-2026-07-10-dual-scan-consolidation/`
- Evidence: `dec_mrepu7h7` (C1 anchors), main run failures for #583/#584/#586
- Review: charter progress log

---

# 中文

## 概要

Break-glass 修复，恢复 main full-check 全绿。main 当前有两个 PR seam 不跑的确定性红因：(1) `check-cli-help-contract` 读 PR#583 已删除的全局选项字典而 ENOENT crash；(2) `check-duplicate-definitions` 因 PR#587 起 `gui/normalizeDecisionId` 在两个 renderer module 重复定义而红。#583/#584/#586 的 post-merge main run 全红——正是 `dec_mrepu7h7` 所治理的 admission 缺口的活体复现。

## 改动内容

- `tools/check-cli-help-contract.mjs`：取证源切到现行权威。旧 checker 用 regex 解析 `command-registry.ts` 的对象字面量与已删字典；注册表改为 spec 派生后，这些提取匹配到**零个命令**、所有 kind/flag 检查空转通过——门在 crash 之前就已经死了。重写后解析 `command-spec/*.ts` 条目并逐命令断言：usage flag 必有非空 options 描述、summary/examples/receiptContract 在场、example flag ⊆ usage、kind 不重复、无兜底文案。**反空转下限**：解析出的命令数 <20 本身即失败，未来源形状再变不可能再静默通过。删除 receipt-contracts 交叉核对——`commandReceiptContractsByKind` 已是 spec 派生 + `satisfies` 类型级穷尽，编译器已执法。
- `tools/check-cli-help-contract.test.mjs`：退役旧源形状 fixture，换新契约阳性对照 8 项（缺声明/空描述/缺 summary·examples·receiptContract/example 越界 flag/重复 kind/兜底文案/空转拒绝）。
- `packages/gui/src/renderer/model/fact-triage.ts`：局部 `normalizeDecisionId` 改名 `decisionIdFromRef`。两个同名函数语义不同（triadic 版恒返回字符串；本版对非 decision ref 返回 undefined 作过滤守卫），合并会改行为——正确修法是取语义准确的独立名。调用点同步，无行为变化。

## 任务与范围

- Harness 任务：`task_01KX5HEBCHAKMA25FH5KHRWSEX`（治理 charter；P0 项下的 break-glass）
- 分支：`fix/cli-help-contract-spec-source`
- 公开范围：`tools/check-cli-help-contract.{mjs,test.mjs}`、`packages/gui/src/renderer/model/fact-triage.ts`
- 私有计划 / 证据是否已更新：yes
- 范围外：把这些 gate 前移到 PR seam（属 `dec_mrepu7h7`，待裁决）；W4 描述符迁移（独立分支）

## 版本影响

- 版本：不改版本，原因是 gate 工具与内部改名
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/check-cli-help-contract.mjs`（gate-manifest 条目 `check-cli-help-contract`）判定逻辑重取证源；门只加强不削弱（逐命令断言 + 反空转下限 vs 此前的空转）
- 依据：break-glass（main 现红）+ 治理 charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` P0 范围；ADR-0012 D2 定义描述符为帮助权威，本 checker 即读它
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：yes
- Break-glass 原因：PR#583 合入后 main full-check 连红（#583/#584/#586 三个 run 全 failure）；两个确定性红因已定位并修复
- Break-glass 范围：仅恢复两个失败 gate 至绿且不削弱任一（help-contract 增强；duplicate-definitions 未动，违规以改名消解）
- 后续治理任务：task_01KX5HEBCHAKMA25FH5KHRWSEX（治理 charter P0；裁决 dec_mrepu7h7 将确定性 gate 前移 PR seam——本次事故是其第三份在案证据）

## 验证

- `origin/main` 基准 SHA：`d512c3b`
- 当前分支与 `origin/main` 的 merge-base：`d512c3b`
- 最近一次 `git fetch origin` 时间：2026-07-10 ~18:45 +08:00
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...fix/cli-help-contract-spec-source`
- 私有证据 commit / 路径：charter 任务包 progress/facts
- Reviewer 证据路径：本 PR body + `tools/check-cli-help-contract.test.mjs`
- GitHub Actions `rewrite-ci` run URL：待产生
- 勾选情况与英文块一致：全量 `npm run check` 端到端 exit 0（含两个此前红的 gate）；阳性对照 8/8；改名后 duplicate gate 通过；`npm ci` 未单独跑（按 lockfile 同步依赖且无 lockfile diff）
- 未运行：无

## Review Evidence

- 自审：CEO 亲写；两个根因均先从 main CI 日志（check-cli-help-contract.mjs:13 ENOENT）与本地实跑复现后再修
- Reviewer subagent：无（break-glass）；PR 打开后 Codex connector findings 将逐条 ground-truth
- 人工 review：待定
- 阻塞发现：无

## 残余风险

- checker 仍是 regex-on-source（break-glass 最小改动）；更深的 AST 描述符门随 P2-2 分支落地。反空转下限已兜住杀死旧 checker 的那类失效。

## 参考

- 任务：治理 charter 任务包
- 证据：`dec_mrepu7h7`（C1 锚）、#583/#584/#586 的 main run failure
- Review：charter progress 记录
