### PR TITLE
perf(gui): isolate execution evidence projection

### DIFF
--- a/packages/kernel/src/layout/index.ts
+++ b/packages/kernel/src/layout/index.ts
@@ -38,6 +38,7 @@ export interface HarnessLayout {
   readonly attributionEventsRoot: string;
   readonly cacheRoot: string;
   readonly projectionPath: string;
+  readonly executionEvidenceProjectionPath: string;
   readonly writeJournalRoot: string;
   readonly journalPath: string;
   readonly watermarkPath: string;
@@ -187,6 +188,7 @@ function buildHarnessLayout(settings: HarnessLayoutSettings): HarnessLayout {
     attributionEventsRoot: path.join(authoredRoot, "attribution-events"),
     cacheRoot: path.join(localRoot, "cache"),
     projectionPath: path.join(localRoot, "cache", "projections.sqlite"),
+    executionEvidenceProjectionPath: path.join(localRoot, "cache", "execution-evidence.sqlite"),
     writeJournalRoot,
     journalPath: path.join(writeJournalRoot, "writes.jsonl"),
     watermarkPath: path.join(writeJournalRoot, "watermark.json"),

--- a/packages/kernel/src/local/local-layout-file-system.ts
+++ b/packages/kernel/src/local/local-layout-file-system.ts
@@ -16,6 +16,7 @@ export const localEvidenceFileSystem = {
 };
 
 export const localProjectionSourceFileSystem = {
+  realpath: (inputPath: string): string => realpathSync.native(inputPath),
   readStableDirents: (inputPath: string): { readonly entries: ReadonlyArray<Dirent<string>>; readonly signature: string } => {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const before = projectionSourceStatSignature(inputPath);

--- a/packages/kernel/src/projection/execution-evidence-source.ts
+++ b/packages/kernel/src/projection/execution-evidence-source.ts
@@ -1,0 +1,240 @@
+import path from "node:path";
+import { executionDeclaration } from "../entity/execution-declaration.ts";
+import { sha256Text, stablePayloadHash } from "../integrity/stable-hash.ts";
+import type { HarnessLayoutInput } from "../layout/index.ts";
+import { resolveHarnessLayout } from "../layout/index.ts";
+import { localProjectionSourceFileSystem } from "../local/local-layout-file-system.ts";
+import { readFrontmatter, readScalar } from "../markdown/frontmatter.ts";
+import {
+  projectDeclaredEntitySource,
+  readDeclaredEntitySource,
+  type DeclaredEntitySourceHint,
+  type DeclaredEntitySourceInput,
+  type DeclaredEntitySourceResult,
+  type DeclaredProjectionRow
+} from "./entity-declaration-projection.ts";
+import type {
+  DeclaredEntitySourceSnapshot,
+  DeclaredProjectionSnapshot
+} from "./projection-source-snapshot.ts";
+
+export interface ExecutionEvidenceTaskTitleRow {
+  readonly taskId: string;
+  readonly title: string;
+}
+
+export interface ExecutionEvidenceSourceSnapshot {
+  readonly taskTitles: ReadonlyArray<ExecutionEvidenceTaskTitleRow>;
+  readonly executionRows: ReadonlyArray<DeclaredProjectionRow>;
+  readonly executionTable: DeclaredProjectionSnapshot;
+  readonly sourceHash: string;
+}
+
+export interface IncrementalExecutionEvidenceSourceSnapshot {
+  readonly taskTitles: ReadonlyArray<ExecutionEvidenceTaskTitleRow>;
+  readonly executionSource: DeclaredEntitySourceSnapshot;
+  readonly sourceHash: string;
+}
+
+export function captureStableExecutionEvidenceSource(
+  rootInput: HarnessLayoutInput
+): ExecutionEvidenceSourceSnapshot {
+  let previous = captureExecutionEvidenceSource(rootInput);
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const current = captureExecutionEvidenceSource(rootInput);
+    if (current.sourceHash === previous.sourceHash) return current;
+    previous = current;
+  }
+  throw new Error("execution evidence authored sources did not stabilize");
+}
+
+export function captureExecutionEvidenceTaskTitles(
+  rootInput: HarnessLayoutInput
+): ReadonlyArray<ExecutionEvidenceTaskTitleRow> {
+  return readExecutionEvidenceTaskTitles(rootInput);
+}
+
+export function captureStableIncrementalExecutionEvidenceSource(
+  rootInput: HarnessLayoutInput,
+  taskTitles: ReadonlyArray<ExecutionEvidenceTaskTitleRow>,
+  sourceHints: ReadonlyArray<DeclaredEntitySourceHint>,
+  touchedPaths: ReadonlyArray<string>
+): IncrementalExecutionEvidenceSourceSnapshot {
+  let previous = captureIncrementalExecutionEvidenceSource(rootInput, taskTitles, sourceHints, touchedPaths);
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const current = captureIncrementalExecutionEvidenceSource(rootInput, taskTitles, sourceHints, touchedPaths);
+    if (current.sourceHash === previous.sourceHash) return current;
+    previous = current;
+  }
+  throw new Error("incremental execution evidence authored sources did not stabilize");
+}
+
+export function executionEvidenceTaskTitleSourceTouched(
+  rootInput: HarnessLayoutInput,
+  touchedPaths: ReadonlyArray<string>
+): boolean {
+  const tasksRoot = canonicalProjectionSourcePath(resolveHarnessLayout(rootInput).tasksRoot);
+  return touchedPaths.some((inputPath) => {
+    const relative = path.relative(tasksRoot, canonicalProjectionSourcePath(inputPath));
+    return relative !== "" &&
+      !relative.startsWith("..") &&
+      !path.isAbsolute(relative) &&
+      path.basename(relative) === "INDEX.md";
+  });
+}
+
+function captureExecutionEvidenceSource(
+  rootInput: HarnessLayoutInput
+): ExecutionEvidenceSourceSnapshot {
+  const taskTitles = readExecutionEvidenceTaskTitles(rootInput);
+  const executionSource = readDeclaredEntitySource(rootInput, executionDeclaration);
+  const executions = projectDeclaredEntitySource(rootInput, executionDeclaration, executionSource);
+  const executionTable = {
+    declaration: executionDeclaration,
+    table: executionDeclaration.projection.table,
+    rows: executions.rows,
+    documents: executions.documents
+  } satisfies DeclaredProjectionSnapshot;
+  return {
+    taskTitles,
+    executionRows: executions.rows,
+    executionTable,
+    sourceHash: executionEvidenceSourceHash(taskTitles, executionSource.hash)
+  };
+}
+
+function captureIncrementalExecutionEvidenceSource(
+  rootInput: HarnessLayoutInput,
+  taskTitles: ReadonlyArray<ExecutionEvidenceTaskTitleRow>,
+  sourceHints: ReadonlyArray<DeclaredEntitySourceHint>,
+  touchedPaths: ReadonlyArray<string>
+): IncrementalExecutionEvidenceSourceSnapshot {
+  const source = readIncrementalExecutionSource(rootInput, sourceHints, touchedPaths);
+  return {
+    taskTitles,
+    executionSource: {
+      declaration: executionDeclaration,
+      table: executionDeclaration.projection.table,
+      source
+    },
+    sourceHash: executionEvidenceSourceHash(taskTitles, source.hash)
+  };
+}
+
+function readIncrementalExecutionSource(
+  rootInput: HarnessLayoutInput,
+  sourceHints: ReadonlyArray<DeclaredEntitySourceHint>,
+  touchedPaths: ReadonlyArray<string>
+): DeclaredEntitySourceResult {
+  const authoredRoot = canonicalProjectionSourcePath(resolveHarnessLayout(rootInput).authoredRoot);
+  const touchedSourcePaths = new Set(touchedPaths
+    .map((inputPath) => relativeExecutionSourcePath(authoredRoot, inputPath))
+    .filter((sourcePath): sourcePath is string => sourcePath !== undefined));
+  const previousInputs = sourceHints
+    .filter((hint) => hint.sourceKind === executionDeclaration.kind)
+    .map((hint) => ({
+      relativePath: hint.sourcePath,
+      statSignature: hint.statSignature,
+      contentSha256: hint.contentSha256
+    }));
+  const inputs: DeclaredEntitySourceInput[] = previousInputs
+    .filter((input) => !touchedSourcePaths.has(input.relativePath));
+  for (const sourcePath of touchedSourcePaths) {
+    const current = readExecutionSourceInput(authoredRoot, sourcePath);
+    if (current) inputs.push(current);
+  }
+  inputs.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+  return {
+    inputs,
+    hash: stablePayloadHash({
+      schema: "declared-entity-source/v1",
+      kind: executionDeclaration.kind,
+      inputs: inputs.map(({ relativePath, contentSha256 }) => ({ relativePath, contentSha256 }))
+    }),
+    stats: {
+      directoriesVisited: 0,
+      entriesVisited: touchedSourcePaths.size,
+      filesMatched: inputs.length,
+      cacheHit: true
+    }
+  };
+}
+
+function readExecutionSourceInput(
+  authoredRoot: string,
+  sourcePath: string
+): DeclaredEntitySourceInput | undefined {
+  const documentPath = path.join(authoredRoot, sourcePath);
+  if (localProjectionSourceFileSystem.statSignature(documentPath) === null) return undefined;
+  const source = localProjectionSourceFileSystem.readStableText(documentPath);
+  return {
+    relativePath: sourcePath,
+    body: source.body,
+    statSignature: source.signature,
+    contentSha256: sha256Text(source.body)
+  };
+}
+
+function relativeExecutionSourcePath(authoredRoot: string, inputPath: string): string | undefined {
+  const relative = path.relative(authoredRoot, canonicalProjectionSourcePath(inputPath));
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) return undefined;
+  const sourcePath = relative.split(path.sep).join("/");
+  return /^tasks\/[^/]+\/executions\/[^/]+\.md$/u.test(sourcePath) ? sourcePath : undefined;
+}
+
+function canonicalProjectionSourcePath(inputPath: string): string {
+  let current = path.resolve(inputPath);
+  const suffix: string[] = [];
+  while (true) {
+    try {
+      return path.join(localProjectionSourceFileSystem.realpath(current), ...suffix.reverse());
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) return path.resolve(inputPath);
+      suffix.push(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+function executionEvidenceSourceHash(
+  taskTitles: ReadonlyArray<ExecutionEvidenceTaskTitleRow>,
+  executionSourceHash: string
+): string {
+  return stablePayloadHash({
+    schema: "execution-evidence-source/v1",
+    taskTitles,
+    executionSourceHash
+  });
+}
+
+function readExecutionEvidenceTaskTitles(rootInput: HarnessLayoutInput): ReadonlyArray<ExecutionEvidenceTaskTitleRow> {
+  const tasksRoot = resolveHarnessLayout(rootInput).tasksRoot;
+  if (localProjectionSourceFileSystem.statSignature(tasksRoot) === null) return [];
+  const directory = localProjectionSourceFileSystem.readStableDirents(tasksRoot);
+  const rows: ExecutionEvidenceTaskTitleRow[] = [];
+  const signatures = new Map<string, string>();
+  for (const entry of directory.entries) {
+    if (!entry.isDirectory()) continue;
+    const indexPath = path.join(tasksRoot, entry.name, "INDEX.md");
+    if (localProjectionSourceFileSystem.statSignature(indexPath) === null) continue;
+    const source = localProjectionSourceFileSystem.readStableText(indexPath);
+    signatures.set(indexPath, source.signature);
+    const frontmatter = readFrontmatter(source.body);
+    if (!frontmatter) continue;
+    const taskId = readScalar(frontmatter, "task_id") || entry.name;
+    rows.push({
+      taskId,
+      title: readScalar(frontmatter, "title") || taskId
+    });
+  }
+  if (localProjectionSourceFileSystem.statSignature(tasksRoot) !== directory.signature) {
+    throw new Error("execution evidence task-title directory changed while reading");
+  }
+  for (const [indexPath, signature] of signatures) {
+    if (localProjectionSourceFileSystem.statSignature(indexPath) !== signature) {
+      throw new Error(`execution evidence task title changed while reading: ${indexPath}`);
+    }
+  }
+  return rows.sort((left, right) => left.taskId.localeCompare(right.taskId));
+}

--- a/packages/kernel/src/projection/projection-generation-readiness.ts
+++ b/packages/kernel/src/projection/projection-generation-readiness.ts
@@ -75,7 +75,7 @@ export function ensureProjectionGenerationReady(
     const projection = readTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides });
     warnings.push(...projection.warnings);
     observer?.afterProjectionValidated?.();
-    const snapshot = captureStableProjectionDatabaseIdentity(projectionPath);
+    const snapshot = captureStableProjectionDatabaseIdentity(projectionPath, projectionVersion);
     if (before !== null && before === snapshot.databaseSignature) {
       return {
         ready: new ReadyProjectionGenerationHandle(
@@ -89,6 +89,19 @@ export function ensureProjectionGenerationReady(
     }
   }
   throw new ProjectionGenerationChangedError("projection database did not stabilize across validation");
+}
+
+export function establishReadyProjectionGeneration(
+  projectionPath: string,
+  expectedVersion: string
+): ReadyProjectionGeneration {
+  const snapshot = captureStableProjectionDatabaseIdentity(projectionPath, expectedVersion);
+  return new ReadyProjectionGenerationHandle(
+    projectionPath,
+    snapshot.sourceHash,
+    snapshot.version,
+    snapshot.databaseSignature
+  );
 }
 
 export function assertReadyProjectionGeneration(
@@ -112,7 +125,7 @@ export function projectionDatabaseSignature(projectionPath: string): string {
   return signature;
 }
 
-function captureStableProjectionDatabaseIdentity(projectionPath: string): {
+function captureStableProjectionDatabaseIdentity(projectionPath: string, expectedVersion: string): {
   readonly sourceHash: string;
   readonly version: string;
   readonly databaseSignature: string;
@@ -135,7 +148,7 @@ function captureStableProjectionDatabaseIdentity(projectionPath: string): {
     }
     const after = projectionDatabaseSignature(projectionPath);
     if (before === after) {
-      if (version !== projectionVersion) throw new ProjectionGenerationChangedError("ready projection schema version changed");
+      if (version !== expectedVersion) throw new ProjectionGenerationChangedError("ready projection schema version changed");
       return { sourceHash, version, databaseSignature: after };
     }
   }

--- a/packages/kernel/src/projection/sqlite-execution-evidence-projection.ts
+++ b/packages/kernel/src/projection/sqlite-execution-evidence-projection.ts
@@ -37,18 +37,63 @@ export function applyExecutionEvidenceProjectionDelta(
     for (const id of changedExecutionIds) {
       yield* sql`DELETE FROM execution_evidence_projection WHERE execution_id = ${id}`;
       yield* sql`DELETE FROM execution_output_projection WHERE execution_id = ${id}`;
+      yield* sql`DELETE FROM facet_integrity_leaf WHERE leaf_kind = 'execution' AND entity_id = ${id}`;
     }
     const summaries = executionChange.upsertRows.map(executionSummary);
     for (const rows of chunks(summaries, 250)) yield* insertExecutionSummaryRows(sql, rows);
     const outputs = executionChange.upsertRows.flatMap(executionOutputs);
     for (const rows of chunks(outputs, 250)) yield* insertExecutionOutputRows(sql, rows);
+    for (const row of executionChange.upsertRows) {
+      yield* upsertIntegrityLeaf(sql, executionIntegrityLeaf(row));
+    }
   });
 }
 
-export function hashExecutionEvidenceProjectionState(
+export function replaceExecutionEvidenceFacetIntegrity(
+  sql: SqlClient.SqlClient,
+  taskTitles: ReadonlyArray<{ readonly taskId: string; readonly title: string }>,
+  executionRows: ReadonlyArray<DeclaredProjectionRow>
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    yield* sql`DELETE FROM facet_integrity_leaf`;
+    const leaves = [
+      ...taskTitles.map((row) => taskIntegrityLeaf(row.taskId, row.title)),
+      ...executionRows.map(executionIntegrityLeaf)
+    ];
+    for (const rows of chunks(leaves, 250)) yield* insertIntegrityLeaves(sql, rows);
+  });
+}
+
+export function hashExecutionEvidenceFacetIntegrityState(
   sql: SqlClient.SqlClient
 ): Effect.Effect<string, unknown> {
   return Effect.gen(function* () {
+    const rows = yield* sql<Record<string, unknown>>`
+      SELECT leaf_kind, entity_id, row_hash
+      FROM facet_integrity_leaf
+      ORDER BY leaf_kind, entity_id
+    `;
+    return integrityStateHash(rows.map((row) => ({
+      kind: String(row.leaf_kind),
+      id: String(row.entity_id),
+      rowHash: String(row.row_hash)
+    })));
+  });
+}
+
+export function hashExecutionEvidenceTaskIntegrityLeaf(taskId: string, title: string): string {
+  return taskIntegrityLeaf(taskId, title).rowHash;
+}
+
+export function hashExecutionEvidenceFacetState(
+  sql: SqlClient.SqlClient
+): Effect.Effect<string, unknown> {
+  return Effect.gen(function* () {
+    const taskTitles = yield* sql<Record<string, unknown>>`
+      SELECT task_id, title
+      FROM task_projection
+      ORDER BY task_id
+    `;
     const executions = yield* sql<Record<string, unknown>>`
       SELECT execution_id, task_ref, state, executor_id, executor_kind,
              responsible_human, claimed_at, submitted_at, closed_at, latest_at, archival
@@ -64,11 +109,24 @@ export function hashExecutionEvidenceProjectionState(
       FROM execution_output_projection
       ORDER BY execution_id, ordinal
     `;
-    return stablePayloadHash({
-      schema: "execution-evidence-projection-state/v1",
-      executions,
-      outputs
-    });
+    const outputsByExecution = new Map<string, Array<Record<string, unknown>>>();
+    for (const output of outputs) {
+      const executionId = String(output.execution_id);
+      const existing = outputsByExecution.get(executionId) ?? [];
+      existing.push(output);
+      outputsByExecution.set(executionId, existing);
+    }
+    return integrityStateHash([
+      ...taskTitles.map((row) => taskIntegrityLeaf(String(row.task_id), String(row.title))),
+      ...executions.map((row) => ({
+        kind: "execution",
+        id: String(row.execution_id),
+        rowHash: executionIntegrityHash(
+          executionSummaryValuesFromRecord(row),
+          (outputsByExecution.get(String(row.execution_id)) ?? []).map(executionOutputValuesFromRecord)
+        )
+      }))
+    ]);
   });
 }
 
@@ -114,6 +172,14 @@ function createExecutionEvidenceProjectionTables(sql: SqlClient.SqlClient): Effe
         checker_receipt_ref TEXT,
         PRIMARY KEY (execution_id, evidence_id),
         UNIQUE (execution_id, ordinal)
+      )
+    `;
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS facet_integrity_leaf (
+        leaf_kind TEXT NOT NULL,
+        entity_id TEXT NOT NULL,
+        row_hash TEXT NOT NULL,
+        PRIMARY KEY (leaf_kind, entity_id)
       )
     `;
     yield* sql`
@@ -176,6 +242,108 @@ interface ExecutionOutputInsertRow {
   readonly receiptResult: string | null;
   readonly evidenceSha256: string | null;
   readonly checkerReceiptRef: string | null;
+}
+
+interface IntegrityLeaf {
+  readonly kind: string;
+  readonly id: string;
+  readonly rowHash: string;
+}
+
+function taskIntegrityLeaf(taskId: string, title: string): IntegrityLeaf {
+  return {
+    kind: "task",
+    id: taskId,
+    rowHash: stablePayloadHash({ schema: "execution-evidence-task-integrity/v1", taskId, title })
+  };
+}
+
+function executionIntegrityLeaf(row: DeclaredProjectionRow): IntegrityLeaf {
+  const summary = executionSummary(row);
+  return {
+    kind: "execution",
+    id: summary.executionId,
+    rowHash: executionIntegrityHash(
+      executionSummaryValues(summary),
+      executionOutputs(row).map(executionOutputValues)
+    )
+  };
+}
+
+function executionIntegrityHash(
+  summary: ReadonlyArray<unknown>,
+  outputs: ReadonlyArray<ReadonlyArray<unknown>>
+): string {
+  return stablePayloadHash({
+    schema: "execution-evidence-execution-integrity/v1",
+    summary,
+    outputs
+  });
+}
+
+function integrityStateHash(leaves: ReadonlyArray<IntegrityLeaf>): string {
+  return stablePayloadHash({
+    schema: "execution-evidence-facet-integrity/v2",
+    leaves: [...leaves].sort((left, right) =>
+      left.kind.localeCompare(right.kind) || left.id.localeCompare(right.id))
+  });
+}
+
+function upsertIntegrityLeaf(
+  sql: SqlClient.SqlClient,
+  leaf: IntegrityLeaf
+): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT INTO facet_integrity_leaf (leaf_kind, entity_id, row_hash)
+    VALUES (${leaf.kind}, ${leaf.id}, ${leaf.rowHash})
+    ON CONFLICT (leaf_kind, entity_id) DO UPDATE SET row_hash = excluded.row_hash
+  `;
+}
+
+function insertIntegrityLeaves(
+  sql: SqlClient.SqlClient,
+  leaves: ReadonlyArray<IntegrityLeaf>
+): Effect.Effect<unknown, unknown> {
+  return sql.unsafe(`
+    INSERT INTO facet_integrity_leaf (leaf_kind, entity_id, row_hash)
+    VALUES ${leaves.map(() => "(?, ?, ?)").join(", ")}
+  `, leaves.flatMap((leaf) => [leaf.kind, leaf.id, leaf.rowHash]));
+}
+
+function executionSummaryValues(row: ExecutionSummaryInsertRow): ReadonlyArray<unknown> {
+  return [
+    row.executionId, row.taskRef, row.state, row.executorId, row.executorKind,
+    row.responsibleHuman, row.claimedAt, row.submittedAt, row.closedAt,
+    row.latestAt, row.archival
+  ];
+}
+
+function executionSummaryValuesFromRecord(row: Record<string, unknown>): ReadonlyArray<unknown> {
+  return [
+    row.execution_id, row.task_ref, row.state, row.executor_id, row.executor_kind,
+    row.responsible_human, row.claimed_at, row.submitted_at, row.closed_at,
+    row.latest_at, row.archival
+  ];
+}
+
+function executionOutputValues(row: ExecutionOutputInsertRow): ReadonlyArray<unknown> {
+  return [
+    row.executionId, row.ordinal, row.evidenceId, row.executionRef, row.substrate,
+    row.inlineText, row.filePath, row.url, row.objectRef, row.objectSha256,
+    row.objectSize, row.objectMediaType, row.entityRef, row.checkerId,
+    row.checkerVersion, row.targetEvidenceId, row.targetSha256, row.checkedAt,
+    row.receiptResult, row.evidenceSha256, row.checkerReceiptRef
+  ];
+}
+
+function executionOutputValuesFromRecord(row: Record<string, unknown>): ReadonlyArray<unknown> {
+  return [
+    row.execution_id, row.ordinal, row.evidence_id, row.execution_ref, row.substrate,
+    row.inline_text, row.file_path, row.url, row.object_ref, row.object_sha256,
+    row.object_size, row.object_media_type, row.entity_ref, row.checker_id,
+    row.checker_version, row.target_evidence_id, row.target_sha256, row.checked_at,
+    row.receipt_result, row.evidence_sha256, row.checker_receipt_ref
+  ];
 }
 
 function executionSummary(row: DeclaredProjectionRow): ExecutionSummaryInsertRow {

--- a/packages/kernel/src/projection/sqlite-execution-evidence-reader.ts
+++ b/packages/kernel/src/projection/sqlite-execution-evidence-reader.ts
@@ -3,11 +3,11 @@ import type { HarnessLayoutOverrides } from "../layout/index.ts";
 import {
   assertReadyProjectionDatabaseUnchanged,
   assertReadyProjectionGeneration,
-  ensureProjectionGenerationReady,
   projectionDatabaseSignature,
   ProjectionGenerationChangedError,
   type ReadyProjectionGeneration
 } from "./projection-generation-readiness.ts";
+import { ensureExecutionEvidenceGenerationReady } from "./sqlite-execution-evidence-store.ts";
 
 export interface ExecutionEvidenceCursor {
   readonly generation: string;
@@ -81,7 +81,7 @@ export interface ExecutionEvidenceReadObserver {
 export function queryExecutionEvidencePage(
   options: ExecutionEvidencePageOptions
 ): ExecutionEvidencePage {
-  const ready = ensureProjectionGenerationReady({
+  const ready = ensureExecutionEvidenceGenerationReady({
     rootDir: options.rootDir,
     layoutOverrides: options.layoutOverrides
   }).ready;
@@ -89,7 +89,7 @@ export function queryExecutionEvidencePage(
     return queryExecutionEvidencePageFromReadyGeneration(ready, options);
   } catch (error) {
     if (options.cursor || !(error instanceof ProjectionGenerationChangedError)) throw error;
-    const reacquired = ensureProjectionGenerationReady({
+    const reacquired = ensureExecutionEvidenceGenerationReady({
       rootDir: options.rootDir,
       layoutOverrides: options.layoutOverrides
     }).ready;

--- a/packages/kernel/src/projection/sqlite-execution-evidence-store.ts
+++ b/packages/kernel/src/projection/sqlite-execution-evidence-store.ts
@@ -1,0 +1,325 @@
+import path from "node:path";
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+import type { HarnessLayoutOverrides } from "../layout/index.ts";
+import { createHarnessRuntimeContext, resolveHarnessLayout } from "../layout/index.ts";
+import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
+import {
+  assertReadyProjectionDatabaseUnchanged,
+  establishReadyProjectionGeneration,
+  type ReadyProjectionGeneration
+} from "./projection-generation-readiness.ts";
+import {
+  captureExecutionEvidenceTaskTitles,
+  captureStableExecutionEvidenceSource,
+  captureStableIncrementalExecutionEvidenceSource,
+  executionEvidenceTaskTitleSourceTouched
+} from "./execution-evidence-source.ts";
+import type { ExecutionEvidenceSourceSnapshot } from "./execution-evidence-source.ts";
+import {
+  applyExecutionEvidenceProjectionDelta,
+  hashExecutionEvidenceFacetIntegrityState,
+  hashExecutionEvidenceFacetState,
+  hashExecutionEvidenceTaskIntegrityLeaf,
+  replaceExecutionEvidenceFacetIntegrity,
+  replaceExecutionEvidenceProjectionRows
+} from "./sqlite-execution-evidence-projection.ts";
+import {
+  applyDeclaredSourceManifestDelta,
+  buildDeclaredProjectionDeltaFromSources,
+  declaredSourceManifestRows,
+  readDeclaredSourceManifestRows,
+  replaceDeclaredSourceManifestRows
+} from "./sqlite-declared-source-manifest.ts";
+import { projectionDatabaseFileSignature } from "./sqlite-projection-database-signature.ts";
+import { runSqlite } from "./sqlite-projection-store.ts";
+import type { ProjectionReadResult } from "./types.ts";
+
+export const executionEvidenceProjectionVersion = "execution-evidence/v2";
+
+export interface EnsureExecutionEvidenceGenerationOptions {
+  readonly rootDir: string;
+  readonly layoutOverrides?: HarnessLayoutOverrides;
+}
+
+export interface EnsureExecutionEvidenceGenerationResult {
+  readonly ready: ReadyProjectionGeneration;
+  readonly warnings: ProjectionReadResult["warnings"];
+}
+
+export interface ExecutionEvidenceGenerationObserver {
+  readonly afterProjectionValidated?: () => void;
+}
+
+export interface UpdateExecutionEvidenceGenerationOptions extends EnsureExecutionEvidenceGenerationOptions {
+  readonly touchedPaths: ReadonlyArray<string>;
+  readonly previousSourceFingerprint: string;
+}
+
+export type ExecutionEvidenceUpdateMode = "incremental" | "rebuild" | "unchanged";
+
+interface ExecutionEvidenceMeta {
+  readonly version: string;
+  readonly sourceHash: string;
+  readonly rowsHash: string;
+}
+
+interface ValidatedFacet {
+  readonly signature: string;
+  readonly meta: ExecutionEvidenceMeta;
+}
+
+const validatedFacets = new Map<string, ValidatedFacet>();
+
+export function defaultExecutionEvidenceProjectionPath(rootDir: string): string {
+  return resolveHarnessLayout(rootDir).executionEvidenceProjectionPath;
+}
+
+export function ensureExecutionEvidenceGenerationReady(
+  options: EnsureExecutionEvidenceGenerationOptions,
+  observer?: ExecutionEvidenceGenerationObserver
+): EnsureExecutionEvidenceGenerationResult {
+  const runtimeContext = createHarnessRuntimeContext(options.rootDir, options.layoutOverrides);
+  const projectionPath = resolveHarnessLayout(runtimeContext).executionEvidenceProjectionPath;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const source = captureStableExecutionEvidenceSource(runtimeContext);
+    if (!executionEvidenceProjectionIsCurrent(projectionPath, source.sourceHash)) {
+      writeExecutionEvidenceProjection(projectionPath, source);
+    }
+    observer?.afterProjectionValidated?.();
+    if (!executionEvidenceProjectionIsCurrent(projectionPath, source.sourceHash)) continue;
+    const ready = establishReadyProjectionGeneration(
+      projectionPath,
+      executionEvidenceProjectionVersion
+    );
+    if (ready.sourceHash !== source.sourceHash) continue;
+    const verified = captureStableExecutionEvidenceSource(runtimeContext);
+    if (verified.sourceHash !== source.sourceHash) continue;
+    assertReadyProjectionDatabaseUnchanged(ready);
+    return { ready, warnings: [] };
+  }
+  throw new Error("execution evidence generation did not stabilize");
+}
+
+export function rebuildExecutionEvidenceProjection(
+  options: EnsureExecutionEvidenceGenerationOptions
+): EnsureExecutionEvidenceGenerationResult {
+  const runtimeContext = createHarnessRuntimeContext(options.rootDir, options.layoutOverrides);
+  const projectionPath = resolveHarnessLayout(runtimeContext).executionEvidenceProjectionPath;
+  const source = captureStableExecutionEvidenceSource(runtimeContext);
+  writeExecutionEvidenceProjection(projectionPath, source);
+  return {
+    ready: establishReadyProjectionGeneration(projectionPath, executionEvidenceProjectionVersion),
+    warnings: []
+  };
+}
+
+export function updateExecutionEvidenceProjectionIncrementally(
+  options: UpdateExecutionEvidenceGenerationOptions
+): EnsureExecutionEvidenceGenerationResult & { readonly mode: ExecutionEvidenceUpdateMode } {
+  const runtimeContext = createHarnessRuntimeContext(options.rootDir, options.layoutOverrides);
+  const projectionPath = resolveHarnessLayout(runtimeContext).executionEvidenceProjectionPath;
+  if (!executionEvidenceProjectionIsCurrent(projectionPath, options.previousSourceFingerprint)) {
+    return { ...rebuildExecutionEvidenceProjection(options), mode: "rebuild" };
+  }
+  const previousManifest = readDeclaredSourceManifestRows(projectionPath);
+  const taskTitles = executionEvidenceTaskTitleSourceTouched(runtimeContext, options.touchedPaths)
+    ? captureExecutionEvidenceTaskTitles(runtimeContext)
+    : readProjectedExecutionEvidenceTaskTitles(projectionPath);
+  const source = captureStableIncrementalExecutionEvidenceSource(
+    runtimeContext,
+    taskTitles,
+    previousManifest,
+    options.touchedPaths
+  );
+  if (source.sourceHash === options.previousSourceFingerprint) {
+    return {
+      ready: establishReadyProjectionGeneration(projectionPath, executionEvidenceProjectionVersion),
+      warnings: [],
+      mode: "unchanged"
+    };
+  }
+  const declaredDelta = buildDeclaredProjectionDeltaFromSources(
+    runtimeContext,
+    previousManifest,
+    [source.executionSource]
+  );
+  runSqlite(projectionPath, Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    yield* sql`BEGIN IMMEDIATE`;
+    try {
+      yield* applyExecutionEvidenceProjectionDelta(sql, declaredDelta);
+      yield* applyDeclaredSourceManifestDelta(sql, declaredDelta.manifest);
+      yield* updateTaskTitles(sql, source.taskTitles);
+      yield* sql`UPDATE projection_meta SET value = ${source.sourceHash} WHERE key = 'sourceHash'`;
+      const rowsHash = yield* hashExecutionEvidenceFacetIntegrityState(sql);
+      yield* sql`UPDATE projection_meta SET value = ${rowsHash} WHERE key = 'rowsHash'`;
+      yield* sql`COMMIT`;
+    } catch (error) {
+      yield* sql`ROLLBACK`;
+      throw error;
+    }
+  }));
+  validatedFacets.delete(projectionPath);
+  return {
+    ready: establishReadyProjectionGeneration(projectionPath, executionEvidenceProjectionVersion),
+    warnings: [],
+    mode: "incremental"
+  };
+}
+
+function executionEvidenceProjectionIsCurrent(
+  projectionPath: string,
+  sourceHash: string
+): boolean {
+  if (!localRuntimeStateFileSystem.exists(projectionPath)) return false;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const signature = projectionDatabaseFileSignature(projectionPath);
+    if (signature === null) return false;
+    const cached = validatedFacets.get(projectionPath);
+    if (cached?.signature === signature) {
+      return cached.meta.version === executionEvidenceProjectionVersion &&
+        cached.meta.sourceHash === sourceHash;
+    }
+    try {
+      const meta = readExecutionEvidenceMeta(projectionPath);
+      if (meta.version !== executionEvidenceProjectionVersion || meta.sourceHash !== sourceHash) return false;
+      const hashes = runSqlite(projectionPath, Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        return {
+          rowsHash: yield* hashExecutionEvidenceFacetState(sql),
+          integrityHash: yield* hashExecutionEvidenceFacetIntegrityState(sql)
+        };
+      }));
+      const after = projectionDatabaseFileSignature(projectionPath);
+      if (after === null || after !== signature) continue;
+      if (hashes.rowsHash !== meta.rowsHash || hashes.integrityHash !== meta.rowsHash) return false;
+      validatedFacets.set(projectionPath, { signature: after, meta });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+function writeExecutionEvidenceProjection(
+  projectionPath: string,
+  source: ExecutionEvidenceSourceSnapshot
+): void {
+  localRuntimeStateFileSystem.mkdirp(path.dirname(projectionPath));
+  const tempPath = `${projectionPath}.${process.pid}.${Date.now()}.tmp`;
+  localRuntimeStateFileSystem.remove(tempPath);
+  try {
+    runSqlite(tempPath, Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`PRAGMA journal_mode = DELETE`;
+      yield* sql`BEGIN IMMEDIATE`;
+      try {
+        yield* sql`CREATE TABLE projection_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`;
+        yield* sql`CREATE TABLE task_projection (task_id TEXT PRIMARY KEY, title TEXT NOT NULL)`;
+        for (const rows of chunks(source.taskTitles, 250)) {
+          yield* sql.unsafe(
+            `INSERT INTO task_projection (task_id, title) VALUES ${rows.map(() => "(?, ?)").join(", ")}`,
+            rows.flatMap((row) => [row.taskId, row.title])
+          );
+        }
+        yield* replaceExecutionEvidenceProjectionRows(sql, source.executionRows);
+        yield* replaceExecutionEvidenceFacetIntegrity(sql, source.taskTitles, source.executionRows);
+        yield* replaceDeclaredSourceManifestRows(sql, declaredSourceManifestRows([source.executionTable]));
+        yield* insertExecutionEvidenceMeta(sql, "version", executionEvidenceProjectionVersion);
+        yield* insertExecutionEvidenceMeta(sql, "sourceHash", source.sourceHash);
+        yield* insertExecutionEvidenceMeta(sql, "rowsHash", "");
+        const rowsHash = yield* hashExecutionEvidenceFacetIntegrityState(sql);
+        yield* sql`UPDATE projection_meta SET value = ${rowsHash} WHERE key = 'rowsHash'`;
+        yield* sql`COMMIT`;
+      } catch (error) {
+        yield* sql`ROLLBACK`;
+        throw error;
+      }
+    }));
+    localRuntimeStateFileSystem.rename(tempPath, projectionPath);
+    validatedFacets.delete(projectionPath);
+  } catch (error) {
+    localRuntimeStateFileSystem.remove(tempPath);
+    throw error;
+  }
+}
+
+function updateTaskTitles(
+  sql: SqlClient.SqlClient,
+  currentRows: ReadonlyArray<{ readonly taskId: string; readonly title: string }>
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    const existingRows = yield* sql<{ readonly task_id: unknown; readonly title: unknown }>`
+      SELECT task_id, title FROM task_projection
+    `;
+    const existing = new Map(existingRows.map((row) => [String(row.task_id), String(row.title)]));
+    const currentIds = new Set(currentRows.map((row) => row.taskId));
+    for (const taskId of existing.keys()) {
+      if (!currentIds.has(taskId)) {
+        yield* sql`DELETE FROM task_projection WHERE task_id = ${taskId}`;
+        yield* sql`DELETE FROM facet_integrity_leaf WHERE leaf_kind = 'task' AND entity_id = ${taskId}`;
+      }
+    }
+    for (const row of currentRows) {
+      if (existing.get(row.taskId) === row.title) continue;
+      yield* sql`
+        INSERT INTO task_projection (task_id, title) VALUES (${row.taskId}, ${row.title})
+        ON CONFLICT (task_id) DO UPDATE SET title = excluded.title
+      `;
+      const rowHash = hashExecutionEvidenceTaskIntegrityLeaf(row.taskId, row.title);
+      yield* sql`
+        INSERT INTO facet_integrity_leaf (leaf_kind, entity_id, row_hash)
+        VALUES ('task', ${row.taskId}, ${rowHash})
+        ON CONFLICT (leaf_kind, entity_id) DO UPDATE SET row_hash = excluded.row_hash
+      `;
+    }
+  });
+}
+
+function readExecutionEvidenceMeta(projectionPath: string): ExecutionEvidenceMeta {
+  return runSqlite(projectionPath, Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const rows = yield* sql<{ readonly key: unknown; readonly value: unknown }>`
+      SELECT key, value FROM projection_meta
+    `;
+    const meta = new Map(rows.map((row) => [String(row.key), String(row.value)]));
+    return {
+      version: meta.get("version") ?? "",
+      sourceHash: meta.get("sourceHash") ?? "",
+      rowsHash: meta.get("rowsHash") ?? ""
+    };
+  }));
+}
+
+function readProjectedExecutionEvidenceTaskTitles(
+  projectionPath: string
+): ReadonlyArray<{ readonly taskId: string; readonly title: string }> {
+  return runSqlite(projectionPath, Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const rows = yield* sql<{ readonly task_id: unknown; readonly title: unknown }>`
+      SELECT task_id, title FROM task_projection ORDER BY task_id
+    `;
+    return rows.map((row) => ({ taskId: String(row.task_id), title: String(row.title) }));
+  }));
+}
+
+function insertExecutionEvidenceMeta(
+  sql: SqlClient.SqlClient,
+  key: string,
+  value: string
+): Effect.Effect<unknown, unknown> {
+  return sql`INSERT INTO projection_meta (key, value) VALUES (${key}, ${value})`;
+}
+
+function chunks<Value>(
+  values: ReadonlyArray<Value>,
+  size: number
+): ReadonlyArray<ReadonlyArray<Value>> {
+  const output: Value[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    output.push(values.slice(index, index + size));
+  }
+  return output;
+}

--- a/packages/kernel/src/projection/sqlite-projection-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-store.ts
@@ -20,9 +20,8 @@ import type {
   TaskProjectionQueryFilters,
   TaskProjectionRow
 } from "./types.ts";
-import { hashExecutionEvidenceProjectionState } from "./sqlite-execution-evidence-projection.ts";
 
-export const projectionVersion = "entity-projection/d4-v12";
+export const projectionVersion = "entity-projection/d4-v13";
 const baseTaskProjectionColumns = [
   "task_id",
   "title",
@@ -160,7 +159,6 @@ export function writeProjectionDatabase(
     yield* insertMeta(sql, "decisionRowsHash", meta.decisionRowsHash ?? "");
     yield* insertMeta(sql, "declaredRowsHash", meta.declaredRowsHash ?? "");
     yield* insertMeta(sql, "declaredManifestHash", meta.declaredManifestHash ?? "");
-    yield* insertMeta(sql, "executionEvidenceRowsHash", meta.executionEvidenceRowsHash ?? "");
     yield* insertMeta(sql, "attributionRowsHash", meta.attributionRowsHash ?? "");
     yield* insertMeta(sql, "attributionSourceHash", meta.attributionSourceHash ?? "");
     yield* insertMeta(sql, "taskSourceHash", meta.taskSourceHash ?? "");
@@ -181,8 +179,6 @@ export function writeProjectionDatabase(
     yield* sql`CREATE INDEX relation_coverage_decision_ref ON relation_coverage (decision_ref)`;
     yield* sql`CREATE INDEX task_fact_anchors_task_id ON task_fact_anchors (task_id)`;
     if (materializeSupplemental) yield* materializeSupplemental(sql);
-    const executionEvidenceRowsHash = yield* hashExecutionEvidenceProjectionState(sql);
-    yield* sql`UPDATE projection_meta SET value = ${executionEvidenceRowsHash} WHERE key = 'executionEvidenceRowsHash'`;
     const attributionRowsHash = yield* hashAttributionProjectionState(sql);
     yield* sql`UPDATE projection_meta SET value = ${attributionRowsHash} WHERE key = 'attributionRowsHash'`;
   });
@@ -307,7 +303,6 @@ function readProjectionDatabase(
         decisionRowsHash: meta.get("decisionRowsHash") ?? "",
         declaredRowsHash: meta.get("declaredRowsHash") ?? "",
         declaredManifestHash: meta.get("declaredManifestHash") ?? "",
-        executionEvidenceRowsHash: meta.get("executionEvidenceRowsHash") ?? "",
         attributionRowsHash: meta.get("attributionRowsHash") ?? "",
         attributionSourceHash: meta.get("attributionSourceHash") ?? "",
         taskSourceHash: meta.get("taskSourceHash") ?? "",

--- a/packages/kernel/src/projection/sqlite-projection-update-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-update-store.ts
@@ -5,10 +5,6 @@ import type { ProjectionGraphRows } from "./sqlite-projection-store.ts";
 import { deleteDeclaredProjectionRows, upsertDeclaredProjectionRows } from "./entity-declaration-projection.ts";
 import { applyDeclaredSourceManifestDelta, type DeclaredProjectionDelta } from "./sqlite-declared-source-manifest.ts";
 import {
-  applyExecutionEvidenceProjectionDelta,
-  hashExecutionEvidenceProjectionState
-} from "./sqlite-execution-evidence-projection.ts";
-import {
   applyProjectionSourceCacheChange,
   type ProjectionSourceCacheChange
 } from "./sqlite-projection-source-cache.ts";
@@ -74,7 +70,6 @@ export function updateProjectionDatabase(
         yield* deleteDeclaredProjectionRows(sql, table.declaration, table.deletePrimaryKeys);
         yield* upsertDeclaredProjectionRows(sql, table.declaration, table.upsertRows);
       }
-      yield* applyExecutionEvidenceProjectionDelta(sql, change.declaredDelta);
       yield* applyDeclaredSourceManifestDelta(sql, change.declaredDelta.manifest);
       if (change.sourceCache) yield* applyProjectionSourceCacheChange(sql, change.sourceCache);
       if (change.attributionDelta) {
@@ -89,10 +84,6 @@ export function updateProjectionDatabase(
       yield* upsertMeta(sql, "decisionRowsHash", change.meta.decisionRowsHash ?? "");
       yield* upsertMeta(sql, "declaredRowsHash", change.meta.declaredRowsHash ?? "");
       yield* upsertMeta(sql, "declaredManifestHash", change.meta.declaredManifestHash ?? "");
-      const executionEvidenceRowsHash = executionEvidenceChanged(change.declaredDelta) || !change.meta.executionEvidenceRowsHash
-        ? yield* hashExecutionEvidenceProjectionState(sql)
-        : change.meta.executionEvidenceRowsHash;
-      yield* upsertMeta(sql, "executionEvidenceRowsHash", executionEvidenceRowsHash);
       const attributionRowsHash = reuseAttributionRowsHash && change.meta.attributionRowsHash
         ? change.meta.attributionRowsHash
         : yield* hashAttributionProjectionState(sql);
@@ -107,11 +98,6 @@ export function updateProjectionDatabase(
       throw error;
     }
   }));
-}
-
-function executionEvidenceChanged(delta: DeclaredProjectionDelta): boolean {
-  const executionTable = delta.tables.find((table) => table.declaration.projection.table === "execution_projection");
-  return Boolean(executionTable && (executionTable.deletePrimaryKeys.length > 0 || executionTable.upsertRows.length > 0));
 }
 
 function canReuseAttributionRowsHash(

--- a/packages/kernel/src/projection/sqlite-task-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-projection.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { SqlClient } from "@effect/sql";
 import { Effect } from "effect";
 import { createHarnessRuntimeContext } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
@@ -16,7 +15,6 @@ import {
   queryTaskSubtreeRows,
   readAttributionProjectionStateHash,
   readRelationGraphRows,
-  runSqlite,
   writeProjectionDatabase,
   tryReadProjectionDatabase
 } from "./sqlite-projection-store.ts";
@@ -30,10 +28,6 @@ import {
   replaceDeclaredSourceManifestRows
 } from "./sqlite-declared-source-manifest.ts";
 import { updateProjectionDatabase } from "./sqlite-projection-update-store.ts";
-import {
-  hashExecutionEvidenceProjectionState,
-  replaceExecutionEvidenceProjectionRows
-} from "./sqlite-execution-evidence-projection.ts";
 import {
   captureProjectionSourceCacheSnapshot,
   readProjectionSourceCacheSnapshot,
@@ -123,8 +117,6 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
     for (const table of snapshot.declaredTables) {
       yield* replaceDeclaredProjectionRows(sql, table.declaration, table.rows);
     }
-    yield* replaceExecutionEvidenceProjectionRows(sql, snapshot.declaredTables
-      .find((table) => table.table === "execution_projection")?.rows ?? []);
     yield* replaceDeclaredSourceManifestRows(sql, declaredManifestRows);
     yield* replaceProjectionSourceCacheRows(sql, sourceCache);
     yield* replaceAttributionProjectionRows(sql, snapshot.attributionEvents);
@@ -259,29 +251,6 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
       "projection_tampered",
       "Declared entity projection rows no longer match authored entity state.",
       "Discard the generated cache and rebuild it from authored entities; do not merge generated projection edits."
-    ));
-    const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
-    return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };
-  }
-
-  let executionEvidenceRowsMatch = true;
-  if (!cachedValidation) {
-    try {
-      const actualHash = runSqlite(projectionPath, Effect.flatMap(
-        SqlClient.SqlClient,
-        hashExecutionEvidenceProjectionState
-      ));
-      executionEvidenceRowsMatch = existing.meta.executionEvidenceRowsHash === actualHash;
-    } catch {
-      executionEvidenceRowsMatch = false;
-    }
-  }
-  if (!executionEvidenceRowsMatch) {
-    warnings.push(hardFail(
-      "generated-cache",
-      "projection_tampered",
-      "Execution evidence read-model rows no longer match their recorded hash.",
-      "Discard the generated cache and rebuild it from authored Execution entities; do not trust edited projection rows."
     ));
     const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
     return { rows: rebuilt.rows, warnings: [...warnings, ...rebuilt.warnings] };

--- a/packages/kernel/src/projection/types.ts
+++ b/packages/kernel/src/projection/types.ts
@@ -186,7 +186,6 @@ export interface ProjectionMeta {
   readonly decisionRowsHash?: string;
   readonly declaredRowsHash?: string;
   readonly declaredManifestHash?: string;
-  readonly executionEvidenceRowsHash?: string;
   readonly attributionRowsHash?: string;
   readonly attributionSourceHash?: string;
   readonly taskSourceHash?: string;

--- a/packages/kernel/src/store/daemon-projection-generation-manager.ts
+++ b/packages/kernel/src/store/daemon-projection-generation-manager.ts
@@ -6,12 +6,14 @@ import type {
   StableProjectionSourceFence
 } from "../ports/projection-source-fence.ts";
 import {
-  ensureProjectionGenerationReady,
   ProjectionGenerationChangedError,
-  type EnsureProjectionGenerationResult,
   type ReadyProjectionGeneration
 } from "../projection/projection-generation-readiness.ts";
-import { updateTaskProjectionIncrementally } from "../projection/sqlite-task-incremental-projection.ts";
+import {
+  ensureExecutionEvidenceGenerationReady,
+  updateExecutionEvidenceProjectionIncrementally,
+  type EnsureExecutionEvidenceGenerationResult
+} from "../projection/sqlite-execution-evidence-store.ts";
 import {
   queryExecutionEvidencePageFromReadyGeneration,
   type ExecutionEvidencePage,
@@ -63,7 +65,7 @@ export interface DaemonProjectionGenerationManagerOptions {
   readonly layoutOverrides?: HarnessLayoutOverrides;
   readonly prepare?: (
     request: DaemonProjectionPreparationRequest
-  ) => EnsureProjectionGenerationResult | Promise<EnsureProjectionGenerationResult>;
+  ) => EnsureExecutionEvidenceGenerationResult | Promise<EnsureExecutionEvidenceGenerationResult>;
   readonly onPreparation?: (event: DaemonProjectionPreparationEvent) => void;
   readonly sourceFence?: ProjectionSourceFenceReader;
   readonly reconcileIntervalMs?: number | false;
@@ -232,22 +234,22 @@ export function createDaemonProjectionGenerationManager(
 
   function prepareProjectionGeneration(
     request: DaemonProjectionPreparationRequest
-  ): EnsureProjectionGenerationResult & { readonly mode: Exclude<DaemonProjectionPreparationMode, "custom"> } {
-    let mode: Exclude<DaemonProjectionPreparationMode, "custom"> = "full-readiness";
+  ): EnsureExecutionEvidenceGenerationResult & { readonly mode: Exclude<DaemonProjectionPreparationMode, "custom"> } {
     if (request.touchedPaths.length > 0 && request.previousSourceFingerprint) {
-      mode = updateTaskProjectionIncrementally({
+      const updated = updateExecutionEvidenceProjectionIncrementally({
         rootDir: options.rootDir,
         ...(options.layoutOverrides ? { layoutOverrides: options.layoutOverrides } : {}),
         touchedPaths: request.touchedPaths,
         previousSourceFingerprint: request.previousSourceFingerprint
-      }).mode;
+      });
+      return updated;
     }
     return {
-      ...ensureProjectionGenerationReady({
+      ...ensureExecutionEvidenceGenerationReady({
         rootDir: options.rootDir,
         ...(options.layoutOverrides ? { layoutOverrides: options.layoutOverrides } : {})
       }),
-      mode
+      mode: "full-readiness"
     };
   }
 
@@ -370,7 +372,7 @@ const unknownProjectionSourceFenceReader: ProjectionSourceFenceReader = {
   capture: () => ({ kind: "unknown", reason: "git-unavailable" })
 };
 
-function preparationMode(result: EnsureProjectionGenerationResult): DaemonProjectionPreparationMode {
+function preparationMode(result: EnsureExecutionEvidenceGenerationResult): DaemonProjectionPreparationMode {
   if (!("mode" in result)) return "custom";
   const mode = result.mode;
   return mode === "full-readiness" || mode === "incremental" || mode === "rebuild" || mode === "unchanged"

--- a/packages/kernel/test/store/daemon-runtime.test.ts
+++ b/packages/kernel/test/store/daemon-runtime.test.ts
@@ -168,7 +168,7 @@ test("multi-repo daemon keeps projection generations and evidence pages isolated
     const generations = status.repos.map((repo) => repo.projectionGeneration);
     assert.ok(generations.every((generation) => generation.validationRuns === 1));
     assert.equal(new Set(generations.map((generation) => generation.sourceHash)).size, 5);
-    assert.equal(new Set(repos.map((repo) => resolveHarnessLayout(createHarnessRuntimeContext(repo.rootDir)).projectionPath)).size, 5);
+    assert.equal(new Set(repos.map((repo) => resolveHarnessLayout(createHarnessRuntimeContext(repo.rootDir)).executionEvidenceProjectionPath)).size, 5);
 
     await runtime.enqueueInteractiveWrite("repo-1", {
       commandId: "cmd-first-generation-invalidation",
@@ -485,7 +485,7 @@ test("daemon no-op materializer preserves the ready projection generation", asyn
     });
     await runtime.start();
     await runtime.queryExecutionEvidencePage({ limit: 1 });
-    const projectionPath = resolveHarnessLayout(createHarnessRuntimeContext(rootDir)).projectionPath;
+    const projectionPath = resolveHarnessLayout(createHarnessRuntimeContext(rootDir)).executionEvidenceProjectionPath;
     const before = projectionDatabaseSignature(projectionPath);
 
     const report = await runtime.enqueueMaterializerBatch();

--- a/packages/kernel/test/store/helpers/execution-evidence.ts
+++ b/packages/kernel/test/store/helpers/execution-evidence.ts
@@ -1,0 +1,137 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+export interface ExecutionEvidenceIdentity {
+  readonly taskId: string;
+  readonly executionId: string;
+}
+
+export function ids(index: number): ExecutionEvidenceIdentity {
+  const suffix = String(index).padStart(26, "0");
+  return { taskId: `task_${suffix}`, executionId: `exe_${suffix}` };
+}
+
+export function withExecutionEvidenceHarness(run: (rootDir: string) => void): void {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-execution-evidence-"));
+  try {
+    run(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+export function writeExecutionEvidenceTask(rootDir: string, taskId: string, title: string): void {
+  const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+  mkdirSync(taskRoot, { recursive: true });
+  writeFileSync(path.join(taskRoot, "INDEX.md"), [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    `title: ${title}`,
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    "  status: active",
+    "  ref: ",
+    `  titleSnapshot: ${title}`,
+    "  url: ",
+    "  bindingCreatedAt: 2026-07-13T00:00:00.000Z",
+    "  bindingFingerprint: sha256:fixture",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "---",
+    "",
+    `# ${title}`,
+    ""
+  ].join("\n"), "utf8");
+}
+
+export function writeExecutionEvidence(
+  rootDir: string,
+  taskId: string,
+  executionId: string,
+  submittedAt: string,
+  outputs: ReadonlyArray<unknown>,
+  executorId = "codex"
+): string {
+  const executionRoot = path.join(rootDir, "harness/tasks", taskId, "executions");
+  mkdirSync(executionRoot, { recursive: true });
+  const executionPath = path.join(executionRoot, `${executionId}.md`);
+  writeFileSync(executionPath, `${JSON.stringify({
+    schema: "execution/v2",
+    execution_id: executionId,
+    task_ref: `task/${taskId}`,
+    state: "submitted",
+    primary_actor: {
+      principal: { personId: "person_test" },
+      executor: { kind: "agent", id: executorId },
+      responsibleHuman: "person_test"
+    },
+    claimed_at: submittedAt,
+    submitted_at: submittedAt,
+    closed_at: null,
+    session_bindings: [],
+    outputs,
+    submission: null
+  }, null, 2)}\n`, "utf8");
+  return executionPath;
+}
+
+export function inlineExecutionEvidenceOutput(
+  identity: ExecutionEvidenceIdentity,
+  evidenceId: string,
+  text: string
+): unknown {
+  return {
+    evidence_id: evidenceId,
+    execution_ref: `execution/${identity.taskId}/${identity.executionId}`,
+    locator: { substrate: "inline", text },
+    checker_receipt_ref: `${evidenceId.includes("first") ? "" : evidenceId === "ev-inline" ? "ev-receipt" : ""}` || undefined
+  };
+}
+
+export function fileExecutionEvidenceOutput(
+  identity: ExecutionEvidenceIdentity,
+  evidenceId: string,
+  filePath: string
+): unknown {
+  return {
+    evidence_id: evidenceId,
+    execution_ref: `execution/${identity.taskId}/${identity.executionId}`,
+    locator: { substrate: "file", path: filePath }
+  };
+}
+
+export function checkerExecutionEvidenceOutput(
+  identity: ExecutionEvidenceIdentity,
+  evidenceId: string,
+  targetEvidenceId: string,
+  result: "pass" | "fail"
+): unknown {
+  return {
+    evidence_id: evidenceId,
+    execution_ref: `execution/${identity.taskId}/${identity.executionId}`,
+    locator: {
+      substrate: "checker_receipt",
+      receipt: {
+        checker_id: "test-checker",
+        checker_version: "1",
+        target_evidence_id: targetEvidenceId,
+        target_sha256: null,
+        checked_at: "2026-07-13T00:10:00.000Z",
+        result
+      }
+    }
+  };
+}
+
+export function openFullProjection(rootDir: string, readOnly = true): DatabaseSync {
+  return new DatabaseSync(path.join(rootDir, ".harness/cache/projections.sqlite"), { readOnly });
+}
+
+export function openExecutionEvidenceProjection(rootDir: string, readOnly = true): DatabaseSync {
+  return new DatabaseSync(path.join(rootDir, ".harness/cache/execution-evidence.sqlite"), { readOnly });
+}

--- a/packages/kernel/test/store/sqlite-execution-evidence-projection.test.ts
+++ b/packages/kernel/test/store/sqlite-execution-evidence-projection.test.ts
@@ -1,20 +1,92 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, rmSync } from "node:fs";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 import {
   queryExecutionEvidencePage,
   queryExecutionEvidencePageFromReadyGeneration
 } from "../../src/projection/sqlite-execution-evidence-reader.ts";
-import { ensureProjectionGenerationReady } from "../../src/projection/projection-generation-readiness.ts";
-import { captureProjectionSourceSnapshot } from "../../src/projection/projection-source-snapshot.ts";
-import { updateTaskProjectionIncrementally } from "../../src/projection/sqlite-task-incremental-projection.ts";
+import {
+  ensureExecutionEvidenceGenerationReady,
+  rebuildExecutionEvidenceProjection,
+  updateExecutionEvidenceProjectionIncrementally
+} from "../../src/projection/sqlite-execution-evidence-store.ts";
 import { rebuildTaskProjection } from "../../src/projection/sqlite-task-projection.ts";
+import {
+  checkerExecutionEvidenceOutput as checkerOutput,
+  fileExecutionEvidenceOutput as fileOutput,
+  ids,
+  inlineExecutionEvidenceOutput as inlineOutput,
+  openExecutionEvidenceProjection as openEvidenceProjection,
+  openFullProjection,
+  withExecutionEvidenceHarness as withHarness,
+  writeExecutionEvidence as writeExecution,
+  writeExecutionEvidenceTask as writeTask
+} from "./helpers/execution-evidence.ts";
 
-test("full projection normalizes execution outputs into queryable SQL rows", () => {
+test("execution evidence first page publishes an isolated facet without building the full repository projection", () => {
+  withHarness((rootDir) => {
+    const identity = ids(1);
+    writeTask(rootDir, identity.taskId, "Isolated Evidence facet");
+    writeExecution(rootDir, identity.taskId, identity.executionId, "2026-07-13T00:01:00.000Z", [
+      inlineOutput(identity, "ev-isolated", "Evidence without the full projection")
+    ]);
+
+    const page = queryExecutionEvidencePage({ rootDir, limit: 1 });
+
+    assert.equal(page.groups[0]?.title, "Isolated Evidence facet");
+    assert.equal(existsSync(path.join(rootDir, ".harness/cache/execution-evidence.sqlite")), true);
+    assert.equal(existsSync(path.join(rootDir, ".harness/cache/projections.sqlite")), false);
+  });
+});
+
+test("full repository projection does not duplicate the isolated Evidence tables", () => {
+  withHarness((rootDir) => {
+    const identity = ids(1);
+    writeTask(rootDir, identity.taskId, "No duplicated Evidence tables");
+    writeExecution(rootDir, identity.taskId, identity.executionId, "2026-07-13T00:01:00.000Z", [
+      inlineOutput(identity, "ev-isolated", "Only the facet owns this row")
+    ]);
+
+    rebuildTaskProjection({ rootDir });
+
+    const db = openFullProjection(rootDir);
+    try {
+      const tables = db.prepare(`
+        SELECT name FROM sqlite_master
+        WHERE type = 'table' AND name IN ('execution_evidence_projection', 'execution_output_projection')
+      `).all();
+      assert.deepEqual(tables, []);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+test("full repository projection rebuild does not invalidate an Evidence cursor or generation", () => {
+  withHarness((rootDir) => {
+    for (let index = 1; index <= 2; index += 1) {
+      const identity = ids(index);
+      writeTask(rootDir, identity.taskId, `Independent facet ${index}`);
+      writeExecution(rootDir, identity.taskId, identity.executionId, `2026-07-13T00:0${index}:00.000Z`, [
+        inlineOutput(identity, `ev-${index}`, `Evidence ${index}`)
+      ]);
+    }
+    const firstPage = queryExecutionEvidencePage({ rootDir, limit: 1 });
+    const before = ensureExecutionEvidenceGenerationReady({ rootDir }).ready;
+
+    rebuildTaskProjection({ rootDir });
+
+    const secondPage = queryExecutionEvidencePage({ rootDir, limit: 1, cursor: firstPage.nextCursor! });
+    const after = ensureExecutionEvidenceGenerationReady({ rootDir }).ready;
+    assert.equal(secondPage.groups[0]?.executions[0]?.executionId, ids(1).executionId);
+    assert.equal(after.sourceHash, before.sourceHash);
+    assert.equal(after.databaseSignature, before.databaseSignature);
+  });
+});
+
+test("isolated Evidence facet normalizes execution outputs into queryable SQL rows", () => {
   withHarness((rootDir) => {
     const first = ids(1);
     writeTask(rootDir, first.taskId, "First task");
@@ -23,9 +95,9 @@ test("full projection normalizes execution outputs into queryable SQL rows", () 
       checkerOutput(first, "ev-receipt", "ev-inline", "pass")
     ]);
 
-    rebuildTaskProjection({ rootDir });
+    rebuildExecutionEvidenceProjection({ rootDir });
 
-    const db = openProjection(rootDir);
+    const db = openEvidenceProjection(rootDir);
     try {
       assert.deepEqual(db.prepare(`
         SELECT execution_id, task_ref, executor_id, executor_kind,
@@ -83,9 +155,8 @@ test("incremental execution changes replace only that execution output rows", ()
     writeExecution(rootDir, second.taskId, second.executionId, "2026-07-13T00:02:00.000Z", [
       inlineOutput(second, "ev-second", "Untouched")
     ]);
-    rebuildTaskProjection({ rootDir });
-    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
-    const db = openProjection(rootDir, false);
+    const previousSourceFingerprint = rebuildExecutionEvidenceProjection({ rootDir }).ready.sourceHash;
+    const db = openEvidenceProjection(rootDir, false);
     try {
       db.exec(`
         CREATE TRIGGER preserve_untouched_execution_outputs
@@ -99,6 +170,12 @@ test("incremental execution changes replace only that execution output rows", ()
         WHEN OLD.execution_id = '${second.executionId}'
         BEGIN SELECT RAISE(ABORT, 'untouched summary deleted'); END
       `);
+      db.exec(`
+        CREATE TRIGGER preserve_untouched_execution_integrity
+        BEFORE UPDATE ON facet_integrity_leaf
+        WHEN OLD.leaf_kind = 'execution' AND OLD.entity_id = '${second.executionId}'
+        BEGIN SELECT RAISE(ABORT, 'untouched integrity leaf updated'); END
+      `);
     } finally {
       db.close();
     }
@@ -106,14 +183,14 @@ test("incremental execution changes replace only that execution output rows", ()
       inlineOutput(first, "ev-first-updated", "After")
     ]);
 
-    const result = updateTaskProjectionIncrementally({
+    const result = updateExecutionEvidenceProjectionIncrementally({
       rootDir,
       touchedPaths: [changedPath],
       previousSourceFingerprint
     });
 
     assert.equal(result.mode, "incremental");
-    const updated = openProjection(rootDir);
+    const updated = openEvidenceProjection(rootDir);
     try {
       assert.deepEqual(updated.prepare(`
         SELECT execution_id, evidence_id, inline_text
@@ -133,6 +210,68 @@ test("incremental execution changes replace only that execution output rows", ()
   });
 });
 
+test("incremental task-title changes update the Evidence facet without rebuilding execution rows", () => {
+  withHarness((rootDir) => {
+    const identity = ids(1);
+    writeTask(rootDir, identity.taskId, "Before title");
+    writeExecution(rootDir, identity.taskId, identity.executionId, "2026-07-13T00:01:00.000Z", [
+      inlineOutput(identity, "ev-title", "Preserved evidence")
+    ]);
+    const previousSourceFingerprint = rebuildExecutionEvidenceProjection({ rootDir }).ready.sourceHash;
+    const db = openEvidenceProjection(rootDir, false);
+    try {
+      db.exec(`
+        CREATE TRIGGER preserve_execution_on_title_change
+        BEFORE DELETE ON execution_evidence_projection
+        BEGIN SELECT RAISE(ABORT, 'execution row deleted'); END
+      `);
+    } finally {
+      db.close();
+    }
+    writeTask(rootDir, identity.taskId, "After title");
+    const indexPath = path.join(rootDir, "harness/tasks", identity.taskId, "INDEX.md");
+
+    const result = updateExecutionEvidenceProjectionIncrementally({
+      rootDir,
+      touchedPaths: [indexPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    const page = queryExecutionEvidencePageFromReadyGeneration(result.ready, { limit: 1 });
+    assert.equal(page.groups[0]?.title, "After title");
+    assert.equal(page.groups[0]?.executions[0]?.outputs[0]?.text, "Preserved evidence");
+  });
+});
+
+test("incremental execution source changes add and delete manifest-backed rows", () => {
+  withHarness((rootDir) => {
+    const first = ids(1);
+    const second = ids(2);
+    const added = { taskId: first.taskId, executionId: second.executionId };
+    writeTask(rootDir, first.taskId, "Execution manifest changes");
+    const deletedPath = writeExecution(rootDir, first.taskId, first.executionId, "2026-07-13T00:01:00.000Z", [
+      inlineOutput(first, "ev-deleted", "Deleted evidence")
+    ]);
+    const previousSourceFingerprint = rebuildExecutionEvidenceProjection({ rootDir }).ready.sourceHash;
+    rmSync(deletedPath);
+    const addedPath = writeExecution(rootDir, added.taskId, added.executionId, "2026-07-13T00:02:00.000Z", [
+      inlineOutput(added, "ev-added", "Added evidence")
+    ]);
+
+    const result = updateExecutionEvidenceProjectionIncrementally({
+      rootDir,
+      touchedPaths: [deletedPath, addedPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    const page = queryExecutionEvidencePageFromReadyGeneration(result.ready, { limit: 2 });
+    assert.deepEqual(page.groups[0]?.executions.map((execution) => execution.executionId), [second.executionId]);
+    assert.equal(page.groups[0]?.executions[0]?.outputs[0]?.text, "Added evidence");
+  });
+});
+
 test("execution evidence uses stable execution keyset pages and SQL aggregate stats", () => {
   withHarness((rootDir) => {
     for (let index = 1; index <= 3; index += 1) {
@@ -147,7 +286,7 @@ test("execution evidence uses stable execution keyset pages and SQL aggregate st
     writeExecution(rootDir, newest.taskId, newest.executionId, "2026-07-13T00:04:00.000Z", [
       inlineOutput(newest, "ev-4", "Evidence 4")
     ]);
-    rebuildTaskProjection({ rootDir });
+    rebuildExecutionEvidenceProjection({ rootDir });
 
     const firstPage = queryExecutionEvidencePage({ rootDir, limit: 2 });
 
@@ -174,11 +313,11 @@ test("execution evidence uses stable execution keyset pages and SQL aggregate st
     assert.equal(secondPage.nextCursor, null);
     assert.deepEqual(secondPage.stats, firstPage.stats);
 
-    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const previousSourceFingerprint = ensureExecutionEvidenceGenerationReady({ rootDir }).ready.sourceHash;
     const movedPath = writeExecution(rootDir, ids(1).taskId, ids(1).executionId, "2026-07-13T00:05:00.000Z", [
       inlineOutput(ids(1), "ev-1", "Evidence 1")
     ]);
-    const updated = updateTaskProjectionIncrementally({
+    const updated = updateExecutionEvidenceProjectionIncrementally({
       rootDir,
       touchedPaths: [movedPath],
       previousSourceFingerprint
@@ -198,9 +337,9 @@ test("execution evidence rebuilds normalized SQL rows after generated-cache tamp
     writeExecution(rootDir, identity.taskId, identity.executionId, "2026-07-13T00:01:00.000Z", [
       inlineOutput(identity, "ev-original", "Original evidence")
     ]);
-    rebuildTaskProjection({ rootDir });
+    rebuildExecutionEvidenceProjection({ rootDir });
 
-    const db = openProjection(rootDir, false);
+    const db = openEvidenceProjection(rootDir, false);
     try {
       db.prepare("UPDATE execution_output_projection SET inline_text = 'TAMPERED'").run();
     } finally {
@@ -209,6 +348,35 @@ test("execution evidence rebuilds normalized SQL rows after generated-cache tamp
 
     const page = queryExecutionEvidencePage({ rootDir, limit: 1 });
     assert.equal(page.groups[0]?.executions[0]?.outputs[0]?.text, "Original evidence");
+  });
+});
+
+test("execution evidence rebuilds after integrity-leaf tampering", () => {
+  withHarness((rootDir) => {
+    const identity = ids(1);
+    writeTask(rootDir, identity.taskId, "Integrity leaf check");
+    writeExecution(rootDir, identity.taskId, identity.executionId, "2026-07-13T00:01:00.000Z", [
+      inlineOutput(identity, "ev-integrity", "Integrity evidence")
+    ]);
+    rebuildExecutionEvidenceProjection({ rootDir });
+    const db = openEvidenceProjection(rootDir, false);
+    try {
+      db.prepare("UPDATE facet_integrity_leaf SET row_hash = 'sha256:tampered'").run();
+    } finally {
+      db.close();
+    }
+
+    queryExecutionEvidencePage({ rootDir, limit: 1 });
+
+    const repaired = openEvidenceProjection(rootDir);
+    try {
+      assert.notEqual(
+        repaired.prepare("SELECT row_hash FROM facet_integrity_leaf LIMIT 1").get()?.row_hash,
+        "sha256:tampered"
+      );
+    } finally {
+      repaired.close();
+    }
   });
 });
 
@@ -227,7 +395,7 @@ test("execution evidence page caps output previews without losing total counts",
         ...Array.from({ length: 6 }, (_, index) => inlineOutput(identity, `ev-${index}`, `Evidence ${index}`))
       ]
     );
-    rebuildTaskProjection({ rootDir });
+    rebuildExecutionEvidenceProjection({ rootDir });
 
     const page = queryExecutionEvidencePage({ rootDir, limit: 1 });
     const execution = page.groups[0]?.executions[0];
@@ -255,14 +423,14 @@ test("execution evidence page pins generation rows outputs and stats to one SQLi
       "2026-07-13T00:01:00.000Z",
       [inlineOutput(identity, "ev-before", "Before")]
     );
-    rebuildTaskProjection({ rootDir });
-    const db = openProjection(rootDir, false);
+    rebuildExecutionEvidenceProjection({ rootDir });
+    const db = openEvidenceProjection(rootDir, false);
     try {
       db.exec("PRAGMA journal_mode = WAL");
     } finally {
       db.close();
     }
-    const ready = ensureProjectionGenerationReady({ rootDir }).ready;
+    const ready = ensureExecutionEvidenceGenerationReady({ rootDir }).ready;
     let writerCommitted = false;
     let pinnedPage: ReturnType<typeof queryExecutionEvidencePageFromReadyGeneration> | null = null;
 
@@ -272,7 +440,7 @@ test("execution evidence page pins generation rows outputs and stats to one SQLi
         { limit: 1 },
         {
           afterExecutionRowsRead: () => {
-            const writer = openProjection(rootDir, false);
+            const writer = openEvidenceProjection(rootDir, false);
             try {
               writer.exec("BEGIN IMMEDIATE");
               writer.prepare(`
@@ -304,7 +472,7 @@ test("execution evidence page pins generation rows outputs and stats to one SQLi
     assert.equal(pinnedPage?.groups[0]?.executions[0]?.outputs[0]?.text, "Before");
     assert.equal(pinnedPage?.groups[0]?.executions[0]?.outputCount, 1);
     assert.equal(pinnedPage?.stats.totalOutputs, 1);
-    const refreshed = openProjection(rootDir);
+    const refreshed = openEvidenceProjection(rootDir);
     try {
       assert.equal(refreshed.prepare("SELECT COUNT(*) AS count FROM execution_output_projection").get()?.count, 2);
       assert.equal(refreshed.prepare("SELECT inline_text FROM execution_output_projection ORDER BY ordinal").get()?.inline_text, "After");
@@ -322,24 +490,24 @@ test("ready generation handle rejects database changes that bypass generation va
     writeExecution(rootDir, identity.taskId, identity.executionId, "2026-07-13T00:01:00.000Z", [
       inlineOutput(identity, "ev-original", "Original")
     ]);
-    rebuildTaskProjection({ rootDir });
-    const journal = openProjection(rootDir, false);
+    rebuildExecutionEvidenceProjection({ rootDir });
+    const journal = openEvidenceProjection(rootDir, false);
     try {
       journal.exec("PRAGMA journal_mode = WAL");
     } finally {
       journal.close();
     }
-    const ready = ensureProjectionGenerationReady({ rootDir }).ready;
+    const ready = ensureExecutionEvidenceGenerationReady({ rootDir }).ready;
     assert.equal(Object.isFrozen(ready), true);
     const forged = Object.assign(Object.create(Object.getPrototypeOf(ready)) as object, ready) as typeof ready;
     assert.throws(
       () => queryExecutionEvidencePageFromReadyGeneration(forged, { limit: 1 }),
       /handle was not established by the projection validator/
     );
-    const pinnedReader = openProjection(rootDir);
+    const pinnedReader = openEvidenceProjection(rootDir);
     pinnedReader.exec("BEGIN");
     pinnedReader.prepare("SELECT value FROM projection_meta WHERE key = 'sourceHash'").get();
-    const db = openProjection(rootDir, false);
+    const db = openEvidenceProjection(rootDir, false);
     try {
       db.prepare("UPDATE execution_output_projection SET inline_text = 'TAMPERED'").run();
     } finally {
@@ -365,15 +533,15 @@ test("ready generation acquisition retries when the database changes after valid
     writeExecution(rootDir, identity.taskId, identity.executionId, "2026-07-13T00:01:00.000Z", [
       inlineOutput(identity, "ev-original", "Original")
     ]);
-    rebuildTaskProjection({ rootDir });
+    rebuildExecutionEvidenceProjection({ rootDir });
     let tampered = false;
 
-    const acquired = ensureProjectionGenerationReady(
+    const acquired = ensureExecutionEvidenceGenerationReady(
       { rootDir },
       {
         afterProjectionValidated: () => {
           if (tampered) return;
-          const db = openProjection(rootDir, false);
+          const db = openEvidenceProjection(rootDir, false);
           try {
             db.prepare("UPDATE execution_output_projection SET inline_text = 'TAMPERED'").run();
             tampered = true;
@@ -400,18 +568,18 @@ test("ready generation acquisition does not trust a cached validation across WAL
     writeExecution(rootDir, identity.taskId, identity.executionId, "2026-07-13T00:01:00.000Z", [
       inlineOutput(identity, "ev-original", "Original")
     ]);
-    rebuildTaskProjection({ rootDir });
-    const journal = openProjection(rootDir, false);
+    rebuildExecutionEvidenceProjection({ rootDir });
+    const journal = openEvidenceProjection(rootDir, false);
     try {
       journal.exec("PRAGMA journal_mode = WAL");
     } finally {
       journal.close();
     }
-    ensureProjectionGenerationReady({ rootDir });
-    const pinnedReader = openProjection(rootDir);
+    ensureExecutionEvidenceGenerationReady({ rootDir });
+    const pinnedReader = openEvidenceProjection(rootDir);
     pinnedReader.exec("BEGIN");
     pinnedReader.prepare("SELECT value FROM projection_meta WHERE key = 'sourceHash'").get();
-    const writer = openProjection(rootDir, false);
+    const writer = openEvidenceProjection(rootDir, false);
     try {
       writer.prepare("UPDATE execution_output_projection SET inline_text = 'TAMPERED'").run();
     } finally {
@@ -419,7 +587,7 @@ test("ready generation acquisition does not trust a cached validation across WAL
     }
 
     try {
-      const reacquired = ensureProjectionGenerationReady({ rootDir }).ready;
+      const reacquired = ensureExecutionEvidenceGenerationReady({ rootDir }).ready;
       assert.equal(
         queryExecutionEvidencePageFromReadyGeneration(reacquired, { limit: 1 })
           .groups[0]?.executions[0]?.outputs[0]?.text,
@@ -431,119 +599,3 @@ test("ready generation acquisition does not trust a cached validation across WAL
     }
   });
 });
-
-interface Identity {
-  readonly taskId: string;
-  readonly executionId: string;
-}
-
-function ids(index: number): Identity {
-  const suffix = String(index).padStart(26, "0");
-  return { taskId: `task_${suffix}`, executionId: `exe_${suffix}` };
-}
-
-function withHarness(run: (rootDir: string) => void): void {
-  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-execution-evidence-"));
-  try {
-    run(rootDir);
-  } finally {
-    rmSync(rootDir, { recursive: true, force: true });
-  }
-}
-
-function writeTask(rootDir: string, taskId: string, title: string): void {
-  const taskRoot = path.join(rootDir, "harness/tasks", taskId);
-  mkdirSync(taskRoot, { recursive: true });
-  writeFileSync(path.join(taskRoot, "INDEX.md"), [
-    "---",
-    "schema: task-package/v2",
-    `task_id: ${taskId}`,
-    `title: ${title}`,
-    "lifecycle:",
-    "  bindingSchema: lifecycle-binding/v1",
-    "  engine: local",
-    "  status: active",
-    "  ref: ",
-    `  titleSnapshot: ${title}`,
-    "  url: ",
-    "  bindingCreatedAt: 2026-07-13T00:00:00.000Z",
-    "  bindingFingerprint: sha256:fixture",
-    "packageDisposition: active",
-    "vertical: default",
-    "preset: default",
-    "---",
-    "",
-    `# ${title}`,
-    ""
-  ].join("\n"), "utf8");
-}
-
-function writeExecution(
-  rootDir: string,
-  taskId: string,
-  executionId: string,
-  submittedAt: string,
-  outputs: ReadonlyArray<unknown>,
-  executorId = "codex"
-): string {
-  const executionRoot = path.join(rootDir, "harness/tasks", taskId, "executions");
-  mkdirSync(executionRoot, { recursive: true });
-  const executionPath = path.join(executionRoot, `${executionId}.md`);
-  writeFileSync(executionPath, `${JSON.stringify({
-    schema: "execution/v2",
-    execution_id: executionId,
-    task_ref: `task/${taskId}`,
-    state: "submitted",
-    primary_actor: {
-      principal: { personId: "person_test" },
-      executor: { kind: "agent", id: executorId },
-      responsibleHuman: "person_test"
-    },
-    claimed_at: submittedAt,
-    submitted_at: submittedAt,
-    closed_at: null,
-    session_bindings: [],
-    outputs,
-    submission: null
-  }, null, 2)}\n`, "utf8");
-  return executionPath;
-}
-
-function inlineOutput(identity: Identity, evidenceId: string, text: string): unknown {
-  return {
-    evidence_id: evidenceId,
-    execution_ref: `execution/${identity.taskId}/${identity.executionId}`,
-    locator: { substrate: "inline", text },
-    checker_receipt_ref: `${evidenceId.includes("first") ? "" : evidenceId === "ev-inline" ? "ev-receipt" : ""}` || undefined
-  };
-}
-
-function fileOutput(identity: Identity, evidenceId: string, filePath: string): unknown {
-  return {
-    evidence_id: evidenceId,
-    execution_ref: `execution/${identity.taskId}/${identity.executionId}`,
-    locator: { substrate: "file", path: filePath }
-  };
-}
-
-function checkerOutput(identity: Identity, evidenceId: string, targetEvidenceId: string, result: "pass" | "fail"): unknown {
-  return {
-    evidence_id: evidenceId,
-    execution_ref: `execution/${identity.taskId}/${identity.executionId}`,
-    locator: {
-      substrate: "checker_receipt",
-      receipt: {
-        checker_id: "test-checker",
-        checker_version: "1",
-        target_evidence_id: targetEvidenceId,
-        target_sha256: null,
-        checked_at: "2026-07-13T00:10:00.000Z",
-        result
-      }
-    }
-  };
-}
-
-function openProjection(rootDir: string, readOnly = true): DatabaseSync {
-  return new DatabaseSync(path.join(rootDir, ".harness/cache/projections.sqlite"), { readOnly });
-}

--- a/packages/kernel/test/store/sqlite-rebuild.test.ts
+++ b/packages/kernel/test/store/sqlite-rebuild.test.ts
@@ -8,7 +8,6 @@ import { DatabaseSync } from "node:sqlite";
 import { Effect, Option } from "effect";
 import { auditTaskProvenance, checkTaskProjection, hashTaskProjectionRows, queryDecisionProjection, queryTaskExecutionTrace, readTaskProjection, rebuildTaskProjection } from "../../src/index.ts";
 import { replaceAttributionProjectionRows } from "../../src/projection/sqlite-attribution-projection.ts";
-import { replaceExecutionEvidenceProjectionRows } from "../../src/projection/sqlite-execution-evidence-projection.ts";
 import { writeProjectionDatabase } from "../../src/projection/sqlite-projection-store.ts";
 import { makeJournaledWriteCoordinator, makeMarkdownArtifactStore } from "../../src/store/index.ts";
 import { docWrite, withTempStore } from "./helpers.ts";
@@ -111,7 +110,6 @@ test("SQLite projection full-generation materialization runs inside one transact
         if (nestedBegin._tag === "Right") {
           return yield* Effect.fail(new Error("full-generation materialization was not transaction-scoped"));
         }
-        yield* replaceExecutionEvidenceProjectionRows(sql, []);
         yield* replaceAttributionProjectionRows(sql, []);
       })
     );

--- a/tools/perf/gui-projection-benchmark.mjs
+++ b/tools/perf/gui-projection-benchmark.mjs
@@ -5,8 +5,12 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { aggregateExecutions } from "../../packages/gui/src/renderer/execution-data.ts";
 import { queryExecutionEvidencePage, queryExecutions, rebuildTaskProjection } from "../../packages/kernel/src/index.ts";
-import { ensureProjectionGenerationReady } from "../../packages/kernel/src/projection/projection-generation-readiness.ts";
 import { queryExecutionEvidencePageFromReadyGeneration } from "../../packages/kernel/src/projection/sqlite-execution-evidence-reader.ts";
+import {
+  ensureExecutionEvidenceGenerationReady,
+  rebuildExecutionEvidenceProjection,
+  updateExecutionEvidenceProjectionIncrementally
+} from "../../packages/kernel/src/projection/sqlite-execution-evidence-store.ts";
 import { captureProjectionSourceFingerprint } from "../../packages/kernel/src/projection/projection-source-snapshot.ts";
 import { readDeclaredSourceManifestRows } from "../../packages/kernel/src/projection/sqlite-declared-source-manifest.ts";
 import { updateTaskProjectionIncrementally } from "../../packages/kernel/src/projection/sqlite-task-incremental-projection.ts";
@@ -23,19 +27,25 @@ try {
   const fixtureRows = [];
   for (let index = 0; index < size; index += 1) fixtureRows.push(writeTask(index));
   const fixtureMs = performance.now() - fixtureStart;
+  initAuthoredGit();
+
+  const evidenceFacetBuildStart = performance.now();
+  rebuildExecutionEvidenceProjection({ rootDir });
+  const evidenceFacetBuildMs = performance.now() - evidenceFacetBuildStart;
 
   const rebuildStart = performance.now();
   const rebuilt = rebuildTaskProjection({ rootDir });
   const rebuildMs = performance.now() - rebuildStart;
-  initAuthoredGit();
 
   const querySamples = sample(20, () => queryExecutions({ rootDir }));
   const executions = querySamples.value;
   const legacyExecutionsPayloadBytes = Buffer.byteLength(JSON.stringify({ ok: true, executions }), "utf8");
   const warmQueryP95 = percentile(querySamples.samples, 0.95);
-  const evidencePageSamples = sample(20, () => queryExecutionEvidencePage({ rootDir, limit: 25 }));
+  // The direct API intentionally revalidates authored sources on every call. Keep this
+  // diagnostic sample bounded; the GUI hot path is the ready daemon generation below.
+  const evidencePageSamples = sample(5, () => queryExecutionEvidencePage({ rootDir, limit: 25 }));
   const evidencePage = evidencePageSamples.value;
-  const readyGeneration = ensureProjectionGenerationReady({ rootDir }).ready;
+  const readyGeneration = ensureExecutionEvidenceGenerationReady({ rootDir }).ready;
   const readyEvidencePageSamples = sample(20, () => queryExecutionEvidencePageFromReadyGeneration(readyGeneration, { limit: 25 }));
   const readyEvidencePageP95 = percentile(readyEvidencePageSamples.samples, 0.95);
   const daemonRuntime = createDaemonRuntime({ rootDir, materializerPollMs: false });
@@ -56,8 +66,16 @@ try {
   const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
   const manifest = readDeclaredSourceManifestRows(projectionPath);
   const previousSourceFingerprint = captureProjectionSourceFingerprint(rootDir, manifest).fingerprint;
+  const previousEvidenceSourceFingerprint = readyGeneration.sourceHash;
   const changedBody = JSON.parse(readFileSync(changedExecution.executionPath, "utf8"));
   writeFileSync(changedExecution.executionPath, `${JSON.stringify({ ...changedBody, state: "accepted" }, null, 2)}\n`);
+  const incrementalEvidenceStarted = performance.now();
+  const incrementalEvidence = updateExecutionEvidenceProjectionIncrementally({
+    rootDir,
+    touchedPaths: [changedExecution.executionPath],
+    previousSourceFingerprint: previousEvidenceSourceFingerprint
+  });
+  const incrementalEvidenceMs = performance.now() - incrementalEvidenceStarted;
   const incrementalStarted = performance.now();
   const incremental = updateTaskProjectionIncrementally({
     rootDir,
@@ -66,7 +84,7 @@ try {
   });
   const incrementalExecutionMs = performance.now() - incrementalStarted;
   const result = {
-    schema: "gui-projection-benchmark/v1",
+    schema: "gui-projection-benchmark/v2",
     fixture: {
       tasks: size,
       executions: size,
@@ -76,6 +94,7 @@ try {
     },
     milliseconds: {
       fixture: rounded(fixtureMs),
+      evidenceFacetBuild: rounded(evidenceFacetBuildMs),
       rebuild: rounded(rebuildMs),
       queryExecutions: summarize(querySamples.samples),
       queryExecutionEvidencePage: summarize(evidencePageSamples.samples),
@@ -83,6 +102,7 @@ try {
       queryExecutionEvidencePageFromDaemonGeneration: summarize(daemonEvidencePageSamples.samples),
       daemonGenerationReady: rounded(daemonGenerationReadyMs),
       aggregateExecutions: summarize(aggregateSamples.samples),
+      incrementalEvidence: rounded(incrementalEvidenceMs),
       incrementalExecution: rounded(incrementalExecutionMs)
     },
     assertions: {
@@ -119,11 +139,24 @@ try {
         : size === 5_000
           ? rebuildMs <= 9_000
           : null,
-      coldFirstUsableMs: rounded(rebuildMs + daemonGenerationReadyMs + daemonEvidencePageP95),
-      coldFirstUsableBudgetMs: size === 1_000 || size === 5_000 ? 10_000 : null,
-      coldFirstUsableWithinBudget: size === 1_000 || size === 5_000
-        ? rebuildMs + daemonGenerationReadyMs + daemonEvidencePageP95 <= 10_000
+      evidenceFacetBuildBudgetMs: size === 1_000 ? 3_000 : size === 5_000 ? 9_000 : null,
+      evidenceFacetBuildWithinBudget: size === 1_000
+        ? evidenceFacetBuildMs <= 3_000
+        : size === 5_000
+          ? evidenceFacetBuildMs <= 9_000
+          : null,
+      coldFirstUsableMs: rounded(evidenceFacetBuildMs + readyEvidencePageP95),
+      coldFirstUsableBudgetMs: size === 1_000 ? 3_000 : size === 5_000 ? 9_000 : null,
+      coldFirstUsableWithinBudget: size === 1_000
+        ? evidenceFacetBuildMs + readyEvidencePageP95 <= 3_000
+        : size === 5_000
+          ? evidenceFacetBuildMs + readyEvidencePageP95 <= 9_000
         : null,
+      incrementalEvidenceBudgetMs: size === 1_000 || size === 5_000 ? 250 : null,
+      incrementalEvidenceWithinBudget: size === 1_000 || size === 5_000
+        ? incrementalEvidenceMs <= 250
+        : null,
+      incrementalEvidenceMode: incrementalEvidence.mode,
       incrementalExecutionMode: incremental.mode
     }
   };
@@ -138,7 +171,10 @@ try {
       !result.assertions.daemonGenerationReused ||
       !result.assertions.daemonFirstPageMatchesReadyPage ||
       result.assertions.coldProjectionBuildWithinBudget === false ||
+      result.assertions.evidenceFacetBuildWithinBudget === false ||
       result.assertions.coldFirstUsableWithinBudget === false ||
+      result.assertions.incrementalEvidenceWithinBudget === false ||
+      incrementalEvidence.mode !== "incremental" ||
       incremental.mode !== "incremental") {
     process.exitCode = 1;
   }


### PR DESCRIPTION
# English

## Summary

Isolate the GUI execution-evidence read model into a per-repository `execution-evidence.sqlite` facet so the first usable Evidence page no longer waits for the broad repository projection. The facet owns its source dependencies, manifest, integrity state, ready generation, cursor invalidation, and incremental update path.

This keeps the existing bounded SQL page contract while making single-execution refreshes proportional to changed rows and preserving daemon-owned source fences.

## What Changed

- Added an isolated Evidence projection store with atomic publication and its own schema/version/source hash.
- Moved normalized execution summaries and outputs out of `projections.sqlite`.
- Added manifest-backed incremental add/update/delete handling and per-entity integrity leaves.
- Routed daemon generation reuse and Evidence readers through the isolated facet.
- Added regression coverage for facet independence, cursor stability, tamper recovery, WAL races, bounded payloads, and changed-row updates.
- Updated the GUI projection benchmark to report facet cold, ready, daemon, and incremental timings separately.

## Version Impact

- No version change because this is an internal generated-cache/read-path optimization with no public API or package contract change.

## Verification

- [x] `npm run check:ci` executed: 12/13 workflow groups passed; the only red item was the environment-only GitHub required-context check with repository variables absent.
- [x] `GITHUB_REPOSITORY=FairladyZ625/harness-anything GITHUB_TOKEN=$(gh auth token) npm run harness:check-github-required-contexts` (14 contexts).
- [x] Post-rebase `npm run typecheck` and `npm run lint`.
- [x] Post-rebase complexity, import-boundary, dead-export, duplicate-definition, and integrity-single-source gates.
- [x] Post-rebase focused Evidence/daemon tests (34/34).
- [x] `git diff --check`.
- [x] `npm run perf:gui -- --size 5000`: all Evidence facet assertions passed (cold 4.40s, ready p95 3.16ms, daemon p95 3.46ms, incremental 52.57ms, 28.8KB payload, 175 visible items).
- Not run: a second full `check:ci` after rebasing three non-overlapping mainline changes; affected checks were rerun locally and the PR workflows provide the authoritative full rerun.

## Review Evidence

- Self-review: inspected the complete diff for source-fence, database-generation, manifest, integrity, query snapshot, and cross-facet coupling risks.
- Additional review: none; this slice was intentionally completed without subagent delegation.
- Blocking findings: none.

## Residual Risk

- The legacy broad `projections.sqlite` diagnostic rebuild still exceeded its 9s benchmark budget under a system load average above 60 (51.15s). It is now off the Evidence first-page path; this PR does not optimize that background projection.
- Direct non-daemon Evidence calls intentionally perform full authored-source validation. The GUI daemon path reuses a fenced ready generation.

## References

- Task: `task_01KXCS9KEKA2H3H8614ZBB984J`
- Evidence: commit `a485fff2`; `tools/perf/gui-projection-benchmark.mjs`

---

# 中文

## 摘要

将 GUI 的执行证据读模型拆分为每仓库独立的 `execution-evidence.sqlite` facet，使 Evidence 首屏不再等待宽域仓库投影完成。该 facet 独立拥有源依赖、manifest、完整性状态、ready generation、游标失效和增量更新路径。

现有的有界 SQL 分页契约保持不变，单条 Execution 更新只处理变化行，同时继续由 daemon source fence 保证代际一致性。

## 改动内容

- 新增独立 Evidence 投影存储，使用原子发布以及独立 schema、version 和 source hash。
- 将规范化执行摘要与输出表从 `projections.sqlite` 移出。
- 新增基于 manifest 的增量新增、更新、删除，以及逐实体完整性叶子。
- 将 daemon generation 复用和 Evidence reader 路由到独立 facet。
- 新增 facet 独立性、游标稳定性、篡改恢复、WAL 竞态、有界 payload 和按变化行更新的回归测试。
- 更新 GUI 投影基准，分别报告 facet 冷启动、ready、daemon 和增量耗时。

## 版本影响

- 不改版本，因为这是生成缓存与内部读取路径优化，不改变公开 API 或包契约。

## 验证

- [x] 已执行 `npm run check:ci`：13 个 workflow group 中 12 个通过；唯一红项是本地缺少仓库变量时的 GitHub required-context 环境检查。
- [x] `GITHUB_REPOSITORY=FairladyZ625/harness-anything GITHUB_TOKEN=$(gh auth token) npm run harness:check-github-required-contexts`（14 个 contexts）。
- [x] 变基后执行 `npm run typecheck` 和 `npm run lint`。
- [x] 变基后执行复杂度、导入边界、dead export、重复定义和完整性单一来源检查。
- [x] 变基后 Evidence/daemon 聚焦测试 34/34 通过。
- [x] `git diff --check`。
- [x] `npm run perf:gui -- --size 5000`：Evidence facet 全部断言通过（冷构建 4.40s、ready p95 3.16ms、daemon p95 3.46ms、增量 52.57ms、payload 28.8KB、175 个可见项）。
- 未运行：变基三个互不重叠的主线改动后，没有再次执行整轮 `check:ci`；已复跑受影响检查，PR workflow 将提供权威全量复验。

## 审查证据

- 自查：逐项审阅完整 diff，覆盖 source fence、数据库 generation、manifest、完整性、查询快照和跨 facet 耦合风险。
- 额外审查：无；本切片按约定未使用 subagent 委派。
- 阻塞发现：无。

## 残余风险

- 在系统 load average 超过 60 时，旧的宽域 `projections.sqlite` 诊断重建仍超过 9s 预算（51.15s）。它已经移出 Evidence 首屏路径；本 PR 不优化该后台投影。
- 非 daemon 的直接 Evidence 调用仍会完整验证 authored source；GUI daemon 热路径复用经过 fence 的 ready generation。

## 关联材料

- 任务：`task_01KXCS9KEKA2H3H8614ZBB984J`
- 证据：提交 `a485fff2`；`tools/perf/gui-projection-benchmark.mjs`
