### PR TITLE
fix: hide Windows Git subprocess windows

### DIFF
--- a/packages/adapters/local/src/git-diff-evidence.ts
+++ b/packages/adapters/local/src/git-diff-evidence.ts
@@ -134,7 +134,8 @@ function readGit(rootDir: string, args: ReadonlyArray<string>): { readonly ok: t
       stdout: execFileSync("git", ["-C", rootDir, "-c", "core.longpaths=true", ...args], {
         encoding: "utf8",
         maxBuffer: gitMaxBuffer,
-        stdio: ["ignore", "pipe", "ignore"]
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true
       })
     };
   } catch (error) {

--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -298,7 +298,8 @@ function readTaskTreeStatus(rootInput: HarnessLayoutInput, taskId: string): Loca
   const output = execFileSync("git", ["-C", packagePath, "status", "--porcelain", "-uall", "--", "."], {
     encoding: "utf8",
     maxBuffer: gitMaxBuffer,
-    stdio: ["ignore", "pipe", "pipe"]
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true
   });
   const entries = output
     .split(/\r?\n/u)
@@ -313,7 +314,8 @@ function gitTopLevel(inputPath: string): string | null {
     return execFileSync("git", ["-C", inputPath, "rev-parse", "--show-toplevel"], {
       encoding: "utf8",
       maxBuffer: gitMaxBuffer,
-      stdio: ["ignore", "pipe", "pipe"]
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true
     }).trim();
   } catch {
     return null;

--- a/packages/cli/src/commands/core/authored-git.ts
+++ b/packages/cli/src/commands/core/authored-git.ts
@@ -37,7 +37,7 @@ function validateAuthoredRelativePaths(
 
 export function gitTopLevel(inputPath: string): string | null {
   try {
-    return normalizeExistingPath(execFileSync("git", ["-C", inputPath, "rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim());
+    return normalizeExistingPath(execFileSync("git", ["-C", inputPath, "rev-parse", "--show-toplevel"], { encoding: "utf8", windowsHide: true }).trim());
   } catch {
     return null;
   }

--- a/packages/cli/src/commands/core/worktree.ts
+++ b/packages/cli/src/commands/core/worktree.ts
@@ -208,7 +208,7 @@ function gitBranchExists(root: string, branchName: string): boolean {
 }
 
 function git(cwd: string, args: ReadonlyArray<string>): string {
-  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], windowsHide: true });
 }
 
 function worktreeFailure(command: string, message: string, code: CliErrorCodeValue, taskId: string) {

--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -78,7 +78,8 @@ function readGitConfigEmail(authoredRoot: string): string | undefined {
   try {
     const configured = execFileSync("git", ["-C", authoredRoot, "config", "user.email"], {
       encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"]
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true
     }).trim();
     return configured || undefined;
   } catch {
@@ -210,6 +211,7 @@ async function startDaemon(input: DaemonCommandInput): Promise<number> {
     ], {
       detached: true,
       stdio: "ignore",
+      windowsHide: true,
       env: { ...process.env, HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: target.userRoot, HARNESS_DAEMON_ID: target.daemonId }
     });
     child.unref();
@@ -438,6 +440,7 @@ async function startBootstrapDaemon(rootDir: string, repoId: string, registryPat
   ], {
     detached: true,
     stdio: "ignore",
+    windowsHide: true,
     env: { ...process.env, HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: target.userRoot, HARNESS_DAEMON_ID: target.daemonId }
   });
   child.unref();
@@ -550,7 +553,7 @@ function requiredOption(args: ReadonlyArray<string>, name: string): string {
 
 function runDaemonGit(cwd: string, args: ReadonlyArray<string>): void {
   try {
-    execFileSync("git", [...args], { cwd, stdio: "ignore" });
+    execFileSync("git", [...args], { cwd, stdio: "ignore", windowsHide: true });
   } catch {
     throw new Error(`git ${args.join(" ")} failed in ${cwd}`);
   }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -141,7 +141,8 @@ function isInsideDoctorGitWorkTree(rootDir: string): boolean {
   try {
     const output = execFileSync("git", ["-C", rootDir, "rev-parse", "--is-inside-work-tree"], {
       encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"]
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true
     }).trim();
     return output === "true";
   } catch {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -227,7 +227,8 @@ function readGitText(rootDir: string, args: ReadonlyArray<string>): string | und
   try {
     return execFileSync("git", ["-C", rootDir, ...args], {
       encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"]
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true
     }).trim();
   } catch {
     return undefined;
@@ -238,6 +239,7 @@ function runInitGit(rootDir: string, args: ReadonlyArray<string>, author?: CliGi
   execFileSync("git", ["-C", rootDir, ...args], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
     env: {
       ...process.env,
       ...(author ? {

--- a/packages/cli/src/daemon/doc-sync-service.ts
+++ b/packages/cli/src/daemon/doc-sync-service.ts
@@ -472,7 +472,7 @@ function resolveChangePath(authoredRoot: string, pathInput: string): { readonly 
 
 function gitText(cwd: string, args: ReadonlyArray<string>): string | null {
   try {
-    return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trimEnd();
+    return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], windowsHide: true }).trimEnd();
   } catch {
     return null;
   }
@@ -480,7 +480,7 @@ function gitText(cwd: string, args: ReadonlyArray<string>): string | null {
 
 function gitBlobText(cwd: string, args: ReadonlyArray<string>): string | null {
   try {
-    return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+    return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], windowsHide: true });
   } catch {
     return null;
   }

--- a/packages/kernel/src/projection/post-merge-checks.ts
+++ b/packages/kernel/src/projection/post-merge-checks.ts
@@ -95,7 +95,11 @@ function findDuplicateExternalBindings(entries: ReadonlyArray<TaskSourceEntry>):
 
 function findTrackedGeneratedFiles(rootDir: string): ReadonlyArray<ProjectionWarning> {
   try {
-    const output = execFileSync("git", ["-C", rootDir, "ls-files", "--", ".harness", ".journal", ".projection.sqlite", ".adopt-claims"], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    const output = execFileSync("git", ["-C", rootDir, "ls-files", "--", ".harness", ".journal", ".projection.sqlite", ".adopt-claims"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true
+    }).trim();
     if (output.length === 0) return [];
     return [hardFail(
       "collaboration-gate",

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import type { ExecFileSyncOptionsWithStringEncoding } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import type { VcsCommitAuthor, VersionControlSystem } from "../ports/version-control-system.ts";
@@ -155,20 +156,7 @@ function runGit(repoRoot: string, ...args: ReadonlyArray<string>): string {
 
 function runGitAs(repoRoot: string, author: VcsCommitAuthor | undefined, ...args: ReadonlyArray<string>): string {
   try {
-    return execFileSync("git", ["-C", repoRoot, ...args], {
-      encoding: "utf8",
-      maxBuffer: gitMaxBuffer,
-      stdio: ["ignore", "pipe", "pipe"],
-      env: {
-        ...process.env,
-        ...(author ? {
-          GIT_AUTHOR_NAME: author.name,
-          GIT_AUTHOR_EMAIL: author.email,
-          GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? author.name,
-          GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? author.email
-        } : {})
-      }
-    });
+    return execFileSync("git", ["-C", repoRoot, ...args], localGitProcessOptions(author));
   } catch (error) {
     throw new VcsCommandError({
       command: args[0] ?? "command",
@@ -178,6 +166,24 @@ function runGitAs(repoRoot: string, author: VcsCommitAuthor | undefined, ...args
       stderrSummary: commandErrorSummary(error)
     });
   }
+}
+
+export function localGitProcessOptions(author?: VcsCommitAuthor): ExecFileSyncOptionsWithStringEncoding {
+  return {
+    encoding: "utf8",
+    maxBuffer: gitMaxBuffer,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+    env: {
+      ...process.env,
+      ...(author ? {
+        GIT_AUTHOR_NAME: author.name,
+        GIT_AUTHOR_EMAIL: author.email,
+        GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? author.name,
+        GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? author.email
+      } : {})
+    }
+  };
 }
 
 function commandErrorCode(error: unknown): string | number | undefined {

--- a/packages/kernel/test/store/local-version-control-system.test.ts
+++ b/packages/kernel/test/store/local-version-control-system.test.ts
@@ -1,0 +1,91 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import ts from "typescript";
+import { makeLocalVersionControlSystem, localGitProcessOptions } from "../../src/store/local-version-control-system.ts";
+import { VcsCommandError } from "../../src/ports/version-control-system.ts";
+
+test("local Git subprocesses stay hidden on Windows while preserving captured output", () => {
+  const options = localGitProcessOptions();
+
+  assert.equal(options.windowsHide, true);
+  assert.equal(options.encoding, "utf8");
+  assert.deepEqual(options.stdio, ["ignore", "pipe", "pipe"]);
+});
+
+test("local Git execution preserves captured output and typed command errors", () => {
+  const repoRoot = mkdtempSync(path.join(tmpdir(), "ha-hidden-git-"));
+  const nonRepoRoot = mkdtempSync(path.join(tmpdir(), "ha-hidden-git-error-"));
+  try {
+    execFileSync("git", ["-C", repoRoot, "init", "-b", "hidden-window-test"], { stdio: "ignore" });
+    execFileSync("git", [
+      "-C", repoRoot,
+      "-c", "user.name=Harness Test",
+      "-c", "user.email=harness@example.test",
+      "commit", "--allow-empty", "-m", "seed"
+    ], { stdio: "ignore" });
+    const vcs = makeLocalVersionControlSystem();
+
+    assert.equal(vcs.currentBranch(repoRoot), "hidden-window-test");
+    assert.throws(
+      () => vcs.commit(nonRepoRoot, "must fail"),
+      (error: unknown) => error instanceof VcsCommandError
+        && error.command === "commit"
+        && error.cwd === nonRepoRoot
+        && typeof error.stderrSummary === "string"
+        && error.stderrSummary.length > 0
+    );
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+    rmSync(nonRepoRoot, { recursive: true, force: true });
+  }
+});
+
+test("every production Git subprocess explicitly hides its Windows window", () => {
+  const repoRoot = path.resolve(import.meta.dirname, "../../../..");
+  const sourceFiles = typescriptFiles(path.join(repoRoot, "packages"), repoRoot);
+  const missing = sourceFiles.flatMap((file) => missingWindowsHideCalls(repoRoot, file));
+
+  assert.deepEqual(missing, []);
+});
+
+function typescriptFiles(directory: string, repoRoot: string): ReadonlyArray<string> {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return entry.name === "test" || entry.name === "dist" ? [] : typescriptFiles(entryPath, repoRoot);
+    return entry.isFile() && entry.name.endsWith(".ts") ? [path.relative(repoRoot, entryPath)] : [];
+  });
+}
+
+function missingWindowsHideCalls(repoRoot: string, relativePath: string): ReadonlyArray<string> {
+  const sourceText = readFileSync(path.join(repoRoot, relativePath), "utf8");
+  const sourceFile = ts.createSourceFile(relativePath, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const missing: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node)
+      && ts.isIdentifier(node.expression)
+      && node.expression.text === "execFileSync"
+      && node.arguments[0]?.getText(sourceFile) === '"git"') {
+      const options = node.arguments[2];
+      const usesContract = options?.getText(sourceFile).startsWith("localGitProcessOptions(") ?? false;
+      const hidesWindow = options && ts.isObjectLiteralExpression(options) && options.properties.some((property) =>
+        ts.isPropertyAssignment(property)
+        && property.name.getText(sourceFile) === "windowsHide"
+        && property.initializer.kind === ts.SyntaxKind.TrueKeyword
+      );
+      if (!usesContract && !hidesWindow) {
+        const line = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+        missing.push(`${relativePath}:${line}`);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return missing;
+}


### PR DESCRIPTION
# English

## Summary

Prevent HA daemon Git polling and other production Git child processes from opening visible console windows or stealing focus on Windows.

## What Changed

- Added `windowsHide: true` to every production `execFileSync("git", ...)` call under `packages/**`.
- Added the same hidden-window contract to both detached local daemon service spawns.
- Added a test-covered kernel Git process-options contract.
- Added behavior coverage for captured Git output and `VcsCommandError` mapping, plus an AST audit that fails when a future production Git call omits the Windows-hidden option.

## Task And Scope

- Harness task: `task_01KXCS2XMGEBWAVKX56V3PC4QP`
- Branch: `codex/fix-windows-daemon-git-window`
- Public scope: production Git child-process options, detached daemon spawn options, and focused regression tests
- Private planning/evidence updated: yes
- Out of scope: daemon lifecycle semantics; changing the 5-second materializer cadence; claiming Windows GUI/focus verification from macOS

## Version Impact

- Version: no version change because this is an unreleased bug fix and versioning belongs to a separate release task
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: Harness task `task_01KXCS2XMGEBWAVKX56V3PC4QP` and issue #691
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `51b37449766dfea3a1a7c80c4ad2a3a550719d68`
- Branch merge-base with `origin/main`: `51b37449766dfea3a1a7c80c4ad2a3a550719d68`
- Last `git fetch origin` time: 2026-07-13 before worktree creation
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: Harness task `task_01KXCS2XMGEBWAVKX56V3PC4QP`
- Reviewer evidence path: two-axis Standards/Spec review recorded in the Harness task execution
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci` (the isolated worktree used `npm install` against the lockfile); Windows service-mode focus observation requires a Windows host

## Review Evidence

- Self-review: production call-site audit, `git diff --check`, focused red/green tests, and final full gate
- Reviewer subagent: Standards found no hard violation; Spec P2 requested broader regression protection and was closed by behavior tests plus the AST production-call audit
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The code-level process contract is covered on macOS, but the final user-visible acceptance check—multiple service-mode polling intervals without a visible window or focus change—still requires Windows runtime observation.

## References

- Task: `task_01KXCS2XMGEBWAVKX56V3PC4QP`
- Evidence: commit `004713e`
- Review: two-axis Standards/Spec review; no open P0/P1/P2
- Closes #691

---

# 中文

## 概要

防止 HA daemon 的 Git 轮询及其他生产 Git 子进程在 Windows 上弹出可见控制台窗口或抢夺前台焦点。

## 改动内容

- 为 `packages/**` 下所有生产 `execFileSync("git", ...)` 调用增加 `windowsHide: true`。
- 为两个 detached 本地 daemon service 启动路径增加相同的隐藏窗口合同。
- 增加带测试的 kernel Git process-options 合同。
- 增加 Git 输出捕获、`VcsCommandError` 映射行为测试，以及可阻止未来 production Git 调用遗漏隐藏选项的 AST 审计测试。

## 任务与范围

- Harness 任务：`task_01KXCS2XMGEBWAVKX56V3PC4QP`
- 分支：`codex/fix-windows-daemon-git-window`
- 公开范围：生产 Git 子进程选项、detached daemon spawn 选项与聚焦回归测试
- 私有计划 / 证据是否已更新：yes
- 范围外：daemon 生命周期语义；修改 5 秒 materializer 周期；在 macOS 上冒充完成 Windows GUI/焦点验收

## 版本影响

- 版本：不改版本，因为这是未发布 bug 修复，版本调整应由独立 release task 处理
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：Harness task `task_01KXCS2XMGEBWAVKX56V3PC4QP` 与 issue #691
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`51b37449766dfea3a1a7c80c4ad2a3a550719d68`
- 当前分支与 `origin/main` 的 merge-base：`51b37449766dfea3a1a7c80c4ad2a3a550719d68`
- 最近一次 `git fetch origin` 时间：2026-07-13，创建 worktree 前
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：Harness task `task_01KXCS2XMGEBWAVKX56V3PC4QP`
- Reviewer 证据路径：Harness task execution 中记录的 Standards/Spec 双轴审查
- GitHub Actions `rewrite-ci` run URL：等待运行
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：`npm ci`（隔离 worktree 使用 `npm install` 并遵循 lockfile）；Windows service 模式焦点观察需要 Windows 主机

## 审查证据

- 自查：production 调用面审计、`git diff --check`、聚焦红绿测试与最终完整 gate
- Reviewer subagent：Standards 无硬违规；Spec P2 要求扩大回归保护，已通过行为测试与 AST production-call 审计关闭
- 人工审查：等待
- 阻塞发现：无 open finding

## 残余风险

- 代码级进程合同已在 macOS 覆盖，但最终用户可见验收——service 模式连续多个轮询周期不弹窗、不改变焦点——仍需 Windows runtime 观察。

## 关联材料

- 任务：`task_01KXCS2XMGEBWAVKX56V3PC4QP`
- 证据：commit `004713e`
- 审查：Standards/Spec 双轴审查；无 open P0/P1/P2
- Closes #691

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，然后 `# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear: Mergify merge queue, then delete the branch and worktree. / 合并方式和合并后分支清理计划清楚：Mergify merge queue，随后删除分支与 worktree。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
