### PR TITLE
fix: 已迁移 fact 退出 factAnchors triage 全集（事实分诊孤儿 710→276）

### DIFF
--- a/packages/kernel/src/projection/relation-graph-projection.ts
+++ b/packages/kernel/src/projection/relation-graph-projection.ts
@@ -390,7 +390,14 @@ function buildGraphRefIndex(rootInput: HarnessLayoutInput, decisions: ReadonlyAr
     if (factsBody === null) continue;
     for (const record of parseFactFlowRecords(factsBody)) {
       const factKey = `${taskId}/${record.fact_id}`;
+      // Migrated facts stay in factRefs so relation records that still reference
+      // them (e.g. supersedes-fact hosted on the archived fact) keep resolving
+      // and endpoint validation stays clean. But they leave factAnchors — the
+      // triage/coverage fact universe — because they have been rehomed to their
+      // task's execution.outputs (fact-migration/v1 trace) and must not surface
+      // as live orphan facts.
       factRefs.add(factKey);
+      if (record.migration?.state === "migrated") continue;
       factAnchors.push({
         factRef: `fact/${factKey}`,
         taskId,


### PR DESCRIPTION
# English

## Summary

Migrated facts (those rehomed to their task's `execution.outputs` with a `fact-migration/v1` trace) were still counted as live orphan facts in the GUI Fact Triage — 434 of them kept the orphan count pinned near 588 even after the Fact→Execution migration. Root cause: `buildGraphRefIndex` in `relation-graph-projection.ts` pushes every fact record into `factAnchors` (the triage/coverage fact universe) with no awareness of `migration.state`.

This excludes `migration.state === "migrated"` facts from `factAnchors` so they leave the Fact universe, while keeping them in `factRefs` so relation records that still reference them (e.g. `supersedes-fact` hosted on an archived fact) keep resolving and endpoint validation stays clean.

## What Changed

- `packages/kernel/src/projection/relation-graph-projection.ts`: in `buildGraphRefIndex`, add `factKey` to `factRefs` for all facts, then `continue` before `factAnchors.push` when `record.migration?.state === "migrated"`.

## Task And Scope

- Harness task: task_01KXBCE1PSD8WBCREC6P03Q22P (片 A · kernel), decision dec_01KXBCCBB6AVABTCVNNRS9YAR7.
- Branch: claude-code/migrated-fact-exit-projection
- Public scope: `packages/kernel` (single projection function).
- Private planning updated: yes (task plan, decision).
- Out of scope: the GUI Execution view (片 B) and a global executions list endpoint are tracked under the same task/decision; not in this PR.

## Version Impact

- Version: no version change (read-path projection fix).
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: no (projection read path; no schema/gate/CI change).
- Authority: decision dec_01KXBCCBB6AVABTCVNNRS9YAR7 (accepted), which relates migration charter dec_01KXASA5 and realizes the read-path consequence of dec_mrem0ys8/CH4.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide sufficiency.
- Break-glass: no.

## Verification

- Base `origin/main` SHA: a9e9174
- Branch merge-base with `origin/main`: a9e9174 (ahead 1, behind 0)
- Last `git fetch origin` time: 2026-07-12 (immediately before this PR)
- Sync method: none needed.
- Public diff command: `git diff a9e9174...HEAD`
- Before/after projection against the canonical ledger (same data):
  - `factAnchors`: 710 → 276 (exactly the 434 migrated facts leave the triage universe)
  - `coverageRows` covered/uncovered: 129/166 → 129/166 (unchanged — negative control passes)
  - `edges`: 731 → 731 (no dropped edges; supersedes-fact relationships preserved)
  - `validateRelationGraphRecords`: 0 → 0 issues (no dangling relation endpoints)
- [x] `npm run check:local` (fast tier green, 63.9s)
- [x] `npm run typecheck` (via check:local)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: none beyond CI.

## Review Evidence

- Self-review (CEO): the naive first cut removed migrated facts from both `factAnchors` and `factRefs`, which orphaned `supersedes-fact` records hosted on archived facts and raised `relation_endpoint_unknown` validation issues (0→4). Corrected to keep `factRefs` and only exclude from `factAnchors`; re-verified 0 validation issues, edges/coverage unchanged.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- Two migrated facts are `supersedes-fact` sources (instrument-correction observations that superseded shell-injection-corrupted facts); their whole supersede chain migrated together, so no non-migrated fact loses a relationship. Their correction narrative remains archived in `execution.outputs` and will be visible in the upcoming Execution view.
- The Fact Triage orphan count drop to ~154 is derived from the projection; the visible GUI count updates once the renderer re-reads the projection.

## References

- Task: task_01KXBCE1PSD8WBCREC6P03Q22P
- Decision: dec_01KXBCCBB6AVABTCVNNRS9YAR7 (relates dec_01KXASA5, realizes dec_mrem0ys8/CH4)

---

# 中文

## 概要

已迁移的 fact（带 `fact-migration/v1` trace、人已归到所属 task 的 `execution.outputs`）在 GUI 事实分诊里仍被当作 live 孤儿 fact——434 条让孤儿计数在 Fact→Execution 迁移后仍卡在 588 附近。根因：`relation-graph-projection.ts` 的 `buildGraphRefIndex` 把每条 fact 都推进 `factAnchors`（triage/coverage 的 fact 全集），完全不认 `migration.state`。

本 PR 把 `migration.state === "migrated"` 的 fact 从 `factAnchors` 剔除（退出 Fact 全集），但**保留在 `factRefs`**，使仍指向它们的关系记录（如归档 fact 上挂的 `supersedes-fact`）继续解析、endpoint 校验保持干净。

## 改动内容

- `packages/kernel/src/projection/relation-graph-projection.ts`：`buildGraphRefIndex` 中，所有 fact 都 `factRefs.add(factKey)`，然后在 `record.migration?.state === "migrated"` 时 `continue`（跳过 `factAnchors.push`）。

## 任务与范围

- Harness 任务：task_01KXBCE1PSD8WBCREC6P03Q22P（片 A · kernel），决策 dec_01KXBCCBB6AVABTCVNNRS9YAR7。
- 分支：claude-code/migrated-fact-exit-projection
- 公开范围：`packages/kernel`（单个投影函数）。
- 私有计划已更新：yes（task plan、decision）。
- 范围外：GUI 执行证据视图（片 B）与全局 executions 列表端点挂在同一 task/decision 下，不在本 PR。

## 版本影响

- 版本：不改版本（读路径投影修正）。
- 发布影响：不发布。

## 治理声明

- 是否触碰 protected surface：no（投影读路径；无 schema/gate/CI 改动）。
- 依据：决策 dec_01KXBCCBB6AVABTCVNNRS9YAR7（已 accept），relates 迁移 charter dec_01KXASA5、落实 dec_mrem0ys8/CH4 读路径后果。
- 机器检查边界：本 PR 只声明该段存在；充分性由 reviewer 判断。
- Break-glass：no。

## 验证

- `origin/main` 基准 SHA：a9e9174
- 与 `origin/main` 的 merge-base：a9e9174（ahead 1, behind 0）
- 最近 `git fetch origin` 时间：2026-07-12（本 PR 前）
- 同步方式：不需要。
- 公开 diff 命令：`git diff a9e9174...HEAD`
- 对同一 canonical ledger 的改前/改后投影对照：
  - `factAnchors`：710 → 276（正好 434 条迁移 fact 退出 triage 全集）
  - `coverageRows` covered/uncovered：129/166 → 129/166（不变——阴性对照过）
  - `edges`：731 → 731（无掉边；supersedes-fact 关系保留）
  - `validateRelationGraphRecords`：0 → 0 issue（无悬空端点）
- [x] `npm run check:local`（fast tier 绿，63.9s）
- [x] `npm run typecheck`（随 check:local）
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：除 CI 外无。

## 审查证据

- 自查（CEO）：首版天真实现把迁移 fact 从 `factAnchors` 和 `factRefs` 一起剔除，导致归档 fact 上挂的 `supersedes-fact` 记录悬空、`relation_endpoint_unknown` 校验 0→4。改为保留 `factRefs`、只出 `factAnchors`；复验 0 issue，edges/coverage 不变。
- 人工审查：pending。
- 阻塞发现：无。

## 残余风险

- 2 条迁移 fact 是 `supersedes-fact` 源（"仪器纠正"型观察，取代了被 shell 注入污染的坏 fact）；其整条 supersede 链一起迁走，无未迁移 fact 失去关系。纠正叙述仍归档在 `execution.outputs`，将在后续 Execution 视图可见。
- 事实分诊孤儿计数掉到 ~154 是从投影推导；GUI 可见计数在 renderer 重读投影后更新。

## 关联材料

- 任务：task_01KXBCE1PSD8WBCREC6P03Q22P
- 决策：dec_01KXBCCBB6AVABTCVNNRS9YAR7（relates dec_01KXASA5，落实 dec_mrem0ys8/CH4）
