### PR TITLE
fix: resolve code-doc anchors across git roots

### DIFF
--- a/packages/application/src/code-doc-reconciliation.ts
+++ b/packages/application/src/code-doc-reconciliation.ts
@@ -1,4 +1,4 @@
-import type { VersionControlSystem } from "../../kernel/src/index.ts";
+import { makeCodeDocGitEvidenceResolver, type VersionControlSystem } from "../../kernel/src/index.ts";
 
 export const CODE_DOC_RECONCILIATION_DOCUMENT = "code-doc-anchors.json";
 
@@ -8,7 +8,8 @@ export interface CodeDocReconciliationInput {
   readonly taskId: string;
   readonly documents: ReadonlyArray<CodeDocDocument>;
   readonly rootDir: string;
-  readonly versionControlSystem?: Pick<VersionControlSystem, "commitExists" | "pathExistsAtCommit">;
+  readonly authoredRoot: string;
+  readonly versionControlSystem?: Pick<VersionControlSystem, "normalizePath" | "topLevel" | "commitExists" | "pathExistsAtCommit">;
 }
 
 export interface CodeDocDocument {
@@ -136,6 +137,10 @@ export function evaluateCodeDocReconciliationGate(input: CodeDocReconciliationIn
     }]);
   }
   const versionControlSystem = input.versionControlSystem;
+  const gitEvidence = makeCodeDocGitEvidenceResolver({
+    rootDir: input.rootDir,
+    authoredRoot: input.authoredRoot
+  }, versionControlSystem);
   const warnings: CodeDocReconciliationWarning[] = [];
   const issues: CodeDocReconciliationIssue[] = [];
   let checkedAnchors = 0;
@@ -146,7 +151,7 @@ export function evaluateCodeDocReconciliationGate(input: CodeDocReconciliationIn
       checkedAnchors += 1;
       if (anchor.kind === "commit") {
         hardAnchorCount += 1;
-        if (!versionControlSystem.commitExists(input.rootDir, anchor.sha)) {
+        if (!gitEvidence.resolve({ sha: anchor.sha }).ok) {
           issues.push({
             code: "code_doc_git_ref_missing",
             recordId: record.id,
@@ -157,7 +162,8 @@ export function evaluateCodeDocReconciliationGate(input: CodeDocReconciliationIn
       }
       if (anchor.kind === "path") {
         hardAnchorCount += 1;
-        if (!versionControlSystem.commitExists(input.rootDir, anchor.sha)) {
+        const resolution = gitEvidence.resolve({ sha: anchor.sha, path: anchor.path });
+        if (!resolution.ok && resolution.reason === "commit-missing") {
           issues.push({
             code: "code_doc_git_ref_missing",
             recordId: record.id,
@@ -165,7 +171,7 @@ export function evaluateCodeDocReconciliationGate(input: CodeDocReconciliationIn
           });
           continue;
         }
-        if (!versionControlSystem.pathExistsAtCommit(input.rootDir, anchor.sha, anchor.path)) {
+        if (!resolution.ok) {
           issues.push({
             code: "code_doc_path_missing",
             recordId: record.id,
@@ -176,7 +182,7 @@ export function evaluateCodeDocReconciliationGate(input: CodeDocReconciliationIn
       }
       if (anchor.sha) {
         hardAnchorCount += 1;
-        if (!versionControlSystem.commitExists(input.rootDir, anchor.sha)) {
+        if (!gitEvidence.resolve({ sha: anchor.sha }).ok) {
           issues.push({
             code: "code_doc_git_ref_missing",
             recordId: record.id,

--- a/packages/application/src/task-lifecycle-orchestrator.ts
+++ b/packages/application/src/task-lifecycle-orchestrator.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import type { ArtifactStore, DomainStatus, EngineError, TaskHolderPrincipal, TaskId, VersionControlSystem, WriteError } from "../../kernel/src/index.ts";
-import { isDomainStatus, isTerminalStatus, readTaskProjection } from "../../kernel/src/index.ts";
+import { isDomainStatus, isTerminalStatus, readTaskProjection, resolveHarnessLayout } from "../../kernel/src/index.ts";
 import type { HarnessLayoutOverrides } from "../../kernel/src/index.ts";
 import { readFrontmatter, readScalar } from "../../kernel/src/index.ts";
 import { evaluateCodeDocReconciliationGate } from "./code-doc-reconciliation.ts";
@@ -40,7 +40,7 @@ export interface TaskLifecycleOrchestratorOptions {
   readonly taskWriter: TaskLifecycleWriter;
   readonly artifactStore: Pick<ArtifactStore, "readTaskPackage">;
   readonly documentPlaceholderPolicy?: TaskDocumentPlaceholderPolicy;
-  readonly codeDocVersionControlSystem?: Pick<VersionControlSystem, "commitExists" | "pathExistsAtCommit">;
+  readonly codeDocVersionControlSystem?: Pick<VersionControlSystem, "normalizePath" | "topLevel" | "commitExists" | "pathExistsAtCommit">;
   readonly now?: () => string;
   readonly executionCompletionService?: ExecutionCompletionService;
   readonly completionGateResolver?: (input: {
@@ -170,7 +170,13 @@ export function makeTaskLifecycleOrchestrator(options: TaskLifecycleOrchestrator
       if (documentPlaceholder) return documentPlaceholder;
 
       if (completionGates.gates.includes("code-doc-reconciliation")) {
-        const codeDocReconciliation = yield* validateCodeDocReconciliation(options.artifactStore, options.rootDir, payload.taskId, options.codeDocVersionControlSystem);
+        const codeDocReconciliation = yield* validateCodeDocReconciliation(
+          options.artifactStore,
+          options.rootDir,
+          resolveHarnessLayout({ rootDir: options.rootDir, layoutOverrides: options.layoutOverrides }).authoredRoot,
+          payload.taskId,
+          options.codeDocVersionControlSystem
+        );
         if (codeDocReconciliation) return codeDocReconciliation;
       }
 
@@ -362,8 +368,9 @@ function validateActiveTaskPlanPlaceholder(
 function validateCodeDocReconciliation(
   artifactStore: Pick<ArtifactStore, "readTaskPackage">,
   rootDir: string,
+  authoredRoot: string,
   taskId: string,
-  versionControlSystem: Pick<VersionControlSystem, "commitExists" | "pathExistsAtCommit"> | undefined
+  versionControlSystem: Pick<VersionControlSystem, "normalizePath" | "topLevel" | "commitExists" | "pathExistsAtCommit"> | undefined
 ): Effect.Effect<TaskLifecycleFailure | null> {
   return Effect.gen(function* () {
     const taskPackage = yield* artifactStore.readTaskPackage(taskId as TaskId).pipe(
@@ -375,6 +382,7 @@ function validateCodeDocReconciliation(
     const gate = evaluateCodeDocReconciliationGate({
       taskId,
       rootDir,
+      authoredRoot,
       documents: taskPackage.documents,
       versionControlSystem
     });

--- a/packages/application/test/code-doc-reconciliation-git-roots.test.ts
+++ b/packages/application/test/code-doc-reconciliation-git-roots.test.ts
@@ -1,0 +1,113 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeLocalVersionControlSystem } from "../../kernel/src/index.ts";
+import { CODE_DOC_RECONCILIATION_DOCUMENT, evaluateCodeDocReconciliationGate } from "../src/code-doc-reconciliation.ts";
+
+test("code-doc reconciliation resolves a private harness commit outside the outer repository history", () => {
+  withNestedGitFixture(({ rootDir, authoredRoot, outerSha, authoredSha }) => {
+    const versionControlSystem = makeLocalVersionControlSystem();
+    assert.equal(versionControlSystem.commitExists(rootDir, authoredSha), false, "the old outer-root lookup reproduces the missing commit");
+
+    const result = evaluateCodeDocReconciliationGate({
+      taskId: "task-1",
+      rootDir,
+      authoredRoot,
+      versionControlSystem,
+      documents: documents([{ kind: "commit", sha: authoredSha }])
+    });
+
+    assert.equal(result.ok, true);
+    assert.notEqual(outerSha, authoredSha);
+  });
+});
+
+test("code-doc reconciliation resolves public and private anchors independently in one document", () => {
+  withNestedGitFixture(({ rootDir, authoredRoot, outerSha, authoredSha, authoredEvidencePath }) => {
+    const versionControlSystem = makeLocalVersionControlSystem();
+    assert.equal(versionControlSystem.commitExists(rootDir, authoredSha), false, "private commit is absent from the outer repository");
+    assert.equal(versionControlSystem.commitExists(authoredRoot, outerSha), false, "public commit is absent from the authored repository");
+
+    const result = evaluateCodeDocReconciliationGate({
+      taskId: "task-1",
+      rootDir,
+      authoredRoot,
+      versionControlSystem,
+      documents: documents([
+        { kind: "commit", sha: outerSha },
+        { kind: "path", sha: authoredSha, path: authoredEvidencePath }
+      ])
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.checkedAnchors, 2);
+  });
+});
+
+function documents(anchors: ReadonlyArray<Record<string, string>>) {
+  return [
+    { path: "closeout.md", body: "# Closeout\n" },
+    {
+      path: CODE_DOC_RECONCILIATION_DOCUMENT,
+      body: `${JSON.stringify({
+        schema: "code-doc-reconciliation/v1",
+        taskId: "task-1",
+        records: [{ id: "closeout", ledgerPath: "closeout.md", kind: "closeout", anchors }]
+      }, null, 2)}\n`
+    }
+  ];
+}
+
+function withNestedGitFixture(fn: (fixture: {
+  readonly rootDir: string;
+  readonly authoredRoot: string;
+  readonly outerSha: string;
+  readonly authoredSha: string;
+  readonly authoredEvidencePath: string;
+}) => void): void {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-code-doc-git-roots-"));
+  const authoredRoot = path.join(rootDir, "harness");
+  const authoredEvidencePath = "tasks/task-1/artifacts/impl-report.md";
+  try {
+    initializeRepo(rootDir);
+    writeFileSync(path.join(rootDir, ".gitignore"), "harness/\n", "utf8");
+    writeFileSync(path.join(rootDir, "public-delivery.txt"), "public delivery\n", "utf8");
+    git(rootDir, "add", ".gitignore", "public-delivery.txt");
+    git(rootDir, "commit", "-m", "seed public delivery");
+    const outerSha = git(rootDir, "rev-parse", "HEAD");
+
+    mkdirSync(path.dirname(path.join(authoredRoot, authoredEvidencePath)), { recursive: true });
+    initializeRepo(authoredRoot);
+    writeFileSync(path.join(authoredRoot, authoredEvidencePath), "private harness delivery\n", "utf8");
+    git(authoredRoot, "add", authoredEvidencePath);
+    git(authoredRoot, "commit", "-m", "seed private delivery");
+    const authoredSha = git(authoredRoot, "rev-parse", "HEAD");
+
+    fn({ rootDir, authoredRoot, outerSha, authoredSha, authoredEvidencePath });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function initializeRepo(repoRoot: string): void {
+  mkdirSync(repoRoot, { recursive: true });
+  git(repoRoot, "init");
+}
+
+function git(repoRoot: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", [
+    "-c", "user.name=Harness Test",
+    "-c", "user.email=harness-test@example.invalid",
+    "-c", "commit.gpgsign=false",
+    ...args
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_NOSYSTEM: "1" },
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}

--- a/packages/application/test/code-doc-reconciliation.test.ts
+++ b/packages/application/test/code-doc-reconciliation.test.ts
@@ -41,6 +41,7 @@ test("code-doc reconciliation accepts commit and path anchors and warns on PR st
   const result = evaluateCodeDocReconciliationGate({
     taskId: "task-1",
     rootDir: "/repo",
+    authoredRoot: "/repo/harness",
     versionControlSystem: versionControlSystem({ commits: [goodSha], paths: [`${goodSha}:packages/app.ts`] }),
     documents: documents([{
       id: "A4-001",
@@ -64,6 +65,7 @@ test("code-doc reconciliation rejects fabricated shas", () => {
   const result = evaluateCodeDocReconciliationGate({
     taskId: "task-1",
     rootDir: "/repo",
+    authoredRoot: "/repo/harness",
     versionControlSystem: versionControlSystem({ commits: [goodSha], paths: [] }),
     documents: documents([{
       id: "A4-001",
@@ -81,6 +83,7 @@ test("code-doc reconciliation rejects missing evidence paths at an existing comm
   const result = evaluateCodeDocReconciliationGate({
     taskId: "task-1",
     rootDir: "/repo",
+    authoredRoot: "/repo/harness",
     versionControlSystem: versionControlSystem({ commits: [goodSha], paths: [] }),
     documents: documents([{
       id: "A4-001",
@@ -98,6 +101,7 @@ test("code-doc reconciliation ignores unrelated package documents but requires t
   const result = evaluateCodeDocReconciliationGate({
     taskId: "task-1",
     rootDir: "/repo",
+    authoredRoot: "/repo/harness",
     versionControlSystem: versionControlSystem({ commits: [goodSha], paths: [] }),
     documents: [{ path: "closeout.md", body: "# Closeout" }]
   });
@@ -120,10 +124,12 @@ function documents(records: ReadonlyArray<Record<string, unknown>>) {
   ];
 }
 
-function versionControlSystem(input: { readonly commits: ReadonlyArray<string>; readonly paths: ReadonlyArray<string> }): Pick<VersionControlSystem, "commitExists" | "pathExistsAtCommit"> {
+function versionControlSystem(input: { readonly commits: ReadonlyArray<string>; readonly paths: ReadonlyArray<string> }): Pick<VersionControlSystem, "normalizePath" | "topLevel" | "commitExists" | "pathExistsAtCommit"> {
   const commits = new Set(input.commits);
   const paths = new Set(input.paths);
   return {
+    normalizePath: (inputPath) => inputPath,
+    topLevel: (inputPath) => inputPath,
     commitExists: (_repoRoot, sha) => commits.has(sha),
     pathExistsAtCommit: (_repoRoot, sha, relativePath) => paths.has(`${sha}:${relativePath}`)
   };

--- a/packages/application/test/task-lifecycle-write-failure.test.ts
+++ b/packages/application/test/task-lifecycle-write-failure.test.ts
@@ -370,8 +370,10 @@ function validCodeDocAnchors(): string {
   }, null, 2)}\n`;
 }
 
-function codeDocVersionControlSystem(): Pick<VersionControlSystem, "commitExists" | "pathExistsAtCommit"> {
+function codeDocVersionControlSystem(): Pick<VersionControlSystem, "normalizePath" | "topLevel" | "commitExists" | "pathExistsAtCommit"> {
   return {
+    normalizePath: (inputPath) => inputPath,
+    topLevel: (inputPath) => inputPath,
     commitExists: (_repoRoot, sha) => sha === codeDocSha,
     pathExistsAtCommit: () => true
   };

--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { Effect } from "effect";
 import { CODE_DOC_RECONCILIATION_DOCUMENT, evaluateCodeDocReconciliationGate, makeExecutionCompletionService, makeTaskLifecycleOrchestrator, renderCodeDocReconciliationDraft, type TaskLifecycleResult } from "../../../../application/src/index.ts";
-import { makeLocalVersionControlSystem, taskDocumentPath } from "../../../../kernel/src/index.ts";
+import { makeLocalVersionControlSystem, resolveHarnessLayout, taskDocumentPath } from "../../../../kernel/src/index.ts";
 import { cliError, CliErrorCode, isCliErrorCode, type CliErrorCode as CliErrorCodeValue } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
 import type { CommandRunner } from "../../cli/runner-registry.ts";
@@ -97,6 +97,7 @@ function runTaskCodeDocReconcile(
       taskId: action.taskId,
       documents,
       rootDir: context.rootDir,
+      authoredRoot: resolveHarnessLayout(context.layoutInput).authoredRoot,
       versionControlSystem: makeLocalVersionControlSystem()
     });
     if (!evaluation.ok) {

--- a/packages/kernel/src/git/code-doc-git-evidence.ts
+++ b/packages/kernel/src/git/code-doc-git-evidence.ts
@@ -1,0 +1,63 @@
+import type { VersionControlSystem } from "../ports/version-control-system.ts";
+
+type CodeDocGitEvidenceVersionControlSystem = Pick<
+  VersionControlSystem,
+  "normalizePath" | "topLevel" | "commitExists" | "pathExistsAtCommit"
+>;
+
+export interface CodeDocGitEvidence {
+  readonly sha: string;
+  readonly path?: string;
+}
+
+export type CodeDocGitEvidenceResolution =
+  | { readonly ok: true; readonly repoRoot: string }
+  | { readonly ok: false; readonly reason: "commit-missing" | "path-missing" };
+
+export interface CodeDocGitEvidenceResolver {
+  readonly candidateRoots: ReadonlyArray<string>;
+  readonly resolve: (evidence: CodeDocGitEvidence) => CodeDocGitEvidenceResolution;
+}
+
+export function makeCodeDocGitEvidenceResolver(
+  input: { readonly rootDir: string; readonly authoredRoot: string },
+  versionControlSystem: CodeDocGitEvidenceVersionControlSystem
+): CodeDocGitEvidenceResolver {
+  const candidateRoots = uniqueRepoRoots([
+    versionControlSystem.topLevel(input.rootDir),
+    versionControlSystem.topLevel(input.authoredRoot)
+  ], versionControlSystem);
+
+  return {
+    candidateRoots,
+    resolve: (evidence) => {
+      const commitRoots = candidateRoots.filter((repoRoot) =>
+        versionControlSystem.commitExists(repoRoot, evidence.sha)
+      );
+      if (commitRoots.length === 0) return { ok: false, reason: "commit-missing" };
+      if (evidence.path === undefined) return { ok: true, repoRoot: commitRoots[0]! };
+      const pathRoot = commitRoots.find((repoRoot) =>
+        versionControlSystem.pathExistsAtCommit(repoRoot, evidence.sha, evidence.path!)
+      );
+      return pathRoot
+        ? { ok: true, repoRoot: pathRoot }
+        : { ok: false, reason: "path-missing" };
+    }
+  };
+}
+
+function uniqueRepoRoots(
+  roots: ReadonlyArray<string | null>,
+  versionControlSystem: Pick<VersionControlSystem, "normalizePath">
+): ReadonlyArray<string> {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const root of roots) {
+    if (root === null) continue;
+    const normalized = versionControlSystem.normalizePath(root);
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    unique.push(root);
+  }
+  return unique;
+}

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -24,6 +24,7 @@ export {
   decisionContentCanonicalization
 } from "./integrity/decision-content-digest.ts";
 export { validateOutputEvidence } from "./local/output-evidence-validator.ts";
+export { makeCodeDocGitEvidenceResolver } from "./git/code-doc-git-evidence.ts";
 export * from "./layout/index.ts";
 export * from "./markdown/frontmatter.ts";
 export * from "./ports/artifact-store-writer.ts";

--- a/packages/kernel/src/store/write-journal-code-doc-policy.ts
+++ b/packages/kernel/src/store/write-journal-code-doc-policy.ts
@@ -2,6 +2,7 @@ import type { DocumentWrite } from "../ports/artifact-store-writer.ts";
 import type { VersionControlSystem } from "../ports/version-control-system.ts";
 import type { WriteOp } from "../ports/write-coordinator.ts";
 import { normalizeRelativeDocumentPath } from "../layout/index.ts";
+import { makeCodeDocGitEvidenceResolver } from "../git/code-doc-git-evidence.ts";
 import { rejectWrite } from "./write-journal-rejection.ts";
 import { taskIdForWriteOp } from "./write-journal-entity.ts";
 
@@ -47,19 +48,24 @@ export function assertReservedCodeDocWrite(
 
 export function assertCodeDocGitEvidence(
   rootDir: string,
+  authoredRoot: string,
   op: WriteOp,
   versionControlSystem: VersionControlSystem
 ): void {
   if (op.kind !== "code_doc_reconcile") return;
   const document = parseAndValidateDocument(documentWrite(op), op);
-  const repoRoot = versionControlSystem.topLevel(rootDir) ?? rootDir;
+  const gitEvidence = makeCodeDocGitEvidenceResolver({ rootDir, authoredRoot }, versionControlSystem);
   for (const record of document.records) {
     for (const anchor of record.anchors) {
       if (!anchor.sha) continue;
-      if (!versionControlSystem.commitExists(repoRoot, anchor.sha)) {
+      const resolution = gitEvidence.resolve({
+        sha: anchor.sha,
+        ...(anchor.kind === "path" ? { path: anchor.path! } : {})
+      });
+      if (!resolution.ok && resolution.reason === "commit-missing") {
         rejectWrite(`code-doc anchor commit does not exist: ${anchor.sha}`, op.entityId);
       }
-      if (anchor.kind === "path" && !versionControlSystem.pathExistsAtCommit(repoRoot, anchor.sha, anchor.path!)) {
+      if (!resolution.ok) {
         rejectWrite(`code-doc anchor path does not exist at ${anchor.sha}: ${anchor.path}`, op.entityId);
       }
     }

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -373,7 +373,7 @@ function createJournalRecord(rootDir: string, journalPath: string, op: {
 function preflightWriteOp(rootDir: string, rootInput: HarnessLayoutInput, op: WriteOp, versionControlSystem?: VersionControlSystem): void {
   const vcs = versionControlSystem ?? makeLocalVersionControlSystem();
   const plan = assertCommitPlanAddable(rootDir, writeOpTouchedPaths(rootInput, op), rootInput, { versionControlSystem: vcs });
-  assertCodeDocGitEvidence(rootDir, op, vcs);
+  assertCodeDocGitEvidence(rootDir, resolveHarnessLayout(rootInput).authoredRoot, op, vcs);
   if (op.kind === "task_tree_stage" && plan) {
     assertNoUncoordinatedCodeDocChange(op, vcs.workingTreeFiles(plan.repoRoot, plan.relativePaths));
   }

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -144,6 +144,7 @@ const publicRuntimeSurface = [
   "isTaskWorkKind",
   "isTerminalStatus",
   "listTaskIndexPaths",
+  "makeCodeDocGitEvidenceResolver",
   "makeJournaledWriteCoordinator",
   "makeLocalLockRegistry",
   "makeLocalVersionControlSystem",

--- a/packages/kernel/test/store/code-doc-git-evidence.test.ts
+++ b/packages/kernel/test/store/code-doc-git-evidence.test.ts
@@ -1,0 +1,104 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import { taskEntityId } from "../../src/domain/index.ts";
+import { makeJournaledWriteCoordinator } from "../../src/store/index.ts";
+import { makeLocalVersionControlSystem } from "../../src/store/local-version-control-system.ts";
+import { withTempStore } from "./helpers.ts";
+
+test("WriteCoordinator code-doc preflight accepts a commit from the private authored repository", () => {
+  withTempStore((rootDir) => {
+    const fixture = initializeNestedGitFixture(rootDir);
+    const local = makeLocalVersionControlSystem();
+    assert.equal(local.commitExists(rootDir, fixture.authoredSha), false, "the old outer-root lookup reproduces the missing commit");
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+
+    const ack = Effect.runSync(coordinator.enqueue(codeDocOp(
+      "private-code-doc",
+      [{ kind: "commit", sha: fixture.authoredSha }]
+    )));
+
+    assert.equal(ack.accepted, true);
+  });
+});
+
+test("WriteCoordinator code-doc preflight resolves mixed outer and authored repository anchors", () => {
+  withTempStore((rootDir) => {
+    const fixture = initializeNestedGitFixture(rootDir);
+    const local = makeLocalVersionControlSystem();
+    assert.equal(local.commitExists(rootDir, fixture.authoredSha), false);
+    assert.equal(local.commitExists(fixture.authoredRoot, fixture.outerSha), false);
+    const coordinator = makeJournaledWriteCoordinator({ rootDir });
+
+    const ack = Effect.runSync(coordinator.enqueue(codeDocOp("mixed-code-doc", [
+      { kind: "commit", sha: fixture.outerSha },
+      { kind: "path", sha: fixture.authoredSha, path: fixture.authoredEvidencePath }
+    ])));
+
+    assert.equal(ack.accepted, true);
+  });
+});
+
+function codeDocOp(opId: string, anchors: ReadonlyArray<Record<string, string>>) {
+  return {
+    opId,
+    entityId: taskEntityId("task-1"),
+    kind: "code_doc_reconcile" as const,
+    payload: {
+      path: "code-doc-anchors.json",
+      body: `${JSON.stringify({
+        schema: "code-doc-reconciliation/v1",
+        taskId: "task-1",
+        records: [{ id: "closeout", ledgerPath: "closeout.md", kind: "closeout", anchors }]
+      }, null, 2)}\n`
+    }
+  };
+}
+
+function initializeNestedGitFixture(rootDir: string): {
+  readonly authoredRoot: string;
+  readonly outerSha: string;
+  readonly authoredSha: string;
+  readonly authoredEvidencePath: string;
+} {
+  const authoredRoot = path.join(rootDir, "harness");
+  const authoredEvidencePath = "tasks/task-1/artifacts/impl-report.md";
+  initializeGitRepository(rootDir);
+  writeFileSync(path.join(rootDir, ".gitignore"), "harness/\n", "utf8");
+  writeFileSync(path.join(rootDir, "public-delivery.txt"), "public delivery\n", "utf8");
+  runHermeticGit(rootDir, "add", ".gitignore", "public-delivery.txt");
+  runHermeticGit(rootDir, "commit", "-m", "seed public delivery");
+  const outerSha = runHermeticGit(rootDir, "rev-parse", "HEAD");
+
+  mkdirSync(path.dirname(path.join(authoredRoot, authoredEvidencePath)), { recursive: true });
+  initializeGitRepository(authoredRoot);
+  writeFileSync(path.join(authoredRoot, "tasks/task-1/closeout.md"), "# Closeout\n", "utf8");
+  writeFileSync(path.join(authoredRoot, authoredEvidencePath), "private harness delivery\n", "utf8");
+  runHermeticGit(authoredRoot, "add", "tasks/task-1/closeout.md", authoredEvidencePath);
+  runHermeticGit(authoredRoot, "commit", "-m", "seed private delivery");
+  const authoredSha = runHermeticGit(authoredRoot, "rev-parse", "HEAD");
+  return { authoredRoot, outerSha, authoredSha, authoredEvidencePath };
+}
+
+function initializeGitRepository(repoRoot: string): void {
+  mkdirSync(repoRoot, { recursive: true });
+  runHermeticGit(repoRoot, "init");
+}
+
+function runHermeticGit(repoRoot: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", [
+    "-c", "user.name=Harness Test",
+    "-c", "user.email=harness-test@example.invalid",
+    "-c", "commit.gpgsign=false",
+    ...args
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_NOSYSTEM: "1" },
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}


### PR DESCRIPTION
# English

## Summary

Fixes the code-doc reconcile wrong-root defect (task_01KX8FR4WTAV5HB9WC6SC74AE3): both the completion gate and the WriteCoordinator preflight resolved every commit/path anchor against the outer public repo only, so anchors referencing commits in the private authored harness repo (a separate git history) were rejected as `missing commit`. This structurally blocked pure-ledger tasks from completing — e.g. the KTY P1 bootstrap task's reconcile anchored private commit `881b06b4` and could not pass the gate.

Gate semantics ruled in dec_01KXA2H6W5K4HGSR55ST77N4AE: this gate's invariant is SHA reference integrity — both truth repos are legitimate evidence surfaces and dangling references stay rejected (fail-closed). It is not a delivery-repository-ownership proof; that obligation belongs to the completionGates contract line and is explicitly recorded as rejected-for-this-fix (RJ1).

## What Changed

- `packages/kernel/src/git/code-doc-git-evidence.ts` (new): single shared `makeCodeDocGitEvidenceResolver`. Candidate roots = `[topLevel(rootDir), topLevel(authoredRoot)]`, deduped by normalized path. A commit anchor resolves if the SHA exists in any candidate repo; if in none, fail-closed `commit-missing`. Path anchors are checked only inside repos that contain the SHA; if the path exists in none of them, fail-closed `path-missing`.
- `packages/application/src/code-doc-reconciliation.ts`: the completion gate routes all three anchor branches (commit, path, generic sha) through the resolver; `authoredRoot` becomes a required input.
- `packages/application/src/task-lifecycle-orchestrator.ts` + `packages/cli/src/commands/core/task-gates.ts`: both callers derive `authoredRoot` from `resolveHarnessLayout` (layout overrides respected).
- `packages/kernel/src/store/write-journal-code-doc-policy.ts` + `write-journal-coordinator.ts`: the WriteCoordinator preflight uses the same resolver — the two enforcement paths can no longer diverge.
- Tests: new dual-git-root fixtures in `packages/application/test/code-doc-reconciliation-git-roots.test.ts` and `packages/kernel/test/store/code-doc-git-evidence.test.ts` (red/green verified: restoring the old outer-only lookup fails 4 cross-root assertions); public-surface contract updated for the new kernel export.

## Task And Scope

- Harness task: task_01KX8FR4WTAV5HB9WC6SC74AE3
- Branch: fix/code-doc-reconcile-git-root
- Public scope: kernel git-evidence resolver + code-doc gate/preflight wiring + regressions
- Private planning/evidence updated: yes (implementation report in the task package)
- Out of scope: task-level delivery-repository obligation (`deliveryRepositories`) — explicitly deferred to the completionGates contract line per dec_01KXA2H6W5K4HGSR55ST77N4AE RJ1; no CLI parser, anchor schema, or completionGates list changes

## Version Impact

- Version: no version change because this is a pre-release workspace fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no (gate semantics preserved per decision; fail-closed retained; no CI/gate config changes)
- Protected surface scope: not applicable
- Authority: dec_01KXA2H6W5K4HGSR55ST77N4AE (gate-semantics ruling) + task_01KX8FR4WTAV5HB9WC6SC74AE3
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: delivery-repository obligation deferred to the completionGates contract line (recorded in the decision)

## Verification

- Base `origin/main` SHA: d1836700b781192612f49871dfa6a665bc8d651f
- Branch merge-base with `origin/main`: d1836700b781192612f49871dfa6a665bc8d651f
- Last `git fetch origin` time: 2026-07-12 (before commit)
- Sync method: none needed
- Public diff command: `git diff origin/main...fix/code-doc-reconcile-git-root`
- Private evidence commit/path: harness/tasks/task_01KX8FR4WTAV5HB9WC6SC74AE3-code-doc-reconcile-git-sha-complete/artifacts/impl-report-codex.md
- Reviewer evidence path: same as above
- GitHub Actions `rewrite-ci` run URL: pending (populated by CI on this PR)
- [x] `npm ci` (worker environment)
- [x] `git diff --check`
- [x] `npm run check` (exit 0 on HEAD 37368de: typecheck, eslint, Node tests, GUI tests, 35 manifest gates)
- [x] `npm run typecheck` (via check)
- [x] `npm test` (via check; targeted 27/27 including new dual-root fixtures)
- [x] `npm run harness:check-import-boundaries` (via check)
- [x] `npm run harness:scan-forbidden-symbols` (via check)
- [x] `npm run harness:check-private-boundary` (via check)
- [x] `npm run harness:check-package-policy` (via check)
- [x] `npm run harness:check-implementation-contracts` (via check)
- [x] `npm run harness:check-schema-contracts` (via check)
- [x] `npm run harness:check-legacy-intake-readiness` (via check)
- [x] `npm run harness:smoke-cli-package` (via check)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: none

## Review Evidence

- Self-review: worker red/green contrast (old outer-only behavior fails 4 new cross-root assertions; resolver passes)
- Reviewer subagent: independent review during implementation raised the delivery-obligation concern; escalated via checkpoint and adjudicated in dec_01KXA2H6W5K4HGSR55ST77N4AE before commit
- Human review: pending on this PR
- Blocking findings: none (the raised concern was ruled a new gate-semantics line, not a weakening of this gate)

## Residual Risk

- The gate guarantees SHA/path reference integrity across candidate evidence repos; it does not prove delivery-repository ownership — this is the explicit boundary recorded in dec_01KXA2H6W5K4HGSR55ST77N4AE.

## References

- Task: task_01KX8FR4WTAV5HB9WC6SC74AE3
- Evidence: harness/tasks/task_01KX8FR4WTAV5HB9WC6SC74AE3-code-doc-reconcile-git-sha-complete/artifacts/impl-report-codex.md
- Review: dec_01KXA2H6W5K4HGSR55ST77N4AE

---

# 中文

## 概要

修复 code-doc reconcile 错 git 根缺陷（task_01KX8FR4WTAV5HB9WC6SC74AE3）：完成门与 WriteCoordinator preflight 此前把所有 commit/path anchor 都只在外层公开仓解析，导致引用私有 authored harness 仓（独立 git 历史）commit 的 anchor 被误报 `missing commit`。这结构性地卡死纯账本任务收口——例如 KTY P1 bootstrap 任务的 reconcile 锚私有 commit `881b06b4`，无法过门。

门语义已裁决（dec_01KXA2H6W5K4HGSR55ST77N4AE）：该门的不变量是 SHA 引用完整性——两个真相仓都是合法证据面，悬空引用仍被拒（fail-closed）；它不是交付仓归属证明——该 obligation 归 completionGates 契约线，已作为 RJ1 显式留痕拒绝搭车。

## 改动内容

- `packages/kernel/src/git/code-doc-git-evidence.ts`（新增）：单一共享 `makeCodeDocGitEvidenceResolver`。候选仓根 = `[topLevel(rootDir), topLevel(authoredRoot)]`，按 normalized path 去重。commit anchor 在任一候选仓存在即解析成功；两仓皆无 → fail-closed `commit-missing`。path anchor 只在包含该 SHA 的仓内检查；所有所属仓都缺 path → fail-closed `path-missing`。
- `packages/application/src/code-doc-reconciliation.ts`：完成门三个 anchor 分支（commit、path、通用 sha）全部走 resolver；`authoredRoot` 成为必需输入。
- `packages/application/src/task-lifecycle-orchestrator.ts` + `packages/cli/src/commands/core/task-gates.ts`：两处调用方均从 `resolveHarnessLayout` 派生 `authoredRoot`（尊重 layout overrides）。
- `packages/kernel/src/store/write-journal-code-doc-policy.ts` + `write-journal-coordinator.ts`：WriteCoordinator preflight 共用同一 resolver——两条执法路径不再可能分叉。
- 测试：`packages/application/test/code-doc-reconciliation-git-roots.test.ts` 与 `packages/kernel/test/store/code-doc-git-evidence.test.ts` 新增真实双层 git fixture（红绿实证：恢复旧 outer-only 行为 4 个跨根断言失败）；public-surface 契约测试登记新 kernel 导出。

## 任务与范围

- Harness 任务：task_01KX8FR4WTAV5HB9WC6SC74AE3
- 分支：fix/code-doc-reconcile-git-root
- 公开范围：kernel git-evidence resolver + code-doc 门/preflight 接线 + 回归测试
- 私有计划 / 证据是否已更新：yes（实现报告在任务包）
- 范围外：任务级交付仓 obligation（`deliveryRepositories`）——按 dec_01KXA2H6W5K4HGSR55ST77N4AE RJ1 显式推迟到 completionGates 契约线；未改 CLI parser、anchor schema、completionGates 列表

## 版本影响

- 版本：不改版本，原因是 pre-release workspace 修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no（门语义按决策保持；fail-closed 保留；未改 CI/gate 配置）
- protected surface 范围：不适用
- 依据：dec_01KXA2H6W5K4HGSR55ST77N4AE（门语义裁决）+ task_01KX8FR4WTAV5HB9WC6SC74AE3
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：交付仓 obligation 推迟至 completionGates 契约线（已记录于决策）

## 验证

- `origin/main` 基准 SHA：d1836700b781192612f49871dfa6a665bc8d651f
- 当前分支与 `origin/main` 的 merge-base：d1836700b781192612f49871dfa6a665bc8d651f
- 最近一次 `git fetch origin` 时间：2026-07-12（提交前）
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...fix/code-doc-reconcile-git-root`
- 私有证据 commit / 路径：harness/tasks/task_01KX8FR4WTAV5HB9WC6SC74AE3-code-doc-reconcile-git-sha-complete/artifacts/impl-report-codex.md
- Reviewer 证据路径：同上
- GitHub Actions `rewrite-ci` run URL：pending（本 PR CI 产生后回填）
- [x] `npm ci`（worker 环境）
- [x] `git diff --check`
- [x] `npm run check`（HEAD 37368de exit 0：typecheck、eslint、Node、GUI、35 manifest gates）
- [x] `npm run typecheck`（含于 check）
- [x] `npm test`（含于 check；定向 27/27 含新增双根 fixture）
- [x] `npm run harness:check-import-boundaries`（含于 check）
- [x] `npm run harness:scan-forbidden-symbols`（含于 check）
- [x] `npm run harness:check-private-boundary`（含于 check）
- [x] `npm run harness:check-package-policy`（含于 check）
- [x] `npm run harness:check-implementation-contracts`（含于 check）
- [x] `npm run harness:check-schema-contracts`（含于 check）
- [x] `npm run harness:check-legacy-intake-readiness`（含于 check）
- [x] `npm run harness:smoke-cli-package`（含于 check）
- [ ] GitHub Actions `rewrite-ci` passed
- 未执行：无

## Review Evidence

- Self-review：worker 红绿对照（恢复旧 outer-only 行为 4 个新断言失败；resolver 下通过）
- Reviewer subagent：实现期独立复审提出交付 obligation 疑虑；经 checkpoint 上报并在提交前由 dec_01KXA2H6W5K4HGSR55ST77N4AE 裁决
- Human review：本 PR 待审
- Blocking findings：无（疑虑被裁定为新门语义线，非本门削弱）

## 残余风险

- 该门保证候选证据仓内 SHA/path 引用完整性，不证明交付仓归属——这是 dec_01KXA2H6W5K4HGSR55ST77N4AE 的显式边界。

## References

- Task: task_01KX8FR4WTAV5HB9WC6SC74AE3
- Evidence: harness/tasks/task_01KX8FR4WTAV5HB9WC6SC74AE3-code-doc-reconcile-git-sha-complete/artifacts/impl-report-codex.md
- Review: dec_01KXA2H6W5K4HGSR55ST77N4AE
