### PR TITLE
fix(gui): repair design tokens for contrast and prose readability

### DIFF
--- a/packages/gui/src/renderer/styles.css
+++ b/packages/gui/src/renderer/styles.css
@@ -20,31 +20,32 @@
   --color-border: oklch(0.35 0.01 285);
   --color-border-strong: oklch(0.45 0.012 285);
   --color-text: oklch(0.94 0.004 285);
-  --color-text-muted: oklch(0.74 0.01 285);
-  --color-text-faint: oklch(0.62 0.012 285);
+  --color-text-muted: oklch(0.80 0.01 285);
+  --color-text-faint: oklch(0.72 0.01 285);
 
-  /* coordinationStatus 六色 + unknown，等亮度 OKLch */
-  --color-status-planned: oklch(0.72 0.03 285);
-  --color-status-active: oklch(0.72 0.14 250);
-  --color-status-blocked: oklch(0.75 0.14 75);
-  --color-status-in-review: oklch(0.72 0.14 305);
-  --color-status-done: oklch(0.74 0.14 150);
-  --color-status-cancelled: oklch(0.55 0.01 285);
-  --color-status-unknown: oklch(0.70 0.12 25);
+  /* coordinationStatus 六色 + unknown，等亮度 OKLch（L≈0.78；cancelled 中性） */
+  --color-status-planned: oklch(0.78 0.03 285);
+  --color-status-active: oklch(0.78 0.14 250);
+  --color-status-blocked: oklch(0.78 0.14 75);
+  --color-status-in-review: oklch(0.78 0.14 305);
+  --color-status-done: oklch(0.78 0.14 150);
+  --color-status-cancelled: oklch(0.68 0.02 285);
+  --color-status-unknown: oklch(0.78 0.12 25);
 
   /* 唯一行动强调色：closeoutReadiness=ready 与主操作 */
   --color-accent: oklch(0.80 0.13 195);
   --color-accent-fg: oklch(0.18 0.02 195);
 
-  /* freshness 通道 */
-  --color-stale: oklch(0.75 0.12 75);
-  --color-danger: oklch(0.65 0.18 25);
+  /* freshness / 语义成功 / 危险 */
+  --color-stale: oklch(0.78 0.12 75);
+  --color-danger: oklch(0.72 0.17 25);
+  --color-success: oklch(0.80 0.13 150);
 
   /* 关系语义轴(dec_01KXA7811SVVT8P66HNDFZQ7DF CH4):权威/证据/执行/松关联 */
-  --color-axis-authority: oklch(0.72 0.14 250);
-  --color-axis-evidence: oklch(0.75 0.12 75);
-  --color-axis-execution: oklch(0.74 0.14 150);
-  --color-axis-assoc: oklch(0.62 0.012 285);
+  --color-axis-authority: oklch(0.78 0.14 250);
+  --color-axis-evidence: oklch(0.78 0.12 75);
+  --color-axis-execution: oklch(0.78 0.14 150);
+  --color-axis-assoc: oklch(0.72 0.01 285);
 }
 
 /*
@@ -59,26 +60,28 @@ html[data-theme="light"] {
   --color-border-strong: oklch(0.81 0.006 285);
   --color-text: oklch(0.23 0.006 285);
   --color-text-muted: oklch(0.46 0.008 285);
-  --color-text-faint: oklch(0.61 0.008 285);
+  --color-text-faint: oklch(0.52 0.008 285);
 
+  /* 亮色状态色：压 L 使 vs bg ≥4.5:1（WCAG AA） */
   --color-status-planned: oklch(0.52 0.03 285);
-  --color-status-active: oklch(0.54 0.16 250);
-  --color-status-blocked: oklch(0.57 0.13 75);
-  --color-status-in-review: oklch(0.54 0.16 305);
-  --color-status-done: oklch(0.56 0.14 150);
-  --color-status-cancelled: oklch(0.6 0.01 285);
-  --color-status-unknown: oklch(0.55 0.15 25);
+  --color-status-active: oklch(0.52 0.16 250);
+  --color-status-blocked: oklch(0.52 0.14 75);
+  --color-status-in-review: oklch(0.52 0.16 305);
+  --color-status-done: oklch(0.50 0.14 150);
+  --color-status-cancelled: oklch(0.50 0.02 285);
+  --color-status-unknown: oklch(0.52 0.15 25);
 
-  --color-accent: oklch(0.58 0.12 195);
+  --color-accent: oklch(0.48 0.12 195);
   --color-accent-fg: oklch(0.99 0.005 195);
 
-  --color-stale: oklch(0.57 0.12 75);
-  --color-danger: oklch(0.54 0.19 25);
+  --color-stale: oklch(0.52 0.12 75);
+  --color-danger: oklch(0.52 0.19 25);
+  --color-success: oklch(0.48 0.13 150);
 
   /* 关系语义轴 — 亮色主题保持色相一致,仅调亮度 */
-  --color-axis-authority: oklch(0.54 0.16 250);
-  --color-axis-evidence: oklch(0.57 0.12 75);
-  --color-axis-execution: oklch(0.56 0.14 150);
+  --color-axis-authority: oklch(0.52 0.16 250);
+  --color-axis-evidence: oklch(0.52 0.12 75);
+  --color-axis-execution: oklch(0.50 0.14 150);
   --color-axis-assoc: oklch(0.46 0.012 285);
 }
 
@@ -90,25 +93,39 @@ body {
   font-size: var(--ui-font-body);
 }
 
+/*
+ * 字阶 token（CJK 底线：中文 ≥12px；micro 仅 mono id）
+ * micro:11 / meta:12 / body:14 / title:16 / heading:20 / prose:15
+ */
 html {
-  --ui-font-meta: 13px;
-  --ui-font-body: 15px;
-  --ui-font-title: 18px;
+  --ui-font-micro: 11px;
+  --ui-font-meta: 12px;
+  --ui-font-body: 14px;
+  --ui-font-title: 16px;
   --ui-font-heading: 20px;
+  --ui-font-prose: 15px;
 }
 
 html[data-ui-scale="compact"] {
+  --ui-font-micro: 11px;
   --ui-font-meta: 12px;
-  --ui-font-body: 14px;
-  --ui-font-title: 17px;
+  --ui-font-body: 13px;
+  --ui-font-title: 15px;
   --ui-font-heading: 18px;
+  --ui-font-prose: 14px;
 }
 
 html[data-ui-scale="comfortable"] {
-  --ui-font-meta: 14px;
-  --ui-font-body: 16px;
-  --ui-font-title: 20px;
+  --ui-font-micro: 12px;
+  --ui-font-meta: 13px;
+  --ui-font-body: 15px;
+  --ui-font-title: 18px;
   --ui-font-heading: 22px;
+  --ui-font-prose: 16px;
+}
+
+.ui-micro {
+  font-size: var(--ui-font-micro);
 }
 
 .ui-meta {
@@ -127,6 +144,10 @@ html[data-ui-scale="comfortable"] {
   font-size: var(--ui-font-heading);
 }
 
+.ui-prose {
+  font-size: var(--ui-font-prose);
+}
+
 ::selection {
   background: oklch(0.45 0.08 250);
 }
@@ -137,9 +158,10 @@ html[data-theme="light"] ::selection {
 
 /* 文档阅读区排版（react-markdown 输出） */
 .prose-harness {
-  font-size: var(--ui-font-body);
-  line-height: 1.7;
+  font-size: var(--ui-font-prose);
+  line-height: 1.75;
   color: var(--color-text);
+  max-width: 42rem;
 }
 .prose-harness h1 {
   font-size: var(--ui-font-heading);
@@ -154,12 +176,12 @@ html[data-theme="light"] ::selection {
 }
 .prose-harness p {
   margin: 0.6rem 0;
-  color: var(--color-text-muted);
+  color: var(--color-text);
 }
 .prose-harness ul {
   padding-left: 1.25rem;
   list-style: disc;
-  color: var(--color-text-muted);
+  color: var(--color-text);
 }
 .prose-harness li {
   margin: 0.25rem 0;
@@ -210,7 +232,7 @@ html[data-theme="light"] ::selection {
   border-left: 2px solid var(--color-border-strong);
   padding-left: 1rem;
   margin: 0.75rem 0;
-  color: var(--color-text-faint);
+  color: var(--color-text-muted);
 }
 .prose-harness input[type="checkbox"] {
   accent-color: var(--color-accent);


### PR DESCRIPTION
# English

## Summary

Repair the GUI design-token layer: add the missing `--color-success`, lift every foreground token that actually failed WCAG AA contrast (in **both** themes), give long prose a readable measure, and complete the `--ui-font-*` scale.

One file changed: `packages/gui/src/renderer/styles.css`.

## What Changed

- **`--color-success` added** (dark `oklch(0.80 0.13 150)` = 10.08:1, light `oklch(0.48 0.13 150)` = 5.56:1). `badges.tsx:182` referenced `text-success`, a token that **did not exist** — decision `active` badges rendered with no colour at all.
- **Dark theme**: `text-muted` 0.74→0.80, `text-faint` 0.62→0.72, the six `status-*` colours to L≈0.78, `cancelled` 0.55→0.68, `danger` 0.65→0.72. Only `cancelled` (3.69:1) genuinely failed AA; the rest gain headroom.
- **Light theme**: 8 tokens (`faint`, `blocked`, `done`, `cancelled`, `accent`, `stale`, …) measured **below 4.5:1** against `--color-bg`. Lightness lowered so all now pass AA. Light — not dark — was the real problem surface.
- **`.prose-harness`**: `max-width: 42rem` (CJK reads at 32–40 chars/line), `line-height: 1.75`, body text colour `text-muted` → `text`, font size driven by `--ui-font-prose`.
- **Font scale completed**: `micro:11 / meta:12 / body:14 / title:16 / heading:20 / prose:15`, with `compact` and `comfortable` variants. This unblocks a later codemod of the ~618 hardcoded `text-[Npx]` occurrences; **that codemod is not in this PR.**

## Task And Scope

- Harness task: `task_01KXE5SP9YG6YRY5BTHQ6NQ77A` (GUI-D), parent `task_01KWGEE4WVM6C702RQP9TX9A9C`
- Branch: `fix/gui-design-tokens`
- Public scope: `packages/gui/src/renderer/styles.css` only
- Private planning/evidence updated: yes
- Out of scope: the `text-[Npx]` → token codemod (~40 renderer files, would collide with in-flight i18n work); axis-colour line-style channel; per-entity colour tokens

## Version Impact

- Version: no version change because this is an internal GUI stylesheet fix with no package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KXE3RQR6A0EXQ1CEGDASM6ES` (GUI readability adjudication)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `6058149a5cb9a4de88dc7913338f10ec3d651218`
- Branch merge-base with `origin/main`: `6058149a5cb9a4de88dc7913338f10ec3d651218` (identical — branch is exactly 1 commit ahead, 0 behind)
- Last `git fetch origin` time: immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff 6058149a..fd2e1847 -- packages/gui/src/renderer/styles.css`
- Private evidence commit/path: `harness/tasks/task_01KXE5SP9YG6YRY5BTHQ6NQ77A-gui-d-token-color-success-wcag-aa/`
- Reviewer evidence path: `harness/context/research/2026-07-13-gui-ux-audit/G5-P0-report.md`
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `npm run check:ci` (derives and runs all 13 pull_request gate jobs from `tools/gate-manifest.json`) — reported all green locally
- [ ] GitHub Actions `rewrite-ci` passed — **CI on this PR is the authoritative gate; local green is an assertion, not proof**
- Not run: nothing skipped

**Contrast figures were independently recomputed, not taken on trust.** The upstream audit's dark-theme numbers were systematically wrong. Recomputing OKLch → linear sRGB → WCAG relative luminance against `--color-bg` on the *old* values:

| token | audit claimed | independently measured |
|---|---|---|
| `text-muted` | 3.65:1 | **7.76:1** |
| `text-faint` | 1.89:1 | **4.91:1** |
| `status-cancelled` | 1.44:1 | **3.69:1** |
| `status-planned` | 3.22:1 | **7.19:1** |
| `danger` | 3.7:1 | **5.09:1** |

Only `cancelled` genuinely failed AA in dark mode. The audit's "light theme all pass ≥7:1" claim was inverted — light was the failing surface. This PR fixes the real failures and raises headroom on the rest.

## Review Evidence

- Self-review: full diff read; contrast maths recomputed from first principles by the author
- Reviewer subagent: implementation by a frontend worker; its contrast figures independently reproduced and confirmed
- Human review: pending
- Blocking findings: none

## Residual Risk

- Raising all `status-*` to a uniform L≈0.78 preserves the equal-luminance intent but shifts perceived weight slightly; visual check on a real ledger is the acceptance step.
- The ~618 hardcoded `text-[Npx]` occurrences still bypass the token scale. The scale now exists; the codemod is deliberately deferred to avoid colliding with in-flight work.

## References

- Task: `task_01KXE5SP9YG6YRY5BTHQ6NQ77A`
- Evidence: `harness/context/research/2026-07-13-gui-ux-audit/G5-P0-report.md`
- Review: `dec_01KXE3RQR6A0EXQ1CEGDASM6ES`

---

# 中文

## 概要

修复 GUI 设计 token 层：补上缺失的 `--color-success`，把**亮暗两个主题**下真正挂 WCAG AA 的前景色全部抬到线上，给长正文一个可读的行宽，并补全 `--ui-font-*` 字阶。

单文件改动：`packages/gui/src/renderer/styles.css`。

## 改动内容

- **补 `--color-success`**（暗色 `oklch(0.80 0.13 150)` = 10.08:1，亮色 `oklch(0.48 0.13 150)` = 5.56:1）。`badges.tsx:182` 引用了 `text-success`——一个**根本不存在**的 token，导致 decision `active` 徽章完全无色。
- **暗色主题**：`text-muted` 0.74→0.80、`text-faint` 0.62→0.72、六个 `status-*` 统一到 L≈0.78、`cancelled` 0.55→0.68、`danger` 0.65→0.72。暗色下**真正**挂 AA 的只有 `cancelled`（3.69:1），其余是抬余量。
- **亮色主题**：8 个 token（`faint` / `blocked` / `done` / `cancelled` / `accent` / `stale` 等）实测对 `--color-bg` **低于 4.5:1**，压亮度后全部过 AA。**亮色才是重灾区，不是暗色。**
- **`.prose-harness`**：`max-width: 42rem`（中文 32–40 字/行）、`line-height: 1.75`、正文色从 `text-muted` 改回 `text`、字号走 `--ui-font-prose`。
- **补全字阶**：`micro:11 / meta:12 / body:14 / title:16 / heading:20 / prose:15`，含 `compact` / `comfortable` 两档。这为后续把 ~618 处硬编码 `text-[Npx]` 收进 token 的 codemod 铺路；**那个 codemod 不在本 PR。**

## 任务与范围

- Harness 任务：`task_01KXE5SP9YG6YRY5BTHQ6NQ77A`（GUI-D），父任务 `task_01KWGEE4WVM6C702RQP9TX9A9C`
- 分支：`fix/gui-design-tokens`
- 公开范围：仅 `packages/gui/src/renderer/styles.css`
- 私有计划 / 证据是否已更新：yes
- 范围外：`text-[Npx]` → token 的 codemod（涉及约 40 个 renderer 文件，会与在飞的 i18n 线撞车）；轴色改线型通道；per-entity 分色 token

## 版本影响

- 版本：不改版本，原因是这是 GUI 内部样式表修复，不改任何包对外表面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`dec_01KXE3RQR6A0EXQ1CEGDASM6ES`（GUI 可读性裁决）
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`6058149a5cb9a4de88dc7913338f10ec3d651218`
- 当前分支与 `origin/main` 的 merge-base：`6058149a5cb9a4de88dc7913338f10ec3d651218`（完全一致——分支正好领先 1 个 commit，落后 0）
- 最近一次 `git fetch origin` 时间：开 PR 前刚跑
- 同步方式：不需要
- 公开 diff 命令：`git diff 6058149a..fd2e1847 -- packages/gui/src/renderer/styles.css`
- 私有证据 commit/path：`harness/tasks/task_01KXE5SP9YG6YRY5BTHQ6NQ77A-gui-d-token-color-success-wcag-aa/`
- Reviewer 证据路径：`harness/context/research/2026-07-13-gui-ux-audit/G5-P0-report.md`
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [x] `npm run check:ci`（从 `tools/gate-manifest.json` 派生并逐个执行 CI 在 pull_request 上跑的全部 13 个 job）——本地报全绿
- [ ] GitHub Actions `rewrite-ci` passed —— **本 PR 上的 CI 才是权威门；本地绿是断言，不是证据**
- 未运行：无

**对比度数字是独立复算的，不是照抄的。** 上游审计的暗色数字系统性错误。把**旧值**按 OKLch → linear sRGB → WCAG relative luminance 对 `--color-bg` 重算：

| token | 审计声称 | 独立实测 |
|---|---|---|
| `text-muted` | 3.65:1 | **7.76:1** |
| `text-faint` | 1.89:1 | **4.91:1** |
| `status-cancelled` | 1.44:1 | **3.69:1** |
| `status-planned` | 3.22:1 | **7.19:1** |
| `danger` | 3.7:1 | **5.09:1** |

暗色下真正挂 AA 的只有 `cancelled` 一个。审计「亮色全过 ≥7:1」的结论完全反了——亮色才是挂的那一面。本 PR 修真实的失败项，并给其余项抬余量。

## 审查证据

- 自查：全量读 diff；对比度换算由作者从第一性原理重算
- Reviewer subagent：由前端 worker 实现；其对比度数字已被独立复现并确认
- 人工审查：待办
- 阻塞发现：无

## 残余风险

- 把所有 `status-*` 统一抬到 L≈0.78 保持了等亮度意图，但会轻微改变视觉权重；在真实账本上肉眼验收是收口步骤。
- ~618 处硬编码 `text-[Npx]` 仍绕过字阶 token。字阶现在存在了，codemod 有意延后以避开在飞工作的冲突。

## 关联材料

- 任务：`task_01KXE5SP9YG6YRY5BTHQ6NQ77A`
- 证据：`harness/context/research/2026-07-13-gui-ux-audit/G5-P0-report.md`
- 审查：`dec_01KXE3RQR6A0EXQ1CEGDASM6ES`
