### PR TITLE
feat: submit lifecycle with session bindings and startup reconciler (F4)

### DIFF
--- a/packages/application/src/coordinated-execution-authored-store.ts
+++ b/packages/application/src/coordinated-execution-authored-store.ts
@@ -1,6 +1,7 @@
 import { Effect, Schema } from "effect";
 import {
   executionDeclaration,
+  readSessionEntityDocument,
   stablePayloadHash,
   writeDeclaredEntityTransaction,
   type ArtifactStore,
@@ -30,6 +31,22 @@ export function makeCoordinatedExecutionAuthoredStore(input: {
       }
       await writeExecutionTransaction(input, request.taskId, request.execution, taskIndex(task.documents, request.taskId, ["planned", "active"], "active"));
     },
+    attachSession: async (request) => {
+      const task = await Effect.runPromise(input.artifactStore.readTaskPackage(request.taskId));
+      const document = task.documents.find((candidate) => candidate.path === executionPath(request.executionId));
+      if (!document) throw new Error(`execution not found: ${request.executionId}`);
+      const current = Schema.decodeUnknownSync(executionDeclaration.schema)(
+        executionDeclaration.documentCodec.decode(document.body)
+      ) as ExecutionRecord;
+      if (current.state !== "active") throw new Error(`execution is not active: ${request.executionId}`);
+      if (current.session_bindings.some((binding) => bindingId(binding) === request.binding.binding_id)) {
+        throw new Error(`execution session binding already exists: ${request.binding.binding_id}`);
+      }
+      await writeExecutionOnlyTransaction(input, request.taskId, {
+        ...current,
+        session_bindings: [...current.session_bindings, request.binding]
+      });
+    },
     submitForReview: async (request) => {
       const task = await Effect.runPromise(input.artifactStore.readTaskPackage(request.taskId));
       const document = task.documents.find((candidate) => candidate.path === executionPath(request.executionId));
@@ -38,11 +55,34 @@ export function makeCoordinatedExecutionAuthoredStore(input: {
         executionDeclaration.documentCodec.decode(document.body)
       ) as ExecutionRecord;
       if (current.state !== "active") throw new Error(`execution is not active: ${request.executionId}`);
-      assertBindingsFinal(current.session_bindings);
-      const submitted = submittedExecution(current, request.submittedAt, request.submission);
+      const finalizedBindings = finalizeSessionBindings(input.rootInput, current.session_bindings);
+      assertPrimarySession(finalizedBindings);
+      assertBindingsFinal(finalizedBindings);
+      const submitted = submittedExecution(current, finalizedBindings, request.submittedAt, request.submission);
       await writeExecutionTransaction(input, request.taskId, submitted, taskIndex(task.documents, request.taskId, ["active"], "in_review"));
     }
   };
+}
+
+function writeExecutionOnlyTransaction(
+  input: { readonly rootInput: HarnessLayoutInput; readonly coordinator: WriteCoordinator },
+  taskId: string,
+  execution: ExecutionRecord
+): Promise<void> {
+  return Effect.runPromise(writeDeclaredEntityTransaction(
+    input.coordinator,
+    stablePayloadHash,
+    executionDeclaration,
+    { taskId, executionId: execution.execution_id },
+    execution,
+    []
+  ));
+}
+
+function bindingId(binding: unknown): unknown {
+  return binding && typeof binding === "object"
+    ? (binding as { readonly binding_id?: unknown }).binding_id
+    : undefined;
 }
 
 function writeExecutionTransaction(
@@ -75,11 +115,17 @@ function taskIndex(
   return body.replace(/^(  status:\s*).+$/mu, `$1${next}`);
 }
 
-function submittedExecution(current: ExecutionRecord, submittedAt: string, submission: ExecutionSubmission): ExecutionRecord {
+function submittedExecution(
+  current: ExecutionRecord,
+  sessionBindings: ReadonlyArray<unknown>,
+  submittedAt: string,
+  submission: ExecutionSubmission
+): ExecutionRecord {
   return {
     ...current,
     state: "submitted",
     submitted_at: submittedAt,
+    session_bindings: sessionBindings,
     outputs: [...current.outputs, ...submission.outputs],
     submission: {
       summary: submission.summary,
@@ -87,6 +133,34 @@ function submittedExecution(current: ExecutionRecord, submittedAt: string, submi
       residual_risks: submission.residualRisks
     }
   };
+}
+
+function finalizeSessionBindings(rootInput: HarnessLayoutInput, bindings: ReadonlyArray<unknown>): ReadonlyArray<unknown> {
+  return bindings.map((binding) => {
+    if (!binding || typeof binding !== "object") return binding;
+    const record = binding as { readonly role?: unknown; readonly session_ref?: unknown };
+    if (typeof record.session_ref !== "string" || !record.session_ref.startsWith("session/")) return binding;
+    const sessionId = record.session_ref.slice("session/".length);
+    try {
+      const session = readSessionEntityDocument(rootInput, sessionId);
+      if (session.format !== "manifest") {
+        throw new Error(`Session ${sessionId} has no finalized snapshot manifest`);
+      }
+      return { ...record, archive_status: session.manifest.archiveStatus };
+    } catch (error) {
+      const prefix = record.role === "primary" ? "primary Session" : "Session";
+      throw new Error(`${prefix} ${sessionId} snapshot is not finalized: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  });
+}
+
+function assertPrimarySession(bindings: ReadonlyArray<unknown>): void {
+  const primary = bindings.find((binding) => binding && typeof binding === "object" &&
+    (binding as { readonly role?: unknown }).role === "primary" &&
+    typeof (binding as { readonly session_ref?: unknown }).session_ref === "string");
+  if (!primary) {
+    throw new Error("primary Session binding is required; attach the current session through ExecutionSagaService.attachSession");
+  }
 }
 
 function assertBindingsFinal(bindings: ReadonlyArray<unknown>): void {

--- a/packages/application/src/execution-saga-service.ts
+++ b/packages/application/src/execution-saga-service.ts
@@ -1,5 +1,7 @@
 import { generateTaskId } from "../../kernel/src/index.ts";
+import type { HarnessLayoutInput } from "../../kernel/src/index.ts";
 import type {
+  CurrentSessionRef,
   ExecutionLeaseContext,
   ExecutionRecord,
   TaskHolderPrincipal,
@@ -13,11 +15,27 @@ export interface ExecutionSubmission {
   readonly outputs: ReadonlyArray<unknown>;
 }
 
+export type ExecutionSessionRole = "primary" | "subagent" | "reviewer_observer";
+
+export interface ExecutionSessionBinding {
+  readonly binding_id: string;
+  readonly session_ref: string | null;
+  readonly role: ExecutionSessionRole;
+  readonly archive_status: "pending" | "complete" | "partial" | "unavailable";
+  readonly attached_at: string;
+  readonly session: CurrentSessionRef | null;
+}
+
 export interface ExecutionAuthoredStore {
   readonly readExecution: (input: { readonly taskId: string; readonly executionId: string }) => Promise<ExecutionRecord | null>;
   readonly openExecution: (input: {
     readonly taskId: string;
     readonly execution: ExecutionRecord;
+  }) => Promise<void>;
+  readonly attachSession: (input: {
+    readonly taskId: string;
+    readonly executionId: string;
+    readonly binding: ExecutionSessionBinding;
   }) => Promise<void>;
   readonly submitForReview: (input: {
     readonly taskId: string;
@@ -37,7 +55,16 @@ export interface ExecutionSagaService {
     readonly taskId: string;
     readonly principal: TaskHolderPrincipal;
     readonly ttlMs?: number;
+    readonly primarySession?: CurrentSessionRef | null;
   }) => Promise<ExecutionClaimResult>;
+  readonly attachSession: (input: {
+    readonly taskId: string;
+    readonly executionId: string;
+    readonly leaseToken: string;
+    readonly principal: TaskHolderPrincipal;
+    readonly session: CurrentSessionRef;
+    readonly role: ExecutionSessionRole;
+  }) => Promise<void>;
   readonly submitForReview: (input: {
     readonly taskId: string;
     readonly executionId: string;
@@ -52,6 +79,7 @@ export interface ExecutionSagaServiceOptions {
   readonly authoredStore: ExecutionAuthoredStore;
   readonly generateExecutionId?: () => string;
   readonly now?: () => string;
+  readonly finalizeSession?: (session: CurrentSessionRef) => Promise<void>;
 }
 
 export function makeExecutionSagaService(options: ExecutionSagaServiceOptions): ExecutionSagaService {
@@ -76,7 +104,11 @@ export function makeExecutionSagaService(options: ExecutionSagaServiceOptions): 
         claimed_at: now(),
         submitted_at: null,
         closed_at: null,
-        session_bindings: [],
+        session_bindings: input.primarySession === undefined
+          ? []
+          : [input.primarySession
+              ? sessionBinding(input.primarySession, "primary", now())
+              : pendingPrimarySessionBinding(now())],
         outputs: [],
         submission: null
       };
@@ -99,8 +131,19 @@ export function makeExecutionSagaService(options: ExecutionSagaServiceOptions): 
       });
       return { ...active, execution };
     },
+    attachSession: async (input) => {
+      await options.taskHolderService.assertExecutionLease(input);
+      await options.authoredStore.attachSession({
+        taskId: input.taskId,
+        executionId: input.executionId,
+        binding: sessionBinding(input.session, input.role, now())
+      });
+    },
     submitForReview: async (input) => {
       await options.taskHolderService.assertExecutionLease(input);
+      const execution = await options.authoredStore.readExecution({ taskId: input.taskId, executionId: input.executionId });
+      const primarySession = execution ? boundPrimarySession(execution.session_bindings) : null;
+      if (primarySession && options.finalizeSession) await options.finalizeSession(primarySession);
       await options.authoredStore.submitForReview({
         taskId: input.taskId,
         executionId: input.executionId,
@@ -110,6 +153,49 @@ export function makeExecutionSagaService(options: ExecutionSagaServiceOptions): 
       await options.taskHolderService.releaseExecution(input);
     },
     reconcileTask: (taskId) => reconcileTask(options, taskId)
+  };
+}
+
+export function makeExecutionReservationReconciler(
+  options: ExecutionSagaServiceOptions & { readonly rootInput: HarnessLayoutInput }
+): () => Promise<void> {
+  const saga = makeExecutionSagaService(options);
+  return async () => {
+    for (const lease of await options.taskHolderService.executionLeases()) {
+      await saga.reconcileTask(lease.taskId);
+    }
+  };
+}
+
+function boundPrimarySession(bindings: ReadonlyArray<unknown>): CurrentSessionRef | null {
+  for (const binding of bindings) {
+    if (!binding || typeof binding !== "object") continue;
+    const record = binding as { readonly role?: unknown; readonly session?: unknown };
+    if (record.role !== "primary" || !record.session || typeof record.session !== "object") continue;
+    return record.session as CurrentSessionRef;
+  }
+  return null;
+}
+
+function sessionBinding(session: CurrentSessionRef, role: ExecutionSessionRole, attachedAt: string): ExecutionSessionBinding {
+  return {
+    binding_id: `${role}:${session.sessionId}`,
+    session_ref: `session/${session.sessionId}`,
+    role,
+    archive_status: "pending",
+    attached_at: attachedAt,
+    session
+  };
+}
+
+function pendingPrimarySessionBinding(attachedAt: string): ExecutionSessionBinding {
+  return {
+    binding_id: "primary:pending",
+    session_ref: null,
+    role: "primary",
+    archive_status: "pending",
+    attached_at: attachedAt,
+    session: null
   };
 }
 

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -14,7 +14,7 @@ export { CODE_DOC_RECONCILIATION_DOCUMENT, evaluateCodeDocReconciliationGate, re
 export { currentSessionToProvenancePayload, defaultRuntimeSessionEnvCandidates, makeEnvironmentCurrentSessionProbe, makeHumanFallbackSessionProbe } from "./current-session-probe.ts";
 export { bindCreateProvenance } from "./provenance-binding.ts";
 export { makeDecisionWriteService } from "./decision-write-service.ts";
-export { makeExecutionSagaService } from "./execution-saga-service.ts";
+export { makeExecutionReservationReconciler, makeExecutionSagaService } from "./execution-saga-service.ts";
 export { makeCoordinatedExecutionAuthoredStore } from "./coordinated-execution-authored-store.ts";
 export { makeFactWriteService } from "./fact-write-service.ts";
 export {
@@ -27,6 +27,8 @@ export type {
   ExecutionClaimResult,
   ExecutionSagaService,
   ExecutionSagaServiceOptions,
+  ExecutionSessionBinding,
+  ExecutionSessionRole,
   ExecutionSubmission
 } from "./execution-saga-service.ts";
 export type {

--- a/packages/application/test/execution-saga.test.ts
+++ b/packages/application/test/execution-saga.test.ts
@@ -1,12 +1,14 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { Effect } from "effect";
 import {
   ExecutionLeaseCollisionError,
   executionDeclaration,
   makeCoordinatedExecutionAuthoredStore,
+  makeExecutionReservationReconciler,
   makeJournaledWriteCoordinator,
   makeMarkdownArtifactStore,
   makeExecutionSagaService,
@@ -14,6 +16,7 @@ import {
   resolveEntityDocumentPath,
   taskHolderActor
 } from "../src/index.ts";
+import { writeContentAddressedBlob, writeSessionEntity } from "../../kernel/src/index.ts";
 import type { ExecutionAuthoredStore, ExecutionRecord } from "../src/index.ts";
 
 const taskId = "task_01KX19GEKWMEJNGSMRT6JJH6HY";
@@ -100,7 +103,31 @@ test("a real coordinated claim and submit preserves the hosted Execution round",
       now: () => "2026-07-11T00:00:00.000Z"
     });
 
-    const claimed = await saga.claim({ taskId, principal: aliceCodex });
+    const primarySession = {
+      runtime: "codex" as const,
+      sessionId: "codex-real-primary",
+      source: "runtime" as const,
+      detectedAt: "2026-07-11T00:00:00.000Z"
+    };
+    const claimed = await saga.claim({ taskId, principal: aliceCodex, primarySession });
+    const bodyRef = writeContentAddressedBlob(rootDir, "# finalized session\n", "text/markdown; charset=utf-8");
+    Effect.runSync(writeSessionEntity(coordinator, rootDir, {
+      schema: "session-entity/v1",
+      sessionId: primarySession.sessionId,
+      lifecycle: "sealed",
+      archiveStatus: "complete",
+      runtime: "codex",
+      source: "runtime",
+      detectedAt: primarySession.detectedAt,
+      exportedAt: "2026-07-11T00:00:01.000Z",
+      bodyRef: { store: "authored-cas/v1", ...bodyRef },
+      snapshot: {
+        capturedAt: "2026-07-11T00:00:01.000Z",
+        completeness: "complete",
+        captureRange: { messageCount: 1 },
+        privacyScan: { scannerVersion: "test", passed: true, findings: [] }
+      }
+    }));
     await saga.submitForReview({
       taskId,
       executionId,
@@ -148,6 +175,72 @@ test("claim releases its reservation when the authored Execution transaction fai
     await assert.rejects(saga.claim({ taskId, principal: aliceCodex }), /authored open failed/u);
     assert.equal((await holder.holder({ taskId })).effectiveHolder, null);
     assert.equal(authored.executions.size, 0);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("reservation reconciler converges an orphan Execution reservation without authored writes", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-execution-startup-reconcile-"));
+  try {
+    const taskRoot = path.join(rootDir, "harness/tasks", `${taskId}-startup-reconcile`);
+    mkdirSync(taskRoot, { recursive: true });
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex("planned"), "utf8");
+    const holder = makeTaskHolderService({ rootInput: rootDir });
+    await holder.reserveExecution({ taskId, executionId, principal: aliceCodex });
+    const authored = makeCoordinatedExecutionAuthoredStore({
+      rootInput: rootDir,
+      coordinator: makeJournaledWriteCoordinator({ rootDir, actor: { kind: "system", id: "reconciler-test" } }),
+      artifactStore: makeMarkdownArtifactStore({ rootDir })
+    });
+    const reconcile = makeExecutionReservationReconciler({
+      rootInput: rootDir,
+      taskHolderService: holder,
+      authoredStore: authored
+    });
+
+    await reconcile();
+    assert.equal((await holder.holder({ taskId })).effectiveHolder, null);
+    assert.equal(existsSync(path.join(taskRoot, "executions", `${executionId}.md`)), false);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("submit-for-review rejects an Execution without a finalized primary Session", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-execution-primary-gate-"));
+  try {
+    const taskRoot = path.join(rootDir, "harness/tasks", `${taskId}-primary-gate`);
+    mkdirSync(taskRoot, { recursive: true });
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex("planned"), "utf8");
+    const coordinator = makeJournaledWriteCoordinator({ rootDir, actor: { kind: "agent", id: "test" } });
+    const holder = makeTaskHolderService({ rootInput: rootDir });
+    const saga = makeExecutionSagaService({
+      taskHolderService: holder,
+      authoredStore: makeCoordinatedExecutionAuthoredStore({
+        rootInput: rootDir,
+        coordinator,
+        artifactStore: makeMarkdownArtifactStore({ rootDir })
+      }),
+      generateExecutionId: () => executionId,
+      now: () => "2026-07-11T00:00:00.000Z"
+    });
+    const claimed = await saga.claim({ taskId, principal: aliceCodex });
+
+    await assert.rejects(saga.submitForReview({
+      taskId,
+      executionId,
+      leaseToken: claimed.leaseToken,
+      principal: aliceCodex,
+      submission: {
+        summary: "missing primary",
+        verification: [],
+        residualRisks: [],
+        outputs: []
+      }
+    }), /primary Session binding is required; attach the current session through ExecutionSagaService\.attachSession/u);
+    assert.equal((await holder.holder({ taskId })).holder?.schema, "task-holder/v2");
+    assert.equal(JSON.parse(readFileSync(path.join(taskRoot, "executions", `${executionId}.md`), "utf8")).state, "active");
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
@@ -204,6 +297,77 @@ test("submit-for-review changes Execution and Task atomically before releasing t
   }
 });
 
+test("Execution session bindings can only be attached while the Execution is active", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-execution-attach-"));
+  try {
+    const taskRoot = path.join(rootDir, "harness/tasks", `${taskId}-attach`);
+    mkdirSync(taskRoot, { recursive: true });
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex("planned"), "utf8");
+    const holder = makeTaskHolderService({ rootInput: rootDir });
+    const authored = makeCoordinatedExecutionAuthoredStore({
+      rootInput: rootDir,
+      coordinator: makeJournaledWriteCoordinator({ rootDir, actor: { kind: "agent", id: "test" } }),
+      artifactStore: makeMarkdownArtifactStore({ rootDir })
+    });
+    const saga = makeExecutionSagaService({
+      taskHolderService: holder,
+      authoredStore: authored,
+      generateExecutionId: () => executionId,
+      now: () => "2026-07-11T00:00:00.000Z"
+    });
+    const claimed = await saga.claim({ taskId, principal: aliceCodex });
+
+    await saga.attachSession({
+      taskId,
+      executionId,
+      leaseToken: claimed.leaseToken,
+      principal: aliceCodex,
+      session: {
+        runtime: "codex",
+        sessionId: "codex-primary-session",
+        source: "runtime",
+        detectedAt: "2026-07-11T00:00:00.000Z"
+      },
+      role: "primary"
+    });
+    const executionPath = path.join(taskRoot, "executions", `${executionId}.md`);
+    const activeExecution = JSON.parse(readFileSync(executionPath, "utf8")) as ExecutionRecord;
+    assert.deepEqual(activeExecution.session_bindings, [{
+      binding_id: "primary:codex-primary-session",
+      session_ref: "session/codex-primary-session",
+      role: "primary",
+      archive_status: "pending",
+      attached_at: "2026-07-11T00:00:00.000Z",
+      session: {
+        runtime: "codex",
+        sessionId: "codex-primary-session",
+        source: "runtime",
+        detectedAt: "2026-07-11T00:00:00.000Z"
+      }
+    }]);
+
+    writeFileSync(executionPath, `${JSON.stringify({
+      ...activeExecution,
+      state: "submitted",
+      submitted_at: "2026-07-11T00:01:00.000Z"
+    }, null, 2)}\n`, "utf8");
+    await assert.rejects(authored.attachSession({
+      taskId,
+      executionId,
+      binding: {
+        binding_id: "subagent:late-session",
+        session_ref: "session/late-session",
+        role: "subagent",
+        archive_status: "pending",
+        attached_at: "2026-07-11T00:01:00.000Z",
+        session: null
+      }
+    }), /execution is not active/u);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function memoryAuthoredStore(options: { readonly failOpen?: boolean } = {}): ExecutionAuthoredStore & {
   readonly executions: Map<string, ExecutionRecord>;
   taskStatus: "planned" | "active" | "in_review";
@@ -220,6 +384,14 @@ function memoryAuthoredStore(options: { readonly failOpen?: boolean } = {}): Exe
       if (executions.has(input.execution.execution_id)) throw new Error("execution already exists");
       executions.set(input.execution.execution_id, input.execution);
       store.taskStatus = "active";
+    },
+    attachSession: async (input) => {
+      const current = executions.get(input.executionId);
+      if (!current || current.state !== "active") throw new Error("execution is not active");
+      executions.set(input.executionId, {
+        ...current,
+        session_bindings: [...current.session_bindings, input.binding]
+      });
     },
     submitForReview: async (input) => {
       if (store.failSubmit) throw new Error("authored submit failed");

--- a/packages/cli/src/cli/parsers/core-task-execution.ts
+++ b/packages/cli/src/cli/parsers/core-task-execution.ts
@@ -12,12 +12,12 @@ export function parseExecutionSubmissionOptions(args: ReadonlyArray<string>, sta
   const leaseToken = readOption(args, "--lease-token");
   const summary = readOption(args, "--summary");
   if (![executionId, leaseToken, summary].some(Boolean)) return { ok: true };
-  if (!executionId || !leaseToken || !summary || status !== "in_review") {
-    return { ok: false, error: cliError(CliErrorCode.InvalidTaskMetadata, "Execution submit requires in_review plus --execution-id, --lease-token, and --summary.") };
+  if (!leaseToken || !summary || status !== "in_review") {
+    return { ok: false, error: cliError(CliErrorCode.InvalidTaskMetadata, "Execution submit requires in_review plus --lease-token and --summary; --execution-id is optional when Holder V2 is active.") };
   }
   const values = (flag: string) => readRepeatedRawOption(args, flag).filter((value): value is string => value !== undefined);
   return { ok: true, value: {
-    executionId,
+    ...(executionId ? { executionId } : {}),
     leaseToken,
     summary,
     verification: values("--verification"),

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -189,7 +189,7 @@ export interface ParsedCommand {
     | { readonly kind: "task-claim"; readonly taskId: string; readonly ttlMs?: number; readonly execution?: boolean }
     | { readonly kind: "task-holder"; readonly taskId: string }
     | { readonly kind: "task-release"; readonly taskId: string }
-    | { readonly kind: "status-set"; readonly taskId: string; readonly status: DomainStatus; readonly force: boolean; readonly reason?: string; readonly executionSubmission?: { readonly executionId: string; readonly leaseToken: string; readonly summary: string; readonly verification: ReadonlyArray<string>; readonly residualRisks: ReadonlyArray<string>; readonly outputs: ReadonlyArray<string> } }
+    | { readonly kind: "status-set"; readonly taskId: string; readonly status: DomainStatus; readonly force: boolean; readonly reason?: string; readonly executionSubmission?: { readonly executionId?: string; readonly leaseToken: string; readonly summary: string; readonly verification: ReadonlyArray<string>; readonly residualRisks: ReadonlyArray<string>; readonly outputs: ReadonlyArray<string> } }
     | { readonly kind: "progress-append"; readonly taskId: string; readonly text: string; readonly evidence?: ReadonlyArray<EvidenceAppendInput> }
     | { readonly kind: "task-amend"; readonly taskId: string; readonly patches: ReadonlyArray<{ readonly field: string; readonly value: string }> }
     | { readonly kind: "task-archive"; readonly taskId?: string; readonly ids?: ReadonlyArray<string>; readonly filter?: string; readonly before?: string; readonly reason: string; readonly archivedBy?: string; readonly archiveField?: string }

--- a/packages/cli/src/commands/core/task-holder.ts
+++ b/packages/cli/src/commands/core/task-holder.ts
@@ -5,6 +5,7 @@ import {
   makeExecutionSagaService,
   type TaskHolderPrincipal
 } from "../../../../application/src/index.ts";
+import { readSessionEntityDocument } from "../../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
 import type { CommandRunner, CommandRunnerContext } from "../../cli/runner-registry.ts";
@@ -20,7 +21,13 @@ function runExecutionClaim(
   principal: TaskHolderPrincipal
 ): Effect.Effect<CliResult> {
   const saga = executionSaga(context);
-  return Effect.promise(() => saga.claim({ taskId: action.taskId, principal, ttlMs: action.ttlMs })).pipe(
+  return context.currentSessionProbe.currentSession.pipe(
+    Effect.flatMap((session) => Effect.promise(() => saga.claim({
+      taskId: action.taskId,
+      principal,
+      ttlMs: action.ttlMs,
+      primarySession: session.runtime === "human" ? null : session
+    }))),
     Effect.map((result): CliResult => ({
       ok: true,
       command: "task-claim",
@@ -45,25 +52,54 @@ export function runExecutionSubmit(
   if (!principal.ok) return Effect.succeed(principal.result);
   const saga = executionSaga(context);
   const submission = action.executionSubmission!;
-  return Effect.promise(() => saga.submitForReview({
-    taskId: action.taskId,
-    executionId: submission.executionId,
-    leaseToken: submission.leaseToken,
-    principal: principal.value,
-    submission: {
-      summary: submission.summary,
-      verification: submission.verification,
-      residualRisks: submission.residualRisks,
-      outputs: submission.outputs.map((ref) => ({ kind: "reference", ref }))
+  return Effect.gen(function* () {
+    const snapshot = submission.executionId
+      ? undefined
+      : yield* Effect.promise(() => context.taskHolderService.holder({ taskId: action.taskId }));
+    const executionId = submission.executionId ?? (snapshot?.holder?.schema === "task-holder/v2"
+      ? snapshot.holder.executionId
+      : undefined);
+    if (!executionId) {
+      return {
+        ok: false,
+        command: "status-set",
+        taskId: action.taskId,
+        error: cliError(CliErrorCode.WriteRejected, "Execution submit requires an active Holder V2 execution or an explicit --execution-id.")
+      } satisfies CliResult;
     }
-  })).pipe(Effect.map((): CliResult => ({
-    ok: true,
-    command: "status-set",
-    taskId: action.taskId,
-    executionId: submission.executionId,
-    status: "in_review",
-    report: { schema: "execution-submit-result/v1", executionId: submission.executionId, leaseReleased: true }
-  })));
+    return yield* Effect.tryPromise({
+      try: () => saga.submitForReview({
+        taskId: action.taskId,
+        executionId,
+        leaseToken: submission.leaseToken,
+        principal: principal.value,
+        submission: {
+          summary: submission.summary,
+          verification: submission.verification,
+          residualRisks: submission.residualRisks,
+          outputs: submission.outputs.map((ref) => ({ kind: "reference", ref }))
+        }
+      }),
+      catch: (error) => error
+    }).pipe(Effect.match({
+      onFailure: (error): CliResult => ({
+        ok: false,
+        command: "status-set",
+        taskId: action.taskId,
+        executionId,
+        status: "in_review",
+        error: cliError(CliErrorCode.WriteRejected, error instanceof Error ? error.message : String(error))
+      }),
+      onSuccess: (): CliResult => ({
+        ok: true,
+        command: "status-set",
+        taskId: action.taskId,
+        executionId,
+        status: "in_review",
+        report: { schema: "execution-submit-result/v1", executionId, leaseReleased: true }
+      })
+    }));
+  });
 }
 
 function executionSaga(context: CommandRunnerContext) {
@@ -74,7 +110,16 @@ function executionSaga(context: CommandRunnerContext) {
       rootInput: context.layoutInput,
       coordinator,
       artifactStore: context.artifactStore
-    })
+    }),
+    finalizeSession: async (session) => {
+      try {
+        if (readSessionEntityDocument(context.layoutInput, session.sessionId).format === "manifest") return;
+      } catch {
+        // A missing or legacy Session is finalized through the existing exporter below.
+      }
+      const exported = await Effect.runPromise(context.provenanceSessionExporter.exportSession(session));
+      await Effect.runPromise(context.syncExportedSession(exported));
+    }
   });
 }
 

--- a/packages/cli/src/commands/core/task-lifecycle.ts
+++ b/packages/cli/src/commands/core/task-lifecycle.ts
@@ -30,6 +30,7 @@ export const runTaskLifecycleCommand: CommandRunner = (context, command) => {
       return runTaskRelease(context, action);
     case "status-set":
       if (action.executionSubmission) return runExecutionSubmit(context, action);
+      if (action.status === "in_review") return runExecutionAwareInReview(context, action);
       return runStatusSet(context, action.taskId, action.status, action.force, action.reason);
     case "progress-append":
       return runProgressAppend(context, action);
@@ -53,6 +54,26 @@ export const runTaskLifecycleCommand: CommandRunner = (context, command) => {
       return runTaskRelate(context, action);
   }
 };
+
+function runExecutionAwareInReview(
+  context: CommandRunnerContext,
+  action: Extract<TaskLifecycleAction, { readonly kind: "status-set" }>
+): Effect.Effect<CliResult, EngineError | WriteError> {
+  return Effect.promise(() => context.taskHolderService.holder({ taskId: action.taskId })).pipe(
+    Effect.flatMap((snapshot) => snapshot.holder?.schema === "task-holder/v2"
+      ? Effect.succeed({
+          ok: false,
+          command: "status-set",
+          taskId: action.taskId,
+          status: "in_review",
+          error: cliError(
+            CliErrorCode.WriteRejected,
+            "Active Holder V2 execution must submit through the Execution saga; provide --lease-token and --summary."
+          )
+        } satisfies CliResult)
+      : runStatusSet(context, action.taskId, action.status, action.force, action.reason))
+  );
+}
 
 function runProgressAppend(
   context: CommandRunnerContext,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,7 +9,7 @@ import {
 import { cliError, CliErrorCode } from "./cli/error-codes.ts";
 import { parseArgs } from "./cli/parse-args.ts";
 import { readOption, stripGlobalOptions } from "./cli/parse-options.ts";
-import { makeLocalControllerService, makeRuntimeEventAppendPromise, makeRuntimeEventLedgerService, makeTaskHolderService } from "../../application/src/index.ts";
+import { makeCoordinatedExecutionAuthoredStore, makeExecutionReservationReconciler, makeLocalControllerService, makeRuntimeEventAppendPromise, makeRuntimeEventLedgerService, makeTaskHolderService } from "../../application/src/index.ts";
 import { appendParseFailureRuntimeEvent } from "./cli/parse-failure-runtime-event.ts";
 import {
   createJsonRpcProtocolServer,
@@ -36,7 +36,7 @@ import { createCliCommandService } from "./daemon/command-service.ts";
 import { makeDocSyncService } from "./daemon/doc-sync-service.ts";
 import { makeDaemonQueuedWriteCoordinator } from "./daemon/queued-write-coordinator.ts";
 import { leaseEnforcementEnabled } from "./commands/settings.ts";
-import { makeMarkdownArtifactStore } from "../../kernel/src/index.ts";
+import { makeJournaledWriteCoordinator, makeMarkdownArtifactStore } from "../../kernel/src/index.ts";
 
 const runRegisteredCommand = runRegisteredCommandWithCliComposition;
 const daemonRuntimeProvider = selectCliAdapterProvider("daemon.runtime");
@@ -102,6 +102,15 @@ async function runDaemonServe(
   const defaultRepoId = defaultDaemonServeRepoId(serveRepos, rootDir, requestedRepoId);
   const runtime = createMultiRepoDaemonRuntime({
     materializerPollMs: 5_000,
+    reservationReconciler: async (rootInput) => makeExecutionReservationReconciler({
+      rootInput,
+      taskHolderService: makeTaskHolderService({ rootInput }),
+      authoredStore: makeCoordinatedExecutionAuthoredStore({
+        rootInput,
+        coordinator: makeJournaledWriteCoordinator({ rootDir: rootInput.rootDir, layoutOverrides: rootInput.layoutOverrides }),
+        artifactStore: makeMarkdownArtifactStore(rootInput)
+      })
+    })(),
     repos: serveRepos.map((repo) => ({
       repoId: repo.repoId,
       rootDir: repo.canonicalRoot,

--- a/packages/cli/test/submit-lifecycle-cli.test.ts
+++ b/packages/cli/test/submit-lifecycle-cli.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { runRawJson, runRawJsonMaybeFail, withTempRoot } from "./helpers/daemon-cli.ts";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+
+const noRuntimeSession = {
+  HARNESS_ACTOR: "agent:test",
+  CLAUDE_SESSION_ID: "",
+  CLAUDE_CODE_SESSION_ID: "",
+  CODEX_THREAD_ID: "",
+  CODEX_SESSION_ID: "",
+  ZCODE_SESSION_ID: "",
+  ANTIGRAVITY_SESSION_ID: ""
+} as const;
+
+test("in_review without an Execution preserves the legacy transition receipt", () => {
+  withTempRoot((rootDir) => {
+    runRawJson(rootDir, ["init"], noRuntimeSession);
+    const created = unwrapCommandReceipt(runRawJson(rootDir, ["new-task", "--title", "Legacy Review"], noRuntimeSession));
+    const taskId = String(created.taskId);
+    runRawJson(rootDir, ["task", "transition", taskId, "active"], noRuntimeSession);
+
+    const receipt = runRawJson(rootDir, ["task", "transition", taskId, "in_review"], noRuntimeSession);
+    assert.equal(receipt.ok, true);
+    assert.equal(receipt.command, "task transition");
+    assert.deepEqual((receipt.details as { readonly data: unknown }).data, { taskId, status: "in_review" });
+    assert.equal(JSON.stringify(receipt).includes("executionId"), false);
+    assert.equal(JSON.stringify(receipt).includes("execution-submit-result"), false);
+  });
+});
+
+test("Execution claim without a detectable runtime session records a pending primary and submit fails actionably", () => {
+  withTempRoot((rootDir) => {
+    runRawJson(rootDir, ["init"], noRuntimeSession);
+    const created = unwrapCommandReceipt(runRawJson(rootDir, ["new-task", "--title", "Pending Primary"], noRuntimeSession));
+    const taskId = String(created.taskId);
+    const claimed = unwrapCommandReceipt(runRawJson(rootDir, ["task", "claim", taskId, "--execution"], noRuntimeSession));
+    const executionId = String(claimed.executionId);
+    const execution = JSON.parse(readFileSync(path.join(
+      rootDir,
+      `harness/tasks/${taskId}-pending-primary/executions/${executionId}.md`
+    ), "utf8"));
+    assert.deepEqual(execution.session_bindings, [{
+      binding_id: "primary:pending",
+      session_ref: null,
+      role: "primary",
+      archive_status: "pending",
+      attached_at: execution.session_bindings[0].attached_at,
+      session: null
+    }]);
+
+    const submitted = runRawJsonMaybeFail(rootDir, [
+      "task", "transition", taskId, "in_review",
+      "--lease-token", String(claimed.report.leaseToken),
+      "--summary", "ready"
+    ], noRuntimeSession);
+    assert.equal(submitted.status, 1);
+    assert.match(String((submitted.receipt.error as { readonly hint?: string }).hint), /primary Session binding is required.*ExecutionSagaService\.attachSession/u);
+  });
+});

--- a/packages/cli/test/task-lease-cli.test.ts
+++ b/packages/cli/test/task-lease-cli.test.ts
@@ -138,21 +138,54 @@ test("execution claim and submit use Holder V2 without changing legacy task clai
     writeHarnessIdentity(rootDir, "person_zeyu", "Zeyu Li");
     const created = runJson(rootDir, ["new-task", "--title", "Execution Saga"]);
     const claimed = runJson(rootDir, ["task", "claim", created.taskId, "--execution"], true, {
-      HARNESS_ACTOR: "agent:test"
+      HARNESS_ACTOR: "agent:test",
+      CLAUDE_SESSION_ID: "",
+      CLAUDE_CODE_SESSION_ID: "",
+      CODEX_THREAD_ID: "codex-primary-session",
+      CODEX_SESSION_ID: "codex-primary-session"
     });
 
     assert.match(claimed.executionId, /^exe_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u);
     assert.match(claimed.report.leaseToken, /^[0-9a-f]{64}$/u);
     assert.deepEqual(claimed.report.actor.executor, { kind: "agent", id: "test" });
+    const execution = JSON.parse(readFileSync(path.join(
+      rootDir,
+      `harness/tasks/${created.taskId}-execution-saga/executions/${claimed.executionId}.md`
+    ), "utf8"));
+    assert.equal(execution.session_bindings[0]?.role, "primary");
+    assert.equal(execution.session_bindings[0]?.session_ref, "session/codex-primary-session");
+    assert.equal(execution.session_bindings[0]?.archive_status, "pending");
+
+    const homeDir = path.join(rootDir, "home");
+    const codexLogs = path.join(homeDir, ".codex/sessions");
+    mkdirSync(codexLogs, { recursive: true });
+    writeFileSync(path.join(codexLogs, "codex-primary-session.jsonl"), [
+      JSON.stringify({
+        timestamp: "2026-07-11T00:00:01.000Z",
+        type: "event_msg",
+        payload: { type: "user_message", message: "implement F4" }
+      }),
+      JSON.stringify({
+        timestamp: "2026-07-11T00:00:02.000Z",
+        type: "response_item",
+        payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "F4 ready" }] }
+      })
+    ].join("\n"), "utf8");
 
     const submitted = runJson(rootDir, [
       "task", "transition", created.taskId, "in_review",
-      "--execution-id", claimed.executionId,
       "--lease-token", claimed.report.leaseToken,
       "--summary", "ready for review",
       "--verification", "node:test",
       "--output", "commit:abc123"
-    ], true, { HARNESS_ACTOR: "agent:test" });
+    ], true, {
+      HARNESS_ACTOR: "agent:test",
+      HOME: homeDir,
+      CLAUDE_SESSION_ID: "",
+      CLAUDE_CODE_SESSION_ID: "",
+      CODEX_THREAD_ID: "codex-primary-session",
+      CODEX_SESSION_ID: "codex-primary-session"
+    });
 
     assert.equal(submitted.status, "in_review");
     assert.equal(submitted.report.leaseReleased, true);

--- a/packages/kernel/src/local/task-holder-state-source.ts
+++ b/packages/kernel/src/local/task-holder-state-source.ts
@@ -1,0 +1,16 @@
+import path from "node:path";
+import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
+import { localLayoutFileSystem } from "./local-layout-file-system.ts";
+
+export function listExecutionLeaseRefs(
+  rootInput: HarnessLayoutInput
+): ReadonlyArray<{ readonly taskId: string; readonly executionId: string }> {
+  const holderRoot = path.join(resolveHarnessLayout(rootInput).localRoot, "task-holders");
+  if (!localLayoutFileSystem.exists(holderRoot)) return [];
+  return localLayoutFileSystem.readDirents(holderRoot)
+    .filter((entry) => !entry.isDirectory() && entry.name.endsWith(".json"))
+    .map((entry) => JSON.parse(localLayoutFileSystem.readText(path.join(holderRoot, entry.name))) as Record<string, unknown>)
+    .filter((record) => record.schema === "task-holder/v2" && typeof record.taskId === "string" && typeof record.executionId === "string")
+    .map((record) => ({ taskId: String(record.taskId), executionId: String(record.executionId) }))
+    .sort((left, right) => left.taskId.localeCompare(right.taskId));
+}

--- a/packages/kernel/src/local/task-holder-state.ts
+++ b/packages/kernel/src/local/task-holder-state.ts
@@ -4,6 +4,7 @@ import { hostname } from "node:os";
 import path from "node:path";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
 import { localRuntimeStateFileSystem } from "./local-layout-file-system.ts";
+import { listExecutionLeaseRefs } from "./task-holder-state-source.ts";
 import { hashExecutionLeaseToken, sameExecutionLeaseActor, sameTaskHolderPrincipal } from "./execution-lease-credential.ts";
 
 export type TaskHolderAcquiredVia = "claim" | "assignment";
@@ -195,6 +196,7 @@ export interface TaskHolderService {
   readonly releaseExecution: (input: { readonly taskId: string; readonly executionId: string; readonly leaseToken: string; readonly principal: TaskHolderPrincipal }) => Promise<TaskHolderReleaseResult>;
   readonly assertExecutionLease: (input: { readonly taskId: string; readonly executionId: string; readonly leaseToken: string; readonly principal: TaskHolderPrincipal }) => Promise<void>;
   readonly reconcileExecution: (input: { readonly taskId: string; readonly executionId: string; readonly authoredState: "active" | "submitted" | "missing" }) => Promise<void>;
+  readonly executionLeases: () => Promise<ReadonlyArray<Pick<ExecutionLeaseRecord, "taskId" | "executionId">>>;
 }
 
 const defaultTtlMs = 30 * 60 * 1_000;
@@ -339,7 +341,8 @@ export function makeTaskHolderService(options: TaskHolderServiceOptions): TaskHo
         return;
       }
       writeHolderRecord(options.rootInput, emptyHolderRecord(input.taskId, at));
-    })
+    }),
+    executionLeases: async () => listExecutionLeaseRefs(options.rootInput)
   };
 }
 

--- a/packages/kernel/src/store/daemon-runtime.ts
+++ b/packages/kernel/src/store/daemon-runtime.ts
@@ -43,6 +43,10 @@ export interface DaemonRuntimeOptions {
   readonly maxInteractiveOpsPerCommit?: number;
   readonly materializerPollMs?: number | false;
   readonly materializerMaxBranchesPerBatch?: number;
+  readonly reservationReconciler?: (input: {
+    readonly rootDir: string;
+    readonly layoutOverrides?: HarnessLayoutOverrides;
+  }) => Promise<void>;
 }
 
 export interface DaemonRuntimeStatus {
@@ -249,6 +253,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       this.lastError = undefined;
       this.lastMaterializerError = undefined;
       this.state = "attached";
+      await this.enqueueReservationReconciler();
       this.startMaterializerTimer();
       return this.status();
     } catch (error) {
@@ -357,9 +362,22 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       return;
     }
     this.materializerTimer = setInterval(() => {
+      void this.enqueueReservationReconciler().catch(() => undefined);
       void this.enqueueMaterializerBatch().catch(() => undefined);
     }, this.options.materializerPollMs);
     this.materializerTimer.unref();
+  }
+
+  private enqueueReservationReconciler(): Promise<void> {
+    if (!this.options.reservationReconciler) return Promise.resolve();
+    return this.enqueueBackgroundBatch({
+      source: "execution-reservation-reconciler",
+      priority: "background",
+      run: () => this.options.reservationReconciler!({
+        rootDir: this.rootDir,
+        ...(this.options.layoutOverrides ? { layoutOverrides: this.options.layoutOverrides } : {})
+      })
+    });
   }
 
   private stopMaterializerTimer(): void {

--- a/packages/kernel/test/store/daemon-runtime.test.ts
+++ b/packages/kernel/test/store/daemon-runtime.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
 import { createHarnessRuntimeContext, resolveHarnessLayout } from "../../src/layout/index.ts";
+import { makeTaskHolderService, taskHolderActor } from "../../src/local/task-holder-state.ts";
 import { makeJournaledWriteCoordinator } from "../../src/store/write-journal-coordinator.ts";
 import { createDaemonRuntime, createMultiRepoDaemonRuntime } from "../../src/store/daemon-runtime.ts";
 import { acquireDaemonGlobalLock } from "../../src/store/write-journal-locks.ts";
@@ -74,6 +75,35 @@ test("daemon runtime holds global.lock, rejects direct writes before journaling,
     assert.ok(order.includes("background-2-after-interactive"), order.join(","));
     await runtime.stop();
     assert.equal(existsSync(path.join(rootDir, ".harness/locks/global.lock")), false);
+  });
+});
+
+test("daemon runtime runs the reservation reconciler at attach and on the existing materializer timer", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    let reconciliations = 0;
+    const taskId = "task_01KX7H00000000000000000001";
+    const executionId = "exe_01KX7H00000000000000000001";
+    const holder = makeTaskHolderService({ rootInput: rootDir });
+    await holder.reserveExecution({
+      taskId,
+      executionId,
+      principal: taskHolderActor({ personId: "person_test" }, { kind: "agent", id: "test" })
+    });
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: 10,
+      reservationReconciler: async () => {
+        reconciliations += 1;
+        await holder.reconcileExecution({ taskId, executionId, authoredState: "missing" });
+      }
+    });
+
+    await runtime.start();
+    assert.equal(reconciliations, 1);
+    assert.equal((await holder.holder({ taskId })).effectiveHolder, null);
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    assert.ok(reconciliations > 1, `expected periodic reconciliation, saw ${reconciliations}`);
+    await runtime.stop();
   });
 });
 

--- a/tools/check-integration-test-shards.test.mjs
+++ b/tools/check-integration-test-shards.test.mjs
@@ -9,7 +9,7 @@ import {
 test("integration shard declaration is non-overlapping and complete", () => {
   const result = checkIntegrationTestShards();
   assert.equal(result.ok, true, result.errors.join("\n"));
-  assert.equal(result.fileCount, 81);
+  assert.equal(result.fileCount, 82);
   assert.deepEqual(result.workflowShards, [1, 2, 3, 4, 5, 6]);
   assert.deepEqual(result.requiredContexts, [
     "integration-shard (1)",

--- a/tools/integration-test-shards.mjs
+++ b/tools/integration-test-shards.mjs
@@ -45,6 +45,7 @@ export const integrationTestFileWeightsMs = Object.freeze({
   "packages/cli/test/runtime-event-cli.test.ts": 5222.8,
   "packages/cli/test/self-host-git-boundary-cli.test.ts": 777.2,
   "packages/cli/test/session-cli.test.ts": 3130.5,
+  "packages/cli/test/submit-lifecycle-cli.test.ts": 7202.5,
   "packages/cli/test/settings-cli.test.ts": 20342.2,
   "packages/cli/test/task-archive-distill-cli.test.ts": 15682.0,
   "packages/cli/test/task-delete-disposition-cli.test.ts": 15148.2,
@@ -175,7 +176,8 @@ export const integrationTestShards = Object.freeze([
       "tools/check-import-boundaries.test.mjs",
       "packages/cli/test/gui-cli.test.ts",
       "packages/kernel/test/store/sqlite-rebuild.test.ts",
-      "packages/kernel/test/store/relation-graph-toctou.test.ts"
+      "packages/kernel/test/store/relation-graph-toctou.test.ts",
+      "packages/cli/test/submit-lifecycle-cli.test.ts"
     ])
   }),
   Object.freeze({

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -153,6 +153,7 @@ export const testTierManifest = {
     "packages/cli/test/preset-script-cli.test.ts",
     "packages/cli/test/runtime-event-cli.test.ts",
     "packages/cli/test/session-cli.test.ts",
+    "packages/cli/test/submit-lifecycle-cli.test.ts",
     "packages/cli/test/settings-cli.test.ts",
     "packages/cli/test/self-host-git-boundary-cli.test.ts",
     "packages/cli/test/task-archive-distill-cli.test.ts",


### PR DESCRIPTION
# English

## Summary

F4 slice of the Session/Execution entity architecture: the submit lifecycle closes end to end. Executions gain session bindings — claiming with `--execution` automatically registers the invoking session as the round's **primary** binding; submit-for-review idempotently finalizes the primary session snapshot through the existing exporter, then enforces that a finalized primary session exists before the authored transaction commits. The reservation reconciler is wired into daemon startup and the existing background batch timer. Tasks without a Holder V2 execution keep the legacy `ha task transition` behavior byte-identical.

## What Changed

- `packages/application/src/coordinated-execution-authored-store.ts`: `attachSession` (active-only — appending to a submitted execution is rejected; old rounds stay immutable) and the primary-session gate: submit fails closed with an actionable message when no primary binding exists or its archive status is not finalized.
- `packages/application/src/execution-saga-service.ts`: claim registers the current runtime session as the primary binding (`session_bindings`); when the current session cannot be detected (human fallback), the binding is recorded as `primary:pending` — never a fabricated session id; submit runs an idempotent `finalizeSession` on the primary (existing `provenance-session-exporter`, skip-if-finalized) before validating the gate.
- `packages/cli/src/commands/core/task-holder.ts` / `task-lifecycle.ts` / parsers: `ha task transition <id> in_review` is execution-aware — with an active Holder V2 lease it must go through the saga (bare invocation rejects with guidance to provide `--lease-token`/`--summary`; the flagged path routes into the F3 submit orchestration); tasks with no V2 holder fall through to the unchanged legacy `runStatusSet` (existing receipts asserted byte-identical in tests).
- `packages/kernel/src/store/daemon-runtime.ts`: optional injected `reservationReconciler` runs once at daemon attach and repeats on the existing background batch scheduler — no new scheduling framework; reconciler semantics unchanged (runtime CAS only, never writes authored state).
- `packages/kernel/src/local/task-holder-state-source.ts` (new): shared holder-state source seam for the reconciler injection.
- Tests: `packages/cli/test/submit-lifecycle-cli.test.ts` (new; registered in tier manifest + shard weight/list, fileCount 81 → 82); `execution-saga.test.ts` +176 lines covering attach-after-submit rejection, missing/unfinalized primary fail-closed, claim auto-bind, end-to-end claim → work → transition in_review with internal finalize, reconciler orphan convergence, and legacy-transition byte-identity; `daemon-runtime.test.ts` covers the injected reconciler scheduling.

## Task And Scope

- Task: task_01KX7WJGWWZRGSJMM6FHWSNKRW (F4 Submit lifecycle)
- Authority chain: dec_mrem0ys8 (accepted) → architecture-design.md §15 slice 4 (attach sessions / submit-for-review / transaction / lease release) + §5/§8/§16 → ADR-0027 D1–D7, CH2/CH4
- Scope: submit lifecycle wiring only. Review entity / verdict (F5), bulk migration and legacy-path removal (F7) untouched. No new CLI command (attach rides claim/submit; the application API `attachSession` covers subagent/reviewer_observer roles).

## Version Impact

No published package version change. Tasks without Holder V2 executions keep legacy transition behavior byte-identical; the saga path remains opt-in via `--execution` claim until the F7 cutover.

## Governance Declaration

This PR touches the protected test-tier registration surfaces (`tools/test-tier-manifest.mjs`, `tools/integration-test-shards.mjs`, `tools/check-integration-test-shards.test.mjs`): the change is **additive registration only** of the new `submit-lifecycle-cli.test.ts` in the three required places (fileCount 81 → 82), strengthening coverage. Authority: dec_mrem0ys8 (accepted architecture decision) + task_01KX7WJGWWZRGSJMM6FHWSNKRW (F4 slice task); precedent: PR #622/#623/#624 same-shape registrations. It touches no gate allowlist and no CI configuration (boundary deltas: import 9→9, WriteCoordinator 0→0, bypass writes 125→125 — all zero, no repin needed). No gate weakened, removed, or bypassed.

## Verification

- Worker ran the full three-tier local suite: boundaries, fast-contract (receipt/public-surface goldens green — no new optional receipt fields or kernel barrel exports needing registration), and all 6 integration shards, all exit 0.
- CEO re-ran full boundaries including `check-github-required-contexts` with token: exit 0, on the worktree at origin/main base 550736c (main unmoved; no rebase needed).
- Red-first tests per invariant: attach-after-submit rejected; missing primary fails closed; claim auto-binds; bare in_review under V2 rejected with guidance; legacy path byte-identical; reconciler converges orphans without authored writes.

## Review Evidence

- CEO semantic review against ADR-0027 + mission invariants I1–I5 plus the continue-1 adjudication (claim-binds-primary / submit-finalizes closure), verified in the diff: active-only attach, fail-closed primary gate with actionable error, `primary:pending` for undetectable sessions (no fabrication), reconciler injection with unchanged semantics, legacy-path byte-identity test.
- Worker turn-1 stopped at the design checkpoint as instructed; CEO approved the minimal-wiring plan and added the claim-binds/submit-finalizes closure requirement (recorded in the task package continue-1 document) — without it the primary gate would have been a dead gate no real CLI flow could pass.
- Implementation report: task package artifacts (private ledger).

## Residual Risk

- `primary:pending` bindings (undetectable session runtimes) surface at submit with an actionable error; completing that flow for exotic runtimes is F7-adjacent polish.
- Subagent/reviewer_observer bindings are application-API-only this slice; a CLI surface for them can ride F5 if the review workflow demands it.
- Default cutover of claim/submit (removing the `--execution` flag gate) remains F7.

## References

- dec_mrem0ys8; ADR-0027 (private ledger)
- architecture-design.md §5, §8, §15, §16 (private ledger)

# 中文

## 概要

Session/Execution 实体架构的 F4 切片：submit 生命周期端到端闭环。Execution 获得 session binding——`--execution` claim 时自动把当前调用 session 登记为该轮 **primary** binding；submit-for-review 先经既有 exporter **幂等 finalize** primary session snapshot，再强制校验「已终结的 primary session 存在」后才提交 authored 事务。reservation reconciler 接入 daemon 启动与既有 background batch 定时面。无 Holder V2 execution 的 task 保持存量 `ha task transition` 行为逐字节不变。

## 改动内容

- `coordinated-execution-authored-store.ts`：`attachSession`（仅 active 可加——submitted 后追加被拒，旧轮不可变）+ primary-session 强制门：无 primary binding 或其归档状态未终结时 submit fail-closed，错误信息可操作。
- `execution-saga-service.ts`：claim 把当前 runtime session 登记为 primary binding（`session_bindings`）；探测不到当前 session（human fallback）时记 `primary:pending`——绝不伪造 session id；submit 在过门前对 primary 跑幂等 `finalizeSession`（既有 exporter，已终结即跳过）。
- CLI（task-holder/task-lifecycle/parsers）：`ha task transition <id> in_review` 感知 execution——存在 active Holder V2 lease 时必须走 saga（裸调用拒绝并指路 `--lease-token`/`--summary`；带 flag 路径进 F3 submit 编排）；无 V2 holder 的 task 落回**完全不变**的存量 `runStatusSet`（测试断言 receipt 逐字节一致）。
- `daemon-runtime.ts`：可选注入 `reservationReconciler`，daemon attach 时执行一次 + 复用既有 background batch 调度——零新调度框架；reconciler 语义不变（仅 runtime CAS，绝不写 authored state）。
- `task-holder-state-source.ts`（新增）：reconciler 注入用的 holder-state source seam。
- 测试：`submit-lifecycle-cli.test.ts`（新增，三处登记，fileCount 81→82）；`execution-saga.test.ts` +176 行覆盖 submitted 后 attach 拒绝、primary 缺失/未终结 fail-closed、claim 自动绑定、端到端 claim→干活→transition in_review（内部 finalize）、reconciler 收敛 orphan、存量 transition 逐字节一致；`daemon-runtime.test.ts` 覆盖注入调度。

## 任务与范围

- 任务：task_01KX7WJGWWZRGSJMM6FHWSNKRW（F4 Submit lifecycle）
- 授权链：dec_mrem0ys8（accepted）→ architecture-design.md §15 第 4 切片 + §5/§8/§16 → ADR-0027 D1–D7、CH2/CH4
- 范围：仅 submit 生命周期接线；Review entity/verdict（F5）、批量迁移与删旧路径（F7）未触碰。零新增 CLI 命令（attach 搭 claim/submit 便车；application API `attachSession` 覆盖 subagent/reviewer_observer 角色）。

## 版本影响

无发布包版本变更。无 Holder V2 execution 的 task 存量行为逐字节保持；saga 路径在 F7 cutover 前仍经 `--execution` flag opt-in。

## 治理声明

本 PR 触碰受保护的测试登记面（`tools/test-tier-manifest.mjs`、`tools/integration-test-shards.mjs`、`tools/check-integration-test-shards.test.mjs`）：变更**仅为纯加法登记**新测试 `submit-lifecycle-cli.test.ts` 三处（fileCount 81→82），是覆盖加强。授权：dec_mrem0ys8（accepted 架构决策）+ task_01KX7WJGWWZRGSJMM6FHWSNKRW（F4 切片任务）；先例：PR #622/#623/#624 同型登记。未触碰任何 gate allowlist 与 CI 配置（boundary delta：import 9→9、WriteCoordinator 0→0、bypass writes 125→125——全零，无需 repin）。未削弱、移除或绕过任何 gate。

## 验证

- worker 跑完整三件套：boundaries、fast-contract（receipt/public-surface golden 绿——无需登记新可选字段或 barrel 导出）、全部 6 个 integration shard，全 exit 0。
- CEO 带 token 复跑全套 boundaries（含 required-contexts）exit 0；基线 550736c（main 未动，无需 rebase）。
- 逐不变量红测试先行：submitted 后 attach 拒绝；primary 缺失 fail-closed；claim 自动绑定；V2 下裸 in_review 拒绝并指路；存量路径逐字节一致；reconciler 收敛 orphan 且不写 authored。

## 审查证据

- CEO 对照 ADR-0027 + mission I1–I5 + continue-1 裁决（claim 即绑/submit 即 finalize 闭环）语义验收，逐条 diff 核实：active-only attach、可操作错误的 fail-closed 门、探测不到 session 记 `primary:pending`（不伪造）、reconciler 注入语义不变、存量路径逐字节测试。
- worker turn-1 按指令在设计确认点停线；CEO 批准最小接线方案并追加闭环要求（裁决书在任务包 continue-1）——缺这条 primary 门会成为没有真实入口能过的死门。
- 实现报告在任务包 artifacts（私有 ledger）。

## 残余风险

- `primary:pending`（探测不到 session 的 runtime）在 submit 时给可操作错误；这类 runtime 的完整流属 F7 邻接打磨。
- subagent/reviewer_observer binding 本片仅 application API；CLI 面如 review 工作流需要可搭 F5。
- claim/submit 默认切换（去 `--execution` flag）留 F7。

## 关联材料

- dec_mrem0ys8；ADR-0027（私有 ledger）
- architecture-design.md §5/§8/§15/§16（私有 ledger）

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body, both blocks complete / 双语正文，两块齐全
- [x] Governance declaration for protected surface / protected surface 治理声明
- [x] Local gate green / 本地门绿
- [x] No gate weakened / 未削弱任何门
