### PR TITLE
feat(tools): derive the local gate set from the manifest instead of remembering it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,15 @@ Harness Anything is a repo-native harness. Public code and docs live in this rep
 1. Branch from latest `origin/main`.
 2. Keep implementation changes scoped to the task or issue.
 3. Add or update tests for behavior changes.
-4. Run `npm run check` before requesting review.
-5. In the PR, list the verification commands and any deferred work.
+4. Run `npm run check:ci` before requesting review. It reads
+   `tools/gate-manifest.json` and runs **every** job CI runs on a pull request —
+   nine of them, and the `boundaries` job alone carries 35 gates. Do not
+   substitute `npm run check:local`: that is a fast-tier subset and is not equal
+   to any CI job, which is why "green locally, red in CI" keeps happening. Set
+   `GITHUB_REPOSITORY` and `GITHUB_TOKEN` first; the `boundaries` job reads
+   GitHub's live branch rules.
+5. In the PR, paste the `npm run check:ci -- --json <path>` receipt rather than
+   asserting the gates passed, and list any deferred work.
 6. If you changed CLI code and use the built bin (`npx ha`), rebuild the
    workspace dist (`npm run build -w @harness-anything/cli`); running from
    source (`node packages/cli/src/index.ts`) is always fresh. Refresh a global

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "check:pr": "npm run typecheck && npm run lint && npm run test:fast && npm run test:contract && npm run test:integration && npm run test:gui && node tools/run-manifest-gates.mjs --package-surface checkPr --exclude typecheck,lint,test-fast,test-contract,test-integration,test-gui",
     "check:local": "node tools/run-local-check.mjs",
     "check:local:gates": "node tools/run-local-gates-check.mjs",
+    "check:ci": "node tools/run-ci-equivalent.mjs",
     "check:local:full": "node tools/run-local-check.mjs --full",
     "harness:check-file-complexity": "node tools/check-file-complexity.mjs",
     "harness:check-cli-structure": "node tools/check-cli-structure.mjs",

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/task.plan/en-US.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/task.plan/en-US.md
@@ -36,5 +36,6 @@ If this task is not a CI/gate/governance task but requires modifying CI/gate aut
 
 ## Verification
 
-- List required local checks, CI, and review evidence.
+- **Stop point = `npm run check:ci` green + a local commit.** It derives *every* job CI runs on a pull request from `tools/gate-manifest.json` and runs them all. Do not hand-copy a list of gates here: lists rot (`check:local` is only a fast-tier subset, and the `boundaries` job alone carries 35 gates), whereas this command grows with the manifest. Paste the `--json <path>` receipt into this section verbatim rather than writing "all green" — a receipt is an artifact, an assertion is not.
+- List any review and human acceptance conditions this task additionally requires.
 - Per `dec_mrg3z1we/CH4`, Facts are explicit `0..N` promotions, not a review or completion quantity gate; verify delivery through Execution outputs, review, closeout, and the applicable completion gates.

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/task.plan/zh-CN.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/task.plan/zh-CN.md
@@ -36,5 +36,6 @@ Task Contract: harness-task v1
 
 ## Verification
 
-- 列出需要通过的本地检查、CI 和 review。
+- **停止点 = `npm run check:ci` 全绿 + 本地 commit。** 它从 `tools/gate-manifest.json` 派生出 CI 在 pull_request 上跑的**全部** job 并逐个执行——不要在这里手抄一张门的清单：清单会腐烂（`check:local` 只是 fast tier 子集，光 `boundaries` 一个 job 就 35 道门），而这条命令会跟着 manifest 自动长。把 `--json <path>` 回执原样贴进本节，别只写「全绿」——回执是产物，断言不是。
+- 列出本任务额外需要的 review 与人工验收条件。
 - 依据 `dec_mrg3z1we/CH4`，Fact 是 `0..N` 的显式晋升，不是 review 或 completion 的数量门；交付通过 Execution outputs、review、closeout 与适用的 completion gates 验证。

--- a/tools/run-ci-equivalent.mjs
+++ b/tools/run-ci-equivalent.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// 本地跑一遍 CI 在 pull_request 上跑的全部 job。
+//
+// 存在的理由:本仓的门集不是四道、也不是五道 —— 它是 gate-manifest.json 里
+// executionSurfaces.rewriteCi.pullRequestJobs 声明的 9 个 workflow job(光 boundaries
+// 一个就 35 道门),而 `check:local` 只是 fast tier 的一个子集,不等于任何一个 CI job。
+// 靠人(或 agent)记住一张会增长的清单,已经连续失败了五次 —— 每次都是"本地全绿、CI 红",
+// 每次的修法都是"下次记得再多跑一道",而清单还在长。
+//
+// 所以这里不枚举 job,而是【从 manifest 派生】。新增一个 job、给某个 job 挂一道新门,
+// 这个命令自动跟上,不需要任何人记住任何事。
+//
+// 用法:
+//   npm run check:ci                     跑全部可本地执行的 job
+//   npm run check:ci -- --job boundaries  只跑指定 job(可重复)
+//   npm run check:ci -- --json           额外吐一份机器可读回执(贴进 PR / worker 报告)
+//
+// 回执是产物,不是断言:每个 job 的真实 exit code 都在里面。CEO 会重跑并比对数字。
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const manifest = JSON.parse(readFileSync(path.join(root, "tools/gate-manifest.json"), "utf8"));
+
+// pr-body-lint 需要一个真实 PR body,本地没有;integration-shard 需要分片参数,单独展开。
+const INTEGRATION_SHARDS = 6;
+const NOT_LOCALLY_RUNNABLE = new Set(["pr-body-lint"]);
+
+// GitHub 上的活配置(分支保护规则)不是代码,读它需要凭据。缺凭据是环境问题不是代码问题,
+// 所以显式提示而不是让它红在一个看不懂的地方。
+const NEEDS_GITHUB = ["GITHUB_REPOSITORY", "GITHUB_TOKEN"];
+
+function deriveJobs() {
+  const jobs = new Map();
+  for (const gate of manifest.gates ?? []) {
+    for (const job of gate.executionSurfaces?.rewriteCi?.pullRequestJobs ?? []) {
+      if (!jobs.has(job)) jobs.set(job, []);
+      jobs.get(job).push(gate.id);
+    }
+  }
+  return jobs;
+}
+
+// gui-build 内含 `vite build`,它写出 packages/gui/dist;之后任何 `tsc -b` 都会被
+// TS6305「陈旧产物」毒化 —— 那是假红,会让人去查一个根本不存在的类型错误。
+// CI 里每个 job 是干净 checkout,所以碰不到;本地必须每个 job 之前自己清一次。
+function clearIncrementalArtifacts() {
+  rmSync(path.join(root, "packages/gui/dist"), { recursive: true, force: true });
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.name === "node_modules" || entry.name === ".git") continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.name.endsWith(".tsbuildinfo")) rmSync(full, { force: true });
+    }
+  }
+}
+
+function runJob(job, shard) {
+  clearIncrementalArtifacts();
+  const args = ["tools/run-manifest-gates.mjs", "--workflow-job", job, "--exclude", "mergify-queue-metadata-edit-noop"];
+  if (shard !== undefined) args.push("--shard", String(shard));
+  const started = Date.now();
+  const result = spawnSync(process.execPath, args, { cwd: root, stdio: "inherit" });
+  return {
+    job: shard === undefined ? job : `${job} (${shard})`,
+    exitCode: result.status ?? 1,
+    seconds: Math.round((Date.now() - started) / 1000)
+  };
+}
+
+const argv = process.argv.slice(2);
+const wanted = [];
+// 回执写文件,不写 stdout —— 每个 gate 都是 stdio:inherit,stdout 早被它们的输出占满了,
+// 把 JSON 混进去等于交出一份没法解析的回执(实测第一版就是这么废的)。
+let receiptPath = null;
+for (let index = 0; index < argv.length; index += 1) {
+  if (argv[index] === "--job") { wanted.push(argv[index + 1]); index += 1; continue; }
+  if (argv[index] === "--json") { receiptPath = argv[index + 1] ?? "check-ci-receipt.json"; index += 1; continue; }
+  throw new Error(`unknown option: ${argv[index]}`);
+}
+
+const derived = deriveJobs();
+const missingCredentials = NEEDS_GITHUB.filter((name) => !process.env[name]);
+if (missingCredentials.length > 0) {
+  console.error(
+    `\n[check:ci] ${missingCredentials.join(" and ")} not set. The boundaries job reads GitHub's live\n` +
+    `           branch rules (check-github-required-contexts) and will fail for environmental\n` +
+    `           reasons, not code reasons. Set them first:\n\n` +
+    `             export GITHUB_REPOSITORY=<owner>/<name>\n` +
+    `             export GITHUB_TOKEN=$(gh auth token)\n`
+  );
+}
+
+const selected = wanted.length > 0 ? wanted : [...derived.keys()];
+const plan = [];
+for (const job of selected) {
+  if (!derived.has(job)) throw new Error(`no gate in the manifest declares workflow job "${job}"`);
+  if (NOT_LOCALLY_RUNNABLE.has(job)) {
+    console.error(`[check:ci] skipping ${job}: needs a real pull request, cannot run locally.`);
+    continue;
+  }
+  if (job === "integration-shard") {
+    for (let shard = 1; shard <= INTEGRATION_SHARDS; shard += 1) plan.push([job, shard]);
+    continue;
+  }
+  plan.push([job, undefined]);
+}
+
+console.error(
+  `\n[check:ci] ${plan.length} runs derived from tools/gate-manifest.json ` +
+  `(${[...derived].map(([job, gates]) => `${job}:${gates.length}`).join(" ")})\n`
+);
+
+const receipts = [];
+for (const [job, shard] of plan) {
+  receipts.push(runJob(job, shard));
+}
+
+const failed = receipts.filter((receipt) => receipt.exitCode !== 0);
+console.error("\n──── check:ci ────");
+for (const receipt of receipts) {
+  console.error(`  ${receipt.exitCode === 0 ? "✓" : "✗"} ${receipt.job.padEnd(24)} exit=${receipt.exitCode}  ${receipt.seconds}s`);
+}
+console.error(failed.length === 0 ? "  ALL GREEN\n" : `  RED: ${failed.map((receipt) => receipt.job).join(", ")}\n`);
+
+if (receiptPath !== null) {
+  writeFileSync(receiptPath, `${JSON.stringify({ schema: "check-ci-receipt/v1", receipts, ok: failed.length === 0 }, null, 2)}\n`);
+  console.error(`  receipt → ${receiptPath}\n`);
+}
+
+process.exit(failed.length === 0 ? 0 : 1);


### PR DESCRIPTION
# English

## Summary

The same failure — **green locally, red in CI** — happened five separate times in one week. Each time the fix was to add one more gate to the remembered checklist. The checklist kept growing.

The fifth time, I counted. CI runs **nine workflow jobs** on a pull request. The `boundaries` job alone carries **35 gates**. And `npm run check:local`, which everyone treated as "the local gate", is a **fast-tier subset that is not equal to any CI job** — it runs almost none of those 35. `npm run check`, which `AGENTS.md` called "the final local gate before a public commit", is the `aggregate-full-check` gate, which is **main-only** and is not what runs on a PR either.

So the lesson is not "we missed gate X". It is that **a checklist a human has to maintain is an instrument that lies** — and it hands you positive reinforcement every time the local run comes back green.

`npm run check:ci` **derives** the job set from `tools/gate-manifest.json` instead of enumerating it. Add a job, or hang a new gate on an existing job, and this command follows automatically. Nobody has to remember anything.

## What Changed

- `tools/run-ci-equivalent.mjs` — reads `executionSurfaces.rewriteCi.pullRequestJobs` out of the gate manifest, runs every job, and prints a per-job receipt. Two things it handles that a hand-run does not:
  - **Clears `packages/gui/dist` and every `*.tsbuildinfo` between jobs.** The `gui-build` job runs `vite build`, which writes `packages/gui/dist` and then poisons any subsequent `tsc -b` with TS6305 stale-artifact errors — a *false* red that sends you hunting a type error that does not exist. CI never sees this because each job is a clean checkout.
  - **Expands `integration-shard` into its six shards** and skips `pr-body-lint` (it needs a real PR), saying so out loud rather than silently dropping coverage.
- `--json <path>` writes a machine-readable receipt **to a file**. It cannot go to stdout: every gate runs with `stdio: "inherit"`, so stdout already belongs to them, and mixing JSON into it produces a receipt nobody can parse. (The first version of this script did exactly that. It was caught by using it.)
- `package.json` — `check:ci` script.
- `CONTRIBUTING.md` and both `task.plan` preset templates — the stop point is now *this one command plus its receipt*, not a hand-copied list of gates. **A list in a template rots; a command does not.**

## Task And Scope

- Harness task: `task_01KXCR4R2GT5DY9HZJABNT5DFQ` (the dogfood defect roll-up whose five CI failures motivated this)
- Branch: `feat/check-ci-derived`
- Public scope: one new tool, one script entry, and three documentation surfaces
- Private planning/evidence updated: yes (`harness/AGENTS.md` corrected in the same spirit — it was asserting a gate that is not the gate)
- Out of scope: fixing the gates this command exposes (see Residual Risk)

## Version Impact

- Version: no version change because this adds developer tooling and touches no shipped surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: **no.** This command *runs* existing gates; it does not add, remove, weaken, or reconfigure any of them. `tools/gate-manifest.json` is read-only to it.
- Protected surface scope: not applicable
- Authority: not applicable — this is tooling, not a governance change
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Follow-up governance task: `task_01KXD1A53XRKQ4DZPH32FM6BH1` (see Residual Risk)

## Verification

- Base `origin/main` SHA: `01e131e`
- Sync method: branched from `origin/main`
- Verified **with the thing it builds**: `npm run check:ci` on this branch, all nine jobs.

**Positive control, twice.** A tool that reports "all green" is worthless until you have watched it go red:

1. Injected an unused variable into `packages/gui/src/renderer/model/__canary.ts` → `check:ci --job boundaries` went **red immediately** (exit 1). Removed it → green.
2. Then it caught **its own author**: the first full run went red on `boundaries` because `run-ci-equivalent.mjs` itself imported `existsSync` and `statSync` without using them. The tool's first real find was a lint error in the tool. Fixed in this branch.

## Review Evidence

- Self-review: yes. The `--json`-to-stdout design was a genuine defect — the receipt was unparseable because the gates own stdout — and it was found by using the tool rather than by reading it.
- Reviewer subagent: not run
- Human review: pending
- Blocking findings: none

## Residual Risk

- **This command makes existing gate rot visible; it does not fix it.** Two examples surfaced immediately:
  - `check-docmap-fresh` is nominally enforced (it hangs on the `boundaries` job) but **silently skips in CI and in every worktree** — it reads the private, git-ignored `harness/docmap.json`, which does not exist in those checkouts, so it prints "skipped" and exits 0. The only place it actually runs is a canonical local checkout, **where it is currently red** (a `docmap/v1` schema ParseError). A gate nobody's enforcement surface can see has been red for an unknown length of time. Filed as `task_01KXD1A53XRKQ4DZPH32FM6BH1`.
  - `check-github-required-contexts` reads GitHub's **live** branch rules and needs `GITHUB_REPOSITORY` + `GITHUB_TOKEN`. Without them the `boundaries` job fails locally for environmental reasons, not code reasons. The command says so explicitly rather than letting you debug a phantom.
- `pr-body-lint` cannot run locally (it needs a real PR body). The command **logs the skip** instead of quietly dropping it — a silent skip is how you get a gate nobody runs.
- Wall-clock is real: a full run is roughly 10 minutes, most of it the six integration shards. `--job <name>` exists for tight loops, but the full run is the one that counts before opening a PR.

## References

- Task: `task_01KXCR4R2GT5DY9HZJABNT5DFQ`
- Follow-up: `task_01KXD1A53XRKQ4DZPH32FM6BH1`
- Review: pending

---

# 中文

## 概要

同一个失败——**本地全绿、CI 红**——一周内发生了 **五次**。每一次的修法都是往那张靠记忆维护的清单里再加一道门。而清单还在长。

第五次我去数了。CI 在 pull_request 上跑 **9 个 workflow job**，光 `boundaries` 一个就挂着 **35 道门**。而所有人当作"本地那道门"的 `npm run check:local`，是个 **fast-tier 子集，不等于任何一个 CI job**——那 35 道门它几乎一道都不跑。`AGENTS.md` 里被称作"公开提交前最终本地 gate"的 `npm run check`，是 `aggregate-full-check`，**main-only 档**，同样不是 PR 上跑的东西。

所以教训不是"我们漏了第 X 道门"。教训是：**一张需要人维护的清单，本身就是一个会骗人的仪器**——而且每次本地跑绿，它都在给你正反馈。

`npm run check:ci` 不枚举 job，而是从 `tools/gate-manifest.json` **派生**。新增一个 job、或给既有 job 挂一道新门，这条命令自动跟上。**没人需要记住任何东西。**

## 改动内容

- `tools/run-ci-equivalent.mjs` —— 从 gate manifest 读 `executionSurfaces.rewriteCi.pullRequestJobs`，逐个 job 跑，输出逐 job 回执。它处理了两件手工跑做不到的事：
  - **每个 job 之前清掉 `packages/gui/dist` 与所有 `*.tsbuildinfo`。** `gui-build` 内含 `vite build`，它写出 `packages/gui/dist`，之后任何 `tsc -b` 都会被 TS6305 陈旧产物毒化——那是**假红**，会让你去追一个根本不存在的类型错误。CI 从来碰不到，因为它每个 job 都是干净 checkout。
  - **把 `integration-shard` 展开成 6 个分片**；`pr-body-lint` 需要真实 PR body，跳过时**明确打印出来**，而不是悄悄丢掉覆盖面。
- `--json <path>` 把机器可读回执**写进文件**。它不能走 stdout：每个 gate 都是 `stdio: "inherit"`，stdout 早就是它们的了，把 JSON 混进去等于交出一份没人能解析的回执。（本脚本第一版就是这么写的。是**用**它的时候发现的，不是**读**它的时候。）
- `package.json` —— `check:ci` 脚本。
- `CONTRIBUTING.md` 与两份 `task.plan` preset 模板 —— 停止点改成**这一条命令 + 它的回执**，不再让人手抄门清单。**模板里的清单会腐烂，命令不会。**

## 任务与范围

- Harness 任务：`task_01KXCR4R2GT5DY9HZJABNT5DFQ`（那五次 CI 红就发生在这条线上）
- 分支：`feat/check-ci-derived`
- 公开范围：一个新工具、一条脚本、三处文档面
- 私有计划 / 证据是否已更新：yes（`harness/AGENTS.md` 同步纠正——它一直在担保一道**并不是那道门**的门）
- 范围外：修这条命令暴露出来的那些门（见 Residual Risk）

## 版本影响

- 版本：不改版本，原因是只加开发工具，不碰任何交付面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：**否。** 这条命令只是**跑**既有的门；它不新增、不删除、不削弱、不重配任何一道。对 `tools/gate-manifest.json` 是只读。
- protected surface 范围：不适用
- 依据：不适用——这是工具，不是治理变更
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- 后续治理任务：`task_01KXD1A53XRKQ4DZPH32FM6BH1`（见 Residual Risk）

## 验证

- `origin/main` 基准 SHA：`01e131e`
- 同步方式：从 `origin/main` 开分支
- **用它自己验它自己**：本分支上跑 `npm run check:ci`，9 个 job 全过。

**阳性对照做了两次。** 一个只会说"全绿"的工具，在你亲眼见它红过之前，一文不值：

1. 往 `packages/gui/src/renderer/model/__canary.ts` 塞一个未使用变量 → `check:ci --job boundaries` **立刻红**（exit 1）。撤掉 → 绿。
2. 然后它抓住了**它的作者**：第一次全量跑红在 `boundaries`，因为 `run-ci-equivalent.mjs` 自己 import 了 `existsSync` 和 `statSync` 却没用。**这个工具的第一个真实发现，是工具自己的 lint 错误。** 本分支已修。

## Review Evidence

- 自审：yes。`--json` 走 stdout 是个真缺陷——回执因为 stdout 被 gate 占着而无法解析——它是在**用**这个工具的时候暴露的，不是在**读**代码的时候。
- Reviewer subagent：未跑
- 人工复核：待办
- 阻塞发现：无

## Residual Risk

- **这条命令让既有的门禁腐烂显形了，但没有修它。** 两个当场浮出水面的例子：
  - `check-docmap-fresh` 名义上受执法（它挂在 `boundaries` job 上），但**在 CI 与所有 worktree 里都静默跳过**——它读的是私有、git-ignored 的 `harness/docmap.json`，那些 checkout 里根本没有这个文件，于是它打印 "skipped" 然后 exit 0。**它唯一真正会跑的地方是 canonical 本地工作树，而它在那儿现在是红的**（`docmap/v1` schema ParseError）。**一道任何执法面都看不见的门，已经红了不知道多久。** 已立 `task_01KXD1A53XRKQ4DZPH32FM6BH1`。
  - `check-github-required-contexts` 读的是 GitHub 上**活的**分支保护规则，需要 `GITHUB_REPOSITORY` + `GITHUB_TOKEN`。不带就本地红，那是**环境原因不是代码原因**。这条命令会明说，而不是让你去 debug 一个幻影。
- `pr-body-lint` 本地跑不了（需要真实 PR body）。命令会**把这次跳过打印出来**，而不是悄悄丢掉——**静默跳过正是"一道没人跑的门"的诞生方式。**
- 耗时是真的：全量约 10 分钟，大头是 6 个 integration 分片。想快就用 `--job <name>`，但开 PR 前算数的是全量那一次。

## References

- 任务：`task_01KXCR4R2GT5DY9HZJABNT5DFQ`
- 后续：`task_01KXD1A53XRKQ4DZPH32FM6BH1`
- 复核：待办
