### PR TITLE
fix(gui): four graph defects — empty spotlight from territory, zone overlap, fixed columns, unscrollable cards

### DIFF
--- a/packages/gui/src/renderer/components/GraphFilterPanel.tsx
+++ b/packages/gui/src/renderer/components/GraphFilterPanel.tsx
@@ -88,7 +88,9 @@ export function GraphFilterPanel({ filters, setFilters, availableModules }: Prop
         )}
       </button>
 
-      <div className={`px-3 pb-3 flex-col gap-4 ${open ? "flex" : "hidden"}`}>
+      {/* D4:nowheel + max-h + overflow-y-auto。此面板浮在画布上(ReactFlow Panel),滚轮原本会被
+          d3-zoom 吞掉缩放画布;加 nowheel 让滚轮滚动面板内容,max-h 防止模块多时撑出视口。*/}
+      <div className={`nowheel px-3 pb-3 flex-col gap-4 ${open ? "flex max-h-[60vh] overflow-y-auto" : "hidden"}`}>
         {/* Semantic Axis Filter */}
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-1.5 text-[11px] text-text-muted font-mono uppercase tracking-wide">

--- a/packages/gui/src/renderer/graph/canvasEgoLayout.ts
+++ b/packages/gui/src/renderer/graph/canvasEgoLayout.ts
@@ -148,6 +148,25 @@ export interface CanvasEgoInput {
   shown: Map<string, number>;
   /** 渲染为详情卡片的 node id 集(其余为紧凑 chip)。 */
   expanded: Set<string>;
+  /** 用户拖拽调整后的卡片尺寸覆盖(node id → {w,h});未覆盖的走内容估算。 */
+  sizeOverrides?: ReadonlyMap<string, { w: number; h: number }>;
+}
+
+/**
+ * Ego 图的入口不变量:把任何 endpoint 形态(decision/<id>、task/<id>、fact/<...>)
+ * 或裸 task id 归一为 ego 图 byId 的键空间。
+ *
+ * D1 根因:territory chip 发射的 navRef 是 `task/<id>`(territoryLayout.buildChipNode),
+ * 而 ego 图 byId 的 task 键是裸 id(buildEgoGraph)。useEgoCanvas.openFocus 修复前直接把
+ * navRef 当 focusId → bfsShown 从 `task/<id>` 出发,adj/byId 都键不上 → 焦点命中失败 →
+ * layoutCanvasEgo 在 `if (!meta) continue` 处丢弃 → 0 节点(空白画布)。
+ *
+ * 修复:openFocus 内部强制经此函数归一,使任何入口形态都收敛到 byId 键空间。territory
+ * chip / FocusSwitcher / 双击 / 抽屉「设为焦点」/ 历史前后退都共用同一个入口不变量,
+ * 下一个入口不会再踩同一个坑。
+ */
+export function egoFocusIdOf(ref: string): string {
+  return endpointToNodeId(ref);
 }
 
 // 节点尺寸(确定性布局用)。chip 紧凑一条;card 固定宽,高按内容估算并封顶。
@@ -157,9 +176,20 @@ const CARD_W = 360;
 const GAP_X = 72;
 const GAP_Y = 26;
 
-/** 卡片高度:内容感知估算 + 封顶。节点即以此高渲染,分区溢出内滚 → 零重叠。 */
-function estimateCardHeight(entity: Entity, row: TaskRow | DecisionRow | FactRef): number {
-  if (entity === "task") return 150;
+/**
+ * 卡片高度:内容感知估算 + 封顶。节点即以此高渲染,分区溢出内滚 → 零重叠。
+ *
+ * D4:task 高度修复前是常量 150(无视标题长度)—— 长标题被截、内容溢出。
+ * 现在按标题行数 + body 徽章/新鲜度/meta 的固定开销估算,与 decision/fact 同源。
+ */
+export function estimateCardHeight(entity: Entity, row: TaskRow | DecisionRow | FactRef): number {
+  if (entity === "task") {
+    const t = row as TaskRow;
+    // header(32) + body(badges 24 + freshness 20 + meta 20 + gaps 16 ≈ 80) + footer(20) ≈ 130
+    // + title 每行 22px(卡片宽 360,padding 后 ~320,约 30 字符/行)
+    const titleLines = Math.max(1, Math.ceil((t.title ?? "").length / 30));
+    return Math.min(260, 130 + titleLines * 22);
+  }
   if (entity === "fact") {
     const f = row as FactRef;
     const obs = Math.min(160, 56 + Math.ceil((f.text?.length ?? 0) / 42) * 20);
@@ -177,13 +207,16 @@ function nodeDims(
   entity: Entity,
   expanded: boolean,
   row: NodeMeta["row"] | undefined,
+  override?: { w: number; h: number },
 ): { w: number; h: number } {
+  if (override) return override;
   if (expanded && row) return { w: CARD_W, h: estimateCardHeight(entity, row) };
   return { w: CHIP_W, h: CHIP_H };
 }
 
 export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
   const { focusId, filters, shown, expanded } = input;
+  const sizeOverrides = input.sizeOverrides;
   const { byId, adj, synthEdges } = buildEgoGraph(
     input.tasks,
     input.decisions,
@@ -193,6 +226,10 @@ export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
 
   const axisOn = (axis: SemanticAxis): boolean => filters.axes[axis];
   const typeOn = (entity: Entity): boolean => filters.types.has(entity);
+  const dimOf = (id: string) => {
+    const meta = byId.get(id);
+    return nodeDims(meta?.entity ?? "task", expanded.has(id), meta?.row, sizeOverrides?.get(id));
+  };
 
   // ── 可见集:shown 中通过类型过滤者;焦点恒可见(不被自身类型开关抹掉) ──
   const vis = new Set<string>();
@@ -232,10 +269,6 @@ export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
 
   // ── 分列:按 side:level 聚列,barycenter 排序,竖排居中于 y=0 ──
   const pos = new Map<string, { x: number; y: number }>();
-  const dimOf = (id: string) => {
-    const meta = byId.get(id);
-    return nodeDims(meta?.entity ?? "task", expanded.has(id), meta?.row);
-  };
   const cols = new Map<string, string[]>();
   for (const id of vis) {
     const k = `${side.get(id)}:${lvl.get(id)}`;
@@ -286,7 +319,7 @@ export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
     if (!meta) continue;
     const center = pos.get(id) ?? { x: 0, y: 0 };
     const isExpanded = expanded.has(id);
-    const { w, h } = nodeDims(meta.entity, isExpanded, meta.row);
+    const { w, h } = nodeDims(meta.entity, isExpanded, meta.row, sizeOverrides?.get(id));
     let hiddenCount = 0;
     for (const a of adj.get(id) ?? []) {
       if (

--- a/packages/gui/src/renderer/graph/graphLayout.ts
+++ b/packages/gui/src/renderer/graph/graphLayout.ts
@@ -73,6 +73,7 @@ export async function computeGraphLayout(input: LayoutInput): Promise<LayoutOutp
       filters,
       coverageRows,
       expandedZones: input.territory.expandedZones,
+      containerWidth: input.territory.containerWidth,
     });
   }
 
@@ -89,6 +90,7 @@ export async function computeGraphLayout(input: LayoutInput): Promise<LayoutOutp
       inLoopEdges,
       shown: input.canvas.shown,
       expanded: input.canvas.expanded,
+      sizeOverrides: input.canvas.sizeOverrides,
     });
   }
 

--- a/packages/gui/src/renderer/graph/graphLayoutTypes.ts
+++ b/packages/gui/src/renderer/graph/graphLayoutTypes.ts
@@ -48,16 +48,26 @@ export interface LayoutInput {
    * (三类实体统一、按跳级分层列、原地展开累计保留),旁路 simpleEgo/threeLane。
    *   shown    — 累积可见集 node id → 距焦点跳数。
    *   expanded — 渲染为详情卡片的 node id 集(其余紧凑 chip)。
+   *   sizeOverrides — 用户拖拽调整后的卡片尺寸(node id → {w,h});D4 NodeResizer 持久化。
    */
-  canvas?: { shown: Map<string, number>; expanded: Set<string> };
+  canvas?: {
+    shown: Map<string, number>;
+    expanded: Set<string>;
+    sizeOverrides?: ReadonlyMap<string, { w: number; h: number }>;
+  };
   /**
    * L1 领地总览(IA v2 Layer 0)。存在即走 layoutTerritory —— 把台账按 rootTask /
    * supersede-refine 链分区成「领地块」,一块一块地铺开,点块内实体 → 切到聚光灯(L2)。
    * 与 canvas(L2)互斥:territory 在则 canvas 不传,反之亦然。
    *   skel          — 骨架轴(task 按 milestone / decision 按 supersede-refine 家族 + 落地)。
    *   expandedZones — 已展开(不折叠 done/planned)的 zone id 集;默认折叠 hot-only。
+   *   containerWidth — D3:领地摆放区的容器宽度(像素),用于派生列数。未传 → 兜底 3 列。
    */
-  territory?: { skel: "task" | "decision"; expandedZones: Set<string> };
+  territory?: {
+    skel: "task" | "decision";
+    expandedZones: Set<string>;
+    containerWidth?: number;
+  };
 }
 
 export interface LayoutOutput {

--- a/packages/gui/src/renderer/graph/nodes/EgoNode.tsx
+++ b/packages/gui/src/renderer/graph/nodes/EgoNode.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from "react";
-import { Handle, Position } from "@xyflow/react";
+import { Handle, Position, NodeResizer } from "@xyflow/react";
 import { X, Crosshair, ArrowsOutSimple } from "@phosphor-icons/react";
 import {
   StatusBadge,
@@ -31,6 +31,10 @@ const AXIS_VAR: Record<Entity, string> = {
   fact: "var(--color-axis-evidence)",
 };
 const KD_LETTER: Record<Entity, string> = { task: "T", decision: "D", fact: "F" };
+
+// NodeResizer 下限:卡片不能拖到比 chip 还小(否则内容无法装下)。
+const CARD_MIN_W = 240;
+const CARD_MIN_H = 100;
 
 const HANDLE_CLS =
   "!h-2 !w-2 !min-w-2 !min-h-2 !border-0 !bg-[var(--color-border-strong)]";
@@ -99,6 +103,20 @@ export function EgoNode({ data, selected }: any) {
         boxShadow: focus ? `0 0 0 2px ${axis}, 0 8px 28px rgba(0,0,0,0.28)` : undefined,
       }}
     >
+      {/* D4:NodeResizer —— 用户「手动拖放大缩小组件」的入口。只在展开卡片上显示。
+          onResizeEnd 把最终尺寸持久化到 sizeOverrides(localStorage),布局器下次按此尺寸渲染。
+          minWidth/minHeight 防止拖到 0;nodesDraggable={false} 不影响 resize(RF 独立处理)。*/}
+      <NodeResizer
+        isVisible={true}
+        minWidth={CARD_MIN_W}
+        minHeight={CARD_MIN_H}
+        onResizeEnd={(_evt, params) => {
+          if (data.onResizeEnd) {
+            data.onResizeEnd(data.id, params.width, params.height);
+          }
+        }}
+        handleClassName="!border-[var(--color-border-strong)] !bg-surface-raised"
+      />
       <Handles />
       {/* header */}
       <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-2.5 py-1.5">
@@ -145,7 +163,9 @@ export function EgoNode({ data, selected }: any) {
       </div>
 
       {/* scrollable body */}
-      <div className="mt-1.5 flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain px-2.5 pb-2">
+      {/* D4:nowheel 类让 React Flow 的 d3-zoom filter 把滚轮让给此容器(否则滚轮被拿去缩放画布,
+          overflow-y-auto 形同虚设)。noWheelClassName 默认就是 "nowheel",无需在 ReactFlow 上配置。*/}
+      <div className="nowheel mt-1.5 flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain px-2.5 pb-2">
         {entity === "task" && <TaskBody t={data.raw as TaskRow} />}
         {entity === "decision" && <DecisionBody d={data.raw as DecisionRow} />}
         {entity === "fact" && <FactBody f={data.raw as FactRef} />}

--- a/packages/gui/src/renderer/graph/territoryLayout.ts
+++ b/packages/gui/src/renderer/graph/territoryLayout.ts
@@ -34,13 +34,28 @@ const ZONE_W = 340;
 const ZONE_HEADER_H = 78;
 const ZONE_BODY_PAD_Y = 8;
 const ZONE_BODY_PAD_X = 8;
-const GRID_COLS = 3;
+const DEFAULT_GRID_COLS = 3;
+const GRID_COLS_MAX = 6;
 const ZONE_GAP_X = 20;
 const ZONE_GAP_Y = 20;
 const SECTION_HEADER_H = 34;
 const SECTION_GAP_Y = 40;
 const TOP_PAD = 16;
 const LEFT_PAD = 24;
+
+/**
+ * D3:由容器宽度派生领地列数(取代硬编码 GRID_COLS=3)。
+ *
+ * 接受「zone 摆放区」净宽(已扣除 LEFT_PAD*2)。每列净宽 = ZONE_W + ZONE_GAP_X
+ * (末列无 gap,但保守按等量整除,留一点右侧呼吸空间)。宽屏能并排 4-5 列,窄屏回落 1-2 列。
+ * 无效/未测量(width ≤ 0)→ 兜底 DEFAULT_GRID_COLS,保持既有首屏体验。
+ */
+export function deriveGridCols(zoneAreaWidth: number): number {
+  if (!Number.isFinite(zoneAreaWidth) || zoneAreaWidth <= 0) return DEFAULT_GRID_COLS;
+  const perCol = ZONE_W + ZONE_GAP_X;
+  const cols = Math.floor((zoneAreaWidth + ZONE_GAP_X) / perCol);
+  return Math.max(1, Math.min(GRID_COLS_MAX, cols));
+}
 
 export interface TerritoryInput {
   skel: "task" | "decision";
@@ -52,10 +67,17 @@ export interface TerritoryInput {
   coverageRows?: ReadonlyArray<RelationCoverageRow>;
   /** 已展开(不折叠)的 zone id 集;默认折叠 hot-only。 */
   expandedZones: Set<string>;
+  /**
+   * D3:领地摆放区的容器宽度(像素,含两侧 LEFT_PAD)。测量后由 GraphView 传入;
+   * 未传( undefined / 0)→ 兜底 DEFAULT_GRID_COLS=3,保持纯函数对老调用方的兼容。
+   */
+  containerWidth?: number;
 }
 
 export function layoutTerritory(input: TerritoryInput): LayoutOutput {
   const { skel, expandedZones, filters } = input;
+  // D3:列数由容器宽度派生;未测量时兜底 DEFAULT_GRID_COLS。
+  const gridCols = deriveGridCols((input.containerWidth ?? 0) - LEFT_PAD * 2);
   const partitionInput = {
     tasks: input.tasks,
     decisions: input.decisions,
@@ -81,7 +103,7 @@ export function layoutTerritory(input: TerritoryInput): LayoutOutput {
     if (section.zones.length === 0) continue;
 
     // section header
-    const sectionW = GRID_COLS * ZONE_W + (GRID_COLS - 1) * ZONE_GAP_X;
+    const sectionW = gridCols * ZONE_W + (gridCols - 1) * ZONE_GAP_X;
     rfNodes.push({
       id: `territory-section:${section.id}`,
       type: "territoryZone",
@@ -96,7 +118,7 @@ export function layoutTerritory(input: TerritoryInput): LayoutOutput {
     });
     cursorY += SECTION_HEADER_H + 8;
 
-    const rows = chunk(section.zones, GRID_COLS);
+    const rows = chunk(section.zones, gridCols);
     for (const row of rows) {
       for (const zone of row) {
         const folded = !expandedZones.has(zone.id);
@@ -179,7 +201,7 @@ export function layoutTerritory(input: TerritoryInput): LayoutOutput {
   }
 
   const bounds = {
-    width: Math.max(maxX, LEFT_PAD + GRID_COLS * ZONE_W) - LEFT_PAD,
+    width: Math.max(maxX, LEFT_PAD + gridCols * ZONE_W) - LEFT_PAD,
     height: cursorY - TOP_PAD,
   };
 
@@ -232,6 +254,13 @@ function buildChipNode(
 
 // ── 几何辅助 ──
 
+/**
+ * D2:zone 盒高 = 实际发射 chip 的总高(盒子与孩子同源)。
+ *
+ * 修复前:Math.min(ZONE_MAX_BODY_H, h) 把盒子夹在 460,但 chip 发射按真实成员数(不夹),
+ * 行推进按夹过的高度 → chip 溢出到下一个 zone/section。现在盒子跟着 chip 走,零溢出;
+ * ZONE_MAX_BODY_H 仅作极端上界(2400,容纳 50 个 decision 卡片),正常场景触不到。
+ */
 function computeBodyH(zone: Zone, folded: boolean): number {
   const memberH = zone.skel === "task" ? GEO.TASK_CHIP_H : GEO.DECISION_CARD_H;
   const memberGap = zone.skel === "task" ? GEO.TASK_CHIP_GAP : GEO.DECISION_CARD_GAP;
@@ -243,8 +272,10 @@ function computeBodyH(zone: Zone, folded: boolean): number {
 
 function visibleMembers(zone: Zone, folded: boolean): Member[] {
   if (!folded) return zone.members.slice(0, 50);
-  if (zone.skel === "decision") return zone.members;
-  return zone.members.slice(0, GEO.FOLDED_TASK_CAP);
+  // D2:decision zone 修复前不折叠(直接 return zone.members)→ ≥5 家族默认就重叠。
+  // 现在与 task 同源 —— 折叠态按 score 排序后只显前 N 个,其余进 fold 提示。
+  const cap = zone.skel === "decision" ? GEO.FOLDED_DECISION_CAP : GEO.FOLDED_TASK_CAP;
+  return zone.members.slice(0, cap);
 }
 
 function chunk<T>(arr: T[], size: number): T[][] {

--- a/packages/gui/src/renderer/graph/territoryPartition.ts
+++ b/packages/gui/src/renderer/graph/territoryPartition.ts
@@ -27,8 +27,13 @@ const TASK_CHIP_GAP = 4;
 const DECISION_CARD_H = 92;
 const DECISION_CARD_GAP = 10;
 const ZONE_MIN_BODY_H = 36;
-const ZONE_MAX_BODY_H = 460;
+// D2:zone 盒高现在跟着 chip 实际数量走(不再夹),ZONE_MAX_BODY_H 仅作上界 sanity guard,
+// 避免极端数据(50 成员 × 92px)造出 5000px 单块。实际布局里 expanded 已 slice(0,50)。
+const ZONE_MAX_BODY_H = 2400;
 const FOLDED_TASK_CAP = 8;
+// D2:decision zone 修复前压根不折叠(visibleMembers 直接 return members)→ ≥5 家族默认就重叠。
+// 现在与 task 同源 —— 折叠态只显前 N 个家族(按 score 已排),其余进 fold 提示。
+const FOLDED_DECISION_CAP = 3;
 export const GEO = {
   TASK_CHIP_H,
   TASK_CHIP_GAP,
@@ -37,6 +42,7 @@ export const GEO = {
   ZONE_MIN_BODY_H,
   ZONE_MAX_BODY_H,
   FOLDED_TASK_CAP,
+  FOLDED_DECISION_CAP,
 };
 
 // ── 内部结构 ──

--- a/packages/gui/src/renderer/graph/useEgoCanvas.ts
+++ b/packages/gui/src/renderer/graph/useEgoCanvas.ts
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useReactFlow } from "@xyflow/react";
 
 import type { TaskRow, RelationEdge, DecisionRow, FactRef } from "../model/types";
 import type { AxisFilter } from "./graphLayoutTypes";
 import { endpointToNodeId } from "./endpoint";
-import { buildEgoGraph, bfsShown, neighborsOf, type EgoGraph } from "./canvasEgoLayout";
+import { buildEgoGraph, bfsShown, neighborsOf, egoFocusIdOf, type EgoGraph } from "./canvasEgoLayout";
 import { pickDefaultFocus } from "./graphLayoutShared";
 import {
   createFocusHistory,
@@ -30,8 +29,6 @@ import {
  * 收起都只增不减,永不重排已铺开的画布。
  */
 
-// 换焦点时把焦点摆到视口正中所用的缩放:焦点卡片(360 宽)+ 左右各一列 chip 同屏可读。
-const FOCUS_ZOOM = 0.9;
 // openFocus 默认铺开的跳数(上游 2 跳 + 下游 2 跳)。
 const DEFAULT_HOPS = 2;
 
@@ -60,8 +57,6 @@ export function useEgoCanvas({
   relations,
   axes,
   focusRef,
-  nodes,
-  resolvedFocusId,
 }: {
   tasks: TaskRow[];
   decisions: DecisionRow[];
@@ -69,13 +64,7 @@ export function useEgoCanvas({
   relations: RelationEdge[];
   axes: AxisFilter;
   focusRef?: string | null;
-  /** 布局器算出的 React Flow 节点(用于「换焦点即居中」读焦点节点的实际盒子)。 */
-  nodes: ReadonlyArray<any>;
-  /** 布局器最终采用的焦点(用户未显式聚焦时是默认焦点)。 */
-  resolvedFocusId: string | null;
 }): EgoCanvas {
-  const { setCenter } = useReactFlow();
-
   const [focusId, setFocusId] = useState<string | null>(null);
   const [history, setHistory] = useState<FocusHistoryState>(createFocusHistory);
   const [shown, setShown] = useState<Map<string, number>>(() => new Map());
@@ -98,9 +87,14 @@ export function useEgoCanvas({
 
   const openFocus = useCallback(
     (id: string) => {
-      setFocusId(id);
-      setHistory((prev) => pushFocus(prev, id)); // 重复推同 id 会被 pushFocus 折叠
-      resetCanvasTo(id);
+      // D1:ego 图入口不变量。territory chip 发射的 navRef 是 `task/<id>` 形态,而 ego
+      // byId 键为裸 task id —— 不归一直接传会让焦点命中失败 → 空白画布。所有入口
+      // (territory chip / FocusSwitcher / 双击 / 抽屉「设为焦点」/ 历史前后退)都经此归一,
+      // 把 endpoint 形态收敛到 byId 键空间。裸 id 原样通过(幂等)。
+      const canonical = egoFocusIdOf(id);
+      setFocusId(canonical);
+      setHistory((prev) => pushFocus(prev, canonical)); // 重复推同 id 会被 pushFocus 折叠
+      resetCanvasTo(canonical);
     },
     [resetCanvasTo],
   );
@@ -168,24 +162,6 @@ export function useEgoCanvas({
     const def = pickDefaultFocus(decisions, tasks);
     if (def) openFocusRef.current(def);
   }, [focusId, focusRef, decisions, tasks]);
-
-  // 换焦点时把焦点节点摆进视口正中 —— 兑现「以它为中心」,同时躲开左上角 Filters 面板
-  // (fitView 按整图 bbox 居中,下游更宽时会把焦点推到左侧压在面板底下)。
-  // 只在焦点变化时触发:累积展开 / 长邻居永不重排已有画布。
-  const lastCenteredFocus = useRef<string | null>(null);
-  useEffect(() => {
-    if (!resolvedFocusId) return;
-    if (lastCenteredFocus.current === resolvedFocusId) return;
-    const focusNode = nodes.find((n) => n.id === resolvedFocusId);
-    if (!focusNode) return;
-    lastCenteredFocus.current = resolvedFocusId;
-    const cx = focusNode.position.x + Number(focusNode.width ?? 0) / 2;
-    const cy = focusNode.position.y + Number(focusNode.height ?? 0) / 2;
-    const frame = window.requestAnimationFrame(() => {
-      setCenter(cx, cy, { zoom: FOCUS_ZOOM, duration: 320 });
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [resolvedFocusId, nodes, setCenter]);
 
   return {
     focusId,

--- a/packages/gui/src/renderer/views/GraphView.tsx
+++ b/packages/gui/src/renderer/views/GraphView.tsx
@@ -20,13 +20,8 @@ import type {
   RelationCoverageRow,
   FactAnchorRow,
 } from "../../api/renderer-dto.ts";
-import { endpointToNodeId } from "../graph/endpoint";
 import { GraphDrawer } from "../graph/GraphDrawer";
-import {
-  computeGraphLayout,
-  type AxisFilter,
-  type GraphFilterInput,
-} from "../graph/graphLayout";
+import { type GraphFilterInput } from "../graph/graphLayout";
 import { useEgoCanvas } from "../graph/useEgoCanvas";
 
 import { TaskNode } from "../graph/nodes/TaskNode";
@@ -49,6 +44,13 @@ import { FocusSwitcher } from "../components/FocusSwitcher";
 import { FocusHistoryBar } from "../components/FocusHistoryBar";
 import { useColorMode } from "./graphColorMode";
 import { GraphLegend } from "./GraphLegend";
+import {
+  useGraphLayout,
+  useCenterOnFocus,
+  useGraphDrawer,
+  useContainerWidth,
+  useNodeSizeOverrides,
+} from "./graphViewHooks";
 
 const nodeTypes = {
   task: TaskNode,
@@ -66,15 +68,13 @@ const edgeTypes = {
   interactive: InteractiveEdge,
 };
 
-const EMPTY_LOOP = new Set<string>();
-
 const MINIMAP_AXIS: Record<string, string> = {
   task: "var(--color-axis-execution)",
   decision: "var(--color-axis-authority)",
   fact: "var(--color-axis-evidence)",
 };
 
-function defaultAxes(): AxisFilter {
+function defaultAxes() {
   // relates (assoc) 默认关 — dec_01KXA7811SVVT8P66HNDFZQ7DF CH4。
   return { authority: true, evidence: true, execution: true, assoc: false };
 }
@@ -100,22 +100,13 @@ function GraphViewInner({
 }) {
   const colorMode = useColorMode();
 
-  // 边焦点(仅抽屉展示)独立于节点焦点。修 #3:此前用单一 focusId 同时承载节点和边,
-  // 点边时把 edge id 当 focusNodeId 传给布局器,导致布局器拿不到节点 → 整张图塌成
-  // 单个空节点。节点焦点 / 画布累积态现在整块住在 useEgoCanvas 里。
-  //   selectedId — 抽屉里展示的节点。点空白 / Esc / 抽屉关闭即清空。
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [focusEdgeId, setFocusEdgeId] = useState<string | null>(null);
-  const [resolvedFocusId, setResolvedFocusId] = useState<string | null>(null);
-  const [expandedFacts] = useState<Set<string>>(new Set());
+  // D3:测领地容器宽度 → deriveGridCols 派生列数(取代硬编码 GRID_COLS=3)。
+  const { ref: canvasContainerRef, width: containerWidth } = useContainerWidth<HTMLDivElement>();
+  // D4:用户拖拽的卡片尺寸(NodeResizer)+ localStorage 持久化。
+  const { sizeOverrides, setSizeOverride } = useNodeSizeOverrides();
 
-  const [nodes, setNodes] = useState<any[]>([]);
-  const [edges, setEdges] = useState<any[]>([]);
-  const [cycleWarning, setCycleWarning] = useState<{
-    count: number;
-    cycles: string[][];
-  }>({ count: 0, cycles: [] });
-  const [error, setError] = useState<string | null>(null);
+  // expandedFacts 是既有入口(三泳道/fact 折叠徽章),聚光灯模式下不参与布局,保持空集常量。
+  const expandedFacts = useMemo(() => new Set<string>(), []);
 
   const availableModules = useMemo(
     () => Array.from(new Set(tasks.map((t) => t.module))).sort(),
@@ -170,8 +161,6 @@ function GraphViewInner({
     relations,
     axes: filters.axes,
     focusRef,
-    nodes,
-    resolvedFocusId,
   });
 
   // L1 领地总览状态机(territory ↔ spotlight 模式切换 + 骨架轴 + zone 折叠态)。
@@ -190,58 +179,33 @@ function GraphViewInner({
     if (focusRef) setViewMode("spotlight");
   }, [focusRef, setViewMode]);
 
-  useEffect(() => {
-    const ac = new AbortController();
-    computeGraphLayout({
-      tasks,
-      relations,
-      decisions: decisions ?? [],
-      facts: facts ?? [],
-      coverageRows: coverageRows ?? [],
-      factAnchors: factAnchors ?? [],
-      focusNodeId: viewMode === "territory" ? null : focusId,
-      expandedFacts,
-      filters: layoutInputFilters,
-      inLoopNodes: EMPTY_LOOP,
-      inLoopEdges: EMPTY_LOOP,
-      ...(viewMode === "territory"
-        ? { territory: { skel, expandedZones } }
-        : { canvas: { shown, expanded } }),
-    })
-      .then(({ nodes: rfNodes, edges: rfEdges, cycleWarning: warning, resolvedFocusId: rid }) => {
-        if (ac.signal.aborted) return;
-        setError(null);
-        setNodes(rfNodes);
-        setEdges(rfEdges);
-        setCycleWarning(warning);
-        setResolvedFocusId(rid);
-      })
-      .catch((err) => {
-        if (ac.signal.aborted) return;
-        console.error("Failed to compute graph layout", err);
-        setError(err instanceof Error ? err.stack || err.message : String(err));
-      });
-    return () => ac.abort();
-  }, [
+  // 布局调度(异步 + AbortController)外置到 useGraphLayout;GraphView 只消费结果。
+  // 传 containerWidth(D3 领地列数)和 sizeOverrides(D4 卡片尺寸)过布局链。
+  const { nodes, edges, cycleWarning, error, resolvedFocusId } = useGraphLayout({
     tasks,
     relations,
-    decisions,
-    facts,
+    decisions: decisions ?? [],
+    facts: facts ?? [],
     coverageRows,
     factAnchors,
     focusId,
     expandedFacts,
-    layoutInputFilters,
+    filters: layoutInputFilters,
     shown,
     expanded,
     viewMode,
     skel,
     expandedZones,
-  ]);
+    containerWidth,
+    sizeOverrides,
+  });
+
+  // 「换焦点即居中」:布局后的 nodes + resolvedFocusId 驱动 setCenter。
+  // 从 useEgoCanvas 抽出来放这儿,因为此 hook 在 useGraphLayout 之后调用,能拿到真实节点盒子。
+  useCenterOnFocus(nodes, resolvedFocusId);
 
   // 单击 chip = 就地展开成卡片并长出邻居(累积,永不重排已有画布)。
-  // 卡片(已展开)单击不处理 —— 收起 / 详情 / 设为中心 走卡片自身按钮。
-  // territory 模式下 territoryChip 单击 → 切到聚光灯(openFocus);fold chip → toggleZone。
+  // territory 模式下 territoryChip 单击 → 切到聚光灯(enterSpotlight);fold chip → toggleZone。
   const onNodeClick = useCallback(
     (_evt: any, node: any) => {
       if (node.type === "territoryChip") {
@@ -254,7 +218,6 @@ function GraphViewInner({
         return;
       }
       if (node.type === "territoryZone") {
-        // zone header 的折叠按钮走 zoneId;背景点击不处理
         if (node.data?.zoneId) toggleZone(node.data.zoneId);
         return;
       }
@@ -275,15 +238,15 @@ function GraphViewInner({
   );
 
   const onEdgeClick = useCallback((_: any, edge: any) => {
-    // 修 #3:边焦点独立成 focusEdgeId,不再混入 focusId,布局不会重算。
-    setSelectedId(null);
-    setFocusEdgeId((prev) => (prev === edge.id ? null : edge.id));
+    setDrawerState((prev) => ({
+      ...prev,
+      selectedId: null,
+      focusEdgeId: prev.focusEdgeId === edge.id ? null : edge.id,
+    }));
   }, []);
 
   const onPaneClick = useCallback(() => {
-    // 点空白只关抽屉,不动焦点(让用户「跳过去回得来」)。
-    setSelectedId(null);
-    setFocusEdgeId(null);
+    setDrawerState((prev) => ({ ...prev, selectedId: null, focusEdgeId: null }));
   }, []);
 
   // Esc = 关抽屉(不退焦点;焦点有显式「退出聚焦」按钮)。
@@ -291,48 +254,44 @@ function GraphViewInner({
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
       if (e.target instanceof HTMLElement && e.target.closest("input,textarea,select")) return;
-      setSelectedId(null);
-      setFocusEdgeId(null);
+      setDrawerState((prev) => ({ ...prev, selectedId: null, focusEdgeId: null }));
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
-  // Drawer
+  // 抽屉状态(节点选中 / 边选中)+ 派生数据 + 回调,外置到 useGraphDrawer。
+  // onEdgeClick / onPaneClick / Esc 通过 setDrawerState 原子更新两个 id(避免竞态)。
+  const [drawerState, setDrawerState] = useState<{ selectedId: string | null; focusEdgeId: string | null }>(
+    { selectedId: null, focusEdgeId: null },
+  );
+  const setSelectedId = useCallback(
+    (id: string | null) => setDrawerState((prev) => ({ ...prev, selectedId: id })),
+    [],
+  );
+  const setFocusEdgeId = useCallback(
+    (id: string | null) => setDrawerState((prev) => ({ ...prev, focusEdgeId: id })),
+    [],
+  );
+  const drawer = useGraphDrawer({
+    nodes,
+    focusId,
+    relations,
+    openFocus,
+    selectedId: drawerState.selectedId,
+    focusEdgeId: drawerState.focusEdgeId,
+    setSelectedId,
+    setFocusEdgeId,
+  });
+
+  // 面包屑节点:用户没显式设焦点时,fallback 到布局器挑的默认焦点(resolvedFocusId)。
   const focusNode = focusId ? nodes.find((n) => n.id === focusId) : null;
-  const selectedNode = selectedId ? nodes.find((n) => n.id === selectedId) : null;
-  const focusEdge = focusEdgeId ? edges.find((e) => e.id === focusEdgeId) : null;
-  // 面包屑节点:用户没显式设焦点时,fallback 到布局器挑的默认焦点
-  // (resolvedFocusId),让用户始终知道「当前在看谁的图」。
   const breadcrumbNode =
     focusNode ?? (resolvedFocusId ? nodes.find((n) => n.id === resolvedFocusId) ?? null : null);
+  const selectedNode = drawer.selectedId ? nodes.find((n) => n.id === drawer.selectedId) : null;
+  const focusEdge = drawer.focusEdgeId ? edges.find((e) => e.id === drawer.focusEdgeId) : null;
 
-  const drawerNodesMap = useMemo(() => {
-    const map = new Map();
-    nodes.forEach((n) => {
-      if (n.type === "moduleGroup" || n.type === "laneBackground") return;
-      map.set(n.id, {
-        id: n.id,
-        entity: n.type === "decisionFocus" ? "decision" : n.type,
-        label: n.data.label,
-        sub: n.data.sub,
-        // GraphDrawer 读 closeoutReadiness/engine/freshness/module 等字段,
-        // 这些只存在于完整 TaskRow (n.data.raw) 上,不在 React Flow 节点的
-        // 顶层 data 上。修 #1:此前误传 n.data,导致 CloseoutBadge/EngineBadge
-        // 拿到 undefined,CLOSEOUT_META[undefined] 直接抛 → 点 task 节点必崩。
-        task: n.type === "task" ? n.data.raw : undefined,
-        // 修 GUI 可用性(dec_01KXA7811SVVT8P66HNDFZQ7DF):抽屉现在可被任何
-        // 节点打开(单击=选中),包括 lineage lane 里的 decision / fact 节点。
-        // 这些节点的 n.data 不带 chosen/rejected/claims 等字段(只有 n.data.raw
-        // 才是完整 DecisionRow/FactRef)。raw 优先取 n.data.raw,fallback n.data
-        // 兼容老的 simpleEgoLayout 节点(其 data 即实体本身)。
-        raw: (n.data?.raw ?? n.data) as typeof n.data,
-      });
-    });
-    return map;
-  }, [nodes]);
-
-  // Node/edge count for header (exclude backgrounds)
+  // Node/edge count for header (exclude backgrounds).
   const visibleNodeCount = useMemo(
     () =>
       nodes.filter(
@@ -344,7 +303,7 @@ function GraphViewInner({
     [nodes],
   );
 
-  // 注入卡片交互回调(收起 / 设为中心 / 详情跳转)+ id 到 ego 节点 data。
+  // 注入卡片交互回调(收起 / 设为中心 / 详情跳转 / 拖拽 resize)+ id 到 ego 节点 data。
   // territory 节点注入 onOpen(chip → 聚光灯)+ onFold(zone 折叠)。
   const displayNodes = useMemo(
     () =>
@@ -358,6 +317,7 @@ function GraphViewInner({
               onCollapse: collapseNode,
               onRefocus: openFocus,
               onNavigate: onNavigateEntity,
+              onResizeEnd: (id: string, w: number, h: number) => setSizeOverride(id, { w, h }),
             },
           };
         }
@@ -369,70 +329,29 @@ function GraphViewInner({
         }
         return n;
       }),
-    [nodes, collapseNode, openFocus, onNavigateEntity, enterSpotlight, toggleZone],
+    [nodes, collapseNode, openFocus, onNavigateEntity, setSizeOverride, enterSpotlight, toggleZone],
   );
-
-  // 抽屉里展示的实体(优先 selectedNode,fallback 到 focusNode)。这样单击非焦点
-  // 节点能看抽屉,focus 节点也能看抽屉。upCount/downCount 跟随「抽屉里那个」。
-  const drawerNodeId = selectedNode?.id ?? focusNode?.id ?? null;
-
-  // 上游 / 下游 1-hop 邻居计数 (供 GraphDrawer「链路」展示)。绑定到 drawerNodeId,
-  // 而不是 focusId,确保抽屉展示与计数口径一致。
-  const { upCount, downCount } = useMemo(() => {
-    if (!drawerNodeId) return { upCount: 0, downCount: 0 };
-    let up = 0;
-    let down = 0;
-    for (const e of relations) {
-      const from = endpointToNodeId(e.from);
-      const to = endpointToNodeId(e.to);
-      if (from === drawerNodeId) down += 1;
-      if (to === drawerNodeId) up += 1;
-    }
-    return { upCount: up, downCount: down };
-  }, [drawerNodeId, relations]);
-
-  const closeDrawer = useCallback(() => {
-    setSelectedId(null);
-    setFocusEdgeId(null);
-  }, []);
-  // 边抽屉里「跳转源/目标节点」= 把该节点设为画布中心(openFocus 重排 ±2),并关边抽屉。
-  const focusFromDrawer = useCallback(
-    (id: string | null) => {
-      if (!id) {
-        closeDrawer();
-        return;
-      }
-      setFocusEdgeId(null);
-      openFocus(id);
-    },
-    [closeDrawer, openFocus],
-  );
-  // 抽屉里「设为焦点」按钮 = 把当前抽屉里的节点设为画布中心。
-  const setDrawerAsFocus = useCallback(() => {
-    if (!drawerNodeId) return;
-    openFocus(drawerNodeId);
-  }, [drawerNodeId, openFocus]);
 
   // Switcher 入口:点选 = 设为画布中心(openFocus 重排 ±2)。
   const switchFocusFromList = useCallback(
     (nodeId: string) => {
       openFocus(nodeId);
-      setFocusEdgeId(null);
+      setDrawerState((prev) => ({ ...prev, focusEdgeId: null }));
     },
     [openFocus],
   );
 
-  // 面包屑数据:显示当前焦点(显式 or 布局默认)。kind 用 type 反推
-  // (decisionFocus/decision=decision)。
+  // 面包屑数据:显示当前焦点(显式 or 布局默认)。
   const breadcrumb = useMemo(() => {
     if (!breadcrumbNode) return null;
-    const kindRaw = breadcrumbNode.type === "decisionFocus" || breadcrumbNode.type === "decision"
-      ? "decision"
-      : breadcrumbNode.type === "task"
-        ? "task"
-        : breadcrumbNode.type === "fact"
-          ? "fact"
-          : (breadcrumbNode.type ?? "node");
+    const kindRaw =
+      breadcrumbNode.type === "decisionFocus" || breadcrumbNode.type === "decision"
+        ? "decision"
+        : breadcrumbNode.type === "task"
+          ? "task"
+          : breadcrumbNode.type === "fact"
+            ? "fact"
+            : (breadcrumbNode.type ?? "node");
     const title = breadcrumbNode.data?.label ?? breadcrumbNode.id;
     return {
       kindLabel: kindRaw,
@@ -474,7 +393,7 @@ function GraphViewInner({
         edgeCount={edges.length}
         resolvedFocusId={resolvedFocusId}
         cycleWarning={cycleWarning}
-        hasFocus={Boolean(focusId || focusEdgeId)}
+        hasFocus={Boolean(focusId || drawer.focusEdgeId)}
       />
 
       <FocusHistoryBar
@@ -486,7 +405,7 @@ function GraphViewInner({
         onClear={clearFocus}
       />
 
-      <div className="flex min-h-0 flex-1 relative">
+      <div ref={canvasContainerRef} className="flex min-h-0 flex-1 relative">
         <FocusSwitcher
           decisions={decisions ?? []}
           tasks={tasks}
@@ -503,12 +422,8 @@ function GraphViewInner({
           onEdgeClick={onEdgeClick}
           onPaneClick={onPaneClick}
           colorMode={colorMode}
-          // 不用 fitView:画布视口由 useEgoCanvas 在换焦点时 setCenter 到焦点节点。
-          // 留着 fitView prop 会在节点测量完成后按整图 bbox 复位,把刚居中的焦点重新
-          // 推到一侧(下游更宽时压在左上角 Filters 面板底下),并把缩放改回 fit 值。
           minZoom={0.1}
           maxZoom={2}
-          // 双击 = 设为画布中心。默认的 d3 双击缩放会和 setCenter 抢同一次手势。
           zoomOnDoubleClick={false}
           nodesDraggable={false}
           nodesConnectable={false}
@@ -524,7 +439,6 @@ function GraphViewInner({
           <MiniMap
             nodeColor={(n) => {
               if (n.type === "laneBackground" || n.type === "territoryZone") return "rgba(255, 255, 255, 0.04)";
-              // ego / territoryChip 节点按语义轴上色 —— 否则暗色 minimap 上全是暗灰方块,等于隐形。
               if (n.type === "ego") return MINIMAP_AXIS[(n.data as any)?.entity as string] ?? "var(--color-axis-execution)";
               if (n.type === "territoryChip") return territoryChipColor((n.data as any)?.entity as string) ?? "var(--color-border-strong)";
               if (n.type === "decisionFocus" || n.type === "decision") return "var(--color-accent)";
@@ -553,17 +467,17 @@ function GraphViewInner({
         {/* 节点详情已就地进卡片;抽屉仅保留「边详情」(点关系边)这一路。 */}
         {(selectedNode || focusEdge) && (
           <GraphDrawer
-            focusNode={selectedNode ? drawerNodesMap.get(selectedId) : undefined}
+            focusNode={selectedNode ? drawer.drawerNodesMap.get(drawer.selectedId) : undefined}
             focusEdge={focusEdge ? focusEdge.data : undefined}
-            nodes={drawerNodesMap}
+            nodes={drawer.drawerNodesMap}
             edges={relations}
-            upCount={upCount}
-            downCount={downCount}
-            onClose={closeDrawer}
-            onFocus={focusFromDrawer}
+            upCount={drawer.upCount}
+            downCount={drawer.downCount}
+            onClose={drawer.closeDrawer}
+            onFocus={drawer.focusFromDrawer}
             onNavigateEntity={onNavigateEntity}
-            isFocused={drawerNodeId !== null && drawerNodeId === focusId}
-            onSetAsFocus={setDrawerAsFocus}
+            isFocused={drawer.drawerNodeId !== null && drawer.drawerNodeId === focusId}
+            onSetAsFocus={drawer.setDrawerAsFocus}
           />
         )}
       </div>

--- a/packages/gui/src/renderer/views/graphViewHooks.ts
+++ b/packages/gui/src/renderer/views/graphViewHooks.ts
@@ -1,0 +1,386 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { useReactFlow } from "@xyflow/react";
+
+import type { TaskRow, RelationEdge, DecisionRow, FactRef } from "../model/types";
+import type { RelationCoverageRow, FactAnchorRow } from "../../api/renderer-dto.ts";
+import { endpointToNodeId } from "../graph/endpoint";
+import { computeGraphLayout, type GraphFilterInput } from "../graph/graphLayout";
+import type { ViewMode, TerritorySkel } from "../graph/useTerritoryView";
+
+/**
+ * GraphView 的状态 hook 集合。
+ *
+ * GraphView 在 600 行复杂度门下,所以把状态机外置于此:
+ *   useGraphLayout       — computeGraphLayout 异步调度 + nodes/edges/error 状态。
+ *   useCenterOnFocus     — 换焦点即居中(读焦点节点盒子 → setCenter)。
+ *   useGraphDrawer       — 抽屉(节点详情 / 边详情)的选中态 + 派生数据 + 回调。
+ *   useContainerWidth    — D3:ResizeObserver 测量容器宽度,供领地列数派生。
+ *   useNodeSizeOverrides — D4:用户拖拽调整的卡片尺寸 + localStorage 持久化(NodeResizer)。
+ *
+ * GraphView 本身只做:组合这些 hook + 注入交互回调 + 渲染。
+ */
+
+const EMPTY_LOOP = new Set<string>();
+
+// ══ D3:容器宽度测量 ══
+
+/**
+ * ResizeObserver 测量容器宽度。返回 ref(贴到容器) + width(像素,未测量=0)。
+ * 用于 D3:领地列数由容器宽度派生(deriveGridCols),取代硬编码 GRID_COLS=3。
+ */
+export function useContainerWidth<T extends HTMLElement>(): {
+  ref: RefObject<T | null>;
+  width: number;
+} {
+  const ref = useRef<T | null>(null);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setWidth(entry.contentRect.width);
+    });
+    ro.observe(el);
+    // 首帧同步取值(ResizeObserver 是异步的,首屏 layout 前给个真值避免兜底 3 列闪一下)
+    setWidth(el.getBoundingClientRect().width);
+    return () => ro.disconnect();
+  }, []);
+
+  return { ref, width };
+}
+
+// ══ D4:卡片尺寸覆盖 + localStorage 持久化 ══
+
+const SIZE_OVERRIDES_KEY = "harness:gui:ego-card-sizes";
+
+function readSizes(): Map<string, { w: number; h: number }> {
+  if (typeof window === "undefined") return new Map();
+  try {
+    const raw = window.localStorage.getItem(SIZE_OVERRIDES_KEY);
+    if (!raw) return new Map();
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return new Map();
+    const out = new Map<string, { w: number; h: number }>();
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (
+        v && typeof v === "object" &&
+        typeof (v as any).w === "number" && typeof (v as any).h === "number"
+      ) {
+        out.set(k, { w: (v as any).w, h: (v as any).h });
+      }
+    }
+    return out;
+  } catch {
+    return new Map();
+  }
+}
+
+function writeSizes(sizes: ReadonlyMap<string, { w: number; h: number }>): void {
+  if (typeof window === "undefined") return;
+  try {
+    const obj: Record<string, { w: number; h: number }> = {};
+    for (const [k, v] of sizes) obj[k] = v;
+    window.localStorage.setItem(SIZE_OVERRIDES_KEY, JSON.stringify(obj));
+  } catch {
+    // 隐私模式 / quota 满:静默降级,不阻断 UI。
+  }
+}
+
+/**
+ * NodeResizer 拖拽调整后的卡片尺寸,持久化在 localStorage(复用 favorites.ts 模式)。
+ * 串过 useGraphLayout → computeGraphLayout → layoutCanvasEgo.nodeDims,使布局器尊重
+ * 用户手动调整的尺寸而非每次按内容估算覆盖掉。
+ */
+export function useNodeSizeOverrides(): {
+  sizeOverrides: ReadonlyMap<string, { w: number; h: number }>;
+  setSizeOverride: (id: string, size: { w: number; h: number }) => void;
+} {
+  const [sizes, setSizes] = useState<Map<string, { w: number; h: number }>>(() => readSizes());
+
+  const setSizeOverride = useCallback((id: string, size: { w: number; h: number }) => {
+    setSizes((prev) => {
+      const next = new Map(prev);
+      next.set(id, size);
+      writeSizes(next);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === SIZE_OVERRIDES_KEY) setSizes(readSizes());
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  return { sizeOverrides: sizes, setSizeOverride };
+}
+
+// ══ 布局调度 ══
+
+export interface GraphLayoutInput {
+  tasks: TaskRow[];
+  relations: RelationEdge[];
+  decisions: DecisionRow[];
+  facts: FactRef[];
+  coverageRows?: ReadonlyArray<RelationCoverageRow>;
+  factAnchors?: ReadonlyArray<FactAnchorRow>;
+  focusId: string | null;
+  expandedFacts: Set<string>;
+  filters: GraphFilterInput;
+  shown: Map<string, number>;
+  expanded: Set<string>;
+  viewMode: ViewMode;
+  skel: TerritorySkel;
+  expandedZones: Set<string>;
+  /** D3:领地摆放区容器宽度(像素);0 = 未测量 → 兜底 3 列。 */
+  containerWidth: number;
+  /** D4:用户拖拽的卡片尺寸覆盖;布局器据此而非纯内容估算。 */
+  sizeOverrides: ReadonlyMap<string, { w: number; h: number }>;
+}
+
+export interface GraphLayoutOutput {
+  nodes: any[];
+  edges: any[];
+  cycleWarning: { count: number; cycles: string[][] };
+  error: string | null;
+  resolvedFocusId: string | null;
+}
+
+/**
+ * computeGraphLayout 的 React 封装:异步调度 + AbortController 取消 + 状态托管。
+ * 抽出来让 GraphView 只消费 {nodes, edges, ...} 而不关心调度细节。
+ */
+export function useGraphLayout(input: GraphLayoutInput): GraphLayoutOutput {
+  const {
+    tasks,
+    relations,
+    decisions,
+    facts,
+    coverageRows,
+    factAnchors,
+    focusId,
+    expandedFacts,
+    filters,
+    shown,
+    expanded,
+    viewMode,
+    skel,
+    expandedZones,
+    containerWidth,
+    sizeOverrides,
+  } = input;
+
+  const [nodes, setNodes] = useState<any[]>([]);
+  const [edges, setEdges] = useState<any[]>([]);
+  const [cycleWarning, setCycleWarning] = useState<{
+    count: number;
+    cycles: string[][];
+  }>({ count: 0, cycles: [] });
+  const [error, setError] = useState<string | null>(null);
+  const [resolvedFocusId, setResolvedFocusId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    computeGraphLayout({
+      tasks,
+      relations,
+      decisions,
+      facts,
+      coverageRows: coverageRows ?? [],
+      factAnchors: factAnchors ?? [],
+      focusNodeId: viewMode === "territory" ? null : focusId,
+      expandedFacts,
+      filters,
+      inLoopNodes: EMPTY_LOOP,
+      inLoopEdges: EMPTY_LOOP,
+      ...(viewMode === "territory"
+        ? { territory: { skel, expandedZones, containerWidth } }
+        : { canvas: { shown, expanded, sizeOverrides } }),
+    })
+      .then(({ nodes: rfNodes, edges: rfEdges, cycleWarning: warning, resolvedFocusId: rid }) => {
+        if (ac.signal.aborted) return;
+        setError(null);
+        setNodes(rfNodes);
+        setEdges(rfEdges);
+        setCycleWarning(warning);
+        setResolvedFocusId(rid);
+      })
+      .catch((err) => {
+        if (ac.signal.aborted) return;
+        console.error("Failed to compute graph layout", err);
+        setError(err instanceof Error ? err.stack || err.message : String(err));
+      });
+    return () => ac.abort();
+  }, [
+    tasks,
+    relations,
+    decisions,
+    facts,
+    coverageRows,
+    factAnchors,
+    focusId,
+    expandedFacts,
+    filters,
+    shown,
+    expanded,
+    viewMode,
+    skel,
+    expandedZones,
+    containerWidth,
+    sizeOverrides,
+  ]);
+
+  return { nodes, edges, cycleWarning, error, resolvedFocusId };
+}
+
+// ══ 换焦点即居中 ══
+
+// 焦点卡片(360 宽)+ 左右各一列 chip 同屏可读所用的缩放。
+const FOCUS_ZOOM = 0.9;
+
+/**
+ * 换焦点时把焦点节点摆进视口正中 —— 兑现「以它为中心」,同时躲开左上角 Filters 面板
+ * (fitView 按整图 bbox 居中,下游更宽时会把焦点推到左侧压在面板底下)。
+ *
+ * 从 useEgoCanvas 抽出来,因为 useEgoCanvas 在 hook 调用链里早于 useGraphLayout
+ * (布局需要 focusId),拿不到布局后的 nodes。此 hook 在 GraphView 里 useGraphLayout 之后调用,
+ * 读真实 nodes + resolvedFocusId 做 setCenter。
+ *
+ * 只在焦点变化时触发:累积展开 / 长邻居永不重排已有画布。
+ */
+export function useCenterOnFocus(
+  nodes: ReadonlyArray<any>,
+  resolvedFocusId: string | null,
+): void {
+  const { setCenter } = useReactFlow();
+  const lastCenteredFocus = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!resolvedFocusId) return;
+    if (lastCenteredFocus.current === resolvedFocusId) return;
+    const focusNode = nodes.find((n) => n.id === resolvedFocusId);
+    if (!focusNode) return;
+    lastCenteredFocus.current = resolvedFocusId;
+    const cx = focusNode.position.x + Number(focusNode.width ?? 0) / 2;
+    const cy = focusNode.position.y + Number(focusNode.height ?? 0) / 2;
+    const frame = window.requestAnimationFrame(() => {
+      setCenter(cx, cy, { zoom: FOCUS_ZOOM, duration: 320 });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [resolvedFocusId, nodes, setCenter]);
+}
+
+// ══ 抽屉 ══
+
+export interface GraphDrawerInput {
+  nodes: ReadonlyArray<any>;
+  focusId: string | null;
+  relations: RelationEdge[];
+  openFocus: (id: string) => void;
+  /** 抽屉选中态(节点 id)由 GraphView 持有,使 onEdgeClick/onPaneClick/Esc 能原子更新两 id。 */
+  selectedId: string | null;
+  focusEdgeId: string | null;
+  setSelectedId: (id: string | null) => void;
+  setFocusEdgeId: (id: string | null) => void;
+}
+
+export interface GraphDrawerOutput {
+  selectedId: string | null;
+  focusEdgeId: string | null;
+  setSelectedId: (id: string | null) => void;
+  setFocusEdgeId: (id: string | null) => void;
+  closeDrawer: () => void;
+  drawerNodesMap: Map<any, any>;
+  drawerNodeId: string | null;
+  upCount: number;
+  downCount: number;
+  focusFromDrawer: (id: string | null) => void;
+  setDrawerAsFocus: () => void;
+}
+
+/**
+ * 抽屉(节点详情 / 边详情)状态 + 派生数据 + 回调。
+ * selectedId 与 focusEdgeId 独立(点节点开节点抽屉,点边开边抽屉,互不抢)。
+ * drawerNodeId 是抽屉里实际展示的节点(优先 selected,fallback focus),upCount/downCount 跟随它。
+ */
+export function useGraphDrawer(input: GraphDrawerInput): GraphDrawerOutput {
+  const { nodes, focusId, relations, openFocus, selectedId, focusEdgeId, setSelectedId, setFocusEdgeId } = input;
+
+  const closeDrawer = useCallback(() => {
+    setSelectedId(null);
+    setFocusEdgeId(null);
+  }, [setSelectedId, setFocusEdgeId]);
+
+  // 抽屉里展示的实体(优先 selectedNode,fallback 到 focusNode)。
+  const focusNode = focusId ? nodes.find((n) => n.id === focusId) : null;
+  const selectedNode = selectedId ? nodes.find((n) => n.id === selectedId) : null;
+  const drawerNodeId = selectedNode?.id ?? focusNode?.id ?? null;
+
+  // GraphDrawer 读 closeoutReadiness/engine/freshness/module 等字段,这些只存在于完整
+  // TaskRow(n.data.raw)上。修 #1:此前误传 n.data 导致徽章拿 undefined 崩溃。
+  const drawerNodesMap = useMemo(() => {
+    const map = new Map();
+    nodes.forEach((n) => {
+      if (n.type === "moduleGroup" || n.type === "laneBackground") return;
+      map.set(n.id, {
+        id: n.id,
+        entity: n.type === "decisionFocus" ? "decision" : n.type,
+        label: n.data.label,
+        sub: n.data.sub,
+        task: n.type === "task" ? n.data.raw : undefined,
+        raw: (n.data?.raw ?? n.data) as typeof n.data,
+      });
+    });
+    return map;
+  }, [nodes]);
+
+  const { upCount, downCount } = useMemo(() => {
+    if (!drawerNodeId) return { upCount: 0, downCount: 0 };
+    let up = 0;
+    let down = 0;
+    for (const e of relations) {
+      const from = endpointToNodeId(e.from);
+      const to = endpointToNodeId(e.to);
+      if (from === drawerNodeId) down += 1;
+      if (to === drawerNodeId) up += 1;
+    }
+    return { upCount: up, downCount: down };
+  }, [drawerNodeId, relations]);
+
+  const focusFromDrawer = useCallback(
+    (id: string | null) => {
+      if (!id) {
+        closeDrawer();
+        return;
+      }
+      setFocusEdgeId(null);
+      openFocus(id);
+    },
+    [closeDrawer, openFocus],
+  );
+
+  const setDrawerAsFocus = useCallback(() => {
+    if (!drawerNodeId) return;
+    openFocus(drawerNodeId);
+  }, [drawerNodeId, openFocus]);
+
+  return {
+    selectedId,
+    focusEdgeId,
+    setSelectedId,
+    setFocusEdgeId,
+    closeDrawer,
+    drawerNodesMap,
+    drawerNodeId,
+    upCount,
+    downCount,
+    focusFromDrawer,
+    setDrawerAsFocus,
+  };
+}

--- a/packages/gui/test/canvas-ego-layout.vitest.ts
+++ b/packages/gui/test/canvas-ego-layout.vitest.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { layoutCanvasEgo, buildEgoGraph, bfsShown } from "../src/renderer/graph/canvasEgoLayout";
+import {
+  layoutCanvasEgo,
+  buildEgoGraph,
+  bfsShown,
+  egoFocusIdOf,
+  estimateCardHeight,
+} from "../src/renderer/graph/canvasEgoLayout";
 import type { TaskRow, DecisionRow, FactRef, RelationEdge } from "../src/renderer/model/types";
 import type { AxisFilter, GraphFilterInput } from "../src/renderer/graph/graphLayoutTypes";
 
@@ -150,5 +156,102 @@ describe("layoutCanvasEgo", () => {
     expect(byId.get(FOCUS)!.style.width).toBe(360); // CARD_W
     expect(byId.get("task_C")!.data.expanded).toBe(false);
     expect(byId.get("task_C")!.style.width).toBe(216); // CHIP_W
+  });
+});
+
+// ══ D1:领地→聚光灯 ID 命名空间归一 ══
+// 复现:territoryLayout.buildChipNode 给 task chip 发射的 navRef 是 `task/<id>` 形态,
+// 而 ego 图 byId 的 task 键是裸 id(canvasEgoLayout.buildEgoGraph)。
+// 修复前 useEgoCanvas.openFocus 直接把 navRef 当 focusId → bfsShown 从 task/<id> 出发,
+// adj/byId 都键不上 → 焦点不在 byId → layoutCanvasEgo 丢弃 → 0 节点(空白画布)。
+// 修复:导出 egoFocusIdOf 作为 ego 图入口不变量,openFocus 必须经它归一。
+describe("D1 · egoFocusIdOf (territory chip → ego 焦点归一)", () => {
+  it("task/<id> 归一为裸 id(territory chip navRef 形态)", () => {
+    // territoryLayout.buildChipNode:m.entity === "task" ? `task/${m.id}` : m.id
+    expect(egoFocusIdOf("task/task_01ABC")).toBe("task_01ABC");
+  });
+
+  it("decision/<id> 与裸 task id 原样通过(其他入口形态)", () => {
+    // decision chip navRef = `decision/${id}`(已与 byId 键对齐)
+    expect(egoFocusIdOf("decision/dec_X")).toBe("decision/dec_X");
+    // FocusSwitcher / 双击 / 抽屉「设为焦点」传的是裸 task id
+    expect(egoFocusIdOf("task_01ABC")).toBe("task_01ABC");
+    // fact ref 原样通过
+    expect(egoFocusIdOf("fact/task_x/F1")).toBe("fact/task_x/F1");
+  });
+
+  it("领地 task chip navRef 经 egoFocusIdOf 后喂进 ego 图 >0 节点(集成)", () => {
+    // 真实场景:task_C 有子任务 C1/C2;从领地点 task_C chip 进聚光灯。
+    const { tasks, decisions, facts, relations } = scene();
+    const navRef = "task/task_C"; // territoryLayout 给 task_C chip 的 navRef
+    const focusId = egoFocusIdOf(navRef); // 修复后 openFocus 内部做这步
+    const graph = buildEgoGraph(tasks, decisions, facts, relations);
+    const shown = bfsShown(graph, focusId, 2, ALL_AXES);
+    const out = layoutCanvasEgo({
+      focusId,
+      tasks,
+      decisions,
+      facts,
+      relations,
+      filters: filters(),
+      inLoopEdges: new Set(),
+      shown,
+      expanded: new Set([focusId]),
+    });
+    expect(out.nodes.length).toBeGreaterThan(0);
+    expect(out.nodes.some((n) => n.id === "task_C")).toBe(true);
+    // 焦点本身必须渲染为卡片
+    const focus = out.nodes.find((n) => n.id === "task_C");
+    expect(focus?.data.expanded).toBe(true);
+  });
+
+  it("阴性对照:不经归一直接用 navRef 当 focusId → 0 节点(复现 D1 bug)", () => {
+    // 这是修复前 useEgoCanvas.openFocus 的行为:直接 setFocusId(navRef)。
+    const { tasks, decisions, facts, relations } = scene();
+    const navRef = "task/task_C"; // 未经 egoFocusIdOf 归一
+    const graph = buildEgoGraph(tasks, decisions, facts, relations);
+    // byId 键为裸 task id,task/task_C 不在里面
+    expect(graph.byId.has(navRef)).toBe(false);
+    expect(graph.byId.has(egoFocusIdOf(navRef))).toBe(true);
+    const out = layoutCanvasEgo({
+      focusId: navRef,
+      tasks,
+      decisions,
+      facts,
+      relations,
+      filters: filters(),
+      inLoopEdges: new Set(),
+      shown: bfsShown(graph, navRef, 2, ALL_AXES),
+      expanded: new Set([navRef]),
+    });
+    // bug:焦点不在 byId → vis 集为空 → 0 节点
+    expect(out.nodes.length).toBe(0);
+  });
+});
+
+// ══ D4:task 卡片高度内容感知 ══
+// 修复前 estimateCardHeight 对 task 永远返回 150,长标题被截、短标题浪费空间。
+describe("D4 · estimateCardHeight(task 内容感知)", () => {
+  it("短标题 task 卡片高度基线", () => {
+    const t = task("t_short", { title: "短标题" });
+    const h = estimateCardHeight("task", t);
+    expect(h).toBeGreaterThan(0);
+    expect(h).toBeLessThanOrEqual(260); // 合理上限
+  });
+
+  it("长标题 task 卡片比短标题高(内容感知)", () => {
+    const shortT = task("t_s", { title: "short" });
+    const longT = task("t_l", { title: "X".repeat(120) });
+    const shortH = estimateCardHeight("task", shortT);
+    const longH = estimateCardHeight("task", longT);
+    // 修复前:两者都返回 150(完全相等,bug)。修复后:长标题需要更多行 → 更高。
+    expect(longH).toBeGreaterThan(shortH);
+  });
+
+  it("task 卡片高度不再是无视内容的常量 150(回归)", () => {
+    // 修复前:任何 task 都返回 exactly 150。修复后:基线随内容浮动。
+    const t = task("t", { title: "a".repeat(80) });
+    const h = estimateCardHeight("task", t);
+    expect(h).not.toBe(150);
   });
 });

--- a/packages/gui/test/territory-layout.vitest.ts
+++ b/packages/gui/test/territory-layout.vitest.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { layoutTerritory } from "../src/renderer/graph/territoryLayout";
+import { layoutTerritory, deriveGridCols } from "../src/renderer/graph/territoryLayout";
 import type { TaskRow, DecisionRow, RelationEdge } from "../src/renderer/model/types";
 import type { GraphFilterInput } from "../src/renderer/graph/graphLayoutTypes";
 
@@ -400,5 +400,187 @@ describe("layoutTerritory · 横切", () => {
     });
     expect(out.bounds.width).toBeGreaterThan(0);
     expect(out.bounds.height).toBeGreaterThan(0);
+  });
+});
+
+// ══ D2:zone 展开后 chip 溢出重叠 + decision zone 不折叠 ══
+// 复现:territoryLayout.computeBodyH 把 zone 高度夹在 ZONE_MAX_BODY_H=460,
+// 但 chip 发射按实际成员数(不夹),行推进按夹过的高度 → chip 溢出到下一个 zone/section。
+// 附带同源 bug:visibleMembers 对 decision skel 直接 return zone.members(不折叠),
+// 所以 ≥5 个家族的 decision zone 默认折叠态就已经重叠。
+describe("D2 · zone 展开后零重叠(盒子与孩子同源)", () => {
+  it("task skel:展开大 zone(21 成员)chip 不压到下一行 zone", () => {
+    // 4 个 milestone zone(填满 GRID_COLS=3 的第 1 行 + 第 2 行第 1 个)。
+    // root_big 展开后 21 chip;夹到 460 → 溢出 ~250px 压到 root_d(下一行)。
+    const tasks = [
+      task("root_big", { rootTaskId: "root_big", rootTitle: "Big" }),
+      ...Array.from({ length: 20 }, (_, i) =>
+        task(`big_c${i}`, { parentTaskId: "root_big", rootTaskId: "root_big" }),
+      ),
+      task("root_b", { rootTaskId: "root_b", rootTitle: "B" }),
+      task("b1", { parentTaskId: "root_b", rootTaskId: "root_b" }),
+      task("root_c", { rootTaskId: "root_c", rootTitle: "C" }),
+      task("c1", { parentTaskId: "root_c", rootTaskId: "root_c" }),
+      task("root_d", { rootTaskId: "root_d", rootTitle: "D" }),
+      task("d1", { parentTaskId: "root_d", rootTaskId: "root_d" }),
+    ];
+    const out = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ modules: new Set(["m"]) }),
+      expandedZones: new Set(["root:root_big"]),
+    });
+    expectNoOverlap(out.nodes);
+  });
+
+  it("task skel:展开的 zone 自身 chip 不溢出 zone 盒子(chip-within-zone)", () => {
+    const tasks = [
+      task("root_big", { rootTaskId: "root_big", rootTitle: "Big" }),
+      ...Array.from({ length: 20 }, (_, i) =>
+        task(`big_c${i}`, { parentTaskId: "root_big", rootTaskId: "root_big" }),
+      ),
+    ];
+    const out = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ modules: new Set(["m"]) }),
+      expandedZones: new Set(["root:root_big"]),
+    });
+    const zone = out.nodes.find(
+      (n) => n.type === "territoryZone" && n.data?.zoneId === "root:root_big",
+    );
+    expect(zone).toBeTruthy();
+    const zoneBottom = zone!.position.y + (zone!.height ?? 0);
+    const memberChips = out.nodes.filter(
+      (n) => n.type === "territoryChip" && n.data?.entity === "task",
+    );
+    // 每个 chip 的底边必须在 zone 盒子内(修复前:超出夹过的高度 → 溢出)
+    for (const chip of memberChips) {
+      const chipBottom = chip.position.y + (chip.height ?? 0);
+      expect(chipBottom).toBeLessThanOrEqual(zoneBottom + 1); // +1 容差
+    }
+  });
+
+  it("decision skel:≥5 家族默认折叠态不重叠(decision 也折叠)", () => {
+    // 7 个决策族都落地到 milestone M(同 1 zone),外加 milestone N(下一 section)。
+    // 修复前:decision 不折叠 → 7 chip × 92px = 644,body 夹 460 → 溢出 184px 到 N。
+    const tasks = [
+      task("root_M", { rootTaskId: "root_M", rootTitle: "M" }),
+      task("root_N", { rootTaskId: "root_N", rootTitle: "N" }),
+    ];
+    const decisionsM = Array.from({ length: 7 }, (_, i) =>
+      decision(`dec_M${i}`, { title: `DM${i}`, state: "proposed" }),
+    );
+    const decisionsN = [decision("dec_N0", { title: "DN0" })];
+    const relations = [
+      ...decisionsM.map((d) => rel(`decision/${d.decisionId}`, "task/root_M", "derives")),
+      rel("decision/dec_N0", "task/root_N", "derives"),
+    ];
+    const out = layoutTerritory({
+      skel: "decision",
+      tasks,
+      decisions: [...decisionsM, ...decisionsN],
+      facts: [],
+      relations,
+      filters: filters(),
+      expandedZones: new Set(), // 默认折叠
+    });
+    expectNoOverlap(out.nodes);
+  });
+
+  it("decision skel:展开大 zone(7 家族)也不重叠", () => {
+    const tasks = [
+      task("root_M", { rootTaskId: "root_M", rootTitle: "M" }),
+      task("root_N", { rootTaskId: "root_N", rootTitle: "N" }),
+    ];
+    const decisionsM = Array.from({ length: 7 }, (_, i) =>
+      decision(`dec_M${i}`, { title: `DM${i}`, state: "proposed" }),
+    );
+    const decisionsN = [decision("dec_N0", { title: "DN0" })];
+    const relations = [
+      ...decisionsM.map((d) => rel(`decision/${d.decisionId}`, "task/root_M", "derives")),
+      rel("decision/dec_N0", "task/root_N", "derives"),
+    ];
+    const out = layoutTerritory({
+      skel: "decision",
+      tasks,
+      decisions: [...decisionsM, ...decisionsN],
+      facts: [],
+      relations,
+      filters: filters(),
+      expandedZones: new Set(["landing:__landed__"]), // 展开(landing zone id 由 partition 决定,这里用宽松匹配)
+    });
+    // 即使展开,zone 盒高必须跟着 chip 数走,不能夹。
+    expectNoOverlap(out.nodes);
+  });
+});
+
+// ══ D3:列数由视口宽度派生(不再硬编码 3) ══
+describe("D3 · deriveGridCols(视口宽度派生列数)", () => {
+  it("窄视口(单列)", () => {
+    // 一列需要 ZONE_W=340;两侧 LEFT_PAD=24 各。
+    expect(deriveGridCols(360)).toBe(1);
+    expect(deriveGridCols(400)).toBe(1);
+  });
+
+  it("中视口(2-3 列)", () => {
+    // 2 列需 ~700;3 列需 ~1060。
+    expect(deriveGridCols(720)).toBe(2);
+    expect(deriveGridCols(1060)).toBe(3);
+  });
+
+  it("宽视口(4+ 列)", () => {
+    expect(deriveGridCols(1420)).toBe(4);
+    expect(deriveGridCols(1800)).toBe(5);
+  });
+
+  it("默认值:未测量(width 缺省/0)→ 兜底 3 列", () => {
+    expect(deriveGridCols(0)).toBe(3);
+    expect(deriveGridCols(-1)).toBe(3);
+  });
+
+  it("集成:layoutTerritory 接受 containerWidth,宽屏 4 列", () => {
+    // 8 个 milestone zone,宽屏(4 列)→ 前 4 个在第 1 行;窄屏(3 列)→ 前 3 个在第 1 行。
+    const tasks: TaskRow[] = [];
+    for (let i = 0; i < 8; i++) {
+      const root = `root_${i}`;
+      tasks.push(task(root, { rootTaskId: root, rootTitle: `R${i}` }));
+      tasks.push(task(`${root}_c`, { parentTaskId: root, rootTaskId: root }));
+    }
+    const wide = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ modules: new Set(["m"]) }),
+      expandedZones: new Set(),
+      containerWidth: 1600,
+    });
+    const narrow = layoutTerritory({
+      skel: "task",
+      tasks,
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters({ modules: new Set(["m"]) }),
+      expandedZones: new Set(),
+      containerWidth: 800,
+    });
+    // 宽屏(4 列)的第 4 个 zone 的 x 应远大于窄屏(2 列)第 3 个 zone 的 x —— 列数不同 → 摆位不同。
+    // 用 bounds.width 间接断言:更多列 → 更宽。
+    expect(wide.bounds.width).toBeGreaterThan(narrow.bounds.width);
+    // 且实际有 4 列:第 1 行有 4 个 zone 横向排开(不同 x)。
+    const wideZones = wide.nodes.filter(
+      (n) => n.type === "territoryZone" && n.data?.variant === "zone",
+    );
+    const xs = new Set(wideZones.map((n) => n.position.x));
+    expect(xs.size).toBeGreaterThanOrEqual(4); // 至少 4 个不同的 x(列)
   });
 });


### PR DESCRIPTION
# English

## Summary

Four defects found dogfooding the three-layer graph IA (L1 territory / L2 spotlight / L3 in-place expansion), all root-caused against the real layout code before any of them was touched.

**D1 — clicking a Task chip in the territory dropped you into an empty spotlight.** The ego canvas keys tasks by their **bare** id (`task_01…`) but decisions by a **namespaced** one (`decision/dec_…`). The territory chip handed `openFocus` its `navRef`, which is the *endpoint* form — `task/task_01…`. That string matches no key in `EgoGraph.byId`, so the BFS returned a single phantom entry and `layoutCanvasEgo` dropped it at `if (!meta) continue`: **zero nodes**. Decision chips worked purely by coincidence — their ref already equals the key. Every other entry into `openFocus` (FocusSwitcher, double-click, drawer, default focus) passes a bare id, which is exactly why entering spotlight directly always worked.

The fix does not patch the chip. `openFocus` is the one point every entry converges on, so normalization now lives there as an entry invariant (`egoFocusIdOf`) — the next entry point cannot reintroduce this. Patching the chip side would also have broken `onNavigateEntity`, which legitimately consumes the endpoint form.

**D2 — expanding a territory zone made its chips overlap the neighbours.** The zone box was clamped to `ZONE_MAX_BODY_H=460` while chip emission was unbounded, and the row advanced by the *clamped* height: the zone declared `bottom=612` while its chips ran to `854`. **A related bug nobody had hit yet:** `visibleMembers` returned `zone.members` unfolded for decision zones, so a decision territory with ≥5 families **already overlapped in its default collapsed state**, with no user action at all. The existing test was structurally blind to both — it called `expectNoOverlap` twice and passed `expandedZones: new Set()` both times, passing on the luck of a 2-family fixture.

**D3 — the territory grid was hardcoded to 3 columns** with no viewport input anywhere in the chain. Column count is now derived from the measured container width.

**D4 — content inside expanded node cards could not be scrolled.** The CSS was innocent: the scroll container already had `min-h-0 flex-1 overflow-y-auto` and nothing in the stylesheet hides scrollbars. **React Flow was eating the wheel.** `nowheel` appeared zero times in the entire renderer; RF 12's d3-zoom filter only yields the wheel to a scroll container carrying that class, so every wheel event went to canvas zoom and was `preventDefault()`ed. The scroll event never fired, so macOS overlay scrollbars never appeared. Task card height was also a hardcoded 150px regardless of content, which is why it overflowed so hard. Cards are now content-aware and **drag-resizable** (`NodeResizer`, persisted).

## What Changed

- `graph/canvasEgoLayout.ts` — `egoFocusIdOf()` as the ego-graph entry invariant; `sizeOverrides` threaded into `CanvasEgoInput`; `estimateCardHeight()` replaces the constant 150.
- `graph/useEgoCanvas.ts` — `openFocus` normalizes before `setFocusId` / `pushFocus`.
- `graph/territoryLayout.ts` — zone box height and chip emission derive from the same visible-member set; column count from container width.
- `graph/nodes/EgoNode.tsx` — `nowheel` on the scroll container; `NodeResizer`.
- `views/GraphView.tsx` — **580 → 495 lines**; canvas state extracted to `views/graphViewHooks.ts`. Split first, then extended, so the 600-line complexity gate never had to be argued with.
- `test/canvas-ego-layout.vitest.ts`, `test/territory-layout.vitest.ts` — 16 new tests, **each one verified red before the fix**. The territory suite now actually passes a non-empty `expandedZones` and covers the decision skeleton.

## Task And Scope

- Harness task: `task_01KXCR5E9WAKBH7F6H236BN1DX` (parent: `task_01KXCR4R2GT5DY9HZJABNT5DFQ`, the dogfood defect roll-up)
- Branch: `feat/gui-graph-defects`
- Public scope: `packages/gui` renderer only
- Private planning/evidence updated: yes
- Out of scope: global back/forward and the task document tree (companion PR); backend document listing (companion PR)

## Version Impact

- Version: no version change because this is renderer-only work with no CLI surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KXA7811SVVT8P66HNDFZQ7DF` (three-layer IA), `dec_01KXBGJQFQARSZHHQW1WADFDNC` (L2 canvas model)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `b6b4164` (rebased; 0 behind)
- Sync method: rebase
- **All 8 CI workflow jobs run locally**, derived from `tools/gate-manifest.json` rather than remembered: `typecheck`, `fast-contract`, `package-policy`, `boundaries` (34 gates), `gui-build`, `node26-compatibility`, `full-check`, `supply-chain` — all green.
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm check:local` — exit 0
- [x] `pnpm test` — 0 failed
- [x] `boundaries` — 34/34 (needs `GITHUB_REPOSITORY` + `GITHUB_TOKEN`; `check-github-required-contexts` reads live branch rules)
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR

Negative control: all 16 new tests were confirmed **red before the fix**. The pre-existing territory suite is the cautionary example — it was green throughout because it never exercised the expanded case.

## Review Evidence

- Self-review: yes. The reported root causes were re-checked against the code rather than accepted; the D1 fix location (`openFocus` rather than the chip) was specifically confirmed as the convergence point of all entries.
- Reviewer subagent: not run
- Human review: pending
- Blocking findings: none

## Residual Risk

- **D4 and the resize handle are not proven by these tests.** The suite covers pure layout functions; `nowheel` wheel behaviour and `NodeResizer` interaction are **runtime** properties that only a real Electron session can confirm. This is the honest gap — CEO dogfood is the acceptance step, not the test suite.
- `NodeResizer` under `nodesDraggable={false}` is untested at runtime. React Flow's docs say the two are independent; that has not been verified here.
- Resize commits on `onResizeEnd` → layout recompute, so there is a one-frame settle after the drag. If `GraphView` re-renders mid-drag for unrelated reasons, RF's internal drag dimensions could be overwritten by props. Real-time `onNodesChange` sync is the larger refactor that was not done.
- Removing the `ZONE_MAX_BODY_H` clamp on the box means a 50-member expanded decision zone is ~4600px tall. It no longer overlaps — it is merely long. Internal scrolling/virtualization is out of scope.
- Column measurement uses `ResizeObserver`; on the very first frame the ref is not mounted (width 0), so the grid can briefly show the 3-column fallback before settling.
- `sizeOverrides` persist to a localStorage key with **no project isolation** (unlike `favorites.ts`, which keys by `projectId`). Task ids are globally unique so a collision is unlikely, but the isolation is genuinely absent.

## References

- Task: `task_01KXCR5E9WAKBH7F6H236BN1DX`
- Evidence: `dec_01KXA7811SVVT8P66HNDFZQ7DF`, `dec_01KXBGJQFQARSZHHQW1WADFDNC`
- Review: pending

---

# 中文

## 概要

dogfood 三层关系图 IA（L1 领地 / L2 聚光灯 / L3 原地展开）时暴露的四个缺陷。四条根因都是**先在真实布局代码上跑通复现**才动手的。

**D1 —— 在领地点 Task chip 进聚光灯是一片空白。** ego 画布里 task 用**裸 id** 作键（`task_01…`），decision 用**带前缀**的（`decision/dec_…`）。而领地 chip 交给 `openFocus` 的是 *endpoint* 形态：`task/task_01…`。这个串在 `EgoGraph.byId` 里一个键都匹配不上 → BFS 返回一个幽灵条目 → `layoutCanvasEgo` 在 `if (!meta) continue` 处丢弃 → **零节点**。**decision chip 能用纯属巧合**——它的 ref 恰好就等于键。而所有其他入口（FocusSwitcher / 双击 / 抽屉 / 默认焦点）传的都是裸 id，这正是"直接进聚光灯一直没事"的原因。

修法**不动 chip**。`openFocus` 是所有入口的共同汇聚点，所以归一化作为**入口不变量**落在那里（`egoFocusIdOf`）——下一个新入口没法再把这个 bug 带回来。而且改 chip 侧会打断 `onNavigateEntity`，它是**正当地**在消费 endpoint 形态。

**D2 —— 展开领地 zone,它的 chip 会压到邻居身上。** zone 盒高被 `ZONE_MAX_BODY_H=460` 夹住，但 chip 是**无上限发射**的，行推进只按**夹过的**高度走：zone 声称自己 `bottom=612`，chip 一路铺到 `854`。**还有一个谁都没撞上的同源 bug**：`visibleMembers` 对 decision zone 直接返回 `zone.members` 不折叠，所以**决策领地只要 ≥5 个家族，默认收起状态下就已经重叠了**，不需要用户做任何操作。既有测试对两者**结构性失明**——它调了两次 `expectNoOverlap`，两次都传 `expandedZones: new Set()`，靠一个只有 2 个家族的 fixture 侥幸全绿。

**D3 —— 领地网格硬编码 3 列**，整条链路没有任何视口输入。列数现在由实测容器宽度派生。

**D4 —— 展开的节点卡片里的内容滚不动。** CSS 是无辜的：滚动容器早就有 `min-h-0 flex-1 overflow-y-auto`，样式表里也没有任何隐藏滚动条的规则。**是 React Flow 把滚轮吃了。** 全渲染进程里 `nowheel` 出现 **0 次**；RF 12 的 d3-zoom filter 只在滚动容器带这个类时才让出滚轮，否则滚轮全被拿去缩放画布并 `preventDefault()`。**滚动事件从未触发**，macOS 的浮层滚动条自然永远不出现。另外 task 卡片高度写死 150px 完全不看内容——这是它溢出得那么厉害的直接原因。卡片现在内容感知，且**可拖拽调整大小**（`NodeResizer`，尺寸持久化）。

## 改动内容

- `graph/canvasEgoLayout.ts` —— `egoFocusIdOf()` 作为 ego 图入口不变量；`sizeOverrides` 串入 `CanvasEgoInput`；`estimateCardHeight()` 取代常量 150。
- `graph/useEgoCanvas.ts` —— `openFocus` 在 `setFocusId` / `pushFocus` 之前先归一化。
- `graph/territoryLayout.ts` —— zone 盒高与 chip 发射**同源**于同一个 visible-member 集合；列数由容器宽度派生。
- `graph/nodes/EgoNode.tsx` —— 滚动容器加 `nowheel`；接入 `NodeResizer`。
- `views/GraphView.tsx` —— **580 → 495 行**；画布状态抽进 `views/graphViewHooks.ts`。**先拆再加**，所以 600 行门禁全程没成为问题。
- `test/canvas-ego-layout.vitest.ts`、`test/territory-layout.vitest.ts` —— 16 个新测试，**每一个都验证过"修之前是红的"**。领地套件现在真的传入非空 `expandedZones`，并覆盖 decision 骨架轴。

## 任务与范围

- Harness 任务：`task_01KXCR5E9WAKBH7F6H236BN1DX`（父任务 `task_01KXCR4R2GT5DY9HZJABNT5DFQ` = dogfood 缺陷收口）
- 分支：`feat/gui-graph-defects`
- 公开范围：只动 `packages/gui` 渲染进程
- 私有计划 / 证据是否已更新：yes
- 范围外：全局前进后退与任务文档树（配套 PR）；后端文档列表（配套 PR）

## 版本影响

- 版本：不改版本，原因是只动渲染进程、不碰 CLI 面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`dec_01KXA7811SVVT8P66HNDFZQ7DF`（三层 IA）、`dec_01KXBGJQFQARSZHHQW1WADFDNC`（L2 画布模型）
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`b6b4164`（已 rebase，落后 0）
- 同步方式：rebase
- **CI 的 8 个 workflow job 本地全跑**，job 集是从 `tools/gate-manifest.json` **派生**的，不靠记忆枚举：`typecheck`、`fast-contract`、`package-policy`、`boundaries`（34 道门）、`gui-build`、`node26-compatibility`、`full-check`、`supply-chain` —— 全绿。
- [x] `pnpm typecheck` —— exit 0
- [x] `pnpm check:local` —— exit 0
- [x] `pnpm test` —— 0 失败
- [x] `boundaries` —— 34/34（需要 `GITHUB_REPOSITORY` + `GITHUB_TOKEN`，因为 `check-github-required-contexts` 会去读 GitHub 上活的分支保护规则）
- [ ] GitHub Actions `rewrite-ci` passed —— 待本 PR 的 CI

阴性对照：16 个新测试**全部确认过"修之前是红的"**。既有的领地套件是反面教材——它全程是绿的，因为它从来没跑过展开的情况。

## Review Evidence

- 自审：yes。实现方报的根因我逐条回到代码复核，不采信报告；D1 的修复位置（落在 `openFocus` 而不是 chip）我专门确认过它确实是所有入口的汇聚点。
- Reviewer subagent：未跑
- 人工复核：待办
- 阻塞发现：无

## Residual Risk

- **D4 和拖拽 resize，这些测试证明不了。** 套件覆盖的是纯布局函数；`nowheel` 的滚轮行为与 `NodeResizer` 交互是**运行时**属性，只有真实 Electron 会话能确认。**这是诚实的缺口——验收步骤是 CEO dogfood，不是测试套件。**
- `NodeResizer` 在 `nodesDraggable={false}` 下的行为未做运行时验证。React Flow 文档说两者独立，但这里没验过。
- resize 在 `onResizeEnd` 提交 → 布局重算，所以拖完有一帧的落定延迟。如果 `GraphView` 在拖拽中途因无关原因重渲染，RF 内部的 drag 维度可能被 prop 覆盖。实时 `onNodesChange` 同步是更大的重构，没做。
- 去掉盒子的 `ZONE_MAX_BODY_H` 夹之后，一个展开的 50 成员 decision zone 高约 4600px。它**不再重叠**，只是很长。内部滚动 / 虚拟化超出范围。
- 列数测量走 `ResizeObserver`；首帧 ref 还没挂载（width=0），所以网格可能先闪一下 3 列兜底再落定。
- `sizeOverrides` 持久化到 localStorage，**没有项目维度隔离**（`favorites.ts` 是按 `projectId` 隔离的）。task id 全局唯一所以撞的概率低，但**这个隔离确实是缺的**。

## References

- 任务：`task_01KXCR5E9WAKBH7F6H236BN1DX`
- 证据：`dec_01KXA7811SVVT8P66HNDFZQ7DF`、`dec_01KXBGJQFQARSZHHQW1WADFDNC`
- 复核：待办
