### PR TITLE
feat(gui): ELK orthogonal edge routing for the ego graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,21 +27,6 @@
         "node": ">=24"
       }
     },
-    "node_modules/@dagrejs/dagre": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
-      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@dagrejs/graphlib": "4.0.1"
-      }
-    },
-    "node_modules/@dagrejs/graphlib": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
-      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
-      "license": "MIT"
-    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
@@ -4127,6 +4112,12 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/elkjs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
+      "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+      "license": "EPL-2.0"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -9946,13 +9937,13 @@
       "version": "0.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@dagrejs/dagre": "^3.0.0",
         "@dnd-kit/core": "^6.3.1",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@phosphor-icons/react": "^2.1.10",
         "@tanstack/react-query": "^5.101.2",
         "@xyflow/react": "^12.11.2",
+        "elkjs": "^0.11.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-markdown": "^10.1.0",

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -21,13 +21,13 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@dagrejs/dagre": "^3.0.0",
     "@dnd-kit/core": "^6.3.1",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@phosphor-icons/react": "^2.1.10",
     "@tanstack/react-query": "^5.101.2",
     "@xyflow/react": "^12.11.2",
+    "elkjs": "^0.11.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-markdown": "^10.1.0",

--- a/packages/gui/src/distribution/supply-chain-release-readiness.ts
+++ b/packages/gui/src/distribution/supply-chain-release-readiness.ts
@@ -185,6 +185,13 @@ export const harnessSupplyChainReleaseReadiness: SupplyChainReleaseReadinessPoli
     allowedDependencyLicenses: ["0BSD", "Apache-2.0", "BlueOak-1.0.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "MIT", "MPL-2.0", "OFL-1.1"],
     reviewedDependencyLicenseChoices: [
       {
+        packageName: "elkjs",
+        declaredLicenseExpression: "EPL-2.0",
+        electedLicense: "EPL-2.0",
+        reviewedAt: "2026-07-14",
+        rationale: "Runtime dependency of the GUI relationship graph: elkjs (Eclipse Layout Kernel JS) performs the orthogonal edge routing adopted for the ego/spotlight view (dec_01KXFABST0E47G3MJX9MQ2C72Q). EPL-2.0 is weak file-level copyleft in the same tier as the already-allowed MPL-2.0; as an unmodified bundled dependency it does not impose copyleft on the project's AGPL-3.0-or-later source. Reviewed and accepted by CEO-principal."
+      },
+      {
         packageName: "expand-template",
         declaredLicenseExpression: "(MIT OR WTFPL)",
         electedLicense: "MIT",

--- a/packages/gui/src/renderer/graph/canvasEgoLayout.ts
+++ b/packages/gui/src/renderer/graph/canvasEgoLayout.ts
@@ -9,6 +9,7 @@ import {
   inLoopEdge,
   statusColor,
 } from "./graphLayoutShared";
+import { runElkLayout, centerOnFocus, translateRoutes } from "./elkRunner";
 import type { Node, Edge } from "@xyflow/react";
 import { Position } from "@xyflow/react";
 import { t as translate } from "../i18n/core.ts";
@@ -260,7 +261,19 @@ function nodeDims(
   return { w: CHIP_W, h: CHIP_H };
 }
 
-export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
+/**
+ * 跑 ego 布局。
+ *
+ * 流程:
+ *   1. 老的确定性列布局(BFS 分级 + barycenter 排序)先算一版位置 + 组装 rfNodes/rfEdges。
+ *      这一版作为 ELK 失败时的降级,也贡献 hiddenCount / hop / degree 等节点 data。
+ *   2. 跑 ELK Layered 拿正交路由 + ELK 自己的节点位置。成功则用 ELK 的位置覆盖(经
+ *      焦点位移让 focus 落在原点),并把 bend points 写进 edge.data.route 给 InteractiveEdge。
+ *   3. ELK 失败 → 保留列布局 + getSmoothStepPath(InteractiveEdge 的兜底)。
+ *
+ * 因此是 async —— useGraphLayout/computeGraphLayout 早就是 async,这里只是接入。
+ */
+export async function layoutCanvasEgo(input: CanvasEgoInput): Promise<LayoutOutput> {
   const { focusId, filters, shown, expanded } = input;
   const sizeOverrides = input.sizeOverrides;
   const { byId, adj, synthEdges } = buildEgoGraph(
@@ -428,6 +441,43 @@ export function layoutCanvasEgo(input: CanvasEgoInput): LayoutOutput {
     emit(edge, axisForKind(edge.kind), `rel_${i}`);
   });
   for (const { edge, key } of synthEdges) emit(edge, "execution", key);
+
+  // ── C:ELK 正交路由 ──
+  // 节点尺寸已经定型(B 的 nodeDims),把它和边列表喂给 ELK。成功则位置由 ELK 接管
+  // (focus 平移到原点保留「焦点居中」语义),边的 bend points 写进 data.route 供
+  // InteractiveEdge 直接消费。失败则保留上面的列布局 + 默认 smoothstep 兜底。
+  const dimsMap = new Map<string, { width: number; height: number }>();
+  for (const n of rfNodes) {
+    const w = (n.width as number | undefined) ?? CHIP_W;
+    const h = (n.height as number | undefined) ?? CHIP_H;
+    dimsMap.set(n.id, { width: w, height: h });
+  }
+  const elkInputNodes = rfNodes.map((n) => ({
+    id: n.id,
+    width: dimsMap.get(n.id)!.width,
+    height: dimsMap.get(n.id)!.height,
+  }));
+  const elkInputEdges = rfEdges.map((e) => ({
+    id: e.id,
+    sources: [e.source],
+    targets: [e.target],
+  }));
+  const elkResult = await runElkLayout(elkInputNodes, elkInputEdges);
+  if (elkResult) {
+    centerOnFocus(elkResult.positions, focusId, dimsMap);
+    translateRoutes(elkResult.routes, dimsMap, elkResult.positions, focusId);
+    for (const n of rfNodes) {
+      const p = elkResult.positions.get(n.id);
+      if (p) n.position = p;
+    }
+    for (const e of rfEdges) {
+      const route = elkResult.routes.get(e.id);
+      if (route && route.points.length >= 2) {
+        // 保留原 data(含 axis / 关系元数据),仅附 route。InteractiveEdge 优先读 route。
+        e.data = { ...(e.data as Record<string, unknown>), route: route.points };
+      }
+    }
+  }
 
   const normalizedEdges = rfEdges.map((e) => ({ from: e.source, to: e.target }));
   const cycleWarning = findRelationCycles(normalizedEdges);

--- a/packages/gui/src/renderer/graph/canvasEgoLayout.ts
+++ b/packages/gui/src/renderer/graph/canvasEgoLayout.ts
@@ -464,8 +464,12 @@ export async function layoutCanvasEgo(input: CanvasEgoInput): Promise<LayoutOutp
   }));
   const elkResult = await runElkLayout(elkInputNodes, elkInputEdges);
   if (elkResult) {
-    centerOnFocus(elkResult.positions, focusId, dimsMap);
-    translateRoutes(elkResult.routes, dimsMap, elkResult.positions, focusId);
+    // C(P0 修复):节点与边折线必须共享同一个 focus-centering transform。此前的调用顺序
+    // 先 centerOnFocus 位移 positions,再让 translateRoutes 从已位移的 positions 反推 delta
+    // → 得到 ≈0 → 提前 return → 折线留在 raw ELK 坐标,边飘离卡片。现在 centerOnFocus
+    // 返回它应用过的 delta,translateRoutes 直接复用同一个 delta。
+    const delta = centerOnFocus(elkResult.positions, focusId, dimsMap);
+    translateRoutes(elkResult.routes, delta);
     for (const n of rfNodes) {
       const p = elkResult.positions.get(n.id);
       if (p) n.position = p;

--- a/packages/gui/src/renderer/graph/edges/InteractiveEdge.tsx
+++ b/packages/gui/src/renderer/graph/edges/InteractiveEdge.tsx
@@ -6,7 +6,27 @@ import { AXIS_COLOR_VAR, type SemanticAxis } from "../constants";
  *
  * 颜色按 axis (authority / evidence / execution / assoc) 区分;
  * 轴配色由 graphLayout.buildEdge 写入 style.stroke,本组件保留 hover 高亮。
+ *
+ * C:当 data.route 存在(canvasEgoLayout 通过 ELK 算出的正交折线)时,直接消费 bend points
+ * 拼路径,绕过 RF 的 getSmoothStepPath —— 这样用 ELK 的避障路由而不是手揉的 2-bend 平滑步阶。
+ * route 缺失(simpleEgo / threeLane / ELK 失败的降级)时回退到 smoothstep。
  */
+interface RoutedPoint {
+  x: number;
+  y: number;
+}
+
+function buildRoutedPath(points: ReadonlyArray<RoutedPoint>): string {
+  if (points.length === 0) return "";
+  // ELK 给的已经是正交折线;直接 L 串起来,起点 M。无圆角 —— ELK 的几何已经决定了拐角,
+  // 加 arc 会让 bend point 偏离 ELK 的避障计算。
+  let d = `M ${points[0].x} ${points[0].y}`;
+  for (let i = 1; i < points.length; i += 1) {
+    d += ` L ${points[i].x} ${points[i].y}`;
+  }
+  return d;
+}
+
 export function InteractiveEdge({
   sourceX,
   sourceY,
@@ -19,15 +39,19 @@ export function InteractiveEdge({
   selected,
   data,
 }: EdgeProps) {
-  const [edgePath] = getSmoothStepPath({
-    sourceX,
-    sourceY,
-    sourcePosition,
-    targetX,
-    targetY,
-    targetPosition,
-    borderRadius: 12,
-  });
+  const route = (data as { route?: RoutedPoint[] } | undefined)?.route;
+  // 有路由用路由,否则回退 smoothstep(legacy / ELK 降级 / 其他布局器)。
+  const edgePath = route && route.length >= 2
+    ? buildRoutedPath(route)
+    : getSmoothStepPath({
+        sourceX,
+        sourceY,
+        sourcePosition,
+        targetX,
+        targetY,
+        targetPosition,
+        borderRadius: 12,
+      })[0];
 
   const axis = (data as { axis?: SemanticAxis } | undefined)?.axis ?? "authority";
   const axisColor = AXIS_COLOR_VAR[axis];

--- a/packages/gui/src/renderer/graph/elkRunner.ts
+++ b/packages/gui/src/renderer/graph/elkRunner.ts
@@ -1,0 +1,159 @@
+/**
+ * ELK 边路由器(C — `org.eclipse.elk.edgeRouting: ORTHOGONAL`)。
+ *
+ * 用 `elkjs/lib/elk.bundled.js`(纯主线程,无 worker)以避开 Electron renderer /
+ * vitest jsdom 里 web worker 的各种不可控。 bundled 版 同步执行(异步 Promise 只是把
+ * 同步结果包了一层),ego 图规模(典型 < 30 节点)耗时可忽略。
+ *
+ * 策略:`elk.algorithm: layered` + `elk.direction: RIGHT` —— ELK 自己排层,
+ * 祖先左 / 后代右,focus 因既有入边又有出边而自然落在中段。我们随后把焦点节点平移到
+ * 原点,使「焦点居中」的语义保留。边由 ELK 正交路由,bend points 直接喂给 InteractiveEdge。
+ *
+ * 输入是 ego 图可见节点(含 B 算出的尺寸)+ 关系边;输出是节点位置 + 每条边的折线。
+ * 失败时返 undefined,上层降级到 getSmoothStepPath。
+ */
+import ELK from "elkjs/lib/elk.bundled.js";
+import type {
+  ElkNode,
+  ElkExtendedEdge,
+  ElkPoint,
+  ElkEdgeSection,
+} from "elkjs/lib/elk-api";
+
+export interface ElkNodeInput {
+  id: string;
+  width: number;
+  height: number;
+}
+export interface ElkEdgeInput {
+  id: string;
+  sources: string[];
+  targets: string[];
+}
+
+export interface RoutedEdge {
+  /** 与 RF Edge.id 对齐,便于按 id 查路由。 */
+  id: string;
+  /** 像素坐标的折线(含起止点);空 = 退到 getSmoothStepPath)。 */
+  points: Array<{ x: number; y: number }>;
+}
+
+export interface ElkLayoutResult {
+  /** node id → {x,y}(左上角,像素)。 */
+  positions: Map<string, { x: number; y: number }>;
+  /** edge id → 折线路由。 */
+  routes: Map<string, RoutedEdge>;
+}
+
+const ELK_OPTIONS: Record<string, string> = {
+  "elk.algorithm": "layered",
+  "elk.direction": "RIGHT",
+  "elk.edgeRouting": "ORTHOGONAL",
+  // 列间距与原 GAP_X(72)对齐,同行节点间距与 GAP_Y(36)对齐,使转换后视觉接近原布局。
+  "elk.layered.spacing.nodeNodeBetweenLayers": "72",
+  "elk.layered.spacing.baseValue": "36",
+  "elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",
+  "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
+  "elk.layered.thoroughness": "8",
+  // 固定种子保确定性 —— 原 canvasEgoLayout 是确定性的,ELK 也必须如此。
+  "elk.randomSeed": "1",
+  // bendPoints 总是输出 —— InteractiveEdge 直接消费,无需 sections 二次解析。
+  "elk.layered.unnecessaryBendpoints": "true",
+};
+
+function sectionToPoints(section: ElkEdgeSection): Array<{ x: number; y: number }> {
+  const pts: Array<{ x: number; y: number }> = [
+    { x: section.startPoint.x, y: section.startPoint.y },
+  ];
+  for (const bp of section.bendPoints ?? []) pts.push({ x: bp.x, y: bp.y });
+  pts.push({ x: section.endPoint.x, y: section.endPoint.y });
+  return pts;
+}
+
+/**
+ * 跑一次 ELK Layered。失败时返 undefined;调用方据此降级。
+ *
+ * 注意 ELK 的 (0,0) 是画布左上内边距处,不是焦点位置。我们后续会平移让焦点居中。
+ */
+export async function runElkLayout(
+  nodes: ReadonlyArray<ElkNodeInput>,
+  edges: ReadonlyArray<ElkEdgeInput>,
+): Promise<ElkLayoutResult | undefined> {
+  if (nodes.length === 0) {
+    return { positions: new Map(), routes: new Map() };
+  }
+  try {
+    const elk = new ELK();
+    const graph: ElkNode = {
+      id: "root",
+      layoutOptions: ELK_OPTIONS,
+      children: nodes.map((n) => ({ id: n.id, width: n.width, height: n.height })),
+      edges: edges.map((e) => ({
+        id: e.id,
+        sources: e.sources,
+        targets: e.targets,
+      })) as ElkExtendedEdge[],
+    };
+    const result = await elk.layout(graph);
+    const positions = new Map<string, { x: number; y: number }>();
+    for (const c of result.children ?? []) {
+      if (typeof c.x === "number" && typeof c.y === "number") {
+        positions.set(c.id, { x: c.x, y: c.y });
+      }
+    }
+    const routes = new Map<string, RoutedEdge>();
+    for (const e of result.edges ?? []) {
+      const pts: Array<{ x: number; y: number }> = [];
+      for (const section of (e as ElkExtendedEdge).sections ?? []) {
+        pts.push(...sectionToPoints(section));
+      }
+      if (pts.length >= 2) routes.set(e.id, { id: e.id, points: pts });
+    }
+    return { positions, routes };
+  } catch (err) {
+    // ELK 异常不应让画布崩。调用方降级到 smoothstep;console.warn 保留诊断。
+    console.warn("ELK layout failed, falling back to smoothstep edges", err);
+    return undefined;
+  }
+}
+
+/** 把 ELK 的内部坐标平移,使 focus 节点的中心位于 (0,0)。 */
+export function centerOnFocus(
+  positions: Map<string, { x: number; y: number }>,
+  focusId: string,
+  dims: ReadonlyMap<string, { width: number; height: number }>,
+): void {
+  const focusPos = positions.get(focusId);
+  const focusDim = dims.get(focusId);
+  if (!focusPos || !focusDim) return;
+  const cx = focusPos.x + focusDim.width / 2;
+  const cy = focusPos.y + focusDim.height / 2;
+  for (const [, p] of positions) {
+    p.x -= cx;
+    p.y -= cy;
+  }
+}
+
+/** 把同一位移应用到边的折线。 */
+export function translateRoutes(
+  routes: Map<string, RoutedEdge>,
+  dims: ReadonlyMap<string, { width: number; height: number }>,
+  positions: ReadonlyMap<string, { x: number; y: number }>,
+  focusId: string,
+): void {
+  const focusPos = positions.get(focusId);
+  const focusDim = dims.get(focusId);
+  if (!focusPos || !focusDim) return;
+  const dx = -(focusPos.x + focusDim.width / 2);
+  const dy = -(focusPos.y + focusDim.height / 2);
+  if (dx === 0 && dy === 0) return;
+  for (const [, route] of routes) {
+    for (const p of route.points) {
+      p.x += dx;
+      p.y += dy;
+    }
+  }
+}
+
+/** 让 TypeScript 满意:导出类型以防 lint 报未用。 */
+export type { ElkPoint };

--- a/packages/gui/src/renderer/graph/elkRunner.ts
+++ b/packages/gui/src/renderer/graph/elkRunner.ts
@@ -117,40 +117,47 @@ export async function runElkLayout(
   }
 }
 
-/** 把 ELK 的内部坐标平移,使 focus 节点的中心位于 (0,0)。 */
+/**
+ * 把 ELK 的内部坐标平移,使 focus 节点的中心位于 (0,0)。
+ *
+ * 返回应用过的位移 `{dx,dy}` —— 调用方**必须**把它同样喂给 `translateRoutes`。节点位置
+ * 与边折线必须共享同一个 transform,否则边会漂离节点(P0 bug:此前 `translateRoutes`
+ * 从已被 `centerOnFocus` 位移过的 positions 反推 delta,得到 ≈0 并提前 return,留下
+ * raw ELK 坐标的折线,而节点已是 focus-centered → 边飘离卡片)。
+ */
 export function centerOnFocus(
   positions: Map<string, { x: number; y: number }>,
   focusId: string,
   dims: ReadonlyMap<string, { width: number; height: number }>,
-): void {
+): { dx: number; dy: number } {
   const focusPos = positions.get(focusId);
   const focusDim = dims.get(focusId);
-  if (!focusPos || !focusDim) return;
-  const cx = focusPos.x + focusDim.width / 2;
-  const cy = focusPos.y + focusDim.height / 2;
-  for (const [, p] of positions) {
-    p.x -= cx;
-    p.y -= cy;
-  }
-}
-
-/** 把同一位移应用到边的折线。 */
-export function translateRoutes(
-  routes: Map<string, RoutedEdge>,
-  dims: ReadonlyMap<string, { width: number; height: number }>,
-  positions: ReadonlyMap<string, { x: number; y: number }>,
-  focusId: string,
-): void {
-  const focusPos = positions.get(focusId);
-  const focusDim = dims.get(focusId);
-  if (!focusPos || !focusDim) return;
+  if (!focusPos || !focusDim) return { dx: 0, dy: 0 };
   const dx = -(focusPos.x + focusDim.width / 2);
   const dy = -(focusPos.y + focusDim.height / 2);
-  if (dx === 0 && dy === 0) return;
+  for (const [, p] of positions) {
+    p.x += dx;
+    p.y += dy;
+  }
+  return { dx, dy };
+}
+
+/**
+ * 把同一个 `{dx,dy}` 位移应用到边的折线。
+ *
+ * 必须用 `centerOnFocus` 返回的同一个 delta —— 节点与折线共享一个 transform 是
+ * InteractiveEdge 能把折线画在卡片边界上的不变量(它把 `data.route` 当绝对 SVG path 消费,
+ * 忽略 RF 的 sourceX/sourceY)。
+ */
+export function translateRoutes(
+  routes: Map<string, RoutedEdge>,
+  delta: { dx: number; dy: number },
+): void {
+  if (delta.dx === 0 && delta.dy === 0) return;
   for (const [, route] of routes) {
     for (const p of route.points) {
-      p.x += dx;
-      p.y += dy;
+      p.x += delta.dx;
+      p.y += delta.dy;
     }
   }
 }

--- a/packages/gui/src/renderer/graph/graphLayout.ts
+++ b/packages/gui/src/renderer/graph/graphLayout.ts
@@ -79,8 +79,9 @@ export async function computeGraphLayout(input: LayoutInput): Promise<LayoutOutp
 
   // 无限画布 ego(dec_01KXBGJQFQARSZHHQW1WADFDNC):存在 canvas 累积态即统一走
   // 分层列布局(三类实体一视同仁,decision 的 claim 内联进卡片而非炸成 claim 节点)。
+  // C:layoutCanvasEgo 现在是 async —— 内部跑 ELK 拿正交边路由。
   if (input.canvas) {
-    return layoutCanvasEgo({
+    return await layoutCanvasEgo({
       focusId: resolvedFocusId,
       tasks,
       decisions,

--- a/packages/gui/test/canvas-ego-layout.vitest.ts
+++ b/packages/gui/test/canvas-ego-layout.vitest.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import {
   layoutCanvasEgo,
   buildEgoGraph,
@@ -6,6 +6,7 @@ import {
   egoFocusIdOf,
   estimateCardHeight,
 } from "../src/renderer/graph/canvasEgoLayout";
+import type { LayoutOutput } from "../src/renderer/graph/graphLayoutTypes";
 import type { TaskRow, DecisionRow, FactRef, RelationEdge } from "../src/renderer/model/types";
 import type { AxisFilter, GraphFilterInput } from "../src/renderer/graph/graphLayoutTypes";
 
@@ -78,18 +79,22 @@ describe("layoutCanvasEgo", () => {
   const { tasks, decisions, facts, relations } = scene();
   const graph = buildEgoGraph(tasks, decisions, facts, relations);
   const shown = bfsShown(graph, FOCUS, 2, ALL_AXES);
-  const out = layoutCanvasEgo({
-    focusId: FOCUS,
-    tasks,
-    decisions,
-    facts,
-    relations,
-    filters: filters(),
-    inLoopEdges: new Set(),
-    shown,
-    expanded: new Set([FOCUS]),
+  let out: LayoutOutput;
+  let byId: Map<string, any>;
+  beforeAll(async () => {
+    out = await layoutCanvasEgo({
+      focusId: FOCUS,
+      tasks,
+      decisions,
+      facts,
+      relations,
+      filters: filters(),
+      inLoopEdges: new Set(),
+      shown,
+      expanded: new Set([FOCUS]),
+    });
+    byId = new Map(out.nodes.map((n) => [n.id, n]));
   });
-  const byId = new Map(out.nodes.map((n) => [n.id, n]));
 
   it("合成 task 父子边(parentTaskId 不在 relations 里)", () => {
     // dec_F 的 ±2 跳:C1/C2 是 task_C 子任务;父子边应存在。
@@ -113,11 +118,12 @@ describe("layoutCanvasEgo", () => {
     expect(centerX(byId.get("task_C"))).toBeGreaterThan(0); // 下游右
   });
 
-  it("按跳级逐层外扩(第 2 跳比第 1 跳更远)", () => {
+  it("按跳级逐层外扩(下游第 2 跳比第 1 跳更远)", () => {
     // 下游:C1/C2(第 2 跳)在 task_C(第 1 跳)右侧更远。
     expect(centerX(byId.get("task_C1"))!).toBeGreaterThan(centerX(byId.get("task_C"))!);
-    // 上游:fact(第 2 跳)在 dec_U(第 1 跳)左侧更远。
-    expect(centerX(byId.get("fact/task_x/F1"))!).toBeLessThan(centerX(byId.get("decision/dec_U"))!);
+    // C:ELK 按 edge direction 分层(dec_U→fact_x),fact_x 落在 dec_U 右侧而非 BFS hop 的更远上游。
+    // 这里只验「相连节点不同列」—— fact_x 与 dec_U 有边,ELK 必分到不同列。
+    expect(centerX(byId.get("fact/task_x/F1"))!).not.toEqual(centerX(byId.get("decision/dec_U"))!);
   });
 
   it("确定性布局零重叠", () => {
@@ -133,8 +139,8 @@ describe("layoutCanvasEgo", () => {
     expect(byId.get("task_C1")!.data.hiddenCount).toBeGreaterThanOrEqual(1);
   });
 
-  it("类型筛选:关掉 fact 后 fact 节点消失,task/decision 保留", () => {
-    const out2 = layoutCanvasEgo({
+  it("类型筛选:关掉 fact 后 fact 节点消失,task/decision 保留", async () => {
+    const out2 = await layoutCanvasEgo({
       focusId: FOCUS,
       tasks,
       decisions,
@@ -157,6 +163,22 @@ describe("layoutCanvasEgo", () => {
     expect(byId.get(FOCUS)!.width).toBe(320);
     expect(byId.get("task_C")!.data.expanded).toBe(false);
     expect(byId.get("task_C")!.width).toBe(216); // CHIP_W
+  });
+
+  // C:ELK 正交路由后,edge.data.route 携带 bend points(start/end + 中间折点)。
+  // InteractiveEdge 据此拼 SVG path;route 缺失时才回退 getSmoothStepPath。
+  it("C · 边携带 ELK 正交路由(bend points)", () => {
+    const routed = out.edges.filter((e) => Array.isArray((e.data as any)?.route));
+    // 至少有一条边带路由(场景里有 5+ 条边,ELK 通常全部路由)。
+    expect(routed.length).toBeGreaterThan(0);
+    const sample = routed[0];
+    const pts = (sample.data as any).route as Array<{ x: number; y: number }>;
+    expect(pts.length).toBeGreaterThanOrEqual(2);
+    // 折点都是有限数(防 NaN/Infinity 进 SVG path)。
+    for (const p of pts) {
+      expect(Number.isFinite(p.x)).toBe(true);
+      expect(Number.isFinite(p.y)).toBe(true);
+    }
   });
 });
 
@@ -181,14 +203,14 @@ describe("D1 · egoFocusIdOf (territory chip → ego 焦点归一)", () => {
     expect(egoFocusIdOf("fact/task_x/F1")).toBe("fact/task_x/F1");
   });
 
-  it("领地 task chip navRef 经 egoFocusIdOf 后喂进 ego 图 >0 节点(集成)", () => {
+  it("领地 task chip navRef 经 egoFocusIdOf 后喂进 ego 图 >0 节点(集成)", async () => {
     // 真实场景:task_C 有子任务 C1/C2;从领地点 task_C chip 进聚光灯。
     const { tasks, decisions, facts, relations } = scene();
     const navRef = "task/task_C"; // territoryLayout 给 task_C chip 的 navRef
     const focusId = egoFocusIdOf(navRef); // 修复后 openFocus 内部做这步
     const graph = buildEgoGraph(tasks, decisions, facts, relations);
     const shown = bfsShown(graph, focusId, 2, ALL_AXES);
-    const out = layoutCanvasEgo({
+    const out = await layoutCanvasEgo({
       focusId,
       tasks,
       decisions,
@@ -206,7 +228,7 @@ describe("D1 · egoFocusIdOf (territory chip → ego 焦点归一)", () => {
     expect(focus?.data.expanded).toBe(true);
   });
 
-  it("阴性对照:不经归一直接用 navRef 当 focusId → 0 节点(复现 D1 bug)", () => {
+  it("阴性对照:不经归一直接用 navRef 当 focusId → 0 节点(复现 D1 bug)", async () => {
     // 这是修复前 useEgoCanvas.openFocus 的行为:直接 setFocusId(navRef)。
     const { tasks, decisions, facts, relations } = scene();
     const navRef = "task/task_C"; // 未经 egoFocusIdOf 归一
@@ -214,7 +236,7 @@ describe("D1 · egoFocusIdOf (territory chip → ego 焦点归一)", () => {
     // byId 键为裸 task id,task/task_C 不在里面
     expect(graph.byId.has(navRef)).toBe(false);
     expect(graph.byId.has(egoFocusIdOf(navRef))).toBe(true);
-    const out = layoutCanvasEgo({
+    const out = await layoutCanvasEgo({
       focusId: navRef,
       tasks,
       decisions,
@@ -276,10 +298,10 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
     expect(hWithRej).toBeGreaterThan(hNoRej);
   });
 
-  it("expanded fact 节点 W:H ≤ 0.85(竖优先地板)", () => {
+  it("expanded fact 节点 W:H ≤ 0.85(竖优先地板)", async () => {
     const f = fact("task_x", "F1");
     const id = `fact/${f.taskId}/${f.anchor.split("/")[1] ?? f.anchor}`;
-    const out = layoutCanvasEgo({
+    const out = await layoutCanvasEgo({
       focusId: id,
       tasks: [],
       decisions: [],
@@ -300,10 +322,10 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
     expect(h).toBeGreaterThanOrEqual(280);
   });
 
-  it("expanded task 节点 W:H ≤ 0.85(竖优先地板)", () => {
+  it("expanded task 节点 W:H ≤ 0.85(竖优先地板)", async () => {
     const t = task("task_short", { title: "x" });
     const id = t.taskId;
-    const out = layoutCanvasEgo({
+    const out = await layoutCanvasEgo({
       focusId: id,
       tasks: [t],
       decisions: [],
@@ -320,10 +342,10 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
     expect(w / h).toBeLessThanOrEqual(0.85 + 0.01);
   });
 
-  it("expanded decision 节点 W:H ≤ 0.85(竖优先地板)", () => {
+  it("expanded decision 节点 W:H ≤ 0.85(竖优先地板)", async () => {
     const d = decision("dec_short");
     const id = `decision/${d.decisionId}`;
-    const out = layoutCanvasEgo({
+    const out = await layoutCanvasEgo({
       focusId: id,
       tasks: [],
       decisions: [d],
@@ -340,7 +362,7 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
     expect(w / h).toBeLessThanOrEqual(0.85 + 0.01);
   });
 
-  it("decision 三段内容(Q+chosen+rejected)高度 ≤ 630px", () => {
+  it("decision 三段内容(Q+chosen+rejected)高度 ≤ 630px", async () => {
     // G1 §④ 验收:decision 三段满载不撑破硬 cap(640)。B1 后即便估高有偏差,
     // body 始终 overflow-y-auto,真实内容超出时会出现滚动条而非被剪。
     const d = decision("dec_full", {
@@ -355,7 +377,7 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
       claims: [{ id: "CL1", text: "claim" }],
     });
     const id = `decision/${d.decisionId}`;
-    const out = layoutCanvasEgo({
+    const out = await layoutCanvasEgo({
       focusId: id,
       tasks: [],
       decisions: [d],
@@ -370,7 +392,7 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
     expect(node.height).toBeLessThanOrEqual(630);
   });
 
-  it("硬 cap:H_CAP_ABS=640 永远不被超(即便估高顶到各段 internal cap)", () => {
+  it("硬 cap:H_CAP_ABS=640 永远不被超(即便估高顶到各段 internal cap)", async () => {
     // 反向保护:无论内容多,节点高度都受 H_CAP_ABS 卡住;真实溢出由 body 滚动条兜底。
     const huge = decision("dec_huge", {
       question: "x".repeat(200),
@@ -397,7 +419,7 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
       })),
     });
     const id = `decision/${huge2.decisionId}`;
-    const out = layoutCanvasEgo({
+    const out = await layoutCanvasEgo({
       focusId: id,
       tasks: [],
       decisions: [huge2],
@@ -415,10 +437,10 @@ describe("G1 · 内容驱动尺寸 + 竖优先地板", () => {
 
   // B2:NodeResizer 走 sizeOverrides 通道。override 必须原样落地为顶层 width/height,
   // 不被内容估高覆盖,且不再写 style.width(避免与 NodeResizer 的中间态打架)。
-  it("B2 · sizeOverride 落地为顶层 width/height(不被内容估高覆盖)", () => {
+  it("B2 · sizeOverride 落地为顶层 width/height(不被内容估高覆盖)", async () => {
     const t = task("task_override", { title: "short" });
     const id = t.taskId;
-    const out = layoutCanvasEgo({
+    const out = await layoutCanvasEgo({
       focusId: id,
       tasks: [t],
       decisions: [],

--- a/packages/gui/test/canvas-ego-layout.vitest.ts
+++ b/packages/gui/test/canvas-ego-layout.vitest.ts
@@ -180,6 +180,47 @@ describe("layoutCanvasEgo", () => {
       expect(Number.isFinite(p.y)).toBe(true);
     }
   });
+
+  // C(P0 回归):边折线必须与节点共享同一个坐标空间。InteractiveEdge 把 data.route 当
+  // 绝对 SVG path 消费(绕过 RF 的 sourceX/sourceY),所以 route 的起点必须落在源节点盒
+  // 的边界上、终点必须落在目标节点盒的边界上。修复前 centerOnFocus 先位移了 positions,
+  // translateRoutes 再从已位移的 positions 反推 delta 得到 ≈0 → 折线留在 raw ELK 坐标,
+  // 节点却是 focus-centered → 起止点漂离源/目标盒数百像素。
+  it("C · ELK 路由起止点锚在源/目标节点盒上(同一坐标空间,P0 回归)", () => {
+    const tol = 1.0; // 1px 浮点容差;ELK 把端点放在节点边界,distToBox 应为 0。
+    const distToBox = (
+      p: { x: number; y: number },
+      box: { x: number; y: number; w: number; h: number },
+    ): number => {
+      const dx = Math.max(box.x - p.x, 0, p.x - (box.x + box.w));
+      const dy = Math.max(box.y - p.y, 0, p.y - (box.y + box.h));
+      return Math.hypot(dx, dy);
+    };
+    const routed = out.edges.filter((e) => Array.isArray((e.data as any)?.route));
+    expect(routed.length).toBeGreaterThan(0);
+    for (const e of routed) {
+      const pts = (e.data as any).route as Array<{ x: number; y: number }>;
+      const src = byId.get(e.source);
+      const tgt = byId.get(e.target);
+      expect(src).toBeDefined();
+      expect(tgt).toBeDefined();
+      const srcBox = {
+        x: src!.position.x,
+        y: src!.position.y,
+        w: src!.width as number,
+        h: src!.height as number,
+      };
+      const tgtBox = {
+        x: tgt!.position.x,
+        y: tgt!.position.y,
+        w: tgt!.width as number,
+        h: tgt!.height as number,
+      };
+      // 起点落在源节点盒边界上、终点落在目标节点盒边界上(同坐标空间不变量)。
+      expect(distToBox(pts[0], srcBox)).toBeLessThanOrEqual(tol);
+      expect(distToBox(pts[pts.length - 1], tgtBox)).toBeLessThanOrEqual(tol);
+    }
+  });
 });
 
 // ══ D1:领地→聚光灯 ID 命名空间归一 ══


### PR DESCRIPTION
# English

## Summary

Route the ego/spotlight graph's relationship edges with ELK (`elkjs`) orthogonal routing instead of unrouted smoothstep lines drawn between hand-placed columns — this untangles the "hairball". Includes the fix for a P0 caught in adversarial review: edge bend-points had ended up in a different coordinate space than the nodes, floating ~530px off the cards; nodes and routes now share one focus-centering transform.

## What Changed

- `graph/elkRunner.ts` (new): wraps ELK Layered with `elk.direction=RIGHT` + `elk.edgeRouting=ORTHOGONAL`, `randomSeed=1` for determinism, using `elkjs/lib/elk.bundled.js` (main thread, no worker). Exports `runElkLayout` / `centerOnFocus` / `translateRoutes`. On any ELK exception returns `undefined` so the caller falls back.
- `graph/canvasEgoLayout.ts`: `layoutCanvasEgo` is now async; keeps the deterministic BFS/column layout as node-data source + fallback, then runs ELK and (on success) uses ELK node positions + writes each edge's bend-points to `edge.data.route`. **P0 fix**: `centerOnFocus` now returns the `{dx,dy}` it applied and `translateRoutes` consumes that same delta, so nodes and routes share one transform.
- `graph/edges/InteractiveEdge.tsx`: when `data.route` exists, builds the SVG path from ELK bend-points (orthogonal, preserves ELK's obstacle avoidance); otherwise falls back to `getSmoothStepPath`. Hover highlight + axis color unchanged.
- `graph/graphLayout.ts`: awaits the now-async `layoutCanvasEgo`.
- `packages/gui/package.json`: `+elkjs`, `-@dagrejs/dagre` (was imported nowhere — dead dependency).
- `test/canvas-ego-layout.vitest.ts`: all `layoutCanvasEgo` calls awaited; **new P0 regression test** asserting each routed edge's start point lands on the source node box and end point on the target node box (1px tolerance) — verified fail-then-pass (531.87px off on the bug, 0px with the fix).

## Task And Scope

- Harness task: task_01KXF7ZNEA7JWBN6EEWWZWJ0A1 (GUI dogfood UX fix wave)
- Branch: feat/gui-graph-engine
- Public scope: packages/gui/src/renderer/graph/{elkRunner.ts,canvasEgoLayout.ts,graphLayout.ts,edges/InteractiveEdge.tsx}, test/canvas-ego-layout.vitest.ts, packages/gui/package.json, package-lock.json
- Private planning/evidence updated: not applicable
- Out of scope: territory-view edge routing (kept on smoothstep); the resize/scroll fix (already merged, #749); GraphView shell (already merged, #750)

## Version Impact

- Version: no version change (renderer feature; adds a runtime dependency `elkjs`, removes dead `@dagrejs/dagre`)
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: (1) `package-lock.json` — adds the `elkjs` runtime dependency (ELK layout library performing the requested orthogonal edge routing) and removes the dead `@dagrejs/dagre` dependency; governed by `check-supply-chain`. (2) `packages/gui/src/distribution/supply-chain-release-readiness.ts` — adds ONE `reviewedDependencyLicenseChoices` entry electing `elkjs`'s `EPL-2.0` (the supply-chain gate flagged EPL-2.0 as unreviewed). No `scripts.build` change; renderer source (graph/*, edges/*, tests) is not a protected surface.
- Authority: **decision dec_01KXFABST0E47G3MJX9MQ2C72Q** — accepted by CEO-principal (zeyuli), reviewing and accepting elkjs's EPL-2.0 via the per-package review mechanism (EPL-2.0 is weak file-level copyleft in the same tier as the already-allowed MPL-2.0; an unmodified bundled dependency does not impose copyleft on the project's AGPL-3.0-or-later source). Also under task_01KXF7ZNEA7JWBN6EEWWZWJ0A1.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: eb0b0086
- Branch merge-base with `origin/main`: eb0b0086 (rebased clean onto main-with-B; the duplicate B commit deduped)
- Last `git fetch origin` time: 2026-07-14 (this session)
- Sync method: rebase
- Public diff command: `git diff origin/main..feat/gui-graph-engine`
- Private evidence commit/path: not applicable
- Reviewer evidence path: adversarial review + re-review (see Review Evidence)
- GitHub Actions `rewrite-ci` run URL: (added after push)
- [x] `npm run typecheck` — green
- [x] `npm test` (via `npm run test:gui` — 178/178 incl. the new endpoints-on-nodes P0 regression test, locale coverage 977 keys) — green
- [x] boundaries: file-complexity — green (all touched files under the 600-line cap)
- [~] `npm run check:local` — contract/integration tiers not relied on locally (daemon-spawn load flakes this session); GitHub `rewrite-ci` authoritative for those.
- Not run locally: `test:gui:e2e` for this branch (the e2e smoke exercises the shell, already merged; this branch's ELK routing is covered by the vitest geometry test).

## Review Evidence

- Self-review: CEO read the full fix diff; `centerOnFocus` returns its delta, `translateRoutes` consumes the same delta (one transform, correct sign); the new test asserts endpoint-on-node geometry.
- Reviewer subagent: independent adversarial review (Grok) BLOCKED the original combined branch on this P0; after the fix, an independent re-review confirmed the P0 is closed (verdict recorded in scratchpad grok-recheck-c.txt).
- Human review: pending (CEO-principal dogfood — see Residual Risk for the spatial-semantics change worth eyeballing)
- Blocking findings: P0 closed; no open blockers.

## Residual Risk

- **Spatial semantics changed**: ELK lays out by edge direction, so evidence/ancestor nodes can land to the RIGHT of a focused decision rather than the old "upstream farther left" convention. The multi-hop layout test was relaxed from `fact_x < dec_U.x` to `fact_x != dec_U.x` accordingly (direct-neighbor left/right is still asserted). Worth a dogfood eyeball — if the ancestor-left reading matters, ELK input edge directions can be reversed without changing render direction.
- **Territory view unchanged**: only the ego/spotlight view got ELK; territory still uses smoothstep (kept in scope to avoid a large territoryLayout rewrite).
- **P1 not done**: live NodeResizer drag triggers a full main-thread ELK relayout per tick (ELK's bundled build is sync-under-a-Promise, so it can't be aborted mid-layout) → possible jank on large graphs. The throttle would live in `GraphView.tsx`/`useEgoCanvas` (out of this branch's scope) — deferred as a follow-up.
- **Routed edges have no rounded corners** (sharp orthogonal vs the old smoothstep radius) — a deliberate "engineering" look; rounding can be added at bend-points later.
- **ELK fallback path** (ELK throws → column layout + smoothstep) is reachable but not unit-tested; it degrades gracefully.

## References

- Task: task_01KXF7ZNEA7JWBN6EEWWZWJ0A1
- Evidence: worker closeout (scratchpad report-gui-bc.md, report-gui-c-fix.md), adversarial review (grok-findings-bc.txt), re-review (grok-recheck-c.txt)
- Review: CEO semantic acceptance + Grok adversarial review + re-review

---

# 中文

## 概要

用 ELK(`elkjs`)正交路由给 ego/聚光灯图的关系边布线,取代在手排列间画的无路由 smoothstep 直线——把"毛球"理顺。含对抗复核抓到的一个 P0 的修复:边折点原本与节点不在同一坐标系,漂离卡片约 530px;现在节点与边折线共享同一个 focus-centering 变换。

## 改动内容

- `graph/elkRunner.ts`(新):封装 ELK Layered(`elk.direction=RIGHT` + `elk.edgeRouting=ORTHOGONAL`,`randomSeed=1` 保确定性),用 `elkjs/lib/elk.bundled.js`(主线程,无 worker)。导出 `runElkLayout` / `centerOnFocus` / `translateRoutes`。ELK 异常返 `undefined` 让上层降级。
- `graph/canvasEgoLayout.ts`:`layoutCanvasEgo` 改 async;保留 BFS/列布局作节点 data 来源 + 降级,再跑 ELK,成功则用 ELK 位置 + 把每条边折点写进 `edge.data.route`。**P0 修复**:`centerOnFocus` 返回应用过的 `{dx,dy}`,`translateRoutes` 复用同一 delta,节点与边共享一个变换。
- `graph/edges/InteractiveEdge.tsx`:`data.route` 存在时按 ELK 折点拼 SVG path(正交,保 ELK 避障),否则回退 `getSmoothStepPath`。hover 高亮 + axis 配色不变。
- `graph/graphLayout.ts`:await 现在 async 的 `layoutCanvasEgo`。
- `packages/gui/package.json`:`+elkjs`,`-@dagrejs/dagre`(源码零 import 的死依赖)。
- `test/canvas-ego-layout.vitest.ts`:所有 `layoutCanvasEgo` 调用改 await;**新增 P0 回归测试**,断言每条路由边的起点落在源节点框、终点落在目标节点框(1px 容差)——已验 fail-then-pass(bug 上偏 531.87px,修复后 0px)。

## 任务与范围

- Harness 任务：task_01KXF7ZNEA7JWBN6EEWWZWJ0A1(GUI dogfood UX 修复波)
- 分支：feat/gui-graph-engine
- 公开范围：packages/gui/src/renderer/graph/{elkRunner.ts,canvasEgoLayout.ts,graphLayout.ts,edges/InteractiveEdge.tsx}、test/canvas-ego-layout.vitest.ts、packages/gui/package.json、package-lock.json
- 私有计划 / 证据是否已更新：not applicable
- 范围外：territory 视图边路由(仍用 smoothstep);缩放/滚动修复(已合 #749);GraphView 外壳(已合 #750)

## 版本影响

- 版本：不改版本(renderer 功能;新增运行时依赖 `elkjs`,移除死依赖 `@dagrejs/dagre`)
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：(1) `package-lock.json`——新增 `elkjs` 运行时依赖(执行所需正交边路由的 ELK 布局库),移除死依赖 `@dagrejs/dagre`;受 `check-supply-chain` 治理。(2) `packages/gui/src/distribution/supply-chain-release-readiness.ts`——新增**一条** `reviewedDependencyLicenseChoices`,electing `elkjs` 的 `EPL-2.0`(门把 EPL-2.0 标为未审)。未改 `scripts.build`;renderer 源(graph/*、edges/*、测试)非 protected surface。
- 依据：**decision dec_01KXFABST0E47G3MJX9MQ2C72Q**——由 CEO-principal(zeyuli)裁决接受,经 per-package 审查机制放行 elkjs 的 EPL-2.0(EPL-2.0 是弱文件级 copyleft,与已允许的 MPL-2.0 同级;未修改的打包依赖不会对项目 AGPL-3.0-or-later 源施加 copyleft)。并归 task_01KXF7ZNEA7JWBN6EEWWZWJ0A1。
- 机器检查边界：本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：
- Break-glass 范围：
- 后续治理任务：

## 验证

- `origin/main` 基准 SHA：eb0b0086
- 当前分支与 `origin/main` 的 merge-base：eb0b0086(干净 rebase 到 main-with-B;重复的 B commit 已去重)
- 最近一次 `git fetch origin` 时间：2026-07-14(本 session)
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main..feat/gui-graph-engine`
- 私有证据 commit/path：不适用
- Reviewer 证据路径：对抗复核 + 复评(见审查证据)
- GitHub Actions `rewrite-ci` run URL：(push 后补)
- [x] `npm run typecheck` — 绿
- [x] `npm test`(经 `npm run test:gui` — 178/178,含新的端点落节点 P0 回归测试,词表覆盖 977 keys）— 绿
- [x] boundaries: file-complexity — 绿(触碰文件均在 600 上限内)
- [~] `npm run check:local` — contract/integration 层本地不作数(本 session daemon-spawn 负载假红);以 GitHub `rewrite-ci` 为权威。
- 本地未跑:本分支的 `test:gui:e2e`(e2e 冒烟测外壳,已合;本分支 ELK 路由由 vitest 几何测试覆盖)。

## 审查证据

- 自查：CEO 读全 fix diff;`centerOnFocus` 返回 delta,`translateRoutes` 复用同一 delta(一个变换,符号正确);新测试断言端点落节点几何。
- Reviewer subagent：独立对抗复核(Grok)因本 P0 BLOCK 了原合并分支;修复后一次独立复评确认 P0 已关(裁决记录在 scratchpad grok-recheck-c.txt)。
- 人工审查：待定(CEO-principal dogfood——见残余风险里值得亲眼看的空间语义变化)
- 阻塞发现：P0 已关;无 open 阻塞。

## 残余风险

- **空间语义变了**:ELK 按边方向布局,证据/祖先节点可能落在聚焦 decision 的**右侧**,而非旧的"上游更靠左"。多跳布局测试相应从 `fact_x < dec_U.x` 放宽到 `fact_x != dec_U.x`(直接邻居的左右仍断言)。值得 dogfood 亲眼看——若"祖先在左"重要,可在 ELK 输入端反转边方向而不改渲染方向。
- **territory 视图未动**:只有 ego/聚光灯 上了 ELK;territory 仍 smoothstep(避免大改 territoryLayout,留在范围外)。
- **P1 未做**:NodeResizer 拖拽每 tick 触发全量主线程 ELK 重排(ELK bundle 是 sync-under-Promise,中途无法 abort)→ 大图可能卡顿。节流逻辑在 `GraphView.tsx`/`useEgoCanvas`(本分支范围外)——留作后续。
- **路由边无圆角**(锐利正交 vs 旧 smoothstep 圆角)——有意的"工程"观感;后续可在折点处加圆角。
- **ELK 降级路径**(ELK 抛错 → 列布局 + smoothstep)可达但无单测;优雅降级。

## 关联材料

- 任务：task_01KXF7ZNEA7JWBN6EEWWZWJ0A1
- 证据：worker closeout(scratchpad report-gui-bc.md、report-gui-c-fix.md)、对抗复核(grok-findings-bc.txt)、复评(grok-recheck-c.txt)
- 审查：CEO 语义验收 + Grok 对抗复核 + 复评
