### PR TITLE
refactor: fold GitRunner into VersionControlSystem

### DIFF
--- a/packages/application/src/code-doc-reconciliation.ts
+++ b/packages/application/src/code-doc-reconciliation.ts
@@ -1,3 +1,5 @@
+import type { VersionControlSystem } from "../../kernel/src/index.ts";
+
 export const CODE_DOC_RECONCILIATION_DOCUMENT = "code-doc-anchors.json";
 
 export type CodeDocLoadBearingKind = "closeout" | "evidence" | "decision-claim" | "review";
@@ -6,7 +8,7 @@ export interface CodeDocReconciliationInput {
   readonly taskId: string;
   readonly documents: ReadonlyArray<CodeDocDocument>;
   readonly rootDir: string;
-  readonly git?: GitRunner;
+  readonly versionControlSystem?: Pick<VersionControlSystem, "commitExists" | "pathExistsAtCommit">;
 }
 
 export interface CodeDocDocument {
@@ -46,11 +48,6 @@ export type CodeDocReconciliationResult = {
   readonly warnings: ReadonlyArray<CodeDocReconciliationWarning>;
   readonly issues: ReadonlyArray<CodeDocReconciliationIssue>;
 };
-
-export interface GitRunner {
-  readonly commitExists: (sha: string) => boolean;
-  readonly pathExistsAtCommit: (sha: string, relativePath: string) => boolean;
-}
 
 interface CodeDocAnchorDocument {
   readonly schema: "code-doc-reconciliation/v1";
@@ -93,13 +90,13 @@ export function evaluateCodeDocReconciliationGate(input: CodeDocReconciliationIn
   if (schemaIssues.length > 0) return failed(0, 0, [], schemaIssues);
 
   const contract = parsed as CodeDocAnchorDocument;
-  if (!input.git) {
+  if (!input.versionControlSystem) {
     return failed(contract.records.length, 0, [], [{
       code: "code_doc_git_unavailable",
-      message: "Code-doc reconciliation requires an injected git runner."
+      message: "Code-doc reconciliation requires an injected version-control system."
     }]);
   }
-  const git = input.git;
+  const versionControlSystem = input.versionControlSystem;
   const warnings: CodeDocReconciliationWarning[] = [];
   const issues: CodeDocReconciliationIssue[] = [];
   let checkedAnchors = 0;
@@ -110,7 +107,7 @@ export function evaluateCodeDocReconciliationGate(input: CodeDocReconciliationIn
       checkedAnchors += 1;
       if (anchor.kind === "commit") {
         hardAnchorCount += 1;
-        if (!git.commitExists(anchor.sha)) {
+        if (!versionControlSystem.commitExists(input.rootDir, anchor.sha)) {
           issues.push({
             code: "code_doc_git_ref_missing",
             recordId: record.id,
@@ -121,7 +118,7 @@ export function evaluateCodeDocReconciliationGate(input: CodeDocReconciliationIn
       }
       if (anchor.kind === "path") {
         hardAnchorCount += 1;
-        if (!git.commitExists(anchor.sha)) {
+        if (!versionControlSystem.commitExists(input.rootDir, anchor.sha)) {
           issues.push({
             code: "code_doc_git_ref_missing",
             recordId: record.id,
@@ -129,7 +126,7 @@ export function evaluateCodeDocReconciliationGate(input: CodeDocReconciliationIn
           });
           continue;
         }
-        if (!git.pathExistsAtCommit(anchor.sha, anchor.path)) {
+        if (!versionControlSystem.pathExistsAtCommit(input.rootDir, anchor.sha, anchor.path)) {
           issues.push({
             code: "code_doc_path_missing",
             recordId: record.id,
@@ -140,7 +137,7 @@ export function evaluateCodeDocReconciliationGate(input: CodeDocReconciliationIn
       }
       if (anchor.sha) {
         hardAnchorCount += 1;
-        if (!git.commitExists(anchor.sha)) {
+        if (!versionControlSystem.commitExists(input.rootDir, anchor.sha)) {
           issues.push({
             code: "code_doc_git_ref_missing",
             recordId: record.id,

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -40,7 +40,7 @@ export { makeProvenanceSessionExporter } from "./provenance-session-exporter.ts"
 export { classifyStaticZones, classifyTouchedZones, forbiddenTouchesForZones } from "./doc-sync.ts";
 export { makeRuntimeEventAppendPromise, makeRuntimeEventLedgerService } from "./runtime-event-ledger-service.ts";
 export { listDecisionDocuments, readDecisionDocument } from "./decision-document-reader.ts";
-export type { CodeDocDocument, CodeDocReconciliationInput, CodeDocReconciliationIssue, CodeDocReconciliationResult, CodeDocReconciliationWarning, GitRunner } from "./code-doc-reconciliation.ts";
+export type { CodeDocDocument, CodeDocReconciliationInput, CodeDocReconciliationIssue, CodeDocReconciliationResult, CodeDocReconciliationWarning } from "./code-doc-reconciliation.ts";
 export type { EnvironmentCurrentSessionProbeOptions, HumanFallbackSessionProbeOptions, RuntimeSessionEnvCandidate } from "./current-session-probe.ts";
 export type { ProvenanceBindingOptions } from "./provenance-binding.ts";
 export type {

--- a/packages/application/src/task-lifecycle-orchestrator.ts
+++ b/packages/application/src/task-lifecycle-orchestrator.ts
@@ -1,11 +1,10 @@
 import { Effect } from "effect";
-import type { ArtifactStore, DomainStatus, EngineError, TaskId, WriteError } from "../../kernel/src/index.ts";
+import type { ArtifactStore, DomainStatus, EngineError, TaskId, VersionControlSystem, WriteError } from "../../kernel/src/index.ts";
 import { isDomainStatus, isTerminalStatus, readTaskProjection } from "../../kernel/src/index.ts";
 import { parseFactFlowRecords } from "../../kernel/src/index.ts";
 import type { HarnessLayoutOverrides } from "../../kernel/src/index.ts";
 import { readFrontmatter, readScalar } from "../../kernel/src/index.ts";
 import { evaluateCodeDocReconciliationGate } from "./code-doc-reconciliation.ts";
-import type { GitRunner } from "./code-doc-reconciliation.ts";
 import { evaluateCompletionGate, evaluateReviewGate, isCloseoutPlaceholderMarkdown, isReviewPlaceholderMarkdown, parseReviewMarkdown } from "./task-lifecycle-gates.ts";
 import type { TaskDocumentPlaceholderPolicy, VerifierBackedReviewContract } from "./task-lifecycle-gates.ts";
 
@@ -41,7 +40,7 @@ export interface TaskLifecycleOrchestratorOptions {
   readonly taskWriter: TaskLifecycleWriter;
   readonly artifactStore: Pick<ArtifactStore, "readTaskPackage">;
   readonly documentPlaceholderPolicy?: TaskDocumentPlaceholderPolicy;
-  readonly codeDocGit?: GitRunner;
+  readonly codeDocVersionControlSystem?: Pick<VersionControlSystem, "commitExists" | "pathExistsAtCommit">;
   readonly now?: () => string;
 }
 
@@ -142,7 +141,7 @@ export function makeTaskLifecycleOrchestrator(options: TaskLifecycleOrchestrator
       const documentPlaceholder = yield* validateCompletionDocumentPlaceholders(options.artifactStore, payload.taskId, options.documentPlaceholderPolicy);
       if (documentPlaceholder) return documentPlaceholder;
 
-      const codeDocReconciliation = yield* validateCodeDocReconciliation(options.artifactStore, options.rootDir, payload.taskId, options.codeDocGit);
+      const codeDocReconciliation = yield* validateCodeDocReconciliation(options.artifactStore, options.rootDir, payload.taskId, options.codeDocVersionControlSystem);
       if (codeDocReconciliation) return codeDocReconciliation;
 
       const completionGate = evaluateCompletionGate({
@@ -234,7 +233,7 @@ function validateCodeDocReconciliation(
   artifactStore: Pick<ArtifactStore, "readTaskPackage">,
   rootDir: string,
   taskId: string,
-  git: GitRunner | undefined
+  versionControlSystem: Pick<VersionControlSystem, "commitExists" | "pathExistsAtCommit"> | undefined
 ): Effect.Effect<TaskLifecycleFailure | null> {
   return Effect.gen(function* () {
     const taskPackage = yield* artifactStore.readTaskPackage(taskId as TaskId).pipe(
@@ -247,7 +246,7 @@ function validateCodeDocReconciliation(
       taskId,
       rootDir,
       documents: taskPackage.documents,
-      git
+      versionControlSystem
     });
     if (gate.ok) return null;
     return {

--- a/packages/application/test/code-doc-reconciliation.test.ts
+++ b/packages/application/test/code-doc-reconciliation.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { VersionControlSystem } from "../../kernel/src/index.ts";
 import {
   CODE_DOC_RECONCILIATION_DOCUMENT,
-  evaluateCodeDocReconciliationGate,
-  type GitRunner
+  evaluateCodeDocReconciliationGate
 } from "../src/code-doc-reconciliation.ts";
 
 const goodSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -13,7 +13,7 @@ test("code-doc reconciliation accepts commit and path anchors and warns on PR st
   const result = evaluateCodeDocReconciliationGate({
     taskId: "task-1",
     rootDir: "/repo",
-    git: gitRunner({ commits: [goodSha], paths: [`${goodSha}:packages/app.ts`] }),
+    versionControlSystem: versionControlSystem({ commits: [goodSha], paths: [`${goodSha}:packages/app.ts`] }),
     documents: documents([{
       id: "A4-001",
       ledgerPath: "closeout.md",
@@ -36,7 +36,7 @@ test("code-doc reconciliation rejects fabricated shas", () => {
   const result = evaluateCodeDocReconciliationGate({
     taskId: "task-1",
     rootDir: "/repo",
-    git: gitRunner({ commits: [goodSha], paths: [] }),
+    versionControlSystem: versionControlSystem({ commits: [goodSha], paths: [] }),
     documents: documents([{
       id: "A4-001",
       ledgerPath: "closeout.md",
@@ -53,7 +53,7 @@ test("code-doc reconciliation rejects missing evidence paths at an existing comm
   const result = evaluateCodeDocReconciliationGate({
     taskId: "task-1",
     rootDir: "/repo",
-    git: gitRunner({ commits: [goodSha], paths: [] }),
+    versionControlSystem: versionControlSystem({ commits: [goodSha], paths: [] }),
     documents: documents([{
       id: "A4-001",
       ledgerPath: "closeout.md",
@@ -70,7 +70,7 @@ test("code-doc reconciliation ignores unrelated package documents but requires t
   const result = evaluateCodeDocReconciliationGate({
     taskId: "task-1",
     rootDir: "/repo",
-    git: gitRunner({ commits: [goodSha], paths: [] }),
+    versionControlSystem: versionControlSystem({ commits: [goodSha], paths: [] }),
     documents: [{ path: "closeout.md", body: "# Closeout" }]
   });
 
@@ -92,11 +92,11 @@ function documents(records: ReadonlyArray<Record<string, unknown>>) {
   ];
 }
 
-function gitRunner(input: { readonly commits: ReadonlyArray<string>; readonly paths: ReadonlyArray<string> }): GitRunner {
+function versionControlSystem(input: { readonly commits: ReadonlyArray<string>; readonly paths: ReadonlyArray<string> }): Pick<VersionControlSystem, "commitExists" | "pathExistsAtCommit"> {
   const commits = new Set(input.commits);
   const paths = new Set(input.paths);
   return {
-    commitExists: (sha) => commits.has(sha),
-    pathExistsAtCommit: (sha, relativePath) => paths.has(`${sha}:${relativePath}`)
+    commitExists: (_repoRoot, sha) => commits.has(sha),
+    pathExistsAtCommit: (_repoRoot, sha, relativePath) => paths.has(`${sha}:${relativePath}`)
   };
 }

--- a/packages/application/test/task-lifecycle-write-failure.test.ts
+++ b/packages/application/test/task-lifecycle-write-failure.test.ts
@@ -4,8 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
-import { makeMarkdownArtifactStore, type ArtifactStore, type EngineError, type TaskPackageRead, type WriteError } from "../../kernel/src/index.ts";
-import type { GitRunner } from "../src/code-doc-reconciliation.ts";
+import { makeMarkdownArtifactStore, type ArtifactStore, type EngineError, type TaskPackageRead, type VersionControlSystem, type WriteError } from "../../kernel/src/index.ts";
 import { makeTaskLifecycleOrchestrator, type TaskLifecycleWriter } from "../src/task-lifecycle-orchestrator.ts";
 import { runEffect } from "./effect-test-helpers.ts";
 
@@ -54,7 +53,7 @@ for (const { name, error, code } of writeFailureCases) {
         rootDir,
         taskWriter: failingWriter(error),
         artifactStore: makeMarkdownArtifactStore({ rootDir }),
-        codeDocGit: codeDocGit(),
+        codeDocVersionControlSystem: codeDocVersionControlSystem(),
         now: () => "2026-06-13T00:00:00.000Z"
       });
 
@@ -124,7 +123,7 @@ test("completeTask evaluates closeout and review placeholders through ArtifactSt
       documentPlaceholderPolicy: {
         closeoutPlaceholderFingerprints: ["Summarize the completed behavior change."]
       },
-      codeDocGit: codeDocGit(),
+      codeDocVersionControlSystem: codeDocVersionControlSystem(),
       now: () => "2026-06-13T00:00:00.000Z"
     });
 
@@ -242,9 +241,9 @@ function validCodeDocAnchors(): string {
   }, null, 2)}\n`;
 }
 
-function codeDocGit(): GitRunner {
+function codeDocVersionControlSystem(): Pick<VersionControlSystem, "commitExists" | "pathExistsAtCommit"> {
   return {
-    commitExists: (sha) => sha === codeDocSha,
+    commitExists: (_repoRoot, sha) => sha === codeDocSha,
     pathExistsAtCommit: () => true
   };
 }

--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -1,9 +1,7 @@
-import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { Effect } from "effect";
 import { makeTaskLifecycleOrchestrator, type TaskLifecycleResult } from "../../../../application/src/index.ts";
-import type { GitRunner } from "../../../../application/src/index.ts";
-import { taskDocumentPath } from "../../../../kernel/src/index.ts";
+import { makeLocalVersionControlSystem, taskDocumentPath } from "../../../../kernel/src/index.ts";
 import { cliError, CliErrorCode, isCliErrorCode, type CliErrorCode as CliErrorCodeValue } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
 import type { CommandRunner } from "../../cli/runner-registry.ts";
@@ -22,7 +20,7 @@ export const runTaskGatesCommand: CommandRunner = (context, command) => {
     taskWriter: context.engine,
     artifactStore: context.artifactStore,
     documentPlaceholderPolicy: bundledTaskDocumentPlaceholderPolicy(),
-    codeDocGit: localGitRunner(context.rootDir)
+    codeDocVersionControlSystem: makeLocalVersionControlSystem()
   });
   if (action.kind === "task-review") {
     return orchestrator.reviewTask({ taskId: action.taskId, reviewerId: action.reviewerId }).pipe(
@@ -135,22 +133,6 @@ function taskGateHint(code: string, hint: string, taskId: string): string {
     hint,
     `To make closeoutReadiness ready/passed, run ha task transition ${taskId} in_review, replace closeout.md placeholder content with real Summary/Verification/Residual Risk, run ha fact record --task ${taskId} --statement "..." --source "..." for evidence, run ha task review ${taskId}, then run ha task complete ${taskId} --ci passed.`
   ].join(" ");
-}
-
-function localGitRunner(rootDir: string): GitRunner {
-  return {
-    commitExists: (sha) => runGit(rootDir, ["cat-file", "-e", `${sha}^{commit}`]),
-    pathExistsAtCommit: (sha, relativePath) => runGit(rootDir, ["cat-file", "-e", `${sha}:${relativePath}`])
-  };
-}
-
-function runGit(rootDir: string, args: ReadonlyArray<string>): boolean {
-  try {
-    execFileSync("git", ["-C", rootDir, ...args], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 function cliErrorCode(code: string): CliErrorCodeValue {

--- a/packages/kernel/src/ports/version-control-system.ts
+++ b/packages/kernel/src/ports/version-control-system.ts
@@ -16,6 +16,8 @@ export interface VersionControlSystem {
   readonly currentBranch: (repoRoot: string) => string | null;
   readonly originHeadBranch: (repoRoot: string) => string | null;
   readonly refExists: (repoRoot: string, ref: string) => boolean;
+  readonly commitExists: (repoRoot: string, sha: string) => boolean;
+  readonly pathExistsAtCommit: (repoRoot: string, sha: string, relativePath: string) => boolean;
   readonly checkout: (repoRoot: string, ref: string) => void;
   readonly createBranch: (repoRoot: string, branch: string) => void;
   readonly mergeNoFf: (repoRoot: string, branch: string, message: string) => void;

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -59,6 +59,22 @@ export function makeLocalVersionControlSystem(): VersionControlSystem {
         return false;
       }
     },
+    commitExists: (repoRoot, sha) => {
+      try {
+        runGit(repoRoot, "cat-file", "-e", `${sha}^{commit}`);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    pathExistsAtCommit: (repoRoot, sha, relativePath) => {
+      try {
+        runGit(repoRoot, "cat-file", "-e", `${sha}:${relativePath}`);
+        return true;
+      } catch {
+        return false;
+      }
+    },
     checkout: (repoRoot, ref) => {
       runGit(repoRoot, "checkout", ref);
     },

--- a/packages/kernel/test/store/global-committer-lock.test.ts
+++ b/packages/kernel/test/store/global-committer-lock.test.ts
@@ -422,6 +422,8 @@ function fakeVersionControlSystem(repoRoot: string): VersionControlSystem {
     currentBranch: () => "main",
     originHeadBranch: () => null,
     refExists: (_repoRoot, ref) => ref === "refs/heads/main" || ref === "main",
+    commitExists: () => true,
+    pathExistsAtCommit: () => true,
     checkout: () => undefined,
     createBranch: () => undefined,
     mergeNoFf: () => undefined,

--- a/tools/gate-allowlists/check-kernel-dead-exports.json
+++ b/tools/gate-allowlists/check-kernel-dead-exports.json
@@ -1119,22 +1119,12 @@
         "reason": "PLT-Bedrock W2 intentionally exposes the LockRegistry port contract as public kernel surface for composition roots and downstream port wiring."
       },
       {
-        "value": "makeLocalVersionControlSystem",
-        "ref": "task_01KWXKR6JQ9Y91KNWW8FBMTBTB",
-        "reason": "PLT-Bedrock W2 intentionally exposes the local VCS implementation factory through the kernel composition surface."
-      },
-      {
         "value": "VcsCommandError",
         "ref": "task_01KWXKR6JQ9Y91KNWW8FBMTBTB",
         "reason": "PLT-Bedrock W2 intentionally exposes the VersionControlSystem port contract as public kernel surface for composition roots and downstream port wiring."
       },
       {
         "value": "VcsCommitAuthor",
-        "ref": "task_01KWXKR6JQ9Y91KNWW8FBMTBTB",
-        "reason": "PLT-Bedrock W2 intentionally exposes the VersionControlSystem port contract as public kernel surface for composition roots and downstream port wiring."
-      },
-      {
-        "value": "VersionControlSystem",
         "ref": "task_01KWXKR6JQ9Y91KNWW8FBMTBTB",
         "reason": "PLT-Bedrock W2 intentionally exposes the VersionControlSystem port contract as public kernel surface for composition roots and downstream port wiring."
       },

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -481,7 +481,6 @@
         { "file": "packages/adapters/local/src/git-diff-evidence.ts", "command": "git" },
         { "file": "packages/adapters/local/src/index.ts", "command": "git" },
         { "file": "packages/cli/src/commands/core/authored-git.ts", "command": "git" },
-        { "file": "packages/cli/src/commands/core/task-gates.ts", "command": "git" },
         { "file": "packages/cli/src/commands/doctor.ts", "command": "git" },
         { "file": "packages/kernel/src/projection/post-merge-checks.ts", "command": "git" },
         { "file": "packages/kernel/src/store/local-version-control-system.ts", "command": "git" }


### PR DESCRIPTION
# English

## Summary

Charter P4-3: delete the `GitRunner` hypothetical seam. The interface had exactly one adapter in the whole repo — `localGitRunner` in task-gates.ts, a lambda shelling out to `git cat-file`-class commands — while the real version-control seam (`VersionControlSystem`) sat alongside. One adapter is not a seam; it is indirection debt. Net −14 lines.

## What Changed

- Deleted the `GitRunner` interface (application) and `localGitRunner` wrapper (CLI); `code-doc-reconciliation` now consumes the kernel `VersionControlSystem` port, extended with `commitExists`/`pathExistsAtCommit` queries; the CLI composition root injects `makeLocalVersionControlSystem()`.
- Ledger tightening that falls out of the deletion (authorized case-by-case during the work): two `check-kernel-dead-exports` allowlist entries removed because their exports are now genuinely consumed, and one stale `write-road-registry` directWrites record removed because the task-gates git shell-out no longer exists. All three shrink exemption surface; no gate logic touched.
- Regression coverage: code-doc reconciliation unit tests and task-complete CLI tests pass through the unified port (this path gated two real task completions today).

## Task And Scope

- Harness task: `task_01KX5XRPK3V9GSPFEWZT08VWSJ` (charter `task_01KX5HEBCHAKMA25FH5KHRWSEX` P4-3)
- Branch: `codex/p4-delete-gitrunner-seam`
- Public scope: `packages/application/**`, `packages/cli/**`, `packages/kernel/**` (port extension), two ledger JSON files under `tools/` (entry deletions only)
- Private planning/evidence updated: yes
- Out of scope: gate logic in `tools/*.mjs` (zero changes); other P4 items

## Version Impact

- Version: no version change because this is an internal seam removal with behavior-preserving regressions
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-allowlists/check-kernel-dead-exports.json` (2 entries removed) and `tools/write-road-registry.json` (1 stale directWrites record removed) — exemption/ledger data only, both strictly tightening; checker logic untouched
- Authority: charter P4-3 mission + CEO case-by-case authorization recorded in task package; consistent with dec_mrctkg69 (no new gate exemptions) and dec_mreqd1zg (write-road ledger reflects real write roads)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: `af52460`
- Branch merge-base with `origin/main`: `af52460`
- Last `git fetch origin` time: 2026-07-10 ~21:05 +08:00
- Sync method: rebase (bd44dc7 → 4f0f947 → af52460, no conflicts)
- Public diff command: `git diff origin/main...codex/p4-delete-gitrunner-seam`
- Private evidence commit/path: task package progress/facts
- Reviewer evidence path: this PR body + code-doc reconciliation tests
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci` — not run; worktree deps synced to lockfile (`npm install`, no lockfile diff)
- [x] `git diff --check`
- [x] `npm run check` — exit 0 on final base af52460 (node tests pass, GUI pass, 34 manifest gates)
- [x] `npm run typecheck` — via `npm run check`
- [x] `npm test` — via `npm run check`
- [x] `npm run harness:check-import-boundaries` — via `npm run check`
- [x] `npm run harness:scan-forbidden-symbols` — via `npm run check`
- [x] `npm run harness:check-private-boundary` — via `npm run check`
- [x] `npm run harness:check-package-policy` — via `npm run check`
- [x] `npm run harness:check-implementation-contracts` — via `npm run check`
- [x] `npm run harness:check-schema-contracts` — via `npm run check`
- [x] `npm run harness:check-legacy-intake-readiness` — via `npm run check`
- [x] `npm run harness:smoke-cli-package` — via `npm run check`
- [ ] GitHub Actions `rewrite-ci` passed — pending
- Not run: none. Positive controls: dead-export and write-road gates pass with the tightened ledgers; grep shows zero GitRunner references remain outside dist

## Review Evidence

- Self-review: Codex worker (GPT-5.6 Terra) implemented; stopped twice at authority boundaries (allowlist edits, stale write-road record) and proceeded only on recorded CEO authorization; CEO ground-truthed scope and net deletion
- Reviewer subagent: CEO review against P4-3 mission contract
- Human review: pending
- Blocking findings: none

## Residual Risk

- `VersionControlSystem` gains two read-only queries; consumers beyond code-doc reconciliation are unaffected.

## References

- Task: `harness/tasks/task_01KX5XRPK3V9GSPFEWZT08VWSJ-p4-3-gitrunner-seam-versioncontrolsystem/`
- Evidence: charter P4-3 (A#11)
- Review: task package progress log

---

# 中文

## 概要

Charter P4-3：删除 `GitRunner` 假想 seam。该 interface 全仓只有一个 adapter——task-gates.ts 里 shell 出 `git cat-file` 类命令的 `localGitRunner` lambda——而真正的版本控制 seam（`VersionControlSystem`）就在旁边。一个 adapter 不是 seam，是间接层债务。净删 14 行。

## 改动内容

- 删除 `GitRunner` interface（application）与 `localGitRunner` 包装（CLI）；`code-doc-reconciliation` 改为消费 kernel 的 `VersionControlSystem` port（扩展 `commitExists`/`pathExistsAtCommit` 两个查询），CLI 组合根注入 `makeLocalVersionControlSystem()`。
- 删除带来的台账收紧（工作中逐条经 CEO 授权）：`check-kernel-dead-exports` allowlist 删 2 条（其导出现有真实消费方）、`write-road-registry` 删 1 条 stale directWrites 记录（task-gates 的 git shell-out 已不存在）。三条均缩小豁免面，checker 逻辑零改动。
- 回归覆盖：code-doc reconciliation 单测与 task-complete CLI 测试全过（该路径今天刚把关过两次真实任务收口）。

## 任务与范围

- Harness 任务：`task_01KX5XRPK3V9GSPFEWZT08VWSJ`（charter P4-3）
- 分支：`codex/p4-delete-gitrunner-seam`
- 公开范围：`packages/application/**`、`packages/cli/**`、`packages/kernel/**`（port 扩展）、`tools/` 下两个台账 JSON（仅删条目）
- 私有计划 / 证据是否已更新：yes
- 范围外：`tools/*.mjs` gate 逻辑（零改动）；其他 P4 项

## 版本影响

- 版本：不改版本，原因是内部 seam 移除且回归保行为
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/gate-allowlists/check-kernel-dead-exports.json`（删 2 条）与 `tools/write-road-registry.json`（删 1 条 stale 记录）——仅豁免/台账数据，均严格收紧；checker 逻辑未动
- 依据：charter P4-3 mission + 任务包中逐条记录的 CEO 授权；与 dec_mrctkg69（不加豁免）、dec_mreqd1zg（write-road 台账反映真实写路）同向
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no

## 验证

- `origin/main` 基准 SHA：`af52460`
- 当前分支与 `origin/main` 的 merge-base：`af52460`
- 最近一次 `git fetch origin` 时间：2026-07-10 ~21:05 +08:00
- 同步方式：rebase（bd44dc7 → 4f0f947 → af52460，均无冲突）
- 公开 diff 命令：`git diff origin/main...codex/p4-delete-gitrunner-seam`
- 私有证据 commit / 路径：任务包 progress/facts
- Reviewer 证据路径：本 PR body + code-doc reconciliation 测试
- GitHub Actions `rewrite-ci` run URL：待产生
- 勾选情况与英文块一致：最终基线 af52460 上全量 `npm run check` exit 0；dead-export 与 write-road 门在收紧后的台账下通过；grep 证明 dist 外零 GitRunner 残留；`npm ci` 未单独跑（按 lockfile 同步依赖且无 lockfile diff）
- 未运行：无

## Review Evidence

- 自审：Codex worker（GPT-5.6 Terra）实现；两次在授权边界主动停车（allowlist 删改、stale write-road 记录），均在 CEO 逐条授权后才继续；CEO ground-truth 范围与净删
- Reviewer subagent：CEO 按 P4-3 mission 契约审
- 人工 review：待定
- 阻塞发现：无

## 残余风险

- `VersionControlSystem` 新增两个只读查询；code-doc reconciliation 之外的消费方不受影响。

## 参考

- 任务：`harness/tasks/task_01KX5XRPK3V9GSPFEWZT08VWSJ-p4-3-gitrunner-seam-versioncontrolsystem/`
- 证据：charter P4-3（A#11）
- Review：任务包 progress 记录
