### PR TITLE
fix(cli): serialize daemon socket ownership

### DIFF
--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -233,14 +233,15 @@ async function statusDaemon(input: DaemonCommandInput): Promise<number> {
   const rpcStatus = await readReachableDaemonStatus(target);
   emitDaemonResult("daemon-status", {
     ...lockStatus,
-    reachable: Boolean(rpcStatus),
     ...(rpcStatus ?? {
       version: resolveCliVersion(),
       protocolVersion: currentDaemonProtocolVersion,
       queueDepth: 0,
       queue: { interactive: 0, normal: 0, background: 0, maintenance: 0, running: false },
       connections: { active: 0, total: 0 }
-    })
+    }),
+    started: rpcStatus?.started === true,
+    reachable: Boolean(rpcStatus)
   }, input.json);
   return 0;
 }

--- a/packages/cli/src/commands/daemon/serve-transport.ts
+++ b/packages/cli/src/commands/daemon/serve-transport.ts
@@ -1,12 +1,34 @@
+import { randomUUID } from "node:crypto";
+import { closeSync, existsSync, fsyncSync, openSync, readFileSync, renameSync, rmSync, writeSync } from "node:fs";
+import net from "node:net";
+import path from "node:path";
 import {
   createNamedPipeTransportServer,
   createUnixSocketTransportServer,
+  ensurePrivateUnixSocketDirectory,
   type DaemonAuthenticationContext,
   type DaemonTransportConnection,
   type JsonRpcProtocolServer,
   type NamedPipeTransportServer,
   type UnixSocketTransportServer
 } from "../../../../daemon/src/index.ts";
+
+interface DaemonSocketOwnerRecord {
+  readonly schema: "daemon-socket-owner/v1";
+  readonly pid: number;
+  readonly ownerToken: string;
+}
+
+export interface DaemonSocketOwnership {
+  readonly release: () => void;
+}
+
+export class DaemonSocketAlreadyOwnedError extends Error {
+  constructor(endpoint: string, ownerPid?: number) {
+    super(`daemon socket ${endpoint} is already owned${ownerPid === undefined ? "" : ` by pid ${ownerPid}`}`);
+    this.name = "DaemonSocketAlreadyOwnedError";
+  }
+}
 
 export interface DaemonLocalTransportOptions {
   readonly daemonId: string;
@@ -38,4 +60,211 @@ export function createDaemonLocalTransport(
     onConnection: options.onConnection,
     onConnectionClosed: options.onConnectionClosed
   });
+}
+
+export async function acquireDaemonSocketOwnership(
+  endpoint: string,
+  platform: NodeJS.Platform = process.platform
+): Promise<DaemonSocketOwnership> {
+  if (platform === "win32") return { release: () => undefined };
+
+  ensurePrivateUnixSocketDirectory(path.dirname(endpoint));
+  const lockPath = `${endpoint}.owner`;
+  return acquireUnixSocketOwnership(endpoint, lockPath);
+}
+
+export async function withDaemonSocketOwnership<Result>(
+  endpoint: string,
+  run: () => Promise<Result>
+): Promise<Result> {
+  const ownership = await acquireDaemonSocketOwnership(endpoint);
+  try {
+    return await run();
+  } finally {
+    ownership.release();
+  }
+}
+
+async function acquireUnixSocketOwnership(endpoint: string, lockPath: string): Promise<DaemonSocketOwnership> {
+  const ownerToken = randomUUID();
+  const record = {
+    schema: "daemon-socket-owner/v1",
+    pid: process.pid,
+    ownerToken
+  } satisfies DaemonSocketOwnerRecord;
+
+  try {
+    createOwnerLock(lockPath, record);
+  } catch (error) {
+    if (!isAlreadyExistsError(error)) throw error;
+    const existing = readOwnerLock(lockPath);
+    if (!existing) throw new DaemonSocketAlreadyOwnedError(endpoint);
+    if (processIsAlive(existing.pid)) {
+      const state = await waitForSocketOwner(endpoint, lockPath, existing);
+      if (state === "reachable") throw new DaemonSocketAlreadyOwnedError(endpoint, existing.pid);
+      return acquireUnixSocketOwnership(endpoint, lockPath);
+    }
+    quarantineStaleOwnerLock(lockPath, existing, ownerToken);
+    try {
+      createOwnerLock(lockPath, record);
+    } catch (retryError) {
+      if (isAlreadyExistsError(retryError)) {
+        throw new DaemonSocketAlreadyOwnedError(endpoint, readOwnerLock(lockPath)?.pid);
+      }
+      throw retryError;
+    }
+  }
+
+  return {
+    release: () => {
+      const current = readOwnerLock(lockPath);
+      if (current?.ownerToken === ownerToken) rmSync(lockPath, { force: true });
+    }
+  };
+}
+
+function waitForSocketOwner(
+  endpoint: string,
+  lockPath: string,
+  expected: DaemonSocketOwnerRecord
+): Promise<"reachable" | "released"> {
+  return new Promise((resolve, reject) => {
+    let inspecting = false;
+    let settled = false;
+    const ownershipTimer = setInterval(() => {
+      void inspect();
+    }, 25);
+    void inspect();
+
+    async function inspect(): Promise<void> {
+      if (settled || inspecting) return;
+      inspecting = true;
+      try {
+        const current = readOwnerLock(lockPath);
+        if ((!current && !existsSync(lockPath)) || (current && current.ownerToken !== expected.ownerToken) || !processIsAlive(expected.pid)) {
+          finish("released");
+          return;
+        }
+        if (await endpointIsReachable(endpoint)) finish("reachable");
+      } catch (error) {
+        fail(error);
+      } finally {
+        inspecting = false;
+      }
+    }
+
+    function finish(state: "reachable" | "released"): void {
+      if (settled) return;
+      settled = true;
+      clearInterval(ownershipTimer);
+      resolve(state);
+    }
+
+    function fail(error: unknown): void {
+      if (settled) return;
+      settled = true;
+      clearInterval(ownershipTimer);
+      reject(error);
+    }
+  });
+}
+
+function endpointIsReachable(endpoint: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.createConnection(endpoint);
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, 100);
+    socket.once("connect", () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once("error", () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
+function createOwnerLock(lockPath: string, record: DaemonSocketOwnerRecord): void {
+  const fd = openSync(lockPath, "wx", 0o600);
+  try {
+    writeSync(fd, JSON.stringify(record));
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function readOwnerLock(lockPath: string): DaemonSocketOwnerRecord | undefined {
+  if (!existsSync(lockPath)) return undefined;
+  try {
+    const record = JSON.parse(readFileSync(lockPath, "utf8")) as Partial<DaemonSocketOwnerRecord>;
+    if (
+      record.schema === "daemon-socket-owner/v1"
+      && typeof record.pid === "number"
+      && Number.isSafeInteger(record.pid)
+      && record.pid > 0
+      && typeof record.ownerToken === "string"
+      && record.ownerToken.length > 0
+    ) {
+      return record as DaemonSocketOwnerRecord;
+    }
+  } catch {
+    // A concurrently starting owner may not have finished its durable write.
+  }
+  return undefined;
+}
+
+function quarantineStaleOwnerLock(
+  lockPath: string,
+  expected: DaemonSocketOwnerRecord,
+  contenderToken: string
+): void {
+  const quarantinePath = `${lockPath}.stale.${expected.ownerToken}.${contenderToken}`;
+  try {
+    renameSync(lockPath, quarantinePath);
+  } catch (error) {
+    if (isNoSuchFileError(error)) return;
+    throw error;
+  }
+  const quarantined = readOwnerLock(quarantinePath);
+  if (quarantined?.ownerToken !== expected.ownerToken || processIsAlive(quarantined.pid)) {
+    try {
+      renameSync(quarantinePath, lockPath);
+    } catch {
+      // Another contender already established the authoritative owner lock.
+    }
+    throw new DaemonSocketAlreadyOwnedError(lockPath, quarantined?.pid);
+  }
+  rmSync(quarantinePath, { force: true });
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !isNoSuchProcessError(error);
+  }
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return errorCode(error) === "EEXIST";
+}
+
+function isNoSuchFileError(error: unknown): boolean {
+  return errorCode(error) === "ENOENT";
+}
+
+function isNoSuchProcessError(error: unknown): boolean {
+  return errorCode(error) === "ESRCH";
+}
+
+function errorCode(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error
+    ? (error as { readonly code?: unknown }).code
+    : undefined;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,7 +28,7 @@ import {
   type DaemonServeHooks
 } from "./commands/daemon/productization.ts";
 import { runDaemonConnect } from "./commands/daemon/connect.ts";
-import { createDaemonLocalTransport } from "./commands/daemon/serve-transport.ts";
+import { createDaemonLocalTransport, withDaemonSocketOwnership } from "./commands/daemon/serve-transport.ts";
 import { runRegisteredCommandWithCliComposition } from "./composition/command-executor.ts";
 import { selectCliAdapterProvider } from "./composition/adapter-registry.ts";
 import { daemonIdFromEnv, daemonUserRoot, localUserDaemonEndpoint, runCommandThroughDaemon } from "./daemon/client.ts";
@@ -100,51 +100,68 @@ async function runDaemonServe(
 ): Promise<void> {
   const requestedRepoId = readOption(args, "--repo") ?? process.env.HARNESS_DAEMON_REPO_ID ?? "canonical";
   const userRoot = readOption(args, "--user-root") ?? daemonUserRoot();
-  const serveRepos = daemonServeRepos(rootDir, layoutOverrides, requestedRepoId, userRoot);
-  const defaultRepoId = defaultDaemonServeRepoId(serveRepos, rootDir, requestedRepoId);
-  const runtime = createMultiRepoDaemonRuntime({
-    materializerPollMs: 5_000,
-    reservationReconciler: async (rootInput) => {
-      const canonicalRoot = typeof rootInput === "string" ? rootInput : rootInput.rootDir;
-      const repoId = serveRepos.find((repo) => repo.canonicalRoot === canonicalRoot)?.repoId;
-      return makeDaemonReservationReconciler(rootInput, repoId ? runtime.getRepoRuntime(repoId) : undefined)();
-    },
-    repos: serveRepos.map((repo) => ({
-      repoId: repo.repoId,
-      rootDir: repo.canonicalRoot,
-      displayName: repo.displayName,
-      ...(layoutOverrides ? { layoutOverrides } : {})
-    }))
-  });
-  const startStatus = await runtime.start();
-  if (startStatus.repoCount > 0 && startStatus.attachedCount === 0 && startStatus.unavailableCount > 0) {
-    throw new Error(`daemon did not attach any registered repo: ${startStatus.repos.map((repo) => `${repo.repoId}:${repo.lastError ?? repo.state}`).join("; ")}`);
-  }
-  const idleMs = parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true });
   const endpoint = readOption(args, "--socket") ?? localUserDaemonEndpoint(userRoot, daemonIdFromEnv());
-  const connections: DaemonConnectionStats = { active: 0, total: 0 };
-  const serviceHost = createDaemonServiceHost(runtime, serveRepos, defaultRepoId, layoutOverrides, idleMs, endpoint, connections);
-  serviceHost.startRegistryReconcile(userRoot);
-  const transport = createDaemonLocalTransport({
-    daemonId: serviceHost.daemonId,
-    endpoint,
-    createProtocolServer: serviceHost.createProtocolServer,
-    onConnection: () => {
-      connections.active += 1;
-      connections.total += 1;
-    },
-    onConnectionClosed: () => {
-      connections.active = Math.max(0, connections.active - 1);
+  return withDaemonSocketOwnership(endpoint, async () => {
+    let runtime: MultiRepoHarnessDaemonRuntime | undefined;
+    let serviceHost: ReturnType<typeof createDaemonServiceHost> | undefined;
+    try {
+      const serveRepos = daemonServeRepos(rootDir, layoutOverrides, requestedRepoId, userRoot);
+      const defaultRepoId = defaultDaemonServeRepoId(serveRepos, rootDir, requestedRepoId);
+      runtime = createMultiRepoDaemonRuntime({
+        materializerPollMs: 5_000,
+        reservationReconciler: async (rootInput) => {
+          const canonicalRoot = typeof rootInput === "string" ? rootInput : rootInput.rootDir;
+          const repoId = serveRepos.find((repo) => repo.canonicalRoot === canonicalRoot)?.repoId;
+          return makeDaemonReservationReconciler(rootInput, repoId ? runtime?.getRepoRuntime(repoId) : undefined)();
+        },
+        repos: serveRepos.map((repo) => ({
+          repoId: repo.repoId,
+          rootDir: repo.canonicalRoot,
+          displayName: repo.displayName,
+          ...(layoutOverrides ? { layoutOverrides } : {})
+        }))
+      });
+      const startStatus = await runtime.start();
+      if (startStatus.repoCount > 0 && startStatus.attachedCount === 0 && startStatus.unavailableCount > 0) {
+        throw new Error(`daemon did not attach any registered repo: ${startStatus.repos.map((repo) => `${repo.repoId}:${repo.lastError ?? repo.state}`).join("; ")}`);
+      }
+      const idleMs = parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true });
+      const connections: DaemonConnectionStats = { active: 0, total: 0 };
+      serviceHost = createDaemonServiceHost(runtime, serveRepos, defaultRepoId, layoutOverrides, idleMs, endpoint, connections);
+      serviceHost.startRegistryReconcile(userRoot);
+      const transport = createDaemonLocalTransport({
+        daemonId: serviceHost.daemonId,
+        endpoint,
+        createProtocolServer: serviceHost.createProtocolServer,
+        onConnection: () => {
+          connections.active += 1;
+          connections.total += 1;
+        },
+        onConnectionClosed: () => {
+          connections.active = Math.max(0, connections.active - 1);
+        }
+      });
+      await transport.start();
+      serviceHost.onStop(async () => {
+        await transport.stop();
+      });
+      hooks.onStarted?.(serviceHost.status());
+      serviceHost.scheduleIdleExit();
+      await Promise.race([waitForStopSignal(), serviceHost.waitForStopRequest()]);
+    } finally {
+      let stoppedByHost = false;
+      try {
+        if (serviceHost) {
+          await serviceHost.stop();
+          stoppedByHost = true;
+        } else if (runtime) {
+          await runtime.stop();
+        }
+      } finally {
+        if (!stoppedByHost && serviceHost && runtime) await runtime.stop();
+      }
     }
   });
-  await transport.start();
-  hooks.onStarted?.(serviceHost.status());
-  serviceHost.onStop(async () => {
-    await transport.stop();
-  });
-  serviceHost.scheduleIdleExit();
-  await Promise.race([waitForStopSignal(), serviceHost.waitForStopRequest()]);
-  await serviceHost.stop();
 }
 
 function repoAvailabilityFailure(

--- a/packages/cli/test/daemon-autostart-socket-race-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-socket-race-cli.test.ts
@@ -1,0 +1,156 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { acquireDaemonSocketOwnership } from "../src/commands/daemon/serve-transport.ts";
+import {
+  delay,
+  runDaemonCommand,
+  runRawJson,
+  runRawJsonAsync,
+  withTempRootAsync
+} from "./helpers/daemon-cli.ts";
+
+const concurrentClientCount = 8;
+
+test("an unreachable socket owner hands startup ownership to one waiting contender", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const endpoint = path.join(rootDir, "daemon.sock");
+    const first = await acquireDaemonSocketOwnership(endpoint);
+    const contender = Promise.resolve().then(() => acquireDaemonSocketOwnership(endpoint));
+
+    await delay(50);
+    first.release();
+
+    const second = await contender;
+    second.release();
+  });
+});
+
+test("daemon status cannot report started when its lock exists but the socket is unreachable", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
+    const lockPath = path.join(rootDir, ".harness/locks/global.lock");
+    mkdirSync(path.dirname(lockPath), { recursive: true });
+    writeFileSync(lockPath, JSON.stringify({
+      pid: 999_999,
+      hostname: "test-host",
+      heartbeatAt: new Date().toISOString(),
+      ownerKind: "daemon",
+      ownerToken: "unreachable-owner"
+    }), "utf8");
+
+    const status = runDaemonCommand(rootDir, ["daemon", "status", "--json"]);
+    assert.equal(status.started, false);
+    assert.equal(status.reachable, false);
+  });
+});
+
+test("concurrent cold-start clients converge on one reachable daemon socket owner", async () => {
+  await withTempRootAsync(async (workspaceRoot) => {
+    const userRoot = path.join(workspaceRoot, "user-daemon");
+    const repoRoots = Array.from(
+      { length: concurrentClientCount },
+      (_, index) => path.join(workspaceRoot, `repo-${index}`)
+    );
+
+    for (const [index, rootDir] of repoRoots.entries()) {
+      mkdirSync(rootDir, { recursive: true });
+      runRawJson(rootDir, ["init"], {
+        HARNESS_DAEMON_MODE: "direct",
+        HARNESS_DAEMON_USER_ROOT: userRoot
+      });
+      runDaemonCommand(rootDir, [
+        "daemon",
+        "repo",
+        "register",
+        "--repo-id",
+        `repo-${index}`,
+        "--root",
+        rootDir,
+        "--user-root",
+        userRoot,
+        "--no-link",
+        "--json"
+      ], { HARNESS_DAEMON_USER_ROOT: userRoot });
+    }
+
+    const clientResults = await Promise.allSettled(repoRoots.map((rootDir, index) =>
+      runRawJsonAsync(rootDir, ["--repo", `repo-${index}`, "task", "list"], {
+        HARNESS_DAEMON_MODE: "local",
+        HARNESS_DAEMON_USER_ROOT: userRoot,
+        HARNESS_DAEMON_IDLE_MS: "60000"
+      })
+    ));
+
+    try {
+      assert.deepEqual(
+        clientResults.map((result) => result.status),
+        Array.from({ length: concurrentClientCount }, () => "fulfilled"),
+        clientResults.map(describeSettledResult).join("\n")
+      );
+      for (const result of clientResults) {
+        assert.equal(result.status === "fulfilled" && result.value.ok, true, describeSettledResult(result));
+      }
+
+      const status = runDaemonCommand(repoRoots[0]!, [
+        "--repo",
+        "repo-0",
+        "daemon",
+        "status",
+        "--user-root",
+        userRoot,
+        "--json"
+      ], { HARNESS_DAEMON_USER_ROOT: userRoot });
+      assert.equal(status.started, true);
+      assert.equal(status.reachable, true);
+      assert.equal(typeof status.pid, "number");
+      assert.equal(Array.isArray(status.repos), true);
+      assert.deepEqual(
+        (status.repos as Array<{ readonly state?: unknown }>).map((repo) => repo.state),
+        Array.from({ length: concurrentClientCount }, () => "attached")
+      );
+
+      const lockPids = repoRoots.map(readDaemonLockPid);
+      assert.deepEqual([...new Set(lockPids)], [status.pid]);
+    } finally {
+      await stopDaemonProcesses(repoRoots);
+    }
+  });
+});
+
+function readDaemonLockPid(rootDir: string): number {
+  const lockPath = path.join(rootDir, ".harness/locks/global.lock");
+  assert.equal(existsSync(lockPath), true, `missing daemon lock: ${lockPath}`);
+  const lock = JSON.parse(readFileSync(lockPath, "utf8")) as { readonly pid?: unknown };
+  assert.equal(typeof lock.pid, "number", `daemon lock has no pid: ${lockPath}`);
+  return lock.pid as number;
+}
+
+async function stopDaemonProcesses(repoRoots: ReadonlyArray<string>): Promise<void> {
+  const pids = new Set<number>();
+  for (const rootDir of repoRoots) {
+    try {
+      pids.add(readDaemonLockPid(rootDir));
+    } catch {
+      // A failed cold start may leave some repos without a daemon lock.
+    }
+  }
+  for (const pid of pids) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // The process may already have exited after losing the socket race.
+    }
+  }
+  await delay(100);
+}
+
+function describeSettledResult(result: PromiseSettledResult<Record<string, unknown>>): string {
+  return result.status === "fulfilled"
+    ? JSON.stringify(result.value)
+    : result.reason instanceof Error
+      ? `${result.reason.name}: ${result.reason.message}`
+      : String(result.reason);
+}

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -674,6 +674,48 @@
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
       }
+    ],
+    "daemonTransportLifecycle": [
+      {
+        "value": "packages/cli/src/commands/daemon/serve-transport.ts#rmSync@1",
+        "ref": "task_01KXD0A37NN8ZQEJ2ENG5K313V",
+        "reason": "Daemon socket ownership lock: operational transport lifecycle state (owner-lock claim/verify/release for single-instance daemon serve), not entity data; coordinator cannot govern its own transport bootstrap. Anchored to autostart socket-race fix."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/serve-transport.ts#openSync@1",
+        "ref": "task_01KXD0A37NN8ZQEJ2ENG5K313V",
+        "reason": "Daemon socket ownership lock: operational transport lifecycle state (owner-lock claim/verify/release for single-instance daemon serve), not entity data; coordinator cannot govern its own transport bootstrap. Anchored to autostart socket-race fix."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/serve-transport.ts#writeSync@1",
+        "ref": "task_01KXD0A37NN8ZQEJ2ENG5K313V",
+        "reason": "Daemon socket ownership lock: operational transport lifecycle state (owner-lock claim/verify/release for single-instance daemon serve), not entity data; coordinator cannot govern its own transport bootstrap. Anchored to autostart socket-race fix."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/serve-transport.ts#fsyncSync@1",
+        "ref": "task_01KXD0A37NN8ZQEJ2ENG5K313V",
+        "reason": "Daemon socket ownership lock: operational transport lifecycle state (owner-lock claim/verify/release for single-instance daemon serve), not entity data; coordinator cannot govern its own transport bootstrap. Anchored to autostart socket-race fix."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/serve-transport.ts#closeSync@1",
+        "ref": "task_01KXD0A37NN8ZQEJ2ENG5K313V",
+        "reason": "Daemon socket ownership lock: operational transport lifecycle state (owner-lock claim/verify/release for single-instance daemon serve), not entity data; coordinator cannot govern its own transport bootstrap. Anchored to autostart socket-race fix."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/serve-transport.ts#renameSync@1",
+        "ref": "task_01KXD0A37NN8ZQEJ2ENG5K313V",
+        "reason": "Daemon socket ownership lock: operational transport lifecycle state (owner-lock claim/verify/release for single-instance daemon serve), not entity data; coordinator cannot govern its own transport bootstrap. Anchored to autostart socket-race fix."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/serve-transport.ts#renameSync@2",
+        "ref": "task_01KXD0A37NN8ZQEJ2ENG5K313V",
+        "reason": "Daemon socket ownership lock: operational transport lifecycle state (owner-lock claim/verify/release for single-instance daemon serve), not entity data; coordinator cannot govern its own transport bootstrap. Anchored to autostart socket-race fix."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/serve-transport.ts#rmSync@2",
+        "ref": "task_01KXD0A37NN8ZQEJ2ENG5K313V",
+        "reason": "Daemon socket ownership lock: operational transport lifecycle state (owner-lock claim/verify/release for single-instance daemon serve), not entity data; coordinator cannot govern its own transport bootstrap. Anchored to autostart socket-race fix."
+      }
     ]
   }
 }

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -11,608 +11,1413 @@
   ],
   "rowCountReconciliation": {
     "phase1FunctionalRows": 26,
-    "registryRows": 40,
-    "difference": "Six additional rows split mixed write functions and infrastructure: module canonical/view, script declared writes/produces, worktree code/binding, task-holder runtime state, one WriteCoordinator runtime substrate row, and the Fact-to-Execution administrative migration road. Two further ADR-0028 P4 rows register the attributed doc_sync_submit coordinator road and the preset script staging-mirror ingest road. One ADR-0028 P5 row registers the coordinator-owned immutable attribution event trail. One ADR-0029 TW-01 row registers the authority replication submission road (attributed-coordinator entry over forced-command SSH). One ADR-0029 TW-02 row registers the compound receipt durable store (client-side crash-recovery receipt records, fsync + atomic rename). One ADR-0029 TW-03 row registers the broker local-view native applier (crash-safe transparent view materialization). One ADR-0029 TW-04 row registers the platform semantic-probe scratch writes (temporary qualification probes, created and removed inside one probe run). One ADR-0029 TW-06 row registers the authority fence enrollment anchor and durability boundary stores."
+    "registryRows": 41,
+    "difference": "Six additional rows split mixed write functions and infrastructure: module canonical/view, script declared writes/produces, worktree code/binding, task-holder runtime state, one WriteCoordinator runtime substrate row, and the Fact-to-Execution administrative migration road. Two further ADR-0028 P4 rows register the attributed doc_sync_submit coordinator road and the preset script staging-mirror ingest road. One ADR-0028 P5 row registers the coordinator-owned immutable attribution event trail. One ADR-0029 TW-01 row registers the authority replication submission road (attributed-coordinator entry over forced-command SSH). One ADR-0029 TW-02 row registers the compound receipt durable store (client-side crash-recovery receipt records, fsync + atomic rename). One ADR-0029 TW-03 row registers the broker local-view native applier (crash-safe transparent view materialization). One ADR-0029 TW-04 row registers the platform semantic-probe scratch writes (temporary qualification probes, created and removed inside one probe run). One ADR-0029 TW-06 row registers the authority fence enrollment anchor and durability boundary stores. One daemon transport row registers the socket owner-lock lifecycle state (task_01KXD0A37NN8ZQEJ2ENG5K313V): ephemeral single-instance mutex outside SoT, not entity data."
   },
   "rows": [
     {
       "id": "task.package.create",
-      "sourceInventoryRows": [1],
+      "sourceInventoryRows": [
+        1
+      ],
       "road": "A",
       "bearing": "task-lifecycle",
-      "channel": { "pathClass": "rpc-only", "zoneClass": "task-authored-structured" },
-      "entry": ["cli", "daemon-rpc", "preset-internal"],
-      "writeKinds": ["package_create"],
-      "cliActions": ["new-task"],
-      "evidence": ["packages/adapters/local/src/index.ts:122", "packages/cli/src/commands/preset-task.ts:208", "packages/cli/src/commands/legacy-rebuild.ts:74"],
+      "channel": {
+        "pathClass": "rpc-only",
+        "zoneClass": "task-authored-structured"
+      },
+      "entry": [
+        "cli",
+        "daemon-rpc",
+        "preset-internal"
+      ],
+      "writeKinds": [
+        "package_create"
+      ],
+      "cliActions": [
+        "new-task"
+      ],
+      "evidence": [
+        "packages/adapters/local/src/index.ts:122",
+        "packages/cli/src/commands/preset-task.ts:208",
+        "packages/cli/src/commands/legacy-rebuild.ts:74"
+      ],
       "freshness": "coordinator-batch-document"
     },
     {
       "id": "task.lifecycle.transition",
-      "sourceInventoryRows": [2],
+      "sourceInventoryRows": [
+        2
+      ],
       "road": "A",
       "bearing": "task-lifecycle",
-      "channel": { "pathClass": "rpc-only", "zoneClass": "task-authored-structured" },
-      "entry": ["cli", "daemon-rpc", "gui-bridge"],
-      "writeKinds": ["transition_local", "package_archive", "package_tombstone", "package_reopen", "package_supersede", "package_delete_hard"],
-      "cliActions": ["status-set", "task-archive", "task-delete", "task-reopen", "task-supersede", "task-complete", "task-review", "task-review-execution"],
-      "apiRoutes": ["tasks.status.set", "tasks.review"],
-      "guiBridgeMethods": ["setTaskStatus", "reviewTask"],
-      "callsiteFiles": ["packages/adapters/local/src/task-writes.ts"],
-      "evidence": ["packages/adapters/local/src/index.ts:182", "packages/adapters/local/src/index.ts:310", "packages/application/src/local-controller-service.ts:95"],
+      "channel": {
+        "pathClass": "rpc-only",
+        "zoneClass": "task-authored-structured"
+      },
+      "entry": [
+        "cli",
+        "daemon-rpc",
+        "gui-bridge"
+      ],
+      "writeKinds": [
+        "transition_local",
+        "package_archive",
+        "package_tombstone",
+        "package_reopen",
+        "package_supersede",
+        "package_delete_hard"
+      ],
+      "cliActions": [
+        "status-set",
+        "task-archive",
+        "task-delete",
+        "task-reopen",
+        "task-supersede",
+        "task-complete",
+        "task-review",
+        "task-review-execution"
+      ],
+      "apiRoutes": [
+        "tasks.status.set",
+        "tasks.review"
+      ],
+      "guiBridgeMethods": [
+        "setTaskStatus",
+        "reviewTask"
+      ],
+      "callsiteFiles": [
+        "packages/adapters/local/src/task-writes.ts"
+      ],
+      "evidence": [
+        "packages/adapters/local/src/index.ts:182",
+        "packages/adapters/local/src/index.ts:310",
+        "packages/application/src/local-controller-service.ts:95"
+      ],
       "freshness": "coordinator-conditional-task-state"
     },
     {
       "id": "task.progress.append",
-      "sourceInventoryRows": [3],
+      "sourceInventoryRows": [
+        3
+      ],
       "road": "A",
       "bearing": "task-progress",
-      "channel": { "pathClass": "rpc-only", "zoneClass": "task-authored-structured" },
-      "entry": ["cli", "daemon-rpc", "gui-bridge"],
-      "writeKinds": ["progress_append"],
-      "cliActions": ["progress-append"],
-      "apiRoutes": ["tasks.progress.append"],
-      "guiBridgeMethods": ["appendTaskProgress"],
-      "callsiteFiles": ["packages/adapters/local/src/task-writes.ts"],
-      "evidence": ["packages/cli/src/commands/core/task-lifecycle.ts:49", "packages/adapters/local/src/task-writes.ts:54", "packages/kernel/src/store/write-journal-operations.ts:256"],
+      "channel": {
+        "pathClass": "rpc-only",
+        "zoneClass": "task-authored-structured"
+      },
+      "entry": [
+        "cli",
+        "daemon-rpc",
+        "gui-bridge"
+      ],
+      "writeKinds": [
+        "progress_append"
+      ],
+      "cliActions": [
+        "progress-append"
+      ],
+      "apiRoutes": [
+        "tasks.progress.append"
+      ],
+      "guiBridgeMethods": [
+        "appendTaskProgress"
+      ],
+      "callsiteFiles": [
+        "packages/adapters/local/src/task-writes.ts"
+      ],
+      "evidence": [
+        "packages/cli/src/commands/core/task-lifecycle.ts:49",
+        "packages/adapters/local/src/task-writes.ts:54",
+        "packages/kernel/src/store/write-journal-operations.ts:256"
+      ],
       "freshness": "append-delta"
     },
     {
       "id": "task.force-terminal-audit",
-      "sourceInventoryRows": [4],
+      "sourceInventoryRows": [
+        4
+      ],
       "road": "A",
       "bearing": "task-lifecycle",
-      "channel": { "pathClass": "rpc-only", "zoneClass": "task-authored-structured" },
-      "entry": ["cli"],
-      "cliActions": ["task-complete"],
-      "evidence": ["packages/cli/src/commands/core/task-lifecycle.ts:87", "packages/cli/src/commands/core/task-lifecycle.ts:122"],
+      "channel": {
+        "pathClass": "rpc-only",
+        "zoneClass": "task-authored-structured"
+      },
+      "entry": [
+        "cli"
+      ],
+      "cliActions": [
+        "task-complete"
+      ],
+      "evidence": [
+        "packages/cli/src/commands/core/task-lifecycle.ts:87",
+        "packages/cli/src/commands/core/task-lifecycle.ts:122"
+      ],
       "freshness": "progress-append-plus-transition"
     },
     {
       "id": "task.holder.runtime-state",
-      "sourceInventoryRows": [2],
+      "sourceInventoryRows": [
+        2
+      ],
       "road": "A",
       "bearing": "task-holder",
-      "channel": { "pathClass": "coordinator-runtime-state", "zoneClass": "task-holder-runtime-state" },
-      "entry": ["daemon-rpc", "cli"],
-      "cliActions": ["task-claim", "task-release"],
-      "directWrites": [{ "file": "packages/kernel/src/local/local-layout-file-system.ts" }],
-      "evidence": ["packages/kernel/src/local/task-holder-state.ts:410", "packages/kernel/src/local/local-layout-file-system.ts:16"],
+      "channel": {
+        "pathClass": "coordinator-runtime-state",
+        "zoneClass": "task-holder-runtime-state"
+      },
+      "entry": [
+        "daemon-rpc",
+        "cli"
+      ],
+      "cliActions": [
+        "task-claim",
+        "task-release"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/kernel/src/local/local-layout-file-system.ts"
+        }
+      ],
+      "evidence": [
+        "packages/kernel/src/local/task-holder-state.ts:410",
+        "packages/kernel/src/local/local-layout-file-system.ts:16"
+      ],
       "freshness": "runtime-state-cas"
     },
     {
       "id": "task.document.write-stage",
-      "sourceInventoryRows": [5],
+      "sourceInventoryRows": [
+        5
+      ],
       "road": "D",
       "bearing": "task-document",
-      "channel": { "pathClass": "doc-sync-allowed", "zoneClass": "task-authored-prose-or-stage" },
-      "entry": ["cli", "daemon-rpc", "internal", "gui-review"],
-      "writeKinds": ["doc_write", "doc_stage", "task_tree_stage", "code_doc_reconcile"],
-      "cliActions": ["task-amend", "task-code-doc-reconcile", "task-relate"],
-      "callsiteFiles": ["packages/adapters/local/src/task-writes.ts"],
-      "directWrites": [
-        { "file": "packages/cli/src/daemon/doc-sync-service.ts" },
-        { "file": "packages/cli/src/daemon/doc-sync-service.ts", "command": "git" }
+      "channel": {
+        "pathClass": "doc-sync-allowed",
+        "zoneClass": "task-authored-prose-or-stage"
+      },
+      "entry": [
+        "cli",
+        "daemon-rpc",
+        "internal",
+        "gui-review"
       ],
-      "evidence": ["packages/adapters/local/src/index.ts:224", "packages/adapters/local/src/task-writes.ts:67", "packages/application/src/task-lifecycle-orchestrator.ts:115", "packages/cli/src/commands/core/task-gates.ts:93", "packages/cli/src/daemon/doc-sync-service.ts:166"],
+      "writeKinds": [
+        "doc_write",
+        "doc_stage",
+        "task_tree_stage",
+        "code_doc_reconcile"
+      ],
+      "cliActions": [
+        "task-amend",
+        "task-code-doc-reconcile",
+        "task-relate"
+      ],
+      "callsiteFiles": [
+        "packages/adapters/local/src/task-writes.ts"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/daemon/doc-sync-service.ts"
+        },
+        {
+          "file": "packages/cli/src/daemon/doc-sync-service.ts",
+          "command": "git"
+        }
+      ],
+      "evidence": [
+        "packages/adapters/local/src/index.ts:224",
+        "packages/adapters/local/src/task-writes.ts:67",
+        "packages/application/src/task-lifecycle-orchestrator.ts:115",
+        "packages/cli/src/commands/core/task-gates.ts:93",
+        "packages/cli/src/daemon/doc-sync-service.ts:166"
+      ],
       "freshness": "doc-sync-submit-cas-post-apply"
     },
     {
       "id": "write-coordinator.runtime-substrate",
-      "sourceInventoryRows": [1, 2, 3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 24],
+      "sourceInventoryRows": [
+        1,
+        2,
+        3,
+        5,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        24
+      ],
       "road": "A",
       "bearing": "write-coordinator-runtime",
       "leaseRequired": false,
-      "channel": { "pathClass": "coordinator-runtime-state", "zoneClass": "wal-locks-and-flush-substrate" },
-      "entry": ["write-coordinator"],
+      "channel": {
+        "pathClass": "coordinator-runtime-state",
+        "zoneClass": "wal-locks-and-flush-substrate"
+      },
+      "entry": [
+        "write-coordinator"
+      ],
       "callsiteFiles": [
         "packages/cli/src/commands/core/coordinated-machine-write.ts",
         "packages/kernel/src/store/daemon-runtime-queue.ts",
         "packages/kernel/src/write-coordination/write-helpers.ts"
       ],
       "directWrites": [
-        { "file": "packages/kernel/src/store/local-lock-registry.ts" },
-        { "file": "packages/kernel/src/store/markdown-artifact-store.ts" },
-        { "file": "packages/kernel/src/store/write-journal-decision-documents.ts" },
-        { "file": "packages/kernel/src/store/write-journal-durable.ts" },
-        { "file": "packages/kernel/src/store/write-journal-locks.ts" },
-        { "file": "packages/kernel/src/store/write-journal-operations.ts" }
+        {
+          "file": "packages/kernel/src/store/local-lock-registry.ts"
+        },
+        {
+          "file": "packages/kernel/src/store/markdown-artifact-store.ts"
+        },
+        {
+          "file": "packages/kernel/src/store/write-journal-decision-documents.ts"
+        },
+        {
+          "file": "packages/kernel/src/store/write-journal-durable.ts"
+        },
+        {
+          "file": "packages/kernel/src/store/write-journal-locks.ts"
+        },
+        {
+          "file": "packages/kernel/src/store/write-journal-operations.ts"
+        }
       ],
-      "evidence": ["packages/kernel/src/write-coordination/write-helpers.ts:20", "packages/kernel/src/store/write-journal-durable.ts:109", "packages/kernel/src/store/write-journal-locks.ts:125"],
+      "evidence": [
+        "packages/kernel/src/write-coordination/write-helpers.ts:20",
+        "packages/kernel/src/store/write-journal-durable.ts:109",
+        "packages/kernel/src/store/write-journal-locks.ts:125"
+      ],
       "freshness": "wal-lock-and-atomic-flush"
     },
     {
       "id": "attribution.event.immutable-store",
-      "sourceInventoryRows": [1],
+      "sourceInventoryRows": [
+        1
+      ],
       "road": "A",
       "bearing": "attribution-audit",
       "leaseRequired": false,
-      "channel": { "pathClass": "coordinator-authored", "zoneClass": "immutable-attribution-event-trail" },
-      "entry": ["write-coordinator", "ledger-materializer"],
+      "channel": {
+        "pathClass": "coordinator-authored",
+        "zoneClass": "immutable-attribution-event-trail"
+      },
+      "entry": [
+        "write-coordinator",
+        "ledger-materializer"
+      ],
       "cliActions": [],
       "directWrites": [
-        { "file": "packages/kernel/src/store/write-journal-durable.ts" }
+        {
+          "file": "packages/kernel/src/store/write-journal-durable.ts"
+        }
       ],
-      "evidence": ["packages/kernel/src/store/write-journal-attribution-events.ts:28", "packages/kernel/src/store/write-journal-durable.ts:117"],
+      "evidence": [
+        "packages/kernel/src/store/write-journal-attribution-events.ts:28",
+        "packages/kernel/src/store/write-journal-durable.ts:117"
+      ],
       "freshness": "append-only-op-id-shard"
     },
     {
       "id": "task.migration.backfill",
-      "sourceInventoryRows": [6],
+      "sourceInventoryRows": [
+        6
+      ],
       "road": "D",
       "bearing": "admin-migration",
       "leaseRequired": false,
-      "channel": { "pathClass": "admin-rpc", "zoneClass": "task-authored-prose" },
-      "entry": ["cli-migration"],
-      "cliActions": ["migrate-anchors", "migrate-provenance"],
-      "callsiteFiles": ["packages/cli/src/commands/anchor-backfill.ts", "packages/cli/src/commands/core/provenance-backfill.ts"],
-      "evidence": ["packages/cli/src/commands/anchor-backfill.ts:132", "packages/cli/src/commands/core/provenance-backfill.ts:75"],
+      "channel": {
+        "pathClass": "admin-rpc",
+        "zoneClass": "task-authored-prose"
+      },
+      "entry": [
+        "cli-migration"
+      ],
+      "cliActions": [
+        "migrate-anchors",
+        "migrate-provenance"
+      ],
+      "callsiteFiles": [
+        "packages/cli/src/commands/anchor-backfill.ts",
+        "packages/cli/src/commands/core/provenance-backfill.ts"
+      ],
+      "evidence": [
+        "packages/cli/src/commands/anchor-backfill.ts:132",
+        "packages/cli/src/commands/core/provenance-backfill.ts:75"
+      ],
       "freshness": "migration-full-body"
     },
     {
       "id": "fact.execution-migration",
-      "sourceInventoryRows": [6],
+      "sourceInventoryRows": [
+        6
+      ],
       "road": "D",
       "bearing": "task-fact-execution",
       "leaseRequired": false,
-      "channel": { "pathClass": "admin-rpc", "zoneClass": "task-authored-structured" },
-      "entry": ["cli-migration"],
-      "cliActions": ["migrate-fact-execution"],
-      "callsiteFiles": ["packages/cli/src/commands/fact-execution-migration.ts"],
-      "evidence": ["packages/cli/src/commands/fact-execution-migration.ts:71", "packages/cli/src/commands/fact-execution-migration.ts:185"],
+      "channel": {
+        "pathClass": "admin-rpc",
+        "zoneClass": "task-authored-structured"
+      },
+      "entry": [
+        "cli-migration"
+      ],
+      "cliActions": [
+        "migrate-fact-execution"
+      ],
+      "callsiteFiles": [
+        "packages/cli/src/commands/fact-execution-migration.ts"
+      ],
+      "evidence": [
+        "packages/cli/src/commands/fact-execution-migration.ts:71",
+        "packages/cli/src/commands/fact-execution-migration.ts:185"
+      ],
       "freshness": "confirmed-plan-coordinator-batch"
     },
     {
       "id": "fact.record",
-      "sourceInventoryRows": [7],
+      "sourceInventoryRows": [
+        7
+      ],
       "road": "A",
       "bearing": "task-fact",
       "leaseRequired": true,
-      "channel": { "pathClass": "rpc-only", "zoneClass": "task-authored-structured" },
-      "entry": ["cli", "decision-reckon", "distill-promote"],
-      "writeKinds": ["doc_write"],
-      "cliActions": ["record-fact", "decision-reckon", "distill-commit"],
-      "callsiteFiles": ["packages/application/src/fact-write-service.ts"],
-      "evidence": ["packages/application/src/fact-write-service.ts:85", "packages/application/src/fact-write-service.ts:107", "packages/cli/src/commands/core/decision-reckon.ts:44"],
+      "channel": {
+        "pathClass": "rpc-only",
+        "zoneClass": "task-authored-structured"
+      },
+      "entry": [
+        "cli",
+        "decision-reckon",
+        "distill-promote"
+      ],
+      "writeKinds": [
+        "doc_write"
+      ],
+      "cliActions": [
+        "record-fact",
+        "decision-reckon",
+        "distill-commit"
+      ],
+      "callsiteFiles": [
+        "packages/application/src/fact-write-service.ts"
+      ],
+      "evidence": [
+        "packages/application/src/fact-write-service.ts:85",
+        "packages/application/src/fact-write-service.ts:107",
+        "packages/cli/src/commands/core/decision-reckon.ts:44"
+      ],
       "freshness": "append-record-delta"
     },
     {
       "id": "fact.invalidate",
-      "sourceInventoryRows": [8],
+      "sourceInventoryRows": [
+        8
+      ],
       "road": "A",
       "bearing": "task-fact",
       "leaseRequired": true,
-      "channel": { "pathClass": "rpc-only", "zoneClass": "task-authored-structured" },
-      "entry": ["cli"],
-      "writeKinds": ["fact_invalidate"],
-      "cliActions": ["fact-invalidate"],
-      "callsiteFiles": ["packages/application/src/fact-write-service.ts"],
-      "evidence": ["packages/application/src/fact-write-service.ts:128", "packages/application/src/fact-write-service.ts:151", "packages/kernel/src/store/write-journal-operations.ts:296"],
+      "channel": {
+        "pathClass": "rpc-only",
+        "zoneClass": "task-authored-structured"
+      },
+      "entry": [
+        "cli"
+      ],
+      "writeKinds": [
+        "fact_invalidate"
+      ],
+      "cliActions": [
+        "fact-invalidate"
+      ],
+      "callsiteFiles": [
+        "packages/application/src/fact-write-service.ts"
+      ],
+      "evidence": [
+        "packages/application/src/fact-write-service.ts:128",
+        "packages/application/src/fact-write-service.ts:151",
+        "packages/kernel/src/store/write-journal-operations.ts:296"
+      ],
       "freshness": "append-relation-delta-with-required-facts"
     },
     {
       "id": "decision.propose",
-      "sourceInventoryRows": [9],
+      "sourceInventoryRows": [
+        9
+      ],
       "road": "A",
       "bearing": "decision",
       "leaseRequired": false,
-      "channel": { "pathClass": "rpc-only", "zoneClass": "decision-authored-structured" },
-      "entry": ["cli", "daemon-rpc"],
-      "writeKinds": ["decision_propose"],
-      "cliActions": ["decision-propose"],
-      "callsiteFiles": ["packages/application/src/decision-write-service.ts"],
-      "evidence": ["packages/application/src/decision-write-service.ts:104", "packages/application/src/decision-write-service.ts:285"],
+      "channel": {
+        "pathClass": "rpc-only",
+        "zoneClass": "decision-authored-structured"
+      },
+      "entry": [
+        "cli",
+        "daemon-rpc"
+      ],
+      "writeKinds": [
+        "decision_propose"
+      ],
+      "cliActions": [
+        "decision-propose"
+      ],
+      "callsiteFiles": [
+        "packages/application/src/decision-write-service.ts"
+      ],
+      "evidence": [
+        "packages/application/src/decision-write-service.ts:104",
+        "packages/application/src/decision-write-service.ts:285"
+      ],
       "freshness": "decision-watermark-cas"
     },
     {
       "id": "decision.state.transition",
-      "sourceInventoryRows": [10],
+      "sourceInventoryRows": [
+        10
+      ],
       "road": "A",
       "bearing": "decision",
       "leaseRequired": false,
-      "channel": { "pathClass": "rpc-only", "zoneClass": "decision-authored-structured" },
-      "entry": ["cli", "daemon-rpc"],
-      "writeKinds": ["decision_accept", "decision_reject", "decision_defer", "decision_supersede", "decision_retire"],
-      "cliActions": ["decision-accept", "decision-reject", "decision-defer", "decision-supersede", "decision-retire"],
-      "callsiteFiles": ["packages/application/src/decision-write-service.ts"],
-      "evidence": ["packages/application/src/decision-write-service.ts:113", "packages/application/src/decision-write-service.ts:200", "packages/application/src/decision-write-service.ts:267"],
+      "channel": {
+        "pathClass": "rpc-only",
+        "zoneClass": "decision-authored-structured"
+      },
+      "entry": [
+        "cli",
+        "daemon-rpc"
+      ],
+      "writeKinds": [
+        "decision_accept",
+        "decision_reject",
+        "decision_defer",
+        "decision_supersede",
+        "decision_retire"
+      ],
+      "cliActions": [
+        "decision-accept",
+        "decision-reject",
+        "decision-defer",
+        "decision-supersede",
+        "decision-retire"
+      ],
+      "callsiteFiles": [
+        "packages/application/src/decision-write-service.ts"
+      ],
+      "evidence": [
+        "packages/application/src/decision-write-service.ts:113",
+        "packages/application/src/decision-write-service.ts:200",
+        "packages/application/src/decision-write-service.ts:267"
+      ],
       "freshness": "decision-watermark-cas"
     },
     {
       "id": "decision.amend",
-      "sourceInventoryRows": [11],
+      "sourceInventoryRows": [
+        11
+      ],
       "road": "A",
       "bearing": "decision",
       "leaseRequired": false,
-      "channel": { "pathClass": "rpc-only", "zoneClass": "decision-authored-structured" },
-      "entry": ["cli", "daemon-rpc"],
-      "writeKinds": ["decision_amend"],
-      "cliActions": ["decision-amend"],
-      "callsiteFiles": ["packages/application/src/decision-write-service.ts"],
-      "evidence": ["packages/application/src/decision-write-service.ts:119", "packages/application/src/decision-write-service.ts:267"],
+      "channel": {
+        "pathClass": "rpc-only",
+        "zoneClass": "decision-authored-structured"
+      },
+      "entry": [
+        "cli",
+        "daemon-rpc"
+      ],
+      "writeKinds": [
+        "decision_amend"
+      ],
+      "cliActions": [
+        "decision-amend"
+      ],
+      "callsiteFiles": [
+        "packages/application/src/decision-write-service.ts"
+      ],
+      "evidence": [
+        "packages/application/src/decision-write-service.ts:119",
+        "packages/application/src/decision-write-service.ts:267"
+      ],
       "freshness": "decision-watermark-cas"
     },
     {
       "id": "decision.relate",
-      "sourceInventoryRows": [12],
+      "sourceInventoryRows": [
+        12
+      ],
       "road": "A",
       "bearing": "decision",
       "leaseRequired": false,
-      "channel": { "pathClass": "rpc-only", "zoneClass": "decision-authored-structured" },
-      "entry": ["cli", "daemon-rpc"],
-      "writeKinds": ["decision_relate"],
-      "cliActions": ["decision-relate"],
-      "callsiteFiles": ["packages/application/src/decision-write-service.ts"],
-      "evidence": ["packages/application/src/decision-write-service.ts:56", "packages/application/src/decision-write-service.ts:124", "packages/kernel/src/store/write-journal-decision-documents.ts:61"],
+      "channel": {
+        "pathClass": "rpc-only",
+        "zoneClass": "decision-authored-structured"
+      },
+      "entry": [
+        "cli",
+        "daemon-rpc"
+      ],
+      "writeKinds": [
+        "decision_relate"
+      ],
+      "cliActions": [
+        "decision-relate"
+      ],
+      "callsiteFiles": [
+        "packages/application/src/decision-write-service.ts"
+      ],
+      "evidence": [
+        "packages/application/src/decision-write-service.ts:56",
+        "packages/application/src/decision-write-service.ts:124",
+        "packages/kernel/src/store/write-journal-decision-documents.ts:61"
+      ],
       "freshness": "append-relation"
     },
     {
       "id": "decision.relation.mutate",
-      "sourceInventoryRows": [13],
+      "sourceInventoryRows": [
+        13
+      ],
       "road": "A",
       "bearing": "decision",
       "leaseRequired": false,
-      "channel": { "pathClass": "rpc-only", "zoneClass": "decision-authored-structured" },
-      "entry": ["cli", "daemon-rpc"],
-      "writeKinds": ["relation_retire", "relation_replace"],
-      "cliActions": ["decision-relation-retire", "decision-relation-replace"],
-      "callsiteFiles": ["packages/application/src/decision-write-service.ts"],
-      "evidence": ["packages/application/src/decision-write-service.ts:134", "packages/application/src/decision-write-service.ts:267"],
+      "channel": {
+        "pathClass": "rpc-only",
+        "zoneClass": "decision-authored-structured"
+      },
+      "entry": [
+        "cli",
+        "daemon-rpc"
+      ],
+      "writeKinds": [
+        "relation_retire",
+        "relation_replace"
+      ],
+      "cliActions": [
+        "decision-relation-retire",
+        "decision-relation-replace"
+      ],
+      "callsiteFiles": [
+        "packages/application/src/decision-write-service.ts"
+      ],
+      "evidence": [
+        "packages/application/src/decision-write-service.ts:134",
+        "packages/application/src/decision-write-service.ts:267"
+      ],
       "freshness": "decision-watermark-cas"
     },
     {
       "id": "module.registry.canonical",
-      "sourceInventoryRows": [14],
+      "sourceInventoryRows": [
+        14
+      ],
       "road": "A",
       "bearing": "module-registry",
       "leaseRequired": false,
-      "channel": { "pathClass": "rpc-only", "zoneClass": "module-authored-structured" },
-      "entry": ["cli"],
-      "writeKinds": ["module_registry_write"],
-      "cliActions": ["module-register", "module-unregister", "module-step"],
-      "evidence": ["packages/cli/src/commands/extensions/module.ts:43", "packages/cli/src/commands/extensions/state.ts:380"],
+      "channel": {
+        "pathClass": "rpc-only",
+        "zoneClass": "module-authored-structured"
+      },
+      "entry": [
+        "cli"
+      ],
+      "writeKinds": [
+        "module_registry_write"
+      ],
+      "cliActions": [
+        "module-register",
+        "module-unregister",
+        "module-step"
+      ],
+      "evidence": [
+        "packages/cli/src/commands/extensions/module.ts:43",
+        "packages/cli/src/commands/extensions/state.ts:380"
+      ],
       "freshness": "coordinator-registry-replace"
     },
     {
       "id": "module.registry.generated-view",
-      "sourceInventoryRows": [14],
+      "sourceInventoryRows": [
+        14
+      ],
       "road": "D",
       "bearing": "generated-view",
       "leaseRequired": false,
-      "channel": { "pathClass": "generated-local", "zoneClass": "non-sot-projection" },
-      "entry": ["cli"],
-      "directWrites": [{ "file": "packages/cli/src/commands/extensions/module-registry-view.ts" }],
-      "evidence": ["packages/cli/src/commands/extensions/state.ts:389", "packages/cli/src/commands/extensions/module-registry-view.ts:7"],
+      "channel": {
+        "pathClass": "generated-local",
+        "zoneClass": "non-sot-projection"
+      },
+      "entry": [
+        "cli"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/commands/extensions/module-registry-view.ts"
+        }
+      ],
+      "evidence": [
+        "packages/cli/src/commands/extensions/state.ts:389",
+        "packages/cli/src/commands/extensions/module-registry-view.ts:7"
+      ],
       "freshness": "derived-view"
     },
     {
       "id": "module.scaffold",
-      "sourceInventoryRows": [15],
+      "sourceInventoryRows": [
+        15
+      ],
       "road": "D",
       "bearing": "admin-scaffold",
       "leaseRequired": false,
-      "channel": { "pathClass": "admin-rpc", "zoneClass": "module-authored-docs" },
-      "entry": ["cli"],
-      "writeKinds": ["module_scaffold_write"],
-      "cliActions": ["module-scaffold"],
-      "evidence": ["packages/cli/src/commands/extensions/module.ts:71", "packages/kernel/src/store/write-journal-operations.ts:394"],
+      "channel": {
+        "pathClass": "admin-rpc",
+        "zoneClass": "module-authored-docs"
+      },
+      "entry": [
+        "cli"
+      ],
+      "writeKinds": [
+        "module_scaffold_write"
+      ],
+      "cliActions": [
+        "module-scaffold"
+      ],
+      "evidence": [
+        "packages/cli/src/commands/extensions/module.ts:71",
+        "packages/kernel/src/store/write-journal-operations.ts:394"
+      ],
       "freshness": "scaffold-template-write"
     },
     {
       "id": "session.provenance.claim-check",
-      "sourceInventoryRows": [16],
+      "sourceInventoryRows": [
+        16
+      ],
       "road": "B",
       "bearing": "session-composite-manifest-blob",
       "leaseRequired": false,
-      "channel": { "pathClass": "declared-manifest-plus-claim-check", "zoneClass": "session-provenance" },
-      "entry": ["cli", "internal"],
-      "writeKinds": ["doc_write", "machine_artifact_write"],
-      "machineArtifactBoundaries": ["provenance-session"],
-      "cliActions": ["session-backfill", "session-export", "session-sync"],
-      "callsiteFiles": ["packages/kernel/src/entity/declaration.ts"],
-      "evidence": ["packages/application/src/provenance-session-exporter.ts:134", "packages/kernel/src/entity/declaration.ts:53", "packages/cli/src/commands/core/session.ts:16", "packages/cli/src/commands/core/session.ts:91", "packages/cli/src/commands/core/session-cutover.ts:38"],
+      "channel": {
+        "pathClass": "declared-manifest-plus-claim-check",
+        "zoneClass": "session-provenance"
+      },
+      "entry": [
+        "cli",
+        "internal"
+      ],
+      "writeKinds": [
+        "doc_write",
+        "machine_artifact_write"
+      ],
+      "machineArtifactBoundaries": [
+        "provenance-session"
+      ],
+      "cliActions": [
+        "session-backfill",
+        "session-export",
+        "session-sync"
+      ],
+      "callsiteFiles": [
+        "packages/kernel/src/entity/declaration.ts"
+      ],
+      "evidence": [
+        "packages/application/src/provenance-session-exporter.ts:134",
+        "packages/kernel/src/entity/declaration.ts:53",
+        "packages/cli/src/commands/core/session.ts:16",
+        "packages/cli/src/commands/core/session.ts:91",
+        "packages/cli/src/commands/core/session-cutover.ts:38"
+      ],
       "freshness": "coordinated-manifest-plus-content-addressed-blob-ref"
     },
     {
       "id": "runtime-event.coordinated-jsonl",
-      "sourceInventoryRows": [17],
+      "sourceInventoryRows": [
+        17
+      ],
       "road": "D",
       "bearing": "runtime-event-audit",
       "leaseRequired": false,
-      "channel": { "pathClass": "generated-local", "zoneClass": "runtime-event-telemetry" },
-      "entry": ["cli", "internal"],
-      "writeKinds": ["machine_artifact_append_jsonl"],
-      "machineArtifactBoundaries": ["runtime-event-ledger"],
-      "cliActions": ["runtime-event-append"],
-      "callsiteFiles": ["packages/application/src/runtime-event-ledger-service.ts"],
-      "evidence": ["packages/application/src/runtime-event-ledger-service.ts:145", "packages/application/src/runtime-event-ledger-service.ts:174"],
+      "channel": {
+        "pathClass": "generated-local",
+        "zoneClass": "runtime-event-telemetry"
+      },
+      "entry": [
+        "cli",
+        "internal"
+      ],
+      "writeKinds": [
+        "machine_artifact_append_jsonl"
+      ],
+      "machineArtifactBoundaries": [
+        "runtime-event-ledger"
+      ],
+      "cliActions": [
+        "runtime-event-append"
+      ],
+      "callsiteFiles": [
+        "packages/application/src/runtime-event-ledger-service.ts"
+      ],
+      "evidence": [
+        "packages/application/src/runtime-event-ledger-service.ts:145",
+        "packages/application/src/runtime-event-ledger-service.ts:174"
+      ],
       "freshness": "append-jsonl-telemetry"
     },
     {
       "id": "docmap.derived-write",
-      "sourceInventoryRows": [18],
+      "sourceInventoryRows": [
+        18
+      ],
       "road": "D",
       "bearing": "derived-projection",
       "leaseRequired": false,
-      "channel": { "pathClass": "generated-or-authored-derived", "zoneClass": "non-sot-projection" },
-      "entry": ["cli"],
-      "machineArtifactBoundaries": ["docmap-derived"],
-      "cliActions": ["doc-generate"],
-      "evidence": ["packages/cli/src/commands/core/doc.ts:13", "packages/cli/src/commands/core/docmap-generate.ts:37"],
+      "channel": {
+        "pathClass": "generated-or-authored-derived",
+        "zoneClass": "non-sot-projection"
+      },
+      "entry": [
+        "cli"
+      ],
+      "machineArtifactBoundaries": [
+        "docmap-derived"
+      ],
+      "cliActions": [
+        "doc-generate"
+      ],
+      "evidence": [
+        "packages/cli/src/commands/core/doc.ts:13",
+        "packages/cli/src/commands/core/docmap-generate.ts:37"
+      ],
       "freshness": "derived-json"
     },
     {
       "id": "distill.lesson.artifacts",
-      "sourceInventoryRows": [19],
+      "sourceInventoryRows": [
+        19
+      ],
       "road": "D",
       "bearing": "derived-artifact",
       "leaseRequired": false,
-      "channel": { "pathClass": "generated-local", "zoneClass": "non-sot-artifact" },
-      "entry": ["cli"],
-      "machineArtifactBoundaries": ["distill-candidate"],
-      "cliActions": ["distill-candidate", "lesson-promote", "lesson-sediment"],
-      "directWrites": [{ "file": "packages/cli/src/commands/lesson.ts" }],
-      "evidence": ["packages/cli/src/commands/core/distill.ts:37", "packages/cli/src/commands/lesson.ts:16"],
+      "channel": {
+        "pathClass": "generated-local",
+        "zoneClass": "non-sot-artifact"
+      },
+      "entry": [
+        "cli"
+      ],
+      "machineArtifactBoundaries": [
+        "distill-candidate"
+      ],
+      "cliActions": [
+        "distill-candidate",
+        "lesson-promote",
+        "lesson-sediment"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/commands/lesson.ts"
+        }
+      ],
+      "evidence": [
+        "packages/cli/src/commands/core/distill.ts:37",
+        "packages/cli/src/commands/lesson.ts:16"
+      ],
       "freshness": "derived-json"
     },
     {
       "id": "legacy.migration.artifacts",
-      "sourceInventoryRows": [20],
+      "sourceInventoryRows": [
+        20
+      ],
       "road": "D",
       "bearing": "admin-import",
       "leaseRequired": false,
-      "channel": { "pathClass": "admin-import", "zoneClass": "legacy-forward-or-report" },
-      "entry": ["cli-migration"],
-      "machineArtifactBoundaries": ["legacy-forward"],
-      "cliActions": ["legacy-copy-safe-docs", "legacy-index", "legacy-intake-plan", "migrate-run", "migrate-structure"],
-      "directWrites": [
-        { "file": "packages/cli/src/commands/migration-collision.ts" },
-        { "file": "packages/cli/src/commands/migration-scan.ts" },
-        { "file": "packages/cli/src/commands/migration.ts" }
+      "channel": {
+        "pathClass": "admin-import",
+        "zoneClass": "legacy-forward-or-report"
+      },
+      "entry": [
+        "cli-migration"
       ],
-      "evidence": ["packages/cli/src/commands/migration.ts:337", "packages/cli/src/commands/migration-collision.ts:60", "packages/cli/src/commands/migration-scan.ts:267"],
+      "machineArtifactBoundaries": [
+        "legacy-forward"
+      ],
+      "cliActions": [
+        "legacy-copy-safe-docs",
+        "legacy-index",
+        "legacy-intake-plan",
+        "migrate-run",
+        "migrate-structure"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/commands/migration-collision.ts"
+        },
+        {
+          "file": "packages/cli/src/commands/migration-scan.ts"
+        },
+        {
+          "file": "packages/cli/src/commands/migration.ts"
+        }
+      ],
+      "evidence": [
+        "packages/cli/src/commands/migration.ts:337",
+        "packages/cli/src/commands/migration-collision.ts:60",
+        "packages/cli/src/commands/migration-scan.ts:267"
+      ],
       "freshness": "admin-copy-or-report"
     },
     {
       "id": "governance.projection.rebuild",
-      "sourceInventoryRows": [21],
+      "sourceInventoryRows": [
+        21
+      ],
       "road": "D",
       "bearing": "derived-projection",
       "leaseRequired": false,
-      "channel": { "pathClass": "generated-local", "zoneClass": "non-sot-projection" },
-      "entry": ["cli", "read-path-auto-rebuild", "gui-bridge"],
-      "cliActions": ["governance-rebuild", "materializer-run"],
-      "apiRoutes": ["governance.rebuild"],
-      "guiBridgeMethods": ["rebuildGovernance"],
-      "directWrites": [
-        { "file": "packages/cli/src/commands/governance.ts" },
-        { "file": "packages/kernel/src/projection/sqlite-projection-store.ts" }
+      "channel": {
+        "pathClass": "generated-local",
+        "zoneClass": "non-sot-projection"
+      },
+      "entry": [
+        "cli",
+        "read-path-auto-rebuild",
+        "gui-bridge"
       ],
-      "evidence": ["packages/kernel/src/projection/sqlite-task-projection.ts:45", "packages/kernel/src/projection/sqlite-projection-store.ts:49", "packages/cli/src/commands/governance.ts:29"],
+      "cliActions": [
+        "governance-rebuild",
+        "materializer-run"
+      ],
+      "apiRoutes": [
+        "governance.rebuild"
+      ],
+      "guiBridgeMethods": [
+        "rebuildGovernance"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/commands/governance.ts"
+        },
+        {
+          "file": "packages/kernel/src/projection/sqlite-projection-store.ts"
+        }
+      ],
+      "evidence": [
+        "packages/kernel/src/projection/sqlite-task-projection.ts:45",
+        "packages/kernel/src/projection/sqlite-projection-store.ts:49",
+        "packages/cli/src/commands/governance.ts:29"
+      ],
       "freshness": "rebuildable-projection"
     },
     {
       "id": "graph.panorama.generated",
-      "sourceInventoryRows": [22],
+      "sourceInventoryRows": [
+        22
+      ],
       "road": "D",
       "bearing": "derived-projection",
       "leaseRequired": false,
-      "channel": { "pathClass": "generated-local", "zoneClass": "non-sot-projection" },
-      "entry": ["cli"],
-      "cliActions": ["graph"],
-      "directWrites": [{ "file": "packages/cli/src/commands/graph-panorama.ts" }],
-      "evidence": ["packages/cli/src/commands/graph-panorama.ts:32"],
+      "channel": {
+        "pathClass": "generated-local",
+        "zoneClass": "non-sot-projection"
+      },
+      "entry": [
+        "cli"
+      ],
+      "cliActions": [
+        "graph"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/commands/graph-panorama.ts"
+        }
+      ],
+      "evidence": [
+        "packages/cli/src/commands/graph-panorama.ts:32"
+      ],
       "freshness": "derived-html"
     },
     {
       "id": "repository.bootstrap.admin",
-      "sourceInventoryRows": [23],
+      "sourceInventoryRows": [
+        23
+      ],
       "road": "D",
       "bearing": "admin-bootstrap",
       "leaseRequired": false,
-      "channel": { "pathClass": "admin-bootstrap", "zoneClass": "repository-local" },
-      "entry": ["cli"],
-      "cliActions": ["init", "gui"],
-      "apiRoutes": ["terminal.sessions.create", "terminal.sessions.resize", "terminal.sessions.close"],
-      "directWrites": [
-        { "file": "packages/cli/src/commands/core/init.ts" },
-        { "file": "packages/cli/src/commands/init.ts" },
-        { "file": "packages/cli/src/commands/extensions/repository-scaffold.ts" },
-        { "file": "packages/cli/src/commands/daemon/productization.ts" },
-        { "file": "packages/daemon/src/transport/unix-socket.ts" },
-        { "file": "packages/kernel/src/daemon/registry.ts" }
+      "channel": {
+        "pathClass": "admin-bootstrap",
+        "zoneClass": "repository-local"
+      },
+      "entry": [
+        "cli"
       ],
-      "evidence": ["packages/cli/src/commands/init.ts:184", "packages/cli/src/commands/extensions/repository-scaffold.ts:21", "packages/cli/src/commands/daemon/productization.ts:338"],
+      "cliActions": [
+        "init",
+        "gui"
+      ],
+      "apiRoutes": [
+        "terminal.sessions.create",
+        "terminal.sessions.resize",
+        "terminal.sessions.close"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/commands/core/init.ts"
+        },
+        {
+          "file": "packages/cli/src/commands/init.ts"
+        },
+        {
+          "file": "packages/cli/src/commands/extensions/repository-scaffold.ts"
+        },
+        {
+          "file": "packages/cli/src/commands/daemon/productization.ts"
+        },
+        {
+          "file": "packages/daemon/src/transport/unix-socket.ts"
+        },
+        {
+          "file": "packages/kernel/src/daemon/registry.ts"
+        }
+      ],
+      "evidence": [
+        "packages/cli/src/commands/init.ts:184",
+        "packages/cli/src/commands/extensions/repository-scaffold.ts:21",
+        "packages/cli/src/commands/daemon/productization.ts:338"
+      ],
       "freshness": "admin-bootstrap-direct"
     },
     {
       "id": "preset.config.evidence",
-      "sourceInventoryRows": [24],
+      "sourceInventoryRows": [
+        24
+      ],
       "road": "D",
       "bearing": "admin-config",
       "leaseRequired": false,
-      "channel": { "pathClass": "admin-config", "zoneClass": "preset-local" },
-      "entry": ["cli"],
-      "writeKinds": ["machine_artifact_write"],
-      "machineArtifactBoundaries": ["preset-evidence-registry"],
-      "cliActions": ["preset-action", "preset-install", "preset-run", "preset-seed", "preset-uninstall"],
-      "directWrites": [
-        { "file": "packages/cli/src/commands/extensions/machine-evidence-registry.ts" },
-        { "file": "packages/cli/src/commands/extensions/preset.ts" },
-        { "file": "packages/cli/src/commands/extensions/preset-evidence.ts" },
-        { "file": "packages/cli/src/commands/extensions/state.ts" }
+      "channel": {
+        "pathClass": "admin-config",
+        "zoneClass": "preset-local"
+      },
+      "entry": [
+        "cli"
       ],
-      "evidence": ["packages/cli/src/commands/extensions/preset.ts:135", "packages/cli/src/commands/extensions/state.ts:348"],
+      "writeKinds": [
+        "machine_artifact_write"
+      ],
+      "machineArtifactBoundaries": [
+        "preset-evidence-registry"
+      ],
+      "cliActions": [
+        "preset-action",
+        "preset-install",
+        "preset-run",
+        "preset-seed",
+        "preset-uninstall"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/commands/extensions/machine-evidence-registry.ts"
+        },
+        {
+          "file": "packages/cli/src/commands/extensions/preset.ts"
+        },
+        {
+          "file": "packages/cli/src/commands/extensions/preset-evidence.ts"
+        },
+        {
+          "file": "packages/cli/src/commands/extensions/state.ts"
+        }
+      ],
+      "evidence": [
+        "packages/cli/src/commands/extensions/preset.ts:135",
+        "packages/cli/src/commands/extensions/state.ts:348"
+      ],
       "freshness": "admin-config-or-evidence"
     },
     {
       "id": "script-run.declared-write-scopes",
-      "sourceInventoryRows": [25],
+      "sourceInventoryRows": [
+        25
+      ],
       "road": "D",
       "bearing": "script-dynamic-output",
       "leaseRequired": false,
-      "channel": { "pathClass": "declared-script-scope", "zoneClass": "dynamic-output" },
-      "entry": ["cli", "preset-runner"],
-      "cliActions": ["script-run"],
+      "channel": {
+        "pathClass": "declared-script-scope",
+        "zoneClass": "dynamic-output"
+      },
+      "entry": [
+        "cli",
+        "preset-runner"
+      ],
+      "cliActions": [
+        "script-run"
+      ],
       "directWrites": [
-        { "file": "packages/cli/src/commands/extensions/preset-script-runner.ts" },
-        { "file": "packages/cli/src/commands/extensions/script-host.ts" },
-        { "file": "packages/cli/src/commands/extensions/shared.ts" }
+        {
+          "file": "packages/cli/src/commands/extensions/preset-script-runner.ts"
+        },
+        {
+          "file": "packages/cli/src/commands/extensions/script-host.ts"
+        },
+        {
+          "file": "packages/cli/src/commands/extensions/shared.ts"
+        }
       ],
       "presetWriteScopes": [
         "{{outputRoot}}/**",
         "{{paths.adrRoot}}/**",
         "{{paths.milestonesRoot}}/**"
       ],
-      "evidence": ["packages/cli/src/commands/extensions/script-host.ts:75", "packages/cli/src/commands/extensions/preset-script-runner.ts:95"],
+      "evidence": [
+        "packages/cli/src/commands/extensions/script-host.ts:75",
+        "packages/cli/src/commands/extensions/preset-script-runner.ts:95"
+      ],
       "freshness": "declared-writes"
     },
     {
       "id": "script-run.declared-produces",
-      "sourceInventoryRows": [25],
+      "sourceInventoryRows": [
+        25
+      ],
       "road": "D",
       "bearing": "script-dynamic-output",
       "leaseRequired": false,
-      "channel": { "pathClass": "declared-script-produce", "zoneClass": "dynamic-output" },
-      "entry": ["cli"],
+      "channel": {
+        "pathClass": "declared-script-produce",
+        "zoneClass": "dynamic-output"
+      },
+      "entry": [
+        "cli"
+      ],
       "presetProduces": [
         "{{paths.adrRoot}}/*.md",
         "{{paths.adrRoot}}/0000-template.md",
         "{{paths.adrRoot}}/README.md"
       ],
-      "evidence": ["packages/cli/src/commands/extensions/script-host.ts:186", "packages/cli/src/commands/extensions/assets/software-coding/vertical.json:250"],
+      "evidence": [
+        "packages/cli/src/commands/extensions/script-host.ts:186",
+        "packages/cli/src/commands/extensions/assets/software-coding/vertical.json:250"
+      ],
       "freshness": "declared-produces"
     },
     {
       "id": "public-code-change.git",
-      "sourceInventoryRows": [26],
+      "sourceInventoryRows": [
+        26
+      ],
       "road": "C",
       "bearing": "code-change",
       "leaseRequired": false,
-      "channel": { "pathClass": "git-worktree", "zoneClass": "code-truth" },
-      "entry": ["cli", "external-git"],
-      "cliActions": ["adopt-multica", "git-diff", "worktree-create"],
-      "directWrites": [
-        { "file": "packages/adapters/local/src/git-diff-evidence.ts", "command": "git" },
-        { "file": "packages/adapters/local/src/index.ts", "command": "git" },
-        { "file": "packages/cli/src/commands/core/authored-git.ts", "command": "git" },
-        { "file": "packages/cli/src/commands/doctor.ts", "command": "git" },
-        { "file": "packages/kernel/src/projection/post-merge-checks.ts", "command": "git" },
-        { "file": "packages/kernel/src/store/local-version-control-system.ts", "command": "git" }
+      "channel": {
+        "pathClass": "git-worktree",
+        "zoneClass": "code-truth"
+      },
+      "entry": [
+        "cli",
+        "external-git"
       ],
-      "evidence": ["packages/cli/src/commands/core/worktree.ts:183", "packages/kernel/src/store/local-version-control-system.ts:21"],
+      "cliActions": [
+        "adopt-multica",
+        "git-diff",
+        "worktree-create"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/adapters/local/src/git-diff-evidence.ts",
+          "command": "git"
+        },
+        {
+          "file": "packages/adapters/local/src/index.ts",
+          "command": "git"
+        },
+        {
+          "file": "packages/cli/src/commands/core/authored-git.ts",
+          "command": "git"
+        },
+        {
+          "file": "packages/cli/src/commands/doctor.ts",
+          "command": "git"
+        },
+        {
+          "file": "packages/kernel/src/projection/post-merge-checks.ts",
+          "command": "git"
+        },
+        {
+          "file": "packages/kernel/src/store/local-version-control-system.ts",
+          "command": "git"
+        }
+      ],
+      "evidence": [
+        "packages/cli/src/commands/core/worktree.ts:183",
+        "packages/kernel/src/store/local-version-control-system.ts:21"
+      ],
       "freshness": "git-ref"
     },
     {
       "id": "worktree.binding-cache",
-      "sourceInventoryRows": [26],
+      "sourceInventoryRows": [
+        26
+      ],
       "road": "D",
       "bearing": "generated-cache",
       "leaseRequired": false,
-      "channel": { "pathClass": "generated-local", "zoneClass": "non-sot-cache" },
-      "entry": ["cli"],
-      "directWrites": [{ "file": "packages/cli/src/commands/core/worktree.ts" }],
-      "evidence": ["packages/cli/src/commands/core/worktree.ts:183"],
+      "channel": {
+        "pathClass": "generated-local",
+        "zoneClass": "non-sot-cache"
+      },
+      "entry": [
+        "cli"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/commands/core/worktree.ts"
+        }
+      ],
+      "evidence": [
+        "packages/cli/src/commands/core/worktree.ts:183"
+      ],
       "freshness": "local-binding-cache"
     },
     {
       "id": "doc.sync.submit",
-      "sourceInventoryRows": [5],
+      "sourceInventoryRows": [
+        5
+      ],
       "road": "A",
       "bearing": "task-document",
-      "channel": { "pathClass": "doc-sync-allowed", "zoneClass": "task-authored-prose-canonical" },
-      "entry": ["cli", "daemon-rpc"],
-      "writeKinds": ["doc_sync_submit"],
-      "evidence": ["packages/cli/src/daemon/doc-sync-service.ts:243", "packages/kernel/src/domain/write-op-kind.ts:1"],
+      "channel": {
+        "pathClass": "doc-sync-allowed",
+        "zoneClass": "task-authored-prose-canonical"
+      },
+      "entry": [
+        "cli",
+        "daemon-rpc"
+      ],
+      "writeKinds": [
+        "doc_sync_submit"
+      ],
+      "evidence": [
+        "packages/cli/src/daemon/doc-sync-service.ts:243",
+        "packages/kernel/src/domain/write-op-kind.ts:1"
+      ],
       "freshness": "doc-sync-submit-cas-post-apply"
     },
     {
       "id": "preset.script.staging-ingest",
-      "sourceInventoryRows": [25],
+      "sourceInventoryRows": [
+        25
+      ],
       "road": "A",
       "bearing": "script-canonical-ingest",
-      "channel": { "pathClass": "coordinator-ingest", "zoneClass": "script-staging-mirror-to-canonical" },
-      "entry": ["cli", "preset-runner"],
-      "writeKinds": ["script_ingest"],
-      "callsiteFiles": ["packages/cli/src/commands/core/extension.ts"],
-      "directWrites": [
-        { "file": "packages/cli/src/commands/extensions/script-staging.ts", "api": "mkdirSync" },
-        { "file": "packages/cli/src/commands/extensions/script-staging.ts", "api": "cpSync" }
+      "channel": {
+        "pathClass": "coordinator-ingest",
+        "zoneClass": "script-staging-mirror-to-canonical"
+      },
+      "entry": [
+        "cli",
+        "preset-runner"
       ],
-      "evidence": ["packages/cli/src/commands/extensions/script-staging.ts:32", "packages/cli/src/commands/core/extension.ts:10"],
+      "writeKinds": [
+        "script_ingest"
+      ],
+      "callsiteFiles": [
+        "packages/cli/src/commands/core/extension.ts"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/commands/extensions/script-staging.ts",
+          "api": "mkdirSync"
+        },
+        {
+          "file": "packages/cli/src/commands/extensions/script-staging.ts",
+          "api": "cpSync"
+        }
+      ],
+      "evidence": [
+        "packages/cli/src/commands/extensions/script-staging.ts:32",
+        "packages/cli/src/commands/core/extension.ts:10"
+      ],
       "freshness": "staging-mirror-ingest"
     },
     {
       "id": "authority.replication.submit",
-      "sourceInventoryRows": [1],
+      "sourceInventoryRows": [
+        1
+      ],
       "road": "A",
       "bearing": "authority-replication",
       "leaseRequired": false,
-      "channel": { "pathClass": "coordinator-attributed", "zoneClass": "canonical-entity-via-attributed-coordinator" },
-      "entry": ["forced-command-ssh", "authority-daemon"],
-      "callsiteFiles": ["packages/application/src/authority/service.ts"],
-      "evidence": ["packages/application/src/authority/service.ts:86", "packages/daemon/src/authority/forced-command-session.ts:1"],
+      "channel": {
+        "pathClass": "coordinator-attributed",
+        "zoneClass": "canonical-entity-via-attributed-coordinator"
+      },
+      "entry": [
+        "forced-command-ssh",
+        "authority-daemon"
+      ],
+      "callsiteFiles": [
+        "packages/application/src/authority/service.ts"
+      ],
+      "evidence": [
+        "packages/application/src/authority/service.ts:86",
+        "packages/daemon/src/authority/forced-command-session.ts:1"
+      ],
       "freshness": "authority-serialized-first-parent"
     },
     {
       "id": "receipt.compound.durable-store",
-      "sourceInventoryRows": [1],
+      "sourceInventoryRows": [
+        1
+      ],
       "road": "A",
       "bearing": "receipt-durability",
       "leaseRequired": false,
-      "channel": { "pathClass": "runtime-local-durable", "zoneClass": "compound-receipt-crash-recovery" },
-      "entry": ["cli"],
-      "directWrites": [
-        { "file": "packages/cli/src/receipt/durable-store.ts" }
+      "channel": {
+        "pathClass": "runtime-local-durable",
+        "zoneClass": "compound-receipt-crash-recovery"
+      },
+      "entry": [
+        "cli"
       ],
-      "evidence": ["packages/cli/src/receipt/durable-store.ts:76", "packages/application/src/receipt/service.ts:1"],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/receipt/durable-store.ts"
+        }
+      ],
+      "evidence": [
+        "packages/cli/src/receipt/durable-store.ts:76",
+        "packages/application/src/receipt/service.ts:1"
+      ],
       "freshness": "fsync-atomic-rename"
     },
     {
       "id": "broker.local-view.native-apply",
-      "sourceInventoryRows": [1],
+      "sourceInventoryRows": [
+        1
+      ],
       "road": "A",
       "bearing": "broker-local-view",
       "leaseRequired": false,
-      "channel": { "pathClass": "broker-local-view", "zoneClass": "transparent-view-materialization" },
-      "entry": ["broker"],
-      "directWrites": [
-        { "file": "packages/daemon/src/broker/native-applier.ts" },
-        { "file": "packages/daemon/src/broker/durable-state-store.ts" },
-        { "file": "packages/daemon/src/broker/conflict-store.ts" },
-        { "file": "packages/daemon/src/broker/cas-store.ts" }
+      "channel": {
+        "pathClass": "broker-local-view",
+        "zoneClass": "transparent-view-materialization"
+      },
+      "entry": [
+        "broker"
       ],
-      "evidence": ["packages/daemon/src/broker/native-applier.ts:168", "packages/daemon/src/broker/durable-state-store.ts:1"],
+      "directWrites": [
+        {
+          "file": "packages/daemon/src/broker/native-applier.ts"
+        },
+        {
+          "file": "packages/daemon/src/broker/durable-state-store.ts"
+        },
+        {
+          "file": "packages/daemon/src/broker/conflict-store.ts"
+        },
+        {
+          "file": "packages/daemon/src/broker/cas-store.ts"
+        }
+      ],
+      "evidence": [
+        "packages/daemon/src/broker/native-applier.ts:168",
+        "packages/daemon/src/broker/durable-state-store.ts:1"
+      ],
       "freshness": "crash-safe-cut-apply"
     },
     {
       "id": "platform.qualification.semantic-probe",
-      "sourceInventoryRows": [1],
+      "sourceInventoryRows": [
+        1
+      ],
       "road": "D",
       "bearing": "platform-probe",
       "leaseRequired": false,
-      "channel": { "pathClass": "probe-scratch", "zoneClass": "ephemeral-qualification-probe" },
-      "entry": ["daemon"],
-      "directWrites": [
-        { "file": "packages/daemon/src/platform/semantic-probe.ts" }
+      "channel": {
+        "pathClass": "probe-scratch",
+        "zoneClass": "ephemeral-qualification-probe"
+      },
+      "entry": [
+        "daemon"
       ],
-      "evidence": ["packages/daemon/src/platform/semantic-probe.ts:19", "packages/daemon/src/platform/qualification.ts:1"],
+      "directWrites": [
+        {
+          "file": "packages/daemon/src/platform/semantic-probe.ts"
+        }
+      ],
+      "evidence": [
+        "packages/daemon/src/platform/semantic-probe.ts:19",
+        "packages/daemon/src/platform/qualification.ts:1"
+      ],
       "freshness": "ephemeral-probe-create-and-remove"
     },
     {
       "id": "fence.authority.enrollment-and-durability",
-      "sourceInventoryRows": [1],
+      "sourceInventoryRows": [
+        1
+      ],
       "road": "A",
       "bearing": "authority-fence",
       "leaseRequired": false,
-      "channel": { "pathClass": "runtime-local-durable", "zoneClass": "fence-enrollment-and-durability-boundary" },
-      "entry": ["daemon"],
-      "directWrites": [
-        { "file": "packages/daemon/src/fence/authority-fence.ts" },
-        { "file": "packages/daemon/src/fence/durability.ts" }
+      "channel": {
+        "pathClass": "runtime-local-durable",
+        "zoneClass": "fence-enrollment-and-durability-boundary"
+      },
+      "entry": [
+        "daemon"
       ],
-      "evidence": ["packages/daemon/src/fence/authority-fence.ts:42", "packages/daemon/src/fence/durability.ts:145"],
+      "directWrites": [
+        {
+          "file": "packages/daemon/src/fence/authority-fence.ts"
+        },
+        {
+          "file": "packages/daemon/src/fence/durability.ts"
+        }
+      ],
+      "evidence": [
+        "packages/daemon/src/fence/authority-fence.ts:42",
+        "packages/daemon/src/fence/durability.ts:145"
+      ],
       "freshness": "fenced-fsync-ordered-boundary"
+    },
+    {
+      "id": "daemon.socket-ownership.lock",
+      "sourceInventoryRows": [
+        26
+      ],
+      "road": "D",
+      "bearing": "generated-cache",
+      "leaseRequired": false,
+      "channel": {
+        "pathClass": "generated-local",
+        "zoneClass": "non-sot-cache"
+      },
+      "entry": [
+        "cli"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/commands/daemon/serve-transport.ts"
+        }
+      ],
+      "evidence": [
+        "packages/cli/src/commands/daemon/serve-transport.ts:1"
+      ],
+      "freshness": "daemon-socket-owner-lock"
     }
   ]
 }


### PR DESCRIPTION
# English

## Summary

Concurrent `ha` CLI clients triggering daemon autostart spawned multiple short-lived daemons that unconditionally unlink/rebind the same unix socket, and an exiting (idle) daemon could delete the socket a newer instance had just bound. Observed 2026-07-13: 5+ local outages in one day (connect ENOENT, GlobalWriteConflict, `status` reporting started while unreachable) plus the same flake class in CI (PR #695 first-round fast-contract red, rerun green). This PR serializes socket ownership at the serve lifecycle level.

## What Changed

- `packages/cli/src/commands/daemon/serve-transport.ts` (new): atomic socket-ownership acquisition — a serve process claims an owner lock (unique `ownerToken`) before starting its runtime; losers wait for the winner to become reachable and connect to it; stale owner locks (dead pid) are quarantined and ownership handed to exactly one contender.
- `packages/cli/src/index.ts`, `packages/cli/src/commands/daemon/productization.ts`: serve/stop lifecycle wired through ownership — cleanup verifies the `ownerToken` before releasing, so an old daemon can never unlink a successor's socket; `daemon status` reports `started=true` only when the RPC endpoint is actually reachable (no more started-but-ENOENT window).
- `packages/cli/test/daemon-autostart-socket-race-cli.test.ts` (new): positive control — N=8 concurrent cold-start clients. Red before the fix (3 succeeded / 5 failed), green after (8/8 succeed, all repo locks point at one pid). Plus: unreachable-owner handover to exactly one contender; status cannot report started while unreachable.

Mechanism invariants (from the task contract): (1) at most one daemon serve bound per socket path — losers connect to the winner; (2) idle-exit never deletes a socket it does not own; (3) `status` agrees with connectivity.

## Task And Scope

- Harness task: task_01KXD0A37NN8ZQEJ2ENG5K313V
- Branch: fix/daemon-autostart-socket-race
- Public scope: packages/cli daemon serve lifecycle + tests only
- Private planning/evidence updated: yes (task package plan/progress in private ledger)
- Out of scope: TW-05 direct-mode fail-close guard and TW-06 fence semantics (untouched, `daemon/client.ts` not modified); parse-failure diagnostics (merged separately as #701); worktree ha-write routing (follow-up task, depends on this PR)

## Version Impact

- Version: no version change because this is a bug fix within existing daemon behavior, no public API change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: gate-allowlist `check-bypass-write-boundary` (+8 entries, GROWTH_REQUIRES_GOVERNANCE_REVIEW marker shows delta honestly) and `tools/write-road-registry.json` (+1 row `daemon.socket-ownership.lock`, rowCountReconciliation updated 40->41). Both register the daemon socket owner-lock as governed operational transport state; no gate was weakened, no existing entry modified. Registered by CEO session (commit 6075f99), not by the implementation worker.
- Authority: harness task task_01KXD0A37NN8ZQEJ2ENG5K313V (discovered-defect fix under standing authorization); allowlist entries and registry row carry the task ref inline
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: f606ca62 (merge of #702)
- Branch merge-base with `origin/main`: f606ca62
- Last `git fetch origin` time: 2026-07-13 (pre-push, same session)
- Sync method: rebase (onto f606ca62 before final gate run)
- Public diff command: `git diff f606ca62..544a9223`
- Private evidence commit/path: harness/tasks/task_01KXD0A37NN8ZQEJ2ENG5K313V-daemon-autostart-socket-daemon-socket-socket/
- Reviewer evidence path: same task package (task_plan.md invariants 1-3)
- GitHub Actions `rewrite-ci` run URL: pending (attached by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (via root `check:local`, 16/16 steps, exit 0, 152.3s)
- [x] `npm run typecheck` (via `check:local`)
- [x] `npm test` (fast 322/322, contract 441/441; N=8 race control red-then-green)
- [x] `npm run harness:check-import-boundaries` (via `check:local`)
- [x] `npm run harness:scan-forbidden-symbols` (via `check:local`)
- [x] `npm run harness:check-private-boundary` (via `check:local`)
- [x] `npm run harness:check-package-policy` (via `check:local`)
- [x] `npm run harness:check-implementation-contracts` (via `check:local`)
- [x] `npm run harness:check-schema-contracts` (via `check:local`)
- [x] `npm run harness:check-legacy-intake-readiness` (via `check:local`)
- [x] `npm run harness:smoke-cli-package` (via `check:local`)
- [ ] GitHub Actions `rewrite-ci` passed

---

# 中文

## 摘要

并发 `ha` CLI 客户端触发 daemon autostart 时，多个短命 daemon 会无条件 unlink/rebind 同一 unix socket，且 idle 退出的旧 daemon 能删掉新实例刚 bind 的 socket。2026-07-13 实测单日 5+ 次本地断档（connect ENOENT、GlobalWriteConflict、`status` 报 started 但连不上），CI 侧同款 flake（PR #695 首轮 fast-contract 红、rerun 复绿）。本 PR 在 serve 生命周期层序列化 socket 所有权。

## 变更内容

- `packages/cli/src/commands/daemon/serve-transport.ts`（新）：原子 socket 所有权抢占——serve 进程启动 runtime 前先抢 owner lock（唯一 `ownerToken`）；输者等待赢者可连接后连接赢者；陈旧 owner lock（pid 已死）被隔离，所有权只移交给恰好一个竞争者。
- `packages/cli/src/index.ts`、`packages/cli/src/commands/daemon/productization.ts`：serve/stop 生命周期接入所有权——清理前校验 `ownerToken`，旧 daemon 永远删不掉继任者的 socket；`daemon status` 仅在 RPC 实际可达时报 `started=true`（消除 started-but-ENOENT 窗口）。
- `packages/cli/test/daemon-autostart-socket-race-cli.test.ts`（新）：阳性对照——N=8 并发冷启动。修复前红（3 成功/5 失败），修复后绿（8/8 成功，全部 repo lock 指向同一 pid）；另含 owner 不可达时恰一竞争者接管、status 不可在不可达时报 started 两条对照。

机制不变量（任务契约）：①同一 socket 路径至多一个 daemon serve 绑定，输者连接赢者；②idle-exit 不删除不属于自己的 socket；③status 与可连接性一致。

## 任务与范围

- Harness task：task_01KXD0A37NN8ZQEJ2ENG5K313V
- 分支：fix/daemon-autostart-socket-race
- 公开范围：仅 packages/cli daemon serve 生命周期 + 测试
- 私有计划/证据已更新：是（任务包 plan/progress 在私有账本）
- 范围外：TW-05 direct-mode fail-close 守卫与 TW-06 fence（零改动，`daemon/client.ts` 未碰）；parse-failure 诊断（已单独合入 #701）；worktree ha 写路由（后续任务，依赖本 PR）

## 版本影响

- 版本：无版本变更，原因：现有 daemon 行为内的 bug 修复，无公开 API 变化
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是
- 受保护面范围：gate-allowlist `check-bypass-write-boundary`（+8 条，GROWTH_REQUIRES_GOVERNANCE_REVIEW 标记如实显示增量）与 `tools/write-road-registry.json`（+1 行 `daemon.socket-ownership.lock`，rowCountReconciliation 40->41）。均为把 daemon socket owner-lock 注册为受治理的运维性 transport 状态；未削弱任何门、未改任何既有条目。由 CEO 会话注册（commit 6075f99），非实现 worker。
- 授权依据：harness 任务 task_01KXD0A37NN8ZQEJ2ENG5K313V（发现即修常设授权下的缺陷修复）；allowlist 条目与 registry 行内联携带任务 ref
- 机器检查边界：本 PR 仅断言声明存在；声明是否真实充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- Base `origin/main` SHA：f606ca62（#702 合并点）
- 分支与 `origin/main` 的 merge-base：f606ca62
- 最近 `git fetch origin` 时间：2026-07-13（push 前，同一会话）
- 同步方式：rebase（最终 gate 前已 rebase 到 f606ca62）
- 公开 diff 命令：`git diff f606ca62..544a9223`
- 私有证据 commit/路径：harness/tasks/task_01KXD0A37NN8ZQEJ2ENG5K313V-daemon-autostart-socket-daemon-socket-socket/
- 评审证据路径：同任务包（task_plan.md 不变量 1-3）
- GitHub Actions `rewrite-ci` run URL：待 CI 附上
- 复选框状态同英文块（根 `check:local` 16/16 全绿 exit 0 / fast 322/322 / contract 441/441 / N=8 对照先红后绿）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
