### PR TITLE
fix: resolve daemon CLI entrypoint by runtime artifact

### DIFF
--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -557,7 +557,12 @@ function runDaemonGit(cwd: string, args: ReadonlyArray<string>): void {
 }
 
 function productizationCliEntrypointPath(): string {
-  return realpathSync(fileURLToPath(new URL("../../index.ts", import.meta.url)));
+  const entrypointDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+  const found = ["index.js", "index.ts"]
+    .map((filename) => path.join(entrypointDir, filename))
+    .find((candidate) => existsSync(candidate));
+  if (!found) throw new Error(`CLI entrypoint not found in: ${entrypointDir}`);
+  return realpathSync(found);
 }
 
 function daemonAssetPath(relativePath: string): string {


### PR DESCRIPTION
# English

## Summary

`ha daemon start --service` failed with `journal_unavailable / ENOENT lstat '.../dist/cli/src/index.ts'` in the built (dist) CLI. Root cause was not a stale dist — it was a hardcoded `.ts` suffix in the daemon child-process entrypoint resolver. This fixes the resolver to detect the actual on-disk entrypoint (`.js` in dist, `.ts` in dev), restoring `daemon start` in both run modes.

## What Changed

- `packages/cli/src/commands/daemon/productization.ts`: `productizationCliEntrypointPath()` no longer builds `new URL("../../index.ts", …)`. It resolves the CLI entrypoint directory from `import.meta.url`, then probes `index.js` / `index.ts` for the one that exists (mirroring the existing `daemonAssetPath()` candidate-probe pattern) before `realpathSync`. Dev runs hit `src/index.ts`; dist runs hit `dist/cli/src/index.js`.

## Task And Scope

- Harness task: task_01KX9YZY07 (transparent-workspace validation) — this fix unblocks daemon-backed `ha decision` dogfooding for that task; the fix itself is a standalone CLI bug.
- Branch: `fix/daemon-entry-resolution`
- Public scope: one CLI source function.
- Private planning/evidence updated: not applicable
- Out of scope: no change to daemon protocol, hooks, build config, or `package.json` exports.

## Version Impact

- Version: no version change because this is an internal bug fix with no CLI surface/contract change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `a9e917402559e0b517d4d00296706301886331cb`
- Branch merge-base with `origin/main`: `a9e917402559e0b517d4d00296706301886331cb` (branch is on latest main; no sync needed)
- Last `git fetch origin` time: 2026-07-12 (pre-PR)
- Sync method: none needed
- Public diff command: `git diff origin/main -- packages/cli/src/commands/daemon/productization.ts`
- Private evidence commit/path: not applicable
- Reviewer evidence path: `/private/tmp/codex-daemon-entry-fix-report.md` (worker report, CEO ground-truthed)
- GitHub Actions `rewrite-ci` run URL: pending (this PR)
- [x] `npm run check:local` (fast tier): 404 pass / 0 fail
- [x] `npm run typecheck`
- [x] `npx eslint packages/cli/src/commands/daemon/productization.ts`
- [x] `git diff --check`
- [x] daemon start/status/stop end-to-end against dist entrypoint: `started=true reachable=true pid=77053`, clean stop, lock removed
- [x] dev-mode daemon integration test: `daemon start service status and stop expose productized status contract` — 1 pass
- Not run: full `npm run check` / `npm test` (all tiers) and GitHub Actions `rewrite-ci` — deferred to CI on this PR.

## Review Evidence

- Self-review: CEO ground-truthed the diff (mechanism-correct probe, not a suffix swap), the commit, and the daemon start/stop evidence with negative control.
- Reviewer subagent: Codex worker authored + validated in an isolated worktree.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- Not exercised on Windows/systemd/launchd service-manager E2E; the bug lives in the cross-platform Node child-process entrypoint resolution, and macOS detached service is verified end-to-end.

## References

- Task: task_01KX9YZY07-validate-cross-platform-transparent-workspace-architecture
- Evidence: `/private/tmp/codex-daemon-entry-fix-report.md`
- Review: CEO ground-truth in-session (diff + daemon start/stop + negative control).

---

# 中文

## 摘要

`ha daemon start --service` 在构建后的（dist）CLI 下报 `journal_unavailable / ENOENT lstat '.../dist/cli/src/index.ts'`。真因不是 dist 陈旧，而是 daemon 子进程入口解析里硬编码了 `.ts` 后缀。本 PR 让解析器探测磁盘上实际存在的入口（dist 命中 `.js`、dev 命中 `.ts`），在两种运行模式下都恢复 `daemon start`。

## 变更内容

- `packages/cli/src/commands/daemon/productization.ts`：`productizationCliEntrypointPath()` 不再构造 `new URL("../../index.ts", …)`。改为从 `import.meta.url` 解析 CLI 入口目录，再探测 `index.js` / `index.ts` 中实际存在的那个（复用同文件 `daemonAssetPath()` 的候选探测模式），最后 `realpathSync`。dev 命中 `src/index.ts`，dist 命中 `dist/cli/src/index.js`。

## 任务与范围

- Harness 任务：task_01KX9YZY07（透明工作区验证）——本修复解锁该任务 daemon 支撑的 `ha decision` dogfood；修复本身是独立的 CLI bug。
- 分支：`fix/daemon-entry-resolution`
- 公开范围：一个 CLI 源函数。
- 私有规划/证据更新：不适用
- 范围外：不改 daemon 协议、hook、build 配置、`package.json` exports。

## 版本影响

- 版本：无版本变更，内部 bug 修复，不改 CLI 面/契约。
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 权威依据：不适用
- 机器检查边界：本 PR 仅断言声明存在；是否属实与充分由 reviewer 判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- Base `origin/main` SHA：`a9e917402559e0b517d4d00296706301886331cb`
- 分支与 `origin/main` 的 merge-base：`a9e917402559e0b517d4d00296706301886331cb`（分支已在最新 main，无需同步）
- 最近 `git fetch origin` 时间：2026-07-12（PR 前）
- 同步方式：无需同步
- 公开 diff 命令：`git diff origin/main -- packages/cli/src/commands/daemon/productization.ts`
- 私有证据 commit/路径：不适用
- Reviewer 证据路径：`/private/tmp/codex-daemon-entry-fix-report.md`（worker 报告，CEO 已 ground-truth）
- GitHub Actions `rewrite-ci` run URL：待本 PR 触发
- [x] `npm run check:local`（fast 档）：404 通过 / 0 失败
- [x] `npm run typecheck`
- [x] `npx eslint packages/cli/src/commands/daemon/productization.ts`
- [x] `git diff --check`
- [x] daemon start/status/stop 对 dist 入口端到端：`started=true reachable=true pid=77053`，干净停止，lock 已清
- [x] dev 模式 daemon 集成用例：`daemon start service status and stop expose productized status contract` — 1 通过
- 未运行：完整 `npm run check` / `npm test`（全 tier）与 GitHub Actions `rewrite-ci`——交本 PR 的 CI。

## 复核证据

- 自审：CEO 已 ground-truth diff（探测机制正确，非硬换后缀）、commit、daemon start/stop 证据（含阴性对照）。
- Reviewer 子代理：Codex worker 在独立 worktree 实现 + 验证。
- 人工复核：待。
- 阻塞发现：无。

## 残余风险

- 未在 Windows/systemd/launchd 服务管理器级 E2E 验证；bug 位于跨平台共用的 Node 子进程入口解析，macOS detached service 已端到端验证。

## 参考

- 任务：task_01KX9YZY07-validate-cross-platform-transparent-workspace-architecture
- 证据：`/private/tmp/codex-daemon-entry-fix-report.md`
- 复核：本会话 CEO ground-truth（diff + daemon start/stop + 阴性对照）。
