### PR TITLE
feat: declare principals for attribution backfill (ADR-0028 P7b)

### DIFF
--- a/packages/cli/src/cli/command-spec/command-spec-migration-diagnostics.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-migration-diagnostics.ts
@@ -100,10 +100,10 @@ export const migrationDiagnosticsCommandSpecs = defineCommandSpecs([
   },
   {
     "kind": "migrate-attribution",
-    "usage": "migrate attribution [--dry-run|--apply --confirm-plan <id>] [--json]",
-    "options": [{"flag":"--dry-run","description":"Produce a deterministic attribution backfill report without writing; this is the default."},{"flag":"--apply","description":"Append only the exact-match migration events from the confirmed plan."},{"flag":"--confirm-plan","description":"Confirm the exact plan id returned by dry-run before applying."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
+    "usage": "migrate attribution [--dry-run|--apply --confirm-plan <id>] [--declare-principal <personId> --declare-authority <decision-id>] [--json]",
+    "options": [{"flag":"--dry-run","description":"Produce a deterministic attribution backfill report without writing; this is the default."},{"flag":"--apply","description":"Append the exact-match and explicitly declared migration events from the confirmed plan."},{"flag":"--confirm-plan","description":"Confirm the exact plan id returned by dry-run before applying."},{"flag":"--declare-principal","description":"One-time principal declaration; must name a person in harness/people.yaml and be paired with --declare-authority."},{"flag":"--declare-authority","description":"Decision id authorizing the one-time principal declaration; must be paired with --declare-principal."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
     "summary": "Plan or apply immutable synthetic attribution events for honest legacy matches.",
-    "examples": ["harness-anything migrate attribution --dry-run --json", "harness-anything migrate attribution --apply --confirm-plan abf_0123456789abcdef"],
+    "examples": ["harness-anything migrate attribution --dry-run --json", "harness-anything migrate attribution --dry-run --declare-principal person_zeyu --declare-authority dec_01KXC8A0H95BW8F3J56GP5DFYN --json", "harness-anything migrate attribution --apply --confirm-plan abf_0123456789abcdef"],
     "parse": parseMigrationArgs,
     "run": runMigrationCommand,
     "receiptContract": {

--- a/packages/cli/src/cli/error-codes.ts
+++ b/packages/cli/src/cli/error-codes.ts
@@ -1,5 +1,6 @@
 export const CliErrorCode = {
   ArchivedHardDeleteForbidden: "archived_hard_delete_forbidden",
+  AttributionDeclarationInvalid: "attribution_declaration_invalid",
   ArtifactReadFailed: "artifact_read_failed",
   ArtifactWriteRejected: "artifact_write_rejected",
   CiNotPassed: "ci_not_passed",
@@ -221,6 +222,7 @@ export interface CliErrorCodeDefinition {
 
 export const cliErrorCodeRegistry = {
   [CliErrorCode.ArchivedHardDeleteForbidden]: { category: "domain", defaultHint: "Archived tasks cannot be hard deleted." },
+  [CliErrorCode.AttributionDeclarationInvalid]: { category: "migration", defaultHint: "Attribution declaration requires a registered principal and explicit decision authority." },
   [CliErrorCode.ArtifactReadFailed]: { category: "domain", defaultHint: "Artifact read failed." },
   [CliErrorCode.ArtifactWriteRejected]: { category: "domain", defaultHint: "Artifact write was rejected." },
   [CliErrorCode.ArchiveReferenceUnresolved]: { category: "command", defaultHint: "Archive would leave a task-owned relation endpoint unresolved." },

--- a/packages/cli/src/cli/parse-migration-args.ts
+++ b/packages/cli/src/cli/parse-migration-args.ts
@@ -118,6 +118,17 @@ export function parseMigrationArgs(args: ReadonlyArray<string>, rootDir: string,
     if (migrateArgs.includes("--dry-run") && migrateArgs.includes("--apply")) {
       return { ok: false, error: cliError(CliErrorCode.ConflictingMigrationMode, "Use only one of --dry-run or --apply.") };
     }
+    const declarePrincipal = readOption(migrateArgs, "--declare-principal");
+    const declareAuthority = readOption(migrateArgs, "--declare-authority");
+    if ((declarePrincipal && !declareAuthority) || (!declarePrincipal && declareAuthority)) {
+      return {
+        ok: false,
+        error: cliError(
+          CliErrorCode.AttributionDeclarationInvalid,
+          "Use --declare-principal <personId> and --declare-authority <decision-id> together."
+        )
+      };
+    }
     return {
       ok: true,
       value: {
@@ -126,7 +137,8 @@ export function parseMigrationArgs(args: ReadonlyArray<string>, rootDir: string,
         action: {
           kind: "migrate-attribution",
           mode: migrateArgs.includes("--apply") ? "apply" : "dry-run",
-          confirmPlan: readOption(migrateArgs, "--confirm-plan")
+          confirmPlan: readOption(migrateArgs, "--confirm-plan"),
+          ...(declarePrincipal && declareAuthority ? { declarePrincipal, declareAuthority } : {})
         }
       }
     };

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -261,7 +261,7 @@ export interface ParsedCommand {
     | { readonly kind: "migrate-structure"; readonly mode: "plan" | "apply"; readonly confirmPlan: boolean }
     | { readonly kind: "migrate-anchors"; readonly mode: AnchorBackfillMode }
     | { readonly kind: "migrate-fact-execution"; readonly mode: "dry-run" | "apply"; readonly batchSize: number; readonly batch: number; readonly sampleSize: number; readonly confirmPlan?: string; readonly manualListFile?: string }
-    | { readonly kind: "migrate-attribution"; readonly mode: "dry-run" | "apply"; readonly confirmPlan?: string }
+    | { readonly kind: "migrate-attribution"; readonly mode: "dry-run" | "apply"; readonly confirmPlan?: string; readonly declarePrincipal?: string; readonly declareAuthority?: string }
     | { readonly kind: "migrate-provenance"; readonly mode: ProvenanceBackfillMode }
     | { readonly kind: "migrate-run"; readonly planOnly: boolean; readonly outDir: string; readonly locale?: "zh-CN" | "en-US"; readonly assumeLocale?: "zh-CN" | "en-US"; readonly allowDirty: boolean; readonly sessionDir?: string }
     | { readonly kind: "migrate-verify"; readonly sessionPath?: string; readonly fullCutover: boolean }

--- a/packages/cli/src/commands/attribution-backfill.ts
+++ b/packages/cli/src/commands/attribution-backfill.ts
@@ -1,12 +1,31 @@
 import { Effect } from "effect";
-import { applyAttributionBackfill, planAttributionBackfill } from "../../../kernel/src/index.ts";
+import { AttributionBackfillDeclarationError, applyAttributionBackfill, planAttributionBackfill } from "../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../cli/error-codes.ts";
 import type { CommandRunner } from "../cli/runner-registry.ts";
 import type { CliResult } from "../cli/types.ts";
 
 export const runMigrateAttribution: CommandRunner = (context, command) => Effect.sync(() => {
   const action = command.action as Extract<typeof command.action, { readonly kind: "migrate-attribution" }>;
-  const plan = planAttributionBackfill(context.layoutInput);
+  const declaration = action.declarePrincipal && action.declareAuthority
+    ? { personId: action.declarePrincipal, authority: action.declareAuthority }
+    : undefined;
+  let plan: ReturnType<typeof planAttributionBackfill>;
+  try {
+    plan = planAttributionBackfill(context.layoutInput, declaration);
+  } catch (error) {
+    if (!(error instanceof AttributionBackfillDeclarationError)) throw error;
+    return {
+      ok: false,
+      command: "migrate-attribution",
+      migrationMode: action.mode === "dry-run" ? "plan" : "apply",
+      rows: 0,
+      report: { mode: action.mode, appliedEvents: 0 },
+      error: cliError(
+        CliErrorCode.AttributionDeclarationInvalid,
+        error instanceof Error ? error.message : "Attribution declaration is invalid."
+      )
+    } satisfies CliResult;
+  }
   if (action.mode === "dry-run") return attributionBackfillResult("plan", plan, 0);
   if (action.confirmPlan !== plan.planId) {
     return {
@@ -21,7 +40,7 @@ export const runMigrateAttribution: CommandRunner = (context, command) => Effect
       )
     } satisfies CliResult;
   }
-  const applied = applyAttributionBackfill(context.layoutInput, action.confirmPlan);
+  const applied = applyAttributionBackfill(context.layoutInput, action.confirmPlan, declaration);
   return attributionBackfillResult("apply", applied.plan, applied.appliedEvents, applied.recordedAt);
 });
 

--- a/packages/cli/test/attribution-backfill-cli.test.ts
+++ b/packages/cli/test/attribution-backfill-cli.test.ts
@@ -5,12 +5,12 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, 
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { queryDecisionProjection, rebuildTaskProjection } from "../../kernel/src/index.ts";
+import { queryDecisionProjection, queryTaskProjection, rebuildTaskProjection } from "../../kernel/src/index.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
-test("attribution backfill dry-run is deterministic and apply emits only exact-match migration events", () => {
+test("attribution backfill declaration resolves every legacy shape without overriding exact matches", () => {
   withFixture((rootDir) => {
     rebuildTaskProjection({ rootDir });
     const beforeRows = queryDecisionProjection({ rootDir, filters: {} }).rows;
@@ -29,36 +29,88 @@ test("attribution backfill dry-run is deterministic and apply emits only exact-m
     assert.equal(first.report.planId, second.report.planId);
     assert.equal(first.report.reportDigest, second.report.reportDigest);
     assert.equal(first.report.summary.legacyDerived, 1);
-    assert.equal(first.report.summary.unresolved, 5);
+    assert.equal(first.report.summary.declared, 0);
+    assert.equal(first.report.summary.unresolved, 7);
     assert.deepEqual(decisionBodies(rootDir), authoredBefore);
     assert.deepEqual(existsSync(eventRoot) ? readdirSync(eventRoot) : [], eventFilesBefore);
 
-    const unconfirmed = runJson(rootDir, ["migrate", "attribution", "--apply"], false);
+    const principalOnly = runJson(rootDir, ["migrate", "attribution", "--declare-principal", "person_declared"], false);
+    assert.equal(principalOnly.ok, false);
+    assert.equal(principalOnly.error.code, "attribution_declaration_invalid");
+    const authorityOnly = runJson(rootDir, ["migrate", "attribution", "--declare-authority", "dec_AUTHORITY"], false);
+    assert.equal(authorityOnly.ok, false);
+    assert.equal(authorityOnly.error.code, "attribution_declaration_invalid");
+    const missingPerson = runJson(rootDir, declarationArgs("person_missing"), false);
+    assert.equal(missingPerson.ok, false);
+    assert.equal(missingPerson.error.code, "attribution_declaration_invalid");
+
+    const declared = runJson(rootDir, declarationArgs("person_declared"));
+    const declaredAgain = runJson(rootDir, declarationArgs("person_declared"));
+    const changedDeclaration = runJson(rootDir, [
+      "migrate", "attribution", "--declare-principal", "person_declared", "--declare-authority", "dec_OTHER_AUTHORITY"
+    ]);
+    assert.equal(declared.report.planId, declaredAgain.report.planId);
+    assert.notEqual(declared.report.planId, changedDeclaration.report.planId);
+    assert.deepEqual(declared.report.declaration, { personId: "person_declared", authority: "dec_AUTHORITY" });
+    assert.equal(declared.report.summary.legacyDerived, 1);
+    assert.equal(declared.report.summary.declared, 7);
+    assert.equal(declared.report.summary.unresolved, 0);
+
+    const exact = candidate(declared, "decision", "dec_HUMAN", "proposedBy");
+    assert.equal(exact.resolution, "legacy-derived");
+    assert.equal(exact.actor.principal.personId, "person_fixture");
+    const humanVariant = candidate(declared, "decision", "dec_AGENT", "arbiter");
+    assert.equal(humanVariant.resolution, "declared");
+    assert.equal(humanVariant.actor.principal.personId, "person_declared");
+    assert.equal(humanVariant.actor.executor, null);
+    const agent = candidate(declared, "decision", "dec_AGENT", "proposedBy");
+    assert.deepEqual(agent.actor.executor, { kind: "agent", id: "historical-agent" });
+    const system = candidate(declared, "decision", "dec_SYSTEM", "proposedBy");
+    assert.deepEqual(system.actor.executor, { kind: "agent", id: "historical-cron" });
+    assert.match(system.reason, /normalized legacy system actor to agent executor/u);
+    const trackedTask = candidate(declared, "task", "task_TRACKED", "createdBy");
+    assert.equal(trackedTask.actor.executor, null);
+    assert.equal(trackedTask.occurredAt, "2025-12-31T23:00:00Z");
+    assert.equal(trackedTask.anchorMissing, undefined);
+    const missingAnchorTask = candidate(declared, "task", "task_UNTRACKED", "createdBy");
+    assert.equal(missingAnchorTask.anchorMissing, true);
+    assert.match(missingAnchorTask.reason, /historical anchor missing/u);
+
+    const unconfirmed = runJson(rootDir, [...declarationArgs("person_declared"), "--apply"], false);
     assert.equal(unconfirmed.ok, false);
     assert.equal(unconfirmed.error.code, "plan_confirmation_required");
     assert.deepEqual(existsSync(eventRoot) ? readdirSync(eventRoot) : [], eventFilesBefore);
 
     const applied = runJson(rootDir, [
-      "migrate", "attribution", "--apply", "--confirm-plan", String(first.report.planId)
+      ...declarationArgs("person_declared"), "--apply", "--confirm-plan", String(declared.report.planId)
     ]);
-    assert.equal(applied.report.appliedEvents, 1);
+    assert.equal(applied.report.appliedEvents, 8);
     assert.deepEqual(decisionBodies(rootDir), authoredBefore);
     const migrationEvents = readEvents(eventRoot).filter((event) => event.principalSource.kind === "migration");
-    assert.equal(migrationEvents.length, 1);
-    assert.equal(migrationEvents[0]?.entityId, "decision/dec_HUMAN");
-    assert.equal(migrationEvents[0]?.actor.principal.personId, "person_fixture");
-    assert.equal(migrationEvents[0]?.actor.executor, null);
-    assert.equal(migrationEvents[0]?.principalSource.kind, "migration");
-    assert.equal(migrationEvents[0]?.principalSource.kind === "migration" && migrationEvents[0].principalSource.evidenceRef, first.report.reportDigest);
-    assert.equal(migrationEvents[0]?.at, "2026-01-01T00:00:00.000Z");
-    assert.notEqual(migrationEvents[0]?.recordedAt, migrationEvents[0]?.at);
+    assert.equal(migrationEvents.length, 8);
+    assert.equal(migrationEvents.every((event) => event.principalSource.evidenceRef === declared.report.reportDigest), true);
+    const exactEvent = eventFor(migrationEvents, "decision/dec_HUMAN", "decision_propose");
+    assert.equal(exactEvent.actor.principal.personId, "person_fixture");
+    assert.equal(exactEvent.actor.executor, null);
+    assert.equal(exactEvent.at, "2026-01-01T00:00:00.000Z");
+    assert.notEqual(exactEvent.recordedAt, exactEvent.at);
+    const systemEvent = eventFor(migrationEvents, "decision/dec_SYSTEM", "decision_propose");
+    assert.deepEqual(systemEvent.actor.executor, { kind: "agent", id: "historical-cron" });
+    const trackedTaskEvent = eventFor(migrationEvents, "task/task_TRACKED", "package_create");
+    assert.equal(trackedTaskEvent.at, "2025-12-31T23:00:00Z");
+    assert.notEqual(trackedTaskEvent.recordedAt, trackedTaskEvent.at);
+    const missingAnchorEvent = eventFor(migrationEvents, "task/task_UNTRACKED", "package_create");
+    assert.equal(missingAnchorEvent.at, missingAnchorEvent.recordedAt);
 
     const afterRows = queryDecisionProjection({ rootDir, filters: {} }).rows;
-    const migrated = afterRows.find((row) => row.decisionId === "dec_HUMAN")!;
-    assert.equal(migrated.attribution.completeness, "complete");
-    assert.equal(migrated.attribution.trailCount, 1);
-    assert.equal(afterRows.find((row) => row.decisionId === "dec_AGENT")?.attribution.originator, null);
-    assert.equal(afterRows.find((row) => row.decisionId === "dec_SYSTEM")?.attribution.originator, null);
+    assert.equal(afterRows.every((row) => row.attribution.completeness === "complete"), true);
+    const afterTasks = queryTaskProjection({ rootDir, filters: {} }).rows;
+    assert.equal(afterTasks.length, 2);
+    assert.equal(afterTasks.every((row) => row.attribution.completeness === "complete"), true);
+    const covered = runJson(rootDir, declarationArgs("person_declared"));
+    assert.equal(covered.report.summary.alreadyCovered, 8);
+    assert.equal(covered.report.summary.declared, 0);
+    assert.equal(covered.report.summary.applicableEvents, 0);
   });
 });
 
@@ -71,19 +123,62 @@ function withFixture(fn: (rootDir: string) => void): void {
   execFileSync("git", ["-C", harnessRoot, "config", "user.email", "harness@example.test"], { stdio: "ignore" });
   writeFile(rootDir, "harness/people.yaml", JSON.stringify({
     schema: "harness-people/v1",
-    people: [{ personId: "person_fixture", displayName: "Fixture", primaryEmail: "fixture@example.test", roles: [] }],
+    people: [
+      { personId: "person_fixture", displayName: "Fixture", primaryEmail: "fixture@example.test", roles: [], credentials: [] },
+      { personId: "person_declared", displayName: "Declared", primaryEmail: "declared@example.test", roles: [], credentials: [] }
+    ],
     roles: []
   }));
+  writeFile(rootDir, "harness/harness.yaml", [
+    "schema: harness-anything/v1",
+    "layout:",
+    "  authoredRoot: harness",
+    "  localRoot: .harness",
+    "settings:",
+    "  identity:",
+    "    personId: person_declared",
+    "    displayName: Declared",
+    ""
+  ].join("\n"));
   writeDecision(rootDir, "dec_HUMAN", "human", "person_fixture", "agent", "legacy-arbiter");
   writeDecision(rootDir, "dec_AGENT", "agent", "historical-agent", "human", "unknown-person");
   writeDecision(rootDir, "dec_SYSTEM", "system", "historical-cron", "agent", "legacy-arbiter");
+  writeTask(rootDir, "task_TRACKED");
   execFileSync("git", ["-C", harnessRoot, "add", "."], { stdio: "ignore" });
-  execFileSync("git", ["-C", harnessRoot, "commit", "-m", "fixture"], { stdio: "ignore" });
+  execFileSync("git", ["-C", harnessRoot, "commit", "-m", "fixture"], {
+    stdio: "ignore",
+    env: { ...process.env, GIT_AUTHOR_DATE: "2025-12-31T23:00:00+00:00", GIT_COMMITTER_DATE: "2025-12-31T23:00:00+00:00" }
+  });
+  writeTask(rootDir, "task_UNTRACKED");
   try {
     fn(rootDir);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
+}
+
+function writeTask(rootDir: string, id: string): void {
+  writeFile(rootDir, `harness/tasks/${id}/INDEX.md`, [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${id}`,
+    `title: ${id}`,
+    "status: planned",
+    "createdAt: 2025-01-01T00:00:00.000Z",
+    "updatedAt: 2025-01-01T00:00:00.000Z",
+    "lifecycle:",
+    "  engine: local",
+    "  ref: local",
+    "  bindingCreatedAt: 2025-01-01T00:00:00.000Z",
+    "  bindingFingerprint: sha256:fixture",
+    "createdBy:",
+    "  name: Historical User",
+    "  email: historical@example.test",
+    "---",
+    "",
+    `# ${id}`,
+    ""
+  ].join("\n"));
 }
 
 function writeDecision(rootDir: string, id: string, kind: "human" | "agent" | "system", actorId: string, arbiterKind: "human" | "agent", arbiterId: string): void {
@@ -128,6 +223,24 @@ function decisionBodies(rootDir: string): ReadonlyArray<string> {
 function readEvents(eventRoot: string): ReadonlyArray<Record<string, any>> {
   if (!existsSync(eventRoot)) return [];
   return readdirSync(eventRoot).sort().map((name) => JSON.parse(readFileSync(path.join(eventRoot, name), "utf8")) as Record<string, any>);
+}
+
+function declarationArgs(personId: string): ReadonlyArray<string> {
+  return ["migrate", "attribution", "--declare-principal", personId, "--declare-authority", "dec_AUTHORITY"];
+}
+
+function candidate(report: Record<string, any>, entityKind: string, entityId: string, role: string): Record<string, any> {
+  const row = report.report.candidates.find((item: Record<string, any>) =>
+    item.entityKind === entityKind && item.entityId === entityId && item.role === role
+  );
+  assert.ok(row, `missing candidate ${entityKind}/${entityId}:${role}`);
+  return row;
+}
+
+function eventFor(events: ReadonlyArray<Record<string, any>>, entityId: string, kind: string): Record<string, any> {
+  const event = events.find((item) => item.entityId === entityId && item.kind === kind);
+  assert.ok(event, `missing event ${entityId}:${kind}`);
+  return event;
 }
 
 function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, any> {

--- a/packages/cli/test/parse-args.test.ts
+++ b/packages/cli/test/parse-args.test.ts
@@ -156,7 +156,7 @@ const parseCases: ReadonlyArray<ParseCase> = [
   { name: "migrate plan", argv: ["migrate", "plan", "--limit", "5"], kind: "migrate-plan", fields: { limit: 5 } },
   { name: "migrate structure", argv: ["migrate", "structure", "--apply", "--confirm-plan"], kind: "migrate-structure", fields: { mode: "apply", confirmPlan: true } },
   { name: "migrate anchors", argv: ["migrate", "anchors", "--apply"], kind: "migrate-anchors", fields: { mode: "apply" } },
-  { name: "migrate attribution", argv: ["migrate", "attribution", "--apply", "--confirm-plan", "abf_123"], kind: "migrate-attribution", fields: { mode: "apply", confirmPlan: "abf_123" } },
+  { name: "migrate attribution", argv: ["migrate", "attribution", "--apply", "--confirm-plan", "abf_123", "--declare-principal", "person_zeyu", "--declare-authority", "dec_AUTHORITY"], kind: "migrate-attribution", fields: { mode: "apply", confirmPlan: "abf_123", declarePrincipal: "person_zeyu", declareAuthority: "dec_AUTHORITY" } },
   { name: "migrate fact execution", argv: ["migrate", "fact-execution", "--apply", "--confirm-plan", "fxm_123", "--batch-size", "25", "--batch", "2", "--sample-size", "3"], kind: "migrate-fact-execution", fields: { mode: "apply", confirmPlan: "fxm_123", batchSize: 25, batch: 2, sampleSize: 3 } },
   { name: "migrate fact execution manual list", argv: ["migrate", "fact-execution", "--dry-run", "--apply-manual", "artifacts/facts.txt"], kind: "migrate-fact-execution", fields: { mode: "dry-run", manualListFile: "artifacts/facts.txt", batchSize: 50, batch: 1, sampleSize: 5 } },
   { name: "migrate provenance", argv: ["migrate", "provenance", "--apply"], kind: "migrate-provenance", fields: { mode: "apply" } },

--- a/packages/kernel/src/composition/index.ts
+++ b/packages/kernel/src/composition/index.ts
@@ -5,4 +5,4 @@ export { makeMarkdownArtifactStore } from "../store/markdown-artifact-store.ts";
 export { makeJournaledWriteCoordinator, makeOperationalJournaledWriteCoordinator } from "../store/write-journal-coordinator.ts";
 export { makeLocalLockRegistry } from "../store/local-lock-registry.ts";
 export { makeLocalVersionControlSystem } from "../store/local-version-control-system.ts";
-export { applyAttributionBackfill, planAttributionBackfill } from "../store/attribution-backfill.ts";
+export { AttributionBackfillDeclarationError, applyAttributionBackfill, planAttributionBackfill } from "../store/attribution-backfill.ts";

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -58,6 +58,7 @@ export * from "./schemas/task-schema-resolver.ts";
 export {
   makeJournaledWriteCoordinator,
   makeOperationalJournaledWriteCoordinator,
+  AttributionBackfillDeclarationError,
   applyAttributionBackfill,
   planAttributionBackfill,
   makeLocalLockRegistry,

--- a/packages/kernel/src/store/attribution-backfill.ts
+++ b/packages/kernel/src/store/attribution-backfill.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import { stablePayloadHash } from "../integrity/stable-hash.ts";
@@ -8,13 +9,27 @@ import { readDecisionProjectionRows } from "../projection/sqlite-decision-source
 import { readMarkdownSource, taskEntryToRow } from "../projection/sqlite-task-source.ts";
 import type { ActorAxes } from "../schemas/actor-attribution.ts";
 import type { WriteOpKind } from "../domain/write-op-kind.ts";
-import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
+import { firstCommitAtForPath, makeLocalVersionControlSystem } from "./local-version-control-system.ts";
 import { commitTouchedPaths } from "./write-journal-git.ts";
 import { makeLocalGitAttributionEventStore } from "./write-journal-attribution-events.ts";
 import type { JournalRecordV2 } from "./write-journal-types.ts";
 import { durableFileExists } from "./write-journal-durable.ts";
 
 type LegacyActor = { readonly kind: "human" | "agent" | "system"; readonly id: string };
+
+export interface AttributionBackfillDeclaration {
+  readonly personId: string;
+  readonly authority: string;
+}
+
+export class AttributionBackfillDeclarationError extends Error {
+  readonly _tag = "AttributionBackfillDeclarationError";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "AttributionBackfillDeclarationError";
+  }
+}
 
 export interface AttributionBackfillCandidate {
   readonly entityId: string;
@@ -23,19 +38,22 @@ export interface AttributionBackfillCandidate {
   readonly legacyActor: LegacyActor | null;
   readonly operation: WriteOpKind;
   readonly occurredAt: string | null;
-  readonly resolution: "legacy-derived" | "unresolved" | "already-covered";
+  readonly resolution: "legacy-derived" | "declared" | "unresolved" | "already-covered";
   readonly actor: ActorAxes | null;
   readonly reason: string;
+  readonly anchorMissing?: true;
 }
 
 export interface AttributionBackfillPlan {
   readonly schema: "attribution-backfill-report/v1";
   readonly planId: string;
   readonly reportDigest: string;
+  readonly declaration?: AttributionBackfillDeclaration;
   readonly candidates: ReadonlyArray<AttributionBackfillCandidate>;
   readonly summary: {
     readonly scanned: number;
     readonly legacyDerived: number;
+    readonly declared: number;
     readonly unresolved: number;
     readonly alreadyCovered: number;
     readonly applicableEvents: number;
@@ -48,25 +66,31 @@ export interface AttributionBackfillApplyResult {
   readonly recordedAt: string;
 }
 
-export function planAttributionBackfill(rootInput: HarnessLayoutInput): AttributionBackfillPlan {
+export function planAttributionBackfill(
+  rootInput: HarnessLayoutInput,
+  declaration?: AttributionBackfillDeclaration
+): AttributionBackfillPlan {
   const personIds = readLegacyPersonIds(rootInput);
+  if (declaration) assertDeclaration(declaration, personIds);
   const covered = new Set(readAttributionEvents(rootInput).map((event) => event.entityId));
   const candidates = [
     ...taskCandidates(rootInput),
     ...decisionCandidates(rootInput)
-  ].map((candidate) => resolveCandidate(candidate, personIds, covered))
+  ].map((candidate) => resolveCandidate(candidate, personIds, covered, declaration))
     .sort((left, right) => `${left.entityKind}:${left.entityId}:${left.role}`.localeCompare(`${right.entityKind}:${right.entityId}:${right.role}`));
-  const payload = { candidates, personIds: [...personIds].sort() };
+  const payload = { candidates, personIds: [...personIds].sort(), ...(declaration ? { declaration } : {}) };
   const reportDigest = stablePayloadHash(payload);
   const planId = `abf_${reportDigest.slice(0, 20)}`;
   return {
     schema: "attribution-backfill-report/v1",
     planId,
     reportDigest: `sha256:${reportDigest}`,
+    ...(declaration ? { declaration } : {}),
     candidates,
     summary: {
       scanned: candidates.length,
       legacyDerived: candidates.filter((candidate) => candidate.resolution === "legacy-derived").length,
+      declared: candidates.filter((candidate) => candidate.resolution === "declared").length,
       unresolved: candidates.filter((candidate) => candidate.resolution === "unresolved").length,
       alreadyCovered: candidates.filter((candidate) => candidate.resolution === "already-covered").length,
       applicableEvents: candidates.filter(isApplicableCandidate).length
@@ -74,19 +98,29 @@ export function planAttributionBackfill(rootInput: HarnessLayoutInput): Attribut
   };
 }
 
+function assertDeclaration(declaration: AttributionBackfillDeclaration, personIds: ReadonlySet<string>): void {
+  if (!declaration.personId.trim() || !declaration.authority.trim()) {
+    throw new AttributionBackfillDeclarationError("attribution declaration requires non-empty personId and authority");
+  }
+  if (!personIds.has(declaration.personId)) {
+    throw new AttributionBackfillDeclarationError(`attribution declaration principal ${declaration.personId} does not exist in harness/people.yaml`);
+  }
+}
+
 export function applyAttributionBackfill(
   rootInput: HarnessLayoutInput,
   expectedPlanId: string,
+  declaration?: AttributionBackfillDeclaration,
   recordedAt = new Date().toISOString()
 ): AttributionBackfillApplyResult {
-  const plan = planAttributionBackfill(rootInput);
+  const plan = planAttributionBackfill(rootInput, declaration);
   if (expectedPlanId !== plan.planId) throw new Error(`attribution backfill requires --confirm-plan ${plan.planId}`);
   const layout = resolveHarnessLayout(rootInput);
   const vcs = makeLocalVersionControlSystem();
   const store = makeLocalGitAttributionEventStore();
   const commitSha = vcs.currentHead(layout.authoredRoot);
   const writes = plan.candidates.filter(isApplicableCandidate).map((candidate) => {
-    const record = syntheticJournalRecord(candidate, plan);
+    const record = syntheticJournalRecord(candidate, plan, recordedAt);
     return store.ensure(record, {
       rootDir: layout.rootDir,
       rootInput,
@@ -115,16 +149,21 @@ export function applyAttributionBackfill(
 }
 
 function taskCandidates(rootInput: HarnessLayoutInput): ReadonlyArray<Omit<AttributionBackfillCandidate, "resolution" | "actor" | "reason">> {
-  return readMarkdownSource(rootInput).entries.map((entry) => taskEntryToRow(rootInput, entry))
-    .filter((row) => row.createdBy !== undefined)
-    .map((row) => ({
-      entityId: row.taskId,
-      entityKind: "task" as const,
-      role: "createdBy" as const,
-      legacyActor: null,
-      operation: "package_create" as const,
-      occurredAt: null
-    }));
+  const layout = resolveHarnessLayout(rootInput);
+  return readMarkdownSource(rootInput).entries.map((entry) => ({ entry, row: taskEntryToRow(rootInput, entry) }))
+    .filter(({ row }) => row.createdBy !== undefined)
+    .map(({ entry, row }) => {
+      const occurredAt = firstCommitAtForPath(layout.authoredRoot, path.dirname(entry.indexPath));
+      return {
+        entityId: row.taskId,
+        entityKind: "task" as const,
+        role: "createdBy" as const,
+        legacyActor: null,
+        operation: "package_create" as const,
+        occurredAt,
+        ...(occurredAt ? {} : { anchorMissing: true as const })
+      };
+    });
 }
 
 function decisionCandidates(rootInput: HarnessLayoutInput): ReadonlyArray<Omit<AttributionBackfillCandidate, "resolution" | "actor" | "reason">> {
@@ -135,7 +174,8 @@ function decisionCandidates(rootInput: HarnessLayoutInput): ReadonlyArray<Omit<A
       role: "proposedBy" as const,
       legacyActor: row.proposedBy,
       operation: "decision_propose" as const,
-      occurredAt: row.proposedAt ?? null
+      occurredAt: row.proposedAt ?? null,
+      ...(row.proposedAt ? {} : { anchorMissing: true as const })
     }] : []),
     ...(row.arbiter ? [{
       entityId: row.decisionId,
@@ -143,7 +183,8 @@ function decisionCandidates(rootInput: HarnessLayoutInput): ReadonlyArray<Omit<A
       role: "arbiter" as const,
       legacyActor: row.arbiter,
       operation: decisionOutcomeOperation(row.state),
-      occurredAt: row.decidedAt ?? null
+      occurredAt: row.decidedAt ?? null,
+      ...(row.decidedAt ? {} : { anchorMissing: true as const })
     }] : [])
   ]);
 }
@@ -151,11 +192,21 @@ function decisionCandidates(rootInput: HarnessLayoutInput): ReadonlyArray<Omit<A
 function resolveCandidate(
   candidate: Omit<AttributionBackfillCandidate, "resolution" | "actor" | "reason">,
   personIds: ReadonlySet<string>,
-  covered: ReadonlySet<string>
+  covered: ReadonlySet<string>,
+  declaration?: AttributionBackfillDeclaration
 ): AttributionBackfillCandidate {
   if (covered.has(candidate.entityId) || covered.has(`${candidate.entityKind}/${candidate.entityId}`)) {
     return { ...candidate, resolution: "already-covered", actor: null, reason: "durable attribution event already exists" };
   }
+  if (candidate.legacyActor?.kind === "human" && personIds.has(candidate.legacyActor.id) && candidate.occurredAt) {
+    return {
+      ...candidate,
+      resolution: "legacy-derived",
+      actor: { principal: { kind: "person", personId: candidate.legacyActor.id }, executor: null },
+      reason: "legacy human id exactly matches the person registry"
+    };
+  }
+  if (declaration) return declaredCandidate(candidate, declaration);
   if (!candidate.legacyActor) {
     return { ...candidate, resolution: "unresolved", actor: null, reason: "legacy createdBy name/email is evidence, not a principal id" };
   }
@@ -165,24 +216,34 @@ function resolveCandidate(
   if (!personIds.has(candidate.legacyActor.id)) {
     return { ...candidate, resolution: "unresolved", actor: null, reason: "legacy human id has no exact person registry match" };
   }
-  if (!candidate.occurredAt) {
-    return { ...candidate, resolution: "unresolved", actor: null, reason: "legacy record lacks a historical occurrence time" };
-  }
+  return { ...candidate, resolution: "unresolved", actor: null, reason: "legacy record lacks a historical occurrence time" };
+}
+
+function declaredCandidate(
+  candidate: Omit<AttributionBackfillCandidate, "resolution" | "actor" | "reason">,
+  declaration: AttributionBackfillDeclaration
+): AttributionBackfillCandidate {
+  const executor = candidate.legacyActor?.kind === "agent" || candidate.legacyActor?.kind === "system"
+    ? { kind: "agent" as const, id: candidate.legacyActor.id }
+    : null;
+  const normalization = candidate.legacyActor?.kind === "system" ? "; normalized legacy system actor to agent executor" : "";
+  const anchor = candidate.anchorMissing ? "; historical anchor missing, apply will use recordedAt" : "";
   return {
     ...candidate,
-    resolution: "legacy-derived",
-    actor: { principal: { kind: "person", personId: candidate.legacyActor.id }, executor: null },
-    reason: "legacy human id exactly matches the person registry"
+    resolution: "declared",
+    actor: { principal: { kind: "person", personId: declaration.personId }, executor },
+    reason: `principal supplied by one-time declaration ${declaration.authority}${normalization}${anchor}`
   };
 }
 
-function isApplicableCandidate(candidate: AttributionBackfillCandidate): candidate is AttributionBackfillCandidate & { readonly actor: ActorAxes; readonly occurredAt: string } {
-  return candidate.resolution === "legacy-derived" && candidate.actor !== null && candidate.occurredAt !== null;
+function isApplicableCandidate(candidate: AttributionBackfillCandidate): candidate is AttributionBackfillCandidate & { readonly actor: ActorAxes } {
+  return (candidate.resolution === "legacy-derived" || candidate.resolution === "declared") && candidate.actor !== null;
 }
 
 function syntheticJournalRecord(
-  candidate: AttributionBackfillCandidate & { readonly actor: ActorAxes; readonly occurredAt: string },
-  plan: AttributionBackfillPlan
+  candidate: AttributionBackfillCandidate & { readonly actor: ActorAxes },
+  plan: AttributionBackfillPlan,
+  recordedAt: string
 ): JournalRecordV2 {
   const evidence = { planId: plan.planId, reportDigest: plan.reportDigest, candidate };
   const payloadHash = stablePayloadHash(evidence);
@@ -194,8 +255,8 @@ function syntheticJournalRecord(
     kind: candidate.operation,
     actor: candidate.actor,
     principalSource: { kind: "migration", evidenceRef: plan.reportDigest },
-    executorSource: "none",
-    at: candidate.occurredAt,
+    executorSource: candidate.actor.executor ? "client-asserted" : "none",
+    at: candidate.occurredAt ?? recordedAt,
     payloadRef: { path: `attribution-migration-report:${plan.planId}`, sha256: plan.reportDigest },
     payload: { payloadHash }
   };

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -113,6 +113,19 @@ export function makeLocalVersionControlSystem(): VersionControlSystem {
   };
 }
 
+export function firstCommitAtForPath(repoRoot: string, inputPath: string): string | null {
+  const relativePath = path.relative(repoRoot, inputPath);
+  if (relativePath === "" || relativePath === ".." || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) return null;
+  try {
+    return runGit(repoRoot, "log", "--reverse", "--format=%aI", "--", relativePath.split(path.sep).join("/"))
+      .split(/\r?\n/u)
+      .map((entry) => entry.trim())
+      .find(Boolean) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 function gitTopLevel(inputPath: string): string | null {
   try {
     return normalizeExistingPath(runGit(inputPath, "rev-parse", "--show-toplevel").trim());

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -10,6 +10,7 @@ const publicRuntimeSurface = [
   "ActorKindSchema",
   "ActorRefSchema",
   "ArtifactStore",
+  "AttributionBackfillDeclarationError",
   "CurrentSessionProbe",
   "CurrentSessionRuntimeSchema",
   "DecisionPackageSchema",


### PR DESCRIPTION
# English

## Summary

ADR-0028 Phase 7b extension — adds a one-time **declaration input** to `ha migrate attribution` so the single-operator legacy history can be resolved to a canonical principal without inventing any persistent mapping layer. The one essential fact is `personId + executor`; richer profile (name/email) is a lookup keyed on `personId` via the person registry, never a stored mapping.

## What Changed

- New paired flags `--declare-principal <personId> --declare-authority <decision-id>` (both required together, fail-closed otherwise). Candidates that would be `unresolved` become a new resolution `declared`; the declaration is pure command input embedded only in the plan/report and synthetic event evidence — no persistent mapping/registry file is created. With no flags, behavior is byte-for-byte unchanged.
- Four declared constructions: human variant → `{principal:declared, executor:null}`; agent → `{principal:declared, executor:{agent,id}}`; system → `{principal:declared, executor:{agent,id}}` (**normalized system→agent**, stated in reason); task `createdBy{name,email}` → `{principal:declared, executor:null}`. Resolution order `already-covered` → exact-match `legacy-derived` → `declared` → `unresolved`, so a declaration never overrides honest exact matches.
- Honest history-time anchor: new read-only `firstCommitAtForPath` runs `git log --reverse --format=%aI -- <task-package>` to recover the package's first authored commit time. When no real anchor exists, `at=recordedAt` and the report flags `anchorMissing:true` — no fabricated history time. Decisions keep existing `proposedAt`/`decidedAt`.
- Audit closure: plan/report embed `declaration:{personId, authority}`; the declaration participates in the deterministic `planId` hash. Synthetic events keep `principalSource:{kind:"migration", evidenceRef:reportDigest}`.

## Task And Scope

- Harness task: `task_01KXBDHY6BCWPQDWXPYQQ70ZVV` (P7 backfill actor)
- Branch: `feat/dual-axis-p7b-declare-principal`
- Public scope: `packages/cli` migration args/command + `packages/kernel` attribution-backfill store + tests
- Private planning/evidence updated: yes
- Out of scope: real-ledger apply, legacy-field retirement (next package, only after coverage 100%)

## Version Impact

- Version: no version change because this is an additive CLI flag behind an existing command
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none — no manifest/gate/write-road/registry file in this diff
- Authority: ADR-0028 Phase 7b (line 59, one-time explicit declaration) + decision `dec_01KXC8A0H95BW8F3J56GP5DFYN` (active)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: `task_01KXBDHY6BCWPQDWXPYQQ70ZVV` (7b retirement remainder)

## Verification

- Base `origin/main` SHA: `e13fd392c805af58b57a0b69a78f0e1a40ed474f` (merge-base)
- Branch merge-base with `origin/main`: `e13fd392c805af58b57a0b69a78f0e1a40ed474f`
- Last `git fetch origin` time: 2026-07-12T23:33:21Z
- Sync method: rebase (onto latest `origin/main` before opening this PR)
- Public diff command: `git diff origin/main...feat/dual-axis-p7b-declare-principal`
- Private evidence commit/path: `harness/tasks/task_01KXBDHY6BCWPQDWXPYQQ70ZVV-p7-backfill-actor/artifacts/p7b-ext-report-codex.md`
- Reviewer evidence path: `harness/tasks/task_01KXBDHY6BCWPQDWXPYQQ70ZVV-p7-backfill-actor/review.md`
- GitHub Actions `rewrite-ci` run URL: see PR checks
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (check:local, exit 0, 49.6s)
- [x] `npm run typecheck`
- [x] `npm test` (test:integration, 692 tests, 691 pass, 0 fail, 1 Windows skip, exit 0; re-run post-rebase)
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] Boundaries manifest (`run-manifest-gates.mjs --workflow-job boundaries`) — 34 commands pass, exit 0
- Not run: none

## Review Evidence

- Self-review: CEO ground-truthed the source diff (not the worker report) — four declared constructions, system→agent normalization, task history anchor, planId hash coverage, `principalSource=migration` all confirmed.
- Reviewer subagent: not applicable (single coherent package)
- Human review: CEO semantic acceptance against dec_01KXC8A0H9 (four constructions match the adjudication exactly)
- Blocking findings: none

## Residual Risk

- Real-ledger declaration dry-run, real coverage, and real apply are intentionally NOT executed here; they are the next CEO step in a separate migration action.

## References

- Task: `task_01KXBDHY6BCWPQDWXPYQQ70ZVV`
- Evidence: `artifacts/p7b-ext-report-codex.md`, `artifacts/p7b-ext-mission.md`
- Review: `review.md`

---

# 中文

## 概要

ADR-0028 第 7b 阶段扩展 —— 给 `ha migrate attribution` 加一次性**声明输入**,让单人历史账本能收敛到规范 principal,而**不建任何持久映射层**。本质数据只有 `personId + executor`;更全的档案(名字/邮箱)是以 `personId` 为键向 person registry 查询,而非存储映射。

## 改动内容

- 新增成对 flag `--declare-principal <personId> --declare-authority <decision-id>`(必须同给,否则 fail-closed)。原本会 `unresolved` 的 candidate 转为新 resolution `declared`;声明纯粹是命令输入,只进入 plan/report 与 synthetic event 证据,**不创建任何持久映射/registry 文件**。无 flag 时行为逐字节不变。
- 四类 declared 构造:human 变体 → `{principal:声明, executor:null}`;agent → `{principal:声明, executor:{agent,id}}`;system → `{principal:声明, executor:{agent,id}}`(**归一化 system→agent**,reason 明示);task `createdBy{name,email}` → `{principal:声明, executor:null}`。解析顺序 `already-covered` → exact-match `legacy-derived` → `declared` → `unresolved`,声明绝不覆盖诚实 exact-match。
- 诚实历史时间锚:新增只读 `firstCommitAtForPath`,跑 `git log --reverse --format=%aI -- <task 包>` 取回该包首次 authored commit 时间。取不到真实锚时 `at=recordedAt` 且报告标 `anchorMissing:true`,**不伪造历史时间**。decision 沿用既有 `proposedAt`/`decidedAt`。
- 审计闭环:plan/report 内嵌 `declaration:{personId, authority}`;声明参与确定性 `planId` hash。synthetic event 仍走 `principalSource:{kind:"migration", evidenceRef:reportDigest}`。

## 任务与范围

- Harness 任务:`task_01KXBDHY6BCWPQDWXPYQQ70ZVV`(P7 backfill actor)
- 分支:`feat/dual-axis-p7b-declare-principal`
- 公开范围:`packages/cli` 迁移参数/命令 + `packages/kernel` attribution-backfill store + 测试
- 私有计划 / 证据是否已更新:yes
- 范围外:真实账本 apply、legacy 字段退场(下一个包,coverage 达 100% 之后)

## 版本影响

- 版本:不改版本,原因是这是既有命令下的加法式 CLI flag
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:无 —— 本 diff 无 manifest/gate/write-road/registry 文件
- 依据:ADR-0028 第 7b 阶段(第 59 行,一次性显式声明)+ 决策 `dec_01KXC8A0H95BW8F3J56GP5DFYN`(active)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:`task_01KXBDHY6BCWPQDWXPYQQ70ZVV`(7b 退场残余)

## 验证

- `origin/main` 基准 SHA:`e13fd392c805af58b57a0b69a78f0e1a40ed474f`(merge-base)
- 当前分支与 `origin/main` 的 merge-base:`e13fd392c805af58b57a0b69a78f0e1a40ed474f`
- 最近一次 `git fetch origin` 时间:2026-07-12T23:33:21Z
- 同步方式:rebase(开 PR 前 rebase 到最新 `origin/main`)
- 公开 diff 命令:`git diff origin/main...feat/dual-axis-p7b-declare-principal`
- 私有证据 commit/path:`harness/tasks/task_01KXBDHY6BCWPQDWXPYQQ70ZVV-p7-backfill-actor/artifacts/p7b-ext-report-codex.md`
- Reviewer 证据路径:`harness/tasks/task_01KXBDHY6BCWPQDWXPYQQ70ZVV-p7-backfill-actor/review.md`
- GitHub Actions `rewrite-ci` run URL:见 PR checks
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`(check:local,exit 0,49.6s)
- [x] `npm run typecheck`
- [x] `npm test`(test:integration,692 测试,691 pass,0 fail,1 Windows skip,exit 0;rebase 后重跑)
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [x] Boundaries manifest(`run-manifest-gates.mjs --workflow-job boundaries`)—— 34 命令全过,exit 0
- 未运行:无

## 审查证据

- 自查:CEO 对源码 diff 逐条 ground-truth(非信 worker 报告)—— 四类 declared 构造、system→agent 归一化、task 历史锚、planId hash 覆盖、`principalSource=migration` 全部确认。
- Reviewer subagent:不适用(单一连贯包)
- 人工审查:CEO 语义验收对照 dec_01KXC8A0H9(四类构造精确匹配裁决)
- 阻塞发现:无

## 残余风险

- 真实账本声明 dry-run、真实 coverage、真实 apply 均有意未在此执行;它们是 CEO 下一步独立迁移动作。

## 关联材料

- 任务:`task_01KXBDHY6BCWPQDWXPYQQ70ZVV`
- 证据:`artifacts/p7b-ext-report-codex.md`、`artifacts/p7b-ext-mission.md`
- 审查:`review.md`
