### PR TITLE
feat: enrich GUI decision and fact DTOs via public read projection

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -210,6 +210,14 @@ export interface DecisionProjectionRow {
   readonly path: string;
   readonly moduleKeys: ReadonlyArray<string>;
   readonly productLineKeys: ReadonlyArray<string>;
+  readonly riskTier?: "low" | "medium" | "high";
+  readonly urgency?: "low" | "medium" | "high";
+  readonly vertical?: string;
+  readonly preset?: string;
+  readonly proposedBy?: { readonly kind: "agent" | "human" | "system"; readonly id: string };
+  readonly proposedAt?: string;
+  readonly arbiter?: { readonly kind: "agent" | "human" | "system"; readonly id: string };
+  readonly provenance?: ReadonlyArray<{ readonly runtime: string; readonly sessionId: string; readonly boundAt: string }>;
   readonly decidedAt?: string;
 }
 
@@ -293,6 +301,7 @@ export interface FactProjectionRow {
   readonly confidence: FactConfidence;
   readonly memoryClass: FactMemoryClass;
   readonly memoryTags: ReadonlyArray<FactMemoryTag>;
+  readonly provenance: ReadonlyArray<{ readonly runtime: string; readonly sessionId: string; readonly boundAt: string }>;
 }
 
 export interface TaskFactListSuccess extends LocalControllerSuccess {

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -198,6 +198,17 @@ export interface DecisionProjectionRejected {
   readonly whyNot: string;
 }
 
+export interface DecisionProjectionActor {
+  readonly kind: "agent" | "human" | "system";
+  readonly id: string;
+}
+
+export interface ProjectionProvenanceEntry {
+  readonly runtime: string;
+  readonly sessionId: string;
+  readonly boundAt: string;
+}
+
 export interface DecisionProjectionRow {
   readonly schema: "d4-decision-row/v1";
   readonly decisionId: string;
@@ -214,10 +225,10 @@ export interface DecisionProjectionRow {
   readonly urgency?: "low" | "medium" | "high";
   readonly vertical?: string;
   readonly preset?: string;
-  readonly proposedBy?: { readonly kind: "agent" | "human" | "system"; readonly id: string };
+  readonly proposedBy?: DecisionProjectionActor;
   readonly proposedAt?: string;
-  readonly arbiter?: { readonly kind: "agent" | "human" | "system"; readonly id: string };
-  readonly provenance?: ReadonlyArray<{ readonly runtime: string; readonly sessionId: string; readonly boundAt: string }>;
+  readonly arbiter?: DecisionProjectionActor;
+  readonly provenance?: ReadonlyArray<ProjectionProvenanceEntry>;
   readonly decidedAt?: string;
 }
 
@@ -301,7 +312,7 @@ export interface FactProjectionRow {
   readonly confidence: FactConfidence;
   readonly memoryClass: FactMemoryClass;
   readonly memoryTags: ReadonlyArray<FactMemoryTag>;
-  readonly provenance: ReadonlyArray<{ readonly runtime: string; readonly sessionId: string; readonly boundAt: string }>;
+  readonly provenance: ReadonlyArray<ProjectionProvenanceEntry>;
 }
 
 export interface TaskFactListSuccess extends LocalControllerSuccess {

--- a/packages/application/src/local-controller-service.ts
+++ b/packages/application/src/local-controller-service.ts
@@ -161,7 +161,8 @@ function toFactProjectionRow(taskId: string, fact: FactRecord): FactProjectionRo
     observedAt: fact.observedAt,
     confidence: fact.confidence,
     memoryClass: fact.memoryClass,
-    memoryTags: fact.memoryTags
+    memoryTags: fact.memoryTags,
+    provenance: fact.provenance
   };
 }
 

--- a/packages/application/test/local-controller-service.test.ts
+++ b/packages/application/test/local-controller-service.test.ts
@@ -51,12 +51,16 @@ test("local controller service reads projection and writes through injected task
     const decisions = service.getDecisions();
     assert.equal(decisions.ok, true);
     assert.deepEqual(decisions.decisions.map((decision) => decision.decisionId), ["dec_test"]);
+    assert.deepEqual(decisions.decisions[0]?.proposedBy, { kind: "agent", id: "codex" });
+    assert.deepEqual(decisions.decisions[0]?.arbiter, { kind: "human", id: "ZeyuLi" });
+    assert.deepEqual(decisions.decisions[0]?.provenance, [{ runtime: "codex", sessionId: "session-1", boundAt: "2026-07-07T00:00:00.000Z" }]);
     const decisionDetail = service.getDecisionDetail({ decisionId: "dec_test" });
     assert.equal(decisionDetail.ok, true);
     assert.equal(decisionDetail.decision.title, "Projection Decision");
     const facts = await service.getTaskFacts({ taskId: "task-1" });
     assert.equal(facts.ok, true);
     assert.deepEqual(facts.facts.map((fact) => fact.ref), ["fact/task-1/F-12345678"]);
+    assert.deepEqual(facts.facts[0]?.provenance, [{ runtime: "codex", sessionId: "session-1", boundAt: "2026-07-07T00:00:00.000Z" }]);
     assert.deepEqual(await service.getTaskDocument({ taskId: "task-1", path: "C:\\Users\\name\\secret.md" }), {
       ok: false,
       error: {

--- a/packages/gui/src/renderer/components/FactInspector.tsx
+++ b/packages/gui/src/renderer/components/FactInspector.tsx
@@ -138,6 +138,7 @@ export function FactInspector({
                 )}
               </div>
               <p className="mt-2 text-[13px] font-medium leading-relaxed text-text">{fact.text}</p>
+              <div className="mt-1 font-mono text-[11px] text-text-faint">source {fact.source ?? "未知/—"}</div>
             </div>
 
             <div className="rounded-md border border-border bg-surface-raised px-2.5 py-2">
@@ -171,9 +172,9 @@ export function FactInspector({
               <div className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
                 provenance
               </div>
-              {task?.provenance?.length ? (
+              {fact.provenance?.length ? (
                 <div className="mt-1 space-y-1">
-                  {task.provenance.map((entry) => (
+                  {fact.provenance.map((entry) => (
                     <div key={`${entry.sessionId}-${entry.boundAt}`} className="font-mono text-[11px] text-text-muted">
                       {entry.runtime}:{entry.sessionId.slice(0, 8)}... · {entry.boundAt.slice(0, 16).replace("T", " ")}
                     </div>
@@ -181,7 +182,7 @@ export function FactInspector({
                 </div>
               ) : (
                 <p className="mt-1 text-[12px] text-text-faint">
-                  当前 task 投影未携带 entity provenance；后续由宿主 task 包投影补齐。
+                  当前 fact 投影未携带 provenance。
                 </p>
               )}
             </div>

--- a/packages/gui/src/renderer/components/badges.tsx
+++ b/packages/gui/src/renderer/components/badges.tsx
@@ -203,8 +203,8 @@ const RISK_META: Record<RiskTier, { label: string; cls: string }> = {
   low: { label: "低风险", cls: "text-text-muted" },
 };
 
-export function RiskTierBadge({ tier }: { tier: RiskTier }) {
-  const m = RISK_META[tier];
+export function RiskTierBadge({ tier }: { tier?: RiskTier }) {
+  const m = tier ? RISK_META[tier] : { label: "未知", cls: "text-text-faint" };
   return (
     <span className={`inline-flex items-center gap-1 font-mono text-[12px] ${m.cls}`} title="风险/重要性 → 评审深度">
       <Scales weight="bold" className="text-[12px]" />
@@ -219,8 +219,8 @@ const URGENCY_META: Record<Urgency, { label: string; cls: string }> = {
   low: { label: "不急", cls: "text-text-faint" },
 };
 
-export function UrgencyBadge({ urgency }: { urgency: Urgency }) {
-  const m = URGENCY_META[urgency];
+export function UrgencyBadge({ urgency }: { urgency?: Urgency }) {
+  const m = urgency ? URGENCY_META[urgency] : { label: "未知", cls: "text-text-faint" };
   return (
     <span className={`inline-flex items-center gap-1 font-mono text-[12px] ${m.cls}`} title="紧急 → 队列排队">
       <Lightning weight="bold" className="text-[12px]" />

--- a/packages/gui/src/renderer/graph/GraphDrawer.tsx
+++ b/packages/gui/src/renderer/graph/GraphDrawer.tsx
@@ -159,7 +159,7 @@ export function GraphDrawer({
                     <span className="rounded bg-accent px-1.5 py-0.5 text-accent-fg">
                       {dec.state}
                     </span>
-                    <span className="text-text-muted">{dec.riskTier} risk · {dec.urgency} urgency</span>
+                    <span className="text-text-muted">{dec.riskTier ?? "未知"} risk · {dec.urgency ?? "未知"} urgency</span>
                   </div>
                   <div className="rounded-md border border-border bg-surface-raised px-2.5 py-2">
                     <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">

--- a/packages/gui/src/renderer/model/copy-context.ts
+++ b/packages/gui/src/renderer/model/copy-context.ts
@@ -80,7 +80,7 @@ export function buildFactTriageContext(
   } else {
     for (const dec of citingDecisions) {
       lines.push(
-        `- \`decision/${dec.decisionId}\` — ${dec.title} [state: ${dec.state}, risk: ${dec.riskTier}]`,
+        `- \`decision/${dec.decisionId}\` — ${dec.title} [state: ${dec.state}, risk: ${dec.riskTier ?? "未知"}]`,
       );
       lines.push(`  - Q: ${dec.question}`);
     }

--- a/packages/gui/src/renderer/model/triadic.ts
+++ b/packages/gui/src/renderer/model/triadic.ts
@@ -85,8 +85,8 @@ export function rationaleFor(ref: string, relations: RelationEdge[]): string | u
   )?.rationale;
 }
 
-export const axisRank = (value: "high" | "medium" | "low") =>
-  value === "high" ? 0 : value === "medium" ? 1 : 2;
+export const axisRank = (value?: "high" | "medium" | "low") =>
+  value === "high" ? 0 : value === "medium" ? 1 : value === "low" ? 2 : 3;
 
 export function sortDecisionQueue(decisions: DecisionRow[]): DecisionRow[] {
   return [...decisions].sort((a, b) => {
@@ -94,6 +94,6 @@ export function sortDecisionQueue(decisions: DecisionRow[]): DecisionRow[] {
     if (risk !== 0) return risk;
     const urgency = axisRank(a.urgency) - axisRank(b.urgency);
     if (urgency !== 0) return urgency;
-    return a.proposedAt.localeCompare(b.proposedAt);
+    return (a.proposedAt ?? "").localeCompare(b.proposedAt ?? "");
   });
 }

--- a/packages/gui/src/renderer/model/types.ts
+++ b/packages/gui/src/renderer/model/types.ts
@@ -65,7 +65,7 @@ export interface TaskRow {
   /** 该 task 由哪条 decision 派生（生成式派生时必填；顶层独立 task 可空） */
   spawningDecision?: string;
   /** entity 原文溯源（⚠️ 与 RelationEdge.provenance 同名不同义） */
-  provenance?: ProvenanceEntry[];
+  provenance?: ReadonlyArray<ProvenanceEntry>;
   /**
    * 直接父任务（task 树层级，来自 projection frontmatter `parent` 字段）。
    * 与 spawningDecision 不同:这是 task→task 的层级关系,不是 decision 派生。
@@ -132,22 +132,22 @@ export interface DecisionRow {
   decisionId: string;
   title: string;
   state: DecisionState;
-  riskTier: RiskTier; // 风险/重要性 → 评审 pipeline 深度（低 risk 自动过，不进人队列）
-  urgency: Urgency; // 紧急 → 决策队列排队顺序（与 riskTier 正交）
-  vertical: string;
-  preset: string;
-  proposedBy: { kind: "agent" | "human" | "system"; id: string };
+  riskTier?: RiskTier; // 缺失即未知；不得以 UI 默认值合成风险等级
+  urgency?: Urgency; // 缺失即未知；不得以 UI 默认值合成紧急等级
+  vertical?: string;
+  preset?: string;
+  proposedBy?: { kind: "agent" | "human" | "system"; id: string };
   /** arbiter 必须 ≠ proposedBy（防自证） */
   arbiter?: { kind: "agent" | "human" | "system"; id: string };
-  proposedAt: string;
+  proposedAt?: string;
   decidedAt?: string;
   question: string; // 这条决策回答的问题（复现当时场景）
   chosen: DecisionClaim[]; // 决定了什么策略
   rejected: DecisionClaim[]; // ⚠️ 必填非空，每条带 evidence + why_not（否决比选择更重要）
   claims: { id: string; text: string }[]; // 承重论点（覆盖度查询的锚点）
   /** entity 原文溯源（⚠️ 与 RelationEdge.provenance 同名不同义） */
-  provenance: ProvenanceEntry[];
-  lastChangedAt: string;
+  provenance?: ReadonlyArray<ProvenanceEntry>;
+  lastChangedAt?: string;
   /**
    * 决策就绪信号灯(41 §3.1a)。evidence 活性 / 覆盖度由 relation/fact
    * 投影推导；其余可选信号由后续专用投影提供。
@@ -177,6 +177,10 @@ export interface FactRef {
   at: string;
   /** Immutable observation confidence from task-fact-row/v1. */
   confidence: "low" | "medium" | "high";
+  /** Authored fact source, passed through from task-fact-row/v1. */
+  source?: string;
+  /** Authored fact provenance, passed through from task-fact-row/v1. */
+  provenance?: ReadonlyArray<ProvenanceEntry>;
   /** 是否已被 invalidated-by/supersedes-fact 边标记失效（由图投影推得） */
   invalidated?: boolean;
 }

--- a/packages/gui/src/renderer/triadic-data.ts
+++ b/packages/gui/src/renderer/triadic-data.ts
@@ -143,6 +143,8 @@ function adaptFactRows(
     text: row.statement,
     at: row.observedAt,
     confidence: row.confidence,
+    source: row.source,
+    provenance: row.provenance,
     invalidated: invalidated.has(row.ref)
   }));
 }
@@ -176,19 +178,20 @@ function adaptDecisionRows(
       decisionId: row.decisionId,
       title: row.title,
       state: decisionState(row.state),
-      riskTier: "medium",
-      urgency: "medium",
-      vertical: row.moduleKeys[0] ?? "software/coding",
-      preset: "decision-projection",
-      proposedBy: { kind: "system", id: "projection" },
-      proposedAt: row.decidedAt ?? "1970-01-01T00:00:00.000Z",
+      riskTier: row.riskTier,
+      urgency: row.urgency,
+      vertical: row.vertical,
+      preset: row.preset,
+      proposedBy: row.proposedBy,
+      proposedAt: row.proposedAt,
+      arbiter: row.arbiter,
       decidedAt: row.decidedAt,
       question: row.question,
       chosen,
       rejected,
       claims: [...chosen, ...rejected].map((claim) => ({ id: claim.id, text: claim.text })),
-      provenance: [],
-      lastChangedAt: row.decidedAt ?? "1970-01-01T00:00:00.000Z"
+      provenance: row.provenance,
+      lastChangedAt: row.decidedAt
     };
   });
 }

--- a/packages/gui/src/renderer/views/DecisionPoolView.tsx
+++ b/packages/gui/src/renderer/views/DecisionPoolView.tsx
@@ -35,6 +35,7 @@ const selectClass =
 
 function withinRange(decision: DecisionRow, range: TimeRange) {
   if (range === "all") return true;
+  if (!decision.proposedAt) return false;
   const days = range === "14d" ? 14 : 30;
   const since = Date.now() - days * 24 * 60 * 60 * 1000;
   return new Date(decision.proposedAt).getTime() >= since;
@@ -68,7 +69,7 @@ function ChainView({
 }) {
   const chain = supersedeChain(decision, relations);
   const hasSupersede = chain.supersedes.length > 0 || chain.supersededBy.length > 0;
-  const amended = decision.decidedAt && decision.lastChangedAt !== decision.decidedAt;
+  const amended = decision.decidedAt && decision.lastChangedAt && decision.lastChangedAt !== decision.decidedAt;
 
   if (!hasSupersede && !amended) {
     return <span className="font-mono text-[11px] text-text-faint">no supersede/amend chain</span>;
@@ -91,7 +92,7 @@ function ChainView({
       )}
       {amended && (
         <span className="rounded bg-surface-raised px-1.5 py-0.5 font-mono text-text-muted">
-          amended @ {decision.lastChangedAt.slice(5, 16).replace("T", " ")}
+          amended @ {decision.lastChangedAt?.slice(5, 16).replace("T", " ")}
         </span>
       )}
     </div>
@@ -113,11 +114,11 @@ export function DecisionPoolView({
 }) {
   const [tab, setTab] = useState<PoolTab>("proposed");
   const [stateFilter, setStateFilter] = useState<DecisionState | "all">("all");
-  const [riskFilter, setRiskFilter] = useState<DecisionRow["riskTier"] | "all">("all");
-  const [urgencyFilter, setUrgencyFilter] = useState<DecisionRow["urgency"] | "all">("all");
+  const [riskFilter, setRiskFilter] = useState<NonNullable<DecisionRow["riskTier"]> | "unknown" | "all">("all");
+  const [urgencyFilter, setUrgencyFilter] = useState<NonNullable<DecisionRow["urgency"]> | "unknown" | "all">("all");
   const [verticalFilter, setVerticalFilter] = useState("all");
   const [presetFilter, setPresetFilter] = useState("all");
-  const [proposedByFilter, setProposedByFilter] = useState<DecisionRow["proposedBy"]["kind"] | "all">("all");
+  const [proposedByFilter, setProposedByFilter] = useState<NonNullable<DecisionRow["proposedBy"]>["kind"] | "unknown" | "all">("all");
   const [timeRange, setTimeRange] = useState<TimeRange>("all");
   const handledFocusRef = useRef<string | null>(null);
 
@@ -154,19 +155,19 @@ export function DecisionPoolView({
     return () => window.cancelAnimationFrame(frame);
   }, [decisions, focusedDecisionId]);
 
-  const verticals = useMemo(() => [...new Set(decisions.map((decision) => decision.vertical))].sort(), [decisions]);
-  const presets = useMemo(() => [...new Set(decisions.map((decision) => decision.preset))].sort(), [decisions]);
+  const verticals = useMemo(() => [...new Set(decisions.flatMap((decision) => decision.vertical ? [decision.vertical] : []))].sort(), [decisions]);
+  const presets = useMemo(() => [...new Set(decisions.flatMap((decision) => decision.preset ? [decision.preset] : []))].sort(), [decisions]);
 
   const rows = useMemo(() => {
     const tabStates = new Set(TAB_STATE[tab]);
     return sortDecisionQueue(decisions)
       .filter((decision) => tabStates.has(decision.state))
       .filter((decision) => stateFilter === "all" || decision.state === stateFilter)
-      .filter((decision) => riskFilter === "all" || decision.riskTier === riskFilter)
-      .filter((decision) => urgencyFilter === "all" || decision.urgency === urgencyFilter)
+      .filter((decision) => riskFilter === "all" || riskFilter === "unknown" ? !decision.riskTier : decision.riskTier === riskFilter)
+      .filter((decision) => urgencyFilter === "all" || urgencyFilter === "unknown" ? !decision.urgency : decision.urgency === urgencyFilter)
       .filter((decision) => verticalFilter === "all" || decision.vertical === verticalFilter)
       .filter((decision) => presetFilter === "all" || decision.preset === presetFilter)
-      .filter((decision) => proposedByFilter === "all" || decision.proposedBy.kind === proposedByFilter)
+      .filter((decision) => proposedByFilter === "all" || proposedByFilter === "unknown" ? !decision.proposedBy : decision.proposedBy?.kind === proposedByFilter)
       .filter((decision) => withinRange(decision, timeRange));
   }, [decisions, presetFilter, proposedByFilter, riskFilter, stateFilter, tab, timeRange, urgencyFilter, verticalFilter]);
 
@@ -215,17 +216,19 @@ export function DecisionPoolView({
             <option key={state} value={state}>state: {state}</option>
           ))}
         </select>
-        <select className={selectClass} value={riskFilter} onChange={(event) => setRiskFilter(event.target.value as DecisionRow["riskTier"] | "all")}>
+        <select className={selectClass} value={riskFilter} onChange={(event) => setRiskFilter(event.target.value as typeof riskFilter)}>
           <option value="all">risk: all</option>
           <option value="high">risk: high</option>
           <option value="medium">risk: medium</option>
           <option value="low">risk: low</option>
+          <option value="unknown">risk: unknown</option>
         </select>
-        <select className={selectClass} value={urgencyFilter} onChange={(event) => setUrgencyFilter(event.target.value as DecisionRow["urgency"] | "all")}>
+        <select className={selectClass} value={urgencyFilter} onChange={(event) => setUrgencyFilter(event.target.value as typeof urgencyFilter)}>
           <option value="all">urgency: all</option>
           <option value="high">urgency: high</option>
           <option value="medium">urgency: medium</option>
           <option value="low">urgency: low</option>
+          <option value="unknown">urgency: unknown</option>
         </select>
         <select className={selectClass} value={verticalFilter} onChange={(event) => setVerticalFilter(event.target.value)}>
           <option value="all">vertical: all</option>
@@ -235,11 +238,12 @@ export function DecisionPoolView({
           <option value="all">preset: all</option>
           {presets.map((preset) => <option key={preset} value={preset}>{preset}</option>)}
         </select>
-        <select className={selectClass} value={proposedByFilter} onChange={(event) => setProposedByFilter(event.target.value as DecisionRow["proposedBy"]["kind"] | "all")}>
+        <select className={selectClass} value={proposedByFilter} onChange={(event) => setProposedByFilter(event.target.value as typeof proposedByFilter)}>
           <option value="all">proposedBy: all</option>
           <option value="human">proposedBy: human</option>
           <option value="agent">proposedBy: agent</option>
           <option value="system">proposedBy: system</option>
+          <option value="unknown">proposedBy: unknown</option>
         </select>
         <select className={selectClass} value={timeRange} onChange={(event) => setTimeRange(event.target.value as TimeRange)}>
           <option value="all">time: all</option>
@@ -273,10 +277,10 @@ export function DecisionPoolView({
                   <h2 className="mt-1 truncate text-[15px] font-semibold text-text">{decision.title}</h2>
                   <p className="mt-0.5 truncate text-[12px] text-text-muted">Q: {decision.question}</p>
                   <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[11px] text-text-faint">
-                    <span>{decision.vertical}</span>
-                    <span>{decision.preset}</span>
-                    <span>proposedBy {decision.proposedBy.kind}:{decision.proposedBy.id}</span>
-                    <span>proposed {decision.proposedAt.slice(5, 16).replace("T", " ")}</span>
+                    <span>{decision.vertical ?? "未知/—"}</span>
+                    <span>{decision.preset ?? "未知/—"}</span>
+                    <span>proposedBy {decision.proposedBy ? `${decision.proposedBy.kind}:${decision.proposedBy.id}` : "未知/—"}</span>
+                    <span>proposed {decision.proposedAt ? decision.proposedAt.slice(5, 16).replace("T", " ") : "未知/—"}</span>
                   </div>
                 </div>
                 {onFocusGraph && (

--- a/packages/gui/src/renderer/views/DecisionsView.tsx
+++ b/packages/gui/src/renderer/views/DecisionsView.tsx
@@ -69,7 +69,7 @@ export function DecisionsView({
       const [rb, ub] = sortKey(b);
       if (ra !== rb) return ra - rb;
       if (ua !== ub) return ua - ub;
-      return a.proposedAt.localeCompare(b.proposedAt);
+      return (a.proposedAt ?? "").localeCompare(b.proposedAt ?? "");
     });
     return [...sorted(active), ...sorted(skippedOnes)];
   }, [decisions, skipped]);
@@ -256,7 +256,7 @@ export function DecisionsView({
                     <button
                       key={d.decisionId}
                       onClick={() => setCursor(i)}
-                      title={`${d.decisionId} · ${d.riskTier}/${d.urgency}`}
+                      title={`${d.decisionId} · ${d.riskTier ?? "未知"}/${d.urgency ?? "未知"}`}
                       className={`flex shrink-0 items-center gap-1 rounded px-2 py-1 font-mono text-[10px] ${
                         i === idx
                           ? "bg-accent text-accent-fg"

--- a/packages/gui/src/renderer/views/decisions-verdict.tsx
+++ b/packages/gui/src/renderer/views/decisions-verdict.tsx
@@ -169,7 +169,7 @@ function buildConflictRejection(d: DecisionRow): { code: string; reason: string;
  * 返回元组,lexicographic 比较即"先按 riskTier,同级再按 urgency"。
  * high=0 / medium=1 / low=2 —— 承重决策优先承重,承重同级里紧急优先。
  */
-const axisRank = (v: "high" | "medium" | "low") => (v === "high" ? 0 : v === "medium" ? 1 : 2);
+const axisRank = (v?: "high" | "medium" | "low") => (v === "high" ? 0 : v === "medium" ? 1 : v === "low" ? 2 : 3);
 export const sortKey = (d: DecisionRow): readonly [number, number] =>
   [axisRank(d.riskTier), axisRank(d.urgency)] as const;
 
@@ -306,7 +306,7 @@ export function VerdictCard({
   readOnly?: boolean;
 }) {
   const cov = coverageOf(d, facts);
-  const selfArb = d.proposedBy.id === d.arbiter?.id;
+  const selfArb = d.proposedBy?.id === d.arbiter?.id;
   const derived = derivedTasks(d, relations, tasks);
   const chain = supersedeChain(d, relations);
   // 评审深度提示:riskTier 驱动(E50 防意外:GUI 只提示不强拦)
@@ -418,7 +418,7 @@ export function VerdictCard({
       {/* 提议/批准者 + proposer≠arbiter 自证警示(actorClass 审计性展示,INV-7 已删 → 不再强拒 agent) */}
       <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-text-faint">
         <span>
-          proposedBy <span className="font-mono text-text-muted">{d.proposedBy.kind}:{d.proposedBy.id}</span>
+          proposedBy <span className="font-mono text-text-muted">{d.proposedBy ? `${d.proposedBy.kind}:${d.proposedBy.id}` : "未知/—"}</span>
         </span>
         <span>
           arbiter <span className="font-mono text-text-muted">{d.arbiter ? `${d.arbiter.kind}:${d.arbiter.id}` : "待决策批准"}</span>
@@ -485,7 +485,7 @@ export function VerdictCard({
       {/* ⑤ provenance 三字段 + 原文追溯入口 */}
       <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px]">
         <span className="text-text-faint">provenance:</span>
-        {d.provenance.map((p) => (
+        {d.provenance?.map((p) => (
           <button
             key={p.sessionId}
             onClick={() => onTrace(p.sessionId)}

--- a/packages/gui/test/fact-triage.vitest.ts
+++ b/packages/gui/test/fact-triage.vitest.ts
@@ -283,6 +283,37 @@ describe("fact-triage signal metadata", () => {
 });
 
 describe("cross-entity navigation projection", () => {
+  it("keeps absent decision DTO fields explicit instead of synthesizing placeholders", () => {
+    const rendered = buildTriadicRendererData({
+      graph: { ok: true, edges: [], coverageRows: [], factAnchors: [], warnings: [] },
+      decisions: {
+        ok: true,
+        decisions: [{
+          schema: "d4-decision-row/v1",
+          decisionId: "dec_missing",
+          state: "proposed",
+          title: "Missing fields stay unknown",
+          question: "Q?",
+          chosen: [],
+          rejected: [],
+          path: "harness/decisions/decision-dec_missing/decision.md",
+          moduleKeys: [],
+          productLineKeys: []
+        }],
+        warnings: []
+      },
+      factResults: []
+    });
+
+    expect(rendered.decisions[0]).toMatchObject({
+      decisionId: "dec_missing",
+      riskTier: undefined,
+      urgency: undefined,
+      proposedBy: undefined,
+      provenance: undefined
+    });
+  });
+
   it("derives the TaskDetail decision source from the real relation graph", () => {
     const relations = [
       edge("decision/dec_parent", "task/task_a", "derives"),

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -157,8 +157,15 @@ test("GUI bridge projects a hermetic decision-task-fact ledger into renderer dat
     });
 
     assert.deepEqual(projection.decisions.map((decision) => decision.decisionId), ["dec_gui"]);
+    assert.deepEqual(projection.decisions[0]?.riskTier, "medium");
+    assert.deepEqual(projection.decisions[0]?.urgency, "medium");
+    assert.deepEqual(projection.decisions[0]?.proposedBy, { kind: "agent", id: "codex" });
+    assert.deepEqual(projection.decisions[0]?.arbiter, { kind: "human", id: "ZeyuLi" });
+    assert.deepEqual(projection.decisions[0]?.provenance, [{ runtime: "codex", sessionId: "session-gui", boundAt: "2026-07-10T00:00:00.000Z" }]);
     assert.deepEqual(projection.facts.map((fact) => fact.anchor), ["task-1/F-12345678"]);
     assert.deepEqual(projection.facts.map((fact) => fact.confidence), ["high"]);
+    assert.deepEqual(projection.facts[0]?.source, "test");
+    assert.deepEqual(projection.facts[0]?.provenance, [{ runtime: "codex", sessionId: "session-gui", boundAt: "2026-07-10T00:00:00.000Z" }]);
     assert.deepEqual(projection.factAnchors.map((anchor) => anchor.factRef), ["fact/task-1/F-12345678"]);
     assert.deepEqual(projection.coverageRows.map((row) => row.coveringFactRef), ["fact/task-1/F-12345678"]);
     assert.deepEqual(projection.relations.map((relation) => relation.kind).sort(), [
@@ -174,6 +181,14 @@ test("GUI bridge projects a hermetic decision-task-fact ledger into renderer dat
     await waitForDaemonIdle();
     rmSync(rootDir, { recursive: true, force: true });
   }
+});
+
+test("renderer adapter contains no decision placeholder defaults", () => {
+  const adapter = readFileSync(path.join(import.meta.dirname, "../src/renderer/triadic-data.ts"), "utf8");
+
+  assert.doesNotMatch(adapter, /riskTier:\s*["']medium["']/u);
+  assert.doesNotMatch(adapter, /proposedBy:\s*\{\s*kind:\s*["']system["']/u);
+  assert.doesNotMatch(adapter, /id:\s*["']projection["']/u);
 });
 
 test("GUI service bridge preserves document results and daemon-side validation shape", async () => {

--- a/packages/kernel/src/projection/sqlite-decision-source.ts
+++ b/packages/kernel/src/projection/sqlite-decision-source.ts
@@ -59,6 +59,14 @@ function decisionDocumentToProjectionRow(rootDir: string, documentPath: string):
     path: relativeSourcePath(rootDir, documentPath),
     moduleKeys: decision.applies_to.modules,
     productLineKeys: decision.applies_to.productLines,
+    ...(decision.riskTier ? { riskTier: decision.riskTier } : {}),
+    ...(decision.urgency ? { urgency: decision.urgency } : {}),
+    ...(decision.vertical ? { vertical: decision.vertical } : {}),
+    ...(decision.preset ? { preset: decision.preset } : {}),
+    ...(decision.proposedBy ? { proposedBy: decision.proposedBy } : {}),
+    ...(decision.proposedAt ? { proposedAt: decision.proposedAt } : {}),
+    ...(decision.arbiter ? { arbiter: decision.arbiter } : {}),
+    ...(decision.provenance ? { provenance: decision.provenance } : {}),
     ...(decision.decidedAt ? { decidedAt: decision.decidedAt } : {})
   };
 }
@@ -152,6 +160,14 @@ function canonicalDecisionProjectionRow(row: DecisionProjectionRow): DecisionPro
     path: row.path,
     moduleKeys: [...row.moduleKeys],
     productLineKeys: [...row.productLineKeys],
+    ...(row.riskTier ? { riskTier: row.riskTier } : {}),
+    ...(row.urgency ? { urgency: row.urgency } : {}),
+    ...(row.vertical ? { vertical: row.vertical } : {}),
+    ...(row.preset ? { preset: row.preset } : {}),
+    ...(row.proposedBy ? { proposedBy: { ...row.proposedBy } } : {}),
+    ...(row.proposedAt ? { proposedAt: row.proposedAt } : {}),
+    ...(row.arbiter ? { arbiter: { ...row.arbiter } } : {}),
+    ...(row.provenance ? { provenance: row.provenance.map((entry) => ({ ...entry })) } : {}),
     ...(row.decidedAt ? { decidedAt: row.decidedAt } : {})
   };
 }

--- a/packages/kernel/src/projection/sqlite-projection-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-store.ts
@@ -13,7 +13,7 @@ import type {
   TaskProjectionRow
 } from "./types.ts";
 
-const projectionVersion = "entity-projection/d4-v2";
+export const projectionVersion = "entity-projection/d4-v2";
 const baseTaskProjectionColumns = [
   "task_id",
   "title",

--- a/packages/kernel/src/projection/sqlite-projection-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-store.ts
@@ -13,7 +13,7 @@ import type {
   TaskProjectionRow
 } from "./types.ts";
 
-const projectionVersion = "entity-projection/d4-v1";
+const projectionVersion = "entity-projection/d4-v2";
 const baseTaskProjectionColumns = [
   "task_id",
   "title",
@@ -105,6 +105,14 @@ export function writeProjectionDatabase(
         path TEXT NOT NULL,
         module_keys_json TEXT NOT NULL,
         product_line_keys_json TEXT NOT NULL,
+        risk_tier TEXT,
+        urgency TEXT,
+        vertical TEXT,
+        preset TEXT,
+        proposed_by_json TEXT,
+        proposed_at TEXT,
+        arbiter_json TEXT,
+        provenance_json TEXT,
         decided_at TEXT
       )
     `;
@@ -253,6 +261,7 @@ function readProjectionDatabase(
     const decisionRecords = yield* sql.unsafe<DecisionRecord>("SELECT * FROM decision_projection ORDER BY COALESCE(legacy_number, 1000000000), decision_id");
     return {
       meta: {
+        version: meta.get("version"),
         sourceHash: meta.get("sourceHash") ?? "",
         rowsHash: meta.get("rowsHash") ?? "",
         decisionRowsHash: meta.get("decisionRowsHash") ?? ""
@@ -318,11 +327,14 @@ export function insertDecisionRow(sql: SqlClient.SqlClient, row: DecisionProject
   return sql`
     INSERT OR REPLACE INTO decision_projection (
       decision_id, legacy_id, legacy_number, state, title, question, chosen_json,
-      rejected_json, path, module_keys_json, product_line_keys_json, decided_at
+      rejected_json, path, module_keys_json, product_line_keys_json, risk_tier, urgency,
+      vertical, preset, proposed_by_json, proposed_at, arbiter_json, provenance_json, decided_at
     ) VALUES (
       ${row.decisionId}, ${row.legacyId ?? null}, ${row.legacyId ? legacyNumberFromLabel(row.legacyId) ?? null : null},
       ${row.state}, ${row.title}, ${row.question}, ${JSON.stringify(row.chosen)}, ${JSON.stringify(row.rejected)},
-      ${row.path}, ${JSON.stringify(row.moduleKeys)}, ${JSON.stringify(row.productLineKeys)}, ${row.decidedAt ?? null}
+      ${row.path}, ${JSON.stringify(row.moduleKeys)}, ${JSON.stringify(row.productLineKeys)}, ${row.riskTier ?? null}, ${row.urgency ?? null},
+      ${row.vertical ?? null}, ${row.preset ?? null}, ${row.proposedBy ? JSON.stringify(row.proposedBy) : null}, ${row.proposedAt ?? null},
+      ${row.arbiter ? JSON.stringify(row.arbiter) : null}, ${row.provenance ? JSON.stringify(row.provenance) : null}, ${row.decidedAt ?? null}
     )
   `;
 }
@@ -386,6 +398,14 @@ interface DecisionRecord {
   readonly path: string;
   readonly module_keys_json: string;
   readonly product_line_keys_json: string;
+  readonly risk_tier: string | null;
+  readonly urgency: string | null;
+  readonly vertical: string | null;
+  readonly preset: string | null;
+  readonly proposed_by_json: string | null;
+  readonly proposed_at: string | null;
+  readonly arbiter_json: string | null;
+  readonly provenance_json: string | null;
   readonly decided_at: string | null;
 }
 
@@ -437,6 +457,14 @@ function recordToDecisionRow(record: DecisionRecord): DecisionProjectionRow {
     path: record.path,
     moduleKeys: JSON.parse(record.module_keys_json) as ReadonlyArray<string>,
     productLineKeys: JSON.parse(record.product_line_keys_json) as ReadonlyArray<string>,
+    ...(record.risk_tier ? { riskTier: record.risk_tier as DecisionProjectionRow["riskTier"] } : {}),
+    ...(record.urgency ? { urgency: record.urgency as DecisionProjectionRow["urgency"] } : {}),
+    ...(record.vertical ? { vertical: record.vertical } : {}),
+    ...(record.preset ? { preset: record.preset } : {}),
+    ...(record.proposed_by_json ? { proposedBy: JSON.parse(record.proposed_by_json) as NonNullable<DecisionProjectionRow["proposedBy"]> } : {}),
+    ...(record.proposed_at ? { proposedAt: record.proposed_at } : {}),
+    ...(record.arbiter_json ? { arbiter: JSON.parse(record.arbiter_json) as NonNullable<DecisionProjectionRow["arbiter"]> } : {}),
+    ...(record.provenance_json ? { provenance: JSON.parse(record.provenance_json) as NonNullable<DecisionProjectionRow["provenance"]> } : {}),
     ...(record.decided_at ? { decidedAt: record.decided_at } : {})
   };
 }

--- a/packages/kernel/src/projection/sqlite-task-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-projection.ts
@@ -5,7 +5,7 @@ import { resolveHarnessLayout } from "../layout/index.ts";
 import { buildCheckReport, hardFail, runPostMergeChecks, warning } from "./post-merge-checks.ts";
 import type { FactAnchorRow, RelationCoverageRow, RelationGraphEdgeRow } from "./relation-graph-projection.ts";
 import { buildRelationGraphProjection } from "./relation-graph-projection.ts";
-import { queryDecisionProjectionRows, queryTaskChildrenRows, queryTaskProjectionRows, queryTaskSubtreeRows, readRelationGraphRows, writeProjectionDatabase, tryReadProjectionDatabase } from "./sqlite-projection-store.ts";
+import { projectionVersion, queryDecisionProjectionRows, queryTaskChildrenRows, queryTaskProjectionRows, queryTaskSubtreeRows, readRelationGraphRows, writeProjectionDatabase, tryReadProjectionDatabase } from "./sqlite-projection-store.ts";
 import { compareDecisionRows, hashDecisionProjectionRows, readDecisionProjectionRows } from "./sqlite-decision-source.ts";
 import { compareRows, hashExactRows, readMarkdownSource, taskEntryToRow } from "./sqlite-task-source.ts";
 export { hashTaskProjectionRows } from "./sqlite-task-source.ts";
@@ -97,7 +97,7 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
     return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
   }
 
-  if (existing.meta.version !== "entity-projection/d4-v2") {
+  if (existing.meta.version !== projectionVersion) {
     warnings.push(warning(
       "generated-cache",
       "projection_stale",

--- a/packages/kernel/src/projection/sqlite-task-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-projection.ts
@@ -97,6 +97,17 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
     return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
   }
 
+  if (existing.meta.version !== "entity-projection/d4-v2") {
+    warnings.push(warning(
+      "generated-cache",
+      "projection_stale",
+      "Projection cache schema version was stale and has been rebuilt from markdown.",
+      "Run harness-anything governance rebuild after upgrading projection schema."
+    ));
+    const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
+    return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
+  }
+
   if (existing.meta.sourceHash !== source.hash) {
     warnings.push(warning(
       "generated-cache",

--- a/packages/kernel/src/projection/types.ts
+++ b/packages/kernel/src/projection/types.ts
@@ -107,6 +107,14 @@ export interface DecisionProjectionRow {
   readonly path: string;
   readonly moduleKeys: ReadonlyArray<string>;
   readonly productLineKeys: ReadonlyArray<string>;
+  readonly riskTier?: "low" | "medium" | "high";
+  readonly urgency?: "low" | "medium" | "high";
+  readonly vertical?: string;
+  readonly preset?: string;
+  readonly proposedBy?: { readonly kind: "agent" | "human" | "system"; readonly id: string };
+  readonly proposedAt?: string;
+  readonly arbiter?: { readonly kind: "agent" | "human" | "system"; readonly id: string };
+  readonly provenance?: ReadonlyArray<{ readonly runtime: string; readonly sessionId: string; readonly boundAt: string }>;
   readonly decidedAt?: string;
 }
 
@@ -169,6 +177,7 @@ export interface TaskProjectionOptions {
 }
 
 export interface ProjectionMeta {
+  readonly version?: string;
   readonly sourceHash: string;
   readonly rowsHash: string;
   readonly decisionRowsHash?: string;

--- a/packages/kernel/test/store/sqlite-rebuild.test.ts
+++ b/packages/kernel/test/store/sqlite-rebuild.test.ts
@@ -4,7 +4,7 @@ import { mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { Effect, Option } from "effect";
-import { checkTaskProjection, hashTaskProjectionRows, readTaskProjection, rebuildTaskProjection } from "../../src/index.ts";
+import { checkTaskProjection, hashTaskProjectionRows, queryDecisionProjection, readTaskProjection, rebuildTaskProjection } from "../../src/index.ts";
 import { makeJournaledWriteCoordinator, makeMarkdownArtifactStore } from "../../src/store/index.ts";
 import { docWrite, withTempStore } from "./helpers.ts";
 
@@ -99,13 +99,42 @@ test("SQLite projection rebuild materializes decision rows for query readers", (
     const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
     const db = new DatabaseSync(projectionPath, { readOnly: true });
     try {
-      const row = db.prepare("SELECT decision_id, legacy_id, state FROM decision_projection WHERE legacy_id = ?").get("E72") as Record<string, unknown>;
+      const row = db.prepare("SELECT decision_id, legacy_id, state, risk_tier, urgency, vertical, preset, proposed_by_json, proposed_at, arbiter_json, provenance_json FROM decision_projection WHERE legacy_id = ?").get("E72") as Record<string, unknown>;
       assert.equal(row.decision_id, "dec_M5_E72_SELFHOST");
       assert.equal(row.legacy_id, "E72");
       assert.equal(row.state, "active");
+      assert.equal(row.risk_tier, "medium");
+      assert.equal(row.urgency, "medium");
+      assert.equal(row.vertical, "software/coding");
+      assert.equal(row.preset, "architecture-decision");
+      assert.deepEqual(JSON.parse(String(row.proposed_by_json)), { kind: "agent", id: "test" });
+      assert.equal(row.proposed_at, "2026-07-04T00:00:00.000Z");
+      assert.deepEqual(JSON.parse(String(row.arbiter_json)), { kind: "human", id: "ZeyuLi" });
+      assert.deepEqual(JSON.parse(String(row.provenance_json)), [{ runtime: "human", sessionId: "human-cli-1", boundAt: "2026-07-04T00:00:00.000Z" }]);
     } finally {
       db.close();
     }
+  });
+});
+
+test("SQLite projection rebuilds stale schema versions before serving decision DTO rows", () => {
+  withTempStore((rootDir) => {
+    writeIndex(rootDir, "task-1", "Task One", "active");
+    writeDecision(rootDir, "dec_M5_E72_SELFHOST", "wm-1");
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const db = new DatabaseSync(projectionPath);
+    try {
+      db.prepare("UPDATE projection_meta SET value = ? WHERE key = 'version'").run("entity-projection/d4-v1");
+    } finally {
+      db.close();
+    }
+
+    const result = queryDecisionProjection({ rootDir, filters: {} });
+
+    assert.equal(result.warnings.some((warning) => warning.code === "projection_stale"), true);
+    assert.deepEqual(result.rows[0]?.proposedBy, { kind: "agent", id: "test" });
+    assert.deepEqual(result.rows[0]?.provenance, [{ runtime: "human", sessionId: "human-cli-1", boundAt: "2026-07-04T00:00:00.000Z" }]);
   });
 });
 


### PR DESCRIPTION
# English

## Summary

Enrich the public read projection so the GUI receives real decision attribution/risk fields (`riskTier`, `urgency`, `proposedBy`, `proposedAt`, `arbiter`, `provenance`, `vertical`, `preset`) and fact `source`/`provenance`, end-to-end from kernel SQLite through application/daemon DTOs to the renderer. Removes all fabricated GUI placeholder values (hardcoded `medium` risk, `system/projection` proposer, Unix-epoch timestamps, empty provenance) and renders missing values as an explicit unknown state instead. Authorized by decision `dec_mrf2nzvf` (claim C2: the gap is in the kernel projection row contract, not the route layer).

## What Changed

- kernel: `DecisionProjectionRow` gains optional decision fields; `sqlite-decision-source` passes them through (parser already read them); `decision_projection` table gains nullable columns with insert/read round-trip; `FactProjectionRow` gains `source`/`provenance`.
- kernel schema evolution: `projectionVersion` bumped `entity-projection/d4-v1` -> `d4-v2`; the read path now compares the stored `projection_meta.version` and, on mismatch (including legacy caches without a version), emits the existing `projection_stale` warning and rebuilds via the existing `rebuildTaskProjection` path. No ALTER or new migration mechanism.
- application: row reuse points and `toFactProjectionRow` pass the new fields through unchanged.
- GUI: `triadic-data.ts` is now a pure DTO adapter (all placeholder literals deleted); `DecisionRow` model types widened to optional; badges, sorting, filtering, time ranges, verdict cards, decision pool, fact inspector, graph drawer render explicit "unknown" for missing values and never synthesize data. Daemon transit needs no route changes: the contract registry maps service methods dynamically.
- tests: kernel sqlite round-trip and stale-version rebuild; application field fidelity; daemon/service-bridge passthrough; GUI vitest for missing-value rendering plus a regression assertion that the old placeholder literals do not reappear.
- follow-up commit: the stale-cache check references the shared `projectionVersion` constant instead of a duplicated string literal, so a future version bump cannot silently desynchronize the check.
- follow-up commit: `check-service-mappability` (CI boundaries job) flagged the new `proposedBy`/`arbiter`/`provenance` fields for using inline object types on the Service contract surface; they now use named types `DecisionProjectionActor` and `ProjectionProvenanceEntry`.

## Task And Scope

- Harness task: task_01KX69AFMASEZZCFEXZA0YQ9FP
- Branch: codex/gui-dto-enrichment
- Public scope: packages/kernel/src/projection, packages/application, packages/gui, plus tests
- Private planning/evidence updated: yes
- Out of scope: `packages/cli/src/commands/extensions/` (untouched), write-path commands, any new migration framework

## Version Impact

- Version: no version change because this is a read-projection contract enrichment consumed by the workspace GUI; no published artifact changes.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: decision dec_mrf2nzvf (accepted; C2 amendment covers the kernel projection-row scope)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: acd234a3fd8f0cc856ef0344c410eb0c306bed98
- Branch merge-base with `origin/main`: acd234a3fd8f0cc856ef0344c410eb0c306bed98
- Last `git fetch origin` time: 2026-07-11 00:20 (+08:00)
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/gui-dto-enrichment`
- Private evidence commit/path: harness task package artifacts (impl-report with field-mapping table, schema-evolution rationale, test matrix)
- Reviewer evidence path: same impl-report
- GitHub Actions `rewrite-ci` run URL: pending (will be attached by CI on this PR)
- [x] `npm run check` (via `npm run check:local`, fast tier, 16 local steps)
- [x] `npm run typecheck` (within check:local)
- [x] `npm test` (targeted: kernel sqlite-rebuild + application local-controller-service + gui service-bridge, 31/31; GUI vitest fact-triage 17/17)
- [x] `git diff --check`
- [x] `npm run harness:check-import-boundaries` (within check:local)
- [x] `npm run harness:scan-forbidden-symbols` (within check:local)
- [x] `npm run harness:check-private-boundary` (within check:local)
- [x] `npm run harness:check-package-policy` (within check:local)
- [x] `npm run harness:check-implementation-contracts` (within check:local)
- [x] `npm run harness:check-schema-contracts` (within check:local)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` (workspace already installed; check:local validates the tree), `npm run harness:check-legacy-intake-readiness` and `npm run harness:smoke-cli-package` (not in the fast tier; covered by cloud CI on this PR), full integration shards (covered by cloud CI)

## Review Evidence

- Self-review: worker implementation report with field-mapping table; CEO line-level review of the placeholder removal, sqlite schema/insert/read round-trip, and stale-version rebuild wiring
- Reviewer subagent: not used; CEO reviewed the diff directly
- Human review: pending on this PR
- Blocking findings: (1) acceptance found the version check used a duplicated string literal instead of the shared constant — fixed; (2) CI `check-service-mappability` rejected inline object types on the Service contract — fixed with named types. Both fixed in follow-up commits on this branch.

## Residual Risk

- Existing projection caches are rebuilt once on first read after upgrade (by design, via the existing rebuild path); a large ledger pays a one-time rebuild cost.
- GUI unknown-state copy ("未知"/"—") is a rendering convention, not yet a design-reviewed spec; visual acceptance of the triage views remains a separate dogfood item.

## References

- Task: task_01KX69AFMASEZZCFEXZA0YQ9FP
- Evidence: decision dec_mrf2nzvf (C2), task package impl-report
- Review: this PR

---

# 中文

## 概要

增强公共读投影，让 GUI 拿到真实的决策归属/风险字段（`riskTier`、`urgency`、`proposedBy`、`proposedAt`、`arbiter`、`provenance`、`vertical`、`preset`）与 fact 的 `source`/`provenance`，全链从 kernel SQLite 经 application/daemon DTO 到 renderer。删除 GUI 全部编造占位值（硬编码 `medium` 风险、`system/projection` 提议者、Unix 纪元时间戳、空 provenance），缺值改为显式未知态渲染。授权决策 `dec_mrf2nzvf`（C2 声明：缺口在 kernel 投影行契约，不在路由层）。

## 改动内容

- kernel：`DecisionProjectionRow` 增加可选决策字段；`sqlite-decision-source` 透传（parser 本就读到这些字段）；`decision_projection` 表新增可空列并打通 insert/读回；`FactProjectionRow` 增加 `source`/`provenance`。
- kernel schema 演进：`projectionVersion` 从 `entity-projection/d4-v1` 提升到 `d4-v2`；读取端现在比对已落盘的 `projection_meta.version`，不匹配（含无 version 的旧缓存）即发出既有 `projection_stale` warning 并走既有 `rebuildTaskProjection` 重建。无 ALTER、无新迁移机制。
- application：row 复用点与 `toFactProjectionRow` 原样透传新字段。
- GUI：`triadic-data.ts` 改为纯 DTO 适配（占位字面量全部删除）；`DecisionRow` 模型类型放宽为可选；badge、排序、筛选、时间范围、裁决卡片、决策池、fact inspector、graph drawer 对缺值显式渲染「未知/—」，不合成数据。daemon 中转无需改路由：契约注册表动态映射 service method。
- 测试：kernel sqlite 回读与旧版本重建；application 字段保真；daemon/service-bridge 透传；GUI vitest 缺值渲染 + 旧占位字面量不回归的断言。
- 追加提交：stale 缓存判定改为引用共享 `projectionVersion` 常量而非重复字符串字面量，避免未来 bump 版本时判定静默失联。
- 追加提交：CI boundaries 的 `check-service-mappability` 判红——Service 契约面上新字段 `proposedBy`/`arbiter`/`provenance` 用了内联对象类型；已改为命名类型 `DecisionProjectionActor` 与 `ProjectionProvenanceEntry`。

## 任务与范围

- Harness 任务：task_01KX69AFMASEZZCFEXZA0YQ9FP
- 分支：codex/gui-dto-enrichment
- 公开范围：packages/kernel/src/projection、packages/application、packages/gui 及测试
- 私有计划 / 证据是否已更新：yes
- 范围外：`packages/cli/src/commands/extensions/`（零触碰）、写路径命令、任何新迁移框架

## 版本影响

- 版本：不改版本，原因是本改动为 workspace GUI 消费的读投影契约增强，无已发布工件变化。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：decision dec_mrf2nzvf（accepted；C2 修正覆盖 kernel 投影行范围）
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：acd234a3fd8f0cc856ef0344c410eb0c306bed98
- 当前分支与 `origin/main` 的 merge-base：acd234a3fd8f0cc856ef0344c410eb0c306bed98
- 最近一次 `git fetch origin` 时间：2026-07-11 00:20（+08:00）
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...codex/gui-dto-enrichment`
- 私有证据 commit/path：harness 任务包 artifacts（impl-report 含字段映射终表、schema 演进依据、测试矩阵）
- Reviewer 证据路径：同 impl-report
- GitHub Actions `rewrite-ci` run URL：待本 PR CI 附上
- [x] `npm run check`（经 `npm run check:local` fast 档，16 步本地检查）
- [x] `npm run typecheck`（含于 check:local）
- [x] `npm test`（定向：kernel sqlite-rebuild + application local-controller-service + gui service-bridge 共 31/31；GUI vitest fact-triage 17/17）
- [x] `git diff --check`
- [x] `npm run harness:check-import-boundaries`（含于 check:local）
- [x] `npm run harness:scan-forbidden-symbols`（含于 check:local）
- [x] `npm run harness:check-private-boundary`（含于 check:local）
- [x] `npm run harness:check-package-policy`（含于 check:local）
- [x] `npm run harness:check-implementation-contracts`（含于 check:local）
- [x] `npm run harness:check-schema-contracts`（含于 check:local）
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci`（workspace 已安装，check:local 校验现树）、`npm run harness:check-legacy-intake-readiness` 与 `npm run harness:smoke-cli-package`（不在 fast 档，由本 PR 云端 CI 覆盖）、完整 integration shard（云端 CI 覆盖）

## 审查证据

- 自查：worker 实现报告含字段映射终表；CEO 对占位删除、sqlite schema/insert/读回与旧版本重建接线做了行级复核
- Reviewer subagent：未使用；CEO 直接复核 diff
- 人工审查：待本 PR
- 阻塞发现：(1) 验收抓到版本判定用重复字符串字面量而非共享常量——已修；(2) CI `check-service-mappability` 拒绝 Service 契约面内联对象类型——已用命名类型修复。两处均在本分支追加提交。

## 残余风险

- 升级后既有投影缓存首次读取会整体重建一次（设计如此，走既有重建路径）；大台账付一次性重建成本。
- GUI 未知态文案（「未知/—」）是渲染约定，尚非设计评审过的规范；triage 视图的视觉验收仍是独立 dogfood 项。

## 关联材料

- 任务：task_01KX69AFMASEZZCFEXZA0YQ9FP
- 证据：decision dec_mrf2nzvf（C2）、任务包 impl-report
- 审查：本 PR

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
