### PR TITLE
feat(application): 人可以批自己提的决策(agent 仍不能自批)

### DIFF
--- a/packages/application/src/decision-write-service.ts
+++ b/packages/application/src/decision-write-service.ts
@@ -391,9 +391,16 @@ function assertIndependentJudgmentActor(options: DecisionWriteServiceOptions, de
       event.kind === "decision_propose" &&
       (event.entityId === decisionId || event.entityId === `decision/${decisionId}`)
     );
+    // 溯源仍然 fail-closed,对谁都一样:判定前必须能验到那条不可变的 propose 事件。
+    // 下面豁免的只是「判定者与提议者不得同一」,不是「提议事件必须存在」。
     if (!propose) return rejection(decisionId, "decision judgment requires an immutable decision_propose attribution event");
+    // 判定动作没有 executor = 一个人在直接操作 → 分离校验整条豁免:人可以批自己提的,
+    // 也可以批别人提的(dec_01KXCHW9MFV8E3QGZJJW91YNDS)。分离不变量承重的目的是阻止
+    // **agent** 给自己签字 —— 那是问责层的核心承诺 —— 不是阻止人给自己签字。单人
+    // 操作者是绝大多数决策的唯一提议者兼唯一权威,一律分离等于把他锁在自己的台账外面。
+    if (!currentActor.executor) return null;
     return sameActorAxes(propose.actor, currentActor)
-      ? rejection(decisionId, "decision judgment actor must differ from the decision_propose actor")
+      ? rejection(decisionId, "an agent may not judge the decision it proposed; a human must sign off")
       : null;
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);

--- a/packages/application/test/decision-write-service.test.ts
+++ b/packages/application/test/decision-write-service.test.ts
@@ -176,24 +176,65 @@ test("decision accept emits an append-only body mutation for judgment-only ratio
   assert.match(payload.writeMode?.appendBody ?? "", /CEO accepted this as a judgment-only policy choice/u);
 });
 
-test("decision write service rejects self-judgment from the same full ActorAxes and unsupported transitions", () => {
+test("an agent may not judge the decision it proposed, and terminal transitions stay rejected", () => {
   const service = makeRawDecisionWriteService({
     coordinator: fakeCoordinator([]),
-    attribution: proposerAttribution,
+    attribution: proposerAttribution, // executor = agent:claude — the same agent that proposed
     readAttributionEvents: () => [proposeAttributionEvent]
   });
   const proposed = decisionPackage({ state: "proposed" });
   const rejected = decisionPackage({ state: "rejected" });
 
-  const selfArbiter = Effect.runSyncExit(service.accept({ current: proposed, judgmentOnlyRationale: "Self judgment must still be rejected." }));
+  const selfArbiter = Effect.runSyncExit(service.accept({ current: proposed, judgmentOnlyRationale: "Agent self judgment must still be rejected." }));
   const terminalTransition = Effect.runSyncExit(service.accept({
     current: rejected
   }));
 
   assert.equal(selfArbiter._tag, "Failure");
-  assert.match(failureReason(selfArbiter.cause), /must differ from the decision_propose actor/u);
+  assert.match(failureReason(selfArbiter.cause), /an agent may not judge the decision it proposed/u);
   assert.equal(terminalTransition._tag, "Failure");
   assert.match(failureReason(terminalTransition.cause), /terminal_state/u);
+});
+
+// dec_01KXCHW9MFV8E3QGZJJW91YNDS:分离不变量防的是 agent 自我签字,不是人自我签字。
+test("a human judging directly may accept the decision they proposed themselves", () => {
+  const humanProposeEvent = {
+    ...proposeAttributionEvent,
+    ...humanDirectAttribution // propose 也是这个人直接做的,没有 executor
+  } as AttributionEvent;
+  const enqueued: WriteOp[] = [];
+  const service = makeRawDecisionWriteService({
+    coordinator: fakeCoordinator(enqueued),
+    attribution: humanDirectAttribution, // 判定者:同一个人,直接操作,无 executor
+    readAttributionEvents: () => [humanProposeEvent]
+  });
+
+  const result = Effect.runSync(service.accept({
+    current: decisionPackage({ state: "proposed" }),
+    judgmentOnlyRationale: "A solo operator is both the only proposer and the only authority.",
+    opIdPrefix: "accept"
+  }));
+
+  assert.deepEqual(result, { decisionId: "dec_TEST", state: "active" });
+  assert.equal(enqueued.length, 1);
+});
+
+test("a human judging directly may also accept a decision an agent proposed", () => {
+  const enqueued: WriteOp[] = [];
+  const service = makeRawDecisionWriteService({
+    coordinator: fakeCoordinator(enqueued),
+    attribution: humanDirectAttribution, // 人直接判定
+    readAttributionEvents: () => [proposeAttributionEvent] // agent:claude 提的
+  });
+
+  const result = Effect.runSync(service.accept({
+    current: decisionPackage({ state: "proposed" }),
+    judgmentOnlyRationale: "Human signoff on an agent-proposed decision.",
+    opIdPrefix: "accept"
+  }));
+
+  assert.deepEqual(result, { decisionId: "dec_TEST", state: "active" });
+  assert.equal(enqueued.length, 1);
 });
 
 test("decision judgment fails closed when the immutable propose attribution event is missing", () => {
@@ -474,6 +515,10 @@ const judgmentAttribution = {
   principalSource: { kind: "migration", evidenceRef: "test/judgment" },
   executorSource: "none"
 } as const;
+
+// 人在直接操作:principal 是人,executor 为空(没有 agent 在代跑)。判定动作长这样时
+// 分离校验整条豁免(dec_01KXCHW9MFV8E3QGZJJW91YNDS)。
+const humanDirectAttribution = judgmentAttribution;
 
 const proposeAttributionEvent = {
   schema: "attribution-event/v1",


### PR DESCRIPTION
# English

## Summary

A solo operator could not approve their own decisions. The judgment separation rule rejected any accept/reject whose actor matched the `decision_propose` actor on both attribution axes — so every decision Zeyu raised himself was permanently unapprovable, locking him out of his own ledger.

The rule is load-bearing for one thing: stopping an **agent** from signing off its own work. That is the core promise of the accountability layer. It was never meant to stop a human from signing off their own work. So the exemption now hangs on the **executor axis** rather than on actor equality.

## What Changed

`assertIndependentJudgmentActor` in `packages/application/src/decision-write-service.ts`:

- A judgment with **no executor** is a human acting directly, and is always allowed — they may accept a decision they proposed themselves, and they may accept one anyone else proposed.
- An **agent-executed** judgment must still differ from the propose actor. Rejection message is now explicit about why: `an agent may not judge the decision it proposed; a human must sign off`.
- **Provenance stays fail-closed for everyone.** The immutable `decision_propose` attribution event is still required before any judgment, human or not — the exemption relaxes only "judge must differ from proposer", never "the propose event must exist". (The first draft of this patch put the exemption too early and skipped that check; the existing fail-closed test caught it.)

Three tests now cover the matrix: agent self-judgment rejected, human judging their own proposal accepted, human judging an agent's proposal accepted.

## Task And Scope

- Harness task: `task_01KXARDPXSSHMH3QPGPD26RA5P` (GUI decision write path — this is its unblocking prerequisite)
- Branch: `fix/decision-human-self-approval`
- Public scope: `packages/application` only (one function plus its tests)
- Private planning/evidence updated: yes
- Out of scope: the typed daemon/application decision write boundary the GUI still needs

## Version Impact

- Version: no version change because this is a behaviour fix inside an existing service, with no CLI surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KXCHW9MFV8E3QGZJJW91YNDS` (accepted 2026-07-13) — "a human may sign off on anything including their own proposal; an agent may not sign off its own"
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: the merge of #686 (ADR-0028 P7), which introduced the `sameActorAxes` rule this PR amends
- Sync method: branched from `origin/main`
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm check:local` — passed, fast tier, 69s
- [x] `pnpm test` — **1447 passed, 0 failed** (full node suite; the invariant is reachable from CLI and application paths, so the whole suite was run rather than one file)
- [x] **Negative control**: with the source change reverted and the new tests kept, 2 tests fail (17 pass / 2 fail). With the change, 19/19 pass. The tests therefore prove the behaviour rather than merely accompanying it.
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR

## Review Evidence

- Self-review: yes. The first version of this patch silently disabled the fail-closed propose-event check for human judgments — a real regression, caught by the pre-existing test `decision judgment fails closed when the immutable propose attribution event is missing`, and fixed by moving the exemption after the provenance lookup rather than before it.
- Reviewer subagent: not run
- Human review: pending
- Blocking findings: none

## Residual Risk

- **Agent A arbitrating a decision agent B proposed is deliberately allowed, not an oversight.** It is groundwork for fully-managed agent-to-agent operation; narrowing the rule to "arbiter must be human" was considered and rejected (`dec_01KXCHW9MFV8E3QGZJJW91YNDS` CH2). The one thing that is forbidden is an agent closing its own loop — the same executor both proposing and judging — which is exactly what the invariant catches.
- A human judging directly is now unconstrained by construction. That is the intent, and the ledger still records who did it, but there is no longer any mechanical second-pair-of-eyes requirement for human-only decisions.

## References

- Task: `task_01KXARDPXSSHMH3QPGPD26RA5P`
- Evidence: `dec_01KXCHW9MFV8E3QGZJJW91YNDS`
- Review: pending

---

# 中文

## 概要

单人操作者批不了自己的决策。判定分离规则会拒绝任何"判定者与 `decision_propose` 的 actor 在两条归属轴上完全相同"的 accept/reject——于是泽宇自己提的每一条决策都永远批不了，被锁在自己的台账外面。

这条规则真正承重的只有一件事：**阻止 agent 给自己的活签字**。那是问责层的核心承诺。它从来不是为了阻止人给自己签字。所以豁免条件改挂在 **executor 轴**上，而不是挂在 actor 相等性上。

## 改动内容

`packages/application/src/decision-write-service.ts` 的 `assertIndependentJudgmentActor`：

- 判定动作**没有 executor** = 一个人在直接操作 → 无条件放行：他可以批自己提的，也可以批任何别人提的。
- **由 agent 执行**的判定动作仍必须与提议者不同。拒绝理由现在明说为什么：`an agent may not judge the decision it proposed; a human must sign off`。
- **溯源对谁都仍然 fail-closed。** 判定之前依然必须能验到那条不可变的 `decision_propose` 归属事件——豁免放宽的只是"判定者不得与提议者同一"，绝不是"提议事件必须存在"。（本补丁第一版把豁免放得太早，连这条校验一起绕过了；是既有的 fail-closed 测试把它抓出来的。）

三个测试覆盖完整矩阵：agent 自批被拒、人批自己提的被放行、人批 agent 提的被放行。

## 任务与范围

- Harness 任务：`task_01KXARDPXSSHMH3QPGPD26RA5P`（GUI 决策写路径——本 PR 是它的解锁前置）
- 分支：`fix/decision-human-self-approval`
- 公开范围：只动 `packages/application`（一个函数 + 它的测试）
- 私有计划 / 证据是否已更新：yes
- 范围外：GUI 仍需要的 typed daemon/application decision write boundary

## 版本影响

- 版本：不改版本，原因是这是既有服务内部的行为修正，不改 CLI 面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`dec_01KXCHW9MFV8E3QGZJJW91YNDS`（2026-07-13 accepted）——"人可以批任何东西，包括自己提的；agent 不能批自己提的"
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- 后续治理任务：不适用

## 验证

- `origin/main` 基准：#686（ADR-0028 P7）的合入点，正是它引入了本 PR 要修订的 `sameActorAxes` 规则
- 同步方式：从 `origin/main` 开分支
- [x] `pnpm typecheck` —— exit 0
- [x] `pnpm check:local` —— fast 档全绿，69 秒
- [x] `pnpm test` —— **1447 通过，0 失败**（全量 node 测试；这条不变量在 CLI 与 application 路径上都够得着，所以跑全量而不是单文件）
- [x] **阴性对照**：把源码改动回滚、只留新测试 → 2 个测试红（17 过 / 2 红）；带上改动 → 19/19 全绿。也就是说这些测试是在**证明**行为，而不只是陪跑。
- [ ] GitHub Actions `rewrite-ci` passed —— 待本 PR 的 CI

## Review Evidence

- 自审：yes。本补丁第一版把豁免放在溯源校验之前，**静默关掉了人类判定的 fail-closed 提议事件校验**——这是真回归，被既有测试 `decision judgment fails closed when the immutable propose attribution event is missing` 抓住，改成把豁免挪到溯源查找之后才修好。
- Reviewer subagent：未跑
- 人工复核：待办
- 阻塞发现：无

## Residual Risk

- **agent A 批 agent B 提的决策是有意放行的，不是疏漏。** 这是为将来全托管 A2A(agent-to-agent)铺路；把规则收窄成「arbiter 必须是人」已被考虑并否决(`dec_01KXCHW9MFV8E3QGZJJW91YNDS` CH2)。唯一禁止的是 agent **自我闭环**——同一 executor 既提议又判定——而这正是本不变量抓的那一条。
- 人直接判定现在在机制上不受任何约束。这正是意图，台账也仍然记录是谁干的，但纯人类决策不再有任何机械的"第二双眼睛"要求。

## References

- 任务：`task_01KXARDPXSSHMH3QPGPD26RA5P`
- 证据：`dec_01KXCHW9MFV8E3QGZJJW91YNDS`
- 复核：待办
