### PR TITLE
feat: dual-axis P5 immutable attribution event store

### DIFF
--- a/packages/kernel/src/layout/index.ts
+++ b/packages/kernel/src/layout/index.ts
@@ -35,6 +35,7 @@ export interface HarnessLayout {
   readonly localRoot: string;
   readonly generatedRoot: string;
   readonly runtimeEventLedgerRoot: string;
+  readonly attributionEventsRoot: string;
   readonly cacheRoot: string;
   readonly projectionPath: string;
   readonly writeJournalRoot: string;
@@ -176,6 +177,7 @@ function buildHarnessLayout(settings: HarnessLayoutSettings): HarnessLayout {
     localRoot,
     generatedRoot,
     runtimeEventLedgerRoot: path.join(generatedRoot, "runtime-events"),
+    attributionEventsRoot: path.join(authoredRoot, "attribution-events"),
     cacheRoot: path.join(localRoot, "cache"),
     projectionPath: path.join(localRoot, "cache", "projections.sqlite"),
     writeJournalRoot,

--- a/packages/kernel/src/local/attribution-event-source.ts
+++ b/packages/kernel/src/local/attribution-event-source.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+import { Schema } from "effect";
+import type { HarnessLayoutInput } from "../layout/index.ts";
+import { resolveHarnessLayout } from "../layout/index.ts";
+import { stablePayloadHash } from "../integrity/stable-hash.ts";
+import { AttributionEventSchema, type AttributionEvent } from "../schemas/attribution-event.ts";
+import { localLayoutFileSystem } from "./local-layout-file-system.ts";
+
+export function readAttributionEvents(rootInput: HarnessLayoutInput): ReadonlyArray<AttributionEvent> {
+  const eventsRoot = resolveHarnessLayout(rootInput).attributionEventsRoot;
+  if (!localLayoutFileSystem.exists(eventsRoot)) return [];
+  return localLayoutFileSystem.readDirents(eventsRoot)
+    .filter((entry) => !entry.isDirectory() && entry.name.endsWith(".jsonl"))
+    .map((entry) => decodeAttributionEvent(localLayoutFileSystem.readText(path.join(eventsRoot, entry.name))))
+    .sort((left, right) => left.eventId.localeCompare(right.eventId));
+}
+
+export function attributionEventSourceHash(rootInput: HarnessLayoutInput): string {
+  return stablePayloadHash(readAttributionEvents(rootInput));
+}
+
+function decodeAttributionEvent(body: string): AttributionEvent {
+  const lines = body.trim().split("\n").filter(Boolean);
+  if (lines.length !== 1) throw new Error("immutable attribution event shard must contain exactly one event");
+  return Schema.decodeUnknownSync(AttributionEventSchema)(JSON.parse(lines[0]!));
+}

--- a/packages/kernel/src/projection/sqlite-attribution-projection.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-projection.ts
@@ -15,7 +15,6 @@ export interface AttributionProjectionRow {
   readonly operation: string;
   readonly actor: ActorAxes;
   readonly occurredAt: string;
-  readonly commitSha: string;
   readonly principalSource: PrincipalSource;
   readonly executorSource: ExecutorSource;
   readonly payloadHash: string;
@@ -45,7 +44,7 @@ export function readAttributionProjection(
     const sql = yield* SqlClient.SqlClient;
     const records = yield* sql<AttributionRecord>`
       SELECT event_id, op_id, subject_ref, operation, principal_person_id,
-             executor_agent_id, occurred_at, commit_sha, source_json
+             executor_agent_id, occurred_at, source_json
       FROM attribution_events
       ORDER BY occurred_at, event_id
     `;
@@ -64,7 +63,6 @@ function createAttributionTable(sql: SqlClient.SqlClient): Effect.Effect<unknown
         principal_person_id TEXT NOT NULL,
         executor_agent_id TEXT,
         occurred_at TEXT NOT NULL,
-        commit_sha TEXT NOT NULL,
         source_json TEXT NOT NULL
       )
     `;
@@ -76,11 +74,11 @@ function insertAttributionEvent(sql: SqlClient.SqlClient, event: AttributionEven
   return sql`
     INSERT INTO attribution_events (
       event_id, op_id, subject_ref, operation, principal_person_id,
-      executor_agent_id, occurred_at, commit_sha, source_json
+      executor_agent_id, occurred_at, source_json
     ) VALUES (
       ${event.eventId}, ${event.opId}, ${event.entityId}, ${event.kind},
       ${event.actor.principal.personId}, ${event.actor.executor?.id ?? null},
-      ${event.at}, ${event.mutationCommitSha}, ${JSON.stringify(eventSource(event))}
+      ${event.at}, ${JSON.stringify(eventSource(event))}
     )
   `;
 }
@@ -93,7 +91,6 @@ function eventToProjectionRow(event: AttributionEvent): AttributionProjectionRow
     operation: event.kind,
     actor: event.actor,
     occurredAt: event.at,
-    commitSha: event.mutationCommitSha,
     principalSource: event.principalSource,
     executorSource: event.executorSource,
     payloadHash: event.payloadHash,
@@ -113,7 +110,6 @@ function recordToProjectionRow(record: AttributionRecord): AttributionProjection
       executor: record.executor_agent_id === null ? null : { kind: "agent", id: String(record.executor_agent_id) }
     },
     occurredAt: String(record.occurred_at),
-    commitSha: String(record.commit_sha),
     principalSource: source.principalSource,
     executorSource: source.executorSource,
     payloadHash: source.payloadHash,
@@ -145,6 +141,5 @@ interface AttributionRecord {
   readonly principal_person_id: unknown;
   readonly executor_agent_id: unknown;
   readonly occurred_at: unknown;
-  readonly commit_sha: unknown;
   readonly source_json: unknown;
 }

--- a/packages/kernel/src/projection/sqlite-attribution-projection.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-projection.ts
@@ -1,0 +1,150 @@
+import type { HarnessLayoutInput } from "../layout/index.ts";
+import { resolveHarnessLayout } from "../layout/index.ts";
+import { localLayoutFileSystem } from "../local/local-layout-file-system.ts";
+import { readAttributionEvents } from "../local/attribution-event-source.ts";
+import type { ActorAxes, ExecutorSource, PrincipalSource } from "../schemas/actor-attribution.ts";
+import type { AttributionEvent } from "../schemas/attribution-event.ts";
+import { runSqlite } from "./sqlite-projection-store.ts";
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+
+export interface AttributionProjectionRow {
+  readonly eventId: string;
+  readonly opId: string;
+  readonly subjectRef: string;
+  readonly operation: string;
+  readonly actor: ActorAxes;
+  readonly occurredAt: string;
+  readonly commitSha: string;
+  readonly principalSource: PrincipalSource;
+  readonly executorSource: ExecutorSource;
+  readonly payloadHash: string;
+  readonly payloadRef: AttributionEvent["payloadRef"];
+}
+
+export function materializeAttributionProjection(
+  rootInput: HarnessLayoutInput,
+  projectionPath = resolveHarnessLayout(rootInput).projectionPath
+): ReadonlyArray<AttributionProjectionRow> {
+  if (!localLayoutFileSystem.exists(projectionPath)) throw new Error("base projection database must exist before attribution materialization");
+  const events = readAttributionEvents(rootInput);
+  runSqlite(projectionPath, Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    yield* createAttributionTable(sql);
+    yield* sql`DELETE FROM attribution_events`;
+    for (const event of events) yield* insertAttributionEvent(sql, event);
+  }));
+  return events.map(eventToProjectionRow);
+}
+
+export function readAttributionProjection(
+  rootInput: HarnessLayoutInput,
+  projectionPath = resolveHarnessLayout(rootInput).projectionPath
+): ReadonlyArray<AttributionProjectionRow> {
+  return runSqlite(projectionPath, Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const records = yield* sql<AttributionRecord>`
+      SELECT event_id, op_id, subject_ref, operation, principal_person_id,
+             executor_agent_id, occurred_at, commit_sha, source_json
+      FROM attribution_events
+      ORDER BY occurred_at, event_id
+    `;
+    return records.map(recordToProjectionRow);
+  }));
+}
+
+function createAttributionTable(sql: SqlClient.SqlClient): Effect.Effect<unknown, unknown> {
+  return Effect.gen(function* () {
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS attribution_events (
+        event_id TEXT PRIMARY KEY,
+        op_id TEXT NOT NULL UNIQUE,
+        subject_ref TEXT NOT NULL,
+        operation TEXT NOT NULL,
+        principal_person_id TEXT NOT NULL,
+        executor_agent_id TEXT,
+        occurred_at TEXT NOT NULL,
+        commit_sha TEXT NOT NULL,
+        source_json TEXT NOT NULL
+      )
+    `;
+    yield* sql`CREATE INDEX IF NOT EXISTS attribution_events_subject_time ON attribution_events(subject_ref, occurred_at, event_id)`;
+  });
+}
+
+function insertAttributionEvent(sql: SqlClient.SqlClient, event: AttributionEvent): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT INTO attribution_events (
+      event_id, op_id, subject_ref, operation, principal_person_id,
+      executor_agent_id, occurred_at, commit_sha, source_json
+    ) VALUES (
+      ${event.eventId}, ${event.opId}, ${event.entityId}, ${event.kind},
+      ${event.actor.principal.personId}, ${event.actor.executor?.id ?? null},
+      ${event.at}, ${event.mutationCommitSha}, ${JSON.stringify(eventSource(event))}
+    )
+  `;
+}
+
+function eventToProjectionRow(event: AttributionEvent): AttributionProjectionRow {
+  return {
+    eventId: event.eventId,
+    opId: event.opId,
+    subjectRef: event.entityId,
+    operation: event.kind,
+    actor: event.actor,
+    occurredAt: event.at,
+    commitSha: event.mutationCommitSha,
+    principalSource: event.principalSource,
+    executorSource: event.executorSource,
+    payloadHash: event.payloadHash,
+    payloadRef: event.payloadRef
+  };
+}
+
+function recordToProjectionRow(record: AttributionRecord): AttributionProjectionRow {
+  const source = JSON.parse(String(record.source_json)) as ReturnType<typeof eventSource>;
+  return {
+    eventId: String(record.event_id),
+    opId: String(record.op_id),
+    subjectRef: String(record.subject_ref),
+    operation: String(record.operation),
+    actor: {
+      principal: { kind: "person", personId: String(record.principal_person_id) },
+      executor: record.executor_agent_id === null ? null : { kind: "agent", id: String(record.executor_agent_id) }
+    },
+    occurredAt: String(record.occurred_at),
+    commitSha: String(record.commit_sha),
+    principalSource: source.principalSource,
+    executorSource: source.executorSource,
+    payloadHash: source.payloadHash,
+    payloadRef: source.payloadRef
+  };
+}
+
+function eventSource(event: AttributionEvent): {
+  readonly journalRecordSchema: "write-journal/v2";
+  readonly principalSource: PrincipalSource;
+  readonly executorSource: ExecutorSource;
+  readonly payloadHash: string;
+  readonly payloadRef: AttributionEvent["payloadRef"];
+} {
+  return {
+    journalRecordSchema: event.journalRecordSchema,
+    principalSource: event.principalSource,
+    executorSource: event.executorSource,
+    payloadHash: event.payloadHash,
+    payloadRef: event.payloadRef
+  };
+}
+
+interface AttributionRecord {
+  readonly event_id: unknown;
+  readonly op_id: unknown;
+  readonly subject_ref: unknown;
+  readonly operation: unknown;
+  readonly principal_person_id: unknown;
+  readonly executor_agent_id: unknown;
+  readonly occurred_at: unknown;
+  readonly commit_sha: unknown;
+  readonly source_json: unknown;
+}

--- a/packages/kernel/src/projection/sqlite-projection-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-store.ts
@@ -13,7 +13,7 @@ import type {
   TaskProjectionRow
 } from "./types.ts";
 
-export const projectionVersion = "entity-projection/d4-v4";
+export const projectionVersion = "entity-projection/d4-v5";
 const baseTaskProjectionColumns = [
   "task_id",
   "title",

--- a/packages/kernel/src/projection/sqlite-task-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-projection.ts
@@ -12,6 +12,8 @@ import type { FactAnchorRow, RelationCoverageRow, RelationGraphEdgeRow } from ".
 import { buildRelationGraphProjection } from "./relation-graph-projection.ts";
 import { projectionVersion, queryDecisionProjectionRows, queryTaskChildrenRows, queryTaskProjectionRows, queryTaskSubtreeRows, readRelationGraphRows, writeProjectionDatabase, tryReadProjectionDatabase } from "./sqlite-projection-store.ts";
 import { compareDecisionRows, hashDecisionProjectionRows, readDecisionProjectionRows } from "./sqlite-decision-source.ts";
+import { materializeAttributionProjection } from "./sqlite-attribution-projection.ts";
+import { attributionEventSourceHash } from "../local/attribution-event-source.ts";
 import { compareRows, hashExactRows, readMarkdownSource, taskEntryToRow } from "./sqlite-task-source.ts";
 export { hashTaskProjectionRows } from "./sqlite-task-source.ts";
 export type {
@@ -70,6 +72,7 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
   projectDeclaredEntities(runtimeContext, sessionEntityDeclaration, projectionPath);
   projectDeclaredEntities(runtimeContext, executionDeclaration, projectionPath);
   projectDeclaredEntities(runtimeContext, reviewDeclaration, projectionPath);
+  materializeAttributionProjection(runtimeContext, projectionPath);
   return {
     rows,
     warnings: source.warnings
@@ -175,7 +178,7 @@ function projectionSourceHash(taskSourceHash: string, rootInput: ReturnType<type
     table: declaration.projection.table,
     rows: discoverDeclaredEntityRows(rootInput, declaration)
   }));
-  return sha256Text(JSON.stringify({ taskSourceHash, entityRows }));
+  return sha256Text(JSON.stringify({ taskSourceHash, entityRows, attributionEventSourceHash: attributionEventSourceHash(rootInput) }));
 }
 
 function declaredProjectionMatches(rootInput: ReturnType<typeof createHarnessRuntimeContext>, projectionPath: string): boolean {

--- a/packages/kernel/src/schemas/attribution-event.ts
+++ b/packages/kernel/src/schemas/attribution-event.ts
@@ -18,7 +18,6 @@ export const AttributionEventSchema = Schema.Struct({
   principalSource: PrincipalSourceSchema,
   executorSource: ExecutorSourceSchema,
   at: NonBlankStringSchema,
-  mutationCommitSha: NonBlankStringSchema,
   payloadHash: NonBlankStringSchema,
   payloadRef: JournalPayloadRefSchema
 }).pipe(Schema.filter((event) => (

--- a/packages/kernel/src/schemas/attribution-event.ts
+++ b/packages/kernel/src/schemas/attribution-event.ts
@@ -1,0 +1,30 @@
+import { Schema } from "effect";
+import { NonBlankStringSchema } from "./common.ts";
+import {
+  ActorAxesSchema,
+  ExecutorSourceSchema,
+  PrincipalSourceSchema
+} from "./actor-attribution.ts";
+import { JournalPayloadRefSchema, WriteJournalOpKindSchema } from "./write-journal.ts";
+
+export const AttributionEventSchema = Schema.Struct({
+  schema: Schema.Literal("attribution-event/v1"),
+  eventId: NonBlankStringSchema,
+  opId: NonBlankStringSchema,
+  journalRecordSchema: Schema.Literal("write-journal/v2"),
+  entityId: NonBlankStringSchema,
+  kind: WriteJournalOpKindSchema,
+  actor: ActorAxesSchema,
+  principalSource: PrincipalSourceSchema,
+  executorSource: ExecutorSourceSchema,
+  at: NonBlankStringSchema,
+  mutationCommitSha: NonBlankStringSchema,
+  payloadHash: NonBlankStringSchema,
+  payloadRef: JournalPayloadRefSchema
+}).pipe(Schema.filter((event) => (
+  event.actor.executor === null
+    ? event.executorSource === "none"
+    : event.executorSource === "client-asserted"
+)));
+
+export type AttributionEvent = Schema.Schema.Type<typeof AttributionEventSchema>;

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -6,3 +6,4 @@ export * from "./local-lock-registry.ts";
 export * from "./local-version-control-system.ts";
 export * from "./markdown-artifact-store.ts";
 export * from "./write-journal-coordinator.ts";
+export * from "./write-journal-attribution-events.ts";

--- a/packages/kernel/src/store/ledger-materializer.ts
+++ b/packages/kernel/src/store/ledger-materializer.ts
@@ -3,11 +3,14 @@ import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import type { VersionControlSystem } from "../ports/version-control-system.ts";
 import { updateTaskProjectionIncrementally } from "../projection/sqlite-task-incremental-projection.ts";
+import { materializeAttributionProjection } from "../projection/sqlite-attribution-projection.ts";
+import { rebuildTaskProjection } from "../projection/sqlite-task-projection.ts";
 import { readMarkdownSource } from "../projection/sqlite-task-source.ts";
 import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
 import { resolveTrunkBranch } from "./write-journal-git.ts";
 import { withRepoLocks } from "./write-journal-locks.ts";
 import type { OwnedLock } from "./write-journal-types.ts";
+import { durableFileExists } from "./write-journal-durable.ts";
 
 export interface LedgerMaterializerBranchReport {
   readonly branch: string;
@@ -24,6 +27,7 @@ export interface LedgerMaterializerReport {
   readonly branches: ReadonlyArray<LedgerMaterializerBranchReport>;
   readonly warnings: ReadonlyArray<string>;
   readonly projectionRebuilt: boolean;
+  readonly attributionEventsProjected: number;
 }
 
 export interface LedgerMaterializerOptions {
@@ -46,7 +50,8 @@ export function runLedgerMaterializer(rootInput: HarnessLayoutInput, options: Le
       considered: 0,
       branches: [],
       warnings: ["authored root is not a Git repository"],
-      projectionRebuilt: false
+      projectionRebuilt: false,
+      attributionEventsProjected: 0
     };
   }
 
@@ -71,7 +76,8 @@ function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dr
       considered: 0,
       branches: [],
       warnings: [`trunk branch ${trunkBranch} does not exist`],
-      projectionRebuilt: false
+      projectionRebuilt: false,
+      attributionEventsProjected: 0
     };
   }
 
@@ -124,13 +130,24 @@ function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dr
     });
   }
 
+  const layout = resolveHarnessLayout(rootInput);
+  let attributionEventsProjected = 0;
+  if (!dryRun) {
+    if (!durableFileExists(layout.projectionPath)) rebuildTaskProjection({
+      rootDir: layout.rootDir,
+      ...(typeof rootInput === "object" ? { layoutOverrides: rootInput.layoutOverrides } : {})
+    });
+    attributionEventsProjected = materializeAttributionProjection(rootInput, layout.projectionPath).length;
+  }
+
   return {
     dryRun,
     merged,
     considered: reports.filter((report) => report.commitCount > 0).length,
     branches: reports,
     warnings,
-    projectionRebuilt: merged > 0
+    projectionRebuilt: merged > 0,
+    attributionEventsProjected
   };
 }
 

--- a/packages/kernel/src/store/write-journal-attribution-events.ts
+++ b/packages/kernel/src/store/write-journal-attribution-events.ts
@@ -28,6 +28,26 @@ export interface AttributionEventWrite {
   readonly touchedPaths: ReadonlyArray<string>;
 }
 
+export function planAttributionEventCommit(
+  rootDir: string,
+  rootInput: HarnessLayoutInput,
+  touchedPaths: ReadonlyArray<string>,
+  versionControlSystem: VersionControlSystem
+): { readonly willCommit: boolean; readonly preCommitSha: string } {
+  const plan = resolveCommitPlan(rootDir, touchedPaths, rootInput, versionControlSystem);
+  if (plan) {
+    return {
+      willCommit: versionControlSystem.workingTreeFiles(plan.repoRoot, plan.relativePaths).trim().length > 0,
+      preCommitSha: versionControlSystem.currentHead(plan.repoRoot)
+    };
+  }
+  const localRoot = resolveHarnessLayout(rootInput).localRoot;
+  return {
+    willCommit: touchedPaths.some((filePath) => !isLocalRuntimePath(localRoot, filePath)),
+    preCommitSha: "no-git-change"
+  };
+}
+
 export function makeLocalGitAttributionEventStore(): AttributionEventStore {
   return {
     ensure: ensureLocalAttributionEvent,
@@ -36,7 +56,7 @@ export function makeLocalGitAttributionEventStore(): AttributionEventStore {
   };
 }
 
-export function createAttributionEvent(record: JournalRecordV2, mutationCommitSha: string): AttributionEvent {
+export function createAttributionEvent(record: JournalRecordV2): AttributionEvent {
   if (!record.payloadRef || typeof record.payload?.payloadHash !== "string") {
     throw new Error(`attributed journal record ${record.opId} lacks immutable payload evidence`);
   }
@@ -51,14 +71,13 @@ export function createAttributionEvent(record: JournalRecordV2, mutationCommitSh
     principalSource: record.principalSource,
     executorSource: record.executorSource,
     at: record.at,
-    mutationCommitSha,
     payloadHash: record.payload.payloadHash,
     payloadRef: record.payloadRef
   });
 }
 
 function ensureLocalAttributionEvent(record: JournalRecordV2, context: AttributionEventStoreContext): AttributionEventWrite {
-  const event = createAttributionEvent(record, context.commitSha);
+  const event = createAttributionEvent(record);
   const eventPath = localEventPath(context.rootInput, event.opId);
   if (eventExistsAtCommit(eventPath, context)) return { event, touchedPaths: [] };
   if (durableFileExists(eventPath)) {
@@ -101,16 +120,16 @@ function decodeEvent(body: string): AttributionEvent {
 }
 
 function assertSameEvent(existing: AttributionEvent, candidate: AttributionEvent): void {
-  if (existing.opId !== candidate.opId || stableStringify(eventIdentity(existing)) !== stableStringify(eventIdentity(candidate))) {
+  if (existing.opId !== candidate.opId || stableStringify(existing) !== stableStringify(candidate)) {
     throw new Error(`attribution event collision for op ${candidate.opId}`);
   }
 }
 
-function eventIdentity(event: AttributionEvent): Omit<AttributionEvent, "mutationCommitSha"> {
-  const { mutationCommitSha: _mutationCommitSha, ...identity } = event;
-  return identity;
-}
-
 function readAttributionEventText(filePath: string): string {
   return Buffer.from(readFileBytes(filePath)).toString("utf8");
+}
+
+function isLocalRuntimePath(rootPath: string, filePath: string): boolean {
+  const relativePath = path.relative(rootPath, filePath);
+  return relativePath.length === 0 || (relativePath !== ".." && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath));
 }

--- a/packages/kernel/src/store/write-journal-attribution-events.ts
+++ b/packages/kernel/src/store/write-journal-attribution-events.ts
@@ -1,0 +1,116 @@
+import path from "node:path";
+import { Schema } from "effect";
+import type { HarnessLayoutInput } from "../layout/index.ts";
+import { resolveHarnessLayout } from "../layout/index.ts";
+import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
+import { readAttributionEvents } from "../local/attribution-event-source.ts";
+import type { VersionControlSystem } from "../ports/version-control-system.ts";
+import { AttributionEventSchema, type AttributionEvent } from "../schemas/attribution-event.ts";
+import { resolveCommitPlan } from "./write-journal-git.ts";
+import type { JournalRecordV2 } from "./write-journal-types.ts";
+import { appendImmutableJsonLineDurably, durableFileExists, readFileBytes } from "./write-journal-durable.ts";
+
+export interface AttributionEventStoreContext {
+  readonly rootDir: string;
+  readonly rootInput: HarnessLayoutInput;
+  readonly commitSha: string;
+  readonly versionControlSystem: VersionControlSystem;
+}
+
+export interface AttributionEventStore {
+  readonly ensure: (record: JournalRecordV2, context: AttributionEventStoreContext) => AttributionEventWrite;
+  readonly confirms: (event: AttributionEvent, context: AttributionEventStoreContext) => boolean;
+  readonly readAll: (rootInput: HarnessLayoutInput) => ReadonlyArray<AttributionEvent>;
+}
+
+export interface AttributionEventWrite {
+  readonly event: AttributionEvent;
+  readonly touchedPaths: ReadonlyArray<string>;
+}
+
+export function makeLocalGitAttributionEventStore(): AttributionEventStore {
+  return {
+    ensure: ensureLocalAttributionEvent,
+    confirms: localEventIsDurable,
+    readAll: readAttributionEvents
+  };
+}
+
+export function createAttributionEvent(record: JournalRecordV2, mutationCommitSha: string): AttributionEvent {
+  if (!record.payloadRef || typeof record.payload?.payloadHash !== "string") {
+    throw new Error(`attributed journal record ${record.opId} lacks immutable payload evidence`);
+  }
+  return Schema.decodeUnknownSync(AttributionEventSchema)({
+    schema: "attribution-event/v1",
+    eventId: `attribution:${record.opId}`,
+    opId: record.opId,
+    journalRecordSchema: record.schema,
+    entityId: record.entityId,
+    kind: record.kind,
+    actor: record.actor,
+    principalSource: record.principalSource,
+    executorSource: record.executorSource,
+    at: record.at,
+    mutationCommitSha,
+    payloadHash: record.payload.payloadHash,
+    payloadRef: record.payloadRef
+  });
+}
+
+function ensureLocalAttributionEvent(record: JournalRecordV2, context: AttributionEventStoreContext): AttributionEventWrite {
+  const event = createAttributionEvent(record, context.commitSha);
+  const eventPath = localEventPath(context.rootInput, event.opId);
+  if (eventExistsAtCommit(eventPath, context)) return { event, touchedPaths: [] };
+  if (durableFileExists(eventPath)) {
+    assertSameEvent(decodeEvent(readAttributionEventText(eventPath)), event);
+    return { event, touchedPaths: [eventPath] };
+  }
+  if (!appendImmutableJsonLineDurably(eventPath, event)) {
+    assertSameEvent(decodeEvent(readAttributionEventText(eventPath)), event);
+  }
+  return { event, touchedPaths: [eventPath] };
+}
+
+function localEventIsDurable(event: AttributionEvent, context: AttributionEventStoreContext): boolean {
+  const eventPath = localEventPath(context.rootInput, event.opId);
+  if (eventExistsAtCommit(eventPath, context)) return true;
+  if (!durableFileExists(eventPath)) return false;
+  try {
+    assertSameEvent(decodeEvent(readAttributionEventText(eventPath)), event);
+    return resolveCommitPlan(context.rootDir, [eventPath], context.rootInput, context.versionControlSystem) === null;
+  } catch {
+    return false;
+  }
+}
+
+function eventExistsAtCommit(eventPath: string, context: AttributionEventStoreContext): boolean {
+  const plan = resolveCommitPlan(context.rootDir, [eventPath], context.rootInput, context.versionControlSystem);
+  return plan !== null &&
+    context.versionControlSystem.commitExists(plan.repoRoot, context.commitSha) &&
+    plan.relativePaths.every((relativePath) => context.versionControlSystem.pathExistsAtCommit(plan.repoRoot, context.commitSha, relativePath));
+}
+
+function localEventPath(rootInput: HarnessLayoutInput, opId: string): string {
+  return path.join(resolveHarnessLayout(rootInput).attributionEventsRoot, `${sha256Text(opId)}.jsonl`);
+}
+
+function decodeEvent(body: string): AttributionEvent {
+  const lines = body.trim().split("\n").filter(Boolean);
+  if (lines.length !== 1) throw new Error("immutable attribution event shard must contain exactly one event");
+  return Schema.decodeUnknownSync(AttributionEventSchema)(JSON.parse(lines[0]!));
+}
+
+function assertSameEvent(existing: AttributionEvent, candidate: AttributionEvent): void {
+  if (existing.opId !== candidate.opId || stableStringify(eventIdentity(existing)) !== stableStringify(eventIdentity(candidate))) {
+    throw new Error(`attribution event collision for op ${candidate.opId}`);
+  }
+}
+
+function eventIdentity(event: AttributionEvent): Omit<AttributionEvent, "mutationCommitSha"> {
+  const { mutationCommitSha: _mutationCommitSha, ...identity } = event;
+  return identity;
+}
+
+function readAttributionEventText(filePath: string): string {
+  return Buffer.from(readFileBytes(filePath)).toString("utf8");
+}

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -27,7 +27,7 @@ import { assertCommitPlanAddable, commitTouchedPaths } from "./write-journal-git
 import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
 import { assertCodeDocGitEvidence, assertNoUncoordinatedCodeDocChange } from "./write-journal-code-doc-policy.ts";
 import { runLedgerMaterializer } from "./ledger-materializer.ts";
-import { makeLocalGitAttributionEventStore, type AttributionEventStore } from "./write-journal-attribution-events.ts";
+import { createAttributionEvent, makeLocalGitAttributionEventStore, planAttributionEventCommit, type AttributionEventStore } from "./write-journal-attribution-events.ts";
 import { assertDirectWriteAllowed, withRepoLocks, WriteLockHeldError } from "./write-journal-locks.ts";
 import { NonTaskWriteEntityError, taskIdForJournalRecord } from "./write-journal-entity.ts";
 import { rejectWrite, WriteRejectedError } from "./write-journal-rejection.ts";
@@ -303,9 +303,25 @@ function flushRecords(
     committedOpIds.push(record.opId);
   }
 
+  const eventVcs = versionControlSystem ?? makeLocalVersionControlSystem();
+  const attributedRecords = plannedRecords
+    .map((entry) => entry.record)
+    .filter((record): record is Extract<ReadableJournalRecord, { readonly schema: "write-journal/v2" }> => record.schema === "write-journal/v2");
+  const eventCommitPlan = planAttributionEventCommit(rootDir, rootInput, touchedPaths, eventVcs);
+  const mutationWillCommit = eventCommitPlan.willCommit;
+  const eventWrites = mutationWillCommit
+    ? attributedRecords
+    .map((record) => attributionEventStore.ensure(record, {
+      rootDir,
+      rootInput,
+      commitSha: eventCommitPlan.preCommitSha,
+      versionControlSystem: eventVcs
+    }))
+    : [];
+  const eventPaths = eventWrites.flatMap((write) => write.touchedPaths);
   const mutationCommitSha = commitTouchedPaths(
     rootDir,
-    touchedPaths,
+    [...touchedPaths, ...eventPaths],
     committedOpIds,
     rootInput,
     semanticCommitMessage(rootDir, plannedRecords.map((entry) => entry.record)),
@@ -315,36 +331,18 @@ function flushRecords(
       versionControlSystem
     }
   );
-  const eventVcs = versionControlSystem ?? makeLocalVersionControlSystem();
-  const eventWrites = plannedRecords
-    .filter((entry): entry is typeof entry & { readonly record: Extract<ReadableJournalRecord, { readonly schema: "write-journal/v2" }> } => entry.record.schema === "write-journal/v2")
-    .map(({ record }) => attributionEventStore.ensure(record, {
+  const attributionEvents = mutationWillCommit
+    ? eventWrites.map((write) => write.event)
+    : attributedRecords.map(createAttributionEvent);
+  const confirmedAttributionOpIds = new Set(attributionEvents
+    .filter((event) => attributionEventStore.confirms(event, {
       rootDir,
       rootInput,
       commitSha: mutationCommitSha,
       versionControlSystem: eventVcs
-    }));
-  const eventPaths = eventWrites.flatMap((write) => write.touchedPaths);
-  const attributionCommitSha = eventPaths.length > 0
-    ? commitTouchedPaths(
-      rootDir,
-      eventPaths,
-      eventWrites.map((write) => write.event.opId),
-      rootInput,
-      `attribution trail: ${eventWrites.map((write) => write.event.opId).join(",")}`,
-      sessionId,
-      { author: commitAuthor, versionControlSystem }
-    )
-    : mutationCommitSha;
-  const confirmedAttributionOpIds = new Set(eventWrites
-    .filter((write) => attributionEventStore.confirms(write.event, {
-      rootDir,
-      rootInput,
-      commitSha: attributionCommitSha,
-      versionControlSystem: eventVcs
     }))
-    .map((write) => write.event.opId));
-  if (confirmedAttributionOpIds.size !== eventWrites.length) {
+    .map((event) => event.opId));
+  if (mutationWillCommit && confirmedAttributionOpIds.size !== eventWrites.length) {
     throw new Error("attribution event durability confirmation failed");
   }
   const projectionHash = committedOpIds.length > 0
@@ -358,7 +356,7 @@ function flushRecords(
     const fullWatermark = {
       schema: "write-watermark/v1",
       lastCommittedOpIds: allCommitted,
-      lastCommitSha: attributionCommitSha,
+      lastCommitSha: mutationCommitSha,
       projectionHash,
       updatedAt: new Date().toISOString()
     } satisfies WriteWatermark;

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -27,6 +27,7 @@ import { assertCommitPlanAddable, commitTouchedPaths } from "./write-journal-git
 import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
 import { assertCodeDocGitEvidence, assertNoUncoordinatedCodeDocChange } from "./write-journal-code-doc-policy.ts";
 import { runLedgerMaterializer } from "./ledger-materializer.ts";
+import { makeLocalGitAttributionEventStore, type AttributionEventStore } from "./write-journal-attribution-events.ts";
 import { assertDirectWriteAllowed, withRepoLocks, WriteLockHeldError } from "./write-journal-locks.ts";
 import { NonTaskWriteEntityError, taskIdForJournalRecord } from "./write-journal-entity.ts";
 import { rejectWrite, WriteRejectedError } from "./write-journal-rejection.ts";
@@ -95,6 +96,7 @@ function makeJournaledWriteCoordinatorInternal(
   const heldGlobalLock = options.heldGlobalLock;
   const commitAuthor = options.commitAuthor;
   const versionControlSystem = options.versionControlSystem;
+  const attributionEventStore = options.attributionEventStore ?? makeLocalGitAttributionEventStore();
   const sessionId = cleanSessionId(options.sessionId);
   const autoMaterialize = options.autoMaterialize ?? true;
   const pending: WriteOp[] = [];
@@ -103,7 +105,7 @@ function makeJournaledWriteCoordinatorInternal(
       const state = readDurableState(journalPath, watermarkPath, rootDir);
       pending.splice(0, pending.length);
       const pendingRecords = uniquePendingRecords(state.records, state.applied);
-      return flushRecords(reason, rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor, versionControlSystem);
+      return flushRecords(reason, rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor, versionControlSystem, attributionEventStore);
     }, { heldGlobalLock }),
     catch: (cause): WriteError => toJournalError(cause)
   });
@@ -111,7 +113,7 @@ function makeJournaledWriteCoordinatorInternal(
     try: (): RecoveryReport => withRepoLocks(rootDir, runtimeContext, journalPath, operationalActor, lockTtlMs, [], () => {
       const state = readDurableState(journalPath, watermarkPath, rootDir);
       const pendingRecords = uniquePendingRecords(state.records, state.applied);
-      const report = flushRecords("recovery", rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor, versionControlSystem);
+      const report = flushRecords("recovery", rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor, versionControlSystem, attributionEventStore);
       return {
         replayedOps: report.opCount,
         recoveredWatermark: report.watermark
@@ -278,7 +280,8 @@ function flushRecords(
   fileApplied: ReadonlySet<string>,
   sessionId?: string,
   commitAuthor?: GitCommitAuthor,
-  versionControlSystem?: VersionControlSystem
+  versionControlSystem?: VersionControlSystem,
+  attributionEventStore: AttributionEventStore = makeLocalGitAttributionEventStore()
 ): FlushReport {
   const touchedPaths: string[] = [];
   const committedOpIds: string[] = [];
@@ -300,7 +303,7 @@ function flushRecords(
     committedOpIds.push(record.opId);
   }
 
-  const lastCommitSha = commitTouchedPaths(
+  const mutationCommitSha = commitTouchedPaths(
     rootDir,
     touchedPaths,
     committedOpIds,
@@ -312,6 +315,38 @@ function flushRecords(
       versionControlSystem
     }
   );
+  const eventVcs = versionControlSystem ?? makeLocalVersionControlSystem();
+  const eventWrites = plannedRecords
+    .filter((entry): entry is typeof entry & { readonly record: Extract<ReadableJournalRecord, { readonly schema: "write-journal/v2" }> } => entry.record.schema === "write-journal/v2")
+    .map(({ record }) => attributionEventStore.ensure(record, {
+      rootDir,
+      rootInput,
+      commitSha: mutationCommitSha,
+      versionControlSystem: eventVcs
+    }));
+  const eventPaths = eventWrites.flatMap((write) => write.touchedPaths);
+  const attributionCommitSha = eventPaths.length > 0
+    ? commitTouchedPaths(
+      rootDir,
+      eventPaths,
+      eventWrites.map((write) => write.event.opId),
+      rootInput,
+      `attribution trail: ${eventWrites.map((write) => write.event.opId).join(",")}`,
+      sessionId,
+      { author: commitAuthor, versionControlSystem }
+    )
+    : mutationCommitSha;
+  const confirmedAttributionOpIds = new Set(eventWrites
+    .filter((write) => attributionEventStore.confirms(write.event, {
+      rootDir,
+      rootInput,
+      commitSha: attributionCommitSha,
+      versionControlSystem: eventVcs
+    }))
+    .map((write) => write.event.opId));
+  if (confirmedAttributionOpIds.size !== eventWrites.length) {
+    throw new Error("attribution event durability confirmation failed");
+  }
   const projectionHash = committedOpIds.length > 0
     ? rebuildProjectionHash(rootDir, rootInput, touchedPaths, previousProjectionSourceHash)
     : previousWatermark?.projectionHash ?? "no-projection-change";
@@ -323,12 +358,12 @@ function flushRecords(
     const fullWatermark = {
       schema: "write-watermark/v1",
       lastCommittedOpIds: allCommitted,
-      lastCommitSha,
+      lastCommitSha: attributionCommitSha,
       projectionHash,
       updatedAt: new Date().toISOString()
     } satisfies WriteWatermark;
     writeWatermarkDurably(watermarkPath, fullWatermark);
-    if (tryCompactJournal(journalPath, new Set(allCommitted)) && recentCommitted.length < allCommitted.length) {
+    if (tryCompactJournal(journalPath, new Set(allCommitted), confirmedAttributionOpIds) && recentCommitted.length < allCommitted.length) {
       writeWatermarkDurably(watermarkPath, {
         ...fullWatermark,
         lastCommittedOpIds: recentCommitted,
@@ -480,9 +515,9 @@ function recentOpIds(opIds: ReadonlyArray<string>): ReadonlyArray<string> {
   return opIds.slice(-maxWatermarkCommittedOpIds);
 }
 
-function tryCompactJournal(journalPath: string, coveredOpIds: ReadonlySet<string>): boolean {
+function tryCompactJournal(journalPath: string, coveredOpIds: ReadonlySet<string>, confirmedAttributionOpIds: ReadonlySet<string>): boolean {
   try {
-    compactJournalDurably(journalPath, coveredOpIds);
+    compactJournalDurably(journalPath, coveredOpIds, confirmedAttributionOpIds);
     return true;
   } catch {
     // Compaction is an optimization. The watermark is authoritative for replay,
@@ -491,7 +526,7 @@ function tryCompactJournal(journalPath: string, coveredOpIds: ReadonlySet<string
   }
 }
 
-function compactJournalDurably(journalPath: string, coveredOpIds: ReadonlySet<string>): void {
+function compactJournalDurably(journalPath: string, coveredOpIds: ReadonlySet<string>, confirmedAttributionOpIds: ReadonlySet<string>): void {
   if (!existsSync(journalPath)) return;
   const body = readFileSync(journalPath, "utf8");
   if (body.trim().length === 0) return;
@@ -502,6 +537,7 @@ function compactJournalDurably(journalPath: string, coveredOpIds: ReadonlySet<st
     .filter((line) => {
       const parsed = JSON.parse(line) as Partial<ReadableJournalRecord | LockTakeoverRecord | DeleteAuditRecord | ApplyMarkerRecord>;
       if (parsed.schema !== "write-journal/v1" && parsed.schema !== "write-journal/v2" && parsed.schema !== "apply-marker/v1") return true;
+      if (parsed.schema === "write-journal/v2" && typeof parsed.opId === "string" && !confirmedAttributionOpIds.has(parsed.opId)) return true;
       return typeof parsed.opId !== "string" || !coveredOpIds.has(parsed.opId);
     });
   writeFileDurably(journalPath, retained.length === 0 ? "" : `${retained.join("\n")}\n`);

--- a/packages/kernel/src/store/write-journal-durable.ts
+++ b/packages/kernel/src/store/write-journal-durable.ts
@@ -113,6 +113,25 @@ export function appendJsonLineDurably(filePath: string, value: JournalRecord | J
   }
 }
 
+export function appendImmutableJsonLineDurably(filePath: string, value: object): boolean {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  let fd: number;
+  try {
+    fd = openSync(filePath, "wx");
+  } catch (error) {
+    if (existsSync(filePath)) return false;
+    throw error;
+  }
+  try {
+    writeSync(fd, `${JSON.stringify(value)}\n`, null, "utf8");
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  fsyncDirectory(path.dirname(filePath));
+  return true;
+}
+
 function journalLineSchema(value: unknown): unknown {
   return typeof value === "object" && value !== null && "schema" in value
     ? value.schema

--- a/packages/kernel/src/store/write-journal-types.ts
+++ b/packages/kernel/src/store/write-journal-types.ts
@@ -1,6 +1,7 @@
 import type { EntityId, TaskId } from "../domain/index.ts";
 import type { HarnessLayoutOverrides } from "../layout/index.ts";
 import type { VersionControlSystem } from "../ports/version-control-system.ts";
+import type { AttributionEventStore } from "./write-journal-attribution-events.ts";
 import type { WriteOp } from "../ports/write-coordinator.ts";
 import type { ActorAxes, AgentRef, OperationalActor, WriteAttribution } from "../schemas/actor-attribution.ts";
 export type { OperationalActor } from "../schemas/actor-attribution.ts";
@@ -23,6 +24,7 @@ export interface JournaledWriteCoordinatorOptions {
   readonly autoMaterialize?: boolean;
   readonly commitAuthor?: GitCommitAuthor;
   readonly versionControlSystem?: VersionControlSystem;
+  readonly attributionEventStore?: AttributionEventStore;
 }
 
 export type JournalRecoveryOptions = Omit<JournaledWriteCoordinatorOptions, "attribution">;

--- a/packages/kernel/test/contracts/dual-axis-attribution-schema.test.ts
+++ b/packages/kernel/test/contracts/dual-axis-attribution-schema.test.ts
@@ -10,6 +10,7 @@ import {
   WriteAttributionSchema
 } from "../../src/schemas/actor-attribution.ts";
 import { RuntimeEventRecordV2Schema } from "../../src/schemas/runtime-event.ts";
+import { AttributionEventSchema } from "../../src/schemas/attribution-event.ts";
 import { JournalRecordV2Schema } from "../../src/schemas/write-journal.ts";
 
 const fixtureRoot = "packages/kernel/fixtures/schemas/write-journal-op";
@@ -60,6 +61,35 @@ test("write attribution enforces executor/source correspondence", () => {
     principalSource: source,
     executorSource: "client-asserted"
   }));
+});
+
+test("immutable attribution event reuses actor axes and enforces source correspondence", () => {
+  const decode = Schema.decodeUnknownSync(AttributionEventSchema);
+  const event = {
+    schema: "attribution-event/v1",
+    eventId: "attribution:op-schema",
+    opId: "op-schema",
+    journalRecordSchema: "write-journal/v2",
+    entityId: "task/task-schema",
+    kind: "doc_write",
+    actor: {
+      principal: { kind: "person", personId: "person_zeyu" },
+      executor: { kind: "agent", id: "codex" }
+    },
+    principalSource: {
+      kind: "local-configured",
+      authority: "harness.yaml",
+      authoritySha256: "sha256:fixture"
+    },
+    executorSource: "client-asserted",
+    at: "2026-07-13T00:00:00.000Z",
+    mutationCommitSha: "commit-schema",
+    payloadHash: "payload-schema",
+    payloadRef: { path: ".harness/write-journal/payloads/op-schema.json", sha256: "sha256:payload" }
+  } as const;
+
+  assert.deepEqual(decode(event).actor, Schema.decodeUnknownSync(ActorAxesSchema)(event.actor));
+  assert.throws(() => decode({ ...event, executorSource: "none" }));
 });
 
 test("governed invalid fixtures fail closed", () => {

--- a/packages/kernel/test/contracts/dual-axis-attribution-schema.test.ts
+++ b/packages/kernel/test/contracts/dual-axis-attribution-schema.test.ts
@@ -83,7 +83,6 @@ test("immutable attribution event reuses actor axes and enforces source correspo
     },
     executorSource: "client-asserted",
     at: "2026-07-13T00:00:00.000Z",
-    mutationCommitSha: "commit-schema",
     payloadHash: "payload-schema",
     payloadRef: { path: ".harness/write-journal/payloads/op-schema.json", sha256: "sha256:payload" }
   } as const;

--- a/packages/kernel/test/store/attribution-event-store.test.ts
+++ b/packages/kernel/test/store/attribution-event-store.test.ts
@@ -1,0 +1,169 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import {
+  makeJournaledWriteCoordinator,
+  rebuildTaskProjection
+} from "../../src/index.ts";
+import { readAttributionProjection } from "../../src/projection/sqlite-attribution-projection.ts";
+import type { AttributionEventStore } from "../../src/store/write-journal-attribution-events.ts";
+import { makeLocalGitAttributionEventStore } from "../../src/store/write-journal-attribution-events.ts";
+import { readAttributionEvents } from "../../src/local/attribution-event-source.ts";
+import { readJournal } from "../../src/store/write-journal-durable.ts";
+import { testWriteAttribution } from "../test-attribution.ts";
+import { docWrite, withTempStore } from "./helpers.ts";
+
+test("attribution event is idempotent by opId and preserves every WAL attribution field", () => {
+  withTempStore((rootDir) => {
+    initializeAttributionGit(rootDir);
+    const attribution = testWriteAttribution();
+    const coordinator = makeJournaledWriteCoordinator({ rootDir, attribution });
+    const op = docWrite("op-attribution-fields", "task-fields", "progress.md", "field evidence\n");
+
+    Effect.runSync(coordinator.enqueue(op));
+    const journalRecord = readJournal(path.join(rootDir, ".harness/write-journal/writes.jsonl"), rootDir)[0]!;
+    assert.equal(journalRecord.schema, "write-journal/v2");
+    Effect.runSync(coordinator.flush("explicit"));
+
+    const event = readAttributionEvents(rootDir)[0]!;
+    assert.deepEqual({
+      opId: event.opId,
+      entityId: event.entityId,
+      kind: event.kind,
+      actor: event.actor,
+      principalSource: event.principalSource,
+      executorSource: event.executorSource,
+      at: event.at,
+      payloadHash: event.payloadHash,
+      payloadRef: event.payloadRef
+    }, {
+      opId: journalRecord.opId,
+      entityId: journalRecord.entityId,
+      kind: journalRecord.kind,
+      actor: journalRecord.actor,
+      principalSource: journalRecord.principalSource,
+      executorSource: journalRecord.executorSource,
+      at: journalRecord.at,
+      payloadHash: journalRecord.payload?.payloadHash,
+      payloadRef: journalRecord.payloadRef
+    });
+
+    const replay = makeJournaledWriteCoordinator({ rootDir, attribution });
+    Effect.runSync(replay.enqueue(op));
+    assert.equal(Effect.runSync(replay.flush("explicit")).opCount, 0);
+    assert.equal(readAttributionEvents(rootDir).length, 1);
+    assert.equal(readdirSync(path.join(rootDir, "harness/attribution-events")).length, 1);
+  });
+});
+
+test("crash before event append retains WAL until recovery confirms the immutable event", () => {
+  withTempStore((rootDir) => {
+    initializeAttributionGit(rootDir);
+    const failingStore = failEventStore("before");
+    const crashed = makeJournaledWriteCoordinator({ rootDir, attribution: testWriteAttribution(), attributionEventStore: failingStore });
+    Effect.runSync(crashed.enqueue(docWrite("op-crash-before-event", "task-crash-before", "progress.md", "before\n")));
+
+    const result = Effect.runSync(Effect.either(crashed.flush("explicit")));
+    assert.equal(result._tag, "Left");
+    assert.match(readFileSync(path.join(rootDir, ".harness/write-journal/writes.jsonl"), "utf8"), /op-crash-before-event/u);
+    assert.equal(readAttributionEvents(rootDir).length, 0);
+
+    Effect.runSync(makeJournaledWriteCoordinator({ rootDir, attribution: testWriteAttribution() }).recover);
+    assert.equal(readFileSync(path.join(rootDir, ".harness/write-journal/writes.jsonl"), "utf8"), "");
+    assert.equal(readAttributionEvents(rootDir)[0]?.opId, "op-crash-before-event");
+  });
+});
+
+test("crash after event append retains WAL, then recovery commits the event and compacts", () => {
+  withTempStore((rootDir) => {
+    initializeAttributionGit(rootDir);
+    const failingStore = failEventStore("after");
+    const crashed = makeJournaledWriteCoordinator({ rootDir, attribution: testWriteAttribution(), attributionEventStore: failingStore });
+    Effect.runSync(crashed.enqueue(docWrite("op-crash-after-event", "task-crash-after", "progress.md", "after\n")));
+
+    const result = Effect.runSync(Effect.either(crashed.flush("explicit")));
+    assert.equal(result._tag, "Left");
+    assert.match(readFileSync(path.join(rootDir, ".harness/write-journal/writes.jsonl"), "utf8"), /op-crash-after-event/u);
+    assert.equal(readAttributionEvents(rootDir)[0]?.opId, "op-crash-after-event");
+
+    Effect.runSync(makeJournaledWriteCoordinator({ rootDir, attribution: testWriteAttribution() }).recover);
+    assert.equal(readFileSync(path.join(rootDir, ".harness/write-journal/writes.jsonl"), "utf8"), "");
+    assert.match(attributionGit(rootDir, "log", "--oneline", "--", "attribution-events"), /attribution trail/u);
+    assert.equal(readAttributionEvents(rootDir).length, 1);
+  });
+});
+
+test("deleting WAL and SQLite rebuilds identical attribution rows only from event SoT", () => {
+  withTempStore((rootDir) => {
+    initializeAttributionGit(rootDir);
+    const attribution = testWriteAttribution();
+    const coordinator = makeJournaledWriteCoordinator({ rootDir, attribution });
+    Effect.runSync(coordinator.enqueue(docWrite("op-rebuild-one", "task-rebuild", "one.md", "one\n")));
+    Effect.runSync(coordinator.enqueue(docWrite("op-rebuild-two", "task-rebuild", "two.md", "two\n")));
+    Effect.runSync(coordinator.flush("explicit"));
+
+    rebuildTaskProjection({ rootDir });
+    const before = readAttributionProjection(rootDir);
+    const journalPath = path.join(rootDir, ".harness/write-journal/writes.jsonl");
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    rmSync(journalPath, { force: true });
+    rmSync(projectionPath, { force: true });
+    assert.equal(existsSync(journalPath), false);
+    assert.equal(existsSync(projectionPath), false);
+
+    rebuildTaskProjection({ rootDir });
+    const after = readAttributionProjection(rootDir);
+    assert.deepEqual(after, before);
+    assert.equal(after.length, 2);
+    assert.deepEqual(after.map((row) => ({
+      actor: row.actor,
+      principalSource: row.principalSource,
+      executorSource: row.executorSource
+    })), [
+      { actor: attribution.actor, principalSource: attribution.principalSource, executorSource: attribution.executorSource },
+      { actor: attribution.actor, principalSource: attribution.principalSource, executorSource: attribution.executorSource }
+    ]);
+  });
+});
+
+function failEventStore(point: "before" | "after"): AttributionEventStore {
+  const delegate = makeLocalGitAttributionEventStore();
+  let failed = false;
+  return {
+    ...delegate,
+    ensure: (record, context) => {
+      if (!failed && point === "before") {
+        failed = true;
+        throw new Error("simulated crash before attribution event append");
+      }
+      const write = delegate.ensure(record, context);
+      if (!failed && point === "after") {
+        failed = true;
+        throw new Error("simulated crash after attribution event append");
+      }
+      return write;
+    }
+  };
+}
+
+function initializeAttributionGit(rootDir: string): void {
+  const harnessRoot = path.join(rootDir, "harness");
+  mkdirSync(harnessRoot, { recursive: true });
+  execFileSync("git", ["-C", harnessRoot, "init", "-b", "main"], { stdio: "ignore" });
+  execFileSync("git", ["-C", harnessRoot, "config", "user.name", "Harness Test"], { stdio: "ignore" });
+  execFileSync("git", ["-C", harnessRoot, "config", "user.email", "harness@example.test"], { stdio: "ignore" });
+  writeFileSync(path.join(harnessRoot, ".gitkeep"), "", "utf8");
+  execFileSync("git", ["-C", harnessRoot, "add", "--", ".gitkeep"], { stdio: "ignore" });
+  execFileSync("git", ["-C", harnessRoot, "commit", "-m", "seed"], { stdio: "ignore" });
+}
+
+function attributionGit(rootDir: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", path.join(rootDir, "harness"), ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}

--- a/packages/kernel/test/store/attribution-event-store.test.ts
+++ b/packages/kernel/test/store/attribution-event-store.test.ts
@@ -63,6 +63,7 @@ test("attribution event is idempotent by opId and preserves every WAL attributio
 test("crash before event append retains WAL until recovery confirms the immutable event", () => {
   withTempStore((rootDir) => {
     initializeAttributionGit(rootDir);
+    const seedHead = attributionGit(rootDir, "rev-parse", "HEAD");
     const failingStore = failEventStore("before");
     const crashed = makeJournaledWriteCoordinator({ rootDir, attribution: testWriteAttribution(), attributionEventStore: failingStore });
     Effect.runSync(crashed.enqueue(docWrite("op-crash-before-event", "task-crash-before", "progress.md", "before\n")));
@@ -71,16 +72,20 @@ test("crash before event append retains WAL until recovery confirms the immutabl
     assert.equal(result._tag, "Left");
     assert.match(readFileSync(path.join(rootDir, ".harness/write-journal/writes.jsonl"), "utf8"), /op-crash-before-event/u);
     assert.equal(readAttributionEvents(rootDir).length, 0);
+    assert.equal(attributionGit(rootDir, "rev-parse", "HEAD"), seedHead);
 
     Effect.runSync(makeJournaledWriteCoordinator({ rootDir, attribution: testWriteAttribution() }).recover);
     assert.equal(readFileSync(path.join(rootDir, ".harness/write-journal/writes.jsonl"), "utf8"), "");
     assert.equal(readAttributionEvents(rootDir)[0]?.opId, "op-crash-before-event");
+    assert.match(attributionGit(rootDir, "log", "--oneline", "-1"), /task\(doc\): task-crash-before progress\.md \[op-crash-before-event\]/u);
+    assert.equal(attributionGit(rootDir, "rev-list", "--count", "HEAD"), "2");
   });
 });
 
-test("crash after event append retains WAL, then recovery commits the event and compacts", () => {
+test("crash after event append retains WAL, then recovery commits mutation and event together", () => {
   withTempStore((rootDir) => {
     initializeAttributionGit(rootDir);
+    const seedHead = attributionGit(rootDir, "rev-parse", "HEAD");
     const failingStore = failEventStore("after");
     const crashed = makeJournaledWriteCoordinator({ rootDir, attribution: testWriteAttribution(), attributionEventStore: failingStore });
     Effect.runSync(crashed.enqueue(docWrite("op-crash-after-event", "task-crash-after", "progress.md", "after\n")));
@@ -89,10 +94,12 @@ test("crash after event append retains WAL, then recovery commits the event and 
     assert.equal(result._tag, "Left");
     assert.match(readFileSync(path.join(rootDir, ".harness/write-journal/writes.jsonl"), "utf8"), /op-crash-after-event/u);
     assert.equal(readAttributionEvents(rootDir)[0]?.opId, "op-crash-after-event");
+    assert.equal(attributionGit(rootDir, "rev-parse", "HEAD"), seedHead);
 
     Effect.runSync(makeJournaledWriteCoordinator({ rootDir, attribution: testWriteAttribution() }).recover);
     assert.equal(readFileSync(path.join(rootDir, ".harness/write-journal/writes.jsonl"), "utf8"), "");
-    assert.match(attributionGit(rootDir, "log", "--oneline", "--", "attribution-events"), /attribution trail/u);
+    assert.match(attributionGit(rootDir, "log", "--oneline", "-1"), /task\(doc\): task-crash-after progress\.md \[op-crash-after-event\]/u);
+    assert.equal(attributionGit(rootDir, "rev-list", "--count", "HEAD"), "2");
     assert.equal(readAttributionEvents(rootDir).length, 1);
   });
 });

--- a/packages/kernel/test/store/ledger-materializer.test.ts
+++ b/packages/kernel/test/store/ledger-materializer.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
 import { makeJournaledWriteCoordinator, runLedgerMaterializer } from "../../src/store/index.ts";
+import { readAttributionProjection } from "../../src/projection/sqlite-attribution-projection.ts";
 import { docWrite, withTempStore } from "./helpers.ts";
 
 test("WriteCoordinator commits session-routed writes to a session branch", () => {
@@ -53,6 +54,8 @@ test("ledger materializer dry-runs and merges pending session branches", () => {
     assert.equal(git(rootDir, "branch", "--list", "sessions/codex-session-2"), "");
     assert.equal(git(rootDir, "rev-parse", "--abbrev-ref", "HEAD"), "master");
     assert.equal(readGitFile(rootDir, "tasks/task-2/note.md"), "materialized write\n");
+    assert.equal(merged.attributionEventsProjected, 1);
+    assert.equal(readAttributionProjection(rootDir)[0]?.opId, "op-materialize");
   });
 });
 

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -6,7 +6,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
-import { hashTaskProjectionRows, rebuildTaskProjection } from "../../src/index.ts";
+import { hashTaskProjectionRows, rebuildTaskProjection, sha256Text } from "../../src/index.ts";
 import { makeJournaledWriteCoordinator } from "../../src/store/index.ts";
 import { resolveCommitPlan } from "../../src/store/write-journal-git.ts";
 import { moduleEntityId, taskEntityId } from "../../src/domain/index.ts";
@@ -373,7 +373,10 @@ test("WriteCoordinator commits self-host authored writes inside ignored nested h
     assert.equal(report.watermark, "op-nested");
     assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-1/notes.md"), "utf8"), "nested");
     assert.match(runGit(path.join(rootDir, "harness"), "log", "--oneline", "-1"), /task\(doc\): task-1 notes\.md \[op-nested\]/);
-    assert.equal(runGit(path.join(rootDir, "harness"), "show", "--name-only", "--format=", "HEAD"), "tasks/task-1/notes.md");
+    assert.equal(runGit(path.join(rootDir, "harness"), "show", "--name-only", "--format=", "HEAD"), [
+      `attribution-events/${sha256Text("op-nested")}.jsonl`,
+      "tasks/task-1/notes.md"
+    ].join("\n"));
     assert.equal(runGit(path.join(rootDir, "harness"), "status", "--short"), "M notes/unrelated.md");
     assert.equal(runGit(rootDir, "status", "--short"), "");
     assert.equal(existsSync(path.join(rootDir, ".harness/write-journal/watermark.json")), true);
@@ -450,6 +453,8 @@ test("WriteCoordinator records nested harness HEAD when self-host flush has no s
     };
 
     assert.equal(watermark.lastCommitSha, nestedHead);
+    assert.equal(runGit(harnessRoot, "rev-parse", "HEAD"), nestedHead);
+    assert.equal(existsSync(path.join(harnessRoot, "attribution-events")), false);
   });
 });
 

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -59,6 +59,11 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
+        "value": "packages/kernel/src/store/write-journal-durable.ts#closeSync@4",
+        "ref": "task_01KXBDH7PQ41C66KFSA01ENG7N",
+        "reason": "ADR-0028 P5 coordinator-owned immutable attribution event append closes its exclusive shard descriptor after fsync; this permanent trail is not a bypass caller."
+      },
+      {
         "value": "packages/kernel/src/store/write-journal-durable.ts#fsyncSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
@@ -74,6 +79,11 @@
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
       },
       {
+        "value": "packages/kernel/src/store/write-journal-durable.ts#fsyncSync@4",
+        "ref": "task_01KXBDH7PQ41C66KFSA01ENG7N",
+        "reason": "ADR-0028 P5 coordinator-owned immutable attribution event append fsyncs each exclusive shard before the event can confirm WAL compaction safety."
+      },
+      {
         "value": "packages/kernel/src/store/write-journal-durable.ts#mkdirSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
@@ -82,6 +92,11 @@
         "value": "packages/kernel/src/store/write-journal-durable.ts#mkdirSync@2",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
+      },
+      {
+        "value": "packages/kernel/src/store/write-journal-durable.ts#mkdirSync@3",
+        "ref": "task_01KXBDH7PQ41C66KFSA01ENG7N",
+        "reason": "ADR-0028 P5 coordinator-owned immutable attribution event store creates its Git-authored shard directory before exclusive append."
       },
       {
         "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@1",
@@ -97,6 +112,11 @@
         "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
+      },
+      {
+        "value": "packages/kernel/src/store/write-journal-durable.ts#openSync@4",
+        "ref": "task_01KXBDH7PQ41C66KFSA01ENG7N",
+        "reason": "ADR-0028 P5 coordinator-owned immutable attribution event store uses exclusive create so an opId shard can never be overwritten or compacted."
       },
       {
         "value": "packages/kernel/src/store/write-journal-durable.ts#renameSync@1",
@@ -122,6 +142,11 @@
         "value": "packages/kernel/src/store/write-journal-durable.ts#writeSync@3",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C0 coordinator/flusher internal durable write path; this is the daemon-owned write implementation, not a bypass caller."
+      },
+      {
+        "value": "packages/kernel/src/store/write-journal-durable.ts#writeSync@4",
+        "ref": "task_01KXBDH7PQ41C66KFSA01ENG7N",
+        "reason": "ADR-0028 P5 coordinator-owned immutable attribution event store writes one permanent event line to an exclusive Git-authored shard."
       },
       {
         "value": "packages/kernel/src/store/write-journal-locks.ts#closeSync@1",

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -11,8 +11,8 @@
   ],
   "rowCountReconciliation": {
     "phase1FunctionalRows": 26,
-    "registryRows": 35,
-    "difference": "Seven additional rows split mixed write functions and infrastructure: module canonical/view, runtime-event coordinated/direct, script declared writes/produces, worktree code/binding, task-holder runtime state, one WriteCoordinator runtime substrate row, and the Fact-to-Execution administrative migration road. Two further ADR-0028 P4 rows register the attributed doc_sync_submit coordinator road and the preset script staging-mirror ingest road."
+    "registryRows": 36,
+    "difference": "Seven additional rows split mixed write functions and infrastructure: module canonical/view, runtime-event coordinated/direct, script declared writes/produces, worktree code/binding, task-holder runtime state, one WriteCoordinator runtime substrate row, and the Fact-to-Execution administrative migration road. Two further ADR-0028 P4 rows register the attributed doc_sync_submit coordinator road and the preset script staging-mirror ingest road. One ADR-0028 P5 row registers the coordinator-owned immutable attribution event trail."
   },
   "rows": [
     {
@@ -120,6 +120,20 @@
       ],
       "evidence": ["packages/kernel/src/write-coordination/write-helpers.ts:20", "packages/kernel/src/store/write-journal-durable.ts:109", "packages/kernel/src/store/write-journal-locks.ts:125"],
       "freshness": "wal-lock-and-atomic-flush"
+    },
+    {
+      "id": "attribution.event.immutable-store",
+      "sourceInventoryRows": [1],
+      "road": "A",
+      "bearing": "attribution-audit",
+      "leaseRequired": false,
+      "channel": { "pathClass": "coordinator-authored", "zoneClass": "immutable-attribution-event-trail" },
+      "entry": ["write-coordinator", "ledger-materializer"],
+      "directWrites": [
+        { "file": "packages/kernel/src/store/write-journal-durable.ts" }
+      ],
+      "evidence": ["packages/kernel/src/store/write-journal-attribution-events.ts:28", "packages/kernel/src/store/write-journal-durable.ts:117"],
+      "freshness": "append-only-op-id-shard"
     },
     {
       "id": "task.migration.backfill",


### PR DESCRIPTION
# English

## Summary

ADR-0028 Phase 5: physically separate the compactable crash-recovery WAL from an immutable, append-only attribution event store. Dual-axis attribution (principal person + executor agent) previously lived only in the WAL, which `compactJournalDurably` deletes once the watermark covers it — so the permanent trail required by `dec_mrd7jiux` was being destroyed on compaction. P5 introduces a Git-authored, append-only, never-compacted attribution event shard produced by the same `opId` as the WAL record, gates WAL compaction on durable confirmation of that event, and teaches the materializer to rebuild the attribution projection from the event source of truth. Core acceptance: after deleting the WAL and the SQLite projection, dual-axis attribution rebuilds byte-identically from the immutable event SoT alone.

## What Changed

- New `attribution-event/v1` schema reusing the single-source `ActorAxes` / source / write-kind schemas.
- New immutable attribution event store (`write-journal-attribution-events.ts`): switchable `AttributionEventStore` interface + local Git shard impl; one `sha256(opId)` shard per op, exclusive-create, idempotent, no compaction API.
- New Git-authored `attribution-events` root under `authoredRoot` (committed SoT, survives WAL deletion).
- Coordinator flush: after the entity-mutation commit it ensures + commits + confirms the attribution event per v2 record, then only compacts WAL rows whose event is confirmed durable (`compactJournalDurably` gate). Operational v1 flow untouched.
- Materializer gains a second responsibility: project the `attribution_events` table from the event SoT (`sqlite-attribution-projection.ts`), alongside existing session-branch merging.
- Task-projection rebuild + freshness hash now include the immutable event source, so a deleted SQLite projection rebuilds attribution from events.
- Governance data registration: one write-road-registry row for the event trail; five durable-append calls registered in the bypass-write-boundary allowlist with P5 rationale.

## Task And Scope

- Harness task: task_01KXBDH7PQ41C66KFSA01ENG7N (P5)
- Branch: feat/dual-axis-p5-event-store
- Public scope: `packages/kernel/**` (store/projection/schemas/layout/local) + `tools/write-road-registry.json` + `tools/gate-allowlists/check-bypass-write-boundary.json`
- Private planning/evidence updated: yes (task_plan / mission / report in private harness ledger)
- Out of scope: runtime-event/lease convergence (P6), projection backfill + legacy-field retirement (P7)

## Version Impact

- Version: no version change because this is an internal kernel storage-layer addition, no CLI surface or published contract change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/write-road-registry.json` (new registered write surface for the event trail) and `tools/gate-allowlists/check-bypass-write-boundary.json` (five durable-append calls for the coordinator-owned immutable event store)
- Authority: ADR-0028 §D2 — the immutable attribution event store is a newly introduced load-bearing write surface; the ADR is its governance basis. This registers a new governed write; it does not weaken, bypass, or disable any gate.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 1246361b128aa58a51316c109c13117cf57dee45
- Branch merge-base with `origin/main`: 1246361b128aa58a51316c109c13117cf57dee45
- Last `git fetch origin` time: 2026-07-13 (just before PR)
- Sync method: none needed (branch base == current origin/main)
- Public diff command: `git diff origin/main..feat/dual-axis-p5-event-store -- packages/ tools/`
- Private evidence commit/path: harness/tasks/task_01KXBDH7PQ.../artifacts/p5-report-codex.md
- Reviewer evidence path: harness/tasks/task_01KXBDH7PQ.../review.md
- GitHub Actions `rewrite-ci` run URL: (populated by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (via `npm run check:local` fast tier, exit 0: 319 fast + 405 contract)
- [x] `npm run typecheck`
- [x] `npm test` (focused: attribution-event-store + materializer + schema + regression, 50/50; P5 store suite 7/7)
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] Boundaries manifest job (`check-write-road-registry` 36 rows / `check-bypass-write-boundary` 133 governed calls / `check-duplicate-definitions` / `check-cli-structure`), exit 0 — re-run independently by CEO
- Not run: full cloud integration + GUI shards (assigned to cloud CI by design)

## Review Evidence

- Self-review: worker crash-matrix + delete-and-rebuild tests pass; CEO independently re-ran check:local (56.5s exit 0) and boundaries manifest (exit 0)
- Reviewer subagent: not applicable (CEO semantic acceptance direct)
- Human review: CEO semantic acceptance vs ADR-0028 §D2 — compaction gate, event-store append-only/idempotent, materializer event-SoT rebuild, and delete-and-rebuild core acceptance all ground-truthed against source diff
- Blocking findings: none

## Residual Risk

- Central audit-store deployment is intentionally unimplemented; the switchable `AttributionEventStore` seam exists and the selected impl is the ADR-approved local Git shard. Central落点 tracked to multi-collab evolution.
- coordinator.ts (594) and sqlite-projection-store.ts (599) are close to the 600-line file-complexity cap; future edits to these files must budget lines or split.

## References

- Task: task_01KXBDH7PQ41C66KFSA01ENG7N
- Evidence: harness/tasks/task_01KXBDH7PQ.../artifacts/p5-report-codex.md
- Review: harness/tasks/task_01KXBDH7PQ.../review.md

---

# 中文

## 概要

ADR-0028 Phase 5：把可 compact 的崩溃恢复 WAL 与 **immutable、append-only 归属事件存储**物理分离。双轴归属（principal 人 + executor agent）此前只活在 WAL 里，而 `compactJournalDurably` 在 watermark 覆盖后会删掉这些行——`dec_mrd7jiux` 要求的永久 trail 因此在 compact 时被物理销毁。P5 引入一条 Git-authored、append-only、永不 compact 的归属事件 shard，与 WAL 记录由同一 `opId` 产生；WAL compact 以该事件的持久确认为前置门；materializer 学会从事件 SoT 重建归属投影。**核心验收：删掉 WAL 和 SQLite 投影后，双轴归属仅凭 immutable 事件 SoT 逐字段一致重建。**

## 改动内容

- 新增 `attribution-event/v1` schema，复用单源 `ActorAxes` / source / write-kind。
- 新增 immutable 归属事件存储（`write-journal-attribution-events.ts`）：可切换 `AttributionEventStore` 接口 + 本地 Git shard 实现；每 op 一个 `sha256(opId)` shard、exclusive-create、幂等、无 compaction API。
- 新增 Git-authored `attribution-events` 根（挂在 `authoredRoot` 下，进版本控制、survive WAL 删除）。
- Coordinator flush：实体 mutation commit 后，对每条 v2 记录 ensure + commit + confirm 归属事件，然后只 compact 那些事件已确认持久的 WAL 行（`compactJournalDurably` 门）。operational v1 路径不动。
- Materializer 增加第二职责：从事件 SoT 物化 `attribution_events` 表（`sqlite-attribution-projection.ts`），与既有 session 分支 merge 并存。
- task 投影 rebuild + freshness hash 纳入 immutable 事件源，删掉 SQLite 投影后归属可从事件重建。
- 治理数据登记：write-road-registry 加一行事件 trail；bypass-write-boundary allowlist 登记五处 durable-append 调用（带 P5 rationale）。

## 任务与范围

- Harness 任务：task_01KXBDH7PQ41C66KFSA01ENG7N（P5）
- 分支：feat/dual-axis-p5-event-store
- 公开范围：`packages/kernel/**`（store/projection/schemas/layout/local）+ `tools/write-road-registry.json` + `tools/gate-allowlists/check-bypass-write-boundary.json`
- 私有计划 / 证据是否已更新：yes（task_plan / mission / report 在私有 harness 账本）
- 范围外：runtime-event/lease 收敛（P6）、投影 backfill + 旧字段退场（P7）

## 版本影响

- 版本：不改版本，原因是这是 kernel 内部存储层新增，无 CLI 面或已发布契约变化。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/write-road-registry.json`（事件 trail 的新登记写面）与 `tools/gate-allowlists/check-bypass-write-boundary.json`（coordinator-owned immutable 事件存储的五处 durable-append 调用）
- 依据：ADR-0028 §D2——immutable 归属事件存储是新增承重写面，本 ADR 即其治理依据。此处是**登记一条新的受治理写入**，不削弱、不绕过、不禁用任何门。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：1246361b128aa58a51316c109c13117cf57dee45
- 当前分支与 `origin/main` 的 merge-base：1246361b128aa58a51316c109c13117cf57dee45
- 最近一次 `git fetch origin` 时间：2026-07-13（PR 前）
- 同步方式：不需要（分支基线 == 当前 origin/main）
- 公开 diff 命令：`git diff origin/main..feat/dual-axis-p5-event-store -- packages/ tools/`
- 私有证据 commit/path：harness/tasks/task_01KXBDH7PQ.../artifacts/p5-report-codex.md
- Reviewer 证据路径：harness/tasks/task_01KXBDH7PQ.../review.md
- GitHub Actions `rewrite-ci` run URL：（CI 在本 PR 上生成）
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`（经 `npm run check:local` fast tier，exit 0：319 fast + 405 contract）
- [x] `npm run typecheck`
- [x] `npm test`（聚焦：attribution-event-store + materializer + schema + 回归，50/50；P5 store 组 7/7）
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] Boundaries manifest job（`check-write-road-registry` 36 行 / `check-bypass-write-boundary` 133 受治理调用 / `check-duplicate-definitions` / `check-cli-structure`），exit 0——CEO 独立复跑
- 未运行：完整云端 integration + GUI shards（按设计交云端 CI）

## 审查证据

- 自查：worker crash-matrix + 删后重建测试通过；CEO 独立复跑 check:local（56.5s exit 0）与 boundaries manifest（exit 0）
- Reviewer subagent：不适用（CEO 直接语义验收）
- 人工审查：CEO 对照 ADR-0028 §D2 语义验收——compaction 门、事件存储 append-only/幂等、materializer 事件-SoT 重建、删后重建核心验收，全部对着源码 diff ground-truth
- 阻塞发现：无

## 残余风险

- 中心 audit-store 部署有意未实现；可切换 `AttributionEventStore` 接缝已在，选定实现为 ADR 批准的本地 Git shard。中心落点归多人协作演进。
- coordinator.ts（594）与 sqlite-projection-store.ts（599）逼近 600 行 file-complexity 上限；后续改这两个文件必须算行数预算或拆分。

## 关联材料

- 任务：task_01KXBDH7PQ41C66KFSA01ENG7N
- 证据：harness/tasks/task_01KXBDH7PQ.../artifacts/p5-report-codex.md
- 审查：harness/tasks/task_01KXBDH7PQ.../review.md
