### PR TITLE
feat(gui): 三元语关系图 ego 改为无限累积画布（分级分列 + 原地展开）

### DIFF
--- a/packages/gui/src/renderer/graph/GraphDrawer.tsx
+++ b/packages/gui/src/renderer/graph/GraphDrawer.tsx
@@ -53,8 +53,8 @@ export function GraphDrawer({
       <aside className="flex w-[26rem] shrink-0 flex-col overflow-y-auto border-l border-border bg-surface">
         <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
           <GitBranch weight="duotone" className="shrink-0 text-text-muted" />
-          <span className="font-mono text-xs text-text-muted">Edge (Relation)</span>
-          <span className="rounded bg-surface-raised px-1.5 py-0.5 text-[10px] text-text-faint">
+          <span className="font-mono ui-meta text-text-muted">Edge (Relation)</span>
+          <span className="rounded bg-surface-raised px-1.5 py-0.5 text-[11px] text-text-faint">
             {focusEdge.kind}
           </span>
           <button
@@ -66,33 +66,33 @@ export function GraphDrawer({
           </button>
         </div>
         <div className="flex flex-col gap-3 px-3 py-3">
-          <p className="text-[13px] leading-snug text-text">
+          <p className="ui-body leading-snug text-text">
             这是一个 <strong>{KIND_LABEL[focusEdge.kind] ?? focusEdge.kind}</strong> 关系边。
           </p>
-          <div className="rounded-md border border-border bg-surface-raised px-2.5 py-2 flex flex-col gap-2 text-[11px] text-text-muted">
+          <div className="rounded-md border border-border bg-surface-raised px-2.5 py-2 flex flex-col gap-2 ui-meta text-text-muted">
              <div><span className="font-bold text-text">From:</span> {focusEdge.from}</div>
              <div><span className="font-bold text-text">To:</span> {focusEdge.to}</div>
           </div>
           {focusEdge.provenance && (
              <div className="rounded-md border border-border bg-surface-raised px-2.5 py-2 flex flex-col gap-1">
-               <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
+               <span className="font-mono text-[11px] uppercase tracking-wide text-text-faint">
                  Provenance
                </span>
-               <div className="font-mono text-[11px] text-text-muted">
+               <div className="font-mono ui-meta text-text-muted">
                  {focusEdge.provenance}
                </div>
              </div>
           )}
           <div className="flex gap-2">
-            <button 
+            <button
                onClick={() => onFocus(endpointToNodeId(focusEdge.from))}
-               className="flex-1 rounded border border-border px-2 py-1.5 text-xs text-text-muted hover:bg-surface-raised hover:text-text"
+               className="flex-1 rounded border border-border px-2 py-1.5 ui-meta text-text-muted hover:bg-surface-raised hover:text-text"
             >
               跳转源节点
             </button>
-            <button 
+            <button
                onClick={() => onFocus(endpointToNodeId(focusEdge.to))}
-               className="flex-1 rounded border border-border px-2 py-1.5 text-xs text-text-muted hover:bg-surface-raised hover:text-text"
+               className="flex-1 rounded border border-border px-2 py-1.5 ui-meta text-text-muted hover:bg-surface-raised hover:text-text"
             >
               跳转目标节点
             </button>
@@ -113,8 +113,8 @@ export function GraphDrawer({
     <aside className="flex w-[26rem] shrink-0 flex-col overflow-y-auto border-l border-border bg-surface">
       <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
         <GitBranch weight="duotone" className="shrink-0 text-text-muted" />
-        <span className="font-mono text-xs text-text-muted">{focusNode.id}</span>
-        <span className="rounded bg-surface-raised px-1.5 py-0.5 text-[10px] text-text-faint">
+        <span className="font-mono ui-meta text-text-muted">{focusNode.id}</span>
+        <span className="rounded bg-surface-raised px-1.5 py-0.5 text-[11px] text-text-faint">
           {focusNode.entity}
         </span>
         {onNavigateEntity && (
@@ -127,9 +127,9 @@ export function GraphDrawer({
               )
             }
             title="在侧栏打开(task→详情, decision→决策池, fact→分诊)"
-            className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[10px] text-text-muted hover:border-border-strong hover:text-text"
+            className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[11px] text-text-muted hover:border-border-strong hover:text-text"
           >
-            <ArrowsOutSimple weight="bold" className="text-[10px]" />
+            <ArrowsOutSimple weight="bold" className="text-[11px]" />
             打开
           </button>
         )}
@@ -137,18 +137,18 @@ export function GraphDrawer({
           isFocused ? (
             <span
               title="此节点已是焦点"
-              className="inline-flex items-center gap-1 rounded border border-accent/40 bg-accent/10 px-1.5 py-0.5 text-[10px] text-accent"
+              className="inline-flex items-center gap-1 rounded border border-accent/40 bg-accent/10 px-1.5 py-0.5 text-[11px] text-accent"
             >
-              <Crosshair weight="bold" className="text-[10px]" />
+              <Crosshair weight="bold" className="text-[11px]" />
               焦点
             </span>
           ) : (
             <button
               onClick={onSetAsFocus}
               title="把这个节点设为图焦点(双击节点同效)"
-              className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[10px] text-text-muted hover:border-accent hover:text-accent"
+              className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[11px] text-text-muted hover:border-accent hover:text-accent"
             >
-              <Crosshair weight="bold" className="text-[10px]" />
+              <Crosshair weight="bold" className="text-[11px]" />
               设为焦点
             </button>
           )
@@ -163,7 +163,7 @@ export function GraphDrawer({
       </div>
 
       <div className="flex flex-col gap-3 px-3 py-3">
-        <p className="text-[13px] leading-snug text-text">{focusNode.label}</p>
+        <p className="ui-title font-semibold leading-snug text-text">{focusNode.label}</p>
 
         {focusTask ? (
           <>
@@ -173,7 +173,7 @@ export function GraphDrawer({
               <EngineBadge engine={focusTask.engine} locked={isExternal(focusTask)} />
             </div>
             <FreshnessTag freshness={focusTask.freshness} lastKnownAt={focusTask.lastKnownAt} />
-            <div className="flex gap-3 font-mono text-[11px] text-text-muted">
+            <div className="flex gap-3 font-mono ui-meta text-text-muted">
               <span>module: {focusTask.module}</span>
               <span>raw: {focusTask.rawStatus}</span>
             </div>
@@ -184,34 +184,36 @@ export function GraphDrawer({
               const dec = focusNode.raw as DecisionRow;
               return (
                 <>
-                  <div className="flex items-center gap-2 font-mono text-[11px]">
+                  <div className="flex items-center gap-2 font-mono ui-meta">
                     <span className="rounded bg-accent px-1.5 py-0.5 text-accent-fg">
                       {dec.state}
                     </span>
                     <span className="text-text-muted">{dec.riskTier ?? "未知"} risk · {dec.urgency ?? "未知"} urgency</span>
                   </div>
                   <div className="rounded-md border border-border bg-surface-raised px-2.5 py-2">
-                    <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
+                    <span className="font-mono text-[11px] uppercase tracking-wide text-text-faint">
                       Question
                     </span>
-                    <p className="text-[12px] font-medium text-text mt-1">{dec.question}</p>
+                    <p className="ui-body font-medium text-text mt-1 max-h-[38vh] overflow-y-auto overscroll-contain pr-1">{dec.question}</p>
                   </div>
                   {dec.chosen.length > 0 && (
                     <div className="rounded-md border border-accent/30 bg-accent-fg/5 px-2.5 py-2">
-                      <span className="font-mono text-[10px] uppercase tracking-wide text-accent">
+                      <span className="font-mono text-[11px] uppercase tracking-wide text-accent">
                         Chosen
                       </span>
-                      {dec.chosen.map(c => (
-                        <p key={c.id} className="text-[12px] text-text mt-1">{c.text}</p>
-                      ))}
+                      <div className="mt-1 max-h-[38vh] overflow-y-auto overscroll-contain pr-1 flex flex-col gap-1">
+                        {dec.chosen.map(c => (
+                          <p key={c.id} className="ui-body text-text">{c.text}</p>
+                        ))}
+                      </div>
                     </div>
                   )}
                   {dec.claims && dec.claims.length > 0 && (
                     <div className="rounded-md border border-border bg-surface-raised px-2.5 py-2">
-                      <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
+                      <span className="font-mono text-[11px] uppercase tracking-wide text-text-faint">
                         Claims
                       </span>
-                      <ul className="list-inside list-disc text-[12px] text-text-muted mt-1">
+                      <ul className="list-inside list-disc ui-body text-text-muted mt-1 max-h-[34vh] overflow-y-auto overscroll-contain pr-1">
                         {dec.claims.map(c => (
                           <li key={c.id}>{c.text}</li>
                         ))}
@@ -228,23 +230,23 @@ export function GraphDrawer({
               const fact = focusNode.raw as FactRef;
               return (
                 <>
-                  <div className="flex items-center gap-2 font-mono text-[11px]">
+                  <div className="flex items-center gap-2 font-mono ui-meta">
                     <span className="rounded bg-stale px-1.5 py-0.5 text-stale-fg">
                       {fact.category}
                     </span>
                     <span className="text-text-muted">@ {fact.at}</span>
                   </div>
                   <div className="rounded-md border border-stale/30 bg-stale/5 px-2.5 py-3">
-                    <span className="font-mono text-[10px] uppercase tracking-wide text-stale">
+                    <span className="font-mono text-[11px] uppercase tracking-wide text-stale">
                       Fact Observation
                     </span>
-                    <p className="text-[13px] leading-relaxed text-text mt-1.5 font-medium">{fact.text}</p>
+                    <p className="ui-body leading-relaxed text-text mt-1.5 font-medium max-h-[42vh] overflow-y-auto overscroll-contain pr-1">{fact.text}</p>
                   </div>
                   <div className="rounded-md border border-border bg-surface-raised px-2.5 py-2 flex flex-col gap-1">
-                    <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
+                    <span className="font-mono text-[11px] uppercase tracking-wide text-text-faint">
                       Anchor Details
                     </span>
-                    <div className="font-mono text-[11px] text-text-muted">
+                    <div className="font-mono ui-meta text-text-muted">
                        <div>Task ID: {fact.taskId}</div>
                        <div>Anchor: {fact.anchor}</div>
                     </div>
@@ -254,57 +256,61 @@ export function GraphDrawer({
             })()}
           </div>
         ) : (
-          <div className="rounded-md border border-border bg-surface-raised px-2.5 py-2 text-[11px] text-text-muted">
+          <div className="rounded-md border border-border bg-surface-raised px-2.5 py-2 ui-meta text-text-muted">
             {focusNode.entity} 节点
           </div>
         )}
 
-        <div className="rounded-md border border-border bg-surface-raised px-2.5 py-2 font-mono text-[11px] text-text-muted">
+        <div className="rounded-md border border-border bg-surface-raised px-2.5 py-2 font-mono ui-meta text-text-muted">
           链路：上游 {upCount} · 下游 {downCount}
         </div>
 
         {directOut.length > 0 && (
           <div className="flex flex-col gap-1">
-            <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
+            <span className="font-mono text-[11px] uppercase tracking-wide text-text-faint">
               出边 {directOut.length}
             </span>
-            {directOut.map((e, i) => {
-              const peer = nodes.get(endpointToNodeId(e.to));
-              return (
-                <button
-                  key={`o-${i}`}
-                  onClick={() => onFocus(endpointToNodeId(e.to))}
-                  className="flex items-center gap-1.5 rounded px-1.5 py-1 text-left text-xs hover:bg-surface-raised"
-                >
-                  <span className="shrink-0 text-[10px] text-text-faint">{KIND_LABEL[e.kind]} →</span>
-                  <span className="shrink-0 font-mono text-[11px] text-text-muted">{e.to}</span>
-                  <span className="truncate text-text-muted">{peer ? truncate(peer.label, 20) : ""}</span>
-                </button>
-              );
-            })}
+            <div className="flex flex-col gap-1 max-h-[30vh] overflow-y-auto overscroll-contain pr-1">
+              {directOut.map((e, i) => {
+                const peer = nodes.get(endpointToNodeId(e.to));
+                return (
+                  <button
+                    key={`o-${i}`}
+                    onClick={() => onFocus(endpointToNodeId(e.to))}
+                    className="flex items-center gap-1.5 rounded px-1.5 py-1 text-left ui-meta hover:bg-surface-raised"
+                  >
+                    <span className="shrink-0 text-[11px] text-text-faint">{KIND_LABEL[e.kind]} →</span>
+                    <span className="shrink-0 font-mono ui-meta text-text-muted">{e.to}</span>
+                    <span className="truncate text-text-muted">{peer ? truncate(peer.label, 20) : ""}</span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         )}
 
         {directIn.length > 0 && (
           <div className="flex flex-col gap-1">
-            <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
+            <span className="font-mono text-[11px] uppercase tracking-wide text-text-faint">
               入边 {directIn.length}
             </span>
-            {directIn.map((e, i) => {
-              const peer = nodes.get(endpointToNodeId(e.from));
-              return (
-                <button
-                  key={`i-${i}`}
-                  onClick={() => onFocus(endpointToNodeId(e.from))}
-                  className="flex items-center gap-1.5 rounded px-1.5 py-1 text-left text-xs hover:bg-surface-raised"
-                >
-                  <ArrowSquareOut weight="bold" className="shrink-0 text-[10px] text-text-faint" />
-                  <span className="shrink-0 text-[10px] text-text-faint">← {KIND_LABEL_IN[e.kind]}</span>
-                  <span className="shrink-0 font-mono text-[11px] text-text-muted">{e.from}</span>
-                  <span className="truncate text-text-muted">{peer ? truncate(peer.label, 20) : ""}</span>
-                </button>
-              );
-            })}
+            <div className="flex flex-col gap-1 max-h-[30vh] overflow-y-auto overscroll-contain pr-1">
+              {directIn.map((e, i) => {
+                const peer = nodes.get(endpointToNodeId(e.from));
+                return (
+                  <button
+                    key={`i-${i}`}
+                    onClick={() => onFocus(endpointToNodeId(e.from))}
+                    className="flex items-center gap-1.5 rounded px-1.5 py-1 text-left ui-meta hover:bg-surface-raised"
+                  >
+                    <ArrowSquareOut weight="bold" className="shrink-0 text-[11px] text-text-faint" />
+                    <span className="shrink-0 text-[11px] text-text-faint">← {KIND_LABEL_IN[e.kind]}</span>
+                    <span className="shrink-0 font-mono ui-meta text-text-muted">{e.from}</span>
+                    <span className="truncate text-text-muted">{peer ? truncate(peer.label, 20) : ""}</span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         )}
       </div>

--- a/packages/gui/src/renderer/graph/canvasEgoLayout.ts
+++ b/packages/gui/src/renderer/graph/canvasEgoLayout.ts
@@ -303,6 +303,10 @@ export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
       id,
       type: "ego",
       position: { x: center.x - w / 2, y: center.y - h / 2 },
+      // 尺寸同时给 style(渲染)和顶层 width/height(RF 内部维度)。少了顶层这对,
+      // node.measured 直到 DOM 观测才有值,MiniMap 的 nodeHasDimensions() 判假 → 一个方块都不画。
+      width: w,
+      height: h,
       style: { width: w, height: h },
       data: {
         entity: meta.entity,

--- a/packages/gui/src/renderer/graph/canvasEgoLayout.ts
+++ b/packages/gui/src/renderer/graph/canvasEgoLayout.ts
@@ -1,0 +1,379 @@
+import type { TaskRow, RelationEdge, DecisionRow, FactRef } from "../model/types";
+import { parseEndpoint, endpointToNodeId } from "./endpoint";
+import { axisForKind, type SemanticAxis } from "./constants";
+import type { AxisFilter, GraphFilterInput, LayoutOutput } from "./graphLayoutTypes";
+import {
+  buildEdge,
+  factRefOf,
+  findRelationCycles,
+  inLoopEdge,
+  statusColor,
+} from "./graphLayoutShared";
+import type { Node, Edge } from "@xyflow/react";
+import { Position } from "@xyflow/react";
+
+/**
+ * 无限画布 ego 布局(dec_01KXBGJQFQARSZHHQW1WADFDNC refines dec_01KXA7811)。
+ *
+ * 取代 simpleEgoLayout 的单跳径向 / threeLaneLayout 的 claim 泳道:三类实体统一,
+ * 以焦点为 0 级,按跳级(BFS hop)分层成列——上游系谱→左,下游落地→右,同级竖排,
+ * barycenter 排序减少交叉。确定性布局,零重叠,不测 DOM。
+ *
+ * 累积模型:GraphView 持有 `shown`(累积可见集 id→hop)与 `expanded`(渲染为卡片的 id)。
+ * 本文件导出:
+ *   buildEgoGraph  — 统一图(byId + adj,含合成父子边),布局与 GraphView reveal 共用。
+ *   bfsShown       — 从焦点 BFS 到 maxHop 的可见集(openFocus 用,按轴过滤)。
+ *   neighborsOf    — 某节点通过轴过滤的一跳邻居 id(revealNeighbors 用)。
+ *   layoutCanvasEgo — 纯布局器:给定 (focusId, shown, expanded, filters) → 节点位置 + 边。
+ * 展开/收起/长邻居的状态变更在 GraphView(单击永不重排已展开画布)。
+ */
+
+export type Entity = "task" | "decision" | "fact";
+
+export interface NodeMeta {
+  entity: Entity;
+  row: TaskRow | DecisionRow | FactRef;
+}
+
+export interface AdjEntry {
+  other: string;
+  dir: "out" | "in";
+  axis: SemanticAxis;
+  edge: RelationEdge;
+  /** 去重键(避免同一条边正反各画一次)。 */
+  key: string;
+}
+
+export interface EgoGraph {
+  byId: Map<string, NodeMeta>;
+  adj: Map<string, AdjEntry[]>;
+  /** 合成的 task 父子边(执行轴),供边组装复用。 */
+  synthEdges: Array<{ edge: RelationEdge; key: string }>;
+}
+
+/** 统一图:byId(三类实体归一 id) + adj(relations 双向 + 合成 task 父子边)。 */
+export function buildEgoGraph(
+  tasks: TaskRow[],
+  decisions: DecisionRow[],
+  facts: FactRef[],
+  relations: RelationEdge[],
+): EgoGraph {
+  const byId = new Map<string, NodeMeta>();
+  for (const t of tasks) byId.set(t.taskId, { entity: "task", row: t });
+  for (const d of decisions) byId.set(`decision/${d.decisionId}`, { entity: "decision", row: d });
+  for (const f of facts) byId.set(factRefOf(f), { entity: "fact", row: f });
+
+  const adj = new Map<string, AdjEntry[]>();
+  const addAdj = (a: string, e: AdjEntry) => {
+    const list = adj.get(a);
+    if (list) list.push(e);
+    else adj.set(a, [e]);
+  };
+  const link = (edge: RelationEdge, axis: SemanticAxis, key: string) => {
+    const s = endpointToNodeId(edge.from);
+    const t = endpointToNodeId(edge.to);
+    if (!byId.has(s) || !byId.has(t)) return; // 跳过悬挂端点
+    addAdj(s, { other: t, dir: "out", axis, edge, key });
+    addAdj(t, { other: s, dir: "in", axis, edge, key });
+  };
+
+  relations.forEach((edge, i) => {
+    if (!parseEndpoint(edge.from) || !parseEndpoint(edge.to)) return;
+    link(edge, axisForKind(edge.kind), `rel_${i}`);
+  });
+
+  // 合成父子边:parent → child,执行轴(parentTaskId 不在 relations 里)。
+  const synthEdges: Array<{ edge: RelationEdge; key: string }> = [];
+  const taskIds = new Set(tasks.map((t) => t.taskId));
+  for (const t of tasks) {
+    if (t.parentTaskId && taskIds.has(t.parentTaskId)) {
+      const edge: RelationEdge = {
+        from: `task/${t.parentTaskId}`,
+        to: `task/${t.taskId}`,
+        kind: "depends-on",
+        provenance: "local-document",
+        rationale: "子任务",
+      };
+      const key = `child_${t.taskId}`;
+      link(edge, "execution", key);
+      synthEdges.push({ edge, key });
+    }
+  }
+
+  return { byId, adj, synthEdges };
+}
+
+/** 从焦点 BFS 到 maxHop 的可见集(id → hop),按轴过滤。openFocus 铺开默认 ±2 跳。 */
+export function bfsShown(
+  graph: EgoGraph,
+  focusId: string,
+  maxHop: number,
+  axes: AxisFilter,
+): Map<string, number> {
+  const shown = new Map<string, number>([[focusId, 0]]);
+  const queue: Array<[string, number]> = [[focusId, 0]];
+  while (queue.length) {
+    const [id, h] = queue.shift()!;
+    if (h >= maxHop) continue;
+    for (const a of graph.adj.get(id) ?? []) {
+      if (!axes[a.axis]) continue;
+      if (!shown.has(a.other)) {
+        shown.set(a.other, h + 1);
+        queue.push([a.other, h + 1]);
+      }
+    }
+  }
+  return shown;
+}
+
+/** 某节点通过轴过滤的一跳邻居 id(去重)。revealNeighbors 用。 */
+export function neighborsOf(graph: EgoGraph, id: string, axes: AxisFilter): string[] {
+  const out = new Set<string>();
+  for (const a of graph.adj.get(id) ?? []) {
+    if (axes[a.axis]) out.add(a.other);
+  }
+  return [...out];
+}
+
+export interface CanvasEgoInput {
+  focusId: string;
+  tasks: TaskRow[];
+  decisions: DecisionRow[];
+  facts: FactRef[];
+  /** 原始 relations(未按 axis 预筛;本布局器内部按 filters.axes 自筛)。 */
+  relations: RelationEdge[];
+  filters: GraphFilterInput;
+  inLoopEdges: Set<string>;
+  /** 累积可见集:node id → 距焦点跳数。 */
+  shown: Map<string, number>;
+  /** 渲染为详情卡片的 node id 集(其余为紧凑 chip)。 */
+  expanded: Set<string>;
+}
+
+// 节点尺寸(确定性布局用)。chip 紧凑一条;card 固定宽,高按内容估算并封顶。
+const CHIP_W = 216;
+const CHIP_H = 46;
+const CARD_W = 360;
+const GAP_X = 72;
+const GAP_Y = 26;
+
+/** 卡片高度:内容感知估算 + 封顶。节点即以此高渲染,分区溢出内滚 → 零重叠。 */
+function estimateCardHeight(entity: Entity, row: TaskRow | DecisionRow | FactRef): number {
+  if (entity === "task") return 150;
+  if (entity === "fact") {
+    const f = row as FactRef;
+    const obs = Math.min(160, 56 + Math.ceil((f.text?.length ?? 0) / 42) * 20);
+    return 108 + obs;
+  }
+  const d = row as DecisionRow;
+  let h = 130;
+  if (d.question) h += Math.min(96, 34 + Math.ceil(d.question.length / 40) * 20);
+  if (d.chosen && d.chosen.length) h += Math.min(120, 34 + d.chosen.length * 26);
+  if (d.claims && d.claims.length) h += Math.min(120, 30 + d.claims.length * 24);
+  return Math.min(476, h);
+}
+
+function nodeDims(
+  entity: Entity,
+  expanded: boolean,
+  row: NodeMeta["row"] | undefined,
+): { w: number; h: number } {
+  if (expanded && row) return { w: CARD_W, h: estimateCardHeight(entity, row) };
+  return { w: CHIP_W, h: CHIP_H };
+}
+
+export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
+  const { focusId, filters, shown, expanded } = input;
+  const { byId, adj, synthEdges } = buildEgoGraph(
+    input.tasks,
+    input.decisions,
+    input.facts,
+    input.relations,
+  );
+
+  const axisOn = (axis: SemanticAxis): boolean => filters.axes[axis];
+  const typeOn = (entity: Entity): boolean => filters.types.has(entity);
+
+  // ── 可见集:shown 中通过类型过滤者;焦点恒可见(不被自身类型开关抹掉) ──
+  const vis = new Set<string>();
+  for (const id of shown.keys()) {
+    if (id === focusId) {
+      vis.add(id);
+      continue;
+    }
+    const meta = byId.get(id);
+    if (meta && typeOn(meta.entity)) vis.add(id);
+  }
+  if (byId.has(focusId)) vis.add(focusId);
+
+  // ── 分级:BFS from focus,边方向定侧(出=下游/右,入=上游/左),更深处沿父方向 ──
+  const lvl = new Map<string, number>([[focusId, 0]]);
+  const side = new Map<string, "focus" | "up" | "down">([[focusId, "focus"]]);
+  const queue = [focusId];
+  while (queue.length) {
+    const id = queue.shift()!;
+    const L = lvl.get(id)!;
+    for (const a of adj.get(id) ?? []) {
+      if (!axisOn(a.axis) || !vis.has(a.other) || lvl.has(a.other)) continue;
+      lvl.set(a.other, L + 1);
+      side.set(a.other, id === focusId ? (a.dir === "out" ? "down" : "up") : side.get(id)!);
+      queue.push(a.other);
+    }
+  }
+  // 筛选下变孤立的 vis 节点 → 归到最远下游一列,不丢失。
+  let far = 1;
+  for (const v of lvl.values()) far = Math.max(far, v);
+  for (const id of vis) {
+    if (!lvl.has(id)) {
+      lvl.set(id, far + 1);
+      side.set(id, "down");
+    }
+  }
+
+  // ── 分列:按 side:level 聚列,barycenter 排序,竖排居中于 y=0 ──
+  const pos = new Map<string, { x: number; y: number }>();
+  const dimOf = (id: string) => {
+    const meta = byId.get(id);
+    return nodeDims(meta?.entity ?? "task", expanded.has(id), meta?.row);
+  };
+  const cols = new Map<string, string[]>();
+  for (const id of vis) {
+    const k = `${side.get(id)}:${lvl.get(id)}`;
+    const list = cols.get(k);
+    if (list) list.push(id);
+    else cols.set(k, [id]);
+  }
+  pos.set(focusId, { x: 0, y: 0 });
+  const bary = (id: string, innerL: number): number => {
+    let s = 0;
+    let n = 0;
+    for (const a of adj.get(id) ?? []) {
+      if (!axisOn(a.axis)) continue;
+      if (lvl.get(a.other) === innerL && pos.has(a.other)) {
+        s += pos.get(a.other)!.y;
+        n += 1;
+      }
+    }
+    return n ? s / n : 1e9;
+  };
+  for (const [sd, sign] of [
+    ["down", 1],
+    ["up", -1],
+  ] as const) {
+    let cx = dimOf(focusId).w / 2;
+    let L = 1;
+    while (cols.has(`${sd}:${L}`)) {
+      const ids = cols.get(`${sd}:${L}`)!;
+      ids.sort((a, b) => bary(a, L - 1) - bary(b, L - 1));
+      const w = Math.max(...ids.map((id) => dimOf(id).w));
+      cx += GAP_X + w / 2;
+      const totalH = ids.reduce((acc, id) => acc + dimOf(id).h + GAP_Y, -GAP_Y);
+      let y = -totalH / 2;
+      for (const id of ids) {
+        const h = dimOf(id).h;
+        pos.set(id, { x: sign * cx, y: y + h / 2 });
+        y += h + GAP_Y;
+      }
+      cx += w / 2;
+      L += 1;
+    }
+  }
+
+  // ── 组装 React Flow 节点 ──
+  const rfNodes: Node[] = [];
+  for (const id of vis) {
+    const meta = byId.get(id);
+    if (!meta) continue;
+    const center = pos.get(id) ?? { x: 0, y: 0 };
+    const isExpanded = expanded.has(id);
+    const { w, h } = nodeDims(meta.entity, isExpanded, meta.row);
+    let hiddenCount = 0;
+    for (const a of adj.get(id) ?? []) {
+      if (
+        axisOn(a.axis) &&
+        !shown.has(a.other) &&
+        byId.has(a.other) &&
+        typeOn(byId.get(a.other)!.entity)
+      ) {
+        hiddenCount += 1;
+      }
+    }
+    const navRef = meta.entity === "task" ? `task/${id}` : id;
+    rfNodes.push({
+      id,
+      type: "ego",
+      position: { x: center.x - w / 2, y: center.y - h / 2 },
+      style: { width: w, height: h },
+      data: {
+        entity: meta.entity,
+        raw: meta.row,
+        label: labelOf(meta),
+        focus: id === focusId,
+        expanded: isExpanded,
+        hop: lvl.get(id) ?? 0,
+        degree: (adj.get(id) ?? []).filter((a) => axisOn(a.axis)).length,
+        hiddenCount,
+        color: meta.entity === "task" ? statusColor(meta.row as TaskRow) : undefined,
+        navRef,
+      },
+      zIndex: id === focusId ? 6 : isExpanded ? 5 : 1,
+    });
+  }
+
+  // ── 组装边:两端都在 vis + 轴开 ──
+  const rfEdges: Edge[] = [];
+  const emit = (edge: RelationEdge, axis: SemanticAxis, key: string) => {
+    const s = endpointToNodeId(edge.from);
+    const t = endpointToNodeId(edge.to);
+    if (!vis.has(s) || !vis.has(t) || !axisOn(axis)) return;
+    rfEdges.push(
+      buildEdge({
+        edgeId: `e_${key}`,
+        edge,
+        sourceId: s,
+        targetId: t,
+        sourcePosition: Position.Right,
+        targetPosition: Position.Left,
+        axis,
+        isLoop: inLoopEdge(input.inLoopEdges, edge),
+      }),
+    );
+  };
+  input.relations.forEach((edge, i) => {
+    if (!parseEndpoint(edge.from) || !parseEndpoint(edge.to)) return;
+    emit(edge, axisForKind(edge.kind), `rel_${i}`);
+  });
+  for (const { edge, key } of synthEdges) emit(edge, "execution", key);
+
+  const normalizedEdges = rfEdges.map((e) => ({ from: e.source, to: e.target }));
+  const cycleWarning = findRelationCycles(normalizedEdges);
+
+  let minX = 0;
+  let minY = 0;
+  let maxX = 0;
+  let maxY = 0;
+  for (const n of rfNodes) {
+    const w = (n.style?.width as number) ?? CHIP_W;
+    const h = (n.style?.height as number) ?? CHIP_H;
+    minX = Math.min(minX, n.position.x);
+    minY = Math.min(minY, n.position.y);
+    maxX = Math.max(maxX, n.position.x + w);
+    maxY = Math.max(maxY, n.position.y + h);
+  }
+
+  return {
+    nodes: rfNodes,
+    edges: rfEdges,
+    cycleWarning: { count: cycleWarning.cycles.length, cycles: cycleWarning.cycles },
+    resolvedFocusId: focusId,
+    focusClaims: [],
+    bounds: { width: maxX - minX, height: maxY - minY },
+  };
+}
+
+function labelOf(meta: NodeMeta): string {
+  if (meta.entity === "task") return (meta.row as TaskRow).title;
+  if (meta.entity === "decision") return (meta.row as DecisionRow).title;
+  const f = meta.row as FactRef;
+  return f.text?.slice(0, 48) ?? f.anchor;
+}

--- a/packages/gui/src/renderer/graph/graphLayout.ts
+++ b/packages/gui/src/renderer/graph/graphLayout.ts
@@ -1,6 +1,7 @@
 import { parseEndpoint } from "./endpoint";
 import { edgePassesAxisFilter, pickDefaultFocus } from "./graphLayoutShared";
 import type { LayoutInput, LayoutOutput } from "./graphLayoutTypes";
+import { layoutCanvasEgo } from "./canvasEgoLayout";
 import { layoutSimpleEgo } from "./simpleEgoLayout";
 import { layoutThreeLane } from "./threeLaneLayout";
 
@@ -59,7 +60,23 @@ export async function computeGraphLayout(input: LayoutInput): Promise<LayoutOutp
     };
   }
 
-  // 分两类布局:decision focus 走三泳道;其他走简化 ego。
+  // 无限画布 ego(dec_01KXBGJQFQARSZHHQW1WADFDNC):存在 canvas 累积态即统一走
+  // 分层列布局(三类实体一视同仁,decision 的 claim 内联进卡片而非炸成 claim 节点)。
+  if (input.canvas) {
+    return layoutCanvasEgo({
+      focusId: resolvedFocusId,
+      tasks,
+      decisions,
+      facts,
+      relations: validEdges, // axis 过滤在布局器内部做(与原型 relOk 一致)
+      filters,
+      inLoopEdges,
+      shown: input.canvas.shown,
+      expanded: input.canvas.expanded,
+    });
+  }
+
+  // 分两类布局(legacy fallback,canvas 缺省时):decision focus 走三泳道;其他走简化 ego。
   const focusDecision = decisions.find((d) => `decision/${d.decisionId}` === resolvedFocusId);
   if (focusDecision && filters.types.has("decision")) {
     return layoutThreeLane({

--- a/packages/gui/src/renderer/graph/graphLayoutTypes.ts
+++ b/packages/gui/src/renderer/graph/graphLayoutTypes.ts
@@ -43,6 +43,13 @@ export interface LayoutInput {
   filters: GraphFilterInput;
   inLoopNodes: Set<string>;
   inLoopEdges: Set<string>;
+  /**
+   * 无限画布 ego 累积态(dec_01KXBGJQFQARSZHHQW1WADFDNC)。存在即走 layoutCanvasEgo
+   * (三类实体统一、按跳级分层列、原地展开累计保留),旁路 simpleEgo/threeLane。
+   *   shown    — 累积可见集 node id → 距焦点跳数。
+   *   expanded — 渲染为详情卡片的 node id 集(其余紧凑 chip)。
+   */
+  canvas?: { shown: Map<string, number>; expanded: Set<string> };
 }
 
 export interface LayoutOutput {

--- a/packages/gui/src/renderer/graph/nodes/EgoNode.tsx
+++ b/packages/gui/src/renderer/graph/nodes/EgoNode.tsx
@@ -1,0 +1,242 @@
+import type { MouseEvent } from "react";
+import { Handle, Position } from "@xyflow/react";
+import { X, Crosshair, ArrowsOutSimple } from "@phosphor-icons/react";
+import {
+  StatusBadge,
+  CloseoutBadge,
+  EngineBadge,
+  FreshnessTag,
+} from "../../components/badges";
+import { isExternal } from "../../model/types";
+import type { TaskRow, DecisionRow, FactRef } from "../../model/types";
+
+/**
+ * 无限画布 ego 节点(dec_01KXBGJQFQARSZHHQW1WADFDNC)。
+ * 一个组件两态:
+ *   chip — 紧凑一条(默认),点一下就地展开成卡片并长出邻居。
+ *   card — 详情卡片(镜像 GraphDrawer 清晰度:徽章 / 轴色分区 / 大字 / 固定高内滚)。
+ *
+ * 交互回调由 GraphView 在 setNodes 时注入 data:
+ *   data.onCollapse(id)  收起卡片(保留已展开邻居)
+ *   data.onRefocus(id)   设为画布中心(重排 ±2 跳)
+ *   data.onNavigate(ref) 跳转该实体专属详情页(task→详情 / decision→池 / fact→分诊)
+ * chip 的"点击展开"走 ReactFlow onNodeClick,不在此处理。
+ */
+
+type Entity = "task" | "decision" | "fact";
+
+const AXIS_VAR: Record<Entity, string> = {
+  task: "var(--color-axis-execution)",
+  decision: "var(--color-axis-authority)",
+  fact: "var(--color-axis-evidence)",
+};
+const KD_LETTER: Record<Entity, string> = { task: "T", decision: "D", fact: "F" };
+
+const HANDLE_CLS =
+  "!h-2 !w-2 !min-w-2 !min-h-2 !border-0 !bg-[var(--color-border-strong)]";
+
+function Handles() {
+  return (
+    <>
+      <Handle type="target" position={Position.Left} className={HANDLE_CLS} />
+      <Handle type="source" position={Position.Right} className={HANDLE_CLS} />
+    </>
+  );
+}
+
+export function EgoNode({ data, selected }: any) {
+  const entity: Entity = data.entity;
+  const axis = AXIS_VAR[entity];
+  const focus = Boolean(data.focus);
+
+  if (!data.expanded) {
+    // ── chip ──
+    return (
+      <div
+        className="flex h-full w-full items-center gap-2 overflow-hidden rounded-lg border bg-surface-raised pl-0 pr-2.5 cursor-pointer transition-shadow duration-150 hover:shadow-md"
+        style={{
+          borderColor: focus ? axis : selected ? axis : "var(--color-border-strong)",
+          borderWidth: focus ? 2 : 1,
+          boxShadow: focus ? `0 0 0 2px ${axis}` : undefined,
+        }}
+      >
+        <Handles />
+        <div className="h-full w-[3px] shrink-0 rounded-l" style={{ backgroundColor: axis }} />
+        <span
+          className="grid size-[18px] shrink-0 place-items-center rounded font-mono text-[10px] font-bold"
+          style={{ backgroundColor: `color-mix(in srgb, ${axis} 18%, transparent)`, color: axis }}
+        >
+          {KD_LETTER[entity]}
+        </span>
+        {entity === "task" && (
+          <span
+            className="size-[7px] shrink-0 rounded-full"
+            style={{ backgroundColor: data.color ?? "var(--color-status-planned)" }}
+          />
+        )}
+        <span className="ui-meta min-w-0 flex-1 truncate text-text">{data.label}</span>
+        {data.hiddenCount > 0 && (
+          <span className="shrink-0 rounded-full bg-surface px-1.5 py-0.5 font-mono text-[10px] text-text-faint">
+            +{data.hiddenCount}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  // ── card ──
+  const stop = (fn?: (arg: any) => void, arg?: any) => (e: MouseEvent) => {
+    e.stopPropagation();
+    fn?.(arg);
+  };
+
+  return (
+    <div
+      className="flex h-full w-full flex-col overflow-hidden rounded-xl border bg-surface shadow-lg"
+      style={{
+        borderColor: focus ? axis : "var(--color-border-strong)",
+        borderWidth: focus ? 2 : 1,
+        boxShadow: focus ? `0 0 0 2px ${axis}, 0 8px 28px rgba(0,0,0,0.28)` : undefined,
+      }}
+    >
+      <Handles />
+      {/* header */}
+      <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-2.5 py-1.5">
+        <span
+          className="grid h-[18px] shrink-0 place-items-center rounded px-1.5 font-mono text-[9px] font-bold uppercase tracking-wide"
+          style={{ backgroundColor: `color-mix(in srgb, ${axis} 18%, transparent)`, color: axis }}
+        >
+          {entity}
+        </span>
+        <span className="ml-auto flex items-center gap-1">
+          {data.onRefocus && !focus && (
+            <button
+              onClick={stop(data.onRefocus, data.id ?? undefined)}
+              title="设为画布中心(重排前后 2 跳)"
+              className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[10px] text-text-muted hover:border-[var(--color-border-strong)] hover:text-text"
+            >
+              <Crosshair weight="bold" className="text-[10px]" />
+              设为中心
+            </button>
+          )}
+          {data.onNavigate && (
+            <button
+              onClick={stop(data.onNavigate, data.navRef)}
+              title="打开专属详情页(task→详情 · decision→决策池 · fact→分诊)"
+              className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[10px] text-text-muted hover:border-accent hover:text-accent"
+            >
+              <ArrowsOutSimple weight="bold" className="text-[10px]" />
+              详情 ↗
+            </button>
+          )}
+          <button
+            onClick={stop(data.onCollapse, data.id ?? undefined)}
+            title="收起(保留已展开邻居)"
+            className="grid size-5 place-items-center rounded text-text-faint hover:bg-surface-raised hover:text-text"
+          >
+            <X weight="bold" className="text-[11px]" />
+          </button>
+        </span>
+      </div>
+
+      {/* title */}
+      <div className="shrink-0 px-2.5 pt-2">
+        <p className="ui-body font-semibold leading-snug text-text">{cardTitle(entity, data)}</p>
+      </div>
+
+      {/* scrollable body */}
+      <div className="mt-1.5 flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain px-2.5 pb-2">
+        {entity === "task" && <TaskBody t={data.raw as TaskRow} />}
+        {entity === "decision" && <DecisionBody d={data.raw as DecisionRow} />}
+        {entity === "fact" && <FactBody f={data.raw as FactRef} />}
+      </div>
+
+      {/* footer */}
+      <div className="flex shrink-0 items-center justify-between border-t border-border px-2.5 py-1 font-mono text-[10px] text-text-faint">
+        <span>度数 {data.degree ?? 0} · 第 {data.hop ?? 0} 跳</span>
+        {data.hiddenCount > 0 && <span>还有 +{data.hiddenCount} 未展开</span>}
+      </div>
+    </div>
+  );
+}
+
+function cardTitle(entity: Entity, data: any): string {
+  if (entity === "fact") return `证据 · ${(data.raw as FactRef).text?.slice(0, 60) ?? ""}`;
+  return data.label;
+}
+
+function TaskBody({ t }: { t: TaskRow }) {
+  return (
+    <>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <StatusBadge status={t.coordinationStatus} />
+        <CloseoutBadge value={t.closeoutReadiness} />
+        <EngineBadge engine={t.engine} locked={isExternal(t)} />
+      </div>
+      <FreshnessTag freshness={t.freshness} lastKnownAt={t.lastKnownAt} />
+      <div className="flex flex-wrap gap-x-3 gap-y-1 font-mono text-[11px] text-text-muted">
+        <span>module: {t.module}</span>
+        {t.riskTier && <span>risk: {t.riskTier}</span>}
+        {t.urgency && <span>urgency: {t.urgency}</span>}
+      </div>
+    </>
+  );
+}
+
+function DecisionBody({ d }: { d: DecisionRow }) {
+  return (
+    <>
+      <div className="flex items-center gap-2 font-mono text-[11px]">
+        <span className="rounded bg-accent px-1.5 py-0.5 text-accent-fg">{d.state}</span>
+        <span className="text-text-muted">
+          {(d.riskTier ?? "未知")} risk · {(d.urgency ?? "未知")} urgency
+        </span>
+      </div>
+      {d.question && (
+        <div className="rounded-md border border-border bg-surface-raised px-2 py-1.5">
+          <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">Question</span>
+          <p className="ui-body mt-0.5 font-medium text-text">{d.question}</p>
+        </div>
+      )}
+      {d.chosen && d.chosen.length > 0 && (
+        <div className="rounded-md border border-accent/30 bg-accent-fg/5 px-2 py-1.5">
+          <span className="font-mono text-[10px] uppercase tracking-wide text-accent">Chosen</span>
+          <div className="mt-0.5 flex flex-col gap-1">
+            {d.chosen.map((c) => (
+              <p key={c.id} className="ui-body text-text">{c.text}</p>
+            ))}
+          </div>
+        </div>
+      )}
+      {d.claims && d.claims.length > 0 && (
+        <div className="rounded-md border border-border bg-surface-raised px-2 py-1.5">
+          <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">Claims</span>
+          <ul className="ui-body mt-0.5 list-inside list-disc text-text-muted">
+            {d.claims.map((c) => (
+              <li key={c.id}>{c.text}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+}
+
+function FactBody({ f }: { f: FactRef }) {
+  return (
+    <>
+      <div className="flex items-center gap-2 font-mono text-[11px]">
+        <span className="rounded bg-stale px-1.5 py-0.5 text-stale-fg">{f.category}</span>
+        <span className="text-text-muted">@ {f.at}</span>
+      </div>
+      <div className="rounded-md border border-stale/30 bg-stale/5 px-2 py-1.5">
+        <span className="font-mono text-[10px] uppercase tracking-wide text-stale">Fact Observation</span>
+        <p className="ui-body mt-0.5 font-medium leading-relaxed text-text">{f.text}</p>
+      </div>
+      <div className="rounded-md border border-border bg-surface-raised px-2 py-1.5 font-mono text-[11px] text-text-muted">
+        <div>Task: {f.taskId}</div>
+        <div>Anchor: {f.anchor}</div>
+      </div>
+    </>
+  );
+}

--- a/packages/gui/src/renderer/graph/useEgoCanvas.ts
+++ b/packages/gui/src/renderer/graph/useEgoCanvas.ts
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useReactFlow } from "@xyflow/react";
+
+import type { TaskRow, RelationEdge, DecisionRow, FactRef } from "../model/types";
+import type { AxisFilter } from "./graphLayoutTypes";
+import { endpointToNodeId } from "./endpoint";
+import { buildEgoGraph, bfsShown, neighborsOf, type EgoGraph } from "./canvasEgoLayout";
+import { pickDefaultFocus } from "./graphLayoutShared";
+import {
+  createFocusHistory,
+  currentFocus,
+  canGoBack as historyCanGoBack,
+  canGoForward as historyCanGoForward,
+  goBack as historyGoBack,
+  goForward as historyGoForward,
+  pushFocus,
+  type FocusHistoryState,
+} from "./focusHistory";
+
+/**
+ * 无限画布 ego 的状态机(dec_01KXBGJQFQARSZHHQW1WADFDNC)。
+ *
+ * 一个焦点 + 两个累积集,外加焦点历史与「换焦点即居中」的视口动作:
+ *   focusId  — 当前画布中心(布局器据此分级)。
+ *   shown    — 累积可见集 node id → 距焦点跳数。openFocus 铺 ±2;展开卡片时长出
+ *              它的一跳邻居;收起**不撤**任何节点(累计保留)。
+ *   expanded — 渲染为详情卡片的 node id,其余是紧凑 chip。
+ *
+ * 不变量:只有 openFocus / 历史前进后退会重排画布(resetCanvasTo);单击展开、
+ * 收起都只增不减,永不重排已铺开的画布。
+ */
+
+// 换焦点时把焦点摆到视口正中所用的缩放:焦点卡片(360 宽)+ 左右各一列 chip 同屏可读。
+const FOCUS_ZOOM = 0.9;
+// openFocus 默认铺开的跳数(上游 2 跳 + 下游 2 跳)。
+const DEFAULT_HOPS = 2;
+
+export interface EgoCanvas {
+  focusId: string | null;
+  shown: Map<string, number>;
+  expanded: Set<string>;
+  canBack: boolean;
+  canForward: boolean;
+  /** 设为画布中心:切焦点 + 推历史 + 重排 ±2 跳。 */
+  openFocus: (id: string) => void;
+  /** chip 就地展开成卡片,并把它的一跳邻居加入 shown(长出下一环,累积)。 */
+  expandNode: (id: string) => void;
+  /** 收起卡片,保留已展开邻居(累计保留)。 */
+  collapseNode: (id: string) => void;
+  /** 退出聚焦:清空焦点与累积态(不脚印化,不动历史)。 */
+  clearFocus: () => void;
+  goBack: () => void;
+  goForward: () => void;
+}
+
+export function useEgoCanvas({
+  tasks,
+  decisions,
+  facts,
+  relations,
+  axes,
+  focusRef,
+  nodes,
+  resolvedFocusId,
+}: {
+  tasks: TaskRow[];
+  decisions: DecisionRow[];
+  facts: FactRef[];
+  relations: RelationEdge[];
+  axes: AxisFilter;
+  focusRef?: string | null;
+  /** 布局器算出的 React Flow 节点(用于「换焦点即居中」读焦点节点的实际盒子)。 */
+  nodes: ReadonlyArray<any>;
+  /** 布局器最终采用的焦点(用户未显式聚焦时是默认焦点)。 */
+  resolvedFocusId: string | null;
+}): EgoCanvas {
+  const { setCenter } = useReactFlow();
+
+  const [focusId, setFocusId] = useState<string | null>(null);
+  const [history, setHistory] = useState<FocusHistoryState>(createFocusHistory);
+  const [shown, setShown] = useState<Map<string, number>>(() => new Map());
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+
+  // 统一图(byId + adj,含合成 task 父子边),供 openFocus / 展开的 BFS 遍历复用。
+  const egoGraph: EgoGraph = useMemo(
+    () => buildEgoGraph(tasks, decisions, facts, relations),
+    [tasks, decisions, facts, relations],
+  );
+
+  // 重排画布到某焦点:铺开前后各 2 跳、只展开焦点自身(累积态重置)。
+  const resetCanvasTo = useCallback(
+    (id: string) => {
+      setShown(bfsShown(egoGraph, id, DEFAULT_HOPS, axes));
+      setExpanded(new Set([id]));
+    },
+    [egoGraph, axes],
+  );
+
+  const openFocus = useCallback(
+    (id: string) => {
+      setFocusId(id);
+      setHistory((prev) => pushFocus(prev, id)); // 重复推同 id 会被 pushFocus 折叠
+      resetCanvasTo(id);
+    },
+    [resetCanvasTo],
+  );
+  // 稳定引用:bootstrap effect 只在 focusRef / 数据变时触发,不因 openFocus 身份变动而重排。
+  const openFocusRef = useRef(openFocus);
+  openFocusRef.current = openFocus;
+
+  const expandNode = useCallback(
+    (id: string) => {
+      setExpanded((prev) => new Set(prev).add(id));
+      setShown((prev) => {
+        const next = new Map(prev);
+        const base = next.get(id) ?? 0;
+        for (const nb of neighborsOf(egoGraph, id, axes)) {
+          if (!next.has(nb)) next.set(nb, base + 1);
+        }
+        return next;
+      });
+    },
+    [egoGraph, axes],
+  );
+
+  const collapseNode = useCallback((id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+
+  const clearFocus = useCallback(() => {
+    setFocusId(null);
+    setShown(new Map());
+    setExpanded(new Set());
+    // 不动历史:用户「退出聚焦」不脚印化。清空后 bootstrap 会重开默认焦点。
+  }, []);
+
+  // 历史前进 / 后退:切焦点 + 重排画布(不重复推栈)。
+  const stepHistory = useCallback(
+    (step: (prev: FocusHistoryState) => FocusHistoryState) => {
+      setHistory((prev) => {
+        const next = step(prev);
+        if (next === prev) return prev;
+        const f = currentFocus(next);
+        setFocusId(f);
+        if (f) resetCanvasTo(f);
+        return next;
+      });
+    },
+    [resetCanvasTo],
+  );
+  const goBack = useCallback(() => stepHistory(historyGoBack), [stepHistory]);
+  const goForward = useCallback(() => stepHistory(historyGoForward), [stepHistory]);
+
+  // 跨视图带入的 focusRef → 打开该焦点(用户「跳到这张图」的足迹)。
+  useEffect(() => {
+    if (!focusRef) return;
+    const nodeId = endpointToNodeId(focusRef);
+    if (nodeId) openFocusRef.current(nodeId);
+  }, [focusRef]);
+
+  // 首次(数据到位而未聚焦、且无外部 focusRef)= 打开默认焦点,铺开 ±2。
+  useEffect(() => {
+    if (focusId || focusRef) return;
+    const def = pickDefaultFocus(decisions, tasks);
+    if (def) openFocusRef.current(def);
+  }, [focusId, focusRef, decisions, tasks]);
+
+  // 换焦点时把焦点节点摆进视口正中 —— 兑现「以它为中心」,同时躲开左上角 Filters 面板
+  // (fitView 按整图 bbox 居中,下游更宽时会把焦点推到左侧压在面板底下)。
+  // 只在焦点变化时触发:累积展开 / 长邻居永不重排已有画布。
+  const lastCenteredFocus = useRef<string | null>(null);
+  useEffect(() => {
+    if (!resolvedFocusId) return;
+    if (lastCenteredFocus.current === resolvedFocusId) return;
+    const focusNode = nodes.find((n) => n.id === resolvedFocusId);
+    if (!focusNode) return;
+    lastCenteredFocus.current = resolvedFocusId;
+    const cx = focusNode.position.x + Number(focusNode.width ?? 0) / 2;
+    const cy = focusNode.position.y + Number(focusNode.height ?? 0) / 2;
+    const frame = window.requestAnimationFrame(() => {
+      setCenter(cx, cy, { zoom: FOCUS_ZOOM, duration: 320 });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [resolvedFocusId, nodes, setCenter]);
+
+  return {
+    focusId,
+    shown,
+    expanded,
+    canBack: historyCanGoBack(history),
+    canForward: historyCanGoForward(history),
+    openFocus,
+    expandNode,
+    collapseNode,
+    clearFocus,
+    goBack,
+    goForward,
+  };
+}

--- a/packages/gui/src/renderer/views/GraphView.tsx
+++ b/packages/gui/src/renderer/views/GraphView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useCallback, useRef } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import {
   ReactFlow,
   MiniMap,
@@ -7,7 +7,6 @@ import {
   BackgroundVariant,
   ReactFlowProvider,
   Panel,
-  useReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
@@ -28,23 +27,7 @@ import {
   type AxisFilter,
   type GraphFilterInput,
 } from "../graph/graphLayout";
-import {
-  buildEgoGraph,
-  bfsShown,
-  neighborsOf,
-  type EgoGraph,
-} from "../graph/canvasEgoLayout";
-import { pickDefaultFocus } from "../graph/graphLayoutShared";
-import {
-  createFocusHistory,
-  currentFocus,
-  canGoBack as historyCanGoBack,
-  canGoForward as historyCanGoForward,
-  goBack as historyGoBack,
-  goForward as historyGoForward,
-  pushFocus,
-  type FocusHistoryState,
-} from "../graph/focusHistory";
+import { useEgoCanvas } from "../graph/useEgoCanvas";
 
 import { TaskNode } from "../graph/nodes/TaskNode";
 import { DecisionNode } from "../graph/nodes/DecisionNode";
@@ -79,9 +62,6 @@ const edgeTypes = {
 
 const EMPTY_LOOP = new Set<string>();
 
-// 换焦点时把焦点摆到视口正中所用的缩放:焦点卡片(360 宽)+ 左右各一列 chip 同屏可读。
-const FOCUS_ZOOM = 0.9;
-
 const MINIMAP_AXIS: Record<string, string> = {
   task: "var(--color-axis-execution)",
   decision: "var(--color-axis-authority)",
@@ -112,35 +92,16 @@ function GraphViewInner({
   onNavigateEntity?: (ref: string) => void;
   focusRef?: string | null;
 }) {
-  const { setCenter } = useReactFlow();
   const colorMode = useColorMode();
 
-  // 节点焦点(布局重算依赖)+ 边焦点(仅抽屉展示)。修 #3:此前用单一 focusId
-  // 同时承载节点和边,点边时把 edge id 当 focusNodeId 传给布局器,导致
-  // layoutSimpleEgo 拿不到节点 → 整张图塌成单个空节点。
-  //
-  // GUI 可用性补齐(dec_01KXA7811SVVT8P66HNDFZQ7DF):拆开「选中」与「聚焦」。
-  //   focusId    — 布局焦点(三泳道中心 / ego 中心)。受 FocusSwitcher / 双击 /
-  //                 抽屉「设为焦点」/ 跨视图 focusRef 驱动,所有变更入焦点历史。
-  //   selectedId — 抽屉里展示的节点(单击节点选中)。点空白 / Esc / 抽屉关闭即清空。
-  const [focusId, setFocusId] = useState<string | null>(null);
+  // 边焦点(仅抽屉展示)独立于节点焦点。修 #3:此前用单一 focusId 同时承载节点和边,
+  // 点边时把 edge id 当 focusNodeId 传给布局器,导致布局器拿不到节点 → 整张图塌成
+  // 单个空节点。节点焦点 / 画布累积态现在整块住在 useEgoCanvas 里。
+  //   selectedId — 抽屉里展示的节点。点空白 / Esc / 抽屉关闭即清空。
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [focusEdgeId, setFocusEdgeId] = useState<string | null>(null);
   const [resolvedFocusId, setResolvedFocusId] = useState<string | null>(null);
   const [expandedFacts] = useState<Set<string>>(new Set());
-  const [history, setHistory] = useState<FocusHistoryState>(createFocusHistory);
-
-  // 无限画布 ego 累积态(dec_01KXBGJQFQARSZHHQW1WADFDNC):
-  //   shown    — 累积可见集 node id → 距焦点跳数(openFocus 铺 ±2,展开时长邻居,收起不撤)。
-  //   expanded — 渲染为详情卡片的 node id(其余紧凑 chip)。
-  const [shown, setShown] = useState<Map<string, number>>(() => new Map());
-  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
-
-  // 焦点切换统一入口:更新 focusId + 推历史。重复推同 id 会被 pushFocus 折叠。
-  const setFocusAndPushHistory = useCallback((id: string) => {
-    setFocusId(id);
-    setHistory((prev) => pushFocus(prev, id));
-  }, []);
 
   const [nodes, setNodes] = useState<any[]>([]);
   const [edges, setEdges] = useState<any[]>([]);
@@ -183,71 +144,29 @@ function GraphViewInner({
     [filters],
   );
 
-  // 统一图(byId + adj,含合成 task 父子边),供 openFocus/reveal 的 BFS 遍历复用。
-  const egoGraph: EgoGraph = useMemo(
-    () => buildEgoGraph(tasks, decisions ?? [], facts ?? [], relations),
-    [tasks, decisions, facts, relations],
-  );
-
-  // 重排画布到某焦点:铺开前后各 2 跳、只展开焦点自身(累积态重置)。
-  const resetCanvasTo = useCallback(
-    (id: string) => {
-      setShown(bfsShown(egoGraph, id, 2, filters.axes));
-      setExpanded(new Set([id]));
-    },
-    [egoGraph, filters.axes],
-  );
-
-  // 打开焦点(双击 / switcher / 抽屉 / 跨视图)= 设焦点 + 推历史 + 重排 ±2。
-  const openFocus = useCallback(
-    (id: string) => {
-      setFocusAndPushHistory(id);
-      resetCanvasTo(id);
-    },
-    [setFocusAndPushHistory, resetCanvasTo],
-  );
-  // 稳定引用:effect 只在 focusRef / 数据变时触发,不因 openFocus 身份变动而重排画布。
-  const openFocusRef = useRef(openFocus);
-  openFocusRef.current = openFocus;
-
-  // chip 就地展开成卡片,并把它通过轴过滤的一跳邻居加入 shown(长出下一环,累积)。
-  const expandNode = useCallback(
-    (id: string) => {
-      setExpanded((prev) => new Set(prev).add(id));
-      setShown((prev) => {
-        const next = new Map(prev);
-        const base = next.get(id) ?? 0;
-        for (const nb of neighborsOf(egoGraph, id, filters.axes)) {
-          if (!next.has(nb)) next.set(nb, base + 1);
-        }
-        return next;
-      });
-    },
-    [egoGraph, filters.axes],
-  );
-
-  // 收起卡片,保留已展开邻居(累计保留,单击/收起永不重排已展开画布)。
-  const collapseNode = useCallback((id: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      next.delete(id);
-      return next;
-    });
-  }, []);
-
-  // 跨视图带入的 focusRef → 打开该焦点(用户「跳到这张图」的足迹)。
-  useEffect(() => {
-    if (!focusRef) return;
-    const nodeId = endpointToNodeId(focusRef);
-    if (nodeId) openFocusRef.current(nodeId);
-  }, [focusRef]);
-
-  // 首次(数据到位而未聚焦、且无外部 focusRef)= 打开默认焦点,铺开 ±2。
-  useEffect(() => {
-    if (focusId || focusRef) return;
-    const def = pickDefaultFocus(decisions ?? [], tasks);
-    if (def) openFocusRef.current(def);
-  }, [focusId, focusRef, decisions, tasks]);
+  // 无限画布 ego 状态机(焦点 / 累积可见集 / 已展开卡片 / 焦点历史 / 换焦点即居中)。
+  const {
+    focusId,
+    shown,
+    expanded,
+    canBack,
+    canForward,
+    openFocus,
+    expandNode,
+    collapseNode,
+    clearFocus,
+    goBack,
+    goForward,
+  } = useEgoCanvas({
+    tasks,
+    decisions: decisions ?? [],
+    facts: facts ?? [],
+    relations,
+    axes: filters.axes,
+    focusRef,
+    nodes,
+    resolvedFocusId,
+  });
 
   useEffect(() => {
     const ac = new AbortController();
@@ -292,27 +211,6 @@ function GraphViewInner({
     shown,
     expanded,
   ]);
-
-  // 换焦点(openFocus)时把焦点节点摆进视口正中 —— 兑现「以它为中心」,同时躲开左上角
-  // Filters 面板(fitView 全景会按图 bbox 居中,下游更宽时焦点被推到左侧压在面板下)。
-  // 只在焦点变化时触发:累积展开 / 长邻居永不重排已有画布
-  // (dec_01KXBGJQFQARSZHHQW1WADFDNC「单击永不重排」)。用 ref 记住上次已居中的焦点。
-  const lastCenteredFocus = useRef<string | null>(null);
-  useEffect(() => {
-    if (!resolvedFocusId) return;
-    if (lastCenteredFocus.current === resolvedFocusId) return;
-    const focusNode = nodes.find((n) => n.id === resolvedFocusId);
-    if (!focusNode) return;
-    lastCenteredFocus.current = resolvedFocusId;
-    const w = Number(focusNode.style?.width ?? 0);
-    const h = Number(focusNode.style?.height ?? 0);
-    const cx = focusNode.position.x + w / 2;
-    const cy = focusNode.position.y + h / 2;
-    const frame = window.requestAnimationFrame(() => {
-      setCenter(cx, cy, { zoom: FOCUS_ZOOM, duration: 320 });
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [resolvedFocusId, nodes, setCenter]);
 
   // 单击 chip = 就地展开成卡片并长出邻居(累积,永不重排已有画布)。
   // 卡片(已展开)单击不处理 —— 收起 / 详情 / 设为中心 走卡片自身按钮。
@@ -459,36 +357,6 @@ function GraphViewInner({
     openFocus(drawerNodeId);
   }, [drawerNodeId, openFocus]);
 
-  // 历史导航:back/forward。currentFocus 为 null 表示走到历史外(默认焦点),
-  // 此时仍把 focusId 同步到 null 让布局器挑默认。
-  // 历史前进/后退:切焦点 + 重排画布(resetCanvasTo,不重复推栈)。
-  const goBackStack = useCallback(() => {
-    setHistory((prev) => {
-      const next = historyGoBack(prev);
-      if (next === prev) return prev;
-      const f = currentFocus(next);
-      setFocusId(f);
-      if (f) resetCanvasTo(f);
-      return next;
-    });
-  }, [resetCanvasTo]);
-  const goForwardStack = useCallback(() => {
-    setHistory((prev) => {
-      const next = historyGoForward(prev);
-      if (next === prev) return prev;
-      const f = currentFocus(next);
-      setFocusId(f);
-      if (f) resetCanvasTo(f);
-      return next;
-    });
-  }, [resetCanvasTo]);
-  const clearFocus = useCallback(() => {
-    setFocusId(null);
-    setShown(new Map());
-    setExpanded(new Set());
-    // 不动历史:用户「退出聚焦」不脚印化。清空后 bootstrap 会重开默认焦点。
-  }, []);
-
   // Switcher 入口:点选 = 设为画布中心(openFocus 重排 ±2)。
   const switchFocusFromList = useCallback(
     (nodeId: string) => {
@@ -554,11 +422,11 @@ function GraphViewInner({
       />
 
       <FocusHistoryBar
-        canBack={historyCanGoBack(history)}
-        canForward={historyCanGoForward(history)}
+        canBack={canBack}
+        canForward={canForward}
         breadcrumb={breadcrumb}
-        onBack={goBackStack}
-        onForward={goForwardStack}
+        onBack={goBack}
+        onForward={goForward}
         onClear={clearFocus}
       />
 
@@ -579,10 +447,13 @@ function GraphViewInner({
           onEdgeClick={onEdgeClick}
           onPaneClick={onPaneClick}
           colorMode={colorMode}
-          fitView
-          fitViewOptions={{ padding: 0.1 }}
+          // 不用 fitView:画布视口由 useEgoCanvas 在换焦点时 setCenter 到焦点节点。
+          // 留着 fitView prop 会在节点测量完成后按整图 bbox 复位,把刚居中的焦点重新
+          // 推到一侧(下游更宽时压在左上角 Filters 面板底下),并把缩放改回 fit 值。
           minZoom={0.1}
           maxZoom={2}
+          // 双击 = 设为画布中心。默认的 d3 双击缩放会和 setCenter 抢同一次手势。
+          zoomOnDoubleClick={false}
           nodesDraggable={false}
           nodesConnectable={false}
           attributionPosition="bottom-right"

--- a/packages/gui/src/renderer/views/GraphView.tsx
+++ b/packages/gui/src/renderer/views/GraphView.tsx
@@ -79,6 +79,15 @@ const edgeTypes = {
 
 const EMPTY_LOOP = new Set<string>();
 
+// 换焦点时把焦点摆到视口正中所用的缩放:焦点卡片(360 宽)+ 左右各一列 chip 同屏可读。
+const FOCUS_ZOOM = 0.9;
+
+const MINIMAP_AXIS: Record<string, string> = {
+  task: "var(--color-axis-execution)",
+  decision: "var(--color-axis-authority)",
+  fact: "var(--color-axis-evidence)",
+};
+
 function defaultAxes(): AxisFilter {
   // relates (assoc) 默认关 — dec_01KXA7811SVVT8P66HNDFZQ7DF CH4。
   return { authority: true, evidence: true, execution: true, assoc: false };
@@ -103,7 +112,7 @@ function GraphViewInner({
   onNavigateEntity?: (ref: string) => void;
   focusRef?: string | null;
 }) {
-  const { fitView } = useReactFlow();
+  const { setCenter } = useReactFlow();
   const colorMode = useColorMode();
 
   // 节点焦点(布局重算依赖)+ 边焦点(仅抽屉展示)。修 #3:此前用单一 focusId
@@ -284,18 +293,26 @@ function GraphViewInner({
     expanded,
   ]);
 
-  // fitView 只在换焦点(openFocus)时触发 —— 累积展开 / 长邻居永不重排已有画布
-  // (dec_01KXBGJQFQARSZHHQW1WADFDNC「单击永不重排」)。用 ref 记住上次已 fit 的焦点。
-  const lastFitFocus = useRef<string | null>(null);
+  // 换焦点(openFocus)时把焦点节点摆进视口正中 —— 兑现「以它为中心」,同时躲开左上角
+  // Filters 面板(fitView 全景会按图 bbox 居中,下游更宽时焦点被推到左侧压在面板下)。
+  // 只在焦点变化时触发:累积展开 / 长邻居永不重排已有画布
+  // (dec_01KXBGJQFQARSZHHQW1WADFDNC「单击永不重排」)。用 ref 记住上次已居中的焦点。
+  const lastCenteredFocus = useRef<string | null>(null);
   useEffect(() => {
-    if (!resolvedFocusId || nodes.length === 0) return;
-    if (lastFitFocus.current === resolvedFocusId) return;
-    lastFitFocus.current = resolvedFocusId;
+    if (!resolvedFocusId) return;
+    if (lastCenteredFocus.current === resolvedFocusId) return;
+    const focusNode = nodes.find((n) => n.id === resolvedFocusId);
+    if (!focusNode) return;
+    lastCenteredFocus.current = resolvedFocusId;
+    const w = Number(focusNode.style?.width ?? 0);
+    const h = Number(focusNode.style?.height ?? 0);
+    const cx = focusNode.position.x + w / 2;
+    const cy = focusNode.position.y + h / 2;
     const frame = window.requestAnimationFrame(() => {
-      fitView({ padding: 0.2, duration: 320 });
+      setCenter(cx, cy, { zoom: FOCUS_ZOOM, duration: 320 });
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [resolvedFocusId, nodes.length, fitView]);
+  }, [resolvedFocusId, nodes, setCenter]);
 
   // 单击 chip = 就地展开成卡片并长出邻居(累积,永不重排已有画布)。
   // 卡片(已展开)单击不处理 —— 收起 / 详情 / 设为中心 走卡片自身按钮。
@@ -580,6 +597,8 @@ function GraphViewInner({
           <MiniMap
             nodeColor={(n) => {
               if (n.type === "laneBackground") return "rgba(255, 255, 255, 0.04)";
+              // ego 节点按语义轴上色 —— 否则暗色 minimap 上全是暗灰方块,等于隐形。
+              if (n.type === "ego") return MINIMAP_AXIS[(n.data as any)?.entity as string] ?? "var(--color-axis-execution)";
               if (n.type === "decisionFocus" || n.type === "decision") return "var(--color-accent)";
               if (n.type === "fact") return "var(--color-stale)";
               return "var(--color-border-strong)";

--- a/packages/gui/src/renderer/views/GraphView.tsx
+++ b/packages/gui/src/renderer/views/GraphView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useCallback } from "react";
+import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import {
   ReactFlow,
   MiniMap,
@@ -29,6 +29,13 @@ import {
   type GraphFilterInput,
 } from "../graph/graphLayout";
 import {
+  buildEgoGraph,
+  bfsShown,
+  neighborsOf,
+  type EgoGraph,
+} from "../graph/canvasEgoLayout";
+import { pickDefaultFocus } from "../graph/graphLayoutShared";
+import {
   createFocusHistory,
   currentFocus,
   canGoBack as historyCanGoBack,
@@ -43,6 +50,7 @@ import { TaskNode } from "../graph/nodes/TaskNode";
 import { DecisionNode } from "../graph/nodes/DecisionNode";
 import { DecisionFocusNode } from "../graph/nodes/DecisionFocusNode";
 import { FactNode } from "../graph/nodes/FactNode";
+import { EgoNode } from "../graph/nodes/EgoNode";
 import { ModuleGroupNode } from "../graph/nodes/ModuleGroupNode";
 import { LaneBackgroundNode } from "../graph/nodes/LaneBackgroundNode";
 import { InteractiveEdge } from "../graph/edges/InteractiveEdge";
@@ -60,6 +68,7 @@ const nodeTypes = {
   decision: DecisionNode,
   decisionFocus: DecisionFocusNode,
   fact: FactNode,
+  ego: EgoNode,
   moduleGroup: ModuleGroupNode,
   laneBackground: LaneBackgroundNode,
 };
@@ -109,22 +118,20 @@ function GraphViewInner({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [focusEdgeId, setFocusEdgeId] = useState<string | null>(null);
   const [resolvedFocusId, setResolvedFocusId] = useState<string | null>(null);
-  const [expandedFacts, setExpandedFacts] = useState<Set<string>>(new Set());
+  const [expandedFacts] = useState<Set<string>>(new Set());
   const [history, setHistory] = useState<FocusHistoryState>(createFocusHistory);
+
+  // 无限画布 ego 累积态(dec_01KXBGJQFQARSZHHQW1WADFDNC):
+  //   shown    — 累积可见集 node id → 距焦点跳数(openFocus 铺 ±2,展开时长邻居,收起不撤)。
+  //   expanded — 渲染为详情卡片的 node id(其余紧凑 chip)。
+  const [shown, setShown] = useState<Map<string, number>>(() => new Map());
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
 
   // 焦点切换统一入口:更新 focusId + 推历史。重复推同 id 会被 pushFocus 折叠。
   const setFocusAndPushHistory = useCallback((id: string) => {
     setFocusId(id);
     setHistory((prev) => pushFocus(prev, id));
   }, []);
-
-  // 跨视图带入的 focusRef → 换焦点 + 入历史(用户「跳到这张图」的足迹)。
-  useEffect(() => {
-    if (!focusRef) return;
-    const nodeId = endpointToNodeId(focusRef);
-    if (nodeId) setFocusAndPushHistory(nodeId);
-    // 仅依赖 focusRef:每次外部 ref 变更都要响应,即便值相同(避免漏触发)。
-  }, [focusRef, setFocusAndPushHistory]);
 
   const [nodes, setNodes] = useState<any[]>([]);
   const [edges, setEdges] = useState<any[]>([]);
@@ -167,6 +174,72 @@ function GraphViewInner({
     [filters],
   );
 
+  // 统一图(byId + adj,含合成 task 父子边),供 openFocus/reveal 的 BFS 遍历复用。
+  const egoGraph: EgoGraph = useMemo(
+    () => buildEgoGraph(tasks, decisions ?? [], facts ?? [], relations),
+    [tasks, decisions, facts, relations],
+  );
+
+  // 重排画布到某焦点:铺开前后各 2 跳、只展开焦点自身(累积态重置)。
+  const resetCanvasTo = useCallback(
+    (id: string) => {
+      setShown(bfsShown(egoGraph, id, 2, filters.axes));
+      setExpanded(new Set([id]));
+    },
+    [egoGraph, filters.axes],
+  );
+
+  // 打开焦点(双击 / switcher / 抽屉 / 跨视图)= 设焦点 + 推历史 + 重排 ±2。
+  const openFocus = useCallback(
+    (id: string) => {
+      setFocusAndPushHistory(id);
+      resetCanvasTo(id);
+    },
+    [setFocusAndPushHistory, resetCanvasTo],
+  );
+  // 稳定引用:effect 只在 focusRef / 数据变时触发,不因 openFocus 身份变动而重排画布。
+  const openFocusRef = useRef(openFocus);
+  openFocusRef.current = openFocus;
+
+  // chip 就地展开成卡片,并把它通过轴过滤的一跳邻居加入 shown(长出下一环,累积)。
+  const expandNode = useCallback(
+    (id: string) => {
+      setExpanded((prev) => new Set(prev).add(id));
+      setShown((prev) => {
+        const next = new Map(prev);
+        const base = next.get(id) ?? 0;
+        for (const nb of neighborsOf(egoGraph, id, filters.axes)) {
+          if (!next.has(nb)) next.set(nb, base + 1);
+        }
+        return next;
+      });
+    },
+    [egoGraph, filters.axes],
+  );
+
+  // 收起卡片,保留已展开邻居(累计保留,单击/收起永不重排已展开画布)。
+  const collapseNode = useCallback((id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+
+  // 跨视图带入的 focusRef → 打开该焦点(用户「跳到这张图」的足迹)。
+  useEffect(() => {
+    if (!focusRef) return;
+    const nodeId = endpointToNodeId(focusRef);
+    if (nodeId) openFocusRef.current(nodeId);
+  }, [focusRef]);
+
+  // 首次(数据到位而未聚焦、且无外部 focusRef)= 打开默认焦点,铺开 ±2。
+  useEffect(() => {
+    if (focusId || focusRef) return;
+    const def = pickDefaultFocus(decisions ?? [], tasks);
+    if (def) openFocusRef.current(def);
+  }, [focusId, focusRef, decisions, tasks]);
+
   useEffect(() => {
     const ac = new AbortController();
     computeGraphLayout({
@@ -181,6 +254,7 @@ function GraphViewInner({
       filters: layoutInputFilters,
       inLoopNodes: EMPTY_LOOP,
       inLoopEdges: EMPTY_LOOP,
+      canvas: { shown, expanded },
     })
       .then(({ nodes: rfNodes, edges: rfEdges, cycleWarning: warning, resolvedFocusId: rid }) => {
         if (ac.signal.aborted) return;
@@ -206,78 +280,41 @@ function GraphViewInner({
     focusId,
     expandedFacts,
     layoutInputFilters,
+    shown,
+    expanded,
   ]);
 
-  // Fit view when node count changes or focus changes
+  // fitView 只在换焦点(openFocus)时触发 —— 累积展开 / 长邻居永不重排已有画布
+  // (dec_01KXBGJQFQARSZHHQW1WADFDNC「单击永不重排」)。用 ref 记住上次已 fit 的焦点。
+  const lastFitFocus = useRef<string | null>(null);
   useEffect(() => {
-    if (nodes.length === 0) return;
+    if (!resolvedFocusId || nodes.length === 0) return;
+    if (lastFitFocus.current === resolvedFocusId) return;
+    lastFitFocus.current = resolvedFocusId;
     const frame = window.requestAnimationFrame(() => {
-      fitView({ padding: 0.12, duration: 200 });
+      fitView({ padding: 0.2, duration: 320 });
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [edges.length, fitView, nodes.length, resolvedFocusId]);
+  }, [resolvedFocusId, nodes.length, fitView]);
 
-  // 单击 = 选中并开抽屉(不换焦点)。fact 节点 / claim 行的展开 toggle 仍走单击,
-  // 因为它们是「展开 / 收起」局部交互,不涉及抽屉。
+  // 单击 chip = 就地展开成卡片并长出邻居(累积,永不重排已有画布)。
+  // 卡片(已展开)单击不处理 —— 收起 / 详情 / 设为中心 走卡片自身按钮。
   const onNodeClick = useCallback(
-    (evt: any, node: any) => {
-      if (node.type === "laneBackground" || node.type === "moduleGroup") return;
-      // 点击 fact 节点 → 折叠回去 (toggle expand)
-      if (node.type === "fact" && typeof node.id === "string" && node.id.startsWith("fact/")) {
-        setExpandedFacts((prev) => {
-          const next = new Set(prev);
-          if (next.has(node.id)) next.delete(node.id);
-          else next.add(node.id);
-          return next;
-        });
-        return;
-      }
-      // 点击 decisionFocus 上的具体 claim 行 → 仅 toggle 该 claim 的 evidence facts。
-      // 修 #4:此前点击焦点卡片任意位置都批量 toggle 所有 claim 的 fact,无法定位
-      // 具体行;现在用 data-claim-id 锚到具体 claim。
-      // 修 #5:factRefs 在 threeLaneLayout 里取 coverageRows.coveringFactRef 与
-      // evidence 边的并集,避免仅有规范/transitive 覆盖但无 direct edge 时漏掉。
-      if (node.type === "decisionFocus" && node.data?.claimRows) {
-        const target = evt?.target as HTMLElement | null;
-        const claimRowEl = target?.closest?.("[data-claim-id]");
-        const claimId = claimRowEl?.getAttribute("data-claim-id");
-        if (claimId) {
-          const rows = node.data.claimRows as Array<{
-            claimId: string;
-            factRefs?: string[];
-          }>;
-          const row = rows.find((r) => r.claimId === claimId);
-          const refs = row?.factRefs ?? [];
-          if (refs.length > 0) {
-            setExpandedFacts((prev) => {
-              const next = new Set(prev);
-              const allOpen = refs.every((f) => next.has(f));
-              if (allOpen) refs.forEach((f) => next.delete(f));
-              else refs.forEach((f) => next.add(f));
-              return next;
-            });
-          }
-          return;
-        }
-        // 未命中 claim 行 → 落到「选中开抽屉」(不再像旧版那样 toggle 焦点)。
-      }
-      setSelectedId(node.id);
-      setFocusEdgeId(null);
+    (_evt: any, node: any) => {
+      if (node.type !== "ego") return;
+      if (node.data?.expanded) return;
+      expandNode(node.id);
     },
-    [],
+    [expandNode],
   );
 
-  // 双击 = 设为焦点(显式切换,推历史)。
+  // 双击 = 设为画布中心(openFocus:重排前后各 2 跳,推历史)。
   const onNodeDoubleClick = useCallback(
     (_evt: any, node: any) => {
-      if (node.type === "laneBackground" || node.type === "moduleGroup") return;
-      if (!node.id || typeof node.id !== "string") return;
-      setFocusAndPushHistory(node.id);
-      // 双击后也把抽屉对齐到焦点,符合「我想看它的全貌」。
-      setSelectedId(node.id);
-      setFocusEdgeId(null);
+      if (node.type !== "ego" || typeof node.id !== "string") return;
+      openFocus(node.id);
     },
-    [setFocusAndPushHistory],
+    [openFocus],
   );
 
   const onEdgeClick = useCallback((_: any, edge: any) => {
@@ -344,6 +381,26 @@ function GraphViewInner({
     [nodes],
   );
 
+  // 注入卡片交互回调(收起 / 设为中心 / 详情跳转)+ id 到 ego 节点 data。
+  const displayNodes = useMemo(
+    () =>
+      nodes.map((n) =>
+        n.type === "ego"
+          ? {
+              ...n,
+              data: {
+                ...n.data,
+                id: n.id,
+                onCollapse: collapseNode,
+                onRefocus: openFocus,
+                onNavigate: onNavigateEntity,
+              },
+            }
+          : n,
+      ),
+    [nodes, collapseNode, openFocus, onNavigateEntity],
+  );
+
   // 抽屉里展示的实体(优先 selectedNode,fallback 到 focusNode)。这样单击非焦点
   // 节点能看抽屉,focus 节点也能看抽屉。upCount/downCount 跟随「抽屉里那个」。
   const drawerNodeId = selectedNode?.id ?? focusNode?.id ?? null;
@@ -367,57 +424,61 @@ function GraphViewInner({
     setSelectedId(null);
     setFocusEdgeId(null);
   }, []);
-  // 抽屉里点边列表项 = 既选中(抽屉跟着走)又换焦点(因为「跳到那个节点」就是
-  // 想看它的图)。这种「抽屉里跳」就是用户的 focus 意图,推历史。
+  // 边抽屉里「跳转源/目标节点」= 把该节点设为画布中心(openFocus 重排 ±2),并关边抽屉。
   const focusFromDrawer = useCallback(
     (id: string | null) => {
       if (!id) {
         closeDrawer();
         return;
       }
-      setSelectedId(id);
       setFocusEdgeId(null);
-      setFocusAndPushHistory(id);
+      openFocus(id);
     },
-    [closeDrawer, setFocusAndPushHistory],
+    [closeDrawer, openFocus],
   );
-  // 抽屉里「设为焦点」按钮 = 把当前抽屉里的节点升级为焦点(不切抽屉内容)。
+  // 抽屉里「设为焦点」按钮 = 把当前抽屉里的节点设为画布中心。
   const setDrawerAsFocus = useCallback(() => {
     if (!drawerNodeId) return;
-    setFocusAndPushHistory(drawerNodeId);
-  }, [drawerNodeId, setFocusAndPushHistory]);
+    openFocus(drawerNodeId);
+  }, [drawerNodeId, openFocus]);
 
   // 历史导航:back/forward。currentFocus 为 null 表示走到历史外(默认焦点),
   // 此时仍把 focusId 同步到 null 让布局器挑默认。
+  // 历史前进/后退:切焦点 + 重排画布(resetCanvasTo,不重复推栈)。
   const goBackStack = useCallback(() => {
     setHistory((prev) => {
       const next = historyGoBack(prev);
       if (next === prev) return prev;
-      setFocusId(currentFocus(next));
+      const f = currentFocus(next);
+      setFocusId(f);
+      if (f) resetCanvasTo(f);
       return next;
     });
-  }, []);
+  }, [resetCanvasTo]);
   const goForwardStack = useCallback(() => {
     setHistory((prev) => {
       const next = historyGoForward(prev);
       if (next === prev) return prev;
-      setFocusId(currentFocus(next));
+      const f = currentFocus(next);
+      setFocusId(f);
+      if (f) resetCanvasTo(f);
       return next;
     });
-  }, []);
+  }, [resetCanvasTo]);
   const clearFocus = useCallback(() => {
     setFocusId(null);
-    // 不动历史:用户「退出聚焦」不脚印化(经典浏览器也不会因为关 tab 入栈)。
+    setShown(new Map());
+    setExpanded(new Set());
+    // 不动历史:用户「退出聚焦」不脚印化。清空后 bootstrap 会重开默认焦点。
   }, []);
 
-  // Switcher 入口:点选 = 设焦点 + 抽屉跟着走。
+  // Switcher 入口:点选 = 设为画布中心(openFocus 重排 ±2)。
   const switchFocusFromList = useCallback(
     (nodeId: string) => {
-      setFocusAndPushHistory(nodeId);
-      setSelectedId(nodeId);
+      openFocus(nodeId);
       setFocusEdgeId(null);
     },
-    [setFocusAndPushHistory],
+    [openFocus],
   );
 
   // 面包屑数据:显示当前焦点(显式 or 布局默认)。kind 用 type 反推
@@ -492,7 +553,7 @@ function GraphViewInner({
           onFocus={switchFocusFromList}
         />
         <ReactFlow
-          nodes={nodes}
+          nodes={displayNodes}
           edges={edges}
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
@@ -536,15 +597,10 @@ function GraphViewInner({
           </Panel>
         </ReactFlow>
 
-        {(selectedNode || focusNode || focusEdge) && (
+        {/* 节点详情已就地进卡片;抽屉仅保留「边详情」(点关系边)这一路。 */}
+        {(selectedNode || focusEdge) && (
           <GraphDrawer
-            focusNode={
-              selectedNode
-                ? drawerNodesMap.get(selectedId)
-                : focusNode
-                  ? drawerNodesMap.get(focusId)
-                  : undefined
-            }
+            focusNode={selectedNode ? drawerNodesMap.get(selectedId) : undefined}
             focusEdge={focusEdge ? focusEdge.data : undefined}
             nodes={drawerNodesMap}
             edges={relations}

--- a/packages/gui/test/canvas-ego-layout.vitest.ts
+++ b/packages/gui/test/canvas-ego-layout.vitest.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { layoutCanvasEgo, buildEgoGraph, bfsShown } from "../src/renderer/graph/canvasEgoLayout";
+import type { TaskRow, DecisionRow, FactRef, RelationEdge } from "../src/renderer/model/types";
+import type { AxisFilter, GraphFilterInput } from "../src/renderer/graph/graphLayoutTypes";
+
+// 精简工厂:布局器只读少数字段,其余用类型断言跳过。
+const task = (id: string, extra: Partial<TaskRow> = {}): TaskRow =>
+  ({ taskId: id, title: `T ${id}`, coordinationStatus: "active", module: "m", ...extra }) as unknown as TaskRow;
+const decision = (id: string, extra: Partial<DecisionRow> = {}): DecisionRow =>
+  ({
+    decisionId: id,
+    title: `D ${id}`,
+    state: "active",
+    question: "q",
+    chosen: [],
+    rejected: [],
+    claims: [],
+    ...extra,
+  }) as unknown as DecisionRow;
+const fact = (taskId: string, tail: string): FactRef =>
+  ({ anchor: `${taskId}/${tail}`, taskId, category: "finding", text: `obs ${tail}`, at: "2026", confidence: "high" }) as unknown as FactRef;
+const rel = (from: string, to: string, kind: RelationEdge["kind"]): RelationEdge =>
+  ({ from, to, kind, provenance: "local-document" }) as RelationEdge;
+
+const ALL_AXES: AxisFilter = { authority: true, evidence: true, execution: true, assoc: true };
+const filters = (over: Partial<GraphFilterInput> = {}): GraphFilterInput => ({
+  modules: new Set<string>(),
+  types: new Set(["task", "decision", "fact"]),
+  axes: ALL_AXES,
+  ...over,
+});
+
+// 场景:焦点 dec_F。上游 dec_U refines→dec_F(dec_U 更有一个 evidence fact);
+// 下游 dec_F derives→task_C;task_C 有子任务 C1/C2;C1 又有孙任务 C1a(第 3 跳)。
+function scene() {
+  const tasks = [
+    task("task_C"),
+    task("task_C1", { parentTaskId: "task_C" }),
+    task("task_C2", { parentTaskId: "task_C" }),
+    task("task_C1a", { parentTaskId: "task_C1" }),
+  ];
+  const decisions = [
+    decision("dec_F", { chosen: [{ id: "CH1", text: "chosen text", evidence: [], whyNot: undefined } as any] }),
+    decision("dec_U"),
+  ];
+  const facts = [fact("task_x", "F1")];
+  const relations = [
+    rel("decision/dec_U", "decision/dec_F", "refines"), // 上游(focus 是 to → in → left)
+    rel("decision/dec_F/CH1", "task/task_C", "derives"), // 下游(focus 是 from → out → right)
+    rel("decision/dec_U/C1", "fact/task_x/F1", "evidenced-by"), // dec_U 的证据(第 2 跳上游)
+  ];
+  return { tasks, decisions, facts, relations };
+}
+
+const FOCUS = "decision/dec_F";
+
+function boxesOverlap(a: any, b: any): boolean {
+  const aw = a.style.width;
+  const ah = a.style.height;
+  const bw = b.style.width;
+  const bh = b.style.height;
+  return (
+    a.position.x < b.position.x + bw &&
+    b.position.x < a.position.x + aw &&
+    a.position.y < b.position.y + bh &&
+    b.position.y < a.position.y + ah
+  );
+}
+const centerX = (n: any) => n.position.x + n.style.width / 2;
+
+describe("layoutCanvasEgo", () => {
+  const { tasks, decisions, facts, relations } = scene();
+  const graph = buildEgoGraph(tasks, decisions, facts, relations);
+  const shown = bfsShown(graph, FOCUS, 2, ALL_AXES);
+  const out = layoutCanvasEgo({
+    focusId: FOCUS,
+    tasks,
+    decisions,
+    facts,
+    relations,
+    filters: filters(),
+    inLoopEdges: new Set(),
+    shown,
+    expanded: new Set([FOCUS]),
+  });
+  const byId = new Map(out.nodes.map((n) => [n.id, n]));
+
+  it("合成 task 父子边(parentTaskId 不在 relations 里)", () => {
+    // dec_F 的 ±2 跳:C1/C2 是 task_C 子任务;父子边应存在。
+    expect(shown.has("task_C1")).toBe(true);
+    expect(shown.has("task_C2")).toBe(true);
+    expect(out.edges.some((e) => e.id === "e_child_task_C1")).toBe(true);
+    expect(out.edges.some((e) => e.id === "e_child_task_C2")).toBe(true);
+  });
+
+  it("默认 ±2 跳铺开(第 3 跳 C1a 不在 shown)", () => {
+    expect(shown.get(FOCUS)).toBe(0);
+    expect(shown.get("decision/dec_U")).toBe(1);
+    expect(shown.get("task_C")).toBe(1);
+    expect(shown.get("task_C1")).toBe(2);
+    expect(shown.has("task_C1a")).toBe(false); // 第 3 跳,默认不铺
+  });
+
+  it("焦点居中,上游→左 / 下游→右", () => {
+    expect(centerX(byId.get(FOCUS))).toBeCloseTo(0, 0);
+    expect(centerX(byId.get("decision/dec_U"))).toBeLessThan(0); // 上游左
+    expect(centerX(byId.get("task_C"))).toBeGreaterThan(0); // 下游右
+  });
+
+  it("按跳级逐层外扩(第 2 跳比第 1 跳更远)", () => {
+    // 下游:C1/C2(第 2 跳)在 task_C(第 1 跳)右侧更远。
+    expect(centerX(byId.get("task_C1"))!).toBeGreaterThan(centerX(byId.get("task_C"))!);
+    // 上游:fact(第 2 跳)在 dec_U(第 1 跳)左侧更远。
+    expect(centerX(byId.get("fact/task_x/F1"))!).toBeLessThan(centerX(byId.get("decision/dec_U"))!);
+  });
+
+  it("确定性布局零重叠", () => {
+    const ns = out.nodes;
+    for (let i = 0; i < ns.length; i += 1) {
+      for (let j = i + 1; j < ns.length; j += 1) {
+        expect(boxesOverlap(ns[i], ns[j])).toBe(false);
+      }
+    }
+  });
+
+  it("+N 徽章:C1 有未展开的孙任务", () => {
+    expect(byId.get("task_C1")!.data.hiddenCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("类型筛选:关掉 fact 后 fact 节点消失,task/decision 保留", () => {
+    const out2 = layoutCanvasEgo({
+      focusId: FOCUS,
+      tasks,
+      decisions,
+      facts,
+      relations,
+      filters: filters({ types: new Set(["task", "decision"]) }),
+      inLoopEdges: new Set(),
+      shown,
+      expanded: new Set([FOCUS]),
+    });
+    const ids = new Set(out2.nodes.map((n) => n.id));
+    expect(ids.has("fact/task_x/F1")).toBe(false);
+    expect(ids.has("decision/dec_U")).toBe(true);
+    expect(ids.has("task_C")).toBe(true);
+  });
+
+  it("焦点渲染为卡片(expanded),其余为 chip", () => {
+    expect(byId.get(FOCUS)!.data.expanded).toBe(true);
+    expect(byId.get(FOCUS)!.style.width).toBe(360); // CARD_W
+    expect(byId.get("task_C")!.data.expanded).toBe(false);
+    expect(byId.get("task_C")!.style.width).toBe(216); // CHIP_W
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -5,5 +5,6 @@ export const guiVitestManifest = [
   "packages/gui/test/task-adapter.vitest.ts",
   "packages/gui/test/graphLayout.vitest.ts",
   "packages/gui/test/genealogy-timeline.vitest.ts",
-  "packages/gui/test/graphNavigation.vitest.ts"
+  "packages/gui/test/graphNavigation.vitest.ts",
+  "packages/gui/test/canvas-ego-layout.vitest.ts"
 ];


### PR DESCRIPTION
# English

## Summary

Rebuilds the triadic graph's ego view as an infinite, accumulating canvas: the clicked entity sits at the centre of the viewport, its neighbourhood is laid out in hop-numbered columns (upstream left, downstream right), and clicking any chip expands it into a full detail card **in place** while revealing its next ring of neighbours. Collapsing a card never retracts what it revealed, so you can keep walking outward on one canvas instead of jumping between pages.

This implements `dec_01KXBGJQFQARSZHHQW1WADFDNC` (refines `dec_01KXA7811SVVT8P66HNDFZQ7DF`, which had specified a fixed three-column ego view). The outer views are untouched; only the secondary spotlight/ego page changes.

## What Changed

- New `canvasEgoLayout.ts`: deterministic hop-layered BFS layout. Levels come from BFS off the focus, side comes from edge direction, columns are ordered by barycenter, and card heights are estimated from content so the layout is overlap-free without DOM measurement.
- It also synthesises task parent/child edges. `TaskRow.parentTaskId` is not part of `relations`, so the previous ego layout could never show a task's subtasks at all.
- New `EgoNode.tsx`: one component, two states. Compact chip by default (axis colour bar, kind badge, status dot, `+N` hidden-neighbour count); on click it becomes a detail card mirroring the drawer's density, with `set as centre` / `open detail page ↗` / `collapse` actions.
- New `useEgoCanvas.ts`: the canvas state machine (focus, the accumulating `shown` map and `expanded` set, focus history, recentre-on-focus-change). Extracted from `GraphView`, which had grown past the 600-line complexity budget.
- `GraphView` now drives the canvas and keeps the drawer only for edge detail (node detail lives in the card). Node detail pages are reachable from the card via the existing `navigateToEntity` route.
- Earlier commit on this branch: detail-drawer type sizes now follow the `--ui-font-*` scale, and over-long sections scroll inside their own section instead of stretching the drawer.

Three defects were found and fixed while verifying, all of which a symmetric demo graph had been hiding:

- The `fitView` prop re-fit the viewport after nodes were measured, overwriting the `setCenter` that centres the focus. On an asymmetric graph this slides the focus card under the top-left filter panel and resets the zoom.
- ReactFlow's default double-click zoom consumed the gesture before `onNodeDoubleClick` ran, so double-click-to-recentre never worked.
- MiniMap drew nothing: ego nodes carried dimensions only in `style`, so `node.measured` stayed undefined and `nodeHasDimensions()` rejected every node. Minimap nodes are now also tinted by semantic axis instead of a dark grey that was invisible on the dark canvas.

## Task And Scope

- Harness task: `task_01KXBBF233BQ0SRCD571BAMZMP` (GUI IA — ego layer, packages/gui)
- Branch: `feat/gui-drawer-fonts-caps`
- Public scope: `packages/gui` renderer only (graph layout, ego node, canvas hook, graph view, layout tests)
- Private planning/evidence updated: yes (task_plan L2 section rewritten to the canvas model)
- Out of scope: L1 territory overview; decision coverage lamps on the card (deferred — `claims[]` carries no evidence, real coverage needs `coverageRows`); retiring the now-unused `simpleEgo`/`threeLane` layouts (kept as fallback)

## Version Impact

- Version: no version change because this is renderer-only work with no CLI surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KXBGJQFQARSZHHQW1WADFDNC` (accepted), refines `dec_01KXA7811SVVT8P66HNDFZQ7DF`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `7a05ba932c496e27fe32d296f5b97f294b0860b5`
- Branch merge-base with `origin/main`: `7a05ba932c496e27fe32d296f5b97f294b0860b5`
- Last `git fetch origin` time: 2026-07-13, immediately before rebase
- Sync method: rebase
- Public diff command: `git diff origin/main...feat/gui-drawer-fonts-caps`
- Private evidence commit/path: `harness/tasks/task_01KXBBF233BQ0SRCD571BAMZMP-gui-ia-ego-packages-gui/task_plan.md`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] `git diff --check`
- [x] `pnpm typecheck` (`tsc -b`, exit 0)
- [x] `pnpm check:local` (fast tier, passed in 70s — includes import boundaries, private boundary, package policy, implementation/schema contracts, legacy intake, file complexity)
- [x] `pnpm exec eslint` on every changed file (exit 0)
- [x] GUI test suite: 8 files / 80 tests passed, including 8 new layout tests (hop levels, upstream-left/downstream-right, level-by-level outward growth, zero AABB overlap, `+N` badge, type filter, chip-vs-card sizing, synthesised parent/child edges)
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR
- Not run: integration/E2E shards and `harness:smoke-cli-package` (no CLI surface touched; the fast local tier defers these to cloud CI by design)

Behavioural verification ran against a live render (fixture harness, dev-only, not committed), with zero console errors throughout:

- initial focus card centred in the pane at the intended zoom (viewport transform `translate(600px, 418.5px) scale(0.9)`, focus at world origin — this is what caught the `fitView` bug: the pre-fix value was `scale(0.722)`, i.e. `setCenter` was being overwritten)
- click a chip → it becomes a detail card in place, header still `12 nodes · 11 edges`
- collapse the card → still `12 nodes · 11 edges`, confirming accumulation is retained
- double-click a chip → refocus and re-layout to that entity's ±2 hops (`9 nodes · 8 edges`), still centred at `scale(0.9)`
- MiniMap renders all 12 nodes, tinted by axis

## Review Evidence

- Self-review: yes — full diff re-read; the three defects above were found by ground-truthing the rendered viewport transform rather than trusting the screenshot
- Reviewer subagent: not run
- Human review: pending
- Blocking findings: none

## Residual Risk

- The layered layout is verified on a fixture (8 tasks / 2 decisions / 2 facts). Density and column ordering on the full live ledger have not been dogfooded yet; that is the next step on the task.
- Card heights are estimated from content rather than measured, so an unusually long decision `question` will scroll inside its section instead of growing the card. Intentional (deterministic, overlap-free layout), but it is a trade.
- `simpleEgoLayout` / `threeLaneLayout` remain as fallbacks and are now unreachable in practice. Left in place deliberately to avoid a big-bang deletion; they should be retired once the canvas has real usage behind it.

## References

- Task: `task_01KXBBF233BQ0SRCD571BAMZMP`
- Evidence: `dec_01KXBGJQFQARSZHHQW1WADFDNC`, `dec_01KXA7811SVVT8P66HNDFZQ7DF`
- Review: pending

---

# 中文

## 概要

把三元语关系图的 ego 视图重做成**无限累积画布**：点开的实体固定在视口正中，邻域按跳级分列铺开（上游在左、下游在右），点任意 chip 就**原地**长成详情卡片，同时长出它的下一环邻居。收起卡片不会撤掉已经露出来的节点，所以可以在同一张画布上一直往外走，而不是在页面之间跳来跳去。

本 PR 落地 `dec_01KXBGJQFQARSZHHQW1WADFDNC`（refines `dec_01KXA7811SVVT8P66HNDFZQ7DF`，后者原定的是固定三列 ego）。外层视图一律不动，只改二级的聚光灯 / ego 页。

## 改动内容

- 新增 `canvasEgoLayout.ts`：确定性的跳级分层布局。层级来自以焦点为起点的 BFS，左右侧由边方向决定，同列用 barycenter 排序，卡片高度按内容估算，因而不依赖 DOM 测量就能保证零重叠。
- 该布局器还会**合成 task 父子边**。`TaskRow.parentTaskId` 根本不在 `relations` 里，所以此前的 ego 布局从来显示不出一个任务的子任务。
- 新增 `EgoNode.tsx`：一个组件两态。默认是紧凑 chip（轴色条、种类徽章、状态点、`+N` 未展开邻居数）；点击后就地变成详情卡片，密度对齐抽屉，带「设为中心 / 详情 ↗ / 收起」三个动作。
- 新增 `useEgoCanvas.ts`：画布状态机（焦点、累积的 `shown` 映射与 `expanded` 集合、焦点历史、换焦点即居中）。从 `GraphView` 抽出来——后者已经越过 600 行的复杂度预算。
- `GraphView` 现在驱动画布，抽屉只保留「边详情」这一路（节点详情已经进卡片）。卡片上的「详情 ↗」走现成的 `navigateToEntity` 跳到实体专属详情页。
- 本分支上一个 commit：详情抽屉字号接上 `--ui-font-*` 标度，超长分区在自己的分区内滚动，不再把抽屉撑变形。

验证过程中发现并修掉三个真实缺陷，它们都被一张恰好左右对称的样例图掩盖着：

- `fitView` prop 会在节点测量完成后按整图 bbox 复位视口，把「让焦点居中」的 `setCenter` 覆盖掉。图一旦不对称，焦点卡片就会重新滑到左上角 Filters 面板底下，缩放也被改回 fit 值。
- ReactFlow 默认的双击缩放先吃掉了手势，`onNodeDoubleClick` 从来没跑到过 —— 也就是说「双击设为中心」一直是坏的。
- MiniMap 一个方块都不画：ego 节点的尺寸只写在 `style` 里，`node.measured` 一直是 undefined，`nodeHasDimensions()` 于是拒绝了每一个节点。顺带把 minimap 节点按语义轴上色，此前那个暗灰色在暗色画布上等于隐形。

## 任务与范围

- Harness 任务：`task_01KXBBF233BQ0SRCD571BAMZMP`（GUI IA — ego 层，packages/gui）
- 分支：`feat/gui-drawer-fonts-caps`
- 公开范围：只动 `packages/gui` 渲染进程（图布局、ego 节点、画布 hook、图视图、布局单测）
- 私有计划 / 证据是否已更新：yes（task_plan 的 L2 段已按画布模型改写）
- 范围外：L1 领地总览；卡片上的决策 coverage 灯（推迟——`claims[]` 不带证据，真 coverage 要读 `coverageRows`）；退役已经不再走的 `simpleEgo` / `threeLane` 布局（留作 fallback）

## 版本影响

- 版本：不改版本，原因是本 PR 只动渲染进程，不碰 CLI 面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`dec_01KXBGJQFQARSZHHQW1WADFDNC`（已 accept），refines `dec_01KXA7811SVVT8P66HNDFZQ7DF`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`7a05ba932c496e27fe32d296f5b97f294b0860b5`
- 当前分支与 `origin/main` 的 merge-base：`7a05ba932c496e27fe32d296f5b97f294b0860b5`
- 最近一次 `git fetch origin` 时间：2026-07-13，rebase 之前刚拉
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...feat/gui-drawer-fonts-caps`
- 私有证据 commit/path：`harness/tasks/task_01KXBBF233BQ0SRCD571BAMZMP-gui-ia-ego-packages-gui/task_plan.md`
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待 CI 在本 PR 上填
- [x] `git diff --check`
- [x] `pnpm typecheck`（`tsc -b`，exit 0）
- [x] `pnpm check:local`（fast 档，70 秒全绿——含 import 边界、私有边界、package policy、实现 / schema 契约、legacy intake、文件复杂度）
- [x] 所有改动文件跑 `pnpm exec eslint`（exit 0）
- [x] GUI 测试：8 个文件 / 80 个测试全过，含 8 个新增布局单测（跳级分层、上游左下游右、逐层外扩、AABB 零重叠、`+N` 徽章、类型筛选、chip 与卡片尺寸、合成父子边）
- [ ] GitHub Actions `rewrite-ci` passed —— 待本 PR 的 CI
- 未运行：integration / E2E 分片与 `harness:smoke-cli-package`（没碰 CLI 面；本地 fast 档按设计把这些交给云端 CI）

行为验证跑在真实渲染上（fixture harness，dev-only，未提交），全程零控制台错误：

- 初始焦点卡片按预期缩放居中于画布窗格（viewport transform `translate(600px, 418.5px) scale(0.9)`，焦点在世界原点——正是这一步抓到了 `fitView` 的 bug：修前的值是 `scale(0.722)`，说明 `setCenter` 被覆盖了）
- 点 chip → 原地变详情卡片，头部仍是 `12 节点 · 11 边`
- 收起卡片 → 仍是 `12 节点 · 11 边`，证实累计保留
- 双击 chip → 换焦点并重排成该实体的 ±2 跳（`9 节点 · 8 边`），仍居中于 `scale(0.9)`
- MiniMap 12 个节点全部画出，按轴上色

## Review Evidence

- 自审：yes——完整 diff 复读；上面三个缺陷是靠 ground-truth 渲染后的 viewport transform 抓到的，不是靠看截图
- Reviewer subagent：未跑
- 人工复核：待办
- 阻塞发现：无

## Residual Risk

- 分层布局目前只在 fixture（8 task / 2 decision / 2 fact）上验过。真实 ledger 全量数据下的密度和列排序还没 dogfood，这是该任务的下一步。
- 卡片高度是按内容估算而非实测，所以特别长的决策 `question` 会在分区内滚动而不是把卡片撑高。这是有意的取舍（换来确定性、零重叠的布局），但确实是个取舍。
- `simpleEgoLayout` / `threeLaneLayout` 作为 fallback 留着，实际上已经走不到了。故意不做大爆炸式删除；等画布有真实使用量之后再退役。

## References

- 任务：`task_01KXBBF233BQ0SRCD571BAMZMP`
- 证据：`dec_01KXBGJQFQARSZHHQW1WADFDNC`、`dec_01KXA7811SVVT8P66HNDFZQ7DF`
- 复核：待办
