### PR TITLE
feat(gui): global back/forward navigation + task detail document tree

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import { TaskPreviewDrawer } from "./components/TaskPreviewDrawer.tsx";
 import { MockViewBanner } from "./components/shell-chrome.tsx";
 import { AppSidebar } from "./components/AppSidebar.tsx";
 import { ViewSwitch } from "./components/ViewSwitch.tsx";
+import { NavigationHistoryBar } from "./components/NavigationHistoryBar.tsx";
 import {
   DEFAULT_TASK_FILTERS,
   applyTaskFilters,
@@ -17,9 +18,30 @@ import { useTasksQuery, useSetTaskStatusMutation } from "./task-data.ts";
 import { useTriadicProjectionQuery } from "./triadic-data.ts";
 import { useFavorites } from "./model/favorites.ts";
 import { MOCK_BACKED_VIEWS, type ViewId } from "./shell-config.tsx";
+import { useNavigationHistory } from "./navigation/useNavigationHistory.ts";
 
 function AppShell() {
-  const [view, setView] = useState<ViewId>("overview");
+  // 应用位置由导航历史栈持有:entries[index] 是唯一真源。
+  // 六个位置状态(view/selectedId/previewId/focusedEntityRef/taskFilters/drill)
+  // 全部从 location 派生,变更只走 navigate() / updateLocation() —— 这是
+  // 「所有导航都进历史栈」的结构性保证(没有独立 setter 可绕过)。
+  const {
+    location,
+    navigate,
+    updateLocation,
+    back,
+    forward,
+    canBack,
+    canForward,
+  } = useNavigationHistory({
+    view: "overview",
+    selectedId: null,
+    previewId: null,
+    focusedEntityRef: null,
+    taskFilters: DEFAULT_TASK_FILTERS,
+    drill: null,
+  });
+
   const tasksQuery = useTasksQuery();
   const triadicQuery = useTriadicProjectionQuery();
   const realTasks = useMemo(
@@ -42,17 +64,7 @@ function AppShell() {
   const relations = triadicQuery.relations;
   const coverageRows = triadicQuery.coverageRows;
   const factAnchors = triadicQuery.factAnchors;
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [previewId, setPreviewId] = useState<string | null>(null);
-  const [focusedEntityRef, setFocusedEntityRef] = useState<string | null>(null);
-  const [taskFilters, setTaskFilters] =
-    useState<TaskFilters>(DEFAULT_TASK_FILTERS);
   const [projectSwitcherOpen, setProjectSwitcherOpen] = useState(false);
-  const [drill, setDrill] = useState<{
-    lane: string;
-    status: SnapshotStatus;
-    groupBy: LaneGroupBy;
-  } | null>(null);
 
   const projectTasks = useMemo(
     () => tasks.filter((t) => t.projectId === projectId),
@@ -68,16 +80,16 @@ function AppShell() {
   ).length;
 
   const selected = useMemo(
-    () => tasks.find((t) => t.taskId === selectedId) ?? null,
-    [tasks, selectedId],
+    () => tasks.find((t) => t.taskId === location.selectedId) ?? null,
+    [tasks, location.selectedId],
   );
   const previewTask = useMemo(
-    () => tasks.find((t) => t.taskId === previewId) ?? null,
-    [previewId, tasks],
+    () => tasks.find((t) => t.taskId === location.previewId) ?? null,
+    [location.previewId, tasks],
   );
   const filteredProjectTasks = useMemo(
-    () => applyTaskFilters(projectTasks, taskFilters, favorites),
-    [projectTasks, taskFilters, favorites],
+    () => applyTaskFilters(projectTasks, location.taskFilters, favorites),
+    [projectTasks, location.taskFilters, favorites],
   );
 
   // 决策批准角标:proposed 决策数(唯一面向人的"待人处理"计数)
@@ -94,18 +106,30 @@ function AppShell() {
     }
   };
 
+  // ── 导航入口:全部汇流到 navigate() ──────────────────────────────
+  // 原来有四个入口绕过了 goto 直接改 state(drillToBoard / navigateToEntity /
+  // focusEntityInGraph / 多视图 switcher),历史栈会漏记。现在统一走 navigate。
+
   const goto = (v: ViewId) => {
-    setView(v);
-    setFocusedEntityRef(null);
-    setSelectedId(null);
-    setPreviewId(null);
-    if (v !== "board") setDrill(null);
+    navigate({
+      view: v,
+      focusedEntityRef: null,
+      selectedId: null,
+      previewId: null,
+      drill: v !== "board" ? null : location.drill,
+    });
   };
 
   const openProject = () => {
-    setTaskFilters(DEFAULT_TASK_FILTERS);
     setProjectSwitcherOpen(false);
-    goto("overview");
+    navigate({
+      view: "overview",
+      focusedEntityRef: null,
+      selectedId: null,
+      previewId: null,
+      drill: null,
+      taskFilters: DEFAULT_TASK_FILTERS,
+    });
   };
 
   const drillToBoard = (
@@ -115,21 +139,21 @@ function AppShell() {
   ) => {
     // 特殊占位 __all__ 表示不锁定 lane(只 drill 到状态维度)
     const groupBy: LaneGroupBy = dimension === "root" ? "root" : "module";
-    setDrill({ lane, status, groupBy });
-    setView("board");
-    setSelectedId(null);
-    setPreviewId(null);
+    navigate({
+      view: "board",
+      drill: { lane, status, groupBy },
+      selectedId: null,
+      previewId: null,
+    });
   };
 
+  // 抽屉开关是「精修」不是「导航」——不推栈,但快照保留最新值。
   const openTaskPreview = (id: string) => {
-    setSelectedId(null);
-    setPreviewId(id);
+    updateLocation({ selectedId: null, previewId: id });
   };
 
   const openTaskDetail = (id: string) => {
-    setFocusedEntityRef(`task/${id}`);
-    setPreviewId(null);
-    setSelectedId(id);
+    navigate({ focusedEntityRef: `task/${id}`, previewId: null, selectedId: id });
   };
 
   // W2B 活链接:跨实体跳转(task→详情, decision→决策池, fact→事实分诊)
@@ -139,33 +163,69 @@ function AppShell() {
       openTaskDetail(id);
     } else if (ref.startsWith("decision/")) {
       const decisionId = ref.split("/")[1];
-      setFocusedEntityRef(`decision/${decisionId}`);
-      setView("decisionPool");
-      setSelectedId(null);
-      setPreviewId(null);
+      navigate({
+        focusedEntityRef: `decision/${decisionId}`,
+        view: "decisionPool",
+        selectedId: null,
+        previewId: null,
+      });
     } else if (ref.startsWith("fact/")) {
-      setFocusedEntityRef(ref);
-      setView("factTriage");
-      setSelectedId(null);
-      setPreviewId(null);
+      navigate({
+        focusedEntityRef: ref,
+        view: "factTriage",
+        selectedId: null,
+        previewId: null,
+      });
     }
   };
   const navigateToDecision = (decisionId: string) =>
     navigateToEntity(`decision/${decisionId}`);
   const navigateToTask = (taskId: string) => openTaskDetail(taskId);
   const focusEntityInGraph = (ref: string) => {
-    setFocusedEntityRef(ref);
-    setView("graph");
-    setSelectedId(null);
-    setPreviewId(null);
+    navigate({
+      focusedEntityRef: ref,
+      view: "graph",
+      selectedId: null,
+      previewId: null,
+    });
   };
 
-  const showMockBanner = !selected && MOCK_BACKED_VIEWS.has(view);
+  // 全局快捷键:Cmd+[ / Cmd+] (Mac) / Ctrl+[ / Ctrl+] (Win/Linux)
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const mod = event.metaKey || event.ctrlKey;
+      if (!mod) return;
+      if (event.key === "[") {
+        event.preventDefault();
+        back();
+      } else if (event.key === "]") {
+        event.preventDefault();
+        forward();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [back, forward]);
+
+  // 鼠标侧键:button 3 = 后退,button 4 = 前进(浏览器/Electron 惯例)
+  useEffect(() => {
+    const onMouseDown = (event: MouseEvent) => {
+      if (event.button === 3) {
+        back();
+      } else if (event.button === 4) {
+        forward();
+      }
+    };
+    window.addEventListener("mousedown", onMouseDown);
+    return () => window.removeEventListener("mousedown", onMouseDown);
+  }, [back, forward]);
+
+  const showMockBanner = !selected && MOCK_BACKED_VIEWS.has(location.view);
 
   return (
     <div className="flex h-dvh flex-col overflow-hidden md:flex-row">
       <AppSidebar
-        view={view}
+        view={location.view}
         selected={selected}
         tasksQuery={tasksQuery}
         projectTasks={projectTasks}
@@ -187,15 +247,21 @@ function AppShell() {
 
       <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         {showMockBanner && <MockViewBanner />}
+        <NavigationHistoryBar
+          canBack={canBack}
+          canForward={canForward}
+          onBack={back}
+          onForward={forward}
+        />
         <div className="flex min-h-0 min-w-0 flex-1 flex-row overflow-hidden">
           <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             <ViewSwitch
-              view={view}
+              view={location.view}
               selected={selected}
               filteredProjectTasks={filteredProjectTasks}
-              taskFilters={taskFilters}
-              drill={drill}
-              focusedEntityRef={focusedEntityRef}
+              taskFilters={location.taskFilters}
+              drill={location.drill}
+              focusedEntityRef={location.focusedEntityRef}
               project={project}
               projectTasks={projectTasks}
               tasks={tasks}
@@ -204,17 +270,19 @@ function AppShell() {
               events={MOCK_EVENTS}
               projectName={project.name}
               goto={goto}
-              onMultiViewSwitch={setView}
+              onMultiViewSwitch={(v: ViewId) => navigate({ view: v })}
               onOpenTaskPreview={openTaskPreview}
               onDrillToBoard={drillToBoard}
               onUpdateTask={updateTask}
-              onSelectTask={setSelectedId}
-              onClearSelection={() => setSelectedId(null)}
+              onSelectTask={(id: string) => navigate({ selectedId: id })}
+              onClearSelection={() => navigate({ selectedId: null })}
               onNavigateEntity={navigateToEntity}
               onNavigateDecision={navigateToDecision}
               onNavigateTask={navigateToTask}
               onFocusEntityInGraph={focusEntityInGraph}
-              onFiltersChange={setTaskFilters}
+              onFiltersChange={(filters: TaskFilters) =>
+                updateLocation({ taskFilters: filters })
+              }
               onToggleFavorite={toggleFavorite}
               onOpenProject={openProject}
             />
@@ -226,7 +294,7 @@ function AppShell() {
         tasks={projectTasks}
         relations={relations}
         events={projectEvents}
-        onClose={() => setPreviewId(null)}
+        onClose={() => updateLocation({ previewId: null })}
         onOpenDetail={openTaskDetail}
         onPreviewTask={openTaskPreview}
       />

--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -1,107 +1,22 @@
 import { useEffect, useMemo, useState } from "react";
-import {
-  Kanban,
-  FolderSimple,
-  SquaresFour,
-  Graph,
-  Scales,
-  Stack,
-  PlugsConnected,
-  GearSix,
-  CaretUpDown,
-  CloudSlash,
-  WarningCircle,
-  GitBranch,
-  FirstAidKit,
-  ClockCounterClockwise,
-  ClipboardText,
-} from "@phosphor-icons/react";
 import type { SnapshotStatus } from "./model/types.ts";
-import {
-  MOCK_PRESETS,
-  MOCK_ADAPTERS,
-  MOCK_EVENTS,
-} from "./model/mock.ts";
+import { MOCK_EVENTS } from "./model/mock.ts";
 import { ThemeProvider } from "./theme.tsx";
-import { HomeView } from "./views/HomeView.tsx";
-import { OverviewView } from "./views/OverviewView.tsx";
-import { BoardView } from "./views/BoardView.tsx";
-import { DecisionsView } from "./views/DecisionsView.tsx";
-import { DecisionPoolView } from "./views/DecisionPoolView.tsx";
-import { FactTriageView } from "./views/FactTriageView.tsx";
-import { ExecutionEvidenceView } from "./views/ExecutionEvidenceView.tsx";
-import { GraphView } from "./views/GraphView.tsx";
-import { GenealogyTimelineView } from "./views/GenealogyTimelineView.tsx";
-import { PresetsView } from "./views/PresetsView.tsx";
-import { AdaptersView } from "./views/AdaptersView.tsx";
-import { SettingsView } from "./views/SettingsView.tsx";
-import { TaskDetailView } from "./views/TaskDetailView.tsx";
 import { TaskPreviewDrawer } from "./components/TaskPreviewDrawer.tsx";
-import { ThemeToggle, NavButton, ProjectSummary, MockViewBanner } from "./components/shell-chrome.tsx";
+import { MockViewBanner } from "./components/shell-chrome.tsx";
+import { AppSidebar } from "./components/AppSidebar.tsx";
+import { ViewSwitch } from "./components/ViewSwitch.tsx";
 import {
   DEFAULT_TASK_FILTERS,
   applyTaskFilters,
   type TaskFilters,
 } from "./model/taskFilters.ts";
+import type { LaneGroupBy } from "./views/SwimlaneBoard.tsx";
 import { adaptProjectionRows, buildRealProject } from "./task-adapter.ts";
 import { useTasksQuery, useSetTaskStatusMutation } from "./task-data.ts";
 import { useTriadicProjectionQuery } from "./triadic-data.ts";
 import { useFavorites } from "./model/favorites.ts";
-import type { LaneGroupBy } from "./views/SwimlaneBoard.tsx";
-
-type ViewId =
-  | "home"
-  | "overview"
-  | "board"
-  | "decisions"
-  | "decisionPool"
-  | "factTriage"
-  | "executions"
-  | "graph"
-  | "genealogy"
-  | "presets"
-  | "adapters"
-  | "settings";
-
-// 这些视图的数据仍为 mock:preset/adapter 管理面无真实后端。进入时顶部显式挂 MOCK 横幅。
-const MOCK_BACKED_VIEWS: ReadonlySet<ViewId> = new Set([
-  "home",
-  "presets",
-  "adapters",
-]);
-
-// W2C:列表并入看板(第三种 layout),独立「列表」入口删除。
-const WORKSPACE_NAV: { id: ViewId; label: string; icon: React.ReactNode; isNew?: true }[] = [
-  { id: "overview", label: "总览", icon: <SquaresFour weight="duotone" /> },
-  { id: "board", label: "看板", icon: <Kanban weight="duotone" /> },
-  { id: "decisions", label: "决策批准", icon: <Scales weight="duotone" /> },
-  { id: "decisionPool", label: "决策池", icon: <GitBranch weight="duotone" /> },
-  { id: "factTriage", label: "事实分诊", icon: <FirstAidKit weight="duotone" /> },
-  { id: "executions", label: "执行证据", icon: <ClipboardText weight="duotone" />, isNew: true },
-  { id: "graph", label: "关系图", icon: <Graph weight="duotone" /> },
-  { id: "genealogy", label: "演化史", icon: <ClockCounterClockwise weight="duotone" /> },
-];
-
-const MANAGE_NAV: { id: ViewId; label: string; icon: React.ReactNode }[] = [
-  { id: "presets", label: "Preset / Vertical", icon: <Stack weight="duotone" /> },
-  { id: "adapters", label: "引擎 Adapter", icon: <PlugsConnected weight="duotone" /> },
-  { id: "settings", label: "设置", icon: <GearSix weight="duotone" /> },
-];
-
-const VIEW_LABEL: Record<ViewId, string> = {
-  home: "项目",
-  overview: "总览",
-  board: "看板",
-  decisions: "决策批准",
-  decisionPool: "决策池",
-  factTriage: "事实分诊",
-  executions: "执行证据",
-  graph: "关系图",
-  genealogy: "演化史",
-  presets: "Preset / Vertical",
-  adapters: "引擎 Adapter",
-  settings: "设置",
-};
+import { MOCK_BACKED_VIEWS, type ViewId } from "./shell-config.tsx";
 
 function AppShell() {
   const [view, setView] = useState<ViewId>("overview");
@@ -249,321 +164,60 @@ function AppShell() {
 
   return (
     <div className="flex h-dvh flex-col overflow-hidden md:flex-row">
-      <aside className="flex max-h-[42dvh] w-full shrink-0 flex-col overflow-y-auto border-b border-border bg-surface md:max-h-none md:w-56 md:overflow-visible md:border-r md:border-b-0">
-        <div className="flex items-center gap-2 px-3 pt-3 pb-1">
-          <span className="font-mono text-[11px] font-semibold tracking-wide text-text-muted">
-            HARNESS
-          </span>
-          <span
-            title="本地模式 · 未同步（V2：多端同步）"
-            className="inline-flex items-center gap-1 rounded border border-border px-1 py-px font-mono text-[10px] text-text-faint"
-          >
-            <CloudSlash weight="bold" />
-            本地
-          </span>
-          <div className="ml-auto">
-            <ThemeToggle />
-          </div>
-        </div>
-
-        <div className="px-3 pb-1">
-          {tasksQuery.isSuccess ? (
-            projectTasks.length > 0 ? (
-              <span
-                data-testid="real-task-summary"
-                className="block font-mono text-[11px] text-text-faint"
-              >
-                Active work · {activeCount} of {projectTasks.length} tasks
-              </span>
-            ) : (
-              <span
-                data-testid="task-empty-state"
-                className="block font-mono text-[11px] text-text-faint"
-              >
-                No task rows available from the local task bridge
-              </span>
-            )
-          ) : tasksQuery.isError ? (
-            <span className="block font-mono text-[11px] text-status-blocked">
-              台账桥读取失败
-            </span>
-          ) : (
-            <span className="block font-mono text-[11px] text-text-faint">
-              读取本地台账…
-            </span>
-          )}
-        </div>
-
-        <div className="px-3 pt-2 pb-2">
-          <div className="relative">
-            <button
-              onClick={() => setProjectSwitcherOpen((open) => !open)}
-              title="快速切换项目"
-              className={`flex w-full items-center gap-2 rounded-md border px-2 py-2 text-left text-sm font-medium hover:border-border-strong ${
-                projectSwitcherOpen || view === "home"
-                  ? "border-border-strong bg-surface-raised"
-                  : "border-border bg-surface-raised"
-              }`}
-            >
-              <FolderSimple weight="duotone" className="shrink-0 text-text-muted" />
-              <span className="min-w-0 flex-1">
-                <span className="block truncate">{project.name}</span>
-                <span className="block truncate font-mono text-[11px] text-text-faint">
-                  {project.preset}
-                </span>
-              </span>
-              <CaretUpDown weight="bold" className="shrink-0 text-text-faint" />
-            </button>
-
-            {projectSwitcherOpen && (
-              <div className="absolute left-0 right-0 z-30 mt-2 rounded-lg border border-border-strong bg-surface-raised p-2 shadow-2xl shadow-black/35 md:right-auto md:w-[320px]">
-                <div className="flex items-center justify-between px-1 pb-2">
-                  <span className="font-mono text-[11px] uppercase tracking-wide text-text-faint">
-                    快速切换
-                  </span>
-                  <span className="font-mono text-[11px] text-text-faint">
-                    {projects.length} projects
-                  </span>
-                </div>
-                <div className="flex max-h-[330px] flex-col gap-1.5 overflow-y-auto">
-                  {projects.map((p) => (
-                    <ProjectSummary
-                      key={p.id}
-                      project={p}
-                      tasks={tasks}
-                      active={p.id === projectId}
-                      onOpen={openProject}
-                    />
-                  ))}
-                </div>
-                <div className="mt-2 grid grid-cols-2 gap-1.5 border-t border-border pt-2">
-                  <button
-                    onClick={() => {
-                      setProjectSwitcherOpen(false);
-                      goto("home");
-                    }}
-                    className="rounded-md border border-border px-2 py-1.5 text-left text-[12px] font-medium text-text-muted hover:border-border-strong hover:text-text"
-                  >
-                    管理全部
-                  </button>
-                  <button
-                    disabled
-                    className="inline-flex items-center justify-center gap-1 rounded-md border border-border px-2 py-1.5 text-[12px] text-text-faint opacity-70"
-                  >
-                    <WarningCircle weight="bold" />
-                    本地模式
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className="px-3 pt-1 pb-1 font-mono text-[12px] uppercase tracking-wide text-text-faint">
-          工作区
-        </div>
-        <nav className="flex gap-1 overflow-x-auto px-2 pb-1 md:flex-col md:gap-0.5 md:overflow-visible md:pb-0">
-          {WORKSPACE_NAV.map((item) => (
-            <NavButton
-              key={item.id}
-              active={view === item.id && !selected}
-              onClick={() => goto(item.id)}
-              icon={item.icon}
-              label={item.label}
-              badge={item.id === "decisions" ? inboxCount : undefined}
-              isNew={item.isNew}
-            />
-          ))}
-        </nav>
-
-        <div className="px-3 pt-3 pb-1 font-mono text-[12px] uppercase tracking-wide text-text-faint">
-          管理
-        </div>
-        <nav className="flex gap-1 overflow-x-auto px-2 pb-2 md:flex-col md:gap-0.5 md:overflow-visible md:pb-0">
-          {MANAGE_NAV.map((item) => (
-            <NavButton
-              key={item.id}
-              active={view === item.id && !selected}
-              onClick={() => goto(item.id)}
-              icon={item.icon}
-              label={item.label}
-            />
-          ))}
-        </nav>
-
-        <div className="mt-auto hidden border-t border-border px-3 py-2.5 md:block">
-          <button
-            disabled
-            title="V2 预览：账号登录后可多设备同步、远程访问项目"
-            className="flex w-full cursor-not-allowed items-center gap-2 text-left opacity-70"
-          >
-            <span className="grid size-6 shrink-0 place-items-center rounded-full bg-surface-raised font-mono text-[11px] font-semibold text-text-muted">
-              Z
-            </span>
-            <span className="min-w-0">
-              <span className="block truncate text-xs text-text">本地模式</span>
-              <span className="block truncate text-[10px] text-text-faint">
-                账号与同步 · V2
-              </span>
-            </span>
-          </button>
-        </div>
-      </aside>
+      <AppSidebar
+        view={view}
+        selected={selected}
+        tasksQuery={tasksQuery}
+        projectTasks={projectTasks}
+        activeCount={activeCount}
+        project={project}
+        projects={projects}
+        projectId={projectId}
+        tasks={tasks}
+        projectSwitcherOpen={projectSwitcherOpen}
+        onProjectSwitcherToggle={() => setProjectSwitcherOpen((open) => !open)}
+        onManageAll={() => {
+          setProjectSwitcherOpen(false);
+          goto("home");
+        }}
+        openProject={openProject}
+        goto={goto}
+        inboxCount={inboxCount}
+      />
 
       <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         {showMockBanner && <MockViewBanner />}
         <div className="flex min-h-0 min-w-0 flex-1 flex-row overflow-hidden">
           <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-            {!selected && (
-              <div
-                data-testid="multi-view-switcher"
-                className="flex items-center gap-2 border-b border-border bg-surface/60 px-4 py-1.5"
-              >
-                <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
-                  多视图
-                </span>
-                <div className="flex items-center gap-0.5 rounded-md border border-border p-0.5">
-                  {([
-                    { id: "graph", label: "关系图" },
-                    { id: "genealogy", label: "演化史" },
-                  ] as const).map((item) => (
-                    <button
-                      key={item.id}
-                      onClick={() => setView(item.id)}
-                      className={`rounded px-2 py-0.5 text-[12px] ${
-                        view === item.id
-                          ? "bg-surface-raised font-medium text-text"
-                          : "text-text-muted hover:text-text"
-                      }`}
-                    >
-                      {item.label}
-                    </button>
-                  ))}
-                </div>
-                <span className="text-[11px] text-text-faint">
-                  常驻切换 · 关系图看结构,演化史看 decision 谱系随时间的 refine/narrow/supersede
-                </span>
-              </div>
-            )}
-            {selected ? (
-              <TaskDetailView
-                task={selected}
-                tasks={tasks}
-                relations={relations}
-                decisions={decisions}
-                onBack={() => setSelectedId(null)}
-                onUpdate={updateTask}
-                onSelect={setSelectedId}
-                projectName={project.name}
-                fromViewLabel={VIEW_LABEL[view]}
-                onNavigateDecision={navigateToDecision}
-                onNavigateEntity={navigateToEntity}
-              />
-            ) : view === "home" ? (
-              <HomeView
-                projects={projects}
-                tasks={tasks}
-                events={MOCK_EVENTS}
-                currentProjectId={projectId}
-                onOpenProject={openProject}
-              />
-            ) : view === "overview" ? (
-              <OverviewView
-                project={project}
-                tasks={projectTasks}
-                decisions={decisions}
-                facts={facts}
-                relations={relations}
-                onSelect={openTaskPreview}
-                onDrill={drillToBoard}
-                onOpenInbox={() => goto("decisions")}
-                onOpenDecisionPool={() => goto("decisionPool")}
-              />
-            ) : view === "board" ? (
-              <BoardView
-                tasks={filteredProjectTasks}
-                allTasks={projectTasks}
-                filters={taskFilters}
-                onFiltersChange={setTaskFilters}
-                onSelect={openTaskPreview}
-                onUpdate={updateTask}
-                drill={drill}
-                relations={relations}
-                favorites={favorites}
-                onToggleFavorite={toggleFavorite}
-              />
-            ) : view === "graph" ? (
-              <GraphView
-                tasks={projectTasks}
-                relations={relations}
-                decisions={decisions}
-                facts={facts}
-                coverageRows={coverageRows}
-                factAnchors={factAnchors}
-                onNavigateEntity={navigateToEntity}
-                focusRef={focusedEntityRef}
-              />
-            ) : view === "genealogy" ? (
-              <GenealogyTimelineView
-                decisions={decisions}
-                relations={relations}
-                focusRef={focusedEntityRef}
-                onNavigateEntity={navigateToEntity}
-                onFocusGraph={focusEntityInGraph}
-              />
-            ) : view === "factTriage" ? (
-              <FactTriageView
-                facts={facts}
-                relations={relations}
-                decisions={decisions}
-                tasks={tasks}
-                coverageRows={coverageRows}
-                factAnchors={factAnchors}
-                onNavigateDecision={navigateToDecision}
-                onNavigateTask={navigateToTask}
-                focusedFactRef={
-                  focusedEntityRef?.startsWith("fact/") ? focusedEntityRef : null
-                }
-                onFocusGraph={focusEntityInGraph}
-              />
-            ) : view === "executions" ? (
-              <ExecutionEvidenceView />
-            ) : view === "decisions" ? (
-              <DecisionsView
-                decisions={decisions}
-                tasks={tasks}
-                relations={relations}
-                facts={facts}
-                onTraceSession={(sid) => {
-                  // 原型占位：真实由 coordinator 内置 conversation-mining 导出该 session 原文（E47）
-                  console.log("[prototype] trace session:", sid);
-                }}
-                onDecide={() => undefined}
-                readOnly
-                onNavigateDecision={navigateToDecision}
-                onNavigateTask={navigateToTask}
-                onFocusGraph={focusEntityInGraph}
-                coverageRows={coverageRows}
-              />
-            ) : view === "decisionPool" ? (
-              <DecisionPoolView
-                decisions={decisions}
-                facts={facts}
-                relations={relations}
-                focusedDecisionId={
-                  focusedEntityRef?.startsWith("decision/")
-                    ? focusedEntityRef.split("/")[1]
-                    : null
-                }
-                onFocusGraph={focusEntityInGraph}
-              />
-            ) : view === "presets" ? (
-              <PresetsView presets={MOCK_PRESETS} project={project} />
-            ) : view === "adapters" ? (
-              <AdaptersView adapters={MOCK_ADAPTERS} tasks={projectTasks} />
-            ) : (
-              <SettingsView />
-            )}
+            <ViewSwitch
+              view={view}
+              selected={selected}
+              filteredProjectTasks={filteredProjectTasks}
+              taskFilters={taskFilters}
+              drill={drill}
+              focusedEntityRef={focusedEntityRef}
+              project={project}
+              projectTasks={projectTasks}
+              tasks={tasks}
+              triadic={{ decisions, facts, relations, coverageRows, factAnchors }}
+              favorites={favorites}
+              events={MOCK_EVENTS}
+              projectName={project.name}
+              goto={goto}
+              onMultiViewSwitch={setView}
+              onOpenTaskPreview={openTaskPreview}
+              onDrillToBoard={drillToBoard}
+              onUpdateTask={updateTask}
+              onSelectTask={setSelectedId}
+              onClearSelection={() => setSelectedId(null)}
+              onNavigateEntity={navigateToEntity}
+              onNavigateDecision={navigateToDecision}
+              onNavigateTask={navigateToTask}
+              onFocusEntityInGraph={focusEntityInGraph}
+              onFiltersChange={setTaskFilters}
+              onToggleFavorite={toggleFavorite}
+              onOpenProject={openProject}
+            />
           </div>
         </div>
       </main>

--- a/packages/gui/src/renderer/components/AppSidebar.tsx
+++ b/packages/gui/src/renderer/components/AppSidebar.tsx
@@ -1,0 +1,217 @@
+import {
+  FolderSimple,
+  CaretUpDown,
+  CloudSlash,
+  WarningCircle,
+} from "@phosphor-icons/react";
+import type { Project, TaskRow } from "../model/types.ts";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { ThemeToggle, NavButton, ProjectSummary } from "./shell-chrome.tsx";
+import {
+  WORKSPACE_NAV,
+  MANAGE_NAV,
+  type ViewId,
+} from "../shell-config.tsx";
+
+/**
+ * AppShell 侧边栏:项目标识 + 台账桥状态 + 项目切换器 + 工作区/管理导航。
+ *
+ * 从 App.tsx 抽出(历史栈任务的前置拆分)。纯展示:所有状态与回调由 AppShell
+ * 通过 props 注入,本组件不持有任何应用位置态。
+ */
+interface AppSidebarProps {
+  view: ViewId;
+  selected: TaskRow | null;
+  tasksQuery: UseQueryResult;
+  projectTasks: TaskRow[];
+  activeCount: number;
+  project: Project;
+  projects: Project[];
+  projectId: string;
+  tasks: TaskRow[];
+  projectSwitcherOpen: boolean;
+  onProjectSwitcherToggle: () => void;
+  /** 「管理全部」入口:关闭切换器 + 导航到 home。 */
+  onManageAll: () => void;
+  openProject: () => void;
+  goto: (v: ViewId) => void;
+  inboxCount: number;
+}
+
+export function AppSidebar({
+  view,
+  selected,
+  tasksQuery,
+  projectTasks,
+  activeCount,
+  project,
+  projects,
+  projectId,
+  tasks,
+  projectSwitcherOpen,
+  onProjectSwitcherToggle,
+  onManageAll,
+  openProject,
+  goto,
+  inboxCount,
+}: AppSidebarProps) {
+  return (
+    <aside className="flex max-h-[42dvh] w-full shrink-0 flex-col overflow-y-auto border-b border-border bg-surface md:max-h-none md:w-56 md:overflow-visible md:border-r md:border-b-0">
+      <div className="flex items-center gap-2 px-3 pt-3 pb-1">
+        <span className="font-mono text-[11px] font-semibold tracking-wide text-text-muted">
+          HARNESS
+        </span>
+        <span
+          title="本地模式 · 未同步（V2：多端同步）"
+          className="inline-flex items-center gap-1 rounded border border-border px-1 py-px font-mono text-[10px] text-text-faint"
+        >
+          <CloudSlash weight="bold" />
+          本地
+        </span>
+        <div className="ml-auto">
+          <ThemeToggle />
+        </div>
+      </div>
+
+      <div className="px-3 pb-1">
+        {tasksQuery.isSuccess ? (
+          projectTasks.length > 0 ? (
+            <span
+              data-testid="real-task-summary"
+              className="block font-mono text-[11px] text-text-faint"
+            >
+              Active work · {activeCount} of {projectTasks.length} tasks
+            </span>
+          ) : (
+            <span
+              data-testid="task-empty-state"
+              className="block font-mono text-[11px] text-text-faint"
+            >
+              No task rows available from the local task bridge
+            </span>
+          )
+        ) : tasksQuery.isError ? (
+          <span className="block font-mono text-[11px] text-status-blocked">
+            台账桥读取失败
+          </span>
+        ) : (
+          <span className="block font-mono text-[11px] text-text-faint">
+            读取本地台账…
+          </span>
+        )}
+      </div>
+
+      <div className="px-3 pt-2 pb-2">
+        <div className="relative">
+          <button
+            onClick={onProjectSwitcherToggle}
+            title="快速切换项目"
+            className={`flex w-full items-center gap-2 rounded-md border px-2 py-2 text-left text-sm font-medium hover:border-border-strong ${
+              projectSwitcherOpen || view === "home"
+                ? "border-border-strong bg-surface-raised"
+                : "border-border bg-surface-raised"
+            }`}
+          >
+            <FolderSimple weight="duotone" className="shrink-0 text-text-muted" />
+            <span className="min-w-0 flex-1">
+              <span className="block truncate">{project.name}</span>
+              <span className="block truncate font-mono text-[11px] text-text-faint">
+                {project.preset}
+              </span>
+            </span>
+            <CaretUpDown weight="bold" className="shrink-0 text-text-faint" />
+          </button>
+
+          {projectSwitcherOpen && (
+            <div className="absolute left-0 right-0 z-30 mt-2 rounded-lg border border-border-strong bg-surface-raised p-2 shadow-2xl shadow-black/35 md:right-auto md:w-[320px]">
+              <div className="flex items-center justify-between px-1 pb-2">
+                <span className="font-mono text-[11px] uppercase tracking-wide text-text-faint">
+                  快速切换
+                </span>
+                <span className="font-mono text-[11px] text-text-faint">
+                  {projects.length} projects
+                </span>
+              </div>
+              <div className="flex max-h-[330px] flex-col gap-1.5 overflow-y-auto">
+                {projects.map((p) => (
+                  <ProjectSummary
+                    key={p.id}
+                    project={p}
+                    tasks={tasks}
+                    active={p.id === projectId}
+                    onOpen={openProject}
+                  />
+                ))}
+              </div>
+              <div className="mt-2 grid grid-cols-2 gap-1.5 border-t border-border pt-2">
+                <button
+                  onClick={onManageAll}
+                  className="rounded-md border border-border px-2 py-1.5 text-left text-[12px] font-medium text-text-muted hover:border-border-strong hover:text-text"
+                >
+                  管理全部
+                </button>
+                <button
+                  disabled
+                  className="inline-flex items-center justify-center gap-1 rounded-md border border-border px-2 py-1.5 text-[12px] text-text-faint opacity-70"
+                >
+                  <WarningCircle weight="bold" />
+                  本地模式
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="px-3 pt-1 pb-1 font-mono text-[12px] uppercase tracking-wide text-text-faint">
+        工作区
+      </div>
+      <nav className="flex gap-1 overflow-x-auto px-2 pb-1 md:flex-col md:gap-0.5 md:overflow-visible md:pb-0">
+        {WORKSPACE_NAV.map((item) => (
+          <NavButton
+            key={item.id}
+            active={view === item.id && !selected}
+            onClick={() => goto(item.id)}
+            icon={item.icon}
+            label={item.label}
+            badge={item.id === "decisions" ? inboxCount : undefined}
+            isNew={item.isNew}
+          />
+        ))}
+      </nav>
+
+      <div className="px-3 pt-3 pb-1 font-mono text-[12px] uppercase tracking-wide text-text-faint">
+        管理
+      </div>
+      <nav className="flex gap-1 overflow-x-auto px-2 pb-2 md:flex-col md:gap-0.5 md:overflow-visible md:pb-0">
+        {MANAGE_NAV.map((item) => (
+          <NavButton
+            key={item.id}
+            active={view === item.id && !selected}
+            onClick={() => goto(item.id)}
+            icon={item.icon}
+            label={item.label}
+          />
+        ))}
+      </nav>
+
+      <div className="mt-auto hidden border-t border-border px-3 py-2.5 md:block">
+        <button
+          disabled
+          title="V2 预览：账号登录后可多设备同步、远程访问项目"
+          className="flex w-full cursor-not-allowed items-center gap-2 text-left opacity-70"
+        >
+          <span className="grid size-6 shrink-0 place-items-center rounded-full bg-surface-raised font-mono text-[11px] font-semibold text-text-muted">
+            Z
+          </span>
+          <span className="min-w-0">
+            <span className="block truncate text-xs text-text">本地模式</span>
+            <span className="block truncate text-[10px] text-text-faint">
+              账号与同步 · V2
+            </span>
+          </span>
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/packages/gui/src/renderer/components/NavigationHistoryBar.tsx
+++ b/packages/gui/src/renderer/components/NavigationHistoryBar.tsx
@@ -1,0 +1,53 @@
+import { ArrowLeft, ArrowRight } from "@phosphor-icons/react";
+
+/**
+ * AppShell 全局后退/前进栏。经典浏览器式 ← / → 按钮 + 快捷键提示。
+ *
+ * 状态机由 AppShell 用 navigation/useNavigationHistory 持有,本组件纯展示。
+ * 快捷键 Cmd+[ / Cmd+] 和鼠标侧键(button 3/4)在 AppShell 的 useEffect 里监听,
+ * 不在这——保持本组件无副作用、可 SSR。
+ */
+interface Props {
+  canBack: boolean;
+  canForward: boolean;
+  onBack: () => void;
+  onForward: () => void;
+}
+
+export function NavigationHistoryBar({ canBack, canForward, onBack, onForward }: Props) {
+  return (
+    <div
+      data-testid="nav-history-bar"
+      className="flex items-center gap-0.5 border-b border-border bg-surface/60 px-2 py-1"
+    >
+      <button
+        type="button"
+        onClick={onBack}
+        disabled={!canBack}
+        title="后退 (Cmd+[ 或鼠标侧键)"
+        aria-label="后退"
+        className={`grid size-6 place-items-center rounded ${
+          canBack
+            ? "text-text-muted hover:bg-surface-raised hover:text-text"
+            : "text-text-faint opacity-40"
+        }`}
+      >
+        <ArrowLeft weight="bold" className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={onForward}
+        disabled={!canForward}
+        title="前进 (Cmd+] 或鼠标侧键)"
+        aria-label="前进"
+        className={`grid size-6 place-items-center rounded ${
+          canForward
+            ? "text-text-muted hover:bg-surface-raised hover:text-text"
+            : "text-text-faint opacity-40"
+        }`}
+      >
+        <ArrowRight weight="bold" className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/packages/gui/src/renderer/components/ViewSwitch.tsx
+++ b/packages/gui/src/renderer/components/ViewSwitch.tsx
@@ -1,0 +1,247 @@
+import type { TaskRow, Project, EventEntry, SnapshotStatus } from "../model/types.ts";
+import type { TaskFilters } from "../model/taskFilters.ts";
+import type { LaneGroupBy } from "../views/SwimlaneBoard.tsx";
+import type { TriadicRendererData } from "../triadic-data.ts";
+import { MOCK_PRESETS, MOCK_ADAPTERS } from "../model/mock.ts";
+import { VIEW_LABEL, type ViewId } from "../shell-config.tsx";
+import { HomeView } from "../views/HomeView.tsx";
+import { OverviewView } from "../views/OverviewView.tsx";
+import { BoardView } from "../views/BoardView.tsx";
+import { DecisionsView } from "../views/DecisionsView.tsx";
+import { DecisionPoolView } from "../views/DecisionPoolView.tsx";
+import { FactTriageView } from "../views/FactTriageView.tsx";
+import { ExecutionEvidenceView } from "../views/ExecutionEvidenceView.tsx";
+import { GraphView } from "../views/GraphView.tsx";
+import { GenealogyTimelineView } from "../views/GenealogyTimelineView.tsx";
+import { PresetsView } from "../views/PresetsView.tsx";
+import { AdaptersView } from "../views/AdaptersView.tsx";
+import { SettingsView } from "../views/SettingsView.tsx";
+import { TaskDetailView } from "../views/TaskDetailView.tsx";
+
+type DrillState = { lane: string; status: SnapshotStatus; groupBy: LaneGroupBy } | null;
+
+/**
+ * 主内容区的视图路由:任务详情(选中时优先)+ 多视图切换条 + 视图表。
+ *
+ * 从 App.tsx 抽出(历史栈任务的前置拆分)。选中任务时渲染 TaskDetailView;
+ * 否则按当前 view 渲染对应视图。所有应用位置态与导航回调由 AppShell 注入。
+ */
+export interface ViewSwitchProps {
+  view: ViewId;
+  selected: TaskRow | null;
+  filteredProjectTasks: TaskRow[];
+  taskFilters: TaskFilters;
+  drill: DrillState;
+  focusedEntityRef: string | null;
+  project: Project;
+  projectTasks: TaskRow[];
+  tasks: TaskRow[];
+  triadic: Pick<TriadicRendererData, "decisions" | "facts" | "relations" | "coverageRows" | "factAnchors">;
+  favorites: Set<string>;
+  events: EventEntry[];
+  projectName: string;
+  goto: (v: ViewId) => void;
+  onMultiViewSwitch: (v: ViewId) => void;
+  onOpenTaskPreview: (id: string) => void;
+  onDrillToBoard: (lane: string, status: SnapshotStatus, dimension: "root" | "module") => void;
+  onUpdateTask: (id: string, patch: Partial<TaskRow>) => void;
+  onSelectTask: (id: string) => void;
+  /** TaskDetailView 的「返回上一层」:清空选中态(回到视图表)。 */
+  onClearSelection: () => void;
+  onNavigateEntity: (ref: string) => void;
+  onNavigateDecision: (decisionId: string) => void;
+  onNavigateTask: (taskId: string) => void;
+  onFocusEntityInGraph: (ref: string) => void;
+  onFiltersChange: (filters: TaskFilters) => void;
+  onToggleFavorite: (taskId: string) => void;
+  onOpenProject: () => void;
+}
+
+export function ViewSwitch(props: ViewSwitchProps) {
+  const {
+    view,
+    selected,
+    filteredProjectTasks,
+    taskFilters,
+    drill,
+    focusedEntityRef,
+    project,
+    projectTasks,
+    tasks,
+    triadic,
+    favorites,
+    events,
+    projectName,
+    goto,
+    onMultiViewSwitch,
+    onOpenTaskPreview,
+    onDrillToBoard,
+    onUpdateTask,
+    onSelectTask,
+    onClearSelection,
+    onNavigateEntity,
+    onNavigateDecision,
+    onNavigateTask,
+    onFocusEntityInGraph,
+    onFiltersChange,
+    onToggleFavorite,
+    onOpenProject,
+  } = props;
+
+  const { decisions, facts, relations, coverageRows, factAnchors } = triadic;
+
+  return (
+    <>
+      {!selected && (
+        <div
+          data-testid="multi-view-switcher"
+          className="flex items-center gap-2 border-b border-border bg-surface/60 px-4 py-1.5"
+        >
+          <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
+            多视图
+          </span>
+          <div className="flex items-center gap-0.5 rounded-md border border-border p-0.5">
+            {([
+              { id: "graph", label: "关系图" },
+              { id: "genealogy", label: "演化史" },
+            ] as const).map((item) => (
+              <button
+                key={item.id}
+                onClick={() => onMultiViewSwitch(item.id)}
+                className={`rounded px-2 py-0.5 text-[12px] ${
+                  view === item.id
+                    ? "bg-surface-raised font-medium text-text"
+                    : "text-text-muted hover:text-text"
+                }`}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+          <span className="text-[11px] text-text-faint">
+            常驻切换 · 关系图看结构,演化史看 decision 谱系随时间的 refine/narrow/supersede
+          </span>
+        </div>
+      )}
+      {selected ? (
+        <TaskDetailView
+          task={selected}
+          tasks={tasks}
+          relations={relations}
+          decisions={decisions}
+          onBack={onClearSelection}
+          onUpdate={onUpdateTask}
+          onSelect={onSelectTask}
+          projectName={projectName}
+          fromViewLabel={VIEW_LABEL[view]}
+          onNavigateDecision={onNavigateDecision}
+          onNavigateEntity={onNavigateEntity}
+        />
+      ) : view === "home" ? (
+        <HomeView
+          projects={[project]}
+          tasks={tasks}
+          events={events}
+          currentProjectId={project.id}
+          onOpenProject={onOpenProject}
+        />
+      ) : view === "overview" ? (
+        <OverviewView
+          project={project}
+          tasks={projectTasks}
+          decisions={decisions}
+          facts={facts}
+          relations={relations}
+          onSelect={onOpenTaskPreview}
+          onDrill={onDrillToBoard}
+          onOpenInbox={() => goto("decisions")}
+          onOpenDecisionPool={() => goto("decisionPool")}
+        />
+      ) : view === "board" ? (
+        <BoardView
+          tasks={filteredProjectTasks}
+          allTasks={projectTasks}
+          filters={taskFilters}
+          onFiltersChange={onFiltersChange}
+          onSelect={onOpenTaskPreview}
+          onUpdate={onUpdateTask}
+          drill={drill}
+          relations={relations}
+          favorites={favorites}
+          onToggleFavorite={onToggleFavorite}
+        />
+      ) : view === "graph" ? (
+        <GraphView
+          tasks={projectTasks}
+          relations={relations}
+          decisions={decisions}
+          facts={facts}
+          coverageRows={coverageRows}
+          factAnchors={factAnchors}
+          onNavigateEntity={onNavigateEntity}
+          focusRef={focusedEntityRef}
+        />
+      ) : view === "genealogy" ? (
+        <GenealogyTimelineView
+          decisions={decisions}
+          relations={relations}
+          focusRef={focusedEntityRef}
+          onNavigateEntity={onNavigateEntity}
+          onFocusGraph={onFocusEntityInGraph}
+        />
+      ) : view === "factTriage" ? (
+        <FactTriageView
+          facts={facts}
+          relations={relations}
+          decisions={decisions}
+          tasks={tasks}
+          coverageRows={coverageRows}
+          factAnchors={factAnchors}
+          onNavigateDecision={onNavigateDecision}
+          onNavigateTask={onNavigateTask}
+          focusedFactRef={
+            focusedEntityRef?.startsWith("fact/") ? focusedEntityRef : null
+          }
+          onFocusGraph={onFocusEntityInGraph}
+        />
+      ) : view === "executions" ? (
+        <ExecutionEvidenceView />
+      ) : view === "decisions" ? (
+        <DecisionsView
+          decisions={decisions}
+          tasks={tasks}
+          relations={relations}
+          facts={facts}
+          onTraceSession={(sid) => {
+            // 原型占位：真实由 coordinator 内置 conversation-mining 导出该 session 原文（E47）
+            console.log("[prototype] trace session:", sid);
+          }}
+          onDecide={() => undefined}
+          readOnly
+          onNavigateDecision={onNavigateDecision}
+          onNavigateTask={onNavigateTask}
+          onFocusGraph={onFocusEntityInGraph}
+          coverageRows={coverageRows}
+        />
+      ) : view === "decisionPool" ? (
+        <DecisionPoolView
+          decisions={decisions}
+          facts={facts}
+          relations={relations}
+          focusedDecisionId={
+            focusedEntityRef?.startsWith("decision/")
+              ? focusedEntityRef.split("/")[1]
+              : null
+          }
+          onFocusGraph={onFocusEntityInGraph}
+        />
+      ) : view === "presets" ? (
+        <PresetsView presets={MOCK_PRESETS} project={project} />
+      ) : view === "adapters" ? (
+        <AdaptersView adapters={MOCK_ADAPTERS} tasks={projectTasks} />
+      ) : (
+        <SettingsView />
+      )}
+    </>
+  );
+}

--- a/packages/gui/src/renderer/components/taskDetail/DocTree.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/DocTree.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+import { CaretRight, CaretDown } from "@phosphor-icons/react";
+import type { DocTreeNode } from "../../model/docTree.ts";
+import { collectDirectoryPaths } from "../../model/docTree.ts";
+import { DocPresence } from "./widgets.tsx";
+
+/**
+ * 文档路径分段树(替代原来的 6-组扁平分组)。
+ *
+ * 支持展开 artifacts/ 及更深子目录。目录节点可折叠,文件节点点击选中。
+ * 默认展开根级目录,让用户一眼看到主要分区;嵌套目录折叠(避免过长)。
+ */
+interface DocTreeProps {
+  nodes: DocTreeNode[];
+  activeDoc: string;
+  onSelectDoc: (path: string) => void;
+}
+
+export function DocTree({ nodes, activeDoc, onSelectDoc }: DocTreeProps) {
+  // 默认展开根级目录(depth 0),让用户一眼看到主要分区。
+  const [expanded, setExpanded] = useState<Set<string>>(() =>
+    new Set(collectDirectoryPaths(nodes, 0)),
+  );
+
+  // 切换任务 / 文档清单刷新时,重置展开态到默认。
+  useEffect(() => {
+    setExpanded(new Set(collectDirectoryPaths(nodes, 0)));
+  }, [nodes]);
+
+  const toggle = (path: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  if (nodes.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border px-2 py-3 text-[12px] text-text-faint">
+        投影未返回文档清单
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      {nodes.map((node) => (
+        <TreeNodeView
+          key={node.path}
+          node={node}
+          depth={0}
+          expanded={expanded}
+          activeDoc={activeDoc}
+          onToggle={toggle}
+          onSelectDoc={onSelectDoc}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TreeNodeView({
+  node,
+  depth,
+  expanded,
+  activeDoc,
+  onToggle,
+  onSelectDoc,
+}: {
+  node: DocTreeNode;
+  depth: number;
+  expanded: Set<string>;
+  activeDoc: string;
+  onToggle: (path: string) => void;
+  onSelectDoc: (path: string) => void;
+}) {
+  const isExpanded = expanded.has(node.path);
+  const indent = depth * 12 + 4;
+
+  if (node.isDir) {
+    return (
+      <>
+        <button
+          onClick={() => onToggle(node.path)}
+          className="flex w-full items-center gap-1 rounded-md py-1 pr-2 text-left text-[12px] font-medium text-text-muted hover:text-text"
+          style={{ paddingLeft: indent }}
+        >
+          {isExpanded ? (
+            <CaretDown weight="bold" className="shrink-0 text-[10px] text-text-faint" />
+          ) : (
+            <CaretRight weight="bold" className="shrink-0 text-[10px] text-text-faint" />
+          )}
+          <span className="min-w-0 truncate">{node.name}/</span>
+          <span className="ml-auto shrink-0 font-mono text-[10px] text-text-faint">
+            {countDocs(node)}
+          </span>
+        </button>
+        {isExpanded &&
+          node.children.map((child) => (
+            <TreeNodeView
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              expanded={expanded}
+              activeDoc={activeDoc}
+              onToggle={onToggle}
+              onSelectDoc={onSelectDoc}
+            />
+          ))}
+      </>
+    );
+  }
+
+  const doc = node.doc;
+  if (!doc) return null;
+
+  return (
+    <button
+      onClick={() => onSelectDoc(doc.path)}
+      className={`flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left text-[13px] ${
+        activeDoc === doc.path
+          ? "bg-surface-raised text-text"
+          : "text-text-muted hover:text-text"
+      }`}
+      style={{ paddingLeft: indent + 14 }}
+    >
+      <DocPresence doc={doc} />
+      <span className="min-w-0 truncate">{doc.title}</span>
+      {doc.required && (
+        <span className="shrink-0 rounded border border-border px-1 text-[9px] text-text-faint">
+          必需
+        </span>
+      )}
+      {!doc.present && doc.required && (
+        <span
+          className="shrink-0 text-[10px]"
+          style={{ color: "var(--color-danger)" }}
+        >
+          缺失
+        </span>
+      )}
+    </button>
+  );
+}
+
+/** 递归统计目录下的文件数(含子目录)。 */
+function countDocs(node: DocTreeNode): number {
+  if (!node.isDir) return 0;
+  let count = 0;
+  for (const child of node.children) {
+    if (child.isDir) count += countDocs(child);
+    else count++;
+  }
+  return count;
+}

--- a/packages/gui/src/renderer/graph/focusHistory.ts
+++ b/packages/gui/src/renderer/graph/focusHistory.ts
@@ -1,23 +1,30 @@
 /**
  * GraphView 焦点历史栈(dec_01KXA7811SVVT8P66HNDFZQ7DF — 关系图可用性补齐)。
  *
- * 纯函数 + 显式 state,刻意不挂 React,以便 vitest 直接覆盖 back/forward/push
- * 三条核心迁移。GraphView 用 useState 持有 FocusHistoryState,变更走这里的函数。
+ * 迁移逻辑(back/forward/前向截断)住在 navigation/historyStack.ts,这里只提供
+ * 「条目 = 实体 id」这一种特化。纯函数 + 显式 state,刻意不挂 React,以便 vitest
+ * 直接覆盖三条核心迁移。
  *
  * 设计:
  *   - history 只收「主动切换焦点」的足迹:双击节点 / FocusSwitcher 点选 / 抽屉
  *     「设为焦点」按钮 / focusRef 跨视图带入。布局器自己挑的默认焦点不进栈,
  *     用户「退出聚焦」(关抽屉/点空白) 也不进栈 —— 这些都不算用户「跳到过」。
- *   - push 截断 forward 栈(经典浏览器语义):从历史中间换新焦点后,旧 future 作废。
- *   - 重复连推同 id 视为 no-op,避免点 Switcher 同一项把栈灌满。
+ *   - index=-1 表示当前焦点不在栈里(默认焦点 / 退出聚焦)。
  */
 
-export interface FocusHistoryState {
-  /** 完整足迹;back 从 [0,index-1] 取,forward 从 [index+1]。 */
-  entries: string[];
-  /** 当前焦点在 entries 中的下标;-1 表示当前不在历史里(默认焦点 / 退出聚焦)。 */
-  index: number;
-}
+import {
+  canGoBack,
+  canGoForward,
+  current,
+  goBack,
+  goForward,
+  push,
+  type HistoryState,
+} from "../navigation/historyStack.ts";
+
+export type FocusHistoryState = HistoryState<string>;
+
+export { canGoBack, canGoForward, goBack, goForward };
 
 export function createFocusHistory(): FocusHistoryState {
   return { entries: [], index: -1 };
@@ -25,40 +32,14 @@ export function createFocusHistory(): FocusHistoryState {
 
 /** 当前落在历史里的焦点 id;若 index=-1 返回 null(不代表「无焦点」,只代表「不在栈里」)。 */
 export function currentFocus(state: FocusHistoryState): string | null {
-  return state.index >= 0 && state.index < state.entries.length
-    ? state.entries[state.index]
-    : null;
+  return current(state);
 }
 
-export function canGoBack(state: FocusHistoryState): boolean {
-  return state.index > 0;
+/** 推一个新焦点。重复推同 id 不变(防误灌栈);截断 forward 栈。 */
+export function pushFocus(state: FocusHistoryState, id: string): FocusHistoryState {
+  return push(state, id, sameFocus);
 }
 
-export function canGoForward(state: FocusHistoryState): boolean {
-  return state.index >= 0 && state.index < state.entries.length - 1;
-}
-
-/**
- * 推一个新焦点。重复推同 id 不变(防误灌栈)。截断 forward 栈:
- * 从历史中间换焦点后,旧 future 作废。
- */
-export function pushFocus(
-  state: FocusHistoryState,
-  id: string,
-): FocusHistoryState {
-  if (currentFocus(state) === id) return state;
-  const nextIndex = state.index + 1;
-  const truncated = state.entries.slice(0, nextIndex);
-  truncated.push(id);
-  return { entries: truncated, index: nextIndex };
-}
-
-export function goBack(state: FocusHistoryState): FocusHistoryState {
-  if (!canGoBack(state)) return state;
-  return { ...state, index: state.index - 1 };
-}
-
-export function goForward(state: FocusHistoryState): FocusHistoryState {
-  if (!canGoForward(state)) return state;
-  return { ...state, index: state.index + 1 };
+function sameFocus(left: string, right: string): boolean {
+  return left === right;
 }

--- a/packages/gui/src/renderer/model/docTree.ts
+++ b/packages/gui/src/renderer/model/docTree.ts
@@ -1,0 +1,111 @@
+import type { DocEntry } from "./types.ts";
+
+/**
+ * 文档路径分段树。
+ *
+ * 后端放开后 documents DTO 含递归路径(artifacts/orchestration/report.md)。
+ * 原来的 inferDocGroup 把没匹配上的路径全倒进「进度」兜底桶,多层子目录全糊在一起。
+ * 本模块按真实目录结构建树,让用户能展开 artifacts/ 及更深子目录。
+ *
+ * 纯函数,不挂 React,vitest 直接覆盖。
+ */
+
+export interface DocTreeNode {
+  /** 展示名:文件用 DocEntry.title,目录用路径分段。 */
+  name: string;
+  /** 完整路径(文件=文档路径,目录=目录前缀)。 */
+  path: string;
+  isDir: boolean;
+  /** 仅叶子节点有:对应的文档条目。 */
+  doc?: DocEntry;
+  children: DocTreeNode[];
+}
+
+interface TrieNode {
+  name: string;
+  path: string;
+  doc?: DocEntry;
+  children: Map<string, TrieNode>;
+}
+
+/**
+ * 从扁平文档列表构建路径树。按目录优先 + 字母序排序。
+ *
+ * 形如:
+ *   artifacts/           (dir)
+ *     findings.md        (file)
+ *     orchestration/     (dir)
+ *       notes.md         (file)
+ *       report.md        (file)
+ *   INDEX.md             (file)
+ *   plan/                (dir)
+ *     task-plan.md       (file)
+ */
+export function buildDocTree(docs: readonly DocEntry[]): DocTreeNode[] {
+  const root = buildTrie(docs);
+  return flattenAndSort(root);
+}
+
+function buildTrie(docs: readonly DocEntry[]): Map<string, TrieNode> {
+  const root: Map<string, TrieNode> = new Map();
+  for (const doc of docs) {
+    const segments = doc.path.split("/").filter((s) => s.length > 0);
+    let level = root;
+    let path = "";
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i];
+      path = path ? `${path}/${seg}` : seg;
+      const isLeaf = i === segments.length - 1;
+      if (!level.has(seg)) {
+        const node: TrieNode = {
+          name: seg,
+          path,
+          children: new Map(),
+        };
+        if (isLeaf) node.doc = doc;
+        level.set(seg, node);
+      } else if (isLeaf) {
+        // 已作为目录存在,现在发现它也是文件(文件系统不会这样,但防御性处理)
+        level.get(seg)!.doc = doc;
+      }
+      level = level.get(seg)!.children;
+    }
+  }
+  return root;
+}
+
+function flattenAndSort(nodes: Map<string, TrieNode>): DocTreeNode[] {
+  const result: DocTreeNode[] = [];
+  for (const node of nodes.values()) {
+    const children = flattenAndSort(node.children);
+    result.push({
+      name: node.doc?.title ?? node.name,
+      path: node.path,
+      isDir: children.length > 0,
+      doc: node.doc,
+      children,
+    });
+  }
+  return sortNodes(result);
+}
+
+/** 目录优先,同类按名字字母序。 */
+function sortNodes(nodes: DocTreeNode[]): DocTreeNode[] {
+  return nodes.sort((a, b) => {
+    if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+/** 收集树中所有目录路径(用于默认展开根级目录)。 */
+export function collectDirectoryPaths(nodes: readonly DocTreeNode[], maxDepth = 0): string[] {
+  const paths: string[] = [];
+  function walk(node: DocTreeNode, depth: number) {
+    if (node.isDir && depth <= maxDepth) {
+      paths.push(node.path);
+      for (const child of node.children) walk(child, depth + 1);
+    }
+  }
+  for (const node of nodes) walk(node, 0);
+  return paths;
+}

--- a/packages/gui/src/renderer/navigation/historyStack.ts
+++ b/packages/gui/src/renderer/navigation/historyStack.ts
@@ -1,0 +1,76 @@
+/**
+ * 前向截断历史栈的泛型核心(经典浏览器语义)。
+ *
+ * 图内焦点历史(graph/focusHistory.ts,条目=实体 id)与应用位置历史
+ * (navigation/navigationHistory.ts,条目=AppLocation)只在两处不同:条目类型,
+ * 以及"两个条目算不算同一个"的判据。除此之外 back/forward/截断的迁移完全一致 ——
+ * 所以这里只存在一份实现,两边各自提供条目类型与相等性,不各写一遍。
+ *
+ * index = -1 表示"当前不在栈里"(图内的默认焦点 / 退出聚焦属于这种情况);
+ * 应用位置历史从 index=0 播种,永远落在栈里。
+ */
+
+export interface HistoryState<T> {
+  /** 完整足迹;back 从 [0,index-1] 取,forward 从 [index+1]。 */
+  entries: T[];
+  /** 当前条目在 entries 中的下标;-1 表示当前不在历史里。 */
+  index: number;
+}
+
+/** 当前落在历史里的条目;index=-1 时返回 null(不代表"没有条目",只代表"不在栈里")。 */
+export function current<T>(state: HistoryState<T>): T | null {
+  return state.index >= 0 && state.index < state.entries.length
+    ? state.entries[state.index]
+    : null;
+}
+
+export function canGoBack<T>(state: HistoryState<T>): boolean {
+  return state.index > 0;
+}
+
+export function canGoForward<T>(state: HistoryState<T>): boolean {
+  return state.index >= 0 && state.index < state.entries.length - 1;
+}
+
+/**
+ * 推一个新条目。与当前条目等价则 no-op(防误灌栈)。截断 forward 栈:
+ * 从历史中间推新条目后,旧 future 作废。
+ */
+export function push<T>(
+  state: HistoryState<T>,
+  entry: T,
+  equals: (a: T, b: T) => boolean,
+): HistoryState<T> {
+  const head = current(state);
+  if (head !== null && equals(head, entry)) return state;
+  const nextIndex = state.index + 1;
+  const truncated = state.entries.slice(0, nextIndex);
+  truncated.push(entry);
+  return { entries: truncated, index: nextIndex };
+}
+
+/**
+ * 原地更新当前条目(不推栈,不截断 forward)。用于非导航性的微调 ——
+ * 用户"调了一下筛选"不该单独占一个历史条目,但下次导航的快照里应带上最新值。
+ */
+export function patch<T>(
+  state: HistoryState<T>,
+  entry: T,
+  equals: (a: T, b: T) => boolean,
+): HistoryState<T> {
+  const head = current(state);
+  if (head === null || equals(head, entry)) return state;
+  const entries = state.entries.slice();
+  entries[state.index] = entry;
+  return { entries, index: state.index };
+}
+
+export function goBack<T>(state: HistoryState<T>): HistoryState<T> {
+  if (!canGoBack(state)) return state;
+  return { ...state, index: state.index - 1 };
+}
+
+export function goForward<T>(state: HistoryState<T>): HistoryState<T> {
+  if (!canGoForward(state)) return state;
+  return { ...state, index: state.index + 1 };
+}

--- a/packages/gui/src/renderer/navigation/navigationHistory.ts
+++ b/packages/gui/src/renderer/navigation/navigationHistory.ts
@@ -2,6 +2,16 @@ import type { TaskFilters } from "../model/taskFilters.ts";
 import type { SnapshotStatus } from "../model/types.ts";
 import type { LaneGroupBy } from "../views/SwimlaneBoard.tsx";
 import type { ViewId } from "../shell-config.tsx";
+import {
+  canGoBack,
+  canGoForward,
+  current,
+  goBack,
+  goForward,
+  patch,
+  push,
+  type HistoryState,
+} from "./historyStack.ts";
 
 /**
  * AppShell 级全局导航历史(泛化自 graph/focusHistory.ts)。
@@ -11,8 +21,10 @@ import type { ViewId } from "../shell-config.tsx";
  * 「我在哪」的全部六个状态(view / selectedId / previewId / focusedEntityRef /
  * taskFilters / drill),让后退/前进能跨视图还原用户的位置。
  *
- * 语义与 focusHistory 完全一致:
- *   - push 截断 forward 栈(经典浏览器语义):从历史中间换位置后,旧 future 作废。
+ * 迁移逻辑(back/forward/前向截断/原地更新)与 focusHistory 共用同一个泛型核心
+ * historyStack.ts —— 两者只在「条目类型」与「两个条目算不算同一个」上不同,
+ * 不各写一遍。本模块只提供 AppLocation 这一种特化:
+ *   - pushLocation 截断 forward 栈(经典浏览器语义):从历史中间换位置后,旧 future 作废。
  *   - 重复推相同位置视为 no-op,避免把栈灌满。
  *   - patchCurrent 原地更新当前位置(不推栈)——用于过滤器微调、抽屉开关等
  *     非导航性变更,不单独占一个历史条目,但快照里保留最新值。
@@ -35,27 +47,18 @@ export interface AppLocation {
   drill: DrillState | null;
 }
 
-export interface NavigationHistoryState {
-  /** 完整足迹;back 从 [0,index-1] 取,forward 从 [index+,index]。 */
-  entries: AppLocation[];
-  /** 当前位置在 entries 中的下标。 */
-  index: number;
-}
+export type NavigationHistoryState = HistoryState<AppLocation>;
+
+export { canGoBack, canGoForward, goBack, goForward };
 
 export function createNavigationHistory(initial: AppLocation): NavigationHistoryState {
   return { entries: [initial], index: 0 };
 }
 
 export function currentLocation(state: NavigationHistoryState): AppLocation {
-  return state.entries[state.index];
-}
-
-export function canGoBack(state: NavigationHistoryState): boolean {
-  return state.index > 0;
-}
-
-export function canGoForward(state: NavigationHistoryState): boolean {
-  return state.index < state.entries.length - 1;
+  const head = current(state);
+  if (head === null) throw new Error("navigation history is always seeded with an initial location");
+  return head;
 }
 
 /** 结构化比较两个应用位置是否等价(taskFilters / drill 含嵌套结构,走 JSON 序列化)。 */
@@ -78,11 +81,7 @@ export function pushLocation(
   state: NavigationHistoryState,
   next: AppLocation,
 ): NavigationHistoryState {
-  if (locationsEqual(currentLocation(state), next)) return state;
-  const nextIndex = state.index + 1;
-  const truncated = state.entries.slice(0, nextIndex);
-  truncated.push(next);
-  return { entries: truncated, index: nextIndex };
+  return push(state, next, locationsEqual);
 }
 
 /**
@@ -91,22 +90,7 @@ export function pushLocation(
  */
 export function patchCurrent(
   state: NavigationHistoryState,
-  patch: Partial<AppLocation>,
+  fields: Partial<AppLocation>,
 ): NavigationHistoryState {
-  const current = currentLocation(state);
-  const updated: AppLocation = { ...current, ...patch };
-  if (locationsEqual(current, updated)) return state;
-  const entries = state.entries.slice();
-  entries[state.index] = updated;
-  return { entries, index: state.index };
-}
-
-export function goBack(state: NavigationHistoryState): NavigationHistoryState {
-  if (!canGoBack(state)) return state;
-  return { ...state, index: state.index - 1 };
-}
-
-export function goForward(state: NavigationHistoryState): NavigationHistoryState {
-  if (!canGoForward(state)) return state;
-  return { ...state, index: state.index + 1 };
+  return patch(state, { ...currentLocation(state), ...fields }, locationsEqual);
 }

--- a/packages/gui/src/renderer/navigation/navigationHistory.ts
+++ b/packages/gui/src/renderer/navigation/navigationHistory.ts
@@ -1,0 +1,112 @@
+import type { TaskFilters } from "../model/taskFilters.ts";
+import type { SnapshotStatus } from "../model/types.ts";
+import type { LaneGroupBy } from "../views/SwimlaneBoard.tsx";
+import type { ViewId } from "../shell-config.tsx";
+
+/**
+ * AppShell 级全局导航历史(泛化自 graph/focusHistory.ts)。
+ *
+ * focusHistory 只记一个 node id,活在 GraphView 里,离开图就销毁。本模块把
+ * 「历史条目」从 node id 泛化成完整的应用位置快照(AppLocation)——涵盖构成
+ * 「我在哪」的全部六个状态(view / selectedId / previewId / focusedEntityRef /
+ * taskFilters / drill),让后退/前进能跨视图还原用户的位置。
+ *
+ * 语义与 focusHistory 完全一致:
+ *   - push 截断 forward 栈(经典浏览器语义):从历史中间换位置后,旧 future 作废。
+ *   - 重复推相同位置视为 no-op,避免把栈灌满。
+ *   - patchCurrent 原地更新当前位置(不推栈)——用于过滤器微调、抽屉开关等
+ *     非导航性变更,不单独占一个历史条目,但快照里保留最新值。
+ *
+ * 纯函数 + 显式 state,刻意不挂 React,以便 vitest 直接覆盖。
+ */
+
+export interface DrillState {
+  lane: string;
+  status: SnapshotStatus;
+  groupBy: LaneGroupBy;
+}
+
+export interface AppLocation {
+  view: ViewId;
+  selectedId: string | null;
+  previewId: string | null;
+  focusedEntityRef: string | null;
+  taskFilters: TaskFilters;
+  drill: DrillState | null;
+}
+
+export interface NavigationHistoryState {
+  /** 完整足迹;back 从 [0,index-1] 取,forward 从 [index+,index]。 */
+  entries: AppLocation[];
+  /** 当前位置在 entries 中的下标。 */
+  index: number;
+}
+
+export function createNavigationHistory(initial: AppLocation): NavigationHistoryState {
+  return { entries: [initial], index: 0 };
+}
+
+export function currentLocation(state: NavigationHistoryState): AppLocation {
+  return state.entries[state.index];
+}
+
+export function canGoBack(state: NavigationHistoryState): boolean {
+  return state.index > 0;
+}
+
+export function canGoForward(state: NavigationHistoryState): boolean {
+  return state.index < state.entries.length - 1;
+}
+
+/** 结构化比较两个应用位置是否等价(taskFilters / drill 含嵌套结构,走 JSON 序列化)。 */
+export function locationsEqual(a: AppLocation, b: AppLocation): boolean {
+  return (
+    a.view === b.view &&
+    a.selectedId === b.selectedId &&
+    a.previewId === b.previewId &&
+    a.focusedEntityRef === b.focusedEntityRef &&
+    JSON.stringify(a.taskFilters) === JSON.stringify(b.taskFilters) &&
+    JSON.stringify(a.drill) === JSON.stringify(b.drill)
+  );
+}
+
+/**
+ * 推一个新位置。与当前位置相同则 no-op(防误灌栈)。截断 forward 栈:
+ * 从历史中间换位置后,旧 future 作废。
+ */
+export function pushLocation(
+  state: NavigationHistoryState,
+  next: AppLocation,
+): NavigationHistoryState {
+  if (locationsEqual(currentLocation(state), next)) return state;
+  const nextIndex = state.index + 1;
+  const truncated = state.entries.slice(0, nextIndex);
+  truncated.push(next);
+  return { entries: truncated, index: nextIndex };
+}
+
+/**
+ * 原地更新当前位置(不推栈)。用于过滤器微调等非导航性变更——
+ * 用户「调了一下筛选」不该单独占一个历史条目,但下次导航的快照里应带上最新值。
+ */
+export function patchCurrent(
+  state: NavigationHistoryState,
+  patch: Partial<AppLocation>,
+): NavigationHistoryState {
+  const current = currentLocation(state);
+  const updated: AppLocation = { ...current, ...patch };
+  if (locationsEqual(current, updated)) return state;
+  const entries = state.entries.slice();
+  entries[state.index] = updated;
+  return { entries, index: state.index };
+}
+
+export function goBack(state: NavigationHistoryState): NavigationHistoryState {
+  if (!canGoBack(state)) return state;
+  return { ...state, index: state.index - 1 };
+}
+
+export function goForward(state: NavigationHistoryState): NavigationHistoryState {
+  if (!canGoForward(state)) return state;
+  return { ...state, index: state.index + 1 };
+}

--- a/packages/gui/src/renderer/navigation/useNavigationHistory.ts
+++ b/packages/gui/src/renderer/navigation/useNavigationHistory.ts
@@ -1,0 +1,64 @@
+import { useCallback, useState } from "react";
+import type { AppLocation, NavigationHistoryState } from "./navigationHistory.ts";
+import {
+  canGoBack,
+  canGoForward,
+  createNavigationHistory,
+  currentLocation,
+  goBack as historyGoBack,
+  goForward as historyGoForward,
+  patchCurrent,
+  pushLocation,
+} from "./navigationHistory.ts";
+
+/**
+ * AppShell 全局导航历史 hook。
+ *
+ * 历史栈是应用位置的**唯一真源**:entries[index] 即当前位置,所有读取走
+ * `location.*`,所有变更走 `navigate()` 或 `updateLocation()`。
+ *
+ * - `navigate(patch)`:合并 patch 到当前位置 → 推入历史(截断 forward)。
+ *   用于视图切换、跨实体跳转、打开任务详情等「导航」。
+ * - `updateLocation(patch)`:合并 patch 到当前位置 → 原地改(不推栈)。
+ *   用于过滤器微调、抽屉开关等「精修」——不该单独占一个历史条目。
+ *
+ * 这个设计让「所有导航都进历史栈」成为**结构性不变量**:没有独立的
+ * setView / setSelectedId / ... —— 下一个改 App.tsx 的人想绕过历史栈,
+ * 得先把 setter 加回来,而 navigationHistory.vitest.ts 的源码扫描会拦住。
+ */
+export function useNavigationHistory(initial: AppLocation) {
+  const [history, setHistory] = useState<NavigationHistoryState>(() =>
+    createNavigationHistory(initial),
+  );
+
+  const location = currentLocation(history);
+
+  const navigate = useCallback((patch: Partial<AppLocation>) => {
+    setHistory((prev) => {
+      const next: AppLocation = { ...currentLocation(prev), ...patch };
+      return pushLocation(prev, next);
+    });
+  }, []);
+
+  const updateLocation = useCallback((patch: Partial<AppLocation>) => {
+    setHistory((prev) => patchCurrent(prev, patch));
+  }, []);
+
+  const back = useCallback(() => {
+    setHistory((prev) => historyGoBack(prev));
+  }, []);
+
+  const forward = useCallback(() => {
+    setHistory((prev) => historyGoForward(prev));
+  }, []);
+
+  return {
+    location,
+    navigate,
+    updateLocation,
+    back,
+    forward,
+    canBack: canGoBack(history),
+    canForward: canGoForward(history),
+  };
+}

--- a/packages/gui/src/renderer/shell-config.tsx
+++ b/packages/gui/src/renderer/shell-config.tsx
@@ -1,0 +1,74 @@
+import {
+  Kanban,
+  SquaresFour,
+  Graph,
+  Scales,
+  Stack,
+  PlugsConnected,
+  GearSix,
+  GitBranch,
+  FirstAidKit,
+  ClockCounterClockwise,
+  ClipboardText,
+} from "@phosphor-icons/react";
+
+/**
+ * AppShell 级常量与类型:ViewId 路由表 + 导航分组 + 视图标签。
+ *
+ * 从 App.tsx 抽出(历史栈任务的前置拆分),让 AppSidebar / ViewSwitch / AppShell
+ * 共用同一份路由定义,避免三份拷贝漂移。
+ */
+
+export type ViewId =
+  | "home"
+  | "overview"
+  | "board"
+  | "decisions"
+  | "decisionPool"
+  | "factTriage"
+  | "executions"
+  | "graph"
+  | "genealogy"
+  | "presets"
+  | "adapters"
+  | "settings";
+
+// 这些视图的数据仍为 mock:preset/adapter 管理面无真实后端。进入时顶部显式挂 MOCK 横幅。
+export const MOCK_BACKED_VIEWS: ReadonlySet<ViewId> = new Set([
+  "home",
+  "presets",
+  "adapters",
+]);
+
+// W2C:列表并入看板(第三种 layout),独立「列表」入口删除。
+export const WORKSPACE_NAV: { id: ViewId; label: string; icon: React.ReactNode; isNew?: true }[] = [
+  { id: "overview", label: "总览", icon: <SquaresFour weight="duotone" /> },
+  { id: "board", label: "看板", icon: <Kanban weight="duotone" /> },
+  { id: "decisions", label: "决策批准", icon: <Scales weight="duotone" /> },
+  { id: "decisionPool", label: "决策池", icon: <GitBranch weight="duotone" /> },
+  { id: "factTriage", label: "事实分诊", icon: <FirstAidKit weight="duotone" /> },
+  { id: "executions", label: "执行证据", icon: <ClipboardText weight="duotone" />, isNew: true },
+  { id: "graph", label: "关系图", icon: <Graph weight="duotone" /> },
+  { id: "genealogy", label: "演化史", icon: <ClockCounterClockwise weight="duotone" /> },
+];
+
+export const MANAGE_NAV: { id: ViewId; label: string; icon: React.ReactNode }[] = [
+  { id: "presets", label: "Preset / Vertical", icon: <Stack weight="duotone" /> },
+  { id: "adapters", label: "引擎 Adapter", icon: <PlugsConnected weight="duotone" /> },
+  { id: "settings", label: "设置", icon: <GearSix weight="duotone" /> },
+];
+
+export const VIEW_LABEL: Record<ViewId, string> = {
+  home: "项目",
+  overview: "总览",
+  board: "看板",
+  decisions: "决策批准",
+  decisionPool: "决策池",
+  factTriage: "事实分诊",
+  executions: "执行证据",
+  graph: "关系图",
+  genealogy: "演化史",
+  presets: "Preset / Vertical",
+  adapters: "引擎 Adapter",
+  settings: "设置",
+};

--- a/packages/gui/src/renderer/views/TaskDetailView.tsx
+++ b/packages/gui/src/renderer/views/TaskDetailView.tsx
@@ -17,7 +17,7 @@ import type {
   TaskRow,
   RelationEdge,
 } from "../model/types";
-import { isExternal, isTerminal, DOC_GROUPS } from "../model/types";
+import { isExternal, isTerminal } from "../model/types";
 import {
   STATUS_META,
   StatusBadge,
@@ -33,9 +33,11 @@ import {
   OUT_LABEL,
   IN_LABEL,
 } from "../components/taskDetail/constants";
-import { AxisRow, DocPresence } from "../components/taskDetail/widgets";
+import { AxisRow } from "../components/taskDetail/widgets";
 import { PhaseSteps } from "../components/taskDetail/PhaseSteps";
 import { RelationRow } from "../components/taskDetail/RelationRow";
+import { DocTree } from "../components/taskDetail/DocTree";
+import { buildDocTree } from "../model/docTree";
 import { normalizeTaskId, spawningDecisionOf } from "../model/triadic";
 import { useTaskDetailQuery, useTaskDocumentQuery, useReviewTaskMutation } from "../task-data";
 
@@ -177,11 +179,9 @@ export function TaskDetailView({
       };
     });
   }, [detailQuery.data, task.docs]);
-  // 文档清单只看必读/计划/设计/进度/收口/证据 6 组;其他归入进度(滚动日志)。
-  const docGroups = useMemo(
-    () => DOC_GROUPS.filter((g) => realDocs.some((d) => d.group === g)),
-    [realDocs],
-  );
+  // 文档路径分段树:按真实目录结构(artifacts/ 及更深子目录可展开),
+  // 替代原来的 6-组扁平分组(inferDocGroup 把没匹配上的路径全倒进兜底桶)。
+  const docTree = useMemo(() => buildDocTree(realDocs), [realDocs]);
 
   const [activeDoc, setActiveDoc] = useState(
     () => realDocs[0]?.path ?? task.docs[0]?.path ?? "",
@@ -239,57 +239,13 @@ export function TaskDetailView({
       </header>
 
       <div className="flex min-h-0 flex-1">
-        {/* 文档目录树 */}
+        {/* 文档目录树(路径分段树,支持展开 artifacts/ 及更深子目录) */}
         <nav className="w-56 shrink-0 overflow-y-auto border-r border-border bg-surface p-3">
-          {docGroups.length === 0 ? (
-            <div className="rounded-md border border-dashed border-border px-2 py-3 text-[12px] text-text-faint">
-              投影未返回文档清单
-            </div>
-          ) : (
-            docGroups.map((g) => {
-              const groupDocs = realDocs.filter((d) => d.group === g);
-              const presentCount = groupDocs.filter((d) => d.present).length;
-              return (
-                <div key={g} className="mb-3">
-                  <div className="flex items-center justify-between px-1 pb-1">
-                    <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
-                      {g}
-                    </span>
-                    <span className="font-mono text-[10px] text-text-faint">
-                      {presentCount}/{groupDocs.length}
-                    </span>
-                  </div>
-                  {groupDocs.map((d) => (
-                    <button
-                      key={d.path}
-                      onClick={() => setActiveDoc(d.path)}
-                      className={`flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-left text-[13px] ${
-                        activeDoc === d.path
-                          ? "bg-surface-raised text-text"
-                          : "text-text-muted hover:text-text"
-                      }`}
-                    >
-                      <DocPresence doc={d} />
-                      <span className="min-w-0 truncate">{d.title}</span>
-                      {d.required && (
-                        <span className="shrink-0 rounded border border-border px-1 text-[9px] text-text-faint">
-                          必需
-                        </span>
-                      )}
-                      {!d.present && d.required && (
-                        <span
-                          className="shrink-0 text-[10px]"
-                          style={{ color: "var(--color-danger)" }}
-                        >
-                          缺失
-                        </span>
-                      )}
-                    </button>
-                  ))}
-                </div>
-              );
-            })
-          )}
+          <DocTree
+            nodes={docTree}
+            activeDoc={activeDoc}
+            onSelectDoc={setActiveDoc}
+          />
         </nav>
 
         {/* 文档阅读区 */}

--- a/packages/gui/test/docTree.vitest.ts
+++ b/packages/gui/test/docTree.vitest.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDocTree,
+  collectDirectoryPaths,
+} from "../src/renderer/model/docTree.ts";
+import type { DocEntry } from "../src/renderer/model/types.ts";
+
+/**
+ * 文档路径分段树测试。
+ *
+ * 后端放开后 documents DTO 含递归路径(artifacts/orchestration/report.md)。
+ * 原来的 inferDocGroup 把没匹配上的路径全倒进「进度」兜底桶。本测试验证
+ * buildDocTree 按真实目录结构建树,支持多层嵌套。
+ */
+
+function doc(path: string, overrides: Partial<DocEntry> = {}): DocEntry {
+  return {
+    path,
+    title: path.split("/").pop() ?? path,
+    group: "进度",
+    required: false,
+    present: true,
+    ...overrides,
+  };
+}
+
+describe("buildDocTree basic structure", () => {
+  it("renders flat files as root-level leaves", () => {
+    const tree = buildDocTree([
+      doc("INDEX.md"),
+      doc("progress.md"),
+    ]);
+    expect(tree).toHaveLength(2);
+    expect(tree.every((n) => !n.isDir)).toBe(true);
+    expect(tree.map((n) => n.path)).toEqual(["INDEX.md", "progress.md"]);
+  });
+
+  it("returns an empty array for no documents", () => {
+    expect(buildDocTree([])).toEqual([]);
+  });
+});
+
+describe("buildDocTree nested directories", () => {
+  const tree = buildDocTree([
+    doc("INDEX.md"),
+    doc("progress.md"),
+    doc("plan/task-plan.md"),
+    doc("artifacts/findings.md"),
+    doc("artifacts/orchestration/report.md"),
+    doc("artifacts/orchestration/notes.md", { present: false }),
+  ]);
+
+  it("groups files under their parent directories", () => {
+    // Root: 2 dirs (artifacts, plan) + 2 files (INDEX, progress) — dirs first
+    expect(tree.map((n) => n.name)).toEqual([
+      "artifacts",
+      "plan",
+      "INDEX.md",
+      "progress.md",
+    ]);
+
+    const artifacts = tree[0];
+    expect(artifacts.isDir).toBe(true);
+    expect(artifacts.children.map((n) => n.name)).toEqual([
+      "orchestration",
+      "findings.md",
+    ]);
+
+    const orchestration = artifacts.children[0];
+    expect(orchestration.isDir).toBe(true);
+    expect(orchestration.children.map((n) => n.name)).toEqual([
+      "notes.md",
+      "report.md",
+    ]);
+  });
+
+  it("preserves DocEntry on leaf nodes (present/required/title)", () => {
+    const artifacts = tree[0];
+    const orchestration = artifacts.children[0];
+    const notes = orchestration.children[0];
+    expect(notes.doc?.present).toBe(false);
+    expect(notes.doc?.path).toBe("artifacts/orchestration/notes.md");
+
+    const report = orchestration.children[1];
+    expect(report.doc?.present).toBe(true);
+  });
+
+  it("sets isDir=false on leaf nodes and isDir=true on branch nodes", () => {
+    const plan = tree[1];
+    expect(plan.isDir).toBe(true);
+    expect(plan.children[0].isDir).toBe(false);
+  });
+
+  it("sorts directories before files, alphabetical within each group", () => {
+    // At root: artifacts/ and plan/ (dirs) before INDEX.md and progress.md (files)
+    expect(tree[0].isDir).toBe(true);
+    expect(tree[1].isDir).toBe(true);
+    expect(tree[2].isDir).toBe(false);
+    expect(tree[3].isDir).toBe(false);
+    expect(tree[0].name).toBe("artifacts");
+    expect(tree[1].name).toBe("plan");
+  });
+});
+
+describe("buildDocTree deep nesting", () => {
+  it("handles arbitrarily deep paths (4+ levels)", () => {
+    const tree = buildDocTree([
+      doc("a/b/c/d/e.md"),
+      doc("a/b/f.md"),
+      doc("a/g.md"),
+    ]);
+
+    expect(tree).toHaveLength(1);
+    const a = tree[0];
+    expect(a.name).toBe("a");
+    expect(a.children.map((n) => n.name)).toEqual(["b", "g.md"]);
+
+    const b = a.children[0];
+    expect(b.children.map((n) => n.name)).toEqual(["c", "f.md"]);
+
+    const c = b.children[0];
+    expect(c.children.map((n) => n.name)).toEqual(["d"]);
+
+    const d = c.children[0];
+    expect(d.children.map((n) => n.name)).toEqual(["e.md"]);
+    expect(d.children[0].doc?.path).toBe("a/b/c/d/e.md");
+  });
+
+  it("merges files at different depths under the same ancestor", () => {
+    const tree = buildDocTree([
+      doc("artifacts/top.md"),
+      doc("artifacts/deep/inner.md"),
+    ]);
+
+    const artifacts = tree[0];
+    expect(artifacts.children.map((n) => n.name)).toEqual(["deep", "top.md"]);
+    expect(artifacts.children[0].children[0].doc?.path).toBe("artifacts/deep/inner.md");
+  });
+});
+
+describe("buildDocTree title display", () => {
+  it("uses DocEntry.title for file display name, not raw filename", () => {
+    const tree = buildDocTree([
+      doc("plan/task-plan.md", { title: "任务计划" }),
+    ]);
+    const plan = tree[0];
+    expect(plan.name).toBe("plan"); // directory uses segment name
+    expect(plan.children[0].name).toBe("任务计划"); // file uses title
+  });
+});
+
+describe("collectDirectoryPaths", () => {
+  it("collects directory paths up to maxDepth", () => {
+    const tree = buildDocTree([
+      doc("a/b.md"),
+      doc("x/y/z.md"),
+    ]);
+
+    // depth 0: top-level dirs only
+    expect(collectDirectoryPaths(tree, 0).sort()).toEqual(["a", "x"]);
+
+    // depth 1: include second-level dirs
+    expect(collectDirectoryPaths(tree, 1).sort()).toEqual(["a", "x", "x/y"]);
+  });
+
+  it("with maxDepth=0 returns only root directories (for default expand)", () => {
+    const tree = buildDocTree([
+      doc("artifacts/inner/deep.md"),
+      doc("plan/task.md"),
+    ]);
+    const rootDirs = collectDirectoryPaths(tree, 0);
+    expect(rootDirs.sort()).toEqual(["artifacts", "plan"]);
+  });
+});

--- a/packages/gui/test/navigationHistory.vitest.ts
+++ b/packages/gui/test/navigationHistory.vitest.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  canGoBack,
+  canGoForward,
+  createNavigationHistory,
+  currentLocation,
+  goBack,
+  goForward,
+  locationsEqual,
+  patchCurrent,
+  pushLocation,
+  type AppLocation,
+} from "../src/renderer/navigation/navigationHistory.ts";
+import { DEFAULT_TASK_FILTERS } from "../src/renderer/model/taskFilters.ts";
+
+/**
+ * AppShell 全局导航历史栈测试。
+ *
+ * 两组覆盖:
+ * 1. 纯函数:push / back / forward / truncate / dedup / patchCurrent —
+ *    泛化自 graphNavigation.vitest.ts,语义不变,只是条目从 string 变成 AppLocation。
+ * 2. 源码不变量:App.tsx 不得重新引入直接的位置-state setter(所有导航必须走
+ *    navigate / updateLocation)。这是「所有导航都进历史栈」的机械保护——下一个
+ *    改 App.tsx 的人如果偷偷加回 setView(...) 等,本测试会拦住。
+ */
+
+function location(overrides: Partial<AppLocation> = {}): AppLocation {
+  return {
+    view: "overview",
+    selectedId: null,
+    previewId: null,
+    focusedEntityRef: null,
+    taskFilters: DEFAULT_TASK_FILTERS,
+    drill: null,
+    ...overrides,
+  };
+}
+
+describe("navigationHistory create + current", () => {
+  it("seeds history with the initial location at index 0", () => {
+    const initial = location({ view: "board" });
+    const state = createNavigationHistory(initial);
+    expect(state.entries).toHaveLength(1);
+    expect(state.index).toBe(0);
+    expect(currentLocation(state)).toEqual(initial);
+    expect(canGoBack(state)).toBe(false);
+    expect(canGoForward(state)).toBe(false);
+  });
+});
+
+describe("navigationHistory push", () => {
+  it("pushes a new location and advances the index", () => {
+    const state = createNavigationHistory(location());
+    const next = pushLocation(state, location({ view: "board" }));
+    expect(next.entries).toHaveLength(2);
+    expect(next.index).toBe(1);
+    expect(currentLocation(next).view).toBe("board");
+  });
+
+  it("does not push an equivalent location (dedup)", () => {
+    const initial = location({ view: "board", selectedId: "task-1" });
+    const state = createNavigationHistory(initial);
+    const same = pushLocation(state, location({ view: "board", selectedId: "task-1" }));
+    expect(same).toBe(state);
+    expect(same.entries).toHaveLength(1);
+  });
+
+  it("pushes when any field differs (view, selectedId, focusedEntityRef, drill)", () => {
+    const state = createNavigationHistory(location({ view: "overview" }));
+
+    expect(pushLocation(state, location({ view: "board" })).entries).toHaveLength(2);
+    expect(
+      pushLocation(state, location({ selectedId: "task-1" })).entries,
+    ).toHaveLength(2);
+    expect(
+      pushLocation(state, location({ focusedEntityRef: "decision/d1" })).entries,
+    ).toHaveLength(2);
+  });
+
+  it("detects taskFilters differences structurally (not by reference)", () => {
+    const state = createNavigationHistory(location());
+    const changedFilters = {
+      ...DEFAULT_TASK_FILTERS,
+      query: "blocking",
+    };
+    const next = pushLocation(state, location({ taskFilters: changedFilters }));
+    expect(next.entries).toHaveLength(2);
+    expect(currentLocation(next).taskFilters.query).toBe("blocking");
+  });
+
+  it("detects drill differences structurally", () => {
+    const state = createNavigationHistory(location());
+    const withDrill = pushLocation(state, location({
+      view: "board",
+      drill: { lane: "root", status: "blocked", groupBy: "root" as const },
+    }));
+    expect(withDrill.entries).toHaveLength(2);
+    expect(currentLocation(withDrill).drill).toEqual({
+      lane: "root",
+      status: "blocked",
+      groupBy: "root",
+    });
+  });
+});
+
+describe("navigationHistory forward truncation", () => {
+  it("truncates the forward stack when pushing after going back", () => {
+    let state = createNavigationHistory(location({ view: "overview" }));
+    state = pushLocation(state, location({ view: "board" }));
+    state = pushLocation(state, location({ view: "graph" }));
+    expect(state.entries.map((e) => e.view)).toEqual(["overview", "board", "graph"]);
+
+    state = goBack(state); // board
+    state = goBack(state); // overview
+    expect(currentLocation(state).view).toBe("overview");
+    expect(canGoForward(state)).toBe(true);
+
+    state = pushLocation(state, location({ view: "decisions" }));
+    expect(state.entries.map((e) => e.view)).toEqual(["overview", "decisions"]);
+    expect(state.index).toBe(1);
+    expect(canGoForward(state)).toBe(false);
+  });
+});
+
+describe("navigationHistory back/forward", () => {
+  it("goBack is a no-op at the head of history", () => {
+    const state = createNavigationHistory(location());
+    expect(goBack(state)).toBe(state);
+  });
+
+  it("goForward is a no-op at the tip of history", () => {
+    const state = createNavigationHistory(location());
+    expect(goForward(state)).toBe(state);
+  });
+
+  it("moves back and forward through the stack", () => {
+    let state = createNavigationHistory(location({ view: "overview" }));
+    state = pushLocation(state, location({ view: "board", selectedId: "t1" }));
+    state = pushLocation(state, location({ view: "graph", focusedEntityRef: "task/t1" }));
+
+    state = goBack(state);
+    expect(currentLocation(state).view).toBe("board");
+    expect(currentLocation(state).selectedId).toBe("t1");
+    state = goBack(state);
+    expect(currentLocation(state).view).toBe("overview");
+    expect(currentLocation(state).selectedId).toBeNull();
+
+    state = goForward(state);
+    expect(currentLocation(state).view).toBe("board");
+    state = goForward(state);
+    expect(currentLocation(state).view).toBe("graph");
+    expect(currentLocation(state).focusedEntityRef).toBe("task/t1");
+  });
+});
+
+describe("navigationHistory patchCurrent", () => {
+  it("updates the current entry in place without pushing", () => {
+    const state = createNavigationHistory(location({ view: "board" }));
+    const patched = patchCurrent(state, { taskFilters: { ...DEFAULT_TASK_FILTERS, query: "x" } });
+    expect(patched.entries).toHaveLength(1);
+    expect(currentLocation(patched).taskFilters.query).toBe("x");
+  });
+
+  it("is a no-op when the patch produces an equivalent location", () => {
+    const state = createNavigationHistory(location({ view: "board" }));
+    expect(patchCurrent(state, { view: "board" })).toBe(state);
+  });
+
+  it("preserves forward stack (does not truncate)", () => {
+    let state = createNavigationHistory(location({ view: "overview" }));
+    state = pushLocation(state, location({ view: "board" }));
+    state = goBack(state); // at overview, board is forward
+    const patched = patchCurrent(state, { selectedId: "t1" });
+    expect(patched.entries).toHaveLength(2);
+    expect(canGoForward(patched)).toBe(true);
+    expect(currentLocation(patched).selectedId).toBe("t1");
+  });
+});
+
+describe("navigationHistory locationsEqual", () => {
+  it("returns true for deeply equal locations", () => {
+    const a = location({ view: "board", drill: { lane: "root", status: "blocked", groupBy: "root" as const } });
+    const b = location({ view: "board", drill: { lane: "root", status: "blocked", groupBy: "root" as const } });
+    expect(locationsEqual(a, b)).toBe(true);
+  });
+
+  it("returns false when taskFilters content differs", () => {
+    const a = location({ taskFilters: { ...DEFAULT_TASK_FILTERS, query: "a" } });
+    const b = location({ taskFilters: { ...DEFAULT_TASK_FILTERS, query: "b" } });
+    expect(locationsEqual(a, b)).toBe(false);
+  });
+});
+
+// ── 源码不变量:所有导航入口必须汇流到 navigate() ──────────────────
+// App.tsx 曾经有六个并排的 useState 构成「应用位置」,其中四个导航入口绕过了
+// goto 直接改 state,历史栈会漏记。重构后位置状态由 useNavigationHistory 持有,
+// 变更只走 navigate / updateLocation。如果下一个改 App.tsx 的人加回了直接 setter,
+// 本测试拦住——这是 N1 唯一真正的不变量。
+describe("App.tsx navigation funnel invariant", () => {
+  const appSource = readFileSync(
+    path.resolve(import.meta.dirname, "../src/renderer/App.tsx"),
+    "utf-8",
+  );
+
+  const BANNED_SETTERS = [
+    "setView(",
+    "setSelectedId(",
+    "setPreviewId(",
+    "setFocusedEntityRef(",
+    "setDrill(",
+    "setTaskFilters(",
+  ];
+
+  it("does not reintroduce direct location-state setters", () => {
+    const offenders = BANNED_SETTERS.filter((token) => appSource.includes(token));
+    expect(offenders).toEqual([]);
+  });
+
+  it("routes location changes through navigate() and updateLocation()", () => {
+    expect(appSource).toContain("navigate(");
+    expect(appSource).toContain("updateLocation(");
+    expect(appSource).toContain("useNavigationHistory(");
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -1,5 +1,6 @@
 export const guiVitestManifest = [
   "packages/gui/test/renderer-app-model.vitest.ts",
+  "packages/gui/test/navigationHistory.vitest.ts",
   "packages/gui/test/fact-triage.vitest.ts",
   "packages/gui/test/taskFilters.vitest.ts",
   "packages/gui/test/task-adapter.vitest.ts",

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -1,6 +1,7 @@
 export const guiVitestManifest = [
   "packages/gui/test/renderer-app-model.vitest.ts",
   "packages/gui/test/navigationHistory.vitest.ts",
+  "packages/gui/test/docTree.vitest.ts",
   "packages/gui/test/fact-triage.vitest.ts",
   "packages/gui/test/taskFilters.vitest.ts",
   "packages/gui/test/task-adapter.vitest.ts",


### PR DESCRIPTION
# English

## Summary

Two gaps found while dogfooding the three-layer graph IA: the app had no global back/forward, and the Task detail view could not show a task package's subdirectories.

**Global back/forward.** A correct forward-truncating history stack already existed — but only inside the graph canvas, tracking a single node id, and it died the moment you left the graph. Meanwhile the six pieces of app location (`view`, `selectedId`, `previewId`, `focusedEntityRef`, `taskFilters`, `drill`) sat as six adjacent `useState`s in `App.tsx`, and **four of the six navigators mutated them directly, bypassing `goto` entirely**. A back button built on top of that would have silently forgotten half of what the user did — worse than no back button at all.

So the fix is not "add a stack", it is **make the location a single value that only the history can change**. `useNavigationHistory` now owns the location and exposes only `{location, navigate, updateLocation, back, forward}`. The six individual setters no longer exist, so there is nothing left to bypass: "every navigation enters the history" is guaranteed by construction rather than by convention.

**Task detail doc tree.** `inferDocGroup()` classified documents by filename and dumped every unmatched path into a fallback "progress" bucket. Once the backend stops truncating the document list (companion PR), every `artifacts/**` path would have piled into that bucket. The sidebar now renders a real path-segment tree with collapsible directories.

## What Changed

- `renderer/navigation/navigationHistory.ts` — pure history stack (push with dedup, forward truncation, `patchCurrent`, structural location equality).
- `renderer/navigation/useNavigationHistory.ts` — owns app location; returns no setters.
- `renderer/App.tsx` — **589 → 311 lines.** All six navigators funnel through `navigate()` / `updateLocation()`.
- `renderer/components/ViewSwitch.tsx`, `renderer/shell-config.tsx` — extracted from `App.tsx` so the history work would not push it past the 600-line complexity gate. Landed as a separate commit so it can be reviewed and reverted on its own.
- `renderer/components/NavigationHistoryBar.tsx` — the ← / → affordance. Also binds `Cmd+[` / `Cmd+]` and mouse buttons 3/4.
- `renderer/model/docTree.ts` + `renderer/components/taskDetail/DocTree.tsx` — path-segment tree.
- `renderer/views/TaskDetailView.tsx` — sidebar switched to `DocTree`. `inferDocGroup` is retained for two other jobs (computing `required`, and the reading-pane breadcrumb label), so it is not dead.
- `tools/gui-test-manifest.mjs` — registers the two new suites.

## Task And Scope

- Harness task: `task_01KXCR5STPM5Q39ZKZYJ87CDG1` (parent: `task_01KXCR4R2GT5DY9HZJABNT5DFQ`, the dogfood defect roll-up)
- Branch: `feat/gui-global-nav`
- Public scope: `packages/gui` renderer only, plus two lines in `tools/gui-test-manifest.mjs`
- Private planning/evidence updated: yes
- Out of scope: the backend document-listing widening (companion PR); Electron native menu items for back/forward; restoring graph zoom/pan on back

## Version Impact

- Version: no version change because this is renderer-only work with no CLI surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KXA7811SVVT8P66HNDFZQ7DF` (three-layer IA — this PR fixes defects found dogfooding it)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `82c9bcc` (rebased onto it; branch is 0 behind)
- Sync method: rebase
- Gates re-run **by the reviewer, independently, after the rebase** — not taken from the implementation report:
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm check:local` — exit 0
- [x] `pnpm test` — **1456 passed, 0 failed**
- [x] `node tools/run-manifest-gates.mjs --workflow-job gui-build` — exit 0
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR

Note for anyone re-running these: the `gui-build` gate runs `vite build`, which writes `packages/gui/dist` and then poisons a subsequent `tsc -b` with TS6305 stale-artifact errors. Run the gates in separate passes, or delete `packages/gui/dist` and `*.tsbuildinfo` in between. CI runs them as separate jobs, so CI is unaffected.

## Review Evidence

- Self-review: yes. One finding during review turned out to be **my own measurement error**: `git diff origin/main..HEAD` appeared to show this branch reverting kernel files, which read as an out-of-scope violation. It was not — `origin/main` had advanced past the branch point, so the diff was showing main's new commits inverted. Re-measured against the merge-base: this branch touches `packages/gui` only. Baselines that move create phantom findings.
- Reviewer subagent: not run
- Human review: pending
- Blocking findings: none

## Residual Risk

- **The source-scanning invariant test is the weak part, not the invariant.** `navigationHistory.vitest.ts` scans `App.tsx` for a hardcoded list of banned setter names. A seventh location field, or a navigator that moves into another component, would slip past it. The real guarantee is structural (the setters do not exist), so this test is belt-and-braces — but do not mistake it for the enforcement.
- Back into the graph restores the focused entity, not zoom/pan/expansion state. Accepted for v1.
- Opening the preview drawer is `updateLocation` (does not push history), on the theory that an overlay is not a page. If dogfooding says back should close the drawer, that is a one-line change.
- Mouse button 3/4 listeners are bound on `window`, not scoped to the main region.
- Pre-existing, not fixed here: clicking a related task in `TaskDetailView` updates `selectedId` but not `focusedEntityRef`, so entering the graph afterwards still focuses the previous entity.

## References

- Task: `task_01KXCR5STPM5Q39ZKZYJ87CDG1`
- Evidence: `dec_01KXA7811SVVT8P66HNDFZQ7DF`
- Review: pending

---

# 中文

## 概要

dogfood 三层关系图 IA 时暴露的两个缺口：应用没有全局前进/后退；Task 详情看不到任务包的子目录。

**全局前进后退。** 轮子其实早就有了——一个正确的前向截断历史栈，但它只活在关系图画布内部、只记一个 node id，**一离开图就被销毁**。而构成"应用位置"的六个状态（`view`/`selectedId`/`previewId`/`focusedEntityRef`/`taskFilters`/`drill`）就并排躺在 `App.tsx` 里，**六个导航入口中有四个直接改 state、完全绕过 `goto`**。在这之上做一个后退按钮，它会静默地忘掉用户干过的一半事——**比没有后退按钮更糟**，因为用户会信任它。

所以修法不是"加一个栈"，而是**把 location 变成一个只有历史栈能改的值**。`useNavigationHistory` 现在持有 location，只暴露 `{location, navigate, updateLocation, back, forward}`——**六个独立 setter 在代码里不存在了**，于是没有东西可以绕过：「所有导航都进历史栈」由**结构**保证，不靠自觉。

**Task 详情文档树。** `inferDocGroup()` 按文件名分类，把每个没匹配上的路径倒进一个兜底的"进度"桶。等后端不再截断文档列表（配套 PR），所有 `artifacts/**` 会全糊在那个桶里。侧边栏现在渲染真正的路径分段树，子目录可折叠。

## 改动内容

- `renderer/navigation/navigationHistory.ts` —— 纯历史栈（去重 push、前向截断、`patchCurrent`、location 结构化比较而非引用比较）。
- `renderer/navigation/useNavigationHistory.ts` —— 持有应用 location，**不返回任何 setter**。
- `renderer/App.tsx` —— **589 → 311 行**。六个导航入口全部汇流到 `navigate()` / `updateLocation()`。
- `renderer/components/ViewSwitch.tsx`、`renderer/shell-config.tsx` —— 从 `App.tsx` 拆出，否则历史栈一加就撞 600 行复杂度门。**单独一个 commit**，可独立复核与回滚。
- `renderer/components/NavigationHistoryBar.tsx` —— ← / → 按钮，另接 `Cmd+[` / `Cmd+]` 与鼠标侧键 3/4。
- `renderer/model/docTree.ts` + `renderer/components/taskDetail/DocTree.tsx` —— 路径分段树。
- `renderer/views/TaskDetailView.tsx` —— 侧边栏换成 `DocTree`。`inferDocGroup` 保留（它还承担计算 `required` 与阅读区面包屑标签两件事，不是死代码）。
- `tools/gui-test-manifest.mjs` —— 登记两个新测试套件。

## 任务与范围

- Harness 任务：`task_01KXCR5STPM5Q39ZKZYJ87CDG1`（父任务 `task_01KXCR4R2GT5DY9HZJABNT5DFQ` = dogfood 缺陷收口）
- 分支：`feat/gui-global-nav`
- 公开范围：只动 `packages/gui` 渲染进程 + `tools/gui-test-manifest.mjs` 两行
- 私有计划 / 证据是否已更新：yes
- 范围外：后端文档列表放开（配套 PR）；Electron 原生菜单的前进/后退项；后退还原图的 zoom/pan

## 版本影响

- 版本：不改版本，原因是只动渲染进程、不碰 CLI 面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`dec_01KXA7811SVVT8P66HNDFZQ7DF`（三层 IA —— 本 PR 修的是 dogfood 它时暴露的缺陷）
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`82c9bcc`（已 rebase 到它，落后 0）
- 同步方式：rebase
- 下面四门是**复核方 rebase 之后独立重跑的**，不采信实现方报告里的数字：
- [x] `pnpm typecheck` —— exit 0
- [x] `pnpm check:local` —— exit 0
- [x] `pnpm test` —— **1456 通过，0 失败**
- [x] `node tools/run-manifest-gates.mjs --workflow-job gui-build` —— exit 0
- [ ] GitHub Actions `rewrite-ci` passed —— 待本 PR 的 CI

给要重跑的人一条提醒：`gui-build` 那道门内含 `vite build`，会写出 `packages/gui/dist`，随后再跑 `tsc -b` 就会被 TS6305 陈旧产物毒化。两组门分两轮跑，或中间删掉 `packages/gui/dist` 与 `*.tsbuildinfo`。CI 里是独立 job，不受影响。

## Review Evidence

- 自审：yes。复核中有一条"发现"最后证明是**我自己的仪器错了**：`git diff origin/main..HEAD` 看起来显示这条分支把 kernel 文件回退了，读起来像越界。并不是——`origin/main` 在开分支之后前进了，diff 把 main 的新 commit 反着显示出来。换 merge-base 重测：本分支只动 `packages/gui`。**基线会动，就会凭空造出 phantom finding。**
- Reviewer subagent：未跑
- 人工复核：待办
- 阻塞发现：无

## Residual Risk

- **弱的是那个不变量测试，不是不变量本身。** `navigationHistory.vitest.ts` 用一张硬编码的禁用 setter 名单去扫 `App.tsx` 源码文本。加第 7 个位置字段、或把导航挪进别的组件，它就瞎了。**真正的保证是结构性的**（setter 根本不存在），这个测试只是多余的保险——别把它误当成执法面。
- 后退回到图只还原焦点实体，不还原 zoom/pan/展开集合。v1 接受。
- 打开预览抽屉走 `updateLocation`（不推栈），理由是 overlay 不是"页面"。如果 dogfood 觉得后退应该关抽屉，一行代码的事。
- 鼠标侧键 3/4 的监听挂在 `window` 上，没有 scope 到主区域。
- 既有问题，本 PR 未修：`TaskDetailView` 里点关联任务只改 `selectedId` 不改 `focusedEntityRef`，所以之后进图聚焦的还是上一个实体。

## References

- 任务：`task_01KXCR5STPM5Q39ZKZYJ87CDG1`
- 证据：`dec_01KXA7811SVVT8P66HNDFZQ7DF`
- 复核：待办
