### PR TITLE
feat: session entity as first composite-manifest-blob declaration (F2)

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -37,6 +37,8 @@ export {
   taskHolderPrincipalFromActor
 } from "../../kernel/src/index.ts";
 export { makeProvenanceSessionExporter } from "./provenance-session-exporter.ts";
+export { readSessionEntity } from "./session-entity-reader.ts";
+export type { SessionEntityReadResult } from "./session-entity-reader.ts";
 export { classifyStaticZones, classifyTouchedZones, forbiddenTouchesForZones } from "./doc-sync.ts";
 export { makeRuntimeEventAppendPromise, makeRuntimeEventLedgerService } from "./runtime-event-ledger-service.ts";
 export { listDecisionDocuments, readDecisionDocument } from "./decision-document-reader.ts";

--- a/packages/application/src/provenance-session-exporter.ts
+++ b/packages/application/src/provenance-session-exporter.ts
@@ -1,8 +1,9 @@
 import path from "node:path";
 import { Effect } from "effect";
-import type { ArtifactStore, CurrentSessionProbePort, CurrentSessionRef, CurrentSessionRuntime, CurrentSessionSource, WriteCoordinator, WriteError } from "../../kernel/src/index.ts";
-import { moduleEntityId, readFrontmatter, readScalar, resolveHarnessLayout, stablePayloadHash, writeContentAddressedBlob, writeCoordinatedPayload, type HarnessLayoutInput } from "../../kernel/src/index.ts";
+import type { ArtifactStore, CurrentSessionProbePort, CurrentSessionRef, CurrentSessionRuntime, CurrentSessionSource, SessionManifest, WriteCoordinator, WriteError } from "../../kernel/src/index.ts";
+import { privateTextScannerVersion, resolveHarnessLayout, scanPrivateText, writeContentAddressedBlob, writeSessionEntity, type HarnessLayoutInput } from "../../kernel/src/index.ts";
 import { discoverRuntimeSessions, displayRuntimePath, resolveRuntimeConversation, type RuntimeConversation, type RuntimeConversationMessage } from "./runtime-session-logs.ts";
+import { readSessionEntity } from "./session-entity-reader.ts";
 
 export interface ProvenanceSessionExporterOptions {
   readonly rootInput: HarnessLayoutInput;
@@ -47,7 +48,7 @@ export interface ProvenanceSessionBackfillResult {
 export interface ProvenanceSessionExporterRejected {
   readonly _tag: "ProvenanceSessionExporterRejected";
   readonly sessionId: string;
-  readonly code: "transcript_unavailable" | "session_not_found" | "read_failed" | "write_failed";
+  readonly code: "transcript_unavailable" | "privacy_scan_failed" | "session_not_found" | "read_failed" | "write_failed";
   readonly reason: string;
 }
 
@@ -114,20 +115,28 @@ function writeSessionDocument(
         "transcript_unavailable"
       ));
     }
+    const privacyFindings = [
+      ...scanPrivateText(JSON.stringify(session), "manifest"),
+      ...conversation.messages.flatMap((message, index) => scanPrivateText(message.text, `snapshot.messages.${index}`))
+    ];
+    if (privacyFindings.some((finding) => finding.severity === "error")) {
+      return yield* Effect.fail(sessionRejection(
+        session.sessionId,
+        `privacy scan failed: ${privacyFindings.map((finding) => finding.ruleId).join(", ")}`,
+        "privacy_scan_failed"
+      ));
+    }
     const body = renderSessionMarkdown(session, conversation);
     const bodyRef = yield* Effect.try({
-      try: () => writeContentAddressedBlob(rootInput, body, sessionMediaType),
+      try: () => ({
+        store: "authored-cas/v1" as const,
+        ...writeContentAddressedBlob(rootInput, body, sessionMediaType)
+      }),
       catch: (cause) => sessionRejection(session.sessionId, cause instanceof Error ? cause.message : String(cause), "write_failed")
     });
-    return yield* writeCoordinatedPayload(options.coordinator, stablePayloadHash, {
-      entityId: moduleEntityId("provenance-session"),
-      kind: "machine_artifact_write",
-      opIdPrefix: `session-export-${session.sessionId}`,
-      payload: {
-        boundary: "provenance-session",
-        path: target.rootRelativePath,
-        bodyRef
-      }
+    const manifest = toSessionManifest(session, conversation, bodyRef, privacyFindings);
+    return yield* writeSessionEntity(options.coordinator, rootInput, manifest, {
+      opIdPrefix: `session-export-${session.sessionId}`
     }).pipe(
       Effect.map(() => ({
         session,
@@ -140,35 +149,38 @@ function writeSessionDocument(
 
 function readSessionDocument(
   rootInput: HarnessLayoutInput,
-  options: Pick<ProvenanceSessionExporterOptions, "artifactStore">,
+  _options: Pick<ProvenanceSessionExporterOptions, "artifactStore">,
   sessionId: string
 ): Effect.Effect<ProvenanceSessionExportResult, ProvenanceSessionExporterRejected> {
-  return Effect.gen(function* () {
-    const target = resolveSessionPath(rootInput, sessionId);
-    return yield* options.artifactStore.readAuthoredDocument(target.authoredRelativePath).pipe(
-      Effect.mapError((error) => sessionRejection(
-        sessionId,
-        error._tag === "ArtifactReadFailed" ? `session not found: ${sessionId}` : "session read failed",
-        error._tag === "ArtifactReadFailed" ? "session_not_found" : "read_failed"
-      )),
-      Effect.flatMap((document) => Effect.try({
-        try: () => {
-          const body = document.body;
-          const session = parseSessionMarkdown(body, sessionId);
-          if (session.runtime !== "human" && !/^### (?:User|Assistant|Summary)(?: \(|$)/mu.test(body)) {
-            throw new Error(`session transcript unavailable: ${sessionId}`);
-          }
-          return {
-            session,
-            path: target.authoredRelativePath
-          };
+  return Effect.try({
+    try: () => {
+      const target = resolveSessionPath(rootInput, sessionId);
+      const result = readSessionEntity(rootInput, sessionId);
+      const metadata = result.format === "manifest" ? result.manifest : result.metadata;
+      assertRuntime(metadata.runtime);
+      assertSource(metadata.source);
+      return {
+        session: {
+          schema: sessionSchema,
+          sessionId: metadata.sessionId,
+          runtime: metadata.runtime,
+          source: metadata.source,
+          detectedAt: metadata.detectedAt,
+          exportedAt: metadata.exportedAt,
+          ...(metadata.user ? { user: metadata.user } : {})
         },
-        catch: (cause) => {
-          const reason = cause instanceof Error ? cause.message : "session read failed";
-          return sessionRejection(sessionId, reason, reason.startsWith("session transcript unavailable:") ? "transcript_unavailable" : "read_failed");
-        }
-      }))
-    );
+        path: target.authoredRelativePath
+      };
+    },
+    catch: (cause) => {
+      const reason = cause instanceof Error ? cause.message : "session read failed";
+      const missing = isMissingFileError(cause);
+      return sessionRejection(
+        sessionId,
+        missing ? `session not found: ${sessionId}` : reason,
+        missing ? "session_not_found" : reason.startsWith("session transcript unavailable:") ? "transcript_unavailable" : "read_failed"
+      );
+    }
   });
 }
 
@@ -207,29 +219,6 @@ function resolveSessionPath(rootInput: HarnessLayoutInput, sessionId: string): {
   };
 }
 
-function parseSessionMarkdown(body: string, expectedSessionId: string): ProvenanceSessionDocument {
-  const frontmatter = readFrontmatter(body);
-  if (!frontmatter) throw new Error("session markdown missing frontmatter");
-  const schema = readScalar(frontmatter, "schema", { required: true });
-  if (schema !== sessionSchema) throw new Error(`unsupported session schema: ${schema}`);
-  const sessionId = readScalar(frontmatter, "sessionId", { required: true });
-  if (sessionId !== expectedSessionId) throw new Error(`session id mismatch: ${sessionId}`);
-  const runtime = readScalar(frontmatter, "runtime", { required: true });
-  const source = readScalar(frontmatter, "source", { required: true });
-  assertRuntime(runtime);
-  assertSource(source);
-  const user = readScalar(frontmatter, "user");
-  return {
-    schema,
-    sessionId,
-    runtime,
-    source,
-    detectedAt: readScalar(frontmatter, "detectedAt", { required: true }),
-    exportedAt: readScalar(frontmatter, "exportedAt", { required: true }),
-    ...(user ? { user } : {})
-  };
-}
-
 function renderSessionMarkdown(session: ProvenanceSessionDocument, conversation: RuntimeConversation): string {
   return [
     "---",
@@ -257,6 +246,42 @@ function renderSessionMarkdown(session: ProvenanceSessionDocument, conversation:
     ...renderConversationMessages(conversation.messages),
     ""
   ].join("\n");
+}
+
+function toSessionManifest(
+  session: ProvenanceSessionDocument,
+  conversation: RuntimeConversation,
+  bodyRef: SessionManifest["bodyRef"],
+  privacyFindings: SessionManifest["snapshot"]["privacyScan"]["findings"]
+): SessionManifest {
+  const timestamps = conversation.messages.flatMap((message) => message.timestamp ? [message.timestamp] : []);
+  const complete = session.runtime === "human" || conversation.warnings.length === 0;
+  return {
+    schema: "session-entity/v1",
+    sessionId: session.sessionId,
+    lifecycle: complete ? "sealed" : "partial",
+    archiveStatus: complete ? "complete" : "partial",
+    runtime: session.runtime,
+    source: session.source,
+    detectedAt: session.detectedAt,
+    exportedAt: session.exportedAt,
+    ...(session.user ? { user: session.user } : {}),
+    bodyRef,
+    snapshot: {
+      capturedAt: session.exportedAt,
+      completeness: complete ? "complete" : "partial",
+      captureRange: {
+        messageCount: conversation.messages.length,
+        ...(timestamps[0] ? { firstMessageAt: timestamps[0] } : {}),
+        ...(timestamps.at(-1) ? { lastMessageAt: timestamps.at(-1) } : {})
+      },
+      privacyScan: {
+        scannerVersion: privateTextScannerVersion,
+        passed: true,
+        findings: privacyFindings
+      }
+    }
+  };
 }
 
 function renderWarnings(warnings: ReadonlyArray<string>): ReadonlyArray<string> {
@@ -321,4 +346,8 @@ function writeErrorMessage(error: WriteError): string {
   if (error._tag === "WriteConflict") return error.owner ? `write conflict for ${error.taskId}: ${error.owner}` : `write conflict for ${error.taskId}`;
   if (error._tag === "GlobalWriteConflict") return error.owner ? `global write conflict: ${error.owner}` : "global write conflict";
   return error.cause instanceof Error ? error.cause.message : "session export failed";
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === "ENOENT");
 }

--- a/packages/application/src/provenance-session-exporter.ts
+++ b/packages/application/src/provenance-session-exporter.ts
@@ -48,7 +48,7 @@ export interface ProvenanceSessionBackfillResult {
 export interface ProvenanceSessionExporterRejected {
   readonly _tag: "ProvenanceSessionExporterRejected";
   readonly sessionId: string;
-  readonly code: "transcript_unavailable" | "privacy_scan_failed" | "session_not_found" | "read_failed" | "write_failed";
+  readonly code: "transcript_unavailable" | "session_not_found" | "read_failed" | "write_failed";
   readonly reason: string;
 }
 
@@ -115,17 +115,13 @@ function writeSessionDocument(
         "transcript_unavailable"
       ));
     }
+    // Capture is report-only: sessions land in the private ledger (system of record),
+    // so findings are recorded honestly in the manifest and enforcement stays at the
+    // publish boundary (buildPublishableProjection fails closed there).
     const privacyFindings = [
       ...scanPrivateText(JSON.stringify(session), "manifest"),
       ...conversation.messages.flatMap((message, index) => scanPrivateText(message.text, `snapshot.messages.${index}`))
     ];
-    if (privacyFindings.some((finding) => finding.severity === "error")) {
-      return yield* Effect.fail(sessionRejection(
-        session.sessionId,
-        `privacy scan failed: ${privacyFindings.map((finding) => finding.ruleId).join(", ")}`,
-        "privacy_scan_failed"
-      ));
-    }
     const body = renderSessionMarkdown(session, conversation);
     const bodyRef = yield* Effect.try({
       try: () => ({
@@ -277,7 +273,7 @@ function toSessionManifest(
       },
       privacyScan: {
         scannerVersion: privateTextScannerVersion,
-        passed: true,
+        passed: !privacyFindings.some((finding) => finding.severity === "error"),
         findings: privacyFindings
       }
     }

--- a/packages/application/src/session-entity-reader.ts
+++ b/packages/application/src/session-entity-reader.ts
@@ -1,0 +1,24 @@
+import {
+  readContentAddressedTextBlob,
+  readSessionEntityDocument,
+  type HarnessLayoutInput,
+  type SessionManifest
+} from "../../kernel/src/index.ts";
+
+export interface SessionEntityReadResult {
+  readonly format: "manifest";
+  readonly manifest: SessionManifest;
+  readonly body: string;
+}
+
+export function readSessionEntity(
+  rootInput: HarnessLayoutInput,
+  sessionId: string
+): SessionEntityReadResult | Exclude<ReturnType<typeof readSessionEntityDocument>, { readonly format: "manifest" }> {
+  const result = readSessionEntityDocument(rootInput, sessionId);
+  if (result.format === "legacy") return result;
+  return {
+    ...result,
+    body: readContentAddressedTextBlob(rootInput, result.manifest.bodyRef)
+  };
+}

--- a/packages/application/test/provenance-session-exporter.test.ts
+++ b/packages/application/test/provenance-session-exporter.test.ts
@@ -4,12 +4,12 @@ import path from "node:path";
 import assert from "node:assert/strict";
 import test from "node:test";
 import { Effect } from "effect";
-import { bindCreateProvenance, makeHumanFallbackSessionProbe, makeProvenanceSessionExporter } from "../src/index.ts";
-import { makeJournaledWriteCoordinator, makeMarkdownArtifactStore, moduleEntityId, type CurrentSessionRef, type WriteCoordinator, type WriteError } from "../../kernel/src/index.ts";
+import { bindCreateProvenance, makeHumanFallbackSessionProbe, makeProvenanceSessionExporter, readSessionEntity } from "../src/index.ts";
+import { makeJournaledWriteCoordinator, makeMarkdownArtifactStore, type CurrentSessionRef, type WriteCoordinator, type WriteError } from "../../kernel/src/index.ts";
 import type { ProvenanceSessionExporterOptions } from "../src/index.ts";
 import { runEffect, runEffectExit } from "./effect-test-helpers.ts";
 
-test("provenance session exporter writes human fallback markdown and reads it by id", async () => {
+test("provenance session exporter writes a compact manifest and reads its immutable body by id", async () => {
   const rootDir = createHarnessRoot();
   try {
     const exporter = makeTestProvenanceSessionExporter(rootDir, {
@@ -34,11 +34,15 @@ test("provenance session exporter writes human fallback markdown and reads it by
 
     const sessionPath = path.join(rootDir, "harness", exported.path);
     assert.equal(existsSync(sessionPath), true);
-    const body = readFileSync(sessionPath, "utf8");
-    assert.match(body, /^schema: provenance-session\/v1$/m);
-    assert.match(body, /^sessionId: human-cli-1783036800000$/m);
-    assert.match(body, /^runtime: human$/m);
-    assert.match(body, /^source: manual$/m);
+    const manifestBody = readFileSync(sessionPath, "utf8");
+    assert.equal(manifestBody.includes("## Conversation"), false);
+    const stored = readSessionEntity(rootDir, "human-cli-1783036800000");
+    assert.equal(stored.format, "manifest");
+    if (stored.format !== "manifest") assert.fail("expected a Session Entity manifest");
+    assert.equal(stored.manifest.schema, "session-entity/v1");
+    assert.equal(stored.manifest.sessionId, "human-cli-1783036800000");
+    assert.equal(stored.manifest.bodyRef.store, "authored-cas/v1");
+    assert.match(stored.body, /## Conversation/u);
 
     const readBack = await runEffect(exporter.readById("human-cli-1783036800000"));
     assert.deepEqual(readBack, exported);
@@ -77,7 +81,7 @@ test("provenance session exporter renders Claude Code JSONL conversation text", 
     });
 
     const exported = await runEffect(exporter.exportCurrentSession());
-    const body = readFileSync(path.join(rootDir, "harness", exported.path), "utf8");
+    const body = readSessionEntity(rootDir, exported.session.sessionId).body;
     assert.match(body, /## Conversation/u);
     assert.match(body, /Claude user original line/u);
     assert.match(body, /Claude assistant original line/u);
@@ -120,17 +124,15 @@ test("provenance session exporter renders Codex JSONL conversation text", async 
     });
 
     const exported = await runEffect(exporter.exportCurrentSession());
-    const body = readFileSync(path.join(rootDir, "harness", exported.path), "utf8");
+    const stored = readSessionEntity(rootDir, exported.session.sessionId);
+    const body = stored.body;
     assert.match(body, /## Conversation/u);
     assert.match(body, /Codex user original line/u);
     assert.match(body, /Codex assistant original line/u);
 
-    const payload = readOnlyJournalPayload(rootDir);
-    assert.equal(payload.boundary, "provenance-session");
-    assert.equal(payload.path, "harness/sessions/codex-session-1.md");
-    assert.equal("body" in payload, false);
-    assert.equal(JSON.stringify(payload).includes("Codex user original line"), false);
-    const bodyRef = assertContentAddressedBlobRef(payload.bodyRef);
+    assert.equal(stored.format, "manifest");
+    if (stored.format !== "manifest") assert.fail("expected a Session Entity manifest");
+    const bodyRef = stored.manifest.bodyRef;
     assert.equal(bodyRef.mediaType, "text/markdown; charset=utf-8");
     assert.equal(readFileSync(path.join(rootDir, bodyRef.ref), "utf8"), body);
   } finally {
@@ -171,10 +173,40 @@ test("provenance session exporter accepts an explicit runtime transcript file", 
     });
 
     const exported = await runEffect(exporter.exportCurrentSession({ transcriptFile }));
-    const body = readFileSync(path.join(rootDir, "harness", exported.path), "utf8");
+    const body = readSessionEntity(rootDir, exported.session.sessionId).body;
     assert.match(body, /Export this Desktop transcript explicitly\./u);
     assert.match(body, /The explicit transcript was archived\./u);
     assert.match(body, new RegExp(`Runtime log: ${transcriptFile.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}`, "u"));
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("provenance session exporter fails closed before persisting privacy scan findings", async () => {
+  const rootDir = createHarnessRoot();
+  try {
+    const transcriptFile = path.join(rootDir, "private-thread.jsonl");
+    writeFileSync(transcriptFile, JSON.stringify({
+      timestamp: "2026-07-03T00:00:00.000Z",
+      type: "event_msg",
+      payload: { type: "user_message", message: "api_key=must-not-persist" }
+    }), "utf8");
+    const exporter = makeTestProvenanceSessionExporter(rootDir, {
+      currentSessionProbe: fixedSessionProbe({
+        runtime: "codex",
+        sessionId: "private-session",
+        source: "runtime",
+        detectedAt: "2026-07-03T00:00:00.000Z"
+      }),
+      now: () => "2026-07-03T00:01:00.000Z"
+    });
+
+    const result = await runEffectExit(exporter.exportCurrentSession({ transcriptFile }));
+
+    assert.equal(result._tag, "Failure");
+    assert.match(String(result.cause), /privacy scan failed/u);
+    assert.equal(existsSync(path.join(rootDir, "harness/sessions/private-session.md")), false);
+    assert.equal(existsSync(path.join(rootDir, "harness/objects")), false);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
@@ -227,31 +259,18 @@ test("provenance session exporter dedupes identical claim-check blobs and verifi
     await runEffect(exporter.exportCurrentSession());
     await runEffect(exporter.exportCurrentSession());
 
-    const payload = readOnlyJournalPayload(rootDir);
-    const bodyRef = assertContentAddressedBlobRef(payload.bodyRef);
+    const stored = readSessionEntity(rootDir, "codex-session-1");
+    assert.equal(stored.format, "manifest");
+    if (stored.format !== "manifest") assert.fail("expected a Session Entity manifest");
+    const bodyRef = stored.manifest.bodyRef;
     assert.deepEqual(listObjectFiles(rootDir), [bodyRef.ref]);
     assert.match(readFileSync(path.join(rootDir, bodyRef.ref), "utf8"), /Deduped Codex user line/u);
 
     writeFileSync(path.join(rootDir, bodyRef.ref), "corrupted blob", "utf8");
-    const corruptCoordinator = makeJournaledWriteCoordinator({ rootDir });
-    const corruptResult = await runEffect(Effect.either(Effect.gen(function* () {
-      yield* corruptCoordinator.enqueue({
-        opId: "session-export-corrupt-blob",
-        entityId: moduleEntityId("provenance-session"),
-        kind: "machine_artifact_write",
-        payload: {
-          boundary: "provenance-session",
-          path: "harness/sessions/corrupt.md",
-          bodyRef
-        }
-      });
-      yield* corruptCoordinator.flush("explicit");
-    })));
-    assert.equal(corruptResult._tag, "Left");
-    if (corruptResult._tag === "Left") {
-      assert.equal(corruptResult.left._tag, "JournalUnavailable");
-      assert.match(corruptResult.left.cause instanceof Error ? corruptResult.left.cause.message : String(corruptResult.left.cause), /content-addressed blob sha256 mismatch/u);
-    }
+    assert.throws(
+      () => readSessionEntity(rootDir, "codex-session-1"),
+      /content-addressed blob sha256 mismatch/u
+    );
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
@@ -354,7 +373,7 @@ test("provenance session exporter renders ZCode model I/O JSONL conversation tex
     });
 
     const exported = await runEffect(exporter.exportCurrentSession());
-    const body = readFileSync(path.join(rootDir, "harness", exported.path), "utf8");
+    const body = readSessionEntity(rootDir, exported.session.sessionId).body;
     assert.match(body, /## Conversation/u);
     assert.match(body, /ZCode user original line/u);
     assert.match(body, /ZCode assistant original line/u);
@@ -393,7 +412,7 @@ test("provenance session exporter backfills Codex runtime logs by discovered ses
 
     assert.equal(result.schema, "provenance-session-backfill/v1");
     assert.deepEqual(result.exported.map((entry) => entry.session.sessionId), ["codex-thread-1"]);
-    const body = readFileSync(path.join(rootDir, "harness", "sessions", "codex-thread-1.md"), "utf8");
+    const body = readSessionEntity(rootDir, "codex-thread-1").body;
     assert.match(body, /Backfilled Codex user line/u);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
@@ -430,7 +449,7 @@ test("provenance session exporter backfills ZCode runtime logs by discovered ses
 
     assert.equal(result.schema, "provenance-session-backfill/v1");
     assert.deepEqual(result.exported.map((entry) => entry.session.sessionId), ["sess_zcode-thread-1"]);
-    const body = readFileSync(path.join(rootDir, "harness", "sessions", "sess_zcode-thread-1.md"), "utf8");
+    const body = readSessionEntity(rootDir, "sess_zcode-thread-1").body;
     assert.match(body, /Backfilled ZCode user line/u);
     assert.match(body, /Backfilled ZCode assistant line/u);
   } finally {
@@ -575,32 +594,6 @@ function createHarnessRoot(): string {
   mkdirSync(path.join(rootDir, "harness"), { recursive: true });
   writeFileSync(path.join(rootDir, "harness", "harness.yaml"), "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n", "utf8");
   return rootDir;
-}
-
-function readOnlyJournalPayload(rootDir: string): Record<string, unknown> {
-  const payloadRoot = path.join(rootDir, ".harness", "write-journal", "payloads");
-  const payloadFiles = readdirSync(payloadRoot).filter((entry) => entry.endsWith(".json"));
-  assert.equal(payloadFiles.length, 1);
-  return JSON.parse(readFileSync(path.join(payloadRoot, payloadFiles[0]!), "utf8")) as Record<string, unknown>;
-}
-
-interface TestContentAddressedBlobRef {
-  readonly ref: string;
-  readonly sha256: string;
-  readonly size: number;
-  readonly mediaType: string;
-}
-
-function assertContentAddressedBlobRef(value: unknown): TestContentAddressedBlobRef {
-  assert.equal(Boolean(value && typeof value === "object"), true);
-  const candidate = value as Partial<TestContentAddressedBlobRef>;
-  assert.equal(typeof candidate.ref, "string");
-  assert.equal(typeof candidate.sha256, "string");
-  assert.equal(typeof candidate.size, "number");
-  assert.equal(typeof candidate.mediaType, "string");
-  assert.match(candidate.sha256!, /^[0-9a-f]{64}$/u);
-  assert.equal(candidate.ref, `harness/objects/sha256/${candidate.sha256!.slice(0, 2)}/${candidate.sha256!.slice(2)}`);
-  return candidate as TestContentAddressedBlobRef;
 }
 
 function listObjectFiles(rootDir: string): ReadonlyArray<string> {

--- a/packages/application/test/provenance-session-exporter.test.ts
+++ b/packages/application/test/provenance-session-exporter.test.ts
@@ -182,14 +182,14 @@ test("provenance session exporter accepts an explicit runtime transcript file", 
   }
 });
 
-test("provenance session exporter fails closed before persisting privacy scan findings", async () => {
+test("provenance session exporter records privacy scan findings in the manifest without blocking capture", async () => {
   const rootDir = createHarnessRoot();
   try {
     const transcriptFile = path.join(rootDir, "private-thread.jsonl");
     writeFileSync(transcriptFile, JSON.stringify({
       timestamp: "2026-07-03T00:00:00.000Z",
       type: "event_msg",
-      payload: { type: "user_message", message: "api_key=must-not-persist" }
+      payload: { type: "user_message", message: "API_KEY=captured-in-private-ledger" }
     }), "utf8");
     const exporter = makeTestProvenanceSessionExporter(rootDir, {
       currentSessionProbe: fixedSessionProbe({
@@ -203,10 +203,13 @@ test("provenance session exporter fails closed before persisting privacy scan fi
 
     const result = await runEffectExit(exporter.exportCurrentSession({ transcriptFile }));
 
-    assert.equal(result._tag, "Failure");
-    assert.match(String(result.cause), /privacy scan failed/u);
-    assert.equal(existsSync(path.join(rootDir, "harness/sessions/private-session.md")), false);
-    assert.equal(existsSync(path.join(rootDir, "harness/objects")), false);
+    assert.equal(result._tag, "Success");
+    const manifest = JSON.parse(readFileSync(path.join(rootDir, "harness/sessions/private-session.md"), "utf8")) as {
+      snapshot: { privacyScan: { passed: boolean; findings: ReadonlyArray<{ ruleId: string }> } };
+    };
+    assert.equal(manifest.snapshot.privacyScan.passed, false);
+    assert.equal(manifest.snapshot.privacyScan.findings.some((finding) => finding.ruleId === "env-secret-marker"), true);
+    assert.equal(existsSync(path.join(rootDir, "harness/objects")), true);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }

--- a/packages/cli/src/commands/core/session.ts
+++ b/packages/cli/src/commands/core/session.ts
@@ -2,8 +2,9 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import type { CurrentSessionRef } from "../../../../kernel/src/index.ts";
-import { moduleEntityId, resolveHarnessLayout, stablePayloadHash, writeContentAddressedBlob, writeCoordinatedPayload } from "../../../../kernel/src/index.ts";
+import { moduleEntityId, resolveHarnessLayout, stablePayloadHash, writeContentAddressedBlob, writeCoordinatedPayload, writeSessionEntity } from "../../../../kernel/src/index.ts";
 import type { FlushReport, WriteError } from "../../../../kernel/src/index.ts";
+import { readSessionEntity } from "../../../../application/src/index.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult, SessionExportRuntime, SessionExportSource } from "../../cli/types.ts";
 import type { CommandRunner } from "../../cli/runner-registry.ts";
@@ -116,6 +117,16 @@ function writeExistingSessionDocuments(
       const rootRelativePath = rootRelativeSessionPath(context.layoutInput, authoredRelativePath);
       const absolutePath = path.join(resolveHarnessLayout(context.layoutInput).rootDir, rootRelativePath);
       const body = readFileSync(absolutePath, "utf8");
+      if (body.trimStart().startsWith("{")) {
+        const sessionId = path.basename(authoredRelativePath, ".md");
+        const session = readSessionEntity(context.layoutInput, sessionId);
+        if (session.format !== "manifest") throw new Error(`expected Session Entity manifest: ${authoredRelativePath}`);
+        yield* writeSessionEntity(coordinator, context.layoutInput, session.manifest, {
+          flush: false,
+          opIdPrefix: `session-sync-${index}`
+        });
+        continue;
+      }
       const bodyRef = writeContentAddressedBlob(context.layoutInput, body, "text/markdown; charset=utf-8");
       yield* writeCoordinatedPayload(coordinator, stablePayloadHash, {
         entityId: moduleEntityId("provenance-session"),

--- a/packages/cli/test/decision-cli.test.ts
+++ b/packages/cli/test/decision-cli.test.ts
@@ -43,7 +43,10 @@ test("CLI decision propose writes a decision package through the coordinator", (
     const sessionId = /sessionId: "(human-cli-\d+)"/u.exec(body)?.[1];
     assert.ok(sessionId);
     assert.equal(existsSync(path.join(rootDir, "harness", "sessions", `${sessionId}.md`)), true);
-    assert.match(readFileSync(path.join(rootDir, "harness", "sessions", `${sessionId}.md`), "utf8"), /^runtime: human$/mu);
+    const sessionManifest = JSON.parse(readFileSync(path.join(rootDir, "harness", "sessions", `${sessionId}.md`), "utf8")) as { schema: string; sessionId: string; runtime: string };
+    assert.equal(sessionManifest.schema, "session-entity/v1");
+    assert.equal(sessionManifest.sessionId, sessionId);
+    assert.equal(sessionManifest.runtime, "human");
     assert.match(readFileSync(path.join(rootDir, ".harness/write-journal/watermark.json"), "utf8"), /write-watermark\/v1/);
   });
 });

--- a/packages/cli/test/fact-cli.test.ts
+++ b/packages/cli/test/fact-cli.test.ts
@@ -42,7 +42,9 @@ test("CLI record fact writes a task-local stable F-id through the coordinator", 
     assert.match(factsBody, /^- \{fact_id: F-DEADBEEF, statement: "Decision CLI has a human terminal fallback\.", source: "manual verification", observedAt: "2026-07-03T00:00:00\.000Z", confidence: high, memoryClass: semantic, memoryTags: \[tool_memory, pattern\], provenance: \[\{runtime: "human", sessionId: "human-cli-\d+", boundAt: "2026-07-03T00:00:00\.000Z"\}\]\}$/mu);
     const sessionId = /sessionId: "(human-cli-\d+)"/u.exec(factsBody)?.[1];
     assert.ok(sessionId);
-    assert.equal(readFileSync(path.join(rootDir, "harness", "sessions", `${sessionId}.md`), "utf8").includes(`sessionId: ${sessionId}`), true);
+    const sessionManifest = JSON.parse(readFileSync(path.join(rootDir, "harness", "sessions", `${sessionId}.md`), "utf8")) as { schema: string; sessionId: string };
+    assert.equal(sessionManifest.schema, "session-entity/v1");
+    assert.equal(sessionManifest.sessionId, sessionId);
     assert.match(readFileSync(path.join(rootDir, ".harness/write-journal/watermark.json"), "utf8"), /write-watermark\/v1/);
   });
 });

--- a/packages/cli/test/new-task-cli.test.ts
+++ b/packages/cli/test/new-task-cli.test.ts
@@ -166,7 +166,10 @@ function assertHumanProvenance(rootDir: string, index: string): void {
   assert.match(index, /provenance:\n  - \{runtime: "human", sessionId: "human-cli-\d+", boundAt: "\d{4}-\d{2}-\d{2}T/u);
   const sessionId = /sessionId: "(human-cli-\d+)"/u.exec(index)?.[1];
   assert.ok(sessionId);
-  assert.match(readFileSync(path.join(rootDir, "harness", "sessions", `${sessionId}.md`), "utf8"), new RegExp(`sessionId: ${sessionId}`, "u"));
+  const sessionManifest = JSON.parse(readFileSync(path.join(rootDir, "harness", "sessions", `${sessionId}.md`), "utf8")) as { schema: string; sessionId: string; runtime: string };
+  assert.equal(sessionManifest.schema, "session-entity/v1");
+  assert.equal(sessionManifest.sessionId, sessionId);
+  assert.equal(sessionManifest.runtime, "human");
 }
 
 function assertGeneratedTaskId(value: unknown): string {

--- a/packages/cli/test/session-cli.test.ts
+++ b/packages/cli/test/session-cli.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { writeContentAddressedBlob } from "../../kernel/src/index.ts";
+import { readSessionEntity } from "../../application/src/index.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const cleanRuntimeEnv = {
@@ -43,9 +45,9 @@ test("CLI session export binds CODEX_THREAD_ID and writes managed session markdo
     assert.equal(exported.report.session.sessionId, "019f28de-f7f6-7223-a2a8-b2968686fe21");
     assert.equal(exported.report.git.committed, true);
     assert.equal(exported.report.git.coordinator, "write-journal");
-    const body = readFileSync(path.join(rootDir, exported.paths.primary), "utf8");
-    assert.match(body, /sessionId: 019f28de-f7f6-7223-a2a8-b2968686fe21/u);
-    assert.match(body, /Desktop transcript passed explicitly\./u);
+    const stored = readSessionEntity(rootDir, "019f28de-f7f6-7223-a2a8-b2968686fe21");
+    assert.equal(stored.format, "manifest");
+    assert.match(stored.body, /Desktop transcript passed explicitly\./u);
     assert.match(writeWatermarkBody(rootDir), /"schema":"write-watermark\/v1"/u);
     assert.match(writeWatermarkBody(rootDir), /session-export-019f28de-f7f6-7223-a2a8-b2968686fe21/u);
     assert.equal(gitStatus(harnessRoot), "");
@@ -105,6 +107,46 @@ test("CLI session sync writes existing untracked session exports through the jou
   });
 });
 
+test("CLI session sync routes structured manifests through declared entity writes", () => {
+  withTempRoot((rootDir) => {
+    const harnessRoot = path.join(rootDir, "harness");
+    mkdirSync(path.join(harnessRoot, "sessions"), { recursive: true });
+    initHarnessGit(harnessRoot);
+    const bodyRef = {
+      store: "authored-cas/v1",
+      ...writeContentAddressedBlob(rootDir, "# Session synced-manifest\n", "text/markdown; charset=utf-8")
+    };
+    writeFileSync(path.join(harnessRoot, "sessions", "synced-manifest.md"), `${JSON.stringify({
+      schema: "session-entity/v1",
+      sessionId: "synced-manifest",
+      lifecycle: "sealed",
+      archiveStatus: "complete",
+      runtime: "codex",
+      source: "runtime",
+      detectedAt: "2026-07-04T00:00:00.000Z",
+      exportedAt: "2026-07-04T00:01:00.000Z",
+      bodyRef,
+      snapshot: {
+        capturedAt: "2026-07-04T00:01:00.000Z",
+        completeness: "complete",
+        captureRange: { messageCount: 1 },
+        privacyScan: { scannerVersion: "publish-redaction/v1", passed: true, findings: [] }
+      }
+    }, null, 2)}\n`);
+
+    const synced = runJson(rootDir, ["session", "sync"]);
+
+    assert.equal(synced.ok, true);
+    const payloadRoot = path.join(rootDir, ".harness", "write-journal", "payloads");
+    const payloadFile = readdirSync(payloadRoot).find((entry) => entry.endsWith(".json"));
+    assert.ok(payloadFile);
+    const payload = JSON.parse(readFileSync(path.join(payloadRoot, payloadFile), "utf8"));
+    assert.equal(payload.entityDocument.declaration.kind, "session");
+    assert.equal("boundary" in payload, false);
+    assert.equal(gitStatus(harnessRoot), "");
+  });
+});
+
 test("CLI session backfill discovers Codex runtime logs and writes exports through the journal", () => {
   withTempRoot((rootDir) => {
     const harnessRoot = path.join(rootDir, "harness");
@@ -131,7 +173,7 @@ test("CLI session backfill discovers Codex runtime logs and writes exports throu
     assert.equal(backfilled.report.exported[0].session.sessionId, "codex-thread-backfill");
     assert.equal(backfilled.report.git.committed, true);
     assert.equal(backfilled.report.git.coordinator, "write-journal");
-    assert.match(readFileSync(path.join(harnessRoot, "sessions", "codex-thread-backfill.md"), "utf8"), /Backfill this Codex thread/u);
+    assert.match(readSessionEntity(rootDir, "codex-thread-backfill").body, /Backfill this Codex thread/u);
     assert.match(writeWatermarkBody(rootDir), /"schema":"write-watermark\/v1"/u);
     assert.match(writeWatermarkBody(rootDir), /session-export-codex-thread-backfill/u);
     assert.equal(gitStatus(harnessRoot), "");
@@ -166,8 +208,8 @@ test("CLI session backfill discovers ZCode runtime logs and writes exports throu
     assert.equal(backfilled.report.exported[0].session.sessionId, "sess_zcode-thread-backfill");
     assert.equal(backfilled.report.git.committed, true);
     assert.equal(backfilled.report.git.coordinator, "write-journal");
-    assert.match(readFileSync(path.join(harnessRoot, "sessions", "sess_zcode-thread-backfill.md"), "utf8"), /Backfill this ZCode thread/u);
-    assert.match(readFileSync(path.join(harnessRoot, "sessions", "sess_zcode-thread-backfill.md"), "utf8"), /ZCode backfill response/u);
+    assert.match(readSessionEntity(rootDir, "sess_zcode-thread-backfill").body, /Backfill this ZCode thread/u);
+    assert.match(readSessionEntity(rootDir, "sess_zcode-thread-backfill").body, /ZCode backfill response/u);
     assert.match(writeWatermarkBody(rootDir), /"schema":"write-watermark\/v1"/u);
     assert.match(writeWatermarkBody(rootDir), /session-export-sess_zcode-thread-backfill/u);
     assert.equal(gitStatus(harnessRoot), "");

--- a/packages/kernel/src/composition/index.ts
+++ b/packages/kernel/src/composition/index.ts
@@ -1,6 +1,6 @@
 // @slice-activation PLT-Bedrock W1 exposes local kernel implementation factories
 // for application composition roots without making store internals public.
-export { writeContentAddressedBlob } from "../store/content-addressed-blob-store.ts";
+export { readContentAddressedTextBlob, writeContentAddressedBlob } from "../store/content-addressed-blob-store.ts";
 export { makeMarkdownArtifactStore } from "../store/markdown-artifact-store.ts";
 export { makeJournaledWriteCoordinator } from "../store/write-journal-coordinator.ts";
 export { makeLocalLockRegistry } from "../store/local-lock-registry.ts";

--- a/packages/kernel/src/entity/declaration.ts
+++ b/packages/kernel/src/entity/declaration.ts
@@ -34,7 +34,15 @@ export interface DeclaredEntityDocumentWritePayload {
     readonly declaration: EntityPathDeclaration;
     readonly identity: Readonly<Record<string, string>>;
     readonly body: string;
+    readonly blobRef?: DeclaredContentAddressedBlobRef;
   };
+}
+
+export interface DeclaredContentAddressedBlobRef {
+  readonly ref: string;
+  readonly sha256: string;
+  readonly size: number;
+  readonly mediaType: string;
 }
 
 export function decodeEntityDeclaration(input: unknown): EntityDeclaration {
@@ -99,11 +107,14 @@ export function writeDeclaredEntity(
   hashPayload: PayloadHasher,
   declaration: EntityDeclaration,
   identity: Readonly<Record<string, string>>,
-  value: unknown
+  value: unknown,
+  options: { readonly flush?: boolean; readonly opIdPrefix?: string } = {}
 ): Effect.Effect<void, WriteError> {
   const decoded = Schema.decodeUnknownSync(declaration.schema)(value) as Readonly<Record<string, unknown>>;
+  const bodyRef = declaration.storageForm === "composite-manifest-blob"
+    ? readField(decoded, declaration.blob!.referenceField)
+    : undefined;
   if (declaration.storageForm === "composite-manifest-blob") {
-    const bodyRef = readField(decoded, declaration.blob!.referenceField);
     if (!isContentAddressedBlobReference(bodyRef)) throw new Error(`composite manifest is missing a valid ${declaration.blob!.referenceField}`);
   }
   const identityKey = declaration.rootResolver.identity.at(-1)!;
@@ -111,6 +122,7 @@ export function writeDeclaredEntity(
   return writeCoordinatedPayload(coordinator, hashPayload, {
     entityId,
     kind: "doc_write",
+    ...(options.opIdPrefix ? { opIdPrefix: options.opIdPrefix } : {}),
     payload: {
       entityDocument: {
         declaration: {
@@ -119,10 +131,11 @@ export function writeDeclaredEntity(
           rootResolver: declaration.rootResolver
         },
         identity,
-        body: declaration.documentCodec.encode(decoded)
+        body: declaration.documentCodec.encode(decoded),
+        ...(isContentAddressedBlobReference(bodyRef) ? { blobRef: bodyRef } : {})
       }
     } satisfies DeclaredEntityDocumentWritePayload
-  });
+  }, { flush: options.flush });
 }
 
 function validateRootResolver(rootResolver: EntityRootResolverDeclaration | undefined, storageForm: EntityStorageForm): void {
@@ -206,7 +219,7 @@ export function readField(entity: Readonly<Record<string, unknown>>, field: stri
   ), entity);
 }
 
-function isContentAddressedBlobReference(value: unknown): boolean {
+function isContentAddressedBlobReference(value: unknown): value is DeclaredContentAddressedBlobRef {
   if (!value || typeof value !== "object") return false;
   const ref = value as Record<string, unknown>;
   return typeof ref.ref === "string" && typeof ref.sha256 === "string" && /^[0-9a-f]{64}$/u.test(ref.sha256) &&

--- a/packages/kernel/src/entity/field-contracts.ts
+++ b/packages/kernel/src/entity/field-contracts.ts
@@ -2,8 +2,9 @@ import type { TaskFrontmatter } from "../schemas/registry.ts";
 import type { DecisionPackage } from "../schemas/decision-package.ts";
 import type { EntityRelationRecord } from "../domain/entity-relation.ts";
 import type { FactRecordDocument } from "../schemas/fact-record.ts";
+import { sessionFieldContracts } from "./session-declaration.ts";
 
-export type EntityKindWithFieldCoverage = "decision" | "task" | "fact" | "relation";
+export type EntityKindWithFieldCoverage = "decision" | "task" | "fact" | "relation" | "session";
 export type EntityFieldMutability = "immutable" | "lifecycle" | "amendable" | "derived";
 export type EntityFieldReadSurface =
   | { readonly kind: "projection"; readonly path: string; readonly queryable: boolean }
@@ -92,7 +93,8 @@ export const entityFieldContracts = {
   decision: decisionFieldContracts,
   task: taskFieldContracts,
   fact: factFieldContracts,
-  relation: relationFieldContracts
+  relation: relationFieldContracts,
+  session: sessionFieldContracts
 } as const;
 
 export const decisionAmendableFields = ["title", "chosen", "rejected", "claims"] as const satisfies ReadonlyArray<DecisionFieldKey>;

--- a/packages/kernel/src/entity/registry.ts
+++ b/packages/kernel/src/entity/registry.ts
@@ -10,8 +10,9 @@ import {
   type RelationFieldKey,
   type TaskFieldKey
 } from "./field-contracts.ts";
+import { sessionEntityRegistration } from "./session-declaration.ts";
 
-export type KernelEntityKind = "decision" | "task" | "fact" | "relation";
+export type KernelEntityKind = "decision" | "task" | "fact" | "relation" | "session";
 export const entityStorageForms = [
   "lifecycle",
   "schema",
@@ -103,6 +104,7 @@ export type EntityRegistryShape = {
   readonly task: EntityRegistration<TaskFieldKey>;
   readonly fact: EntityRegistration<FactFieldKey>;
   readonly relation: EntityRegistration<RelationFieldKey>;
+  readonly session: typeof sessionEntityRegistration;
 };
 
 export const entityRegistry = {
@@ -181,7 +183,8 @@ export const entityRegistry = {
       unsupported("D4", "hard-delete", "relation records are provenance-bearing and are not physically deleted")
     ]),
     storageForm: "host_frontmatter"
-  }
+  },
+  session: sessionEntityRegistration
 } satisfies EntityRegistryShape;
 
 export const entityRegistryKinds = Object.keys(entityRegistry) as ReadonlyArray<KernelEntityKind>;

--- a/packages/kernel/src/entity/session-declaration.ts
+++ b/packages/kernel/src/entity/session-declaration.ts
@@ -1,0 +1,67 @@
+import { SessionManifestSchema, type SessionFieldKey } from "../schemas/session-manifest.ts";
+import type { EntityFieldContract } from "./field-contracts.ts";
+import type { EntityRegistration } from "./registry.ts";
+
+const show = (path: string) => ({ kind: "show" as const, path });
+const projection = (path: string, queryable: boolean) => ({ kind: "projection" as const, path, queryable });
+const immutable = (reason: string, ...read: EntityFieldContract["read"]): EntityFieldContract => ({
+  mutability: "immutable",
+  read,
+  write: [],
+  reason
+});
+const lifecycle = (reason: string, operation: string, ...read: EntityFieldContract["read"]): EntityFieldContract => ({
+  mutability: "lifecycle",
+  read,
+  write: [{ kind: "lifecycle", operation }],
+  reason
+});
+
+export const sessionFieldContracts = {
+  schema: immutable("schema discriminator is fixed", show("session.schema")),
+  sessionId: immutable("session identity is stable", projection("session_id", true), show("session.sessionId")),
+  lifecycle: lifecycle("session lifecycle owns state transitions", "session-transition", projection("lifecycle", true), show("session.lifecycle")),
+  archiveStatus: lifecycle("snapshot finalization owns archive status", "session-snapshot", projection("archive_status", true), show("session.archiveStatus")),
+  runtime: immutable("runtime is capture provenance", projection("runtime", true), show("session.runtime")),
+  source: immutable("source is capture provenance", show("session.source")),
+  detectedAt: immutable("detection time is capture provenance", show("session.detectedAt")),
+  exportedAt: lifecycle("snapshot finalization owns export time", "session-snapshot", projection("exported_at", true), show("session.exportedAt")),
+  user: immutable("user is capture provenance", show("session.user")),
+  bodyRef: lifecycle("snapshot finalization binds immutable body content", "session-snapshot", projection("body_sha256", true), show("session.bodyRef")),
+  snapshot: lifecycle("snapshot finalization owns capture and privacy metadata", "session-snapshot", show("session.snapshot"))
+} satisfies Record<SessionFieldKey, EntityFieldContract>;
+
+export const sessionEntityRegistration = {
+  kind: "session",
+  schema: SessionManifestSchema,
+  mutabilityContract: sessionFieldContracts,
+  anchors: { entityRef: "session/{sessionId}", anchors: [] },
+  dispositionMatrix: {
+    entries: {
+      retire: { level: "D1", action: "retire", supported: false, writeOpKinds: [], reason: "session lifecycle uses archive" },
+      supersede: { level: "D1", action: "supersede", supported: false, writeOpKinds: [], reason: "session snapshots are never overwritten by supersession" },
+      invalidate: { level: "D1", action: "invalidate", supported: false, writeOpKinds: [], reason: "session provenance is retained" },
+      archive: { level: "D2", action: "archive", supported: true, writeOpKinds: ["doc_write"], reason: "archive preserves manifest and immutable body reference" },
+      tombstone: { level: "D3", action: "tombstone", supported: false, writeOpKinds: [], reason: "privacy purge retains audit metadata" },
+      "hard-delete": { level: "D4", action: "hard-delete", supported: false, writeOpKinds: [], reason: "session audit metadata is not hard deleted" }
+    }
+  },
+  storageForm: "composite-manifest-blob",
+  rootResolver: { pathTemplate: "sessions/{sessionId}.md", identity: ["sessionId"] },
+  projection: {
+    table: "session_projection",
+    columns: [
+      { name: "session_id", field: "sessionId", type: "text", primaryKey: true },
+      { name: "lifecycle", field: "lifecycle", type: "text" },
+      { name: "archive_status", field: "archiveStatus", type: "text" },
+      { name: "runtime", field: "runtime", type: "text" },
+      { name: "exported_at", field: "exportedAt", type: "text" },
+      { name: "body_sha256", field: "bodyRef.sha256", type: "text" }
+    ]
+  },
+  documentCodec: {
+    decode: (body: string) => /^schema:\s*provenance-session\/v1\s*$/mu.test(body) ? undefined : JSON.parse(body) as unknown,
+    encode: (value: unknown) => `${JSON.stringify(value, null, 2)}\n`
+  },
+  blob: { referenceField: "bodyRef", store: "content-addressed" }
+} satisfies EntityRegistration<SessionFieldKey, "session">;

--- a/packages/kernel/src/entity/session.ts
+++ b/packages/kernel/src/entity/session.ts
@@ -1,0 +1,94 @@
+import { Effect, Schema } from "effect";
+import type { WriteError } from "../domain/index.ts";
+import { stablePayloadHash } from "../integrity/stable-hash.ts";
+import type { HarnessLayoutInput } from "../layout/index.ts";
+import { localLayoutFileSystem } from "../local/local-layout-file-system.ts";
+import { readFrontmatter, readScalar } from "../markdown/frontmatter.ts";
+import type { WriteCoordinator } from "../ports/index.ts";
+import { SessionManifestSchema, type SessionManifest } from "../schemas/session-manifest.ts";
+import { decodeEntityDeclaration, resolveEntityDocumentPath, writeDeclaredEntity } from "./declaration.ts";
+import { sessionEntityRegistration } from "./session-declaration.ts";
+
+export const sessionEntityDeclaration = decodeEntityDeclaration(sessionEntityRegistration);
+
+export interface SessionManifestReadResult {
+  readonly format: "manifest";
+  readonly manifest: SessionManifest;
+}
+
+export interface LegacySessionReadResult {
+  readonly format: "legacy";
+  readonly legacy: true;
+  readonly metadata: {
+    readonly schema: "provenance-session/v1";
+    readonly sessionId: string;
+    readonly runtime: string;
+    readonly source: string;
+    readonly detectedAt: string;
+    readonly exportedAt: string;
+    readonly user?: string;
+  };
+  readonly body: string;
+}
+
+export type SessionReadResult = SessionManifestReadResult | LegacySessionReadResult;
+
+export function writeSessionEntity(
+  coordinator: WriteCoordinator,
+  _rootInput: HarnessLayoutInput,
+  manifest: SessionManifest,
+  options: { readonly flush?: boolean; readonly opIdPrefix?: string } = {}
+): Effect.Effect<void, WriteError> {
+  return writeDeclaredEntity(
+    coordinator,
+    stablePayloadHash,
+    sessionEntityDeclaration,
+    { sessionId: manifest.sessionId },
+    manifest,
+    options
+  );
+}
+
+export function readSessionEntityDocument(rootInput: HarnessLayoutInput, sessionId: string): SessionReadResult {
+  const manifestPath = resolveEntityDocumentPath(rootInput, sessionEntityDeclaration, { sessionId });
+  const document = localLayoutFileSystem.readText(manifestPath);
+  if (document.startsWith("---\n") || document.startsWith("---\r\n")) {
+    return readLegacySession(document, sessionId);
+  }
+  const manifest = Schema.decodeUnknownSync(SessionManifestSchema)(
+    sessionEntityDeclaration.documentCodec.decode(document)
+  );
+  if (manifest.sessionId !== sessionId) throw new Error(`session id mismatch: ${manifest.sessionId}`);
+  return {
+    format: "manifest",
+    manifest
+  };
+}
+
+function readLegacySession(body: string, expectedSessionId: string): LegacySessionReadResult {
+  const frontmatter = readFrontmatter(body);
+  if (!frontmatter) throw new Error("session markdown missing frontmatter");
+  const schema = readScalar(frontmatter, "schema", { required: true });
+  if (schema !== "provenance-session/v1") throw new Error(`unsupported session schema: ${schema}`);
+  const sessionId = readScalar(frontmatter, "sessionId", { required: true });
+  if (sessionId !== expectedSessionId) throw new Error(`session id mismatch: ${sessionId}`);
+  const runtime = readScalar(frontmatter, "runtime", { required: true });
+  if (runtime !== "human" && !/^### (?:User|Assistant|Summary)(?: \(|$)/mu.test(body)) {
+    throw new Error(`session transcript unavailable: ${sessionId}`);
+  }
+  const user = readScalar(frontmatter, "user");
+  return {
+    format: "legacy",
+    legacy: true,
+    metadata: {
+      schema,
+      sessionId,
+      runtime,
+      source: readScalar(frontmatter, "source", { required: true }),
+      detectedAt: readScalar(frontmatter, "detectedAt", { required: true }),
+      exportedAt: readScalar(frontmatter, "exportedAt", { required: true }),
+      ...(user ? { user } : {})
+    },
+    body
+  };
+}

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -4,6 +4,11 @@ export * from "./docmap/docmap-unique.ts";
 export * from "./entity/disposition.ts";
 export * from "./entity/field-contracts.ts";
 export * from "./entity/registry.ts";
+export {
+  readSessionEntityDocument,
+  writeSessionEntity
+} from "./entity/session.ts";
+export type { SessionManifest } from "./schemas/session-manifest.ts";
 export { sha256Text, stablePayloadHash, stableStringify } from "./integrity/stable-hash.ts";
 export * from "./layout/index.ts";
 export * from "./markdown/frontmatter.ts";
@@ -23,6 +28,7 @@ export {
   makeLocalLockRegistry,
   makeLocalVersionControlSystem,
   makeMarkdownArtifactStore,
+  readContentAddressedTextBlob,
   writeContentAddressedBlob
 } from "./composition/index.ts";
 export { writeCoordinatedPayload, writeCoordinatedTaskDocuments } from "./write-coordination/write-helpers.ts";

--- a/packages/kernel/src/projection/entity-declaration-projection.ts
+++ b/packages/kernel/src/projection/entity-declaration-projection.ts
@@ -63,6 +63,7 @@ function discoverDeclaredEntityRows(
     resolveEntityDocumentPath(rootInput, declaration, identity);
     const documentPath = path.join(layout.authoredRoot, relativePath);
     const raw = declaration.documentCodec.decode(localLayoutFileSystem.readText(documentPath));
+    if (raw === undefined) continue;
     const decoded = Schema.decodeUnknownSync(declaration.schema)(raw) as Readonly<Record<string, unknown>>;
     rows.push(projectRow(decoded, declaration.projection.columns));
   }

--- a/packages/kernel/src/publish/publish-safety.ts
+++ b/packages/kernel/src/publish/publish-safety.ts
@@ -52,7 +52,7 @@ export interface PublishRedactionFinding {
   readonly path?: string;
 }
 
-const scannerVersion = "publish-redaction/v1";
+export const privateTextScannerVersion = "publish-redaction/v1";
 
 const privateTextPatterns: ReadonlyArray<{
   readonly ruleId: string;
@@ -155,7 +155,7 @@ export function buildPublishableProjection(input: PublishProjectionInput): Publi
       links,
       readiness,
       redactionReport: {
-        scannerVersion,
+        scannerVersion: privateTextScannerVersion,
         findings,
         passed: true
       },
@@ -213,6 +213,12 @@ function scanPublishInput(input: PublishProjectionInput): ReadonlyArray<PublishR
   scanText(input.summary, "summary", findings);
   scanLinks(input.links, "links", findings);
   scanLinks(input.readiness.evidenceLinks, "readiness.evidenceLinks", findings);
+  return findings;
+}
+
+export function scanPrivateText(text: string, path: string): ReadonlyArray<PublishRedactionFinding> {
+  const findings: PublishRedactionFinding[] = [];
+  scanText(text, path, findings);
   return findings;
 }
 

--- a/packages/kernel/src/schemas/session-manifest.ts
+++ b/packages/kernel/src/schemas/session-manifest.ts
@@ -1,0 +1,47 @@
+import { Schema } from "effect";
+
+const SessionIdSchema = Schema.String.pipe(Schema.pattern(/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u));
+
+export const SessionBodyRefSchema = Schema.Struct({
+  store: Schema.Literal("authored-cas/v1"),
+  ref: Schema.String,
+  sha256: Schema.String.pipe(Schema.pattern(/^[0-9a-f]{64}$/u)),
+  size: Schema.Int.pipe(Schema.nonNegative()),
+  mediaType: Schema.String
+});
+
+export const SessionManifestSchema = Schema.Struct({
+  schema: Schema.Literal("session-entity/v1"),
+  sessionId: SessionIdSchema,
+  lifecycle: Schema.Literal("active", "sealed", "partial", "unavailable", "archived"),
+  archiveStatus: Schema.Literal("complete", "partial", "unavailable"),
+  runtime: Schema.Literal("human", "claude-code", "codex", "zcode", "antigravity"),
+  source: Schema.Literal("runtime", "manual"),
+  detectedAt: Schema.String,
+  exportedAt: Schema.String,
+  user: Schema.optional(Schema.String),
+  bodyRef: SessionBodyRefSchema,
+  snapshot: Schema.Struct({
+    capturedAt: Schema.String,
+    completeness: Schema.Literal("complete", "partial"),
+    captureRange: Schema.Struct({
+      messageCount: Schema.Int.pipe(Schema.nonNegative()),
+      firstMessageAt: Schema.optional(Schema.String),
+      lastMessageAt: Schema.optional(Schema.String)
+    }),
+    privacyScan: Schema.Struct({
+      scannerVersion: Schema.String,
+      passed: Schema.Boolean,
+      findings: Schema.Array(Schema.Struct({
+        ruleId: Schema.String,
+        severity: Schema.Literal("info", "warning", "error"),
+        message: Schema.String,
+        path: Schema.optional(Schema.String)
+      }))
+    })
+  })
+});
+
+export type SessionBodyRef = typeof SessionBodyRefSchema.Type;
+export type SessionManifest = typeof SessionManifestSchema.Type;
+export type SessionFieldKey = keyof SessionManifest;

--- a/packages/kernel/src/store/write-journal-operations.ts
+++ b/packages/kernel/src/store/write-journal-operations.ts
@@ -55,7 +55,7 @@ export interface WriteTransactionPlan {
 export function writeTransactionPlan(op: WriteOp): WriteTransactionPlan {
   if (op.kind === "doc_write" && hasDeclaredEntityDocument(op.payload)) {
     return {
-      touchedPaths: (rootInput) => [declaredEntityDocument(rootInput, op).targetPath],
+      touchedPaths: (rootInput) => declaredEntityTouchedPaths(rootInput, op),
       documentWrites: () => [],
       apply: (rootInput) => {
         const document = declaredEntityDocument(rootInput, op);
@@ -290,7 +290,7 @@ function hasDeclaredEntityDocument(payload: unknown): payload is DeclaredEntityD
 function declaredEntityDocument(
   rootInput: HarnessLayoutInput,
   op: WriteOp
-): { readonly targetPath: string; readonly body: string } {
+): { readonly targetPath: string; readonly body: string; readonly blobPath?: string } {
   if (!hasDeclaredEntityDocument(op.payload)) rejectWrite(`${op.kind} op requires entityDocument payload`, op.entityId);
   const document = op.payload.entityDocument;
   if (!document || typeof document !== "object" || typeof document.body !== "string" || !isStringRecord(document.identity)) {
@@ -303,7 +303,7 @@ function declaredEntityDocument(
     }
     return {
       targetPath: resolveEntityDocumentPath(rootInput, declaration, document.identity),
-      body: document.body
+      body: document.body, ...(document.blobRef ? { blobPath: resolveContentAddressedBlobPath(rootInput, document.blobRef) } : {})
     };
   } catch (error) {
     rejectWrite(error instanceof Error ? error.message : String(error), op.entityId);
@@ -461,3 +461,8 @@ export type MachineArtifactBoundary =
   | "distill-candidate"
   | "legacy-forward"
   | "preset-evidence-registry";
+
+function declaredEntityTouchedPaths(rootInput: HarnessLayoutInput, op: WriteOp): ReadonlyArray<string> {
+  const document = declaredEntityDocument(rootInput, op);
+  return [document.targetPath, ...(document.blobPath ? [document.blobPath] : [])];
+}

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -154,10 +154,12 @@ const publicRuntimeSurface = [
   "parseWriteEntityId",
   "planTemplateMaterialization",
   "priorityTiers",
+  "privateTextScannerVersion",
   "queryDecisionProjection",
   "queryTaskChildren",
   "queryTaskProjection",
   "queryTaskSubtree",
+  "readContentAddressedTextBlob",
   "readDaemonRegistry",
   "readDecisionFactCoverage",
   "readDocmapManifest",
@@ -167,6 +169,7 @@ const publicRuntimeSurface = [
   "readRelationGraphAuthoredSourceKinds",
   "readRelationGraphProjection",
   "readScalar",
+  "readSessionEntityDocument",
   "readTaskProjection",
   "rebuildTaskProjection",
   "registerDaemonRepo",
@@ -189,6 +192,7 @@ const publicRuntimeSurface = [
   "runtimeEventInterruptActions",
   "runtimeEventKinds",
   "runtimeEventResultStatuses",
+  "scanPrivateText",
   "schemaRegistry",
   "sha256Text",
   "slugifyTaskTitle",
@@ -217,7 +221,8 @@ const publicRuntimeSurface = [
   "warning",
   "writeContentAddressedBlob",
   "writeCoordinatedPayload",
-  "writeCoordinatedTaskDocuments"
+  "writeCoordinatedTaskDocuments",
+  "writeSessionEntity"
 ];
 
 test("kernel public runtime surface matches the golden snapshot", () => {

--- a/packages/kernel/test/store/entity-registry-substrate.test.ts
+++ b/packages/kernel/test/store/entity-registry-substrate.test.ts
@@ -13,6 +13,7 @@ import {
   projectDeclaredEntities,
   readDeclaredProjectionRows
 } from "../../src/projection/entity-declaration-projection.ts";
+import { entityRegistry } from "../../src/entity/registry.ts";
 import { stablePayloadHash } from "../../src/integrity/stable-hash.ts";
 import { writeContentAddressedBlob } from "../../src/store/content-addressed-blob-store.ts";
 import { makeJournaledWriteCoordinator } from "../../src/store/write-journal-coordinator.ts";
@@ -202,4 +203,17 @@ test("fixture declarations resolve, coordinate writes, and project hosted and co
     )) as { readonly bodyRef?: unknown };
     assert.deepEqual(manifest.bodyRef, bodyRef);
   });
+});
+
+test("entity registry declares the five-tuple surface for decision task fact relation and session", () => {
+  assert.deepEqual(Object.keys(entityRegistry).sort(), ["decision", "fact", "relation", "session", "task"]);
+  assert.equal(entityRegistry.session.storageForm, "composite-manifest-blob");
+  assert.equal(entityRegistry.decision.storageForm, "lifecycle");
+  assert.equal(entityRegistry.task.storageForm, "lifecycle");
+  assert.equal(entityRegistry.fact.storageForm, "schema");
+  assert.equal(entityRegistry.relation.storageForm, "host_frontmatter");
+  assert.equal(entityRegistry.decision.dispositionMatrix.entries["hard-delete"].supported, false);
+  assert.equal(entityRegistry.fact.dispositionMatrix.entries.invalidate.supported, true);
+  assert.equal(entityRegistry.fact.dispositionMatrix.entries["hard-delete"].supported, false);
+  assert.equal(Object.keys(entityRegistry.fact.mutabilityContract).includes("statement"), true);
 });

--- a/packages/kernel/test/store/relation-graph-projection.test.ts
+++ b/packages/kernel/test/store/relation-graph-projection.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import {
   checkTaskProjection,
   deriveRelationId,
-  entityRegistry,
   evaluateEntityDisposition,
   evaluateImplicitDispositionRecommendations,
   formatFactFlowRecord,
@@ -179,18 +178,6 @@ test("relation graph coverage treats invalidated facts as not live", () => {
       relationPath: []
     }]);
   });
-});
-
-test("entity registry declares the five-tuple surface for decision task fact and relation", () => {
-  assert.deepEqual(Object.keys(entityRegistry).sort(), ["decision", "fact", "relation", "task"]);
-  assert.equal(entityRegistry.decision.storageForm, "lifecycle");
-  assert.equal(entityRegistry.task.storageForm, "lifecycle");
-  assert.equal(entityRegistry.fact.storageForm, "schema");
-  assert.equal(entityRegistry.relation.storageForm, "host_frontmatter");
-  assert.equal(entityRegistry.decision.dispositionMatrix.entries["hard-delete"].supported, false);
-  assert.equal(entityRegistry.fact.dispositionMatrix.entries.invalidate.supported, true);
-  assert.equal(entityRegistry.fact.dispositionMatrix.entries["hard-delete"].supported, false);
-  assert.equal(Object.keys(entityRegistry.fact.mutabilityContract).includes("statement"), true);
 });
 
 test("entity disposition lower-bound blocks D3 and D4 when active incoming relations exist", () => {

--- a/packages/kernel/test/store/session-entity.test.ts
+++ b/packages/kernel/test/store/session-entity.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import {
+  projectDeclaredEntities,
+  readDeclaredProjectionRows
+} from "../../src/projection/entity-declaration-projection.ts";
+import {
+  readSessionEntityDocument,
+  sessionEntityDeclaration,
+  writeSessionEntity
+} from "../../src/entity/session.ts";
+import { getEntityRegistration } from "../../src/entity/registry.ts";
+import { writeContentAddressedBlob } from "../../src/store/content-addressed-blob-store.ts";
+import { makeJournaledWriteCoordinator } from "../../src/store/write-journal-coordinator.ts";
+import { withTempStore } from "./helpers.ts";
+
+test("session manifests coordinate compact state, immutable transcript bodies, and rebuildable projections", () => {
+  withTempStore((rootDir) => {
+    const body = "# Session ses_1\n\n### User\n\nHello.\n";
+    const bodyRef = {
+      store: "authored-cas/v1" as const,
+      ...writeContentAddressedBlob(rootDir, body, "text/markdown; charset=utf-8")
+    };
+    const manifest = {
+      schema: "session-entity/v1" as const,
+      sessionId: "ses_1",
+      lifecycle: "sealed" as const,
+      archiveStatus: "complete" as const,
+      runtime: "codex" as const,
+      source: "runtime" as const,
+      detectedAt: "2026-07-11T01:00:00.000Z",
+      exportedAt: "2026-07-11T01:05:00.000Z",
+      bodyRef,
+      snapshot: {
+        capturedAt: "2026-07-11T01:05:00.000Z",
+        completeness: "complete" as const,
+        captureRange: {
+          messageCount: 1,
+          firstMessageAt: "2026-07-11T01:01:00.000Z",
+          lastMessageAt: "2026-07-11T01:01:00.000Z"
+        },
+        privacyScan: {
+          scannerVersion: "publish-redaction/v1",
+          passed: true,
+          findings: []
+        }
+      }
+    };
+    const coordinator = makeJournaledWriteCoordinator({
+      rootDir,
+      actor: { kind: "agent", id: "test" }
+    });
+
+    Effect.runSync(writeSessionEntity(coordinator, rootDir, manifest));
+    assert.equal(getEntityRegistration("session"), sessionEntityDeclaration);
+
+    const stored = readFileSync(path.join(rootDir, "harness/sessions/ses_1.md"), "utf8");
+    assert.equal(stored.includes("Hello."), false);
+    assert.deepEqual(readSessionEntityDocument(rootDir, "ses_1"), {
+      format: "manifest",
+      manifest
+    });
+    assert.equal(readFileSync(path.join(rootDir, bodyRef.ref), "utf8"), body);
+
+    const projectionPath = path.join(rootDir, ".harness/cache/session-projection.sqlite");
+    const projected = projectDeclaredEntities(rootDir, sessionEntityDeclaration, projectionPath);
+    assert.deepEqual(projected.rows, [{
+      session_id: "ses_1",
+      lifecycle: "sealed",
+      archive_status: "complete",
+      runtime: "codex",
+      exported_at: "2026-07-11T01:05:00.000Z",
+      body_sha256: bodyRef.sha256
+    }]);
+    assert.deepEqual(readDeclaredProjectionRows(projectionPath, sessionEntityDeclaration), projected.rows);
+  });
+});
+
+test("session reader marks existing transcript markdown as legacy without rewriting it", () => {
+  withTempStore((rootDir) => {
+    const legacyBody = [
+      "---",
+      "schema: provenance-session/v1",
+      "sessionId: legacy-session",
+      "runtime: claude-code",
+      "source: runtime",
+      "detectedAt: 2026-07-10T01:00:00.000Z",
+      "exportedAt: 2026-07-10T01:05:00.000Z",
+      "---",
+      "",
+      "# Session legacy-session",
+      "",
+      "### User",
+      "",
+      "Legacy transcript.",
+      ""
+    ].join("\n");
+    const sessionPath = path.join(rootDir, "harness/sessions/legacy-session.md");
+    mkdirSync(path.dirname(sessionPath), { recursive: true });
+    writeFileSync(sessionPath, legacyBody, "utf8");
+
+    assert.deepEqual(readSessionEntityDocument(rootDir, "legacy-session"), {
+      format: "legacy",
+      legacy: true,
+      metadata: {
+        schema: "provenance-session/v1",
+        sessionId: "legacy-session",
+        runtime: "claude-code",
+        source: "runtime",
+        detectedAt: "2026-07-10T01:00:00.000Z",
+        exportedAt: "2026-07-10T01:05:00.000Z"
+      },
+      body: legacyBody
+    });
+    assert.equal(readFileSync(sessionPath, "utf8"), legacyBody);
+    const projectionPath = path.join(rootDir, ".harness/cache/legacy-session-projection.sqlite");
+    assert.deepEqual(projectDeclaredEntities(rootDir, sessionEntityDeclaration, projectionPath).rows, []);
+  });
+});

--- a/tools/check-integration-test-shards.test.mjs
+++ b/tools/check-integration-test-shards.test.mjs
@@ -9,7 +9,7 @@ import {
 test("integration shard declaration is non-overlapping and complete", () => {
   const result = checkIntegrationTestShards();
   assert.equal(result.ok, true, result.errors.join("\n"));
-  assert.equal(result.fileCount, 79);
+  assert.equal(result.fileCount, 80);
   assert.deepEqual(result.workflowShards, [1, 2, 3, 4, 5, 6]);
   assert.deepEqual(result.requiredContexts, [
     "integration-shard (1)",

--- a/tools/integration-test-shards.mjs
+++ b/tools/integration-test-shards.mjs
@@ -72,6 +72,7 @@ export const integrationTestFileWeightsMs = Object.freeze({
   "packages/kernel/test/store/relation-graph-projection.test.ts": 850.9,
   "packages/kernel/test/store/relation-graph-toctou.test.ts": 473.9,
   "packages/kernel/test/store/same-task-fifo.test.ts": 7647.4,
+  "packages/kernel/test/store/session-entity.test.ts": 500.0,
   "packages/kernel/test/store/sqlite-incremental-projection.test.ts": 4800.3,
   "packages/kernel/test/store/sqlite-rebuild.test.ts": 734.2,
   "tools/check-docs-release-map.test.mjs": 590.0,
@@ -135,6 +136,7 @@ export const integrationTestShards = Object.freeze([
       "packages/cli/test/diagnostics-cli.test.ts",
       "packages/kernel/test/store/entity-disposition.test.ts",
       "packages/kernel/test/store/entity-registry-substrate.test.ts",
+      "packages/kernel/test/store/session-entity.test.ts",
       "packages/kernel/test/store/daemon-registry.test.ts"
     ])
   }),

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -179,6 +179,7 @@ export const testTierManifest = {
     "packages/kernel/test/store/relation-graph-projection.test.ts",
     "packages/kernel/test/store/relation-graph-toctou.test.ts",
     "packages/kernel/test/store/same-task-fifo.test.ts",
+    "packages/kernel/test/store/session-entity.test.ts",
     "packages/kernel/test/store/sqlite-incremental-projection.test.ts",
     "packages/kernel/test/store/sqlite-rebuild.test.ts",
     "tools/check-docs-release-map.test.mjs",

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -274,16 +274,16 @@
       "id": "session.provenance.claim-check",
       "sourceInventoryRows": [16],
       "road": "B",
-      "bearing": "machine-artifact",
+      "bearing": "session-composite-manifest-blob",
       "leaseRequired": false,
-      "channel": { "pathClass": "claim-check", "zoneClass": "session-provenance" },
+      "channel": { "pathClass": "declared-manifest-plus-claim-check", "zoneClass": "session-provenance" },
       "entry": ["cli", "internal"],
-      "writeKinds": ["machine_artifact_write"],
+      "writeKinds": ["doc_write", "machine_artifact_write"],
       "machineArtifactBoundaries": ["provenance-session"],
       "cliActions": ["session-backfill", "session-export", "session-sync"],
-      "callsiteFiles": ["packages/application/src/provenance-session-exporter.ts"],
-      "evidence": ["packages/application/src/provenance-session-exporter.ts:85", "packages/kernel/src/store/content-addressed-blob-store.ts:15"],
-      "freshness": "content-addressed-blob-ref"
+      "callsiteFiles": ["packages/cli/src/commands/core/session.ts"],
+      "evidence": ["packages/application/src/provenance-session-exporter.ts:135", "packages/kernel/src/entity/declaration.ts:103", "packages/cli/src/commands/core/session.ts:114"],
+      "freshness": "coordinated-manifest-plus-content-addressed-blob-ref"
     },
     {
       "id": "runtime-event.coordinated-jsonl",


### PR DESCRIPTION
# English

## Summary

F2 slice of the Session/Execution entity architecture: Session becomes the first real `composite-manifest-blob` entity declared on the F1 registry substrate. The authored compact manifest is the current-state source of truth (ADR-0016 R2); the transcript body is an immutable content-addressed blob referenced by `bodyRef`. No Session-specific CRUD/Coordinator/Projection stack was added.

## What Changed

- `packages/kernel/src/schemas/session-manifest.ts` (new): `session-entity/v1` manifest schema — stable `sessionId`, lifecycle/archive status, runtime/source provenance, `bodyRef` (store/ref/sha256/size/mediaType), snapshot completeness, capture range, privacy scan report.
- `packages/kernel/src/entity/session-declaration.ts` (new): full five-tuple registration — mutability contracts, disposition matrix (archive-only; no supersede/tombstone/hard-delete), `composite-manifest-blob` storage form, root resolver `sessions/{sessionId}.md`, declarative SQLite projection columns, blob reference field.
- `packages/kernel/src/entity/session.ts` (new): `writeSessionEntity` (declaration → `writeDeclaredEntity` → existing WriteCoordinator, coordinator-only) and `readSessionEntityDocument` (manifest decode + id check; legacy `provenance-session/v1` Markdown returned as `format: "legacy"` without rewriting, preserving the #582 transcript-unavailable fail-closed check).
- `packages/application/src/session-entity-reader.ts` (new): manifest reader + CAS body read; missing blob or hash/size mismatch fails closed.
- `packages/application/src/provenance-session-exporter.ts`: export pipeline reordered to privacy-scan → immutable CAS blob write → coordinated manifest write; missing transcript keeps failing closed. Privacy scan at capture is **report-only**: findings are recorded honestly in the manifest's `privacyScan` report (`passed: false` on error findings) and persistence proceeds — the private ledger is the system of record, and rejection stays at the publish boundary where `buildPublishableProjection` already fails closed. (An earlier reject-on-finding draft made every real transcript mentioning a local absolute path abort the primary CLI write on developer machines — caught by running the CLI integration tier locally on macOS, where CI's `/home/runner` paths never trip the `absolute-local-path` rule.)
- `packages/kernel/src/publish/publish-safety.ts`: exports the existing private-text scanner (`scanPrivateText`, `privateTextScannerVersion`) for snapshot reuse — no second redaction ruleset.
- `packages/kernel/src/store/write-journal-operations.ts`: declared-entity touched paths now include the referenced CAS object so manifest+blob land in the same coordinator commit; lease/claim branches untouched.
- `packages/cli/src/commands/core/session.ts`: export/backfill consume the new exporter; `session sync` routes structured manifests through the declared entity write, keeping the narrow artifact helper for legacy provenance only.
- `tools/write-road-registry.json`: the existing Session write road re-described as declared-manifest-plus-claim-check with refreshed evidence anchors (registry reflects the new real write path; road count unchanged).
- Tests: `packages/kernel/test/store/session-entity.test.ts` (new, registered in tier manifest + shard weight/list, fileCount 79 → 80) covering coordinated write, bodyRef integrity, legacy read, SQLite drop-and-rebuild; exporter/CLI suites updated; public-surface golden snapshot registers the deliberate new exports.

## Task And Scope

- Task: task_01KX7G4MPV8BW22G3WDFW0P69R (F2 Session Entity)
- Authority chain: dec_mrem0ys8 (accepted) → architecture-design.md §3.1/§9.1/§10/§16.3/§16.6/§16.8/§16.10 → ADR-0016 R2 (merged to ledger 2026-07-11)
- Scope: Session entity only. Execution/lease/claim surfaces untouched (parallel F3 slice); `check-kernel-dead-exports.json` untouched.

## Version Impact

No published package version change. Legacy `harness/sessions/*.md` files are read-compatible (flagged `legacy: true`) and never rewritten; bulk migration is the F7 cutover slice.

## Governance Declaration

This PR touches `tools/write-road-registry.json` (gate-checked inventory): the change **re-describes the existing Session write road** to match the new declared-manifest write path (bearing/channel/writeKinds/evidence anchors updated; no road added or removed, `check-write-road-registry` green). It does NOT touch `check-kernel-dead-exports.json` or `check-bypass-write-boundary.json`. The public-surface golden snapshot additions register deliberate new exports (session entity API + scanner reuse exports), strengthening the characterization. Authority: dec_mrem0ys8 + task_01KX7G4MPV8BW22G3WDFW0P69R. No gate weakened, removed, or bypassed.

## Verification

- Full local CI boundaries suite (including `check-github-required-contexts` with token): all commands passed, exit 0, run by CEO on the worktree at origin/main base 6ced57a.
- Typecheck clean; contract tier 379/379; focused integration (substrate + session entity + session CLI) 13/13; duplicate-definitions, dead-exports, import/write/bypass/private boundaries all green.
- Fail-closed positive controls in tests: tampered blob hash rejected; missing transcript rejected; privacy findings recorded in the manifest (`passed: false`) without blocking capture.
- Full integration tier (all 6 shards) re-run locally after the follow-up commit: green. Existing characterization tests (decision/fact/new-task CLI, registry surface) updated to assert the new `session-entity/v1` manifest format — a stronger characterization than the old frontmatter regexes.

## Review Evidence

- CEO semantic review against ADR-0016 R2 + mission invariants I1–I5: declaration-based accession (no parallel stack, §16.10), coordinator-only manifest writes, privacy-scan-before-persist ordering, legacy read-only compatibility, scanner reuse — each verified in the diff, not from the report.
- Shared-surface audit: `registry.ts` additive (session registration), `publish-safety.ts` export-only, `write-journal-operations.ts` declared-entity paths only — lease branch verified untouched (F3 mutual exclusion held).
- Implementation report: task package artifacts (private ledger).

## Residual Risk

- Blob is written before the manifest; a coordinator failure can leave an orphan CAS object (GC-able, the architecture's expected recovery model, §7).
- Privacy policy at capture is record-not-redact; sensitive content stays in the private ledger with an honest `passed: false` report, and the publish boundary remains the enforcement point.
- Legacy sessions remain on the old read path until F7 cutover.

## References

- dec_mrem0ys8; ADR-0016 R2 (private ledger)
- architecture-design.md §3.1, §9.1, §10, §16 (private ledger)

# 中文

## 概要

Session/Execution 实体架构的 F2 切片：Session 成为 F1 registry 基座上第一个真实的 `composite-manifest-blob` 实体。authored compact manifest 是 current-state 唯一真相（ADR-0016 R2）；transcript 正文是不可变 content-addressed blob，经 `bodyRef` 引用。未新增任何 Session 专用 CRUD/Coordinator/Projection 栈。

## 改动内容

- `session-manifest.ts`（新增）：`session-entity/v1` schema——稳定 `sessionId`、lifecycle/archive 状态、runtime/source 溯源、`bodyRef`（store/ref/sha256/size/mediaType）、snapshot 完整性、capture range、隐私扫描报告。
- `session-declaration.ts`（新增）：完整五元组注册——mutability 契约、disposition matrix（仅 archive；不支持 supersede/tombstone/hard-delete）、`composite-manifest-blob` 形态、root resolver `sessions/{sessionId}.md`、声明式 SQLite 投影列、blob 引用字段。
- `session.ts`（新增）：`writeSessionEntity`（声明 → `writeDeclaredEntity` → 既有 WriteCoordinator，coordinator-only）与 `readSessionEntityDocument`（manifest 解码 + id 校验；存量 `provenance-session/v1` Markdown 以 `format: "legacy"` 返回、不改写，保留 #582 transcript-unavailable fail-closed）。
- `session-entity-reader.ts`（新增）：manifest reader + CAS 正文读取；blob 缺失或 hash/size 不符 fail-closed。
- `provenance-session-exporter.ts`：导出流水线重排为 隐私扫描 → 不可变 CAS blob 写入 → coordinated manifest 写入；缺 transcript 沿用 fail-closed。capture 层隐私扫描为 **report-only**：finding 如实记录进 manifest 的 `privacyScan` 报告（有 error finding 时 `passed: false`），持久化照常进行——私有 ledger 是 system of record，拒绝语义留在 publish 边界（`buildPublishableProjection` 已 fail-closed）。（早先的 reject-on-finding 草案会让任何提到本机绝对路径的真实 transcript 连坐拒掉主 CLI 写入；本地 macOS 跑 CLI integration tier 抓出，CI 的 `/home/runner` 路径撞不上 `absolute-local-path` 规则。）
- `publish-safety.ts`：导出既有 private-text scanner（`scanPrivateText`/`privateTextScannerVersion`）供 snapshot 复用——没有第二套 redaction 规则。
- `write-journal-operations.ts`：declared-entity touched paths 现包含被引用的 CAS object，manifest+blob 同一次 coordinator commit 交付；lease/claim 分支未触碰。
- `session.ts`（CLI）：export/backfill 消费新 exporter；`session sync` 对 structured manifest 走 declared entity write，narrow artifact helper 仅保留给 legacy provenance。
- `write-road-registry.json`：既有 Session write road 重新描述为 declared-manifest-plus-claim-check，证据锚刷新（registry 如实反映新写路径；road 数不变）。
- 测试：`session-entity.test.ts`（新增，tier manifest + shard 权重/清单三处登记，fileCount 79→80），覆盖 coordinated write、bodyRef 完整性、legacy 读取、SQLite 删除重建；exporter/CLI 套件更新；公共面 golden snapshot 登记有意新导出。

## 任务与范围

- 任务：task_01KX7G4MPV8BW22G3WDFW0P69R（F2 Session Entity）
- 授权链：dec_mrem0ys8（accepted）→ architecture-design.md §3.1/§9.1/§10/§16.3/§16.6/§16.8/§16.10 → ADR-0016 R2（2026-07-11 已入 ledger）
- 范围：仅 Session 实体；execution/lease/claim 面未触碰（F3 并行切片）；`check-kernel-dead-exports.json` 未触碰。

## 版本影响

无发布包版本变更。存量 `harness/sessions/*.md` 读侧兼容（标记 `legacy: true`）、绝不改写；批量迁移属 F7 cutover 切片。

## 治理声明

本 PR 触碰 `tools/write-road-registry.json`（受门禁校验的 inventory）：变更为**重新描述既有 Session write road** 以匹配新的 declared-manifest 写路径（bearing/channel/writeKinds/证据锚更新；road 数不增不减，`check-write-road-registry` 绿）。未触碰 `check-kernel-dead-exports.json` 与 `check-bypass-write-boundary.json`。公共面快照新增为登记有意导出（session entity API + scanner 复用导出），是加强而非削弱 characterization。授权：dec_mrem0ys8 + task_01KX7G4MPV8BW22G3WDFW0P69R。未削弱、移除或绕过任何 gate。

## 验证

- 本地整套 CI boundaries（含带 token 的 `check-github-required-contexts`）：全部通过，exit 0，由 CEO 在基于 origin/main 6ced57a 的 worktree 上复跑。
- typecheck 干净；contract 379/379；相关 integration（基座 + session entity + session CLI）13/13；duplicate-definitions、dead-exports、import/write/bypass/private boundaries 全绿。
- 测试内 fail-closed 阳性对照：篡改 blob hash 拒绝；缺 transcript 拒绝；隐私 finding 如实记录进 manifest（`passed: false`）且不阻断 capture。
- 补充 commit 后本地重跑完整 integration tier（全部 6 shard）：绿。存量 characterization 测试（decision/fact/new-task CLI、registry 面）更新为断言新 `session-entity/v1` manifest 格式——比旧 frontmatter 正则更强的 characterization。

## 审查证据

- CEO 对照 ADR-0016 R2 + mission 不变量 I1–I5 语义验收：声明式接入（无平行栈，§16.10）、coordinator-only manifest 写、先扫描后持久化顺序、legacy 只读兼容、scanner 复用——逐条在 diff 中核实，非转述报告。
- 共享面审计：`registry.ts` 纯加法（session 注册）、`publish-safety.ts` 仅导出、`write-journal-operations.ts` 仅 declared-entity 路径——lease 分支核实未触碰（F3 互斥成立）。
- 实现报告在任务包 artifacts（私有 ledger）。

## 残余风险

- blob 先写、manifest 后写；coordinator 失败可留下可 GC 的孤儿 CAS object（架构 §7 预期恢复模型）。
- capture 层隐私策略为记录不脱敏；敏感内容留在私有 ledger 并带诚实的 `passed: false` 报告，publish 边界仍是执法点。
- 存量 session 在 F7 cutover 前留在旧读路径。

## 关联材料

- dec_mrem0ys8；ADR-0016 R2（私有 ledger）
- architecture-design.md §3.1/§9.1/§10/§16（私有 ledger）

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body, both blocks complete / 双语正文，两块齐全
- [x] Governance declaration for protected surface / protected surface 治理声明
- [x] Local gate green / 本地门绿
- [x] No gate weakened / 未削弱任何门
