### PR TITLE
fix: reserve code-doc anchors for coordinator CLI

### DIFF
--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -106,6 +106,7 @@ export function makeLocalLifecycleEngine(options: LocalLifecycleOptions): LocalL
     stageTaskTree: (input) => stageTaskPackageTree(runtimeContext, coordinator, input),
     taskTreeStatus: (input) => taskTreeStatus(runtimeContext, input),
     replaceTaskDocument: (input) => replaceTaskDocument(runtimeContext, coordinator, input),
+    writeCodeDocReconciliation: (input) => writeCodeDocReconciliation(runtimeContext, coordinator, input),
     archiveTask: (input) => archiveTask(runtimeContext, coordinator, input),
     supersedeTask: (input) => supersedeTask(runtimeContext, coordinator, clock, input, options.bindCreateProvenance),
     deleteTask: (input) => deleteTask(runtimeContext, coordinator, input),
@@ -267,6 +268,18 @@ function replaceTaskDocument(
     yield* readIndexEffect(rootInput, input.taskId);
     yield* writeTaskDocument(coordinator, stablePayloadHash, input.taskId, input.path, input.body, { kind: "doc_write" });
     return { taskId: input.taskId, path: input.path } satisfies LocalProgressResult;
+  });
+}
+
+function writeCodeDocReconciliation(
+  rootInput: HarnessLayoutInput,
+  coordinator: WriteCoordinator,
+  input: { readonly taskId: string; readonly body: string }
+): Effect.Effect<LocalProgressResult, EngineError | WriteError> {
+  return Effect.gen(function* () {
+    yield* readIndexEffect(rootInput, input.taskId);
+    yield* writeTaskDocument(coordinator, stablePayloadHash, input.taskId, "code-doc-anchors.json", input.body, { kind: "code_doc_reconcile" });
+    return { taskId: input.taskId, path: "code-doc-anchors.json" } satisfies LocalProgressResult;
   });
 }
 

--- a/packages/adapters/local/src/types.ts
+++ b/packages/adapters/local/src/types.ts
@@ -85,6 +85,11 @@ export interface WriteTaskDocumentInput extends StageTaskDocumentInput {
   readonly body: string;
 }
 
+export interface WriteCodeDocReconciliationInput {
+  readonly taskId: TaskId;
+  readonly body: string;
+}
+
 export interface TaskReasonInput {
   readonly taskId: TaskId;
   readonly reason: string;
@@ -140,6 +145,7 @@ export interface LocalLifecycleEngine {
   readonly stageTaskTree: (input: StageTaskTreeInput) => Effect.Effect<LocalProgressResult, EngineError | WriteError>;
   readonly taskTreeStatus: (input: StageTaskTreeInput) => Effect.Effect<LocalTaskTreeStatusResult, EngineError | WriteError>;
   readonly replaceTaskDocument: (input: WriteTaskDocumentInput) => Effect.Effect<LocalProgressResult, EngineError | WriteError>;
+  readonly writeCodeDocReconciliation: (input: WriteCodeDocReconciliationInput) => Effect.Effect<LocalProgressResult, EngineError | WriteError>;
   readonly archiveTask: (input: TaskReasonInput) => Effect.Effect<LocalTaskResult, EngineError | WriteError>;
   readonly supersedeTask: (input: SupersedeTaskInput) => Effect.Effect<LocalSupersedeResult, EngineError | WriteError>;
   readonly deleteTask: (input: DeleteTaskInput) => Effect.Effect<LocalDeleteResult, EngineError | WriteError>;

--- a/packages/cli/src/cli/runner-registry.ts
+++ b/packages/cli/src/cli/runner-registry.ts
@@ -71,6 +71,10 @@ export interface CommandRunnerEngine {
     readonly path: string;
     readonly body: string;
   }) => EngineEffect<{ readonly taskId: string; readonly path: string }>;
+  readonly writeCodeDocReconciliation: (input: {
+    readonly taskId: string;
+    readonly body: string;
+  }) => EngineEffect<{ readonly taskId: string; readonly path: string }>;
   readonly archiveTask: (input: {
     readonly taskId: string;
     readonly reason: string;

--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -90,9 +90,8 @@ function runTaskCodeDocReconcile(
       } satisfies CliResult;
     }
 
-    const write = yield* context.engine.replaceTaskDocument({
+    const write = yield* context.engine.writeCodeDocReconciliation({
       taskId: action.taskId,
-      path: CODE_DOC_RECONCILIATION_DOCUMENT,
       body: draft.body
     });
     return {

--- a/packages/cli/test/local-lifecycle-cli.test.ts
+++ b/packages/cli/test/local-lifecycle-cli.test.ts
@@ -622,9 +622,11 @@ function writeFact(rootDir: string, directoryName: string): void {
 }
 
 function writeCodeDocAnchors(rootDir: string, directoryName: string, sha = ensureAnchorCommit(rootDir)): void {
-  const anchors = [{ id: "A4-001", ledgerPath: "closeout.md", kind: "closeout", anchors: [{ kind: "path", sha, path: "evidence/code-doc-anchor.txt" }] }];
-  const body = JSON.stringify({ schema: "code-doc-reconciliation/v1", taskId: directoryName, records: anchors }, null, 2);
-  writeFileSync(path.join(rootDir, "harness/tasks", directoryName, "code-doc-anchors.json"), `${body}\n`, "utf8");
+  runJson(rootDir, [
+    "task", "code-doc", "reconcile", directoryName,
+    "--commit", sha,
+    "--path", "evidence/code-doc-anchor.txt"
+  ]);
 }
 
 function ensureAnchorCommit(rootDir: string): string {

--- a/packages/cli/test/task-document-gates-cli.test.ts
+++ b/packages/cli/test/task-document-gates-cli.test.ts
@@ -103,7 +103,7 @@ test("CLI task-complete rejects fabricated code-doc shas", () => {
     writeReview(rootDir, "task-1");
     writeFact(rootDir, "task-1");
     writeRealCloseout(rootDir, "task-1");
-    writeCodeDocAnchors(rootDir, "task-1", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    writeCodeDocAnchorsRaw(rootDir, "task-1", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
     const blocked = runJson(rootDir, ["task-complete", "task-1", "--reviewer", "reviewer-a", "--ci", "passed"], false);
 
@@ -119,7 +119,7 @@ test("CLI task-complete reports the underlying completion write failure", () => 
     writeIndex(rootDir, "task-1", "Complete Task", "in_review", { provenance: false });
     writeReview(rootDir, "task-1");
     writeFact(rootDir, "task-1");
-    writeRealCloseout(rootDir, "task-1");
+    writeRealCloseout(rootDir, "task-1", { coordinatedAnchors: false });
 
     const blocked = runJson(rootDir, ["task-complete", "task-1", "--reviewer", "reviewer-a", "--ci", "passed"], false);
 
@@ -286,7 +286,11 @@ function writeReview(rootDir: string, directoryName: string): void {
   ].join("\n"), "utf8");
 }
 
-function writeRealCloseout(rootDir: string, directoryName: string): void {
+function writeRealCloseout(
+  rootDir: string,
+  directoryName: string,
+  options: { readonly coordinatedAnchors?: boolean } = {}
+): void {
   writeCloseout(rootDir, directoryName, [
     "## Summary",
     "",
@@ -300,7 +304,8 @@ function writeRealCloseout(rootDir: string, directoryName: string): void {
     "",
     "No residual risk accepted."
   ]);
-  writeCodeDocAnchors(rootDir, directoryName);
+  if (options.coordinatedAnchors ?? true) writeCodeDocAnchors(rootDir, directoryName);
+  else writeCodeDocAnchorsRaw(rootDir, directoryName, ensureAnchorCommit(rootDir));
 }
 
 function writeFact(rootDir: string, directoryName: string): void {
@@ -317,6 +322,14 @@ function writeCloseout(rootDir: string, directoryName: string, lines: ReadonlyAr
 }
 
 function writeCodeDocAnchors(rootDir: string, directoryName: string, sha = ensureAnchorCommit(rootDir)): void {
+  runJson(rootDir, [
+    "task", "code-doc", "reconcile", directoryName,
+    "--commit", sha,
+    "--path", "evidence/code-doc-anchor.txt"
+  ]);
+}
+
+function writeCodeDocAnchorsRaw(rootDir: string, directoryName: string, sha: string): void {
   writeFileSync(path.join(rootDir, "harness/tasks", directoryName, "code-doc-anchors.json"), `${JSON.stringify({
     schema: "code-doc-reconciliation/v1",
     taskId: directoryName,

--- a/packages/cli/test/task-transition-sweep-cli.test.ts
+++ b/packages/cli/test/task-transition-sweep-cli.test.ts
@@ -181,16 +181,11 @@ function writeReview(rootDir: string, taskPath: string): void {
 }
 
 function writeCodeDocAnchors(rootDir: string, taskPath: string, taskId: string, sha = ensureAnchorCommit(rootDir)): void {
-  writeFileSync(path.join(rootDir, taskPath, "code-doc-anchors.json"), `${JSON.stringify({
-    schema: "code-doc-reconciliation/v1",
-    taskId,
-    records: [{
-      id: "A4-001",
-      ledgerPath: "closeout.md",
-      kind: "closeout",
-      anchors: [{ kind: "path", sha, path: "evidence/code-doc-anchor.txt" }]
-    }]
-  }, null, 2)}\n`, "utf8");
+  runJson(rootDir, [
+    "task", "code-doc", "reconcile", taskId,
+    "--commit", sha,
+    "--path", "evidence/code-doc-anchor.txt"
+  ]);
 }
 
 function ensureAnchorCommit(rootDir: string): string {

--- a/packages/kernel/src/ports/version-control-system.ts
+++ b/packages/kernel/src/ports/version-control-system.ts
@@ -10,6 +10,7 @@ export interface VersionControlSystem {
   readonly topLevel: (inputPath: string) => string | null;
   readonly isIgnored: (repoRoot: string, relativePath: string) => boolean;
   readonly add: (repoRoot: string, input: { readonly paths: ReadonlyArray<string>; readonly force?: boolean }) => void;
+  readonly workingTreeFiles: (repoRoot: string, paths: ReadonlyArray<string>) => string;
   readonly stagedFiles: (repoRoot: string, paths: ReadonlyArray<string>) => string;
   readonly commit: (repoRoot: string, message: string, author?: VcsCommitAuthor) => void;
   readonly currentHead: (repoRoot: string) => string;

--- a/packages/kernel/src/ports/write-coordinator.ts
+++ b/packages/kernel/src/ports/write-coordinator.ts
@@ -9,6 +9,7 @@ export type TaskWriteOpKind =
   | "doc_stage"
   | "task_tree_stage"
   | "doc_write"
+  | "code_doc_reconcile"
   | "package_archive"
   | "package_tombstone"
   | "package_reopen"

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -22,6 +22,7 @@ export function makeLocalVersionControlSystem(): VersionControlSystem {
       if (input.paths.length === 0) return;
       runGit(repoRoot, "add", "-A", ...(input.force ? ["-f"] : []), "--", ...input.paths);
     },
+    workingTreeFiles: (repoRoot, paths) => runGit(repoRoot, "status", "--porcelain", "-uall", "--", ...paths),
     stagedFiles: (repoRoot, paths) => runGit(repoRoot, "diff", "--cached", "--name-only", "--", ...paths),
     commit: (repoRoot, message, author) => {
       runGitAs(repoRoot, author, "commit", "-m", message);

--- a/packages/kernel/src/store/write-journal-code-doc-policy.ts
+++ b/packages/kernel/src/store/write-journal-code-doc-policy.ts
@@ -1,0 +1,190 @@
+import type { DocumentWrite } from "../ports/artifact-store-writer.ts";
+import type { VersionControlSystem } from "../ports/version-control-system.ts";
+import type { WriteOp } from "../ports/write-coordinator.ts";
+import { normalizeRelativeDocumentPath } from "../layout/index.ts";
+import { rejectWrite } from "./write-journal-rejection.ts";
+import { taskIdForWriteOp } from "./write-journal-entity.ts";
+
+export const CODE_DOC_RECONCILIATION_PATH = "code-doc-anchors.json";
+
+interface CodeDocAnchor {
+  readonly kind: "commit" | "path" | "pr";
+  readonly sha?: string;
+  readonly path?: string;
+  readonly ref?: string;
+}
+
+interface CodeDocRecord {
+  readonly id: string;
+  readonly ledgerPath: string;
+  readonly kind: "closeout" | "review" | "evidence" | "decision-claim";
+  readonly anchors: ReadonlyArray<CodeDocAnchor>;
+}
+
+interface CodeDocDocument {
+  readonly schema: "code-doc-reconciliation/v1";
+  readonly taskId: string;
+  readonly records: ReadonlyArray<CodeDocRecord>;
+}
+
+export function assertReservedCodeDocWrite(
+  op: WriteOp,
+  writes: ReadonlyArray<DocumentWrite>
+): void {
+  const stagedPath = op.kind === "doc_stage" ? payloadPath(op) : undefined;
+  const reservedWrites = writes.filter((write) => normalizedPath(write.path, op) === CODE_DOC_RECONCILIATION_PATH);
+  const stagesReservedPath = stagedPath !== undefined && normalizedPath(stagedPath, op) === CODE_DOC_RECONCILIATION_PATH;
+
+  if ((reservedWrites.length > 0 || stagesReservedPath) && op.kind !== "code_doc_reconcile") {
+    rejectWrite(remediation(taskIdForWriteOp(op)), op.entityId);
+  }
+  if (op.kind !== "code_doc_reconcile") return;
+  if (writes.length !== 1 || reservedWrites.length !== 1) {
+    rejectWrite(`code_doc_reconcile may only write ${CODE_DOC_RECONCILIATION_PATH}`, op.entityId);
+  }
+  parseAndValidateDocument(reservedWrites[0]!, op);
+}
+
+export function assertCodeDocGitEvidence(
+  rootDir: string,
+  op: WriteOp,
+  versionControlSystem: VersionControlSystem
+): void {
+  if (op.kind !== "code_doc_reconcile") return;
+  const document = parseAndValidateDocument(documentWrite(op), op);
+  const repoRoot = versionControlSystem.topLevel(rootDir) ?? rootDir;
+  for (const record of document.records) {
+    for (const anchor of record.anchors) {
+      if (!anchor.sha) continue;
+      if (!versionControlSystem.commitExists(repoRoot, anchor.sha)) {
+        rejectWrite(`code-doc anchor commit does not exist: ${anchor.sha}`, op.entityId);
+      }
+      if (anchor.kind === "path" && !versionControlSystem.pathExistsAtCommit(repoRoot, anchor.sha, anchor.path!)) {
+        rejectWrite(`code-doc anchor path does not exist at ${anchor.sha}: ${anchor.path}`, op.entityId);
+      }
+    }
+  }
+}
+
+export function assertNoUncoordinatedCodeDocChange(op: WriteOp, status: string): void {
+  if (op.kind !== "task_tree_stage") return;
+  const dirtyReservedPath = status
+    .split(/\r?\n/u)
+    .map(statusPath)
+    .find((entry) => entry && entry.split("/").at(-1) === CODE_DOC_RECONCILIATION_PATH);
+  if (dirtyReservedPath) rejectWrite(remediation(taskIdForWriteOp(op)), op.entityId);
+}
+
+function parseAndValidateDocument(write: DocumentWrite, op: WriteOp): CodeDocDocument {
+  let value: unknown;
+  try {
+    value = JSON.parse(write.body);
+  } catch {
+    rejectWrite(`${CODE_DOC_RECONCILIATION_PATH} must contain valid JSON`, op.entityId);
+  }
+  if (!isObject(value) || value.schema !== "code-doc-reconciliation/v1") {
+    rejectWrite(`${CODE_DOC_RECONCILIATION_PATH} must use schema code-doc-reconciliation/v1`, op.entityId);
+  }
+  const taskId = taskIdForWriteOp(op);
+  if (value.taskId !== taskId || !Array.isArray(value.records) || value.records.length === 0) {
+    rejectWrite(`${CODE_DOC_RECONCILIATION_PATH} must match task ${taskId} and contain records`, op.entityId);
+  }
+  const ids = new Set<string>();
+  const records = value.records.map((record, index) => validateRecord(record, index, ids, op));
+  return { schema: "code-doc-reconciliation/v1", taskId, records };
+}
+
+function validateRecord(
+  value: unknown,
+  index: number,
+  ids: Set<string>,
+  op: WriteOp
+): CodeDocRecord {
+  if (!isObject(value) || typeof value.id !== "string" || value.id.length === 0 || ids.has(value.id)) {
+    rejectWrite(`code-doc record ${index} requires a unique id`, op.entityId);
+  }
+  const recordId = value.id;
+  ids.add(recordId);
+  if (typeof value.ledgerPath !== "string" || !isRecordKind(value.kind)) {
+    rejectWrite(`code-doc record ${value.id} requires ledgerPath and a supported record kind`, op.entityId);
+  }
+  const ledgerPath = normalizedPath(value.ledgerPath, op);
+  if (!Array.isArray(value.anchors) || value.anchors.length === 0) {
+    rejectWrite(`code-doc record ${value.id} requires anchors`, op.entityId);
+  }
+  const anchors = value.anchors.map((anchor, anchorIndex) => validateAnchor(anchor, recordId, anchorIndex, op));
+  if (!anchors.some((anchor) => anchor.kind === "commit" || anchor.kind === "path")) {
+    rejectWrite(`code-doc record ${value.id} requires a commit or path anchor`, op.entityId);
+  }
+  return { id: value.id, ledgerPath, kind: value.kind, anchors };
+}
+
+function validateAnchor(value: unknown, recordId: string, index: number, op: WriteOp): CodeDocAnchor {
+  if (!isObject(value) || (value.kind !== "commit" && value.kind !== "path" && value.kind !== "pr")) {
+    rejectWrite(`code-doc record ${recordId} anchor ${index} has invalid kind`, op.entityId);
+  }
+  const sha = typeof value.sha === "string" ? value.sha : undefined;
+  if ((value.kind === "commit" || value.kind === "path") && !isFullSha(sha)) {
+    rejectWrite(`code-doc record ${recordId} anchor ${index} requires a full commit SHA`, op.entityId);
+  }
+  if (sha !== undefined && !isFullSha(sha)) {
+    rejectWrite(`code-doc record ${recordId} anchor ${index} has invalid SHA`, op.entityId);
+  }
+  const anchorPath = typeof value.path === "string" ? value.path : undefined;
+  const anchorRef = typeof value.ref === "string" ? value.ref : undefined;
+  if (value.kind === "path" && (!anchorPath || normalizedPath(anchorPath, op) !== anchorPath)) {
+    rejectWrite(`code-doc record ${recordId} path anchor requires a normalized path`, op.entityId);
+  }
+  if (value.kind === "pr" && (!anchorRef || anchorRef.length === 0)) {
+    rejectWrite(`code-doc record ${recordId} PR anchor requires ref`, op.entityId);
+  }
+  return {
+    kind: value.kind,
+    ...(sha ? { sha } : {}),
+    ...(value.kind === "path" ? { path: anchorPath! } : {}),
+    ...(value.kind === "pr" ? { ref: anchorRef! } : {})
+  };
+}
+
+function documentWrite(op: WriteOp): DocumentWrite {
+  const payload = op.payload;
+  if (!isObject(payload) || typeof payload.path !== "string" || typeof payload.body !== "string") {
+    rejectWrite("code_doc_reconcile requires path and body", op.entityId);
+  }
+  return { taskId: taskIdForWriteOp(op), path: payload.path, body: payload.body };
+}
+
+function payloadPath(op: WriteOp): string | undefined {
+  return isObject(op.payload) && typeof op.payload.path === "string" ? op.payload.path : undefined;
+}
+
+function normalizedPath(value: string, op: WriteOp): string {
+  try {
+    return normalizeRelativeDocumentPath(value);
+  } catch (error) {
+    rejectWrite(error instanceof Error ? error.message : String(error), op.entityId);
+  }
+}
+
+function statusPath(line: string): string {
+  if (line.length < 4) return "";
+  const value = line.slice(3).trim();
+  const renamed = value.lastIndexOf(" -> ");
+  return (renamed >= 0 ? value.slice(renamed + 4) : value).replace(/^"|"$/gu, "");
+}
+
+function remediation(taskId: string): string {
+  return `${CODE_DOC_RECONCILIATION_PATH} is a reserved machine document; do not write or stage it directly. Run ha task code-doc reconcile ${taskId} --commit <40-sha> --path <repo-relative-path> [--pr <url>]`;
+}
+
+function isFullSha(value: string | undefined): value is string {
+  return typeof value === "string" && /^[0-9a-f]{40}$/u.test(value);
+}
+
+function isRecordKind(value: unknown): value is CodeDocRecord["kind"] {
+  return value === "closeout" || value === "review" || value === "evidence" || value === "decision-claim";
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -24,6 +24,8 @@ import { hashTaskProjectionRows } from "../projection/sqlite-task-projection.ts"
 import { readMarkdownSource } from "../projection/sqlite-task-source.ts";
 import { appendJsonLineDurably, readDurableState, readPayloadRef, writePayloadRef, writeWatermarkDurably, writeFileDurably } from "./write-journal-durable.ts";
 import { assertCommitPlanAddable, commitTouchedPaths } from "./write-journal-git.ts";
+import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
+import { assertCodeDocGitEvidence, assertNoUncoordinatedCodeDocChange } from "./write-journal-code-doc-policy.ts";
 import { runLedgerMaterializer } from "./ledger-materializer.ts";
 import { assertDirectWriteAllowed, withRepoLocks, WriteLockHeldError } from "./write-journal-locks.ts";
 import { NonTaskWriteEntityError, taskIdForJournalRecord } from "./write-journal-entity.ts";
@@ -292,7 +294,12 @@ function createJournalRecord(rootDir: string, journalPath: string, op: {
 }
 
 function preflightWriteOp(rootDir: string, rootInput: HarnessLayoutInput, op: WriteOp, versionControlSystem?: VersionControlSystem): void {
-  assertCommitPlanAddable(rootDir, writeOpTouchedPaths(rootInput, op), rootInput, { versionControlSystem });
+  const vcs = versionControlSystem ?? makeLocalVersionControlSystem();
+  const plan = assertCommitPlanAddable(rootDir, writeOpTouchedPaths(rootInput, op), rootInput, { versionControlSystem: vcs });
+  assertCodeDocGitEvidence(rootDir, op, vcs);
+  if (op.kind === "task_tree_stage" && plan) {
+    assertNoUncoordinatedCodeDocChange(op, vcs.workingTreeFiles(plan.repoRoot, plan.relativePaths));
+  }
   try {
     assertDocumentWritePathsDoNotCollide(rootInput, documentWritesForWriteOp(op));
   } catch (error) {
@@ -365,7 +372,7 @@ function recordCommitDetail(kind: JournalRecordKind, payload: Record<string, unk
   if (kind === "transition_local" && typeof payload.to === "string") return `-> ${payload.to}`;
   if (kind === "progress_append") return "progress.md";
   if ((kind === "machine_artifact_write" || kind === "machine_artifact_append_jsonl") && typeof payload.path === "string") return payload.path;
-  if ((kind === "doc_write" || kind === "doc_stage") && typeof payload.path === "string") return payload.path;
+  if ((kind === "doc_write" || kind === "doc_stage" || kind === "code_doc_reconcile") && typeof payload.path === "string") return payload.path;
   if (kind === "task_tree_stage") return "task package";
   if (kind === "module_registry_write" && typeof payload.operation === "string") return payload.operation;
   if (kind === "module_scaffold_write") return "scaffold";

--- a/packages/kernel/src/store/write-journal-operations-internal.ts
+++ b/packages/kernel/src/store/write-journal-operations-internal.ts
@@ -153,6 +153,7 @@ const documentWriteKinds = new Set<WriteOp["kind"]>([
   "transition_local",
   "progress_append",
   "doc_write",
+  "code_doc_reconcile",
   "fact_invalidate",
   "package_archive",
   "package_tombstone",

--- a/packages/kernel/src/store/write-journal-operations.ts
+++ b/packages/kernel/src/store/write-journal-operations.ts
@@ -12,6 +12,7 @@ import { taskIdForWriteOp } from "./write-journal-entity.ts";
 import { appendJsonLineDurably, writeFileDurably } from "./write-journal-durable.ts";
 import { rejectTaskWrite, rejectWrite } from "./write-journal-rejection.ts";
 import { resolveContentAddressedBlobPath } from "./content-addressed-blob-store.ts";
+import { assertReservedCodeDocWrite } from "./write-journal-code-doc-policy.ts";
 import { writeDocument } from "./markdown-artifact-store.ts";
 import {
   applyDocumentAppendRecord,
@@ -264,7 +265,9 @@ export function writeTransactionPlan(op: WriteOp): WriteTransactionPlan {
 }
 
 export function validateWriteTransaction(rootInput: HarnessLayoutInput, op: WriteOp): void {
-  writeTransactionPlan(op).validate(rootInput);
+  const plan = writeTransactionPlan(op);
+  assertReservedCodeDocWrite(op, plan.documentWrites());
+  plan.validate(rootInput);
 }
 
 export function applyWriteOp(rootInput: HarnessLayoutInput, op: WriteOp): DocumentWrite | null {

--- a/packages/kernel/test/store/global-committer-lock.test.ts
+++ b/packages/kernel/test/store/global-committer-lock.test.ts
@@ -10,6 +10,7 @@ import { taskEntityId, type WriteError } from "../../src/domain/index.ts";
 import { sha256Text } from "../../src/integrity/stable-hash.ts";
 import type { VersionControlSystem } from "../../src/ports/index.ts";
 import { makeJournaledWriteCoordinator } from "../../src/store/index.ts";
+import { makeLocalVersionControlSystem } from "../../src/store/local-version-control-system.ts";
 import { docWrite, withTempStore, withTempStoreAsync } from "./helpers.ts";
 
 const execFileAsync = promisify(execFile);
@@ -397,6 +398,100 @@ test("double stale lock takeover race keeps a single committer", async () => {
   });
 });
 
+test("WriteCoordinator reserves code-doc-anchors.json for the dedicated operation", () => {
+  withTempStore((rootDir) => {
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+    const genericFailure = runWriteFailure(coordinator.enqueue(docWrite("raw-code-doc", "task-1", "code-doc-anchors.json", "{}")));
+    assert.equal(genericFailure._tag, "WriteRejected");
+    assert.match(genericFailure.reason, /reserved machine document/u);
+    assert.match(genericFailure.reason, /ha task code-doc reconcile task-1/u);
+
+    const invalidDedicated = runWriteFailure(coordinator.enqueue({
+      opId: "bad-code-doc",
+      entityId: taskEntityId("task-1"),
+      kind: "code_doc_reconcile",
+      payload: { path: "code-doc-anchors.json", body: "{}" }
+    }));
+    assert.equal(invalidDedicated._tag, "WriteRejected");
+    assert.match(invalidDedicated.reason, /schema code-doc-reconciliation\/v1/u);
+  });
+});
+
+test("WriteCoordinator accepts validated dedicated code-doc writes", () => {
+  withTempStore((rootDir) => {
+    seedCodeDocTaskLedgers(rootDir);
+    const local = makeLocalVersionControlSystem();
+    const harnessRoot = path.join(rootDir, "harness");
+    const coordinator = makeJournaledWriteCoordinator({
+      rootDir,
+      versionControlSystem: {
+        ...local,
+        normalizePath: (inputPath) => path.resolve(inputPath),
+        topLevel: (inputPath) => path.resolve(inputPath).startsWith(harnessRoot) ? harnessRoot : rootDir,
+        isIgnored: () => false,
+        commitExists: () => true,
+        pathExistsAtCommit: () => true
+      }
+    });
+
+    const ack = Effect.runSync(coordinator.enqueue({
+      opId: "valid-code-doc",
+      entityId: taskEntityId("task-1"),
+      kind: "code_doc_reconcile",
+      payload: { path: "code-doc-anchors.json", body: validCodeDocDocument() }
+    }));
+
+    assert.equal(ack.accepted, true);
+  });
+});
+
+test("WriteCoordinator rejects task-tree staging with a hand-written code-doc file", () => {
+  withTempStore((rootDir) => {
+    seedCodeDocTaskLedgers(rootDir);
+    const local = makeLocalVersionControlSystem();
+    const harnessRoot = path.join(rootDir, "harness");
+    const coordinator = makeJournaledWriteCoordinator({
+      rootDir,
+      versionControlSystem: {
+        ...local,
+        normalizePath: (inputPath) => path.resolve(inputPath),
+        topLevel: (inputPath) => path.resolve(inputPath).startsWith(harnessRoot) ? harnessRoot : rootDir,
+        isIgnored: () => false,
+        workingTreeFiles: () => "?? tasks/task-1/code-doc-anchors.json\n"
+      }
+    });
+
+    const failure = runWriteFailure(coordinator.enqueue({
+      opId: "stage-raw-code-doc",
+      entityId: taskEntityId("task-1"),
+      kind: "task_tree_stage",
+      payload: { scope: "task-package" }
+    }));
+
+    assert.equal(failure._tag, "WriteRejected");
+    assert.match(failure.reason, /do not write or stage it directly/u);
+  });
+});
+
+function seedCodeDocTaskLedgers(rootDir: string): void {
+  const taskRoot = path.join(rootDir, "harness/tasks/task-1");
+  mkdirSync(taskRoot, { recursive: true });
+  writeFileSync(path.join(taskRoot, "closeout.md"), "# Closeout\n", "utf8");
+}
+
+function validCodeDocDocument(): string {
+  return `${JSON.stringify({
+    schema: "code-doc-reconciliation/v1",
+    taskId: "task-1",
+    records: [{
+      id: "closeout",
+      ledgerPath: "closeout.md",
+      kind: "closeout",
+      anchors: [{ kind: "path", sha: "0123456789abcdef0123456789abcdef01234567", path: "packages/kernel/src/index.ts" }]
+    }]
+  }, null, 2)}\n`;
+}
+
 function runWriteFailure<A>(effect: Effect.Effect<A, WriteError>): WriteError {
   const result = Effect.runSync(Effect.either(effect));
   assert.equal(result._tag, "Left");
@@ -414,6 +509,7 @@ function fakeVersionControlSystem(repoRoot: string): VersionControlSystem {
     topLevel: (inputPath) => path.resolve(inputPath).startsWith(`${harnessRoot}${path.sep}`) || path.resolve(inputPath) === harnessRoot ? harnessRoot : repoRoot,
     isIgnored: () => false,
     add: () => undefined,
+    workingTreeFiles: () => "",
     stagedFiles: () => "tasks/task-1/notes.md\n",
     commit: () => {
       commitCount += 1;

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -19,7 +19,7 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@161:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@162:9",
         "ref": "task_01KX68A7MK6HH9TM16T95M8ZZK",
         "reason": "P3-1 hard-delete apply relocated from coordinator to the op transaction plan; same coordinator-executed durable write path, not a bypass caller."
       },
@@ -224,27 +224,27 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@364:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@367:9",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@387:3",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@390:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@399:5",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@402:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@367:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@370:9",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#writeFileSync@365:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#writeFileSync@368:9",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       }

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -87,7 +87,7 @@
       "bearing": "task-document",
       "channel": { "pathClass": "doc-sync-allowed", "zoneClass": "task-authored-prose-or-stage" },
       "entry": ["cli", "daemon-rpc", "internal", "gui-review"],
-      "writeKinds": ["doc_write", "doc_stage", "task_tree_stage"],
+      "writeKinds": ["doc_write", "doc_stage", "task_tree_stage", "code_doc_reconcile"],
       "cliActions": ["task-amend", "task-code-doc-reconcile", "task-relate"],
       "callsiteFiles": ["packages/adapters/local/src/task-writes.ts"],
       "directWrites": [


### PR DESCRIPTION
# English

### Summary

Reserve `code-doc-anchors.json` as a machine-authored task document. Normal task closeout can now write it only through `ha task code-doc reconcile`, which emits a dedicated `code_doc_reconcile` WriteOp through Write Coordinator.

### Changes

- Added a dedicated coordinator operation and local engine method for code-doc reconciliation writes.
- Added Coordinator preflight validation for route, JSON/schema, task/record structure, full commit SHAs, and path-at-commit evidence.
- Generic `doc_write`, `doc_stage`, package batch writes, and other operation kinds are rejected when they target the reserved path.
- `task_tree_stage` rejects dirty or untracked hand-authored `code-doc-anchors.json` files with an executable remediation command.
- Preserved all four contract record kinds: `closeout`, `review`, `evidence`, and `decision-claim`; the current generator emits the first two.
- Updated successful lifecycle fixtures to call the CLI instead of hand-writing JSON.

### Validation

- Targeted Coordinator and lifecycle regression tests: 65 passed, 0 failed.
- Full Node suite: 1231 passed, 0 failed, 1 skipped.
- GUI suite: 39 passed, 0 failed.
- Package manifest gates: 35 passed.
- `check-bypass-write-boundary`: 125 existing governed calls, delta 0.
- `check-write-road-registry`: 32 rows and 308 discovered write surfaces passed.

### Governance and authority

- Task: `task_01KX7KMMXF6B6C8VSMX3JWRVR7` (`Enforce CLI-only code-doc anchor writes`), risk tier high.
- Parent task: `task_01KX69SACPDC93JAP373PM2979` (`code-doc anchor authoring CLI`).
- `tools/write-road-registry.json` adds the dedicated WriteOp to the existing task-document road.
- `tools/gate-allowlists/check-bypass-write-boundary.json` only relocates six existing entries after source line movement; the governed debt count remains 125.
- No gate logic was weakened and no break-glass path was used.

# 中文

### 摘要

将 `code-doc-anchors.json` 定义为机器生成的 Task 文档。正常收尾只能通过 `ha task code-doc reconcile` 写入，由该命令向 Write Coordinator 提交专用 `code_doc_reconcile` WriteOp。

### 变更

- 新增专用 Coordinator operation 和本地 engine 写入方法。
- Coordinator 在入队时二次校验写路、JSON/schema、Task/record 结构、完整 commit SHA 与 path-at-commit 证据。
- 通用 `doc_write`、`doc_stage`、package batch 和其他 operation 命中保留路径时全部拒绝。
- `task_tree_stage` 发现手写或未提交的 `code-doc-anchors.json` 时拒绝整包 stage，并返回可执行修复命令。
- 兼容契约现有四种 record kind：`closeout`、`review`、`evidence`、`decision-claim`；当前生成器先生成前两种。
- 成功生命周期测试夹具改为真实调用 CLI，不再手写 JSON。

### 验证

- Coordinator 与生命周期针对性回归：65 通过，0 失败。
- 完整 Node：1231 通过，0 失败，1 跳过。
- GUI：39 通过，0 失败。
- Package manifest gates：35 通过。
- `check-bypass-write-boundary`：既有受治理调用 125，增量 0。
- `check-write-road-registry`：32 条写路、308 个发现的写面全部通过。

### 治理与授权

- Task：`task_01KX7KMMXF6B6C8VSMX3JWRVR7`，高风险写路径修复。
- 前置 Task：`task_01KX69SACPDC93JAP373PM2979`，code-doc authoring CLI。
- `tools/write-road-registry.json` 将专用 WriteOp 登记到现有 task-document 写路。
- `tools/gate-allowlists/check-bypass-write-boundary.json` 只重定位 6 条因代码行移动而漂移的既有记录，债务数仍为 125。
- 没有削弱 gate，没有使用 break-glass。

## 治理声明

- 授权 Task：`task_01KX7KMMXF6B6C8VSMX3JWRVR7`，高风险 code-doc 写路径治理修复。
- 前置授权：`task_01KX69SACPDC93JAP373PM2979`。
- 受保护路径：`tools/write-road-registry.json` 与 `tools/gate-allowlists/check-bypass-write-boundary.json`。
- Break-glass：未使用。
- 影响：登记专用 WriteOp，并重定位既有 allowlist 行号；没有削弱任何 checker。
