### PR TITLE
refactor: centralize relation authored sources behind one manifest

### DIFF
--- a/packages/kernel/src/projection/relation-graph-projection.ts
+++ b/packages/kernel/src/projection/relation-graph-projection.ts
@@ -6,6 +6,11 @@ import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import { readFrontmatter, readScalar } from "../markdown/frontmatter.ts";
 import { parseRelationFlowRecords } from "./relation-flow-frontmatter.ts";
+import {
+  deriveRelationTaskAuthoredSources,
+  relationDecisionAuthoredSourceKind,
+  type RelationAuthoredSourceKind
+} from "./relation-source-manifest.ts";
 import { sourcePath } from "./sqlite-task-source.ts";
 import { readDirIfPresent, readTextFileIfPresent, statPathIfPresent } from "./toctou-safe-fs.ts";
 
@@ -50,6 +55,7 @@ interface DecisionSource {
   readonly decisionRef: string;
   readonly filePath: string;
   readonly frontmatter: string;
+  readonly sourceKind: RelationAuthoredSourceKind;
   readonly visible: boolean;
 }
 
@@ -64,7 +70,7 @@ interface GraphRefIndex {
 export interface RelationRecordEntry {
   readonly hostRef: string;
   readonly ownerRef: string;
-  readonly sourceKind: "task-index" | "task-facts" | "decision-document";
+  readonly sourceKind: RelationAuthoredSourceKind;
   readonly record: EntityRelationRecord;
   readonly sourcePath: string;
   readonly recordIndex: number;
@@ -160,34 +166,31 @@ function collectRelationRecordEntries(
 
   for (const taskDir of listTaskDirs(layout.tasksRoot)) {
     const taskId = readTaskPackageId(taskDir);
-    const indexPath = path.join(taskDir, "INDEX.md");
-    if (existsSync(indexPath)) {
-      const indexBody = readTextFileIfPresent(indexPath);
-      const frontmatter = indexBody === null ? null : readFrontmatter(indexBody);
-      if (frontmatter) {
+    for (const source of deriveRelationTaskAuthoredSources(taskDir)) {
+      if (!existsSync(source.filePath)) continue;
+      const body = readTextFileIfPresent(source.filePath);
+      if (body === null) continue;
+      if (source.content === "frontmatter") {
+        const frontmatter = readFrontmatter(body);
+        if (!frontmatter) continue;
         entries.push(...recordsToEntries({
           hostRef: `task/${taskId}`,
           ownerRef: `task/${taskId}`,
-          sourceKind: "task-index",
+          sourceKind: source.kind,
           records: parseRelationFlowRecords(frontmatter),
-          sourceFile: indexPath,
+          sourceFile: source.filePath,
+          rootDir
+        }));
+      } else {
+        entries.push(...recordsToEntries({
+          hostRefForRecord: (record) => factRelationHostRef(taskId, record),
+          ownerRef: `task/${taskId}`,
+          sourceKind: source.kind,
+          records: parseRelationFlowRecords(body),
+          sourceFile: source.filePath,
           rootDir
         }));
       }
-    }
-
-    const factsPath = path.join(taskDir, layout.factDocumentName);
-    if (existsSync(factsPath)) {
-      const factsBody = readTextFileIfPresent(factsPath);
-      if (factsBody === null) continue;
-      entries.push(...recordsToEntries({
-        hostRefForRecord: (record) => factRelationHostRef(taskId, record),
-        ownerRef: `task/${taskId}`,
-        sourceKind: "task-facts",
-        records: parseRelationFlowRecords(factsBody),
-        sourceFile: factsPath,
-        rootDir
-      }));
     }
   }
 
@@ -196,7 +199,7 @@ function collectRelationRecordEntries(
     entries.push(...recordsToEntries({
       hostRef: decision.decisionRef,
       ownerRef: decision.decisionRef,
-      sourceKind: "decision-document",
+      sourceKind: decision.sourceKind,
       records: parseRelationFlowRecords(decision.frontmatter),
       sourceFile: decision.filePath,
       rootDir
@@ -397,7 +400,8 @@ function readDecisionSources(rootInput: HarnessLayoutInput): ReadonlyArray<Decis
   const decisions: Array<Omit<DecisionSource, "visible"> & { readonly watermark: string }> = [];
   const watermarkCounts = new Map<string, number>();
   for (const filePath of listTextFiles(layout.decisionsRoot)) {
-    if (path.basename(filePath) !== "decision.md") continue;
+    const sourceKind = relationDecisionAuthoredSourceKind(filePath);
+    if (sourceKind === null) continue;
     const body = readTextFileIfPresent(filePath);
     if (body === null) continue;
     const frontmatter = readFrontmatter(body);
@@ -410,6 +414,7 @@ function readDecisionSources(rootInput: HarnessLayoutInput): ReadonlyArray<Decis
       decisionRef: `decision/${decisionId}`,
       filePath,
       frontmatter,
+      sourceKind,
       watermark
     });
   }
@@ -418,6 +423,7 @@ function readDecisionSources(rootInput: HarnessLayoutInput): ReadonlyArray<Decis
     decisionRef: decision.decisionRef,
     filePath: decision.filePath,
     frontmatter: decision.frontmatter,
+    sourceKind: decision.sourceKind,
     visible: decision.watermark.length > 0 && watermarkCounts.get(decision.watermark) === 1
   })).sort((a, b) => a.decisionRef.localeCompare(b.decisionRef));
 }
@@ -430,8 +436,9 @@ function buildGraphRefIndex(rootInput: HarnessLayoutInput, decisions: ReadonlyAr
   for (const taskDir of listTaskDirs(layout.tasksRoot)) {
     const taskId = readTaskPackageId(taskDir);
     taskIds.add(taskId);
-    const factsPath = path.join(taskDir, layout.factDocumentName);
-    if (!existsSync(factsPath)) continue;
+    const factsPath = deriveRelationTaskAuthoredSources(taskDir)
+      .find((source) => source.kind === "task-facts")?.filePath;
+    if (!factsPath || !existsSync(factsPath)) continue;
     const factsBody = readTextFileIfPresent(factsPath);
     if (factsBody === null) continue;
     for (const record of parseFactFlowRecords(factsBody)) {

--- a/packages/kernel/src/projection/relation-source-manifest.ts
+++ b/packages/kernel/src/projection/relation-source-manifest.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+
+export const relationAuthoredSourceManifest = [
+  {
+    kind: "task-index",
+    scope: "task",
+    relativePath: "INDEX.md",
+    content: "frontmatter"
+  },
+  {
+    kind: "task-facts",
+    scope: "task",
+    relativePath: "facts.md",
+    content: "document"
+  },
+  {
+    kind: "decision-document",
+    scope: "decision",
+    relativePath: "decision.md",
+    content: "frontmatter"
+  }
+] as const;
+
+export type RelationAuthoredSourceDefinition = (typeof relationAuthoredSourceManifest)[number];
+export type RelationAuthoredSourceKind = RelationAuthoredSourceDefinition["kind"];
+export type RelationTaskAuthoredSourceDefinition = Extract<RelationAuthoredSourceDefinition, { readonly scope: "task" }>;
+
+export type RelationTaskAuthoredSource = RelationTaskAuthoredSourceDefinition & { readonly filePath: string };
+
+export function deriveRelationTaskAuthoredSources(taskDir: string): ReadonlyArray<RelationTaskAuthoredSource> {
+  return relationAuthoredSourceManifest
+    .filter((source): source is RelationTaskAuthoredSourceDefinition => source.scope === "task")
+    .map((source) => ({ ...source, filePath: path.join(taskDir, source.relativePath) }));
+}
+
+export function relationDecisionAuthoredSourceKind(filePath: string): RelationAuthoredSourceKind | null {
+  const source = relationAuthoredSourceManifest.find((candidate) =>
+    candidate.scope === "decision" && path.basename(filePath) === candidate.relativePath
+  );
+  return source?.kind ?? null;
+}

--- a/packages/kernel/src/projection/sqlite-task-source.ts
+++ b/packages/kernel/src/projection/sqlite-task-source.ts
@@ -6,6 +6,11 @@ import { sha256Text } from "../integrity/stable-hash.ts";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import { readFrontmatter, readNestedScalar, readScalar } from "../markdown/frontmatter.ts";
+import {
+  deriveRelationTaskAuthoredSources,
+  relationDecisionAuthoredSourceKind,
+  type RelationAuthoredSourceKind
+} from "./relation-source-manifest.ts";
 import type { ProjectionCanonicalStatus, CoordinationStatus, ProjectionWarning, TaskFieldExtensionProjection, TaskProjectionRow } from "./types.ts";
 import { readDirIfPresent, readDirNamesIfPresent, readTextFileIfPresent, statPathIfPresent } from "./toctou-safe-fs.ts";
 
@@ -26,23 +31,23 @@ export function readTaskProjectionSourceHashInputs(rootInput: HarnessLayoutInput
   return readTaskProjectionSource(rootInput).sourceInputs;
 }
 
+export function readRelationGraphSourceHashInputKinds(rootInput: HarnessLayoutInput): ReadonlyArray<RelationAuthoredSourceKind> {
+  return [...new Set(readTaskProjectionSource(rootInput).relationSourceInputs.map((input) => input.kind))].sort();
+}
+
 function readTaskProjectionSource(rootInput: HarnessLayoutInput): {
   readonly entries: ReadonlyArray<TaskSourceEntry>;
   readonly sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>;
+  readonly relationSourceInputs: ReadonlyArray<RelationSourceHashInput>;
   readonly warnings: ReadonlyArray<ProjectionWarning>;
 } {
   const layout = resolveHarnessLayout(rootInput);
   const rootDir = layout.rootDir;
   const tasksDir = layout.tasksRoot;
-  if (!existsSync(tasksDir)) {
-    return { entries: [], sourceInputs: [], warnings: [] };
-  }
-
   const warnings: ProjectionWarning[] = [];
   const entries: TaskSourceEntry[] = [];
-  const taskEntries = readDirNamesIfPresent(tasksDir);
-  if (taskEntries === null) return { entries: [], sourceInputs: [], warnings: [] };
-  for (const name of taskEntries.sort()) {
+  const taskEntries = existsSync(tasksDir) ? readDirNamesIfPresent(tasksDir) : [];
+  for (const name of (taskEntries ?? []).sort()) {
     const indexPath = path.join(tasksDir, name, "INDEX.md");
     if (!existsSync(indexPath)) continue;
     const body = readTextFileIfPresent(indexPath);
@@ -65,17 +70,19 @@ function readTaskProjectionSource(rootInput: HarnessLayoutInput): {
     }
   }
 
+  const relationSourceInputs = readRelationGraphSourceInputs(rootDir, layout, entries);
+  const supplementalSourceInputs = readTaskSupplementalSourceInputs(rootDir, entries);
+  const taskIndexInputs = entries.flatMap((entry) => relationSourceInputs.filter((input) =>
+    input.kind === "task-index" && input.taskId === entry.taskId
+  ));
+  const remainingSourceInputs = [
+    ...relationSourceInputs.filter((input) => input.kind !== "task-index"),
+    ...supplementalSourceInputs
+  ].sort((a, b) => a.sourcePath.localeCompare(b.sourcePath));
   return {
     entries,
-    sourceInputs: [
-      ...entries.map((entry) => ({
-        kind: "task-index",
-        taskId: entry.taskId,
-        sourcePath: sourcePath(rootDir, entry.indexPath),
-        body: entry.body
-      })),
-      ...readRelationGraphSourceInputs(rootDir, layout, entries)
-    ],
+    sourceInputs: [...taskIndexInputs, ...remainingSourceInputs],
+    relationSourceInputs,
     warnings
   };
 }
@@ -91,6 +98,11 @@ export interface TaskProjectionSourceHashInput {
   readonly kind: string;
   readonly sourcePath: string;
   readonly body: string;
+}
+
+interface RelationSourceHashInput extends TaskProjectionSourceHashInput {
+  readonly kind: RelationAuthoredSourceKind;
+  readonly taskId?: string;
 }
 
 export function taskEntryToRow(
@@ -203,10 +215,48 @@ function readRelationGraphSourceInputs(
   rootDir: string,
   layout: ReturnType<typeof resolveHarnessLayout>,
   entries: ReadonlyArray<TaskSourceEntry>
-): ReadonlyArray<{ readonly kind: string; readonly sourcePath: string; readonly body: string }> {
+): ReadonlyArray<RelationSourceHashInput> {
   const taskDocumentInputs = entries
+    .flatMap((entry) => deriveRelationTaskAuthoredSources(path.dirname(entry.indexPath)).map((source) => ({
+      kind: source.kind,
+      path: source.filePath,
+      ...(source.kind === "task-index" ? { taskId: entry.taskId } : {}),
+      ...(source.filePath === entry.indexPath ? { body: entry.body } : {})
+    })))
+    .filter((input) => input.body !== undefined || existsSync(input.path))
+    .flatMap((input) => {
+      const body = input.body ?? readTextFileIfPresent(input.path);
+      return body === null
+        ? []
+        : [{
+          kind: input.kind,
+          ...(input.taskId ? { taskId: input.taskId } : {}),
+          sourcePath: sourcePath(rootDir, input.path),
+          body
+        }];
+    });
+  const decisionInputs = listDecisionDocuments(layout.decisionsRoot)
+    .flatMap((decisionPath) => {
+      const kind = relationDecisionAuthoredSourceKind(decisionPath);
+      if (kind === null) return [];
+      const body = readTextFileIfPresent(decisionPath);
+      return body === null
+        ? []
+        : [{
+          kind,
+          sourcePath: sourcePath(rootDir, decisionPath),
+          body
+        }];
+    });
+  return [...taskDocumentInputs, ...decisionInputs];
+}
+
+function readTaskSupplementalSourceInputs(
+  rootDir: string,
+  entries: ReadonlyArray<TaskSourceEntry>
+): ReadonlyArray<TaskProjectionSourceHashInput> {
+  return entries
     .flatMap((entry) => [
-      { kind: "task-facts", path: path.join(path.dirname(entry.indexPath), layout.factDocumentName) },
       { kind: "task-module", path: path.join(path.dirname(entry.indexPath), "module.md") },
       { kind: "task-review", path: path.join(path.dirname(entry.indexPath), "review.md") },
       { kind: "task-closeout", path: path.join(path.dirname(entry.indexPath), "closeout.md") }
@@ -222,25 +272,13 @@ function readRelationGraphSourceInputs(
           body
         }];
     });
-  const decisionInputs = listDecisionDocuments(layout.decisionsRoot)
-    .flatMap((decisionPath) => {
-      const body = readTextFileIfPresent(decisionPath);
-      return body === null
-        ? []
-        : [{
-          kind: "decision-document",
-          sourcePath: sourcePath(rootDir, decisionPath),
-          body
-        }];
-    });
-  return [...taskDocumentInputs, ...decisionInputs].sort((a, b) => a.sourcePath.localeCompare(b.sourcePath));
 }
 
 function listDecisionDocuments(decisionsRoot: string): ReadonlyArray<string> {
   if (!existsSync(decisionsRoot)) return [];
   const stat = statPathIfPresent(decisionsRoot);
   if (stat === null) return [];
-  if (stat.isFile()) return path.basename(decisionsRoot) === "decision.md" ? [decisionsRoot] : [];
+  if (stat.isFile()) return relationDecisionAuthoredSourceKind(decisionsRoot) === null ? [] : [decisionsRoot];
   if (!stat.isDirectory()) return [];
   const entries = readDirIfPresent(decisionsRoot);
   if (entries === null) return [];

--- a/packages/kernel/test/contracts/relation-source-hash-inputs.test.ts
+++ b/packages/kernel/test/contracts/relation-source-hash-inputs.test.ts
@@ -5,10 +5,14 @@ import test from "node:test";
 import { deriveRelationId, formatFactFlowRecord, formatRelationFlowRecord } from "../../src/index.ts";
 import type { EntityRelationRecord, FactRecord } from "../../src/index.ts";
 import { readRelationGraphAuthoredSourceKinds } from "../../src/projection/relation-graph-projection.ts";
-import { readTaskProjectionSourceHashInputs } from "../../src/projection/sqlite-task-source.ts";
+import {
+  readMarkdownSource,
+  readRelationGraphSourceHashInputKinds,
+  readTaskProjectionSourceHashInputs
+} from "../../src/projection/sqlite-task-source.ts";
 import { withTempStore } from "../store/helpers.ts";
 
-test("relation authored source kinds are covered by task projection sourceHash inputs", () => {
+test("relation graph collection and freshness enumerate the same authored source kinds", () => {
   withTempStore((rootDir) => {
     writeIndex(rootDir, "task-source", "Task Source", [
       relationRecord({
@@ -48,11 +52,51 @@ test("relation authored source kinds are covered by task projection sourceHash i
     ]);
 
     const authoredKinds = readRelationGraphAuthoredSourceKinds({ rootDir });
-    const sourceHashKinds = new Set(readTaskProjectionSourceHashInputs({ rootDir }).map((input) => input.kind));
-    const missingKinds = authoredKinds.filter((kind) => !sourceHashKinds.has(kind));
+    const sourceHashKinds = readRelationGraphSourceHashInputKinds({ rootDir });
 
     assert.deepEqual(authoredKinds, ["decision-document", "task-facts", "task-index"]);
-    assert.deepEqual(missingKinds, []);
+    assert.deepEqual(sourceHashKinds, ["decision-document", "task-facts", "task-index"]);
+    assert.deepEqual(sourceHashKinds, authoredKinds);
+  });
+});
+
+test("freshness preserves task index hash input order", () => {
+  withTempStore((rootDir) => {
+    writeIndex(rootDir, "task_a", "Lowercase Task");
+    writeIndex(rootDir, "task_Z", "Uppercase Task");
+
+    const taskIndexPaths = readTaskProjectionSourceHashInputs({ rootDir })
+      .filter((input) => input.kind === "task-index")
+      .map((input) => input.sourcePath);
+
+    assert.deepEqual(taskIndexPaths, [
+      "harness/tasks/task_Z/INDEX.md",
+      "harness/tasks/task_a/INDEX.md"
+    ]);
+  });
+});
+
+test("decision-only relation changes invalidate freshness", () => {
+  withTempStore((rootDir) => {
+    writeDecision(rootDir, "dec_SOURCE", [
+      relationRecord({
+        source: "decision/dec_SOURCE/C1",
+        target: "task/task-before",
+        type: "derives"
+      })
+    ]);
+    const before = readMarkdownSource({ rootDir }).hash;
+
+    writeDecision(rootDir, "dec_SOURCE", [
+      relationRecord({
+        source: "decision/dec_SOURCE/C1",
+        target: "task/task-after",
+        type: "derives"
+      })
+    ]);
+
+    assert.notEqual(readMarkdownSource({ rootDir }).hash, before);
+    assert.deepEqual(readRelationGraphSourceHashInputKinds({ rootDir }), ["decision-document"]);
   });
 });
 


### PR DESCRIPTION
# English

## Summary

Charter P3-3 (ADR-0022 D8): the relation projection had two independently hand-written lists of "which files carry relation semantics" — graph collection in `relation-graph-projection.ts` (task INDEX.md, facts.md, decision documents) and freshness hashing in `sqlite-task-source.ts` (facts/module/review/closeout, decision documents). A missed hash input means a stale-edge cache reads as fresh on destructive-delete paths. This PR makes drift structurally impossible by deriving both consumers from one authored-source manifest, and fixes a real bug the work uncovered.

## What Changed

- New `packages/kernel/src/projection/relation-source-manifest.ts`: single declaration of relation-bearing sources (`task-index`, `task-facts`, `decision-document`) with scope, relative path, and read shape. Graph collection derives its readers from it; freshness hashing derives its inputs from it (module/review/closeout remain as additional freshness inputs, declared alongside).
- Bug fix (found during migration): a decisions-only harness layout with no `tasksRoot` returned early and **omitted decision documents from the freshness hash** — decision relation edits could leave the graph cache stale-but-fresh. Fixed with a regression test asserting decision-only relation changes invalidate freshness.
- Tests assert both consumers enumerate the same source-kind set (positive control: deleting a manifest entry turns the test red).
- Investigation note: task INDEX.md was already part of freshness via `TaskSourceEntry.indexPath/body` — the apparent asymmetry there was benign and is now explicit in the manifest.

## Task And Scope

- Harness task: `task_01KX5XRJDV13NK025SYKTMPFGF` (charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` P3-3)
- Branch: `codex/p3-relation-authored-source`
- Public scope: `packages/kernel/**` only (4 files, +189/−59)
- Private planning/evidence updated: yes
- Out of scope: any tools/ gate; other projection work (P3-1/P3-2/P3-4)

## Version Impact

- Version: no version change because this is an internal kernel refactor plus a cache-correctness fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: `4f0f947`
- Branch merge-base with `origin/main`: `4f0f947`
- Last `git fetch origin` time: 2026-07-10 ~20:36 +08:00
- Sync method: rebase (twice today: dc17b1a → bd44dc7 → 4f0f947, no conflicts)
- Public diff command: `git diff origin/main...codex/p3-relation-authored-source`
- Private evidence commit/path: task package progress/facts
- Reviewer evidence path: this PR body + kernel projection tests
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci` — not run; worktree deps seeded from canonical (no lockfile diff)
- [x] `git diff --check`
- [x] `npm run check` — exit 0 after final rebase (1145 node tests pass / 1 skip, GUI 38, 34 manifest gates)
- [x] `npm run typecheck` — via `npm run check`
- [x] `npm test` — via `npm run check`
- [x] `npm run harness:check-import-boundaries` — via `npm run check`
- [x] `npm run harness:scan-forbidden-symbols` — via `npm run check`
- [x] `npm run harness:check-private-boundary` — via `npm run check`
- [x] `npm run harness:check-package-policy` — via `npm run check`
- [x] `npm run harness:check-implementation-contracts` — via `npm run check`
- [x] `npm run harness:check-schema-contracts` — via `npm run check`
- [x] `npm run harness:check-legacy-intake-readiness` — via `npm run check`
- [x] `npm run harness:smoke-cli-package` — via `npm run check`
- [ ] GitHub Actions `rewrite-ci` passed — pending
- Not run: none. Positive controls: manifest-entry deletion turns consistency test red; decision-only freshness regression test

## Review Evidence

- Self-review: Codex worker (GPT-5.6) implemented; CEO ground-truthed: single commit, scope confined to packages/kernel (0 files outside), full check re-run green after each rebase
- Reviewer subagent: CEO review against ADR-0022 D8 contract
- Human review: pending
- Blocking findings: none

## Residual Risk

- module/review/closeout are freshness inputs but not graph-collection sources by design (they carry no relation records today); the manifest now states this explicitly, so promoting one later is a one-line manifest change caught by the consistency test.

## References

- Task: `harness/tasks/task_01KX5XRJDV13NK025SYKTMPFGF-p3-3-relation-authored-source/`
- Evidence: ADR-0022 D8; charter P3-3
- Review: task package progress log

---

# 中文

## 概要

Charter P3-3（ADR-0022 D8）：relation 投影有两份独立手写的「哪些文件承载 relation 语义」清单——图收集（`relation-graph-projection.ts`：task INDEX.md、facts.md、decision 文档）与 freshness 哈希（`sqlite-task-source.ts`：facts/module/review/closeout、decision 文档）。漏一个哈希输入 = 破坏性删除路径上陈旧边缓存假新鲜。本 PR 让两个消费方都从单一 authored-source 清单派生，使漂移在结构上不可能，并修复迁移中发现的一个真实 bug。

## 改动内容

- 新增 `packages/kernel/src/projection/relation-source-manifest.ts`：单点声明 relation 承载来源（`task-index`/`task-facts`/`decision-document`）的 scope、相对路径与读取形态。图收集据此派生读取器，freshness 据此派生哈希输入（module/review/closeout 作为补充 freshness 输入同处声明）。
- **Bug 修复**（迁移中发现）：无 `tasksRoot` 的 decisions-only 布局会提前返回、**把 decision 文档漏出 freshness 哈希**——decision 上的 relation 编辑可能留下假新鲜的图缓存。已修复并加回归测试（decision-only 变更必须使 freshness 失效）。
- 测试断言两个消费方枚举的来源种类集合一致（阳性对照：从清单删一项该测试变红）。
- 核实说明：task INDEX.md 原本已经通过 `TaskSourceEntry.indexPath/body` 参与 freshness——表面不对称是良性的，现已在清单中显式化。

## 任务与范围

- Harness 任务：`task_01KX5XRJDV13NK025SYKTMPFGF`（charter P3-3）
- 分支：`codex/p3-relation-authored-source`
- 公开范围：仅 `packages/kernel/**`（4 文件，+189/−59）
- 私有计划 / 证据是否已更新：yes
- 范围外：tools/ 任何 gate；其他投影项（P3-1/P3-2/P3-4）

## 版本影响

- 版本：不改版本，原因是 kernel 内部重构 + 缓存正确性修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no

## 验证

- `origin/main` 基准 SHA：`4f0f947`
- 当前分支与 `origin/main` 的 merge-base：`4f0f947`
- 最近一次 `git fetch origin` 时间：2026-07-10 ~20:36 +08:00
- 同步方式：rebase（今日两次：dc17b1a → bd44dc7 → 4f0f947，均无冲突）
- 公开 diff 命令：`git diff origin/main...codex/p3-relation-authored-source`
- 私有证据 commit / 路径：任务包 progress/facts
- Reviewer 证据路径：本 PR body + kernel 投影测试
- GitHub Actions `rewrite-ci` run URL：待产生
- 勾选情况与英文块一致：最终 rebase 后全量 `npm run check` exit 0（node 1145 通过/1 跳过、GUI 38、34 项 manifest gate）；阳性对照=删清单项测试变红、decision-only freshness 回归；`npm ci` 未单独跑（依赖自 canonical 播种、无 lockfile diff）
- 未运行：无

## Review Evidence

- 自审：Codex worker（GPT-5.6）实现；CEO ground-truth：单 commit、范围收束 packages/kernel（范围外 0 文件）、每次 rebase 后全量 check 重验绿
- Reviewer subagent：CEO 按 ADR-0022 D8 契约审
- 人工 review：待定
- 阻塞发现：无

## 残余风险

- module/review/closeout 按设计只是 freshness 输入、不是图收集来源（当前不承载 relation 记录）；清单已显式声明，未来若晋升为来源是一行清单改动且被一致性测试覆盖。

## 参考

- 任务：`harness/tasks/task_01KX5XRJDV13NK025SYKTMPFGF-p3-3-relation-authored-source/`
- 证据：ADR-0022 D8；charter P3-3
- Review：任务包 progress 记录
