### PR TITLE
fix: unify host and runner preset policy semantics

### DIFF
--- a/packages/cli/src/commands/extensions/preset-policy.ts
+++ b/packages/cli/src/commands/extensions/preset-policy.ts
@@ -169,6 +169,36 @@ export type PresetPolicyResolution =
   | { readonly ok: true; readonly policy: ResolvedPresetPolicy | null }
   | { readonly ok: false; readonly error: CliError };
 
+export interface ScriptPolicySubject {
+  readonly source: "user" | "vertical" | "preset";
+  readonly scriptId: string;
+  readonly presetId?: string;
+}
+
+export function resolveScriptPolicy(
+  rootInput: HarnessLayoutInput,
+  presets: ReadonlyArray<ResolvedPreset>,
+  subject: ScriptPolicySubject
+): PresetPolicyResolution {
+  if (subject.source === "preset") {
+    const owner = presets.find((preset) => preset.manifest.id === subject.presetId);
+    return owner ? resolvePresetPolicy(rootInput, owner) : { ok: true, policy: null };
+  }
+  if (subject.source !== "vertical") return { ok: true, policy: null };
+
+  const owners = presets.filter((preset) =>
+    preset.manifest.policyPath &&
+    preset.manifest.capabilityImports.some((capability) => capability.id === subject.scriptId)
+  );
+  if (owners.length === 0) return { ok: true, policy: null };
+  if (owners.length > 1) {
+    return invalidPolicy(
+      `Script ${subject.scriptId} has multiple policy-owning presets: ${owners.map((owner) => owner.manifest.id).join(", ")}.`
+    );
+  }
+  return resolvePresetPolicy(rootInput, owners[0]);
+}
+
 export function resolvePresetPolicy(rootInput: HarnessLayoutInput, preset: ResolvedPreset): PresetPolicyResolution {
   const declaredPath = preset.manifest.policyPath;
   if (!declaredPath) return { ok: true, policy: null };

--- a/packages/cli/src/commands/extensions/preset-script-runner.ts
+++ b/packages/cli/src/commands/extensions/preset-script-runner.ts
@@ -8,7 +8,7 @@ import { cliError, CliErrorCode, isCliErrorCode } from "../../cli/error-codes.ts
 import type { CliResult } from "../../cli/types.ts";
 import type { ResolvedPreset } from "./state.ts";
 import type { ScriptEntry } from "./script-host.ts";
-import { resolvePresetPolicy, type ResolvedPresetPolicy } from "./preset-policy.ts";
+import { resolveScriptPolicy, type PresetPolicyResolution, type ResolvedPresetPolicy } from "./preset-policy.ts";
 import { toSlash } from "./machine-evidence-registry.ts";
 import { executeScript } from "./script-executor.ts";
 import {
@@ -68,6 +68,7 @@ function presetScriptPurpose(entrypointName: string): ScriptEntry["metadata"]["p
 export function runScriptEntrypoint(
   rootInput: HarnessLayoutInput,
   preset: ResolvedPreset,
+  presets: ReadonlyArray<ResolvedPreset>,
   presetSummary: unknown,
   entrypoint: ScriptEntrypoint,
   entrypointName: string,
@@ -91,7 +92,7 @@ export function runScriptEntrypoint(
       }
     };
   }
-  const outputRoot = taskPackagePath(rootInput, taskId), policy = resolvePresetPolicy(rootInput, preset);
+  const outputRoot = taskPackagePath(rootInput, taskId), policy = resolveRunnerScriptPolicy(rootInput, presets, preset);
   const writeScope = resolveDeclaredWriteScopes(entrypoint.writes, layout, outputRoot);
   const readScope = entrypoint.reads
     ? resolveDeclaredReadScopes(entrypoint.reads, layout, outputRoot)
@@ -181,6 +182,26 @@ export function runScriptEntrypoint(
     generated: execution.generated.map((filePath) => path.relative(rootDir, filePath).split(path.sep).join("/")),
     scriptedResult: readScriptedResult(outputRoot)
   };
+}
+
+function resolveRunnerScriptPolicy(
+  rootInput: HarnessLayoutInput,
+  presets: ReadonlyArray<ResolvedPreset>,
+  preset: ResolvedPreset
+): PresetPolicyResolution {
+  for (const capability of preset.manifest.capabilityImports) {
+    if (!capability.id.startsWith("vertical:")) continue;
+    const verticalPolicy = resolveScriptPolicy(rootInput, presets, {
+      source: "vertical",
+      scriptId: capability.id
+    });
+    if (!verticalPolicy.ok) return verticalPolicy;
+  }
+  return resolveScriptPolicy(rootInput, presets, {
+    source: "preset",
+    scriptId: `preset:${preset.manifest.id}`,
+    presetId: preset.manifest.id
+  });
 }
 
 function buildPresetContext(options: {

--- a/packages/cli/src/commands/extensions/script-host.ts
+++ b/packages/cli/src/commands/extensions/script-host.ts
@@ -5,7 +5,7 @@ import type { HarnessLayoutInput } from "../../../../kernel/src/index.ts";
 import { resolveHarnessLayout } from "../../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
-import { resolvePresetPolicy, type PresetPolicyResolution } from "./preset-policy.ts";
+import { resolveScriptPolicy, type PresetPolicyResolution } from "./preset-policy.ts";
 import { executeScript } from "./script-executor.ts";
 import { discoverPresets } from "./state.ts";
 import {
@@ -61,7 +61,12 @@ export function runScriptHost(options: {
   readonly allowFailedScriptResult?: boolean;
 }): ScriptHostRunResult {
   const layout = resolveHarnessLayout(options.rootInput);
-  const validation = validateResolvedScript(options.script), policy = resolveScriptPolicy(options.rootInput, options.script);
+  const validation = validateResolvedScript(options.script);
+  const policy = resolveScriptPolicy(options.rootInput, discoverPresets(options.rootInput), {
+    source: options.script.entry.source,
+    scriptId: options.script.entry.id,
+    presetId: typeof options.script.context?.presetId === "string" ? options.script.context.presetId : undefined
+  });
   if (!validation.ok || !policy.ok) return invalidScriptOrPolicy(options.commandName, validation, policy);
 
   const scriptPath = path.resolve(options.script.manifestRoot, options.script.entry.command);
@@ -241,32 +246,6 @@ function invalidScriptOrPolicy(
   if (!validation.ok) return scriptFailure(command, CliErrorCode.ScriptContractInvalid, validation.hint);
   if (!policy.ok) return scriptFailure(command, policy.error.code, policy.error.hint);
   throw new Error("Script and policy validation unexpectedly succeeded.");
-}
-
-function resolveScriptPolicy(rootInput: HarnessLayoutInput, script: ResolvedScriptEntry): PresetPolicyResolution {
-  const presets = discoverPresets(rootInput);
-  if (script.entry.source === "preset") {
-    const presetId = typeof script.context?.presetId === "string" ? script.context.presetId : "";
-    const owner = presets.find((preset) => preset.manifest.id === presetId);
-    return owner ? resolvePresetPolicy(rootInput, owner) : { ok: true, policy: null };
-  }
-  if (script.entry.source !== "vertical") return { ok: true, policy: null };
-
-  const owners = presets.filter((preset) =>
-    preset.manifest.policyPath &&
-    preset.manifest.capabilityImports.some((capability) => capability.id === script.entry.id)
-  );
-  if (owners.length === 0) return { ok: true, policy: null };
-  if (owners.length > 1) {
-    return {
-      ok: false,
-      error: cliError(
-        CliErrorCode.PresetPolicyInvalid,
-        `Script ${script.entry.id} has multiple policy-owning presets: ${owners.map((owner) => owner.manifest.id).join(", ")}.`
-      )
-    };
-  }
-  return resolvePresetPolicy(rootInput, owners[0]);
 }
 
 function scriptFailure(command: string, code: CliErrorCode, hint: string, runDir?: string, rootDir?: string): { readonly ok: false; readonly result: CliResult } {

--- a/packages/cli/src/commands/extensions/state.ts
+++ b/packages/cli/src/commands/extensions/state.ts
@@ -339,7 +339,7 @@ export function runPresetEntrypoint(
       });
     }
     const presetSummary = publicPresetSummary(preset);
-    const scriptResult = runScriptEntrypoint(rootInput, preset, presetSummary, declaredEntrypoint, entrypoint, taskId, evidenceDir, commandName, inputs);
+    const scriptResult = runScriptEntrypoint(rootInput, preset, discoverPresets(rootInput), presetSummary, declaredEntrypoint, entrypoint, taskId, evidenceDir, commandName, inputs);
     if (!scriptResult.ok) return scriptResult.result;
     generated.push(...scriptResult.generated);
     if (scriptResult.scriptedResult) {

--- a/packages/cli/test/preset-script-imports-cli.test.ts
+++ b/packages/cli/test/preset-script-imports-cli.test.ts
@@ -139,6 +139,32 @@ test("policy envelope capability can be reused by a non-native preset id", () =>
   });
 });
 
+test("host and preset runner reject the same conflicting vertical policy owners", () => {
+  withCanonicalTempRoot((rootDir) => {
+    const sharedCapability = "vertical:software-coding:repository-audit";
+    for (const presetId of ["policy-owner-a", "policy-owner-b"]) {
+      writePolicyCapturePreset(rootDir, presetId, undefined, [
+        { id: sharedCapability, kind: "checker", version: "1", required: true },
+        { id: PRESET_POLICY_SCHEMA_CREATE_MILESTONE, kind: "command", version: "1", required: true }
+      ]);
+      writeFile(rootDir, `harness/policies/presets/${presetId}.policy.json`, JSON.stringify({
+        schema: "preset-policy/create-milestone/v1",
+        presetId,
+        rules: {}
+      }));
+    }
+
+    const host = runJson(rootDir, ["script", "run", sharedCapability], false);
+    const runner = runJson(rootDir, [
+      "preset", "action", "policy-owner-a", "capture", "--task", "task-policy-conflict", "--allow-scripts"
+    ], false);
+
+    assert.equal(host.ok, false);
+    assert.equal(runner.ok, false);
+    assert.deepEqual(runner.error, host.error);
+  });
+});
+
 test("missing policy is public-default null while malformed, unknown-key, wrong-preset, and escape fixtures fail closed", () => {
   withCanonicalTempRoot((rootDir) => {
     writePolicyCapturePreset(rootDir, "create-milestone");
@@ -339,7 +365,8 @@ function writeProcessPreset(rootDir: string, presetId: string, title: string, co
 function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, any> {
   try {
     const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
-      encoding: "utf8"
+      encoding: "utf8",
+      env: { ...process.env, HARNESS_ACTOR: "agent:test" }
     });
     const parsed = JSON.parse(output) as Record<string, any>;
     if (expectSuccess) assert.equal(parsed.ok, true, output);

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -595,12 +595,12 @@
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#mkdirSync@122:3",
+        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#mkdirSync@123:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#writeFileSync@124:3",
+        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#writeFileSync@125:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
@@ -610,27 +610,27 @@
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#writeFileSync@155:3",
+        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#writeFileSync@157:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/script-host.ts#mkdirSync@87:3",
+        "value": "packages/cli/src/commands/extensions/script-host.ts#mkdirSync@92:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@155:3",
+        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@160:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@156:3",
+        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@161:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@90:3",
+        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@95:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       }


### PR DESCRIPTION
# English

## Summary

Unify preset policy enforcement semantics between the script host and the preset script runner: both faces now resolve policy through one shared source-aware resolver, and the runner gains the multi-owner conflict rejection it previously lacked. Implements accepted decision dec_mrf7apah (CH1).

## What Changed

- `packages/cli/src/commands/extensions/preset-policy.ts`: the host's private source-aware resolver is promoted here as `resolveScriptPolicy` (source `preset` → owner preset policy; source `vertical` → capability-owner aggregation with multi-owner conflict rejection; other sources → public-default null).
- `packages/cli/src/commands/extensions/script-host.ts`: drops its private resolver and calls the shared one — semantics unchanged on the host face (no narrowing).
- `packages/cli/src/commands/extensions/preset-script-runner.ts` + `state.ts`: the runner now resolves through the same shared resolver and additionally rejects multi-owner conflicts on the vertical capabilities the preset imports, instead of silently resolving only the explicit current preset.
- `packages/cli/test/preset-script-imports-cli.test.ts`: positive-control test constructs a multi-owner conflict and asserts host and runner both fail with **identical** error objects (`assert.deepEqual(runner.error, host.error)`).
- `tools/gate-allowlists/check-bypass-write-boundary.json`: 7 line-anchor repins after the refactor (pure drift, governed write count 125 → 125, delta=0).

## Task And Scope

- Task: task_01KX7G474705JJC0TSG8DQZ72B (host/runner 政策解析语义统一到 host 侧)
- Decision: dec_mrf7apah (accepted 2026-07-11, arbiter human:lizeyu)
- Scope: CLI extensions policy resolution only; no kernel/daemon changes; no error-code or receipt shape changes.

## Version Impact

No published package version change. Behavior change: preset script runs that import vertical capabilities with conflicting policy owners now fail closed with `preset_policy_invalid` (previously silently allowed) — this is the decision's intent.

## Governance Declaration

This PR touches `tools/gate-allowlists/check-bypass-write-boundary.json` (protected gate surface). Change is **additive-neutral line-anchor repinning only**: 7 entries repinned to new line numbers after code moved, entry count and governed-write delta both 0 (`current=125 previous=125 delta=0`). Authority: dec_mrf7apah + task_01KX7G474705JJC0TSG8DQZ72B; precedent for delta=0 repins: commit 6d94455 and PR #608. No gate was weakened, removed, or bypassed.

## Verification

- RED→GREEN: the new conflict test fails on main (runner returned success) and passes with this change.
- `npm run check:local` green after rebase onto latest origin/main (0a6ffad), 43.8s.
- `node tools/check-bypass-write-boundary.mjs` green, delta=0.
- Affected suite `preset-script-imports-cli.test.ts` 28/28; `npm run typecheck` green.
- Error-shape consumer sweep: no new error codes; `preset_policy_invalid` reused; repo-wide grep of receipt/policy-report consumers found no shape dependencies to update.

## Review Evidence

- CEO semantic review against dec_mrf7apah: CH1 satisfied via shared code path (not duplicated logic); RJ2 red line respected (host semantics not narrowed); positive control asserts identical verdicts on both faces.
- Worker implementation report: `harness/tasks/task_01KX7G474705JJC0TSG8DQZ72B-host-runner-host-dec-mrf7apah/artifacts/impl-report.md` (private ledger).

## Residual Risk

- The runner discards an ok vertical policy after conflict checking (it applies the preset-source policy for preset-source entrypoints, matching host semantics for the same subject); if a future decision wants imported vertical policies to constrain preset runs, that is a semantic extension requiring its own decision.
- `discoverPresets` is now called once more per preset run (host + runner paths); negligible cost, noted for future consolidation.

## References

- dec_mrf7apah (harness ledger, private)
- Fact F-G6PN1KB1 (drift case file)
- PR #601 (P4-1 capability-declaration-driven policy envelope, prior stage)

# 中文

## 概要

统一 script host 与 preset script runner 两个执法面的政策解析语义：两面改走同一个共享的 source-aware resolver，runner 补上此前缺失的多 owner 冲突拒绝。落地已接受决策 dec_mrf7apah（CH1）。

## 改动内容

- `preset-policy.ts`：host 侧原私有 resolver 上移为共享 `resolveScriptPolicy`（preset 源 → owner preset 政策；vertical 源 → capability owner 聚合 + 多 owner 冲突拒绝；其他源 → 公共默认 null）。
- `script-host.ts`：删除私有 resolver，改调共享实现——host 面语义不变（未收窄）。
- `preset-script-runner.ts` + `state.ts`：runner 改走同一共享 resolver，并对 preset 导入的 vertical capabilities 增加多 owner 冲突拒绝（此前只解析显式当前 preset、静默放行冲突）。
- `preset-script-imports-cli.test.ts`：阳性对照测试构造多 owner 冲突，断言 host 与 runner 以**完全一致**的 error 对象双双拒绝（deepEqual）。
- `check-bypass-write-boundary.json`：重构后 7 条行号锚 repin（纯漂移，受治理写调用 125→125，delta=0）。

## 任务与范围

- 任务：task_01KX7G474705JJC0TSG8DQZ72B（host/runner 政策解析语义统一到 host 侧）
- 决策：dec_mrf7apah（2026-07-11 accepted，arbiter human:lizeyu）
- 范围：仅 CLI extensions 政策解析；不动 kernel/daemon；错误码与 receipt 形状零变更。

## 版本影响

无发布包版本变更。行为变化：导入了政策 owner 冲突的 vertical capability 的 preset 运行现在 fail-closed 报 `preset_policy_invalid`（此前静默放行）——这正是决策意图。

## 治理声明

本 PR 触碰 `tools/gate-allowlists/check-bypass-write-boundary.json`（protected gate surface）。变更**仅为行号锚 repin**：代码移动后 7 条锚更新行号，条目数与受治理写调用 delta 均为 0（`current=125 previous=125 delta=0`）。授权：dec_mrf7apah + task_01KX7G474705JJC0TSG8DQZ72B；delta=0 repin 先例：commit 6d94455 与 PR #608。未削弱、移除或绕过任何 gate。

## 验证

- 红→绿：新冲突测试在 main 上失败（runner 返回成功），本变更后通过。
- rebase 最新 origin/main（0a6ffad）后 `npm run check:local` 绿，43.8s。
- `node tools/check-bypass-write-boundary.mjs` 绿，delta=0。
- 受影响套件 `preset-script-imports-cli.test.ts` 28/28；`npm run typecheck` 绿。
- 错误形状消费者清扫：无新错误码；复用 `preset_policy_invalid`；全仓 grep receipt/政策报告消费者无需同步。

## 审查证据

- CEO 对照 dec_mrf7apah 语义验收：CH1 经共享代码路径成立（非复制逻辑）；RJ2 红线未犯（host 语义未收窄）；阳性对照断言两面同裁决。
- worker 实现报告：`harness/tasks/task_01KX7G474705JJC0TSG8DQZ72B-host-runner-host-dec-mrf7apah/artifacts/impl-report.md`（私有 ledger）。

## 残余风险

- runner 对冲突检查通过的 vertical 政策不施加（preset 源入口应用 preset 政策，与 host 对同一主体的语义一致）；若未来要让导入的 vertical 政策约束 preset 运行，属语义扩展需另立决策。
- `discoverPresets` 每次 preset 运行多调用一次（host+runner 两路径）；成本可忽略，留待后续合并。

## 关联材料

- dec_mrf7apah（私有 ledger）
- Fact F-G6PN1KB1（漂移立案）
- PR #601（P4-1 政策信封声明化，前一阶段）

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body, both blocks complete / 双语正文，两块齐全
- [x] Governance declaration for protected surface / protected surface 治理声明
- [x] Local gate green after rebase / rebase 后本地门绿
- [x] No gate weakened / 未削弱任何门
