### PR TITLE
feat: execution entity, claim saga, and lease v2 with two-axis identity (F3)

### DIFF
--- a/packages/application/src/coordinated-execution-authored-store.ts
+++ b/packages/application/src/coordinated-execution-authored-store.ts
@@ -1,0 +1,105 @@
+import { Effect, Schema } from "effect";
+import {
+  executionDeclaration,
+  stablePayloadHash,
+  writeDeclaredEntityTransaction,
+  type ArtifactStore,
+  type HarnessLayoutInput,
+  type WriteCoordinator
+} from "../../kernel/src/index.ts";
+import type { ExecutionRecord } from "../../kernel/src/index.ts";
+import type { ExecutionAuthoredStore, ExecutionSubmission } from "./execution-saga-service.ts";
+
+export function makeCoordinatedExecutionAuthoredStore(input: {
+  readonly rootInput: HarnessLayoutInput;
+  readonly coordinator: WriteCoordinator;
+  readonly artifactStore: Pick<ArtifactStore, "readTaskPackage">;
+}): ExecutionAuthoredStore {
+  return {
+    readExecution: async (request) => {
+      const task = await Effect.runPromise(input.artifactStore.readTaskPackage(request.taskId));
+      const document = task.documents.find((candidate) => candidate.path === executionPath(request.executionId));
+      return document
+        ? Schema.decodeUnknownSync(executionDeclaration.schema)(executionDeclaration.documentCodec.decode(document.body)) as ExecutionRecord
+        : null;
+    },
+    openExecution: async (request) => {
+      const task = await Effect.runPromise(input.artifactStore.readTaskPackage(request.taskId));
+      if (task.documents.some((document) => document.path === executionPath(request.execution.execution_id))) {
+        throw new Error(`execution already exists: ${request.execution.execution_id}`);
+      }
+      await writeExecutionTransaction(input, request.taskId, request.execution, taskIndex(task.documents, request.taskId, ["planned", "active"], "active"));
+    },
+    submitForReview: async (request) => {
+      const task = await Effect.runPromise(input.artifactStore.readTaskPackage(request.taskId));
+      const document = task.documents.find((candidate) => candidate.path === executionPath(request.executionId));
+      if (!document) throw new Error(`execution not found: ${request.executionId}`);
+      const current = Schema.decodeUnknownSync(executionDeclaration.schema)(
+        executionDeclaration.documentCodec.decode(document.body)
+      ) as ExecutionRecord;
+      if (current.state !== "active") throw new Error(`execution is not active: ${request.executionId}`);
+      assertBindingsFinal(current.session_bindings);
+      const submitted = submittedExecution(current, request.submittedAt, request.submission);
+      await writeExecutionTransaction(input, request.taskId, submitted, taskIndex(task.documents, request.taskId, ["active"], "in_review"));
+    }
+  };
+}
+
+function writeExecutionTransaction(
+  input: { readonly rootInput: HarnessLayoutInput; readonly coordinator: WriteCoordinator },
+  taskId: string,
+  execution: ExecutionRecord,
+  indexBody: string
+): Promise<void> {
+  return Effect.runPromise(writeDeclaredEntityTransaction(
+    input.coordinator,
+    stablePayloadHash,
+    executionDeclaration,
+    { taskId, executionId: execution.execution_id },
+    execution,
+    [{ taskId, path: "INDEX.md", body: indexBody }]
+  ));
+}
+
+function taskIndex(
+  documents: ReadonlyArray<{ readonly path: string; readonly body: string }>,
+  taskId: string,
+  allowed: ReadonlyArray<string>,
+  next: "active" | "in_review"
+): string {
+  const body = documents.find((document) => document.path === "INDEX.md")?.body;
+  if (!body) throw new Error(`task INDEX.md missing: ${taskId}`);
+  const status = body.match(/^  status:\s*(.+)$/mu)?.[1]?.trim();
+  if (!status || !allowed.includes(status)) throw new Error(`task status ${status ?? "unknown"} cannot enter ${next}`);
+  if (!/^  engine:\s*local$/mu.test(body)) throw new Error(`task is not local: ${taskId}`);
+  return body.replace(/^(  status:\s*).+$/mu, `$1${next}`);
+}
+
+function submittedExecution(current: ExecutionRecord, submittedAt: string, submission: ExecutionSubmission): ExecutionRecord {
+  return {
+    ...current,
+    state: "submitted",
+    submitted_at: submittedAt,
+    outputs: [...current.outputs, ...submission.outputs],
+    submission: {
+      summary: submission.summary,
+      verification: submission.verification,
+      residual_risks: submission.residualRisks
+    }
+  };
+}
+
+function assertBindingsFinal(bindings: ReadonlyArray<unknown>): void {
+  for (const binding of bindings) {
+    const status = binding && typeof binding === "object"
+      ? (binding as { readonly archive_status?: unknown }).archive_status
+      : undefined;
+    if (status !== "complete" && status !== "partial" && status !== "unavailable") {
+      throw new Error("all execution session bindings require a final archive_status");
+    }
+  }
+}
+
+function executionPath(executionId: string): string {
+  return `executions/${executionId}.md`;
+}

--- a/packages/application/src/execution-saga-service.ts
+++ b/packages/application/src/execution-saga-service.ts
@@ -1,0 +1,122 @@
+import { generateTaskId } from "../../kernel/src/index.ts";
+import type {
+  ExecutionLeaseContext,
+  ExecutionRecord,
+  TaskHolderPrincipal,
+  TaskHolderService
+} from "../../kernel/src/index.ts";
+
+export interface ExecutionSubmission {
+  readonly summary: string;
+  readonly verification: ReadonlyArray<string>;
+  readonly residualRisks: ReadonlyArray<string>;
+  readonly outputs: ReadonlyArray<unknown>;
+}
+
+export interface ExecutionAuthoredStore {
+  readonly readExecution: (input: { readonly taskId: string; readonly executionId: string }) => Promise<ExecutionRecord | null>;
+  readonly openExecution: (input: {
+    readonly taskId: string;
+    readonly execution: ExecutionRecord;
+  }) => Promise<void>;
+  readonly submitForReview: (input: {
+    readonly taskId: string;
+    readonly executionId: string;
+    readonly submittedAt: string;
+    readonly submission: ExecutionSubmission;
+  }) => Promise<void>;
+}
+
+export interface ExecutionClaimResult extends ExecutionLeaseContext {
+  readonly execution: ExecutionRecord;
+}
+
+export interface ExecutionSagaService {
+  readonly reconcileTask: (taskId: string) => Promise<void>;
+  readonly claim: (input: {
+    readonly taskId: string;
+    readonly principal: TaskHolderPrincipal;
+    readonly ttlMs?: number;
+  }) => Promise<ExecutionClaimResult>;
+  readonly submitForReview: (input: {
+    readonly taskId: string;
+    readonly executionId: string;
+    readonly leaseToken: string;
+    readonly principal: TaskHolderPrincipal;
+    readonly submission: ExecutionSubmission;
+  }) => Promise<void>;
+}
+
+export interface ExecutionSagaServiceOptions {
+  readonly taskHolderService: TaskHolderService;
+  readonly authoredStore: ExecutionAuthoredStore;
+  readonly generateExecutionId?: () => string;
+  readonly now?: () => string;
+}
+
+export function makeExecutionSagaService(options: ExecutionSagaServiceOptions): ExecutionSagaService {
+  const now = () => options.now?.() ?? new Date().toISOString();
+  const generateExecutionId = options.generateExecutionId ?? (() => `exe_${generateTaskId().slice("task_".length)}`);
+  return {
+    claim: async (input) => {
+      await reconcileTask(options, input.taskId);
+      const executionId = generateExecutionId();
+      const reservation = await options.taskHolderService.reserveExecution({
+        taskId: input.taskId,
+        executionId,
+        principal: input.principal,
+        ttlMs: input.ttlMs
+      });
+      const execution: ExecutionRecord = {
+        schema: "execution/v1",
+        execution_id: executionId,
+        task_ref: `task/${input.taskId}`,
+        state: "active",
+        primary_actor: input.principal,
+        claimed_at: now(),
+        submitted_at: null,
+        closed_at: null,
+        session_bindings: [],
+        outputs: [],
+        submission: null
+      };
+      try {
+        await options.authoredStore.openExecution({ taskId: input.taskId, execution });
+      } catch (error) {
+        await options.taskHolderService.releaseExecution({
+          taskId: input.taskId,
+          executionId,
+          leaseToken: reservation.leaseToken,
+          principal: input.principal
+        });
+        throw error;
+      }
+      const active = await options.taskHolderService.activateExecution({
+        taskId: input.taskId,
+        executionId,
+        leaseToken: reservation.leaseToken,
+        principal: input.principal
+      });
+      return { ...active, execution };
+    },
+    submitForReview: async (input) => {
+      await options.taskHolderService.assertExecutionLease(input);
+      await options.authoredStore.submitForReview({
+        taskId: input.taskId,
+        executionId: input.executionId,
+        submittedAt: now(),
+        submission: input.submission
+      });
+      await options.taskHolderService.releaseExecution(input);
+    },
+    reconcileTask: (taskId) => reconcileTask(options, taskId)
+  };
+}
+
+async function reconcileTask(options: ExecutionSagaServiceOptions, taskId: string): Promise<void> {
+  const lease = (await options.taskHolderService.holder({ taskId })).holder;
+  if (lease?.schema !== "task-holder/v2") return;
+  const execution = await options.authoredStore.readExecution({ taskId, executionId: lease.executionId });
+  const authoredState = execution?.state === "submitted" ? "submitted" : execution?.state === "active" ? "active" : "missing";
+  await options.taskHolderService.reconcileExecution({ taskId, executionId: lease.executionId, authoredState });
+}

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -14,6 +14,8 @@ export { CODE_DOC_RECONCILIATION_DOCUMENT, evaluateCodeDocReconciliationGate, re
 export { currentSessionToProvenancePayload, defaultRuntimeSessionEnvCandidates, makeEnvironmentCurrentSessionProbe, makeHumanFallbackSessionProbe } from "./current-session-probe.ts";
 export { bindCreateProvenance } from "./provenance-binding.ts";
 export { makeDecisionWriteService } from "./decision-write-service.ts";
+export { makeExecutionSagaService } from "./execution-saga-service.ts";
+export { makeCoordinatedExecutionAuthoredStore } from "./coordinated-execution-authored-store.ts";
 export { makeFactWriteService } from "./fact-write-service.ts";
 export {
   taskWriteApiRoutePolicies,
@@ -21,12 +23,20 @@ export {
   taskWriteCliRoutePolicy
 } from "./task-write-route-policy.ts";
 export type {
+  ExecutionAuthoredStore,
+  ExecutionClaimResult,
+  ExecutionSagaService,
+  ExecutionSagaServiceOptions,
+  ExecutionSubmission
+} from "./execution-saga-service.ts";
+export type {
   TaskWriteApiRoutePolicy,
   TaskWriteCliRoutePolicy,
   TaskWriteCommandClass
 } from "./task-write-route-policy.ts";
 export {
   TaskClaimCollisionError,
+  ExecutionLeaseCollisionError,
   TaskLeaseRequiredError,
   TaskReleaseNotHolderError,
   isTaskHolderError,
@@ -69,6 +79,9 @@ export type {
   FactWriteServiceOptions
 } from "./fact-write-service.ts";
 export type {
+  ExecutionLeaseContext,
+  ExecutionLeaseRecord,
+  ExecutionLeaseReservation,
   TaskHolderAcquiredVia,
   TaskHolderClaimResult,
   TaskHolderCredential,
@@ -81,6 +94,9 @@ export type {
   TaskHolderServiceOptions,
   TaskHolderSnapshot
 } from "../../kernel/src/index.ts";
+export { executionDeclaration, executionStates, resolveEntityDocumentPath } from "../../kernel/src/index.ts";
+export { makeJournaledWriteCoordinator, makeMarkdownArtifactStore } from "../../kernel/src/index.ts";
+export type { ExecutionRecord, ExecutionState } from "../../kernel/src/index.ts";
 export type {
   ProvenanceSessionBackfillOptions,
   ProvenanceSessionBackfillResult,

--- a/packages/application/src/runtime-event-ledger-service.ts
+++ b/packages/application/src/runtime-event-ledger-service.ts
@@ -32,6 +32,8 @@ export interface RuntimeEventAppendInput {
     readonly sessionId: string;
     readonly runtime?: RuntimeEventRuntime | "unknown";
     readonly taskId?: string;
+    readonly executionId?: string | null;
+    readonly reviewId?: string | null;
     readonly decisionId?: string;
     readonly factRef?: string;
   };
@@ -116,6 +118,8 @@ function toRuntimeEventRecord(
       sessionId: input.session.sessionId,
       runtime: input.session.runtime ?? "unknown",
       ...(input.session.taskId ? { taskId: input.session.taskId } : {}),
+      executionId: input.session.executionId ?? null,
+      reviewId: input.session.reviewId ?? null,
       ...(input.session.decisionId ? { decisionId: input.session.decisionId } : {}),
       ...(input.session.factRef ? { factRef: input.session.factRef } : {})
     },
@@ -217,11 +221,16 @@ function decodeRuntimeEventLine(line: string, sessionId: string, lineNumber: num
 }
 
 function normalizeRuntimeEventRecord(value: unknown): unknown {
-  if (!isRecord(value) || !isRecord(value.actor) || isRecord(value.actor.principal)) return value;
+  if (!isRecord(value)) return value;
+  const session = isRecord(value.session)
+    ? { ...value.session, executionId: value.session.executionId ?? null, reviewId: value.session.reviewId ?? null }
+    : value.session;
+  if (!isRecord(value.actor) || isRecord(value.actor.principal)) return { ...value, session };
   const actor = value.actor;
-  if (typeof actor.personId !== "string") return value;
+  if (typeof actor.personId !== "string") return { ...value, session };
   return {
     ...value,
+    session,
     actor: {
       principal: actor,
       executor: null,

--- a/packages/application/test/execution-saga.test.ts
+++ b/packages/application/test/execution-saga.test.ts
@@ -1,0 +1,270 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  ExecutionLeaseCollisionError,
+  executionDeclaration,
+  makeCoordinatedExecutionAuthoredStore,
+  makeJournaledWriteCoordinator,
+  makeMarkdownArtifactStore,
+  makeExecutionSagaService,
+  makeTaskHolderService,
+  resolveEntityDocumentPath,
+  taskHolderActor
+} from "../src/index.ts";
+import type { ExecutionAuthoredStore, ExecutionRecord } from "../src/index.ts";
+
+const taskId = "task_01KX19GEKWMEJNGSMRT6JJH6HY";
+const executionId = "exe_01KX7H00000000000000000001";
+const secondExecutionId = "exe_01KX7H00000000000000000002";
+const aliceCodex = taskHolderActor(
+  { personId: "alice", displayName: "Alice" },
+  { kind: "agent", id: "codex" }
+);
+const aliceClaude = taskHolderActor(
+  { personId: "alice", displayName: "Alice" },
+  { kind: "agent", id: "claude-code" }
+);
+
+test("Execution is a hosted entity and Holder V2 rejects a second executor", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-execution-saga-"));
+  try {
+    mkdirSync(path.join(rootDir, "harness/tasks", taskId), { recursive: true });
+    assert.equal(
+      resolveEntityDocumentPath(rootDir, executionDeclaration, { taskId, executionId }),
+      path.join(rootDir, "harness/tasks", taskId, "executions", `${executionId}.md`)
+    );
+
+    const service = makeTaskHolderService({
+      rootInput: rootDir,
+      now: () => new Date("2026-07-11T00:00:00.000Z")
+    });
+    const reserved = await service.reserveExecution({ taskId, executionId, principal: aliceCodex, ttlMs: 60_000 });
+
+    assert.equal(reserved.holder?.schema, "task-holder/v2");
+    assert.equal(reserved.holder?.executionId, executionId);
+    assert.deepEqual(reserved.effectiveHolder?.executor, { kind: "agent", id: "codex" });
+    assert.match(reserved.leaseToken, /^[0-9a-f]{64}$/u);
+
+    await assert.rejects(
+      service.reserveExecution({
+        taskId,
+        executionId: "exe_01KX7H00000000000000000002",
+        principal: aliceClaude,
+        ttlMs: 60_000
+      }),
+      ExecutionLeaseCollisionError
+    );
+    await assert.rejects(service.activateExecution({
+      taskId,
+      executionId,
+      leaseToken: reserved.leaseToken,
+      principal: aliceClaude
+    }), /requires an active lease/u);
+    await assert.rejects(service.release({ taskId, principal: aliceCodex }), /is not held/u);
+    const active = await service.activateExecution({
+      taskId,
+      executionId,
+      leaseToken: reserved.leaseToken,
+      principal: aliceCodex
+    });
+    assert.equal(active.phase, "active");
+    assert.equal(
+      readFileSync(path.join(rootDir, ".harness/task-holders", `${taskId}.json`), "utf8").includes(reserved.leaseToken),
+      false
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("a real coordinated claim and submit preserves the hosted Execution round", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-execution-real-"));
+  try {
+    const taskRoot = path.join(rootDir, "harness/tasks", `${taskId}-round-trip`);
+    mkdirSync(taskRoot, { recursive: true });
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex("planned"), "utf8");
+    const coordinator = makeJournaledWriteCoordinator({ rootDir, actor: { kind: "agent", id: "test" } });
+    const holder = makeTaskHolderService({ rootInput: rootDir });
+    const executionIds = [executionId, secondExecutionId];
+    const saga = makeExecutionSagaService({
+      taskHolderService: holder,
+      authoredStore: makeCoordinatedExecutionAuthoredStore({
+        rootInput: rootDir,
+        coordinator,
+        artifactStore: makeMarkdownArtifactStore({ rootDir })
+      }),
+      generateExecutionId: () => executionIds.shift()!,
+      now: () => "2026-07-11T00:00:00.000Z"
+    });
+
+    const claimed = await saga.claim({ taskId, principal: aliceCodex });
+    await saga.submitForReview({
+      taskId,
+      executionId,
+      leaseToken: claimed.leaseToken,
+      principal: aliceCodex,
+      submission: {
+        summary: "round one",
+        verification: ["node:test"],
+        residualRisks: ["review pending"],
+        outputs: [{ kind: "commit", ref: "abc123" }]
+      }
+    });
+
+    const stored = JSON.parse(readFileSync(path.join(taskRoot, "executions", `${executionId}.md`), "utf8")) as ExecutionRecord;
+    assert.equal(stored.state, "submitted");
+    assert.deepEqual(stored.outputs, [{ kind: "commit", ref: "abc123" }]);
+    assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: in_review$/mu);
+
+    writeFileSync(path.join(taskRoot, "executions", `${executionId}.md`), `${JSON.stringify({ ...stored, state: "changes_requested" }, null, 2)}\n`, "utf8");
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex("active"), "utf8");
+    const rework = await saga.claim({ taskId, principal: aliceCodex });
+
+    assert.equal(rework.execution.execution_id, secondExecutionId);
+    const oldRound = JSON.parse(readFileSync(path.join(taskRoot, "executions", `${executionId}.md`), "utf8")) as ExecutionRecord;
+    assert.equal(oldRound.state, "changes_requested");
+    assert.deepEqual(oldRound.outputs, [{ kind: "commit", ref: "abc123" }]);
+    assert.equal(JSON.parse(readFileSync(path.join(taskRoot, "executions", `${secondExecutionId}.md`), "utf8")).state, "active");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("claim releases its reservation when the authored Execution transaction fails", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-execution-claim-rollback-"));
+  try {
+    const holder = makeTaskHolderService({ rootInput: rootDir });
+    const authored = memoryAuthoredStore({ failOpen: true });
+    const saga = makeExecutionSagaService({
+      taskHolderService: holder,
+      authoredStore: authored,
+      generateExecutionId: () => executionId,
+      now: () => "2026-07-11T00:00:00.000Z"
+    });
+
+    await assert.rejects(saga.claim({ taskId, principal: aliceCodex }), /authored open failed/u);
+    assert.equal((await holder.holder({ taskId })).effectiveHolder, null);
+    assert.equal(authored.executions.size, 0);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("submit-for-review changes Execution and Task atomically before releasing the Lease", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-execution-submit-"));
+  try {
+    const holder = makeTaskHolderService({ rootInput: rootDir });
+    const authored = memoryAuthoredStore();
+    const saga = makeExecutionSagaService({
+      taskHolderService: holder,
+      authoredStore: authored,
+      generateExecutionId: () => executionId,
+      now: () => "2026-07-11T00:00:00.000Z"
+    });
+    const claimed = await saga.claim({ taskId, principal: aliceCodex });
+    authored.failSubmit = true;
+
+    await assert.rejects(saga.submitForReview({
+      taskId,
+      executionId,
+      leaseToken: claimed.leaseToken,
+      principal: aliceCodex,
+      submission: {
+        summary: "ready for review",
+        verification: ["test:pass"],
+        residualRisks: [],
+        outputs: [{ kind: "commit", ref: "abc123" }]
+      }
+    }), /authored submit failed/u);
+    assert.equal(authored.executions.get(executionId)?.state, "active");
+    assert.equal(authored.taskStatus, "active");
+    assert.notEqual((await holder.holder({ taskId })).effectiveHolder, null);
+
+    authored.failSubmit = false;
+    await saga.submitForReview({
+      taskId,
+      executionId,
+      leaseToken: claimed.leaseToken,
+      principal: aliceCodex,
+      submission: {
+        summary: "ready for review",
+        verification: ["test:pass"],
+        residualRisks: [],
+        outputs: [{ kind: "commit", ref: "abc123" }]
+      }
+    });
+    assert.equal(authored.executions.get(executionId)?.state, "submitted");
+    assert.equal(authored.taskStatus, "in_review");
+    assert.equal((await holder.holder({ taskId })).effectiveHolder, null);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function memoryAuthoredStore(options: { readonly failOpen?: boolean } = {}): ExecutionAuthoredStore & {
+  readonly executions: Map<string, ExecutionRecord>;
+  taskStatus: "planned" | "active" | "in_review";
+  failSubmit: boolean;
+} {
+  const executions = new Map<string, ExecutionRecord>();
+  const store = {
+    executions,
+    taskStatus: "planned" as const satisfies "planned" | "active" | "in_review",
+    failSubmit: false,
+    readExecution: async (input) => executions.get(input.executionId) ?? null,
+    openExecution: async (input) => {
+      if (options.failOpen) throw new Error("authored open failed");
+      if (executions.has(input.execution.execution_id)) throw new Error("execution already exists");
+      executions.set(input.execution.execution_id, input.execution);
+      store.taskStatus = "active";
+    },
+    submitForReview: async (input) => {
+      if (store.failSubmit) throw new Error("authored submit failed");
+      const current = executions.get(input.executionId);
+      if (!current || current.state !== "active") throw new Error("execution is not active");
+      executions.set(input.executionId, {
+        ...current,
+        state: "submitted",
+        submitted_at: input.submittedAt,
+        outputs: input.submission.outputs,
+        submission: {
+          summary: input.submission.summary,
+          verification: input.submission.verification,
+          residual_risks: input.submission.residualRisks
+        }
+      });
+      store.taskStatus = "in_review";
+    }
+  };
+  return store;
+}
+
+function taskIndex(status: "planned" | "active" | "in_review"): string {
+  return [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    "title: Execution fixture",
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    `  status: ${status}`,
+    "  ref:",
+    "  titleSnapshot: Execution fixture",
+    "  url:",
+    "  bindingCreatedAt: 2026-07-11T00:00:00.000Z",
+    "  bindingFingerprint: sha256:fixture",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "provenance:",
+    "  - {runtime: \"node-test\", sessionId: \"execution-saga\", boundAt: \"2026-07-11T00:00:00.000Z\"}",
+    "---",
+    "",
+    "# Execution fixture",
+    ""
+  ].join("\n");
+}

--- a/packages/application/test/runtime-event-ledger-service.test.ts
+++ b/packages/application/test/runtime-event-ledger-service.test.ts
@@ -20,7 +20,8 @@ test("runtime event ledger appends fsynced JSONL and reads schema-validated reco
       session: {
         sessionId: "codex-session-1",
         runtime: "codex",
-        taskId: "task_01KWK8Z8V1YF1N0V0H2F6R1AYW"
+        taskId: "task_01KWK8Z8V1YF1N0V0H2F6R1AYW",
+        executionId: "exe_01KX7H00000000000000000001"
       },
       actor: {
         personId: "person_zeyu",
@@ -55,6 +56,8 @@ test("runtime event ledger appends fsynced JSONL and reads schema-validated reco
     assert.equal(readBack.events[0]?.actor?.principal.personId, "person_zeyu");
     assert.equal(readBack.events[0]?.actor?.executor, null);
     assert.equal(readBack.events[0]?.actor?.responsibleHuman, "person:person_zeyu");
+    assert.equal(readBack.events[0]?.session.executionId, "exe_01KX7H00000000000000000001");
+    assert.equal(readBack.events[0]?.session.reviewId, null);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }

--- a/packages/cli/src/cli/command-runtime-events.ts
+++ b/packages/cli/src/cli/command-runtime-events.ts
@@ -22,7 +22,8 @@ export function appendCommandRuntimeEvent(
       session: {
         sessionId: session.sessionId,
         runtime: session.runtime,
-        ...entityRefs
+        ...entityRefs,
+        executionId: entityRefs.executionId ?? null
       },
       tool: {
         toolName: command.action.kind,
@@ -54,12 +55,14 @@ export function appendCommandRuntimeEvent(
 function eventEntityRefs(
   action: ParsedCommand["action"],
   result: CliResult
-): { readonly taskId?: string; readonly decisionId?: string; readonly factRef?: string } {
+): { readonly taskId?: string; readonly executionId?: string; readonly decisionId?: string; readonly factRef?: string } {
   const taskId = result.taskId ?? actionTaskId(action);
   const decisionId = result.decisionId ?? ("decisionId" in action ? action.decisionId : undefined);
   const factRef = result.factRef;
+  const executionId = result.executionId ?? ("executionSubmission" in action ? action.executionSubmission?.executionId : undefined);
   return {
     ...(taskId ? { taskId } : {}),
+    ...(executionId ? { executionId } : {}),
     ...(decisionId ? { decisionId } : {}),
     ...(factRef ? { factRef } : {})
   };

--- a/packages/cli/src/cli/command-spec/command-spec-core.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-core.ts
@@ -127,14 +127,15 @@ export const coreCommandSpecs = defineCommandSpecs([
   },
   {
     "kind": "task-claim",
-    "usage": "task claim <id> [--ttl-ms <ms>] [--json]",
-    "options": [{"flag":"--ttl-ms","description":"Set the task holder lease duration in milliseconds."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
+    "usage": "task claim <id> [--execution] [--ttl-ms <ms>] [--json]",
+    "options": [{"flag":"--execution","description":"Open a new Execution round with a Holder V2 credential."},{"flag":"--ttl-ms","description":"Set the task holder lease duration in milliseconds."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
     "summary": "Claim a task holder lease for the authenticated principal.",
     "examples": ["harness-anything task claim task_01ABC --ttl-ms 1800000"],
     "parse": parseCoreTaskArgs,
     "run": runTaskLifecycleCommand,
     "receiptContract": {
       "data": ["taskId", "report"],
+      "optionalData": { "executionId": "Only emitted when --execution opens a Holder V2 round." },
       "paths": []
     },
     "eventPolicy": {
@@ -179,7 +180,7 @@ export const coreCommandSpecs = defineCommandSpecs([
   {
     "kind": "status-set",
     "usage": "task transition <id> <planned|active|blocked|in_review|done|cancelled> [--force --reason <reason>]",
-    "options": [{"flag":"--force","description":"Force the lifecycle transition with audit metadata."},{"flag":"--reason","description":"Record the reason for the lifecycle change."}],
+    "options": [{"flag":"--force","description":"Force the lifecycle transition with audit metadata."},{"flag":"--reason","description":"Record the reason for the lifecycle change."},{"flag":"--execution-id","description":"Submit the exact active Execution when transitioning to in_review."},{"flag":"--lease-token","description":"Authenticate the Holder V2 execution lease."},{"flag":"--summary","description":"Record the Execution submission summary."}],
     "aliases": ["task status set <id> <status> (deprecated, use task transition; retires at E77/F6 acceptance)"],
     "summary": "Move a local task to a new lifecycle status.",
     "examples": ["harness-anything task transition task_01ABC active --reason \"work started\""],
@@ -189,7 +190,9 @@ export const coreCommandSpecs = defineCommandSpecs([
       "data": ["taskId", "status"],
       "optionalData": {
         "forced": "Only emitted for audited terminal recovery transitions invoked with --force.",
-        "forceAudit": "Only emitted for audited terminal recovery transitions that append force audit evidence."
+        "forceAudit": "Only emitted for audited terminal recovery transitions that append force audit evidence.",
+        "executionId": "Only emitted for Holder V2 execution submission.",
+        "report": "Only emitted for Holder V2 execution submission."
       },
       "paths": [],
       "optionalPaths": {

--- a/packages/cli/src/cli/parsers/core-task-execution.ts
+++ b/packages/cli/src/cli/parsers/core-task-execution.ts
@@ -1,0 +1,27 @@
+import type { DomainStatus } from "../../../../kernel/src/index.ts";
+import { cliError, CliErrorCode } from "../error-codes.ts";
+import { readOption, readRepeatedRawOption } from "../parse-options.ts";
+import type { CliResult, ParsedCommand } from "../types.ts";
+
+type Submission = Extract<ParsedCommand["action"], { readonly kind: "status-set" }>["executionSubmission"];
+
+export function parseExecutionSubmissionOptions(args: ReadonlyArray<string>, status: DomainStatus):
+  | { readonly ok: true; readonly value?: Submission }
+  | { readonly ok: false; readonly error: CliResult["error"] } {
+  const executionId = readOption(args, "--execution-id");
+  const leaseToken = readOption(args, "--lease-token");
+  const summary = readOption(args, "--summary");
+  if (![executionId, leaseToken, summary].some(Boolean)) return { ok: true };
+  if (!executionId || !leaseToken || !summary || status !== "in_review") {
+    return { ok: false, error: cliError(CliErrorCode.InvalidTaskMetadata, "Execution submit requires in_review plus --execution-id, --lease-token, and --summary.") };
+  }
+  const values = (flag: string) => readRepeatedRawOption(args, flag).filter((value): value is string => value !== undefined);
+  return { ok: true, value: {
+    executionId,
+    leaseToken,
+    summary,
+    verification: values("--verification"),
+    residualRisks: values("--residual-risk"),
+    outputs: values("--output")
+  } };
+}

--- a/packages/cli/src/cli/parsers/core-task.ts
+++ b/packages/cli/src/cli/parsers/core-task.ts
@@ -5,6 +5,7 @@ import { readOption, readRepeatedRawOption, readRequiredValueOption } from "../p
 import type { CliResult, ParsedCommand } from "../types.ts";
 import { parseTaskArchive } from "./core-task-archive.ts";
 import { parseTaskCodeDocReconcile } from "./core-task-code-doc.ts";
+import { parseExecutionSubmissionOptions } from "./core-task-execution.ts";
 import { parseTaskList } from "./core-task-list.ts";
 
 type ParseResult = { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] };
@@ -54,6 +55,7 @@ function parseTaskClaim(args: ReadonlyArray<string>, rootDir: string, json: bool
   return ok(rootDir, json, {
     kind: "task-claim",
     taskId: args[2],
+    execution: args.includes("--execution"),
     ...(ttlMs !== undefined ? { ttlMs } : {})
   });
 }
@@ -67,12 +69,15 @@ function parseStatusSet(args: ReadonlyArray<string>, rootDir: string, json: bool
   if (force && !reason) {
     return { ok: false, error: cliError(CliErrorCode.MissingForceReason, "Forced terminal status changes require --reason for audit evidence.") };
   }
+  const executionSubmission = parseExecutionSubmissionOptions(args, args[4]);
+  if (!executionSubmission.ok) return executionSubmission;
   return ok(rootDir, json, {
     kind: "status-set",
     taskId: args[3],
     status: args[4],
     force,
-    reason
+    reason,
+    ...(executionSubmission.value ? { executionSubmission: executionSubmission.value } : {})
   });
 }
 

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -99,6 +99,7 @@ export interface CliResult {
   readonly command: string;
   readonly taskId?: string;
   readonly decisionId?: string;
+  readonly executionId?: string;
   readonly factId?: string;
   readonly factRef?: string;
   readonly decisionState?: string;
@@ -185,10 +186,10 @@ export interface ParsedCommand {
   readonly action:
     | { readonly kind: "init"; readonly addNpmScripts: boolean; readonly projectName?: string }
     | { readonly kind: "new-task"; readonly taskId?: string; readonly title: string; readonly parent?: string; readonly slug: string; readonly allowManualId: boolean; readonly fromLegacyId?: string; readonly titleProvided: boolean; readonly slugProvided: boolean; readonly workKind?: TaskWorkKind; readonly riskTier?: PriorityTier; readonly urgency?: PriorityTier; readonly vertical?: string; readonly preset?: string; readonly profile?: string; readonly moduleKey?: string; readonly registerModule?: { readonly key: string; readonly title: string; readonly prefix?: string; readonly scope: string }; readonly longRunning: boolean; readonly dryRun: boolean; readonly locale?: "zh-CN" | "en-US" }
-    | { readonly kind: "task-claim"; readonly taskId: string; readonly ttlMs?: number }
+    | { readonly kind: "task-claim"; readonly taskId: string; readonly ttlMs?: number; readonly execution?: boolean }
     | { readonly kind: "task-holder"; readonly taskId: string }
     | { readonly kind: "task-release"; readonly taskId: string }
-    | { readonly kind: "status-set"; readonly taskId: string; readonly status: DomainStatus; readonly force: boolean; readonly reason?: string }
+    | { readonly kind: "status-set"; readonly taskId: string; readonly status: DomainStatus; readonly force: boolean; readonly reason?: string; readonly executionSubmission?: { readonly executionId: string; readonly leaseToken: string; readonly summary: string; readonly verification: ReadonlyArray<string>; readonly residualRisks: ReadonlyArray<string>; readonly outputs: ReadonlyArray<string> } }
     | { readonly kind: "progress-append"; readonly taskId: string; readonly text: string; readonly evidence?: ReadonlyArray<EvidenceAppendInput> }
     | { readonly kind: "task-amend"; readonly taskId: string; readonly patches: ReadonlyArray<{ readonly field: string; readonly value: string }> }
     | { readonly kind: "task-archive"; readonly taskId?: string; readonly ids?: ReadonlyArray<string>; readonly filter?: string; readonly before?: string; readonly reason: string; readonly archivedBy?: string; readonly archiveField?: string }

--- a/packages/cli/src/commands/core/task-holder.ts
+++ b/packages/cli/src/commands/core/task-holder.ts
@@ -1,5 +1,10 @@
 import { Effect } from "effect";
-import { isTaskHolderError, type TaskHolderPrincipal } from "../../../../application/src/index.ts";
+import {
+  isTaskHolderError,
+  makeCoordinatedExecutionAuthoredStore,
+  makeExecutionSagaService,
+  type TaskHolderPrincipal
+} from "../../../../application/src/index.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
 import type { CommandRunner, CommandRunnerContext } from "../../cli/runner-registry.ts";
@@ -9,6 +14,70 @@ type TaskHolderAction = Extract<
   { readonly kind: "task-claim" | "task-holder" | "task-release" }
 >;
 
+function runExecutionClaim(
+  context: CommandRunnerContext,
+  action: Extract<TaskHolderAction, { readonly kind: "task-claim" }>,
+  principal: TaskHolderPrincipal
+): Effect.Effect<CliResult> {
+  const saga = executionSaga(context);
+  return Effect.promise(() => saga.claim({ taskId: action.taskId, principal, ttlMs: action.ttlMs })).pipe(
+    Effect.map((result): CliResult => ({
+      ok: true,
+      command: "task-claim",
+      taskId: action.taskId,
+      executionId: result.executionId,
+      report: {
+        schema: "execution-claim-result/v1",
+        executionId: result.executionId,
+        leaseToken: result.leaseToken,
+        leaseExpiresAt: result.leaseExpiresAt,
+        actor: result.execution.primary_actor
+      }
+    }))
+  );
+}
+
+export function runExecutionSubmit(
+  context: CommandRunnerContext,
+  action: Extract<Parameters<CommandRunner>[1]["action"], { readonly kind: "status-set" }>
+): Effect.Effect<CliResult> {
+  const principal = taskHolderPrincipal(context);
+  if (!principal.ok) return Effect.succeed(principal.result);
+  const saga = executionSaga(context);
+  const submission = action.executionSubmission!;
+  return Effect.promise(() => saga.submitForReview({
+    taskId: action.taskId,
+    executionId: submission.executionId,
+    leaseToken: submission.leaseToken,
+    principal: principal.value,
+    submission: {
+      summary: submission.summary,
+      verification: submission.verification,
+      residualRisks: submission.residualRisks,
+      outputs: submission.outputs.map((ref) => ({ kind: "reference", ref }))
+    }
+  })).pipe(Effect.map((): CliResult => ({
+    ok: true,
+    command: "status-set",
+    taskId: action.taskId,
+    executionId: submission.executionId,
+    status: "in_review",
+    report: { schema: "execution-submit-result/v1", executionId: submission.executionId, leaseReleased: true }
+  })));
+}
+
+function executionSaga(context: CommandRunnerContext) {
+  const coordinator = context.makeWriteCoordinator(context.actorAttribution().actor);
+  return makeExecutionSagaService({
+    taskHolderService: context.taskHolderService,
+    authoredStore: makeCoordinatedExecutionAuthoredStore({
+      rootInput: context.layoutInput,
+      coordinator,
+      artifactStore: context.artifactStore
+    })
+  });
+}
+
 export function runTaskClaim(
   context: CommandRunnerContext,
   action: Extract<TaskHolderAction, { readonly kind: "task-claim" }>
@@ -16,6 +85,7 @@ export function runTaskClaim(
   return Effect.gen(function* () {
     const principal = taskHolderPrincipal(context);
     if (!principal.ok) return principal.result;
+    if (action.execution) return yield* runExecutionClaim(context, action, principal.value);
     return yield* Effect.tryPromise({
       try: () => context.taskHolderService.claim({ taskId: action.taskId, principal: principal.value, ttlMs: action.ttlMs }),
       catch: taskHolderCommandFailure

--- a/packages/cli/src/commands/core/task-lifecycle.ts
+++ b/packages/cli/src/commands/core/task-lifecycle.ts
@@ -7,7 +7,7 @@ import type { CliResult } from "../../cli/types.ts";
 import type { CommandRunner, CommandRunnerContext } from "../../cli/runner-registry.ts";
 import { runTaskArchive } from "./task-archive.ts";
 import { runTaskAmend } from "./task-amend.ts";
-import { runTaskClaim, runTaskHolder, runTaskRelease } from "./task-holder.ts";
+import { runExecutionSubmit, runTaskClaim, runTaskHolder, runTaskRelease } from "./task-holder.ts";
 import { lifecycleReason } from "./task-lifecycle-shared.ts";
 import { runTaskRelate } from "./task-relations.ts";
 import { runTaskSupersede } from "./task-supersede.ts";
@@ -29,6 +29,7 @@ export const runTaskLifecycleCommand: CommandRunner = (context, command) => {
     case "task-release":
       return runTaskRelease(context, action);
     case "status-set":
+      if (action.executionSubmission) return runExecutionSubmit(context, action);
       return runStatusSet(context, action.taskId, action.status, action.force, action.reason);
     case "progress-append":
       return runProgressAppend(context, action);

--- a/packages/cli/test/receipt-contracts.test.ts
+++ b/packages/cli/test/receipt-contracts.test.ts
@@ -137,6 +137,10 @@ test("optional receipt contract fields carry non-empty absence reasons", () => {
     field: "data.report",
     reason: "Only emitted when the creation path produces a structured creation report."
   }, {
+    command: "task-claim",
+    field: "data.executionId",
+    reason: "Only emitted when --execution opens a Holder V2 round."
+  }, {
     command: "status-set",
     field: "data.forced",
     reason: "Only emitted for audited terminal recovery transitions invoked with --force."
@@ -144,6 +148,14 @@ test("optional receipt contract fields carry non-empty absence reasons", () => {
     command: "status-set",
     field: "data.forceAudit",
     reason: "Only emitted for audited terminal recovery transitions that append force audit evidence."
+  }, {
+    command: "status-set",
+    field: "data.executionId",
+    reason: "Only emitted for Holder V2 execution submission."
+  }, {
+    command: "status-set",
+    field: "data.report",
+    reason: "Only emitted for Holder V2 execution submission."
   }, {
     command: "status-set",
     field: "paths.primary",

--- a/packages/cli/test/task-lease-cli.test.ts
+++ b/packages/cli/test/task-lease-cli.test.ts
@@ -133,6 +133,34 @@ test("configured identity supports direct human claim through --actor", () => {
   });
 });
 
+test("execution claim and submit use Holder V2 without changing legacy task claim", () => {
+  withTempRoot((rootDir) => {
+    writeHarnessIdentity(rootDir, "person_zeyu", "Zeyu Li");
+    const created = runJson(rootDir, ["new-task", "--title", "Execution Saga"]);
+    const claimed = runJson(rootDir, ["task", "claim", created.taskId, "--execution"], true, {
+      HARNESS_ACTOR: "agent:test"
+    });
+
+    assert.match(claimed.executionId, /^exe_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u);
+    assert.match(claimed.report.leaseToken, /^[0-9a-f]{64}$/u);
+    assert.deepEqual(claimed.report.actor.executor, { kind: "agent", id: "test" });
+
+    const submitted = runJson(rootDir, [
+      "task", "transition", created.taskId, "in_review",
+      "--execution-id", claimed.executionId,
+      "--lease-token", claimed.report.leaseToken,
+      "--summary", "ready for review",
+      "--verification", "node:test",
+      "--output", "commit:abc123"
+    ], true, { HARNESS_ACTOR: "agent:test" });
+
+    assert.equal(submitted.status, "in_review");
+    assert.equal(submitted.report.leaseReleased, true);
+    const holder = runJson(rootDir, ["task", "holder", created.taskId]);
+    assert.equal(holder.report.effectiveHolder, null);
+  });
+});
+
 test("same configured person can renew a claim through a different agent", () => {
   withTempRoot((rootDir) => {
     writeHarnessIdentity(rootDir, "person_zeyu", "Zeyu Li");

--- a/packages/kernel/fixtures/schemas/runtime-event-record/valid.json
+++ b/packages/kernel/fixtures/schemas/runtime-event-record/valid.json
@@ -6,7 +6,9 @@
   "session": {
     "sessionId": "codex-session-1",
     "runtime": "codex",
-    "taskId": "task_01KWK8Z8V1YF1N0V0H2F6R1AYW"
+    "taskId": "task_01KWK8Z8V1YF1N0V0H2F6R1AYW",
+    "executionId": null,
+    "reviewId": null
   },
   "turn": null,
   "step": null,

--- a/packages/kernel/src/domain/execution.ts
+++ b/packages/kernel/src/domain/execution.ts
@@ -1,0 +1,32 @@
+export const executionStates = ["active", "submitted", "accepted", "changes_requested", "abandoned"] as const;
+export type ExecutionState = (typeof executionStates)[number];
+
+export interface ExecutionActor {
+  readonly principal: {
+    readonly personId: string;
+    readonly displayName?: string;
+    readonly primaryEmail?: string;
+    readonly providerId?: string;
+    readonly credential?: { readonly kind: string; readonly issuer: string; readonly subject: string };
+  };
+  readonly executor: { readonly kind: "agent"; readonly id: string } | null;
+  readonly responsibleHuman: string;
+}
+
+export interface ExecutionRecord {
+  readonly schema: "execution/v1";
+  readonly execution_id: string;
+  readonly task_ref: string;
+  readonly state: ExecutionState;
+  readonly primary_actor: ExecutionActor;
+  readonly claimed_at: string;
+  readonly submitted_at: string | null;
+  readonly closed_at: string | null;
+  readonly session_bindings: ReadonlyArray<unknown>;
+  readonly outputs: ReadonlyArray<unknown>;
+  readonly submission: {
+    readonly summary: string;
+    readonly verification: ReadonlyArray<string>;
+    readonly residual_risks: ReadonlyArray<string>;
+  } | null;
+}

--- a/packages/kernel/src/domain/runtime-event.ts
+++ b/packages/kernel/src/domain/runtime-event.ts
@@ -55,6 +55,8 @@ export interface RuntimeEventRecord {
     readonly sessionId: string;
     readonly runtime: RuntimeEventRuntime | "unknown";
     readonly taskId?: string;
+    readonly executionId: string | null;
+    readonly reviewId: string | null;
     readonly decisionId?: string;
     readonly factRef?: string;
   };

--- a/packages/kernel/src/entity/declaration.ts
+++ b/packages/kernel/src/entity/declaration.ts
@@ -3,8 +3,9 @@ import { Effect, Schema } from "effect";
 import { declaredEntityId } from "../domain/entity-id.ts";
 import type { WriteError } from "../domain/index.ts";
 import type { HarnessLayoutInput } from "../layout/index.ts";
-import { normalizeRelativeDocumentPath, resolveHarnessLayout } from "../layout/index.ts";
+import { normalizeRelativeDocumentPath, resolveHarnessLayout, taskPackagePath } from "../layout/index.ts";
 import { localLayoutFileSystem } from "../local/local-layout-file-system.ts";
+import type { DocumentWrite } from "../ports/artifact-store-writer.ts";
 import type { WriteCoordinator } from "../ports/index.ts";
 import { writeCoordinatedPayload, type PayloadHasher } from "../write-coordination/write-helpers.ts";
 import {
@@ -36,6 +37,35 @@ export interface DeclaredEntityDocumentWritePayload {
     readonly body: string;
     readonly blobRef?: DeclaredContentAddressedBlobRef;
   };
+  readonly companionWrites?: ReadonlyArray<DocumentWrite>;
+}
+
+export function writeDeclaredEntityTransaction(
+  coordinator: WriteCoordinator,
+  hashPayload: PayloadHasher,
+  declaration: EntityDeclaration,
+  identity: Readonly<Record<string, string>>,
+  value: unknown,
+  companionWrites: ReadonlyArray<DocumentWrite>
+): Effect.Effect<void, WriteError> {
+  const decoded = Schema.decodeUnknownSync(declaration.schema)(value) as Readonly<Record<string, unknown>>;
+  const identityKey = declaration.rootResolver.identity.at(-1)!;
+  return writeCoordinatedPayload(coordinator, hashPayload, {
+    entityId: declaredEntityId(declaration.kind, identity[identityKey] ?? ""),
+    kind: "doc_write",
+    payload: {
+      entityDocument: {
+        declaration: {
+          kind: declaration.kind,
+          storageForm: declaration.storageForm,
+          rootResolver: declaration.rootResolver
+        },
+        identity,
+        body: declaration.documentCodec.encode(decoded)
+      },
+      companionWrites
+    } satisfies DeclaredEntityDocumentWritePayload
+  });
 }
 
 export interface DeclaredContentAddressedBlobRef {
@@ -94,10 +124,16 @@ export function resolveEntityDocumentPath(
   const resolver = declaration.rootResolver;
   if (declaration.storageForm === "hosted-entity") {
     const host = resolver.host!;
-    const hostPath = resolveDeclaredPath(layout.authoredRoot, host.pathTemplate, host.identity, identity);
+    const declaredHostPath = resolveDeclaredPath(layout.authoredRoot, host.pathTemplate, host.identity, identity);
+    const hostPath = !localLayoutFileSystem.exists(declaredHostPath) && host.entityKind === "task"
+      ? taskPackagePath(rootInput, identity[host.identity[0]!] ?? "")
+      : declaredHostPath;
     if (!localLayoutFileSystem.exists(hostPath)) {
       throw new Error(`host entity package not found: ${host.entityKind}/${identity[host.identity[0]!] ?? "unknown"}`);
     }
+    const declaredTarget = resolveDeclaredPath(layout.authoredRoot, resolver.pathTemplate, resolver.identity, identity);
+    const hostedSuffix = path.relative(declaredHostPath, declaredTarget);
+    return path.join(hostPath, hostedSuffix);
   }
   return resolveDeclaredPath(layout.authoredRoot, resolver.pathTemplate, resolver.identity, identity);
 }

--- a/packages/kernel/src/entity/execution-declaration.ts
+++ b/packages/kernel/src/entity/execution-declaration.ts
@@ -1,0 +1,70 @@
+import { Schema } from "effect";
+import { executionStates } from "../domain/execution.ts";
+import { decodeEntityDeclaration, jsonEntityDocumentCodec } from "./declaration.ts";
+
+const PersonPrincipalSchema = Schema.Struct({
+  personId: Schema.String,
+  displayName: Schema.optional(Schema.String),
+  primaryEmail: Schema.optional(Schema.String),
+  providerId: Schema.optional(Schema.String),
+  credential: Schema.optional(Schema.Struct({ kind: Schema.String, issuer: Schema.String, subject: Schema.String }))
+});
+
+export const ExecutionSchema = Schema.Struct({
+  schema: Schema.Literal("execution/v1"),
+  execution_id: Schema.String.pipe(Schema.pattern(/^exe_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u)),
+  task_ref: Schema.String.pipe(Schema.pattern(/^task\/task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u)),
+  state: Schema.Literal(...executionStates),
+  primary_actor: Schema.Struct({
+    principal: PersonPrincipalSchema,
+    executor: Schema.NullOr(Schema.Struct({ kind: Schema.Literal("agent"), id: Schema.String })),
+    responsibleHuman: Schema.String
+  }),
+  claimed_at: Schema.String,
+  submitted_at: Schema.NullOr(Schema.String),
+  closed_at: Schema.NullOr(Schema.String),
+  session_bindings: Schema.Array(Schema.Unknown),
+  outputs: Schema.Array(Schema.Unknown),
+  submission: Schema.NullOr(Schema.Struct({
+    summary: Schema.String,
+    verification: Schema.Array(Schema.String),
+    residual_risks: Schema.Array(Schema.String)
+  }))
+});
+
+export const executionDeclaration = decodeEntityDeclaration({
+  kind: "execution",
+  schema: ExecutionSchema,
+  documentCodec: jsonEntityDocumentCodec,
+  mutabilityContract: {
+    identity: { mutability: "immutable", read: [{ kind: "show", path: "execution.identity" }], write: [], reason: "claim identity is immutable" },
+    state: { mutability: "lifecycle", read: [{ kind: "projection", path: "state", queryable: true }], write: [{ kind: "lifecycle", operation: "transition" }], reason: "domain command lifecycle" },
+    evidence: { mutability: "append-only", read: [{ kind: "show", path: "execution.evidence" }], write: [{ kind: "append", operation: "append" }], reason: "execution evidence is never overwritten" }
+  },
+  anchors: { entityRef: "execution/{taskId}/{executionId}", anchors: [] },
+  dispositionMatrix: {
+    entries: {
+      retire: { level: "D1", action: "retire", supported: true, writeOpKinds: ["doc_write"], reason: "abandon preserves history" },
+      supersede: { level: "D1", action: "supersede", supported: false, writeOpKinds: [], reason: "a new execution is a new round" },
+      invalidate: { level: "D1", action: "invalidate", supported: false, writeOpKinds: [], reason: "not an execution disposition" },
+      archive: { level: "D2", action: "archive", supported: false, writeOpKinds: [], reason: "follows host task" },
+      tombstone: { level: "D3", action: "tombstone", supported: false, writeOpKinds: [], reason: "not in F3" },
+      "hard-delete": { level: "D4", action: "hard-delete", supported: false, writeOpKinds: [], reason: "execution history is durable" }
+    }
+  },
+  storageForm: "hosted-entity",
+  rootResolver: {
+    pathTemplate: "tasks/{taskId}/executions/{executionId}.md",
+    identity: ["taskId", "executionId"],
+    host: { entityKind: "task", pathTemplate: "tasks/{taskId}", identity: ["taskId"] }
+  },
+  projection: {
+    table: "execution_projection",
+    columns: [
+      { name: "execution_id", field: "execution_id", type: "text", primaryKey: true },
+      { name: "task_ref", field: "task_ref", type: "text" },
+      { name: "state", field: "state", type: "text" },
+      { name: "executor", field: "primary_actor.executor", type: "json" }
+    ]
+  }
+});

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,4 +1,7 @@
 export * from "./domain/index.ts";
+export { executionStates } from "./domain/execution.ts";
+export type { ExecutionRecord, ExecutionState } from "./domain/execution.ts";
+export { executionDeclaration } from "./entity/execution-declaration.ts";
 export * from "./docmap/index.ts";
 export * from "./docmap/docmap-unique.ts";
 export * from "./entity/disposition.ts";
@@ -9,6 +12,7 @@ export {
   writeSessionEntity
 } from "./entity/session.ts";
 export type { SessionManifest } from "./schemas/session-manifest.ts";
+export { resolveEntityDocumentPath, writeDeclaredEntityTransaction } from "./entity/declaration.ts";
 export { sha256Text, stablePayloadHash, stableStringify } from "./integrity/stable-hash.ts";
 export * from "./layout/index.ts";
 export * from "./markdown/frontmatter.ts";
@@ -41,6 +45,7 @@ export {
 export type { DaemonRegistry, DaemonRegistryRepo } from "./daemon/registry.ts";
 export {
   TaskClaimCollisionError,
+  ExecutionLeaseCollisionError,
   TaskLeaseRequiredError,
   TaskReleaseNotHolderError,
   isTaskHolderError,
@@ -52,6 +57,9 @@ export {
 } from "./local/task-holder-state.ts";
 export type {
   TaskHolderAcquiredVia,
+  ExecutionLeaseContext,
+  ExecutionLeaseRecord,
+  ExecutionLeaseReservation,
   TaskHolderClaimResult,
   TaskHolderCredential,
   TaskHolderExecutor,

--- a/packages/kernel/src/local/execution-lease-credential.ts
+++ b/packages/kernel/src/local/execution-lease-credential.ts
@@ -1,0 +1,16 @@
+import { createHash } from "node:crypto";
+import type { TaskHolderPrincipal } from "./task-holder-state.ts";
+
+export function sameTaskHolderPrincipal(left: TaskHolderPrincipal, right: TaskHolderPrincipal): boolean {
+  return left.principal.personId === right.principal.personId;
+}
+
+export function sameExecutionLeaseActor(left: TaskHolderPrincipal, right: TaskHolderPrincipal): boolean {
+  return sameTaskHolderPrincipal(left, right) &&
+    left.executor?.kind === right.executor?.kind &&
+    left.executor?.id === right.executor?.id;
+}
+
+export function hashExecutionLeaseToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}

--- a/packages/kernel/src/local/task-holder-state.ts
+++ b/packages/kernel/src/local/task-holder-state.ts
@@ -4,6 +4,7 @@ import { hostname } from "node:os";
 import path from "node:path";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
 import { localRuntimeStateFileSystem } from "./local-layout-file-system.ts";
+import { hashExecutionLeaseToken, sameExecutionLeaseActor, sameTaskHolderPrincipal } from "./execution-lease-credential.ts";
 
 export type TaskHolderAcquiredVia = "claim" | "assignment";
 
@@ -44,12 +45,41 @@ export interface TaskHolderRecord {
   readonly version: string;
 }
 
+export interface ExecutionLeaseRecord {
+  readonly schema: "task-holder/v2";
+  readonly taskId: string;
+  readonly executionId: string;
+  readonly phase: "reserving" | "active";
+  readonly holder: TaskHolderPrincipal;
+  readonly tokenHash: string;
+  readonly acquiredVia: "claim";
+  readonly acquiredAt: string;
+  readonly leaseExpiresAt: string;
+  readonly releasedAt: null;
+  readonly updatedAt: string;
+  readonly version: string;
+}
+
+type AnyTaskHolderRecord = TaskHolderRecord | ExecutionLeaseRecord;
+
 export interface TaskHolderSnapshot {
   readonly taskId: string;
-  readonly holder: TaskHolderRecord | null;
+  readonly holder: AnyTaskHolderRecord | null;
   readonly effectiveHolder: TaskHolderPrincipal | null;
   readonly leaseExpiresAt: string | null;
   readonly orphan: boolean;
+}
+
+export interface ExecutionLeaseReservation extends TaskHolderSnapshot {
+  readonly executionId: string;
+  readonly leaseToken: string;
+  readonly phase: "reserving";
+}
+
+export interface ExecutionLeaseContext extends TaskHolderSnapshot {
+  readonly executionId: string;
+  readonly leaseToken: string;
+  readonly phase: "active";
 }
 
 export interface TaskHolderClaimResult extends TaskHolderSnapshot {
@@ -64,7 +94,7 @@ export interface TaskHolderReleaseResult extends TaskHolderSnapshot {
 }
 
 export class TaskClaimCollisionError extends Error {
-  readonly code = "task_claim_collision";
+  readonly code: string = "task_claim_collision";
   readonly taskId: string;
   readonly holder: TaskHolderPrincipal;
   readonly leaseExpiresAt: string;
@@ -75,6 +105,17 @@ export class TaskClaimCollisionError extends Error {
     this.taskId = input.taskId;
     this.holder = input.holder;
     this.leaseExpiresAt = input.leaseExpiresAt;
+  }
+}
+
+export class ExecutionLeaseCollisionError extends TaskClaimCollisionError {
+  override readonly code = "execution_lease_collision";
+  readonly executionId: string;
+
+  constructor(input: { readonly taskId: string; readonly executionId: string; readonly holder: TaskHolderPrincipal; readonly leaseExpiresAt: string }) {
+    super(input);
+    this.name = "ExecutionLeaseCollisionError";
+    this.executionId = input.executionId;
   }
 }
 
@@ -149,6 +190,11 @@ export interface TaskHolderService {
   readonly holder: (input: { readonly taskId: string }) => Promise<TaskHolderSnapshot>;
   readonly release: (input: { readonly taskId: string; readonly principal: TaskHolderPrincipal }) => Promise<TaskHolderReleaseResult>;
   readonly assertActiveLease: (input: { readonly taskId: string; readonly principal: TaskHolderPrincipal }) => Promise<void>;
+  readonly reserveExecution: (input: { readonly taskId: string; readonly executionId: string; readonly principal: TaskHolderPrincipal; readonly ttlMs?: number }) => Promise<ExecutionLeaseReservation>;
+  readonly activateExecution: (input: { readonly taskId: string; readonly executionId: string; readonly leaseToken: string; readonly principal: TaskHolderPrincipal }) => Promise<ExecutionLeaseContext>;
+  readonly releaseExecution: (input: { readonly taskId: string; readonly executionId: string; readonly leaseToken: string; readonly principal: TaskHolderPrincipal }) => Promise<TaskHolderReleaseResult>;
+  readonly assertExecutionLease: (input: { readonly taskId: string; readonly executionId: string; readonly leaseToken: string; readonly principal: TaskHolderPrincipal }) => Promise<void>;
+  readonly reconcileExecution: (input: { readonly taskId: string; readonly executionId: string; readonly authoredState: "active" | "submitted" | "missing" }) => Promise<void>;
 }
 
 const defaultTtlMs = 30 * 60 * 1_000;
@@ -162,7 +208,7 @@ export function makeTaskHolderService(options: TaskHolderServiceOptions): TaskHo
       const at = now();
       const current = readHolderRecord(options.rootInput, input.taskId);
       const snapshot = holderSnapshot(input.taskId, current, at);
-      if (snapshot.effectiveHolder && !samePrincipal(snapshot.effectiveHolder, input.principal)) {
+      if (snapshot.effectiveHolder && !sameTaskHolderPrincipal(snapshot.effectiveHolder, input.principal)) {
         throw new TaskClaimCollisionError({
           taskId: input.taskId,
           holder: snapshot.effectiveHolder,
@@ -194,7 +240,7 @@ export function makeTaskHolderService(options: TaskHolderServiceOptions): TaskHo
       const at = now();
       const current = readHolderRecord(options.rootInput, input.taskId);
       const snapshot = holderSnapshot(input.taskId, current, at);
-      if (!snapshot.effectiveHolder || !samePrincipal(snapshot.effectiveHolder, input.principal)) {
+      if (current?.schema !== "task-holder/v1" || !snapshot.effectiveHolder || !sameTaskHolderPrincipal(snapshot.effectiveHolder, input.principal)) {
         throw new TaskReleaseNotHolderError({
           taskId: input.taskId,
           principal: input.principal,
@@ -205,7 +251,7 @@ export function makeTaskHolderService(options: TaskHolderServiceOptions): TaskHo
       }
       const releasedAt = at.toISOString();
       const record: TaskHolderRecord = {
-        ...(current ?? emptyHolderRecord(input.taskId, releasedAt)),
+        ...current,
         holder: null,
         acquiredVia: null,
         acquiredAt: null,
@@ -224,7 +270,7 @@ export function makeTaskHolderService(options: TaskHolderServiceOptions): TaskHo
     }),
     assertActiveLease: async (input) => {
       const snapshot = holderSnapshot(input.taskId, readHolderRecord(options.rootInput, input.taskId), now());
-      if (snapshot.effectiveHolder && samePrincipal(snapshot.effectiveHolder, input.principal)) return;
+      if (snapshot.effectiveHolder && sameTaskHolderPrincipal(snapshot.effectiveHolder, input.principal)) return;
       throw new TaskLeaseRequiredError({
         taskId: input.taskId,
         principal: input.principal,
@@ -232,7 +278,68 @@ export function makeTaskHolderService(options: TaskHolderServiceOptions): TaskHo
         leaseExpiresAt: snapshot.leaseExpiresAt,
         orphan: snapshot.orphan
       });
-    }
+    },
+    reserveExecution: (input) => withTaskHolderMutationLock(options.rootInput, input.taskId, () => {
+      const at = now();
+      const current = readHolderRecord(options.rootInput, input.taskId);
+      const snapshot = holderSnapshot(input.taskId, current, at);
+      if (snapshot.effectiveHolder) {
+        throw new ExecutionLeaseCollisionError({
+          taskId: input.taskId,
+          executionId: "executionId" in current! ? current.executionId : "unknown",
+          holder: snapshot.effectiveHolder,
+          leaseExpiresAt: snapshot.leaseExpiresAt ?? ""
+        });
+      }
+      const acquiredAt = at.toISOString();
+      const leaseToken = randomBytes(32).toString("hex");
+      const record: ExecutionLeaseRecord = {
+        schema: "task-holder/v2",
+        taskId: input.taskId,
+        executionId: input.executionId,
+        phase: "reserving",
+        holder: input.principal,
+        tokenHash: hashExecutionLeaseToken(leaseToken),
+        acquiredVia: "claim",
+        acquiredAt,
+        leaseExpiresAt: new Date(at.getTime() + ttl(input.ttlMs)).toISOString(),
+        releasedAt: null,
+        updatedAt: acquiredAt,
+        version: holderVersion(acquiredAt)
+      };
+      writeHolderRecord(options.rootInput, record);
+      return { ...holderSnapshot(input.taskId, record, at), executionId: input.executionId, leaseToken, phase: "reserving" };
+    }),
+    activateExecution: (input) => withTaskHolderMutationLock(options.rootInput, input.taskId, () => {
+      const at = now();
+      const current = requireExecutionCredential(readHolderRecord(options.rootInput, input.taskId), input, at);
+      if (current.phase !== "reserving") throw new Error(`execution lease is not reserving: ${input.executionId}`);
+      const record: ExecutionLeaseRecord = { ...current, phase: "active", updatedAt: at.toISOString(), version: holderVersion(at.toISOString()) };
+      writeHolderRecord(options.rootInput, record);
+      return { ...holderSnapshot(input.taskId, record, at), executionId: input.executionId, leaseToken: input.leaseToken, phase: "active" };
+    }),
+    releaseExecution: (input) => withTaskHolderMutationLock(options.rootInput, input.taskId, () => {
+      const at = now();
+      const current = requireExecutionCredential(readHolderRecord(options.rootInput, input.taskId), input, at);
+      const releasedAt = at.toISOString();
+      const record = emptyHolderRecord(input.taskId, releasedAt);
+      writeHolderRecord(options.rootInput, record);
+      return { ...holderSnapshot(input.taskId, record, at), released: true, previousHolder: current.holder, releasedAt };
+    }),
+    assertExecutionLease: async (input) => {
+      const current = requireExecutionCredential(readHolderRecord(options.rootInput, input.taskId), input, now());
+      if (current.phase !== "active") throw new Error(`execution lease is not active: ${input.executionId}`);
+    },
+    reconcileExecution: (input) => withTaskHolderMutationLock(options.rootInput, input.taskId, () => {
+      const current = readHolderRecord(options.rootInput, input.taskId);
+      if (current?.schema !== "task-holder/v2" || current.executionId !== input.executionId) return;
+      const at = now().toISOString();
+      if (input.authoredState === "active") {
+        if (current.phase === "reserving") writeHolderRecord(options.rootInput, { ...current, phase: "active", updatedAt: at, version: holderVersion(at) });
+        return;
+      }
+      writeHolderRecord(options.rootInput, emptyHolderRecord(input.taskId, at));
+    })
   };
 }
 
@@ -289,7 +396,7 @@ export function isTaskHolderError(error: unknown): error is TaskClaimCollisionEr
     error instanceof TaskReleaseNotHolderError;
 }
 
-function holderSnapshot(taskId: string, record: TaskHolderRecord | null, at: Date): TaskHolderSnapshot {
+function holderSnapshot(taskId: string, record: AnyTaskHolderRecord | null, at: Date): TaskHolderSnapshot {
   const effective = effectiveHolder(record, at);
   return {
     taskId,
@@ -300,22 +407,22 @@ function holderSnapshot(taskId: string, record: TaskHolderRecord | null, at: Dat
   };
 }
 
-function effectiveHolder(record: TaskHolderRecord | null, at: Date): TaskHolderPrincipal | null {
+function effectiveHolder(record: AnyTaskHolderRecord | null, at: Date): TaskHolderPrincipal | null {
   if (!record?.holder || !record.leaseExpiresAt || record.releasedAt) return null;
   return Date.parse(record.leaseExpiresAt) > at.getTime() ? record.holder : null;
 }
 
-function readHolderRecord(rootInput: HarnessLayoutInput, taskId: string): TaskHolderRecord | null {
+function readHolderRecord(rootInput: HarnessLayoutInput, taskId: string): AnyTaskHolderRecord | null {
   const filePath = holderRecordPath(rootInput, taskId);
   if (!localRuntimeStateFileSystem.exists(filePath)) return null;
-  const parsed = JSON.parse(localRuntimeStateFileSystem.readText(filePath)) as TaskHolderRecord;
-  if (parsed.schema !== "task-holder/v1" || parsed.taskId !== taskId) {
+  const parsed = JSON.parse(localRuntimeStateFileSystem.readText(filePath)) as AnyTaskHolderRecord;
+  if ((parsed.schema !== "task-holder/v1" && parsed.schema !== "task-holder/v2") || parsed.taskId !== taskId) {
     throw new Error(`invalid task holder record for ${taskId}`);
   }
   return parsed;
 }
 
-function writeHolderRecord(rootInput: HarnessLayoutInput, record: TaskHolderRecord): void {
+function writeHolderRecord(rootInput: HarnessLayoutInput, record: AnyTaskHolderRecord): void {
   const filePath = holderRecordPath(rootInput, record.taskId);
   localRuntimeStateFileSystem.mkdirp(path.dirname(filePath));
   const tempPath = `${filePath}.${process.pid}.${randomBytes(4).toString("hex")}.tmp`;
@@ -464,8 +571,24 @@ function normalizeTtlMs(value: number): number {
   return Math.floor(value);
 }
 
-function samePrincipal(left: TaskHolderPrincipal, right: TaskHolderPrincipal): boolean {
-  return left.principal.personId === right.principal.personId;
+function requireExecutionCredential(
+  record: AnyTaskHolderRecord | null,
+  input: { readonly taskId: string; readonly executionId: string; readonly leaseToken: string; readonly principal: TaskHolderPrincipal },
+  at: Date
+): ExecutionLeaseRecord {
+  const valid = record?.schema === "task-holder/v2" &&
+    Date.parse(record.leaseExpiresAt) > at.getTime() &&
+    record.executionId === input.executionId &&
+    record.tokenHash === hashExecutionLeaseToken(input.leaseToken) &&
+    sameExecutionLeaseActor(record.holder, input.principal);
+  if (!valid) throw new TaskLeaseRequiredError({
+    taskId: input.taskId,
+    principal: input.principal,
+    holder: effectiveHolder(record, at),
+    leaseExpiresAt: record?.leaseExpiresAt ?? null,
+    orphan: Boolean(record?.holder && !effectiveHolder(record, at))
+  });
+  return record;
 }
 
 function holderVersion(at: string): string {

--- a/packages/kernel/src/schemas/runtime-event.ts
+++ b/packages/kernel/src/schemas/runtime-event.ts
@@ -51,6 +51,8 @@ export const RuntimeEventRecordSchema = Schema.Struct({
     sessionId: Schema.String,
     runtime: Schema.Union(CurrentSessionRuntimeSchema, Schema.Literal("unknown")),
     taskId: OptionalString,
+    executionId: Schema.NullOr(Schema.String),
+    reviewId: Schema.NullOr(Schema.String),
     decisionId: OptionalString,
     factRef: OptionalString
   }),

--- a/packages/kernel/src/store/write-journal-operations.ts
+++ b/packages/kernel/src/store/write-journal-operations.ts
@@ -54,12 +54,16 @@ export interface WriteTransactionPlan {
 
 export function writeTransactionPlan(op: WriteOp): WriteTransactionPlan {
   if (op.kind === "doc_write" && hasDeclaredEntityDocument(op.payload)) {
+    const companionWrites = declaredEntityCompanionWrites(op.payload);
     return {
-      touchedPaths: (rootInput) => declaredEntityTouchedPaths(rootInput, op),
-      documentWrites: () => [],
+      touchedPaths: (rootInput) => [
+        ...declaredEntityTouchedPaths(rootInput, op),
+        ...companionWrites.map((write) => documentTargetPath(rootInput, write))
+      ],
+      documentWrites: () => companionWrites,
       apply: (rootInput) => {
         const document = declaredEntityDocument(rootInput, op);
-        writeFileDurably(document.targetPath, document.body);
+        writeDocumentsAtomically(rootInput, companionWrites, document);
         return null;
       },
       validate: (rootInput) => {
@@ -287,6 +291,14 @@ function hasDeclaredEntityDocument(payload: unknown): payload is DeclaredEntityD
   return Boolean(payload && typeof payload === "object" && "entityDocument" in payload);
 }
 
+function declaredEntityCompanionWrites(payload: DeclaredEntityDocumentWritePayload): ReadonlyArray<DocumentWrite> {
+  const writes = payload.companionWrites ?? [];
+  if (!Array.isArray(writes) || writes.some((write) => !write || typeof write.path !== "string" || typeof write.body !== "string")) {
+    rejectWrite("declared entity companionWrites must be document writes");
+  }
+  return writes;
+}
+
 function declaredEntityDocument(
   rootInput: HarnessLayoutInput,
   op: WriteOp
@@ -392,8 +404,12 @@ export { isProgressAppendDeltaPayload, readHardDeletePayload } from "./write-jou
 
 
 
-function writeDocumentsAtomically(rootInput: HarnessLayoutInput, writes: ReadonlyArray<DocumentWrite>): void {
-  if (writes.length === 0) rejectWrite("batch document write requires at least one write");
+function writeDocumentsAtomically(
+  rootInput: HarnessLayoutInput,
+  writes: ReadonlyArray<DocumentWrite>,
+  declaredEntity?: { readonly targetPath: string; readonly body: string }
+): void {
+  if (writes.length === 0 && !declaredEntity) rejectWrite("batch document write requires at least one write");
   const entries = writes.map((write) => ({
     write,
     targetPath: documentTargetPath(rootInput, write)
@@ -403,14 +419,17 @@ function writeDocumentsAtomically(rootInput: HarnessLayoutInput, writes: Readonl
     if (targetPaths.has(entry.targetPath)) rejectTaskWrite(`duplicate batch write target: ${entry.write.path}`, entry.write.taskId);
     targetPaths.add(entry.targetPath);
   }
+  if (declaredEntity && targetPaths.has(declaredEntity.targetPath)) rejectWrite("declared entity transaction has duplicate targets");
 
-  const backups = entries.map((entry) => ({
-    targetPath: entry.targetPath,
-    existed: existsSync(entry.targetPath),
-    body: existsSync(entry.targetPath) ? readFileSync(entry.targetPath, "utf8") : null
+  const targets = [...(declaredEntity ? [declaredEntity.targetPath] : []), ...entries.map((entry) => entry.targetPath)];
+  const backups = targets.map((targetPath) => ({
+    targetPath,
+    existed: existsSync(targetPath),
+    body: existsSync(targetPath) ? readFileSync(targetPath, "utf8") : null
   }));
 
   try {
+    if (declaredEntity) writeFileDurably(declaredEntity.targetPath, declaredEntity.body);
     for (const entry of entries) writeDocument(rootInput, entry.write);
   } catch (error) {
     for (const backup of backups.reverse()) {

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -19,6 +19,7 @@ const publicRuntimeSurface = [
   "DomainStatusSchema",
   "EntityRelationRecordSchema",
   "EntityRelationsSchema",
+  "ExecutionLeaseCollisionError",
   "FactRecordSchema",
   "FreshnessSchema",
   "HarnessCheckReportSchema",
@@ -95,6 +96,8 @@ const publicRuntimeSurface = [
   "entityStorageForms",
   "evaluateEntityDisposition",
   "evaluateImplicitDispositionRecommendations",
+  "executionDeclaration",
+  "executionStates",
   "explainDecisionStateTransition",
   "explainStatusTransition",
   "factConfidenceLevels",
@@ -182,6 +185,7 @@ const publicRuntimeSurface = [
   "requiredSchemaIds",
   "reservePublishIdempotencyKey",
   "resolveDaemonRepoByRoot",
+  "resolveEntityDocumentPath",
   "resolveEntityRoot",
   "resolveHarnessLayout",
   "resolveTaskSchema",
@@ -222,6 +226,7 @@ const publicRuntimeSurface = [
   "writeContentAddressedBlob",
   "writeCoordinatedPayload",
   "writeCoordinatedTaskDocuments",
+  "writeDeclaredEntityTransaction",
   "writeSessionEntity"
 ];
 

--- a/tools/check-integration-test-shards.test.mjs
+++ b/tools/check-integration-test-shards.test.mjs
@@ -9,7 +9,7 @@ import {
 test("integration shard declaration is non-overlapping and complete", () => {
   const result = checkIntegrationTestShards();
   assert.equal(result.ok, true, result.errors.join("\n"));
-  assert.equal(result.fileCount, 80);
+  assert.equal(result.fileCount, 81);
   assert.deepEqual(result.workflowShards, [1, 2, 3, 4, 5, 6]);
   assert.deepEqual(result.requiredContexts, [
     "integration-shard (1)",

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -19,7 +19,7 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@181:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@185:9",
         "ref": "task_01KX68A7MK6HH9TM16T95M8ZZK",
         "reason": "P3-1 hard-delete apply relocated from coordinator to the op transaction plan; same coordinator-executed durable write path, not a bypass caller."
       },
@@ -224,27 +224,27 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@418:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@437:9",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@441:3",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@460:3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@453:5",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@472:5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@421:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@440:9",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#writeFileSync@419:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#writeFileSync@438:9",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       }

--- a/tools/integration-test-shards.mjs
+++ b/tools/integration-test-shards.mjs
@@ -5,6 +5,7 @@ export const integrationShardCount = 6;
 export const integrationTestFileWeightsMs = Object.freeze({
   "packages/adapters/multica/test/multica-readonly-adopt.test.ts": 782.5,
   "packages/application/test/local-controller-service.test.ts": 507.0,
+  "packages/application/test/execution-saga.test.ts": 1200.0,
   "packages/cli/test/actor-attribution-cli.test.ts": 3640.4,
   "packages/cli/test/anchor-backfill-cli.test.ts": 16962.1,
   "packages/cli/test/attribution-diff-cli.test.ts": 4299.9,
@@ -117,6 +118,7 @@ export const integrationTestShards = Object.freeze([
       "tools/check-runtime-release-readiness.test.mjs",
       "tools/check-docs-release-map.test.mjs",
       "packages/application/test/local-controller-service.test.ts",
+      "packages/application/test/execution-saga.test.ts",
       "packages/kernel/test/store/portable-path-collision.test.ts"
     ])
   }),

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -111,6 +111,7 @@ export const testTierManifest = {
   ],
   integration: [
     "packages/adapters/multica/test/multica-readonly-adopt.test.ts",
+    "packages/application/test/execution-saga.test.ts",
     "packages/application/test/local-controller-service.test.ts",
     "packages/daemon/test/transport-integration.test.ts",
     "packages/cli/test/actor-attribution-cli.test.ts",


### PR DESCRIPTION
# English

## Summary

F3 slice of the Session/Execution entity architecture: Execution becomes a formal `hosted-entity` declared on the F1 registry substrate, and the task lease is upgraded to Holder V2 — a runtime CAS lease that binds `taskId + executionId + token hash + principal/executor two-axis identity`. Claiming follows a recoverable saga (reservation → authored Execution open → active), and submit-for-review is a single authored transaction that atomically moves `Execution → submitted` and `Task → in_review`, releasing the lease only after the transaction succeeds (ADR-0027 CH2). All CLI wiring is opt-in behind flags; existing `ha task transition` behavior is unchanged.

## What Changed

- `packages/kernel/src/domain/execution.ts` (new): pure Execution domain states and record.
- `packages/kernel/src/entity/execution-declaration.ts` (new): `execution/v1` hosted-entity five-tuple — root `tasks/{taskId}/executions/{executionId}.md`, projection contract, disposition matrix.
- `packages/kernel/src/local/task-holder-state.ts`: `task-holder/v2` record with `executionId`, `phase (reserving|active)`, `tokenHash` (SHA-256; raw token never persisted), and both actor axes; second claim collides with `execution_lease_collision` even for the same principal; legacy release cannot bypass the V2 credential.
- `packages/kernel/src/local/execution-lease-credential.ts` (new): token generation/hashing.
- `packages/application/src/coordinated-execution-authored-store.ts` (new): authored Execution open (fails closed if the execution file already exists — old rounds are never overwritten) and the submit transaction builder.
- `packages/application/src/execution-saga-service.ts` (new): claim saga (reservation reconciler → authored open → lease activate) and submit-for-review orchestration; worker path has no accept/complete capability.
- `packages/kernel/src/entity/declaration.ts`: declared-entity companion transaction helper + slugged task package host-root resolution.
- `packages/kernel/src/store/write-journal-operations.ts`: the existing `doc_write` declared-entity plan can carry companion document writes executed under the existing atomic backup/rollback helper — **no new WriteOpKind**; merged with F2's blob-touched-paths semantics (`touchedPaths = [manifest, blob?, ...companions]`).
- Runtime Events: `session` events gain required nullable `executionId`/`reviewId` linkage; unknown is an explicit `null` (never guessed); legacy v1 reads normalize to `null`.
- CLI (opt-in only): `ha task claim <id> --execution` and `ha task transition <id> in_review --execution-id <exe> --lease-token <token> --summary ... [--verification/--residual-risk/--output]`; default paths untouched.
- Tests: `packages/application/test/execution-saga.test.ts` (new, registered in tier manifest + shard 2 + fileCount 80 → 81 after rebase over F2) covering double-claim collision, authored-open failure releasing the reservation, submit-failure atomicity (state and lease unchanged), rework creating E2 with E1 outputs intact, raw-token non-persistence, and legacy-release bypass rejection; CLI lease integration extended.

## Task And Scope

- Task: task_01KX7G4S7M73206DV3N1R4Q05A (F3 Execution + Lease v2)
- Authority chain: dec_mrem0ys8 (accepted) → architecture-design.md §3.2/§5/§6/§7/§8/§16 → ADR-0027 D1–D7 (merged to ledger 2026-07-11); two-axis attribution per dec_mrd7jiux
- Scope: execution/lease/claim surfaces only. Session manifest/blob/export untouched (F2, merged as #623); Review entity, three-valued verdict, and lifecycle cutover remain F5/F4/F7.

## Version Impact

No published package version change. Existing lease/transition behavior preserved; the saga path is flag-gated until the F4 lifecycle slice switches defaults.

## Governance Declaration

This PR touches `tools/gate-allowlists/check-bypass-write-boundary.json` (protected gate surface). Change is **line-anchor repinning only**: 6 entries in `write-journal-operations.ts` repinned after additive code movement, entry count and governed-write delta both 0 (`current=125 previous=125 delta=0`). Authority: dec_mrem0ys8 + task_01KX7G4S7M73206DV3N1R4Q05A; precedent for delta=0 repins: PR #608 / #617 / #622. `check-kernel-dead-exports.json` is untouched (gate green, no stale entries). No gate weakened, removed, or bypassed.

## Verification

- Rebased onto post-F2 main (`eef1ce3`); the `writeTransactionPlan` declared-entity branch merges F2 blob paths with F3 companion writes, verified by running both features' suites together: execution-saga + session-entity + substrate + task-lease CLI + exporter, 38/38.
- Full local CI boundaries (including `check-github-required-contexts` with token): exit 0.
- All 6 integration shards run locally after the rebase: green (lesson from #623 institutionalized).
- Typecheck/lint clean; duplicate-definitions and dead-exports green.

## Review Evidence

- CEO semantic review against ADR-0027 D1–D7 + mission invariants I1–I5, verified in the diff: companion transaction reuses the existing atomic write path (no new WriteOpKind — the mission's stop-condition never triggered), lease collision/no-overwrite/token-hash-only assertions present, `executionId` explicitly nullable in the event schema, CLI strictly flag-gated.
- Mutual-exclusion audit vs F2: no session manifest/blob/export files touched; shared surfaces (kernel index, declaration.ts, write-journal-operations.ts) additive and reported, resolved in rebase by the CEO.
- Implementation report: task package artifacts (private ledger).

## Residual Risk

- The reservation reconciler runs at claim time; daemon-startup periodic sweep is deferred to the lifecycle/cutover slices.
- This slice validates registered bindings are finalized at submit; primary-Session-must-exist and snapshot/finalize orchestration depend on F2/F4 wiring.
- Review entity, three-valued verdict, `changes_requested` command, and the complete gate are F5/F4/F7; the state machine keeps those exits open without implementing privileged paths.

## References

- dec_mrem0ys8; ADR-0027; dec_mrd7jiux (private ledger)
- architecture-design.md §3.2, §5, §6, §7, §8, §16 (private ledger)

# 中文

## 概要

Session/Execution 实体架构的 F3 切片：Execution 成为 F1 registry 基座上的正式 `hosted-entity`，task lease 升级为 Holder V2——绑定 `taskId + executionId + token 哈希 + principal/executor 双轴身份` 的 runtime CAS。claim 走可恢复 saga（reservation → authored Execution 开轮 → active）；submit-for-review 是单个 authored 事务，原子推进 `Execution → submitted` 与 `Task → in_review`，事务成功后才释放 lease（ADR-0027 CH2）。CLI 全部 flag 灰度，存量 `ha task transition` 行为不变。

## 改动内容

- `execution.ts`（新增）：纯 Execution domain 状态与 record。
- `execution-declaration.ts`（新增）：`execution/v1` hosted-entity 五元组——root `tasks/{taskId}/executions/{executionId}.md`、投影契约、disposition matrix。
- `task-holder-state.ts`：`task-holder/v2` record 带 `executionId`、`phase (reserving|active)`、`tokenHash`（SHA-256，raw token 不落盘）与双轴身份；同 principal 第二次 claim 也报 `execution_lease_collision`；legacy release 绕不过 V2 credential。
- `execution-lease-credential.ts`（新增）：token 生成/哈希。
- `coordinated-execution-authored-store.ts`（新增）：authored Execution 开轮（文件已存在即 fail-closed——旧轮永不覆盖）与 submit 事务构造。
- `execution-saga-service.ts`（新增）：claim saga（reservation reconciler → authored 开轮 → lease 激活）与 submit-for-review 编排；worker 路径无 accept/complete 能力。
- `declaration.ts`：declared-entity companion 事务 helper + slugged 任务包 host-root 解析。
- `write-journal-operations.ts`：既有 `doc_write` declared-entity plan 可携带 companion document writes，复用既有原子 backup/rollback——**零新增 WriteOpKind**；与 F2 的 blob touched-paths 语义合并（`touchedPaths = [manifest, blob?, ...companions]`）。
- Runtime Event：`session` 事件增加必需 nullable `executionId`/`reviewId` linkage；未知显式 `null`（不猜造）；legacy v1 读取规范化为 `null`。
- CLI（纯 opt-in）：`ha task claim <id> --execution` 与 `ha task transition <id> in_review --execution-id <exe> --lease-token <token> --summary ...`；默认路径不动。
- 测试：`execution-saga.test.ts`（新增，tier manifest + shard 2 + fileCount 80→81（rebase 过 F2 后）三处登记），覆盖双 claim 冲突、authored 开轮失败释放 reservation、submit 失败原子性（状态与 lease 均不变）、返工建 E2 且 E1 outputs 原样、raw token 不落盘、legacy release 绕过被拒；CLI lease integration 扩展。

## 任务与范围

- 任务：task_01KX7G4S7M73206DV3N1R4Q05A（F3 Execution + Lease v2）
- 授权链：dec_mrem0ys8（accepted）→ architecture-design.md §3.2/§5/§6/§7/§8/§16 → ADR-0027 D1–D7（2026-07-11 已入 ledger）；双轴归属按 dec_mrd7jiux
- 范围：仅 execution/lease/claim 面；Session manifest/blob/export 未触碰（F2 已以 #623 合入）；Review entity/三值 verdict/lifecycle cutover 属 F5/F4/F7。

## 版本影响

无发布包版本变更。存量 lease/transition 行为保持；saga 路径 flag 门控，默认切换属 F4 lifecycle 切片。

## 治理声明

本 PR 触碰 `tools/gate-allowlists/check-bypass-write-boundary.json`（protected gate surface）。变更**仅为行号锚 repin**：`write-journal-operations.ts` 加法代码移动后 6 条锚更新，条目数与受治理写调用 delta 均为 0（`current=125 previous=125 delta=0`）。授权：dec_mrem0ys8 + task_01KX7G4S7M73206DV3N1R4Q05A；delta=0 先例：PR #608/#617/#622。`check-kernel-dead-exports.json` 未触碰（门绿、无 stale 条目）。未削弱、移除或绕过任何 gate。

## 验证

- 已 rebase 到 F2 合入后的 main（`eef1ce3`）；`writeTransactionPlan` declared-entity 分支合并 F2 blob 路径与 F3 companion writes，两特性套件合跑验证：execution-saga + session-entity + substrate + task-lease CLI + exporter，38/38。
- 本地整套 CI boundaries（含带 token 的 required-contexts）exit 0。
- rebase 后本地跑全部 6 个 integration shard：绿（#623 教训已固化）。
- typecheck/lint 干净；duplicate-definitions 与 dead-exports 绿。

## 审查证据

- CEO 对照 ADR-0027 D1–D7 + mission 不变量 I1–I5 语义验收，逐条 diff 核实：companion 事务复用既有原子写路径（零新 WriteOpKind——mission 停止条件未触发）、lease 冲突/不覆盖/仅存哈希断言在测、event schema `executionId` 显式 nullable、CLI 严格 flag 门控。
- 与 F2 互斥审计：session manifest/blob/export 文件零触碰；共享面（kernel index/declaration.ts/write-journal-operations.ts）纯加法且已单列，rebase 冲突由 CEO 亲手合并。
- 实现报告在任务包 artifacts（私有 ledger）。

## 残余风险

- reservation reconciler 在 claim 时执行；daemon 启动定时扫描留给 lifecycle/cutover 切片。
- 本片只验证 submit 时已登记 binding 均终结；primary Session 必须存在与 snapshot/finalize 编排依赖 F2/F4 接线。
- Review entity、三值 verdict、`changes_requested` 命令与 complete gate 属 F5/F4/F7；状态机保留出口、不实现越权路径。

## 关联材料

- dec_mrem0ys8；ADR-0027；dec_mrd7jiux（私有 ledger）
- architecture-design.md §3.2/§5/§6/§7/§8/§16（私有 ledger）

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body, both blocks complete / 双语正文，两块齐全
- [x] Governance declaration for protected surface / protected surface 治理声明
- [x] Local gate green / 本地门绿
- [x] No gate weakened / 未削弱任何门
