### PR TITLE
fix(gui): resolve 11 adversarial-review findings in triadic graph (task-click crash P1)

### DIFF
--- a/packages/gui/e2e/electron-smoke.e2e.mjs
+++ b/packages/gui/e2e/electron-smoke.e2e.mjs
@@ -99,13 +99,32 @@ test("Electron shell opens its first BrowserWindow", { timeout: 90_000 }, async 
   await page.locator(".react-flow__node-task").nth(1).waitFor({ state: "detached" });
   assert.equal(await page.locator(".react-flow__edge").count(), 2, "disabling assoc hides its edge again");
 
-  await focusCard.click();
+  // Per-claim expand (#4): each claim row is independently clickable via its
+  // data-claim-id attribute, instead of the legacy whole-card "toggle all".
+  // The smoke fixture has CH1 with the only evidence fact (F-ABCDEFGH); CH2/RJ1
+  // have no evidence so clicking them is a no-op.
+  const ch1Row = focusCard.locator("[data-claim-id='CH1']");
+  await ch1Row.waitFor();
+  await ch1Row.click();
   const expandedFact = page.locator('.react-flow__node-fact[data-id="fact/task-gui-smoke/F-ABCDEFGH"]');
   await expandedFact.waitFor({ timeout: 10_000 });
   assert.equal((await expandedFact.textContent())?.trim(), "F");
   assert.equal(await page.locator(".react-flow__edge").count(), 3, "expanding a fact badge reveals its evidence edge");
   await expandedFact.click();
   await expandedFact.waitFor({ state: "detached" });
+
+  // Regression (#1 P1): clicking a task node used to crash the drawer because
+  // GraphView passed `n.data` instead of `n.data.raw` to GraphDrawer, and
+  // CloseoutBadge read `CLOSEOUT_META[undefined]`. Now the drawer should open
+  // and render task-specific badges (status / closeout / engine).
+  const taskNode = page.locator(".react-flow__node-task").first();
+  await taskNode.click();
+  const taskDrawer = page.locator("aside");
+  await taskDrawer.getByText("task-gui-smoke", { exact: true }).waitFor();
+  // Smoke fixture: status=active → closeoutReadiness=not_required → engine=local.
+  await taskDrawer.getByText("Active", { exact: true }).waitFor();
+  await taskDrawer.getByText("无需收口", { exact: true }).waitFor();
+  await taskDrawer.getByText("local", { exact: true }).waitFor();
 
   const viewSwitcher = page.getByText("同一实体 · 多视图", { exact: true }).locator("..");
   await viewSwitcher.getByRole("button", { name: "演化史", exact: true }).click();

--- a/packages/gui/src/renderer/graph/claimCoverage.ts
+++ b/packages/gui/src/renderer/graph/claimCoverage.ts
@@ -45,6 +45,10 @@ export function computeClaimCoverage(
   // 适 App.tsx 未透传 coverageRows 的场景(GraphView 只拿到 decisions + relations + facts)。
   // 注意:decision.claims 是 {id,text} 列表(全集),chosen/rejected 才有 evidence —
   // 所以先按 id 建索引,再遍历全集 claims 给没有 evidence 的 claim 标 uncovered。
+  // 修 #10:此前 Path B 在 evidence 为空时把 unknown 直接翻成 uncovered,把
+  // coverageRows 缺失/loading 误当成「确认风险」。现在 Path B 只升级 unknown→covered
+  // (有 evidence 时);无证据则保持 unknown,等 coverageRows 到位后再由 Path A
+  // 拍板。Path A 的 uncovered 判定保持原义(kernel 已计算 = 真风险)。
   const evidenceById = new Map<string, string[]>();
   for (const claim of [...decision.chosen, ...decision.rejected]) {
     evidenceById.set(claim.id, claim.evidence);
@@ -56,10 +60,8 @@ export function computeClaimCoverage(
     if (evidence.length > 0) {
       info.evidenceFacts = [...new Set([...info.evidenceFacts, ...evidence])];
       if (info.status === "unknown") info.status = "covered";
-    } else if (info.status === "unknown") {
-      // 仍未被任何路径标 covered → uncovered (风险视角)
-      info.status = "uncovered";
     }
+    // evidence 为空且 Path A 未触 → 保持 unknown (loading/缺数据),不再误降为 uncovered。
   }
 
   return [...byClaim.values()];

--- a/packages/gui/src/renderer/graph/graphLayoutShared.ts
+++ b/packages/gui/src/renderer/graph/graphLayoutShared.ts
@@ -115,7 +115,11 @@ export function buildEdge(input: BuildEdgeInput): Edge {
     source: input.sourceId,
     sourceHandle: input.sourceClaimId ? `claim-${input.sourceClaimId}` : undefined,
     target: input.targetId,
-    targetHandle: input.targetClaimId ? `claim-${input.targetClaimId}` : undefined,
+    // 修 #7:DecisionFocusNode 的 per-claim target handle 命名为 `claim-<id>-in`
+    // (DecisionFocusNode.tsx:97-101)。此前 buildEdge 给 targetClaimId 也拼 `claim-<id>`,
+    // 不匹配任何 handle → 边不显示。聚焦后代(refines 目标=focus)场景下 lineage
+    // 边现在会带 targetClaimId,需要拼对后缀。
+    targetHandle: input.targetClaimId ? `claim-${input.targetClaimId}-in` : undefined,
     type: "interactive",
     data: { ...input.edge, axis: input.axis },
     animated: false,

--- a/packages/gui/src/renderer/graph/nodes/DecisionFocusNode.tsx
+++ b/packages/gui/src/renderer/graph/nodes/DecisionFocusNode.tsx
@@ -14,6 +14,12 @@ interface ClaimRow {
   status: "covered" | "uncovered" | "unknown";
   evidenceCount: number;
   derivesCount: number;
+  /**
+   * 该 claim 可展开的 fact ref 列表(并集:coverageRows.coveringFactRef ∪
+   * 直接 evidence 边的 factRef)。GraphView 的 onNodeClick 用 data-claim-id
+   * 锚到具体 claim,只 toggle 该行 factRefs,不再批量 toggle 全部 claim。
+   */
+  factRefs?: string[];
 }
 
 interface FocusData {
@@ -79,11 +85,16 @@ export function DecisionFocusNode({ data, selected }: NodeProps) {
         )}
         {rows.map((row) => {
           const covColor = COVERAGE_COLOR_VAR[row.status];
+          const hasFacts = (row.factRefs?.length ?? 0) > 0;
           return (
             <div
               key={row.claimId}
-              className="relative flex items-center gap-2 px-3 border-b border-white/5 last:border-b-0"
+              data-claim-id={row.claimId}
+              className={`relative flex items-center gap-2 px-3 border-b border-white/5 last:border-b-0 ${
+                hasFacts ? "cursor-pointer hover:bg-white/[0.03]" : ""
+              }`}
               style={{ minHeight: 44 }}
+              title={hasFacts ? `点击切换 ${row.factRefs!.length} 条证据 fact` : undefined}
             >
               {/* per-claim source/target handles — let edges anchor to a specific claim row */}
               <Handle

--- a/packages/gui/src/renderer/graph/simpleEgoLayout.ts
+++ b/packages/gui/src/renderer/graph/simpleEgoLayout.ts
@@ -20,18 +20,23 @@ export function layoutSimpleEgo(input: SimpleEgoInput): LayoutOutput {
   const neighbors = new Map<string, "task" | "decision" | "fact">();
   const egoEdges: RelationEdge[] = [];
 
+  // 修 #9:filters.types 之前从未被读 → task/decision/fact 类型开关在 ego 布局
+  // 里完全失效。focus 自身不参与过滤(用户主动选中的实体不应被自身类型开关
+  // 抹掉),但其 1-hop 邻居按类型开关筛选。
+  const allowedTypes = input.filters.types;
+
   for (const edge of input.relations) {
     const fromId = endpointToNodeId(edge.from);
     const toId = endpointToNodeId(edge.to);
     if (fromId === input.focusId) {
       const parsed = parseEndpoint(edge.to);
-      if (parsed) {
+      if (parsed && allowedTypes.has(parsed.entity)) {
         neighbors.set(parsed.id, parsed.entity);
         egoEdges.push(edge);
       }
     } else if (toId === input.focusId) {
       const parsed = parseEndpoint(edge.from);
-      if (parsed) {
+      if (parsed && allowedTypes.has(parsed.entity)) {
         neighbors.set(parsed.id, parsed.entity);
         egoEdges.push(edge);
       }

--- a/packages/gui/src/renderer/graph/threeLaneLayout.ts
+++ b/packages/gui/src/renderer/graph/threeLaneLayout.ts
@@ -43,6 +43,8 @@ export function layoutThreeLane(input: ThreeLaneInput): LayoutOutput {
   const derives: { edge: RelationEdge; other: TaskRow; claimId?: string }[] = [];
   const evidence: { edge: RelationEdge; fact: FactRef; claimId?: string }[] = [];
   const assocTasks: { edge: RelationEdge; other: TaskRow; claimId?: string }[] = [];
+  // 修 #8:此前 assoc→decision 边被静默丢弃,开 assoc 轴也显不出。
+  const assocDecisions: { edge: RelationEdge; other: DecisionRow; claimId?: string }[] = [];
 
   for (const edge of input.relations) {
     const fromNode = endpointToNodeId(edge.from);
@@ -75,8 +77,12 @@ export function layoutThreeLane(input: ThreeLaneInput): LayoutOutput {
       if (otherParsed.entity === "task") {
         const t = input.tasks.find((x) => x.taskId === otherId);
         if (t) assocTasks.push({ edge, other: t, claimId: claimFromFocus });
+      } else if (otherParsed.entity === "decision") {
+        // relates/implements 到另一 decision:与 lineage lane 的
+        // authority 轴(refines/narrows/supersedes)语义正交,不会重复。
+        const d = input.decisions.find((x) => `decision/${x.decisionId}` === otherId);
+        if (d) assocDecisions.push({ edge, other: d, claimId: claimFromFocus });
       }
-      // assoc→decision 暂不画(避免与 lineage lane 重复)
     } else if (axis === "authority" && edge.kind === "supports" && otherParsed.entity === "task") {
       // supports 偶尔指向 task (执行支撑),归入 derives lane 避免丢失。
       const t = input.tasks.find((x) => x.taskId === otherId);
@@ -112,11 +118,15 @@ export function layoutThreeLane(input: ThreeLaneInput): LayoutOutput {
     const rows = Math.max(1, dc.length, Math.ceil(ec.length / 3));
     return { info, rows, derives: dc, evidence: ec };
   });
-  const hasStray = strayDerives.length > 0 || assocTasks.length > 0;
+  const hasStray =
+    strayDerives.length > 0 || assocTasks.length > 0 || assocDecisions.length > 0;
   if (hasStray) {
+    // 修 #8:assoc 区域顺序叠 assocTasks + assocDecisions;stray 行的高度要同时盖住
+    // 派生 stray 与 assoc 两组,否则 assoc decision 会越过 lane 底边。
+    const assocTotal = assocTasks.length + assocDecisions.length;
     claimRows.push({
       info: { claimId: "·", status: "unknown", evidenceFacts: [] },
-      rows: Math.max(1, strayDerives.length, assocTasks.length),
+      rows: Math.max(1, strayDerives.length, assocTotal),
       derives: strayDerives,
       evidence: [],
     });
@@ -178,12 +188,28 @@ export function layoutThreeLane(input: ThreeLaneInput): LayoutOutput {
       claims: focus.claims,
       chosen: focus.chosen,
       rejected: focus.rejected,
-      claimRows: claimRows.map((r) => ({
-        claimId: r.info.claimId,
-        status: r.info.status,
-        evidenceCount: r.evidence.length,
-        derivesCount: r.derives.length,
-      })),
+      claimRows: claimRows.map((r) => {
+        // 修 #5:factRefs 取 coverageRows.coveringFactRef 与 evidence 边
+        // factRef 的并集。GraphView 的 onNodeClick 用这个 list 锚到具体
+        // claim 行 → 不再仅靠 coverageRows(否则仅有 canonical/transitive
+        // 覆盖、无 direct edge 时点击会漏 toggle)。
+        const claimRef =
+          r.info.claimId === "·" ? null : `decision/${focus.decisionId}/${r.info.claimId}`;
+        const covRefs = claimRef
+          ? (input.coverageRows ?? [])
+              .filter((c) => c.claimRef === claimRef && c.coveringFactRef)
+              .map((c) => c.coveringFactRef as string)
+          : [];
+        const edgeRefs = r.evidence.map((e) => factRefOf(e.fact));
+        const factRefs = [...new Set([...covRefs, ...edgeRefs])];
+        return {
+          claimId: r.info.claimId,
+          status: r.info.status,
+          evidenceCount: factRefs.length,
+          derivesCount: r.derives.length,
+          factRefs,
+        };
+      }),
       focus: true,
       raw: focus,
     },
@@ -213,22 +239,38 @@ export function layoutThreeLane(input: ThreeLaneInput): LayoutOutput {
         raw: other,
       },
     });
+    // 修 #7:尊重 kernel canonical 方向 (from --kind--> to)。此前恒渲染
+    // other→focus,聚焦后代(decendant refines ancestor)时箭头反 + 丢 claim
+    // handle。同时把 focus 端的 claim 锚保留到 sourceClaimId/targetClaimId。
+    const fromNodeId = endpointToNodeId(item.edge.from);
+    const focusIsSource = fromNodeId === focusId;
+    const sourceId = focusIsSource ? focusId : id;
+    const targetId = focusIsSource ? id : focusId;
+    const focusClaimId = focusIsSource
+      ? endpointClaimId(item.edge.from)
+      : endpointClaimId(item.edge.to);
     const isLoop = inLoopEdge(input.inLoopEdges, item.edge);
     rfEdges.push(
       buildEdge({
         edgeId: `e_lineage_${i}`,
         edge: item.edge,
-        sourceId: id,
-        targetId: focusId,
+        sourceId,
+        targetId,
         sourcePosition: Position.Right,
         targetPosition: Position.Left,
         axis: "authority",
+        sourceClaimId: focusIsSource ? focusClaimId : undefined,
+        targetClaimId: focusIsSource ? undefined : focusClaimId,
         isLoop,
       }),
     );
   });
 
-  // Derives lane (右) — 按 claim 行排布
+  // Derives lane (右) — 按 claim 行排布。
+  // 修 #6:多 claim 派生同一 task 时,此前会 push 多个相同 React Flow 节点 id
+  // (位置歧义 + 共享边目标)。现在首次出现即注册,后续 claim 只补一条以
+  // sourceHandle 区分的边,target 指向同一节点。
+  const placedTaskIds = new Set<string>();
   let runningY = cardY + DECISION_CARD_PAD_Y;
   const claimYById = new Map<string, number>();
   claimRows.forEach((row) => {
@@ -236,22 +278,25 @@ export function layoutThreeLane(input: ThreeLaneInput): LayoutOutput {
     row.derives.forEach((item, i) => {
       const t = item.other;
       const id = t.taskId;
-      const y = runningY + i * (TASK_H + TASK_GAP_Y);
-      rfNodes.push({
-        id,
-        type: "task",
-        position: { x: LANE_X.derives + 20, y },
-        style: { width: TASK_W, height: TASK_H },
-        data: {
-          label: t.title,
-          taskId: t.taskId,
-          coordinationStatus: t.coordinationStatus,
-          color: statusColor(t),
-          focus: false,
-          dimmed: false,
-          raw: t,
-        },
-      });
+      if (!placedTaskIds.has(id)) {
+        placedTaskIds.add(id);
+        const y = runningY + i * (TASK_H + TASK_GAP_Y);
+        rfNodes.push({
+          id,
+          type: "task",
+          position: { x: LANE_X.derives + 20, y },
+          style: { width: TASK_W, height: TASK_H },
+          data: {
+            label: t.title,
+            taskId: t.taskId,
+            coordinationStatus: t.coordinationStatus,
+            color: statusColor(t),
+            focus: false,
+            dimmed: false,
+            raw: t,
+          },
+        });
+      }
       const isLoop = inLoopEdge(input.inLoopEdges, item.edge);
       rfEdges.push(
         buildEdge({
@@ -270,16 +315,17 @@ export function layoutThreeLane(input: ThreeLaneInput): LayoutOutput {
     runningY += row.rows * CLAIM_ROW_H;
   });
 
-  // Assoc (松关联) → 右泳道下方
-  if (assocTasks.length > 0) {
-    const assocStartY = runningY + 24;
+  // Assoc (松关联) → 右泳道下方。修 #8:同时容纳 assoc task 与 assoc decision
+  // (relates/implements 到 decision),此前 assoc→decision 边被丢弃。
+  if (assocTasks.length > 0 || assocDecisions.length > 0) {
+    let assocCursorY = runningY + 24;
     assocTasks.forEach((item, i) => {
       const t = item.other;
       const id = `${t.taskId}__assoc`;
       rfNodes.push({
         id,
         type: "task",
-        position: { x: LANE_X.derives + 20, y: assocStartY + i * (TASK_H + TASK_GAP_Y) },
+        position: { x: LANE_X.derives + 20, y: assocCursorY },
         style: { width: TASK_W, height: TASK_H, opacity: 0.85 },
         data: {
           label: t.title,
@@ -292,10 +338,49 @@ export function layoutThreeLane(input: ThreeLaneInput): LayoutOutput {
           assoc: true,
         },
       });
+      assocCursorY += TASK_H + TASK_GAP_Y;
       const isLoop = inLoopEdge(input.inLoopEdges, item.edge);
       rfEdges.push(
         buildEdge({
-          edgeId: `e_assoc_${i}`,
+          edgeId: `e_assoc_task_${i}`,
+          edge: item.edge,
+          sourceId: focusId,
+          targetId: id,
+          sourcePosition: Position.Right,
+          targetPosition: Position.Left,
+          axis: "assoc",
+          sourceClaimId: item.claimId,
+          isLoop,
+        }),
+      );
+    });
+    assocDecisions.forEach((item, i) => {
+      const d = item.other;
+      const id = `decision/${d.decisionId}__assoc`;
+      rfNodes.push({
+        id,
+        type: "decision",
+        position: { x: LANE_X.derives + 20, y: assocCursorY },
+        style: { width: TASK_W, height: TASK_H, opacity: 0.85 },
+        data: {
+          label: d.title,
+          decisionId: d.decisionId,
+          state: d.state,
+          riskTier: d.riskTier,
+          urgency: d.urgency,
+          question: d.question,
+          claims: d.claims,
+          focus: false,
+          dimmed: false,
+          raw: d,
+          assoc: true,
+        },
+      });
+      assocCursorY += TASK_H + TASK_GAP_Y;
+      const isLoop = inLoopEdge(input.inLoopEdges, item.edge);
+      rfEdges.push(
+        buildEdge({
+          edgeId: `e_assoc_decision_${i}`,
           edge: item.edge,
           sourceId: focusId,
           targetId: id,

--- a/packages/gui/src/renderer/views/DecisionPoolView.tsx
+++ b/packages/gui/src/renderer/views/DecisionPoolView.tsx
@@ -160,14 +160,29 @@ export function DecisionPoolView({
 
   const rows = useMemo(() => {
     const tabStates = new Set(TAB_STATE[tab]);
+    // 修 #2(预存 bug,归属 dec_mrf2nzvf):三元 `||`/`?:` 优先级让 riskFilter="all"
+    // 走到 !decision.riskTier 分支,把所有有 riskTier 的决策反筛掉;urgency/proposedBy
+    // 同样的运算符陷阱。显式拆成「all 放行 + unknown 反查 + 精确匹配」三路,并加括号。
     return sortDecisionQueue(decisions)
       .filter((decision) => tabStates.has(decision.state))
       .filter((decision) => stateFilter === "all" || decision.state === stateFilter)
-      .filter((decision) => riskFilter === "all" || riskFilter === "unknown" ? !decision.riskTier : decision.riskTier === riskFilter)
-      .filter((decision) => urgencyFilter === "all" || urgencyFilter === "unknown" ? !decision.urgency : decision.urgency === urgencyFilter)
+      .filter((decision) => {
+        if (riskFilter === "all") return true;
+        if (riskFilter === "unknown") return !decision.riskTier;
+        return decision.riskTier === riskFilter;
+      })
+      .filter((decision) => {
+        if (urgencyFilter === "all") return true;
+        if (urgencyFilter === "unknown") return !decision.urgency;
+        return decision.urgency === urgencyFilter;
+      })
       .filter((decision) => verticalFilter === "all" || decision.vertical === verticalFilter)
       .filter((decision) => presetFilter === "all" || decision.preset === presetFilter)
-      .filter((decision) => proposedByFilter === "all" || proposedByFilter === "unknown" ? !decision.proposedBy : decision.proposedBy?.kind === proposedByFilter)
+      .filter((decision) => {
+        if (proposedByFilter === "all") return true;
+        if (proposedByFilter === "unknown") return !decision.proposedBy;
+        return decision.proposedBy?.kind === proposedByFilter;
+      })
       .filter((decision) => withinRange(decision, timeRange));
   }, [decisions, presetFilter, proposedByFilter, riskFilter, stateFilter, tab, timeRange, urgencyFilter, verticalFilter]);
 

--- a/packages/gui/src/renderer/views/GenealogyTimelineView.tsx
+++ b/packages/gui/src/renderer/views/GenealogyTimelineView.tsx
@@ -7,6 +7,7 @@ import {
   collectLineage,
   computeLayout,
   decisionIdOf,
+  findGenealogyCycles,
   timeMsOf,
 } from "./genealogy/layout";
 import { DecisionDetailPanel } from "./genealogy/DecisionDetailPanel";
@@ -45,6 +46,13 @@ export function GenealogyTimelineView({
   }, [decisions]);
 
   const edges = useMemo(() => buildGenealogyEdges(relations, byId), [relations, byId]);
+
+  // 修 #11:refines/narrows/supersedes/supports 边集若成环,collectLineage 会静默
+  // 截断。cycle 警告与 focus 无关(只要边集成环就告警),独立于 layout 计算。
+  const cycleWarning = useMemo(() => {
+    const cycles = findGenealogyCycles(edges);
+    return { count: cycles.length, cycles };
+  }, [edges]);
 
   // 参与谱系（有任一谱系边）的 decision——左栏候选焦点集。
   const participants = useMemo(() => {
@@ -156,6 +164,14 @@ export function GenealogyTimelineView({
         <span className="font-mono text-[12px] text-text-faint">
           {participants.length} 决策参与谱系 · {edges.length} 条演化边
         </span>
+        {cycleWarning.count > 0 && (
+          <span
+            className="inline-flex items-center gap-1 rounded bg-danger/10 px-1.5 py-0.5 font-mono text-danger"
+            title={cycleWarning.cycles.map((c) => c.join(" → ")).join("\n")}
+          >
+            谱系环警告 · {cycleWarning.count}
+          </span>
+        )}
         {focus && (
           <span className="font-mono text-[11px] text-text-faint">
             焦点谱系：{ancestorCount} 祖先 · {descendantCount} 后代

--- a/packages/gui/src/renderer/views/GraphView.tsx
+++ b/packages/gui/src/renderer/views/GraphView.tsx
@@ -81,12 +81,19 @@ function GraphViewInner({
   focusRef?: string | null;
 }) {
   const { fitView } = useReactFlow();
+  // 节点焦点(布局重算依赖)+ 边焦点(仅抽屉展示)。修 #3:此前用单一 focusId
+  // 同时承载节点和边,点边时把 edge id 当 focusNodeId 传给布局器,导致
+  // layoutSimpleEgo 拿不到节点 → 整张图塌成单个空节点。
   const [focusId, setFocusId] = useState<string | null>(null);
+  const [focusEdgeId, setFocusEdgeId] = useState<string | null>(null);
   const [resolvedFocusId, setResolvedFocusId] = useState<string | null>(null);
   const [expandedFacts, setExpandedFacts] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    if (focusRef) setFocusId(endpointToNodeId(focusRef));
+    if (focusRef) {
+      setFocusEdgeId(null);
+      setFocusId(endpointToNodeId(focusRef));
+    }
   }, [focusRef]);
 
   const [nodes, setNodes] = useState<any[]>([]);
@@ -181,7 +188,7 @@ function GraphViewInner({
   }, [edges.length, fitView, nodes.length, resolvedFocusId]);
 
   const onNodeClick = useCallback(
-    (_: any, node: any) => {
+    (evt: any, node: any) => {
       if (node.type === "laneBackground" || node.type === "moduleGroup") return;
       // 点击 fact 节点 → 折叠回去 (toggle expand)
       if (node.type === "fact" && typeof node.id === "string" && node.id.startsWith("fact/")) {
@@ -193,48 +200,54 @@ function GraphViewInner({
         });
         return;
       }
-      // 点击 decisionFocus 上的 claim 行(带 data.claimRow)→ toggle 展开该 claim 的 evidence facts
+      // 点击 decisionFocus 上的具体 claim 行 → 仅 toggle 该 claim 的 evidence facts。
+      // 修 #4:此前点击焦点卡片任意位置都批量 toggle 所有 claim 的 fact,无法定位
+      // 具体行;现在用 data-claim-id 锚到具体 claim。
+      // 修 #5:factRefs 在 threeLaneLayout 里取 coverageRows.coveringFactRef 与
+      // evidence 边的并集,避免仅有规范/transitive 覆盖但无 direct edge 时漏掉。
       if (node.type === "decisionFocus" && node.data?.claimRows) {
-        const claimRows: Array<{ claimId: string; evidenceCount: number }> = node.data.claimRows;
-        const decisionId: string = node.data.decisionId;
-        const factsToToggle = claimRows
-          .filter((r) => r.evidenceCount > 0)
-          .flatMap((r) => {
-            // 展开 coverageRows 给的 coveringFactRef(从 coverageRows 找)
-            const refs = (coverageRows ?? [])
-              .filter((c) => c.claimRef === `decision/${decisionId}/${r.claimId}` && c.coveringFactRef)
-              .map((c) => c.coveringFactRef as string);
-            return refs;
-          });
-        if (factsToToggle.length > 0) {
-          setExpandedFacts((prev) => {
-            const next = new Set(prev);
-            const allOpen = factsToToggle.every((f) => next.has(f));
-            if (allOpen) factsToToggle.forEach((f) => next.delete(f));
-            else factsToToggle.forEach((f) => next.add(f));
-            return next;
-          });
+        const target = evt?.target as HTMLElement | null;
+        const claimRowEl = target?.closest?.("[data-claim-id]");
+        const claimId = claimRowEl?.getAttribute("data-claim-id");
+        if (claimId) {
+          const rows = node.data.claimRows as Array<{
+            claimId: string;
+            factRefs?: string[];
+          }>;
+          const row = rows.find((r) => r.claimId === claimId);
+          const refs = row?.factRefs ?? [];
+          if (refs.length > 0) {
+            setExpandedFacts((prev) => {
+              const next = new Set(prev);
+              const allOpen = refs.every((f) => next.has(f));
+              if (allOpen) refs.forEach((f) => next.delete(f));
+              else refs.forEach((f) => next.add(f));
+              return next;
+            });
+          }
           return;
         }
+        // 点击焦点卡片但未命中 claim 行 → 落到 setFocusId toggle(关闭抽屉)。
       }
+      setFocusEdgeId(null);
       setFocusId((prev) => (prev === node.id ? null : node.id));
     },
-    [coverageRows],
+    [],
   );
 
   const onEdgeClick = useCallback((_: any, edge: any) => {
-    setFocusId((prev) => (prev === edge.id ? null : edge.id));
+    // 修 #3:边焦点独立成 focusEdgeId,不再混入 focusId,布局不会重算。
+    setFocusEdgeId((prev) => (prev === edge.id ? null : edge.id));
   }, []);
 
   const onPaneClick = useCallback(() => {
     setFocusId(null);
+    setFocusEdgeId(null);
   }, []);
 
   // Drawer
-  const focusNode =
-    focusId && !focusId.startsWith("e_") ? nodes.find((n) => n.id === focusId) : null;
-  const focusEdge =
-    focusId && focusId.startsWith("e_") ? edges.find((e) => e.id === focusId) : null;
+  const focusNode = focusId ? nodes.find((n) => n.id === focusId) : null;
+  const focusEdge = focusEdgeId ? edges.find((e) => e.id === focusEdgeId) : null;
 
   const drawerNodesMap = useMemo(() => {
     const map = new Map();
@@ -245,7 +258,11 @@ function GraphViewInner({
         entity: n.type === "decisionFocus" ? "decision" : n.type,
         label: n.data.label,
         sub: n.data.sub,
-        task: n.type === "task" ? n.data : undefined,
+        // GraphDrawer 读 closeoutReadiness/engine/freshness/module 等字段,
+        // 这些只存在于完整 TaskRow (n.data.raw) 上,不在 React Flow 节点的
+        // 顶层 data 上。修 #1:此前误传 n.data,导致 CloseoutBadge/EngineBadge
+        // 拿到 undefined,CLOSEOUT_META[undefined] 直接抛 → 点 task 节点必崩。
+        task: n.type === "task" ? n.data.raw : undefined,
         raw: n.data,
       });
     });
@@ -271,6 +288,16 @@ function GraphViewInner({
     }
     return { upCount: up, downCount: down };
   }, [focusId, relations]);
+
+  const closeDrawer = useCallback(() => {
+    setFocusId(null);
+    setFocusEdgeId(null);
+  }, []);
+  const focusFromDrawer = useCallback((id: string | null) => {
+    // Drawer 跳转目标恒为节点 id(边无独立跳转语义)。
+    setFocusEdgeId(null);
+    setFocusId(id);
+  }, []);
 
   if (error) {
     return (
@@ -341,7 +368,7 @@ function GraphViewInner({
           </span>
         )}
         <span className="ml-auto text-text-faint">
-          {focusId
+          {focusId || focusEdgeId
             ? "Esc / 点击空白处退出聚焦 · 点击 claim 行展开证据 fact"
             : "默认聚焦式 ego · 点击节点切换焦点 (Powered by React Flow)"}
         </span>
@@ -399,8 +426,8 @@ function GraphViewInner({
             edges={relations}
             upCount={upCount}
             downCount={downCount}
-            onClose={() => setFocusId(null)}
-            onFocus={setFocusId}
+            onClose={closeDrawer}
+            onFocus={focusFromDrawer}
             onNavigateEntity={onNavigateEntity}
           />
         )}

--- a/packages/gui/src/renderer/views/genealogy/layout.ts
+++ b/packages/gui/src/renderer/views/genealogy/layout.ts
@@ -60,6 +60,8 @@ export interface TimelineLayout {
   ticks: { x: number; label: string }[];
   minT: number;
   maxT: number;
+  /** 修 #11:谱系边成环时,显式带出 cycle 列表供视图告警(此前 BFS 静默截断)。 */
+  cycleWarning: { count: number; cycles: string[][] };
 }
 
 /** 把 `decision/dec_x/CH1` 之类的 ref 归一成裸 decision id；非 decision 端返回 null。 */
@@ -148,6 +150,53 @@ export function collectLineage(
   return depth;
 }
 
+/**
+ * 修 #11:在谱系边集里检测环。collectLineage 的 BFS 遇到环会静默终止(已访问
+ * 节点跳过),导致环里的节点拿到任意 depth,但调用方完全不知数据里有环。
+ * 此函数显式找出所有简单环,供视图发 INV 风格的告警。
+ *
+ * 注:仅按 GenealogyEdge.from/to 形成的有向图找环,与 graphLayoutShared 的
+ * findRelationCycles 同思路,但保持谱系视图自包含(不引入 graph/** 依赖)。
+ */
+export function findGenealogyCycles(edges: GenealogyEdge[]): string[][] {
+  const byFrom = new Map<string, string[]>();
+  for (const edge of edges) {
+    const arr = byFrom.get(edge.from) ?? [];
+    arr.push(edge.to);
+    byFrom.set(edge.from, arr);
+  }
+  const cycles: string[][] = [];
+  const seenKeys = new Set<string>();
+  const visited = new Set<string>();
+  const onStack = new Set<string>();
+  const stack: string[] = [];
+
+  const visit = (node: string) => {
+    if (onStack.has(node)) {
+      const start = stack.indexOf(node);
+      if (start >= 0) {
+        const cycle = [...stack.slice(start), node];
+        const key = cycle.join(">");
+        if (!seenKeys.has(key)) {
+          seenKeys.add(key);
+          cycles.push(cycle);
+        }
+      }
+      return;
+    }
+    if (visited.has(node)) return;
+    onStack.add(node);
+    stack.push(node);
+    for (const next of byFrom.get(node) ?? []) visit(next);
+    stack.pop();
+    onStack.delete(node);
+    visited.add(node);
+  };
+
+  for (const node of byFrom.keys()) visit(node);
+  return cycles;
+}
+
 /** 时间轴上做 3–6 个刻度。 */
 export function axisTicks(minT: number, maxT: number): { t: number; label: string }[] {
   if (!(maxT > minT)) return [];
@@ -167,6 +216,7 @@ const EMPTY_LAYOUT: TimelineLayout = {
   ticks: [],
   minT: 0,
   maxT: 0,
+  cycleWarning: { count: 0, cycles: [] },
 };
 
 /**
@@ -233,5 +283,16 @@ export function computeLayout(
     x: PAD_X + xOfTime(tick.t),
     label: tick.label,
   }));
-  return { nodes: placed, width, height, ticks, minT, maxT };
+  // 修 #11:refines/narrows/supersedes/supports 边集里若成环,collectLineage 会
+  // 静默截断(depth 任意赋),视图此前毫无提示。现在显式计算 cycle 列表上抛。
+  const cycles = findGenealogyCycles(edges);
+  return {
+    nodes: placed,
+    width,
+    height,
+    ticks,
+    minT,
+    maxT,
+    cycleWarning: { count: cycles.length, cycles },
+  };
 }

--- a/packages/gui/test/genealogy-timeline.vitest.ts
+++ b/packages/gui/test/genealogy-timeline.vitest.ts
@@ -6,6 +6,11 @@ import type {
   RelationEdge,
 } from "../src/renderer/model/types.ts";
 import { GenealogyTimelineView } from "../src/renderer/views/GenealogyTimelineView.tsx";
+import {
+  buildGenealogyEdges,
+  computeLayout,
+  findGenealogyCycles,
+} from "../src/renderer/views/genealogy/layout.ts";
 
 /**
  * 谱系 timeline 视图的组件级测试。验证:
@@ -156,5 +161,56 @@ describe("GenealogyTimelineView filter correctness", () => {
     // dec_b refines dec_a 多个 claim 锚去重为一条)。
     expect(markup).toContain("4 条演化边");
     expect(markup).toContain("4 决策参与谱系");
+  });
+});
+
+describe("Genealogy cycle warning (修 #11)", () => {
+  it("findGenealogyCycles 检测 A→B→A 的 refines 环", () => {
+    const decisions: DecisionRow[] = ["dec_a", "dec_b"].map((id) =>
+      baseDecision({ decisionId: id }),
+    );
+    const relations: RelationEdge[] = [
+      edge("decision/dec_a", "decision/dec_b", "refines"),
+      edge("decision/dec_b", "decision/dec_a", "refines"),
+    ];
+    const edges = buildGenealogyEdges(
+      relations,
+      new Map(decisions.map((d) => [d.decisionId, d])),
+    );
+    const cycles = findGenealogyCycles(edges);
+    expect(cycles.length).toBeGreaterThan(0);
+    // 至少一条环把 dec_a / dec_b 都卷进去
+    const involved = new Set(cycles.flat());
+    expect(involved.has("dec_a")).toBe(true);
+    expect(involved.has("dec_b")).toBe(true);
+  });
+
+  it("computeLayout 把 cycle 警告透出,TimelineLayout.cycleWarning 非空", () => {
+    const decisions: DecisionRow[] = ["dec_a", "dec_b"].map((id) =>
+      baseDecision({ decisionId: id, title: id }),
+    );
+    const relations: RelationEdge[] = [
+      edge("decision/dec_a", "decision/dec_b", "refines"),
+      edge("decision/dec_b", "decision/dec_a", "refines"),
+    ];
+    const byId = new Map(decisions.map((d) => [d.decisionId, d]));
+    const edges = buildGenealogyEdges(relations, byId);
+    const layout = computeLayout(decisions[0], edges, byId, 900);
+    expect(layout.cycleWarning.count).toBeGreaterThan(0);
+    expect(layout.cycleWarning.cycles.length).toBe(layout.cycleWarning.count);
+  });
+
+  it("渲染时 header 显示「谱系环警告 · N」(SSR 快照)", () => {
+    const decisions: DecisionRow[] = ["dec_a", "dec_b"].map((id) =>
+      baseDecision({ decisionId: id, title: id }),
+    );
+    const relations: RelationEdge[] = [
+      edge("decision/dec_a", "decision/dec_b", "refines"),
+      edge("decision/dec_b", "decision/dec_a", "refines"),
+    ];
+    const markup = renderToStaticMarkup(
+      createElement(GenealogyTimelineView, { decisions, relations }),
+    );
+    expect(markup).toContain("谱系环警告");
   });
 });

--- a/packages/gui/test/graphLayout.vitest.ts
+++ b/packages/gui/test/graphLayout.vitest.ts
@@ -153,15 +153,47 @@ describe("computeGraphLayout: ego three-lane (dec_01KXA7811SVVT8P66HNDFZQ7DF)", 
     const out = await computeGraphLayout(baseInput());
     expect(out.resolvedFocusId).toBe(`decision/${FOCUS_DECISION_ID}`);
 
-    // 6 claim 行都应被计算(CH1 应是 uncovered — 只有 assoc,assoc 还被默认关了)
+    // 6 claim 行都应被计算
+    // 修 #10 后:coverageRows 缺失时 Path B 只升级 unknown→covered,不再误降为
+    // uncovered。C3/CH1 有 evidence 时是 covered,无 evidence 则保持 unknown
+    // (灰,loading/缺数据),等 kernel coverageRows 到位再由 Path A 拍板。
     expect(out.focusClaims).toHaveLength(6);
     const byClaim = new Map(out.focusClaims.map((c) => [c.claimId, c.status]));
     expect(byClaim.get("C1")).toBe("covered");
     expect(byClaim.get("C2")).toBe("covered");
-    expect(byClaim.get("C3")).toBe("uncovered"); // 无 evidence
+    expect(byClaim.get("C3")).toBe("unknown"); // 无 evidence + coverageRows 缺 → unknown
     expect(byClaim.get("C4")).toBe("covered");
     expect(byClaim.get("C5")).toBe("covered");
-    expect(byClaim.get("CH1")).toBe("uncovered"); // 无 evidence
+    expect(byClaim.get("CH1")).toBe("unknown"); // 无 evidence + coverageRows 缺 → unknown
+  });
+
+  it("Path A 的 uncovered 是权威(kernel coverageRows 明示无证据 → 红灯)", async () => {
+    // 修 #10 回归覆盖:当 kernel 给出 coverageRows 且 status="uncovered" 时,
+    // Path A 必须把 claim 标 uncovered (风险视角),不被 Path B 拉回 unknown。
+    const uncoveredRow = (claimId: string) => ({
+      decisionRef: `decision/${FOCUS_DECISION_ID}`,
+      claimRef: `decision/${FOCUS_DECISION_ID}/${claimId}`,
+      status: "uncovered" as const,
+      relationPath: [],
+    });
+    const out = await computeGraphLayout(
+      baseInput({
+        coverageRows: [
+          uncoveredRow("C1"),
+          uncoveredRow("C2"),
+          uncoveredRow("C3"),
+          uncoveredRow("C4"),
+          uncoveredRow("C5"),
+          uncoveredRow("CH1"),
+        ],
+      }),
+    );
+    const byClaim = new Map(out.focusClaims.map((c) => [c.claimId, c.status]));
+    // 即使 chosen 里 C1/C2/C4/C5 有 evidence(kernel 反向判定 uncovered,模拟
+    // evidence 走被 invalidated-by 等渠道失活),也以 Path A 为准。
+    expect(byClaim.get("C1")).toBe("uncovered");
+    expect(byClaim.get("C3")).toBe("uncovered");
+    expect(byClaim.get("CH1")).toBe("uncovered");
   });
 
   it("渲染三个 lane 背景 + 一个 decisionFocus 节点", async () => {
@@ -239,5 +271,202 @@ describe("computeGraphLayout: ego three-lane (dec_01KXA7811SVVT8P66HNDFZQ7DF)", 
     const factRef = "fact/task_01KX2GZ3NTFARZ0WC39NXVT25K/F-PRTXCD0P";
     expect(endpointToNodeId(factRef)).toBe(factRef);
     expect(endpointToNodeId(`decision/${FOCUS_DECISION_ID}/C1`)).toBe(`decision/${FOCUS_DECISION_ID}`);
+  });
+
+  it("修 #4/#5:focus 节点 claimRows 带 factRefs 并集(coverageRows ∪ evidence 边)", async () => {
+    // C1 在 chosen 里挂了 evidence=['fact/.../F-96WH7P98'],同时 relations 里也
+    // 有直接的 C1 evidenced-by 边到同一 fact。并集后 factRefs 含 1 条去重 fact。
+    const out = await computeGraphLayout(baseInput());
+    const focus = out.nodes.find((n) => n.type === "decisionFocus");
+    const rows = (focus?.data as { claimRows: Array<{ claimId: string; factRefs?: string[] }> }).claimRows;
+    const c1 = rows.find((r) => r.claimId === "C1");
+    expect(c1?.factRefs).toBeDefined();
+    expect(c1?.factRefs).toContain("fact/task_01KX3PGD74EXEEV6DFM49ARDJ2/F-96WH7P98");
+    // CH1 无 evidence、无 coverage row(空 coverageRows)→ factRefs 为空
+    const ch1 = rows.find((r) => r.claimId === "CH1");
+    expect(ch1?.factRefs ?? []).toHaveLength(0);
+  });
+
+  it("修 #5:仅 coverageRows 给出 coveringFactRef(无直接 evidence 边)也进 factRefs", async () => {
+    // 模拟 kernel 投影里有 transitive coverage 但 relation_edges 没直接边。
+    const out = await computeGraphLayout(
+      baseInput({
+        coverageRows: [
+          {
+            decisionRef: `decision/${FOCUS_DECISION_ID}`,
+            claimRef: `decision/${FOCUS_DECISION_ID}/CH1`,
+            status: "covered" as const,
+            coveringFactRef: "fact/task_01KX3PGD74EXEEV6DFM49ARDJ2/F-COVERED",
+          },
+        ],
+      }),
+    );
+    const focus = out.nodes.find((n) => n.type === "decisionFocus");
+    const rows = (focus?.data as { claimRows: Array<{ claimId: string; factRefs?: string[] }> }).claimRows;
+    const ch1 = rows.find((r) => r.claimId === "CH1");
+    expect(ch1?.factRefs).toContain("fact/task_01KX3PGD74EXEEV6DFM49ARDJ2/F-COVERED");
+  });
+
+  it("修 #6:多 claim 派生同一 task → 只渲染一个 task 节点(去重)", async () => {
+    // C1/C2/C3/C4 都 derives 同一 task_01KX2GZ3NTFARZ0WC39NXVT25K。
+    const out = await computeGraphLayout(baseInput());
+    const taskNodes = out.nodes.filter(
+      (n) => n.id === "task_01KX2GZ3NTFARZ0WC39NXVT25K",
+    );
+    expect(taskNodes).toHaveLength(1);
+    // 4 条 derives 边仍然都在(sourceHandle 区分 claim),target 是同一节点。
+    const derivesEdges = out.edges.filter(
+      (e) => e.target === "task_01KX2GZ3NTFARZ0WC39NXVT25K" && e.sourceHandle?.startsWith("claim-"),
+    );
+    expect(derivesEdges).toHaveLength(4);
+    const handles = new Set(derivesEdges.map((e) => e.sourceHandle));
+    expect(handles.has("claim-C1")).toBe(true);
+    expect(handles.has("claim-C2")).toBe(true);
+    expect(handles.has("claim-C3")).toBe(true);
+    expect(handles.has("claim-C4")).toBe(true);
+  });
+
+  it("修 #7:聚焦后代时 lineage 边按 canonical 方向(focus→other),claim handle 保留", async () => {
+    // 真实场景:dec_focus/CH1 refines dec_ancestor。当前 focus=dec_focus
+    // (descendant),other=dec_ancestor。canonical 方向 = focus→other。
+    const focusDecision: DecisionRow = {
+      decisionId: "dec_focus",
+      title: "后代决策",
+      state: "active",
+      question: "Q?",
+      chosen: [{ id: "CH1", text: "策略", evidence: [] }],
+      rejected: [],
+      claims: [{ id: "CH1", text: "策略" }],
+    };
+    const ancestorDecision: DecisionRow = {
+      decisionId: "dec_ancestor",
+      title: "祖先决策",
+      state: "active",
+      question: "Q?",
+      chosen: [{ id: "CH1", text: "策略", evidence: [] }],
+      rejected: [],
+      claims: [{ id: "CH1", text: "策略" }],
+    };
+    const lineageRelations: RelationEdge[] = [
+      {
+        from: "decision/dec_focus/CH1",
+        to: "decision/dec_ancestor",
+        kind: "refines",
+        provenance: "local-document",
+      },
+    ];
+    const out = await computeGraphLayout({
+      tasks,
+      relations: lineageRelations,
+      decisions: [focusDecision, ancestorDecision],
+      facts,
+      coverageRows: [],
+      focusNodeId: "decision/dec_focus",
+      expandedFacts: new Set(),
+      filters: {
+        modules: new Set(["kernel"]),
+        types: new Set(["decision", "task", "fact"]),
+        axes: { authority: true, evidence: true, execution: true, assoc: false },
+      },
+      inLoopNodes: new Set(),
+      inLoopEdges: new Set(),
+    });
+    // lineage 边 source=focus(带 CH1 handle),target=ancestor
+    const lineageEdge = out.edges.find((e) => e.id.startsWith("e_lineage_"));
+    expect(lineageEdge).toBeDefined();
+    expect(lineageEdge?.source).toBe("decision/dec_focus");
+    expect(lineageEdge?.target).toBe("decision/dec_ancestor");
+    expect(lineageEdge?.sourceHandle).toBe("claim-CH1");
+  });
+
+  it("修 #8:assoc decision↔decision 边打开 assoc 轴后渲染 assoc decision 节点", async () => {
+    // dec_other 通过 relates 关联 dec_focus;之前 assoc 轴打开也看不到。
+    const otherDecision: DecisionRow = {
+      decisionId: "dec_other_assoc",
+      title: "松关联决策",
+      state: "active",
+      question: "Q?",
+      chosen: [{ id: "CH1", text: "x", evidence: [] }],
+      rejected: [],
+      claims: [{ id: "CH1", text: "x" }],
+    };
+    const assocRelations: RelationEdge[] = [
+      ...relations,
+      {
+        from: `decision/${FOCUS_DECISION_ID}/CH1`,
+        to: "decision/dec_other_assoc",
+        kind: "relates",
+        provenance: "local-document",
+      },
+    ];
+    const out = await computeGraphLayout(
+      baseInput({
+        decisions: [decision, lineageDecision, otherDecision],
+        relations: assocRelations,
+        filters: {
+          modules: new Set(["kernel"]),
+          types: new Set(["decision", "task", "fact"]),
+          axes: { authority: true, evidence: true, execution: true, assoc: true },
+        },
+      }),
+    );
+    // 至少有 dec_other_assoc 关联节点(dec_mrd7jiux 也算,baseInput 里通过 RJ3 relates)。
+    const assocDecNode = out.nodes.find(
+      (n) => typeof n.id === "string" && n.id === "decision/dec_other_assoc__assoc",
+    );
+    expect(assocDecNode).toBeDefined();
+    expect(assocDecNode?.type).toBe("decision");
+    // assoc 边至少有一条(dec_other_assoc 那条 id 唯一)
+    const assocEdges = out.edges.filter((e) => e.id.startsWith("e_assoc_decision_"));
+    expect(assocEdges.length).toBeGreaterThanOrEqual(1);
+    const otherAssocEdge = assocEdges.find((e) => e.target === "decision/dec_other_assoc__assoc");
+    expect(otherAssocEdge).toBeDefined();
+    expect(otherAssocEdge?.source).toBe(`decision/${FOCUS_DECISION_ID}`);
+  });
+});
+
+describe("computeGraphLayout: simpleEgo (task focus) filter (#9)", () => {
+  it("task focus:关闭 decision 类型 → decision 邻居被过滤,fact/task 不受影响", async () => {
+    const focusTaskId = "task_01KX2GZ3NTFARZ0WC39NXVT25K";
+    // ego 关系:fact 与 focus task 同宿主(dec→fact 的 fact.taskId = focusTaskId);
+    // 以及 decision→focus task 的 derives。
+    const factRefOfFocus = `fact/${focusTaskId}/F-PRTXCD0P`;
+    const egoRelations: RelationEdge[] = [
+      // focus task 同宿主的 fact(用 produces 表达 task→fact 邻接)
+      {
+        from: `task/${focusTaskId}`,
+        to: factRefOfFocus,
+        kind: "produces",
+        provenance: "local-document",
+      },
+      // decision → focus task (derives)
+      {
+        from: "decision/dec_mrczk07e/C1",
+        to: `task/${focusTaskId}`,
+        kind: "derives",
+        provenance: "local-document",
+      },
+    ];
+    const out = await computeGraphLayout({
+      tasks,
+      relations: egoRelations,
+      decisions: [decision],
+      facts,
+      coverageRows: [],
+      focusNodeId: focusTaskId,
+      expandedFacts: new Set(),
+      filters: {
+        modules: new Set(["kernel"]),
+        // 关 decision,留 task + fact
+        types: new Set(["task", "fact"]),
+        axes: { authority: true, evidence: true, execution: true, assoc: false },
+      },
+      inLoopNodes: new Set(),
+      inLoopEdges: new Set(),
+    });
+    const nodeTypes = new Set(out.nodes.map((n) => n.type));
+    expect(nodeTypes.has("task")).toBe(true); // focus 自身
+    expect(nodeTypes.has("fact")).toBe(true); // fact 邻居保留
+    expect(nodeTypes.has("decision")).toBe(false); // 修 #9:decision 被 types 过滤掉
   });
 });


### PR DESCRIPTION
# English

## Summary

Fix all 11 adversarial-review findings from the triadic graph rebuild (task_01KXA7YYZQWMEBHD9CHPXEVA1A). The headline is #1: clicking a task node crashed the renderer because GraphView passed React Flow display data instead of the raw `TaskRow`, so the drawer read `closeoutReadiness`/`engine`/`freshness`/`module` as undefined. Also fixes coverage-lamp mislabeling, genealogy edge direction, multi-claim duplicate nodes, assoc decision edges, per-claim fact toggle, and adds a genealogy cycle warning. Each fix has vitest coverage; the merged E2E now clicks a task node to prevent #1 regressing.

## What Changed

- #1 (P1 crash, introduced by the rebuild): `GraphView.tsx` passes `n.data.raw` (the `TaskRow`) to the drawer; E2E adds a task-node click asserting the drawer renders.
- #2 (pre-existing, attributed to dec_mrf2nzvf — see commit): `DecisionPoolView.tsx` filter ternary precedence split into explicit branches.
- #3: `GraphView.tsx` splits `focusEdgeId` into its own state so edge selection no longer triggers a node re-layout that erases it.
- #4: `DecisionFocusNode.tsx` adds `data-claim-id`; GraphView anchors the toggle to the specific claim row instead of all claims.
- #5: `threeLaneLayout.ts` unions `coverageRows.coveringFactRef` with evidence edges for `claimRows.factRefs`.
- #6: `threeLaneLayout.ts` de-dupes tasks derived by multiple claims into one node with distinct source handles.
- #7: `threeLaneLayout.ts` renders lineage edges by canonical `from/to` direction and aligns the claim target handle.
- #8: `threeLaneLayout.ts` adds an `assocDecisions` bucket so the assoc axis can reveal decision↔decision `relates` edges.
- #9: `simpleEgoLayout.ts` consults `filters.types` so task/fact-focus type toggles hide neighbors.
- #10: `claimCoverage.ts` Path B only upgrades unknown→covered; missing/loading coverage stays `unknown` instead of being shown as confirmed risk.
- #11: `genealogy/layout.ts` detects `refines` cycles and surfaces a "谱系环警告" header in `GenealogyTimelineView.tsx`.

## Task And Scope

- Harness task: task_01KXAMDTVAXTN5PYYM9Z9V2DXW (parent coordination task task_01KXA7Q2RC0N0QJPAN9BF4PJ7Y); source: adversarial review in task_01KXA7YYZQWMEBHD9CHPXEVA1A
- Branch: fix/gui-triadic-findings
- Public scope: packages/gui renderer graph/views + e2e + gui tests only
- Private planning/evidence updated: yes (task ledger + per-finding disposition table)
- Out of scope: kernel/application/IPC/backend; writing-side enforcement of refines cycles (#11 warns in renderer only; fail-closed at ingest would be a separate task)

## Version Impact

- Version: no version change because this is a renderer-internal bug-fix batch
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: decision dec_01KXA7811SVVT8P66HNDFZQ7DF (accepted); #2 additionally attributed to dec_mrf2nzvf
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: e7d4bb7
- Branch merge-base with `origin/main`: e7d4bb7
- Last `git fetch origin` time: 2026-07-12
- Sync method: rebase
- Public diff command: `git diff origin/main...fix/gui-triadic-findings`
- Private evidence commit/path: harness task ledger for task_01KXAMDTVAXTN5PYYM9Z9V2DXW
- Reviewer evidence path: harness task package review document (final disposition table)
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci` — not run (verified root install)
- [x] `git diff --check`
- [x] `npm run check` — via `check:local`, 16 steps green (CEO re-ran; stale composite `dist` needed `tsc -b packages/gui --force`, a known local-only artifact issue)
- [x] `npm run typecheck`
- [x] `npm test` — `cd packages/gui && npm run test:e2e` 1/1 passed; gui vitest 63/63
- [x] `npm run harness:check-import-boundaries` (within check:local)
- [x] `npm run harness:scan-forbidden-symbols` (within check:local)
- [x] `npm run harness:check-private-boundary` (within check:local)
- [x] `npm run harness:check-package-policy` (within check:local)
- [x] `npm run harness:check-implementation-contracts` (within check:local)
- [x] `npm run harness:check-schema-contracts` (within check:local)
- [ ] `npm run harness:check-legacy-intake-readiness` — covered by CI
- [ ] `npm run harness:smoke-cli-package` — covered by CI (no CLI change)
- [ ] GitHub Actions `rewrite-ci` passed — pending
- Not run: root `npm test` and CLI smoke locally; covered by required CI. CI-equivalent gui gate chain (`run-manifest-gates.mjs --workflow-job gui-build`) re-run by the CEO and green.

## Review Evidence

- Self-review: worker fixed each finding with a reproduction and vitest/E2E coverage (gui vitest 63/63, E2E 1/1).
- Reviewer subagent: the findings themselves are the adversarial review (task_01KXA7YYZQWMEBHD9CHPXEVA1A).
- Human review: CEO ground-truthed #1 (task: n.data.raw at GraphView.tsx:265), #10 (Path B unknown-preserving), and re-ran the root gate and gui-build gate.
- Blocking findings: none open; the disposition table in the task closeout records every finding as fixed (with #2 attributed as pre-existing).

## Residual Risk

- #11 warns on refines cycles in the renderer but does not block them at ingest; writing-side fail-closed would be a separate decision/task.
- assoc-lane height estimation is approximate under extreme assoc task+decision stacking (pre-existing layout behavior, not in the findings list).

## References

- Task: task_01KXAMDTVAXTN5PYYM9Z9V2DXW
- Evidence: harness task ledger (disposition table, gate results)
- Review: task_01KXA7YYZQWMEBHD9CHPXEVA1A (adversarial findings source)

---

# 中文

## 概要

修复三原语关系图重构的对抗复核全部 11 条 findings(来源 task_01KXA7YYZQWMEBHD9CHPXEVA1A)。头号是 #1:点 task 节点崩溃——GraphView 传了 React Flow 显示态而非原始 `TaskRow`,drawer 读 `closeoutReadiness`/`engine`/`freshness`/`module` 全 undefined。另修覆盖灯误标、谱系边方向、多 claim 重复节点、assoc decision 边、per-claim fact 展开,并加谱系环告警。每条修复带 vitest;已合并的 E2E 现在会点击 task 节点防 #1 回归。

## 改动内容

- #1(P1 崩溃,本次引入):`GraphView.tsx` 向 drawer 传 `n.data.raw`(`TaskRow`);E2E 加点 task 节点断言抽屉渲染。
- #2(预存,归属 dec_mrf2nzvf — 见 commit):`DecisionPoolView.tsx` 过滤三元优先级拆成显式分支。
- #3:`GraphView.tsx` 拆 `focusEdgeId` 独立 state,边选择不再触发抹掉它的节点重排。
- #4:`DecisionFocusNode.tsx` 加 `data-claim-id`;GraphView 把 toggle 锚到具体 claim 行而非全部。
- #5:`threeLaneLayout.ts` 把 `coverageRows.coveringFactRef` 与 evidence 边并集给 `claimRows.factRefs`。
- #6:`threeLaneLayout.ts` 把多 claim derive 的同一 task 去重成单节点 + 区分 source handle。
- #7:`threeLaneLayout.ts` 按 canonical `from/to` 方向渲染谱系边并对齐 claim target handle。
- #8:`threeLaneLayout.ts` 新增 `assocDecisions` bucket,assoc 轴可显 decision↔decision `relates` 边。
- #9:`simpleEgoLayout.ts` 读 `filters.types`,task/fact focus 时类型开关生效。
- #10:`claimCoverage.ts` Path B 只升级 unknown→covered;缺失/加载中的覆盖保持 `unknown`,不再显示为确认风险。
- #11:`genealogy/layout.ts` 检测 `refines` 环并在 `GenealogyTimelineView.tsx` header 显示「谱系环警告」。

## 任务与范围

- Harness 任务:task_01KXAMDTVAXTN5PYYM9Z9V2DXW(父协调任务 task_01KXA7Q2RC0N0QJPAN9BF4PJ7Y);来源:task_01KXA7YYZQWMEBHD9CHPXEVA1A 的对抗复核
- 分支:fix/gui-triadic-findings
- 公开范围:仅 packages/gui renderer graph/views + e2e + gui 测试
- 私有计划 / 证据是否已更新:yes(任务台账 + 逐条分诊表)
- 范围外:kernel/application/IPC/后端;refines 环的写入侧强制(#11 仅 renderer 告警,ingest fail-closed 另立任务)

## 版本影响

- 版本:不改版本,原因是 renderer 内部 bug 修复批
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:决策 dec_01KXA7811SVVT8P66HNDFZQ7DF(已接受);#2 另归属 dec_mrf2nzvf
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- `origin/main` 基准 SHA:e7d4bb7
- 当前分支与 `origin/main` 的 merge-base:e7d4bb7
- 最近一次 `git fetch origin` 时间:2026-07-12
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...fix/gui-triadic-findings`
- 私有证据 commit/path:task_01KXAMDTVAXTN5PYYM9Z9V2DXW 的 harness 任务台账
- Reviewer 证据路径:harness 任务包 review 文档(最终分诊表)
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- [ ] `npm ci` — 未跑(根安装已验证)
- [x] `git diff --check`
- [x] `npm run check` — 经 `check:local`,16 步绿(CEO 复跑;stale composite `dist` 需 `tsc -b packages/gui --force`,已知本地产物问题)
- [x] `npm run typecheck`
- [x] `npm test` — `cd packages/gui && npm run test:e2e` 1/1 绿;gui vitest 63/63
- [x] `npm run harness:check-import-boundaries`(check:local 内)
- [x] `npm run harness:scan-forbidden-symbols`(check:local 内)
- [x] `npm run harness:check-private-boundary`(check:local 内)
- [x] `npm run harness:check-package-policy`(check:local 内)
- [x] `npm run harness:check-implementation-contracts`(check:local 内)
- [x] `npm run harness:check-schema-contracts`(check:local 内)
- [ ] `npm run harness:check-legacy-intake-readiness` — 交 CI
- [ ] `npm run harness:smoke-cli-package` — 交 CI(无 CLI 改动)
- [ ] GitHub Actions `rewrite-ci` passed — 待跑
- 未运行:根 `npm test` 与 CLI smoke 本地未跑,由 required CI 覆盖。CI 同款 gui gate 链(`run-manifest-gates.mjs --workflow-job gui-build`)由 CEO 复跑且绿。

## 审查证据

- 自查:worker 逐条 finding 带复现 + vitest/E2E 覆盖(gui vitest 63/63,E2E 1/1)。
- Reviewer subagent:findings 本身即对抗复核(task_01KXA7YYZQWMEBHD9CHPXEVA1A)。
- 人工审查:CEO ground-truth 了 #1(GraphView.tsx:265 传 n.data.raw)、#10(Path B 保持 unknown),并复跑了根 gate 与 gui-build gate。
- 阻塞发现:无;任务 closeout 的分诊表记录每条 finding 为已修(#2 标注预存)。

## 残余风险

- #11 在 renderer 告警 refines 环但不在 ingest 侧阻断;写入侧 fail-closed 需另立决策/任务。
- assoc 泳道高度估算在极端 assoc task+decision 叠加下为近似(预存布局行为,不在 findings 列表)。

## 关联材料

- 任务:task_01KXAMDTVAXTN5PYYM9Z9V2DXW
- 证据:harness 任务台账(分诊表、gate 结果)
- 审查:task_01KXA7YYZQWMEBHD9CHPXEVA1A(对抗 findings 来源)
