### PR TITLE
feat: add injectable home user preset layer

### DIFF
--- a/packages/cli/src/commands/extensions/state.ts
+++ b/packages/cli/src/commands/extensions/state.ts
@@ -274,10 +274,12 @@ function presetLayerRoots(rootInput: HarnessLayoutInput, layer: "project" | "use
 }
 
 function presetUserHomeRoot(): string {
+  // Default lives under ~/.harness so the cross-project layer never claims a
+  // bare directory in the OS home; HARNESS_USER_HOME points at that root.
   return path.resolve(
     process.env.HARNESS_USER_HOME && process.env.HARNESS_USER_HOME.length > 0
       ? process.env.HARNESS_USER_HOME
-      : os.homedir()
+      : path.join(os.homedir(), ".harness")
   );
 }
 

--- a/packages/cli/src/commands/extensions/state.ts
+++ b/packages/cli/src/commands/extensions/state.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { Effect, Schema } from "effect";
 import {
@@ -132,35 +133,37 @@ function safePresetSourcePath(sourcePath: string): string {
 }
 
 function readLayerPresetEntries(rootInput: HarnessLayoutInput, layer: "project" | "user"): ReadonlyArray<PresetResolutionEntry> {
-  const layerRoot = presetLayerRoot(rootInput, layer);
-  if (!existsSync(layerRoot)) return [];
-  return readdirSync(layerRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .flatMap((entry): ReadonlyArray<PresetResolutionEntry> => {
-      const presetPath = path.join(layerRoot, entry.name, "preset.json");
-      if (!existsSync(presetPath)) {
-        return [{
-          id: entry.name,
-          layer,
-          sourcePath: presetPath,
-          issues: [extensionIssue("preset_path_id_mismatch", `Preset directory ${entry.name} is missing preset.json.`, "preset.json")]
-        }];
-      }
-      const decoded = decodePresetManifestFileResult(presetPath);
-      if (decoded.ok && decoded.value.id !== entry.name) {
-        const invalid = {
-          layer,
-          sourcePath: presetPath,
-          issues: [extensionIssue("preset_path_id_mismatch", `Preset manifest id ${decoded.value.id} must match directory ${entry.name}.`, "id")]
-        };
-        return [
-          { ...invalid, id: entry.name, directoryId: entry.name },
-          { ...invalid, id: decoded.value.id, directoryId: entry.name }
-        ];
-      }
-      return decoded.ok
-        ? [{ manifest: decoded.value, layer, sourcePath: presetPath }]
-        : [{ id: entry.name, layer, sourcePath: presetPath, issues: decoded.issues }];
+  return presetLayerRoots(rootInput, layer)
+    .flatMap((layerRoot) => {
+      if (!existsSync(layerRoot)) return [];
+      return readdirSync(layerRoot, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .flatMap((entry): ReadonlyArray<PresetResolutionEntry> => {
+          const presetPath = path.join(layerRoot, entry.name, "preset.json");
+          if (!existsSync(presetPath)) {
+            return [{
+              id: entry.name,
+              layer,
+              sourcePath: presetPath,
+              issues: [extensionIssue("preset_path_id_mismatch", `Preset directory ${entry.name} is missing preset.json.`, "preset.json")]
+            }];
+          }
+          const decoded = decodePresetManifestFileResult(presetPath);
+          if (decoded.ok && decoded.value.id !== entry.name) {
+            const invalid = {
+              layer,
+              sourcePath: presetPath,
+              issues: [extensionIssue("preset_path_id_mismatch", `Preset manifest id ${decoded.value.id} must match directory ${entry.name}.`, "id")]
+            };
+            return [
+              { ...invalid, id: entry.name, directoryId: entry.name },
+              { ...invalid, id: decoded.value.id, directoryId: entry.name }
+            ];
+          }
+          return decoded.ok
+            ? [{ manifest: decoded.value, layer, sourcePath: presetPath }]
+            : [{ id: entry.name, layer, sourcePath: presetPath, issues: decoded.issues }];
+        });
     });
 }
 
@@ -260,7 +263,22 @@ function presetLayerRoot(rootInput: HarnessLayoutInput, layer: "project" | "user
   const layout = resolveHarnessLayout(rootInput);
   return layer === "project"
     ? path.join(layout.localRoot, "presets")
-    : path.join(layout.localRoot, "user-presets");
+    : path.join(presetUserHomeRoot(), "presets");
+}
+
+function presetLayerRoots(rootInput: HarnessLayoutInput, layer: "project" | "user"): ReadonlyArray<string> {
+  const layout = resolveHarnessLayout(rootInput);
+  return layer === "project"
+    ? [path.join(layout.localRoot, "presets")]
+    : [path.join(layout.localRoot, "user-presets"), path.join(presetUserHomeRoot(), "presets")];
+}
+
+function presetUserHomeRoot(): string {
+  return path.resolve(
+    process.env.HARNESS_USER_HOME && process.env.HARNESS_USER_HOME.length > 0
+      ? process.env.HARNESS_USER_HOME
+      : os.homedir()
+  );
 }
 
 export function presetManifestPath(rootInput: HarnessLayoutInput, layer: "project" | "user", presetId: string): string {

--- a/packages/cli/test/conflict-preflight-cli.test.ts
+++ b/packages/cli/test/conflict-preflight-cli.test.ts
@@ -163,10 +163,11 @@ test("CLI conflict preflight blocks representative write commands before output"
     const cases: ReadonlyArray<{
       readonly args: ReadonlyArray<string>;
       readonly missingPath: string;
+      readonly env?: NodeJS.ProcessEnv;
     }> = [
       { args: ["init"], missingPath: "harness/harness.yaml" },
       { args: ["module", "register", "billing", "--title", "Billing", "--scope", "packages/billing/**"], missingPath: "harness/modules.json" },
-      { args: ["preset", "seed"], missingPath: ".harness/user-presets" },
+      { args: ["preset", "seed"], missingPath: ".harness/presets", env: { HARNESS_USER_HOME: path.join(rootDir, ".harness") } },
       { args: ["preset", "run", "module", "check", "--task", "task-1"], missingPath: ".harness/evidence/presets/module" },
       { args: ["preset", "action", "module", "check", "--task", "task-1"], missingPath: ".harness/evidence/presets/module" },
       { args: ["script", "run", "missing-script", "--task", "task-1"], missingPath: ".harness" },
@@ -175,7 +176,7 @@ test("CLI conflict preflight blocks representative write commands before output"
     ];
 
     for (const entry of cases) {
-      const result = runJson(rootDir, entry.args);
+      const result = runJson(rootDir, entry.args, entry.env);
       assert.equal(result.ok, false, entry.args.join(" "));
       assert.equal(result.error?.code, "conflict_marker_present", entry.args.join(" "));
       assert.equal(existsSync(path.join(rootDir, entry.missingPath)), false, entry.args.join(" "));

--- a/packages/cli/test/preset-module-cli.test.ts
+++ b/packages/cli/test/preset-module-cli.test.ts
@@ -9,29 +9,6 @@ import test from "node:test";
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const bundledPresetIndexPath = path.resolve("packages/cli/src/commands/extensions/assets/software-coding/presets/index.json");
 
-test("CLI preset discovery honors project over user over bundled presets", () => {
-  withTempRoot((rootDir) => {
-    writePreset(rootDir, ".harness/user-presets/standard-task/preset.json", {
-      id: "standard-task",
-      title: "User Standard Task",
-      version: "1.0.0"
-    });
-    writePreset(rootDir, ".harness/presets/standard-task/preset.json", {
-      id: "standard-task",
-      title: "Project Standard Task",
-      version: "2.0.0"
-    });
-
-    const result = runJson(rootDir, ["preset", "list"]);
-
-    assert.equal(result.ok, true);
-    assert.equal(result.command, "preset-list");
-    const standard = result.presets.find((preset: Record<string, unknown>) => preset.id === "standard-task");
-    assert.equal(standard.title, "Project Standard Task");
-    assert.equal(standard.layer, "project");
-    assert.equal(result.presets.some((preset: Record<string, unknown>) => preset.id === "module"), true);
-  });
-});
 
 test("CLI preset CRUD validates, installs, audits, and removes project presets", () => {
   withTempRoot((rootDir) => {
@@ -486,10 +463,11 @@ test("CLI module CRUD maintains generated module view and module-step state", ()
   });
 });
 
-function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, any> {
+function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true, env: NodeJS.ProcessEnv = {}): Record<string, any> {
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
-      encoding: "utf8"
+      encoding: "utf8",
+      env: { ...process.env, ...env }
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/preset-user-root-cli.test.ts
+++ b/packages/cli/test/preset-user-root-cli.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+
+test("CLI preset discovery honors project over user over bundled presets", () => {
+  withTempRoot((rootDir) => {
+    const userHome = mkdtempSync(path.join(tmpdir(), "ha-user-presets-"));
+    try {
+      writePreset(userHome, "presets/standard-task/preset.json", {
+        id: "standard-task",
+        title: "Home User Standard Task",
+        version: "1.5.0"
+      });
+      writePreset(rootDir, ".harness/user-presets/standard-task/preset.json", {
+        id: "standard-task",
+        title: "Legacy User Standard Task",
+        version: "1.0.0"
+      });
+      writePreset(rootDir, ".harness/presets/standard-task/preset.json", {
+        id: "standard-task",
+        title: "Project Standard Task",
+        version: "2.0.0"
+      });
+
+      const result = runJson(rootDir, ["preset", "list"], true, {
+        HARNESS_USER_HOME: userHome
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.command, "preset-list");
+      const standard = result.presets.find((preset: Record<string, unknown>) => preset.id === "standard-task");
+      assert.equal(standard.title, "Project Standard Task");
+      assert.equal(standard.layer, "project");
+      assert.equal(result.presets.some((preset: Record<string, unknown>) => preset.id === "module"), true);
+    } finally {
+      rmSync(userHome, { recursive: true, force: true });
+    }
+  });
+});
+
+test("CLI preset discovery honors home user presets over legacy user-presets", () => {
+  withTempRoot((rootDir) => {
+    const userHome = mkdtempSync(path.join(tmpdir(), "ha-user-presets-"));
+    try {
+      writePreset(rootDir, ".harness/user-presets/standard-task/preset.json", {
+        id: "standard-task",
+        title: "Legacy User Standard Task",
+        version: "1.0.0"
+      });
+      writePreset(userHome, "presets/standard-task/preset.json", {
+        id: "standard-task",
+        title: "Home User Standard Task",
+        version: "1.5.0"
+      });
+
+      const result = runJson(rootDir, ["preset", "list"], true, {
+        HARNESS_USER_HOME: userHome
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.command, "preset-list");
+      const standard = result.presets.find((preset: Record<string, unknown>) => preset.id === "standard-task");
+      assert.equal(standard.title, "Home User Standard Task");
+      assert.equal(standard.layer, "user");
+    } finally {
+      rmSync(userHome, { recursive: true, force: true });
+    }
+  });
+});
+
+test("CLI preset install/uninstall/list/audit operate in injected home user root", () => {
+  withTempRoot((rootDir) => {
+    const userHome = mkdtempSync(path.join(tmpdir(), "ha-user-presets-"));
+    const sourceDir = path.join(rootDir, "source-preset");
+    const homePresetPath = path.join(userHome, "presets", "custom-task", "preset.json");
+    try {
+      writePreset(sourceDir, "preset.json", {
+        id: "custom-task",
+        title: "Custom Task",
+        version: "1.0.0"
+      });
+
+      const installed = runJson(rootDir, ["preset", "install", sourceDir], true, {
+        HARNESS_USER_HOME: userHome
+      });
+      assert.equal(installed.ok, true);
+      assert.equal(installed.command, "preset-install");
+      assert.equal(installed.preset.id, "custom-task");
+      assert.equal(existsSync(homePresetPath), true);
+
+      const listed = runJson(rootDir, ["preset", "list"], true, {
+        HARNESS_USER_HOME: userHome
+      });
+      assert.equal(listed.presets.some((preset: Record<string, unknown>) => preset.id === "custom-task" && preset.layer === "user"), true);
+
+      const audited = runJson(rootDir, ["preset", "audit"], true, {
+        HARNESS_USER_HOME: userHome
+      });
+      assert.equal(audited.ok, true);
+      assert.equal(audited.presets.some((preset: Record<string, unknown>) => preset.id === "custom-task" && preset.layer === "user"), true);
+
+      const removed = runJson(rootDir, ["preset", "uninstall", "custom-task"], true, {
+        HARNESS_USER_HOME: userHome
+      });
+      assert.equal(removed.ok, true);
+      assert.equal(removed.command, "preset-uninstall");
+      assert.equal(existsSync(homePresetPath), false);
+    } finally {
+      rmSync(userHome, { recursive: true, force: true });
+    }
+  });
+});
+
+test("CLI missing injected home user preset root is treated as empty until install", () => {
+  withTempRoot((rootDir) => {
+    const userHome = mkdtempSync(path.join(tmpdir(), "ha-user-presets-"));
+    const sourceDir = path.join(rootDir, "source-preset");
+    const homePresetRoot = path.join(userHome, "presets");
+    const homePresetPath = path.join(homePresetRoot, "custom-task", "preset.json");
+    try {
+      rmSync(userHome, { recursive: true, force: true });
+      writePreset(sourceDir, "preset.json", {
+        id: "custom-task",
+        title: "Custom Task",
+        version: "1.0.0"
+      });
+
+      const listed = runJson(rootDir, ["preset", "list"], true, {
+        HARNESS_USER_HOME: userHome
+      });
+      assert.equal(listed.ok, true);
+      assert.equal(existsSync(homePresetRoot), false);
+
+      const audited = runJson(rootDir, ["preset", "audit"], true, {
+        HARNESS_USER_HOME: userHome
+      });
+      assert.equal(audited.ok, true);
+      assert.equal(existsSync(homePresetRoot), false);
+
+      const installed = runJson(rootDir, ["preset", "install", sourceDir], true, {
+        HARNESS_USER_HOME: userHome
+      });
+      assert.equal(installed.ok, true);
+      assert.equal(installed.preset.layer, "user");
+      assert.equal(existsSync(homePresetPath), true);
+    } finally {
+      rmSync(userHome, { recursive: true, force: true });
+    }
+  });
+});
+
+function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true, env: NodeJS.ProcessEnv = {}): Record<string, any> {
+  try {
+    const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+      encoding: "utf8",
+      env: { ...process.env, ...env }
+    });
+    return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
+  } catch (error) {
+    if (expectSuccess) throw error;
+    const failure = error as { readonly stdout?: string };
+    return unwrapCommandReceipt(JSON.parse(failure.stdout ?? "{}") as Record<string, any>);
+  }
+}
+
+function withTempRoot<T>(fn: (rootDir: string) => T): T {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-p2-cli-"));
+  try {
+    return fn(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function writePreset(rootDir: string, relativePath: string, overrides: {
+  readonly id: string;
+  readonly title: string;
+  readonly version: string;
+  readonly templateSelections?: ReadonlyArray<Record<string, unknown>>;
+}): void {
+  const filePath = path.join(rootDir, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(makePreset(overrides), null, 2), "utf8");
+}
+
+function makePreset(overrides: {
+  readonly id: string;
+  readonly title: string;
+  readonly version: string;
+  readonly templateSelections?: ReadonlyArray<Record<string, unknown>>;
+}): Record<string, unknown> {
+  return {
+    schema: "preset-manifest/v1",
+    id: overrides.id,
+    title: overrides.title,
+    vertical: "software/coding",
+    version: overrides.version,
+    kernelVersionRange: {
+      min: "1.0.0",
+      maxExclusive: "2.0.0"
+    },
+    capabilityImports: [],
+    profiles: [{
+      id: "baseline",
+      title: "Baseline",
+      checkerProfile: "standard",
+      templateSelections: overrides.templateSelections ?? []
+    }],
+    defaultProfile: "baseline"
+  };
+}

--- a/tools/check-integration-test-shards.test.mjs
+++ b/tools/check-integration-test-shards.test.mjs
@@ -9,7 +9,7 @@ import {
 test("integration shard declaration is non-overlapping and complete", () => {
   const result = checkIntegrationTestShards();
   assert.equal(result.ok, true, result.errors.join("\n"));
-  assert.equal(result.fileCount, 76);
+  assert.equal(result.fileCount, 77);
   assert.deepEqual(result.workflowShards, [1, 2, 3, 4, 5, 6]);
   assert.deepEqual(result.requiredContexts, [
     "integration-shard (1)",

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -426,22 +426,22 @@
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#mkdirSync@305:3",
+        "value": "packages/cli/src/commands/extensions/state.ts#mkdirSync@325:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#mkdirSync@337:5",
+        "value": "packages/cli/src/commands/extensions/state.ts#mkdirSync@357:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@338:5",
+        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@358:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@358:3",
+        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@378:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },

--- a/tools/integration-test-shards.mjs
+++ b/tools/integration-test-shards.mjs
@@ -35,6 +35,7 @@ export const integrationTestFileWeightsMs = Object.freeze({
   "packages/cli/test/preset-github-issue-repair-cli.test.ts": 2819.6,
   "packages/cli/test/preset-milestone-closeout-cli.test.ts": 2414.0,
   "packages/cli/test/preset-module-cli.test.ts": 22821.6,
+  "packages/cli/test/preset-user-root-cli.test.ts": 3000.0,
   "packages/cli/test/preset-script-cli.test.ts": 21150.1,
   "packages/cli/test/preset-script-imports-cli.test.ts": 1132.0,
   "packages/cli/test/preset-subtask-expansion-cli.test.ts": 17807.0,
@@ -173,6 +174,7 @@ export const integrationTestShards = Object.freeze([
     id: 6,
     files: Object.freeze([
       "packages/cli/test/preset-module-cli.test.ts",
+      "packages/cli/test/preset-user-root-cli.test.ts",
       "packages/cli/test/migration-adopt-cli.test.ts",
       "packages/cli/test/task-archive-distill-cli.test.ts",
       "packages/cli/test/fact-cli.test.ts",

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -144,6 +144,7 @@ export const testTierManifest = {
     "packages/cli/test/preset-github-issue-repair-cli.test.ts",
     "packages/cli/test/preset-milestone-closeout-cli.test.ts",
     "packages/cli/test/preset-module-cli.test.ts",
+    "packages/cli/test/preset-user-root-cli.test.ts",
     "packages/cli/test/preset-subtask-expansion-cli.test.ts",
     "packages/cli/test/preset-script-imports-cli.test.ts",
     "packages/cli/test/preset-script-cli.test.ts",


### PR DESCRIPTION
# English

## Summary

Give the preset "user" layer a real cross-project home (decision dec_mreamq6x, sub-answer C4): the user layer now resolves to a home-directory root (`~/.harness/presets/<id>/preset.json` by default, injectable via `HARNESS_USER_HOME` for hermetic tests) instead of a project-internal path. Precedence stays `builtin < user < project`. The legacy project-internal `user-presets` path remains readable for compatibility (home wins on the same id) but is no longer a write target.

## What Changed

- `packages/cli/src/commands/extensions/state.ts`: user-layer roots resolve through a single `presetUserHomeRoot()` (env override or `~/.harness`); discovery reads legacy `user-presets` then home (home overrides same id); `preset install` (default user) writes to the home root; missing home root is an empty layer (no error, no eager mkdir).
- `packages/cli/test/preset-user-root-cli.test.ts` (new, 217 lines): layer precedence, home-over-legacy override, install target, hermetic injection, missing-root silence.
- `packages/cli/test/preset-module-cli.test.ts`, `conflict-preflight-cli.test.ts`: aligned to the injectable root.
- `tools/test-tier-manifest.mjs`, `integration-test-shards.mjs`, `check-integration-test-shards.test.mjs`: register the new test file in shard 6.
- CEO follow-up commits: default root fixed from bare `os.homedir()` to `~/.harness` so the cross-project layer never claims a bare `~/presets` directory; `tools/gate-allowlists/check-bypass-write-boundary.json` re-pinned — the four pre-existing state.ts write points shifted +20 lines, entries updated value-only (same refs, same reasons, entry count unchanged at 125, no new write grant).

## Task And Scope

- Harness task: task_01KX68Z90DE4F45JCW4V7V40ZD
- Branch: codex/user-preset-layer
- Public scope: preset layer resolution and tests + shard manifest registration (7 files, +276/−58)
- Private planning/evidence updated: yes (mission and worker impl-report in the task package)
- Out of scope: folder-level (recursive upward) preset loading — a separate undecided layer; write migration of legacy user-presets content

## Version Impact

- Version: no version change because the layer contract is additive (legacy path stays readable; new default only activates where `~/.harness/presets` exists).
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: test-shard manifest registration is additive test-infrastructure bookkeeping; the write-boundary allowlist edit is a value-only line re-pin of four existing governed entries (no new grant, count unchanged, refs/reasons untouched) — verified by the gate's own delta=0 output.
- Authority: decision dec_mreamq6x (accepted; C4 names the missing home-level user layer as authorized follow-up work), task task_01KX68Z90DE4F45JCW4V7V40ZD
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: e656fc4
- Branch merge-base with `origin/main`: e656fc4 (rebased, clean)
- Last `git fetch origin` time: 2026-07-10 ~15:55 UTC
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/user-preset-layer`
- Private evidence commit/path: task package impl-report for task_01KX68Z90DE4F45JCW4V7V40ZD (private ledger)
- Reviewer evidence path: see References
- GitHub Actions `rewrite-ci` run URL: pending (runs on this PR)
- [x] `npm run check` (as `npm run check:local` fast tier: worker green; CEO re-run after the default-root fix and rebase, exit 0)
- [x] CI-shape integration shard 6 (carries the new test file): `node tools/run-manifest-gates.mjs --workflow-job integration-shard --shard 6 --exclude mergify-queue-metadata-edit-noop` (CEO run, exit 0)
- [x] Targeted tests: preset-user-root + preset-module + conflict-preflight, exit 0
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run typecheck` (covered by check:local fast tier and CI)
- [ ] `npm test` (integration covered by CI shards)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: remaining checklist items individually — covered by the manifest-driven gate runner above and by CI on this PR.

## Review Evidence

- Self-review: CEO ground-truthed the diff surface and the layer-resolution code path; found and fixed one defect before push (default root was bare `os.homedir()`, yielding `~/presets` instead of `~/.harness/presets`); verified ledger writes landed in the canonical task package and the public branch tracks zero harness files.
- Reviewer subagent: implementation by Codex worker; gates re-run by CEO after the fix.
- Human review: repository owner acts as merge authority via the queue.
- Blocking findings: none

## Residual Risk

- The default-root branch (no `HARNESS_USER_HOME`) is not exercised hermetically by tests (tests always inject the root); the line is single-point and auditable, and the env-injected path covers the resolution logic.
- Legacy project-internal `user-presets` stays readable indefinitely; retiring it needs a small follow-up decision once real installs migrate.

## References

- Task: task_01KX68Z90DE4F45JCW4V7V40ZD
- Evidence: decision dec_mreamq6x (preset distribution tiering; C4)
- Review: task package impl-report (private ledger)

---

# 中文

## 概要

给 preset 的 "user" 层一个真正跨项目的家（裁决 dec_mreamq6x 子取舍 C4）：user 层现解析到 home 目录级根（默认 `~/.harness/presets/<id>/preset.json`，hermetic 测试经 `HARNESS_USER_HOME` 注入），不再是项目内路径。优先级保持 `builtin < user < project`。旧项目内 `user-presets` 路径保留兼容读取（同 id 时 home 覆盖），不再作为写入目标。

## 改动内容

- `packages/cli/src/commands/extensions/state.ts`：user 层根收敛到单点 `presetUserHomeRoot()`（env 覆盖或 `~/.harness`）；发现顺序=先旧 `user-presets` 后 home（同 id home 覆盖）；`preset install`（默认 user）落 home 根；home 根缺失=空层（不报错、不提前建目录）。
- `packages/cli/test/preset-user-root-cli.test.ts`（新增 217 行）：层优先级、home 压旧路径、install 落点、hermetic 注入、缺根静默。
- `packages/cli/test/preset-module-cli.test.ts`、`conflict-preflight-cli.test.ts`：对齐可注入根。
- `tools/test-tier-manifest.mjs`、`integration-test-shards.mjs`、`check-integration-test-shards.test.mjs`：新测试文件登记进 shard 6。
- CEO 追加提交：默认根从裸 `os.homedir()` 修为 `~/.harness`，跨项目层不得在 OS home 根下直接占用 `~/presets` 目录；`tools/gate-allowlists/check-bypass-write-boundary.json` 重钉——state.ts 四个既有受治理写点行号整体 +20，仅更新 value（ref/reason 不动，条目数 125 不变，零新增写授权）。

## 任务与范围

- Harness 任务：task_01KX68Z90DE4F45JCW4V7V40ZD
- 分支：codex/user-preset-layer
- 公开范围：preset 分层解析与测试 + shard manifest 登记（7 文件，+276/−58）
- 私有计划 / 证据是否已更新：yes（mission 与 worker 实现报告在任务包）
- 范围外：文件夹级（递归向上）preset 加载——另一个未裁决层级；旧 user-presets 内容的写迁移

## 版本影响

- 版本：不改版本，原因是分层契约为加法（旧路径仍可读；新默认仅在 `~/.harness/presets` 存在时生效）。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：test-shard manifest 登记是加法性测试基建记账；write-boundary allowlist 改动为四条既有受治理条目的行号重钉（仅 value，零新增授权，条目数不变，门自身输出 delta=0 佐证）。
- 依据：决策 dec_mreamq6x（accepted；C4 点名 home 级 user 层缺位为已授权后续工作）、任务 task_01KX68Z90DE4F45JCW4V7V40ZD
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：e656fc4
- 当前分支与 `origin/main` 的 merge-base：e656fc4（已 rebase，干净）
- 最近一次 `git fetch origin` 时间：2026-07-10 约 15:55 UTC
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...codex/user-preset-layer`
- 私有证据 commit/path：task_01KX68Z90DE4F45JCW4V7V40ZD 任务包 impl-report（私有台账）
- Reviewer 证据路径：见关联材料
- GitHub Actions `rewrite-ci` run URL：待本 PR 触发
- [x] `npm run check`（以 `npm run check:local` fast 档执行：worker 绿；CEO 修默认根并 rebase 后复跑 exit 0）
- [x] CI 同款 integration shard 6（承载新测试文件）：`node tools/run-manifest-gates.mjs --workflow-job integration-shard --shard 6 --exclude mergify-queue-metadata-edit-noop`（CEO 跑，exit 0）
- [x] 定向测试：preset-user-root + preset-module + conflict-preflight，exit 0
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run typecheck`（由 check:local fast 档与 CI 覆盖）
- [ ] `npm test`（integration 由 CI shards 覆盖）
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：其余清单项未单独执行——由上述 manifest 驱动 gate runner 与本 PR 的 CI 覆盖。

## 审查证据

- 自查：CEO ground-truth diff 面与分层解析代码路径；push 前发现并修复一处缺陷（默认根为裸 `os.homedir()`，会得到 `~/presets` 而非 `~/.harness/presets`）；核验台账写入落 canonical 任务包、公开分支零 harness 追踪文件。
- Reviewer subagent：实现由 Codex worker 完成；CEO 修复后复跑门禁。
- 人工审查：仓库所有者经队列行使合并权。
- 阻塞发现：无

## 残余风险

- 默认根分支（无 `HARNESS_USER_HOME`）未被 hermetic 测试覆盖（测试恒注入根）；该行单点可审计，解析逻辑由注入路径覆盖。
- 旧项目内 `user-presets` 无限期保留可读；真实安装迁移后的退役需一条小的后续决策。

## 关联材料

- 任务：task_01KX68Z90DE4F45JCW4V7V40ZD
- 证据：决策 dec_mreamq6x（preset 分发分级；C4）
- 审查：任务包 impl-report（私有台账）

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
