### PR TITLE
fix(cli): parse multi-id charter anchors and honor grandfathered milestones

### DIFF
--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/create-milestone/scripts/preset-action.mjs
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/create-milestone/scripts/preset-action.mjs
@@ -191,7 +191,12 @@ function checkOverview(overviewPath, contract) {
   const status = matchScalar(body, /-\s+\*\*状态\*\*:\s*(.+)|-\s+\*\*Status\*\*:\s*(.+)/u);
   const mission = matchScalar(body, /-\s+\*\*Mission\*\*:\s*(.+)/u);
   const charterAnchor = stripMarkdown(matchScalar(body, /-\s+\*\*(?:Approval anchor|Decision 锚)\*\*:\s*(.+)/u));
-  const decisionAnchors = charterAnchor ? [charterAnchor] : [];
+  const anchorRule = policy?.rules?.charterAnchor;
+  const decisionAnchors = charterAnchor ? extractDecisionAnchorTokens(charterAnchor) : [];
+  const anchorIdPattern = anchorRule ? new RegExp(anchorRule.idPattern, "u") : null;
+  const hasValidAnchorTokens = decisionAnchors.length > 0
+    && (!anchorIdPattern || decisionAnchors.every((anchor) => anchorIdPattern.test(anchor)));
+  const grandfathered = (anchorRule?.grandfatheredMilestoneSlugs ?? []).includes(slug);
   const missing = [];
   const warnings = [];
   if (!body.includes("milestone-map:v1") && !/(?:目标 \(North Star\)|North Star)/u.test(body)) missing.push("milestone-map:v1 marker");
@@ -204,12 +209,12 @@ function checkOverview(overviewPath, contract) {
   if (!/(?:旧路径何时废止|Retired old path)/u.test(body)) missing.push("usage question: retired old path");
   if (!/(?:任务映射|Task Mapping|W 波次总表|Wave Decomposition)/u.test(body)) missing.push("task mapping section");
   if (!/(?:依赖与入口|Dependencies|入口条件)/u.test(body)) missing.push("dependencies and entry section");
-  const anchorRule = policy?.rules?.charterAnchor;
-  if (anchorRule?.required && !charterAnchor) missing.push("approval anchor");
-  if (charterAnchor && anchorRule && !new RegExp(anchorRule.idPattern, "u").test(charterAnchor)) {
+  if (anchorRule?.required && !grandfathered && !charterAnchor) missing.push("approval anchor");
+  if (charterAnchor && anchorRule && !hasValidAnchorTokens) {
     missing.push("approval anchor matches policy idPattern");
   }
-  if (charterAnchor && anchorRule?.entityType === "decision" && !findDecision(charterAnchor)) {
+  if (charterAnchor && hasValidAnchorTokens && anchorRule?.entityType === "decision"
+    && decisionAnchors.some((anchor) => !findDecision(anchor))) {
     missing.push("approval anchor exists under decisions root");
   }
 
@@ -249,6 +254,10 @@ function checkOverview(overviewPath, contract) {
     missing,
     warnings
   };
+}
+
+function extractDecisionAnchorTokens(value) {
+  return value.match(/(?<![A-Za-z0-9_])dec_[^,、，/／;；\s()[\]{}（）<>《》:：.!?。！？]+/gu) ?? [];
 }
 
 function renderOverview(input) {

--- a/packages/cli/src/commands/extensions/preset-policy.ts
+++ b/packages/cli/src/commands/extensions/preset-policy.ts
@@ -33,7 +33,9 @@ const CreateMilestonePolicySchema = Schema.Struct({
     charterAnchor: Schema.optional(Schema.Struct({
       required: Schema.Boolean,
       entityType: Schema.Literal("decision"),
-      idPattern: Schema.String
+      idPattern: Schema.String,
+      policyEffectiveDate: Schema.optional(Schema.String.pipe(Schema.pattern(/^\d{4}-\d{2}-\d{2}$/u))),
+      grandfatheredMilestoneSlugs: Schema.optional(Schema.Array(Schema.String))
     })),
     requiredSections: Schema.optional(Schema.Array(Schema.Literal("gate-retro", "fact-evidence"))),
     additionalReferences: Schema.optional(Schema.Array(AdditionalReferenceSchema))
@@ -93,7 +95,13 @@ const POLICY_ENVELOPES: ReadonlyArray<PolicyEnvelopeDefinition> = [
     validateEnvelopeRules: (rules) => {
       exactObjectArray(rules.requiredArtifacts, "$.rules.requiredArtifacts", ["id", "role", "root", "path"]);
       if (rules.charterAnchor !== undefined) {
-        exactObject(rules.charterAnchor, "$.rules.charterAnchor", ["required", "entityType", "idPattern"]);
+        exactObject(rules.charterAnchor, "$.rules.charterAnchor", [
+          "required",
+          "entityType",
+          "idPattern",
+          "policyEffectiveDate",
+          "grandfatheredMilestoneSlugs"
+        ]);
       }
       exactObjectArray(rules.additionalReferences, "$.rules.additionalReferences", ["kind", "ref", "label"]);
     },
@@ -104,6 +112,15 @@ const POLICY_ENVELOPES: ReadonlyArray<PolicyEnvelopeDefinition> = [
       }
       if (envelopePolicy.rules.charterAnchor) {
         new RegExp(envelopePolicy.rules.charterAnchor.idPattern, "u");
+        const grandfatheredSlugs = envelopePolicy.rules.charterAnchor.grandfatheredMilestoneSlugs ?? [];
+        if (new Set(grandfatheredSlugs).size !== grandfatheredSlugs.length) {
+          throw new Error("Create-milestone charterAnchor grandfatheredMilestoneSlugs must not contain duplicates.");
+        }
+        for (const slug of grandfatheredSlugs) {
+          if (!/^[a-z0-9][a-z0-9-]*$/u.test(slug)) {
+            throw new Error(`Invalid grandfathered milestone slug: ${slug}.`);
+          }
+        }
       }
       if (envelopePolicy.rules.requiredArtifacts) {
         validateCreateMilestoneArtifacts(envelopePolicy.rules.requiredArtifacts);

--- a/packages/cli/test/preset-create-milestone-cli.test.ts
+++ b/packages/cli/test/preset-create-milestone-cli.test.ts
@@ -9,6 +9,29 @@ import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
+const knownGrandfatheredMilestoneSlugs = [
+  "com-market",
+  "com-mobile",
+  "com-sync",
+  "com-team",
+  "m1-minimal-loop",
+  "m2-5-cli",
+  "m2-5-gui",
+  "m2-coding-vertical",
+  "m3-triadic-kernel",
+  "m4-metabolism",
+  "m5-circulation",
+  "m6-productization-gate",
+  "gui-v1-local-remote",
+  "gui-v2-aggregation",
+  "plt-adapter",
+  "plt-archive-distill",
+  "plt-cli",
+  "plt-cross-repo",
+  "plt-notify",
+  "plt-task-tree",
+  "prod-vertical-expansion"
+] as const;
 
 test("CLI create-milestone public default scaffolds and checks only the minimum three-artifact contract", () => {
   withTempRoot((rootDir) => {
@@ -112,6 +135,64 @@ test("CLI create-milestone rejects an unsafe required-artifact policy before run
   });
 });
 
+test("CLI create-milestone checker allows a grandfathered legacy milestone without an anchor", () => {
+  withPolicyMilestone((rootDir, taskId, overviewPath, policy) => {
+    policy.rules.charterAnchor.grandfatheredMilestoneSlugs = ["plt-test"];
+    writePolicy(rootDir, policy);
+    removeApprovalAnchor(overviewPath);
+
+    const checked = checkMilestone(rootDir, taskId);
+
+    assert.equal(checked.report.status, "passed");
+  });
+});
+
+test("CLI create-milestone checker keeps the anchor gate closed for non-grandfathered milestones", () => {
+  withPolicyMilestone((rootDir, taskId, overviewPath) => {
+    removeApprovalAnchor(overviewPath);
+
+    const checked = checkMilestone(rootDir, taskId, false);
+
+    assert.equal(checked.report.status, "blocked");
+    assert.deepEqual(checked.report.missing.map((item: { missing: string }) => item.missing), ["approval anchor"]);
+  });
+});
+
+test("CLI create-milestone checker validates every decision in a multi-id anchor with CJK annotations", () => {
+  withPolicyMilestone((rootDir, taskId, overviewPath) => {
+    createCharterDecision(rootDir, "dec_SECOND_CHARTER");
+    replaceApprovalAnchor(
+      overviewPath,
+      "治理依据：dec_TEST_CHARTER（主章程）、dec_SECOND_CHARTER（补充决策）"
+    );
+
+    const checked = checkMilestone(rootDir, taskId);
+
+    assert.equal(checked.report.status, "passed");
+    assert.deepEqual(checked.report.items[0].decisionAnchors, ["dec_SECOND_CHARTER", "dec_TEST_CHARTER"]);
+  });
+});
+
+test("CLI create-milestone checker rejects an anchor field with no valid decision token", () => {
+  withPolicyMilestone((rootDir, taskId, overviewPath) => {
+    replaceApprovalAnchor(overviewPath, "章程决策待定（没有可验证的决策编号）");
+
+    const checked = checkMilestone(rootDir, taskId, false);
+
+    assert.equal(checked.report.status, "blocked");
+    assert.deepEqual(checked.report.missing.map((item: { missing: string }) => item.missing), [
+      "approval anchor matches policy idPattern"
+    ]);
+  });
+});
+
+test("create-milestone policy fixture pins the exact grandfathered legacy slug set", () => {
+  const policy = fiveArtifactPolicy();
+
+  assert.equal(policy.rules.charterAnchor.grandfatheredMilestoneSlugs.length, 21);
+  assert.deepEqual(policy.rules.charterAnchor.grandfatheredMilestoneSlugs, knownGrandfatheredMilestoneSlugs);
+});
+
 function createMilestoneTask(rootDir: string): Record<string, any> {
   return runJson(rootDir, [
     "task", "create",
@@ -122,10 +203,10 @@ function createMilestoneTask(rootDir: string): Record<string, any> {
   ]);
 }
 
-function createCharterDecision(rootDir: string): void {
+function createCharterDecision(rootDir: string, decisionId = "dec_TEST_CHARTER"): void {
   runJson(rootDir, [
     "decision", "propose",
-    "--id", "dec_TEST_CHARTER",
+    "--id", decisionId,
     "--title", "Test Milestone Charter",
     "--question", "Should this milestone exist?",
     "--chosen", "Create the milestone through the preset",
@@ -173,10 +254,46 @@ function fiveArtifactPolicy(): Record<string, any> {
         { id: "html", role: "html", root: "milestones", path: "milestones-dossier.html" },
         { id: "task-plan", role: "supporting", root: "task", path: "task_plan.md" }
       ],
-      charterAnchor: { required: true, entityType: "decision", idPattern: "^dec_[A-Za-z0-9_]+$" },
+      charterAnchor: {
+        required: true,
+        entityType: "decision",
+        idPattern: "^dec_[A-Za-z0-9_]+$",
+        policyEffectiveDate: "2026-07-10",
+        grandfatheredMilestoneSlugs: [...knownGrandfatheredMilestoneSlugs]
+      },
       additionalReferences: [{ kind: "command", ref: "npm run pr:doctor", label: "PR diagnostics" }]
     }
   };
+}
+
+function withPolicyMilestone(
+  fn: (
+    rootDir: string,
+    taskId: string,
+    overviewPath: string,
+    policy: Record<string, any>
+  ) => void
+): void {
+  withTempRoot((rootDir) => {
+    runJson(rootDir, ["init"]);
+    const created = createMilestoneTask(rootDir);
+    createCharterDecision(rootDir);
+    const policy = fiveArtifactPolicy();
+    writePolicy(rootDir, policy);
+    scaffoldMilestone(rootDir, created.taskId, "dec_TEST_CHARTER");
+    const overviewPath = path.join(rootDir, "harness/milestones/platform/plt-test/00-overview.md");
+    fn(rootDir, created.taskId, overviewPath, policy);
+  });
+}
+
+function removeApprovalAnchor(overviewPath: string): void {
+  const body = readFileSync(overviewPath, "utf8");
+  writeFileSync(overviewPath, body.replace(/\n- \*\*Approval anchor\*\*:.*$/mu, ""), "utf8");
+}
+
+function replaceApprovalAnchor(overviewPath: string, value: string): void {
+  const body = readFileSync(overviewPath, "utf8");
+  writeFileSync(overviewPath, body.replace(/(- \*\*Approval anchor\*\*:\s*).*$/mu, `$1${value}`), "utf8");
 }
 
 function writePolicy(rootDir: string, policy: unknown): void {


### PR DESCRIPTION
# English

## Summary

The `create-milestone` checker rejected approval anchors that carry more than one decision id, and it had no way to express that a milestone predates the anchor policy itself. This PR fixes both: it parses every `dec_` token out of an anchor field, and it teaches the policy envelope an optional grandfathering list.

This change grandfathers nothing on its own. The exemption list lives in each repository's own policy file, so a repository that does not declare one sees identical behaviour to today.

## What Changed

- `preset-action.mjs`: extract every `dec_` token from the approval anchor (splitting on separators, tolerating annotation prose including CJK), validate each token against the policy `idPattern`, and require every referenced decision to exist under the decisions root. Previously only a single bare id was accepted, so a milestone citing several charter decisions failed the gate despite being properly governed.
- `preset-policy.ts`: accept two optional `charterAnchor` fields — `policyEffectiveDate` (ISO date) and `grandfatheredMilestoneSlugs` (string array). Both are validated: slugs must be well-formed and duplicate-free.
- `preset-create-milestone-cli.test.ts`: five new tests — a grandfathered milestone with no anchor passes; a **non**-grandfathered milestone with no anchor is still blocked; a multi-id anchor with CJK annotation parses and validates every token; an anchor with no valid token is still blocked; and a fixture test pinning the exact legacy slug set.

The gate stays closed for new work: grandfathering is only consulted when the anchor is absent, and only for explicitly listed slugs. A listed milestone that writes a malformed anchor still fails.

## Task And Scope

- Harness task: `task_01KXFX39AHPN207SP2D663TD17`
- Branch: `codex/create-milestone-anchor-fix`
- Public scope: `packages/cli` (preset checker script, preset policy envelope, CLI tests)
- Private planning/evidence updated: yes (governing decision and task recorded in the private ledger)
- Out of scope: this repository's own grandfathered slug list, which is a private-ledger policy edit and is deliberately not part of this PR; opportunistic backfill of real anchors onto legacy milestones that already have a citable decision.

## Version Impact

- Version: no version change because this is an internal checker fix with no published surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: the `create-milestone` gate checker and the preset policy envelope schema.
- Authority: task `task_01KXFX39AHPN207SP2D663TD17`, decision `dec_01KXFX193FSY1EM51NM9BPWXCK`. **The decision is currently `proposed`, not yet accepted.** That is deliberate and safe: this PR only adds the *capability* to grandfather. The enactment is the repository's own policy edit, which is a separate private-ledger change held until the decision is accepted by the human arbiter.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: see Residual Risk below.

## Verification

- Base `origin/main` SHA: `bbec6a54499eaed7cee17b7ecb64893db3152202`
- Branch merge-base with `origin/main`: `bbec6a54499eaed7cee17b7ecb64893db3152202`
- Last `git fetch origin` time: 2026-07-14T10:02Z
- Sync method: rebase (branch was 2 behind; rebased and re-ran the local gate afterwards)
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: governing decision `dec_01KXFX193FSY1EM51NM9BPWXCK` in the private ledger
- Reviewer evidence path: private ledger task package for `task_01KXFX39AHPN207SP2D663TD17`
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `npm run check:local` — **passed (26.0s)** after the rebase. This is the sanctioned local stop-point gate (it runs typecheck, lint, the affected fast and contract test tiers, and the local gate set).
- [x] Targeted suite: `packages/cli/test/preset-create-milestone-cli.test.ts` — **8/8 passing**, including the three pre-existing tests.
- [x] `git diff --check`
- Not run: the individual `harness:*` scripts and the full `npm run check` / `npm test` / `npm ci` were not run standalone. Reason: `check:local` is the declared local stop-point gate and covers the affected tiers; the full manifest-declared gate set runs in CI on this PR. Recorded honestly rather than ticked.

## Review Evidence

- Self-review: reviewed the checker diff for gate-weakening. Grandfathering is consulted only in the "anchor absent" branch, so a non-listed milestone without an anchor still fails; a listed milestone with a malformed anchor still fails; and multi-id anchors now require *every* referenced decision to exist (strictly stronger than before).
- Reviewer subagent: not used for this PR.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- **The shipped pin test cannot guard a repository's real exemption list.** It pins a fixture, because the real list lives in a repository's private policy file, which CI cannot see. So it documents the expected shape but cannot mechanically stop someone adding a slug to their own policy without a decision. Two things bound this: the list is *not* in this package, so it cannot be smuggled into a code PR alongside the change that needs it; and any edit is a visible policy change in that repository's ledger. Full mechanical enforcement would need a ledger-side gate and is not attempted here.
- **The end-to-end "the real repository goes green" check runs after merge, not before.** The local daemon serves the pre-merge build, and direct canonical writes are (correctly) refused, so the pre-merge evidence is the fixture-driven test suite rather than a live run against a real milestone tree.

## References

- Task: `task_01KXFX39AHPN207SP2D663TD17`
- Evidence: `dec_01KXFX193FSY1EM51NM9BPWXCK`
- Review: self-review recorded above

---

# 中文

## 概要

`create-milestone` checker 拒绝任何携带一个以上 decision id 的 approval anchor,也无法表达"某个 milestone 早于 anchor 策略本身"这件事。本 PR 修掉这两点:从 anchor 字段里提取**每一个** `dec_` token,并让 policy envelope 支持一份可选的祖父豁免名单。

**本改动自身不豁免任何东西。** 豁免名单存放在各仓库自己的 policy 文件里,没有声明名单的仓库,行为与今天完全一致。

## 改动内容

- `preset-action.mjs`:从 approval anchor 中提取**每一个** `dec_` token(按分隔符切分,容忍含中日韩文字的注释散文),逐个对照 policy 的 `idPattern` 校验,并要求**每一个**被引用的 decision 都真实存在于 decisions 根下。此前只接受单个裸 id,于是一个引用了多条 charter 决策的 milestone,明明治理做得更好,反而过不了门。
- `preset-policy.ts`:接受两个可选的 `charterAnchor` 字段——`policyEffectiveDate`(ISO 日期)与 `grandfatheredMilestoneSlugs`(字符串数组)。两者都做校验:slug 必须格式合法且不得重复。
- `preset-create-milestone-cli.test.ts`:新增五个测试——在名单上的 milestone 无 anchor 可通过;**不在**名单上的 milestone 无 anchor **仍然被拦**;含 CJK 注释的多 id anchor 能正确解析并逐个校验;不含任何合法 token 的 anchor 仍然被拦;以及一个把已知 legacy slug 集合钉死的 fixture 测试。

**门对新工作依然是关着的**:祖父逻辑只在"anchor 缺失"这一条分支里被查询,且只对显式列出的 slug 生效。名单上的 milestone 如果写了一个畸形 anchor,照样失败。

## 任务与范围

- Harness 任务:`task_01KXFX39AHPN207SP2D663TD17`
- 分支:`codex/create-milestone-anchor-fix`
- 公开范围:`packages/cli`(preset checker 脚本、preset policy envelope、CLI 测试)
- 私有计划 / 证据是否已更新:yes(治理决策与任务已记入私有账本)
- 范围外:本仓库自己的祖父名单——那是私有账本的 policy 改动,**刻意不放进本 PR**;以及给已有可引用决策的 legacy milestone 惰性回填真实 anchor。

## 版本影响

- 版本:不改版本,原因是这是内部 checker 修复,不改变任何已发布接口。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:`create-milestone` 门的 checker,以及 preset policy envelope 的 schema。
- 依据:任务 `task_01KXFX39AHPN207SP2D663TD17`,决策 `dec_01KXFX193FSY1EM51NM9BPWXCK`。**该决策当前状态为 `proposed`,尚未被 accept。** 这是刻意且安全的:本 PR 只提供"能够祖父豁免"的**能力**,真正的**执行**是各仓库自己的 policy 改动——那是一笔独立的私有账本变更,**扣在人类 arbiter accept 决策之前不落库**。
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:见下方残余风险。

## 验证

- `origin/main` 基准 SHA:`bbec6a54499eaed7cee17b7ecb64893db3152202`
- 当前分支与 `origin/main` 的 merge-base:`bbec6a54499eaed7cee17b7ecb64893db3152202`
- 最近一次 `git fetch origin` 时间:2026-07-14T10:02Z
- 同步方式:rebase(分支曾落后 2 个提交;rebase 后**重跑**了本地门)
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:私有账本中的治理决策 `dec_01KXFX193FSY1EM51NM9BPWXCK`
- Reviewer 证据路径:私有账本中 `task_01KXFX39AHPN207SP2D663TD17` 的任务包
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- [x] `npm run check:local` —— rebase 后**通过(26.0s)**。这是既定的本地停止点门(它会跑 typecheck、lint、受影响的 fast 与 contract 测试层,以及本地 gate 集合)。
- [x] 定向测试:`packages/cli/test/preset-create-milestone-cli.test.ts` —— **8/8 通过**(含 3 个既有测试)。
- [x] `git diff --check`
- 未运行:各个 `harness:*` 单项脚本,以及完整的 `npm run check` / `npm test` / `npm ci`,均未单独执行。原因:`check:local` 是既定的本地停止点门且已覆盖受影响层级;完整的 manifest 声明门集合会在本 PR 的 CI 上跑。**如实记录,不假勾。**

## 审查证据

- 自查:专门核了 checker diff 会不会**削弱门**。结论:祖父逻辑只在"anchor 缺失"分支被查询,所以不在名单上、又没有 anchor 的 milestone 仍然失败;在名单上、但写了畸形 anchor 的 milestone 也仍然失败;而且多 id anchor 现在要求**每一个**被引用的 decision 都存在——这比改动前**更严**,不是更松。
- Reviewer subagent:本 PR 未使用。
- 人工审查:待办。
- 阻塞发现:无。

## 残余风险

- **随本 PR 发布的那个"钉死测试",守不住任何仓库真实的豁免名单。** 它钉的是 fixture——因为真实名单存放在各仓库的**私有** policy 文件里,**CI 根本看不见它**。所以它只能记录期望形状,**无法机械地阻止**有人不立决策就往自己的 policy 里塞一个 slug。有两点约束着这个风险:名单**不在**本包内,因此**无法被夹带进"需要它豁免的那个代码 PR"**;并且任何改动都是该仓库账本里一笔可见的 policy 变更。要做到完全的机械强制,需要一个账本侧的门,本 PR 不做尝试。
- **"真实仓库确实全绿"这个端到端验证,发生在合并之后而非之前。** 本地 daemon 服务的是合并前的构建,而直写 canonical 被(正确地)拒绝,所以合并前的证据是 fixture 驱动的测试套件,而不是对真实 milestone 树的实跑。

## 关联材料

- 任务:`task_01KXFX39AHPN207SP2D663TD17`
- 证据:`dec_01KXFX193FSY1EM51NM9BPWXCK`
- 审查:自查结论见上
