### PR TITLE
feat(gui): L1 领地总览 — 三层 IA 收口(领地 → 聚光灯 → 抽丝剥茧)

### DIFF
--- a/packages/gui/src/renderer/components/GraphFilterPanel.tsx
+++ b/packages/gui/src/renderer/components/GraphFilterPanel.tsx
@@ -1,4 +1,5 @@
-import { Funnel, SquaresFour, Graph, Bandaids } from "@phosphor-icons/react";
+import { useState } from "react";
+import { Funnel, SquaresFour, Graph, Bandaids, CaretDown, CaretRight } from "@phosphor-icons/react";
 import {
   AXIS_COLOR_VAR,
   AXIS_LABEL,
@@ -54,14 +55,40 @@ export function GraphFilterPanel({ filters, setFilters, availableModules }: Prop
     }));
   };
 
+  // 默认收起:这个面板是覆盖在画布上的浮层,常驻展开会永久吃掉左上角 ——
+  // 聚光灯模式下压住焦点卡片,领地模式下压住第一个领地块。收起态是一颗 pill,
+  // 上面标出「已收窄」的筛选数,状态一眼可见,画布还给内容。
+  const [open, setOpen] = useState(false);
+  const narrowed =
+    AXIS_ORDER.filter((a) => !filters.axes[a]).length +
+    (3 - filters.types.size) +
+    Math.max(0, availableModules.length - filters.modules.size);
+
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-border bg-surface shadow-sm w-[260px] pointer-events-auto">
-      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+    <div
+      className={`flex flex-col rounded-lg border border-border bg-surface shadow-sm pointer-events-auto ${open ? "gap-3 w-[260px]" : ""}`}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title={open ? "收起筛选面板" : "展开筛选面板"}
+        className={`flex items-center gap-2 px-3 py-2 text-left hover:bg-surface-raised rounded-lg ${open ? "border-b border-border rounded-b-none" : ""}`}
+      >
+        {open ? (
+          <CaretDown weight="bold" className="text-text-faint text-[10px]" />
+        ) : (
+          <CaretRight weight="bold" className="text-text-faint text-[10px]" />
+        )}
         <Funnel weight="duotone" className="text-text-muted" />
         <span className="font-mono text-xs font-semibold text-text">Filters</span>
-      </div>
+        {!open && narrowed > 0 && (
+          <span className="rounded-full bg-accent px-1.5 py-0.5 font-mono text-[10px] text-accent-fg">
+            {narrowed}
+          </span>
+        )}
+      </button>
 
-      <div className="px-3 pb-3 flex flex-col gap-4">
+      <div className={`px-3 pb-3 flex-col gap-4 ${open ? "flex" : "hidden"}`}>
         {/* Semantic Axis Filter */}
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-1.5 text-[11px] text-text-muted font-mono uppercase tracking-wide">

--- a/packages/gui/src/renderer/components/TerritoryModeBar.tsx
+++ b/packages/gui/src/renderer/components/TerritoryModeBar.tsx
@@ -1,0 +1,71 @@
+import { Panel } from "@xyflow/react";
+import type { ViewMode, TerritorySkel } from "../graph/useTerritoryView";
+
+/**
+ * L1 ↔ L2 模式切换条(IA v2 Layer 0 ↔ Layer 1)。
+ *
+ * 三个开关:
+ *   领地 ↔ 聚光灯 — 顶层视图模式(L1 = 首屏领地总览,L2 = ego 聚光灯)。
+ *   任务 / 决策   — territory 内的骨架轴(只有领地模式显示)。
+ *
+ * 放在 ReactFlow 的 Panel(position="top-center)里,与左上 Filters 面板、右上 minimap 不冲突。
+ */
+export function TerritoryModeBar({
+  viewMode,
+  skel,
+  onModeChange,
+  onSkelChange,
+}: {
+  viewMode: ViewMode;
+  skel: TerritorySkel;
+  onModeChange: (m: ViewMode) => void;
+  onSkelChange: (s: TerritorySkel) => void;
+}) {
+  return (
+    <Panel position="top-center">
+      <div className="flex items-center gap-2 rounded-lg border border-border bg-surface-raised px-1.5 py-1 shadow-sm">
+        <div className="flex overflow-hidden rounded-md border border-border">
+          <ModeBtn active={viewMode === "territory"} onClick={() => onModeChange("territory")}>
+            领地
+          </ModeBtn>
+          <ModeBtn active={viewMode === "spotlight"} onClick={() => onModeChange("spotlight")}>
+            聚光灯
+          </ModeBtn>
+        </div>
+        {viewMode === "territory" && (
+          <div className="flex overflow-hidden rounded-md border border-border">
+            <ModeBtn active={skel === "task"} onClick={() => onSkelChange("task")}>
+              任务
+            </ModeBtn>
+            <ModeBtn active={skel === "decision"} onClick={() => onSkelChange("decision")}>
+              决策
+            </ModeBtn>
+          </div>
+        )}
+      </div>
+    </Panel>
+  );
+}
+
+function ModeBtn({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-2.5 py-1 text-[12px] font-medium transition-colors ${
+        active
+          ? "bg-accent text-accent-fg"
+          : "bg-surface text-text-muted hover:text-text"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/gui/src/renderer/graph/graphLayout.ts
+++ b/packages/gui/src/renderer/graph/graphLayout.ts
@@ -2,6 +2,7 @@ import { parseEndpoint } from "./endpoint";
 import { edgePassesAxisFilter, pickDefaultFocus } from "./graphLayoutShared";
 import type { LayoutInput, LayoutOutput } from "./graphLayoutTypes";
 import { layoutCanvasEgo } from "./canvasEgoLayout";
+import { layoutTerritory } from "./territoryLayout";
 import { layoutSimpleEgo } from "./simpleEgoLayout";
 import { layoutThreeLane } from "./threeLaneLayout";
 
@@ -58,6 +59,21 @@ export async function computeGraphLayout(input: LayoutInput): Promise<LayoutOutp
       focusClaims: [],
       bounds: { width: 0, height: 0 },
     };
+  }
+
+  // L1 领地总览(IA v2 Layer 0):存在 territory 入参即走领地布局(分区成块、点实体切聚光灯)。
+  // territory 与 canvas(L2)互斥 —— GraphView 按当前 viewMode 传其一。
+  if (input.territory) {
+    return layoutTerritory({
+      skel: input.territory.skel,
+      tasks,
+      decisions: decisions ?? [],
+      facts: facts ?? [],
+      relations: validEdges,
+      filters,
+      coverageRows,
+      expandedZones: input.territory.expandedZones,
+    });
   }
 
   // 无限画布 ego(dec_01KXBGJQFQARSZHHQW1WADFDNC):存在 canvas 累积态即统一走

--- a/packages/gui/src/renderer/graph/graphLayoutTypes.ts
+++ b/packages/gui/src/renderer/graph/graphLayoutTypes.ts
@@ -50,6 +50,14 @@ export interface LayoutInput {
    *   expanded — 渲染为详情卡片的 node id 集(其余紧凑 chip)。
    */
   canvas?: { shown: Map<string, number>; expanded: Set<string> };
+  /**
+   * L1 领地总览(IA v2 Layer 0)。存在即走 layoutTerritory —— 把台账按 rootTask /
+   * supersede-refine 链分区成「领地块」,一块一块地铺开,点块内实体 → 切到聚光灯(L2)。
+   * 与 canvas(L2)互斥:territory 在则 canvas 不传,反之亦然。
+   *   skel          — 骨架轴(task 按 milestone / decision 按 supersede-refine 家族 + 落地)。
+   *   expandedZones — 已展开(不折叠 done/planned)的 zone id 集;默认折叠 hot-only。
+   */
+  territory?: { skel: "task" | "decision"; expandedZones: Set<string> };
 }
 
 export interface LayoutOutput {

--- a/packages/gui/src/renderer/graph/nodes/TerritoryChipNode.tsx
+++ b/packages/gui/src/renderer/graph/nodes/TerritoryChipNode.tsx
@@ -1,0 +1,227 @@
+import type { NodeProps } from "@xyflow/react";
+import { ArrowsOutSimple } from "@phosphor-icons/react";
+import type { TaskRow, DecisionRow } from "../../model/types";
+import { STATUS_META } from "../../components/badges";
+
+/**
+ * L1 领地总览的实体 chip 节点(IA v2 Layer 0)。
+ *
+ * 两种形态(同一组件按 skel 切换):
+ *   task skel     — 紧凑一条(30px 高):状态色点 + 标题 + hiddenCount 徽章。点击 → 聚光灯(L2)。
+ *   decision skel — 家族卡片(92px 高):标题 + 状态标签 + coverage 灯 + 历史版本 / 派生计数。
+ *                   带视觉「堆叠」效果(historyCount>0 时背后错开两层,= 同一决策的多个版本)。
+ *
+ * 与 EgoNode(L2 的 chip/card)同源但不同行:L1 chip 的点击语义是「进聚光灯」而非 L2 的
+ * 「就地展开」。所以交互回调叫 onOpen(切到 L2 + openFocus),不是 onCollapse/expandNode。
+ * chip 本身不展开成卡片 —— 详情是 L2 / L3 的职责,L1 只负责分区与健康信号。
+ *
+ * 另有 entity='fold' 的特殊 chip:zone 折叠态底部的「▸ 还有 N 项」提示,点击 → 展开 zone。
+ */
+
+interface ChipData {
+  entity: "task" | "decision" | "fold";
+  skel?: "task" | "decision";
+  raw?: TaskRow | DecisionRow;
+  label?: string;
+  color?: string;
+  dimmed?: boolean;
+  hiddenCount?: number;
+  state?: string;
+  coverage?: { covered: number; total: number; uncovered: number };
+  historyCount?: number;
+  derivedCount?: number;
+  riskTier?: string;
+  urgency?: string;
+  unlanded?: boolean;
+  navRef?: string;
+  zoneId?: string;
+  onOpen?: (ref: string) => void;
+  onFold?: (id: string) => void;
+}
+
+const KD_LETTER: Record<string, string> = { task: "T", decision: "D" };
+const AXIS_VAR: Record<string, string> = {
+  task: "var(--color-axis-execution)",
+  decision: "var(--color-axis-authority)",
+};
+const DECISION_STATE_COLOR: Record<string, string> = {
+  proposed: "var(--color-status-in-review)",
+  active: "var(--color-axis-authority)",
+  deferred: "var(--color-status-planned)",
+  retired: "var(--color-text-faint)",
+  rejected: "var(--color-status-cancelled)",
+};
+
+export function TerritoryChipNode({ data }: NodeProps) {
+  const d = data as unknown as ChipData;
+
+  // fold 提示行
+  if (d.entity === "fold") {
+    return (
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          if (d.zoneId) d.onFold?.(d.zoneId);
+        }}
+        className="flex h-full w-full items-center justify-center rounded-md border border-dashed border-border px-2 py-0.5 text-[11.5px] text-text-muted hover:border-[var(--color-border-strong)] hover:text-text"
+      >
+        {d.label}
+      </button>
+    );
+  }
+
+  if (d.skel === "decision") {
+    return <DecisionCardChip d={d} />;
+  }
+  return <TaskChip d={d} />;
+}
+
+function TaskChip({ d }: { d: ChipData }) {
+  const axis = AXIS_VAR[d.entity] ?? AXIS_VAR.task;
+  return (
+    <div
+      onClick={(e) => {
+        e.stopPropagation();
+        if (d.navRef) d.onOpen?.(d.navRef);
+      }}
+      className={`flex h-full w-full cursor-pointer items-center gap-2 overflow-hidden rounded-lg border bg-surface-raised px-2.5 transition-colors hover:border-[var(--color-border-strong)] ${
+        d.dimmed ? "opacity-60" : ""
+      }`}
+      style={{ borderColor: "var(--color-border)" }}
+    >
+      <span
+        className="grid size-[18px] shrink-0 place-items-center rounded font-mono text-[10px] font-bold"
+        style={{
+          backgroundColor: `color-mix(in srgb, ${axis} 18%, transparent)`,
+          color: axis,
+        }}
+      >
+        {KD_LETTER[d.entity] ?? "?"}
+      </span>
+      <span
+        className="size-[7px] shrink-0 rounded-full"
+        style={{ backgroundColor: d.color ?? "var(--color-status-planned)" }}
+      />
+      <span
+        className={`ui-body min-w-0 flex-1 truncate text-[12.5px] ${
+          d.dimmed ? "text-text-muted" : "text-text"
+        }`}
+      >
+        {d.label}
+      </span>
+      {d.hiddenCount !== undefined && d.hiddenCount > 0 && (
+        <span className="shrink-0 rounded-full bg-surface px-1.5 py-0.5 font-mono text-[10px] text-text-faint">
+          +{d.hiddenCount}
+        </span>
+      )}
+      <ArrowsOutSimple
+        weight="bold"
+        className="shrink-0 text-[11px] text-text-faint"
+      />
+    </div>
+  );
+}
+
+function DecisionCardChip({ d }: { d: ChipData }) {
+  const axis = AXIS_VAR.decision;
+  const hasHistory = (d.historyCount ?? 0) > 0;
+  const state = d.state ?? "active";
+  const stateColor = DECISION_STATE_COLOR[state] ?? axis;
+
+  return (
+    // 堆叠效果:historyCount>0 时,relative 容器后跟两个 absolute 层(错开 4px / 8px)。
+    // 通过包裹层实现 —— 但 React Flow 节点尺寸固定,堆叠只在节点内视觉表达。
+    <div className="relative h-full w-full">
+      {hasHistory && (
+        <>
+          <div
+            className="absolute inset-0 rounded-xl border bg-surface"
+            style={{
+              transform: "translate(5px, 5px)",
+              borderColor: "var(--color-border)",
+              opacity: 0.5,
+            }}
+          />
+          <div
+            className="absolute inset-0 rounded-xl border bg-surface"
+            style={{
+              transform: "translate(3px, 3px)",
+              borderColor: "var(--color-border)",
+              opacity: 0.75,
+            }}
+          />
+        </>
+      )}
+      <div
+        onClick={(e) => {
+          e.stopPropagation();
+          if (d.navRef) d.onOpen?.(d.navRef);
+        }}
+        className="relative flex h-full w-full cursor-pointer flex-col gap-1.5 overflow-hidden rounded-xl border bg-surface-raised px-3 py-2 transition-colors hover:border-[var(--color-axis-authority)]"
+        style={{
+          borderColor: d.unlanded
+            ? "color-mix(in oklch, var(--color-danger) 30%, transparent)"
+            : "var(--color-border)",
+        }}
+      >
+        {/* 标题(最多 2 行)*/}
+        <p
+          className="ui-body line-clamp-2 text-[12.5px] font-semibold leading-snug text-text"
+          style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}
+        >
+          {d.label}
+        </p>
+
+        {/* 健康行:状态 + coverage 灯 + 历史版本 + 派生 */}
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 ui-meta text-[10.5px]">
+          <span
+            className="rounded px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase"
+            style={{
+              color: stateColor,
+              backgroundColor: `color-mix(in oklch, ${stateColor} 14%, transparent)`,
+            }}
+          >
+            {state}
+          </span>
+          {d.coverage && d.coverage.total > 0 && (
+            <span className="flex items-center gap-1">
+              {Array.from({ length: Math.min(d.coverage.total, 8) }).map((_, i) => (
+                <span
+                  key={i}
+                  className="inline-block h-[6px] w-[6px] rounded-[1px]"
+                  style={{
+                    backgroundColor:
+                      i < d.coverage!.covered
+                        ? "var(--color-status-done)"
+                        : "var(--color-danger)",
+                  }}
+                />
+              ))}
+            </span>
+          )}
+          {hasHistory && (
+            <span style={{ color: "var(--color-axis-authority)" }}>
+              ⧉ {d.historyCount}
+            </span>
+          )}
+          {d.derivedCount !== undefined && d.derivedCount > 0 && (
+            <span className="flex items-center gap-1" style={{ color: "var(--color-axis-execution)" }}>
+              ▸ {d.derivedCount} 派生
+            </span>
+          )}
+          {d.riskTier === "high" && (
+            <span style={{ color: "var(--color-danger)" }}>high risk</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** GraphView minimap 用:territoryChip 的 entity → 轴色。 */
+export function territoryChipColor(entity: string): string {
+  return AXIS_VAR[entity] ?? "var(--color-border-strong)";
+}
+
+/** statusColor 兜底(task 无 STATUS_META 命中时)。re-export 以便 GraphView 共享。 */
+export { STATUS_META };

--- a/packages/gui/src/renderer/graph/nodes/TerritoryZoneNode.tsx
+++ b/packages/gui/src/renderer/graph/nodes/TerritoryZoneNode.tsx
@@ -1,0 +1,276 @@
+import type { NodeProps } from "@xyflow/react";
+import type { SemanticAxis } from "../constants";
+import { AXIS_COLOR_VAR } from "../constants";
+import type { SnapshotStatus } from "../../model/types";
+
+/**
+ * L1 领地总览的 zone 背景节点(IA v2 Layer 0)。
+ *
+ * 泛化自 LaneBackgroundNode(L2 三泳道背景):同样是「不参与点击拖拽的纯视觉分区壳」,
+ * 但 L1 的 zone 承载更丰富的健康信号 —— task zone 画状态比例条 + done/active 计数,
+ * decision zone 画 coverage 灯 + 状态分布。两种变体共享一个组件:
+ *
+ *   variant 'section' — 宽薄一行,只画 section 标题(里程碑 / 模块 / 未落地)。
+ *   variant 'zone'    — 一块领地:header(标题 + 健康条 + meta)+ chip 容器底板。
+ *
+ * 节点尺寸由布局器算好通过 style.width/height + 顶层 width/height 同时给(顶层必给,
+ * 否则 MiniMap 一个方块都不画 —— 同 ego 节点)。chip 是独立 React Flow 节点,叠在 zone 上。
+ */
+
+type Variant = "section" | "zone";
+
+interface ZoneData {
+  variant?: Variant;
+  title?: string;
+  subtitle?: string;
+  skel?: "task" | "decision";
+  axis?: SemanticAxis;
+  virtual?: boolean;
+  unlanded?: boolean;
+  // task 健康:
+  statusCounts?: Record<string, number>;
+  isAllDone?: boolean;
+  // decision 健康:
+  stateCounts?: Record<string, number>;
+  coverageSummary?: { covered: number; total: number; uncovered: number };
+  historyTotal?: number;
+  total?: number;
+  folded?: boolean;
+  zoneId?: string;
+  onFold?: (id: string) => void;
+}
+
+const STATUS_BAR_ORDER: Array<{ key: SnapshotStatus; label: string; color: string }> = [
+  { key: "blocked", label: "blocked", color: "var(--color-status-blocked)" },
+  { key: "active", label: "active", color: "var(--color-status-active)" },
+  { key: "in_review", label: "封存", color: "var(--color-status-in-review)" },
+  { key: "planned", label: "planned", color: "var(--color-status-planned)" },
+  { key: "done", label: "done", color: "var(--color-status-done)" },
+  { key: "cancelled", label: "cancelled", color: "var(--color-status-cancelled)" },
+];
+
+const DECISION_STATE_COLOR: Record<string, string> = {
+  proposed: "var(--color-status-in-review)",
+  active: "var(--color-axis-authority)",
+  deferred: "var(--color-status-planned)",
+  retired: "var(--color-text-faint)",
+  rejected: "var(--color-status-cancelled)",
+};
+
+export function TerritoryZoneNode({ data }: NodeProps) {
+  const d = data as unknown as ZoneData;
+
+  if (d.variant === "section") {
+    return (
+      <div className="flex h-full w-full items-end gap-3 px-1 pb-1">
+        <span className="ui-body text-[14px] font-semibold text-text">{d.title}</span>
+        {d.subtitle && (
+          <span className="ui-meta text-[11.5px] text-text-faint">{d.subtitle}</span>
+        )}
+      </div>
+    );
+  }
+
+  const axis = d.axis ?? "execution";
+  const accent = d.unlanded
+    ? "var(--color-danger)"
+    : AXIS_COLOR_VAR[axis];
+  const total = d.total ?? 0;
+
+  return (
+    <div
+      className="flex h-full w-full flex-col overflow-hidden rounded-xl border bg-surface"
+      style={{
+        borderColor: d.unlanded
+          ? "color-mix(in oklch, var(--color-danger) 40%, transparent)"
+          : "var(--color-border)",
+        borderWidth: d.unlanded ? 2 : 1,
+      }}
+    >
+      {/* zone header */}
+      <div
+        className="flex shrink-0 flex-col gap-1.5 px-3 pt-2.5 pb-2 border-b"
+        style={{ borderColor: "var(--color-border)" }}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
+            style={{ backgroundColor: accent, opacity: 0.7 }}
+          />
+          {d.isAllDone && (
+            <span
+              className="text-[12px] font-bold"
+              style={{ color: "var(--color-status-done)" }}
+            >
+              ✓
+            </span>
+          )}
+          <span
+            className={`ui-body min-w-0 flex-1 truncate text-[13px] font-semibold ${
+              d.virtual ? "text-text-muted" : "text-text"
+            }`}
+          >
+            {d.title}
+          </span>
+          {d.folded !== undefined && d.zoneId && d.onFold && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                d.onFold?.(d.zoneId!);
+              }}
+              className="shrink-0 rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-text-muted hover:border-[var(--color-border-strong)] hover:text-text"
+            >
+              {d.folded ? "▸ 展开" : "▾ 收起"}
+            </button>
+          )}
+        </div>
+
+        {/* 健康条(task skel:状态比例条)*/}
+        {d.skel === "task" && d.statusCounts && total > 0 && (
+          <StatusBar counts={d.statusCounts} total={total} />
+        )}
+
+        {/* 健康条(decision skel:coverage 灯 + 状态分布)*/}
+        {d.skel === "decision" && (
+          <DecisionHealth
+            coverage={d.coverageSummary}
+            stateCounts={d.stateCounts}
+            historyTotal={d.historyTotal}
+          />
+        )}
+
+        {/* meta 行 */}
+        {d.skel === "task" && d.statusCounts && (
+          <TaskMeta counts={d.statusCounts} total={total} allDone={d.isAllDone ?? false} />
+        )}
+      </div>
+      {/* chip 容器底板(实际 chip 是独立 RF 节点叠在 zone 的 body 区域)*/}
+      <div className="flex min-h-0 flex-1 flex-col px-2 py-2" />
+    </div>
+  );
+}
+
+function StatusBar({ counts, total }: { counts: Record<string, number>; total: number }) {
+  return (
+    <div
+      className="flex h-[5px] w-full overflow-hidden rounded-full"
+      style={{ backgroundColor: "var(--color-surface-raised)" }}
+    >
+      {STATUS_BAR_ORDER.map(({ key, color }) => {
+        const v = counts[key];
+        if (!v) return null;
+        return (
+          <div
+            key={key}
+            style={{ width: `${(v / total) * 100}%`, backgroundColor: color }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function TaskMeta({
+  counts,
+  total,
+  allDone,
+}: {
+  counts: Record<string, number>;
+  total: number;
+  allDone: boolean;
+}) {
+  const items: Array<{ label: string; color?: string; bold?: boolean }> = [];
+  if (counts.blocked)
+    items.push({ label: `${counts.blocked} blocked`, color: "var(--color-status-blocked)", bold: true });
+  if (counts.active)
+    items.push({ label: `${counts.active} active`, color: "var(--color-status-active)", bold: true });
+  if (counts.in_review) items.push({ label: `${counts.in_review} 封存` });
+  if (counts.planned) items.push({ label: `${counts.planned} planned` });
+  if (counts.done)
+    items.push({
+      label: `${counts.done} done`,
+      color: "var(--color-status-done)",
+      bold: allDone,
+    });
+  if (counts.cancelled)
+    items.push({ label: `${counts.cancelled} cancelled` });
+  void total;
+  return (
+    <div className="flex flex-wrap gap-x-2.5 gap-y-0.5 ui-meta text-[11px] text-text-muted">
+      {items.map((it, i) => (
+        <span
+          key={i}
+          style={{
+            color: it.color,
+            fontWeight: it.bold ? 600 : 400,
+            opacity: it.color ? 1 : undefined,
+          }}
+        >
+          {it.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function DecisionHealth({
+  coverage,
+  stateCounts,
+  historyTotal,
+}: {
+  coverage?: { covered: number; total: number; uncovered: number };
+  stateCounts?: Record<string, number>;
+  historyTotal?: number;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 ui-meta text-[11px] text-text-muted">
+      {coverage && coverage.total > 0 && (
+        <span className="flex items-center gap-1.5">
+          <span className="flex items-center gap-0.5">
+            {/* coverage 灯:covered 绿 / uncovered 红 / 每灯一 claim,封顶 10 */}
+            {Array.from({ length: Math.min(coverage.total, 10) }).map((_, i) => {
+              const covered = i < coverage.covered;
+              return (
+                <span
+                  key={i}
+                  className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
+                  style={{
+                    backgroundColor: covered
+                      ? "var(--color-status-done)"
+                      : "var(--color-danger)",
+                  }}
+                />
+              );
+            })}
+          </span>
+          <span>
+            {coverage.covered}/{coverage.total} claim
+          </span>
+        </span>
+      )}
+      {stateCounts && (
+        <span className="flex items-center gap-1.5">
+          {Object.entries(stateCounts).map(([state, cnt]) => (
+            <span
+              key={state}
+              className="rounded px-1 font-mono text-[10px]"
+              style={{
+                color: DECISION_STATE_COLOR[state] ?? "var(--color-text-muted)",
+                backgroundColor: `color-mix(in oklch, ${
+                  DECISION_STATE_COLOR[state] ?? "var(--color-text-muted)"
+                } 12%, transparent)`,
+              }}
+            >
+              {cnt} {state}
+            </span>
+          ))}
+        </span>
+      )}
+      {historyTotal !== undefined && historyTotal > 0 && (
+        <span style={{ color: "var(--color-axis-authority)" }}>
+          ⧉ {historyTotal} 历史版本
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/gui/src/renderer/graph/territoryLayout.ts
+++ b/packages/gui/src/renderer/graph/territoryLayout.ts
@@ -1,0 +1,258 @@
+import type { TaskRow, RelationEdge, DecisionRow, FactRef } from "../model/types";
+import type { RelationCoverageRow } from "../../api/renderer-dto.ts";
+import { parseEndpoint } from "./endpoint";
+import type { GraphFilterInput, LayoutOutput } from "./graphLayoutTypes";
+import {
+  partitionTaskTerritory,
+  partitionDecisionTerritory,
+  GEO,
+  type Section,
+  type Zone,
+  type Member,
+} from "./territoryPartition";
+import type { Node } from "@xyflow/react";
+
+/**
+ * L1 领地总览布局(IA v2 Layer 0 / dec_01KXA7811SVVT8P66HNDFZQ7DF)。
+ *
+ * 取代「300 条平铺列表」的首屏:把台账按固有结构分区成「领地块」,一块一块铺开,
+ * 让用户一眼看出「哪块干什么、各自健康度」。是聚光灯(L2)的入口 —— 点块内实体即
+ * 切换到 ego 画布并以它为焦点。
+ *
+ * 纯函数 + 确定性:输入 rows + relations + filters + expandedZones → React Flow 节点。
+ * 零重叠(网格布局)、双主题(节点只用 CSS 变量)、节点尺寸顶层 width/height 必给(MiniMap)。
+ * 无边(L1 是「空间形状」,关系线在 L2 聚光灯才画)。
+ *
+ * 分区逻辑(两条骨架轴)在 territoryPartition.ts;本文件只管几何摆放 + 节点组装。
+ */
+
+export type { TerritorySkel } from "./territoryPartition";
+export type { Section, Zone, Member } from "./territoryPartition";
+
+// ── 几何常量 ──
+const ZONE_W = 340;
+const ZONE_HEADER_H = 78;
+const ZONE_BODY_PAD_Y = 8;
+const ZONE_BODY_PAD_X = 8;
+const GRID_COLS = 3;
+const ZONE_GAP_X = 20;
+const ZONE_GAP_Y = 20;
+const SECTION_HEADER_H = 34;
+const SECTION_GAP_Y = 40;
+const TOP_PAD = 16;
+const LEFT_PAD = 24;
+
+export interface TerritoryInput {
+  skel: "task" | "decision";
+  tasks: TaskRow[];
+  decisions: DecisionRow[];
+  facts: FactRef[];
+  relations: RelationEdge[];
+  filters: GraphFilterInput;
+  coverageRows?: ReadonlyArray<RelationCoverageRow>;
+  /** 已展开(不折叠)的 zone id 集;默认折叠 hot-only。 */
+  expandedZones: Set<string>;
+}
+
+export function layoutTerritory(input: TerritoryInput): LayoutOutput {
+  const { skel, expandedZones, filters } = input;
+  const partitionInput = {
+    tasks: input.tasks,
+    decisions: input.decisions,
+    relations: input.relations,
+    filters,
+    coverageRows: input.coverageRows,
+  };
+  const typeOn = (e: "task" | "decision") => filters.types.has(e);
+  const sections: Section[] =
+    skel === "task"
+      ? typeOn("task")
+        ? partitionTaskTerritory(partitionInput)
+        : []
+      : typeOn("decision")
+        ? partitionDecisionTerritory(partitionInput)
+        : [];
+
+  const rfNodes: Node[] = [];
+  let cursorY = TOP_PAD;
+  let maxX = LEFT_PAD;
+
+  for (const section of sections) {
+    if (section.zones.length === 0) continue;
+
+    // section header
+    const sectionW = GRID_COLS * ZONE_W + (GRID_COLS - 1) * ZONE_GAP_X;
+    rfNodes.push({
+      id: `territory-section:${section.id}`,
+      type: "territoryZone",
+      position: { x: LEFT_PAD, y: cursorY },
+      width: sectionW,
+      height: SECTION_HEADER_H,
+      style: { width: sectionW, height: SECTION_HEADER_H },
+      data: { variant: "section", title: section.title, subtitle: section.subtitle, skel },
+      zIndex: -1,
+      selectable: false,
+      draggable: false,
+    });
+    cursorY += SECTION_HEADER_H + 8;
+
+    const rows = chunk(section.zones, GRID_COLS);
+    for (const row of rows) {
+      for (const zone of row) {
+        const folded = !expandedZones.has(zone.id);
+        zone.bodyH = computeBodyH(zone, folded);
+        zone.h = ZONE_HEADER_H + ZONE_BODY_PAD_Y * 2 + zone.bodyH;
+      }
+      const rowH = Math.max(...row.map((z) => z.h ?? 0));
+
+      let cursorX = LEFT_PAD;
+      for (const zone of row) {
+        const zh = zone.h ?? 0;
+        const folded = !expandedZones.has(zone.id);
+        const shown = visibleMembers(zone, folded);
+        const memberH = zone.skel === "task" ? GEO.TASK_CHIP_H : GEO.DECISION_CARD_H;
+        const memberGap = zone.skel === "task" ? GEO.TASK_CHIP_GAP : GEO.DECISION_CARD_GAP;
+        const memberW = ZONE_W - ZONE_BODY_PAD_X * 2;
+
+        // zone 背景
+        rfNodes.push({
+          id: `territory-zone:${zone.id}`,
+          type: "territoryZone",
+          position: { x: cursorX, y: cursorY },
+          width: ZONE_W,
+          height: zh,
+          style: { width: ZONE_W, height: zh },
+          data: {
+            variant: "zone",
+            title: zone.title,
+            axis: zone.axis,
+            virtual: zone.virtual,
+            unlanded: zone.unlanded,
+            skel: zone.skel,
+            statusCounts: zone.statusCounts,
+            isAllDone: zone.isAllDone,
+            stateCounts: zone.stateCounts,
+            coverageSummary: zone.coverageSummary,
+            historyTotal: zone.historyTotal,
+            total: zone.total,
+            folded,
+            zoneId: zone.id,
+          },
+          zIndex: 0,
+          selectable: false,
+          draggable: false,
+        });
+
+        // member chips
+        let memberY = ZONE_HEADER_H + ZONE_BODY_PAD_Y;
+        for (const m of shown) {
+          rfNodes.push(buildChipNode(m, cursorX + ZONE_BODY_PAD_X, cursorY + memberY, memberW, memberH, zone));
+          memberY += memberH + memberGap;
+        }
+
+        // fold 提示
+        if (folded && zone.members.length > shown.length) {
+          const hidden = zone.members.length - shown.length;
+          rfNodes.push({
+            id: `territory-fold:${zone.id}`,
+            type: "territoryChip",
+            position: { x: cursorX + ZONE_BODY_PAD_X, y: cursorY + memberY },
+            width: memberW,
+            height: GEO.TASK_CHIP_H,
+            style: { width: memberW, height: GEO.TASK_CHIP_H },
+            data: {
+              entity: "fold",
+              label: `▸ 还有 ${hidden} 项（多为 done）— 展开`,
+              zoneId: zone.id,
+              skel: zone.skel,
+            },
+            zIndex: 2,
+          });
+        }
+
+        cursorX += ZONE_W + ZONE_GAP_X;
+        maxX = Math.max(maxX, cursorX);
+      }
+      cursorY += rowH + ZONE_GAP_Y;
+    }
+    cursorY += SECTION_GAP_Y;
+  }
+
+  const bounds = {
+    width: Math.max(maxX, LEFT_PAD + GRID_COLS * ZONE_W) - LEFT_PAD,
+    height: cursorY - TOP_PAD,
+  };
+
+  return {
+    nodes: rfNodes,
+    edges: [],
+    cycleWarning: { count: 0, cycles: [] },
+    resolvedFocusId: null,
+    focusClaims: [],
+    bounds,
+  };
+}
+
+function buildChipNode(
+  m: Member,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  zone: Zone,
+): Node {
+  const navRef = m.entity === "task" ? `task/${m.id}` : m.id;
+  return {
+    id: m.id,
+    type: "territoryChip",
+    position: { x, y },
+    width: w,
+    height: h,
+    style: { width: w, height: h },
+    data: {
+      entity: m.entity,
+      raw: m.row,
+      label: m.label,
+      color: m.color,
+      dimmed: m.dimmed,
+      hiddenCount: m.hiddenCount,
+      state: m.state,
+      coverage: m.coverage,
+      historyCount: m.historyCount,
+      derivedCount: m.derivedCount,
+      riskTier: m.riskTier,
+      urgency: m.urgency,
+      skel: zone.skel,
+      unlanded: zone.unlanded,
+      navRef,
+    },
+    zIndex: 2,
+  };
+}
+
+// ── 几何辅助 ──
+
+function computeBodyH(zone: Zone, folded: boolean): number {
+  const memberH = zone.skel === "task" ? GEO.TASK_CHIP_H : GEO.DECISION_CARD_H;
+  const memberGap = zone.skel === "task" ? GEO.TASK_CHIP_GAP : GEO.DECISION_CARD_GAP;
+  const shown = visibleMembers(zone, folded);
+  const extra = folded && zone.members.length > shown.length ? 1 : 0;
+  const h = (shown.length + extra) * memberH + Math.max(0, shown.length + extra - 1) * memberGap;
+  return Math.max(GEO.ZONE_MIN_BODY_H, Math.min(GEO.ZONE_MAX_BODY_H, h));
+}
+
+function visibleMembers(zone: Zone, folded: boolean): Member[] {
+  if (!folded) return zone.members.slice(0, 50);
+  if (zone.skel === "decision") return zone.members;
+  return zone.members.slice(0, GEO.FOLDED_TASK_CAP);
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+// parseEndpoint 在 graphLayout.ts 的 validEdges 过滤里用,territory 收到的 relations 已过滤;
+// 这里保留 void 以防 tree-shake 误报 import 未用(实际 TerritoryInput.relations 已是过滤后的)。
+void parseEndpoint;

--- a/packages/gui/src/renderer/graph/territoryPartition.ts
+++ b/packages/gui/src/renderer/graph/territoryPartition.ts
@@ -1,0 +1,468 @@
+import type { TaskRow, RelationEdge, DecisionRow } from "../model/types";
+import type { RelationCoverageRow } from "../../api/renderer-dto.ts";
+import { endpointToNodeId } from "./endpoint";
+import { type SemanticAxis } from "./constants";
+import type { GraphFilterInput } from "./graphLayoutTypes";
+import { computeClaimCoverage } from "./claimCoverage";
+import { statusColor } from "./graphLayoutShared";
+import { sortDecisionQueue } from "../model/triadic";
+
+/**
+ * L1 领地分区逻辑(IA v2 Layer 0)。
+ *
+ * 从 territoryLayout.ts 抽出,因为分区(task/decision)+ 评分 + 家族收拢 占了 ~400 行,
+ * 与纯几何布局(layoutTerritory)职责不同,合起来 >600 行触发文件复杂度门。
+ *
+ * 两条骨架轴:
+ *   task     — 按 rootTask(milestone)分区;有子任务的根=里程碑块,独立任务按模块聚合。
+ *   decision — 按 supersede/refine/narrows 链(权威轴)union-find 收拢成「家族」,
+ *              再按 landing(派生的 task 落到哪个 milestone)二次分区;无落地=示警区。
+ */
+
+export type TerritorySkel = "task" | "decision";
+
+// ── 几何常量(与 territoryLayout.ts 共享)──
+const TASK_CHIP_H = 30;
+const TASK_CHIP_GAP = 4;
+const DECISION_CARD_H = 92;
+const DECISION_CARD_GAP = 10;
+const ZONE_MIN_BODY_H = 36;
+const ZONE_MAX_BODY_H = 460;
+const FOLDED_TASK_CAP = 8;
+export const GEO = {
+  TASK_CHIP_H,
+  TASK_CHIP_GAP,
+  DECISION_CARD_H,
+  DECISION_CARD_GAP,
+  ZONE_MIN_BODY_H,
+  ZONE_MAX_BODY_H,
+  FOLDED_TASK_CAP,
+};
+
+// ── 内部结构 ──
+export interface Member {
+  id: string;
+  entity: "task" | "decision";
+  row: TaskRow | DecisionRow;
+  label: string;
+  color?: string;
+  dimmed: boolean;
+  hiddenCount: number;
+  state?: string;
+  coverage?: { covered: number; total: number; uncovered: number };
+  historyCount?: number;
+  derivedCount?: number;
+  riskTier?: string;
+  urgency?: string;
+}
+
+export interface Zone {
+  id: string;
+  title: string;
+  axis: SemanticAxis;
+  virtual: boolean;
+  unlanded: boolean;
+  skel: "task" | "decision";
+  statusCounts?: Record<string, number>;
+  isAllDone?: boolean;
+  stateCounts?: Record<string, number>;
+  coverageSummary?: { covered: number; total: number; uncovered: number };
+  historyTotal?: number;
+  total: number;
+  members: Member[];
+  // 派生几何(布局阶段填):
+  bodyH?: number;
+  h?: number;
+}
+
+export interface Section {
+  id: string;
+  title: string;
+  subtitle: string;
+  zones: Zone[];
+}
+
+export interface PartitionInput {
+  tasks: TaskRow[];
+  decisions: DecisionRow[];
+  relations: RelationEdge[];
+  filters: GraphFilterInput;
+  coverageRows?: ReadonlyArray<RelationCoverageRow>;
+}
+
+// ══ task 领地 ══
+
+export function partitionTaskTerritory(input: PartitionInput): Section[] {
+  const { tasks, relations, filters } = input;
+  const visible = tasks.filter(
+    (t) => filters.modules.has(t.module) && filters.types.has("task"),
+  );
+
+  const byRoot = new Map<string, TaskRow[]>();
+  for (const t of visible) {
+    const root = t.rootTaskId ?? t.taskId;
+    const list = byRoot.get(root);
+    if (list) list.push(t);
+    else byRoot.set(root, [t]);
+  }
+
+  const derivesByTask = new Map<string, number>();
+  for (const e of relations) {
+    if (e.kind !== "derives") continue;
+    const t = endpointToNodeId(e.to);
+    derivesByTask.set(t, (derivesByTask.get(t) ?? 0) + 1);
+  }
+
+  const milestoneZones: Zone[] = [];
+  const soloByModule = new Map<string, TaskRow[]>();
+
+  for (const [rootId, members] of byRoot) {
+    if (members.length > 1) {
+      const root = members.find((m) => m.taskId === rootId);
+      milestoneZones.push(
+        buildTaskZone(`root:${rootId}`, root?.rootTitle ?? root?.title ?? rootId, members, derivesByTask, false),
+      );
+    } else {
+      const t = members[0];
+      const mod = t.module || "(未分模块)";
+      const list = soloByModule.get(mod);
+      if (list) list.push(t);
+      else soloByModule.set(mod, [t]);
+    }
+  }
+
+  const moduleZones: Zone[] = [];
+  for (const [mod, list] of soloByModule) {
+    moduleZones.push(buildTaskZone(`mod:${mod}`, mod, list, derivesByTask, true));
+  }
+
+  milestoneZones.sort((a, b) => taskZoneRank(a) - taskZoneRank(b));
+  moduleZones.sort((a, b) => taskZoneRank(a) - taskZoneRank(b));
+
+  const sections: Section[] = [];
+  if (milestoneZones.length > 0) {
+    sections.push({
+      id: "milestones",
+      title: "里程碑 / 任务树",
+      subtitle: `${milestoneZones.length} 块 · 排序:阻塞 → 进行 → 规划 → 完成`,
+      zones: milestoneZones,
+    });
+  }
+  if (moduleZones.length > 0) {
+    sections.push({
+      id: "solo",
+      title: "独立任务（按模块聚合）",
+      subtitle: `${moduleZones.reduce((s, z) => s + z.total, 0)} 项`,
+      zones: moduleZones,
+    });
+  }
+  return sections;
+}
+
+function buildTaskZone(
+  id: string,
+  title: string,
+  members: TaskRow[],
+  derivesByTask: Map<string, number>,
+  virtual: boolean,
+): Zone {
+  const statusCounts: Record<string, number> = {};
+  for (const t of members) {
+    const s = t.coordinationStatus ?? "unknown";
+    statusCounts[s] = (statusCounts[s] ?? 0) + 1;
+  }
+  const total = members.length;
+  const isAllDone = total > 0 && (statusCounts.done ?? 0) === total;
+
+  const sorted = [...members].sort((a, b) => taskScore(b) - taskScore(a));
+  const memberList: Member[] = sorted.map((t) => {
+    const nodeId = t.taskId;
+    const decCount = derivesByTask.get(nodeId) ?? 0;
+    return {
+      id: nodeId,
+      entity: "task" as const,
+      row: t,
+      label: t.title,
+      color: statusColor(t),
+      dimmed: t.coordinationStatus === "done" || t.coordinationStatus === "cancelled",
+      hiddenCount: decCount,
+    };
+  });
+
+  return {
+    id,
+    title,
+    axis: "execution",
+    virtual,
+    unlanded: false,
+    skel: "task",
+    statusCounts,
+    isAllDone,
+    total,
+    members: memberList,
+  };
+}
+
+/** task 重要性:阻塞 > 进行 > 封存 > 规划 > done/cancelled;叠加近期性。 */
+function taskScore(t: TaskRow): number {
+  const base: Record<string, number> = {
+    blocked: 40,
+    active: 28,
+    in_review: 22,
+    planned: 12,
+    done: 4,
+    cancelled: 2,
+    unknown: 8,
+  };
+  let s = base[t.coordinationStatus ?? "unknown"] ?? 8;
+  const da = daysAgo(t.lastKnownAt);
+  s += da < 3 ? 24 : da < 7 ? 14 : da < 30 ? 6 : 0;
+  return s;
+}
+
+/** zone 排序键:blocked → active → done 占比多(沉底)。 */
+function taskZoneRank(z: Zone): number {
+  const c = z.statusCounts ?? {};
+  if ((c.blocked ?? 0) > 0) return 0;
+  if ((c.active ?? 0) > 0) return 1;
+  const doneRatio = z.total > 0 ? (c.done ?? 0) / z.total : 0;
+  if (doneRatio >= 0.8) return 3;
+  return 2;
+}
+
+// ══ decision 领地 ══
+
+export function partitionDecisionTerritory(input: PartitionInput): Section[] {
+  const { decisions, tasks, relations, filters, coverageRows } = input;
+  const visible = decisions.filter((_d) => filters.types.has("decision"));
+
+  // union-find:权威轴连起来的 decision = 同一家族
+  const parent = new Map<string, string>();
+  const find = (x: string): string => {
+    let r = x;
+    while (parent.get(r) && parent.get(r) !== r) r = parent.get(r)!;
+    parent.set(x, r);
+    return r;
+  };
+  const union = (a: string, b: string) => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent.set(ra, rb);
+  };
+  for (const d of visible) parent.set(`decision/${d.decisionId}`, `decision/${d.decisionId}`);
+  for (const e of relations) {
+    if (e.kind !== "supersedes" && e.kind !== "refines" && e.kind !== "narrows") continue;
+    const s = endpointToNodeId(e.from);
+    const t = endpointToNodeId(e.to);
+    if (parent.has(s) && parent.has(t)) union(s, t);
+  }
+
+  const fams = new Map<string, string[]>();
+  for (const d of visible) {
+    const id = `decision/${d.decisionId}`;
+    const root = find(id);
+    const list = fams.get(root);
+    if (list) list.push(id);
+    else fams.set(root, [id]);
+  }
+
+  const superseded = new Set<string>();
+  for (const e of relations) {
+    if (e.kind === "supersedes") superseded.add(endpointToNodeId(e.to));
+  }
+
+  const decById = new Map<string, DecisionRow>(
+    visible.map((d) => [`decision/${d.decisionId}`, d] as [string, DecisionRow]),
+  );
+  const taskById = new Map<string, TaskRow>(tasks.map((t) => [t.taskId, t] as [string, TaskRow]));
+
+  const derivesFromDecision = new Map<string, string[]>();
+  for (const e of relations) {
+    if (e.kind !== "derives") continue;
+    const s = endpointToNodeId(e.from);
+    const t = endpointToNodeId(e.to);
+    // endpointToNodeId 把 task/task_X 剥成 task_X;decision/dec_Y 保留前缀。
+    if (s.startsWith("decision/") && !t.startsWith("decision/") && !t.startsWith("fact/")) {
+      const list = derivesFromDecision.get(s);
+      if (list) list.push(t);
+      else derivesFromDecision.set(s, [t]);
+    }
+  }
+
+  interface Fam {
+    headId: string;
+    members: string[];
+    landing: string | null;
+    landingRootId: string | null;
+  }
+  const famList: Fam[] = [];
+  for (const [, memberIds] of fams) {
+    const cands = memberIds.filter((id) => !superseded.has(id));
+    const pool = cands.length > 0 ? cands : memberIds;
+    const sorted = [...pool].sort((a, b) => {
+      const da = decById.get(a);
+      const db = decById.get(b);
+      return decisionScore(db) - decisionScore(da);
+    });
+    const headId = sorted[0];
+
+    const landingCnt = new Map<string, number>();
+    let landingTitle: string | null = null;
+    let landingRootId: string | null = null;
+    for (const mid of memberIds) {
+      const taskIds = derivesFromDecision.get(mid) ?? [];
+      for (const tid of taskIds) {
+        const task = taskById.get(tid);
+        if (!task) continue;
+        const rootId = task.rootTaskId ?? task.taskId;
+        landingCnt.set(rootId, (landingCnt.get(rootId) ?? 0) + 1);
+      }
+    }
+    if (landingCnt.size > 0) {
+      let best = -1;
+      for (const [rootId, cnt] of landingCnt) {
+        if (cnt > best) {
+          best = cnt;
+          landingRootId = rootId;
+          const rep = tasks.find((t) => (t.rootTaskId ?? t.taskId) === rootId);
+          landingTitle = rep?.rootTitle ?? rep?.title ?? rootId;
+        }
+      }
+    }
+    famList.push({ headId, members: memberIds, landing: landingTitle, landingRootId });
+  }
+
+  const byLanding = new Map<string, Fam[]>();
+  for (const f of famList) {
+    const key = f.landing ?? "__unlanded__";
+    const list = byLanding.get(key);
+    if (list) list.push(f);
+    else byLanding.set(key, [f]);
+  }
+
+  const landingEntries = [...byLanding.entries()].sort((a, b) => {
+    const au = a[0] === "__unlanded__";
+    const bu = b[0] === "__unlanded__";
+    if (au !== bu) return au ? 1 : -1;
+    const aProp = a[1].some((f) => f.members.some((id) => decById.get(id)?.state === "proposed"));
+    const bProp = b[1].some((f) => f.members.some((id) => decById.get(id)?.state === "proposed"));
+    if (aProp !== bProp) return aProp ? -1 : 1;
+    const aMax = Math.max(...a[1].map((f) => decisionScore(decById.get(f.headId))));
+    const bMax = Math.max(...b[1].map((f) => decisionScore(decById.get(f.headId))));
+    return bMax - aMax;
+  });
+
+  const sections: Section[] = [];
+  for (const [landingKey, famsAtLanding] of landingEntries) {
+    const unlanded = landingKey === "__unlanded__";
+    const landingTitle = unlanded ? "未落地" : (famsAtLanding[0].landing ?? "");
+    const title = unlanded
+      ? "⚠ 未落地（没有派生任务的决策族）"
+      : `里程碑 · ${landingTitle}`;
+    const zones: Zone[] = [
+      buildDecisionZone(landingKey, landingTitle, famsAtLanding, decById, derivesFromDecision, coverageRows, unlanded),
+    ];
+    sections.push({
+      id: `landing:${landingKey}`,
+      title,
+      subtitle: `${famsAtLanding.length} 个决策族`,
+      zones,
+    });
+  }
+
+  return sections;
+}
+
+function buildDecisionZone(
+  id: string,
+  title: string,
+  fams: { headId: string; members: string[] }[],
+  decById: Map<string, DecisionRow>,
+  derivesFromDecision: Map<string, string[]>,
+  coverageRows: ReadonlyArray<RelationCoverageRow> | undefined,
+  unlanded: boolean,
+): Zone {
+  const heads = fams.map((f) => ({ f, head: decById.get(f.headId)! })).filter((x) => x.head);
+  const sorted = sortDecisionQueue(heads.map((x) => x.head));
+  const sortedFams = sorted
+    .map((d) => heads.find((x) => x.head.decisionId === d.decisionId)!)
+    .filter(Boolean);
+
+  const members: Member[] = sortedFams.map(({ f, head }) => {
+    const cov = computeClaimCoverage(head, coverageRows);
+    const covered = cov.filter((c) => c.status === "covered").length;
+    const uncovered = cov.filter((c) => c.status === "uncovered").length;
+    const famDerived = new Set<string>();
+    for (const mid of f.members) {
+      for (const tid of derivesFromDecision.get(mid) ?? []) famDerived.add(tid);
+    }
+    return {
+      id: `decision/${head.decisionId}`,
+      entity: "decision" as const,
+      row: head,
+      label: head.title,
+      dimmed: head.state === "retired" || head.state === "rejected",
+      hiddenCount: 0,
+      state: head.state,
+      coverage: { covered, total: cov.length, uncovered },
+      historyCount: f.members.length - 1,
+      derivedCount: famDerived.size,
+      riskTier: head.riskTier,
+      urgency: head.urgency,
+    };
+  });
+
+  const stateCounts: Record<string, number> = {};
+  let covCovered = 0;
+  let covTotal = 0;
+  let historyTotal = 0;
+  for (const { f, head } of sortedFams) {
+    stateCounts[head.state] = (stateCounts[head.state] ?? 0) + 1;
+    const cov = computeClaimCoverage(head, coverageRows);
+    covCovered += cov.filter((c) => c.status === "covered").length;
+    covTotal += cov.length;
+    historyTotal += f.members.length - 1;
+  }
+
+  return {
+    id,
+    title,
+    axis: "authority",
+    virtual: false,
+    unlanded,
+    skel: "decision",
+    stateCounts,
+    coverageSummary: { covered: covCovered, total: covTotal, uncovered: covTotal - covCovered },
+    historyTotal,
+    total: members.length,
+    members,
+  };
+}
+
+/** decision 重要性:proposed > active > deferred > retired/rejected;叠加 uncovered + 近期性。 */
+function decisionScore(d: DecisionRow | undefined): number {
+  if (!d) return 0;
+  const base: Record<string, number> = {
+    proposed: 34,
+    active: 20,
+    deferred: 10,
+    retired: 0,
+    rejected: 0,
+  };
+  let s = base[d.state] ?? 5;
+  const unc = d.claims.filter((c) => {
+    const chosen = d.chosen.find((x) => x.id === c.id);
+    return !chosen?.evidence?.length;
+  }).length;
+  s += Math.min(15, unc * 3);
+  const da = daysAgo(d.proposedAt ?? d.lastChangedAt ?? "");
+  s += da < 3 ? 26 : da < 7 ? 16 : da < 30 ? 6 : 0;
+  return s;
+}
+
+function daysAgo(iso: string): number {
+  if (!iso) return 999;
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return 999;
+  return Math.max(0, Math.floor((Date.now() - t) / 86_400_000));
+}

--- a/packages/gui/src/renderer/graph/useTerritoryView.ts
+++ b/packages/gui/src/renderer/graph/useTerritoryView.ts
@@ -1,0 +1,70 @@
+import { useState, useCallback } from "react";
+
+/**
+ * L1 领地总览的视图状态(IA v2 Layer 0)。
+ *
+ * GraphView 在 600 行复杂度门下,所以 territory 的三个状态外置于此 hook:
+ *
+ *   viewMode  — 'territory'(首屏默认)↔ 'spotlight'(L2 ego)。
+ *   skel      — territory 内的骨架轴(task 按 milestone / decision 按 supersede 家族)。
+ *   expandedZones — 不折叠的 zone id 集(默认空 = 全折叠 hot-only)。
+ *
+ * 切换到 spotlight 由 chip 点击触发(setViewMode + openFocus 两步),回领地由 GraphView
+ * 顶栏的「回领地」按钮触发。openFocus 由 useEgoCanvas 提供,作为参数注入。
+ */
+
+export type ViewMode = "territory" | "spotlight";
+export type TerritorySkel = "task" | "decision";
+
+export interface TerritoryView {
+  viewMode: ViewMode;
+  skel: TerritorySkel;
+  expandedZones: Set<string>;
+  /** 点 territory chip → 切到 spotlight + openFocus。 */
+  enterSpotlight: (nodeId: string) => void;
+  /** 直接切模式(模式条的「领地 / 聚光灯」按钮)。切到 spotlight 时不重置焦点。 */
+  setViewMode: (m: ViewMode) => void;
+  /** 「回领地」。 */
+  enterTerritory: () => void;
+  setSkel: (skel: TerritorySkel) => void;
+  /** zone 折叠切换(头 / 折叠行的 ▸)。 */
+  toggleZone: (zoneId: string) => void;
+}
+
+export function useTerritoryView(openFocus: (id: string) => void): TerritoryView {
+  const [viewMode, setViewMode] = useState<ViewMode>("territory");
+  const [skel, setSkel] = useState<TerritorySkel>("task");
+  const [expandedZones, setExpandedZones] = useState<Set<string>>(() => new Set());
+
+  const enterSpotlight = useCallback(
+    (nodeId: string) => {
+      setViewMode("spotlight");
+      openFocus(nodeId);
+    },
+    [openFocus],
+  );
+
+  const enterTerritory = useCallback(() => {
+    setViewMode("territory");
+  }, []);
+
+  const toggleZone = useCallback((zoneId: string) => {
+    setExpandedZones((prev) => {
+      const next = new Set(prev);
+      if (next.has(zoneId)) next.delete(zoneId);
+      else next.add(zoneId);
+      return next;
+    });
+  }, []);
+
+  return {
+    viewMode,
+    skel,
+    expandedZones,
+    enterSpotlight,
+    setViewMode,
+    enterTerritory,
+    setSkel,
+    toggleZone,
+  };
+}

--- a/packages/gui/src/renderer/views/GraphView.tsx
+++ b/packages/gui/src/renderer/views/GraphView.tsx
@@ -36,7 +36,11 @@ import { FactNode } from "../graph/nodes/FactNode";
 import { EgoNode } from "../graph/nodes/EgoNode";
 import { ModuleGroupNode } from "../graph/nodes/ModuleGroupNode";
 import { LaneBackgroundNode } from "../graph/nodes/LaneBackgroundNode";
+import { TerritoryZoneNode } from "../graph/nodes/TerritoryZoneNode";
+import { TerritoryChipNode, territoryChipColor } from "../graph/nodes/TerritoryChipNode";
 import { InteractiveEdge } from "../graph/edges/InteractiveEdge";
+import { useTerritoryView } from "../graph/useTerritoryView";
+import { TerritoryModeBar } from "../components/TerritoryModeBar";
 import {
   GraphFilterPanel,
   type GraphFilters,
@@ -54,6 +58,8 @@ const nodeTypes = {
   ego: EgoNode,
   moduleGroup: ModuleGroupNode,
   laneBackground: LaneBackgroundNode,
+  territoryZone: TerritoryZoneNode,
+  territoryChip: TerritoryChipNode,
 };
 
 const edgeTypes = {
@@ -168,6 +174,22 @@ function GraphViewInner({
     resolvedFocusId,
   });
 
+  // L1 领地总览状态机(territory ↔ spotlight 模式切换 + 骨架轴 + zone 折叠态)。
+  const {
+    viewMode,
+    skel,
+    expandedZones,
+    enterSpotlight,
+    setViewMode,
+    setSkel,
+    toggleZone,
+  } = useTerritoryView(openFocus);
+
+  // 跨视图带入的 focusRef → 切到聚光灯(用户「跳到这张图」的足迹 = 要看某实体)。
+  useEffect(() => {
+    if (focusRef) setViewMode("spotlight");
+  }, [focusRef, setViewMode]);
+
   useEffect(() => {
     const ac = new AbortController();
     computeGraphLayout({
@@ -177,12 +199,14 @@ function GraphViewInner({
       facts: facts ?? [],
       coverageRows: coverageRows ?? [],
       factAnchors: factAnchors ?? [],
-      focusNodeId: focusId,
+      focusNodeId: viewMode === "territory" ? null : focusId,
       expandedFacts,
       filters: layoutInputFilters,
       inLoopNodes: EMPTY_LOOP,
       inLoopEdges: EMPTY_LOOP,
-      canvas: { shown, expanded },
+      ...(viewMode === "territory"
+        ? { territory: { skel, expandedZones } }
+        : { canvas: { shown, expanded } }),
     })
       .then(({ nodes: rfNodes, edges: rfEdges, cycleWarning: warning, resolvedFocusId: rid }) => {
         if (ac.signal.aborted) return;
@@ -210,17 +234,35 @@ function GraphViewInner({
     layoutInputFilters,
     shown,
     expanded,
+    viewMode,
+    skel,
+    expandedZones,
   ]);
 
   // 单击 chip = 就地展开成卡片并长出邻居(累积,永不重排已有画布)。
   // 卡片(已展开)单击不处理 —— 收起 / 详情 / 设为中心 走卡片自身按钮。
+  // territory 模式下 territoryChip 单击 → 切到聚光灯(openFocus);fold chip → toggleZone。
   const onNodeClick = useCallback(
     (_evt: any, node: any) => {
+      if (node.type === "territoryChip") {
+        const d = node.data ?? {};
+        if (d.entity === "fold" && d.zoneId) {
+          toggleZone(d.zoneId);
+          return;
+        }
+        if (d.navRef) enterSpotlight(d.navRef);
+        return;
+      }
+      if (node.type === "territoryZone") {
+        // zone header 的折叠按钮走 zoneId;背景点击不处理
+        if (node.data?.zoneId) toggleZone(node.data.zoneId);
+        return;
+      }
       if (node.type !== "ego") return;
       if (node.data?.expanded) return;
       expandNode(node.id);
     },
-    [expandNode],
+    [expandNode, toggleZone, enterSpotlight],
   );
 
   // 双击 = 设为画布中心(openFocus:重排前后各 2 跳,推历史)。
@@ -290,30 +332,44 @@ function GraphViewInner({
     return map;
   }, [nodes]);
 
-  // Node/edge count for header (exclude lane backgrounds)
+  // Node/edge count for header (exclude backgrounds)
   const visibleNodeCount = useMemo(
-    () => nodes.filter((n) => n.type !== "moduleGroup" && n.type !== "laneBackground").length,
+    () =>
+      nodes.filter(
+        (n) =>
+          n.type !== "moduleGroup" &&
+          n.type !== "laneBackground" &&
+          n.type !== "territoryZone",
+      ).length,
     [nodes],
   );
 
   // 注入卡片交互回调(收起 / 设为中心 / 详情跳转)+ id 到 ego 节点 data。
+  // territory 节点注入 onOpen(chip → 聚光灯)+ onFold(zone 折叠)。
   const displayNodes = useMemo(
     () =>
-      nodes.map((n) =>
-        n.type === "ego"
-          ? {
-              ...n,
-              data: {
-                ...n.data,
-                id: n.id,
-                onCollapse: collapseNode,
-                onRefocus: openFocus,
-                onNavigate: onNavigateEntity,
-              },
-            }
-          : n,
-      ),
-    [nodes, collapseNode, openFocus, onNavigateEntity],
+      nodes.map((n) => {
+        if (n.type === "ego") {
+          return {
+            ...n,
+            data: {
+              ...n.data,
+              id: n.id,
+              onCollapse: collapseNode,
+              onRefocus: openFocus,
+              onNavigate: onNavigateEntity,
+            },
+          };
+        }
+        if (n.type === "territoryChip" || n.type === "territoryZone") {
+          return {
+            ...n,
+            data: { ...n.data, onOpen: enterSpotlight, onFold: toggleZone },
+          };
+        }
+        return n;
+      }),
+    [nodes, collapseNode, openFocus, onNavigateEntity, enterSpotlight, toggleZone],
   );
 
   // 抽屉里展示的实体(优先 selectedNode,fallback 到 focusNode)。这样单击非焦点
@@ -467,9 +523,10 @@ function GraphViewInner({
           <Controls className="bg-surface-raised border-border" />
           <MiniMap
             nodeColor={(n) => {
-              if (n.type === "laneBackground") return "rgba(255, 255, 255, 0.04)";
-              // ego 节点按语义轴上色 —— 否则暗色 minimap 上全是暗灰方块,等于隐形。
+              if (n.type === "laneBackground" || n.type === "territoryZone") return "rgba(255, 255, 255, 0.04)";
+              // ego / territoryChip 节点按语义轴上色 —— 否则暗色 minimap 上全是暗灰方块,等于隐形。
               if (n.type === "ego") return MINIMAP_AXIS[(n.data as any)?.entity as string] ?? "var(--color-axis-execution)";
+              if (n.type === "territoryChip") return territoryChipColor((n.data as any)?.entity as string) ?? "var(--color-border-strong)";
               if (n.type === "decisionFocus" || n.type === "decision") return "var(--color-accent)";
               if (n.type === "fact") return "var(--color-stale)";
               return "var(--color-border-strong)";
@@ -477,6 +534,12 @@ function GraphViewInner({
             nodeStrokeColor="var(--color-border-strong)"
             maskColor="rgba(0, 0, 0, 0.5)"
             className="bg-surface border border-border rounded overflow-hidden"
+          />
+          <TerritoryModeBar
+            viewMode={viewMode}
+            skel={skel}
+            onModeChange={setViewMode}
+            onSkelChange={setSkel}
           />
           <Panel position="top-left">
             <GraphFilterPanel

--- a/packages/gui/test/territory-layout.vitest.ts
+++ b/packages/gui/test/territory-layout.vitest.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect } from "vitest";
+import { layoutTerritory } from "../src/renderer/graph/territoryLayout";
+import type { TaskRow, DecisionRow, RelationEdge } from "../src/renderer/model/types";
+import type { GraphFilterInput } from "../src/renderer/graph/graphLayoutTypes";
+
+// ── 精简工厂 ──
+const task = (id: string, extra: Partial<TaskRow> = {}): TaskRow =>
+  ({
+    taskId: id,
+    title: `T ${id}`,
+    coordinationStatus: "active",
+    module: "m",
+    rootTaskId: id,
+    rootTitle: `Root ${id}`,
+    lastKnownAt: new Date().toISOString(),
+    ...extra,
+  }) as unknown as TaskRow;
+
+const decision = (id: string, extra: Partial<DecisionRow> = {}): DecisionRow =>
+  ({
+    decisionId: id,
+    title: `D ${id}`,
+    state: "active",
+    question: "q",
+    chosen: [],
+    rejected: [],
+    claims: [],
+    ...extra,
+  }) as unknown as DecisionRow;
+
+const rel = (from: string, to: string, kind: RelationEdge["kind"]): RelationEdge =>
+  ({ from, to, kind, provenance: "local-document" }) as RelationEdge;
+
+const ALL_FILTERS: GraphFilterInput = {
+  modules: new Set<string>(),
+  types: new Set(["task", "decision", "fact"]),
+  axes: { authority: true, evidence: true, execution: true, assoc: true },
+};
+
+const filters = (over: Partial<GraphFilterInput> = {}): GraphFilterInput => ({
+  ...ALL_FILTERS,
+  ...over,
+});
+
+// ── 辅助:节点重叠检测 ──
+function boxesOverlap(a: any, b: any): boolean {
+  const aw = a.width ?? a.style?.width ?? 0;
+  const ah = a.height ?? a.style?.height ?? 0;
+  const bw = b.width ?? b.style?.width ?? 0;
+  const bh = b.height ?? b.style?.height ?? 0;
+  return (
+    a.position.x < b.position.x + bw &&
+    b.position.x < a.position.x + aw &&
+    a.position.y < b.position.y + bh &&
+    b.position.y < a.position.y + ah
+  );
+}
+
+// section 节点是宽薄标签,不参与重叠检测(它们故意横跨整行)
+// chip 故意叠在 zone 上面(zone 是背景),所以只检测:
+//   zone-vs-zone(不同 zone 不应重叠)
+//   chip-vs-chip(不同 chip 不应重叠)
+function zoneNodes(ns: any[]): any[] {
+  return ns.filter((n) => n.type === "territoryZone" && n.data?.variant === "zone");
+}
+function chipNodes(ns: any[]): any[] {
+  return ns.filter((n) => n.type === "territoryChip");
+}
+/** zone-vs-zone + chip-vs-chip 零重叠(不检 zone-vs-chip:后者故意叠在前者上)。 */
+function expectNoOverlap(ns: any[]) {
+  const zones = zoneNodes(ns);
+  const chips = chipNodes(ns);
+  for (let i = 0; i < zones.length; i++) {
+    for (let j = i + 1; j < zones.length; j++) {
+      expect(boxesOverlap(zones[i], zones[j])).toBe(false);
+    }
+  }
+  for (let i = 0; i < chips.length; i++) {
+    for (let j = i + 1; j < chips.length; j++) {
+      expect(boxesOverlap(chips[i], chips[j])).toBe(false);
+    }
+  }
+}
+
+// ══ TASK 领地 ══
+describe("layoutTerritory · task skel", () => {
+  it("milestone(root+子任务)和独立任务按模块分区", () => {
+    const tasks = [
+      // milestone A:root_A + 2 子任务
+      task("root_A", { rootTaskId: "root_A", rootTitle: "Milestone A", title: "Milestone A" }),
+      task("A1", { parentTaskId: "root_A", rootTaskId: "root_A", rootTitle: "Milestone A" }),
+      task("A2", { parentTaskId: "root_A", rootTaskId: "root_A", rootTitle: "Milestone A" }),
+      // 独立任务(无 parent, 无子)
+      task("solo1", { module: "gui", rootTaskId: "solo1", rootTitle: "solo1" }),
+      task("solo2", { module: "gui", rootTaskId: "solo2", rootTitle: "solo2" }),
+      task("solo3", { module: "kernel", rootTaskId: "solo3", rootTitle: "solo3" }),
+    ];
+    const out = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ modules: new Set(["m", "gui", "kernel"]) }),
+      expandedZones: new Set(),
+    });
+    const zoneTitles = out.nodes
+      .filter((n) => n.type === "territoryZone" && n.data?.variant === "zone")
+      .map((n) => n.data.title);
+    expect(zoneTitles).toContain("Milestone A");
+    expect(zoneTitles.some((t) => t === "gui")).toBe(true);
+    expect(zoneTitles.some((t) => t === "kernel")).toBe(true);
+  });
+
+  it("确定性布局零重叠(zone + chip)", () => {
+    const tasks = [
+      task("root_A", { rootTaskId: "root_A", rootTitle: "A" }),
+      task("A1", { parentTaskId: "root_A", rootTaskId: "root_A" }),
+      task("A2", { parentTaskId: "root_A", rootTaskId: "root_A" }),
+      task("root_B", { rootTaskId: "root_B", rootTitle: "B" }),
+      task("B1", { parentTaskId: "root_B", rootTaskId: "root_B" }),
+    ];
+    for (let seed = 0; seed < 3; seed++) {
+      const out = layoutTerritory({
+        skel: "task",
+        tasks,
+        decisions: [],
+        facts: [],
+        relations: [],
+        filters: filters({ modules: new Set(["m"]) }),
+        expandedZones: new Set(),
+      });
+      expectNoOverlap(out.nodes);
+    }
+  });
+
+  it("折叠态默认只显前 8 个 hot;展开后显全部", () => {
+    const children = Array.from({ length: 15 }, (_, i) =>
+      task(`c${i}`, {
+        parentTaskId: "root_big",
+        rootTaskId: "root_big",
+        coordinationStatus: i < 3 ? "active" : "done",
+      }),
+    );
+    const tasks = [task("root_big", { rootTaskId: "root_big", rootTitle: "Big" }), ...children];
+
+    const folded = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ modules: new Set(["m"]) }),
+      expandedZones: new Set(),
+    });
+    const foldedChips = folded.nodes.filter((n) => n.type === "territoryChip" && n.data?.entity === "task");
+    // 折叠态:8 chip + 1 fold 提示
+    expect(foldedChips.length).toBe(8);
+    expect(folded.nodes.some((n) => n.type === "territoryChip" && n.data?.entity === "fold")).toBe(true);
+
+    const expanded = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ modules: new Set(["m"]) }),
+      expandedZones: new Set(["root:root_big"]),
+    });
+    const expandedChips = expanded.nodes.filter((n) => n.type === "territoryChip" && n.data?.entity === "task");
+    // 展开态:全部(1 root + 15 children = 16)
+    expect(expandedChips.length).toBe(16);
+    expect(expanded.nodes.some((n) => n.type === "territoryChip" && n.data?.entity === "fold")).toBe(false);
+  });
+
+  it("状态比例条数据正确(每个状态的计数)", () => {
+    const tasks = [
+      task("root", { rootTaskId: "root", rootTitle: "R" }),
+      task("c1", { parentTaskId: "root", rootTaskId: "root", coordinationStatus: "active" }),
+      task("c2", { parentTaskId: "root", rootTaskId: "root", coordinationStatus: "done" }),
+      task("c3", { parentTaskId: "root", rootTaskId: "root", coordinationStatus: "blocked" }),
+    ];
+    const out = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ modules: new Set(["m"]) }),
+      expandedZones: new Set(),
+    });
+    const zone = out.nodes.find((n) => n.type === "territoryZone" && n.data?.variant === "zone");
+    expect(zone.data.statusCounts).toMatchObject({ active: 2, done: 1, blocked: 1 });
+    expect(zone.data.total).toBe(4);
+    expect(zone.data.isAllDone).toBe(false);
+  });
+
+  it("全部 done → isAllDone=true", () => {
+    const tasks = [
+      task("root", { rootTaskId: "root", rootTitle: "R", coordinationStatus: "done" }),
+      task("c1", { parentTaskId: "root", rootTaskId: "root", coordinationStatus: "done" }),
+    ];
+    const out = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ modules: new Set(["m"]) }),
+      expandedZones: new Set(),
+    });
+    const zone = out.nodes.find((n) => n.type === "territoryZone" && n.data?.variant === "zone");
+    expect(zone.data.isAllDone).toBe(true);
+  });
+
+  it("所有节点都有顶层 width/height(MiniMap 必须)", () => {
+    const tasks = [
+      task("root", { rootTaskId: "root", rootTitle: "R" }),
+      task("c1", { parentTaskId: "root", rootTaskId: "root" }),
+    ];
+    const out = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ modules: new Set(["m"]) }),
+      expandedZones: new Set(),
+    });
+    for (const n of out.nodes) {
+      expect(n.width).toBeTruthy();
+      expect(n.height).toBeTruthy();
+    }
+  });
+});
+
+// ══ DECISION 领地 ══
+describe("layoutTerritory · decision skel", () => {
+  it("supersede/refine 链 → 同一家族", () => {
+    const decisions = [
+      decision("dec_A", { title: "Original" }),
+      decision("dec_B", { title: "Refined", state: "proposed" }),
+    ];
+    const relations = [
+      rel("decision/dec_B", "decision/dec_A", "refines"),
+    ];
+    const out = layoutTerritory({
+      skel: "decision",
+      tasks: [],
+      decisions,
+      facts: [],
+      relations,
+      filters: filters(),
+      expandedZones: new Set(),
+    });
+    // 两个 decision 同一家族 → 只有一个 head chip
+    const chips = out.nodes.filter((n) => n.type === "territoryChip" && n.data?.entity === "decision");
+    expect(chips.length).toBe(1);
+    // head = 非被替代 + 最高分;dec_B 是 proposed(分更高)+ 没被 supersede → head
+    expect(chips[0].data.label).toBe("Refined");
+    expect(chips[0].data.historyCount).toBe(1); // 1 历史版本(另一个成员)
+  });
+
+  it("derives → task → rootTaskId = 落地 milestone 派生", () => {
+    const tasks = [
+      task("root_M", { rootTaskId: "root_M", rootTitle: "Milestone M" }),
+      task("M1", { parentTaskId: "root_M", rootTaskId: "root_M" }),
+    ];
+    const decisions = [decision("dec_L", { title: "Landed Decision" })];
+    const relations = [rel("decision/dec_L", "task/M1", "derives")];
+    const out = layoutTerritory({
+      skel: "decision",
+      tasks,
+      decisions,
+      facts: [],
+      relations,
+      filters: filters(),
+      expandedZones: new Set(),
+    });
+    const sections = out.nodes.filter((n) => n.type === "territoryZone" && n.data?.variant === "section");
+    expect(sections.some((s) => s.data.title.includes("Milestone M"))).toBe(true);
+  });
+
+  it("无 derives 的决策 → 未落地示警区", () => {
+    const decisions = [
+      decision("dec_L", { title: "Landed" }),
+      decision("dec_U", { title: "Unlanded", state: "proposed" }),
+    ];
+    const tasks = [task("root_M", { rootTaskId: "root_M", rootTitle: "M" })];
+    const relations = [rel("decision/dec_L", "task/root_M", "derives")];
+    const out = layoutTerritory({
+      skel: "decision",
+      tasks,
+      decisions,
+      facts: [],
+      relations,
+      filters: filters(),
+      expandedZones: new Set(),
+    });
+    const sections = out.nodes.filter((n) => n.type === "territoryZone" && n.data?.variant === "section");
+    expect(sections.some((s) => s.data.title.includes("⚠ 未落地"))).toBe(true);
+  });
+
+  it("coverage 灯数据正确(有 evidence = covered)", () => {
+    const decisions = [
+      decision("dec_C", {
+        title: "With Claims",
+        claims: [{ id: "CH1", text: "claim1" }, { id: "CH2", text: "claim2" }] as any,
+        chosen: [{ id: "CH1", text: "c1", evidence: ["fact/task_x/F1"], whyNot: undefined }] as any,
+      }),
+    ];
+    const out = layoutTerritory({
+      skel: "decision",
+      tasks: [],
+      decisions,
+      facts: [],
+      relations: [],
+      filters: filters(),
+      expandedZones: new Set(),
+    });
+    const zone = out.nodes.find((n) => n.type === "territoryZone" && n.data?.variant === "zone");
+    // CH1 有 evidence → covered;CH2 无 → not covered
+    expect(zone.data.coverageSummary.total).toBe(2);
+    expect(zone.data.coverageSummary.covered).toBe(1);
+  });
+
+  it("decision 领地零重叠", () => {
+    const decisions = [
+      decision("dec1", { title: "D1" }),
+      decision("dec2", { title: "D2" }),
+      decision("dec3", { title: "D3" }),
+      decision("dec4", { title: "D4" }),
+    ];
+    const tasks = [task("root_M", { rootTaskId: "root_M", rootTitle: "M" })];
+    const relations = [
+      rel("decision/dec1", "task/root_M", "derives"),
+      rel("decision/dec2", "task/root_M", "derives"),
+      // dec3/dec4 未落地
+    ];
+    const out = layoutTerritory({
+      skel: "decision",
+      tasks,
+      decisions,
+      facts: [],
+      relations,
+      filters: filters(),
+      expandedZones: new Set(),
+    });
+    const ns = out.nodes;
+    expectNoOverlap(ns);
+  });
+});
+
+// ═─ 横切 ─═
+describe("layoutTerritory · 横切", () => {
+  it("类型过滤:关掉 task 后 task 领地空", () => {
+    const tasks = [task("t1", { rootTaskId: "t1" })];
+    const out = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ types: new Set(["decision", "fact"]) }),
+      expandedZones: new Set(),
+    });
+    expect(out.nodes.length).toBe(0);
+  });
+
+  it("无边(L1 是分区形状,边在 L2 才画)", () => {
+    const tasks = [
+      task("root", { rootTaskId: "root", rootTitle: "R" }),
+      task("c1", { parentTaskId: "root", rootTaskId: "root" }),
+    ];
+    const out = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ modules: new Set(["m"]) }),
+      expandedZones: new Set(),
+    });
+    expect(out.edges.length).toBe(0);
+  });
+
+  it("bounds 非零(有内容时)", () => {
+    const tasks = [
+      task("root", { rootTaskId: "root", rootTitle: "R" }),
+      task("c1", { parentTaskId: "root", rootTaskId: "root" }),
+    ];
+    const out = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ modules: new Set(["m"]) }),
+      expandedZones: new Set(),
+    });
+    expect(out.bounds.width).toBeGreaterThan(0);
+    expect(out.bounds.height).toBeGreaterThan(0);
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -6,5 +6,6 @@ export const guiVitestManifest = [
   "packages/gui/test/graphLayout.vitest.ts",
   "packages/gui/test/genealogy-timeline.vitest.ts",
   "packages/gui/test/graphNavigation.vitest.ts",
-  "packages/gui/test/canvas-ego-layout.vitest.ts"
+  "packages/gui/test/canvas-ego-layout.vitest.ts",
+  "packages/gui/test/territory-layout.vitest.ts"
 ];


### PR DESCRIPTION
# English

## Summary

Adds L1, the territory overview — the top layer of the graph's three-level information architecture. Instead of dropping you into a node soup, the graph now opens on a grid of **territories**: one block per milestone (tasks grouped by their root task) or per decision family (grouped by the supersede/refine chain), each with a health bar, its top items, and a fold for the rest. An **unlanded warning zone** surfaces decisions that were made but never derived any work. Clicking any chip drops into the L2 spotlight canvas focused on that entity.

This completes `dec_01KXA7811SVVT8P66HNDFZQ7DF`'s three-layer IA (L3 drawer fusion and L2 infinite canvas landed in #685).

## What Changed

- `graph/territoryPartition.ts` — partitions the ledger into zones along two skeleton axes: tasks by `rootTaskId` (milestone), decisions by supersede/refine family plus `derives` landing. Standalone tasks aggregate by module; decisions with no landing go to the unlanded zone.
- `graph/territoryLayout.ts` — deterministic zone grid layout, mirroring the pure-function shape of `canvasEgoLayout.ts` from L2.
- `graph/nodes/TerritoryZoneNode.tsx` / `TerritoryChipNode.tsx` — zone card (title, status health bar, item list, fold) and item chip.
- `graph/useTerritoryView.ts` — view-mode state (territory ↔ spotlight), skeleton axis, zone fold state.
- `components/TerritoryModeBar.tsx` — mode + skeleton switcher.
- `graph/graphLayout.ts` / `graphLayoutTypes.ts` / `views/GraphView.tsx` — territory branch in the layout dispatcher, wiring, and chip-click → `openFocus` into L2.
- `components/GraphFilterPanel.tsx` — **the filter panel is now collapsible and starts collapsed.** It is an overlay pinned to the top-left of the canvas and was permanently expanded: in spotlight mode it sat on the focus card, and in the new territory mode it buried the first zone entirely. It now collapses to a pill that shows how many filters are narrowing the view.

## Task And Scope

- Harness task: `task_01KXBBF233BQ0SRCD571BAMZMP` (GUI IA — three-layer, packages/gui)
- Branch: `feat/gui-ia-l1-territory`
- Public scope: `packages/gui` renderer only, plus one line in `tools/gui-test-manifest.mjs` to register the new test suite
- Private planning/evidence updated: yes
- Out of scope: decision coverage lamps on cards (deferred); retiring the unused `simpleEgo`/`threeLane` fallbacks

## Version Impact

- Version: no version change because this is renderer-only work with no CLI surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KXA7811SVVT8P66HNDFZQ7DF` (three-layer IA), `dec_01KXBGJQFQARSZHHQW1WADFDNC` (L2 canvas model)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `486c2fc3ee0dc3618388bc1ba6ffdeb996bb91e0`
- Branch merge-base with `origin/main`: same
- Last `git fetch origin` time: 2026-07-13, immediately before opening this PR
- Sync method: rebase (branch is 0 behind)
- Public diff command: `git diff origin/main...feat/gui-ia-l1-territory`
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm check:local` — passed, fast tier, 66s
- [x] `node tools/run-manifest-gates.mjs --workflow-job gui-build` — passed (9 test files / 94 tests, plus vite build)
- [x] 14 new layout tests (zone partitioning, zero overlap, fold, coverage, unlanded detection)
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR

Semantic acceptance was done against a **high-density fixture** (183 tasks across 8 milestones with deliberately uneven fan-out of 3/12/24/45/8/31/5/17 children, 30 orphan tasks, 40 decisions in 8 supersede families, 12 unlanded decisions), because scale was the stated residual risk. Result: 11 zones / 73 chips rendered with zero console errors, the 45-child milestone folds cleanly rather than exploding, and the unlanded zone correctly collects the 12 landing-less decisions. The dev fixture was removed before commit.

One note for reviewers: running the `gui-build` gate (which runs `vite build`) writes `packages/gui/dist` and then poisons a subsequent `tsc -b` with TS6305 stale-artifact errors. Run `pnpm check:local` and the gui-build gate in separate passes, or delete `packages/gui/dist` and `*.tsbuildinfo` between them. CI runs them as separate jobs so this does not affect CI.

## Review Evidence

- Self-review: yes — gates re-run independently rather than taken from the implementation report; the density fixture was built specifically to attack the stated residual risk, and a negative control was used to confirm the TS6305 failure was a build-cache artifact and not a code defect
- Reviewer subagent: not run
- Human review: pending
- Blocking findings: none

## Residual Risk

- Zone titles truncate aggressively; with many similarly-named milestones the grid can read as repetitive. Not a defect, but a legibility limit worth watching on real data.
- `territoryPartition` reads `rootTaskId` and falls back to `taskId`. That field is filled by `task-adapter.ts:computeRootTaskId` in the real data path, so it is present in the app — but any consumer that bypasses the adapter will see every milestone collapse into the "standalone tasks" bucket.
- Territory mode renders zones with no edges between them. Cross-territory relations are only visible after dropping into spotlight.

## References

- Task: `task_01KXBBF233BQ0SRCD571BAMZMP`
- Evidence: `dec_01KXA7811SVVT8P66HNDFZQ7DF`, `dec_01KXBGJQFQARSZHHQW1WADFDNC`
- Review: pending

---

# 中文

## 概要

补上 L1 领地总览——关系图三层信息架构的最上面一层。图不再一上来就把你扔进节点海，而是先给一屏**领地**：每个 milestone 一块（task 按 rootTask 归组），或每个决策家族一块（按 supersede/refine 链归组），每块带健康条、头部条目和"还有 N 项 — 展开"的折叠。一个**未落地示警区**专门收那些定了却没派生出任何工作的决策。点任意 chip 就落进 L2 聚光灯画布，并以它为焦点。

至此 `dec_01KXA7811SVVT8P66HNDFZQ7DF` 的三层 IA 齐了（L3 抽屉融合与 L2 无限画布已随 #685 合入）。

## 改动内容

- `graph/territoryPartition.ts` —— 沿两条骨架轴把台账分区：task 按 `rootTaskId`（milestone），decision 按 supersede/refine 家族 + `derives` 落地。独立任务按模块聚合；没有落地的决策进未落地区。
- `graph/territoryLayout.ts` —— 确定性的 zone 网格布局，形状与 L2 的 `canvasEgoLayout.ts` 同构（纯函数布局器）。
- `graph/nodes/TerritoryZoneNode.tsx` / `TerritoryChipNode.tsx` —— 领地卡片（标题、状态健康条、条目列表、折叠）与条目 chip。
- `graph/useTerritoryView.ts` —— 视图模式状态机（领地 ↔ 聚光灯）、骨架轴、zone 折叠态。
- `components/TerritoryModeBar.tsx` —— 模式 + 骨架轴切换条。
- `graph/graphLayout.ts` / `graphLayoutTypes.ts` / `views/GraphView.tsx` —— 布局分发器加 territory 分支、接线、chip 单击 → `openFocus` 进 L2。
- `components/GraphFilterPanel.tsx` —— **筛选面板改成可折叠，且默认收起。** 它是钉在画布左上角的浮层且一直常驻展开：聚光灯模式下压在焦点卡片上，新的领地模式下直接把第一个领地整块埋掉。现在收起成一颗 pill，上面标出"已收窄"的筛选数。

## 任务与范围

- Harness 任务：`task_01KXBBF233BQ0SRCD571BAMZMP`（GUI IA 三层，packages/gui）
- 分支：`feat/gui-ia-l1-territory`
- 公开范围：只动 `packages/gui` 渲染进程，外加 `tools/gui-test-manifest.mjs` 一行（登记新测试套件）
- 私有计划 / 证据是否已更新：yes
- 范围外：卡片上的决策 coverage 灯（推迟）；退役已走不到的 `simpleEgo`/`threeLane` fallback

## 版本影响

- 版本：不改版本，原因是只动渲染进程，不碰 CLI 面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`dec_01KXA7811SVVT8P66HNDFZQ7DF`（三层 IA）、`dec_01KXBGJQFQARSZHHQW1WADFDNC`（L2 画布模型）
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`486c2fc3ee0dc3618388bc1ba6ffdeb996bb91e0`
- merge-base：同上
- 最近一次 `git fetch origin` 时间：2026-07-13，开 PR 前刚拉
- 同步方式：rebase（落后 0）
- 公开 diff 命令：`git diff origin/main...feat/gui-ia-l1-territory`
- [x] `pnpm typecheck` —— exit 0
- [x] `pnpm check:local` —— fast 档全绿，66 秒
- [x] `node tools/run-manifest-gates.mjs --workflow-job gui-build` —— 全绿（9 文件 / 94 测试 + vite build）
- [x] 14 个新布局单测（zone 分区、零重叠、折叠、coverage、未落地识别）
- [ ] GitHub Actions `rewrite-ci` passed —— 待本 PR 的 CI

语义验收是拿一个**高密度 fixture** 做的（8 个 milestone 共 183 个 task，子任务数刻意不均：3/12/24/45/8/31/5/17；30 个孤儿任务；40 个决策分 8 条 supersede 家族链；12 个未落地决策）——因为"真实规模下会不会糊"正是实现方自己写下的最大残余风险。结果：**11 个 zone / 73 个 chip 渲染，零控制台错误**，45 个子任务的 milestone 干净折叠而不是撑爆，未落地区正确收走了那 12 条无落地决策。dev fixture 已在 commit 前删除。

给 reviewer 的一条提醒：跑 `gui-build` 那道门（内含 `vite build`）会写出 `packages/gui/dist`，随后再跑 `tsc -b` 就会被 TS6305 陈旧产物报错毒化。要么把 `check:local` 和 gui-build 分两轮跑，要么中间删掉 `packages/gui/dist` 与 `*.tsbuildinfo`。CI 里这两道门是独立 job，不受影响。

## Review Evidence

- 自审：yes —— 三道门我自己重跑，不采信实现方报告里的数字；高密度 fixture 是专门冲着"最大残余风险"造的；TS6305 那次红用阴性对照证明是构建缓存产物而非代码缺陷
- Reviewer subagent：未跑
- 人工复核：待办
- 阻塞发现：无

## Residual Risk

- 领地标题截断较狠，milestone 命名相近时整屏会显得重复。不是缺陷，但真实数据上值得盯的可读性上限。
- `territoryPartition` 读 `rootTaskId`，缺失时回退到 `taskId`。真实数据路径里这个字段由 `task-adapter.ts:computeRootTaskId` 填充，所以应用内没问题——但任何绕过 adapter 的消费方会看到所有 milestone 塌进"独立任务"桶。
- 领地模式下 zone 之间不画边。跨领地的关系只有落进聚光灯才看得到。

## References

- 任务：`task_01KXBBF233BQ0SRCD571BAMZMP`
- 证据：`dec_01KXA7811SVVT8P66HNDFZQ7DF`、`dec_01KXBGJQFQARSZHHQW1WADFDNC`
- 复核：待办
