### PR TITLE
fix(tools): self-heal TS6305 stale-artifact false red in check:local

### DIFF
--- a/tools/clear-incremental-artifacts.mjs
+++ b/tools/clear-incremental-artifacts.mjs
@@ -1,0 +1,35 @@
+/**
+ * Clear incremental TypeScript/build artifacts that produce false TS6305 reds.
+ *
+ * `gui-build`'s `vite build` writes packages/gui/dist; a later `tsc -b` is then
+ * poisoned by TS6305 "stale output" — a false red that sends you hunting for a
+ * type error that does not exist. CI hits a clean checkout so never sees it;
+ * local runners must clear it themselves. Any operation that writes gui/dist
+ * (worktree add, rebase, a manual build) followed by a `tsc -b` reproduces it.
+ *
+ * Used by run-ci-equivalent (clears before every job) and run-local-check
+ * (clears + retries only when the incremental typecheck fails, so the common
+ * path keeps full incremental speed).
+ */
+import { readdirSync, rmSync } from "node:fs";
+import path from "node:path";
+
+export function clearIncrementalArtifacts(root) {
+  rmSync(path.join(root, "packages/gui/dist"), { recursive: true, force: true });
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.name === "node_modules" || entry.name === ".git") continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.name.endsWith(".tsbuildinfo")) rmSync(full, { force: true });
+    }
+  }
+}

--- a/tools/run-ci-equivalent.mjs
+++ b/tools/run-ci-equivalent.mjs
@@ -19,7 +19,7 @@
 // 回执是产物,不是断言:每个 job 的真实 exit code 都在里面。CEO 会重跑并比对数字。
 
 import { spawnSync } from "node:child_process";
-import { readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -27,6 +27,7 @@ import {
   resolveEnforcementConstant
 } from "./enforcement-constants.mjs";
 import { discoverQosPrefix, prefixCommand, withLocalHeavySlot } from "./local-resource-governance.mjs";
+import { clearIncrementalArtifacts } from "./clear-incremental-artifacts.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const manifestPath = path.join(root, "tools/gate-manifest.json");
@@ -119,35 +120,12 @@ export function formatSummary(receipts, skipped) {
   return `${lines.join("\n")}\n`;
 }
 
-// gui-build 内含 `vite build`,它写出 packages/gui/dist;之后任何 `tsc -b` 都会被
-// TS6305「陈旧产物」毒化 —— 那是假红,会让人去查一个根本不存在的类型错误。
-// CI 里每个 job 是干净 checkout,所以碰不到;本地必须每个 job 之前自己清一次。
-function clearIncrementalArtifacts() {
-  rmSync(path.join(root, "packages/gui/dist"), { recursive: true, force: true });
-  const stack = [root];
-  while (stack.length > 0) {
-    const dir = stack.pop();
-    let entries;
-    try {
-      entries = readdirSync(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (entry.name === "node_modules" || entry.name === ".git") continue;
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) stack.push(full);
-      else if (entry.name.endsWith(".tsbuildinfo")) rmSync(full, { force: true });
-    }
-  }
-}
-
 export function buildCiJobInvocation(qosPrefix, args) {
   return prefixCommand(qosPrefix, process.execPath, args);
 }
 
 function runJob(job, shard, { qosPrefix, env }) {
-  clearIncrementalArtifacts();
+  clearIncrementalArtifacts(root);
   const args = ["tools/run-manifest-gates.mjs", "--workflow-job", job, "--exclude", "mergify-queue-metadata-edit-noop"];
   if (shard !== undefined) args.push("--shard", String(shard));
   const invocation = buildCiJobInvocation(qosPrefix, args);

--- a/tools/run-local-check.mjs
+++ b/tools/run-local-check.mjs
@@ -17,6 +17,7 @@ import {
   prefixCommand,
   withLocalHeavySlot
 } from "./local-resource-governance.mjs";
+import { clearIncrementalArtifacts } from "./clear-incremental-artifacts.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const LINTABLE_EXTENSION = /\.(?:c|m)?js$|\.tsx?$/u;
@@ -140,7 +141,18 @@ async function main(argv) {
     );
     const started = Date.now();
     for (const step of steps) {
-      if (!runStep(step, qosPrefix, lease.childEnv)) {
+      let ok = runStep(step, qosPrefix, lease.childEnv);
+      if (!ok && step[0] === "incremental typecheck") {
+        // TS6305 self-heal: a prior `vite build` (worktree add, rebase, a manual
+        // build) leaves packages/gui/dist stale and poisons `tsc -b` with a false
+        // red. Clear incremental artifacts and retry once — a clean pass proves it
+        // was staleness; a repeat failure is a real type error. Paid only on
+        // failure, so the common path keeps full incremental speed.
+        console.log("↻ typecheck failed — clearing stale incremental artifacts, retrying once (TS6305 self-heal)…");
+        clearIncrementalArtifacts(repoRoot);
+        ok = runStep(step, qosPrefix, lease.childEnv);
+      }
+      if (!ok) {
         console.error(`\nLocal check stopped at: ${step[0]}. Fix it and re-run.`);
         process.exitCode = 1;
         return;


### PR DESCRIPTION
# English

## Summary
Give `check:local` the same TS6305 stale-artifact recovery that `run-ci-equivalent` already has, via a shared helper — so a rebase / worktree-add no longer produces a false type-error red locally.

## What Changed
- New `tools/clear-incremental-artifacts.mjs`: the `packages/gui/dist` + `.tsbuildinfo` cleanup, extracted verbatim from `run-ci-equivalent` so it has a single source of truth.
- `run-ci-equivalent.mjs`: imports the shared helper instead of an inline copy (pure refactor, behavior identical; dropped now-unused `readdirSync`/`rmSync` fs imports).
- `run-local-check.mjs`: on incremental-typecheck failure, clear artifacts and retry once. A clean pass proves it was staleness; a repeat failure is a real type error. Paid only on failure, so the common path keeps full incremental speed.

## Task And Scope
Dev tooling only (`tools/`). No product / GUI / CLI / schema change.

## Version Impact
None.

## Governance Declaration
- **Protected surface touched: yes.** `tools/run-local-check.mjs` and `tools/run-ci-equivalent.mjs` are protected surfaces of the `check-local-load-governance` gate; `run-ci-equivalent.mjs` is additionally protected by `check-enforcement-constants`.
- **Authority: `dec_01KXFEMGFNT0QF5PTXVDGQGZ76`** ("local check/test load governance", state `active`, standing-policy) — the decision that governs exactly these files. This change sits inside its lever ②: the stop point is `check:local` (light gate) and GitHub CI stays the complete authority. It makes that stop point trustworthy by removing a false red; it does not move the stop point.
- **Invariants preserved:** the machine-wide semaphore, QoS prefix, and per-session test concurrency (levers ①③④) are untouched — `withLocalHeavySlot` / `discoverQosPrefix` call sites are unchanged, and the `check-local-load-governance` gate passes in CI. `check-enforcement-constants` is unaffected: `getEnforcementConstant` / `resolveEnforcementConstant` usage in `run-ci-equivalent.mjs` is byte-identical; only the inline TS6305 cleanup moved to a shared module.
- **No load added:** the clear+retry runs only after a typecheck has already failed, so the steady-state load footprint is unchanged — consistent with the decision's goal of reducing per-task load.
- **Break-glass: no.** No gate weakened, no CI authority / gate-manifest / branch-protection / workflow change.
- **Design note:** chose a runner self-heal over a `post-rewrite` git hook — it covers all causes (rebase / worktree-add / manual build, not just rebase), needs no `hooks:install`, and costs nothing on the passing path.

## Verification
- Happy path preserved: `npm run check:local` GREEN, incremental typecheck 0.3–9s, no clearing on success (verified twice).
- Lint clean on all three files; `node --check` OK; shared export loads.
- Recovery mechanism already proven this session: `tsc -b --force` recovered the exact rebase-induced TS6305 in a worktree; clearing `.tsbuildinfo` + `gui/dist` is the equivalent.
- CI on this PR: every job green except this governance declaration, which this revision fixes.

## Review Evidence
Root-caused from `run-ci-equivalent.mjs` (its comment documents the same `vite build → gui/dist → tsc -b` TS6305 poison, but only the CI-equivalent runner cleared it — `check:local` lacked it). CEO diagnosis, this session, after hitting the false red while landing PR #770.

## Residual Risk
The full fail→heal→pass path was not demonstrated in one artificial run: the exact TS6305 needs a real rebase-stale `.tsbuildinfo`, which `rm` / `vite build` alone do not synthesize. Mitigated by proven-equivalent recovery plus happy-path verification. Low risk — the change is a retry-on-failure that can only add a second attempt; it cannot make a passing typecheck fail.

## References
- Authority: `dec_01KXFEMGFNT0QF5PTXVDGQGZ76` (local check/test load governance).
- `tools/run-ci-equivalent.mjs` (the existing TS6305 handling this ports to local).

---

# 中文

## 概要
把 `run-ci-equivalent` 早就有的 TS6305 陈旧产物恢复能力，经共享 helper 也给 `check:local`——rebase / 建 worktree 后本地不再报"假类型错"。

## 改动内容
- 新增 `tools/clear-incremental-artifacts.mjs`：清 `packages/gui/dist` + `.tsbuildinfo`，从 `run-ci-equivalent` 原样抽出，单一权威源。
- `run-ci-equivalent.mjs`：改为 import 共享 helper（纯重构，行为不变；删掉不再用的 `readdirSync`/`rmSync`）。
- `run-local-check.mjs`：增量 typecheck 失败时清一次产物 + 重试一次。清完过=陈旧假红自愈；清完仍失败=真类型错。只在失败时付费，正常路径保留全增量速度。

## 任务与范围
仅开发工具（`tools/`）。无产品 / GUI / CLI / schema 改动。

## 版本影响
无。

## 治理声明
- **触碰受保护面：是。** `tools/run-local-check.mjs` 与 `tools/run-ci-equivalent.mjs` 是 `check-local-load-governance` 门的受保护面；`run-ci-equivalent.mjs` 另受 `check-enforcement-constants` 保护。
- **授权：`dec_01KXFEMGFNT0QF5PTXVDGQGZ76`**（「本地 check/test 负载治理」，状态 `active`，standing-policy）——正是治理这两个文件的决策。本改动落在其**杠杆②**范围内：停止点是 `check:local`（轻门）、GitHub CI 保持完整权威。它通过消除假红让这个停止点可信，**不移动停止点**。
- **不变量未动：** 全机信号量、QoS 前缀、每会话测试并发（杠杆①③④）均未触碰——`withLocalHeavySlot` / `discoverQosPrefix` 调用点原样不变，`check-local-load-governance` 门在 CI 上通过。`check-enforcement-constants` 亦不受影响：`run-ci-equivalent.mjs` 里 `getEnforcementConstant` / `resolveEnforcementConstant` 的用法逐字未变，只是把内联的 TS6305 清理挪进共享模块。
- **不增负载：** 清理+重试只在 typecheck 已经失败后才跑，稳态负载足迹不变——与该决策「降低每 task 负载足迹」的目标一致。
- **Break-glass：否。** 不削任何门，不涉及 CI 权威 / gate-manifest / 分支保护 / workflow。
- **设计取舍：** 选 runner 自愈而非 `post-rewrite` git 钩子——覆盖所有成因（rebase / 建 worktree / 手动 build，不只 rebase）、不依赖 `hooks:install`、正常路径零开销。

## 验证
- Happy path 未破坏：`check:local` 全绿，增量 typecheck 0.3–9s，成功时不清理（验两次）。
- 三文件 lint 干净；`node --check` 过；共享 export 可加载。
- 恢复机制本会话已证：`tsc -b --force` 恢复了 worktree 里真实的 rebase 型 TS6305；清 `.tsbuildinfo` + `gui/dist` 是等价操作。
- 本 PR 的 CI：除这条治理声明外全部绿，本次修订即修此项。

## 审查证据
根因来自 `run-ci-equivalent.mjs`（其注释记录了同一个 `vite build → gui/dist → tsc -b` 的 TS6305 毒化，但只有 CI-equivalent 清了，`check:local` 漏了）。本会话落 PR #770 时撞到假红后 CEO 诊断。

## 残余风险
全程「失败→自愈→通过」未在单次人造运行里演示：精确 TS6305 需要真实 rebase 后的陈旧 `.tsbuildinfo`，`rm` / `vite build` 单独造不出。以等价恢复已证 + happy path 验证兜底。低风险——改动是失败重试，只会多试一次，不会把通过的 typecheck 变红。

## 关联材料
- 授权决策：`dec_01KXFEMGFNT0QF5PTXVDGQGZ76`（本地 check/test 负载治理）。
- `tools/run-ci-equivalent.mjs`（本次移植到本地的既有 TS6305 处理）。
