### PR TITLE
feat: --apply-manual mode for fact-execution migration (144 manual facts migrated)

### DIFF
--- a/packages/cli/src/cli/command-spec/command-spec-migration-diagnostics.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-migration-diagnostics.ts
@@ -100,10 +100,10 @@ export const migrationDiagnosticsCommandSpecs = defineCommandSpecs([
   },
   {
     "kind": "migrate-fact-execution",
-    "usage": "migrate fact-execution [--dry-run|--apply --confirm-plan <id>] [--batch-size <n>] [--batch <n>] [--sample-size <n>] [--json]",
-    "options": [{"flag":"--dry-run","description":"Classify and preview without writing; this is the default."},{"flag":"--apply","description":"Apply only three-signal intersection candidates in the selected batch."},{"flag":"--confirm-plan","description":"Confirm the exact plan id returned by dry-run before applying."},{"flag":"--batch-size","description":"Limit each coordinated batch to 1-200 automatic candidates."},{"flag":"--batch","description":"Select the one-based batch number."},{"flag":"--sample-size","description":"Set samples per classification bucket."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
-    "summary": "Classify orphan Facts with three signals and migrate only the automatic intersection into execution outputs.",
-    "examples": ["harness-anything migrate fact-execution --dry-run --json", "harness-anything migrate fact-execution --apply --confirm-plan fxm_0123456789abcdef --batch 1"],
+    "usage": "migrate fact-execution [--dry-run|--apply --confirm-plan <id>] [--apply-manual <fact-ref-list>] [--batch-size <n>] [--batch <n>] [--sample-size <n>] [--json]",
+    "options": [{"flag":"--dry-run","description":"Classify and preview without writing; this is the default."},{"flag":"--apply","description":"Apply the selected automatic or manual-list candidates in the selected batch."},{"flag":"--apply-manual","description":"Select exact fact/<task-id>/<fact-id> refs from a root-relative list file, bypassing three-signal classification."},{"flag":"--confirm-plan","description":"Confirm the exact plan id returned by dry-run before applying."},{"flag":"--batch-size","description":"Limit each coordinated batch to 1-200 selected candidates."},{"flag":"--batch","description":"Select the one-based batch number."},{"flag":"--sample-size","description":"Set samples per classification bucket."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
+    "summary": "Migrate automatic three-signal Facts or an exact manually confirmed Fact list into execution outputs.",
+    "examples": ["harness-anything migrate fact-execution --dry-run --json", "harness-anything migrate fact-execution --dry-run --apply-manual artifacts/facts.txt --json", "harness-anything migrate fact-execution --apply --confirm-plan fxm_0123456789abcdef --batch 1"],
     "parse": parseMigrationArgs,
     "run": runMigrationCommand,
     "receiptContract": {

--- a/packages/cli/src/cli/parse-migration-args.ts
+++ b/packages/cli/src/cli/parse-migration-args.ts
@@ -1,5 +1,5 @@
 import { cliError, CliErrorCode } from "./error-codes.ts";
-import { readOption } from "./parse-options.ts";
+import { readOption, readRequiredValueOption } from "./parse-options.ts";
 import type { CliResult, ParsedCommand } from "./types.ts";
 
 type ParseResult = { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] };
@@ -91,6 +91,8 @@ export function parseMigrationArgs(args: ReadonlyArray<string>, rootDir: string,
     const batchSize = Number(readOption(migrateArgs, "--batch-size") ?? 50);
     const batch = Number(readOption(migrateArgs, "--batch") ?? 1);
     const sampleSize = Number(readOption(migrateArgs, "--sample-size") ?? 5);
+    const manualList = readRequiredValueOption(migrateArgs, "--apply-manual");
+    if (!manualList.ok) return manualList;
     if (![batchSize, batch, sampleSize].every((value) => Number.isSafeInteger(value) && value > 0) || batchSize > 200) {
       return { ok: false, error: cliError(CliErrorCode.ConflictingMigrationMode, "Use positive integer batch/sample sizes; --batch-size is capped at 200.") };
     }
@@ -105,7 +107,8 @@ export function parseMigrationArgs(args: ReadonlyArray<string>, rootDir: string,
           batchSize,
           batch,
           sampleSize,
-          confirmPlan: readOption(migrateArgs, "--confirm-plan")
+          confirmPlan: readOption(migrateArgs, "--confirm-plan"),
+          manualListFile: manualList.value
         }
       }
     };

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -260,7 +260,7 @@ export interface ParsedCommand {
     | { readonly kind: "migrate-plan"; readonly limit: number }
     | { readonly kind: "migrate-structure"; readonly mode: "plan" | "apply"; readonly confirmPlan: boolean }
     | { readonly kind: "migrate-anchors"; readonly mode: AnchorBackfillMode }
-    | { readonly kind: "migrate-fact-execution"; readonly mode: "dry-run" | "apply"; readonly batchSize: number; readonly batch: number; readonly sampleSize: number; readonly confirmPlan?: string }
+    | { readonly kind: "migrate-fact-execution"; readonly mode: "dry-run" | "apply"; readonly batchSize: number; readonly batch: number; readonly sampleSize: number; readonly confirmPlan?: string; readonly manualListFile?: string }
     | { readonly kind: "migrate-provenance"; readonly mode: ProvenanceBackfillMode }
     | { readonly kind: "migrate-run"; readonly planOnly: boolean; readonly outDir: string; readonly locale?: "zh-CN" | "en-US"; readonly assumeLocale?: "zh-CN" | "en-US"; readonly allowDirty: boolean; readonly sessionDir?: string }
     | { readonly kind: "migrate-verify"; readonly sessionPath?: string; readonly fullCutover: boolean }

--- a/packages/cli/src/commands/fact-execution-migration.ts
+++ b/packages/cli/src/commands/fact-execution-migration.ts
@@ -34,25 +34,44 @@ interface TargetPlan {
   readonly skipReason?: "non_done_without_active_execution" | "multiple_active_executions";
 }
 
+interface ManualSelection {
+  readonly file: string;
+  readonly requestedRefs: ReadonlyArray<string>;
+  readonly candidates: ReadonlyArray<FactExecutionCandidate>;
+  readonly unresolvedRefs: ReadonlyArray<string>;
+  readonly invalidLines: ReadonlyArray<string>;
+}
+
 export function runMigrateFactExecution(
   context: CommandRunnerContext,
   rootInput: HarnessLayoutInput,
   action: MigrateFactExecutionAction
 ): Effect.Effect<CliResult, WriteError> {
   const classification = classifyFactExecutionCandidates(rootInput);
-  const planId = migrationPlanId(classification.orphans);
-  const batchCount = Math.ceil(classification.automatic.length / action.batchSize);
+  const manual = action.manualListFile ? readManualSelection(rootInput, action.manualListFile, classification.orphans) : undefined;
+  const candidates = manual?.candidates ?? classification.automatic;
+  const planId = manual ? manualMigrationPlanId(manual) : migrationPlanId(classification.orphans);
+  const batchCount = Math.ceil(candidates.length / action.batchSize);
   const start = (action.batch - 1) * action.batchSize;
-  const allTargets = classification.automatic.map((candidate) => targetPlan(rootInput, candidate, planId));
+  const allTargets = candidates.map((candidate) => targetPlan(rootInput, candidate, planId));
   const targets = allTargets.slice(start, start + action.batchSize);
   const pendingTargets = targets.filter((entry) => !entry.candidate.fact.migration && entry.target);
   const report = (appliedFacts: number, appliedTasks: number) => buildReport(
-    action, planId, batchCount, classification, allTargets, targets, appliedFacts, appliedTasks
+    action, planId, batchCount, classification, allTargets, targets, manual, appliedFacts, appliedTasks
   );
 
-  if (action.mode === "dry-run" || pendingTargets.length === 0) {
+  if (action.mode === "dry-run") {
     return Effect.succeed(migrationResult(action, report(0, 0)));
   }
+  if (manual && (manual.unresolvedRefs.length > 0 || manual.invalidLines.length > 0)) {
+    return Effect.succeed({
+      ok: false,
+      command: "migrate-fact-execution",
+      error: cliError(CliErrorCode.RefNotFound, "Manual Fact list contains invalid or unresolved refs; inspect the dry-run report."),
+      report: report(0, 0)
+    });
+  }
+  if (pendingTargets.length === 0) return Effect.succeed(migrationResult(action, report(0, 0)));
   if (action.confirmPlan !== planId) {
     return Effect.succeed({
       ok: false,
@@ -80,6 +99,7 @@ function buildReport(
   classification: ReturnType<typeof classifyFactExecutionCandidates>,
   allTargets: ReadonlyArray<TargetPlan>,
   targets: ReadonlyArray<TargetPlan>,
+  manual: ManualSelection | undefined,
   appliedFacts: number,
   appliedTasks: number
 ): Record<string, unknown> {
@@ -97,6 +117,7 @@ function buildReport(
   return {
     schema: "fact-execution-migration-report/v1",
     mode: action.mode,
+    selectionMode: manual ? "manual-list" : "automatic-intersection",
     planId,
     classifier: {
       signals: ["memoryClass=episodic", "no active evidenced-by reference", "delivery wording"],
@@ -110,8 +131,16 @@ function buildReport(
       episodicOrphans,
       deliveryWordingOrphans: wordingOrphans,
       automaticIntersection: classification.automatic.length,
-      automaticReady: allTargets.filter((entry) => entry.target && !entry.candidate.fact.migration).length,
-      automaticSkipped: allTargets.filter((entry) => !entry.target).length,
+      ...(manual ? {
+        manualRequested: manual.requestedRefs.length,
+        manualResolved: manual.candidates.length,
+        manualUnresolved: manual.unresolvedRefs.length,
+        manualReady: allTargets.filter((entry) => entry.target && !entry.candidate.fact.migration).length,
+        manualSkipped: allTargets.filter((entry) => !entry.target).length
+      } : {
+        automaticReady: allTargets.filter((entry) => entry.target && !entry.candidate.fact.migration).length,
+        automaticSkipped: allTargets.filter((entry) => !entry.target).length
+      }),
       manualDifference: classification.manual.length,
       bearingObservations: classification.bearingObservations.length,
       alreadyMigrated: classification.alreadyMigrated,
@@ -121,7 +150,7 @@ function buildReport(
       appliedFacts,
       appliedTasks
     },
-    automaticSkipReasons: Object.fromEntries([...Map.groupBy(
+    [manual ? "manualSkipReasons" : "automaticSkipReasons"]: Object.fromEntries([...Map.groupBy(
       allTargets.filter((entry) => entry.skipReason),
       (entry) => entry.skipReason!
     )].map(([reason, entries]) => [reason, entries.length])),
@@ -130,6 +159,7 @@ function buildReport(
       target: entry.target,
       ...(entry.skipReason ? { skipReason: entry.skipReason } : {})
     })),
+    ...(manual ? { manualList: { file: manual.file, unresolvedRefs: manual.unresolvedRefs, invalidLines: manual.invalidLines } } : {}),
     manualConfirmation: classification.manual.map(row),
     samples: {
       automatic: sample(classification.automatic),
@@ -140,6 +170,27 @@ function buildReport(
       strategy: "git-revert",
       note: "Each applied batch is one coordinated journal flush. Revert its generated repository commit; facts and executions are never hard-deleted by this command."
     }
+  };
+}
+
+function readManualSelection(
+  rootInput: HarnessLayoutInput,
+  listFile: string,
+  candidates: ReadonlyArray<FactExecutionCandidate>
+): ManualSelection {
+  const rootDir = resolveHarnessLayout(rootInput).rootDir;
+  const file = path.isAbsolute(listFile) ? listFile : path.join(rootDir, listFile);
+  const lines = readFileSync(file, "utf8").split(/\r?\n/u).map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+  const invalidLines = lines.filter((line) => !/^fact\/task_[0-9A-Z]+\/F-[0-9A-Z]+$/u.test(line));
+  const requestedRefs = [...new Set(lines.filter((line) => !invalidLines.includes(line)))];
+  const byRef = new Map(candidates.map((candidate) => [candidate.factRef, candidate]));
+  return {
+    file,
+    requestedRefs,
+    candidates: requestedRefs.flatMap((factRef) => byRef.get(factRef) ?? []),
+    unresolvedRefs: requestedRefs.filter((factRef) => !byRef.has(factRef)),
+    invalidLines
   };
 }
 
@@ -299,6 +350,12 @@ function migrateFactsBody(body: string, migrations: ReadonlyMap<string, FactMigr
 
 function migrationPlanId(candidates: ReadonlyArray<FactExecutionCandidate>): string {
   return `fxm_${sha256Text(candidates.map((entry) => `${entry.classification}\n${entry.factRef}\n${entry.fact.statement}`).join("\n")).slice(0, 16)}`;
+}
+
+function manualMigrationPlanId(selection: ManualSelection): string {
+  const statementByRef = new Map(selection.candidates.map((entry) => [entry.factRef, entry.fact.statement]));
+  const payload = selection.requestedRefs.map((factRef) => `${factRef}\n${statementByRef.get(factRef) ?? "unresolved"}`).join("\n");
+  return `fxm_${sha256Text(`manual-list\n${payload}`).slice(0, 16)}`;
 }
 
 function archivalExecutionId(planId: string, taskId: string): string {

--- a/packages/cli/test/fact-execution-migration-cli.test.ts
+++ b/packages/cli/test/fact-execution-migration-cli.test.ts
@@ -80,6 +80,49 @@ test("fact-execution migration classifies three signals, requires plan confirmat
   });
 });
 
+test("fact-execution manual list migrates an explicitly confirmed Fact through the shared archival path", () => {
+  withTempRoot((rootDir) => {
+    writeFile(rootDir, "AGENTS.md", "# Agent Context\n");
+    writeFile(rootDir, "CLAUDE.md", "# Claude Context\n");
+    runJson(rootDir, ["init"]);
+    const created = runJson(rootDir, ["new-task", "--title", "Manual Historical Delivery"]);
+    const taskPath = String(created.packagePath);
+    const indexPath = path.join(rootDir, taskPath, "INDEX.md");
+    const taskId = readFileSync(indexPath, "utf8").match(/^task_id:\s*(\S+)/mu)?.[1];
+    assert.ok(taskId);
+    writeFileSync(indexPath, readFileSync(indexPath, "utf8").replace(/^  status:\s*planned$/mu, "  status: done"), "utf8");
+    writeFile(rootDir, `${taskPath}/facts.md`, [
+      "# Facts",
+      "",
+      fact("F-MAN0A1YX", "The operator completed the historical handoff.", "semantic"),
+      ""
+    ].join("\n"));
+    writeFile(rootDir, "artifacts/manual-facts.txt", `# CEO-confirmed delivery facts\nfact/${taskId}/F-MAN0A1YX\n`);
+
+    const dryRun = runJson(rootDir, [
+      "migrate", "fact-execution", "--dry-run", "--apply-manual", "artifacts/manual-facts.txt"
+    ]);
+    assert.equal(dryRun.report.selectionMode, "manual-list");
+    assert.equal(dryRun.report.summary.manualRequested, 1);
+    assert.equal(dryRun.report.summary.manualReady, 1, JSON.stringify(dryRun.report));
+    assert.equal(dryRun.report.summary.manualSkipped, 0);
+
+    const applied = runJson(rootDir, [
+      "migrate", "fact-execution", "--apply", "--apply-manual", "artifacts/manual-facts.txt",
+      "--confirm-plan", String(dryRun.report.planId)
+    ]);
+    assert.equal(applied.report.summary.appliedFacts, 1);
+    const migrated = parseFactFlowRecords(readFileSync(path.join(rootDir, taskPath, "facts.md"), "utf8"))[0];
+    assert.equal(migrated?.migration?.schema, "fact-migration/v1");
+    assert.equal(migrated?.migration?.state, "migrated");
+    const executionId = migrated?.migration?.execution_ref.split("/").at(-1);
+    assert.ok(executionId);
+    const execution = JSON.parse(readFileSync(path.join(rootDir, taskPath, "executions", `${executionId}.md`), "utf8")) as Record<string, any>;
+    assert.equal(execution.outputs[0].locator.text, "The operator completed the historical handoff.");
+    assert.equal(execution.outputs[0].evidence_id, migrated?.migration?.evidence_id);
+  });
+});
+
 function factsBody(): string {
   return [
     "# Facts",

--- a/packages/cli/test/parse-args.test.ts
+++ b/packages/cli/test/parse-args.test.ts
@@ -157,6 +157,7 @@ const parseCases: ReadonlyArray<ParseCase> = [
   { name: "migrate structure", argv: ["migrate", "structure", "--apply", "--confirm-plan"], kind: "migrate-structure", fields: { mode: "apply", confirmPlan: true } },
   { name: "migrate anchors", argv: ["migrate", "anchors", "--apply"], kind: "migrate-anchors", fields: { mode: "apply" } },
   { name: "migrate fact execution", argv: ["migrate", "fact-execution", "--apply", "--confirm-plan", "fxm_123", "--batch-size", "25", "--batch", "2", "--sample-size", "3"], kind: "migrate-fact-execution", fields: { mode: "apply", confirmPlan: "fxm_123", batchSize: 25, batch: 2, sampleSize: 3 } },
+  { name: "migrate fact execution manual list", argv: ["migrate", "fact-execution", "--dry-run", "--apply-manual", "artifacts/facts.txt"], kind: "migrate-fact-execution", fields: { mode: "dry-run", manualListFile: "artifacts/facts.txt", batchSize: 50, batch: 1, sampleSize: 5 } },
   { name: "migrate provenance", argv: ["migrate", "provenance", "--apply"], kind: "migrate-provenance", fields: { mode: "apply" } },
   { name: "migrate run", argv: ["migrate", "run", "--plan-only", "--session-dir", "session", "--locale", "en-US", "--assume-locale", "zh-CN", "--allow-dirty"], kind: "migrate-run", fields: { planOnly: true, outDir: "session", sessionDir: "session", locale: "en-US", assumeLocale: "zh-CN", allowDirty: true } },
   { name: "migrate verify", argv: ["migrate", "verify", "session.json"], kind: "migrate-verify", fields: { sessionPath: "session.json", fullCutover: false } },


### PR DESCRIPTION
# English

## Summary

Adds `--apply-manual <fact-ref-list>` selection mode to `ha migrate fact-execution`, per charter dec_01KXASA5. It migrates a human-confirmed factRef list (bypassing three-signal classification) into archival execution.outputs, reusing the automatic path's archival-execution / validateOutputEvidence / fact-migration trace / coordinated-write logic — no second migration implementation.

## What Changed

- `--apply-manual` mode: `parse-migration-args.ts`, `types.ts`, `command-spec-migration-diagnostics.ts`; selection swap only in `fact-execution-migration.ts:45-92`, reusing targetPlan/migrationWrites/archival-execution/trace.
- List validation + fail-close: unresolved refs → dry-run lists them, apply returns RefNotFound; dedup. non-done-without-active-execution still fail-closes.
- Report distinguishes manual-list vs automatic-intersection (requested/resolved/ready/skipped).
- Positive control test: a semantic fact (misses automatic signals) migrates via exact manual list into archival execution.outputs with aligned fact-migration/v1 trace.

## Task And Scope

- Harness task: task_01KXB3S8N41MKDPMXHAJ8DNG6A (root task_01KXAS76S9DVBJJMV7TBRJVWM3)
- Branch: claude-code/manual-apply-157-manual-3-planned-cancelled
- Public scope: `packages/cli` (migrate command manual mode + parser + tests).
- Private planning/evidence updated: yes (mission, worker report, factref list)
- Out of scope: the ledger migration itself already ran against canonical harness (144 manual facts migrated); this PR is the command code only.

## Version Impact

- Version: no version change (migration tooling extension).
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no (extends existing migrate command's selection mode; no schema/gate change)
- Authority: charter decision dec_01KXASA5KC11KVMHA6P7F9BKJH (accepted) and task task_01KXB3S8N41MKDPMXHAJ8DNG6A.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide sufficiency.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 711e6bc
- Branch merge-base with `origin/main`: 711e6bc
- Last `git fetch origin` time: 2026-07-12 (immediately before this PR)
- Sync method: none needed (ahead 1, behind 0)
- Public diff command: `git diff 711e6bc...HEAD`
- Private evidence commit/path: worker report + manual-apply-factrefs.txt in the tail-execution task package
- Reviewer evidence path: CEO semantic acceptance (manual mode reuses automatic path; 144/157 migrated, 13 non-done fail-closed honestly)
- GitHub Actions `rewrite-ci` run URL: pending — see the Checks tab
- [x] `npm run check` (worker ran check:local green + targeted red→green)
- [x] `npm run typecheck`
- [x] `npm test` (targeted migration + parse-args suites)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: none beyond CI.

## Review Evidence

- Self-review: CEO semantic acceptance — manual-apply reuses automatic archival/trace/validate path (no divergence); 144 migrated, 13 non-done-without-active-execution fail-closed (incl. C's F-HKXKXNHV, not forced), plan non-drift confirmed.
- Human review: pending
- Blocking findings: none

## Residual Risk

- 13 manual-list facts fail-closed (non-done without active execution), same class as the 25 automatic skips; resolved only after their tasks reach done/have an execution.
- D (F-Y4XDTBEN) still blocked: commit bbf37b6 not yet on origin/main.

## References

- Task: task_01KXB3S8N41MKDPMXHAJ8DNG6A (root task_01KXAS76S9DVBJJMV7TBRJVWM3)
- Evidence: charter dec_01KXASA5; worker report + factref list
- Review: CEO semantic acceptance

---

# 中文

## 概要

给 `ha migrate fact-execution` 加 `--apply-manual <fact-ref 清单>` 选择模式(依据 charter dec_01KXASA5):把人工确认的 factRef 清单(绕过三信号分类)迁入归档 execution.outputs,**复用 automatic 路径的归档 execution / validateOutputEvidence / fact-migration trace / coordinated-write 逻辑,不另写迁移实现**。

## 改动内容

- `--apply-manual` 模式:`parse-migration-args.ts`、`types.ts`、`command-spec-migration-diagnostics.ts`;仅在 `fact-execution-migration.ts:45-92` 替换候选选择,复用 targetPlan/migrationWrites/归档 execution/trace。
- 清单校验 + fail-close:unresolved refs → dry-run 列出、apply 返回 RefNotFound;去重。non-done 无 active execution 仍 fail-close。
- 报告区分 manual-list vs automatic-intersection(requested/resolved/ready/skipped)。
- 阳性对照测试:semantic fact(不命中 automatic 信号)经精确 manual 清单迁入归档 execution.outputs,fact-migration/v1 trace 对齐。

## 任务与范围

- Harness 任务:task_01KXB3S8N41MKDPMXHAJ8DNG6A(root task_01KXAS76S9DVBJJMV7TBRJVWM3)
- 分支:claude-code/manual-apply-157-manual-3-planned-cancelled
- 公开范围:`packages/cli`(migrate 命令 manual 模式 + parser + 测试)。
- 私有计划/证据是否已更新:yes(mission、worker report、factref 清单)
- 范围外:ledger 迁移本身已对 canonical harness 执行(144 条 manual fact 已迁);本 PR 只是命令代码。

## 版本影响

- 版本:不改版本(迁移工具扩展)。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no(扩展现有 migrate 命令的选择模式;无 schema/gate 改动)
- 依据:charter 决策 dec_01KXASA5KC11KVMHA6P7F9BKJH(已 accept)及任务 task_01KXB3S8N41MKDPMXHAJ8DNG6A。
- 机器检查边界:本 PR 只声明该段存在;充分性由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:711e6bc
- 当前分支与 `origin/main` 的 merge-base:711e6bc
- 最近一次 `git fetch origin` 时间:2026-07-12(本 PR 前)
- 同步方式:不需要(ahead 1, behind 0)
- 公开 diff 命令:`git diff 711e6bc...HEAD`
- 私有证据 commit/path:尾部执行 task 包的 worker report + manual-apply-factrefs.txt
- Reviewer 证据路径:CEO 语义验收(manual 模式复用 automatic 路径;144/157 迁移、13 non-done 诚实 fail-close)
- GitHub Actions `rewrite-ci` run URL:pending —— 见 Checks 页
- [x] `npm run check`(worker 跑 check:local 绿 + 定向 red→green)
- [x] `npm run typecheck`
- [x] `npm test`(定向 migration + parse-args)
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:除 CI 外无。

## 审查证据

- 自查:CEO 语义验收——manual-apply 复用 automatic 归档/trace/validate 路径(无分叉);144 迁移、13 条 non-done 无 execution 诚实 fail-close(含 C 的 F-HKXKXNHV,未 force),plan 未漂移。
- 人工审查:pending
- 阻塞发现:无

## 残余风险

- 13 条 manual 清单 fact fail-close(non-done 无 active execution),与 25 条 automatic skip 同类;待其 task 转 done/有 execution 后才能迁。
- D(F-Y4XDTBEN)仍 blocked:commit bbf37b6 尚未并入 origin/main。

## 关联材料

- 任务:task_01KXB3S8N41MKDPMXHAJ8DNG6A(root task_01KXAS76S9DVBJJMV7TBRJVWM3)
- 证据:charter dec_01KXASA5;worker report + factref 清单
- 审查:CEO 语义验收
