### PR TITLE
fix(gui): hide .gitkeep placeholders from task doc tree

### DIFF
--- a/packages/gui/src/renderer/model/docTree.ts
+++ b/packages/gui/src/renderer/model/docTree.ts
@@ -42,8 +42,19 @@ interface TrieNode {
  *     task-plan.md       (file)
  */
 export function buildDocTree(docs: readonly DocEntry[]): DocTreeNode[] {
-  const root = buildTrie(docs);
+  const visible = docs.filter((doc) => !isIgnoredDoc(doc.path));
+  const root = buildTrie(visible);
   return flattenAndSort(root);
+}
+
+/**
+ * 忽略仅用于版本控制占位、非用户内容的文件。
+ * `.gitkeep` 只是为让空目录进 git 而存在,展示给用户没有意义。
+ * 若某目录仅含 `.gitkeep`,过滤后该目录不再入 trie,空目录一并隐去。
+ */
+function isIgnoredDoc(path: string): boolean {
+  const base = path.split("/").filter((s) => s.length > 0).pop() ?? "";
+  return base === ".gitkeep";
 }
 
 function buildTrie(docs: readonly DocEntry[]): Map<string, TrieNode> {

--- a/packages/gui/test/docTree.vitest.ts
+++ b/packages/gui/test/docTree.vitest.ts
@@ -40,6 +40,35 @@ describe("buildDocTree basic structure", () => {
   });
 });
 
+describe("buildDocTree ignores .gitkeep placeholders", () => {
+  it("drops a root-level .gitkeep", () => {
+    const tree = buildDocTree([
+      doc("INDEX.md"),
+      doc(".gitkeep"),
+    ]);
+    expect(tree.map((n) => n.path)).toEqual(["INDEX.md"]);
+  });
+
+  it("drops a nested .gitkeep but keeps its siblings and directory", () => {
+    const tree = buildDocTree([
+      doc("artifacts/keymgmt-design/.gitkeep"),
+      doc("artifacts/keymgmt-design/design.md"),
+    ]);
+    const artifacts = tree[0];
+    const keymgmt = artifacts.children[0];
+    expect(keymgmt.name).toBe("keymgmt-design");
+    expect(keymgmt.children.map((n) => n.name)).toEqual(["design.md"]);
+  });
+
+  it("removes a directory that only held a .gitkeep", () => {
+    const tree = buildDocTree([
+      doc("INDEX.md"),
+      doc("artifacts/empty-dir/.gitkeep"),
+    ]);
+    expect(tree.map((n) => n.name)).toEqual(["INDEX.md"]);
+  });
+});
+
 describe("buildDocTree nested directories", () => {
   const tree = buildDocTree([
     doc("INDEX.md"),


### PR DESCRIPTION
# English

## Summary

The task detail's artifacts document tree listed `.gitkeep` files. `.gitkeep` is a version-control placeholder that exists only to keep an otherwise-empty directory in git — it is not user content and is noise in the tree. This PR filters `.gitkeep` out of the document tree so neither the file nor a directory that held only a `.gitkeep` shows up. Directly addresses the CEO-principal's dogfood report.

## What Changed

- `packages/gui/src/renderer/model/docTree.ts`: `buildDocTree` now filters entries whose basename is `.gitkeep` before building the trie. Because filtering happens before trie construction, a directory whose only member was a `.gitkeep` no longer appears at all (empty placeholder dirs disappear too).
- `packages/gui/test/docTree.vitest.ts`: 3 new cases — drop a root-level `.gitkeep`, keep siblings while dropping a nested `.gitkeep`, and remove a directory that held only a `.gitkeep`.

## Task And Scope

- Harness task: not applicable (CEO-principal dogfood UX fix)
- Branch: fix/gui-hide-gitkeep-doc-tree
- Public scope: packages/gui/src/renderer/model/docTree.ts, packages/gui/test/docTree.vitest.ts
- Private planning/evidence updated: not applicable
- Out of scope: any other artifacts-tree behaviour (sort/expand/title unchanged)

## Version Impact

- Version: no version change because this is a renderer display filter with no package API change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none (pure renderer model function + its unit test; no gate/manifest/CI/branch-protection surface)
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: 90684ef8
- Branch merge-base with `origin/main`: 90684ef8 (rebased clean, 1 commit ahead)
- Last `git fetch origin` time: 2026-07-14 (this session)
- Sync method: rebase
- Public diff command: `git diff origin/main..fix/gui-hide-gitkeep-doc-tree`
- Private evidence commit/path: not applicable
- Reviewer evidence path: CEO self-review
- GitHub Actions `rewrite-ci` run URL: (added after push)
- [x] `npm run typecheck` — green (gui project references, exit 0)
- [x] `npm test` (docTree.vitest.ts — 14/14, incl. 3 new `.gitkeep` cases) — green
- [x] `eslint packages/gui/src/renderer/model/docTree.ts` — clean; file 122 lines (well under the 600 file-complexity cap)
- [~] full `npm run check` / contract tiers — not run locally; GitHub `rewrite-ci` authoritative.
- Not run: boundary/contract suite — relying on `rewrite-ci`.

## Review Evidence

- Self-review: CEO read the full diff; confirmed the filter is a pure predicate on basename and cannot drop real content (only exact `.gitkeep`), and that empty-placeholder-dir removal is intended.
- Reviewer subagent: none (small pure-function change with direct unit coverage)
- Human review: pending (CEO-principal dogfood)
- Blocking findings: none

## Residual Risk

- If a user ever authored a real file literally named `.gitkeep` with content, it would also be hidden. This is acceptable: `.gitkeep` is by convention a content-free placeholder, and the artifacts tree is for authored task documents.

## References

- Task: not applicable
- Evidence: docTree.vitest.ts unit tests
- Review: CEO self-review + dogfood

---

# 中文

## 概要

Task 详情的 artifacts 文档树把 `.gitkeep` 文件也列了出来。`.gitkeep` 只是版本控制占位文件,存在的唯一目的是让空目录能进 git —— 它不是用户内容,在树里是噪音。本 PR 把 `.gitkeep` 从文档树过滤掉:该文件本身、以及只含 `.gitkeep` 的目录都不再显示。直接落实 CEO-principal 的 dogfood 反馈。

## 改动内容

- `packages/gui/src/renderer/model/docTree.ts`:`buildDocTree` 在建 trie 前先过滤 basename 为 `.gitkeep` 的条目。因过滤发生在建树之前,只含一个 `.gitkeep` 的目录也整个消失(空占位目录一并隐去)。
- `packages/gui/test/docTree.vitest.ts`:新增 3 例 —— 丢根级 `.gitkeep`、丢嵌套 `.gitkeep` 但保留同级、移除只含 `.gitkeep` 的目录。

## 任务与范围

- Harness 任务：不适用（CEO-principal dogfood UX 修复）
- 分支：fix/gui-hide-gitkeep-doc-tree
- 公开范围：packages/gui/src/renderer/model/docTree.ts、packages/gui/test/docTree.vitest.ts
- 私有计划 / 证据是否已更新：not applicable
- 范围外：artifacts 树的其它行为（排序/展开/标题不变）

## 版本影响

- 版本：不改版本,这是 renderer 显示过滤,无包 API 变化。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无（纯 renderer model 函数 + 其单测；不碰 gate/manifest/CI/分支保护）
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：
- Break-glass 范围：
- 后续治理任务：

## 验证

- `origin/main` 基准 SHA：90684ef8
- 当前分支与 `origin/main` 的 merge-base：90684ef8（干净 rebase,领先 1 commit）
- 最近一次 `git fetch origin` 时间：2026-07-14（本 session）
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main..fix/gui-hide-gitkeep-doc-tree`
- 私有证据 commit/path：不适用
- Reviewer 证据路径：CEO 自查
- GitHub Actions `rewrite-ci` run URL：（push 后补）
- [x] `npm run typecheck` — 绿（gui 项目引用,exit 0）
- [x] `npm test`（docTree.vitest.ts — 14/14,含 3 新 `.gitkeep` 例）— 绿
- [x] `eslint packages/gui/src/renderer/model/docTree.ts` — 干净;文件 122 行(远低于 600 file-complexity 上限)
- [~] 完整 `npm run check` / contract 层 — 本地未跑;以 GitHub `rewrite-ci` 为权威。
- 未运行：boundary/contract 套件 —— 以 `rewrite-ci` 为准。

## 审查证据

- 自查：CEO 读全 diff;确认过滤是对 basename 的纯谓词,不会误删真内容(只匹配精确 `.gitkeep`),空占位目录移除是预期行为。
- Reviewer subagent：无(小的纯函数改动,有直接单测覆盖)
- 人工审查：待定(CEO-principal dogfood)
- 阻塞发现：无

## 残余风险

- 若用户曾真的创建一个字面名为 `.gitkeep` 且有内容的文件,也会被隐藏。可接受:`.gitkeep` 按约定是无内容占位符,而 artifacts 树是给用户撰写的任务文档看的。

## 关联材料

- 任务：不适用
- 证据：docTree.vitest.ts 单测
- 审查：CEO 自查 + dogfood
