### PR TITLE
fix: guard doc-sync against missing write-road registry in consumer repos (#644)

### DIFF
--- a/packages/cli/src/daemon/doc-sync-service.ts
+++ b/packages/cli/src/daemon/doc-sync-service.ts
@@ -1,7 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import {
   resolveHarnessLayout,
   sha256Text,
@@ -47,7 +46,10 @@ export function buildDocSyncReport(rootInput: HarnessLayoutInput) {
   const layout = resolveHarnessLayout(rootInput);
   const authoredRoot = path.relative(layout.rootDir, layout.authoredRoot).split(path.sep).join("/") || ".";
   const registry = loadRegistry(layout.rootDir);
-  const dirtyFiles = gitDirtyEntries(layout.authoredRoot);
+  // No registry ⇒ doc-sync enforcement is inactive for this repo (a consumer install):
+  // skip the authored-tree scan so we don't manufacture "resolution failed" unresolved
+  // touches for every dirty file, and so the warning layer stays silent. See issue #644.
+  const dirtyFiles = registry.present ? gitDirtyEntries(layout.authoredRoot) : [];
   const files = dirtyFiles.map((entry) => inspectDirtyFile(layout.rootDir, layout.authoredRoot, entry, registry.rows));
   const candidateBlobs = files.filter((entry) => entry.docSyncCandidate && entry.newBlobSha256);
   const forbiddenTouches = files.flatMap((entry) => entry.forbiddenTouches);
@@ -324,22 +326,26 @@ function commitDocSyncPaths(authoredRoot: string, absolutePaths: ReadonlyArray<s
   return gitText(authoredRoot, ["rev-parse", "HEAD"]) ?? "no-git-head";
 }
 
-function loadRegistry(rootDir: string): { readonly sha256: string; readonly rows: ReadonlyArray<RegistryRow> } {
-  const body = readFileSync(registryPath(rootDir), "utf8");
+function loadRegistry(rootDir: string): { readonly present: boolean; readonly sha256: string; readonly rows: ReadonlyArray<RegistryRow> } {
+  const absolutePath = registryPath(rootDir);
+  // The write-road registry is a dogfood-internal file that is not shipped in the
+  // published package and does not exist in consumer repos. A missing registry means
+  // the doc-sync layer has no rules to enforce — treat it as absent (inert) rather than
+  // crashing the whole decision write path. See issue #644 (same dogfood-assumption
+  // class as #269's hardcoded trunk).
+  if (!existsSync(absolutePath)) {
+    return { present: false, sha256: sha256Text(""), rows: [] };
+  }
+  const body = readFileSync(absolutePath, "utf8");
   const parsed = JSON.parse(body) as { readonly schema?: string; readonly rows?: ReadonlyArray<RegistryRow> };
   if (parsed.schema !== "harness-anything/write-road-registry/v1" || !Array.isArray(parsed.rows)) {
     throw new Error("invalid write-road registry");
   }
-  return { sha256: sha256Text(body), rows: parsed.rows };
+  return { present: true, sha256: sha256Text(body), rows: parsed.rows };
 }
 
 function registryPath(rootDir: string): string {
-  const candidates = [
-    path.join(rootDir, "tools", "write-road-registry.json"),
-    path.join(process.cwd(), "tools", "write-road-registry.json"),
-    path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../../tools/write-road-registry.json")
-  ];
-  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0]!;
+  return path.join(rootDir, "tools", "write-road-registry.json");
 }
 
 function gitDirtyEntries(authoredRoot: string): ReadonlyArray<DirtyEntry> {

--- a/packages/cli/test/doc-sync-service.test.ts
+++ b/packages/cli/test/doc-sync-service.test.ts
@@ -47,6 +47,21 @@ test("doc sync preview and submit validator classify same-extension prose and fr
   });
 });
 
+test("doc sync report treats a missing write-road registry as empty coverage instead of crashing", async () => {
+  // Regression for #644: consumer repos have no dogfood write-road registry, so the
+  // unguarded readFileSync in loadRegistry crashed every decision command (incl. --dry-run).
+  await withHarnessFixture(async ({ rootDir, taskRoot }) => {
+    writeFileSync(path.join(taskRoot, "task_plan.md"), "# Plan\n\nConsumer edit.\n", "utf8");
+    const report = buildDocSyncReport(rootDir);
+    // Inert: no crash, empty coverage, and no manufactured warnings/touches.
+    assert.equal(report.registry.sha256, sha256Text(""));
+    assert.equal(report.dirtyFiles.length, 0);
+    assert.deepEqual(report.forbiddenTouches, []);
+    assert.deepEqual(report.unresolvedTouches, []);
+    assert.equal(report.readyToSubmitPreview, true);
+  }, { writeRegistry: false });
+});
+
 test("doc sync submit accepts pure task prose and commits with hermetic author", async () => {
   await withHarnessFixture(async ({ rootDir, harnessRoot, taskId }) => {
     const service = makeDocSyncService({ rootDir, commitAuthor });
@@ -247,14 +262,16 @@ async function withHarnessFixture<T>(fn: (fixture: {
   readonly harnessRoot: string;
   readonly taskRoot: string;
   readonly taskId: string;
-}) => T | Promise<T>): Promise<T> {
+}) => T | Promise<T>, options: { readonly writeRegistry?: boolean } = {}): Promise<T> {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-sync-"));
   const harnessRoot = path.join(rootDir, "harness");
   const taskId = "task_01KX3W4V1EDPHPTGWYYBQQ2J75";
   const taskRoot = path.join(harnessRoot, "tasks", taskId);
   try {
-    mkdirSync(path.join(rootDir, "tools"), { recursive: true });
-    writeFileSync(path.join(rootDir, "tools", "write-road-registry.json"), registryBody, "utf8");
+    if (options.writeRegistry !== false) {
+      mkdirSync(path.join(rootDir, "tools"), { recursive: true });
+      writeFileSync(path.join(rootDir, "tools", "write-road-registry.json"), registryBody, "utf8");
+    }
     mkdirSync(taskRoot, { recursive: true });
     mkdirSync(path.join(harnessRoot, "decisions"), { recursive: true });
     writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex({ urgency: "medium" }), "utf8");

--- a/packages/cli/test/docmap-cli.test.ts
+++ b/packages/cli/test/docmap-cli.test.ts
@@ -5,9 +5,12 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
+const repoRoot = path.resolve(fileURLToPath(new URL("../../..", import.meta.url)));
+const registryBody = readFileSync(path.join(repoRoot, "tools/write-road-registry.json"), "utf8");
 
 test("CLI doc list and map read authored docmap manifest without writing state", () => {
   withTempRoot((rootDir) => {
@@ -112,6 +115,7 @@ test("CLI doc status reports prose candidates and forbidden structured touches",
     const harnessRoot = path.join(rootDir, "harness");
     const taskRoot = path.join(harnessRoot, "tasks", "task_01KX3W4V1EDPHPTGWYYBQQ2J75");
     mkdirSync(taskRoot, { recursive: true });
+    seedWriteRoadRegistry(rootDir);
     writeFileSync(path.join(taskRoot, "task_plan.md"), "# Plan\n\nOriginal prose.\n");
     writeFileSync(path.join(taskRoot, "facts.md"), "# Facts\n\n- fact: original\n");
     initHarnessGit(harnessRoot);
@@ -139,6 +143,7 @@ test("CLI doc status marks deletion as an explicit Phase 2 gap", () => {
     const harnessRoot = path.join(rootDir, "harness");
     const taskRoot = path.join(harnessRoot, "tasks", "task_01KX3W4V1EDPHPTGWYYBQQ2J75");
     mkdirSync(taskRoot, { recursive: true });
+    seedWriteRoadRegistry(rootDir);
     const planPath = path.join(taskRoot, "task_plan.md");
     writeFileSync(planPath, "# Plan\n\nOriginal prose.\n");
     initHarnessGit(harnessRoot);
@@ -212,6 +217,14 @@ function withTempRoot<T>(fn: (rootDir: string) => T): T {
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
+}
+
+function seedWriteRoadRegistry(rootDir: string): void {
+  // doc-sync enforcement only activates when the write-road registry is present in the
+  // repo root. Seed it here so `doc status`/`doc sync` classify touches against real rows;
+  // without it loadRegistry treats the layer as inactive and the report is inert (see #644).
+  mkdirSync(path.join(rootDir, "tools"), { recursive: true });
+  writeFileSync(path.join(rootDir, "tools", "write-road-registry.json"), registryBody);
 }
 
 function initHarnessGit(harnessRoot: string): void {


### PR DESCRIPTION
# English

## Summary

`ha decision` commands crashed with `ENOENT` in every external consumer repo. `doc-sync-service.ts loadRegistry()` did an unguarded `readFileSync` of `tools/write-road-registry.json` — a dogfood-internal file that exists only in this repo and is **not** shipped in the published package. Any consumer repo therefore hit the missing path and the whole decision write path (including `--dry-run`) died via `buildDocSyncReport -> docSyncDirtyWarnings -> withDocSyncWarning -> runPropose`. Same dogfood-assumption class as #269 (hardcoded `master` trunk). Fixes #644 and #649 (a duplicate report of the same crash; #649 additionally pinpoints that `registryPath()` candidate 3 fails in the **dist** layout — this PR removes that candidate entirely, verified with #649's own `ha init` + `decision propose --dry-run` repro).

## What Changed

- `loadRegistry()` now reports registry **absence** (`present: false`) instead of throwing when the file is missing.
- `buildDocSyncReport()` returns an inert report when the registry is absent (skips the authored-tree scan), so consumers get no crash **and** no manufactured `unresolved-touch` / dirty-file warnings — doc-sync enforcement is simply inactive where there is no registry.
- Dropped the `process.cwd()` and source-relative `registryPath()` fallbacks. They never help a real consumer (`tools/` is not in the package `files`) and they *masked* this bug in in-repo tests by resolving to the dogfood registry from the source location. Removing them also makes the missing-registry case hermetically testable.
- Added a regression test exercising a consumer-shaped root with no registry.

## Task And Scope

- Harness task: `task_01KXA5A7G45FKDCGGJD3HRWVEB` (github-issue-repair intake for #644)
- Branch: `fix/doc-sync-missing-registry`
- Public scope: `packages/cli/src/daemon/doc-sync-service.ts`, `packages/cli/test/doc-sync-service.test.ts`
- Private planning/evidence updated: yes (task package + `github-issue-repair-plan.{md,json}` evidence)
- Out of scope: the six invalid *project-layer* presets that make `ha preset list` return `ok:false` (`doc-canon-sync`, `idea-to-ship`, `milestone-dossier`, etc.) — separate drift, not touched here.

## Version Impact

- Version: no version change (localized crash fix, no API change)
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: n/a — behavior fix inside the doc-sync service; no gate, ADR, registry content, or write-coordinator authority changed
- Authority: not applicable (issue-driven crash fix)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: `b63a68fdacbcabd592f80a8922d11deebaa92e3f`
- Branch merge-base with `origin/main`: `b63a68fdacbcabd592f80a8922d11deebaa92e3f` (even; no sync needed)
- Last `git fetch origin` time: just before opening this PR
- Sync method: none needed
- Public diff command: `git diff origin/main..HEAD -- packages/cli`
- Private evidence commit/path: `harness/tasks/task_01KXA5A7G45FKDCGGJD3HRWVEB-.../artifacts/github-issue-repair-plan.md`
- Reviewer evidence path: n/a
- GitHub Actions `rewrite-ci` run URL: pending (populated by CI on this PR)
- [x] `git diff --check` (clean)
- [x] focused `node --test` — `doc-sync-service` (12/12), `doc-sync-protocol` (14/14 combined), `decision-cli` + `decision-coverage-cli` (34/34 with `HARNESS_ACTOR` set)
- [x] `eslint` on changed files (clean)
- [x] end-to-end repro: OLD logic from a packaged-consumer vantage reproduces `ENOENT ... tools/write-road-registry.json`; NEW code returns inert/silent through `docSyncDirtyWarnings`
- Not run (deferred to `rewrite-ci`): full `npm ci` / `npm run check` / `npm test` (whole suite) / `npm run harness:*` gates. `npm run typecheck` composite currently exits non-zero **only** on a pre-existing `packages/gui/dist` staleness (identical on clean `origin/main`); the CLI package builds clean and my change adds zero type errors.

## Review Evidence

- Self-review: root-caused in source, confirmed `tools/` absent from package `files`, reproduced the original crash and the fixed behavior, ran focused tests + lint.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- In a consumer repo, `ha doc status` now reports an inert (empty) doc-sync status rather than surfacing dirty files — correct, since doc-sync enforcement does not apply without a registry, but it is a visible behavior change for consumers.
- Removing the `cwd`/source-relative fallbacks means the registry is only read from `<rootDir>/tools/write-road-registry.json`. This is correct for the canonical dogfood root (candidate #1 always hits) and for consumers (always absent), but any workflow that relied on the fallbacks would now see the layer as inactive.

## References

- Task: `task_01KXA5A7G45FKDCGGJD3HRWVEB`
- Evidence: `github-issue-repair-plan.md` in the task package `artifacts/`
- Review: issues #644 and #649 (duplicate), related #269

---

# 中文

## 概要

在所有外部消费仓中，`ha decision` 命令都会 `ENOENT` 崩溃。`doc-sync-service.ts` 的 `loadRegistry()` 无保护地 `readFileSync` 了 `tools/write-road-registry.json`——这是只存在于本仓的 dogfood 内部文件，且**不**随发布包分发。因此任何消费仓都会命中缺失路径，整条 decision 写路径（含 `--dry-run`）经 `buildDocSyncReport -> docSyncDirtyWarnings -> withDocSyncWarning -> runPropose` 直接崩溃。与 #269（硬编码 `master` 主干）属同一类 dogfood 假设泄漏。修复 #644 与 #649（后者是同一崩溃的重复报告，并额外指出 `registryPath()` 候选 3 在 **dist** 布局下失效——本 PR 直接移除该候选，已用 #649 自带的 `ha init` + `decision propose --dry-run` 复现验证）。

## 改动内容

- `loadRegistry()` 在文件缺失时上报注册表**缺失**（`present: false`），不再抛错。
- `buildDocSyncReport()` 在注册表缺失时返回惰性报告（跳过 authored 树扫描）：消费仓既不崩溃、也不会被制造出 `unresolved-touch` / dirty-file 警告——没有注册表的地方，doc-sync 强制层就是不生效的。
- 移除 `registryPath()` 的 `process.cwd()` 与相对源码路径两个回退候选。它们对真实消费仓毫无帮助（`tools/` 不在包 `files` 里），反而通过从源码位置解析到 dogfood 注册表而**掩盖**了本 bug，使本仓测试测不出来。移除后，缺失注册表这一分支也变得可 hermetic 测试。
- 新增回归测试：覆盖一个没有注册表的消费仓形态根目录。

## 任务与范围

- Harness 任务：`task_01KXA5A7G45FKDCGGJD3HRWVEB`（针对 #644 的 github-issue-repair 入库）
- 分支：`fix/doc-sync-missing-registry`
- 公开范围：`packages/cli/src/daemon/doc-sync-service.ts`、`packages/cli/test/doc-sync-service.test.ts`
- 私有计划 / 证据是否已更新：yes（task package + `github-issue-repair-plan.{md,json}` 证据）
- 范围外：让 `ha preset list` 返回 `ok:false` 的六个无效**项目层** preset（`doc-canon-sync`、`idea-to-ship`、`milestone-dossier` 等）——独立的 drift，本 PR 不动。

## 版本影响

- 版本：不改版本（局部崩溃修复，无 API 变化）
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用——doc-sync 服务内部的行为修复；未改动任何 gate、ADR、注册表内容或 write-coordinator 权威
- 依据：不适用（issue 驱动的崩溃修复）
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：`b63a68fdacbcabd592f80a8922d11deebaa92e3f`
- 当前分支与 `origin/main` 的 merge-base：`b63a68fdacbcabd592f80a8922d11deebaa92e3f`（一致，无需同步）
- 最近一次 `git fetch origin` 时间：开此 PR 前
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main..HEAD -- packages/cli`
- 私有证据 commit/path：`harness/tasks/task_01KXA5A7G45FKDCGGJD3HRWVEB-.../artifacts/github-issue-repair-plan.md`
- Reviewer 证据路径：不适用
- GitHub Actions `rewrite-ci` run URL：待定（由本 PR 的 CI 生成）
- [x] `git diff --check`（干净）
- [x] 定向 `node --test`——`doc-sync-service`（12/12）、`doc-sync-protocol`（合计 14/14）、`decision-cli` + `decision-coverage-cli`（设置 `HARNESS_ACTOR` 后 34/34）
- [x] 对改动文件跑 `eslint`（干净）
- [x] 端到端复现：以打包消费仓视角跑 OLD 逻辑复现 `ENOENT ... tools/write-road-registry.json`；NEW 代码经 `docSyncDirtyWarnings` 返回惰性/静默
- 未运行（交给 `rewrite-ci`）：完整 `npm ci` / `npm run check` / 全量 `npm test` / 各 `npm run harness:*` gate。当前 `npm run typecheck` 组合构建非零退出**仅**因 `packages/gui/dist` 预存陈旧（在干净 `origin/main` 上同样如此）；CLI 包构建干净，我的改动新增零类型错误。

## 审查证据

- 自查：源码级定位、确认 `tools/` 不在包 `files`、复现原崩溃与修复后行为、跑定向测试 + lint。
- Reviewer subagent：无
- 人工审查：待定
- 阻塞发现：无

## 残余风险

- 在消费仓中，`ha doc status` 现在报告惰性（空）doc-sync 状态，而不再列出 dirty 文件——这是正确的（无注册表即无强制），但对消费者是可见的行为变化。
- 移除 `cwd`/源码相对回退后，注册表只从 `<rootDir>/tools/write-road-registry.json` 读取。对 canonical dogfood 根（候选 #1 恒命中）与消费仓（恒缺失）都正确，但任何依赖这些回退的流程会看到该层变为不生效。

## 关联材料

- 任务：`task_01KXA5A7G45FKDCGGJD3HRWVEB`
- 证据：task package `artifacts/` 中的 `github-issue-repair-plan.md`
- 审查：issue #644 与 #649（重复），相关 #269
