### PR TITLE
perf(gui): prepare validated projection generations

### DIFF
--- a/packages/kernel/src/local/local-layout-file-system.ts
+++ b/packages/kernel/src/local/local-layout-file-system.ts
@@ -36,6 +36,9 @@ export const localProjectionSourceFileSystem = {
   },
   statSignature: (inputPath: string): string | null => {
     return projectionSourceStatSignature(inputPath);
+  },
+  statSignatureIfNonEmpty: (inputPath: string): string | null => {
+    return projectionSourceStatSignature(inputPath, true);
   }
 };
 
@@ -50,9 +53,10 @@ export function listProjectionSourceDirectoryPaths(rootPath: string): ReadonlyAr
   }
 }
 
-function projectionSourceStatSignature(inputPath: string): string | null {
+function projectionSourceStatSignature(inputPath: string, requireNonEmpty = false): string | null {
   try {
     const stats = statSync(inputPath, { bigint: true });
+    if (requireNonEmpty && stats.size === 0n) return null;
     return [stats.dev, stats.ino, stats.mode, stats.size, stats.mtimeNs, stats.ctimeNs].join(":");
   } catch {
     return null;

--- a/packages/kernel/src/projection/projection-generation-readiness.ts
+++ b/packages/kernel/src/projection/projection-generation-readiness.ts
@@ -1,0 +1,151 @@
+import { DatabaseSync } from "node:sqlite";
+import path from "node:path";
+import type { HarnessLayoutOverrides } from "../layout/index.ts";
+import { resolveHarnessLayout } from "../layout/index.ts";
+import { projectionDatabaseFileSignature } from "./sqlite-projection-database-signature.ts";
+import { projectionVersion } from "./sqlite-projection-store.ts";
+import { defaultTaskProjectionPath, readTaskProjection } from "./sqlite-task-projection.ts";
+import type { ProjectionReadResult } from "./types.ts";
+
+const readyProjectionGenerationBrand = Symbol("ready-projection-generation");
+const issuedReadyProjectionGenerations = new WeakSet<object>();
+
+export interface ReadyProjectionGeneration {
+  readonly projectionPath: string;
+  readonly sourceHash: string;
+  readonly version: string;
+  readonly databaseSignature: string;
+  readonly [readyProjectionGenerationBrand]: true;
+}
+
+export interface EnsureProjectionGenerationOptions {
+  readonly rootDir: string;
+  readonly layoutOverrides?: HarnessLayoutOverrides;
+}
+
+export interface EnsureProjectionGenerationResult {
+  readonly ready: ReadyProjectionGeneration;
+  readonly warnings: ProjectionReadResult["warnings"];
+}
+
+export interface ProjectionGenerationReadinessObserver {
+  readonly afterProjectionValidated?: () => void;
+}
+
+export class ProjectionGenerationChangedError extends Error {
+  constructor(message = "ready projection generation changed; reacquire it before querying") {
+    super(message);
+    this.name = "ProjectionGenerationChangedError";
+  }
+}
+
+class ReadyProjectionGenerationHandle implements ReadyProjectionGeneration {
+  readonly [readyProjectionGenerationBrand] = true as const;
+  readonly projectionPath: string;
+  readonly sourceHash: string;
+  readonly version: string;
+  readonly databaseSignature: string;
+
+  constructor(
+    projectionPath: string,
+    sourceHash: string,
+    version: string,
+    databaseSignature: string
+  ) {
+    this.projectionPath = projectionPath;
+    this.sourceHash = sourceHash;
+    this.version = version;
+    this.databaseSignature = databaseSignature;
+    issuedReadyProjectionGenerations.add(this);
+    Object.freeze(this);
+  }
+}
+
+export function ensureProjectionGenerationReady(
+  options: EnsureProjectionGenerationOptions,
+  observer?: ProjectionGenerationReadinessObserver
+): EnsureProjectionGenerationResult {
+  const rootDir = path.resolve(options.rootDir);
+  const projectionPath = options.layoutOverrides
+    ? resolveHarnessLayout({ rootDir, layoutOverrides: options.layoutOverrides }).projectionPath
+    : defaultTaskProjectionPath(rootDir);
+  const warnings: ProjectionReadResult["warnings"][number][] = [];
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const before = projectionDatabaseFileSignature(projectionPath);
+    const projection = readTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides });
+    warnings.push(...projection.warnings);
+    observer?.afterProjectionValidated?.();
+    const snapshot = captureStableProjectionDatabaseIdentity(projectionPath);
+    if (before !== null && before === snapshot.databaseSignature) {
+      return {
+        ready: new ReadyProjectionGenerationHandle(
+          projectionPath,
+          snapshot.sourceHash,
+          snapshot.version,
+          snapshot.databaseSignature
+        ),
+        warnings
+      };
+    }
+  }
+  throw new ProjectionGenerationChangedError("projection database did not stabilize across validation");
+}
+
+export function assertReadyProjectionGeneration(
+  ready: ReadyProjectionGeneration
+): asserts ready is ReadyProjectionGenerationHandle {
+  if (!(ready instanceof ReadyProjectionGenerationHandle) || !issuedReadyProjectionGenerations.has(ready)) {
+    throw new TypeError("ready projection generation handle was not established by the projection validator");
+  }
+}
+
+export function assertReadyProjectionDatabaseUnchanged(ready: ReadyProjectionGeneration): void {
+  assertReadyProjectionGeneration(ready);
+  if (projectionDatabaseSignature(ready.projectionPath) !== ready.databaseSignature) {
+    throw new ProjectionGenerationChangedError();
+  }
+}
+
+export function projectionDatabaseSignature(projectionPath: string): string {
+  const signature = projectionDatabaseFileSignature(projectionPath);
+  if (signature === null) throw new ProjectionGenerationChangedError("ready projection database is unavailable");
+  return signature;
+}
+
+function captureStableProjectionDatabaseIdentity(projectionPath: string): {
+  readonly sourceHash: string;
+  readonly version: string;
+  readonly databaseSignature: string;
+} {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const before = projectionDatabaseSignature(projectionPath);
+    const db = new DatabaseSync(projectionPath, { readOnly: true });
+    let sourceHash: string;
+    let version: string;
+    try {
+      db.exec("BEGIN");
+      sourceHash = readRequiredMeta(db, "sourceHash");
+      version = readRequiredMeta(db, "version");
+      db.exec("COMMIT");
+    } catch (error) {
+      if (db.isTransaction) db.exec("ROLLBACK");
+      throw error;
+    } finally {
+      db.close();
+    }
+    const after = projectionDatabaseSignature(projectionPath);
+    if (before === after) {
+      if (version !== projectionVersion) throw new ProjectionGenerationChangedError("ready projection schema version changed");
+      return { sourceHash, version, databaseSignature: after };
+    }
+  }
+  throw new ProjectionGenerationChangedError("projection database did not stabilize while acquiring a ready generation");
+}
+
+function readRequiredMeta(db: DatabaseSync, key: string): string {
+  const row = db.prepare("SELECT value FROM projection_meta WHERE key = ?").get(key) as { readonly value?: unknown } | undefined;
+  if (!row || typeof row.value !== "string" || row.value.length === 0) {
+    throw new ProjectionGenerationChangedError(`ready projection metadata is missing ${key}`);
+  }
+  return row.value;
+}

--- a/packages/kernel/src/projection/sqlite-execution-evidence-reader.ts
+++ b/packages/kernel/src/projection/sqlite-execution-evidence-reader.ts
@@ -1,7 +1,13 @@
 import { DatabaseSync } from "node:sqlite";
-import path from "node:path";
-import { resolveHarnessLayout, type HarnessLayoutOverrides } from "../layout/index.ts";
-import { defaultTaskProjectionPath, readTaskProjection } from "./sqlite-task-projection.ts";
+import type { HarnessLayoutOverrides } from "../layout/index.ts";
+import {
+  assertReadyProjectionDatabaseUnchanged,
+  assertReadyProjectionGeneration,
+  ensureProjectionGenerationReady,
+  projectionDatabaseSignature,
+  ProjectionGenerationChangedError,
+  type ReadyProjectionGeneration
+} from "./projection-generation-readiness.ts";
 
 export interface ExecutionEvidenceCursor {
   readonly generation: string;
@@ -57,39 +63,90 @@ export interface ExecutionEvidencePage {
   readonly nextCursor: ExecutionEvidenceCursor | null;
 }
 
-interface ExecutionEvidencePageOptions {
+interface ExecutionEvidencePageOptions extends ExecutionEvidencePageQuery {
   readonly rootDir: string;
   readonly layoutOverrides?: HarnessLayoutOverrides;
+}
+
+export interface ExecutionEvidencePageQuery {
   readonly limit: number;
   readonly cursor?: ExecutionEvidenceCursor;
+}
+
+export interface ExecutionEvidenceReadObserver {
+  readonly afterExecutionRowsRead?: () => void;
+  readonly afterSnapshotRead?: (page: ExecutionEvidencePage) => void;
 }
 
 export function queryExecutionEvidencePage(
   options: ExecutionEvidencePageOptions
 ): ExecutionEvidencePage {
-  const db = openFreshExecutionEvidenceProjection(options);
+  const ready = ensureProjectionGenerationReady({
+    rootDir: options.rootDir,
+    layoutOverrides: options.layoutOverrides
+  }).ready;
   try {
-    return readExecutionEvidencePage(db, options);
-  } finally {
-    db.close();
+    return queryExecutionEvidencePageFromReadyGeneration(ready, options);
+  } catch (error) {
+    if (options.cursor || !(error instanceof ProjectionGenerationChangedError)) throw error;
+    const reacquired = ensureProjectionGenerationReady({
+      rootDir: options.rootDir,
+      layoutOverrides: options.layoutOverrides
+    }).ready;
+    return queryExecutionEvidencePageFromReadyGeneration(reacquired, options);
   }
 }
 
-// Internal benchmark/daemon seam. Callers must establish projection freshness first.
-export function queryExecutionEvidencePageFromReadyProjection(
-  options: ExecutionEvidencePageOptions
+// Internal daemon/benchmark seam. The opaque handle proves freshness was established first.
+export function queryExecutionEvidencePageFromReadyGeneration(
+  ready: ReadyProjectionGeneration,
+  query: ExecutionEvidencePageQuery,
+  observer?: ExecutionEvidenceReadObserver
 ): ExecutionEvidencePage {
-  const db = new DatabaseSync(executionEvidenceProjectionPath(options), { readOnly: true });
+  assertReadyProjectionDatabaseUnchanged(ready);
+  const before = ready.databaseSignature;
+  const db = new DatabaseSync(ready.projectionPath, { readOnly: true });
   try {
-    return readExecutionEvidencePage(db, options);
+    const page = readExecutionEvidencePage(db, ready, query, observer);
+    const after = projectionDatabaseSignature(ready.projectionPath);
+    if (after !== before) throw new ProjectionGenerationChangedError("projection database changed while reading its generation");
+    return page;
   } finally {
     db.close();
   }
 }
 
-function readExecutionEvidencePage(db: DatabaseSync, options: ExecutionEvidencePageOptions): ExecutionEvidencePage {
-  const limit = executionEvidencePageLimit(options.limit);
-  const cursor = options.cursor;
+function readExecutionEvidencePage(
+  db: DatabaseSync,
+  ready: ReadyProjectionGeneration,
+  query: ExecutionEvidencePageQuery,
+  observer?: ExecutionEvidenceReadObserver
+): ExecutionEvidencePage {
+  db.exec("BEGIN");
+  try {
+    assertReadyProjectionGeneration(ready);
+    const version = readProjectionMeta(db, "version");
+    const sourceHash = readProjectionMeta(db, "sourceHash");
+    if (version !== ready.version || sourceHash !== ready.sourceHash) {
+      throw new ProjectionGenerationChangedError();
+    }
+    const page = readExecutionEvidenceSnapshot(db, query, observer);
+    observer?.afterSnapshotRead?.(page);
+    db.exec("COMMIT");
+    return page;
+  } catch (error) {
+    if (db.isTransaction) db.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+function readExecutionEvidenceSnapshot(
+  db: DatabaseSync,
+  query: ExecutionEvidencePageQuery,
+  observer?: ExecutionEvidenceReadObserver
+): ExecutionEvidencePage {
+  const limit = executionEvidencePageLimit(query.limit);
+  const cursor = query.cursor;
   if (cursor) validateExecutionEvidenceCursor(cursor);
   const generation = readExecutionEvidenceGeneration(db);
   if (cursor && cursor.generation !== generation) {
@@ -118,6 +175,7 @@ function readExecutionEvidencePage(db: DatabaseSync, options: ExecutionEvidenceP
   ) as Array<Record<string, unknown>>;
   const hasNextPage = executionRows.length > limit;
   const visibleExecutionRows = executionRows.slice(0, limit);
+  observer?.afterExecutionRowsRead?.();
   const executionIds = visibleExecutionRows.map((row) => String(row.execution_id));
   const outputRows = executionIds.length === 0 ? [] : db.prepare(`
       SELECT * FROM (
@@ -184,18 +242,6 @@ function readExecutionEvidencePage(db: DatabaseSync, options: ExecutionEvidenceP
       executionId: String(last.execution_id)
     } : null
   };
-}
-
-function openFreshExecutionEvidenceProjection(options: ExecutionEvidencePageOptions): DatabaseSync {
-  const rootDir = path.resolve(options.rootDir);
-  readTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides });
-  return new DatabaseSync(executionEvidenceProjectionPath(options), { readOnly: true });
-}
-
-function executionEvidenceProjectionPath(options: ExecutionEvidencePageOptions): string {
-  return options.layoutOverrides
-    ? resolveHarnessLayout({ rootDir: path.resolve(options.rootDir), layoutOverrides: options.layoutOverrides }).projectionPath
-    : defaultTaskProjectionPath(path.resolve(options.rootDir));
 }
 
 function toExecutionEvidence(
@@ -298,9 +344,13 @@ function validateExecutionEvidenceCursor(cursor: ExecutionEvidenceCursor): void 
 }
 
 function readExecutionEvidenceGeneration(db: DatabaseSync): string {
-  const row = db.prepare("SELECT value FROM projection_meta WHERE key = 'sourceHash'").get() as { readonly value?: unknown } | undefined;
+  return readProjectionMeta(db, "sourceHash");
+}
+
+function readProjectionMeta(db: DatabaseSync, key: string): string {
+  const row = db.prepare("SELECT value FROM projection_meta WHERE key = ?").get(key) as { readonly value?: unknown } | undefined;
   if (!row || typeof row.value !== "string" || row.value.length === 0) {
-    throw new Error("execution evidence projection generation is missing");
+    throw new ProjectionGenerationChangedError(`execution evidence projection metadata is missing ${key}`);
   }
   return row.value;
 }

--- a/packages/kernel/src/projection/sqlite-projection-database-signature.ts
+++ b/packages/kernel/src/projection/sqlite-projection-database-signature.ts
@@ -1,0 +1,11 @@
+import { localProjectionSourceFileSystem } from "../local/local-layout-file-system.ts";
+
+export function projectionDatabaseFileSignature(projectionPath: string): string | null {
+  const database = localProjectionSourceFileSystem.statSignature(projectionPath);
+  if (database === null) return null;
+  return JSON.stringify({
+    database,
+    rollbackJournal: localProjectionSourceFileSystem.statSignatureIfNonEmpty(`${projectionPath}-journal`),
+    writeAheadLog: localProjectionSourceFileSystem.statSignatureIfNonEmpty(`${projectionPath}-wal`)
+  });
+}

--- a/packages/kernel/src/projection/sqlite-projection-validation-cache.ts
+++ b/packages/kernel/src/projection/sqlite-projection-validation-cache.ts
@@ -1,5 +1,5 @@
-import { localProjectionSourceFileSystem } from "../local/local-layout-file-system.ts";
 import type { DeclaredSourceManifestRow } from "./sqlite-declared-source-manifest.ts";
+import { projectionDatabaseFileSignature } from "./sqlite-projection-database-signature.ts";
 
 export interface ProjectionValidationCacheEntry {
   readonly signature: string;
@@ -11,7 +11,7 @@ const projectionValidationCacheLimit = 16;
 
 export function readCachedProjectionValidation(projectionPath: string): ProjectionValidationCacheEntry | null {
   const cached = projectionValidationCache.get(projectionPath);
-  if (!cached || localProjectionSourceFileSystem.statSignature(projectionPath) !== cached.signature) return null;
+  if (!cached || projectionDatabaseFileSignature(projectionPath) !== cached.signature) return null;
   projectionValidationCache.delete(projectionPath);
   projectionValidationCache.set(projectionPath, cached);
   return cached;
@@ -21,7 +21,7 @@ export function rememberProjectionValidation(
   projectionPath: string,
   declaredManifest: ReadonlyArray<DeclaredSourceManifestRow>
 ): void {
-  const signature = localProjectionSourceFileSystem.statSignature(projectionPath);
+  const signature = projectionDatabaseFileSignature(projectionPath);
   if (signature === null) return;
   projectionValidationCache.delete(projectionPath);
   projectionValidationCache.set(projectionPath, { signature, declaredManifest });

--- a/packages/kernel/test/store/sqlite-execution-evidence-projection.test.ts
+++ b/packages/kernel/test/store/sqlite-execution-evidence-projection.test.ts
@@ -5,7 +5,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
-import { queryExecutionEvidencePage } from "../../src/projection/sqlite-execution-evidence-reader.ts";
+import {
+  queryExecutionEvidencePage,
+  queryExecutionEvidencePageFromReadyGeneration
+} from "../../src/projection/sqlite-execution-evidence-reader.ts";
+import { ensureProjectionGenerationReady } from "../../src/projection/projection-generation-readiness.ts";
 import { captureProjectionSourceSnapshot } from "../../src/projection/projection-source-snapshot.ts";
 import { updateTaskProjectionIncrementally } from "../../src/projection/sqlite-task-incremental-projection.ts";
 import { rebuildTaskProjection } from "../../src/projection/sqlite-task-projection.ts";
@@ -237,6 +241,194 @@ test("execution evidence page caps output previews without losing total counts",
     assert.equal(execution?.hasMoreOutputs, true);
     assert.equal(page.stats.totalOutputs, 8);
     assert.ok(Buffer.byteLength(JSON.stringify(page), "utf8") < 250 * 1024);
+  });
+});
+
+test("execution evidence page pins generation rows outputs and stats to one SQLite snapshot", () => {
+  withHarness((rootDir) => {
+    const identity = ids(1);
+    writeTask(rootDir, identity.taskId, "Snapshot evidence");
+    writeExecution(
+      rootDir,
+      identity.taskId,
+      identity.executionId,
+      "2026-07-13T00:01:00.000Z",
+      [inlineOutput(identity, "ev-before", "Before")]
+    );
+    rebuildTaskProjection({ rootDir });
+    const db = openProjection(rootDir, false);
+    try {
+      db.exec("PRAGMA journal_mode = WAL");
+    } finally {
+      db.close();
+    }
+    const ready = ensureProjectionGenerationReady({ rootDir }).ready;
+    let writerCommitted = false;
+    let pinnedPage: ReturnType<typeof queryExecutionEvidencePageFromReadyGeneration> | null = null;
+
+    assert.throws(
+      () => queryExecutionEvidencePageFromReadyGeneration(
+        ready,
+        { limit: 1 },
+        {
+          afterExecutionRowsRead: () => {
+            const writer = openProjection(rootDir, false);
+            try {
+              writer.exec("BEGIN IMMEDIATE");
+              writer.prepare(`
+                UPDATE execution_output_projection
+                SET evidence_id = 'ev-after', inline_text = 'After'
+                WHERE execution_id = ?
+              `).run(identity.executionId);
+              writer.prepare(`
+                INSERT INTO execution_output_projection (
+                  execution_id, ordinal, evidence_id, execution_ref, substrate, inline_text
+                ) VALUES (?, 1, 'ev-added', ?, 'inline', 'Added')
+              `).run(identity.executionId, `execution/${identity.taskId}/${identity.executionId}`);
+              writer.prepare("UPDATE projection_meta SET value = 'generation-after' WHERE key = 'sourceHash'").run();
+              writer.exec("COMMIT");
+              writerCommitted = true;
+            } finally {
+              writer.close();
+            }
+          },
+          afterSnapshotRead: (page) => {
+            pinnedPage = page;
+          }
+        }
+      ),
+      /projection database changed while reading/
+    );
+
+    assert.equal(writerCommitted, true);
+    assert.equal(pinnedPage?.groups[0]?.executions[0]?.outputs[0]?.text, "Before");
+    assert.equal(pinnedPage?.groups[0]?.executions[0]?.outputCount, 1);
+    assert.equal(pinnedPage?.stats.totalOutputs, 1);
+    const refreshed = openProjection(rootDir);
+    try {
+      assert.equal(refreshed.prepare("SELECT COUNT(*) AS count FROM execution_output_projection").get()?.count, 2);
+      assert.equal(refreshed.prepare("SELECT inline_text FROM execution_output_projection ORDER BY ordinal").get()?.inline_text, "After");
+      assert.equal(refreshed.prepare("SELECT value FROM projection_meta WHERE key = 'sourceHash'").get()?.value, "generation-after");
+    } finally {
+      refreshed.close();
+    }
+  });
+});
+
+test("ready generation handle rejects database changes that bypass generation validation", () => {
+  withHarness((rootDir) => {
+    const identity = ids(1);
+    writeTask(rootDir, identity.taskId, "Ready handle tamper");
+    writeExecution(rootDir, identity.taskId, identity.executionId, "2026-07-13T00:01:00.000Z", [
+      inlineOutput(identity, "ev-original", "Original")
+    ]);
+    rebuildTaskProjection({ rootDir });
+    const journal = openProjection(rootDir, false);
+    try {
+      journal.exec("PRAGMA journal_mode = WAL");
+    } finally {
+      journal.close();
+    }
+    const ready = ensureProjectionGenerationReady({ rootDir }).ready;
+    assert.equal(Object.isFrozen(ready), true);
+    const forged = Object.assign(Object.create(Object.getPrototypeOf(ready)) as object, ready) as typeof ready;
+    assert.throws(
+      () => queryExecutionEvidencePageFromReadyGeneration(forged, { limit: 1 }),
+      /handle was not established by the projection validator/
+    );
+    const pinnedReader = openProjection(rootDir);
+    pinnedReader.exec("BEGIN");
+    pinnedReader.prepare("SELECT value FROM projection_meta WHERE key = 'sourceHash'").get();
+    const db = openProjection(rootDir, false);
+    try {
+      db.prepare("UPDATE execution_output_projection SET inline_text = 'TAMPERED'").run();
+    } finally {
+      db.close();
+    }
+
+    try {
+      assert.throws(
+        () => queryExecutionEvidencePageFromReadyGeneration(ready, { limit: 1 }),
+        /ready projection generation changed/
+      );
+    } finally {
+      pinnedReader.exec("ROLLBACK");
+      pinnedReader.close();
+    }
+  });
+});
+
+test("ready generation acquisition retries when the database changes after validation", () => {
+  withHarness((rootDir) => {
+    const identity = ids(1);
+    writeTask(rootDir, identity.taskId, "Acquire race");
+    writeExecution(rootDir, identity.taskId, identity.executionId, "2026-07-13T00:01:00.000Z", [
+      inlineOutput(identity, "ev-original", "Original")
+    ]);
+    rebuildTaskProjection({ rootDir });
+    let tampered = false;
+
+    const acquired = ensureProjectionGenerationReady(
+      { rootDir },
+      {
+        afterProjectionValidated: () => {
+          if (tampered) return;
+          const db = openProjection(rootDir, false);
+          try {
+            db.prepare("UPDATE execution_output_projection SET inline_text = 'TAMPERED'").run();
+            tampered = true;
+          } finally {
+            db.close();
+          }
+        }
+      }
+    );
+
+    assert.equal(tampered, true);
+    assert.equal(
+      queryExecutionEvidencePageFromReadyGeneration(acquired.ready, { limit: 1 })
+        .groups[0]?.executions[0]?.outputs[0]?.text,
+      "Original"
+    );
+  });
+});
+
+test("ready generation acquisition does not trust a cached validation across WAL changes", () => {
+  withHarness((rootDir) => {
+    const identity = ids(1);
+    writeTask(rootDir, identity.taskId, "Cached WAL validation");
+    writeExecution(rootDir, identity.taskId, identity.executionId, "2026-07-13T00:01:00.000Z", [
+      inlineOutput(identity, "ev-original", "Original")
+    ]);
+    rebuildTaskProjection({ rootDir });
+    const journal = openProjection(rootDir, false);
+    try {
+      journal.exec("PRAGMA journal_mode = WAL");
+    } finally {
+      journal.close();
+    }
+    ensureProjectionGenerationReady({ rootDir });
+    const pinnedReader = openProjection(rootDir);
+    pinnedReader.exec("BEGIN");
+    pinnedReader.prepare("SELECT value FROM projection_meta WHERE key = 'sourceHash'").get();
+    const writer = openProjection(rootDir, false);
+    try {
+      writer.prepare("UPDATE execution_output_projection SET inline_text = 'TAMPERED'").run();
+    } finally {
+      writer.close();
+    }
+
+    try {
+      const reacquired = ensureProjectionGenerationReady({ rootDir }).ready;
+      assert.equal(
+        queryExecutionEvidencePageFromReadyGeneration(reacquired, { limit: 1 })
+          .groups[0]?.executions[0]?.outputs[0]?.text,
+        "Original"
+      );
+    } finally {
+      pinnedReader.exec("ROLLBACK");
+      pinnedReader.close();
+    }
   });
 });
 

--- a/tools/perf/gui-projection-benchmark.mjs
+++ b/tools/perf/gui-projection-benchmark.mjs
@@ -4,7 +4,8 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { aggregateExecutions } from "../../packages/gui/src/renderer/execution-data.ts";
 import { queryExecutionEvidencePage, queryExecutions, rebuildTaskProjection } from "../../packages/kernel/src/index.ts";
-import { queryExecutionEvidencePageFromReadyProjection } from "../../packages/kernel/src/projection/sqlite-execution-evidence-reader.ts";
+import { ensureProjectionGenerationReady } from "../../packages/kernel/src/projection/projection-generation-readiness.ts";
+import { queryExecutionEvidencePageFromReadyGeneration } from "../../packages/kernel/src/projection/sqlite-execution-evidence-reader.ts";
 import { captureProjectionSourceFingerprint } from "../../packages/kernel/src/projection/projection-source-snapshot.ts";
 import { readDeclaredSourceManifestRows } from "../../packages/kernel/src/projection/sqlite-declared-source-manifest.ts";
 import { updateTaskProjectionIncrementally } from "../../packages/kernel/src/projection/sqlite-task-incremental-projection.ts";
@@ -31,7 +32,8 @@ try {
   const warmQueryP95 = percentile(querySamples.samples, 0.95);
   const evidencePageSamples = sample(20, () => queryExecutionEvidencePage({ rootDir, limit: 25 }));
   const evidencePage = evidencePageSamples.value;
-  const readyEvidencePageSamples = sample(20, () => queryExecutionEvidencePageFromReadyProjection({ rootDir, limit: 25 }));
+  const readyGeneration = ensureProjectionGenerationReady({ rootDir }).ready;
+  const readyEvidencePageSamples = sample(20, () => queryExecutionEvidencePageFromReadyGeneration(readyGeneration, { limit: 25 }));
   const readyEvidencePageP95 = percentile(readyEvidencePageSamples.samples, 0.95);
   const evidencePagePayloadBytes = Buffer.byteLength(JSON.stringify(evidencePage), "utf8");
   const evidencePageVisibleItems = evidencePage.groups.length +
@@ -65,7 +67,7 @@ try {
       rebuild: rounded(rebuildMs),
       queryExecutions: summarize(querySamples.samples),
       queryExecutionEvidencePage: summarize(evidencePageSamples.samples),
-      queryExecutionEvidencePageFromReadyProjection: summarize(readyEvidencePageSamples.samples),
+      queryExecutionEvidencePageFromReadyGeneration: summarize(readyEvidencePageSamples.samples),
       aggregateExecutions: summarize(aggregateSamples.samples),
       incrementalExecution: rounded(incrementalExecutionMs)
     },


### PR DESCRIPTION
# English

## Summary

- Introduce an opaque, exact-instance ReadyProjectionGeneration capability that binds full projection validation to one stable SQLite database identity.
- Pin Execution Evidence rows, outputs, statistics, version, and source hash to one explicit SQLite read transaction.
- Detect main database, rollback journal, and non-empty WAL changes; reject tamper, validation-to-acquire races, forged handles, and any database change during a page read.
- Keep the existing production freshness path unchanged. This is a correctness prerequisite for the proposed daemon-owned generation manager, not a claim that the GUI route is already fast.

## Governance

- Task: task_01KXCS9KEKA2H3H8614ZBB984J
- Accepted SQL-first decision: dec_01KXDHHPYGJ3X4984T3RMWQJDV
- Proposed daemon generation-fence decision: dec_01KXDNPMSB80WW3WF0JVBCAWQ4
- The proposed decision is not activated by this pull request.

## Verification

- TypeScript typecheck and ESLint passed.
- Focused application and kernel tests: 12/12.
- Fast tests: 319/319.
- Contract tests: 441/441.
- GUI tests: 138/138.
- Static manifest gates and supply-chain SBOM gate passed.
- Five 1,000-execution benchmark runs kept the direct ready-page p95 below 9 ms; production validation and cold projection remain follow-up work and are not represented as complete.

# 中文

## 摘要

- 新增不可伪造的 ReadyProjectionGeneration 能力，把完整投影校验与一个稳定的 SQLite 数据库身份绑定。
- Execution Evidence 的执行、输出、统计、版本和 source hash 全部固定在同一个 SQLite 读事务快照内。
- 同时检测主库、rollback journal 和非空 WAL；拒绝旁路篡改、校验到铸造之间的竞态、伪造 handle，以及页面读取期间的任何数据库物理变化。
- 本 PR 不改变现有生产 freshness 路径。它是未来 daemon 代际管理器的正确性前置，不宣称 GUI 生产路径已经完成性能目标。

## 治理边界

- 任务：task_01KXCS9KEKA2H3H8614ZBB984J
- 已接受的 SQL-first 决策：dec_01KXDHHPYGJ3X4984T3RMWQJDV
- 待接受的 daemon generation-fence 决策：dec_01KXDNPMSB80WW3WF0JVBCAWQ4
- 本 PR 不会提前启用这条待接受决策。

## 验证

- TypeScript typecheck 与 ESLint 通过。
- application/kernel 聚焦测试 12/12。
- fast 测试 319/319。
- contract 测试 441/441。
- GUI 测试 138/138。
- 静态 manifest 门禁与 supply-chain SBOM 门禁通过。
- 5 次一千 Execution 基准中，direct-ready 页面 p95 均低于 9 ms；生产校验与冷构建仍是后续工作，不会把内部 seam 的结果冒充 GUI 端到端完成。