### PR TITLE
feat: SME W3 — task/decision/module typed mutations + module attribution projection

### DIFF
--- a/packages/application/src/authority/task-decision-module-command-v2.ts
+++ b/packages/application/src/authority/task-decision-module-command-v2.ts
@@ -1,0 +1,407 @@
+import { Schema } from "effect";
+import {
+  DecisionPackageSchema,
+  type DecisionPackage,
+  type EntityRelationRecord
+} from "../../../kernel/src/index.ts";
+import { canonicalPayloadDigestV2, decodeRelationV2 } from "./fact-relation-command-v2.ts";
+import {
+  SemanticAdmissionErrorV2,
+  type SemanticMutationEnvelopeV2
+} from "./semantic-mutation-envelope-v2.ts";
+
+export const taskDecisionModuleTypedCommandsV2 = [
+  "task.create",
+  "task.transition",
+  "task.append",
+  "task.document",
+  "decision.propose",
+  "decision.state",
+  "decision.amend",
+  "decision.relation",
+  "module.register",
+  "module.unregister",
+  "module.step"
+] as const;
+
+export type TaskDecisionModuleTypedCommandV2 = (typeof taskDecisionModuleTypedCommandsV2)[number];
+
+export interface TaskCreatePayloadV2 {
+  readonly schema: "task.create/v1";
+  readonly taskId: string;
+  readonly packageSlug?: string;
+  readonly indexBody: string;
+}
+
+export interface TaskTransitionPayloadV2 {
+  readonly schema: "task.transition/v1";
+  readonly taskId: string;
+  readonly to: string;
+}
+
+export interface TaskAppendPayloadV2 {
+  readonly schema: "task.append/v1";
+  readonly taskId: string;
+  readonly text: string;
+}
+
+export interface TaskDocumentPayloadV2 {
+  readonly schema: "task.document/v1";
+  readonly taskId: string;
+  readonly path: string;
+  readonly body: string;
+}
+
+export interface DecisionProposePayloadV2 {
+  readonly schema: "decision.propose/v1";
+  readonly decision: DecisionPackage;
+  readonly body?: string;
+}
+
+export type DecisionStateTransitionV2 = "accept" | "reject" | "defer" | "supersede" | "retire";
+
+export interface DecisionStatePayloadV2 {
+  readonly schema: "decision.state/v1";
+  readonly transition: DecisionStateTransitionV2;
+  readonly decision: DecisionPackage;
+  readonly body?: string;
+}
+
+export interface DecisionAmendPayloadV2 {
+  readonly schema: "decision.amend/v1";
+  readonly decision: DecisionPackage;
+  readonly body?: string;
+}
+
+export interface DecisionRelationPayloadV2 {
+  readonly schema: "decision.relation/v1";
+  readonly decisionId: string;
+  readonly relation: EntityRelationRecord;
+}
+
+export interface ModuleRecordV2 {
+  readonly key: string;
+  readonly title: string;
+  readonly prefix?: string;
+  readonly status: string;
+  readonly branch?: string;
+  readonly owner?: string;
+  readonly currentStep?: string;
+  readonly scopes: ReadonlyArray<string>;
+  readonly shared?: ReadonlyArray<string>;
+  readonly dependsOn?: ReadonlyArray<string>;
+  readonly steps: ReadonlyArray<{ readonly id: string; readonly state: string }>;
+}
+
+export interface ModuleRegisterPayloadV2 {
+  readonly schema: "module.register/v1";
+  readonly module: ModuleRecordV2;
+}
+
+export interface ModuleUnregisterPayloadV2 {
+  readonly schema: "module.unregister/v1";
+  readonly moduleKey: string;
+}
+
+export interface ModuleStepPayloadV2 {
+  readonly schema: "module.step/v1";
+  readonly moduleKey: string;
+  readonly stepId: string;
+  readonly state: "planned" | "in-progress" | "blocked" | "done";
+}
+
+export type TaskDecisionModuleCommandPayloadV2 =
+  | TaskCreatePayloadV2
+  | TaskTransitionPayloadV2
+  | TaskAppendPayloadV2
+  | TaskDocumentPayloadV2
+  | DecisionProposePayloadV2
+  | DecisionStatePayloadV2
+  | DecisionAmendPayloadV2
+  | DecisionRelationPayloadV2
+  | ModuleRegisterPayloadV2
+  | ModuleUnregisterPayloadV2
+  | ModuleStepPayloadV2;
+
+export function decodeTaskDecisionModuleCommandPayloadV2(envelope: SemanticMutationEnvelopeV2): {
+  readonly payload: TaskDecisionModuleCommandPayloadV2;
+  readonly decodedBytes: bigint;
+} {
+  if (envelope.intent.kind !== "typed") throw taskDecisionModulePayloadAdmission("TYPED_COMMAND_REQUIRED");
+  if (envelope.intent.command.registryVersion !== 1 || envelope.intent.command.version !== 1) {
+    throw taskDecisionModulePayloadAdmission("TYPED_COMMAND_VERSION_UNSUPPORTED");
+  }
+  if (!taskDecisionModuleTypedCommandsV2.includes(envelope.intent.command.name as TaskDecisionModuleTypedCommandV2)) {
+    throw taskDecisionModulePayloadAdmission("TYPED_COMMAND_UNREGISTERED");
+  }
+  if (envelope.intent.canonicalPayload.kind !== "inline") throw taskDecisionModulePayloadAdmission("AUTHORITY_PAYLOAD_CAS_UNSUPPORTED");
+  const bytes = envelope.intent.canonicalPayload.bytes;
+  if (envelope.intent.canonicalPayload.size !== BigInt(bytes.length)) throw taskDecisionModulePayloadAdmission("CANONICAL_PAYLOAD_SIZE_MISMATCH");
+  if (!taskDecisionModulePayloadBytesEqual(envelope.intent.canonicalPayloadDigest, canonicalPayloadDigestV2(bytes))) {
+    throw taskDecisionModulePayloadAdmission("CANONICAL_PAYLOAD_DIGEST_MISMATCH");
+  }
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(Buffer.from(bytes).toString("utf8"));
+  } catch {
+    throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_INVALID");
+  }
+  const payload = strictTaskDecisionModulePayload(decoded);
+  if (!taskDecisionModulePayloadBytesEqual(bytes, encodeTaskDecisionModuleCommandPayloadV2(payload))) {
+    throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_NON_CANONICAL");
+  }
+  if (payload.schema.replace("/v1", "") !== envelope.intent.command.name) {
+    throw taskDecisionModulePayloadAdmission("TYPED_COMMAND_PAYLOAD_MISMATCH");
+  }
+  return { payload, decodedBytes: BigInt(bytes.length) };
+}
+
+export function encodeTaskDecisionModuleCommandPayloadV2(payload: TaskDecisionModuleCommandPayloadV2): Uint8Array {
+  return Buffer.from(JSON.stringify(canonicalTaskDecisionModulePayloadWire(payload)), "utf8");
+}
+
+function strictTaskDecisionModulePayload(value: unknown): TaskDecisionModuleCommandPayloadV2 {
+  const discriminator = exactTaskDecisionModuleObject(value, ["schema"], true);
+  switch (discriminator.schema) {
+    case "task.create/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "packageSlug", "indexBody"], false, ["packageSlug"]);
+      return {
+        schema: discriminator.schema,
+        taskId: taskDecisionModuleText(row.taskId),
+        ...(row.packageSlug === undefined ? {} : { packageSlug: taskDecisionModuleText(row.packageSlug) }),
+        indexBody: stringValue(row.indexBody)
+      };
+    }
+    case "task.transition/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "to"]);
+      return { schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), to: taskDecisionModuleText(row.to) };
+    }
+    case "task.append/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "text"]);
+      return { schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), text: taskDecisionModuleNonBlank(row.text) };
+    }
+    case "task.document/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "path", "body"]);
+      return { schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), path: taskDecisionModuleText(row.path), body: stringValue(row.body) };
+    }
+    case "decision.propose/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "decision", "body"], false, ["body"]);
+      return { schema: discriminator.schema, decision: decision(row.decision), ...(optionalString(row.body, "body")) };
+    }
+    case "decision.state/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "transition", "decision", "body"], false, ["body"]);
+      const transition = taskDecisionModuleText(row.transition);
+      if (!["accept", "reject", "defer", "supersede", "retire"].includes(transition)) {
+        throw taskDecisionModulePayloadAdmission("DECISION_STATE_TRANSITION_UNSUPPORTED");
+      }
+      return {
+        schema: discriminator.schema,
+        transition: transition as DecisionStateTransitionV2,
+        decision: decision(row.decision),
+        ...(optionalString(row.body, "body"))
+      };
+    }
+    case "decision.amend/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "decision", "body"], false, ["body"]);
+      return { schema: discriminator.schema, decision: decision(row.decision), ...(optionalString(row.body, "body")) };
+    }
+    case "decision.relation/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "decisionId", "relation"]);
+      return { schema: discriminator.schema, decisionId: taskDecisionModuleText(row.decisionId), relation: decodeRelationV2(row.relation) };
+    }
+    case "module.register/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "module"]);
+      return { schema: discriminator.schema, module: moduleRecord(row.module) };
+    }
+    case "module.unregister/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "moduleKey"]);
+      return { schema: discriminator.schema, moduleKey: registryKey(row.moduleKey) };
+    }
+    case "module.step/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "moduleKey", "stepId", "state"]);
+      const state = taskDecisionModuleText(row.state);
+      if (!["planned", "in-progress", "blocked", "done"].includes(state)) throw taskDecisionModulePayloadAdmission("MODULE_STEP_STATE_INVALID");
+      return {
+        schema: discriminator.schema,
+        moduleKey: registryKey(row.moduleKey),
+        stepId: taskDecisionModuleText(row.stepId),
+        state: state as ModuleStepPayloadV2["state"]
+      };
+    }
+    default:
+      throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_SCHEMA_UNSUPPORTED");
+  }
+}
+
+function canonicalTaskDecisionModulePayloadWire(payload: TaskDecisionModuleCommandPayloadV2): object {
+  switch (payload.schema) {
+    case "task.create/v1":
+      return { schema: payload.schema, taskId: payload.taskId, ...(payload.packageSlug ? { packageSlug: payload.packageSlug } : {}), indexBody: payload.indexBody };
+    case "task.transition/v1":
+      return { schema: payload.schema, taskId: payload.taskId, to: payload.to };
+    case "task.append/v1":
+      return { schema: payload.schema, taskId: payload.taskId, text: payload.text };
+    case "task.document/v1":
+      return { schema: payload.schema, taskId: payload.taskId, path: payload.path, body: payload.body };
+    case "decision.propose/v1":
+      return { schema: payload.schema, decision: decisionWire(payload.decision), ...(payload.body === undefined ? {} : { body: payload.body }) };
+    case "decision.state/v1":
+      return { schema: payload.schema, transition: payload.transition, decision: decisionWire(payload.decision), ...(payload.body === undefined ? {} : { body: payload.body }) };
+    case "decision.amend/v1":
+      return { schema: payload.schema, decision: decisionWire(payload.decision), ...(payload.body === undefined ? {} : { body: payload.body }) };
+    case "decision.relation/v1":
+      return { schema: payload.schema, decisionId: payload.decisionId, relation: relationWire(payload.relation) };
+    case "module.register/v1":
+      return { schema: payload.schema, module: moduleWire(payload.module) };
+    case "module.unregister/v1":
+      return { schema: payload.schema, moduleKey: payload.moduleKey };
+    case "module.step/v1":
+      return { schema: payload.schema, moduleKey: payload.moduleKey, stepId: payload.stepId, state: payload.state };
+  }
+}
+
+function decision(value: unknown): DecisionPackage {
+  try {
+    return Schema.decodeUnknownSync(DecisionPackageSchema)(value);
+  } catch {
+    throw taskDecisionModulePayloadAdmission("DECISION_PAYLOAD_INVALID");
+  }
+}
+
+function decisionWire(value: DecisionPackage): object {
+  return {
+    schema: value.schema,
+    decision_id: value.decision_id,
+    ...(value._coordinatorWatermark === undefined ? {} : { _coordinatorWatermark: value._coordinatorWatermark }),
+    title: value.title,
+    state: value.state,
+    riskTier: value.riskTier,
+    urgency: value.urgency,
+    vertical: value.vertical,
+    preset: value.preset,
+    ...(value.decisionClass === undefined ? {} : { decisionClass: value.decisionClass }),
+    applies_to: { modules: [...value.applies_to.modules], productLines: [...value.applies_to.productLines] },
+    proposedAt: value.proposedAt,
+    ...(value.decidedAt === undefined ? {} : { decidedAt: value.decidedAt }),
+    ...(value.contentPins === undefined ? {} : { contentPins: value.contentPins.map((entry) => ({ ...entry })) }),
+    provenance: value.provenance.map((entry) => ({ ...entry })),
+    question: value.question,
+    chosen: value.chosen.map((entry) => ({ ...entry })),
+    rejected: value.rejected.map((entry) => ({ ...entry })),
+    claims: value.claims.map((entry) => ({ ...entry })),
+    relations: value.relations.map(relationWire)
+  };
+}
+
+function relationWire(value: EntityRelationRecord): object {
+  return {
+    relation_id: value.relation_id,
+    source: value.source,
+    target: value.target,
+    type: value.type,
+    strength: value.strength,
+    direction: value.direction,
+    origin: value.origin,
+    rationale: value.rationale,
+    state: value.state
+  };
+}
+
+function moduleRecord(value: unknown): ModuleRecordV2 {
+  const row = exactTaskDecisionModuleObject(value, [
+    "key", "title", "prefix", "status", "branch", "owner", "currentStep", "scopes", "shared", "dependsOn", "steps"
+  ], false, ["prefix", "branch", "owner", "currentStep", "shared", "dependsOn"]);
+  const steps = taskDecisionModuleArray(row.steps, "steps").map((entry) => {
+    const step = exactTaskDecisionModuleObject(entry, ["id", "state"]);
+    return { id: taskDecisionModuleText(step.id), state: taskDecisionModuleText(step.state) };
+  });
+  return {
+    key: registryKey(row.key),
+    title: taskDecisionModuleNonBlank(row.title),
+    ...(row.prefix === undefined ? {} : { prefix: taskDecisionModuleText(row.prefix) }),
+    status: taskDecisionModuleText(row.status),
+    ...(row.branch === undefined ? {} : { branch: taskDecisionModuleText(row.branch) }),
+    ...(row.owner === undefined ? {} : { owner: taskDecisionModuleText(row.owner) }),
+    ...(row.currentStep === undefined ? {} : { currentStep: taskDecisionModuleText(row.currentStep) }),
+    scopes: stringArray(row.scopes, "scopes"),
+    ...(row.shared === undefined ? {} : { shared: stringArray(row.shared, "shared") }),
+    ...(row.dependsOn === undefined ? {} : { dependsOn: stringArray(row.dependsOn, "dependsOn") }),
+    steps
+  };
+}
+
+function moduleWire(value: ModuleRecordV2): object {
+  return {
+    key: value.key,
+    title: value.title,
+    ...(value.prefix === undefined ? {} : { prefix: value.prefix }),
+    status: value.status,
+    ...(value.branch === undefined ? {} : { branch: value.branch }),
+    ...(value.owner === undefined ? {} : { owner: value.owner }),
+    ...(value.currentStep === undefined ? {} : { currentStep: value.currentStep }),
+    scopes: [...value.scopes],
+    ...(value.shared === undefined ? {} : { shared: [...value.shared] }),
+    ...(value.dependsOn === undefined ? {} : { dependsOn: [...value.dependsOn] }),
+    steps: value.steps.map((step) => ({ id: step.id, state: step.state }))
+  };
+}
+
+function exactTaskDecisionModuleObject(
+  value: unknown,
+  keys: ReadonlyArray<string>,
+  allowAdditional = false,
+  optional: ReadonlyArray<string> = []
+): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_INVALID");
+  const row = value as Record<string, unknown>;
+  const actual = Object.keys(row);
+  if (keys.some((key) => !optional.includes(key) && !actual.includes(key))
+    || (!allowAdditional && actual.some((key) => !keys.includes(key)))) {
+    throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_UNKNOWN_OR_MISSING_FIELD");
+  }
+  return row;
+}
+
+function optionalString(value: unknown, key: string): Readonly<Record<string, string>> {
+  return value === undefined ? {} : { [key]: stringValue(value) };
+}
+
+function taskDecisionModuleArray(value: unknown, name: string): ReadonlyArray<unknown> {
+  if (!Array.isArray(value)) throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_INVALID", name);
+  return value;
+}
+
+function stringArray(value: unknown, name: string): ReadonlyArray<string> {
+  return taskDecisionModuleArray(value, name).map(taskDecisionModuleText);
+}
+
+function stringValue(value: unknown): string {
+  if (typeof value !== "string") throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_INVALID");
+  return value;
+}
+
+function taskDecisionModuleText(value: unknown): string {
+  const result = stringValue(value);
+  if (!result || result.trim() !== result) throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_INVALID");
+  return result;
+}
+
+function taskDecisionModuleNonBlank(value: unknown): string {
+  const result = stringValue(value);
+  if (!result.trim()) throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_INVALID");
+  return result;
+}
+
+function registryKey(value: unknown): string {
+  const result = taskDecisionModuleText(value);
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/u.test(result)) throw taskDecisionModulePayloadAdmission("MODULE_KEY_INVALID");
+  return result;
+}
+
+function taskDecisionModulePayloadAdmission(code: string, message = code): SemanticAdmissionErrorV2 {
+  return new SemanticAdmissionErrorV2(code, message);
+}
+
+function taskDecisionModulePayloadBytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  return Buffer.from(left).equals(Buffer.from(right));
+}

--- a/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
@@ -1,0 +1,582 @@
+import {
+  DecisionPackageSchema,
+  decisionEntityId,
+  decisionFieldContracts,
+  deriveRelationId,
+  entityRegistry,
+  explainDecisionStateTransition,
+  explainStatusTransition,
+  isDomainStatus,
+  moduleEntityId,
+  normalizeRelativeDocumentPath,
+  parseDecisionDocument,
+  readFrontmatter,
+  readScalar,
+  taskEntityId,
+  validateRelationRecordsForHost,
+  type DecisionPackage,
+  type DomainStatus,
+  type EntityRelationRecord,
+  type RegistryMutationPlanInput,
+  type WriteOp,
+  type WriteOpKind
+} from "../../../kernel/src/index.ts";
+import { Schema } from "effect";
+import {
+  decodeTaskDecisionModuleCommandPayloadV2,
+  type DecisionAmendPayloadV2,
+  type DecisionProposePayloadV2,
+  type DecisionRelationPayloadV2,
+  type DecisionStatePayloadV2,
+  type ModuleRecordV2,
+  type ModuleRegisterPayloadV2,
+  type ModuleStepPayloadV2,
+  type ModuleUnregisterPayloadV2,
+  type TaskAppendPayloadV2,
+  type TaskCreatePayloadV2,
+  type TaskDecisionModuleCommandPayloadV2,
+  type TaskDocumentPayloadV2,
+  type TaskTransitionPayloadV2
+} from "./task-decision-module-command-v2.ts";
+import {
+  SemanticAdmissionErrorV2,
+  type AuthoritySemanticCompilerV2,
+  type PathCasV2,
+  type RegistryEntityRefV2,
+  type SemanticBaseCasV2
+} from "./semantic-mutation-envelope-v2.ts";
+import type {
+  HostedDocumentSnapshotV2,
+  SemanticEntityBaseV2
+} from "./fact-relation-semantic-compiler-v2.ts";
+
+export {
+  encodeTaskDecisionModuleCommandPayloadV2,
+  taskDecisionModuleTypedCommandsV2,
+  type DecisionAmendPayloadV2,
+  type DecisionProposePayloadV2,
+  type DecisionRelationPayloadV2,
+  type DecisionStatePayloadV2,
+  type DecisionStateTransitionV2,
+  type ModuleRecordV2,
+  type ModuleRegisterPayloadV2,
+  type ModuleStepPayloadV2,
+  type ModuleUnregisterPayloadV2,
+  type TaskAppendPayloadV2,
+  type TaskCreatePayloadV2,
+  type TaskDecisionModuleCommandPayloadV2,
+  type TaskDecisionModuleTypedCommandV2,
+  type TaskDocumentPayloadV2,
+  type TaskTransitionPayloadV2
+} from "./task-decision-module-command-v2.ts";
+
+export interface TaskDecisionModuleAuthorityStateV2 {
+  readonly readEntityBase: (entityRef: RegistryEntityRefV2) => Promise<SemanticEntityBaseV2 | null>;
+  readonly readHostedDocument: (path: string) => Promise<HostedDocumentSnapshotV2 | null>;
+}
+
+export interface TaskDecisionModuleSemanticCompilerV2Options {
+  readonly state: TaskDecisionModuleAuthorityStateV2;
+}
+
+interface CompiledTaskDecisionModuleCommandV2 {
+  readonly mutationPlan: RegistryMutationPlanInput;
+  readonly operation: WriteOp;
+  readonly requiredBaseRefs: ReadonlyArray<RegistryEntityRefV2>;
+  readonly requiredPathSnapshots: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }>;
+}
+
+interface ModuleRegistryV2 {
+  readonly schema: "module-registry/v1";
+  readonly modules: ReadonlyArray<ModuleRecordV2>;
+}
+
+const registryVersion = 1;
+
+export function makeTaskDecisionModuleSemanticCompilerV2(
+  options: TaskDecisionModuleSemanticCompilerV2Options
+): AuthoritySemanticCompilerV2 {
+  return {
+    compile: async (envelope) => {
+      const { payload, decodedBytes } = decodeTaskDecisionModuleCommandPayloadV2(envelope);
+      const compiled = await compileTaskDecisionModulePayload(options.state, payload);
+      await verifyTaskDecisionModuleBaseCas(options.state, envelope.intent.kind === "typed" ? envelope.intent.baseCas : [], compiled.requiredBaseRefs);
+      verifyTaskDecisionModulePathCas(envelope.intent.kind === "typed" ? envelope.intent.declaredPathCas : [], compiled.requiredPathSnapshots);
+      return { mutationPlan: compiled.mutationPlan, operation: compiled.operation, decodedBytes };
+    }
+  };
+}
+
+async function compileTaskDecisionModulePayload(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: TaskDecisionModuleCommandPayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  switch (payload.schema) {
+    case "task.create/v1": return compileTaskCreate(payload);
+    case "task.transition/v1": return compileTaskTransition(state, payload);
+    case "task.append/v1": return compileTaskAppend(payload);
+    case "task.document/v1": return compileTaskDocument(state, payload);
+    case "decision.propose/v1": return compileDecisionPropose(payload);
+    case "decision.state/v1": return compileDecisionState(state, payload);
+    case "decision.amend/v1": return compileDecisionAmend(state, payload);
+    case "decision.relation/v1": return compileDecisionRelation(state, payload);
+    case "module.register/v1": return compileModuleRegister(state, payload);
+    case "module.unregister/v1": return compileModuleUnregister(state, payload);
+    case "module.step/v1": return compileModuleStep(state, payload);
+  }
+}
+
+function compileTaskCreate(payload: TaskCreatePayloadV2): CompiledTaskDecisionModuleCommandV2 {
+  const task = parseTaskIndex(payload.indexBody);
+  if (task.taskId !== payload.taskId) throw admission("TASK_ID_MISMATCH");
+  if (task.status !== "planned") throw admission("TASK_CREATE_REQUIRES_PLANNED_STATUS");
+  return taskCompilation(payload.taskId, "create", "package_create", {
+    path: "INDEX.md",
+    body: payload.indexBody,
+    ...(payload.packageSlug ? { packageSlug: payload.packageSlug } : {})
+  }, [taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)]);
+}
+
+async function compileTaskTransition(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: TaskTransitionPayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  if (!isDomainStatus(payload.to)) throw admission("TASK_TRANSITION_STATUS_INVALID");
+  const to = payload.to as DomainStatus;
+  const path = taskPath(payload.taskId, "INDEX.md");
+  const snapshot = await requiredTaskDecisionModuleDocument(state, path, "TASK_INDEX_NOT_FOUND");
+  const current = parseTaskIndex(snapshot.body);
+  if (current.taskId !== payload.taskId) throw admission("TASK_ID_MISMATCH");
+  if (!explainStatusTransition(current.status as DomainStatus, to).allowed) throw admission("TASK_TRANSITION_INVALID");
+  const body = replaceTaskStatus(snapshot.body, to);
+  return taskCompilation(payload.taskId, "transition", "transition_local", {
+    path: "INDEX.md",
+    body,
+    to
+  }, [taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)], [{ path, snapshot }]);
+}
+
+function compileTaskAppend(payload: TaskAppendPayloadV2): CompiledTaskDecisionModuleCommandV2 {
+  return taskCompilation(payload.taskId, "append", "progress_append", {
+    path: "progress.md",
+    append: payload.text
+  }, [taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)]);
+}
+
+async function compileTaskDocument(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: TaskDocumentPayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const documentPath = normalizeRelativeDocumentPath(payload.path);
+  assertTaskDocumentSurface(documentPath);
+  const path = taskPath(payload.taskId, documentPath);
+  const snapshot = await state.readHostedDocument(path);
+  return taskCompilation(payload.taskId, "document", "doc_write", {
+    path: documentPath,
+    body: payload.body
+  }, [taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)], snapshot ? [{ path, snapshot }] : []);
+}
+
+function taskCompilation(
+  taskId: string,
+  action: "create" | "transition" | "append" | "document",
+  kind: WriteOpKind,
+  payload: unknown,
+  requiredBaseRefs: ReadonlyArray<RegistryEntityRefV2>,
+  requiredPathSnapshots: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }> = []
+): CompiledTaskDecisionModuleCommandV2 {
+  const documentPath = (payload as { readonly path: string }).path;
+  return {
+    mutationPlan: taskDecisionModulePlan([{ entityKind: "task", identity: { taskId }, action, storageContext: { documentPath } }]),
+    operation: { opId: "authority-overrides-this", entityId: taskEntityId(taskId), kind, payload },
+    requiredBaseRefs,
+    requiredPathSnapshots
+  };
+}
+
+function compileDecisionPropose(payload: DecisionProposePayloadV2): CompiledTaskDecisionModuleCommandV2 {
+  const decision = decodeTaskDecisionModuleDecision(payload.decision);
+  if (decision.state !== "proposed") throw admission("DECISION_PROPOSE_REQUIRES_PROPOSED_STATE");
+  assertDecisionRelations(decision.decision_id, decision.relations);
+  const decisionRef = taskDecisionModuleEntityRef("decision", `decision/${decision.decision_id}`);
+  const relationMutations = decision.relations.map(relationCreateIntent);
+  return {
+    mutationPlan: taskDecisionModulePlan([
+      { entityKind: "decision", identity: { decisionId: decision.decision_id }, action: "propose" },
+      ...relationMutations
+    ]),
+    operation: decisionOperation("decision_propose", decision, payload.body),
+    requiredBaseRefs: [decisionRef, ...decision.relations.map((relation) => taskDecisionModuleEntityRef("relation", `relation/${relation.relation_id}`))],
+    requiredPathSnapshots: []
+  };
+}
+
+async function compileDecisionState(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: DecisionStatePayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const next = decodeTaskDecisionModuleDecision(payload.decision);
+  const path = decisionPath(next.decision_id);
+  const snapshot = await requiredTaskDecisionModuleDocument(state, path, "DECISION_DOCUMENT_NOT_FOUND");
+  const current = decodeTaskDecisionModuleDecision(parseDecisionDocument(snapshot.body).decision);
+  assertSameDecision(current, next);
+  const expectedState = {
+    accept: "active",
+    reject: "rejected",
+    defer: "deferred",
+    supersede: "retired",
+    retire: "retired"
+  }[payload.transition];
+  if (next.state !== expectedState || !explainDecisionStateTransition(current.state, next.state).allowed) {
+    throw admission("DECISION_STATE_TRANSITION_INVALID");
+  }
+  const allowedStateFields: Array<keyof DecisionPackage> = ["state", "decidedAt", "contentPins"];
+  if (payload.transition === "accept") allowedStateFields.push("claims", "decisionClass");
+  assertOnlyDecisionFieldsChanged(current, next, new Set(allowedStateFields));
+  return {
+    mutationPlan: taskDecisionModulePlan([{ entityKind: "decision", identity: { decisionId: next.decision_id }, action: "state" }]),
+    operation: decisionOperation(`decision_${payload.transition}` as WriteOpKind, next, payload.body, current),
+    requiredBaseRefs: [taskDecisionModuleEntityRef("decision", `decision/${next.decision_id}`)],
+    requiredPathSnapshots: [{ path, snapshot }]
+  };
+}
+
+async function compileDecisionAmend(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: DecisionAmendPayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const next = decodeTaskDecisionModuleDecision(payload.decision);
+  const path = decisionPath(next.decision_id);
+  const snapshot = await requiredTaskDecisionModuleDocument(state, path, "DECISION_DOCUMENT_NOT_FOUND");
+  const current = decodeTaskDecisionModuleDecision(parseDecisionDocument(snapshot.body).decision);
+  assertSameDecision(current, next);
+  const changed = changedDecisionFields(current, next);
+  if (changed.length === 0 || changed.some((field) => decisionFieldContracts[field].mutability !== "amendable")) {
+    throw admission("DECISION_AMEND_FIELD_INVALID");
+  }
+  return {
+    mutationPlan: taskDecisionModulePlan([{ entityKind: "decision", identity: { decisionId: next.decision_id }, action: "amend" }]),
+    operation: decisionOperation("decision_amend", next, payload.body, current),
+    requiredBaseRefs: [taskDecisionModuleEntityRef("decision", `decision/${next.decision_id}`)],
+    requiredPathSnapshots: [{ path, snapshot }]
+  };
+}
+
+async function compileDecisionRelation(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: DecisionRelationPayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const relation = payload.relation;
+  if (relation.state !== "active" || deriveRelationId(relation) !== relation.relation_id) throw admission("RELATION_PAYLOAD_INVALID");
+  assertDecisionRelations(payload.decisionId, [relation]);
+  const path = decisionPath(payload.decisionId);
+  const snapshot = await requiredTaskDecisionModuleDocument(state, path, "DECISION_DOCUMENT_NOT_FOUND");
+  const current = decodeTaskDecisionModuleDecision(parseDecisionDocument(snapshot.body).decision);
+  if (current.decision_id !== payload.decisionId) throw admission("DECISION_ID_MISMATCH");
+  if (current.relations.some((entry) => entry.relation_id === relation.relation_id)) throw admission("RELATION_ALREADY_EXISTS");
+  const next = { ...current, relations: [...current.relations, relation] };
+  return {
+    mutationPlan: taskDecisionModulePlan([
+      { entityKind: "decision", identity: { decisionId: payload.decisionId }, action: "relation" },
+      relationCreateIntent(relation)
+    ]),
+    operation: {
+      ...decisionOperation("decision_relate", next, undefined, current),
+      payload: {
+        decision: next,
+        writeMode: { kind: "append_relation", relation }
+      }
+    },
+    requiredBaseRefs: [
+      taskDecisionModuleEntityRef("decision", `decision/${payload.decisionId}`),
+      taskDecisionModuleEntityRef("relation", `relation/${relation.relation_id}`)
+    ],
+    requiredPathSnapshots: [{ path, snapshot }]
+  };
+}
+
+function decisionOperation(
+  kind: WriteOpKind,
+  decision: DecisionPackage,
+  body?: string,
+  current?: DecisionPackage
+): WriteOp {
+  return {
+    opId: "authority-overrides-this",
+    entityId: decisionEntityId(decision.decision_id),
+    kind,
+    payload: {
+      decision,
+      ...(body === undefined ? {} : { body }),
+      writeMode: { kind: "snapshot", expectedWatermark: current?._coordinatorWatermark ?? null }
+    }
+  };
+}
+
+async function compileModuleRegister(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: ModuleRegisterPayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const { registry, snapshot } = await moduleRegistry(state);
+  const modules = registry.modules.some((entry) => entry.key === payload.module.key)
+    ? registry.modules.map((entry) => entry.key === payload.module.key ? payload.module : entry)
+    : [...registry.modules, payload.module];
+  return moduleCompilation(payload.module.key, "register", { schema: "module-registry/v1", modules }, snapshot);
+}
+
+async function compileModuleUnregister(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: ModuleUnregisterPayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const { registry, snapshot } = await moduleRegistry(state);
+  if (!snapshot) throw admission("MODULE_REGISTRY_NOT_FOUND");
+  const current = registry.modules.find((entry) => entry.key === payload.moduleKey);
+  if (!current || current.status === "unregistered") throw admission("MODULE_NOT_FOUND");
+  return moduleCompilation(payload.moduleKey, "unregister", {
+    schema: "module-registry/v1",
+    modules: registry.modules.map((entry) => entry.key === payload.moduleKey ? { ...entry, status: "unregistered" } : entry)
+  }, snapshot);
+}
+
+async function compileModuleStep(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: ModuleStepPayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const { registry, snapshot } = await moduleRegistry(state);
+  if (!snapshot) throw admission("MODULE_REGISTRY_NOT_FOUND");
+  const current = registry.modules.find((entry) => entry.key === payload.moduleKey);
+  if (!current || current.status === "unregistered") throw admission("MODULE_NOT_FOUND");
+  const step = { id: payload.stepId, state: payload.state };
+  const steps = current.steps.some((entry) => entry.id === payload.stepId)
+    ? current.steps.map((entry) => entry.id === payload.stepId ? step : entry)
+    : [...current.steps, step];
+  return moduleCompilation(payload.moduleKey, "step", {
+    schema: "module-registry/v1",
+    modules: registry.modules.map((entry) => entry.key === payload.moduleKey ? { ...entry, steps } : entry)
+  }, snapshot);
+}
+
+function moduleCompilation(
+  moduleKey: string,
+  action: "register" | "unregister" | "step",
+  registry: ModuleRegistryV2,
+  snapshot: HostedDocumentSnapshotV2 | null
+): CompiledTaskDecisionModuleCommandV2 {
+  return {
+    mutationPlan: taskDecisionModulePlan([{ entityKind: "module", identity: { moduleKey }, action }]),
+    operation: {
+      opId: "authority-overrides-this",
+      entityId: moduleEntityId(moduleKey),
+      kind: "module_registry_write",
+      payload: { operation: action, registry }
+    },
+    requiredBaseRefs: [taskDecisionModuleEntityRef("module", `module/${encodeURIComponent(moduleKey)}`)],
+    requiredPathSnapshots: snapshot ? [{ path: "modules.json", snapshot }] : []
+  };
+}
+
+async function moduleRegistry(state: TaskDecisionModuleAuthorityStateV2): Promise<{
+  readonly registry: ModuleRegistryV2;
+  readonly snapshot: HostedDocumentSnapshotV2 | null;
+}> {
+  const snapshot = await state.readHostedDocument("modules.json");
+  if (!snapshot) return { registry: { schema: "module-registry/v1", modules: [] }, snapshot: null };
+  let value: unknown;
+  try {
+    value = JSON.parse(snapshot.body);
+  } catch {
+    throw admission("MODULE_REGISTRY_INVALID");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw admission("MODULE_REGISTRY_INVALID");
+  const row = value as { readonly schema?: unknown; readonly modules?: unknown };
+  if (row.schema !== "module-registry/v1" || !Array.isArray(row.modules)) throw admission("MODULE_REGISTRY_INVALID");
+  const modules = row.modules.map(decodeModuleRecord);
+  if (new Set(modules.map((entry) => entry.key)).size !== modules.length) throw admission("MODULE_REGISTRY_DUPLICATE_KEY");
+  return { registry: { schema: "module-registry/v1", modules }, snapshot };
+}
+
+function decodeModuleRecord(value: unknown): ModuleRecordV2 {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw admission("MODULE_REGISTRY_INVALID");
+  const row = value as Record<string, unknown>;
+  if (typeof row.key !== "string" || typeof row.title !== "string" || typeof row.status !== "string"
+    || !Array.isArray(row.scopes) || !Array.isArray(row.steps)) throw admission("MODULE_REGISTRY_INVALID");
+  const optional = (key: string): string | undefined => row[key] === undefined
+    ? undefined
+    : typeof row[key] === "string" ? row[key] : (() => { throw admission("MODULE_REGISTRY_INVALID"); })();
+  const stringArray = (key: string): ReadonlyArray<string> | undefined => row[key] === undefined
+    ? undefined
+    : Array.isArray(row[key]) && row[key].every((entry) => typeof entry === "string")
+      ? row[key] as ReadonlyArray<string>
+      : (() => { throw admission("MODULE_REGISTRY_INVALID"); })();
+  const steps = row.steps.map((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) throw admission("MODULE_REGISTRY_INVALID");
+    const step = entry as Record<string, unknown>;
+    if (typeof step.id !== "string" || typeof step.state !== "string") throw admission("MODULE_REGISTRY_INVALID");
+    return { id: step.id, state: step.state };
+  });
+  return {
+    key: row.key,
+    title: row.title,
+    ...(optional("prefix") === undefined ? {} : { prefix: optional("prefix")! }),
+    status: row.status,
+    ...(optional("branch") === undefined ? {} : { branch: optional("branch")! }),
+    ...(optional("owner") === undefined ? {} : { owner: optional("owner")! }),
+    ...(optional("currentStep") === undefined ? {} : { currentStep: optional("currentStep")! }),
+    scopes: row.scopes as ReadonlyArray<string>,
+    ...(stringArray("shared") === undefined ? {} : { shared: stringArray("shared")! }),
+    ...(stringArray("dependsOn") === undefined ? {} : { dependsOn: stringArray("dependsOn")! }),
+    steps
+  };
+}
+
+async function verifyTaskDecisionModuleBaseCas(
+  state: TaskDecisionModuleAuthorityStateV2,
+  claimed: ReadonlyArray<SemanticBaseCasV2>,
+  requiredRefs: ReadonlyArray<RegistryEntityRefV2>
+): Promise<void> {
+  const required = uniqueTaskDecisionModuleRefs(requiredRefs);
+  if (claimed.length !== required.length) throw admission("BASE_CAS_CONFLICT");
+  const byRef = new Map(claimed.map((entry) => [taskDecisionModuleEntityRefKey(entry.entityRef), entry]));
+  if (byRef.size !== claimed.length) throw admission("BASE_CAS_CONFLICT");
+  for (const ref of required) {
+    const row = byRef.get(taskDecisionModuleEntityRefKey(ref));
+    if (!row) throw admission("BASE_CAS_CONFLICT");
+    const actual = await state.readEntityBase(ref);
+    if (!actual) {
+      if (row.expectedSemanticVersion !== null || row.expectedStateDigest !== null) throw admission("BASE_CAS_CONFLICT");
+    } else if (row.expectedSemanticVersion !== actual.semanticVersion || !nullableTaskDecisionModuleBytesEqual(row.expectedStateDigest, actual.stateDigest)) {
+      throw admission("BASE_CAS_CONFLICT");
+    }
+  }
+}
+
+function verifyTaskDecisionModulePathCas(
+  claimed: ReadonlyArray<PathCasV2>,
+  required: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }>
+): void {
+  if (claimed.length !== required.length) throw admission("BASE_CAS_CONFLICT");
+  const byPath = new Map(claimed.map((entry) => [entry.path, entry]));
+  if (byPath.size !== claimed.length) throw admission("BASE_CAS_CONFLICT");
+  for (const { path, snapshot } of required) {
+    const row = byPath.get(path);
+    if (!row || row.expectedEpoch !== snapshot.epoch || row.expectedRevision !== snapshot.revision
+      || !taskDecisionModuleBytesEqual(row.expectedBlobDigest, snapshot.blobDigest)) throw admission("BASE_CAS_CONFLICT");
+  }
+}
+
+function parseTaskIndex(body: string): { readonly taskId: string; readonly status: string } {
+  const frontmatter = readFrontmatter(body);
+  if (!frontmatter || readScalar(frontmatter, "schema", { required: true }) !== "task-package/v2") {
+    throw admission("TASK_INDEX_INVALID");
+  }
+  const taskId = readScalar(frontmatter, "task_id", { required: true });
+  const status = readScalar(frontmatter, "  status", { required: true });
+  if (!isDomainStatus(status)) throw admission("TASK_INDEX_INVALID");
+  return { taskId, status };
+}
+
+function replaceTaskStatus(body: string, status: string): string {
+  const matches = [...body.matchAll(/^  status:[ \t]*(.*)$/gmu)];
+  if (matches.length !== 1) throw admission("TASK_INDEX_INVALID");
+  return body.replace(/^  status:[ \t]*(.*)$/mu, `  status: ${status}`);
+}
+
+function assertTaskDocumentSurface(path: string): void {
+  if (path === "INDEX.md" || path === "progress.md" || path === "facts.md"
+    || path.startsWith("executions/") || path.startsWith("reviews/")) {
+    throw admission("TASK_DOCUMENT_SURFACE_OWNED_BY_TYPED_ACTION");
+  }
+}
+
+function decodeTaskDecisionModuleDecision(value: unknown): DecisionPackage {
+  try {
+    return Schema.decodeUnknownSync(DecisionPackageSchema)(value);
+  } catch {
+    throw admission("DECISION_PAYLOAD_INVALID");
+  }
+}
+
+function assertSameDecision(current: DecisionPackage, next: DecisionPackage): void {
+  if (current.decision_id !== next.decision_id) throw admission("DECISION_ID_MISMATCH");
+}
+
+function changedDecisionFields(current: DecisionPackage, next: DecisionPackage): ReadonlyArray<keyof DecisionPackage> {
+  return (Object.keys(decisionFieldContracts) as ReadonlyArray<keyof DecisionPackage>)
+    .filter((field) => JSON.stringify(current[field]) !== JSON.stringify(next[field]));
+}
+
+function assertOnlyDecisionFieldsChanged(
+  current: DecisionPackage,
+  next: DecisionPackage,
+  allowed: ReadonlySet<keyof DecisionPackage>
+): void {
+  const rejected = changedDecisionFields(current, next).find((field) => !allowed.has(field));
+  if (rejected) throw admission(`DECISION_STATE_FIELD_INVALID:${String(rejected)}`);
+}
+
+function assertDecisionRelations(decisionId: string, relations: ReadonlyArray<EntityRelationRecord>): void {
+  for (const relation of relations) {
+    if (deriveRelationId(relation) !== relation.relation_id) throw admission("RELATION_ID_MISMATCH");
+  }
+  const issues = validateRelationRecordsForHost(`decision/${decisionId}`, relations);
+  if (issues.length > 0) throw admission(`RELATION_DOMAIN_INVALID:${issues[0]!.code}`);
+}
+
+function relationCreateIntent(relation: EntityRelationRecord): RegistryMutationPlanInput["mutations"][number] {
+  return {
+    entityKind: "relation",
+    identity: { relationId: relation.relation_id },
+    action: "create",
+    storageContext: { sourceRef: relation.source }
+  };
+}
+
+async function requiredTaskDecisionModuleDocument(
+  state: TaskDecisionModuleAuthorityStateV2,
+  path: string,
+  code: string
+): Promise<HostedDocumentSnapshotV2> {
+  const snapshot = await state.readHostedDocument(path);
+  if (!snapshot) throw admission(code);
+  return snapshot;
+}
+
+function decisionPath(decisionId: string): string {
+  const locator = entityRegistry.decision.storageLocator;
+  if (locator.status !== "ready") throw admission("REGISTRY_FACET_NOT_WRITABLE");
+  const target = locator.locator.locate({ decisionId }, {}).targets[0];
+  if (!target?.path) throw admission("DECISION_STORAGE_TARGET_REQUIRED");
+  return target.path;
+}
+
+function taskPath(taskId: string, documentPath: string): string {
+  return `tasks/${taskId}/${documentPath}`;
+}
+
+function taskDecisionModulePlan(mutations: RegistryMutationPlanInput["mutations"]): RegistryMutationPlanInput {
+  return { registryVersion, mutations };
+}
+
+function taskDecisionModuleEntityRef(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
+  return { registryVersion, entityKind, canonicalRef };
+}
+
+function taskDecisionModuleEntityRefKey(ref: RegistryEntityRefV2): string {
+  return `${ref.registryVersion}\0${ref.entityKind}\0${ref.canonicalRef}`;
+}
+
+function uniqueTaskDecisionModuleRefs(refs: ReadonlyArray<RegistryEntityRefV2>): ReadonlyArray<RegistryEntityRefV2> {
+  return [...new Map(refs.map((ref) => [taskDecisionModuleEntityRefKey(ref), ref])).values()];
+}
+
+function admission(code: string, message = code): SemanticAdmissionErrorV2 {
+  return new SemanticAdmissionErrorV2(code, message);
+}
+
+function taskDecisionModuleBytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  return Buffer.from(left).equals(Buffer.from(right));
+}
+
+function nullableTaskDecisionModuleBytesEqual(left: Uint8Array | null, right: Uint8Array | null): boolean {
+  return left === null || right === null ? left === right : taskDecisionModuleBytesEqual(left, right);
+}

--- a/packages/application/src/public-exports.ts
+++ b/packages/application/src/public-exports.ts
@@ -4,6 +4,7 @@
 // 卡 600 行。两道门夹住同一个文件 —— 搬走 barrel 是唯一不动门禁的出路。
 
 export { commandReceiptEnvelope } from "./command-receipt.ts";
+export { readModuleAttributionProjection } from "../../kernel/src/index.ts";
 export {
   authorityProtocolTuple,
   canonicalAuthorityRequestDigest,
@@ -43,6 +44,7 @@ export * from "./authority/actor-axes-binding-v2.ts";
 export * from "./authority/canonical-cbor.ts";
 export * from "./authority/semantic-mutation-envelope-v2.ts";
 export * from "./authority/fact-relation-semantic-compiler-v2.ts";
+export * from "./authority/task-decision-module-semantic-compiler-v2.ts";
 export * from "./authority/committed-attribution-event-v2.ts";
 export type { AuthoritySubmissionV2Options } from "./authority/service.ts";
 export type {

--- a/packages/application/test/task-decision-module-authority-positive-v2.test.ts
+++ b/packages/application/test/task-decision-module-authority-positive-v2.test.ts
@@ -1,0 +1,347 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  actorAxesBindingDigestV2,
+  actorAxesBindingTokenDigestV2,
+  canonicalPayloadDigestV2,
+  createAuthoritySubmissionService,
+  createInMemoryAuthorityOperationRegistry,
+  createInMemoryReplicaChangeLog,
+  encodeSemanticMutationEnvelopeV2,
+  encodeTaskDecisionModuleCommandPayloadV2,
+  issueActorAxesBindingV2,
+  makeTaskDecisionModuleSemanticCompilerV2,
+  semanticMutationEnvelopeV2Schema,
+  semanticMutationSetDigestV2,
+  semanticRequestDigestV2,
+  type ActorAxesBindingClaimsV2,
+  type ReplicaChangeLog,
+  type SemanticBaseCasV2,
+  type SemanticMutationEnvelopeV2,
+  type SemanticMutationSetV2,
+  type TaskDecisionModuleCommandPayloadV2
+} from "../src/index.ts";
+import {
+  entityRegistry,
+  makeJournaledWriteCoordinator,
+  readUnionAttributionEvents,
+  type DecisionPackage,
+  type RegistryEntityRefV2
+} from "../../kernel/src/index.ts";
+
+test("task, decision, and module typed writes publish through their existing physical stores with one digest", async () => {
+  await withHermeticGit(async ({ rootDir, env }) => {
+    const claims = actorClaims();
+    const secret = Buffer.alloc(32, 0x5a);
+    const token = issueActorAxesBindingV2(claims, {
+      algorithm: "HMAC-SHA-256", issuer: "authority.test", keyId: "key-w3", secret
+    });
+    const tokenDigest = actorAxesBindingTokenDigestV2(token);
+    const changeLog = createInMemoryReplicaChangeLog();
+    const service = authority(rootDir, env, claims, secret, tokenDigest, changeLog);
+    const fixtures: ReadonlyArray<{
+      readonly payload: TaskDecisionModuleCommandPayloadV2;
+      readonly mutationSet: SemanticMutationSetV2;
+      readonly baseCas: ReadonlyArray<SemanticBaseCasV2>;
+      readonly assertPhysical: () => void;
+    }> = [
+      {
+        payload: { schema: "task.create/v1", taskId: "task_W3", indexBody: taskIndex() },
+        mutationSet: set("task", "task/task_W3", "create"),
+        baseCas: [absent(ref("task", "task/task_W3"))],
+        assertPhysical: () => assert.match(readFileSync(path.join(rootDir, "harness/tasks/task_W3/INDEX.md"), "utf8"), /task_id: task_W3/u)
+      },
+      {
+        payload: { schema: "decision.propose/v1", decision: decisionPackage() },
+        mutationSet: set("decision", "decision/dec_W3_POS", "propose"),
+        baseCas: [absent(ref("decision", "decision/dec_W3_POS"))],
+        assertPhysical: () => assert.match(readFileSync(path.join(rootDir, "harness/decisions/decision-dec_W3_POS/decision.md"), "utf8"), /decision_id: dec_W3_POS/u)
+      },
+      {
+        payload: {
+          schema: "module.register/v1",
+          module: { key: "kernel", title: "Kernel", status: "active", scopes: ["packages/kernel/**"], steps: [] }
+        },
+        mutationSet: set("module", "module/kernel", "register"),
+        baseCas: [absent(ref("module", "module/kernel"))],
+        assertPhysical: () => {
+          const registry = JSON.parse(readFileSync(path.join(rootDir, "harness/modules.json"), "utf8")) as { readonly modules: ReadonlyArray<{ readonly key: string }> };
+          assert.deepEqual(registry.modules.map((entry) => entry.key), ["kernel"]);
+        }
+      }
+    ];
+
+    const receipts = [];
+    for (const [index, fixture] of fixtures.entries()) {
+      const envelope = bindEnvelope(requestEnvelope(index + 1, fixture.payload, fixture.baseCas, fixture.mutationSet), claims, tokenDigest);
+      const receipt = await service.submitV2!({
+        requestId: `w3-positive-${index}`,
+        presentationToken: token,
+        envelope: encodeSemanticMutationEnvelopeV2(envelope)
+      });
+      assert.equal(receipt.tag, "COMMITTED", JSON.stringify(receipt));
+      if (receipt.tag !== "COMMITTED") continue;
+      fixture.assertPhysical();
+      receipts.push({ receipt, mutationSet: fixture.mutationSet });
+    }
+    assert.equal(receipts.length, 3);
+
+    const events = readUnionAttributionEvents(rootDir);
+    const changes = await changeLog.changesAfter(claims.workspaceId, 0);
+    for (const { receipt, mutationSet } of receipts) {
+      const digest = Buffer.from(semanticMutationSetDigestV2(mutationSet)).toString("hex");
+      assert.equal(receipt.authorityIntegrity?.semanticMutationSetDigest, digest);
+      assert.equal(events.find((event) => event.opId === receipt.opId)?.authorityIntegrity?.semanticMutationSetDigest, digest);
+      assert.equal(changes.find((change) => change.opId === receipt.opId)?.authorityIntegrity?.semanticMutationSetDigest, digest);
+      assert.deepEqual(readBatchTrailer(git(rootDir, env, "log", "-1", "--format=%B", receipt.commitSha)), [{
+        opId: receipt.opId,
+        semanticMutationSetDigest: digest
+      }]);
+    }
+    assert.equal(existsSync(path.join(rootDir, "harness/modules/kernel.json")), false);
+  });
+});
+
+function authority(
+  rootDir: string,
+  env: NodeJS.ProcessEnv,
+  claims: ActorAxesBindingClaimsV2,
+  secret: Uint8Array,
+  tokenDigest: Uint8Array,
+  changeLog: ReplicaChangeLog
+) {
+  return createAuthoritySubmissionService({
+    workspaceId: claims.workspaceId,
+    coordinatorFactory: {
+      create: ({ attribution }) => makeJournaledWriteCoordinator({
+        rootDir,
+        attribution,
+        commitAuthor: { name: "ZeyuLi", email: "zeyuli@example.test" },
+        autoMaterialize: false
+      })
+    },
+    tokenVerifier: { verify: async () => { throw new Error("v1 verifier must not run"); } },
+    operationRegistry: createInMemoryAuthorityOperationRegistry(),
+    replicaChangeLog: changeLog,
+    publicationInspector: {
+      currentHead: async () => gitOptional(rootDir, env, "rev-parse", "--verify", "HEAD"),
+      inspectPublishedHead: async () => {
+        const row = git(rootDir, env, "rev-list", "--parents", "-n", "1", "HEAD").split(" ");
+        return { commitSha: row[0]!, parentCommits: row.slice(1) };
+      }
+    },
+    fenceWitness: { assertHeld: async () => undefined },
+    v2: {
+      schemaTuple,
+      channelNonceDigest,
+      bindingRuntime: {
+        proofKeys: { resolve: () => ({ algorithm: "HMAC-SHA-256", secret }) },
+        validatePresentationToken: async (input) => bytesEqual(input.tokenDigest, tokenDigest),
+        getBinding: async () => ({
+          bindingId: claims.bindingId,
+          principalPersonId: claims.principalPersonId,
+          executorAgentId: claims.executorAgentId,
+          workspaceId: claims.workspaceId,
+          deviceId: claims.deviceId,
+          viewId: claims.viewId,
+          sessionId: claims.sessionId,
+          active: true,
+          attribution: {
+            actor: {
+              principal: { kind: "person", personId: claims.principalPersonId },
+              executor: { kind: "agent", id: claims.executorAgentId! }
+            },
+            principalSource: { kind: "daemon-authenticated", providerId: "authority.test", credentialFingerprint: "sha256:redacted" },
+            executorSource: "client-asserted"
+          }
+        }),
+        currentAuthorityGeneration: () => claims.authorityGeneration,
+        currentRevocationEpochs: async () => claims.revocationEpochs,
+        nowMs: () => 2_000n,
+        consumeOperation: async () => true,
+        validateAdmissionTokenRef: async (input) => input.tokenId === claims.tokenId && bytesEqual(input.tokenDigest, tokenDigest)
+      },
+      entityRegistrations: [entityRegistry.task, entityRegistry.decision, entityRegistry.module],
+      semanticCompiler: makeTaskDecisionModuleSemanticCompilerV2({
+        state: { readEntityBase: async () => null, readHostedDocument: async () => null }
+      }),
+      operationNamespaceVerifier: { verify: async () => undefined }
+    }
+  });
+}
+
+function requestEnvelope(
+  randomByte: number,
+  payloadValue: TaskDecisionModuleCommandPayloadV2,
+  baseCas: ReadonlyArray<SemanticBaseCasV2>,
+  mutationSet: SemanticMutationSetV2
+): SemanticMutationEnvelopeV2 {
+  const payload = encodeTaskDecisionModuleCommandPayloadV2(payloadValue);
+  return finalize({
+    schema: semanticMutationEnvelopeV2Schema,
+    workspaceId: "workspace-w3-positive",
+    operationId: {
+      namespace: {
+        schema: "operation-namespace/v1", workspaceId: "workspace-w3-positive", deviceId: "device-w3",
+        authorityGeneration: 1n, namespaceId: "namespace-w3", expiresAt: 8_000n,
+        issuer: "authority.test", keyId: "namespace-key", proof: Buffer.alloc(32, 3)
+      },
+      clientRandom128: Buffer.alloc(16, randomByte)
+    },
+    binding: {
+      bindingId: "binding-w3", actorAxesBindingDigest: Buffer.alloc(32), deviceId: "device-w3",
+      viewId: "view-w3", sessionId: "session-w3",
+      admissionTokenRef: { tokenId: "token-w3", tokenDigest: Buffer.alloc(32) }
+    },
+    schemaTuple,
+    intent: {
+      kind: "typed",
+      command: { registryVersion: 1, name: payloadValue.schema.replace("/v1", ""), version: 1 },
+      canonicalPayload: { kind: "inline", size: BigInt(payload.length), bytes: payload },
+      canonicalPayloadDigest: canonicalPayloadDigestV2(payload),
+      baseCas,
+      declaredPathCas: []
+    },
+    claimedMutationSet: mutationSet,
+    claimedSemanticMutationSetDigest: semanticMutationSetDigestV2(mutationSet),
+    claimedSemanticRequestDigest: Buffer.alloc(32)
+  });
+}
+
+function bindEnvelope(
+  envelope: SemanticMutationEnvelopeV2,
+  claims: ActorAxesBindingClaimsV2,
+  tokenDigest: Uint8Array
+): SemanticMutationEnvelopeV2 {
+  return finalize({
+    ...envelope,
+    binding: {
+      bindingId: claims.bindingId,
+      actorAxesBindingDigest: actorAxesBindingDigestV2(claims),
+      deviceId: claims.deviceId,
+      viewId: claims.viewId,
+      sessionId: claims.sessionId,
+      admissionTokenRef: { tokenId: claims.tokenId, tokenDigest }
+    }
+  });
+}
+
+function finalize(envelope: SemanticMutationEnvelopeV2): SemanticMutationEnvelopeV2 {
+  return { ...envelope, claimedSemanticRequestDigest: semanticRequestDigestV2(envelope) };
+}
+
+function actorClaims(): ActorAxesBindingClaimsV2 {
+  return {
+    tokenId: "token-w3", bindingId: "binding-w3", principalPersonId: "person_zeyu", executorAgentId: "agent_w3",
+    workspaceId: "workspace-w3-positive", deviceId: "device-w3", viewId: "view-w3", sessionId: "session-w3",
+    allowedEntityKinds: ["task", "module", "decision"],
+    allowedActions: ["create", "propose", "register"],
+    resourceScopes: [{ kind: "workspace" }], pathFootprint: null,
+    maxBytes: 128n * 1024n, maxMutations: 8, maxOperations: 8,
+    authorityGeneration: 1n, channelNonceDigest, schemaTuple,
+    issuedAt: 1_000n, notBefore: 1_000n, expiresAt: 9_000n,
+    revocationEpochs: { global: 1n, workspace: 1n, device: 1n, view: 1n, principal: 1n, executor: 1n }
+  };
+}
+
+async function withHermeticGit(body: (input: { readonly rootDir: string; readonly env: NodeJS.ProcessEnv }) => Promise<void>) {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-w3-positive-"));
+  const env = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_AUTHOR_NAME: "ZeyuLi", GIT_AUTHOR_EMAIL: "zeyuli@example.test",
+    GIT_COMMITTER_NAME: "Harness Authority", GIT_COMMITTER_EMAIL: "authority@example.test"
+  };
+  try {
+    execFileSync("git", ["-C", rootDir, "init", "-q"], { env });
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+    execFileSync("git", ["-C", path.join(rootDir, "harness"), "init", "-q"], { env });
+    execFileSync("git", ["-C", path.join(rootDir, "harness"), "commit", "--allow-empty", "-m", "test: initialize W3 positive control"], { env });
+    await body({ rootDir, env });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function set(entityKind: string, canonicalRef: string, action: string): SemanticMutationSetV2 {
+  return { registryVersion: 1, mutations: [{ entity: ref(entityKind, canonicalRef), action: { registryVersion: 1, action } }] };
+}
+
+function ref(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
+  return { registryVersion: 1, entityKind, canonicalRef };
+}
+
+function absent(entityRef: RegistryEntityRefV2): SemanticBaseCasV2 {
+  return { entityRef, expectedSemanticVersion: null, expectedStateDigest: null };
+}
+
+function taskIndex(): string {
+  return [
+    "---", "schema: task-package/v2", "task_id: task_W3", "title: W3 positive",
+    "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", "  status: planned",
+    "  ref: ", "  titleSnapshot: W3 positive", "  url: ",
+    "  bindingCreatedAt: 2026-07-14T00:00:00.000Z", `  bindingFingerprint: sha256:${"b".repeat(64)}`,
+    "packageDisposition: active", "vertical: default", "preset: default",
+    "provenance:", "  - {runtime: codex, sessionId: session-w3, boundAt: 2026-07-14T00:00:00.000Z}",
+    "---", "", "# W3 positive", ""
+  ].join("\n");
+}
+
+function decisionPackage(): DecisionPackage {
+  return {
+    schema: "decision-package/v1", decision_id: "dec_W3_POS", title: "W3 positive", state: "proposed",
+    riskTier: "medium", urgency: "medium", vertical: "software/coding", preset: "architecture-decision",
+    applies_to: { modules: [], productLines: [] }, proposedAt: "2026-07-14T00:00:00.000Z",
+    provenance: [{ runtime: "codex", sessionId: "session-w3", boundAt: "2026-07-14T00:00:00.000Z" }],
+    question: "Should W3 publish a decision?", chosen: [{ id: "CH1", text: "Yes." }],
+    rejected: [{ id: "RJ1", text: "No.", why_not: "Positive control requires a write." }],
+    claims: [{ id: "C1", text: "The write is typed." }], relations: []
+  };
+}
+
+function git(rootDir: string, env: NodeJS.ProcessEnv, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", path.join(rootDir, "harness"), ...args], { encoding: "utf8", env }).trim();
+}
+
+function gitOptional(rootDir: string, env: NodeJS.ProcessEnv, ...args: ReadonlyArray<string>): string | null {
+  try { return git(rootDir, env, ...args); } catch { return null; }
+}
+
+function readBatchTrailer(commitBody: string): ReadonlyArray<{ readonly opId: string; readonly semanticMutationSetDigest: string }> {
+  const value = commitBody.split("\n")
+    .find((line) => line.startsWith("Harness-Authority-Batch: "))
+    ?.slice("Harness-Authority-Batch: ".length);
+  if (!value) throw new Error("authority batch trailer missing");
+  const encoded = value.split(":").at(-1);
+  if (!encoded) throw new Error("authority batch trailer vector missing");
+  const bytes = Buffer.from(encoded, "base64url");
+  const count = bytes.readUInt32BE(0);
+  let offset = 4;
+  const entries: Array<{ readonly opId: string; readonly semanticMutationSetDigest: string }> = [];
+  for (let index = 0; index < count; index += 1) {
+    const length = bytes.readUInt32BE(offset);
+    offset += 4;
+    const opId = bytes.subarray(offset, offset + length).toString("utf8");
+    offset += length;
+    const semanticMutationSetDigest = bytes.subarray(offset, offset + 32).toString("hex");
+    offset += 32;
+    entries.push({ opId, semanticMutationSetDigest });
+  }
+  return entries;
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  return Buffer.from(left).equals(Buffer.from(right));
+}
+
+const channelNonceDigest = Buffer.alloc(32, 0x22);
+const schemaTuple = {
+  wire: 2, event: 2, receipt: 2, digest: 2, policy: 1,
+  commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
+} as const;

--- a/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
+++ b/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
@@ -1,0 +1,558 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  assertMutationClaimMatchesV2,
+  canonicalPayloadDigestV2,
+  encodeFactRelationCommandPayloadV2,
+  encodeTaskDecisionModuleCommandPayloadV2,
+  makeFactRelationSemanticCompilerV2,
+  makeTaskDecisionModuleSemanticCompilerV2,
+  materializeCommittedAttributionEventV2,
+  materializeCommittedAttributionProjectionV2,
+  readModuleAttributionProjection,
+  semanticMutationEnvelopeV2Schema,
+  semanticMutationSetDigestV2,
+  semanticRequestDigestV2,
+  type FactRelationCommandPayloadV2,
+  type HostedDocumentSnapshotV2,
+  type ModuleRecordV2,
+  type PathCasV2,
+  type RegistryEntityRefV2,
+  type SemanticBaseCasV2,
+  type SemanticEntityBaseV2,
+  type SemanticMutationEnvelopeV2,
+  type SemanticMutationSetV2,
+  type TaskDecisionModuleCommandPayloadV2
+} from "../src/index.ts";
+import {
+  actorAxesBindingCoreDigestV2,
+  compileRegistryMutationPlan,
+  createWritableEntityRegistry,
+  deriveRelationId,
+  entityRegistry,
+  type DecisionPackage,
+  type EntityRegistration,
+  type EntityRelationRecord
+} from "../../kernel/src/index.ts";
+
+const registry = createWritableEntityRegistry([
+  entityRegistry.task,
+  entityRegistry.decision,
+  entityRegistry.module,
+  entityRegistry.relation
+]);
+const stateDigest = Buffer.alloc(32, 0x11);
+
+test("task/decision/module register only their OQ-3 actions and remain typed-only", () => {
+  assert.deepEqual(entityRegistry.task.mutationContract, { status: "ready", actions: ["create", "transition", "append", "document"] });
+  assert.deepEqual(entityRegistry.decision.mutationContract, { status: "ready", actions: ["propose", "state", "amend", "relation"] });
+  assert.deepEqual(entityRegistry.module.mutationContract, { status: "ready", actions: ["register", "unregister", "step"] });
+  assert.equal(entityRegistry.task.semanticDiff.status, "typed-only");
+  assert.equal(entityRegistry.decision.semanticDiff.status, "typed-only");
+  assert.equal(entityRegistry.module.semanticDiff.status, "typed-only");
+  assert.equal(entityRegistry.module.projectionFacet.status, "ready");
+  assert.deepEqual(entityRegistry.module.projectionFacet.status === "ready"
+    ? entityRegistry.module.projectionFacet.attributionTarget
+    : null, {
+    table: "module_attribution_projection",
+    idColumn: "module_key",
+    identityField: "moduleKey",
+    materialization: "mutation-index"
+  });
+});
+
+test("all task actions compile to one exact package-hosted StoragePlan", async () => {
+  const taskId = "task_T";
+  const taskRef = ref("task", `task/${taskId}`);
+  const index = taskIndex(taskId, "planned");
+  const indexSnapshot = snapshot(index);
+  const bases = new Map([[key(taskRef), base("task-v1")]]);
+  const documents = new Map([[`tasks/${taskId}/INDEX.md`, indexSnapshot]]);
+  const compiler = makeTaskDecisionModuleSemanticCompilerV2({ state: authorityState(bases, documents) });
+
+  const fixtures: ReadonlyArray<{
+    readonly payload: TaskDecisionModuleCommandPayloadV2;
+    readonly baseCas: ReadonlyArray<SemanticBaseCasV2>;
+    readonly pathCas?: ReadonlyArray<PathCasV2>;
+    readonly pair: string;
+    readonly target: string;
+    readonly opKind: string;
+  }> = [
+    {
+      payload: { schema: "task.create/v1", taskId: "task_NEW", packageSlug: "new", indexBody: taskIndex("task_NEW", "planned") },
+      baseCas: [absent(ref("task", "task/task_NEW"))],
+      pair: "task/task_NEW:create", target: "tasks/task_NEW/INDEX.md", opKind: "package_create"
+    },
+    {
+      payload: { schema: "task.transition/v1", taskId, to: "active" },
+      baseCas: [present(taskRef, "task-v1")], pathCas: [cas(`tasks/${taskId}/INDEX.md`, indexSnapshot)],
+      pair: `task/${taskId}:transition`, target: `tasks/${taskId}/INDEX.md`, opKind: "transition_local"
+    },
+    {
+      payload: { schema: "task.append/v1", taskId, text: "2026-07-14 W3 typed progress" },
+      baseCas: [present(taskRef, "task-v1")],
+      pair: `task/${taskId}:append`, target: `tasks/${taskId}/progress.md`, opKind: "progress_append"
+    },
+    {
+      payload: { schema: "task.document/v1", taskId, path: "notes/design.md", body: "# Design\n" },
+      baseCas: [present(taskRef, "task-v1")],
+      pair: `task/${taskId}:document`, target: `tasks/${taskId}/notes/design.md`, opKind: "doc_write"
+    }
+  ];
+
+  for (const fixture of fixtures) {
+    const compiled = await compiler.compile(envelope(fixture.payload, fixture.baseCas, fixture.pathCas));
+    const plan = compileRegistryMutationPlan(registry, compiled.mutationPlan);
+    assert.deepEqual(plan.mutationSet.mutations.map(pair), [fixture.pair]);
+    assert.deepEqual(plan.storagePlan.touchedPaths, [fixture.target]);
+    assert.deepEqual(plan.storagePlan.consistencyScopes, [`entity:task/${fixture.payload.taskId}`]);
+    assert.equal(compiled.operation.kind, fixture.opKind);
+  }
+});
+
+test("all decision actions compile exact decision mutations; relation also creates its first-class relation", async () => {
+  const proposed = decisionPackage();
+  const active = decisionPackage({
+    state: "active",
+    decidedAt: "2026-07-14T00:00:00.000Z",
+    contentPins: [contentPin()]
+  });
+  const proposedSnapshot = snapshot(decisionDocument(proposed));
+  const activeSnapshot = snapshot(decisionDocument(active));
+  const decisionRef = ref("decision", "decision/dec_W3");
+  const relation = relationRecord("decision/dec_W3/C1", "task/task_T", "derives");
+  const relationRef = ref("relation", `relation/${relation.relation_id}`);
+
+  const cases = [
+    {
+      payload: { schema: "decision.propose/v1", decision: proposed } as const,
+      state: authorityState(), baseCas: [absent(decisionRef)], pathCas: [],
+      expected: ["decision/dec_W3:propose"], opKind: "decision_propose"
+    },
+    {
+      payload: { schema: "decision.state/v1", transition: "accept", decision: active } as const,
+      state: authorityState(new Map([[key(decisionRef), base("decision-v1")]]), new Map([[decisionPath(), proposedSnapshot]])),
+      baseCas: [present(decisionRef, "decision-v1")], pathCas: [cas(decisionPath(), proposedSnapshot)],
+      expected: ["decision/dec_W3:state"], opKind: "decision_accept"
+    },
+    {
+      payload: { schema: "decision.amend/v1", decision: { ...active, title: "Amended decision" } } as const,
+      state: authorityState(new Map([[key(decisionRef), base("decision-v2")]]), new Map([[decisionPath(), activeSnapshot]])),
+      baseCas: [present(decisionRef, "decision-v2")], pathCas: [cas(decisionPath(), activeSnapshot)],
+      expected: ["decision/dec_W3:amend"], opKind: "decision_amend"
+    },
+    {
+      payload: { schema: "decision.relation/v1", decisionId: "dec_W3", relation } as const,
+      state: authorityState(new Map([[key(decisionRef), base("decision-v2")]]), new Map([[decisionPath(), activeSnapshot]])),
+      baseCas: [present(decisionRef, "decision-v2"), absent(relationRef)], pathCas: [cas(decisionPath(), activeSnapshot)],
+      expected: [`decision/dec_W3:relation`, `relation/${relation.relation_id}:create`], opKind: "decision_relate"
+    }
+  ];
+
+  for (const fixture of cases) {
+    const compiler = makeTaskDecisionModuleSemanticCompilerV2({ state: fixture.state });
+    const compiled = await compiler.compile(envelope(fixture.payload, fixture.baseCas, fixture.pathCas));
+    const plan = compileRegistryMutationPlan(registry, compiled.mutationPlan);
+    assert.deepEqual(new Set(plan.mutationSet.mutations.map(pair)), new Set(fixture.expected));
+    assert.deepEqual(plan.storagePlan.touchedPaths, [decisionPath()]);
+    assert.equal(compiled.operation.kind, fixture.opKind);
+  }
+});
+
+test("module register/unregister/step compile canonical modules.json snapshots", async () => {
+  const module = moduleRecord();
+  const moduleRef = ref("module", "module/kernel");
+  const registryBody = `${JSON.stringify({ schema: "module-registry/v1", modules: [module] }, null, 2)}\n`;
+  const registrySnapshot = snapshot(registryBody);
+  const presentState = authorityState(
+    new Map([[key(moduleRef), base("module-v1")]]),
+    new Map([["modules.json", registrySnapshot]])
+  );
+  const fixtures = [
+    {
+      payload: { schema: "module.register/v1", module } as const,
+      state: authorityState(), baseCas: [absent(moduleRef)], pathCas: [], action: "register"
+    },
+    {
+      payload: { schema: "module.unregister/v1", moduleKey: "kernel" } as const,
+      state: presentState, baseCas: [present(moduleRef, "module-v1")], pathCas: [cas("modules.json", registrySnapshot)], action: "unregister"
+    },
+    {
+      payload: { schema: "module.step/v1", moduleKey: "kernel", stepId: "W3", state: "done" } as const,
+      state: presentState, baseCas: [present(moduleRef, "module-v1")], pathCas: [cas("modules.json", registrySnapshot)], action: "step"
+    }
+  ];
+
+  for (const fixture of fixtures) {
+    const compiler = makeTaskDecisionModuleSemanticCompilerV2({ state: fixture.state });
+    const compiled = await compiler.compile(envelope(fixture.payload, fixture.baseCas, fixture.pathCas));
+    const plan = compileRegistryMutationPlan(registry, compiled.mutationPlan);
+    assert.deepEqual(plan.mutationSet.mutations.map(pair), [`module/kernel:${fixture.action}`]);
+    assert.deepEqual(plan.storagePlan.touchedPaths, ["modules.json"]);
+    assert.equal(compiled.operation.entityId, "module/kernel");
+    assert.equal(compiled.operation.kind, "module_registry_write");
+    assert.equal((compiled.operation.payload as { readonly operation: string }).operation, fixture.action);
+  }
+});
+
+test("every W3 action is independently disabled at the named registry boundary", async () => {
+  for (const registration of [entityRegistry.task, entityRegistry.decision, entityRegistry.module] as const) {
+    if (registration.mutationContract.status !== "ready") throw new Error("fixture requires ready mutation contract");
+    for (const action of registration.mutationContract.actions) {
+      const disabled = {
+        ...registration,
+        mutationContract: {
+          status: "ready" as const,
+          actions: registration.mutationContract.actions.filter((candidate) => candidate !== action)
+        }
+      } as EntityRegistration<string, typeof registration.kind>;
+      const gated = createWritableEntityRegistry([disabled]);
+      assert.throws(() => compileRegistryMutationPlan(gated, {
+        registryVersion: 1,
+        mutations: [{
+          entityKind: registration.kind,
+          identity: identityFor(registration.kind),
+          action,
+          ...(registration.kind === "task" ? { storageContext: { documentPath: "INDEX.md" } } : {})
+        }]
+      }), new RegExp(`UNKNOWN_SEMANTIC_ACTION:${registration.kind}:${action}`, "u"));
+    }
+  }
+});
+
+test("storage-only hosted fact bytes never upgrade into a task mutation", async () => {
+  const factRef = ref("fact", "fact/task_T/F-DEADBEEF");
+  const factPayload: FactRelationCommandPayloadV2 = {
+    schema: "fact.create/v1",
+    ownerTaskId: "task_T",
+    factId: "F-DEADBEEF",
+    statement: "Hosted storage is not a task semantic mutation.",
+    source: "W3 boundary control",
+    observedAt: "2026-07-14T00:00:00.000Z",
+    confidence: "high",
+    memoryClass: "episodic",
+    memoryTags: [],
+    provenance: [{ runtime: "codex", sessionId: "w3", boundAt: "2026-07-14T00:00:00.000Z" }]
+  };
+  const compiler = makeFactRelationSemanticCompilerV2({ state: authorityState() });
+  const compiled = await compiler.compile(factEnvelope(factPayload, [absent(factRef)]));
+  const plan = compileRegistryMutationPlan(createWritableEntityRegistry([entityRegistry.fact]), compiled.mutationPlan);
+  assert.deepEqual(plan.storagePlan.touchedPaths, ["tasks/task_T/facts.md"]);
+  assert.deepEqual(plan.mutationSet.mutations.map(pair), ["fact/task_T/F-DEADBEEF:create"]);
+  assert.equal(plan.mutationSet.mutations.some((mutation) => mutation.entity.entityKind === "task"), false);
+
+  const taskCompiler = makeTaskDecisionModuleSemanticCompilerV2({ state: authorityState() });
+  await assert.rejects(taskCompiler.compile(envelope({
+    schema: "task.document/v1", taskId: "task_T", path: "facts.md", body: "# Facts\n"
+  }, [absent(ref("task", "task/task_T"))])), /TASK_DOCUMENT_SURFACE_OWNED_BY_TYPED_ACTION/u);
+});
+
+test("unknown command, transparent fallback, base-CAS, and mutation claim mismatch fail closed", async () => {
+  const moduleRef = ref("module", "module/kernel");
+  const payload = { schema: "module.register/v1", module: moduleRecord() } as const;
+  const compiler = makeTaskDecisionModuleSemanticCompilerV2({ state: authorityState() });
+  const draft = envelope(payload, [absent(moduleRef)]);
+  const compiled = await compiler.compile(draft);
+  const exact = compileRegistryMutationPlan(registry, compiled.mutationPlan).mutationSet;
+  const omission: SemanticMutationSetV2 = { registryVersion: 1, mutations: [] };
+  assert.throws(() => assertMutationClaimMatchesV2(withClaim(draft, omission), exact), /SEMANTIC_MUTATION_MISMATCH/u);
+
+  if (draft.intent.kind !== "typed") throw new Error("fixture must be typed");
+  await assert.rejects(compiler.compile(finalize({
+    ...draft,
+    intent: { ...draft.intent, command: { ...draft.intent.command, name: "module.unknown" } }
+  })), /TYPED_COMMAND_UNREGISTERED/u);
+  await assert.rejects(compiler.compile(finalize({
+    ...draft,
+    intent: { kind: "transparent-file", interpretation: "full-semantic", files: [] }
+  })), /TYPED_COMMAND_REQUIRED/u);
+  await assert.rejects(compiler.compile(envelope(payload, [present(moduleRef, "wrong-version")])), /BASE_CAS_CONFLICT/u);
+});
+
+test("module journal mutation appears in registry-derived attribution read surface with cross-layer digests", () => {
+  const mutationSet: SemanticMutationSetV2 = {
+    registryVersion: 1,
+    mutations: [{
+      entity: ref("module", "module/kernel"),
+      action: { registryVersion: 1, action: "step" }
+    }]
+  };
+  const actorAxesBinding = {
+    bindingId: "binding-w3",
+    principalPersonId: "person_zeyu",
+    executorAgentId: "agent_w3",
+    workspaceId: "workspace-w3",
+    deviceId: "device-w3",
+    viewId: "view-w3",
+    sessionId: "session-w3",
+    schemaTuple
+  };
+  const mutationDigest = Buffer.from(semanticMutationSetDigestV2(mutationSet)).toString("hex");
+  const actorDigest = Buffer.from(actorAxesBindingCoreDigestV2(actorAxesBinding)).toString("hex");
+  const event = materializeCommittedAttributionEventV2({
+    receipt: {
+      tag: "COMMITTED",
+      workspaceId: "workspace-w3",
+      opId: "op-module-step",
+      semanticDigest: "33".repeat(32),
+      revision: 9,
+      commitSha: "a".repeat(40),
+      previousCommit: "b".repeat(40),
+      authorityIntegrity: {
+        schema: "authority-operation-integrity/v2",
+        semanticRequestDigest: "33".repeat(32),
+        semanticMutationSetDigest: mutationDigest,
+        mutationRegistryVersion: 1,
+        actorAxesBindingDigest: actorDigest,
+        canonicalMutationSet: mutationSet
+      }
+    },
+    actorAxesBinding,
+    physicalChanges: [{ path: "modules.json", beforeDigest: "44".repeat(32), afterDigest: "55".repeat(32) }],
+    occurredAt: "2026-07-14T00:00:00.000Z",
+    recordedAt: "2026-07-14T00:00:00.001Z"
+  });
+  const root = mkdtempSync(path.join(tmpdir(), "ha-w3-module-attribution-"));
+  try {
+    const projectionPath = path.join(root, "projection.sqlite");
+    writeFileSync(projectionPath, "", "utf8");
+    const rows = materializeCommittedAttributionProjectionV2(projectionPath, [event]);
+    const modules = readModuleAttributionProjection(projectionPath, "kernel");
+    assert.deepEqual(rows.map((row) => [row.subjectRef, row.operation]), [["module/kernel", "step"]]);
+    assert.equal(event.semanticMutationSetDigest, mutationDigest);
+    assert.equal(event.actorAxesBindingDigest, actorDigest);
+    assert.equal(modules.length, 1);
+    assert.equal(modules[0]?.moduleKey, "kernel");
+    assert.equal(modules[0]?.attribution.completeness, "complete");
+    assert.equal(modules[0]?.attribution.trailCount, 1);
+    assert.equal(modules[0]?.attribution.latestActor?.principal.personId, "person_zeyu");
+    assert.equal(modules[0]?.attribution.latestActor?.executor?.id, "agent_w3");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function envelope(
+  payloadValue: TaskDecisionModuleCommandPayloadV2,
+  baseCas: ReadonlyArray<SemanticBaseCasV2>,
+  declaredPathCas: ReadonlyArray<PathCasV2> = []
+): SemanticMutationEnvelopeV2 {
+  const payload = encodeTaskDecisionModuleCommandPayloadV2(payloadValue);
+  return typedEnvelope(payloadValue.schema.replace("/v1", ""), payload, baseCas, declaredPathCas);
+}
+
+function factEnvelope(
+  payloadValue: FactRelationCommandPayloadV2,
+  baseCas: ReadonlyArray<SemanticBaseCasV2>
+): SemanticMutationEnvelopeV2 {
+  const payload = encodeFactRelationCommandPayloadV2(payloadValue);
+  return typedEnvelope(payloadValue.schema.replace("/v1", ""), payload, baseCas, []);
+}
+
+function typedEnvelope(
+  command: string,
+  payload: Uint8Array,
+  baseCas: ReadonlyArray<SemanticBaseCasV2>,
+  declaredPathCas: ReadonlyArray<PathCasV2>
+): SemanticMutationEnvelopeV2 {
+  const mutationSet: SemanticMutationSetV2 = { registryVersion: 1, mutations: [] };
+  return finalize({
+    schema: semanticMutationEnvelopeV2Schema,
+    workspaceId: "workspace-w3",
+    operationId: {
+      namespace: {
+        schema: "operation-namespace/v1", workspaceId: "workspace-w3", deviceId: "device-w3",
+        authorityGeneration: 1n, namespaceId: "namespace-w3", expiresAt: 9_000n,
+        issuer: "authority.test", keyId: "namespace-key", proof: Buffer.alloc(32, 3)
+      },
+      clientRandom128: Buffer.alloc(16, 7)
+    },
+    binding: {
+      bindingId: "binding-w3", actorAxesBindingDigest: Buffer.alloc(32, 4), deviceId: "device-w3",
+      viewId: "view-w3", sessionId: "session-w3",
+      admissionTokenRef: { tokenId: "token-w3", tokenDigest: Buffer.alloc(32, 5) }
+    },
+    schemaTuple,
+    intent: {
+      kind: "typed",
+      command: { registryVersion: 1, name: command, version: 1 },
+      canonicalPayload: { kind: "inline", size: BigInt(payload.length), bytes: payload },
+      canonicalPayloadDigest: canonicalPayloadDigestV2(payload),
+      baseCas,
+      declaredPathCas
+    },
+    claimedMutationSet: mutationSet,
+    claimedSemanticMutationSetDigest: semanticMutationSetDigestV2(mutationSet),
+    claimedSemanticRequestDigest: Buffer.alloc(32)
+  });
+}
+
+function finalize(envelopeValue: SemanticMutationEnvelopeV2): SemanticMutationEnvelopeV2 {
+  return { ...envelopeValue, claimedSemanticRequestDigest: semanticRequestDigestV2(envelopeValue) };
+}
+
+function withClaim(envelopeValue: SemanticMutationEnvelopeV2, claim: SemanticMutationSetV2): SemanticMutationEnvelopeV2 {
+  return finalize({
+    ...envelopeValue,
+    claimedMutationSet: claim,
+    claimedSemanticMutationSetDigest: semanticMutationSetDigestV2(claim)
+  });
+}
+
+function authorityState(
+  bases: ReadonlyMap<string, SemanticEntityBaseV2> = new Map(),
+  documents: ReadonlyMap<string, HostedDocumentSnapshotV2> = new Map()
+) {
+  return {
+    readEntityBase: async (entityRef: RegistryEntityRefV2) => bases.get(key(entityRef)) ?? null,
+    readHostedDocument: async (documentPath: string) => documents.get(documentPath) ?? null
+  };
+}
+
+function decisionPackage(overrides: Partial<DecisionPackage> = {}): DecisionPackage {
+  return {
+    schema: "decision-package/v1",
+    decision_id: "dec_W3",
+    _coordinatorWatermark: "watermark-w3",
+    title: "W3 decision",
+    state: "proposed",
+    riskTier: "medium",
+    urgency: "medium",
+    vertical: "software/coding",
+    preset: "architecture-decision",
+    applies_to: { modules: ["kernel"], productLines: [] },
+    proposedAt: "2026-07-14T00:00:00.000Z",
+    provenance: [{ runtime: "codex", sessionId: "session-w3", boundAt: "2026-07-14T00:00:00.000Z" }],
+    question: "Should W3 compile typed mutations?",
+    chosen: [{ id: "CH1", text: "Compile at the authority." }],
+    rejected: [{ id: "RJ1", text: "Trust the client.", why_not: "Claims are completeness assertions only." }],
+    claims: [{ id: "C1", text: "Authority recomputes the canonical set." }],
+    relations: [],
+    ...overrides
+  };
+}
+
+function contentPin() {
+  return {
+    action: "accept" as const,
+    state: "active" as const,
+    decidedAt: "2026-07-14T00:00:00.000Z",
+    arbiter: { kind: "human" as const, id: "person_zeyu" },
+    canonicalization: "decision-content/v1" as const,
+    digest: `sha256:${"a".repeat(64)}`
+  };
+}
+
+function decisionDocument(decision: DecisionPackage): string {
+  return [
+    "---", `schema: ${decision.schema}`, `decision_id: ${decision.decision_id}`,
+    `_coordinatorWatermark: ${decision._coordinatorWatermark ?? "watermark-w3"}`,
+    `title: ${JSON.stringify(decision.title)}`, `state: ${decision.state}`,
+    `riskTier: ${decision.riskTier}`, `urgency: ${decision.urgency}`,
+    `vertical: ${JSON.stringify(decision.vertical)}`, `preset: ${JSON.stringify(decision.preset)}`,
+    "applies_to:", `  modules: ${flowArray(decision.applies_to.modules)}`, `  productLines: ${flowArray(decision.applies_to.productLines)}`,
+    `proposedAt: ${JSON.stringify(decision.proposedAt)}`,
+    ...(decision.decidedAt ? [`decidedAt: ${JSON.stringify(decision.decidedAt)}`] : []),
+    ...(decision.contentPins ? ["contentPins:", ...decision.contentPins.map((entry) => `  - ${flowObject(entry)}`)] : []),
+    "provenance:", ...decision.provenance.map((entry) => `  - ${flowObject(entry)}`),
+    `question: ${JSON.stringify(decision.question)}`,
+    "chosen:", ...decision.chosen.map((entry) => `  - ${flowObject(entry)}`),
+    "rejected:", ...decision.rejected.map((entry) => `  - ${flowObject(entry)}`),
+    "claims:", ...decision.claims.map((entry) => `  - ${flowObject(entry)}`),
+    "relations:", ...decision.relations.map((entry) => `  - ${flowObject(entry)}`),
+    "---", "", `# ${decision.title}`, ""
+  ].join("\n");
+}
+
+function flowArray(values: ReadonlyArray<string>): string {
+  return `[${values.map((value) => JSON.stringify(value)).join(", ")}]`;
+}
+
+function flowObject(value: Record<string, unknown>): string {
+  return `{ ${Object.entries(value).map(([key, entry]) => `${key}: ${flowValue(entry)}`).join(", ")} }`;
+}
+
+function flowValue(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value)) return flowArray(value.map(String));
+  if (value && typeof value === "object") return flowObject(value as Record<string, unknown>);
+  return JSON.stringify(value);
+}
+
+function relationRecord(source: string, target: string, type: EntityRelationRecord["type"]): EntityRelationRecord {
+  const row = {
+    source, target, type, strength: "strong" as const, direction: "directed" as const,
+    origin: "declared" as const, rationale: "W3 relation mutation.", state: "active" as const
+  };
+  return { relation_id: deriveRelationId(row), ...row };
+}
+
+function moduleRecord(): ModuleRecordV2 {
+  return {
+    key: "kernel", title: "Kernel", status: "active", scopes: ["packages/kernel/**"],
+    shared: [], dependsOn: [], steps: []
+  };
+}
+
+function taskIndex(taskId: string, status: string): string {
+  return [
+    "---", "schema: task-package/v2", `task_id: ${taskId}`, `title: ${taskId}`,
+    "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", `  status: ${status}`,
+    "  ref: ", `  titleSnapshot: ${taskId}`, "  url: ",
+    "  bindingCreatedAt: 2026-07-14T00:00:00.000Z", `  bindingFingerprint: sha256:${"b".repeat(64)}`,
+    "packageDisposition: active", "vertical: default", "preset: default",
+    "provenance:", "  - {runtime: codex, sessionId: session-w3, boundAt: 2026-07-14T00:00:00.000Z}",
+    "---", "", `# ${taskId}`, ""
+  ].join("\n");
+}
+
+function snapshot(body: string): HostedDocumentSnapshotV2 {
+  return { body, epoch: "epoch-w3", revision: 7n, blobDigest: Buffer.alloc(32, 0x22) };
+}
+
+function cas(documentPath: string, value: HostedDocumentSnapshotV2): PathCasV2 {
+  return { path: documentPath, expectedEpoch: value.epoch, expectedRevision: value.revision, expectedBlobDigest: value.blobDigest };
+}
+
+function ref(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
+  return { registryVersion: 1, entityKind, canonicalRef };
+}
+
+function key(entityRef: RegistryEntityRefV2): string {
+  return `${entityRef.registryVersion}\0${entityRef.entityKind}\0${entityRef.canonicalRef}`;
+}
+
+function base(semanticVersion: string): SemanticEntityBaseV2 {
+  return { semanticVersion, stateDigest };
+}
+
+function present(entityRef: RegistryEntityRefV2, semanticVersion: string): SemanticBaseCasV2 {
+  return { entityRef, expectedSemanticVersion: semanticVersion, expectedStateDigest: stateDigest };
+}
+
+function absent(entityRef: RegistryEntityRefV2): SemanticBaseCasV2 {
+  return { entityRef, expectedSemanticVersion: null, expectedStateDigest: null };
+}
+
+function pair(mutation: SemanticMutationSetV2["mutations"][number]): string {
+  return `${mutation.entity.canonicalRef}:${mutation.action.action}`;
+}
+
+function identityFor(kind: "task" | "decision" | "module") {
+  if (kind === "task") return { taskId: "task_T" };
+  if (kind === "decision") return { decisionId: "dec_W3" };
+  return { moduleKey: "kernel" };
+}
+
+function decisionPath(): string {
+  return "decisions/decision-dec_W3/decision.md";
+}
+
+const schemaTuple = {
+  wire: 2, event: 2, receipt: 2, digest: 2, policy: 1,
+  commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
+} as const;

--- a/packages/kernel/src/entity/registry-contract.ts
+++ b/packages/kernel/src/entity/registry-contract.ts
@@ -81,6 +81,7 @@ export interface ReadyProjectionFacet {
     readonly table: string;
     readonly idColumn: string;
     readonly identityField: string;
+    readonly materialization?: "existing-entity-table" | "mutation-index";
   };
 }
 

--- a/packages/kernel/src/entity/registry.ts
+++ b/packages/kernel/src/entity/registry.ts
@@ -13,7 +13,6 @@ import { canonicalEntityKinds, type CanonicalEntityKind } from "./canonical-kind
 import { executionDeclaration } from "./execution-declaration.ts";
 import { reviewDeclaration } from "./review-declaration.ts";
 import {
-  deferredRegistryFacet,
   readyIdentityProjectionFacets,
   readyStorageLocator,
   typedOnlySemanticDiff
@@ -93,8 +92,8 @@ export const entityRegistry = {
         };
       }
     }),
-    mutationContract: deferredRegistryFacet("W3", "OQ-3 action vocabulary is not registered"),
-    semanticDiff: deferredRegistryFacet("W5", "managed decision semanticDiff is not installed"),
+    mutationContract: { status: "ready", actions: ["propose", "state", "amend", "relation"] },
+    semanticDiff: typedOnlySemanticDiff("W3 enables typed commands only; managed decision semanticDiff remains owned by W5"),
   },
   task: {
     kind: "task",
@@ -117,13 +116,21 @@ export const entityRegistry = {
       table: "task_projection", idColumn: "task_id", identityField: "taskId"
     }),
     storageLocator: readyStorageLocator({
-      locate: (identity) => ({
-        targets: [{ kind: "document", path: `tasks/${identity.taskId}`, access: "prefix" }],
-        consistencyScope: `entity:task/${identity.taskId}`
-      })
+      locate: (identity, context) => {
+        const packagePath = `tasks/${identity.taskId}`;
+        const documentPath = context.documentPath;
+        return {
+          targets: [{
+            kind: "document",
+            path: documentPath ? `${packagePath}/${validateRegistryDocumentPath(documentPath)}` : packagePath,
+            access: documentPath ? "exact" : "prefix"
+          }],
+          consistencyScope: `entity:task/${identity.taskId}`
+        };
+      }
     }),
-    mutationContract: deferredRegistryFacet("W3", "OQ-3 action vocabulary is not registered"),
-    semanticDiff: deferredRegistryFacet("W5", "managed task semanticDiff is not installed"),
+    mutationContract: { status: "ready", actions: ["create", "transition", "append", "document"] },
+    semanticDiff: typedOnlySemanticDiff("W3 enables typed commands only; managed task semanticDiff remains owned by W5"),
   },
   fact: {
     kind: "fact",
@@ -194,15 +201,20 @@ export const entityRegistry = {
       unsupported("D4", "hard-delete", "module registry history is retained")
     ]),
     storageForm: "schema",
-    ...readyIdentityProjectionFacets("module", ["moduleKey"]),
+    ...readyIdentityProjectionFacets("module", ["moduleKey"], {
+      table: "module_attribution_projection",
+      idColumn: "module_key",
+      identityField: "moduleKey",
+      materialization: "mutation-index"
+    }),
     storageLocator: readyStorageLocator({
       locate: () => ({
         targets: [{ kind: "document", path: "modules.json", access: "exact" }],
         consistencyScope: "path:modules.json"
       })
     }),
-    mutationContract: deferredRegistryFacet("W3", "OQ-3 action vocabulary is not registered"),
-    semanticDiff: deferredRegistryFacet("W5", "module registry semanticDiff is not installed"),
+    mutationContract: { status: "ready", actions: ["register", "unregister", "step"] },
+    semanticDiff: typedOnlySemanticDiff("W3 enables typed commands only; module registry semanticDiff remains owned by W5"),
   },
   session: sessionEntityRegistration,
   execution: executionDeclaration,
@@ -262,4 +274,15 @@ function decodeCanonicalSegment(value: string): string {
     throw new Error(`INVALID_CANONICAL_ENTITY_SEGMENT:${value}`);
   }
   return decoded;
+}
+
+function validateRegistryDocumentPath(value: string): string {
+  if (!value || value.startsWith("/") || value.endsWith("/") || value.includes("\\")) {
+    throw new Error(`INVALID_REGISTRY_DOCUMENT_PATH:${value}`);
+  }
+  const segments = value.split("/");
+  if (segments.some((segment) => !segment || segment === "." || segment === ".." || segment.includes("\0"))) {
+    throw new Error(`INVALID_REGISTRY_DOCUMENT_PATH:${value}`);
+  }
+  return value;
 }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -101,6 +101,7 @@ export * from "./publish/index.ts";
 export * from "./projection/sqlite-task-projection.ts";
 export {
   materializeAttributionProjectionFromEvents,
+  readModuleAttributionProjection,
   readAttributionProjection
 } from "./projection/sqlite-attribution-projection.ts";
 export type { EntityAttributionProjection } from "./projection/types.ts";

--- a/packages/kernel/src/projection/sqlite-attribution-projection.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-projection.ts
@@ -52,6 +52,11 @@ export interface AttributionProjectionRow {
   readonly digestStatus: AttributionDigestStatus;
 }
 
+export interface ModuleAttributionProjectionRow {
+  readonly moduleKey: string;
+  readonly attribution: EntityAttributionProjection;
+}
+
 export function materializeAttributionProjection(
   rootInput: HarnessLayoutInput,
   projectionPath = resolveHarnessLayout(rootInput).projectionPath
@@ -70,6 +75,30 @@ export function materializeAttributionProjectionFromEvents(
     yield* materializeEntityAttributionBlocks(sql, events);
   })));
   return events.flatMap(eventToProjectionRows);
+}
+
+export function readModuleAttributionProjection(
+  projectionPath: string,
+  moduleKey?: string
+): ReadonlyArray<ModuleAttributionProjectionRow> {
+  const facet = entityRegistry.module.projectionFacet;
+  if (facet.status !== "ready" || !facet.attributionTarget
+    || facet.attributionTarget.materialization !== "mutation-index") {
+    throw new Error("MODULE_ATTRIBUTION_PROJECTION_FACET_NOT_READY");
+  }
+  const target = facet.attributionTarget;
+  return runSqlite(projectionPath, Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const where = moduleKey === undefined ? "" : ` WHERE ${target.idColumn} = ?`;
+    const rows = yield* sql.unsafe<Record<string, unknown>>(
+      `SELECT ${target.idColumn}, attribution_json FROM ${target.table}${where} ORDER BY ${target.idColumn}`,
+      moduleKey === undefined ? [] : [moduleKey]
+    );
+    return rows.map((row) => ({
+      moduleKey: String(row[target.idColumn]),
+      attribution: JSON.parse(String(row.attribution_json)) as EntityAttributionProjection
+    }));
+  }));
 }
 
 export function replaceAttributionProjectionRows(
@@ -143,6 +172,12 @@ export function materializeEntityAttributionBlocks(
     const existing = new Set((yield* sql<{ readonly name: string }>`SELECT name FROM sqlite_master WHERE type = 'table'`)
       .map((row) => String(row.name)));
     for (const target of registryAttributionTargets()) {
+      if (target.materialization === "mutation-index") {
+        const hasIndexedRows = rows.some((row) => row.entityKind === target.kind);
+        if (!hasIndexedRows && !existing.has(target.table)) continue;
+        yield* ensureMutationIndexTarget(sql, target, rows, true);
+        existing.add(target.table);
+      }
       if (!existing.has(target.table)) continue;
       yield* sql.unsafe(`UPDATE ${target.table} SET attribution_json = ?`, [JSON.stringify(unresolvedEntityAttribution())]);
       const records = yield* sql.unsafe<Record<string, unknown>>(`SELECT ${target.idColumn} FROM ${target.table}`);
@@ -168,6 +203,9 @@ export function materializeEntityAttributionTargets(
     for (const target of uniqueTargets.values()) {
       const declaration = registryAttributionTargets().find((candidate) => candidate.table === target.table);
       if (!declaration) throw new Error(`unknown attributed projection table: ${target.table}`);
+      if (declaration.materialization === "mutation-index") {
+        yield* ensureMutationIndexTarget(sql, declaration, [], false, [target.id]);
+      }
       yield* sql.unsafe(`UPDATE ${declaration.table} SET attribution_json = ? WHERE ${declaration.idColumn} = ?`, [
         JSON.stringify(unresolvedEntityAttribution()), target.id
       ]);
@@ -190,6 +228,9 @@ export function materializeEntityAttributionSubjects(
       for (const subjectRef of new Set(subjectRefs)) {
         const id = resolveTargetId(subjectRef, target.kind) ?? legacyTargetId(subjectRef, target.kind);
         if (!id) continue;
+        if (target.materialization === "mutation-index") {
+          yield* ensureMutationIndexTarget(sql, target, [], false, [id]);
+        }
         const records = yield* sql.unsafe<Record<string, unknown>>(
           `SELECT ${target.idColumn} AS entity_id FROM ${target.table} WHERE ${target.idColumn} = ?`, [id]
         );
@@ -400,12 +441,42 @@ function registryAttributionTargets(): ReadonlyArray<{
   readonly table: string;
   readonly idColumn: string;
   readonly identityField: string;
+  readonly materialization: "existing-entity-table" | "mutation-index";
 }> {
   return canonicalEntityKinds.flatMap((kind) => {
     const facet = entityRegistry[kind].projectionFacet;
     return facet.status === "ready" && facet.attributionTarget
-      ? [{ kind, ...facet.attributionTarget }]
+      ? [{ kind, materialization: "existing-entity-table" as const, ...facet.attributionTarget }]
       : [];
+  });
+}
+
+function ensureMutationIndexTarget(
+  sql: SqlClient.SqlClient,
+  target: ReturnType<typeof registryAttributionTargets>[number],
+  rows: ReadonlyArray<AttributionProjectionRow>,
+  replace: boolean,
+  explicitIds: ReadonlyArray<string> = []
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    yield* sql.unsafe(
+      `CREATE TABLE IF NOT EXISTS ${target.table} (`
+      + `${target.idColumn} TEXT PRIMARY KEY, `
+      + "attribution_json TEXT NOT NULL DEFAULT '{\"originator\":null,\"latestActor\":null,\"trailCount\":0,\"completeness\":\"unresolved\"}')"
+    );
+    if (replace) yield* sql.unsafe(`DELETE FROM ${target.table}`);
+    const ids = new Set(explicitIds);
+    for (const row of rows) {
+      if (row.entityKind !== target.kind) continue;
+      const id = resolveTargetId(row.subjectRef, target.kind);
+      if (id) ids.add(id);
+    }
+    for (const id of ids) {
+      yield* sql.unsafe(
+        `INSERT INTO ${target.table} (${target.idColumn}) VALUES (?) ON CONFLICT (${target.idColumn}) DO NOTHING`,
+        [id]
+      );
+    }
   });
 }
 

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -190,6 +190,7 @@ const publicRuntimeSurface = [
   "readDecisionFactCoverage",
   "readEntityCascadeImpact",
   "readFrontmatter",
+  "readModuleAttributionProjection",
   "readNestedScalar",
   "readRelationGraphAuthoredSourceKinds",
   "readRelationGraphProjection",

--- a/packages/kernel/test/store/entity-registry-substrate.test.ts
+++ b/packages/kernel/test/store/entity-registry-substrate.test.ts
@@ -277,8 +277,8 @@ test("writable registration fails closed when any required facet is missing or d
     );
   }
   for (const kind of entityRegistryKinds) {
-    const isW2Writable = kind === "fact" || kind === "relation";
-    assert.equal(entityRegistry[kind].mutationContract.status, isW2Writable ? "ready" : "deferred");
+    const isWritable = kind === "task" || kind === "decision" || kind === "fact" || kind === "relation" || kind === "module";
+    assert.equal(entityRegistry[kind].mutationContract.status, isWritable ? "ready" : "deferred");
     assert.equal(entityRegistry[kind].projectionFacet.status, "ready", `${kind} derives the W1 union projection from the registry`);
     if (entityRegistry[kind].projectionFacet.status === "ready" && entityRegistry[kind].identityCodec.status === "ready") {
       assert.deepEqual(
@@ -286,7 +286,7 @@ test("writable registration fails closed when any required facet is missing or d
         entityRegistry[kind].identityCodec.codec.decode(canonicalRefs[kind])
       );
     }
-    if (isW2Writable) {
+    if (isWritable) {
       assert.doesNotThrow(() => createWritableEntityRegistry([
         entityRegistry[kind] as EntityRegistration<string, KernelEntityKind>
       ]));

--- a/tools/perf/task-decision-module-v2-benchmark.mjs
+++ b/tools/perf/task-decision-module-v2-benchmark.mjs
@@ -1,0 +1,286 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import process from "node:process";
+import { Effect } from "effect";
+import {
+  canonicalAuthorityRequestDigest,
+  canonicalPayloadDigestV2,
+  createAuthoritySubmissionService,
+  createInMemoryAuthorityOperationRegistry,
+  createInMemoryReplicaChangeLog,
+  encodeTaskDecisionModuleCommandPayloadV2,
+  makeTaskDecisionModuleSemanticCompilerV2,
+  semanticMutationEnvelopeV2Schema,
+  semanticMutationSetDigestV2,
+  semanticRequestDigestV2
+} from "../../packages/application/src/index.ts";
+import {
+  compileRegistryMutationPlan,
+  createWritableEntityRegistry,
+  entityRegistry,
+  makeJournaledWriteCoordinator
+} from "../../packages/kernel/src/index.ts";
+
+const writerCounts = integerListOption("--writers", [2, 4, 8]);
+const rounds = integerOption("--rounds", 10);
+const groups = enumListOption("--groups", ["task-same-package", "decision-module-disjoint"], ["task-same-package", "decision-module-disjoint"]);
+const workspaceId = "workspace-w3-perf";
+const baseDigest = Buffer.alloc(32, 0x11);
+const token = "w3-perf-token";
+const channelNonceDigest = "sha256:w3-perf-channel";
+const protocol = { wire: 1, event: 1, receipt: 1, digest: 1, commandRegistry: 1 };
+const scenarios = [];
+
+for (const group of groups) {
+  for (const writers of writerCounts) scenarios.push(await runScenario(group, writers));
+}
+
+process.stdout.write(`${JSON.stringify({
+  schema: "task-decision-module-v2-concurrency-benchmark/v1",
+  measuredAt: new Date().toISOString(),
+  sourceCommit: gitAt(process.cwd(), "rev-parse", "HEAD"),
+  environment: { node: process.version, platform: process.platform, arch: process.arch },
+  workload: "task append same package; decision propose + module register logically disjoint",
+  rounds,
+  scenarios
+}, null, 2)}\n`);
+
+async function runScenario(group, writers) {
+  return withGit(group, writers, async ({ rootDir, env }) => {
+    const queueWaitByOp = new Map();
+    const submitStartedByOp = new Map();
+    const service = authority(rootDir, env, queueWaitByOp, submitStartedByOp);
+    const compiler = makeTaskDecisionModuleSemanticCompilerV2({
+      state: {
+        readEntityBase: async (entityRef) => entityRef.entityKind === "task"
+          ? { semanticVersion: "task-v1", stateDigest: baseDigest }
+          : null,
+        readHostedDocument: async () => null
+      }
+    });
+    const registry = createWritableEntityRegistry([entityRegistry.task, entityRegistry.decision, entityRegistry.module]);
+    const samples = { endToEndMs: [], compilerMs: [], queueWaitMs: [], commitIndexMs: [] };
+    for (let round = 0; round < rounds; round += 1) {
+      const rows = await Promise.all(Array.from({ length: writers }, async (_, writer) => {
+        const fixture = operationFixture(group, writers, round, writer);
+        const started = performance.now();
+        const compileStarted = performance.now();
+        const semantic = await compiler.compile(fixture.envelope);
+        const compiled = compileRegistryMutationPlan(registry, semantic.mutationPlan);
+        const compilerMs = performance.now() - compileStarted;
+        if (compiled.mutationSet.mutations.length !== 1 || compiled.storagePlan.targets.length !== 1) {
+          throw new Error("W3 benchmark expected one mutation and one hosted target");
+        }
+        submitStartedByOp.set(fixture.opId, performance.now());
+        const receipt = await service.submit(v1Envelope(fixture.opId, { ...semantic.operation, opId: fixture.opId }));
+        const endToEndMs = performance.now() - started;
+        if (receipt.tag !== "COMMITTED") throw new Error(`${fixture.opId} returned ${receipt.tag}`);
+        const queueWaitMs = queueWaitByOp.get(fixture.opId);
+        if (queueWaitMs === undefined) throw new Error(`queue wait missing for ${fixture.opId}`);
+        return { endToEndMs, compilerMs, queueWaitMs, commitIndexMs: Math.max(0, endToEndMs - compilerMs - queueWaitMs) };
+      }));
+      for (const row of rows) for (const key of Object.keys(samples)) samples[key].push(row[key]);
+    }
+    return {
+      group,
+      writers,
+      attempts: samples.endToEndMs.length,
+      endToEndMs: summary(samples.endToEndMs),
+      segments: {
+        registryCompileSemanticDiffMs: summary(samples.compilerMs),
+        coordinatorQueueWaitMs: summary(samples.queueWaitMs),
+        commitIndexMs: summary(samples.commitIndexMs)
+      }
+    };
+  });
+}
+
+function operationFixture(group, writers, round, writer) {
+  const ordinal = round * writers + writer;
+  const suffix = `${group}-n${writers}-r${round}-w${writer}`;
+  let payloadValue;
+  let baseCas;
+  if (group === "task-same-package") {
+    const taskId = `task_W3_SAME_N${writers}`;
+    payloadValue = { schema: "task.append/v1", taskId, text: `W3 performance ${suffix}` };
+    baseCas = [present("task", `task/${taskId}`)];
+  } else if (writer % 2 === 0) {
+    const decisionId = `dec_W3_${writers}_${ordinal}`;
+    payloadValue = { schema: "decision.propose/v1", decision: decision(decisionId) };
+    baseCas = [absent("decision", `decision/${decisionId}`)];
+  } else {
+    const moduleKey = `module-${writers}-${ordinal}`;
+    payloadValue = {
+      schema: "module.register/v1",
+      module: { key: moduleKey, title: moduleKey, status: "active", scopes: [`packages/${moduleKey}/**`], steps: [] }
+    };
+    baseCas = [absent("module", `module/${moduleKey}`)];
+  }
+  const payload = encodeTaskDecisionModuleCommandPayloadV2(payloadValue);
+  const mutationSet = { registryVersion: 1, mutations: [] };
+  const draft = {
+    schema: semanticMutationEnvelopeV2Schema,
+    workspaceId,
+    operationId: {
+      namespace: {
+        schema: "operation-namespace/v1", workspaceId, deviceId: "device-w3-perf", authorityGeneration: 1n,
+        namespaceId: "namespace-w3-perf", expiresAt: 9_000n, issuer: "authority.perf", keyId: "namespace-key", proof: Buffer.alloc(32, 3)
+      },
+      clientRandom128: Buffer.from(fixedHex(ordinal + (group === "task-same-package" ? 1 : 1_000_000), 32), "hex")
+    },
+    binding: {
+      bindingId: "binding-w3-perf", actorAxesBindingDigest: Buffer.alloc(32, 4), deviceId: "device-w3-perf",
+      viewId: "view-w3-perf", sessionId: "session-w3-perf",
+      admissionTokenRef: { tokenId: "token-w3-perf", tokenDigest: Buffer.alloc(32, 5) }
+    },
+    schemaTuple: {
+      wire: 2, event: 2, receipt: 2, digest: 2, policy: 1,
+      commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
+    },
+    intent: {
+      kind: "typed", command: { registryVersion: 1, name: payloadValue.schema.replace("/v1", ""), version: 1 },
+      canonicalPayload: { kind: "inline", size: BigInt(payload.length), bytes: payload },
+      canonicalPayloadDigest: canonicalPayloadDigestV2(payload), baseCas, declaredPathCas: []
+    },
+    claimedMutationSet: mutationSet,
+    claimedSemanticMutationSetDigest: semanticMutationSetDigestV2(mutationSet),
+    claimedSemanticRequestDigest: Buffer.alloc(32)
+  };
+  return { opId: `w3-perf-${suffix}`, envelope: { ...draft, claimedSemanticRequestDigest: semanticRequestDigestV2(draft) } };
+}
+
+function authority(rootDir, env, queueWaitByOp, submitStartedByOp) {
+  return createAuthoritySubmissionService({
+    workspaceId,
+    coordinatorFactory: {
+      create: ({ attribution }) => {
+        const coordinator = makeJournaledWriteCoordinator({
+          rootDir, attribution, commitAuthor: { name: "W3 Benchmark", email: "benchmark@example.test" }, autoMaterialize: false
+        });
+        return {
+          enqueue: (operation) => Effect.gen(function* () {
+            const started = submitStartedByOp.get(operation.opId);
+            if (started === undefined) throw new Error(`submit start missing for ${operation.opId}`);
+            queueWaitByOp.set(operation.opId, performance.now() - started);
+            return yield* coordinator.enqueue(operation);
+          }),
+          flush: coordinator.flush,
+          recover: coordinator.recover
+        };
+      }
+    },
+    tokenVerifier: {
+      verify: async ({ token: presented }) => {
+        if (presented !== token) throw new Error("invalid benchmark token");
+        return {
+          attribution: {
+            actor: { principal: { kind: "person", personId: "person_zeyu" }, executor: { kind: "agent", id: "agent-w3-perf" } },
+            principalSource: { kind: "daemon-authenticated", providerId: "w3-perf", credentialFingerprint: "sha256:redacted" },
+            executorSource: "client-asserted"
+          },
+          claims: {
+            tokenId: "token-w3-perf", issuer: "w3-perf", keyId: "key-w3-perf", workspaceId,
+            deviceId: "device-w3-perf", viewId: "view-w3-perf", actorId: "person_zeyu", executorId: "agent-w3-perf",
+            sessionId: "session-w3-perf", authorityGeneration: 1, channelNonceDigest, protocol,
+            commandScopes: ["repo.document.write"], pathScopes: ["harness/**"], maxBytes: 128 * 1024, maxOps: 1,
+            issuedAt: "2026-07-14T00:00:00.000Z", notBefore: "2026-07-14T00:00:00.000Z",
+            expiresAt: "2026-07-15T00:00:00.000Z", revocationEpoch: 1
+          }
+        };
+      }
+    },
+    operationRegistry: createInMemoryAuthorityOperationRegistry(),
+    replicaChangeLog: createInMemoryReplicaChangeLog(),
+    publicationInspector: {
+      currentHead: async () => gitOptional(rootDir, env, "rev-parse", "--verify", "HEAD"),
+      inspectPublishedHead: async () => {
+        const row = git(rootDir, env, "rev-list", "--parents", "-n", "1", "HEAD").split(" ");
+        return { commitSha: row[0], parentCommits: row.slice(1) };
+      }
+    },
+    fenceWitness: { assertHeld: async () => undefined },
+    now: () => "2026-07-14T00:00:00.000Z"
+  });
+}
+
+function v1Envelope(opId, operation) {
+  const envelope = { workspaceId, opId, claimedDigest: "pending", command: "repo.document.write", operation, delegationToken: token, channelNonceDigest, protocol };
+  return { ...envelope, claimedDigest: canonicalAuthorityRequestDigest(envelope) };
+}
+
+async function withGit(group, writers, body) {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-w3-perf-"));
+  const env = {
+    ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_AUTHOR_NAME: "W3 Benchmark", GIT_AUTHOR_EMAIL: "benchmark@example.test",
+    GIT_COMMITTER_NAME: "Harness Authority", GIT_COMMITTER_EMAIL: "authority@example.test"
+  };
+  try {
+    execFileSync("git", ["-C", rootDir, "init", "-q"], { env });
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    const harnessRoot = path.join(rootDir, "harness");
+    mkdirSync(harnessRoot, { recursive: true });
+    execFileSync("git", ["-C", harnessRoot, "init", "-q"], { env });
+    if (group === "task-same-package") {
+      const taskRoot = path.join(harnessRoot, "tasks", `task_W3_SAME_N${writers}`);
+      mkdirSync(taskRoot, { recursive: true });
+      writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex(`task_W3_SAME_N${writers}`), "utf8");
+    }
+    execFileSync("git", ["-C", harnessRoot, "add", "."], { env });
+    execFileSync("git", ["-C", harnessRoot, "commit", "--allow-empty", "-m", "test: initialize W3 benchmark"], { env });
+    return await body({ rootDir, env });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function decision(id) {
+  return {
+    schema: "decision-package/v1", decision_id: id, title: id, state: "proposed", riskTier: "medium", urgency: "medium",
+    vertical: "software/coding", preset: "architecture-decision", applies_to: { modules: [], productLines: [] },
+    proposedAt: "2026-07-14T00:00:00.000Z",
+    provenance: [{ runtime: "codex", sessionId: "session-w3-perf", boundAt: "2026-07-14T00:00:00.000Z" }],
+    question: `Publish ${id}?`, chosen: [{ id: "CH1", text: "Yes." }],
+    rejected: [{ id: "RJ1", text: "No.", why_not: "Benchmark positive path." }],
+    claims: [{ id: "C1", text: "The benchmark request is typed." }], relations: []
+  };
+}
+
+function taskIndex(taskId) {
+  return [
+    "---", "schema: task-package/v2", `task_id: ${taskId}`, `title: ${taskId}`,
+    "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", "  status: active", "  ref: ",
+    `  titleSnapshot: ${taskId}`, "  url: ", "  bindingCreatedAt: 2026-07-14T00:00:00.000Z",
+    `  bindingFingerprint: sha256:${"b".repeat(64)}`, "packageDisposition: active", "vertical: default", "preset: default",
+    "provenance:", "  - {runtime: codex, sessionId: session-w3-perf, boundAt: 2026-07-14T00:00:00.000Z}", "---", "", `# ${taskId}`, ""
+  ].join("\n");
+}
+
+function present(entityKind, canonicalRef) {
+  return { entityRef: { registryVersion: 1, entityKind, canonicalRef }, expectedSemanticVersion: "task-v1", expectedStateDigest: baseDigest };
+}
+
+function absent(entityKind, canonicalRef) {
+  return { entityRef: { registryVersion: 1, entityKind, canonicalRef }, expectedSemanticVersion: null, expectedStateDigest: null };
+}
+
+function summary(values) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return { p50Ms: round(percentile(sorted, 0.5)), p95Ms: round(percentile(sorted, 0.95)), maxMs: round(sorted.at(-1) ?? 0), samplesMs: values.map(round) };
+}
+
+function percentile(sorted, quantile) {
+  return sorted.length === 0 ? 0 : sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * quantile) - 1))];
+}
+
+function round(value) { return Math.round(value * 100) / 100; }
+function fixedHex(value, length) { return value.toString(16).padStart(length, "0").slice(-length); }
+function integerOption(name, fallback) { const i = process.argv.indexOf(name); if (i < 0) return fallback; const value = Number(process.argv[i + 1]); if (!Number.isInteger(value) || value <= 0) throw new Error(`${name} invalid`); return value; }
+function integerListOption(name, fallback) { const i = process.argv.indexOf(name); if (i < 0) return fallback; const values = String(process.argv[i + 1]).split(",").map(Number); if (values.some((value) => !Number.isInteger(value) || value <= 0)) throw new Error(`${name} invalid`); return values; }
+function enumListOption(name, allowed, fallback) { const i = process.argv.indexOf(name); if (i < 0) return fallback; const values = String(process.argv[i + 1]).split(","); if (values.some((value) => !allowed.includes(value))) throw new Error(`${name} invalid`); return [...new Set(values)]; }
+function git(rootDir, env, ...args) { return execFileSync("git", ["-C", path.join(rootDir, "harness"), ...args], { encoding: "utf8", env }).trim(); }
+function gitOptional(rootDir, env, ...args) { try { return git(rootDir, env, ...args); } catch { return null; } }
+function gitAt(cwd, ...args) { return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim(); }


### PR DESCRIPTION
# English

## Summary

SME wave W3 (charter task_01KXCZ8C1B): task, decision, and module become v2-writable kinds. Per-action typed requests (task create/transition/append/document, decision propose/state/amend/relation, module register/unregister/step) are decoded by the authority, which **recomputes the exact mutation set** and publishes it through each kind's existing hosted physical store (task package host doc, decision package/frontmatter, canonical `modules.json`) — no per-entity files, no client-claimed authorization. This wave closes the module "journal has identity but the read face has no attribution" gap: module journal mutations now surface in the same registry-derived attribution projection. It also establishes the **storage-effect ≠ semantic-mutation** boundary: a hosted fact write that touches a task-hosted file produces only a fact mutation, never a spurious task mutation. v2-writable coverage now spans task/decision/fact/relation/module.

## What Changed

- `packages/application/src/authority/task-decision-module-command-v2.ts` (new): typed command payloads + canonical wire codec for the 11 task/decision/module actions (exact-ref only, OQ-6).
- `packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts` (new): the authority-side per-action semantic compiler. Each action recomputes an exact mutation set + one hosted StoragePlan; decision.relation also creates its first-class relation; module actions compile canonical `modules.json` snapshots (`module_registry_write`). A hosted fact touching a task's host file yields only a fact mutation (no task mutation). Every admission guard throws `SemanticAdmissionErrorV2` — fail-closed, no host-only fallback.
- `packages/kernel/src/entity/registry.ts` / `registry-contract.ts`: task/decision/module `mutationContract` moves **deferred → ready** (`task: [create,transition,append,document]`, `decision: [propose,state,amend,relation]`, `module: [register,unregister,step]`) with actions in the registry entry (W0 single source, OQ-3-derived — no ninth list); `semanticDiff` stays `typedOnlySemanticDiff` (W5 owns full semanticDiff).
- `packages/kernel/src/projection/sqlite-attribution-projection.ts`: module `projectionFacet` is now a ready consumer, so module journal mutations appear in the registry-derived attribution read face (closing the identity-without-attribution gap).
- Tests + perf: `task-decision-module-semantic-compiler-v2.test.ts` (storage-only-host-touch control, per-action independent-disable, six negative controls), `task-decision-module-authority-positive-v2.test.ts` (3-kind single-op hosted publish + four-layer digest consistency + module read-face + dual-axis), `tools/perf/task-decision-module-v2-benchmark.mjs` (segmented benchmark, task-same-package + decision-module-disjoint groups).

## Task And Scope

- Harness task: task_01KXD8G0WS75DZY7DRESB372ME (SME W3)
- Branch: feat/sme-w3-task-decision-module (rebased onto origin/main a955946; clean, disjoint from upstream surfaces)
- Public scope: 12 files in kernel/application + tests + tools-perf; zero protected surfaces (verified via `git diff-tree`); no check:ci receipt committed
- Out of scope: session/execution/review writable enablement (W4, typed-only); full transparent semanticDiff for the five ready kinds (W5)

## Version Impact

- Version: no version change (additive authority write path behind existing wire behavior)
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: SME charter (task_01KXCZ8C1B §5/W3 + §6-9); A0 frozen contract; A1 (#712) authority-recompute admission; W0 (#715) single-source registry; W1 (#719) projection; W2 (#724) fact/relation slice; OQ-3 accepted (dec_01KXDHSHZF), OQ-2 accepted (dec_01KXDHT4T0)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none (W4 continues the wave chain)

## Verification

- Base `origin/main` SHA: a955946
- Branch merge-base with `origin/main`: a955946 (rebased, behind 0)
- Last `git fetch origin` time: 2026-07-14 (pre-push, same session)
- Sync method: rebase (clean; upstream commits disjoint from this kernel/application authority surface)
- Public diff command: `git diff a955946..<merge-head>`
- Private evidence commit/path: harness/tasks/task_01KXD8G0WS75DZY7DRESB372ME-.../ (task_plan invariants; review.md CEO semantic acceptance + paired perf; artifacts/perf-paired-corroboration.json)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending (attached by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (via `check:ci`, 13/13 manifest-derived runs; `--json` receipt written to /tmp — not committed)
- [x] `npm run typecheck` (via `check:ci`)
- [x] `npm test` (storage-only-host-touch + six negative controls; 3-kind single-op publish + four-layer digest; explicit `HARNESS_DAEMON_MODE=local` daemon route)
- [x] `npm run harness:check-import-boundaries` (via `check:ci`)
- [x] `npm run harness:scan-forbidden-symbols` (via `check:ci`)
- [x] `npm run harness:check-private-boundary` (via `check:ci`)
- [x] `npm run harness:check-package-policy` (via `check:ci`)
- [x] `npm run harness:check-implementation-contracts` (via `check:ci`)
- [x] `npm run harness:check-schema-contracts` (via `check:ci`)
- [x] `npm run harness:check-legacy-intake-readiness` (via `check:ci`)
- [x] `npm run harness:smoke-cli-package` (via `check:ci`)
- [ ] GitHub Actions `rewrite-ci` passed

Performance — CEO paired relative-overhead corroboration (dec_01KXE36A4V standing policy; 4 interleaved same-timeslot rounds, median):

| group | N | A1 e2e p95 | W3 e2e p95 | W3/A1 ratio | net-new compile p95 | net-new fraction |
|---|---:|---:|---:|---:|---:|---:|
| task-same-package | 2 | 735.6ms | 617.4ms | 0.839 | 0.92ms | 0.15% |
| task-same-package | 4 | 1103.3ms | 862.2ms | 0.781 | 0.41ms | 0.05% |
| task-same-package | 8 | 1762.9ms | 1460.8ms | 0.829 | 0.68ms | 0.05% |
| decision-module-disjoint | 2 | 735.6ms | 664.9ms | 0.904 | 1.28ms | 0.19% |
| decision-module-disjoint | 4 | 1103.3ms | 1062.7ms | 0.963 | 0.54ms | 0.05% |
| decision-module-disjoint | 8 | 1762.9ms | 1845.7ms | 1.047 | 0.90ms | 0.05% |

W3 net-new typed-compiler logic p95 ≤ 1.28ms (≤ 0.19% of end-to-end) across every cell — no measurable relative overhead from W3's own code. 5/6 cells at or below A1-baseline; the one cell above 1.0 (decision-module-disjoint N=8 = 1.047, +4.7%) is within the 20% relative gate and lives entirely in the shared commit+index term (run-to-run infra variance at N=8), not W3 logic.

---

# 中文

## 摘要

SME W3 波次（charter task_01KXCZ8C1B）：task、decision、module 成为 v2-writable kind。逐 action typed request（task create/transition/append/document、decision propose/state/amend/relation、module register/unregister/step）由 authority 解码并**重算 exact mutation 集**，经各自既有 hosted 物理存储发布（task package 宿主文档、decision package/frontmatter、canonical `modules.json`）——不产 per-entity 文件、不由 client claim 授权自身。本波闭合 module「journal 有 identity、读面无 attribution」现状裂缝：module journal mutation 现出现在同一 registry-derived attribution 投影。并确立 **storage-effect ≠ semantic-mutation** 边界：touch task 宿主文件的 hosted fact 写只产生 fact mutation，绝不产生伪 task mutation。v2-writable 覆盖现达 task/decision/fact/relation/module。

## 变更内容

- `authority/task-decision-module-command-v2.ts`（新）：11 个 task/decision/module action 的 typed payload + canonical wire codec（exact-ref only，OQ-6）。
- `authority/task-decision-module-semantic-compiler-v2.ts`（新）：authority 侧逐 action 语义 compiler，每 action 重算 exact mutation 集 + 单 hosted StoragePlan；decision.relation 同时产一等 relation；module action 编译 canonical `modules.json` snapshot（`module_registry_write`）。touch task 宿主的 hosted fact 只产 fact mutation（零 task mutation）。所有准入守卫 throw `SemanticAdmissionErrorV2`——fail-closed，无 host-only fallback。
- `kernel/entity/registry.ts` / `registry-contract.ts`：task/decision/module `mutationContract` **deferred → ready**（action 落 registry entry，W0 单一源，OQ-3 派生，无第九名单）；`semanticDiff` 仍 `typedOnlySemanticDiff`（完整 semanticDiff 留 W5）。
- `kernel/projection/sqlite-attribution-projection.ts`：module `projectionFacet` 成为 ready consumer，module journal mutation 现出现在 registry-derived attribution 读面（闭合 identity-无-attribution 裂缝）。
- 测试+性能：`task-decision-module-semantic-compiler-v2.test.ts`（storage-only-host-touch 控制 + 逐 action 独立禁用 + 六负控）、`task-decision-module-authority-positive-v2.test.ts`（三 kind 单 op hosted 发布 + 四层 digest + module 读面 + 双轴）、`tools/perf/task-decision-module-v2-benchmark.mjs`（分段 benchmark）。

## 任务与范围

- Harness task：task_01KXD8G0WS75DZY7DRESB372ME（SME W3）
- 分支：feat/sme-w3-task-decision-module（rebase 至 origin/main a955946；干净，与上游面不相交）
- 公开范围：12 文件（kernel/application + 测试 + tools-perf）；零受保护面（`git diff-tree` 口径）；无误 commit check:ci 回执
- 范围外：session/execution/review 的 writable 启用（W4，typed-only）；五 ready kind 的完整 transparent semanticDiff（W5）

## 版本影响

- 版本：无版本变更（既有 wire 行为背后的 additive authority 写路径）
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权依据：SME charter（task_01KXCZ8C1B §5/W3 + §6-9）；A0 冻结契约；A1（#712）authority 重算准入；W0（#715）单一派生源 registry；W1（#719）projection；W2（#724）fact/relation 切片；OQ-3 已接受（dec_01KXDHSHZF）、OQ-2 已接受（dec_01KXDHT4T0）
- 机器检查边界：本 PR 仅断言声明存在；声明是否真实充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无（W4 继续波次链）

## 验证

- Base `origin/main` SHA：a955946
- 分支与 `origin/main` merge-base：a955946（已 rebase，behind 0）
- 最近 `git fetch origin` 时间：2026-07-14（push 前，同一会话）
- 同步方式：rebase（干净；上游 commit 与本 kernel/application authority 面不相交）
- 公开 diff 命令：`git diff a955946..<merge-head>`
- 私有证据路径：harness/tasks/task_01KXD8G0WS75DZY7DRESB372ME-.../（plan 不变量、review.md CEO 语义验收 + paired 性能坐实、artifacts/perf-paired-corroboration.json）
- 复选框状态同英文块（check:ci 13/13 manifest 派生 runs 全绿，`--json` 回执写 /tmp 未 commit；storage-only-host-touch + 六负控；三 kind 单 op 发布 + 四层 digest；daemon 路显式 local）

性能——CEO paired 相对开销坐实（dec_01KXE36A4V 常设政策；4 轮同时段交替取中位）：W3 净新增 typed-compiler 逻辑 p95 ≤1.28ms（占端到端 ≤0.19%，每格）——零可测相对开销；6 格 5 格 ≤ A1-baseline，唯一略高格 decision-module-disjoint N=8=1.047（+4.7%，全在共享 commit+index 运行间噪音）远低于 20% 相对回归门。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
