### PR TITLE
feat: derive integration gates and stabilize write anchors

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -94,6 +94,8 @@ jobs:
         node-version: [24, 26]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -139,6 +141,8 @@ jobs:
         run: echo "Reusing successful source validation for the same head SHA."
       - uses: actions/checkout@v4
         if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
         with:
@@ -186,6 +190,8 @@ jobs:
         run: echo "Reusing successful source validation for the same head SHA."
       - uses: actions/checkout@v4
         if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
         with:
@@ -284,6 +290,8 @@ jobs:
         run: echo "Reusing successful source validation for the same head SHA."
       - uses: actions/checkout@v4
         if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
         with:

--- a/tools/check-bypass-write-boundary.mjs
+++ b/tools/check-bypass-write-boundary.mjs
@@ -1,15 +1,10 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import ts from "typescript";
 import { entryValues, loadGateAllowlist } from "./gate-allowlists/load-gate-allowlist.mjs";
 
-// Governance: W8 task_01KWW58383X74ZK28Y068CQ2TG closes bypass write channels
-// under dec_mr9acuxm. This is an AST gate per dec_GATE_DEFENSE_ROOT_CAUSE:
-// new fs write calls in kernel/adapters/cli authored or machine-read surfaces
-// require an explicit allowlist entry or must route through WriteCoordinator.
-
-const root = process.cwd();
 const targetRoots = [
   "packages/kernel/src/store",
   "packages/adapters/local/src",
@@ -17,101 +12,70 @@ const targetRoots = [
 ];
 
 const fsWriteApis = new Set([
-  "appendFile",
-  "appendFileSync",
-  "closeSync",
-  "copyFile",
-  "copyFileSync",
-  "cp",
-  "cpSync",
-  "fsyncSync",
-  "mkdir",
-  "mkdirSync",
-  "open",
-  "openSync",
-  "rename",
-  "renameSync",
-  "rm",
-  "rmSync",
-  "rmdir",
-  "rmdirSync",
-  "symlink",
-  "symlinkSync",
-  "truncate",
-  "truncateSync",
-  "unlink",
-  "unlinkSync",
-  "write",
-  "writeFile",
-  "writeFileSync",
-  "writeSync"
+  "appendFile", "appendFileSync", "closeSync", "copyFile", "copyFileSync", "cp", "cpSync",
+  "fsyncSync", "mkdir", "mkdirSync", "open", "openSync", "rename", "renameSync", "rm",
+  "rmSync", "rmdir", "rmdirSync", "symlink", "symlinkSync", "truncate", "truncateSync",
+  "unlink", "unlinkSync", "write", "writeFile", "writeFileSync", "writeSync"
 ]);
 
-const allowlist = loadGateAllowlist("check-bypass-write-boundary", {
-  requiredSections: ["coordinatedCore", "exemptHumanOrBootstrap", "legacyArchive", "freshGateRegistry"]
-});
-const allowed = new Set(Object.values(allowlist).flatMap((entries) => entryValues(entries)));
-const findings = [];
-
-for (const rel of targetRoots.flatMap(walkTypeScriptFiles)) {
-  inspectFile(rel);
+export function scanBypassWriteCalls(root = process.cwd()) {
+  return targetRoots.flatMap((relRoot) => walkTypeScriptFiles(root, relRoot)).flatMap((rel) => inspectFile(root, rel));
 }
 
-const stale = [...allowed].filter((entry) => !findings.some((finding) => finding.key === entry));
-for (const entry of stale) {
-  findings.push({
-    key: entry,
-    message: `allowlist entry is stale and should be removed: ${entry}`,
-    allowed: false
+export function checkBypassWriteBoundary(root = process.cwd()) {
+  const allowlist = loadGateAllowlist("check-bypass-write-boundary", {
+    requiredSections: ["coordinatedCore", "exemptHumanOrBootstrap", "legacyArchive", "freshGateRegistry"]
   });
-}
+  const allowed = new Set(Object.values(allowlist).flatMap((entries) => entryValues(entries)));
+  const findings = scanBypassWriteCalls(root).map((finding) => ({
+    ...finding,
+    message: `${finding.api} writes filesystem state outside the coordinator unless explicitly governed`,
+    allowed: allowed.has(finding.key)
+  }));
 
-const violations = findings.filter((finding) => !finding.allowed);
-if (violations.length > 0) {
-  console.error("Bypass write boundary check failed:");
-  for (const finding of violations) {
-    console.error(`- ${finding.key}: ${finding.message}`);
+  for (const entry of allowed) {
+    if (!findings.some((finding) => finding.key === entry)) {
+      findings.push({ key: entry, message: `allowlist entry is stale and should be removed: ${entry}`, allowed: false });
+    }
   }
-  process.exitCode = 1;
-} else {
-  console.log(`Bypass write boundary check passed (${findings.length} governed fs write call(s)).`);
+  return { findings, violations: findings.filter((finding) => !finding.allowed) };
 }
 
-function inspectFile(rel) {
-  const abs = path.join(root, rel);
-  const sourceText = readFileSync(abs, "utf8");
+function inspectFile(root, rel) {
+  const sourceText = readFileSync(path.join(root, rel), "utf8");
   const sourceFile = ts.createSourceFile(rel, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
   const bindings = fsBindings(sourceFile);
-  if (bindings.named.size === 0 && bindings.namespaces.size === 0) return;
+  if (bindings.named.size === 0 && bindings.namespaces.size === 0) return [];
+  const occurrences = new Map();
+  const findings = [];
 
   visit(sourceFile, (node) => {
     if (!ts.isCallExpression(node)) return;
     const api = calledFsApi(node.expression, bindings);
     if (!api) return;
+    const occurrence = (occurrences.get(api) ?? 0) + 1;
+    occurrences.set(api, occurrence);
     const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.expression.getStart(sourceFile));
-    const key = `${rel}#${api}@${line + 1}:${character + 1}`;
     findings.push({
-      key,
-      message: `${api} writes filesystem state outside the coordinator unless explicitly governed`,
-      allowed: allowed.has(key)
+      api,
+      key: `${rel}#${api}@${occurrence}`,
+      legacyKey: `${rel}#${api}@${line + 1}:${character + 1}`
     });
   });
+  return findings;
 }
 
 function fsBindings(sourceFile) {
   const named = new Map();
   const namespaces = new Set();
   for (const statement of sourceFile.statements) {
-    if (!ts.isImportDeclaration(statement)) continue;
-    if (!ts.isStringLiteral(statement.moduleSpecifier)) continue;
-    if (statement.moduleSpecifier.text !== "node:fs" && statement.moduleSpecifier.text !== "node:fs/promises") continue;
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    if (!["node:fs", "node:fs/promises"].includes(statement.moduleSpecifier.text)) continue;
     const clause = statement.importClause;
     if (!clause) continue;
     if (clause.name) namespaces.add(clause.name.text);
     const namedBindings = clause.namedBindings;
-    if (namedBindings && ts.isNamespaceImport(namedBindings)) {
-      namespaces.add(namedBindings.name.text);
-    }
+    if (namedBindings && ts.isNamespaceImport(namedBindings)) namespaces.add(namedBindings.name.text);
     if (namedBindings && ts.isNamedImports(namedBindings)) {
       for (const element of namedBindings.elements) {
         const imported = (element.propertyName ?? element.name).text;
@@ -124,10 +88,8 @@ function fsBindings(sourceFile) {
 
 function calledFsApi(expression, bindings) {
   if (ts.isIdentifier(expression)) return bindings.named.get(expression.text);
-  if (!ts.isPropertyAccessExpression(expression)) return undefined;
-  if (!bindings.namespaces.has(expression.expression.getText())) return undefined;
-  const api = expression.name.text;
-  return fsWriteApis.has(api) ? api : undefined;
+  if (!ts.isPropertyAccessExpression(expression) || !bindings.namespaces.has(expression.expression.getText())) return undefined;
+  return fsWriteApis.has(expression.name.text) ? expression.name.text : undefined;
 }
 
 function visit(node, fn) {
@@ -135,18 +97,24 @@ function visit(node, fn) {
   ts.forEachChild(node, (child) => visit(child, fn));
 }
 
-function walkTypeScriptFiles(relRoot) {
+function walkTypeScriptFiles(root, relRoot) {
   const absRoot = path.join(root, relRoot);
   if (!existsSync(absRoot)) return [];
-  const out = [];
-  const visitDir = (dir) => {
-    for (const entry of ts.sys.readDirectory(dir, [".ts"], undefined, undefined)) {
-      const stat = statSync(entry);
-      if (stat.isFile() && !entry.endsWith(".d.ts")) {
-        out.push(path.relative(root, entry).split(path.sep).join("/"));
-      }
-    }
-  };
-  visitDir(absRoot);
-  return out.sort();
+  return ts.sys.readDirectory(absRoot, [".ts"], undefined, undefined)
+    .filter((entry) => statSync(entry).isFile() && !entry.endsWith(".d.ts"))
+    .map((entry) => path.relative(root, entry).split(path.sep).join("/"))
+    .sort();
 }
+
+function main() {
+  const result = checkBypassWriteBoundary();
+  if (result.violations.length > 0) {
+    console.error("Bypass write boundary check failed:");
+    for (const finding of result.violations) console.error(`- ${finding.key}: ${finding.message}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`Bypass write boundary check passed (${result.findings.length} governed fs write call(s)).`);
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/tools/check-bypass-write-boundary.test.mjs
+++ b/tools/check-bypass-write-boundary.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { migrateBypassWriteAnchors } from "./migrate-bypass-write-anchors.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const checkerPath = path.join(repoRoot, "tools/check-bypass-write-boundary.mjs");
@@ -19,7 +20,29 @@ test("bypass write boundary accepts explicitly governed fs write calls", () => {
       "  writeFileSync('harness/generated-human.md', 'ok', 'utf8');",
       "}"
     ]);
-    writeAllowlist(policyRoot, "packages/kernel/src/store/fixture.ts#writeFileSync@3:3");
+    writeAllowlist(policyRoot, "packages/kernel/src/store/fixture.ts#writeFileSync@1");
+
+    const result = runChecker(root, policyRoot);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Bypass write boundary check passed/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(policyRoot, { recursive: true, force: true });
+  }
+});
+
+test("bypass write boundary stable anchors survive unrelated leading lines", () => {
+  const root = makeFixtureRoot();
+  const policyRoot = mkdtempSync(path.join(tmpdir(), "ha-w8-policy-"));
+  try {
+    writeStore(root, [
+      "// unrelated leading line",
+      "import { writeFileSync } from 'node:fs';",
+      "export function apply() {",
+      "  writeFileSync('harness/generated-human.md', 'ok', 'utf8');",
+      "}"
+    ]);
+    writeAllowlist(policyRoot, "packages/kernel/src/store/fixture.ts#writeFileSync@1");
 
     const result = runChecker(root, policyRoot);
     assert.equal(result.status, 0, result.stderr);
@@ -44,11 +67,43 @@ test("bypass write boundary rejects new fs writes outside the allowlist", () => 
 
     const result = runChecker(root, policyRoot);
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /packages\/kernel\/src\/store\/fixture\.ts#writeFileSync@3:3/u);
+    assert.match(result.stderr, /packages\/kernel\/src\/store\/fixture\.ts#writeFileSync@1/u);
   } finally {
     rmSync(root, { recursive: true, force: true });
     rmSync(policyRoot, { recursive: true, force: true });
   }
+});
+
+test("bypass write boundary rejects stale stable anchors", () => {
+  const root = makeFixtureRoot();
+  const policyRoot = mkdtempSync(path.join(tmpdir(), "ha-w8-policy-"));
+  try {
+    writeStore(root, ["export function noWrites() {}"]);
+    writeAllowlist(policyRoot, "packages/kernel/src/store/fixture.ts#writeFileSync@1");
+    const result = runChecker(root, policyRoot);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /allowlist entry is stale and should be removed/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(policyRoot, { recursive: true, force: true });
+  }
+});
+
+test("bypass write anchor migration converts legacy positions mechanically", () => {
+  const source = {
+    schema: "harness-anything/gate-allowlist/v1",
+    gateId: "check-bypass-write-boundary",
+    entries: {
+      coordinatedCore: [{ value: "a.ts#writeFileSync@4:3", ref: "task_X", reason: "fixture" }]
+    }
+  };
+  const result = migrateBypassWriteAnchors(source, [{
+    legacyKey: "a.ts#writeFileSync@4:3",
+    key: "a.ts#writeFileSync@1"
+  }]);
+  assert.equal(result.migratedCount, 1);
+  assert.equal(result.allowlist.entries.coordinatedCore[0].value, "a.ts#writeFileSync@1");
+  assert.equal(source.entries.coordinatedCore[0].value, "a.ts#writeFileSync@4:3");
 });
 
 function makeFixtureRoot() {

--- a/tools/check-integration-test-shards.mjs
+++ b/tools/check-integration-test-shards.mjs
@@ -1,29 +1,81 @@
 #!/usr/bin/env node
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { integrationShardCount, integrationShardSummaries, validateIntegrationTestShards } from "./integration-test-shards.mjs";
-import { testTierManifest } from "./test-tier-manifest.mjs";
+import {
+  integrationShardCount,
+  integrationShardSummaries,
+  integrationTestFileWeightsMs,
+  validateIntegrationTestShards
+} from "./integration-test-shards.mjs";
+import {
+  deriveTestTierManifest,
+  discoverTestFiles,
+  discoverTestTierManifest,
+  explicitTestTierManifest
+} from "./test-tier-manifest.mjs";
+import { validateManifest } from "./node-test-runner-lib.mjs";
 
-const repoRoot = path.resolve(import.meta.dirname, "..");
-const workflowPath = path.join(repoRoot, ".github/workflows/rewrite-ci.yml");
-const gateManifestPath = path.join(repoRoot, "tools/gate-manifest.json");
+const defaultRepoRoot = path.resolve(import.meta.dirname, "..");
+const workflowPath = path.join(defaultRepoRoot, ".github/workflows/rewrite-ci.yml");
+const gateManifestPath = path.join(defaultRepoRoot, "tools/gate-manifest.json");
+const deletionAllowlistRelativePath = "tools/gate-allowlists/check-integration-test-shards.json";
 
 export function checkIntegrationTestShards({
+  repoRoot = defaultRepoRoot,
+  explicitManifest = explicitTestTierManifest,
+  weightOverrides = integrationTestFileWeightsMs,
+  previousTestCount,
+  baselineRef,
   workflowText = readFileSync(workflowPath, "utf8"),
-  gateManifestText = readFileSync(gateManifestPath, "utf8")
+  gateManifestText = readFileSync(gateManifestPath, "utf8"),
+  deletionAllowlistText
 } = {}) {
-  const validation = validateIntegrationTestShards(testTierManifest.integration);
+  const testFiles = discoverTestFiles(repoRoot);
+  const testTierManifest = discoverTestTierManifest(repoRoot, { explicitManifest });
+  const integrationFiles = testTierManifest.integration;
+  const manifestValidation = validateManifest(testFiles, testTierManifest);
+  const shardValidation = validateIntegrationTestShards(integrationFiles, weightOverrides);
   const workflowValidation = validateIntegrationShardWorkflowMatrix(workflowText, integrationShardCount);
-  const manifestValidation = validateIntegrationShardRequiredContexts(gateManifestText, integrationShardCount);
-  const errors = [...validation.errors, ...workflowValidation.errors, ...manifestValidation.errors];
+  const gateValidation = validateIntegrationShardRequiredContexts(gateManifestText, integrationShardCount);
+  const baseline = previousTestCount === undefined
+    ? previousIntegrationTestState(repoRoot, explicitManifest, baselineRef)
+    : { count: previousTestCount, files: null, ref: null };
+  const resolvedPreviousCount = baseline.count;
+  const delta = resolvedPreviousCount === null ? null : integrationFiles.length - resolvedPreviousCount;
+  const deletionValidation = validateIntentionalTestDeletions({
+    repoRoot,
+    testFiles,
+    integrationFiles,
+    baseline,
+    delta,
+    currentText: deletionAllowlistText
+  });
+  const ratchetErrors = resolvedPreviousCount === null
+    ? ["unable to resolve previous integration test count from Git baseline"]
+    : deletionValidation.errors;
+  const errors = [
+    ...manifestValidation.errors,
+    ...shardValidation.errors,
+    ...workflowValidation.errors,
+    ...gateValidation.errors,
+    ...ratchetErrors
+  ];
+
   return {
     ok: errors.length === 0,
     errors,
-    summaries: integrationShardSummaries(),
-    fileCount: testTierManifest.integration.length,
+    derivedFiles: integrationFiles,
+    executionFiles: integrationFiles,
+    summaries: integrationShardSummaries(integrationFiles, weightOverrides),
+    currentCount: integrationFiles.length,
+    previousCount: resolvedPreviousCount,
+    delta,
+    deletedFiles: deletionValidation.deletedFiles,
+    confirmedDeletions: deletionValidation.confirmedDeletions,
     workflowShards: workflowValidation.shards,
-    requiredContexts: manifestValidation.contexts
+    requiredContexts: gateValidation.contexts
   };
 }
 
@@ -31,15 +83,11 @@ export function validateIntegrationShardWorkflowMatrix(workflowText, shardCount 
   const shards = parseIntegrationShardMatrix(workflowText);
   const expected = Array.from({ length: shardCount }, (_, index) => index + 1);
   const errors = [];
-
   if (shards.length === 0) {
     errors.push("integration-shard workflow matrix shard list is missing");
-    return { shards, errors };
-  }
-  if (shards.length !== expected.length || shards.some((value, index) => value !== expected[index])) {
+  } else if (!sameOrderedList(shards, expected)) {
     errors.push(`integration-shard workflow matrix mismatch: expected [${expected.join(", ")}], got [${shards.join(", ")}]`);
   }
-
   return { shards, errors };
 }
 
@@ -47,7 +95,6 @@ export function validateIntegrationShardRequiredContexts(gateManifestText, shard
   const expected = Array.from({ length: shardCount }, (_, index) => `integration-shard (${index + 1})`);
   const errors = [];
   let manifest;
-
   try {
     manifest = JSON.parse(gateManifestText);
   } catch (error) {
@@ -57,20 +104,152 @@ export function validateIntegrationShardRequiredContexts(gateManifestText, shard
   const gate = Array.isArray(manifest.gates) ? manifest.gates.find((entry) => entry.id === "test-integration") : undefined;
   const githubContexts = gate?.githubContext?.requiredContexts;
   const branchProtectionContexts = gate?.executionSurfaces?.branchProtection?.contexts;
-
   if (!Array.isArray(githubContexts)) {
     errors.push("test-integration githubContext.requiredContexts is missing");
   } else if (!sameOrderedList(githubContexts, expected)) {
     errors.push(`test-integration githubContext.requiredContexts mismatch: expected [${expected.join(", ")}], got [${githubContexts.join(", ")}]`);
   }
-
   if (!Array.isArray(branchProtectionContexts)) {
     errors.push("test-integration executionSurfaces.branchProtection.contexts is missing");
   } else if (!sameOrderedList(branchProtectionContexts, expected)) {
     errors.push(`test-integration executionSurfaces.branchProtection.contexts mismatch: expected [${expected.join(", ")}], got [${branchProtectionContexts.join(", ")}]`);
   }
-
   return { contexts: Array.isArray(githubContexts) ? githubContexts : [], errors };
+}
+
+function previousIntegrationTestState(repoRoot, explicitManifest, requestedRef) {
+  try {
+    const ref = requestedRef ?? resolveBaselineRef(repoRoot);
+    if (ref === null) return { count: null, files: null, ref: null };
+    const output = execFileSync("git", ["ls-tree", "-r", "--name-only", ref, "--", "packages", "tools"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    const files = output.split(/\r?\n/u).filter((file) => /\.(?:test|spec)\.(?:mjs|js|ts)$/u.test(file));
+    const integration = deriveTestTierManifest(files, explicitManifest).integration;
+    return { count: integration.length, files: integration, ref };
+  } catch {
+    return { count: null, files: null, ref: null };
+  }
+}
+
+function validateIntentionalTestDeletions({ repoRoot, testFiles, integrationFiles, baseline, delta, currentText }) {
+  const current = parseDeletionAllowlist(
+    currentText ?? readDeletionAllowlist(repoRoot),
+    deletionAllowlistRelativePath
+  );
+  const previous = baseline.ref === null
+    ? { paths: [], errors: [] }
+    : parseDeletionAllowlist(readBaselineDeletionAllowlist(repoRoot, baseline.ref), `${baseline.ref}:${deletionAllowlistRelativePath}`);
+  const errors = [...current.errors, ...previous.errors];
+  const previousPaths = new Set(previous.paths);
+  const newlyConfirmed = current.paths.filter((file) => !previousPaths.has(file));
+  const previousIntegration = new Set(baseline.files ?? []);
+  const currentIntegration = new Set(integrationFiles);
+  const deletedFiles = baseline.files === null
+    ? []
+    : [...previousIntegration].filter((file) => !currentIntegration.has(file)).sort();
+  const deletedSet = new Set(deletedFiles);
+  const confirmedDeletions = deletedFiles.filter((file) => newlyConfirmed.includes(file));
+
+  for (const file of current.paths) {
+    if (testFiles.includes(file)) errors.push(`intentional test deletion path exists on disk: ${file}`);
+  }
+  for (const file of newlyConfirmed) {
+    if (!deletedSet.has(file)) errors.push(`new intentional test deletion confirmation does not match a baseline deletion: ${file}`);
+  }
+
+  if (delta < 0) {
+    if (baseline.files === null) {
+      errors.push(`integration test count decreased: current=${integrationFiles.length} previous=${baseline.count} delta=${delta}`);
+    } else {
+      const unconfirmed = deletedFiles.filter((file) => !newlyConfirmed.includes(file));
+      if (unconfirmed.length > 0) {
+        errors.push(`integration test count decreased without path confirmation: current=${integrationFiles.length} previous=${baseline.count} delta=${delta} unconfirmed=[${unconfirmed.join(", ")}]`);
+      }
+    }
+  }
+
+  return { errors, deletedFiles, confirmedDeletions };
+}
+
+function readDeletionAllowlist(repoRoot) {
+  try {
+    return readFileSync(path.join(repoRoot, deletionAllowlistRelativePath), "utf8");
+  } catch (error) {
+    return JSON.stringify({ readError: error.message });
+  }
+}
+
+function readBaselineDeletionAllowlist(repoRoot, ref) {
+  try {
+    return execFileSync("git", ["show", `${ref}:${deletionAllowlistRelativePath}`], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+  } catch {
+    return emptyDeletionAllowlistText();
+  }
+}
+
+function parseDeletionAllowlist(text, displayPath) {
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    return { paths: [], errors: [`${displayPath} is not valid JSON: ${error.message}`] };
+  }
+  if (parsed.readError) return { paths: [], errors: [`unable to read ${displayPath}: ${parsed.readError}`] };
+  if (parsed.schema !== "harness-anything/gate-allowlist/v1" || parsed.gateId !== "check-integration-test-shards") {
+    return { paths: [], errors: [`${displayPath} must be a check-integration-test-shards gate allowlist`] };
+  }
+  const entries = parsed.entries?.intentionalTestDeletions;
+  if (!Array.isArray(entries)) return { paths: [], errors: [`${displayPath} missing entries.intentionalTestDeletions`] };
+  const paths = [];
+  const errors = [];
+  for (const [index, entry] of entries.entries()) {
+    const label = `${displayPath} entries.intentionalTestDeletions[${index}]`;
+    if (typeof entry?.value !== "string" || !/^(?:packages|tools)\/.+\.(?:test|spec)\.(?:mjs|js|ts)$/u.test(entry.value)) {
+      errors.push(`${label}.value must be an exact repository test file path`);
+      continue;
+    }
+    if (typeof entry.ref !== "string" || !/^(?:ADR-\d{4}|dec_[A-Za-z0-9_]+|task_[A-Z0-9]+)/u.test(entry.ref)) {
+      errors.push(`${label}.ref must cite an ADR, decision, or task id`);
+    }
+    if (typeof entry.reason !== "string" || entry.reason.trim() === "") errors.push(`${label}.reason must be non-empty`);
+    if (paths.includes(entry.value)) errors.push(`${label}.value is duplicated: ${entry.value}`);
+    paths.push(entry.value);
+  }
+  return { paths, errors };
+}
+
+function emptyDeletionAllowlistText() {
+  return JSON.stringify({
+    schema: "harness-anything/gate-allowlist/v1",
+    gateId: "check-integration-test-shards",
+    entries: { intentionalTestDeletions: [] }
+  });
+}
+
+function resolveBaselineRef(repoRoot) {
+  if (!process.env.CI && process.env.HARNESS_TEST_COUNT_BASE_REF) return process.env.HARNESS_TEST_COUNT_BASE_REF;
+  const head = git(repoRoot, ["rev-parse", "HEAD"]);
+  if (head === null) return null;
+  const worktreeChanges = git(repoRoot, ["status", "--porcelain", "--", "packages", "tools"]);
+  if (worktreeChanges) return head;
+  const mergeBase = git(repoRoot, ["merge-base", "HEAD", "origin/main"]);
+  if (mergeBase !== null && mergeBase !== head) return mergeBase;
+  return git(repoRoot, ["rev-parse", "HEAD^"]);
+}
+
+function git(repoRoot, args) {
+  try {
+    return execFileSync("git", args, { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  } catch {
+    return null;
+  }
 }
 
 function sameOrderedList(actual, expected) {
@@ -81,7 +260,6 @@ function parseIntegrationShardMatrix(workflowText) {
   const lines = workflowText.split(/\r?\n/u);
   let inIntegrationShardJob = false;
   let jobIndent = 0;
-
   for (const line of lines) {
     const jobMatch = /^(\s*)integration-shard:\s*$/u.exec(line);
     if (jobMatch) {
@@ -89,41 +267,30 @@ function parseIntegrationShardMatrix(workflowText) {
       jobIndent = jobMatch[1].length;
       continue;
     }
-    if (!inIntegrationShardJob) {
-      continue;
-    }
+    if (!inIntegrationShardJob) continue;
     const nextJobMatch = /^(\s*)[A-Za-z0-9_-]+:\s*$/u.exec(line);
-    if (nextJobMatch && nextJobMatch[1].length <= jobIndent) {
-      return [];
-    }
+    if (nextJobMatch && nextJobMatch[1].length <= jobIndent) return [];
     const shardMatch = /^\s*shard:\s*\[(.+?)\]\s*$/u.exec(line);
     if (shardMatch) {
-      return shardMatch[1]
-        .split(",")
-        .map((entry) => Number(entry.trim()))
-        .filter((value) => Number.isInteger(value));
+      return shardMatch[1].split(",").map((entry) => Number(entry.trim())).filter(Number.isInteger);
     }
   }
-
   return [];
 }
 
 function main() {
   const result = checkIntegrationTestShards();
   if (!result.ok) {
-    for (const error of result.errors) {
-      console.error(error);
-    }
+    for (const error of result.errors) console.error(error);
     process.exitCode = 1;
     return;
   }
-
-  console.log(`integration shard check passed: manifestFiles=${result.fileCount} shards=${result.summaries.length} workflowShards=[${result.workflowShards.join(", ")}] requiredContexts=[${result.requiredContexts.join(", ")}]`);
+  const previous = result.previousCount === null ? "unavailable" : result.previousCount;
+  const delta = result.delta === null ? "unavailable" : result.delta;
+  console.log(`integration shard check passed: current=${result.currentCount} previous=${previous} delta=${delta} shards=${result.summaries.length} workflowShards=[${result.workflowShards.join(", ")}] requiredContexts=[${result.requiredContexts.join(", ")}]`);
   for (const summary of result.summaries) {
     console.log(`shard ${summary.id}: files=${summary.files} estimatedMs=${summary.estimatedMs.toFixed(1)}`);
   }
 }
 
-if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main();
-}
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/tools/check-integration-test-shards.test.mjs
+++ b/tools/check-integration-test-shards.test.mjs
@@ -1,15 +1,20 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import {
   checkIntegrationTestShards,
   validateIntegrationShardRequiredContexts,
   validateIntegrationShardWorkflowMatrix
 } from "./check-integration-test-shards.mjs";
+import { assignIntegrationTestShards, validateIntegrationTestShards } from "./integration-test-shards.mjs";
 
 test("integration shard declaration is non-overlapping and complete", () => {
   const result = checkIntegrationTestShards();
   assert.equal(result.ok, true, result.errors.join("\n"));
-  assert.equal(result.fileCount, 82);
+  assert.equal(result.currentCount, 82);
   assert.deepEqual(result.workflowShards, [1, 2, 3, 4, 5, 6]);
   assert.deepEqual(result.requiredContexts, [
     "integration-shard (1)",
@@ -22,6 +27,240 @@ test("integration shard declaration is non-overlapping and complete", () => {
   assert.equal(result.summaries.length, 6);
   assert.ok(result.summaries.every((summary) => summary.files > 0));
 });
+
+test("new integration tests are assigned without manifest or shard registration", () => {
+  const files = ["tools/z.test.mjs", "tools/a.test.mjs", "tools/new.test.mjs"];
+  const shards = assignIntegrationTestShards(files, {
+    "tools/a.test.mjs": 10,
+    "tools/z.test.mjs": 20
+  }, 2, 5);
+
+  assert.deepEqual(shards, [
+    { id: 1, files: ["tools/z.test.mjs"] },
+    { id: 2, files: ["tools/a.test.mjs", "tools/new.test.mjs"] }
+  ]);
+});
+
+test("a new test file from disk is derived and executed as integration with zero registration", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-integration-discovery-"));
+  try {
+    const testRoot = path.join(root, "tools");
+    mkdirSync(testRoot, { recursive: true });
+    for (let index = 1; index <= 7; index += 1) {
+      writeFileSync(path.join(testRoot, `fixture-${index}.test.mjs`), "", "utf8");
+    }
+    const result = checkIntegrationTestShards({
+      repoRoot: root,
+      explicitManifest: { fast: [], contract: [] },
+      weightOverrides: {},
+      previousTestCount: 6,
+      deletionAllowlistText: deletionAllowlistText()
+    });
+    assert.equal(result.ok, true, result.errors.join("\n"));
+    assert.equal(result.delta, 1);
+    assert.deepEqual(result.derivedFiles, result.executionFiles);
+    assert.ok(result.derivedFiles.includes("tools/fixture-7.test.mjs"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("default shard assignment is deterministic across discovery order", () => {
+  const files = ["tools/c.test.mjs", "tools/a.test.mjs", "tools/b.test.mjs", "tools/d.test.mjs"];
+  const forward = assignIntegrationTestShards(files, {}, 2, 10);
+  const reverse = assignIntegrationTestShards([...files].reverse(), {}, 2, 10);
+  assert.deepEqual(forward, reverse);
+});
+
+test("integration shard validation rejects duplicate inputs and stale weight overrides", () => {
+  const result = validateIntegrationTestShards(
+    ["tools/a.test.mjs", "tools/a.test.mjs"],
+    { "tools/missing.test.mjs": 10 }
+  );
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.errors, [
+    "integration manifest contains duplicate files",
+    "integration weight references non-integration file: tools/missing.test.mjs",
+    "derived integration shard is empty"
+  ]);
+});
+
+test("integration count ratchet rejects a real deleted test file from disk", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-integration-ratchet-"));
+  try {
+    const testRoot = path.join(root, "tools");
+    mkdirSync(testRoot, { recursive: true });
+    for (let index = 1; index <= 7; index += 1) {
+      writeFileSync(path.join(testRoot, `fixture-${index}.test.mjs`), "", "utf8");
+    }
+    writeDeletionAllowlist(root);
+
+    git(root, ["init", "-q"]);
+    git(root, ["config", "user.name", "Harness Test"]);
+    git(root, ["config", "user.email", "harness@example.test"]);
+    git(root, ["add", "tools"]);
+    git(root, ["commit", "-qm", "register integration tests"]);
+
+    unlinkSync(path.join(testRoot, "fixture-7.test.mjs"));
+    const after = checkIntegrationTestShards({
+      repoRoot: root,
+      explicitManifest: { fast: [], contract: [] },
+      weightOverrides: {}
+    });
+    assert.equal(after.ok, false);
+    assert.equal(after.currentCount, 6);
+    assert.equal(after.previousCount, 7);
+    assert.equal(after.delta, -1);
+    assert.match(after.errors.join("\n"), /integration test count decreased without path confirmation: current=6 previous=7 delta=-1/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("integration count ratchet accepts an intentional deletion with a new exact-path confirmation", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-integration-confirmed-deletion-"));
+  try {
+    const testRoot = path.join(root, "tools");
+    mkdirSync(testRoot, { recursive: true });
+    for (let index = 1; index <= 7; index += 1) {
+      writeFileSync(path.join(testRoot, `fixture-${index}.test.mjs`), "", "utf8");
+    }
+    writeDeletionAllowlist(root);
+
+    git(root, ["init", "-q"]);
+    git(root, ["config", "user.name", "Harness Test"]);
+    git(root, ["config", "user.email", "harness@example.test"]);
+    git(root, ["add", "tools"]);
+    git(root, ["commit", "-qm", "register integration tests"]);
+
+    unlinkSync(path.join(testRoot, "fixture-7.test.mjs"));
+    writeDeletionAllowlist(root, [{
+      value: "tools/fixture-7.test.mjs",
+      ref: "task_01KX815CJ22WY13QCR0Q3HX4F9",
+      reason: "The fixture models an explicitly reviewed removal."
+    }]);
+    const after = checkIntegrationTestShards({
+      repoRoot: root,
+      explicitManifest: { fast: [], contract: [] },
+      weightOverrides: {}
+    });
+
+    assert.equal(after.ok, true, after.errors.join("\n"));
+    assert.equal(after.delta, -1);
+    assert.deepEqual(after.deletedFiles, ["tools/fixture-7.test.mjs"]);
+    assert.deepEqual(after.confirmedDeletions, ["tools/fixture-7.test.mjs"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("an already-merged deletion confirmation does not burden an unrelated later change", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-integration-persisted-confirmation-"));
+  try {
+    const testRoot = path.join(root, "tools");
+    mkdirSync(testRoot, { recursive: true });
+    for (let index = 1; index <= 6; index += 1) {
+      writeFileSync(path.join(testRoot, `fixture-${index}.test.mjs`), "", "utf8");
+    }
+    writeDeletionAllowlist(root, [{
+      value: "tools/fixture-7.test.mjs",
+      ref: "task_01KX815CJ22WY13QCR0Q3HX4F9",
+      reason: "The prior change intentionally removed this fixture."
+    }]);
+
+    git(root, ["init", "-q"]);
+    git(root, ["config", "user.name", "Harness Test"]);
+    git(root, ["config", "user.email", "harness@example.test"]);
+    git(root, ["add", "tools"]);
+    git(root, ["commit", "-qm", "baseline after intentional deletion"]);
+
+    writeFileSync(path.join(root, "tools/unrelated.txt"), "later change\n", "utf8");
+    const result = checkIntegrationTestShards({
+      repoRoot: root,
+      explicitManifest: { fast: [], contract: [] },
+      weightOverrides: {}
+    });
+    assert.equal(result.ok, true, result.errors.join("\n"));
+    assert.equal(result.delta, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a persisted deletion confirmation is rejected if its path reappears", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-integration-reappeared-confirmation-"));
+  try {
+    const testRoot = path.join(root, "tools");
+    mkdirSync(testRoot, { recursive: true });
+    for (let index = 1; index <= 6; index += 1) {
+      writeFileSync(path.join(testRoot, `fixture-${index}.test.mjs`), "", "utf8");
+    }
+    writeDeletionAllowlist(root, [{
+      value: "tools/fixture-7.test.mjs",
+      ref: "task_01KX815CJ22WY13QCR0Q3HX4F9",
+      reason: "The prior change intentionally removed this fixture."
+    }]);
+
+    git(root, ["init", "-q"]);
+    git(root, ["config", "user.name", "Harness Test"]);
+    git(root, ["config", "user.email", "harness@example.test"]);
+    git(root, ["add", "tools"]);
+    git(root, ["commit", "-qm", "baseline after intentional deletion"]);
+
+    writeFileSync(path.join(testRoot, "fixture-7.test.mjs"), "", "utf8");
+    const result = checkIntegrationTestShards({
+      repoRoot: root,
+      explicitManifest: { fast: [], contract: [] },
+      weightOverrides: {}
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /intentional test deletion path exists on disk: tools\/fixture-7\.test\.mjs/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+}
+
+test("integration count ratchet fails closed when the Git baseline is unavailable", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-integration-no-git-"));
+  try {
+    mkdirSync(path.join(root, "tools"), { recursive: true });
+    for (let index = 1; index <= 6; index += 1) {
+      writeFileSync(path.join(root, "tools", `fixture-${index}.test.mjs`), "", "utf8");
+    }
+    const result = checkIntegrationTestShards({
+      repoRoot: root,
+      explicitManifest: { fast: [], contract: [] },
+      weightOverrides: {},
+      deletionAllowlistText: deletionAllowlistText()
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /unable to resolve previous integration test count from Git baseline/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function writeDeletionAllowlist(root, entries = []) {
+  const allowlistRoot = path.join(root, "tools/gate-allowlists");
+  mkdirSync(allowlistRoot, { recursive: true });
+  writeFileSync(
+    path.join(allowlistRoot, "check-integration-test-shards.json"),
+    deletionAllowlistText(entries),
+    "utf8"
+  );
+}
+
+function deletionAllowlistText(entries = []) {
+  return JSON.stringify({
+    schema: "harness-anything/gate-allowlist/v1",
+    gateId: "check-integration-test-shards",
+    entries: { intentionalTestDeletions: entries }
+  });
+}
 
 test("integration shard checker rejects workflow matrix drift", () => {
   const workflow = [

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -4,633 +4,633 @@
   "entries": {
     "coordinatedCore": [
       {
-        "value": "packages/kernel/src/store/markdown-artifact-store.ts#mkdirSync@68:3",
+        "value": "packages/kernel/src/store/markdown-artifact-store.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/markdown-artifact-store.ts#renameSync@72:3",
+        "value": "packages/kernel/src/store/markdown-artifact-store.ts#renameSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/markdown-artifact-store.ts#writeFileSync@71:3",
+        "value": "packages/kernel/src/store/markdown-artifact-store.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@185:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@1",
         "ref": "task_01KX68A7MK6HH9TM16T95M8ZZK",
         "reason": "P3-1 hard-delete apply relocated from coordinator to the op transaction plan; same coordinator-executed durable write path, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/local-lock-registry.ts#mkdirSync@25:3",
+        "value": "packages/kernel/src/store/local-lock-registry.ts#mkdirSync@1",
         "ref": "task_01KWXKR6JQ9Y91KNWW8FBMTBTB",
         "reason": "PLT-Bedrock W2 local LockRegistry implementation for external adopt claim directories; callers acquire through the LockRegistry port."
       },
       {
-        "value": "packages/kernel/src/store/local-lock-registry.ts#mkdirSync@26:3",
+        "value": "packages/kernel/src/store/local-lock-registry.ts#mkdirSync@2",
         "ref": "task_01KWXKR6JQ9Y91KNWW8FBMTBTB",
         "reason": "PLT-Bedrock W2 local LockRegistry implementation for external adopt claim directories; callers acquire through the LockRegistry port."
       },
       {
-        "value": "packages/kernel/src/store/local-lock-registry.ts#rmSync@30:9",
+        "value": "packages/kernel/src/store/local-lock-registry.ts#rmSync@1",
         "ref": "task_01KWXKR6JQ9Y91KNWW8FBMTBTB",
         "reason": "PLT-Bedrock W2 local LockRegistry implementation for external adopt claim release; callers release through the LockRegistry lease."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-decision-documents.ts#mkdirSync@31:3",
+        "value": "packages/kernel/src/store/write-journal-decision-documents.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#closeSync@115:5",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#closeSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#closeSync@144:5",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#closeSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#closeSync@156:5",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#closeSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#fsyncSync@113:5",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#fsyncSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#fsyncSync@142:5",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#fsyncSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#fsyncSync@154:5",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#fsyncSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#mkdirSync@109:3",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#mkdirSync@132:3",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#mkdirSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@110:14",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@134:14",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@152:14",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#renameSync@146:3",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#renameSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#writeSync@112:5",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#writeSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#writeSync@137:7",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#writeSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-durable.ts#writeSync@140:7",
+        "value": "packages/kernel/src/store/write-journal-durable.ts#writeSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#closeSync@178:7",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#closeSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#closeSync@229:5",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#closeSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#closeSync@254:5",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#closeSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#fsyncSync@176:7",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#fsyncSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#fsyncSync@227:5",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#fsyncSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#fsyncSync@252:5",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#fsyncSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#mkdirSync@125:3",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#openSync@160:12",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#openSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#openSync@224:14",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#openSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#openSync@237:10",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#openSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#renameSync@153:7",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#renameSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#renameSync@194:7",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#renameSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#renameSync@294:3",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#renameSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#rmSync@187:30",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#rmSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#rmSync@188:28",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#rmSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#rmSync@192:28",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#rmSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#rmSync@275:3",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#rmSync@4",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#unlinkSync@203:47",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#unlinkSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#writeSync@168:7",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#writeSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#writeSync@226:5",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#writeSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-locks.ts#writeSync@245:5",
+        "value": "packages/kernel/src/store/write-journal-locks.ts#writeSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@437:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@460:3",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@472:5",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#mkdirSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@440:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#rmSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
-        "value": "packages/kernel/src/store/write-journal-operations.ts#writeFileSync@438:9",
+        "value": "packages/kernel/src/store/write-journal-operations.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       }
     ],
     "exemptHumanOrBootstrap": [
       {
-        "value": "packages/cli/src/commands/core/init.ts#mkdirSync@108:3",
+        "value": "packages/cli/src/commands/core/init.ts#mkdirSync@1",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init Configure-Verify smoke package bootstrap write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/core/init.ts#rmSync@42:7",
+        "value": "packages/cli/src/commands/core/init.ts#rmSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/core/init.ts#rmSync@50:7",
+        "value": "packages/cli/src/commands/core/init.ts#rmSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/core/init.ts#writeFileSync@109:3",
+        "value": "packages/cli/src/commands/core/init.ts#writeFileSync@1",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init Configure-Verify smoke package bootstrap write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@275:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@276:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@277:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#cpSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@274:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@338:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@345:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@358:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@4",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@391:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@394:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@6",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@403:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#mkdirSync@7",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@339:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@360:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@396:5",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@398:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@4",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@412:3",
+        "value": "packages/cli/src/commands/daemon/productization.ts#writeFileSync@5",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C4 daemon bootstrap/productization write: service templates, people roster bootstrap, hook install, mirror/report setup; only valid during explicit daemon bootstrap/install commands and not an active projection or decision authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/module-registry-view.ts#mkdirSync@9:3",
+        "value": "packages/cli/src/commands/extensions/module-registry-view.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/module-registry-view.ts#writeFileSync@13:3",
+        "value": "packages/cli/src/commands/extensions/module-registry-view.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset.ts#mkdirSync@157:3",
+        "value": "packages/cli/src/commands/extensions/preset.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset.ts#mkdirSync@170:7",
+        "value": "packages/cli/src/commands/extensions/preset.ts#mkdirSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset.ts#rmSync@210:3",
+        "value": "packages/cli/src/commands/extensions/preset.ts#rmSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset.ts#writeFileSync@158:3",
+        "value": "packages/cli/src/commands/extensions/preset.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset.ts#writeFileSync@171:7",
+        "value": "packages/cli/src/commands/extensions/preset.ts#writeFileSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#mkdirSync@28:33",
+        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#mkdirSync@31:38",
+        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#mkdirSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#mkdirSync@49:5",
+        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#mkdirSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#mkdirSync@92:3",
+        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#mkdirSync@4",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#writeFileSync@114:3",
+        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#writeFileSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#writeFileSync@50:5",
+        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#writeFileSync@93:3",
+        "value": "packages/cli/src/commands/extensions/repository-scaffold.ts#writeFileSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/shared.ts#mkdirSync@72:3",
+        "value": "packages/cli/src/commands/extensions/shared.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/shared.ts#writeFileSync@73:3",
+        "value": "packages/cli/src/commands/extensions/shared.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#mkdirSync@325:3",
+        "value": "packages/cli/src/commands/extensions/state.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#mkdirSync@358:5",
+        "value": "packages/cli/src/commands/extensions/state.ts#mkdirSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@359:5",
+        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@379:3",
+        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/governance.ts#mkdirSync@62:3",
+        "value": "packages/cli/src/commands/governance.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/governance.ts#mkdirSync@79:3",
+        "value": "packages/cli/src/commands/governance.ts#mkdirSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/governance.ts#writeFileSync@63:3",
+        "value": "packages/cli/src/commands/governance.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/governance.ts#writeFileSync@80:3",
+        "value": "packages/cli/src/commands/governance.ts#writeFileSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/graph-panorama.ts#mkdirSync@49:3",
+        "value": "packages/cli/src/commands/graph-panorama.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/graph-panorama.ts#writeFileSync@50:3",
+        "value": "packages/cli/src/commands/graph-panorama.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/init.ts#mkdirSync@31:5",
+        "value": "packages/cli/src/commands/init.ts#mkdirSync@1",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init local directory bootstrap write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/init.ts#mkdirSync@289:5",
+        "value": "packages/cli/src/commands/init.ts#mkdirSync@2",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init harness.yaml bootstrap write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/init.ts#writeFileSync@53:5",
+        "value": "packages/cli/src/commands/init.ts#writeFileSync@1",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init optional package.json script bootstrap write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/init.ts#writeFileSync@290:5",
+        "value": "packages/cli/src/commands/init.ts#writeFileSync@2",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init harness.yaml bootstrap write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/init.ts#writeFileSync@299:3",
+        "value": "packages/cli/src/commands/init.ts#writeFileSync@3",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init harness.yaml name update write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/init.ts#writeFileSync@306:3",
+        "value": "packages/cli/src/commands/init.ts#writeFileSync@4",
         "ref": "task_01KWY3JAVQRKW19VB21EZKHQHK",
         "reason": "Init outer .gitignore bootstrap isolation write; governed by dec_mraja5we task scope and not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/lesson.ts#mkdirSync@17:5",
+        "value": "packages/cli/src/commands/lesson.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/lesson.ts#writeFileSync@18:5",
+        "value": "packages/cli/src/commands/lesson.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       }
     ],
     "legacyArchive": [
       {
-        "value": "packages/cli/src/commands/migration-collision.ts#mkdirSync@63:3",
+        "value": "packages/cli/src/commands/migration-collision.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C5 legacy archive/intake artifact write; boundary is harness/legacy or compatibility session evidence, not active projection authority."
       },
       {
-        "value": "packages/cli/src/commands/migration-collision.ts#writeFileSync@64:3",
+        "value": "packages/cli/src/commands/migration-collision.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C5 legacy archive/intake artifact write; boundary is harness/legacy or compatibility session evidence, not active projection authority."
       },
       {
-        "value": "packages/cli/src/commands/migration-scan.ts#mkdirSync@272:5",
+        "value": "packages/cli/src/commands/migration-scan.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C5 legacy archive/intake artifact write; boundary is harness/legacy or compatibility session evidence, not active projection authority."
       },
       {
-        "value": "packages/cli/src/commands/migration-scan.ts#mkdirSync@278:3",
+        "value": "packages/cli/src/commands/migration-scan.ts#mkdirSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C5 legacy archive/intake artifact write; boundary is harness/legacy or compatibility session evidence, not active projection authority."
       },
       {
-        "value": "packages/cli/src/commands/migration-scan.ts#writeFileSync@279:3",
+        "value": "packages/cli/src/commands/migration-scan.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C5 legacy archive/intake artifact write; boundary is harness/legacy or compatibility session evidence, not active projection authority."
       },
       {
-        "value": "packages/cli/src/commands/migration.ts#mkdirSync@175:5",
+        "value": "packages/cli/src/commands/migration.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C5 legacy archive/intake artifact write; boundary is harness/legacy or compatibility session evidence, not active projection authority."
       },
       {
-        "value": "packages/cli/src/commands/migration.ts#mkdirSync@385:3",
+        "value": "packages/cli/src/commands/migration.ts#mkdirSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C5 legacy archive/intake artifact write; boundary is harness/legacy or compatibility session evidence, not active projection authority."
       },
       {
-        "value": "packages/cli/src/commands/migration.ts#mkdirSync@496:3",
+        "value": "packages/cli/src/commands/migration.ts#mkdirSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C5 legacy archive/intake artifact write; boundary is harness/legacy or compatibility session evidence, not active projection authority."
       },
       {
-        "value": "packages/cli/src/commands/migration.ts#writeFileSync@176:5",
+        "value": "packages/cli/src/commands/migration.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C5 legacy archive/intake artifact write; boundary is harness/legacy or compatibility session evidence, not active projection authority."
       },
       {
-        "value": "packages/cli/src/commands/migration.ts#writeFileSync@386:3",
+        "value": "packages/cli/src/commands/migration.ts#writeFileSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C5 legacy archive/intake artifact write; boundary is harness/legacy or compatibility session evidence, not active projection authority."
       },
       {
-        "value": "packages/cli/src/commands/migration.ts#writeFileSync@498:3",
+        "value": "packages/cli/src/commands/migration.ts#writeFileSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C5 legacy archive/intake artifact write; boundary is harness/legacy or compatibility session evidence, not active projection authority."
       }
     ],
     "freshGateRegistry": [
       {
-        "value": "packages/cli/src/commands/core/worktree.ts#mkdirSync@185:3",
+        "value": "packages/cli/src/commands/core/worktree.ts#mkdirSync@1",
         "ref": "task_01KWY3Z4VEVP6FNT28ZFA809GW",
         "reason": "C11 generated worktree binding registry write; stores rebuildable local .harness/generated binding state, not authored task truth."
       },
       {
-        "value": "packages/cli/src/commands/core/worktree.ts#writeFileSync@186:3",
+        "value": "packages/cli/src/commands/core/worktree.ts#writeFileSync@1",
         "ref": "task_01KWY3Z4VEVP6FNT28ZFA809GW",
         "reason": "C11 generated worktree binding registry write; stores rebuildable local .harness/generated binding state, not authored task truth."
       },
       {
-        "value": "packages/cli/src/commands/extensions/machine-evidence-registry.ts#writeFileSync@23:3",
+        "value": "packages/cli/src/commands/extensions/machine-evidence-registry.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset-evidence.ts#writeFileSync@27:3",
+        "value": "packages/cli/src/commands/extensions/preset-evidence.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#mkdirSync@123:3",
+        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#writeFileSync@125:3",
+        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#writeFileSync@156:3",
+        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#writeFileSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#writeFileSync@157:3",
+        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#writeFileSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/script-host.ts#mkdirSync@92:3",
+        "value": "packages/cli/src/commands/extensions/script-host.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@160:3",
+        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@161:3",
+        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       },
       {
-        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@95:3",
+        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       }

--- a/tools/gate-allowlists/check-integration-test-shards.json
+++ b/tools/gate-allowlists/check-integration-test-shards.json
@@ -1,0 +1,7 @@
+{
+  "schema": "harness-anything/gate-allowlist/v1",
+  "gateId": "check-integration-test-shards",
+  "entries": {
+    "intentionalTestDeletions": []
+  }
+}

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -971,11 +971,13 @@
       "tierReason": null,
       "authoritySource": [
         "tools/test-tier-manifest.mjs",
+        "tools/integration-test-shards.mjs",
         "tools/run-node-tests.mjs",
         "package.json:scripts.test:integration"
       ],
       "consumerScope": [
-        "node:test suites classified as integration"
+        "all disk-discovered node:test suites not explicitly classified as fast or contract",
+        "deterministically derived integration shard execution sets"
       ],
       "githubContext": {
         "requiredContexts": [
@@ -994,16 +996,18 @@
         ]
       },
       "allowlistPolicy": {
-        "allowed": true,
-        "location": "tools/test-tier-manifest.mjs",
+        "allowed": false,
+        "location": null,
         "adrOrDecisionRequired": false,
-        "notes": "Tier registration is explicit and fail-closed."
+        "notes": "Integration is the fail-safe default for disk-discovered tests; fast and contract remain explicitly registered."
       },
       "changeControl": {
         "ordinaryImplementationMayModify": false,
         "requiresGovernanceEvidence": true,
         "protectedSurfaces": [
           "tools/test-tier-manifest.mjs",
+          "tools/integration-test-shards.mjs",
+          "tools/run-node-tests.mjs",
           "package.json:scripts.test:integration"
         ]
       },
@@ -1040,7 +1044,8 @@
       "positiveControl": {
         "status": "covered",
         "evidence": [
-          "tools/integration-test-shards.mjs and integration-tier test assertions under packages/**/test/**"
+          "tools/run-node-tests.test.mjs",
+          "tools/check-integration-test-shards.test.mjs"
         ]
       }
     },
@@ -1872,7 +1877,8 @@
         "harness/adr/ADR-0016-write-coordinator-scope-authored-markdown-boundary.md",
         "task_01KWW58383X74ZK28Y068CQ2TG",
         "dec_mr9acuxm",
-        "dec_GATE_DEFENSE_ROOT_CAUSE"
+        "dec_GATE_DEFENSE_ROOT_CAUSE",
+        "tools/migrate-bypass-write-anchors.mjs"
       ],
       "consumerScope": [
         "AST-classified fs write calls in packages/kernel/src/store, packages/adapters/local/src, and packages/cli/src/commands",
@@ -1900,6 +1906,7 @@
         "requiresGovernanceEvidence": true,
         "protectedSurfaces": [
           "tools/check-bypass-write-boundary.mjs",
+          "tools/migrate-bypass-write-anchors.mjs",
           "tools/gate-allowlists/check-bypass-write-boundary.json",
           "package.json:scripts.harness:check-bypass-write-boundary",
           "tools/gate-manifest.json"
@@ -2560,10 +2567,13 @@
       "authoritySource": [
         "tools/test-tier-manifest.mjs",
         "tools/integration-test-shards.mjs",
-        "tools/check-integration-test-shards.mjs"
+        "tools/check-integration-test-shards.mjs",
+        "tools/gate-allowlists/check-integration-test-shards.json"
       ],
       "consumerScope": [
-        "integration shard declaration must cover every integration test file exactly once"
+        "disk-derived integration shards must cover every integration test file exactly once",
+        "integration test count decreases must fail unless every deleted path has a new repository confirmation",
+        "workflow shards and required contexts must remain aligned"
       ],
       "githubContext": {
         "requiredContexts": [
@@ -2577,10 +2587,10 @@
         ]
       },
       "allowlistPolicy": {
-        "allowed": false,
-        "location": null,
-        "adrOrDecisionRequired": false,
-        "notes": "The shard checker is fail-closed and has no allowlist."
+        "allowed": true,
+        "location": "tools/gate-allowlists/check-integration-test-shards.json",
+        "adrOrDecisionRequired": true,
+        "notes": "Entries name exact intentionally deleted test paths; only confirmations newly added relative to the Git baseline can authorize the matching deletion."
       },
       "changeControl": {
         "ordinaryImplementationMayModify": false,
@@ -2589,6 +2599,7 @@
           "tools/test-tier-manifest.mjs",
           "tools/integration-test-shards.mjs",
           "tools/check-integration-test-shards.mjs",
+          "tools/gate-allowlists/check-integration-test-shards.json",
           "package.json:scripts.harness:check-integration-test-shards",
           "tools/gate-manifest.json"
         ]

--- a/tools/integration-test-shards.mjs
+++ b/tools/integration-test-shards.mjs
@@ -1,7 +1,8 @@
-import { testTierManifest } from "./test-tier-manifest.mjs";
-
 export const integrationShardCount = 6;
+export const defaultIntegrationTestWeightMs = 1000;
 
+// Optional balancing overrides. New tests need no entry: they receive the
+// deterministic default weight and are placed into the lightest shard.
 export const integrationTestFileWeightsMs = Object.freeze({
   "packages/adapters/multica/test/multica-readonly-adopt.test.ts": 782.5,
   "packages/application/test/local-controller-service.test.ts": 507.0,
@@ -87,201 +88,66 @@ export const integrationTestFileWeightsMs = Object.freeze({
   "tools/relation-weathering-spike.test.mjs": 182.9
 });
 
-export const integrationTestShards = Object.freeze([
-  Object.freeze({
-    id: 1,
-    files: Object.freeze([
-      "packages/cli/test/local-lifecycle-cli.test.ts",
-      "packages/cli/test/progress-evidence-cli.test.ts",
-      "packages/cli/test/task-delete-disposition-cli.test.ts",
-      "packages/cli/test/task-document-gates-cli.test.ts",
-      "packages/cli/test/distill-cli.test.ts",
-      "packages/cli/test/attribution-diff-cli.test.ts",
-      "packages/cli/test/write-lock-retry-cli.test.ts",
-      "packages/cli/test/graph-cli.test.ts",
-      "packages/cli/test/projection-freshness-cli.test.ts",
-      "packages/kernel/test/store/crash-before-watermark.test.ts",
-      "packages/cli/test/self-host-git-boundary-cli.test.ts",
-      "packages/kernel/test/store/relation-cascade-direction.test.ts"
-    ])
-  }),
-  Object.freeze({
-    id: 2,
-    files: Object.freeze([
-      "packages/cli/test/daemon-thin-client-cli.test.ts",
-      "packages/cli/test/anchor-backfill-cli.test.ts",
-      "packages/cli/test/post-merge-check-cli.test.ts",
-      "packages/cli/test/task-show-relation-list-cli.test.ts",
-      "tools/quickstart-demo.test.mjs",
-      "packages/cli/test/conflict-preflight-cli.test.ts",
-      "packages/cli/test/local-lifecycle-crlf-cli.test.ts",
-      "tools/check-kernel-dead-exports.test.mjs",
-      "tools/check-runtime-release-readiness.test.mjs",
-      "tools/check-docs-release-map.test.mjs",
-      "packages/application/test/local-controller-service.test.ts",
-      "packages/application/test/execution-saga.test.ts",
-      "packages/kernel/test/store/portable-path-collision.test.ts"
-    ])
-  }),
-  Object.freeze({
-    id: 3,
-    files: Object.freeze([
-      "packages/cli/test/check-governance-cli.test.ts",
-      "packages/cli/test/preset-subtask-expansion-cli.test.ts",
-      "packages/cli/test/decision-task-metadata-cli.test.ts",
-      "tools/check-supply-chain.test.mjs",
-      "packages/cli/test/init-cli.test.ts",
-      "packages/cli/test/docmap-cli.test.ts",
-      "packages/cli/test/actor-attribution-cli.test.ts",
-      "packages/cli/test/preset-milestone-closeout-cli.test.ts",
-      "packages/kernel/test/store/global-committer-lock.test.ts",
-      "packages/cli/test/preset-script-imports-cli.test.ts",
-      "packages/cli/test/diagnostics-cli.test.ts",
-      "packages/kernel/test/store/entity-disposition.test.ts",
-      "packages/kernel/test/store/entity-registry-substrate.test.ts",
-      "packages/kernel/test/store/session-entity.test.ts",
-      "packages/kernel/test/store/daemon-registry.test.ts"
-    ])
-  }),
-  Object.freeze({
-    id: 4,
-    files: Object.freeze([
-      "packages/cli/test/decision-coverage-cli.test.ts",
-      "packages/cli/test/settings-cli.test.ts",
-      "packages/cli/test/decision-cli.test.ts",
-      "packages/cli/test/task-tree-cli.test.ts",
-      "packages/cli/test/extension-cli.test.ts",
-      "packages/kernel/test/store/sqlite-incremental-projection.test.ts",
-      "packages/cli/test/preset-create-milestone-cli.test.ts",
-      "packages/cli/test/doctor-cli.test.ts",
-      "packages/cli/test/worktree-cli.test.ts",
-      "packages/kernel/test/store/ledger-materializer.test.ts",
-      "packages/kernel/test/store/conditional-delta-writes.test.ts",
-      "packages/kernel/test/store/journal-idempotency.test.ts",
-      "packages/kernel/test/store/payload-hash.test.ts",
-      "packages/daemon/test/transport-integration.test.ts"
-    ])
-  }),
-  Object.freeze({
-    id: 5,
-    files: Object.freeze([
-      "packages/cli/test/task-transition-sweep-cli.test.ts",
-      "packages/cli/test/preset-script-cli.test.ts",
-      "packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts",
-      "packages/cli/test/p16-command-parity-cli.test.ts",
-      "packages/kernel/test/store/same-task-fifo.test.ts",
-      "packages/cli/test/new-task-cli.test.ts",
-      "packages/cli/test/preset-create-milestone-render-html-cli.test.ts",
-      "packages/kernel/test/store/daemon-runtime.test.ts",
-      "tools/check-import-boundaries.test.mjs",
-      "packages/cli/test/gui-cli.test.ts",
-      "packages/kernel/test/store/sqlite-rebuild.test.ts",
-      "packages/kernel/test/store/relation-graph-toctou.test.ts",
-      "packages/cli/test/submit-lifecycle-cli.test.ts"
-    ])
-  }),
-  Object.freeze({
-    id: 6,
-    files: Object.freeze([
-      "packages/cli/test/preset-module-cli.test.ts",
-      "packages/cli/test/preset-user-root-cli.test.ts",
-      "packages/cli/test/migration-adopt-cli.test.ts",
-      "packages/cli/test/task-archive-distill-cli.test.ts",
-      "packages/cli/test/fact-cli.test.ts",
-      "packages/cli/test/runtime-event-cli.test.ts",
-      "packages/cli/test/task-list-cli.test.ts",
-      "packages/cli/test/session-cli.test.ts",
-      "packages/cli/test/preset-github-issue-repair-cli.test.ts",
-      "packages/kernel/test/store/progress-append-delta.test.ts",
-      "packages/kernel/test/store/relation-graph-projection.test.ts",
-      "packages/cli/test/task-lease-cli.test.ts",
-      "packages/adapters/multica/test/multica-readonly-adopt.test.ts",
-      "tools/graph-panorama.test.mjs",
-      "tools/relation-weathering-spike.test.mjs"
-    ])
-  })
-]);
+export function assignIntegrationTestShards(
+  manifestFiles,
+  weightOverrides = integrationTestFileWeightsMs,
+  shardCount = integrationShardCount,
+  defaultWeightMs = defaultIntegrationTestWeightMs
+) {
+  const shards = Array.from({ length: shardCount }, (_, index) => ({ id: index + 1, files: [], estimatedMs: 0 }));
+  const weightedFiles = [...new Set(manifestFiles)]
+    .map((file) => ({ file, weight: weightOverrides[file] ?? defaultWeightMs }))
+    .sort((left, right) => right.weight - left.weight || left.file.localeCompare(right.file));
 
-export function parseIntegrationShardId(value) {
+  for (const { file, weight } of weightedFiles) {
+    const lightest = [...shards].sort((left, right) => left.estimatedMs - right.estimatedMs || left.id - right.id)[0];
+    lightest.files.push(file);
+    lightest.estimatedMs += weight;
+  }
+
+  return shards.map(({ id, files }) => ({ id, files: files.sort() }));
+}
+
+export function parseIntegrationShardId(value, shardCount = integrationShardCount) {
   const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 1 || parsed > integrationShardCount) {
-    throw new Error(`--shard must be an integer from 1 to ${integrationShardCount}`);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > shardCount) {
+    throw new Error(`--shard must be an integer from 1 to ${shardCount}`);
   }
   return parsed;
 }
 
-export function selectIntegrationShardFiles(shardValue) {
-  const validation = validateIntegrationTestShards();
-  if (!validation.ok) {
-    throw new Error(`integration shard declaration is invalid:\n${validation.errors.join("\n")}`);
-  }
-  const shardId = parseIntegrationShardId(shardValue);
-  const shard = integrationTestShards.find((candidate) => candidate.id === shardId);
-  if (!shard) {
-    throw new Error(`integration shard ${shardId} is not declared`);
-  }
-  return [...shard.files].sort();
+export function selectIntegrationShardFiles(shardValue, manifestFiles) {
+  const shards = assignIntegrationTestShards(manifestFiles);
+  const shardId = parseIntegrationShardId(shardValue, shards.length);
+  return [...shards[shardId - 1].files];
 }
 
-export function integrationShardSummaries() {
-  return integrationTestShards.map((shard) => ({
+export function integrationShardSummaries(manifestFiles, weightOverrides = integrationTestFileWeightsMs) {
+  return assignIntegrationTestShards(manifestFiles, weightOverrides).map((shard) => ({
     id: shard.id,
     files: shard.files.length,
-    estimatedMs: shard.files.reduce((sum, file) => sum + (integrationTestFileWeightsMs[file] ?? 0), 0)
+    estimatedMs: shard.files.reduce(
+      (sum, file) => sum + (weightOverrides[file] ?? defaultIntegrationTestWeightMs),
+      0
+    )
   }));
 }
 
-export function validateIntegrationTestShards(manifestFiles = testTierManifest.integration) {
+export function validateIntegrationTestShards(manifestFiles, weightOverrides = integrationTestFileWeightsMs) {
   const errors = [];
   const manifestSet = new Set(manifestFiles);
-  const shardIds = new Set();
-  const seen = new Map();
+  const shards = assignIntegrationTestShards(manifestFiles, weightOverrides);
+  const assigned = shards.flatMap((shard) => shard.files);
 
-  for (const shard of integrationTestShards) {
-    if (!Number.isInteger(shard.id) || shard.id < 1 || shard.id > integrationShardCount) {
-      errors.push(`invalid integration shard id: ${String(shard.id)}`);
-    }
-    if (shardIds.has(shard.id)) {
-      errors.push(`duplicate integration shard id: ${shard.id}`);
-    }
-    shardIds.add(shard.id);
-    if (!Array.isArray(shard.files) || shard.files.length === 0) {
-      errors.push(`integration shard ${shard.id} is empty`);
-      continue;
-    }
-    for (const file of shard.files) {
-      if (!manifestSet.has(file)) {
-        errors.push(`integration shard ${shard.id} references non-integration file: ${file}`);
-      }
-      const previous = seen.get(file);
-      if (previous !== undefined) {
-        errors.push(`integration file appears in multiple shards: ${file} (${previous}, ${shard.id})`);
-      }
-      seen.set(file, shard.id);
-    }
+  if (manifestSet.size !== manifestFiles.length) errors.push("integration manifest contains duplicate files");
+  if (assigned.length !== manifestSet.size || assigned.some((file) => !manifestSet.has(file))) {
+    errors.push("derived integration shards do not exactly cover the integration manifest");
   }
-
-  for (let id = 1; id <= integrationShardCount; id += 1) {
-    if (!shardIds.has(id)) {
-      errors.push(`missing integration shard id: ${id}`);
-    }
+  for (const [file, weight] of Object.entries(weightOverrides)) {
+    if (!manifestSet.has(file)) errors.push(`integration weight references non-integration file: ${file}`);
+    if (!Number.isFinite(weight) || weight <= 0) errors.push(`integration file has invalid weight: ${file}`);
   }
+  if (shards.some((shard) => shard.files.length === 0)) errors.push("derived integration shard is empty");
 
-  for (const file of manifestFiles) {
-    if (!seen.has(file)) {
-      errors.push(`integration file missing from shards: ${file}`);
-    }
-    const weight = integrationTestFileWeightsMs[file];
-    if (!Number.isFinite(weight) || weight <= 0) {
-      errors.push(`integration file has no positive weight: ${file}`);
-    }
-  }
-
-  for (const file of Object.keys(integrationTestFileWeightsMs)) {
-    if (!manifestSet.has(file)) {
-      errors.push(`integration weight references non-integration file: ${file}`);
-    }
-  }
-
-  return { ok: errors.length === 0, errors };
+  return { ok: errors.length === 0, errors, shards };
 }

--- a/tools/migrate-bypass-write-anchors.mjs
+++ b/tools/migrate-bypass-write-anchors.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { scanBypassWriteCalls } from "./check-bypass-write-boundary.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const allowlistPath = path.join(repoRoot, "tools/gate-allowlists/check-bypass-write-boundary.json");
+
+export function migrateBypassWriteAnchors(allowlist, findings) {
+  const stableByLegacy = new Map(findings.map((finding) => [finding.legacyKey, finding.key]));
+  let migratedCount = 0;
+  const entries = structuredClone(allowlist.entries);
+  for (const sectionEntries of Object.values(entries)) {
+    for (const entry of sectionEntries) {
+      const stable = stableByLegacy.get(entry.value);
+      if (!stable) throw new Error(`no fs write call matches legacy anchor: ${entry.value}`);
+      entry.value = stable;
+      migratedCount += 1;
+    }
+  }
+  return { allowlist: { ...allowlist, entries }, migratedCount };
+}
+
+function main(args) {
+  const write = args.includes("--write");
+  const source = JSON.parse(readFileSync(allowlistPath, "utf8"));
+  const result = migrateBypassWriteAnchors(source, scanBypassWriteCalls(repoRoot));
+  const output = `${JSON.stringify(result.allowlist, null, 2)}\n`;
+  if (write) {
+    writeFileSync(allowlistPath, output, "utf8");
+    console.log(`migrated ${result.migratedCount} bypass write anchors in ${path.relative(repoRoot, allowlistPath)}`);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) main(process.argv.slice(2));

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -4,11 +4,10 @@ import { spawn } from "node:child_process";
 import { availableParallelism } from "node:os";
 import { resolve } from "node:path";
 import { selectIntegrationShardFiles } from "./integration-test-shards.mjs";
-import { collectSlowTests, collectTestFiles, formatSlowTestSummary, parseRunnerArgs, resolveTestConcurrency, selectTestFiles } from "./node-test-runner-lib.mjs";
-import { testTierManifest, testTierNames } from "./test-tier-manifest.mjs";
+import { collectSlowTests, formatSlowTestSummary, parseRunnerArgs, resolveTestConcurrency, selectTestFiles } from "./node-test-runner-lib.mjs";
+import { discoverTestTierManifest, testTierNames } from "./test-tier-manifest.mjs";
 
 const repoRoot = resolve(import.meta.dirname, "..");
-const roots = ["packages", "tools"];
 
 // Reuse type-strip/compile output across the test host and every CLI
 // subprocess it spawns (integration tests cold-start `node src/index.ts` per
@@ -28,7 +27,8 @@ try {
   process.exit(2);
 }
 
-const testFiles = await collectTestFiles(repoRoot, roots);
+const testTierManifest = discoverTestTierManifest(repoRoot);
+const testFiles = Object.values(testTierManifest).flat().sort();
 const selection = selectTestFiles(testFiles, testTierManifest, options.tier);
 
 if (selection.errors.length > 0) {
@@ -39,7 +39,7 @@ if (selection.errors.length > 0) {
 }
 
 if (options.shard !== undefined) {
-  selection.files = selectIntegrationShardFiles(options.shard);
+  selection.files = selectIntegrationShardFiles(options.shard, selection.files);
 }
 
 if (selection.files.length === 0) {

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import test from "node:test";
 import { collectSlowTests, formatSlowTestSummary, parseCompletedTestLine, parseRunnerArgs, resolveTestConcurrency, selectTestFiles, validateManifest } from "./node-test-runner-lib.mjs";
-import { testTierManifest, testTierNames } from "./test-tier-manifest.mjs";
+import { deriveTestTierManifest, discoverTestTierManifest, testTierNames } from "./test-tier-manifest.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
 
 test("parseRunnerArgs accepts tier and slow summary options", () => {
   assert.deepEqual(parseRunnerArgs(["--tier", "fast", "--slow-threshold-ms", "250", "--slow-limit=3"], testTierNames), {
@@ -105,7 +109,30 @@ test("validateManifest rejects duplicates and missing manifest entries", () => {
   ]);
 });
 
-test("selectTestFiles returns sorted tier files from the repository manifest", () => {
+test("unregistered test files default to the integration tier", () => {
+  const manifest = deriveTestTierManifest(
+    ["fast.test.ts", "contract.test.ts", "new.test.ts"],
+    { fast: ["fast.test.ts"], contract: ["contract.test.ts"] }
+  );
+  assert.deepEqual(manifest, {
+    fast: ["fast.test.ts"],
+    contract: ["contract.test.ts"],
+    integration: ["new.test.ts"]
+  });
+});
+
+test("integration discovery equals the files executed by the CI runner", () => {
+  const manifest = discoverTestTierManifest(repoRoot);
+  const result = spawnSync(process.execPath, ["tools/run-node-tests.mjs", "--tier", "integration", "--list"], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.stdout.trim().split(/\r?\n/u), manifest.integration);
+});
+
+test("selectTestFiles returns sorted tier files from the derived repository manifest", () => {
+  const testTierManifest = discoverTestTierManifest(repoRoot);
   const allFiles = Object.values(testTierManifest).flat().sort();
   const result = selectTestFiles(allFiles, testTierManifest, "fast");
   assert.deepEqual(result.errors, []);

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -1,4 +1,10 @@
-export const testTierManifest = {
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+const testFilePattern = /\.(test|spec)\.(?:mjs|js|ts)$/u;
+const ignoredDirectoryNames = new Set(["node_modules", "dist", "out", "coverage", ".git"]);
+
+export const explicitTestTierManifest = {
   fast: [
     "packages/adapters/local/test/task-writes.test.ts",
     "packages/cli/test/doc-sync-service.test.ts",
@@ -108,91 +114,44 @@ export const testTierManifest = {
     "tools/skill-contracts.test.mjs",
     "tools/smoke-cli-package.test.mjs",
     "tools/scan-forbidden-symbols.test.mjs"
-  ],
-  integration: [
-    "packages/adapters/multica/test/multica-readonly-adopt.test.ts",
-    "packages/application/test/execution-saga.test.ts",
-    "packages/application/test/local-controller-service.test.ts",
-    "packages/daemon/test/transport-integration.test.ts",
-    "packages/cli/test/actor-attribution-cli.test.ts",
-    "packages/cli/test/anchor-backfill-cli.test.ts",
-    "packages/cli/test/attribution-diff-cli.test.ts",
-    "packages/cli/test/check-governance-cli.test.ts",
-    "packages/cli/test/conflict-preflight-cli.test.ts",
-    "packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts",
-    "packages/cli/test/daemon-thin-client-cli.test.ts",
-    "packages/cli/test/diagnostics-cli.test.ts",
-    "packages/cli/test/decision-cli.test.ts",
-    "packages/cli/test/decision-coverage-cli.test.ts",
-    "packages/cli/test/decision-task-metadata-cli.test.ts",
-    "packages/cli/test/docmap-cli.test.ts",
-    "packages/cli/test/distill-cli.test.ts",
-    "packages/cli/test/doctor-cli.test.ts",
-    "packages/cli/test/extension-cli.test.ts",
-    "packages/cli/test/fact-cli.test.ts",
-    "packages/cli/test/gui-cli.test.ts",
-    "packages/cli/test/graph-cli.test.ts",
-    "packages/cli/test/init-cli.test.ts",
-    "packages/cli/test/local-lifecycle-crlf-cli.test.ts",
-    "packages/cli/test/local-lifecycle-cli.test.ts",
-    "packages/cli/test/task-lease-cli.test.ts",
-    "packages/cli/test/migration-adopt-cli.test.ts",
-    "packages/cli/test/new-task-cli.test.ts",
-    "packages/cli/test/p16-command-parity-cli.test.ts",
-    "packages/cli/test/post-merge-check-cli.test.ts",
-    "packages/cli/test/projection-freshness-cli.test.ts",
-    "packages/cli/test/progress-evidence-cli.test.ts",
-    "packages/cli/test/preset-create-milestone-cli.test.ts",
-    "packages/cli/test/preset-create-milestone-render-html-cli.test.ts",
-    "packages/cli/test/preset-github-issue-repair-cli.test.ts",
-    "packages/cli/test/preset-milestone-closeout-cli.test.ts",
-    "packages/cli/test/preset-module-cli.test.ts",
-    "packages/cli/test/preset-user-root-cli.test.ts",
-    "packages/cli/test/preset-subtask-expansion-cli.test.ts",
-    "packages/cli/test/preset-script-imports-cli.test.ts",
-    "packages/cli/test/preset-script-cli.test.ts",
-    "packages/cli/test/runtime-event-cli.test.ts",
-    "packages/cli/test/session-cli.test.ts",
-    "packages/cli/test/submit-lifecycle-cli.test.ts",
-    "packages/cli/test/settings-cli.test.ts",
-    "packages/cli/test/self-host-git-boundary-cli.test.ts",
-    "packages/cli/test/task-archive-distill-cli.test.ts",
-    "packages/cli/test/task-delete-disposition-cli.test.ts",
-    "packages/cli/test/task-document-gates-cli.test.ts",
-    "packages/cli/test/task-list-cli.test.ts",
-    "packages/cli/test/task-show-relation-list-cli.test.ts",
-    "packages/cli/test/task-transition-sweep-cli.test.ts",
-    "packages/cli/test/task-tree-cli.test.ts",
-    "packages/cli/test/worktree-cli.test.ts",
-    "packages/cli/test/write-lock-retry-cli.test.ts",
-    "packages/kernel/test/store/crash-before-watermark.test.ts",
-    "packages/kernel/test/store/conditional-delta-writes.test.ts",
-    "packages/kernel/test/store/daemon-registry.test.ts",
-    "packages/kernel/test/store/daemon-runtime.test.ts",
-    "packages/kernel/test/store/entity-registry-substrate.test.ts",
-    "packages/kernel/test/store/entity-disposition.test.ts",
-    "packages/kernel/test/store/global-committer-lock.test.ts",
-    "packages/kernel/test/store/journal-idempotency.test.ts",
-    "packages/kernel/test/store/ledger-materializer.test.ts",
-    "packages/kernel/test/store/payload-hash.test.ts",
-    "packages/kernel/test/store/portable-path-collision.test.ts",
-    "packages/kernel/test/store/progress-append-delta.test.ts",
-    "packages/kernel/test/store/relation-cascade-direction.test.ts",
-    "packages/kernel/test/store/relation-graph-projection.test.ts",
-    "packages/kernel/test/store/relation-graph-toctou.test.ts",
-    "packages/kernel/test/store/same-task-fifo.test.ts",
-    "packages/kernel/test/store/session-entity.test.ts",
-    "packages/kernel/test/store/sqlite-incremental-projection.test.ts",
-    "packages/kernel/test/store/sqlite-rebuild.test.ts",
-    "tools/check-docs-release-map.test.mjs",
-    "tools/check-import-boundaries.test.mjs",
-    "tools/check-kernel-dead-exports.test.mjs",
-    "tools/quickstart-demo.test.mjs",
-    "tools/check-runtime-release-readiness.test.mjs",
-    "tools/check-supply-chain.test.mjs",
-    "tools/graph-panorama.test.mjs",
-    "tools/relation-weathering-spike.test.mjs"
   ]
 };
 
-export const testTierNames = Object.freeze(Object.keys(testTierManifest));
+export const testTierNames = Object.freeze(["fast", "contract", "integration"]);
+
+export function deriveTestTierManifest(testFiles, explicitManifest = explicitTestTierManifest) {
+  const explicitlyClassified = new Set(Object.values(explicitManifest).flat());
+  return {
+    fast: [...(explicitManifest.fast ?? [])],
+    contract: [...(explicitManifest.contract ?? [])],
+    integration: [...testFiles].filter((file) => !explicitlyClassified.has(file)).sort()
+  };
+}
+
+export function discoverTestFiles(repoRoot, roots = ["packages", "tools"]) {
+  const files = [];
+  for (const root of roots) {
+    walk(path.join(repoRoot, root), repoRoot, files);
+  }
+  return files.sort();
+}
+
+export function discoverTestTierManifest(repoRoot, options = {}) {
+  return deriveTestTierManifest(
+    discoverTestFiles(repoRoot, options.roots),
+    options.explicitManifest ?? explicitTestTierManifest
+  );
+}
+
+function walk(directory, repoRoot, files) {
+  if (!existsSync(directory)) return;
+  for (const entry of readdirSync(directory, { withFileTypes: true }).sort((left, right) => left.name.localeCompare(right.name))) {
+    if (entry.name.startsWith(".") || ignoredDirectoryNames.has(entry.name)) continue;
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      walk(entryPath, repoRoot, files);
+    } else if (entry.isFile() && testFilePattern.test(entry.name)) {
+      files.push(path.relative(repoRoot, entryPath).split(path.sep).join("/"));
+    }
+  }
+}


### PR DESCRIPTION
# English

## Summary

Eliminate the three gate registration hotspots that force every feature PR to hand-edit the same `tools/` files (integration tier list, shard assignments, literal `fileCount`, line/column allowlist anchors), which structurally serialized the merge queue. After this PR, adding an integration test requires zero `tools/` edits, deleting one requires a loud path-level confirmation, and the write-boundary allowlist no longer drifts when unrelated lines move.

## What Changed

- **Zero-registration integration tier**: `tools/test-tier-manifest.mjs` keeps fast/contract explicit; every other disk-discovered `*.test|spec.(mjs|js|ts)` under `packages/` and `tools/` defaults to integration (fail-safe direction: misclassification lands in the slower, stricter tier). Runner and shard checker share one discovery function, with a consistency test asserting the derived list equals the runner's actual execution set.
- **Derived shard assignment**: `tools/integration-test-shards.mjs` drops the hand-maintained file list; unlisted files get a default weight and deterministic lightest-shard/lowest-id assignment (order-independent, asserted by test). Hand weights remain as optional rebalancing overrides; stale overrides are rejected.
- **Deletion ratchet replaces literal fileCount**: the checker reports `current/previous/delta` against the Git baseline (merge-base with `origin/main`; fails closed when unresolvable). A count decrease is red unless each deleted path is confirmed in `tools/gate-allowlists/check-integration-test-shards.json`, and only confirmations newly added relative to the baseline authorize a deletion — merged entries stay neutral for later PRs, and a confirmed path reappearing on disk is red. CI ignores the local-only `HARNESS_TEST_COUNT_BASE_REF` injection variable.
- **Stable write-boundary anchors**: all 125 `check-bypass-write-boundary.json` entries mechanically migrated (via `tools/migrate-bypass-write-anchors.mjs`) from `file#symbol@line:col` to `file#fsApi@occurrence`; unrelated line insertion no longer drifts anchors, while a new ungoverned write call is still rejected (both positive controls in tests).
- **CI checkout depth**: `boundaries` and `full-check` checkout steps gain `fetch-depth: 0` so the Git-baseline ratchet can resolve merge-base; job IDs, steps, matrices, and required contexts are unchanged.
- Defense-equivalence map (every old red scenario → new red behavior, each row bound to an exact test) recorded in the task package impl report.

## Task And Scope

- Harness task: task_01KX815CJ22WY13QCR0Q3HX4F9
- Branch: feat/dehotspot-gate-registration
- Public scope: `tools/` gate mechanisms, `tools/gate-allowlists/`, `tools/gate-manifest.json`, `.github/workflows/rewrite-ci.yml` (checkout depth only)
- Private planning/evidence updated: yes (impl-report + orchestration records in task package)
- Out of scope: `packages/*` (parallel F5 slice), `.mergify.yml`, CI job structure, other allowlist families (none are line-anchored)

## Version Impact

- Version: no version change because this changes repo tooling/gates only, not published package behavior
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/test-tier-manifest.mjs`, `tools/integration-test-shards.mjs`, `tools/check-integration-test-shards.mjs(.test.mjs)`, `tools/check-bypass-write-boundary.mjs(.test.mjs)`, `tools/gate-allowlists/*`, `tools/gate-manifest.json`, `.github/workflows/rewrite-ci.yml` (checkout fetch-depth)
- Authority: dec_mrg1k3sd (parallel-queueing default + gate hot-file elimination charter) and task_01KX815CJ22WY13QCR0Q3HX4F9; anchor-drift lineage dec_GATE_DEFENSE_ROOT_CAUSE / ADR-0022
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none — defense equivalence is proven in-slice (mapping table with per-row tests)

## Verification

- Base `origin/main` SHA: 7dd384517cfde4384d7942b96902b60cf5e953dc
- Branch merge-base with `origin/main`: 7dd384517cfde4384d7942b96902b60cf5e953dc
- Last `git fetch origin` time: 2026-07-11 (pre-PR)
- Sync method: none needed
- Public diff command: `git diff origin/main...feat/dehotspot-gate-registration`
- Private evidence commit/path: harness/tasks/task_01KX815CJ22WY13QCR0Q3HX4F9-filecount-shard-allowlist/artifacts/impl-report.md
- Reviewer evidence path: same impl-report (defense-equivalence map with exact test names)
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed

Local gate evidence: boundaries (33 manifest commands, including live required-contexts with token) exit 0; fast 296/296, contract 382/382; all 6 integration shards exit 0.

---

# 中文

## 摘要

消灭迫使每个功能 PR 手工编辑同几个 `tools/` 文件的三大门禁登记热点（integration tier 清单、shard 分配、手写 `fileCount`、行列号 allowlist 锚）——这些热点让任意两个 PR 结构性冲突、把合并队列废成串行。本 PR 之后：新增 integration 测试零 `tools/` 编辑；删除测试需要路径级显式确认（响亮可审）；write-boundary allowlist 不再因无关行移动而漂移。

## 变更内容

- **integration tier 零登记**：fast/contract 保持显式登记，磁盘上其余测试默认归入 integration（fail-safe 朝向：误分类只会进更慢更严的 tier）。runner 与 shard checker 共用同一发现函数，并有一致性测试断言派生清单 = 实际执行集。
- **shard 派生分配**：删除手维护文件清单；无权重文件按默认权重确定性分配到最轻 shard（与发现顺序无关，有测试断言）；手写权重保留为可选重平衡覆盖，陈旧覆盖被拒绝。
- **删除棘轮替代手写 fileCount**：checker 对 Git 基线（与 origin/main 的 merge-base；不可解析时 fail-closed）报告 `current/previous/delta`。数量下降必须在 `tools/gate-allowlists/check-integration-test-shards.json` 逐路径确认，且只有相对基线**新增**的确认条目才能授权本次删除——已合入条目对后续 PR 保持中性，被确认路径重新出现在磁盘则红。CI 忽略仅供本地的 `HARNESS_TEST_COUNT_BASE_REF` 注入变量。
- **write-boundary 稳定锚**：125 条锚由一次性脚本（`tools/migrate-bypass-write-anchors.mjs`）从 `file#symbol@line:col` 机械迁移为 `file#fsApi@occurrence`；无关行插入不再漂移，新增未治理写调用仍然必红（两条阳性对照都有测试）。
- **CI checkout 深度**：`boundaries` 与 `full-check` 的 checkout 加 `fetch-depth: 0` 供棘轮取 merge-base；job ID、步骤、matrix、required contexts 全部未动。
- 防御等价映射表（旧机制每种红场景 → 新机制同样红，每行挂精确测试名）已写入任务包 impl-report。

## 任务与范围

- Harness 任务：task_01KX815CJ22WY13QCR0Q3HX4F9
- 分支：feat/dehotspot-gate-registration
- 公开范围：`tools/` 门禁机制、`tools/gate-allowlists/`、`tools/gate-manifest.json`、`.github/workflows/rewrite-ci.yml`（仅 checkout 深度）
- 私有规划/证据已更新：是（任务包 impl-report + 编排记录）
- 范围外：`packages/*`（并行 F5 切片）、`.mergify.yml`、CI job 结构、其余 allowlist 家族（均非行锚型）

## 版本影响

- 版本：无版本变更，原因是仅改仓库工具/门禁，不改已发布包行为
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是
- 受保护面范围：`tools/test-tier-manifest.mjs`、`tools/integration-test-shards.mjs`、`tools/check-integration-test-shards.mjs(.test.mjs)`、`tools/check-bypass-write-boundary.mjs(.test.mjs)`、`tools/gate-allowlists/*`、`tools/gate-manifest.json`、`.github/workflows/rewrite-ci.yml`（checkout fetch-depth）
- 授权依据：dec_mrg1k3sd（并行入队为默认 + 门禁热点消灭 charter）与 task_01KX815CJ22WY13QCR0Q3HX4F9；锚漂移谱系 dec_GATE_DEFENSE_ROOT_CAUSE / ADR-0022
- 机器检查边界：本 PR 仅断言声明存在；声明是否真实充分由 reviewer 判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无——防御等价性已在本片内证明（映射表逐行挂测试）

## 验证

- 基线 `origin/main` SHA：7dd384517cfde4384d7942b96902b60cf5e953dc
- 分支与 `origin/main` 的 merge-base：7dd384517cfde4384d7942b96902b60cf5e953dc
- 最近 `git fetch origin` 时间：2026-07-11（发 PR 前）
- 同步方式：无需同步
- 公开 diff 命令：`git diff origin/main...feat/dehotspot-gate-registration`
- 私有证据 commit/路径：harness/tasks/task_01KX815CJ22WY13QCR0Q3HX4F9-filecount-shard-allowlist/artifacts/impl-report.md
- Reviewer 证据路径：同上 impl-report（防御等价映射表含精确测试名）
- GitHub Actions `rewrite-ci` run URL：待 CI 回填
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed

本地门禁证据：boundaries（33 条 manifest 命令，含带 token 的 live required-contexts）exit 0；fast 296/296、contract 382/382；6 个 integration shard 全部 exit 0。
