### PR TITLE
fix: rename duplicate actor attribution helpers to restore main green

### DIFF
--- a/packages/cli/src/commands/actor-attribution-checker.ts
+++ b/packages/cli/src/commands/actor-attribution-checker.ts
@@ -16,19 +16,19 @@ function inheritedHumanActorIssue(line: string): ReadonlyArray<ProfileValidation
   let record: Record<string, unknown>;
   try {
     const parsed: unknown = JSON.parse(line);
-    if (!isRecord(parsed)) return [];
+    if (!isJsonRecord(parsed)) return [];
     record = parsed;
   } catch {
     return [];
   }
 
-  const actor = isRecord(record.actor) ? record.actor : undefined;
+  const actor = isJsonRecord(record.actor) ? record.actor : undefined;
   const source = actor?.source ?? record.source;
   if (actor?.kind !== "human" || source !== "env") return [];
 
-  const actorId = stringValue(actor.id, "unknown");
-  const opId = stringValue(record.opId, "unknown-op");
-  const entityId = stringValue(record.entityId, "unknown-entity");
+  const actorId = stringOrFallback(actor.id, "unknown");
+  const opId = stringOrFallback(record.opId, "unknown-op");
+  const entityId = stringOrFallback(record.entityId, "unknown-entity");
   return [profileIssue(
     "actor-attribution-checker",
     "human_actor_from_inherited_env",
@@ -38,10 +38,10 @@ function inheritedHumanActorIssue(line: string): ReadonlyArray<ProfileValidation
   )];
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function stringValue(value: unknown, fallback: string): string {
+function stringOrFallback(value: unknown, fallback: string): string {
   return typeof value === "string" && value.length > 0 ? value : fallback;
 }

--- a/packages/cli/src/composition/actor-attribution.ts
+++ b/packages/cli/src/composition/actor-attribution.ts
@@ -76,7 +76,7 @@ export function daemonActorAttribution(actor: AuthenticatedActor): CliActorAttri
 export function readCliJournalActorFromEnv(env: NodeJS.ProcessEnv): CliJournalActor | undefined {
   const raw = readEnv(env, "HARNESS_ACTOR");
   if (!raw) return undefined;
-  const actor = parseActor(raw, "HARNESS_ACTOR");
+  const actor = parseActorToken(raw, "HARNESS_ACTOR");
   if (actor.kind === "human") {
     throw new CliActorAttributionError(
       "HARNESS_ACTOR cannot assert a human actor because environment variables are inherited by child processes. " +
@@ -88,14 +88,14 @@ export function readCliJournalActorFromEnv(env: NodeJS.ProcessEnv): CliJournalAc
 }
 
 export function readCliJournalActorFromFlag(raw: string): CliJournalActor {
-  return parseActor(raw, "--actor");
+  return parseActorToken(raw, "--actor");
 }
 
 export function journalActorWithSource(attribution: CliActorAttribution): CliJournalActor & { readonly source: CliActorAttribution["source"] } {
   return { ...attribution.actor, source: attribution.source };
 }
 
-function parseActor(raw: string, channel: "HARNESS_ACTOR" | "--actor"): CliJournalActor {
+function parseActorToken(raw: string, channel: "HARNESS_ACTOR" | "--actor"): CliJournalActor {
   const separator = raw.indexOf(":");
   if (separator <= 0 || separator === raw.length - 1) {
     throw new CliActorAttributionError(`${channel} must use kind:id form, for example ${channel === "HARNESS_ACTOR" ? "agent:codex" : "human:lizeyu"}.`);


### PR DESCRIPTION
# English

## Summary

Restores main's full-check to green. PR#592 introduced three function definitions whose names collide with existing ones under the `check-duplicate-definitions` gate: `cli/isRecord` (actor-attribution-checker vs settings), `cli/stringValue` (actor-attribution-checker vs json-input), `cli/parseActor` (actor-attribution vs decision-shared). The gate runs only in main full-check, so PR#592's PR-seam run was green while main run 29091693225 fails — the fourth deterministic post-merge red today, same admission-gap class adjudicated by `dec_mrepu7h7` (accepted).

## What Changed

- `packages/cli/src/commands/actor-attribution-checker.ts`: local `isRecord` → `isJsonRecord`, local `stringValue` → `stringOrFallback`. Semantics of the colliding pairs are context-specific (fallback-returning string reader vs json-input's variant), so distinct names, not a merged implementation.
- `packages/cli/src/composition/actor-attribution.ts`: local `parseActor` → `parseActorToken`. The two `parseActor`s genuinely differ: this one is strict (throws `CliActorAttributionError`, validates id charset, carries channel context); decision-shared's is lenient (returns null). Merging would change behavior on both sides.
- All three are file-local functions; no exports or behavior change. Rename-only diff.

## Task And Scope

- Harness task: `task_01KX5HEBCHAKMA25FH5KHRWSEX` (governance charter P0 scope: keep main green)
- Branch: `fix/actor-attribution-dupes`
- Public scope: `packages/cli/src/commands/actor-attribution-checker.ts`, `packages/cli/src/composition/actor-attribution.ts`
- Private planning/evidence updated: yes (charter progress/fact)
- Out of scope: systemic fix (front-loading deterministic gates to the PR seam) — in flight under `dec_mrepu7h7` implementation task `task_01KX5Z4NY4XM4P9EYWH9PA2PAR`

## Version Impact

- Version: no version change because this is a rename-only internal fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: `bd44dc7`
- Branch merge-base with `origin/main`: `bd44dc7`
- Last `git fetch origin` time: 2026-07-10 ~20:05 +08:00
- Sync method: branched from origin/main tip
- Public diff command: `git diff origin/main...fix/actor-attribution-dupes`
- Private evidence commit/path: charter task package progress/facts
- Reviewer evidence path: this PR body
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci` — not run; worktree deps seeded from canonical (no lockfile diff)
- [x] `git diff --check`
- [x] `npm run check` — exit 0 end-to-end (see check log; includes previously failing `check-duplicate-definitions`)
- [x] `npm run typecheck` — via `npm run check`
- [x] `npm test` — via `npm run check`
- [x] `npm run harness:check-import-boundaries` — via `npm run check`
- [x] `npm run harness:scan-forbidden-symbols` — via `npm run check`
- [x] `npm run harness:check-private-boundary` — via `npm run check`
- [x] `npm run harness:check-package-policy` — via `npm run check`
- [x] `npm run harness:check-implementation-contracts` — via `npm run check`
- [x] `npm run harness:check-schema-contracts` — via `npm run check`
- [x] `npm run harness:check-legacy-intake-readiness` — via `npm run check`
- [x] `npm run harness:smoke-cli-package` — via `npm run check`
- [ ] GitHub Actions `rewrite-ci` passed — pending
- Not run: none. Positive control: `node tools/check-duplicate-definitions.mjs` exit 1 on clean main (3 duplicates), exit 0 after rename

## Review Evidence

- Self-review: CEO-authored; all three duplicates reproduced on clean main `bd44dc7` before fixing; semantic difference of each pair inspected before choosing rename over merge
- Reviewer subagent: none (two-file rename)
- Human review: pending
- Blocking findings: none

## Residual Risk

- None functional. The class-level risk (gate runs post-merge only) is being removed by the P0 implementation task.

## References

- Task: `harness/tasks/task_01KX5HEBCHAKMA25FH5KHRWSEX-architecture-governance-charter-2026-07-10-dual-scan-consolidation/`
- Evidence: main run 29091693225 (in progress at PR-open time, deterministic red cause proven locally); `dec_mrepu7h7`
- Review: charter progress log

---

# 中文

## 概要

恢复 main full-check 全绿。PR#592 引入三个与既有函数在 `check-duplicate-definitions` 门下同名冲突的定义：`cli/isRecord`（actor-attribution-checker vs settings）、`cli/stringValue`（actor-attribution-checker vs json-input）、`cli/parseActor`（actor-attribution vs decision-shared）。该门只在 main full-check 执行，#592 的 PR seam 全绿而 main run 29091693225 必红——今天第四次确定性 post-merge 红，属 `dec_mrepu7h7`（已 accept）所裁的同一 admission 缺口类。

## 改动内容

- `packages/cli/src/commands/actor-attribution-checker.ts`：局部 `isRecord` → `isJsonRecord`、局部 `stringValue` → `stringOrFallback`。冲突对语义各有上下文（带 fallback 的字符串读取 vs json-input 变体），取独立名不强行合并。
- `packages/cli/src/composition/actor-attribution.ts`：局部 `parseActor` → `parseActorToken`。两个 `parseActor` 语义确实不同：本文件版严格（抛 `CliActorAttributionError`、校验 id 字符集、携带 channel 上下文），decision-shared 版宽松（返 null）。合并会同时改变双方行为。
- 三个均为文件局部函数，无导出、无行为变化，纯改名 diff。

## 任务与范围

- Harness 任务：`task_01KX5HEBCHAKMA25FH5KHRWSEX`（治理 charter P0 范围：保 main 绿）
- 分支：`fix/actor-attribution-dupes`
- 公开范围：`packages/cli/src/commands/actor-attribution-checker.ts`、`packages/cli/src/composition/actor-attribution.ts`
- 私有计划 / 证据是否已更新：yes
- 范围外：系统性修复（确定性 gate 前移 PR seam）在 `dec_mrepu7h7` 实现任务 `task_01KX5Z4NY4XM4P9EYWH9PA2PAR` 进行中

## 版本影响

- 版本：不改版本，原因是纯改名内部修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no

## 验证

- `origin/main` 基准 SHA：`bd44dc7`
- 当前分支与 `origin/main` 的 merge-base：`bd44dc7`
- 最近一次 `git fetch origin` 时间：2026-07-10 ~20:05 +08:00
- 同步方式：自 origin/main tip 开分支
- 公开 diff 命令：`git diff origin/main...fix/actor-attribution-dupes`
- 私有证据 commit / 路径：charter 任务包 progress/facts
- Reviewer 证据路径：本 PR body
- GitHub Actions `rewrite-ci` run URL：待产生
- 勾选情况与英文块一致：全量 `npm run check` exit 0（含此前红的 duplicate 门）；阳性对照=干净 main 上该门 exit 1（3 组重复）、改名后 exit 0；`npm ci` 未单独跑（依赖自 canonical 播种、无 lockfile diff）
- 未运行：无

## Review Evidence

- 自审：CEO 亲写；三组重复均先在干净 main `bd44dc7` 复现、逐对核对语义差异后选择改名而非合并
- Reviewer subagent：无（两文件改名）
- 人工 review：待定
- 阻塞发现：无

## 残余风险

- 功能无。类级风险（门只在合入后跑）由 P0 实现任务移除中。

## 参考

- 任务：治理 charter 任务包
- 证据：main run 29091693225、`dec_mrepu7h7`
- Review：charter progress 记录
