### PR TITLE
feat(gui): triadic graph usability — focus switcher, minimap fix, history, click semantics

### DIFF
--- a/packages/gui/e2e/electron-smoke.e2e.mjs
+++ b/packages/gui/e2e/electron-smoke.e2e.mjs
@@ -9,6 +9,22 @@ import { _electron as electron } from "playwright-core";
 
 const repoRoot = resolve(import.meta.dirname, "../../..");
 const guiRoot = resolve(repoRoot, "packages/gui");
+
+// dec_01KXA7811SVVT8P66HNDFZQ7DF GUI usability evidence shots. The directory
+// is a sibling of the hermetic ledger so it gets cleaned up with the test run
+// but stays readable from a developer machine. Set HARNESS_GUI_E2E_SHOTS to
+// a stable absolute path to retain shots across runs (used for closeout evidence).
+const screenshotDir = process.env.HARNESS_GUI_E2E_SHOTS
+  ? resolve(process.env.HARNESS_GUI_E2E_SHOTS)
+  : mkdtempSync(path.join(tmpdir(), "ha-gui-e2e-shots-"));
+
+async function captureGraphEvidence(page, name) {
+  const file = path.join(screenshotDir, `${name}.png`);
+  await page.screenshot({ path: file, fullPage: false }).catch((error) => {
+    console.warn(`[screenshot] ${name} failed: ${error.message}`);
+  });
+  return file;
+}
 test("Electron shell opens its first BrowserWindow", { timeout: 90_000 }, async (t) => {
   const ledgerRoot = mkdtempSync(path.join(tmpdir(), "ha-gui-e2e-"));
   writeTriadicLedger(ledgerRoot);
@@ -38,7 +54,7 @@ test("Electron shell opens its first BrowserWindow", { timeout: 90_000 }, async 
   page.on("console", (message) => {
     if (message.type() === "error") consoleFailures.push(message.text());
   });
-  page.on("pageerror", (error) => consoleFailures.push(error.message));
+  page.on("pageerror", (error) => consoleFailures.push(`${error.message}\n${error.stack ?? ""}`));
   await page.waitForLoadState("domcontentloaded");
 
   assert.equal(await page.title(), "Harness Anything");
@@ -75,7 +91,9 @@ test("Electron shell opens its first BrowserWindow", { timeout: 90_000 }, async 
   // task projection. The hermetic authored ledger exercises the focused ego
   // graph, claim coverage, semantic-axis filters, fact expansion, and the
   // genealogy multi-view without a renderer-side mock.
-  await page.getByRole("button", { name: /关系图/u }).click();
+  // Scope to the workspace nav (sidebar) — the permanent multi-view switcher
+  // also exposes a 关系图 button (dec_01KXA7811SVVT8P66HNDFZQ7DF GUI usability).
+  await page.getByRole("complementary").getByRole("button", { name: "关系图" }).click();
   await page.locator(".react-flow").waitFor({ timeout: 10_000 });
   const focusCard = page.locator(".react-flow__node-decisionFocus");
   await focusCard.waitFor({ timeout: 10_000 });
@@ -89,6 +107,30 @@ test("Electron shell opens its first BrowserWindow", { timeout: 90_000 }, async 
   assert.equal(await page.locator(".react-flow__node-fact").count(), 0, "facts start folded into claim badges");
   assert.equal(await page.locator(".react-flow__edge").count(), 2);
   assert.equal(await page.getByText("MOCK", { exact: true }).count(), 0, "triadic views must not be mock-backed");
+
+  // GUI usability (dec_01KXA7811SVVT8P66HNDFZQ7DF): the renderer ships a
+  // permanent multi-view switcher (graph/genealogy), a left FocusSwitcher
+  // sidebar (search + entity list), a focus history bar with back/forward,
+  // and the ReactFlow colorMode hookup so the MiniMap inherits dark theme
+  // instead of painting a white SVG box.
+  await page.getByTestId("multi-view-switcher").waitFor();
+  const focusSwitcher = page.getByTestId("focus-switcher");
+  await focusSwitcher.waitFor();
+  await focusSwitcher.getByRole("searchbox").waitFor();
+  await focusSwitcher.getByText("Expose the triadic projection to the GUI", { exact: false }).waitFor();
+  await focusSwitcher.getByText("Render the real triadic projection", { exact: false }).waitFor();
+  const focusHistoryBar = page.getByTestId("focus-history-bar");
+  await focusHistoryBar.waitFor();
+  // Default-picked focus is on the graph but not yet in history; back/forward disabled.
+  assert.equal(await focusHistoryBar.getByRole("button", { name: "上一个焦点" }).isDisabled(), true);
+  assert.equal(await focusHistoryBar.getByRole("button", { name: "下一个焦点" }).isDisabled(), true);
+  // The MiniMap must render once colorMode flows in (regression: previously the
+  // missing colorMode prop left it painting a stark white box on dark theme).
+  await page.locator(".react-flow__minimap").waitFor({ timeout: 10_000 });
+  // Breadcrumb shows the focused decision (the layout-picked default).
+  await focusHistoryBar.getByText("decision/dec_gui_smoke", { exact: true }).waitFor();
+  // Evidence: default-focus graph with MiniMap and breadcrumb visible.
+  await captureGraphEvidence(page, "01-graph-default-focus-minimap");
 
   const assocToggle = page.getByRole("button", { name: /关联.*relates.*implements/u });
   assert.match(await assocToggle.getAttribute("class") ?? "", /opacity-60/u, "assoc must default off");
@@ -117,6 +159,9 @@ test("Electron shell opens its first BrowserWindow", { timeout: 90_000 }, async 
   // GraphView passed `n.data` instead of `n.data.raw` to GraphDrawer, and
   // CloseoutBadge read `CLOSEOUT_META[undefined]`. Now the drawer should open
   // and render task-specific badges (status / closeout / engine).
+  // dec_01KXA7811SVVT8P66HNDFZQ7DF GUI usability: single click selects + opens
+  // the drawer WITHOUT changing the focus, so the focused decision card stays
+  // central. The drawer exposes an explicit "设为焦点" button.
   const taskNode = page.locator(".react-flow__node-task").first();
   await taskNode.click();
   const taskDrawer = page.locator("aside");
@@ -125,8 +170,74 @@ test("Electron shell opens its first BrowserWindow", { timeout: 90_000 }, async 
   await taskDrawer.getByText("Active", { exact: true }).waitFor();
   await taskDrawer.getByText("无需收口", { exact: true }).waitFor();
   await taskDrawer.getByText("local", { exact: true }).waitFor();
+  // Single click did NOT change focus: the focused decision card is still
+  // centered (the decisionFocus node stays rendered) and the breadcrumb still
+  // shows the focused decision, not the selected task.
+  await page.locator(".react-flow__node-decisionFocus").waitFor();
+  await focusHistoryBar.getByText("decision/dec_gui_smoke", { exact: true }).waitFor();
+  await taskDrawer.getByRole("button", { name: "设为焦点" }).waitFor();
+  // Evidence: single-click opened the drawer; breadcrumb still shows the focus.
+  await captureGraphEvidence(page, "02-click-opens-drawer-no-focus-change");
+  // Close the drawer so it does not crowd subsequent interactions; the focus
+  // must remain on dec_gui_smoke after Esc.
+  await taskDrawer.getByRole("button", { name: /退出抽屉|退出聚焦/u }).click();
 
-  const viewSwitcher = page.getByText("同一实体 · 多视图", { exact: true }).locator("..");
+  // Focus switcher: type-to-search narrows the list, and clicking a hit
+  // changes focus (driving both layout and history).
+  const switcherInput = focusSwitcher.getByRole("searchbox");
+  await switcherInput.fill("ancestor");
+  await focusSwitcher.getByText("Earlier GUI projection decision", { exact: false }).waitFor();
+  await focusSwitcher.getByText("Expose the triadic projection to the GUI", { exact: false }).waitFor({ state: "detached" });
+  // Evidence: switcher search narrows the list.
+  await captureGraphEvidence(page, "03-focus-switcher-search");
+  await switcherInput.clear();
+  // Pick the ancestor decision through the switcher (verifies setFocusId).
+  await focusSwitcher.getByRole("button").filter({ hasText: "Earlier GUI projection decision" }).click();
+  await focusHistoryBar.getByText("decision/dec_gui_ancestor", { exact: true })
+    .waitFor()
+    .catch(async () => {
+      const bodyText = await page.locator("body").innerText().catch(() => "<empty>");
+      throw new Error(
+        `breadcrumb did not show dec_gui_ancestor after switcher click.\n`
+        + `consoleFailures:\n${consoleFailures.join("\n")}\n`
+        + `bodyText (first 2000 chars):\n${bodyText.slice(0, 2000)}`,
+      );
+    });
+  // History now has [ancestor] — back stays disabled because there is nothing
+  // earlier in the user-navigated stack. Set a second focus to exercise back.
+  await focusSwitcher.getByRole("button").filter({ hasText: "Expose the triadic projection to the GUI" }).click();
+  await focusHistoryBar.getByText("decision/dec_gui_smoke", { exact: true }).waitFor();
+  assert.equal(await focusHistoryBar.getByRole("button", { name: "上一个焦点" }).isDisabled(), false);
+  // Evidence: history now has two entries with back/forward enabled.
+  await captureGraphEvidence(page, "04-focus-history-back-forward-enabled");
+  // Back returns to the ancestor; forward restores the smoke decision.
+  await focusHistoryBar.getByRole("button", { name: "上一个焦点" }).click();
+  await focusHistoryBar.getByText("decision/dec_gui_ancestor", { exact: true }).waitFor();
+  // Evidence: after back, breadcrumb shows the ancestor.
+  await captureGraphEvidence(page, "05-focus-history-back-to-ancestor");
+  assert.equal(await focusHistoryBar.getByRole("button", { name: "下一个焦点" }).isDisabled(), false);
+  await focusHistoryBar.getByRole("button", { name: "下一个焦点" }).click();
+  await focusHistoryBar.getByText("decision/dec_gui_smoke", { exact: true }).waitFor();
+
+  // Click-then-set-as-focus is the explicit keyboardless way to change focus
+  // to a non-decision node. The drawer exposes a "设为焦点" button exactly for
+  // this — equivalent to onNodeDoubleClick but discoverable.
+  await page.locator(".react-flow__node-task").first().click();
+  await page.locator("aside").getByRole("button", { name: "设为焦点" }).click();
+  await focusHistoryBar.getByText("task-gui-smoke", { exact: true })
+    .waitFor()
+    .catch(async () => {
+      const bodyText = await page.locator("body").innerText().catch(() => "<empty>");
+      throw new Error(
+        `breadcrumb did not show task after set-as-focus button.\n`
+        + `consoleFailures:\n${consoleFailures.join("\n")}\n`
+        + `bodyText (first 2000 chars):\n${bodyText.slice(0, 2000)}`,
+      );
+    });
+  // Evidence: focus switched to a task node via the explicit button.
+  await captureGraphEvidence(page, "06-set-as-focus-task");
+
+  const viewSwitcher = page.getByTestId("multi-view-switcher");
   await viewSwitcher.getByRole("button", { name: "演化史", exact: true }).click();
   await page.getByRole("heading", { name: "决策演化史", exact: true }).waitFor();
   await page.getByText(/2 决策参与谱系 · 1 条演化边/u).waitFor();

--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -408,10 +408,13 @@ function AppShell() {
         {showMockBanner && <MockViewBanner />}
         <div className="flex min-h-0 min-w-0 flex-1 flex-row overflow-hidden">
           <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-            {!selected && (view === "graph" || view === "genealogy") && (
-              <div className="flex items-center gap-2 border-b border-border bg-surface/60 px-4 py-1.5">
+            {!selected && (
+              <div
+                data-testid="multi-view-switcher"
+                className="flex items-center gap-2 border-b border-border bg-surface/60 px-4 py-1.5"
+              >
                 <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
-                  同一实体 · 多视图
+                  多视图
                 </span>
                 <div className="flex items-center gap-0.5 rounded-md border border-border p-0.5">
                   {([
@@ -432,7 +435,7 @@ function AppShell() {
                   ))}
                 </div>
                 <span className="text-[11px] text-text-faint">
-                  关系图看结构 · 演化史看 decision 谱系随时间的 refine/narrow/supersede
+                  常驻切换 · 关系图看结构,演化史看 decision 谱系随时间的 refine/narrow/supersede
                 </span>
               </div>
             )}

--- a/packages/gui/src/renderer/components/FocusHistoryBar.tsx
+++ b/packages/gui/src/renderer/components/FocusHistoryBar.tsx
@@ -1,0 +1,103 @@
+import { ArrowLeft, ArrowRight, Crosshair, X } from "@phosphor-icons/react";
+
+/**
+ * GraphView 焦点历史 + 面包屑(dec_01KXA7811SVVT8P66HNDFZQ7DF — 关系图可用性)。
+ *
+ * 经典浏览器式 back/forward 按钮 + 当前焦点实体的「类型 + 标题」面包屑。
+ * 让用户「跳过去回得来」,知道当前看的是谁的图。
+ *
+ * 纯展示;状态机由 GraphView 用 graph/focusHistory.ts 持有,本组件只接
+ * (state, label) + 三个回调。breadcrumbLabel 为空表示当前无焦点或焦点是
+ * 布局器挑的默认(不在历史里),此时仍允许 back 到上一个手动焦点。
+ */
+
+interface Props {
+  canBack: boolean;
+  canForward: boolean;
+  /** 当前焦点节点的展示信息(kind/title);focusId 不在历史里也可显示。 */
+  breadcrumb: { kindLabel: string; title: string; nodeId: string } | null;
+  onBack: () => void;
+  onForward: () => void;
+  onClear: () => void;
+}
+
+export function FocusHistoryBar({
+  canBack,
+  canForward,
+  breadcrumb,
+  onBack,
+  onForward,
+  onClear,
+}: Props) {
+  return (
+    <div
+      data-testid="focus-history-bar"
+      className="flex items-center gap-1 border-b border-border bg-surface/60 px-2 py-1 text-[11px]"
+    >
+      <button
+        type="button"
+        onClick={onBack}
+        disabled={!canBack}
+        title="上一个焦点 (back)"
+        aria-label="上一个焦点"
+        className={`grid size-6 place-items-center rounded ${
+          canBack
+            ? "text-text-muted hover:bg-surface-raised hover:text-text"
+            : "text-text-faint opacity-40"
+        }`}
+      >
+        <ArrowLeft weight="bold" className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={onForward}
+        disabled={!canForward}
+        title="下一个焦点 (forward)"
+        aria-label="下一个焦点"
+        className={`grid size-6 place-items-center rounded ${
+          canForward
+            ? "text-text-muted hover:bg-surface-raised hover:text-text"
+            : "text-text-faint opacity-40"
+        }`}
+      >
+        <ArrowRight weight="bold" className="size-3.5" />
+      </button>
+
+      {breadcrumb ? (
+        <>
+          <span className="mx-1 inline-flex items-center gap-1 rounded border border-border bg-surface-raised px-1.5 py-0.5">
+            <Crosshair weight="bold" className="size-3 text-accent" />
+            <span className="font-mono uppercase tracking-wide text-text-faint">
+              {breadcrumb.kindLabel}
+            </span>
+            <span
+              className="max-w-[280px] truncate text-text"
+              title={breadcrumb.title}
+            >
+              {breadcrumb.title}
+            </span>
+            <span
+              className="truncate font-mono text-[10px] text-text-faint"
+              title={breadcrumb.nodeId}
+            >
+              {breadcrumb.nodeId}
+            </span>
+          </span>
+          <button
+            type="button"
+            onClick={onClear}
+            title="退出聚焦"
+            aria-label="退出聚焦"
+            className="grid size-5 place-items-center rounded text-text-faint hover:bg-surface-raised hover:text-text"
+          >
+            <X weight="bold" className="size-3" />
+          </button>
+        </>
+      ) : (
+        <span className="px-2 font-mono text-text-faint">
+          默认聚焦式 ego · 双击节点或左栏点选切换焦点
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/gui/src/renderer/components/FocusSwitcher.tsx
+++ b/packages/gui/src/renderer/components/FocusSwitcher.tsx
@@ -1,0 +1,178 @@
+import { useMemo, useState } from "react";
+import { MagnifyingGlass, Graph } from "@phosphor-icons/react";
+import type { DecisionRow, TaskRow } from "../model/types";
+
+/**
+ * GraphView 焦点切换器(dec_01KXA7811SVVT8P66HNDFZQ7DF — 关系图可用性)。
+ *
+ * 移植原型 .harness/generated/triadic-graph/index.html 的左栏交互:
+ *   - 顶部搜索框(标题子串匹配,空格分词 AND);
+ *   - 列表按「关系度数」(claim / 边数)降序,承接原型 decs.sort(byDeg);
+ *   - 点选 = 换焦点(setFocusId),并显示当前焦点高亮(active);
+ *   - decisions 优先(tasks 在它之后,facts 不进列表——锚点而非焦点候选)。
+ *
+ * 不调后端、不读写 IPC;纯展示组件,焦点变更由父组件 GraphView 走 setFocusId。
+ */
+
+interface Props {
+  decisions: DecisionRow[];
+  tasks: TaskRow[];
+  /** 当前焦点节点 id(decision/<id> | task/<id> | fact/...);列表命中即高亮。 */
+  focusId: string | null;
+  /** 用户点选实体时触发;父组件负责推焦点历史 + 触发布局重算。 */
+  onFocus: (nodeId: string) => void;
+}
+
+const KIND_LABEL: Record<"decision" | "task", string> = {
+  decision: "decision",
+  task: "task",
+};
+
+const KIND_COLOR: Record<"decision" | "task", string> = {
+  decision: "var(--color-accent)",
+  task: "var(--color-axis-execution)",
+};
+
+interface ListItem {
+  kind: "decision" | "task";
+  id: string;
+  nodeId: string;
+  title: string;
+  meta: string;
+  weight: number;
+}
+
+/** 把搜索串切成查询段,空返回 null(表示不过滤)。 */
+function splitQueryTerms(query: string): string[] | null {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return null;
+  return trimmed.split(/\s+/u);
+}
+
+function matchesQuery(title: string, id: string, terms: string[] | null): boolean {
+  if (!terms) return true;
+  const hay = `${title} ${id}`.toLowerCase();
+  return terms.every((term) => hay.includes(term));
+}
+
+export function FocusSwitcher({ decisions, tasks, focusId, onFocus }: Props) {
+  const [query, setQuery] = useState("");
+
+  const items = useMemo<ListItem[]>(() => {
+    const decisionItems: ListItem[] = decisions.map((d) => ({
+      kind: "decision",
+      id: d.decisionId,
+      nodeId: `decision/${d.decisionId}`,
+      title: d.title,
+      meta: `${d.state} · ${d.claims.length} claim`,
+      // claim 数 + 状态权重:active/proposed 优先。
+      weight: d.claims.length * 10 + (d.state === "active" ? 5 : d.state === "proposed" ? 3 : 0),
+    }));
+    const taskItems: ListItem[] = tasks.map((t) => ({
+      kind: "task",
+      id: t.taskId,
+      nodeId: t.taskId,
+      title: t.title,
+      meta: `${t.coordinationStatus} · ${t.module || "—"}`,
+      // task 排在 decision 之后;同 kind 内按 module/title 稳定。
+      weight: 0,
+    }));
+    // decisions 按 weight 降序;tasks 保留输入顺序(已按 module/project 排好)。
+    decisionItems.sort((a, b) => b.weight - a.weight);
+    return [...decisionItems, ...taskItems];
+  }, [decisions, tasks]);
+
+  const terms = splitQueryTerms(query);
+  const visible = useMemo(
+    () => items.filter((it) => matchesQuery(it.title, it.id, terms)),
+    [items, terms],
+  );
+
+  const decisionCount = items.filter((it) => it.kind === "decision").length;
+
+  return (
+    <aside
+      data-testid="focus-switcher"
+      className="flex w-64 shrink-0 flex-col border-r border-border bg-surface"
+    >
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <Graph weight="duotone" className="shrink-0 text-text-muted" />
+        <span className="font-mono text-[11px] uppercase tracking-wide text-text-faint">
+          焦点切换
+        </span>
+        <span className="ml-auto font-mono text-[11px] text-text-faint">
+          {decisionCount} 决策 · {items.length - decisionCount} 任务
+        </span>
+      </div>
+
+      <label className="relative block border-b border-border px-2 py-2">
+        <span className="sr-only">搜索焦点实体</span>
+        <MagnifyingGlass
+          weight="bold"
+          className="pointer-events-none absolute left-3.5 top-1/2 size-3.5 -translate-y-1/2 text-text-faint"
+        />
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="搜索决策 / 任务…"
+          className="w-full rounded-md border border-border bg-surface-raised py-1.5 pl-7 pr-2 text-[12px] text-text placeholder:text-text-faint focus:border-accent focus:outline-none"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </label>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        {visible.length === 0 ? (
+          <div className="px-3 py-3 text-[12px] leading-relaxed text-text-faint">
+            没有命中的实体。清空搜索看全部。
+          </div>
+        ) : (
+          <ul className="flex flex-col py-1">
+            {visible.map((it) => {
+              const active = it.nodeId === focusId;
+              const accent = KIND_COLOR[it.kind];
+              return (
+                <li key={`${it.kind}/${it.id}`}>
+                  <button
+                    type="button"
+                    onClick={() => onFocus(it.nodeId)}
+                    title={it.title}
+                    aria-pressed={active}
+                    className={`group flex w-full flex-col gap-0.5 border-l-2 px-3 py-1.5 text-left transition-colors ${
+                      active
+                        ? "border-l-accent bg-accent/10 text-text"
+                        : "border-l-transparent text-text-muted hover:bg-surface-raised hover:text-text"
+                    }`}
+                    style={active ? { borderColor: accent } : undefined}
+                  >
+                    <span className="flex items-center gap-1.5">
+                      <span
+                        className="inline-block size-1.5 shrink-0 rounded-full"
+                        style={{ backgroundColor: accent }}
+                        aria-hidden="true"
+                      />
+                      <span
+                        className={`font-mono text-[10px] uppercase tracking-wide ${
+                          active ? "text-accent" : "text-text-faint"
+                        }`}
+                      >
+                        {KIND_LABEL[it.kind]}
+                      </span>
+                      <span className="ml-auto truncate font-mono text-[10px] text-text-faint">
+                        {it.meta}
+                      </span>
+                    </span>
+                    <span className="line-clamp-2 text-[12px] leading-snug">
+                      {it.title}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/packages/gui/src/renderer/graph/GraphDrawer.tsx
+++ b/packages/gui/src/renderer/graph/GraphDrawer.tsx
@@ -1,4 +1,4 @@
-import { X, GitBranch, ArrowSquareOut, ArrowsOutSimple } from "@phosphor-icons/react";
+import { X, GitBranch, ArrowSquareOut, ArrowsOutSimple, Crosshair } from "@phosphor-icons/react";
 import type { RelationEdge } from "../model/types";
 import {
   StatusBadge,
@@ -26,6 +26,13 @@ interface Props {
   onFocus: (id: string | null) => void;
   /** W2B 活链接:在列表/详情侧打开该 entity(task→detail, decision→pool, fact→triage) */
   onNavigateEntity?: (ref: string) => void;
+  /**
+   * 抽屉里当前展示的节点是否已经是焦点(dec_01KXA7811SVVT8P66HNDFZQ7DF — 关系图
+   * 可用性)。是 → 隐藏「设为焦点」按钮;否 → 显示,点一下显式换焦点。
+   */
+  isFocused?: boolean;
+  /** 抽屉里「设为焦点」按钮触发的回调;父组件负责推焦点历史。 */
+  onSetAsFocus?: () => void;
 }
 
 export function GraphDrawer({
@@ -38,6 +45,8 @@ export function GraphDrawer({
   onClose,
   onFocus,
   onNavigateEntity,
+  isFocused,
+  onSetAsFocus,
 }: Props) {
   if (focusEdge) {
     return (
@@ -124,9 +133,29 @@ export function GraphDrawer({
             打开
           </button>
         )}
+        {onSetAsFocus && (
+          isFocused ? (
+            <span
+              title="此节点已是焦点"
+              className="inline-flex items-center gap-1 rounded border border-accent/40 bg-accent/10 px-1.5 py-0.5 text-[10px] text-accent"
+            >
+              <Crosshair weight="bold" className="text-[10px]" />
+              焦点
+            </span>
+          ) : (
+            <button
+              onClick={onSetAsFocus}
+              title="把这个节点设为图焦点(双击节点同效)"
+              className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[10px] text-text-muted hover:border-accent hover:text-accent"
+            >
+              <Crosshair weight="bold" className="text-[10px]" />
+              设为焦点
+            </button>
+          )
+        )}
         <button
           onClick={onClose}
-          title="退出聚焦 (Esc)"
+          title="退出抽屉 (Esc)"
           className="ml-auto grid size-6 place-items-center rounded text-text-faint hover:bg-surface-raised hover:text-text"
         >
           <X weight="bold" />

--- a/packages/gui/src/renderer/graph/focusHistory.ts
+++ b/packages/gui/src/renderer/graph/focusHistory.ts
@@ -1,0 +1,64 @@
+/**
+ * GraphView 焦点历史栈(dec_01KXA7811SVVT8P66HNDFZQ7DF — 关系图可用性补齐)。
+ *
+ * 纯函数 + 显式 state,刻意不挂 React,以便 vitest 直接覆盖 back/forward/push
+ * 三条核心迁移。GraphView 用 useState 持有 FocusHistoryState,变更走这里的函数。
+ *
+ * 设计:
+ *   - history 只收「主动切换焦点」的足迹:双击节点 / FocusSwitcher 点选 / 抽屉
+ *     「设为焦点」按钮 / focusRef 跨视图带入。布局器自己挑的默认焦点不进栈,
+ *     用户「退出聚焦」(关抽屉/点空白) 也不进栈 —— 这些都不算用户「跳到过」。
+ *   - push 截断 forward 栈(经典浏览器语义):从历史中间换新焦点后,旧 future 作废。
+ *   - 重复连推同 id 视为 no-op,避免点 Switcher 同一项把栈灌满。
+ */
+
+export interface FocusHistoryState {
+  /** 完整足迹;back 从 [0,index-1] 取,forward 从 [index+1]。 */
+  entries: string[];
+  /** 当前焦点在 entries 中的下标;-1 表示当前不在历史里(默认焦点 / 退出聚焦)。 */
+  index: number;
+}
+
+export function createFocusHistory(): FocusHistoryState {
+  return { entries: [], index: -1 };
+}
+
+/** 当前落在历史里的焦点 id;若 index=-1 返回 null(不代表「无焦点」,只代表「不在栈里」)。 */
+export function currentFocus(state: FocusHistoryState): string | null {
+  return state.index >= 0 && state.index < state.entries.length
+    ? state.entries[state.index]
+    : null;
+}
+
+export function canGoBack(state: FocusHistoryState): boolean {
+  return state.index > 0;
+}
+
+export function canGoForward(state: FocusHistoryState): boolean {
+  return state.index >= 0 && state.index < state.entries.length - 1;
+}
+
+/**
+ * 推一个新焦点。重复推同 id 不变(防误灌栈)。截断 forward 栈:
+ * 从历史中间换焦点后,旧 future 作废。
+ */
+export function pushFocus(
+  state: FocusHistoryState,
+  id: string,
+): FocusHistoryState {
+  if (currentFocus(state) === id) return state;
+  const nextIndex = state.index + 1;
+  const truncated = state.entries.slice(0, nextIndex);
+  truncated.push(id);
+  return { entries: truncated, index: nextIndex };
+}
+
+export function goBack(state: FocusHistoryState): FocusHistoryState {
+  if (!canGoBack(state)) return state;
+  return { ...state, index: state.index - 1 };
+}
+
+export function goForward(state: FocusHistoryState): FocusHistoryState {
+  if (!canGoForward(state)) return state;
+  return { ...state, index: state.index + 1 };
+}

--- a/packages/gui/src/renderer/views/GraphLegend.tsx
+++ b/packages/gui/src/renderer/views/GraphLegend.tsx
@@ -1,0 +1,71 @@
+/**
+ * GraphView 顶部图例 + 状态栏(dec_01KXA7811SVVT8P66HNDFZQ7DF)。
+ *
+ * 从 GraphView.tsx 抽出来,让 GraphView 主文件回到 600 行内的复杂度门。
+ * 纯展示 + 把交互提示话术随焦点状态切换。
+ */
+
+interface Props {
+  visibleNodeCount: number;
+  edgeCount: number;
+  resolvedFocusId: string | null;
+  cycleWarning: { count: number; cycles: string[][] };
+  hasFocus: boolean;
+}
+
+export function GraphLegend({
+  visibleNodeCount,
+  edgeCount,
+  resolvedFocusId,
+  cycleWarning,
+  hasFocus,
+}: Props) {
+  return (
+    <header className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b border-border px-4 py-2 text-[11px] text-text-muted">
+      <span className="font-mono text-text-faint">
+        {visibleNodeCount} 节点 · {edgeCount} 边
+        {resolvedFocusId ? ` · 聚焦 ${resolvedFocusId}` : ""}
+      </span>
+      <span className="inline-flex items-center gap-1">
+        <span
+          className="inline-block h-2.5 w-2.5 rounded-sm border"
+          style={{
+            borderColor: "var(--color-axis-execution)",
+            background: "var(--color-surface-raised)",
+          }}
+        />
+        task（方块·派生）
+      </span>
+      <span className="inline-flex items-center gap-1">
+        <span className="inline-block h-2.5 w-2.5 rounded border" style={{ borderColor: "var(--color-accent)", background: "rgba(176,124,240,0.2)" }} />
+        decision（菱形·主张+claim）
+      </span>
+      <span className="inline-flex items-center gap-1">
+        <span className="inline-block h-2.5 w-2.5 rounded-full border" style={{ borderColor: "var(--color-axis-evidence)", background: "rgba(240,162,60,0.2)" }} />
+        fact（圆·证据徽章）
+      </span>
+      <span className="inline-flex items-center gap-2">
+        <span className="text-text-faint">coverage:</span>
+        <span className="inline-flex items-center gap-1">
+          <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: "var(--color-status-done)" }} /> 已佐证
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: "var(--color-danger)" }} /> 无证据
+        </span>
+      </span>
+      {cycleWarning.count > 0 && (
+        <span
+          className="inline-flex items-center gap-1 rounded bg-danger/10 px-1.5 py-0.5 font-mono text-danger"
+          title={cycleWarning.cycles.map((c) => c.join(" → ")).join("\n")}
+        >
+          INV-3 环警告 · {cycleWarning.count}
+        </span>
+      )}
+      <span className="ml-auto text-text-faint">
+        {hasFocus
+          ? "Esc / 点击空白处关抽屉 · 单击=选中 · 双击=设焦点 · 点击 claim 行展开证据 fact"
+          : "默认聚焦式 ego · 左栏搜索/双击节点换焦点 (Powered by React Flow)"}
+      </span>
+    </header>
+  );
+}

--- a/packages/gui/src/renderer/views/GraphView.tsx
+++ b/packages/gui/src/renderer/views/GraphView.tsx
@@ -28,6 +28,16 @@ import {
   type AxisFilter,
   type GraphFilterInput,
 } from "../graph/graphLayout";
+import {
+  createFocusHistory,
+  currentFocus,
+  canGoBack as historyCanGoBack,
+  canGoForward as historyCanGoForward,
+  goBack as historyGoBack,
+  goForward as historyGoForward,
+  pushFocus,
+  type FocusHistoryState,
+} from "../graph/focusHistory";
 
 import { TaskNode } from "../graph/nodes/TaskNode";
 import { DecisionNode } from "../graph/nodes/DecisionNode";
@@ -40,6 +50,10 @@ import {
   GraphFilterPanel,
   type GraphFilters,
 } from "../components/GraphFilterPanel";
+import { FocusSwitcher } from "../components/FocusSwitcher";
+import { FocusHistoryBar } from "../components/FocusHistoryBar";
+import { useColorMode } from "./graphColorMode";
+import { GraphLegend } from "./GraphLegend";
 
 const nodeTypes = {
   task: TaskNode,
@@ -81,20 +95,36 @@ function GraphViewInner({
   focusRef?: string | null;
 }) {
   const { fitView } = useReactFlow();
+  const colorMode = useColorMode();
+
   // 节点焦点(布局重算依赖)+ 边焦点(仅抽屉展示)。修 #3:此前用单一 focusId
   // 同时承载节点和边,点边时把 edge id 当 focusNodeId 传给布局器,导致
   // layoutSimpleEgo 拿不到节点 → 整张图塌成单个空节点。
+  //
+  // GUI 可用性补齐(dec_01KXA7811SVVT8P66HNDFZQ7DF):拆开「选中」与「聚焦」。
+  //   focusId    — 布局焦点(三泳道中心 / ego 中心)。受 FocusSwitcher / 双击 /
+  //                 抽屉「设为焦点」/ 跨视图 focusRef 驱动,所有变更入焦点历史。
+  //   selectedId — 抽屉里展示的节点(单击节点选中)。点空白 / Esc / 抽屉关闭即清空。
   const [focusId, setFocusId] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [focusEdgeId, setFocusEdgeId] = useState<string | null>(null);
   const [resolvedFocusId, setResolvedFocusId] = useState<string | null>(null);
   const [expandedFacts, setExpandedFacts] = useState<Set<string>>(new Set());
+  const [history, setHistory] = useState<FocusHistoryState>(createFocusHistory);
 
+  // 焦点切换统一入口:更新 focusId + 推历史。重复推同 id 会被 pushFocus 折叠。
+  const setFocusAndPushHistory = useCallback((id: string) => {
+    setFocusId(id);
+    setHistory((prev) => pushFocus(prev, id));
+  }, []);
+
+  // 跨视图带入的 focusRef → 换焦点 + 入历史(用户「跳到这张图」的足迹)。
   useEffect(() => {
-    if (focusRef) {
-      setFocusEdgeId(null);
-      setFocusId(endpointToNodeId(focusRef));
-    }
-  }, [focusRef]);
+    if (!focusRef) return;
+    const nodeId = endpointToNodeId(focusRef);
+    if (nodeId) setFocusAndPushHistory(nodeId);
+    // 仅依赖 focusRef:每次外部 ref 变更都要响应,即便值相同(避免漏触发)。
+  }, [focusRef, setFocusAndPushHistory]);
 
   const [nodes, setNodes] = useState<any[]>([]);
   const [edges, setEdges] = useState<any[]>([]);
@@ -187,6 +217,8 @@ function GraphViewInner({
     return () => window.cancelAnimationFrame(frame);
   }, [edges.length, fitView, nodes.length, resolvedFocusId]);
 
+  // 单击 = 选中并开抽屉(不换焦点)。fact 节点 / claim 行的展开 toggle 仍走单击,
+  // 因为它们是「展开 / 收起」局部交互,不涉及抽屉。
   const onNodeClick = useCallback(
     (evt: any, node: any) => {
       if (node.type === "laneBackground" || node.type === "moduleGroup") return;
@@ -227,27 +259,59 @@ function GraphViewInner({
           }
           return;
         }
-        // 点击焦点卡片但未命中 claim 行 → 落到 setFocusId toggle(关闭抽屉)。
+        // 未命中 claim 行 → 落到「选中开抽屉」(不再像旧版那样 toggle 焦点)。
       }
+      setSelectedId(node.id);
       setFocusEdgeId(null);
-      setFocusId((prev) => (prev === node.id ? null : node.id));
     },
     [],
   );
 
+  // 双击 = 设为焦点(显式切换,推历史)。
+  const onNodeDoubleClick = useCallback(
+    (_evt: any, node: any) => {
+      if (node.type === "laneBackground" || node.type === "moduleGroup") return;
+      if (!node.id || typeof node.id !== "string") return;
+      setFocusAndPushHistory(node.id);
+      // 双击后也把抽屉对齐到焦点,符合「我想看它的全貌」。
+      setSelectedId(node.id);
+      setFocusEdgeId(null);
+    },
+    [setFocusAndPushHistory],
+  );
+
   const onEdgeClick = useCallback((_: any, edge: any) => {
     // 修 #3:边焦点独立成 focusEdgeId,不再混入 focusId,布局不会重算。
+    setSelectedId(null);
     setFocusEdgeId((prev) => (prev === edge.id ? null : edge.id));
   }, []);
 
   const onPaneClick = useCallback(() => {
-    setFocusId(null);
+    // 点空白只关抽屉,不动焦点(让用户「跳过去回得来」)。
+    setSelectedId(null);
     setFocusEdgeId(null);
+  }, []);
+
+  // Esc = 关抽屉(不退焦点;焦点有显式「退出聚焦」按钮)。
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (e.target instanceof HTMLElement && e.target.closest("input,textarea,select")) return;
+      setSelectedId(null);
+      setFocusEdgeId(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
   }, []);
 
   // Drawer
   const focusNode = focusId ? nodes.find((n) => n.id === focusId) : null;
+  const selectedNode = selectedId ? nodes.find((n) => n.id === selectedId) : null;
   const focusEdge = focusEdgeId ? edges.find((e) => e.id === focusEdgeId) : null;
+  // 面包屑节点:用户没显式设焦点时,fallback 到布局器挑的默认焦点
+  // (resolvedFocusId),让用户始终知道「当前在看谁的图」。
+  const breadcrumbNode =
+    focusNode ?? (resolvedFocusId ? nodes.find((n) => n.id === resolvedFocusId) ?? null : null);
 
   const drawerNodesMap = useMemo(() => {
     const map = new Map();
@@ -263,7 +327,12 @@ function GraphViewInner({
         // 顶层 data 上。修 #1:此前误传 n.data,导致 CloseoutBadge/EngineBadge
         // 拿到 undefined,CLOSEOUT_META[undefined] 直接抛 → 点 task 节点必崩。
         task: n.type === "task" ? n.data.raw : undefined,
-        raw: n.data,
+        // 修 GUI 可用性(dec_01KXA7811SVVT8P66HNDFZQ7DF):抽屉现在可被任何
+        // 节点打开(单击=选中),包括 lineage lane 里的 decision / fact 节点。
+        // 这些节点的 n.data 不带 chosen/rejected/claims 等字段(只有 n.data.raw
+        // 才是完整 DecisionRow/FactRef)。raw 优先取 n.data.raw,fallback n.data
+        // 兼容老的 simpleEgoLayout 节点(其 data 即实体本身)。
+        raw: (n.data?.raw ?? n.data) as typeof n.data,
       });
     });
     return map;
@@ -275,29 +344,100 @@ function GraphViewInner({
     [nodes],
   );
 
-  // 上游 / 下游 1-hop 邻居计数 (供 GraphDrawer「链路」展示)。
+  // 抽屉里展示的实体(优先 selectedNode,fallback 到 focusNode)。这样单击非焦点
+  // 节点能看抽屉,focus 节点也能看抽屉。upCount/downCount 跟随「抽屉里那个」。
+  const drawerNodeId = selectedNode?.id ?? focusNode?.id ?? null;
+
+  // 上游 / 下游 1-hop 邻居计数 (供 GraphDrawer「链路」展示)。绑定到 drawerNodeId,
+  // 而不是 focusId,确保抽屉展示与计数口径一致。
   const { upCount, downCount } = useMemo(() => {
-    if (!focusId) return { upCount: 0, downCount: 0 };
+    if (!drawerNodeId) return { upCount: 0, downCount: 0 };
     let up = 0;
     let down = 0;
     for (const e of relations) {
       const from = endpointToNodeId(e.from);
       const to = endpointToNodeId(e.to);
-      if (from === focusId) down += 1;
-      if (to === focusId) up += 1;
+      if (from === drawerNodeId) down += 1;
+      if (to === drawerNodeId) up += 1;
     }
     return { upCount: up, downCount: down };
-  }, [focusId, relations]);
+  }, [drawerNodeId, relations]);
 
   const closeDrawer = useCallback(() => {
+    setSelectedId(null);
+    setFocusEdgeId(null);
+  }, []);
+  // 抽屉里点边列表项 = 既选中(抽屉跟着走)又换焦点(因为「跳到那个节点」就是
+  // 想看它的图)。这种「抽屉里跳」就是用户的 focus 意图,推历史。
+  const focusFromDrawer = useCallback(
+    (id: string | null) => {
+      if (!id) {
+        closeDrawer();
+        return;
+      }
+      setSelectedId(id);
+      setFocusEdgeId(null);
+      setFocusAndPushHistory(id);
+    },
+    [closeDrawer, setFocusAndPushHistory],
+  );
+  // 抽屉里「设为焦点」按钮 = 把当前抽屉里的节点升级为焦点(不切抽屉内容)。
+  const setDrawerAsFocus = useCallback(() => {
+    if (!drawerNodeId) return;
+    setFocusAndPushHistory(drawerNodeId);
+  }, [drawerNodeId, setFocusAndPushHistory]);
+
+  // 历史导航:back/forward。currentFocus 为 null 表示走到历史外(默认焦点),
+  // 此时仍把 focusId 同步到 null 让布局器挑默认。
+  const goBackStack = useCallback(() => {
+    setHistory((prev) => {
+      const next = historyGoBack(prev);
+      if (next === prev) return prev;
+      setFocusId(currentFocus(next));
+      return next;
+    });
+  }, []);
+  const goForwardStack = useCallback(() => {
+    setHistory((prev) => {
+      const next = historyGoForward(prev);
+      if (next === prev) return prev;
+      setFocusId(currentFocus(next));
+      return next;
+    });
+  }, []);
+  const clearFocus = useCallback(() => {
     setFocusId(null);
-    setFocusEdgeId(null);
+    // 不动历史:用户「退出聚焦」不脚印化(经典浏览器也不会因为关 tab 入栈)。
   }, []);
-  const focusFromDrawer = useCallback((id: string | null) => {
-    // Drawer 跳转目标恒为节点 id(边无独立跳转语义)。
-    setFocusEdgeId(null);
-    setFocusId(id);
-  }, []);
+
+  // Switcher 入口:点选 = 设焦点 + 抽屉跟着走。
+  const switchFocusFromList = useCallback(
+    (nodeId: string) => {
+      setFocusAndPushHistory(nodeId);
+      setSelectedId(nodeId);
+      setFocusEdgeId(null);
+    },
+    [setFocusAndPushHistory],
+  );
+
+  // 面包屑数据:显示当前焦点(显式 or 布局默认)。kind 用 type 反推
+  // (decisionFocus/decision=decision)。
+  const breadcrumb = useMemo(() => {
+    if (!breadcrumbNode) return null;
+    const kindRaw = breadcrumbNode.type === "decisionFocus" || breadcrumbNode.type === "decision"
+      ? "decision"
+      : breadcrumbNode.type === "task"
+        ? "task"
+        : breadcrumbNode.type === "fact"
+          ? "fact"
+          : (breadcrumbNode.type ?? "node");
+    const title = breadcrumbNode.data?.label ?? breadcrumbNode.id;
+    return {
+      kindLabel: kindRaw,
+      title: typeof title === "string" ? title : String(title ?? ""),
+      nodeId: breadcrumbNode.id,
+    };
+  }, [breadcrumbNode]);
 
   if (error) {
     return (
@@ -327,62 +467,40 @@ function GraphViewInner({
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
-      <header className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b border-border px-4 py-2 text-[11px] text-text-muted">
-        <span className="font-mono text-text-faint">
-          {visibleNodeCount} 节点 · {edges.length} 边
-          {resolvedFocusId ? ` · 聚焦 ${resolvedFocusId}` : ""}
-        </span>
-        <span className="inline-flex items-center gap-1">
-          <span
-            className="inline-block h-2.5 w-2.5 rounded-sm border"
-            style={{
-              borderColor: "var(--color-axis-execution)",
-              background: "var(--color-surface-raised)",
-            }}
-          />
-          task（方块·派生）
-        </span>
-        <span className="inline-flex items-center gap-1">
-          <span className="inline-block h-2.5 w-2.5 rounded border" style={{ borderColor: "var(--color-accent)", background: "rgba(176,124,240,0.2)" }} />
-          decision（菱形·主张+claim）
-        </span>
-        <span className="inline-flex items-center gap-1">
-          <span className="inline-block h-2.5 w-2.5 rounded-full border" style={{ borderColor: "var(--color-axis-evidence)", background: "rgba(240,162,60,0.2)" }} />
-          fact（圆·证据徽章）
-        </span>
-        <span className="inline-flex items-center gap-2">
-          <span className="text-text-faint">coverage:</span>
-          <span className="inline-flex items-center gap-1">
-            <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: "var(--color-status-done)" }} /> 已佐证
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: "var(--color-danger)" }} /> 无证据
-          </span>
-        </span>
-        {cycleWarning.count > 0 && (
-          <span
-            className="inline-flex items-center gap-1 rounded bg-danger/10 px-1.5 py-0.5 font-mono text-danger"
-            title={cycleWarning.cycles.map((c) => c.join(" → ")).join("\n")}
-          >
-            INV-3 环警告 · {cycleWarning.count}
-          </span>
-        )}
-        <span className="ml-auto text-text-faint">
-          {focusId || focusEdgeId
-            ? "Esc / 点击空白处退出聚焦 · 点击 claim 行展开证据 fact"
-            : "默认聚焦式 ego · 点击节点切换焦点 (Powered by React Flow)"}
-        </span>
-      </header>
+      <GraphLegend
+        visibleNodeCount={visibleNodeCount}
+        edgeCount={edges.length}
+        resolvedFocusId={resolvedFocusId}
+        cycleWarning={cycleWarning}
+        hasFocus={Boolean(focusId || focusEdgeId)}
+      />
+
+      <FocusHistoryBar
+        canBack={historyCanGoBack(history)}
+        canForward={historyCanGoForward(history)}
+        breadcrumb={breadcrumb}
+        onBack={goBackStack}
+        onForward={goForwardStack}
+        onClear={clearFocus}
+      />
 
       <div className="flex min-h-0 flex-1 relative">
+        <FocusSwitcher
+          decisions={decisions ?? []}
+          tasks={tasks}
+          focusId={focusId}
+          onFocus={switchFocusFromList}
+        />
         <ReactFlow
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           onNodeClick={onNodeClick}
+          onNodeDoubleClick={onNodeDoubleClick}
           onEdgeClick={onEdgeClick}
           onPaneClick={onPaneClick}
+          colorMode={colorMode}
           fitView
           fitViewOptions={{ padding: 0.1 }}
           minZoom={0.1}
@@ -418,9 +536,15 @@ function GraphViewInner({
           </Panel>
         </ReactFlow>
 
-        {(focusNode || focusEdge) && (
+        {(selectedNode || focusNode || focusEdge) && (
           <GraphDrawer
-            focusNode={focusNode ? drawerNodesMap.get(focusId) : undefined}
+            focusNode={
+              selectedNode
+                ? drawerNodesMap.get(selectedId)
+                : focusNode
+                  ? drawerNodesMap.get(focusId)
+                  : undefined
+            }
             focusEdge={focusEdge ? focusEdge.data : undefined}
             nodes={drawerNodesMap}
             edges={relations}
@@ -429,6 +553,8 @@ function GraphViewInner({
             onClose={closeDrawer}
             onFocus={focusFromDrawer}
             onNavigateEntity={onNavigateEntity}
+            isFocused={drawerNodeId !== null && drawerNodeId === focusId}
+            onSetAsFocus={setDrawerAsFocus}
           />
         )}
       </div>

--- a/packages/gui/src/renderer/views/graphColorMode.ts
+++ b/packages/gui/src/renderer/views/graphColorMode.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import type { ColorMode } from "@xyflow/react";
+
+/**
+ * GraphView colorMode 联动(dec_01KXA7811SVVT8P66HNDFZQ7DF — 关系图可用性)。
+ *
+ * ReactFlow 的 minimap SVG 背景默认吃库内置 #fff,只有显式给 ReactFlow 传
+ * colorMode="dark" 才会应用 .react-flow.dark 的 CSS 变量。本模块按
+ * document.documentElement.dataset.theme(theme.tsx:41 维护)输出当前 colorMode,
+ * 并 MutationObserver 监听切换。
+ *
+ * SSR 安全:vitest 的 renderer-app-model 用例在 node 里 renderToStaticMarkup,
+ * 没有 document;此时回落到 "dark"(应用默认主题),useEffect 里再补监听。
+ */
+export function useColorMode(): ColorMode {
+  const [mode, setMode] = useState<ColorMode>(() => readColorMode());
+  useEffect(() => {
+    // mount 后再读一次,避免 SSR 默认与真实 data-theme 不一致。
+    setMode(readColorMode());
+    if (typeof document === "undefined") return;
+    const observer = new MutationObserver(() => {
+      setMode(readColorMode());
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+    return () => observer.disconnect();
+  }, []);
+  return mode;
+}
+
+function readColorMode(): ColorMode {
+  if (typeof document === "undefined") return "dark";
+  return document.documentElement.dataset.theme === "light" ? "light" : "dark";
+}

--- a/packages/gui/test/graphNavigation.vitest.ts
+++ b/packages/gui/test/graphNavigation.vitest.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  canGoBack,
+  canGoForward,
+  createFocusHistory,
+  currentFocus,
+  goBack,
+  goForward,
+  pushFocus,
+} from "../src/renderer/graph/focusHistory.ts";
+
+/**
+ * GraphView 焦点历史栈(dec_01KXA7811SVVT8P66HNDFZQ7DF — 关系图可用性)。
+ *
+ * 覆盖 push/truncate/back/forward/no-op 五条核心迁移;GraphView 的 back/forward
+ * 按钮 + 面包屑依赖这些不变量。
+ */
+
+describe("focusHistory push", () => {
+  it("starts empty with no current focus", () => {
+    const state = createFocusHistory();
+    expect(currentFocus(state)).toBeNull();
+    expect(canGoBack(state)).toBe(false);
+    expect(canGoForward(state)).toBe(false);
+  });
+
+  it("pushes a focus id and exposes it as current", () => {
+    const state = pushFocus(createFocusHistory(), "decision/dec_a");
+    expect(currentFocus(state)).toBe("decision/dec_a");
+    expect(state.entries).toEqual(["decision/dec_a"]);
+    expect(state.index).toBe(0);
+  });
+
+  it("does not push the same id twice in a row (avoid stack flooding)", () => {
+    const first = pushFocus(createFocusHistory(), "decision/dec_a");
+    const second = pushFocus(first, "decision/dec_a");
+    expect(second).toBe(first);
+    expect(second.entries).toEqual(["decision/dec_a"]);
+  });
+
+  it("supports pushing distinct ids sequentially", () => {
+    let state = createFocusHistory();
+    state = pushFocus(state, "decision/dec_a");
+    state = pushFocus(state, "decision/dec_b");
+    state = pushFocus(state, "task/task_x");
+    expect(state.entries).toEqual(["decision/dec_a", "decision/dec_b", "task/task_x"]);
+    expect(state.index).toBe(2);
+    expect(currentFocus(state)).toBe("task/task_x");
+  });
+});
+
+describe("focusHistory forward truncation", () => {
+  it("truncates the forward stack when pushing after going back", () => {
+    let state = createFocusHistory();
+    state = pushFocus(state, "decision/dec_a");
+    state = pushFocus(state, "decision/dec_b");
+    state = pushFocus(state, "decision/dec_c");
+    state = goBack(state); // back to dec_b
+    state = goBack(state); // back to dec_a
+    expect(currentFocus(state)).toBe("decision/dec_a");
+    expect(canGoForward(state)).toBe(true);
+
+    state = pushFocus(state, "decision/dec_d");
+    expect(state.entries).toEqual(["decision/dec_a", "decision/dec_d"]);
+    expect(state.index).toBe(1);
+    expect(canGoForward(state)).toBe(false);
+  });
+});
+
+describe("focusHistory back/forward", () => {
+  it("goBack is a no-op at the head of history", () => {
+    const state = pushFocus(createFocusHistory(), "decision/dec_a");
+    const back = goBack(state);
+    expect(back).toBe(state);
+  });
+
+  it("goForward is a no-op at the tip of history", () => {
+    const state = pushFocus(createFocusHistory(), "decision/dec_a");
+    const forward = goForward(state);
+    expect(forward).toBe(state);
+  });
+
+  it("moves back and forward through the stack deterministically", () => {
+    let state = createFocusHistory();
+    state = pushFocus(state, "decision/dec_a");
+    state = pushFocus(state, "decision/dec_b");
+    state = pushFocus(state, "decision/dec_c");
+
+    state = goBack(state);
+    expect(currentFocus(state)).toBe("decision/dec_b");
+    state = goBack(state);
+    expect(currentFocus(state)).toBe("decision/dec_a");
+
+    state = goForward(state);
+    expect(currentFocus(state)).toBe("decision/dec_b");
+    state = goForward(state);
+    expect(currentFocus(state)).toBe("decision/dec_c");
+  });
+
+  it("disables back at index 0 and forward at the tip", () => {
+    let state = createFocusHistory();
+    state = pushFocus(state, "decision/dec_a");
+    state = pushFocus(state, "decision/dec_b");
+    expect(canGoBack(state)).toBe(true);
+    state = goBack(state);
+    expect(canGoBack(state)).toBe(false);
+    expect(canGoForward(state)).toBe(true);
+    state = goForward(state);
+    expect(canGoForward(state)).toBe(false);
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -4,5 +4,6 @@ export const guiVitestManifest = [
   "packages/gui/test/taskFilters.vitest.ts",
   "packages/gui/test/task-adapter.vitest.ts",
   "packages/gui/test/graphLayout.vitest.ts",
-  "packages/gui/test/genealogy-timeline.vitest.ts"
+  "packages/gui/test/genealogy-timeline.vitest.ts",
+  "packages/gui/test/graphNavigation.vitest.ts"
 ];


### PR DESCRIPTION
# English

## Summary

Restore the navigation/wayfinding layer that was dropped when the triadic graph was ported from the prototype into GraphView, plus fix the white minimap. Adds a searchable focus switcher, split click semantics (single-click selects + opens drawer; set-focus via double-click or an explicit drawer button), focus history (back/forward + breadcrumb), and a persistent multi-view switcher. Addresses the three dogfood pain points (can't change focus, white minimap, view switching undiscoverable). Pure renderer.

## What Changed

- MiniMap white → dark: `<ReactFlow colorMode={...}>` now follows `document.documentElement.dataset.theme` (root cause: React Flow's minimap SVG background used the library default `#fff` because the graph never entered dark colorMode). New `graph/graphColorMode.ts` (`useColorMode`).
- Focus switcher: new `components/FocusSwitcher.tsx` — searchable entity list in the left panel to change the graph focus (ported from the prototype's left list + search).
- Click semantics split: single-click selects + opens the drawer without changing focus; set-focus via double-click or an explicit "set as focus" button in the drawer (previously one conflated toggle).
- Focus history: back/forward stack + a breadcrumb showing the current focus entity (title + kind); cross-view focus entry pushes history.
- Persistent multi-view switcher (关系图 ↔ 演化史) surfaced at the top instead of hidden behind a conditional.
- Split `GraphView` into `graphColorMode.ts` + `GraphLegend.tsx` to satisfy the file-complexity gate.
- Bonus fix: a lineage-lane decision node could crash the drawer (`dec.chosen` undefined); drawer node map now falls back to `n.data.raw`.

## Task And Scope

- Harness task: task_01KXARDC4MACMQYRYSJQ25M4ZP (parent coordination task task_01KXA7Q2RC0N0QJPAN9BF4PJ7Y)
- Branch: fix/gui-usability-nav
- Public scope: packages/gui renderer only (`views/GraphView.tsx`, `App.tsx`, new `components/FocusSwitcher.tsx` + `graph/graphColorMode.ts` + `GraphLegend.tsx`, `graph/**`, styles, gui tests + e2e)
- Private planning/evidence updated: yes (task ledger)
- Out of scope: backend/IPC/kernel; ⌘K command palette (did FocusSwitcher per the either/or contract); decision write consumption (separate batch, blocked on identity layer)

## Version Impact

- Version: no version change because this is a renderer-internal usability change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: decision dec_01KXA7811SVVT8P66HNDFZQ7DF (accepted; navigation completes the focused-ego display scheme, principle 1/6)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 27d6937
- Branch merge-base with `origin/main`: 27d6937
- Last `git fetch origin` time: 2026-07-12
- Sync method: none needed (branch tip on latest main)
- Public diff command: `git diff origin/main...fix/gui-usability-nav`
- Private evidence commit/path: harness task ledger for task_01KXARDC4MACMQYRYSJQ25M4ZP
- Reviewer evidence path: harness task package review document; screenshots at a scratch path (not committed)
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci` — not run (verified root install; worker ran `npm install --prefer-offline` to backfill one missing dist)
- [x] `git diff --check`
- [x] `npm run check` — via `check:local`, 16 steps green (CEO re-ran; stale composite `dist` needed `tsc -b packages/gui --force`)
- [x] `npm run typecheck`
- [x] `npm test` — `cd packages/gui && npm run test:e2e` 1/1 passed (real Electron); gui vitest 72/72
- [x] `npm run harness:check-import-boundaries` (within check:local)
- [x] `npm run harness:scan-forbidden-symbols` (within check:local)
- [x] `npm run harness:check-private-boundary` (within check:local)
- [x] `npm run harness:check-package-policy` (within check:local)
- [x] `npm run harness:check-implementation-contracts` (within check:local)
- [x] `npm run harness:check-schema-contracts` (within check:local)
- [ ] `npm run harness:check-legacy-intake-readiness` — covered by CI
- [ ] `npm run harness:smoke-cli-package` — covered by CI (no CLI change)
- [ ] GitHub Actions `rewrite-ci` passed — pending
- Not run: root `npm test` and CLI smoke locally; covered by required CI. CI-equivalent gui gate chain (`run-manifest-gates.mjs --workflow-job gui-build`) re-run by the CEO and green.

## Review Evidence

- Self-review: worker verified with 72 gui tests + a real Electron E2E asserting focus switch, click-to-select-not-refocus, history back/forward, and minimap presence; 6 screenshots captured.
- Reviewer subagent: n/a for this slice (adversarial review can run over the merged nav stack later).
- Human review: CEO ground-truthed the minimap `colorMode` fix and FocusSwitcher, viewed screenshot 03 (focus switcher + dark minimap + persistent view switcher), and re-ran the root + gui-build gates.
- Blocking findings: none open.

## Residual Risk

- `onNodeDoubleClick` is unreliable in Electron+Playwright (double-click may not fire); set-focus falls back to an explicit drawer button (same code path). A pane-level `zoomOnDoubleClick={false}` + stopPropagation is a possible future hardening.
- ⌘K command palette not implemented (FocusSwitcher chosen per the either/or contract); tracked as a follow-up if wanted.
- MiniMap background color is not hard-asserted across themes in E2E (CSS-var color assertions are brittle); verified visually in screenshot 01.

## References

- Task: task_01KXARDC4MACMQYRYSJQ25M4ZP
- Evidence: harness task ledger; dogfood screenshots
- Review: harness task package review document

---

# 中文

## 概要

补回三原语关系图从原型移植进 GraphView 时丢掉的导航/寻路层,并修复 minimap 白屏。新增可搜索焦点切换器、拆开点击语义(单击=选中+开抽屉;设焦点走双击或抽屉显式按钮)、焦点历史(back/forward + 面包屑)、常驻多视图切换条。解决 dogfood 三痛点(切不了焦点、minimap 白屏、视图切换发现性差)。纯 renderer。

## 改动内容

- minimap 白→深:`<ReactFlow colorMode={...}>` 现按 `document.documentElement.dataset.theme` 联动(根因:图从未进 dark colorMode,minimap SVG 背景吃了 React Flow 库默认 `#fff`)。新增 `graph/graphColorMode.ts`(`useColorMode`)。
- 焦点切换器:新增 `components/FocusSwitcher.tsx`——左栏可搜索实体列表换焦点(移植原型左栏+搜索)。
- 点击语义拆开:单击=选中+开抽屉不换焦点;设焦点走双击或抽屉"设为焦点"按钮(此前是二合一 toggle)。
- 焦点历史:back/forward 栈 + 显示当前焦点实体(title+kind)的面包屑;跨视图带焦点入图推历史。
- 常驻多视图切换条(关系图↔演化史)提到顶部,不再藏在条件渲染后。
- `GraphView` 拆出 `graphColorMode.ts` + `GraphLegend.tsx` 满足 file-complexity 门。
- 顺手修:lineage 泳道的 decision 节点可能崩抽屉(`dec.chosen` undefined);抽屉节点 map 现 fallback 到 `n.data.raw`。

## 任务与范围

- Harness 任务:task_01KXARDC4MACMQYRYSJQ25M4ZP(父协调任务 task_01KXA7Q2RC0N0QJPAN9BF4PJ7Y)
- 分支:fix/gui-usability-nav
- 公开范围:仅 packages/gui renderer(`views/GraphView.tsx`、`App.tsx`、新 `components/FocusSwitcher.tsx`+`graph/graphColorMode.ts`+`GraphLegend.tsx`、`graph/**`、样式、gui 测试+e2e)
- 私有计划 / 证据是否已更新:yes(任务台账)
- 范围外:后端/IPC/kernel;⌘K command palette(按 either/or 契约做了 FocusSwitcher);决策写消费(另一批,阻塞在身份层)

## 版本影响

- 版本:不改版本,原因是 renderer 内部可用性改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:决策 dec_01KXA7811SVVT8P66HNDFZQ7DF(已接受;导航补全聚焦式显示方案,原则 1/6)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- `origin/main` 基准 SHA:27d6937
- 当前分支与 `origin/main` 的 merge-base:27d6937
- 最近一次 `git fetch origin` 时间:2026-07-12
- 同步方式:不需要(分支基于最新 main)
- 公开 diff 命令:`git diff origin/main...fix/gui-usability-nav`
- 私有证据 commit/path:task_01KXARDC4MACMQYRYSJQ25M4ZP 的 harness 任务台账
- Reviewer 证据路径:harness 任务包 review 文档;截图在 scratch 路径(未提交)
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- [ ] `npm ci` — 未跑(根安装已验证;worker 跑了 `npm install --prefer-offline` 补一个缺失 dist)
- [x] `git diff --check`
- [x] `npm run check` — 经 `check:local`,16 步绿(CEO 复跑;stale composite dist 需 `tsc -b packages/gui --force`)
- [x] `npm run typecheck`
- [x] `npm test` — `cd packages/gui && npm run test:e2e` 1/1 绿(真 Electron);gui vitest 72/72
- [x] `npm run harness:check-import-boundaries`(check:local 内)
- [x] `npm run harness:scan-forbidden-symbols`(check:local 内)
- [x] `npm run harness:check-private-boundary`(check:local 内)
- [x] `npm run harness:check-package-policy`(check:local 内)
- [x] `npm run harness:check-implementation-contracts`(check:local 内)
- [x] `npm run harness:check-schema-contracts`(check:local 内)
- [ ] `npm run harness:check-legacy-intake-readiness` — 交 CI
- [ ] `npm run harness:smoke-cli-package` — 交 CI(无 CLI 改动)
- [ ] GitHub Actions `rewrite-ci` passed — 待跑
- 未运行:根 `npm test` 与 CLI smoke 本地未跑,由 required CI 覆盖。CI 同款 gui gate 链(`run-manifest-gates.mjs --workflow-job gui-build`)由 CEO 复跑且绿。

## 审查证据

- 自查:worker 以 72 gui 测试 + 真 Electron E2E(断言焦点切换、单击选中不换焦点、历史 back/forward、minimap 存在)验证;截 6 张图。
- Reviewer subagent:本切片暂无(对合并后导航栈的对抗复核可后置)。
- 人工审查:CEO ground-truth 了 minimap `colorMode` 修复与 FocusSwitcher,看了截图 03(焦点切换器+深色 minimap+常驻视图切换),并复跑根 + gui-build gate。
- 阻塞发现:无。

## 残余风险

- `onNodeDoubleClick` 在 Electron+Playwright 下不稳定(双击可能不触发);设焦点兜底走抽屉显式按钮(同代码路径)。未来可用 pane 级 `zoomOnDoubleClick={false}`+stopPropagation 加固。
- ⌘K command palette 未实现(按 either/or 契约选了 FocusSwitcher);需要时另立跟进。
- minimap 背景色在 E2E 未跨主题硬断言(CSS-var 颜色断言脆);已在截图 01 目验。

## 关联材料

- 任务:task_01KXARDC4MACMQYRYSJQ25M4ZP
- 证据:harness 任务台账;dogfood 截图
- 审查:harness 任务包 review 文档
