### PR TITLE
feat(gui): decision genealogy timeline view, multi-view switcher, BoardView de-mock

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -13,10 +13,10 @@ import {
   WarningCircle,
   GitBranch,
   FirstAidKit,
+  ClockCounterClockwise,
 } from "@phosphor-icons/react";
 import type { SnapshotStatus } from "./model/types.ts";
 import {
-  MOCK_TASK_RELATIONS,
   MOCK_PRESETS,
   MOCK_ADAPTERS,
   MOCK_EVENTS,
@@ -29,6 +29,7 @@ import { DecisionsView } from "./views/DecisionsView.tsx";
 import { DecisionPoolView } from "./views/DecisionPoolView.tsx";
 import { FactTriageView } from "./views/FactTriageView.tsx";
 import { GraphView } from "./views/GraphView.tsx";
+import { GenealogyTimelineView } from "./views/GenealogyTimelineView.tsx";
 import { PresetsView } from "./views/PresetsView.tsx";
 import { AdaptersView } from "./views/AdaptersView.tsx";
 import { SettingsView } from "./views/SettingsView.tsx";
@@ -54,6 +55,7 @@ type ViewId =
   | "decisionPool"
   | "factTriage"
   | "graph"
+  | "genealogy"
   | "presets"
   | "adapters"
   | "settings";
@@ -73,6 +75,7 @@ const WORKSPACE_NAV: { id: ViewId; label: string; icon: React.ReactNode }[] = [
   { id: "decisionPool", label: "决策池", icon: <GitBranch weight="duotone" /> },
   { id: "factTriage", label: "事实分诊", icon: <FirstAidKit weight="duotone" /> },
   { id: "graph", label: "关系图", icon: <Graph weight="duotone" /> },
+  { id: "genealogy", label: "演化史", icon: <ClockCounterClockwise weight="duotone" /> },
 ];
 
 const MANAGE_NAV: { id: ViewId; label: string; icon: React.ReactNode }[] = [
@@ -89,6 +92,7 @@ const VIEW_LABEL: Record<ViewId, string> = {
   decisionPool: "决策池",
   factTriage: "事实分诊",
   graph: "关系图",
+  genealogy: "演化史",
   presets: "Preset / Vertical",
   adapters: "引擎 Adapter",
   settings: "设置",
@@ -404,6 +408,34 @@ function AppShell() {
         {showMockBanner && <MockViewBanner />}
         <div className="flex min-h-0 min-w-0 flex-1 flex-row overflow-hidden">
           <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+            {!selected && (view === "graph" || view === "genealogy") && (
+              <div className="flex items-center gap-2 border-b border-border bg-surface/60 px-4 py-1.5">
+                <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
+                  同一实体 · 多视图
+                </span>
+                <div className="flex items-center gap-0.5 rounded-md border border-border p-0.5">
+                  {([
+                    { id: "graph", label: "关系图" },
+                    { id: "genealogy", label: "演化史" },
+                  ] as const).map((item) => (
+                    <button
+                      key={item.id}
+                      onClick={() => setView(item.id)}
+                      className={`rounded px-2 py-0.5 text-[12px] ${
+                        view === item.id
+                          ? "bg-surface-raised font-medium text-text"
+                          : "text-text-muted hover:text-text"
+                      }`}
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+                <span className="text-[11px] text-text-faint">
+                  关系图看结构 · 演化史看 decision 谱系随时间的 refine/narrow/supersede
+                </span>
+              </div>
+            )}
             {selected ? (
               <TaskDetailView
                 task={selected}
@@ -447,7 +479,7 @@ function AppShell() {
                 onSelect={openTaskPreview}
                 onUpdate={updateTask}
                 drill={drill}
-                relations={MOCK_TASK_RELATIONS}
+                relations={relations}
                 favorites={favorites}
                 onToggleFavorite={toggleFavorite}
               />
@@ -459,6 +491,14 @@ function AppShell() {
                 facts={facts}
                 onNavigateEntity={navigateToEntity}
                 focusRef={focusedEntityRef}
+              />
+            ) : view === "genealogy" ? (
+              <GenealogyTimelineView
+                decisions={decisions}
+                relations={relations}
+                focusRef={focusedEntityRef}
+                onNavigateEntity={navigateToEntity}
+                onFocusGraph={focusEntityInGraph}
               />
             ) : view === "factTriage" ? (
               <FactTriageView
@@ -517,7 +557,7 @@ function AppShell() {
       <TaskPreviewDrawer
         task={previewTask}
         tasks={projectTasks}
-        relations={MOCK_TASK_RELATIONS}
+        relations={relations}
         events={projectEvents}
         onClose={() => setPreviewId(null)}
         onOpenDetail={openTaskDetail}

--- a/packages/gui/src/renderer/model/mock-work.ts
+++ b/packages/gui/src/renderer/model/mock-work.ts
@@ -3,7 +3,6 @@ import type {
   TaskRow,
   DocEntry,
   Project,
-  RelationEdge,
 } from "./types";
 
 export const MOCK_PROJECTS: Project[] = [
@@ -454,44 +453,4 @@ export const MOCK_TASKS: TaskRow[] = [
     lastKnownAt: "2026-06-11T08:15:00",
     docs: docs(["review/walkthrough.md", "evidence/run-log.md"]),
   }),
-];
-
-/* ---------------- 任务关系 ---------------- */
-
-export const MOCK_TASK_RELATIONS: RelationEdge[] = [
-  /* ===== harness-anything：依赖主链 KER-101 → KER-102 → KER-106 ===== */
-  { from: "KER-102", to: "KER-101", kind: "depends-on", provenance: "local-document" },
-  { from: "KER-106", to: "KER-102", kind: "depends-on", provenance: "local-document" },
-  { from: "KER-109", to: "KER-101", kind: "depends-on", provenance: "local-document" },
-  /* 父子树：KER-103 拆出 store 两个子任务 */
-  { from: "KER-103", to: "STO-210", kind: "relates", provenance: "local-document" },
-  { from: "KER-103", to: "STO-211", kind: "relates", provenance: "local-document" },
-  { from: "KER-107", to: "KER-103", kind: "depends-on", provenance: "local-document" },
-  /* GUI 链挂在 schema 契约之后 */
-  { from: "GUI-401", to: "KER-102", kind: "depends-on", provenance: "local-document" },
-  { from: "GUI-402", to: "GUI-401", kind: "depends-on", provenance: "local-document" },
-  { from: "GUI-403", to: "KER-106", kind: "relates", provenance: "local-document" },
-  { from: "CI-602", to: "GUI-401", kind: "depends-on", provenance: "local-document" },
-  { from: "CI-601", to: "KER-106", kind: "relates", provenance: "local-document" },
-  /* 引用关系（不构成依赖） */
-  { from: "KER-108", to: "KER-102", kind: "relates", provenance: "local-document" },
-  /* 外部引擎侧记录的关系：provenance=external-engine */
-  { from: "ADP-501", to: "GH-2214", kind: "relates", provenance: "external-engine" },
-  { from: "FAI-37", to: "KER-101", kind: "depends-on", provenance: "external-engine" },
-  { from: "LIN-92", to: "ADP-502", kind: "depends-on", provenance: "external-engine" },
-  { from: "LIN-88", to: "LIN-92", kind: "relates", provenance: "external-engine" },
-  { from: "ADP-502", to: "KER-103", kind: "depends-on", provenance: "local-document" },
-
-  /* ===== coding-agent-harness：文档/模板流水 ===== */
-  { from: "DOC-12", to: "DOC-11", kind: "depends-on", provenance: "local-document" },
-  { from: "TPL-22", to: "TPL-21", kind: "depends-on", provenance: "local-document" },
-  { from: "DOC-13", to: "TPL-21", kind: "relates", provenance: "local-document" },
-  { from: "DSH-32", to: "DSH-31", kind: "relates", provenance: "external-engine" },
-
-  /* ===== rag-pipeline-svc：ingest → retrieval → eval 主链 ===== */
-  { from: "RAG-2", to: "RAG-1", kind: "depends-on", provenance: "local-document" },
-  { from: "RAG-3", to: "RAG-1", kind: "depends-on", provenance: "local-document" },
-  { from: "RAG-4", to: "RAG-3", kind: "depends-on", provenance: "local-document" },
-  { from: "RAG-4", to: "RAG-5", kind: "depends-on", provenance: "local-document" },
-  { from: "RAG-1", to: "RAG-6", kind: "relates", provenance: "external-engine" },
 ];

--- a/packages/gui/src/renderer/views/GenealogyTimelineView.tsx
+++ b/packages/gui/src/renderer/views/GenealogyTimelineView.tsx
@@ -1,259 +1,29 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { ClockCounterClockwise } from "@phosphor-icons/react";
+import type { DecisionRow, RelationEdge } from "../model/types";
 import {
-  ClockCounterClockwise,
-  GitBranch,
-  Graph,
-  MagnifyingGlass,
-  ArrowSquareOut,
-  X,
-} from "@phosphor-icons/react";
-import type { DecisionRow, RelationEdge, RelationKind } from "../model/types";
-import { DecisionStateBadge } from "../components/badges";
+  KIND_META,
+  buildGenealogyEdges,
+  collectLineage,
+  computeLayout,
+  decisionIdOf,
+  timeMsOf,
+} from "./genealogy/layout";
+import { DecisionDetailPanel } from "./genealogy/DecisionDetailPanel";
+import { GenealogyEmptyState, IsolatedNodeMessage } from "./genealogy/EmptyStates";
+import { ParticipantsSidebar } from "./genealogy/ParticipantsSidebar";
+import { TimelinePlot } from "./genealogy/TimelinePlot";
 
 /**
- * 决策谱系「演化史」视图（Jaeger-timeline 式）。
- *
- * 承接 dec_01KXA7811SVVT8P66HNDFZQ7DF 原则 6：关系图解决「结构」，而 decision
- * 谱系（refines/narrows/supersedes/supports）本质是**时间演化**，用一条时间轴
- * 更清晰——X=decidedAt（缺则 fallback proposedAt），行=谱系深度，节点=决策卡。
+ * 决策谱系「演化史」视图入口壳（Jaeger-timeline 式）。
  *
  * 纯前端派生：从 triadicQuery.relations 里筛 kind ∈ 谱系四类且两端皆 decision，
  * 以选中 decision 为焦点上溯祖先 / 下溯后代。不改后端、不换图库、不碰 graph/**。
+ *
+ * 本文件只做编排（状态 / 派生 memo / 布局计算 / 子组件装配），职责细节见
+ * ./genealogy/ 下的 layout（纯逻辑）、ParticipantsSidebar / TimelinePlot /
+ * DecisionDetailPanel / EmptyStates（展示子组件）。
  */
-
-// 谱系边：只认权威轴里表达「思想演化」的四类关系，两端必须都是 decision。
-const GENEALOGY_KINDS = new Set<RelationKind>([
-  "refines",
-  "narrows",
-  "supersedes",
-  "supports",
-]);
-
-// 每类边的语义标签 + 语义色（复用 styles.css 里已定义的 token，绝不新造）。
-const KIND_META: Record<
-  string,
-  { label: string; color: string; verb: string }
-> = {
-  refines: { label: "细化", color: "var(--color-accent)", verb: "细化了" },
-  narrows: { label: "收窄", color: "var(--color-status-in-review)", verb: "收窄了" },
-  supersedes: { label: "推翻", color: "var(--color-danger)", verb: "推翻了" },
-  supports: { label: "支撑", color: "var(--color-status-done)", verb: "支撑了" },
-};
-
-// ---- 布局常量（px）----
-const CARD_W = 210;
-const CARD_H = 60;
-const ROW_H = 82;
-const AXIS_H = 34;
-const PAD_X = 28;
-const PAD_Y = 20;
-const LANE_GAP = 26; // 同一深度带内两卡的最小水平间隙
-
-/** 把 `decision/dec_x/CH1` 之类的 ref 归一成裸 decision id；非 decision 端返回 null。 */
-function decisionIdOf(ref: string): string | null {
-  if (!ref.startsWith("decision/")) return null;
-  const rest = ref.slice("decision/".length);
-  const id = rest.split("/")[0];
-  return id.length > 0 ? id : null;
-}
-
-/** decidedAt 优先，缺则 proposedAt；都无 → null（优雅降级）。 */
-function timeMsOf(decision: DecisionRow): number | null {
-  const raw = decision.decidedAt ?? decision.proposedAt;
-  if (!raw) return null;
-  const ms = new Date(raw).getTime();
-  return Number.isFinite(ms) ? ms : null;
-}
-
-function shortTime(decision: DecisionRow): string {
-  const raw = decision.decidedAt ?? decision.proposedAt;
-  if (!raw) return "无判定时间";
-  return raw.slice(0, 10);
-}
-
-interface GenealogyEdge {
-  from: string; // 后代（较新，refines/narrows/... 的一方）
-  to: string; // 祖先（较旧，被 refine 的一方）
-  kind: RelationKind;
-  rationale?: string;
-}
-
-interface LaidOutNode {
-  id: string;
-  decision: DecisionRow;
-  depth: number; // 相对焦点：祖先为负、焦点为 0、后代为正
-  timeMs: number | null;
-  x: number; // 卡片左上角 x（含 PAD）
-  y: number; // 卡片左上角 y（含 AXIS + PAD）
-}
-
-/** 全量谱系边（decision→decision），去重。 */
-function buildGenealogyEdges(
-  relations: RelationEdge[],
-  byId: Map<string, DecisionRow>,
-): GenealogyEdge[] {
-  const seen = new Set<string>();
-  const edges: GenealogyEdge[] = [];
-  for (const relation of relations) {
-    if (!GENEALOGY_KINDS.has(relation.kind)) continue;
-    const from = decisionIdOf(relation.from);
-    const to = decisionIdOf(relation.to);
-    if (!from || !to || from === to) continue;
-    if (!byId.has(from) || !byId.has(to)) continue;
-    const key = `${from}|${to}|${relation.kind}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    edges.push({ from, to, kind: relation.kind, rationale: relation.rationale });
-  }
-  return edges;
-}
-
-/** 以 focus 为中心，上溯祖先（沿 from→to）+ 下溯后代（沿 to→from），返回带 depth 的谱系集合。 */
-function collectLineage(
-  focusId: string,
-  edges: GenealogyEdge[],
-): Map<string, number> {
-  const outByFrom = new Map<string, GenealogyEdge[]>();
-  const inByTo = new Map<string, GenealogyEdge[]>();
-  for (const edge of edges) {
-    (outByFrom.get(edge.from) ?? outByFrom.set(edge.from, []).get(edge.from)!).push(edge);
-    (inByTo.get(edge.to) ?? inByTo.set(edge.to, []).get(edge.to)!).push(edge);
-  }
-
-  const depth = new Map<string, number>([[focusId, 0]]);
-
-  // 上溯祖先：focus --refines--> ancestor，祖先更旧 → 负 depth。
-  const upQueue: string[] = [focusId];
-  while (upQueue.length > 0) {
-    const current = upQueue.shift()!;
-    const currentDepth = depth.get(current)!;
-    for (const edge of outByFrom.get(current) ?? []) {
-      if (!depth.has(edge.to)) {
-        depth.set(edge.to, currentDepth - 1);
-        upQueue.push(edge.to);
-      }
-    }
-  }
-
-  // 下溯后代：descendant --refines--> focus，后代更新 → 正 depth。
-  const downQueue: string[] = [focusId];
-  while (downQueue.length > 0) {
-    const current = downQueue.shift()!;
-    const currentDepth = depth.get(current)!;
-    for (const edge of inByTo.get(current) ?? []) {
-      if (!depth.has(edge.from)) {
-        depth.set(edge.from, currentDepth + 1);
-        downQueue.push(edge.from);
-      }
-    }
-  }
-
-  return depth;
-}
-
-/** 时间轴上做 3–6 个刻度。 */
-function axisTicks(minT: number, maxT: number): { t: number; label: string }[] {
-  if (!(maxT > minT)) return [];
-  const count = 5;
-  const ticks: { t: number; label: string }[] = [];
-  for (let i = 0; i <= count; i += 1) {
-    const t = minT + ((maxT - minT) * i) / count;
-    ticks.push({ t, label: new Date(t).toISOString().slice(0, 10) });
-  }
-  return ticks;
-}
-
-function DecisionDetailPanel({
-  decision,
-  onClose,
-  onNavigateEntity,
-  onFocusGraph,
-}: {
-  decision: DecisionRow;
-  onClose: () => void;
-  onNavigateEntity?: (ref: string) => void;
-  onFocusGraph?: (ref: string) => void;
-}) {
-  return (
-    <aside className="flex w-[340px] shrink-0 flex-col border-l border-border bg-surface">
-      <header className="flex items-start gap-2 border-b border-border px-3 py-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-1.5">
-            <span className="font-mono text-[11px] text-text-faint">{decision.decisionId}</span>
-            <DecisionStateBadge state={decision.state} />
-          </div>
-          <h3 className="mt-1 text-[15px] font-semibold leading-snug text-text">{decision.title}</h3>
-        </div>
-        <button
-          onClick={onClose}
-          title="关闭详情"
-          className="grid size-6 shrink-0 place-items-center rounded text-text-faint hover:bg-surface-raised hover:text-text"
-        >
-          <X weight="bold" />
-        </button>
-      </header>
-      <div className="min-h-0 flex-1 overflow-auto px-3 py-3">
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[11px] text-text-faint">
-          <span>decided {decision.decidedAt ? decision.decidedAt.slice(0, 16).replace("T", " ") : "—"}</span>
-          <span>proposed {decision.proposedAt ? decision.proposedAt.slice(0, 16).replace("T", " ") : "—"}</span>
-        </div>
-        <p className="mt-2 text-[12px] leading-relaxed text-text-muted">
-          <span className="font-semibold text-text-faint">Q: </span>
-          {decision.question}
-        </p>
-        {decision.chosen.length > 0 && (
-          <section className="mt-3">
-            <div className="font-mono text-[10px] uppercase tracking-wide text-text-faint">chosen</div>
-            <ul className="mt-1 space-y-1">
-              {decision.chosen.map((claim) => (
-                <li key={claim.id} className="flex gap-1.5 text-[12px] leading-snug text-text">
-                  <span className="font-mono text-[10px] text-accent">{claim.id}</span>
-                  <span className="min-w-0">{claim.text}</span>
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-        {decision.rejected.length > 0 && (
-          <section className="mt-3">
-            <div className="font-mono text-[10px] uppercase tracking-wide text-text-faint">rejected</div>
-            <ul className="mt-1 space-y-1">
-              {decision.rejected.map((claim) => (
-                <li key={claim.id} className="text-[12px] leading-snug text-text-muted">
-                  <span className="font-mono text-[10px] text-danger">{claim.id}</span> {claim.text}
-                  {claim.whyNot && (
-                    <span className="mt-0.5 block text-[11px] text-text-faint">↳ {claim.whyNot}</span>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-      </div>
-      <footer className="flex items-center gap-2 border-t border-border px-3 py-2.5">
-        {onNavigateEntity && (
-          <button
-            onClick={() => onNavigateEntity(`decision/${decision.decisionId}`)}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[12px] text-text-muted hover:border-border-strong hover:text-text"
-          >
-            <ArrowSquareOut weight="bold" />
-            在决策池查看
-          </button>
-        )}
-        {onFocusGraph && (
-          <button
-            onClick={() => onFocusGraph(`decision/${decision.decisionId}`)}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[12px] text-text-muted hover:border-border-strong hover:text-accent"
-          >
-            <Graph weight="bold" />
-            在关系图聚焦
-          </button>
-        )}
-      </footer>
-    </aside>
-  );
-}
-
 export function GenealogyTimelineView({
   decisions,
   relations,
@@ -300,7 +70,6 @@ export function GenealogyTimelineView({
 
   const [focusId, setFocusId] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [hoverId, setHoverId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
 
   // 跨视图带入的焦点优先；否则挑谱系最大的一个。
@@ -342,68 +111,13 @@ export function GenealogyTimelineView({
   }, []);
 
   // 焦点谱系的布局。
-  const layout = useMemo(() => {
-    if (!focus) {
-      return { nodes: [] as LaidOutNode[], width: 0, height: 0, ticks: [] as { x: number; label: string }[], minT: 0, maxT: 0 };
-    }
-    const depthMap = collectLineage(focus.decisionId, edges);
-    const rawNodes = [...depthMap.entries()]
-      .map(([id, depth]) => {
-        const decision = byId.get(id);
-        if (!decision) return null;
-        return { id, decision, depth, timeMs: timeMsOf(decision) };
-      })
-      .filter((node): node is Omit<LaidOutNode, "x" | "y"> => node !== null);
-
-    const times = rawNodes.map((node) => node.timeMs).filter((t): t is number => t !== null);
-    const minT = times.length > 0 ? Math.min(...times) : 0;
-    const maxT = times.length > 0 ? Math.max(...times) : 0;
-    const span = maxT - minT;
-
-    const plotW = Math.max(360, plotWidth - PAD_X * 2 - CARD_W);
-    const xOfTime = (timeMs: number | null): number => {
-      if (timeMs === null) return 0; // 无时间 → 贴最左，并在卡上标注
-      if (span <= 0) return plotW / 2;
-      return ((timeMs - minT) / span) * plotW;
-    };
-
-    // 按 depth 升序（祖先在上）分带，带内按 x 排序后贪心装道，保证零重叠。
-    const depths = [...new Set(rawNodes.map((node) => node.depth))].sort((a, b) => a - b);
-    const placed: LaidOutNode[] = [];
-    let rowCursor = 0;
-    for (const depth of depths) {
-      const group = rawNodes
-        .filter((node) => node.depth === depth)
-        .sort((a, b) => xOfTime(a.timeMs) - xOfTime(b.timeMs));
-      const laneRight: number[] = [];
-      for (const node of group) {
-        const nx = xOfTime(node.timeMs);
-        let lane = laneRight.findIndex((right) => nx >= right + LANE_GAP);
-        if (lane === -1) {
-          lane = laneRight.length;
-          laneRight.push(0);
-        }
-        laneRight[lane] = nx + CARD_W;
-        placed.push({
-          ...node,
-          x: PAD_X + nx,
-          y: AXIS_H + PAD_Y + (rowCursor + lane) * ROW_H,
-        });
-      }
-      rowCursor += Math.max(1, laneRight.length);
-    }
-
-    const width = PAD_X * 2 + plotW + CARD_W;
-    const height = AXIS_H + PAD_Y * 2 + rowCursor * ROW_H;
-    const ticks = axisTicks(minT, maxT).map((tick) => ({
-      x: PAD_X + xOfTime(tick.t),
-      label: tick.label,
-    }));
-    return { nodes: placed, width, height, ticks, minT, maxT };
-  }, [focus, edges, byId, plotWidth]);
+  const layout = useMemo(
+    () => computeLayout(focus, edges, byId, plotWidth),
+    [focus, edges, byId, plotWidth],
+  );
 
   const nodeById = useMemo(() => {
-    const map = new Map<string, LaidOutNode>();
+    const map = new Map<string, (typeof layout.nodes)[number]>();
     for (const node of layout.nodes) map.set(node.id, node);
     return map;
   }, [layout.nodes]);
@@ -429,19 +143,7 @@ export function GenealogyTimelineView({
   }, [participants, query]);
 
   if (edges.length === 0) {
-    return (
-      <div
-        data-testid="genealogy-timeline-empty-state"
-        className="flex h-full min-h-0 flex-1 flex-col items-center justify-center gap-2 bg-surface px-6 text-center"
-      >
-        <ClockCounterClockwise weight="duotone" className="text-3xl text-text-faint" />
-        <div className="text-[14px] font-semibold text-text">暂无决策谱系可展示</div>
-        <div className="max-w-md text-[12px] leading-relaxed text-text-faint">
-          当前 ledger 里没有 refines / narrows / supersedes / supports 的 decision→decision 边。
-          出现思想演化关系后，这里会按时间轴渲染其谱系。
-        </div>
-      </div>
-    );
+    return <GenealogyEmptyState />;
   }
 
   return (
@@ -472,171 +174,32 @@ export function GenealogyTimelineView({
       </header>
 
       <div className="flex min-h-0 flex-1">
-        {/* 左栏：谱系参与决策列表（选一个作焦点，主区聚焦其演化史）。 */}
-        <div className="flex w-[260px] shrink-0 flex-col border-r border-border bg-surface/60">
-          <div className="border-b border-border px-2.5 py-2">
-            <div className="flex items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1">
-              <MagnifyingGlass weight="bold" className="text-text-faint" />
-              <input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="搜索决策 id / 标题"
-                className="min-w-0 flex-1 bg-transparent text-[12px] text-text outline-none placeholder:text-text-faint"
-              />
-            </div>
-          </div>
-          <div className="min-h-0 flex-1 overflow-auto py-1">
-            {filteredParticipants.map((decision) => {
-              const active = decision.decisionId === focusId;
-              const size = lineageSize.get(decision.decisionId) ?? 0;
-              return (
-                <button
-                  key={decision.decisionId}
-                  onClick={() => {
-                    setFocusId(decision.decisionId);
-                    setSelectedId(null);
-                  }}
-                  className={`flex w-full flex-col gap-0.5 border-l-2 px-2.5 py-1.5 text-left transition-colors ${
-                    active
-                      ? "border-accent bg-accent/10"
-                      : "border-transparent hover:bg-surface-raised"
-                  }`}
-                >
-                  <div className="flex items-center gap-1.5">
-                    <span className="truncate font-mono text-[10px] text-text-faint">{decision.decisionId}</span>
-                    <span className="ml-auto inline-flex items-center gap-0.5 font-mono text-[10px] text-text-faint">
-                      <GitBranch weight="bold" />
-                      {size}
-                    </span>
-                  </div>
-                  <span className={`truncate text-[12px] leading-snug ${active ? "text-text" : "text-text-muted"}`}>
-                    {decision.title}
-                  </span>
-                  <span className="font-mono text-[10px] text-text-faint">{shortTime(decision)}</span>
-                </button>
-              );
-            })}
-            {filteredParticipants.length === 0 && (
-              <div className="px-3 py-6 text-center text-[12px] text-text-faint">无匹配决策</div>
-            )}
-          </div>
-        </div>
+        <ParticipantsSidebar
+          participants={filteredParticipants}
+          focusId={focusId}
+          lineageSize={lineageSize}
+          query={query}
+          onQueryChange={setQuery}
+          onFocus={(id) => {
+            setFocusId(id);
+            setSelectedId(null);
+          }}
+        />
 
         {/* 主区：时间轴谱系。 */}
         <div ref={plotRef} className="relative min-h-0 min-w-0 flex-1 overflow-auto bg-bg">
           {focus && layout.nodes.length <= 1 ? (
-            <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
-              <div className="text-[13px] font-semibold text-text">{focus.title}</div>
-              <div className="max-w-md text-[12px] leading-relaxed text-text-faint">
-                该决策暂无 refines / narrows / supersedes / supports 谱系关系（孤立节点）。
-                从左栏选择一个带谱系的决策查看其演化史。
-              </div>
-            </div>
+            <IsolatedNodeMessage decision={focus} />
           ) : (
-            <div className="relative" style={{ width: layout.width, height: layout.height, minWidth: "100%" }}>
-              {/* 时间轴刻度 + 竖向网格 */}
-              <svg
-                className="pointer-events-none absolute inset-0"
-                width={layout.width}
-                height={layout.height}
-              >
-                <defs>
-                  {(["refines", "narrows", "supersedes", "supports"] as const).map((kind) => (
-                    <marker
-                      key={kind}
-                      id={`gen-arrow-${kind}`}
-                      viewBox="0 0 8 8"
-                      refX="7"
-                      refY="4"
-                      markerWidth="6"
-                      markerHeight="6"
-                      orient="auto-start-reverse"
-                    >
-                      <path d="M0,0 L8,4 L0,8 z" fill={KIND_META[kind].color} />
-                    </marker>
-                  ))}
-                </defs>
-                {layout.ticks.map((tick, index) => (
-                  <g key={index}>
-                    <line
-                      x1={tick.x}
-                      y1={AXIS_H}
-                      x2={tick.x}
-                      y2={layout.height}
-                      stroke="var(--color-border)"
-                      strokeWidth="1"
-                      strokeDasharray="2 4"
-                    />
-                    <text x={tick.x + 3} y={20} fill="var(--color-text-faint)" fontSize="10" fontFamily="var(--font-mono)">
-                      {tick.label}
-                    </text>
-                  </g>
-                ))}
-                {/* 谱系边 */}
-                {lineageEdges.map((edge, index) => {
-                  const ancestor = nodeById.get(edge.to)!;
-                  const descendant = nodeById.get(edge.from)!;
-                  const ancRight = ancestor.x <= descendant.x;
-                  const sx = ancRight ? ancestor.x + CARD_W : ancestor.x;
-                  const sy = ancestor.y + CARD_H / 2;
-                  const ex = ancRight ? descendant.x : descendant.x + CARD_W;
-                  const ey = descendant.y + CARD_H / 2;
-                  const dx = (ex - sx) * 0.45;
-                  const incident = hoverId === edge.from || hoverId === edge.to;
-                  const dim = hoverId !== null && !incident;
-                  return (
-                    <path
-                      key={index}
-                      d={`M ${sx} ${sy} C ${sx + dx} ${sy}, ${ex - dx} ${ey}, ${ex} ${ey}`}
-                      fill="none"
-                      stroke={KIND_META[edge.kind]?.color ?? "var(--color-border-strong)"}
-                      strokeWidth={incident ? 2.2 : 1.4}
-                      strokeOpacity={dim ? 0.15 : 0.85}
-                      markerEnd={`url(#gen-arrow-${edge.kind})`}
-                    />
-                  );
-                })}
-              </svg>
-
-              {/* 决策卡 */}
-              {layout.nodes.map((node) => {
-                const isFocus = node.depth === 0;
-                const isSelected = node.id === selectedId;
-                const dim = hoverId !== null && hoverId !== node.id;
-                return (
-                  <button
-                    key={node.id}
-                    onClick={() => setSelectedId((prev) => (prev === node.id ? null : node.id))}
-                    onMouseEnter={() => setHoverId(node.id)}
-                    onMouseLeave={() => setHoverId(null)}
-                    style={{ left: node.x, top: node.y, width: CARD_W, height: CARD_H }}
-                    className={`absolute flex flex-col justify-center gap-1 rounded-lg border px-2.5 py-1.5 text-left transition-colors ${
-                      isFocus
-                        ? "border-accent bg-accent/10"
-                        : isSelected
-                          ? "border-border-strong bg-surface-raised"
-                          : "border-border bg-surface hover:border-border-strong"
-                    } ${dim ? "opacity-40" : ""}`}
-                  >
-                    <div className="flex items-center gap-1.5">
-                      <span className="truncate font-mono text-[10px] text-text-faint">{node.id}</span>
-                      {isFocus && (
-                        <span className="ml-auto rounded bg-accent px-1 py-px font-mono text-[9px] font-semibold text-accent-fg">
-                          焦点
-                        </span>
-                      )}
-                    </div>
-                    <span className="truncate text-[12px] font-medium leading-tight text-text">{node.decision.title}</span>
-                    <div className="flex items-center gap-1.5">
-                      <span className="font-mono text-[9px] text-text-faint">{shortTime(node.decision)}</span>
-                      {node.timeMs === null && (
-                        <span className="rounded bg-stale/15 px-1 font-mono text-[9px] text-stale">无时间</span>
-                      )}
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
+            <TimelinePlot
+              layout={layout}
+              nodeById={nodeById}
+              lineageEdges={lineageEdges}
+              selectedId={selectedId}
+              onToggleSelect={(id) =>
+                setSelectedId((prev) => (prev === id ? null : id))
+              }
+            />
           )}
         </div>
 

--- a/packages/gui/src/renderer/views/GenealogyTimelineView.tsx
+++ b/packages/gui/src/renderer/views/GenealogyTimelineView.tsx
@@ -1,0 +1,654 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  ClockCounterClockwise,
+  GitBranch,
+  Graph,
+  MagnifyingGlass,
+  ArrowSquareOut,
+  X,
+} from "@phosphor-icons/react";
+import type { DecisionRow, RelationEdge, RelationKind } from "../model/types";
+import { DecisionStateBadge } from "../components/badges";
+
+/**
+ * 决策谱系「演化史」视图（Jaeger-timeline 式）。
+ *
+ * 承接 dec_01KXA7811SVVT8P66HNDFZQ7DF 原则 6：关系图解决「结构」，而 decision
+ * 谱系（refines/narrows/supersedes/supports）本质是**时间演化**，用一条时间轴
+ * 更清晰——X=decidedAt（缺则 fallback proposedAt），行=谱系深度，节点=决策卡。
+ *
+ * 纯前端派生：从 triadicQuery.relations 里筛 kind ∈ 谱系四类且两端皆 decision，
+ * 以选中 decision 为焦点上溯祖先 / 下溯后代。不改后端、不换图库、不碰 graph/**。
+ */
+
+// 谱系边：只认权威轴里表达「思想演化」的四类关系，两端必须都是 decision。
+const GENEALOGY_KINDS = new Set<RelationKind>([
+  "refines",
+  "narrows",
+  "supersedes",
+  "supports",
+]);
+
+// 每类边的语义标签 + 语义色（复用 styles.css 里已定义的 token，绝不新造）。
+const KIND_META: Record<
+  string,
+  { label: string; color: string; verb: string }
+> = {
+  refines: { label: "细化", color: "var(--color-accent)", verb: "细化了" },
+  narrows: { label: "收窄", color: "var(--color-status-in-review)", verb: "收窄了" },
+  supersedes: { label: "推翻", color: "var(--color-danger)", verb: "推翻了" },
+  supports: { label: "支撑", color: "var(--color-status-done)", verb: "支撑了" },
+};
+
+// ---- 布局常量（px）----
+const CARD_W = 210;
+const CARD_H = 60;
+const ROW_H = 82;
+const AXIS_H = 34;
+const PAD_X = 28;
+const PAD_Y = 20;
+const LANE_GAP = 26; // 同一深度带内两卡的最小水平间隙
+
+/** 把 `decision/dec_x/CH1` 之类的 ref 归一成裸 decision id；非 decision 端返回 null。 */
+function decisionIdOf(ref: string): string | null {
+  if (!ref.startsWith("decision/")) return null;
+  const rest = ref.slice("decision/".length);
+  const id = rest.split("/")[0];
+  return id.length > 0 ? id : null;
+}
+
+/** decidedAt 优先，缺则 proposedAt；都无 → null（优雅降级）。 */
+function timeMsOf(decision: DecisionRow): number | null {
+  const raw = decision.decidedAt ?? decision.proposedAt;
+  if (!raw) return null;
+  const ms = new Date(raw).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function shortTime(decision: DecisionRow): string {
+  const raw = decision.decidedAt ?? decision.proposedAt;
+  if (!raw) return "无判定时间";
+  return raw.slice(0, 10);
+}
+
+interface GenealogyEdge {
+  from: string; // 后代（较新，refines/narrows/... 的一方）
+  to: string; // 祖先（较旧，被 refine 的一方）
+  kind: RelationKind;
+  rationale?: string;
+}
+
+interface LaidOutNode {
+  id: string;
+  decision: DecisionRow;
+  depth: number; // 相对焦点：祖先为负、焦点为 0、后代为正
+  timeMs: number | null;
+  x: number; // 卡片左上角 x（含 PAD）
+  y: number; // 卡片左上角 y（含 AXIS + PAD）
+}
+
+/** 全量谱系边（decision→decision），去重。 */
+function buildGenealogyEdges(
+  relations: RelationEdge[],
+  byId: Map<string, DecisionRow>,
+): GenealogyEdge[] {
+  const seen = new Set<string>();
+  const edges: GenealogyEdge[] = [];
+  for (const relation of relations) {
+    if (!GENEALOGY_KINDS.has(relation.kind)) continue;
+    const from = decisionIdOf(relation.from);
+    const to = decisionIdOf(relation.to);
+    if (!from || !to || from === to) continue;
+    if (!byId.has(from) || !byId.has(to)) continue;
+    const key = `${from}|${to}|${relation.kind}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    edges.push({ from, to, kind: relation.kind, rationale: relation.rationale });
+  }
+  return edges;
+}
+
+/** 以 focus 为中心，上溯祖先（沿 from→to）+ 下溯后代（沿 to→from），返回带 depth 的谱系集合。 */
+function collectLineage(
+  focusId: string,
+  edges: GenealogyEdge[],
+): Map<string, number> {
+  const outByFrom = new Map<string, GenealogyEdge[]>();
+  const inByTo = new Map<string, GenealogyEdge[]>();
+  for (const edge of edges) {
+    (outByFrom.get(edge.from) ?? outByFrom.set(edge.from, []).get(edge.from)!).push(edge);
+    (inByTo.get(edge.to) ?? inByTo.set(edge.to, []).get(edge.to)!).push(edge);
+  }
+
+  const depth = new Map<string, number>([[focusId, 0]]);
+
+  // 上溯祖先：focus --refines--> ancestor，祖先更旧 → 负 depth。
+  const upQueue: string[] = [focusId];
+  while (upQueue.length > 0) {
+    const current = upQueue.shift()!;
+    const currentDepth = depth.get(current)!;
+    for (const edge of outByFrom.get(current) ?? []) {
+      if (!depth.has(edge.to)) {
+        depth.set(edge.to, currentDepth - 1);
+        upQueue.push(edge.to);
+      }
+    }
+  }
+
+  // 下溯后代：descendant --refines--> focus，后代更新 → 正 depth。
+  const downQueue: string[] = [focusId];
+  while (downQueue.length > 0) {
+    const current = downQueue.shift()!;
+    const currentDepth = depth.get(current)!;
+    for (const edge of inByTo.get(current) ?? []) {
+      if (!depth.has(edge.from)) {
+        depth.set(edge.from, currentDepth + 1);
+        downQueue.push(edge.from);
+      }
+    }
+  }
+
+  return depth;
+}
+
+/** 时间轴上做 3–6 个刻度。 */
+function axisTicks(minT: number, maxT: number): { t: number; label: string }[] {
+  if (!(maxT > minT)) return [];
+  const count = 5;
+  const ticks: { t: number; label: string }[] = [];
+  for (let i = 0; i <= count; i += 1) {
+    const t = minT + ((maxT - minT) * i) / count;
+    ticks.push({ t, label: new Date(t).toISOString().slice(0, 10) });
+  }
+  return ticks;
+}
+
+function DecisionDetailPanel({
+  decision,
+  onClose,
+  onNavigateEntity,
+  onFocusGraph,
+}: {
+  decision: DecisionRow;
+  onClose: () => void;
+  onNavigateEntity?: (ref: string) => void;
+  onFocusGraph?: (ref: string) => void;
+}) {
+  return (
+    <aside className="flex w-[340px] shrink-0 flex-col border-l border-border bg-surface">
+      <header className="flex items-start gap-2 border-b border-border px-3 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="font-mono text-[11px] text-text-faint">{decision.decisionId}</span>
+            <DecisionStateBadge state={decision.state} />
+          </div>
+          <h3 className="mt-1 text-[15px] font-semibold leading-snug text-text">{decision.title}</h3>
+        </div>
+        <button
+          onClick={onClose}
+          title="关闭详情"
+          className="grid size-6 shrink-0 place-items-center rounded text-text-faint hover:bg-surface-raised hover:text-text"
+        >
+          <X weight="bold" />
+        </button>
+      </header>
+      <div className="min-h-0 flex-1 overflow-auto px-3 py-3">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[11px] text-text-faint">
+          <span>decided {decision.decidedAt ? decision.decidedAt.slice(0, 16).replace("T", " ") : "—"}</span>
+          <span>proposed {decision.proposedAt ? decision.proposedAt.slice(0, 16).replace("T", " ") : "—"}</span>
+        </div>
+        <p className="mt-2 text-[12px] leading-relaxed text-text-muted">
+          <span className="font-semibold text-text-faint">Q: </span>
+          {decision.question}
+        </p>
+        {decision.chosen.length > 0 && (
+          <section className="mt-3">
+            <div className="font-mono text-[10px] uppercase tracking-wide text-text-faint">chosen</div>
+            <ul className="mt-1 space-y-1">
+              {decision.chosen.map((claim) => (
+                <li key={claim.id} className="flex gap-1.5 text-[12px] leading-snug text-text">
+                  <span className="font-mono text-[10px] text-accent">{claim.id}</span>
+                  <span className="min-w-0">{claim.text}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        {decision.rejected.length > 0 && (
+          <section className="mt-3">
+            <div className="font-mono text-[10px] uppercase tracking-wide text-text-faint">rejected</div>
+            <ul className="mt-1 space-y-1">
+              {decision.rejected.map((claim) => (
+                <li key={claim.id} className="text-[12px] leading-snug text-text-muted">
+                  <span className="font-mono text-[10px] text-danger">{claim.id}</span> {claim.text}
+                  {claim.whyNot && (
+                    <span className="mt-0.5 block text-[11px] text-text-faint">↳ {claim.whyNot}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </div>
+      <footer className="flex items-center gap-2 border-t border-border px-3 py-2.5">
+        {onNavigateEntity && (
+          <button
+            onClick={() => onNavigateEntity(`decision/${decision.decisionId}`)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[12px] text-text-muted hover:border-border-strong hover:text-text"
+          >
+            <ArrowSquareOut weight="bold" />
+            在决策池查看
+          </button>
+        )}
+        {onFocusGraph && (
+          <button
+            onClick={() => onFocusGraph(`decision/${decision.decisionId}`)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[12px] text-text-muted hover:border-border-strong hover:text-accent"
+          >
+            <Graph weight="bold" />
+            在关系图聚焦
+          </button>
+        )}
+      </footer>
+    </aside>
+  );
+}
+
+export function GenealogyTimelineView({
+  decisions,
+  relations,
+  focusRef,
+  onNavigateEntity,
+  onFocusGraph,
+}: {
+  decisions: DecisionRow[];
+  relations: RelationEdge[];
+  /** 跨视图带入的聚焦实体（decision/<id>）；用于多视图切换同一实体。 */
+  focusRef?: string | null;
+  onNavigateEntity?: (ref: string) => void;
+  onFocusGraph?: (ref: string) => void;
+}) {
+  const byId = useMemo(() => {
+    const map = new Map<string, DecisionRow>();
+    for (const decision of decisions) map.set(decision.decisionId, decision);
+    return map;
+  }, [decisions]);
+
+  const edges = useMemo(() => buildGenealogyEdges(relations, byId), [relations, byId]);
+
+  // 参与谱系（有任一谱系边）的 decision——左栏候选焦点集。
+  const participants = useMemo(() => {
+    const ids = new Set<string>();
+    for (const edge of edges) {
+      ids.add(edge.from);
+      ids.add(edge.to);
+    }
+    return [...ids]
+      .map((id) => byId.get(id)!)
+      .filter(Boolean)
+      .sort((a, b) => (timeMsOf(b) ?? 0) - (timeMsOf(a) ?? 0));
+  }, [edges, byId]);
+
+  // 每个 decision 的谱系规模（祖先+后代数），用于默认挑一个「最有料」的焦点。
+  const lineageSize = useMemo(() => {
+    const size = new Map<string, number>();
+    for (const decision of participants) {
+      size.set(decision.decisionId, collectLineage(decision.decisionId, edges).size - 1);
+    }
+    return size;
+  }, [participants, edges]);
+
+  const [focusId, setFocusId] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [hoverId, setHoverId] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+
+  // 跨视图带入的焦点优先；否则挑谱系最大的一个。
+  useEffect(() => {
+    const incoming = focusRef ? decisionIdOf(focusRef) : null;
+    if (incoming && byId.has(incoming)) {
+      setFocusId(incoming);
+      return;
+    }
+    setFocusId((current) => {
+      if (current && byId.has(current)) return current;
+      if (participants.length === 0) return null;
+      let best = participants[0].decisionId;
+      let bestSize = lineageSize.get(best) ?? 0;
+      for (const decision of participants) {
+        const size = lineageSize.get(decision.decisionId) ?? 0;
+        if (size > bestSize) {
+          best = decision.decisionId;
+          bestSize = size;
+        }
+      }
+      return best;
+    });
+  }, [focusRef, byId, participants, lineageSize]);
+
+  const focus = focusId ? byId.get(focusId) ?? null : null;
+
+  // 容器宽度测量（时间轴需要具体像素宽）。
+  const plotRef = useRef<HTMLDivElement | null>(null);
+  const [plotWidth, setPlotWidth] = useState(900);
+  useLayoutEffect(() => {
+    const element = plotRef.current;
+    if (!element) return;
+    const update = () => setPlotWidth(element.clientWidth);
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  // 焦点谱系的布局。
+  const layout = useMemo(() => {
+    if (!focus) {
+      return { nodes: [] as LaidOutNode[], width: 0, height: 0, ticks: [] as { x: number; label: string }[], minT: 0, maxT: 0 };
+    }
+    const depthMap = collectLineage(focus.decisionId, edges);
+    const rawNodes = [...depthMap.entries()]
+      .map(([id, depth]) => {
+        const decision = byId.get(id);
+        if (!decision) return null;
+        return { id, decision, depth, timeMs: timeMsOf(decision) };
+      })
+      .filter((node): node is Omit<LaidOutNode, "x" | "y"> => node !== null);
+
+    const times = rawNodes.map((node) => node.timeMs).filter((t): t is number => t !== null);
+    const minT = times.length > 0 ? Math.min(...times) : 0;
+    const maxT = times.length > 0 ? Math.max(...times) : 0;
+    const span = maxT - minT;
+
+    const plotW = Math.max(360, plotWidth - PAD_X * 2 - CARD_W);
+    const xOfTime = (timeMs: number | null): number => {
+      if (timeMs === null) return 0; // 无时间 → 贴最左，并在卡上标注
+      if (span <= 0) return plotW / 2;
+      return ((timeMs - minT) / span) * plotW;
+    };
+
+    // 按 depth 升序（祖先在上）分带，带内按 x 排序后贪心装道，保证零重叠。
+    const depths = [...new Set(rawNodes.map((node) => node.depth))].sort((a, b) => a - b);
+    const placed: LaidOutNode[] = [];
+    let rowCursor = 0;
+    for (const depth of depths) {
+      const group = rawNodes
+        .filter((node) => node.depth === depth)
+        .sort((a, b) => xOfTime(a.timeMs) - xOfTime(b.timeMs));
+      const laneRight: number[] = [];
+      for (const node of group) {
+        const nx = xOfTime(node.timeMs);
+        let lane = laneRight.findIndex((right) => nx >= right + LANE_GAP);
+        if (lane === -1) {
+          lane = laneRight.length;
+          laneRight.push(0);
+        }
+        laneRight[lane] = nx + CARD_W;
+        placed.push({
+          ...node,
+          x: PAD_X + nx,
+          y: AXIS_H + PAD_Y + (rowCursor + lane) * ROW_H,
+        });
+      }
+      rowCursor += Math.max(1, laneRight.length);
+    }
+
+    const width = PAD_X * 2 + plotW + CARD_W;
+    const height = AXIS_H + PAD_Y * 2 + rowCursor * ROW_H;
+    const ticks = axisTicks(minT, maxT).map((tick) => ({
+      x: PAD_X + xOfTime(tick.t),
+      label: tick.label,
+    }));
+    return { nodes: placed, width, height, ticks, minT, maxT };
+  }, [focus, edges, byId, plotWidth]);
+
+  const nodeById = useMemo(() => {
+    const map = new Map<string, LaidOutNode>();
+    for (const node of layout.nodes) map.set(node.id, node);
+    return map;
+  }, [layout.nodes]);
+
+  // 焦点谱系内的边（两端都在布局集合里）。
+  const lineageEdges = useMemo(
+    () => edges.filter((edge) => nodeById.has(edge.from) && nodeById.has(edge.to)),
+    [edges, nodeById],
+  );
+
+  const selected = selectedId ? byId.get(selectedId) ?? null : null;
+  const ancestorCount = layout.nodes.filter((node) => node.depth < 0).length;
+  const descendantCount = layout.nodes.filter((node) => node.depth > 0).length;
+
+  const filteredParticipants = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return participants;
+    return participants.filter(
+      (decision) =>
+        decision.title.toLowerCase().includes(needle) ||
+        decision.decisionId.toLowerCase().includes(needle),
+    );
+  }, [participants, query]);
+
+  if (edges.length === 0) {
+    return (
+      <div
+        data-testid="genealogy-timeline-empty-state"
+        className="flex h-full min-h-0 flex-1 flex-col items-center justify-center gap-2 bg-surface px-6 text-center"
+      >
+        <ClockCounterClockwise weight="duotone" className="text-3xl text-text-faint" />
+        <div className="text-[14px] font-semibold text-text">暂无决策谱系可展示</div>
+        <div className="max-w-md text-[12px] leading-relaxed text-text-faint">
+          当前 ledger 里没有 refines / narrows / supersedes / supports 的 decision→decision 边。
+          出现思想演化关系后，这里会按时间轴渲染其谱系。
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      <header className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b border-border px-4 py-2.5">
+        <h1 className="ui-title inline-flex items-center gap-1.5 font-semibold">
+          <ClockCounterClockwise weight="duotone" className="text-accent" />
+          决策演化史
+        </h1>
+        <span className="font-mono text-[12px] text-text-faint">
+          {participants.length} 决策参与谱系 · {edges.length} 条演化边
+        </span>
+        {focus && (
+          <span className="font-mono text-[11px] text-text-faint">
+            焦点谱系：{ancestorCount} 祖先 · {descendantCount} 后代
+          </span>
+        )}
+        <div className="ml-auto flex flex-wrap items-center gap-2 text-[11px]">
+          {(["refines", "narrows", "supersedes", "supports"] as const).map((kind) => (
+            <span key={kind} className="inline-flex items-center gap-1 text-text-muted">
+              <svg width="18" height="6" aria-hidden>
+                <line x1="0" y1="3" x2="18" y2="3" stroke={KIND_META[kind].color} strokeWidth="2" />
+              </svg>
+              {KIND_META[kind].label}
+            </span>
+          ))}
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        {/* 左栏：谱系参与决策列表（选一个作焦点，主区聚焦其演化史）。 */}
+        <div className="flex w-[260px] shrink-0 flex-col border-r border-border bg-surface/60">
+          <div className="border-b border-border px-2.5 py-2">
+            <div className="flex items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1">
+              <MagnifyingGlass weight="bold" className="text-text-faint" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="搜索决策 id / 标题"
+                className="min-w-0 flex-1 bg-transparent text-[12px] text-text outline-none placeholder:text-text-faint"
+              />
+            </div>
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto py-1">
+            {filteredParticipants.map((decision) => {
+              const active = decision.decisionId === focusId;
+              const size = lineageSize.get(decision.decisionId) ?? 0;
+              return (
+                <button
+                  key={decision.decisionId}
+                  onClick={() => {
+                    setFocusId(decision.decisionId);
+                    setSelectedId(null);
+                  }}
+                  className={`flex w-full flex-col gap-0.5 border-l-2 px-2.5 py-1.5 text-left transition-colors ${
+                    active
+                      ? "border-accent bg-accent/10"
+                      : "border-transparent hover:bg-surface-raised"
+                  }`}
+                >
+                  <div className="flex items-center gap-1.5">
+                    <span className="truncate font-mono text-[10px] text-text-faint">{decision.decisionId}</span>
+                    <span className="ml-auto inline-flex items-center gap-0.5 font-mono text-[10px] text-text-faint">
+                      <GitBranch weight="bold" />
+                      {size}
+                    </span>
+                  </div>
+                  <span className={`truncate text-[12px] leading-snug ${active ? "text-text" : "text-text-muted"}`}>
+                    {decision.title}
+                  </span>
+                  <span className="font-mono text-[10px] text-text-faint">{shortTime(decision)}</span>
+                </button>
+              );
+            })}
+            {filteredParticipants.length === 0 && (
+              <div className="px-3 py-6 text-center text-[12px] text-text-faint">无匹配决策</div>
+            )}
+          </div>
+        </div>
+
+        {/* 主区：时间轴谱系。 */}
+        <div ref={plotRef} className="relative min-h-0 min-w-0 flex-1 overflow-auto bg-bg">
+          {focus && layout.nodes.length <= 1 ? (
+            <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+              <div className="text-[13px] font-semibold text-text">{focus.title}</div>
+              <div className="max-w-md text-[12px] leading-relaxed text-text-faint">
+                该决策暂无 refines / narrows / supersedes / supports 谱系关系（孤立节点）。
+                从左栏选择一个带谱系的决策查看其演化史。
+              </div>
+            </div>
+          ) : (
+            <div className="relative" style={{ width: layout.width, height: layout.height, minWidth: "100%" }}>
+              {/* 时间轴刻度 + 竖向网格 */}
+              <svg
+                className="pointer-events-none absolute inset-0"
+                width={layout.width}
+                height={layout.height}
+              >
+                <defs>
+                  {(["refines", "narrows", "supersedes", "supports"] as const).map((kind) => (
+                    <marker
+                      key={kind}
+                      id={`gen-arrow-${kind}`}
+                      viewBox="0 0 8 8"
+                      refX="7"
+                      refY="4"
+                      markerWidth="6"
+                      markerHeight="6"
+                      orient="auto-start-reverse"
+                    >
+                      <path d="M0,0 L8,4 L0,8 z" fill={KIND_META[kind].color} />
+                    </marker>
+                  ))}
+                </defs>
+                {layout.ticks.map((tick, index) => (
+                  <g key={index}>
+                    <line
+                      x1={tick.x}
+                      y1={AXIS_H}
+                      x2={tick.x}
+                      y2={layout.height}
+                      stroke="var(--color-border)"
+                      strokeWidth="1"
+                      strokeDasharray="2 4"
+                    />
+                    <text x={tick.x + 3} y={20} fill="var(--color-text-faint)" fontSize="10" fontFamily="var(--font-mono)">
+                      {tick.label}
+                    </text>
+                  </g>
+                ))}
+                {/* 谱系边 */}
+                {lineageEdges.map((edge, index) => {
+                  const ancestor = nodeById.get(edge.to)!;
+                  const descendant = nodeById.get(edge.from)!;
+                  const ancRight = ancestor.x <= descendant.x;
+                  const sx = ancRight ? ancestor.x + CARD_W : ancestor.x;
+                  const sy = ancestor.y + CARD_H / 2;
+                  const ex = ancRight ? descendant.x : descendant.x + CARD_W;
+                  const ey = descendant.y + CARD_H / 2;
+                  const dx = (ex - sx) * 0.45;
+                  const incident = hoverId === edge.from || hoverId === edge.to;
+                  const dim = hoverId !== null && !incident;
+                  return (
+                    <path
+                      key={index}
+                      d={`M ${sx} ${sy} C ${sx + dx} ${sy}, ${ex - dx} ${ey}, ${ex} ${ey}`}
+                      fill="none"
+                      stroke={KIND_META[edge.kind]?.color ?? "var(--color-border-strong)"}
+                      strokeWidth={incident ? 2.2 : 1.4}
+                      strokeOpacity={dim ? 0.15 : 0.85}
+                      markerEnd={`url(#gen-arrow-${edge.kind})`}
+                    />
+                  );
+                })}
+              </svg>
+
+              {/* 决策卡 */}
+              {layout.nodes.map((node) => {
+                const isFocus = node.depth === 0;
+                const isSelected = node.id === selectedId;
+                const dim = hoverId !== null && hoverId !== node.id;
+                return (
+                  <button
+                    key={node.id}
+                    onClick={() => setSelectedId((prev) => (prev === node.id ? null : node.id))}
+                    onMouseEnter={() => setHoverId(node.id)}
+                    onMouseLeave={() => setHoverId(null)}
+                    style={{ left: node.x, top: node.y, width: CARD_W, height: CARD_H }}
+                    className={`absolute flex flex-col justify-center gap-1 rounded-lg border px-2.5 py-1.5 text-left transition-colors ${
+                      isFocus
+                        ? "border-accent bg-accent/10"
+                        : isSelected
+                          ? "border-border-strong bg-surface-raised"
+                          : "border-border bg-surface hover:border-border-strong"
+                    } ${dim ? "opacity-40" : ""}`}
+                  >
+                    <div className="flex items-center gap-1.5">
+                      <span className="truncate font-mono text-[10px] text-text-faint">{node.id}</span>
+                      {isFocus && (
+                        <span className="ml-auto rounded bg-accent px-1 py-px font-mono text-[9px] font-semibold text-accent-fg">
+                          焦点
+                        </span>
+                      )}
+                    </div>
+                    <span className="truncate text-[12px] font-medium leading-tight text-text">{node.decision.title}</span>
+                    <div className="flex items-center gap-1.5">
+                      <span className="font-mono text-[9px] text-text-faint">{shortTime(node.decision)}</span>
+                      {node.timeMs === null && (
+                        <span className="rounded bg-stale/15 px-1 font-mono text-[9px] text-stale">无时间</span>
+                      )}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {selected && (
+          <DecisionDetailPanel
+            decision={selected}
+            onClose={() => setSelectedId(null)}
+            onNavigateEntity={onNavigateEntity}
+            onFocusGraph={onFocusGraph}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/gui/src/renderer/views/genealogy/DecisionDetailPanel.tsx
+++ b/packages/gui/src/renderer/views/genealogy/DecisionDetailPanel.tsx
@@ -1,0 +1,95 @@
+import { ArrowSquareOut, Graph, X } from "@phosphor-icons/react";
+import type { DecisionRow } from "../../model/types";
+import { DecisionStateBadge } from "../../components/badges";
+
+/** 选中决策的详情面板（右栏）：id / 状态 / question / chosen / rejected + 外链。 */
+export function DecisionDetailPanel({
+  decision,
+  onClose,
+  onNavigateEntity,
+  onFocusGraph,
+}: {
+  decision: DecisionRow;
+  onClose: () => void;
+  onNavigateEntity?: (ref: string) => void;
+  onFocusGraph?: (ref: string) => void;
+}) {
+  return (
+    <aside className="flex w-[340px] shrink-0 flex-col border-l border-border bg-surface">
+      <header className="flex items-start gap-2 border-b border-border px-3 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="font-mono text-[11px] text-text-faint">{decision.decisionId}</span>
+            <DecisionStateBadge state={decision.state} />
+          </div>
+          <h3 className="mt-1 text-[15px] font-semibold leading-snug text-text">{decision.title}</h3>
+        </div>
+        <button
+          onClick={onClose}
+          title="关闭详情"
+          className="grid size-6 shrink-0 place-items-center rounded text-text-faint hover:bg-surface-raised hover:text-text"
+        >
+          <X weight="bold" />
+        </button>
+      </header>
+      <div className="min-h-0 flex-1 overflow-auto px-3 py-3">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[11px] text-text-faint">
+          <span>decided {decision.decidedAt ? decision.decidedAt.slice(0, 16).replace("T", " ") : "—"}</span>
+          <span>proposed {decision.proposedAt ? decision.proposedAt.slice(0, 16).replace("T", " ") : "—"}</span>
+        </div>
+        <p className="mt-2 text-[12px] leading-relaxed text-text-muted">
+          <span className="font-semibold text-text-faint">Q: </span>
+          {decision.question}
+        </p>
+        {decision.chosen.length > 0 && (
+          <section className="mt-3">
+            <div className="font-mono text-[10px] uppercase tracking-wide text-text-faint">chosen</div>
+            <ul className="mt-1 space-y-1">
+              {decision.chosen.map((claim) => (
+                <li key={claim.id} className="flex gap-1.5 text-[12px] leading-snug text-text">
+                  <span className="font-mono text-[10px] text-accent">{claim.id}</span>
+                  <span className="min-w-0">{claim.text}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        {decision.rejected.length > 0 && (
+          <section className="mt-3">
+            <div className="font-mono text-[10px] uppercase tracking-wide text-text-faint">rejected</div>
+            <ul className="mt-1 space-y-1">
+              {decision.rejected.map((claim) => (
+                <li key={claim.id} className="text-[12px] leading-snug text-text-muted">
+                  <span className="font-mono text-[10px] text-danger">{claim.id}</span> {claim.text}
+                  {claim.whyNot && (
+                    <span className="mt-0.5 block text-[11px] text-text-faint">↳ {claim.whyNot}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </div>
+      <footer className="flex items-center gap-2 border-t border-border px-3 py-2.5">
+        {onNavigateEntity && (
+          <button
+            onClick={() => onNavigateEntity(`decision/${decision.decisionId}`)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[12px] text-text-muted hover:border-border-strong hover:text-text"
+          >
+            <ArrowSquareOut weight="bold" />
+            在决策池查看
+          </button>
+        )}
+        {onFocusGraph && (
+          <button
+            onClick={() => onFocusGraph(`decision/${decision.decisionId}`)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[12px] text-text-muted hover:border-border-strong hover:text-accent"
+          >
+            <Graph weight="bold" />
+            在关系图聚焦
+          </button>
+        )}
+      </footer>
+    </aside>
+  );
+}

--- a/packages/gui/src/renderer/views/genealogy/EmptyStates.tsx
+++ b/packages/gui/src/renderer/views/genealogy/EmptyStates.tsx
@@ -1,0 +1,32 @@
+import { ClockCounterClockwise } from "@phosphor-icons/react";
+import type { DecisionRow } from "../../model/types";
+
+/** 全 ledger 无任何谱系边时的占位（data-testid 供集成测试定位）。 */
+export function GenealogyEmptyState() {
+  return (
+    <div
+      data-testid="genealogy-timeline-empty-state"
+      className="flex h-full min-h-0 flex-1 flex-col items-center justify-center gap-2 bg-surface px-6 text-center"
+    >
+      <ClockCounterClockwise weight="duotone" className="text-3xl text-text-faint" />
+      <div className="text-[14px] font-semibold text-text">暂无决策谱系可展示</div>
+      <div className="max-w-md text-[12px] leading-relaxed text-text-faint">
+        当前 ledger 里没有 refines / narrows / supersedes / supports 的 decision→decision 边。
+        出现思想演化关系后，这里会按时间轴渲染其谱系。
+      </div>
+    </div>
+  );
+}
+
+/** 焦点决策为孤立节点（无任何谱系边）时的主区提示。 */
+export function IsolatedNodeMessage({ decision }: { decision: DecisionRow }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+      <div className="text-[13px] font-semibold text-text">{decision.title}</div>
+      <div className="max-w-md text-[12px] leading-relaxed text-text-faint">
+        该决策暂无 refines / narrows / supersedes / supports 谱系关系（孤立节点）。
+        从左栏选择一个带谱系的决策查看其演化史。
+      </div>
+    </div>
+  );
+}

--- a/packages/gui/src/renderer/views/genealogy/ParticipantsSidebar.tsx
+++ b/packages/gui/src/renderer/views/genealogy/ParticipantsSidebar.tsx
@@ -1,0 +1,70 @@
+import { GitBranch, MagnifyingGlass } from "@phosphor-icons/react";
+import type { DecisionRow } from "../../model/types";
+import { shortTime } from "./layout";
+
+/**
+ * 左栏：参与谱系的决策列表（搜索框 + 焦点候选）。点选一项即把主区焦点切到它的演化史。
+ */
+export function ParticipantsSidebar({
+  participants,
+  focusId,
+  lineageSize,
+  query,
+  onQueryChange,
+  onFocus,
+}: {
+  participants: DecisionRow[];
+  focusId: string | null;
+  lineageSize: Map<string, number>;
+  query: string;
+  onQueryChange: (value: string) => void;
+  onFocus: (decisionId: string) => void;
+}) {
+  return (
+    <div className="flex w-[260px] shrink-0 flex-col border-r border-border bg-surface/60">
+      <div className="border-b border-border px-2.5 py-2">
+        <div className="flex items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1">
+          <MagnifyingGlass weight="bold" className="text-text-faint" />
+          <input
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder="搜索决策 id / 标题"
+            className="min-w-0 flex-1 bg-transparent text-[12px] text-text outline-none placeholder:text-text-faint"
+          />
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto py-1">
+        {participants.map((decision) => {
+          const active = decision.decisionId === focusId;
+          const size = lineageSize.get(decision.decisionId) ?? 0;
+          return (
+            <button
+              key={decision.decisionId}
+              onClick={() => onFocus(decision.decisionId)}
+              className={`flex w-full flex-col gap-0.5 border-l-2 px-2.5 py-1.5 text-left transition-colors ${
+                active
+                  ? "border-accent bg-accent/10"
+                  : "border-transparent hover:bg-surface-raised"
+              }`}
+            >
+              <div className="flex items-center gap-1.5">
+                <span className="truncate font-mono text-[10px] text-text-faint">{decision.decisionId}</span>
+                <span className="ml-auto inline-flex items-center gap-0.5 font-mono text-[10px] text-text-faint">
+                  <GitBranch weight="bold" />
+                  {size}
+                </span>
+              </div>
+              <span className={`truncate text-[12px] leading-snug ${active ? "text-text" : "text-text-muted"}`}>
+                {decision.title}
+              </span>
+              <span className="font-mono text-[10px] text-text-faint">{shortTime(decision)}</span>
+            </button>
+          );
+        })}
+        {participants.length === 0 && (
+          <div className="px-3 py-6 text-center text-[12px] text-text-faint">无匹配决策</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/gui/src/renderer/views/genealogy/TimelinePlot.tsx
+++ b/packages/gui/src/renderer/views/genealogy/TimelinePlot.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+import type { GenealogyEdge, LaidOutNode, TimelineLayout } from "./layout";
+import { AXIS_H, CARD_H, CARD_W, KIND_META, shortTime } from "./layout";
+
+/**
+ * 主区时间轴谱系：时间刻度 + 竖向网格 + 谱系边（带箭头与语义色）+ 决策卡。
+ * hover 高亮自管：悬停一张卡时，与之无关的边/卡会被压暗。
+ */
+export function TimelinePlot({
+  layout,
+  nodeById,
+  lineageEdges,
+  selectedId,
+  onToggleSelect,
+}: {
+  layout: TimelineLayout;
+  nodeById: Map<string, LaidOutNode>;
+  lineageEdges: GenealogyEdge[];
+  selectedId: string | null;
+  onToggleSelect: (id: string) => void;
+}) {
+  const [hoverId, setHoverId] = useState<string | null>(null);
+
+  return (
+    <div className="relative" style={{ width: layout.width, height: layout.height, minWidth: "100%" }}>
+      {/* 时间轴刻度 + 竖向网格 */}
+      <svg
+        className="pointer-events-none absolute inset-0"
+        width={layout.width}
+        height={layout.height}
+      >
+        <defs>
+          {(["refines", "narrows", "supersedes", "supports"] as const).map((kind) => (
+            <marker
+              key={kind}
+              id={`gen-arrow-${kind}`}
+              viewBox="0 0 8 8"
+              refX="7"
+              refY="4"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto-start-reverse"
+            >
+              <path d="M0,0 L8,4 L0,8 z" fill={KIND_META[kind].color} />
+            </marker>
+          ))}
+        </defs>
+        {layout.ticks.map((tick, index) => (
+          <g key={index}>
+            <line
+              x1={tick.x}
+              y1={AXIS_H}
+              x2={tick.x}
+              y2={layout.height}
+              stroke="var(--color-border)"
+              strokeWidth="1"
+              strokeDasharray="2 4"
+            />
+            <text x={tick.x + 3} y={20} fill="var(--color-text-faint)" fontSize="10" fontFamily="var(--font-mono)">
+              {tick.label}
+            </text>
+          </g>
+        ))}
+        {/* 谱系边 */}
+        {lineageEdges.map((edge, index) => {
+          const ancestor = nodeById.get(edge.to)!;
+          const descendant = nodeById.get(edge.from)!;
+          const ancRight = ancestor.x <= descendant.x;
+          const sx = ancRight ? ancestor.x + CARD_W : ancestor.x;
+          const sy = ancestor.y + CARD_H / 2;
+          const ex = ancRight ? descendant.x : descendant.x + CARD_W;
+          const ey = descendant.y + CARD_H / 2;
+          const dx = (ex - sx) * 0.45;
+          const incident = hoverId === edge.from || hoverId === edge.to;
+          const dim = hoverId !== null && !incident;
+          return (
+            <path
+              key={index}
+              d={`M ${sx} ${sy} C ${sx + dx} ${sy}, ${ex - dx} ${ey}, ${ex} ${ey}`}
+              fill="none"
+              stroke={KIND_META[edge.kind]?.color ?? "var(--color-border-strong)"}
+              strokeWidth={incident ? 2.2 : 1.4}
+              strokeOpacity={dim ? 0.15 : 0.85}
+              markerEnd={`url(#gen-arrow-${edge.kind})`}
+            />
+          );
+        })}
+      </svg>
+
+      {/* 决策卡 */}
+      {layout.nodes.map((node) => {
+        const isFocus = node.depth === 0;
+        const isSelected = node.id === selectedId;
+        const dim = hoverId !== null && hoverId !== node.id;
+        return (
+          <button
+            key={node.id}
+            onClick={() => onToggleSelect(node.id)}
+            onMouseEnter={() => setHoverId(node.id)}
+            onMouseLeave={() => setHoverId(null)}
+            style={{ left: node.x, top: node.y, width: CARD_W, height: CARD_H }}
+            className={`absolute flex flex-col justify-center gap-1 rounded-lg border px-2.5 py-1.5 text-left transition-colors ${
+              isFocus
+                ? "border-accent bg-accent/10"
+                : isSelected
+                  ? "border-border-strong bg-surface-raised"
+                  : "border-border bg-surface hover:border-border-strong"
+            } ${dim ? "opacity-40" : ""}`}
+          >
+            <div className="flex items-center gap-1.5">
+              <span className="truncate font-mono text-[10px] text-text-faint">{node.id}</span>
+              {isFocus && (
+                <span className="ml-auto rounded bg-accent px-1 py-px font-mono text-[9px] font-semibold text-accent-fg">
+                  焦点
+                </span>
+              )}
+            </div>
+            <span className="truncate text-[12px] font-medium leading-tight text-text">{node.decision.title}</span>
+            <div className="flex items-center gap-1.5">
+              <span className="font-mono text-[9px] text-text-faint">{shortTime(node.decision)}</span>
+              {node.timeMs === null && (
+                <span className="rounded bg-stale/15 px-1 font-mono text-[9px] text-stale">无时间</span>
+              )}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/gui/src/renderer/views/genealogy/layout.ts
+++ b/packages/gui/src/renderer/views/genealogy/layout.ts
@@ -1,0 +1,237 @@
+import type { DecisionRow, RelationEdge, RelationKind } from "../../model/types";
+
+/**
+ * 决策谱系「演化史」视图的纯逻辑层：常量、类型、关系筛选、深度优先谱系收集、
+ * 时间轴布局计算。无 React、无 JSX，方便单测与复用。
+ *
+ * 承接 dec_01KXA7811SVVT8P66HNDFZQ7DF 原则 6：关系图解决「结构」，而 decision
+ * 谱系（refines/narrows/supersedes/supports）本质是**时间演化**，用一条时间轴
+ * 更清晰——X=decidedAt（缺则 fallback proposedAt），行=谱系深度，节点=决策卡。
+ */
+
+// 谱系边：只认权威轴里表达「思想演化」的四类关系，两端必须都是 decision。
+export const GENEALOGY_KINDS = new Set<RelationKind>([
+  "refines",
+  "narrows",
+  "supersedes",
+  "supports",
+]);
+
+// 每类边的语义标签 + 语义色（复用 styles.css 里已定义的 CSS 变量，绝不新造）。
+export const KIND_META: Record<
+  string,
+  { label: string; color: string; verb: string }
+> = {
+  refines: { label: "细化", color: "var(--color-accent)", verb: "细化了" },
+  narrows: { label: "收窄", color: "var(--color-status-in-review)", verb: "收窄了" },
+  supersedes: { label: "推翻", color: "var(--color-danger)", verb: "推翻了" },
+  supports: { label: "支撑", color: "var(--color-status-done)", verb: "支撑了" },
+};
+
+// ---- 布局常量（px）----
+export const CARD_W = 210;
+export const CARD_H = 60;
+export const ROW_H = 82;
+export const AXIS_H = 34;
+export const PAD_X = 28;
+export const PAD_Y = 20;
+export const LANE_GAP = 26; // 同一深度带内两卡的最小水平间隙
+
+export interface GenealogyEdge {
+  from: string; // 后代（较新，refines/narrows/... 的一方）
+  to: string; // 祖先（较旧，被 refine 的一方）
+  kind: RelationKind;
+  rationale?: string;
+}
+
+export interface LaidOutNode {
+  id: string;
+  decision: DecisionRow;
+  depth: number; // 相对焦点：祖先为负、焦点为 0、后代为正
+  timeMs: number | null;
+  x: number; // 卡片左上角 x（含 PAD）
+  y: number; // 卡片左上角 y（含 AXIS + PAD）
+}
+
+export interface TimelineLayout {
+  nodes: LaidOutNode[];
+  width: number;
+  height: number;
+  ticks: { x: number; label: string }[];
+  minT: number;
+  maxT: number;
+}
+
+/** 把 `decision/dec_x/CH1` 之类的 ref 归一成裸 decision id；非 decision 端返回 null。 */
+export function decisionIdOf(ref: string): string | null {
+  if (!ref.startsWith("decision/")) return null;
+  const rest = ref.slice("decision/".length);
+  const id = rest.split("/")[0];
+  return id.length > 0 ? id : null;
+}
+
+/** decidedAt 优先，缺则 proposedAt；都无 → null（优雅降级）。 */
+export function timeMsOf(decision: DecisionRow): number | null {
+  const raw = decision.decidedAt ?? decision.proposedAt;
+  if (!raw) return null;
+  const ms = new Date(raw).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export function shortTime(decision: DecisionRow): string {
+  const raw = decision.decidedAt ?? decision.proposedAt;
+  if (!raw) return "无判定时间";
+  return raw.slice(0, 10);
+}
+
+/** 全量谱系边（decision→decision），去重。 */
+export function buildGenealogyEdges(
+  relations: RelationEdge[],
+  byId: Map<string, DecisionRow>,
+): GenealogyEdge[] {
+  const seen = new Set<string>();
+  const edges: GenealogyEdge[] = [];
+  for (const relation of relations) {
+    if (!GENEALOGY_KINDS.has(relation.kind)) continue;
+    const from = decisionIdOf(relation.from);
+    const to = decisionIdOf(relation.to);
+    if (!from || !to || from === to) continue;
+    if (!byId.has(from) || !byId.has(to)) continue;
+    const key = `${from}|${to}|${relation.kind}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    edges.push({ from, to, kind: relation.kind, rationale: relation.rationale });
+  }
+  return edges;
+}
+
+/** 以 focus 为中心，上溯祖先（沿 from→to）+ 下溯后代（沿 to→from），返回带 depth 的谱系集合。 */
+export function collectLineage(
+  focusId: string,
+  edges: GenealogyEdge[],
+): Map<string, number> {
+  const outByFrom = new Map<string, GenealogyEdge[]>();
+  const inByTo = new Map<string, GenealogyEdge[]>();
+  for (const edge of edges) {
+    (outByFrom.get(edge.from) ?? outByFrom.set(edge.from, []).get(edge.from)!).push(edge);
+    (inByTo.get(edge.to) ?? inByTo.set(edge.to, []).get(edge.to)!).push(edge);
+  }
+
+  const depth = new Map<string, number>([[focusId, 0]]);
+
+  // 上溯祖先：focus --refines--> ancestor，祖先更旧 → 负 depth。
+  const upQueue: string[] = [focusId];
+  while (upQueue.length > 0) {
+    const current = upQueue.shift()!;
+    const currentDepth = depth.get(current)!;
+    for (const edge of outByFrom.get(current) ?? []) {
+      if (!depth.has(edge.to)) {
+        depth.set(edge.to, currentDepth - 1);
+        upQueue.push(edge.to);
+      }
+    }
+  }
+
+  // 下溯后代：descendant --refines--> focus，后代更新 → 正 depth。
+  const downQueue: string[] = [focusId];
+  while (downQueue.length > 0) {
+    const current = downQueue.shift()!;
+    const currentDepth = depth.get(current)!;
+    for (const edge of inByTo.get(current) ?? []) {
+      if (!depth.has(edge.from)) {
+        depth.set(edge.from, currentDepth + 1);
+        downQueue.push(edge.from);
+      }
+    }
+  }
+
+  return depth;
+}
+
+/** 时间轴上做 3–6 个刻度。 */
+export function axisTicks(minT: number, maxT: number): { t: number; label: string }[] {
+  if (!(maxT > minT)) return [];
+  const count = 5;
+  const ticks: { t: number; label: string }[] = [];
+  for (let i = 0; i <= count; i += 1) {
+    const t = minT + ((maxT - minT) * i) / count;
+    ticks.push({ t, label: new Date(t).toISOString().slice(0, 10) });
+  }
+  return ticks;
+}
+
+const EMPTY_LAYOUT: TimelineLayout = {
+  nodes: [],
+  width: 0,
+  height: 0,
+  ticks: [],
+  minT: 0,
+  maxT: 0,
+};
+
+/**
+ * 焦点谱系的时间轴布局：按 depth 升序（祖先在上）分带，带内按 x 排序后贪心装道，
+ * 保证零重叠。无焦点 → 空布局。
+ */
+export function computeLayout(
+  focus: DecisionRow | null,
+  edges: GenealogyEdge[],
+  byId: Map<string, DecisionRow>,
+  plotWidth: number,
+): TimelineLayout {
+  if (!focus) return EMPTY_LAYOUT;
+
+  const depthMap = collectLineage(focus.decisionId, edges);
+  const rawNodes = [...depthMap.entries()]
+    .map(([id, depth]) => {
+      const decision = byId.get(id);
+      if (!decision) return null;
+      return { id, decision, depth, timeMs: timeMsOf(decision) };
+    })
+    .filter((node): node is Omit<LaidOutNode, "x" | "y"> => node !== null);
+
+  const times = rawNodes.map((node) => node.timeMs).filter((t): t is number => t !== null);
+  const minT = times.length > 0 ? Math.min(...times) : 0;
+  const maxT = times.length > 0 ? Math.max(...times) : 0;
+  const span = maxT - minT;
+
+  const plotW = Math.max(360, plotWidth - PAD_X * 2 - CARD_W);
+  const xOfTime = (timeMs: number | null): number => {
+    if (timeMs === null) return 0; // 无时间 → 贴最左，并在卡上标注
+    if (span <= 0) return plotW / 2;
+    return ((timeMs - minT) / span) * plotW;
+  };
+
+  const depths = [...new Set(rawNodes.map((node) => node.depth))].sort((a, b) => a - b);
+  const placed: LaidOutNode[] = [];
+  let rowCursor = 0;
+  for (const depth of depths) {
+    const group = rawNodes
+      .filter((node) => node.depth === depth)
+      .sort((a, b) => xOfTime(a.timeMs) - xOfTime(b.timeMs));
+    const laneRight: number[] = [];
+    for (const node of group) {
+      const nx = xOfTime(node.timeMs);
+      let lane = laneRight.findIndex((right) => nx >= right + LANE_GAP);
+      if (lane === -1) {
+        lane = laneRight.length;
+        laneRight.push(0);
+      }
+      laneRight[lane] = nx + CARD_W;
+      placed.push({
+        ...node,
+        x: PAD_X + nx,
+        y: AXIS_H + PAD_Y + (rowCursor + lane) * ROW_H,
+      });
+    }
+    rowCursor += Math.max(1, laneRight.length);
+  }
+
+  const width = PAD_X * 2 + plotW + CARD_W;
+  const height = AXIS_H + PAD_Y * 2 + rowCursor * ROW_H;
+  const ticks = axisTicks(minT, maxT).map((tick) => ({
+    x: PAD_X + xOfTime(tick.t),
+    label: tick.label,
+  }));
+  return { nodes: placed, width, height, ticks, minT, maxT };
+}

--- a/packages/gui/test/genealogy-timeline.vitest.ts
+++ b/packages/gui/test/genealogy-timeline.vitest.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type {
+  DecisionRow,
+  RelationEdge,
+} from "../src/renderer/model/types.ts";
+import { GenealogyTimelineView } from "../src/renderer/views/GenealogyTimelineView.tsx";
+
+/**
+ * 谱系 timeline 视图的组件级测试。验证:
+ *  1. 无谱系边时优雅降级出 empty-state(dec_01KXA7811SVVT8P66HNDFZQ7DF 原则 6 多视图)。
+ *  2. 筛选严格:只认 refines/narrows/supersedes/supports 且两端皆 decision。
+ *     用真实账本里观察到的边形态验证(dec_md ↔ dec_mr* 的 refines/narrows 链)。
+ *  3. claim 锚正确剥离:`decision/dec_x/C1` 归一成 `dec_x` 参与谱系。
+ *
+ * 真实账本(2026-07-12 .harness/generated/triadic-graph)统计:
+ *  refines 77 + narrows 24 + supersedes 7 + supports 2 = 110 条 decision↔decision 边。
+ *  「genealogy empty」是数据环境(daemon 未连),不是筛选逻辑 bug——此测试为凭证。
+ */
+
+function baseDecision(overrides: Partial<DecisionRow> = {}): DecisionRow {
+  return {
+    decisionId: "dec_default",
+    title: "默认决策",
+    state: "active",
+    question: "Q?",
+    chosen: [],
+    rejected: [],
+    claims: [],
+    ...overrides,
+  };
+}
+
+function edge(
+  from: string,
+  to: string,
+  kind: RelationEdge["kind"],
+  extra: Partial<RelationEdge> = {},
+): RelationEdge {
+  return { from, to, kind, provenance: "local-document", ...extra };
+}
+
+describe("GenealogyTimelineView empty-state", () => {
+  it("renders the dedicated empty state when there are no relations at all", () => {
+    const markup = renderToStaticMarkup(
+      createElement(GenealogyTimelineView, {
+        decisions: [baseDecision()],
+        relations: [],
+      }),
+    );
+
+    expect(markup).toContain("genealogy-timeline-empty-state");
+    expect(markup).toContain("暂无决策谱系可展示");
+  });
+
+  it("still shows the empty state when only non-genealogy edges exist (derives/evidenced-by/depends-on)", () => {
+    // 这些都是真实账本里大量存在但**不属于**思想演化谱系的边——必须被筛掉。
+    const relations: RelationEdge[] = [
+      edge("decision/dec_a", "task/task_1", "derives"),
+      edge("decision/dec_a/CH1", "fact/task_1/F-001", "evidenced-by"),
+      edge("task/task_2", "task/task_1", "depends-on"),
+      edge("decision/dec_a", "decision/dec_b", "relates"),
+    ];
+
+    const markup = renderToStaticMarkup(
+      createElement(GenealogyTimelineView, {
+        decisions: [baseDecision({ decisionId: "dec_a" }), baseDecision({ decisionId: "dec_b" })],
+        relations,
+      }),
+    );
+
+    expect(markup).toContain("genealogy-timeline-empty-state");
+  });
+
+  it("ignores genealogy edges that touch a non-decision endpoint", () => {
+    // refines/narrows/supports 只在 decision↔decision 时算谱系;
+    // task→task 或 fact→decision 即便用同样 kind 也不算。
+    const relations: RelationEdge[] = [
+      edge("task/task_a", "task/task_b", "refines"),
+      edge("fact/task_a/F-001", "decision/dec_a", "supports"),
+    ];
+
+    const markup = renderToStaticMarkup(
+      createElement(GenealogyTimelineView, {
+        decisions: [baseDecision({ decisionId: "dec_a" })],
+        relations,
+      }),
+    );
+
+    expect(markup).toContain("genealogy-timeline-empty-state");
+  });
+});
+
+describe("GenealogyTimelineView filter correctness", () => {
+  it("lists decisions joined by refines/narrows as focus candidates", () => {
+    // 复刻真实账本形态:dec_01KXA7... narrows dec_mrcaa7tp(源自 dec_01KXA7811SVVT8P66HNDFZQ7DF)。
+    const decisions: DecisionRow[] = [
+      baseDecision({
+        decisionId: "dec_mrcaa7tp",
+        title: "GUI 控制面 = 可遍历三元语图",
+        proposedAt: "2026-06-01T00:00:00.000Z",
+        decidedAt: "2026-06-05T00:00:00.000Z",
+      }),
+      baseDecision({
+        decisionId: "dec_01KXA7811SVVT8P66HNDFZQ7DF",
+        title: "聚焦式 ego + claim 一等 + 语义轴 + coverage + 多视图",
+        proposedAt: "2026-07-12T03:00:00.000Z",
+        decidedAt: "2026-07-12T03:30:00.000Z",
+      }),
+    ];
+    const relations: RelationEdge[] = [
+      // 带_claim_锚:source 锚到 CH1,target 为裸 decision(真实账本格式)。
+      edge(
+        "decision/dec_01KXA7811SVVT8P66HNDFZQ7DF/C1",
+        "decision/dec_mrcaa7tp",
+        "narrows",
+        { rationale: "收窄为具体显示范式" },
+      ),
+    ];
+
+    const markup = renderToStaticMarkup(
+      createElement(GenealogyTimelineView, { decisions, relations }),
+    );
+
+    // header 统计:2 决策参与,1 演化边
+    expect(markup).toContain("2 决策参与谱系");
+    expect(markup).toContain("1 条演化边");
+    // 左栏 participant 列表里两个 decision 都出现
+    expect(markup).toContain("dec_mrcaa7tp");
+    expect(markup).toContain("dec_01KXA7811SVVT8P66HNDFZQ7DF");
+    expect(markup).toContain("GUI 控制面 = 可遍历三元语图");
+    // 不该出现 empty-state
+    expect(markup).not.toContain("genealogy-timeline-empty-state");
+  });
+
+  it("counts all four genealogy kinds and dedupes identical from|to|kind triples", () => {
+    const decisions: DecisionRow[] = ["dec_a", "dec_b", "dec_c", "dec_d"].map((id) =>
+      baseDecision({ decisionId: id, title: id }),
+    );
+    const relations: RelationEdge[] = [
+      edge("decision/dec_b", "decision/dec_a", "refines"),
+      edge("decision/dec_c", "decision/dec_a", "narrows"),
+      edge("decision/dec_d", "decision/dec_a", "supersedes"),
+      edge("decision/dec_a", "decision/dec_b", "supports"),
+      // 重复同一条 refines(可能来自不同 source claim)应去重
+      edge("decision/dec_b/CH1", "decision/dec_a", "refines"),
+      edge("decision/dec_b/CH2", "decision/dec_a", "refines"),
+    ];
+
+    const markup = renderToStaticMarkup(
+      createElement(GenealogyTimelineView, { decisions, relations }),
+    );
+
+    // 4 个唯一 from|to|kind 组合(b/d/c supersedes + a supports b 都各算一条;
+    // dec_b refines dec_a 多个 claim 锚去重为一条)。
+    expect(markup).toContain("4 条演化边");
+    expect(markup).toContain("4 决策参与谱系");
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -3,5 +3,6 @@ export const guiVitestManifest = [
   "packages/gui/test/fact-triage.vitest.ts",
   "packages/gui/test/taskFilters.vitest.ts",
   "packages/gui/test/task-adapter.vitest.ts",
-  "packages/gui/test/graphLayout.vitest.ts"
+  "packages/gui/test/graphLayout.vitest.ts",
+  "packages/gui/test/genealogy-timeline.vitest.ts"
 ];


### PR DESCRIPTION
# English

## Summary

Add a decision genealogy "evolution history" view (Jaeger-timeline style: X axis = decidedAt with proposedAt fallback, rows = lineage depth) as a sibling main view next to the relation graph, wire a multi-view switcher in App.tsx, and remove the mock task relations from BoardView in favor of real projection data. Implements principle 6 (multi-view; the relation graph is one main view, not the only one) of accepted decision dec_01KXA7811SVVT8P66HNDFZQ7DF. Pure renderer change.

## What Changed

- New `views/GenealogyTimelineView.tsx` plus `views/genealogy/` submodules (layout logic, timeline plot, participants sidebar, detail panel, empty states — all under the file-complexity limit): filters relations to decision-to-decision genealogy kinds (refines / narrows / supersedes / supports, claim-anchored refs handled), builds the lineage of a focused decision via BFS, and renders it on a time axis with decision cards and hover detail.
- App.tsx: registers the "演化史" view with a "same entity · multi-view" switcher between 关系图 and 演化史.
- BoardView (and its task preview usage) now consumes real `relations` from the triadic projection query; `MOCK_TASK_RELATIONS` removed from `model/mock-work.ts`.
- 5 new component-level vitest cases covering genealogy edge filtering (including claim-anchored source refs), empty states, and rendering.

## Task And Scope

- Harness task: task_01KXA7YGRQ7DVTPJ47CP76752T (parent coordination task task_01KXA7Q2RC0N0QJPAN9BF4PJ7Y, GUI-V1 milestone)
- Branch: feat/gui-genealogy-timeline
- Public scope: packages/gui renderer only (`views/GenealogyTimelineView.tsx`, `views/genealogy/**`, `App.tsx`, `model/mock-work.ts`, gui tests)
- Private planning/evidence updated: yes (harness task ledger progress)
- Out of scope: `graph/**` and GraphView internals (parallel PR feat/gui-triadic-mainview), backend/kernel/IPC, passing coverageRows/factAnchors into GraphView (follow-up after both PRs merge)

## Version Impact

- Version: no version change because this is a renderer-internal feature with no published artifact change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: decision dec_01KXA7811SVVT8P66HNDFZQ7DF (accepted), principle 6
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: d3c8f19
- Branch merge-base with `origin/main`: d3c8f19
- Last `git fetch origin` time: 2026-07-12 (immediately before push)
- Sync method: rebase
- Public diff command: `git diff origin/main...feat/gui-genealogy-timeline`
- Private evidence commit/path: harness task ledger for task_01KXA7YGRQ7DVTPJ47CP76752T
- Reviewer evidence path: harness task package review document
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci` — not run locally (worktree seeded from verified root install)
- [x] `git diff --check`
- [x] `npm run check` — via `check:local` fast tier (52 manifest gates; re-run and confirmed green by the CEO after the split commit)
- [x] `npm run typecheck`
- [ ] `npm test` — root suite deferred to CI (gui-scoped diff; `test:gui` 44/44 green locally)
- [x] `npm run harness:check-import-boundaries` (within check:local)
- [x] `npm run harness:scan-forbidden-symbols` (within check:local)
- [x] `npm run harness:check-private-boundary` (within check:local)
- [x] `npm run harness:check-package-policy` (within check:local)
- [x] `npm run harness:check-implementation-contracts` (within check:local)
- [x] `npm run harness:check-schema-contracts` (within check:local)
- [ ] `npm run harness:check-legacy-intake-readiness` — covered by CI
- [ ] `npm run harness:smoke-cli-package` — covered by CI (no CLI change)
- [ ] GitHub Actions `rewrite-ci` passed — pending
- Not run: root `npm test` and CLI smoke locally; both covered by required CI on this PR

## Review Evidence

- Self-review: worker verified genealogy filtering against real-ledger-format fixtures (claim-anchored refs) and adjudicated the "empty genealogy" observation from a prior attempt as a daemon-not-connected environment issue, backed by a unit test plus ledger statistics (110 decision-to-decision genealogy edges)
- Reviewer subagent: adversarial review scheduled as a follow-up harness task
- Human review: CEO semantic acceptance (multi-view switcher wiring implements principle 6; BoardView de-mock verified) recorded in the task ledger
- Blocking findings: none open

## Residual Risk

- No live-Electron screenshot yet (worktree sandbox lacks the Electron binary); verification used component-level rendering tests plus the production bundle build. CEO dogfood on the merged build is the remaining visual pass.
- Lineages deeper than about 5 generations or wider than about 10 siblings per depth grow tall (scrollable, no overflow); real ledger lineages observed today are 3-4 levels.
- Multi-view switcher currently covers 关系图 ↔ 演化史 only, per task scope.

## References

- Task: task_01KXA7YGRQ7DVTPJ47CP76752T
- Evidence: harness task ledger progress entries
- Review: harness task package review document

---

# 中文

## 概要

新增 decision 谱系「演化史」视图(Jaeger-timeline 式:X 轴 = decidedAt,缺省回退 proposedAt;行 = 谱系深度),作为与关系图并列的主视图;在 App.tsx 接多视图切换;BoardView 去掉 mock 任务关系改吃真实投影数据。落实已接受决策 dec_01KXA7811SVVT8P66HNDFZQ7DF 的原则 6(多视图;关系图是主视图之一而非唯一)。纯 renderer 改动。

## 改动内容

- 新增 `views/GenealogyTimelineView.tsx` 与 `views/genealogy/` 子模块(布局逻辑、时间轴绘制、参与者侧栏、详情面板、空态——全部低于 file-complexity 上限):从 relations 筛 decision↔decision 谱系四类(refines / narrows / supersedes / supports,兼容 claim 锚 ref),BFS 构建焦点决策的谱系,按时间轴渲染决策卡与悬停详情。
- App.tsx:注册「演化史」视图,新增「同一实体 · 多视图」切换条(关系图 ↔ 演化史)。
- BoardView(及其任务预览)改吃三原语投影 query 的真实 `relations`;`model/mock-work.ts` 删除 `MOCK_TASK_RELATIONS`。
- 新增 5 个组件级 vitest 用例,覆盖谱系边筛选(含 claim 锚源 ref)、空态与渲染。

## 任务与范围

- Harness 任务:task_01KXA7YGRQ7DVTPJ47CP76752T(父协调任务 task_01KXA7Q2RC0N0QJPAN9BF4PJ7Y,GUI-V1 里程碑)
- 分支:feat/gui-genealogy-timeline
- 公开范围:仅 packages/gui renderer(`views/GenealogyTimelineView.tsx`、`views/genealogy/**`、`App.tsx`、`model/mock-work.ts`、gui 测试)
- 私有计划 / 证据是否已更新:yes(harness 任务台账 progress)
- 范围外:`graph/**` 与 GraphView 内部(并行 PR feat/gui-triadic-mainview)、后端/kernel/IPC、向 GraphView 透传 coverageRows/factAnchors(两 PR 合并后跟进)

## 版本影响

- 版本:不改版本,原因是 renderer 内部功能,无已发布工件变化
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:决策 dec_01KXA7811SVVT8P66HNDFZQ7DF(已接受),原则 6
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- `origin/main` 基准 SHA:d3c8f19
- 当前分支与 `origin/main` 的 merge-base:d3c8f19
- 最近一次 `git fetch origin` 时间:2026-07-12(push 前)
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...feat/gui-genealogy-timeline`
- 私有证据 commit/path:task_01KXA7YGRQ7DVTPJ47CP76752T 的 harness 任务台账
- Reviewer 证据路径:harness 任务包 review 文档
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- [ ] `npm ci` — 本地未跑(worktree 由已验证的根安装播种)
- [x] `git diff --check`
- [x] `npm run check` — 经 `check:local` fast tier(52 个 manifest 门;拆分 commit 后由 CEO 复跑确认绿)
- [x] `npm run typecheck`
- [ ] `npm test` — 根套件交 CI(diff 限 gui;本地 `test:gui` 44/44 绿)
- [x] `npm run harness:check-import-boundaries`(check:local 内)
- [x] `npm run harness:scan-forbidden-symbols`(check:local 内)
- [x] `npm run harness:check-private-boundary`(check:local 内)
- [x] `npm run harness:check-package-policy`(check:local 内)
- [x] `npm run harness:check-implementation-contracts`(check:local 内)
- [x] `npm run harness:check-schema-contracts`(check:local 内)
- [ ] `npm run harness:check-legacy-intake-readiness` — 交 CI
- [ ] `npm run harness:smoke-cli-package` — 交 CI(无 CLI 改动)
- [ ] GitHub Actions `rewrite-ci` passed — 待跑
- 未运行:根 `npm test` 与 CLI smoke 本地未跑;两者由本 PR 的 required CI 覆盖

## 审查证据

- 自查:worker 以真实账本格式 fixture(含 claim 锚 ref)验证谱系筛选,并把前次尝试的「谱系为空」裁定为 daemon 未连的环境问题,证据=单测 + 账本统计(110 条 decision↔decision 谱系边)
- Reviewer subagent:对抗复核已排为后续 harness 任务
- 人工审查:CEO 语义验收(多视图切换条落实原则 6;BoardView 去 mock 已核),记录于任务台账
- 阻塞发现:无

## 残余风险

- 尚无真机 Electron 截图(worktree 沙箱无 Electron binary);验证用组件级渲染测试 + 生产 bundle 构建替代,合并后 CEO dogfood 补真机视觉验证。
- 谱系深于约 5 代或同深度超过约 10 个兄弟时视图会变高(可滚动不溢出);当前真实账本谱系约 3-4 层。
- 多视图切换条按任务范围仅覆盖 关系图 ↔ 演化史。

## 关联材料

- 任务:task_01KXA7YGRQ7DVTPJ47CP76752T
- 证据:harness 任务台账 progress 记录
- 审查:harness 任务包 review 文档
