### PR TITLE
fix(gui): ego card scroll always-on + live NodeResizer

### DIFF
--- a/packages/gui/src/renderer/graph/canvasEgoLayout.ts
+++ b/packages/gui/src/renderer/graph/canvasEgoLayout.ts
@@ -171,7 +171,8 @@ export function egoFocusIdOf(ref: string): string {
 }
 
 // 节点尺寸(确定性布局用)。chip 紧凑一条;card 按 kind 分档宽,高按内容估算 +
-// 竖优先地板 + 硬 cap。scrollable 写入 data,EgoNode 据此条件挂 overflow-y-auto。
+// 竖优先地板 + 硬 cap。body 的 overflow 始终由 EgoNode 挂 overflow-y-auto(B1),
+// 这里只算几何尺寸,不再产出 scrollable 标志。
 const CHIP_W = 216;
 const CHIP_H = 46;
 // 内容驱动宽:按 kind 分档(fact 窄 / task 中 / decision 宽),不再是一刀切 360。
@@ -180,7 +181,8 @@ const GAP_X = 72;
 const GAP_Y = 36;
 // 竖优先地板:W:H ≤ 0.85(防横条)。短内容也按此垫高,但不再强制统一比例。
 const W_H_FLOOR = 0.85;
-// 硬 cap:超出则内部滚动(DecisionBody 三段满载刚好留余地)。
+// 硬 cap:节点最大高度。超出此高 → 节点保持 640,body 区由 overflow-y-auto 出滚动条。
+// (B1 后,真实内容超过估高也会被 overflow-y-auto 兜底,不会静默剪裁。)
 const H_CAP_ABS = 640;
 
 /** cpl = chars per line,从卡片宽派生(padding 24 + 字宽 8.5px)。 */
@@ -225,8 +227,6 @@ export function estimateCardHeight(entity: Entity, row: TaskRow | DecisionRow | 
 export interface CardDims {
   w: number;
   h: number;
-  /** true = 内容估高超出 H_CAP_ABS,body 区挂 overflow-y-auto。 */
-  scrollable: boolean;
 }
 
 /**
@@ -235,6 +235,9 @@ export interface CardDims {
  * 地板 = round(w / 0.85):竖优先,防横条(W:H > 0.85)。短内容会被垫到此高度,
  * 但不再强制统一比例(避免短 fact 撑成 9:16 的留白装腔)。
  * cap = H_CAP_ABS(640):DecisionBody 三段满载 ≈ 586,留余地不滚;超出才滚。
+ *
+ * B1:不再返 scrollable 标志 —— EgoNode body 始终 overflow-y-auto,内容低于盒子时
+ * Tailwind 不渲染滚动条,超出时自动出。任何估高偏差都降级到「滚动条出现」而非「文本消失」。
  */
 function nodeDims(
   entity: Entity,
@@ -243,17 +246,18 @@ function nodeDims(
   override?: { w: number; h: number },
 ): CardDims {
   if (override) {
-    // 用户已拖拽:尊重其选择,不重算 scrollable(他们看到的就是真相)。
-    return { w: override.w, h: override.h, scrollable: false };
+    // 用户已拖拽:尊重其选择(他们看到的就是真相)。即使拖得比内容小,body 的
+    // overflow-y-auto 会兜底出滚动条,不会被剪。
+    return { w: override.w, h: override.h };
   }
   if (expanded && row) {
     const w = CARD_W[entity];
     const estimated = estimateCardHeight(entity, row);
     const floored = Math.max(estimated, Math.round(w / W_H_FLOOR));
-    const scrollable = floored > H_CAP_ABS;
-    return { w, h: scrollable ? H_CAP_ABS : floored, scrollable };
+    const h = Math.min(floored, H_CAP_ABS);
+    return { w, h };
   }
-  return { w: CHIP_W, h: CHIP_H, scrollable: false };
+  return { w: CHIP_W, h: CHIP_H };
 }
 
 export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
@@ -361,7 +365,7 @@ export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
     if (!meta) continue;
     const center = pos.get(id) ?? { x: 0, y: 0 };
     const isExpanded = expanded.has(id);
-    const { w, h, scrollable } = nodeDims(meta.entity, isExpanded, meta.row, sizeOverrides?.get(id));
+    const { w, h } = nodeDims(meta.entity, isExpanded, meta.row, sizeOverrides?.get(id));
     let hiddenCount = 0;
     for (const a of adj.get(id) ?? []) {
       if (
@@ -378,11 +382,12 @@ export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
       id,
       type: "ego",
       position: { x: center.x - w / 2, y: center.y - h / 2 },
-      // 尺寸同时给 style(渲染)和顶层 width/height(RF 内部维度)。少了顶层这对,
-      // node.measured 直到 DOM 观测才有值,MiniMap 的 nodeHasDimensions() 判假 → 一个方块都不画。
+      // RF 包装盒的 inline 尺寸派生自 node.width/node.height(getNodeInlineStyleDimensions:
+      // `node.width ?? node.style?.width`)。顶层这对同时喂给 MiniMap 的 nodeHasDimensions
+      // (`node.measured ?? node.width ?? node.initialWidth`)。不再写 style.width/height:
+      // 它只是 node.width 的回退,反而与 NodeResizer 在 drag 期间的中间维度抢道(B2)。
       width: w,
       height: h,
-      style: { width: w, height: h },
       data: {
         entity: meta.entity,
         raw: meta.row,
@@ -394,9 +399,6 @@ export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
         hiddenCount,
         color: meta.entity === "task" ? statusColor(meta.row as TaskRow) : undefined,
         navRef,
-        // 内容驱动尺寸的副产物:body 区是否挂 overflow-y-auto。false 时 body 用
-        // overflow-hidden(短内容不滚、不晃),EgoNode 据此条件挂滚动条。
-        scrollable,
       },
       zIndex: id === focusId ? 6 : isExpanded ? 5 : 1,
     });
@@ -435,8 +437,9 @@ export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
   let maxX = 0;
   let maxY = 0;
   for (const n of rfNodes) {
-    const w = (n.style?.width as number) ?? CHIP_W;
-    const h = (n.style?.height as number) ?? CHIP_H;
+    // B2:顶层 width/height 取代 style.width/height 作为尺寸真相。
+    const w = (n.width as number | undefined) ?? CHIP_W;
+    const h = (n.height as number | undefined) ?? CHIP_H;
     minX = Math.min(minX, n.position.x);
     minY = Math.min(minY, n.position.y);
     maxX = Math.max(maxX, n.position.x + w);

--- a/packages/gui/src/renderer/graph/nodes/EgoNode.tsx
+++ b/packages/gui/src/renderer/graph/nodes/EgoNode.tsx
@@ -105,12 +105,20 @@ export function EgoNode({ data, selected }: any) {
       }}
     >
       {/* D4:NodeResizer —— 用户「手动拖放大缩小组件」的入口。只在展开卡片上显示。
-          onResizeEnd 把最终尺寸持久化到 sizeOverrides(localStorage),布局器下次按此尺寸渲染。
+          onResize 把每个 drag tick 的中间尺寸同步到 sizeOverrides,使布局器立即按新尺寸
+          重排——可见的实时缩放(RF 受控模式下 NodeResizer 的内部 dimensionChange 不会经
+          onNodesChange 回流到我们的 nodes 状态,所以必须由 EgoNode 主动上报)。
+          onResizeEnd 同样上报一次,确保最终尺寸写入。
           minWidth/minHeight 防止拖到 0;nodesDraggable={false} 不影响 resize(RF 独立处理)。*/}
       <NodeResizer
         isVisible={true}
         minWidth={CARD_MIN_W}
         minHeight={CARD_MIN_H}
+        onResize={(_evt, params) => {
+          if (data.onResizeEnd) {
+            data.onResizeEnd(data.id, params.width, params.height);
+          }
+        }}
         onResizeEnd={(_evt, params) => {
           if (data.onResizeEnd) {
             data.onResizeEnd(data.id, params.width, params.height);
@@ -164,13 +172,11 @@ export function EgoNode({ data, selected }: any) {
       {/* scrollable body */}
       {/* D4:nowheel 类让 React Flow 的 d3-zoom filter 把滚轮让给此容器(否则滚轮被拿去缩放画布,
           overflow-y-auto 形同虚设)。noWheelClassName 默认就是 "nowheel",无需在 ReactFlow 上配置。
-          G1:scrollable 来自内容驱动尺寸(nodeDims)。短内容(fact ≤200 字 / task 单行)scrollable=false,
-          用 overflow-hidden 防止恒挂空滚动条;长内容(decision 三段满载)才挂 overflow-y-auto。*/}
-      <div
-        className={`nowheel mt-1.5 flex min-h-0 flex-1 flex-col gap-2 overscroll-contain px-2.5 pb-2 ${
-          data.scrollable ? "overflow-y-auto" : "overflow-hidden"
-        }`}
-      >
+          B1:始终挂 overflow-y-auto —— 内容适配时 Tailwind 不会渲染滚动条(视觉等价 overflow-hidden),
+          一旦真实内容超过节点盒(高估或被用户拖小),滚动条自然出现。这避免了 estimateCardHeight
+          的启发式低估导致内容被 overflow-hidden 静默剪裁("组件大了,但是滚动不了了")。
+          min-h-0 + flex-1 让 flex 子项在父盒固定高时正确收缩,从而能产生 overflow。*/}
+      <div className="nowheel mt-1.5 flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain px-2.5 pb-2">
         {entity === "task" && <TaskBody t={data.raw as TaskRow} />}
         {entity === "decision" && <DecisionBody d={data.raw as DecisionRow} />}
         {entity === "fact" && <FactBody f={data.raw as FactRef} />}

--- a/packages/gui/src/renderer/views/graphViewHooks.ts
+++ b/packages/gui/src/renderer/views/graphViewHooks.ts
@@ -93,21 +93,23 @@ function writeSizes(sizes: ReadonlyMap<string, { w: number; h: number }>): void 
  * NodeResizer 拖拽调整后的卡片尺寸,持久化在 localStorage(复用 favorites.ts 模式)。
  * 串过 useGraphLayout → computeGraphLayout → layoutCanvasEgo.nodeDims,使布局器尊重
  * 用户手动调整的尺寸而非每次按内容估算覆盖掉。
+ *
+ * B2:EgoNode 的 NodeResizer 同时挂了 onResize(drag 每一 tick)与 onResizeEnd(松手),
+ * 让受控模式下也能看到实时缩放。为避免 drag 期间 60Hz 写 localStorage,内存状态立即更新,
+ * 磁盘写入经 setTimeout 防抖(最后一次更新后 250ms)。
  */
 export function useNodeSizeOverrides(): {
   sizeOverrides: ReadonlyMap<string, { w: number; h: number }>;
   setSizeOverride: (id: string, size: { w: number; h: number }) => void;
 } {
   const [sizes, setSizes] = useState<Map<string, { w: number; h: number }>>(() => readSizes());
+  // sizesRef 让防抖的磁盘写入拿到最新值,而不是闭包捕获的旧 sizes。
+  const sizesRef = useRef<Map<string, { w: number; h: number }>>(sizes);
+  const writeTimerRef = useRef<number | null>(null);
 
-  const setSizeOverride = useCallback((id: string, size: { w: number; h: number }) => {
-    setSizes((prev) => {
-      const next = new Map(prev);
-      next.set(id, size);
-      writeSizes(next);
-      return next;
-    });
-  }, []);
+  useEffect(() => {
+    sizesRef.current = sizes;
+  }, [sizes]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -116,6 +118,37 @@ export function useNodeSizeOverrides(): {
     };
     window.addEventListener("storage", onStorage);
     return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  // 挂载卸载时把未刷盘的覆盖持久化下去,防 drag 中途关闭/刷新丢失最后一次写入。
+  useEffect(() => {
+    return () => {
+      if (writeTimerRef.current !== null) {
+        window.clearTimeout(writeTimerRef.current);
+        writeTimerRef.current = null;
+        writeSizes(sizesRef.current);
+      }
+    };
+  }, []);
+
+  const setSizeOverride = useCallback((id: string, size: { w: number; h: number }) => {
+    setSizes((prev) => {
+      // 同值短路:drag 末尾的 onResizeEnd 常与上一 tick 同值,跳过避免无谓重排。
+      const existing = prev.get(id);
+      if (existing && existing.w === size.w && existing.h === size.h) return prev;
+      const next = new Map(prev);
+      next.set(id, size);
+      sizesRef.current = next;
+      return next;
+    });
+    // 防抖刷盘:drag 期间 60Hz 触发,只有松手后 250ms 静默期才真正落盘。
+    if (writeTimerRef.current !== null) {
+      window.clearTimeout(writeTimerRef.current);
+    }
+    writeTimerRef.current = window.setTimeout(() => {
+      writeTimerRef.current = null;
+      writeSizes(sizesRef.current);
+    }, 250);
   }, []);
 
   return { sizeOverrides: sizes, setSizeOverride };

--- a/packages/gui/test/canvas-ego-layout.vitest.ts
+++ b/packages/gui/test/canvas-ego-layout.vitest.ts
@@ -61,10 +61,10 @@ function scene() {
 const FOCUS = "decision/dec_F";
 
 function boxesOverlap(a: any, b: any): boolean {
-  const aw = a.style.width;
-  const ah = a.style.height;
-  const bw = b.style.width;
-  const bh = b.style.height;
+  const aw = a.width;
+  const ah = a.height;
+  const bw = b.width;
+  const bh = b.height;
   return (
     a.position.x < b.position.x + bw &&
     b.position.x < a.position.x + aw &&
@@ -72,7 +72,7 @@ function boxesOverlap(a: any, b: any): boolean {
     b.position.y < a.position.y + ah
   );
 }
-const centerX = (n: any) => n.position.x + n.style.width / 2;
+const centerX = (n: any) => n.position.x + n.width / 2;
 
 describe("layoutCanvasEgo", () => {
   const { tasks, decisions, facts, relations } = scene();
@@ -153,10 +153,10 @@ describe("layoutCanvasEgo", () => {
 
   it("焦点渲染为卡片(expanded),其余为 chip", () => {
     expect(byId.get(FOCUS)!.data.expanded).toBe(true);
-    // G1:决策卡片宽 = 320(按 kind 分档,不再一刀切 360)。
-    expect(byId.get(FOCUS)!.style.width).toBe(320);
+    // G1:决策卡片宽 = 320(按 kind 分档,不再一刀切 360)。B2:改用顶层 width(不再写 style.width)。
+    expect(byId.get(FOCUS)!.width).toBe(320);
     expect(byId.get("task_C")!.data.expanded).toBe(false);
-    expect(byId.get("task_C")!.style.width).toBe(216); // CHIP_W
+    expect(byId.get("task_C")!.width).toBe(216); // CHIP_W
   });
 });
 
@@ -257,10 +257,11 @@ describe("D4 · estimateCardHeight(task 内容感知)", () => {
   });
 });
 
-// ══ G1:内容驱动尺寸 + 竖优先地板 + scrollable 标志 ══
+// ══ G1:内容驱动尺寸 + 竖优先地板 ══
 // 节点宽按 kind 分档(fact 280 / task 300 / decision 320),高按内容估算 + 地板(W:H ≤ 0.85)
-// + 硬 cap(640)。estimateCardHeight 只返内容估高(无地板无 cap);nodeDims 叠地板与 cap,
-// 并输出 scrollable 标志给 EgoNode 决定 overflow。详见 canvasEgoLayout.ts 注释。
+// + 硬 cap(640)。estimateCardHeight 只返内容估高(无地板无 cap);nodeDims 叠地板与 cap。
+// B1:EgoNode body 改为始终 overflow-y-auto(Tailwind 在不溢出时不渲染滚动条),node.data 不再
+// 携带 scrollable —— 真实内容超过估高也会被滚动条兜底,而非 overflow-hidden 静默剪裁。
 describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
   it("estimateCardHeight 对 decision 包含 rejected 段(原漏算)", () => {
     const dNoRej = decision("d1");
@@ -290,13 +291,13 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
       expanded: new Set([id]),
     });
     const node = out.nodes.find((n) => n.id === id)!;
-    const w = node.style?.width as number;
-    const h = node.style?.height as number;
+    // B2:尺寸改用顶层 width/height(不再写 style.width/height)。
+    const w = node.width as number;
+    const h = node.height as number;
     // W:H ≤ 0.85(竖优先地板),允许少许浮点。
     expect(w / h).toBeLessThanOrEqual(0.85 + 0.01);
-    // G1 §④ 验收:fact ≤200 字时 h ≥ 280,无滚动条。
+    // G1 §④ 验收:fact ≤200 字时 h ≥ 280。
     expect(h).toBeGreaterThanOrEqual(280);
-    expect(node.data?.scrollable).toBe(false);
   });
 
   it("expanded task 节点 W:H ≤ 0.85(竖优先地板)", () => {
@@ -314,10 +315,9 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
       expanded: new Set([id]),
     });
     const node = out.nodes.find((n) => n.id === id)!;
-    const w = node.style?.width as number;
-    const h = node.style?.height as number;
+    const w = node.width as number;
+    const h = node.height as number;
     expect(w / h).toBeLessThanOrEqual(0.85 + 0.01);
-    expect(node.data?.scrollable).toBe(false);
   });
 
   it("expanded decision 节点 W:H ≤ 0.85(竖优先地板)", () => {
@@ -335,14 +335,14 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
       expanded: new Set([id]),
     });
     const node = out.nodes.find((n) => n.id === id)!;
-    const w = node.style?.width as number;
-    const h = node.style?.height as number;
+    const w = node.width as number;
+    const h = node.height as number;
     expect(w / h).toBeLessThanOrEqual(0.85 + 0.01);
-    expect(node.data?.scrollable).toBe(false);
   });
 
-  it("decision 三段内容(Q+chosen+rejected)在 630px 内不滚", () => {
-    // 验证 G1 §④ 验收:decision 三段满载不滚。
+  it("decision 三段内容(Q+chosen+rejected)高度 ≤ 630px", () => {
+    // G1 §④ 验收:decision 三段满载不撑破硬 cap(640)。B1 后即便估高有偏差,
+    // body 始终 overflow-y-auto,真实内容超出时会出现滚动条而非被剪。
     const d = decision("dec_full", {
       question: "x".repeat(80),
       chosen: [
@@ -367,29 +367,25 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
       expanded: new Set([id]),
     });
     const node = out.nodes.find((n) => n.id === id)!;
-    expect(node.style?.height).toBeLessThanOrEqual(630);
-    expect(node.data?.scrollable).toBe(false);
+    expect(node.height).toBeLessThanOrEqual(630);
   });
 
-  it("超长 decision(Q+chosen+rejected+claims 都满)触发 scrollable(cap=640)", () => {
-    // 各段都顶到 estimateCardHeight 内部 cap,总和超出 H_CAP_ABS=640 → scrollable=true。
+  it("硬 cap:H_CAP_ABS=640 永远不被超(即便估高顶到各段 internal cap)", () => {
+    // 反向保护:无论内容多,节点高度都受 H_CAP_ABS 卡住;真实溢出由 body 滚动条兜底。
     const huge = decision("dec_huge", {
-      question: "x".repeat(200),  // 估高 +96(internal cap)
+      question: "x".repeat(200),
       chosen: Array.from({ length: 6 }, (_, i) => ({
         id: `CH${i}`, text: "chosen", evidence: [],
-      })) as any,  // 估高 +120(internal cap)
+      })) as any,
       rejected: Array.from({ length: 5 }, (_, i) => ({
         id: `RJ${i}`, text: "nope", evidence: [], whyNot: "why",
-      })) as any,  // 估高 +120(internal cap)
+      })) as any,
       claims: Array.from({ length: 5 }, (_, i) => ({
         id: `CL${i}`, text: "claim",
-      })),  // 估高 +120(internal cap)
+      })),
     });
-    // 估算总和:130 + 96 + 120 + 120 + 120 = 586,刚到不了 640。
-    // 但用 more 内容(Q 接近 200 字 → 96 cap、chosen 8 项 → 仍 120 cap)... 实际 internal
-    // caps 让 decision 很难超 640。改用 multi-section decision with longer Q:
     const huge2 = decision("dec_huge2", {
-      question: "y".repeat(400),  // estimateCardHeight 内部 cap 96
+      question: "y".repeat(400),
       chosen: Array.from({ length: 10 }, (_, i) => ({
         id: `CH${i}`, text: "c", evidence: [],
       })) as any,
@@ -413,11 +409,32 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
       expanded: new Set([id]),
     });
     const node = out.nodes.find((n) => n.id === id)!;
-    // nodeDims 永远把 scrollable = floored > 640;floored = max(estimated, w/0.85=376)。
-    // 若 estimateCardHeight 内部 caps 让总估高 ≤ 640,scrollable=false。
-    // 这条测试是**反向保护**:确认我们没意外把所有 decision 都标成 scrollable。
-    expect(node.style?.height).toBeLessThanOrEqual(640);
-    expect(node.data?.scrollable).toBe(false);
+    expect(node.height).toBeLessThanOrEqual(640);
     void huge; // huge 是对照(同样不会撑破 cap,留作文档说明)。
+  });
+
+  // B2:NodeResizer 走 sizeOverrides 通道。override 必须原样落地为顶层 width/height,
+  // 不被内容估高覆盖,且不再写 style.width(避免与 NodeResizer 的中间态打架)。
+  it("B2 · sizeOverride 落地为顶层 width/height(不被内容估高覆盖)", () => {
+    const t = task("task_override", { title: "short" });
+    const id = t.taskId;
+    const out = layoutCanvasEgo({
+      focusId: id,
+      tasks: [t],
+      decisions: [],
+      facts: [],
+      relations: [],
+      filters: filters(),
+      inLoopEdges: new Set(),
+      shown: new Map([[id, 0]]),
+      expanded: new Set([id]),
+      sizeOverrides: new Map([[id, { w: 500, h: 400 }]]),
+    });
+    const node = out.nodes.find((n) => n.id === id)!;
+    expect(node.width).toBe(500);
+    expect(node.height).toBe(400);
+    // B2:不再写 style.width / style.height —— 让 NodeResizer 控盒子。
+    expect(node.style?.width).toBeUndefined();
+    expect(node.style?.height).toBeUndefined();
   });
 });


### PR DESCRIPTION
# English

## Summary

Fix the ego graph card regression from content-driven node sizing: (1) the internal scrollbar disappeared so overflow content (a fact's lower text, a decision's claims) was clipped and unreachable, and (2) drag-to-resize handles stopped working. This is split out from a larger graph-engine branch; the ELK edge-routing half is held back for a P0 fix (see Residual Risk).

## What Changed

- `graph/nodes/EgoNode.tsx`: card body is now always `overflow-y-auto` (a scrollbar appears only when content actually overflows) instead of the heuristic `data.scrollable ? auto : hidden` that silently clipped under-estimated content; `NodeResizer` now reports each `onResize` tick (not only `onResizeEnd`) so live drag is visible under React Flow controlled mode.
- `graph/canvasEgoLayout.ts`: dropped the `scrollable` field and the `style.width`/`style.height` writes; node size is now the single top-level `width`/`height` (what React Flow's box sizing and MiniMap `nodeHasDimensions` read), so a dragged/overridden size is not fought by re-applied inline styles.
- `views/graphViewHooks.ts`: `useNodeSizeOverrides.setSizeOverride` splits immediate in-memory state from a 250ms-debounced localStorage flush (drag no longer thrashes localStorage at 60Hz); unmount flushes the pending write.
- `test/canvas-ego-layout.vitest.ts`: removed the now-deleted `scrollable` assertions; size assertions read `node.width`/`node.height`; added a test that a size override lands as top-level width/height with no `style.width`.

## Task And Scope

- Harness task: task_01KXF7ZNEA7JWBN6EEWWZWJ0A1 (GUI dogfood UX fix wave)
- Branch: fix/gui-ego-scroll-resize
- Public scope: packages/gui/src/renderer/graph/{nodes/EgoNode.tsx,canvasEgoLayout.ts}, views/graphViewHooks.ts, test/canvas-ego-layout.vitest.ts
- Private planning/evidence updated: not applicable
- Out of scope: ELK edge routing (held back, separate follow-up); GraphView/EntityWorkspace shell (separate PR); territory layout

## Version Impact

- Version: no version change because this is a renderer bugfix with no package API change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none (renderer graph node/layout components; no gate/manifest/CI/branch-protection surface)
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: 06cbb030
- Branch merge-base with `origin/main`: 06cbb030 (cherry-picked onto origin/main, 1 commit)
- Last `git fetch origin` time: 2026-07-14 (this session)
- Sync method: rebase (cherry-pick onto latest origin/main)
- Public diff command: `git diff origin/main..fix/gui-ego-scroll-resize`
- Private evidence commit/path: not applicable
- Reviewer evidence path: adversarial review (see Review Evidence)
- GitHub Actions `rewrite-ci` run URL: (added after push)
- [x] `npm run typecheck` — green
- [x] `npm test` (via `npm run test:gui` — 176/176, locale coverage 978 keys) — green
- [x] boundaries: file-complexity — green (all touched files under the 600-line cap)
- [~] `npm run check:local` — contract/integration tiers not relied on locally (daemon-spawn load flakes this session); GitHub Actions `rewrite-ci` is authoritative for those.
- Not run locally: full `test:gui:e2e` in this branch (graph e2e is exercised by the shell PR; this branch is layout-internal). Live drag *visual* smoothness is not covered by an automated test (see Residual Risk).

## Review Evidence

- Self-review: CEO read the full diff; scroll-always-on removes the clip-without-scrollbar failure; size truth consolidated to top-level width/height.
- Reviewer subagent: independent adversarial review (Grok) of the combined graph-engine branch. It BLOCKED the branch on a P0 in the ELK routing half (edge bend-points in a different coordinate space than nodes); that half is split off for a fix. For this scroll/resize half it confirmed: MiniMap dimensions preserved, localStorage flush-on-unmount correct, fallback path intact. The two P1 concerns it raised (live-resize triggering a full ELK relayout per tick; NodeResizer vs full node rewrite) are ELK-interaction issues that do not apply to this branch — without ELK, the per-resize relayout is the cheap synchronous column layout.
- Human review: pending (CEO-principal dogfood)
- Blocking findings: none for this branch (the P0 belongs to the ELK half, not here)

## Residual Risk

- Live drag *visual* smoothness (does the card visibly track the handle under controlled React Flow mode) is verified by a unit test on override persistence, not by an automated interaction test — needs a manual dogfood drag on a multi-node ego canvas.
- The 250ms localStorage debounce can lose the final size if the app is closed within 250ms of releasing the handle; an unmount flush mitigates the normal path.

## References

- Task: task_01KXF7ZNEA7JWBN6EEWWZWJ0A1
- Evidence: worker closeout (scratchpad report-gui-bc.md), adversarial review (scratchpad grok-findings-bc.txt)
- Review: CEO semantic acceptance + Grok adversarial review

---

# 中文

## 概要

修复内容驱动节点尺寸引入的 ego 图卡片回归:(1)内部滚动条消失,溢出内容(fact 的下半段文字、decision 的 claims)被剪裁且无法滚到;(2)拖拽缩放手柄失灵。本 PR 从更大的图引擎分支拆出;ELK 边路由那一半因一个 P0 暂扣待修(见残余风险)。

## 改动内容

- `graph/nodes/EgoNode.tsx`:卡片体改为始终 `overflow-y-auto`(仅内容真的溢出时才出滚动条),取代原先 `data.scrollable ? auto : hidden` 的启发式(估高偏小就静默剪裁);`NodeResizer` 现在每个 `onResize` tick 都上报(不只 `onResizeEnd`),受控模式下拖拽才可见。
- `graph/canvasEgoLayout.ts`:删除 `scrollable` 字段与 `style.width`/`style.height` 写入;尺寸真相收敛为顶层单一 `width`/`height`(React Flow 盒尺寸与 MiniMap `nodeHasDimensions` 读的就是它),拖拽/override 的尺寸不再被重新施加的 inline style 打架。
- `views/graphViewHooks.ts`:`setSizeOverride` 拆成即时内存态 + 250ms 防抖落盘(拖拽不再 60Hz 写爆 localStorage);卸载前 flush 待写。
- `test/canvas-ego-layout.vitest.ts`:移除已删的 `scrollable` 断言;尺寸断言改读 `node.width`/`node.height`;新增「override 落地为顶层 width/height 且无 style.width」测试。

## 任务与范围

- Harness 任务：task_01KXF7ZNEA7JWBN6EEWWZWJ0A1(GUI dogfood UX 修复波)
- 分支：fix/gui-ego-scroll-resize
- 公开范围：packages/gui/src/renderer/graph/{nodes/EgoNode.tsx,canvasEgoLayout.ts}、views/graphViewHooks.ts、test/canvas-ego-layout.vitest.ts
- 私有计划 / 证据是否已更新：not applicable
- 范围外：ELK 边路由(暂扣,单独跟进);GraphView/EntityWorkspace 外壳(单独 PR);territory 布局

## 版本影响

- 版本：不改版本,原因是 renderer bugfix,无包 API 变化
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无(renderer 图节点/布局组件;不碰 gate/manifest/CI/分支保护)
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：
- Break-glass 范围：
- 后续治理任务：

## 验证

- `origin/main` 基准 SHA：06cbb030
- 当前分支与 `origin/main` 的 merge-base：06cbb030(cherry-pick 到最新 origin/main,1 commit)
- 最近一次 `git fetch origin` 时间：2026-07-14(本 session)
- 同步方式：rebase(cherry-pick 到最新 origin/main)
- 公开 diff 命令：`git diff origin/main..fix/gui-ego-scroll-resize`
- 私有证据 commit/path：不适用
- Reviewer 证据路径：对抗复核(见审查证据)
- GitHub Actions `rewrite-ci` run URL：(push 后补)
- [x] `npm run typecheck` — 绿
- [x] `npm test`(经 `npm run test:gui` — 176/176,词表覆盖 978 keys）— 绿
- [x] boundaries: file-complexity — 绿(触碰文件均在 600 上限内)
- [~] `npm run check:local` — contract/integration 层本地不作数(本 session daemon-spawn 负载假红);那些层以 GitHub `rewrite-ci` 为权威。
- 本地未跑：本分支的完整 `test:gui:e2e`(图 e2e 由外壳 PR 覆盖,本分支是布局内部);拖拽**视觉**流畅度无自动化测试覆盖(见残余风险)。

## 审查证据

- 自查：CEO 读全 diff;滚动 always-on 消除「剪裁但无滚动条」;尺寸真相收敛顶层 width/height。
- Reviewer subagent：对合并的图引擎分支做了独立对抗复核(Grok)。它因 ELK 那半的一个 P0(边折点与节点不在同一坐标系)BLOCK 了整条分支;那半已拆出待修。对本滚动/缩放半,它确认:MiniMap 尺寸保留、localStorage 卸载 flush 正确、降级路径完好。它提的两个 P1(拖拽每 tick 触发全量 ELK 重排;NodeResizer 与全量 setNodes 打架)是 ELK 交互问题,不适用本分支——无 ELK 时,每次缩放的重排是便宜的同步列布局。
- 人工审查：待定(CEO-principal dogfood)
- 阻塞发现：本分支无(P0 属于 ELK 那半,不在此)

## 残余风险

- 拖拽**视觉**流畅度(受控 React Flow 模式下卡片是否随手柄可见移动)由 override 持久化单测覆盖,非交互自动化测试——需在多节点 ego 画布上人工 dogfood 拖一下。
- 250ms localStorage 防抖:释放手柄后 250ms 内关闭 app 可能丢最后一次尺寸;卸载 flush 兜底正常路径。

## 关联材料

- 任务：task_01KXF7ZNEA7JWBN6EEWWZWJ0A1
- 证据：worker closeout(scratchpad report-gui-bc.md)、对抗复核(scratchpad grok-findings-bc.txt)
- 审查：CEO 语义验收 + Grok 对抗复核
