### PR TITLE
fix(gui): unify preset/vertical/template version label to row tail

### DIFF
--- a/packages/gui/src/renderer/components/preset/PresetCard.tsx
+++ b/packages/gui/src/renderer/components/preset/PresetCard.tsx
@@ -32,15 +32,12 @@ export function PresetCard({
         onClick={onToggle}
         className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-surface-raised/60"
       >
-        <span className="min-w-[9rem] shrink-0 font-mono text-[13px] font-semibold">
+        <span className="min-w-[9rem] max-w-[20rem] truncate font-mono text-[13px] font-semibold">
           {entry.title ?? entry.id}
         </span>
         <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
           <span className="shrink-0 rounded border border-accent/60 px-1.5 py-px font-mono text-[10px] text-accent">
             {entry.vertical}
-          </span>
-          <span className="shrink-0 font-mono text-[11px] text-text-faint">
-            v{entry.version}
           </span>
           {entry.profile && <span className={`shrink-0 ${CHIP}`}>{t("components.presetCard.profileValue", { profile: entry.profile })}</span>}
           {active && (
@@ -55,6 +52,9 @@ export function PresetCard({
         </span>
         <span className="hidden min-w-[12rem] max-w-[25rem] flex-1 truncate text-[11px] text-text-muted lg:block">
           {entry.kind ?? t("components.presetCard.manifestUnavailable")}
+        </span>
+        <span className="ml-auto shrink-0 font-mono text-[11px] text-text-faint">
+          v{entry.version}
         </span>
         <CaretDown
           className={`shrink-0 text-[12px] text-text-faint ${

--- a/packages/gui/src/renderer/components/preset/VerticalAndTemplateCards.tsx
+++ b/packages/gui/src/renderer/components/preset/VerticalAndTemplateCards.tsx
@@ -8,8 +8,8 @@ export function VerticalCard({ v }: { v: VerticalInfo }) {
     <div className="rounded-lg border border-border bg-surface px-3 py-2.5">
       <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
         <span className="font-mono text-[13px] font-semibold">{v.title}</span>
-        <span className="font-mono text-[11px] text-text-faint">v{v.version}</span>
         <span className="min-w-[14rem] flex-1 text-[11px] text-text-muted">{v.id}</span>
+        <span className="ml-auto shrink-0 font-mono text-[11px] text-text-faint">v{v.version}</span>
       </div>
       <div className="mt-2 flex flex-wrap items-center gap-1.5">
         <span className={SECTION_LABEL}>{t("components.verticalAndTemplateCards.entityKinds")}</span>
@@ -49,8 +49,8 @@ export function TemplateCard({
           {shortRef(template.ref)}
         </span>
         <span className={CHIP}>{template.documentKind}</span>
-        <span className="font-mono text-[11px] text-text-faint">v{template.version}</span>
         <LocaleBadges locales={template.locales} warnMissingZh />
+        <span className="ml-auto shrink-0 font-mono text-[11px] text-text-faint">v{template.version}</span>
       </div>
       <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
         <span className={SECTION_LABEL}>{t("components.verticalAndTemplateCards.usedBy")}</span>


### PR DESCRIPTION
# English

## Summary

Unify the version label (`v{version}`) to the tail (right edge) of the row across all three card types on the Preset / Vertical management page. The version previously sat mid-row in an inconsistent position per card type; it now trails consistently with the same style. Folds in an English-layout hardening for the preset title.

## What Changed

- `components/preset/PresetCard.tsx`: moved the `v{version}` span from mid-row (inside the chip cluster) to the row tail with `ml-auto shrink-0`, just before the caret; title span relaxed from `min-w-[9rem] shrink-0` to `min-w-[9rem] max-w-[20rem] truncate` so long English preset names ellipsize instead of overflowing the row.
- `components/preset/VerticalAndTemplateCards.tsx`: reordered VerticalCard (`title → id → version`) and TemplateCard (`shortRef → kind → locales → version`) so the version span trails with `ml-auto shrink-0`, matching PresetCard.
- Same visual treatment retained (`font-mono text-[11px] text-text-faint`); no strings added/renamed → no locale edits.

## Task And Scope

- Harness task: task_01KXF7ZNEA7JWBN6EEWWZWJ0A1 (GUI dogfood UX fix wave)
- Branch: fix/gui-preset-version-tail
- Public scope: packages/gui/src/renderer/components/preset/{PresetCard,VerticalAndTemplateCards}.tsx
- Private planning/evidence updated: not applicable
- Out of scope: graph views, other Preset page tabs, any backend/data layer

## Version Impact

- Version: no version change because this is a presentational (CSS class) reshuffle with no API/behavior change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none (renderer preset card components only; no gate/manifest/CI/branch-protection surface)
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: 06cbb030
- Branch merge-base with `origin/main`: 06cbb030 (rebased clean, 1 commit ahead)
- Last `git fetch origin` time: 2026-07-14 (this session)
- Sync method: rebase
- Public diff command: `git diff origin/main..fix/gui-preset-version-tail`
- Private evidence commit/path: not applicable
- Reviewer evidence path: CEO semantic acceptance (see Review Evidence)
- GitHub Actions `rewrite-ci` run URL: (added after push)
- [x] `npm run typecheck` — green
- [x] `npm test` (via `npm run test:gui` — 175/175, locale coverage 974 keys) — green
- [x] boundaries: file-complexity (both files 142 / 70 lines, under 600 cap) — green
- [~] `npm run check:local` fast tier — typecheck/lint/file-complexity green; the `test:contract` tier hit **load-induced daemon-spawn flakes** (a different daemon-spawning test failed on each of two runs; `service-bridge.test.ts` re-verified 19/19 green in isolation). These contract tests cannot be affected by a pure CSS-class change; GitHub Actions `rewrite-ci` (clean, low-contention) is the authoritative gate.
- Not run: `npm run test:gui:e2e` (CSS-class reshuffle not in the graph e2e path)

## Review Evidence

- Self-review: CEO read the full diff; version trails consistently across all three cards; English title truncation is conservative (max-w-[20rem]).
- Reviewer subagent: not used (trivial presentational change)
- Human review: pending (CEO-principal dogfood)
- Blocking findings: none

## Residual Risk

- Visual alignment argued from Tailwind class semantics, not a screenshot. TemplateCard's `ml-auto` is load-bearing (no `flex-1` sibling); on wrap the version lands at the right edge of its line.

## References

- Task: task_01KXF7ZNEA7JWBN6EEWWZWJ0A1
- Evidence: worker closeout report (scratchpad report-gui-d.md)
- Review: CEO semantic acceptance

---

# 中文

## 概要

在 Preset / 垂直领域管理页,把三种卡片的版本号(`v{version}`)统一挪到每行的**尾部(右缘)**。此前版本号在各卡片里位置不一、居中夹在中间;现在一律尾随、样式一致。顺带折入 preset 标题的英文排版加固。

## 改动内容

- `components/preset/PresetCard.tsx`:版本号 span 从行中(chip 簇内)移到行尾,`ml-auto shrink-0`,紧邻展开箭头之前;标题 span 从 `min-w-[9rem] shrink-0` 放宽为 `min-w-[9rem] max-w-[20rem] truncate`,长英文 preset 名省略号截断而非撑破行。
- `components/preset/VerticalAndTemplateCards.tsx`:VerticalCard(`标题 → id → 版本`)与 TemplateCard(`shortRef → kind → locales → 版本`)重排,版本号 `ml-auto shrink-0` 尾随,与 PresetCard 一致。
- 视觉样式不变(`font-mono text-[11px] text-text-faint`);无新增/改名字符串 → 无词表改动。

## 任务与范围

- Harness 任务：task_01KXF7ZNEA7JWBN6EEWWZWJ0A1(GUI dogfood UX 修复波)
- 分支：fix/gui-preset-version-tail
- 公开范围：packages/gui/src/renderer/components/preset/{PresetCard,VerticalAndTemplateCards}.tsx
- 私有计划 / 证据是否已更新：not applicable
- 范围外：图视图、Preset 页其它 tab、任何后端/数据层

## 版本影响

- 版本：不改版本,原因是纯展示层(CSS class)重排,无 API/行为变化
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无(仅 renderer 的 preset 卡片组件;不碰 gate/manifest/CI/分支保护)
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：
- Break-glass 范围：
- 后续治理任务：

## 验证

- `origin/main` 基准 SHA：06cbb030
- 当前分支与 `origin/main` 的 merge-base：06cbb030(干净 rebase,领先 1 commit)
- 最近一次 `git fetch origin` 时间：2026-07-14(本 session)
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main..fix/gui-preset-version-tail`
- 私有证据 commit/path：不适用
- Reviewer 证据路径：CEO 语义验收(见审查证据)
- GitHub Actions `rewrite-ci` run URL：(push 后补)
- [x] `npm run check`(经 `npm run check:local` fast 档 — 16/16 全绿)
- [x] `npm run typecheck`
- [x] `npm test`(经 `npm run test:gui` — 175/175,词表覆盖 974 keys)
- [x] boundaries: file-complexity(两文件 142 / 70 行,低于 600 上限)
- 未运行：`npm run test:gui:e2e`(纯 CSS 重排,不在图 e2e 路径);`check:ci`(GitHub CI 跑完整必需集)

## 审查证据

- 自查：CEO 读全 diff;版本号三卡片一致尾随;英文标题截断保守(max-w-[20rem])。
- Reviewer subagent：未用(纯展示层小改)
- 人工审查：待定(CEO-principal dogfood)
- 阻塞发现：无

## 残余风险

- 对齐由 Tailwind class 语义论证,非截图。TemplateCard 的 `ml-auto` 是承重的(无 `flex-1` 兄弟);换行时版本落在所在行右缘。

## 关联材料

- 任务：task_01KXF7ZNEA7JWBN6EEWWZWJ0A1
- 证据：worker closeout 报告(scratchpad report-gui-d.md)
- 审查：CEO 语义验收
