### PR TITLE
fix(cli): preserve parse errors when diagnostics fail

### DIFF
--- a/packages/cli/src/cli/parse-failure-runtime-event.ts
+++ b/packages/cli/src/cli/parse-failure-runtime-event.ts
@@ -28,8 +28,9 @@ export async function appendParseFailureRuntimeEvent(
     await (dependencies.append ?? appendOperationalParseFailureRuntimeEvent)(argv, error);
   } catch (diagnosticError) {
     try {
+      const detail = diagnosticError instanceof Error ? diagnosticError.message : String(diagnosticError);
       (dependencies.warn ?? console.error)(
-        `warning: unable to append CLI parse-failure diagnostic: ${errorMessage(diagnosticError)}`
+        `warning: unable to append CLI parse-failure diagnostic: ${detail}`
       );
     } catch {
       // A broken stderr must not turn best-effort diagnostics into the primary failure.
@@ -95,8 +96,4 @@ async function appendOperationalParseFailureRuntimeEvent(
     });
     yield* coordinator.flush("explicit");
   }));
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/cli/src/cli/parse-failure-runtime-event.ts
+++ b/packages/cli/src/cli/parse-failure-runtime-event.ts
@@ -1,49 +1,102 @@
-import { Effect } from "effect";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { Effect, Schema } from "effect";
+import { makeEnvironmentCurrentSessionProbe } from "../../../application/src/index.ts";
 import {
-  makeEnvironmentCurrentSessionProbe,
-  makeRuntimeEventLedgerService,
-  runtimeEventActorFromTaskHolderPrincipal
-} from "../../../application/src/index.ts";
-import { makeOperationalJournaledWriteCoordinator } from "../../../kernel/src/index.ts";
+  makeOperationalJournaledWriteCoordinator,
+  moduleEntityId,
+  resolveHarnessLayout,
+  RuntimeEventRecordSchema,
+  stablePayloadHash
+} from "../../../kernel/src/index.ts";
 import type { CommandFailureReceipt } from "./receipt.ts";
 import { stripGlobalOptions } from "./parse-options.ts";
-import { resolveCliTaskHolderPrincipal, resolveLocalCliActorAttribution } from "../composition/local-principal.ts";
+
+type ParseFailureError = CommandFailureReceipt["error"];
+
+interface ParseFailureRuntimeEventDependencies {
+  readonly append?: (argv: ReadonlyArray<string>, error: ParseFailureError) => Promise<void>;
+  readonly warn?: (message: string) => void;
+}
 
 export async function appendParseFailureRuntimeEvent(
   argv: ReadonlyArray<string>,
-  error: CommandFailureReceipt["error"]
+  error: ParseFailureError,
+  dependencies: ParseFailureRuntimeEventDependencies = {}
+): Promise<void> {
+  try {
+    await (dependencies.append ?? appendOperationalParseFailureRuntimeEvent)(argv, error);
+  } catch (diagnosticError) {
+    try {
+      (dependencies.warn ?? console.error)(
+        `warning: unable to append CLI parse-failure diagnostic: ${errorMessage(diagnosticError)}`
+      );
+    } catch {
+      // A broken stderr must not turn best-effort diagnostics into the primary failure.
+    }
+  }
+}
+
+async function appendOperationalParseFailureRuntimeEvent(
+  argv: ReadonlyArray<string>,
+  error: ParseFailureError
 ): Promise<void> {
   const stripped = stripGlobalOptions(argv);
   const layoutOverrides = stripped.authoredRoot ? { authoredRoot: stripped.authoredRoot } : undefined;
   const rootInput = layoutOverrides ? { rootDir: stripped.rootDir, layoutOverrides } : stripped.rootDir;
+  const layout = resolveHarnessLayout(rootInput);
   const session = await Effect.runPromise(makeEnvironmentCurrentSessionProbe().currentSession);
-  const attribution = resolveLocalCliActorAttribution(rootInput, process.env, stripped.actor);
-  const actor = runtimeEventActorFromTaskHolderPrincipal(resolveCliTaskHolderPrincipal(rootInput, attribution));
-  const service = makeRuntimeEventLedgerService({
-    rootInput,
-    coordinator: makeOperationalJournaledWriteCoordinator({
-      rootDir: stripped.rootDir,
-      ...(layoutOverrides ? { layoutOverrides } : {}),
-      operationalActor: { scope: "operational", kind: "agent", id: "runtime-event-cli" }
-    })
-  });
-  await Effect.runPromise(service.append({
+  const recordedAt = new Date().toISOString();
+  const eventId = `evt_${randomUUID()}`;
+  const event = Schema.decodeUnknownSync(RuntimeEventRecordSchema)({
+    schema: "runtime-event/v1",
+    eventId,
+    recordedAt,
     kind: "result",
-    actor,
     session: {
       sessionId: session.sessionId,
-      runtime: session.runtime
+      runtime: session.runtime,
+      executionId: null,
+      reviewId: null
     },
+    turn: null,
+    step: null,
     tool: {
       toolName: "parse",
       ...(error?.code ? { errorCode: error.code } : {})
     },
+    approval: null,
+    interrupt: null,
     result: {
       status: "failed",
       summary: "CLI parse failed",
       ...(error?.code ? { errorCode: error.code } : {})
-    }
-  })).catch(() => {
-    // Parse errors must remain honest even when telemetry is unavailable.
+    },
+    cost: null
   });
+  const payload = {
+    boundary: "runtime-event-ledger",
+    path: path.relative(layout.rootDir, layout.runtimeEventLedgerPath(session.sessionId)).split(path.sep).join("/"),
+    value: event
+  };
+  const coordinator = makeOperationalJournaledWriteCoordinator({
+    rootDir: stripped.rootDir,
+    ...(layoutOverrides ? { layoutOverrides } : {}),
+    operationalActor: { scope: "operational", kind: "agent", id: "runtime-event-cli" }
+  });
+  const opId = `runtime-event-${eventId}-${stablePayloadHash(payload).slice(0, 16)}`;
+
+  await Effect.runPromise(Effect.gen(function* () {
+    yield* coordinator.enqueue({
+      opId,
+      entityId: moduleEntityId("runtime-event-ledger"),
+      kind: "machine_artifact_append_jsonl",
+      payload
+    });
+    yield* coordinator.flush("explicit");
+  }));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/cli/test/runtime-event-cli.test.ts
+++ b/packages/cli/test/runtime-event-cli.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
 import { appendCommandRuntimeEvent } from "../src/cli/command-runtime-events.ts";
+import { appendParseFailureRuntimeEvent } from "../src/cli/parse-failure-runtime-event.ts";
 import type { CommandRunnerContext } from "../src/cli/runner-registry.ts";
 import type { ParsedCommand } from "../src/cli/types.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
@@ -167,24 +168,62 @@ test("CLI entity write fails closed before runtime event append when principal c
   });
 });
 
-test("CLI parse failures append safe failed command events", () => {
+test("CLI parse failures append operational events without business actor attribution", () => {
   withTempRoot((rootDir) => {
     const sessionId = "codex-w2-parse-failure";
-    const result = runJson(rootDir, ["definitely-not-a-command", "--secret", "do-not-store"], false, {
+    const output = runJsonWithStderr(rootDir, [
+      "decision", "propose",
+      "--title", "Malformed rejection",
+      "--question", "Which option?",
+      "--chosen", "Chosen option",
+      "--rejected", '{"badfield":"do-not-store"}'
+    ], {
       CODEX_SESSION_ID: sessionId,
-      CODEX_THREAD_ID: ""
-    });
+      CODEX_THREAD_ID: "",
+      HARNESS_ACTOR: "",
+      HARNESS_GIT_AUTHOR_NAME: "",
+      HARNESS_GIT_AUTHOR_EMAIL: "",
+      GIT_AUTHOR_NAME: "",
+      GIT_AUTHOR_EMAIL: ""
+    }, 2);
     const ledgerPath = path.join(rootDir, ".harness/generated/runtime-events", `${sessionId}.jsonl`);
     const body = readFileSync(ledgerPath, "utf8");
     const events = readJsonl(ledgerPath);
 
-    assert.equal(result.ok, false);
+    assert.equal(output.result.ok, false);
+    assert.equal(output.result.error?.code, "invalid_decision_amend_patch");
+    assert.match(output.result.error?.hint ?? "", /rejected JSON requires text/u);
+    assert.doesNotMatch(output.stderr, /CliActorAttributionError/u);
     assert.equal(events.length, 1);
+    assert.equal(events[0].actor, undefined);
+    assert.equal(events[0].actorAxes, undefined);
     assert.equal(events[0].tool.toolName, "parse");
     assert.equal(events[0].result.status, "failed");
-    assert.equal(events[0].result.errorCode, "unknown_command");
+    assert.equal(events[0].result.errorCode, "invalid_decision_amend_patch");
     assert.equal(body.includes("do-not-store"), false);
   });
+});
+
+test("parse-failure diagnostic injection failures preserve the primary error and emit a warning", async () => {
+  const primaryError = {
+    code: "invalid_json_input",
+    category: "parse",
+    hint: "rejected JSON requires text"
+  } as const;
+  const warnings: string[] = [];
+
+  await appendParseFailureRuntimeEvent([], primaryError, {
+    append: async (_argv, error) => {
+      assert.equal(error, primaryError);
+      throw new Error("injected runtime-event failure");
+    },
+    warn: (message) => warnings.push(message)
+  });
+
+  assert.equal(primaryError.hint, "rejected JSON requires text");
+  assert.deepEqual(warnings, [
+    "warning: unable to append CLI parse-failure diagnostic: injected runtime-event failure"
+  ]);
 });
 
 test("CLI event append and list write local JSONL without task lifecycle mutation", () => {


### PR DESCRIPTION
# English

## Summary

CLI parse-failure diagnostics previously required a resolved business actor before appending the runtime event. Without `HARNESS_ACTOR`, `resolveLocalCliActorAttribution` threw `CliActorAttributionError` and **masked the original parse error** (observed 2026-07-13: a `decision propose` JSON field-name mistake surfaced as an attribution error, multiplying triage cost). This PR fixes two invariants: diagnostic events are operational records signed by `OperationalActor` (no business actor required, none fabricated), and no failure in the diagnostic path can ever mask the primary error.

## What Changed

- `packages/cli/src/cli/parse-failure-runtime-event.ts`: the parse-failure runtime event no longer resolves business actor attribution. The event is written actor-less (`runtime-event/v1`) through `makeOperationalJournaledWriteCoordinator` with `OperationalActor { scope: "operational", kind: "agent", id: "runtime-event-cli" }`. The whole diagnostic append is wrapped so any failure degrades to a single stderr warning (not a black hole, never a thrown error); the primary parse error always propagates unchanged.
- `packages/cli/test/runtime-event-cli.test.ts`: two positive controls, both red before the fix and green after: (1) no-actor environment + malformed JSON → the original `rejected JSON requires text` error is visible (exit 2), the event lands on disk without a fabricated business actor; (2) injected diagnostic failure → primary error untouched, warning emitted.

## Task And Scope

- Harness task: task_01KXD0AETSZBTAPPZ03Q3ZT7XW
- Branch: fix/parse-failure-operational-actor
- Public scope: packages/cli (parse-failure diagnostic path + tests) only
- Private planning/evidence updated: yes (task package plan/progress in private ledger)
- Out of scope: canonical entity write attribution (fail-closed semantics untouched, `local-principal.ts` unmodified); daemon socket lifecycle (separate task/PR)

## Version Impact

- Version: no version change because this is a bug fix within existing CLI behavior, no public API change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: ADR-0028 (OperationalActor for non-business writes); harness task task_01KXD0AETSZBTAPPZ03Q3ZT7XW
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 01e131e97d2ad9253b0c67e3645876240cfc6625
- Branch merge-base with `origin/main`: 01e131e97d2ad9253b0c67e3645876240cfc6625
- Last `git fetch origin` time: 2026-07-13 (pre-push, same session)
- Sync method: none needed (branch based on current main)
- Public diff command: `git diff 01e131e9..3664682d`
- Private evidence commit/path: harness/tasks/task_01KXD0AETSZBTAPPZ03Q3ZT7XW-parse-failure-actor-operationalactor/
- Reviewer evidence path: same task package (task_plan.md invariants 1-2)
- GitHub Actions `rewrite-ci` run URL: pending (will be attached by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (via root `check:local`, 16/16, 118s)
- [x] `npm run typecheck` (via root `check:local`)
- [x] `npm test` (runtime-event integration 11/11; hermetic no-actor + `GIT_CONFIG_GLOBAL=/dev/null` 2/2)
- [x] `npm run harness:check-import-boundaries` (via `check:local`)
- [x] `npm run harness:scan-forbidden-symbols` (via `check:local`)
- [x] `npm run harness:check-private-boundary` (via `check:local`)
- [x] `npm run harness:check-package-policy` (via `check:local`)
- [x] `npm run harness:check-implementation-contracts` (via `check:local`)
- [x] `npm run harness:check-schema-contracts` (via `check:local`)
- [x] `npm run harness:check-legacy-intake-readiness` (via `check:local`)
- [x] `npm run harness:smoke-cli-package` (via `check:local`)
- [ ] GitHub Actions `rewrite-ci` passed

---

# 中文

## 摘要

CLI 参数解析失败后的诊断路径此前要求先解析出业务 actor 才能落 runtime event。无 `HARNESS_ACTOR` 时 `resolveLocalCliActorAttribution` 抛 `CliActorAttributionError` 并**掩盖原始解析错误**（2026-07-13 实测：`decision propose` 的 JSON 字段名错误被报成 attribution 错误，排障成本放大数倍）。本 PR 修两条不变量：诊断事件是 operational 记录、由 `OperationalActor` 署名（不要求也不伪造业务 actor）；诊断路径任何失败绝不掩盖主错误。

## 变更内容

- `packages/cli/src/cli/parse-failure-runtime-event.ts`：parse-failure runtime event 不再解析业务 actor 归属。事件以 actor-less（`runtime-event/v1`）形式经 `makeOperationalJournaledWriteCoordinator` 落盘，署名为 `OperationalActor { scope: "operational", kind: "agent", id: "runtime-event-cli" }`。整条诊断 append 被包裹：任何失败降级为一行 stderr warning（不是黑洞、也绝不抛出），主解析错误原样冒泡。
- `packages/cli/test/runtime-event-cli.test.ts`：两个阳性对照（修复前红、修复后绿）：①无 actor 环境 + 坏 JSON → 原始 `rejected JSON requires text` 可见（exit 2），事件落盘且无伪造业务 actor；②注入诊断失败 → 主错误不变，warning 落 stderr。

## 任务与范围

- Harness task：task_01KXD0AETSZBTAPPZ03Q3ZT7XW
- 分支：fix/parse-failure-operational-actor
- 公开范围：仅 packages/cli（parse-failure 诊断路径 + 测试）
- 私有计划/证据已更新：是（任务包 plan/progress 在私有账本）
- 范围外：canonical entity 写归属（fail-closed 语义零改动，`local-principal.ts` 未动）；daemon socket 生命周期（另一任务/PR）

## 版本影响

- 版本：无版本变更，原因：现有 CLI 行为内的 bug 修复，无公开 API 变化
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权依据：ADR-0028（非业务写走 OperationalActor）；harness 任务 task_01KXD0AETSZBTAPPZ03Q3ZT7XW
- 机器检查边界：本 PR 仅断言声明存在；声明是否真实充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- Base `origin/main` SHA：01e131e97d2ad9253b0c67e3645876240cfc6625
- 分支与 `origin/main` 的 merge-base：01e131e97d2ad9253b0c67e3645876240cfc6625
- 最近 `git fetch origin` 时间：2026-07-13（push 前，同一会话）
- 同步方式：无需（分支基于当前 main）
- 公开 diff 命令：`git diff 01e131e9..3664682d`
- 私有证据 commit/路径：harness/tasks/task_01KXD0AETSZBTAPPZ03Q3ZT7XW-parse-failure-actor-operationalactor/
- 评审证据路径：同任务包（task_plan.md 不变量 1-2）
- GitHub Actions `rewrite-ci` run URL：待 CI 附上
- 复选框状态同英文块（本地 `check:local` 16/16 全绿 118s；runtime-event 集成 11/11；hermetic 复验 2/2）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
