### PR TITLE
perf(kernel): persist projection sources as SQL deltas

### DIFF
--- a/packages/kernel/src/local/attribution-event-source.ts
+++ b/packages/kernel/src/local/attribution-event-source.ts
@@ -4,6 +4,7 @@ import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import { sha256Text, stablePayloadHash } from "../integrity/stable-hash.ts";
 import { AttributionEventSchema, type AttributionEvent } from "../schemas/attribution-event.ts";
+import { isSafeRelativeSourceCachePath } from "./persistent-source-cache-paths.ts";
 import { localLayoutFileSystem, localProjectionSourceFileSystem } from "./local-layout-file-system.ts";
 
 export interface AttributionEventSourceInput {
@@ -15,11 +16,55 @@ export interface AttributionEventSourceInput {
 
 interface AttributionEventSourceCacheEntry {
   readonly source: AttributionEventSource;
-  readonly signatures: ReadonlyMap<string, string>;
+  readonly signatures: ReadonlyMap<string, string | null>;
 }
+
+export interface AttributionEventSourcePersistentCache {
+  readonly schema: "attribution-event-source-cache/v1";
+  readonly layoutIdentity: string;
+  readonly source: AttributionEventSource;
+  readonly signatures: ReadonlyArray<{ readonly relativePath: string; readonly signature: string | null }>;
+}
+
+export type AttributionSourceCacheRestore = "fresh" | "stale" | "invalid";
 
 const attributionEventSourceCache = new Map<string, AttributionEventSourceCacheEntry>();
 const attributionEventSourceCacheLimit = 16;
+
+export function captureAttributionEventSourcePersistentCache(
+  rootInput: HarnessLayoutInput
+): AttributionEventSourcePersistentCache | null {
+  const layout = resolveHarnessLayout(rootInput);
+  const cached = attributionEventSourceCache.get(layout.attributionEventsRoot);
+  if (!cached || !stableAttributionSignatures(cached.signatures)) return null;
+  return {
+    schema: "attribution-event-source-cache/v1",
+    layoutIdentity: layout.attributionEventsRoot,
+    source: cached.source,
+    signatures: [...cached.signatures].map(([inputPath, signature]) => ({
+      relativePath: path.relative(layout.rootDir, inputPath).split(path.sep).join("/"),
+      signature
+    }))
+  };
+}
+
+export function restoreAttributionEventSourcePersistentCache(
+  rootInput: HarnessLayoutInput,
+  persisted: AttributionEventSourcePersistentCache
+): AttributionSourceCacheRestore {
+  if (!validPersistentAttributionCache(persisted)) return "invalid";
+  const layout = resolveHarnessLayout(rootInput);
+  if (persisted.layoutIdentity !== layout.attributionEventsRoot) return "stale";
+  const signatures = new Map(persisted.signatures.map(({ relativePath, signature }) => [
+    path.resolve(layout.rootDir, relativePath),
+    signature
+  ]));
+  rememberAttributionEventSourceCache(layout.attributionEventsRoot, {
+    source: persisted.source,
+    signatures
+  });
+  return stableAttributionSignatures(signatures) ? "fresh" : "stale";
+}
 
 export interface AttributionEventSource {
   readonly inputs: ReadonlyArray<AttributionEventSourceInput>;
@@ -37,8 +82,12 @@ export function readAttributionEventSource(rootInput: HarnessLayoutInput): Attri
 function readAttributionEventSourceAttempt(rootInput: HarnessLayoutInput, attempt: number): AttributionEventSource {
   const eventsRoot = resolveHarnessLayout(rootInput).attributionEventsRoot;
   if (!localLayoutFileSystem.exists(eventsRoot)) {
-    attributionEventSourceCache.delete(eventsRoot);
-    return emptyAttributionEventSource();
+    const source = emptyAttributionEventSource();
+    rememberAttributionEventSourceCache(eventsRoot, {
+      source,
+      signatures: new Map([[eventsRoot, null]])
+    });
+    return source;
   }
   const cached = attributionEventSourceCache.get(eventsRoot);
   if (cached && stableAttributionSignatures(cached.signatures)) {
@@ -77,7 +126,7 @@ function readAttributionEventSourceAttempt(rootInput: HarnessLayoutInput, attemp
       return retryAttributionEventSource(rootInput, eventsRoot, attempt);
     }
   }
-  const signatures = new Map<string, string>([
+  const signatures = new Map<string, string | null>([
     [eventsRoot, directory.signature],
     ...inputs.map((input) => [path.join(eventsRoot, input.relativePath), input.statSignature] as const)
   ]);
@@ -89,21 +138,28 @@ function readAttributionEventSourceAttempt(rootInput: HarnessLayoutInput, attemp
       inputs: inputs.map(({ relativePath, contentSha256 }) => ({ relativePath, contentSha256 }))
     })
   };
+  rememberAttributionEventSourceCache(eventsRoot, { source, signatures });
+  return source;
+}
+
+function rememberAttributionEventSourceCache(
+  eventsRoot: string,
+  entry: AttributionEventSourceCacheEntry
+): void {
   attributionEventSourceCache.delete(eventsRoot);
-  attributionEventSourceCache.set(eventsRoot, { source, signatures });
+  attributionEventSourceCache.set(eventsRoot, entry);
   while (attributionEventSourceCache.size > attributionEventSourceCacheLimit) {
     const oldest = attributionEventSourceCache.keys().next().value as string | undefined;
     if (oldest === undefined) break;
     attributionEventSourceCache.delete(oldest);
   }
-  return source;
 }
 
-function stableAttributionSignatures(signatures: ReadonlyMap<string, string>): boolean {
+function stableAttributionSignatures(signatures: ReadonlyMap<string, string | null>): boolean {
   return attributionSignaturesMatch(signatures) && attributionSignaturesMatch(signatures);
 }
 
-function attributionSignaturesMatch(signatures: ReadonlyMap<string, string>): boolean {
+function attributionSignaturesMatch(signatures: ReadonlyMap<string, string | null>): boolean {
   for (const [inputPath, expected] of signatures) {
     if (localProjectionSourceFileSystem.statSignature(inputPath) !== expected) return false;
   }
@@ -127,9 +183,36 @@ function emptyAttributionEventSource(): AttributionEventSource {
   };
 }
 
+function validPersistentAttributionSource(source: AttributionEventSource): boolean {
+  if (source.inputs.some((input) => sha256Text(input.body) !== input.contentSha256)) return false;
+  return source.hash === stablePayloadHash({
+    schema: "attribution-event-source/v2",
+    inputs: source.inputs.map(({ relativePath, contentSha256 }) => ({ relativePath, contentSha256 }))
+  });
+}
+
+function validPersistentAttributionCache(persisted: AttributionEventSourcePersistentCache): boolean {
+  if (persisted.schema !== "attribution-event-source-cache/v1" ||
+      typeof persisted.layoutIdentity !== "string" ||
+      !Array.isArray(persisted.source?.inputs) ||
+      !Array.isArray(persisted.signatures)) return false;
+  if (persisted.source.inputs.some((input) =>
+    typeof input.relativePath !== "string" ||
+    !isSafeRelativeSourceCachePath(input.relativePath) ||
+    typeof input.body !== "string" ||
+    typeof input.statSignature !== "string" ||
+    typeof input.contentSha256 !== "string")) return false;
+  if (persisted.signatures.some((entry) =>
+    typeof entry.relativePath !== "string" ||
+    !isSafeRelativeSourceCachePath(entry.relativePath) ||
+    (entry.signature !== null && typeof entry.signature !== "string"))) return false;
+  return validPersistentAttributionSource(persisted.source);
+}
+
+
 export function readAttributionEventsFromSource(source: AttributionEventSource): ReadonlyArray<AttributionEvent> {
   return source.inputs
-    .map((input) => decodeAttributionEvent(input.body))
+    .map((input) => decodeAttributionEventBody(input.body))
     .sort((left, right) => left.eventId.localeCompare(right.eventId));
 }
 
@@ -137,7 +220,7 @@ export function attributionEventSourceHash(rootInput: HarnessLayoutInput): strin
   return readAttributionEventSource(rootInput).hash;
 }
 
-function decodeAttributionEvent(body: string): AttributionEvent {
+export function decodeAttributionEventBody(body: string): AttributionEvent {
   const lines = body.trim().split("\n").filter(Boolean);
   if (lines.length !== 1) throw new Error("immutable attribution event shard must contain exactly one event");
   return Schema.decodeUnknownSync(AttributionEventSchema)(JSON.parse(lines[0]!));

--- a/packages/kernel/src/local/local-layout-file-system.ts
+++ b/packages/kernel/src/local/local-layout-file-system.ts
@@ -1,5 +1,6 @@
 import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import type { Dirent } from "node:fs";
+import path from "node:path";
 import type { LayoutFileSystem } from "../layout/file-system.ts";
 
 export const localLayoutFileSystem: LayoutFileSystem = {
@@ -37,6 +38,17 @@ export const localProjectionSourceFileSystem = {
     return projectionSourceStatSignature(inputPath);
   }
 };
+
+export function listProjectionSourceDirectoryPaths(rootPath: string): ReadonlyArray<string> {
+  try {
+    if (!statSync(rootPath).isDirectory()) return [];
+    return [rootPath, ...readdirSync(rootPath, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name !== ".git" && entry.name !== "node_modules")
+      .flatMap((entry) => listProjectionSourceDirectoryPaths(path.join(rootPath, entry.name)))];
+  } catch {
+    return [];
+  }
+}
 
 function projectionSourceStatSignature(inputPath: string): string | null {
   try {

--- a/packages/kernel/src/local/persistent-source-cache-paths.ts
+++ b/packages/kernel/src/local/persistent-source-cache-paths.ts
@@ -1,0 +1,61 @@
+import path from "node:path";
+import { listProjectionSourceDirectoryPaths, localProjectionSourceFileSystem } from "./local-layout-file-system.ts";
+
+export function serializeSourceCacheSignatures<Signature extends string | null>(
+  rootDir: string,
+  signatures: ReadonlyMap<string, Signature>
+): ReadonlyArray<{ readonly relativePath: string; readonly signature: Signature }> {
+  return [...signatures].map(([inputPath, signature]) => ({
+    relativePath: path.relative(rootDir, inputPath).split(path.sep).join("/"),
+    signature
+  }));
+}
+
+export function restoreSourceCacheSignatures<Signature extends string | null>(
+  rootDir: string,
+  signatures: ReadonlyArray<{ readonly relativePath: string; readonly signature: Signature }>
+): ReadonlyMap<string, Signature> {
+  return new Map(signatures.map(({ relativePath, signature }) => [path.resolve(rootDir, relativePath), signature]));
+}
+
+export function isSafeRelativeSourceCachePath(inputPath: string): boolean {
+  return inputPath.length > 0 && !path.isAbsolute(inputPath) &&
+    !inputPath.split(/[\\/]/u).some((segment) => segment === ".." || segment.length === 0);
+}
+
+export function sameSourceCacheSignatures(
+  left: ReadonlyMap<string, string | null>,
+  right: ReadonlyMap<string, string | null>
+): boolean {
+  return left.size === right.size && [...left].every(([inputPath, signature]) => right.get(inputPath) === signature);
+}
+
+export function captureRequiredSourceCacheSignatures(
+  paths: Iterable<string>
+): ReadonlyMap<string, string> | null {
+  const signatures = new Map<string, string>();
+  for (const inputPath of new Set(paths)) {
+    const signature = localProjectionSourceFileSystem.statSignature(inputPath);
+    if (signature === null) return null;
+    signatures.set(inputPath, signature);
+  }
+  return signatures;
+}
+
+export function captureSourceCacheWatchSignatures(
+  paths: Iterable<string>
+): ReadonlyMap<string, string | null> {
+  return new Map([...new Set(paths)].map((inputPath) => [
+    inputPath,
+    localProjectionSourceFileSystem.statSignature(inputPath)
+  ]));
+}
+
+export function sourceCacheSignaturesMatch(signatures: ReadonlyMap<string, string | null>): boolean {
+  return [...signatures].every(([inputPath, expected]) =>
+    localProjectionSourceFileSystem.statSignature(inputPath) === expected);
+}
+
+export function listSourceCacheDirectoryPaths(rootPath: string): ReadonlyArray<string> {
+  return listProjectionSourceDirectoryPaths(rootPath);
+}

--- a/packages/kernel/src/projection/projection-source-snapshot.ts
+++ b/packages/kernel/src/projection/projection-source-snapshot.ts
@@ -20,7 +20,7 @@ import {
   type DeclaredProjectionRow
 } from "./entity-declaration-projection.ts";
 import { readLegacyPersonIds } from "./entity-attribution-projection.ts";
-import { readDecisionProjectionRows } from "./sqlite-decision-source.ts";
+import { readDecisionProjectionRowsFromSource } from "./sqlite-decision-source.ts";
 import { readMarkdownSource } from "./sqlite-task-source.ts";
 import type { DecisionProjectionRow } from "./types.ts";
 
@@ -87,7 +87,7 @@ export function captureProjectionSourceFingerprint(
 
 export function captureProjectionSourceSnapshot(rootInput: HarnessLayoutInput): ProjectionSourceSnapshot {
   const source = captureProjectionSourceFingerprint(rootInput);
-  const decisionRows = readDecisionProjectionRows(rootInput);
+  const decisionRows = readDecisionProjectionRowsFromSource(rootInput, source.taskSource.sourceInputs);
   const declaredTables = source.declaredSources.map(({ declaration, table, source: declaredSource }) => {
     const projected = projectDeclaredEntitySource(rootInput, declaration, declaredSource);
     return {

--- a/packages/kernel/src/projection/relation-graph-projection.ts
+++ b/packages/kernel/src/projection/relation-graph-projection.ts
@@ -11,7 +11,7 @@ import {
   relationDecisionAuthoredSourceKind,
   type RelationAuthoredSourceKind
 } from "./relation-source-manifest.ts";
-import { sourcePath } from "./sqlite-task-source.ts";
+import { sourcePath, type TaskProjectionSourceHashInput } from "./sqlite-task-source.ts";
 import { readDirIfPresent, readTextFileIfPresent, statPathIfPresent } from "./toctou-safe-fs.ts";
 import { buildClaimFulfillmentRows } from "./claim-fulfillment-projection.ts";
 
@@ -92,10 +92,14 @@ export interface RelationRecordValidationIssue {
   };
 }
 
-export function buildRelationGraphProjection(rootInput: HarnessLayoutInput): RelationGraphProjection {
-  const decisions = readDecisionSources(rootInput);
-  const refIndex = buildGraphRefIndex(rootInput, decisions);
-  const entries = collectRelationRecordEntries(rootInput, decisions);
+export function buildRelationGraphProjection(
+  rootInput: HarnessLayoutInput,
+  sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput> = []
+): RelationGraphProjection {
+  const sourceBodies = sourceBodyHints(rootInput, sourceInputs);
+  const decisions = readDecisionSources(rootInput, sourceBodies);
+  const refIndex = buildGraphRefIndex(rootInput, decisions, sourceBodies);
+  const entries = collectRelationRecordEntries(rootInput, decisions, sourceBodies);
   const edges = relationEntriesToEdges(entries, refIndex);
   return {
     edges,
@@ -161,17 +165,18 @@ export function detectRelationGraphCycles(edges: ReadonlyArray<RelationGraphEdge
 
 function collectRelationRecordEntries(
   rootInput: HarnessLayoutInput,
-  decisions: ReadonlyArray<DecisionSource>
+  decisions: ReadonlyArray<DecisionSource>,
+  sourceBodies: ReadonlyMap<string, string> = new Map()
 ): ReadonlyArray<RelationRecordEntry> {
   const layout = resolveHarnessLayout(rootInput);
   const rootDir = layout.rootDir;
   const entries: RelationRecordEntry[] = [];
 
   for (const taskDir of listTaskDirs(layout.tasksRoot)) {
-    const taskId = readTaskPackageId(taskDir);
+    const taskId = readTaskPackageId(taskDir, sourceBodies);
     for (const source of deriveRelationTaskAuthoredSources(taskDir)) {
       if (!existsSync(source.filePath)) continue;
-      const body = readTextFileIfPresent(source.filePath);
+      const body = readSourceBody(source.filePath, sourceBodies);
       if (body === null) continue;
       if (source.content === "frontmatter") {
         const frontmatter = readFrontmatter(body);
@@ -340,14 +345,17 @@ function canonicalRelationRecord(record: EntityRelationRecord): string {
   return formatRelationFlowRecord(record);
 }
 
-function readDecisionSources(rootInput: HarnessLayoutInput): ReadonlyArray<DecisionSource> {
+function readDecisionSources(
+  rootInput: HarnessLayoutInput,
+  sourceBodies: ReadonlyMap<string, string> = new Map()
+): ReadonlyArray<DecisionSource> {
   const layout = resolveHarnessLayout(rootInput);
   const decisions: Array<Omit<DecisionSource, "visible"> & { readonly watermark: string }> = [];
   const watermarkCounts = new Map<string, number>();
   for (const filePath of listTextFiles(layout.decisionsRoot)) {
     const sourceKind = relationDecisionAuthoredSourceKind(filePath);
     if (sourceKind === null) continue;
-    const body = readTextFileIfPresent(filePath);
+    const body = readSourceBody(filePath, sourceBodies);
     if (body === null) continue;
     const frontmatter = readFrontmatter(body);
     if (!frontmatter || readScalar(frontmatter, "schema") !== "decision-package/v1") continue;
@@ -373,20 +381,24 @@ function readDecisionSources(rootInput: HarnessLayoutInput): ReadonlyArray<Decis
   })).sort((a, b) => a.decisionRef.localeCompare(b.decisionRef));
 }
 
-function buildGraphRefIndex(rootInput: HarnessLayoutInput, decisions: ReadonlyArray<DecisionSource>): GraphRefIndex {
+function buildGraphRefIndex(
+  rootInput: HarnessLayoutInput,
+  decisions: ReadonlyArray<DecisionSource>,
+  sourceBodies: ReadonlyMap<string, string> = new Map()
+): GraphRefIndex {
   const layout = resolveHarnessLayout(rootInput);
   const taskIds = new Set<string>();
   const doneTaskIds = new Set<string>();
   const factRefs = new Set<string>();
   const factAnchors: FactAnchorRow[] = [];
   for (const taskDir of listTaskDirs(layout.tasksRoot)) {
-    const taskId = readTaskPackageId(taskDir);
+    const taskId = readTaskPackageId(taskDir, sourceBodies);
     taskIds.add(taskId);
-    if (readTaskPackageStatus(taskDir) === "done") doneTaskIds.add(taskId);
+    if (readTaskPackageStatus(taskDir, sourceBodies) === "done") doneTaskIds.add(taskId);
     const factsPath = deriveRelationTaskAuthoredSources(taskDir)
       .find((source) => source.kind === "task-facts")?.filePath;
     if (!factsPath || !existsSync(factsPath)) continue;
-    const factsBody = readTextFileIfPresent(factsPath);
+    const factsBody = readSourceBody(factsPath, sourceBodies);
     if (factsBody === null) continue;
     for (const record of parseFactFlowRecords(factsBody)) {
       const factKey = `${taskId}/${record.fact_id}`;
@@ -457,16 +469,16 @@ function readFlowObjectBlock(frontmatter: string, key: string): string {
   return output.join("\n");
 }
 
-function readTaskPackageId(taskDir: string): string {
+function readTaskPackageId(taskDir: string, sourceBodies: ReadonlyMap<string, string> = new Map()): string {
   const indexPath = path.join(taskDir, "INDEX.md");
   if (!existsSync(indexPath)) return path.basename(taskDir);
-  const body = readTextFileIfPresent(indexPath);
+  const body = readSourceBody(indexPath, sourceBodies);
   const frontmatter = body === null ? null : readFrontmatter(body);
   return (frontmatter ? readScalar(frontmatter, "task_id") : "") || path.basename(taskDir);
 }
 
-function readTaskPackageStatus(taskDir: string): string {
-  const body = readTextFileIfPresent(path.join(taskDir, "INDEX.md"));
+function readTaskPackageStatus(taskDir: string, sourceBodies: ReadonlyMap<string, string> = new Map()): string {
+  const body = readSourceBody(path.join(taskDir, "INDEX.md"), sourceBodies);
   const frontmatter = body === null ? null : readFrontmatter(body);
   return frontmatter ? readScalar(frontmatter, "  status") : "";
 }
@@ -493,6 +505,18 @@ function listTextFiles(inputPath: string): ReadonlyArray<string> {
     .filter((entry) => entry.name !== ".git" && entry.name !== "node_modules")
     .flatMap((entry) => listTextFiles(path.join(inputPath, entry.name)))
     .sort();
+}
+
+function sourceBodyHints(
+  rootInput: HarnessLayoutInput,
+  sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>
+): ReadonlyMap<string, string> {
+  const rootDir = resolveHarnessLayout(rootInput).rootDir;
+  return new Map(sourceInputs.map((input) => [path.resolve(rootDir, input.sourcePath), input.body]));
+}
+
+function readSourceBody(filePath: string, sourceBodies: ReadonlyMap<string, string>): string | null {
+  return sourceBodies.get(filePath) ?? readTextFileIfPresent(filePath);
 }
 
 function isRelationGraphTextLikePath(filePath: string): boolean {

--- a/packages/kernel/src/projection/sqlite-attribution-projection.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-projection.ts
@@ -1,12 +1,13 @@
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import { localLayoutFileSystem } from "../local/local-layout-file-system.ts";
-import { readAttributionEvents } from "../local/attribution-event-source.ts";
+import { decodeAttributionEventBody, readAttributionEvents } from "../local/attribution-event-source.ts";
 import type { ActorAxes, ExecutorSource, PrincipalSource } from "../schemas/actor-attribution.ts";
 import type { AttributionEvent } from "../schemas/attribution-event.ts";
 import { unresolvedEntityAttribution } from "./entity-attribution-projection.ts";
 import type { EntityAttributionProjection } from "./types.ts";
 import { runSqlite } from "./sqlite-projection-store.ts";
+import type { ProjectionSourceCacheChange } from "./sqlite-projection-source-cache.ts";
 import { SqlClient } from "@effect/sql";
 import { Effect } from "effect";
 
@@ -58,37 +59,55 @@ export function replaceAttributionProjectionRows(
 
 export function applyAttributionProjectionDelta(
   sql: SqlClient.SqlClient,
-  events: ReadonlyArray<AttributionEvent>
+  delta: AttributionProjectionDelta
 ): Effect.Effect<ReadonlyArray<string>, unknown> {
   return Effect.gen(function* () {
     yield* createAttributionTable(sql);
-    const existingRecords = yield* sql<AttributionRecord>`
-      SELECT event_id, op_id, subject_ref, operation, principal_person_id,
-             executor_agent_id, occurred_at, recorded_at, source_json
-      FROM attribution_events
-      ORDER BY occurred_at, event_id
-    `;
-    const existing = existingRecords.map(recordToProjectionRow);
-    const current = events.map(eventToProjectionRow);
-    const existingById = new Map(existing.map((row) => [row.eventId, row]));
-    const currentById = new Map(current.map((row) => [row.eventId, row]));
-    const changedIds = new Set([
-      ...existing.filter((row) => JSON.stringify(row) !== JSON.stringify(currentById.get(row.eventId))).map((row) => row.eventId),
-      ...current.filter((row) => JSON.stringify(row) !== JSON.stringify(existingById.get(row.eventId))).map((row) => row.eventId)
-    ]);
-    const affectedSubjects = new Set<string>();
-    for (const eventId of changedIds) {
-      const previous = existingById.get(eventId);
-      const next = currentById.get(eventId);
-      if (previous) affectedSubjects.add(previous.subjectRef);
-      if (next) affectedSubjects.add(next.subjectRef);
+    for (const eventId of delta.deleteEventIds) {
       yield* sql`DELETE FROM attribution_events WHERE event_id = ${eventId}`;
     }
-    for (const event of events) {
-      if (changedIds.has(event.eventId)) yield* insertAttributionEvent(sql, event);
-    }
-    return [...affectedSubjects];
+    for (const event of delta.upsertEvents) yield* insertAttributionEvent(sql, event);
+    return delta.affectedSubjects;
   });
+}
+
+export interface AttributionProjectionDelta {
+  readonly deleteEventIds: ReadonlyArray<string>;
+  readonly upsertEvents: ReadonlyArray<AttributionEvent>;
+  readonly affectedSubjects: ReadonlyArray<string>;
+}
+
+export function buildAttributionProjectionDelta(
+  change: ProjectionSourceCacheChange
+): AttributionProjectionDelta {
+  const previous = new Map(change.previous.files
+    .filter((row) => row.cacheKind === "attribution")
+    .map((row) => [row.sourcePath, row]));
+  const current = new Map(change.current.files
+    .filter((row) => row.cacheKind === "attribution")
+    .map((row) => [row.sourcePath, row]));
+  const deleteEventIds = new Set<string>();
+  const upsertEvents: AttributionEvent[] = [];
+  const affectedSubjects = new Set<string>();
+  for (const [sourcePath, row] of previous) {
+    const next = current.get(sourcePath);
+    if (next?.contentSha256 === row.contentSha256) continue;
+    const event = decodeAttributionEventBody(row.body);
+    deleteEventIds.add(event.eventId);
+    affectedSubjects.add(event.entityId);
+  }
+  for (const [sourcePath, row] of current) {
+    const prior = previous.get(sourcePath);
+    if (prior?.contentSha256 === row.contentSha256) continue;
+    const event = decodeAttributionEventBody(row.body);
+    upsertEvents.push(event);
+    affectedSubjects.add(event.entityId);
+  }
+  return {
+    deleteEventIds: [...deleteEventIds],
+    upsertEvents,
+    affectedSubjects: [...affectedSubjects]
+  };
 }
 
 export function materializeEntityAttributionBlocks(

--- a/packages/kernel/src/projection/sqlite-decision-source.ts
+++ b/packages/kernel/src/projection/sqlite-decision-source.ts
@@ -8,11 +8,23 @@ import { parseObjectList, parseStringArray, readBlockScalar, unquote } from "../
 import type { DecisionPackage } from "../schemas/decision-package.ts";
 import type { DecisionProjectionRow } from "./types.ts";
 import { unresolvedEntityAttribution } from "./entity-attribution-projection.ts";
+import type { TaskProjectionSourceHashInput } from "./sqlite-task-source.ts";
 
 export function readDecisionProjectionRows(rootInput: HarnessLayoutInput): ReadonlyArray<DecisionProjectionRow> {
   const layout = resolveHarnessLayout(rootInput);
   return listDecisionDocumentPaths(layout.decisionsRoot)
     .map((documentPath) => decisionDocumentToProjectionRow(layout.rootDir, documentPath))
+    .sort(compareDecisionRows);
+}
+
+export function readDecisionProjectionRowsFromSource(
+  rootInput: HarnessLayoutInput,
+  sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>
+): ReadonlyArray<DecisionProjectionRow> {
+  const layout = resolveHarnessLayout(rootInput);
+  return sourceInputs
+    .filter((input) => input.kind === "decision-document" && path.basename(input.sourcePath) === "decision.md")
+    .map((input) => decisionDocumentBodyToProjectionRow(layout.rootDir, path.resolve(layout.rootDir, input.sourcePath), input.body))
     .sort(compareDecisionRows);
 }
 
@@ -24,6 +36,21 @@ export function readDecisionProjectionRowsForPaths(
   return uniqueDecisionDocumentPaths(documentPaths.map((documentPath) => path.resolve(documentPath)))
     .filter((documentPath) => existsSync(documentPath) && path.basename(documentPath) === "decision.md")
     .map((documentPath) => decisionDocumentToProjectionRow(layout.rootDir, documentPath))
+    .sort(compareDecisionRows);
+}
+
+export function readDecisionProjectionRowsForPathsFromSource(
+  rootInput: HarnessLayoutInput,
+  documentPaths: ReadonlyArray<string>,
+  sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>
+): ReadonlyArray<DecisionProjectionRow> {
+  const layout = resolveHarnessLayout(rootInput);
+  const bodiesByPath = new Map(sourceInputs
+    .filter((input) => input.kind === "decision-document")
+    .map((input) => [path.resolve(layout.rootDir, input.sourcePath), input.body]));
+  return uniqueDecisionDocumentPaths(documentPaths.map((documentPath) => path.resolve(documentPath)))
+    .filter((documentPath) => path.basename(documentPath) === "decision.md" && bodiesByPath.has(documentPath))
+    .map((documentPath) => decisionDocumentBodyToProjectionRow(layout.rootDir, documentPath, bodiesByPath.get(documentPath)!))
     .sort(compareDecisionRows);
 }
 
@@ -42,6 +69,14 @@ export function compareDecisionRows(a: DecisionProjectionRow, b: DecisionProject
 
 function decisionDocumentToProjectionRow(rootDir: string, documentPath: string): DecisionProjectionRow {
   const body = readFileSync(documentPath, "utf8");
+  return decisionDocumentBodyToProjectionRow(rootDir, documentPath, body);
+}
+
+function decisionDocumentBodyToProjectionRow(
+  rootDir: string,
+  documentPath: string,
+  body: string
+): DecisionProjectionRow {
   const frontmatter = readFrontmatter(body) ?? "";
   const decision = readDecisionSourceFields(frontmatter);
   const legacyId = legacyIdFromDecisionId(decision.decision_id);

--- a/packages/kernel/src/projection/sqlite-projection-source-cache.ts
+++ b/packages/kernel/src/projection/sqlite-projection-source-cache.ts
@@ -1,0 +1,524 @@
+import path from "node:path";
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+import { sha256Text, stablePayloadHash } from "../integrity/stable-hash.ts";
+import type { HarnessLayoutInput } from "../layout/index.ts";
+import { resolveHarnessLayout } from "../layout/index.ts";
+import { readFrontmatter } from "../markdown/frontmatter.ts";
+import {
+  captureAttributionEventSourcePersistentCache,
+  restoreAttributionEventSourcePersistentCache,
+  type AttributionEventSourcePersistentCache
+} from "../local/attribution-event-source.ts";
+import {
+  captureMarkdownSourcePersistentCache,
+  restoreMarkdownSourcePersistentCache,
+  type MarkdownSourcePersistentCache,
+  type TaskProjectionSourceHashInput
+} from "./sqlite-task-source.ts";
+import { runSqlite } from "./sqlite-projection-store.ts";
+
+type ProjectionSourceCacheKind = "task" | "attribution";
+
+export interface ProjectionSourceCacheFileRow {
+  readonly cacheKind: ProjectionSourceCacheKind;
+  readonly sourcePath: string;
+  readonly sourceKind: string;
+  readonly ownerId?: string;
+  readonly statSignature: string;
+  readonly contentSha256: string;
+  readonly body: string;
+}
+
+export interface ProjectionSourceCacheWatchRow {
+  readonly cacheKind: ProjectionSourceCacheKind;
+  readonly sourcePath: string;
+  readonly statSignature: string | null;
+}
+
+export interface ProjectionSourceCacheMetadataRow {
+  readonly cacheKind: ProjectionSourceCacheKind;
+  readonly payloadJson: string;
+  readonly payloadSha256: string;
+}
+
+export interface ProjectionSourceCacheSnapshot {
+  readonly files: ReadonlyArray<ProjectionSourceCacheFileRow>;
+  readonly watches: ReadonlyArray<ProjectionSourceCacheWatchRow>;
+  readonly metadata: ReadonlyArray<ProjectionSourceCacheMetadataRow>;
+  readonly hash: string;
+}
+
+export interface ProjectionSourceCacheChange {
+  readonly previous: ProjectionSourceCacheSnapshot;
+  readonly current: ProjectionSourceCacheSnapshot;
+}
+
+interface SourceCacheFileRecord {
+  readonly cache_kind: unknown;
+  readonly source_path: unknown;
+  readonly source_kind: unknown;
+  readonly owner_id: unknown;
+  readonly stat_signature: unknown;
+  readonly content_sha256: unknown;
+  readonly body: unknown;
+}
+
+interface SourceCacheWatchRecord {
+  readonly cache_kind: unknown;
+  readonly source_path: unknown;
+  readonly stat_signature: unknown;
+}
+
+interface SourceCacheMetadataRecord {
+  readonly cache_kind: unknown;
+  readonly payload_json: unknown;
+  readonly payload_sha256: unknown;
+}
+
+export function captureProjectionSourceCacheSnapshot(
+  rootInput: HarnessLayoutInput
+): ProjectionSourceCacheSnapshot | null {
+  const task = captureMarkdownSourcePersistentCache(rootInput);
+  const attribution = captureAttributionEventSourcePersistentCache(rootInput);
+  if (!task || !attribution) return null;
+  const layout = resolveHarnessLayout(rootInput);
+  const taskEntries = new Map(task.result.entries.map((entry) => [entry.indexPath, entry]));
+  const taskFiles = task.result.sourceInputs.map((input) => {
+    const entry = taskEntries.get(input.sourcePath);
+    return {
+      cacheKind: "task" as const,
+      sourcePath: input.sourcePath,
+      sourceKind: input.kind,
+      ...(entry ? { ownerId: entry.taskId } : {}),
+      statSignature: input.statSignature,
+      contentSha256: sha256Text(input.body),
+      body: input.body
+    };
+  });
+  const attributionFiles = attribution.source.inputs.map((input) => ({
+    cacheKind: "attribution" as const,
+    sourcePath: rootRelativePath(layout.rootDir, path.join(layout.attributionEventsRoot, input.relativePath)),
+    sourceKind: "attribution-event",
+    statSignature: input.statSignature,
+    contentSha256: input.contentSha256,
+    body: input.body
+  }));
+  const fileKeys = new Set([...taskFiles, ...attributionFiles].map(cachePathKey));
+  const watches = [
+    ...task.directorySignatures.map((entry) => ({ cacheKind: "task" as const, sourcePath: entry.relativePath, statSignature: entry.signature })),
+    ...attribution.signatures
+      .filter((entry) => !fileKeys.has(cachePathKey({ cacheKind: "attribution", sourcePath: entry.relativePath })))
+      .map((entry) => ({ cacheKind: "attribution" as const, sourcePath: entry.relativePath, statSignature: entry.signature }))
+  ];
+  return projectionSourceCacheSnapshot({
+    files: [...taskFiles, ...attributionFiles],
+    watches,
+    metadata: [
+      metadataRow("task", { schema: "task-source-cache-metadata/v1", layoutIdentity: task.layoutIdentity, warnings: task.result.warnings }),
+      metadataRow("attribution", { schema: "attribution-source-cache-metadata/v1", layoutIdentity: attribution.layoutIdentity })
+    ]
+  });
+}
+
+export function readProjectionSourceCacheSnapshot(projectionPath: string): ProjectionSourceCacheSnapshot {
+  return runSqlite(projectionPath, Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    yield* sql`BEGIN`;
+    try {
+      const files = yield* sql<SourceCacheFileRecord>`
+        SELECT cache_kind, source_path, source_kind, owner_id, stat_signature,
+               content_sha256, body
+        FROM projection_source_cache_files
+        ORDER BY cache_kind, source_path
+      `;
+      const watches = yield* sql<SourceCacheWatchRecord>`
+        SELECT cache_kind, source_path, stat_signature
+        FROM projection_source_cache_watches
+        ORDER BY cache_kind, source_path
+      `;
+      const metadata = yield* sql<SourceCacheMetadataRecord>`
+        SELECT cache_kind, payload_json, payload_sha256
+        FROM projection_source_cache_metadata
+        ORDER BY cache_kind
+      `;
+      const snapshot = projectionSourceCacheSnapshot({
+        files: files.map(recordToFileRow),
+        watches: watches.map(recordToWatchRow),
+        metadata: metadata.map(recordToMetadataRow)
+      });
+      yield* sql`COMMIT`;
+      return snapshot;
+    } catch (error) {
+      yield* sql`ROLLBACK`;
+      throw error;
+    }
+  }));
+}
+
+export function restoreProjectionSourceCacheSnapshot(
+  rootInput: HarnessLayoutInput,
+  snapshot: ProjectionSourceCacheSnapshot
+): {
+  readonly valid: boolean;
+  readonly task: "fresh" | "stale";
+  readonly attribution: "fresh" | "stale";
+} {
+  try {
+    const layout = resolveHarnessLayout(rootInput);
+    const metadata = new Map(snapshot.metadata.map((row) => [row.cacheKind, JSON.parse(row.payloadJson) as Record<string, unknown>]));
+    const taskMetadata = requiredMetadata(metadata, "task");
+    const attributionMetadata = requiredMetadata(metadata, "attribution");
+    const taskLayoutIdentity = [layout.rootDir, layout.authoredRoot, layout.tasksRoot, layout.decisionsRoot].join("\0");
+    if (taskMetadata.layoutIdentity !== taskLayoutIdentity ||
+        attributionMetadata.layoutIdentity !== layout.attributionEventsRoot) {
+      return { valid: true, task: "stale", attribution: "stale" };
+    }
+    const taskFiles = snapshot.files.filter((row) => row.cacheKind === "task");
+    const taskInputs: TaskProjectionSourceHashInput[] = taskFiles
+      .map((row) => ({ kind: row.sourceKind, sourcePath: row.sourcePath, body: row.body, statSignature: row.statSignature }))
+      .sort(compareTaskSourceInputs);
+    const task: MarkdownSourcePersistentCache = {
+      schema: "markdown-source-cache/v1",
+      layoutIdentity: String(taskMetadata.layoutIdentity),
+      result: {
+        entries: taskFiles.filter((row) => row.sourceKind === "task-index").map((row) => ({
+          taskId: row.ownerId ?? path.basename(path.dirname(row.sourcePath)),
+          indexPath: row.sourcePath,
+          body: row.body,
+          frontmatter: readFrontmatter(row.body) ?? "",
+          statSignature: row.statSignature
+        })),
+        hash: taskSourceHash(taskInputs),
+        warnings: Array.isArray(taskMetadata.warnings) ? taskMetadata.warnings as MarkdownSourcePersistentCache["result"]["warnings"] : [],
+        sourceInputs: taskInputs
+      },
+      fileSignatures: taskFiles.map((row) => ({ relativePath: row.sourcePath, signature: row.statSignature })),
+      directorySignatures: snapshot.watches
+        .filter((row) => row.cacheKind === "task")
+        .map((row) => ({ relativePath: row.sourcePath, signature: row.statSignature }))
+    };
+    const attributionFiles = snapshot.files.filter((row) => row.cacheKind === "attribution");
+    const attribution: AttributionEventSourcePersistentCache = {
+      schema: "attribution-event-source-cache/v1",
+      layoutIdentity: String(attributionMetadata.layoutIdentity),
+      source: {
+        inputs: attributionFiles.map((row) => ({
+          relativePath: path.relative(layout.attributionEventsRoot, path.resolve(layout.rootDir, row.sourcePath)).split(path.sep).join("/"),
+          body: row.body,
+          statSignature: row.statSignature,
+          contentSha256: row.contentSha256
+        })),
+        hash: stablePayloadHash({
+          schema: "attribution-event-source/v2",
+          inputs: attributionFiles.map((row) => ({
+            relativePath: path.relative(layout.attributionEventsRoot, path.resolve(layout.rootDir, row.sourcePath)).split(path.sep).join("/"),
+            contentSha256: row.contentSha256
+          }))
+        })
+      },
+      signatures: [
+        ...attributionFiles.map((row) => ({ relativePath: row.sourcePath, signature: row.statSignature })),
+        ...snapshot.watches
+          .filter((row) => row.cacheKind === "attribution")
+          .map((row) => ({ relativePath: row.sourcePath, signature: row.statSignature }))
+      ]
+    };
+    const taskRestore = restoreMarkdownSourcePersistentCache(rootInput, task);
+    const attributionRestore = restoreAttributionEventSourcePersistentCache(rootInput, attribution);
+    if (taskRestore === "invalid" || attributionRestore === "invalid") {
+      return { valid: false, task: "stale", attribution: "stale" };
+    }
+    return { valid: true, task: taskRestore, attribution: attributionRestore };
+  } catch {
+    return { valid: false, task: "stale", attribution: "stale" };
+  }
+}
+
+export function replaceProjectionSourceCacheRows(
+  sql: SqlClient.SqlClient,
+  snapshot: ProjectionSourceCacheSnapshot
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    yield* createProjectionSourceCacheTables(sql);
+    yield* sql`DELETE FROM projection_source_cache_files`;
+    yield* sql`DELETE FROM projection_source_cache_watches`;
+    yield* sql`DELETE FROM projection_source_cache_metadata`;
+    for (const rows of chunks(snapshot.files, 250)) yield* insertFileRows(sql, rows);
+    for (const rows of chunks(snapshot.watches, 500)) yield* insertWatchRows(sql, rows);
+    for (const row of snapshot.metadata) yield* upsertMetadataRow(sql, row);
+  });
+}
+
+export function applyProjectionSourceCacheChange(
+  sql: SqlClient.SqlClient,
+  change: ProjectionSourceCacheChange
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    yield* createProjectionSourceCacheTables(sql);
+    const currentFiles = new Map(change.current.files.map((row) => [cachePathKey(row), row]));
+    const previousFiles = new Map(change.previous.files.map((row) => [cachePathKey(row), row]));
+    for (const [key, row] of previousFiles) {
+      if (!currentFiles.has(key)) yield* deleteCachePath(sql, "projection_source_cache_files", row);
+    }
+    for (const [key, row] of currentFiles) {
+      if (!sameFileRow(previousFiles.get(key), row)) yield* upsertFileRow(sql, row);
+    }
+    const currentWatches = new Map(change.current.watches.map((row) => [cachePathKey(row), row]));
+    const previousWatches = new Map(change.previous.watches.map((row) => [cachePathKey(row), row]));
+    for (const [key, row] of previousWatches) {
+      if (!currentWatches.has(key)) yield* deleteCachePath(sql, "projection_source_cache_watches", row);
+    }
+    for (const [key, row] of currentWatches) {
+      if (!sameWatchRow(previousWatches.get(key), row)) yield* upsertWatchRow(sql, row);
+    }
+    const previousMetadata = new Map(change.previous.metadata.map((row) => [row.cacheKind, row]));
+    for (const row of change.current.metadata) {
+      if (previousMetadata.get(row.cacheKind)?.payloadSha256 !== row.payloadSha256) yield* upsertMetadataRow(sql, row);
+    }
+  });
+}
+
+export function updateProjectionSourceCacheSnapshot(
+  projectionPath: string,
+  previous: ProjectionSourceCacheSnapshot,
+  current: ProjectionSourceCacheSnapshot
+): void {
+  runSqlite(projectionPath, Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    yield* sql`BEGIN IMMEDIATE`;
+    try {
+      yield* applyProjectionSourceCacheChange(sql, { previous, current });
+      yield* sql`
+        INSERT OR REPLACE INTO projection_meta (key, value)
+        VALUES ('sourceCacheHash', ${current.hash})
+      `;
+      yield* sql`COMMIT`;
+    } catch (error) {
+      yield* sql`ROLLBACK`;
+      throw error;
+    }
+  }));
+}
+
+function projectionSourceCacheSnapshot(input: {
+  readonly files: ReadonlyArray<ProjectionSourceCacheFileRow>;
+  readonly watches: ReadonlyArray<ProjectionSourceCacheWatchRow>;
+  readonly metadata: ReadonlyArray<ProjectionSourceCacheMetadataRow>;
+}): ProjectionSourceCacheSnapshot {
+  const files = [...input.files].sort(compareCachePaths);
+  const watches = [...input.watches].sort(compareCachePaths);
+  const metadata = [...input.metadata].sort((left, right) => left.cacheKind.localeCompare(right.cacheKind));
+  assertCacheKinds(metadata.map((row) => row.cacheKind));
+  for (const row of files) {
+    if (sha256Text(row.body) !== row.contentSha256) throw new Error(`projection source cache body hash mismatch: ${row.sourcePath}`);
+  }
+  for (const row of metadata) {
+    const expected = stablePayloadHash({ schema: "projection-source-cache-metadata-payload/v1", payloadJson: row.payloadJson });
+    if (row.payloadSha256 !== expected) throw new Error(`projection source cache metadata hash mismatch: ${row.cacheKind}`);
+  }
+  return {
+    files,
+    watches,
+    metadata,
+    hash: stablePayloadHash({
+      schema: "projection-source-cache/v2",
+      files: files.map(({ body: _body, ...row }) => row),
+      watches,
+      metadata: metadata.map(({ cacheKind, payloadSha256 }) => ({ cacheKind, payloadSha256 }))
+    })
+  };
+}
+
+function metadataRow(cacheKind: ProjectionSourceCacheKind, payload: unknown): ProjectionSourceCacheMetadataRow {
+  const payloadJson = JSON.stringify(payload);
+  return {
+    cacheKind,
+    payloadJson,
+    payloadSha256: stablePayloadHash({ schema: "projection-source-cache-metadata-payload/v1", payloadJson })
+  };
+}
+
+function createProjectionSourceCacheTables(sql: SqlClient.SqlClient): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS projection_source_cache_files (
+        cache_kind TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        source_kind TEXT NOT NULL,
+        owner_id TEXT,
+        stat_signature TEXT NOT NULL,
+        content_sha256 TEXT NOT NULL,
+        body TEXT NOT NULL,
+        PRIMARY KEY (cache_kind, source_path)
+      )
+    `;
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS projection_source_cache_watches (
+        cache_kind TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        stat_signature TEXT,
+        PRIMARY KEY (cache_kind, source_path)
+      )
+    `;
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS projection_source_cache_metadata (
+        cache_kind TEXT PRIMARY KEY,
+        payload_json TEXT NOT NULL,
+        payload_sha256 TEXT NOT NULL
+      )
+    `;
+  });
+}
+
+function upsertFileRow(sql: SqlClient.SqlClient, row: ProjectionSourceCacheFileRow): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT OR REPLACE INTO projection_source_cache_files (
+      cache_kind, source_path, source_kind, owner_id, stat_signature,
+      content_sha256, body
+    ) VALUES (
+      ${row.cacheKind}, ${row.sourcePath}, ${row.sourceKind}, ${row.ownerId ?? null},
+      ${row.statSignature}, ${row.contentSha256}, ${row.body}
+    )
+  `;
+}
+
+function insertFileRows(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<ProjectionSourceCacheFileRow>
+): Effect.Effect<unknown, unknown> {
+  return sql.unsafe(`
+    INSERT INTO projection_source_cache_files (
+      cache_kind, source_path, source_kind, owner_id, stat_signature,
+      content_sha256, body
+    ) VALUES ${rows.map(() => "(?, ?, ?, ?, ?, ?, ?)").join(", ")}
+  `, rows.flatMap((row) => [
+    row.cacheKind,
+    row.sourcePath,
+    row.sourceKind,
+    row.ownerId ?? null,
+    row.statSignature,
+    row.contentSha256,
+    row.body
+  ]));
+}
+
+function upsertWatchRow(sql: SqlClient.SqlClient, row: ProjectionSourceCacheWatchRow): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT OR REPLACE INTO projection_source_cache_watches (cache_kind, source_path, stat_signature)
+    VALUES (${row.cacheKind}, ${row.sourcePath}, ${row.statSignature})
+  `;
+}
+
+function insertWatchRows(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<ProjectionSourceCacheWatchRow>
+): Effect.Effect<unknown, unknown> {
+  return sql.unsafe(`
+    INSERT INTO projection_source_cache_watches (cache_kind, source_path, stat_signature)
+    VALUES ${rows.map(() => "(?, ?, ?)").join(", ")}
+  `, rows.flatMap((row) => [row.cacheKind, row.sourcePath, row.statSignature]));
+}
+
+function upsertMetadataRow(sql: SqlClient.SqlClient, row: ProjectionSourceCacheMetadataRow): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT OR REPLACE INTO projection_source_cache_metadata (cache_kind, payload_json, payload_sha256)
+    VALUES (${row.cacheKind}, ${row.payloadJson}, ${row.payloadSha256})
+  `;
+}
+
+function deleteCachePath(
+  sql: SqlClient.SqlClient,
+  table: "projection_source_cache_files" | "projection_source_cache_watches",
+  row: { readonly cacheKind: string; readonly sourcePath: string }
+): Effect.Effect<unknown, unknown> {
+  return sql.unsafe(`DELETE FROM ${table} WHERE cache_kind = ? AND source_path = ?`, [row.cacheKind, row.sourcePath]);
+}
+
+function recordToFileRow(record: SourceCacheFileRecord): ProjectionSourceCacheFileRow {
+  return {
+    cacheKind: cacheKind(record.cache_kind),
+    sourcePath: String(record.source_path),
+    sourceKind: String(record.source_kind),
+    ...(record.owner_id === null ? {} : { ownerId: String(record.owner_id) }),
+    statSignature: String(record.stat_signature),
+    contentSha256: String(record.content_sha256),
+    body: String(record.body)
+  };
+}
+
+function recordToWatchRow(record: SourceCacheWatchRecord): ProjectionSourceCacheWatchRow {
+  return {
+    cacheKind: cacheKind(record.cache_kind),
+    sourcePath: String(record.source_path),
+    statSignature: record.stat_signature === null ? null : String(record.stat_signature)
+  };
+}
+
+function recordToMetadataRow(record: SourceCacheMetadataRecord): ProjectionSourceCacheMetadataRow {
+  return {
+    cacheKind: cacheKind(record.cache_kind),
+    payloadJson: String(record.payload_json),
+    payloadSha256: String(record.payload_sha256)
+  };
+}
+
+function cacheKind(value: unknown): ProjectionSourceCacheKind {
+  const kind = String(value);
+  if (kind !== "task" && kind !== "attribution") throw new Error(`unknown projection source cache kind: ${kind}`);
+  return kind;
+}
+
+function requiredMetadata(
+  rows: ReadonlyMap<ProjectionSourceCacheKind, Record<string, unknown>>,
+  kind: ProjectionSourceCacheKind
+): Record<string, unknown> {
+  const row = rows.get(kind);
+  if (!row) throw new Error(`projection source cache metadata missing: ${kind}`);
+  return row;
+}
+
+function assertCacheKinds(kinds: ReadonlyArray<ProjectionSourceCacheKind>): void {
+  if (kinds.length !== 2 || new Set(kinds).size !== 2 || !kinds.includes("task") || !kinds.includes("attribution")) {
+    throw new Error("projection source cache metadata must contain task and attribution rows");
+  }
+}
+
+function rootRelativePath(rootDir: string, inputPath: string): string {
+  return path.relative(rootDir, inputPath).split(path.sep).join("/");
+}
+
+function cachePathKey(row: { readonly cacheKind: string; readonly sourcePath: string }): string {
+  return `${row.cacheKind}\0${row.sourcePath}`;
+}
+
+function compareCachePaths(
+  left: { readonly cacheKind: string; readonly sourcePath: string },
+  right: { readonly cacheKind: string; readonly sourcePath: string }
+): number {
+  return cachePathKey(left).localeCompare(cachePathKey(right));
+}
+
+function compareTaskSourceInputs(left: TaskProjectionSourceHashInput, right: TaskProjectionSourceHashInput): number {
+  const leftRank = left.kind === "task-index" ? 0 : 1;
+  const rightRank = right.kind === "task-index" ? 0 : 1;
+  return leftRank - rightRank || left.sourcePath.localeCompare(right.sourcePath);
+}
+
+function taskSourceHash(inputs: ReadonlyArray<TaskProjectionSourceHashInput>): string {
+  return `sha256:${sha256Text(JSON.stringify(inputs.map(({ kind, sourcePath, body }) => ({ kind, sourcePath, body }))))}`;
+}
+
+function sameFileRow(left: ProjectionSourceCacheFileRow | undefined, right: ProjectionSourceCacheFileRow): boolean {
+  return left !== undefined && stablePayloadHash({ ...left, body: undefined }) === stablePayloadHash({ ...right, body: undefined });
+}
+
+function sameWatchRow(left: ProjectionSourceCacheWatchRow | undefined, right: ProjectionSourceCacheWatchRow): boolean {
+  return left !== undefined && left.statSignature === right.statSignature;
+}
+
+function chunks<Value>(values: ReadonlyArray<Value>, size: number): ReadonlyArray<ReadonlyArray<Value>> {
+  const output: Value[][] = [];
+  for (let index = 0; index < values.length; index += size) output.push(values.slice(index, index + size));
+  return output;
+}

--- a/packages/kernel/src/projection/sqlite-projection-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-store.ts
@@ -21,7 +21,7 @@ import type {
   TaskProjectionRow
 } from "./types.ts";
 
-export const projectionVersion = "entity-projection/d4-v10";
+export const projectionVersion = "entity-projection/d4-v11";
 const baseTaskProjectionColumns = [
   "task_id",
   "title",
@@ -163,6 +163,7 @@ export function writeProjectionDatabase(
     yield* insertMeta(sql, "attributionRowsHash", meta.attributionRowsHash ?? "");
     yield* insertMeta(sql, "attributionSourceHash", meta.attributionSourceHash ?? "");
     yield* insertMeta(sql, "taskSourceHash", meta.taskSourceHash ?? "");
+    yield* insertMeta(sql, "sourceCacheHash", meta.sourceCacheHash ?? "");
     yield* insertMeta(sql, "legacyPersonIdsHash", meta.legacyPersonIdsHash ?? "");
     for (const row of rows) yield* insertTaskRow(sql, row, projectedTaskFieldExtensions);
     for (const row of decisionRows) yield* insertDecisionRow(sql, row);
@@ -294,6 +295,7 @@ function readProjectionDatabase(
         attributionRowsHash: meta.get("attributionRowsHash") ?? "",
         attributionSourceHash: meta.get("attributionSourceHash") ?? "",
         taskSourceHash: meta.get("taskSourceHash") ?? "",
+        sourceCacheHash: meta.get("sourceCacheHash") ?? "",
         legacyPersonIdsHash: meta.get("legacyPersonIdsHash") ?? ""
       },
       rows: taskRecords.map((record) => recordToTaskRow(record, taskFieldExtensions)),

--- a/packages/kernel/src/projection/sqlite-projection-update-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-update-store.ts
@@ -2,14 +2,18 @@ import { SqlClient } from "@effect/sql";
 import { Effect } from "effect";
 import type { ProjectionMeta, TaskFieldExtensionProjection, TaskProjectionRow, DecisionProjectionRow } from "./types.ts";
 import type { ProjectionGraphRows } from "./sqlite-projection-store.ts";
-import type { AttributionEvent } from "../schemas/attribution-event.ts";
 import { deleteDeclaredProjectionRows, upsertDeclaredProjectionRows } from "./entity-declaration-projection.ts";
 import { applyDeclaredSourceManifestDelta, type DeclaredProjectionDelta } from "./sqlite-declared-source-manifest.ts";
+import {
+  applyProjectionSourceCacheChange,
+  type ProjectionSourceCacheChange
+} from "./sqlite-projection-source-cache.ts";
 import {
   applyAttributionProjectionDelta,
   materializeEntityAttributionSubjects,
   materializeEntityAttributionTargets,
 } from "./sqlite-attribution-projection.ts";
+import type { AttributionProjectionDelta } from "./sqlite-attribution-projection.ts";
 import {
   insertCoverageRow,
   insertDecisionRow,
@@ -31,7 +35,8 @@ export function updateProjectionDatabase(
     readonly meta: ProjectionMeta;
     readonly graphRows?: ProjectionGraphRows;
     readonly declaredDelta: DeclaredProjectionDelta;
-    readonly attributionEvents?: ReadonlyArray<AttributionEvent>;
+    readonly attributionDelta?: AttributionProjectionDelta;
+    readonly sourceCache?: ProjectionSourceCacheChange;
     readonly taskFieldExtensions?: ReadonlyArray<TaskFieldExtensionProjection>;
   }
 ): void {
@@ -40,6 +45,7 @@ export function updateProjectionDatabase(
     const projectedTaskFieldExtensions = queryableTaskFieldExtensions(change.taskFieldExtensions ?? []);
     yield* sql`BEGIN IMMEDIATE`;
     try {
+      const reuseAttributionRowsHash = yield* canReuseAttributionRowsHash(sql, change);
       for (const taskId of uniqueProjectionIds(change.deleteTaskIds)) {
         yield* sql`DELETE FROM task_projection WHERE task_id = ${taskId}`;
       }
@@ -65,8 +71,9 @@ export function updateProjectionDatabase(
         yield* upsertDeclaredProjectionRows(sql, table.declaration, table.upsertRows);
       }
       yield* applyDeclaredSourceManifestDelta(sql, change.declaredDelta.manifest);
-      if (change.attributionEvents) {
-        const affectedSubjects = yield* applyAttributionProjectionDelta(sql, change.attributionEvents);
+      if (change.sourceCache) yield* applyProjectionSourceCacheChange(sql, change.sourceCache);
+      if (change.attributionDelta) {
+        const affectedSubjects = yield* applyAttributionProjectionDelta(sql, change.attributionDelta);
         yield* materializeEntityAttributionSubjects(sql, affectedSubjects);
         yield* materializeEntityAttributionTargets(sql, changedAttributionTargets(change));
       } else {
@@ -77,10 +84,13 @@ export function updateProjectionDatabase(
       yield* upsertMeta(sql, "decisionRowsHash", change.meta.decisionRowsHash ?? "");
       yield* upsertMeta(sql, "declaredRowsHash", change.meta.declaredRowsHash ?? "");
       yield* upsertMeta(sql, "declaredManifestHash", change.meta.declaredManifestHash ?? "");
-      const attributionRowsHash = yield* hashAttributionProjectionState(sql);
+      const attributionRowsHash = reuseAttributionRowsHash && change.meta.attributionRowsHash
+        ? change.meta.attributionRowsHash
+        : yield* hashAttributionProjectionState(sql);
       yield* upsertMeta(sql, "attributionRowsHash", attributionRowsHash);
       yield* upsertMeta(sql, "attributionSourceHash", change.meta.attributionSourceHash ?? "");
       yield* upsertMeta(sql, "taskSourceHash", change.meta.taskSourceHash ?? "");
+      if (change.sourceCache) yield* upsertMeta(sql, "sourceCacheHash", change.sourceCache.current.hash);
       yield* upsertMeta(sql, "legacyPersonIdsHash", change.meta.legacyPersonIdsHash ?? "");
       yield* sql`COMMIT`;
     } catch (error) {
@@ -88,6 +98,38 @@ export function updateProjectionDatabase(
       throw error;
     }
   }));
+}
+
+function canReuseAttributionRowsHash(
+  sql: SqlClient.SqlClient,
+  change: {
+    readonly deleteTaskIds: ReadonlyArray<string>;
+    readonly upsertTaskRows: ReadonlyArray<TaskProjectionRow>;
+    readonly deleteDecisionIds: ReadonlyArray<string>;
+    readonly upsertDecisionRows: ReadonlyArray<DecisionProjectionRow>;
+    readonly declaredDelta: DeclaredProjectionDelta;
+    readonly attributionDelta?: AttributionProjectionDelta;
+  }
+): Effect.Effect<boolean, unknown> {
+  return Effect.gen(function* () {
+    if (change.attributionDelta) return false;
+    const finalTaskIds = new Set(change.upsertTaskRows.map((row) => row.taskId));
+    if (change.deleteTaskIds.some((taskId) => !finalTaskIds.has(taskId))) return false;
+    const finalDecisionIds = new Set(change.upsertDecisionRows.map((row) => row.decisionId));
+    if (change.deleteDecisionIds.some((decisionId) => !finalDecisionIds.has(decisionId))) return false;
+    for (const table of change.declaredDelta.tables) {
+      const primaryKey = table.declaration.projection.columns.find((column) => column.primaryKey)!;
+      const finalIds = new Set(table.upsertRows.map((row) => String(row[primaryKey.name])));
+      if (table.deletePrimaryKeys.some((id) => !finalIds.has(id))) return false;
+    }
+    for (const target of changedAttributionTargets(change)) {
+      const idColumn = attributionEntityIdColumns.get(target.table);
+      if (!idColumn) throw new Error(`unknown attributed projection table: ${target.table}`);
+      const records = yield* sql.unsafe(`SELECT 1 FROM ${target.table} WHERE ${idColumn} = ? LIMIT 1`, [target.id]);
+      if (records.length === 0) return false;
+    }
+    return true;
+  });
 }
 
 function changedAttributionTargets(change: {
@@ -115,3 +157,11 @@ function upsertMeta(sql: SqlClient.SqlClient, key: string, value: string): Effec
 function uniqueProjectionIds(values: ReadonlyArray<string>): ReadonlyArray<string> {
   return [...new Set(values)];
 }
+
+const attributionEntityIdColumns = new Map([
+  ["task_projection", "task_id"],
+  ["decision_projection", "decision_id"],
+  ["session_projection", "session_id"],
+  ["execution_projection", "execution_id"],
+  ["review_projection", "review_id"]
+]);

--- a/packages/kernel/src/projection/sqlite-projection-validation-cache.ts
+++ b/packages/kernel/src/projection/sqlite-projection-validation-cache.ts
@@ -1,0 +1,33 @@
+import { localProjectionSourceFileSystem } from "../local/local-layout-file-system.ts";
+import type { DeclaredSourceManifestRow } from "./sqlite-declared-source-manifest.ts";
+
+export interface ProjectionValidationCacheEntry {
+  readonly signature: string;
+  readonly declaredManifest: ReadonlyArray<DeclaredSourceManifestRow>;
+}
+
+const projectionValidationCache = new Map<string, ProjectionValidationCacheEntry>();
+const projectionValidationCacheLimit = 16;
+
+export function readCachedProjectionValidation(projectionPath: string): ProjectionValidationCacheEntry | null {
+  const cached = projectionValidationCache.get(projectionPath);
+  if (!cached || localProjectionSourceFileSystem.statSignature(projectionPath) !== cached.signature) return null;
+  projectionValidationCache.delete(projectionPath);
+  projectionValidationCache.set(projectionPath, cached);
+  return cached;
+}
+
+export function rememberProjectionValidation(
+  projectionPath: string,
+  declaredManifest: ReadonlyArray<DeclaredSourceManifestRow>
+): void {
+  const signature = localProjectionSourceFileSystem.statSignature(projectionPath);
+  if (signature === null) return;
+  projectionValidationCache.delete(projectionPath);
+  projectionValidationCache.set(projectionPath, { signature, declaredManifest });
+  while (projectionValidationCache.size > projectionValidationCacheLimit) {
+    const oldest = projectionValidationCache.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    projectionValidationCache.delete(oldest);
+  }
+}

--- a/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
@@ -1,11 +1,10 @@
 import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { createHarnessRuntimeContext, resolveHarnessLayout } from "../layout/index.ts";
-import { readAttributionEventsFromSource } from "../local/attribution-event-source.ts";
 import { readScalar } from "../markdown/frontmatter.ts";
 import type { RelationGraphEdgeRow } from "./relation-graph-projection.ts";
 import { buildRelationGraphProjection } from "./relation-graph-projection.ts";
-import { compareDecisionRows, hashDecisionProjectionRows, readDecisionProjectionRowsForPaths } from "./sqlite-decision-source.ts";
+import { compareDecisionRows, hashDecisionProjectionRows, readDecisionProjectionRowsForPathsFromSource } from "./sqlite-decision-source.ts";
 import {
   applyDeclaredProjectionDeltaToSnapshots,
   buildDeclaredProjectionDeltaFromSources,
@@ -15,11 +14,24 @@ import {
 import {
   readAttributionProjectionStateHash,
   readRelationGraphRows,
+  projectionVersion,
   tryReadProjectionDatabase
 } from "./sqlite-projection-store.ts";
 import { updateProjectionDatabase } from "./sqlite-projection-update-store.ts";
+import { buildAttributionProjectionDelta } from "./sqlite-attribution-projection.ts";
+import {
+  captureProjectionSourceCacheSnapshot,
+  readProjectionSourceCacheSnapshot,
+  restoreProjectionSourceCacheSnapshot
+} from "./sqlite-projection-source-cache.ts";
 import { compareRows, hashExactRows, readMarkdownSource, sourcePath, taskEntryToRow } from "./sqlite-task-source.ts";
-import { rebuildTaskProjection } from "./sqlite-task-projection.ts";
+import {
+  rebuildTaskProjection
+} from "./sqlite-task-projection.ts";
+import {
+  readCachedProjectionValidation,
+  rememberProjectionValidation
+} from "./sqlite-projection-validation-cache.ts";
 import {
   captureProjectionSourceFingerprint,
   hashDeclaredProjectionSnapshots,
@@ -44,13 +56,29 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   if (!existing.ok) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
+  if (existing.meta.version !== projectionVersion) {
+    return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+  }
+  const cachedValidation = readCachedProjectionValidation(projectionPath);
+  let persistedSourceCache: ReturnType<typeof readProjectionSourceCacheSnapshot> | undefined;
+  if (!cachedValidation) {
+    try {
+      persistedSourceCache = readVerifiedProjectionSourceCache(projectionPath, existing.meta.sourceCacheHash);
+      const restored = restoreProjectionSourceCacheSnapshot(runtimeContext, persistedSourceCache);
+      if (!restored.valid) throw new Error("projection source cache payload invalid");
+    } catch {
+      return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+    }
+  }
   let declaredManifest: ReturnType<typeof readDeclaredSourceManifestRows>;
   let existingDeclaredTables: ReturnType<typeof readDeclaredProjectionSnapshots>;
   let attributionRowsHash: string;
   try {
-    declaredManifest = readDeclaredSourceManifestRows(projectionPath);
+    declaredManifest = cachedValidation?.declaredManifest ?? readDeclaredSourceManifestRows(projectionPath);
     existingDeclaredTables = readDeclaredProjectionSnapshots(projectionPath);
-    attributionRowsHash = readAttributionProjectionStateHash(projectionPath);
+    attributionRowsHash = cachedValidation
+      ? existing.meta.attributionRowsHash ?? ""
+      : readAttributionProjectionStateHash(projectionPath);
   } catch {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
@@ -64,7 +92,9 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   const oldGraph = safeReadRelationGraphRows(projectionPath);
   const declaredEntityOnly = options.touchedPaths.length > 0 && options.touchedPaths
     .every((filePath) => isDeclaredEntityFile(resolveHarnessLayout(runtimeContext).authoredRoot, realPathIfExists(filePath)));
-  const newGraph = declaredEntityOnly || options.touchedPaths.length === 0 ? null : buildRelationGraphProjection(runtimeContext);
+  const newGraph = declaredEntityOnly || options.touchedPaths.length === 0
+    ? null
+    : buildRelationGraphProjection(runtimeContext, snapshot.taskSource.sourceInputs);
   const affected = affectedProjectionEntities({
     rootDir,
     rootInput: runtimeContext,
@@ -98,7 +128,13 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   }
 
   const taskChange = incrementalTaskRows(runtimeContext, source.entries, existing.rows, affected.taskIds, options.taskFieldExtensions);
-  const decisionChange = incrementalDecisionRows(runtimeContext, existing.decisionRows, affected.decisionIds, affected.decisionPaths);
+  const decisionChange = incrementalDecisionRows(
+    runtimeContext,
+    existing.decisionRows,
+    affected.decisionIds,
+    affected.decisionPaths,
+    source.sourceInputs
+  );
   const rowsHash = hashExactRows(taskChange.rows);
   const decisionRowsHash = hashDecisionProjectionRows(decisionChange.rows);
   const declaredRowsHash = hashDeclaredProjectionSnapshots(
@@ -117,6 +153,30 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   if (verifiedSourceHash !== sourceHash) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
+  const sourceCacheNeedsRefresh = existing.meta.taskSourceHash !== snapshot.taskSource.hash ||
+    existing.meta.attributionSourceHash !== snapshot.attributionSource.hash;
+  if (sourceCacheNeedsRefresh && !persistedSourceCache) {
+    try {
+      persistedSourceCache = readVerifiedProjectionSourceCache(projectionPath, existing.meta.sourceCacheHash);
+    } catch {
+      return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+    }
+  }
+  const sourceCache = sourceCacheNeedsRefresh ? captureProjectionSourceCacheSnapshot(runtimeContext) : null;
+  if (sourceCacheNeedsRefresh && !sourceCache) {
+    return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+  }
+  const sourceCacheChange = sourceCache && persistedSourceCache && sourceCache.hash !== persistedSourceCache.hash
+    ? { previous: persistedSourceCache, current: sourceCache }
+    : undefined;
+  const attributionChanged = existing.meta.attributionSourceHash !== snapshot.attributionSource.hash;
+  let attributionDelta: ReturnType<typeof buildAttributionProjectionDelta> | undefined;
+  if (attributionChanged) {
+    if (!sourceCacheChange) {
+      return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+    }
+    attributionDelta = buildAttributionProjectionDelta(sourceCacheChange);
+  }
 
   updateProjectionDatabase(projectionPath, {
     deleteTaskIds: [...taskChange.deleteIds],
@@ -129,8 +189,10 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
       decisionRowsHash,
       declaredRowsHash,
       declaredManifestHash,
+      attributionRowsHash: existing.meta.attributionRowsHash,
       attributionSourceHash: snapshot.attributionSource.hash,
       taskSourceHash: snapshot.taskSource.hash,
+      sourceCacheHash: sourceCache?.hash ?? existing.meta.sourceCacheHash,
       legacyPersonIdsHash: hashProjectionLegacyPersonIds(snapshot.legacyPersonIds)
     },
     ...(newGraph ? { graphRows: {
@@ -139,17 +201,26 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
       factAnchors: newGraph.factAnchors
     } } : {}),
     declaredDelta,
-    ...(existing.meta.attributionSourceHash === snapshot.attributionSource.hash
-      ? {}
-      : { attributionEvents: readAttributionEventsFromSource(snapshot.attributionSource) }),
+    ...(sourceCacheChange ? { sourceCache: sourceCacheChange } : {}),
+    ...(attributionDelta ? { attributionDelta } : {}),
     taskFieldExtensions: options.taskFieldExtensions
   });
+  rememberProjectionValidation(projectionPath, declaredDelta.manifest.currentRows);
 
   return {
     rows: taskChange.rows,
     warnings: source.warnings,
     mode: "incremental"
   };
+}
+
+function readVerifiedProjectionSourceCache(
+  projectionPath: string,
+  expectedHash: string | undefined
+): ReturnType<typeof readProjectionSourceCacheSnapshot> {
+  const snapshot = readProjectionSourceCacheSnapshot(projectionPath);
+  if (snapshot.hash !== expectedHash) throw new Error("projection source cache hash mismatch");
+  return snapshot;
 }
 
 function hasAffectedProjectionEntities(affected: {
@@ -214,16 +285,17 @@ function incrementalTaskRows(
 }
 
 function incrementalDecisionRows(
-  rootInput: Parameters<typeof readDecisionProjectionRowsForPaths>[0],
+  rootInput: Parameters<typeof readDecisionProjectionRowsForPathsFromSource>[0],
   existingRows: ReadonlyArray<DecisionProjectionRow>,
   affectedDecisionIds: ReadonlySet<string>,
-  affectedDecisionPaths: ReadonlySet<string>
+  affectedDecisionPaths: ReadonlySet<string>,
+  sourceInputs: ReturnType<typeof readMarkdownSource>["sourceInputs"]
 ): {
   readonly rows: ReadonlyArray<DecisionProjectionRow>;
   readonly currentRows: ReadonlyArray<DecisionProjectionRow>;
   readonly deleteIds: ReadonlySet<string>;
 } {
-  const currentRows = readDecisionProjectionRowsForPaths(rootInput, [...affectedDecisionPaths]);
+  const currentRows = readDecisionProjectionRowsForPathsFromSource(rootInput, [...affectedDecisionPaths], sourceInputs);
   const deleteIds = new Set([...affectedDecisionIds, ...currentRows.map((row) => row.decisionId)]);
   return {
     rows: [

--- a/packages/kernel/src/projection/sqlite-task-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-projection.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { Effect } from "effect";
 import { createHarnessRuntimeContext } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
-import { localProjectionSourceFileSystem } from "../local/local-layout-file-system.ts";
 import { replaceDeclaredProjectionRows } from "./entity-declaration-projection.ts";
 import { buildCheckReport, hardFail, runPostMergeChecks, warning } from "./post-merge-checks.ts";
 import type { FactAnchorRow, RelationCoverageRow, RelationGraphEdgeRow } from "./relation-graph-projection.ts";
@@ -29,6 +28,18 @@ import {
   replaceDeclaredSourceManifestRows
 } from "./sqlite-declared-source-manifest.ts";
 import { updateProjectionDatabase } from "./sqlite-projection-update-store.ts";
+import {
+  captureProjectionSourceCacheSnapshot,
+  readProjectionSourceCacheSnapshot,
+  replaceProjectionSourceCacheRows,
+  restoreProjectionSourceCacheSnapshot,
+  updateProjectionSourceCacheSnapshot,
+  type ProjectionSourceCacheSnapshot
+} from "./sqlite-projection-source-cache.ts";
+import {
+  readCachedProjectionValidation,
+  rememberProjectionValidation
+} from "./sqlite-projection-validation-cache.ts";
 import { materializeEntityAttributionBlocks, replaceAttributionProjectionRows } from "./sqlite-attribution-projection.ts";
 import { compareRows, hashExactRows, taskEntryToRow } from "./sqlite-task-source.ts";
 import {
@@ -68,14 +79,6 @@ import type {
   TaskProjectionQueryFilters
 } from "./types.ts";
 
-interface ProjectionValidationCacheEntry {
-  readonly signature: string;
-  readonly declaredManifest: ReturnType<typeof readDeclaredSourceManifestRows>;
-}
-
-const projectionValidationCache = new Map<string, ProjectionValidationCacheEntry>();
-const projectionValidationCacheLimit = 16;
-
 export function defaultTaskProjectionPath(rootDir: string): string {
   return resolveHarnessLayout(rootDir).projectionPath;
 }
@@ -95,6 +98,7 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
   const declaredManifestRows = declaredSourceManifestRows(snapshot.declaredTables, snapshot.declaredSources);
   const declaredManifestHash = hashDeclaredSourceManifestRows(declaredManifestRows);
   const relationGraph = stableBuild.relationGraph;
+  const sourceCache = stableBuild.sourceCache;
   writeProjectionDatabase(projectionPath, rows, decisionRows, {
     sourceHash: snapshot.fingerprint,
     rowsHash,
@@ -103,6 +107,7 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
     declaredManifestHash,
     attributionSourceHash: snapshot.attributionSource.hash,
     taskSourceHash: snapshot.taskSource.hash,
+    sourceCacheHash: sourceCache.hash,
     legacyPersonIdsHash: hashProjectionLegacyPersonIds(snapshot.legacyPersonIds)
   }, {
     relationEdges: relationGraph.edges,
@@ -113,6 +118,7 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
       yield* replaceDeclaredProjectionRows(sql, table.declaration, table.rows);
     }
     yield* replaceDeclaredSourceManifestRows(sql, declaredManifestRows);
+    yield* replaceProjectionSourceCacheRows(sql, sourceCache);
     yield* replaceAttributionProjectionRows(sql, snapshot.attributionEvents);
     yield* materializeEntityAttributionBlocks(sql, snapshot.attributionEvents);
   }));
@@ -126,14 +132,16 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
 function captureStableProjectionBuild(runtimeContext: ReturnType<typeof createHarnessRuntimeContext>): {
   readonly snapshot: ReturnType<typeof captureProjectionSourceSnapshot>;
   readonly relationGraph: ReturnType<typeof buildRelationGraphProjection>;
+  readonly sourceCache: ProjectionSourceCacheSnapshot;
 } {
   let lastFailure: unknown = new Error("projection authored sources did not stabilize during rebuild");
   for (let attempt = 0; attempt < 3; attempt += 1) {
     try {
       const snapshot = captureProjectionSourceSnapshot(runtimeContext);
-      const relationGraph = buildRelationGraphProjection(runtimeContext);
+      const relationGraph = buildRelationGraphProjection(runtimeContext, snapshot.taskSource.sourceInputs);
       const verified = captureProjectionSourceFingerprint(runtimeContext);
-      if (verified.fingerprint === snapshot.fingerprint) return { snapshot, relationGraph };
+      const sourceCache = captureProjectionSourceCacheSnapshot(runtimeContext);
+      if (verified.fingerprint === snapshot.fingerprint && sourceCache) return { snapshot, relationGraph, sourceCache };
       lastFailure = new Error("projection authored sources did not stabilize during rebuild");
     } catch (error) {
       lastFailure = error;
@@ -183,6 +191,24 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
   }
 
   const cachedValidation = readCachedProjectionValidation(projectionPath);
+  let persistedSourceCache: ProjectionSourceCacheSnapshot | null = null;
+  if (!cachedValidation) {
+    try {
+      persistedSourceCache = readProjectionSourceCacheSnapshot(projectionPath);
+      if (existing.meta.sourceCacheHash !== persistedSourceCache.hash) throw new Error("projection source cache hash mismatch");
+      const restored = restoreProjectionSourceCacheSnapshot(runtimeContext, persistedSourceCache);
+      if (!restored.valid) throw new Error("projection source cache payload invalid");
+    } catch {
+      warnings.push(hardFail(
+        "generated-cache",
+        "projection_tampered",
+        "Projection source cache no longer matches its recorded hash.",
+        "Discard the generated cache and rebuild it from authored state; do not merge generated projection edits."
+      ));
+      const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
+      return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
+    }
+  }
   let declaredManifest: ReturnType<typeof readDeclaredSourceManifestRows>;
   try {
     declaredManifest = cachedValidation?.declaredManifest ?? readDeclaredSourceManifestRows(projectionPath);
@@ -308,35 +334,16 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
     return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
   }
 
+  const currentSourceCache = persistedSourceCache ? captureProjectionSourceCacheSnapshot(runtimeContext) : null;
+  if (persistedSourceCache && currentSourceCache && currentSourceCache.hash !== persistedSourceCache.hash) {
+    updateProjectionSourceCacheSnapshot(projectionPath, persistedSourceCache, currentSourceCache);
+  }
   if (!cachedValidation) rememberProjectionValidation(projectionPath, declaredManifest);
 
   return {
     rows: [...existing.rows].sort(compareRows),
     warnings
   };
-}
-
-function readCachedProjectionValidation(projectionPath: string): ProjectionValidationCacheEntry | null {
-  const cached = projectionValidationCache.get(projectionPath);
-  if (!cached || localProjectionSourceFileSystem.statSignature(projectionPath) !== cached.signature) return null;
-  projectionValidationCache.delete(projectionPath);
-  projectionValidationCache.set(projectionPath, cached);
-  return cached;
-}
-
-function rememberProjectionValidation(
-  projectionPath: string,
-  declaredManifest: ReturnType<typeof readDeclaredSourceManifestRows>
-): void {
-  const signature = localProjectionSourceFileSystem.statSignature(projectionPath);
-  if (signature === null) return;
-  projectionValidationCache.delete(projectionPath);
-  projectionValidationCache.set(projectionPath, { signature, declaredManifest });
-  while (projectionValidationCache.size > projectionValidationCacheLimit) {
-    const oldest = projectionValidationCache.keys().next().value as string | undefined;
-    if (oldest === undefined) break;
-    projectionValidationCache.delete(oldest);
-  }
 }
 
 export function queryTaskProjection(options: TaskProjectionOptions & { readonly filters: TaskProjectionQueryFilters }): ProjectionReadResult {

--- a/packages/kernel/src/projection/sqlite-task-row.ts
+++ b/packages/kernel/src/projection/sqlite-task-row.ts
@@ -1,0 +1,126 @@
+import path from "node:path";
+import type { CloseoutReadiness } from "../domain/index.ts";
+import { isDomainStatus, isPackageDisposition, isPriorityTier, isTaskWorkKind, isTerminalStatus } from "../domain/index.ts";
+import type { HarnessLayoutInput } from "../layout/index.ts";
+import { resolveHarnessLayout } from "../layout/index.ts";
+import { readScalar } from "../markdown/frontmatter.ts";
+import { unresolvedEntityAttribution } from "./entity-attribution-projection.ts";
+import { readTextFileIfPresent, statPathIfPresent } from "./toctou-safe-fs.ts";
+import type {
+  CoordinationStatus,
+  ProjectionCanonicalStatus,
+  TaskFieldExtensionProjection,
+  TaskProjectionRow
+} from "./types.ts";
+
+export interface TaskSourceEntry {
+  readonly taskId: string;
+  readonly indexPath: string;
+  readonly body: string;
+  readonly frontmatter: string;
+  readonly statSignature: string;
+}
+
+export function taskEntryToRow(
+  rootInput: HarnessLayoutInput,
+  entry: TaskSourceEntry,
+  fieldExtensions: ReadonlyArray<TaskFieldExtensionProjection> = []
+): TaskProjectionRow {
+  const rootDir = resolveHarnessLayout(rootInput).rootDir;
+  const rawStatus = readScalar(entry.frontmatter, "  status") || "unknown";
+  const canonicalStatus = isDomainStatus(rawStatus) ? rawStatus : "unknown";
+  const rawDisposition = readScalar(entry.frontmatter, "packageDisposition") || "active";
+  const packageDisposition = isPackageDisposition(rawDisposition) ? rawDisposition : "active";
+  const lifecycleEngine = readScalar(entry.frontmatter, "  engine") || "local";
+  const taskDir = path.dirname(entry.indexPath);
+  return {
+    schema: "sqlite-task-row/v1",
+    taskId: readScalar(entry.frontmatter, "task_id") || entry.taskId,
+    title: readScalar(entry.frontmatter, "title") || entry.taskId,
+    ...readParent(entry.frontmatter),
+    canonicalStatus,
+    coordinationStatus: coordinationStatus(canonicalStatus),
+    rawStatus,
+    packageDisposition,
+    closeoutReadiness: closeoutReadiness(rootInput, entry.taskId, canonicalStatus),
+    lifecycleEngine,
+    freshness: canonicalStatus === "unknown" || !isPackageDisposition(rawDisposition) ? "stale-but-usable" : "fresh",
+    updatedAt: (statPathIfPresent(entry.indexPath)?.mtime ?? new Date(0)).toISOString(),
+    source: lifecycleEngine === "local" ? "local-document" : "external-engine",
+    sourcePath: sourcePath(rootDir, entry.indexPath),
+    ...readExtensionMetadata(entry.frontmatter),
+    ...readFieldExtensions(entry.frontmatter, fieldExtensions),
+    ...readTaskMetadata(entry.frontmatter),
+    ...readModuleMetadata(taskDir),
+    hasLessonCandidates: statPathIfPresent(path.join(taskDir, "lesson_candidates.md")) !== null,
+    attribution: unresolvedEntityAttribution()
+  };
+}
+
+export function sourcePath(rootDir: string, filePath: string): string {
+  return path.relative(rootDir, filePath).split(path.sep).join("/");
+}
+
+function readParent(frontmatter: string): { readonly parentTaskId?: string } {
+  const parentTaskId = readScalar(frontmatter, "parent");
+  return parentTaskId ? { parentTaskId } : {};
+}
+
+function readExtensionMetadata(frontmatter: string): { readonly vertical?: string; readonly preset?: string; readonly profile?: string } {
+  const vertical = readScalar(frontmatter, "vertical");
+  const preset = readScalar(frontmatter, "preset");
+  const profile = readScalar(frontmatter, "profile");
+  return {
+    ...(vertical ? { vertical } : {}),
+    ...(preset ? { preset } : {}),
+    ...(profile ? { profile } : {})
+  };
+}
+
+function readFieldExtensions(
+  frontmatter: string,
+  extensions: ReadonlyArray<TaskFieldExtensionProjection>
+): { readonly fieldExtensions?: Readonly<Record<string, string | null>> } {
+  if (extensions.length === 0) return {};
+  const values = Object.fromEntries(extensions.map((extension) => {
+    const rawValue = readScalar(frontmatter, extension.field);
+    return [extension.field, extension.values.includes(rawValue) ? rawValue : extension.default];
+  }));
+  return Object.values(values).some((value) => value !== null) ? { fieldExtensions: values } : {};
+}
+
+function readTaskMetadata(frontmatter: string): Pick<TaskProjectionRow, "workKind" | "riskTier" | "urgency"> {
+  const workKind = readScalar(frontmatter, "workKind");
+  const riskTier = readScalar(frontmatter, "riskTier");
+  const urgency = readScalar(frontmatter, "urgency");
+  return {
+    ...(isTaskWorkKind(workKind) ? { workKind } : {}),
+    ...(isPriorityTier(riskTier) ? { riskTier } : {}),
+    ...(isPriorityTier(urgency) ? { urgency } : {})
+  };
+}
+
+function readModuleMetadata(taskDir: string): { readonly moduleKey?: string; readonly moduleTitle?: string } {
+  const body = readTextFileIfPresent(path.join(taskDir, "module.md"));
+  if (body === null) return {};
+  const moduleKey = body.match(/^Module key:[ \t]*(.+)$/mu)?.[1]?.trim() ?? "";
+  const moduleTitle = body.match(/^Module title:[ \t]*(.+)$/mu)?.[1]?.trim() ?? "";
+  return {
+    ...(moduleKey ? { moduleKey } : {}),
+    ...(moduleTitle ? { moduleTitle } : {})
+  };
+}
+
+function coordinationStatus(status: ProjectionCanonicalStatus): CoordinationStatus {
+  if (status === "unknown") return "unknown";
+  if (status === "blocked") return "blocked";
+  if (status === "in_review") return "in_review";
+  return isTerminalStatus(status) ? "terminal" : "open";
+}
+
+function closeoutReadiness(rootInput: HarnessLayoutInput, taskId: string, status: ProjectionCanonicalStatus): CloseoutReadiness {
+  if (status === "unknown") return "missing";
+  if (!isTerminalStatus(status) && status !== "in_review") return "not_required";
+  const closeoutPath = path.join(resolveHarnessLayout(rootInput).tasksRoot, taskId, "closeout.md");
+  return statPathIfPresent(closeoutPath) === null ? "missing" : "ready";
+}

--- a/packages/kernel/src/projection/sqlite-task-source.ts
+++ b/packages/kernel/src/projection/sqlite-task-source.ts
@@ -1,67 +1,186 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
-import type { CloseoutReadiness } from "../domain/index.ts";
-import { isDomainStatus, isPackageDisposition, isPriorityTier, isTaskWorkKind, isTerminalStatus } from "../domain/index.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import { localProjectionSourceFileSystem } from "../local/local-layout-file-system.ts";
-import { readFrontmatter, readScalar } from "../markdown/frontmatter.ts";
+import { readFrontmatter } from "../markdown/frontmatter.ts";
 import {
   deriveRelationTaskAuthoredSources,
   relationDecisionAuthoredSourceKind,
   type RelationAuthoredSourceKind
 } from "./relation-source-manifest.ts";
-import type { ProjectionCanonicalStatus, CoordinationStatus, ProjectionWarning, TaskFieldExtensionProjection, TaskProjectionRow } from "./types.ts";
-import { unresolvedEntityAttribution } from "./entity-attribution-projection.ts";
-import { readDirIfPresent, readDirNamesIfPresent, readTextFileIfPresent, statPathIfPresent } from "./toctou-safe-fs.ts";
+import type { ProjectionWarning, TaskProjectionRow } from "./types.ts";
+import {
+  isSafeRelativeSourceCachePath,
+  captureRequiredSourceCacheSignatures,
+  captureSourceCacheWatchSignatures,
+  listSourceCacheDirectoryPaths,
+  restoreSourceCacheSignatures,
+  sameSourceCacheSignatures,
+  sourceCacheSignaturesMatch,
+  serializeSourceCacheSignatures
+} from "../local/persistent-source-cache-paths.ts";
+import { readDirIfPresent, readDirNamesIfPresent, statPathIfPresent } from "./toctou-safe-fs.ts";
+import { sourcePath, taskEntryToRow, type TaskSourceEntry } from "./sqlite-task-row.ts";
+
+export { sourcePath, taskEntryToRow };
+export type { TaskSourceEntry };
 
 interface MarkdownSourceCacheEntry {
-  readonly result: ReturnType<typeof markdownSourceResult>;
+  readonly result: MarkdownSourceResult;
   readonly fileSignatures: ReadonlyMap<string, string>;
-  readonly directorySignatures: ReadonlyMap<string, string>;
+  readonly directorySignatures: ReadonlyMap<string, string | null>;
 }
+
+type MarkdownSourceResult = ReturnType<typeof markdownSourceResult>;
+
+export interface MarkdownSourcePersistentCache {
+  readonly schema: "markdown-source-cache/v1";
+  readonly layoutIdentity: string;
+  readonly result: {
+    readonly entries: ReadonlyArray<{
+      readonly taskId: string;
+      readonly indexPath: string;
+      readonly body: string;
+      readonly frontmatter: string;
+      readonly statSignature: string;
+    }>;
+    readonly hash: string;
+    readonly warnings: ReadonlyArray<ProjectionWarning>;
+    readonly sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>;
+  };
+  readonly fileSignatures: ReadonlyArray<{ readonly relativePath: string; readonly signature: string }>;
+  readonly directorySignatures: ReadonlyArray<{ readonly relativePath: string; readonly signature: string | null }>;
+}
+
+export type PersistentSourceCacheRestore = "fresh" | "stale" | "invalid";
 
 const markdownSourceCache = new Map<string, MarkdownSourceCacheEntry>();
 const markdownSourceCacheLimit = 16;
+
+export function captureMarkdownSourcePersistentCache(
+  rootInput: HarnessLayoutInput
+): MarkdownSourcePersistentCache | null {
+  const layout = resolveHarnessLayout(rootInput);
+  const cacheKey = markdownSourceCacheKey(layout);
+  const cached = markdownSourceCache.get(cacheKey);
+  if (!cached || !markdownSourceCacheEntryMatches(cached)) return null;
+  return {
+    schema: "markdown-source-cache/v1",
+    layoutIdentity: cacheKey,
+    result: {
+      ...cached.result,
+      entries: cached.result.entries.map((entry) => ({
+        ...entry,
+        indexPath: sourcePath(layout.rootDir, entry.indexPath)
+      }))
+    },
+    fileSignatures: serializeSourceCacheSignatures(layout.rootDir, cached.fileSignatures),
+    directorySignatures: serializeSourceCacheSignatures(layout.rootDir, cached.directorySignatures)
+  };
+}
+
+export function restoreMarkdownSourcePersistentCache(
+  rootInput: HarnessLayoutInput,
+  persisted: MarkdownSourcePersistentCache
+): PersistentSourceCacheRestore {
+  if (!validPersistentMarkdownSource(persisted)) return "invalid";
+  const layout = resolveHarnessLayout(rootInput);
+  const cacheKey = markdownSourceCacheKey(layout);
+  if (persisted.layoutIdentity !== cacheKey) return "stale";
+  const entry: MarkdownSourceCacheEntry = {
+    result: {
+      ...persisted.result,
+      entries: persisted.result.entries.map((source) => ({
+        ...source,
+        indexPath: path.resolve(layout.rootDir, source.indexPath)
+      }))
+    },
+    fileSignatures: restoreSourceCacheSignatures(layout.rootDir, persisted.fileSignatures),
+    directorySignatures: restoreSourceCacheSignatures(layout.rootDir, persisted.directorySignatures)
+  };
+  rememberMarkdownSourceCache(cacheKey, entry);
+  return markdownSourceCacheEntryMatches(entry) ? "fresh" : "stale";
+}
+
+function validPersistentMarkdownSource(persisted: MarkdownSourcePersistentCache): boolean {
+  if (persisted.schema !== "markdown-source-cache/v1" ||
+      typeof persisted.layoutIdentity !== "string" ||
+      !Array.isArray(persisted.result?.entries) ||
+      !Array.isArray(persisted.result?.sourceInputs) ||
+      !Array.isArray(persisted.fileSignatures) ||
+      !Array.isArray(persisted.directorySignatures)) return false;
+  if (persisted.result.sourceInputs.some((input) =>
+    typeof input.kind !== "string" ||
+    typeof input.sourcePath !== "string" ||
+    !isSafeRelativeSourceCachePath(input.sourcePath) ||
+    typeof input.body !== "string" ||
+    typeof input.statSignature !== "string")) return false;
+  if (persisted.result.entries.some((entry) =>
+    typeof entry.taskId !== "string" ||
+    typeof entry.indexPath !== "string" ||
+    !isSafeRelativeSourceCachePath(entry.indexPath) ||
+    typeof entry.body !== "string" ||
+    typeof entry.frontmatter !== "string" ||
+    typeof entry.statSignature !== "string")) return false;
+  if (persisted.fileSignatures.some((entry) =>
+    !isSafeRelativeSourceCachePath(entry.relativePath) || typeof entry.signature !== "string")) return false;
+  if (persisted.directorySignatures.some((entry) =>
+    !isSafeRelativeSourceCachePath(entry.relativePath) ||
+    (entry.signature !== null && typeof entry.signature !== "string"))) return false;
+  if (hashTaskSourceInputs(persisted.result.sourceInputs) !== persisted.result.hash) return false;
+  const bodiesByPath = new Map(persisted.result.sourceInputs.map((input) => [input.sourcePath, input.body]));
+  return persisted.result.entries.every((entry) => bodiesByPath.get(entry.indexPath) === entry.body);
+}
 
 export function readMarkdownSource(rootInput: HarnessLayoutInput): {
   readonly entries: ReadonlyArray<TaskSourceEntry>;
   readonly hash: string;
   readonly warnings: ReadonlyArray<ProjectionWarning>;
+  readonly sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>;
 } {
   const layout = resolveHarnessLayout(rootInput);
-  const cacheKey = layout.rootDir;
+  const cacheKey = markdownSourceCacheKey(layout);
   const cached = markdownSourceCache.get(cacheKey);
   if (cached && markdownSourceCacheEntryMatches(cached)) {
     markdownSourceCache.delete(cacheKey);
     markdownSourceCache.set(cacheKey, cached);
     return cached.result;
   }
-  const source = readTaskProjectionSource(rootInput);
+  const source = readTaskProjectionSource(rootInput, cached);
   const result = markdownSourceResult(source);
   const cacheEntry = createMarkdownSourceCacheEntry(layout, source, result);
   markdownSourceCache.delete(cacheKey);
-  if (cacheEntry) {
-    markdownSourceCache.set(cacheKey, cacheEntry);
-    while (markdownSourceCache.size > markdownSourceCacheLimit) {
-      const oldest = markdownSourceCache.keys().next().value as string | undefined;
-      if (oldest === undefined) break;
-      markdownSourceCache.delete(oldest);
-    }
-  }
+  if (cacheEntry) rememberMarkdownSourceCache(cacheKey, cacheEntry);
   return result;
+}
+
+function markdownSourceCacheKey(layout: ReturnType<typeof resolveHarnessLayout>): string {
+  return [layout.rootDir, layout.authoredRoot, layout.tasksRoot, layout.decisionsRoot].join("\0");
+}
+
+function rememberMarkdownSourceCache(cacheKey: string, entry: MarkdownSourceCacheEntry): void {
+  markdownSourceCache.delete(cacheKey);
+  markdownSourceCache.set(cacheKey, entry);
+  while (markdownSourceCache.size > markdownSourceCacheLimit) {
+    const oldest = markdownSourceCache.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    markdownSourceCache.delete(oldest);
+  }
 }
 
 function markdownSourceResult(source: ReturnType<typeof readTaskProjectionSource>): {
   readonly entries: ReadonlyArray<TaskSourceEntry>;
   readonly hash: string;
   readonly warnings: ReadonlyArray<ProjectionWarning>;
+  readonly sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>;
 } {
   return {
     entries: source.entries,
-    hash: hashText(JSON.stringify(source.sourceInputs)),
-    warnings: source.warnings
+    hash: hashTaskSourceInputs(source.sourceInputs),
+    warnings: source.warnings,
+    sourceInputs: source.sourceInputs
   };
 }
 
@@ -78,70 +197,60 @@ function createMarkdownSourceCacheEntry(
     layout.authoredRoot,
     layout.tasksRoot,
     layout.decisionsRoot,
+    ...source.taskPackagePaths,
     ...source.entries.map((entry) => path.dirname(entry.indexPath)),
     ...[...files.keys()].map(path.dirname),
-    ...listSourceDirectoryPaths(layout.decisionsRoot)
+    ...listSourceCacheDirectoryPaths(layout.decisionsRoot)
   ]);
-  const beforeFiles = capturePathSignatures(files.keys());
-  const beforeDirectories = captureExistingPathSignatures(directories);
+  const beforeFiles = captureRequiredSourceCacheSignatures(files.keys());
+  const beforeDirectories = captureSourceCacheWatchSignatures(directories);
   if (beforeFiles === null) return null;
-  for (const [filePath, body] of files) {
-    if (readTextFileIfPresent(filePath) !== body) return null;
-  }
-  const afterFiles = capturePathSignatures(files.keys());
-  const afterDirectories = captureExistingPathSignatures(directories);
+  const afterFiles = captureRequiredSourceCacheSignatures(files.keys());
+  const afterDirectories = captureSourceCacheWatchSignatures(directories);
   if (afterFiles === null ||
-      !samePathSignatures(beforeFiles, afterFiles) ||
-      !samePathSignatures(beforeDirectories, afterDirectories)) return null;
-  return { result, fileSignatures: afterFiles, directorySignatures: afterDirectories };
+      !sameSourceCacheSignatures(beforeFiles, afterFiles) ||
+      !sameSourceCacheSignatures(beforeDirectories, afterDirectories) ||
+      source.sourceInputs.some((input) =>
+        afterFiles.get(path.join(layout.rootDir, input.sourcePath)) !== input.statSignature)) return null;
+  return {
+    result,
+    fileSignatures: afterFiles,
+    directorySignatures: afterDirectories
+  };
 }
 
 function markdownSourceCacheEntryMatches(entry: MarkdownSourceCacheEntry): boolean {
-  const signatures = new Map([...entry.directorySignatures, ...entry.fileSignatures]);
-  return cachedPathSignaturesMatch(signatures) && cachedPathSignaturesMatch(signatures);
+  const signatures = new Map<string, string | null>([...entry.directorySignatures, ...entry.fileSignatures]);
+  return sourceCacheSignaturesMatch(signatures) && sourceCacheSignaturesMatch(signatures);
 }
 
-function capturePathSignatures(paths: Iterable<string>): ReadonlyMap<string, string> | null {
-  const signatures = new Map<string, string>();
-  for (const filePath of new Set(paths)) {
-    const signature = localProjectionSourceFileSystem.statSignature(filePath);
-    if (signature === null) return null;
-    signatures.set(filePath, signature);
+function reusableSourceBodies(
+  rootDir: string,
+  reusable: MarkdownSourceCacheEntry | undefined
+): ReadonlyMap<string, string> {
+  if (!reusable) return new Map();
+  return new Map(reusable.result.sourceInputs.map((input) => [
+    path.resolve(rootDir, input.sourcePath),
+    input.body
+  ]));
+}
+
+function readReusableSourceText(
+  filePath: string,
+  reusableBodies: ReadonlyMap<string, string>,
+  reusableSignatures: ReadonlyMap<string, string> | undefined
+): { readonly body: string; readonly signature: string } | null {
+  const currentSignature = localProjectionSourceFileSystem.statSignature(filePath);
+  if (currentSignature === null) return null;
+  const reusableBody = reusableBodies.get(filePath);
+  if (reusableBody !== undefined && reusableSignatures?.get(filePath) === currentSignature) {
+    return { body: reusableBody, signature: currentSignature };
   }
-  return signatures;
-}
-
-function captureExistingPathSignatures(paths: Iterable<string>): ReadonlyMap<string, string> {
-  const signatures = new Map<string, string>();
-  for (const filePath of new Set(paths)) {
-    const signature = localProjectionSourceFileSystem.statSignature(filePath);
-    if (signature !== null) signatures.set(filePath, signature);
+  try {
+    return localProjectionSourceFileSystem.readStableText(filePath);
+  } catch {
+    return null;
   }
-  return signatures;
-}
-
-function cachedPathSignaturesMatch(signatures: ReadonlyMap<string, string>): boolean {
-  for (const [filePath, expected] of signatures) {
-    if (localProjectionSourceFileSystem.statSignature(filePath) !== expected) return false;
-  }
-  return true;
-}
-
-function samePathSignatures(
-  left: ReadonlyMap<string, string>,
-  right: ReadonlyMap<string, string>
-): boolean {
-  return left.size === right.size && [...left].every(([filePath, signature]) => right.get(filePath) === signature);
-}
-
-function listSourceDirectoryPaths(rootPath: string): ReadonlyArray<string> {
-  const stat = statPathIfPresent(rootPath);
-  if (!stat?.isDirectory()) return [];
-  const entries = readDirIfPresent(rootPath);
-  if (entries === null) return [];
-  return [rootPath, ...entries
-    .filter((entry) => entry.isDirectory() && entry.name !== ".git" && entry.name !== "node_modules")
-    .flatMap((entry) => listSourceDirectoryPaths(path.join(rootPath, entry.name)))];
 }
 
 export function readTaskProjectionSourceHashInputs(rootInput: HarnessLayoutInput): ReadonlyArray<TaskProjectionSourceHashInput> {
@@ -152,8 +261,9 @@ export function readRelationGraphSourceHashInputKinds(rootInput: HarnessLayoutIn
   return [...new Set(readTaskProjectionSource(rootInput).relationSourceInputs.map((input) => input.kind))].sort();
 }
 
-function readTaskProjectionSource(rootInput: HarnessLayoutInput): {
+function readTaskProjectionSource(rootInput: HarnessLayoutInput, reusable?: MarkdownSourceCacheEntry): {
   readonly entries: ReadonlyArray<TaskSourceEntry>;
+  readonly taskPackagePaths: ReadonlyArray<string>;
   readonly sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>;
   readonly relationSourceInputs: ReadonlyArray<RelationSourceHashInput>;
   readonly warnings: ReadonlyArray<ProjectionWarning>;
@@ -163,18 +273,23 @@ function readTaskProjectionSource(rootInput: HarnessLayoutInput): {
   const tasksDir = layout.tasksRoot;
   const warnings: ProjectionWarning[] = [];
   const entries: TaskSourceEntry[] = [];
+  const reusableBodies = reusableSourceBodies(rootDir, reusable);
   const taskEntries = existsSync(tasksDir) ? readDirNamesIfPresent(tasksDir) : [];
+  const taskPackagePaths = (taskEntries ?? [])
+    .map((name) => path.join(tasksDir, name))
+    .filter((inputPath) => statPathIfPresent(inputPath)?.isDirectory());
   for (const name of (taskEntries ?? []).sort()) {
     const indexPath = path.join(tasksDir, name, "INDEX.md");
     if (!existsSync(indexPath)) continue;
-    const body = readTextFileIfPresent(indexPath);
-    if (body === null) continue;
+    const sourceText = readReusableSourceText(indexPath, reusableBodies, reusable?.fileSignatures);
+    if (sourceText === null) continue;
     try {
       entries.push({
         taskId: name,
         indexPath,
-        body,
-        frontmatter: parseFrontmatter(body)
+        body: sourceText.body,
+        frontmatter: parseFrontmatter(sourceText.body),
+        statSignature: sourceText.signature
       });
     } catch (error) {
       warnings.push({
@@ -187,8 +302,8 @@ function readTaskProjectionSource(rootInput: HarnessLayoutInput): {
     }
   }
 
-  const relationSourceInputs = readRelationGraphSourceInputs(rootDir, layout, entries);
-  const supplementalSourceInputs = readTaskSupplementalSourceInputs(rootDir, entries);
+  const relationSourceInputs = readRelationGraphSourceInputs(rootDir, layout, entries, reusableBodies, reusable?.fileSignatures);
+  const supplementalSourceInputs = readTaskSupplementalSourceInputs(rootDir, entries, reusableBodies, reusable?.fileSignatures);
   const taskIndexInputs = entries.flatMap((entry) => relationSourceInputs.filter((input) =>
     input.kind === "task-index" && input.taskId === entry.taskId
   ));
@@ -198,65 +313,23 @@ function readTaskProjectionSource(rootInput: HarnessLayoutInput): {
   ].sort((a, b) => a.sourcePath.localeCompare(b.sourcePath));
   return {
     entries,
+    taskPackagePaths,
     sourceInputs: [...taskIndexInputs, ...remainingSourceInputs],
     relationSourceInputs,
     warnings
   };
 }
 
-export interface TaskSourceEntry {
-  readonly taskId: string;
-  readonly indexPath: string;
-  readonly body: string;
-  readonly frontmatter: string;
-}
-
 export interface TaskProjectionSourceHashInput {
   readonly kind: string;
   readonly sourcePath: string;
   readonly body: string;
+  readonly statSignature: string;
 }
 
 interface RelationSourceHashInput extends TaskProjectionSourceHashInput {
   readonly kind: RelationAuthoredSourceKind;
   readonly taskId?: string;
-}
-
-export function taskEntryToRow(
-  rootInput: HarnessLayoutInput,
-  entry: TaskSourceEntry,
-  fieldExtensions: ReadonlyArray<TaskFieldExtensionProjection> = []
-): TaskProjectionRow {
-  const rootDir = resolveHarnessLayout(rootInput).rootDir;
-  const rawStatus = readScalar(entry.frontmatter, "  status") || "unknown";
-  const canonicalStatus = isDomainStatus(rawStatus) ? rawStatus : "unknown";
-  const rawDisposition = readScalar(entry.frontmatter, "packageDisposition") || "active";
-  const packageDisposition = isPackageDisposition(rawDisposition) ? rawDisposition : "active";
-  const lifecycleEngine = readScalar(entry.frontmatter, "  engine") || "local";
-  const source = sourcePath(rootDir, entry.indexPath);
-  const taskDir = path.dirname(entry.indexPath);
-  return {
-    schema: "sqlite-task-row/v1",
-    taskId: readScalar(entry.frontmatter, "task_id") || entry.taskId,
-    title: readScalar(entry.frontmatter, "title") || entry.taskId,
-    ...readParent(entry.frontmatter),
-    canonicalStatus,
-    coordinationStatus: coordinationStatus(canonicalStatus),
-    rawStatus,
-    packageDisposition,
-    closeoutReadiness: closeoutReadiness(rootInput, entry.taskId, canonicalStatus),
-    lifecycleEngine,
-    freshness: canonicalStatus === "unknown" || !isPackageDisposition(rawDisposition) ? "stale-but-usable" : "fresh",
-    updatedAt: (statPathIfPresent(entry.indexPath)?.mtime ?? new Date(0)).toISOString(),
-    source: lifecycleEngine === "local" ? "local-document" : "external-engine",
-    sourcePath: source,
-    ...readExtensionMetadata(entry.frontmatter),
-    ...readFieldExtensions(entry.frontmatter, fieldExtensions),
-    ...readTaskMetadata(entry.frontmatter),
-    ...readModuleMetadata(taskDir),
-    hasLessonCandidates: existsSync(path.join(taskDir, "lesson_candidates.md")),
-    attribution: unresolvedEntityAttribution()
-  };
 }
 
 function parseFrontmatter(body: string): string {
@@ -265,96 +338,47 @@ function parseFrontmatter(body: string): string {
   return frontmatter;
 }
 
-function readParent(frontmatter: string): { readonly parentTaskId?: string } {
-  const parentTaskId = readScalar(frontmatter, "parent");
-  return parentTaskId ? { parentTaskId } : {};
-}
-
-function readExtensionMetadata(frontmatter: string): { readonly vertical?: string; readonly preset?: string; readonly profile?: string } {
-  const vertical = readScalar(frontmatter, "vertical");
-  const preset = readScalar(frontmatter, "preset");
-  const profile = readScalar(frontmatter, "profile");
-  return {
-    ...(vertical ? { vertical } : {}),
-    ...(preset ? { preset } : {}),
-    ...(profile ? { profile } : {})
-  };
-}
-
-function readFieldExtensions(
-  frontmatter: string,
-  extensions: ReadonlyArray<TaskFieldExtensionProjection>
-): { readonly fieldExtensions?: Readonly<Record<string, string | null>> } {
-  if (extensions.length === 0) return {};
-  const values = Object.fromEntries(extensions.map((extension) => {
-    const rawValue = readScalar(frontmatter, extension.field);
-    return [
-      extension.field,
-      extension.values.includes(rawValue) ? rawValue : extension.default
-    ];
-  }));
-  return Object.values(values).some((value) => value !== null) ? { fieldExtensions: values } : {};
-}
-
-function readTaskMetadata(frontmatter: string): Pick<TaskProjectionRow, "workKind" | "riskTier" | "urgency"> {
-  const workKind = readScalar(frontmatter, "workKind");
-  const riskTier = readScalar(frontmatter, "riskTier");
-  const urgency = readScalar(frontmatter, "urgency");
-  return {
-    ...(isTaskWorkKind(workKind) ? { workKind } : {}),
-    ...(isPriorityTier(riskTier) ? { riskTier } : {}),
-    ...(isPriorityTier(urgency) ? { urgency } : {})
-  };
-}
-
-function readModuleMetadata(taskDir: string): { readonly moduleKey?: string; readonly moduleTitle?: string } {
-  const modulePath = path.join(taskDir, "module.md");
-  if (!existsSync(modulePath)) return {};
-  const body = readTextFileIfPresent(modulePath);
-  if (body === null) return {};
-  const moduleKey = body.match(/^Module key:[ \t]*(.+)$/mu)?.[1]?.trim() ?? "";
-  const moduleTitle = body.match(/^Module title:[ \t]*(.+)$/mu)?.[1]?.trim() ?? "";
-  return {
-    ...(moduleKey ? { moduleKey } : {}),
-    ...(moduleTitle ? { moduleTitle } : {})
-  };
-}
-
 function readRelationGraphSourceInputs(
   rootDir: string,
   layout: ReturnType<typeof resolveHarnessLayout>,
-  entries: ReadonlyArray<TaskSourceEntry>
+  entries: ReadonlyArray<TaskSourceEntry>,
+  reusableBodies: ReadonlyMap<string, string>,
+  reusableSignatures: ReadonlyMap<string, string> | undefined
 ): ReadonlyArray<RelationSourceHashInput> {
   const taskDocumentInputs = entries
     .flatMap((entry) => deriveRelationTaskAuthoredSources(path.dirname(entry.indexPath)).map((source) => ({
       kind: source.kind,
       path: source.filePath,
       ...(source.kind === "task-index" ? { taskId: entry.taskId } : {}),
-      ...(source.filePath === entry.indexPath ? { body: entry.body } : {})
+      ...(source.filePath === entry.indexPath ? { body: entry.body, statSignature: entry.statSignature } : {})
     })))
     .filter((input) => input.body !== undefined || existsSync(input.path))
     .flatMap((input) => {
-      const body = input.body ?? readTextFileIfPresent(input.path);
-      return body === null
+      const sourceText = input.body === undefined
+        ? readReusableSourceText(input.path, reusableBodies, reusableSignatures)
+        : { body: input.body, signature: input.statSignature! };
+      return sourceText === null
         ? []
         : [{
           kind: input.kind,
           ...(input.taskId ? { taskId: input.taskId } : {}),
           sourcePath: sourcePath(rootDir, input.path),
-          body
+          body: sourceText.body,
+          statSignature: sourceText.signature
         }];
     });
   const decisionInputs = listDecisionDocuments(layout.decisionsRoot)
     .flatMap((decisionPath) => {
       const kind = relationDecisionAuthoredSourceKind(decisionPath);
       if (kind === null) return [];
-      const body = readTextFileIfPresent(decisionPath);
-      return body === null
+      const sourceText = readReusableSourceText(decisionPath, reusableBodies, reusableSignatures);
+      return sourceText === null
         ? []
         : [{
           kind,
           sourcePath: sourcePath(rootDir, decisionPath),
-          body
+          body: sourceText.body,
+          statSignature: sourceText.signature
         }];
     });
   return [...taskDocumentInputs, ...decisionInputs];
@@ -362,7 +386,9 @@ function readRelationGraphSourceInputs(
 
 function readTaskSupplementalSourceInputs(
   rootDir: string,
-  entries: ReadonlyArray<TaskSourceEntry>
+  entries: ReadonlyArray<TaskSourceEntry>,
+  reusableBodies: ReadonlyMap<string, string>,
+  reusableSignatures: ReadonlyMap<string, string> | undefined
 ): ReadonlyArray<TaskProjectionSourceHashInput> {
   return entries
     .flatMap((entry) => [
@@ -372,13 +398,14 @@ function readTaskSupplementalSourceInputs(
     ])
     .filter((input) => existsSync(input.path))
     .flatMap((input) => {
-      const body = readTextFileIfPresent(input.path);
-      return body === null
+      const sourceText = readReusableSourceText(input.path, reusableBodies, reusableSignatures);
+      return sourceText === null
         ? []
         : [{
           kind: input.kind,
           sourcePath: sourcePath(rootDir, input.path),
-          body
+          body: sourceText.body,
+          statSignature: sourceText.signature
         }];
     });
 }
@@ -397,25 +424,6 @@ function listDecisionDocuments(decisionsRoot: string): ReadonlyArray<string> {
     .sort();
 }
 
-function coordinationStatus(status: ProjectionCanonicalStatus): CoordinationStatus {
-  if (status === "unknown") return "unknown";
-  if (status === "blocked") return "blocked";
-  if (status === "in_review") return "in_review";
-  return isTerminalStatus(status) ? "terminal" : "open";
-}
-
-function closeoutReadiness(rootInput: HarnessLayoutInput, taskId: string, status: ProjectionCanonicalStatus): CloseoutReadiness {
-  if (status === "unknown") return "missing";
-  if (!isTerminalStatus(status) && status !== "in_review") return "not_required";
-  const taskDir = path.join(resolveHarnessLayout(rootInput).tasksRoot, taskId);
-  if (existsSync(path.join(taskDir, "closeout.md"))) return "ready";
-  return "missing";
-}
-
-export function sourcePath(rootDir: string, filePath: string): string {
-  return path.relative(rootDir, filePath).split(path.sep).join("/");
-}
-
 export function hashExactRows(rows: ReadonlyArray<TaskProjectionRow>): string {
   return hashText(JSON.stringify([...rows].sort(compareRows).map(canonicalTaskProjectionRow)));
 }
@@ -429,6 +437,14 @@ export function hashTaskProjectionRows(rows: ReadonlyArray<TaskProjectionRow>): 
 
 function hashText(text: string): string {
   return `sha256:${sha256Text(text)}`;
+}
+
+function hashTaskSourceInputs(inputs: ReadonlyArray<TaskProjectionSourceHashInput>): string {
+  return hashText(JSON.stringify(inputs.map(({ kind, sourcePath: inputPath, body }) => ({
+    kind,
+    sourcePath: inputPath,
+    body
+  }))));
 }
 
 export function compareRows(a: TaskProjectionRow, b: TaskProjectionRow): number {

--- a/packages/kernel/src/projection/types.ts
+++ b/packages/kernel/src/projection/types.ts
@@ -189,5 +189,6 @@ export interface ProjectionMeta {
   readonly attributionRowsHash?: string;
   readonly attributionSourceHash?: string;
   readonly taskSourceHash?: string;
+  readonly sourceCacheHash?: string;
   readonly legacyPersonIdsHash?: string;
 }

--- a/packages/kernel/test/store/sqlite-projection-atomicity.test.ts
+++ b/packages/kernel/test/store/sqlite-projection-atomicity.test.ts
@@ -92,6 +92,32 @@ test("task cache rejects a concurrent rewrite between signature passes", () => {
   });
 });
 
+test("task cache rejects an atomic rewrite after a stable body read", () => {
+  withTempStore((rootDir) => {
+    const taskPath = writeCacheTask(rootDir, "Task A");
+    const originalReadStableText = localProjectionSourceFileSystem.readStableText;
+    let mutated = false;
+    localProjectionSourceFileSystem.readStableText = (inputPath) => {
+      const stable = originalReadStableText(inputPath);
+      if (!mutated && inputPath === taskPath) {
+        mutated = true;
+        writeCacheTask(rootDir, "Task B");
+      }
+      return stable;
+    };
+    let result: ReturnType<typeof rebuildTaskProjection>;
+    try {
+      result = rebuildTaskProjection({ rootDir });
+    } finally {
+      localProjectionSourceFileSystem.readStableText = originalReadStableText;
+    }
+
+    assert.equal(mutated, true);
+    assert.equal(result.rows[0]?.title, "Task B");
+    assert.equal(readTaskProjection({ rootDir }).rows[0]?.title, "Task B");
+  });
+});
+
 test("declared source cache rejects a concurrent rewrite between signature passes", () => {
   withTempStore((rootDir) => {
     const executionPath = writeCacheExecution(rootDir, "submitted");

--- a/packages/kernel/test/store/sqlite-projection-integrity.test.ts
+++ b/packages/kernel/test/store/sqlite-projection-integrity.test.ts
@@ -87,6 +87,33 @@ test("projection reads reject attribution event table tampering", () => {
   });
 });
 
+test("projection reads reject persisted source cache tampering", () => {
+  withTempStore((rootDir) => {
+    writeIntegrityTask(rootDir, "task-a", "Task A", "active");
+    writeIntegrityAttribution(rootDir, "event-task", "task/task-a", "progress_append");
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const db = new DatabaseSync(projectionPath);
+    try {
+      db.prepare("UPDATE projection_source_cache_metadata SET payload_json = ? WHERE cache_kind = 'task'")
+        .run(JSON.stringify({ schema: "task-source-cache-metadata/v1", warnings: [] }));
+    } finally {
+      db.close();
+    }
+
+    const rejected = readTaskProjection({ rootDir });
+
+    assert.equal(rejected.warnings.some((warning) => warning.code === "projection_tampered"), true);
+    assert.equal(rejected.rows[0]?.taskId, "task-a");
+    const rebuilt = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      assert.equal(rebuilt.prepare("SELECT COUNT(*) AS count FROM projection_source_cache_metadata").get()?.count, 2);
+    } finally {
+      rebuilt.close();
+    }
+  });
+});
+
 test("legacy sessions coexist with incremental execution updates", () => {
   withTempStore((rootDir) => {
     const taskId = "task_00000000000000000000000001";

--- a/packages/kernel/test/store/sqlite-projection-source-cache.test.ts
+++ b/packages/kernel/test/store/sqlite-projection-source-cache.test.ts
@@ -1,0 +1,418 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { captureProjectionSourceSnapshot } from "../../src/projection/projection-source-snapshot.ts";
+import { updateTaskProjectionIncrementally } from "../../src/projection/sqlite-task-incremental-projection.ts";
+import { readTaskProjection, rebuildTaskProjection } from "../../src/projection/sqlite-task-projection.ts";
+
+test("fresh processes reuse persisted task decision and attribution bodies", () => {
+  withTempProjection((rootDir) => {
+    seedHarness(rootDir);
+    writeAttributionEvent(rootDir, "event-fresh-a", "task/task-a");
+    writeAttributionEvent(rootDir, "event-fresh-b", "task/task-b");
+    rebuildTaskProjection({ rootDir });
+
+    const result = runFreshProcess(rootDir, freshProjectionBodyCacheReaderScript);
+
+    assert.deepEqual(result, {
+      taskBodiesRead: 0,
+      decisionBodiesRead: 0,
+      attributionBodiesRead: 0,
+      warnings: []
+    });
+  });
+});
+
+test("fresh process single task changes read only the changed authored body", () => {
+  withTempProjection((rootDir) => {
+    seedHarness(rootDir);
+    writeAttributionEvent(rootDir, "event-fresh-a", "task/task-a");
+    writeAttributionEvent(rootDir, "event-fresh-b", "task/task-b");
+    rebuildTaskProjection({ rootDir });
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPath = writeIndex(rootDir, "task-b", "Task task-b changed", "done");
+
+    const result = runFreshIncrementalProcess(rootDir, touchedPath, previousSourceFingerprint);
+
+    assert.deepEqual(result, {
+      taskBodiesRead: 1,
+      decisionBodiesRead: 0,
+      attributionBodiesRead: 0,
+      mode: "incremental"
+    });
+    assert.equal(readTaskProjection({ rootDir }).rows.find((row) => row.taskId === "task-b")?.canonicalStatus, "done");
+  });
+});
+
+test("fresh process single decision changes read only the changed authored body", () => {
+  withTempProjection((rootDir) => {
+    seedHarness(rootDir);
+    writeAttributionEvent(rootDir, "event-fresh-a", "task/task-a");
+    rebuildTaskProjection({ rootDir });
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPath = writeDecision(rootDir, "Changed cached decision");
+
+    const result = runFreshIncrementalProcess(rootDir, touchedPath, previousSourceFingerprint);
+
+    assert.deepEqual(result, {
+      taskBodiesRead: 0,
+      decisionBodiesRead: 1,
+      attributionBodiesRead: 0,
+      mode: "incremental"
+    });
+  });
+});
+
+test("fresh process single attribution addition reads only the new shard", () => {
+  withTempProjection((rootDir) => {
+    seedHarness(rootDir);
+    writeAttributionEvent(rootDir, "event-fresh-a", "task/task-a");
+    writeAttributionEvent(rootDir, "event-fresh-b", "task/task-b");
+    rebuildTaskProjection({ rootDir });
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPath = writeAttributionEvent(rootDir, "event-fresh-c", "task/task-c");
+
+    const result = runFreshIncrementalProcess(rootDir, touchedPath, previousSourceFingerprint);
+
+    assert.deepEqual(result, {
+      taskBodiesRead: 0,
+      decisionBodiesRead: 0,
+      attributionBodiesRead: 1,
+      mode: "incremental"
+    });
+  });
+});
+
+test("persisted absent source watches detect the first task without a full rebuild", () => {
+  withTempProjection((rootDir) => {
+    rebuildTaskProjection({ rootDir });
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPath = writeIndex(rootDir, "task-first", "First task", "active");
+
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [touchedPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    assert.equal(result.rows[0]?.taskId, "task-first");
+    assert.equal(readTaskProjection({ rootDir }).warnings.some((warning) => warning.code === "projection_stale"), false);
+  });
+});
+
+test("persisted source watches detect an INDEX created inside an existing task directory", () => {
+  withTempProjection((rootDir) => {
+    mkdirSync(path.join(rootDir, "harness/tasks/task-late-index"), { recursive: true });
+    rebuildTaskProjection({ rootDir });
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPath = writeIndex(rootDir, "task-late-index", "Late index", "active");
+
+    const result = runFreshIncrementalProcessWithRows(rootDir, touchedPath, previousSourceFingerprint);
+
+    assert.equal(result.mode, "incremental");
+    assert.deepEqual(result.taskIds, ["task-late-index"]);
+  });
+});
+
+test("persisted source caches never cross authored layout identities", () => {
+  withTempProjection((rootDir) => {
+    writeIndex(rootDir, "task-layout", "Default layout task", "active");
+    rebuildTaskProjection({ rootDir });
+    writeIndex(rootDir, "task-layout", "Alternate layout task", "active", "alternate");
+
+    const result = readTaskProjection({
+      rootDir,
+      layoutOverrides: { authoredRoot: "alternate" }
+    });
+
+    assert.equal(result.rows[0]?.title, "Alternate layout task");
+    assert.equal(result.warnings.some((warning) => warning.code === "projection_stale"), true);
+  });
+});
+
+test("single task changes never rewrite unchanged persisted source rows", () => {
+  withTempProjection((rootDir) => {
+    seedHarness(rootDir);
+    writeAttributionEvent(rootDir, "event-locality-a", "task/task-a");
+    writeAttributionEvent(rootDir, "event-locality-b", "task/task-b");
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const db = new DatabaseSync(projectionPath);
+    try {
+      db.exec(`
+        CREATE TRIGGER reject_unchanged_source_file_rewrite
+        BEFORE INSERT ON projection_source_cache_files
+        WHEN NEW.source_path <> 'harness/tasks/task-b/INDEX.md'
+        BEGIN SELECT RAISE(ABORT, 'unchanged source row rewritten'); END
+      `);
+    } finally {
+      db.close();
+    }
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPath = writeIndex(rootDir, "task-b", "Task task-b changed", "done");
+
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [touchedPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    const updated = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      assert.match(String(updated.prepare(`
+        SELECT body FROM projection_source_cache_files
+        WHERE cache_kind = 'task' AND source_path = 'harness/tasks/task-b/INDEX.md'
+      `).get()?.body), /Task task-b changed/u);
+      assert.equal(updated.prepare(`
+        SELECT COUNT(*) AS count FROM sqlite_master
+        WHERE type = 'trigger' AND name = 'reject_unchanged_source_file_rewrite'
+      `).get()?.count, 1);
+    } finally {
+      updated.close();
+    }
+  });
+});
+
+test("single attribution additions only insert the new SQL rows", () => {
+  withTempProjection((rootDir) => {
+    seedHarness(rootDir);
+    writeAttributionEvent(rootDir, "event-locality-a", "task/task-a");
+    writeAttributionEvent(rootDir, "event-locality-b", "task/task-b");
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const db = new DatabaseSync(projectionPath);
+    try {
+      db.exec(`
+        CREATE TRIGGER reject_existing_attribution_source_rewrite
+        BEFORE INSERT ON projection_source_cache_files
+        WHEN NEW.cache_kind = 'attribution'
+          AND NEW.source_path <> 'harness/attribution-events/event-locality-c.jsonl'
+        BEGIN SELECT RAISE(ABORT, 'existing attribution source rewritten'); END;
+        CREATE TRIGGER reject_existing_attribution_event_rewrite
+        BEFORE INSERT ON attribution_events
+        WHEN NEW.event_id <> 'event-locality-c'
+        BEGIN SELECT RAISE(ABORT, 'existing attribution event rewritten'); END
+      `);
+    } finally {
+      db.close();
+    }
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPath = writeAttributionEvent(rootDir, "event-locality-c", "task/task-c");
+
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [touchedPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    const updated = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      assert.equal(updated.prepare("SELECT COUNT(*) AS count FROM attribution_events").get()?.count, 3);
+      assert.equal(updated.prepare(`
+        SELECT COUNT(*) AS count FROM projection_source_cache_files WHERE cache_kind = 'attribution'
+      `).get()?.count, 3);
+    } finally {
+      updated.close();
+    }
+  });
+});
+
+function runFreshProcess(rootDir: string, script: string): unknown {
+  const child = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    cwd: process.cwd(),
+    env: { ...process.env, HARNESS_ROOT: rootDir },
+    encoding: "utf8"
+  });
+  assert.equal(child.status, 0, child.stderr);
+  return JSON.parse(child.stdout.trim());
+}
+
+function runFreshIncrementalProcess(
+  rootDir: string,
+  touchedPath: string,
+  previousSourceFingerprint: string
+): unknown {
+  const child = spawnSync(process.execPath, ["--input-type=module", "-e", freshIncrementalSourceCacheReaderScript], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HARNESS_ROOT: rootDir,
+      HARNESS_PREVIOUS_SOURCE_FINGERPRINT: previousSourceFingerprint,
+      HARNESS_TOUCHED_PATH: touchedPath
+    },
+    encoding: "utf8"
+  });
+  assert.equal(child.status, 0, child.stderr);
+  return JSON.parse(child.stdout.trim());
+}
+
+function runFreshIncrementalProcessWithRows(
+  rootDir: string,
+  touchedPath: string,
+  previousSourceFingerprint: string
+): { readonly mode: string; readonly taskIds: ReadonlyArray<string> } {
+  const child = spawnSync(process.execPath, ["--input-type=module", "-e", freshIncrementalRowsReaderScript], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HARNESS_ROOT: rootDir,
+      HARNESS_PREVIOUS_SOURCE_FINGERPRINT: previousSourceFingerprint,
+      HARNESS_TOUCHED_PATH: touchedPath
+    },
+    encoding: "utf8"
+  });
+  assert.equal(child.status, 0, child.stderr);
+  return JSON.parse(child.stdout.trim()) as { readonly mode: string; readonly taskIds: ReadonlyArray<string> };
+}
+
+function withTempProjection(run: (rootDir: string) => void): void {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-projection-source-cache-"));
+  try {
+    run(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function seedHarness(rootDir: string): void {
+  for (const taskId of ["task-a", "task-b", "task-c"]) {
+    writeIndex(rootDir, taskId, `Task ${taskId}`, "active");
+  }
+  writeDecision(rootDir, "Cached decision");
+}
+
+function writeIndex(rootDir: string, taskId: string, title: string, status: string, authoredRoot = "harness"): string {
+  const indexPath = path.join(rootDir, authoredRoot, "tasks", taskId, "INDEX.md");
+  mkdirSync(path.dirname(indexPath), { recursive: true });
+  writeFileSync(indexPath, [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    `title: ${title}`,
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    `  status: ${status}`,
+    "  ref: ",
+    `  titleSnapshot: ${title}`,
+    "  url: ",
+    "  bindingCreatedAt: 2026-07-07T00:00:00.000Z",
+    "  bindingFingerprint: sha256:fixture",
+    "packageDisposition: active",
+    "---",
+    ""
+  ].join("\n"));
+  stamp(indexPath);
+  return indexPath;
+}
+
+function writeDecision(rootDir: string, title: string): string {
+  const decisionPath = path.join(rootDir, "harness/decisions/decision-cache/decision.md");
+  mkdirSync(path.dirname(decisionPath), { recursive: true });
+  writeFileSync(decisionPath, [
+    "---",
+    "schema: decision-package/v1",
+    "decision_id: dec_CACHE",
+    "_coordinatorWatermark: wm-cache",
+    `title: ${title}`,
+    "state: active",
+    "question: Cache authored sources?",
+    "chosen: []",
+    "rejected: []",
+    "claims: []",
+    "relations: []",
+    "---",
+    ""
+  ].join("\n"));
+  stamp(decisionPath);
+  return decisionPath;
+}
+
+function writeAttributionEvent(rootDir: string, eventId: string, entityId: string): string {
+  const eventPath = path.join(rootDir, "harness/attribution-events", `${eventId}.jsonl`);
+  mkdirSync(path.dirname(eventPath), { recursive: true });
+  writeFileSync(eventPath, `${JSON.stringify({
+    schema: "attribution-event/v1",
+    eventId,
+    opId: `op-${eventId}`,
+    journalRecordSchema: "write-journal/v2",
+    entityId,
+    kind: "progress_append",
+    actor: {
+      principal: { kind: "person", personId: "person_test" },
+      executor: { kind: "agent", id: "agent_test" }
+    },
+    principalSource: {
+      kind: "local-configured",
+      authority: "harness.yaml",
+      authoritySha256: `sha256:${"0".repeat(64)}`
+    },
+    executorSource: "client-asserted",
+    at: "2026-07-07T00:00:00.000Z",
+    recordedAt: "2026-07-07T00:00:01.000Z",
+    payloadHash: `sha256:${"1".repeat(64)}`,
+    payloadRef: {
+      path: `.harness/payloads/${eventId}.json`,
+      sha256: `sha256:${"1".repeat(64)}`
+    }
+  })}\n`);
+  stamp(eventPath);
+  return eventPath;
+}
+
+function stamp(filePath: string): void {
+  const fixed = new Date("2026-07-07T00:00:00.000Z");
+  utimesSync(filePath, fixed, fixed);
+}
+
+const bodyCounterPrelude = `
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+const originalReadFileSync = fs.readFileSync;
+const counts = { taskBodiesRead: 0, decisionBodiesRead: 0, attributionBodiesRead: 0 };
+fs.readFileSync = function(input, ...args) {
+  const inputPath = typeof input === "string" ? input : "";
+  if (inputPath.endsWith("/INDEX.md") && inputPath.includes("/harness/tasks/")) counts.taskBodiesRead += 1;
+  if (inputPath.includes("/harness/decisions/")) counts.decisionBodiesRead += 1;
+  if (inputPath.includes("/harness/attribution-events/")) counts.attributionBodiesRead += 1;
+  return Reflect.apply(originalReadFileSync, this, [input, ...args]);
+};
+syncBuiltinESMExports();
+`;
+
+const freshProjectionBodyCacheReaderScript = `${bodyCounterPrelude}
+const { readTaskProjection } = await import("./packages/kernel/src/projection/sqlite-task-projection.ts");
+const projection = readTaskProjection({ rootDir: process.env.HARNESS_ROOT });
+process.stdout.write(JSON.stringify({
+  ...counts,
+  warnings: projection.warnings.map((warning) => warning.code)
+}));
+`;
+
+const freshIncrementalSourceCacheReaderScript = `${bodyCounterPrelude}
+const { updateTaskProjectionIncrementally } = await import("./packages/kernel/src/projection/sqlite-task-incremental-projection.ts");
+const result = updateTaskProjectionIncrementally({
+  rootDir: process.env.HARNESS_ROOT,
+  touchedPaths: [process.env.HARNESS_TOUCHED_PATH],
+  previousSourceFingerprint: process.env.HARNESS_PREVIOUS_SOURCE_FINGERPRINT
+});
+process.stdout.write(JSON.stringify({ ...counts, mode: result.mode }));
+`;
+
+const freshIncrementalRowsReaderScript = `
+const { updateTaskProjectionIncrementally } = await import("./packages/kernel/src/projection/sqlite-task-incremental-projection.ts");
+const result = updateTaskProjectionIncrementally({
+  rootDir: process.env.HARNESS_ROOT,
+  touchedPaths: [process.env.HARNESS_TOUCHED_PATH],
+  previousSourceFingerprint: process.env.HARNESS_PREVIOUS_SOURCE_FINGERPRINT
+});
+process.stdout.write(JSON.stringify({ mode: result.mode, taskIds: result.rows.map((row) => row.taskId) }));
+`;


### PR DESCRIPTION
# English

## Summary

This PR replaces process-only and whole-blob projection source reuse with a transactional SQLite row model. Task, Decision, and Attribution source entries are persisted independently, verified by content hash and filesystem signature, and updated through row-level deltas. The change is intentionally a foundation slice for the larger GUI performance task: it improves restart behavior and incremental locality, but it does not claim that the current raw body column is the final storage architecture or that the 5,000-entity cold-start target is complete.

## What Changed

- Added per-file source cache, directory-watch, and metadata tables with one read transaction and atomic publication with projection metadata.
- Restored unchanged Task, Decision, and Attribution sources across fresh processes without rereading authored bodies; one changed source reads and writes only its own row.
- Replaced full Attribution table comparison with changed-shard SQL deltas and affected-subject rematerialization.
- Reused validated projection generations and unchanged attribution hashes on safe incremental paths.
- Added TOCTOU, layout identity, tamper, absent-index, fresh-process, and SQL row-locality regression coverage.
- Split Task row materialization from source discovery to preserve the repository complexity boundary.

## Task And Scope

- Harness task: `task_01KXCS9KEKA2H3H8614ZBB984J`
- Branch: `codex/gui-projection-persistent-cache`
- Public scope: kernel projection source persistence, integrity, and incremental update locality
- Private planning/evidence updated: yes
- Out of scope: GUI pagination and virtualization, splash UI, normalized Execution output tables, Git generation cuts, segmented Attribution authority, and claiming completion of the 5,000-entity cold-start objective

## Version Impact

- Version: no package version change because this is an unreleased internal projection implementation change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `packages/kernel/src/**` and kernel projection integration tests
- Authority: performance task `task_01KXCS9KEKA2H3H8614ZBB984J`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: the same active performance task retains the 5,000-entity cold-start, query-path split, normalized Execution Evidence read model, and background-loading work

## Verification

- Base `origin/main` SHA: `4b7bbd67dbe7e0f8cba99a01dc6f2f64e98b3745`
- Branch merge-base with `origin/main`: `4b7bbd67dbe7e0f8cba99a01dc6f2f64e98b3745`
- Last `git fetch origin` time: `2026-07-13T09:58:33Z`
- Sync method: rebase
- Public diff command: `git diff --check origin/main...HEAD`
- Private evidence commit/path: maintained in the governed Harness task package; not published in this repository
- Reviewer evidence path: PR checks and review discussion
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `git diff --check`
- [x] `npm run check:pr`
- [x] `npm run typecheck`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:check-private-boundary`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: standalone `npm run check`; `npm run check:pr` ran the PR-required fast, contract, integration, GUI, and 32 manifest gate surfaces instead

Performance evidence on a quiet local run: 1,000 Tasks and Executions, 5,000 Outputs, and 5,000 Attribution Events rebuilt in 5.14 seconds; warm Execution query p95 was 88.62 ms; one Execution incremental update was 336.89 ms. A 5,000-entity run rebuilt in 24.64 seconds, queried at 436.95 ms p95, and updated one Execution in 1.65 seconds. The large cold result remains open work and is not hidden by the passing 1,000-entity budget.

## Review Evidence

- Self-review: checked atomic publication, layout isolation, source-body integrity, and SQL locality; fixed an existing-task-directory watch hole found by the full integration suite
- Reviewer subagent: independent read-only architecture and correctness reviews found no remaining blocker for this transitional slice
- Human review: pending
- Blocking findings: none known

## Residual Risk

- `projection_source_cache_files.body` is a transitional authored-body mirror. Follow-up work should replace it with compact manifest or Git object identity, especially for Attribution.
- Warm Execution routes still perform broad projection readiness work. The next query-path PR must separate generation readiness from resource SQL queries.
- The 5,000-entity cold path remains above the ten-second product objective and therefore the parent performance task remains active.

## References

- Task: `task_01KXCS9KEKA2H3H8614ZBB984J`
- Evidence: local benchmark and complete PR gate output summarized above
- Review: independent storage architecture review completed before PR creation

---

# 中文

## 概要

本 PR 不再围绕一个巨型 JSON 缓存继续打补丁，而是把 Task、Decision、Attribution 的投影来源改为 SQLite 行级模型。每个来源文件各自拥有路径、类型、签名、内容哈希与元数据；发生变化时只更新对应行，并与投影数据和 generation 元数据在同一个事务中发布。这个改动是整体 GUI 性能任务的基础切片，不是最终架构：它解决重启后重复读取和单文件变化触发全量重写的问题，但不会把当前 raw body 列包装成终局，也不会声称五千条冷启动目标已经完成。

## 改动内容

- 新增来源文件表、目录 watch 表和元数据表，读取时使用同一个 SQLite 事务，避免多人或多进程并发时读到混合代际。
- 新进程能够复用未变化的 Task、Decision、Attribution 正文；单个来源变化只读取、校验和写入自己的行。
- Attribution 不再全表比较后重写，而是根据变化 shard 生成删除与插入差量，只重算受影响 subject 的归因摘要。
- 安全条件满足时复用已验证 generation 和 Attribution hash，降低普通 Execution 增量更新成本。
- 增加原子替换竞态、TOCTOU、布局隔离、篡改检测、已有 Task 目录后补 INDEX、跨进程正文读取次数、SQL 行级局部性等回归测试。
- 将 Task 行物化与来源发现拆分，保持文件复杂度和模块职责边界。

## 任务与范围

- Harness 任务：`task_01KXCS9KEKA2H3H8614ZBB984J`
- 分支：`codex/gui-projection-persistent-cache`
- 公开范围：kernel 投影来源持久化、完整性验证、增量更新局部性
- 私有计划 / 证据是否已更新：yes
- 范围外：GUI 分页和虚拟列表、开屏动画、Execution Output 规范化子表、Git generation cut、Attribution 分段 authority，以及宣称五千条冷启动目标完成

## 版本影响

- 版本：不改包版本，因为这是尚未发布的内部投影实现调整
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`packages/kernel/src/**` 与 kernel 投影集成测试
- 依据：性能任务 `task_01KXCS9KEKA2H3H8614ZBB984J`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：同一个 active 性能任务继续承接五千条冷启动、查询路径拆分、Execution Evidence 规范化读模型与后台加载工作

## 验证

- `origin/main` 基准 SHA：`4b7bbd67dbe7e0f8cba99a01dc6f2f64e98b3745`
- 当前分支与 `origin/main` 的 merge-base：`4b7bbd67dbe7e0f8cba99a01dc6f2f64e98b3745`
- 最近一次 `git fetch origin` 时间：`2026-07-13T09:58:33Z`
- 同步方式：rebase
- 公开 diff 命令：`git diff --check origin/main...HEAD`
- 私有证据 commit/path：记录在受治理的 Harness 任务包中，不发布到公开仓库
- Reviewer 证据路径：PR checks 与审查讨论
- GitHub Actions `rewrite-ci` run URL：等待 CI
- [x] `git diff --check`
- [x] `npm run check:pr`
- [x] `npm run typecheck`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:check-private-boundary`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：未单独运行 `npm run check`；`npm run check:pr` 已覆盖 PR 所需的 fast、contract、integration、GUI 和三十二项 manifest gate

安静环境的一次性能结果为：一千个 Task 与 Execution、五千个 Output、五千个 Attribution Event，冷构建五点一四秒，warm Execution 查询 p95 为八十八点六二毫秒，单个 Execution 增量更新三百三十六点八九毫秒。五千条场景冷构建仍为二十四点六四秒，查询 p95 为四百三十六点九五毫秒，单个 Execution 增量更新一点六五秒。五千条冷构建仍明显高于十秒目标，所以父性能任务继续保持 active，不能用一千条预算通过来掩盖剩余问题。

## 审查证据

- 自查：检查原子发布、布局隔离、正文完整性和 SQL 局部性；完整集成测试发现已有 Task 目录后补 INDEX 的 watch 漏洞后，已增加回归测试并修复
- Reviewer subagent：独立只读架构与正确性审查确认当前过渡切片没有剩余 blocker
- 人工审查：等待
- 阻塞发现：当前无已知阻塞项

## 残余风险

- `projection_source_cache_files.body` 仍是过渡性的 authored-body 镜像，后续应改成紧凑 manifest 或 Git object identity，尤其不应长期保存 Attribution 原文副本。
- warm Execution route 仍会承担过宽的 projection readiness 工作，下一 PR 必须把 generation readiness 与具体资源 SQL 查询拆开。
- 五千条冷启动尚未达到十秒产品目标，因此整体性能任务不会关闭；开屏和 skeleton 只能改善感知，不能替代真实预算。

## 关联材料

- 任务：`task_01KXCS9KEKA2H3H8614ZBB984J`
- 证据：上面的本地基准与完整 PR 门禁结果
- 审查：创建 PR 前已完成独立存储架构审查

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses two complete language blocks. / PR 正文使用完整双语块。
- [x] Protected surface governance authority is declared. / 已声明 protected surface 治理依据。
- [x] No private harness files or local agent files are included. / 不包含私有 Harness 文件或本地 Agent 文件。
- [x] No absolute local filesystem paths are included. / 不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于任务范围。
- [x] Version, verification, review, residual risk, and merge scope are stated. / 已说明版本、验证、审查、残余风险与合并范围。
- [x] No admin bypass is planned. / 不计划管理员绕过。
