### PR TITLE
fix: preserve CLI failure observability (repeated evidence, attribution warnings, journal cause anchor)

### DIFF
--- a/packages/cli/src/cli/command-runtime-events.ts
+++ b/packages/cli/src/cli/command-runtime-events.ts
@@ -68,7 +68,12 @@ function eventEntityRefs(
 function commandRuntimeEventActor(context: CommandRunnerContext) {
   try {
     return runtimeEventActorFromTaskHolderPrincipal(context.taskHolderPrincipal());
-  } catch {
+  } catch (error) {
+    process.stderr.write(`warning: runtime event actor attribution unavailable: ${runtimeEventActorResolutionMessage(error)}\n`);
     return undefined;
   }
+}
+
+function runtimeEventActorResolutionMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/cli/src/cli/command-spec/command-spec-core.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-core.ts
@@ -204,9 +204,9 @@ export const coreCommandSpecs = defineCommandSpecs([
   },
   {
     "kind": "progress-append",
-    "usage": "task progress append <id> --text <text> [--evidence type:PATH:summary]",
-    "options": [{"flag":"--text","description":"Progress text appended as-is (no Markdown formatting or normalization)."},{"flag":"--evidence","description":"Attach evidence in type:path:summary format."}],
-    "summary": "Append the provided text as-is to a task package, with optional evidence; no Markdown formatting or normalization is applied.",
+    "usage": "task progress append <id> --text <text> [--evidence type:PATH:summary]...",
+    "options": [{"flag":"--text","description":"Progress text appended as-is (no Markdown formatting or normalization)."},{"flag":"--evidence","description":"Attach evidence in type:path:summary format; repeat for multiple entries."}],
+    "summary": "Append the provided text as-is to a task package, with optional repeatable evidence; no Markdown formatting or normalization is applied.",
     "examples": ["harness-anything task progress append task_01ABC --text \"Implemented parser guard\" --evidence log:artifacts/check.log:passed"],
     "parse": parseCoreTaskArgs,
     "run": runTaskLifecycleCommand,

--- a/packages/cli/src/cli/parsers/core-task.ts
+++ b/packages/cli/src/cli/parsers/core-task.ts
@@ -1,7 +1,7 @@
 import { domainStatuses, isDomainStatus } from "../../../../kernel/src/index.ts";
 import { slugifyTaskTitle } from "../../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../error-codes.ts";
-import { readOption, readRequiredValueOption } from "../parse-options.ts";
+import { readOption, readRepeatedRawOption, readRequiredValueOption } from "../parse-options.ts";
 import type { CliResult, ParsedCommand } from "../types.ts";
 import { parseTaskArchive } from "./core-task-archive.ts";
 import { parseTaskCodeDocReconcile } from "./core-task-code-doc.ts";
@@ -81,7 +81,7 @@ function parseProgressAppend(args: ReadonlyArray<string>, rootDir: string, json:
   if (!text) {
     return { ok: false, error: cliError(CliErrorCode.MissingText, "Use --text for progress append.") };
   }
-  const evidence = parseEvidence(readOption(args, "--evidence"));
+  const evidence = parseEvidence(readRepeatedRawOption(args, "--evidence"));
   if (!evidence.ok) return { ok: false, error: evidence.error };
   return ok(rootDir, json, {
     kind: "progress-append",
@@ -214,14 +214,20 @@ function parseTaskRelate(args: ReadonlyArray<string>, rootDir: string, json: boo
   });
 }
 
-function parseEvidence(value: string | undefined):
-  | { readonly ok: true; readonly value?: { readonly type: string; readonly path: string; readonly summary: string } }
+function parseEvidence(values: ReadonlyArray<string | undefined>):
+  | { readonly ok: true; readonly value?: ReadonlyArray<{ readonly type: string; readonly path: string; readonly summary: string }> }
   | { readonly ok: false; readonly error: NonNullable<CliResult["error"]> } {
-  if (!value) return { ok: true };
-  const [type, evidencePath, ...summaryParts] = value.split(":");
-  return type && evidencePath && summaryParts.length > 0
-    ? { ok: true, value: { type, path: evidencePath, summary: summaryParts.join(":") } }
-    : { ok: false, error: cliError(CliErrorCode.InvalidEvidence, "Use --evidence type:PATH:summary.") };
+  if (values.length === 0) return { ok: true };
+  const evidence: Array<{ readonly type: string; readonly path: string; readonly summary: string }> = [];
+  for (const value of values) {
+    if (!value) return { ok: false, error: cliError(CliErrorCode.InvalidEvidence, "Use --evidence type:PATH:summary.") };
+    const [type, evidencePath, ...summaryParts] = value.split(":");
+    if (!type || !evidencePath || summaryParts.length === 0) {
+      return { ok: false, error: cliError(CliErrorCode.InvalidEvidence, "Use --evidence type:PATH:summary.") };
+    }
+    evidence.push({ type, path: evidencePath, summary: summaryParts.join(":") });
+  }
+  return { ok: true, value: evidence };
 }
 
 function ok(rootDir: string, json: boolean, action: ParsedCommand["action"]): ParseResult {

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -189,7 +189,7 @@ export interface ParsedCommand {
     | { readonly kind: "task-holder"; readonly taskId: string }
     | { readonly kind: "task-release"; readonly taskId: string }
     | { readonly kind: "status-set"; readonly taskId: string; readonly status: DomainStatus; readonly force: boolean; readonly reason?: string }
-    | { readonly kind: "progress-append"; readonly taskId: string; readonly text: string; readonly evidence?: EvidenceAppendInput }
+    | { readonly kind: "progress-append"; readonly taskId: string; readonly text: string; readonly evidence?: ReadonlyArray<EvidenceAppendInput> }
     | { readonly kind: "task-amend"; readonly taskId: string; readonly patches: ReadonlyArray<{ readonly field: string; readonly value: string }> }
     | { readonly kind: "task-archive"; readonly taskId?: string; readonly ids?: ReadonlyArray<string>; readonly filter?: string; readonly before?: string; readonly reason: string; readonly archivedBy?: string; readonly archiveField?: string }
     | { readonly kind: "task-supersede"; readonly oldTaskId: string; readonly title?: string; readonly slug?: string; readonly reason: string; readonly byTaskId?: string; readonly confirm?: string; readonly allowOpenFindings: boolean; readonly deletedBy?: string }

--- a/packages/cli/src/commands/core/task-lifecycle.ts
+++ b/packages/cli/src/commands/core/task-lifecycle.ts
@@ -57,9 +57,8 @@ function runProgressAppend(
   context: CommandRunnerContext,
   action: Extract<TaskLifecycleAction, { readonly kind: "progress-append" }>
 ): Effect.Effect<CliResult, EngineError | WriteError> {
-  const text = action.evidence
-    ? `${action.text}\n\nEvidence: ${action.evidence.type}:${action.evidence.path}:${action.evidence.summary}`
-    : action.text;
+  const evidence = action.evidence?.map((entry) => `Evidence: ${entry.type}:${entry.path}:${entry.summary}`).join("\n");
+  const text = evidence ? `${action.text}\n\n${evidence}` : action.text;
   return context.engine.appendProgress({ taskId: action.taskId, text }).pipe(Effect.map((result): CliResult => ({
     ok: true,
     command: "progress-append",

--- a/packages/cli/test/p16-command-parity-cli.test.ts
+++ b/packages/cli/test/p16-command-parity-cli.test.ts
@@ -44,7 +44,8 @@ test("P16 lifecycle provenance flags write auditable task notes", () => {
     const replacement = runJson(rootDir, ["new-task", "--title", "Replacement Task"]);
 
     const progress = runJson(rootDir, ["task", "progress", "append", oldTask.taskId, "--text", "Ran verification", "--evidence", "log:artifacts/check.log:passed"]);
-    assert.equal(progress.report.evidence.path, "artifacts/check.log");
+    assert.equal(progress.report.evidence.length, 1);
+    assert.equal(progress.report.evidence[0].path, "artifacts/check.log");
     assert.match(readFileSync(path.join(rootDir, oldTask.packagePath, "progress.md"), "utf8"), /Evidence: log:artifacts\/check.log:passed/);
 
     const mismatch = runJson(rootDir, ["task", "supersede", oldTask.taskId, "--by", replacement.taskId, "--confirm", "wrong"], false);

--- a/packages/cli/test/parse-args.test.ts
+++ b/packages/cli/test/parse-args.test.ts
@@ -59,7 +59,7 @@ const parseCases: ReadonlyArray<ParseCase> = [
     kind: "status-set",
     fields: { taskId: "task_1", status: "done", force: true, reason: "verified" }
   },
-  { name: "progress append", argv: ["task", "progress", "append", "task_1", "--text", "hello", "--evidence", "log:artifacts/run.log:passed"], kind: "progress-append", fields: { taskId: "task_1", text: "hello", evidence: { type: "log", path: "artifacts/run.log", summary: "passed" } } },
+  { name: "progress append repeated evidence", argv: ["task", "progress", "append", "task_1", "--text", "hello", "--evidence", "log:artifacts/run.log:passed", "--evidence", "test:artifacts/unit.log:green"], kind: "progress-append", fields: { taskId: "task_1", text: "hello", evidence: [{ type: "log", path: "artifacts/run.log", summary: "passed" }, { type: "test", path: "artifacts/unit.log", summary: "green" }] } },
   { name: "task amend", argv: ["task", "amend", "task_1", "--set", "taskClass:milestone"], kind: "task-amend", fields: { taskId: "task_1", patches: [{ field: "taskClass", value: "milestone" }] } },
   { name: "task archive", argv: ["task", "archive", "task_1", "--reason", "done", "--archived-by", "alice", "--archive-field", "packageDisposition"], kind: "task-archive", fields: { taskId: "task_1", reason: "done", archivedBy: "alice", archiveField: "packageDisposition" } },
   { name: "task archive ids", argv: ["task", "archive", "--ids", "task_1,task_2", "--reason", "done"], kind: "task-archive", fields: { ids: ["task_1", "task_2"], reason: "done" } },

--- a/packages/cli/test/progress-evidence-cli.test.ts
+++ b/packages/cli/test/progress-evidence-cli.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { withTestHarnessRoot as withTempRoot } from "./helpers/git-fixtures.ts";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
+
+test("CLI appends every repeated progress evidence entry", () => {
+  withTempRoot((rootDir) => {
+    const created = runJson(rootDir, ["new-task", "--title", "Task One"]);
+    const taskId = assertGeneratedTaskId(created.taskId);
+
+    const result = runJson(rootDir, [
+      "task", "progress", "append", taskId, "--text", "Implemented local CLI",
+      "--evidence", "log:artifacts/check.log:passed",
+      "--evidence", "test:artifacts/unit.log:green"
+    ]);
+    const progress = readFileSync(path.join(rootDir, `harness/tasks/${taskId}-task-one/progress.md`), "utf8");
+
+    assert.equal(result.ok, true);
+    assert.match(progress, /Evidence: log:artifacts\/check\.log:passed/);
+    assert.match(progress, /Evidence: test:artifacts\/unit\.log:green/);
+  });
+});
+
+function assertGeneratedTaskId(value: unknown): string {
+  assert.equal(typeof value, "string");
+  assert.match(value, taskIdPattern);
+  return value;
+}
+
+function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
+  const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+    encoding: "utf8",
+    env: { ...process.env, HARNESS_ACTOR: "agent:test" }
+  });
+  return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
+}

--- a/packages/cli/test/runtime-event-cli.test.ts
+++ b/packages/cli/test/runtime-event-cli.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -92,6 +92,24 @@ test("CLI task transition runtime event records dual-axis actor", () => {
     assert.equal(events[0].actor.principal.personId, "person_tester");
     assert.deepEqual(events[0].actor.executor, { kind: "agent", id: "codex-cli" });
     assert.equal(events[0].actor.responsibleHuman, "person:person_tester");
+  });
+});
+
+test("CLI warns when runtime event actor attribution cannot be resolved", () => {
+  withTempRoot((rootDir) => {
+    writeFileSync(path.join(rootDir, "harness/harness.yaml"), "schema: harness-anything/v1\nsettings:\n", "utf8");
+    const sessionId = "codex-runtime-event-missing-actor";
+    const output = runJsonWithStderr(rootDir, ["new-task", "--title", "Missing Actor Event"], {
+      CODEX_SESSION_ID: sessionId,
+      CODEX_THREAD_ID: ""
+    });
+    const ledgerPath = path.join(rootDir, ".harness/generated/runtime-events", `${sessionId}.jsonl`);
+    const events = readJsonl(ledgerPath);
+
+    assert.equal(output.result.ok, true);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].actor, undefined);
+    assert.match(output.stderr, /runtime event actor attribution unavailable: Local writes require a configured person identity/u);
   });
 });
 
@@ -259,4 +277,27 @@ function runJson(
     const failure = error as { readonly stdout?: string };
     return unwrapCommandReceipt(JSON.parse(failure.stdout ?? "{}") as Record<string, any>);
   }
+}
+
+function runJsonWithStderr(
+  rootDir: string,
+  args: ReadonlyArray<string>,
+  env: Readonly<Record<string, string>> = {}
+): { readonly result: Record<string, any>; readonly stderr: string } {
+  const child = spawnSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...cleanRuntimeEnv,
+      HARNESS_ACTOR: "agent:harness-test",
+      HARNESS_GIT_AUTHOR_NAME: "Harness Tester",
+      HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test",
+      ...env
+    }
+  });
+  assert.equal(child.status, 0);
+  return {
+    result: unwrapCommandReceipt(JSON.parse(child.stdout) as Record<string, any>),
+    stderr: child.stderr
+  };
 }

--- a/packages/kernel/test/store/journal-idempotency.test.ts
+++ b/packages/kernel/test/store/journal-idempotency.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import { taskEntityId } from "../../src/domain/index.ts";
@@ -46,6 +46,24 @@ test("WriteCoordinator reports duplicate batch write conflicts on the conflictin
         entityId: "task/task-conflict",
         reason: "duplicate batch write target: INDEX.md"
       });
+    }
+  });
+});
+
+test("WriteCoordinator retains the underlying journal read failure", () => {
+  withTempStore((rootDir) => {
+    const journalDir = path.join(rootDir, ".harness/write-journal");
+    mkdirSync(journalDir, { recursive: true });
+    writeFileSync(path.join(journalDir, "writes.jsonl"), "{\"schema\":\"write-journal/v1\"}\n", "utf8");
+
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    const result = Effect.runSync(Effect.either(coordinator.enqueue(docWrite("op-malformed-journal", "task-cause", "progress.md", "entry"))));
+
+    assert.equal(result._tag, "Left");
+    if (result._tag === "Left") {
+      assert.equal(result.left._tag, "JournalUnavailable");
+      assert.equal(result.left.cause instanceof Error, true);
+      assert.match((result.left.cause as Error).message, /malformed journal record: missing required fields/);
     }
   });
 });

--- a/tools/check-integration-test-shards.test.mjs
+++ b/tools/check-integration-test-shards.test.mjs
@@ -9,7 +9,7 @@ import {
 test("integration shard declaration is non-overlapping and complete", () => {
   const result = checkIntegrationTestShards();
   assert.equal(result.ok, true, result.errors.join("\n"));
-  assert.equal(result.fileCount, 77);
+  assert.equal(result.fileCount, 78);
   assert.deepEqual(result.workflowShards, [1, 2, 3, 4, 5, 6]);
   assert.deepEqual(result.requiredContexts, [
     "integration-shard (1)",

--- a/tools/integration-test-shards.mjs
+++ b/tools/integration-test-shards.mjs
@@ -38,6 +38,7 @@ export const integrationTestFileWeightsMs = Object.freeze({
   "packages/cli/test/preset-user-root-cli.test.ts": 3000.0,
   "packages/cli/test/preset-script-cli.test.ts": 21150.1,
   "packages/cli/test/preset-script-imports-cli.test.ts": 1132.0,
+  "packages/cli/test/progress-evidence-cli.test.ts": 700.0,
   "packages/cli/test/preset-subtask-expansion-cli.test.ts": 17807.0,
   "packages/cli/test/projection-freshness-cli.test.ts": 1723.3,
   "packages/cli/test/runtime-event-cli.test.ts": 5222.8,
@@ -87,6 +88,7 @@ export const integrationTestShards = Object.freeze([
     id: 1,
     files: Object.freeze([
       "packages/cli/test/local-lifecycle-cli.test.ts",
+      "packages/cli/test/progress-evidence-cli.test.ts",
       "packages/cli/test/task-delete-disposition-cli.test.ts",
       "packages/cli/test/task-document-gates-cli.test.ts",
       "packages/cli/test/distill-cli.test.ts",

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -139,6 +139,7 @@ export const testTierManifest = {
     "packages/cli/test/p16-command-parity-cli.test.ts",
     "packages/cli/test/post-merge-check-cli.test.ts",
     "packages/cli/test/projection-freshness-cli.test.ts",
+    "packages/cli/test/progress-evidence-cli.test.ts",
     "packages/cli/test/preset-create-milestone-cli.test.ts",
     "packages/cli/test/preset-create-milestone-render-html-cli.test.ts",
     "packages/cli/test/preset-github-issue-repair-cli.test.ts",


### PR DESCRIPTION
# English

## Summary

Three independent honesty defects made CLI failures silently disappear: (1) the underlying cause of journal read failures needed a regression anchor after being fixed upstream, (2) `task progress append` silently dropped every `--evidence` flag after the first, and (3) runtime-event actor attribution failures were swallowed by a bare catch, leaving events without an actor and no trace of why. This PR makes repeated evidence flags fully effective end-to-end, makes attribution failures observable on stderr without crashing the command, and anchors the journal-cause behavior with a corruption-path regression test.

## What Changed

- `parsers/core-task.ts` + `types.ts` + `task-lifecycle.ts`: `--evidence` now parses via the existing `readRepeatedRawOption` mechanism into an array carried end-to-end; every entry is written as its own `Evidence:` line in `progress.md`. The `progress-evidence/v1` receipt payload `evidence` field is now an array.
- `command-spec-core.ts`: usage and option help declare `--evidence` as repeatable.
- `command-runtime-events.ts`: the bare catch around task-holder-principal resolution now writes a specific stderr warning (`runtime event actor attribution unavailable: <reason>`) before returning undefined; commands still complete and events still append.
- `journal-idempotency.test.ts`: new regression anchor asserting `JournalUnavailable` retains the underlying `Error` cause on a corrupted `writes.jsonl` (the original toJournalError defect is already fixed on main; verified by negative control on the base).
- Tests: repeated-evidence end-to-end test moved into its own `progress-evidence-cli.test.ts` (the host file was at the 700-line complexity ceiling), hermetic attribution-failure stderr test, parser characterization updates.
- Test registries: `test-tier-manifest.mjs`, `integration-test-shards.mjs` (weight + shard 1), and the shard checker's file count updated for the new test file.

## Task And Scope

- Harness task: task_01KX28JY3T24XQ89ZH0ZVNVPH4 (batch C of the architecture-stability night, task_01KX6CXX3YGQV9C9QG7T78Y4C6)
- Branch: fix/honesty-trio
- Public scope: packages/cli evidence parsing + runtime-event attribution observability; packages/kernel test-only regression anchor
- Private planning/evidence updated: yes
- Out of scope: `--from-file` parser semantics (parallel lane), runtime-event schema evolution, journal error adapter rewrite

## Version Impact

- Version: no version change because these are honesty bug fixes within the unpublished workspace CLI
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/test-tier-manifest.mjs`, `tools/integration-test-shards.mjs`, `tools/check-integration-test-shards.test.mjs` — additive registration of the new `progress-evidence-cli.test.ts` (tier list, shard 1 weight entry, file-count assertion 77→78). No shard topology, weights of existing files, workflow matrix, or required contexts changed; the registration is itself mandated by these checkers.
- Authority: task task_01KX28JY3T24XQ89ZH0ZVNVPH4 (batch C of architecture-stability night task_01KX6CXX3YGQV9C9QG7T78Y4C6)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: bfb3b38
- Branch merge-base with `origin/main`: bfb3b38 (rebased)
- Last `git fetch origin` time: 2026-07-11 01:05 (+08:00)
- Sync method: rebase
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: implementation report in the harness task package (artifacts/impl-report.md)
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] `npm run check:local` (fast tier, re-run after rebase onto latest main)
- [x] targeted: `parse-args.test.ts` 139/139, `journal-idempotency.test.ts` 3/3, `runtime-event-cli.test.ts` 9/9, repeated-evidence end-to-end test
- [ ] GitHub Actions `rewrite-ci` passed (queue gate)
- Not run: full `npm run check` / `npm test` locally — delegated to `rewrite-ci` on this PR per local-check throttle policy (dec_mr9fs0bc)

## Review Evidence

- Self-review: red→green pairs verified per case; case 1 premise checked with a negative control on the base commit (test passes on main, anchoring existing behavior)
- Reviewer subagent: implementation by Codex worker; CEO semantic review of diff against the mission invariants (cause preserved / repeated flags effective / attribution failure observable)
- Human review: merge-queue reviewers
- Blocking findings: none

## Residual Risk

- `progress-evidence/v1` receipt payload `evidence` changed from a single object to an array; consumers of this unpublished receipt payload must read the array shape.
- Attribution failure reasons live on stderr only; the runtime event JSON itself cannot carry the failure reason without a schema evolution, catalogued for a follow-up decision.

## References

- Task: task_01KX28JY3T24XQ89ZH0ZVNVPH4
- Evidence: artifacts/impl-report.md in the task package (red/green per case)
- Review: this PR

---

# 中文

## 概要

三个独立的诚实性缺陷让 CLI 的失败被静默吞掉：（1）journal 读取失败的底层 cause 在上游修复后缺回归锚；（2）`task progress append` 对第一条之后的所有 `--evidence` 静默丢弃；（3）运行时事件的归属解析失败被裸 catch 吞掉，事件无 actor 且无任何痕迹。本 PR 让重复 evidence 端到端全部生效、让归属失败在不中断命令的前提下可观测（stderr 警告）、并用损坏路径回归测试锚定 journal cause 行为。

## 改动内容

- `parsers/core-task.ts` + `types.ts` + `task-lifecycle.ts`：`--evidence` 改用既有 `readRepeatedRawOption` 机制解析为数组并端到端传递；每条 evidence 在 `progress.md` 各写一行 `Evidence:`。receipt 的 `progress-evidence/v1` payload `evidence` 字段升级为数组。
- `command-spec-core.ts`：usage 与选项帮助声明 `--evidence` 可重复。
- `command-runtime-events.ts`：task-holder-principal 解析的裸 catch 改为先写具体 stderr 警告（`runtime event actor attribution unavailable: <原因>`）再返回 undefined；命令继续完成、事件照常追加。
- `journal-idempotency.test.ts`：新增回归锚，断言损坏 `writes.jsonl` 时 `JournalUnavailable` 保留底层 `Error` cause（toJournalError 原缺陷在 main 已修，基线阴性对照验证）。
- 测试：重复 evidence 端到端测试独立为 `progress-evidence-cli.test.ts`（原宿主文件已顶到 700 行复杂度上限）、hermetic 归属失败 stderr、parser characterization 同步。
- 测试登记：`test-tier-manifest.mjs`、`integration-test-shards.mjs`（权重 + shard 1）及 shard checker 文件计数同步新测试文件。

## 任务与范围

- Harness 任务：task_01KX28JY3T24XQ89ZH0ZVNVPH4（架构稳定修复夜 task_01KX6CXX3YGQV9C9QG7T78Y4C6 批次 C）
- 分支：fix/honesty-trio
- 公开范围：packages/cli evidence 解析 + 运行时事件归属可观测性；packages/kernel 仅测试回归锚
- 私有计划 / 证据是否已更新：yes
- 范围外：`--from-file` parser 语义（并行车道）、runtime-event schema 演进、journal 错误适配器重写

## 版本影响

- 版本：不改版本，原因是这是未发布 workspace CLI 内的诚实性缺陷修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/test-tier-manifest.mjs`、`tools/integration-test-shards.mjs`、`tools/check-integration-test-shards.test.mjs`——对新增 `progress-evidence-cli.test.ts` 的附加性登记（tier 清单、shard 1 权重条目、文件计数断言 77→78）。未改变 shard 拓扑、既有文件权重、workflow matrix 或 required contexts；登记本身是这些 checker 的强制要求。
- 依据：任务 task_01KX28JY3T24XQ89ZH0ZVNVPH4（架构稳定修复夜 task_01KX6CXX3YGQV9C9QG7T78Y4C6 批次 C）
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：bfb3b38
- 当前分支与 `origin/main` 的 merge-base：bfb3b38（已 rebase）
- 最近一次 `git fetch origin` 时间：2026-07-11 01:05（+08:00）
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：任务包 artifacts/impl-report.md 实现报告
- Reviewer 证据路径：见审查证据
- GitHub Actions `rewrite-ci` run URL：待本 PR CI 回填
- [x] `npm run check:local`（fast 档，rebase 到最新 main 后重跑）
- [x] 定向：`parse-args.test.ts` 139/139、`journal-idempotency.test.ts` 3/3、`runtime-event-cli.test.ts` 9/9、重复 evidence 端到端测试
- [ ] GitHub Actions `rewrite-ci` passed（队列门）
- 未运行：本地完整 `npm run check` / `npm test`——按本地减负策略（dec_mr9fs0bc）交由本 PR 的 `rewrite-ci` 执行

## 审查证据

- 自查：逐案核红→绿对；案 1 前提用基线阴性对照确认（测试在 main 即绿，锚定既有行为）
- Reviewer subagent：实现由 Codex worker 完成；CEO 按 mission 不变量（cause 保留 / 重复 flag 生效 / 归属失败可观测）做语义 diff 复核
- 人工审查：merge-queue reviewers
- 阻塞发现：无

## 残余风险

- receipt 的 `progress-evidence/v1` payload `evidence` 从单对象变为数组；该未发布 receipt payload 的消费方需按数组读取。
- 归属失败原因目前只在 stderr；运行时事件 JSON 本身无法在不做 schema 演进的情况下携带失败原因，已编目为后续决策项。

## 关联材料

- 任务：task_01KX28JY3T24XQ89ZH0ZVNVPH4
- 证据：任务包 artifacts/impl-report.md（逐案红绿）
- 审查：本 PR
