### PR TITLE
feat(cli): define language-neutral architecture code graph

### DIFF
--- a/packages/cli/src/commands/extensions/assets/software-coding/architecture/EXTRACTOR_SELECTION.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/architecture/EXTRACTOR_SELECTION.md
@@ -1,0 +1,36 @@
+# JavaScript and TypeScript Dependency Extractor Selection
+
+Status: accepted for the `javascript-typescript/imports-v1` adapter
+
+Evidence checked: 2026-07-14
+
+## Decision
+
+Use dependency-cruiser behind a Harness-owned process and JSON adapter boundary. The raw tool output is not a public contract: the adapter must decode it into `architecture-code-graph/v1`, whose file, package, and dependency records contain no dependency-cruiser-specific types.
+
+This selection does not add the dependency or enable scanning. The implementation slice owns the pinned package version, golden raw-output fixtures, execution limits, and real repository snapshot.
+
+## Evidence
+
+| Criterion | dependency-cruiser | Madge | TypeScript compiler API |
+| --- | --- | --- | --- |
+| License | MIT in the [official license](https://github.com/sverweij/dependency-cruiser/blob/main/LICENSE) | MIT in the [official license](https://github.com/pahen/madge/blob/master/LICENSE) | TypeScript is Apache-2.0; direct use would still make Harness own dependency traversal and resolution policy |
+| Maintenance | npm registry metadata reported `18.1.0`, modified 2026-07-12 | npm registry metadata reported `8.0.0`, modified 2024-08-05 | Maintained with TypeScript, but it is a compiler building block rather than a dependency-graph product contract |
+| Machine output | The official [output format](https://github.com/sverweij/dependency-cruiser/blob/main/doc/output-format.md) documents JSON modules, dependencies, rules, and summary; the project tests its output schema | The official [README](https://github.com/pahen/madge) documents JSON output and a programmatic API | Harness would have to design, implement, and maintain module-resolution traversal and graph serialization |
+| Invocation isolation | The official [CLI](https://github.com/sverweij/dependency-cruiser/blob/main/doc/cli.md) supports explicit JSON output and scoped input; Harness can invoke an argv array with `shell: false` | CLI and API are available, but the package wraps `dependency-tree` and its resolver stack | In-process compiler objects and TypeScript-specific types would increase coupling to one language implementation |
+| Performance posture | Include/exclude controls permit bounded scans; no official apples-to-apples benchmark was found, so P3b must record a deterministic fixture and measured repository runtime rather than claim an unverified advantage | No official apples-to-apples benchmark was found | Potentially tunable, but Harness would own caching, traversal, and performance regressions |
+| Supply-chain surface | npm registry metadata reported 18 direct dependencies and Node `^22 || ^24 || >=26` | npm registry metadata reported multiple runtime dependencies and Node `>=18` | No extra parser package beyond the existing compiler, but substantially more first-party code and maintenance surface |
+
+Primary metadata endpoints: [dependency-cruiser npm registry record](https://registry.npmjs.org/dependency-cruiser/latest) and [Madge npm registry record](https://registry.npmjs.org/madge/latest). dependency-cruiser's official [API documentation](https://github.com/sverweij/dependency-cruiser/blob/main/doc/api.md) also exposes an in-process API, but the fixed Harness seam deliberately chooses process isolation so tool types and failures cannot leak into common CLI contracts.
+
+## Fixed boundary
+
+- Adapter identity: `javascript-typescript/imports-v1`.
+- Tool identity: `dependency-cruiser`.
+- Invocation: executable plus argv, repository root as cwd, `shell: false`, JSON stdout only.
+- Success: decoded and validated `architecture-code-graph/v1`.
+- Missing executable or package capability: existing `tool-missing` contract.
+- Non-zero exit, malformed JSON, unknown output fields, or graph-contract violation: existing `invalid` contract.
+- Mapping files to architecture nodes and semantic drift comparison remain downstream responsibilities.
+
+The seam is replaceable: a future Python, Go, or alternate JS/TS adapter can produce the same language-neutral graph without changing snapshot or comparator contracts.

--- a/packages/cli/src/commands/extensions/assets/software-coding/architecture/contracts/architecture-adapters.mjs
+++ b/packages/cli/src/commands/extensions/assets/software-coding/architecture/contracts/architecture-adapters.mjs
@@ -3,6 +3,7 @@ import {
   validateArchitectureComparisonResult,
   validateArchitectureProviderObservation
 } from "./architecture-adapter-contracts.mjs";
+import { javascriptTypeScriptExtractorBoundary } from "./architecture-code-graph.mjs";
 import { compareArchitectureText } from "./architecture-portable-path.mjs";
 import {
   architectureFindingsHaveUniqueIds,
@@ -25,6 +26,7 @@ const providerRegistry = new Map([
 const fixedRegistry = { providers: providerRegistry, extractors: adapterRegistry };
 const contractDigest = `sha256:${"0".repeat(64)}`;
 const likeC4ProviderAdapterId = "likec4/model-v1";
+const jsTsExtractorBoundary = javascriptTypeScriptExtractorBoundary();
 
 export async function runDeclaredArchitectureExtractors(options) {
   return runArchitectureAdapterPipeline(options, fixedRegistry);
@@ -308,7 +310,7 @@ async function runMissingJavaScriptTypeScriptAdapter({ extractor }) {
       role: "extractor",
       declarationId: extractor.id,
       adapter: extractor.adapter,
-      tool: "dependency-cruiser",
+      tool: jsTsExtractorBoundary.tool,
       version: null,
       reason: "fixed-adapter-capability-unavailable",
       hint: "The fixed JavaScript/TypeScript extractor adapter capability is not connected in this release; no local setup action can enable it."

--- a/packages/cli/src/commands/extensions/assets/software-coding/architecture/contracts/architecture-code-graph.mjs
+++ b/packages/cli/src/commands/extensions/assets/software-coding/architecture/contracts/architecture-code-graph.mjs
@@ -1,0 +1,191 @@
+import { createHash } from "node:crypto";
+import { isArchitectureStableId, isPortablePhysicalPath } from "./architecture-manifest.mjs";
+import { compareArchitectureText, findPortableCollisions, portablePathKey } from "./architecture-portable-path.mjs";
+import { isArchitectureDigest, isArchitectureRecord, validArchitectureProvenance } from "./architecture-report-contracts.mjs";
+
+const graphKeys = ["schema", "extractor", "tool", "files", "packages", "dependencies", "stats"];
+const extractorKeys = ["id", "adapter", "sourceScopeIds", "inputDigest", "toolRef"];
+const fileKeys = ["path", "sourceScopeId", "packageId"];
+const packageKeys = ["id", "manifestPath"];
+const dependencyKeys = ["sourcePath", "targetPath", "mechanism", "specifier"];
+const statsKeys = ["sourceFiles", "packageCount", "dependencyEdges"];
+const contractDigest = `sha256:${"0".repeat(64)}`;
+const jsTsBoundary = deepFreeze({
+  adapter: "javascript-typescript/imports-v1",
+  tool: "dependency-cruiser",
+  invocation: {
+    mode: "argv",
+    cwd: "repository-root",
+    executable: "depcruise",
+    outputType: "json",
+    shell: false
+  },
+  result: {
+    successSchema: "architecture-code-graph/v1",
+    missingStatus: "tool-missing",
+    invalidStatus: "invalid"
+  }
+});
+
+export function javascriptTypeScriptExtractorBoundary() {
+  return jsTsBoundary;
+}
+
+export function buildArchitectureCodeGraph(input) {
+  return {
+    ...input,
+    files: [...input.files].sort((left, right) => compareArchitectureText(left.path, right.path)),
+    packages: [...input.packages].sort((left, right) => compareArchitectureText(left.id, right.id)),
+    dependencies: [...input.dependencies].sort(compareDependencies)
+  };
+}
+
+export function architectureCodeGraphJson(value) {
+  return `${JSON.stringify(buildArchitectureCodeGraph(value), null, 2)}\n`;
+}
+
+export function architectureCodeGraphDigest(value) {
+  return `sha256:${createHash("sha256").update(architectureCodeGraphJson(value)).digest("hex")}`;
+}
+
+export function validateArchitectureCodeGraph(value) {
+  if (!hasExactKeys(value, graphKeys)) return invalid("$", "Code graphs must use the closed architecture-code-graph/v1 shape.");
+  const issues = [];
+  if (value.schema !== "architecture-code-graph/v1") issues.push(issue("schema", "Code graph schema must be architecture-code-graph/v1."));
+  if (!validExtractor(value.extractor)) issues.push(issue("extractor", "Code graphs require a closed extractor identity and input digest."));
+  if (!validExtractorTool(value.tool, value.extractor)) issues.push(issue("tool", "Extractor tool provenance must match the graph extractor and fixed adapter tool."));
+  if (!Array.isArray(value.files) || value.files.some((entry) => !validFile(entry))) issues.push(issue("files", "Files must use closed portable path records."));
+  if (!Array.isArray(value.packages) || value.packages.some((entry) => !validPackage(entry))) issues.push(issue("packages", "Packages must use closed stable identities and portable manifest paths."));
+  if (!Array.isArray(value.dependencies) || value.dependencies.some((entry) => !validDependency(entry))) issues.push(issue("dependencies", "Dependencies must use closed portable file-edge records."));
+  if (!validStats(value.stats)) issues.push(issue("stats", "Code graph stats must be non-negative integers."));
+  if (issues.length > 0) return { ok: false, issues };
+
+  validateReferences(value, issues);
+  validateIdentityAndOrder(value, issues);
+  validateStats(value, issues);
+  return issues.length > 0 ? { ok: false, issues } : { ok: true, value };
+}
+
+function validateReferences(value, issues) {
+  const scopeIds = new Set(value.extractor.sourceScopeIds);
+  const packageIds = new Set(value.packages.map((entry) => entry.id));
+  const filePaths = new Set(value.files.map((entry) => entry.path));
+  for (const [index, file] of value.files.entries()) {
+    if (!scopeIds.has(file.sourceScopeId)) issues.push(issue(`files[${index}].sourceScopeId`, "File source scope must be declared by the extractor."));
+    if (file.packageId !== null && !packageIds.has(file.packageId)) issues.push(issue(`files[${index}].packageId`, "File package must resolve inside this graph."));
+  }
+  for (const [index, dependency] of value.dependencies.entries()) {
+    if (!filePaths.has(dependency.sourcePath) || !filePaths.has(dependency.targetPath)) {
+      issues.push(issue(`dependencies[${index}]`, "Dependency endpoints must resolve to graph files."));
+    }
+  }
+}
+
+function validateIdentityAndOrder(value, issues) {
+  const filePaths = value.files.map((entry) => entry.path);
+  const packageIds = value.packages.map((entry) => entry.id);
+  const packageManifestKeys = value.packages.map((entry) => portablePathKey(entry.manifestPath));
+  const dependencies = value.dependencies.map(dependencyIdentity);
+  if (!sameValues(filePaths, sortedUnique(filePaths))) issues.push(issue("files", "Files must be sorted by unique portable path."));
+  if (!sameValues(packageIds, sortedUnique(packageIds))) issues.push(issue("packages", "Packages must be sorted by unique stable ID."));
+  if (new Set(packageManifestKeys).size !== packageManifestKeys.length) issues.push(issue("packages", "Package manifest paths must be unique on portable filesystems."));
+  if (!sameValues(dependencies, sortedUnique(dependencies))) issues.push(issue("dependencies", "Dependencies must be sorted and unique."));
+  const collisions = findPortableCollisions([
+    ...filePaths,
+    ...value.packages.map((entry) => entry.manifestPath),
+    ...value.dependencies.flatMap((entry) => [entry.sourcePath, entry.targetPath])
+  ]);
+  if (collisions.length > 0) issues.push(issue("$", "Code graph paths must not collide on portable filesystems."));
+}
+
+function validateStats(value, issues) {
+  if (value.stats.sourceFiles !== value.files.length ||
+    value.stats.packageCount !== value.packages.length ||
+    value.stats.dependencyEdges !== value.dependencies.length) {
+    issues.push(issue("stats", "Code graph stats must equal the graph record counts."));
+  }
+}
+
+function validExtractor(value) {
+  return hasExactKeys(value, extractorKeys) &&
+    isArchitectureStableId(value.id) &&
+    typeof value.adapter === "string" && value.adapter.length > 0 &&
+    sortedStableIds(value.sourceScopeIds) &&
+    isArchitectureDigest(value.inputDigest) &&
+    value.toolRef === `extractor:${value.id}`;
+}
+
+function validExtractorTool(tool, extractor) {
+  return extractor !== undefined && tool?.role === "extractor" &&
+    tool.declarationId === extractor.id &&
+    tool.adapter === extractor.adapter &&
+    (extractor.adapter !== jsTsBoundary.adapter || tool.tool === jsTsBoundary.tool) &&
+    validArchitectureProvenance({
+      commit: { sha: null, verification: "unverified" },
+      sourceDigest: contractDigest,
+      modelDigest: contractDigest,
+      tools: [tool]
+    });
+}
+
+function validFile(value) {
+  return hasExactKeys(value, fileKeys) && isPortablePhysicalPath(value.path) &&
+    isArchitectureStableId(value.sourceScopeId) &&
+    (value.packageId === null || isArchitectureStableId(value.packageId));
+}
+
+function validPackage(value) {
+  return hasExactKeys(value, packageKeys) && isArchitectureStableId(value.id) && isPortablePhysicalPath(value.manifestPath);
+}
+
+function validDependency(value) {
+  return hasExactKeys(value, dependencyKeys) &&
+    isPortablePhysicalPath(value.sourcePath) && isPortablePhysicalPath(value.targetPath) &&
+    isArchitectureStableId(value.mechanism) && typeof value.specifier === "string" && value.specifier.length > 0;
+}
+
+function validStats(value) {
+  return hasExactKeys(value, statsKeys) && statsKeys.every((key) => Number.isInteger(value[key]) && value[key] >= 0);
+}
+
+function sortedStableIds(value) {
+  return Array.isArray(value) && value.length > 0 && value.every(isArchitectureStableId) && sameValues(value, sortedUnique(value));
+}
+
+function compareDependencies(left, right) {
+  return compareArchitectureText(dependencyIdentity(left), dependencyIdentity(right));
+}
+
+function dependencyIdentity(value) {
+  return [value.sourcePath, value.targetPath, value.mechanism, value.specifier].join("\0");
+}
+
+function sortedUnique(value) {
+  return [...new Set(value)].sort(compareArchitectureText);
+}
+
+function sameValues(left, right) {
+  return left.length === right.length && left.every((entry, index) => entry === right[index]);
+}
+
+function hasExactKeys(value, keys) {
+  if (!isArchitectureRecord(value)) return false;
+  const actual = Object.keys(value);
+  return actual.length === keys.length && keys.every((key) => Object.prototype.hasOwnProperty.call(value, key));
+}
+
+function issue(path, message) {
+  return { code: "architecture_code_graph_invalid", path, message };
+}
+
+function invalid(path, message) {
+  return { ok: false, issues: [issue(path, message)] };
+}
+
+function deepFreeze(value) {
+  Object.freeze(value);
+  for (const nested of Object.values(value)) {
+    if (nested !== null && typeof nested === "object" && !Object.isFrozen(nested)) deepFreeze(nested);
+  }
+  return value;
+}

--- a/packages/cli/test/architecture-code-graph-contract.test.ts
+++ b/packages/cli/test/architecture-code-graph-contract.test.ts
@@ -1,0 +1,122 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const contractPath = "../src/commands/extensions/assets/software-coding/architecture/contracts/architecture-code-graph.mjs";
+
+test("language-neutral code graphs have a closed, portable contract", async () => {
+  const { validateArchitectureCodeGraph } = await import(contractPath);
+  const graph = codeGraph();
+
+  assert.equal(validateArchitectureCodeGraph(graph).ok, true);
+  for (const invalid of [
+    { ...graph, generatedAt: "unstable" },
+    { ...graph, files: [{ ...graph.files[0], path: "/tmp/api.ts" }, graph.files[1]] },
+    { ...graph, files: [...graph.files].reverse() },
+    { ...graph, dependencies: [graph.dependencies[0], structuredClone(graph.dependencies[0])] },
+    { ...graph, tool: { ...graph.tool, tool: "another-extractor" } }
+  ]) {
+    assert.equal(validateArchitectureCodeGraph(invalid).ok, false);
+  }
+});
+
+test("graph construction and digest are stable across input order", async () => {
+  const {
+    architectureCodeGraphDigest,
+    architectureCodeGraphJson,
+    buildArchitectureCodeGraph
+  } = await import(contractPath);
+  const input = codeGraph();
+  const reordered = {
+    ...input,
+    files: [...input.files].reverse(),
+    packages: [...input.packages].reverse(),
+    dependencies: [...input.dependencies].reverse()
+  };
+
+  const first = buildArchitectureCodeGraph(input);
+  const second = buildArchitectureCodeGraph(reordered);
+
+  assert.equal(architectureCodeGraphJson(first), architectureCodeGraphJson(second));
+  assert.equal(architectureCodeGraphDigest(input), architectureCodeGraphDigest(reordered));
+  assert.match(architectureCodeGraphDigest(first), /^sha256:[0-9a-f]{64}$/u);
+  assert.deepEqual(first.files.map((entry: Record<string, unknown>) => entry.path), ["packages/api.ts", "packages/store.ts"]);
+});
+
+test("file, package, dependency, and stats references fail closed", async () => {
+  const { validateArchitectureCodeGraph } = await import(contractPath);
+  const graph = codeGraph();
+  const mutations = [
+    (candidate: Record<string, any>) => { candidate.files[0].sourceScopeId = "scope.missing"; },
+    (candidate: Record<string, any>) => { candidate.files[0].packageId = "package.missing"; },
+    (candidate: Record<string, any>) => { candidate.dependencies[0].targetPath = "packages/missing.ts"; },
+    (candidate: Record<string, any>) => { candidate.packages[0].manifestPath = "packages/NUL"; },
+    (candidate: Record<string, any>) => { candidate.packages.push({ id: "package.other", manifestPath: "PACKAGES/package.json" }); candidate.stats.packageCount = 2; },
+    (candidate: Record<string, any>) => { candidate.stats.dependencyEdges = 2; },
+    (candidate: Record<string, any>) => { candidate.dependencies[0].extra = true; }
+  ];
+
+  for (const mutate of mutations) {
+    const candidate = structuredClone(graph);
+    mutate(candidate);
+    assert.equal(validateArchitectureCodeGraph(candidate).ok, false);
+  }
+});
+
+test("the fixed JS/TS seam freezes argv isolation and result states", async () => {
+  const { javascriptTypeScriptExtractorBoundary } = await import(contractPath);
+
+  assert.deepEqual(javascriptTypeScriptExtractorBoundary(), {
+    adapter: "javascript-typescript/imports-v1",
+    tool: "dependency-cruiser",
+    invocation: {
+      mode: "argv",
+      cwd: "repository-root",
+      executable: "depcruise",
+      outputType: "json",
+      shell: false
+    },
+    result: {
+      successSchema: "architecture-code-graph/v1",
+      missingStatus: "tool-missing",
+      invalidStatus: "invalid"
+    }
+  });
+  assert.equal(Object.isFrozen(javascriptTypeScriptExtractorBoundary()), true);
+});
+
+function codeGraph() {
+  return {
+    schema: "architecture-code-graph/v1",
+    extractor: {
+      id: "js-ts-imports",
+      adapter: "javascript-typescript/imports-v1",
+      sourceScopeIds: ["repository-js-ts"],
+      inputDigest: `sha256:${"1".repeat(64)}`,
+      toolRef: "extractor:js-ts-imports"
+    },
+    tool: {
+      role: "extractor",
+      declarationId: "js-ts-imports",
+      adapter: "javascript-typescript/imports-v1",
+      tool: "dependency-cruiser",
+      version: "18.1.0"
+    },
+    files: [
+      { path: "packages/api.ts", sourceScopeId: "repository-js-ts", packageId: "package.api" },
+      { path: "packages/store.ts", sourceScopeId: "repository-js-ts", packageId: null }
+    ],
+    packages: [
+      { id: "package.api", manifestPath: "packages/package.json" }
+    ],
+    dependencies: [
+      {
+        sourcePath: "packages/api.ts",
+        targetPath: "packages/store.ts",
+        mechanism: "import",
+        specifier: "./store.js"
+      }
+    ],
+    stats: { sourceFiles: 2, packageCount: 1, dependencyEdges: 1 }
+  };
+}


### PR DESCRIPTION
# English

## Summary

- Select dependency-cruiser for the fixed `javascript-typescript/imports-v1` seam using official repository, CLI, output-format, API, license, and npm-registry evidence.
- Add the language-neutral `architecture-code-graph/v1` contract for files, packages, internal dependencies, stable ordering, canonical digest, portable paths, and closed provenance.
- Freeze an argv-only, `shell: false` process boundary without installing or running the extractor in this slice.

## Scope

4 files, +352/-1. No dependency, lockfile, Kernel schema, node mapping, real scan, or drift business-rule changes.

## Verification

- Relevant architecture contracts: 18/18 pass.
- Full contract lane: 490/490 pass.
- Typecheck, ESLint, import boundary, duplicate definition, file complexity, CLI package build and copied assets pass.
- `check:ci` ran all 13 lanes. Its first run hit one pre-existing daemon timing flake in integration shard 5 and two local workspace-link failures caused by a temporary cross-worktree `node_modules` symlink.
- After a clean worktree `npm ci`: the exact daemon test passed 6/6, integration shard 5 passed 146/146, supply-chain passed with CycloneDX SBOM, and GUI passed 143/143 plus production build.

Task: `task_01KXEAHSXSSPWP1SHFS0JAEDYK`

# 中文

## 摘要

- 基于官方仓库、CLI、输出格式、API、许可证和 npm registry 证据，为固定 `javascript-typescript/imports-v1` seam 选择 dependency-cruiser。
- 新增语言中立的 `architecture-code-graph/v1` 合同，覆盖文件、package、内部依赖、稳定排序、canonical digest、portable path 和封闭 provenance。
- 固定 argv-only、`shell: false` 的进程边界；本切片不安装依赖、不执行真实 extractor。

## 范围

共 4 个文件，+352/-1；不修改依赖/lockfile、Kernel schema、node mapping、真实扫描或 drift 业务规则。

## 验证

- 相关 architecture contract：18/18 通过。
- 完整 contract lane：490/490 通过。
- Typecheck、ESLint、import boundary、重复定义、复杂度 gate、CLI package build 与资产复制均通过。
- `check:ci` 首轮完整运行命中一个既有 daemon timing flake，并因临时跨 worktree `node_modules` 软链接导致 supply-chain/GUI 的本地依赖布局失败。
- 在 worktree 内执行干净 `npm ci` 后：原 daemon 测试连续 6/6、integration shard 5 为 146/146、CycloneDX supply-chain gate、GUI 143/143 与生产构建均通过。

Task：`task_01KXEAHSXSSPWP1SHFS0JAEDYK`