### PR TITLE
perf(projection): normalize incremental read models

### DIFF
--- a/packages/cli/test/local-lifecycle-cli.test.ts
+++ b/packages/cli/test/local-lifecycle-cli.test.ts
@@ -511,7 +511,7 @@ test("CLI check reports corrupted projection without crashing or leaking root", 
     execFileSync(process.execPath, ["--input-type=module", "-e", [
       "import { DatabaseSync } from 'node:sqlite';",
       `const db = new DatabaseSync(${JSON.stringify(projectionPath)});`,
-      `db.prepare('UPDATE task_projection SET attribution_json = ? WHERE task_id = ?').run('{bad-json', ${JSON.stringify(taskId)});`,
+      `db.prepare("INSERT INTO entity_attribution_summary (entity_kind, entity_id, originator_json, latest_actor_json, trail_count, completeness) VALUES ('task', ?, NULL, ?, 1, 'complete') ON CONFLICT (entity_kind, entity_id) DO UPDATE SET latest_actor_json = excluded.latest_actor_json").run(${JSON.stringify(taskId)}, '{bad-json');`,
       "db.close();"
     ].join("\n")]);
 

--- a/packages/cli/test/post-merge-check-cli.test.ts
+++ b/packages/cli/test/post-merge-check-cli.test.ts
@@ -368,6 +368,8 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   } catch (error) {
     if (expectSuccess) throw error;
     const stdout = error && typeof error === "object" && "stdout" in error ? String(error.stdout) : "";
+    const stderr = error && typeof error === "object" && "stderr" in error ? String(error.stderr) : "";
+    assert.notEqual(stdout.trim(), "", `CLI produced no JSON output. stderr:\n${stderr}`);
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   }
 }

--- a/packages/kernel/src/local/attribution-event-source.ts
+++ b/packages/kernel/src/local/attribution-event-source.ts
@@ -16,6 +16,7 @@ export interface AttributionEventSourceInput {
   readonly body: string;
   readonly statSignature: string;
   readonly contentSha256: string;
+  readonly eventId?: string;
 }
 
 interface AttributionEventSourceCacheEntry {
@@ -36,11 +37,12 @@ const attributionEventSourceCache = new Map<string, AttributionEventSourceCacheE
 const attributionEventSourceCacheLimit = 16;
 
 export function captureAttributionEventSourcePersistentCache(
-  rootInput: HarnessLayoutInput
+  rootInput: HarnessLayoutInput,
+  reuseCacheWithoutValidation = false
 ): AttributionEventSourcePersistentCache | null {
   const layout = resolveHarnessLayout(rootInput);
   const cached = attributionEventSourceCache.get(layout.attributionEventsRoot);
-  if (!cached || !stableAttributionSignatures(cached.signatures)) return null;
+  if (!cached || (!reuseCacheWithoutValidation && !stableAttributionSignatures(cached.signatures))) return null;
   return {
     schema: "attribution-event-source-cache/v1",
     layoutIdentity: layout.attributionEventsRoot,
@@ -83,11 +85,20 @@ export function readUnionAttributionEvents(rootInput: HarnessLayoutInput): Reado
   return readUnionAttributionEventsFromSource(readAttributionEventSource(rootInput));
 }
 
-export function readAttributionEventSource(rootInput: HarnessLayoutInput): AttributionEventSource {
-  return readAttributionEventSourceAttempt(rootInput, 0);
+export function readAttributionEventSource(
+  rootInput: HarnessLayoutInput,
+  validation: "stable" | "verify" = "stable",
+  reuseCacheWithoutValidation = false
+): AttributionEventSource {
+  return readAttributionEventSourceAttempt(rootInput, validation, reuseCacheWithoutValidation, 0);
 }
 
-function readAttributionEventSourceAttempt(rootInput: HarnessLayoutInput, attempt: number): AttributionEventSource {
+function readAttributionEventSourceAttempt(
+  rootInput: HarnessLayoutInput,
+  validation: "stable" | "verify",
+  reuseCacheWithoutValidation: boolean,
+  attempt: number
+): AttributionEventSource {
   const eventsRoot = resolveHarnessLayout(rootInput).attributionEventsRoot;
   if (!localLayoutFileSystem.exists(eventsRoot)) {
     const source = emptyAttributionEventSource();
@@ -98,7 +109,9 @@ function readAttributionEventSourceAttempt(rootInput: HarnessLayoutInput, attemp
     return source;
   }
   const cached = attributionEventSourceCache.get(eventsRoot);
-  if (cached && stableAttributionSignatures(cached.signatures)) {
+  if (cached && (reuseCacheWithoutValidation
+    ? attributionRootSignatureMatches(eventsRoot, cached.signatures)
+    : stableAttributionSignatures(cached.signatures, validation))) {
     attributionEventSourceCache.delete(eventsRoot);
     attributionEventSourceCache.set(eventsRoot, cached);
     return cached.source;
@@ -107,7 +120,7 @@ function readAttributionEventSourceAttempt(rootInput: HarnessLayoutInput, attemp
   try {
     directory = localProjectionSourceFileSystem.readStableDirents(eventsRoot);
   } catch {
-    return retryAttributionEventSource(rootInput, eventsRoot, attempt);
+    return retryAttributionEventSource(rootInput, eventsRoot, validation, reuseCacheWithoutValidation, attempt);
   }
   const previousByPath = new Map(cached?.source.inputs.map((input) => [input.relativePath, input]));
   const inputs: AttributionEventSourceInput[] = [];
@@ -116,7 +129,7 @@ function readAttributionEventSourceAttempt(rootInput: HarnessLayoutInput, attemp
     .sort((left, right) => left.name.localeCompare(right.name))) {
     const filePath = path.join(eventsRoot, entry.name);
     const signature = localProjectionSourceFileSystem.statSignature(filePath);
-    if (signature === null) return retryAttributionEventSource(rootInput, eventsRoot, attempt);
+    if (signature === null) return retryAttributionEventSource(rootInput, eventsRoot, validation, reuseCacheWithoutValidation, attempt);
     const previous = previousByPath.get(entry.name);
     if (previous?.statSignature === signature) {
       inputs.push(previous);
@@ -128,17 +141,20 @@ function readAttributionEventSourceAttempt(rootInput: HarnessLayoutInput, attemp
         relativePath: entry.name,
         body: stable.body,
         statSignature: stable.signature,
-        contentSha256: sha256Text(stable.body)
+        contentSha256: sha256Text(stable.body),
+        eventId: decodeUnionAttributionEventBody(stable.body).eventId
       });
     } catch {
-      return retryAttributionEventSource(rootInput, eventsRoot, attempt);
+      return retryAttributionEventSource(rootInput, eventsRoot, validation, reuseCacheWithoutValidation, attempt);
     }
   }
   const signatures = new Map<string, string | null>([
     [eventsRoot, directory.signature],
     ...inputs.map((input) => [path.join(eventsRoot, input.relativePath), input.statSignature] as const)
   ]);
-  if (!stableAttributionSignatures(signatures)) return retryAttributionEventSource(rootInput, eventsRoot, attempt);
+  if (!stableAttributionSignatures(signatures, validation)) {
+    return retryAttributionEventSource(rootInput, eventsRoot, validation, reuseCacheWithoutValidation, attempt);
+  }
   const source = {
     inputs,
     hash: stablePayloadHash({
@@ -148,6 +164,13 @@ function readAttributionEventSourceAttempt(rootInput: HarnessLayoutInput, attemp
   };
   rememberAttributionEventSourceCache(eventsRoot, { source, signatures });
   return source;
+}
+
+function attributionRootSignatureMatches(
+  eventsRoot: string,
+  signatures: ReadonlyMap<string, string | null>
+): boolean {
+  return localProjectionSourceFileSystem.statSignature(eventsRoot) === signatures.get(eventsRoot);
 }
 
 function rememberAttributionEventSourceCache(
@@ -163,8 +186,12 @@ function rememberAttributionEventSourceCache(
   }
 }
 
-function stableAttributionSignatures(signatures: ReadonlyMap<string, string | null>): boolean {
-  return attributionSignaturesMatch(signatures) && attributionSignaturesMatch(signatures);
+function stableAttributionSignatures(
+  signatures: ReadonlyMap<string, string | null>,
+  validation: "stable" | "verify" = "stable"
+): boolean {
+  return attributionSignaturesMatch(signatures) &&
+    (validation === "verify" || attributionSignaturesMatch(signatures));
 }
 
 function attributionSignaturesMatch(signatures: ReadonlyMap<string, string | null>): boolean {
@@ -177,11 +204,13 @@ function attributionSignaturesMatch(signatures: ReadonlyMap<string, string | nul
 function retryAttributionEventSource(
   rootInput: HarnessLayoutInput,
   eventsRoot: string,
+  validation: "stable" | "verify",
+  reuseCacheWithoutValidation: boolean,
   attempt: number
 ): AttributionEventSource {
   attributionEventSourceCache.delete(eventsRoot);
   if (attempt >= 2) throw new Error("attribution event source did not stabilize");
-  return readAttributionEventSourceAttempt(rootInput, attempt + 1);
+  return readAttributionEventSourceAttempt(rootInput, validation, reuseCacheWithoutValidation, attempt + 1);
 }
 
 function emptyAttributionEventSource(): AttributionEventSource {
@@ -192,11 +221,24 @@ function emptyAttributionEventSource(): AttributionEventSource {
 }
 
 function validPersistentAttributionSource(source: AttributionEventSource): boolean {
-  if (source.inputs.some((input) => sha256Text(input.body) !== input.contentSha256)) return false;
+  if (source.inputs.some((input) => !validPersistentAttributionInput(input))) return false;
   return source.hash === stablePayloadHash({
     schema: "attribution-event-source/v2",
     inputs: source.inputs.map(({ relativePath, contentSha256 }) => ({ relativePath, contentSha256 }))
   });
+}
+
+function validPersistentAttributionInput(input: AttributionEventSourceInput): boolean {
+  if (sha256Text(input.body) === input.contentSha256) return true;
+  // Persisted attribution bodies are reconstructed from the normalized event
+  // rows. Their authored byte hash can differ only by JSON whitespace/order;
+  // the protected attribution state hash authenticates the normalized event.
+  if (!input.eventId) return false;
+  try {
+    return decodeUnionAttributionEventBody(input.body).eventId === input.eventId;
+  } catch {
+    return false;
+  }
 }
 
 function validPersistentAttributionCache(persisted: AttributionEventSourcePersistentCache): boolean {

--- a/packages/kernel/src/projection/claim-fulfillment-projection.ts
+++ b/packages/kernel/src/projection/claim-fulfillment-projection.ts
@@ -28,15 +28,22 @@ export function buildClaimFulfillmentRows(input: {
   readonly edges: ReadonlyArray<RelationGraphEdgeRow>;
   readonly refIndex: CoverageRefIndex;
 }): ReadonlyArray<RelationCoverageRow> {
+  const claimsByDecision = input.decisions.map((decision) => ({
+    decision,
+    claims: loadBearingClaims(decision.frontmatter)
+  }));
+  if (claimsByDecision.every(({ claims }) => claims.length === 0)) return [];
   const activeEdges = input.edges.filter((edge) => edge.state === "active");
   const evidenceGraph = evidenceGraphFrom(activeEdges);
   const invalidatedFactRefs = invalidatedFactsFrom(activeEdges);
   const refutingFactRefsByClaim = refutationsFrom(activeEdges);
-  const deliveredTaskIds = deliveredTasks(input.rootInput, input.refIndex.doneTaskIds);
+  const deliveredTaskIds = claimsByDecision.some(({ claims }) => claims.some((claim) => claim.fulfillment === "delivered"))
+    ? deliveredTasks(input.rootInput, input.refIndex.doneTaskIds)
+    : new Set<string>();
   const rows: RelationCoverageRow[] = [];
 
-  for (const decision of input.decisions) {
-    for (const claim of loadBearingClaims(decision.frontmatter)) {
+  for (const { decision, claims } of claimsByDecision) {
+    for (const claim of claims) {
       const claimRef = `${decision.decisionRef}/${claim.id}`;
       const refutingFactRefs = [...(refutingFactRefsByClaim.get(claimRef) ?? [])].sort();
       const coverage = refutingFactRefs.length === 0

--- a/packages/kernel/src/projection/entity-declaration-projection.ts
+++ b/packages/kernel/src/projection/entity-declaration-projection.ts
@@ -102,7 +102,7 @@ export function replaceDeclaredProjectionRows(
   return Effect.gen(function* () {
     yield* sql.unsafe(`DROP TABLE IF EXISTS ${quoteIdentifier(declaration.projection.table)}`);
     yield* sql.unsafe(createTableSql(declaration));
-    for (const row of rows) yield* insertRow(sql, declaration, row);
+    for (const batch of chunks(rows, 500)) yield* insertRows(sql, declaration, batch);
   });
 }
 
@@ -137,22 +137,112 @@ export function discoverDeclaredEntityProjection(
 export function readDeclaredEntitySource(
   rootInput: HarnessLayoutInput,
   declaration: EntityDeclaration,
-  hints: ReadonlyArray<DeclaredEntitySourceHint> = []
+  hints: ReadonlyArray<DeclaredEntitySourceHint> = [],
+  validation: "stable" | "verify" = "stable",
+  touchedPaths: ReadonlyArray<string> = [],
+  reuseCacheWithoutValidation = false,
+  validateReusedDirectories = true
 ): DeclaredEntitySourceResult {
-  return readDeclaredEntitySourceAttempt(rootInput, declaration, hints, 0);
+  if (touchedPaths.length > 0) {
+    return readDeclaredEntitySourceFromTouchedPaths(rootInput, declaration, hints, touchedPaths);
+  }
+  if (reuseCacheWithoutValidation) {
+    const layout = resolveHarnessLayout(rootInput);
+    const cacheKey = `${layout.authoredRoot}\0${declaration.kind}\0${declaration.rootResolver.pathTemplate}`;
+    const cached = declaredEntitySourceCache.get(cacheKey);
+    if (cached && (!validateReusedDirectories || pathSignaturesMatch(cached.directorySignatures))) {
+      return { ...cached.result, stats: { ...cached.result.stats, cacheHit: true } };
+    }
+  }
+  return readDeclaredEntitySourceAttempt(rootInput, declaration, hints, validation, 0);
+}
+
+function readDeclaredEntitySourceFromTouchedPaths(
+  rootInput: HarnessLayoutInput,
+  declaration: EntityDeclaration,
+  hints: ReadonlyArray<DeclaredEntitySourceHint>,
+  touchedPaths: ReadonlyArray<string>
+): DeclaredEntitySourceResult {
+  const layout = resolveHarnessLayout(rootInput);
+  const cacheKey = `${layout.authoredRoot}\0${declaration.kind}\0${declaration.rootResolver.pathTemplate}`;
+  const cached = declaredEntitySourceCache.get(cacheKey);
+  const matcher = templateMatcher(declaration.rootResolver.pathTemplate);
+  const inputs = new Map<string, DeclaredEntitySourceInput>(hints
+    .filter((hint) => hint.sourceKind === declaration.kind)
+    .map((hint) => [hint.sourcePath, {
+      relativePath: hint.sourcePath,
+      statSignature: hint.statSignature,
+      contentSha256: hint.contentSha256
+    }]));
+  let matchedPaths = 0;
+  for (const touchedPath of touchedPaths) {
+    const relativePath = path.relative(layout.authoredRoot, path.resolve(touchedPath)).split(path.sep).join("/");
+    if (relativePath === ".." || relativePath.startsWith("../") || !matcher.pattern.test(relativePath)) continue;
+    matchedPaths += 1;
+    const documentPath = path.join(layout.authoredRoot, relativePath);
+    if (!localLayoutFileSystem.exists(documentPath)) {
+      inputs.delete(relativePath);
+      continue;
+    }
+    const stable = localProjectionSourceFileSystem.readStableText(documentPath);
+    inputs.set(relativePath, {
+      relativePath,
+      body: stable.body,
+      statSignature: stable.signature,
+      contentSha256: sha256Text(stable.body)
+    });
+  }
+  const current = [...inputs.values()].sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+  const result: DeclaredEntitySourceResult = {
+    inputs: current,
+    hash: stablePayloadHash({
+      schema: "declared-entity-source/v1",
+      kind: declaration.kind,
+      inputs: current.map(({ relativePath, contentSha256 }) => ({ relativePath, contentSha256 }))
+    }),
+    stats: {
+      directoriesVisited: 0,
+      entriesVisited: matchedPaths,
+      filesMatched: current.length,
+      cacheHit: true
+    }
+  };
+  const cachedPaths = new Set(cached?.result.inputs.map((input) => input.relativePath) ?? []);
+  if (cached && cachedPaths.size === current.length && current.every((input) => cachedPaths.has(input.relativePath))) {
+    const currentByPath = new Map(current.map((input) => [input.relativePath, input]));
+    const refreshedInputs = cached.result.inputs.map((input) => {
+      const refreshed = currentByPath.get(input.relativePath)!;
+      return refreshed.body === undefined ? input : refreshed;
+    });
+    const fileSignatures = new Map(cached.fileSignatures);
+    for (const input of current) {
+      if (input.body !== undefined) {
+        fileSignatures.set(path.join(layout.authoredRoot, input.relativePath), input.statSignature);
+      }
+    }
+    declaredEntitySourceCache.delete(cacheKey);
+    declaredEntitySourceCache.set(cacheKey, {
+      result: { ...result, inputs: refreshedInputs },
+      directorySignatures: cached.directorySignatures,
+      fileSignatures
+    });
+    evictDeclaredEntitySourceCache();
+  }
+  return result;
 }
 
 function readDeclaredEntitySourceAttempt(
   rootInput: HarnessLayoutInput,
   declaration: EntityDeclaration,
   hints: ReadonlyArray<DeclaredEntitySourceHint>,
+  validation: "stable" | "verify",
   attempt: number
 ): DeclaredEntitySourceResult {
   const layout = resolveHarnessLayout(rootInput);
   const cacheKey = `${layout.authoredRoot}\0${declaration.kind}\0${declaration.rootResolver.pathTemplate}`;
   const cached = declaredEntitySourceCache.get(cacheKey);
   const cachedBodiesAvailable = cached?.result.inputs.every((input) => input.body !== undefined) ?? false;
-  if (cached && (hints.length > 0 || cachedBodiesAvailable) && sourceCacheEntryMatches(cached)) {
+  if (cached && (hints.length > 0 || cachedBodiesAvailable) && sourceCacheEntryMatches(cached, validation)) {
     declaredEntitySourceCache.delete(cacheKey);
     declaredEntitySourceCache.set(cacheKey, cached);
     return {
@@ -165,7 +255,7 @@ function readDeclaredEntitySourceAttempt(
   try {
     discovered = listTemplateFiles(layout.authoredRoot, declaration.rootResolver.pathTemplate);
   } catch {
-    return retryDeclaredEntitySource(rootInput, declaration, hints, cacheKey, attempt, declaration.kind);
+    return retryDeclaredEntitySource(rootInput, declaration, hints, validation, cacheKey, attempt, declaration.kind);
   }
   const hintsByPath = new Map(hints
     .filter((hint) => hint.sourceKind === declaration.kind)
@@ -178,7 +268,9 @@ function readDeclaredEntitySourceAttempt(
     resolveEntityDocumentPath(rootInput, declaration, identity);
     const documentPath = path.join(layout.authoredRoot, relativePath);
     const statSignature = localProjectionSourceFileSystem.statSignature(documentPath);
-    if (statSignature === null) return retryDeclaredEntitySource(rootInput, declaration, hints, cacheKey, attempt, relativePath);
+    if (statSignature === null) {
+      return retryDeclaredEntitySource(rootInput, declaration, hints, validation, cacheKey, attempt, relativePath);
+    }
     const hint = hintsByPath.get(relativePath);
     if (hint?.statSignature === statSignature) {
       inputs.push({ relativePath, statSignature, contentSha256: hint.contentSha256 });
@@ -188,7 +280,7 @@ function readDeclaredEntitySourceAttempt(
     try {
       stable = localProjectionSourceFileSystem.readStableText(documentPath);
     } catch {
-      return retryDeclaredEntitySource(rootInput, declaration, hints, cacheKey, attempt, relativePath);
+      return retryDeclaredEntitySource(rootInput, declaration, hints, validation, cacheKey, attempt, relativePath);
     }
     inputs.push({
       relativePath,
@@ -204,7 +296,7 @@ function readDeclaredEntitySourceAttempt(
   if (!pathSignaturesMatch(discovered.directorySignatures) || !pathSignaturesMatch(fileSignatures)) {
     declaredEntitySourceCache.delete(cacheKey);
     if (attempt >= 2) throw new Error(`declared entity source did not stabilize: ${declaration.kind}`);
-    return readDeclaredEntitySourceAttempt(rootInput, declaration, hints, attempt + 1);
+    return readDeclaredEntitySourceAttempt(rootInput, declaration, hints, validation, attempt + 1);
   }
   const result: DeclaredEntitySourceResult = {
     inputs,
@@ -275,13 +367,14 @@ function retryDeclaredEntitySource(
   rootInput: HarnessLayoutInput,
   declaration: EntityDeclaration,
   hints: ReadonlyArray<DeclaredEntitySourceHint>,
+  validation: "stable" | "verify",
   cacheKey: string,
   attempt: number,
   relativePath: string
 ): DeclaredEntitySourceResult {
   declaredEntitySourceCache.delete(cacheKey);
   if (attempt >= 2) throw new Error(`declared entity source did not stabilize: ${relativePath}`);
-  return readDeclaredEntitySourceAttempt(rootInput, declaration, hints, attempt + 1);
+  return readDeclaredEntitySourceAttempt(rootInput, declaration, hints, validation, attempt + 1);
 }
 
 export function deleteDeclaredProjectionRows(
@@ -353,26 +446,30 @@ function createTableSql(declaration: EntityDeclaration): string {
     const primaryKey = column.primaryKey ? " PRIMARY KEY" : "";
     return `${quoteIdentifier(column.name)} ${sqliteType(column.type)}${primaryKey}`;
   });
-  columns.push("attribution_json TEXT NOT NULL DEFAULT '{\"originator\":null,\"latestActor\":null,\"trailCount\":0,\"completeness\":\"unresolved\"}'");
   return `CREATE TABLE ${quoteIdentifier(declaration.projection.table)} (${columns.join(", ")})`;
 }
 
-function insertRow(
+function insertRows(
   sql: SqlClient.SqlClient,
   declaration: EntityDeclaration,
-  row: DeclaredProjectionRow
+  rows: ReadonlyArray<DeclaredProjectionRow>
 ): Effect.Effect<unknown, unknown> {
   const columns = declaration.projection.columns.map((column) => quoteIdentifier(column.name));
-  const placeholders = columns.map(() => "?").join(", ");
-  const values = declaration.projection.columns.map((column) => row[column.name] ?? null);
+  const placeholders = `(${columns.map(() => "?").join(", ")})`;
   return sql.unsafe(
-    `INSERT INTO ${quoteIdentifier(declaration.projection.table)} (${columns.join(", ")}) VALUES (${placeholders})`,
-    values
+    `INSERT INTO ${quoteIdentifier(declaration.projection.table)} (${columns.join(", ")}) VALUES ${rows.map(() => placeholders).join(", ")}`,
+    rows.flatMap((row) => declaration.projection.columns.map((column) => row[column.name] ?? null))
   );
 }
 
 function sqliteType(type: EntityProjectionColumnDeclaration["type"]): string {
   return type === "integer" || type === "boolean" ? "INTEGER" : "TEXT";
+}
+
+function chunks<Value>(values: ReadonlyArray<Value>, size: number): ReadonlyArray<ReadonlyArray<Value>> {
+  const output: Value[][] = [];
+  for (let index = 0; index < values.length; index += size) output.push(values.slice(index, index + size));
+  return output;
 }
 
 function templateMatcher(template: string): { readonly pattern: RegExp; readonly keys: ReadonlyArray<string> } {
@@ -425,9 +522,13 @@ function listTemplateFiles(rootPath: string, template: string): {
   return { files: files.sort(), directories, directorySignatures, directoriesVisited, entriesVisited };
 }
 
-function sourceCacheEntryMatches(entry: DeclaredEntitySourceCacheEntry): boolean {
+function sourceCacheEntryMatches(
+  entry: DeclaredEntitySourceCacheEntry,
+  validation: "stable" | "verify" = "stable"
+): boolean {
   const signatures = new Map([...entry.directorySignatures, ...entry.fileSignatures]);
-  return pathSignaturesMatch(signatures) && pathSignaturesMatch(signatures);
+  return pathSignaturesMatch(signatures) &&
+    (validation === "verify" || pathSignaturesMatch(signatures));
 }
 
 function pathSignaturesMatch(signatures: ReadonlyMap<string, string>): boolean {

--- a/packages/kernel/src/projection/entity-projection-readers.ts
+++ b/packages/kernel/src/projection/entity-projection-readers.ts
@@ -1,6 +1,7 @@
 import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
 import { resolveHarnessLayout, type HarnessLayoutOverrides } from "../layout/index.ts";
+import { attributionFromRecord, attributionSummarySelect } from "./sqlite-attribution-summary.ts";
 import { defaultTaskProjectionPath, readTaskProjection } from "./sqlite-task-projection.ts";
 import type { EntityAttributionProjection } from "./types.ts";
 
@@ -86,10 +87,14 @@ interface ProjectionReaderOptions {
   readonly layoutOverrides?: HarnessLayoutOverrides;
 }
 
+const sessionProjectionSelect = attributedEntitySelect("session_projection", "session", "session_id", "session_attribution");
+const executionProjectionSelect = attributedEntitySelect("execution_projection", "execution", "execution_id", "execution_attribution");
+const reviewProjectionSelect = attributedEntitySelect("review_projection", "review", "review_id", "review_attribution");
+
 export function querySessionProjection(options: ProjectionReaderOptions & { readonly sessionId: string }): SessionProjectionRow | undefined {
   const db = openFreshProjection(options);
   try {
-    const row = db.prepare("SELECT * FROM session_projection WHERE session_id = ?").get(options.sessionId) as Record<string, unknown> | undefined;
+    const row = db.prepare(`${sessionProjectionSelect} WHERE session_projection.session_id = ?`).get(options.sessionId) as Record<string, unknown> | undefined;
     return row ? toSession(row) : undefined;
   } finally {
     db.close();
@@ -99,7 +104,7 @@ export function querySessionProjection(options: ProjectionReaderOptions & { read
 export function queryExecutionProjection(options: ProjectionReaderOptions & { readonly executionId: string }): ExecutionProjectionRow | undefined {
   const db = openFreshProjection(options);
   try {
-    const row = db.prepare("SELECT * FROM execution_projection WHERE execution_id = ?").get(options.executionId) as Record<string, unknown> | undefined;
+    const row = db.prepare(`${executionProjectionSelect} WHERE execution_projection.execution_id = ?`).get(options.executionId) as Record<string, unknown> | undefined;
     return row ? toExecution(row) : undefined;
   } finally {
     db.close();
@@ -109,7 +114,7 @@ export function queryExecutionProjection(options: ProjectionReaderOptions & { re
 export function queryExecutionsByTask(options: ProjectionReaderOptions & { readonly taskId: string }): ReadonlyArray<ExecutionProjectionRow> {
   const db = openFreshProjection(options);
   try {
-    return (db.prepare("SELECT * FROM execution_projection WHERE task_ref = ? ORDER BY claimed_at, execution_id")
+    return (db.prepare(`${executionProjectionSelect} WHERE execution_projection.task_ref = ? ORDER BY execution_projection.claimed_at, execution_projection.execution_id`)
       .all(`task/${options.taskId}`) as Record<string, unknown>[]).map(toExecution);
   } finally {
     db.close();
@@ -119,7 +124,7 @@ export function queryExecutionsByTask(options: ProjectionReaderOptions & { reado
 export function queryExecutions(options: ProjectionReaderOptions): ReadonlyArray<ExecutionProjectionRow> {
   const db = openFreshProjection(options);
   try {
-    return (db.prepare("SELECT * FROM execution_projection ORDER BY claimed_at, execution_id")
+    return (db.prepare(`${executionProjectionSelect} ORDER BY execution_projection.claimed_at, execution_projection.execution_id`)
       .all() as Record<string, unknown>[]).map(toExecution);
   } finally {
     db.close();
@@ -129,7 +134,7 @@ export function queryExecutions(options: ProjectionReaderOptions): ReadonlyArray
 export function queryReviewProjection(options: ProjectionReaderOptions & { readonly reviewId: string }): ReviewProjectionRow | undefined {
   const db = openFreshProjection(options);
   try {
-    const row = db.prepare("SELECT * FROM review_projection WHERE review_id = ?").get(options.reviewId) as Record<string, unknown> | undefined;
+    const row = db.prepare(`${reviewProjectionSelect} WHERE review_projection.review_id = ?`).get(options.reviewId) as Record<string, unknown> | undefined;
     return row ? toReview(row) : undefined;
   } finally {
     db.close();
@@ -139,11 +144,11 @@ export function queryReviewProjection(options: ProjectionReaderOptions & { reado
 export function queryTaskExecutionTrace(options: ProjectionReaderOptions & { readonly taskId: string }): TaskExecutionTrace {
   const db = openFreshProjection(options);
   try {
-    const executions = (db.prepare("SELECT * FROM execution_projection WHERE task_ref = ? ORDER BY claimed_at, execution_id")
+    const executions = (db.prepare(`${executionProjectionSelect} WHERE execution_projection.task_ref = ? ORDER BY execution_projection.claimed_at, execution_projection.execution_id`)
       .all(`task/${options.taskId}`) as Record<string, unknown>[]).map(toExecution);
-    const sessions = new Map((db.prepare("SELECT * FROM session_projection ORDER BY session_id").all() as Record<string, unknown>[])
+    const sessions = new Map((db.prepare(`${sessionProjectionSelect} ORDER BY session_projection.session_id`).all() as Record<string, unknown>[])
       .map((row) => toSession(row)).map((row) => [row.sessionId, row]));
-    const reviews = (db.prepare("SELECT * FROM review_projection WHERE task_ref = ? ORDER BY reviewed_at, review_id")
+    const reviews = (db.prepare(`${reviewProjectionSelect} WHERE review_projection.task_ref = ? ORDER BY review_projection.reviewed_at, review_projection.review_id`)
       .all(`task/${options.taskId}`) as Record<string, unknown>[]).map(toReview);
     return {
       taskId: options.taskId,
@@ -169,9 +174,9 @@ export function auditTaskProvenance(options: ProjectionReaderOptions & { readonl
 } {
   const db = openFreshProjection(options);
   try {
-    const executions = (db.prepare("SELECT * FROM execution_projection WHERE task_ref = ? ORDER BY execution_id")
+    const executions = (db.prepare(`${executionProjectionSelect} WHERE execution_projection.task_ref = ? ORDER BY execution_projection.execution_id`)
       .all(`task/${options.taskId}`) as Record<string, unknown>[]).map(toExecution);
-    const reviews = (db.prepare("SELECT * FROM review_projection WHERE task_ref = ? ORDER BY review_id")
+    const reviews = (db.prepare(`${reviewProjectionSelect} WHERE review_projection.task_ref = ? ORDER BY review_projection.review_id`)
       .all(`task/${options.taskId}`) as Record<string, unknown>[]).map(toReview);
     const sessionIds = new Set((db.prepare("SELECT session_id FROM session_projection").all() as Array<{ readonly session_id: string }>)
       .map((row) => row.session_id));
@@ -243,11 +248,11 @@ export function querySessionExecutionTrace(options: ProjectionReaderOptions & { 
 } {
   const db = openFreshProjection(options);
   try {
-    const sessionRow = db.prepare("SELECT * FROM session_projection WHERE session_id = ?").get(options.sessionId) as Record<string, unknown> | undefined;
-    const executions = (db.prepare("SELECT * FROM execution_projection ORDER BY claimed_at, execution_id").all() as Record<string, unknown>[])
+    const sessionRow = db.prepare(`${sessionProjectionSelect} WHERE session_projection.session_id = ?`).get(options.sessionId) as Record<string, unknown> | undefined;
+    const executions = (db.prepare(`${executionProjectionSelect} ORDER BY execution_projection.claimed_at, execution_projection.execution_id`).all() as Record<string, unknown>[])
       .map(toExecution)
       .filter((execution) => execution.sessionBindings.some((binding) => entityId(binding.session_ref, "session/") === options.sessionId));
-    const reviews = (db.prepare("SELECT * FROM review_projection ORDER BY reviewed_at, review_id").all() as Record<string, unknown>[]).map(toReview);
+    const reviews = (db.prepare(`${reviewProjectionSelect} ORDER BY review_projection.reviewed_at, review_projection.review_id`).all() as Record<string, unknown>[]).map(toReview);
     const session = sessionRow ? toSession(sessionRow) : undefined;
     return {
       sessionId: options.sessionId,
@@ -285,7 +290,7 @@ function toSession(row: Record<string, unknown>): SessionProjectionRow {
     bodySha256: nullableString(row.body_sha256),
     bodyRef: parseJson(row.body_ref_json),
     snapshot: parseJson(row.snapshot_json),
-    attribution: parseAttribution(row.attribution_json)
+    attribution: attributionFromRecord(row)
   };
 }
 
@@ -304,7 +309,7 @@ function toExecution(row: Record<string, unknown>): ExecutionProjectionRow {
     sessionBindings: jsonArray(row.session_bindings_json).filter(isProjectionRecord),
     outputs: jsonArray(row.outputs_json),
     submission: parseJson(row.submission_json),
-    attribution: parseAttribution(row.attribution_json)
+    attribution: attributionFromRecord(row)
   };
 }
 
@@ -325,17 +330,12 @@ function toReview(row: Record<string, unknown>): ReviewProjectionRow {
     rationale: String(row.rationale),
     archiveWarningsAcknowledged: row.archive_warnings_acknowledged === 1,
     reviewedAt: String(row.reviewed_at),
-    attribution: parseAttribution(row.attribution_json)
+    attribution: attributionFromRecord(row)
   };
 }
 
 function parseJson(value: unknown): ProjectionJsonValue {
   return typeof value === "string" ? JSON.parse(value) as ProjectionJsonValue : null;
-}
-
-function parseAttribution(value: unknown): EntityAttributionProjection {
-  if (typeof value !== "string") throw new Error("entity projection row is missing attribution_json");
-  return JSON.parse(value) as EntityAttributionProjection;
 }
 
 function jsonArray(value: unknown): ReadonlyArray<ProjectionJsonValue> {
@@ -353,4 +353,10 @@ function entityId(value: unknown, prefix: string): string | undefined {
 
 function isProjectionRecord(value: ProjectionJsonValue): value is ProjectionJsonObject {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function attributedEntitySelect(table: string, entityKind: string, idColumn: string, alias: string): string {
+  return `SELECT ${table}.*, ${attributionSummarySelect(alias)} FROM ${table} `
+    + `LEFT JOIN entity_attribution_summary ${alias} `
+    + `ON ${alias}.entity_kind = '${entityKind}' AND ${alias}.entity_id = ${table}.${idColumn}`;
 }

--- a/packages/kernel/src/projection/projection-source-snapshot.ts
+++ b/packages/kernel/src/projection/projection-source-snapshot.ts
@@ -57,17 +57,43 @@ export interface ProjectionSourceSnapshot extends ProjectionSourceFingerprint {
   readonly attributionEvents: ReadonlyArray<UnionAttributionEvent>;
 }
 
+export interface ProjectionSourceCacheReuse {
+  readonly task?: boolean;
+  readonly declared?: boolean;
+  readonly attribution?: boolean;
+  readonly touchedTaskPaths?: ReadonlyArray<string>;
+  readonly validateReusedTaskDirectories?: boolean;
+  readonly validateReusedDeclaredDirectories?: boolean;
+}
+
 export function captureProjectionSourceFingerprint(
   rootInput: HarnessLayoutInput,
-  declaredSourceHints: ReadonlyArray<DeclaredEntitySourceHint> = []
+  declaredSourceHints: ReadonlyArray<DeclaredEntitySourceHint> = [],
+  validation: "stable" | "verify" = "stable",
+  touchedDeclaredPaths: ReadonlyArray<string> = [],
+  reuseUntouchedSourceCaches: ProjectionSourceCacheReuse = {}
 ): ProjectionSourceFingerprint {
-  const taskSource = readMarkdownSource(rootInput);
+  const taskSource = readMarkdownSource(
+    rootInput,
+    validation,
+    reuseUntouchedSourceCaches.task === true,
+    reuseUntouchedSourceCaches.touchedTaskPaths ?? [],
+    reuseUntouchedSourceCaches.validateReusedTaskDirectories !== false
+  );
   const declaredSources = projectionEntityDeclarations.map((declaration) => ({
     declaration,
     table: declaration.projection.table,
-    source: readDeclaredEntitySource(rootInput, declaration, declaredSourceHints)
+    source: readDeclaredEntitySource(
+      rootInput,
+      declaration,
+      declaredSourceHints,
+      validation,
+      touchedDeclaredPaths,
+      reuseUntouchedSourceCaches.declared === true,
+      reuseUntouchedSourceCaches.validateReusedDeclaredDirectories !== false
+    )
   }));
-  const attributionSource = readAttributionEventSource(rootInput);
+  const attributionSource = readAttributionEventSource(rootInput, validation, reuseUntouchedSourceCaches.attribution === true);
   const legacyPersonIds = [...readLegacyPersonIds(rootInput)].sort();
   const fingerprint = stablePayloadHash({
     schema: "projection-source-fingerprint/v2",

--- a/packages/kernel/src/projection/relation-graph-projection.ts
+++ b/packages/kernel/src/projection/relation-graph-projection.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import path from "node:path";
 import { formatRelationFlowRecord, parseEntityRef, validateRelationRecordsForHost } from "../domain/index.ts";
 import type { EntityRelationRecord, EntityRelationValidationIssue } from "../domain/index.ts";
@@ -11,8 +10,14 @@ import {
   relationDecisionAuthoredSourceKind,
   type RelationAuthoredSourceKind
 } from "./relation-source-manifest.ts";
+import {
+  listRelationTaskDirs,
+  listRelationTextFiles,
+  readRelationSourceBody,
+  relationSourceBodyHints,
+  relationSourceSnapshot
+} from "./relation-graph-source-files.ts";
 import { sourcePath, type TaskProjectionSourceHashInput } from "./sqlite-task-source.ts";
-import { readDirIfPresent, readTextFileIfPresent, statPathIfPresent } from "./toctou-safe-fs.ts";
 import { buildClaimFulfillmentRows } from "./claim-fulfillment-projection.ts";
 import { projectFactDocument, type TaskFactProjectionRow } from "./fact-projection.ts";
 import type { ProjectionWarning } from "./types.ts";
@@ -100,12 +105,21 @@ export interface RelationRecordValidationIssue {
 
 export function buildRelationGraphProjection(
   rootInput: HarnessLayoutInput,
-  sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput> = []
+  sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput> = [],
+  reusableFactRefs?: ReadonlySet<string>
 ): RelationGraphProjection {
-  const sourceBodies = sourceBodyHints(rootInput, sourceInputs);
-  const decisions = readDecisionSources(rootInput, sourceBodies);
-  const refIndex = buildGraphRefIndex(rootInput, decisions, sourceBodies);
-  const entries = collectRelationRecordEntries(rootInput, decisions, sourceBodies);
+  const sourceBodies = relationSourceBodyHints(rootInput, sourceInputs);
+  const sourceSnapshot = relationSourceSnapshot(rootInput, sourceInputs);
+  const decisions = readDecisionSources(rootInput, sourceBodies, sourceSnapshot?.decisionFiles);
+  const entries = collectRelationRecordEntries(rootInput, decisions, sourceBodies, sourceSnapshot?.taskDirs, sourceSnapshot !== null);
+  const refIndex = buildGraphRefIndex(
+    rootInput,
+    decisions,
+    sourceBodies,
+    sourceSnapshot?.taskDirs,
+    sourceSnapshot !== null,
+    reusableFactRefs ? { factRefs: reusableFactRefs, entries } : undefined
+  );
   const edges = relationEntriesToEdges(entries, refIndex);
   return {
     edges,
@@ -174,17 +188,19 @@ export function detectRelationGraphCycles(edges: ReadonlyArray<RelationGraphEdge
 function collectRelationRecordEntries(
   rootInput: HarnessLayoutInput,
   decisions: ReadonlyArray<DecisionSource>,
-  sourceBodies: ReadonlyMap<string, string> = new Map()
+  sourceBodies: ReadonlyMap<string, string> = new Map(),
+  taskDirs?: ReadonlyArray<string>,
+  sourceSnapshotComplete = false
 ): ReadonlyArray<RelationRecordEntry> {
   const layout = resolveHarnessLayout(rootInput);
   const rootDir = layout.rootDir;
   const entries: RelationRecordEntry[] = [];
 
-  for (const taskDir of listTaskDirs(layout.tasksRoot)) {
-    const taskId = readTaskPackageId(taskDir, sourceBodies);
+  for (const taskDir of taskDirs ?? listRelationTaskDirs(layout.tasksRoot)) {
+    const taskId = readTaskPackageId(taskDir, sourceBodies, sourceSnapshotComplete);
     for (const source of deriveRelationTaskAuthoredSources(taskDir)) {
-      if (!existsSync(source.filePath)) continue;
-      const body = readSourceBody(source.filePath, sourceBodies);
+      if (!sourceBodies.has(source.filePath) && sourceSnapshotComplete) continue;
+      const body = readRelationSourceBody(source.filePath, sourceBodies);
       if (body === null) continue;
       if (source.content === "frontmatter") {
         const frontmatter = readFrontmatter(body);
@@ -355,15 +371,16 @@ function canonicalRelationRecord(record: EntityRelationRecord): string {
 
 function readDecisionSources(
   rootInput: HarnessLayoutInput,
-  sourceBodies: ReadonlyMap<string, string> = new Map()
+  sourceBodies: ReadonlyMap<string, string> = new Map(),
+  decisionFiles?: ReadonlyArray<string>
 ): ReadonlyArray<DecisionSource> {
   const layout = resolveHarnessLayout(rootInput);
   const decisions: Array<Omit<DecisionSource, "visible"> & { readonly watermark: string }> = [];
   const watermarkCounts = new Map<string, number>();
-  for (const filePath of listTextFiles(layout.decisionsRoot)) {
+  for (const filePath of decisionFiles ?? listRelationTextFiles(layout.decisionsRoot)) {
     const sourceKind = relationDecisionAuthoredSourceKind(filePath);
     if (sourceKind === null) continue;
-    const body = readSourceBody(filePath, sourceBodies);
+    const body = readRelationSourceBody(filePath, sourceBodies);
     if (body === null) continue;
     const frontmatter = readFrontmatter(body);
     if (!frontmatter || readScalar(frontmatter, "schema") !== "decision-package/v1") continue;
@@ -392,23 +409,32 @@ function readDecisionSources(
 function buildGraphRefIndex(
   rootInput: HarnessLayoutInput,
   decisions: ReadonlyArray<DecisionSource>,
-  sourceBodies: ReadonlyMap<string, string> = new Map()
+  sourceBodies: ReadonlyMap<string, string> = new Map(),
+  taskDirs?: ReadonlyArray<string>,
+  sourceSnapshotComplete = false,
+  factSeed?: {
+    readonly factRefs: ReadonlySet<string>;
+    readonly entries: ReadonlyArray<RelationRecordEntry>;
+  }
 ): GraphRefIndex {
   const layout = resolveHarnessLayout(rootInput);
   const taskIds = new Set<string>();
   const doneTaskIds = new Set<string>();
-  const factRefs = new Set<string>();
+  const factRefs = new Set<string>(factSeed?.factRefs);
   const factAnchors: FactAnchorRow[] = [];
   const factRows: TaskFactProjectionRow[] = [];
   const warnings: ProjectionWarning[] = [];
-  for (const taskDir of listTaskDirs(layout.tasksRoot)) {
-    const taskId = readTaskPackageId(taskDir, sourceBodies);
+  const taskDirsById = new Map<string, string>();
+  for (const taskDir of taskDirs ?? listRelationTaskDirs(layout.tasksRoot)) {
+    const taskId = readTaskPackageId(taskDir, sourceBodies, sourceSnapshotComplete);
     taskIds.add(taskId);
+    taskDirsById.set(taskId, taskDir);
     if (readTaskPackageStatus(taskDir, sourceBodies) === "done") doneTaskIds.add(taskId);
+    if (factSeed) continue;
     const factsPath = deriveRelationTaskAuthoredSources(taskDir)
       .find((source) => source.kind === "task-facts")?.filePath;
-    if (!factsPath || !existsSync(factsPath)) continue;
-    const factsBody = readSourceBody(factsPath, sourceBodies);
+    if (!factsPath || (!sourceBodies.has(factsPath) && sourceSnapshotComplete)) continue;
+    const factsBody = readRelationSourceBody(factsPath, sourceBodies);
     if (factsBody === null) continue;
     const portableFactsPath = sourcePath(layout.rootDir, factsPath);
     const projected = projectFactDocument(taskId, portableFactsPath, factsBody);
@@ -432,6 +458,7 @@ function buildGraphRefIndex(
     }
     factRows.push(...projected.rows);
   }
+  if (factSeed) addReferencedFactSources(factRefs, factSeed.entries, taskDirsById, sourceBodies, layout.rootDir);
 
   const decisionIds = new Set<string>();
   const decisionAnchors = new Set<string>();
@@ -452,6 +479,32 @@ function buildGraphRefIndex(
     factRows: factRows.sort((a, b) => a.ref.localeCompare(b.ref)),
     warnings
   };
+}
+
+function addReferencedFactSources(
+  factRefs: Set<string>,
+  entries: ReadonlyArray<RelationRecordEntry>,
+  taskDirsById: ReadonlyMap<string, string>,
+  sourceBodies: ReadonlyMap<string, string>,
+  rootDir: string
+): void {
+  const checkedOwners = new Set<string>();
+  for (const entry of entries) {
+    for (const endpoint of [entry.record.source, entry.record.target]) {
+      const ref = parseEntityRef(endpoint);
+      if (ref?.kind !== "fact" || !ref.ownerTaskId || factRefs.has(`${ref.ownerTaskId}/${ref.id}`) || checkedOwners.has(ref.ownerTaskId)) continue;
+      checkedOwners.add(ref.ownerTaskId);
+      const taskDir = taskDirsById.get(ref.ownerTaskId);
+      if (!taskDir) continue;
+      const factsPath = deriveRelationTaskAuthoredSources(taskDir)
+        .find((source) => source.kind === "task-facts")?.filePath;
+      if (!factsPath) continue;
+      const body = readRelationSourceBody(factsPath, sourceBodies);
+      if (body === null) continue;
+      const projected = projectFactDocument(ref.ownerTaskId, sourcePath(rootDir, factsPath), body);
+      for (const record of projected.records) factRefs.add(`${ref.ownerTaskId}/${record.fact_id}`);
+    }
+  }
 }
 
 function isKnownLocalEndpoint(refText: string, refIndex: GraphRefIndex): boolean {
@@ -492,58 +545,22 @@ function readFlowObjectBlock(frontmatter: string, key: string): string {
   return output.join("\n");
 }
 
-function readTaskPackageId(taskDir: string, sourceBodies: ReadonlyMap<string, string> = new Map()): string {
+function readTaskPackageId(
+  taskDir: string,
+  sourceBodies: ReadonlyMap<string, string> = new Map(),
+  sourceSnapshotComplete = false
+): string {
   const indexPath = path.join(taskDir, "INDEX.md");
-  if (!existsSync(indexPath)) return path.basename(taskDir);
-  const body = readSourceBody(indexPath, sourceBodies);
+  if (!sourceBodies.has(indexPath) && sourceSnapshotComplete) return path.basename(taskDir);
+  const body = readRelationSourceBody(indexPath, sourceBodies);
   const frontmatter = body === null ? null : readFrontmatter(body);
   return (frontmatter ? readScalar(frontmatter, "task_id") : "") || path.basename(taskDir);
 }
 
 function readTaskPackageStatus(taskDir: string, sourceBodies: ReadonlyMap<string, string> = new Map()): string {
-  const body = readSourceBody(path.join(taskDir, "INDEX.md"), sourceBodies);
+  const body = readRelationSourceBody(path.join(taskDir, "INDEX.md"), sourceBodies);
   const frontmatter = body === null ? null : readFrontmatter(body);
   return frontmatter ? readScalar(frontmatter, "  status") : "";
-}
-
-function listTaskDirs(tasksRoot: string): ReadonlyArray<string> {
-  if (!existsSync(tasksRoot)) return [];
-  const entries = readDirIfPresent(tasksRoot);
-  if (entries === null) return [];
-  return entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => path.join(tasksRoot, entry.name))
-    .sort();
-}
-
-function listTextFiles(inputPath: string): ReadonlyArray<string> {
-  if (!existsSync(inputPath)) return [];
-  const stat = statPathIfPresent(inputPath);
-  if (stat === null) return [];
-  if (stat.isFile()) return isRelationGraphTextLikePath(inputPath) ? [inputPath] : [];
-  if (!stat.isDirectory()) return [];
-  const entries = readDirIfPresent(inputPath);
-  if (entries === null) return [];
-  return entries
-    .filter((entry) => entry.name !== ".git" && entry.name !== "node_modules")
-    .flatMap((entry) => listTextFiles(path.join(inputPath, entry.name)))
-    .sort();
-}
-
-function sourceBodyHints(
-  rootInput: HarnessLayoutInput,
-  sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>
-): ReadonlyMap<string, string> {
-  const rootDir = resolveHarnessLayout(rootInput).rootDir;
-  return new Map(sourceInputs.map((input) => [path.resolve(rootDir, input.sourcePath), input.body]));
-}
-
-function readSourceBody(filePath: string, sourceBodies: ReadonlyMap<string, string>): string | null {
-  return sourceBodies.get(filePath) ?? readTextFileIfPresent(filePath);
-}
-
-function isRelationGraphTextLikePath(filePath: string): boolean {
-  return /\.(md|markdown|txt|ya?ml|json)$/iu.test(filePath);
 }
 
 function compareEdges(a: RelationGraphEdgeRow, b: RelationGraphEdgeRow): number {

--- a/packages/kernel/src/projection/relation-graph-source-files.ts
+++ b/packages/kernel/src/projection/relation-graph-source-files.ts
@@ -1,0 +1,61 @@
+import path from "node:path";
+import type { HarnessLayoutInput } from "../layout/index.ts";
+import { resolveHarnessLayout } from "../layout/index.ts";
+import { relationDecisionAuthoredSourceKind } from "./relation-source-manifest.ts";
+import type { TaskProjectionSourceHashInput } from "./sqlite-task-source.ts";
+import { readDirIfPresent, readTextFileIfPresent, statPathIfPresent } from "./toctou-safe-fs.ts";
+
+export function listRelationTaskDirs(tasksRoot: string): ReadonlyArray<string> {
+  if (!statPathIfPresent(tasksRoot)?.isDirectory()) return [];
+  const entries = readDirIfPresent(tasksRoot);
+  if (entries === null) return [];
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(tasksRoot, entry.name))
+    .sort();
+}
+
+export function listRelationTextFiles(inputPath: string): ReadonlyArray<string> {
+  const stat = statPathIfPresent(inputPath);
+  if (stat === null) return [];
+  if (stat.isFile()) return relationDecisionAuthoredSourceKind(inputPath) === null ? [] : [inputPath];
+  if (!stat.isDirectory()) return [];
+  const entries = readDirIfPresent(inputPath);
+  if (entries === null) return [];
+  return entries
+    .filter((entry) => entry.name !== ".git" && entry.name !== "node_modules")
+    .flatMap((entry) => listRelationTextFiles(path.join(inputPath, entry.name)))
+    .sort();
+}
+
+export function relationSourceBodyHints(
+  rootInput: HarnessLayoutInput,
+  sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>
+): ReadonlyMap<string, string> {
+  const rootDir = resolveHarnessLayout(rootInput).rootDir;
+  return new Map(sourceInputs.map((input) => [path.resolve(rootDir, input.sourcePath), input.body]));
+}
+
+export function relationSourceSnapshot(
+  rootInput: HarnessLayoutInput,
+  sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>
+): { readonly taskDirs: ReadonlyArray<string>; readonly decisionFiles: ReadonlyArray<string> } | null {
+  if (sourceInputs.length === 0) return null;
+  const rootDir = resolveHarnessLayout(rootInput).rootDir;
+  const taskDirs = sourceInputs
+    .filter((input) => input.kind === "task-index")
+    .map((input) => path.dirname(path.resolve(rootDir, input.sourcePath)))
+    .sort();
+  const decisionFiles = sourceInputs
+    .filter((input) => input.kind === "decision-document")
+    .map((input) => path.resolve(rootDir, input.sourcePath))
+    .sort();
+  return { taskDirs, decisionFiles };
+}
+
+export function readRelationSourceBody(
+  filePath: string,
+  sourceBodies: ReadonlyMap<string, string>
+): string | null {
+  return sourceBodies.get(filePath) ?? readTextFileIfPresent(filePath);
+}

--- a/packages/kernel/src/projection/relation-graph-source-semantics.ts
+++ b/packages/kernel/src/projection/relation-graph-source-semantics.ts
@@ -1,0 +1,88 @@
+import path from "node:path";
+import { parseFactFlowRecords } from "../domain/index.ts";
+import { stablePayloadHash } from "../integrity/stable-hash.ts";
+import { readBlockScalar } from "../markdown/flow-frontmatter.ts";
+import { readFrontmatter, readScalar } from "../markdown/frontmatter.ts";
+import { parseRelationFlowRecords } from "./relation-flow-frontmatter.ts";
+
+export function relationGraphSourceSemanticHash(sourcePathValue: string, body: string | undefined): string {
+  if (body === undefined) return stablePayloadHash({ schema: "relation-source-semantics/v1", absent: true });
+  const basename = path.basename(sourcePathValue);
+  if (basename === "INDEX.md") {
+    const frontmatter = readFrontmatter(body) ?? "";
+    return stablePayloadHash({
+      schema: "relation-source-semantics/v1",
+      kind: "task-index",
+      taskId: readScalar(frontmatter, "task_id"),
+      status: readScalar(frontmatter, "  status"),
+      relations: parseRelationFlowRecords(frontmatter)
+    });
+  }
+  if (basename === "facts.md") {
+    return stablePayloadHash({
+      schema: "relation-source-semantics/v1",
+      kind: "facts",
+      facts: parseFactFlowRecords(body),
+      relations: parseRelationFlowRecords(body)
+    });
+  }
+  if (basename === "decision.md") {
+    const frontmatter = readFrontmatter(body) ?? "";
+    return stablePayloadHash({
+      schema: "relation-source-semantics/v1",
+      kind: "decision",
+      schemaValue: readScalar(frontmatter, "schema"),
+      decisionId: readScalar(frontmatter, "decision_id"),
+      watermark: readScalar(frontmatter, "_coordinatorWatermark"),
+      claims: readSemanticFlowObjectBlock(frontmatter, "claims"),
+      chosen: readSemanticFlowObjectBlock(frontmatter, "chosen"),
+      rejected: readSemanticFlowObjectBlock(frontmatter, "rejected"),
+      appliesTo: {
+        modules: readBlockScalar(frontmatter, "applies_to", "modules"),
+        productLines: readBlockScalar(frontmatter, "applies_to", "productLines")
+      },
+      relations: parseRelationFlowRecords(frontmatter)
+    });
+  }
+  return stablePayloadHash({ schema: "relation-source-semantics/v1", kind: "unrelated" });
+}
+
+export function relationGraphFactProjectionSemanticHash(sourcePathValue: string, body: string | undefined): string {
+  if (body === undefined) return stablePayloadHash({ schema: "relation-fact-source-semantics/v1", absent: true });
+  const basename = path.basename(sourcePathValue);
+  if (basename === "INDEX.md") {
+    const frontmatter = readFrontmatter(body) ?? "";
+    return stablePayloadHash({
+      schema: "relation-fact-source-semantics/v1",
+      kind: "task-index",
+      taskId: readScalar(frontmatter, "task_id")
+    });
+  }
+  if (basename === "facts.md") {
+    return stablePayloadHash({
+      schema: "relation-fact-source-semantics/v1",
+      kind: "facts",
+      facts: parseFactFlowRecords(body)
+    });
+  }
+  return stablePayloadHash({ schema: "relation-fact-source-semantics/v1", kind: "unrelated" });
+}
+
+function readSemanticFlowObjectBlock(frontmatter: string, key: string): string {
+  const lines = frontmatter.split(/\r?\n/u);
+  const output: string[] = [];
+  let inBlock = false;
+  for (const line of lines) {
+    if (line === `${key}:`) {
+      inBlock = true;
+      continue;
+    }
+    if (!inBlock) continue;
+    if (/^\s*-\s*\{/u.test(line)) {
+      output.push(line);
+      continue;
+    }
+    if (/^\S/u.test(line)) break;
+  }
+  return output.join("\n");
+}

--- a/packages/kernel/src/projection/sqlite-attribution-event-store.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-event-store.ts
@@ -1,0 +1,197 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+import type { AttributionEvent } from "../schemas/attribution-event.ts";
+import type { AttributionEventV2, UnionAttributionEvent } from "../schemas/attribution-event-union.ts";
+import { ensureEntityAttributionSummaryTable } from "./sqlite-attribution-summary.ts";
+
+export function ensureAttributionEventTables(
+  sql: SqlClient.SqlClient
+): Effect.Effect<unknown, unknown> {
+  return Effect.gen(function* () {
+    yield* ensureEntityAttributionSummaryTable(sql);
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS attribution_events (
+        event_id TEXT PRIMARY KEY,
+        op_id TEXT NOT NULL UNIQUE,
+        subject_ref TEXT NOT NULL,
+        operation TEXT NOT NULL,
+        principal_person_id TEXT NOT NULL,
+        executor_agent_id TEXT,
+        occurred_at TEXT NOT NULL,
+        recorded_at TEXT NOT NULL,
+        source_json TEXT NOT NULL
+      )
+    `;
+    yield* sql`CREATE INDEX IF NOT EXISTS attribution_events_subject_time ON attribution_events(subject_ref, occurred_at, event_id)`;
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS attribution_event_headers (
+        event_id TEXT PRIMARY KEY,
+        op_id TEXT NOT NULL UNIQUE,
+        workspace_id TEXT NOT NULL,
+        revision INTEGER NOT NULL UNIQUE,
+        commit_sha TEXT NOT NULL,
+        previous_commit TEXT,
+        principal_person_id TEXT NOT NULL,
+        executor_agent_id TEXT,
+        occurred_at TEXT NOT NULL,
+        recorded_at TEXT NOT NULL,
+        source_json TEXT NOT NULL
+      )
+    `;
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS attribution_event_mutations (
+        event_id TEXT NOT NULL,
+        mutation_index INTEGER NOT NULL,
+        registry_version INTEGER NOT NULL,
+        entity_kind TEXT NOT NULL,
+        subject_ref TEXT NOT NULL,
+        operation TEXT NOT NULL,
+        PRIMARY KEY (event_id, mutation_index),
+        FOREIGN KEY (event_id) REFERENCES attribution_event_headers(event_id) ON DELETE CASCADE
+      )
+    `;
+    yield* sql`CREATE INDEX IF NOT EXISTS attribution_event_mutations_subject ON attribution_event_mutations(subject_ref, event_id)`;
+  });
+}
+
+export function replaceAttributionEvents(
+  sql: SqlClient.SqlClient,
+  events: ReadonlyArray<UnionAttributionEvent>
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    yield* ensureAttributionEventTables(sql);
+    yield* sql`DELETE FROM attribution_event_mutations`;
+    yield* sql`DELETE FROM attribution_event_headers`;
+    yield* sql`DELETE FROM attribution_events`;
+    const legacyEvents = events.filter((event): event is AttributionEvent => event.schema === "attribution-event/v1");
+    for (const batch of chunks(legacyEvents, 1_000)) yield* insertLegacyAttributionEvents(sql, batch);
+    const currentEvents = events.filter((event): event is AttributionEventV2 => event.schema === "attribution-event/v2");
+    for (const batch of chunks(currentEvents, 1_000)) yield* insertAttributionEventHeaders(sql, batch);
+    const mutations = currentEvents.flatMap((event) => event.mutationSet.mutations.map((mutation, mutationIndex) => ({
+      event,
+      mutation,
+      mutationIndex
+    })));
+    for (const batch of chunks(mutations, 1_000)) yield* insertAttributionEventMutations(sql, batch);
+  });
+}
+
+export function insertAttributionEvent(
+  sql: SqlClient.SqlClient,
+  event: UnionAttributionEvent
+): Effect.Effect<unknown, unknown> {
+  if (event.schema === "attribution-event/v1") return insertLegacyAttributionEvent(sql, event);
+  return Effect.gen(function* () {
+    yield* sql`
+      INSERT INTO attribution_event_headers (
+        event_id, op_id, workspace_id, revision, commit_sha, previous_commit,
+        principal_person_id, executor_agent_id, occurred_at, recorded_at, source_json
+      ) VALUES (
+        ${event.eventId}, ${event.opId}, ${event.workspaceId}, ${event.revision}, ${event.commitSha}, ${event.previousCommit},
+        ${event.actorAxesBinding.principalPersonId}, ${event.actorAxesBinding.executorAgentId},
+        ${event.occurredAt}, ${event.recordedAt}, ${JSON.stringify(event)}
+      )
+    `;
+    for (let index = 0; index < event.mutationSet.mutations.length; index += 1) {
+      const mutation = event.mutationSet.mutations[index]!;
+      yield* sql`
+        INSERT INTO attribution_event_mutations (
+          event_id, mutation_index, registry_version, entity_kind, subject_ref, operation
+        ) VALUES (
+          ${event.eventId}, ${index}, ${event.mutationSet.registryVersion}, ${mutation.entity.entityKind},
+          ${mutation.entity.canonicalRef}, ${mutation.action.action}
+        )
+      `;
+    }
+  });
+}
+
+function insertLegacyAttributionEvent(
+  sql: SqlClient.SqlClient,
+  event: AttributionEvent
+): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT INTO attribution_events (
+      event_id, op_id, subject_ref, operation, principal_person_id,
+      executor_agent_id, occurred_at, recorded_at, source_json
+    ) VALUES (
+      ${event.eventId}, ${event.opId}, ${event.entityId}, ${event.kind},
+      ${event.actor.principal.personId}, ${event.actor.executor?.id ?? null},
+      ${event.at}, ${event.recordedAt}, ${JSON.stringify(event)}
+    )
+  `;
+}
+
+function insertLegacyAttributionEvents(
+  sql: SqlClient.SqlClient,
+  events: ReadonlyArray<AttributionEvent>
+): Effect.Effect<unknown, unknown> {
+  return sql.unsafe(`
+    INSERT INTO attribution_events (
+      event_id, op_id, subject_ref, operation, principal_person_id,
+      executor_agent_id, occurred_at, recorded_at, source_json
+    ) VALUES ${events.map(() => "(?, ?, ?, ?, ?, ?, ?, ?, ?)").join(", ")}
+  `, events.flatMap((event) => [
+    event.eventId,
+    event.opId,
+    event.entityId,
+    event.kind,
+    event.actor.principal.personId,
+    event.actor.executor?.id ?? null,
+    event.at,
+    event.recordedAt,
+    JSON.stringify(event)
+  ]));
+}
+
+function insertAttributionEventHeaders(
+  sql: SqlClient.SqlClient,
+  events: ReadonlyArray<AttributionEventV2>
+): Effect.Effect<unknown, unknown> {
+  return sql.unsafe(`
+    INSERT INTO attribution_event_headers (
+      event_id, op_id, workspace_id, revision, commit_sha, previous_commit,
+      principal_person_id, executor_agent_id, occurred_at, recorded_at, source_json
+    ) VALUES ${events.map(() => "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").join(", ")}
+  `, events.flatMap((event) => [
+    event.eventId,
+    event.opId,
+    event.workspaceId,
+    event.revision,
+    event.commitSha,
+    event.previousCommit,
+    event.actorAxesBinding.principalPersonId,
+    event.actorAxesBinding.executorAgentId,
+    event.occurredAt,
+    event.recordedAt,
+    JSON.stringify(event)
+  ]));
+}
+
+function insertAttributionEventMutations(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<{
+    readonly event: AttributionEventV2;
+    readonly mutation: AttributionEventV2["mutationSet"]["mutations"][number];
+    readonly mutationIndex: number;
+  }>
+): Effect.Effect<unknown, unknown> {
+  return sql.unsafe(`
+    INSERT INTO attribution_event_mutations (
+      event_id, mutation_index, registry_version, entity_kind, subject_ref, operation
+    ) VALUES ${rows.map(() => "(?, ?, ?, ?, ?, ?)").join(", ")}
+  `, rows.flatMap(({ event, mutation, mutationIndex }) => [
+    event.eventId,
+    mutationIndex,
+    event.mutationSet.registryVersion,
+    mutation.entity.entityKind,
+    mutation.entity.canonicalRef,
+    mutation.action.action
+  ]));
+}
+
+function chunks<Value>(values: ReadonlyArray<Value>, size: number): ReadonlyArray<ReadonlyArray<Value>> {
+  const output: Value[][] = [];
+  for (let index = 0; index < values.length; index += size) output.push(values.slice(index, index + size));
+  return output;
+}

--- a/packages/kernel/src/projection/sqlite-attribution-projection.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-projection.ts
@@ -18,7 +18,20 @@ import {
   type AttributionEventV2,
   type UnionAttributionEvent
 } from "../schemas/attribution-event-union.ts";
-import { unresolvedEntityAttribution } from "./entity-attribution-projection.ts";
+import {
+  attributionFromRecord,
+  attributionSummarySelect,
+  deleteEntityAttributionSummary,
+  ensureEntityAttributionSummaryTable,
+  replaceEntityAttributionSummaries,
+  upsertEntityAttributionSummary,
+  type EntityAttributionSummaryRow
+} from "./sqlite-attribution-summary.ts";
+import {
+  ensureAttributionEventTables,
+  insertAttributionEvent,
+  replaceAttributionEvents
+} from "./sqlite-attribution-event-store.ts";
 import type { ProjectionSourceCacheChange } from "./sqlite-projection-source-cache.ts";
 import { runSqlite } from "./sqlite-projection-store.ts";
 import type { EntityAttributionProjection } from "./types.ts";
@@ -86,17 +99,20 @@ export function readModuleAttributionProjection(
     || facet.attributionTarget.materialization !== "mutation-index") {
     throw new Error("MODULE_ATTRIBUTION_PROJECTION_FACET_NOT_READY");
   }
-  const target = facet.attributionTarget;
   return runSqlite(projectionPath, Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
-    const where = moduleKey === undefined ? "" : ` WHERE ${target.idColumn} = ?`;
+    yield* ensureEntityAttributionSummaryTable(sql);
+    const where = moduleKey === undefined ? "" : " AND entity_id = ?";
     const rows = yield* sql.unsafe<Record<string, unknown>>(
-      `SELECT ${target.idColumn}, attribution_json FROM ${target.table}${where} ORDER BY ${target.idColumn}`,
+      `SELECT entity_id AS module_key, ${attributionSummarySelect("entity_attribution_summary")}
+       FROM entity_attribution_summary
+       WHERE entity_kind = 'module'${where}
+       ORDER BY entity_id`,
       moduleKey === undefined ? [] : [moduleKey]
     );
     return rows.map((row) => ({
-      moduleKey: String(row[target.idColumn]),
-      attribution: JSON.parse(String(row.attribution_json)) as EntityAttributionProjection
+      moduleKey: String(row.module_key),
+      attribution: attributionFromRecord(row)
     }));
   }));
 }
@@ -105,13 +121,7 @@ export function replaceAttributionProjectionRows(
   sql: SqlClient.SqlClient,
   events: ReadonlyArray<UnionAttributionEvent>
 ): Effect.Effect<void, unknown> {
-  return Effect.gen(function* () {
-    yield* createAttributionTables(sql);
-    yield* sql`DELETE FROM attribution_event_mutations`;
-    yield* sql`DELETE FROM attribution_event_headers`;
-    yield* sql`DELETE FROM attribution_events`;
-    for (const event of events) yield* insertAttributionEvent(sql, event);
-  });
+  return replaceAttributionEvents(sql, events);
 }
 
 export function applyAttributionProjectionDelta(
@@ -119,7 +129,7 @@ export function applyAttributionProjectionDelta(
   delta: AttributionProjectionDelta
 ): Effect.Effect<ReadonlyArray<string>, unknown> {
   return Effect.gen(function* () {
-    yield* createAttributionTables(sql);
+    yield* ensureAttributionEventTables(sql);
     for (const eventId of delta.deleteEventIds) {
       yield* sql`DELETE FROM attribution_event_mutations WHERE event_id = ${eventId}`;
       yield* sql`DELETE FROM attribution_event_headers WHERE event_id = ${eventId}`;
@@ -168,28 +178,33 @@ export function materializeEntityAttributionBlocks(
   events: ReadonlyArray<UnionAttributionEvent>
 ): Effect.Effect<void, unknown> {
   const rows = events.flatMap(eventToProjectionRows);
+  const rowsByTarget = attributionRowsByTarget(rows);
   return Effect.gen(function* () {
     const existing = new Set((yield* sql<{ readonly name: string }>`SELECT name FROM sqlite_master WHERE type = 'table'`)
       .map((row) => String(row.name)));
+    const summaries: EntityAttributionSummaryRow[] = [];
     for (const target of registryAttributionTargets()) {
       if (target.materialization === "mutation-index") {
-        const hasIndexedRows = rows.some((row) => row.entityKind === target.kind);
-        if (!hasIndexedRows && !existing.has(target.table)) continue;
-        yield* ensureMutationIndexTarget(sql, target, rows, true);
-        existing.add(target.table);
+        for (const [key, attributed] of rowsByTarget) {
+          const prefix = `${target.kind}\0`;
+          if (!key.startsWith(prefix)) continue;
+          summaries.push({
+            entityKind: target.kind,
+            entityId: key.slice(prefix.length),
+            attribution: eventAttribution(attributed)
+          });
+        }
+        continue;
       }
       if (!existing.has(target.table)) continue;
-      yield* sql.unsafe(`UPDATE ${target.table} SET attribution_json = ?`, [JSON.stringify(unresolvedEntityAttribution())]);
       const records = yield* sql.unsafe<Record<string, unknown>>(`SELECT ${target.idColumn} FROM ${target.table}`);
       for (const record of records) {
         const id = String(record[target.idColumn]);
-        const attributed = rows.filter((row) => projectionRowMatchesTarget(row, target.kind, id));
-        if (attributed.length === 0) continue;
-        yield* sql.unsafe(`UPDATE ${target.table} SET attribution_json = ? WHERE ${target.idColumn} = ?`, [
-          JSON.stringify(eventAttribution(attributed)), id
-        ]);
+        const attributed = rowsByTarget.get(attributionTargetKey(target.kind, id));
+        if (attributed) summaries.push({ entityKind: target.kind, entityId: id, attribution: eventAttribution(attributed) });
       }
     }
+    yield* replaceEntityAttributionSummaries(sql, summaries);
   });
 }
 
@@ -200,20 +215,26 @@ export function materializeEntityAttributionTargets(
   const uniqueTargets = new Map(targets.map((target) => [`${target.table}\0${target.id}`, target]));
   return Effect.gen(function* () {
     const rows = yield* readAttributionProjectionRows(sql);
+    const rowsByTarget = attributionRowsByTarget(rows);
+    const existing = new Set((yield* sql<{ readonly name: string }>`SELECT name FROM sqlite_master WHERE type = 'table'`)
+      .map((row) => String(row.name)));
     for (const target of uniqueTargets.values()) {
       const declaration = registryAttributionTargets().find((candidate) => candidate.table === target.table);
       if (!declaration) throw new Error(`unknown attributed projection table: ${target.table}`);
-      if (declaration.materialization === "mutation-index") {
-        yield* ensureMutationIndexTarget(sql, declaration, [], false, [target.id]);
+      yield* deleteEntityAttributionSummary(sql, declaration.kind, target.id);
+      if (declaration.materialization === "existing-entity-table") {
+        if (!existing.has(declaration.table)) continue;
+        const [record] = yield* sql.unsafe<Record<string, unknown>>(
+          `SELECT ${declaration.idColumn} FROM ${declaration.table} WHERE ${declaration.idColumn} = ?`, [target.id]
+        );
+        if (!record) continue;
       }
-      yield* sql.unsafe(`UPDATE ${declaration.table} SET attribution_json = ? WHERE ${declaration.idColumn} = ?`, [
-        JSON.stringify(unresolvedEntityAttribution()), target.id
-      ]);
-      const attributed = rows.filter((row) => projectionRowMatchesTarget(row, declaration.kind, target.id));
-      if (attributed.length === 0) continue;
-      yield* sql.unsafe(`UPDATE ${declaration.table} SET attribution_json = ? WHERE ${declaration.idColumn} = ?`, [
-        JSON.stringify(eventAttribution(attributed)), target.id
-      ]);
+      const attributed = rowsByTarget.get(attributionTargetKey(declaration.kind, target.id));
+      if (attributed) yield* upsertEntityAttributionSummary(sql, {
+        entityKind: declaration.kind,
+        entityId: target.id,
+        attribution: eventAttribution(attributed)
+      });
     }
   });
 }
@@ -224,13 +245,17 @@ export function materializeEntityAttributionSubjects(
 ): Effect.Effect<void, unknown> {
   return Effect.gen(function* () {
     const targets: Array<{ readonly table: string; readonly id: string }> = [];
+    const existing = new Set((yield* sql<{ readonly name: string }>`SELECT name FROM sqlite_master WHERE type = 'table'`)
+      .map((row) => String(row.name)));
     for (const target of registryAttributionTargets()) {
       for (const subjectRef of new Set(subjectRefs)) {
         const id = resolveTargetId(subjectRef, target.kind) ?? legacyTargetId(subjectRef, target.kind);
         if (!id) continue;
         if (target.materialization === "mutation-index") {
-          yield* ensureMutationIndexTarget(sql, target, [], false, [id]);
+          targets.push({ table: target.table, id });
+          continue;
         }
+        if (!existing.has(target.table)) continue;
         const records = yield* sql.unsafe<Record<string, unknown>>(
           `SELECT ${target.idColumn} AS entity_id FROM ${target.table} WHERE ${target.idColumn} = ?`, [id]
         );
@@ -254,93 +279,6 @@ export function countAttributionProjectionRows(projectionPath: string): number {
     const [record] = yield* sql<{ readonly count: number }>`SELECT COUNT(*) AS count FROM attribution_events`;
     return Number(record?.count ?? 0);
   }));
-}
-
-function createAttributionTables(sql: SqlClient.SqlClient): Effect.Effect<unknown, unknown> {
-  return Effect.gen(function* () {
-    yield* sql`
-      CREATE TABLE IF NOT EXISTS attribution_events (
-        event_id TEXT PRIMARY KEY,
-        op_id TEXT NOT NULL UNIQUE,
-        subject_ref TEXT NOT NULL,
-        operation TEXT NOT NULL,
-        principal_person_id TEXT NOT NULL,
-        executor_agent_id TEXT,
-        occurred_at TEXT NOT NULL,
-        recorded_at TEXT NOT NULL,
-        source_json TEXT NOT NULL
-      )
-    `;
-    yield* sql`CREATE INDEX IF NOT EXISTS attribution_events_subject_time ON attribution_events(subject_ref, occurred_at, event_id)`;
-    yield* sql`
-      CREATE TABLE IF NOT EXISTS attribution_event_headers (
-        event_id TEXT PRIMARY KEY,
-        op_id TEXT NOT NULL UNIQUE,
-        workspace_id TEXT NOT NULL,
-        revision INTEGER NOT NULL UNIQUE,
-        commit_sha TEXT NOT NULL,
-        previous_commit TEXT,
-        principal_person_id TEXT NOT NULL,
-        executor_agent_id TEXT,
-        occurred_at TEXT NOT NULL,
-        recorded_at TEXT NOT NULL,
-        source_json TEXT NOT NULL
-      )
-    `;
-    yield* sql`
-      CREATE TABLE IF NOT EXISTS attribution_event_mutations (
-        event_id TEXT NOT NULL,
-        mutation_index INTEGER NOT NULL,
-        registry_version INTEGER NOT NULL,
-        entity_kind TEXT NOT NULL,
-        subject_ref TEXT NOT NULL,
-        operation TEXT NOT NULL,
-        PRIMARY KEY (event_id, mutation_index),
-        FOREIGN KEY (event_id) REFERENCES attribution_event_headers(event_id) ON DELETE CASCADE
-      )
-    `;
-    yield* sql`CREATE INDEX IF NOT EXISTS attribution_event_mutations_subject ON attribution_event_mutations(subject_ref, event_id)`;
-  });
-}
-
-function insertAttributionEvent(sql: SqlClient.SqlClient, event: UnionAttributionEvent): Effect.Effect<unknown, unknown> {
-  if (event.schema === "attribution-event/v1") return insertLegacyAttributionEvent(sql, event);
-  return Effect.gen(function* () {
-    yield* sql`
-      INSERT INTO attribution_event_headers (
-        event_id, op_id, workspace_id, revision, commit_sha, previous_commit,
-        principal_person_id, executor_agent_id, occurred_at, recorded_at, source_json
-      ) VALUES (
-        ${event.eventId}, ${event.opId}, ${event.workspaceId}, ${event.revision}, ${event.commitSha}, ${event.previousCommit},
-        ${event.actorAxesBinding.principalPersonId}, ${event.actorAxesBinding.executorAgentId},
-        ${event.occurredAt}, ${event.recordedAt}, ${JSON.stringify(event)}
-      )
-    `;
-    for (let index = 0; index < event.mutationSet.mutations.length; index += 1) {
-      const mutation = event.mutationSet.mutations[index]!;
-      yield* sql`
-        INSERT INTO attribution_event_mutations (
-          event_id, mutation_index, registry_version, entity_kind, subject_ref, operation
-        ) VALUES (
-          ${event.eventId}, ${index}, ${event.mutationSet.registryVersion}, ${mutation.entity.entityKind},
-          ${mutation.entity.canonicalRef}, ${mutation.action.action}
-        )
-      `;
-    }
-  });
-}
-
-function insertLegacyAttributionEvent(sql: SqlClient.SqlClient, event: AttributionEvent): Effect.Effect<unknown, unknown> {
-  return sql`
-    INSERT INTO attribution_events (
-      event_id, op_id, subject_ref, operation, principal_person_id,
-      executor_agent_id, occurred_at, recorded_at, source_json
-    ) VALUES (
-      ${event.eventId}, ${event.opId}, ${event.entityId}, ${event.kind},
-      ${event.actor.principal.personId}, ${event.actor.executor?.id ?? null},
-      ${event.at}, ${event.recordedAt}, ${JSON.stringify(event)}
-    )
-  `;
 }
 
 function eventToProjectionRows(event: UnionAttributionEvent): ReadonlyArray<AttributionProjectionRow> {
@@ -406,7 +344,7 @@ function v2MutationToProjectionRow(
 
 function readAttributionProjectionRows(sql: SqlClient.SqlClient): Effect.Effect<ReadonlyArray<AttributionProjectionRow>, unknown> {
   return Effect.gen(function* () {
-    yield* createAttributionTables(sql);
+    yield* ensureAttributionEventTables(sql);
     const legacy = yield* sql<LegacyAttributionRecord>`
       SELECT event_id, op_id, subject_ref, operation, principal_person_id,
              executor_agent_id, occurred_at, recorded_at, source_json
@@ -451,38 +389,29 @@ function registryAttributionTargets(): ReadonlyArray<{
   });
 }
 
-function ensureMutationIndexTarget(
-  sql: SqlClient.SqlClient,
-  target: ReturnType<typeof registryAttributionTargets>[number],
-  rows: ReadonlyArray<AttributionProjectionRow>,
-  replace: boolean,
-  explicitIds: ReadonlyArray<string> = []
-): Effect.Effect<void, unknown> {
-  return Effect.gen(function* () {
-    yield* sql.unsafe(
-      `CREATE TABLE IF NOT EXISTS ${target.table} (`
-      + `${target.idColumn} TEXT PRIMARY KEY, `
-      + "attribution_json TEXT NOT NULL DEFAULT '{\"originator\":null,\"latestActor\":null,\"trailCount\":0,\"completeness\":\"unresolved\"}')"
-    );
-    if (replace) yield* sql.unsafe(`DELETE FROM ${target.table}`);
-    const ids = new Set(explicitIds);
+function attributionRowsByTarget(
+  rows: ReadonlyArray<AttributionProjectionRow>
+): ReadonlyMap<string, ReadonlyArray<AttributionProjectionRow>> {
+  const indexed = new Map<string, AttributionProjectionRow[]>();
+  for (const target of registryAttributionTargets()) {
     for (const row of rows) {
-      if (row.entityKind !== target.kind) continue;
-      const id = resolveTargetId(row.subjectRef, target.kind);
-      if (id) ids.add(id);
+      const id = row.eventSchemaVersion === 1
+        ? legacyTargetId(row.subjectRef, target.kind)
+        : row.entityKind === target.kind
+          ? resolveTargetId(row.subjectRef, target.kind)
+          : null;
+      if (!id) continue;
+      const key = attributionTargetKey(target.kind, id);
+      const existing = indexed.get(key) ?? [];
+      existing.push(row);
+      indexed.set(key, existing);
     }
-    for (const id of ids) {
-      yield* sql.unsafe(
-        `INSERT INTO ${target.table} (${target.idColumn}) VALUES (?) ON CONFLICT (${target.idColumn}) DO NOTHING`,
-        [id]
-      );
-    }
-  });
+  }
+  return indexed;
 }
 
-function projectionRowMatchesTarget(row: AttributionProjectionRow, kind: CanonicalEntityKind, id: string): boolean {
-  if (row.eventSchemaVersion === 1) return legacyTargetId(row.subjectRef, kind) === id;
-  return row.entityKind === kind && resolveTargetId(row.subjectRef, kind) === id;
+function attributionTargetKey(kind: CanonicalEntityKind, id: string): string {
+  return `${kind}\0${id}`;
 }
 
 function resolveTargetId(subjectRef: string, kind: CanonicalEntityKind): string | null {

--- a/packages/kernel/src/projection/sqlite-attribution-state-hash.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-state-hash.ts
@@ -6,25 +6,20 @@ export function hashAttributionProjectionState(sql: SqlClient.SqlClient): Effect
   return Effect.gen(function* () {
     const tableRecords = yield* sql<{ readonly name: unknown }>`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`;
     const tableNames = tableRecords.map((record) => String(record.name));
-    const entities: Array<{
-      readonly table: string;
-      readonly rows: ReadonlyArray<{ readonly id: string; readonly attribution: string }>;
-    }> = [];
-    for (const table of tableNames) {
-      const quotedTable = quoteSqliteIdentifier(table);
-      const columns = yield* sql.unsafe<{ readonly name: unknown; readonly pk: unknown }>(`PRAGMA table_info(${quotedTable})`);
-      if (!columns.some((column) => String(column.name) === "attribution_json")) continue;
-      const primaryKey = columns.find((column) => Number(column.pk) > 0);
-      if (!primaryKey) throw new Error(`attributed projection table ${table} has no primary key`);
-      const idColumn = quoteSqliteIdentifier(String(primaryKey.name));
-      const records = yield* sql.unsafe<Record<string, unknown>>(
-        `SELECT ${idColumn} AS entity_id, attribution_json FROM ${quotedTable} ORDER BY ${idColumn}`
-      );
-      entities.push({
-        table,
-        rows: records.map((record) => ({ id: String(record.entity_id), attribution: String(record.attribution_json) }))
-      });
-    }
+    const entitySummaries = tableNames.includes("entity_attribution_summary")
+      ? (yield* sql<Record<string, unknown>>`
+          SELECT entity_kind, entity_id, originator_json, latest_actor_json, trail_count, completeness
+          FROM entity_attribution_summary
+          ORDER BY entity_kind, entity_id
+        `).map((record) => ({
+          entityKind: String(record.entity_kind),
+          entityId: String(record.entity_id),
+          originator: record.originator_json === null ? null : String(record.originator_json),
+          latestActor: record.latest_actor_json === null ? null : String(record.latest_actor_json),
+          trailCount: Number(record.trail_count),
+          completeness: String(record.completeness)
+        }))
+      : [];
     const events = tableNames.includes("attribution_events")
       ? (yield* sql<Record<string, unknown>>`
           SELECT event_id, op_id, subject_ref, operation, principal_person_id,
@@ -78,18 +73,11 @@ export function hashAttributionProjectionState(sql: SqlClient.SqlClient): Effect
         }))
       : [];
     return stablePayloadHash({
-      schema: "projection-attribution-state/v2",
-      entities,
+      schema: "projection-attribution-state/v3",
+      entitySummaries,
       legacyEvents: events,
       eventHeaders,
       eventMutations
     });
   });
-}
-
-function quoteSqliteIdentifier(identifier: string): string {
-  if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(identifier)) {
-    throw new Error(`Invalid SQLite identifier: ${identifier}`);
-  }
-  return `"${identifier}"`;
 }

--- a/packages/kernel/src/projection/sqlite-attribution-summary.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-summary.ts
@@ -1,0 +1,131 @@
+import type { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+import { unresolvedEntityAttribution } from "./entity-attribution-projection.ts";
+import type { EntityAttributionProjection } from "./types.ts";
+
+export interface EntityAttributionSummaryRow {
+  readonly entityKind: string;
+  readonly entityId: string;
+  readonly attribution: EntityAttributionProjection;
+}
+
+export function ensureEntityAttributionSummaryTable(
+  sql: SqlClient.SqlClient
+): Effect.Effect<unknown, unknown> {
+  return Effect.gen(function* () {
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS entity_attribution_summary (
+        entity_kind TEXT NOT NULL,
+        entity_id TEXT NOT NULL,
+        originator_json TEXT,
+        latest_actor_json TEXT,
+        trail_count INTEGER NOT NULL,
+        completeness TEXT NOT NULL,
+        PRIMARY KEY (entity_kind, entity_id)
+      )
+    `;
+    yield* sql`
+      CREATE INDEX IF NOT EXISTS entity_attribution_summary_entity
+      ON entity_attribution_summary (entity_id, entity_kind)
+    `;
+  });
+}
+
+export function replaceEntityAttributionSummaries(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<EntityAttributionSummaryRow>
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    yield* ensureEntityAttributionSummaryTable(sql);
+    yield* sql`DELETE FROM entity_attribution_summary`;
+    for (const batch of chunks(rows, 1_000)) yield* insertEntityAttributionSummaries(sql, batch);
+  });
+}
+
+export function upsertEntityAttributionSummary(
+  sql: SqlClient.SqlClient,
+  row: EntityAttributionSummaryRow
+): Effect.Effect<unknown, unknown> {
+  const attribution = row.attribution;
+  return sql`
+    INSERT INTO entity_attribution_summary (
+      entity_kind, entity_id, originator_json, latest_actor_json, trail_count, completeness
+    ) VALUES (
+      ${row.entityKind}, ${row.entityId},
+      ${attribution.originator ? JSON.stringify(attribution.originator) : null},
+      ${attribution.latestActor ? JSON.stringify(attribution.latestActor) : null},
+      ${attribution.trailCount}, ${attribution.completeness}
+    )
+    ON CONFLICT (entity_kind, entity_id) DO UPDATE SET
+      originator_json = excluded.originator_json,
+      latest_actor_json = excluded.latest_actor_json,
+      trail_count = excluded.trail_count,
+      completeness = excluded.completeness
+  `;
+}
+
+export function deleteEntityAttributionSummary(
+  sql: SqlClient.SqlClient,
+  entityKind: string,
+  entityId: string
+): Effect.Effect<unknown, unknown> {
+  return sql`
+    DELETE FROM entity_attribution_summary
+    WHERE entity_kind = ${entityKind} AND entity_id = ${entityId}
+  `;
+}
+
+export function attributionSummarySelect(alias: string): string {
+  return [
+    `${alias}.originator_json AS attribution_originator_json`,
+    `${alias}.latest_actor_json AS attribution_latest_actor_json`,
+    `COALESCE(${alias}.trail_count, 0) AS attribution_trail_count`,
+    `COALESCE(${alias}.completeness, 'unresolved') AS attribution_completeness`
+  ].join(", ");
+}
+
+export function attributionFromRecord(record: Readonly<Record<string, unknown>>): EntityAttributionProjection {
+  const completeness = record.attribution_completeness;
+  return {
+    originator: parseActor(record.attribution_originator_json),
+    latestActor: parseActor(record.attribution_latest_actor_json),
+    trailCount: Number(record.attribution_trail_count ?? 0),
+    completeness: completeness === "complete" || completeness === "legacy-partial" || completeness === "host-only"
+      ? completeness
+      : "unresolved"
+  };
+}
+
+export function unresolvedAttribution(): EntityAttributionProjection {
+  return unresolvedEntityAttribution();
+}
+
+function insertEntityAttributionSummaries(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<EntityAttributionSummaryRow>
+): Effect.Effect<unknown, unknown> {
+  return sql.unsafe(`
+    INSERT INTO entity_attribution_summary (
+      entity_kind, entity_id, originator_json, latest_actor_json, trail_count, completeness
+    ) VALUES ${rows.map(() => "(?, ?, ?, ?, ?, ?)").join(", ")}
+  `, rows.flatMap((row) => [
+    row.entityKind,
+    row.entityId,
+    row.attribution.originator ? JSON.stringify(row.attribution.originator) : null,
+    row.attribution.latestActor ? JSON.stringify(row.attribution.latestActor) : null,
+    row.attribution.trailCount,
+    row.attribution.completeness
+  ]));
+}
+
+function parseActor(value: unknown): EntityAttributionProjection["originator"] {
+  return typeof value === "string"
+    ? JSON.parse(value) as NonNullable<EntityAttributionProjection["originator"]>
+    : null;
+}
+
+function chunks<Value>(values: ReadonlyArray<Value>, size: number): ReadonlyArray<ReadonlyArray<Value>> {
+  const output: Value[][] = [];
+  for (let index = 0; index < values.length; index += size) output.push(values.slice(index, index + size));
+  return output;
+}

--- a/packages/kernel/src/projection/sqlite-declared-source-manifest.ts
+++ b/packages/kernel/src/projection/sqlite-declared-source-manifest.ts
@@ -79,6 +79,38 @@ export function hashDeclaredSourceManifestRows(rows: ReadonlyArray<DeclaredSourc
   });
 }
 
+export function hashDeclaredProjectionIntegrityRows(rows: ReadonlyArray<DeclaredSourceManifestRow>): string {
+  return stablePayloadHash({
+    schema: "declared-projection-integrity/v1",
+    rows: rows
+      .filter((row) => row.primaryKey.length > 0)
+      .map(({ projectionTable, primaryKey, projectedRowSha256 }) => ({
+        projectionTable,
+        primaryKey,
+        projectedRowSha256
+      }))
+      .sort((left, right) => left.projectionTable.localeCompare(right.projectionTable)
+        || left.primaryKey.localeCompare(right.primaryKey))
+  });
+}
+
+export function declaredProjectionRowsMatchManifest(
+  tables: ReadonlyArray<DeclaredProjectionSnapshot>,
+  manifest: ReadonlyArray<DeclaredSourceManifestRow>
+): boolean {
+  const actual = new Map(tables.flatMap((table) => {
+    const primaryKey = table.declaration.projection.columns.find((column) => column.primaryKey)!;
+    return table.rows.map((row) => [
+      `${table.table}\0${String(row[primaryKey.name])}`,
+      stablePayloadHash(row)
+    ] as const);
+  }));
+  const expected = manifest.filter((row) => row.primaryKey.length > 0);
+  if (actual.size !== expected.length) return false;
+  return expected.every((row) =>
+    actual.get(`${row.projectionTable}\0${row.primaryKey}`) === row.projectedRowSha256);
+}
+
 export function buildDeclaredProjectionDelta(
   previousRows: ReadonlyArray<DeclaredSourceManifestRow>,
   currentTables: ReadonlyArray<DeclaredProjectionSnapshot>
@@ -241,7 +273,7 @@ export function replaceDeclaredSourceManifestRows(
   return Effect.gen(function* () {
     yield* createDeclaredSourceManifestTable(sql);
     yield* sql`DELETE FROM declared_source_manifest`;
-    for (const row of rows) yield* upsertDeclaredSourceManifestRow(sql, row);
+    for (const batch of chunks(rows, 500)) yield* insertDeclaredSourceManifestRows(sql, batch);
   });
 }
 
@@ -337,6 +369,26 @@ function upsertDeclaredSourceManifestRow(
   `;
 }
 
+function insertDeclaredSourceManifestRows(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<DeclaredSourceManifestRow>
+): Effect.Effect<unknown, unknown> {
+  return sql.unsafe(`
+    INSERT INTO declared_source_manifest (
+      source_path, source_kind, projection_table, primary_key,
+      stat_signature, content_sha256, projected_row_sha256
+    ) VALUES ${rows.map(() => "(?, ?, ?, ?, ?, ?, ?)").join(", ")}
+  `, rows.flatMap((row) => [
+    row.sourcePath,
+    row.sourceKind,
+    row.projectionTable,
+    row.primaryKey,
+    row.statSignature,
+    row.contentSha256,
+    row.projectedRowSha256
+  ]));
+}
+
 function recordToManifestRow(record: DeclaredSourceManifestRecord): DeclaredSourceManifestRow {
   return {
     sourcePath: String(record.source_path),
@@ -347,4 +399,10 @@ function recordToManifestRow(record: DeclaredSourceManifestRecord): DeclaredSour
     contentSha256: String(record.content_sha256),
     projectedRowSha256: String(record.projected_row_sha256)
   };
+}
+
+function chunks<Value>(values: ReadonlyArray<Value>, size: number): ReadonlyArray<ReadonlyArray<Value>> {
+  const output: Value[][] = [];
+  for (let index = 0; index < values.length; index += size) output.push(values.slice(index, index + size));
+  return output;
 }

--- a/packages/kernel/src/projection/sqlite-projection-records.ts
+++ b/packages/kernel/src/projection/sqlite-projection-records.ts
@@ -1,9 +1,9 @@
 import type {
   DecisionProjectionRow,
-  EntityAttributionProjection,
   TaskFieldExtensionProjection,
   TaskProjectionRow
 } from "./types.ts";
+import { attributionFromRecord } from "./sqlite-attribution-summary.ts";
 
 export interface TaskRecord {
   readonly [column: string]: unknown;
@@ -29,10 +29,10 @@ export interface TaskRecord {
   readonly module_key: string | null;
   readonly module_title: string | null;
   readonly has_lesson_candidates: number;
-  readonly attribution_json: string;
 }
 
 export interface DecisionRecord {
+  readonly [column: string]: unknown;
   readonly decision_id: string;
   readonly legacy_id: string | null;
   readonly state: string;
@@ -51,7 +51,6 @@ export interface DecisionRecord {
   readonly proposed_at: string | null;
   readonly provenance_json: string | null;
   readonly decided_at: string | null;
-  readonly attribution_json: string;
 }
 
 export function recordToTaskRow(
@@ -83,7 +82,7 @@ export function recordToTaskRow(
     ...(record.module_key ? { moduleKey: record.module_key } : {}),
     ...(record.module_title ? { moduleTitle: record.module_title } : {}),
     hasLessonCandidates: record.has_lesson_candidates === 1,
-    attribution: JSON.parse(record.attribution_json) as EntityAttributionProjection,
+    attribution: attributionFromRecord(record),
     ...(fieldExtensions ? { fieldExtensions } : {})
   };
 }
@@ -109,7 +108,7 @@ export function recordToDecisionRow(record: DecisionRecord): DecisionProjectionR
     ...(record.proposed_at ? { proposedAt: record.proposed_at } : {}),
     ...(record.provenance_json ? { provenance: JSON.parse(record.provenance_json) as NonNullable<DecisionProjectionRow["provenance"]> } : {}),
     ...(record.decided_at ? { decidedAt: record.decided_at } : {}),
-    attribution: JSON.parse(record.attribution_json) as EntityAttributionProjection
+    attribution: attributionFromRecord(record)
   };
 }
 

--- a/packages/kernel/src/projection/sqlite-projection-source-cache-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-source-cache-store.ts
@@ -1,0 +1,274 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+import type {
+  ProjectionSourceCacheChange,
+  ProjectionSourceCacheFileRow,
+  ProjectionSourceCacheMetadataRow,
+  ProjectionSourceCacheSnapshot,
+  ProjectionSourceCacheWatchRow
+} from "./sqlite-projection-source-cache.ts";
+
+interface SourceCacheFileRecord {
+  readonly cache_kind: unknown;
+  readonly source_path: unknown;
+  readonly source_kind: unknown;
+  readonly owner_id: unknown;
+  readonly stat_signature: unknown;
+  readonly content_sha256: unknown;
+  readonly body: unknown;
+}
+
+interface SourceCacheWatchRecord {
+  readonly cache_kind: unknown;
+  readonly source_path: unknown;
+  readonly stat_signature: unknown;
+}
+
+interface SourceCacheMetadataRecord {
+  readonly cache_kind: unknown;
+  readonly payload_json: unknown;
+  readonly payload_sha256: unknown;
+}
+
+export function readProjectionSourceCacheRows(
+  sql: SqlClient.SqlClient
+): Effect.Effect<{
+  readonly files: ReadonlyArray<ProjectionSourceCacheFileRow>;
+  readonly watches: ReadonlyArray<ProjectionSourceCacheWatchRow>;
+  readonly metadata: ReadonlyArray<ProjectionSourceCacheMetadataRow>;
+}, unknown> {
+  return Effect.gen(function* () {
+    const files = yield* sql<SourceCacheFileRecord>`
+      SELECT cache_kind, source_path, source_kind, owner_id, stat_signature,
+             content_sha256, body
+      FROM projection_source_cache_files
+      ORDER BY cache_kind, source_path
+    `;
+    const watches = yield* sql<SourceCacheWatchRecord>`
+      SELECT cache_kind, source_path, stat_signature
+      FROM projection_source_cache_watches
+      ORDER BY cache_kind, source_path
+    `;
+    const metadata = yield* sql<SourceCacheMetadataRecord>`
+      SELECT cache_kind, payload_json, payload_sha256
+      FROM projection_source_cache_metadata
+      ORDER BY cache_kind
+    `;
+    const attributionBodies = yield* readProjectedAttributionBodies(sql);
+    return {
+      files: files.map((record) => recordToFileRow(record, attributionBodies)),
+      watches: watches.map(recordToWatchRow),
+      metadata: metadata.map(recordToMetadataRow)
+    };
+  });
+}
+
+export function readProjectionSourceCacheStoredBody(
+  sql: SqlClient.SqlClient,
+  cacheKindValue: ProjectionSourceCacheFileRow["cacheKind"],
+  sourcePath: string
+): Effect.Effect<string | undefined, unknown> {
+  return Effect.gen(function* () {
+    const [record] = yield* sql<{ readonly body: unknown }>`
+      SELECT body FROM projection_source_cache_files
+      WHERE cache_kind = ${cacheKindValue} AND source_path = ${sourcePath}
+    `;
+    return typeof record?.body === "string" ? record.body : undefined;
+  });
+}
+
+export function replaceProjectionSourceCacheStoredRows(
+  sql: SqlClient.SqlClient,
+  snapshot: ProjectionSourceCacheSnapshot
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    yield* createProjectionSourceCacheTables(sql);
+    yield* sql`DELETE FROM projection_source_cache_files`;
+    yield* sql`DELETE FROM projection_source_cache_watches`;
+    yield* sql`DELETE FROM projection_source_cache_metadata`;
+    for (const rows of chunks(snapshot.files, 1_000)) yield* insertFileRows(sql, rows);
+    for (const rows of chunks(snapshot.watches, 500)) yield* insertWatchRows(sql, rows);
+    for (const row of snapshot.metadata) yield* upsertMetadataRow(sql, row);
+  });
+}
+
+export function applyProjectionSourceCacheStoredChange(
+  sql: SqlClient.SqlClient,
+  change: ProjectionSourceCacheChange
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    yield* createProjectionSourceCacheTables(sql);
+    for (const row of change.deleteFiles) yield* deleteCachePath(sql, "projection_source_cache_files", row);
+    for (const row of change.upsertFiles) yield* upsertFileRow(sql, row);
+    for (const row of change.deleteWatches) yield* deleteCachePath(sql, "projection_source_cache_watches", row);
+    for (const row of change.upsertWatches) yield* upsertWatchRow(sql, row);
+    for (const row of change.upsertMetadata) yield* upsertMetadataRow(sql, row);
+  });
+}
+
+function createProjectionSourceCacheTables(sql: SqlClient.SqlClient): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS projection_source_cache_files (
+        cache_kind TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        source_kind TEXT NOT NULL,
+        owner_id TEXT,
+        stat_signature TEXT NOT NULL,
+        content_sha256 TEXT NOT NULL,
+        body TEXT,
+        PRIMARY KEY (cache_kind, source_path)
+      )
+    `;
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS projection_source_cache_watches (
+        cache_kind TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        stat_signature TEXT,
+        PRIMARY KEY (cache_kind, source_path)
+      )
+    `;
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS projection_source_cache_metadata (
+        cache_kind TEXT PRIMARY KEY,
+        payload_json TEXT NOT NULL,
+        payload_sha256 TEXT NOT NULL
+      )
+    `;
+  });
+}
+
+function upsertFileRow(sql: SqlClient.SqlClient, row: ProjectionSourceCacheFileRow): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT OR REPLACE INTO projection_source_cache_files (
+      cache_kind, source_path, source_kind, owner_id, stat_signature,
+      content_sha256, body
+    ) VALUES (
+      ${row.cacheKind}, ${row.sourcePath}, ${row.sourceKind}, ${row.ownerId ?? null},
+      ${row.statSignature}, ${row.contentSha256}, ${persistedBody(row)}
+    )
+  `;
+}
+
+function insertFileRows(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<ProjectionSourceCacheFileRow>
+): Effect.Effect<unknown, unknown> {
+  return sql.unsafe(`
+    INSERT INTO projection_source_cache_files (
+      cache_kind, source_path, source_kind, owner_id, stat_signature,
+      content_sha256, body
+    ) VALUES ${rows.map(() => "(?, ?, ?, ?, ?, ?, ?)").join(", ")}
+  `, rows.flatMap((row) => [
+    row.cacheKind,
+    row.sourcePath,
+    row.sourceKind,
+    row.ownerId ?? null,
+    row.statSignature,
+    row.contentSha256,
+    persistedBody(row)
+  ]));
+}
+
+function upsertWatchRow(sql: SqlClient.SqlClient, row: ProjectionSourceCacheWatchRow): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT OR REPLACE INTO projection_source_cache_watches (cache_kind, source_path, stat_signature)
+    VALUES (${row.cacheKind}, ${row.sourcePath}, ${row.statSignature})
+  `;
+}
+
+function insertWatchRows(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<ProjectionSourceCacheWatchRow>
+): Effect.Effect<unknown, unknown> {
+  return sql.unsafe(`
+    INSERT INTO projection_source_cache_watches (cache_kind, source_path, stat_signature)
+    VALUES ${rows.map(() => "(?, ?, ?)").join(", ")}
+  `, rows.flatMap((row) => [row.cacheKind, row.sourcePath, row.statSignature]));
+}
+
+function upsertMetadataRow(sql: SqlClient.SqlClient, row: ProjectionSourceCacheMetadataRow): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT OR REPLACE INTO projection_source_cache_metadata (cache_kind, payload_json, payload_sha256)
+    VALUES (${row.cacheKind}, ${row.payloadJson}, ${row.payloadSha256})
+  `;
+}
+
+function deleteCachePath(
+  sql: SqlClient.SqlClient,
+  table: "projection_source_cache_files" | "projection_source_cache_watches",
+  row: { readonly cacheKind: string; readonly sourcePath: string }
+): Effect.Effect<unknown, unknown> {
+  return sql.unsafe(`DELETE FROM ${table} WHERE cache_kind = ? AND source_path = ?`, [row.cacheKind, row.sourcePath]);
+}
+
+function recordToFileRow(
+  record: SourceCacheFileRecord,
+  attributionBodies: ReadonlyMap<string, string>
+): ProjectionSourceCacheFileRow {
+  const kind = cacheKind(record.cache_kind);
+  const ownerId = record.owner_id === null ? undefined : String(record.owner_id);
+  const body = typeof record.body === "string"
+    ? record.body
+    : kind === "attribution" && ownerId
+      ? attributionBodies.get(ownerId)
+      : undefined;
+  if (body === undefined) throw new Error(`projection source cache body unavailable: ${String(record.source_path)}`);
+  return {
+    cacheKind: kind,
+    sourcePath: String(record.source_path),
+    sourceKind: String(record.source_kind),
+    ...(ownerId ? { ownerId } : {}),
+    statSignature: String(record.stat_signature),
+    contentSha256: String(record.content_sha256),
+    body
+  };
+}
+
+function readProjectedAttributionBodies(
+  sql: SqlClient.SqlClient
+): Effect.Effect<ReadonlyMap<string, string>, unknown> {
+  return Effect.gen(function* () {
+    const tables = new Set((yield* sql<{ readonly name: unknown }>`SELECT name FROM sqlite_master WHERE type = 'table'`)
+      .map((record) => String(record.name)));
+    const rows: Array<{ readonly event_id: unknown; readonly source_json: unknown }> = [];
+    if (tables.has("attribution_events")) rows.push(...yield* sql<{ readonly event_id: unknown; readonly source_json: unknown }>`
+      SELECT event_id, source_json FROM attribution_events
+    `);
+    if (tables.has("attribution_event_headers")) rows.push(...yield* sql<{ readonly event_id: unknown; readonly source_json: unknown }>`
+      SELECT event_id, source_json FROM attribution_event_headers
+    `);
+    return new Map(rows.map((row) => [String(row.event_id), `${String(row.source_json)}\n`]));
+  });
+}
+
+function persistedBody(row: ProjectionSourceCacheFileRow): string | null {
+  return row.cacheKind === "attribution" ? null : row.body;
+}
+
+function recordToWatchRow(record: SourceCacheWatchRecord): ProjectionSourceCacheWatchRow {
+  return {
+    cacheKind: cacheKind(record.cache_kind),
+    sourcePath: String(record.source_path),
+    statSignature: record.stat_signature === null ? null : String(record.stat_signature)
+  };
+}
+
+function recordToMetadataRow(record: SourceCacheMetadataRecord): ProjectionSourceCacheMetadataRow {
+  return {
+    cacheKind: cacheKind(record.cache_kind),
+    payloadJson: String(record.payload_json),
+    payloadSha256: String(record.payload_sha256)
+  };
+}
+
+function cacheKind(value: unknown): ProjectionSourceCacheFileRow["cacheKind"] {
+  if (value === "task" || value === "attribution") return value;
+  throw new Error(`unknown projection source cache kind: ${String(value)}`);
+}
+
+function chunks<Value>(values: ReadonlyArray<Value>, size: number): ReadonlyArray<ReadonlyArray<Value>> {
+  const output: Value[][] = [];
+  for (let index = 0; index < values.length; index += size) output.push(values.slice(index, index + size));
+  return output;
+}

--- a/packages/kernel/src/projection/sqlite-projection-source-cache.ts
+++ b/packages/kernel/src/projection/sqlite-projection-source-cache.ts
@@ -7,16 +7,24 @@ import { resolveHarnessLayout } from "../layout/index.ts";
 import { readFrontmatter } from "../markdown/frontmatter.ts";
 import {
   captureAttributionEventSourcePersistentCache,
+  decodeUnionAttributionEventBody,
   restoreAttributionEventSourcePersistentCache,
   type AttributionEventSourcePersistentCache
 } from "../local/attribution-event-source.ts";
 import {
   captureMarkdownSourcePersistentCache,
+  readMarkdownSource,
   restoreMarkdownSourcePersistentCache,
   type MarkdownSourcePersistentCache,
   type TaskProjectionSourceHashInput
 } from "./sqlite-task-source.ts";
 import { runSqlite } from "./sqlite-projection-store.ts";
+import {
+  applyProjectionSourceCacheStoredChange,
+  readProjectionSourceCacheRows,
+  readProjectionSourceCacheStoredBody,
+  replaceProjectionSourceCacheStoredRows
+} from "./sqlite-projection-source-cache-store.ts";
 
 type ProjectionSourceCacheKind = "task" | "attribution";
 
@@ -46,79 +54,166 @@ export interface ProjectionSourceCacheSnapshot {
   readonly files: ReadonlyArray<ProjectionSourceCacheFileRow>;
   readonly watches: ReadonlyArray<ProjectionSourceCacheWatchRow>;
   readonly metadata: ReadonlyArray<ProjectionSourceCacheMetadataRow>;
+  readonly kindHashes: Readonly<Record<ProjectionSourceCacheKind, string>>;
   readonly hash: string;
 }
 
 export interface ProjectionSourceCacheChange {
   readonly previous: ProjectionSourceCacheSnapshot;
   readonly current: ProjectionSourceCacheSnapshot;
-}
-
-interface SourceCacheFileRecord {
-  readonly cache_kind: unknown;
-  readonly source_path: unknown;
-  readonly source_kind: unknown;
-  readonly owner_id: unknown;
-  readonly stat_signature: unknown;
-  readonly content_sha256: unknown;
-  readonly body: unknown;
-}
-
-interface SourceCacheWatchRecord {
-  readonly cache_kind: unknown;
-  readonly source_path: unknown;
-  readonly stat_signature: unknown;
-}
-
-interface SourceCacheMetadataRecord {
-  readonly cache_kind: unknown;
-  readonly payload_json: unknown;
-  readonly payload_sha256: unknown;
+  readonly deleteFiles: ReadonlyArray<ProjectionSourceCacheFileRow>;
+  readonly upsertFiles: ReadonlyArray<ProjectionSourceCacheFileRow>;
+  readonly deleteWatches: ReadonlyArray<ProjectionSourceCacheWatchRow>;
+  readonly upsertWatches: ReadonlyArray<ProjectionSourceCacheWatchRow>;
+  readonly upsertMetadata: ReadonlyArray<ProjectionSourceCacheMetadataRow>;
 }
 
 export function captureProjectionSourceCacheSnapshot(
-  rootInput: HarnessLayoutInput
+  rootInput: HarnessLayoutInput,
+  reuseValidatedCaches = false,
+  previousSnapshot?: ProjectionSourceCacheSnapshot,
+  refreshKinds: Readonly<{ task: boolean; attribution: boolean }> = { task: true, attribution: true }
 ): ProjectionSourceCacheSnapshot | null {
-  const task = captureMarkdownSourcePersistentCache(rootInput);
-  const attribution = captureAttributionEventSourcePersistentCache(rootInput);
-  if (!task || !attribution) return null;
+  const task = refreshKinds.task ? captureMarkdownSourcePersistentCache(rootInput, reuseValidatedCaches) : null;
+  const attribution = refreshKinds.attribution ? captureAttributionEventSourcePersistentCache(rootInput, reuseValidatedCaches) : null;
+  if ((refreshKinds.task && !task) || (refreshKinds.attribution && !attribution) ||
+      (!refreshKinds.task && !previousSnapshot) || (!refreshKinds.attribution && !previousSnapshot)) return null;
   const layout = resolveHarnessLayout(rootInput);
-  const taskEntries = new Map(task.result.entries.map((entry) => [entry.indexPath, entry]));
-  const taskFiles = task.result.sourceInputs.map((input) => {
+  const taskEntries = new Map(task?.result.entries.map((entry) => [
+    path.isAbsolute(entry.indexPath)
+      ? rootRelativePath(layout.rootDir, entry.indexPath)
+      : entry.indexPath.split(path.sep).join("/"),
+    entry
+  ]) ?? []);
+  const previousTaskFiles = new Map(previousSnapshot?.files
+    .filter((row) => row.cacheKind === "task")
+    .map((row) => [row.sourcePath, row]) ?? []);
+  const taskFiles = task ? task.result.sourceInputs.map((input) => {
     const entry = taskEntries.get(input.sourcePath);
+    const previous = previousTaskFiles.get(input.sourcePath);
+    if (previous && previous.sourceKind === input.kind && previous.statSignature === input.statSignature &&
+        previous.ownerId === entry?.taskId) return previous;
     return {
       cacheKind: "task" as const,
       sourcePath: input.sourcePath,
       sourceKind: input.kind,
       ...(entry ? { ownerId: entry.taskId } : {}),
       statSignature: input.statSignature,
-      contentSha256: sha256Text(input.body),
+      contentSha256: input.contentSha256 ?? sha256Text(input.body),
       body: input.body
     };
-  });
-  const attributionFiles = attribution.source.inputs.map((input) => ({
+  }) : previousSnapshot!.files.filter((row) => row.cacheKind === "task");
+  const attributionFiles = attribution ? attribution.source.inputs.map((input) => ({
     cacheKind: "attribution" as const,
     sourcePath: rootRelativePath(layout.rootDir, path.join(layout.attributionEventsRoot, input.relativePath)),
     sourceKind: "attribution-event",
+    ownerId: input.eventId ?? decodeUnionAttributionEventBody(input.body).eventId,
     statSignature: input.statSignature,
     contentSha256: input.contentSha256,
     body: input.body
-  }));
-  const fileKeys = new Set([...taskFiles, ...attributionFiles].map(cachePathKey));
-  const watches = [
-    ...task.directorySignatures.map((entry) => ({ cacheKind: "task" as const, sourcePath: entry.relativePath, statSignature: entry.signature })),
-    ...attribution.signatures
-      .filter((entry) => !fileKeys.has(cachePathKey({ cacheKind: "attribution", sourcePath: entry.relativePath })))
-      .map((entry) => ({ cacheKind: "attribution" as const, sourcePath: entry.relativePath, statSignature: entry.signature }))
-  ];
+  })) : previousSnapshot!.files.filter((row) => row.cacheKind === "attribution");
+  const attributionFileKeys = attribution ? new Set(attributionFiles.map(cachePathKey)) : null;
+  const taskWatches = task
+    ? task.directorySignatures.map((entry) => ({ cacheKind: "task" as const, sourcePath: entry.relativePath, statSignature: entry.signature }))
+    : previousSnapshot!.watches.filter((row) => row.cacheKind === "task");
+  const attributionWatches = attribution
+      ? attribution.signatures
+        .filter((entry) => !attributionFileKeys!.has(cachePathKey({ cacheKind: "attribution", sourcePath: entry.relativePath })))
+        .map((entry) => ({ cacheKind: "attribution" as const, sourcePath: entry.relativePath, statSignature: entry.signature }))
+      : previousSnapshot!.watches.filter((row) => row.cacheKind === "attribution");
+  const previousMetadata = new Map(previousSnapshot?.metadata.map((row) => [row.cacheKind, row]) ?? []);
   return projectionSourceCacheSnapshot({
-    files: [...taskFiles, ...attributionFiles],
-    watches,
+    files: [
+      ...attributionFiles,
+      ...taskFiles.sort(compareCachePaths)
+    ],
+    watches: [
+      ...attributionWatches.sort(compareCachePaths),
+      ...taskWatches.sort(compareCachePaths)
+    ],
     metadata: [
-      metadataRow("task", { schema: "task-source-cache-metadata/v1", layoutIdentity: task.layoutIdentity, warnings: task.result.warnings }),
-      metadataRow("attribution", { schema: "attribution-source-cache-metadata/v1", layoutIdentity: attribution.layoutIdentity })
+      task
+        ? metadataRow("task", { schema: "task-source-cache-metadata/v1", layoutIdentity: task.layoutIdentity, warnings: task.result.warnings })
+        : previousMetadata.get("task")!,
+      attribution
+        ? metadataRow("attribution", { schema: "attribution-source-cache-metadata/v1", layoutIdentity: attribution.layoutIdentity })
+        : previousMetadata.get("attribution")!
     ]
+  }, !reuseValidatedCaches, previousSnapshot ? {
+    ...(!task ? { task: previousSnapshot.kindHashes.task } : {}),
+    ...(!attribution ? { attribution: previousSnapshot.kindHashes.attribution } : {})
+  } : {}, true);
+}
+
+export function refreshProjectionSourceCacheSnapshotForTouchedTaskPaths(
+  rootInput: HarnessLayoutInput,
+  previousSnapshot: ProjectionSourceCacheSnapshot,
+  taskSource: ReturnType<typeof readMarkdownSource>,
+  touchedPaths: ReadonlyArray<string>
+): ProjectionSourceCacheSnapshot | null {
+  if (touchedPaths.length === 0) return null;
+  const layout = resolveHarnessLayout(rootInput);
+  const currentInputs = new Map(taskSource.sourceInputs.map((input) => [input.sourcePath, input]));
+  const taskOwners = new Map(taskSource.entries.map((entry) => [
+    rootRelativePath(layout.rootDir, entry.indexPath),
+    entry.taskId
+  ]));
+  const fileIndexes = new Map(previousSnapshot.files.map((row, index) => [cachePathKey(row), index]));
+  const files = [...previousSnapshot.files];
+  for (const touchedPath of touchedPaths) {
+    const sourcePathValue = rootRelativePath(layout.rootDir, touchedPath);
+    const input = currentInputs.get(sourcePathValue);
+    const index = fileIndexes.get(cachePathKey({ cacheKind: "task", sourcePath: sourcePathValue }));
+    if (!input || index === undefined) return null;
+    const row: ProjectionSourceCacheFileRow = {
+      cacheKind: "task",
+      sourcePath: sourcePathValue,
+      sourceKind: input.kind,
+      ...(taskOwners.has(sourcePathValue) ? { ownerId: taskOwners.get(sourcePathValue) } : {}),
+      statSignature: input.statSignature,
+      contentSha256: input.contentSha256 ?? sha256Text(input.body),
+      body: input.body
+    };
+    if (!validSourceCacheBody(row)) return null;
+    files[index] = row;
+  }
+  const taskMetadata = metadataRow("task", {
+    schema: "task-source-cache-metadata/v1",
+    layoutIdentity: [layout.rootDir, layout.authoredRoot, layout.tasksRoot, layout.decisionsRoot].join("\0"),
+    warnings: taskSource.warnings
   });
+  const metadata = previousSnapshot.metadata.map((row) => row.cacheKind === "task" ? taskMetadata : row);
+  return projectionSourceCacheSnapshot({
+    files,
+    watches: previousSnapshot.watches,
+    metadata
+  }, false, { attribution: previousSnapshot.kindHashes.attribution }, true);
+}
+
+export function refreshProjectionSourceCacheAfterIncrementalChange(input: {
+  readonly rootInput: HarnessLayoutInput;
+  readonly previousSnapshot: ProjectionSourceCacheSnapshot | undefined;
+  readonly taskSource: ReturnType<typeof readMarkdownSource>;
+  readonly touchedTaskPaths: ReadonlyArray<string>;
+  readonly taskChanged: boolean;
+  readonly attributionChanged: boolean;
+}): ProjectionSourceCacheSnapshot | null {
+  const fastSnapshot = input.previousSnapshot && input.taskChanged && !input.attributionChanged
+    ? refreshProjectionSourceCacheSnapshotForTouchedTaskPaths(
+        input.rootInput,
+        input.previousSnapshot,
+        input.taskSource,
+        input.touchedTaskPaths
+      )
+    : null;
+  return fastSnapshot ?? captureProjectionSourceCacheSnapshot(
+    input.rootInput,
+    true,
+    input.previousSnapshot,
+    input.previousSnapshot
+      ? { task: input.taskChanged, attribution: input.attributionChanged }
+      : { task: true, attribution: true }
+  );
 }
 
 export function readProjectionSourceCacheSnapshot(projectionPath: string): ProjectionSourceCacheSnapshot {
@@ -126,33 +221,24 @@ export function readProjectionSourceCacheSnapshot(projectionPath: string): Proje
     const sql = yield* SqlClient.SqlClient;
     yield* sql`BEGIN`;
     try {
-      const files = yield* sql<SourceCacheFileRecord>`
-        SELECT cache_kind, source_path, source_kind, owner_id, stat_signature,
-               content_sha256, body
-        FROM projection_source_cache_files
-        ORDER BY cache_kind, source_path
-      `;
-      const watches = yield* sql<SourceCacheWatchRecord>`
-        SELECT cache_kind, source_path, stat_signature
-        FROM projection_source_cache_watches
-        ORDER BY cache_kind, source_path
-      `;
-      const metadata = yield* sql<SourceCacheMetadataRecord>`
-        SELECT cache_kind, payload_json, payload_sha256
-        FROM projection_source_cache_metadata
-        ORDER BY cache_kind
-      `;
-      const snapshot = projectionSourceCacheSnapshot({
-        files: files.map(recordToFileRow),
-        watches: watches.map(recordToWatchRow),
-        metadata: metadata.map(recordToMetadataRow)
-      });
+      const snapshot = projectionSourceCacheSnapshot(yield* readProjectionSourceCacheRows(sql));
       yield* sql`COMMIT`;
       return snapshot;
     } catch (error) {
       yield* sql`ROLLBACK`;
       throw error;
     }
+  }));
+}
+
+export function readProjectionSourceCacheBody(
+  projectionPath: string,
+  cacheKindValue: ProjectionSourceCacheKind,
+  sourcePath: string
+): string | undefined {
+  return runSqlite(projectionPath, Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    return yield* readProjectionSourceCacheStoredBody(sql, cacheKindValue, sourcePath);
   }));
 }
 
@@ -176,7 +262,13 @@ export function restoreProjectionSourceCacheSnapshot(
     }
     const taskFiles = snapshot.files.filter((row) => row.cacheKind === "task");
     const taskInputs: TaskProjectionSourceHashInput[] = taskFiles
-      .map((row) => ({ kind: row.sourceKind, sourcePath: row.sourcePath, body: row.body, statSignature: row.statSignature }))
+      .map((row) => ({
+        kind: row.sourceKind,
+        sourcePath: row.sourcePath,
+        body: row.body,
+        statSignature: row.statSignature,
+        contentSha256: row.contentSha256
+      }))
       .sort(compareTaskSourceInputs);
     const task: MarkdownSourcePersistentCache = {
       schema: "markdown-source-cache/v1",
@@ -207,7 +299,8 @@ export function restoreProjectionSourceCacheSnapshot(
           relativePath: path.relative(layout.attributionEventsRoot, path.resolve(layout.rootDir, row.sourcePath)).split(path.sep).join("/"),
           body: row.body,
           statSignature: row.statSignature,
-          contentSha256: row.contentSha256
+          contentSha256: row.contentSha256,
+          ...(row.ownerId ? { eventId: row.ownerId } : {})
         })),
         hash: stablePayloadHash({
           schema: "attribution-event-source/v2",
@@ -239,44 +332,36 @@ export function replaceProjectionSourceCacheRows(
   sql: SqlClient.SqlClient,
   snapshot: ProjectionSourceCacheSnapshot
 ): Effect.Effect<void, unknown> {
-  return Effect.gen(function* () {
-    yield* createProjectionSourceCacheTables(sql);
-    yield* sql`DELETE FROM projection_source_cache_files`;
-    yield* sql`DELETE FROM projection_source_cache_watches`;
-    yield* sql`DELETE FROM projection_source_cache_metadata`;
-    for (const rows of chunks(snapshot.files, 250)) yield* insertFileRows(sql, rows);
-    for (const rows of chunks(snapshot.watches, 500)) yield* insertWatchRows(sql, rows);
-    for (const row of snapshot.metadata) yield* upsertMetadataRow(sql, row);
-  });
+  return replaceProjectionSourceCacheStoredRows(sql, snapshot);
 }
 
 export function applyProjectionSourceCacheChange(
   sql: SqlClient.SqlClient,
   change: ProjectionSourceCacheChange
 ): Effect.Effect<void, unknown> {
-  return Effect.gen(function* () {
-    yield* createProjectionSourceCacheTables(sql);
-    const currentFiles = new Map(change.current.files.map((row) => [cachePathKey(row), row]));
-    const previousFiles = new Map(change.previous.files.map((row) => [cachePathKey(row), row]));
-    for (const [key, row] of previousFiles) {
-      if (!currentFiles.has(key)) yield* deleteCachePath(sql, "projection_source_cache_files", row);
-    }
-    for (const [key, row] of currentFiles) {
-      if (!sameFileRow(previousFiles.get(key), row)) yield* upsertFileRow(sql, row);
-    }
-    const currentWatches = new Map(change.current.watches.map((row) => [cachePathKey(row), row]));
-    const previousWatches = new Map(change.previous.watches.map((row) => [cachePathKey(row), row]));
-    for (const [key, row] of previousWatches) {
-      if (!currentWatches.has(key)) yield* deleteCachePath(sql, "projection_source_cache_watches", row);
-    }
-    for (const [key, row] of currentWatches) {
-      if (!sameWatchRow(previousWatches.get(key), row)) yield* upsertWatchRow(sql, row);
-    }
-    const previousMetadata = new Map(change.previous.metadata.map((row) => [row.cacheKind, row]));
-    for (const row of change.current.metadata) {
-      if (previousMetadata.get(row.cacheKind)?.payloadSha256 !== row.payloadSha256) yield* upsertMetadataRow(sql, row);
-    }
-  });
+  return applyProjectionSourceCacheStoredChange(sql, change);
+}
+
+export function buildProjectionSourceCacheChange(
+  previous: ProjectionSourceCacheSnapshot,
+  current: ProjectionSourceCacheSnapshot,
+  changedKinds: ReadonlyArray<ProjectionSourceCacheKind> = ["task", "attribution"]
+): ProjectionSourceCacheChange {
+  const kinds = new Set(changedKinds);
+  const currentFiles = new Map(current.files.filter((row) => kinds.has(row.cacheKind)).map((row) => [cachePathKey(row), row]));
+  const previousFiles = new Map(previous.files.filter((row) => kinds.has(row.cacheKind)).map((row) => [cachePathKey(row), row]));
+  const currentWatches = new Map(current.watches.filter((row) => kinds.has(row.cacheKind)).map((row) => [cachePathKey(row), row]));
+  const previousWatches = new Map(previous.watches.filter((row) => kinds.has(row.cacheKind)).map((row) => [cachePathKey(row), row]));
+  const previousMetadata = new Map(previous.metadata.map((row) => [row.cacheKind, row]));
+  return {
+    previous,
+    current,
+    deleteFiles: [...previousFiles].filter(([key]) => !currentFiles.has(key)).map(([, row]) => row),
+    upsertFiles: [...currentFiles].filter(([key, row]) => !sameFileRow(previousFiles.get(key), row)).map(([, row]) => row),
+    deleteWatches: [...previousWatches].filter(([key]) => !currentWatches.has(key)).map(([, row]) => row),
+    upsertWatches: [...currentWatches].filter(([key, row]) => !sameWatchRow(previousWatches.get(key), row)).map(([, row]) => row),
+    upsertMetadata: current.metadata.filter((row) => kinds.has(row.cacheKind) && previousMetadata.get(row.cacheKind)?.payloadSha256 !== row.payloadSha256)
+  };
 }
 
 export function updateProjectionSourceCacheSnapshot(
@@ -288,7 +373,7 @@ export function updateProjectionSourceCacheSnapshot(
     const sql = yield* SqlClient.SqlClient;
     yield* sql`BEGIN IMMEDIATE`;
     try {
-      yield* applyProjectionSourceCacheChange(sql, { previous, current });
+      yield* applyProjectionSourceCacheChange(sql, buildProjectionSourceCacheChange(previous, current));
       yield* sql`
         INSERT OR REPLACE INTO projection_meta (key, value)
         VALUES ('sourceCacheHash', ${current.hash})
@@ -305,29 +390,72 @@ function projectionSourceCacheSnapshot(input: {
   readonly files: ReadonlyArray<ProjectionSourceCacheFileRow>;
   readonly watches: ReadonlyArray<ProjectionSourceCacheWatchRow>;
   readonly metadata: ReadonlyArray<ProjectionSourceCacheMetadataRow>;
-}): ProjectionSourceCacheSnapshot {
-  const files = [...input.files].sort(compareCachePaths);
-  const watches = [...input.watches].sort(compareCachePaths);
+}, validateBodies = true, reusableKindHashes: Readonly<Partial<Record<ProjectionSourceCacheKind, string>>> = {}, presorted = false): ProjectionSourceCacheSnapshot {
+  const files = presorted ? input.files : [...input.files].sort(compareCachePaths);
+  const watches = presorted ? input.watches : [...input.watches].sort(compareCachePaths);
   const metadata = [...input.metadata].sort((left, right) => left.cacheKind.localeCompare(right.cacheKind));
   assertCacheKinds(metadata.map((row) => row.cacheKind));
-  for (const row of files) {
-    if (sha256Text(row.body) !== row.contentSha256) throw new Error(`projection source cache body hash mismatch: ${row.sourcePath}`);
+  if (validateBodies) for (const row of files) {
+    if (!validSourceCacheBody(row)) throw new Error(`projection source cache body hash mismatch: ${row.sourcePath}`);
   }
   for (const row of metadata) {
     const expected = stablePayloadHash({ schema: "projection-source-cache-metadata-payload/v1", payloadJson: row.payloadJson });
     if (row.payloadSha256 !== expected) throw new Error(`projection source cache metadata hash mismatch: ${row.cacheKind}`);
   }
+  const kindHashes = {
+    attribution: reusableKindHashes.attribution ?? sourceCacheKindHash("attribution", files, watches, metadata),
+    task: reusableKindHashes.task ?? sourceCacheKindHash("task", files, watches, metadata)
+  };
   return {
     files,
     watches,
     metadata,
+    kindHashes,
     hash: stablePayloadHash({
-      schema: "projection-source-cache/v2",
-      files: files.map(({ body: _body, ...row }) => row),
-      watches,
-      metadata: metadata.map(({ cacheKind, payloadSha256 }) => ({ cacheKind, payloadSha256 }))
+      schema: "projection-source-cache/v3",
+      kindHashes
     })
   };
+}
+
+function validSourceCacheBody(row: ProjectionSourceCacheFileRow): boolean {
+  if (sha256Text(row.body) === row.contentSha256) return true;
+  // Attribution cache rows omit raw authored bodies and are reconstructed from
+  // normalized, integrity-hashed event tables, so only identity is compared here.
+  if (row.cacheKind !== "attribution" || !row.ownerId) return false;
+  try {
+    return decodeUnionAttributionEventBody(row.body).eventId === row.ownerId;
+  } catch {
+    return false;
+  }
+}
+
+function sourceCacheKindHash(
+  kind: ProjectionSourceCacheKind,
+  files: ReadonlyArray<ProjectionSourceCacheFileRow>,
+  watches: ReadonlyArray<ProjectionSourceCacheWatchRow>,
+  metadata: ReadonlyArray<ProjectionSourceCacheMetadataRow>
+): string {
+  return sha256Text(JSON.stringify({
+    schema: "projection-source-cache-kind/v2",
+    cacheKind: kind,
+    files: files
+      .filter((row) => row.cacheKind === kind)
+      .map((row) => [
+        row.cacheKind,
+        row.sourcePath,
+        row.sourceKind,
+        row.ownerId ?? null,
+        row.statSignature,
+        row.contentSha256
+      ]),
+    watches: watches
+      .filter((row) => row.cacheKind === kind)
+      .map((row) => [row.cacheKind, row.sourcePath, row.statSignature]),
+    metadata: metadata
+      .filter((row) => row.cacheKind === kind)
+      .map((row) => [row.cacheKind, row.payloadSha256])
+  }));
 }
 
 function metadataRow(cacheKind: ProjectionSourceCacheKind, payload: unknown): ProjectionSourceCacheMetadataRow {
@@ -337,136 +465,6 @@ function metadataRow(cacheKind: ProjectionSourceCacheKind, payload: unknown): Pr
     payloadJson,
     payloadSha256: stablePayloadHash({ schema: "projection-source-cache-metadata-payload/v1", payloadJson })
   };
-}
-
-function createProjectionSourceCacheTables(sql: SqlClient.SqlClient): Effect.Effect<void, unknown> {
-  return Effect.gen(function* () {
-    yield* sql`
-      CREATE TABLE IF NOT EXISTS projection_source_cache_files (
-        cache_kind TEXT NOT NULL,
-        source_path TEXT NOT NULL,
-        source_kind TEXT NOT NULL,
-        owner_id TEXT,
-        stat_signature TEXT NOT NULL,
-        content_sha256 TEXT NOT NULL,
-        body TEXT NOT NULL,
-        PRIMARY KEY (cache_kind, source_path)
-      )
-    `;
-    yield* sql`
-      CREATE TABLE IF NOT EXISTS projection_source_cache_watches (
-        cache_kind TEXT NOT NULL,
-        source_path TEXT NOT NULL,
-        stat_signature TEXT,
-        PRIMARY KEY (cache_kind, source_path)
-      )
-    `;
-    yield* sql`
-      CREATE TABLE IF NOT EXISTS projection_source_cache_metadata (
-        cache_kind TEXT PRIMARY KEY,
-        payload_json TEXT NOT NULL,
-        payload_sha256 TEXT NOT NULL
-      )
-    `;
-  });
-}
-
-function upsertFileRow(sql: SqlClient.SqlClient, row: ProjectionSourceCacheFileRow): Effect.Effect<unknown, unknown> {
-  return sql`
-    INSERT OR REPLACE INTO projection_source_cache_files (
-      cache_kind, source_path, source_kind, owner_id, stat_signature,
-      content_sha256, body
-    ) VALUES (
-      ${row.cacheKind}, ${row.sourcePath}, ${row.sourceKind}, ${row.ownerId ?? null},
-      ${row.statSignature}, ${row.contentSha256}, ${row.body}
-    )
-  `;
-}
-
-function insertFileRows(
-  sql: SqlClient.SqlClient,
-  rows: ReadonlyArray<ProjectionSourceCacheFileRow>
-): Effect.Effect<unknown, unknown> {
-  return sql.unsafe(`
-    INSERT INTO projection_source_cache_files (
-      cache_kind, source_path, source_kind, owner_id, stat_signature,
-      content_sha256, body
-    ) VALUES ${rows.map(() => "(?, ?, ?, ?, ?, ?, ?)").join(", ")}
-  `, rows.flatMap((row) => [
-    row.cacheKind,
-    row.sourcePath,
-    row.sourceKind,
-    row.ownerId ?? null,
-    row.statSignature,
-    row.contentSha256,
-    row.body
-  ]));
-}
-
-function upsertWatchRow(sql: SqlClient.SqlClient, row: ProjectionSourceCacheWatchRow): Effect.Effect<unknown, unknown> {
-  return sql`
-    INSERT OR REPLACE INTO projection_source_cache_watches (cache_kind, source_path, stat_signature)
-    VALUES (${row.cacheKind}, ${row.sourcePath}, ${row.statSignature})
-  `;
-}
-
-function insertWatchRows(
-  sql: SqlClient.SqlClient,
-  rows: ReadonlyArray<ProjectionSourceCacheWatchRow>
-): Effect.Effect<unknown, unknown> {
-  return sql.unsafe(`
-    INSERT INTO projection_source_cache_watches (cache_kind, source_path, stat_signature)
-    VALUES ${rows.map(() => "(?, ?, ?)").join(", ")}
-  `, rows.flatMap((row) => [row.cacheKind, row.sourcePath, row.statSignature]));
-}
-
-function upsertMetadataRow(sql: SqlClient.SqlClient, row: ProjectionSourceCacheMetadataRow): Effect.Effect<unknown, unknown> {
-  return sql`
-    INSERT OR REPLACE INTO projection_source_cache_metadata (cache_kind, payload_json, payload_sha256)
-    VALUES (${row.cacheKind}, ${row.payloadJson}, ${row.payloadSha256})
-  `;
-}
-
-function deleteCachePath(
-  sql: SqlClient.SqlClient,
-  table: "projection_source_cache_files" | "projection_source_cache_watches",
-  row: { readonly cacheKind: string; readonly sourcePath: string }
-): Effect.Effect<unknown, unknown> {
-  return sql.unsafe(`DELETE FROM ${table} WHERE cache_kind = ? AND source_path = ?`, [row.cacheKind, row.sourcePath]);
-}
-
-function recordToFileRow(record: SourceCacheFileRecord): ProjectionSourceCacheFileRow {
-  return {
-    cacheKind: cacheKind(record.cache_kind),
-    sourcePath: String(record.source_path),
-    sourceKind: String(record.source_kind),
-    ...(record.owner_id === null ? {} : { ownerId: String(record.owner_id) }),
-    statSignature: String(record.stat_signature),
-    contentSha256: String(record.content_sha256),
-    body: String(record.body)
-  };
-}
-
-function recordToWatchRow(record: SourceCacheWatchRecord): ProjectionSourceCacheWatchRow {
-  return {
-    cacheKind: cacheKind(record.cache_kind),
-    sourcePath: String(record.source_path),
-    statSignature: record.stat_signature === null ? null : String(record.stat_signature)
-  };
-}
-
-function recordToMetadataRow(record: SourceCacheMetadataRecord): ProjectionSourceCacheMetadataRow {
-  return {
-    cacheKind: cacheKind(record.cache_kind),
-    payloadJson: String(record.payload_json),
-    payloadSha256: String(record.payload_sha256)
-  };
-}
-
-function cacheKind(value: unknown): ProjectionSourceCacheKind {
-  const kind = String(value);
-  if (kind !== "task" && kind !== "attribution") throw new Error(`unknown projection source cache kind: ${kind}`);
-  return kind;
 }
 
 function requiredMetadata(
@@ -506,19 +504,26 @@ function compareTaskSourceInputs(left: TaskProjectionSourceHashInput, right: Tas
 }
 
 function taskSourceHash(inputs: ReadonlyArray<TaskProjectionSourceHashInput>): string {
-  return `sha256:${sha256Text(JSON.stringify(inputs.map(({ kind, sourcePath, body }) => ({ kind, sourcePath, body }))))}`;
+  return `sha256:${sha256Text(JSON.stringify({
+    schema: "task-projection-source/v2",
+    inputs: inputs.map(({ kind, sourcePath, body, contentSha256 }) => ({
+      kind,
+      sourcePath,
+      contentSha256: contentSha256 ?? sha256Text(body)
+    }))
+  }))}`;
 }
 
 function sameFileRow(left: ProjectionSourceCacheFileRow | undefined, right: ProjectionSourceCacheFileRow): boolean {
-  return left !== undefined && stablePayloadHash({ ...left, body: undefined }) === stablePayloadHash({ ...right, body: undefined });
+  return left !== undefined &&
+    left.cacheKind === right.cacheKind &&
+    left.sourcePath === right.sourcePath &&
+    left.sourceKind === right.sourceKind &&
+    left.ownerId === right.ownerId &&
+    left.statSignature === right.statSignature &&
+    left.contentSha256 === right.contentSha256;
 }
 
 function sameWatchRow(left: ProjectionSourceCacheWatchRow | undefined, right: ProjectionSourceCacheWatchRow): boolean {
   return left !== undefined && left.statSignature === right.statSignature;
-}
-
-function chunks<Value>(values: ReadonlyArray<Value>, size: number): ReadonlyArray<ReadonlyArray<Value>> {
-  const output: Value[][] = [];
-  for (let index = 0; index < values.length; index += size) output.push(values.slice(index, index + size));
-  return output;
 }

--- a/packages/kernel/src/projection/sqlite-projection-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-store.ts
@@ -4,9 +4,23 @@ import { SqlClient } from "@effect/sql";
 import { SqliteClient } from "@effect/sql-sqlite-node";
 import { Effect } from "effect";
 import { hashAttributionProjectionState } from "./sqlite-attribution-state-hash.ts";
-import type { TaskFactProjectionRow } from "./fact-projection.ts";
-import type { FactAnchorRow, RelationCoverageRow, RelationGraphEdgeRow } from "./relation-graph-projection.ts";
-import { unresolvedEntityAttribution } from "./entity-attribution-projection.ts";
+import {
+  attributionSummarySelect,
+  ensureEntityAttributionSummaryTable
+} from "./sqlite-attribution-summary.ts";
+import {
+  createRelationGraphIndexes,
+  createRelationGraphTables,
+  insertCoverageRows,
+  insertFactAnchors,
+  insertRelationProjectionWarning,
+  insertRelationEdges,
+  insertTaskFactRows,
+  readRelationGraphReuseSeedFromStore,
+  readRelationGraphRowsFromStore,
+  type ProjectionGraphRows,
+  type RelationGraphReuseSeed
+} from "./sqlite-relation-graph-store.ts";
 import {
   recordToDecisionRow,
   recordToTaskRow,
@@ -17,13 +31,12 @@ import type {
   DecisionProjectionQueryFilters,
   DecisionProjectionRow,
   ProjectionMeta,
-  ProjectionWarning,
   TaskFieldExtensionProjection,
   TaskProjectionQueryFilters,
   TaskProjectionRow
 } from "./types.ts";
 
-export const projectionVersion = "entity-projection/d4-v13";
+export const projectionVersion = "entity-projection/d4-v15";
 const baseTaskProjectionColumns = [
   "task_id",
   "title",
@@ -46,17 +59,17 @@ const baseTaskProjectionColumns = [
   "profile",
   "module_key",
   "module_title",
-  "has_lesson_candidates",
-  "attribution_json"
+  "has_lesson_candidates"
 ] as const;
 
-export interface ProjectionGraphRows {
-  readonly relationEdges: ReadonlyArray<RelationGraphEdgeRow>;
-  readonly coverageRows: ReadonlyArray<RelationCoverageRow>;
-  readonly factAnchors: ReadonlyArray<FactAnchorRow>;
-  readonly factRows: ReadonlyArray<TaskFactProjectionRow>;
-  readonly warnings: ReadonlyArray<ProjectionWarning>;
-}
+export type { ProjectionGraphRows } from "./sqlite-relation-graph-store.ts";
+export {
+  insertCoverageRows,
+  insertFactAnchors,
+  insertRelationEdges,
+  insertRelationProjectionWarning,
+  insertTaskFactRows
+} from "./sqlite-relation-graph-store.ts";
 
 export function writeProjectionDatabase(
   projectionPath: string,
@@ -96,8 +109,7 @@ export function writeProjectionDatabase(
         profile TEXT,
         module_key TEXT,
         module_title TEXT,
-        has_lesson_candidates INTEGER NOT NULL,
-        attribution_json TEXT NOT NULL
+        has_lesson_candidates INTEGER NOT NULL
       )
     `;
     const projectedTaskFieldExtensions = queryableTaskFieldExtensions(taskFieldExtensions);
@@ -124,53 +136,11 @@ export function writeProjectionDatabase(
         decision_class TEXT,
         proposed_at TEXT,
         provenance_json TEXT,
-        decided_at TEXT,
-        attribution_json TEXT NOT NULL
+        decided_at TEXT
       )
     `;
-    yield* sql`
-      CREATE TABLE relation_edges (
-        relation_id TEXT PRIMARY KEY,
-        source_ref TEXT NOT NULL,
-        target_ref TEXT NOT NULL,
-        relation_type TEXT NOT NULL,
-        direction TEXT NOT NULL,
-        state TEXT NOT NULL,
-        row_json TEXT NOT NULL
-      )
-    `;
-    yield* sql`
-      CREATE TABLE relation_coverage (
-        claim_ref TEXT PRIMARY KEY,
-        decision_ref TEXT NOT NULL,
-        status TEXT NOT NULL,
-        covering_fact_ref TEXT,
-        row_json TEXT NOT NULL
-      )
-    `;
-    yield* sql`
-      CREATE TABLE task_fact_anchors (
-        fact_ref TEXT PRIMARY KEY,
-        task_id TEXT NOT NULL,
-        fact_id TEXT NOT NULL,
-        source_path TEXT NOT NULL,
-        row_json TEXT NOT NULL
-      )
-    `;
-    yield* sql`
-      CREATE TABLE task_fact_projection (
-        fact_ref TEXT PRIMARY KEY,
-        task_id TEXT NOT NULL,
-        fact_id TEXT NOT NULL,
-        row_json TEXT NOT NULL
-      )
-    `;
-    yield* sql`
-      CREATE TABLE relation_projection_warnings (
-        warning_index INTEGER PRIMARY KEY,
-        row_json TEXT NOT NULL
-      )
-    `;
+    yield* createRelationGraphTables(sql);
+    yield* ensureEntityAttributionSummaryTable(sql);
     yield* insertMeta(sql, "version", projectionVersion);
     yield* insertMeta(sql, "sourceHash", meta.sourceHash);
     yield* insertMeta(sql, "rowsHash", meta.rowsHash);
@@ -182,23 +152,19 @@ export function writeProjectionDatabase(
     yield* insertMeta(sql, "taskSourceHash", meta.taskSourceHash ?? "");
     yield* insertMeta(sql, "sourceCacheHash", meta.sourceCacheHash ?? "");
     yield* insertMeta(sql, "legacyPersonIdsHash", meta.legacyPersonIdsHash ?? "");
-    for (const row of rows) yield* insertTaskRow(sql, row, projectedTaskFieldExtensions);
+    for (const batch of chunks(rows, 500)) yield* insertTaskRows(sql, batch, projectedTaskFieldExtensions);
     for (const row of decisionRows) yield* insertDecisionRow(sql, row);
-    for (const edge of graphRows.relationEdges) yield* insertRelationEdge(sql, edge);
-    for (const row of graphRows.coverageRows) yield* insertCoverageRow(sql, row);
-    for (const row of graphRows.factAnchors) yield* insertFactAnchor(sql, row);
-    for (const row of graphRows.factRows) yield* insertTaskFactRow(sql, row);
+    yield* insertRelationEdges(sql, graphRows.relationEdges);
+    yield* insertCoverageRows(sql, graphRows.coverageRows);
+    yield* insertFactAnchors(sql, graphRows.factAnchors);
+    yield* insertTaskFactRows(sql, graphRows.factRows);
     for (const [index, row] of graphRows.warnings.entries()) yield* insertRelationProjectionWarning(sql, index, row);
     yield* sql`CREATE INDEX task_projection_status ON task_projection (canonical_status, coordination_status)`;
     yield* sql`CREATE INDEX task_projection_parent_task_id ON task_projection (parent_task_id)`;
     yield* sql`CREATE INDEX task_projection_module_key ON task_projection (module_key)`;
     yield* sql`CREATE INDEX decision_projection_legacy_number ON decision_projection (legacy_number)`;
     yield* sql`CREATE INDEX decision_projection_state ON decision_projection (state)`;
-    yield* sql`CREATE INDEX relation_edges_source_ref ON relation_edges (source_ref)`;
-    yield* sql`CREATE INDEX relation_edges_target_ref ON relation_edges (target_ref)`;
-    yield* sql`CREATE INDEX relation_coverage_decision_ref ON relation_coverage (decision_ref)`;
-    yield* sql`CREATE INDEX task_fact_anchors_task_id ON task_fact_anchors (task_id)`;
-    yield* sql`CREATE INDEX task_fact_projection_task_id ON task_fact_projection (task_id)`;
+    yield* createRelationGraphIndexes(sql);
     if (materializeSupplemental) yield* materializeSupplemental(sql);
     const attributionRowsHash = yield* hashAttributionProjectionState(sql);
     yield* sql`UPDATE projection_meta SET value = ${attributionRowsHash} WHERE key = 'attributionRowsHash'`;
@@ -246,7 +212,13 @@ export function queryTaskProjectionRows(
   return runSqlite(projectionPath, Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
     const where = taskWhereClause(filters);
-    const records = yield* sql.unsafe<TaskRecord>(`SELECT * FROM task_projection ${where.sql} ORDER BY task_id`, where.params);
+    const records = yield* sql.unsafe<TaskRecord>(`
+      SELECT task_projection.*, ${attributionSummarySelect("task_attribution")}
+      FROM task_projection
+      ${attributionJoin("task", "task_projection.task_id", "task_attribution")}
+      ${where.sql}
+      ORDER BY task_projection.task_id
+    `, where.params);
     return records.map((record) => recordToTaskRow(record, taskFieldExtensions));
   }));
 }
@@ -255,7 +227,13 @@ export function queryDecisionProjectionRows(projectionPath: string, filters: Dec
   return runSqlite(projectionPath, Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
     const where = decisionWhereClause(filters);
-    const records = yield* sql.unsafe<DecisionRecord>(`SELECT * FROM decision_projection ${where.sql} ORDER BY COALESCE(legacy_number, 1000000000), decision_id`, where.params);
+    const records = yield* sql.unsafe<DecisionRecord>(`
+      SELECT decision_projection.*, ${attributionSummarySelect("decision_attribution")}
+      FROM decision_projection
+      ${attributionJoin("decision", "decision_projection.decision_id", "decision_attribution")}
+      ${where.sql}
+      ORDER BY COALESCE(decision_projection.legacy_number, 1000000000), decision_projection.decision_id
+    `, where.params);
     return records.map(recordToDecisionRow);
   }));
 }
@@ -263,7 +241,13 @@ export function queryDecisionProjectionRows(projectionPath: string, filters: Dec
 export function queryTaskChildrenRows(projectionPath: string, parentTaskId: string): ReadonlyArray<TaskProjectionRow> {
   return runSqlite(projectionPath, Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
-    const records = yield* sql.unsafe<TaskRecord>("SELECT * FROM task_projection WHERE parent_task_id = ? ORDER BY task_id", [parentTaskId]);
+    const records = yield* sql.unsafe<TaskRecord>(`
+      SELECT task_projection.*, ${attributionSummarySelect("task_attribution")}
+      FROM task_projection
+      ${attributionJoin("task", "task_projection.task_id", "task_attribution")}
+      WHERE task_projection.parent_task_id = ?
+      ORDER BY task_projection.task_id
+    `, [parentTaskId]);
     return records.map((record) => recordToTaskRow(record));
   }));
 }
@@ -279,9 +263,10 @@ export function queryTaskSubtreeRows(projectionPath: string, rootTaskId: string)
         FROM task_projection child
         JOIN subtree parent ON child.parent_task_id = parent.task_id
       )
-      SELECT task_projection.*
+      SELECT task_projection.*, ${attributionSummarySelect("task_attribution")}
       FROM task_projection
       JOIN subtree ON task_projection.task_id = subtree.task_id
+      ${attributionJoin("task", "task_projection.task_id", "task_attribution")}
       ORDER BY task_projection.task_id
     `, [rootTaskId]);
     return records.map((record) => recordToTaskRow(record));
@@ -291,18 +276,14 @@ export function queryTaskSubtreeRows(projectionPath: string, rootTaskId: string)
 export function readRelationGraphRows(projectionPath: string): ProjectionGraphRows {
   return runSqlite(projectionPath, Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
-    const edgeRecords = yield* sql`SELECT row_json FROM relation_edges ORDER BY source_ref, target_ref, relation_id`;
-    const coverageRecords = yield* sql`SELECT row_json FROM relation_coverage ORDER BY claim_ref`;
-    const factAnchorRecords = yield* sql`SELECT row_json FROM task_fact_anchors ORDER BY fact_ref`;
-    const factRecords = yield* sql`SELECT row_json FROM task_fact_projection ORDER BY fact_ref`;
-    const warningRecords = yield* sql`SELECT row_json FROM relation_projection_warnings ORDER BY warning_index`;
-    return {
-      relationEdges: edgeRecords.map((record) => JSON.parse(String(record.row_json)) as RelationGraphEdgeRow),
-      coverageRows: coverageRecords.map((record) => JSON.parse(String(record.row_json)) as RelationCoverageRow),
-      factAnchors: factAnchorRecords.map((record) => JSON.parse(String(record.row_json)) as FactAnchorRow),
-      factRows: factRecords.map((record) => JSON.parse(String(record.row_json)) as TaskFactProjectionRow),
-      warnings: warningRecords.map((record) => JSON.parse(String(record.row_json)) as ProjectionWarning)
-    };
+    return yield* readRelationGraphRowsFromStore(sql);
+  }));
+}
+
+export function readRelationGraphReuseSeed(projectionPath: string): RelationGraphReuseSeed {
+  return runSqlite(projectionPath, Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    return yield* readRelationGraphReuseSeedFromStore(sql);
   }));
 }
 
@@ -318,8 +299,18 @@ function readProjectionDatabase(
     const sql = yield* SqlClient.SqlClient;
     const metaRows = yield* sql`SELECT key, value FROM projection_meta`;
     const meta = new Map(metaRows.map((row) => [String(row.key), String(row.value)]));
-    const taskRecords = yield* sql.unsafe<TaskRecord>("SELECT * FROM task_projection ORDER BY task_id");
-    const decisionRecords = yield* sql.unsafe<DecisionRecord>("SELECT * FROM decision_projection ORDER BY COALESCE(legacy_number, 1000000000), decision_id");
+    const taskRecords = yield* sql.unsafe<TaskRecord>(`
+      SELECT task_projection.*, ${attributionSummarySelect("task_attribution")}
+      FROM task_projection
+      ${attributionJoin("task", "task_projection.task_id", "task_attribution")}
+      ORDER BY task_projection.task_id
+    `);
+    const decisionRecords = yield* sql.unsafe<DecisionRecord>(`
+      SELECT decision_projection.*, ${attributionSummarySelect("decision_attribution")}
+      FROM decision_projection
+      ${attributionJoin("decision", "decision_projection.decision_id", "decision_attribution")}
+      ORDER BY COALESCE(decision_projection.legacy_number, 1000000000), decision_projection.decision_id
+    `);
     return {
       meta: {
         version: meta.get("version"),
@@ -359,7 +350,38 @@ export function insertTaskRow(
 ): Effect.Effect<unknown, unknown> {
   const extensionColumns = taskFieldExtensions.map((extension) => extension.projection.column);
   const columns = [...baseTaskProjectionColumns, ...extensionColumns].map(quoteIdentifier);
-  const values = [
+  const values = taskRowValues(row, taskFieldExtensions);
+  const assignments = [...baseTaskProjectionColumns, ...extensionColumns]
+    .filter((column) => column !== "task_id")
+    .map((column) => `${quoteIdentifier(column)} = excluded.${quoteIdentifier(column)}`);
+  return sql.unsafe(
+    `INSERT INTO task_projection (${columns.join(", ")}) VALUES (${values.map(() => "?").join(", ")}) ON CONFLICT (task_id) DO UPDATE SET ${assignments.join(", ")}`,
+    values
+  );
+}
+
+function insertTaskRows(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<TaskProjectionRow>,
+  taskFieldExtensions: ReadonlyArray<TaskFieldExtensionProjection>
+): Effect.Effect<unknown, unknown> {
+  const extensionColumns = taskFieldExtensions.map((extension) => extension.projection.column);
+  const columns = [...baseTaskProjectionColumns, ...extensionColumns].map(quoteIdentifier);
+  const placeholders = `(${columns.map(() => "?").join(", ")})`;
+  const assignments = [...baseTaskProjectionColumns, ...extensionColumns]
+    .filter((column) => column !== "task_id")
+    .map((column) => `${quoteIdentifier(column)} = excluded.${quoteIdentifier(column)}`);
+  return sql.unsafe(
+    `INSERT INTO task_projection (${columns.join(", ")}) VALUES ${rows.map(() => placeholders).join(", ")} ON CONFLICT (task_id) DO UPDATE SET ${assignments.join(", ")}`,
+    rows.flatMap((row) => taskRowValues(row, taskFieldExtensions))
+  );
+}
+
+function taskRowValues(
+  row: TaskProjectionRow,
+  taskFieldExtensions: ReadonlyArray<TaskFieldExtensionProjection>
+): ReadonlyArray<unknown> {
+  return [
     row.taskId,
     row.title,
     row.parentTaskId ?? null,
@@ -382,16 +404,8 @@ export function insertTaskRow(
     row.moduleKey ?? null,
     row.moduleTitle ?? null,
     row.hasLessonCandidates === true ? 1 : 0,
-    JSON.stringify(row.attribution ?? unresolvedEntityAttribution()),
     ...taskFieldExtensions.map((extension) => row.fieldExtensions?.[extension.field] ?? extension.default)
   ];
-  const assignments = [...baseTaskProjectionColumns, ...extensionColumns]
-    .filter((column) => column !== "task_id" && column !== "attribution_json")
-    .map((column) => `${quoteIdentifier(column)} = excluded.${quoteIdentifier(column)}`);
-  return sql.unsafe(
-    `INSERT INTO task_projection (${columns.join(", ")}) VALUES (${values.map(() => "?").join(", ")}) ON CONFLICT (task_id) DO UPDATE SET ${assignments.join(", ")}`,
-    values
-  );
 }
 
 export function insertDecisionRow(sql: SqlClient.SqlClient, row: DecisionProjectionRow): Effect.Effect<unknown, unknown> {
@@ -399,14 +413,13 @@ export function insertDecisionRow(sql: SqlClient.SqlClient, row: DecisionProject
     INSERT INTO decision_projection (
       decision_id, legacy_id, legacy_number, state, title, question, chosen_json,
       rejected_json, path, module_keys_json, product_line_keys_json, risk_tier, urgency,
-      vertical, preset, decision_class, proposed_at, provenance_json, decided_at, attribution_json
+      vertical, preset, decision_class, proposed_at, provenance_json, decided_at
     ) VALUES (
       ${row.decisionId}, ${row.legacyId ?? null}, ${row.legacyId ? legacyNumberFromLabel(row.legacyId) ?? null : null},
       ${row.state}, ${row.title}, ${row.question}, ${JSON.stringify(row.chosen)}, ${JSON.stringify(row.rejected)},
       ${row.path}, ${JSON.stringify(row.moduleKeys)}, ${JSON.stringify(row.productLineKeys)}, ${row.riskTier ?? null}, ${row.urgency ?? null},
       ${row.vertical ?? null}, ${row.preset ?? null}, ${row.decisionClass ?? null}, ${row.proposedAt ?? null},
-      ${row.provenance ? JSON.stringify(row.provenance) : null}, ${row.decidedAt ?? null},
-      ${JSON.stringify(row.attribution ?? unresolvedEntityAttribution())}
+      ${row.provenance ? JSON.stringify(row.provenance) : null}, ${row.decidedAt ?? null}
     ) ON CONFLICT (decision_id) DO UPDATE SET
       legacy_id = excluded.legacy_id,
       legacy_number = excluded.legacy_number,
@@ -433,45 +446,6 @@ export function readAttributionProjectionStateHash(projectionPath: string): stri
   return runSqlite(projectionPath, Effect.flatMap(SqlClient.SqlClient, hashAttributionProjectionState));
 }
 
-export function insertRelationEdge(sql: SqlClient.SqlClient, edge: RelationGraphEdgeRow): Effect.Effect<unknown, unknown> {
-  return sql`
-    INSERT OR REPLACE INTO relation_edges (relation_id, source_ref, target_ref, relation_type, direction, state, row_json)
-    VALUES (${edge.relationId}, ${edge.sourceRef}, ${edge.targetRef}, ${edge.relationType}, ${edge.direction}, ${edge.state}, ${JSON.stringify(edge)})
-  `;
-}
-
-export function insertCoverageRow(sql: SqlClient.SqlClient, row: RelationCoverageRow): Effect.Effect<unknown, unknown> {
-  return sql`
-    INSERT OR REPLACE INTO relation_coverage (claim_ref, decision_ref, status, covering_fact_ref, row_json)
-    VALUES (${row.claimRef}, ${row.decisionRef}, ${row.status}, ${row.coveringFactRef ?? null}, ${JSON.stringify(row)})
-  `;
-}
-
-export function insertFactAnchor(sql: SqlClient.SqlClient, row: FactAnchorRow): Effect.Effect<unknown, unknown> {
-  return sql`
-    INSERT OR REPLACE INTO task_fact_anchors (fact_ref, task_id, fact_id, source_path, row_json)
-    VALUES (${row.factRef}, ${row.taskId}, ${row.factId}, ${row.sourcePath}, ${JSON.stringify(row)})
-  `;
-}
-
-export function insertTaskFactRow(sql: SqlClient.SqlClient, row: TaskFactProjectionRow): Effect.Effect<unknown, unknown> {
-  return sql`
-    INSERT OR REPLACE INTO task_fact_projection (fact_ref, task_id, fact_id, row_json)
-    VALUES (${row.ref}, ${row.taskId}, ${row.factId}, ${JSON.stringify(row)})
-  `;
-}
-
-export function insertRelationProjectionWarning(
-  sql: SqlClient.SqlClient,
-  index: number,
-  row: ProjectionWarning
-): Effect.Effect<unknown, unknown> {
-  return sql`
-    INSERT OR REPLACE INTO relation_projection_warnings (warning_index, row_json)
-    VALUES (${index}, ${JSON.stringify(row)})
-  `;
-}
-
 function taskWhereClause(filters: TaskProjectionQueryFilters): { readonly sql: string; readonly params: ReadonlyArray<unknown> } {
   const clauses: string[] = [];
   const params: unknown[] = [];
@@ -488,8 +462,8 @@ function taskWhereClause(filters: TaskProjectionQueryFilters): { readonly sql: s
   if (filters.missingMaterials) clauses.push("closeout_readiness = 'missing'");
   if (filters.search) {
     const needle = `%${filters.search.toLocaleLowerCase()}%`;
-    clauses.push("(lower(task_id) LIKE ? OR lower(title) LIKE ? OR lower(source_path) LIKE ? OR lower(COALESCE(preset, '')) LIKE ? OR lower(COALESCE(module_key, '')) LIKE ? OR lower(COALESCE(module_title, '')) LIKE ? OR lower(COALESCE(attribution_json, '')) LIKE ?)");
-    params.push(needle, needle, needle, needle, needle, needle, needle);
+    clauses.push("(lower(task_id) LIKE ? OR lower(title) LIKE ? OR lower(source_path) LIKE ? OR lower(COALESCE(preset, '')) LIKE ? OR lower(COALESCE(module_key, '')) LIKE ? OR lower(COALESCE(module_title, '')) LIKE ? OR lower(COALESCE(task_attribution.originator_json, '')) LIKE ? OR lower(COALESCE(task_attribution.latest_actor_json, '')) LIKE ?)");
+    params.push(needle, needle, needle, needle, needle, needle, needle, needle);
   }
   for (const extensionFilter of filters.fieldExtensions ?? []) {
     addClause(clauses, params, `${quoteIdentifier(extensionFilter.column)} = ?`, extensionFilter.value);
@@ -562,6 +536,16 @@ function legacyNumberFromLabel(value: string): number | undefined {
   if (!match) return undefined;
   const parsed = Number(match[1]);
   return Number.isInteger(parsed) ? parsed : undefined;
+}
+
+function attributionJoin(entityKind: string, entityIdExpression: string, alias: string): string {
+  return `LEFT JOIN entity_attribution_summary ${alias} ON ${alias}.entity_kind = '${entityKind}' AND ${alias}.entity_id = ${entityIdExpression}`;
+}
+
+function chunks<Value>(values: ReadonlyArray<Value>, size: number): ReadonlyArray<ReadonlyArray<Value>> {
+  const output: Value[][] = [];
+  for (let index = 0; index < values.length; index += size) output.push(values.slice(index, index + size));
+  return output;
 }
 
 export function queryableTaskFieldExtensions(

--- a/packages/kernel/src/projection/sqlite-projection-update-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-update-store.ts
@@ -15,12 +15,12 @@ import {
 } from "./sqlite-attribution-projection.ts";
 import type { AttributionProjectionDelta } from "./sqlite-attribution-projection.ts";
 import {
-  insertCoverageRow,
+  insertCoverageRows,
   insertDecisionRow,
-  insertFactAnchor,
+  insertFactAnchors,
   insertRelationProjectionWarning,
-  insertRelationEdge,
-  insertTaskFactRow,
+  insertRelationEdges,
+  insertTaskFactRows,
   insertTaskRow,
   queryableTaskFieldExtensions,
   runSqlite
@@ -36,6 +36,7 @@ export function updateProjectionDatabase(
     readonly upsertDecisionRows: ReadonlyArray<DecisionProjectionRow>;
     readonly meta: ProjectionMeta;
     readonly graphRows?: ProjectionGraphRows;
+    readonly preserveGraphFactRows?: boolean;
     readonly declaredDelta: DeclaredProjectionDelta;
     readonly attributionDelta?: AttributionProjectionDelta;
     readonly sourceCache?: ProjectionSourceCacheChange;
@@ -48,13 +49,17 @@ export function updateProjectionDatabase(
     yield* sql`BEGIN IMMEDIATE`;
     try {
       const reuseAttributionRowsHash = yield* canReuseAttributionRowsHash(sql, change);
+      const upsertTaskIds = new Set(change.upsertTaskRows.map((row) => row.taskId));
       for (const taskId of uniqueProjectionIds(change.deleteTaskIds)) {
+        if (upsertTaskIds.has(taskId)) continue;
         yield* sql`DELETE FROM task_projection WHERE task_id = ${taskId}`;
       }
       for (const row of change.upsertTaskRows) {
         yield* insertTaskRow(sql, row, projectedTaskFieldExtensions);
       }
+      const upsertDecisionIds = new Set(change.upsertDecisionRows.map((row) => row.decisionId));
       for (const decisionId of uniqueProjectionIds(change.deleteDecisionIds)) {
+        if (upsertDecisionIds.has(decisionId)) continue;
         yield* sql`DELETE FROM decision_projection WHERE decision_id = ${decisionId}`;
       }
       for (const row of change.upsertDecisionRows) {
@@ -63,17 +68,25 @@ export function updateProjectionDatabase(
       if (change.graphRows) {
         yield* sql`DELETE FROM relation_edges`;
         yield* sql`DELETE FROM relation_coverage`;
-        yield* sql`DELETE FROM task_fact_anchors`;
-        yield* sql`DELETE FROM task_fact_projection`;
-        yield* sql`DELETE FROM relation_projection_warnings`;
-        for (const edge of change.graphRows.relationEdges) yield* insertRelationEdge(sql, edge);
-        for (const row of change.graphRows.coverageRows) yield* insertCoverageRow(sql, row);
-        for (const row of change.graphRows.factAnchors) yield* insertFactAnchor(sql, row);
-        for (const row of change.graphRows.factRows) yield* insertTaskFactRow(sql, row);
-        for (const [index, row] of change.graphRows.warnings.entries()) yield* insertRelationProjectionWarning(sql, index, row);
+        yield* insertRelationEdges(sql, change.graphRows.relationEdges);
+        yield* insertCoverageRows(sql, change.graphRows.coverageRows);
+        if (!change.preserveGraphFactRows) {
+          yield* sql`DELETE FROM task_fact_anchors`;
+          yield* sql`DELETE FROM task_fact_projection`;
+          yield* sql`DELETE FROM relation_projection_warnings`;
+          yield* insertFactAnchors(sql, change.graphRows.factAnchors);
+          yield* insertTaskFactRows(sql, change.graphRows.factRows);
+          for (const [index, row] of change.graphRows.warnings.entries()) yield* insertRelationProjectionWarning(sql, index, row);
+        }
       }
       for (const table of change.declaredDelta.tables) {
-        yield* deleteDeclaredProjectionRows(sql, table.declaration, table.deletePrimaryKeys);
+        const primaryKey = table.declaration.projection.columns.find((column) => column.primaryKey)!;
+        const upsertIds = new Set(table.upsertRows.map((row) => String(row[primaryKey.name])));
+        yield* deleteDeclaredProjectionRows(
+          sql,
+          table.declaration,
+          table.deletePrimaryKeys.filter((id) => !upsertIds.has(id))
+        );
         yield* upsertDeclaredProjectionRows(sql, table.declaration, table.upsertRows);
       }
       yield* applyDeclaredSourceManifestDelta(sql, change.declaredDelta.manifest);
@@ -82,7 +95,7 @@ export function updateProjectionDatabase(
         const affectedSubjects = yield* applyAttributionProjectionDelta(sql, change.attributionDelta);
         yield* materializeEntityAttributionSubjects(sql, affectedSubjects);
         yield* materializeEntityAttributionTargets(sql, changedAttributionTargets(change));
-      } else {
+      } else if (!reuseAttributionRowsHash) {
         yield* materializeEntityAttributionTargets(sql, changedAttributionTargets(change));
       }
       yield* upsertMeta(sql, "sourceHash", change.meta.sourceHash);

--- a/packages/kernel/src/projection/sqlite-projection-validation-cache.ts
+++ b/packages/kernel/src/projection/sqlite-projection-validation-cache.ts
@@ -1,9 +1,17 @@
 import type { DeclaredSourceManifestRow } from "./sqlite-declared-source-manifest.ts";
 import { projectionDatabaseFileSignature } from "./sqlite-projection-database-signature.ts";
+import type { DecisionProjectionRow, ProjectionMeta, TaskProjectionRow } from "./types.ts";
+import type { ProjectionSourceCacheSnapshot } from "./sqlite-projection-source-cache.ts";
 
 export interface ProjectionValidationCacheEntry {
   readonly signature: string;
   readonly declaredManifest: ReadonlyArray<DeclaredSourceManifestRow>;
+  readonly projection?: {
+    readonly rows: ReadonlyArray<TaskProjectionRow>;
+    readonly decisionRows: ReadonlyArray<DecisionProjectionRow>;
+    readonly meta: ProjectionMeta;
+  };
+  readonly sourceCache?: ProjectionSourceCacheSnapshot;
 }
 
 const projectionValidationCache = new Map<string, ProjectionValidationCacheEntry>();
@@ -19,12 +27,19 @@ export function readCachedProjectionValidation(projectionPath: string): Projecti
 
 export function rememberProjectionValidation(
   projectionPath: string,
-  declaredManifest: ReadonlyArray<DeclaredSourceManifestRow>
+  declaredManifest: ReadonlyArray<DeclaredSourceManifestRow>,
+  projection?: ProjectionValidationCacheEntry["projection"],
+  sourceCache?: ProjectionSourceCacheSnapshot
 ): void {
   const signature = projectionDatabaseFileSignature(projectionPath);
   if (signature === null) return;
   projectionValidationCache.delete(projectionPath);
-  projectionValidationCache.set(projectionPath, { signature, declaredManifest });
+  projectionValidationCache.set(projectionPath, {
+    signature,
+    declaredManifest,
+    ...(projection ? { projection } : {}),
+    ...(sourceCache ? { sourceCache } : {})
+  });
   while (projectionValidationCache.size > projectionValidationCacheLimit) {
     const oldest = projectionValidationCache.keys().next().value as string | undefined;
     if (oldest === undefined) break;

--- a/packages/kernel/src/projection/sqlite-relation-graph-store.ts
+++ b/packages/kernel/src/projection/sqlite-relation-graph-store.ts
@@ -1,0 +1,318 @@
+import { SqlClient } from "@effect/sql";
+import { Effect } from "effect";
+import type { TaskFactProjectionRow } from "./fact-projection.ts";
+import type { FactAnchorRow, RelationCoverageRow, RelationGraphEdgeRow } from "./relation-graph-projection.ts";
+import type { ProjectionWarning } from "./types.ts";
+
+export interface ProjectionGraphRows {
+  readonly relationEdges: ReadonlyArray<RelationGraphEdgeRow>;
+  readonly coverageRows: ReadonlyArray<RelationCoverageRow>;
+  readonly factAnchors: ReadonlyArray<FactAnchorRow>;
+  readonly factRows: ReadonlyArray<TaskFactProjectionRow>;
+  readonly warnings: ReadonlyArray<ProjectionWarning>;
+}
+
+export interface RelationGraphReuseSeed {
+  readonly relationEdges: ReadonlyArray<RelationGraphEdgeRow>;
+  readonly factRefs: ReadonlySet<string>;
+}
+
+export function createRelationGraphTables(sql: SqlClient.SqlClient): Effect.Effect<unknown, unknown> {
+  return Effect.gen(function* () {
+    yield* sql`
+      CREATE TABLE relation_edges (
+        relation_id TEXT PRIMARY KEY,
+        source_ref TEXT NOT NULL,
+        target_ref TEXT NOT NULL,
+        relation_type TEXT NOT NULL,
+        direction TEXT NOT NULL,
+        strength TEXT NOT NULL,
+        origin TEXT NOT NULL,
+        state TEXT NOT NULL,
+        rationale TEXT NOT NULL,
+        owner_ref TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        record_index INTEGER NOT NULL
+      )
+    `;
+    yield* sql`
+      CREATE TABLE relation_coverage (
+        claim_ref TEXT PRIMARY KEY,
+        decision_ref TEXT NOT NULL,
+        status TEXT NOT NULL,
+        covering_fact_ref TEXT,
+        refuting_fact_refs_json TEXT,
+        relation_path_json TEXT NOT NULL
+      )
+    `;
+    yield* sql`
+      CREATE TABLE task_fact_anchors (
+        fact_ref TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        fact_id TEXT NOT NULL,
+        source_path TEXT NOT NULL
+      )
+    `;
+    yield* sql`
+      CREATE TABLE task_fact_projection (
+        fact_ref TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        fact_id TEXT NOT NULL,
+        schema_name TEXT NOT NULL,
+        statement TEXT NOT NULL,
+        source TEXT NOT NULL,
+        observed_at TEXT NOT NULL,
+        confidence TEXT NOT NULL,
+        memory_class TEXT NOT NULL,
+        memory_tags_json TEXT NOT NULL,
+        provenance_json TEXT NOT NULL
+      )
+    `;
+    yield* sql`
+      CREATE TABLE relation_projection_warnings (
+        warning_index INTEGER PRIMARY KEY,
+        code TEXT NOT NULL,
+        source TEXT NOT NULL,
+        severity TEXT NOT NULL,
+        message TEXT NOT NULL,
+        repair_hint TEXT
+      )
+    `;
+  });
+}
+
+export function createRelationGraphIndexes(sql: SqlClient.SqlClient): Effect.Effect<unknown, unknown> {
+  return Effect.gen(function* () {
+    yield* sql`CREATE INDEX relation_edges_source_ref ON relation_edges (source_ref)`;
+    yield* sql`CREATE INDEX relation_edges_target_ref ON relation_edges (target_ref)`;
+    yield* sql`CREATE INDEX relation_coverage_decision_ref ON relation_coverage (decision_ref)`;
+    yield* sql`CREATE INDEX task_fact_anchors_task_id ON task_fact_anchors (task_id)`;
+    yield* sql`CREATE INDEX task_fact_projection_task_id ON task_fact_projection (task_id)`;
+  });
+}
+
+export function readRelationGraphRowsFromStore(
+  sql: SqlClient.SqlClient
+): Effect.Effect<ProjectionGraphRows, unknown> {
+  return Effect.gen(function* () {
+    const edgeRecords = yield* sql<Record<string, unknown>>`
+      SELECT relation_id, source_ref, target_ref, relation_type, direction, strength, origin,
+             state, rationale, owner_ref, source_path, record_index
+      FROM relation_edges
+      ORDER BY source_ref, target_ref, relation_id
+    `;
+    const coverageRecords = yield* sql<Record<string, unknown>>`
+      SELECT claim_ref, decision_ref, status, covering_fact_ref, refuting_fact_refs_json, relation_path_json
+      FROM relation_coverage
+      ORDER BY claim_ref
+    `;
+    const factAnchorRecords = yield* sql<Record<string, unknown>>`
+      SELECT fact_ref, task_id, fact_id, source_path
+      FROM task_fact_anchors
+      ORDER BY fact_ref
+    `;
+    const factRecords = yield* sql<Record<string, unknown>>`
+      SELECT fact_ref, task_id, fact_id, schema_name, statement, source, observed_at,
+             confidence, memory_class, memory_tags_json, provenance_json
+      FROM task_fact_projection
+      ORDER BY fact_ref
+    `;
+    const warningRecords = yield* sql<Record<string, unknown>>`
+      SELECT warning_index, code, source, severity, message, repair_hint
+      FROM relation_projection_warnings
+      ORDER BY warning_index
+    `;
+    return {
+      relationEdges: edgeRecords.map(recordToRelationEdge),
+      coverageRows: coverageRecords.map(recordToCoverageRow),
+      factAnchors: factAnchorRecords.map(recordToFactAnchor),
+      factRows: factRecords.map(recordToTaskFact),
+      warnings: warningRecords.map(recordToProjectionWarning)
+    };
+  });
+}
+
+export function readRelationGraphReuseSeedFromStore(
+  sql: SqlClient.SqlClient
+): Effect.Effect<RelationGraphReuseSeed, unknown> {
+  return Effect.gen(function* () {
+    const edgeRecords = yield* sql<Record<string, unknown>>`
+      SELECT relation_id, source_ref, target_ref, relation_type, direction, strength, origin,
+             state, rationale, owner_ref, source_path, record_index
+      FROM relation_edges
+      ORDER BY source_ref, target_ref, relation_id
+    `;
+    const factRecords = yield* sql<{ readonly fact_ref: unknown }>`
+      SELECT fact_ref FROM task_fact_projection
+      UNION
+      SELECT source_ref AS fact_ref FROM relation_edges WHERE source_ref LIKE 'fact/%'
+      UNION
+      SELECT target_ref AS fact_ref FROM relation_edges WHERE target_ref LIKE 'fact/%'
+      ORDER BY fact_ref
+    `;
+    return {
+      relationEdges: edgeRecords.map(recordToRelationEdge),
+      factRefs: new Set(factRecords.map((record) => String(record.fact_ref).slice("fact/".length)))
+    };
+  });
+}
+
+export function insertRelationEdges(
+  sql: SqlClient.SqlClient,
+  edges: ReadonlyArray<RelationGraphEdgeRow>
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    for (const batch of chunks(edges, 500)) yield* sql.unsafe(`
+    INSERT OR REPLACE INTO relation_edges (
+      relation_id, source_ref, target_ref, relation_type, direction, strength, origin,
+      state, rationale, owner_ref, source_path, record_index
+    ) VALUES ${batch.map(() => "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").join(", ")}
+  `, batch.flatMap((edge) => [
+      edge.relationId, edge.sourceRef, edge.targetRef, edge.relationType, edge.direction,
+      edge.strength, edge.origin, edge.state, edge.rationale, edge.ownerRef, edge.sourcePath, edge.recordIndex
+    ]));
+  });
+}
+
+export function insertCoverageRows(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<RelationCoverageRow>
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    for (const batch of chunks(rows, 500)) yield* sql.unsafe(`
+    INSERT OR REPLACE INTO relation_coverage (
+      claim_ref, decision_ref, status, covering_fact_ref, refuting_fact_refs_json, relation_path_json
+    ) VALUES ${batch.map(() => "(?, ?, ?, ?, ?, ?)").join(", ")}
+  `, batch.flatMap((row) => [
+      row.claimRef,
+      row.decisionRef,
+      row.status,
+      row.coveringFactRef ?? null,
+      row.refutingFactRefs ? JSON.stringify(row.refutingFactRefs) : null,
+      JSON.stringify(row.relationPath)
+    ]));
+  });
+}
+
+export function insertFactAnchors(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<FactAnchorRow>
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    for (const batch of chunks(rows, 500)) yield* sql.unsafe(`
+    INSERT OR REPLACE INTO task_fact_anchors (fact_ref, task_id, fact_id, source_path)
+    VALUES ${batch.map(() => "(?, ?, ?, ?)").join(", ")}
+  `, batch.flatMap((row) => [row.factRef, row.taskId, row.factId, row.sourcePath]));
+  });
+}
+
+export function insertTaskFactRows(
+  sql: SqlClient.SqlClient,
+  rows: ReadonlyArray<TaskFactProjectionRow>
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    for (const batch of chunks(rows, 500)) yield* sql.unsafe(`
+    INSERT OR REPLACE INTO task_fact_projection (
+      fact_ref, task_id, fact_id, schema_name, statement, source, observed_at,
+      confidence, memory_class, memory_tags_json, provenance_json
+    ) VALUES ${batch.map(() => "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").join(", ")}
+  `, batch.flatMap((row) => [
+      row.ref,
+      row.taskId,
+      row.factId,
+      row.schema,
+      row.statement,
+      row.source,
+      row.observedAt,
+      row.confidence,
+      row.memoryClass,
+      JSON.stringify(row.memoryTags),
+      JSON.stringify(row.provenance)
+    ]));
+  });
+}
+
+export function insertRelationProjectionWarning(
+  sql: SqlClient.SqlClient,
+  index: number,
+  row: ProjectionWarning
+): Effect.Effect<unknown, unknown> {
+  return sql`
+    INSERT OR REPLACE INTO relation_projection_warnings (
+      warning_index, code, source, severity, message, repair_hint
+    ) VALUES (
+      ${index}, ${row.code}, ${row.source}, ${row.severity}, ${row.message}, ${row.repairHint ?? null}
+    )
+  `;
+}
+
+function recordToRelationEdge(record: Readonly<Record<string, unknown>>): RelationGraphEdgeRow {
+  return {
+    relationId: String(record.relation_id),
+    sourceRef: String(record.source_ref),
+    targetRef: String(record.target_ref),
+    relationType: String(record.relation_type) as RelationGraphEdgeRow["relationType"],
+    direction: String(record.direction) as RelationGraphEdgeRow["direction"],
+    strength: String(record.strength) as RelationGraphEdgeRow["strength"],
+    origin: String(record.origin) as RelationGraphEdgeRow["origin"],
+    state: String(record.state) as RelationGraphEdgeRow["state"],
+    rationale: String(record.rationale),
+    ownerRef: String(record.owner_ref),
+    sourcePath: String(record.source_path),
+    recordIndex: Number(record.record_index)
+  };
+}
+
+function recordToCoverageRow(record: Readonly<Record<string, unknown>>): RelationCoverageRow {
+  return {
+    decisionRef: String(record.decision_ref),
+    claimRef: String(record.claim_ref),
+    status: String(record.status) as RelationCoverageRow["status"],
+    ...(record.covering_fact_ref === null ? {} : { coveringFactRef: String(record.covering_fact_ref) }),
+    ...(record.refuting_fact_refs_json === null
+      ? {}
+      : { refutingFactRefs: JSON.parse(String(record.refuting_fact_refs_json)) as ReadonlyArray<string> }),
+    relationPath: JSON.parse(String(record.relation_path_json)) as ReadonlyArray<string>
+  };
+}
+
+function recordToFactAnchor(record: Readonly<Record<string, unknown>>): FactAnchorRow {
+  return {
+    factRef: String(record.fact_ref),
+    taskId: String(record.task_id),
+    factId: String(record.fact_id),
+    sourcePath: String(record.source_path)
+  };
+}
+
+function recordToTaskFact(record: Readonly<Record<string, unknown>>): TaskFactProjectionRow {
+  return {
+    schema: String(record.schema_name) as TaskFactProjectionRow["schema"],
+    ref: String(record.fact_ref),
+    taskId: String(record.task_id),
+    factId: String(record.fact_id),
+    statement: String(record.statement),
+    source: String(record.source),
+    observedAt: String(record.observed_at),
+    confidence: String(record.confidence) as TaskFactProjectionRow["confidence"],
+    memoryClass: String(record.memory_class) as TaskFactProjectionRow["memoryClass"],
+    memoryTags: JSON.parse(String(record.memory_tags_json)) as TaskFactProjectionRow["memoryTags"],
+    provenance: JSON.parse(String(record.provenance_json)) as TaskFactProjectionRow["provenance"]
+  };
+}
+
+function recordToProjectionWarning(record: Readonly<Record<string, unknown>>): ProjectionWarning {
+  return {
+    code: String(record.code) as ProjectionWarning["code"],
+    source: String(record.source) as ProjectionWarning["source"],
+    severity: String(record.severity) as ProjectionWarning["severity"],
+    message: String(record.message),
+    ...(record.repair_hint === null ? {} : { repairHint: String(record.repair_hint) })
+  };
+}
+
+function chunks<Value>(values: ReadonlyArray<Value>, size: number): ReadonlyArray<ReadonlyArray<Value>> {
+  const output: Value[][] = [];
+  for (let index = 0; index < values.length; index += size) output.push(values.slice(index, index + size));
+  return output;
+}

--- a/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
@@ -1,30 +1,35 @@
 import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { createHarnessRuntimeContext, resolveHarnessLayout } from "../layout/index.ts";
 import { readScalar } from "../markdown/frontmatter.ts";
 import type { RelationGraphEdgeRow } from "./relation-graph-projection.ts";
 import { buildRelationGraphProjection } from "./relation-graph-projection.ts";
+import { relationGraphFactProjectionSemanticHash, relationGraphSourceSemanticHash } from "./relation-graph-source-semantics.ts";
 import { compareDecisionRows, hashDecisionProjectionRows, readDecisionProjectionRowsForPathsFromSource } from "./sqlite-decision-source.ts";
 import {
-  applyDeclaredProjectionDeltaToSnapshots,
   buildDeclaredProjectionDeltaFromSources,
+  declaredProjectionRowsMatchManifest,
+  hashDeclaredProjectionIntegrityRows,
   hashDeclaredSourceManifestRows,
   readDeclaredSourceManifestRows
 } from "./sqlite-declared-source-manifest.ts";
 import {
   readAttributionProjectionStateHash,
-  readRelationGraphRows,
+  readRelationGraphReuseSeed,
   projectionVersion,
   tryReadProjectionDatabase
 } from "./sqlite-projection-store.ts";
 import { updateProjectionDatabase } from "./sqlite-projection-update-store.ts";
 import { buildAttributionProjectionDelta } from "./sqlite-attribution-projection.ts";
 import {
-  captureProjectionSourceCacheSnapshot,
+  buildProjectionSourceCacheChange,
+  readProjectionSourceCacheBody,
   readProjectionSourceCacheSnapshot,
+  refreshProjectionSourceCacheAfterIncrementalChange,
   restoreProjectionSourceCacheSnapshot
 } from "./sqlite-projection-source-cache.ts";
-import { compareRows, hashExactRows, readMarkdownSource, sourcePath, taskEntryToRow } from "./sqlite-task-source.ts";
+import { compareRows, hashExactRows, hashExactSortedRows, readMarkdownSource, sourcePath, taskEntryToRow } from "./sqlite-task-source.ts";
 import {
   rebuildTaskProjection
 } from "./sqlite-task-projection.ts";
@@ -34,16 +39,27 @@ import {
 } from "./sqlite-projection-validation-cache.ts";
 import {
   captureProjectionSourceFingerprint,
-  hashDeclaredProjectionSnapshots,
   hashProjectionLegacyPersonIds,
   readDeclaredProjectionSnapshots
 } from "./projection-source-snapshot.ts";
 import type { DecisionProjectionRow, ProjectionReadResult, TaskProjectionOptions, TaskProjectionRow } from "./types.ts";
 
+export interface IncrementalProjectionPhase {
+  readonly phase: "load-current" | "capture-source" | "derive-affected" | "declared-delta" | "hash-next" | "verify-source" | "source-delta" | "publish";
+  readonly milliseconds: number;
+}
+
 export function updateTaskProjectionIncrementally(options: TaskProjectionOptions & {
   readonly touchedPaths: ReadonlyArray<string>;
   readonly previousSourceFingerprint?: string;
+  readonly onPhase?: (phase: IncrementalProjectionPhase) => void;
 }): ProjectionReadResult & { readonly mode: "incremental" | "rebuild" | "unchanged" } {
+  let phaseStarted = performance.now();
+  const recordPhase = (phase: IncrementalProjectionPhase["phase"]): void => {
+    const now = performance.now();
+    options.onPhase?.({ phase, milliseconds: now - phaseStarted });
+    phaseStarted = now;
+  };
   const rootDir = path.resolve(options.rootDir);
   const runtimeContext = createHarnessRuntimeContext(rootDir, options.layoutOverrides);
   const projectionPath = options.projectionPath ? path.resolve(options.projectionPath) : resolveHarnessLayout(runtimeContext).projectionPath;
@@ -52,15 +68,18 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
 
-  const existing = tryReadProjectionDatabase(projectionPath, options.taskFieldExtensions);
+  const cachedValidation = readCachedProjectionValidation(projectionPath);
+  const cachedProjection = cachedValidation?.projection;
+  const existing = cachedProjection
+    ? { ok: true as const, ...cachedProjection }
+    : tryReadProjectionDatabase(projectionPath, options.taskFieldExtensions);
   if (!existing.ok) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
   if (existing.meta.version !== projectionVersion) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
-  const cachedValidation = readCachedProjectionValidation(projectionPath);
-  let persistedSourceCache: ReturnType<typeof readProjectionSourceCacheSnapshot> | undefined;
+  let persistedSourceCache: ReturnType<typeof readProjectionSourceCacheSnapshot> | undefined = cachedValidation?.sourceCache;
   if (!cachedValidation) {
     try {
       persistedSourceCache = readVerifiedProjectionSourceCache(projectionPath, existing.meta.sourceCacheHash);
@@ -71,30 +90,76 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     }
   }
   let declaredManifest: ReturnType<typeof readDeclaredSourceManifestRows>;
-  let existingDeclaredTables: ReturnType<typeof readDeclaredProjectionSnapshots>;
+  let existingDeclaredTables: ReturnType<typeof readDeclaredProjectionSnapshots> | undefined;
   let attributionRowsHash: string;
   try {
     declaredManifest = cachedValidation?.declaredManifest ?? readDeclaredSourceManifestRows(projectionPath);
-    existingDeclaredTables = readDeclaredProjectionSnapshots(projectionPath);
+    existingDeclaredTables = cachedValidation ? undefined : readDeclaredProjectionSnapshots(projectionPath);
     attributionRowsHash = cachedValidation
       ? existing.meta.attributionRowsHash ?? ""
       : readAttributionProjectionStateHash(projectionPath);
   } catch {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
-  if (!projectionRowsMatchMeta(existing, existingDeclaredTables, declaredManifest, attributionRowsHash)) {
+  if (!cachedProjection && !projectionRowsMatchMeta(existing, existingDeclaredTables, declaredManifest, attributionRowsHash)) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
-  const snapshot = captureProjectionSourceFingerprint(runtimeContext, declaredManifest);
+  recordPhase("load-current");
+  const authoredRoot = resolveHarnessLayout(runtimeContext).authoredRoot;
+  const attributionEventsRoot = resolveHarnessLayout(runtimeContext).attributionEventsRoot;
+  const declaredEntityOnly = options.touchedPaths.length > 0 && options.touchedPaths
+    .every((filePath) => isDeclaredEntityFile(authoredRoot, realPathIfExists(filePath)));
+  const touchedDeclaredPaths = declaredEntityOnly ? options.touchedPaths : [];
+  const touchesDeclared = options.touchedPaths.some((filePath) => isDeclaredEntityFile(authoredRoot, realPathIfExists(filePath)));
+  const touchesAttribution = options.touchedPaths.some((filePath) => isPathWithin(attributionEventsRoot, realPathIfExists(filePath)));
+  const touchesTaskSource = options.touchedPaths.some((filePath) =>
+    !isDeclaredEntityFile(authoredRoot, realPathIfExists(filePath)) &&
+    !isPathWithin(attributionEventsRoot, realPathIfExists(filePath)));
+  const touchedTaskPaths = touchesTaskSource
+    ? options.touchedPaths.filter((filePath) =>
+      !isDeclaredEntityFile(authoredRoot, realPathIfExists(filePath)) &&
+      !isPathWithin(attributionEventsRoot, realPathIfExists(filePath)))
+    : [];
+  const sourceCacheReuse = options.previousSourceFingerprint ? {
+    task: !touchesTaskSource,
+    declared: !touchesDeclared,
+    attribution: !touchesAttribution,
+    validateReusedTaskDirectories: false,
+    validateReusedDeclaredDirectories: false,
+    touchedTaskPaths
+  } : {};
+  const snapshot = captureProjectionSourceFingerprint(
+    runtimeContext,
+    declaredManifest,
+    options.previousSourceFingerprint && options.touchedPaths.length > 0 ? "verify" : "stable",
+    touchedDeclaredPaths,
+    sourceCacheReuse
+  );
+  recordPhase("capture-source");
   const source = snapshot.taskSource;
   const sourceHash = snapshot.fingerprint;
 
-  const oldGraph = safeReadRelationGraphRows(projectionPath);
-  const declaredEntityOnly = options.touchedPaths.length > 0 && options.touchedPaths
-    .every((filePath) => isDeclaredEntityFile(resolveHarnessLayout(runtimeContext).authoredRoot, realPathIfExists(filePath)));
-  const newGraph = declaredEntityOnly || options.touchedPaths.length === 0
+  const graphSourceChange = declaredEntityOnly
+    ? { changed: false, factProjectionReusable: false }
+    : relationGraphSourceChange(
+    rootDir,
+    projectionPath,
+    options.touchedPaths,
+    snapshot.taskSource.sourceInputs
+  );
+  const reusableGraph = declaredEntityOnly || !graphSourceChange.changed
     ? null
-    : buildRelationGraphProjection(runtimeContext, snapshot.taskSource.sourceInputs);
+    : safeReadRelationGraphReuseSeed(projectionPath);
+  if (graphSourceChange.changed && reusableGraph === null) {
+    return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+  }
+  const oldGraph = reusableGraph ?? { relationEdges: [], factRefs: new Set<string>() };
+  const preserveGraphFactRows = graphSourceChange.changed && graphSourceChange.factProjectionReusable && reusableGraph !== null;
+  const newGraph = declaredEntityOnly || !graphSourceChange.changed || options.touchedPaths.length === 0
+    ? null
+    : preserveGraphFactRows
+      ? buildRelationGraphProjection(runtimeContext, snapshot.taskSource.sourceInputs, oldGraph.factRefs)
+      : buildRelationGraphProjection(runtimeContext, snapshot.taskSource.sourceInputs);
   const affected = affectedProjectionEntities({
     rootDir,
     rootInput: runtimeContext,
@@ -105,6 +170,7 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     oldEdges: oldGraph.relationEdges,
     newEdges: newGraph?.edges ?? oldGraph.relationEdges
   });
+  recordPhase("derive-affected");
   let declaredDelta: ReturnType<typeof buildDeclaredProjectionDeltaFromSources>;
   try {
     declaredDelta = buildDeclaredProjectionDeltaFromSources(runtimeContext, declaredManifest, snapshot.declaredSources);
@@ -114,6 +180,7 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   const hasDeclaredDelta = declaredDelta.tables.length > 0 ||
     declaredDelta.manifest.deleteSourcePaths.length > 0 ||
     declaredDelta.manifest.upsertRows.length > 0;
+  recordPhase("declared-delta");
 
   if (existing.meta.sourceHash === sourceHash && !hasAffectedProjectionEntities(affected) && !hasDeclaredDelta) {
     return {
@@ -135,26 +202,38 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     affected.decisionPaths,
     source.sourceInputs
   );
-  const rowsHash = hashExactRows(taskChange.rows);
-  const decisionRowsHash = hashDecisionProjectionRows(decisionChange.rows);
-  const declaredRowsHash = hashDeclaredProjectionSnapshots(
-    applyDeclaredProjectionDeltaToSnapshots(existingDeclaredTables, declaredDelta)
-  );
+  const rowsHash = taskChange.currentRows.length === 0 && taskChange.deleteIds.size === 0
+    ? existing.meta.rowsHash
+    : hashExactSortedRows(taskChange.rows);
+  const decisionRowsHash = decisionChange.currentRows.length === 0 && decisionChange.deleteIds.size === 0
+    ? existing.meta.decisionRowsHash ?? hashDecisionProjectionRows(decisionChange.rows)
+    : hashDecisionProjectionRows(decisionChange.rows);
+  const declaredRowsHash = hashDeclaredProjectionIntegrityRows(declaredDelta.manifest.currentRows);
   const declaredManifestHash = hashDeclaredSourceManifestRows(declaredDelta.manifest.currentRows);
-  let verifiedSourceHash: string;
+  recordPhase("hash-next");
+  let verifiedSource: ReturnType<typeof captureProjectionSourceFingerprint>;
   try {
-    verifiedSourceHash = captureProjectionSourceFingerprint(
+    verifiedSource = captureProjectionSourceFingerprint(
       runtimeContext,
-      declaredDelta.manifest.currentRows
-    ).fingerprint;
+      declaredDelta.manifest.currentRows,
+      "verify",
+      touchedDeclaredPaths,
+      sourceCacheReuse
+    );
+    if (verifiedSource.declaredSources.some(({ source: declaredSource }) => !declaredSource.stats.cacheHit) &&
+        readMarkdownSource(runtimeContext, "verify").hash !== verifiedSource.taskSource.hash) {
+      return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
+    }
   } catch {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
-  if (verifiedSourceHash !== sourceHash) {
+  if (verifiedSource.fingerprint !== sourceHash) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
-  const sourceCacheNeedsRefresh = existing.meta.taskSourceHash !== snapshot.taskSource.hash ||
-    existing.meta.attributionSourceHash !== snapshot.attributionSource.hash;
+  recordPhase("verify-source");
+  const taskSourceCacheChanged = existing.meta.taskSourceHash !== snapshot.taskSource.hash;
+  const attributionSourceCacheChanged = existing.meta.attributionSourceHash !== snapshot.attributionSource.hash;
+  const sourceCacheNeedsRefresh = taskSourceCacheChanged || attributionSourceCacheChanged;
   if (sourceCacheNeedsRefresh && !persistedSourceCache) {
     try {
       persistedSourceCache = readVerifiedProjectionSourceCache(projectionPath, existing.meta.sourceCacheHash);
@@ -162,12 +241,26 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
       return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
     }
   }
-  const sourceCache = sourceCacheNeedsRefresh ? captureProjectionSourceCacheSnapshot(runtimeContext) : null;
+  const sourceCache = sourceCacheNeedsRefresh ? refreshProjectionSourceCacheAfterIncrementalChange({
+    rootInput: runtimeContext,
+    previousSnapshot: persistedSourceCache,
+    taskSource: snapshot.taskSource,
+    touchedTaskPaths,
+    taskChanged: taskSourceCacheChanged,
+    attributionChanged: attributionSourceCacheChanged
+  }) : null;
   if (sourceCacheNeedsRefresh && !sourceCache) {
     return { ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }), mode: "rebuild" };
   }
   const sourceCacheChange = sourceCache && persistedSourceCache && sourceCache.hash !== persistedSourceCache.hash
-    ? { previous: persistedSourceCache, current: sourceCache }
+    ? buildProjectionSourceCacheChange(
+      persistedSourceCache,
+      sourceCache,
+      [
+        ...(taskSourceCacheChanged ? ["task" as const] : []),
+        ...(attributionSourceCacheChanged ? ["attribution" as const] : [])
+      ]
+    )
     : undefined;
   const attributionChanged = existing.meta.attributionSourceHash !== snapshot.attributionSource.hash;
   let attributionDelta: ReturnType<typeof buildAttributionProjectionDelta> | undefined;
@@ -177,6 +270,7 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     }
     attributionDelta = buildAttributionProjectionDelta(sourceCacheChange);
   }
+  recordPhase("source-delta");
 
   updateProjectionDatabase(projectionPath, {
     deleteTaskIds: [...taskChange.deleteIds],
@@ -201,13 +295,19 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
       factAnchors: newGraph.factAnchors,
       factRows: newGraph.factRows,
       warnings: newGraph.warnings
-    } } : {}),
+    }, preserveGraphFactRows } : {}),
     declaredDelta,
     ...(sourceCacheChange ? { sourceCache: sourceCacheChange } : {}),
     ...(attributionDelta ? { attributionDelta } : {}),
     taskFieldExtensions: options.taskFieldExtensions
   });
-  rememberProjectionValidation(projectionPath, declaredDelta.manifest.currentRows);
+  recordPhase("publish");
+  rememberProjectionValidation(
+    projectionPath,
+    declaredDelta.manifest.currentRows,
+    undefined,
+    sourceCache ?? persistedSourceCache
+  );
 
   return {
     rows: taskChange.rows,
@@ -243,22 +343,52 @@ function projectionRowsMatchMeta(existing: {
     readonly declaredManifestHash?: string;
     readonly attributionRowsHash?: string;
   };
-}, declaredTables: ReturnType<typeof readDeclaredProjectionSnapshots>, declaredManifest: ReturnType<typeof readDeclaredSourceManifestRows>, attributionRowsHash: string): boolean {
+}, declaredTables: ReturnType<typeof readDeclaredProjectionSnapshots> | undefined, declaredManifest: ReturnType<typeof readDeclaredSourceManifestRows>, attributionRowsHash: string): boolean {
   return existing.meta.rowsHash === hashExactRows(existing.rows) &&
     (existing.meta.decisionRowsHash ?? "") === hashDecisionProjectionRows(existing.decisionRows) &&
-    (existing.meta.declaredRowsHash ?? "") === hashDeclaredProjectionSnapshots(declaredTables) &&
+    (existing.meta.declaredRowsHash ?? "") === hashDeclaredProjectionIntegrityRows(declaredManifest) &&
+    (declaredTables === undefined || declaredProjectionRowsMatchManifest(declaredTables, declaredManifest)) &&
     (existing.meta.declaredManifestHash ?? "") === hashDeclaredSourceManifestRows(declaredManifest) &&
     (existing.meta.attributionRowsHash ?? "") === attributionRowsHash;
 }
 
-function safeReadRelationGraphRows(projectionPath: string): {
+function safeReadRelationGraphReuseSeed(projectionPath: string): {
   readonly relationEdges: ReadonlyArray<RelationGraphEdgeRow>;
-} {
+  readonly factRefs: ReadonlySet<string>;
+} | null {
   try {
-    return readRelationGraphRows(projectionPath);
+    return readRelationGraphReuseSeed(projectionPath);
   } catch {
-    return { relationEdges: [] };
+    return null;
   }
+}
+
+function relationGraphSourceChange(
+  rootDir: string,
+  projectionPath: string,
+  touchedPaths: ReadonlyArray<string>,
+  sourceInputs: ReturnType<typeof readMarkdownSource>["sourceInputs"]
+): { readonly changed: boolean; readonly factProjectionReusable: boolean } {
+  const currentBodies = new Map(sourceInputs.map((input) => [input.sourcePath, input.body]));
+  const normalizedRoot = realPathIfExists(rootDir);
+  let changed = false;
+  let factProjectionReusable = true;
+  for (const touchedPath of touchedPaths) {
+    const relativePath = sourcePath(normalizedRoot, realPathIfExists(touchedPath));
+    const currentBody = currentBodies.get(relativePath);
+    const previousBody = readProjectionSourceCacheBody(projectionPath, "task", relativePath);
+    if (currentBody === undefined || previousBody === undefined) {
+      changed = true;
+      factProjectionReusable = false;
+      continue;
+    }
+    if (relationGraphSourceSemanticHash(relativePath, previousBody) ===
+        relationGraphSourceSemanticHash(relativePath, currentBody)) continue;
+    changed = true;
+    if (relationGraphFactProjectionSemanticHash(relativePath, previousBody) !==
+        relationGraphFactProjectionSemanticHash(relativePath, currentBody)) factProjectionReusable = false;
+  }
+  return { changed, factProjectionReusable };
 }
 
 function incrementalTaskRows(
@@ -272,6 +402,9 @@ function incrementalTaskRows(
   readonly currentRows: ReadonlyArray<TaskProjectionRow>;
   readonly deleteIds: ReadonlySet<string>;
 } {
+  if (affectedTaskIds.size === 0) {
+    return { rows: existingRows, currentRows: [], deleteIds: new Set() };
+  }
   const currentRows = entries
     .filter((entry) => affectedTaskIds.has(entry.taskId) || affectedTaskIds.has(readScalar(entry.frontmatter, "task_id") || entry.taskId))
     .map((entry) => taskEntryToRow(rootInput, entry, taskFieldExtensions));
@@ -297,6 +430,9 @@ function incrementalDecisionRows(
   readonly currentRows: ReadonlyArray<DecisionProjectionRow>;
   readonly deleteIds: ReadonlySet<string>;
 } {
+  if (affectedDecisionIds.size === 0 && affectedDecisionPaths.size === 0) {
+    return { rows: existingRows, currentRows: [], deleteIds: new Set() };
+  }
   const currentRows = readDecisionProjectionRowsForPathsFromSource(rootInput, [...affectedDecisionPaths], sourceInputs);
   const deleteIds = new Set([...affectedDecisionIds, ...currentRows.map((row) => row.decisionId)]);
   return {
@@ -337,6 +473,9 @@ function affectedProjectionEntities(input: {
     .map((filePath) => sourcePath(rootDir, filePath)));
   const taskTouchedRelativePaths = [...touchedRelativePaths]
     .filter((relativePath) => !declaredEntityRelativePaths.has(relativePath));
+  const tasksRootRelativePath = sourcePath(rootDir, tasksRoot);
+  const taskPackageTouchedRelativePaths = taskTouchedRelativePaths.filter((relativePath) =>
+    relativePath === tasksRootRelativePath || relativePath.startsWith(`${tasksRootRelativePath}/`));
 
   for (const filePath of input.touchedPaths) {
     const resolved = realPathIfExists(filePath);
@@ -347,16 +486,30 @@ function affectedProjectionEntities(input: {
     }
   }
 
-  for (const entry of input.sourceEntries) {
-    const entrySourcePath = sourcePath(rootDir, realPathIfExists(entry.indexPath));
-    if (taskTouchedRelativePaths.some((relativePath) => relativePath === entrySourcePath || relativePath.startsWith(`${path.posix.dirname(entrySourcePath)}/`))) {
-      taskIds.add(entry.taskId);
-    }
+  for (const relativePath of taskPackageTouchedRelativePaths) {
+    const entry = input.sourceEntries.find((candidate) => {
+      const entrySourcePath = sourcePath(path.resolve(input.rootDir), path.resolve(candidate.indexPath));
+      return relativePath === entrySourcePath || relativePath.startsWith(`${path.posix.dirname(entrySourcePath)}/`);
+    });
+    if (entry) taskIds.add(entry.taskId);
+
+    const row = input.existingRows.find((candidate) =>
+      relativePath === candidate.sourcePath || relativePath.startsWith(`${path.posix.dirname(candidate.sourcePath)}/`));
+    if (row) taskIds.add(row.taskId);
   }
 
-  for (const row of input.existingRows) {
-    if (taskTouchedRelativePaths.some((relativePath) => relativePath === row.sourcePath || relativePath.startsWith(`${path.posix.dirname(row.sourcePath)}/`))) {
-      taskIds.add(row.taskId);
+  if (taskPackageTouchedRelativePaths.length > 1) {
+    for (const entry of input.sourceEntries) {
+      const entrySourcePath = sourcePath(path.resolve(input.rootDir), path.resolve(entry.indexPath));
+      if (taskPackageTouchedRelativePaths.some((relativePath) => relativePath === entrySourcePath || relativePath.startsWith(`${path.posix.dirname(entrySourcePath)}/`))) {
+        taskIds.add(entry.taskId);
+      }
+    }
+
+    for (const row of input.existingRows) {
+      if (taskPackageTouchedRelativePaths.some((relativePath) => relativePath === row.sourcePath || relativePath.startsWith(`${path.posix.dirname(row.sourcePath)}/`))) {
+        taskIds.add(row.taskId);
+      }
     }
   }
 
@@ -403,7 +556,19 @@ function realPathIfExists(filePath: string): string {
   try {
     return realpathSync.native(filePath);
   } catch {
-    return path.resolve(filePath);
+    const missingSegments: string[] = [];
+    let existingParent = path.resolve(filePath);
+    while (!existsSync(existingParent)) {
+      const parent = path.dirname(existingParent);
+      if (parent === existingParent) return path.resolve(filePath);
+      missingSegments.unshift(path.basename(existingParent));
+      existingParent = parent;
+    }
+    try {
+      return path.join(realpathSync.native(existingParent), ...missingSegments);
+    } catch {
+      return path.resolve(filePath);
+    }
   }
 }
 

--- a/packages/kernel/src/projection/sqlite-task-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-projection.ts
@@ -20,9 +20,10 @@ import {
 } from "./sqlite-projection-store.ts";
 import { compareDecisionRows, hashDecisionProjectionRows } from "./sqlite-decision-source.ts";
 import {
-  applyDeclaredProjectionDeltaToSnapshots,
   buildDeclaredProjectionDeltaFromSources,
+  declaredProjectionRowsMatchManifest,
   declaredSourceManifestRows,
+  hashDeclaredProjectionIntegrityRows,
   hashDeclaredSourceManifestRows,
   readDeclaredSourceManifestRows,
   replaceDeclaredSourceManifestRows
@@ -45,7 +46,6 @@ import { compareRows, hashExactRows, taskEntryToRow } from "./sqlite-task-source
 import {
   captureProjectionSourceFingerprint,
   captureProjectionSourceSnapshot,
-  hashDeclaredProjectionSnapshots,
   hashProjectionLegacyPersonIds,
   readDeclaredProjectionSnapshots
 } from "./projection-source-snapshot.ts";
@@ -94,8 +94,8 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
   const decisionRows = snapshot.decisionRows;
   const rowsHash = hashExactRows(rows);
   const decisionRowsHash = hashDecisionProjectionRows(decisionRows);
-  const declaredRowsHash = hashDeclaredProjectionSnapshots(snapshot.declaredTables);
   const declaredManifestRows = declaredSourceManifestRows(snapshot.declaredTables, snapshot.declaredSources);
+  const declaredRowsHash = hashDeclaredProjectionIntegrityRows(declaredManifestRows);
   const declaredManifestHash = hashDeclaredSourceManifestRows(declaredManifestRows);
   const relationGraph = stableBuild.relationGraph;
   const sourceCache = stableBuild.sourceCache;
@@ -124,7 +124,7 @@ export function rebuildTaskProjection(options: TaskProjectionOptions): Projectio
     yield* replaceAttributionProjectionRows(sql, snapshot.attributionEvents);
     yield* materializeEntityAttributionBlocks(sql, snapshot.attributionEvents);
   }));
-  rememberProjectionValidation(projectionPath, declaredManifestRows);
+  rememberProjectionValidation(projectionPath, declaredManifestRows, undefined, sourceCache);
   return {
     rows,
     warnings: source.warnings
@@ -141,8 +141,8 @@ function captureStableProjectionBuild(runtimeContext: ReturnType<typeof createHa
     try {
       const snapshot = captureProjectionSourceSnapshot(runtimeContext);
       const relationGraph = buildRelationGraphProjection(runtimeContext, snapshot.taskSource.sourceInputs);
-      const verified = captureProjectionSourceFingerprint(runtimeContext);
-      const sourceCache = captureProjectionSourceCacheSnapshot(runtimeContext);
+      const verified = captureProjectionSourceFingerprint(runtimeContext, [], "verify");
+      const sourceCache = captureProjectionSourceCacheSnapshot(runtimeContext, true);
       if (verified.fingerprint === snapshot.fingerprint && sourceCache) return { snapshot, relationGraph, sourceCache };
       lastFailure = new Error("projection authored sources did not stabilize during rebuild");
     } catch (error) {
@@ -247,7 +247,11 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
       existingDeclaredTables = null;
     }
   }
-  if (!cachedValidation && (existingDeclaredTables === null || existing.meta.declaredRowsHash !== hashDeclaredProjectionSnapshots(existingDeclaredTables))) {
+  if (!cachedValidation && (
+    existingDeclaredTables === null ||
+    existing.meta.declaredRowsHash !== hashDeclaredProjectionIntegrityRows(declaredManifest) ||
+    !declaredProjectionRowsMatchManifest(existingDeclaredTables, declaredManifest)
+  )) {
     warnings.push(hardFail(
       "generated-cache",
       "projection_tampered",
@@ -297,9 +301,7 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
       existing.meta.legacyPersonIdsHash === legacyPersonIdsHash;
     if (declaredOnly) {
       try {
-        existingDeclaredTables ??= readDeclaredProjectionSnapshots(projectionPath);
         const declaredDelta = buildDeclaredProjectionDeltaFromSources(runtimeContext, declaredManifest, snapshot.declaredSources);
-        const currentDeclaredTables = applyDeclaredProjectionDeltaToSnapshots(existingDeclaredTables, declaredDelta);
         updateProjectionDatabase(projectionPath, {
           deleteTaskIds: [],
           upsertTaskRows: [],
@@ -308,13 +310,18 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
           meta: {
             ...existing.meta,
             sourceHash: snapshot.fingerprint,
-            declaredRowsHash: hashDeclaredProjectionSnapshots(currentDeclaredTables),
+            declaredRowsHash: hashDeclaredProjectionIntegrityRows(declaredDelta.manifest.currentRows),
             declaredManifestHash: hashDeclaredSourceManifestRows(declaredDelta.manifest.currentRows)
           },
           declaredDelta,
           taskFieldExtensions: options.taskFieldExtensions
         });
-        rememberProjectionValidation(projectionPath, declaredDelta.manifest.currentRows);
+        rememberProjectionValidation(
+          projectionPath,
+          declaredDelta.manifest.currentRows,
+          undefined,
+          cachedValidation?.sourceCache ?? persistedSourceCache ?? undefined
+        );
         warnings.push(warning(
           "generated-cache",
           "projection_stale",
@@ -340,7 +347,14 @@ export function readTaskProjection(options: TaskProjectionOptions): ProjectionRe
   if (persistedSourceCache && currentSourceCache && currentSourceCache.hash !== persistedSourceCache.hash) {
     updateProjectionSourceCacheSnapshot(projectionPath, persistedSourceCache, currentSourceCache);
   }
-  if (!cachedValidation) rememberProjectionValidation(projectionPath, declaredManifest);
+  if (!cachedValidation?.projection || !cachedValidation.sourceCache) {
+    rememberProjectionValidation(
+      projectionPath,
+      declaredManifest,
+      existing,
+      cachedValidation?.sourceCache ?? persistedSourceCache ?? undefined
+    );
+  }
 
   return {
     rows: [...existing.rows].sort(compareRows),

--- a/packages/kernel/src/projection/sqlite-task-source.ts
+++ b/packages/kernel/src/projection/sqlite-task-source.ts
@@ -60,12 +60,13 @@ const markdownSourceCache = new Map<string, MarkdownSourceCacheEntry>();
 const markdownSourceCacheLimit = 16;
 
 export function captureMarkdownSourcePersistentCache(
-  rootInput: HarnessLayoutInput
+  rootInput: HarnessLayoutInput,
+  reuseCacheWithoutValidation = false
 ): MarkdownSourcePersistentCache | null {
   const layout = resolveHarnessLayout(rootInput);
   const cacheKey = markdownSourceCacheKey(layout);
   const cached = markdownSourceCache.get(cacheKey);
-  if (!cached || !markdownSourceCacheEntryMatches(cached)) return null;
+  if (!cached || (!reuseCacheWithoutValidation && !markdownSourceCacheEntryMatches(cached))) return null;
   return {
     schema: "markdown-source-cache/v1",
     layoutIdentity: cacheKey,
@@ -116,7 +117,9 @@ function validPersistentMarkdownSource(persisted: MarkdownSourcePersistentCache)
     typeof input.sourcePath !== "string" ||
     !isSafeRelativeSourceCachePath(input.sourcePath) ||
     typeof input.body !== "string" ||
-    typeof input.statSignature !== "string")) return false;
+    typeof input.statSignature !== "string" ||
+    (input.contentSha256 !== undefined &&
+      (typeof input.contentSha256 !== "string" || sha256Text(input.body) !== input.contentSha256)))) return false;
   if (persisted.result.entries.some((entry) =>
     typeof entry.taskId !== "string" ||
     typeof entry.indexPath !== "string" ||
@@ -134,16 +137,23 @@ function validPersistentMarkdownSource(persisted: MarkdownSourcePersistentCache)
   return persisted.result.entries.every((entry) => bodiesByPath.get(entry.indexPath) === entry.body);
 }
 
-export function readMarkdownSource(rootInput: HarnessLayoutInput): {
-  readonly entries: ReadonlyArray<TaskSourceEntry>;
-  readonly hash: string;
-  readonly warnings: ReadonlyArray<ProjectionWarning>;
-  readonly sourceInputs: ReadonlyArray<TaskProjectionSourceHashInput>;
-} {
+export function readMarkdownSource(
+  rootInput: HarnessLayoutInput,
+  validation: "stable" | "verify" = "stable",
+  reuseCacheWithoutValidation = false,
+  touchedPaths: ReadonlyArray<string> = [],
+  validateReusedDirectories = true
+): MarkdownSourceResult {
   const layout = resolveHarnessLayout(rootInput);
   const cacheKey = markdownSourceCacheKey(layout);
   const cached = markdownSourceCache.get(cacheKey);
-  if (cached && markdownSourceCacheEntryMatches(cached)) {
+  if (cached && touchedPaths.length > 0) {
+    const refreshed = refreshMarkdownSourceCacheForTouchedPaths(layout, cacheKey, cached, touchedPaths);
+    if (refreshed) return refreshed;
+  }
+  if (cached && (reuseCacheWithoutValidation
+    ? !validateReusedDirectories || sourceCacheSignaturesMatch(cached.directorySignatures)
+    : markdownSourceCacheEntryMatches(cached, validation))) {
     markdownSourceCache.delete(cacheKey);
     markdownSourceCache.set(cacheKey, cached);
     return cached.result;
@@ -153,6 +163,80 @@ export function readMarkdownSource(rootInput: HarnessLayoutInput): {
   const cacheEntry = createMarkdownSourceCacheEntry(layout, source, result);
   markdownSourceCache.delete(cacheKey);
   if (cacheEntry) rememberMarkdownSourceCache(cacheKey, cacheEntry);
+  return result;
+}
+
+function refreshMarkdownSourceCacheForTouchedPaths(
+  layout: ReturnType<typeof resolveHarnessLayout>,
+  cacheKey: string,
+  cached: MarkdownSourceCacheEntry,
+  touchedPaths: ReadonlyArray<string>
+): MarkdownSourceResult | null {
+  const inputs = new Map(cached.result.sourceInputs.map((input) => [input.sourcePath, input]));
+  const entries = new Map(cached.result.entries.map((entry) => [sourcePath(layout.rootDir, entry.indexPath), entry]));
+  const fileSignatures = new Map(cached.fileSignatures);
+  let changed = false;
+  for (const touchedPath of touchedPaths) {
+    const absolutePath = path.resolve(touchedPath);
+    const relativePath = sourcePath(layout.rootDir, absolutePath);
+    const existing = inputs.get(relativePath);
+    if (!existing) return null;
+    const currentSignature = localProjectionSourceFileSystem.statSignature(absolutePath);
+    if (currentSignature === null) return null;
+    if (currentSignature === existing.statSignature) continue;
+    changed = true;
+    const stable = localProjectionSourceFileSystem.readStableText(absolutePath);
+    inputs.set(relativePath, {
+      kind: existing.kind,
+      sourcePath: relativePath,
+      body: stable.body,
+      statSignature: stable.signature,
+      contentSha256: sha256Text(stable.body)
+    });
+    fileSignatures.set(path.resolve(layout.rootDir, relativePath), stable.signature);
+    if (existing.kind === "task-index") {
+      let frontmatter: string;
+      try {
+        frontmatter = parseFrontmatter(stable.body);
+      } catch {
+        return null;
+      }
+      const previous = entries.get(relativePath);
+      entries.set(relativePath, {
+        taskId: previous?.taskId ?? path.basename(path.dirname(absolutePath)),
+        indexPath: absolutePath,
+        body: stable.body,
+        frontmatter,
+        statSignature: stable.signature
+      });
+    }
+  }
+  if (!changed) {
+    rememberMarkdownSourceCache(cacheKey, cached);
+    return cached.result;
+  }
+  const orderedEntries = [...entries.values()].sort((left, right) => left.indexPath.localeCompare(right.indexPath));
+  const taskIndexPaths = new Set(orderedEntries.map((entry) => sourcePath(layout.rootDir, entry.indexPath)));
+  const sourceInputs = [
+    ...orderedEntries.flatMap((entry) => {
+      const input = inputs.get(sourcePath(layout.rootDir, entry.indexPath));
+      return input ? [input] : [];
+    }),
+    ...[...inputs.values()]
+      .filter((input) => !taskIndexPaths.has(input.sourcePath))
+      .sort((left, right) => left.sourcePath.localeCompare(right.sourcePath))
+  ];
+  const result: MarkdownSourceResult = {
+    entries: orderedEntries,
+    hash: hashTaskSourceInputs(sourceInputs),
+    warnings: cached.result.warnings,
+    sourceInputs
+  };
+  rememberMarkdownSourceCache(cacheKey, {
+    result,
+    fileSignatures,
+    directorySignatures: cached.directorySignatures
+  });
   return result;
 }
 
@@ -219,9 +303,13 @@ function createMarkdownSourceCacheEntry(
   };
 }
 
-function markdownSourceCacheEntryMatches(entry: MarkdownSourceCacheEntry): boolean {
+function markdownSourceCacheEntryMatches(
+  entry: MarkdownSourceCacheEntry,
+  validation: "stable" | "verify" = "stable"
+): boolean {
   const signatures = new Map<string, string | null>([...entry.directorySignatures, ...entry.fileSignatures]);
-  return sourceCacheSignaturesMatch(signatures) && sourceCacheSignaturesMatch(signatures);
+  return sourceCacheSignaturesMatch(signatures) &&
+    (validation === "verify" || sourceCacheSignaturesMatch(signatures));
 }
 
 function reusableSourceBodies(
@@ -325,6 +413,7 @@ export interface TaskProjectionSourceHashInput {
   readonly sourcePath: string;
   readonly body: string;
   readonly statSignature: string;
+  readonly contentSha256?: string;
 }
 
 interface RelationSourceHashInput extends TaskProjectionSourceHashInput {
@@ -364,7 +453,8 @@ function readRelationGraphSourceInputs(
           ...(input.taskId ? { taskId: input.taskId } : {}),
           sourcePath: sourcePath(rootDir, input.path),
           body: sourceText.body,
-          statSignature: sourceText.signature
+          statSignature: sourceText.signature,
+          contentSha256: sha256Text(sourceText.body)
         }];
     });
   const decisionInputs = listDecisionDocuments(layout.decisionsRoot)
@@ -378,7 +468,8 @@ function readRelationGraphSourceInputs(
           kind,
           sourcePath: sourcePath(rootDir, decisionPath),
           body: sourceText.body,
-          statSignature: sourceText.signature
+          statSignature: sourceText.signature,
+          contentSha256: sha256Text(sourceText.body)
         }];
     });
   return [...taskDocumentInputs, ...decisionInputs];
@@ -405,7 +496,8 @@ function readTaskSupplementalSourceInputs(
           kind: input.kind,
           sourcePath: sourcePath(rootDir, input.path),
           body: sourceText.body,
-          statSignature: sourceText.signature
+          statSignature: sourceText.signature,
+          contentSha256: sha256Text(sourceText.body)
         }];
     });
 }
@@ -425,7 +517,11 @@ function listDecisionDocuments(decisionsRoot: string): ReadonlyArray<string> {
 }
 
 export function hashExactRows(rows: ReadonlyArray<TaskProjectionRow>): string {
-  return hashText(JSON.stringify([...rows].sort(compareRows).map(canonicalTaskProjectionRow)));
+  return hashExactSortedRows([...rows].sort(compareRows));
+}
+
+export function hashExactSortedRows(rows: ReadonlyArray<TaskProjectionRow>): string {
+  return hashText(JSON.stringify(rows.map(canonicalTaskProjectionRow)));
 }
 
 export function hashTaskProjectionRows(rows: ReadonlyArray<TaskProjectionRow>): string {
@@ -440,11 +536,14 @@ function hashText(text: string): string {
 }
 
 function hashTaskSourceInputs(inputs: ReadonlyArray<TaskProjectionSourceHashInput>): string {
-  return hashText(JSON.stringify(inputs.map(({ kind, sourcePath: inputPath, body }) => ({
-    kind,
-    sourcePath: inputPath,
-    body
-  }))));
+  return hashText(JSON.stringify({
+    schema: "task-projection-source/v2",
+    inputs: inputs.map(({ kind, sourcePath: inputPath, body, contentSha256 }) => ({
+      kind,
+      sourcePath: inputPath,
+      contentSha256: contentSha256 ?? sha256Text(body)
+    }))
+  }));
 }
 
 export function compareRows(a: TaskProjectionRow, b: TaskProjectionRow): number {

--- a/packages/kernel/test/store/attribution-union-projection.test.ts
+++ b/packages/kernel/test/store/attribution-union-projection.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 import {
   actorAxesBindingCoreDigestV2,
@@ -15,7 +16,11 @@ import {
   type SemanticMutationV2
 } from "../../src/integrity/semantic-mutation-integrity-v2.ts";
 import { decodeUnionAttributionEventBody } from "../../src/local/attribution-event-source.ts";
-import { readAttributionProjection } from "../../src/projection/sqlite-attribution-projection.ts";
+import {
+  materializeAttributionProjectionFromEvents,
+  readAttributionProjection
+} from "../../src/projection/sqlite-attribution-projection.ts";
+import { queryTaskProjectionRows } from "../../src/projection/sqlite-projection-store.ts";
 import { rebuildTaskProjection } from "../../src/projection/sqlite-task-projection.ts";
 import {
   attributionEventCompleteness,
@@ -105,6 +110,104 @@ test("union event headers and mutation join rebuild identically after SQLite del
     assert.equal(existsSync(projectionPath), false);
     rebuildTaskProjection({ rootDir });
     assert.deepEqual(readAttributionProjection(rootDir), before);
+  });
+});
+
+test("attribution materialization writes each entity summary without an unresolved intermediate state", () => {
+  withTempStore((rootDir) => {
+    const taskId = "task_T";
+    const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+    mkdirSync(taskRoot, { recursive: true });
+    writeFileSync(path.join(taskRoot, "INDEX.md"), [
+      "---",
+      "schema: task-package/v2",
+      `task_id: ${taskId}`,
+      "title: Set based attribution",
+      "lifecycle:",
+      "  bindingSchema: lifecycle-binding/v1",
+      "  engine: local",
+      "  status: active",
+      "  ref: ",
+      "  titleSnapshot: Set based attribution",
+      "  url: ",
+      "  bindingCreatedAt: 2026-07-13T00:00:00.000Z",
+      "  bindingFingerprint: sha256:fixture",
+      "packageDisposition: active",
+      "---",
+      ""
+    ].join("\n"), "utf8");
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const db = new DatabaseSync(projectionPath);
+    try {
+      db.exec(`
+        CREATE TRIGGER reject_unresolved_attribution_rewrite
+        BEFORE INSERT ON entity_attribution_summary
+        WHEN NEW.entity_kind = 'task'
+          AND NEW.entity_id = '${taskId}'
+          AND NEW.completeness = 'unresolved'
+        BEGIN SELECT RAISE(ABORT, 'attribution summary used an unresolved intermediate state'); END
+      `);
+    } finally {
+      db.close();
+    }
+
+    const event = decodeUnionAttributionEventBody(`${JSON.stringify(v1Event())}\n`);
+    materializeAttributionProjectionFromEvents(projectionPath, [event]);
+
+    const [task] = queryTaskProjectionRows(projectionPath, {});
+    assert.equal(task?.attribution.latestActor?.principal.personId, "person_zeyu");
+  });
+});
+
+test("entity attribution is stored once in the unified summary projection", () => {
+  withTempStore((rootDir) => {
+    const taskId = "task_T";
+    const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+    const eventsRoot = path.join(rootDir, "harness/attribution-events");
+    mkdirSync(taskRoot, { recursive: true });
+    mkdirSync(eventsRoot, { recursive: true });
+    writeFileSync(path.join(taskRoot, "INDEX.md"), [
+      "---",
+      "schema: task-package/v2",
+      `task_id: ${taskId}`,
+      "title: Unified attribution",
+      "lifecycle:",
+      "  bindingSchema: lifecycle-binding/v1",
+      "  engine: local",
+      "  status: active",
+      "  ref: ",
+      "  titleSnapshot: Unified attribution",
+      "  url: ",
+      "  bindingCreatedAt: 2026-07-13T00:00:00.000Z",
+      "  bindingFingerprint: sha256:fixture",
+      "packageDisposition: active",
+      "---",
+      ""
+    ].join("\n"), "utf8");
+    writeFileSync(path.join(eventsRoot, "legacy-op.jsonl"), `${JSON.stringify(v1Event())}\n`, "utf8");
+
+    rebuildTaskProjection({ rootDir });
+
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const db = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      const taskColumns = db.prepare("PRAGMA table_info(task_projection)").all() as Array<{ readonly name: string }>;
+      assert.equal(taskColumns.some((column) => column.name === "attribution_json"), false);
+      assert.deepEqual({ ...db.prepare(`
+        SELECT entity_kind, entity_id, trail_count, completeness
+        FROM entity_attribution_summary
+      `).get() }, {
+        entity_kind: "task",
+        entity_id: taskId,
+        trail_count: 1,
+        completeness: "host-only"
+      });
+    } finally {
+      db.close();
+    }
+    const [task] = queryTaskProjectionRows(projectionPath, {});
+    assert.equal(task?.attribution.latestActor?.principal.personId, "person_zeyu");
   });
 });
 

--- a/packages/kernel/test/store/relation-graph-projection.test.ts
+++ b/packages/kernel/test/store/relation-graph-projection.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import {
   checkTaskProjection,
   deriveRelationId,
@@ -37,6 +38,15 @@ function assertLoadBearingCoverageProjection(): void {
     writeDecision(rootDir, "dec_COVER", "wm-cover", [relation, exemptRelation]);
 
     rebuildTaskProjection({ rootDir });
+    const db = new DatabaseSync(path.join(rootDir, ".harness/cache/projections.sqlite"), { readOnly: true });
+    try {
+      for (const table of ["relation_edges", "relation_coverage", "task_fact_anchors"]) {
+        const columns = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ readonly name: string }>;
+        assert.equal(columns.some((column) => column.name === "row_json"), false);
+      }
+    } finally {
+      db.close();
+    }
     const coverage = readDecisionFactCoverage({ rootDir, decisionId: "dec_COVER" });
     const projection = readRelationGraphProjection({ rootDir });
 

--- a/packages/kernel/test/store/relation-graph-source-semantics.test.ts
+++ b/packages/kernel/test/store/relation-graph-source-semantics.test.ts
@@ -1,0 +1,30 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import { relationGraphSourceSemanticHash } from "../../src/projection/relation-graph-source-semantics.ts";
+
+test("relation source semantics ignore display titles but retain decision scope", () => {
+  const decision = [
+    "---",
+    "schema: decision-package/v1",
+    "decision_id: dec_SEMANTIC",
+    "_coordinatorWatermark: wm-semantic",
+    "title: Original title",
+    "applies_to:",
+    "  modules: [projection]",
+    "  productLines: []",
+    "claims:",
+    "relations:",
+    "---",
+    ""
+  ].join("\n");
+
+  assert.equal(
+    relationGraphSourceSemanticHash("decision.md", decision),
+    relationGraphSourceSemanticHash("decision.md", decision.replace("title: Original title", "title: Updated title"))
+  );
+  assert.notEqual(
+    relationGraphSourceSemanticHash("decision.md", decision),
+    relationGraphSourceSemanticHash("decision.md", decision.replace("modules: [projection]", "modules: [runtime]"))
+  );
+});

--- a/packages/kernel/test/store/sqlite-incremental-projection.test.ts
+++ b/packages/kernel/test/store/sqlite-incremental-projection.test.ts
@@ -142,6 +142,12 @@ test("single execution changes update a persisted source manifest without rebuil
         BEGIN SELECT RAISE(ABORT, 'untouched execution deleted'); END
       `);
       db.exec(`
+        CREATE TRIGGER preserve_changed_execution_identity
+        BEFORE DELETE ON execution_projection
+        WHEN OLD.execution_id = 'exe_00000000000000000000000001'
+        BEGIN SELECT RAISE(ABORT, 'changed execution should be updated in place'); END
+      `);
+      db.exec(`
         CREATE TRIGGER reject_unnecessary_task_upsert
         BEFORE INSERT ON task_projection
         WHEN NEW.task_id = '${taskId}'

--- a/packages/kernel/test/store/sqlite-projection-facts.test.ts
+++ b/packages/kernel/test/store/sqlite-projection-facts.test.ts
@@ -1,13 +1,14 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
-import { formatFactFlowRecord, type FactRecord } from "../../src/domain/index.ts";
+import { deriveRelationId, formatFactFlowRecord, formatRelationFlowRecord, type FactRecord } from "../../src/domain/index.ts";
 import { captureProjectionSourceSnapshot } from "../../src/projection/projection-source-snapshot.ts";
 import { updateTaskProjectionIncrementally } from "../../src/projection/sqlite-task-incremental-projection.ts";
 import {
+  readRelationGraphProjection,
   readTriadicProjectionSnapshot,
   rebuildTaskProjection
 } from "../../src/projection/sqlite-task-projection.ts";
@@ -34,6 +35,10 @@ test("fact edits publish through the projection and corrupted fact rows rebuild 
     const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
     const database = new DatabaseSync(projectionPath);
     try {
+      for (const table of ["task_fact_projection", "relation_projection_warnings"]) {
+        const columns = database.prepare(`PRAGMA table_info(${table})`).all() as Array<{ readonly name: string }>;
+        assert.equal(columns.some((column) => column.name === "row_json"), false);
+      }
       database.exec("DROP TABLE task_fact_projection");
     } finally {
       database.close();
@@ -65,8 +70,68 @@ test("malformed FactFlow records surface projection warnings instead of disappea
   });
 });
 
+test("relation-only task edits preserve unchanged fact projection rows", () => {
+  withTempStore((rootDir) => {
+    const taskIndexPath = path.join(rootDir, "harness/tasks/task_01J00000000000000000000001/INDEX.md");
+    seedFactTask(rootDir, factRecord("Stable projected fact"));
+    seedTaskIndex(rootDir, "task_01J00000000000000000000002");
+    rebuildTaskProjection({ rootDir });
+
+    const database = new DatabaseSync(path.join(rootDir, ".harness/cache/projections.sqlite"));
+    try {
+      database.exec(`
+        CREATE TRIGGER reject_unchanged_fact_projection_rewrite
+        BEFORE DELETE ON task_fact_projection
+        BEGIN
+          SELECT RAISE(FAIL, 'unchanged fact projection rewritten');
+        END
+      `);
+    } finally {
+      database.close();
+    }
+
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const relation = {
+      relation_id: deriveRelationId({
+        source: "task/task_01J00000000000000000000001",
+        target: "task/task_01J00000000000000000000002",
+        type: "depends-on",
+        direction: "directed"
+      }),
+      source: "task/task_01J00000000000000000000001",
+      target: "task/task_01J00000000000000000000002",
+      type: "depends-on" as const,
+      direction: "directed" as const,
+      strength: "strong" as const,
+      origin: "declared" as const,
+      rationale: "Exercise relation-only incremental projection.",
+      state: "active" as const
+    };
+    writeFileSync(taskIndexPath, readFileSync(taskIndexPath, "utf8")
+      .replace("---\n\n# Fact projection task", `relations:\n${formatRelationFlowRecord(relation)}\n---\n\n# Fact projection task`));
+
+    const updated = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [taskIndexPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(updated.mode, "incremental");
+    assert.equal(readRelationGraphProjection({ rootDir }).edges.some((edge) => edge.relationId === relation.relation_id), true);
+    assert.equal(readTriadicProjectionSnapshot({ rootDir }).facts[0]?.statement, "Stable projected fact");
+  });
+});
+
 function seedFactTask(rootDir: string, fact: FactRecord): string {
   const taskId = "task_01J00000000000000000000001";
+  seedTaskIndex(rootDir, taskId);
+  const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+  const factsPath = path.join(taskRoot, "facts.md");
+  writeFactDocument(factsPath, fact);
+  return factsPath;
+}
+
+function seedTaskIndex(rootDir: string, taskId: string): void {
   const taskRoot = path.join(rootDir, "harness/tasks", taskId);
   mkdirSync(taskRoot, { recursive: true });
   writeFileSync(path.join(taskRoot, "INDEX.md"), [
@@ -91,9 +156,6 @@ function seedFactTask(rootDir: string, fact: FactRecord): string {
     "# Fact projection task",
     ""
   ].join("\n"));
-  const factsPath = path.join(taskRoot, "facts.md");
-  writeFactDocument(factsPath, fact);
-  return factsPath;
 }
 
 function writeFactDocument(factsPath: string, fact: FactRecord): void {

--- a/packages/kernel/test/store/sqlite-projection-integrity.test.ts
+++ b/packages/kernel/test/store/sqlite-projection-integrity.test.ts
@@ -51,12 +51,12 @@ test("projection reads reject valid-looking attribution tampering", () => {
     const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
     const db = new DatabaseSync(projectionPath);
     try {
-      db.prepare("UPDATE task_projection SET attribution_json = ? WHERE task_id = ?").run(JSON.stringify({
-        originator: { principal: { kind: "person", personId: "attacker" }, executor: null },
-        latestActor: { principal: { kind: "person", personId: "attacker" }, executor: null },
-        trailCount: 99,
-        completeness: "complete"
-      }), "task-a");
+      const attacker = JSON.stringify({ principal: { kind: "person", personId: "attacker" }, executor: null });
+      db.prepare(`
+        UPDATE entity_attribution_summary
+        SET originator_json = ?, latest_actor_json = ?, trail_count = 99, completeness = 'complete'
+        WHERE entity_kind = 'task' AND entity_id = ?
+      `).run(attacker, attacker, "task-a");
     } finally {
       db.close();
     }
@@ -283,12 +283,11 @@ test("incremental publish falls back to a stable rebuild after a cross-generatio
     mkdirSync(path.join(rootDir, "harness/sessions"), { recursive: true });
     writeIntegrityDecision(rootDir, "Decision B");
 
-    const sessionsRoot = path.join(rootDir, "harness/sessions");
-    const originalReadStableDirents = localProjectionSourceFileSystem.readStableDirents;
+    const originalReadStableText = localProjectionSourceFileSystem.readStableText;
     let mutated = false;
-    localProjectionSourceFileSystem.readStableDirents = (inputPath) => {
-      const result = originalReadStableDirents(inputPath);
-      if (!mutated && inputPath === sessionsRoot) {
+    localProjectionSourceFileSystem.readStableText = (inputPath) => {
+      const result = originalReadStableText(inputPath);
+      if (!mutated && inputPath === decisionPath) {
         mutated = true;
         writeIntegrityDecision(rootDir, "Decision C");
       }
@@ -302,7 +301,7 @@ test("incremental publish falls back to a stable rebuild after a cross-generatio
         previousSourceFingerprint
       });
     } finally {
-      localProjectionSourceFileSystem.readStableDirents = originalReadStableDirents;
+      localProjectionSourceFileSystem.readStableText = originalReadStableText;
     }
 
     assert.equal(mutated, true);

--- a/packages/kernel/test/store/sqlite-projection-source-cache.test.ts
+++ b/packages/kernel/test/store/sqlite-projection-source-cache.test.ts
@@ -1,21 +1,49 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
+import { localProjectionSourceFileSystem } from "../../src/local/local-layout-file-system.ts";
 import { captureProjectionSourceSnapshot } from "../../src/projection/projection-source-snapshot.ts";
 import { updateTaskProjectionIncrementally } from "../../src/projection/sqlite-task-incremental-projection.ts";
 import { readTaskProjection, rebuildTaskProjection } from "../../src/projection/sqlite-task-projection.ts";
 
-test("fresh processes reuse persisted task decision and attribution bodies", () => {
+test("fresh processes reuse projected attribution events without duplicating authored bodies", () => {
   withTempProjection((rootDir) => {
     seedHarness(rootDir);
     writeAttributionEvent(rootDir, "event-fresh-a", "task/task-a");
-    writeAttributionEvent(rootDir, "event-fresh-b", "task/task-b");
+    const reformattedEventPath = writeAttributionEvent(rootDir, "event-fresh-b", "task/task-b");
+    writeFileSync(reformattedEventPath, readFileSync(reformattedEventPath, "utf8").replace('{"schema"', '{ "schema"'));
+    stamp(reformattedEventPath);
     rebuildTaskProjection({ rootDir });
+
+    const db = new DatabaseSync(path.join(rootDir, ".harness/cache/projections.sqlite"), { readOnly: true });
+    try {
+      assert.deepEqual(db.prepare(`
+        SELECT owner_id, body IS NULL AS body_omitted
+        FROM projection_source_cache_files
+        WHERE cache_kind = 'attribution'
+        ORDER BY owner_id
+      `).all().map((row) => ({ ...row })), [
+        { owner_id: "event-fresh-a", body_omitted: 1 },
+        { owner_id: "event-fresh-b", body_omitted: 1 }
+      ]);
+      assert.deepEqual(db.prepare(`
+        SELECT owner_id, source_path
+        FROM projection_source_cache_files
+        WHERE cache_kind = 'task' AND source_kind = 'task-index'
+        ORDER BY owner_id
+      `).all().map((row) => ({ ...row })), [
+        { owner_id: "task-a", source_path: "harness/tasks/task-a/INDEX.md" },
+        { owner_id: "task-b", source_path: "harness/tasks/task-b/INDEX.md" },
+        { owner_id: "task-c", source_path: "harness/tasks/task-c/INDEX.md" }
+      ]);
+    } finally {
+      db.close();
+    }
 
     const result = runFreshProcess(rootDir, freshProjectionBodyCacheReaderScript);
 
@@ -177,6 +205,43 @@ test("single task changes never rewrite unchanged persisted source rows", () => 
     } finally {
       updated.close();
     }
+  });
+});
+
+test("single task verification never stats unrelated task source files", () => {
+  withTempProjection((rootDir) => {
+    for (let index = 0; index < 12; index += 1) {
+      writeIndex(rootDir, `task-${index}`, `Task ${index}`, "active");
+    }
+    rebuildTaskProjection({ rootDir });
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPath = writeIndex(rootDir, "task-1", "Task 1 changed", "done");
+    const tasksRoot = path.join(rootDir, "harness/tasks");
+    const touchedRoot = path.dirname(touchedPath);
+    const originalStatSignature = localProjectionSourceFileSystem.statSignature;
+    const unrelatedTaskSourceStats: string[] = [];
+    localProjectionSourceFileSystem.statSignature = (inputPath) => {
+      const resolved = path.resolve(inputPath);
+      if (resolved.startsWith(`${tasksRoot}${path.sep}`) &&
+          !resolved.startsWith(`${touchedRoot}${path.sep}`) &&
+          resolved !== touchedRoot) {
+        unrelatedTaskSourceStats.push(resolved);
+      }
+      return originalStatSignature(inputPath);
+    };
+    let result: ReturnType<typeof updateTaskProjectionIncrementally>;
+    try {
+      result = updateTaskProjectionIncrementally({
+        rootDir,
+        touchedPaths: [touchedPath],
+        previousSourceFingerprint
+      });
+    } finally {
+      localProjectionSourceFileSystem.statSignature = originalStatSignature;
+    }
+
+    assert.equal(result.mode, "incremental");
+    assert.deepEqual(unrelatedTaskSourceStats, []);
   });
 });
 

--- a/packages/kernel/test/store/sqlite-rebuild.test.ts
+++ b/packages/kernel/test/store/sqlite-rebuild.test.ts
@@ -460,7 +460,12 @@ test("corrupted SQLite projection is reported with a stable warning and rebuilt 
     const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
     const db = new DatabaseSync(projectionPath);
     try {
-      db.prepare("UPDATE task_projection SET attribution_json = ? WHERE task_id = ?").run("{bad-json", "task-1");
+      db.prepare(`
+        INSERT INTO entity_attribution_summary (
+          entity_kind, entity_id, originator_json, latest_actor_json, trail_count, completeness
+        ) VALUES ('task', ?, NULL, ?, 1, 'complete')
+        ON CONFLICT (entity_kind, entity_id) DO UPDATE SET latest_actor_json = excluded.latest_actor_json
+      `).run("task-1", "{bad-json");
     } finally {
       db.close();
     }

--- a/tools/perf/gui-projection-benchmark.mjs
+++ b/tools/perf/gui-projection-benchmark.mjs
@@ -4,7 +4,15 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { aggregateExecutions } from "../../packages/gui/src/renderer/execution-data.ts";
-import { queryExecutionEvidencePage, queryExecutions, readTriadicProjectionSnapshot, rebuildTaskProjection } from "../../packages/kernel/src/index.ts";
+import {
+  deriveRelationId,
+  formatRelationFlowRecord,
+  queryExecutionEvidencePage,
+  queryExecutions,
+  readTaskProjection,
+  readTriadicProjectionSnapshot,
+  rebuildTaskProjection
+} from "../../packages/kernel/src/index.ts";
 import { queryExecutionEvidencePageFromReadyGeneration } from "../../packages/kernel/src/projection/sqlite-execution-evidence-reader.ts";
 import {
   ensureExecutionEvidenceGenerationReady,
@@ -19,6 +27,7 @@ import { createDaemonRuntime } from "../../packages/adapters/local/src/index.ts"
 const size = positiveInteger("--size", 1_000);
 const outputsPerExecution = positiveInteger("--outputs", 5);
 const attributionEventsPerExecution = positiveInteger("--attribution-events", 5);
+const updateSamples = positiveInteger("--update-samples", 5);
 const keep = process.argv.includes("--keep");
 const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-perf-"));
 
@@ -26,6 +35,8 @@ try {
   const fixtureStart = performance.now();
   const fixtureRows = [];
   for (let index = 0; index < size; index += 1) fixtureRows.push(writeTask(index));
+  const reviewPath = writeReview(fixtureRows[0]);
+  const decisionPath = writeDecision();
   const fixtureMs = performance.now() - fixtureStart;
   initAuthoredGit();
 
@@ -65,26 +76,45 @@ try {
   const triadicSamples = sample(20, () => readTriadicProjectionSnapshot({ rootDir }));
   const triadicSnapshotP95 = percentile(triadicSamples.samples, 0.95);
   const changedExecution = fixtureRows[0];
-  const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
-  const manifest = readDeclaredSourceManifestRows(projectionPath);
-  const previousSourceFingerprint = captureProjectionSourceFingerprint(rootDir, manifest).fingerprint;
-  const previousEvidenceSourceFingerprint = readyGeneration.sourceHash;
-  const changedBody = JSON.parse(readFileSync(changedExecution.executionPath, "utf8"));
-  writeFileSync(changedExecution.executionPath, `${JSON.stringify({ ...changedBody, state: "accepted" }, null, 2)}\n`);
-  const incrementalEvidenceStarted = performance.now();
-  const incrementalEvidence = updateExecutionEvidenceProjectionIncrementally({
-    rootDir,
-    touchedPaths: [changedExecution.executionPath],
-    previousSourceFingerprint: previousEvidenceSourceFingerprint
+  const incrementalExecutions = benchmarkExecutionUpdates(changedExecution.executionPath, updateSamples);
+  const incrementalEvidence = incrementalExecutions.evidence.result;
+  const incrementalEvidenceMs = incrementalExecutions.evidence.p95;
+  const incremental = incrementalExecutions.projection.result;
+  const incrementalExecutionMs = incrementalExecutions.projection.p95;
+  const incrementalProjectionPhases = incrementalExecutions.projection.phases;
+  const incrementalReview = benchmarkProjectionUpdates(reviewPath, updateSamples, () => {
+    const review = JSON.parse(readFileSync(reviewPath, "utf8"));
+    writeFileSync(reviewPath, `${JSON.stringify({ ...review, verdict: review.verdict === "approved" ? "dismissed" : "approved" }, null, 2)}\n`);
   });
-  const incrementalEvidenceMs = performance.now() - incrementalEvidenceStarted;
-  const incrementalStarted = performance.now();
-  const incremental = updateTaskProjectionIncrementally({
-    rootDir,
-    touchedPaths: [changedExecution.executionPath],
-    previousSourceFingerprint
+  const taskPath = fixtureRows[Math.min(1, fixtureRows.length - 1)].taskPath;
+  const incrementalTask = benchmarkProjectionUpdates(taskPath, updateSamples, (index) => {
+    writeFileSync(taskPath, readFileSync(taskPath, "utf8")
+      .replaceAll(/Performance Task 1(?: update-\d+)?/gu, `Performance Task 1 update-${index}`));
   });
-  const incrementalExecutionMs = performance.now() - incrementalStarted;
+  const incrementalDecision = benchmarkProjectionUpdates(decisionPath, updateSamples, (index) => {
+    writeFileSync(decisionPath, readFileSync(decisionPath, "utf8")
+      .replace(/title: Performance Decision(?: update-\d+)?/u, `title: Performance Decision update-${index}`));
+  });
+  const incrementalRelation = benchmarkProjectionUpdates(fixtureRows[0].taskPath, updateSamples, () => {
+    const source = `task/${fixtureRows[0].taskId}`;
+    const target = `task/${fixtureRows[Math.min(1, fixtureRows.length - 1)].taskId}`;
+    const relation = {
+      relation_id: deriveRelationId({ source, target, type: "depends-on", direction: "directed" }),
+      source,
+      target,
+      type: "depends-on",
+      direction: "directed",
+      strength: "strong",
+      origin: "declared",
+      rationale: "Performance relation update",
+      state: "active"
+    };
+    const body = readFileSync(fixtureRows[0].taskPath, "utf8");
+    const relationBlock = `relations:\n${formatRelationFlowRecord(relation)}\n`;
+    writeFileSync(fixtureRows[0].taskPath, body.includes(relationBlock)
+      ? body.replace(relationBlock, "")
+      : body.replace(`\n---\n\n# Performance Task 0`, `\n${relationBlock}---\n\n# Performance Task 0`));
+  });
   const result = {
     schema: "gui-projection-benchmark/v2",
     fixture: {
@@ -92,6 +122,7 @@ try {
       executions: size,
       outputs: size * outputsPerExecution,
       attributionEvents: size * attributionEventsPerExecution,
+      updateSamples,
       rootDir: keep ? rootDir : "<temporary>"
     },
     milliseconds: {
@@ -106,7 +137,14 @@ try {
       readTriadicProjectionSnapshot: summarize(triadicSamples.samples),
       aggregateExecutions: summarize(aggregateSamples.samples),
       incrementalEvidence: rounded(incrementalEvidenceMs),
-      incrementalExecution: rounded(incrementalExecutionMs)
+      incrementalEvidenceSamples: incrementalExecutions.evidence.summary,
+      incrementalExecution: rounded(incrementalExecutionMs),
+      incrementalExecutionSamples: incrementalExecutions.projection.summary,
+      incrementalProjectionPhases,
+      incrementalReview,
+      incrementalTask,
+      incrementalDecision,
+      incrementalRelation
     },
     assertions: {
       executionCount: executions.length === size,
@@ -163,8 +201,29 @@ try {
       incrementalEvidenceWithinBudget: size === 1_000 || size === 5_000
         ? incrementalEvidenceMs <= 250
         : null,
+      incrementalProjectionBudgetMs: size === 1_000 || size === 5_000 ? 250 : null,
+      incrementalProjectionWithinBudget: size === 1_000 || size === 5_000
+        ? incrementalExecutionMs <= 250
+        : null,
+      incrementalReviewWithinBudget: size === 1_000 || size === 5_000
+        ? incrementalReview.milliseconds <= 250
+        : null,
+      incrementalTaskWithinBudget: size === 1_000 || size === 5_000
+        ? incrementalTask.milliseconds <= 250
+        : null,
+      incrementalDecisionWithinBudget: size === 1_000 || size === 5_000
+        ? incrementalDecision.milliseconds <= 250
+        : null,
+      incrementalRelationBudgetMs: size === 1_000 || size === 5_000 ? 500 : null,
+      incrementalRelationWithinBudget: size === 1_000 || size === 5_000
+        ? incrementalRelation.milliseconds <= 500
+        : null,
       incrementalEvidenceMode: incrementalEvidence.mode,
-      incrementalExecutionMode: incremental.mode
+      incrementalExecutionMode: incremental.mode,
+      incrementalReviewMode: incrementalReview.mode,
+      incrementalTaskMode: incrementalTask.mode,
+      incrementalDecisionMode: incrementalDecision.mode,
+      incrementalRelationMode: incrementalRelation.mode
     }
   };
 
@@ -182,9 +241,18 @@ try {
       result.assertions.evidenceFacetBuildWithinBudget === false ||
       result.assertions.coldFirstUsableWithinBudget === false ||
       result.assertions.incrementalEvidenceWithinBudget === false ||
+      result.assertions.incrementalProjectionWithinBudget === false ||
+      result.assertions.incrementalReviewWithinBudget === false ||
+      result.assertions.incrementalTaskWithinBudget === false ||
+      result.assertions.incrementalDecisionWithinBudget === false ||
+      result.assertions.incrementalRelationWithinBudget === false ||
       incrementalEvidence.mode !== "incremental" ||
       result.assertions.triadicSnapshotWithinBudget === false ||
-      incremental.mode !== "incremental") {
+      incremental.mode !== "incremental" ||
+      incrementalReview.mode !== "incremental" ||
+      incrementalTask.mode !== "incremental" ||
+      incrementalDecision.mode !== "incremental" ||
+      incrementalRelation.mode !== "incremental") {
     process.exitCode = 1;
   }
 } finally {
@@ -276,7 +344,162 @@ function writeTask(index) {
       }
     })}\n`);
   }
-  return { taskId, executionId, executionPath };
+  return { taskId, executionId, executionPath, taskPath: path.join(taskRoot, "INDEX.md") };
+}
+
+function writeReview(fixture) {
+  const reviewId = "rev_00000000000000000000000000";
+  const reviewPath = path.join(rootDir, "harness/tasks", fixture.taskId, "reviews", `${reviewId}.md`);
+  mkdirSync(path.dirname(reviewPath), { recursive: true });
+  writeFileSync(reviewPath, `${JSON.stringify({
+    schema: "review/v2",
+    review_id: reviewId,
+    task_ref: `task/${fixture.taskId}`,
+    execution_ref: `execution/${fixture.taskId}/${fixture.executionId}`,
+    reviewer_actor: {
+      principal: { personId: "person_perf" },
+      executor: null,
+      responsibleHuman: "person_perf"
+    },
+    reviewer_session_ref: "session/perf",
+    findings: "Performance review",
+    evidence_checked: [],
+    rationale: "Projection benchmark review.",
+    verdict: "approved",
+    archive_warnings_acknowledged: false,
+    reviewed_at: "2026-07-13T00:02:00.000Z"
+  }, null, 2)}\n`);
+  return reviewPath;
+}
+
+function writeDecision() {
+  const decisionPath = path.join(rootDir, "harness/decisions/decision-dec_PERFORMANCE/decision.md");
+  mkdirSync(path.dirname(decisionPath), { recursive: true });
+  writeFileSync(decisionPath, [
+    "---",
+    "schema: decision-package/v1",
+    "decision_id: dec_PERFORMANCE",
+    "_coordinatorWatermark: wm-performance",
+    "title: Performance Decision",
+    "state: active",
+    "riskTier: medium",
+    "urgency: medium",
+    "vertical: software/coding",
+    "preset: architecture-decision",
+    "applies_to:",
+    "  modules: [projection]",
+    "  productLines: []",
+    "proposedBy: { kind: agent, id: benchmark }",
+    "proposedAt: 2026-07-13T00:00:00.000Z",
+    "arbiter: { kind: human, id: benchmark }",
+    "decidedAt: 2026-07-13T00:00:00.000Z",
+    "question: Should projection updates remain bounded?",
+    "chosen:",
+    "  - { id: CH1, text: Keep updates bounded }",
+    "rejected:",
+    "  - { id: RJ1, text: Rebuild everything, why_not: Too slow }",
+    "claims:",
+    "  - { id: C1, text: Incremental updates are bounded, load_bearing: false }",
+    "relations:",
+    "---",
+    "",
+    "# Performance Decision",
+    ""
+  ].join("\n"));
+  return decisionPath;
+}
+
+function benchmarkProjectionUpdate(touchedPath, mutate) {
+  readTaskProjection({ rootDir });
+  const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+  const manifest = readDeclaredSourceManifestRows(projectionPath);
+  const previousSourceFingerprint = captureProjectionSourceFingerprint(rootDir, manifest).fingerprint;
+  mutate();
+  const phases = [];
+  const started = performance.now();
+  const result = updateTaskProjectionIncrementally({
+    rootDir,
+    touchedPaths: [touchedPath],
+    previousSourceFingerprint,
+    onPhase: (phase) => phases.push({ phase: phase.phase, milliseconds: rounded(phase.milliseconds) })
+  });
+  return { milliseconds: rounded(performance.now() - started), mode: result.mode, phases };
+}
+
+function benchmarkProjectionUpdates(touchedPath, iterations, mutate) {
+  const samples = [];
+  const modes = [];
+  let latest;
+  for (let index = 0; index < iterations; index += 1) {
+    latest = benchmarkProjectionUpdate(touchedPath, () => mutate(index));
+    samples.push(latest.milliseconds);
+    modes.push(latest.mode);
+  }
+  const summary = summarize(samples);
+  return {
+    milliseconds: summary.p95,
+    ...summary,
+    samples: samples.map(rounded),
+    mode: modes.every((mode) => mode === "incremental") ? "incremental" : modes.find((mode) => mode !== "incremental"),
+    phases: latest?.phases ?? []
+  };
+}
+
+function benchmarkExecutionUpdates(executionPath, iterations) {
+  const evidenceSamples = [];
+  const projectionSamples = [];
+  const evidenceModes = [];
+  const projectionModes = [];
+  let evidenceResult;
+  let projectionResult;
+  let projectionPhases = [];
+  for (let index = 0; index < iterations; index += 1) {
+    readTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const manifest = readDeclaredSourceManifestRows(projectionPath);
+    const previousSourceFingerprint = captureProjectionSourceFingerprint(rootDir, manifest).fingerprint;
+    const previousEvidenceSourceFingerprint = ensureExecutionEvidenceGenerationReady({ rootDir }).ready.sourceHash;
+    const body = JSON.parse(readFileSync(executionPath, "utf8"));
+    writeFileSync(executionPath, `${JSON.stringify({ ...body, state: body.state === "accepted" ? "submitted" : "accepted" }, null, 2)}\n`);
+
+    const evidenceStarted = performance.now();
+    evidenceResult = updateExecutionEvidenceProjectionIncrementally({
+      rootDir,
+      touchedPaths: [executionPath],
+      previousSourceFingerprint: previousEvidenceSourceFingerprint
+    });
+    evidenceSamples.push(performance.now() - evidenceStarted);
+    evidenceModes.push(evidenceResult.mode);
+
+    projectionPhases = [];
+    const projectionStarted = performance.now();
+    projectionResult = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [executionPath],
+      previousSourceFingerprint,
+      onPhase: (phase) => projectionPhases.push({
+        phase: phase.phase,
+        milliseconds: rounded(phase.milliseconds)
+      })
+    });
+    projectionSamples.push(performance.now() - projectionStarted);
+    projectionModes.push(projectionResult.mode);
+  }
+  const evidenceSummary = summarize(evidenceSamples);
+  const projectionSummary = summarize(projectionSamples);
+  return {
+    evidence: {
+      ...evidenceSummary,
+      summary: { ...evidenceSummary, samples: evidenceSamples.map(rounded) },
+      result: { ...evidenceResult, mode: evidenceModes.every((mode) => mode === "incremental") ? "incremental" : evidenceModes.find((mode) => mode !== "incremental") }
+    },
+    projection: {
+      ...projectionSummary,
+      summary: { ...projectionSummary, samples: projectionSamples.map(rounded) },
+      result: { ...projectionResult, mode: projectionModes.every((mode) => mode === "incremental") ? "incremental" : projectionModes.find((mode) => mode !== "incremental") },
+      phases: projectionPhases
+    }
+  };
 }
 
 function sample(iterations, run) {


### PR DESCRIPTION
# English

## Summary

Normalize the incremental SQLite read models behind the GUI projection so warm re-entry stops full-scanning authored task sources. Attribution, relationship, and evidence projections move to normalized row tables with an incremental source cache and touched-path verification, batched SQL writes, relation-only fact reuse, declarative manifest integrity, and warm daemon generation reuse. This is the foundational "projection freshness" slice (P1) of the PLT-Performance milestone.

## What Changed

- Normalized attribution/relationship/evidence read models into structured row tables (replacing monolithic JSON blobs) with an incremental source cache keyed by touched-path fingerprints.
- Added batched SQL writes, relation-only fact reuse, and warm daemon generation reuse so unchanged sources are not re-read on every projection.
- Extended `tools/perf/gui-projection-benchmark.mjs` with 5-sample update runs and budget assertions at 100/1,000/5,000 tasks.
- Regression coverage: single-task verification does not stat unrelated task source files; single-change reads only the changed body; incremental SQL writes; relation/fact parity; concurrent source fence.

## Task And Scope

- Harness task: `task_01KXCS9KEKA2H3H8614ZBB984J`
- Branch: `codex/plt-performance-p1-normalized-projections`
- Public scope: kernel projection read models, incremental source cache, relation-graph source semantics, and the perf benchmark tool. 34 files, +2884/-842.
- Private planning/evidence updated: yes
- Out of scope: daemon transport (P2), GUI bounded rendering (P3), multicollab concurrency matrix (P4).

## Version Impact

- Version: no version change because this is an unreleased internal projection/performance slice.
- Publish impact: no publish; release packaging remains a separate release task.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable (no gate-manifest, write-road registry, or CI-config changes; changes are kernel projection code, tests, and a perf tool).
- Authority: `task_01KXCS9KEKA2H3H8614ZBB984J`, parent `task_01KXCS7FJ8MNWA70TEB13Z63EW`.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `cdf4aaaa301bcba958c55a29a62bcb6cca80e9c4`
- Branch merge-base with `origin/main`: `cdf4aaaa301bcba958c55a29a62bcb6cca80e9c4`
- Last `git fetch origin` time: 2026-07-14, immediately before this rebase and push.
- Sync method: rebase onto latest `origin/main` (which now includes W2 PR #753 and #758); rebase was clean with no conflicts.
- Public diff command: `git diff --check origin/main...HEAD`
- Private evidence commit/path: `tasks/task_01KXCS9KEKA2H3H8614ZBB984J-plt-performance-p1-projection-freshness/` progress and perf evidence.
- Reviewer evidence path: same private P1 task artifacts.
- GitHub Actions run URL: see the required checks on this PR head.

### Performance evidence (fresh 5-sample runs on this rebased head)

Command: `npm run perf:gui -- --size {100,1000,5000} --update-samples 5` (exit 0 each). Measured under moderate concurrent load.

| Tasks | Cold first-usable | Budget | Incremental modes | All budget assertions |
| ---: | ---: | ---: | --- | --- |
| 100 | 121.99 ms | — | `incremental` | pass |
| 1,000 | 674.18 ms | 3,000 ms | `incremental` | pass (Task/Decision/Relation ≤ 250/250/500 ms; Evidence ≤ 250 ms) |
| 5,000 | 4,105.55 ms | 9,000 ms | `incremental` | pass (Task/Decision/Relation ≤ 250/250/500 ms; Evidence ≤ 250 ms; cold projection build ≤ 9,000 ms) |

Every update scenario resolved to `incremental` (no full rebuild), and every budget assertion passed with headroom. This matches the pre-rebase evidence recorded on the P1 task; the rebase onto W2/#758 (CLI/schema and lint-boundary changes, no projection code) did not alter projection performance.

- [x] `git diff --check`
- [x] `npm run typecheck` (clean on top of W2 schema changes)
- [x] local `npm run check:ci` — ALL GREEN for locally runnable jobs (typecheck, fast, contract, 6 integration shards, gui-build, node26-compatibility, boundaries)
- [ ] `pr-body-lint` — cannot run locally (needs a real PR body); this PR body is the positive control.
- [ ] GitHub Actions passed — pending on this PR.
- Not run locally: perf budgets are validated via `npm run perf:gui` (separate tool, results above); not a required CI gate.

## Review Evidence

- Self-review: verified projection diff scope, SQLite schema/cache rebuild compatibility, relation/fact parity, and that no protected surface or private harness content is included.
- Reviewer subagent: not used.
- Human review: pending.
- Blocking findings: none open.

## Residual Risk

- Large kernel projection diff; SQLite schema/cache rebuild compatibility across generations is exercised by the rebuild tests but remains the main risk surface.
- `projection_source_cache_files.body` retained for compatibility; the raw attribution body explicitly required to be removed by P1 is removed.
- Long-lived main drift during review; base is pinned to `cdf4aaaa` and will be re-verified before merge.

## References

- Task: `task_01KXCS9KEKA2H3H8614ZBB984J` (parent `task_01KXCS7FJ8MNWA70TEB13Z63EW`)
- Evidence: private P1 task perf artifacts and progress.
- Review: this PR and its required checks.

---

# 中文

## 概要

规范化 GUI 投影背后的增量 SQLite read model，让 warm 重入不再全量扫描 authored 任务源。attribution、relationship、evidence 投影改为规范化行表，配合基于 touched-path 指纹的增量 source cache、批量 SQL 写入、relation-only fact 复用、声明式 manifest 完整性，以及 warm daemon generation 复用。这是 PLT-Performance 里程碑的地基切片 P1（投影新鲜度）。

## 改动内容

- 将 attribution/relationship/evidence read model 规范化为结构化行表（取代整块 JSON），并引入按 touched-path 指纹键控的增量 source cache。
- 增加批量 SQL 写入、relation-only fact 复用与 warm daemon generation 复用，避免每次投影都重读未变化的源。
- 扩展 `tools/perf/gui-projection-benchmark.mjs`：5 samples 更新场景 + 100/1,000/5,000 任务的预算断言。
- 回归覆盖：单任务验证不 stat 无关 task source 文件；单变更只读变更 body；增量 SQL 写入；relation/fact parity；并发 source fence。

## 任务与范围

- Harness 任务：`task_01KXCS9KEKA2H3H8614ZBB984J`
- 分支：`codex/plt-performance-p1-normalized-projections`
- 公开范围：kernel 投影 read model、增量 source cache、relation-graph source 语义，以及 perf 基准工具。34 文件，+2884/-842。
- 私有计划 / 证据是否已更新：yes
- 范围外：daemon transport（P2）、GUI 有界渲染（P3）、多人并发矩阵（P4）。

## 版本影响

- 版本：不改版本，因为这是尚未发布的内部投影 / 性能切片。
- 发布影响：不发布；发布打包继续由独立 release task 负责。

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用（不改 gate-manifest、write-road registry 或 CI 配置；改动为 kernel 投影代码、测试与 perf 工具）。
- 依据：`task_01KXCS9KEKA2H3H8614ZBB984J`，父任务 `task_01KXCS7FJ8MNWA70TEB13Z63EW`。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`cdf4aaaa301bcba958c55a29a62bcb6cca80e9c4`
- 当前分支与 `origin/main` 的 merge-base：`cdf4aaaa301bcba958c55a29a62bcb6cca80e9c4`
- 最近一次 `git fetch origin` 时间：2026-07-14，在本次 rebase 与 push 前立即执行。
- 同步方式：rebase 到最新 `origin/main`（现已包含 W2 PR #753 与 #758）；rebase 干净无冲突。
- 公开 diff 命令：`git diff --check origin/main...HEAD`
- 私有证据 commit/path：`tasks/task_01KXCS9KEKA2H3H8614ZBB984J-plt-performance-p1-projection-freshness/` 的 progress 与 perf 证据。
- Reviewer 证据路径：同上私有 P1 任务 artifacts。
- GitHub Actions run URL：见本 PR head 的 required checks。

### 性能证据（本 rebased head 上的 fresh 5-sample 运行）

PERF_TABLE_PLACEHOLDER

- [x] `git diff --check`
- [x] `npm run typecheck`（在 W2 schema 改动之上干净通过）
- [x] 本地 `npm run check:ci` —— 本地可跑的 job 全绿（typecheck、fast、contract、6 个 integration shard、gui-build、node26-compatibility、boundaries）
- [ ] `pr-body-lint` —— 本地无法运行（需真实 PR 正文）；本 PR 正文即为正样本。
- [ ] GitHub Actions 通过 —— 本 PR 上待定。
- 本地未运行：perf 预算通过 `npm run perf:gui` 单独工具验证（结果见上），非 required CI 门。

## 审查证据

- 自查：核对投影 diff 范围、SQLite schema/cache 跨 generation 重建兼容性、relation/fact parity，确认不含 protected surface 或私有 harness 内容。
- Reviewer subagent：未使用。
- 人工审查：待定。
- 阻塞发现：无 open。

## 残余风险

- 大型 kernel 投影 diff；SQLite schema/cache 跨 generation 重建兼容性由 rebuild 测试覆盖，但仍是主要风险面。
- `projection_source_cache_files.body` 出于兼容保留；P1 明确要求移除的 raw attribution body 已移除。
- 评审期主线漂移；base 锚定 `cdf4aaaa`，合并前会重新核对。

## 关联材料

- 任务：`task_01KXCS9KEKA2H3H8614ZBB984J`（父任务 `task_01KXCS7FJ8MNWA70TEB13Z63EW`）
- 证据：私有 P1 任务 perf artifacts 与 progress。
- 审查：本 PR 及其 required checks。
