### PR TITLE
refactor(gui): 演化史换编码——DAG 拓扑接管布局，时间降级为排序约束

### DIFF
--- a/packages/gui/src/renderer/views/GenealogyTimelineView.tsx
+++ b/packages/gui/src/renderer/views/GenealogyTimelineView.tsx
@@ -2,6 +2,8 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ClockCounterClockwise } from "@phosphor-icons/react";
 import type { DecisionRow, RelationEdge } from "../model/types";
 import {
+  ENCODING_META,
+  type EncodingMode,
   KIND_META,
   buildGenealogyEdges,
   collectLineage,
@@ -16,14 +18,10 @@ import { ParticipantsSidebar } from "./genealogy/ParticipantsSidebar";
 import { TimelinePlot } from "./genealogy/TimelinePlot";
 
 /**
- * 决策谱系「演化史」视图入口壳（Jaeger-timeline 式）。
+ * 决策谱系「演化史」视图入口壳。
  *
- * 纯前端派生：从 triadicQuery.relations 里筛 kind ∈ 谱系四类且两端皆 decision，
- * 以选中 decision 为焦点上溯祖先 / 下溯后代。不改后端、不换图库、不碰 graph/**。
- *
- * 本文件只做编排（状态 / 派生 memo / 布局计算 / 子组件装配），职责细节见
- * ./genealogy/ 下的 layout（纯逻辑）、ParticipantsSidebar / TimelinePlot /
- * DecisionDetailPanel / EmptyStates（展示子组件）。
+ * 纯前端派生：从 relations 筛谱系四类边，焦点上溯/下溯。
+ * 时间编码可切换（序数轴 / 日簇折叠 / DAG 拓扑），不再用线性 wall-clock x。
  */
 export function GenealogyTimelineView({
   decisions,
@@ -34,7 +32,6 @@ export function GenealogyTimelineView({
 }: {
   decisions: DecisionRow[];
   relations: RelationEdge[];
-  /** 跨视图带入的聚焦实体（decision/<id>）；用于多视图切换同一实体。 */
   focusRef?: string | null;
   onNavigateEntity?: (ref: string) => void;
   onFocusGraph?: (ref: string) => void;
@@ -47,14 +44,11 @@ export function GenealogyTimelineView({
 
   const edges = useMemo(() => buildGenealogyEdges(relations, byId), [relations, byId]);
 
-  // 修 #11:refines/narrows/supersedes/supports 边集若成环,collectLineage 会静默
-  // 截断。cycle 警告与 focus 无关(只要边集成环就告警),独立于 layout 计算。
   const cycleWarning = useMemo(() => {
     const cycles = findGenealogyCycles(edges);
     return { count: cycles.length, cycles };
   }, [edges]);
 
-  // 参与谱系（有任一谱系边）的 decision——左栏候选焦点集。
   const participants = useMemo(() => {
     const ids = new Set<string>();
     for (const edge of edges) {
@@ -67,7 +61,6 @@ export function GenealogyTimelineView({
       .sort((a, b) => (timeMsOf(b) ?? 0) - (timeMsOf(a) ?? 0));
   }, [edges, byId]);
 
-  // 每个 decision 的谱系规模（祖先+后代数），用于默认挑一个「最有料」的焦点。
   const lineageSize = useMemo(() => {
     const size = new Map<string, number>();
     for (const decision of participants) {
@@ -79,8 +72,9 @@ export function GenealogyTimelineView({
   const [focusId, setFocusId] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
+  const [encoding, setEncoding] = useState<EncodingMode>("ordinal");
+  const [expandedDays, setExpandedDays] = useState<Set<string>>(() => new Set());
 
-  // 跨视图带入的焦点优先；否则挑谱系最大的一个。
   useEffect(() => {
     const incoming = focusRef ? decisionIdOf(focusRef) : null;
     if (incoming && byId.has(incoming)) {
@@ -103,9 +97,14 @@ export function GenealogyTimelineView({
     });
   }, [focusRef, byId, participants, lineageSize]);
 
+  // 换焦点时收起日簇，避免状态串台。
+  useEffect(() => {
+    setExpandedDays(new Set());
+    setSelectedId(null);
+  }, [focusId]);
+
   const focus = focusId ? byId.get(focusId) ?? null : null;
 
-  // 容器宽度测量（时间轴需要具体像素宽）。
   const plotRef = useRef<HTMLDivElement | null>(null);
   const [plotWidth, setPlotWidth] = useState(900);
   useLayoutEffect(() => {
@@ -118,10 +117,13 @@ export function GenealogyTimelineView({
     return () => observer.disconnect();
   }, []);
 
-  // 焦点谱系的布局。
   const layout = useMemo(
-    () => computeLayout(focus, edges, byId, plotWidth),
-    [focus, edges, byId, plotWidth],
+    () =>
+      computeLayout(focus, edges, byId, plotWidth, {
+        encoding,
+        expandedDays,
+      }),
+    [focus, edges, byId, plotWidth, encoding, expandedDays],
   );
 
   const nodeById = useMemo(() => {
@@ -130,15 +132,22 @@ export function GenealogyTimelineView({
     return map;
   }, [layout.nodes]);
 
-  // 焦点谱系内的边（两端都在布局集合里）。
   const lineageEdges = useMemo(
-    () => edges.filter((edge) => nodeById.has(edge.from) && nodeById.has(edge.to)),
-    [edges, nodeById],
+    () => edges.filter((edge) => {
+      // 边端点在布局集合，或被折叠进某个可见簇。
+      const covered = (id: string) =>
+        nodeById.has(id) ||
+        layout.nodes.some((n) => n.isCluster && n.memberIds?.includes(id));
+      return covered(edge.from) && covered(edge.to);
+    }),
+    [edges, nodeById, layout.nodes],
   );
 
   const selected = selectedId ? byId.get(selectedId) ?? null : null;
-  const ancestorCount = layout.nodes.filter((node) => node.depth < 0).length;
-  const descendantCount = layout.nodes.filter((node) => node.depth > 0).length;
+  const ancestorCount = layout.nodes.filter((node) => !node.isCluster && node.depth < 0).length;
+  const descendantCount = layout.nodes.filter((node) => !node.isCluster && node.depth > 0).length;
+  const visibleCards = layout.nodes.filter((n) => !n.isCluster).length;
+  const visibleClusters = layout.nodes.filter((n) => n.isCluster).length;
 
   const filteredParticipants = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -155,7 +164,7 @@ export function GenealogyTimelineView({
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-1 flex-col">
+    <div className="flex h-full min-h-0 flex-1 flex-col" data-testid="genealogy-timeline">
       <header className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b border-border px-4 py-2.5">
         <h1 className="ui-title inline-flex items-center gap-1.5 font-semibold">
           <ClockCounterClockwise weight="duotone" className="text-accent" />
@@ -175,19 +184,69 @@ export function GenealogyTimelineView({
         {focus && (
           <span className="font-mono text-[11px] text-text-faint">
             焦点谱系：{ancestorCount} 祖先 · {descendantCount} 后代
+            {encoding === "day-cluster" && visibleClusters > 0
+              ? ` · ${visibleClusters} 日簇 / ${visibleCards} 卡`
+              : ""}
           </span>
         )}
-        <div className="ml-auto flex flex-wrap items-center gap-2 text-[11px]">
-          {(["refines", "narrows", "supersedes", "supports"] as const).map((kind) => (
-            <span key={kind} className="inline-flex items-center gap-1 text-text-muted">
-              <svg width="18" height="6" aria-hidden>
-                <line x1="0" y1="3" x2="18" y2="3" stroke={KIND_META[kind].color} strokeWidth="2" />
-              </svg>
-              {KIND_META[kind].label}
-            </span>
-          ))}
+
+        {/* 编码方案切换 —— 供 CEO / 泽宇对照 */}
+        <div
+          className="ml-auto flex flex-wrap items-center gap-1 rounded-lg border border-border bg-surface p-0.5"
+          role="tablist"
+          aria-label="时间编码方案"
+        >
+          {(Object.keys(ENCODING_META) as EncodingMode[]).map((mode) => {
+            const meta = ENCODING_META[mode];
+            const active = encoding === mode;
+            return (
+              <button
+                key={mode}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                data-encoding-tab={mode}
+                title={meta.blurb}
+                onClick={() => setEncoding(mode)}
+                className={`rounded-md px-2.5 py-1 font-mono text-[11px] transition-colors ${
+                  active
+                    ? "bg-accent text-accent-fg"
+                    : "text-text-muted hover:bg-surface-raised hover:text-text"
+                }`}
+              >
+                {meta.short}
+              </button>
+            );
+          })}
         </div>
       </header>
+
+      <div className="flex items-center gap-3 border-b border-border px-4 py-1.5">
+        <span className="font-mono text-[11px] text-text-faint">
+          {ENCODING_META[encoding].label}：{ENCODING_META[encoding].blurb}
+        </span>
+        <div className="ml-auto flex flex-wrap items-center gap-2 text-[11px]">
+          {(["refines", "narrows", "supersedes", "supports"] as const).map((kind) => {
+            const meta = KIND_META[kind];
+            return (
+              <span key={kind} className="inline-flex items-center gap-1 text-text-muted">
+                <svg width="22" height="8" aria-hidden>
+                  <line
+                    x1="0"
+                    y1="4"
+                    x2="22"
+                    y2="4"
+                    stroke={meta.color}
+                    strokeWidth={meta.strokeWidth}
+                    strokeDasharray={meta.dash || undefined}
+                  />
+                </svg>
+                {meta.label}
+              </span>
+            );
+          })}
+        </div>
+      </div>
 
       <div className="flex min-h-0 flex-1">
         <ParticipantsSidebar
@@ -202,9 +261,8 @@ export function GenealogyTimelineView({
           }}
         />
 
-        {/* 主区：时间轴谱系。 */}
         <div ref={plotRef} className="relative min-h-0 min-w-0 flex-1 overflow-auto bg-bg">
-          {focus && layout.nodes.length <= 1 ? (
+          {focus && layout.nodes.length <= 1 && !layout.nodes[0]?.isCluster ? (
             <IsolatedNodeMessage decision={focus} />
           ) : (
             <TimelinePlot
@@ -215,6 +273,14 @@ export function GenealogyTimelineView({
               onToggleSelect={(id) =>
                 setSelectedId((prev) => (prev === id ? null : id))
               }
+              onToggleCluster={(dayKey) => {
+                setExpandedDays((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(dayKey)) next.delete(dayKey);
+                  else next.add(dayKey);
+                  return next;
+                });
+              }}
             />
           )}
         </div>

--- a/packages/gui/src/renderer/views/GenealogyTimelineView.tsx
+++ b/packages/gui/src/renderer/views/GenealogyTimelineView.tsx
@@ -3,7 +3,6 @@ import { ClockCounterClockwise } from "@phosphor-icons/react";
 import type { DecisionRow, RelationEdge } from "../model/types";
 import {
   ENCODING_META,
-  type EncodingMode,
   KIND_META,
   buildGenealogyEdges,
   collectLineage,
@@ -21,7 +20,7 @@ import { TimelinePlot } from "./genealogy/TimelinePlot";
  * 决策谱系「演化史」视图入口壳。
  *
  * 纯前端派生：从 relations 筛谱系四类边，焦点上溯/下溯。
- * 时间编码可切换（序数轴 / 日簇折叠 / DAG 拓扑），不再用线性 wall-clock x。
+ * 布局 = DAG 拓扑（x = 谱系深度），同列内同日节点过多时自动折成簇（可展开）。
  */
 export function GenealogyTimelineView({
   decisions,
@@ -72,7 +71,6 @@ export function GenealogyTimelineView({
   const [focusId, setFocusId] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
-  const [encoding, setEncoding] = useState<EncodingMode>("ordinal");
   const [expandedDays, setExpandedDays] = useState<Set<string>>(() => new Set());
 
   useEffect(() => {
@@ -120,10 +118,9 @@ export function GenealogyTimelineView({
   const layout = useMemo(
     () =>
       computeLayout(focus, edges, byId, plotWidth, {
-        encoding,
         expandedDays,
       }),
-    [focus, edges, byId, plotWidth, encoding, expandedDays],
+    [focus, edges, byId, plotWidth, expandedDays],
   );
 
   const nodeById = useMemo(() => {
@@ -184,46 +181,16 @@ export function GenealogyTimelineView({
         {focus && (
           <span className="font-mono text-[11px] text-text-faint">
             焦点谱系：{ancestorCount} 祖先 · {descendantCount} 后代
-            {encoding === "day-cluster" && visibleClusters > 0
+            {visibleClusters > 0
               ? ` · ${visibleClusters} 日簇 / ${visibleCards} 卡`
               : ""}
           </span>
         )}
-
-        {/* 编码方案切换 —— 供 CEO / 泽宇对照 */}
-        <div
-          className="ml-auto flex flex-wrap items-center gap-1 rounded-lg border border-border bg-surface p-0.5"
-          role="tablist"
-          aria-label="时间编码方案"
-        >
-          {(Object.keys(ENCODING_META) as EncodingMode[]).map((mode) => {
-            const meta = ENCODING_META[mode];
-            const active = encoding === mode;
-            return (
-              <button
-                key={mode}
-                type="button"
-                role="tab"
-                aria-selected={active}
-                data-encoding-tab={mode}
-                title={meta.blurb}
-                onClick={() => setEncoding(mode)}
-                className={`rounded-md px-2.5 py-1 font-mono text-[11px] transition-colors ${
-                  active
-                    ? "bg-accent text-accent-fg"
-                    : "text-text-muted hover:bg-surface-raised hover:text-text"
-                }`}
-              >
-                {meta.short}
-              </button>
-            );
-          })}
-        </div>
       </header>
 
       <div className="flex items-center gap-3 border-b border-border px-4 py-1.5">
         <span className="font-mono text-[11px] text-text-faint">
-          {ENCODING_META[encoding].label}：{ENCODING_META[encoding].blurb}
+          {ENCODING_META.dag.label}：{ENCODING_META.dag.blurb}
         </span>
         <div className="ml-auto flex flex-wrap items-center gap-2 text-[11px]">
           {(["refines", "narrows", "supersedes", "supports"] as const).map((kind) => {
@@ -270,6 +237,7 @@ export function GenealogyTimelineView({
               nodeById={nodeById}
               lineageEdges={lineageEdges}
               selectedId={selectedId}
+              expandedDays={expandedDays}
               onToggleSelect={(id) =>
                 setSelectedId((prev) => (prev === id ? null : id))
               }

--- a/packages/gui/src/renderer/views/genealogy/TimelinePlot.tsx
+++ b/packages/gui/src/renderer/views/genealogy/TimelinePlot.tsx
@@ -1,10 +1,18 @@
 import { useState } from "react";
 import type { GenealogyEdge, LaidOutNode, TimelineLayout } from "./layout";
-import { AXIS_H, CARD_H, CARD_W, KIND_META, shortTime } from "./layout";
+import {
+  AXIS_H,
+  CARD_H,
+  CARD_W,
+  CLUSTER_H,
+  CLUSTER_W,
+  KIND_META,
+  shortTime,
+} from "./layout";
 
 /**
- * 主区时间轴谱系：时间刻度 + 竖向网格 + 谱系边（带箭头与语义色）+ 决策卡。
- * hover 高亮自管：悬停一张卡时，与之无关的边/卡会被压暗。
+ * 主区谱系图：刻度 + 网格 + 语义色/线型边 + 决策卡（或日簇）。
+ * hover 高亮自管。day-cluster 点簇展开由 onToggleCluster 上抛。
  */
 export function TimelinePlot({
   layout,
@@ -12,18 +20,33 @@ export function TimelinePlot({
   lineageEdges,
   selectedId,
   onToggleSelect,
+  onToggleCluster,
 }: {
   layout: TimelineLayout;
   nodeById: Map<string, LaidOutNode>;
   lineageEdges: GenealogyEdge[];
   selectedId: string | null;
   onToggleSelect: (id: string) => void;
+  onToggleCluster?: (dayKey: string) => void;
 }) {
   const [hoverId, setHoverId] = useState<string | null>(null);
 
+  // 簇展开后，边的端点可能是簇 id；映射成员 → 可见节点（卡或所属簇）。
+  const resolveVisible = (id: string): LaidOutNode | undefined => {
+    const direct = nodeById.get(id);
+    if (direct) return direct;
+    for (const node of layout.nodes) {
+      if (node.isCluster && node.memberIds?.includes(id)) return node;
+    }
+    return undefined;
+  };
+
   return (
-    <div className="relative" style={{ width: layout.width, height: layout.height, minWidth: "100%" }}>
-      {/* 时间轴刻度 + 竖向网格 */}
+    <div
+      className="relative"
+      style={{ width: layout.width, height: layout.height, minWidth: "100%" }}
+      data-encoding={layout.encoding}
+    >
       <svg
         className="pointer-events-none absolute inset-0"
         width={layout.width}
@@ -56,45 +79,93 @@ export function TimelinePlot({
               strokeWidth="1"
               strokeDasharray="2 4"
             />
-            <text x={tick.x + 3} y={20} fill="var(--color-text-faint)" fontSize="10" fontFamily="var(--font-mono)">
+            <text
+              x={tick.x + 3}
+              y={20}
+              fill="var(--color-text-faint)"
+              fontSize="10"
+              fontFamily="var(--font-mono)"
+            >
               {tick.label}
             </text>
           </g>
         ))}
-        {/* 谱系边 */}
         {lineageEdges.map((edge, index) => {
-          const ancestor = nodeById.get(edge.to)!;
-          const descendant = nodeById.get(edge.from)!;
+          const ancestor = resolveVisible(edge.to);
+          const descendant = resolveVisible(edge.from);
+          if (!ancestor || !descendant) return null;
+          // 同簇内边在折叠时不画，避免自环噪点。
+          if (ancestor.id === descendant.id) return null;
+          const aW = ancestor.isCluster ? CLUSTER_W : CARD_W;
+          const dW = descendant.isCluster ? CLUSTER_W : CARD_W;
+          const aH = ancestor.isCluster ? CLUSTER_H : CARD_H;
+          const dH = descendant.isCluster ? CLUSTER_H : CARD_H;
           const ancRight = ancestor.x <= descendant.x;
-          const sx = ancRight ? ancestor.x + CARD_W : ancestor.x;
-          const sy = ancestor.y + CARD_H / 2;
-          const ex = ancRight ? descendant.x : descendant.x + CARD_W;
-          const ey = descendant.y + CARD_H / 2;
+          const sx = ancRight ? ancestor.x + aW : ancestor.x;
+          const sy = ancestor.y + aH / 2;
+          const ex = ancRight ? descendant.x : descendant.x + dW;
+          const ey = descendant.y + dH / 2;
           const dx = (ex - sx) * 0.45;
-          const incident = hoverId === edge.from || hoverId === edge.to;
+          const meta = KIND_META[edge.kind] ?? {
+            color: "var(--color-border-strong)",
+            dash: "",
+            strokeWidth: 1.4,
+          };
+          const incident =
+            hoverId === edge.from ||
+            hoverId === edge.to ||
+            (ancestor.isCluster && ancestor.memberIds?.includes(hoverId ?? "")) ||
+            (descendant.isCluster && descendant.memberIds?.includes(hoverId ?? ""));
           const dim = hoverId !== null && !incident;
           return (
             <path
               key={index}
               d={`M ${sx} ${sy} C ${sx + dx} ${sy}, ${ex - dx} ${ey}, ${ex} ${ey}`}
               fill="none"
-              stroke={KIND_META[edge.kind]?.color ?? "var(--color-border-strong)"}
-              strokeWidth={incident ? 2.2 : 1.4}
-              strokeOpacity={dim ? 0.15 : 0.85}
+              stroke={meta.color}
+              strokeWidth={incident ? meta.strokeWidth + 0.6 : meta.strokeWidth}
+              strokeOpacity={dim ? 0.12 : 0.88}
+              strokeDasharray={meta.dash || undefined}
               markerEnd={`url(#gen-arrow-${edge.kind})`}
             />
           );
         })}
       </svg>
 
-      {/* 决策卡 */}
       {layout.nodes.map((node) => {
+        if (node.isCluster) {
+          const dim = hoverId !== null && hoverId !== node.id;
+          return (
+            <button
+              key={node.id}
+              type="button"
+              onClick={() => node.dayKey && onToggleCluster?.(node.dayKey)}
+              onMouseEnter={() => setHoverId(node.id)}
+              onMouseLeave={() => setHoverId(null)}
+              style={{ left: node.x, top: node.y, width: CLUSTER_W, height: CLUSTER_H }}
+              className={`absolute flex flex-col justify-center gap-0.5 rounded-xl border border-dashed border-border-strong bg-surface-raised px-3 py-2 text-left transition-colors hover:border-accent ${
+                dim ? "opacity-40" : ""
+              }`}
+              title="点击展开该日决策"
+            >
+              <span className="font-mono text-[11px] font-semibold text-text">
+                {node.dayKey === "NO_TIME" ? "无时间" : node.dayKey}
+              </span>
+              <span className="text-[12px] text-text-muted">
+                {node.clusterSize ?? 0} 条决策 · 点击展开
+              </span>
+            </button>
+          );
+        }
+
         const isFocus = node.depth === 0;
         const isSelected = node.id === selectedId;
         const dim = hoverId !== null && hoverId !== node.id;
         return (
           <button
             key={node.id}
+            type="button"
+            title={node.decision.title}
             onClick={() => onToggleSelect(node.id)}
             onMouseEnter={() => setHoverId(node.id)}
             onMouseLeave={() => setHoverId(null)}
@@ -108,18 +179,45 @@ export function TimelinePlot({
             } ${dim ? "opacity-40" : ""}`}
           >
             <div className="flex items-center gap-1.5">
-              <span className="truncate font-mono text-[10px] text-text-faint">{node.id}</span>
+              <span className="min-w-0 truncate font-mono text-[10px] text-text-faint">
+                {node.id}
+              </span>
               {isFocus && (
-                <span className="ml-auto rounded bg-accent px-1 py-px font-mono text-[9px] font-semibold text-accent-fg">
+                <span className="ml-auto shrink-0 rounded bg-accent px-1 py-px font-mono text-[9px] font-semibold text-accent-fg">
                   焦点
                 </span>
               )}
             </div>
-            <span className="truncate text-[12px] font-medium leading-tight text-text">{node.decision.title}</span>
+            <span className="line-clamp-2 break-words text-[12px] font-medium leading-snug text-text">
+              {node.decision.title}
+            </span>
             <div className="flex items-center gap-1.5">
-              <span className="font-mono text-[9px] text-text-faint">{shortTime(node.decision)}</span>
+              <span className="font-mono text-[9px] text-text-faint">
+                {shortTime(node.decision)}
+              </span>
               {node.timeMs === null && (
-                <span className="rounded bg-stale/15 px-1 font-mono text-[9px] text-stale">无时间</span>
+                <span className="rounded bg-stale/15 px-1 font-mono text-[9px] text-stale">
+                  无时间
+                </span>
+              )}
+              {layout.encoding === "day-cluster" && node.dayKey && onToggleCluster && (
+                <span
+                  role="link"
+                  tabIndex={0}
+                  className="ml-auto cursor-pointer font-mono text-[9px] text-accent hover:underline"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onToggleCluster(node.dayKey!);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.stopPropagation();
+                      onToggleCluster(node.dayKey!);
+                    }
+                  }}
+                >
+                  收起日
+                </span>
               )}
             </div>
           </button>

--- a/packages/gui/src/renderer/views/genealogy/TimelinePlot.tsx
+++ b/packages/gui/src/renderer/views/genealogy/TimelinePlot.tsx
@@ -12,13 +12,14 @@ import {
 
 /**
  * 主区谱系图：刻度 + 网格 + 语义色/线型边 + 决策卡（或日簇）。
- * hover 高亮自管。day-cluster 点簇展开由 onToggleCluster 上抛。
+ * hover 高亮自管。同列同日簇点开展开由 onToggleCluster 上抛。
  */
 export function TimelinePlot({
   layout,
   nodeById,
   lineageEdges,
   selectedId,
+  expandedDays,
   onToggleSelect,
   onToggleCluster,
 }: {
@@ -26,12 +27,13 @@ export function TimelinePlot({
   nodeById: Map<string, LaidOutNode>;
   lineageEdges: GenealogyEdge[];
   selectedId: string | null;
+  expandedDays?: ReadonlySet<string>;
   onToggleSelect: (id: string) => void;
   onToggleCluster?: (dayKey: string) => void;
 }) {
   const [hoverId, setHoverId] = useState<string | null>(null);
 
-  // 簇展开后，边的端点可能是簇 id；映射成员 → 可见节点（卡或所属簇）。
+  // 簇折叠时边的端点是成员 id；映射成员 → 可见节点（卡或所属簇）。
   const resolveVisible = (id: string): LaidOutNode | undefined => {
     const direct = nodeById.get(id);
     if (direct) return direct;
@@ -188,7 +190,7 @@ export function TimelinePlot({
                 </span>
               )}
             </div>
-            <span className="line-clamp-2 break-words text-[12px] font-medium leading-snug text-text">
+            <span className="line-clamp-3 break-words text-[12px] font-medium leading-snug text-text">
               {node.decision.title}
             </span>
             <div className="flex items-center gap-1.5">
@@ -200,7 +202,9 @@ export function TimelinePlot({
                   无时间
                 </span>
               )}
-              {layout.encoding === "day-cluster" && node.dayKey && onToggleCluster && (
+              {node.dayKey &&
+                onToggleCluster &&
+                expandedDays?.has(node.dayKey) && (
                 <span
                   role="link"
                   tabIndex={0}

--- a/packages/gui/src/renderer/views/genealogy/layout-encodings.ts
+++ b/packages/gui/src/renderer/views/genealogy/layout-encodings.ts
@@ -1,0 +1,337 @@
+import type { DecisionRow } from "../../model/types";
+import {
+  AXIS_H,
+  CARD_H,
+  CARD_W,
+  CLUSTER_H,
+  CLUSTER_W,
+  EMPTY_LAYOUT,
+  type GenealogyEdge,
+  type LaidOutNode,
+  type LayoutOptions,
+  type TimelineLayout,
+  PAD_X,
+  PAD_Y,
+  ROW_H,
+  collectRawNodes,
+  findGenealogyCycles,
+  packDepthLanes,
+  type RawLineageNode,
+} from "./layout";
+
+/**
+ * 三种非线性时间编码。各自在真实 143 参与者谱系上可独立截图对照。
+ */
+
+/**
+ * 焦点谱系布局调度。encoding 决定 x 轴语义：
+ * - ordinal：事件序，空白日不占宽
+ * - day-cluster：同日折叠为簇，点开展开
+ * - dag：拓扑 LR，时间只排序
+ */
+export function computeLayout(
+  focus: DecisionRow | null,
+  edges: GenealogyEdge[],
+  byId: Map<string, DecisionRow>,
+  plotWidth: number,
+  options: LayoutOptions = {},
+): TimelineLayout {
+  if (!focus) return EMPTY_LAYOUT;
+  const encoding = options.encoding ?? "ordinal";
+  const expandedDays = options.expandedDays ?? new Set<string>();
+  const cycles = findGenealogyCycles(edges);
+  const cycleWarning = { count: cycles.length, cycles };
+
+  let layout: TimelineLayout;
+  if (encoding === "day-cluster") {
+    layout = computeDayClusterLayout(focus, edges, byId, plotWidth, expandedDays);
+  } else if (encoding === "dag") {
+    layout = computeDagLayout(focus, edges, byId, plotWidth);
+  } else {
+    layout = computeOrdinalLayout(focus, edges, byId, plotWidth);
+  }
+  return { ...layout, cycleWarning };
+}
+
+function timeExtent(nodes: RawLineageNode[]): { minT: number; maxT: number } {
+  const times = nodes.map((n) => n.timeMs).filter((t): t is number => t !== null);
+  if (times.length === 0) return { minT: 0, maxT: 0 };
+  return { minT: Math.min(...times), maxT: Math.max(...times) };
+}
+
+function finishLayout(
+  placed: LaidOutNode[],
+  ticks: { x: number; label: string }[],
+  minT: number,
+  maxT: number,
+  encoding: TimelineLayout["encoding"],
+  cardW: number = CARD_W,
+): TimelineLayout {
+  const maxRight = placed.reduce((m, n) => {
+    const w = n.isCluster ? CLUSTER_W : cardW;
+    return Math.max(m, n.x + w);
+  }, PAD_X + 360);
+  const maxBottom = placed.reduce((m, n) => {
+    const h = n.isCluster ? CLUSTER_H : CARD_H;
+    return Math.max(m, n.y + h);
+  }, AXIS_H + PAD_Y + ROW_H);
+  return {
+    nodes: placed,
+    width: Math.max(maxRight + PAD_X, 480),
+    height: maxBottom + PAD_Y,
+    ticks,
+    minT,
+    maxT,
+    encoding,
+    cycleWarning: { count: 0, cycles: [] },
+  };
+}
+
+/**
+ * 序数轴：按 timeMs 排序后等距占位。同一毫秒用 id 稳定破并列。
+ * 空白日不占 x 宽度——这是相对线性轴的核心修正。
+ */
+export function computeOrdinalLayout(
+  focus: DecisionRow,
+  edges: GenealogyEdge[],
+  byId: Map<string, DecisionRow>,
+  plotWidth: number,
+): TimelineLayout {
+  const raw = collectRawNodes(focus, edges, byId);
+  const { minT, maxT } = timeExtent(raw);
+  const ordered = [...raw].sort((a, b) => {
+    const ta = a.timeMs ?? Number.POSITIVE_INFINITY;
+    const tb = b.timeMs ?? Number.POSITIVE_INFINITY;
+    if (ta !== tb) return ta - tb;
+    return a.id.localeCompare(b.id);
+  });
+
+  const n = Math.max(1, ordered.length);
+  const plotW = Math.max(360, plotWidth - PAD_X * 2 - CARD_W);
+  // 节点多时拉开画布，避免挤成一团；节点少时填满可视宽。
+  const step = Math.max(CARD_W + LANE_STEP_MIN, Math.min(CARD_W + 48, plotW / Math.max(1, n - 1 || 1)));
+  const contentW = Math.max(plotW, (n - 1) * step);
+
+  const rankOf = new Map(ordered.map((node, index) => [node.id, index]));
+  const withX = ordered.map((node) => {
+    const rank = rankOf.get(node.id) ?? 0;
+    const x =
+      n === 1
+        ? PAD_X + contentW / 2 - CARD_W / 2
+        : PAD_X + rank * step;
+    return { ...node, x, isCluster: false as const };
+  });
+
+  const { placed } = packDepthLanes(withX);
+
+  // 刻度：每个新出现的 day 在该日首个节点处标一次。
+  const seenDays = new Set<string>();
+  const ticks: { x: number; label: string }[] = [];
+  for (const node of ordered) {
+    if (seenDays.has(node.dayKey)) continue;
+    seenDays.add(node.dayKey);
+    const rank = rankOf.get(node.id) ?? 0;
+    const x = n === 1 ? PAD_X + contentW / 2 : PAD_X + rank * step;
+    ticks.push({ x, label: node.dayKey === "NO_TIME" ? "无时间" : node.dayKey.slice(5) });
+  }
+
+  return finishLayout(placed, ticks, minT, maxT, "ordinal");
+}
+
+const LANE_STEP_MIN = 12;
+
+/**
+ * 日簇折叠：同日合成簇。expandedDays 内的日展开为独立卡。
+ * 143 → 可读的十余个日单元（参与者日分布约 12 桶）。
+ */
+export function computeDayClusterLayout(
+  focus: DecisionRow,
+  edges: GenealogyEdge[],
+  byId: Map<string, DecisionRow>,
+  plotWidth: number,
+  expandedDays: ReadonlySet<string>,
+): TimelineLayout {
+  const raw = collectRawNodes(focus, edges, byId);
+  const { minT, maxT } = timeExtent(raw);
+
+  const byDay = new Map<string, RawLineageNode[]>();
+  for (const node of raw) {
+    const list = byDay.get(node.dayKey) ?? [];
+    list.push(node);
+    byDay.set(node.dayKey, list);
+  }
+  for (const list of byDay.values()) {
+    list.sort((a, b) => {
+      const ta = a.timeMs ?? 0;
+      const tb = b.timeMs ?? 0;
+      if (ta !== tb) return ta - tb;
+      return a.id.localeCompare(b.id);
+    });
+  }
+
+  const dayOrder = [...byDay.keys()].sort((a, b) => {
+    if (a === "NO_TIME") return 1;
+    if (b === "NO_TIME") return -1;
+    return a.localeCompare(b);
+  });
+
+  // 展开单元序列：折叠日=1 单元，展开日=成员数。
+  type Unit =
+    | { kind: "cluster"; dayKey: string; members: RawLineageNode[] }
+    | { kind: "card"; dayKey: string; node: RawLineageNode };
+  const units: Unit[] = [];
+  for (const day of dayOrder) {
+    const members = byDay.get(day)!;
+    if (members.length === 1 || expandedDays.has(day)) {
+      for (const node of members) units.push({ kind: "card", dayKey: day, node });
+    } else {
+      units.push({ kind: "cluster", dayKey: day, members });
+    }
+  }
+
+  const n = Math.max(1, units.length);
+  const plotW = Math.max(360, plotWidth - PAD_X * 2 - CARD_W);
+  const step = Math.max(CLUSTER_W + LANE_STEP_MIN, Math.min(CARD_W + 40, plotW / Math.max(1, n - 1 || 1)));
+  const contentW = Math.max(plotW, (n - 1) * step);
+
+  const withX: Array<Omit<LaidOutNode, "y">> = units.map((unit, index) => {
+    const x = n === 1 ? PAD_X + contentW / 2 - CARD_W / 2 : PAD_X + index * step;
+    if (unit.kind === "cluster") {
+      // 簇挂在成员 depth 中位数，避免全贴焦点行。
+      const depths = unit.members.map((m) => m.depth).sort((a, b) => a - b);
+      const mid = depths[Math.floor(depths.length / 2)] ?? 0;
+      const seed = unit.members[0]!;
+      return {
+        id: `cluster:${unit.dayKey}`,
+        decision: seed.decision,
+        depth: mid,
+        timeMs: seed.timeMs,
+        dayKey: unit.dayKey,
+        x,
+        isCluster: true,
+        clusterSize: unit.members.length,
+        memberIds: unit.members.map((m) => m.id),
+      };
+    }
+    return {
+      ...unit.node,
+      x,
+      isCluster: false,
+      dayKey: unit.dayKey,
+    };
+  });
+
+  const { placed } = packDepthLanes(withX);
+
+  const ticks: { x: number; label: string }[] = [];
+  const tickDays = new Set<string>();
+  units.forEach((unit, index) => {
+    if (tickDays.has(unit.dayKey)) return;
+    tickDays.add(unit.dayKey);
+    const x = n === 1 ? PAD_X + contentW / 2 : PAD_X + index * step;
+    ticks.push({
+      x,
+      label: unit.dayKey === "NO_TIME" ? "无时间" : unit.dayKey.slice(5),
+    });
+  });
+
+  return finishLayout(placed, ticks, minT, maxT, "day-cluster");
+}
+
+/**
+ * DAG 优先：x = 拓扑层（祖先→后代），同层按时间排序后垂直装道。
+ * 时间不做坐标，只做层内排序约束。
+ */
+export function computeDagLayout(
+  focus: DecisionRow,
+  edges: GenealogyEdge[],
+  byId: Map<string, DecisionRow>,
+  plotWidth: number,
+): TimelineLayout {
+  const raw = collectRawNodes(focus, edges, byId);
+  const { minT, maxT } = timeExtent(raw);
+  const ids = new Set(raw.map((n) => n.id));
+  const nodeById = new Map(raw.map((n) => [n.id, n]));
+
+  // 仅焦点谱系内的边。
+  const local = edges.filter((e) => ids.has(e.from) && ids.has(e.to));
+
+  // 祖先方向 edge.to ← edge.from；拓扑层：无入边（纯祖先端）层 0。
+  // 但我们要「祖先在左、后代在右」：用 depth 平移到非负 rank 更稳——
+  // rank = depth - minDepth，使最老祖先 rank=0。
+  const depths = raw.map((n) => n.depth);
+  const minDepth = depths.length ? Math.min(...depths) : 0;
+  const rankOf = new Map(raw.map((n) => [n.id, n.depth - minDepth]));
+
+  // 若边跨越非相邻 rank，保留；不重算 longest-path（depth BFS 已给谱系层）。
+  // 同 rank 内按时间排序。
+  const byRank = new Map<number, RawLineageNode[]>();
+  for (const node of raw) {
+    const rank = rankOf.get(node.id) ?? 0;
+    const list = byRank.get(rank) ?? [];
+    list.push(node);
+    byRank.set(rank, list);
+  }
+  for (const list of byRank.values()) {
+    list.sort((a, b) => {
+      const ta = a.timeMs ?? Number.POSITIVE_INFINITY;
+      const tb = b.timeMs ?? Number.POSITIVE_INFINITY;
+      if (ta !== tb) return ta - tb;
+      return a.id.localeCompare(b.id);
+    });
+  }
+
+  const ranks = [...byRank.keys()].sort((a, b) => a - b);
+  const maxRank = ranks.length ? Math.max(...ranks) : 0;
+  const plotW = Math.max(360, plotWidth - PAD_X * 2 - CARD_W);
+  const colStep =
+    maxRank <= 0
+      ? 0
+      : Math.max(CARD_W + LANE_STEP_MIN, Math.min(CARD_W + 80, plotW / maxRank));
+  const contentW = Math.max(plotW, maxRank * colStep);
+
+  // 同列垂直堆叠（时间序），不按 depth 分带——depth 已编码为 x。
+  const placed: LaidOutNode[] = [];
+  let maxRows = 1;
+  for (const rank of ranks) {
+    const col = byRank.get(rank) ?? [];
+    maxRows = Math.max(maxRows, col.length);
+    col.forEach((node, row) => {
+      const x =
+        maxRank === 0
+          ? PAD_X + contentW / 2 - CARD_W / 2
+          : PAD_X + rank * colStep;
+      placed.push({
+        ...node,
+        x,
+        y: AXIS_H + PAD_Y + row * ROW_H,
+        isCluster: false,
+      });
+    });
+  }
+
+  // 可选：用 local 边做轻微交叉惩罚重排——保持 deterministic 简单列堆叠。
+  void local;
+  void nodeById;
+
+  const ticks = ranks.map((rank) => {
+    const col = byRank.get(rank) ?? [];
+    const label =
+      rank === 0
+        ? "祖先"
+        : rank === maxRank
+          ? "后代"
+          : `层 ${rank}`;
+    const x =
+      maxRank === 0 ? PAD_X + contentW / 2 : PAD_X + rank * colStep;
+    // 副标签：该列最早日期
+    const day = col[0]?.dayKey;
+    const dayLabel = day && day !== "NO_TIME" ? day.slice(5) : "";
+    return {
+      x,
+      label: dayLabel ? `${label} · ${dayLabel}` : label,
+    };
+  });
+
+  return finishLayout(placed, ticks, minT, maxT, "dag");
+}

--- a/packages/gui/src/renderer/views/genealogy/layout-encodings.ts
+++ b/packages/gui/src/renderer/views/genealogy/layout-encodings.ts
@@ -15,19 +15,17 @@ import {
   ROW_H,
   collectRawNodes,
   findGenealogyCycles,
-  packDepthLanes,
   type RawLineageNode,
 } from "./layout";
 
 /**
- * 三种非线性时间编码。各自在真实 143 参与者谱系上可独立截图对照。
+ * 谱系布局：DAG 拓扑为主视图，日簇折叠为同列内同日节点过多时的自动收敛策略。
+ * 时间降级为排序约束，不再做坐标。
  */
 
 /**
- * 焦点谱系布局调度。encoding 决定 x 轴语义：
- * - ordinal：事件序，空白日不占宽
- * - day-cluster：同日折叠为簇，点开展开
- * - dag：拓扑 LR，时间只排序
+ * 焦点谱系布局调度。唯一编码 = DAG 拓扑（x = 谱系深度 rank），同列内同日节点过多时自动折成簇。
+ * expandedDays 控制簇展开状态（按 dayKey 展开，跨 rank 同日一并展开）。
  */
 export function computeLayout(
   focus: DecisionRow | null,
@@ -37,19 +35,11 @@ export function computeLayout(
   options: LayoutOptions = {},
 ): TimelineLayout {
   if (!focus) return EMPTY_LAYOUT;
-  const encoding = options.encoding ?? "ordinal";
   const expandedDays = options.expandedDays ?? new Set<string>();
   const cycles = findGenealogyCycles(edges);
   const cycleWarning = { count: cycles.length, cycles };
 
-  let layout: TimelineLayout;
-  if (encoding === "day-cluster") {
-    layout = computeDayClusterLayout(focus, edges, byId, plotWidth, expandedDays);
-  } else if (encoding === "dag") {
-    layout = computeDagLayout(focus, edges, byId, plotWidth);
-  } else {
-    layout = computeOrdinalLayout(focus, edges, byId, plotWidth);
-  }
+  const layout = computeDagLayout(focus, edges, byId, plotWidth, expandedDays);
   return { ...layout, cycleWarning };
 }
 
@@ -64,11 +54,9 @@ function finishLayout(
   ticks: { x: number; label: string }[],
   minT: number,
   maxT: number,
-  encoding: TimelineLayout["encoding"],
-  cardW: number = CARD_W,
 ): TimelineLayout {
   const maxRight = placed.reduce((m, n) => {
-    const w = n.isCluster ? CLUSTER_W : cardW;
+    const w = n.isCluster ? CLUSTER_W : CARD_W;
     return Math.max(m, n.x + w);
   }, PAD_X + 360);
   const maxBottom = placed.reduce((m, n) => {
@@ -82,164 +70,18 @@ function finishLayout(
     ticks,
     minT,
     maxT,
-    encoding,
+    encoding: "dag",
     cycleWarning: { count: 0, cycles: [] },
   };
 }
 
-/**
- * 序数轴：按 timeMs 排序后等距占位。同一毫秒用 id 稳定破并列。
- * 空白日不占 x 宽度——这是相对线性轴的核心修正。
- */
-export function computeOrdinalLayout(
-  focus: DecisionRow,
-  edges: GenealogyEdge[],
-  byId: Map<string, DecisionRow>,
-  plotWidth: number,
-): TimelineLayout {
-  const raw = collectRawNodes(focus, edges, byId);
-  const { minT, maxT } = timeExtent(raw);
-  const ordered = [...raw].sort((a, b) => {
-    const ta = a.timeMs ?? Number.POSITIVE_INFINITY;
-    const tb = b.timeMs ?? Number.POSITIVE_INFINITY;
-    if (ta !== tb) return ta - tb;
-    return a.id.localeCompare(b.id);
-  });
-
-  const n = Math.max(1, ordered.length);
-  const plotW = Math.max(360, plotWidth - PAD_X * 2 - CARD_W);
-  // 节点多时拉开画布，避免挤成一团；节点少时填满可视宽。
-  const step = Math.max(CARD_W + LANE_STEP_MIN, Math.min(CARD_W + 48, plotW / Math.max(1, n - 1 || 1)));
-  const contentW = Math.max(plotW, (n - 1) * step);
-
-  const rankOf = new Map(ordered.map((node, index) => [node.id, index]));
-  const withX = ordered.map((node) => {
-    const rank = rankOf.get(node.id) ?? 0;
-    const x =
-      n === 1
-        ? PAD_X + contentW / 2 - CARD_W / 2
-        : PAD_X + rank * step;
-    return { ...node, x, isCluster: false as const };
-  });
-
-  const { placed } = packDepthLanes(withX);
-
-  // 刻度：每个新出现的 day 在该日首个节点处标一次。
-  const seenDays = new Set<string>();
-  const ticks: { x: number; label: string }[] = [];
-  for (const node of ordered) {
-    if (seenDays.has(node.dayKey)) continue;
-    seenDays.add(node.dayKey);
-    const rank = rankOf.get(node.id) ?? 0;
-    const x = n === 1 ? PAD_X + contentW / 2 : PAD_X + rank * step;
-    ticks.push({ x, label: node.dayKey === "NO_TIME" ? "无时间" : node.dayKey.slice(5) });
-  }
-
-  return finishLayout(placed, ticks, minT, maxT, "ordinal");
-}
-
 const LANE_STEP_MIN = 12;
+/** 同列同日节点数达到该阈值时自动折成簇。 */
+const SAME_DAY_CLUSTER_THRESHOLD = 2;
 
 /**
- * 日簇折叠：同日合成簇。expandedDays 内的日展开为独立卡。
- * 143 → 可读的十余个日单元（参与者日分布约 12 桶）。
- */
-export function computeDayClusterLayout(
-  focus: DecisionRow,
-  edges: GenealogyEdge[],
-  byId: Map<string, DecisionRow>,
-  plotWidth: number,
-  expandedDays: ReadonlySet<string>,
-): TimelineLayout {
-  const raw = collectRawNodes(focus, edges, byId);
-  const { minT, maxT } = timeExtent(raw);
-
-  const byDay = new Map<string, RawLineageNode[]>();
-  for (const node of raw) {
-    const list = byDay.get(node.dayKey) ?? [];
-    list.push(node);
-    byDay.set(node.dayKey, list);
-  }
-  for (const list of byDay.values()) {
-    list.sort((a, b) => {
-      const ta = a.timeMs ?? 0;
-      const tb = b.timeMs ?? 0;
-      if (ta !== tb) return ta - tb;
-      return a.id.localeCompare(b.id);
-    });
-  }
-
-  const dayOrder = [...byDay.keys()].sort((a, b) => {
-    if (a === "NO_TIME") return 1;
-    if (b === "NO_TIME") return -1;
-    return a.localeCompare(b);
-  });
-
-  // 展开单元序列：折叠日=1 单元，展开日=成员数。
-  type Unit =
-    | { kind: "cluster"; dayKey: string; members: RawLineageNode[] }
-    | { kind: "card"; dayKey: string; node: RawLineageNode };
-  const units: Unit[] = [];
-  for (const day of dayOrder) {
-    const members = byDay.get(day)!;
-    if (members.length === 1 || expandedDays.has(day)) {
-      for (const node of members) units.push({ kind: "card", dayKey: day, node });
-    } else {
-      units.push({ kind: "cluster", dayKey: day, members });
-    }
-  }
-
-  const n = Math.max(1, units.length);
-  const plotW = Math.max(360, plotWidth - PAD_X * 2 - CARD_W);
-  const step = Math.max(CLUSTER_W + LANE_STEP_MIN, Math.min(CARD_W + 40, plotW / Math.max(1, n - 1 || 1)));
-  const contentW = Math.max(plotW, (n - 1) * step);
-
-  const withX: Array<Omit<LaidOutNode, "y">> = units.map((unit, index) => {
-    const x = n === 1 ? PAD_X + contentW / 2 - CARD_W / 2 : PAD_X + index * step;
-    if (unit.kind === "cluster") {
-      // 簇挂在成员 depth 中位数，避免全贴焦点行。
-      const depths = unit.members.map((m) => m.depth).sort((a, b) => a - b);
-      const mid = depths[Math.floor(depths.length / 2)] ?? 0;
-      const seed = unit.members[0]!;
-      return {
-        id: `cluster:${unit.dayKey}`,
-        decision: seed.decision,
-        depth: mid,
-        timeMs: seed.timeMs,
-        dayKey: unit.dayKey,
-        x,
-        isCluster: true,
-        clusterSize: unit.members.length,
-        memberIds: unit.members.map((m) => m.id),
-      };
-    }
-    return {
-      ...unit.node,
-      x,
-      isCluster: false,
-      dayKey: unit.dayKey,
-    };
-  });
-
-  const { placed } = packDepthLanes(withX);
-
-  const ticks: { x: number; label: string }[] = [];
-  const tickDays = new Set<string>();
-  units.forEach((unit, index) => {
-    if (tickDays.has(unit.dayKey)) return;
-    tickDays.add(unit.dayKey);
-    const x = n === 1 ? PAD_X + contentW / 2 : PAD_X + index * step;
-    ticks.push({
-      x,
-      label: unit.dayKey === "NO_TIME" ? "无时间" : unit.dayKey.slice(5),
-    });
-  });
-
-  return finishLayout(placed, ticks, minT, maxT, "day-cluster");
-}
-
-/**
- * DAG 优先：x = 拓扑层（祖先→后代），同层按时间排序后垂直装道。
+ * DAG 主布局：x = 拓扑层（祖先→后代），同层按时间排序后垂直装道。
+ * 同列内同日节点超过阈值时自动折成簇（收敛策略），可展开。
  * 时间不做坐标，只做层内排序约束。
  */
 export function computeDagLayout(
@@ -247,24 +89,19 @@ export function computeDagLayout(
   edges: GenealogyEdge[],
   byId: Map<string, DecisionRow>,
   plotWidth: number,
+  expandedDays: ReadonlySet<string> = new Set(),
 ): TimelineLayout {
   const raw = collectRawNodes(focus, edges, byId);
   const { minT, maxT } = timeExtent(raw);
   const ids = new Set(raw.map((n) => n.id));
-  const nodeById = new Map(raw.map((n) => [n.id, n]));
 
-  // 仅焦点谱系内的边。
-  const local = edges.filter((e) => ids.has(e.from) && ids.has(e.to));
+  // 仅用于边过滤旁路；布局本身用 depth rank，不重算 longest-path。
+  void edges.filter((e) => ids.has(e.from) && ids.has(e.to));
 
-  // 祖先方向 edge.to ← edge.from；拓扑层：无入边（纯祖先端）层 0。
-  // 但我们要「祖先在左、后代在右」：用 depth 平移到非负 rank 更稳——
-  // rank = depth - minDepth，使最老祖先 rank=0。
   const depths = raw.map((n) => n.depth);
   const minDepth = depths.length ? Math.min(...depths) : 0;
   const rankOf = new Map(raw.map((n) => [n.id, n.depth - minDepth]));
 
-  // 若边跨越非相邻 rank，保留；不重算 longest-path（depth BFS 已给谱系层）。
-  // 同 rank 内按时间排序。
   const byRank = new Map<number, RawLineageNode[]>();
   for (const node of raw) {
     const rank = rankOf.get(node.id) ?? 0;
@@ -290,41 +127,72 @@ export function computeDagLayout(
       : Math.max(CARD_W + LANE_STEP_MIN, Math.min(CARD_W + 80, plotW / maxRank));
   const contentW = Math.max(plotW, maxRank * colStep);
 
-  // 同列垂直堆叠（时间序），不按 depth 分带——depth 已编码为 x。
   const placed: LaidOutNode[] = [];
-  let maxRows = 1;
+
   for (const rank of ranks) {
     const col = byRank.get(rank) ?? [];
-    maxRows = Math.max(maxRows, col.length);
-    col.forEach((node, row) => {
-      const x =
-        maxRank === 0
-          ? PAD_X + contentW / 2 - CARD_W / 2
-          : PAD_X + rank * colStep;
-      placed.push({
-        ...node,
-        x,
-        y: AXIS_H + PAD_Y + row * ROW_H,
-        isCluster: false,
-      });
-    });
-  }
+    const x =
+      maxRank === 0
+        ? PAD_X + contentW / 2 - CARD_W / 2
+        : PAD_X + rank * colStep;
 
-  // 可选：用 local 边做轻微交叉惩罚重排——保持 deterministic 简单列堆叠。
-  void local;
-  void nodeById;
+    // 按日分组，检测同日节点过多（收敛条件）。日序稳定。
+    const byDayInCol = new Map<string, RawLineageNode[]>();
+    for (const node of col) {
+      const list = byDayInCol.get(node.dayKey) ?? [];
+      list.push(node);
+      byDayInCol.set(node.dayKey, list);
+    }
+    const dayKeys = [...byDayInCol.keys()].sort((a, b) => {
+      if (a === "NO_TIME") return 1;
+      if (b === "NO_TIME") return -1;
+      return a.localeCompare(b);
+    });
+
+    let rowCursor = 0;
+    for (const dayKey of dayKeys) {
+      const dayNodes = byDayInCol.get(dayKey)!;
+      const shouldFold =
+        dayNodes.length >= SAME_DAY_CLUSTER_THRESHOLD && !expandedDays.has(dayKey);
+
+      if (shouldFold) {
+        // 簇 id 含 rank，避免跨列同日碰撞；展开态仍按 dayKey 统一控制。
+        const seed = dayNodes[0]!;
+        const midDepths = dayNodes.map((m) => m.depth).sort((a, b) => a - b);
+        const mid = midDepths[Math.floor(midDepths.length / 2)] ?? 0;
+        placed.push({
+          id: `cluster:${rank}:${dayKey}`,
+          decision: seed.decision,
+          depth: mid,
+          timeMs: seed.timeMs,
+          dayKey,
+          x: maxRank === 0 ? PAD_X + contentW / 2 - CLUSTER_W / 2 : x,
+          y: AXIS_H + PAD_Y + rowCursor * ROW_H,
+          isCluster: true,
+          clusterSize: dayNodes.length,
+          memberIds: dayNodes.map((m) => m.id),
+        });
+        rowCursor += 1;
+      } else {
+        for (const node of dayNodes) {
+          placed.push({
+            ...node,
+            x,
+            y: AXIS_H + PAD_Y + rowCursor * ROW_H,
+            isCluster: false,
+            dayKey: node.dayKey,
+          });
+          rowCursor += 1;
+        }
+      }
+    }
+  }
 
   const ticks = ranks.map((rank) => {
     const col = byRank.get(rank) ?? [];
     const label =
-      rank === 0
-        ? "祖先"
-        : rank === maxRank
-          ? "后代"
-          : `层 ${rank}`;
-    const x =
-      maxRank === 0 ? PAD_X + contentW / 2 : PAD_X + rank * colStep;
-    // 副标签：该列最早日期
+      rank === 0 ? "祖先" : rank === maxRank ? "后代" : `层 ${rank}`;
+    const x = maxRank === 0 ? PAD_X + contentW / 2 : PAD_X + rank * colStep;
     const day = col[0]?.dayKey;
     const dayLabel = day && day !== "NO_TIME" ? day.slice(5) : "";
     return {
@@ -333,5 +201,5 @@ export function computeDagLayout(
     };
   });
 
-  return finishLayout(placed, ticks, minT, maxT, "dag");
+  return finishLayout(placed, ticks, minT, maxT);
 }

--- a/packages/gui/src/renderer/views/genealogy/layout.ts
+++ b/packages/gui/src/renderer/views/genealogy/layout.ts
@@ -1,15 +1,12 @@
 import type { DecisionRow, RelationEdge, RelationKind } from "../../model/types";
 
 /**
- * 决策谱系「演化史」视图的纯逻辑层：常量、类型、关系筛选、深度优先谱系收集、
- * 时间轴布局计算。无 React、无 JSX，方便单测与复用。
+ * 决策谱系「演化史」视图的纯逻辑层：常量、类型、关系筛选、深度优先谱系收集。
+ * 布局编码实现见 layout-encodings.ts。
  *
- * 承接 dec_01KXA7811SVVT8P66HNDFZQ7DF 原则 6：关系图解决「结构」，而 decision
- * 谱系（refines/narrows/supersedes/supports）本质是**时间演化**，用一条时间轴
- * 更清晰——X=decidedAt（缺则 fallback proposedAt），行=谱系深度，节点=决策卡。
+ * 时间维度是对的，但线性 wall-clock x 轴对点事件+成簇数据是错的。
  */
 
-// 谱系边：只认权威轴里表达「思想演化」的四类关系，两端必须都是 decision。
 export const GENEALOGY_KINDS = new Set<RelationKind>([
   "refines",
   "narrows",
@@ -17,29 +14,79 @@ export const GENEALOGY_KINDS = new Set<RelationKind>([
   "supports",
 ]);
 
-// 每类边的语义标签 + 语义色（复用 styles.css 里已定义的 CSS 变量，绝不新造）。
+/** 边语义：色 + 线型，不靠回头读图例也能分。 */
 export const KIND_META: Record<
   string,
-  { label: string; color: string; verb: string }
+  { label: string; color: string; verb: string; dash: string; strokeWidth: number }
 > = {
-  refines: { label: "细化", color: "var(--color-accent)", verb: "细化了" },
-  narrows: { label: "收窄", color: "var(--color-status-in-review)", verb: "收窄了" },
-  supersedes: { label: "推翻", color: "var(--color-danger)", verb: "推翻了" },
-  supports: { label: "支撑", color: "var(--color-status-done)", verb: "支撑了" },
+  refines: {
+    label: "细化",
+    color: "var(--color-accent)",
+    verb: "细化了",
+    dash: "",
+    strokeWidth: 1.6,
+  },
+  narrows: {
+    label: "收窄",
+    color: "var(--color-status-in-review)",
+    verb: "收窄了",
+    dash: "5 3",
+    strokeWidth: 1.6,
+  },
+  supersedes: {
+    label: "推翻",
+    color: "var(--color-danger)",
+    verb: "推翻了",
+    dash: "",
+    strokeWidth: 2.4,
+  },
+  supports: {
+    label: "支撑",
+    color: "var(--color-status-done)",
+    verb: "支撑了",
+    dash: "1.5 2.5",
+    strokeWidth: 1.4,
+  },
+};
+
+/** 编码轴：替换线性时间 x 的三种可读方案。 */
+export type EncodingMode = "ordinal" | "day-cluster" | "dag";
+
+export const ENCODING_META: Record<
+  EncodingMode,
+  { label: string; short: string; blurb: string }
+> = {
+  ordinal: {
+    label: "序数轴",
+    short: "序数",
+    blurb: "x=事件序，空白日不占宽",
+  },
+  "day-cluster": {
+    label: "日簇折叠",
+    short: "日簇",
+    blurb: "同日合成簇节点，点开展开",
+  },
+  dag: {
+    label: "DAG 拓扑",
+    short: "DAG",
+    blurb: "谱系拓扑排版，时间只做排序",
+  },
 };
 
 // ---- 布局常量（px）----
-export const CARD_W = 210;
-export const CARD_H = 60;
-export const ROW_H = 82;
+export const CARD_W = 248;
+export const CARD_H = 72;
+export const ROW_H = 94;
 export const AXIS_H = 34;
 export const PAD_X = 28;
 export const PAD_Y = 20;
-export const LANE_GAP = 26; // 同一深度带内两卡的最小水平间隙
+export const LANE_GAP = 18;
+export const CLUSTER_W = 168;
+export const CLUSTER_H = 64;
 
 export interface GenealogyEdge {
-  from: string; // 后代（较新，refines/narrows/... 的一方）
-  to: string; // 祖先（较旧，被 refine 的一方）
+  from: string;
+  to: string;
   kind: RelationKind;
   rationale?: string;
 }
@@ -47,10 +94,14 @@ export interface GenealogyEdge {
 export interface LaidOutNode {
   id: string;
   decision: DecisionRow;
-  depth: number; // 相对焦点：祖先为负、焦点为 0、后代为正
+  depth: number;
   timeMs: number | null;
-  x: number; // 卡片左上角 x（含 PAD）
-  y: number; // 卡片左上角 y（含 AXIS + PAD）
+  x: number;
+  y: number;
+  dayKey?: string;
+  isCluster?: boolean;
+  clusterSize?: number;
+  memberIds?: string[];
 }
 
 export interface TimelineLayout {
@@ -60,11 +111,10 @@ export interface TimelineLayout {
   ticks: { x: number; label: string }[];
   minT: number;
   maxT: number;
-  /** 修 #11:谱系边成环时,显式带出 cycle 列表供视图告警(此前 BFS 静默截断)。 */
+  encoding: EncodingMode;
   cycleWarning: { count: number; cycles: string[][] };
 }
 
-/** 把 `decision/dec_x/CH1` 之类的 ref 归一成裸 decision id；非 decision 端返回 null。 */
 export function decisionIdOf(ref: string): string | null {
   if (!ref.startsWith("decision/")) return null;
   const rest = ref.slice("decision/".length);
@@ -72,12 +122,17 @@ export function decisionIdOf(ref: string): string | null {
   return id.length > 0 ? id : null;
 }
 
-/** decidedAt 优先，缺则 proposedAt；都无 → null（优雅降级）。 */
 export function timeMsOf(decision: DecisionRow): number | null {
   const raw = decision.decidedAt ?? decision.proposedAt;
   if (!raw) return null;
   const ms = new Date(raw).getTime();
   return Number.isFinite(ms) ? ms : null;
+}
+
+export function dayKeyOf(decision: DecisionRow): string {
+  const raw = decision.decidedAt ?? decision.proposedAt;
+  if (!raw) return "NO_TIME";
+  return raw.slice(0, 10);
 }
 
 export function shortTime(decision: DecisionRow): string {
@@ -86,7 +141,6 @@ export function shortTime(decision: DecisionRow): string {
   return raw.slice(0, 10);
 }
 
-/** 全量谱系边（decision→decision），去重。 */
 export function buildGenealogyEdges(
   relations: RelationEdge[],
   byId: Map<string, DecisionRow>,
@@ -107,7 +161,6 @@ export function buildGenealogyEdges(
   return edges;
 }
 
-/** 以 focus 为中心，上溯祖先（沿 from→to）+ 下溯后代（沿 to→from），返回带 depth 的谱系集合。 */
 export function collectLineage(
   focusId: string,
   edges: GenealogyEdge[],
@@ -121,7 +174,6 @@ export function collectLineage(
 
   const depth = new Map<string, number>([[focusId, 0]]);
 
-  // 上溯祖先：focus --refines--> ancestor，祖先更旧 → 负 depth。
   const upQueue: string[] = [focusId];
   while (upQueue.length > 0) {
     const current = upQueue.shift()!;
@@ -134,7 +186,6 @@ export function collectLineage(
     }
   }
 
-  // 下溯后代：descendant --refines--> focus，后代更新 → 正 depth。
   const downQueue: string[] = [focusId];
   while (downQueue.length > 0) {
     const current = downQueue.shift()!;
@@ -150,14 +201,6 @@ export function collectLineage(
   return depth;
 }
 
-/**
- * 修 #11:在谱系边集里检测环。collectLineage 的 BFS 遇到环会静默终止(已访问
- * 节点跳过),导致环里的节点拿到任意 depth,但调用方完全不知数据里有环。
- * 此函数显式找出所有简单环,供视图发 INV 风格的告警。
- *
- * 注:仅按 GenealogyEdge.from/to 形成的有向图找环,与 graphLayoutShared 的
- * findRelationCycles 同思路,但保持谱系视图自包含(不引入 graph/** 依赖)。
- */
 export function findGenealogyCycles(edges: GenealogyEdge[]): string[][] {
   const byFrom = new Map<string, string[]>();
   for (const edge of edges) {
@@ -197,102 +240,81 @@ export function findGenealogyCycles(edges: GenealogyEdge[]): string[][] {
   return cycles;
 }
 
-/** 时间轴上做 3–6 个刻度。 */
-export function axisTicks(minT: number, maxT: number): { t: number; label: string }[] {
-  if (!(maxT > minT)) return [];
-  const count = 5;
-  const ticks: { t: number; label: string }[] = [];
-  for (let i = 0; i <= count; i += 1) {
-    const t = minT + ((maxT - minT) * i) / count;
-    ticks.push({ t, label: new Date(t).toISOString().slice(0, 10) });
-  }
-  return ticks;
+export interface RawLineageNode {
+  id: string;
+  decision: DecisionRow;
+  depth: number;
+  timeMs: number | null;
+  dayKey: string;
 }
 
-const EMPTY_LAYOUT: TimelineLayout = {
+export function collectRawNodes(
+  focus: DecisionRow,
+  edges: GenealogyEdge[],
+  byId: Map<string, DecisionRow>,
+): RawLineageNode[] {
+  const depthMap = collectLineage(focus.decisionId, edges);
+  return [...depthMap.entries()]
+    .map(([id, depth]) => {
+      const decision = byId.get(id);
+      if (!decision) return null;
+      return {
+        id,
+        decision,
+        depth,
+        timeMs: timeMsOf(decision),
+        dayKey: dayKeyOf(decision),
+      };
+    })
+    .filter((node): node is RawLineageNode => node !== null);
+}
+
+/** 同 depth 带内按 x 排序后贪心装道，零重叠。 */
+export function packDepthLanes(
+  nodes: Array<Omit<LaidOutNode, "y"> & { x: number }>,
+  rowH: number = ROW_H,
+): { placed: LaidOutNode[]; rowCount: number } {
+  const depths = [...new Set(nodes.map((n) => n.depth))].sort((a, b) => a - b);
+  const placed: LaidOutNode[] = [];
+  let rowCursor = 0;
+  for (const depth of depths) {
+    const group = nodes
+      .filter((n) => n.depth === depth)
+      .sort((a, b) => a.x - b.x || a.id.localeCompare(b.id));
+    const laneRight: number[] = [];
+    for (const node of group) {
+      const cardW = node.isCluster ? CLUSTER_W : CARD_W;
+      let lane = laneRight.findIndex((right) => node.x >= right + LANE_GAP);
+      if (lane === -1) {
+        lane = laneRight.length;
+        laneRight.push(0);
+      }
+      laneRight[lane] = node.x + cardW;
+      placed.push({
+        ...node,
+        y: AXIS_H + PAD_Y + (rowCursor + lane) * rowH,
+      });
+    }
+    rowCursor += Math.max(1, laneRight.length);
+  }
+  return { placed, rowCount: rowCursor };
+}
+
+export const EMPTY_LAYOUT: TimelineLayout = {
   nodes: [],
   width: 0,
   height: 0,
   ticks: [],
   minT: 0,
   maxT: 0,
+  encoding: "ordinal",
   cycleWarning: { count: 0, cycles: [] },
 };
 
-/**
- * 焦点谱系的时间轴布局：按 depth 升序（祖先在上）分带，带内按 x 排序后贪心装道，
- * 保证零重叠。无焦点 → 空布局。
- */
-export function computeLayout(
-  focus: DecisionRow | null,
-  edges: GenealogyEdge[],
-  byId: Map<string, DecisionRow>,
-  plotWidth: number,
-): TimelineLayout {
-  if (!focus) return EMPTY_LAYOUT;
+export type LayoutOptions = {
+  encoding?: EncodingMode;
+  expandedDays?: ReadonlySet<string>;
+};
 
-  const depthMap = collectLineage(focus.decisionId, edges);
-  const rawNodes = [...depthMap.entries()]
-    .map(([id, depth]) => {
-      const decision = byId.get(id);
-      if (!decision) return null;
-      return { id, decision, depth, timeMs: timeMsOf(decision) };
-    })
-    .filter((node): node is Omit<LaidOutNode, "x" | "y"> => node !== null);
-
-  const times = rawNodes.map((node) => node.timeMs).filter((t): t is number => t !== null);
-  const minT = times.length > 0 ? Math.min(...times) : 0;
-  const maxT = times.length > 0 ? Math.max(...times) : 0;
-  const span = maxT - minT;
-
-  const plotW = Math.max(360, plotWidth - PAD_X * 2 - CARD_W);
-  const xOfTime = (timeMs: number | null): number => {
-    if (timeMs === null) return 0; // 无时间 → 贴最左，并在卡上标注
-    if (span <= 0) return plotW / 2;
-    return ((timeMs - minT) / span) * plotW;
-  };
-
-  const depths = [...new Set(rawNodes.map((node) => node.depth))].sort((a, b) => a - b);
-  const placed: LaidOutNode[] = [];
-  let rowCursor = 0;
-  for (const depth of depths) {
-    const group = rawNodes
-      .filter((node) => node.depth === depth)
-      .sort((a, b) => xOfTime(a.timeMs) - xOfTime(b.timeMs));
-    const laneRight: number[] = [];
-    for (const node of group) {
-      const nx = xOfTime(node.timeMs);
-      let lane = laneRight.findIndex((right) => nx >= right + LANE_GAP);
-      if (lane === -1) {
-        lane = laneRight.length;
-        laneRight.push(0);
-      }
-      laneRight[lane] = nx + CARD_W;
-      placed.push({
-        ...node,
-        x: PAD_X + nx,
-        y: AXIS_H + PAD_Y + (rowCursor + lane) * ROW_H,
-      });
-    }
-    rowCursor += Math.max(1, laneRight.length);
-  }
-
-  const width = PAD_X * 2 + plotW + CARD_W;
-  const height = AXIS_H + PAD_Y * 2 + rowCursor * ROW_H;
-  const ticks = axisTicks(minT, maxT).map((tick) => ({
-    x: PAD_X + xOfTime(tick.t),
-    label: tick.label,
-  }));
-  // 修 #11:refines/narrows/supersedes/supports 边集里若成环,collectLineage 会
-  // 静默截断(depth 任意赋),视图此前毫无提示。现在显式计算 cycle 列表上抛。
-  const cycles = findGenealogyCycles(edges);
-  return {
-    nodes: placed,
-    width,
-    height,
-    ticks,
-    minT,
-    maxT,
-    cycleWarning: { count: cycles.length, cycles },
-  };
-}
+// re-export dispatcher so现有 import { computeLayout } from "./layout" 仍可用
+export { computeLayout } from "./layout-encodings";

--- a/packages/gui/src/renderer/views/genealogy/layout.ts
+++ b/packages/gui/src/renderer/views/genealogy/layout.ts
@@ -49,40 +49,30 @@ export const KIND_META: Record<
   },
 };
 
-/** 编码轴：替换线性时间 x 的三种可读方案。 */
-export type EncodingMode = "ordinal" | "day-cluster" | "dag";
+/** 编码模式：DAG 拓扑（唯一布局），日簇是同列内同日节点过多时的自动收敛策略。 */
+export type EncodingMode = "dag";
 
 export const ENCODING_META: Record<
   EncodingMode,
   { label: string; short: string; blurb: string }
 > = {
-  ordinal: {
-    label: "序数轴",
-    short: "序数",
-    blurb: "x=事件序，空白日不占宽",
-  },
-  "day-cluster": {
-    label: "日簇折叠",
-    short: "日簇",
-    blurb: "同日合成簇节点，点开展开",
-  },
   dag: {
     label: "DAG 拓扑",
     short: "DAG",
-    blurb: "谱系拓扑排版，时间只做排序",
+    blurb: "谱系拓扑排版，时间只做排序；同列同日过多时自动折簇",
   },
 };
 
 // ---- 布局常量（px）----
-export const CARD_W = 248;
-export const CARD_H = 72;
-export const ROW_H = 94;
+// 卡片加宽加高，让真实账本里 80–100 字标题能完整显示（3 行 × ~28 字）。
+export const CARD_W = 280;
+export const CARD_H = 96;
+export const ROW_H = 118;
 export const AXIS_H = 34;
 export const PAD_X = 28;
 export const PAD_Y = 20;
-export const LANE_GAP = 18;
-export const CLUSTER_W = 168;
-export const CLUSTER_H = 64;
+export const CLUSTER_W = 188;
+export const CLUSTER_H = 72;
 
 export interface GenealogyEdge {
   from: string;
@@ -269,37 +259,6 @@ export function collectRawNodes(
     .filter((node): node is RawLineageNode => node !== null);
 }
 
-/** 同 depth 带内按 x 排序后贪心装道，零重叠。 */
-export function packDepthLanes(
-  nodes: Array<Omit<LaidOutNode, "y"> & { x: number }>,
-  rowH: number = ROW_H,
-): { placed: LaidOutNode[]; rowCount: number } {
-  const depths = [...new Set(nodes.map((n) => n.depth))].sort((a, b) => a - b);
-  const placed: LaidOutNode[] = [];
-  let rowCursor = 0;
-  for (const depth of depths) {
-    const group = nodes
-      .filter((n) => n.depth === depth)
-      .sort((a, b) => a.x - b.x || a.id.localeCompare(b.id));
-    const laneRight: number[] = [];
-    for (const node of group) {
-      const cardW = node.isCluster ? CLUSTER_W : CARD_W;
-      let lane = laneRight.findIndex((right) => node.x >= right + LANE_GAP);
-      if (lane === -1) {
-        lane = laneRight.length;
-        laneRight.push(0);
-      }
-      laneRight[lane] = node.x + cardW;
-      placed.push({
-        ...node,
-        y: AXIS_H + PAD_Y + (rowCursor + lane) * rowH,
-      });
-    }
-    rowCursor += Math.max(1, laneRight.length);
-  }
-  return { placed, rowCount: rowCursor };
-}
-
 export const EMPTY_LAYOUT: TimelineLayout = {
   nodes: [],
   width: 0,
@@ -307,12 +266,11 @@ export const EMPTY_LAYOUT: TimelineLayout = {
   ticks: [],
   minT: 0,
   maxT: 0,
-  encoding: "ordinal",
+  encoding: "dag",
   cycleWarning: { count: 0, cycles: [] },
 };
 
 export type LayoutOptions = {
-  encoding?: EncodingMode;
   expandedDays?: ReadonlySet<string>;
 };
 

--- a/packages/gui/test/genealogy-timeline.vitest.ts
+++ b/packages/gui/test/genealogy-timeline.vitest.ts
@@ -199,7 +199,108 @@ describe("Genealogy cycle warning (修 #11)", () => {
     expect(layout.cycleWarning.count).toBeGreaterThan(0);
     expect(layout.cycleWarning.cycles.length).toBe(layout.cycleWarning.count);
   });
+});
 
+describe("Genealogy encoding modes (非线 x 轴)", () => {
+  function chainFixture() {
+    // 同日 3 点 + 隔日 1 点，复现成簇；线性轴会把 3 点叠成柱。
+    const decisions: DecisionRow[] = [
+      baseDecision({
+        decisionId: "dec_old",
+        title: "祖先决策标题足够长不应被截成一截省略号",
+        decidedAt: "2026-07-03T10:00:00.000Z",
+      }),
+      baseDecision({
+        decisionId: "dec_mid_a",
+        title: "同日细化 A",
+        decidedAt: "2026-07-03T12:00:00.000Z",
+      }),
+      baseDecision({
+        decisionId: "dec_mid_b",
+        title: "同日细化 B",
+        decidedAt: "2026-07-03T14:00:00.000Z",
+      }),
+      baseDecision({
+        decisionId: "dec_new",
+        title: "隔日收窄",
+        decidedAt: "2026-07-09T09:00:00.000Z",
+      }),
+    ];
+    const relations: RelationEdge[] = [
+      edge("decision/dec_mid_a", "decision/dec_old", "refines"),
+      edge("decision/dec_mid_b", "decision/dec_old", "refines"),
+      edge("decision/dec_new", "decision/dec_mid_a", "narrows"),
+    ];
+    const byId = new Map(decisions.map((d) => [d.decisionId, d]));
+    const edges = buildGenealogyEdges(relations, byId);
+    // 焦点放根祖先，BFS 才能把 mid_a/mid_b/new 全收进谱系。
+    return { decisions, byId, edges, focus: decisions[0]! };
+  }
+
+  it("ordinal：按事件序拉开，空白日不占宽（07-04..08 不出现空刻度）", () => {
+    const { byId, edges, focus } = chainFixture();
+    const layout = computeLayout(focus, edges, byId, 900, { encoding: "ordinal" });
+    expect(layout.encoding).toBe("ordinal");
+    expect(layout.nodes).toHaveLength(4);
+    // 序数轴上 x 应单调随时间
+    const ordered = [...layout.nodes].sort(
+      (a, b) => (a.timeMs ?? 0) - (b.timeMs ?? 0),
+    );
+    for (let i = 1; i < ordered.length; i += 1) {
+      expect(ordered[i]!.x).toBeGreaterThanOrEqual(ordered[i - 1]!.x);
+    }
+    // 刻度只在有事件的日
+    const labels = layout.ticks.map((t) => t.label);
+    expect(labels.some((l) => l.includes("07-03") || l === "07-03")).toBe(true);
+    expect(labels.every((l) => !l.includes("07-05"))).toBe(true);
+  });
+
+  it("day-cluster：同日折叠，展开后恢复成员卡", () => {
+    const { byId, edges, focus } = chainFixture();
+    const collapsed = computeLayout(focus, edges, byId, 900, {
+      encoding: "day-cluster",
+      expandedDays: new Set(),
+    });
+    expect(collapsed.encoding).toBe("day-cluster");
+    const clusters = collapsed.nodes.filter((n) => n.isCluster);
+    expect(clusters.length).toBeGreaterThanOrEqual(1);
+    const july3 = clusters.find((c) => c.dayKey === "2026-07-03");
+    expect(july3?.clusterSize).toBe(3);
+
+    const expanded = computeLayout(focus, edges, byId, 900, {
+      encoding: "day-cluster",
+      expandedDays: new Set(["2026-07-03"]),
+    });
+    expect(expanded.nodes.every((n) => !n.isCluster)).toBe(true);
+    expect(expanded.nodes).toHaveLength(4);
+  });
+
+  it("dag：祖先在左、后代在右（rank = depth 平移）", () => {
+    const { byId, edges, focus } = chainFixture();
+    const layout = computeLayout(focus, edges, byId, 900, { encoding: "dag" });
+    expect(layout.encoding).toBe("dag");
+    const old = layout.nodes.find((n) => n.id === "dec_old")!;
+    const mid = layout.nodes.find((n) => n.id === "dec_mid_a")!;
+    const neu = layout.nodes.find((n) => n.id === "dec_new")!;
+    expect(old.x).toBeLessThan(mid.x);
+    expect(mid.x).toBeLessThanOrEqual(neu.x);
+  });
+
+  it("视图 header 渲染三种编码 tab", () => {
+    const { decisions } = chainFixture();
+    const relations: RelationEdge[] = [
+      edge("decision/dec_mid_a", "decision/dec_old", "refines"),
+      edge("decision/dec_mid_b", "decision/dec_old", "refines"),
+      edge("decision/dec_new", "decision/dec_mid_a", "narrows"),
+    ];
+    const markup = renderToStaticMarkup(
+      createElement(GenealogyTimelineView, { decisions, relations }),
+    );
+    expect(markup).toContain('data-encoding-tab="ordinal"');
+    expect(markup).toContain('data-encoding-tab="day-cluster"');
+    expect(markup).toContain('data-encoding-tab="dag"');
+    expect(markup).toContain("序数轴");
+  });
   it("渲染时 header 显示「谱系环警告 · N」(SSR 快照)", () => {
     const decisions: DecisionRow[] = ["dec_a", "dec_b"].map((id) =>
       baseDecision({ decisionId: id, title: id }),

--- a/packages/gui/test/genealogy-timeline.vitest.ts
+++ b/packages/gui/test/genealogy-timeline.vitest.ts
@@ -7,10 +7,13 @@ import type {
 } from "../src/renderer/model/types.ts";
 import { GenealogyTimelineView } from "../src/renderer/views/GenealogyTimelineView.tsx";
 import {
+  CARD_H,
+  CARD_W,
   buildGenealogyEdges,
   computeLayout,
   findGenealogyCycles,
 } from "../src/renderer/views/genealogy/layout.ts";
+import { TimelinePlot } from "../src/renderer/views/genealogy/TimelinePlot.tsx";
 
 /**
  * 谱系 timeline 视图的组件级测试。验证:
@@ -201,7 +204,7 @@ describe("Genealogy cycle warning (修 #11)", () => {
   });
 });
 
-describe("Genealogy encoding modes (非线 x 轴)", () => {
+describe("Genealogy layout (DAG 拓扑)", () => {
   function chainFixture() {
     // 同日 3 点 + 隔日 1 点，复现成簇；线性轴会把 3 点叠成柱。
     const decisions: DecisionRow[] = [
@@ -237,56 +240,124 @@ describe("Genealogy encoding modes (非线 x 轴)", () => {
     return { decisions, byId, edges, focus: decisions[0]! };
   }
 
-  it("ordinal：按事件序拉开，空白日不占宽（07-04..08 不出现空刻度）", () => {
+  it("dag：祖先在左、后代在右（rank = depth 平移）", () => {
     const { byId, edges, focus } = chainFixture();
-    const layout = computeLayout(focus, edges, byId, 900, { encoding: "ordinal" });
-    expect(layout.encoding).toBe("ordinal");
-    expect(layout.nodes).toHaveLength(4);
-    // 序数轴上 x 应单调随时间
-    const ordered = [...layout.nodes].sort(
-      (a, b) => (a.timeMs ?? 0) - (b.timeMs ?? 0),
-    );
-    for (let i = 1; i < ordered.length; i += 1) {
-      expect(ordered[i]!.x).toBeGreaterThanOrEqual(ordered[i - 1]!.x);
-    }
-    // 刻度只在有事件的日
-    const labels = layout.ticks.map((t) => t.label);
-    expect(labels.some((l) => l.includes("07-03") || l === "07-03")).toBe(true);
-    expect(labels.every((l) => !l.includes("07-05"))).toBe(true);
+    const layout = computeLayout(focus, edges, byId, 900);
+    expect(layout.encoding).toBe("dag");
+    // dec_old(rank0, 07-03 单点) + cluster rank1:2026-07-03(mid_a,mid_b) + dec_new(rank2)
+    const old = layout.nodes.find((n) => n.id === "dec_old");
+    const cluster = layout.nodes.find((n) => n.isCluster && n.dayKey === "2026-07-03");
+    const neu = layout.nodes.find((n) => n.id === "dec_new");
+    expect(old).toBeDefined();
+    expect(cluster).toBeDefined();
+    expect(neu).toBeDefined();
+    expect(cluster?.id).toMatch(/^cluster:\d+:2026-07-03$/);
+    expect(old?.x).toBeLessThan(cluster?.x ?? Infinity);
+    expect(cluster?.x).toBeLessThanOrEqual(neu?.x ?? -1);
   });
 
-  it("day-cluster：同日折叠，展开后恢复成员卡", () => {
-    const { byId, edges, focus } = chainFixture();
-    const collapsed = computeLayout(focus, edges, byId, 900, {
-      encoding: "day-cluster",
-      expandedDays: new Set(),
-    });
-    expect(collapsed.encoding).toBe("day-cluster");
+  it("同日节点自动收敛为簇（阈值 ≥ 2），展开后恢复成员卡", () => {
+    // 3 个同日节点落在同一深度（都是 mid 的细化）
+    const decisions: DecisionRow[] = [
+      baseDecision({
+        decisionId: "dec_root",
+        title: "根决策",
+        decidedAt: "2026-07-02T10:00:00.000Z",
+      }),
+      baseDecision({
+        decisionId: "dec_mid",
+        title: "中间决策",
+        decidedAt: "2026-07-03T12:00:00.000Z",
+      }),
+      baseDecision({
+        decisionId: "dec_child_a",
+        title: "同日细化 A",
+        decidedAt: "2026-07-03T14:00:00.000Z",
+      }),
+      baseDecision({
+        decisionId: "dec_child_b",
+        title: "同日细化 B",
+        decidedAt: "2026-07-03T15:00:00.000Z",
+      }),
+      baseDecision({
+        decisionId: "dec_child_c",
+        title: "同日细化 C",
+        decidedAt: "2026-07-03T16:00:00.000Z",
+      }),
+    ];
+    const relations: RelationEdge[] = [
+      edge("decision/dec_child_a", "decision/dec_mid", "refines"),
+      edge("decision/dec_child_b", "decision/dec_mid", "refines"),
+      edge("decision/dec_child_c", "decision/dec_mid", "refines"),
+      edge("decision/dec_mid", "decision/dec_root", "refines"),
+    ];
+    const byId = new Map(decisions.map((d) => [d.decisionId, d]));
+    const edges = buildGenealogyEdges(relations, byId);
+    const focus = byId.get("dec_root")!;
+
+    // 同日 3 个节点（dec_child_*）在同一深度应自动折叠
+    const collapsed = computeLayout(focus, edges, byId, 900);
     const clusters = collapsed.nodes.filter((n) => n.isCluster);
     expect(clusters.length).toBeGreaterThanOrEqual(1);
     const july3 = clusters.find((c) => c.dayKey === "2026-07-03");
     expect(july3?.clusterSize).toBe(3);
+    expect(july3?.id).toMatch(/^cluster:\d+:2026-07-03$/);
+    // 折叠后可见节点：root + mid + 1 cluster = 3
+    expect(collapsed.nodes).toHaveLength(3);
 
+    // 展开后恢复成员卡
     const expanded = computeLayout(focus, edges, byId, 900, {
-      encoding: "day-cluster",
       expandedDays: new Set(["2026-07-03"]),
     });
     expect(expanded.nodes.every((n) => !n.isCluster)).toBe(true);
-    expect(expanded.nodes).toHaveLength(4);
+    expect(expanded.nodes).toHaveLength(5);
   });
 
-  it("dag：祖先在左、后代在右（rank = depth 平移）", () => {
-    const { byId, edges, focus } = chainFixture();
-    const layout = computeLayout(focus, edges, byId, 900, { encoding: "dag" });
-    expect(layout.encoding).toBe("dag");
-    const old = layout.nodes.find((n) => n.id === "dec_old")!;
-    const mid = layout.nodes.find((n) => n.id === "dec_mid_a")!;
-    const neu = layout.nodes.find((n) => n.id === "dec_new")!;
-    expect(old.x).toBeLessThan(mid.x);
-    expect(mid.x).toBeLessThanOrEqual(neu.x);
+  it("跨列同日各成独立簇且 id 不撞车", () => {
+    const decisions: DecisionRow[] = [
+      baseDecision({
+        decisionId: "dec_root",
+        title: "根",
+        decidedAt: "2026-07-02T10:00:00.000Z",
+      }),
+      baseDecision({
+        decisionId: "dec_m1",
+        title: "中层 1",
+        decidedAt: "2026-07-03T11:00:00.000Z",
+      }),
+      baseDecision({
+        decisionId: "dec_m2",
+        title: "中层 2",
+        decidedAt: "2026-07-03T12:00:00.000Z",
+      }),
+      baseDecision({
+        decisionId: "dec_c1",
+        title: "子层 1",
+        decidedAt: "2026-07-03T14:00:00.000Z",
+      }),
+      baseDecision({
+        decisionId: "dec_c2",
+        title: "子层 2",
+        decidedAt: "2026-07-03T15:00:00.000Z",
+      }),
+    ];
+    const relations: RelationEdge[] = [
+      edge("decision/dec_m1", "decision/dec_root", "refines"),
+      edge("decision/dec_m2", "decision/dec_root", "refines"),
+      edge("decision/dec_c1", "decision/dec_m1", "refines"),
+      edge("decision/dec_c2", "decision/dec_m2", "refines"),
+    ];
+    const byId = new Map(decisions.map((d) => [d.decisionId, d]));
+    const edges = buildGenealogyEdges(relations, byId);
+    const layout = computeLayout(byId.get("dec_root")!, edges, byId, 900);
+    const clusters = layout.nodes.filter((n) => n.isCluster && n.dayKey === "2026-07-03");
+    expect(clusters.length).toBe(2);
+    const ids = new Set(clusters.map((c) => c.id));
+    expect(ids.size).toBe(2);
+    expect([...ids].every((id) => id.startsWith("cluster:"))).toBe(true);
   });
 
-  it("视图 header 渲染三种编码 tab", () => {
+  it("视图不再渲染编码 tab（只有一个 dag 布局）", () => {
     const { decisions } = chainFixture();
     const relations: RelationEdge[] = [
       edge("decision/dec_mid_a", "decision/dec_old", "refines"),
@@ -296,11 +367,62 @@ describe("Genealogy encoding modes (非线 x 轴)", () => {
     const markup = renderToStaticMarkup(
       createElement(GenealogyTimelineView, { decisions, relations }),
     );
-    expect(markup).toContain('data-encoding-tab="ordinal"');
-    expect(markup).toContain('data-encoding-tab="day-cluster"');
-    expect(markup).toContain('data-encoding-tab="dag"');
-    expect(markup).toContain("序数轴");
+    expect(markup).not.toContain('data-encoding-tab="ordinal"');
+    expect(markup).not.toContain('data-encoding-tab="day-cluster"');
+    expect(markup).not.toContain('data-encoding-tab="dag"');
+    expect(markup).toContain("DAG 拓扑");
+    expect(markup).toContain('data-encoding="dag"');
   });
+
+  it("卡片标题用 3 行 clamp + 加宽加高卡片，长标题不再被硬截", () => {
+    // 卡面：宽 280 / 高 96 / 3 行，覆盖真实账本最长标题（~97 字）。
+    expect(CARD_W).toBeGreaterThanOrEqual(280);
+    expect(CARD_H).toBeGreaterThanOrEqual(96);
+
+    const longTitle =
+      "E1 内容与引擎正交:Vertical 选模板、TemplateLibrary 存正文/locale、Preset 覆盖";
+    const decision = baseDecision({
+      decisionId: "dec_a",
+      title: longTitle,
+      decidedAt: "2026-07-03T10:00:00.000Z",
+    });
+    const layout = {
+      nodes: [
+        {
+          id: "dec_a",
+          decision,
+          depth: 0,
+          timeMs: Date.parse("2026-07-03T10:00:00.000Z"),
+          x: 28,
+          y: 54,
+          dayKey: "2026-07-03",
+          isCluster: false,
+        },
+      ],
+      width: 400,
+      height: 200,
+      ticks: [{ x: 28, label: "祖先" }],
+      minT: 0,
+      maxT: 0,
+      encoding: "dag" as const,
+      cycleWarning: { count: 0, cycles: [] as string[][] },
+    };
+    const nodeById = new Map([["dec_a", layout.nodes[0]!]]);
+    const markup = renderToStaticMarkup(
+      createElement(TimelinePlot, {
+        layout,
+        nodeById,
+        lineageEdges: [],
+        selectedId: null,
+        onToggleSelect: () => undefined,
+      }),
+    );
+    // 完整标题进 DOM（不是 JS 层硬截）；卡面用 line-clamp-3。
+    expect(markup).toContain(longTitle);
+    expect(markup).toContain("line-clamp-3");
+    expect(markup).not.toContain("line-clamp-2");
+  });
+
   it("渲染时 header 显示「谱系环警告 · N」(SSR 快照)", () => {
     const decisions: DecisionRow[] = ["dec_a", "dec_b"].map((id) =>
       baseDecision({ decisionId: id, title: id }),


### PR DESCRIPTION
# English

## Summary

The decision genealogy view ("演化史") encoded time as a linear x-axis, which degenerated on real data: 61% of genealogy edges occur on the same day, so those edges had **zero horizontal displacement** and could only be drawn as long y-axis curves — producing an unreadable spaghetti of 129 edges over 143 decisions.

This replaces the encoding: **the DAG topology now owns the layout, and time is demoted from a coordinate to an ordering constraint plus a column label.** Same-day nodes collapse into day clusters that expand on click.

## What Changed

- `layout-encodings.ts` (new): the layout encoding layer. Three schemes were prototyped against the real ledger; the ordinal-axis scheme was measured and retired.
- `GenealogyTimelineView.tsx` / `TimelinePlot.tsx` / `layout.ts`: consolidated to a DAG-only layout. Day clustering is a node-convergence strategy *inside* the DAG, not a sibling mode.
- Cards carry a `title` attribute so long decision titles are recoverable on hover.
- `genealogy-timeline.vitest.ts`: covers the DAG layout and cluster expand/collapse.

## Task And Scope

- Task: `task_01KXDPX5Y4D56CV50H1X5JFBBA` (closeout), `task_01KXDKX08HEACYWPSX02S43T4X` (prototypes)
- Decision: `dec_01KXDPWFFQB10WSB6QYK8T104P` (accepted) — adopt DAG-as-main-view + day-clustering-as-convergence, retire the ordinal axis.
- Scope is limited to `packages/gui/src/renderer/views/genealogy/**` and its test. No backend, kernel, CLI, or IPC changes.

## Version Impact

None. Renderer-only change; no public API, schema, or CLI surface is affected.

## Governance Declaration

No CI, gate, gate-manifest, or governance surface was modified.

## Verification

`npm run check:ci` (all 13 pull-request jobs, derived from `tools/gate-manifest.json`) — **all green**:

```
✓ typecheck  ✓ fast-contract  ✓ integration-shard (1..6)
✓ boundaries  ✓ package-policy  ✓ supply-chain  ✓ gui-build  ✓ node26-compatibility
```

`supply-chain` failed once on a transient npm-registry TLS disconnect and passed on re-run; it is green on canonical `main` as well (negative control).

Visual verification against the **real ledger** (143 decisions / 129 edges), screenshots in the task package:
- `05-closeout-dag-clustered.png` — default state, 5 cards + 6 day-clusters
- `06-closeout-dag-expanded.png` — clusters expanded, all 19 lineage cards legible

## Review Evidence

The original root-cause diagnosis ("most decisions land on 2026-07-03") was **falsified by the data** — the peak day holds only 24%. The real cause is that **61% of genealogy edges are same-day**. The fix follows from the corrected cause, not the original one.

## Residual Risk

- **Long card titles still truncate visually.** Full text is reachable via hover (`title` attribute), but the stated goal of "no truncation" is mitigated, not met.
- **Vertical space is under-used** — the lower portion of the canvas is empty when the focused lineage is shallow.

Both are polish items, tracked for a follow-up pass.

## References

- Screenshots + real-ledger snapshot: `harness/tasks/task_01KXDPX5Y4D56CV50H1X5JFBBA-*/artifacts/screenshots/`
- Closeout report: same task package, `artifacts/report-genealogy-closeout.md`

---

# 中文

## 概要

决策演化史视图把时间编码成**线性 x 轴**，这在真实数据上必然退化：**61% 的演化边是同日发生的**，这些边在 x 轴上**零位移**，只能靠 y 轴甩长曲线表达——于是 143 个决策、129 条边变成一团读不出结构的意大利面。

本 PR 换掉编码：**谱系拓扑（DAG）接管布局，时间从「坐标」降级为「排序约束 + 列标签」。** 同日节点折成日簇，点击展开。

## 改动内容

- `layout-encodings.ts`（新增）：布局编码层。三套方案在真实账本上跑过原型，序数轴方案经实测淘汰。
- `GenealogyTimelineView.tsx` / `TimelinePlot.tsx` / `layout.ts`：收敛为**唯一的 DAG 布局**。日簇折叠是 DAG **内部**的节点收敛策略，不是并列的第二个 mode。
- 卡片带 `title` 属性，长标题可 hover 取全文。
- `genealogy-timeline.vitest.ts`：覆盖 DAG 布局与日簇展开/折叠。

## 任务与范围

- 任务：`task_01KXDPX5Y4D56CV50H1X5JFBBA`（收口）、`task_01KXDKX08HEACYWPSX02S43T4X`（原型）
- 决策：`dec_01KXDPWFFQB10WSB6QYK8T104P`（accepted）—— DAG 为主视图 + 日簇为收敛手段，序数轴退役。
- 范围严格限于 `packages/gui/src/renderer/views/genealogy/**` 与其测试。**未改动后端、kernel、CLI、IPC。**

## 版本影响

无。纯渲染器改动，不触及任何公开 API、schema 或 CLI 面。

## 治理声明

**未改动任何 CI / gate / gate-manifest / 治理面。**

## 验证

`npm run check:ci`（从 `tools/gate-manifest.json` 派生出的全部 13 个 pull_request job）——**全绿**：

```
✓ typecheck  ✓ fast-contract  ✓ integration-shard (1..6)
✓ boundaries  ✓ package-policy  ✓ supply-chain  ✓ gui-build  ✓ node26-compatibility
```

`supply-chain` 曾因 npm registry 的 TLS 瞬断红过一次，复跑即绿；阴性对照：canonical `main` 上同样是绿（证明非本改动引入）。

在**真实账本**（143 决策 / 129 边）上的视觉验证，截图在任务包：
- `05-closeout-dag-clustered.png` —— 默认态，5 张卡 + 6 个日簇
- `06-closeout-dag-expanded.png` —— 展开后，19 张谱系卡全部可读

## 审查证据

最初的根因诊断（「决策绝大多数落在 2026-07-03」）**被数据证伪**——峰值日仅占 24%。真实成因是 **61% 的演化边同日发生**。本修复依据的是**修正后**的根因，不是最初那个。

## 残余风险

- **长标题仍有视觉截断。** 全文可经 hover（`title` 属性）取得，但「不再截断」这个目标是**被缓解，不是被达成**。
- **垂直空间利用不足** —— 焦点谱系较浅时，画布下方留白。

两项均为打磨项，已记入后续。
