### PR TITLE
refactor(daemon,cli): I1 identity seam — explicit two-question IdentityProvider + person registry split (re-landed post-ADR-0028)

### DIFF
--- a/packages/cli/src/commands/daemon/identity.ts
+++ b/packages/cli/src/commands/daemon/identity.ts
@@ -3,9 +3,23 @@ import os from "node:os";
 import path from "node:path";
 import { makeRuntimeEventAppendPromise, makeRuntimeEventLedgerService } from "../../../../application/src/index.ts";
 import {
+  composeIdentityProvider,
+  credentialKey,
+  hasPersonRegistry,
+  loadPersonRegistry,
   loadPeopleRoster,
+  makePeopleRosterIdentityAdminSnapshot,
+  makePersonAuthorizationProvider,
+  makeTransportDerivedAuthenticationProvider,
   makeTransportDerivedIdentityProvider,
-  peopleRosterFromDocument
+  personRegistryFromLegacyRoster,
+  personRegistryFromRecords,
+  validatePeopleRosterReferences,
+  type CredentialRef,
+  type IdentityAdminSnapshot,
+  type IdentityProvider,
+  type PersonRegistry,
+  type RolePolicy
 } from "../../../../daemon/src/index.ts";
 import { createHarnessRuntimeContext, resolveHarnessLayout } from "../../../../kernel/src/index.ts";
 import { readProjectHarnessSettings } from "../settings.ts";
@@ -16,58 +30,106 @@ export function loadDaemonIdentityWithEmail(
   primaryEmail: string | undefined,
   endpoint?: string
 ): {
-  readonly peopleRoster?: ReturnType<typeof loadPeopleRoster>;
-  readonly identityProvider?: ReturnType<typeof makeTransportDerivedIdentityProvider>;
+  readonly personRegistry?: PersonRegistry;
+  readonly identityProvider?: IdentityProvider;
+  readonly identityAdminSnapshot?: IdentityAdminSnapshot;
   readonly appendRuntimeEvent?: ReturnType<typeof makeRuntimeEventAppendPromise>;
 } {
   const runtimeContext = createHarnessRuntimeContext(rootDir, layoutOverrides);
   const layout = resolveHarnessLayout(runtimeContext);
   const peoplePath = path.join(layout.authoredRoot, "people.yaml");
-  const peopleRoster = existsSync(peoplePath)
-    ? loadPeopleRoster(runtimeContext)
-    : configuredLocalPeopleRoster(runtimeContext, primaryEmail, endpoint);
-  if (!peopleRoster) return {};
+  const transportOptions = {
+    localUnixIssuer: `host:${os.hostname()}`,
+    sshExecIssuer: `host:${os.hostname()}`,
+    namedPipeIssuer: `host:${os.hostname()}:named-pipe`
+  };
+  if (!existsSync(peoplePath)) {
+    const configured = configuredLocalIdentity(runtimeContext, primaryEmail, endpoint, transportOptions);
+    if (!configured) return {};
+    return {
+      ...configured,
+      appendRuntimeEvent: makeRuntimeEventAppendPromise(makeRuntimeEventLedgerService({ rootInput: runtimeContext }))
+    };
+  }
+  const peopleRoster = loadPeopleRoster(runtimeContext);
+  const personRegistry = hasPersonRegistry(runtimeContext)
+    ? loadPersonRegistry(runtimeContext)
+    : personRegistryFromLegacyRoster(peopleRoster);
+  validatePeopleRosterReferences(personRegistry, peopleRoster);
   return {
-    peopleRoster,
-    identityProvider: makeTransportDerivedIdentityProvider(peopleRoster, {
-      localUnixIssuer: `host:${os.hostname()}`,
-      sshExecIssuer: `host:${os.hostname()}`,
-      namedPipeIssuer: `host:${os.hostname()}:named-pipe`
-    }),
+    personRegistry,
+    identityProvider: makeTransportDerivedIdentityProvider(peopleRoster, transportOptions),
+    identityAdminSnapshot: makePeopleRosterIdentityAdminSnapshot(peopleRoster, personRegistry),
     appendRuntimeEvent: makeRuntimeEventAppendPromise(makeRuntimeEventLedgerService({ rootInput: runtimeContext }))
   };
 }
 
-function configuredLocalPeopleRoster(
+function configuredLocalIdentity(
   rootInput: ReturnType<typeof createHarnessRuntimeContext>,
   primaryEmail: string | undefined,
-  endpoint: string | undefined
-): ReturnType<typeof loadPeopleRoster> | undefined {
+  endpoint: string | undefined,
+  transportOptions: Parameters<typeof makeTransportDerivedAuthenticationProvider>[1]
+): {
+  readonly personRegistry: PersonRegistry;
+  readonly identityProvider: IdentityProvider;
+  readonly identityAdminSnapshot: IdentityAdminSnapshot;
+} | undefined {
   const settings = readProjectHarnessSettings(rootInput, "daemon-identity");
   if (!settings.ok || !settings.settings.identity) return undefined;
   const identity = settings.settings.identity;
   if (!primaryEmail) return undefined;
-  const credentials = [
+  const credentials: CredentialRef[] = [
     {
       kind: "unix-socket-owner-boundary",
       issuer: `host:${os.hostname()}`,
       subject: String(process.getuid?.() ?? 0)
     },
     ...(endpoint ? [{
-      kind: "windows-named-pipe-client",
+      kind: "windows-named-pipe-client" as const,
       issuer: `host:${os.hostname()}:named-pipe`,
       subject: endpoint
     }] : [])
   ];
-  return peopleRosterFromDocument(JSON.stringify({
-    schema: "harness-people/v1",
-    people: [{
+  const personRegistry = hasPersonRegistry(rootInput)
+    ? loadPersonRegistry(rootInput)
+    : personRegistryFromRecords([{
       personId: identity.personId,
-      displayName: identity.displayName ?? identity.personId,
-      primaryEmail,
-      roles: ["owner"],
-      credentials
-    }],
-    roles: [{ roleId: "owner", commandClasses: ["admin", "repo-write", "repo-read", "arbiter"] }]
-  }));
+      displayName: identity.displayName ?? identity.personId
+    }]);
+  const person = personRegistry.find(identity.personId);
+  if (!person) throw new Error(`Configured identity is not registered: ${identity.personId}`);
+  if (person.disabled) throw new Error(`Configured identity is disabled: ${identity.personId}`);
+  const credentialKeys = new Set(credentials.map(credentialKey));
+  const authentication = makeTransportDerivedAuthenticationProvider((credential, providerId) => {
+    if (!credentialKeys.has(credentialKey(credential))) {
+      return {
+        ok: false,
+        code: "credential_unknown",
+        providerId,
+        message: "Credential is not bound to the configured local person.",
+        credential
+      };
+    }
+    return { ok: true, personId: person.personId, providerId, credential, primaryEmail };
+  }, transportOptions);
+  const commandClasses = ["admin", "repo-write", "repo-read", "arbiter"] as const;
+  const roles: RolePolicy[] = [{ roleId: "owner", commandClasses }];
+  return {
+    personRegistry,
+    identityProvider: composeIdentityProvider(
+      authentication,
+      makePersonAuthorizationProvider(person.personId, commandClasses)
+    ),
+    identityAdminSnapshot: {
+      people: [{
+        personId: person.personId,
+        displayName: person.displayName,
+        primaryEmail,
+        roles: ["owner"],
+        disabled: false,
+        credentials
+      }],
+      roles
+    }
+  };
 }

--- a/packages/cli/src/composition/local-principal.ts
+++ b/packages/cli/src/composition/local-principal.ts
@@ -5,7 +5,13 @@ import {
   type TaskHolderPersonPrincipal,
   type TaskHolderPrincipal
 } from "../../../application/src/index.ts";
-import { loadPeopleRoster } from "../../../daemon/src/index.ts";
+import {
+  hasPersonRegistry,
+  loadPeopleRoster,
+  loadPersonRegistry,
+  personRegistryFromLegacyRoster,
+  validatePeopleRosterReferences
+} from "../../../daemon/src/index.ts";
 import { resolveHarnessLayout, sha256Text, type HarnessLayoutInput, type PrincipalSource } from "../../../kernel/src/index.ts";
 import { readProjectHarnessSettings } from "../commands/settings.ts";
 import {
@@ -104,7 +110,7 @@ function readConfiguredLocalPrincipalWithSource(rootInput: HarnessLayoutInput, r
 
   const layout = resolveHarnessLayout(rootInput);
   const peoplePath = path.join(layout.authoredRoot, "people.yaml");
-  const registry = registryInput ?? legacyPersonRegistry(rootInput, peoplePath);
+  const registry = registryInput ?? authoredPersonRegistry(rootInput, peoplePath);
   if (!registry) {
     const authorityPath = layout.configPath ?? path.join(layout.authoredRoot, "harness.yaml");
     return {
@@ -140,21 +146,40 @@ function readConfiguredLocalPrincipalWithSource(rootInput: HarnessLayoutInput, r
   };
 }
 
-function legacyPersonRegistry(rootInput: HarnessLayoutInput, peoplePath: string): PersonRegistry | undefined {
-  if (!existsSync(peoplePath)) return undefined;
-  let roster: ReturnType<typeof loadPeopleRoster>;
+function authoredPersonRegistry(rootInput: HarnessLayoutInput, peoplePath: string): PersonRegistry | undefined {
+  const personsPath = path.join(resolveHarnessLayout(rootInput).authoredRoot, "persons.yaml");
+  if (!existsSync(peoplePath) && !existsSync(personsPath)) return undefined;
+  let roster: ReturnType<typeof loadPeopleRoster> | undefined;
   try {
-    roster = loadPeopleRoster(rootInput);
+    roster = existsSync(peoplePath) ? loadPeopleRoster(rootInput) : undefined;
+    const registry = hasPersonRegistry(rootInput)
+      ? loadPersonRegistry(rootInput)
+      : roster
+        ? personRegistryFromLegacyRoster(roster)
+        : undefined;
+    if (!registry) return undefined;
+    if (roster) validatePeopleRosterReferences(registry, roster);
+    const authority = hasPersonRegistry(rootInput) ? "persons.yaml" as const : "people.yaml-legacy" as const;
+    return {
+      authority,
+      authorityPath: authority === "persons.yaml" ? personsPath : peoplePath,
+      find: (personId) => {
+        const person = registry.find(personId);
+        if (!person) return undefined;
+        const binding = roster?.people.find((candidate) => candidate.personId === personId);
+        return {
+          personId: person.personId,
+          displayName: person.displayName,
+          ...(binding?.primaryEmail ? { primaryEmail: binding.primaryEmail } : {}),
+          ...(person.disabled ? { disabled: true } : {})
+        };
+      }
+    };
   } catch (error) {
     throw new CliPrincipalResolutionError(
-      `Unable to validate settings.identity against harness/people.yaml: ${error instanceof Error ? error.message : String(error)}`
+      `Unable to validate settings.identity against the person registry: ${error instanceof Error ? error.message : String(error)}`
     );
   }
-  return {
-    authority: "people.yaml-legacy",
-    authorityPath: peoplePath,
-    find: (personId) => roster.people.find((person) => person.personId === personId)
-  };
 }
 
 function localPrincipalSource(authority: "persons.yaml" | "people.yaml-legacy" | "harness.yaml", authorityPath: string): PrincipalSource {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -279,7 +279,8 @@ function createDaemonServiceHost(
       leaseEnforcementEnabled: (repo) => leaseEnforcementEnabled({ rootDir: repo.canonicalRoot, layoutOverrides }),
       authContext,
       ...(defaultRepoBinding().identity.identityProvider ? { identityProvider: defaultRepoBinding().identity.identityProvider } : {}),
-      ...(defaultRepoBinding().identity.peopleRoster ? { peopleRoster: defaultRepoBinding().identity.peopleRoster } : {}),
+      ...(defaultRepoBinding().identity.personRegistry ? { personRegistry: defaultRepoBinding().identity.personRegistry } : {}),
+      ...(defaultRepoBinding().identity.identityAdminSnapshot ? { identityAdminSnapshot: defaultRepoBinding().identity.identityAdminSnapshot } : {}),
       appendRuntimeEvent: (input, context) => {
         const targetRepoId = context?.repo.repoId ?? defaultRepoId;
         return repoBindings.get(targetRepoId)?.appendRuntimeEvent(input) ?? Promise.resolve();

--- a/packages/daemon/src/identity/authorization.ts
+++ b/packages/daemon/src/identity/authorization.ts
@@ -1,28 +1,54 @@
-import type { JsonRpcMethodContract } from "../protocol/method-registry.ts";
-import type { AuthenticatedActor, PeopleRoster } from "./types.ts";
+import type {
+  AuthorizationProvider,
+  DaemonCommandClass,
+  IdentityAuthorizationAction,
+  IdentityAuthorizationDecision,
+  IdentityAuthorizationFailure,
+  IdentityAuthorizationSuccess,
+  PeopleRoster,
+  PersonId
+} from "./types.ts";
 
-export interface AuthorizationFailure {
-  readonly ok: false;
-  readonly code: "rbac_forbidden" | "command_class_missing";
-  readonly message: string;
-}
+export type AuthorizationFailure = IdentityAuthorizationFailure;
+export type AuthorizationSuccess = IdentityAuthorizationSuccess;
 
-export interface AuthorizationSuccess {
-  readonly ok: true;
-}
-
-export function authorizeActorForMethod(
-  actor: AuthenticatedActor,
-  contract: JsonRpcMethodContract,
+export function authorizePersonForMethod(
+  personId: PersonId,
+  action: IdentityAuthorizationAction,
   roster: PeopleRoster
-): AuthorizationSuccess | AuthorizationFailure {
-  if (!contract.commandClass) {
-    return { ok: false, code: "command_class_missing", message: `Method is missing commandClass: ${contract.method}` };
+): IdentityAuthorizationDecision {
+  if (!action.commandClass) {
+    return { ok: false, code: "command_class_missing", message: `Method is missing commandClass: ${action.method}` };
   }
-  if (actor.roles.some((roleId) => roster.roleAllows(roleId, contract.commandClass!))) return { ok: true };
+  const binding = roster.people.find((person) => person.personId === personId);
+  if (binding?.roles.some((roleId) => roster.roleAllows(roleId, action.commandClass!))) return { ok: true };
   return {
     ok: false,
     code: "rbac_forbidden",
-    message: `Person ${actor.personId} is not authorized for ${contract.commandClass} method ${contract.method}.`
+    message: `Person ${personId} is not authorized for ${action.commandClass} method ${action.method}.`
+  };
+}
+
+export function makePeopleRosterAuthorizationProvider(roster: PeopleRoster): AuthorizationProvider {
+  return { authorize: async ({ personId, action }) => authorizePersonForMethod(personId, action, roster) };
+}
+
+export function makePersonAuthorizationProvider(
+  personId: PersonId,
+  commandClasses: ReadonlyArray<DaemonCommandClass>
+): AuthorizationProvider {
+  const allowed = new Set(commandClasses);
+  return {
+    authorize: async ({ personId: candidate, action }) => {
+      if (!action.commandClass) {
+        return { ok: false, code: "command_class_missing", message: `Method is missing commandClass: ${action.method}` };
+      }
+      if (candidate === personId && allowed.has(action.commandClass)) return { ok: true };
+      return {
+        ok: false,
+        code: "rbac_forbidden",
+        message: `Person ${candidate} is not authorized for ${action.commandClass} method ${action.method}.`
+      };
+    }
   };
 }

--- a/packages/daemon/src/identity/people-roster.ts
+++ b/packages/daemon/src/identity/people-roster.ts
@@ -8,7 +8,9 @@ import {
   type CredentialKind,
   type DaemonCommandClass,
   type IdentityProviderFailure,
+  type IdentityAdminSnapshot,
   type PeopleRoster,
+  type PersonRegistry,
   type PersonProfile,
   type RolePolicy
 } from "./types.ts";
@@ -53,20 +55,36 @@ export function peopleRosterFromDocument(body: string): PeopleRoster {
     resolveCredential: (credential, providerId) => {
       const person = peopleByCredential.get(credentialKey(credential));
       if (!person) return credentialResolutionFailure(providerId, "credential_unknown", "Credential is not bound to a person.", credential);
-      if (person.disabled) return credentialResolutionFailure(providerId, "person_disabled", `Person is disabled: ${person.personId}`, credential);
       return {
         ok: true,
-        actor: {
-          personId: person.personId,
-          displayName: person.displayName,
-          ...(person.primaryEmail ? { primaryEmail: person.primaryEmail } : {}),
-          roles: person.roles,
-          resolvedCredential: credential,
-          providerId
-        }
+        personId: person.personId,
+        providerId,
+        credential,
+        ...(person.primaryEmail ? { primaryEmail: person.primaryEmail } : {})
       };
     },
     roleAllows: (roleId, commandClass) => rolesById.get(roleId)?.commandClasses.includes(commandClass) ?? false
+  };
+}
+
+export function makePeopleRosterIdentityAdminSnapshot(
+  roster: PeopleRoster,
+  registry: PersonRegistry
+): IdentityAdminSnapshot {
+  const bindings = new Map(roster.people.map((person) => [person.personId, person]));
+  return {
+    people: registry.people.map((person) => {
+      const binding = bindings.get(person.personId);
+      return {
+        personId: person.personId,
+        displayName: person.displayName,
+        ...(binding?.primaryEmail ? { primaryEmail: binding.primaryEmail } : {}),
+        roles: binding?.roles ?? [],
+        disabled: person.disabled ?? false,
+        credentials: binding?.credentials ?? []
+      };
+    }),
+    roles: roster.roles
   };
 }
 
@@ -94,7 +112,6 @@ function validateRoster(people: ReadonlyArray<PersonProfile>, roles: ReadonlyArr
     if (!person.personId) throw new Error("personId is required");
     if (personIds.has(person.personId)) throw new Error(`duplicate personId: ${person.personId}`);
     personIds.add(person.personId);
-    if (!person.displayName) throw new Error(`displayName is required for ${person.personId}`);
     for (const roleId of person.roles) {
       if (!roleIds.has(roleId)) throw new Error(`person ${person.personId} references unknown role ${roleId}`);
     }

--- a/packages/daemon/src/identity/person-registry.ts
+++ b/packages/daemon/src/identity/person-registry.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { resolveHarnessLayout, type HarnessLayoutInput } from "../../../kernel/src/index.ts";
+import type { PeopleRoster, PersonRecord, PersonRegistry } from "./types.ts";
+
+export function personRegistryPath(rootInput: HarnessLayoutInput): string {
+  return path.join(resolveHarnessLayout(rootInput).authoredRoot, "persons.yaml");
+}
+
+export function hasPersonRegistry(rootInput: HarnessLayoutInput): boolean {
+  return existsSync(personRegistryPath(rootInput));
+}
+
+export function loadPersonRegistry(rootInput: HarnessLayoutInput): PersonRegistry {
+  const layout = resolveHarnessLayout(rootInput);
+  const filePath = path.join(layout.authoredRoot, "persons.yaml");
+  if (!existsSync(filePath)) {
+    throw new Error(`persons.yaml not found: ${path.relative(layout.rootDir, filePath)}`);
+  }
+  return personRegistryFromDocument(readFileSync(filePath, "utf8"));
+}
+
+export function personRegistryFromDocument(body: string): PersonRegistry {
+  const raw = parsePersonsYaml(body);
+  if (raw.schema !== "harness-persons/v1") throw new Error("persons.yaml schema must be harness-persons/v1");
+  if (!Array.isArray(raw.people)) throw new Error("persons.yaml people must be an array");
+  return personRegistryFromRecords(raw.people);
+}
+
+export function personRegistryFromRecords(people: ReadonlyArray<PersonRecord>): PersonRegistry {
+  const byId = new Map<string, PersonRecord>();
+  for (const person of people) {
+    for (const key of Object.keys(person)) {
+      if (key !== "personId" && key !== "displayName" && key !== "disabled") {
+        throw new Error(`Unsupported person registry key: ${key}`);
+      }
+    }
+    if (!person.personId) throw new Error("personId is required");
+    if (!person.displayName) throw new Error(`displayName is required for ${person.personId}`);
+    if (person.disabled !== undefined && typeof person.disabled !== "boolean") {
+      throw new Error(`disabled must be true or false for ${person.personId}`);
+    }
+    if (byId.has(person.personId)) throw new Error(`duplicate personId: ${person.personId}`);
+    byId.set(person.personId, person);
+  }
+  return {
+    schema: "harness-persons/v1",
+    people: [...people],
+    find: (personId) => byId.get(personId)
+  };
+}
+
+export function personRegistryFromLegacyRoster(roster: PeopleRoster): PersonRegistry {
+  return personRegistryFromRecords(roster.people.map((person) => {
+    if (!person.displayName) throw new Error(`displayName is required for legacy person ${person.personId}`);
+    return {
+      personId: person.personId,
+      displayName: person.displayName,
+      ...(person.disabled ? { disabled: true } : {})
+    };
+  }));
+}
+
+export function validatePeopleRosterReferences(registry: PersonRegistry, roster: PeopleRoster): void {
+  for (const binding of roster.people) {
+    if (!registry.find(binding.personId)) {
+      throw new Error(`people.yaml references unregistered personId: ${binding.personId}`);
+    }
+  }
+}
+
+function parsePersonsYaml(body: string): { readonly schema: string; readonly people: PersonRecord[] } {
+  const trimmed = body.trimStart();
+  if (trimmed.startsWith("{")) {
+    return JSON.parse(body) as { readonly schema: string; readonly people: PersonRecord[] };
+  }
+
+  let schema = "";
+  let inPeople = false;
+  let current: { personId: string; displayName: string; disabled?: boolean } | undefined;
+  const people: Array<{ personId: string; displayName: string; disabled?: boolean }> = [];
+
+  for (const rawLine of body.split(/\r?\n/u)) {
+    const line = rawLine.replace(/\s+#.*$/u, "");
+    if (!line.trim()) continue;
+    const topLevel = /^([A-Za-z][A-Za-z0-9_-]*):(?:\s*(.*))?$/u.exec(line);
+    if (topLevel) {
+      const [, key, value = ""] = topLevel;
+      if (key === "schema") schema = unquotePersonRegistryScalar(value.trim());
+      else if (key === "people") inPeople = true;
+      else throw new Error(`Unsupported persons.yaml key: ${key}`);
+      current = undefined;
+      continue;
+    }
+    if (inPeople) {
+      const started = /^  - personId:\s*(.+)$/u.exec(line);
+      if (started) {
+        current = { personId: unquotePersonRegistryScalar(started[1]), displayName: "" };
+        people.push(current);
+        continue;
+      }
+      if (!current) throw new Error(`people entry must start with personId: ${line.trim()}`);
+      const scalar = /^    (displayName|disabled):\s*(.+)$/u.exec(line);
+      if (scalar) {
+        if (scalar[1] === "displayName") current.displayName = unquotePersonRegistryScalar(scalar[2]);
+        else if (scalar[2] === "true") current.disabled = true;
+        else if (scalar[2] !== "false") throw new Error(`disabled must be true or false for ${current.personId}`);
+        continue;
+      }
+    }
+    throw new Error(`Unsupported persons.yaml line: ${line.trim()}`);
+  }
+  return { schema, people };
+}
+
+function unquotePersonRegistryScalar(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith("\"") && trimmed.endsWith("\"")) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}

--- a/packages/daemon/src/identity/transport-derived-provider.ts
+++ b/packages/daemon/src/identity/transport-derived-provider.ts
@@ -1,7 +1,16 @@
 // @slice-activation PLT-Daemon W4 transport-derived identity provider exported for daemon composition and W7 team server wiring.
 import os from "node:os";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
-import type { CredentialRef, IdentityProvider, IdentityProviderFailure, PeopleRoster } from "./types.ts";
+import { makePeopleRosterAuthorizationProvider } from "./authorization.ts";
+import { composeIdentityProvider } from "./types.ts";
+import type {
+  AuthenticationProvider,
+  CredentialRef,
+  IdentityAuthenticationResult,
+  IdentityProvider,
+  IdentityProviderFailure,
+  PeopleRoster
+} from "./types.ts";
 
 export interface TransportDerivedIdentityProviderOptions {
   readonly localUnixIssuer?: string;
@@ -14,11 +23,21 @@ export function makeTransportDerivedIdentityProvider(
   roster: PeopleRoster,
   options: TransportDerivedIdentityProviderOptions = {}
 ): IdentityProvider {
+  return composeIdentityProvider(
+    makeTransportDerivedAuthenticationProvider(roster.resolveCredential, options),
+    makePeopleRosterAuthorizationProvider(roster)
+  );
+}
+
+export function makeTransportDerivedAuthenticationProvider(
+  resolveCredential: (credential: CredentialRef, providerId: string) => IdentityAuthenticationResult,
+  options: TransportDerivedIdentityProviderOptions = {}
+): AuthenticationProvider {
   const providerId = "transport-derived/v1";
   return {
     providerId,
-    resolveActor: async ({ authContext }) => {
-      const credential = credentialFromAuthContext(authContext, options);
+    authenticate: async (evidence) => {
+      const credential = credentialFromAuthContext(evidence, options);
       if (!credential) {
         return unavailableTransportCredentialFailure(
           providerId,
@@ -26,7 +45,7 @@ export function makeTransportDerivedIdentityProvider(
           "Transport authentication context did not expose a usable credential."
         );
       }
-      return roster.resolveCredential(credential, providerId);
+      return resolveCredential(credential, providerId);
     }
   };
 }

--- a/packages/daemon/src/identity/types.ts
+++ b/packages/daemon/src/identity/types.ts
@@ -25,11 +25,25 @@ export interface CredentialRef {
 
 export interface PersonProfile {
   readonly personId: PersonId;
-  readonly displayName: string;
+  /** Legacy combined people.yaml metadata. Split identity data keeps this in persons.yaml. */
+  readonly displayName?: string;
   readonly primaryEmail?: string;
   readonly roles: ReadonlyArray<RoleId>;
   readonly credentials: ReadonlyArray<CredentialRef>;
+  /** Legacy combined people.yaml metadata. Split identity data keeps this in persons.yaml. */
   readonly disabled?: boolean;
+}
+
+export interface PersonRecord {
+  readonly personId: PersonId;
+  readonly displayName: string;
+  readonly disabled?: boolean;
+}
+
+export interface PersonRegistry {
+  readonly schema: "harness-persons/v1";
+  readonly people: ReadonlyArray<PersonRecord>;
+  readonly find: (personId: PersonId) => PersonRecord | undefined;
 }
 
 export interface RolePolicy {
@@ -41,7 +55,7 @@ export interface PeopleRoster {
   readonly schema: "harness-people/v1";
   readonly people: ReadonlyArray<PersonProfile>;
   readonly roles: ReadonlyArray<RolePolicy>;
-  readonly resolveCredential: (credential: CredentialRef, providerId: string) => IdentityProviderSuccess | IdentityProviderFailure;
+  readonly resolveCredential: (credential: CredentialRef, providerId: string) => IdentityAuthenticationResult;
   readonly roleAllows: (roleId: RoleId, commandClass: DaemonCommandClass) => boolean;
 }
 
@@ -49,7 +63,6 @@ export interface AuthenticatedActor {
   readonly personId: PersonId;
   readonly displayName: string;
   readonly primaryEmail?: string;
-  readonly roles: ReadonlyArray<RoleId>;
   readonly resolvedCredential: CredentialRef;
   readonly providerId: string;
 }
@@ -62,19 +75,14 @@ export interface ActorStamp {
   readonly credential: CredentialRef;
 }
 
-export interface IdentityProviderResolveInput {
-  readonly authContext: DaemonAuthenticationContext;
-  readonly command: {
-    readonly method: string;
-    readonly namespace: "protocol" | "repo" | "admin";
-    readonly requiresRepo: boolean;
-  };
-}
+export type IdentityEvidence = DaemonAuthenticationContext;
 
 export type IdentityProviderFailureCode =
   | "credential_unavailable"
   | "credential_unknown"
+  | "person_unregistered"
   | "person_disabled"
+  | "person_registry_unavailable"
   | "provider_unavailable"
   | "malformed_credential";
 
@@ -86,14 +94,77 @@ export interface IdentityProviderFailure {
   readonly credential?: CredentialRef;
 }
 
-export interface IdentityProviderSuccess {
+export interface IdentityAuthenticationSuccess {
   readonly ok: true;
-  readonly actor: AuthenticatedActor;
+  readonly personId: PersonId;
+  readonly providerId: string;
+  readonly credential: CredentialRef;
+  readonly primaryEmail?: string;
 }
 
-export interface IdentityProvider {
+export type IdentityAuthenticationResult = IdentityAuthenticationSuccess | IdentityProviderFailure;
+
+export interface IdentityAuthorizationAction {
+  readonly method: string;
+  readonly commandClass?: DaemonCommandClass;
+}
+
+export interface IdentityAuthorizationResource {
+  readonly repoId?: string;
+  readonly canonicalRoot?: string;
+}
+
+export interface IdentityAuthorizationInput {
+  readonly personId: PersonId;
+  readonly action: IdentityAuthorizationAction;
+  readonly resource?: IdentityAuthorizationResource;
+}
+
+export interface IdentityAuthorizationSuccess {
+  readonly ok: true;
+}
+
+export interface IdentityAuthorizationFailure {
+  readonly ok: false;
+  readonly code: "rbac_forbidden" | "command_class_missing";
+  readonly message: string;
+}
+
+export type IdentityAuthorizationDecision = IdentityAuthorizationSuccess | IdentityAuthorizationFailure;
+
+export interface AuthenticationProvider {
   readonly providerId: string;
-  readonly resolveActor: (input: IdentityProviderResolveInput) => Promise<IdentityProviderSuccess | IdentityProviderFailure>;
+  readonly authenticate: (evidence: IdentityEvidence) => Promise<IdentityAuthenticationResult>;
+}
+
+export interface AuthorizationProvider {
+  readonly authorize: (input: IdentityAuthorizationInput) => Promise<IdentityAuthorizationDecision>;
+}
+
+/** The only identity contract consumed by daemon core: authenticate, then authorize. */
+export interface IdentityProvider extends AuthenticationProvider, AuthorizationProvider {}
+
+export function composeIdentityProvider(
+  authentication: AuthenticationProvider,
+  authorization: AuthorizationProvider
+): IdentityProvider {
+  return {
+    providerId: authentication.providerId,
+    authenticate: (evidence) => authentication.authenticate(evidence),
+    authorize: (input) => authorization.authorize(input)
+  };
+}
+
+export interface IdentityAdminSnapshot {
+  readonly people: ReadonlyArray<{
+    readonly personId: PersonId;
+    readonly displayName: string;
+    readonly primaryEmail?: string;
+    readonly roles: ReadonlyArray<RoleId>;
+    readonly disabled: boolean;
+    readonly credentials: ReadonlyArray<CredentialRef>;
+  }>;
+  readonly roles: ReadonlyArray<RolePolicy>;
 }
 
 export interface GitCommitAuthor {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -28,34 +28,60 @@ export {
   actorGitCommitAuthor,
   actorStamp,
   actorStampJson,
+  composeIdentityProvider,
   credentialKey,
   type ActorStamp,
+  type AuthenticationProvider,
   type AuthenticatedActor,
+  type AuthorizationProvider,
   type CredentialKind,
   type CredentialRef,
   type DaemonCommandClass,
   type GitCommitAuthor,
+  type IdentityAdminSnapshot,
+  type IdentityAuthenticationResult,
+  type IdentityAuthenticationSuccess,
+  type IdentityAuthorizationAction,
+  type IdentityAuthorizationDecision,
+  type IdentityAuthorizationFailure,
+  type IdentityAuthorizationInput,
+  type IdentityAuthorizationResource,
+  type IdentityAuthorizationSuccess,
+  type IdentityEvidence,
   type IdentityProvider,
   type IdentityProviderFailure,
   type IdentityProviderFailureCode,
-  type IdentityProviderResolveInput,
-  type IdentityProviderSuccess,
   type PeopleRoster,
   type PersonId,
+  type PersonRecord,
+  type PersonRegistry,
   type PersonProfile,
   type RoleId,
   type RolePolicy
 } from "./identity/types.ts";
 export {
   loadPeopleRoster,
+  makePeopleRosterIdentityAdminSnapshot,
   peopleRosterFromDocument
 } from "./identity/people-roster.ts";
 export {
+  hasPersonRegistry,
+  loadPersonRegistry,
+  personRegistryFromDocument,
+  personRegistryFromLegacyRoster,
+  personRegistryFromRecords,
+  personRegistryPath,
+  validatePeopleRosterReferences
+} from "./identity/person-registry.ts";
+export {
+  makeTransportDerivedAuthenticationProvider,
   makeTransportDerivedIdentityProvider,
   type TransportDerivedIdentityProviderOptions
 } from "./identity/transport-derived-provider.ts";
 export {
-  authorizeActorForMethod,
+  authorizePersonForMethod,
+  makePeopleRosterAuthorizationProvider,
+  makePersonAuthorizationProvider,
   type AuthorizationFailure,
   type AuthorizationSuccess
 } from "./identity/authorization.ts";

--- a/packages/daemon/src/protocol/identity-dispatch.ts
+++ b/packages/daemon/src/protocol/identity-dispatch.ts
@@ -1,0 +1,79 @@
+import type {
+  AuthenticatedActor,
+  IdentityProvider,
+  IdentityProviderFailure,
+  PersonRegistry
+} from "../identity/types.ts";
+import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
+import type { JsonRpcMethodContract } from "./method-registry.ts";
+
+export interface IdentityDispatchOptions {
+  readonly authContext?: DaemonAuthenticationContext;
+  readonly identityProvider?: IdentityProvider;
+  readonly personRegistry?: PersonRegistry;
+}
+
+export async function resolveIdentityActorForMethod(
+  contract: JsonRpcMethodContract,
+  options: IdentityDispatchOptions
+): Promise<{ readonly ok: true; readonly actor: AuthenticatedActor } | IdentityProviderFailure | undefined> {
+  const authContext = options.authContext ?? { transportKind: "unix-socket" } satisfies DaemonAuthenticationContext;
+  if (!options.identityProvider) {
+    return authContext.sshForcedCommand || requiresAuthenticatedPrincipal(contract)
+      ? identityFailure(
+          "identity-provider/unavailable",
+          "provider_unavailable",
+          "Daemon writes require an identity provider to authenticate the principal."
+        )
+      : undefined;
+  }
+  if (!options.personRegistry) {
+    return identityFailure(
+      options.identityProvider.providerId,
+      "person_registry_unavailable",
+      "Authenticated daemon requests require a core person registry."
+    );
+  }
+  const authentication = await options.identityProvider.authenticate(authContext);
+  if (!authentication.ok) return authentication;
+  const person = options.personRegistry.find(authentication.personId);
+  if (!person) {
+    return identityFailure(
+      options.identityProvider.providerId,
+      "person_unregistered",
+      `Identity provider authenticated an unregistered personId: ${authentication.personId}`,
+      authentication.credential
+    );
+  }
+  if (person.disabled) {
+    return identityFailure(
+      options.identityProvider.providerId,
+      "person_disabled",
+      `Person is disabled: ${person.personId}`,
+      authentication.credential
+    );
+  }
+  return {
+    ok: true,
+    actor: {
+      personId: person.personId,
+      displayName: person.displayName,
+      ...(authentication.primaryEmail ? { primaryEmail: authentication.primaryEmail } : {}),
+      resolvedCredential: authentication.credential,
+      providerId: authentication.providerId
+    }
+  };
+}
+
+function requiresAuthenticatedPrincipal(contract: JsonRpcMethodContract): boolean {
+  return contract.commandClass !== "repo-read";
+}
+
+function identityFailure(
+  providerId: string,
+  code: IdentityProviderFailure["code"],
+  message: string,
+  credential?: IdentityProviderFailure["credential"]
+): IdentityProviderFailure {
+  return { ok: false, code, providerId, message, ...(credential ? { credential } : {}) };
+}

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -18,9 +18,15 @@ import { failureReceipt, serviceResultReceipt, successReceipt } from "./receipt-
 import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse, type JsonValue } from "./json-rpc-types.ts";
 import { readTaskHolderExecutor, readTaskHolderExecutorForEvent } from "./task-holder-payload.ts";
 import { commandRootMismatch, validateForcedCommandRoot } from "./forced-command-root.ts";
+import { resolveIdentityActorForMethod } from "./identity-dispatch.ts";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
-import { authorizeActorForMethod } from "../identity/authorization.ts";
-import { actorStampJson, type AuthenticatedActor, type IdentityProvider, type PeopleRoster } from "../identity/types.ts";
+import {
+  actorStampJson,
+  type AuthenticatedActor,
+  type IdentityAdminSnapshot,
+  type IdentityProvider,
+  type PersonRegistry
+} from "../identity/types.ts";
 
 export interface DaemonRepoNamespace {
   readonly repoId: string;
@@ -77,7 +83,8 @@ export interface JsonRpcServerOptions {
   readonly leaseEnforcementEnabled?: (repo: DaemonRepoNamespace) => boolean;
   readonly authContext?: DaemonAuthenticationContext;
   readonly identityProvider?: IdentityProvider;
-  readonly peopleRoster?: PeopleRoster;
+  readonly personRegistry?: PersonRegistry;
+  readonly identityAdminSnapshot?: IdentityAdminSnapshot;
   readonly appendRuntimeEvent?: (input: RuntimeEventAppendInput, context?: DaemonRepoServiceContext) => Promise<void>;
 }
 
@@ -144,7 +151,7 @@ async function handleRequest(
   const repoRuntimeFailure = validateRepoRuntime(effectiveContract, repo, options);
   if (repoRuntimeFailure) return response(repoRuntimeFailure);
 
-  const actorResult = await resolveActor(effectiveContract, options);
+  const actorResult = await resolveIdentityActorForMethod(effectiveContract, options);
   if (actorResult && !actorResult.ok) {
     const receipt = failureReceipt(request.method, actorResult.code, actorResult.message, {
       providerId: actorResult.providerId,
@@ -154,8 +161,12 @@ async function handleRequest(
     return response(receipt);
   }
   const actor = actorResult?.actor;
-  if (actor && options.peopleRoster) {
-    const authz = authorizeActorForMethod(actor, effectiveContract, options.peopleRoster);
+  if (actor && options.identityProvider) {
+    const authz = await options.identityProvider.authorize({
+      personId: actor.personId,
+      action: { method: effectiveContract.method, commandClass: effectiveContract.commandClass },
+      ...(repo ? { resource: { repoId: repo.repoId, canonicalRoot: repo.canonicalRoot } } : {})
+    });
     if (!authz.ok) {
       await appendCommandEvent(options, params, effectiveContract, "failed", authz.message, authz.code, actor, repo);
       return response(stampReceipt(failureReceipt(request.method, authz.code, authz.message, {
@@ -392,41 +403,16 @@ function withEffectiveCommandClass(contract: JsonRpcMethodContract, params: Json
   return commandClass ? { ...contract, commandClass } : { ...contract };
 }
 
-async function resolveActor(
-  contract: JsonRpcMethodContract,
-  options: JsonRpcServerOptions
-): Promise<{ readonly ok: true; readonly actor: AuthenticatedActor } | Awaited<ReturnType<IdentityProvider["resolveActor"]>> | undefined> {
-  const authContext = options.authContext ?? { transportKind: "unix-socket" } satisfies DaemonAuthenticationContext;
-  if (!options.identityProvider) {
-    return authContext.sshForcedCommand
-      ? {
-          ok: false,
-          code: "provider_unavailable",
-          providerId: "transport-derived/v1",
-          message: "SSH forced-command authentication requires people.yaml roster validation."
-        }
-      : undefined;
-  }
-  return options.identityProvider.resolveActor({
-    authContext,
-    command: {
-      method: contract.method,
-      namespace: contract.namespace,
-      requiresRepo: contract.requiresRepo
-    }
-  });
-}
-
 function handleAdminMethod(
   contract: JsonRpcMethodContract,
   options: JsonRpcServerOptions
 ): ReturnType<typeof successReceipt> | ReturnType<typeof failureReceipt> {
-  if (!options.peopleRoster) {
+  if (!options.identityAdminSnapshot) {
     return failureReceipt(contract.method, "people_roster_unavailable", "Admin identity methods require a loaded people roster.");
   }
   if (contract.method === "admin.people.list") {
     return successReceipt(contract.method, "listed people", {
-      items: options.peopleRoster.people.map((person) => ({
+      items: options.identityAdminSnapshot.people.map((person) => ({
         personId: person.personId,
         displayName: person.displayName,
         ...(person.primaryEmail ? { primaryEmail: person.primaryEmail } : {}),
@@ -438,7 +424,7 @@ function handleAdminMethod(
   }
   if (contract.method === "admin.rbac.roles.list") {
     return successReceipt(contract.method, "listed RBAC roles", {
-      items: options.peopleRoster.roles.map((role) => ({
+      items: options.identityAdminSnapshot.roles.map((role) => ({
         roleId: role.roleId,
         commandClasses: [...role.commandClasses]
       }))

--- a/packages/daemon/test/doc-sync-protocol.test.ts
+++ b/packages/daemon/test/doc-sync-protocol.test.ts
@@ -7,6 +7,8 @@ import {
   createJsonRpcProtocolServer,
   currentDaemonProtocolVersion,
   jsonRpcMethodContracts,
+  personRegistryFromDocument,
+  type IdentityProvider,
   type JsonRpcResponse
 } from "../src/index.ts";
 
@@ -21,11 +23,30 @@ test("daemon method registry exposes repo.doc.sync.submit as an active repo writ
   assert.equal(contract.outputSchemaId, "daemon.doc-sync-submit-result/v1");
 });
 
-test("repo.doc.sync.submit appends dual-axis actor fields without inventing a human anchor", async () => {
+test("repo.doc.sync.submit appends the authenticated principal and executor axes", async () => {
   const events: Record<string, any>[] = [];
+  const identityProvider: IdentityProvider = {
+    providerId: "doc-sync-test/v1",
+    authenticate: async () => ({
+      ok: true,
+      personId: "person_editor",
+      providerId: "doc-sync-test/v1",
+      credential: { kind: "api-token", issuer: "test", subject: "editor-token" }
+    }),
+    authorize: async () => ({ ok: true })
+  };
   const server = createJsonRpcProtocolServer({
     daemonId: "daemon-test",
     repos: [{ repoId: "canonical", canonicalRoot: "/tmp/canonical" }],
+    authContext: { transportKind: "unix-socket" },
+    identityProvider,
+    personRegistry: personRegistryFromDocument([
+      "schema: harness-persons/v1",
+      "people:",
+      "  - personId: person_editor",
+      "    displayName: Editor",
+      ""
+    ].join("\n")),
     appendRuntimeEvent: async (input) => {
       events.push(input as Record<string, any>);
     },
@@ -65,7 +86,10 @@ test("repo.doc.sync.submit appends dual-axis actor fields without inventing a hu
 
   assert.equal(receipt.ok, true);
   assert.equal(receipt.command, "repo.doc.sync.submit");
-  assert.equal(events.length, 0);
+  assert.equal(events.length, 1);
+  assert.deepEqual(events[0]?.actor?.principal, { kind: "person", personId: "person_editor" });
+  assert.equal(events[0]?.actor?.executor, null);
+  assert.equal("responsibleHuman" in events[0].actor, false);
 });
 
 function emptyLocalController(): LocalControllerService {

--- a/packages/daemon/test/identity-provider-contract.test.ts
+++ b/packages/daemon/test/identity-provider-contract.test.ts
@@ -1,0 +1,342 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { LocalControllerService } from "../../application/src/index.ts";
+import { loadDaemonIdentityWithEmail } from "../../cli/src/commands/daemon/identity.ts";
+import { createInMemoryTerminalSessionService } from "../../gui/src/terminal/session-registry.ts";
+import {
+  composeIdentityProvider,
+  createJsonRpcProtocolServer,
+  currentDaemonProtocolVersion,
+  makeTransportDerivedIdentityProvider,
+  peopleRosterFromDocument,
+  personRegistryFromDocument,
+  personRegistryFromLegacyRoster,
+  validatePeopleRosterReferences,
+  type AuthenticationProvider,
+  type AuthorizationProvider,
+  type IdentityProvider,
+  type JsonRpcResponse
+} from "../src/index.ts";
+
+test("daemon core asks identity providers only who the credential belongs to and whether the person may act", async () => {
+  const calls: string[] = [];
+  const authentication: AuthenticationProvider = {
+    providerId: "fake-two-question/v1",
+    authenticate: async () => {
+      calls.push("authenticate");
+      return {
+        ok: true,
+        personId: "person_fake",
+        providerId: "fake-two-question/v1",
+        credential: { kind: "api-token", issuer: "test", subject: "token-1" }
+      };
+    }
+  };
+  const authorization: AuthorizationProvider = {
+    authorize: async ({ personId, action }) => {
+      calls.push(`authorize:${personId}:${action.commandClass}`);
+      return { ok: true };
+    }
+  };
+  const server = makeServer({
+    identityProvider: composeIdentityProvider(authentication, authorization),
+    personRegistry: personRegistryFromDocument(
+      "schema: harness-persons/v1\npeople:\n  - personId: person_fake\n    displayName: Fake Person\n"
+    ),
+    authContext: { transportKind: "unix-socket" }
+  });
+  await hello(server);
+
+  const receipt = resultReceipt(await server.handle(repoRequest("repo.tasks.list", {})));
+
+  assert.equal(receipt.ok, true);
+  assert.deepEqual(calls, ["authenticate", "authorize:person_fake:repo-read"]);
+  assert.equal((receipt.details.actor as { readonly personId?: string }).personId, "person_fake");
+});
+
+test("daemon rejects identity-provider results that are absent from or disabled in the core person registry", async () => {
+  let personId = "person_missing";
+  let authorizationCalls = 0;
+  const provider: IdentityProvider = {
+    providerId: "fake-integrity/v1",
+    authenticate: async () => ({
+      ok: true,
+      personId,
+      providerId: "fake-integrity/v1",
+      credential: { kind: "api-token", issuer: "test", subject: personId }
+    }),
+    authorize: async () => {
+      authorizationCalls += 1;
+      return { ok: true };
+    }
+  };
+  const server = makeServer({
+    identityProvider: provider,
+    personRegistry: personRegistryFromDocument([
+      "schema: harness-persons/v1",
+      "people:",
+      "  - personId: person_disabled",
+      "    displayName: Disabled Person",
+      "    disabled: true",
+      ""
+    ].join("\n")),
+    authContext: { transportKind: "unix-socket" }
+  });
+  await hello(server);
+
+  const missing = resultReceipt(await server.handle(commandRequest("new-task", "missing-person")));
+  personId = "person_disabled";
+  const disabled = resultReceipt(await server.handle(commandRequest("new-task", "disabled-person")));
+
+  assert.equal(missing.error?.code, "person_unregistered");
+  assert.equal(disabled.error?.code, "person_disabled");
+  assert.equal(authorizationCalls, 0);
+});
+
+test("split person registry contains no credential or role policy and supplies actor metadata after authentication", async () => {
+  const splitRoster = peopleRosterFromDocument([
+    "schema: harness-people/v1",
+    "people:",
+    "  - personId: person_alice",
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: ssh-username",
+    "        issuer: host:team-host",
+    "        subject: alice",
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [repo-write]",
+    ""
+  ].join("\n"));
+  const registry = personRegistryFromDocument(
+    "schema: harness-persons/v1\npeople:\n  - personId: person_alice\n    displayName: Alice\n"
+  );
+
+  assert.doesNotThrow(() => validatePeopleRosterReferences(registry, splitRoster));
+  assert.throws(
+    () => validatePeopleRosterReferences(personRegistryFromDocument("schema: harness-persons/v1\npeople:\n"), splitRoster),
+    /unregistered personId: person_alice/u
+  );
+  assert.throws(
+    () => personRegistryFromDocument(JSON.stringify({
+      schema: "harness-persons/v1",
+      people: [{ personId: "person_alice", displayName: "Alice", roles: ["owner"] }]
+    })),
+    /Unsupported person registry key: roles/u
+  );
+  const server = makeServer({
+    identityProvider: makeTransportDerivedIdentityProvider(splitRoster, { sshExecIssuer: "host:team-host" }),
+    personRegistry: registry,
+    authContext: {
+      transportKind: "ssh-exec",
+      sshExecUser: { username: "alice", host: "team-host", source: "ssh-authenticated-exec" }
+    }
+  });
+  await hello(server);
+  const receipt = resultReceipt(await server.handle(repoRequest("repo.tasks.list", {})));
+  assert.equal((receipt.details.actor as { readonly displayName?: string }).displayName, "Alice");
+
+  const legacy = peopleRosterFromDocument([
+    "schema: harness-people/v1",
+    "people:",
+    "  - personId: person_alice",
+    "    displayName: Alice Admin",
+    "    roles: [owner]",
+    "    credentials: []",
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [repo-write]",
+    ""
+  ].join("\n"));
+  assert.equal(personRegistryFromLegacyRoster(legacy).find("person_alice")?.displayName, "Alice Admin");
+});
+
+test("an existing people.yaml stays authoritative and empty credentials fail as credential_unknown", async (t) => {
+  const rootDir = createIdentityRoot("person_local");
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  writeFileSync(path.join(rootDir, "harness/people.yaml"), [
+    "schema: harness-people/v1",
+    "people:",
+    "  - personId: person_zeyu",
+    "    displayName: ZeyuLi",
+    "    roles: [owner]",
+    "    credentials: []",
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    ""
+  ].join("\n"), "utf8");
+
+  const identity = loadDaemonIdentityWithEmail(rootDir, undefined, "local@example.test");
+  const result = await identity.identityProvider?.authenticate({
+    transportKind: "unix-socket",
+    unixSocketOwnerBoundary: {
+      ownerUid: process.getuid?.() ?? 0,
+      source: "unix-socket-filesystem-owner-boundary"
+    }
+  });
+
+  assert.equal(identity.personRegistry?.find("person_zeyu")?.personId, "person_zeyu");
+  assert.equal(identity.personRegistry?.find("person_local"), undefined);
+  assert.equal(result?.ok, false);
+  if (result && !result.ok) assert.equal(result.code, "credential_unknown");
+});
+
+test("a roster person with matching credentials but no roles fails as rbac_forbidden", async (t) => {
+  const rootDir = createIdentityRoot("person_zeyu");
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  writeFileSync(path.join(rootDir, "harness/people.yaml"), [
+    "schema: harness-people/v1",
+    "people:",
+    "  - personId: person_zeyu",
+    "    displayName: ZeyuLi",
+    "    roles: []",
+    "    credentials:",
+    "      - kind: unix-socket-owner-boundary",
+    `        issuer: host:${os.hostname()}`,
+    `        subject: ${process.getuid?.() ?? 0}`,
+    "roles: []",
+    ""
+  ].join("\n"), "utf8");
+  const identity = loadDaemonIdentityWithEmail(rootDir, undefined, "zeyu@example.test");
+  const server = makeServer({
+    identityProvider: identity.identityProvider,
+    personRegistry: identity.personRegistry,
+    identityAdminSnapshot: identity.identityAdminSnapshot,
+    authContext: {
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: {
+        ownerUid: process.getuid?.() ?? 0,
+        source: "unix-socket-filesystem-owner-boundary"
+      }
+    }
+  });
+  await hello(server);
+
+  const receipt = resultReceipt(await server.handle(commandRequest("new-task", "empty-roles")));
+  assert.equal(receipt.error?.code, "rbac_forbidden");
+});
+
+test("the no-roster ownership path is composed from an AuthenticationProvider instead of a synthetic roster", async (t) => {
+  const rootDir = createIdentityRoot("person_local");
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+
+  const identity = loadDaemonIdentityWithEmail(rootDir, undefined, "local@example.test");
+  const authenticated = await identity.identityProvider?.authenticate({
+    transportKind: "unix-socket",
+    unixSocketOwnerBoundary: {
+      ownerUid: process.getuid?.() ?? 0,
+      source: "unix-socket-filesystem-owner-boundary"
+    }
+  });
+  const authorized = await identity.identityProvider?.authorize({
+    personId: "person_local",
+    action: { method: "repo.tasks.progress.append", commandClass: "repo-write" }
+  });
+
+  assert.equal("peopleRoster" in identity, false);
+  assert.equal(authenticated?.ok && authenticated.personId, "person_local");
+  assert.deepEqual(authorized, { ok: true });
+});
+
+test("unclassified writes cannot bypass a missing identity provider", async () => {
+  let serviceCalls = 0;
+  const server = makeServer({
+    authContext: { transportKind: "unix-socket" },
+    services: {
+      LocalControllerService: emptyLocalController(),
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" }),
+      CliCommandService: {
+        runCommand: async () => {
+          serviceCalls += 1;
+          throw new Error("unclassified command reached service dispatch");
+        }
+      }
+    }
+  });
+  await hello(server);
+
+  const receipt = resultReceipt(await server.handle(commandRequest("future-write-action", "unclassified-action")));
+
+  assert.equal(receipt.error?.code, "provider_unavailable");
+  assert.equal(serviceCalls, 0);
+});
+
+function createIdentityRoot(personId: string): string {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-identity-contract-"));
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  writeFileSync(path.join(rootDir, "harness/harness.yaml"), [
+    "schema: harness-anything/v1",
+    "layout:",
+    "  authoredRoot: harness",
+    "settings:",
+    "  identity:",
+    `    personId: ${personId}`,
+    `    displayName: ${personId}`,
+    ""
+  ].join("\n"), "utf8");
+  return rootDir;
+}
+
+function makeServer(overrides: Partial<Parameters<typeof createJsonRpcProtocolServer>[0]> = {}) {
+  return createJsonRpcProtocolServer({
+    daemonId: "identity-contract-test",
+    repos: [{ repoId: "canonical", canonicalRoot: "/tmp/canonical" }],
+    services: {
+      LocalControllerService: emptyLocalController(),
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" })
+    },
+    ...overrides
+  });
+}
+
+async function hello(server: ReturnType<typeof makeServer>): Promise<void> {
+  await server.handle({
+    jsonrpc: "2.0",
+    id: "hello",
+    method: "protocol.hello",
+    params: { protocolVersion: currentDaemonProtocolVersion }
+  });
+}
+
+function repoRequest(method: string, payload: Record<string, unknown>) {
+  return { jsonrpc: "2.0" as const, id: method, method, params: { repo: { repoId: "canonical" }, payload } };
+}
+
+function commandRequest(action: string, id: string) {
+  return {
+    ...repoRequest("repo.command.run", { command: { rootDir: "/tmp/canonical", json: true, action: { kind: action } } }),
+    id
+  };
+}
+
+function resultReceipt(response: JsonRpcResponse | ReadonlyArray<JsonRpcResponse> | undefined) {
+  assert.ok(response && !Array.isArray(response) && "result" in response);
+  return response.result as {
+    readonly ok: boolean;
+    readonly error?: { readonly code?: string };
+    readonly details: Record<string, unknown>;
+  };
+}
+
+function emptyLocalController(): LocalControllerService {
+  return {
+    getTasks: () => ({ ok: true, tasks: [], warnings: [] }),
+    getTaskDetail: async () => ({ ok: true }),
+    getTaskDocument: async () => ({ ok: true }),
+    getRelationGraph: () => ({ ok: true, edges: [], coverageRows: [], factAnchors: [], warnings: [] }),
+    getDecisions: () => ({ ok: true, decisions: [], warnings: [] }),
+    getDecisionDetail: () => ({ ok: false, error: { code: "decision_not_found", hint: "missing" } }),
+    getTaskFacts: async (payload) => ({ ok: true, taskId: payload.taskId, path: "harness/tasks/task/facts.md", facts: [] }),
+    setTaskStatus: async () => ({ ok: true }),
+    reviewTask: async () => ({ ok: true }),
+    appendTaskProgress: async () => ({ ok: true }),
+    rebuildGovernance: () => ({ ok: true, tasks: [], warnings: [] }),
+    archiveTask: () => ({ ok: true }),
+    openShell: () => ({ ok: true, policy: { displayOnly: true, outputCreatesTaskState: false } })
+  };
+}

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -11,13 +11,17 @@ import { apiRouteContracts } from "../../gui/src/api/api-contract-registry.ts";
 import { createInMemoryTerminalSessionService } from "../../gui/src/terminal/session-registry.ts";
 import { commandSpecs } from "../../cli/src/cli/command-spec/index.ts";
 import {
+  composeIdentityProvider,
   createJsonRpcProtocolServer,
   currentDaemonProtocolVersion,
   jsonRpcServiceMethodContracts,
   jsonRpcMethodContracts,
   repoCommandRunClassifiedActionKinds,
+  makePeopleRosterAuthorizationProvider,
+  makePeopleRosterIdentityAdminSnapshot,
   makeTransportDerivedIdentityProvider,
   peopleRosterFromDocument,
+  personRegistryFromLegacyRoster,
   type IdentityProvider,
   type PeopleRoster,
   type JsonRpcRequest,
@@ -310,8 +314,7 @@ test("notification subscribe is a no-op socket and respects JSON-RPC notificatio
 test("admin people list returns roster data and stamps receipt actor", async () => {
   const roster = sampleRoster();
   const server = makeServer({
-    peopleRoster: roster,
-    identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),
+    ...rosterIdentityOptions(roster),
     authContext: {
       transportKind: "ssh-exec",
       sshExecUser: { username: "alice", host: "team-host", source: "ssh-authenticated-exec" }
@@ -335,12 +338,9 @@ test("admin people list returns roster data and stamps receipt actor", async () 
 test("transport-derived provider rejects unknown credentials without anonymous fallback", async () => {
   const roster = sampleRoster();
   const provider = makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" });
-  const resolved = await provider.resolveActor({
-    authContext: {
-      transportKind: "ssh-exec",
-      sshExecUser: { username: "mallory", host: "team-host", source: "ssh-authenticated-exec" }
-    },
-    command: { method: "repo.tasks.list", namespace: "repo", requiresRepo: true }
+  const resolved = await provider.authenticate({
+    transportKind: "ssh-exec",
+    sshExecUser: { username: "mallory", host: "team-host", source: "ssh-authenticated-exec" }
   });
 
   assert.equal(resolved.ok, false);
@@ -372,41 +372,38 @@ test("SSH forced-command authentication fails closed when the people roster prov
 
   assert.equal(receipt.ok, false);
   assert.equal(receipt.error?.code, "provider_unavailable");
-  assert.match(receipt.error?.hint ?? "", /people\.yaml roster validation/iu);
+  assert.match(receipt.error?.hint ?? "", /identity provider/iu);
 });
 
 test("mock email provider proves provider extension without daemon call-site changes", async () => {
   const roster = sampleRoster();
-  const emailProvider: IdentityProvider = {
+  const emailProvider: IdentityProvider = composeIdentityProvider({
     providerId: "email-session/v1",
-    resolveActor: async ({ authContext }) => {
-      const claims = authContext.sshTunnelToken?.subject.claims;
+    authenticate: async (evidence) => {
+      const claims = evidence.sshTunnelToken?.subject.claims;
       const email = claims && typeof claims.email === "string" ? claims.email.toLowerCase() : "";
       return roster.resolveCredential({ kind: "email-address", issuer: "email:primary", subject: email }, "email-session/v1");
     }
-  };
+  }, makePeopleRosterAuthorizationProvider(roster));
 
-  const resolved = await emailProvider.resolveActor({
-    authContext: {
-      transportKind: "ssh-tunnel",
-      sshTunnelToken: {
-        tokenId: "token-1",
-        tunnelNonce: "nonce-1",
-        subject: {
-          userId: "session-user",
-          hostProfileId: "host-profile",
-          daemonInstanceId: "daemon-test",
-          claims: { email: "ALICE@EXAMPLE.COM" }
-        }
+  const resolved = await emailProvider.authenticate({
+    transportKind: "ssh-tunnel",
+    sshTunnelToken: {
+      tokenId: "token-1",
+      tunnelNonce: "nonce-1",
+      subject: {
+        userId: "session-user",
+        hostProfileId: "host-profile",
+        daemonInstanceId: "daemon-test",
+        claims: { email: "ALICE@EXAMPLE.COM" }
       }
-    },
-    command: { method: "repo.tasks.list", namespace: "repo", requiresRepo: true }
+    }
   });
 
   assert.equal(resolved.ok, true);
   if (resolved.ok) {
-    assert.equal(resolved.actor.personId, "person_alice");
-    assert.equal(resolved.actor.providerId, "email-session/v1");
+    assert.equal(resolved.personId, "person_alice");
+    assert.equal(resolved.providerId, "email-session/v1");
   }
 });
 
@@ -416,8 +413,7 @@ test("RBAC rejects non-arbiter methods and records a runtime event with actor", 
   try {
     const roster = sampleRoster();
     const server = makeServer({
-      peopleRoster: roster,
-      identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),
+      ...rosterIdentityOptions(roster),
       authContext: {
         transportKind: "ssh-exec",
         sshExecUser: { username: "viewer", host: "team-host", source: "ssh-authenticated-exec" }
@@ -456,8 +452,7 @@ test("runtime event append receives the validated repo namespace", async () => {
   const eventRepos: string[] = [];
   const roster = sampleRoster();
   const server = makeServer({
-    peopleRoster: roster,
-    identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),
+    ...rosterIdentityOptions(roster),
     authContext: {
       transportKind: "ssh-exec",
       sshExecUser: { username: "maint", host: "team-host", source: "ssh-authenticated-exec" }
@@ -507,8 +502,7 @@ test("repo.command.run derives RBAC from the inner CLI command", async () => {
   const roster = sampleRoster();
   const calls: string[] = [];
   const server = makeServer({
-    peopleRoster: roster,
-    identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),
+    ...rosterIdentityOptions(roster),
     authContext: {
       transportKind: "ssh-exec",
       sshExecUser: { username: "maint", host: "team-host", source: "ssh-authenticated-exec" }
@@ -677,6 +671,15 @@ function sampleRoster(): PeopleRoster {
     "    commandClasses: [arbiter, repo-write, repo-read]",
     ""
   ].join("\n"));
+}
+
+function rosterIdentityOptions(roster: PeopleRoster) {
+  const personRegistry = personRegistryFromLegacyRoster(roster);
+  return {
+    personRegistry,
+    identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),
+    identityAdminSnapshot: makePeopleRosterIdentityAdminSnapshot(roster, personRegistry)
+  };
 }
 
 function createHarnessRoot(): string {

--- a/packages/daemon/test/task-holder-rpc.test.ts
+++ b/packages/daemon/test/task-holder-rpc.test.ts
@@ -9,8 +9,10 @@ import { makeTaskHolderService } from "../../application/src/index.ts";
 import { createInMemoryTerminalSessionService } from "../../gui/src/terminal/session-registry.ts";
 import {
   createJsonRpcProtocolServer,
+  makePeopleRosterIdentityAdminSnapshot,
   makeTransportDerivedIdentityProvider,
   peopleRosterFromDocument,
+  personRegistryFromLegacyRoster,
   type JsonRpcRequest,
   type JsonRpcResponse,
   type PeopleRoster
@@ -291,10 +293,12 @@ function createActorServer(
   services: Parameters<typeof createJsonRpcProtocolServer>[0]["services"],
   appendRuntimeEvent?: Parameters<typeof createJsonRpcProtocolServer>[0]["appendRuntimeEvent"]
 ) {
+  const personRegistry = personRegistryFromLegacyRoster(roster);
   return createJsonRpcProtocolServer({
     daemonId: "daemon-task-holder-test",
     repos: [{ repoId: "canonical", canonicalRoot: rootDir }],
-    peopleRoster: roster,
+    personRegistry,
+    identityAdminSnapshot: makePeopleRosterIdentityAdminSnapshot(roster, personRegistry),
     identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),
     authContext: {
       transportKind: "ssh-exec",

--- a/packages/daemon/test/transport-integration.test.ts
+++ b/packages/daemon/test/transport-integration.test.ts
@@ -21,8 +21,10 @@ import {
   defaultUnixSocketPath,
   ensurePrivateUnixSocketDirectory,
   encodeJsonLineFrame,
+  makePeopleRosterIdentityAdminSnapshot,
   makeTransportDerivedIdentityProvider,
   peopleRosterFromDocument,
+  personRegistryFromLegacyRoster,
   serveJsonRpcStream,
   sshForcedCommandBootstrapFrame,
   serveSshExecBridge,
@@ -138,31 +140,25 @@ test("unix socket transport rejects an unsafe parent before touching the socket"
 
 test("unix socket owner boundary credential resolves to its roster person", async () => {
   const provider = makeTransportDerivedIdentityProvider(localBoundaryRoster(), { localUnixIssuer: "host:team-host" });
-  const resolved = await provider.resolveActor({
-    authContext: {
-      transportKind: "unix-socket",
-      unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" }
-    },
-    command: { method: "repo.tasks.list", namespace: "repo", requiresRepo: true }
+  const resolved = await provider.authenticate({
+    transportKind: "unix-socket",
+    unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" }
   });
 
   assert.equal(resolved.ok, true);
   if (resolved.ok) {
-    assert.equal(resolved.actor.personId, "person_socket_owner");
-    assert.equal(resolved.actor.resolvedCredential.kind, "unix-socket-owner-boundary");
-    assert.equal(resolved.actor.resolvedCredential.subject, "501");
+    assert.equal(resolved.personId, "person_socket_owner");
+    assert.equal(resolved.credential.kind, "unix-socket-owner-boundary");
+    assert.equal(resolved.credential.subject, "501");
   }
 });
 
 test("legacy unix peer-shaped auth context cannot mint a transport credential", async () => {
   const provider = makeTransportDerivedIdentityProvider(localBoundaryRoster());
-  const resolved = await provider.resolveActor({
-    authContext: {
-      transportKind: "unix-socket",
-      unixPeerCredential: { uid: 501, gid: 20, source: "node-process-owner" }
-    } as unknown as DaemonAuthenticationContext,
-    command: { method: "repo.tasks.list", namespace: "repo", requiresRepo: true }
-  });
+  const resolved = await provider.authenticate({
+    transportKind: "unix-socket",
+    unixPeerCredential: { uid: 501, gid: 20, source: "node-process-owner" }
+  } as unknown as DaemonAuthenticationContext);
 
   assert.equal(resolved.ok, false);
   if (!resolved.ok) {
@@ -173,10 +169,7 @@ test("legacy unix peer-shaped auth context cannot mint a transport credential", 
 
 test("unix socket auth without an owner boundary fails explicitly", async () => {
   const provider = makeTransportDerivedIdentityProvider(localBoundaryRoster());
-  const resolved = await provider.resolveActor({
-    authContext: { transportKind: "unix-socket" },
-    command: { method: "repo.tasks.list", namespace: "repo", requiresRepo: true }
-  });
+  const resolved = await provider.authenticate({ transportKind: "unix-socket" });
 
   assert.equal(resolved.ok, false);
   if (!resolved.ok) {
@@ -210,18 +203,15 @@ test("forced-command credentials keep two members distinct and ignore the shared
   ].join("\n"));
   const provider = makeTransportDerivedIdentityProvider(roster, { sshForcedCommandIssuer: "host:team-host" });
 
-  const resolve = (personId: string) => provider.resolveActor({
-    authContext: {
-      transportKind: "unix-socket" as const,
-      unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" as const },
-      sshForcedCommand: { personId, canonicalRoot: "/srv/canonical", source: "sshd-authorized-keys-forced-command" as const }
-    },
-    command: { method: "repo.tasks.list", namespace: "repo", requiresRepo: true }
+  const resolve = (personId: string) => provider.authenticate({
+    transportKind: "unix-socket" as const,
+    unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" as const },
+    sshForcedCommand: { personId, canonicalRoot: "/srv/canonical", source: "sshd-authorized-keys-forced-command" as const }
   });
   const [alice, bob, unknown] = await Promise.all([resolve("person_alice"), resolve("person_bob"), resolve("person_mallory")]);
 
-  assert.equal(alice.ok && alice.actor.personId, "person_alice");
-  assert.equal(bob.ok && bob.actor.personId, "person_bob");
+  assert.equal(alice.ok && alice.personId, "person_alice");
+  assert.equal(bob.ok && bob.personId, "person_bob");
   assert.equal(unknown.ok, false);
   if (!unknown.ok) assert.equal(unknown.code, "credential_unknown");
 });
@@ -435,9 +425,15 @@ test("SSH tunnel token bootstrap rejects an invalid token before JSON-RPC dispat
 });
 
 function makeProtocolServerFactory(calls: string[] = []): (authContext: DaemonAuthenticationContext) => JsonRpcProtocolServer {
-  return () => createJsonRpcProtocolServer({
+  const roster = protocolIdentityRoster();
+  const personRegistry = personRegistryFromLegacyRoster(roster);
+  return (authContext) => createJsonRpcProtocolServer({
     daemonId: "daemon-test",
     repos: [{ repoId: "canonical", canonicalRoot: "/tmp/canonical" }],
+    authContext,
+    personRegistry,
+    identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),
+    identityAdminSnapshot: makePeopleRosterIdentityAdminSnapshot(roster, personRegistry),
     services: {
       LocalControllerService: localController(calls),
       TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" })
@@ -533,6 +529,24 @@ function localBoundaryRoster(): PeopleRoster {
     "      - kind: unix-socket-owner-boundary",
     "        issuer: host:team-host",
     "        subject: 501",
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    ""
+  ].join("\n"));
+}
+
+function protocolIdentityRoster(): PeopleRoster {
+  return peopleRosterFromDocument([
+    "schema: harness-people/v1",
+    "people:",
+    "  - personId: person_alice",
+    "    displayName: Alice",
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: ssh-username",
+    "        issuer: host:team-host",
+    "        subject: alice",
     "roles:",
     "  - roleId: owner",
     "    commandClasses: [admin, repo-write, repo-read, arbiter]",


### PR DESCRIPTION
# English

## Summary

I1 identity-seam hardening, re-landed on the post-ADR-0028 identity surface. The original I1 implementation (c573ffc, 2026-07-12) predated the dual-axis line's P7b landing and fell 112+ commits behind main; this PR re-implements it using the old diff as a design draft, so the ADR-0028 transport-derived production path (people.yaml → person_zeyu) is wrapped, not replaced. Two-question interface made explicit — `AuthenticationProvider.authenticate` (whose person is this credential?) and `AuthorizationProvider.authorize` (may this person run this command class?) — with daemon core consuming only the composed `IdentityProvider` contract. A minimal person registry (personId, display name, enabled state) is split from the roster and projected from the existing people.yaml when no separate registry exists, so no historical personId is rebuilt or renamed. The no-roster path becomes an independent `AuthenticationProvider` instead of synthesizing a roster (per prior arbitration). This seam is the prerequisite for the identity line (I2 Logto / I4 casbin plug in behind these interfaces) and for KTY second-principal enrollment.

## What Changed

- `packages/daemon/src/identity/types.ts`: explicit `AuthenticationProvider` / `AuthorizationProvider` / composed `IdentityProvider` contracts + `composeIdentityProvider`; admin snapshot types.
- `packages/daemon/src/identity/person-registry.ts` (new): minimal registry (personId/displayName/disabled) + projection from legacy people.yaml roster.
- `packages/daemon/src/identity/transport-derived-provider.ts`: becomes a full `IdentityProvider` implementation; credential-derivation semantics unchanged.
- `packages/daemon/src/identity/{people-roster,authorization}.ts`: roster stays authoritative when people.yaml exists; authorization behind the interface.
- `packages/daemon/src/protocol/identity-dispatch.ts` (new): authenticate → registry/disabled check → authorize dispatch order.
- `packages/cli/src/commands/daemon/identity.ts` + `composition/local-principal.ts`: no-roster path rewritten as AuthenticationProvider; people.yaml presence keeps absolute authority.
- Tests: `identity-provider-contract.test.ts` (+342) covering two-question calls, registry integrity, `person_zeyu`, empty credentials → `credential_unknown`, empty roles → `rbac_forbidden`, no-roster; transport/json-rpc/doc-sync/task-holder tests updated to the seam.

## Task And Scope

- Harness task: task_01KXA0JF9W37CM32VEJ7Z1HCWK (I1, identity line, prerequisite for KTY second-principal enrollment)
- Branch: refactor/i1-identity-seam (force-pushed: old c573ffc replaced by re-implementation on b6b4164)
- Public scope: `packages/daemon/src/{identity,protocol}/**`, `packages/cli/src/{commands/daemon/identity.ts,composition/local-principal.ts,index.ts}`, daemon tests
- Private planning/evidence updated: yes (mission `mission-i1-rebase.md`, real task plan, progress in private harness ledger)
- Out of scope: `harness/people.yaml` (production identity data, consumed only), I2 Logto deployment, I4 casbin decision engine, write-road registry / gate allowlists / CI config (untouched)

## Version Impact

- Version: no version change because this is an internal seam refactor; no published contract changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: dec_01KX9ZGTSH (identity externalization boundary: core anchors personId + two-question narrow interface), dec_01KX8WZH5Y347AD87GGSSQM4Z3 (identity stack: personId sole anchor)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: b6b41649fe3a11b167dbb0ce2edef84991e89f4b
- Worker: root `check:local` 16/16 (322 fast + 437 contract tests); hermetic identity tests (`HOME=$(mktemp -d) GIT_CONFIG_GLOBAL=/dev/null`) 50 pass / 0 fail / 1 Windows-only skip
- CEO independent re-run: root `check:local` green
- Fail-closed contract preserved and tested: people.yaml authoritative when present; empty credentials → `credential_unknown`; empty roles → `rbac_forbidden`
- Semantic acceptance (CEO): two-question contract is the only identity surface daemon core consumes; transport-derived path wrapped not replaced; no personId rebuilt/renamed; no-roster = AuthenticationProvider form

## Review Evidence

- Deep-research basis: `harness/tasks/task_01KX8ECPMCGW71M0VK467N9Z9H-kty-harness/artifacts/adr0028-deep-research-2026-07-13.md` §4.3-4.4 (I1 real state + rebase-not-rebuild requirement)

---

# 中文

## 摘要

I1 身份接缝硬化，重基落到 post-ADR-0028 身份面上。原 I1 实现（c573ffc，2026-07-12）早于双轴线 P7b 落地、落后 main 112+ 提交；本 PR 以旧 diff 为设计稿重实现，把 ADR-0028 的 transport-derived 生产路径（people.yaml → person_zeyu）**包住而非替换**。两问接口显式化——`AuthenticationProvider.authenticate`（这个 credential 是谁的 person？）与 `AuthorizationProvider.authorize`（这个 person 有权跑这个 command class 吗？）——daemon core 只消费组合后的 `IdentityProvider` 契约。person 最小注册表（personId/显示名/启停）与 roster 分离，无独立注册表时从现有 people.yaml 投影，不重建/不重命名任何历史 personId。no-roster 路径改为独立 `AuthenticationProvider`（按此前裁决），不再合成 roster。此接缝是身份线（I2 Logto / I4 casbin 在接口后外挂）与 KTY 第二 principal enrollment 的前置。

## 变更内容

- `types.ts`：显式两问契约 + `composeIdentityProvider` + 管理快照类型。
- `person-registry.ts`（新增）：最小注册表 + legacy roster 投影。
- `transport-derived-provider.ts`：成为完整 IdentityProvider 实现，credential 派生语义不变。
- `identity-dispatch.ts`（新增）：先认证→查注册/停用→再授权。
- CLI 身份组合：no-roster 改 AuthenticationProvider 形态；people.yaml 存在时保持绝对权威。
- 测试：契约测试 +342 行（两问调用/registry 完整性/person_zeyu/空 credentials→credential_unknown/空 roles→rbac_forbidden/no-roster）。

## 任务与范围

- Harness 任务：task_01KXA0JF9W37CM32VEJ7Z1HCWK（I1，身份线，KTY 第二 principal enrollment 前置）
- 分支：refactor/i1-identity-seam（force-push：旧 c573ffc 由基于 b6b4164 的重实现替换）
- 公开面：daemon identity/protocol、CLI 身份组合、daemon 测试
- 私有账本更新：是（mission/写实 task_plan/progress）
- 范围外：`harness/people.yaml`（生产身份数据只消费）、I2 Logto、I4 casbin、registry/allowlists/CI（未动）

## 版本影响

- 版本：无版本变更——内部接缝重构，无已发布契约变化
- 发布影响：无

## 治理声明

- 触碰保护面：否；范围：不适用
- 权威依据：dec_01KX9ZGTSH（身份外挂边界）、dec_01KX8WZH5Y347AD87GGSSQM4Z3（personId 唯一锚）
- 机器检查边界：本 PR 仅断言声明存在；是否真实充分由评审者判断。
- Break-glass：否；理由/范围：不适用
- 后续治理任务：无

## 验证

- 基线 `origin/main` SHA：b6b41649fe3a11b167dbb0ce2edef84991e89f4b
- worker：根 `check:local` 16/16（322 fast + 437 contract）；hermetic 身份测试 50 pass/0 fail/1 Windows skip
- CEO 独立复跑：根 `check:local` 绿
- fail-closed 契约保留并有测试：people.yaml 存在即权威 / credential_unknown / rbac_forbidden
- 语义验收（CEO）：两问契约是 daemon core 唯一消费面；transport-derived 被包住非替换；无 personId 重建；no-roster=AuthenticationProvider 形态

## 评审证据

- 深研依据：KTY 任务包 `adr0028-deep-research-2026-07-13.md` §4.3-4.4
