### PR TITLE
fix: add entropy to decision ids

### DIFF
--- a/packages/cli/src/commands/core/decision-propose.ts
+++ b/packages/cli/src/commands/core/decision-propose.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../../application/src/index.ts";
 import {
   deriveRelationId,
+  generateTaskId,
   type EntityRelationRecord,
   type WriteError
 } from "../../../../kernel/src/index.ts";
@@ -50,7 +51,7 @@ function withDocSyncWarning(rootInput: HarnessLayoutInput, result: CliResult): C
 function proposedDecision(action: ProposeAction, now: string, relations: ReadonlyArray<EntityRelationRecord>): DecisionCreateInput {
   return {
     schema: "decision-package/v1",
-    decision_id: action.decisionId ?? `dec_${Date.now().toString(36)}`,
+    decision_id: action.decisionId ?? generateTaskId().replace(/^task_/u, "dec_"),
     title: action.title,
     state: "proposed",
     riskTier: action.riskTier,

--- a/packages/cli/test/decision-cli.test.ts
+++ b/packages/cli/test/decision-cli.test.ts
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 
@@ -15,7 +16,7 @@ test("CLI decision propose writes a decision package through the coordinator", (
       "decision",
       "propose",
       "--id",
-      "dec_TESTCLI",
+      "dec_mrg9r6j7",
       "--title",
       "Decision CLI",
       "--question",
@@ -32,11 +33,11 @@ test("CLI decision propose writes a decision package through the coordinator", (
 
     assert.equal(result.ok, true);
     assert.equal(result.command, "decision-propose");
-    assert.equal(result.decisionId, "dec_TESTCLI");
+    assert.equal(result.decisionId, "dec_mrg9r6j7");
     assert.equal(result.decisionState, "proposed");
-    const body = readFileSync(path.join(rootDir, "harness/decisions/decision-dec_TESTCLI/decision.md"), "utf8");
+    const body = readFileSync(path.join(rootDir, "harness/decisions/decision-dec_mrg9r6j7/decision.md"), "utf8");
     assert.match(body, /schema: decision-package\/v1/);
-    assert.match(body, /decision_id: dec_TESTCLI/);
+    assert.match(body, /decision_id: dec_mrg9r6j7/);
     assert.match(body, /_coordinatorWatermark: /);
     assert.match(body, /runtime: "human"/);
     assert.match(body, /sessionId: "human-cli-\d+"/);
@@ -49,6 +50,43 @@ test("CLI decision propose writes a decision package through the coordinator", (
     assert.equal(sessionManifest.sessionId, sessionId);
     assert.equal(sessionManifest.runtime, "human");
     assert.match(readFileSync(path.join(rootDir, ".harness/write-journal/watermark.json"), "utf8"), /write-watermark\/v1/);
+  });
+});
+
+test("CLI decision propose generates distinct high-entropy ids in the same millisecond", () => {
+  withTempRoot((rootDir) => {
+    const clockPath = path.join(rootDir, "fixed-clock.mjs");
+    writeFileSync(clockPath, [
+      "const OriginalDate = Date;",
+      "const fixedNow = 1_783_707_123_456;",
+      "globalThis.Date = class extends OriginalDate {",
+      "  constructor(...args) { super(...(args.length > 0 ? args : [fixedNow])); }",
+      "  static now() { return fixedNow; }",
+      "};"
+    ].join("\n"), "utf8");
+    const nodeOptions = `${process.env.NODE_OPTIONS ?? ""} --import=${pathToFileURL(clockPath).href}`.trim();
+    const proposeArgs = [
+      "decision",
+      "propose",
+      "--title",
+      "High entropy decision",
+      "--question",
+      "Should generated decision ids include entropy?",
+      "--chosen",
+      "Use random ULID entropy",
+      "--rejected",
+      "Use timestamp only",
+      "--why-not",
+      "Timestamp-only ids collide across writers"
+    ];
+
+    const first = runJson(rootDir, proposeArgs, true, { NODE_OPTIONS: nodeOptions });
+    const second = runJson(rootDir, proposeArgs, true, { NODE_OPTIONS: nodeOptions });
+
+    assert.match(first.decisionId, /^dec_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u);
+    assert.match(second.decisionId, /^dec_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u);
+    assert.equal(first.decisionId.slice(4, 14), second.decisionId.slice(4, 14));
+    assert.notEqual(first.decisionId, second.decisionId);
   });
 });
 
@@ -497,7 +535,12 @@ function withTempRoot<T>(fn: (rootDir: string) => T): T {
   }
 }
 
-function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, any> {
+function runJson(
+  rootDir: string,
+  args: ReadonlyArray<string>,
+  expectSuccess = true,
+  envOverrides: NodeJS.ProcessEnv = {}
+): Record<string, any> {
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
@@ -509,7 +552,8 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
         CLAUDE_SESSION_ID: "",
         CODEX_SESSION_ID: "",
         CODEX_THREAD_ID: "",
-        ZCODE_SESSION_ID: ""
+        ZCODE_SESSION_ID: "",
+        ...envOverrides
       }
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);


### PR DESCRIPTION
# English

## Summary

Decision ids were generated as `dec_${Date.now().toString(36)}` — a zero-entropy millisecond timestamp. Two proposes in the same millisecond (fleet, second repo, concurrent writers) collide, and decision is the signature carrier: its id is burned into relation strings, claim anchors and prose. This PR switches the default id to the kernel's existing task-id generator with the `dec_` prefix (10-char Crockford Base32 timestamp + 16-char random, ~80-bit entropy). Explicit `--id` behavior is unchanged; legacy timestamp-style ids remain valid everywhere.

## What Changed

- `packages/cli/src/commands/core/decision-propose.ts`: default id now `generateTaskId().replace(/^task_/u, "dec_")` — reuses the kernel generator, no new randomness source.
- `packages/cli/test/decision-cli.test.ts`: new-format assertion, same-millisecond double-propose no-collision (fails on the old implementation — negative control), explicit `--id` passthrough, legacy id `dec_mrg9r6j7` still written/parsed.

## Task And Scope

- Harness task: task_01KX8EQ2RNK22K5VP2WPJ877G8
- Branch: codex/decision-id-entropy
- Public scope: packages/cli only (1 source line + tests)
- Private planning/evidence updated: yes (impl report in task_01KX8275DSR5RHHKNFXNNV8PEN artifacts)
- Out of scope: EntityRef alias semantics (PLT-CrossRepo pre-gate), signature content pinning (separate task)

## Version Impact

- Version: no version change because this is a pre-publish internal fix; no public npm release exists yet
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: n/a
- Authority: decision dec_mrg9r6j7 ("id is identity, location is routing" — accepted 2026-07-11, arbiter human:zeyuli)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: n/a

## Verification

- Base `origin/main` SHA: bc2a32e0b2f0a95ee3ae56a221f1a31b9b560a63
- Branch merge-base with `origin/main`: bc2a32e0b2f0a95ee3ae56a221f1a31b9b560a63
- Last `git fetch origin` time: 2026-07-11 (pre-rebase, same session)
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/decision-id-entropy`
- Private evidence commit/path: harness/tasks/task_01KX8275DSR5RHHKNFXNNV8PEN-agent-oa-alm-markdown/artifacts/orchestration/impl-report-id-entropy.md (private ledger commit d3cb300)
- Reviewer evidence path: same impl report
- GitHub Actions `rewrite-ci` run URL: pending (fills on PR checks)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (full local gate green on rebased branch, includes all items below)
- [x] `npm run typecheck`
- [x] `npm test` (targeted 13/13 + suite via check)
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: none

## Review Evidence

- Self-review: worker ran negative-control regression (old impl fails the collision test)
- Reviewer subagent: CEO semantic acceptance against dec_mrg9r6j7 (diff read line-by-line; matches decision exactly)
- Human review: zeyuli approved the underlying decision batch ("我都同意", 2026-07-11)
- Blocking findings: none

## Residual Risk

- Random collision probability is nonzero (~2^-80), same envelope as task ids. Explicit `--id` uniqueness remains the caller's responsibility; duplicates are rejected by the coordinated write path.

## References

- Task: task_01KX8EQ2RNK22K5VP2WPJ877G8
- Evidence: impl-report-id-entropy.md (private task artifacts)
- Review: dec_mrg9r6j7

---

# 中文

## 摘要

decision id 此前用 `dec_${Date.now().toString(36)}` 生成——纯毫秒时间戳、零熵。同毫秒两次 propose(fleet 多机/第二仓/并发写者)必撞,而 decision 是签字承载体:id 被烧进 relation 字符串、claim 锚与正文引用。本 PR 将默认 id 切换为 kernel 既有 task id 生成器加 `dec_` 前缀(10 位 Crockford Base32 时间戳+16 位随机,约 80bit 熵)。显式 `--id` 行为不变;存量时间戳型 id 全链路继续合法。

## 变更内容

- `packages/cli/src/commands/core/decision-propose.ts`:默认 id 改为 `generateTaskId().replace(/^task_/u, "dec_")`——复用 kernel 生成器,不新造随机源。
- `packages/cli/test/decision-cli.test.ts`:新格式断言、同毫秒双 propose 不碰撞(旧实现上失败=阴性对照)、显式 `--id` 直通、旧 id `dec_mrg9r6j7` 原样写入/解析。

## 任务与范围

- Harness 任务:task_01KX8EQ2RNK22K5VP2WPJ877G8
- 分支:codex/decision-id-entropy
- 公开范围:仅 packages/cli(1 行源码+测试)
- 私有规划/证据已更新:是(实现报告在 task_01KX8275DSR5RHHKNFXNNV8PEN artifacts)
- 范围外:EntityRef alias 语义(PLT-CrossRepo 前置门)、签字内容钉(独立任务)

## 版本影响

- 版本:无版本变更,发布前内部修复,尚无公开 npm 发布
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:不适用
- 授权:决策 dec_mrg9r6j7(「id 是身份、位置是路由」,2026-07-11 accepted,arbiter human:zeyuli)
- 机器检查边界:本 PR 仅断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- 基线 `origin/main` SHA:bc2a32e0b2f0a95ee3ae56a221f1a31b9b560a63
- 分支与 `origin/main` 的 merge-base:bc2a32e0b2f0a95ee3ae56a221f1a31b9b560a63
- 最近 `git fetch origin` 时间:2026-07-11(rebase 前,同会话)
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...codex/decision-id-entropy`
- 私有证据 commit/路径:harness/tasks/task_01KX8275DSR5RHHKNFXNNV8PEN-agent-oa-alm-markdown/artifacts/orchestration/impl-report-id-entropy.md(私有账本 commit d3cb300)
- 评审证据路径:同上实现报告
- GitHub Actions `rewrite-ci` 运行链接:待 PR 检查生成
- 勾选项同英文块(本地全 gate 绿,rewrite-ci 待跑)
- 未运行:无

## 评审证据

- 自评审:worker 做了阴性对照回归(旧实现在碰撞测试上失败)
- 评审 subagent:CEO 对照 dec_mrg9r6j7 逐行读 diff 做语义验收,完全对齐
- 人工评审:泽宇 2026-07-11 批准底层决策批(「我都同意」)
- 阻塞发现:无

## 残余风险

- 随机碰撞概率非零(约 2^-80),与 task id 同包络;显式 `--id` 唯一性仍由调用方负责,重复会被协调写路径拒绝。

## 引用

- 任务:task_01KX8EQ2RNK22K5VP2WPJ877G8
- 证据:impl-report-id-entropy.md(私有任务 artifacts)
- 评审:dec_mrg9r6j7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
