### PR TITLE
fix: emit taskId in preset run success receipts and align receipt contract

### DIFF
--- a/packages/cli/src/cli/command-spec/command-spec-extensions.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-extensions.ts
@@ -153,7 +153,10 @@ export const extensionsCommandSpecs = defineCommandSpecs([
     "parse": parsePresetArgs,
     "run": runExtensionRunnerCommand,
     "receiptContract": {
-      "data": ["taskId", "preset", "evidenceBundle", "generated", "rows", "report"],
+      "data": ["taskId", "preset", "evidenceBundle", "generated", "report"],
+      "optionalData": {
+        "rows": "Only emitted when a scripted preset run writes a numeric rows value in its result."
+      },
       "paths": []
     },
     "eventPolicy": {
@@ -170,9 +173,8 @@ export const extensionsCommandSpecs = defineCommandSpecs([
     "parse": parsePresetArgs,
     "run": runExtensionRunnerCommand,
     "receiptContract": {
-      "data": ["preset", "evidenceBundle", "generated", "report"],
+      "data": ["taskId", "preset", "evidenceBundle", "generated", "report"],
       "optionalData": {
-        "taskId": "Only emitted by scripted preset actions that echo the task id in their script result.",
         "rows": "Only emitted when a scripted preset action writes a numeric rows value in its result."
       },
       "paths": []

--- a/packages/cli/src/commands/extensions/preset-script-runner.ts
+++ b/packages/cli/src/commands/extensions/preset-script-runner.ts
@@ -468,6 +468,7 @@ export function scriptCliResult(options: {
   readonly evidenceDir: string;
   readonly commandName: "preset-run" | "preset-action";
   readonly preset: unknown;
+  readonly taskId: string;
   readonly generated: ReadonlyArray<string>;
   readonly scriptedResult: Record<string, unknown>;
 }): CliResult {
@@ -477,6 +478,7 @@ export function scriptCliResult(options: {
     ok,
     command: options.commandName,
     preset: options.preset,
+    taskId: options.taskId,
     evidenceBundle: path.relative(options.rootDir, options.evidenceDir).split(path.sep).join("/"),
     generated: options.generated,
     warnings: Array.isArray(options.scriptedResult.warnings) ? options.scriptedResult.warnings : undefined,

--- a/packages/cli/src/commands/extensions/state.ts
+++ b/packages/cli/src/commands/extensions/state.ts
@@ -348,6 +348,7 @@ export function runPresetEntrypoint(
         evidenceDir,
         commandName,
         preset: presetSummary,
+        taskId,
         generated,
         scriptedResult: scriptResult.scriptedResult
       });
@@ -380,6 +381,7 @@ export function runPresetEntrypoint(
     ok: true,
     command: commandName,
     preset: publicPresetSummary(preset),
+    taskId,
     evidenceBundle: path.relative(rootDir, evidenceDir).split(path.sep).join("/"),
     generated,
     report: evidence

--- a/packages/cli/test/preset-script-imports-cli.test.ts
+++ b/packages/cli/test/preset-script-imports-cli.test.ts
@@ -421,3 +421,55 @@ function writePolicyCapturePreset(
     ""
   ].join("\n"));
 }
+
+test("CLI preset run scripted success emits a contract-complete receipt", () => {
+  withCanonicalTempRoot((rootDir) => {
+    writeProcessPreset(rootDir, "run-receipt", "Run Receipt", "scripts/preset-action.mjs");
+    writeFile(rootDir, ".harness/presets/run-receipt/scripts/preset-action.mjs", [
+      "#!/usr/bin/env node",
+      "import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';",
+      "import path from 'node:path';",
+      "const context = JSON.parse(readFileSync(process.env.HARNESS_PRESET_CONTEXT, 'utf8'));",
+      "mkdirSync(path.join(context.outputRoot, 'artifacts'), { recursive: true });",
+      "writeFileSync(path.join(context.outputRoot, 'artifacts/preset-result.json'), JSON.stringify({",
+      "  schema: 'script-result/v1',",
+      "  ok: true,",
+      "  rows: 2,",
+      "  report: { schema: 'run-receipt-report/v1' }",
+      "}), 'utf8');",
+      ""
+    ].join("\n"));
+
+    const result = runJson(rootDir, ["preset", "run", "run-receipt", "scaffold", "--task", "task-1", "--allow-scripts"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.taskId, "task-1");
+    assert.equal(result.rows, 2);
+    assert.equal(result.report.schema, "run-receipt-report/v1");
+  });
+});
+
+test("CLI preset run scripted success without rows still passes the receipt contract", () => {
+  withCanonicalTempRoot((rootDir) => {
+    writeProcessPreset(rootDir, "run-no-rows", "Run No Rows", "scripts/preset-action.mjs");
+    writeFile(rootDir, ".harness/presets/run-no-rows/scripts/preset-action.mjs", [
+      "#!/usr/bin/env node",
+      "import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';",
+      "import path from 'node:path';",
+      "const context = JSON.parse(readFileSync(process.env.HARNESS_PRESET_CONTEXT, 'utf8'));",
+      "mkdirSync(path.join(context.outputRoot, 'artifacts'), { recursive: true });",
+      "writeFileSync(path.join(context.outputRoot, 'artifacts/preset-result.json'), JSON.stringify({",
+      "  schema: 'script-result/v1',",
+      "  ok: true,",
+      "  report: { schema: 'run-no-rows-report/v1' }",
+      "}), 'utf8');",
+      ""
+    ].join("\n"));
+
+    const result = runJson(rootDir, ["preset", "run", "run-no-rows", "scaffold", "--task", "task-1", "--allow-scripts"]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.taskId, "task-1");
+    assert.equal(result.rows, undefined);
+  });
+});

--- a/packages/cli/test/receipt-contracts.test.ts
+++ b/packages/cli/test/receipt-contracts.test.ts
@@ -197,9 +197,9 @@ test("optional receipt contract fields carry non-empty absence reasons", () => {
     field: "data.generated",
     reason: "Only emitted for apply/archive rebuild modes that write generated governance views."
   }, {
-    command: "preset-action",
-    field: "data.taskId",
-    reason: "Only emitted by scripted preset actions that echo the task id in their script result."
+    command: "preset-run",
+    field: "data.rows",
+    reason: "Only emitted when a scripted preset run writes a numeric rows value in its result."
   }, {
     command: "preset-action",
     field: "data.rows",

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -431,17 +431,17 @@
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#mkdirSync@357:5",
+        "value": "packages/cli/src/commands/extensions/state.ts#mkdirSync@358:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@358:5",
+        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@359:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@378:3",
+        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@379:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },


### PR DESCRIPTION
# English

## Summary

Every successful `preset run` receipt violated its own declared receipt contract: the contract required `data.taskId` and `data.rows`, but neither success path (scripted or template) ever emitted `taskId`, and `rows` is only present when a script chooses to write one. Failure receipts skip contract validation, so the defect was invisible until success-path coverage was added. This PR makes both success paths emit `taskId`, moves `rows` to `optionalData` for `preset-run`, promotes `taskId` to required data for `preset-action`, and adds the first success-path receipt contract tests.

## What Changed

- `preset-script-runner.ts`: `scriptCliResult` now receives and emits `taskId` in the returned `CliResult`.
- `state.ts`: the scripted call site passes `taskId`; the template-path tail success return now includes `taskId`.
- `command-spec-extensions.ts`: `preset-run` contract requires `data.taskId` and declares `rows` as `optionalData` with an absence reason; `preset-action` moves `taskId` from `optionalData` into required `data`.
- `preset-script-imports-cli.test.ts`: two new tests assert a scripted success receipt is contract-complete with and without `rows`.
- `receipt-contracts.test.ts`: optional-field characterization inventory updated to match the contract change.
- `tools/gate-allowlists/check-bypass-write-boundary.json`: repinned three existing `state.ts` line anchors shifted by the one-line `taskId` addition (357→358, 358→359, 378→379); entry count unchanged (125, delta=0), no new exemptions.

## Task And Scope

- Harness task: task_01KX6CXX3YGQV9C9QG7T78Y4C6 (architecture-stability night, batch A)
- Branch: fix/preset-run-receipt-taskid
- Public scope: packages/cli receipt contract + preset run/action success paths + tests
- Private planning/evidence updated: yes
- Out of scope: preset-action script behavior, receipt validation of failure receipts, any CLI core preset branching

## Version Impact

- Version: no version change because this is a contract-honesty bug fix within the unpublished workspace CLI
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-allowlists/check-bypass-write-boundary.json` — line-anchor repin only for three pre-existing `state.ts` entries displaced by this diff; no entries added or removed (125 before and after, checker reports delta=0).
- Authority: task task_01KX6CXX3YGQV9C9QG7T78Y4C6 (architecture-stability night, batch A); same repin pattern as main commit 6d94455 (`fix: repin write-boundary allowlist to shifted state.ts lines`).
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none — no gate semantics changed

## Verification

- Base `origin/main` SHA: bf32048
- Branch merge-base with `origin/main`: bf32048
- Last `git fetch origin` time: 2026-07-11 00:40 (+08:00)
- Sync method: rebase
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: night-plan batch A entry in the harness task package
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] `npm run check:local` (fast tier; includes typecheck, lint, contract, unit, boundary checks)
- [x] targeted: `packages/cli/test/preset-script-imports-cli.test.ts` (11/11) and `packages/cli/test/receipt-contracts.test.ts` (11/11)
- [ ] GitHub Actions `rewrite-ci` passed (queue gate)
- Not run: full `npm run check` / `npm test` locally — delegated to `rewrite-ci` on this PR per local-check throttle policy (dec_mr9fs0bc)

## Review Evidence

- Self-review: diff re-read against the receipt contract validator (`receipt.ts` validates `contract.data` as required and `optionalData` as allowed; failure receipts skip validation)
- Reviewer subagent: none (small, test-anchored fix)
- Human review: merge-queue reviewers
- Blocking findings: none

## Residual Risk

- Failure receipts still skip contract validation by design; a dishonest failure payload would not be caught by this contract. Catalogued for a follow-up, out of scope here.

## References

- Task: task_01KX6CXX3YGQV9C9QG7T78Y4C6
- Evidence: red→green test pair in preset-script-imports-cli.test.ts (both tests fail on main, pass with this fix)
- Review: this PR

---

# 中文

## 概要

每一条成功的 `preset run` 回执都违反它自己声明的回执契约：契约要求 `data.taskId` 与 `data.rows`，但两条成功路径（脚本路径与模板路径）都从未产出 `taskId`，而 `rows` 只有脚本主动写入时才存在。失败回执跳过契约校验，所以在补上成功路径覆盖之前该缺陷不可见。本 PR 让两条成功路径都产出 `taskId`，把 `preset-run` 的 `rows` 挪到 `optionalData`，把 `preset-action` 的 `taskId` 提升为必填 data，并补上首批成功路径回执契约测试。

## 改动内容

- `preset-script-runner.ts`：`scriptCliResult` 现在接收并在返回的 `CliResult` 中产出 `taskId`。
- `state.ts`：脚本路径调用点传入 `taskId`；模板路径尾部成功返回补上 `taskId`。
- `command-spec-extensions.ts`：`preset-run` 契约必填 `data.taskId`，`rows` 改为带缺失原因的 `optionalData`；`preset-action` 的 `taskId` 从 `optionalData` 移入必填 `data`。
- `preset-script-imports-cli.test.ts`：新增两条测试，断言脚本成功回执在带/不带 `rows` 时都契约完整。
- `receipt-contracts.test.ts`：optional 字段 characterization 清单同步契约变更。
- `tools/gate-allowlists/check-bypass-write-boundary.json`：repin 三条既有 `state.ts` 行号锚（因新增一行 `taskId` 位移：357→358、358→359、378→379）；条目数不变（125，delta=0），无新增豁免。

## 任务与范围

- Harness 任务：task_01KX6CXX3YGQV9C9QG7T78Y4C6（架构稳定修复夜，批次 A）
- 分支：fix/preset-run-receipt-taskid
- 公开范围：packages/cli 回执契约 + preset run/action 成功路径 + 测试
- 私有计划 / 证据是否已更新：yes
- 范围外：preset-action 脚本行为、失败回执的契约校验、任何 CLI core 的 preset 分支逻辑

## 版本影响

- 版本：不改版本，原因是这是未发布 workspace CLI 内的契约诚实性修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/gate-allowlists/check-bypass-write-boundary.json`——仅对本 diff 位移的三条既有 `state.ts` 条目做行号锚 repin；不增不删（前后均 125 条，checker 报 delta=0）。
- 依据：任务 task_01KX6CXX3YGQV9C9QG7T78Y4C6（架构稳定修复夜批次 A）；与 main 提交 6d94455（`fix: repin write-boundary allowlist to shifted state.ts lines`）同一修法先例。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无——未改变任何 gate 语义

## 验证

- `origin/main` 基准 SHA：bf32048
- 当前分支与 `origin/main` 的 merge-base：bf32048
- 最近一次 `git fetch origin` 时间：2026-07-11 00:40（+08:00）
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：harness 任务包中的夜计划批次 A 条目
- Reviewer 证据路径：见审查证据
- GitHub Actions `rewrite-ci` run URL：待本 PR CI 回填
- [x] `npm run check:local`（fast 档；含 typecheck、lint、contract、unit、boundary 检查）
- [x] 定向：`packages/cli/test/preset-script-imports-cli.test.ts`（11/11）与 `packages/cli/test/receipt-contracts.test.ts`（11/11）
- [ ] GitHub Actions `rewrite-ci` passed（队列门）
- 未运行：本地完整 `npm run check` / `npm test`——按本地减负策略（dec_mr9fs0bc）交由本 PR 的 `rewrite-ci` 执行

## 审查证据

- 自查：对照回执契约校验器重读 diff（`receipt.ts` 把 `contract.data` 当必填、`optionalData` 当允许；失败回执跳过校验）
- Reviewer subagent：无（小型、测试锚定的修复）
- 人工审查：merge-queue reviewers
- 阻塞发现：无

## 残余风险

- 失败回执按设计仍跳过契约校验；不诚实的失败 payload 不会被本契约抓住。已编目为后续项，不在本 PR 范围。

## 关联材料

- 任务：task_01KX6CXX3YGQV9C9QG7T78Y4C6
- 证据：preset-script-imports-cli.test.ts 中的红→绿测试对（两条测试在 main 上红、带本修复绿）
- 审查：本 PR
