### PR TITLE
perf: bound projection freshness and incremental deltas

### DIFF
--- a/packages/kernel/src/local/attribution-event-source.ts
+++ b/packages/kernel/src/local/attribution-event-source.ts
@@ -4,7 +4,7 @@ import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import { stablePayloadHash } from "../integrity/stable-hash.ts";
 import { AttributionEventSchema, type AttributionEvent } from "../schemas/attribution-event.ts";
-import { localLayoutFileSystem } from "./local-layout-file-system.ts";
+import { localLayoutFileSystem, localProjectionSourceFileSystem } from "./local-layout-file-system.ts";
 
 export interface AttributionEventSourceInput {
   readonly relativePath: string;
@@ -21,16 +21,26 @@ export function readAttributionEvents(rootInput: HarnessLayoutInput): ReadonlyAr
 }
 
 export function readAttributionEventSource(rootInput: HarnessLayoutInput): AttributionEventSource {
+  return readAttributionEventSourceAttempt(rootInput, 0);
+}
+
+function readAttributionEventSourceAttempt(rootInput: HarnessLayoutInput, attempt: number): AttributionEventSource {
   const eventsRoot = resolveHarnessLayout(rootInput).attributionEventsRoot;
-  const inputs = localLayoutFileSystem.exists(eventsRoot)
-    ? localLayoutFileSystem.readDirents(eventsRoot)
+  if (!localLayoutFileSystem.exists(eventsRoot)) {
+    return { inputs: [], hash: stablePayloadHash({ schema: "attribution-event-source/v1", inputs: [] }) };
+  }
+  const directory = localProjectionSourceFileSystem.readStableDirents(eventsRoot);
+  const inputs = directory.entries
     .filter((entry) => !entry.isDirectory() && entry.name.endsWith(".jsonl"))
-    .map((entry) => ({
-      relativePath: entry.name,
-      body: localLayoutFileSystem.readText(path.join(eventsRoot, entry.name))
-    }))
-    .sort((left, right) => left.relativePath.localeCompare(right.relativePath))
-    : [];
+    .map((entry) => {
+      const stable = localProjectionSourceFileSystem.readStableText(path.join(eventsRoot, entry.name));
+      return { relativePath: entry.name, body: stable.body };
+    })
+    .sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+  if (localProjectionSourceFileSystem.statSignature(eventsRoot) !== directory.signature) {
+    if (attempt >= 2) throw new Error("attribution event source did not stabilize");
+    return readAttributionEventSourceAttempt(rootInput, attempt + 1);
+  }
   return {
     inputs,
     hash: stablePayloadHash({ schema: "attribution-event-source/v1", inputs })

--- a/packages/kernel/src/local/attribution-event-source.ts
+++ b/packages/kernel/src/local/attribution-event-source.ts
@@ -2,14 +2,24 @@ import path from "node:path";
 import { Schema } from "effect";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
-import { stablePayloadHash } from "../integrity/stable-hash.ts";
+import { sha256Text, stablePayloadHash } from "../integrity/stable-hash.ts";
 import { AttributionEventSchema, type AttributionEvent } from "../schemas/attribution-event.ts";
 import { localLayoutFileSystem, localProjectionSourceFileSystem } from "./local-layout-file-system.ts";
 
 export interface AttributionEventSourceInput {
   readonly relativePath: string;
   readonly body: string;
+  readonly statSignature: string;
+  readonly contentSha256: string;
 }
+
+interface AttributionEventSourceCacheEntry {
+  readonly source: AttributionEventSource;
+  readonly signatures: ReadonlyMap<string, string>;
+}
+
+const attributionEventSourceCache = new Map<string, AttributionEventSourceCacheEntry>();
+const attributionEventSourceCacheLimit = 16;
 
 export interface AttributionEventSource {
   readonly inputs: ReadonlyArray<AttributionEventSourceInput>;
@@ -27,23 +37,93 @@ export function readAttributionEventSource(rootInput: HarnessLayoutInput): Attri
 function readAttributionEventSourceAttempt(rootInput: HarnessLayoutInput, attempt: number): AttributionEventSource {
   const eventsRoot = resolveHarnessLayout(rootInput).attributionEventsRoot;
   if (!localLayoutFileSystem.exists(eventsRoot)) {
-    return { inputs: [], hash: stablePayloadHash({ schema: "attribution-event-source/v1", inputs: [] }) };
+    attributionEventSourceCache.delete(eventsRoot);
+    return emptyAttributionEventSource();
   }
-  const directory = localProjectionSourceFileSystem.readStableDirents(eventsRoot);
-  const inputs = directory.entries
-    .filter((entry) => !entry.isDirectory() && entry.name.endsWith(".jsonl"))
-    .map((entry) => {
-      const stable = localProjectionSourceFileSystem.readStableText(path.join(eventsRoot, entry.name));
-      return { relativePath: entry.name, body: stable.body };
-    })
-    .sort((left, right) => left.relativePath.localeCompare(right.relativePath));
-  if (localProjectionSourceFileSystem.statSignature(eventsRoot) !== directory.signature) {
-    if (attempt >= 2) throw new Error("attribution event source did not stabilize");
-    return readAttributionEventSourceAttempt(rootInput, attempt + 1);
+  const cached = attributionEventSourceCache.get(eventsRoot);
+  if (cached && stableAttributionSignatures(cached.signatures)) {
+    attributionEventSourceCache.delete(eventsRoot);
+    attributionEventSourceCache.set(eventsRoot, cached);
+    return cached.source;
   }
-  return {
+  let directory: ReturnType<typeof localProjectionSourceFileSystem.readStableDirents>;
+  try {
+    directory = localProjectionSourceFileSystem.readStableDirents(eventsRoot);
+  } catch {
+    return retryAttributionEventSource(rootInput, eventsRoot, attempt);
+  }
+  const previousByPath = new Map(cached?.source.inputs.map((input) => [input.relativePath, input]));
+  const inputs: AttributionEventSourceInput[] = [];
+  for (const entry of directory.entries
+    .filter((candidate) => !candidate.isDirectory() && candidate.name.endsWith(".jsonl"))
+    .sort((left, right) => left.name.localeCompare(right.name))) {
+    const filePath = path.join(eventsRoot, entry.name);
+    const signature = localProjectionSourceFileSystem.statSignature(filePath);
+    if (signature === null) return retryAttributionEventSource(rootInput, eventsRoot, attempt);
+    const previous = previousByPath.get(entry.name);
+    if (previous?.statSignature === signature) {
+      inputs.push(previous);
+      continue;
+    }
+    try {
+      const stable = localProjectionSourceFileSystem.readStableText(filePath);
+      inputs.push({
+        relativePath: entry.name,
+        body: stable.body,
+        statSignature: stable.signature,
+        contentSha256: sha256Text(stable.body)
+      });
+    } catch {
+      return retryAttributionEventSource(rootInput, eventsRoot, attempt);
+    }
+  }
+  const signatures = new Map<string, string>([
+    [eventsRoot, directory.signature],
+    ...inputs.map((input) => [path.join(eventsRoot, input.relativePath), input.statSignature] as const)
+  ]);
+  if (!stableAttributionSignatures(signatures)) return retryAttributionEventSource(rootInput, eventsRoot, attempt);
+  const source = {
     inputs,
-    hash: stablePayloadHash({ schema: "attribution-event-source/v1", inputs })
+    hash: stablePayloadHash({
+      schema: "attribution-event-source/v2",
+      inputs: inputs.map(({ relativePath, contentSha256 }) => ({ relativePath, contentSha256 }))
+    })
+  };
+  attributionEventSourceCache.delete(eventsRoot);
+  attributionEventSourceCache.set(eventsRoot, { source, signatures });
+  while (attributionEventSourceCache.size > attributionEventSourceCacheLimit) {
+    const oldest = attributionEventSourceCache.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    attributionEventSourceCache.delete(oldest);
+  }
+  return source;
+}
+
+function stableAttributionSignatures(signatures: ReadonlyMap<string, string>): boolean {
+  return attributionSignaturesMatch(signatures) && attributionSignaturesMatch(signatures);
+}
+
+function attributionSignaturesMatch(signatures: ReadonlyMap<string, string>): boolean {
+  for (const [inputPath, expected] of signatures) {
+    if (localProjectionSourceFileSystem.statSignature(inputPath) !== expected) return false;
+  }
+  return true;
+}
+
+function retryAttributionEventSource(
+  rootInput: HarnessLayoutInput,
+  eventsRoot: string,
+  attempt: number
+): AttributionEventSource {
+  attributionEventSourceCache.delete(eventsRoot);
+  if (attempt >= 2) throw new Error("attribution event source did not stabilize");
+  return readAttributionEventSourceAttempt(rootInput, attempt + 1);
+}
+
+function emptyAttributionEventSource(): AttributionEventSource {
+  return {
+    inputs: [],
+    hash: stablePayloadHash({ schema: "attribution-event-source/v2", inputs: [] })
   };
 }
 

--- a/packages/kernel/src/local/attribution-event-source.ts
+++ b/packages/kernel/src/local/attribution-event-source.ts
@@ -6,17 +6,45 @@ import { stablePayloadHash } from "../integrity/stable-hash.ts";
 import { AttributionEventSchema, type AttributionEvent } from "../schemas/attribution-event.ts";
 import { localLayoutFileSystem } from "./local-layout-file-system.ts";
 
+export interface AttributionEventSourceInput {
+  readonly relativePath: string;
+  readonly body: string;
+}
+
+export interface AttributionEventSource {
+  readonly inputs: ReadonlyArray<AttributionEventSourceInput>;
+  readonly hash: string;
+}
+
 export function readAttributionEvents(rootInput: HarnessLayoutInput): ReadonlyArray<AttributionEvent> {
+  return readAttributionEventsFromSource(readAttributionEventSource(rootInput));
+}
+
+export function readAttributionEventSource(rootInput: HarnessLayoutInput): AttributionEventSource {
   const eventsRoot = resolveHarnessLayout(rootInput).attributionEventsRoot;
-  if (!localLayoutFileSystem.exists(eventsRoot)) return [];
-  return localLayoutFileSystem.readDirents(eventsRoot)
+  const inputs = localLayoutFileSystem.exists(eventsRoot)
+    ? localLayoutFileSystem.readDirents(eventsRoot)
     .filter((entry) => !entry.isDirectory() && entry.name.endsWith(".jsonl"))
-    .map((entry) => decodeAttributionEvent(localLayoutFileSystem.readText(path.join(eventsRoot, entry.name))))
+    .map((entry) => ({
+      relativePath: entry.name,
+      body: localLayoutFileSystem.readText(path.join(eventsRoot, entry.name))
+    }))
+    .sort((left, right) => left.relativePath.localeCompare(right.relativePath))
+    : [];
+  return {
+    inputs,
+    hash: stablePayloadHash({ schema: "attribution-event-source/v1", inputs })
+  };
+}
+
+export function readAttributionEventsFromSource(source: AttributionEventSource): ReadonlyArray<AttributionEvent> {
+  return source.inputs
+    .map((input) => decodeAttributionEvent(input.body))
     .sort((left, right) => left.eventId.localeCompare(right.eventId));
 }
 
 export function attributionEventSourceHash(rootInput: HarnessLayoutInput): string {
-  return stablePayloadHash(readAttributionEvents(rootInput));
+  return readAttributionEventSource(rootInput).hash;
 }
 
 function decodeAttributionEvent(body: string): AttributionEvent {

--- a/packages/kernel/src/local/local-layout-file-system.ts
+++ b/packages/kernel/src/local/local-layout-file-system.ts
@@ -13,6 +13,17 @@ export const localEvidenceFileSystem = {
   realpath: (inputPath: string) => realpathSync(inputPath)
 };
 
+export const localProjectionSourceFileSystem = {
+  statSignature: (inputPath: string): string | null => {
+    try {
+      const stats = statSync(inputPath, { bigint: true });
+      return [stats.dev, stats.ino, stats.mode, stats.size, stats.mtimeNs, stats.ctimeNs].join(":");
+    } catch {
+      return null;
+    }
+  }
+};
+
 export const localRuntimeStateFileSystem = {
   createExclusiveText: (inputPath: string, value: string): boolean => {
     let descriptor: number;

--- a/packages/kernel/src/local/local-layout-file-system.ts
+++ b/packages/kernel/src/local/local-layout-file-system.ts
@@ -1,4 +1,5 @@
 import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import type { Dirent } from "node:fs";
 import type { LayoutFileSystem } from "../layout/file-system.ts";
 
 export const localLayoutFileSystem: LayoutFileSystem = {
@@ -14,15 +15,37 @@ export const localEvidenceFileSystem = {
 };
 
 export const localProjectionSourceFileSystem = {
-  statSignature: (inputPath: string): string | null => {
-    try {
-      const stats = statSync(inputPath, { bigint: true });
-      return [stats.dev, stats.ino, stats.mode, stats.size, stats.mtimeNs, stats.ctimeNs].join(":");
-    } catch {
-      return null;
+  readStableDirents: (inputPath: string): { readonly entries: ReadonlyArray<Dirent<string>>; readonly signature: string } => {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const before = projectionSourceStatSignature(inputPath);
+      const entries = readdirSync(inputPath, { withFileTypes: true });
+      const after = projectionSourceStatSignature(inputPath);
+      if (before !== null && before === after) return { entries, signature: after };
     }
+    throw new Error(`projection source directory did not stabilize: ${inputPath}`);
+  },
+  readStableText: (inputPath: string): { readonly body: string; readonly signature: string } => {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const before = projectionSourceStatSignature(inputPath);
+      const body = readFileSync(inputPath, "utf8");
+      const after = projectionSourceStatSignature(inputPath);
+      if (before !== null && before === after) return { body, signature: after };
+    }
+    throw new Error(`projection source file did not stabilize: ${inputPath}`);
+  },
+  statSignature: (inputPath: string): string | null => {
+    return projectionSourceStatSignature(inputPath);
   }
 };
+
+function projectionSourceStatSignature(inputPath: string): string | null {
+  try {
+    const stats = statSync(inputPath, { bigint: true });
+    return [stats.dev, stats.ino, stats.mode, stats.size, stats.mtimeNs, stats.ctimeNs].join(":");
+  } catch {
+    return null;
+  }
+}
 
 export const localRuntimeStateFileSystem = {
   createExclusiveText: (inputPath: string, value: string): boolean => {

--- a/packages/kernel/src/projection/entity-declaration-projection.ts
+++ b/packages/kernel/src/projection/entity-declaration-projection.ts
@@ -8,7 +8,12 @@ import { readField, resolveEntityDocumentPath } from "../entity/declaration.ts";
 import type { EntityProjectionColumnDeclaration } from "../entity/registry.ts";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
-import { localLayoutFileSystem, localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
+import { stablePayloadHash } from "../integrity/stable-hash.ts";
+import {
+  localLayoutFileSystem,
+  localProjectionSourceFileSystem,
+  localRuntimeStateFileSystem
+} from "../local/local-layout-file-system.ts";
 import { quoteIdentifier, runSqlite } from "./sqlite-projection-store.ts";
 
 export type DeclaredProjectionValue = string | number | null;
@@ -19,20 +24,68 @@ export interface DeclaredProjectionResult {
   readonly rows: ReadonlyArray<DeclaredProjectionRow>;
 }
 
+export interface DeclaredEntityDiscoveryStats {
+  readonly directoriesVisited: number;
+  readonly entriesVisited: number;
+  readonly filesMatched: number;
+  readonly cacheHit: boolean;
+}
+
+export interface DeclaredEntityDiscoveryResult {
+  readonly rows: ReadonlyArray<DeclaredProjectionRow>;
+  readonly stats: DeclaredEntityDiscoveryStats;
+}
+
+export interface DeclaredEntitySourceInput {
+  readonly relativePath: string;
+  readonly body: string;
+}
+
+export interface DeclaredEntitySourceResult {
+  readonly inputs: ReadonlyArray<DeclaredEntitySourceInput>;
+  readonly hash: string;
+  readonly stats: DeclaredEntityDiscoveryStats;
+}
+
+interface DeclaredEntitySourceCacheEntry {
+  readonly result: DeclaredEntitySourceResult;
+  readonly directorySignatures: ReadonlyMap<string, string>;
+  readonly fileSignatures: ReadonlyMap<string, string>;
+}
+
+const declaredEntitySourceCache = new Map<string, DeclaredEntitySourceCacheEntry>();
+const declaredEntitySourceCacheLimit = 32;
+
 export function projectDeclaredEntities(
   rootInput: HarnessLayoutInput,
   declaration: EntityDeclaration,
   projectionPath: string
 ): DeclaredProjectionResult {
   const rows = discoverDeclaredEntityRows(rootInput, declaration);
+  return projectDeclaredEntityRows(declaration, projectionPath, rows);
+}
+
+export function projectDeclaredEntityRows(
+  declaration: EntityDeclaration,
+  projectionPath: string,
+  rows: ReadonlyArray<DeclaredProjectionRow>
+): DeclaredProjectionResult {
   localRuntimeStateFileSystem.mkdirp(path.dirname(projectionPath));
-  runSqlite(projectionPath, Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
+  runSqlite(projectionPath, Effect.flatMap(SqlClient.SqlClient, (sql) =>
+    replaceDeclaredProjectionRows(sql, declaration, rows)));
+  return { table: declaration.projection.table, rows };
+}
+
+export function replaceDeclaredProjectionRows(
+  sql: SqlClient.SqlClient,
+  declaration: EntityDeclaration,
+  rows: ReadonlyArray<DeclaredProjectionRow>
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
     yield* sql.unsafe(`DROP TABLE IF EXISTS ${quoteIdentifier(declaration.projection.table)}`);
     yield* sql.unsafe(createTableSql(declaration));
     for (const row of rows) yield* insertRow(sql, declaration, row);
-  }));
-  return { table: declaration.projection.table, rows };
+  });
 }
 
 export function readDeclaredProjectionRows(
@@ -53,22 +106,90 @@ export function discoverDeclaredEntityRows(
   rootInput: HarnessLayoutInput,
   declaration: EntityDeclaration
 ): ReadonlyArray<DeclaredProjectionRow> {
+  return discoverDeclaredEntityProjection(rootInput, declaration).rows;
+}
+
+export function discoverDeclaredEntityProjection(
+  rootInput: HarnessLayoutInput,
+  declaration: EntityDeclaration
+): DeclaredEntityDiscoveryResult {
+  return projectDeclaredEntitySource(rootInput, declaration, readDeclaredEntitySource(rootInput, declaration));
+}
+
+export function readDeclaredEntitySource(
+  rootInput: HarnessLayoutInput,
+  declaration: EntityDeclaration
+): DeclaredEntitySourceResult {
   const layout = resolveHarnessLayout(rootInput);
+  const cacheKey = `${layout.authoredRoot}\0${declaration.kind}\0${declaration.rootResolver.pathTemplate}`;
+  const cached = declaredEntitySourceCache.get(cacheKey);
+  if (cached && sourceCacheEntryMatches(cached)) {
+    declaredEntitySourceCache.delete(cacheKey);
+    declaredEntitySourceCache.set(cacheKey, cached);
+    return {
+      ...cached.result,
+      stats: { ...cached.result.stats, cacheHit: true }
+    };
+  }
   const matcher = templateMatcher(declaration.rootResolver.pathTemplate);
-  const rows: DeclaredProjectionRow[] = [];
-  for (const relativePath of listFiles(layout.authoredRoot)) {
+  const discovered = listTemplateFiles(layout.authoredRoot, declaration.rootResolver.pathTemplate);
+  const inputs: DeclaredEntitySourceInput[] = [];
+  for (const relativePath of discovered.files) {
     const match = matcher.pattern.exec(relativePath);
     if (!match) continue;
     const identity = Object.fromEntries(matcher.keys.map((key, index) => [key, match[index + 1]!]));
     resolveEntityDocumentPath(rootInput, declaration, identity);
     const documentPath = path.join(layout.authoredRoot, relativePath);
-    const raw = declaration.documentCodec.decode(localLayoutFileSystem.readText(documentPath));
+    inputs.push({ relativePath, body: localLayoutFileSystem.readText(documentPath) });
+  }
+  const result: DeclaredEntitySourceResult = {
+    inputs,
+    hash: stablePayloadHash({
+      schema: "declared-entity-source/v1",
+      kind: declaration.kind,
+      inputs
+    }),
+    stats: {
+      directoriesVisited: discovered.directoriesVisited,
+      entriesVisited: discovered.entriesVisited,
+      filesMatched: inputs.length,
+      cacheHit: false
+    }
+  };
+  const directorySignatures = readPathSignatures(discovered.directories);
+  const fileSignatures = readPathSignatures(inputs.map((input) => path.join(layout.authoredRoot, input.relativePath)));
+  if (directorySignatures && fileSignatures) {
+    declaredEntitySourceCache.delete(cacheKey);
+    declaredEntitySourceCache.set(cacheKey, { result, directorySignatures, fileSignatures });
+    evictDeclaredEntitySourceCache();
+  } else {
+    declaredEntitySourceCache.delete(cacheKey);
+  }
+  return result;
+}
+
+export function projectDeclaredEntitySource(
+  rootInput: HarnessLayoutInput,
+  declaration: EntityDeclaration,
+  source: DeclaredEntitySourceResult
+): DeclaredEntityDiscoveryResult {
+  const matcher = templateMatcher(declaration.rootResolver.pathTemplate);
+  const rows: DeclaredProjectionRow[] = [];
+  for (const input of source.inputs) {
+    const match = matcher.pattern.exec(input.relativePath);
+    if (!match) continue;
+    const identity = Object.fromEntries(matcher.keys.map((key, index) => [key, match[index + 1]!]));
+    resolveEntityDocumentPath(rootInput, declaration, identity);
+    const raw = declaration.documentCodec.decode(input.body);
     if (raw === undefined) continue;
     const decoded = Schema.decodeUnknownSync(declaration.schema)(raw) as Readonly<Record<string, unknown>>;
     rows.push(projectRow(decoded, declaration.projection.columns));
   }
   const primaryKey = declaration.projection.columns.find((column) => column.primaryKey)!;
-  return rows.sort((left, right) => String(left[primaryKey.name]).localeCompare(String(right[primaryKey.name])));
+  return {
+    rows: rows.sort((left, right) => String(left[primaryKey.name]).localeCompare(String(right[primaryKey.name]))),
+    stats: source.stats
+  };
 }
 
 function projectRow(
@@ -134,18 +255,81 @@ function templateMatcher(template: string): { readonly pattern: RegExp; readonly
   return { pattern: new RegExp(`^${source}$`, "u"), keys };
 }
 
-function listFiles(rootPath: string): ReadonlyArray<string> {
-  if (!localLayoutFileSystem.exists(rootPath)) return [];
+function listTemplateFiles(rootPath: string, template: string): {
+  readonly files: ReadonlyArray<string>;
+  readonly directories: ReadonlyArray<string>;
+  readonly directoriesVisited: number;
+  readonly entriesVisited: number;
+} {
+  if (!localLayoutFileSystem.exists(rootPath)) return { files: [], directories: [], directoriesVisited: 0, entriesVisited: 0 };
+  const segments = template.split("/");
+  const segmentMatchers = segments.map(templateSegmentMatcher);
   const files: string[] = [];
-  function visit(directory: string): void {
+  const directories: string[] = [];
+  let directoriesVisited = 0;
+  let entriesVisited = 0;
+  function visit(directory: string, segmentIndex: number, relativeSegments: ReadonlyArray<string>): void {
+    directoriesVisited += 1;
+    directories.push(directory);
     for (const entry of localLayoutFileSystem.readDirents(directory)) {
+      entriesVisited += 1;
+      if (!segmentMatchers[segmentIndex]!.test(entry.name)) continue;
       const fullPath = path.join(directory, entry.name);
-      if (entry.isDirectory()) visit(fullPath);
-      else files.push(path.relative(rootPath, fullPath).split(path.sep).join("/"));
+      const nextRelativeSegments = [...relativeSegments, entry.name];
+      if (segmentIndex === segments.length - 1) {
+        if (!entry.isDirectory()) files.push(nextRelativeSegments.join("/"));
+      } else if (entry.isDirectory()) {
+        visit(fullPath, segmentIndex + 1, nextRelativeSegments);
+      }
     }
   }
-  visit(rootPath);
-  return files.sort();
+  visit(rootPath, 0, []);
+  return { files: files.sort(), directories, directoriesVisited, entriesVisited };
+}
+
+function sourceCacheEntryMatches(entry: DeclaredEntitySourceCacheEntry): boolean {
+  return pathSignaturesMatch(entry.directorySignatures) && pathSignaturesMatch(entry.fileSignatures);
+}
+
+function pathSignaturesMatch(signatures: ReadonlyMap<string, string>): boolean {
+  for (const [inputPath, expected] of signatures) {
+    if (readPathSignature(inputPath) !== expected) return false;
+  }
+  return true;
+}
+
+function readPathSignatures(inputPaths: ReadonlyArray<string>): ReadonlyMap<string, string> | null {
+  const signatures = new Map<string, string>();
+  for (const inputPath of inputPaths) {
+    const signature = readPathSignature(inputPath);
+    if (signature === null) return null;
+    signatures.set(inputPath, signature);
+  }
+  return signatures;
+}
+
+function readPathSignature(inputPath: string): string | null {
+  return localProjectionSourceFileSystem.statSignature(inputPath);
+}
+
+function evictDeclaredEntitySourceCache(): void {
+  while (declaredEntitySourceCache.size > declaredEntitySourceCacheLimit) {
+    const oldest = declaredEntitySourceCache.keys().next().value as string | undefined;
+    if (oldest === undefined) return;
+    declaredEntitySourceCache.delete(oldest);
+  }
+}
+
+function templateSegmentMatcher(segment: string): RegExp {
+  let source = "";
+  let cursor = 0;
+  for (const match of segment.matchAll(/\{([^{}]+)\}/gu)) {
+    source += escapeRegExp(segment.slice(cursor, match.index));
+    source += "[^/]+";
+    cursor = match.index + match[0].length;
+  }
+  source += escapeRegExp(segment.slice(cursor));
+  return new RegExp(`^${source}$`, "u");
 }
 
 function escapeRegExp(value: string): string {

--- a/packages/kernel/src/projection/entity-declaration-projection.ts
+++ b/packages/kernel/src/projection/entity-declaration-projection.ts
@@ -161,7 +161,12 @@ function readDeclaredEntitySourceAttempt(
     };
   }
   const matcher = templateMatcher(declaration.rootResolver.pathTemplate);
-  const discovered = listTemplateFiles(layout.authoredRoot, declaration.rootResolver.pathTemplate);
+  let discovered: ReturnType<typeof listTemplateFiles>;
+  try {
+    discovered = listTemplateFiles(layout.authoredRoot, declaration.rootResolver.pathTemplate);
+  } catch {
+    return retryDeclaredEntitySource(rootInput, declaration, hints, cacheKey, attempt, declaration.kind);
+  }
   const hintsByPath = new Map(hints
     .filter((hint) => hint.sourceKind === declaration.kind)
     .map((hint) => [hint.sourcePath, hint]));
@@ -421,7 +426,8 @@ function listTemplateFiles(rootPath: string, template: string): {
 }
 
 function sourceCacheEntryMatches(entry: DeclaredEntitySourceCacheEntry): boolean {
-  return pathSignaturesMatch(entry.directorySignatures) && pathSignaturesMatch(entry.fileSignatures);
+  const signatures = new Map([...entry.directorySignatures, ...entry.fileSignatures]);
+  return pathSignaturesMatch(signatures) && pathSignaturesMatch(signatures);
 }
 
 function pathSignaturesMatch(signatures: ReadonlyMap<string, string>): boolean {

--- a/packages/kernel/src/projection/entity-declaration-projection.ts
+++ b/packages/kernel/src/projection/entity-declaration-projection.ts
@@ -8,7 +8,7 @@ import { readField, resolveEntityDocumentPath } from "../entity/declaration.ts";
 import type { EntityProjectionColumnDeclaration } from "../entity/registry.ts";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
-import { stablePayloadHash } from "../integrity/stable-hash.ts";
+import { sha256Text, stablePayloadHash } from "../integrity/stable-hash.ts";
 import {
   localLayoutFileSystem,
   localProjectionSourceFileSystem,
@@ -33,12 +33,30 @@ export interface DeclaredEntityDiscoveryStats {
 
 export interface DeclaredEntityDiscoveryResult {
   readonly rows: ReadonlyArray<DeclaredProjectionRow>;
+  readonly documents: ReadonlyArray<DeclaredEntityDocumentProjection>;
   readonly stats: DeclaredEntityDiscoveryStats;
+}
+
+export interface DeclaredEntityDocumentProjection {
+  readonly relativePath: string;
+  readonly sourceHash: string;
+  readonly statSignature: string;
+  readonly primaryKey: string;
+  readonly row: DeclaredProjectionRow;
 }
 
 export interface DeclaredEntitySourceInput {
   readonly relativePath: string;
-  readonly body: string;
+  readonly body?: string;
+  readonly statSignature: string;
+  readonly contentSha256: string;
+}
+
+export interface DeclaredEntitySourceHint {
+  readonly sourcePath: string;
+  readonly sourceKind: string;
+  readonly statSignature: string;
+  readonly contentSha256: string;
 }
 
 export interface DeclaredEntitySourceResult {
@@ -118,12 +136,23 @@ export function discoverDeclaredEntityProjection(
 
 export function readDeclaredEntitySource(
   rootInput: HarnessLayoutInput,
-  declaration: EntityDeclaration
+  declaration: EntityDeclaration,
+  hints: ReadonlyArray<DeclaredEntitySourceHint> = []
+): DeclaredEntitySourceResult {
+  return readDeclaredEntitySourceAttempt(rootInput, declaration, hints, 0);
+}
+
+function readDeclaredEntitySourceAttempt(
+  rootInput: HarnessLayoutInput,
+  declaration: EntityDeclaration,
+  hints: ReadonlyArray<DeclaredEntitySourceHint>,
+  attempt: number
 ): DeclaredEntitySourceResult {
   const layout = resolveHarnessLayout(rootInput);
   const cacheKey = `${layout.authoredRoot}\0${declaration.kind}\0${declaration.rootResolver.pathTemplate}`;
   const cached = declaredEntitySourceCache.get(cacheKey);
-  if (cached && sourceCacheEntryMatches(cached)) {
+  const cachedBodiesAvailable = cached?.result.inputs.every((input) => input.body !== undefined) ?? false;
+  if (cached && (hints.length > 0 || cachedBodiesAvailable) && sourceCacheEntryMatches(cached)) {
     declaredEntitySourceCache.delete(cacheKey);
     declaredEntitySourceCache.set(cacheKey, cached);
     return {
@@ -133,6 +162,9 @@ export function readDeclaredEntitySource(
   }
   const matcher = templateMatcher(declaration.rootResolver.pathTemplate);
   const discovered = listTemplateFiles(layout.authoredRoot, declaration.rootResolver.pathTemplate);
+  const hintsByPath = new Map(hints
+    .filter((hint) => hint.sourceKind === declaration.kind)
+    .map((hint) => [hint.sourcePath, hint]));
   const inputs: DeclaredEntitySourceInput[] = [];
   for (const relativePath of discovered.files) {
     const match = matcher.pattern.exec(relativePath);
@@ -140,14 +172,41 @@ export function readDeclaredEntitySource(
     const identity = Object.fromEntries(matcher.keys.map((key, index) => [key, match[index + 1]!]));
     resolveEntityDocumentPath(rootInput, declaration, identity);
     const documentPath = path.join(layout.authoredRoot, relativePath);
-    inputs.push({ relativePath, body: localLayoutFileSystem.readText(documentPath) });
+    const statSignature = localProjectionSourceFileSystem.statSignature(documentPath);
+    if (statSignature === null) return retryDeclaredEntitySource(rootInput, declaration, hints, cacheKey, attempt, relativePath);
+    const hint = hintsByPath.get(relativePath);
+    if (hint?.statSignature === statSignature) {
+      inputs.push({ relativePath, statSignature, contentSha256: hint.contentSha256 });
+      continue;
+    }
+    let stable: ReturnType<typeof localProjectionSourceFileSystem.readStableText>;
+    try {
+      stable = localProjectionSourceFileSystem.readStableText(documentPath);
+    } catch {
+      return retryDeclaredEntitySource(rootInput, declaration, hints, cacheKey, attempt, relativePath);
+    }
+    inputs.push({
+      relativePath,
+      body: stable.body,
+      statSignature: stable.signature,
+      contentSha256: sha256Text(stable.body)
+    });
+  }
+  const fileSignatures = new Map(inputs.map((input) => [
+    path.join(layout.authoredRoot, input.relativePath),
+    input.statSignature
+  ]));
+  if (!pathSignaturesMatch(discovered.directorySignatures) || !pathSignaturesMatch(fileSignatures)) {
+    declaredEntitySourceCache.delete(cacheKey);
+    if (attempt >= 2) throw new Error(`declared entity source did not stabilize: ${declaration.kind}`);
+    return readDeclaredEntitySourceAttempt(rootInput, declaration, hints, attempt + 1);
   }
   const result: DeclaredEntitySourceResult = {
     inputs,
     hash: stablePayloadHash({
       schema: "declared-entity-source/v1",
       kind: declaration.kind,
-      inputs
+      inputs: inputs.map(({ relativePath, contentSha256 }) => ({ relativePath, contentSha256 }))
     }),
     stats: {
       directoriesVisited: discovered.directoriesVisited,
@@ -156,9 +215,8 @@ export function readDeclaredEntitySource(
       cacheHit: false
     }
   };
-  const directorySignatures = readPathSignatures(discovered.directories);
-  const fileSignatures = readPathSignatures(inputs.map((input) => path.join(layout.authoredRoot, input.relativePath)));
-  if (directorySignatures && fileSignatures) {
+  const directorySignatures = discovered.directorySignatures;
+  if (directorySignatures.size > 0 || fileSignatures.size > 0) {
     declaredEntitySourceCache.delete(cacheKey);
     declaredEntitySourceCache.set(cacheKey, { result, directorySignatures, fileSignatures });
     evictDeclaredEntitySourceCache();
@@ -174,22 +232,93 @@ export function projectDeclaredEntitySource(
   source: DeclaredEntitySourceResult
 ): DeclaredEntityDiscoveryResult {
   const matcher = templateMatcher(declaration.rootResolver.pathTemplate);
-  const rows: DeclaredProjectionRow[] = [];
+  const documents: DeclaredEntityDocumentProjection[] = [];
+  const primaryKey = declaration.projection.columns.find((column) => column.primaryKey)!;
   for (const input of source.inputs) {
     const match = matcher.pattern.exec(input.relativePath);
     if (!match) continue;
     const identity = Object.fromEntries(matcher.keys.map((key, index) => [key, match[index + 1]!]));
     resolveEntityDocumentPath(rootInput, declaration, identity);
+    if (input.body === undefined) throw new Error(`declared entity source body was not loaded: ${input.relativePath}`);
     const raw = declaration.documentCodec.decode(input.body);
     if (raw === undefined) continue;
     const decoded = Schema.decodeUnknownSync(declaration.schema)(raw) as Readonly<Record<string, unknown>>;
-    rows.push(projectRow(decoded, declaration.projection.columns));
+    const row = projectRow(decoded, declaration.projection.columns);
+    const identityKey = declaration.rootResolver.identity.at(-1)!;
+    const expectedPrimaryKey = identity[identityKey];
+    const actualPrimaryKey = String(row[primaryKey.name]);
+    if (expectedPrimaryKey !== actualPrimaryKey) {
+      throw new Error(`declared entity path identity ${expectedPrimaryKey} does not match projected identity ${actualPrimaryKey}: ${input.relativePath}`);
+    }
+    documents.push({
+      relativePath: input.relativePath,
+      sourceHash: input.contentSha256,
+      statSignature: input.statSignature,
+      primaryKey: actualPrimaryKey,
+      row
+    });
   }
-  const primaryKey = declaration.projection.columns.find((column) => column.primaryKey)!;
+  documents.sort((left, right) => left.primaryKey.localeCompare(right.primaryKey));
   return {
-    rows: rows.sort((left, right) => String(left[primaryKey.name]).localeCompare(String(right[primaryKey.name]))),
+    rows: documents.map((document) => document.row),
+    documents,
     stats: source.stats
   };
+}
+
+function retryDeclaredEntitySource(
+  rootInput: HarnessLayoutInput,
+  declaration: EntityDeclaration,
+  hints: ReadonlyArray<DeclaredEntitySourceHint>,
+  cacheKey: string,
+  attempt: number,
+  relativePath: string
+): DeclaredEntitySourceResult {
+  declaredEntitySourceCache.delete(cacheKey);
+  if (attempt >= 2) throw new Error(`declared entity source did not stabilize: ${relativePath}`);
+  return readDeclaredEntitySourceAttempt(rootInput, declaration, hints, attempt + 1);
+}
+
+export function deleteDeclaredProjectionRows(
+  sql: SqlClient.SqlClient,
+  declaration: EntityDeclaration,
+  primaryKeys: ReadonlyArray<string>
+): Effect.Effect<void, unknown> {
+  const primaryKey = declaration.projection.columns.find((column) => column.primaryKey)!;
+  return Effect.gen(function* () {
+    for (const value of [...new Set(primaryKeys)]) {
+      yield* sql.unsafe(
+        `DELETE FROM ${quoteIdentifier(declaration.projection.table)} WHERE ${quoteIdentifier(primaryKey.name)} = ?`,
+        [value]
+      );
+    }
+  });
+}
+
+export function upsertDeclaredProjectionRows(
+  sql: SqlClient.SqlClient,
+  declaration: EntityDeclaration,
+  rows: ReadonlyArray<DeclaredProjectionRow>
+): Effect.Effect<void, unknown> {
+  const primaryKey = declaration.projection.columns.find((column) => column.primaryKey)!;
+  const columns = declaration.projection.columns.map((column) => quoteIdentifier(column.name));
+  const placeholders = columns.map(() => "?").join(", ");
+  const assignments = declaration.projection.columns
+    .filter((column) => !column.primaryKey)
+    .map((column) => `${quoteIdentifier(column.name)} = excluded.${quoteIdentifier(column.name)}`)
+    .join(", ");
+  const conflictClause = assignments.length > 0
+    ? `DO UPDATE SET ${assignments}`
+    : "DO NOTHING";
+  return Effect.gen(function* () {
+    for (const row of rows) {
+      const values = declaration.projection.columns.map((column) => row[column.name] ?? null);
+      yield* sql.unsafe(
+        `INSERT INTO ${quoteIdentifier(declaration.projection.table)} (${columns.join(", ")}) VALUES (${placeholders}) ON CONFLICT (${quoteIdentifier(primaryKey.name)}) ${conflictClause}`,
+        values
+      );
+    }
+  });
 }
 
 function projectRow(
@@ -258,20 +387,24 @@ function templateMatcher(template: string): { readonly pattern: RegExp; readonly
 function listTemplateFiles(rootPath: string, template: string): {
   readonly files: ReadonlyArray<string>;
   readonly directories: ReadonlyArray<string>;
+  readonly directorySignatures: ReadonlyMap<string, string>;
   readonly directoriesVisited: number;
   readonly entriesVisited: number;
 } {
-  if (!localLayoutFileSystem.exists(rootPath)) return { files: [], directories: [], directoriesVisited: 0, entriesVisited: 0 };
+  if (!localLayoutFileSystem.exists(rootPath)) return { files: [], directories: [], directorySignatures: new Map(), directoriesVisited: 0, entriesVisited: 0 };
   const segments = template.split("/");
   const segmentMatchers = segments.map(templateSegmentMatcher);
   const files: string[] = [];
   const directories: string[] = [];
+  const directorySignatures = new Map<string, string>();
   let directoriesVisited = 0;
   let entriesVisited = 0;
   function visit(directory: string, segmentIndex: number, relativeSegments: ReadonlyArray<string>): void {
     directoriesVisited += 1;
     directories.push(directory);
-    for (const entry of localLayoutFileSystem.readDirents(directory)) {
+    const stableDirectory = localProjectionSourceFileSystem.readStableDirents(directory);
+    directorySignatures.set(directory, stableDirectory.signature);
+    for (const entry of stableDirectory.entries) {
       entriesVisited += 1;
       if (!segmentMatchers[segmentIndex]!.test(entry.name)) continue;
       const fullPath = path.join(directory, entry.name);
@@ -284,7 +417,7 @@ function listTemplateFiles(rootPath: string, template: string): {
     }
   }
   visit(rootPath, 0, []);
-  return { files: files.sort(), directories, directoriesVisited, entriesVisited };
+  return { files: files.sort(), directories, directorySignatures, directoriesVisited, entriesVisited };
 }
 
 function sourceCacheEntryMatches(entry: DeclaredEntitySourceCacheEntry): boolean {
@@ -296,16 +429,6 @@ function pathSignaturesMatch(signatures: ReadonlyMap<string, string>): boolean {
     if (readPathSignature(inputPath) !== expected) return false;
   }
   return true;
-}
-
-function readPathSignatures(inputPaths: ReadonlyArray<string>): ReadonlyMap<string, string> | null {
-  const signatures = new Map<string, string>();
-  for (const inputPath of inputPaths) {
-    const signature = readPathSignature(inputPath);
-    if (signature === null) return null;
-    signatures.set(inputPath, signature);
-  }
-  return signatures;
 }
 
 function readPathSignature(inputPath: string): string | null {

--- a/packages/kernel/src/projection/projection-source-baseline.ts
+++ b/packages/kernel/src/projection/projection-source-baseline.ts
@@ -1,0 +1,15 @@
+import type { HarnessLayoutInput } from "../layout/index.ts";
+import { resolveHarnessLayout } from "../layout/index.ts";
+import { readDeclaredSourceManifestRows } from "./sqlite-declared-source-manifest.ts";
+import { captureProjectionSourceFingerprint } from "./projection-source-snapshot.ts";
+
+export function captureAuthoredProjectionFingerprint(rootInput: HarnessLayoutInput): string {
+  const projectionPath = resolveHarnessLayout(rootInput).projectionPath;
+  let hints: ReturnType<typeof readDeclaredSourceManifestRows> = [];
+  try {
+    hints = readDeclaredSourceManifestRows(projectionPath);
+  } catch {
+    // A missing or invalid generated manifest is not authoritative; source capture still proceeds.
+  }
+  return captureProjectionSourceFingerprint(rootInput, hints).fingerprint;
+}

--- a/packages/kernel/src/projection/projection-source-snapshot.ts
+++ b/packages/kernel/src/projection/projection-source-snapshot.ts
@@ -1,0 +1,115 @@
+import type { EntityDeclaration } from "../entity/declaration.ts";
+import { executionDeclaration } from "../entity/execution-declaration.ts";
+import { reviewDeclaration } from "../entity/review-declaration.ts";
+import { sessionEntityDeclaration } from "../entity/session.ts";
+import { stablePayloadHash } from "../integrity/stable-hash.ts";
+import type { HarnessLayoutInput } from "../layout/index.ts";
+import {
+  readAttributionEventsFromSource,
+  readAttributionEventSource,
+  type AttributionEventSource
+} from "../local/attribution-event-source.ts";
+import type { AttributionEvent } from "../schemas/attribution-event.ts";
+import {
+  projectDeclaredEntitySource,
+  readDeclaredProjectionRows,
+  readDeclaredEntitySource,
+  type DeclaredEntitySourceResult,
+  type DeclaredProjectionRow
+} from "./entity-declaration-projection.ts";
+import { readLegacyPersonIds } from "./entity-attribution-projection.ts";
+import { readDecisionProjectionRows } from "./sqlite-decision-source.ts";
+import { readMarkdownSource } from "./sqlite-task-source.ts";
+import type { DecisionProjectionRow } from "./types.ts";
+
+export const projectionEntityDeclarations = [
+  sessionEntityDeclaration,
+  executionDeclaration,
+  reviewDeclaration
+] as const;
+
+export interface DeclaredProjectionSnapshot {
+  readonly declaration: EntityDeclaration;
+  readonly table: string;
+  readonly rows: ReadonlyArray<DeclaredProjectionRow>;
+}
+
+export interface DeclaredEntitySourceSnapshot {
+  readonly declaration: EntityDeclaration;
+  readonly table: string;
+  readonly source: DeclaredEntitySourceResult;
+}
+
+export interface ProjectionSourceFingerprint {
+  readonly taskSource: ReturnType<typeof readMarkdownSource>;
+  readonly declaredSources: ReadonlyArray<DeclaredEntitySourceSnapshot>;
+  readonly attributionSource: AttributionEventSource;
+  readonly legacyPersonIds: ReadonlyArray<string>;
+  readonly fingerprint: string;
+}
+
+export interface ProjectionSourceSnapshot extends ProjectionSourceFingerprint {
+  readonly decisionRows: ReadonlyArray<DecisionProjectionRow>;
+  readonly declaredTables: ReadonlyArray<DeclaredProjectionSnapshot>;
+  readonly attributionEvents: ReadonlyArray<AttributionEvent>;
+}
+
+export function captureProjectionSourceFingerprint(rootInput: HarnessLayoutInput): ProjectionSourceFingerprint {
+  const taskSource = readMarkdownSource(rootInput);
+  const declaredSources = projectionEntityDeclarations.map((declaration) => ({
+    declaration,
+    table: declaration.projection.table,
+    source: readDeclaredEntitySource(rootInput, declaration)
+  }));
+  const attributionSource = readAttributionEventSource(rootInput);
+  const legacyPersonIds = [...readLegacyPersonIds(rootInput)].sort();
+  const fingerprint = stablePayloadHash({
+    schema: "projection-source-fingerprint/v2",
+    taskSourceHash: taskSource.hash,
+    declaredSources: declaredSources.map(({ table, source }) => ({ table, sourceHash: source.hash })),
+    attributionSourceHash: attributionSource.hash,
+    legacyPersonIds
+  });
+  return {
+    taskSource,
+    declaredSources,
+    attributionSource,
+    legacyPersonIds,
+    fingerprint
+  };
+}
+
+export function captureProjectionSourceSnapshot(rootInput: HarnessLayoutInput): ProjectionSourceSnapshot {
+  const source = captureProjectionSourceFingerprint(rootInput);
+  const decisionRows = readDecisionProjectionRows(rootInput);
+  const declaredTables = source.declaredSources.map(({ declaration, table, source: declaredSource }) => ({
+    declaration,
+    table,
+    rows: projectDeclaredEntitySource(rootInput, declaration, declaredSource).rows
+  }));
+  const attributionEvents = readAttributionEventsFromSource(source.attributionSource);
+  return {
+    ...source,
+    decisionRows,
+    declaredTables,
+    attributionEvents
+  };
+}
+
+export function hashDeclaredProjectionSnapshots(tables: ReadonlyArray<{
+  readonly table: string;
+  readonly rows: ReadonlyArray<DeclaredProjectionRow>;
+}>): string {
+  return stablePayloadHash({
+    schema: "declared-projection-rows/v1",
+    tables: tables.map(({ table, rows }) => ({ table, rows }))
+  });
+}
+
+export function readDeclaredProjectionSnapshots(projectionPath: string): ReadonlyArray<DeclaredProjectionSnapshot> {
+  return projectionEntityDeclarations.map((declaration) => ({
+    declaration,
+    table: declaration.projection.table,
+    rows: readDeclaredProjectionRows(projectionPath, declaration)
+  }));
+}

--- a/packages/kernel/src/projection/projection-source-snapshot.ts
+++ b/packages/kernel/src/projection/projection-source-snapshot.ts
@@ -15,6 +15,8 @@ import {
   readDeclaredProjectionRows,
   readDeclaredEntitySource,
   type DeclaredEntitySourceResult,
+  type DeclaredEntitySourceHint,
+  type DeclaredEntityDocumentProjection,
   type DeclaredProjectionRow
 } from "./entity-declaration-projection.ts";
 import { readLegacyPersonIds } from "./entity-attribution-projection.ts";
@@ -32,6 +34,7 @@ export interface DeclaredProjectionSnapshot {
   readonly declaration: EntityDeclaration;
   readonly table: string;
   readonly rows: ReadonlyArray<DeclaredProjectionRow>;
+  readonly documents: ReadonlyArray<DeclaredEntityDocumentProjection>;
 }
 
 export interface DeclaredEntitySourceSnapshot {
@@ -54,12 +57,15 @@ export interface ProjectionSourceSnapshot extends ProjectionSourceFingerprint {
   readonly attributionEvents: ReadonlyArray<AttributionEvent>;
 }
 
-export function captureProjectionSourceFingerprint(rootInput: HarnessLayoutInput): ProjectionSourceFingerprint {
+export function captureProjectionSourceFingerprint(
+  rootInput: HarnessLayoutInput,
+  declaredSourceHints: ReadonlyArray<DeclaredEntitySourceHint> = []
+): ProjectionSourceFingerprint {
   const taskSource = readMarkdownSource(rootInput);
   const declaredSources = projectionEntityDeclarations.map((declaration) => ({
     declaration,
     table: declaration.projection.table,
-    source: readDeclaredEntitySource(rootInput, declaration)
+    source: readDeclaredEntitySource(rootInput, declaration, declaredSourceHints)
   }));
   const attributionSource = readAttributionEventSource(rootInput);
   const legacyPersonIds = [...readLegacyPersonIds(rootInput)].sort();
@@ -82,11 +88,15 @@ export function captureProjectionSourceFingerprint(rootInput: HarnessLayoutInput
 export function captureProjectionSourceSnapshot(rootInput: HarnessLayoutInput): ProjectionSourceSnapshot {
   const source = captureProjectionSourceFingerprint(rootInput);
   const decisionRows = readDecisionProjectionRows(rootInput);
-  const declaredTables = source.declaredSources.map(({ declaration, table, source: declaredSource }) => ({
-    declaration,
-    table,
-    rows: projectDeclaredEntitySource(rootInput, declaration, declaredSource).rows
-  }));
+  const declaredTables = source.declaredSources.map(({ declaration, table, source: declaredSource }) => {
+    const projected = projectDeclaredEntitySource(rootInput, declaration, declaredSource);
+    return {
+      declaration,
+      table,
+      rows: projected.rows,
+      documents: projected.documents
+    };
+  });
   const attributionEvents = readAttributionEventsFromSource(source.attributionSource);
   return {
     ...source,
@@ -106,10 +116,15 @@ export function hashDeclaredProjectionSnapshots(tables: ReadonlyArray<{
   });
 }
 
+export function hashProjectionLegacyPersonIds(personIds: ReadonlyArray<string>): string {
+  return stablePayloadHash({ schema: "projection-legacy-people/v1", personIds: [...personIds].sort() });
+}
+
 export function readDeclaredProjectionSnapshots(projectionPath: string): ReadonlyArray<DeclaredProjectionSnapshot> {
   return projectionEntityDeclarations.map((declaration) => ({
     declaration,
     table: declaration.projection.table,
-    rows: readDeclaredProjectionRows(projectionPath, declaration)
+    rows: readDeclaredProjectionRows(projectionPath, declaration),
+    documents: []
   }));
 }

--- a/packages/kernel/src/projection/sqlite-attribution-projection.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-projection.ts
@@ -4,6 +4,7 @@ import { localLayoutFileSystem } from "../local/local-layout-file-system.ts";
 import { readAttributionEvents } from "../local/attribution-event-source.ts";
 import type { ActorAxes, ExecutorSource, PrincipalSource } from "../schemas/actor-attribution.ts";
 import type { AttributionEvent } from "../schemas/attribution-event.ts";
+import { unresolvedEntityAttribution } from "./entity-attribution-projection.ts";
 import type { EntityAttributionProjection } from "./types.ts";
 import { runSqlite } from "./sqlite-projection-store.ts";
 import { SqlClient } from "@effect/sql";
@@ -55,6 +56,41 @@ export function replaceAttributionProjectionRows(
   });
 }
 
+export function applyAttributionProjectionDelta(
+  sql: SqlClient.SqlClient,
+  events: ReadonlyArray<AttributionEvent>
+): Effect.Effect<ReadonlyArray<string>, unknown> {
+  return Effect.gen(function* () {
+    yield* createAttributionTable(sql);
+    const existingRecords = yield* sql<AttributionRecord>`
+      SELECT event_id, op_id, subject_ref, operation, principal_person_id,
+             executor_agent_id, occurred_at, recorded_at, source_json
+      FROM attribution_events
+      ORDER BY occurred_at, event_id
+    `;
+    const existing = existingRecords.map(recordToProjectionRow);
+    const current = events.map(eventToProjectionRow);
+    const existingById = new Map(existing.map((row) => [row.eventId, row]));
+    const currentById = new Map(current.map((row) => [row.eventId, row]));
+    const changedIds = new Set([
+      ...existing.filter((row) => JSON.stringify(row) !== JSON.stringify(currentById.get(row.eventId))).map((row) => row.eventId),
+      ...current.filter((row) => JSON.stringify(row) !== JSON.stringify(existingById.get(row.eventId))).map((row) => row.eventId)
+    ]);
+    const affectedSubjects = new Set<string>();
+    for (const eventId of changedIds) {
+      const previous = existingById.get(eventId);
+      const next = currentById.get(eventId);
+      if (previous) affectedSubjects.add(previous.subjectRef);
+      if (next) affectedSubjects.add(next.subjectRef);
+      yield* sql`DELETE FROM attribution_events WHERE event_id = ${eventId}`;
+    }
+    for (const event of events) {
+      if (changedIds.has(event.eventId)) yield* insertAttributionEvent(sql, event);
+    }
+    return [...affectedSubjects];
+  });
+}
+
 export function materializeEntityAttributionBlocks(
   sql: SqlClient.SqlClient,
   events: ReadonlyArray<AttributionEvent>
@@ -66,6 +102,7 @@ export function materializeEntityAttributionBlocks(
       .map((row) => String(row.name)));
     for (const entity of entityProjectionTables) {
       if (!existing.has(entity.table)) continue;
+      yield* sql.unsafe(`UPDATE ${entity.table} SET attribution_json = ?`, [JSON.stringify(unresolvedEntityAttribution())]);
       const records = yield* sql.unsafe<Record<string, unknown>>(`SELECT ${entity.id} FROM ${entity.table}`);
       for (const record of records) {
         const id = String(record[entity.id]);
@@ -75,6 +112,57 @@ export function materializeEntityAttributionBlocks(
         yield* sql.unsafe(`UPDATE ${entity.table} SET attribution_json = ? WHERE ${entity.id} = ?`, [JSON.stringify(attribution), id]);
       }
     }
+  });
+}
+
+export function materializeEntityAttributionTargets(
+  sql: SqlClient.SqlClient,
+  targets: ReadonlyArray<{ readonly table: string; readonly id: string }>
+): Effect.Effect<void, unknown> {
+  const uniqueTargets = new Map(targets.map((target) => [`${target.table}\0${target.id}`, target]));
+  return Effect.gen(function* () {
+    for (const target of uniqueTargets.values()) {
+      const entity = entityProjectionTables.find((candidate) => candidate.table === target.table);
+      if (!entity) throw new Error(`unknown attributed projection table: ${target.table}`);
+      yield* sql.unsafe(`UPDATE ${entity.table} SET attribution_json = ? WHERE ${entity.id} = ?`, [
+        JSON.stringify(unresolvedEntityAttribution()),
+        target.id
+      ]);
+      const records = yield* sql.unsafe<AttributionRecord>(`
+        SELECT event_id, op_id, subject_ref, operation, principal_person_id,
+               executor_agent_id, occurred_at, recorded_at, source_json
+        FROM attribution_events
+        WHERE subject_ref = ? OR subject_ref = ?
+        ORDER BY occurred_at, event_id
+      `, [target.id, `${entity.prefix}${target.id}`]);
+      if (records.length === 0) continue;
+      yield* sql.unsafe(`UPDATE ${entity.table} SET attribution_json = ? WHERE ${entity.id} = ?`, [
+        JSON.stringify(eventAttribution(records.map(recordToProjectionRow))),
+        target.id
+      ]);
+    }
+  });
+}
+
+export function materializeEntityAttributionSubjects(
+  sql: SqlClient.SqlClient,
+  subjectRefs: ReadonlyArray<string>
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    const targets: Array<{ readonly table: string; readonly id: string }> = [];
+    for (const entity of entityProjectionTables) {
+      for (const subjectRef of new Set(subjectRefs)) {
+        const candidateId = subjectRef.startsWith(entity.prefix)
+          ? subjectRef.slice(entity.prefix.length)
+          : subjectRef;
+        const records = yield* sql.unsafe<Record<string, unknown>>(
+          `SELECT ${entity.id} AS entity_id FROM ${entity.table} WHERE ${entity.id} = ?`,
+          [candidateId]
+        );
+        if (records.length > 0) targets.push({ table: entity.table, id: candidateId });
+      }
+    }
+    yield* materializeEntityAttributionTargets(sql, targets);
   });
 }
 

--- a/packages/kernel/src/projection/sqlite-attribution-projection.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-projection.ts
@@ -29,14 +29,53 @@ export function materializeAttributionProjection(
 ): ReadonlyArray<AttributionProjectionRow> {
   if (!localLayoutFileSystem.exists(projectionPath)) throw new Error("base projection database must exist before attribution materialization");
   const events = readAttributionEvents(rootInput);
-  runSqlite(projectionPath, Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
+  return materializeAttributionProjectionFromEvents(projectionPath, events);
+}
+
+export function materializeAttributionProjectionFromEvents(
+  projectionPath: string,
+  events: ReadonlyArray<AttributionEvent>
+): ReadonlyArray<AttributionProjectionRow> {
+  if (!localLayoutFileSystem.exists(projectionPath)) throw new Error("base projection database must exist before attribution materialization");
+  runSqlite(projectionPath, Effect.flatMap(SqlClient.SqlClient, (sql) => Effect.gen(function* () {
+    yield* replaceAttributionProjectionRows(sql, events);
+    yield* materializeEntityAttributionBlocks(sql, events);
+  })));
+  return events.map(eventToProjectionRow);
+}
+
+export function replaceAttributionProjectionRows(
+  sql: SqlClient.SqlClient,
+  events: ReadonlyArray<AttributionEvent>
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
     yield* createAttributionTable(sql);
     yield* sql`DELETE FROM attribution_events`;
     for (const event of events) yield* insertAttributionEvent(sql, event);
-  }));
-  materializeEntityAttributionBlocks(rootInput, projectionPath);
-  return events.map(eventToProjectionRow);
+  });
+}
+
+export function materializeEntityAttributionBlocks(
+  sql: SqlClient.SqlClient,
+  events: ReadonlyArray<AttributionEvent>
+): Effect.Effect<void, unknown> {
+  const rows = events.map(eventToProjectionRow);
+  const bySubject = Map.groupBy(rows, (row) => row.subjectRef);
+  return Effect.gen(function* () {
+    const existing = new Set((yield* sql<{ readonly name: string }>`SELECT name FROM sqlite_master WHERE type = 'table'`)
+      .map((row) => String(row.name)));
+    for (const entity of entityProjectionTables) {
+      if (!existing.has(entity.table)) continue;
+      const records = yield* sql.unsafe<Record<string, unknown>>(`SELECT ${entity.id} FROM ${entity.table}`);
+      for (const record of records) {
+        const id = String(record[entity.id]);
+        const attributed = bySubject.get(id) ?? bySubject.get(`${entity.prefix}${id}`);
+        if (!attributed || attributed.length === 0) continue;
+        const attribution = eventAttribution(attributed);
+        yield* sql.unsafe(`UPDATE ${entity.table} SET attribution_json = ? WHERE ${entity.id} = ?`, [JSON.stringify(attribution), id]);
+      }
+    }
+  });
 }
 
 export function readAttributionProjection(
@@ -158,27 +197,6 @@ const entityProjectionTables = [
   { table: "execution_projection", id: "execution_id", prefix: "execution/" },
   { table: "review_projection", id: "review_id", prefix: "review/" }
 ] as const;
-
-function materializeEntityAttributionBlocks(rootInput: HarnessLayoutInput, projectionPath: string): void {
-  const rows = readAttributionProjection(rootInput, projectionPath);
-  const bySubject = Map.groupBy(rows, (row) => row.subjectRef);
-  runSqlite(projectionPath, Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
-    const existing = new Set((yield* sql<{ readonly name: string }>`SELECT name FROM sqlite_master WHERE type = 'table'`)
-      .map((row) => String(row.name)));
-    for (const entity of entityProjectionTables) {
-      if (!existing.has(entity.table)) continue;
-      const records = yield* sql.unsafe<Record<string, unknown>>(`SELECT ${entity.id} FROM ${entity.table}`);
-      for (const record of records) {
-        const id = String(record[entity.id]);
-        const events = bySubject.get(id) ?? bySubject.get(`${entity.prefix}${id}`);
-        if (!events || events.length === 0) continue;
-        const attribution = eventAttribution(events);
-        yield* sql.unsafe(`UPDATE ${entity.table} SET attribution_json = ? WHERE ${entity.id} = ?`, [JSON.stringify(attribution), id]);
-      }
-    }
-  }));
-}
 
 function eventAttribution(rows: ReadonlyArray<AttributionProjectionRow>): EntityAttributionProjection {
   const ordered = [...rows].sort((left, right) => left.occurredAt.localeCompare(right.occurredAt) || left.eventId.localeCompare(right.eventId));

--- a/packages/kernel/src/projection/sqlite-declared-source-manifest.ts
+++ b/packages/kernel/src/projection/sqlite-declared-source-manifest.ts
@@ -1,0 +1,350 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+import { stablePayloadHash } from "../integrity/stable-hash.ts";
+import type { EntityDeclaration } from "../entity/declaration.ts";
+import type { HarnessLayoutInput } from "../layout/index.ts";
+import {
+  projectDeclaredEntitySource,
+  type DeclaredEntityDocumentProjection,
+  type DeclaredProjectionRow
+} from "./entity-declaration-projection.ts";
+import type { DeclaredEntitySourceSnapshot, DeclaredProjectionSnapshot } from "./projection-source-snapshot.ts";
+import { runSqlite } from "./sqlite-projection-store.ts";
+
+export interface DeclaredSourceManifestRow {
+  readonly sourcePath: string;
+  readonly sourceKind: string;
+  readonly projectionTable: string;
+  readonly primaryKey: string;
+  readonly statSignature: string;
+  readonly contentSha256: string;
+  readonly projectedRowSha256: string;
+}
+
+export interface DeclaredTableProjectionDelta {
+  readonly declaration: EntityDeclaration;
+  readonly deletePrimaryKeys: ReadonlyArray<string>;
+  readonly upsertRows: ReadonlyArray<DeclaredProjectionRow>;
+}
+
+export interface DeclaredProjectionDelta {
+  readonly tables: ReadonlyArray<DeclaredTableProjectionDelta>;
+  readonly manifest: {
+    readonly deleteSourcePaths: ReadonlyArray<string>;
+    readonly upsertRows: ReadonlyArray<DeclaredSourceManifestRow>;
+    readonly currentRows: ReadonlyArray<DeclaredSourceManifestRow>;
+  };
+}
+
+interface DeclaredSourceManifestRecord {
+  readonly source_path: unknown;
+  readonly source_kind: unknown;
+  readonly projection_table: unknown;
+  readonly primary_key: unknown;
+  readonly stat_signature: unknown;
+  readonly content_sha256: unknown;
+  readonly projected_row_sha256: unknown;
+}
+
+export function declaredSourceManifestRows(
+  tables: ReadonlyArray<DeclaredProjectionSnapshot>,
+  sources: ReadonlyArray<DeclaredEntitySourceSnapshot> = []
+): ReadonlyArray<DeclaredSourceManifestRow> {
+  const documentsByPath = new Map(tables.flatMap((table) =>
+    table.documents.map((document) => [document.relativePath, { table, document }] as const)));
+  const rows = sources.length === 0
+    ? [...documentsByPath.values()].map(({ table, document }) => manifestRowForDocument(table, document))
+    : sources.flatMap((source) => source.source.inputs.map((input) => {
+      const projected = documentsByPath.get(input.relativePath);
+      return projected
+        ? manifestRowForDocument(projected.table, projected.document)
+        : {
+            sourcePath: input.relativePath,
+            sourceKind: source.declaration.kind,
+            projectionTable: source.table,
+            primaryKey: "",
+            statSignature: input.statSignature,
+            contentSha256: input.contentSha256,
+            projectedRowSha256: stablePayloadHash({ ignored: true })
+          };
+    }));
+  assertUniqueProjectedIdentities(rows);
+  return rows.sort((left, right) => left.sourcePath.localeCompare(right.sourcePath));
+}
+
+export function hashDeclaredSourceManifestRows(rows: ReadonlyArray<DeclaredSourceManifestRow>): string {
+  return stablePayloadHash({
+    schema: "declared-source-manifest/v1",
+    rows: [...rows].sort((left, right) => left.sourcePath.localeCompare(right.sourcePath))
+  });
+}
+
+export function buildDeclaredProjectionDelta(
+  previousRows: ReadonlyArray<DeclaredSourceManifestRow>,
+  currentTables: ReadonlyArray<DeclaredProjectionSnapshot>
+): DeclaredProjectionDelta {
+  const currentManifest = declaredSourceManifestRows(currentTables);
+  const currentDocuments = new Map(currentTables.flatMap((table) =>
+    table.documents.map((document) => [document.relativePath, { declaration: table.declaration, document }] as const)));
+  return buildDeltaFromManifest(
+    previousRows,
+    currentManifest,
+    currentDocuments,
+    currentTables.map(({ declaration, table }) => ({ declaration, table }))
+  );
+}
+
+function buildDeltaFromManifest(
+  previousRows: ReadonlyArray<DeclaredSourceManifestRow>,
+  currentManifest: ReadonlyArray<DeclaredSourceManifestRow>,
+  currentDocuments: ReadonlyMap<string, {
+    readonly declaration: EntityDeclaration;
+    readonly document: DeclaredEntityDocumentProjection;
+  }>,
+  declarations: ReadonlyArray<{ readonly declaration: EntityDeclaration; readonly table: string }>
+): DeclaredProjectionDelta {
+  assertUniqueProjectedIdentities(currentManifest);
+  const previousByPath = new Map(previousRows.map((row) => [row.sourcePath, row]));
+  const currentByPath = new Map(currentManifest.map((row) => [row.sourcePath, row]));
+  const tableChanges = new Map<string, {
+    readonly declaration: EntityDeclaration;
+    readonly deletePrimaryKeys: Set<string>;
+    readonly upsertRows: DeclaredProjectionRow[];
+  }>();
+  const tableChange = (declaration: EntityDeclaration) => {
+    const existing = tableChanges.get(declaration.projection.table);
+    if (existing) return existing;
+    const created = { declaration, deletePrimaryKeys: new Set<string>(), upsertRows: [] as DeclaredProjectionRow[] };
+    tableChanges.set(declaration.projection.table, created);
+    return created;
+  };
+  const manifestUpserts: DeclaredSourceManifestRow[] = [];
+  for (const current of currentManifest) {
+    const previous = previousByPath.get(current.sourcePath);
+    if (previous?.statSignature !== current.statSignature) manifestUpserts.push(current);
+    if (previous?.contentSha256 === current.contentSha256 && previous.projectedRowSha256 === current.projectedRowSha256) continue;
+    const projected = currentDocuments.get(current.sourcePath);
+    if (current.primaryKey === "") {
+      if (previous?.primaryKey) tableChange(declarations.find((item) => item.table === previous.projectionTable)!.declaration)
+        .deletePrimaryKeys.add(previous.primaryKey);
+      continue;
+    }
+    if (!projected) throw new Error(`changed declared source was not decoded: ${current.sourcePath}`);
+    const change = tableChange(projected.declaration);
+    if (previous?.primaryKey && previous.primaryKey !== current.primaryKey) change.deletePrimaryKeys.add(previous.primaryKey);
+    change.upsertRows.push(projected.document.row);
+  }
+  const deletedSourcePaths: string[] = [];
+  for (const previous of previousRows) {
+    if (currentByPath.has(previous.sourcePath)) continue;
+    deletedSourcePaths.push(previous.sourcePath);
+    const declaration = declarations.find((item) => item.table === previous.projectionTable)?.declaration;
+    if (declaration && previous.primaryKey) tableChange(declaration).deletePrimaryKeys.add(previous.primaryKey);
+  }
+  return {
+    tables: [...tableChanges.values()].map((change) => ({
+      declaration: change.declaration,
+      deletePrimaryKeys: [...change.deletePrimaryKeys],
+      upsertRows: change.upsertRows
+    })),
+    manifest: {
+      deleteSourcePaths: deletedSourcePaths,
+      upsertRows: manifestUpserts,
+      currentRows: currentManifest
+    }
+  };
+}
+
+export function buildDeclaredProjectionDeltaFromSources(
+  rootInput: HarnessLayoutInput,
+  previousRows: ReadonlyArray<DeclaredSourceManifestRow>,
+  currentSources: ReadonlyArray<DeclaredEntitySourceSnapshot>
+): DeclaredProjectionDelta {
+  const previousByPath = new Map(previousRows.map((row) => [row.sourcePath, row]));
+  const documentsByPath = new Map<string, {
+    readonly declaration: EntityDeclaration;
+    readonly document: DeclaredEntityDocumentProjection;
+  }>();
+  const currentManifest: DeclaredSourceManifestRow[] = [];
+  for (const current of currentSources) {
+    for (const input of current.source.inputs) {
+      const previous = previousByPath.get(input.relativePath);
+      if (input.body === undefined) {
+        if (!previous) throw new Error(`declared source manifest row missing for ${input.relativePath}`);
+        currentManifest.push(previous);
+        continue;
+      }
+      if (previous?.contentSha256 === input.contentSha256) {
+        currentManifest.push({ ...previous, statSignature: input.statSignature });
+        continue;
+      }
+      const projected = projectDeclaredEntitySource(rootInput, current.declaration, {
+        inputs: [input],
+        hash: current.source.hash,
+        stats: current.source.stats
+      });
+      const document = projected.documents[0];
+      if (!document) {
+        currentManifest.push({
+          sourcePath: input.relativePath,
+          sourceKind: current.declaration.kind,
+          projectionTable: current.table,
+          primaryKey: "",
+          statSignature: input.statSignature,
+          contentSha256: input.contentSha256,
+          projectedRowSha256: stablePayloadHash({ ignored: true })
+        });
+        continue;
+      }
+      documentsByPath.set(input.relativePath, { declaration: current.declaration, document });
+      currentManifest.push({
+        sourcePath: input.relativePath,
+        sourceKind: current.declaration.kind,
+        projectionTable: current.table,
+        primaryKey: document.primaryKey,
+        statSignature: input.statSignature,
+        contentSha256: input.contentSha256,
+        projectedRowSha256: stablePayloadHash(document.row)
+      });
+    }
+  }
+  return buildDeltaFromManifest(previousRows, currentManifest, documentsByPath, currentSources.map(({ declaration, table }) => ({ declaration, table })));
+}
+
+export function applyDeclaredProjectionDeltaToSnapshots(
+  snapshots: ReadonlyArray<DeclaredProjectionSnapshot>,
+  delta: DeclaredProjectionDelta
+): ReadonlyArray<DeclaredProjectionSnapshot> {
+  const changes = new Map(delta.tables.map((table) => [table.declaration.projection.table, table]));
+  return snapshots.map((snapshot) => {
+    const change = changes.get(snapshot.table);
+    if (!change) return snapshot;
+    const primaryKey = snapshot.declaration.projection.columns.find((column) => column.primaryKey)!;
+    const replaced = new Set([
+      ...change.deletePrimaryKeys,
+      ...change.upsertRows.map((row) => String(row[primaryKey.name]))
+    ]);
+    return {
+      ...snapshot,
+      rows: [
+        ...snapshot.rows.filter((row) => !replaced.has(String(row[primaryKey.name]))),
+        ...change.upsertRows
+      ].sort((left, right) => String(left[primaryKey.name]).localeCompare(String(right[primaryKey.name])))
+    };
+  });
+}
+
+export function replaceDeclaredSourceManifestRows(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<DeclaredSourceManifestRow>
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    yield* createDeclaredSourceManifestTable(sql);
+    yield* sql`DELETE FROM declared_source_manifest`;
+    for (const row of rows) yield* upsertDeclaredSourceManifestRow(sql, row);
+  });
+}
+
+export function readDeclaredSourceManifestRows(projectionPath: string): ReadonlyArray<DeclaredSourceManifestRow> {
+  return runSqlite(projectionPath, Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const records = yield* sql<DeclaredSourceManifestRecord>`
+      SELECT source_path, source_kind, projection_table, primary_key,
+             stat_signature, content_sha256, projected_row_sha256
+      FROM declared_source_manifest
+      ORDER BY source_path
+    `;
+    return records.map(recordToManifestRow);
+  }));
+}
+
+export function applyDeclaredSourceManifestDelta(
+  sql: SqlClient.SqlClient,
+  change: {
+    readonly deleteSourcePaths: ReadonlyArray<string>;
+    readonly upsertRows: ReadonlyArray<DeclaredSourceManifestRow>;
+  }
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    for (const sourcePath of [...new Set(change.deleteSourcePaths)]) {
+      yield* sql`DELETE FROM declared_source_manifest WHERE source_path = ${sourcePath}`;
+    }
+    for (const row of change.upsertRows) yield* upsertDeclaredSourceManifestRow(sql, row);
+  });
+}
+
+function createDeclaredSourceManifestTable(sql: SqlClient.SqlClient): Effect.Effect<unknown, unknown> {
+  return Effect.gen(function* () {
+    yield* sql`
+      CREATE TABLE declared_source_manifest (
+        source_path TEXT PRIMARY KEY,
+        source_kind TEXT NOT NULL,
+        projection_table TEXT NOT NULL,
+        primary_key TEXT NOT NULL,
+        stat_signature TEXT NOT NULL,
+        content_sha256 TEXT NOT NULL,
+        projected_row_sha256 TEXT NOT NULL
+      )
+    `;
+    yield* sql`
+      CREATE UNIQUE INDEX declared_source_manifest_identity
+      ON declared_source_manifest (projection_table, primary_key)
+      WHERE primary_key <> ''
+    `;
+  });
+}
+
+function manifestRowForDocument(
+  table: DeclaredProjectionSnapshot,
+  document: DeclaredEntityDocumentProjection
+): DeclaredSourceManifestRow {
+  return {
+    sourcePath: document.relativePath,
+    sourceKind: table.declaration.kind,
+    projectionTable: table.table,
+    primaryKey: document.primaryKey,
+    statSignature: document.statSignature,
+    contentSha256: document.sourceHash,
+    projectedRowSha256: stablePayloadHash(document.row)
+  };
+}
+
+function assertUniqueProjectedIdentities(rows: ReadonlyArray<DeclaredSourceManifestRow>): void {
+  const owners = new Map<string, string>();
+  for (const row of rows) {
+    if (!row.primaryKey) continue;
+    const identity = `${row.projectionTable}\0${row.primaryKey}`;
+    const previous = owners.get(identity);
+    if (previous && previous !== row.sourcePath) {
+      throw new Error(`declared entity identity ${row.projectionTable}/${row.primaryKey} is owned by both ${previous} and ${row.sourcePath}`);
+    }
+    owners.set(identity, row.sourcePath);
+  }
+}
+
+function upsertDeclaredSourceManifestRow(
+  sql: SqlClient.SqlClient,
+  row: DeclaredSourceManifestRow
+): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT OR REPLACE INTO declared_source_manifest (
+      source_path, source_kind, projection_table, primary_key,
+      stat_signature, content_sha256, projected_row_sha256
+    ) VALUES (
+      ${row.sourcePath}, ${row.sourceKind}, ${row.projectionTable}, ${row.primaryKey},
+      ${row.statSignature}, ${row.contentSha256}, ${row.projectedRowSha256}
+    )
+  `;
+}
+
+function recordToManifestRow(record: DeclaredSourceManifestRecord): DeclaredSourceManifestRow {
+  return {
+    sourcePath: String(record.source_path),
+    sourceKind: String(record.source_kind),
+    projectionTable: String(record.projection_table),
+    primaryKey: String(record.primary_key),
+    statSignature: String(record.stat_signature),
+    contentSha256: String(record.content_sha256),
+    projectedRowSha256: String(record.projected_row_sha256)
+  };
+}

--- a/packages/kernel/src/projection/sqlite-projection-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-store.ts
@@ -20,7 +20,7 @@ import type {
   TaskProjectionRow
 } from "./types.ts";
 
-export const projectionVersion = "entity-projection/d4-v7";
+export const projectionVersion = "entity-projection/d4-v8";
 const baseTaskProjectionColumns = [
   "task_id",
   "title",
@@ -59,12 +59,13 @@ export function writeProjectionDatabase(
   decisionRows: ReadonlyArray<DecisionProjectionRow>,
   meta: ProjectionMeta,
   graphRows: ProjectionGraphRows = { relationEdges: [], coverageRows: [], factAnchors: [] },
-  taskFieldExtensions: ReadonlyArray<TaskFieldExtensionProjection> = []
+  taskFieldExtensions: ReadonlyArray<TaskFieldExtensionProjection> = [],
+  materializeSupplemental?: (sql: SqlClient.SqlClient) => Effect.Effect<void, unknown>
 ): void {
   mkdirSync(path.dirname(projectionPath), { recursive: true });
   const tempPath = `${projectionPath}.${process.pid}.${Date.now()}.tmp`;
   rmSync(tempPath, { force: true });
-  runSqlite(tempPath, Effect.gen(function* () {
+  const writeEffect = Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
     yield* sql`PRAGMA journal_mode = DELETE`;
     yield* sql`CREATE TABLE projection_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`;
@@ -156,6 +157,7 @@ export function writeProjectionDatabase(
     yield* insertMeta(sql, "sourceHash", meta.sourceHash);
     yield* insertMeta(sql, "rowsHash", meta.rowsHash);
     yield* insertMeta(sql, "decisionRowsHash", meta.decisionRowsHash ?? "");
+    yield* insertMeta(sql, "declaredRowsHash", meta.declaredRowsHash ?? "");
     for (const row of rows) yield* insertTaskRow(sql, row, projectedTaskFieldExtensions);
     for (const row of decisionRows) yield* insertDecisionRow(sql, row);
     for (const edge of graphRows.relationEdges) yield* insertRelationEdge(sql, edge);
@@ -170,7 +172,14 @@ export function writeProjectionDatabase(
     yield* sql`CREATE INDEX relation_edges_target_ref ON relation_edges (target_ref)`;
     yield* sql`CREATE INDEX relation_coverage_decision_ref ON relation_coverage (decision_ref)`;
     yield* sql`CREATE INDEX task_fact_anchors_task_id ON task_fact_anchors (task_id)`;
-  }));
+    if (materializeSupplemental) yield* materializeSupplemental(sql);
+  });
+  try {
+    runSqlite(tempPath, writeEffect);
+  } catch (error) {
+    rmSync(tempPath, { force: true });
+    throw error;
+  }
   renameSync(tempPath, projectionPath);
 }
 
@@ -271,7 +280,8 @@ function readProjectionDatabase(
         version: meta.get("version"),
         sourceHash: meta.get("sourceHash") ?? "",
         rowsHash: meta.get("rowsHash") ?? "",
-        decisionRowsHash: meta.get("decisionRowsHash") ?? ""
+        decisionRowsHash: meta.get("decisionRowsHash") ?? "",
+        declaredRowsHash: meta.get("declaredRowsHash") ?? ""
       },
       rows: taskRecords.map((record) => recordToTaskRow(record, taskFieldExtensions)),
       decisionRows: decisionRecords.map(recordToDecisionRow)

--- a/packages/kernel/src/projection/sqlite-projection-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-store.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { SqlClient } from "@effect/sql";
 import { SqliteClient } from "@effect/sql-sqlite-node";
 import { Effect } from "effect";
+import { stablePayloadHash } from "../integrity/stable-hash.ts";
 import type { FactAnchorRow, RelationCoverageRow, RelationGraphEdgeRow } from "./relation-graph-projection.ts";
 import { unresolvedEntityAttribution } from "./entity-attribution-projection.ts";
 import {
@@ -20,7 +21,7 @@ import type {
   TaskProjectionRow
 } from "./types.ts";
 
-export const projectionVersion = "entity-projection/d4-v8";
+export const projectionVersion = "entity-projection/d4-v10";
 const baseTaskProjectionColumns = [
   "task_id",
   "title",
@@ -158,6 +159,11 @@ export function writeProjectionDatabase(
     yield* insertMeta(sql, "rowsHash", meta.rowsHash);
     yield* insertMeta(sql, "decisionRowsHash", meta.decisionRowsHash ?? "");
     yield* insertMeta(sql, "declaredRowsHash", meta.declaredRowsHash ?? "");
+    yield* insertMeta(sql, "declaredManifestHash", meta.declaredManifestHash ?? "");
+    yield* insertMeta(sql, "attributionRowsHash", meta.attributionRowsHash ?? "");
+    yield* insertMeta(sql, "attributionSourceHash", meta.attributionSourceHash ?? "");
+    yield* insertMeta(sql, "taskSourceHash", meta.taskSourceHash ?? "");
+    yield* insertMeta(sql, "legacyPersonIdsHash", meta.legacyPersonIdsHash ?? "");
     for (const row of rows) yield* insertTaskRow(sql, row, projectedTaskFieldExtensions);
     for (const row of decisionRows) yield* insertDecisionRow(sql, row);
     for (const edge of graphRows.relationEdges) yield* insertRelationEdge(sql, edge);
@@ -173,6 +179,8 @@ export function writeProjectionDatabase(
     yield* sql`CREATE INDEX relation_coverage_decision_ref ON relation_coverage (decision_ref)`;
     yield* sql`CREATE INDEX task_fact_anchors_task_id ON task_fact_anchors (task_id)`;
     if (materializeSupplemental) yield* materializeSupplemental(sql);
+    const attributionRowsHash = yield* hashAttributionProjectionState(sql);
+    yield* sql`UPDATE projection_meta SET value = ${attributionRowsHash} WHERE key = 'attributionRowsHash'`;
   });
   try {
     runSqlite(tempPath, writeEffect);
@@ -281,7 +289,12 @@ function readProjectionDatabase(
         sourceHash: meta.get("sourceHash") ?? "",
         rowsHash: meta.get("rowsHash") ?? "",
         decisionRowsHash: meta.get("decisionRowsHash") ?? "",
-        declaredRowsHash: meta.get("declaredRowsHash") ?? ""
+        declaredRowsHash: meta.get("declaredRowsHash") ?? "",
+        declaredManifestHash: meta.get("declaredManifestHash") ?? "",
+        attributionRowsHash: meta.get("attributionRowsHash") ?? "",
+        attributionSourceHash: meta.get("attributionSourceHash") ?? "",
+        taskSourceHash: meta.get("taskSourceHash") ?? "",
+        legacyPersonIdsHash: meta.get("legacyPersonIdsHash") ?? ""
       },
       rows: taskRecords.map((record) => recordToTaskRow(record, taskFieldExtensions)),
       decisionRows: decisionRecords.map(recordToDecisionRow)
@@ -334,15 +347,18 @@ export function insertTaskRow(
     JSON.stringify(row.attribution ?? unresolvedEntityAttribution()),
     ...taskFieldExtensions.map((extension) => row.fieldExtensions?.[extension.field] ?? extension.default)
   ];
+  const assignments = [...baseTaskProjectionColumns, ...extensionColumns]
+    .filter((column) => column !== "task_id" && column !== "attribution_json")
+    .map((column) => `${quoteIdentifier(column)} = excluded.${quoteIdentifier(column)}`);
   return sql.unsafe(
-    `INSERT OR REPLACE INTO task_projection (${columns.join(", ")}) VALUES (${values.map(() => "?").join(", ")})`,
+    `INSERT INTO task_projection (${columns.join(", ")}) VALUES (${values.map(() => "?").join(", ")}) ON CONFLICT (task_id) DO UPDATE SET ${assignments.join(", ")}`,
     values
   );
 }
 
 export function insertDecisionRow(sql: SqlClient.SqlClient, row: DecisionProjectionRow): Effect.Effect<unknown, unknown> {
   return sql`
-    INSERT OR REPLACE INTO decision_projection (
+    INSERT INTO decision_projection (
       decision_id, legacy_id, legacy_number, state, title, question, chosen_json,
       rejected_json, path, module_keys_json, product_line_keys_json, risk_tier, urgency,
       vertical, preset, decision_class, proposed_at, provenance_json, decided_at, attribution_json
@@ -353,8 +369,74 @@ export function insertDecisionRow(sql: SqlClient.SqlClient, row: DecisionProject
       ${row.vertical ?? null}, ${row.preset ?? null}, ${row.decisionClass ?? null}, ${row.proposedAt ?? null},
       ${row.provenance ? JSON.stringify(row.provenance) : null}, ${row.decidedAt ?? null},
       ${JSON.stringify(row.attribution ?? unresolvedEntityAttribution())}
-    )
+    ) ON CONFLICT (decision_id) DO UPDATE SET
+      legacy_id = excluded.legacy_id,
+      legacy_number = excluded.legacy_number,
+      state = excluded.state,
+      title = excluded.title,
+      question = excluded.question,
+      chosen_json = excluded.chosen_json,
+      rejected_json = excluded.rejected_json,
+      path = excluded.path,
+      module_keys_json = excluded.module_keys_json,
+      product_line_keys_json = excluded.product_line_keys_json,
+      risk_tier = excluded.risk_tier,
+      urgency = excluded.urgency,
+      vertical = excluded.vertical,
+      preset = excluded.preset,
+      decision_class = excluded.decision_class,
+      proposed_at = excluded.proposed_at,
+      provenance_json = excluded.provenance_json,
+      decided_at = excluded.decided_at
   `;
+}
+
+export function readAttributionProjectionStateHash(projectionPath: string): string {
+  return runSqlite(projectionPath, Effect.flatMap(SqlClient.SqlClient, hashAttributionProjectionState));
+}
+
+export function hashAttributionProjectionState(sql: SqlClient.SqlClient): Effect.Effect<string, unknown> {
+  return Effect.gen(function* () {
+    const tableRecords = yield* sql<{ readonly name: unknown }>`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`;
+    const tableNames = tableRecords.map((record) => String(record.name));
+    const entities: Array<{
+      readonly table: string;
+      readonly rows: ReadonlyArray<{ readonly id: string; readonly attribution: string }>;
+    }> = [];
+    for (const table of tableNames) {
+      const columns = yield* sql.unsafe<{ readonly name: unknown; readonly pk: unknown }>(`PRAGMA table_info(${quoteIdentifier(table)})`);
+      if (!columns.some((column) => String(column.name) === "attribution_json")) continue;
+      const primaryKey = columns.find((column) => Number(column.pk) > 0);
+      if (!primaryKey) throw new Error(`attributed projection table ${table} has no primary key`);
+      const idColumn = String(primaryKey.name);
+      const records = yield* sql.unsafe<Record<string, unknown>>(
+        `SELECT ${quoteIdentifier(idColumn)} AS entity_id, attribution_json FROM ${quoteIdentifier(table)} ORDER BY ${quoteIdentifier(idColumn)}`
+      );
+      entities.push({
+        table,
+        rows: records.map((record) => ({ id: String(record.entity_id), attribution: String(record.attribution_json) }))
+      });
+    }
+    const events = tableNames.includes("attribution_events")
+      ? (yield* sql<Record<string, unknown>>`
+          SELECT event_id, op_id, subject_ref, operation, principal_person_id,
+                 executor_agent_id, occurred_at, recorded_at, source_json
+          FROM attribution_events
+          ORDER BY occurred_at, event_id
+        `).map((record) => ({
+          eventId: String(record.event_id),
+          opId: String(record.op_id),
+          subjectRef: String(record.subject_ref),
+          operation: String(record.operation),
+          principalPersonId: String(record.principal_person_id),
+          executorAgentId: record.executor_agent_id === null ? null : String(record.executor_agent_id),
+          occurredAt: String(record.occurred_at),
+          recordedAt: String(record.recorded_at),
+          source: String(record.source_json)
+        }))
+      : [];
+    return stablePayloadHash({ schema: "projection-attribution-state/v1", entities, events });
+  });
 }
 
 export function insertRelationEdge(sql: SqlClient.SqlClient, edge: RelationGraphEdgeRow): Effect.Effect<unknown, unknown> {

--- a/packages/kernel/src/projection/sqlite-projection-update-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-update-store.ts
@@ -2,6 +2,10 @@ import { SqlClient } from "@effect/sql";
 import { Effect } from "effect";
 import type { ProjectionMeta, TaskFieldExtensionProjection, TaskProjectionRow, DecisionProjectionRow } from "./types.ts";
 import type { ProjectionGraphRows } from "./sqlite-projection-store.ts";
+import type { AttributionEvent } from "../schemas/attribution-event.ts";
+import type { DeclaredProjectionSnapshot } from "./projection-source-snapshot.ts";
+import { replaceDeclaredProjectionRows } from "./entity-declaration-projection.ts";
+import { materializeEntityAttributionBlocks, replaceAttributionProjectionRows } from "./sqlite-attribution-projection.ts";
 import {
   insertCoverageRow,
   insertDecisionRow,
@@ -21,6 +25,8 @@ export function updateProjectionDatabase(
     readonly upsertDecisionRows: ReadonlyArray<DecisionProjectionRow>;
     readonly meta: ProjectionMeta;
     readonly graphRows: ProjectionGraphRows;
+    readonly declaredTables: ReadonlyArray<DeclaredProjectionSnapshot>;
+    readonly attributionEvents: ReadonlyArray<AttributionEvent>;
     readonly taskFieldExtensions?: ReadonlyArray<TaskFieldExtensionProjection>;
   }
 ): void {
@@ -47,9 +53,15 @@ export function updateProjectionDatabase(
       for (const edge of change.graphRows.relationEdges) yield* insertRelationEdge(sql, edge);
       for (const row of change.graphRows.coverageRows) yield* insertCoverageRow(sql, row);
       for (const row of change.graphRows.factAnchors) yield* insertFactAnchor(sql, row);
+      for (const table of change.declaredTables) {
+        yield* replaceDeclaredProjectionRows(sql, table.declaration, table.rows);
+      }
+      yield* replaceAttributionProjectionRows(sql, change.attributionEvents);
+      yield* materializeEntityAttributionBlocks(sql, change.attributionEvents);
       yield* upsertMeta(sql, "sourceHash", change.meta.sourceHash);
       yield* upsertMeta(sql, "rowsHash", change.meta.rowsHash);
       yield* upsertMeta(sql, "decisionRowsHash", change.meta.decisionRowsHash ?? "");
+      yield* upsertMeta(sql, "declaredRowsHash", change.meta.declaredRowsHash ?? "");
       yield* sql`COMMIT`;
     } catch (error) {
       yield* sql`ROLLBACK`;

--- a/packages/kernel/src/projection/sqlite-projection-update-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-update-store.ts
@@ -3,15 +3,20 @@ import { Effect } from "effect";
 import type { ProjectionMeta, TaskFieldExtensionProjection, TaskProjectionRow, DecisionProjectionRow } from "./types.ts";
 import type { ProjectionGraphRows } from "./sqlite-projection-store.ts";
 import type { AttributionEvent } from "../schemas/attribution-event.ts";
-import type { DeclaredProjectionSnapshot } from "./projection-source-snapshot.ts";
-import { replaceDeclaredProjectionRows } from "./entity-declaration-projection.ts";
-import { materializeEntityAttributionBlocks, replaceAttributionProjectionRows } from "./sqlite-attribution-projection.ts";
+import { deleteDeclaredProjectionRows, upsertDeclaredProjectionRows } from "./entity-declaration-projection.ts";
+import { applyDeclaredSourceManifestDelta, type DeclaredProjectionDelta } from "./sqlite-declared-source-manifest.ts";
+import {
+  applyAttributionProjectionDelta,
+  materializeEntityAttributionSubjects,
+  materializeEntityAttributionTargets,
+} from "./sqlite-attribution-projection.ts";
 import {
   insertCoverageRow,
   insertDecisionRow,
   insertFactAnchor,
   insertRelationEdge,
   insertTaskRow,
+  hashAttributionProjectionState,
   queryableTaskFieldExtensions,
   runSqlite
 } from "./sqlite-projection-store.ts";
@@ -24,9 +29,9 @@ export function updateProjectionDatabase(
     readonly deleteDecisionIds: ReadonlyArray<string>;
     readonly upsertDecisionRows: ReadonlyArray<DecisionProjectionRow>;
     readonly meta: ProjectionMeta;
-    readonly graphRows: ProjectionGraphRows;
-    readonly declaredTables: ReadonlyArray<DeclaredProjectionSnapshot>;
-    readonly attributionEvents: ReadonlyArray<AttributionEvent>;
+    readonly graphRows?: ProjectionGraphRows;
+    readonly declaredDelta: DeclaredProjectionDelta;
+    readonly attributionEvents?: ReadonlyArray<AttributionEvent>;
     readonly taskFieldExtensions?: ReadonlyArray<TaskFieldExtensionProjection>;
   }
 ): void {
@@ -47,27 +52,60 @@ export function updateProjectionDatabase(
       for (const row of change.upsertDecisionRows) {
         yield* insertDecisionRow(sql, row);
       }
-      yield* sql`DELETE FROM relation_edges`;
-      yield* sql`DELETE FROM relation_coverage`;
-      yield* sql`DELETE FROM task_fact_anchors`;
-      for (const edge of change.graphRows.relationEdges) yield* insertRelationEdge(sql, edge);
-      for (const row of change.graphRows.coverageRows) yield* insertCoverageRow(sql, row);
-      for (const row of change.graphRows.factAnchors) yield* insertFactAnchor(sql, row);
-      for (const table of change.declaredTables) {
-        yield* replaceDeclaredProjectionRows(sql, table.declaration, table.rows);
+      if (change.graphRows) {
+        yield* sql`DELETE FROM relation_edges`;
+        yield* sql`DELETE FROM relation_coverage`;
+        yield* sql`DELETE FROM task_fact_anchors`;
+        for (const edge of change.graphRows.relationEdges) yield* insertRelationEdge(sql, edge);
+        for (const row of change.graphRows.coverageRows) yield* insertCoverageRow(sql, row);
+        for (const row of change.graphRows.factAnchors) yield* insertFactAnchor(sql, row);
       }
-      yield* replaceAttributionProjectionRows(sql, change.attributionEvents);
-      yield* materializeEntityAttributionBlocks(sql, change.attributionEvents);
+      for (const table of change.declaredDelta.tables) {
+        yield* deleteDeclaredProjectionRows(sql, table.declaration, table.deletePrimaryKeys);
+        yield* upsertDeclaredProjectionRows(sql, table.declaration, table.upsertRows);
+      }
+      yield* applyDeclaredSourceManifestDelta(sql, change.declaredDelta.manifest);
+      if (change.attributionEvents) {
+        const affectedSubjects = yield* applyAttributionProjectionDelta(sql, change.attributionEvents);
+        yield* materializeEntityAttributionSubjects(sql, affectedSubjects);
+        yield* materializeEntityAttributionTargets(sql, changedAttributionTargets(change));
+      } else {
+        yield* materializeEntityAttributionTargets(sql, changedAttributionTargets(change));
+      }
       yield* upsertMeta(sql, "sourceHash", change.meta.sourceHash);
       yield* upsertMeta(sql, "rowsHash", change.meta.rowsHash);
       yield* upsertMeta(sql, "decisionRowsHash", change.meta.decisionRowsHash ?? "");
       yield* upsertMeta(sql, "declaredRowsHash", change.meta.declaredRowsHash ?? "");
+      yield* upsertMeta(sql, "declaredManifestHash", change.meta.declaredManifestHash ?? "");
+      const attributionRowsHash = yield* hashAttributionProjectionState(sql);
+      yield* upsertMeta(sql, "attributionRowsHash", attributionRowsHash);
+      yield* upsertMeta(sql, "attributionSourceHash", change.meta.attributionSourceHash ?? "");
+      yield* upsertMeta(sql, "taskSourceHash", change.meta.taskSourceHash ?? "");
+      yield* upsertMeta(sql, "legacyPersonIdsHash", change.meta.legacyPersonIdsHash ?? "");
       yield* sql`COMMIT`;
     } catch (error) {
       yield* sql`ROLLBACK`;
       throw error;
     }
   }));
+}
+
+function changedAttributionTargets(change: {
+  readonly upsertTaskRows: ReadonlyArray<TaskProjectionRow>;
+  readonly upsertDecisionRows: ReadonlyArray<DecisionProjectionRow>;
+  readonly declaredDelta: DeclaredProjectionDelta;
+}): ReadonlyArray<{ readonly table: string; readonly id: string }> {
+  return [
+    ...change.upsertTaskRows.map((row) => ({ table: "task_projection", id: row.taskId })),
+    ...change.upsertDecisionRows.map((row) => ({ table: "decision_projection", id: row.decisionId })),
+    ...change.declaredDelta.tables.flatMap((table) => {
+      const primaryKey = table.declaration.projection.columns.find((column) => column.primaryKey)!;
+      return table.upsertRows.map((row) => ({
+        table: table.declaration.projection.table,
+        id: String(row[primaryKey.name])
+      }));
+    })
+  ];
 }
 
 function upsertMeta(sql: SqlClient.SqlClient, key: string, value: string): Effect.Effect<unknown, unknown> {

--- a/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
@@ -1,17 +1,29 @@
 import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { createHarnessRuntimeContext, resolveHarnessLayout } from "../layout/index.ts";
+import { readAttributionEventsFromSource } from "../local/attribution-event-source.ts";
 import { readScalar } from "../markdown/frontmatter.ts";
 import type { RelationGraphEdgeRow } from "./relation-graph-projection.ts";
 import { buildRelationGraphProjection } from "./relation-graph-projection.ts";
 import { compareDecisionRows, hashDecisionProjectionRows, readDecisionProjectionRowsForPaths } from "./sqlite-decision-source.ts";
-import { readRelationGraphRows, tryReadProjectionDatabase } from "./sqlite-projection-store.ts";
+import {
+  applyDeclaredProjectionDeltaToSnapshots,
+  buildDeclaredProjectionDeltaFromSources,
+  hashDeclaredSourceManifestRows,
+  readDeclaredSourceManifestRows
+} from "./sqlite-declared-source-manifest.ts";
+import {
+  readAttributionProjectionStateHash,
+  readRelationGraphRows,
+  tryReadProjectionDatabase
+} from "./sqlite-projection-store.ts";
 import { updateProjectionDatabase } from "./sqlite-projection-update-store.ts";
 import { compareRows, hashExactRows, readMarkdownSource, sourcePath, taskEntryToRow } from "./sqlite-task-source.ts";
 import { rebuildTaskProjection } from "./sqlite-task-projection.ts";
 import {
-  captureProjectionSourceSnapshot,
+  captureProjectionSourceFingerprint,
   hashDeclaredProjectionSnapshots,
+  hashProjectionLegacyPersonIds,
   readDeclaredProjectionSnapshots
 } from "./projection-source-snapshot.ts";
 import type { DecisionProjectionRow, ProjectionReadResult, TaskProjectionOptions, TaskProjectionRow } from "./types.ts";
@@ -23,21 +35,36 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   const rootDir = path.resolve(options.rootDir);
   const runtimeContext = createHarnessRuntimeContext(rootDir, options.layoutOverrides);
   const projectionPath = options.projectionPath ? path.resolve(options.projectionPath) : resolveHarnessLayout(runtimeContext).projectionPath;
-  const snapshot = captureProjectionSourceSnapshot(runtimeContext);
-  const source = snapshot.taskSource;
-  const sourceHash = snapshot.fingerprint;
 
   if (!existsSync(projectionPath)) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
 
   const existing = tryReadProjectionDatabase(projectionPath, options.taskFieldExtensions);
-  if (!existing.ok || !projectionRowsMatchMeta(existing, projectionPath)) {
+  if (!existing.ok) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
+  let declaredManifest: ReturnType<typeof readDeclaredSourceManifestRows>;
+  let existingDeclaredTables: ReturnType<typeof readDeclaredProjectionSnapshots>;
+  let attributionRowsHash: string;
+  try {
+    declaredManifest = readDeclaredSourceManifestRows(projectionPath);
+    existingDeclaredTables = readDeclaredProjectionSnapshots(projectionPath);
+    attributionRowsHash = readAttributionProjectionStateHash(projectionPath);
+  } catch {
+    return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+  }
+  if (!projectionRowsMatchMeta(existing, existingDeclaredTables, declaredManifest, attributionRowsHash)) {
+    return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+  }
+  const snapshot = captureProjectionSourceFingerprint(runtimeContext, declaredManifest);
+  const source = snapshot.taskSource;
+  const sourceHash = snapshot.fingerprint;
 
   const oldGraph = safeReadRelationGraphRows(projectionPath);
-  const newGraph = buildRelationGraphProjection(runtimeContext);
+  const declaredEntityOnly = options.touchedPaths.length > 0 && options.touchedPaths
+    .every((filePath) => isDeclaredEntityFile(resolveHarnessLayout(runtimeContext).authoredRoot, realPathIfExists(filePath)));
+  const newGraph = declaredEntityOnly || options.touchedPaths.length === 0 ? null : buildRelationGraphProjection(runtimeContext);
   const affected = affectedProjectionEntities({
     rootDir,
     rootInput: runtimeContext,
@@ -46,10 +73,19 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     existingRows: existing.rows,
     existingDecisionRows: existing.decisionRows,
     oldEdges: oldGraph.relationEdges,
-    newEdges: newGraph.edges
+    newEdges: newGraph?.edges ?? oldGraph.relationEdges
   });
+  let declaredDelta: ReturnType<typeof buildDeclaredProjectionDeltaFromSources>;
+  try {
+    declaredDelta = buildDeclaredProjectionDeltaFromSources(runtimeContext, declaredManifest, snapshot.declaredSources);
+  } catch {
+    return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+  }
+  const hasDeclaredDelta = declaredDelta.tables.length > 0 ||
+    declaredDelta.manifest.deleteSourcePaths.length > 0 ||
+    declaredDelta.manifest.upsertRows.length > 0;
 
-  if (existing.meta.sourceHash === sourceHash && !hasAffectedProjectionEntities(affected)) {
+  if (existing.meta.sourceHash === sourceHash && !hasAffectedProjectionEntities(affected) && !hasDeclaredDelta) {
     return {
       rows: [...existing.rows].sort(compareRows),
       warnings: source.warnings,
@@ -57,7 +93,7 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     };
   }
 
-  if (existing.meta.sourceHash !== sourceHash && options.previousSourceFingerprint && existing.meta.sourceHash !== options.previousSourceFingerprint) {
+  if (existing.meta.sourceHash !== sourceHash && existing.meta.sourceHash !== options.previousSourceFingerprint) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
 
@@ -65,7 +101,10 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   const decisionChange = incrementalDecisionRows(runtimeContext, existing.decisionRows, affected.decisionIds, affected.decisionPaths);
   const rowsHash = hashExactRows(taskChange.rows);
   const decisionRowsHash = hashDecisionProjectionRows(decisionChange.rows);
-  const declaredRowsHash = hashDeclaredProjectionSnapshots(snapshot.declaredTables);
+  const declaredRowsHash = hashDeclaredProjectionSnapshots(
+    applyDeclaredProjectionDeltaToSnapshots(existingDeclaredTables, declaredDelta)
+  );
+  const declaredManifestHash = hashDeclaredSourceManifestRows(declaredDelta.manifest.currentRows);
 
   updateProjectionDatabase(projectionPath, {
     deleteTaskIds: [...taskChange.deleteIds],
@@ -76,15 +115,21 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
       sourceHash,
       rowsHash,
       decisionRowsHash,
-      declaredRowsHash
+      declaredRowsHash,
+      declaredManifestHash,
+      attributionSourceHash: snapshot.attributionSource.hash,
+      taskSourceHash: snapshot.taskSource.hash,
+      legacyPersonIdsHash: hashProjectionLegacyPersonIds(snapshot.legacyPersonIds)
     },
-    graphRows: {
+    ...(newGraph ? { graphRows: {
       relationEdges: newGraph.edges,
       coverageRows: newGraph.coverageRows,
       factAnchors: newGraph.factAnchors
-    },
-    declaredTables: snapshot.declaredTables,
-    attributionEvents: snapshot.attributionEvents,
+    } } : {}),
+    declaredDelta,
+    ...(existing.meta.attributionSourceHash === snapshot.attributionSource.hash
+      ? {}
+      : { attributionEvents: readAttributionEventsFromSource(snapshot.attributionSource) }),
     taskFieldExtensions: options.taskFieldExtensions
   });
 
@@ -106,15 +151,19 @@ function hasAffectedProjectionEntities(affected: {
 function projectionRowsMatchMeta(existing: {
   readonly rows: ReadonlyArray<TaskProjectionRow>;
   readonly decisionRows: ReadonlyArray<DecisionProjectionRow>;
-  readonly meta: { readonly rowsHash: string; readonly decisionRowsHash?: string; readonly declaredRowsHash?: string };
-}, projectionPath: string): boolean {
-  try {
-    return existing.meta.rowsHash === hashExactRows(existing.rows) &&
-      (existing.meta.decisionRowsHash ?? "") === hashDecisionProjectionRows(existing.decisionRows) &&
-      (existing.meta.declaredRowsHash ?? "") === hashDeclaredProjectionSnapshots(readDeclaredProjectionSnapshots(projectionPath));
-  } catch {
-    return false;
-  }
+  readonly meta: {
+    readonly rowsHash: string;
+    readonly decisionRowsHash?: string;
+    readonly declaredRowsHash?: string;
+    readonly declaredManifestHash?: string;
+    readonly attributionRowsHash?: string;
+  };
+}, declaredTables: ReturnType<typeof readDeclaredProjectionSnapshots>, declaredManifest: ReturnType<typeof readDeclaredSourceManifestRows>, attributionRowsHash: string): boolean {
+  return existing.meta.rowsHash === hashExactRows(existing.rows) &&
+    (existing.meta.decisionRowsHash ?? "") === hashDecisionProjectionRows(existing.decisionRows) &&
+    (existing.meta.declaredRowsHash ?? "") === hashDeclaredProjectionSnapshots(declaredTables) &&
+    (existing.meta.declaredManifestHash ?? "") === hashDeclaredSourceManifestRows(declaredManifest) &&
+    (existing.meta.attributionRowsHash ?? "") === attributionRowsHash;
 }
 
 function safeReadRelationGraphRows(projectionPath: string): {
@@ -196,11 +245,17 @@ function affectedProjectionEntities(input: {
   const decisionIds = new Set<string>();
   const decisionPaths = new Set<string>();
   const touchedRelativePaths = new Set(input.touchedPaths.map((filePath) => sourcePath(rootDir, realPathIfExists(filePath))));
+  const declaredEntityRelativePaths = new Set(input.touchedPaths
+    .map(realPathIfExists)
+    .filter((filePath) => isDeclaredEntityFile(layout.authoredRoot, filePath))
+    .map((filePath) => sourcePath(rootDir, filePath)));
+  const taskTouchedRelativePaths = [...touchedRelativePaths]
+    .filter((relativePath) => !declaredEntityRelativePaths.has(relativePath));
 
   for (const filePath of input.touchedPaths) {
     const resolved = realPathIfExists(filePath);
     const taskSlug = taskSlugForPath(tasksRoot, resolved);
-    if (taskSlug) taskIds.add(taskSlug);
+    if (taskSlug && !isDeclaredEntityFile(layout.authoredRoot, resolved)) taskIds.add(taskSlug);
     if (path.basename(resolved) === "decision.md" && isPathWithin(decisionsRoot, resolved)) {
       decisionPaths.add(path.join(input.rootDir, sourcePath(rootDir, resolved)));
     }
@@ -208,13 +263,13 @@ function affectedProjectionEntities(input: {
 
   for (const entry of input.sourceEntries) {
     const entrySourcePath = sourcePath(rootDir, realPathIfExists(entry.indexPath));
-    if ([...touchedRelativePaths].some((relativePath) => relativePath === entrySourcePath || relativePath.startsWith(`${path.posix.dirname(entrySourcePath)}/`))) {
+    if (taskTouchedRelativePaths.some((relativePath) => relativePath === entrySourcePath || relativePath.startsWith(`${path.posix.dirname(entrySourcePath)}/`))) {
       taskIds.add(entry.taskId);
     }
   }
 
   for (const row of input.existingRows) {
-    if ([...touchedRelativePaths].some((relativePath) => relativePath === row.sourcePath || relativePath.startsWith(`${path.posix.dirname(row.sourcePath)}/`))) {
+    if (taskTouchedRelativePaths.some((relativePath) => relativePath === row.sourcePath || relativePath.startsWith(`${path.posix.dirname(row.sourcePath)}/`))) {
       taskIds.add(row.taskId);
     }
   }
@@ -240,6 +295,13 @@ function taskSlugForPath(tasksRoot: string, filePath: string): string | undefine
   const relative = path.relative(tasksRoot, filePath);
   const [slug] = relative.split(path.sep);
   return slug && slug.length > 0 ? slug : undefined;
+}
+
+function isDeclaredEntityFile(authoredRoot: string, filePath: string): boolean {
+  if (!isPathWithin(authoredRoot, filePath)) return false;
+  const relative = path.relative(realPathIfExists(authoredRoot), realPathIfExists(filePath)).split(path.sep).join("/");
+  return /^sessions\/[^/]+\.md$/u.test(relative) ||
+    /^tasks\/[^/]+\/(?:executions|reviews)\/[^/]+\.md$/u.test(relative);
 }
 
 function isPathWithin(parent: string, child: string): boolean {

--- a/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
@@ -105,6 +105,18 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     applyDeclaredProjectionDeltaToSnapshots(existingDeclaredTables, declaredDelta)
   );
   const declaredManifestHash = hashDeclaredSourceManifestRows(declaredDelta.manifest.currentRows);
+  let verifiedSourceHash: string;
+  try {
+    verifiedSourceHash = captureProjectionSourceFingerprint(
+      runtimeContext,
+      declaredDelta.manifest.currentRows
+    ).fingerprint;
+  } catch {
+    return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+  }
+  if (verifiedSourceHash !== sourceHash) {
+    return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+  }
 
   updateProjectionDatabase(projectionPath, {
     deleteTaskIds: [...taskChange.deleteIds],

--- a/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
@@ -9,23 +9,30 @@ import { readRelationGraphRows, tryReadProjectionDatabase } from "./sqlite-proje
 import { updateProjectionDatabase } from "./sqlite-projection-update-store.ts";
 import { compareRows, hashExactRows, readMarkdownSource, sourcePath, taskEntryToRow } from "./sqlite-task-source.ts";
 import { rebuildTaskProjection } from "./sqlite-task-projection.ts";
+import {
+  captureProjectionSourceSnapshot,
+  hashDeclaredProjectionSnapshots,
+  readDeclaredProjectionSnapshots
+} from "./projection-source-snapshot.ts";
 import type { DecisionProjectionRow, ProjectionReadResult, TaskProjectionOptions, TaskProjectionRow } from "./types.ts";
 
 export function updateTaskProjectionIncrementally(options: TaskProjectionOptions & {
   readonly touchedPaths: ReadonlyArray<string>;
-  readonly previousSourceHash?: string;
+  readonly previousSourceFingerprint?: string;
 }): ProjectionReadResult & { readonly mode: "incremental" | "rebuild" | "unchanged" } {
   const rootDir = path.resolve(options.rootDir);
   const runtimeContext = createHarnessRuntimeContext(rootDir, options.layoutOverrides);
   const projectionPath = options.projectionPath ? path.resolve(options.projectionPath) : resolveHarnessLayout(runtimeContext).projectionPath;
-  const source = readMarkdownSource(runtimeContext);
+  const snapshot = captureProjectionSourceSnapshot(runtimeContext);
+  const source = snapshot.taskSource;
+  const sourceHash = snapshot.fingerprint;
 
   if (!existsSync(projectionPath)) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
 
   const existing = tryReadProjectionDatabase(projectionPath, options.taskFieldExtensions);
-  if (!existing.ok || !projectionRowsMatchMeta(existing)) {
+  if (!existing.ok || !projectionRowsMatchMeta(existing, projectionPath)) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
 
@@ -42,7 +49,7 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     newEdges: newGraph.edges
   });
 
-  if (existing.meta.sourceHash === source.hash && !hasAffectedProjectionEntities(affected)) {
+  if (existing.meta.sourceHash === sourceHash && !hasAffectedProjectionEntities(affected)) {
     return {
       rows: [...existing.rows].sort(compareRows),
       warnings: source.warnings,
@@ -50,7 +57,7 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     };
   }
 
-  if (existing.meta.sourceHash !== source.hash && options.previousSourceHash && existing.meta.sourceHash !== options.previousSourceHash) {
+  if (existing.meta.sourceHash !== sourceHash && options.previousSourceFingerprint && existing.meta.sourceHash !== options.previousSourceFingerprint) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
 
@@ -58,6 +65,7 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   const decisionChange = incrementalDecisionRows(runtimeContext, existing.decisionRows, affected.decisionIds, affected.decisionPaths);
   const rowsHash = hashExactRows(taskChange.rows);
   const decisionRowsHash = hashDecisionProjectionRows(decisionChange.rows);
+  const declaredRowsHash = hashDeclaredProjectionSnapshots(snapshot.declaredTables);
 
   updateProjectionDatabase(projectionPath, {
     deleteTaskIds: [...taskChange.deleteIds],
@@ -65,15 +73,18 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     deleteDecisionIds: [...decisionChange.deleteIds],
     upsertDecisionRows: decisionChange.currentRows,
     meta: {
-      sourceHash: source.hash,
+      sourceHash,
       rowsHash,
-      decisionRowsHash
+      decisionRowsHash,
+      declaredRowsHash
     },
     graphRows: {
       relationEdges: newGraph.edges,
       coverageRows: newGraph.coverageRows,
       factAnchors: newGraph.factAnchors
     },
+    declaredTables: snapshot.declaredTables,
+    attributionEvents: snapshot.attributionEvents,
     taskFieldExtensions: options.taskFieldExtensions
   });
 
@@ -95,10 +106,15 @@ function hasAffectedProjectionEntities(affected: {
 function projectionRowsMatchMeta(existing: {
   readonly rows: ReadonlyArray<TaskProjectionRow>;
   readonly decisionRows: ReadonlyArray<DecisionProjectionRow>;
-  readonly meta: { readonly rowsHash: string; readonly decisionRowsHash?: string };
-}): boolean {
-  return existing.meta.rowsHash === hashExactRows(existing.rows) &&
-    (existing.meta.decisionRowsHash ?? "") === hashDecisionProjectionRows(existing.decisionRows);
+  readonly meta: { readonly rowsHash: string; readonly decisionRowsHash?: string; readonly declaredRowsHash?: string };
+}, projectionPath: string): boolean {
+  try {
+    return existing.meta.rowsHash === hashExactRows(existing.rows) &&
+      (existing.meta.decisionRowsHash ?? "") === hashDecisionProjectionRows(existing.decisionRows) &&
+      (existing.meta.declaredRowsHash ?? "") === hashDeclaredProjectionSnapshots(readDeclaredProjectionSnapshots(projectionPath));
+  } catch {
+    return false;
+  }
 }
 
 function safeReadRelationGraphRows(projectionPath: string): {

--- a/packages/kernel/src/projection/sqlite-task-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-projection.ts
@@ -127,13 +127,19 @@ function captureStableProjectionBuild(runtimeContext: ReturnType<typeof createHa
   readonly snapshot: ReturnType<typeof captureProjectionSourceSnapshot>;
   readonly relationGraph: ReturnType<typeof buildRelationGraphProjection>;
 } {
+  let lastFailure: unknown = new Error("projection authored sources did not stabilize during rebuild");
   for (let attempt = 0; attempt < 3; attempt += 1) {
-    const snapshot = captureProjectionSourceSnapshot(runtimeContext);
-    const relationGraph = buildRelationGraphProjection(runtimeContext);
-    const verified = captureProjectionSourceFingerprint(runtimeContext);
-    if (verified.fingerprint === snapshot.fingerprint) return { snapshot, relationGraph };
+    try {
+      const snapshot = captureProjectionSourceSnapshot(runtimeContext);
+      const relationGraph = buildRelationGraphProjection(runtimeContext);
+      const verified = captureProjectionSourceFingerprint(runtimeContext);
+      if (verified.fingerprint === snapshot.fingerprint) return { snapshot, relationGraph };
+      lastFailure = new Error("projection authored sources did not stabilize during rebuild");
+    } catch (error) {
+      lastFailure = error;
+    }
   }
-  throw new Error("projection authored sources did not stabilize during rebuild");
+  throw lastFailure;
 }
 
 export function readTaskProjection(options: TaskProjectionOptions): ProjectionReadResult {

--- a/packages/kernel/src/projection/sqlite-task-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-projection.ts
@@ -1,21 +1,22 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
+import { Effect } from "effect";
 import { createHarnessRuntimeContext } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
-import { executionDeclaration } from "../entity/execution-declaration.ts";
-import { reviewDeclaration } from "../entity/review-declaration.ts";
-import { sessionEntityDeclaration } from "../entity/session.ts";
-import { sha256Text } from "../integrity/stable-hash.ts";
-import { discoverDeclaredEntityRows, projectDeclaredEntities, readDeclaredProjectionRows } from "./entity-declaration-projection.ts";
+import { replaceDeclaredProjectionRows } from "./entity-declaration-projection.ts";
 import { buildCheckReport, hardFail, runPostMergeChecks, warning } from "./post-merge-checks.ts";
 import type { FactAnchorRow, RelationCoverageRow, RelationGraphEdgeRow } from "./relation-graph-projection.ts";
 import { buildRelationGraphProjection } from "./relation-graph-projection.ts";
 import { projectionVersion, queryDecisionProjectionRows, queryTaskChildrenRows, queryTaskProjectionRows, queryTaskSubtreeRows, readRelationGraphRows, writeProjectionDatabase, tryReadProjectionDatabase } from "./sqlite-projection-store.ts";
-import { compareDecisionRows, hashDecisionProjectionRows, readDecisionProjectionRows } from "./sqlite-decision-source.ts";
-import { materializeAttributionProjection } from "./sqlite-attribution-projection.ts";
-import { attributionEventSourceHash } from "../local/attribution-event-source.ts";
-import { readLegacyPersonIds } from "./entity-attribution-projection.ts";
-import { compareRows, hashExactRows, readMarkdownSource, taskEntryToRow } from "./sqlite-task-source.ts";
+import { compareDecisionRows, hashDecisionProjectionRows } from "./sqlite-decision-source.ts";
+import { materializeEntityAttributionBlocks, replaceAttributionProjectionRows } from "./sqlite-attribution-projection.ts";
+import { compareRows, hashExactRows, taskEntryToRow } from "./sqlite-task-source.ts";
+import {
+  captureProjectionSourceFingerprint,
+  captureProjectionSourceSnapshot,
+  hashDeclaredProjectionSnapshots,
+  readDeclaredProjectionSnapshots
+} from "./projection-source-snapshot.ts";
 export { hashTaskProjectionRows } from "./sqlite-task-source.ts";
 export type {
   CoordinationStatus,
@@ -54,26 +55,30 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
   const rootDir = path.resolve(options.rootDir);
   const runtimeContext = createHarnessRuntimeContext(rootDir, options.layoutOverrides);
   const projectionPath = options.projectionPath ? path.resolve(options.projectionPath) : resolveHarnessLayout(runtimeContext).projectionPath;
-  const source = readMarkdownSource(runtimeContext);
+  const snapshot = captureProjectionSourceSnapshot(runtimeContext);
+  const source = snapshot.taskSource;
   const rows = source.entries.map((entry) => taskEntryToRow(runtimeContext, entry, options.taskFieldExtensions)).sort(compareRows);
-  const decisionRows = readDecisionProjectionRows(runtimeContext);
+  const decisionRows = snapshot.decisionRows;
   const rowsHash = hashExactRows(rows);
   const decisionRowsHash = hashDecisionProjectionRows(decisionRows);
-  const sourceHash = projectionSourceHash(source.hash, runtimeContext);
+  const declaredRowsHash = hashDeclaredProjectionSnapshots(snapshot.declaredTables);
   const relationGraph = buildRelationGraphProjection(runtimeContext);
   writeProjectionDatabase(projectionPath, rows, decisionRows, {
-    sourceHash,
+    sourceHash: snapshot.fingerprint,
     rowsHash,
-    decisionRowsHash
+    decisionRowsHash,
+    declaredRowsHash
   }, {
     relationEdges: relationGraph.edges,
     coverageRows: relationGraph.coverageRows,
     factAnchors: relationGraph.factAnchors
-  }, options.taskFieldExtensions);
-  projectDeclaredEntities(runtimeContext, sessionEntityDeclaration, projectionPath);
-  projectDeclaredEntities(runtimeContext, executionDeclaration, projectionPath);
-  projectDeclaredEntities(runtimeContext, reviewDeclaration, projectionPath);
-  materializeAttributionProjection(runtimeContext, projectionPath);
+  }, options.taskFieldExtensions, (sql) => Effect.gen(function* () {
+    for (const table of snapshot.declaredTables) {
+      yield* replaceDeclaredProjectionRows(sql, table.declaration, table.rows);
+    }
+    yield* replaceAttributionProjectionRows(sql, snapshot.attributionEvents);
+    yield* materializeEntityAttributionBlocks(sql, snapshot.attributionEvents);
+  }));
   return {
     rows,
     warnings: source.warnings
@@ -84,7 +89,8 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
   const rootDir = path.resolve(options.rootDir);
   const runtimeContext = createHarnessRuntimeContext(rootDir, options.layoutOverrides);
   const projectionPath = options.projectionPath ? path.resolve(options.projectionPath) : resolveHarnessLayout(runtimeContext).projectionPath;
-  const source = readMarkdownSource(runtimeContext);
+  const snapshot = captureProjectionSourceFingerprint(runtimeContext);
+  const source = snapshot.taskSource;
   const warnings = [...source.warnings];
 
   if (!existsSync(projectionPath)) {
@@ -121,7 +127,7 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
     return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
   }
 
-  if (existing.meta.sourceHash !== projectionSourceHash(source.hash, runtimeContext)) {
+  if (existing.meta.sourceHash !== snapshot.fingerprint) {
     warnings.push(warning(
       "generated-cache",
       "projection_stale",
@@ -132,7 +138,8 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
     return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
   }
 
-  if (!declaredProjectionMatches(runtimeContext, projectionPath)) {
+  const actualDeclaredRowsHash = readDeclaredRowsHash(projectionPath);
+  if (actualDeclaredRowsHash === null || existing.meta.declaredRowsHash !== actualDeclaredRowsHash) {
     warnings.push(hardFail(
       "generated-cache",
       "projection_tampered",
@@ -156,45 +163,17 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
     return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
   }
 
-  const currentDecisionRowsHash = hashDecisionProjectionRows(readDecisionProjectionRows(runtimeContext));
-  if ((existing.meta.decisionRowsHash ?? "") !== currentDecisionRowsHash) {
-    warnings.push(warning(
-      "generated-cache",
-      "projection_stale",
-      "Projection decision cache was stale and has been rebuilt from markdown.",
-      "Run harness-anything governance rebuild after authored decision changes or merges."
-    ));
-    const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
-    return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
-  }
-
   return {
     rows: [...existing.rows].sort(compareRows),
     warnings
   };
 }
 
-function projectionSourceHash(taskSourceHash: string, rootInput: ReturnType<typeof createHarnessRuntimeContext>): string {
-  const entityRows = [sessionEntityDeclaration, executionDeclaration, reviewDeclaration].map((declaration) => ({
-    table: declaration.projection.table,
-    rows: discoverDeclaredEntityRows(rootInput, declaration)
-  }));
-  return sha256Text(JSON.stringify({
-    taskSourceHash,
-    entityRows,
-    attributionEventSourceHash: attributionEventSourceHash(rootInput),
-    legacyPersonIds: [...readLegacyPersonIds(rootInput)].sort()
-  }));
-}
-
-function declaredProjectionMatches(rootInput: ReturnType<typeof createHarnessRuntimeContext>, projectionPath: string): boolean {
+function readDeclaredRowsHash(projectionPath: string): string | null {
   try {
-    return [sessionEntityDeclaration, executionDeclaration, reviewDeclaration].every((declaration) =>
-      JSON.stringify(readDeclaredProjectionRows(projectionPath, declaration)) ===
-      JSON.stringify(discoverDeclaredEntityRows(rootInput, declaration))
-    );
+    return hashDeclaredProjectionSnapshots(readDeclaredProjectionSnapshots(projectionPath));
   } catch {
-    return false;
+    return null;
   }
 }
 

--- a/packages/kernel/src/projection/sqlite-task-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-projection.ts
@@ -3,18 +3,39 @@ import path from "node:path";
 import { Effect } from "effect";
 import { createHarnessRuntimeContext } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
+import { localProjectionSourceFileSystem } from "../local/local-layout-file-system.ts";
 import { replaceDeclaredProjectionRows } from "./entity-declaration-projection.ts";
 import { buildCheckReport, hardFail, runPostMergeChecks, warning } from "./post-merge-checks.ts";
 import type { FactAnchorRow, RelationCoverageRow, RelationGraphEdgeRow } from "./relation-graph-projection.ts";
 import { buildRelationGraphProjection } from "./relation-graph-projection.ts";
-import { projectionVersion, queryDecisionProjectionRows, queryTaskChildrenRows, queryTaskProjectionRows, queryTaskSubtreeRows, readRelationGraphRows, writeProjectionDatabase, tryReadProjectionDatabase } from "./sqlite-projection-store.ts";
+import {
+  projectionVersion,
+  queryDecisionProjectionRows,
+  queryTaskChildrenRows,
+  queryTaskProjectionRows,
+  queryTaskSubtreeRows,
+  readAttributionProjectionStateHash,
+  readRelationGraphRows,
+  writeProjectionDatabase,
+  tryReadProjectionDatabase
+} from "./sqlite-projection-store.ts";
 import { compareDecisionRows, hashDecisionProjectionRows } from "./sqlite-decision-source.ts";
+import {
+  applyDeclaredProjectionDeltaToSnapshots,
+  buildDeclaredProjectionDeltaFromSources,
+  declaredSourceManifestRows,
+  hashDeclaredSourceManifestRows,
+  readDeclaredSourceManifestRows,
+  replaceDeclaredSourceManifestRows
+} from "./sqlite-declared-source-manifest.ts";
+import { updateProjectionDatabase } from "./sqlite-projection-update-store.ts";
 import { materializeEntityAttributionBlocks, replaceAttributionProjectionRows } from "./sqlite-attribution-projection.ts";
 import { compareRows, hashExactRows, taskEntryToRow } from "./sqlite-task-source.ts";
 import {
   captureProjectionSourceFingerprint,
   captureProjectionSourceSnapshot,
   hashDeclaredProjectionSnapshots,
+  hashProjectionLegacyPersonIds,
   readDeclaredProjectionSnapshots
 } from "./projection-source-snapshot.ts";
 export { hashTaskProjectionRows } from "./sqlite-task-source.ts";
@@ -47,6 +68,14 @@ import type {
   TaskProjectionQueryFilters
 } from "./types.ts";
 
+interface ProjectionValidationCacheEntry {
+  readonly signature: string;
+  readonly declaredManifest: ReturnType<typeof readDeclaredSourceManifestRows>;
+}
+
+const projectionValidationCache = new Map<string, ProjectionValidationCacheEntry>();
+const projectionValidationCacheLimit = 16;
+
 export function defaultTaskProjectionPath(rootDir: string): string {
   return resolveHarnessLayout(rootDir).projectionPath;
 }
@@ -55,19 +84,26 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
   const rootDir = path.resolve(options.rootDir);
   const runtimeContext = createHarnessRuntimeContext(rootDir, options.layoutOverrides);
   const projectionPath = options.projectionPath ? path.resolve(options.projectionPath) : resolveHarnessLayout(runtimeContext).projectionPath;
-  const snapshot = captureProjectionSourceSnapshot(runtimeContext);
+  const stableBuild = captureStableProjectionBuild(runtimeContext);
+  const snapshot = stableBuild.snapshot;
   const source = snapshot.taskSource;
   const rows = source.entries.map((entry) => taskEntryToRow(runtimeContext, entry, options.taskFieldExtensions)).sort(compareRows);
   const decisionRows = snapshot.decisionRows;
   const rowsHash = hashExactRows(rows);
   const decisionRowsHash = hashDecisionProjectionRows(decisionRows);
   const declaredRowsHash = hashDeclaredProjectionSnapshots(snapshot.declaredTables);
-  const relationGraph = buildRelationGraphProjection(runtimeContext);
+  const declaredManifestRows = declaredSourceManifestRows(snapshot.declaredTables, snapshot.declaredSources);
+  const declaredManifestHash = hashDeclaredSourceManifestRows(declaredManifestRows);
+  const relationGraph = stableBuild.relationGraph;
   writeProjectionDatabase(projectionPath, rows, decisionRows, {
     sourceHash: snapshot.fingerprint,
     rowsHash,
     decisionRowsHash,
-    declaredRowsHash
+    declaredRowsHash,
+    declaredManifestHash,
+    attributionSourceHash: snapshot.attributionSource.hash,
+    taskSourceHash: snapshot.taskSource.hash,
+    legacyPersonIdsHash: hashProjectionLegacyPersonIds(snapshot.legacyPersonIds)
   }, {
     relationEdges: relationGraph.edges,
     coverageRows: relationGraph.coverageRows,
@@ -76,22 +112,35 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
     for (const table of snapshot.declaredTables) {
       yield* replaceDeclaredProjectionRows(sql, table.declaration, table.rows);
     }
+    yield* replaceDeclaredSourceManifestRows(sql, declaredManifestRows);
     yield* replaceAttributionProjectionRows(sql, snapshot.attributionEvents);
     yield* materializeEntityAttributionBlocks(sql, snapshot.attributionEvents);
   }));
+  rememberProjectionValidation(projectionPath, declaredManifestRows);
   return {
     rows,
     warnings: source.warnings
   };
 }
 
+function captureStableProjectionBuild(runtimeContext: ReturnType<typeof createHarnessRuntimeContext>): {
+  readonly snapshot: ReturnType<typeof captureProjectionSourceSnapshot>;
+  readonly relationGraph: ReturnType<typeof buildRelationGraphProjection>;
+} {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const snapshot = captureProjectionSourceSnapshot(runtimeContext);
+    const relationGraph = buildRelationGraphProjection(runtimeContext);
+    const verified = captureProjectionSourceFingerprint(runtimeContext);
+    if (verified.fingerprint === snapshot.fingerprint) return { snapshot, relationGraph };
+  }
+  throw new Error("projection authored sources did not stabilize during rebuild");
+}
+
 export function readTaskProjection(options: TaskProjectionOptions): ProjectionReadResult {
   const rootDir = path.resolve(options.rootDir);
   const runtimeContext = createHarnessRuntimeContext(rootDir, options.layoutOverrides);
   const projectionPath = options.projectionPath ? path.resolve(options.projectionPath) : resolveHarnessLayout(runtimeContext).projectionPath;
-  const snapshot = captureProjectionSourceFingerprint(runtimeContext);
-  const source = snapshot.taskSource;
-  const warnings = [...source.warnings];
+  const warnings: ProjectionReadResult["warnings"][number][] = [];
 
   if (!existsSync(projectionPath)) {
     warnings.push(warning(
@@ -101,7 +150,7 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
       "Run harness-anything governance rebuild to materialize a fresh local projection cache before relying on generated state."
     ));
     const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
-    return { rows: rebuilt.rows, warnings };
+    return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
   }
 
   const existing = tryReadProjectionDatabase(projectionPath, options.taskFieldExtensions);
@@ -127,24 +176,68 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
     return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
   }
 
-  if (existing.meta.sourceHash !== snapshot.fingerprint) {
-    warnings.push(warning(
+  const cachedValidation = readCachedProjectionValidation(projectionPath);
+  let declaredManifest: ReturnType<typeof readDeclaredSourceManifestRows>;
+  try {
+    declaredManifest = cachedValidation?.declaredManifest ?? readDeclaredSourceManifestRows(projectionPath);
+  } catch {
+    warnings.push(hardFail(
       "generated-cache",
-      "projection_stale",
-      "Projection cache was stale and has been rebuilt from markdown.",
-      "Run harness-anything governance rebuild after authored task changes or merges."
+      "projection_tampered",
+      "Projection source manifest could not be read and has been rebuilt from authored state.",
+      "Discard the generated cache and rebuild it from authored entities; do not merge generated projection edits."
+    ));
+    const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
+    return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
+  }
+  if (!cachedValidation && existing.meta.declaredManifestHash !== hashDeclaredSourceManifestRows(declaredManifest)) {
+    warnings.push(hardFail(
+      "generated-cache",
+      "projection_tampered",
+      "Projection source manifest no longer matches its recorded hash.",
+      "Discard the generated cache and rebuild it from authored entities; do not merge generated projection edits."
     ));
     const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
     return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
   }
 
-  const actualDeclaredRowsHash = readDeclaredRowsHash(projectionPath);
-  if (actualDeclaredRowsHash === null || existing.meta.declaredRowsHash !== actualDeclaredRowsHash) {
+  const snapshot = captureProjectionSourceFingerprint(runtimeContext, declaredManifest);
+  const source = snapshot.taskSource;
+  warnings.push(...source.warnings);
+
+  let existingDeclaredTables: ReturnType<typeof readDeclaredProjectionSnapshots> | null = null;
+  if (!cachedValidation) {
+    try {
+      existingDeclaredTables = readDeclaredProjectionSnapshots(projectionPath);
+    } catch {
+      existingDeclaredTables = null;
+    }
+  }
+  if (!cachedValidation && (existingDeclaredTables === null || existing.meta.declaredRowsHash !== hashDeclaredProjectionSnapshots(existingDeclaredTables))) {
     warnings.push(hardFail(
       "generated-cache",
       "projection_tampered",
       "Declared entity projection rows no longer match authored entity state.",
       "Discard the generated cache and rebuild it from authored entities; do not merge generated projection edits."
+    ));
+    const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
+    return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
+  }
+
+  let attributionRowsMatch = true;
+  if (!cachedValidation) {
+    try {
+      attributionRowsMatch = existing.meta.attributionRowsHash === readAttributionProjectionStateHash(projectionPath);
+    } catch {
+      attributionRowsMatch = false;
+    }
+  }
+  if (!attributionRowsMatch) {
+    warnings.push(hardFail(
+      "generated-cache",
+      "projection_tampered",
+      "Projected attribution no longer matches its recorded hash.",
+      "Discard the generated cache and rebuild it from authored attribution events; do not merge generated projection edits."
     ));
     const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
     return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
@@ -163,17 +256,80 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
     return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
   }
 
+  if (existing.meta.sourceHash !== snapshot.fingerprint) {
+    const legacyPersonIdsHash = hashProjectionLegacyPersonIds(snapshot.legacyPersonIds);
+    const declaredOnly = existing.meta.taskSourceHash === snapshot.taskSource.hash &&
+      existing.meta.attributionSourceHash === snapshot.attributionSource.hash &&
+      existing.meta.legacyPersonIdsHash === legacyPersonIdsHash;
+    if (declaredOnly) {
+      try {
+        existingDeclaredTables ??= readDeclaredProjectionSnapshots(projectionPath);
+        const declaredDelta = buildDeclaredProjectionDeltaFromSources(runtimeContext, declaredManifest, snapshot.declaredSources);
+        const currentDeclaredTables = applyDeclaredProjectionDeltaToSnapshots(existingDeclaredTables, declaredDelta);
+        updateProjectionDatabase(projectionPath, {
+          deleteTaskIds: [],
+          upsertTaskRows: [],
+          deleteDecisionIds: [],
+          upsertDecisionRows: [],
+          meta: {
+            ...existing.meta,
+            sourceHash: snapshot.fingerprint,
+            declaredRowsHash: hashDeclaredProjectionSnapshots(currentDeclaredTables),
+            declaredManifestHash: hashDeclaredSourceManifestRows(declaredDelta.manifest.currentRows)
+          },
+          declaredDelta,
+          taskFieldExtensions: options.taskFieldExtensions
+        });
+        rememberProjectionValidation(projectionPath, declaredDelta.manifest.currentRows);
+        warnings.push(warning(
+          "generated-cache",
+          "projection_stale",
+          "Declared entity projection changes were refreshed incrementally.",
+          "No full projection rebuild is required for isolated session, execution, or review changes."
+        ));
+        return { rows: [...existing.rows].sort(compareRows), warnings };
+      } catch {
+        // Fall through to the safe full rebuild when the manifest delta cannot be proven.
+      }
+    }
+    warnings.push(warning(
+      "generated-cache",
+      "projection_stale",
+      "Projection cache was stale and has been rebuilt from markdown.",
+      "Run harness-anything governance rebuild after authored task changes or merges."
+    ));
+    const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
+    return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
+  }
+
+  if (!cachedValidation) rememberProjectionValidation(projectionPath, declaredManifest);
+
   return {
     rows: [...existing.rows].sort(compareRows),
     warnings
   };
 }
 
-function readDeclaredRowsHash(projectionPath: string): string | null {
-  try {
-    return hashDeclaredProjectionSnapshots(readDeclaredProjectionSnapshots(projectionPath));
-  } catch {
-    return null;
+function readCachedProjectionValidation(projectionPath: string): ProjectionValidationCacheEntry | null {
+  const cached = projectionValidationCache.get(projectionPath);
+  if (!cached || localProjectionSourceFileSystem.statSignature(projectionPath) !== cached.signature) return null;
+  projectionValidationCache.delete(projectionPath);
+  projectionValidationCache.set(projectionPath, cached);
+  return cached;
+}
+
+function rememberProjectionValidation(
+  projectionPath: string,
+  declaredManifest: ReturnType<typeof readDeclaredSourceManifestRows>
+): void {
+  const signature = localProjectionSourceFileSystem.statSignature(projectionPath);
+  if (signature === null) return;
+  projectionValidationCache.delete(projectionPath);
+  projectionValidationCache.set(projectionPath, { signature, declaredManifest });
+  while (projectionValidationCache.size > projectionValidationCacheLimit) {
+    const oldest = projectionValidationCache.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    projectionValidationCache.delete(oldest);
   }
 }
 

--- a/packages/kernel/src/projection/sqlite-task-source.ts
+++ b/packages/kernel/src/projection/sqlite-task-source.ts
@@ -97,7 +97,8 @@ function createMarkdownSourceCacheEntry(
 }
 
 function markdownSourceCacheEntryMatches(entry: MarkdownSourceCacheEntry): boolean {
-  return cachedPathSignaturesMatch(entry.fileSignatures) && cachedPathSignaturesMatch(entry.directorySignatures);
+  const signatures = new Map([...entry.directorySignatures, ...entry.fileSignatures]);
+  return cachedPathSignaturesMatch(signatures) && cachedPathSignaturesMatch(signatures);
 }
 
 function capturePathSignatures(paths: Iterable<string>): ReadonlyMap<string, string> | null {

--- a/packages/kernel/src/projection/sqlite-task-source.ts
+++ b/packages/kernel/src/projection/sqlite-task-source.ts
@@ -5,6 +5,7 @@ import { isDomainStatus, isPackageDisposition, isPriorityTier, isTaskWorkKind, i
 import { sha256Text } from "../integrity/stable-hash.ts";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
+import { localProjectionSourceFileSystem } from "../local/local-layout-file-system.ts";
 import { readFrontmatter, readScalar } from "../markdown/frontmatter.ts";
 import {
   deriveRelationTaskAuthoredSources,
@@ -15,17 +16,131 @@ import type { ProjectionCanonicalStatus, CoordinationStatus, ProjectionWarning, 
 import { unresolvedEntityAttribution } from "./entity-attribution-projection.ts";
 import { readDirIfPresent, readDirNamesIfPresent, readTextFileIfPresent, statPathIfPresent } from "./toctou-safe-fs.ts";
 
+interface MarkdownSourceCacheEntry {
+  readonly result: ReturnType<typeof markdownSourceResult>;
+  readonly fileSignatures: ReadonlyMap<string, string>;
+  readonly directorySignatures: ReadonlyMap<string, string>;
+}
+
+const markdownSourceCache = new Map<string, MarkdownSourceCacheEntry>();
+const markdownSourceCacheLimit = 16;
+
 export function readMarkdownSource(rootInput: HarnessLayoutInput): {
   readonly entries: ReadonlyArray<TaskSourceEntry>;
   readonly hash: string;
   readonly warnings: ReadonlyArray<ProjectionWarning>;
 } {
+  const layout = resolveHarnessLayout(rootInput);
+  const cacheKey = layout.rootDir;
+  const cached = markdownSourceCache.get(cacheKey);
+  if (cached && markdownSourceCacheEntryMatches(cached)) {
+    markdownSourceCache.delete(cacheKey);
+    markdownSourceCache.set(cacheKey, cached);
+    return cached.result;
+  }
   const source = readTaskProjectionSource(rootInput);
+  const result = markdownSourceResult(source);
+  const cacheEntry = createMarkdownSourceCacheEntry(layout, source, result);
+  markdownSourceCache.delete(cacheKey);
+  if (cacheEntry) {
+    markdownSourceCache.set(cacheKey, cacheEntry);
+    while (markdownSourceCache.size > markdownSourceCacheLimit) {
+      const oldest = markdownSourceCache.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      markdownSourceCache.delete(oldest);
+    }
+  }
+  return result;
+}
+
+function markdownSourceResult(source: ReturnType<typeof readTaskProjectionSource>): {
+  readonly entries: ReadonlyArray<TaskSourceEntry>;
+  readonly hash: string;
+  readonly warnings: ReadonlyArray<ProjectionWarning>;
+} {
   return {
     entries: source.entries,
     hash: hashText(JSON.stringify(source.sourceInputs)),
     warnings: source.warnings
   };
+}
+
+function createMarkdownSourceCacheEntry(
+  layout: ReturnType<typeof resolveHarnessLayout>,
+  source: ReturnType<typeof readTaskProjectionSource>,
+  result: ReturnType<typeof markdownSourceResult>
+): MarkdownSourceCacheEntry | null {
+  const files = new Map(source.sourceInputs.map((input) => [
+    path.join(layout.rootDir, input.sourcePath),
+    input.body
+  ]));
+  const directories = new Set([
+    layout.authoredRoot,
+    layout.tasksRoot,
+    layout.decisionsRoot,
+    ...source.entries.map((entry) => path.dirname(entry.indexPath)),
+    ...[...files.keys()].map(path.dirname),
+    ...listSourceDirectoryPaths(layout.decisionsRoot)
+  ]);
+  const beforeFiles = capturePathSignatures(files.keys());
+  const beforeDirectories = captureExistingPathSignatures(directories);
+  if (beforeFiles === null) return null;
+  for (const [filePath, body] of files) {
+    if (readTextFileIfPresent(filePath) !== body) return null;
+  }
+  const afterFiles = capturePathSignatures(files.keys());
+  const afterDirectories = captureExistingPathSignatures(directories);
+  if (afterFiles === null ||
+      !samePathSignatures(beforeFiles, afterFiles) ||
+      !samePathSignatures(beforeDirectories, afterDirectories)) return null;
+  return { result, fileSignatures: afterFiles, directorySignatures: afterDirectories };
+}
+
+function markdownSourceCacheEntryMatches(entry: MarkdownSourceCacheEntry): boolean {
+  return cachedPathSignaturesMatch(entry.fileSignatures) && cachedPathSignaturesMatch(entry.directorySignatures);
+}
+
+function capturePathSignatures(paths: Iterable<string>): ReadonlyMap<string, string> | null {
+  const signatures = new Map<string, string>();
+  for (const filePath of new Set(paths)) {
+    const signature = localProjectionSourceFileSystem.statSignature(filePath);
+    if (signature === null) return null;
+    signatures.set(filePath, signature);
+  }
+  return signatures;
+}
+
+function captureExistingPathSignatures(paths: Iterable<string>): ReadonlyMap<string, string> {
+  const signatures = new Map<string, string>();
+  for (const filePath of new Set(paths)) {
+    const signature = localProjectionSourceFileSystem.statSignature(filePath);
+    if (signature !== null) signatures.set(filePath, signature);
+  }
+  return signatures;
+}
+
+function cachedPathSignaturesMatch(signatures: ReadonlyMap<string, string>): boolean {
+  for (const [filePath, expected] of signatures) {
+    if (localProjectionSourceFileSystem.statSignature(filePath) !== expected) return false;
+  }
+  return true;
+}
+
+function samePathSignatures(
+  left: ReadonlyMap<string, string>,
+  right: ReadonlyMap<string, string>
+): boolean {
+  return left.size === right.size && [...left].every(([filePath, signature]) => right.get(filePath) === signature);
+}
+
+function listSourceDirectoryPaths(rootPath: string): ReadonlyArray<string> {
+  const stat = statPathIfPresent(rootPath);
+  if (!stat?.isDirectory()) return [];
+  const entries = readDirIfPresent(rootPath);
+  if (entries === null) return [];
+  return [rootPath, ...entries
+    .filter((entry) => entry.isDirectory() && entry.name !== ".git" && entry.name !== "node_modules")
+    .flatMap((entry) => listSourceDirectoryPaths(path.join(rootPath, entry.name)))];
 }
 
 export function readTaskProjectionSourceHashInputs(rootInput: HarnessLayoutInput): ReadonlyArray<TaskProjectionSourceHashInput> {

--- a/packages/kernel/src/projection/types.ts
+++ b/packages/kernel/src/projection/types.ts
@@ -184,4 +184,5 @@ export interface ProjectionMeta {
   readonly sourceHash: string;
   readonly rowsHash: string;
   readonly decisionRowsHash?: string;
+  readonly declaredRowsHash?: string;
 }

--- a/packages/kernel/src/projection/types.ts
+++ b/packages/kernel/src/projection/types.ts
@@ -185,4 +185,9 @@ export interface ProjectionMeta {
   readonly rowsHash: string;
   readonly decisionRowsHash?: string;
   readonly declaredRowsHash?: string;
+  readonly declaredManifestHash?: string;
+  readonly attributionRowsHash?: string;
+  readonly attributionSourceHash?: string;
+  readonly taskSourceHash?: string;
+  readonly legacyPersonIdsHash?: string;
 }

--- a/packages/kernel/src/store/ledger-materializer.ts
+++ b/packages/kernel/src/store/ledger-materializer.ts
@@ -5,7 +5,7 @@ import type { VersionControlSystem } from "../ports/version-control-system.ts";
 import { updateTaskProjectionIncrementally } from "../projection/sqlite-task-incremental-projection.ts";
 import { materializeAttributionProjection } from "../projection/sqlite-attribution-projection.ts";
 import { rebuildTaskProjection } from "../projection/sqlite-task-projection.ts";
-import { captureProjectionSourceSnapshot } from "../projection/projection-source-snapshot.ts";
+import { captureAuthoredProjectionFingerprint } from "../projection/projection-source-baseline.ts";
 import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
 import { resolveTrunkBranch } from "./write-journal-git.ts";
 import { withRepoLocks } from "./write-journal-locks.ts";
@@ -65,7 +65,7 @@ function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dr
   const warnings: string[] = [];
   let merged = 0;
   let processed = 0;
-  const projectionSourceFingerprintBeforeMerge = captureProjectionSourceSnapshot(rootInput).fingerprint;
+  const projectionSourceFingerprintBeforeMerge = captureAuthoredProjectionFingerprint(rootInput);
   const touchedPaths = new Set<string>();
 
   const trunkBranch = resolveTrunkBranch(repoRoot, undefined, vcs);

--- a/packages/kernel/src/store/ledger-materializer.ts
+++ b/packages/kernel/src/store/ledger-materializer.ts
@@ -5,7 +5,7 @@ import type { VersionControlSystem } from "../ports/version-control-system.ts";
 import { updateTaskProjectionIncrementally } from "../projection/sqlite-task-incremental-projection.ts";
 import { materializeAttributionProjection } from "../projection/sqlite-attribution-projection.ts";
 import { rebuildTaskProjection } from "../projection/sqlite-task-projection.ts";
-import { readMarkdownSource } from "../projection/sqlite-task-source.ts";
+import { captureProjectionSourceSnapshot } from "../projection/projection-source-snapshot.ts";
 import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
 import { resolveTrunkBranch } from "./write-journal-git.ts";
 import { withRepoLocks } from "./write-journal-locks.ts";
@@ -65,7 +65,7 @@ function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dr
   const warnings: string[] = [];
   let merged = 0;
   let processed = 0;
-  const projectionSourceHashBeforeMerge = readMarkdownSource(rootInput).hash;
+  const projectionSourceFingerprintBeforeMerge = captureProjectionSourceSnapshot(rootInput).fingerprint;
   const touchedPaths = new Set<string>();
 
   const trunkBranch = resolveTrunkBranch(repoRoot, undefined, vcs);
@@ -126,7 +126,7 @@ function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dr
       rootDir: layout.rootDir,
       ...(typeof rootInput === "object" && rootInput.layoutOverrides ? { layoutOverrides: rootInput.layoutOverrides } : {}),
       touchedPaths: [...touchedPaths],
-      previousSourceHash: projectionSourceHashBeforeMerge
+      previousSourceFingerprint: projectionSourceFingerprintBeforeMerge
     });
   }
 

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -21,7 +21,7 @@ import {
 } from "../layout/index.ts";
 import { updateTaskProjectionIncrementally } from "../projection/sqlite-task-incremental-projection.ts";
 import { hashTaskProjectionRows } from "../projection/sqlite-task-projection.ts";
-import { readMarkdownSource } from "../projection/sqlite-task-source.ts";
+import { captureProjectionSourceSnapshot } from "../projection/projection-source-snapshot.ts";
 import { appendJsonLineDurably, readDurableState, readPayloadRef, writeWatermarkDurably, writeFileDurably } from "./write-journal-durable.ts";
 import { assertCommitPlanAddable, commitTouchedPaths } from "./write-journal-git.ts";
 import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
@@ -291,7 +291,9 @@ function flushRecords(
   }));
 
   assertCommitPlanAddable(rootDir, plannedRecords.flatMap((record) => record.touchedPaths), rootInput, { versionControlSystem });
-  const previousProjectionSourceHash = records.length > 0 ? readMarkdownSource(rootInput).hash : undefined;
+  const previousProjectionSourceFingerprint = records.length > 0
+    ? captureProjectionSourceSnapshot(rootInput).fingerprint
+    : undefined;
 
   for (const { record, touchedPaths: recordTouchedPaths } of plannedRecords) {
     // Ops with a durable apply marker already mutated their file before a crash;
@@ -346,7 +348,7 @@ function flushRecords(
     throw new Error("attribution event durability confirmation failed");
   }
   const projectionHash = committedOpIds.length > 0
-    ? rebuildProjectionHash(rootDir, rootInput, touchedPaths, previousProjectionSourceHash)
+    ? rebuildProjectionHash(rootDir, rootInput, touchedPaths, previousProjectionSourceFingerprint)
     : previousWatermark?.projectionHash ?? "no-projection-change";
   const allCommitted = [...(previousWatermark?.lastCommittedOpIds ?? []), ...committedOpIds];
   const recentCommitted = recentOpIds(allCommitted);
@@ -498,14 +500,14 @@ function rebuildProjectionHash(
   rootDir: string,
   rootInput: HarnessLayoutInput,
   touchedPaths: ReadonlyArray<string>,
-  previousSourceHash: string | undefined
+  previousSourceFingerprint: string | undefined
 ): string {
   const layoutOverrides = typeof rootInput === "string" ? undefined : rootInput.layoutOverrides;
   return hashTaskProjectionRows(updateTaskProjectionIncrementally({
     rootDir,
     layoutOverrides,
     touchedPaths,
-    previousSourceHash
+    previousSourceFingerprint
   }).rows);
 }
 

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -21,7 +21,7 @@ import {
 } from "../layout/index.ts";
 import { updateTaskProjectionIncrementally } from "../projection/sqlite-task-incremental-projection.ts";
 import { hashTaskProjectionRows } from "../projection/sqlite-task-projection.ts";
-import { captureProjectionSourceSnapshot } from "../projection/projection-source-snapshot.ts";
+import { captureAuthoredProjectionFingerprint } from "../projection/projection-source-baseline.ts";
 import { appendJsonLineDurably, readDurableState, readPayloadRef, writeWatermarkDurably, writeFileDurably } from "./write-journal-durable.ts";
 import { assertCommitPlanAddable, commitTouchedPaths } from "./write-journal-git.ts";
 import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
@@ -292,7 +292,7 @@ function flushRecords(
 
   assertCommitPlanAddable(rootDir, plannedRecords.flatMap((record) => record.touchedPaths), rootInput, { versionControlSystem });
   const previousProjectionSourceFingerprint = records.length > 0
-    ? captureProjectionSourceSnapshot(rootInput).fingerprint
+    ? captureAuthoredProjectionFingerprint(rootInput)
     : undefined;
 
   for (const { record, touchedPaths: recordTouchedPaths } of plannedRecords) {

--- a/packages/kernel/test/store/sqlite-incremental-projection.test.ts
+++ b/packages/kernel/test/store/sqlite-incremental-projection.test.ts
@@ -12,8 +12,113 @@ import {
   readTaskProjection,
   rebuildTaskProjection
 } from "../../src/projection/sqlite-task-projection.ts";
+import { readAttributionProjection } from "../../src/projection/sqlite-attribution-projection.ts";
 import { updateTaskProjectionIncrementally } from "../../src/projection/sqlite-task-incremental-projection.ts";
-import { readMarkdownSource } from "../../src/projection/sqlite-task-source.ts";
+import { captureProjectionSourceSnapshot } from "../../src/projection/projection-source-snapshot.ts";
+import {
+  discoverDeclaredEntityProjection,
+  readDeclaredEntitySource
+} from "../../src/projection/entity-declaration-projection.ts";
+import { executionDeclaration } from "../../src/entity/execution-declaration.ts";
+
+test("first task edit after a full rebuild stays incremental", () => {
+  withProjectionPair((rootDir) => {
+    seedHarness(rootDir);
+    rebuildTaskProjection({ rootDir });
+
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPath = writeIndex(rootDir, "task-a", "Task task-a updated", "done", []);
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [touchedPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    const fresh = readTaskProjection({ rootDir });
+    assert.equal(fresh.warnings.some((warning) => warning.code === "projection_stale"), false);
+    assert.equal(fresh.rows.find((row) => row.taskId === "task-a")?.canonicalStatus, "done");
+  });
+});
+
+test("task edit with a new attribution event stays incremental and immediately fresh", () => {
+  withProjectionPair((rootDir) => {
+    seedHarness(rootDir);
+    rebuildTaskProjection({ rootDir });
+
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPath = writeIndex(rootDir, "task-a", "Task task-a attributed", "done", []);
+    writeAttributionEvent(rootDir, "event-incremental", "task/task-a");
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [touchedPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    assert.equal(readAttributionProjection(rootDir).length, 1);
+    const fresh = readTaskProjection({ rootDir });
+    assert.equal(fresh.warnings.some((warning) => warning.code === "projection_stale"), false);
+    assert.equal(fresh.warnings.some((warning) => warning.severity === "hard-fail"), false);
+    assert.equal(fresh.rows.find((row) => row.taskId === "task-a")?.attribution.latestActor?.principal.personId, "person_test");
+  });
+});
+
+test("declared entity discovery follows path templates without crawling unrelated task artifacts", () => {
+  withProjectionPair((rootDir) => {
+    seedHarness(rootDir);
+    let unrelated = path.join(rootDir, "harness/tasks/task-a/artifacts");
+    for (let depth = 0; depth < 50; depth += 1) {
+      unrelated = path.join(unrelated, `level-${depth}`);
+      mkdirSync(unrelated, { recursive: true });
+      writeFileSync(path.join(unrelated, "trace.log"), "unrelated\n", "utf8");
+    }
+
+    const discovered = discoverDeclaredEntityProjection(rootDir, executionDeclaration);
+
+    assert.deepEqual(discovered.rows, []);
+    assert.equal(discovered.stats.directoriesVisited < 10, true, JSON.stringify(discovered.stats));
+  });
+});
+
+test("declared entity source fingerprinting does not decode entity documents", () => {
+  withProjectionPair((rootDir) => {
+    seedHarness(rootDir);
+    const executionPath = path.join(rootDir, "harness/tasks/task-a/executions/exe-malformed.md");
+    mkdirSync(path.dirname(executionPath), { recursive: true });
+    writeFileSync(executionPath, "not valid execution json\n", "utf8");
+
+    const source = readDeclaredEntitySource(rootDir, executionDeclaration);
+
+    assert.equal(source.inputs.length, 1);
+    assert.equal(source.inputs[0]?.relativePath, "tasks/task-a/executions/exe-malformed.md");
+    assert.equal(source.inputs[0]?.body, "not valid execution json\n");
+    assert.throws(() => discoverDeclaredEntityProjection(rootDir, executionDeclaration));
+  });
+});
+
+test("declared entity source cache reuses verified paths and invalidates same-size rewrites", () => {
+  withProjectionPair((rootDir) => {
+    seedHarness(rootDir);
+    const executionPath = path.join(rootDir, "harness/tasks/task-a/executions/exe-cache.md");
+    mkdirSync(path.dirname(executionPath), { recursive: true });
+    writeFileSync(executionPath, "source-a\n", "utf8");
+    const fixedAt = new Date("2026-07-01T00:00:00.000Z");
+    utimesSync(executionPath, fixedAt, fixedAt);
+
+    const first = readDeclaredEntitySource(rootDir, executionDeclaration);
+    const second = readDeclaredEntitySource(rootDir, executionDeclaration);
+    assert.equal(first.stats.cacheHit, false);
+    assert.equal(second.stats.cacheHit, true);
+
+    writeFileSync(executionPath, "source-b\n", "utf8");
+    utimesSync(executionPath, fixedAt, fixedAt);
+    const changed = readDeclaredEntitySource(rootDir, executionDeclaration);
+    assert.equal(changed.stats.cacheHit, false);
+    assert.equal(changed.inputs[0]?.body, "source-b\n");
+    assert.notEqual(changed.hash, first.hash);
+  });
+});
 
 test("incremental projection matches full rebuild across deterministic random write sequences", () => {
   for (const seed of [7, 19, 43, 71]) {
@@ -27,14 +132,14 @@ test("incremental projection matches full rebuild across deterministic random wr
       for (let step = 0; step < 36; step += 1) {
         const operation = Math.floor(random() * 5);
         const taskId = ["task-a", "task-b", "task-c"][Math.floor(random() * 3)] ?? "task-a";
-        const previousSourceHash = readMarkdownSource(incrementalRoot).hash;
+        const previousSourceFingerprint = captureProjectionSourceSnapshot(incrementalRoot).fingerprint;
         const touchedPaths = applyRandomProjectionWrite(incrementalRoot, operation, taskId, step, seed);
         applyRandomProjectionWrite(rebuildRoot, operation, taskId, step, seed);
 
         updateTaskProjectionIncrementally({
           rootDir: incrementalRoot,
           touchedPaths,
-          previousSourceHash
+          previousSourceFingerprint
         });
         rebuildTaskProjection({ rootDir: rebuildRoot });
 
@@ -53,14 +158,14 @@ test("incremental projection upserts task rows when package slug differs from ta
     rebuildTaskProjection({ rootDir: incrementalRoot });
     rebuildTaskProjection({ rootDir: rebuildRoot });
 
-    const previousSourceHash = readMarkdownSource(incrementalRoot).hash;
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(incrementalRoot).fingerprint;
     const touchedPath = writeIndex(incrementalRoot, taskId, "Slugged Task Updated", "done", [], slug);
     writeIndex(rebuildRoot, taskId, "Slugged Task Updated", "done", [], slug);
 
     updateTaskProjectionIncrementally({
       rootDir: incrementalRoot,
       touchedPaths: [touchedPath],
-      previousSourceHash
+      previousSourceFingerprint
     });
     rebuildTaskProjection({ rootDir: rebuildRoot });
 
@@ -96,6 +201,39 @@ function seedHarness(rootDir: string): void {
   }
   writeFacts(rootDir, "task-a", true);
   writeDecision(rootDir, false);
+}
+
+function writeAttributionEvent(rootDir: string, eventId: string, entityId: string): string {
+  const eventRoot = path.join(rootDir, "harness/attribution-events");
+  mkdirSync(eventRoot, { recursive: true });
+  const eventPath = path.join(eventRoot, `${eventId}.jsonl`);
+  writeFileSync(eventPath, `${JSON.stringify({
+    schema: "attribution-event/v1",
+    eventId,
+    opId: `op-${eventId}`,
+    journalRecordSchema: "write-journal/v2",
+    entityId,
+    kind: "progress_append",
+    actor: {
+      principal: { kind: "person", personId: "person_test" },
+      executor: { kind: "agent", id: "agent_test" }
+    },
+    principalSource: {
+      kind: "local-configured",
+      authority: "harness.yaml",
+      authoritySha256: `sha256:${"0".repeat(64)}`
+    },
+    executorSource: "client-asserted",
+    at: "2026-07-07T00:00:00.000Z",
+    recordedAt: "2026-07-07T00:00:01.000Z",
+    payloadHash: `sha256:${"1".repeat(64)}`,
+    payloadRef: {
+      path: `.harness/payloads/${eventId}.json`,
+      sha256: `sha256:${"1".repeat(64)}`
+    }
+  })}\n`, "utf8");
+  stamp(eventPath);
+  return eventPath;
 }
 
 function applyRandomProjectionWrite(rootDir: string, operation: number, taskId: string, step: number, seed: number): ReadonlyArray<string> {

--- a/packages/kernel/test/store/sqlite-incremental-projection.test.ts
+++ b/packages/kernel/test/store/sqlite-incremental-projection.test.ts
@@ -1,9 +1,11 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { deriveRelationId, formatRelationFlowRecord } from "../../src/domain/index.ts";
 import type { EntityRelationRecord } from "../../src/domain/index.ts";
 import {
@@ -117,6 +119,176 @@ test("declared entity source cache reuses verified paths and invalidates same-si
     assert.equal(changed.stats.cacheHit, false);
     assert.equal(changed.inputs[0]?.body, "source-b\n");
     assert.notEqual(changed.hash, first.hash);
+  });
+});
+
+test("single execution changes update a persisted source manifest without rebuilding the declared table", () => {
+  withProjectionPair((rootDir) => {
+    seedHarness(rootDir);
+    const taskId = "task_00000000000000000000000001";
+    writeIndex(rootDir, taskId, "Execution manifest task", "active", []);
+    const changedPath = writeExecution(rootDir, taskId, "exe_00000000000000000000000001", "submitted");
+    writeExecution(rootDir, taskId, "exe_00000000000000000000000002", "submitted");
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const db = new DatabaseSync(projectionPath);
+    try {
+      const manifestRows = db.prepare("SELECT source_path, primary_key FROM declared_source_manifest ORDER BY source_path").all();
+      assert.equal(manifestRows.length, 2);
+      db.exec(`
+        CREATE TRIGGER preserve_execution_projection_table
+        BEFORE DELETE ON execution_projection
+        WHEN OLD.execution_id = 'exe_00000000000000000000000002'
+        BEGIN SELECT RAISE(ABORT, 'untouched execution deleted'); END
+      `);
+      db.exec(`
+        CREATE TRIGGER reject_unnecessary_task_upsert
+        BEFORE INSERT ON task_projection
+        WHEN NEW.task_id = '${taskId}'
+        BEGIN SELECT RAISE(ABORT, 'execution update rewrote task row'); END
+      `);
+    } finally {
+      db.close();
+    }
+
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    writeExecution(rootDir, taskId, "exe_00000000000000000000000001", "accepted");
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [changedPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    const updated = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      assert.equal(updated.prepare("SELECT state FROM execution_projection WHERE execution_id = ?")
+        .get("exe_00000000000000000000000001")?.state, "accepted");
+      assert.equal(updated.prepare("SELECT COUNT(*) AS count FROM execution_projection").get()?.count, 2);
+      assert.equal(updated.prepare("SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'trigger' AND name = 'preserve_execution_projection_table'").get()?.count, 1);
+      assert.equal(updated.prepare("SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'trigger' AND name = 'reject_unnecessary_task_upsert'").get()?.count, 1);
+      assert.equal(updated.prepare("SELECT COUNT(*) AS count FROM declared_source_manifest").get()?.count, 2);
+    } finally {
+      updated.close();
+    }
+  });
+});
+
+test("fresh processes reuse persisted declared content hashes without reading unchanged bodies", () => {
+  withProjectionPair((rootDir) => {
+    seedHarness(rootDir);
+    const taskId = "task_00000000000000000000000001";
+    writeIndex(rootDir, taskId, "Fresh process manifest task", "active", []);
+    writeExecution(rootDir, taskId, "exe_00000000000000000000000001", "submitted");
+    writeExecution(rootDir, taskId, "exe_00000000000000000000000002", "submitted");
+    rebuildTaskProjection({ rootDir });
+
+    const child = spawnSync(process.execPath, ["--input-type=module", "-e", freshProjectionManifestReaderScript], {
+      cwd: process.cwd(),
+      env: { ...process.env, HARNESS_ROOT: rootDir },
+      encoding: "utf8"
+    });
+
+    assert.equal(child.status, 0, child.stderr);
+    assert.deepEqual(JSON.parse(child.stdout.trim()), {
+      inputs: 2,
+      bodiesRead: 0
+    });
+  });
+});
+
+test("deleted executions remove only their projection row and manifest entry", () => {
+  withProjectionPair((rootDir) => {
+    seedHarness(rootDir);
+    const taskId = "task_00000000000000000000000001";
+    writeIndex(rootDir, taskId, "Execution deletion task", "active", []);
+    const deletedPath = writeExecution(rootDir, taskId, "exe_00000000000000000000000001", "submitted");
+    writeExecution(rootDir, taskId, "exe_00000000000000000000000002", "submitted");
+    rebuildTaskProjection({ rootDir });
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    rmSync(deletedPath);
+
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [deletedPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    const db = new DatabaseSync(path.join(rootDir, ".harness/cache/projections.sqlite"), { readOnly: true });
+    try {
+      assert.equal(db.prepare("SELECT COUNT(*) AS count FROM execution_projection").get()?.count, 1);
+      assert.equal(db.prepare("SELECT COUNT(*) AS count FROM declared_source_manifest").get()?.count, 1);
+      assert.equal(db.prepare("SELECT execution_id FROM execution_projection").get()?.execution_id, "exe_00000000000000000000000002");
+    } finally {
+      db.close();
+    }
+  });
+});
+
+test("metadata-only execution touches update the manifest without rewriting projection rows", () => {
+  withProjectionPair((rootDir) => {
+    seedHarness(rootDir);
+    const taskId = "task_00000000000000000000000001";
+    const executionId = "exe_00000000000000000000000001";
+    writeIndex(rootDir, taskId, "Execution metadata task", "active", []);
+    const executionPath = writeExecution(rootDir, taskId, executionId, "submitted");
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const before = new DatabaseSync(projectionPath);
+    let previousStatSignature: string;
+    try {
+      previousStatSignature = String(before.prepare("SELECT stat_signature FROM declared_source_manifest").get()?.stat_signature);
+      before.exec(`
+        CREATE TRIGGER reject_metadata_only_execution_upsert
+        BEFORE INSERT ON execution_projection
+        WHEN NEW.execution_id = '${executionId}'
+        BEGIN SELECT RAISE(ABORT, 'metadata-only touch rewrote execution row'); END
+      `);
+    } finally {
+      before.close();
+    }
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedAt = new Date("2026-07-13T12:34:56.000Z");
+    utimesSync(executionPath, touchedAt, touchedAt);
+
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [executionPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    const after = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      assert.notEqual(after.prepare("SELECT stat_signature FROM declared_source_manifest").get()?.stat_signature, previousStatSignature);
+      assert.equal(after.prepare("SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'trigger' AND name = 'reject_metadata_only_execution_upsert'").get()?.count, 1);
+      assert.equal(after.prepare("SELECT state FROM execution_projection WHERE execution_id = ?").get(executionId)?.state, "submitted");
+    } finally {
+      after.close();
+    }
+  });
+});
+
+test("deleted attribution events clear stale projected attribution", () => {
+  withProjectionPair((rootDir) => {
+    seedHarness(rootDir);
+    const eventPath = writeAttributionEvent(rootDir, "event-delete", "task/task-a");
+    rebuildTaskProjection({ rootDir });
+    assert.equal(readTaskProjection({ rootDir }).rows.find((row) => row.taskId === "task-a")?.attribution.completeness, "complete");
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    rmSync(eventPath);
+
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [eventPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    assert.equal(readAttributionProjection(rootDir).length, 0);
+    const refreshed = readTaskProjection({ rootDir });
+    assert.equal(refreshed.rows.find((row) => row.taskId === "task-a")?.attribution.completeness, "unresolved");
   });
 });
 
@@ -234,6 +406,31 @@ function writeAttributionEvent(rootDir: string, eventId: string, entityId: strin
   })}\n`, "utf8");
   stamp(eventPath);
   return eventPath;
+}
+
+function writeExecution(rootDir: string, taskId: string, executionId: string, state: "submitted" | "accepted"): string {
+  const executionRoot = path.join(rootDir, "harness/tasks", taskId, "executions");
+  mkdirSync(executionRoot, { recursive: true });
+  const executionPath = path.join(executionRoot, `${executionId}.md`);
+  writeFileSync(executionPath, `${JSON.stringify({
+    schema: "execution/v2",
+    execution_id: executionId,
+    task_ref: `task/${taskId}`,
+    state,
+    primary_actor: {
+      principal: { personId: "person_test" },
+      executor: { kind: "agent", id: "agent_test" },
+      responsibleHuman: "person_test"
+    },
+    claimed_at: "2026-07-13T00:00:00.000Z",
+    submitted_at: "2026-07-13T00:01:00.000Z",
+    closed_at: null,
+    session_bindings: [],
+    outputs: [],
+    submission: null
+  }, null, 2)}\n`, "utf8");
+  stamp(executionPath);
+  return executionPath;
 }
 
 function applyRandomProjectionWrite(rootDir: string, operation: number, taskId: string, step: number, seed: number): ReadonlyArray<string> {
@@ -427,3 +624,16 @@ function stamp(filePath: string): void {
   const fixed = new Date("2026-07-07T00:00:00.000Z");
   utimesSync(filePath, fixed, fixed);
 }
+
+const freshProjectionManifestReaderScript = `
+import { readDeclaredSourceManifestRows } from "./packages/kernel/src/projection/sqlite-declared-source-manifest.ts";
+import { captureProjectionSourceFingerprint } from "./packages/kernel/src/projection/projection-source-snapshot.ts";
+const rootDir = process.env.HARNESS_ROOT;
+const manifest = readDeclaredSourceManifestRows(rootDir + "/.harness/cache/projections.sqlite");
+const snapshot = captureProjectionSourceFingerprint(rootDir, manifest);
+const inputs = snapshot.declaredSources.flatMap((source) => source.source.inputs);
+process.stdout.write(JSON.stringify({
+  inputs: inputs.length,
+  bodiesRead: inputs.filter((input) => input.body !== undefined).length
+}));
+`;

--- a/packages/kernel/test/store/sqlite-projection-atomicity.test.ts
+++ b/packages/kernel/test/store/sqlite-projection-atomicity.test.ts
@@ -6,8 +6,15 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
-import { rebuildTaskProjection } from "../../src/index.ts";
-import { withTempStoreAsync } from "./helpers.ts";
+import { executionDeclaration } from "../../src/entity/execution-declaration.ts";
+import {
+  readAttributionEventSource,
+  readAttributionEventsFromSource
+} from "../../src/local/attribution-event-source.ts";
+import { localProjectionSourceFileSystem } from "../../src/local/local-layout-file-system.ts";
+import { readDeclaredEntitySource } from "../../src/projection/entity-declaration-projection.ts";
+import { readTaskProjection, rebuildTaskProjection } from "../../src/index.ts";
+import { withTempStore, withTempStoreAsync } from "./helpers.ts";
 
 test("SQLite full rebuild atomically publishes complete declared entity generations", async () => {
   await withTempStoreAsync(async (rootDir) => {
@@ -57,6 +64,177 @@ test("SQLite full rebuild atomically publishes complete declared entity generati
     assert.deepEqual(result, { reads: result.reads, failures: 0, partial: 0 });
   });
 });
+
+test("task cache rejects a concurrent rewrite between signature passes", () => {
+  withTempStore((rootDir) => {
+    const taskPath = writeCacheTask(rootDir, "Task A");
+    rebuildTaskProjection({ rootDir });
+    const originalStatSignature = localProjectionSourceFileSystem.statSignature;
+    let mutated = false;
+    localProjectionSourceFileSystem.statSignature = (inputPath) => {
+      const signature = originalStatSignature(inputPath);
+      if (!mutated && inputPath === taskPath) {
+        mutated = true;
+        writeCacheTask(rootDir, "Task B");
+      }
+      return signature;
+    };
+    let result: ReturnType<typeof readTaskProjection>;
+    try {
+      result = readTaskProjection({ rootDir });
+    } finally {
+      localProjectionSourceFileSystem.statSignature = originalStatSignature;
+    }
+
+    assert.equal(mutated, true);
+    assert.equal(result.rows[0]?.title, "Task B");
+    assert.equal(result.warnings.some((warning) => warning.code === "projection_stale"), true);
+  });
+});
+
+test("declared source cache rejects a concurrent rewrite between signature passes", () => {
+  withTempStore((rootDir) => {
+    const executionPath = writeCacheExecution(rootDir, "submitted");
+    readDeclaredEntitySource(rootDir, executionDeclaration);
+    assert.equal(readDeclaredEntitySource(rootDir, executionDeclaration).stats.cacheHit, true);
+    const originalStatSignature = localProjectionSourceFileSystem.statSignature;
+    let mutated = false;
+    localProjectionSourceFileSystem.statSignature = (inputPath) => {
+      const signature = originalStatSignature(inputPath);
+      if (!mutated && inputPath === executionPath) {
+        mutated = true;
+        writeCacheExecution(rootDir, "accepted");
+      }
+      return signature;
+    };
+    let source: ReturnType<typeof readDeclaredEntitySource>;
+    try {
+      source = readDeclaredEntitySource(rootDir, executionDeclaration);
+    } finally {
+      localProjectionSourceFileSystem.statSignature = originalStatSignature;
+    }
+
+    assert.equal(mutated, true);
+    assert.equal(source.stats.cacheHit, false);
+    assert.match(source.inputs[0]?.body ?? "", /"state": "accepted"/u);
+  });
+});
+
+test("attribution cache rejects a concurrent rewrite between signature passes", () => {
+  withTempStore((rootDir) => {
+    const eventPath = writeCacheAttribution(rootDir, "person_alpha");
+    readAttributionEventSource(rootDir);
+    const originalStatSignature = localProjectionSourceFileSystem.statSignature;
+    let mutated = false;
+    localProjectionSourceFileSystem.statSignature = (inputPath) => {
+      const signature = originalStatSignature(inputPath);
+      if (!mutated && inputPath === eventPath) {
+        mutated = true;
+        writeCacheAttribution(rootDir, "person_bravo");
+      }
+      return signature;
+    };
+    let source: ReturnType<typeof readAttributionEventSource>;
+    try {
+      source = readAttributionEventSource(rootDir);
+    } finally {
+      localProjectionSourceFileSystem.statSignature = originalStatSignature;
+    }
+
+    assert.equal(mutated, true);
+    assert.equal(
+      readAttributionEventsFromSource(source)[0]?.actor.principal.personId,
+      "person_bravo"
+    );
+  });
+});
+
+function writeCacheTask(rootDir: string, title: "Task A" | "Task B"): string {
+  const taskId = "task_01J00000000000000000000001";
+  const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+  mkdirSync(taskRoot, { recursive: true });
+  const taskPath = path.join(taskRoot, "INDEX.md");
+  writeFileSync(taskPath, [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    `title: ${title}`,
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    "  status: active",
+    "  ref: ",
+    `  titleSnapshot: ${title}`,
+    "  url: ",
+    "  bindingCreatedAt: 2026-07-13T00:00:00.000Z",
+    "  bindingFingerprint: sha256:fixture",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "---",
+    "",
+    `# ${title}`,
+    ""
+  ].join("\n"));
+  return taskPath;
+}
+
+function writeCacheExecution(rootDir: string, state: "submitted" | "accepted"): string {
+  const taskId = "task_01J00000000000000000000001";
+  const executionId = "exe_01J00000000000000000000001";
+  const executionPath = path.join(rootDir, "harness/tasks", taskId, "executions", `${executionId}.md`);
+  mkdirSync(path.dirname(executionPath), { recursive: true });
+  writeFileSync(executionPath, `${JSON.stringify({
+    schema: "execution/v2",
+    execution_id: executionId,
+    task_ref: `task/${taskId}`,
+    state,
+    primary_actor: {
+      principal: { personId: "person_cache" },
+      executor: { kind: "agent", id: "agent_cache" },
+      responsibleHuman: "person_cache"
+    },
+    claimed_at: "2026-07-13T00:00:00.000Z",
+    submitted_at: "2026-07-13T00:01:00.000Z",
+    closed_at: null,
+    session_bindings: [],
+    outputs: [],
+    submission: null
+  }, null, 2)}\n`);
+  return executionPath;
+}
+
+function writeCacheAttribution(rootDir: string, personId: "person_alpha" | "person_bravo"): string {
+  const eventRoot = path.join(rootDir, "harness/attribution-events");
+  mkdirSync(eventRoot, { recursive: true });
+  const eventPath = path.join(eventRoot, "event-cache-race.jsonl");
+  writeFileSync(eventPath, `${JSON.stringify({
+    schema: "attribution-event/v1",
+    eventId: "event-cache-race",
+    opId: "op-event-cache-race",
+    journalRecordSchema: "write-journal/v2",
+    entityId: "task/task-cache",
+    kind: "progress_append",
+    actor: {
+      principal: { kind: "person", personId },
+      executor: { kind: "agent", id: "agent_cache" }
+    },
+    principalSource: {
+      kind: "local-configured",
+      authority: "harness.yaml",
+      authoritySha256: `sha256:${"0".repeat(64)}`
+    },
+    executorSource: "client-asserted",
+    at: "2026-07-13T00:00:00.000Z",
+    recordedAt: "2026-07-13T00:00:01.000Z",
+    payloadHash: `sha256:${"1".repeat(64)}`,
+    payloadRef: {
+      path: ".harness/payloads/event-cache-race.json",
+      sha256: `sha256:${"1".repeat(64)}`
+    }
+  })}\n`);
+  return eventPath;
+}
 
 function seedAtomicProjectionTask(rootDir: string, executionCount: number): string {
   const taskId = "task_01J00000000000000000000000";

--- a/packages/kernel/test/store/sqlite-projection-atomicity.test.ts
+++ b/packages/kernel/test/store/sqlite-projection-atomicity.test.ts
@@ -1,0 +1,174 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { rebuildTaskProjection } from "../../src/index.ts";
+import { withTempStoreAsync } from "./helpers.ts";
+
+test("SQLite full rebuild atomically publishes complete declared entity generations", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const executionPath = seedAtomicProjectionTask(rootDir, 250);
+    const template = JSON.parse(readFileSync(executionPath, "utf8")) as Record<string, unknown>;
+    rebuildTaskProjection({ rootDir });
+
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const sourceHashes = new Map<string, string>();
+    sourceHashes.set("submitted", readAtomicMetaValue(projectionPath, "sourceHash"));
+    writeAtomicExecutionState(executionPath, template, "accepted");
+    rebuildTaskProjection({ rootDir });
+    sourceHashes.set("accepted", readAtomicMetaValue(projectionPath, "sourceHash"));
+    writeAtomicExecutionState(executionPath, template, "submitted");
+    rebuildTaskProjection({ rootDir });
+
+    const reader = spawn(process.execPath, ["--input-type=module", "-e", atomicProjectionReaderScript], {
+      env: {
+        ...process.env,
+        HARNESS_PROJECTION_PATH: projectionPath,
+        HARNESS_EXPECTED_EXECUTIONS: "250",
+        HARNESS_EXPECTED_GENERATIONS: JSON.stringify([...sourceHashes])
+      },
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    let stdout = "";
+    let stderr = "";
+    reader.stdout.setEncoding("utf8");
+    reader.stderr.setEncoding("utf8");
+    reader.stdout.on("data", (chunk: string) => { stdout += chunk; });
+    reader.stderr.on("data", (chunk: string) => { stderr += chunk; });
+    await waitForAtomicReader(() => stdout.includes("READY\n"));
+
+    for (let iteration = 0; iteration < 8; iteration += 1) {
+      writeAtomicExecutionState(executionPath, template, iteration % 2 === 0 ? "accepted" : "submitted");
+      rebuildTaskProjection({ rootDir });
+    }
+
+    const [exitCode] = await once(reader, "close") as [number];
+    assert.equal(exitCode, 0, stderr);
+    const result = JSON.parse(stdout.trim().split("\n").at(-1)!) as {
+      readonly reads: number;
+      readonly failures: number;
+      readonly partial: number;
+    };
+    assert.equal(result.reads > 0, true);
+    assert.deepEqual(result, { reads: result.reads, failures: 0, partial: 0 });
+  });
+});
+
+function seedAtomicProjectionTask(rootDir: string, executionCount: number): string {
+  const taskId = "task_01J00000000000000000000000";
+  const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+  const executionRoot = path.join(taskRoot, "executions");
+  mkdirSync(executionRoot, { recursive: true });
+  writeFileSync(path.join(taskRoot, "INDEX.md"), [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    "title: Atomic projection",
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    "  status: in_review",
+    "  ref: ",
+    "  titleSnapshot: Atomic projection",
+    "  url: ",
+    "  bindingCreatedAt: 2026-07-11T00:00:00.000Z",
+    "  bindingFingerprint: sha256:fixture",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "---",
+    "",
+    "# Atomic projection",
+    ""
+  ].join("\n"));
+  const template = {
+    schema: "execution/v2",
+    execution_id: "exe_01J00000000000000000000000",
+    task_ref: `task/${taskId}`,
+    state: "submitted",
+    primary_actor: {
+      principal: { personId: "person:test" },
+      executor: { kind: "agent", id: "agent:test" },
+      responsibleHuman: "person:test"
+    },
+    claimed_at: "2026-07-11T01:00:00.000Z",
+    submitted_at: "2026-07-11T01:10:00.000Z",
+    closed_at: null,
+    session_bindings: [],
+    outputs: [],
+    submission: {
+      completion_claim: "ready",
+      deliverables: [],
+      evidence_refs: [],
+      verification_notes: [],
+      known_gaps: [],
+      residual_risks: []
+    }
+  };
+  for (let index = 0; index < executionCount; index += 1) {
+    const executionId = index === 0 ? template.execution_id : `exe_${String(index).padStart(26, "0")}`;
+    writeFileSync(path.join(executionRoot, `${executionId}.md`), `${JSON.stringify({
+      ...template,
+      execution_id: executionId
+    }, null, 2)}\n`);
+  }
+  return path.join(executionRoot, `${template.execution_id}.md`);
+}
+
+function writeAtomicExecutionState(
+  executionPath: string,
+  template: Readonly<Record<string, unknown>>,
+  state: "submitted" | "accepted"
+): void {
+  writeFileSync(executionPath, `${JSON.stringify({ ...template, state }, null, 2)}\n`);
+}
+
+function readAtomicMetaValue(projectionPath: string, key: string): string {
+  const db = new DatabaseSync(projectionPath, { readOnly: true });
+  try {
+    return String(db.prepare("SELECT value FROM projection_meta WHERE key = ?").get(key)?.value);
+  } finally {
+    db.close();
+  }
+}
+
+async function waitForAtomicReader(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("timed out waiting for projection reader");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+const atomicProjectionReaderScript = `
+import { DatabaseSync } from "node:sqlite";
+const projectionPath = process.env.HARNESS_PROJECTION_PATH;
+const expected = Number(process.env.HARNESS_EXPECTED_EXECUTIONS);
+const expectedGenerations = new Map(JSON.parse(process.env.HARNESS_EXPECTED_GENERATIONS));
+let reads = 0;
+let failures = 0;
+let partial = 0;
+process.stdout.write("READY\\n");
+const deadline = Date.now() + 4_000;
+while (Date.now() < deadline) {
+  let db;
+  try {
+    db = new DatabaseSync(projectionPath, { readOnly: true });
+    const row = db.prepare("SELECT COUNT(*) AS count FROM execution_projection").get();
+    const meta = db.prepare("SELECT value FROM projection_meta WHERE key = 'declaredRowsHash'").get();
+    const source = db.prepare("SELECT value FROM projection_meta WHERE key = 'sourceHash'").get();
+    const execution = db.prepare("SELECT state FROM execution_projection WHERE execution_id = 'exe_01J00000000000000000000000'").get();
+    reads += 1;
+    if (Number(row.count) !== expected || typeof meta?.value !== "string" || meta.value.length === 0 || expectedGenerations.get(execution?.state) !== source?.value) partial += 1;
+  } catch {
+    failures += 1;
+  } finally {
+    db?.close();
+  }
+}
+process.stdout.write(JSON.stringify({ reads, failures, partial }) + "\\n");
+`;

--- a/packages/kernel/test/store/sqlite-projection-integrity.test.ts
+++ b/packages/kernel/test/store/sqlite-projection-integrity.test.ts
@@ -1,9 +1,11 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
+import { readAttributionEventSource } from "../../src/local/attribution-event-source.ts";
+import { localProjectionSourceFileSystem } from "../../src/local/local-layout-file-system.ts";
 import {
   queryDecisionProjection,
   readTaskProjection,
@@ -188,6 +190,97 @@ test("declared entity path identity must match the document identity", () => {
     writeFileSync(executionPath, `${JSON.stringify(mismatched)}\n`);
 
     assert.throws(() => rebuildTaskProjection({ rootDir }), /path identity .* does not match projected identity/u);
+  });
+});
+
+test("attribution source cache reuses unchanged bodies and reloads only a changed shard", () => {
+  withTempStore((rootDir) => {
+    for (let index = 0; index < 5; index += 1) {
+      writeIntegrityAttribution(rootDir, `event-cache-${index}`, "task/task-a", "progress_append");
+    }
+    const originalReadStableText = localProjectionSourceFileSystem.readStableText;
+    let attributionBodyReads = 0;
+    localProjectionSourceFileSystem.readStableText = (inputPath) => {
+      if (inputPath.includes(`${path.sep}attribution-events${path.sep}`)) attributionBodyReads += 1;
+      return originalReadStableText(inputPath);
+    };
+    try {
+      const initial = readAttributionEventSource(rootDir);
+      assert.equal(initial.inputs.length, 5);
+      assert.equal(attributionBodyReads, 5);
+
+      const unchanged = readAttributionEventSource(rootDir);
+      assert.equal(unchanged.hash, initial.hash);
+      assert.equal(attributionBodyReads, 5);
+
+      writeIntegrityAttribution(rootDir, "event-cache-2", "task/task-a", "progress_append");
+      const refreshed = readAttributionEventSource(rootDir);
+      assert.equal(refreshed.hash, initial.hash);
+      assert.equal(attributionBodyReads, 6);
+    } finally {
+      localProjectionSourceFileSystem.readStableText = originalReadStableText;
+    }
+  });
+});
+
+test("attribution discovery retries when a shard disappears", () => {
+  withTempStore((rootDir) => {
+    writeIntegrityAttribution(rootDir, "event-keep", "task/task-a", "progress_append");
+    const disappearingPath = path.join(rootDir, "harness/attribution-events/event-disappears.jsonl");
+    writeIntegrityAttribution(rootDir, "event-disappears", "task/task-a", "progress_append");
+    const originalReadStableText = localProjectionSourceFileSystem.readStableText;
+    let removed = false;
+    localProjectionSourceFileSystem.readStableText = (inputPath) => {
+      if (!removed && inputPath === disappearingPath) {
+        removed = true;
+        rmSync(inputPath);
+      }
+      return originalReadStableText(inputPath);
+    };
+    try {
+      const source = readAttributionEventSource(rootDir);
+      assert.equal(removed, true);
+      assert.deepEqual(source.inputs.map((input) => input.relativePath), ["event-keep.jsonl"]);
+    } finally {
+      localProjectionSourceFileSystem.readStableText = originalReadStableText;
+    }
+  });
+});
+
+test("incremental publish falls back to a stable rebuild after a cross-generation decision edit", () => {
+  withTempStore((rootDir) => {
+    writeIntegrityTask(rootDir, "task-a", "Task A", "active");
+    const decisionPath = writeIntegrityDecision(rootDir, "Decision A");
+    rebuildTaskProjection({ rootDir });
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    mkdirSync(path.join(rootDir, "harness/sessions"), { recursive: true });
+    writeIntegrityDecision(rootDir, "Decision B");
+
+    const sessionsRoot = path.join(rootDir, "harness/sessions");
+    const originalReadStableDirents = localProjectionSourceFileSystem.readStableDirents;
+    let mutated = false;
+    localProjectionSourceFileSystem.readStableDirents = (inputPath) => {
+      const result = originalReadStableDirents(inputPath);
+      if (!mutated && inputPath === sessionsRoot) {
+        mutated = true;
+        writeIntegrityDecision(rootDir, "Decision C");
+      }
+      return result;
+    };
+    let result: ReturnType<typeof updateTaskProjectionIncrementally>;
+    try {
+      result = updateTaskProjectionIncrementally({
+        rootDir,
+        touchedPaths: [decisionPath],
+        previousSourceFingerprint
+      });
+    } finally {
+      localProjectionSourceFileSystem.readStableDirents = originalReadStableDirents;
+    }
+
+    assert.equal(mutated, true);
+    assert.equal(result.mode, "rebuild");
+    assert.equal(queryDecisionProjection({ rootDir, filters: {} }).rows[0]?.title, "Decision C");
   });
 });
 

--- a/packages/kernel/test/store/sqlite-projection-integrity.test.ts
+++ b/packages/kernel/test/store/sqlite-projection-integrity.test.ts
@@ -1,0 +1,362 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import {
+  queryDecisionProjection,
+  readTaskProjection,
+  rebuildTaskProjection
+} from "../../src/projection/sqlite-task-projection.ts";
+import { updateTaskProjectionIncrementally } from "../../src/projection/sqlite-task-incremental-projection.ts";
+import { captureProjectionSourceSnapshot } from "../../src/projection/projection-source-snapshot.ts";
+import { withTempStore } from "./helpers.ts";
+
+test("incremental task and decision edits preserve authored attribution", () => {
+  withTempStore((rootDir) => {
+    const taskPath = writeIntegrityTask(rootDir, "task-a", "Task A", "active");
+    const decisionPath = writeIntegrityDecision(rootDir, "Original decision");
+    writeIntegrityAttribution(rootDir, "event-task", "task/task-a", "progress_append");
+    writeIntegrityAttribution(rootDir, "event-decision", "decision/dec_INTEGRITY", "decision_propose");
+    rebuildTaskProjection({ rootDir });
+
+    let previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    writeIntegrityTask(rootDir, "task-a", "Task A updated", "done");
+    assert.equal(updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [taskPath],
+      previousSourceFingerprint
+    }).mode, "incremental");
+    assert.equal(readTaskProjection({ rootDir }).rows[0]?.attribution.latestActor?.principal.personId, "person_integrity");
+
+    previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    writeIntegrityDecision(rootDir, "Updated decision");
+    assert.equal(updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [decisionPath],
+      previousSourceFingerprint
+    }).mode, "incremental");
+    assert.equal(queryDecisionProjection({ rootDir, filters: {} }).rows[0]?.attribution.latestActor?.principal.personId, "person_integrity");
+  });
+});
+
+test("projection reads reject valid-looking attribution tampering", () => {
+  withTempStore((rootDir) => {
+    writeIntegrityTask(rootDir, "task-a", "Task A", "active");
+    writeIntegrityAttribution(rootDir, "event-task", "task/task-a", "progress_append");
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const db = new DatabaseSync(projectionPath);
+    try {
+      db.prepare("UPDATE task_projection SET attribution_json = ? WHERE task_id = ?").run(JSON.stringify({
+        originator: { principal: { kind: "person", personId: "attacker" }, executor: null },
+        latestActor: { principal: { kind: "person", personId: "attacker" }, executor: null },
+        trailCount: 99,
+        completeness: "complete"
+      }), "task-a");
+    } finally {
+      db.close();
+    }
+
+    const rejected = readTaskProjection({ rootDir });
+    assert.equal(rejected.warnings.some((warning) => warning.code === "projection_tampered"), true);
+    assert.notEqual(rejected.rows[0]?.attribution.latestActor?.principal.personId, "attacker");
+    assert.equal(readTaskProjection({ rootDir }).rows[0]?.attribution.latestActor?.principal.personId, "person_integrity");
+  });
+});
+
+test("projection reads reject attribution event table tampering", () => {
+  withTempStore((rootDir) => {
+    writeIntegrityTask(rootDir, "task-a", "Task A", "active");
+    writeIntegrityAttribution(rootDir, "event-task", "task/task-a", "progress_append");
+    rebuildTaskProjection({ rootDir });
+    const db = new DatabaseSync(path.join(rootDir, ".harness/cache/projections.sqlite"));
+    try {
+      db.prepare("UPDATE attribution_events SET principal_person_id = ? WHERE event_id = ?")
+        .run("attacker", "event-task");
+    } finally {
+      db.close();
+    }
+
+    const rejected = readTaskProjection({ rootDir });
+    assert.equal(rejected.warnings.some((warning) => warning.code === "projection_tampered"), true);
+    assert.notEqual(rejected.rows[0]?.attribution.latestActor?.principal.personId, "attacker");
+  });
+});
+
+test("legacy sessions coexist with incremental execution updates", () => {
+  withTempStore((rootDir) => {
+    const taskId = "task_00000000000000000000000001";
+    const executionId = "exe_00000000000000000000000001";
+    writeIntegrityTask(rootDir, taskId, "Execution task", "active");
+    const legacySessionPath = path.join(rootDir, "harness/sessions/legacy-session.md");
+    mkdirSync(path.dirname(legacySessionPath), { recursive: true });
+    writeFileSync(legacySessionPath, "schema: provenance-session/v1\n");
+    const executionPath = writeIntegrityExecution(rootDir, taskId, executionId, "submitted");
+    rebuildTaskProjection({ rootDir });
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    writeIntegrityExecution(rootDir, taskId, executionId, "accepted");
+
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [executionPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    const db = new DatabaseSync(path.join(rootDir, ".harness/cache/projections.sqlite"), { readOnly: true });
+    try {
+      assert.equal(db.prepare("SELECT state FROM execution_projection WHERE execution_id = ?").get(executionId)?.state, "accepted");
+      assert.equal(db.prepare("SELECT primary_key FROM declared_source_manifest WHERE source_path = ?")
+        .get("sessions/legacy-session.md")?.primary_key, "");
+    } finally {
+      db.close();
+    }
+  });
+});
+
+test("session and review edits update only their declared projections", () => {
+  withTempStore((rootDir) => {
+    const taskId = "task_00000000000000000000000001";
+    const executionId = "exe_00000000000000000000000001";
+    const reviewId = "rev_00000000000000000000000001";
+    writeIntegrityTask(rootDir, taskId, "Review task", "in_review");
+    writeIntegrityExecution(rootDir, taskId, executionId, "submitted");
+    const sessionPath = writeIntegritySession(rootDir, "complete");
+    const reviewPath = writeIntegrityReview(rootDir, taskId, executionId, reviewId, "approved");
+    rebuildTaskProjection({ rootDir });
+
+    let previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    writeIntegritySession(rootDir, "partial");
+    assert.equal(updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [sessionPath],
+      previousSourceFingerprint
+    }).mode, "incremental");
+
+    previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    writeIntegrityReview(rootDir, taskId, executionId, reviewId, "dismissed");
+    assert.equal(updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [reviewPath],
+      previousSourceFingerprint
+    }).mode, "incremental");
+
+    const db = new DatabaseSync(path.join(rootDir, ".harness/cache/projections.sqlite"), { readOnly: true });
+    try {
+      assert.equal(db.prepare("SELECT archive_status FROM session_projection WHERE session_id = ?").get("ses_integrity")?.archive_status, "partial");
+      assert.equal(db.prepare("SELECT verdict FROM review_projection WHERE review_id = ?").get(reviewId)?.verdict, "dismissed");
+    } finally {
+      db.close();
+    }
+  });
+});
+
+test("a stale projection baseline cannot hide an untouched authored task change", () => {
+  withTempStore((rootDir) => {
+    const taskAPath = writeIntegrityTask(rootDir, "task-a", "Task A", "active");
+    writeIntegrityTask(rootDir, "task-b", "Task B", "active");
+    rebuildTaskProjection({ rootDir });
+    writeIntegrityTask(rootDir, "task-b", "Task B changed externally", "done");
+    const authoredBeforeWrite = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    writeIntegrityTask(rootDir, "task-a", "Task A changed", "done");
+
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [taskAPath],
+      previousSourceFingerprint: authoredBeforeWrite
+    });
+
+    assert.equal(result.mode, "rebuild");
+    assert.equal(readTaskProjection({ rootDir }).rows.find((row) => row.taskId === "task-b")?.title, "Task B changed externally");
+  });
+});
+
+test("declared entity path identity must match the document identity", () => {
+  withTempStore((rootDir) => {
+    const taskId = "task_00000000000000000000000001";
+    writeIntegrityTask(rootDir, taskId, "Identity task", "active");
+    const executionPath = writeIntegrityExecution(
+      rootDir,
+      taskId,
+      "exe_00000000000000000000000001",
+      "submitted"
+    );
+    const mismatched = JSON.parse(readFileSync(executionPath, "utf8")) as Record<string, unknown>;
+    mismatched.execution_id = "exe_00000000000000000000000002";
+    writeFileSync(executionPath, `${JSON.stringify(mismatched)}\n`);
+
+    assert.throws(() => rebuildTaskProjection({ rootDir }), /path identity .* does not match projected identity/u);
+  });
+});
+
+function writeIntegrityTask(rootDir: string, taskId: string, title: string, status: string): string {
+  const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+  mkdirSync(taskRoot, { recursive: true });
+  const taskPath = path.join(taskRoot, "INDEX.md");
+  writeFileSync(taskPath, [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    `title: ${title}`,
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    `  status: ${status}`,
+    "  ref: ",
+    `  titleSnapshot: ${title}`,
+    "  url: ",
+    "  bindingCreatedAt: 2026-07-13T00:00:00.000Z",
+    "  bindingFingerprint: sha256:fixture",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "---",
+    "",
+    `# ${title}`,
+    ""
+  ].join("\n"));
+  return taskPath;
+}
+
+function writeIntegrityDecision(rootDir: string, title: string): string {
+  const decisionPath = path.join(rootDir, "harness/decisions/decision-dec_INTEGRITY/decision.md");
+  mkdirSync(path.dirname(decisionPath), { recursive: true });
+  writeFileSync(decisionPath, [
+    "---",
+    "schema: decision-package/v1",
+    "decision_id: dec_INTEGRITY",
+    `_coordinatorWatermark: wm-${title.replaceAll(" ", "-")}`,
+    `title: ${title}`,
+    "state: active",
+    "applies_to:",
+    "  modules: []",
+    "  productLines: []",
+    "question: \"Keep projection attribution?\"",
+    "chosen:",
+    "  - { id: \"CH1\", text: \"Yes\" }",
+    "rejected: []",
+    "claims: []",
+    "relations:",
+    "---",
+    "",
+    `# ${title}`,
+    ""
+  ].join("\n"));
+  return decisionPath;
+}
+
+function writeIntegrityAttribution(rootDir: string, eventId: string, entityId: string, kind: string): void {
+  const eventRoot = path.join(rootDir, "harness/attribution-events");
+  mkdirSync(eventRoot, { recursive: true });
+  writeFileSync(path.join(eventRoot, `${eventId}.jsonl`), `${JSON.stringify({
+    schema: "attribution-event/v1",
+    eventId,
+    opId: `op-${eventId}`,
+    journalRecordSchema: "write-journal/v2",
+    entityId,
+    kind,
+    actor: {
+      principal: { kind: "person", personId: "person_integrity" },
+      executor: { kind: "agent", id: "agent_integrity" }
+    },
+    principalSource: {
+      kind: "local-configured",
+      authority: "harness.yaml",
+      authoritySha256: `sha256:${"0".repeat(64)}`
+    },
+    executorSource: "client-asserted",
+    at: "2026-07-13T00:00:00.000Z",
+    recordedAt: "2026-07-13T00:00:01.000Z",
+    payloadHash: `sha256:${"1".repeat(64)}`,
+    payloadRef: { path: `.harness/payloads/${eventId}.json`, sha256: `sha256:${"1".repeat(64)}` }
+  })}\n`);
+}
+
+function writeIntegrityExecution(
+  rootDir: string,
+  taskId: string,
+  executionId: string,
+  state: "submitted" | "accepted"
+): string {
+  const executionPath = path.join(rootDir, "harness/tasks", taskId, "executions", `${executionId}.md`);
+  mkdirSync(path.dirname(executionPath), { recursive: true });
+  writeFileSync(executionPath, `${JSON.stringify({
+    schema: "execution/v2",
+    execution_id: executionId,
+    task_ref: `task/${taskId}`,
+    state,
+    primary_actor: {
+      principal: { personId: "person_integrity" },
+      executor: { kind: "agent", id: "agent_integrity" },
+      responsibleHuman: "person_integrity"
+    },
+    claimed_at: "2026-07-13T00:00:00.000Z",
+    submitted_at: "2026-07-13T00:01:00.000Z",
+    closed_at: null,
+    session_bindings: [],
+    outputs: [],
+    submission: null
+  }, null, 2)}\n`);
+  return executionPath;
+}
+
+function writeIntegritySession(rootDir: string, archiveStatus: "complete" | "partial"): string {
+  const sessionPath = path.join(rootDir, "harness/sessions/ses_integrity.md");
+  mkdirSync(path.dirname(sessionPath), { recursive: true });
+  writeFileSync(sessionPath, `${JSON.stringify({
+    schema: "session-entity/v1",
+    sessionId: "ses_integrity",
+    lifecycle: "sealed",
+    archiveStatus,
+    runtime: "codex",
+    source: "runtime",
+    detectedAt: "2026-07-13T00:00:00.000Z",
+    exportedAt: "2026-07-13T00:01:00.000Z",
+    bodyRef: {
+      store: "authored-cas/v1",
+      ref: `objects/aa/${"a".repeat(64)}`,
+      sha256: "a".repeat(64),
+      mediaType: "text/markdown",
+      size: 10
+    },
+    snapshot: {
+      capturedAt: "2026-07-13T00:01:00.000Z",
+      completeness: archiveStatus === "complete" ? "complete" : "partial",
+      captureRange: { messageCount: 1 },
+      privacyScan: { scannerVersion: "publish-redaction/v1", passed: true, findings: [] }
+    }
+  }, null, 2)}\n`);
+  return sessionPath;
+}
+
+function writeIntegrityReview(
+  rootDir: string,
+  taskId: string,
+  executionId: string,
+  reviewId: string,
+  verdict: "approved" | "dismissed"
+): string {
+  const reviewPath = path.join(rootDir, "harness/tasks", taskId, "reviews", `${reviewId}.md`);
+  mkdirSync(path.dirname(reviewPath), { recursive: true });
+  writeFileSync(reviewPath, `${JSON.stringify({
+    schema: "review/v2",
+    review_id: reviewId,
+    task_ref: `task/${taskId}`,
+    execution_ref: `execution/${taskId}/${executionId}`,
+    reviewer_actor: {
+      principal: { personId: "person_reviewer" },
+      executor: null,
+      responsibleHuman: "person_reviewer"
+    },
+    reviewer_session_ref: "session/ses_integrity",
+    findings: "Integrity review",
+    evidence_checked: [],
+    rationale: "Projection remains consistent.",
+    verdict,
+    archive_warnings_acknowledged: false,
+    reviewed_at: "2026-07-13T00:02:00.000Z"
+  }, null, 2)}\n`);
+  return reviewPath;
+}

--- a/packages/kernel/test/store/sqlite-rebuild.test.ts
+++ b/packages/kernel/test/store/sqlite-rebuild.test.ts
@@ -1,6 +1,8 @@
 // harness-test-tier: integration
 import { testWriteAttribution } from "../test-attribution.ts";
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import test from "node:test";
 import { mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -8,7 +10,7 @@ import { DatabaseSync } from "node:sqlite";
 import { Effect, Option } from "effect";
 import { auditTaskProvenance, checkTaskProjection, hashTaskProjectionRows, queryDecisionProjection, queryTaskExecutionTrace, readTaskProjection, rebuildTaskProjection } from "../../src/index.ts";
 import { makeJournaledWriteCoordinator, makeMarkdownArtifactStore } from "../../src/store/index.ts";
-import { docWrite, withTempStore } from "./helpers.ts";
+import { docWrite, withTempStore, withTempStoreAsync } from "./helpers.ts";
 
 test("markdown artifact store remains the rebuildable source of truth without SQLite", () => {
   withTempStore((rootDir) => {
@@ -152,6 +154,57 @@ test("SQLite projection reads discard tampered declared entity rows", () => {
 
     assert.equal(readEntityProjectionTables(projectionPath).executions[0]?.state, "submitted");
     assert.equal(result.warnings.some((warning) => warning.code === "projection_tampered"), true);
+  });
+});
+
+test("SQLite full rebuild atomically publishes complete declared entity generations", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    writeIndex(rootDir, "task_01J00000000000000000000000", "Projected entities", "in_review");
+    writeProjectionEntities(rootDir);
+    const executionRoot = path.join(rootDir, "harness/tasks/task_01J00000000000000000000000/executions");
+    const templatePath = path.join(executionRoot, "exe_01J00000000000000000000000.md");
+    const template = JSON.parse(readFileSync(templatePath, "utf8")) as Record<string, unknown>;
+    const expectedExecutions = 250;
+    for (let index = 1; index < expectedExecutions; index += 1) {
+      const executionId = `exe_${String(index).padStart(26, "0")}`;
+      writeFileSync(path.join(executionRoot, `${executionId}.md`), `${JSON.stringify({
+        ...template,
+        execution_id: executionId,
+        outputs: []
+      })}\n`);
+    }
+    rebuildTaskProjection({ rootDir });
+
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const reader = spawn(process.execPath, ["--input-type=module", "-e", atomicProjectionReaderScript], {
+      env: {
+        ...process.env,
+        HARNESS_PROJECTION_PATH: projectionPath,
+        HARNESS_EXPECTED_EXECUTIONS: String(expectedExecutions)
+      },
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    let stdout = "";
+    let stderr = "";
+    reader.stdout.setEncoding("utf8");
+    reader.stderr.setEncoding("utf8");
+    reader.stdout.on("data", (chunk: string) => { stdout += chunk; });
+    reader.stderr.on("data", (chunk: string) => { stderr += chunk; });
+    await waitForOutput(() => stdout.includes("READY\n"));
+
+    for (let iteration = 0; iteration < 8; iteration += 1) {
+      rebuildTaskProjection({ rootDir });
+    }
+
+    const [exitCode] = await once(reader, "close") as [number];
+    assert.equal(exitCode, 0, stderr);
+    const result = JSON.parse(stdout.trim().split("\n").at(-1)!) as {
+      readonly reads: number;
+      readonly failures: number;
+      readonly partial: number;
+    };
+    assert.equal(result.reads > 0, true);
+    assert.deepEqual(result, { reads: result.reads, failures: 0, partial: 0 });
   });
 });
 
@@ -579,3 +632,37 @@ function readEntityProjectionTables(projectionPath: string): {
     db.close();
   }
 }
+
+async function waitForOutput(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("timed out waiting for projection reader");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+const atomicProjectionReaderScript = `
+import { DatabaseSync } from "node:sqlite";
+const projectionPath = process.env.HARNESS_PROJECTION_PATH;
+const expected = Number(process.env.HARNESS_EXPECTED_EXECUTIONS);
+let reads = 0;
+let failures = 0;
+let partial = 0;
+process.stdout.write("READY\\n");
+const deadline = Date.now() + 4_000;
+while (Date.now() < deadline) {
+  let db;
+  try {
+    db = new DatabaseSync(projectionPath, { readOnly: true });
+    const row = db.prepare("SELECT COUNT(*) AS count FROM execution_projection").get();
+    const meta = db.prepare("SELECT value FROM projection_meta WHERE key = 'declaredRowsHash'").get();
+    reads += 1;
+    if (Number(row.count) !== expected || typeof meta?.value !== "string" || meta.value.length === 0) partial += 1;
+  } catch {
+    failures += 1;
+  } finally {
+    db?.close();
+  }
+}
+process.stdout.write(JSON.stringify({ reads, failures, partial }) + "\\n");
+`;

--- a/packages/kernel/test/store/sqlite-rebuild.test.ts
+++ b/packages/kernel/test/store/sqlite-rebuild.test.ts
@@ -1,8 +1,6 @@
 // harness-test-tier: integration
 import { testWriteAttribution } from "../test-attribution.ts";
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
-import { once } from "node:events";
 import test from "node:test";
 import { mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -10,7 +8,7 @@ import { DatabaseSync } from "node:sqlite";
 import { Effect, Option } from "effect";
 import { auditTaskProvenance, checkTaskProjection, hashTaskProjectionRows, queryDecisionProjection, queryTaskExecutionTrace, readTaskProjection, rebuildTaskProjection } from "../../src/index.ts";
 import { makeJournaledWriteCoordinator, makeMarkdownArtifactStore } from "../../src/store/index.ts";
-import { docWrite, withTempStore, withTempStoreAsync } from "./helpers.ts";
+import { docWrite, withTempStore } from "./helpers.ts";
 
 test("markdown artifact store remains the rebuildable source of truth without SQLite", () => {
   withTempStore((rootDir) => {
@@ -120,20 +118,37 @@ test("SQLite projection rebuild materializes declared session execution and revi
   });
 });
 
-test("SQLite projection reads rebuild when an authored entity changes", () => {
+test("SQLite projection reads incrementally refresh isolated authored entity changes", () => {
   withTempStore((rootDir) => {
     writeIndex(rootDir, "task_01J00000000000000000000000", "Projected entities", "in_review");
     writeProjectionEntities(rootDir);
     rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const db = new DatabaseSync(projectionPath);
+    try {
+      db.exec(`
+        CREATE TRIGGER preserve_incremental_read_generation
+        BEFORE DELETE ON execution_projection
+        BEGIN SELECT RAISE(ABORT, 'read path rebuilt execution table'); END
+      `);
+    } finally {
+      db.close();
+    }
 
     const executionPath = path.join(rootDir, "harness/tasks/task_01J00000000000000000000000/executions/exe_01J00000000000000000000000.md");
     const execution = JSON.parse(readFileSync(executionPath, "utf8")) as Record<string, unknown>;
     writeFileSync(executionPath, `${JSON.stringify({ ...execution, state: "accepted" }, null, 2)}\n`);
 
     const result = readTaskProjection({ rootDir });
-    const rows = readEntityProjectionTables(path.join(rootDir, ".harness/cache/projections.sqlite"));
+    const rows = readEntityProjectionTables(projectionPath);
     assert.equal(rows.executions[0]?.state, "accepted");
     assert.equal(result.warnings.some((warning) => warning.code === "projection_stale"), true);
+    const refreshed = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      assert.equal(refreshed.prepare("SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'trigger' AND name = 'preserve_incremental_read_generation'").get()?.count, 1);
+    } finally {
+      refreshed.close();
+    }
   });
 });
 
@@ -157,54 +172,23 @@ test("SQLite projection reads discard tampered declared entity rows", () => {
   });
 });
 
-test("SQLite full rebuild atomically publishes complete declared entity generations", async () => {
-  await withTempStoreAsync(async (rootDir) => {
+test("SQLite projection reads discard tampered declared source manifests", () => {
+  withTempStore((rootDir) => {
     writeIndex(rootDir, "task_01J00000000000000000000000", "Projected entities", "in_review");
     writeProjectionEntities(rootDir);
-    const executionRoot = path.join(rootDir, "harness/tasks/task_01J00000000000000000000000/executions");
-    const templatePath = path.join(executionRoot, "exe_01J00000000000000000000000.md");
-    const template = JSON.parse(readFileSync(templatePath, "utf8")) as Record<string, unknown>;
-    const expectedExecutions = 250;
-    for (let index = 1; index < expectedExecutions; index += 1) {
-      const executionId = `exe_${String(index).padStart(26, "0")}`;
-      writeFileSync(path.join(executionRoot, `${executionId}.md`), `${JSON.stringify({
-        ...template,
-        execution_id: executionId,
-        outputs: []
-      })}\n`);
-    }
     rebuildTaskProjection({ rootDir });
-
     const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
-    const reader = spawn(process.execPath, ["--input-type=module", "-e", atomicProjectionReaderScript], {
-      env: {
-        ...process.env,
-        HARNESS_PROJECTION_PATH: projectionPath,
-        HARNESS_EXPECTED_EXECUTIONS: String(expectedExecutions)
-      },
-      stdio: ["ignore", "pipe", "pipe"]
-    });
-    let stdout = "";
-    let stderr = "";
-    reader.stdout.setEncoding("utf8");
-    reader.stderr.setEncoding("utf8");
-    reader.stdout.on("data", (chunk: string) => { stdout += chunk; });
-    reader.stderr.on("data", (chunk: string) => { stderr += chunk; });
-    await waitForOutput(() => stdout.includes("READY\n"));
-
-    for (let iteration = 0; iteration < 8; iteration += 1) {
-      rebuildTaskProjection({ rootDir });
+    const db = new DatabaseSync(projectionPath);
+    try {
+      db.prepare("UPDATE declared_source_manifest SET content_sha256 = ? WHERE source_kind = 'execution'").run("0".repeat(64));
+    } finally {
+      db.close();
     }
 
-    const [exitCode] = await once(reader, "close") as [number];
-    assert.equal(exitCode, 0, stderr);
-    const result = JSON.parse(stdout.trim().split("\n").at(-1)!) as {
-      readonly reads: number;
-      readonly failures: number;
-      readonly partial: number;
-    };
-    assert.equal(result.reads > 0, true);
-    assert.deepEqual(result, { reads: result.reads, failures: 0, partial: 0 });
+    const result = readTaskProjection({ rootDir });
+
+    assert.equal(result.warnings.some((warning) => warning.code === "projection_tampered"), true);
+    assert.notEqual(readProjectionManifestValue(projectionPath, "execution", "content_sha256"), "0".repeat(64));
   });
 });
 
@@ -494,6 +478,15 @@ function writeIndex(
   ].join("\n"));
 }
 
+function readProjectionManifestValue(projectionPath: string, sourceKind: string, column: string): string {
+  const db = new DatabaseSync(projectionPath, { readOnly: true });
+  try {
+    return String(db.prepare(`SELECT ${column} AS value FROM declared_source_manifest WHERE source_kind = ?`).get(sourceKind)?.value);
+  } finally {
+    db.close();
+  }
+}
+
 function writeDecision(rootDir: string, decisionId: string, watermark: string): void {
   const lines = [
     "---",
@@ -632,37 +625,3 @@ function readEntityProjectionTables(projectionPath: string): {
     db.close();
   }
 }
-
-async function waitForOutput(predicate: () => boolean): Promise<void> {
-  const deadline = Date.now() + 5_000;
-  while (!predicate()) {
-    if (Date.now() >= deadline) throw new Error("timed out waiting for projection reader");
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-}
-
-const atomicProjectionReaderScript = `
-import { DatabaseSync } from "node:sqlite";
-const projectionPath = process.env.HARNESS_PROJECTION_PATH;
-const expected = Number(process.env.HARNESS_EXPECTED_EXECUTIONS);
-let reads = 0;
-let failures = 0;
-let partial = 0;
-process.stdout.write("READY\\n");
-const deadline = Date.now() + 4_000;
-while (Date.now() < deadline) {
-  let db;
-  try {
-    db = new DatabaseSync(projectionPath, { readOnly: true });
-    const row = db.prepare("SELECT COUNT(*) AS count FROM execution_projection").get();
-    const meta = db.prepare("SELECT value FROM projection_meta WHERE key = 'declaredRowsHash'").get();
-    reads += 1;
-    if (Number(row.count) !== expected || typeof meta?.value !== "string" || meta.value.length === 0) partial += 1;
-  } catch {
-    failures += 1;
-  } finally {
-    db?.close();
-  }
-}
-process.stdout.write(JSON.stringify({ reads, failures, partial }) + "\\n");
-`;

--- a/tools/perf/gui-projection-benchmark.mjs
+++ b/tools/perf/gui-projection-benchmark.mjs
@@ -10,6 +10,7 @@ import { updateTaskProjectionIncrementally } from "../../packages/kernel/src/pro
 
 const size = positiveInteger("--size", 1_000);
 const outputsPerExecution = positiveInteger("--outputs", 5);
+const attributionEventsPerExecution = positiveInteger("--attribution-events", 5);
 const keep = process.argv.includes("--keep");
 const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-perf-"));
 
@@ -25,6 +26,7 @@ try {
 
   const querySamples = sample(20, () => queryExecutions({ rootDir }));
   const executions = querySamples.value;
+  const warmQueryP95 = percentile(querySamples.samples, 0.95);
   const aggregateSamples = sample(20, () => aggregateExecutions(rebuilt.rows, executions));
   const changedExecution = fixtureRows[0];
   const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
@@ -45,6 +47,7 @@ try {
       tasks: size,
       executions: size,
       outputs: size * outputsPerExecution,
+      attributionEvents: size * attributionEventsPerExecution,
       rootDir: keep ? rootDir : "<temporary>"
     },
     milliseconds: {
@@ -59,14 +62,22 @@ try {
       outputCount: aggregateSamples.value.totalOutputs === size * outputsPerExecution,
       oneThousandWarmQueryP95BudgetMs: size === 1_000 ? 100 : null,
       warmQueryWithinBudget: size === 1_000
-        ? percentile(querySamples.samples, 0.95) <= 100
+        ? warmQueryP95 <= 100
+        : null,
+      oneThousandColdProjectionReadyBudgetMs: size === 1_000 ? 10_000 : null,
+      coldProjectionReadyWithinBudget: size === 1_000
+        ? rebuildMs + warmQueryP95 <= 10_000
         : null,
       incrementalExecutionMode: incremental.mode
     }
   };
 
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-  if (!result.assertions.executionCount || !result.assertions.outputCount || result.assertions.warmQueryWithinBudget === false || incremental.mode !== "incremental") {
+  if (!result.assertions.executionCount ||
+      !result.assertions.outputCount ||
+      result.assertions.warmQueryWithinBudget === false ||
+      result.assertions.coldProjectionReadyWithinBudget === false ||
+      incremental.mode !== "incremental") {
     process.exitCode = 1;
   }
 } finally {
@@ -122,6 +133,36 @@ function writeTask(index) {
     })),
     submission: null
   }, null, 2)}\n`);
+  const attributionRoot = path.join(rootDir, "harness/attribution-events");
+  mkdirSync(attributionRoot, { recursive: true });
+  for (let eventIndex = 0; eventIndex < attributionEventsPerExecution; eventIndex += 1) {
+    const eventId = `event-perf-${index}-${eventIndex}`;
+    writeFileSync(path.join(attributionRoot, `${eventId}.jsonl`), `${JSON.stringify({
+      schema: "attribution-event/v1",
+      eventId,
+      opId: `op-${eventId}`,
+      journalRecordSchema: "write-journal/v2",
+      entityId: `execution/${executionId}`,
+      kind: "progress_append",
+      actor: {
+        principal: { kind: "person", personId: "person_perf" },
+        executor: { kind: "agent", id: "codex" }
+      },
+      principalSource: {
+        kind: "local-configured",
+        authority: "harness.yaml",
+        authoritySha256: `sha256:${"0".repeat(64)}`
+      },
+      executorSource: "client-asserted",
+      at: `2026-07-13T00:00:${String(eventIndex).padStart(2, "0")}.000Z`,
+      recordedAt: `2026-07-13T00:01:${String(eventIndex).padStart(2, "0")}.000Z`,
+      payloadHash: `sha256:${"1".repeat(64)}`,
+      payloadRef: {
+        path: `.harness/payloads/${eventId}.json`,
+        sha256: `sha256:${"1".repeat(64)}`
+      }
+    })}\n`);
+  }
   return { taskId, executionId, executionPath };
 }
 

--- a/tools/perf/gui-projection-benchmark.mjs
+++ b/tools/perf/gui-projection-benchmark.mjs
@@ -1,9 +1,12 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { aggregateExecutions } from "../../packages/gui/src/renderer/execution-data.ts";
 import { queryExecutions, rebuildTaskProjection } from "../../packages/kernel/src/index.ts";
+import { captureProjectionSourceFingerprint } from "../../packages/kernel/src/projection/projection-source-snapshot.ts";
+import { readDeclaredSourceManifestRows } from "../../packages/kernel/src/projection/sqlite-declared-source-manifest.ts";
+import { updateTaskProjectionIncrementally } from "../../packages/kernel/src/projection/sqlite-task-incremental-projection.ts";
 
 const size = positiveInteger("--size", 1_000);
 const outputsPerExecution = positiveInteger("--outputs", 5);
@@ -12,16 +15,30 @@ const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-perf-"));
 
 try {
   const fixtureStart = performance.now();
-  for (let index = 0; index < size; index += 1) writeTask(index);
+  const fixtureRows = [];
+  for (let index = 0; index < size; index += 1) fixtureRows.push(writeTask(index));
   const fixtureMs = performance.now() - fixtureStart;
 
   const rebuildStart = performance.now();
   const rebuilt = rebuildTaskProjection({ rootDir });
   const rebuildMs = performance.now() - rebuildStart;
 
-  const querySamples = sample(5, () => queryExecutions({ rootDir }));
+  const querySamples = sample(20, () => queryExecutions({ rootDir }));
   const executions = querySamples.value;
   const aggregateSamples = sample(20, () => aggregateExecutions(rebuilt.rows, executions));
+  const changedExecution = fixtureRows[0];
+  const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+  const manifest = readDeclaredSourceManifestRows(projectionPath);
+  const previousSourceFingerprint = captureProjectionSourceFingerprint(rootDir, manifest).fingerprint;
+  const changedBody = JSON.parse(readFileSync(changedExecution.executionPath, "utf8"));
+  writeFileSync(changedExecution.executionPath, `${JSON.stringify({ ...changedBody, state: "accepted" }, null, 2)}\n`);
+  const incrementalStarted = performance.now();
+  const incremental = updateTaskProjectionIncrementally({
+    rootDir,
+    touchedPaths: [changedExecution.executionPath],
+    previousSourceFingerprint
+  });
+  const incrementalExecutionMs = performance.now() - incrementalStarted;
   const result = {
     schema: "gui-projection-benchmark/v1",
     fixture: {
@@ -34,20 +51,22 @@ try {
       fixture: rounded(fixtureMs),
       rebuild: rounded(rebuildMs),
       queryExecutions: summarize(querySamples.samples),
-      aggregateExecutions: summarize(aggregateSamples.samples)
+      aggregateExecutions: summarize(aggregateSamples.samples),
+      incrementalExecution: rounded(incrementalExecutionMs)
     },
     assertions: {
       executionCount: executions.length === size,
       outputCount: aggregateSamples.value.totalOutputs === size * outputsPerExecution,
-      oneThousandExecutionBudgetMs: size === 1_000 ? 10_000 : null,
-      queryAndAggregateWithinBudget: size === 1_000
-        ? percentile(querySamples.samples, 0.95) + percentile(aggregateSamples.samples, 0.95) < 10_000
-        : null
+      oneThousandWarmQueryP95BudgetMs: size === 1_000 ? 100 : null,
+      warmQueryWithinBudget: size === 1_000
+        ? percentile(querySamples.samples, 0.95) <= 100
+        : null,
+      incrementalExecutionMode: incremental.mode
     }
   };
 
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-  if (!result.assertions.executionCount || !result.assertions.outputCount || result.assertions.queryAndAggregateWithinBudget === false) {
+  if (!result.assertions.executionCount || !result.assertions.outputCount || result.assertions.warmQueryWithinBudget === false || incremental.mode !== "incremental") {
     process.exitCode = 1;
   }
 } finally {
@@ -81,7 +100,8 @@ function writeTask(index) {
     `# Performance Task ${index}`,
     ""
   ].join("\n"));
-  writeFileSync(path.join(taskRoot, "executions", `${executionId}.md`), `${JSON.stringify({
+  const executionPath = path.join(taskRoot, "executions", `${executionId}.md`);
+  writeFileSync(executionPath, `${JSON.stringify({
     schema: "execution/v2",
     execution_id: executionId,
     task_ref: `task/${taskId}`,
@@ -102,6 +122,7 @@ function writeTask(index) {
     })),
     submission: null
   }, null, 2)}\n`);
+  return { taskId, executionId, executionPath };
 }
 
 function sample(iterations, run) {


### PR DESCRIPTION
# English

## Summary

- Unifies full and incremental projection freshness fingerprints across Task, Decision, Session, Execution, Review, attribution, and legacy people inputs.
- Publishes full SQLite rebuilds atomically, persists declared-source manifests, and applies per-entity projection deltas instead of replacing unchanged declared tables.
- Adds bounded process caches with stable double-signature verification for Task, declared-entity, and attribution sources. Changed attribution shards reload individually; disappearing files and directories retry safely.
- Preserves tamper detection and authored attribution while preventing mixed-generation incremental publication.

## Performance and verification

The 1,000 Execution fixture includes 5,000 outputs and 5,000 attribution events. Cold projection-ready completed in about 5.01 seconds, warm query p95 was 87.70 ms, and one Execution incremental update completed in 389.04 ms. The 5,000 Execution stress fixture remained usable with a 468.67 ms warm-query p95; its 30.09 second cold rebuild remains follow-up work under the active P1/P3 performance program.

`npm run check:pr` passed after the final changes: 322 fast tests, 441 contract tests, 734 integration tests (733 passed, 1 skipped), 138 GUI tests, and all 33 PR manifest gates. Deterministic race tests prove cache hits reject concurrent rewrites, and concurrent readers never observe a partially published generation.

## Governance Declaration

- Authority: task_01KXCS9KEKA2H3H8614ZBB984J authorizes the projection performance implementation and its package/tool verification surfaces.
- Scope: projection freshness, incremental persistence, cache correctness, benchmark coverage, and the directly required governed test/gate metadata.
- Break-glass: no

# 中文

## 摘要

- 统一 full 与 incremental projection 的 freshness fingerprint，覆盖 Task、Decision、Session、Execution、Review、归因事件和 legacy people 输入。
- full rebuild 改为临时 generation 完整构建后原子发布；持久化 declared-source manifest，并按变更实体写入 delta，不再替换未变化的 declared table。
- 为 Task、declared entity 与 attribution source 增加有界进程缓存和双遍稳定签名校验；归因事件只重读变化 shard，文件或目录并发消失时安全重试。
- 保留 tamper 检测与 authored attribution，阻止增量路径发布跨 generation 的 meta/data。

## 性能与验证

1,000 Execution 基准现在包含 5,000 outputs 和 5,000 attribution events：冷 projection-ready 约 5.01 秒，warm query p95 为 87.70 ms，单 Execution 增量更新为 389.04 ms。5,000 Execution 压力夹具 warm query p95 为 468.67 ms；其 30.09 秒冷全构建仍作为 P1/P3 性能计划的后续工作，不在本 PR 中虚报完成。

最终改动后 `npm run check:pr` 全绿：322 fast、441 contract、734 integration（733 pass、1 skip）、138 GUI，以及 33 个 PR manifest gates。新增确定性竞态测试证明并发改写会被第二遍签名拒绝；并发 reader 测试证明不会观察到半发布 generation。

## 治理声明

- 授权：task_01KXCS9KEKA2H3H8614ZBB984J 授权 projection 性能实现，以及对应的 package/tool 验证面变更。
- 范围：projection freshness、增量持久化、缓存正确性、基准覆盖及其直接需要的受治理测试与 gate 元数据。
- Break-glass：否
