### PR TITLE
fix(cli): route worktree ha writes through the canonical daemon

### DIFF
--- a/packages/cli/src/daemon/canonical-harness-root.ts
+++ b/packages/cli/src/daemon/canonical-harness-root.ts
@@ -1,0 +1,42 @@
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import path from "node:path";
+import { resolveHarnessLayout, type HarnessLayoutInput } from "../../../kernel/src/index.ts";
+
+export function resolveCanonicalHarnessRoot(input: HarnessLayoutInput): string {
+  const layout = resolveHarnessLayout(input);
+  if (layout.configPath) return layout.rootDir;
+
+  const gitFilePath = path.join(layout.rootDir, ".git");
+  if (!isFile(gitFilePath)) return layout.rootDir;
+  const gitDir = linkedWorktreeGitDir(gitFilePath);
+  if (!gitDir) return layout.rootDir;
+  const commonDir = linkedWorktreeCommonDir(gitDir);
+  if (!commonDir) return layout.rootDir;
+
+  const canonicalLayout = resolveHarnessLayout(path.dirname(commonDir));
+  return canonicalLayout.configPath ? canonicalLayout.rootDir : layout.rootDir;
+}
+
+function linkedWorktreeGitDir(gitFilePath: string): string | undefined {
+  const match = /^gitdir:\s*(.+?)\s*$/iu.exec(readFileSync(gitFilePath, "utf8"));
+  if (!match) return undefined;
+  const gitDir = path.resolve(path.dirname(gitFilePath), match[1]!);
+  return existsSync(gitDir) ? realpathSync.native(gitDir) : undefined;
+}
+
+function linkedWorktreeCommonDir(gitDir: string): string | undefined {
+  const commonDirPath = path.join(gitDir, "commondir");
+  if (!isFile(commonDirPath)) return undefined;
+  const relativeCommonDir = readFileSync(commonDirPath, "utf8").trim();
+  if (!relativeCommonDir) return undefined;
+  const commonDir = path.resolve(gitDir, relativeCommonDir);
+  return existsSync(commonDir) ? realpathSync.native(commonDir) : undefined;
+}
+
+function isFile(inputPath: string): boolean {
+  try {
+    return statSync(inputPath).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -19,7 +19,10 @@ import {
   type JsonObject,
   type LocalDaemonTarget
 } from "../../../daemon/src/index.ts";
-import { createHarnessRuntimeContext, resolveHarnessLayout } from "../../../kernel/src/index.ts";
+import {
+  createHarnessRuntimeContext,
+  resolveHarnessLayout
+} from "../../../kernel/src/index.ts";
 import { CliErrorCode, cliError } from "../cli/error-codes.ts";
 import type { CommandFailureReceipt, CommandReceipt } from "../cli/receipt.ts";
 import { toCommandReceipt } from "../cli/receipt.ts";
@@ -27,6 +30,7 @@ import type { ParsedCommand } from "../cli/types.ts";
 import { CliActorAttributionError, readCliJournalActorFromEnv, readCliJournalActorFromFlag } from "../composition/actor-attribution.ts";
 import { parsePositiveIntegerOr } from "../cli/value-utils.ts";
 import { buildDocSyncSubmitRequest } from "./doc-sync-service.ts";
+import { resolveCanonicalHarnessRoot } from "./canonical-harness-root.ts";
 
 export {
   daemonIdForRoot,
@@ -107,6 +111,7 @@ export async function runCommandThroughDaemon(
 }
 
 async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfig): Promise<CommandReceipt | CommandFailureReceipt> {
+  command = commandForCanonicalHarness(command);
   const target = resolveLocalDaemonTarget({
     rootDir: command.rootDir,
     repoIdOverride: command.daemonRepoId,
@@ -261,7 +266,8 @@ function directModeRejection(command: ParsedCommand, config: DaemonClientConfig)
 }
 
 function isInitializedHarness(command: ParsedCommand): boolean {
-  const layout = resolveHarnessLayout(createHarnessRuntimeContext(command.rootDir, command.layoutOverrides));
+  const canonicalRoot = resolveCanonicalHarnessRoot(createHarnessRuntimeContext(command.rootDir, command.layoutOverrides));
+  const layout = resolveHarnessLayout(createHarnessRuntimeContext(canonicalRoot, command.layoutOverrides));
   return existsSync(path.join(layout.authoredRoot, "harness.yaml"));
 }
 
@@ -277,6 +283,13 @@ function commandForTarget(command: ParsedCommand, target: LocalDaemonTarget): Pa
   return path.resolve(command.rootDir) === path.resolve(target.canonicalRoot)
     ? command
     : { ...command, rootDir: target.canonicalRoot };
+}
+
+function commandForCanonicalHarness(command: ParsedCommand): ParsedCommand {
+  const canonicalRoot = resolveCanonicalHarnessRoot(createHarnessRuntimeContext(command.rootDir, command.layoutOverrides));
+  return path.resolve(command.rootDir) === path.resolve(canonicalRoot)
+    ? command
+    : { ...command, rootDir: canonicalRoot };
 }
 
 function daemonClientCliEntrypointPath(): string {

--- a/packages/cli/test/daemon-local-identity-cli.test.ts
+++ b/packages/cli/test/daemon-local-identity-cli.test.ts
@@ -1,10 +1,20 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
-import { runRawJson, withTempRoot } from "./helpers/daemon-cli.ts";
+import { readAttributionEvents } from "../../kernel/src/index.ts";
+import {
+  defaultDaemonUserRoot,
+  runDaemonCommand,
+  runRawJson,
+  runRawJsonMaybeFail,
+  stopDaemonQuietly,
+  withTempRoot,
+  withTempRootAsync
+} from "./helpers/daemon-cli.ts";
+import { receiptDataString, writePeopleRoster } from "./helpers/forced-command-daemon.ts";
 
 test("local daemon derives its owner from project identity when people roster is absent", () => {
   withTempRoot((rootDir) => {
@@ -33,3 +43,94 @@ test("local daemon derives its owner from project identity when people roster is
     );
   });
 });
+
+test("linked worktree writes route to the canonical daemon with transport-derived identity", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    initOuterGitRepo(rootDir);
+    const userRoot = defaultDaemonUserRoot(rootDir);
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    const created = runRawJson(rootDir, ["new-task", "--title", "Worktree Daemon Routing"], {
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    writePeopleRoster(rootDir, {
+      personId: "person_owner",
+      displayName: "Owner User",
+      email: "owner@example.test",
+      role: "owner"
+    });
+    runDaemonCommand(rootDir, ["daemon", "start", "--service", "--json"], { HARNESS_DAEMON_USER_ROOT: userRoot });
+
+    const worktreeRoot = path.join(rootDir, ".worktrees", "feature");
+    execFileSync("git", ["-C", rootDir, "worktree", "add", "-q", "-b", "feature", worktreeRoot]);
+    assert.equal(existsSync(path.join(worktreeRoot, "harness")), false);
+    const worktreeCommandRoot = path.join(worktreeRoot, "packages", "cli");
+    mkdirSync(worktreeCommandRoot, { recursive: true });
+
+    const taskId = receiptDataString(created, "taskId");
+    const progressArgs = [
+      "--actor", "agent:worktree-worker",
+      "task", "progress", "append", taskId, "--text", "routed from linked worktree"
+    ];
+    const progressed = runRawJsonMaybeFail(worktreeCommandRoot, progressArgs, {
+      HARNESS_ACTOR: "",
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+
+    assert.equal(progressed.receipt.ok, true, JSON.stringify(progressed.receipt));
+    const progressEvent = readAttributionEvents(rootDir)
+      .findLast((event) => event.actor.executor?.id === "worktree-worker");
+    assert.deepEqual(progressEvent?.actor, {
+      principal: { kind: "person", personId: "person_owner" },
+      executor: { kind: "agent", id: "worktree-worker" }
+    });
+    assert.equal(progressEvent?.principalSource.kind, "daemon-authenticated");
+    assert.equal(progressEvent?.executorSource, "client-asserted");
+
+    stopDaemonQuietly(rootDir, userRoot);
+    const directRejected = runRawJsonMaybeFail(worktreeCommandRoot, progressArgs, {
+      HARNESS_ACTOR: "",
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DIRECT_WRITE_REASON: "",
+      HARNESS_DAEMON_USER_ROOT: userRoot,
+      NODE_TEST_CONTEXT: ""
+    });
+    assert.notEqual(directRejected.status, 0);
+    assert.match(JSON.stringify(directRejected.receipt), /Direct canonical writes are disabled/u);
+
+    const directFallback = runRawJsonMaybeFail(worktreeCommandRoot, progressArgs, {
+      HARNESS_ACTOR: "",
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DIRECT_WRITE_REASON: "recovery",
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    assert.notEqual(directFallback.status, 0);
+    assert.equal((directFallback.receipt.error as { readonly code?: string }).code, "task_not_found");
+    assert.equal(
+      (directFallback.receipt.warnings as ReadonlyArray<{ readonly message?: string }> | undefined)
+        ?.some((warning) => /settings\.identity\.personId/u.test(warning.message ?? "")),
+      true
+    );
+
+    const localWrite = runRawJsonMaybeFail(worktreeCommandRoot, [
+      "--actor", "agent:worktree-worker", "new-task", "--title", "Must Not Write Locally"
+    ], {
+      HARNESS_ACTOR: "",
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DIRECT_WRITE_REASON: "recovery",
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    assert.notEqual(localWrite.status, 0);
+    assert.equal((localWrite.receipt.error as { readonly code?: string }).code, "write_rejected");
+    assert.match((localWrite.receipt.error as { readonly hint?: string }).hint ?? "", /settings\.identity\.personId/u);
+  });
+});
+
+function initOuterGitRepo(rootDir: string): void {
+  execFileSync("git", ["-C", rootDir, "init", "-q", "-b", "main"]);
+  execFileSync("git", ["-C", rootDir, "config", "user.name", "Harness Test"]);
+  execFileSync("git", ["-C", rootDir, "config", "user.email", "harness@example.test"]);
+  writeFileSync(path.join(rootDir, "README.md"), "fixture\n", "utf8");
+  execFileSync("git", ["-C", rootDir, "add", "README.md"]);
+  execFileSync("git", ["-C", rootDir, "commit", "-q", "-m", "seed outer repo"]);
+}

--- a/packages/cli/test/daemon-local-identity-cli.test.ts
+++ b/packages/cli/test/daemon-local-identity-cli.test.ts
@@ -74,6 +74,7 @@ test("linked worktree writes route to the canonical daemon with transport-derive
     ];
     const progressed = runRawJsonMaybeFail(worktreeCommandRoot, progressArgs, {
       HARNESS_ACTOR: "",
+      HARNESS_DAEMON_MODE: "local",
       HARNESS_DAEMON_USER_ROOT: userRoot
     });
 


### PR DESCRIPTION
# English

## Summary

`ha` write commands executed inside a linked git worktree (`.worktrees/*`) systematically failed (five recorded cases on 2026-07-13 across four worker sessions plus one CEO reproduction: `AuthMissing` / `task_not_found`). Root cause: the daemon client judged harness initialization from the worktree's own directory **before** routing — linked worktrees do not contain `harness/` (private, gitignored), so the client wrongly fell into the local write path (which correctly demands an explicit personId under ADR-0028 fail-closed rules); the canonical daemon never received the request. This forced parallel workers to give up ledger writes and pressured toward identity impersonation.

## What Changed

- `packages/cli/src/daemon/canonical-harness-root.ts` (new): deterministic canonical-root resolution — if the current root already has a harness config, use it as-is; otherwise follow the git linked-worktree chain (`.git` file → `gitdir` → `commondir` → main repository) and adopt that root only if it actually contains `harness.yaml`; otherwise fall back to the original root. Read-only fs operations throughout.
- `packages/cli/src/daemon/client.ts`: local command execution rewrites `rootDir` to the canonical root before daemon target resolution, and `isInitializedHarness` consults the canonical root — so same-machine invocations from any linked worktree or nested subdirectory route to the canonical daemon, where identity is transport-derived (unix-socket owner → person) with the executor axis captured. The TW-05 direct-mode fail-close guard and the #703 socket-ownership serialization are untouched.
- `packages/cli/test/daemon-local-identity-cli.test.ts`: positive control red before the fix (`task_not_found` + AuthMissing warning from a linked worktree), green after (progress write from a nested worktree subdirectory succeeds with no `HARNESS_ACTOR` and no personId; the persisted attribution event shows principal person with `daemon-authenticated` source and the executor agent). Negative controls: with the daemon stopped, the same command is still rejected by the TW-05 direct guard, and explicit recovery/local writes still fail closed without personId.

Mechanism invariants (task contract): (1) same-machine ha writes route to the reachable canonical daemon regardless of cwd; (2) canonical-root discovery is deterministic via the git worktree linkage, not cwd guessing; (3) the local path's fail-closed identity gate is not weakened.

## Task And Scope

- Harness task: task_01KXD1YJWQKDNDK572G7QK5K9G
- Branch: fix/worktree-ha-daemon-routing
- Public scope: packages/cli daemon client routing + tests only (3 files)
- Private planning/evidence updated: yes (task package plan/progress in private ledger)
- Out of scope: daemon-side admission policy (root cause was client-side pre-routing; the task checkpoint for server-side admission semantics was not triggered); TW-05/TW-06 guard semantics; write-road registry / gate-allowlists (untouched — verified by worker and CEO)

## Version Impact

- Version: no version change because this is a bug fix within existing CLI routing behavior, no public API change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: harness task task_01KXD1YJWQKDNDK572G7QK5K9G (discovered-defect fix under standing authorization); ADR-0028 transport-derived identity is the mechanism this fix lets worktree callers reach
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: c82bb861415ac861e24e534a18e33efddfbf2443 (merge of #703)
- Branch merge-base with `origin/main`: c82bb861415ac861e24e534a18e33efddfbf2443
- Last `git fetch origin` time: 2026-07-13 (pre-push, same session)
- Sync method: none needed (branch based on current main)
- Public diff command: `git diff c82bb861..1773bbaa`
- Private evidence commit/path: harness/tasks/task_01KXD1YJWQKDNDK572G7QK5K9G-worktree-ha-uid-ha-canonical-daemon-personid-local/
- Reviewer evidence path: same task package (task_plan.md invariants 1-3)
- GitHub Actions `rewrite-ci` run URL: pending (attached by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (via root `check:local`, 16/16 steps, 99.8s)
- [x] `npm run typecheck` (via `check:local`)
- [x] `npm test` (fast 322/322, contract 441/441; FIX1 socket race + TW-05 regression 6/6)
- [x] `npm run harness:check-import-boundaries` (via `check:local`)
- [x] `npm run harness:scan-forbidden-symbols` (via `check:local`)
- [x] `npm run harness:check-private-boundary` (via `check:local`)
- [x] `npm run harness:check-package-policy` (via `check:local`)
- [x] `npm run harness:check-implementation-contracts` (via `check:local`)
- [x] `npm run harness:check-schema-contracts` (via `check:local`)
- [x] `npm run harness:check-legacy-intake-readiness` (via `check:local`)
- [x] `npm run harness:smoke-cli-package` (via `check:local`)
- [ ] GitHub Actions `rewrite-ci` passed

---

# 中文

## 摘要

在 linked git worktree（`.worktrees/*`）内执行 `ha` 写命令系统性失败（2026-07-13 实录五例：四个 worker 会话 + CEO 本人复现，报 `AuthMissing` / `task_not_found`）。根因：daemon client 在路由**之前**用 worktree 自身目录判断 harness 是否初始化——linked worktree 不含 `harness/`（私有、gitignored），于是错误落入 local 写路（该路按 ADR-0028 fail-closed 规则正确地要求显式 personId）；canonical daemon 根本没收到请求。后果是并行 worker 无法自主落台账，并诱发身份冒名压力。

## 变更内容

- `packages/cli/src/daemon/canonical-harness-root.ts`（新）：确定性 canonical root 解析——当前 root 已有 harness 配置则原样使用；否则沿 git linked-worktree 链（`.git` 文件 → `gitdir` → `commondir` → 主仓）解析，且仅当主仓确有 `harness.yaml` 才采纳，否则回退原 root。全程只读 fs 操作。
- `packages/cli/src/daemon/client.ts`：本地命令执行前把 `rootDir` 重写为 canonical root 再做 daemon target 解析，`isInitializedHarness` 也改查 canonical root——同机任意 linked worktree/嵌套子目录的调用都路由到 canonical daemon，身份由 transport 派生（unix-socket owner → person）且 executor 轴被捕获。TW-05 direct-mode fail-close 守卫与 #703 socket 所有权序列化零改动。
- `packages/cli/test/daemon-local-identity-cli.test.ts`：阳性对照修复前红（linked worktree 内 `task_not_found` + AuthMissing warning），修复后绿（无 `HARNESS_ACTOR`、无 personId，从 worktree 嵌套子目录 progress 写成功；落盘 attribution event 显示 principal 为 person、source=`daemon-authenticated`、executor 为 agent）。阴性对照：daemon 停止后同命令仍被 TW-05 direct guard 拒绝；显式 recovery/local 写仍因缺 personId fail-closed。

机制不变量（任务契约）：①同机 ha 写无论 cwd 在哪，daemon 可达即路由到 canonical daemon；②canonical root 发现走 git worktree 链接确定性解析，不靠 cwd 猜测；③local 路的 fail-closed 身份门不弱化。

## 任务与范围

- Harness task：task_01KXD1YJWQKDNDK572G7QK5K9G
- 分支：fix/worktree-ha-daemon-routing
- 公开范围：仅 packages/cli daemon client 路由 + 测试（3 文件）
- 私有计划/证据已更新：是（任务包 plan/progress 在私有账本）
- 范围外：daemon 侧准入策略（根因在客户端预路由，任务 checkpoint 的服务端准入语义判断未触发）；TW-05/TW-06 守卫语义；write-road registry / gate-allowlists（零触碰，worker 与 CEO 双验）

## 版本影响

- 版本：无版本变更，原因：现有 CLI 路由行为内的 bug 修复，无公开 API 变化
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权依据：harness 任务 task_01KXD1YJWQKDNDK572G7QK5K9G（发现即修常设授权下的缺陷修复）；本修复让 worktree 调用方接上 ADR-0028 transport 派生身份机制
- 机器检查边界：本 PR 仅断言声明存在；声明是否真实充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- Base `origin/main` SHA：c82bb861415ac861e24e534a18e33efddfbf2443（#703 合并点）
- 分支与 `origin/main` 的 merge-base：c82bb861415ac861e24e534a18e33efddfbf2443
- 最近 `git fetch origin` 时间：2026-07-13（push 前，同一会话）
- 同步方式：无需（分支基于当前 main）
- 公开 diff 命令：`git diff c82bb861..1773bbaa`
- 私有证据 commit/路径：harness/tasks/task_01KXD1YJWQKDNDK572G7QK5K9G-worktree-ha-uid-ha-canonical-daemon-personid-local/
- 评审证据路径：同任务包（task_plan.md 不变量 1-3）
- GitHub Actions `rewrite-ci` run URL：待 CI 附上
- 复选框状态同英文块（根 `check:local` 16/16 全绿 99.8s / fast 322/322 / contract 441/441 / FIX1+TW-05 回归 6/6 / 对照先红后绿）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
