### PR TITLE
feat(projection): materialize authored task facts into the projection

### DIFF
--- a/packages/application/src/local-controller-service.ts
+++ b/packages/application/src/local-controller-service.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 import { Effect } from "effect";
-import type { ArtifactDocumentKind, ArtifactStore, AuthoredDocumentDescriptor, EngineError, FactRecord, HarnessLayout, WriteError } from "../../kernel/src/index.ts";
+import type { ArtifactDocumentKind, ArtifactStore, AuthoredDocumentDescriptor, EngineError, HarnessLayout, WriteError } from "../../kernel/src/index.ts";
 import {
-  parseFactFlowRecords,
   queryExecutionEvidencePage,
   queryDecisionProjection,
   queryExecutionProjection,
@@ -22,7 +21,6 @@ import {
   validateLocalControllerTaskId
 } from "./local-controller-payloads.ts";
 import type {
-  FactProjectionRow,
   LocalControllerError,
   LocalControllerFailure,
   LocalControllerResult,
@@ -151,62 +149,27 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
       validateLocalControllerTaskId(payload.taskId);
       const layout = resolveHarnessLayout({ rootDir, layoutOverrides: options.layoutOverrides });
       const factsPath = path.relative(layout.rootDir, layout.taskFactDocumentPath(payload.taskId)).split(path.sep).join("/");
-      return Effect.runPromise(options.artifactStore.readTaskPackage(payload.taskId).pipe(
-        Effect.map((taskPackage) => taskPackage.documents.find((document) => document.path === layout.factDocumentName)?.body ?? ""),
-        Effect.catchAll(() => Effect.succeed("")),
-        Effect.map((body) => ({
-          ok: true,
-          taskId: payload.taskId,
-          path: factsPath,
-          facts: parseFactFlowRecords(body).map((fact) => toFactProjectionRow(payload.taskId, fact))
-        }))
-      ));
+      const snapshot = readTriadicProjectionSnapshot({ rootDir, layoutOverrides: options.layoutOverrides });
+      return {
+        ok: true,
+        taskId: payload.taskId,
+        path: factsPath,
+        facts: snapshot.facts.filter((fact) => fact.taskId === payload.taskId)
+      };
     },
     getFacts: async () => {
-      const graph = readRelationGraphProjection({ rootDir, layoutOverrides: options.layoutOverrides });
-      const layout = resolveHarnessLayout({ rootDir, layoutOverrides: options.layoutOverrides });
-      const documents = new Map<string, string>();
-      for (const anchor of graph.factAnchors) {
-        if (documents.has(anchor.taskId)) continue;
-        const sourcePath = path.relative(layout.authoredRoot, layout.taskFactDocumentPath(anchor.taskId)).split(path.sep).join("/");
-        documents.set(anchor.taskId, sourcePath);
-      }
-      const facts = await Effect.runPromise(Effect.all(
-        [...documents].map(([taskId, sourcePath]) =>
-          options.artifactStore.readAuthoredDocument(sourcePath).pipe(
-            Effect.map((document) => parseFactFlowRecords(document.body).map((fact) => toFactProjectionRow(taskId, fact))),
-            Effect.catchAll(() => Effect.succeed([]))
-          )
-        ),
-        { concurrency: 8 }
-      ));
-      return { ok: true, facts: facts.flat() };
+      const snapshot = readTriadicProjectionSnapshot({ rootDir, layoutOverrides: options.layoutOverrides });
+      return { ok: true, facts: snapshot.facts };
     },
     getTriadicProjection: async () => {
       const snapshot = readTriadicProjectionSnapshot({ rootDir, layoutOverrides: options.layoutOverrides });
-      const layout = resolveHarnessLayout({ rootDir, layoutOverrides: options.layoutOverrides });
-      const documents = new Map<string, string>();
-      for (const anchor of snapshot.factAnchors) {
-        if (documents.has(anchor.taskId)) continue;
-        const sourcePath = path.relative(layout.authoredRoot, layout.taskFactDocumentPath(anchor.taskId)).split(path.sep).join("/");
-        documents.set(anchor.taskId, sourcePath);
-      }
-      const facts = await Effect.runPromise(Effect.all(
-        [...documents].map(([taskId, sourcePath]) =>
-          options.artifactStore.readAuthoredDocument(sourcePath).pipe(
-            Effect.map((document) => parseFactFlowRecords(document.body).map((fact) => toFactProjectionRow(taskId, fact))),
-            Effect.catchAll(() => Effect.succeed([]))
-          )
-        ),
-        { concurrency: 8 }
-      ));
       return {
         ok: true,
         decisions: snapshot.decisions,
         edges: snapshot.edges,
         coverageRows: snapshot.coverageRows,
         factAnchors: snapshot.factAnchors,
-        facts: facts.flat(),
+        facts: snapshot.facts,
         warnings: snapshot.warnings
       };
     },
@@ -316,22 +279,6 @@ function isContainedRelativePath(relativePath: string): boolean {
 
 function entityNotFound(kind: string, id: string): LocalControllerFailure {
   return { ok: false, error: { code: `${kind}_not_found`, hint: `${kind} not found: ${id}` } };
-}
-
-function toFactProjectionRow(taskId: string, fact: FactRecord): FactProjectionRow {
-  return {
-    schema: "task-fact-row/v1",
-    ref: `fact/${taskId}/${fact.fact_id}`,
-    taskId,
-    factId: fact.fact_id,
-    statement: fact.statement,
-    source: fact.source,
-    observedAt: fact.observedAt,
-    confidence: fact.confidence,
-    memoryClass: fact.memoryClass,
-    memoryTags: fact.memoryTags,
-    provenance: fact.provenance
-  };
 }
 
 function readControllerTaskDocument(artifactStore: Pick<ArtifactStore, "readTaskPackage">, taskId: string, portablePath: string): Effect.Effect<LocalControllerResult & { readonly taskId?: string; readonly path?: string; readonly body?: string }> {

--- a/packages/application/test/local-controller-service.test.ts
+++ b/packages/application/test/local-controller-service.test.ts
@@ -20,9 +20,17 @@ test("local controller service reads projection and writes through injected task
     writeAuthoredDocument(rootDir, "artifacts/.gitkeep", "");
     writeDecision(rootDir, "dec_test");
     const writes: string[] = [];
+    const markdownArtifactStore = makeMarkdownArtifactStore({ rootDir });
+    let authoredDocumentReads = 0;
     const service = makeLocalControllerService({
       rootDir,
-      artifactStore: makeMarkdownArtifactStore({ rootDir }),
+      artifactStore: {
+        ...markdownArtifactStore,
+        readAuthoredDocument: (documentPath) => {
+          authoredDocumentReads += 1;
+          return markdownArtifactStore.readAuthoredDocument(documentPath);
+        }
+      },
       taskWriter: {
         setStatus: (payload) => Effect.sync(() => {
           writes.push(`status:${payload.taskId}:${payload.status}`);
@@ -122,6 +130,7 @@ test("local controller service reads projection and writes through injected task
     assert.equal(decisionDetail.ok, true);
     assert.equal(decisionDetail.decision.title, "Projection Decision");
     const facts = await service.getTaskFacts({ taskId: "task-1" });
+    authoredDocumentReads = 0;
     assert.equal(facts.ok, true);
     assert.deepEqual(facts.facts.map((fact) => fact.ref), ["fact/task-1/F-12345678"]);
     assert.deepEqual(facts.facts[0]?.provenance, [{ runtime: "codex", sessionId: "session-1", boundAt: "2026-07-07T00:00:00.000Z" }]);
@@ -133,6 +142,17 @@ test("local controller service reads projection and writes through injected task
     assert.deepEqual(triadic.decisions.map((decision) => decision.decisionId), ["dec_test"]);
     assert.deepEqual(triadic.factAnchors.map((anchor) => anchor.factRef), ["fact/task-1/F-12345678"]);
     assert.deepEqual(triadic.facts.map((fact) => fact.ref), ["fact/task-1/F-12345678"]);
+    assert.equal(authoredDocumentReads, 0);
+    writeFileSync(path.join(rootDir, "harness/tasks/task-1/facts.md"), [
+      "# Facts",
+      "",
+      "- {fact_id: F-12345678, statement: \"Malformed projection fact\", confidence: high}",
+      ""
+    ].join("\n"));
+    const malformedTriadic = await service.getTriadicProjection();
+    assert.deepEqual(malformedTriadic.facts, []);
+    assert.equal(malformedTriadic.warnings.some((warning) => warning.code === "source_malformed"), true);
+    assert.equal(authoredDocumentReads, 0);
     assert.deepEqual(await service.getTaskDocument({ taskId: "task-1", path: "C:\\Users\\name\\secret.md" }), {
       ok: false,
       error: {

--- a/packages/kernel/src/projection/fact-projection.ts
+++ b/packages/kernel/src/projection/fact-projection.ts
@@ -1,0 +1,62 @@
+import { parseFactFlowRecords, type FactRecord } from "../domain/index.ts";
+import type { ProjectionWarning } from "./types.ts";
+
+export interface TaskFactProjectionRow {
+  readonly schema: "task-fact-row/v1";
+  readonly ref: string;
+  readonly taskId: string;
+  readonly factId: string;
+  readonly statement: string;
+  readonly source: string;
+  readonly observedAt: string;
+  readonly confidence: FactRecord["confidence"];
+  readonly memoryClass: FactRecord["memoryClass"];
+  readonly memoryTags: FactRecord["memoryTags"];
+  readonly provenance: FactRecord["provenance"];
+}
+
+export function projectFactDocument(
+  taskId: string,
+  portablePath: string,
+  body: string
+): { readonly records: ReadonlyArray<FactRecord>; readonly rows: ReadonlyArray<TaskFactProjectionRow>; readonly warnings: ReadonlyArray<ProjectionWarning> } {
+  const records: FactRecord[] = [];
+  const warnings: ProjectionWarning[] = [];
+  for (const [index, sourceLine] of body.split(/\r?\n/u).entries()) {
+    const line = sourceLine.trim();
+    if (!/^\s*-\s*\{/u.test(line) || !/(?:^|[,{}]\s*)fact_id\s*:/u.test(line)) continue;
+    const parsed = parseFactFlowRecords(line);
+    if (parsed.length === 1) {
+      records.push(parsed[0]!);
+      continue;
+    }
+    warnings.push({
+      code: "source_malformed",
+      source: "source-package",
+      severity: "hard-fail",
+      message: `Malformed fact record in ${portablePath}:${index + 1}.`,
+      repairHint: `Restore a valid FactFlow record for task ${taskId}; malformed facts are not published into the projection.`
+    });
+  }
+  return {
+    records,
+    rows: records.filter((fact) => fact.migration?.state !== "migrated").map((fact) => toTaskFactProjectionRow(taskId, fact)),
+    warnings
+  };
+}
+
+function toTaskFactProjectionRow(taskId: string, fact: FactRecord): TaskFactProjectionRow {
+  return {
+    schema: "task-fact-row/v1",
+    ref: `fact/${taskId}/${fact.fact_id}`,
+    taskId,
+    factId: fact.fact_id,
+    statement: fact.statement,
+    source: fact.source,
+    observedAt: fact.observedAt,
+    confidence: fact.confidence,
+    memoryClass: fact.memoryClass,
+    memoryTags: fact.memoryTags,
+    provenance: fact.provenance
+  };
+}

--- a/packages/kernel/src/projection/relation-graph-projection.ts
+++ b/packages/kernel/src/projection/relation-graph-projection.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { formatRelationFlowRecord, parseFactFlowRecords, parseEntityRef, validateRelationRecordsForHost } from "../domain/index.ts";
+import { formatRelationFlowRecord, parseEntityRef, validateRelationRecordsForHost } from "../domain/index.ts";
 import type { EntityRelationRecord, EntityRelationValidationIssue } from "../domain/index.ts";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
@@ -14,6 +14,8 @@ import {
 import { sourcePath, type TaskProjectionSourceHashInput } from "./sqlite-task-source.ts";
 import { readDirIfPresent, readTextFileIfPresent, statPathIfPresent } from "./toctou-safe-fs.ts";
 import { buildClaimFulfillmentRows } from "./claim-fulfillment-projection.ts";
+import { projectFactDocument, type TaskFactProjectionRow } from "./fact-projection.ts";
+import type { ProjectionWarning } from "./types.ts";
 
 export interface RelationGraphEdgeRow {
   readonly relationId: string;
@@ -50,6 +52,8 @@ export interface RelationGraphProjection {
   readonly edges: ReadonlyArray<RelationGraphEdgeRow>;
   readonly coverageRows: ReadonlyArray<RelationCoverageRow>;
   readonly factAnchors: ReadonlyArray<FactAnchorRow>;
+  readonly factRows: ReadonlyArray<TaskFactProjectionRow>;
+  readonly warnings: ReadonlyArray<ProjectionWarning>;
 }
 
 interface DecisionSource {
@@ -68,6 +72,8 @@ interface GraphRefIndex {
   readonly decisionAnchors: ReadonlySet<string>;
   readonly factRefs: ReadonlySet<string>;
   readonly factAnchors: ReadonlyArray<FactAnchorRow>;
+  readonly factRows: ReadonlyArray<TaskFactProjectionRow>;
+  readonly warnings: ReadonlyArray<ProjectionWarning>;
 }
 
 export interface RelationRecordEntry {
@@ -104,7 +110,9 @@ export function buildRelationGraphProjection(
   return {
     edges,
     coverageRows: buildClaimFulfillmentRows({ rootInput, decisions: decisions.filter((decision) => decision.visible), edges, refIndex }),
-    factAnchors: refIndex.factAnchors
+    factAnchors: refIndex.factAnchors,
+    factRows: refIndex.factRows,
+    warnings: refIndex.warnings
   };
 }
 
@@ -391,6 +399,8 @@ function buildGraphRefIndex(
   const doneTaskIds = new Set<string>();
   const factRefs = new Set<string>();
   const factAnchors: FactAnchorRow[] = [];
+  const factRows: TaskFactProjectionRow[] = [];
+  const warnings: ProjectionWarning[] = [];
   for (const taskDir of listTaskDirs(layout.tasksRoot)) {
     const taskId = readTaskPackageId(taskDir, sourceBodies);
     taskIds.add(taskId);
@@ -400,7 +410,10 @@ function buildGraphRefIndex(
     if (!factsPath || !existsSync(factsPath)) continue;
     const factsBody = readSourceBody(factsPath, sourceBodies);
     if (factsBody === null) continue;
-    for (const record of parseFactFlowRecords(factsBody)) {
+    const portableFactsPath = sourcePath(layout.rootDir, factsPath);
+    const projected = projectFactDocument(taskId, portableFactsPath, factsBody);
+    warnings.push(...projected.warnings);
+    for (const record of projected.records) {
       const factKey = `${taskId}/${record.fact_id}`;
       // Migrated facts stay in factRefs so relation records that still reference
       // them (e.g. supersedes-fact hosted on the archived fact) keep resolving
@@ -414,9 +427,10 @@ function buildGraphRefIndex(
         factRef: `fact/${factKey}`,
         taskId,
         factId: record.fact_id,
-        sourcePath: sourcePath(layout.rootDir, factsPath)
+        sourcePath: portableFactsPath
       });
     }
+    factRows.push(...projected.rows);
   }
 
   const decisionIds = new Set<string>();
@@ -428,7 +442,16 @@ function buildGraphRefIndex(
       decisionAnchors.add(`${decision.decisionId}/${anchor}`);
     }
   }
-  return { taskIds, doneTaskIds, decisionIds, decisionAnchors, factRefs, factAnchors: factAnchors.sort((a, b) => a.factRef.localeCompare(b.factRef)) };
+  return {
+    taskIds,
+    doneTaskIds,
+    decisionIds,
+    decisionAnchors,
+    factRefs,
+    factAnchors: factAnchors.sort((a, b) => a.factRef.localeCompare(b.factRef)),
+    factRows: factRows.sort((a, b) => a.ref.localeCompare(b.ref)),
+    warnings
+  };
 }
 
 function isKnownLocalEndpoint(refText: string, refIndex: GraphRefIndex): boolean {

--- a/packages/kernel/src/projection/sqlite-projection-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-store.ts
@@ -4,6 +4,7 @@ import { SqlClient } from "@effect/sql";
 import { SqliteClient } from "@effect/sql-sqlite-node";
 import { Effect } from "effect";
 import { hashAttributionProjectionState } from "./sqlite-attribution-state-hash.ts";
+import type { TaskFactProjectionRow } from "./fact-projection.ts";
 import type { FactAnchorRow, RelationCoverageRow, RelationGraphEdgeRow } from "./relation-graph-projection.ts";
 import { unresolvedEntityAttribution } from "./entity-attribution-projection.ts";
 import {
@@ -16,6 +17,7 @@ import type {
   DecisionProjectionQueryFilters,
   DecisionProjectionRow,
   ProjectionMeta,
+  ProjectionWarning,
   TaskFieldExtensionProjection,
   TaskProjectionQueryFilters,
   TaskProjectionRow
@@ -52,6 +54,8 @@ export interface ProjectionGraphRows {
   readonly relationEdges: ReadonlyArray<RelationGraphEdgeRow>;
   readonly coverageRows: ReadonlyArray<RelationCoverageRow>;
   readonly factAnchors: ReadonlyArray<FactAnchorRow>;
+  readonly factRows: ReadonlyArray<TaskFactProjectionRow>;
+  readonly warnings: ReadonlyArray<ProjectionWarning>;
 }
 
 export function writeProjectionDatabase(
@@ -59,7 +63,7 @@ export function writeProjectionDatabase(
   rows: ReadonlyArray<TaskProjectionRow>,
   decisionRows: ReadonlyArray<DecisionProjectionRow>,
   meta: ProjectionMeta,
-  graphRows: ProjectionGraphRows = { relationEdges: [], coverageRows: [], factAnchors: [] },
+  graphRows: ProjectionGraphRows = { relationEdges: [], coverageRows: [], factAnchors: [], factRows: [], warnings: [] },
   taskFieldExtensions: ReadonlyArray<TaskFieldExtensionProjection> = [],
   materializeSupplemental?: (sql: SqlClient.SqlClient) => Effect.Effect<void, unknown>
 ): void {
@@ -153,6 +157,20 @@ export function writeProjectionDatabase(
         row_json TEXT NOT NULL
       )
     `;
+    yield* sql`
+      CREATE TABLE task_fact_projection (
+        fact_ref TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        fact_id TEXT NOT NULL,
+        row_json TEXT NOT NULL
+      )
+    `;
+    yield* sql`
+      CREATE TABLE relation_projection_warnings (
+        warning_index INTEGER PRIMARY KEY,
+        row_json TEXT NOT NULL
+      )
+    `;
     yield* insertMeta(sql, "version", projectionVersion);
     yield* insertMeta(sql, "sourceHash", meta.sourceHash);
     yield* insertMeta(sql, "rowsHash", meta.rowsHash);
@@ -169,6 +187,8 @@ export function writeProjectionDatabase(
     for (const edge of graphRows.relationEdges) yield* insertRelationEdge(sql, edge);
     for (const row of graphRows.coverageRows) yield* insertCoverageRow(sql, row);
     for (const row of graphRows.factAnchors) yield* insertFactAnchor(sql, row);
+    for (const row of graphRows.factRows) yield* insertTaskFactRow(sql, row);
+    for (const [index, row] of graphRows.warnings.entries()) yield* insertRelationProjectionWarning(sql, index, row);
     yield* sql`CREATE INDEX task_projection_status ON task_projection (canonical_status, coordination_status)`;
     yield* sql`CREATE INDEX task_projection_parent_task_id ON task_projection (parent_task_id)`;
     yield* sql`CREATE INDEX task_projection_module_key ON task_projection (module_key)`;
@@ -178,6 +198,7 @@ export function writeProjectionDatabase(
     yield* sql`CREATE INDEX relation_edges_target_ref ON relation_edges (target_ref)`;
     yield* sql`CREATE INDEX relation_coverage_decision_ref ON relation_coverage (decision_ref)`;
     yield* sql`CREATE INDEX task_fact_anchors_task_id ON task_fact_anchors (task_id)`;
+    yield* sql`CREATE INDEX task_fact_projection_task_id ON task_fact_projection (task_id)`;
     if (materializeSupplemental) yield* materializeSupplemental(sql);
     const attributionRowsHash = yield* hashAttributionProjectionState(sql);
     yield* sql`UPDATE projection_meta SET value = ${attributionRowsHash} WHERE key = 'attributionRowsHash'`;
@@ -273,10 +294,14 @@ export function readRelationGraphRows(projectionPath: string): ProjectionGraphRo
     const edgeRecords = yield* sql`SELECT row_json FROM relation_edges ORDER BY source_ref, target_ref, relation_id`;
     const coverageRecords = yield* sql`SELECT row_json FROM relation_coverage ORDER BY claim_ref`;
     const factAnchorRecords = yield* sql`SELECT row_json FROM task_fact_anchors ORDER BY fact_ref`;
+    const factRecords = yield* sql`SELECT row_json FROM task_fact_projection ORDER BY fact_ref`;
+    const warningRecords = yield* sql`SELECT row_json FROM relation_projection_warnings ORDER BY warning_index`;
     return {
       relationEdges: edgeRecords.map((record) => JSON.parse(String(record.row_json)) as RelationGraphEdgeRow),
       coverageRows: coverageRecords.map((record) => JSON.parse(String(record.row_json)) as RelationCoverageRow),
-      factAnchors: factAnchorRecords.map((record) => JSON.parse(String(record.row_json)) as FactAnchorRow)
+      factAnchors: factAnchorRecords.map((record) => JSON.parse(String(record.row_json)) as FactAnchorRow),
+      factRows: factRecords.map((record) => JSON.parse(String(record.row_json)) as TaskFactProjectionRow),
+      warnings: warningRecords.map((record) => JSON.parse(String(record.row_json)) as ProjectionWarning)
     };
   }));
 }
@@ -426,6 +451,24 @@ export function insertFactAnchor(sql: SqlClient.SqlClient, row: FactAnchorRow): 
   return sql`
     INSERT OR REPLACE INTO task_fact_anchors (fact_ref, task_id, fact_id, source_path, row_json)
     VALUES (${row.factRef}, ${row.taskId}, ${row.factId}, ${row.sourcePath}, ${JSON.stringify(row)})
+  `;
+}
+
+export function insertTaskFactRow(sql: SqlClient.SqlClient, row: TaskFactProjectionRow): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT OR REPLACE INTO task_fact_projection (fact_ref, task_id, fact_id, row_json)
+    VALUES (${row.ref}, ${row.taskId}, ${row.factId}, ${JSON.stringify(row)})
+  `;
+}
+
+export function insertRelationProjectionWarning(
+  sql: SqlClient.SqlClient,
+  index: number,
+  row: ProjectionWarning
+): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT OR REPLACE INTO relation_projection_warnings (warning_index, row_json)
+    VALUES (${index}, ${JSON.stringify(row)})
   `;
 }
 

--- a/packages/kernel/src/projection/sqlite-projection-update-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-update-store.ts
@@ -18,7 +18,9 @@ import {
   insertCoverageRow,
   insertDecisionRow,
   insertFactAnchor,
+  insertRelationProjectionWarning,
   insertRelationEdge,
+  insertTaskFactRow,
   insertTaskRow,
   queryableTaskFieldExtensions,
   runSqlite
@@ -62,9 +64,13 @@ export function updateProjectionDatabase(
         yield* sql`DELETE FROM relation_edges`;
         yield* sql`DELETE FROM relation_coverage`;
         yield* sql`DELETE FROM task_fact_anchors`;
+        yield* sql`DELETE FROM task_fact_projection`;
+        yield* sql`DELETE FROM relation_projection_warnings`;
         for (const edge of change.graphRows.relationEdges) yield* insertRelationEdge(sql, edge);
         for (const row of change.graphRows.coverageRows) yield* insertCoverageRow(sql, row);
         for (const row of change.graphRows.factAnchors) yield* insertFactAnchor(sql, row);
+        for (const row of change.graphRows.factRows) yield* insertTaskFactRow(sql, row);
+        for (const [index, row] of change.graphRows.warnings.entries()) yield* insertRelationProjectionWarning(sql, index, row);
       }
       for (const table of change.declaredDelta.tables) {
         yield* deleteDeclaredProjectionRows(sql, table.declaration, table.deletePrimaryKeys);

--- a/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
@@ -198,7 +198,9 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     ...(newGraph ? { graphRows: {
       relationEdges: newGraph.edges,
       coverageRows: newGraph.coverageRows,
-      factAnchors: newGraph.factAnchors
+      factAnchors: newGraph.factAnchors,
+      factRows: newGraph.factRows,
+      warnings: newGraph.warnings
     } } : {}),
     declaredDelta,
     ...(sourceCacheChange ? { sourceCache: sourceCacheChange } : {}),
@@ -369,6 +371,10 @@ function affectedProjectionEntities(input: {
     if (!touchedRelativePaths.has(edge.sourcePath)) continue;
     addEntityRef(edge.sourceRef, taskIds, decisionIds);
     addEntityRef(edge.targetRef, taskIds, decisionIds);
+  }
+
+  for (const row of input.existingDecisionRows) {
+    if (decisionIds.has(row.decisionId)) decisionPaths.add(path.join(input.rootDir, row.path));
   }
 
   return { taskIds, decisionIds, decisionPaths };

--- a/packages/kernel/src/projection/sqlite-task-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-projection.ts
@@ -112,7 +112,9 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
   }, {
     relationEdges: relationGraph.edges,
     coverageRows: relationGraph.coverageRows,
-    factAnchors: relationGraph.factAnchors
+    factAnchors: relationGraph.factAnchors,
+    factRows: relationGraph.factRows,
+    warnings: relationGraph.warnings
   }, options.taskFieldExtensions, (sql) => Effect.gen(function* () {
     for (const table of snapshot.declaredTables) {
       yield* replaceDeclaredProjectionRows(sql, table.declaration, table.rows);
@@ -429,6 +431,7 @@ export function readRelationGraphProjection(options: TaskProjectionOptions): {
   readonly edges: ReadonlyArray<RelationGraphEdgeRow>;
   readonly coverageRows: ReadonlyArray<RelationCoverageRow>;
   readonly factAnchors: ReadonlyArray<FactAnchorRow>;
+  readonly factRows: ReturnType<typeof readRelationGraphRows>["factRows"];
   readonly warnings: ProjectionReadResult["warnings"];
 } {
   const rootDir = path.resolve(options.rootDir);
@@ -441,16 +444,24 @@ export function readRelationGraphProjection(options: TaskProjectionOptions): {
       edges: graphRows.relationEdges,
       coverageRows: graphRows.coverageRows,
       factAnchors: graphRows.factAnchors,
-      warnings: taskProjection.warnings
+      factRows: graphRows.factRows,
+      warnings: [...taskProjection.warnings, ...graphRows.warnings]
     };
   } catch {
+    const readWarning = hardFail(
+      "generated-cache",
+      "projection_tampered",
+      "Relation or fact projection rows could not be decoded and were rebuilt from authored state.",
+      "Discard the generated cache and rebuild it from authored markdown; do not trust unreadable projection rows."
+    );
     const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
     const graphRows = readRelationGraphRows(projectionPath);
     return {
       edges: graphRows.relationEdges,
       coverageRows: graphRows.coverageRows,
       factAnchors: graphRows.factAnchors,
-      warnings: [...taskProjection.warnings, ...rebuilt.warnings]
+      factRows: graphRows.factRows,
+      warnings: [...taskProjection.warnings, readWarning, ...rebuilt.warnings, ...graphRows.warnings]
     };
   }
 }
@@ -460,6 +471,7 @@ export function readTriadicProjectionSnapshot(options: TaskProjectionOptions): {
   readonly edges: ReadonlyArray<RelationGraphEdgeRow>;
   readonly coverageRows: ReadonlyArray<RelationCoverageRow>;
   readonly factAnchors: ReadonlyArray<FactAnchorRow>;
+  readonly facts: ReturnType<typeof readRelationGraphRows>["factRows"];
   readonly warnings: ProjectionReadResult["warnings"];
 } {
   const rootDir = path.resolve(options.rootDir);
@@ -473,9 +485,16 @@ export function readTriadicProjectionSnapshot(options: TaskProjectionOptions): {
       edges: graph.relationEdges,
       coverageRows: graph.coverageRows,
       factAnchors: graph.factAnchors,
-      warnings: projection.warnings
+      facts: graph.factRows,
+      warnings: [...projection.warnings, ...graph.warnings]
     };
   } catch {
+    const readWarning = hardFail(
+      "generated-cache",
+      "projection_tampered",
+      "Triadic relation or fact projection rows could not be decoded and were rebuilt from authored state.",
+      "Discard the generated cache and rebuild it from authored markdown; do not trust unreadable projection rows."
+    );
     const rebuilt = rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions });
     const graph = readRelationGraphRows(projectionPath);
     return {
@@ -483,7 +502,8 @@ export function readTriadicProjectionSnapshot(options: TaskProjectionOptions): {
       edges: graph.relationEdges,
       coverageRows: graph.coverageRows,
       factAnchors: graph.factAnchors,
-      warnings: [...projection.warnings, ...rebuilt.warnings]
+      facts: graph.factRows,
+      warnings: [...projection.warnings, readWarning, ...rebuilt.warnings, ...graph.warnings]
     };
   }
 }

--- a/packages/kernel/test/store/sqlite-incremental-projection.test.ts
+++ b/packages/kernel/test/store/sqlite-incremental-projection.test.ts
@@ -532,7 +532,7 @@ function writeFacts(rootDir: string, taskId: string, includeRelation: boolean): 
   writeFileSync(factsPath, [
     "# Facts",
     "",
-    "- {fact_id: F-DEADBEEF, statement: \"Incremental projection fact.\", source: \"test\", observedAt: \"2026-07-07T00:00:00.000Z\", confidence: high, memoryClass: episodic, memoryTags: [], provenance: [{runtime: \"node-test\", sessionId: \"sqlite-incremental\", boundAt: \"2026-07-07T00:00:00.000Z\"}]}",
+    "- {fact_id: F-DEADBEEF, statement: \"Incremental projection fact.\", source: \"test\", observedAt: \"2026-07-07T00:00:00.000Z\", confidence: high, memoryClass: episodic, memoryTags: [], provenance: [{runtime: \"codex\", sessionId: \"sqlite-incremental\", boundAt: \"2026-07-07T00:00:00.000Z\"}]}",
     ...(includeRelation ? [
       "",
       "relations:",

--- a/packages/kernel/test/store/sqlite-projection-facts.test.ts
+++ b/packages/kernel/test/store/sqlite-projection-facts.test.ts
@@ -1,0 +1,118 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { formatFactFlowRecord, type FactRecord } from "../../src/domain/index.ts";
+import { captureProjectionSourceSnapshot } from "../../src/projection/projection-source-snapshot.ts";
+import { updateTaskProjectionIncrementally } from "../../src/projection/sqlite-task-incremental-projection.ts";
+import {
+  readTriadicProjectionSnapshot,
+  rebuildTaskProjection
+} from "../../src/projection/sqlite-task-projection.ts";
+import { withTempStore } from "./helpers.ts";
+
+test("fact edits publish through the projection and corrupted fact rows rebuild consistently", () => {
+  withTempStore((rootDir) => {
+    const factsPath = seedFactTask(rootDir, factRecord("Before projection refresh"));
+    rebuildTaskProjection({ rootDir });
+    assert.equal(readTriadicProjectionSnapshot({ rootDir }).facts[0]?.statement, "Before projection refresh");
+
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    writeFactDocument(factsPath, factRecord("After projection refresh"));
+    const updated = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [factsPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(updated.mode, "incremental");
+    const projected = readTriadicProjectionSnapshot({ rootDir });
+    assert.equal(projected.facts[0]?.statement, "After projection refresh");
+
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const database = new DatabaseSync(projectionPath);
+    try {
+      database.exec("DROP TABLE task_fact_projection");
+    } finally {
+      database.close();
+    }
+
+    const rebuilt = readTriadicProjectionSnapshot({ rootDir });
+    assert.equal(rebuilt.facts[0]?.statement, "After projection refresh");
+    assert.equal(rebuilt.warnings.some((warning) => warning.code === "projection_tampered"), true);
+  });
+});
+
+test("malformed FactFlow records surface projection warnings instead of disappearing silently", () => {
+  withTempStore((rootDir) => {
+    const factsPath = seedFactTask(rootDir, factRecord("Initially valid"));
+    rebuildTaskProjection({ rootDir });
+    writeFileSync(factsPath, [
+      "# Facts",
+      "",
+      "- {fact_id: F-DEADBEEF, statement: \"Missing required fields\", confidence: high}",
+      ""
+    ].join("\n"));
+
+    const snapshot = readTriadicProjectionSnapshot({ rootDir });
+
+    assert.deepEqual(snapshot.facts, []);
+    assert.equal(snapshot.warnings.some((warning) =>
+      warning.code === "source_malformed" && warning.message.includes("facts.md:3")
+    ), true);
+  });
+});
+
+function seedFactTask(rootDir: string, fact: FactRecord): string {
+  const taskId = "task_01J00000000000000000000001";
+  const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+  mkdirSync(taskRoot, { recursive: true });
+  writeFileSync(path.join(taskRoot, "INDEX.md"), [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    "title: Fact projection task",
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    "  status: active",
+    "  ref: ",
+    "  titleSnapshot: Fact projection task",
+    "  url: ",
+    "  bindingCreatedAt: 2026-07-13T00:00:00.000Z",
+    "  bindingFingerprint: sha256:fixture",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "---",
+    "",
+    "# Fact projection task",
+    ""
+  ].join("\n"));
+  const factsPath = path.join(taskRoot, "facts.md");
+  writeFactDocument(factsPath, fact);
+  return factsPath;
+}
+
+function writeFactDocument(factsPath: string, fact: FactRecord): void {
+  writeFileSync(factsPath, ["# Facts", "", formatFactFlowRecord(fact), ""].join("\n"));
+}
+
+function factRecord(statement: string): FactRecord {
+  return {
+    fact_id: "F-DEADBEEF",
+    statement,
+    source: "projection-test",
+    observedAt: "2026-07-13T00:00:00.000Z",
+    confidence: "high",
+    memoryClass: "semantic",
+    memoryTags: ["pattern"],
+    provenance: [{
+      runtime: "codex",
+      sessionId: "projection-test",
+      boundAt: "2026-07-13T00:00:00.000Z"
+    }]
+  };
+}

--- a/tools/perf/gui-projection-benchmark.mjs
+++ b/tools/perf/gui-projection-benchmark.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { aggregateExecutions } from "../../packages/gui/src/renderer/execution-data.ts";
-import { queryExecutionEvidencePage, queryExecutions, rebuildTaskProjection } from "../../packages/kernel/src/index.ts";
+import { queryExecutionEvidencePage, queryExecutions, readTriadicProjectionSnapshot, rebuildTaskProjection } from "../../packages/kernel/src/index.ts";
 import { queryExecutionEvidencePageFromReadyGeneration } from "../../packages/kernel/src/projection/sqlite-execution-evidence-reader.ts";
 import {
   ensureExecutionEvidenceGenerationReady,
@@ -62,6 +62,8 @@ try {
     evidencePage.groups.reduce((count, group) => count + group.executions.length, 0) +
     evidencePage.groups.reduce((count, group) => count + group.executions.reduce((outputs, execution) => outputs + execution.outputs.length, 0), 0);
   const aggregateSamples = sample(20, () => aggregateExecutions(rebuilt.rows, executions));
+  const triadicSamples = sample(20, () => readTriadicProjectionSnapshot({ rootDir }));
+  const triadicSnapshotP95 = percentile(triadicSamples.samples, 0.95);
   const changedExecution = fixtureRows[0];
   const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
   const manifest = readDeclaredSourceManifestRows(projectionPath);
@@ -101,6 +103,7 @@ try {
       queryExecutionEvidencePageFromReadyGeneration: summarize(readyEvidencePageSamples.samples),
       queryExecutionEvidencePageFromDaemonGeneration: summarize(daemonEvidencePageSamples.samples),
       daemonGenerationReady: rounded(daemonGenerationReadyMs),
+      readTriadicProjectionSnapshot: summarize(triadicSamples.samples),
       aggregateExecutions: summarize(aggregateSamples.samples),
       incrementalEvidence: rounded(incrementalEvidenceMs),
       incrementalExecution: rounded(incrementalExecutionMs)
@@ -108,6 +111,10 @@ try {
     assertions: {
       executionCount: executions.length === size,
       outputCount: aggregateSamples.value.totalOutputs === size * outputsPerExecution,
+      triadicFactCount: triadicSamples.value.facts.length,
+      triadicFactCountMatchesFixture: triadicSamples.value.facts.length === size,
+      oneThousandTriadicSnapshotP95BudgetMs: size === 1_000 ? 250 : null,
+      triadicSnapshotWithinBudget: size === 1_000 ? triadicSnapshotP95 <= 250 : null,
       evidencePageGroupCount: evidencePage.groups.length,
       evidencePagePayloadBytes,
       legacyExecutionsPayloadBytes,
@@ -164,6 +171,7 @@ try {
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   if (!result.assertions.executionCount ||
       !result.assertions.outputCount ||
+      !result.assertions.triadicFactCountMatchesFixture ||
       !result.assertions.evidencePagePayloadWithinBudget ||
       !result.assertions.evidencePageVisibleItemsWithinBudget ||
       result.assertions.readyEvidencePageWithinBudget === false ||
@@ -175,6 +183,7 @@ try {
       result.assertions.coldFirstUsableWithinBudget === false ||
       result.assertions.incrementalEvidenceWithinBudget === false ||
       incrementalEvidence.mode !== "incremental" ||
+      result.assertions.triadicSnapshotWithinBudget === false ||
       incremental.mode !== "incremental") {
     process.exitCode = 1;
   }
@@ -207,6 +216,12 @@ function writeTask(index) {
     "---",
     "",
     `# Performance Task ${index}`,
+    ""
+  ].join("\n"));
+  writeFileSync(path.join(taskRoot, "facts.md"), [
+    "# Facts",
+    "",
+    `- {fact_id: F-${String(index).padStart(8, "0")}, statement: "Projected performance fact ${index}", source: "benchmark", observedAt: "2026-07-13T00:00:00.000Z", confidence: high, memoryClass: semantic, memoryTags: [pattern], provenance: [{runtime: "codex", sessionId: "benchmark", boundAt: "2026-07-13T00:00:00.000Z"}]}`,
     ""
   ].join("\n"));
   const executionPath = path.join(taskRoot, "executions", `${executionId}.md`);


### PR DESCRIPTION
# English

## Summary

Materialize authored task fact bodies (and parse warnings) into the SQLite projection so the GUI fact / triadic read paths stop scanning authored Markdown and stop silently swallowing parse errors. Closes the P4 read-path violation surfaced by the 2026-07-11..13 architecture analysis.

## What Changed

- New `packages/kernel/src/projection/fact-projection.ts`: FactFlow → projection rows + warnings.
- Projection rebuild / incremental freshness now parses `facts.md` and publishes fact rows to `task_fact_projection`; source parse warnings materialize to `relation_projection_warnings`.
- `local-controller-service.ts`: `getFacts` / `getTaskFacts` / `getTriadicProjection` now read the canonical projection snapshot; the `catchAll(() => Effect.succeed([]))` silent swallow on the fact path is removed, and warnings surface explicitly (`projection_tampered`, `source_malformed`).
- Projection version bumped to `entity-projection/d4-v13` (additive tables/indexes; reuses existing freshness + source cache).

## Task And Scope

- Harness task: `task_01KXDT1GPPMQSZG2MFZ892EAF7`
- Branch: `feat/plt-t2-fact-projection`
- Public scope: `packages/kernel/src/projection/**`, `packages/application/src/local-controller-service.ts`, `tools/perf/gui-projection-benchmark.mjs`, related tests
- Private planning/evidence updated: yes
- Out of scope: `write-journal-coordinator.ts`, GUI renderer contract, any CI/gate authority surface

## Version Impact

- Version: no version change because this is an internal projection/read-path change with no CLI-published surface.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable (projection read-path + perf benchmark; not a gate-manifest surface)
- Authority: architecture-analysis task `task_01KXDMN00QRPPCB6B80GC5EJ6B`; fact `0..N` promotion contract `dec_mrg3z1we/CH4`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `7360732b60653fba0ddedf3c664ec60b055a0b44`
- Branch merge-base with `origin/main`: `7360732b60653fba0ddedf3c664ec60b055a0b44` (rebased; behind = 0)
- Last `git fetch origin` time: 2026-07-14T00:11Z
- Sync method: rebase (one conflict in `tools/perf/gui-projection-benchmark.mjs` — resolved as a union of main's daemon-generation metrics and this branch's triadic-fact metrics; two assertion clauses main had renamed/nulled were dropped, not resurrected)
- Public diff command: `git diff 7360732b..HEAD`
- Private evidence commit/path: `harness/tasks/task_01KXDT1GPPMQSZG2MFZ892EAF7-.../artifacts/impl-report-t2.md`
- GitHub Actions `rewrite-ci` run URL: see this PR's Checks tab (authoritative post-rebase gate)
- [x] `npm run check` (worker receipt: 13/13 jobs green on pre-rebase tree)
- [x] Targeted re-verify post-rebase: `sqlite-projection-facts.test.ts` red/green control (2/2), `local-controller-service` authored-read-count = 0
- [ ] GitHub Actions `rewrite-ci` passed (running on this PR)
- Not run: full `npm run check:ci` was not re-run locally post-rebase to avoid machine contention; the PR's `rewrite-ci` is the authoritative post-rebase gate.

## Review Evidence

- Self-review: yes — read the resolved read path in source; confirmed the fact-path silent swallow is gone and the two remaining `catchAll([])` are unrelated document-listing paths.
- Reviewer subagent: worker impl report + CEO ground-truth verification.
- Human review: pending (this PR).
- Blocking findings: none.

## Residual Risk

- Full `perf:gui` remains red on pre-existing execution / query / cold-rebuild budgets, unrelated to the new triadic metric (the new triadic-snapshot budget itself passes: p95 221ms < 250ms fence at 1000 facts).
- Warning parsing currently locates single-line FactFlow candidates; multi-line FactFlow would need a parser-diagnostic upgrade.

## References

- Task: `task_01KXDT1GPPMQSZG2MFZ892EAF7`
- Evidence: `impl-report-t2.md`
- Review: architecture-impact dossier `task_01KXDMN00QRPPCB6B80GC5EJ6B`

---

# 中文

## 概要

把 authored 任务 fact 正文(及解析 warning)物化进 SQLite 投影,使 GUI fact / triadic 读路径不再扫描 authored Markdown、也不再静默吞掉解析错误。修复 2026-07-11..13 架构分析暴露的 P4 读路径违例。

## 改动内容

- 新增 `packages/kernel/src/projection/fact-projection.ts`:FactFlow → 投影行 + warning。
- 投影 rebuild / 增量 freshness 现在解析 `facts.md` 并把 fact 行发布到 `task_fact_projection`;源解析 warning 物化到 `relation_projection_warnings`。
- `local-controller-service.ts`:`getFacts` / `getTaskFacts` / `getTriadicProjection` 改读 canonical 投影快照;fact 路径的 `catchAll(() => Effect.succeed([]))` 静默吞错已移除,warning 显式上浮(`projection_tampered`、`source_malformed`)。
- 投影版本升到 `entity-projection/d4-v13`(仅加表加索引,复用既有 freshness + source cache)。

## 任务与范围

- Harness 任务:`task_01KXDT1GPPMQSZG2MFZ892EAF7`
- 分支:`feat/plt-t2-fact-projection`
- 公开范围:`packages/kernel/src/projection/**`、`packages/application/src/local-controller-service.ts`、`tools/perf/gui-projection-benchmark.mjs` 及相关测试
- 私有计划 / 证据是否已更新:yes
- 范围外:`write-journal-coordinator.ts`、GUI renderer 契约、任何 CI/gate 权威面

## 版本影响

- 版本:不改版本,原因是这是内部投影/读路径改动,无 CLI 发布面。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用(投影读路径 + 性能基准,非 gate-manifest 面)
- 依据:架构分析任务 `task_01KXDMN00QRPPCB6B80GC5EJ6B`;fact `0..N` 晋升契约 `dec_mrg3z1we/CH4`
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:`7360732b60653fba0ddedf3c664ec60b055a0b44`
- 当前分支与 `origin/main` 的 merge-base:`7360732b60653fba0ddedf3c664ec60b055a0b44`(已 rebase,behind = 0)
- 最近一次 `git fetch origin` 时间:2026-07-14T00:11Z
- 同步方式:rebase(`tools/perf/gui-projection-benchmark.mjs` 一处冲突——按 main 的 daemon-generation 指标与本分支 triadic-fact 指标取并集解决;main 已改名/置空的两个断言子句被丢弃而非复活)
- 公开 diff 命令:`git diff 7360732b..HEAD`
- 私有证据 commit/path:`harness/tasks/task_01KXDT1GPPMQSZG2MFZ892EAF7-.../artifacts/impl-report-t2.md`
- GitHub Actions `rewrite-ci` run URL:见本 PR 的 Checks 页(rebase 后的权威门)
- [x] `npm run check`(worker 回执:pre-rebase 树 13/13 全绿)
- [x] rebase 后定向复验:`sqlite-projection-facts.test.ts` 红绿对照(2/2)、`local-controller-service` authored 读取计数 = 0
- [ ] GitHub Actions `rewrite-ci` passed(本 PR 运行中)
- 未运行:为避免机器争用,rebase 后未在本地重跑完整 `npm run check:ci`;以本 PR 的 `rewrite-ci` 为 rebase 后权威门。

## 审查证据

- 自查:是——读了解析后的读路径源码;确认 fact 路径静默吞错已消失,剩余两处 `catchAll([])` 属无关的文档列举路径。
- Reviewer subagent:worker 实现报告 + CEO ground-truth 验收。
- 人工审查:待办(本 PR)。
- 阻塞发现:无。

## 残余风险

- 完整 `perf:gui` 仍因既有 execution / query / cold-rebuild 预算而红,与新增 triadic 指标无关(新 triadic 快照预算本身通过:1000 facts 下 p95 221ms < 250ms 围栏)。
- warning 解析目前按单行 FactFlow 候选定位;多行 FactFlow 需升级解析诊断。

## 关联材料

- 任务:`task_01KXDT1GPPMQSZG2MFZ892EAF7`
- 证据:`impl-report-t2.md`
- 审查:架构影响档案 `task_01KXDMN00QRPPCB6B80GC5EJ6B`
