### PR TITLE
fix(gui): separate tsc declaration output from vite dist dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 
 node_modules/
 dist/
+dist-types/
 coverage/
 tmp/
 *.log

--- a/packages/gui/tsconfig.json
+++ b/packages/gui/tsconfig.json
@@ -12,7 +12,7 @@
     "erasableSyntaxOnly": true,
     "jsx": "react-jsx",
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist-types"
   },
   "include": [
     "src/**/*.ts",

--- a/packages/gui/tsconfig.renderer.json
+++ b/packages/gui/tsconfig.renderer.json
@@ -19,7 +19,7 @@
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "types": [],
-    "outDir": "./dist/renderer-types"
+    "outDir": "./dist-types/renderer-types"
   },
   "include": [
     "src/renderer/**/*.ts",


### PR DESCRIPTION
# English

## Summary

`vite build` writes `packages/gui/dist` and empties it first, but that directory also held the composite `tsc` declaration output (`.d.ts`) and its build state. A vite build wiped tsc's outputs while the root `tsconfig.tsbuildinfo` (at the package root, outside `dist`) survived, leaving an inconsistent state that intermittently failed the next `tsc -b` with `TS6305: Output file has not been built from source file`. This PR gives tsc and vite separate output directories so they can no longer collide.

## What Changed

- `packages/gui/tsconfig.json`: `outDir` `./dist` → `./dist-types`.
- `packages/gui/tsconfig.renderer.json`: `outDir` `./dist/renderer-types` → `./dist-types/renderer-types`.
- `.gitignore`: add `dist-types/` (buildinfo files are already ignored via `*.tsbuildinfo`).
- Net effect: vite owns `packages/gui/dist` (web bundle only, what electron-builder packages); tsc owns `packages/gui/dist-types` (declaration-only emit, consumed by nobody outside the repo). The `rmSync(packages/gui/dist)` workaround in `tools/run-ci-equivalent.mjs` is now redundant (left in place as harmless defense-in-depth; not touched here to keep this PR off CI-tooling surface).

## Task And Scope

- Harness task: not applicable (CEO-directed local dev-loop hardening; no code/behaviour change to shipped artifacts).
- Branch: fix/gui-dist-vite-tsc-output-separation
- Public scope: packages/gui/tsconfig.json, packages/gui/tsconfig.renderer.json, .gitignore
- Private planning/evidence updated: not applicable
- Out of scope: run-ci-equivalent.mjs workaround removal (CI tooling; deferred), gate-manifest truth-telling (separate governance change)

## Version Impact

- Version: no version change because this only relocates build-time TypeScript declaration output; no runtime, API, or package surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none (build config: two package tsconfigs + a gitignore rule; no gate/manifest/CI-workflow/branch-protection surface)
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: 90684ef8
- Branch merge-base with `origin/main`: 90684ef8 (rebased clean, 1 commit ahead)
- Last `git fetch origin` time: 2026-07-14 (this session)
- Sync method: rebase
- Public diff command: `git diff origin/main..fix/gui-dist-vite-tsc-output-separation`
- Private evidence commit/path: not applicable
- Reviewer evidence path: CEO self-review (build-config change)
- GitHub Actions `rewrite-ci` run URL: (added after push)
- [x] `npm run typecheck` — green (root `tsc -b` across all packages, exit 0)
- [x] RED→GREEN repro: `tsc -b gui` (green) → `vite build` (empties dist) → `tsc -b gui` again — green, and `packages/gui/dist` now contains ONLY the vite bundle (assets/index.html) while tsc output sits intact in `packages/gui/dist-types/`.
- [~] `npm run check` / `harness:check-*` — not run locally; GitHub `rewrite-ci` authoritative (contract/integration tiers flake under local daemon-spawn load this session).
- Not run: full boundary/contract suite — relying on `rewrite-ci`.

## Review Evidence

- Self-review: CEO read the full diff; verified no consumer references `packages/gui/dist/**` for types (grep) and that electron-builder still globs `packages/gui/dist/**/*` (now cleaner, vite-only).
- Reviewer subagent: none (trivial build-config relocation)
- Human review: pending
- Blocking findings: none

## Residual Risk

- electron-builder globs `packages/gui/dist/**/*`; it now packages only the vite web bundle (previously it also swept the transient `.d.ts`), so the packaged app is slightly leaner, not broken.
- `tools/run-ci-equivalent.mjs` still `rm`s `packages/gui/dist` before `tsc -b`; now redundant but harmless. A follow-up may remove it as part of CI-tooling hardening.

## References

- Task: not applicable
- Evidence: RED→GREEN repro in PR verification section
- Review: CEO self-review

---

# 中文

## 概要

`vite build` 写出 `packages/gui/dist` 且会先清空它,但该目录同时存放 composite `tsc` 的声明产物(`.d.ts`)与构建状态。vite 一 build 就把 tsc 产物清掉,而包根的 `tsconfig.tsbuildinfo`(在 `dist` 之外)幸存,留下"状态说已构建、产物却没了"的不一致态,间歇性令下一次 `tsc -b` 报 `TS6305`。本 PR 让 tsc 与 vite 各用独立输出目录,从此不再相撞。

## 改动内容

- `packages/gui/tsconfig.json`:`outDir` `./dist` → `./dist-types`。
- `packages/gui/tsconfig.renderer.json`:`outDir` `./dist/renderer-types` → `./dist-types/renderer-types`。
- `.gitignore`:新增 `dist-types/`(buildinfo 已由 `*.tsbuildinfo` 忽略)。
- 净效果:vite 独占 `packages/gui/dist`(只放 web bundle,即 electron-builder 打包对象);tsc 独占 `packages/gui/dist-types`(纯声明 emit,仓库外无人消费)。`tools/run-ci-equivalent.mjs` 里的 `rmSync(packages/gui/dist)` 创可贴现已多余(原样保留作无害兜底;本 PR 不动它以避开 CI 工具面)。

## 任务与范围

- Harness 任务：不适用（CEO 直下的本地开发环路硬化；不改任何交付产物的运行行为）
- 分支：fix/gui-dist-vite-tsc-output-separation
- 公开范围：packages/gui/tsconfig.json、packages/gui/tsconfig.renderer.json、.gitignore
- 私有计划 / 证据是否已更新：not applicable
- 范围外：run-ci-equivalent.mjs 创可贴移除（CI 工具，延后）、gate-manifest 真相化（独立治理变更）

## 版本影响

- 版本：不改版本，仅迁移构建期 TS 声明输出目录，无运行时 / API / 包面变化。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无（build 配置：两个包 tsconfig + 一条 gitignore 规则；不碰 gate/manifest/CI workflow/分支保护）
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：
- Break-glass 范围：
- 后续治理任务：

## 验证

- `origin/main` 基准 SHA：90684ef8
- 当前分支与 `origin/main` 的 merge-base：90684ef8（干净 rebase，领先 1 commit）
- 最近一次 `git fetch origin` 时间：2026-07-14（本 session）
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main..fix/gui-dist-vite-tsc-output-separation`
- 私有证据 commit/path：不适用
- Reviewer 证据路径：CEO 自查（build 配置变更）
- GitHub Actions `rewrite-ci` run URL：（push 后补）
- [x] `npm run typecheck` — 绿（根 `tsc -b` 全包 exit 0）
- [x] RED→GREEN 复现：`tsc -b gui`（绿）→ `vite build`（清空 dist）→ 再 `tsc -b gui` —— 绿,且 `packages/gui/dist` 现只含 vite 产物(assets/index.html),tsc 产物完好留在 `packages/gui/dist-types/`。
- [~] `npm run check` / `harness:check-*` — 本地未跑;以 GitHub `rewrite-ci` 为权威(contract/integration 层本 session 受 daemon-spawn 负载假红)。
- 未运行：完整 boundary/contract 套件 —— 以 `rewrite-ci` 为准。

## 审查证据

- 自查：CEO 读全 diff;确认无消费方按 `packages/gui/dist/**` 取类型(grep),electron-builder 仍 glob `packages/gui/dist/**/*`(现更干净,纯 vite)。
- Reviewer subagent：无(平凡 build 配置迁移)
- 人工审查：待定
- 阻塞发现：无

## 残余风险

- electron-builder glob `packages/gui/dist/**/*`;现只打包 vite web bundle(以前会连带扫入临时 `.d.ts`),打包产物更精简,非破坏。
- `tools/run-ci-equivalent.mjs` 仍在 `tsc -b` 前 `rm` `packages/gui/dist`;现多余但无害,后续 CI 工具硬化可移除。

## 关联材料

- 任务：不适用
- 证据：PR 验证段的 RED→GREEN 复现
- 审查：CEO 自查
