### PR TITLE
fix(daemon): isolate local socket runtime directory per user

### DIFF
--- a/packages/cli/test/daemon-connect.test.ts
+++ b/packages/cli/test/daemon-connect.test.ts
@@ -26,6 +26,27 @@ test("daemon endpoint selection uses a named pipe on Windows and a unix socket o
   assert.equal(localUserDaemonEndpoint(userRoot, daemonId, "linux"), localUserDaemonSocketPath(userRoot, daemonId));
 });
 
+test("daemon client resolves the same Linux per-user runtime socket authority", () => {
+  const userRoot = "/srv/harness-user";
+  const daemonId = "team";
+  const runtimeDir = "/run/user/1234";
+  const pathOptions = {
+    env: { XDG_RUNTIME_DIR: runtimeDir },
+    linuxRuntimeRoot: "/missing-run-user",
+    tmpdir: "/shared-tmp",
+    uid: 1234
+  };
+
+  assert.equal(
+    localUserDaemonEndpoint(userRoot, daemonId, "linux", pathOptions),
+    localUserDaemonSocketPath(userRoot, daemonId, { ...pathOptions, platform: "linux" })
+  );
+  assert.equal(
+    localUserDaemonEndpoint(userRoot, daemonId, "linux", pathOptions).startsWith(`${runtimeDir}/harness-anything/`),
+    true
+  );
+});
+
 test("daemon serve transport wires the selected endpoint to the platform adapter", () => {
   const createProtocolServer = () => {
     throw new Error("not used by adapter selection test");

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -17,7 +17,7 @@ import { currentDaemonProtocolVersion } from "../protocol/method-registry.ts";
 import { type JsonObject, type JsonRpcRequest, type JsonRpcResponse } from "../protocol/json-rpc-types.ts";
 import { encodeJsonLineFrame } from "../transport/frame-codec.ts";
 import { defaultNamedPipePath } from "../transport/named-pipe.ts";
-import { defaultUnixSocketPath } from "../transport/unix-socket.ts";
+import { defaultUnixSocketPath, type UnixSocketPathOptions } from "../transport/unix-socket.ts";
 
 export const defaultDaemonAutostartTimeoutMs = 6_000;
 export const defaultDaemonIdleExitMs = 750;
@@ -80,17 +80,24 @@ export function localDaemonSocketPath(rootDir: string): string {
   return defaultUnixSocketPath(daemonIdForRoot(rootDir));
 }
 
-export function localUserDaemonSocketPath(userRoot = daemonUserRoot(), daemonId = daemonIdFromEnv()): string {
-  return defaultUnixSocketPath(daemonIdForUserRoot(userRoot, daemonId));
+export function localUserDaemonSocketPath(
+  userRoot = daemonUserRoot(),
+  daemonId = daemonIdFromEnv(),
+  pathOptions: UnixSocketPathOptions = {}
+): string {
+  return defaultUnixSocketPath(daemonIdForUserRoot(userRoot, daemonId), pathOptions);
 }
 
 export function localUserDaemonEndpoint(
   userRoot = daemonUserRoot(),
   daemonId = daemonIdFromEnv(),
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  pathOptions: Omit<UnixSocketPathOptions, "platform"> = {}
 ): string {
   const endpointId = daemonIdForUserRoot(userRoot, daemonId);
-  return platform === "win32" ? defaultNamedPipePath(endpointId) : defaultUnixSocketPath(endpointId);
+  return platform === "win32"
+    ? defaultNamedPipePath(endpointId)
+    : defaultUnixSocketPath(endpointId, { ...pathOptions, platform });
 }
 
 export function daemonUserRoot(env: NodeJS.ProcessEnv = process.env): string {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -116,6 +116,9 @@ export {
 export {
   createUnixSocketTransportServer,
   defaultUnixSocketPath,
+  ensurePrivateUnixSocketDirectory,
+  unixSocketDirectory,
+  type UnixSocketPathOptions,
   type UnixSocketTransportOptions,
   type UnixSocketTransportServer
 } from "./transport/unix-socket.ts";

--- a/packages/daemon/src/transport/unix-socket.ts
+++ b/packages/daemon/src/transport/unix-socket.ts
@@ -1,5 +1,5 @@
 // @slice-activation PLT-Daemon W3 transport adapters exported for daemon composition roots.
-import { mkdirSync, rmSync, chmodSync, statSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, rmSync, statSync } from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -17,6 +17,14 @@ export interface UnixSocketTransportOptions {
   readonly acceptSshForcedCommand?: boolean;
 }
 
+export interface UnixSocketPathOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly platform?: NodeJS.Platform;
+  readonly uid?: number;
+  readonly tmpdir?: string;
+  readonly linuxRuntimeRoot?: string;
+}
+
 export interface UnixSocketTransportServer {
   readonly kind: "unix-socket";
   readonly endpoint: string;
@@ -24,8 +32,62 @@ export interface UnixSocketTransportServer {
   readonly stop: () => Promise<void>;
 }
 
-export function defaultUnixSocketPath(daemonId: string, uid = process.getuid?.() ?? 0): string {
-  return path.join(os.tmpdir(), "harness-anything", `daemon-${uid}-${safeUnixSocketEndpointId(daemonId)}.sock`);
+export function defaultUnixSocketPath(
+  daemonId: string,
+  options: UnixSocketPathOptions | number = {}
+): string {
+  const normalized = typeof options === "number" ? { uid: options } : options;
+  const uid = normalized.uid ?? process.getuid?.() ?? 0;
+  return path.join(
+    unixSocketDirectory({ ...normalized, uid }),
+    `daemon-${uid}-${safeUnixSocketEndpointId(daemonId)}.sock`
+  );
+}
+
+export function unixSocketDirectory(options: UnixSocketPathOptions = {}): string {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const uid = options.uid ?? process.getuid?.() ?? 0;
+  const tmpdir = readNonEmptyPath(env.TMPDIR) ?? options.tmpdir ?? os.tmpdir();
+
+  if (platform === "linux") {
+    const xdgRuntimeDir = readNonEmptyPath(env.XDG_RUNTIME_DIR);
+    if (xdgRuntimeDir) return path.join(xdgRuntimeDir, "harness-anything");
+
+    const userRuntimeDir = path.join(options.linuxRuntimeRoot ?? "/run/user", String(uid));
+    if (existsSync(userRuntimeDir)) return path.join(userRuntimeDir, "harness-anything");
+  }
+
+  // macOS os.tmpdir() normally resolves to Darwin's per-user temporary
+  // directory. The uid suffix also keeps the fallback safe if it resolves to
+  // a shared directory such as /tmp on any POSIX platform.
+  return path.join(tmpdir, `harness-anything-${uid}`);
+}
+
+export function ensurePrivateUnixSocketDirectory(directory: string, uid = process.getuid?.() ?? 0): void {
+  try {
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    throw privateDirectoryError(directory, uid, undefined, undefined, error);
+  }
+
+  let ownerUid: number;
+  let mode: number;
+  try {
+    const stat = lstatSync(directory);
+    ownerUid = stat.uid;
+    mode = stat.mode & 0o777;
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw privateDirectoryError(directory, uid, ownerUid, mode, undefined, "not a real directory");
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unsafe daemon socket directory")) throw error;
+    throw privateDirectoryError(directory, uid, undefined, undefined, error);
+  }
+
+  if (ownerUid !== uid || mode !== 0o700) {
+    throw privateDirectoryError(directory, uid, ownerUid, mode);
+  }
 }
 
 export function createUnixSocketTransportServer(options: UnixSocketTransportOptions): UnixSocketTransportServer {
@@ -58,7 +120,7 @@ export function createUnixSocketTransportServer(options: UnixSocketTransportOpti
     kind: "unix-socket",
     endpoint,
     start: async () => {
-      mkdirSync(path.dirname(endpoint), { recursive: true, mode: 0o700 });
+      ensurePrivateUnixSocketDirectory(path.dirname(endpoint));
       rmSync(endpoint, { force: true });
       await new Promise<void>((resolve, reject) => {
         server.once("error", reject);
@@ -80,4 +142,26 @@ export function createUnixSocketTransportServer(options: UnixSocketTransportOpti
 
 function safeUnixSocketEndpointId(value: string): string {
   return value.replace(/[^A-Za-z0-9_.-]/gu, "-");
+}
+
+function readNonEmptyPath(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? path.resolve(trimmed) : undefined;
+}
+
+function privateDirectoryError(
+  directory: string,
+  expectedUid: number,
+  ownerUid: number | undefined,
+  mode: number | undefined,
+  cause?: unknown,
+  detail?: string
+): Error {
+  const observed = detail
+    ?? `owner uid ${ownerUid ?? "unknown"}, mode ${mode === undefined ? "unknown" : `0${mode.toString(8)}`}`;
+  const message = [
+    `Unsafe daemon socket directory ${JSON.stringify(directory)} (${observed}); expected a real directory owned by uid ${expectedUid} with mode 0700.`,
+    "Set XDG_RUNTIME_DIR or TMPDIR to a private per-user runtime directory."
+  ].join(" ");
+  return new Error(message, cause === undefined ? undefined : { cause });
 }

--- a/packages/daemon/test/transport-integration.test.ts
+++ b/packages/daemon/test/transport-integration.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdtempSync, statSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, statSync } from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -19,6 +19,7 @@ import {
   currentDaemonProtocolVersion,
   defaultNamedPipePath,
   defaultUnixSocketPath,
+  ensurePrivateUnixSocketDirectory,
   encodeJsonLineFrame,
   makeTransportDerivedIdentityProvider,
   peopleRosterFromDocument,
@@ -27,6 +28,7 @@ import {
   serveSshExecBridge,
   serveSshTunnelTokenStream,
   windowsNamedPipeIntegrationEntry,
+  unixSocketDirectory,
   type DaemonAuthenticationContext,
   type JsonRpcProtocolServer,
   type JsonRpcRequest,
@@ -69,6 +71,69 @@ test("unix socket transport uses single-user path and permissions on POSIX", asy
     "unix-socket-filesystem-owner-boundary"
   );
   socket.end();
+});
+
+test("unix socket path prefers the Linux per-user runtime directory", () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-runtime-"));
+  const runtimeDir = path.join(tempDir, "runtime");
+  const endpoint = defaultUnixSocketPath("daemon test", {
+    env: { XDG_RUNTIME_DIR: runtimeDir },
+    linuxRuntimeRoot: path.join(tempDir, "run-user"),
+    platform: "linux",
+    tmpdir: path.join(tempDir, "shared-tmp"),
+    uid: 1234
+  });
+
+  assert.equal(endpoint, path.join(runtimeDir, "harness-anything", "daemon-1234-daemon-test.sock"));
+});
+
+test("unix socket shared-tmp fallback includes uid and rejects an unsafe pre-existing directory", () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-shared-tmp-"));
+  const uid = process.getuid?.() ?? 0;
+  const directory = unixSocketDirectory({
+    env: {},
+    linuxRuntimeRoot: path.join(tempDir, "missing-run-user"),
+    platform: "linux",
+    tmpdir: tempDir,
+    uid
+  });
+  assert.equal(directory, path.join(tempDir, `harness-anything-${uid}`));
+
+  mkdirSync(directory, { mode: 0o700 });
+  assert.throws(
+    () => ensurePrivateUnixSocketDirectory(directory, uid + 1),
+    (error: unknown) => {
+      assert.match(String(error), /Unsafe daemon socket directory/u);
+      assert.match(String(error), new RegExp(`owner uid ${uid}`, "u"));
+      assert.match(String(error), /XDG_RUNTIME_DIR or TMPDIR/u);
+      assert.doesNotMatch(String(error), /^Error: EACCES/u);
+      return true;
+    }
+  );
+
+  chmodSync(directory, 0o777);
+  assert.throws(
+    () => ensurePrivateUnixSocketDirectory(directory, uid),
+    /mode 0777.*expected.*mode 0700/iu
+  );
+});
+
+test("unix socket transport rejects an unsafe parent before touching the socket", async () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-unsafe-parent-"));
+  const directory = path.join(tempDir, "harness-anything");
+  const socketPath = path.join(directory, "daemon.sock");
+  mkdirSync(directory, { mode: 0o777 });
+  chmodSync(directory, 0o777);
+  const transport = createUnixSocketTransportServer({
+    daemonId: "daemon-test",
+    socketPath,
+    createProtocolServer: makeProtocolServerFactory()
+  });
+
+  await assert.rejects(
+    transport.start(),
+    /Unsafe daemon socket directory.*mode 0777.*XDG_RUNTIME_DIR or TMPDIR/iu
+  );
 });
 
 test("unix socket owner boundary credential resolves to its roster person", async () => {


### PR DESCRIPTION
# English

## Summary

Fixes the daemon Unix socket wedge on multi-user hosts (task_01KX8T26QSPC7TJBCQSD8GXB40). The socket parent directory was `os.tmpdir()/harness-anything/` — a cross-user shared path. On ai-server (2026-07-11 KTY P1 bootstrap), another user (`cyr`) had pre-created it with mode 700, so root1's daemon crashed with a bare `EACCES` and systemd retried forever. The production workaround (`Environment=TMPDIR=/run/user/1000` in the unit) papers over the defect class: any multi-user host without an explicit TMPDIR hits it.

The fix isolates the socket directory per user and validates it fail-closed before any socket file operation.

## What Changed

- `packages/daemon/src/transport/unix-socket.ts`: `defaultUnixSocketPath` now resolves through `unixSocketDirectory` — Linux prefers `XDG_RUNTIME_DIR/harness-anything`, falls back to `/run/user/<uid>/harness-anything` when it exists, then to `os.tmpdir()/harness-anything-<uid>` (uid-suffixed, never a shared parent). New `ensurePrivateUnixSocketDirectory` creates/reuses the directory and fail-closed verifies: real directory, not a symlink, owned by the current uid, mode exactly 0700 — violations raise a diagnostic error naming the directory, observed owner/mode, and suggesting `XDG_RUNTIME_DIR`/`TMPDIR`, instead of a bare `EACCES` retry loop. The server runs this check before unlinking/listening on the socket. Path options are injectable for hermetic tests; the legacy numeric-uid call signature stays compatible.
- `packages/daemon/src/client/local-json-rpc-client.ts`: client endpoints keep delegating to the same `defaultUnixSocketPath` single authority (with explicit platform/options passthrough), so server and client can never diverge; Windows still uses `defaultNamedPipePath`.
- `packages/daemon/src/index.ts`: exports the path-strategy and directory-validation contract.
- `packages/daemon/test/transport-integration.test.ts` + `packages/cli/test/daemon-connect.test.ts`: regressions for XDG preference, uid-suffixed shared-tmp fallback, foreign-owner rejection, wrong-mode rejection, fail-closed before socket touch, and client/server path-authority consistency across platforms.

## Task And Scope

- Harness task: task_01KX8T26QSPC7TJBCQSD8GXB40
- Branch: fix/daemon-socket-per-user
- Public scope: daemon unix-socket transport path strategy + client endpoint resolution + regressions
- Private planning/evidence updated: yes (implementation report in the task package)
- Out of scope: Windows named-pipe ACLs (unchanged), KTY systemd unit edit (deployment-side; five-point retirement criteria for the TMPDIR workaround are documented in the implementation report)

## Version Impact

- Version: no version change because this is a pre-release workspace daemon fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_01KX8T26QSPC7TJBCQSD8GXB40 (defect recorded from KTY P1 bootstrap incident, 2026-07-11)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: d1836700b781192612f49871dfa6a665bc8d651f
- Branch merge-base with `origin/main`: d1836700b781192612f49871dfa6a665bc8d651f
- Last `git fetch origin` time: 2026-07-12 (rebased onto d183670 before this PR)
- Sync method: rebase
- Public diff command: `git diff origin/main...fix/daemon-socket-per-user`
- Private evidence commit/path: harness/tasks/task_01KX8T26QSPC7TJBCQSD8GXB40-daemon-socket-os-tmpdir-harness-anything-700/artifacts/impl-report-codex.md
- Reviewer evidence path: same as above
- GitHub Actions `rewrite-ci` run URL: pending (populated by CI on this PR)
- [x] `npm ci` (worker environment)
- [x] `git diff --check`
- [x] `npm run check` (exit 0 rerun on rebased HEAD ab2ef1f: typecheck, eslint, Node tests, GUI tests, 35 manifest gates)
- [x] `npm run typecheck` (via check)
- [x] `npm test` (via check; targeted: 24 passed / 1 Windows-only skip)
- [x] `npm run harness:check-import-boundaries` (via check)
- [x] `npm run harness:scan-forbidden-symbols` (via check)
- [x] `npm run harness:check-private-boundary` (via check)
- [x] `npm run harness:check-package-policy` (via check)
- [x] `npm run harness:check-implementation-contracts` (via check)
- [x] `npm run harness:check-schema-contracts` (via check)
- [x] `npm run harness:check-legacy-intake-readiness` (via check)
- [x] `npm run harness:smoke-cli-package` (via check)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: none

## Review Evidence

- Self-review: worker red/green regression set; full gate rerun by CEO on rebased HEAD (exit 0)
- Reviewer subagent: not applicable (CEO hunk-by-hunk semantic review against the mission invariants: per-user isolation, fail-closed owner/mode validation, single path authority on both sides)
- Human review: pending on this PR
- Blocking findings: none

## Residual Risk

- Existing custom `--socket` paths whose parent directory is not 0700/owned-by-caller now receive a diagnostic rejection (security tightening; the error message states the remediation).
- The ai-server TMPDIR workaround retirement is deployment-side; the five verifiable criteria are in the task's implementation report and will be executed after this build reaches the host.

## References

- Task: task_01KX8T26QSPC7TJBCQSD8GXB40
- Evidence: harness/tasks/task_01KX8T26QSPC7TJBCQSD8GXB40-daemon-socket-os-tmpdir-harness-anything-700/artifacts/impl-report-codex.md
- Review: same task package

---

# 中文

## 概要

修复多用户主机上 daemon Unix socket 卡死缺陷（task_01KX8T26QSPC7TJBCQSD8GXB40）。socket 父目录原为 `os.tmpdir()/harness-anything/`——跨用户共享路径。ai-server 实测（2026-07-11 KTY P1 bootstrap）：该目录被另一用户 `cyr` 以 700 先创建，root1 的 daemon 裸报 `EACCES` 崩溃、systemd 无限重试。现网 workaround（unit 里 `Environment=TMPDIR=/run/user/1000`）只是止血：任何未显式设 TMPDIR 的多用户主机都会踩同类缺陷。

本修复把 socket 目录按用户隔离，并在任何 socket 文件操作前做 fail-closed 校验。

## 改动内容

- `packages/daemon/src/transport/unix-socket.ts`：`defaultUnixSocketPath` 统一经 `unixSocketDirectory` 解析——Linux 优先 `XDG_RUNTIME_DIR/harness-anything`，回退到已存在的 `/run/user/<uid>/harness-anything`，再回退 `os.tmpdir()/harness-anything-<uid>`（带 uid 后缀，绝不再用共享父目录）。新增 `ensurePrivateUnixSocketDirectory` 创建/复用目录并 fail-closed 校验：真实目录、非 symlink、owner 为当前 uid、mode 精确 0700——违例时报诊断错误（含目录、观察到的 owner/mode、建议设 `XDG_RUNTIME_DIR`/`TMPDIR`），而非裸 `EACCES` 重试循环。服务端在删除旧 socket 或 listen 前先过该校验。路径选项可注入以支持 hermetic 测试；旧的数字 uid 调用签名保持兼容。
- `packages/daemon/src/client/local-json-rpc-client.ts`：client endpoint 继续委托同一个 `defaultUnixSocketPath` 单一 authority（显式透传 platform/options），server/client 永不分叉；Windows 仍走 `defaultNamedPipePath`。
- `packages/daemon/src/index.ts`：导出路径策略与目录校验契约。
- `packages/daemon/test/transport-integration.test.ts` + `packages/cli/test/daemon-connect.test.ts`：回归覆盖 XDG 优先、共享 tmp uid 隔离回退、他人 owner 拒绝、错误 mode 拒绝、触碰 socket 前 fail-closed、跨平台 client/server 路径 authority 一致。

## 任务与范围

- Harness 任务：task_01KX8T26QSPC7TJBCQSD8GXB40
- 分支：fix/daemon-socket-per-user
- 公开范围：daemon unix-socket transport 路径策略 + client endpoint 解析 + 回归测试
- 私有计划 / 证据是否已更新：yes（实现报告在任务包）
- 范围外：Windows named pipe ACL（未改动）、KTY systemd unit 修改（部署侧；TMPDIR workaround 退场五条判据已写入实现报告）

## 版本影响

- 版本：不改版本，原因是 pre-release workspace daemon 修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：task_01KX8T26QSPC7TJBCQSD8GXB40（缺陷源自 2026-07-11 KTY P1 bootstrap 事故记录）
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：d1836700b781192612f49871dfa6a665bc8d651f
- 当前分支与 `origin/main` 的 merge-base：d1836700b781192612f49871dfa6a665bc8d651f
- 最近一次 `git fetch origin` 时间：2026-07-12（开 PR 前已 rebase 到 d183670）
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...fix/daemon-socket-per-user`
- 私有证据 commit / 路径：harness/tasks/task_01KX8T26QSPC7TJBCQSD8GXB40-daemon-socket-os-tmpdir-harness-anything-700/artifacts/impl-report-codex.md
- Reviewer 证据路径：同上
- GitHub Actions `rewrite-ci` run URL：pending（本 PR CI 产生后回填）
- [x] `npm ci`（worker 环境）
- [x] `git diff --check`
- [x] `npm run check`（rebase 后 HEAD ab2ef1f 复跑 exit 0：typecheck、eslint、Node、GUI、35 manifest gates）
- [x] `npm run typecheck`（含于 check）
- [x] `npm test`（含于 check；定向 24 passed / 1 Windows-only skip）
- [x] `npm run harness:check-import-boundaries`（含于 check）
- [x] `npm run harness:scan-forbidden-symbols`（含于 check）
- [x] `npm run harness:check-private-boundary`（含于 check）
- [x] `npm run harness:check-package-policy`（含于 check）
- [x] `npm run harness:check-implementation-contracts`（含于 check）
- [x] `npm run harness:check-schema-contracts`（含于 check）
- [x] `npm run harness:check-legacy-intake-readiness`（含于 check）
- [x] `npm run harness:smoke-cli-package`（含于 check）
- [ ] GitHub Actions `rewrite-ci` passed
- 未执行：无

## Review Evidence

- Self-review：worker 红绿回归；CEO 在 rebase 后 HEAD 复跑全量 gate（exit 0）
- Reviewer subagent：不适用（CEO 逐 hunk 语义验收，对照 mission 不变量：per-user 隔离、fail-closed owner/mode 校验、两侧单一路径 authority）
- Human review：本 PR 待审
- Blocking findings：无

## 残余风险

- 既有自定义 `--socket` 路径若父目录非 0700/非调用者所有，现在会收到诊断性拒绝（安全收紧；报错信息含修复方式）。
- ai-server TMPDIR workaround 退场属部署侧动作；五条可验证判据在任务实现报告中，构建到达主机后执行。

## References

- Task: task_01KX8T26QSPC7TJBCQSD8GXB40
- Evidence: harness/tasks/task_01KX8T26QSPC7TJBCQSD8GXB40-daemon-socket-os-tmpdir-harness-anything-700/artifacts/impl-report-codex.md
- Review: 同任务包
