### PR TITLE
feat(ci): reject retired attribution keys (T6 slice 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "harness:check-gate-surface": "node tools/check-gate-surface.mjs",
     "harness:check-gate-manifest-invariants": "node tools/check-gate-manifest-invariants.mjs",
     "harness:check-enforcement-constants": "node tools/check-enforcement-constants.mjs",
+    "harness:check-retired-keys": "node tools/check-retired-keys.mjs",
     "harness:check-local-load-governance": "node --test tools/local-resource-governance.test.mjs tools/run-local-check.test.mjs tools/run-ci-equivalent.test.mjs tools/run-node-tests.test.mjs tools/run-with-local-resources.test.mjs",
     "harness:check-staged-activation": "node tools/run-staged-activation.mjs",
     "harness:check-template-command-surface": "node tools/check-template-command-surface.mjs",

--- a/packages/kernel/src/domain/retired-attribution-field-cleanup.ts
+++ b/packages/kernel/src/domain/retired-attribution-field-cleanup.ts
@@ -24,12 +24,18 @@ const expectedKeys = {
 } as const satisfies Record<RetiredAttributionDocumentKind, ReadonlyArray<string>>;
 
 export function hasRetiredAttributionFields(body: string, documentKind: RetiredAttributionDocumentKind): boolean {
+  return findRetiredAttributionFields(body, documentKind).length > 0;
+}
+
+export function findRetiredAttributionFields(
+  body: string,
+  documentKind: RetiredAttributionDocumentKind
+): ReadonlyArray<string> {
   const frontmatter = frontmatterSpans(body);
   const keys = new Set<string>(expectedKeys[documentKind]);
-  return frontmatter.lines.some((line) => {
-    const key = topLevelKey(line.content);
-    return key !== null && keys.has(key);
-  });
+  return frontmatter.lines
+    .map((line) => topLevelKey(line.content))
+    .filter((key): key is string => key !== null && keys.has(key));
 }
 
 export function countContentPinArbitersInDocument(body: string): number {

--- a/tools/check-retired-keys.mjs
+++ b/tools/check-retired-keys.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { findRetiredAttributionFields } from "../packages/kernel/src/domain/retired-attribution-field-cleanup.ts";
+import { resolveHarnessLayout } from "../packages/kernel/src/layout/index.ts";
+
+const DEFAULT_ROOT = path.resolve(import.meta.dirname, "..");
+
+export function checkRetiredKeys(root = DEFAULT_ROOT) {
+  const layout = resolveHarnessLayout(root);
+  const documents = [
+    ...listAuthoredDocuments(layout.tasksRoot, "INDEX.md", "task-index"),
+    ...listAuthoredDocuments(layout.decisionsRoot, "decision.md", "decision")
+  ];
+  const findings = [];
+  const counts = { tasks: 0, decisions: 0, retiredKeys: 0 };
+
+  for (const document of documents) {
+    if (document.kind === "task-index") counts.tasks += 1;
+    else counts.decisions += 1;
+
+    let keys;
+    try {
+      keys = findRetiredAttributionFields(readFileSync(document.path, "utf8"), document.kind);
+    } catch (error) {
+      findings.push(`${relativePath(layout.authoredRoot, document.path)}: cannot parse authored frontmatter: ${error.message}`);
+      continue;
+    }
+    for (const key of keys) {
+      counts.retiredKeys += 1;
+      findings.push(`${relativePath(layout.authoredRoot, document.path)}: retired top-level key ${key}`);
+    }
+  }
+
+  return { ok: findings.length === 0, findings, counts };
+}
+
+function listAuthoredDocuments(root, fileName, kind) {
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(root, entry.name, fileName))
+    .filter((file) => existsSync(file))
+    .sort()
+    .map((file) => ({ path: file, kind }));
+}
+
+function relativePath(authoredRoot, file) {
+  return path.relative(authoredRoot, file).split(path.sep).join("/");
+}
+
+function parseArgs(argv) {
+  const rootIndex = argv.indexOf("--root");
+  if (rootIndex === -1) return { root: DEFAULT_ROOT };
+  if (argv[rootIndex + 1] === undefined) throw new Error("--root requires a path");
+  if (argv.length !== 2 || rootIndex !== 0) throw new Error("usage: check-retired-keys [--root <project-root>]");
+  return { root: path.resolve(argv[rootIndex + 1]) };
+}
+
+function main() {
+  const { root } = parseArgs(process.argv.slice(2));
+  const audit = checkRetiredKeys(root);
+  if (!audit.ok) {
+    for (const finding of audit.findings) console.error(`retired key check: ${finding}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `Retired key check passed: ${audit.counts.tasks} task INDEX.md, ` +
+    `${audit.counts.decisions} decision.md, ${audit.counts.retiredKeys} retired keys.`
+  );
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`Retired key check failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 2;
+  }
+}

--- a/tools/check-retired-keys.mjs
+++ b/tools/check-retired-keys.mjs
@@ -9,10 +9,24 @@ const DEFAULT_ROOT = path.resolve(import.meta.dirname, "..");
 
 export function checkRetiredKeys(root = DEFAULT_ROOT) {
   const layout = resolveHarnessLayout(root);
+  // A checker that scans nothing must never report "passed". The canonical ledger lives in
+  // harness/, a private git-ignored subrepo absent from public checkouts, so an empty scan is
+  // expected there — but it is a skip, not a pass. And a ledger root that exists yet yields zero
+  // documents means the instrument is pointed at the wrong place; that is louder than any finding.
+  const ledgerPresent = existsSync(layout.tasksRoot) || existsSync(layout.decisionsRoot);
+  if (!ledgerPresent) return { ok: true, skipped: true, findings: [], counts: { tasks: 0, decisions: 0, retiredKeys: 0 } };
+
   const documents = [
     ...listAuthoredDocuments(layout.tasksRoot, "INDEX.md", "task-index"),
     ...listAuthoredDocuments(layout.decisionsRoot, "decision.md", "decision")
   ];
+  if (documents.length === 0) {
+    throw new Error(
+      `ledger root exists (${layout.authoredRoot}) but holds 0 authored documents; ` +
+      "the checker scanned nothing, so a green result would be meaningless"
+    );
+  }
+
   const findings = [];
   const counts = { tasks: 0, decisions: 0, retiredKeys: 0 };
 
@@ -33,7 +47,7 @@ export function checkRetiredKeys(root = DEFAULT_ROOT) {
     }
   }
 
-  return { ok: findings.length === 0, findings, counts };
+  return { ok: findings.length === 0, skipped: false, findings, counts };
 }
 
 function listAuthoredDocuments(root, fileName, kind) {
@@ -61,6 +75,13 @@ function parseArgs(argv) {
 function main() {
   const { root } = parseArgs(process.argv.slice(2));
   const audit = checkRetiredKeys(root);
+  if (audit.skipped) {
+    console.log(
+      "Retired key check SKIPPED: no canonical ledger in this checkout (harness/ is a private, " +
+      "git-ignored subrepo). Nothing was scanned — this is not a pass."
+    );
+    return;
+  }
   if (!audit.ok) {
     for (const finding of audit.findings) console.error(`retired key check: ${finding}`);
     process.exitCode = 1;

--- a/tools/check-retired-keys.test.mjs
+++ b/tools/check-retired-keys.test.mjs
@@ -1,0 +1,99 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const checkerPath = path.join(repoRoot, "tools/check-retired-keys.mjs");
+
+for (const fixture of [
+  {
+    name: "task createdBy",
+    relativePath: "harness/tasks/task_CREATED_BY/INDEX.md",
+    key: "createdBy",
+    body: frontmatter(["schema: task-package/v2", "task_id: task_CREATED_BY", "createdBy: { name: Legacy }"])
+  },
+  {
+    name: "decision proposedBy",
+    relativePath: "harness/decisions/decision-dec_PROPOSED/decision.md",
+    key: "proposedBy",
+    body: frontmatter(["schema: decision-package/v1", "decision_id: dec_PROPOSED", "proposedBy: { kind: agent, id: legacy }"])
+  },
+  {
+    name: "decision arbiter",
+    relativePath: "harness/decisions/decision-dec_ARBITER/decision.md",
+    key: "arbiter",
+    body: frontmatter(["schema: decision-package/v1", "decision_id: dec_ARBITER", "arbiter: { kind: human, id: legacy }"])
+  }
+]) {
+  test(`positive control rejects retired top-level ${fixture.name}`, () => {
+    const root = makeFixtureRoot({ [fixture.relativePath]: fixture.body });
+    try {
+      const result = runChecker(root);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, new RegExp(`${escapeRegExp(fixture.relativePath.slice("harness/".length))}: retired top-level key ${fixture.key}`, "u"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+}
+
+test("negative control accepts clean task and decision documents", () => {
+  const root = makeFixtureRoot({
+    "harness/tasks/task_CLEAN/INDEX.md": frontmatter(["schema: task-package/v2", "task_id: task_CLEAN"]),
+    "harness/decisions/decision-dec_CLEAN/decision.md": frontmatter(["schema: decision-package/v1", "decision_id: dec_CLEAN"])
+  });
+  try {
+    const result = runChecker(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /1 task INDEX\.md, 1 decision\.md, 0 retired keys/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("negative control preserves active contentPins[].arbiter", () => {
+  const root = makeFixtureRoot({
+    "harness/decisions/decision-dec_PIN/decision.md": frontmatter([
+      "schema: decision-package/v1",
+      "decision_id: dec_PIN",
+      "contentPins:",
+      "  - action: accept",
+      "    arbiter: { kind: human, id: active-arbiter }",
+      "    digest: sha256:test"
+    ])
+  });
+  try {
+    const result = runChecker(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /1 decision\.md, 0 retired keys/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function makeFixtureRoot(files) {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-retired-keys-"));
+  for (const [relativePath, body] of Object.entries(files)) {
+    const file = path.join(root, relativePath);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, body, "utf8");
+  }
+  return root;
+}
+
+function runChecker(root) {
+  return spawnSync(process.execPath, [checkerPath, "--root", root], { encoding: "utf8" });
+}
+
+function frontmatter(lines) {
+  return ["---", ...lines, "---", "", "# Fixture", ""].join("\n");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}

--- a/tools/check-retired-keys.test.mjs
+++ b/tools/check-retired-keys.test.mjs
@@ -76,6 +76,35 @@ test("negative control preserves active contentPins[].arbiter", () => {
   }
 });
 
+test("absent ledger reports SKIPPED, never a pass", () => {
+  // Public checkouts have no harness/ (private git-ignored subrepo). Scanning nothing there is
+  // expected — but it must not masquerade as a green scan.
+  const root = makeFixtureRoot({});
+  try {
+    const result = runChecker(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /SKIPPED: no canonical ledger/u);
+    assert.match(result.stdout, /this is not a pass/u);
+    assert.doesNotMatch(result.stdout, /passed/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("ledger root present but empty is an instrument failure, not a pass", () => {
+  // If the ledger exists yet yields zero documents, the checker is pointed at the wrong place.
+  // Staying silent here would let a broken instrument certify every future PR green.
+  const root = makeFixtureRoot({});
+  mkdirSync(path.join(root, "harness/tasks"), { recursive: true });
+  try {
+    const result = runChecker(root);
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /holds 0 authored documents/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 function makeFixtureRoot(files) {
   const root = mkdtempSync(path.join(tmpdir(), "ha-retired-keys-"));
   for (const [relativePath, body] of Object.entries(files)) {

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -95,6 +95,7 @@
         "check-gate-surface",
         "check-gate-manifest-invariants",
         "check-enforcement-constants",
+        "check-retired-keys",
         "check-local-load-governance",
         "check-staged-activation",
         "check-template-command-surface",
@@ -140,6 +141,7 @@
         "check-gate-surface",
         "check-gate-manifest-invariants",
         "check-enforcement-constants",
+        "check-retired-keys",
         "check-local-load-governance",
         "check-staged-activation",
         "check-template-command-surface",
@@ -155,7 +157,7 @@
         "check-legacy-intake-readiness",
         "check-supply-chain"
       ],
-      "harnessLeafGateCount": 40
+      "harnessLeafGateCount": 41
     },
     "rewriteCi": {
       "pullRequestGateJobs": [
@@ -3228,6 +3230,87 @@
           "check": true,
           "checkPr": true,
           "script": "harness:check-enforcement-constants"
+        },
+        "rewriteCi": {
+          "pullRequestJobs": [
+            "boundaries"
+          ],
+          "nonPullRequestJobs": [
+            "full-check"
+          ]
+        },
+        "branchProtection": {
+          "required": true,
+          "contexts": [
+            "boundaries"
+          ]
+        },
+        "classes": [
+          "local",
+          "pr",
+          "main-full"
+        ]
+      }
+    },
+    {
+      "id": "check-retired-keys",
+      "deterministic": true,
+      "positiveControl": {
+        "status": "covered",
+        "evidence": [
+          "tools/check-retired-keys.test.mjs"
+        ]
+      },
+      "command": "npm run harness:check-retired-keys",
+      "category": "local-consistency",
+      "tier": "pr-required",
+      "tierReason": null,
+      "authoritySource": [
+        "task_01KXE0493Q44XTR1DWY3P5VVWX#slice-4",
+        "packages/kernel/src/domain/retired-attribution-field-cleanup.ts",
+        "packages/kernel/src/schemas/registry.ts:TaskFrontmatterSchema",
+        "packages/kernel/src/schemas/decision-package.ts:DecisionPackageSchema"
+      ],
+      "consumerScope": [
+        "authored harness/tasks/*/INDEX.md top-level frontmatter keys",
+        "authored harness/decisions/*/decision.md top-level frontmatter keys"
+      ],
+      "githubContext": {
+        "requiredContexts": [
+          "boundaries"
+        ],
+        "workflowJobs": [
+          "boundaries",
+          "full-check"
+        ],
+        "nodeVersions": [
+          24,
+          26
+        ]
+      },
+      "allowlistPolicy": {
+        "allowed": false,
+        "location": null,
+        "adrOrDecisionRequired": false,
+        "notes": "Retired top-level attribution keys have no exceptions; nested contentPins[].arbiter remains an active decision contract."
+      },
+      "changeControl": {
+        "ordinaryImplementationMayModify": false,
+        "requiresGovernanceEvidence": true,
+        "protectedSurfaces": [
+          "packages/kernel/src/domain/retired-attribution-field-cleanup.ts",
+          "tools/check-retired-keys.mjs",
+          "tools/check-retired-keys.test.mjs",
+          "package.json:scripts.harness:check-retired-keys",
+          "tools/gate-manifest.json"
+        ]
+      },
+      "bypassFixtureRequired": false,
+      "executionSurfaces": {
+        "packageJson": {
+          "check": true,
+          "checkPr": true,
+          "script": "harness:check-retired-keys"
         },
         "rewriteCi": {
           "pullRequestJobs": [

--- a/tools/gate-manifest.schema.md
+++ b/tools/gate-manifest.schema.md
@@ -190,11 +190,12 @@ Release-policy gate sample:
 
 The registry records:
 
-- 53 gates: 43 deterministic and 10 non-deterministic/composite.
-- 38 `harness:*` leaf gates from `package.json`; 36 are in `check`, 34 are in
-  `check:pr`, and 37 execute in pull-request workflow jobs. The only
-  `harness:*` gate outside the PR workflow is the non-deterministic,
-  schedule-only `check-enforcement-debt-sunset`.
+- 55 gates: 45 deterministic and 10 non-deterministic/composite.
+- 41 `harness:*` scripts in `package.json`, of which 40 are registered leaf
+  gates; 38 are in `check`, 36 are in `check:pr`, and 39 execute in pull-request
+  workflow jobs. `harness:sync-runtime-skills` is an operational command, not a
+  gate. The only registered `harness:*` gate outside the PR workflow is the
+  non-deterministic, schedule-only `check-enforcement-debt-sunset`.
 - 11 formerly main-only deterministic gates added to the existing `boundaries`
   required context: `check-cli-help-contract`, `check-cli-error-codes`,
   `check-error-classification`, `check-duplicate-definitions`,
@@ -207,6 +208,9 @@ The registry records:
 - `check-staged-activation` executes locally, in `boundaries`, and in non-PR
   `full-check`; its wall-clock expiry semantics make it non-deterministic even
   though each production import-graph probe is repository-local and read-only.
+- `check-retired-keys` executes locally, in `boundaries`, and in non-PR
+  `full-check`; it parses authored frontmatter and rejects only retired top-level
+  attribution keys, while preserving active nested `contentPins[].arbiter`.
 - 14 GitHub branch-protection required contexts:
   `boundaries`, `package-policy`, `typecheck (24)`, `fast-contract`,
   `integration-shard (1)`, `integration-shard (2)`,


### PR DESCRIPTION
# English

## Summary

Final slice (④) of T6: a resident CI gate that rejects retired top-level attribution keys, so the
851 documents just cleaned up by T4 cannot silently grow them back. Slices ①②③ are already on main;
this closes T6's enforcement surface.

The gate parses authored frontmatter structurally (not by regex) and rejects only *top-level*
`createdBy` (task `INDEX.md`) and `proposedBy` / `arbiter` (decision `decision.md`). Nested
`contentPins[].arbiter` is an active contract (ADR-0028 dual-axis attribution, and the T3
content-pin verifier depends on it) and is explicitly preserved — a regex-based checker would have
killed all 58 live pins, which is exactly the ADR-0022 anti-pattern this gate is built to avoid.

## What Changed

- `tools/check-retired-keys.mjs` — structural frontmatter checker, reusing the kernel's
  `findRetiredAttributionFields` single source (the same parser T4's migration used); no new YAML parser.
- `tools/check-retired-keys.test.mjs` — 7 tests: 3 positive controls (one per retired key), 2 negative
  controls (clean docs; `contentPins[].arbiter` preserved), 2 instrument-honesty controls (below).
- `tools/gate-manifest.json` — registered as a leaf gate, derived into `boundaries` / `check` / `checkPr`.
  55 gates, 0 drift.
- Follow-up commit `848902c0` fixes an honesty defect found in CEO review: the checker reported
  **"passed: 0 retired keys"** when `harness/` was absent — which is the normal state of a public
  checkout, since the canonical ledger is a private git-ignored subrepo. A checker that scans nothing
  must never certify green. It now distinguishes three states: scanned-and-clean (pass), no ledger to
  scan (**skip, and says so explicitly**), and ledger root present but zero documents (**instrument
  failure, exit 2**).

## Task And Scope

- Harness task: `task_01KXE0493Q44XTR1DWY3P5VVWX` (T6, slice ④ — final slice)
- Branch: `codex/plt-t6-retired-keys`
- Public scope: `tools/` checker + test + gate-manifest registration; `package.json` script entry
- Private planning/evidence updated: yes (`impl-report-t6-slice4.md`, progress appended)
- Out of scope: wiring the canonical ledger's own changes to remote CI (see Residual Risk)

## Version Impact

- Version: no version change because this adds a CI gate, not a published surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-manifest.json` (new leaf gate registered; enforcement and
  declaration land in the same PR, per ADR-0022)
- Authority: task `task_01KXE0493Q44XTR1DWY3P5VVWX` (T6 charter, approved 2026-07-13); ADR-0022
  (gate defense six patterns); ADR-0023 (CI/gate governance authority)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is
  true and sufficient.
- Break-glass: no
- No existing gate thresholds, exemptions, branch protection, or Mergify config were modified.

## Verification

- Base `origin/main` SHA: `bbec6a54`
- Sync method: branched off latest `origin/main`
- Tests: `node --test tools/check-retired-keys.test.mjs` → **7/7 pass**
- Canonical live scan: **627 task INDEX.md + 348 decision.md, 0 retired keys** (T4 completed the
  851-document cleanup earlier today; this gate now holds that line)
- CI-condition probe (no `harness/`): prints `SKIPPED … this is not a pass`, exit 0 — verified it
  does *not* print "passed"
- Manifest derivation: 55 gates, 0 drift; new gate visible in `boundaries` / `check` / `checkPr`
- `npm run check:local`: green (30.6s)
- Note: `check:local` deliberately excludes the `boundaries` structural gate family
  (dec_01KXFEMGFNT0QF5PTXVDGQGZ76 — light local gate, authoritative CI). GitHub CI is the authority here.

## Review Evidence

- Self-review: CEO
- Reviewer subagent: none
- Human review: CEO semantic acceptance — the six ADR-0022 patterns were checked one by one. Found and
  fixed one real defect (the silent-green-on-empty-tree behavior above), which the worker had honestly
  self-reported rather than hidden.
- Blocking findings: none remaining

## Residual Risk

- **The gate cannot run against the canonical ledger on GitHub CI**, because the public checkout does
  not contain `harness/` (private git-ignored subrepo). On CI it correctly reports SKIPPED. Its real
  enforcement point is `check:local` and any local/canonical run. This means a code change that
  reintroduces a retired-key writer would pass CI and only be caught at the next local check — a
  delayed, not absent, signal. Wiring the canonical ledger's own commits to a CI surface is a separate
  decision (it has no CI today), and is deliberately not attempted here.
- The gate holds the line on *documents*. It does not, by itself, prevent a writer from being
  reintroduced in code; it makes the resulting data drift loudly visible.

## References

- Task: `harness/tasks/task_01KXE0493Q44XTR1DWY3P5VVWX-plt-t6-ci/`
- Evidence: `artifacts/impl-report-t6-slice4.md`
- Related: T4 cleanup (`task_01KXDT1W0A5MYVQQJQ4RZJJ6M1`, 851 documents, completed today);
  T3 content-pin verifier (`task_01KXDT1Q0XDQFXRRAFS6QR0ZZ8`, PR #769) — whose 58 live pins this
  gate must not kill

---

# 中文

## 概要

T6 的最后一片（片④）：一道常驻 CI 门，拒绝已退役的顶层归属键，让 T4 今天刚清扫掉的 851 个文档
不会悄悄长回来。片①②③ 已在 main，本 PR 收口 T6 的执法面。

这道门用**结构化 frontmatter 解析（不是裸 regex）**，只拒绝**顶层**的 `createdBy`（task `INDEX.md`）
与 `proposedBy` / `arbiter`（decision `decision.md`）。嵌套的 `contentPins[].arbiter` 是当前活跃契约
（ADR-0028 双轴归属，且 T3 的 content-pin verifier 依赖它），必须保留 —— 一个 `grep arbiter` 的 checker
会把 58 条活跃 pin 全部误杀，而那正是 ADR-0022 反模式的教科书案例，也正是这道门要防的东西。

## 改动内容

- `tools/check-retired-keys.mjs` —— 结构化 frontmatter checker，复用 kernel 的
  `findRetiredAttributionFields` 单源（与 T4 迁移同一个解析器），不新造 YAML 解析器。
- `tools/check-retired-keys.test.mjs` —— 7 个测试：3 个阳性对照（每个退役键各一）、2 个阴性对照
  （干净文档；`contentPins[].arbiter` 保留）、2 个仪器诚实性对照（见下）。
- `tools/gate-manifest.json` —— 登记为 leaf gate，派生进 `boundaries` / `check` / `checkPr`。55 门，0 drift。
- 追加提交 `848902c0` 修掉 CEO 复核中发现的一个诚实性缺陷：当 `harness/` 不存在时，checker 会报
  **「passed: 0 retired keys」**—— 而公开 checkout 里 `harness/` 本来就不存在（canonical 台账是私有的
  git-ignored 子仓）。**一个什么都没扫的 checker 绝不能宣布通过。** 现在它区分三种状态：扫了且干净（通过）、
  没有台账可扫（**明确 SKIPPED，并声明这不是通过**）、台账根存在但零文档（**仪器失效，exit 2**）。

## 任务与范围

- Harness 任务：`task_01KXE0493Q44XTR1DWY3P5VVWX`（T6 片④，最后一片）
- 分支：`codex/plt-t6-retired-keys`
- 公开范围：`tools/` checker + 测试 + gate-manifest 注册；`package.json` 脚本入口
- 私有计划/证据已更新：是（`impl-report-t6-slice4.md`、progress 已 append）
- 不在范围：把 canonical 台账自身的变更接上远端 CI（见残余风险）

## 版本影响

- 版本：无变更，因为这是新增 CI 门，不是发布面
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是
- 受保护面范围：`tools/gate-manifest.json`（注册新 leaf gate；enforcement 与声明同 PR，依 ADR-0022）
- 授权：task `task_01KXE0493Q44XTR1DWY3P5VVWX`（T6 charter，2026-07-13 批准）；ADR-0022（门禁六模式）；
  ADR-0023（CI/gate 治理权威模型）
- 机器检查边界：本 PR 只断言声明存在；是否为真、是否充分由复核者判断。
- Break-glass：无
- 未修改任何既有 gate 的阈值/豁免、未动分支保护与 Mergify 配置。

## 验证

- 基线 `origin/main` SHA：`bbec6a54`
- 同步方式：直接 off 最新 `origin/main`
- 测试：`node --test tools/check-retired-keys.test.mjs` → **7/7 通过**
- Canonical 实扫：**627 个 task INDEX.md + 348 个 decision.md，0 个退役键**（T4 今天早些时候完成了 851
  个文档的清扫；这道门现在守住这条线）
- CI 条件探针（无 `harness/`）：输出 `SKIPPED … this is not a pass`，exit 0 —— 已验证它**不会**输出 "passed"
- Manifest 派生：55 门、0 drift；新门在 `boundaries` / `check` / `checkPr` 里可见
- `npm run check:local`：绿（30.6 秒）
- 注：`check:local` 有意不含 `boundaries` 结构门族（dec_01KXFEMGFNT0QF5PTXVDGQGZ76 —— 本地轻门、CI 权威）。
  此处以 GitHub CI 为权威。

## 复核证据

- 自审：CEO
- 复核 subagent：无
- 人工复核：CEO 语义验收 —— ADR-0022 六模式逐条核过。发现并修复一个真实缺陷（上述"空树静默绿"行为），
  该缺陷是 worker **主动如实自报**而非隐瞒。
- 阻塞发现：无

## 残余风险

- **这道门无法在 GitHub CI 上扫到 canonical 台账**，因为公开 checkout 不含 `harness/`（私有 git-ignored
  子仓）。在 CI 上它正确地报 SKIPPED。它真正的执法点是 `check:local` 与任何本地/canonical 运行。
  这意味着：若某个代码改动重新引入了写退役键的写路径，它会通过 CI，直到下一次本地 check 才被发现 ——
  信号是**延迟**而非**缺失**。把 canonical 台账自身的提交接上 CI 执法面是一个独立决策（它今天没有 CI），
  本 PR 有意不擅自尝试。
- 这道门守的是**文档**。它本身不阻止代码里重新引入一个写退役键的 writer；它让由此产生的数据漂移**响亮可见**。

## 参考

- 任务：`harness/tasks/task_01KXE0493Q44XTR1DWY3P5VVWX-plt-t6-ci/`
- 证据：`artifacts/impl-report-t6-slice4.md`
- 相关：T4 清扫（`task_01KXDT1W0A5MYVQQJQ4RZJJ6M1`，851 个文档，今日完成）；
  T3 content-pin verifier（`task_01KXDT1Q0XDQFXRRAFS6QR0ZZ8`，PR #769）—— 本门绝不能误杀它那 58 条活跃 pin
