### PR TITLE
feat: SME W4 — session/execution/review typed-only mutations (DEFER-TYPED-ONLY machine-owned surfaces)

### DIFF
--- a/packages/application/src/authority/fact-relation-command-v2.ts
+++ b/packages/application/src/authority/fact-relation-command-v2.ts
@@ -12,8 +12,13 @@ import {
 } from "../../../kernel/src/index.ts";
 import {
   SemanticAdmissionErrorV2,
+  bytesEqual,
   type SemanticMutationEnvelopeV2
 } from "./semantic-mutation-envelope-v2.ts";
+import {
+  exactSemanticObjectV2,
+  semanticAdmissionV2
+} from "./semantic-authority-helpers-v2.ts";
 
 export const factRelationTypedCommandsV2 = [
   "fact.create",
@@ -77,28 +82,28 @@ export function decodeFactRelationCommandPayloadV2(envelope: SemanticMutationEnv
   readonly payload: FactRelationCommandPayloadV2;
   readonly decodedBytes: bigint;
 } {
-  if (envelope.intent.kind !== "typed") throw payloadAdmission("TYPED_COMMAND_REQUIRED");
+  if (envelope.intent.kind !== "typed") throw semanticAdmissionV2("TYPED_COMMAND_REQUIRED");
   if (envelope.intent.command.registryVersion !== 1 || envelope.intent.command.version !== 1) {
-    throw payloadAdmission("TYPED_COMMAND_VERSION_UNSUPPORTED");
+    throw semanticAdmissionV2("TYPED_COMMAND_VERSION_UNSUPPORTED");
   }
   if (!factRelationTypedCommandsV2.includes(envelope.intent.command.name as FactRelationTypedCommandV2)) {
-    throw payloadAdmission("TYPED_COMMAND_UNREGISTERED");
+    throw semanticAdmissionV2("TYPED_COMMAND_UNREGISTERED");
   }
-  if (envelope.intent.canonicalPayload.kind !== "inline") throw payloadAdmission("AUTHORITY_PAYLOAD_CAS_UNSUPPORTED");
+  if (envelope.intent.canonicalPayload.kind !== "inline") throw semanticAdmissionV2("AUTHORITY_PAYLOAD_CAS_UNSUPPORTED");
   const bytes = envelope.intent.canonicalPayload.bytes;
-  if (envelope.intent.canonicalPayload.size !== BigInt(bytes.length)) throw payloadAdmission("CANONICAL_PAYLOAD_SIZE_MISMATCH");
-  if (!payloadBytesEqual(envelope.intent.canonicalPayloadDigest, canonicalPayloadDigestV2(bytes))) {
-    throw payloadAdmission("CANONICAL_PAYLOAD_DIGEST_MISMATCH");
+  if (envelope.intent.canonicalPayload.size !== BigInt(bytes.length)) throw semanticAdmissionV2("CANONICAL_PAYLOAD_SIZE_MISMATCH");
+  if (!bytesEqual(envelope.intent.canonicalPayloadDigest, canonicalPayloadDigestV2(bytes))) {
+    throw semanticAdmissionV2("CANONICAL_PAYLOAD_DIGEST_MISMATCH");
   }
   let decoded: unknown;
   try {
     decoded = JSON.parse(Buffer.from(bytes).toString("utf8"));
   } catch {
-    throw payloadAdmission("TYPED_PAYLOAD_INVALID");
+    throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
   }
-  const payload = strictPayload(decoded);
-  if (!payloadBytesEqual(bytes, encodeFactRelationCommandPayloadV2(payload))) throw payloadAdmission("TYPED_PAYLOAD_NON_CANONICAL");
-  if (payload.schema.replace("/v1", "") !== envelope.intent.command.name) throw payloadAdmission("TYPED_COMMAND_PAYLOAD_MISMATCH");
+  const payload = decodeStrictFactRelationPayloadV2(decoded);
+  if (!bytesEqual(bytes, encodeFactRelationCommandPayloadV2(payload))) throw semanticAdmissionV2("TYPED_PAYLOAD_NON_CANONICAL");
+  if (payload.schema.replace("/v1", "") !== envelope.intent.command.name) throw semanticAdmissionV2("TYPED_COMMAND_PAYLOAD_MISMATCH");
   return { payload, decodedBytes: BigInt(bytes.length) };
 }
 
@@ -116,17 +121,17 @@ export function decodeFactRecordV2(value: unknown): FactRecord {
   try {
     return Schema.decodeUnknownSync(FactRecordSchema)({ schema: "fact-record/v1", ...(value as object) });
   } catch {
-    throw payloadAdmission("FACT_PAYLOAD_INVALID");
+    throw semanticAdmissionV2("FACT_PAYLOAD_INVALID");
   }
 }
 
 export function decodeRelationV2(value: unknown): EntityRelationRecord {
   try {
-    const row = exactObject(value, ["relation_id", "source", "target", "type", "strength", "direction", "origin", "rationale", "state"], "relation");
+    const row = exactSemanticObjectV2(value, ["relation_id", "source", "target", "type", "strength", "direction", "origin", "rationale", "state"], { name: "relation" });
     return Schema.decodeUnknownSync(entityRegistry.relation.schema)(row);
   } catch (error) {
     if (error instanceof SemanticAdmissionErrorV2) throw error;
-    throw payloadAdmission("RELATION_PAYLOAD_INVALID");
+    throw semanticAdmissionV2("RELATION_PAYLOAD_INVALID");
   }
 }
 
@@ -185,21 +190,21 @@ function canonicalRelationWire(relation: EntityRelationRecord): object {
   };
 }
 
-function strictPayload(value: unknown): FactRelationCommandPayloadV2 {
-  const row = exactObject(value, ["schema"], "typed payload", true);
+function decodeStrictFactRelationPayloadV2(value: unknown): FactRelationCommandPayloadV2 {
+  const row = exactSemanticObjectV2(value, ["schema"], { name: "typed payload", allowAdditional: true });
   switch (row.schema) {
     case "fact.create/v1":
-      return exactObject(value, ["schema", "ownerTaskId", "factId", "statement", "source", "observedAt", "confidence", "memoryClass", "memoryTags", "provenance"], row.schema) as unknown as FactCreatePayloadV2;
+      return exactSemanticObjectV2(value, ["schema", "ownerTaskId", "factId", "statement", "source", "observedAt", "confidence", "memoryClass", "memoryTags", "provenance"], { name: row.schema }) as unknown as FactCreatePayloadV2;
     case "fact.invalidate/v1":
-      return exactObject(value, ["schema", "ownerTaskId", "factId", "invalidatedByFactId", "rationale"], row.schema) as unknown as FactInvalidatePayloadV2;
+      return exactSemanticObjectV2(value, ["schema", "ownerTaskId", "factId", "invalidatedByFactId", "rationale"], { name: row.schema }) as unknown as FactInvalidatePayloadV2;
     case "relation.create/v1": {
-      const payload = exactObject(value, ["schema", "relation"], row.schema);
+      const payload = exactSemanticObjectV2(value, ["schema", "relation"], { name: row.schema });
       return { schema: row.schema, relation: decodeRelationV2(payload.relation) };
     }
     case "relation.retire/v1":
-      return exactObject(value, ["schema", "sourceRef", "relationId"], row.schema) as unknown as RelationRetirePayloadV2;
+      return exactSemanticObjectV2(value, ["schema", "sourceRef", "relationId"], { name: row.schema }) as unknown as RelationRetirePayloadV2;
     case "relation.replace/v1": {
-      const payload = exactObject(value, ["schema", "sourceRef", "relationId", "replacement"], row.schema);
+      const payload = exactSemanticObjectV2(value, ["schema", "sourceRef", "relationId", "replacement"], { name: row.schema });
       return {
         schema: row.schema,
         sourceRef: payloadText(payload.sourceRef),
@@ -208,34 +213,11 @@ function strictPayload(value: unknown): FactRelationCommandPayloadV2 {
       };
     }
     default:
-      throw payloadAdmission("TYPED_PAYLOAD_SCHEMA_UNSUPPORTED");
+      throw semanticAdmissionV2("TYPED_PAYLOAD_SCHEMA_UNSUPPORTED");
   }
-}
-
-function exactObject(
-  value: unknown,
-  keys: ReadonlyArray<string>,
-  name: string,
-  allowAdditional = false
-): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) throw payloadAdmission("TYPED_PAYLOAD_INVALID");
-  const row = value as Record<string, unknown>;
-  const actual = Object.keys(row);
-  if (keys.some((key) => !actual.includes(key)) || (!allowAdditional && actual.length !== keys.length)) {
-    throw payloadAdmission("TYPED_PAYLOAD_UNKNOWN_OR_MISSING_FIELD", name);
-  }
-  return row;
 }
 
 function payloadText(value: unknown): string {
-  if (typeof value !== "string" || !value || value.trim() !== value) throw payloadAdmission("TYPED_PAYLOAD_INVALID");
+  if (typeof value !== "string" || !value || value.trim() !== value) throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
   return value;
-}
-
-function payloadAdmission(code: string, message = code): SemanticAdmissionErrorV2 {
-  return new SemanticAdmissionErrorV2(code, message);
-}
-
-function payloadBytesEqual(left: Uint8Array, right: Uint8Array): boolean {
-  return Buffer.from(left).equals(Buffer.from(right));
 }

--- a/packages/application/src/authority/fact-relation-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/fact-relation-semantic-compiler-v2.ts
@@ -27,12 +27,15 @@ import {
   type RelationRetirePayloadV2
 } from "./fact-relation-command-v2.ts";
 import {
-  SemanticAdmissionErrorV2,
   type AuthoritySemanticCompilerV2,
-  type PathCasV2,
-  type RegistryEntityRefV2,
-  type SemanticBaseCasV2
+  type RegistryEntityRefV2
 } from "./semantic-mutation-envelope-v2.ts";
+import {
+  semanticAdmissionV2,
+  semanticMutationPlanV2,
+  verifySemanticBaseCasV2,
+  verifySemanticPathCasV2
+} from "./semantic-authority-helpers-v2.ts";
 
 export {
   canonicalPayloadDigestV2,
@@ -83,9 +86,9 @@ export function makeFactRelationSemanticCompilerV2(
   return {
     compile: async (envelope) => {
       const { payload, decodedBytes } = decodeFactRelationCommandPayloadV2(envelope);
-      const compiled = await compilePayload(options.state, payload);
-      await verifyBaseCas(options.state, envelope.intent.kind === "typed" ? envelope.intent.baseCas : [], compiled.requiredBaseRefs);
-      verifyPathCas(envelope.intent.kind === "typed" ? envelope.intent.declaredPathCas : [], compiled.requiredPathSnapshots);
+      const compiled = await compileFactRelationPayloadV2(options.state, payload);
+      await verifySemanticBaseCasV2(options.state, envelope.intent.kind === "typed" ? envelope.intent.baseCas : [], compiled.requiredBaseRefs);
+      verifySemanticPathCasV2(envelope.intent.kind === "typed" ? envelope.intent.declaredPathCas : [], compiled.requiredPathSnapshots);
       return {
         mutationPlan: compiled.mutationPlan,
         operation: compiled.operation,
@@ -95,7 +98,7 @@ export function makeFactRelationSemanticCompilerV2(
   };
 }
 
-async function compilePayload(
+async function compileFactRelationPayloadV2(
   state: FactRelationAuthorityStateV2,
   payload: FactRelationCommandPayloadV2
 ): Promise<CompiledFactRelationCommandV2> {
@@ -126,7 +129,7 @@ function compileFactCreate(payload: FactCreatePayloadV2): CompiledFactRelationCo
   });
   const factRef = entityRef("fact", `fact/${payload.ownerTaskId}/${payload.factId}`);
   return {
-    mutationPlan: plan([{ entityKind: "fact", identity: { taskId: payload.ownerTaskId, factId: payload.factId }, action: "create" }]),
+    mutationPlan: semanticMutationPlanV2([{ entityKind: "fact", identity: { taskId: payload.ownerTaskId, factId: payload.factId }, action: "create" }]),
     operation: {
       opId: "authority-overrides-this",
       entityId: taskEntityId(payload.ownerTaskId),
@@ -139,8 +142,8 @@ function compileFactCreate(payload: FactCreatePayloadV2): CompiledFactRelationCo
 }
 
 function compileFactInvalidate(payload: FactInvalidatePayloadV2): CompiledFactRelationCommandV2 {
-  if (payload.factId === payload.invalidatedByFactId) throw compilerAdmission("FACT_SELF_INVALIDATION");
-  if (!payload.rationale.trim()) throw compilerAdmission("FACT_INVALIDATION_RATIONALE_REQUIRED");
+  if (payload.factId === payload.invalidatedByFactId) throw semanticAdmissionV2("FACT_SELF_INVALIDATION");
+  if (!payload.rationale.trim()) throw semanticAdmissionV2("FACT_INVALIDATION_RATIONALE_REQUIRED");
   const relation = decodeRelationV2({
     relation_id: deriveRelationId({
       source: `fact/${payload.ownerTaskId}/${payload.invalidatedByFactId}`,
@@ -161,7 +164,7 @@ function compileFactInvalidate(payload: FactInvalidatePayloadV2): CompiledFactRe
   const invalidator = entityRef("fact", `fact/${payload.ownerTaskId}/${payload.invalidatedByFactId}`);
   const relationRef = entityRef("relation", `relation/${relation.relation_id}`);
   return {
-    mutationPlan: plan([
+    mutationPlan: semanticMutationPlanV2([
       { entityKind: "fact", identity: { taskId: payload.ownerTaskId, factId: payload.factId }, action: "invalidate" },
       {
         entityKind: "relation",
@@ -193,13 +196,13 @@ async function compileRelationCreate(
   payload: RelationCreatePayloadV2
 ): Promise<CompiledFactRelationCommandV2> {
   const relation = decodeRelationV2(payload.relation);
-  if (relation.state !== "active") throw compilerAdmission("RELATION_CREATE_REQUIRES_ACTIVE_STATE");
+  if (relation.state !== "active") throw semanticAdmissionV2("RELATION_CREATE_REQUIRES_ACTIVE_STATE");
   assertRelationIdentity(relation);
   const host = relationHost(relation.source);
   assertRelationHost(relation, host.hostRef);
   const relationRef = entityRef("relation", `relation/${relation.relation_id}`);
   const hostRef = entityRef(host.kind, host.hostRef);
-  const mutationPlan = plan([{
+  const mutationPlan = semanticMutationPlanV2([{
     entityKind: "relation",
     identity: { relationId: relation.relation_id },
     action: "create",
@@ -231,7 +234,7 @@ async function compileRelationCreate(
   const snapshot = await requiredDocument(state, path);
   if (host.kind === "decision") {
     const current = decodeDecision(parseDecisionDocument(snapshot.body).decision);
-    if (current.decision_id !== host.id) throw compilerAdmission("RELATION_HOST_ID_MISMATCH");
+    if (current.decision_id !== host.id) throw semanticAdmissionV2("RELATION_HOST_ID_MISMATCH");
     return {
       mutationPlan,
       operation: {
@@ -275,17 +278,17 @@ async function compileRelationLifecycle(
   const snapshot = await requiredDocument(state, path);
   const current = currentHostedRelations(snapshot.body, host.kind);
   const existing = current.relations.find((relation) => relation.relation_id === payload.relationId);
-  if (!existing) throw compilerAdmission("RELATION_NOT_FOUND");
-  if (existing.source !== payload.sourceRef) throw compilerAdmission("RELATION_SOURCE_MISMATCH");
-  if (existing.state !== "active") throw compilerAdmission("RELATION_NOT_ACTIVE");
+  if (!existing) throw semanticAdmissionV2("RELATION_NOT_FOUND");
+  if (existing.source !== payload.sourceRef) throw semanticAdmissionV2("RELATION_SOURCE_MISMATCH");
+  if (existing.state !== "active") throw semanticAdmissionV2("RELATION_NOT_ACTIVE");
   const retired = { ...existing, state: "retired" as const };
   const replacement = payload.schema === "relation.replace/v1" ? decodeRelationV2(payload.replacement) : null;
   if (replacement) {
-    if (replacement.state !== "active") throw compilerAdmission("RELATION_REPLACEMENT_REQUIRES_ACTIVE_STATE");
+    if (replacement.state !== "active") throw semanticAdmissionV2("RELATION_REPLACEMENT_REQUIRES_ACTIVE_STATE");
     assertRelationIdentity(replacement);
     const replacementHost = relationHost(replacement.source);
-    if (replacementHost.hostRef !== host.hostRef) throw compilerAdmission("RELATION_REPLACEMENT_HOST_MISMATCH");
-    if (replacement.relation_id === existing.relation_id) throw compilerAdmission("RELATION_REPLACEMENT_ID_UNCHANGED");
+    if (replacementHost.hostRef !== host.hostRef) throw semanticAdmissionV2("RELATION_REPLACEMENT_HOST_MISMATCH");
+    if (replacement.relation_id === existing.relation_id) throw semanticAdmissionV2("RELATION_REPLACEMENT_ID_UNCHANGED");
     assertRelationHost(replacement, host.hostRef);
   }
   const mutations: RegistryMutationPlanInput["mutations"] = [
@@ -313,7 +316,7 @@ async function compileRelationLifecycle(
       .map((relation) => relation.relation_id === existing.relation_id ? retired : relation)
       .concat(replacement ? [replacement] : []);
     return {
-      mutationPlan: plan(mutations),
+      mutationPlan: semanticMutationPlanV2(mutations),
       operation: {
         opId: "authority-overrides-this",
         entityId: `decision/${host.id}` as EntityId,
@@ -328,7 +331,7 @@ async function compileRelationLifecycle(
     };
   }
   return {
-    mutationPlan: plan(mutations),
+    mutationPlan: semanticMutationPlanV2(mutations),
     operation: {
       opId: "authority-overrides-this",
       entityId: taskEntityId(host.kind === "fact" ? host.taskId : host.id),
@@ -346,57 +349,21 @@ async function compileRelationLifecycle(
   };
 }
 
-async function verifyBaseCas(
-  state: FactRelationAuthorityStateV2,
-  claimed: ReadonlyArray<SemanticBaseCasV2>,
-  requiredRefs: ReadonlyArray<RegistryEntityRefV2>
-): Promise<void> {
-  const required = uniqueRefs(requiredRefs);
-  if (claimed.length !== required.length) throw compilerAdmission("BASE_CAS_CONFLICT");
-  const byRef = new Map(claimed.map((entry) => [entityRefKey(entry.entityRef), entry]));
-  if (byRef.size !== claimed.length) throw compilerAdmission("BASE_CAS_CONFLICT");
-  for (const ref of required) {
-    const row = byRef.get(entityRefKey(ref));
-    if (!row) throw compilerAdmission("BASE_CAS_CONFLICT");
-    const actual = await state.readEntityBase(ref);
-    if (!actual) {
-      if (row.expectedSemanticVersion !== null || row.expectedStateDigest !== null) throw compilerAdmission("BASE_CAS_CONFLICT");
-      continue;
-    }
-    if (row.expectedSemanticVersion !== actual.semanticVersion
-      || !nullableBytesEqual(row.expectedStateDigest, actual.stateDigest)) throw compilerAdmission("BASE_CAS_CONFLICT");
-  }
-}
-
-function verifyPathCas(
-  claimed: ReadonlyArray<PathCasV2>,
-  required: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }>
-): void {
-  if (claimed.length !== required.length) throw compilerAdmission("BASE_CAS_CONFLICT");
-  const byPath = new Map(claimed.map((entry) => [entry.path, entry]));
-  if (byPath.size !== claimed.length) throw compilerAdmission("BASE_CAS_CONFLICT");
-  for (const { path, snapshot } of required) {
-    const row = byPath.get(path);
-    if (!row || row.expectedEpoch !== snapshot.epoch || row.expectedRevision !== snapshot.revision
-      || !compilerBytesEqual(row.expectedBlobDigest, snapshot.blobDigest)) throw compilerAdmission("BASE_CAS_CONFLICT");
-  }
-}
-
 function decodeDecision(value: unknown): DecisionPackage {
   try {
     return Schema.decodeUnknownSync(DecisionPackageSchema)(value);
   } catch {
-    throw compilerAdmission("RELATION_HOST_DOCUMENT_INVALID");
+    throw semanticAdmissionV2("RELATION_HOST_DOCUMENT_INVALID");
   }
 }
 
 function assertRelationIdentity(relation: EntityRelationRecord): void {
-  if (deriveRelationId(relation) !== relation.relation_id) throw compilerAdmission("RELATION_ID_MISMATCH");
+  if (deriveRelationId(relation) !== relation.relation_id) throw semanticAdmissionV2("RELATION_ID_MISMATCH");
 }
 
 function assertRelationHost(relation: EntityRelationRecord, hostRef: string): void {
   const issues = validateRelationRecordsForHost(hostRef, [relation]);
-  if (issues.length > 0) throw compilerAdmission(`RELATION_DOMAIN_INVALID:${issues[0]!.code}`);
+  if (issues.length > 0) throw semanticAdmissionV2(`RELATION_DOMAIN_INVALID:${issues[0]!.code}`);
 }
 
 function relationHost(sourceRef: string):
@@ -409,20 +376,20 @@ function relationHost(sourceRef: string):
   if (segments[0] === "fact" && segments[1] && segments[2]) {
     return { kind: "fact", id: segments[2], taskId: segments[1], factId: segments[2], hostRef: `fact/${segments[1]}/${segments[2]}` };
   }
-  throw compilerAdmission("RELATION_STORAGE_SOURCE_UNSUPPORTED");
+  throw semanticAdmissionV2("RELATION_STORAGE_SOURCE_UNSUPPORTED");
 }
 
 function relationStoragePath(relationId: string, sourceRef: string): string {
   const locator = entityRegistry.relation.storageLocator;
-  if (locator.status !== "ready") throw compilerAdmission("REGISTRY_FACET_NOT_WRITABLE");
+  if (locator.status !== "ready") throw semanticAdmissionV2("REGISTRY_FACET_NOT_WRITABLE");
   const target = locator.locator.locate({ relationId }, { sourceRef }).targets[0];
-  if (!target?.path) throw compilerAdmission("RELATION_STORAGE_TARGET_REQUIRED");
+  if (!target?.path) throw semanticAdmissionV2("RELATION_STORAGE_TARGET_REQUIRED");
   return target.path;
 }
 
 async function requiredDocument(state: FactRelationAuthorityStateV2, path: string): Promise<HostedDocumentSnapshotV2> {
   const snapshot = await state.readHostedDocument(path);
-  if (!snapshot) throw compilerAdmission("RELATION_HOST_DOCUMENT_NOT_FOUND");
+  if (!snapshot) throw semanticAdmissionV2("RELATION_HOST_DOCUMENT_NOT_FOUND");
   return snapshot;
 }
 
@@ -443,11 +410,11 @@ function rewriteHostedRelation(
   let next = body;
   if (existing) {
     const before = formatRelationFlowRecord(existing);
-    if (!next.includes(before)) throw compilerAdmission("RELATION_HOST_CODEC_MISMATCH");
+    if (!next.includes(before)) throw semanticAdmissionV2("RELATION_HOST_CODEC_MISMATCH");
     next = next.replace(before, formatRelationFlowRecord({ ...existing, state: "retired" }));
   }
   if (!replacement) return next;
-  if (next.includes(`relation_id: ${replacement.relation_id}`)) throw compilerAdmission("RELATION_ALREADY_EXISTS");
+  if (next.includes(`relation_id: ${replacement.relation_id}`)) throw semanticAdmissionV2("RELATION_ALREADY_EXISTS");
   const line = formatRelationFlowRecord(replacement);
   if (/^relations:\s*$/mu.test(next)) return next.replace(/^relations:\s*$/mu, (heading) => `${heading}\n${line}`);
   const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/u.exec(next);
@@ -461,30 +428,6 @@ function targetFactInSameHost(target: string, taskId: string): ReadonlyArray<str
   return segments[0] === "fact" && segments[1] === taskId && segments[2] ? [segments[2]] : [];
 }
 
-function plan(mutations: RegistryMutationPlanInput["mutations"]): RegistryMutationPlanInput {
-  return { registryVersion, mutations };
-}
-
 function entityRef(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
   return { registryVersion, entityKind, canonicalRef };
-}
-
-function entityRefKey(ref: RegistryEntityRefV2): string {
-  return `${ref.registryVersion}\0${ref.entityKind}\0${ref.canonicalRef}`;
-}
-
-function uniqueRefs(refs: ReadonlyArray<RegistryEntityRefV2>): ReadonlyArray<RegistryEntityRefV2> {
-  return [...new Map(refs.map((ref) => [entityRefKey(ref), ref])).values()];
-}
-
-function compilerAdmission(code: string, message = code): SemanticAdmissionErrorV2 {
-  return new SemanticAdmissionErrorV2(code, message);
-}
-
-function compilerBytesEqual(left: Uint8Array, right: Uint8Array): boolean {
-  return Buffer.from(left).equals(Buffer.from(right));
-}
-
-function nullableBytesEqual(left: Uint8Array | null, right: Uint8Array | null): boolean {
-  return left === null || right === null ? left === right : compilerBytesEqual(left, right);
 }

--- a/packages/application/src/authority/semantic-authority-helpers-v2.ts
+++ b/packages/application/src/authority/semantic-authority-helpers-v2.ts
@@ -1,0 +1,110 @@
+import type { RegistryMutationPlanInput } from "../../../kernel/src/index.ts";
+import {
+  SemanticAdmissionErrorV2,
+  bytesEqual,
+  type PathCasV2,
+  type RegistryEntityRefV2,
+  type SemanticBaseCasV2
+} from "./semantic-mutation-envelope-v2.ts";
+
+interface SemanticEntityBaseReaderV2 {
+  readonly readEntityBase: (entityRef: RegistryEntityRefV2) => Promise<{
+    readonly semanticVersion: string | null;
+    readonly stateDigest: Uint8Array | null;
+  } | null>;
+}
+
+interface SemanticHostedDocumentSnapshotV2 {
+  readonly epoch: string;
+  readonly revision: bigint;
+  readonly blobDigest: Uint8Array;
+}
+
+export function semanticAdmissionV2(code: string, message = code): SemanticAdmissionErrorV2 {
+  return new SemanticAdmissionErrorV2(code, message);
+}
+
+export function exactSemanticObjectV2(
+  value: unknown,
+  keys: ReadonlyArray<string>,
+  options: { readonly name?: string; readonly allowAdditional?: boolean } = {}
+): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
+  }
+  const row = value as Record<string, unknown>;
+  const actual = Object.keys(row);
+  if (keys.some((key) => !actual.includes(key))
+    || (!options.allowAdditional && actual.some((key) => !keys.includes(key)))) {
+    throw semanticAdmissionV2("TYPED_PAYLOAD_UNKNOWN_OR_MISSING_FIELD", options.name);
+  }
+  return row;
+}
+
+export function semanticStringValueV2(value: unknown): string {
+  if (typeof value !== "string") throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
+  return value;
+}
+
+export async function verifySemanticBaseCasV2(
+  state: SemanticEntityBaseReaderV2,
+  claimed: ReadonlyArray<SemanticBaseCasV2>,
+  requiredRefs: ReadonlyArray<RegistryEntityRefV2>
+): Promise<void> {
+  const required = uniqueRegistryEntityRefsV2(requiredRefs);
+  if (claimed.length !== required.length) throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+  const byRef = new Map(claimed.map((entry) => [registryEntityRefKeyV2(entry.entityRef), entry]));
+  if (byRef.size !== claimed.length) throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+  for (const entityRef of required) {
+    const row = byRef.get(registryEntityRefKeyV2(entityRef));
+    if (!row) throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+    const actual = await state.readEntityBase(entityRef);
+    if (!actual) {
+      if (row.expectedSemanticVersion !== null || row.expectedStateDigest !== null) {
+        throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+      }
+    } else if (row.expectedSemanticVersion !== actual.semanticVersion
+      || !nullableSemanticBytesEqualV2(row.expectedStateDigest, actual.stateDigest)) {
+      throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+    }
+  }
+}
+
+export function verifySemanticPathCasV2(
+  claimed: ReadonlyArray<PathCasV2>,
+  required: ReadonlyArray<{ readonly path: string; readonly snapshot: SemanticHostedDocumentSnapshotV2 }>
+): void {
+  if (claimed.length !== required.length) throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+  const byPath = new Map(claimed.map((entry) => [entry.path, entry]));
+  if (byPath.size !== claimed.length) throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+  for (const { path, snapshot } of required) {
+    const row = byPath.get(path);
+    if (!row || row.expectedEpoch !== snapshot.epoch || row.expectedRevision !== snapshot.revision
+      || !bytesEqual(row.expectedBlobDigest, snapshot.blobDigest)) {
+      throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+    }
+  }
+}
+
+export function semanticMutationPlanV2(
+  mutations: RegistryMutationPlanInput["mutations"]
+): RegistryMutationPlanInput {
+  return { registryVersion: 1, mutations };
+}
+
+export function nullableSemanticBytesEqualV2(
+  left: Uint8Array | null,
+  right: Uint8Array | null
+): boolean {
+  return left === null || right === null ? left === right : bytesEqual(left, right);
+}
+
+function registryEntityRefKeyV2(ref: RegistryEntityRefV2): string {
+  return `${ref.registryVersion}\0${ref.entityKind}\0${ref.canonicalRef}`;
+}
+
+function uniqueRegistryEntityRefsV2(
+  refs: ReadonlyArray<RegistryEntityRefV2>
+): ReadonlyArray<RegistryEntityRefV2> {
+  return [...new Map(refs.map((ref) => [registryEntityRefKeyV2(ref), ref])).values()];
+}

--- a/packages/application/src/authority/semantic-mutation-envelope-v2.ts
+++ b/packages/application/src/authority/semantic-mutation-envelope-v2.ts
@@ -395,4 +395,4 @@ function digest(value: CanonicalCborValue, name: string): Uint8Array { return fi
 function nullableDigest(value: CanonicalCborValue, name: string): Uint8Array | null { return value === null ? null : digest(value, name); }
 function uint32(value: CanonicalCborValue | number, name: string): number { if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > 0xffff_ffff) throw new SemanticAdmissionErrorV2("INVALID_ENVELOPE", `${name} must be uint32`); return value; }
 function uint64(value: CanonicalCborValue, name: string): bigint { if (typeof value !== "number" && typeof value !== "bigint") throw new SemanticAdmissionErrorV2("INVALID_ENVELOPE", `${name} must be uint64`); const output = BigInt(value); if (output < 0n) throw new SemanticAdmissionErrorV2("INVALID_ENVELOPE", `${name} must be uint64`); return output; }
-function bytesEqual(left: Uint8Array, right: Uint8Array): boolean { return Buffer.from(left).equals(Buffer.from(right)); }
+export function bytesEqual(left: Uint8Array, right: Uint8Array): boolean { return Buffer.from(left).equals(Buffer.from(right)); }

--- a/packages/application/src/authority/session-execution-review-command-v2.ts
+++ b/packages/application/src/authority/session-execution-review-command-v2.ts
@@ -1,0 +1,172 @@
+import { Schema } from "effect";
+import {
+  entityRegistry,
+  executionDeclaration,
+  reviewDeclaration,
+  type ExecutionRecord,
+  type ReviewRecord,
+  type SessionManifest
+} from "../../../kernel/src/index.ts";
+import { canonicalPayloadDigestV2 } from "./fact-relation-command-v2.ts";
+import {
+  bytesEqual,
+  type SemanticMutationEnvelopeV2
+} from "./semantic-mutation-envelope-v2.ts";
+import {
+  exactSemanticObjectV2,
+  semanticAdmissionV2,
+  semanticStringValueV2
+} from "./semantic-authority-helpers-v2.ts";
+
+export const sessionExecutionReviewTypedCommandsV2 = [
+  "session.export",
+  "session.sync",
+  "session.archive",
+  "execution.claim",
+  "execution.submit",
+  "execution.close",
+  "review.create",
+  "review.dismiss",
+  "review.record"
+] as const;
+
+export type SessionExecutionReviewTypedCommandV2 = (typeof sessionExecutionReviewTypedCommandsV2)[number];
+
+export type SessionActionPayloadV2 = {
+  readonly schema: "session.export/v1" | "session.sync/v1" | "session.archive/v1";
+  readonly manifest: SessionManifest;
+  readonly body: string;
+};
+
+export type ExecutionActionPayloadV2 = {
+  readonly schema: "execution.claim/v1" | "execution.submit/v1" | "execution.close/v1";
+  readonly taskId: string;
+  readonly execution: ExecutionRecord;
+};
+
+export type ReviewActionPayloadV2 = {
+  readonly schema: "review.create/v1" | "review.dismiss/v1" | "review.record/v1";
+  readonly taskId: string;
+  readonly review: ReviewRecord;
+};
+
+export type SessionExecutionReviewCommandPayloadV2 =
+  | SessionActionPayloadV2
+  | ExecutionActionPayloadV2
+  | ReviewActionPayloadV2;
+
+export function decodeSessionExecutionReviewCommandPayloadV2(envelope: SemanticMutationEnvelopeV2): {
+  readonly payload: SessionExecutionReviewCommandPayloadV2;
+  readonly decodedBytes: bigint;
+} {
+  if (envelope.intent.kind !== "typed") throw semanticAdmissionV2("SEMANTIC_DIFF_REQUIRED");
+  if (envelope.intent.command.registryVersion !== 1 || envelope.intent.command.version !== 1) {
+    throw semanticAdmissionV2("TYPED_COMMAND_VERSION_UNSUPPORTED");
+  }
+  if (!sessionExecutionReviewTypedCommandsV2.includes(envelope.intent.command.name as SessionExecutionReviewTypedCommandV2)) {
+    throw semanticAdmissionV2("TYPED_COMMAND_UNREGISTERED");
+  }
+  if (envelope.intent.canonicalPayload.kind !== "inline") throw semanticAdmissionV2("AUTHORITY_PAYLOAD_CAS_UNSUPPORTED");
+  const bytes = envelope.intent.canonicalPayload.bytes;
+  if (envelope.intent.canonicalPayload.size !== BigInt(bytes.length)) throw semanticAdmissionV2("CANONICAL_PAYLOAD_SIZE_MISMATCH");
+  if (!bytesEqual(envelope.intent.canonicalPayloadDigest, canonicalPayloadDigestV2(bytes))) {
+    throw semanticAdmissionV2("CANONICAL_PAYLOAD_DIGEST_MISMATCH");
+  }
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(Buffer.from(bytes).toString("utf8"));
+  } catch {
+    throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
+  }
+  const payload = decodeStrictSessionExecutionReviewPayloadV2(decoded);
+  if (!bytesEqual(bytes, encodeSessionExecutionReviewCommandPayloadV2(payload))) {
+    throw semanticAdmissionV2("TYPED_PAYLOAD_NON_CANONICAL");
+  }
+  if (payload.schema.replace("/v1", "") !== envelope.intent.command.name) {
+    throw semanticAdmissionV2("TYPED_COMMAND_PAYLOAD_MISMATCH");
+  }
+  return { payload, decodedBytes: BigInt(bytes.length) };
+}
+
+export function encodeSessionExecutionReviewCommandPayloadV2(
+  payload: SessionExecutionReviewCommandPayloadV2
+): Uint8Array {
+  return Buffer.from(JSON.stringify(canonicalJsonValue(payload)), "utf8");
+}
+
+function decodeStrictSessionExecutionReviewPayloadV2(value: unknown): SessionExecutionReviewCommandPayloadV2 {
+  const discriminator = exactSemanticObjectV2(value, ["schema"], { allowAdditional: true });
+  switch (discriminator.schema) {
+    case "session.export/v1":
+    case "session.sync/v1":
+    case "session.archive/v1": {
+      const row = exactSemanticObjectV2(value, ["schema", "manifest", "body"]);
+      return {
+        schema: discriminator.schema,
+        manifest: decodeSessionManifest(row.manifest),
+        body: semanticStringValueV2(row.body)
+      };
+    }
+    case "execution.claim/v1":
+    case "execution.submit/v1":
+    case "execution.close/v1": {
+      const row = exactSemanticObjectV2(value, ["schema", "taskId", "execution"]);
+      return {
+        schema: discriminator.schema,
+        taskId: nonBlankText(row.taskId),
+        execution: decodeExecution(row.execution)
+      };
+    }
+    case "review.create/v1":
+    case "review.dismiss/v1":
+    case "review.record/v1": {
+      const row = exactSemanticObjectV2(value, ["schema", "taskId", "review"]);
+      return {
+        schema: discriminator.schema,
+        taskId: nonBlankText(row.taskId),
+        review: decodeReview(row.review)
+      };
+    }
+    default:
+      throw semanticAdmissionV2("TYPED_PAYLOAD_SCHEMA_UNSUPPORTED");
+  }
+}
+
+function decodeSessionManifest(value: unknown): SessionManifest {
+  try {
+    return Schema.decodeUnknownSync(entityRegistry.session.schema)(value) as SessionManifest;
+  } catch {
+    throw semanticAdmissionV2("SESSION_MANIFEST_INVALID");
+  }
+}
+
+function decodeExecution(value: unknown): ExecutionRecord {
+  try {
+    return Schema.decodeUnknownSync(executionDeclaration.schema)(value) as ExecutionRecord;
+  } catch {
+    throw semanticAdmissionV2("EXECUTION_DOCUMENT_INVALID");
+  }
+}
+
+function decodeReview(value: unknown): ReviewRecord {
+  try {
+    return Schema.decodeUnknownSync(reviewDeclaration.schema)(value) as ReviewRecord;
+  } catch {
+    throw semanticAdmissionV2("REVIEW_DOCUMENT_INVALID");
+  }
+}
+
+function nonBlankText(value: unknown): string {
+  const result = semanticStringValueV2(value);
+  if (!result || result.trim() !== result) throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
+  return result;
+}
+
+function canonicalJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalJsonValue);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => [key, canonicalJsonValue(entry)]));
+}

--- a/packages/application/src/authority/session-execution-review-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/session-execution-review-semantic-compiler-v2.ts
@@ -1,0 +1,313 @@
+import { Schema } from "effect";
+import {
+  entityRegistry,
+  executionDeclaration,
+  reviewDeclaration,
+  sha256Text,
+  stablePayloadHash,
+  type EntityId,
+  type ExecutionRecord,
+  type RegistryMutationPlanInput,
+  type ReviewRecord,
+  type SessionManifest,
+  type WriteOp
+} from "../../../kernel/src/index.ts";
+import {
+  decodeSessionExecutionReviewCommandPayloadV2,
+  type ExecutionActionPayloadV2,
+  type ReviewActionPayloadV2,
+  type SessionActionPayloadV2,
+  type SessionExecutionReviewCommandPayloadV2
+} from "./session-execution-review-command-v2.ts";
+import {
+  type AuthoritySemanticCompilerV2,
+  type RegistryEntityRefV2
+} from "./semantic-mutation-envelope-v2.ts";
+import {
+  semanticAdmissionV2 as admission,
+  semanticMutationPlanV2 as plan,
+  verifySemanticBaseCasV2,
+  verifySemanticPathCasV2
+} from "./semantic-authority-helpers-v2.ts";
+import type {
+  HostedDocumentSnapshotV2,
+  SemanticEntityBaseV2
+} from "./fact-relation-semantic-compiler-v2.ts";
+
+export {
+  encodeSessionExecutionReviewCommandPayloadV2,
+  sessionExecutionReviewTypedCommandsV2,
+  type ExecutionActionPayloadV2,
+  type ReviewActionPayloadV2,
+  type SessionActionPayloadV2,
+  type SessionExecutionReviewCommandPayloadV2,
+  type SessionExecutionReviewTypedCommandV2
+} from "./session-execution-review-command-v2.ts";
+
+export interface SessionExecutionReviewAuthorityStateV2 {
+  readonly readEntityBase: (entityRef: RegistryEntityRefV2) => Promise<SemanticEntityBaseV2 | null>;
+  readonly readHostedDocument: (path: string) => Promise<HostedDocumentSnapshotV2 | null>;
+}
+
+export interface SessionExecutionReviewSemanticCompilerV2Options {
+  readonly state: SessionExecutionReviewAuthorityStateV2;
+}
+
+interface CompiledSessionExecutionReviewCommandV2 {
+  readonly mutationPlan: RegistryMutationPlanInput;
+  readonly operation: WriteOp;
+  readonly requiredBaseRefs: ReadonlyArray<RegistryEntityRefV2>;
+  readonly requiredPathSnapshots: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }>;
+}
+
+const registryVersion = 1;
+
+export function makeSessionExecutionReviewSemanticCompilerV2(
+  options: SessionExecutionReviewSemanticCompilerV2Options
+): AuthoritySemanticCompilerV2 {
+  return {
+    compile: async (envelope) => {
+      const { payload, decodedBytes } = decodeSessionExecutionReviewCommandPayloadV2(envelope);
+      const compiled = await compileSessionExecutionReviewPayloadV2(options.state, payload);
+      await verifySemanticBaseCasV2(
+        options.state,
+        envelope.intent.kind === "typed" ? envelope.intent.baseCas : [],
+        compiled.requiredBaseRefs
+      );
+      verifySemanticPathCasV2(
+        envelope.intent.kind === "typed" ? envelope.intent.declaredPathCas : [],
+        compiled.requiredPathSnapshots
+      );
+      return { mutationPlan: compiled.mutationPlan, operation: compiled.operation, decodedBytes };
+    }
+  };
+}
+
+async function compileSessionExecutionReviewPayloadV2(
+  state: SessionExecutionReviewAuthorityStateV2,
+  payload: SessionExecutionReviewCommandPayloadV2
+): Promise<CompiledSessionExecutionReviewCommandV2> {
+  if (payload.schema.startsWith("session.")) return compileSession(state, payload as SessionActionPayloadV2);
+  if (payload.schema.startsWith("execution.")) return compileExecution(state, payload as ExecutionActionPayloadV2);
+  return compileReview(state, payload as ReviewActionPayloadV2);
+}
+
+async function compileSession(
+  state: SessionExecutionReviewAuthorityStateV2,
+  payload: SessionActionPayloadV2
+): Promise<CompiledSessionExecutionReviewCommandV2> {
+  const action = sessionAction(payload.schema);
+  const { manifest, body } = payload;
+  assertSessionBody(manifest, body);
+  if (action === "archive" && manifest.lifecycle !== "archived") throw admission("SESSION_ARCHIVE_STATE_REQUIRED");
+  if (action !== "archive" && manifest.lifecycle === "archived") throw admission("SESSION_ARCHIVE_ACTION_REQUIRED");
+  const path = storagePath("session", { sessionId: manifest.sessionId });
+  const snapshot = await state.readHostedDocument(path);
+  if (action === "export" && snapshot) throw admission("SESSION_ALREADY_EXISTS");
+  if (action === "archive" && !snapshot) throw admission("SESSION_DOCUMENT_NOT_FOUND");
+  const declaration = entityRegistry.session;
+  return {
+    mutationPlan: plan([{
+      entityKind: "session",
+      identity: { sessionId: manifest.sessionId },
+      action
+    }]),
+    operation: declaredDocumentOperation(
+      "session",
+      manifest.sessionId,
+      declaration,
+      { sessionId: manifest.sessionId },
+      declaration.documentCodec.encode(manifest),
+      { blobRef: manifest.bodyRef, blobBody: body }
+    ),
+    requiredBaseRefs: [ref("session", `session/${encodeURIComponent(manifest.sessionId)}`)],
+    requiredPathSnapshots: snapshot ? [{ path, snapshot }] : []
+  };
+}
+
+async function compileExecution(
+  state: SessionExecutionReviewAuthorityStateV2,
+  payload: ExecutionActionPayloadV2
+): Promise<CompiledSessionExecutionReviewCommandV2> {
+  const action = executionAction(payload.schema);
+  const execution = payload.execution;
+  assertExecutionIdentity(payload.taskId, execution);
+  const path = storagePath("execution", { taskId: payload.taskId, executionId: execution.execution_id });
+  const snapshot = await state.readHostedDocument(path);
+  const current = snapshot ? decodeExecutionDocument(snapshot.body) : null;
+  assertExecutionTransition(action, current, execution);
+  return {
+    mutationPlan: plan([{
+      entityKind: "execution",
+      identity: { taskId: payload.taskId, executionId: execution.execution_id },
+      action
+    }]),
+    operation: declaredDocumentOperation(
+      "execution",
+      execution.execution_id,
+      executionDeclaration,
+      { taskId: payload.taskId, executionId: execution.execution_id },
+      executionDeclaration.documentCodec.encode(execution)
+    ),
+    requiredBaseRefs: [ref("execution", `execution/${encodeURIComponent(payload.taskId)}/${encodeURIComponent(execution.execution_id)}`)],
+    requiredPathSnapshots: snapshot ? [{ path, snapshot }] : []
+  };
+}
+
+async function compileReview(
+  state: SessionExecutionReviewAuthorityStateV2,
+  payload: ReviewActionPayloadV2
+): Promise<CompiledSessionExecutionReviewCommandV2> {
+  const action = reviewAction(payload.schema);
+  const review = payload.review;
+  assertReviewIdentity(payload.taskId, review);
+  if (action === "dismiss" && review.verdict !== "dismissed") throw admission("REVIEW_DISMISS_VERDICT_REQUIRED");
+  if (action === "record" && review.verdict === "dismissed") throw admission("REVIEW_RECORD_VERDICT_REQUIRED");
+  const path = storagePath("review", { taskId: payload.taskId, reviewId: review.review_id });
+  const snapshot = await state.readHostedDocument(path);
+  if (snapshot) throw admission("REVIEW_ALREADY_EXISTS");
+  return {
+    mutationPlan: plan([{
+      entityKind: "review",
+      identity: { taskId: payload.taskId, reviewId: review.review_id },
+      action
+    }]),
+    operation: declaredDocumentOperation(
+      "review",
+      review.review_id,
+      reviewDeclaration,
+      { taskId: payload.taskId, reviewId: review.review_id },
+      reviewDeclaration.documentCodec.encode(review)
+    ),
+    requiredBaseRefs: [ref("review", `review/${encodeURIComponent(payload.taskId)}/${encodeURIComponent(review.review_id)}`)],
+    requiredPathSnapshots: []
+  };
+}
+
+function assertSessionBody(manifest: SessionManifest, body: string): void {
+  const bytes = Buffer.from(body, "utf8");
+  if (manifest.bodyRef.sha256 !== sha256Text(body) || manifest.bodyRef.size !== bytes.byteLength) {
+    throw admission("SESSION_BODY_REF_MISMATCH");
+  }
+  if (!manifest.bodyRef.mediaType.trim()) throw admission("SESSION_BODY_MEDIA_TYPE_REQUIRED");
+}
+
+function assertExecutionIdentity(taskId: string, execution: ExecutionRecord): void {
+  if (execution.task_ref !== `task/${taskId}`) throw admission("EXECUTION_TASK_REF_MISMATCH");
+}
+
+function assertExecutionTransition(
+  action: "claim" | "submit" | "close",
+  current: ExecutionRecord | null,
+  next: ExecutionRecord
+): void {
+  if (action === "claim") {
+    if (current) throw admission("EXECUTION_ALREADY_EXISTS");
+    if (next.state !== "active" || next.submitted_at !== null || next.closed_at !== null || next.submission !== null) {
+      throw admission("EXECUTION_CLAIM_STATE_INVALID");
+    }
+    return;
+  }
+  if (!current) throw admission("EXECUTION_DOCUMENT_NOT_FOUND");
+  assertSameExecution(current, next);
+  if (action === "submit") {
+    if (current.state !== "active" || next.state !== "submitted" || next.submitted_at === null
+      || next.closed_at !== null || next.submission === null || !arrayPrefix(current.outputs, next.outputs)) {
+      throw admission("EXECUTION_SUBMIT_STATE_INVALID");
+    }
+    return;
+  }
+  if ((current.state !== "submitted" && current.state !== "changes_requested")
+    || (next.state !== "accepted" && next.state !== "abandoned") || next.closed_at === null) {
+    throw admission("EXECUTION_CLOSE_STATE_INVALID");
+  }
+  if (!same(current.session_bindings, next.session_bindings)
+    || !same(current.outputs, next.outputs) || !same(current.submission, next.submission)) {
+    throw admission("EXECUTION_CLOSE_PAYLOAD_INVALID");
+  }
+}
+
+function assertSameExecution(current: ExecutionRecord, next: ExecutionRecord): void {
+  if (current.execution_id !== next.execution_id || current.task_ref !== next.task_ref
+    || current.claimed_at !== next.claimed_at || !same(current.primary_actor, next.primary_actor)) {
+    throw admission("EXECUTION_IMMUTABLE_FIELD_CHANGED");
+  }
+}
+
+function assertReviewIdentity(taskId: string, review: ReviewRecord): void {
+  if (review.task_ref !== `task/${taskId}` || !review.execution_ref.startsWith(`execution/${taskId}/`)) {
+    throw admission("REVIEW_HOST_REF_MISMATCH");
+  }
+}
+
+function decodeExecutionDocument(body: string): ExecutionRecord {
+  try {
+    return Schema.decodeUnknownSync(executionDeclaration.schema)(
+      executionDeclaration.documentCodec.decode(body)
+    ) as ExecutionRecord;
+  } catch {
+    throw admission("EXECUTION_DOCUMENT_INVALID");
+  }
+}
+
+function declaredDocumentOperation(
+  kind: "session" | "execution" | "review",
+  id: string,
+  declaration: {
+    readonly storageForm: string;
+    readonly rootResolver?: unknown;
+  },
+  identity: Readonly<Record<string, string>>,
+  body: string,
+  blob?: { readonly blobRef: SessionManifest["bodyRef"]; readonly blobBody: string }
+): WriteOp {
+  if (!declaration.rootResolver) throw admission("ENTITY_ROOT_RESOLVER_REQUIRED");
+  return {
+    opId: "authority-overrides-this",
+    entityId: `entity/${kind}/${id}` as EntityId,
+    kind: "doc_write",
+    payload: {
+      entityDocument: {
+        declaration: { kind, storageForm: declaration.storageForm, rootResolver: declaration.rootResolver },
+        identity,
+        body,
+        ...(blob ? blob : {})
+      }
+    }
+  };
+}
+
+function storagePath(
+  kind: "session" | "execution" | "review",
+  identity: Readonly<Record<string, string>>
+): string {
+  const locator = entityRegistry[kind].storageLocator;
+  if (locator.status !== "ready") throw admission("REGISTRY_FACET_NOT_WRITABLE");
+  const target = locator.locator.locate(identity, {}).targets.find((candidate) => candidate.kind === "document");
+  if (!target?.path) throw admission("ENTITY_STORAGE_TARGET_REQUIRED");
+  return target.path;
+}
+
+function ref(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
+  return { registryVersion, entityKind, canonicalRef };
+}
+
+function sessionAction(schema: SessionActionPayloadV2["schema"]): "export" | "sync" | "archive" {
+  return schema.slice("session.".length, -"/v1".length) as "export" | "sync" | "archive";
+}
+
+function executionAction(schema: ExecutionActionPayloadV2["schema"]): "claim" | "submit" | "close" {
+  return schema.slice("execution.".length, -"/v1".length) as "claim" | "submit" | "close";
+}
+
+function reviewAction(schema: ReviewActionPayloadV2["schema"]): "create" | "dismiss" | "record" {
+  return schema.slice("review.".length, -"/v1".length) as "create" | "dismiss" | "record";
+}
+
+function arrayPrefix<T>(prefix: ReadonlyArray<T>, value: ReadonlyArray<T>): boolean {
+  return prefix.length <= value.length && prefix.every((entry, index) => same(entry, value[index]));
+}
+
+function same(left: unknown, right: unknown): boolean {
+  return stablePayloadHash(left) === stablePayloadHash(right);
+}

--- a/packages/application/src/authority/task-decision-module-command-v2.ts
+++ b/packages/application/src/authority/task-decision-module-command-v2.ts
@@ -6,9 +6,13 @@ import {
 } from "../../../kernel/src/index.ts";
 import { canonicalPayloadDigestV2, decodeRelationV2 } from "./fact-relation-command-v2.ts";
 import {
-  SemanticAdmissionErrorV2,
+  bytesEqual,
   type SemanticMutationEnvelopeV2
 } from "./semantic-mutation-envelope-v2.ts";
+import {
+  semanticAdmissionV2,
+  semanticStringValueV2
+} from "./semantic-authority-helpers-v2.ts";
 
 export const taskDecisionModuleTypedCommandsV2 = [
   "task.create",
@@ -127,31 +131,31 @@ export function decodeTaskDecisionModuleCommandPayloadV2(envelope: SemanticMutat
   readonly payload: TaskDecisionModuleCommandPayloadV2;
   readonly decodedBytes: bigint;
 } {
-  if (envelope.intent.kind !== "typed") throw taskDecisionModulePayloadAdmission("TYPED_COMMAND_REQUIRED");
+  if (envelope.intent.kind !== "typed") throw semanticAdmissionV2("TYPED_COMMAND_REQUIRED");
   if (envelope.intent.command.registryVersion !== 1 || envelope.intent.command.version !== 1) {
-    throw taskDecisionModulePayloadAdmission("TYPED_COMMAND_VERSION_UNSUPPORTED");
+    throw semanticAdmissionV2("TYPED_COMMAND_VERSION_UNSUPPORTED");
   }
   if (!taskDecisionModuleTypedCommandsV2.includes(envelope.intent.command.name as TaskDecisionModuleTypedCommandV2)) {
-    throw taskDecisionModulePayloadAdmission("TYPED_COMMAND_UNREGISTERED");
+    throw semanticAdmissionV2("TYPED_COMMAND_UNREGISTERED");
   }
-  if (envelope.intent.canonicalPayload.kind !== "inline") throw taskDecisionModulePayloadAdmission("AUTHORITY_PAYLOAD_CAS_UNSUPPORTED");
+  if (envelope.intent.canonicalPayload.kind !== "inline") throw semanticAdmissionV2("AUTHORITY_PAYLOAD_CAS_UNSUPPORTED");
   const bytes = envelope.intent.canonicalPayload.bytes;
-  if (envelope.intent.canonicalPayload.size !== BigInt(bytes.length)) throw taskDecisionModulePayloadAdmission("CANONICAL_PAYLOAD_SIZE_MISMATCH");
-  if (!taskDecisionModulePayloadBytesEqual(envelope.intent.canonicalPayloadDigest, canonicalPayloadDigestV2(bytes))) {
-    throw taskDecisionModulePayloadAdmission("CANONICAL_PAYLOAD_DIGEST_MISMATCH");
+  if (envelope.intent.canonicalPayload.size !== BigInt(bytes.length)) throw semanticAdmissionV2("CANONICAL_PAYLOAD_SIZE_MISMATCH");
+  if (!bytesEqual(envelope.intent.canonicalPayloadDigest, canonicalPayloadDigestV2(bytes))) {
+    throw semanticAdmissionV2("CANONICAL_PAYLOAD_DIGEST_MISMATCH");
   }
   let decoded: unknown;
   try {
     decoded = JSON.parse(Buffer.from(bytes).toString("utf8"));
   } catch {
-    throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_INVALID");
+    throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
   }
   const payload = strictTaskDecisionModulePayload(decoded);
-  if (!taskDecisionModulePayloadBytesEqual(bytes, encodeTaskDecisionModuleCommandPayloadV2(payload))) {
-    throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_NON_CANONICAL");
+  if (!bytesEqual(bytes, encodeTaskDecisionModuleCommandPayloadV2(payload))) {
+    throw semanticAdmissionV2("TYPED_PAYLOAD_NON_CANONICAL");
   }
   if (payload.schema.replace("/v1", "") !== envelope.intent.command.name) {
-    throw taskDecisionModulePayloadAdmission("TYPED_COMMAND_PAYLOAD_MISMATCH");
+    throw semanticAdmissionV2("TYPED_COMMAND_PAYLOAD_MISMATCH");
   }
   return { payload, decodedBytes: BigInt(bytes.length) };
 }
@@ -169,7 +173,7 @@ function strictTaskDecisionModulePayload(value: unknown): TaskDecisionModuleComm
         schema: discriminator.schema,
         taskId: taskDecisionModuleText(row.taskId),
         ...(row.packageSlug === undefined ? {} : { packageSlug: taskDecisionModuleText(row.packageSlug) }),
-        indexBody: stringValue(row.indexBody)
+        indexBody: semanticStringValueV2(row.indexBody)
       };
     }
     case "task.transition/v1": {
@@ -182,7 +186,7 @@ function strictTaskDecisionModulePayload(value: unknown): TaskDecisionModuleComm
     }
     case "task.document/v1": {
       const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "path", "body"]);
-      return { schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), path: taskDecisionModuleText(row.path), body: stringValue(row.body) };
+      return { schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), path: taskDecisionModuleText(row.path), body: semanticStringValueV2(row.body) };
     }
     case "decision.propose/v1": {
       const row = exactTaskDecisionModuleObject(value, ["schema", "decision", "body"], false, ["body"]);
@@ -192,7 +196,7 @@ function strictTaskDecisionModulePayload(value: unknown): TaskDecisionModuleComm
       const row = exactTaskDecisionModuleObject(value, ["schema", "transition", "decision", "body"], false, ["body"]);
       const transition = taskDecisionModuleText(row.transition);
       if (!["accept", "reject", "defer", "supersede", "retire"].includes(transition)) {
-        throw taskDecisionModulePayloadAdmission("DECISION_STATE_TRANSITION_UNSUPPORTED");
+        throw semanticAdmissionV2("DECISION_STATE_TRANSITION_UNSUPPORTED");
       }
       return {
         schema: discriminator.schema,
@@ -220,7 +224,7 @@ function strictTaskDecisionModulePayload(value: unknown): TaskDecisionModuleComm
     case "module.step/v1": {
       const row = exactTaskDecisionModuleObject(value, ["schema", "moduleKey", "stepId", "state"]);
       const state = taskDecisionModuleText(row.state);
-      if (!["planned", "in-progress", "blocked", "done"].includes(state)) throw taskDecisionModulePayloadAdmission("MODULE_STEP_STATE_INVALID");
+      if (!["planned", "in-progress", "blocked", "done"].includes(state)) throw semanticAdmissionV2("MODULE_STEP_STATE_INVALID");
       return {
         schema: discriminator.schema,
         moduleKey: registryKey(row.moduleKey),
@@ -229,7 +233,7 @@ function strictTaskDecisionModulePayload(value: unknown): TaskDecisionModuleComm
       };
     }
     default:
-      throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_SCHEMA_UNSUPPORTED");
+      throw semanticAdmissionV2("TYPED_PAYLOAD_SCHEMA_UNSUPPORTED");
   }
 }
 
@@ -264,7 +268,7 @@ function decision(value: unknown): DecisionPackage {
   try {
     return Schema.decodeUnknownSync(DecisionPackageSchema)(value);
   } catch {
-    throw taskDecisionModulePayloadAdmission("DECISION_PAYLOAD_INVALID");
+    throw semanticAdmissionV2("DECISION_PAYLOAD_INVALID");
   }
 }
 
@@ -352,22 +356,22 @@ function exactTaskDecisionModuleObject(
   allowAdditional = false,
   optional: ReadonlyArray<string> = []
 ): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_INVALID");
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
   const row = value as Record<string, unknown>;
   const actual = Object.keys(row);
   if (keys.some((key) => !optional.includes(key) && !actual.includes(key))
     || (!allowAdditional && actual.some((key) => !keys.includes(key)))) {
-    throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_UNKNOWN_OR_MISSING_FIELD");
+    throw semanticAdmissionV2("TYPED_PAYLOAD_UNKNOWN_OR_MISSING_FIELD");
   }
   return row;
 }
 
 function optionalString(value: unknown, key: string): Readonly<Record<string, string>> {
-  return value === undefined ? {} : { [key]: stringValue(value) };
+  return value === undefined ? {} : { [key]: semanticStringValueV2(value) };
 }
 
 function taskDecisionModuleArray(value: unknown, name: string): ReadonlyArray<unknown> {
-  if (!Array.isArray(value)) throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_INVALID", name);
+  if (!Array.isArray(value)) throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID", name);
   return value;
 }
 
@@ -375,33 +379,20 @@ function stringArray(value: unknown, name: string): ReadonlyArray<string> {
   return taskDecisionModuleArray(value, name).map(taskDecisionModuleText);
 }
 
-function stringValue(value: unknown): string {
-  if (typeof value !== "string") throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_INVALID");
-  return value;
-}
-
 function taskDecisionModuleText(value: unknown): string {
-  const result = stringValue(value);
-  if (!result || result.trim() !== result) throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_INVALID");
+  const result = semanticStringValueV2(value);
+  if (!result || result.trim() !== result) throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
   return result;
 }
 
 function taskDecisionModuleNonBlank(value: unknown): string {
-  const result = stringValue(value);
-  if (!result.trim()) throw taskDecisionModulePayloadAdmission("TYPED_PAYLOAD_INVALID");
+  const result = semanticStringValueV2(value);
+  if (!result.trim()) throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
   return result;
 }
 
 function registryKey(value: unknown): string {
   const result = taskDecisionModuleText(value);
-  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/u.test(result)) throw taskDecisionModulePayloadAdmission("MODULE_KEY_INVALID");
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/u.test(result)) throw semanticAdmissionV2("MODULE_KEY_INVALID");
   return result;
-}
-
-function taskDecisionModulePayloadAdmission(code: string, message = code): SemanticAdmissionErrorV2 {
-  return new SemanticAdmissionErrorV2(code, message);
-}
-
-function taskDecisionModulePayloadBytesEqual(left: Uint8Array, right: Uint8Array): boolean {
-  return Buffer.from(left).equals(Buffer.from(right));
 }

--- a/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
@@ -39,12 +39,15 @@ import {
   type TaskTransitionPayloadV2
 } from "./task-decision-module-command-v2.ts";
 import {
-  SemanticAdmissionErrorV2,
   type AuthoritySemanticCompilerV2,
-  type PathCasV2,
-  type RegistryEntityRefV2,
-  type SemanticBaseCasV2
+  type RegistryEntityRefV2
 } from "./semantic-mutation-envelope-v2.ts";
+import {
+  semanticAdmissionV2 as admission,
+  semanticMutationPlanV2 as taskDecisionModulePlan,
+  verifySemanticBaseCasV2,
+  verifySemanticPathCasV2
+} from "./semantic-authority-helpers-v2.ts";
 import type {
   HostedDocumentSnapshotV2,
   SemanticEntityBaseV2
@@ -100,8 +103,8 @@ export function makeTaskDecisionModuleSemanticCompilerV2(
     compile: async (envelope) => {
       const { payload, decodedBytes } = decodeTaskDecisionModuleCommandPayloadV2(envelope);
       const compiled = await compileTaskDecisionModulePayload(options.state, payload);
-      await verifyTaskDecisionModuleBaseCas(options.state, envelope.intent.kind === "typed" ? envelope.intent.baseCas : [], compiled.requiredBaseRefs);
-      verifyTaskDecisionModulePathCas(envelope.intent.kind === "typed" ? envelope.intent.declaredPathCas : [], compiled.requiredPathSnapshots);
+      await verifySemanticBaseCasV2(options.state, envelope.intent.kind === "typed" ? envelope.intent.baseCas : [], compiled.requiredBaseRefs);
+      verifySemanticPathCasV2(envelope.intent.kind === "typed" ? envelope.intent.declaredPathCas : [], compiled.requiredPathSnapshots);
       return { mutationPlan: compiled.mutationPlan, operation: compiled.operation, decodedBytes };
     }
   };
@@ -429,41 +432,6 @@ function decodeModuleRecord(value: unknown): ModuleRecordV2 {
   };
 }
 
-async function verifyTaskDecisionModuleBaseCas(
-  state: TaskDecisionModuleAuthorityStateV2,
-  claimed: ReadonlyArray<SemanticBaseCasV2>,
-  requiredRefs: ReadonlyArray<RegistryEntityRefV2>
-): Promise<void> {
-  const required = uniqueTaskDecisionModuleRefs(requiredRefs);
-  if (claimed.length !== required.length) throw admission("BASE_CAS_CONFLICT");
-  const byRef = new Map(claimed.map((entry) => [taskDecisionModuleEntityRefKey(entry.entityRef), entry]));
-  if (byRef.size !== claimed.length) throw admission("BASE_CAS_CONFLICT");
-  for (const ref of required) {
-    const row = byRef.get(taskDecisionModuleEntityRefKey(ref));
-    if (!row) throw admission("BASE_CAS_CONFLICT");
-    const actual = await state.readEntityBase(ref);
-    if (!actual) {
-      if (row.expectedSemanticVersion !== null || row.expectedStateDigest !== null) throw admission("BASE_CAS_CONFLICT");
-    } else if (row.expectedSemanticVersion !== actual.semanticVersion || !nullableTaskDecisionModuleBytesEqual(row.expectedStateDigest, actual.stateDigest)) {
-      throw admission("BASE_CAS_CONFLICT");
-    }
-  }
-}
-
-function verifyTaskDecisionModulePathCas(
-  claimed: ReadonlyArray<PathCasV2>,
-  required: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }>
-): void {
-  if (claimed.length !== required.length) throw admission("BASE_CAS_CONFLICT");
-  const byPath = new Map(claimed.map((entry) => [entry.path, entry]));
-  if (byPath.size !== claimed.length) throw admission("BASE_CAS_CONFLICT");
-  for (const { path, snapshot } of required) {
-    const row = byPath.get(path);
-    if (!row || row.expectedEpoch !== snapshot.epoch || row.expectedRevision !== snapshot.revision
-      || !taskDecisionModuleBytesEqual(row.expectedBlobDigest, snapshot.blobDigest)) throw admission("BASE_CAS_CONFLICT");
-  }
-}
-
 function parseTaskIndex(body: string): { readonly taskId: string; readonly status: string } {
   const frontmatter = readFrontmatter(body);
   if (!frontmatter || readScalar(frontmatter, "schema", { required: true }) !== "task-package/v2") {
@@ -553,30 +521,6 @@ function taskPath(taskId: string, documentPath: string): string {
   return `tasks/${taskId}/${documentPath}`;
 }
 
-function taskDecisionModulePlan(mutations: RegistryMutationPlanInput["mutations"]): RegistryMutationPlanInput {
-  return { registryVersion, mutations };
-}
-
 function taskDecisionModuleEntityRef(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
   return { registryVersion, entityKind, canonicalRef };
-}
-
-function taskDecisionModuleEntityRefKey(ref: RegistryEntityRefV2): string {
-  return `${ref.registryVersion}\0${ref.entityKind}\0${ref.canonicalRef}`;
-}
-
-function uniqueTaskDecisionModuleRefs(refs: ReadonlyArray<RegistryEntityRefV2>): ReadonlyArray<RegistryEntityRefV2> {
-  return [...new Map(refs.map((ref) => [taskDecisionModuleEntityRefKey(ref), ref])).values()];
-}
-
-function admission(code: string, message = code): SemanticAdmissionErrorV2 {
-  return new SemanticAdmissionErrorV2(code, message);
-}
-
-function taskDecisionModuleBytesEqual(left: Uint8Array, right: Uint8Array): boolean {
-  return Buffer.from(left).equals(Buffer.from(right));
-}
-
-function nullableTaskDecisionModuleBytesEqual(left: Uint8Array | null, right: Uint8Array | null): boolean {
-  return left === null || right === null ? left === right : taskDecisionModuleBytesEqual(left, right);
 }

--- a/packages/application/src/doc-sync.ts
+++ b/packages/application/src/doc-sync.ts
@@ -131,6 +131,8 @@ export interface DocSyncValidationResult {
 export function classifyTouchedZones(pathInput: string, status: DirtyEntry["status"], baseBody: string | null, currentBody: string | null, rows: ReadonlyArray<RegistryRow>): ReadonlyArray<TouchedZone> {
   if (status === "deleted") return [unresolved("doc sync deletion is not defined in Phase 2")];
   const normalized = pathInput.split(/[\\/]+/u).join("/");
+  const typedOnlyReason = typedOnlyMachineSurfaceReason(normalized);
+  if (typedOnlyReason) return [unresolved(typedOnlyReason)];
   if (normalized === "modules.json") return rowZones(rows, "module-registry", "module-authored-structured");
   if (normalized.startsWith("decisions/")) return rowZones(rows, "decision", "decision-authored-structured");
   if (!normalized.startsWith("tasks/")) return [unresolved("path is outside the registered doc-sync task document surface")];
@@ -141,6 +143,8 @@ export function classifyTouchedZones(pathInput: string, status: DirtyEntry["stat
 
 export function classifyStaticZones(pathInput: string, rows: ReadonlyArray<RegistryRow>): ReadonlyArray<TouchedZone> {
   const normalized = pathInput.split(/[\\/]+/u).join("/");
+  const typedOnlyReason = typedOnlyMachineSurfaceReason(normalized);
+  if (typedOnlyReason) return [unresolved(typedOnlyReason)];
   if (normalized === "modules.json") return rowZones(rows, "module-registry", "module-authored-structured");
   if (normalized.startsWith("decisions/")) return rowZones(rows, "decision", "decision-authored-structured");
   if (!normalized.startsWith("tasks/")) return [unresolved("path is outside the registered doc-sync task document surface")];
@@ -211,4 +215,17 @@ function unresolved(reason: string, bearing?: string, zoneClass?: string): Touch
 
 function frontmatterChanged(baseBody: string | null, currentBody: string | null): boolean {
   return frontmatterBlock(baseBody ?? "") !== frontmatterBlock(currentBody ?? "");
+}
+
+function typedOnlyMachineSurfaceReason(path: string): string | null {
+  if (/^sessions\/[^/]+\.md$/u.test(path)) {
+    return "session manifests are machine-owned and require a typed session command";
+  }
+  if (/^tasks\/[^/]+\/executions\/[^/]+\.md$/u.test(path)) {
+    return "execution documents are machine-owned and require a typed execution command";
+  }
+  if (/^tasks\/[^/]+\/reviews\/[^/]+\.md$/u.test(path)) {
+    return "review documents are machine-owned and require a typed review command";
+  }
+  return null;
 }

--- a/packages/application/src/public-exports.ts
+++ b/packages/application/src/public-exports.ts
@@ -45,6 +45,7 @@ export * from "./authority/canonical-cbor.ts";
 export * from "./authority/semantic-mutation-envelope-v2.ts";
 export * from "./authority/fact-relation-semantic-compiler-v2.ts";
 export * from "./authority/task-decision-module-semantic-compiler-v2.ts";
+export * from "./authority/session-execution-review-semantic-compiler-v2.ts";
 export * from "./authority/committed-attribution-event-v2.ts";
 export type { AuthoritySubmissionV2Options } from "./authority/service.ts";
 export type {

--- a/packages/application/test/session-execution-review-authority-admission-v2.test.ts
+++ b/packages/application/test/session-execution-review-authority-admission-v2.test.ts
@@ -1,0 +1,249 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Effect } from "effect";
+import {
+  actorAxesBindingDigestV2,
+  actorAxesBindingTokenDigestV2,
+  canonicalPayloadDigestV2,
+  createAuthoritySubmissionService,
+  createInMemoryAuthorityOperationRegistry,
+  createInMemoryReplicaChangeLog,
+  encodeSemanticMutationEnvelopeV2,
+  encodeSessionExecutionReviewCommandPayloadV2,
+  issueActorAxesBindingV2,
+  makeSessionExecutionReviewSemanticCompilerV2,
+  semanticMutationEnvelopeV2Schema,
+  semanticMutationSetDigestV2,
+  semanticRequestDigestV2,
+  type ActorAxesBindingClaimsV2,
+  type SemanticBaseCasV2,
+  type SemanticMutationEnvelopeV2,
+  type SemanticMutationSetV2
+} from "../src/index.ts";
+import {
+  compileRegistryMutationPlan,
+  createWritableEntityRegistry,
+  encodeCanonicalCbor,
+  entityRegistry,
+  semanticMutationWireV2,
+  type RegistryEntityRefV2,
+  type ReviewRecord
+} from "../../kernel/src/index.ts";
+
+const taskId = "task_01KXD8H2QFMMA4T203PJZ77AQ5";
+const executionId = "exe_01KXD8H2QFMMA4T203PJZ77AQ6";
+const reviewId = "rev_01KXD8H2QFMMA4T203PJZ77AQ7";
+
+test("six W4 negative controls reject before PREPARED, enqueue, or token consumption", async () => {
+  const target = ref("review", `review/${taskId}/${reviewId}`);
+  const correctBase = [absent(target)];
+  const semanticCompiler = makeSessionExecutionReviewSemanticCompilerV2({
+    state: { readEntityBase: async () => null, readHostedDocument: async () => null }
+  });
+  const draft = requestEnvelope(1, correctBase, emptySet());
+  const authorityCompilation = await semanticCompiler.compile(draft);
+  const exact = compileRegistryMutationPlan(
+    createWritableEntityRegistry([entityRegistry.session, entityRegistry.execution, entityRegistry.review]),
+    authorityCompilation.mutationPlan
+  ).mutationSet;
+  const claims = actorClaims();
+  const secret = Buffer.alloc(32, 0x5a);
+  const token = issueActorAxesBindingV2(claims, {
+    algorithm: "HMAC-SHA-256", issuer: "authority.test", keyId: "key-w4", secret
+  });
+  const tokenDigest = actorAxesBindingTokenDigestV2(token);
+  const operationRegistry = createInMemoryAuthorityOperationRegistry();
+  let enqueued = 0;
+  let consumed = 0;
+  const service = createAuthoritySubmissionService({
+    workspaceId: claims.workspaceId,
+    coordinatorFactory: {
+      create: () => ({
+        enqueue: (operation) => Effect.sync(() => {
+          enqueued += 1;
+          return { opId: operation.opId, entityId: operation.entityId, accepted: true as const };
+        }),
+        flush: () => Effect.die("negative control must not flush"),
+        recover: Effect.succeed({ replayedOps: 0 })
+      })
+    },
+    tokenVerifier: { verify: async () => { throw new Error("v1 verifier must not run"); } },
+    operationRegistry,
+    replicaChangeLog: createInMemoryReplicaChangeLog(),
+    publicationInspector: {
+      currentHead: async () => null,
+      inspectPublishedHead: async () => { throw new Error("negative control must not publish"); }
+    },
+    fenceWitness: { assertHeld: async () => undefined },
+    v2: {
+      schemaTuple,
+      channelNonceDigest,
+      bindingRuntime: {
+        proofKeys: { resolve: () => ({ algorithm: "HMAC-SHA-256", secret }) },
+        validatePresentationToken: async (input) => bytesEqual(input.tokenDigest, tokenDigest),
+        getBinding: async () => ({
+          bindingId: claims.bindingId, principalPersonId: claims.principalPersonId,
+          executorAgentId: claims.executorAgentId, workspaceId: claims.workspaceId,
+          deviceId: claims.deviceId, viewId: claims.viewId, sessionId: claims.sessionId, active: true,
+          attribution: {
+            actor: { principal: { kind: "person", personId: claims.principalPersonId }, executor: { kind: "agent", id: claims.executorAgentId! } },
+            principalSource: { kind: "daemon-authenticated", providerId: "authority.test", credentialFingerprint: "sha256:redacted" },
+            executorSource: "client-asserted"
+          }
+        }),
+        currentAuthorityGeneration: () => claims.authorityGeneration,
+        currentRevocationEpochs: async () => claims.revocationEpochs,
+        nowMs: () => 2_000n,
+        consumeOperation: async () => { consumed += 1; return true; },
+        validateAdmissionTokenRef: async (input) => input.tokenId === claims.tokenId && bytesEqual(input.tokenDigest, tokenDigest)
+      },
+      entityRegistrations: [entityRegistry.session, entityRegistry.execution, entityRegistry.review],
+      semanticCompiler,
+      operationNamespaceVerifier: { verify: async () => undefined }
+    }
+  });
+  const omission: SemanticMutationSetV2 = { registryVersion: 1, mutations: [] };
+  const addition = canonicalSet([...exact.mutations, {
+    entity: ref("execution", `execution/${taskId}/${executionId}`),
+    action: { registryVersion: 1, action: "claim" }
+  }]);
+  const relabel = canonicalSet(exact.mutations.map((mutation) => ({
+    ...mutation, action: { registryVersion: 1, action: "dismiss" }
+  })));
+  const wrongBase: ReadonlyArray<SemanticBaseCasV2> = [{
+    entityRef: target, expectedSemanticVersion: "review-v1", expectedStateDigest: Buffer.alloc(32, 0xee)
+  }];
+  const cases = [
+    { name: "omission", envelope: requestEnvelope(2, correctBase, omission), reason: "SEMANTIC_MUTATION_MISMATCH" },
+    { name: "addition", envelope: requestEnvelope(3, correctBase, addition), reason: "SEMANTIC_MUTATION_MISMATCH" },
+    { name: "relabel", envelope: requestEnvelope(4, correctBase, relabel), reason: "SEMANTIC_MUTATION_MISMATCH" },
+    { name: "digest", envelope: requestEnvelope(5, correctBase, exact, Buffer.alloc(32, 0xdd)), reason: "SEMANTIC_MUTATION_DIGEST_MISMATCH" },
+    { name: "scope", envelope: requestEnvelope(6, correctBase, exact), reason: "TOKEN_ENTITY_KIND_SCOPE_DENIED" },
+    { name: "base-CAS", envelope: requestEnvelope(7, wrongBase, exact), reason: "BASE_CAS_CONFLICT" }
+  ];
+  for (const fixture of cases) {
+    const envelope = bindEnvelope(fixture.envelope, claims, tokenDigest);
+    const receipt = await service.submitV2!({
+      requestId: `negative-${fixture.name}`,
+      presentationToken: token,
+      envelope: encodeSemanticMutationEnvelopeV2(envelope)
+    });
+    assert.equal(receipt.tag, "REJECTED", fixture.name);
+    assert.equal(receipt.tag === "REJECTED" ? receipt.reason : "", fixture.reason, fixture.name);
+    assert.equal((await operationRegistry.get(claims.workspaceId, receipt.opId))?.state, "REJECTED");
+  }
+  assert.equal(enqueued, 0);
+  assert.equal(consumed, 0);
+});
+
+function requestEnvelope(
+  randomByte: number,
+  baseCas: ReadonlyArray<SemanticBaseCasV2>,
+  mutationSet: SemanticMutationSetV2,
+  mutationDigest = semanticMutationSetDigestV2(mutationSet)
+): SemanticMutationEnvelopeV2 {
+  const payload = encodeSessionExecutionReviewCommandPayloadV2({
+    schema: "review.record/v1", taskId, review: reviewRecord()
+  });
+  return finalize({
+    schema: semanticMutationEnvelopeV2Schema,
+    workspaceId: "workspace-w4-negative",
+    operationId: {
+      namespace: {
+        schema: "operation-namespace/v1", workspaceId: "workspace-w4-negative", deviceId: "device-w4",
+        authorityGeneration: 1n, namespaceId: "namespace-w4", expiresAt: 8_000n,
+        issuer: "authority.test", keyId: "namespace-key", proof: Buffer.alloc(32, 3)
+      },
+      clientRandom128: Buffer.alloc(16, randomByte)
+    },
+    binding: {
+      bindingId: "binding-w4", actorAxesBindingDigest: Buffer.alloc(32), deviceId: "device-w4",
+      viewId: "view-w4", sessionId: "session-w4",
+      admissionTokenRef: { tokenId: "token-w4", tokenDigest: Buffer.alloc(32) }
+    },
+    schemaTuple,
+    intent: {
+      kind: "typed", command: { registryVersion: 1, name: "review.record", version: 1 },
+      canonicalPayload: { kind: "inline", size: BigInt(payload.length), bytes: payload },
+      canonicalPayloadDigest: canonicalPayloadDigestV2(payload), baseCas, declaredPathCas: []
+    },
+    claimedMutationSet: mutationSet,
+    claimedSemanticMutationSetDigest: mutationDigest,
+    claimedSemanticRequestDigest: Buffer.alloc(32)
+  });
+}
+
+function bindEnvelope(
+  envelope: SemanticMutationEnvelopeV2,
+  claims: ActorAxesBindingClaimsV2,
+  tokenDigest: Uint8Array
+): SemanticMutationEnvelopeV2 {
+  return finalize({
+    ...envelope,
+    binding: {
+      bindingId: claims.bindingId, actorAxesBindingDigest: actorAxesBindingDigestV2(claims),
+      deviceId: claims.deviceId, viewId: claims.viewId, sessionId: claims.sessionId,
+      admissionTokenRef: { tokenId: claims.tokenId, tokenDigest }
+    }
+  });
+}
+
+function finalize(value: SemanticMutationEnvelopeV2): SemanticMutationEnvelopeV2 {
+  return { ...value, claimedSemanticRequestDigest: semanticRequestDigestV2(value) };
+}
+
+function actorClaims(): ActorAxesBindingClaimsV2 {
+  return {
+    tokenId: "token-w4", bindingId: "binding-w4", principalPersonId: "person_zeyu", executorAgentId: "agent_w4",
+    workspaceId: "workspace-w4-negative", deviceId: "device-w4", viewId: "view-w4", sessionId: "session-w4",
+    allowedEntityKinds: ["session"], allowedActions: ["record"],
+    resourceScopes: [{ kind: "workspace" }], pathFootprint: null,
+    maxBytes: 64n * 1024n, maxMutations: 8, maxOperations: 8,
+    authorityGeneration: 1n, channelNonceDigest, schemaTuple,
+    issuedAt: 1_000n, notBefore: 1_000n, expiresAt: 9_000n,
+    revocationEpochs: { global: 1n, workspace: 1n, device: 1n, view: 1n, principal: 1n, executor: 1n }
+  };
+}
+
+function reviewRecord(): ReviewRecord {
+  return {
+    schema: "review/v2", review_id: reviewId, task_ref: `task/${taskId}`, execution_ref: `execution/${taskId}/${executionId}`,
+    reviewer_actor: { principal: { personId: "person_reviewer" }, executor: { kind: "agent", id: "agent_reviewer" }, responsibleHuman: "person_reviewer" },
+    reviewer_session_ref: "session/reviewer-w4", findings: "Typed review findings.", evidence_checked: [],
+    rationale: "The exact evidence supports this verdict.", verdict: "approved", archive_warnings_acknowledged: true,
+    reviewed_at: "2026-07-14T00:15:00.000Z"
+  };
+}
+
+function canonicalSet(mutations: SemanticMutationSetV2["mutations"]): SemanticMutationSetV2 {
+  return {
+    registryVersion: 1,
+    mutations: [...mutations].sort((left, right) => Buffer.compare(
+      Buffer.from(encodeCanonicalCbor(semanticMutationWireV2(left))),
+      Buffer.from(encodeCanonicalCbor(semanticMutationWireV2(right)))
+    ))
+  };
+}
+
+function emptySet(): SemanticMutationSetV2 {
+  return { registryVersion: 1, mutations: [] };
+}
+
+function ref(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
+  return { registryVersion: 1, entityKind, canonicalRef };
+}
+
+function absent(entityRef: RegistryEntityRefV2): SemanticBaseCasV2 {
+  return { entityRef, expectedSemanticVersion: null, expectedStateDigest: null };
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  return Buffer.from(left).equals(Buffer.from(right));
+}
+
+const channelNonceDigest = Buffer.alloc(32, 0x22);
+const schemaTuple = {
+  wire: 2, event: 2, receipt: 2, digest: 2, policy: 1,
+  commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
+} as const;

--- a/packages/application/test/session-execution-review-authority-positive-v2.test.ts
+++ b/packages/application/test/session-execution-review-authority-positive-v2.test.ts
@@ -1,0 +1,421 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  actorAxesBindingDigestV2,
+  actorAxesBindingTokenDigestV2,
+  canonicalPayloadDigestV2,
+  createAuthoritySubmissionService,
+  createInMemoryAuthorityOperationRegistry,
+  createInMemoryReplicaChangeLog,
+  encodeSemanticMutationEnvelopeV2,
+  encodeSessionExecutionReviewCommandPayloadV2,
+  issueActorAxesBindingV2,
+  makeSessionExecutionReviewSemanticCompilerV2,
+  materializeCommittedAttributionEventV2,
+  materializeCommittedAttributionProjectionV2,
+  semanticMutationEnvelopeV2Schema,
+  semanticMutationSetDigestV2,
+  semanticRequestDigestV2,
+  type ActorAxesBindingClaimsV2,
+  type HostedDocumentSnapshotV2,
+  type RegistryEntityRefV2,
+  type ReplicaChangeLog,
+  type SemanticBaseCasV2,
+  type SemanticEntityBaseV2,
+  type SemanticMutationEnvelopeV2,
+  type SemanticMutationSetV2,
+  type SessionExecutionReviewCommandPayloadV2
+} from "../src/index.ts";
+import {
+  entityRegistry,
+  makeJournaledWriteCoordinator,
+  readUnionAttributionEvents,
+  sha256Text,
+  type ExecutionRecord,
+  type ReviewRecord,
+  type SessionManifest
+} from "../../kernel/src/index.ts";
+
+const taskId = "task_01KXD8H2QFMMA4T203PJZ77AQ5";
+const executionId = "exe_01KXD8H2QFMMA4T203PJZ77AQ6";
+const sessionId = "session-w4-positive";
+
+test("all W4 actions publish exact refs through one composite/hosted op with cross-layer digests", async () => {
+  await withHermeticGit(async ({ rootDir, env, harnessRoot }) => {
+    const claims = actorClaims();
+    const secret = Buffer.alloc(32, 0x5a);
+    const token = issueActorAxesBindingV2(claims, {
+      algorithm: "HMAC-SHA-256", issuer: "authority.test", keyId: "key-w4", secret
+    });
+    const tokenDigest = actorAxesBindingTokenDigestV2(token);
+    const changeLog = createInMemoryReplicaChangeLog();
+    const bases = new Map<string, SemanticEntityBaseV2>();
+    const compiler = makeSessionExecutionReviewSemanticCompilerV2({
+      state: {
+        readEntityBase: async (entityRef) => bases.get(key(entityRef)) ?? null,
+        readHostedDocument: async (documentPath) => documentSnapshot(harnessRoot, documentPath)
+      }
+    });
+    const service = authority(rootDir, env, claims, secret, tokenDigest, changeLog, compiler);
+    const sessionBody = "# W4 positive session\n\nComposite CAS body.\n";
+    const syncedSessionBody = `${sessionBody}\nSynced snapshot.\n`;
+    const active = executionRecord("active");
+    const submitted = executionRecord("submitted");
+    const accepted = executionRecord("accepted");
+    const fixtures: ReadonlyArray<{
+      readonly payload: SessionExecutionReviewCommandPayloadV2;
+      readonly ref: RegistryEntityRefV2;
+      readonly action: string;
+      readonly path: string;
+    }> = [
+      { payload: { schema: "session.export/v1", manifest: sessionManifest(sessionBody, "sealed"), body: sessionBody }, ref: ref("session", `session/${sessionId}`), action: "export", path: `sessions/${sessionId}.md` },
+      { payload: { schema: "session.sync/v1", manifest: sessionManifest(syncedSessionBody, "sealed"), body: syncedSessionBody }, ref: ref("session", `session/${sessionId}`), action: "sync", path: `sessions/${sessionId}.md` },
+      { payload: { schema: "session.archive/v1", manifest: sessionManifest(syncedSessionBody, "archived"), body: syncedSessionBody }, ref: ref("session", `session/${sessionId}`), action: "archive", path: `sessions/${sessionId}.md` },
+      { payload: { schema: "execution.claim/v1", taskId, execution: active }, ref: ref("execution", `execution/${taskId}/${executionId}`), action: "claim", path: `tasks/${taskId}/executions/${executionId}.md` },
+      { payload: { schema: "execution.submit/v1", taskId, execution: submitted }, ref: ref("execution", `execution/${taskId}/${executionId}`), action: "submit", path: `tasks/${taskId}/executions/${executionId}.md` },
+      { payload: { schema: "execution.close/v1", taskId, execution: accepted }, ref: ref("execution", `execution/${taskId}/${executionId}`), action: "close", path: `tasks/${taskId}/executions/${executionId}.md` },
+      ...(["create", "dismiss", "record"] as const).map((action, index) => {
+        const id = reviewId(index);
+        const verdict = action === "dismiss" ? "dismissed" : action === "record" ? "approved" : "changes_requested";
+        return {
+          payload: { schema: `review.${action}/v1`, taskId, review: reviewRecord(id, verdict) } as SessionExecutionReviewCommandPayloadV2,
+          ref: ref("review", `review/${taskId}/${id}`), action,
+          path: `tasks/${taskId}/reviews/${id}.md`
+        };
+      })
+    ];
+
+    const receipts = [];
+    for (const [index, fixture] of fixtures.entries()) {
+      const snapshot = documentSnapshot(harnessRoot, fixture.path);
+      const baseCas = [baseCasFor(fixture.ref, bases.get(key(fixture.ref)) ?? null)];
+      const pathCas = snapshot ? [pathCasFor(fixture.path, snapshot)] : [];
+      const mutationSet = set(fixture.ref, fixture.action);
+      const envelope = bindEnvelope(requestEnvelope(index + 1, fixture.payload, baseCas, pathCas, mutationSet), claims, tokenDigest);
+      const receipt = await service.submitV2!({
+        requestId: `w4-positive-${index}`,
+        presentationToken: token,
+        envelope: encodeSemanticMutationEnvelopeV2(envelope)
+      });
+      assert.equal(receipt.tag, "COMMITTED", `${fixture.action}:${JSON.stringify(receipt)}`);
+      if (receipt.tag !== "COMMITTED") continue;
+      assert.equal(existsSync(path.join(harnessRoot, fixture.path)), true, fixture.path);
+      const body = readFileSync(path.join(harnessRoot, fixture.path), "utf8");
+      bases.set(key(fixture.ref), { semanticVersion: `w4-v${index + 1}`, stateDigest: Buffer.from(sha256Text(body), "hex") });
+      receipts.push({ receipt, mutationSet, action: fixture.action, path: fixture.path });
+    }
+    assert.equal(receipts.length, 9);
+
+    const session = sessionManifest(syncedSessionBody, "archived");
+    assert.equal(readFileSync(path.join(rootDir, session.bodyRef.ref), "utf8"), syncedSessionBody);
+    assert.match(readFileSync(path.join(harnessRoot, `sessions/${sessionId}.md`), "utf8"), /"lifecycle": "archived"/u);
+    assert.match(readFileSync(path.join(harnessRoot, `tasks/${taskId}/executions/${executionId}.md`), "utf8"), /"state": "accepted"/u);
+    const journalPayloads = readdirSync(path.join(rootDir, ".harness", "write-journal", "payloads"))
+      .map((entry) => readFileSync(path.join(rootDir, ".harness", "write-journal", "payloads", entry), "utf8"));
+    assert.equal(journalPayloads.some((body) => body.includes("Composite CAS body")), false);
+    assert.equal(journalPayloads.some((body) => body.includes("\"blobRef\"") && !body.includes("\"blobBody\"")), true);
+
+    const events = readUnionAttributionEvents(rootDir);
+    const changes = await changeLog.changesAfter(claims.workspaceId, 0);
+    const projectionPath = path.join(rootDir, "w4-attribution.sqlite");
+    writeFileSync(projectionPath, "", "utf8");
+    const actorAxesBinding = {
+      bindingId: claims.bindingId, principalPersonId: claims.principalPersonId,
+      executorAgentId: claims.executorAgentId, workspaceId: claims.workspaceId,
+      deviceId: claims.deviceId, viewId: claims.viewId, sessionId: claims.sessionId, schemaTuple
+    };
+    const projection = materializeCommittedAttributionProjectionV2(
+      projectionPath,
+      receipts.map(({ receipt, path: changedPath }, index) => materializeCommittedAttributionEventV2({
+        receipt,
+        actorAxesBinding,
+        physicalChanges: [{ path: changedPath, beforeDigest: "44".repeat(32), afterDigest: "55".repeat(32) }],
+        occurredAt: `2026-07-14T00:30:${String(index).padStart(2, "0")}.000Z`,
+        recordedAt: `2026-07-14T00:31:${String(index).padStart(2, "0")}.000Z`
+      }))
+    );
+    for (const { receipt, mutationSet, action } of receipts) {
+      const digest = Buffer.from(semanticMutationSetDigestV2(mutationSet)).toString("hex");
+      assert.equal(receipt.authorityIntegrity?.semanticMutationSetDigest, digest);
+      assert.equal(events.find((event) => event.opId === receipt.opId)?.authorityIntegrity?.semanticMutationSetDigest, digest);
+      assert.equal(changes.find((change) => change.opId === receipt.opId)?.authorityIntegrity?.semanticMutationSetDigest, digest);
+      const projected = projection.find((row) => row.opId === receipt.opId);
+      assert.ok(projected, JSON.stringify({ expected: receipt.opId, projected: projection.map((row) => row.opId) }));
+      assert.equal(projected.digestStatus.semanticMutationSet, "verified");
+      assert.equal(projected.operation, action);
+      assert.deepEqual(readBatchTrailer(git(rootDir, env, "log", "-1", "--format=%B", receipt.commitSha)), [{
+        opId: receipt.opId,
+        semanticMutationSetDigest: digest
+      }]);
+    }
+  });
+});
+
+function authority(
+  rootDir: string,
+  env: NodeJS.ProcessEnv,
+  claims: ActorAxesBindingClaimsV2,
+  secret: Uint8Array,
+  tokenDigest: Uint8Array,
+  changeLog: ReplicaChangeLog,
+  semanticCompiler: ReturnType<typeof makeSessionExecutionReviewSemanticCompilerV2>
+) {
+  return createAuthoritySubmissionService({
+    workspaceId: claims.workspaceId,
+    coordinatorFactory: {
+      create: ({ attribution }) => makeJournaledWriteCoordinator({
+        rootDir, attribution, commitAuthor: { name: "ZeyuLi", email: "zeyuli@example.test" }, autoMaterialize: false
+      })
+    },
+    tokenVerifier: { verify: async () => { throw new Error("v1 verifier must not run"); } },
+    operationRegistry: createInMemoryAuthorityOperationRegistry(),
+    replicaChangeLog: changeLog,
+    publicationInspector: {
+      currentHead: async () => gitOptional(rootDir, env, "rev-parse", "--verify", "HEAD"),
+      inspectPublishedHead: async () => {
+        const row = git(rootDir, env, "rev-list", "--parents", "-n", "1", "HEAD").split(" ");
+        return { commitSha: row[0]!, parentCommits: row.slice(1) };
+      }
+    },
+    fenceWitness: { assertHeld: async () => undefined },
+    v2: {
+      schemaTuple,
+      channelNonceDigest,
+      bindingRuntime: {
+        proofKeys: { resolve: () => ({ algorithm: "HMAC-SHA-256", secret }) },
+        validatePresentationToken: async (input) => bytesEqual(input.tokenDigest, tokenDigest),
+        getBinding: async () => ({
+          bindingId: claims.bindingId, principalPersonId: claims.principalPersonId,
+          executorAgentId: claims.executorAgentId, workspaceId: claims.workspaceId,
+          deviceId: claims.deviceId, viewId: claims.viewId, sessionId: claims.sessionId, active: true,
+          attribution: {
+            actor: { principal: { kind: "person", personId: claims.principalPersonId }, executor: { kind: "agent", id: claims.executorAgentId! } },
+            principalSource: { kind: "daemon-authenticated", providerId: "authority.test", credentialFingerprint: "sha256:redacted" },
+            executorSource: "client-asserted"
+          }
+        }),
+        currentAuthorityGeneration: () => claims.authorityGeneration,
+        currentRevocationEpochs: async () => claims.revocationEpochs,
+        nowMs: () => 2_000n,
+        consumeOperation: async () => true,
+        validateAdmissionTokenRef: async (input) => input.tokenId === claims.tokenId && bytesEqual(input.tokenDigest, tokenDigest)
+      },
+      entityRegistrations: [entityRegistry.session, entityRegistry.execution, entityRegistry.review],
+      semanticCompiler,
+      operationNamespaceVerifier: { verify: async () => undefined }
+    }
+  });
+}
+
+function requestEnvelope(
+  randomByte: number,
+  payloadValue: SessionExecutionReviewCommandPayloadV2,
+  baseCas: ReadonlyArray<SemanticBaseCasV2>,
+  declaredPathCas: ReadonlyArray<ReturnType<typeof pathCasFor>>,
+  mutationSet: SemanticMutationSetV2
+): SemanticMutationEnvelopeV2 {
+  const payload = encodeSessionExecutionReviewCommandPayloadV2(payloadValue);
+  return finalize({
+    schema: semanticMutationEnvelopeV2Schema,
+    workspaceId: "workspace-w4-positive",
+    operationId: {
+      namespace: {
+        schema: "operation-namespace/v1", workspaceId: "workspace-w4-positive", deviceId: "device-w4",
+        authorityGeneration: 1n, namespaceId: "namespace-w4", expiresAt: 8_000n,
+        issuer: "authority.test", keyId: "namespace-key", proof: Buffer.alloc(32, 3)
+      },
+      clientRandom128: Buffer.alloc(16, randomByte)
+    },
+    binding: {
+      bindingId: "binding-w4", actorAxesBindingDigest: Buffer.alloc(32), deviceId: "device-w4",
+      viewId: "view-w4", sessionId: "session-w4",
+      admissionTokenRef: { tokenId: "token-w4", tokenDigest: Buffer.alloc(32) }
+    },
+    schemaTuple,
+    intent: {
+      kind: "typed", command: { registryVersion: 1, name: payloadValue.schema.replace("/v1", ""), version: 1 },
+      canonicalPayload: { kind: "inline", size: BigInt(payload.length), bytes: payload },
+      canonicalPayloadDigest: canonicalPayloadDigestV2(payload), baseCas, declaredPathCas
+    },
+    claimedMutationSet: mutationSet,
+    claimedSemanticMutationSetDigest: semanticMutationSetDigestV2(mutationSet),
+    claimedSemanticRequestDigest: Buffer.alloc(32)
+  });
+}
+
+function bindEnvelope(
+  envelope: SemanticMutationEnvelopeV2,
+  claims: ActorAxesBindingClaimsV2,
+  tokenDigest: Uint8Array
+): SemanticMutationEnvelopeV2 {
+  return finalize({
+    ...envelope,
+    binding: {
+      bindingId: claims.bindingId, actorAxesBindingDigest: actorAxesBindingDigestV2(claims),
+      deviceId: claims.deviceId, viewId: claims.viewId, sessionId: claims.sessionId,
+      admissionTokenRef: { tokenId: claims.tokenId, tokenDigest }
+    }
+  });
+}
+
+function finalize(value: SemanticMutationEnvelopeV2): SemanticMutationEnvelopeV2 {
+  return { ...value, claimedSemanticRequestDigest: semanticRequestDigestV2(value) };
+}
+
+function actorClaims(): ActorAxesBindingClaimsV2 {
+  return {
+    tokenId: "token-w4", bindingId: "binding-w4", principalPersonId: "person_zeyu", executorAgentId: "agent_w4",
+    workspaceId: "workspace-w4-positive", deviceId: "device-w4", viewId: "view-w4", sessionId: "session-w4",
+    allowedEntityKinds: ["review", "session", "execution"],
+    allowedActions: ["sync", "claim", "close", "create", "export", "record", "submit", "archive", "dismiss"],
+    resourceScopes: [{ kind: "workspace" }], pathFootprint: null,
+    maxBytes: 256n * 1024n, maxMutations: 16, maxOperations: 16,
+    authorityGeneration: 1n, channelNonceDigest, schemaTuple,
+    issuedAt: 1_000n, notBefore: 1_000n, expiresAt: 9_000n,
+    revocationEpochs: { global: 1n, workspace: 1n, device: 1n, view: 1n, principal: 1n, executor: 1n }
+  };
+}
+
+async function withHermeticGit(body: (input: {
+  readonly rootDir: string;
+  readonly harnessRoot: string;
+  readonly env: NodeJS.ProcessEnv;
+}) => Promise<void>) {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-w4-positive-"));
+  const harnessRoot = path.join(rootDir, "harness");
+  const env = {
+    ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_AUTHOR_NAME: "ZeyuLi", GIT_AUTHOR_EMAIL: "zeyuli@example.test",
+    GIT_COMMITTER_NAME: "Harness Authority", GIT_COMMITTER_EMAIL: "authority@example.test"
+  };
+  try {
+    execFileSync("git", ["-C", rootDir, "init", "-q"], { env });
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    mkdirSync(path.join(harnessRoot, "tasks", taskId), { recursive: true });
+    writeFileSync(path.join(harnessRoot, "tasks", taskId, "INDEX.md"), "# W4 host task\n", "utf8");
+    execFileSync("git", ["-C", harnessRoot, "init", "-q"], { env });
+    execFileSync("git", ["-C", harnessRoot, "add", "."], { env });
+    execFileSync("git", ["-C", harnessRoot, "commit", "-m", "test: initialize W4 positive control"], { env });
+    await body({ rootDir, harnessRoot, env });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function documentSnapshot(harnessRoot: string, documentPath: string): HostedDocumentSnapshotV2 | null {
+  const absolute = path.join(harnessRoot, documentPath);
+  if (!existsSync(absolute)) return null;
+  const body = readFileSync(absolute, "utf8");
+  return { body, epoch: "epoch-w4", revision: 1n, blobDigest: Buffer.from(sha256Text(body), "hex") };
+}
+
+function baseCasFor(entityRef: RegistryEntityRefV2, value: SemanticEntityBaseV2 | null): SemanticBaseCasV2 {
+  return value
+    ? { entityRef, expectedSemanticVersion: value.semanticVersion, expectedStateDigest: value.stateDigest }
+    : { entityRef, expectedSemanticVersion: null, expectedStateDigest: null };
+}
+
+function pathCasFor(documentPath: string, value: HostedDocumentSnapshotV2) {
+  return { path: documentPath, expectedEpoch: value.epoch, expectedRevision: value.revision, expectedBlobDigest: value.blobDigest };
+}
+
+function set(entityRef: RegistryEntityRefV2, action: string): SemanticMutationSetV2 {
+  return { registryVersion: 1, mutations: [{ entity: entityRef, action: { registryVersion: 1, action } }] };
+}
+
+function ref(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
+  return { registryVersion: 1, entityKind, canonicalRef };
+}
+
+function key(entityRef: RegistryEntityRefV2): string {
+  return `${entityRef.registryVersion}\0${entityRef.entityKind}\0${entityRef.canonicalRef}`;
+}
+
+function sessionManifest(body: string, lifecycle: SessionManifest["lifecycle"]): SessionManifest {
+  const sha = sha256Text(body);
+  return {
+    schema: "session-entity/v1", sessionId, lifecycle, archiveStatus: "complete", runtime: "codex", source: "runtime",
+    detectedAt: "2026-07-14T00:00:00.000Z", exportedAt: "2026-07-14T00:01:00.000Z",
+    bodyRef: {
+      store: "authored-cas/v1", ref: `harness/objects/sha256/${sha.slice(0, 2)}/${sha.slice(2)}`,
+      sha256: sha, size: Buffer.byteLength(body), mediaType: "text/markdown; charset=utf-8"
+    },
+    snapshot: {
+      capturedAt: "2026-07-14T00:01:00.000Z", completeness: "complete", captureRange: { messageCount: 1 },
+      privacyScan: { scannerVersion: "w4-test", passed: true, findings: [] }
+    }
+  };
+}
+
+function executionRecord(state: ExecutionRecord["state"]): ExecutionRecord {
+  const submitted = state !== "active";
+  return {
+    schema: "execution/v2", execution_id: executionId, task_ref: `task/${taskId}`, state,
+    primary_actor: { principal: { personId: "person_zeyu" }, executor: { kind: "agent", id: "agent_w4" }, responsibleHuman: "person_zeyu" },
+    claimed_at: "2026-07-14T00:00:00.000Z", submitted_at: submitted ? "2026-07-14T00:10:00.000Z" : null,
+    closed_at: state === "accepted" ? "2026-07-14T00:20:00.000Z" : null, session_bindings: [],
+    outputs: submitted ? [{ evidence_id: "evidence:w4", execution_ref: `execution/${taskId}/${executionId}`, locator: { substrate: "inline", text: "passed" } }] : [],
+    submission: submitted ? {
+      completion_claim: "W4 complete", deliverables: ["typed compiler"], evidence_refs: ["evidence:w4"],
+      verification_notes: ["tested"], known_gaps: [], residual_risks: []
+    } : null
+  };
+}
+
+function reviewId(index: number): string {
+  return `rev_01KXD8H2QFMMA4T203PJZ77AQ${7 + index}`;
+}
+
+function reviewRecord(id: string, verdict: ReviewRecord["verdict"]): ReviewRecord {
+  return {
+    schema: "review/v2", review_id: id, task_ref: `task/${taskId}`, execution_ref: `execution/${taskId}/${executionId}`,
+    reviewer_actor: { principal: { personId: "person_reviewer" }, executor: { kind: "agent", id: "agent_reviewer" }, responsibleHuman: "person_reviewer" },
+    reviewer_session_ref: "session/reviewer-w4", findings: "Typed review findings.", evidence_checked: ["evidence:w4"],
+    rationale: "The exact evidence supports this verdict.", verdict, archive_warnings_acknowledged: true,
+    reviewed_at: "2026-07-14T00:15:00.000Z"
+  };
+}
+
+function git(rootDir: string, env: NodeJS.ProcessEnv, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", path.join(rootDir, "harness"), ...args], { encoding: "utf8", env }).trim();
+}
+
+function gitOptional(rootDir: string, env: NodeJS.ProcessEnv, ...args: ReadonlyArray<string>): string | null {
+  try { return git(rootDir, env, ...args); } catch { return null; }
+}
+
+function readBatchTrailer(commitBody: string): ReadonlyArray<{ readonly opId: string; readonly semanticMutationSetDigest: string }> {
+  const value = commitBody.split("\n").find((line) => line.startsWith("Harness-Authority-Batch: "))?.slice("Harness-Authority-Batch: ".length);
+  if (!value) throw new Error("authority batch trailer missing");
+  const encoded = value.split(":").at(-1);
+  if (!encoded) throw new Error("authority batch trailer vector missing");
+  const bytes = Buffer.from(encoded, "base64url");
+  const count = bytes.readUInt32BE(0);
+  let offset = 4;
+  const entries = [];
+  for (let index = 0; index < count; index += 1) {
+    const length = bytes.readUInt32BE(offset);
+    offset += 4;
+    const opId = bytes.subarray(offset, offset + length).toString("utf8");
+    offset += length;
+    const semanticMutationSetDigest = bytes.subarray(offset, offset + 32).toString("hex");
+    offset += 32;
+    entries.push({ opId, semanticMutationSetDigest });
+  }
+  return entries;
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  return Buffer.from(left).equals(Buffer.from(right));
+}
+
+const channelNonceDigest = Buffer.alloc(32, 0x22);
+const schemaTuple = {
+  wire: 2, event: 2, receipt: 2, digest: 2, policy: 1,
+  commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
+} as const;

--- a/packages/application/test/session-execution-review-semantic-compiler-v2.test.ts
+++ b/packages/application/test/session-execution-review-semantic-compiler-v2.test.ts
@@ -1,0 +1,363 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  canonicalPayloadDigestV2,
+  classifyStaticZones,
+  classifyTouchedZones,
+  encodeSessionExecutionReviewCommandPayloadV2,
+  makeSessionExecutionReviewSemanticCompilerV2,
+  semanticMutationEnvelopeV2Schema,
+  semanticMutationSetDigestV2,
+  semanticRequestDigestV2,
+  type ExecutionActionPayloadV2,
+  type HostedDocumentSnapshotV2,
+  type PathCasV2,
+  type RegistryEntityRefV2,
+  type ReviewActionPayloadV2,
+  type SemanticBaseCasV2,
+  type SemanticEntityBaseV2,
+  type SemanticMutationEnvelopeV2,
+  type SemanticMutationSetV2,
+  type SessionActionPayloadV2,
+  type SessionExecutionReviewCommandPayloadV2
+} from "../src/index.ts";
+import {
+  compileRegistryMutationPlan,
+  createWritableEntityRegistry,
+  entityRegistry,
+  sha256Text,
+  type EntityRegistration,
+  type ExecutionRecord,
+  type ReviewRecord,
+  type SessionManifest
+} from "../../kernel/src/index.ts";
+
+const taskId = "task_01KXD8H2QFMMA4T203PJZ77AQ5";
+const executionId = "exe_01KXD8H2QFMMA4T203PJZ77AQ6";
+const reviewId = "rev_01KXD8H2QFMMA4T203PJZ77AQ7";
+const sessionId = "session-w4";
+const stateDigest = Buffer.alloc(32, 0x11);
+const registry = createWritableEntityRegistry([
+  entityRegistry.session,
+  entityRegistry.execution,
+  entityRegistry.review
+]);
+
+test("session/execution/review register only OQ-3 actions and remain DEFER-TYPED-ONLY", () => {
+  assert.deepEqual(entityRegistry.session.mutationContract, { status: "ready", actions: ["export", "sync", "archive"] });
+  assert.deepEqual(entityRegistry.execution.mutationContract, { status: "ready", actions: ["claim", "submit", "close"] });
+  assert.deepEqual(entityRegistry.review.mutationContract, { status: "ready", actions: ["create", "dismiss", "record"] });
+  for (const kind of ["session", "execution", "review"] as const) {
+    assert.equal(entityRegistry[kind].semanticDiff.status, "typed-only");
+    assert.equal(entityRegistry[kind].projectionFacet.status, "ready");
+  }
+});
+
+test("all session actions compile one composite manifest plus immutable CAS body StoragePlan", async () => {
+  const body = "# Session W4\n\nTyped composite body.\n";
+  const sealed = sessionManifest(body, "sealed");
+  const archived = sessionManifest(body, "archived");
+  const sessionRef = ref("session", `session/${sessionId}`);
+  const path = `sessions/${sessionId}.md`;
+  const current = snapshot(JSON.stringify(sealed));
+  const cases: ReadonlyArray<{
+    readonly payload: SessionActionPayloadV2;
+    readonly state: ReturnType<typeof authorityState>;
+    readonly baseCas: ReadonlyArray<SemanticBaseCasV2>;
+    readonly pathCas?: ReadonlyArray<PathCasV2>;
+    readonly action: string;
+  }> = [
+    {
+      payload: { schema: "session.export/v1", manifest: sealed, body },
+      state: authorityState(), baseCas: [absent(sessionRef)], action: "export"
+    },
+    {
+      payload: { schema: "session.sync/v1", manifest: sealed, body },
+      state: authorityState(new Map([[key(sessionRef), base("session-v1")]]), new Map([[path, current]])),
+      baseCas: [present(sessionRef, "session-v1")], pathCas: [cas(path, current)], action: "sync"
+    },
+    {
+      payload: { schema: "session.archive/v1", manifest: archived, body },
+      state: authorityState(new Map([[key(sessionRef), base("session-v2")]]), new Map([[path, current]])),
+      baseCas: [present(sessionRef, "session-v2")], pathCas: [cas(path, current)], action: "archive"
+    }
+  ];
+  for (const fixture of cases) {
+    const compiled = await makeSessionExecutionReviewSemanticCompilerV2({ state: fixture.state })
+      .compile(envelope(fixture.payload, fixture.baseCas, fixture.pathCas));
+    const planned = compileRegistryMutationPlan(registry, compiled.mutationPlan);
+    assert.deepEqual(planned.mutationSet.mutations.map(pair), [`session/${sessionId}:${fixture.action}`]);
+    assert.deepEqual(planned.storagePlan.targets, [
+      { kind: "content-addressed-blob", access: "exact", referenceField: "bodyRef" },
+      { kind: "document", path, access: "exact" }
+    ]);
+    assert.deepEqual(planned.storagePlan.touchedPaths, [path]);
+    assert.deepEqual(planned.storagePlan.consistencyScopes, [`entity:session/${sessionId}`]);
+    const document = operationDocument(compiled.operation.payload);
+    assert.equal(document.blobBody, body);
+    assert.deepEqual(document.blobRef, fixture.payload.manifest.bodyRef);
+    assert.equal(compiled.operation.kind, "doc_write");
+  }
+});
+
+test("execution claim/submit/close compile exact hosted execution document plans", async () => {
+  const executionRef = ref("execution", `execution/${taskId}/${executionId}`);
+  const path = `tasks/${taskId}/executions/${executionId}.md`;
+  const active = executionRecord("active");
+  const submitted = executionRecord("submitted");
+  const accepted = executionRecord("accepted");
+  const activeSnapshot = snapshot(JSON.stringify(active));
+  const submittedSnapshot = snapshot(JSON.stringify(submitted));
+  const cases: ReadonlyArray<{
+    readonly payload: ExecutionActionPayloadV2;
+    readonly state: ReturnType<typeof authorityState>;
+    readonly baseCas: ReadonlyArray<SemanticBaseCasV2>;
+    readonly pathCas?: ReadonlyArray<PathCasV2>;
+    readonly action: string;
+  }> = [
+    {
+      payload: { schema: "execution.claim/v1", taskId, execution: active },
+      state: authorityState(), baseCas: [absent(executionRef)], action: "claim"
+    },
+    {
+      payload: { schema: "execution.submit/v1", taskId, execution: submitted },
+      state: authorityState(new Map([[key(executionRef), base("execution-v1")]]), new Map([[path, activeSnapshot]])),
+      baseCas: [present(executionRef, "execution-v1")], pathCas: [cas(path, activeSnapshot)], action: "submit"
+    },
+    {
+      payload: { schema: "execution.close/v1", taskId, execution: accepted },
+      state: authorityState(new Map([[key(executionRef), base("execution-v2")]]), new Map([[path, submittedSnapshot]])),
+      baseCas: [present(executionRef, "execution-v2")], pathCas: [cas(path, submittedSnapshot)], action: "close"
+    }
+  ];
+  for (const fixture of cases) {
+    const compiled = await makeSessionExecutionReviewSemanticCompilerV2({ state: fixture.state })
+      .compile(envelope(fixture.payload, fixture.baseCas, fixture.pathCas));
+    const planned = compileRegistryMutationPlan(registry, compiled.mutationPlan);
+    assert.deepEqual(planned.mutationSet.mutations.map(pair), [`execution/${taskId}/${executionId}:${fixture.action}`]);
+    assert.deepEqual(planned.storagePlan.targets, [{ kind: "document", path, access: "exact" }]);
+    assert.deepEqual(planned.storagePlan.consistencyScopes, [`path:${path}`]);
+    assert.equal(operationDocument(compiled.operation.payload).identity.executionId, executionId);
+  }
+});
+
+test("review create/dismiss/record compile immutable hosted review documents without task-host attribution", async () => {
+  const cases: ReadonlyArray<{ readonly schema: ReviewActionPayloadV2["schema"]; readonly verdict: ReviewRecord["verdict"]; readonly action: string }> = [
+    { schema: "review.create/v1", verdict: "changes_requested", action: "create" },
+    { schema: "review.dismiss/v1", verdict: "dismissed", action: "dismiss" },
+    { schema: "review.record/v1", verdict: "approved", action: "record" }
+  ];
+  for (const fixture of cases) {
+    const review = reviewRecord(fixture.verdict);
+    const reviewRef = ref("review", `review/${taskId}/${reviewId}`);
+    const compiled = await makeSessionExecutionReviewSemanticCompilerV2({ state: authorityState() }).compile(envelope({
+      schema: fixture.schema, taskId, review
+    }, [absent(reviewRef)]));
+    const planned = compileRegistryMutationPlan(registry, compiled.mutationPlan);
+    assert.deepEqual(planned.mutationSet.mutations.map(pair), [`review/${taskId}/${reviewId}:${fixture.action}`]);
+    assert.equal(planned.mutationSet.mutations.some((mutation) => mutation.entity.entityKind === "task"), false);
+    assert.deepEqual(planned.storagePlan.touchedPaths, [`tasks/${taskId}/reviews/${reviewId}.md`]);
+    assert.equal(operationDocument(compiled.operation.payload).identity.reviewId, reviewId);
+  }
+});
+
+test("every W4 action is independently disabled at the named registry boundary", () => {
+  for (const registration of [entityRegistry.session, entityRegistry.execution, entityRegistry.review] as const) {
+    if (registration.mutationContract.status !== "ready") throw new Error("fixture requires ready mutation contract");
+    for (const action of registration.mutationContract.actions) {
+      const disabled = {
+        ...registration,
+        mutationContract: { status: "ready" as const, actions: registration.mutationContract.actions.filter((candidate) => candidate !== action) }
+      } as EntityRegistration<string, typeof registration.kind>;
+      assert.throws(() => compileRegistryMutationPlan(createWritableEntityRegistry([disabled]), {
+        registryVersion: 1,
+        mutations: [{ entityKind: registration.kind, identity: identityFor(registration.kind), action }]
+      }), new RegExp(`UNKNOWN_SEMANTIC_ACTION:${registration.kind}:${action}`, "u"));
+    }
+  }
+});
+
+test("transparent save and generic doc-sync reject all W4 machine-owned surfaces without host fallback", async () => {
+  const compiler = makeSessionExecutionReviewSemanticCompilerV2({ state: authorityState() });
+  const typed = envelope({ schema: "review.record/v1", taskId, review: reviewRecord("approved") }, [
+    absent(ref("review", `review/${taskId}/${reviewId}`))
+  ]);
+  await assert.rejects(compiler.compile(finalize({
+    ...typed,
+    intent: { kind: "transparent-file", interpretation: "full-semantic", files: [] }
+  })), /SEMANTIC_DIFF_REQUIRED/u);
+  const paths = [
+    `sessions/${sessionId}.md`,
+    `tasks/${taskId}/executions/${executionId}.md`,
+    `tasks/${taskId}/reviews/${reviewId}.md`
+  ];
+  for (const path of paths) {
+    for (const zones of [classifyStaticZones(path, []), classifyTouchedZones(path, "modified", "before", "after", [])]) {
+      assert.deepEqual(zones.map((zone) => zone.ok), [false]);
+      assert.match(zones[0]!.ok ? "" : zones[0]!.reason, /machine-owned.*typed/u);
+    }
+  }
+});
+
+test("canonical payload and registry mutation digests are deterministic", async () => {
+  const payload: ReviewActionPayloadV2 = { schema: "review.record/v1", taskId, review: reviewRecord("approved") };
+  const reordered = { review: payload.review, taskId: payload.taskId, schema: payload.schema } as ReviewActionPayloadV2;
+  assert.deepEqual(encodeSessionExecutionReviewCommandPayloadV2(payload), encodeSessionExecutionReviewCommandPayloadV2(reordered));
+  const compiler = makeSessionExecutionReviewSemanticCompilerV2({ state: authorityState() });
+  const compiled = await compiler.compile(envelope(payload, [absent(ref("review", `review/${taskId}/${reviewId}`))]));
+  const left = compileRegistryMutationPlan(registry, compiled.mutationPlan).mutationSet;
+  const right = compileRegistryMutationPlan(registry, { ...compiled.mutationPlan, mutations: [...compiled.mutationPlan.mutations].reverse() }).mutationSet;
+  assert.deepEqual(semanticMutationSetDigestV2(left), semanticMutationSetDigestV2(right));
+});
+
+function envelope(
+  payloadValue: SessionExecutionReviewCommandPayloadV2,
+  baseCas: ReadonlyArray<SemanticBaseCasV2>,
+  declaredPathCas: ReadonlyArray<PathCasV2> = []
+): SemanticMutationEnvelopeV2 {
+  const payload = encodeSessionExecutionReviewCommandPayloadV2(payloadValue);
+  const mutationSet: SemanticMutationSetV2 = { registryVersion: 1, mutations: [] };
+  return finalize({
+    schema: semanticMutationEnvelopeV2Schema,
+    workspaceId: "workspace-w4",
+    operationId: {
+      namespace: {
+        schema: "operation-namespace/v1", workspaceId: "workspace-w4", deviceId: "device-w4",
+        authorityGeneration: 1n, namespaceId: "namespace-w4", expiresAt: 9_000n,
+        issuer: "authority.test", keyId: "namespace-key", proof: Buffer.alloc(32, 3)
+      },
+      clientRandom128: Buffer.alloc(16, 7)
+    },
+    binding: {
+      bindingId: "binding-w4", actorAxesBindingDigest: Buffer.alloc(32, 4), deviceId: "device-w4",
+      viewId: "view-w4", sessionId: "session-w4",
+      admissionTokenRef: { tokenId: "token-w4", tokenDigest: Buffer.alloc(32, 5) }
+    },
+    schemaTuple,
+    intent: {
+      kind: "typed",
+      command: { registryVersion: 1, name: payloadValue.schema.replace("/v1", ""), version: 1 },
+      canonicalPayload: { kind: "inline", size: BigInt(payload.length), bytes: payload },
+      canonicalPayloadDigest: canonicalPayloadDigestV2(payload), baseCas, declaredPathCas
+    },
+    claimedMutationSet: mutationSet,
+    claimedSemanticMutationSetDigest: semanticMutationSetDigestV2(mutationSet),
+    claimedSemanticRequestDigest: Buffer.alloc(32)
+  });
+}
+
+function finalize(value: SemanticMutationEnvelopeV2): SemanticMutationEnvelopeV2 {
+  return { ...value, claimedSemanticRequestDigest: semanticRequestDigestV2(value) };
+}
+
+function authorityState(
+  bases: ReadonlyMap<string, SemanticEntityBaseV2> = new Map(),
+  documents: ReadonlyMap<string, HostedDocumentSnapshotV2> = new Map()
+) {
+  return {
+    readEntityBase: async (entityRef: RegistryEntityRefV2) => bases.get(key(entityRef)) ?? null,
+    readHostedDocument: async (path: string) => documents.get(path) ?? null
+  };
+}
+
+function sessionManifest(body: string, lifecycle: SessionManifest["lifecycle"]): SessionManifest {
+  const sha = sha256Text(body);
+  return {
+    schema: "session-entity/v1", sessionId, lifecycle,
+    archiveStatus: "complete", runtime: "codex", source: "runtime",
+    detectedAt: "2026-07-14T00:00:00.000Z", exportedAt: "2026-07-14T00:01:00.000Z",
+    bodyRef: {
+      store: "authored-cas/v1", ref: `harness/objects/sha256/${sha.slice(0, 2)}/${sha.slice(2)}`,
+      sha256: sha, size: Buffer.byteLength(body), mediaType: "text/markdown; charset=utf-8"
+    },
+    snapshot: {
+      capturedAt: "2026-07-14T00:01:00.000Z", completeness: "complete",
+      captureRange: { messageCount: 1 },
+      privacyScan: { scannerVersion: "w4-test", passed: true, findings: [] }
+    }
+  };
+}
+
+function executionRecord(state: ExecutionRecord["state"]): ExecutionRecord {
+  const submitted = state !== "active";
+  return {
+    schema: "execution/v2", execution_id: executionId, task_ref: `task/${taskId}`, state,
+    primary_actor: {
+      principal: { personId: "person_zeyu" }, executor: { kind: "agent", id: "agent_w4" }, responsibleHuman: "person_zeyu"
+    },
+    claimed_at: "2026-07-14T00:00:00.000Z",
+    submitted_at: submitted ? "2026-07-14T00:10:00.000Z" : null,
+    closed_at: state === "accepted" ? "2026-07-14T00:20:00.000Z" : null,
+    session_bindings: [],
+    outputs: submitted ? [{ evidence_id: "evidence:w4", execution_ref: `execution/${taskId}/${executionId}`, locator: { substrate: "inline", text: "passed" } }] : [],
+    submission: submitted ? {
+      completion_claim: "W4 complete", deliverables: ["typed compiler"], evidence_refs: ["evidence:w4"],
+      verification_notes: ["tested"], known_gaps: [], residual_risks: []
+    } : null
+  };
+}
+
+function reviewRecord(verdict: ReviewRecord["verdict"]): ReviewRecord {
+  return {
+    schema: "review/v2", review_id: reviewId, task_ref: `task/${taskId}`,
+    execution_ref: `execution/${taskId}/${executionId}`,
+    reviewer_actor: {
+      principal: { personId: "person_reviewer" }, executor: { kind: "agent", id: "agent_reviewer" }, responsibleHuman: "person_reviewer"
+    },
+    reviewer_session_ref: "session/reviewer-w4", findings: "Typed review findings.",
+    evidence_checked: ["evidence:w4"], rationale: "The exact evidence supports this verdict.", verdict,
+    archive_warnings_acknowledged: true, reviewed_at: "2026-07-14T00:15:00.000Z"
+  };
+}
+
+function operationDocument(payload: unknown): {
+  readonly identity: Record<string, string>;
+  readonly blobRef?: unknown;
+  readonly blobBody?: string;
+} {
+  return (payload as { readonly entityDocument: ReturnType<typeof operationDocument> }).entityDocument;
+}
+
+function snapshot(body: string): HostedDocumentSnapshotV2 {
+  return { body, epoch: "epoch-w4", revision: 7n, blobDigest: Buffer.alloc(32, 0x77) };
+}
+
+function base(semanticVersion: string): SemanticEntityBaseV2 {
+  return { semanticVersion, stateDigest };
+}
+
+function ref(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
+  return { registryVersion: 1, entityKind, canonicalRef };
+}
+
+function key(entityRef: RegistryEntityRefV2): string {
+  return `${entityRef.registryVersion}\0${entityRef.entityKind}\0${entityRef.canonicalRef}`;
+}
+
+function absent(entityRef: RegistryEntityRefV2): SemanticBaseCasV2 {
+  return { entityRef, expectedSemanticVersion: null, expectedStateDigest: null };
+}
+
+function present(entityRef: RegistryEntityRefV2, semanticVersion: string): SemanticBaseCasV2 {
+  return { entityRef, expectedSemanticVersion: semanticVersion, expectedStateDigest: stateDigest };
+}
+
+function cas(path: string, value: HostedDocumentSnapshotV2): PathCasV2 {
+  return { path, expectedEpoch: value.epoch, expectedRevision: value.revision, expectedBlobDigest: value.blobDigest };
+}
+
+function pair(mutation: SemanticMutationSetV2["mutations"][number]): string {
+  return `${mutation.entity.canonicalRef}:${mutation.action.action}`;
+}
+
+function identityFor(kind: "session" | "execution" | "review"): Record<string, string> {
+  if (kind === "session") return { sessionId };
+  if (kind === "execution") return { taskId, executionId };
+  return { taskId, reviewId };
+}
+
+const schemaTuple = {
+  wire: 2, event: 2, receipt: 2, digest: 2, policy: 1,
+  commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
+} as const;

--- a/packages/kernel/src/entity/declaration.ts
+++ b/packages/kernel/src/entity/declaration.ts
@@ -36,6 +36,7 @@ export interface DeclaredEntityDocumentWritePayload {
     readonly identity: Readonly<Record<string, string>>;
     readonly body: string;
     readonly blobRef?: DeclaredContentAddressedBlobRef;
+    readonly blobBody?: string;
   };
   readonly companionWrites?: ReadonlyArray<DocumentWrite>;
 }

--- a/packages/kernel/src/entity/execution-declaration.ts
+++ b/packages/kernel/src/entity/execution-declaration.ts
@@ -2,7 +2,6 @@ import { Schema } from "effect";
 import { executionStates } from "../domain/execution.ts";
 import { decodeEntityDeclaration, jsonEntityDocumentCodec } from "./declaration.ts";
 import {
-  deferredRegistryFacet,
   readyIdentityProjectionFacets,
   readyStorageLocator,
   typedOnlySemanticDiff
@@ -179,7 +178,7 @@ export const executionDeclaration = decodeEntityDeclaration({
       };
     }
   }),
-  mutationContract: deferredRegistryFacet("W4", "OQ-3 action vocabulary is not registered"),
+  mutationContract: { status: "ready", actions: ["claim", "submit", "close"] },
   semanticDiff: typedOnlySemanticDiff("machine-owned execution documents reject transparent canonical writes"),
   rootResolver: {
     pathTemplate: "tasks/{taskId}/executions/{executionId}.md",

--- a/packages/kernel/src/entity/review-declaration.ts
+++ b/packages/kernel/src/entity/review-declaration.ts
@@ -2,7 +2,6 @@ import { Schema } from "effect";
 import { reviewVerdicts } from "../domain/review.ts";
 import { decodeEntityDeclaration, jsonEntityDocumentCodec } from "./declaration.ts";
 import {
-  deferredRegistryFacet,
   readyIdentityProjectionFacets,
   readyStorageLocator,
   typedOnlySemanticDiff
@@ -91,7 +90,7 @@ export const reviewDeclaration = decodeEntityDeclaration({
       };
     }
   }),
-  mutationContract: deferredRegistryFacet("W4", "OQ-3 action vocabulary is not registered"),
+  mutationContract: { status: "ready", actions: ["create", "dismiss", "record"] },
   semanticDiff: typedOnlySemanticDiff("machine-owned review documents reject transparent canonical writes"),
   rootResolver: {
     pathTemplate: "tasks/{taskId}/reviews/{reviewId}.md",

--- a/packages/kernel/src/entity/session-declaration.ts
+++ b/packages/kernel/src/entity/session-declaration.ts
@@ -1,7 +1,6 @@
 import { SessionManifestSchema, type SessionFieldKey } from "../schemas/session-manifest.ts";
 import type { EntityFieldContract } from "./field-contracts.ts";
 import {
-  deferredRegistryFacet,
   readyIdentityProjectionFacets,
   readyStorageLocator,
   typedOnlySemanticDiff
@@ -65,7 +64,7 @@ export const sessionEntityRegistration = {
       consistencyScope: `entity:session/${identity.sessionId}`
     })
   }),
-  mutationContract: deferredRegistryFacet("W4", "OQ-3 action vocabulary is not registered"),
+  mutationContract: { status: "ready", actions: ["export", "sync", "archive"] },
   semanticDiff: typedOnlySemanticDiff("machine-owned session manifests reject transparent canonical writes"),
   rootResolver: { pathTemplate: "sessions/{sessionId}.md", identity: ["sessionId"] },
   projection: {

--- a/packages/kernel/src/store/write-journal-commit-summary.ts
+++ b/packages/kernel/src/store/write-journal-commit-summary.ts
@@ -1,0 +1,49 @@
+import type { EntityId } from "../domain/index.ts";
+import type { JournalRecordKind, ReadableJournalRecord } from "./write-journal-types.ts";
+
+export function writeJournalRecordCommitSummary(
+  record: ReadableJournalRecord,
+  payload: Record<string, unknown>
+): string {
+  const parsed = parseEntityLabel(record.entityId);
+  const detail = recordCommitDetail(record.kind, payload);
+  return `${parsed.kind}(${writeKindVerb(record.kind)}): ${parsed.id}${detail ? ` ${detail}` : ""}`;
+}
+
+function parseEntityLabel(entityId: EntityId): { readonly kind: string; readonly id: string } {
+  const separator = entityId.indexOf("/");
+  if (separator < 0) return { kind: "write", id: entityId };
+  return { kind: entityId.slice(0, separator), id: entityId.slice(separator + 1) };
+}
+
+function writeKindVerb(kind: JournalRecordKind): string {
+  return kind
+    .replace(/^decision_/u, "")
+    .replace(/^package_/u, "")
+    .replace(/_local$/u, "")
+    .replace(/^module_/u, "")
+    .replace(/_write$/u, "")
+    .replace(/_/gu, "-");
+}
+
+function recordCommitDetail(kind: JournalRecordKind, payload: Record<string, unknown>): string {
+  if (kind === "transition_local" && typeof payload.to === "string") return `-> ${payload.to}`;
+  if (kind === "progress_append") return "progress.md";
+  if ((kind === "machine_artifact_write" || kind === "machine_artifact_append_jsonl") && typeof payload.path === "string") return payload.path;
+  if ((kind === "doc_write" || kind === "doc_stage" || kind === "code_doc_reconcile") && typeof payload.path === "string") return payload.path;
+  if (kind === "task_tree_stage") return "task package";
+  if (kind === "module_registry_write" && typeof payload.operation === "string") return payload.operation;
+  if (kind === "module_scaffold_write") return "scaffold";
+  if (kind === "decision_relate") {
+    const decision = payload.decision as { readonly relations?: ReadonlyArray<{ readonly type?: unknown; readonly target?: unknown }> } | undefined;
+    const relation = decision?.relations?.at(-1);
+    if (relation && typeof relation.type === "string" && typeof relation.target === "string") {
+      return `${relation.type} ${relation.target.replace(/^decision\//u, "")}`;
+    }
+  }
+  if (kind.startsWith("decision_")) {
+    const decision = payload.decision as { readonly title?: unknown } | undefined;
+    if (decision && typeof decision.title === "string" && decision.title.trim().length > 0) return decision.title.trim().slice(0, 72);
+  }
+  return "";
+}

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -26,6 +26,7 @@ import { appendJsonLineDurably, readDurableState, readPayloadRef, writeWatermark
 import { assertCommitPlanAddable, commitTouchedPaths } from "./write-journal-git.ts";
 import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
 import { assertCodeDocGitEvidence, assertNoUncoordinatedCodeDocChange } from "./write-journal-code-doc-policy.ts";
+import { writeJournalRecordCommitSummary } from "./write-journal-commit-summary.ts";
 import { runLedgerMaterializer } from "./ledger-materializer.ts";
 import { createAttributionEvent, makeLocalGitAttributionEventStore, planAttributionEventCommit, type AttributionEventStore } from "./write-journal-attribution-events.ts";
 import { assertDirectWriteAllowed, withRepoLocks, WriteLockHeldError } from "./write-journal-locks.ts";
@@ -41,7 +42,9 @@ import {
 } from "./write-journal-records.ts";
 import {
   applyWriteOp,
+  claimCheckedDeclaredEntityWriteOp,
   documentWritesForWriteOp,
+  materializeDeclaredEntityBlob,
   readHardDeletePayload,
   validateWriteTransaction,
   writeOpTouchedPaths
@@ -49,7 +52,7 @@ import {
 import { reconcileDurableFlush, shouldWaitForForeignCommitter } from "./write-journal-receipt.ts";
 import { semanticCommitMessage } from "./write-journal-authority-trailer.ts";
 import { memoizePublicationVcs } from "./write-journal-publication-vcs.ts";
-import type { ApplyMarkerRecord, DeleteAuditRecord, GitCommitAuthor, JournalRecordKind, JournaledWriteCoordinatorOptions, JournalRecoveryOptions, LockConflictRetryOptions, LockTakeoverRecord, OperationalActor, OperationalJournaledWriteCoordinatorOptions, ReadableJournalRecord, WriteWatermark } from "./write-journal-types.ts";
+import type { ApplyMarkerRecord, DeleteAuditRecord, GitCommitAuthor, JournaledWriteCoordinatorOptions, JournalRecoveryOptions, LockConflictRetryOptions, LockTakeoverRecord, OperationalActor, OperationalJournaledWriteCoordinatorOptions, ReadableJournalRecord, WriteWatermark } from "./write-journal-types.ts";
 export type {
   GitCommitAuthor,
   JournalActor,
@@ -128,31 +131,33 @@ function makeJournaledWriteCoordinatorInternal(
     enqueue: (op) => Effect.try({
       try: (): WriteAck => {
         validateOp(runtimeContext, op);
+        const journalOp = claimCheckedDeclaredEntityWriteOp(op);
         const attribution = mode === "attributed"
-          ? decodeWriteAttribution("attribution" in options ? options.attribution : undefined, op.entityId)
+          ? decodeWriteAttribution("attribution" in options ? options.attribution : undefined, journalOp.entityId)
           : undefined;
         if (mode === "recovery-only") {
-          rejectWrite("write coordinator requires request attribution", op.entityId);
+          rejectWrite("write coordinator requires request attribution", journalOp.entityId);
         }
-        if (mode === "operational-machine-artifact" && !op.kind.startsWith("machine_artifact_")) {
-          rejectWrite("operational coordinator only accepts machine artifact writes", op.entityId);
+        if (mode === "operational-machine-artifact" && !journalOp.kind.startsWith("machine_artifact_")) {
+          rejectWrite("operational coordinator only accepts machine artifact writes", journalOp.entityId);
         }
-        preflightWriteOp(rootDir, runtimeContext, op, versionControlSystem);
+        preflightWriteOp(rootDir, runtimeContext, journalOp, versionControlSystem);
         if (!heldGlobalLock) assertDirectWriteAllowed(rootDir, runtimeContext, lockTtlMs);
         const state = readDurableState(journalPath, watermarkPath, rootDir);
-        const existing = state.records.find((record) => record.opId === op.opId);
+        const existing = state.records.find((record) => record.opId === journalOp.opId);
         if (existing) {
-          if (attribution) assertRecordMatchesAttributedOp(existing, op, attribution);
-          else assertRecordMatchesOperationalOp(existing, op, operationalActor);
-          return { opId: op.opId, entityId: op.entityId, accepted: true };
+          if (attribution) assertRecordMatchesAttributedOp(existing, journalOp, attribution);
+          else assertRecordMatchesOperationalOp(existing, journalOp, operationalActor);
+          return { opId: journalOp.opId, entityId: journalOp.entityId, accepted: true };
         }
-        if (state.applied.has(op.opId)) return { opId: op.opId, entityId: op.entityId, accepted: true };
+        if (state.applied.has(journalOp.opId)) return { opId: journalOp.opId, entityId: journalOp.entityId, accepted: true };
+        materializeDeclaredEntityBlob(runtimeContext, op);
         const record = attribution
-          ? createAttributedJournalRecord(rootDir, journalPath, op, attribution)
-          : createOperationalJournalRecord(rootDir, journalPath, op, operationalActor);
+          ? createAttributedJournalRecord(rootDir, journalPath, journalOp, attribution)
+          : createOperationalJournalRecord(rootDir, journalPath, journalOp, operationalActor);
         appendJsonLineDurably(journalPath, record);
-        pending.push(op);
-        return { opId: op.opId, entityId: op.entityId, accepted: true };
+        pending.push(journalOp);
+        return { opId: journalOp.opId, entityId: journalOp.entityId, accepted: true };
       },
       catch: (cause): WriteError => toJournalError(cause, { entityId: op.entityId })
     }),
@@ -334,7 +339,7 @@ function flushRecords(
     rootInput,
     semanticCommitMessage(
       plannedRecords.map((entry) => entry.record),
-      plannedRecords.map((entry) => recordCommitSummary(rootDir, entry.record))
+      plannedRecords.map((entry) => writeJournalRecordCommitSummary(entry.record, readVerifiedPayload(rootDir, entry.record)))
     ),
     sessionId,
     {
@@ -452,51 +457,6 @@ function readVerifiedPayload(rootDir: string, record: ReadableJournalRecord): Re
     rejectWrite(`payload hash mismatch for op ${record.opId}`, record.entityId);
   }
   return payload;
-}
-
-function recordCommitSummary(rootDir: string, record: ReadableJournalRecord): string {
-  const parsed = parseEntityLabel(record.entityId);
-  const payload = readVerifiedPayload(rootDir, record);
-  const detail = recordCommitDetail(record.kind, payload);
-  return `${parsed.kind}(${writeKindVerb(record.kind)}): ${parsed.id}${detail ? ` ${detail}` : ""}`;
-}
-
-function parseEntityLabel(entityId: EntityId): { readonly kind: string; readonly id: string } {
-  const separator = entityId.indexOf("/");
-  if (separator < 0) return { kind: "write", id: entityId };
-  return { kind: entityId.slice(0, separator), id: entityId.slice(separator + 1) };
-}
-
-function writeKindVerb(kind: JournalRecordKind): string {
-  return kind
-    .replace(/^decision_/u, "")
-    .replace(/^package_/u, "")
-    .replace(/_local$/u, "")
-    .replace(/^module_/u, "")
-    .replace(/_write$/u, "")
-    .replace(/_/gu, "-");
-}
-
-function recordCommitDetail(kind: JournalRecordKind, payload: Record<string, unknown>): string {
-  if (kind === "transition_local" && typeof payload.to === "string") return `-> ${payload.to}`;
-  if (kind === "progress_append") return "progress.md";
-  if ((kind === "machine_artifact_write" || kind === "machine_artifact_append_jsonl") && typeof payload.path === "string") return payload.path;
-  if ((kind === "doc_write" || kind === "doc_stage" || kind === "code_doc_reconcile") && typeof payload.path === "string") return payload.path;
-  if (kind === "task_tree_stage") return "task package";
-  if (kind === "module_registry_write" && typeof payload.operation === "string") return payload.operation;
-  if (kind === "module_scaffold_write") return "scaffold";
-  if (kind === "decision_relate") {
-    const decision = payload.decision as { readonly relations?: ReadonlyArray<{ readonly type?: unknown; readonly target?: unknown }> } | undefined;
-    const relation = decision?.relations?.at(-1);
-    if (relation && typeof relation.type === "string" && typeof relation.target === "string") {
-      return `${relation.type} ${relation.target.replace(/^decision\//u, "")}`;
-    }
-  }
-  if (kind.startsWith("decision_")) {
-    const decision = payload.decision as { readonly title?: unknown } | undefined;
-    if (decision && typeof decision.title === "string" && decision.title.trim().length > 0) return decision.title.trim().slice(0, 72);
-  }
-  return "";
 }
 
 function rebuildProjectionHash(

--- a/packages/kernel/src/store/write-journal-operations.ts
+++ b/packages/kernel/src/store/write-journal-operations.ts
@@ -16,7 +16,11 @@ import { decisionDocumentTargetPath, decisionWriteKinds, writeDecisionDocument }
 import { taskIdForWriteOp } from "./write-journal-entity.ts";
 import { appendJsonLineDurably, writeFileDurably } from "./write-journal-durable.ts";
 import { rejectTaskWrite, rejectWrite } from "./write-journal-rejection.ts";
-import { resolveContentAddressedBlobPath } from "./content-addressed-blob-store.ts";
+import {
+  resolveContentAddressedBlobPath,
+  writeContentAddressedBlob
+} from "./content-addressed-blob-store.ts";
+import { sha256Text } from "../integrity/stable-hash.ts";
 import { assertReservedCodeDocWrite } from "./write-journal-code-doc-policy.ts";
 import {
   applyCanonicalAuthoredBatch,
@@ -79,6 +83,9 @@ export function writeTransactionPlan(op: WriteOp): WriteTransactionPlan {
       documentWrites: () => companionWrites,
       apply: (rootInput) => {
         const document = declaredEntityDocument(rootInput, op);
+        if (document.blobBody !== undefined && document.blobRef) {
+          writeContentAddressedBlob(rootInput, document.blobBody, document.blobRef.mediaType);
+        }
         writeDocumentsAtomically(rootInput, companionWrites, document);
         return null;
       },
@@ -318,7 +325,13 @@ function declaredEntityCompanionWrites(payload: DeclaredEntityDocumentWritePaylo
 function declaredEntityDocument(
   rootInput: HarnessLayoutInput,
   op: WriteOp
-): { readonly targetPath: string; readonly body: string; readonly blobPath?: string } {
+): {
+  readonly targetPath: string;
+  readonly body: string;
+  readonly blobPath?: string;
+  readonly blobRef?: DeclaredEntityDocumentWritePayload["entityDocument"]["blobRef"];
+  readonly blobBody?: string;
+} {
   if (!hasDeclaredEntityDocument(op.payload)) rejectWrite(`${op.kind} op requires entityDocument payload`, op.entityId);
   const document = op.payload.entityDocument;
   if (!document || typeof document !== "object" || typeof document.body !== "string" || !isStringRecord(document.identity)) {
@@ -329,9 +342,25 @@ function declaredEntityDocument(
     if (!op.entityId.startsWith(`entity/${declaration.kind}/`)) {
       rejectWrite(`entityDocument kind does not match write entity: ${op.entityId}`, op.entityId);
     }
+    if (document.blobBody !== undefined && typeof document.blobBody !== "string") {
+      rejectWrite("declared entity blobBody must be text", op.entityId);
+    }
+    if (document.blobBody !== undefined && !document.blobRef) {
+      rejectWrite("declared entity blobBody requires blobRef", op.entityId);
+    }
+    if (document.blobBody !== undefined && document.blobRef
+      && (document.blobRef.sha256 !== sha256Text(document.blobBody)
+        || document.blobRef.size !== Buffer.byteLength(document.blobBody, "utf8"))) {
+      rejectWrite("declared entity blobBody does not match blobRef", op.entityId);
+    }
     return {
       targetPath: resolveEntityDocumentPath(rootInput, declaration, document.identity),
-      body: document.body, ...(document.blobRef ? { blobPath: resolveContentAddressedBlobPath(rootInput, document.blobRef) } : {})
+      body: document.body,
+      ...(document.blobRef ? {
+        blobPath: resolveContentAddressedBlobPath(rootInput, document.blobRef),
+        blobRef: document.blobRef
+      } : {}),
+      ...(document.blobBody === undefined ? {} : { blobBody: document.blobBody })
     };
   } catch (error) {
     rejectWrite(error instanceof Error ? error.message : String(error), op.entityId);
@@ -359,6 +388,19 @@ export function writeOpTouchedPaths(rootInput: HarnessLayoutInput, op: WriteOp):
 
 export function documentWritesForWriteOp(op: WriteOp): ReadonlyArray<DocumentWrite> {
   return writeTransactionPlan(op).documentWrites();
+}
+
+export function materializeDeclaredEntityBlob(rootInput: HarnessLayoutInput, op: WriteOp): void {
+  if (!hasDeclaredEntityDocument(op.payload)) return;
+  const document = op.payload.entityDocument;
+  if (document.blobBody === undefined || !document.blobRef) return;
+  writeContentAddressedBlob(rootInput, document.blobBody, document.blobRef.mediaType);
+}
+
+export function claimCheckedDeclaredEntityWriteOp(op: WriteOp): WriteOp {
+  if (!hasDeclaredEntityDocument(op.payload) || op.payload.entityDocument.blobBody === undefined) return op;
+  const { blobBody: _blobBody, ...entityDocument } = op.payload.entityDocument;
+  return { ...op, payload: { ...op.payload, entityDocument } };
 }
 
 export { isProgressAppendDeltaPayload, readHardDeletePayload } from "./write-journal-operations-internal.ts";

--- a/packages/kernel/test/store/entity-registry-substrate.test.ts
+++ b/packages/kernel/test/store/entity-registry-substrate.test.ts
@@ -277,8 +277,7 @@ test("writable registration fails closed when any required facet is missing or d
     );
   }
   for (const kind of entityRegistryKinds) {
-    const isWritable = kind === "task" || kind === "decision" || kind === "fact" || kind === "relation" || kind === "module";
-    assert.equal(entityRegistry[kind].mutationContract.status, isWritable ? "ready" : "deferred");
+    assert.equal(entityRegistry[kind].mutationContract.status, "ready");
     assert.equal(entityRegistry[kind].projectionFacet.status, "ready", `${kind} derives the W1 union projection from the registry`);
     if (entityRegistry[kind].projectionFacet.status === "ready" && entityRegistry[kind].identityCodec.status === "ready") {
       assert.deepEqual(
@@ -286,16 +285,9 @@ test("writable registration fails closed when any required facet is missing or d
         entityRegistry[kind].identityCodec.codec.decode(canonicalRefs[kind])
       );
     }
-    if (isWritable) {
-      assert.doesNotThrow(() => createWritableEntityRegistry([
-        entityRegistry[kind] as EntityRegistration<string, KernelEntityKind>
-      ]));
-    } else {
-      assert.throws(
-        () => createWritableEntityRegistry([entityRegistry[kind] as EntityRegistration<string, KernelEntityKind>]),
-        new RegExp(`REGISTRY_FACET_NOT_WRITABLE:${kind}:mutationContract`, "u")
-      );
-    }
+    assert.doesNotThrow(() => createWritableEntityRegistry([
+      entityRegistry[kind] as EntityRegistration<string, KernelEntityKind>
+    ]));
   }
   for (const kind of ["session", "execution", "review"] as const) {
     assert.equal(entityRegistry[kind].semanticDiff.status, "typed-only");

--- a/tools/perf/session-execution-review-v2-benchmark.mjs
+++ b/tools/perf/session-execution-review-v2-benchmark.mjs
@@ -1,0 +1,324 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import process from "node:process";
+import { Effect } from "effect";
+import {
+  canonicalAuthorityRequestDigest,
+  canonicalPayloadDigestV2,
+  createAuthoritySubmissionService,
+  createInMemoryAuthorityOperationRegistry,
+  createInMemoryReplicaChangeLog,
+  encodeSessionExecutionReviewCommandPayloadV2,
+  makeSessionExecutionReviewSemanticCompilerV2,
+  semanticMutationEnvelopeV2Schema,
+  semanticMutationSetDigestV2,
+  semanticRequestDigestV2
+} from "../../packages/application/src/index.ts";
+import {
+  compileRegistryMutationPlan,
+  createWritableEntityRegistry,
+  entityRegistry,
+  makeJournaledWriteCoordinator,
+  sha256Text
+} from "../../packages/kernel/src/index.ts";
+
+const writerCounts = integerListOption("--writers", [2, 4, 8]);
+const rounds = integerOption("--rounds", 10);
+const groups = enumListOption("--groups", ["session-cas-blob", "hosted-small-op"], ["session-cas-blob", "hosted-small-op"]);
+const blobBytes = integerOption("--blob-bytes", 64 * 1024);
+const workspaceId = "workspace-w4-perf";
+const token = "w4-perf-token";
+const channelNonceDigest = "sha256:w4-perf-channel";
+const protocol = { wire: 1, event: 1, receipt: 1, digest: 1, commandRegistry: 1 };
+const scenarios = [];
+
+for (const group of groups) {
+  for (const writers of writerCounts) scenarios.push(await runScenario(group, writers));
+}
+
+process.stdout.write(`${JSON.stringify({
+  schema: "session-execution-review-v2-concurrency-benchmark/v1",
+  measuredAt: new Date().toISOString(),
+  sourceCommit: gitAt(process.cwd(), "rev-parse", "HEAD"),
+  environment: { node: process.version, platform: process.platform, arch: process.arch },
+  workload: "session composite manifest+CAS blob; disjoint execution/review hosted documents",
+  rounds,
+  blobBytes,
+  thresholds: { writer8AbsoluteP95Ms: 2_000, frozenA1P95Ms: 1_352, maxFrozenBaselineDegradationRatio: 1.2 },
+  scenarios
+}, null, 2)}\n`);
+
+async function runScenario(group, writers) {
+  return withGit(group, writers, async ({ rootDir, env }) => {
+    const queueWaitByOp = new Map();
+    const submitStartedByOp = new Map();
+    const service = authority(rootDir, env, queueWaitByOp, submitStartedByOp);
+    const compiler = makeSessionExecutionReviewSemanticCompilerV2({
+      state: { readEntityBase: async () => null, readHostedDocument: async () => null }
+    });
+    const registry = createWritableEntityRegistry([entityRegistry.session, entityRegistry.execution, entityRegistry.review]);
+    const samples = { endToEndMs: [], compilerMs: [], queueWaitMs: [], commitIndexMs: [] };
+    for (let round = 0; round < rounds; round += 1) {
+      const rows = await Promise.all(Array.from({ length: writers }, async (_, writer) => {
+        const fixture = operationFixture(group, writers, round, writer);
+        const started = performance.now();
+        const compileStarted = performance.now();
+        const semantic = await compiler.compile(fixture.envelope);
+        const compiled = compileRegistryMutationPlan(registry, semantic.mutationPlan);
+        const compilerMs = performance.now() - compileStarted;
+        const expectedTargets = group === "session-cas-blob" ? 2 : 1;
+        if (compiled.mutationSet.mutations.length !== 1 || compiled.storagePlan.targets.length !== expectedTargets) {
+          throw new Error("W4 benchmark compiler produced an unexpected mutation or StoragePlan target count");
+        }
+        submitStartedByOp.set(fixture.opId, performance.now());
+        const receipt = await service.submit(v1Envelope(fixture.opId, { ...semantic.operation, opId: fixture.opId }));
+        const endToEndMs = performance.now() - started;
+        if (receipt.tag !== "COMMITTED") throw new Error(`${fixture.opId} returned ${receipt.tag}`);
+        const queueWaitMs = queueWaitByOp.get(fixture.opId);
+        if (queueWaitMs === undefined) throw new Error(`queue wait missing for ${fixture.opId}`);
+        return { endToEndMs, compilerMs, queueWaitMs, commitIndexMs: Math.max(0, endToEndMs - compilerMs - queueWaitMs) };
+      }));
+      for (const row of rows) for (const key of Object.keys(samples)) samples[key].push(row[key]);
+    }
+    const endToEnd = summary(samples.endToEndMs);
+    return {
+      group,
+      writers,
+      attempts: samples.endToEndMs.length,
+      endToEndMs: endToEnd,
+      gate: {
+        absoluteP95Pass: writers !== 8 || endToEnd.p95Ms < 2_000,
+        frozenBaselinePass: endToEnd.p95Ms < 1_352 * 1.2
+      },
+      segments: {
+        registryCompileSemanticDiffMs: summary(samples.compilerMs),
+        coordinatorQueueWaitMs: summary(samples.queueWaitMs),
+        commitIndexMs: summary(samples.commitIndexMs)
+      }
+    };
+  });
+}
+
+function operationFixture(group, writers, round, writer) {
+  const ordinal = round * writers + writer;
+  const suffix = `${group}-n${writers}-r${round}-w${writer}`;
+  let payloadValue;
+  let entityKind;
+  let canonicalRef;
+  if (group === "session-cas-blob") {
+    const sessionId = `session-w4-perf-${writers}-${ordinal}`;
+    const body = fixedBody(blobBytes, suffix);
+    payloadValue = { schema: "session.export/v1", manifest: sessionManifest(sessionId, body), body };
+    entityKind = "session";
+    canonicalRef = `session/${sessionId}`;
+  } else {
+    const taskId = `task_${stableId(writers * 100_000 + ordinal + 1)}`;
+    const executionId = `exe_${stableId(writers * 200_000 + ordinal + 1)}`;
+    if (writer % 2 === 0) {
+      payloadValue = { schema: "execution.claim/v1", taskId, execution: executionRecord(taskId, executionId) };
+      entityKind = "execution";
+      canonicalRef = `execution/${taskId}/${executionId}`;
+    } else {
+      const reviewId = `rev_${stableId(writers * 300_000 + ordinal + 1)}`;
+      payloadValue = { schema: "review.record/v1", taskId, review: reviewRecord(taskId, executionId, reviewId) };
+      entityKind = "review";
+      canonicalRef = `review/${taskId}/${reviewId}`;
+    }
+  }
+  const payload = encodeSessionExecutionReviewCommandPayloadV2(payloadValue);
+  const mutationSet = { registryVersion: 1, mutations: [] };
+  const draft = {
+    schema: semanticMutationEnvelopeV2Schema,
+    workspaceId,
+    operationId: {
+      namespace: {
+        schema: "operation-namespace/v1", workspaceId, deviceId: "device-w4-perf", authorityGeneration: 1n,
+        namespaceId: "namespace-w4-perf", expiresAt: 9_000n, issuer: "authority.perf", keyId: "namespace-key", proof: Buffer.alloc(32, 3)
+      },
+      clientRandom128: Buffer.from(fixedHex(ordinal + (group === "session-cas-blob" ? 1 : 1_000_000), 32), "hex")
+    },
+    binding: {
+      bindingId: "binding-w4-perf", actorAxesBindingDigest: Buffer.alloc(32, 4), deviceId: "device-w4-perf",
+      viewId: "view-w4-perf", sessionId: "session-w4-perf",
+      admissionTokenRef: { tokenId: "token-w4-perf", tokenDigest: Buffer.alloc(32, 5) }
+    },
+    schemaTuple: {
+      wire: 2, event: 2, receipt: 2, digest: 2, policy: 1,
+      commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
+    },
+    intent: {
+      kind: "typed", command: { registryVersion: 1, name: payloadValue.schema.replace("/v1", ""), version: 1 },
+      canonicalPayload: { kind: "inline", size: BigInt(payload.length), bytes: payload },
+      canonicalPayloadDigest: canonicalPayloadDigestV2(payload),
+      baseCas: [{
+        entityRef: { registryVersion: 1, entityKind, canonicalRef },
+        expectedSemanticVersion: null, expectedStateDigest: null
+      }],
+      declaredPathCas: []
+    },
+    claimedMutationSet: mutationSet,
+    claimedSemanticMutationSetDigest: semanticMutationSetDigestV2(mutationSet),
+    claimedSemanticRequestDigest: Buffer.alloc(32)
+  };
+  return { opId: `w4-perf-${suffix}`, envelope: { ...draft, claimedSemanticRequestDigest: semanticRequestDigestV2(draft) } };
+}
+
+function authority(rootDir, env, queueWaitByOp, submitStartedByOp) {
+  return createAuthoritySubmissionService({
+    workspaceId,
+    coordinatorFactory: {
+      create: ({ attribution }) => {
+        const coordinator = makeJournaledWriteCoordinator({
+          rootDir, attribution, commitAuthor: { name: "W4 Benchmark", email: "benchmark@example.test" }, autoMaterialize: false
+        });
+        return {
+          enqueue: (operation) => Effect.gen(function* () {
+            const started = submitStartedByOp.get(operation.opId);
+            if (started === undefined) throw new Error(`submit start missing for ${operation.opId}`);
+            queueWaitByOp.set(operation.opId, performance.now() - started);
+            return yield* coordinator.enqueue(operation);
+          }),
+          flush: coordinator.flush,
+          recover: coordinator.recover
+        };
+      }
+    },
+    tokenVerifier: {
+      verify: async ({ token: presented }) => {
+        if (presented !== token) throw new Error("invalid benchmark token");
+        return {
+          attribution: {
+            actor: { principal: { kind: "person", personId: "person_zeyu" }, executor: { kind: "agent", id: "agent-w4-perf" } },
+            principalSource: { kind: "daemon-authenticated", providerId: "w4-perf", credentialFingerprint: "sha256:redacted" },
+            executorSource: "client-asserted"
+          },
+          claims: {
+            tokenId: "token-w4-perf", issuer: "w4-perf", keyId: "key-w4-perf", workspaceId,
+            deviceId: "device-w4-perf", viewId: "view-w4-perf", actorId: "person_zeyu", executorId: "agent-w4-perf",
+            sessionId: "session-w4-perf", authorityGeneration: 1, channelNonceDigest, protocol,
+            commandScopes: ["repo.document.write"], pathScopes: ["harness/**"], maxBytes: blobBytes * 2, maxOps: 1,
+            issuedAt: "2026-07-14T00:00:00.000Z", notBefore: "2026-07-14T00:00:00.000Z",
+            expiresAt: "2026-07-15T00:00:00.000Z", revocationEpoch: 1
+          }
+        };
+      }
+    },
+    operationRegistry: createInMemoryAuthorityOperationRegistry(),
+    replicaChangeLog: createInMemoryReplicaChangeLog(),
+    publicationInspector: {
+      currentHead: async () => gitOptional(rootDir, env, "rev-parse", "--verify", "HEAD"),
+      inspectPublishedHead: async () => {
+        const row = git(rootDir, env, "rev-list", "--parents", "-n", "1", "HEAD").split(" ");
+        return { commitSha: row[0], parentCommits: row.slice(1) };
+      }
+    },
+    fenceWitness: { assertHeld: async () => undefined },
+    now: () => "2026-07-14T00:00:00.000Z"
+  });
+}
+
+function v1Envelope(opId, operation) {
+  const envelope = { workspaceId, opId, claimedDigest: "pending", command: "repo.document.write", operation, delegationToken: token, channelNonceDigest, protocol };
+  return { ...envelope, claimedDigest: canonicalAuthorityRequestDigest(envelope) };
+}
+
+async function withGit(group, writers, body) {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-w4-perf-"));
+  const env = {
+    ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_AUTHOR_NAME: "W4 Benchmark", GIT_AUTHOR_EMAIL: "benchmark@example.test",
+    GIT_COMMITTER_NAME: "Harness Authority", GIT_COMMITTER_EMAIL: "authority@example.test"
+  };
+  try {
+    execFileSync("git", ["-C", rootDir, "init", "-q"], { env });
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    const harnessRoot = path.join(rootDir, "harness");
+    mkdirSync(harnessRoot, { recursive: true });
+    execFileSync("git", ["-C", harnessRoot, "init", "-q"], { env });
+    if (group === "hosted-small-op") {
+      for (let round = 0; round < rounds; round += 1) {
+        for (let writer = 0; writer < writers; writer += 1) {
+          const ordinal = round * writers + writer;
+          const taskId = `task_${stableId(writers * 100_000 + ordinal + 1)}`;
+          const taskRoot = path.join(harnessRoot, "tasks", taskId);
+          mkdirSync(taskRoot, { recursive: true });
+          writeFileSync(path.join(taskRoot, "INDEX.md"), `# ${taskId}\n`, "utf8");
+        }
+      }
+    }
+    execFileSync("git", ["-C", harnessRoot, "add", "."], { env });
+    execFileSync("git", ["-C", harnessRoot, "commit", "--allow-empty", "-m", "test: initialize W4 benchmark"], { env });
+    return await body({ rootDir, env });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function sessionManifest(sessionId, body) {
+  const sha = sha256Text(body);
+  return {
+    schema: "session-entity/v1", sessionId, lifecycle: "sealed", archiveStatus: "complete", runtime: "codex", source: "runtime",
+    detectedAt: "2026-07-14T00:00:00.000Z", exportedAt: "2026-07-14T00:01:00.000Z",
+    bodyRef: {
+      store: "authored-cas/v1", ref: `harness/objects/sha256/${sha.slice(0, 2)}/${sha.slice(2)}`,
+      sha256: sha, size: Buffer.byteLength(body), mediaType: "text/markdown; charset=utf-8"
+    },
+    snapshot: {
+      capturedAt: "2026-07-14T00:01:00.000Z", completeness: "complete", captureRange: { messageCount: 1 },
+      privacyScan: { scannerVersion: "w4-perf", passed: true, findings: [] }
+    }
+  };
+}
+
+function executionRecord(taskId, executionId) {
+  return {
+    schema: "execution/v2", execution_id: executionId, task_ref: `task/${taskId}`, state: "active",
+    primary_actor: { principal: { personId: "person_zeyu" }, executor: { kind: "agent", id: "agent-w4-perf" }, responsibleHuman: "person_zeyu" },
+    claimed_at: "2026-07-14T00:00:00.000Z", submitted_at: null, closed_at: null,
+    session_bindings: [], outputs: [], submission: null
+  };
+}
+
+function reviewRecord(taskId, executionId, reviewId) {
+  return {
+    schema: "review/v2", review_id: reviewId, task_ref: `task/${taskId}`, execution_ref: `execution/${taskId}/${executionId}`,
+    reviewer_actor: { principal: { personId: "person_reviewer" }, executor: { kind: "agent", id: "agent-reviewer" }, responsibleHuman: "person_reviewer" },
+    reviewer_session_ref: "session/reviewer-w4", findings: "W4 performance review.", evidence_checked: [],
+    rationale: "The hosted write is measured.", verdict: "approved", archive_warnings_acknowledged: true,
+    reviewed_at: "2026-07-14T00:15:00.000Z"
+  };
+}
+
+function fixedBody(size, suffix) {
+  const prefix = `# ${suffix}\n`;
+  return `${prefix}${"x".repeat(Math.max(0, size - Buffer.byteLength(prefix)))}`;
+}
+
+function stableId(value) {
+  const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+  let remaining = BigInt(value);
+  let result = "";
+  do {
+    result = alphabet[Number(remaining % 32n)] + result;
+    remaining /= 32n;
+  } while (remaining > 0n);
+  return result.padStart(26, "0").slice(-26);
+}
+
+function summary(values) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return { p50Ms: round(percentile(sorted, 0.5)), p95Ms: round(percentile(sorted, 0.95)), maxMs: round(sorted.at(-1) ?? 0), samplesMs: values.map(round) };
+}
+
+function percentile(sorted, quantile) { return sorted.length === 0 ? 0 : sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * quantile) - 1))]; }
+function round(value) { return Math.round(value * 100) / 100; }
+function fixedHex(value, length) { return value.toString(16).padStart(length, "0").slice(-length); }
+function integerOption(name, fallback) { const i = process.argv.indexOf(name); if (i < 0) return fallback; const value = Number(process.argv[i + 1]); if (!Number.isInteger(value) || value <= 0) throw new Error(`${name} invalid`); return value; }
+function integerListOption(name, fallback) { const i = process.argv.indexOf(name); if (i < 0) return fallback; const values = String(process.argv[i + 1]).split(",").map(Number); if (values.some((value) => !Number.isInteger(value) || value <= 0)) throw new Error(`${name} invalid`); return values; }
+function enumListOption(name, allowed, fallback) { const i = process.argv.indexOf(name); if (i < 0) return fallback; const values = String(process.argv[i + 1]).split(","); if (values.some((value) => !allowed.includes(value))) throw new Error(`${name} invalid`); return [...new Set(values)]; }
+function git(rootDir, env, ...args) { return execFileSync("git", ["-C", path.join(rootDir, "harness"), ...args], { encoding: "utf8", env }).trim(); }
+function gitOptional(rootDir, env, ...args) { try { return git(rootDir, env, ...args); } catch { return null; } }
+function gitAt(cwd, ...args) { return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim(); }


### PR DESCRIPTION
# English

## Summary

SME wave W4 (charter task_01KXCZ8C1B): session, execution, and review become typed-only v2-writable kinds. Per-action typed requests (session export/sync/archive, execution claim/submit/close, review create/dismiss/record) are decoded by the authority, which recomputes the exact mutation set; session compiles a composite manifest + immutable CAS body, execution/review compile hosted documents into a typed StoragePlan. All three carry the **DEFER-TYPED-ONLY** disposition: these machine-owned surfaces reject transparent canonical saves (generic doc-sync is fail-closed on `sessions/*.md`, `tasks/*/executions/*.md`, `tasks/*/reviews/*.md`); a missing codec yields `SEMANTIC_DIFF_REQUIRED`, never a host fallback. This wave does not open transparent writes (W5 owns transparent semanticDiff for the other five kinds; these three stay permanently machine-owned). v2-writable now spans all 8 kinds.

This PR also consolidates 10 authority helper functions that had been copy-pasted across the W2/W3/W4 compiler files into a shared `semantic-authority-helpers-v2.ts` module (see What Changed) — a DRY fix that the `check-duplicate-definitions` gate correctly required.

## What Changed

- `packages/application/src/authority/session-execution-review-command-v2.ts`, `session-execution-review-semantic-compiler-v2.ts` (new): typed command codec + per-action authority compiler for the 9 session/execution/review actions.
- `packages/application/src/doc-sync.ts`: `typedOnlyMachineSurfaceReason(path)` rejects generic doc-sync / transparent save on session/execution/review machine-owned paths with a "requires a typed command" reason — the DEFER-TYPED-ONLY enforcement.
- `packages/kernel/src/entity/{session,execution,review}-declaration.ts`: `mutationContract` moves deferred → ready (`session: [export,sync,archive]`, `execution: [claim,submit,close]`, `review: [create,dismiss,record]`), actions in the registry entry (W0 single source, no ninth list); `semanticDiff` = `typedOnlySemanticDiff` ("machine-owned … reject transparent canonical writes").
- `packages/kernel/src/store/write-journal-commit-summary.ts` (new) + `write-journal-coordinator.ts`, `write-journal-operations.ts`: composite manifest + CAS body journaling for session writes.
- **`packages/application/src/authority/semantic-authority-helpers-v2.ts` (new) + edits to `fact-relation-command-v2.ts`, `fact-relation-semantic-compiler-v2.ts`, `task-decision-module-command-v2.ts`, `task-decision-module-semantic-compiler-v2.ts`, `semantic-mutation-envelope-v2.ts`**: extracts 10 shared pure helpers (strictPayload/exactObject/verifyBaseCas/verifyPathCas/plan/bytesEqual/nullableBytesEqual/stringValue/admission and the payload validators) into one module that W2/W3/W4 all import. **The touch to the already-merged W2/W3 compiler files is a pure local-definition → import refactor — function bodies are unchanged and each kind keeps its own distinctly-named payload dispatcher (no dispatch logic was merged). Verified behavior-preserving: W2/W3/W4 compiler + positive tests 10/10; `check-duplicate-definitions` now passes.**
- Tests + perf: `session-execution-review-authority-admission-v2.test.ts` (six negative controls), `-authority-positive-v2.test.ts` (3-kind single-op publish + four-layer digest), `-semantic-compiler-v2.test.ts` (transparent save → `SEMANTIC_DIFF_REQUIRED`, no host fallback), `tools/perf/session-execution-review-v2-benchmark.mjs`.

## Task And Scope

- Harness task: task_01KXD8H2QFMMA4T203PJZ77AQ5 (SME W4)
- Branch: feat/sme-w4-session-execution-review (rebased onto origin/main 5c0fda17; clean, disjoint from upstream surfaces)
- Public scope: 21 files in kernel/application + tests + tools-perf; zero protected surfaces (verified via `git diff-tree`); does NOT touch the files owned by open PR #727 (execution-completion-service / execution-saga / task-execution-consistency); no check:ci receipt committed
- Out of scope: transparent semanticDiff (W5, for the five non-machine-owned kinds; session/execution/review stay permanently DEFER-TYPED-ONLY)

## Version Impact

- Version: no version change (additive authority write path behind existing wire behavior)
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: SME charter (task_01KXCZ8C1B §5/W4 + §6-9); A0 frozen contract; A1 (#712); W0 (#715); W1 (#719); W2 (#724); W3 (#730); OQ-3 accepted (dec_01KXDHSHZF), OQ-2 accepted (dec_01KXDHT4T0)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none (W5 continues the wave chain)

## Verification

- Base `origin/main` SHA: 5c0fda17
- Branch merge-base with `origin/main`: 5c0fda17 (rebased, behind 0)
- Last `git fetch origin` time: 2026-07-14 (pre-push, same session)
- Sync method: rebase (clean; upstream commits disjoint from this kernel/application authority surface)
- Public diff command: `git diff 5c0fda17..<merge-head>`
- Private evidence commit/path: harness/tasks/task_01KXD8H2QFMMA4T203PJZ77AQ5-.../ (task_plan invariants; review.md CEO semantic acceptance + paired perf; artifacts/perf-paired-corroboration.json)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending (attached by CI on this PR)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check` (via `check:ci`, functionally 12/13 in worktree; the one red is supply-chain = incomplete worktree node_modules — the main-repo-root `check-supply-chain` passes and this PR touches no package.json/lock, so a fresh cloud `npm ci` passes it)
- [x] `npm run typecheck`
- [x] `npm test` (six negative controls; 3-kind single-op publish + four-layer digest; transparent save → SEMANTIC_DIFF_REQUIRED; explicit `HARNESS_DAEMON_MODE=local`; W2/W3/W4 compiler+positive 10/10 after the shared-helper refactor)
- [x] `npm run harness:check-duplicate-definitions` (passes — the copy-pasted helpers are consolidated)
- [x] `npm run harness:check-import-boundaries` (via `check:ci`)
- [x] `npm run harness:check-package-policy` (via `check:ci`, green with GITHUB env)
- [ ] GitHub Actions `rewrite-ci` passed

Performance — CEO paired relative-overhead corroboration (dec_01KXE36A4V; 10 rounds across two load regimes, median):

| group | N | W4/A1 ratio | net-new compile p95 | net-new fraction |
|---|---:|---:|---:|---:|
| hosted-small-op | 2 | 0.914 | 0.89ms | 0.14% |
| hosted-small-op | 4 | 1.050 | 0.52ms | 0.05% |
| hosted-small-op | 8 | 1.169 | 0.77ms | 0.04% |
| session-cas-blob | 2 | 1.203 | 2.33ms | 0.27% |
| session-cas-blob | 4 | 1.419 | 1.56ms | 0.11% |
| session-cas-blob | 8 | 1.410 | 3.99ms | 0.16% |

W4's net-new typed-compiler logic is ≤ 4.37ms p95 (≤ 0.27% of end-to-end) everywhere — no measurable logic overhead. hosted-small-op (comparable to A1's small write) stays at 0.89–1.17× baseline. The session-cas-blob 1.2–1.4× is **not a regression**: it is the physical weight of writing a 64 KiB CAS blob + manifest (2 targets, `--blob-bytes 65536`) versus A1's few-byte single-target write (verified by reading both benchmark payloads); A1 is not a valid same-workload proxy for CAS-blob writes. The charter §4 operative gate — slow CAS blobs must not block disjoint small ops beyond A1 p95 — passes, since hosted-small-op stays at baseline.

---

# 中文

## 摘要

SME W4 波次（charter task_01KXCZ8C1B）：session、execution、review 成为 typed-only v2-writable kind。逐 action typed request（session export/sync/archive、execution claim/submit/close、review create/dismiss/record）由 authority 重算 exact mutations；session 编译 composite manifest + immutable CAS body，execution/review 编译 hosted document 为 typed StoragePlan。三 kind 均带 **DEFER-TYPED-ONLY** disposition：machine-owned surface 拒 transparent canonical save（generic doc-sync 对 `sessions/*.md`、`tasks/*/executions/*.md`、`tasks/*/reviews/*.md` fail-closed），缺 codec 走 `SEMANTIC_DIFF_REQUIRED` 非 host fallback。本波不开透明写（W5 owns 其余五 kind 的透明 semanticDiff；这三 kind 永久 machine-owned）。v2-writable 现覆盖全 8 kind。

本 PR 另把 W2/W3/W4 复制粘贴的 10 个 authority helper 收敛进共享模块 `semantic-authority-helpers-v2.ts`——`check-duplicate-definitions` gate 正确要求的 DRY 修复。

## 变更内容

- `authority/session-execution-review-command-v2.ts`、`session-execution-review-semantic-compiler-v2.ts`（新）：9 个 session/execution/review action 的 typed codec + 逐 action authority compiler。
- `doc-sync.ts`：`typedOnlyMachineSurfaceReason(path)` 对 session/execution/review machine-owned 路径拒 generic doc-sync / transparent save（"requires a typed command"）——DEFER-TYPED-ONLY 强制。
- `kernel/entity/{session,execution,review}-declaration.ts`：`mutationContract` deferred → ready（action 落 registry entry，W0 单一源，无第九名单）；`semanticDiff` = `typedOnlySemanticDiff`（machine-owned reject transparent）。
- `kernel/store/write-journal-commit-summary.ts`（新）+ `write-journal-coordinator.ts`、`write-journal-operations.ts`：session 写的 composite manifest + CAS body journaling。
- **`authority/semantic-authority-helpers-v2.ts`（新）+ 改 W2 fact-relation / W3 task-decision-module / envelope 文件**：抽 10 个共享纯 helper 到一个模块供 W2/W3/W4 import。**触碰已合入的 W2/W3 compiler 文件是纯"本地定义→import"重构——函数体不变，各 kind 保留独立命名的 payload dispatcher（未合并 dispatch 逻辑）。已验行为不变：W2/W3/W4 compiler+positive 10/10；check-duplicate-definitions 现 passed。**
- 测试+性能：admission（六负控）/positive（三 kind 单 op+四层 digest）/compiler（transparent save→SEMANTIC_DIFF_REQUIRED 无 host fallback）+ benchmark。

## 任务与范围

- Harness task：task_01KXD8H2QFMMA4T203PJZ77AQ5（SME W4）
- 分支：feat/sme-w4-session-execution-review（rebase 至 origin/main 5c0fda17；干净，与上游面不相交）
- 公开范围：21 文件；零受保护面（diff-tree 口径）；未碰 open PR #727 拥有的文件（execution-completion-service/execution-saga/task-execution-consistency）；无误 commit 回执
- 范围外：transparent semanticDiff（W5，其余五 kind；session/execution/review 永久 DEFER-TYPED-ONLY）

## 版本影响

- 版本：无版本变更（既有 wire 行为背后的 additive authority 写路径）
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权依据：SME charter（task_01KXCZ8C1B §5/W4 + §6-9）；A0 冻结契约；A1（#712）；W0（#715）；W1（#719）；W2（#724）；W3（#730）；OQ-3 已接受（dec_01KXDHSHZF）、OQ-2 已接受（dec_01KXDHT4T0）
- 机器检查边界：本 PR 仅断言声明存在；声明是否真实充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无（W5 继续波次链）

## 验证

- Base `origin/main` SHA：5c0fda17
- 分支与 `origin/main` merge-base：5c0fda17（已 rebase，behind 0）
- 最近 `git fetch origin` 时间：2026-07-14（push 前，同一会话）
- 同步方式：rebase（干净；上游 commit 与本面不相交）
- 公开 diff 命令：`git diff 5c0fda17..<merge-head>`
- 私有证据路径：harness/tasks/task_01KXD8H2QFMMA4T203PJZ77AQ5-.../（plan 不变量、review.md CEO 语义验收 + paired 性能坐实、artifacts/perf-paired-corroboration.json）
- 复选框状态同英文块（check:ci worktree 功能层 12/13，唯一红 supply-chain=worktree node_modules 不完整，主仓根 check-supply-chain passed + 本 PR 无 package.json 改动 → 云端 fresh npm ci 会过；check-duplicate-definitions passed；六负控；transparent save→SEMANTIC_DIFF_REQUIRED；W2/W3/W4 compiler+positive 10/10）

性能——CEO paired 相对开销坐实（dec_01KXE36A4V；10 轮跨两负载取中位）：W4 净新增 typed-compiler 逻辑 p95 ≤4.37ms（占端到端 ≤0.27%，每格）——零可测逻辑开销；hosted-small-op（与 A1 可比小写）0.89-1.17× ≈ baseline；session-cas-blob 1.2-1.4× **非回归**=写 64 KiB CAS blob+manifest（2 target，--blob-bytes 65536）vs A1 几字节单 target 的固有物理重量（验 benchmark 载荷坐实），A1 对 CAS-blob 写非可比 proxy；charter §4 操作性门（CAS blob 不阻塞 disjoint 小写）PASS。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
