### PR TITLE
fix: preserve lease executor on daemon writes

### DIFF
--- a/packages/cli/src/composition/actor-attribution.ts
+++ b/packages/cli/src/composition/actor-attribution.ts
@@ -1,5 +1,5 @@
 import type { AuthenticatedActor } from "../../../daemon/src/index.ts";
-import type { TaskHolderPersonPrincipal } from "../../../application/src/index.ts";
+import type { TaskHolderExecutor, TaskHolderPersonPrincipal } from "../../../application/src/index.ts";
 
 export interface CliJournalActor {
   readonly kind: "agent" | "human" | "system";
@@ -16,6 +16,7 @@ export interface CliActorAttribution {
   readonly commitAuthor: CliGitCommitAuthor;
   readonly source: "env" | "flag" | "daemon";
   readonly authenticatedPrincipal?: TaskHolderPersonPrincipal;
+  readonly executor?: TaskHolderExecutor;
 }
 
 export class CliActorAttributionError extends Error {
@@ -54,7 +55,7 @@ export function resolveLocalCliActorAttribution(
   };
 }
 
-export function daemonActorAttribution(actor: AuthenticatedActor): CliActorAttribution {
+export function daemonActorAttribution(actor: AuthenticatedActor, executor: TaskHolderExecutor | null = null): CliActorAttribution {
   const email = actor.primaryEmail?.trim();
   if (!email) {
     throw new CliActorAttributionError(`Daemon actor ${actor.personId} requires primaryEmail for git author attribution.`);
@@ -63,6 +64,7 @@ export function daemonActorAttribution(actor: AuthenticatedActor): CliActorAttri
     actor: { kind: "human", id: actor.personId },
     commitAuthor: { name: actor.displayName, email },
     source: "daemon",
+    ...(executor ? { executor } : {}),
     authenticatedPrincipal: {
       personId: actor.personId,
       displayName: actor.displayName,

--- a/packages/cli/src/composition/local-principal.ts
+++ b/packages/cli/src/composition/local-principal.ts
@@ -23,7 +23,7 @@ export function resolveCliTaskHolderPrincipal(
   attribution: CliActorAttribution
 ): TaskHolderPrincipal {
   const principal = attribution.authenticatedPrincipal ?? readConfiguredLocalPrincipal(rootInput);
-  return taskHolderActor(principal, taskHolderExecutorFromJournalActor(attribution.actor));
+  return taskHolderActor(principal, attribution.executor ?? taskHolderExecutorFromJournalActor(attribution.actor));
 }
 
 export function readConfiguredLocalPrincipal(rootInput: HarnessLayoutInput): TaskHolderPersonPrincipal {

--- a/packages/cli/src/daemon/command-service.ts
+++ b/packages/cli/src/daemon/command-service.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import type { AuthenticatedActor, JsonObject } from "../../../daemon/src/index.ts";
+import type { TaskHolderExecutor } from "../../../application/src/index.ts";
 import type { WriteCoordinator } from "../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../cli/error-codes.ts";
 import { toCommandReceipt, type CommandFailureReceipt, type CommandReceipt } from "../cli/receipt.ts";
@@ -10,7 +11,7 @@ import { runRegisteredCommandWithCliComposition } from "../composition/command-e
 import { makeDaemonQueuedWriteCoordinator, type CliDaemonRuntime } from "./queued-write-coordinator.ts";
 
 export interface CliCommandService {
-  readonly runCommand: (payload?: JsonObject, context?: { readonly actor?: AuthenticatedActor }) => Promise<CommandReceipt | CommandFailureReceipt>;
+  readonly runCommand: (payload?: JsonObject, context?: { readonly actor?: AuthenticatedActor; readonly executor?: TaskHolderExecutor | null }) => Promise<CommandReceipt | CommandFailureReceipt>;
 }
 
 export interface CliCommandServiceOptions {
@@ -26,7 +27,7 @@ export function createCliCommandService(runtime: CliDaemonRuntime, options: CliC
       const daemonActor = context?.actor;
       const sessionId = readSessionId(payload);
       try {
-        const attribution = daemonActor ? daemonActorAttribution(daemonActor) : undefined;
+        const attribution = daemonActor ? daemonActorAttribution(daemonActor, context?.executor) : undefined;
         const result = await runRegisteredCommandWithCliComposition(command, {
           requireProvidedActorAttribution: true,
           ...(attribution ? { actorAttribution: attribution } : {

--- a/packages/cli/test/daemon-lease-executor-cli.test.ts
+++ b/packages/cli/test/daemon-lease-executor-cli.test.ts
@@ -1,0 +1,94 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import {
+  defaultDaemonUserRoot,
+  runDaemonCommand,
+  runRawJson,
+  stopDaemonQuietly,
+  withTempRootAsync
+} from "./helpers/daemon-cli.ts";
+import {
+  forcedCommandRequest,
+  receiptDataString,
+  writeForcedCommandTeamRoster
+} from "./helpers/forced-command-daemon.ts";
+
+test("forced-command progress writes preserve the thin-client executor in the task lease", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = defaultDaemonUserRoot(rootDir);
+    runRawJson(rootDir, ["init"], { HARNESS_ACTOR: "agent:test", HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    const created = runRawJson(rootDir, ["new-task", "--title", "Lease Executor Refresh"], {
+      HARNESS_ACTOR: "agent:test",
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    enableLeaseEnforcement(rootDir);
+    writeForcedCommandTeamRoster(rootDir);
+
+    try {
+      runDaemonCommand(rootDir, ["daemon", "start", "--service", "--json"], { HARNESS_DAEMON_USER_ROOT: userRoot });
+      const taskId = receiptDataString(created, "taskId");
+      const codex = { kind: "agent", id: "codex" } as const;
+      const claude = { kind: "agent", id: "claude-code" } as const;
+      const claimed = await forcedCommandRequest(rootDir, userRoot, "person_alice", "repo.task.claim", {
+        repo: { repoId: "canonical", canonicalRoot: rootDir },
+        payload: { taskId, executor: codex, ttlMs: 60_000 }
+      });
+      assert.equal(claimed.ok, true, JSON.stringify(claimed));
+
+      const progressed = await forcedCommandRequest(rootDir, userRoot, "person_alice", "repo.command.run", {
+        repo: { repoId: "canonical", canonicalRoot: rootDir },
+        payload: {
+          command: {
+            rootDir,
+            json: true,
+            action: { kind: "progress-append", taskId, text: "refresh lease", evidence: [] }
+          },
+          executor: codex
+        }
+      });
+      assert.equal(progressed.ok, true, JSON.stringify(progressed));
+
+      const holder = await forcedCommandRequest(rootDir, userRoot, "person_alice", "repo.task.holder", {
+        repo: { repoId: "canonical", canonicalRoot: rootDir },
+        payload: { taskId }
+      });
+      const effectiveHolder = (((holder.details as Record<string, unknown>).data as Record<string, unknown>).effectiveHolder as Record<string, unknown>);
+      assert.deepEqual(effectiveHolder.executor, codex);
+
+      const collision = await forcedCommandRequest(rootDir, userRoot, "person_bob", "repo.task.claim", {
+        repo: { repoId: "canonical", canonicalRoot: rootDir },
+        payload: { taskId, executor: claude, ttlMs: 60_000 }
+      });
+      assert.equal(collision.ok, false);
+      assert.match((collision.error as { hint?: string }).hint ?? "", /current holder principal=person_alice, executor=agent:codex/u);
+    } finally {
+      stopDaemonQuietly(rootDir, userRoot);
+    }
+  });
+});
+
+function enableLeaseEnforcement(rootDir: string): void {
+  const harnessRoot = path.join(rootDir, "harness");
+  const configPath = path.join(harnessRoot, "harness.yaml");
+  const config = readFileSync(configPath, "utf8");
+  writeFileSync(configPath, `${config.trimEnd()}\n  tasks:\n    leaseEnforcement: true\n`, "utf8");
+  git(harnessRoot, "add", "harness.yaml");
+  git(harnessRoot, "commit", "-m", "test: enable task lease enforcement");
+}
+
+function git(rootDir: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      HOME: path.join(rootDir, ".home"),
+      GIT_CONFIG_GLOBAL: "/dev/null"
+    }
+  }).trim();
+}

--- a/packages/cli/test/daemon-lease-executor-cli.test.ts
+++ b/packages/cli/test/daemon-lease-executor-cli.test.ts
@@ -88,7 +88,11 @@ function git(rootDir: string, ...args: ReadonlyArray<string>): string {
     env: {
       ...process.env,
       HOME: path.join(rootDir, ".home"),
-      GIT_CONFIG_GLOBAL: "/dev/null"
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_AUTHOR_NAME: "Lease Executor Fixture",
+      GIT_AUTHOR_EMAIL: "lease-executor-fixture@example.com",
+      GIT_COMMITTER_NAME: "Lease Executor Fixture",
+      GIT_COMMITTER_EMAIL: "lease-executor-fixture@example.com"
     }
   }).trim();
 }

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -8,6 +8,7 @@ import {
   type DocSyncSubmitRequestV1,
   type DocSyncSubmitResultV1,
   type LocalControllerService,
+  type TaskHolderExecutor,
   type TaskHolderService
 } from "../../../application/src/index.ts";
 import type { RuntimeEventAppendInput } from "../../../application/src/runtime-event-ledger-service.ts";
@@ -59,7 +60,7 @@ export interface DaemonServiceHost {
     readonly getStatus: (context?: DaemonRepoServiceContext) => JsonObject | Promise<JsonObject>;
   };
   readonly CliCommandService?: {
-    readonly runCommand: (payload?: JsonObject, context?: { readonly actor?: AuthenticatedActor; readonly repo?: DaemonRepoNamespace }) => Promise<CommandReceipt | CommandFailureReceipt>;
+    readonly runCommand: (payload?: JsonObject, context?: { readonly actor?: AuthenticatedActor; readonly executor?: TaskHolderExecutor | null; readonly repo?: DaemonRepoNamespace }) => Promise<CommandReceipt | CommandFailureReceipt>;
   };
   readonly DocSyncService?: {
     readonly submit: (request: DocSyncSubmitRequestV1, context?: { readonly actor?: AuthenticatedActor; readonly repo?: DaemonRepoNamespace }) => Promise<DocSyncSubmitResultV1>;
@@ -272,7 +273,7 @@ async function callServiceMethod(
     if (!services.CliCommandService) {
       return failureReceipt(contract.method, "cli_command_service_unavailable", "Daemon command service is not configured.");
     }
-    return services.CliCommandService.runCommand(payload, { actor, repo });
+    return services.CliCommandService.runCommand(payload, { actor, executor: readTaskHolderExecutor(payload), repo });
   }
   if (contract.method === "repo.task.claim" || contract.method === "repo.task.holder" || contract.method === "repo.task.release") {
     return callTaskHolderMethod(contract, payload, services, actor);
@@ -361,7 +362,8 @@ async function validateTaskLeaseForServiceWrite(
   }
   if (!actor) return failureReceipt(contract.method, "actor_required", "Task lease enforcement requires a per-request authenticated actor.");
   try {
-    await services.TaskHolderService.assertActiveLease({ taskId, principal: taskHolderPrincipalFromActor(actor) });
+    const executor = readTaskHolderExecutor(payload);
+    await services.TaskHolderService.assertActiveLease({ taskId, principal: taskHolderPrincipalFromActor(actor, { executor }) });
     return undefined;
   } catch (error) {
     if (isTaskHolderError(error)) {

--- a/packages/daemon/test/task-holder-rpc.test.ts
+++ b/packages/daemon/test/task-holder-rpc.test.ts
@@ -129,6 +129,47 @@ test("task lease enforcement guards daemon task progress API writes when enabled
   }
 });
 
+test("task progress lease refresh and orphan recovery preserve the requesting executor", async () => {
+  const previous = process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
+  const rootDir = createHarnessRoot(["settings:", "  tasks:", "    leaseEnforcement: true"]);
+  let now = new Date("2026-07-10T00:00:00.000Z");
+  try {
+    delete process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
+    const { alice, bob } = makeActorServers(rootDir, emptyLocalController(), undefined, () => now);
+    await hello(alice);
+    await hello(bob);
+
+    const taskId = "task_01KX19GEKWMEJNGSMRT6JJH6HY";
+    const codex = { kind: "agent", id: "codex" } as const;
+    const claude = { kind: "agent", id: "claude-code" } as const;
+    const claimed = resultReceipt(await alice.handle(taskHolderRequest("repo.task.claim", taskId, { ttlMs: 60_000, executor: codex })));
+    assert.deepEqual(claimed.details.data.effectiveHolder.executor, codex);
+
+    now = new Date("2026-07-10T00:00:10.000Z");
+    const refreshed = resultReceipt(await alice.handle(progressRequest(taskId, codex, "refresh lease")));
+    assert.equal(refreshed.ok, true);
+    const activeHolder = resultReceipt(await alice.handle(taskHolderRequest("repo.task.holder", taskId)));
+    assert.deepEqual(activeHolder.details.data.effectiveHolder.executor, codex);
+
+    const collision = resultReceipt(await bob.handle(taskHolderRequest("repo.task.claim", taskId, { ttlMs: 60_000, executor: claude })));
+    assert.equal(collision.ok, false);
+    assert.match(collision.error?.hint ?? "", /current holder principal=person_alice, executor=agent:codex/u);
+
+    now = new Date("2026-07-10T00:02:00.000Z");
+    const recovered = resultReceipt(await alice.handle(progressRequest(taskId, claude, "recover orphan")));
+    assert.equal(recovered.ok, true);
+    const recoveredHolder = resultReceipt(await alice.handle(taskHolderRequest("repo.task.holder", taskId)));
+    assert.deepEqual(recoveredHolder.details.data.effectiveHolder.executor, claude);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
+    } else {
+      process.env.HARNESS_TASK_LEASE_ENFORCEMENT = previous;
+    }
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("task lease enforcement rejects review by an arbiter who is not the holder", async () => {
   const previous = process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
   const rootDir = createHarnessRoot(["settings:", "  tasks:", "    leaseEnforcement: true"]);
@@ -211,12 +252,13 @@ test("daemon lease enforcement accepts explicit environment disable over workspa
 function makeActorServers(
   rootDir: string,
   localController: LocalControllerService = emptyLocalController(),
-  appendRuntimeEvent?: Parameters<typeof createJsonRpcProtocolServer>[0]["appendRuntimeEvent"]
+  appendRuntimeEvent?: Parameters<typeof createJsonRpcProtocolServer>[0]["appendRuntimeEvent"],
+  now: () => Date = () => new Date("2026-07-10T00:00:00.000Z")
 ) {
   const roster = sampleRoster();
   const taskHolderService = makeTaskHolderService({
     rootInput: rootDir,
-    now: () => new Date("2026-07-10T00:00:00.000Z")
+    now
   });
   const services = {
     LocalControllerService: localController,
@@ -227,6 +269,18 @@ function makeActorServers(
     alice: createActorServer(rootDir, roster, "alice", services, appendRuntimeEvent),
     bob: createActorServer(rootDir, roster, "bob", services, appendRuntimeEvent),
     maint: createActorServer(rootDir, roster, "maint", services, appendRuntimeEvent)
+  };
+}
+
+function progressRequest(taskId: string, executor: { readonly kind: "agent"; readonly id: string }, text: string): JsonRpcRequest {
+  return {
+    jsonrpc: "2.0",
+    id: `progress-${text}`,
+    method: "repo.tasks.progress.append",
+    params: {
+      repo: { repoId: "canonical" },
+      payload: { taskId, executor, text }
+    }
   };
 }
 
@@ -295,7 +349,7 @@ function emptyLocalController(): LocalControllerService {
 function resultReceipt(response: JsonRpcResponse | ReadonlyArray<JsonRpcResponse> | undefined): {
   readonly ok: boolean;
   readonly command: string;
-  readonly error?: { readonly code?: string };
+  readonly error?: { readonly code?: string; readonly hint?: string };
   readonly details: Record<string, any>;
 } {
   assert.ok(response && !Array.isArray(response));
@@ -303,7 +357,7 @@ function resultReceipt(response: JsonRpcResponse | ReadonlyArray<JsonRpcResponse
   return response.result as {
     readonly ok: boolean;
     readonly command: string;
-    readonly error?: { readonly code?: string };
+    readonly error?: { readonly code?: string; readonly hint?: string };
     readonly details: Record<string, any>;
   };
 }


### PR DESCRIPTION
# English

## Summary

Fixes lease-executor loss on daemon writes (P2-D5, found by the KTY P2 cross-machine lease audit rerun, task_01KXA6KCPH): when a write triggered lease renewal or orphan self-heal, the holder's `executor` axis was overwritten to `null`, and subsequent claim collisions degraded to `executor=none`. The kernel preserves executors correctly (existing task-holder-service tests assert it); the loss happened on the daemon call side, which built the lease principal without the executor.

Root cause was an asymmetry in `json-rpc-server.ts`: the claim path passed `{ executor: readTaskHolderExecutor(payload) }` while the service-write lease guard called `taskHolderPrincipalFromActor(actor)` without it. A second same-family path was found and fixed: `repo.command.run` did not thread the CLI-sent executor into the daemon-side CLI composition, so lease principals built there also dropped it.

## What Changed

- `packages/daemon/src/protocol/json-rpc-server.ts`: the service-write lease guard now reads the executor from the request payload and passes it into `taskHolderPrincipalFromActor`, symmetric with the claim path; `repo.command.run` threads `readTaskHolderExecutor(payload)` into `CliCommandService.runCommand`.
- `packages/cli/src/daemon/command-service.ts` + `packages/cli/src/composition/actor-attribution.ts`: `daemonActorAttribution` accepts the authenticated request executor and carries it on `CliActorAttribution`; journal actor and git commit author attribution (person axis) are unchanged.
- `packages/cli/src/composition/local-principal.ts`: the lease principal prefers the explicit daemon executor and falls back to the previous journal-actor derivation — local (non-daemon) behavior is byte-identical.
- Tests: protocol-level regressions for active refresh, orphan recovery, and collision message content (`packages/daemon/test/task-holder-rpc.test.ts`); forced-command thin-client three-step end-to-end regression (claim → progress write renews with executor kept → conflicting claim names the real dual-axis holder) in `packages/cli/test/daemon-lease-executor-cli.test.ts`. Red test confirmed both paths wiped the executor before the fix.

## Task And Scope

- Harness task: task_01KXA9ATY1NW8MH5AH7GHPP9ES
- Branch: fix/lease-guard-executor
- Public scope: daemon write-path lease principal construction + CLI daemon composition executor threading + regressions
- Private planning/evidence updated: yes (implementation report and P2 audit evidence in task packages)
- Out of scope: lease semantics/TTL/error codes (unchanged), runtime-event lease lifecycle fields (task_01KXA7GKVF), PR #641 rebase

## Version Impact

- Version: no version change because this is a pre-release workspace fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_01KXA9ATY1NW8MH5AH7GHPP9ES, derived from P2 audit facts (task_01KXA6KCPH); dual-axis attribution semantics per dec_mrd7jiux
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 0cf6fa1ef7ab2766a2c8770baa388381c426faab
- Branch merge-base with `origin/main`: 0cf6fa1ef7ab2766a2c8770baa388381c426faab
- Last `git fetch origin` time: 2026-07-12 (before PR creation)
- Sync method: none needed
- Public diff command: `git diff origin/main...fix/lease-guard-executor`
- Private evidence commit/path: harness/tasks/task_01KXA9ATY1NW8MH5AH7GHPP9ES-daemon-lease-guard-executor-holder-executor-null/artifacts/impl-report-codex.md
- Reviewer evidence path: same, plus P2 audit report (task_01KXA6KCPH artifacts) P2-D5 section
- GitHub Actions `rewrite-ci` run URL: pending (populated by CI on this PR)
- [x] `npm ci` (worker environment)
- [x] `git diff --check`
- [x] `npm run check` (exit 0 on HEAD 235b477: Node 1355 pass/1 skip, GUI 39 pass, 35 manifest gates)
- [x] `npm run typecheck` (via check)
- [x] `npm test` (via check; focused 7 pass, contract 399 pass, integration 645 pass/1 platform skip)
- [x] `npm run harness:check-import-boundaries` (via check)
- [x] `npm run harness:scan-forbidden-symbols` (via check)
- [x] `npm run harness:check-private-boundary` (via check)
- [x] `npm run harness:check-package-policy` (via check)
- [x] `npm run harness:check-implementation-contracts` (via check)
- [x] `npm run harness:check-schema-contracts` (via check)
- [x] `npm run harness:check-legacy-intake-readiness` (via check)
- [x] `npm run harness:smoke-cli-package` (via check)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: none

## Review Evidence

- Self-review: worker red/green (both loss paths reproduced red before the fix; green after)
- Reviewer subagent: not applicable (CEO hunk-by-hunk semantic review: guard symmetry, executor threading, local-path fallback identity, person-axis attribution untouched)
- Human review: pending on this PR
- Blocking findings: none

## Residual Risk

- Live KTY re-verification of the P2-D5 three-step scenario requires deploying this build to ai-server (deployment-side follow-up; P2 gate final ruling depends on it).
- No release-path executor loss was found in the audit sweep; if another holder-mutation path exists outside daemon service writes, existing kernel tests still guarantee executor preservation once the caller supplies it.

## References

- Task: task_01KXA9ATY1NW8MH5AH7GHPP9ES
- Evidence: harness/tasks/task_01KXA6KCPH70XV4RKN3MPYJZTX-kty-p2-claim-lease-ttl-orphan-release/artifacts/p2-lease-audit-report.md (P2-D5)
- Review: harness/tasks/task_01KXA9ATY1NW8MH5AH7GHPP9ES-daemon-lease-guard-executor-holder-executor-null/artifacts/impl-report-codex.md

---

# 中文

## 概要

修复 daemon 写路径的 lease executor 丢失（P2-D5，KTY P2 跨机 lease 审计复跑发现，task_01KXA6KCPH）：写触发续期或 orphan 自愈时，holder 的 `executor` 轴被覆盖成 `null`，后续 claim 冲突报错退化为 `executor=none`。内核层本身保 executor（既有 task-holder-service 测试有断言）；丢失发生在 daemon 调用侧——构造 lease principal 时没带 executor。

根因是 `json-rpc-server.ts` 的不对称：claim 路径传了 `{ executor: readTaskHolderExecutor(payload) }`，而 service-write lease guard 调 `taskHolderPrincipalFromActor(actor)` 没传。同族第二处一并修复：`repo.command.run` 没把 CLI 发来的 executor 贯通到 daemon 侧 CLI 组合面，那里构造的 lease principal 同样丢轴。

## 改动内容

- `packages/daemon/src/protocol/json-rpc-server.ts`：service-write lease guard 从请求 payload 读 executor 传入 `taskHolderPrincipalFromActor`，与 claim 路径对称；`repo.command.run` 把 `readTaskHolderExecutor(payload)` 贯通给 `CliCommandService.runCommand`。
- `packages/cli/src/daemon/command-service.ts` + `packages/cli/src/composition/actor-attribution.ts`：`daemonActorAttribution` 接受认证请求的 executor 并挂在 `CliActorAttribution` 上；journal actor 与 git commit author（person 轴）归因不变。
- `packages/cli/src/composition/local-principal.ts`：lease principal 优先取显式 daemon executor，无则回退旧的 journal-actor 派生——本地（非 daemon）行为逐字节不变。
- 测试：协议层续期/orphan 恢复/冲突文本回归（`packages/daemon/test/task-holder-rpc.test.ts`）；forced-command 薄客户端三步端到端回归（claim → 写续期保 executor → 冲突报真实双轴 holder，`packages/cli/test/daemon-lease-executor-cli.test.ts`）。红测确认修复前两条路径均丢 executor。

## 任务与范围

- Harness 任务：task_01KXA9ATY1NW8MH5AH7GHPP9ES
- 分支：fix/lease-guard-executor
- 公开范围：daemon 写路径 lease principal 构造 + CLI daemon 组合面 executor 贯通 + 回归测试
- 私有计划 / 证据是否已更新：yes（实现报告与 P2 审计证据在任务包）
- 范围外：lease 语义/TTL/错误码（不变）、runtime-event lease 生命周期字段（task_01KXA7GKVF）、PR #641 rebase

## 版本影响

- 版本：不改版本，原因是 pre-release workspace 修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：task_01KXA9ATY1NW8MH5AH7GHPP9ES，派生自 P2 审计 facts（task_01KXA6KCPH）；双轴归属语义依 dec_mrd7jiux
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：0cf6fa1ef7ab2766a2c8770baa388381c426faab
- 当前分支与 `origin/main` 的 merge-base：0cf6fa1ef7ab2766a2c8770baa388381c426faab
- 最近一次 `git fetch origin` 时间：2026-07-12（开 PR 前）
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...fix/lease-guard-executor`
- 私有证据 commit / 路径：harness/tasks/task_01KXA9ATY1NW8MH5AH7GHPP9ES-daemon-lease-guard-executor-holder-executor-null/artifacts/impl-report-codex.md
- Reviewer 证据路径：同上 + P2 审计报告 P2-D5 节
- GitHub Actions `rewrite-ci` run URL：pending（本 PR CI 产生后回填）
- [x] `npm ci`（worker 环境）
- [x] `git diff --check`
- [x] `npm run check`（HEAD 235b477 exit 0：Node 1355 pass/1 skip、GUI 39 pass、35 manifest gates）
- [x] `npm run typecheck`（含于 check）
- [x] `npm test`（含于 check；focused 7 pass、contract 399 pass、integration 645 pass/1 platform skip）
- [x] `npm run harness:check-import-boundaries`（含于 check）
- [x] `npm run harness:scan-forbidden-symbols`（含于 check）
- [x] `npm run harness:check-private-boundary`（含于 check）
- [x] `npm run harness:check-package-policy`（含于 check）
- [x] `npm run harness:check-implementation-contracts`（含于 check）
- [x] `npm run harness:check-schema-contracts`（含于 check）
- [x] `npm run harness:check-legacy-intake-readiness`（含于 check）
- [x] `npm run harness:smoke-cli-package`（含于 check）
- [ ] GitHub Actions `rewrite-ci` passed
- 未执行：无

## Review Evidence

- Self-review：worker 红绿对照（修复前两条路径红测复现丢 executor，修复后绿）
- Reviewer subagent：不适用（CEO 逐 hunk 语义验收：guard 对称性、executor 贯通、本地路径回退恒等、person 轴归因未动）
- Human review：本 PR 待审
- Blocking findings：无

## 残余风险

- KTY 现网三步场景复验需部署本构建到 ai-server（部署侧后续；P2 gate 终裁依赖它）。
- 审计扫描未发现 release 或其他 holder mutation 路径仍丢 executor；若存在 daemon service write 之外的路径，调用方补齐 executor 后内核测试仍保证保存。

## References

- Task: task_01KXA9ATY1NW8MH5AH7GHPP9ES
- Evidence: harness/tasks/task_01KXA6KCPH70XV4RKN3MPYJZTX-kty-p2-claim-lease-ttl-orphan-release/artifacts/p2-lease-audit-report.md（P2-D5）
- Review: harness/tasks/task_01KXA9ATY1NW8MH5AH7GHPP9ES-daemon-lease-guard-executor-holder-executor-null/artifacts/impl-report-codex.md
