### PR TITLE
fix: make daemon writes materialize visibly (P0 — receipts said ok, ledger was empty)

### DIFF
--- a/packages/cli/src/cli/command-spec/command-spec-runtime-docs.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-runtime-docs.ts
@@ -60,7 +60,7 @@ export const runtimeDocsCommandSpecs = defineCommandSpecs([
     "parse": parseMaterializerArgs,
     "run": runMaterializerCommand,
     "receiptContract": {
-      "data": ["rows", "warnings", "report"],
+      "data": ["rows", "report"],
       "paths": []
     },
     "eventPolicy": {

--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -75,10 +75,34 @@ export function renderReceiptText(receipt: CommandReceipt): string {
   const primaryPath = receipt.paths?.find((entry) => ["package", "primary", "projection"].includes(entry.role))?.path;
   if (primaryPath) parts.push(`path=${formatToken(primaryPath)}`);
   if (typeof receipt.rows === "number") parts.push(`rows=${receipt.rows}`);
+  if (receipt.warnings && receipt.warnings.length > 0) {
+    const warning = receiptWarning(
+      receipt.warnings.find((value) => receiptWarningCode(value) === "pending_materialization") ?? receipt.warnings[0]
+    );
+    parts.push(`warnings=${receipt.warnings.length}`);
+    if (warning.message) parts.push(`warning=${formatToken(warning.message)}`);
+    if (warning.nextCommand) parts.push(`next=${formatToken(warning.nextCommand)}`);
+  }
   const mode = launchMode(data.launchPlan);
   if (mode) parts.push(`mode=${formatToken(mode.mode)}`, `package=${formatToken(mode.packageName)}`);
   parts.push(`summary=${formatToken(receipt.summary)}`);
   return parts.join(" ");
+}
+
+function receiptWarningCode(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const code = (value as { readonly code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function receiptWarning(value: unknown): { readonly message?: string; readonly nextCommand?: string } {
+  if (typeof value === "string") return { message: value };
+  if (!value || typeof value !== "object" || Array.isArray(value)) return { message: String(value) };
+  const warning = value as { readonly message?: unknown; readonly nextCommand?: unknown };
+  return {
+    ...(typeof warning.message === "string" ? { message: warning.message } : {}),
+    ...(typeof warning.nextCommand === "string" ? { nextCommand: warning.nextCommand } : {})
+  };
 }
 
 function renderCapabilitiesText(receipt: CommandReceipt): string {

--- a/packages/cli/src/commands/core/materializer.ts
+++ b/packages/cli/src/commands/core/materializer.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
-import type { CliResult, ParsedCommand } from "../../cli/types.ts";
+import type { CliResult, MaterializerCommandReport, ParsedCommand } from "../../cli/types.ts";
 import type { CommandRunnerContext, CommandRunnerEffect } from "../../cli/runner-registry.ts";
 
 export function runMaterializerCommand(
@@ -15,14 +15,15 @@ export function runMaterializerCommand(
       error: cliError(CliErrorCode.UnknownCommand, `Unsupported materializer command: ${action.kind}`)
     } satisfies CliResult);
   }
-  return Effect.sync(() => {
-    const report = context.runLedgerMaterializer({ dryRun: action.dryRun });
-    return {
-      ok: true,
-      command: "materializer-run",
-      rows: report.branches.length,
-      warnings: report.warnings,
-      report
-    };
-  });
+  return Effect.sync(() => materializerCommandResult(context.runLedgerMaterializer({ dryRun: action.dryRun })));
+}
+
+export function materializerCommandResult(report: MaterializerCommandReport): CliResult {
+  return {
+    ok: true,
+    command: "materializer-run",
+    rows: report.branches.length,
+    warnings: report.warnings,
+    report
+  };
 }

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -104,6 +104,9 @@ export async function runCommandThroughDaemon(
       ? await runRemoteCommand(command, config.remote)
       : await runLocalCommand(command, config);
   } catch (error) {
+    if (command.action.kind === "materializer-run" && config.mode === "local" && !(error instanceof DaemonJsonRpcResponseError)) {
+      return undefined;
+    }
     if (error instanceof CliActorAttributionError) {
       return daemonActorAttributionReceipt(command, error);
     }
@@ -163,7 +166,7 @@ async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfi
       commandForTarget(command, target),
       Effect.runSync(makeEnvironmentCurrentSessionProbe().currentSession)
     )
-  }, 200, {
+  }, 200, command.action.kind === "materializer-run" ? undefined : {
     entryPath: daemonClientCliEntrypointPath(),
     idleExitMs: config.idleExitMs,
     timeoutMs: config.autostartTimeoutMs,

--- a/packages/cli/src/daemon/command-service.ts
+++ b/packages/cli/src/daemon/command-service.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import type { AuthenticatedActor, JsonObject } from "../../../daemon/src/index.ts";
+import { commandClassForCliActionKind, type AuthenticatedActor, type JsonObject } from "../../../daemon/src/index.ts";
 import { makeHumanFallbackSessionProbe, type TaskHolderExecutor } from "../../../application/src/index.ts";
 import type { CurrentSessionRef, WriteCoordinator } from "../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../cli/error-codes.ts";
@@ -8,6 +8,7 @@ import type { ParsedCommand } from "../cli/types.ts";
 import { isPlainRecord } from "../cli/value-utils.ts";
 import { CliActorAttributionError, daemonActorAttribution, migrationWriteAttribution } from "../composition/actor-attribution.ts";
 import { runRegisteredCommandWithCliComposition } from "../composition/command-executor.ts";
+import { materializerCommandResult } from "../commands/core/materializer.ts";
 import { makeDaemonQueuedOperationalWriteCoordinator, makeDaemonQueuedWriteCoordinator, type CliDaemonRuntime } from "./queued-write-coordinator.ts";
 
 export interface CliCommandService {
@@ -29,6 +30,10 @@ export function createCliCommandService(runtime: CliDaemonRuntime, options: CliC
         command = parsedCommand;
         const daemonActor = context?.actor;
         const currentSession = readCurrentSession(payload) ?? Effect.runSync(makeHumanFallbackSessionProbe().currentSession);
+        if (parsedCommand.action.kind === "materializer-run") {
+          const report = await runtime.enqueueMaterializerBatch({ dryRun: parsedCommand.action.dryRun });
+          return toCommandReceipt(materializerCommandResult(report));
+        }
         const attribution = daemonActor ? daemonActorAttribution(daemonActor, context?.executor) : undefined;
         const result = await runRegisteredCommandWithCliComposition(parsedCommand, {
           requireProvidedActorAttribution: true,
@@ -64,7 +69,7 @@ export function createCliCommandService(runtime: CliDaemonRuntime, options: CliC
             actor
           )
         });
-        return toCommandReceipt(result);
+        return toCommandReceipt(await withSessionMaterialization(result, parsedCommand, currentSession, runtime));
       } catch (error) {
         if (error instanceof CurrentSessionPayloadError) {
           return toCommandReceipt({
@@ -85,6 +90,51 @@ export function createCliCommandService(runtime: CliDaemonRuntime, options: CliC
         options.onCommandSettled?.();
       }
     }
+  };
+}
+
+async function withSessionMaterialization(
+  result: Awaited<ReturnType<typeof runRegisteredCommandWithCliComposition>>,
+  command: ParsedCommand,
+  currentSession: CurrentSessionRef,
+  runtime: CliDaemonRuntime
+): Promise<Awaited<ReturnType<typeof runRegisteredCommandWithCliComposition>>> {
+  if (!result.ok || currentSession.source !== "runtime") return result;
+  const commandClass = commandClassForCliActionKind(command.action.kind);
+  if (commandClass !== "repo-write" && commandClass !== "arbiter") return result;
+
+  try {
+    const report = await runtime.enqueueMaterializerBatch({ sessionId: currentSession.sessionId });
+    const target = report.branches.find((branch) => branch.branch === `sessions/${currentSession.sessionId}`);
+    if (!target || target.commitCount === 0 || target.status === "merged") return result;
+    return appendPendingMaterializationWarning(result, currentSession.sessionId, target.warning);
+  } catch (error) {
+    return appendPendingMaterializationWarning(
+      result,
+      currentSession.sessionId,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}
+
+function appendPendingMaterializationWarning(
+  result: Awaited<ReturnType<typeof runRegisteredCommandWithCliComposition>>,
+  sessionId: string,
+  reason?: string
+): Awaited<ReturnType<typeof runRegisteredCommandWithCliComposition>> {
+  const nextCommand = "ha materializer run --json";
+  return {
+    ...result,
+    warnings: [
+      ...(result.warnings ?? []),
+      {
+        severity: "warning",
+        code: "pending_materialization",
+        message: `Write is durable on sessions/${sessionId} but is not yet visible on canonical read paths.${reason ? ` Cause: ${reason}` : ""} Run: ${nextCommand}`,
+        sessionId,
+        nextCommand
+      }
+    ]
   };
 }
 

--- a/packages/cli/src/daemon/queued-write-coordinator.ts
+++ b/packages/cli/src/daemon/queued-write-coordinator.ts
@@ -23,6 +23,18 @@ export interface CliDaemonRuntime {
   readonly status: () => {
     readonly lastRecovery?: RecoveryReport;
   };
+  readonly enqueueMaterializerBatch: (options?: {
+    readonly dryRun?: boolean;
+    readonly sessionId?: string;
+  }) => Promise<{
+    readonly branches: ReadonlyArray<{
+      readonly branch: string;
+      readonly commitCount: number;
+      readonly status: "merged" | "would_merge" | "skipped" | "conflict";
+      readonly warning?: string;
+    }>;
+    readonly warnings: ReadonlyArray<string>;
+  }>;
 }
 
 export function makeDaemonQueuedWriteCoordinator(

--- a/packages/cli/test/daemon-execution-claim-cli.test.ts
+++ b/packages/cli/test/daemon-execution-claim-cli.test.ts
@@ -6,9 +6,12 @@ import { receiptDataString, writePeopleRoster } from "./helpers/forced-command-d
 import { runRawJson, withTempRootAsync } from "./helpers/daemon-cli.ts";
 import { git, receiptPath } from "./helpers/daemon-thin-client-fixtures.ts";
 
-test("daemon-backed Execution claim upgrades Holder V1 and preserves the caller session", async () => {
+test("daemon-backed Execution claim upgrades Holder V1 and preserves the caller session binding", async () => {
   await withTempRootAsync(async (rootDir) => {
     runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
+    const harnessRoot = path.join(rootDir, "harness");
+    git(harnessRoot, "config", "user.name", "Harness Test");
+    git(harnessRoot, "config", "user.email", "harness@example.test");
     writePeopleRoster(rootDir, {
       personId: "person_execution",
       displayName: "Execution User",
@@ -56,13 +59,14 @@ test("daemon-backed Execution claim upgrades Holder V1 and preserves the caller 
       `${executionId}.md`
     );
     const execution = JSON.parse(git(
-      path.join(rootDir, "harness"),
+      harnessRoot,
       "show",
-      `sessions/claiming-codex-session:${executionPath}`
+      `master:${executionPath}`
     )) as {
       readonly session_bindings?: ReadonlyArray<{ readonly session_ref?: string | null }>;
     };
     assert.equal(execution.session_bindings?.[0]?.session_ref, "session/claiming-codex-session");
+    assert.equal(git(harnessRoot, "branch", "--list", "sessions/claiming-codex-session"), "");
 
     const holder = runRawJson(rootDir, ["task", "holder", taskId], {
       HARNESS_DAEMON_MODE: "local",

--- a/packages/cli/test/materializer-recovery-cli.test.ts
+++ b/packages/cli/test/materializer-recovery-cli.test.ts
@@ -137,6 +137,8 @@ test("daemon success receipt declares pending materialization with a next comman
 function createOlderConflictedSessionBranch(rootDir: string, sessionId = "older-conflict"): void {
   const harnessRoot = path.join(rootDir, "harness");
   const sharedPath = path.join(harnessRoot, "conflict.txt");
+  git(rootDir, "config", "user.name", "Harness Test");
+  git(rootDir, "config", "user.email", "harness@example.test");
   writeFileSync(sharedPath, "base\n", "utf8");
   git(rootDir, "add", "conflict.txt");
   git(rootDir, "commit", "-m", "seed conflict fixture");
@@ -151,7 +153,12 @@ function createOlderConflictedSessionBranch(rootDir: string, sessionId = "older-
 }
 
 function git(rootDir: string, ...args: ReadonlyArray<string>): string {
-  return execFileSync("git", ["-C", path.join(rootDir, "harness"), ...args], {
+  return execFileSync("git", [
+    "-C", path.join(rootDir, "harness"),
+    "-c", "user.name=Harness Test",
+    "-c", "user.email=harness@example.test",
+    ...args
+  ], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"]
   }).trim();

--- a/packages/cli/test/materializer-recovery-cli.test.ts
+++ b/packages/cli/test/materializer-recovery-cli.test.ts
@@ -1,0 +1,158 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import {
+  defaultDaemonUserRoot,
+  runDaemonCommand,
+  runRawJson,
+  sleep,
+  stopDaemonQuietly,
+  withTempRoot
+} from "./helpers/daemon-cli.ts";
+import { writePeopleRoster } from "./helpers/forced-command-daemon.ts";
+
+test("materializer recovery does not auto-start a daemon and emits a valid success receipt", () => {
+  withTempRoot((rootDir) => {
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
+
+    const receipt = runRawJson(rootDir, ["materializer", "run", "--dry-run"], {
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_IDLE_MS: "10000"
+    });
+
+    assert.equal(receipt.ok, true, JSON.stringify(receipt));
+    assert.equal(receipt.command, "materializer run");
+    assert.equal((receipt.details as { data?: { report?: { warnings?: unknown[] } } }).data?.report?.warnings?.length, 0);
+    sleep(100);
+    assert.equal(runDaemonCommand(rootDir, ["daemon", "status", "--json"]).started, false);
+  });
+});
+
+test("materializer run uses an already-running daemon without contending for its lock", () => {
+  withTempRoot((rootDir) => {
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
+    writePeopleRoster(rootDir, {
+      personId: "person_materializer",
+      displayName: "Materializer Operator",
+      email: "materializer@example.test",
+      role: "owner"
+    });
+    try {
+      runDaemonCommand(rootDir, ["daemon", "start", "--service", "--json"]);
+
+      const receipt = runRawJson(rootDir, ["materializer", "run", "--dry-run"], {
+        HARNESS_DAEMON_MODE: "local"
+      });
+
+      assert.equal(receipt.ok, true, JSON.stringify(receipt));
+    } finally {
+      stopDaemonQuietly(rootDir, defaultDaemonUserRoot(rootDir));
+    }
+  });
+});
+
+test("daemon write receipt is not successful until its session write is readable despite an older conflict", () => {
+  withTempRoot((rootDir) => {
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
+    writePeopleRoster(rootDir, {
+      personId: "person_visibility",
+      displayName: "Visibility Operator",
+      email: "visibility@example.test",
+      role: "owner"
+    });
+    createOlderConflictedSessionBranch(rootDir);
+
+    try {
+      const decisionId = "dec_receipt_visibility";
+      const receipt = runRawJson(rootDir, [
+        "decision", "propose",
+        "--id", decisionId,
+        "--title", "Receipt visibility",
+        "--question", "Is the successful write readable?",
+        "--chosen", "yes",
+        "--rejected", "no",
+        "--why-not", "A success receipt must be honest"
+      ], {
+        HARNESS_DAEMON_MODE: "local",
+        HARNESS_DAEMON_IDLE_MS: "20000",
+        CODEX_THREAD_ID: "receipt-visibility-session"
+      });
+
+      const decisionPath = path.join(rootDir, "harness/decisions/decision-dec_receipt_visibility/decision.md");
+      assert.equal(receipt.ok, true, JSON.stringify(receipt));
+      assert.equal(existsSync(decisionPath), true, JSON.stringify(receipt));
+      const shown = runRawJson(rootDir, ["decision", "show", decisionId], {
+        HARNESS_DAEMON_MODE: "local",
+        HARNESS_DAEMON_IDLE_MS: "20000",
+        CODEX_THREAD_ID: "receipt-visibility-session"
+      });
+      assert.equal(shown.ok, true, JSON.stringify(shown));
+      assert.equal(git(rootDir, "branch", "--list", "sessions/receipt-visibility-session"), "");
+    } finally {
+      stopDaemonQuietly(rootDir, defaultDaemonUserRoot(rootDir));
+    }
+  });
+});
+
+test("daemon success receipt declares pending materialization with a next command when its own session conflicts", () => {
+  withTempRoot((rootDir) => {
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
+    writePeopleRoster(rootDir, {
+      personId: "person_pending",
+      displayName: "Pending Operator",
+      email: "pending@example.test",
+      role: "owner"
+    });
+    createOlderConflictedSessionBranch(rootDir, "receipt-pending-session");
+
+    try {
+      const receipt = runRawJson(rootDir, [
+        "decision", "propose",
+        "--id", "dec_receipt_pending",
+        "--title", "Pending receipt",
+        "--question", "Can the write be read now?",
+        "--chosen", "not yet",
+        "--rejected", "pretend yes",
+        "--why-not", "That would be dishonest"
+      ], {
+        HARNESS_DAEMON_MODE: "local",
+        HARNESS_DAEMON_IDLE_MS: "20000",
+        CODEX_THREAD_ID: "receipt-pending-session"
+      });
+
+      const warnings = receipt.warnings as ReadonlyArray<{ readonly code?: string; readonly nextCommand?: string }>;
+      const pending = warnings.find((warning) => warning.code === "pending_materialization");
+      assert.equal(receipt.ok, true, JSON.stringify(receipt));
+      assert.equal(pending?.nextCommand, "ha materializer run --json");
+      assert.equal(existsSync(path.join(rootDir, "harness/decisions/decision-dec_receipt_pending/decision.md")), false);
+    } finally {
+      stopDaemonQuietly(rootDir, defaultDaemonUserRoot(rootDir));
+    }
+  });
+});
+
+function createOlderConflictedSessionBranch(rootDir: string, sessionId = "older-conflict"): void {
+  const harnessRoot = path.join(rootDir, "harness");
+  const sharedPath = path.join(harnessRoot, "conflict.txt");
+  writeFileSync(sharedPath, "base\n", "utf8");
+  git(rootDir, "add", "conflict.txt");
+  git(rootDir, "commit", "-m", "seed conflict fixture");
+  git(rootDir, "checkout", "-b", `sessions/${sessionId}`);
+  writeFileSync(sharedPath, "session\n", "utf8");
+  git(rootDir, "add", "conflict.txt");
+  git(rootDir, "commit", "-m", "session conflict");
+  git(rootDir, "checkout", "master");
+  writeFileSync(sharedPath, "trunk\n", "utf8");
+  git(rootDir, "add", "conflict.txt");
+  git(rootDir, "commit", "-m", "trunk conflict");
+}
+
+function git(rootDir: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", path.join(rootDir, "harness"), ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}

--- a/packages/cli/test/receipt-contracts.test.ts
+++ b/packages/cli/test/receipt-contracts.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { commandReceiptContractsByKind } from "../src/cli/receipt-contracts.ts";
-import { toCommandReceipt } from "../src/cli/receipt.ts";
+import { renderReceiptText, toCommandReceipt } from "../src/cli/receipt.ts";
 
 test("command receipts fail closed on undeclared path fields", () => {
   const receipt = toCommandReceipt({
@@ -93,6 +93,45 @@ test("command receipts allow explicitly optional declared data to be absent", ()
   if (!receipt.ok) return;
   assert.equal(receipt.entity?.id, "task_1");
   assert.equal(receipt.paths?.some((entry) => entry.role === "package"), true);
+});
+
+test("materializer warnings use the receipt warning envelope instead of a duplicate data field", () => {
+  const receipt = toCommandReceipt({
+    ok: true,
+    command: "materializer-run",
+    rows: 1,
+    warnings: ["sessions/conflict: merge failed"],
+    report: { branches: [], warnings: ["sessions/conflict: merge failed"] }
+  });
+
+  assert.equal(receipt.ok, true, JSON.stringify(receipt));
+  if (!receipt.ok) return;
+  assert.deepEqual(receipt.warnings, ["sessions/conflict: merge failed"]);
+  assert.equal("warnings" in (receipt.details?.data ?? {}), false);
+});
+
+test("plain text receipts prioritize pending materialization and print its next command", () => {
+  const receipt = toCommandReceipt({
+    ok: true,
+    command: "decision-propose",
+    decisionId: "dec_pending",
+    decisionState: "proposed",
+    path: "harness/decisions/decision-dec_pending/decision.md",
+    report: { schema: "decision-write-cli-report/v1", dryRun: false },
+    warnings: [
+      { code: "decision_body_empty", message: "Add a narrative." },
+      {
+        code: "pending_materialization",
+        message: "Write is durable but not readable. Run: ha materializer run --json",
+        nextCommand: "ha materializer run --json"
+      }
+    ]
+  });
+
+  assert.equal(receipt.ok, true, JSON.stringify(receipt));
+  if (!receipt.ok) return;
+  assert.match(renderReceiptText(receipt), /pending materialization|not readable/iu);
+  assert.match(renderReceiptText(receipt), /next="ha materializer run --json"/u);
 });
 
 test("command receipts accept explicitly optional declared data when present", () => {

--- a/packages/kernel/src/store/daemon-runtime.ts
+++ b/packages/kernel/src/store/daemon-runtime.ts
@@ -78,8 +78,13 @@ export interface HarnessDaemonRuntime {
   readonly status: () => DaemonRuntimeStatus;
   readonly enqueueInteractiveWrite: (request: InteractiveWriteRequest) => Promise<InteractiveWriteReceipt>;
   readonly enqueueBackgroundBatch: <Result>(request: BackgroundBatchRequest<Result>) => Promise<Result>;
-  readonly enqueueMaterializerBatch: () => Promise<LedgerMaterializerReport>;
+  readonly enqueueMaterializerBatch: (options?: DaemonMaterializerBatchOptions) => Promise<LedgerMaterializerReport>;
   readonly queryExecutionEvidencePage: (query: ExecutionEvidencePageQuery) => Promise<ExecutionEvidencePage>;
+}
+
+export interface DaemonMaterializerBatchOptions {
+  readonly dryRun?: boolean;
+  readonly sessionId?: string;
 }
 
 export type DaemonRepoRuntimeState = "attached" | "unavailable" | "detaching" | "detached";
@@ -120,7 +125,7 @@ export interface MultiRepoHarnessDaemonRuntime {
   readonly getRepoRuntime: (repoId: string) => HarnessDaemonRuntime | undefined;
   readonly enqueueInteractiveWrite: (repoId: string, request: InteractiveWriteRequest) => Promise<InteractiveWriteReceipt>;
   readonly enqueueBackgroundBatch: <Result>(repoId: string, request: BackgroundBatchRequest<Result>) => Promise<Result>;
-  readonly enqueueMaterializerBatch: (repoId: string) => Promise<LedgerMaterializerReport>;
+  readonly enqueueMaterializerBatch: (repoId: string, options?: DaemonMaterializerBatchOptions) => Promise<LedgerMaterializerReport>;
 }
 
 export function createDaemonRuntime(options: DaemonRuntimeOptions): HarnessDaemonRuntime {
@@ -131,7 +136,7 @@ export function createDaemonRuntime(options: DaemonRuntimeOptions): HarnessDaemo
     status: () => toDaemonRuntimeStatus(context.status()),
     enqueueInteractiveWrite: (request) => context.enqueueInteractiveWrite(request),
     enqueueBackgroundBatch: (request) => context.enqueueBackgroundBatch(request),
-    enqueueMaterializerBatch: () => context.enqueueMaterializerBatch(),
+    enqueueMaterializerBatch: (batchOptions) => context.enqueueMaterializerBatch(batchOptions),
     queryExecutionEvidencePage: (query) => context.queryExecutionEvidencePage(query)
   };
 }
@@ -186,7 +191,7 @@ export function createMultiRepoDaemonRuntime(options: MultiRepoDaemonRuntimeOpti
     getRepoRuntime: (repoId) => contexts.get(repoId),
     enqueueInteractiveWrite: (repoId, request) => requireContext(contexts, repoId).enqueueInteractiveWrite(request),
     enqueueBackgroundBatch: (repoId, request) => requireContext(contexts, repoId).enqueueBackgroundBatch(request),
-    enqueueMaterializerBatch: (repoId) => requireContext(contexts, repoId).enqueueMaterializerBatch()
+    enqueueMaterializerBatch: (repoId, batchOptions) => requireContext(contexts, repoId).enqueueMaterializerBatch(batchOptions)
   };
   return runtime;
 
@@ -355,7 +360,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       });
   }
 
-  enqueueMaterializerBatch(): Promise<LedgerMaterializerReport> {
+  enqueueMaterializerBatch(batchOptions: DaemonMaterializerBatchOptions = {}): Promise<LedgerMaterializerReport> {
     return this.enqueueBackgroundBatch({
       source: "ledger-materializer",
       priority: "background",
@@ -363,10 +368,18 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
         const started = this.requireAttached();
         const report = runLedgerMaterializer(this.runtimeContext, {
           heldGlobalLock: started.lock,
-          maxBranches: this.materializerMaxBranchesPerBatch
+          ...(batchOptions.dryRun ? { dryRun: true } : {}),
+          ...(batchOptions.sessionId
+            ? { sessionId: batchOptions.sessionId }
+            : { maxBranches: this.materializerMaxBranchesPerBatch })
         });
         if (report.projectionRebuilt) {
           this.projectionGeneration.invalidate();
+        }
+        if (report.warnings.length > 0) {
+          this.lastMaterializerError = report.warnings.join("; ");
+        } else if (!batchOptions.sessionId) {
+          this.lastMaterializerError = undefined;
         }
         return report;
       }

--- a/packages/kernel/src/store/ledger-materializer.ts
+++ b/packages/kernel/src/store/ledger-materializer.ts
@@ -7,7 +7,7 @@ import { countAttributionProjectionRows } from "../projection/sqlite-attribution
 import { rebuildTaskProjection } from "../projection/sqlite-task-projection.ts";
 import { captureAuthoredProjectionFingerprint } from "../projection/projection-source-baseline.ts";
 import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
-import { resolveTrunkBranch } from "./write-journal-git.ts";
+import { resolveTrunkBranch, sessionBranchName } from "./write-journal-git.ts";
 import { withRepoLocks } from "./write-journal-locks.ts";
 import type { OwnedLock } from "./write-journal-types.ts";
 import { durableFileExists } from "./write-journal-durable.ts";
@@ -165,14 +165,6 @@ function materializeBranches(
     projectionRebuilt,
     attributionEventsProjected
   };
-}
-
-function sessionBranchName(sessionId: string): string {
-  const trimmed = sessionId.trim();
-  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(trimmed)) {
-    throw new Error(`invalid materializer session id: ${sessionId}`);
-  }
-  return `sessions/${trimmed}`;
 }
 
 function reachedBranchLimit(processed: number, maxBranches: number | undefined): boolean {

--- a/packages/kernel/src/store/ledger-materializer.ts
+++ b/packages/kernel/src/store/ledger-materializer.ts
@@ -33,6 +33,7 @@ export interface LedgerMaterializerReport {
 export interface LedgerMaterializerOptions {
   readonly dryRun?: boolean;
   readonly maxBranches?: number;
+  readonly sessionId?: string;
   readonly heldGlobalLock?: OwnedLock;
   readonly versionControlSystem?: VersionControlSystem;
 }
@@ -56,11 +57,18 @@ export function runLedgerMaterializer(rootInput: HarnessLayoutInput, options: Le
   }
 
   return withRepoLocks(layout.rootDir, rootInput, layout.journalPath, { scope: "operational", kind: "system", id: "ledger-materializer" }, 60_000, [], () => {
-    return materializeBranches(repoRoot, rootInput, options.dryRun === true, options.maxBranches, versionControlSystem);
+    return materializeBranches(repoRoot, rootInput, options.dryRun === true, options.maxBranches, options.sessionId, versionControlSystem);
   }, { heldGlobalLock: options.heldGlobalLock });
 }
 
-function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dryRun: boolean, maxBranches: number | undefined, vcs: VersionControlSystem): LedgerMaterializerReport {
+function materializeBranches(
+  repoRoot: string,
+  rootInput: HarnessLayoutInput,
+  dryRun: boolean,
+  maxBranches: number | undefined,
+  sessionId: string | undefined,
+  vcs: VersionControlSystem
+): LedgerMaterializerReport {
   const reports: LedgerMaterializerBranchReport[] = [];
   const warnings: string[] = [];
   let merged = 0;
@@ -81,7 +89,9 @@ function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dr
     };
   }
 
-  const branches = vcs.sessionBranches(repoRoot);
+  const branches = sessionId
+    ? vcs.sessionBranches(repoRoot).filter((branch) => branch === sessionBranchName(sessionId))
+    : vcs.sessionBranches(repoRoot);
   for (const branch of branches) {
     const commits = vcs.commitsNotInTrunk(repoRoot, trunkBranch, branch);
     if (commits.length === 0) {
@@ -107,6 +117,7 @@ function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dr
       }
       vcs.deleteBranch(repoRoot, branch);
       merged += 1;
+      processed += 1;
       reports.push({ branch, commitCount: commits.length, status: "merged", commits });
     } catch (error) {
       const warning = `${branch}: ${error instanceof Error ? error.message : String(error)}`;
@@ -118,7 +129,6 @@ function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dr
       }
       reports.push({ branch, commitCount: commits.length, status: "conflict", commits, warning });
     }
-    processed += 1;
     if (reachedBranchLimit(processed, maxBranches)) break;
   }
 
@@ -155,6 +165,14 @@ function materializeBranches(repoRoot: string, rootInput: HarnessLayoutInput, dr
     projectionRebuilt,
     attributionEventsProjected
   };
+}
+
+function sessionBranchName(sessionId: string): string {
+  const trimmed = sessionId.trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(trimmed)) {
+    throw new Error(`invalid materializer session id: ${sessionId}`);
+  }
+  return `sessions/${trimmed}`;
 }
 
 function reachedBranchLimit(processed: number, maxBranches: number | undefined): boolean {

--- a/packages/kernel/src/store/ledger-materializer.ts
+++ b/packages/kernel/src/store/ledger-materializer.ts
@@ -89,9 +89,16 @@ function materializeBranches(
     };
   }
 
-  const branches = sessionId
-    ? vcs.sessionBranches(repoRoot).filter((branch) => branch === sessionBranchName(sessionId))
-    : vcs.sessionBranches(repoRoot);
+  let branches: ReadonlyArray<string>;
+  if (sessionId) {
+    // A session id that yields no branch name (e.g. all-whitespace) must fail loudly:
+    // filtering on undefined would silently report "no branches to materialize".
+    const targetBranch = sessionBranchName(sessionId);
+    if (!targetBranch) throw new Error(`invalid materializer session id: ${sessionId}`);
+    branches = vcs.sessionBranches(repoRoot).filter((branch) => branch === targetBranch);
+  } else {
+    branches = vcs.sessionBranches(repoRoot);
+  }
   for (const branch of branches) {
     const commits = vcs.commitsNotInTrunk(repoRoot, trunkBranch, branch);
     if (commits.length === 0) {

--- a/packages/kernel/src/store/write-journal-git.ts
+++ b/packages/kernel/src/store/write-journal-git.ts
@@ -197,7 +197,7 @@ function branchExists(repoRoot: string, branchName: string, vcs: VersionControlS
   return vcs.refExists(repoRoot, branchName);
 }
 
-function sessionBranchName(sessionId: string | undefined): string | undefined {
+export function sessionBranchName(sessionId: string | undefined): string | undefined {
   const safeSessionId = sessionId?.trim();
   if (!safeSessionId) return undefined;
   if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(safeSessionId)) {

--- a/packages/kernel/test/store/daemon-materializer-runtime.test.ts
+++ b/packages/kernel/test/store/daemon-materializer-runtime.test.ts
@@ -1,0 +1,110 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import { createHarnessRuntimeContext, resolveHarnessLayout } from "../../src/layout/index.ts";
+import type { ProjectionSourceFenceFactory } from "../../src/ports/projection-source-fence.ts";
+import { projectionDatabaseSignature } from "../../src/projection/projection-generation-readiness.ts";
+import { rebuildTaskProjection } from "../../src/projection/sqlite-task-projection.ts";
+import { makeJournaledWriteCoordinator } from "../../src/store/write-journal-coordinator.ts";
+import { createDaemonRuntime, createMultiRepoDaemonRuntime } from "../../../adapters/local/src/index.ts";
+import { docWrite, withTempStoreAsync } from "./helpers.ts";
+import {
+  commitAuthoredFixture,
+  daemonAttribution,
+  git,
+  initAuthoredGit,
+  readGitFile,
+  stableProjectionFence,
+  writeExecutionEvidenceFixture
+} from "./helpers/daemon-runtime.ts";
+
+const testAttribution = daemonAttribution("person_test", "test", "credential-test");
+
+const deterministicProjectionSourceFenceFactory: ProjectionSourceFenceFactory = ({ rootDir }) => {
+  const fence = stableProjectionFence(`test-${path.basename(rootDir)}`, git(rootDir, "rev-parse", "HEAD"), []);
+  return { capture: () => fence };
+};
+
+test("daemon materializer producer runs bounded batches under the lifetime global lock", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const sessionOne = makeJournaledWriteCoordinator({ rootDir, attribution: testAttribution, sessionId: "daemon-mat-1", autoMaterialize: false });
+    Effect.runSync(sessionOne.enqueue(docWrite("op-mat-1", "task-mat-1", "note.md", "one\n")));
+    Effect.runSync(sessionOne.flush("explicit"));
+    const sessionTwo = makeJournaledWriteCoordinator({ rootDir, attribution: testAttribution, sessionId: "daemon-mat-2", autoMaterialize: false });
+    Effect.runSync(sessionTwo.enqueue(docWrite("op-mat-2", "task-mat-2", "note.md", "two\n")));
+    Effect.runSync(sessionTwo.flush("explicit"));
+
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: false,
+      materializerMaxBranchesPerBatch: 1
+    });
+    await runtime.start();
+    const first = await runtime.enqueueMaterializerBatch();
+    const second = await runtime.enqueueMaterializerBatch();
+
+    assert.equal(first.merged, 1);
+    assert.equal(second.merged, 1);
+    assert.equal(git(rootDir, "branch", "--list", "sessions/daemon-mat-*"), "");
+    assert.equal(readGitFile(rootDir, "tasks/task-mat-1/note.md"), "one\n");
+    assert.equal(readGitFile(rootDir, "tasks/task-mat-2/note.md"), "two\n");
+    await runtime.stop();
+  });
+});
+
+test("daemon status exposes materializer merge conflicts", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const conflictPath = path.join(rootDir, "harness/conflict.txt");
+    git(rootDir, "checkout", "-b", "sessions/daemon-conflict");
+    writeFileSync(conflictPath, "session\n", "utf8");
+    git(rootDir, "add", "--", "conflict.txt");
+    git(rootDir, "commit", "-m", "session conflict");
+    git(rootDir, "checkout", "master");
+    writeFileSync(conflictPath, "trunk\n", "utf8");
+    git(rootDir, "add", "--", "conflict.txt");
+    git(rootDir, "commit", "-m", "trunk conflict");
+
+    const runtime = createMultiRepoDaemonRuntime({
+      repos: [{ repoId: "conflict-repo", rootDir }],
+      materializerPollMs: false,
+      materializerMaxBranchesPerBatch: 1
+    });
+    await runtime.start();
+    const report = await runtime.enqueueMaterializerBatch("conflict-repo");
+
+    assert.equal(report.branches[0]?.status, "conflict");
+    assert.match(runtime.status().repos[0]?.lastMaterializerError ?? "", /sessions\/daemon-conflict/u);
+    await runtime.stop();
+  });
+});
+
+test("daemon no-op materializer preserves the ready projection generation", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    writeExecutionEvidenceFixture(rootDir, "No-op materializer");
+    initAuthoredGit(rootDir);
+    commitAuthoredFixture(rootDir);
+    rebuildTaskProjection({ rootDir });
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: false,
+      projectionSourceFenceFactory: deterministicProjectionSourceFenceFactory
+    });
+    await runtime.start();
+    await runtime.queryExecutionEvidencePage({ limit: 1 });
+    const projectionPath = resolveHarnessLayout(createHarnessRuntimeContext(rootDir)).executionEvidenceProjectionPath;
+    const before = projectionDatabaseSignature(projectionPath);
+
+    const report = await runtime.enqueueMaterializerBatch();
+
+    assert.equal(report.merged, 0);
+    assert.equal(projectionDatabaseSignature(projectionPath), before);
+    assert.equal(runtime.status().projectionGeneration.invalidations, 0);
+    assert.equal(runtime.status().projectionGeneration.state, "ready");
+    await runtime.stop();
+  });
+});

--- a/packages/kernel/test/store/daemon-runtime.test.ts
+++ b/packages/kernel/test/store/daemon-runtime.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, readFileSync, statSync, utimesSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
@@ -489,6 +489,33 @@ test("daemon materializer producer runs bounded batches under the lifetime globa
     assert.equal(git(rootDir, "branch", "--list", "sessions/daemon-mat-*"), "");
     assert.equal(readGitFile(rootDir, "tasks/task-mat-1/note.md"), "one\n");
     assert.equal(readGitFile(rootDir, "tasks/task-mat-2/note.md"), "two\n");
+    await runtime.stop();
+  });
+});
+
+test("daemon status exposes materializer merge conflicts", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const conflictPath = path.join(rootDir, "harness/conflict.txt");
+    git(rootDir, "checkout", "-b", "sessions/daemon-conflict");
+    writeFileSync(conflictPath, "session\n", "utf8");
+    git(rootDir, "add", "--", "conflict.txt");
+    git(rootDir, "commit", "-m", "session conflict");
+    git(rootDir, "checkout", "master");
+    writeFileSync(conflictPath, "trunk\n", "utf8");
+    git(rootDir, "add", "--", "conflict.txt");
+    git(rootDir, "commit", "-m", "trunk conflict");
+
+    const runtime = createMultiRepoDaemonRuntime({
+      repos: [{ repoId: "conflict-repo", rootDir }],
+      materializerPollMs: false,
+      materializerMaxBranchesPerBatch: 1
+    });
+    await runtime.start();
+    const report = await runtime.enqueueMaterializerBatch("conflict-repo");
+
+    assert.equal(report.branches[0]?.status, "conflict");
+    assert.match(runtime.status().repos[0]?.lastMaterializerError ?? "", /sessions\/daemon-conflict/u);
     await runtime.stop();
   });
 });

--- a/packages/kernel/test/store/daemon-runtime.test.ts
+++ b/packages/kernel/test/store/daemon-runtime.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, readFileSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, statSync, utimesSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
@@ -9,7 +9,6 @@ import { makeTaskHolderService, taskHolderActor } from "../../src/local/task-hol
 import type { ProjectionSourceFence, ProjectionSourceFenceFactory } from "../../src/ports/projection-source-fence.ts";
 import { queryExecutionEvidencePage } from "../../src/projection/sqlite-execution-evidence-reader.ts";
 import { rebuildTaskProjection } from "../../src/projection/sqlite-task-projection.ts";
-import { projectionDatabaseSignature } from "../../src/projection/projection-generation-readiness.ts";
 import { createDaemonProjectionGenerationManager } from "../../src/store/daemon-projection-generation-manager.ts";
 import { makeJournaledWriteCoordinator } from "../../src/store/write-journal-coordinator.ts";
 import {
@@ -23,7 +22,6 @@ import {
   daemonAttribution,
   git,
   initAuthoredGit,
-  readGitFile,
   spawnJournalOnlyDaemon,
   stableProjectionFence,
   writeExecutionEvidenceFixture
@@ -461,87 +459,6 @@ test("daemon restart after SIGKILL takes over stale lock and recovers durable jo
     assert.equal(status.lastRecovery?.replayedOps, 1);
     assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-crash/recovered.md"), "utf8"), "recovered");
     assert.match(readFileSync(path.join(rootDir, ".harness/write-journal/writes.jsonl"), "utf8"), /"schema":"lock-takeover\/v1"/u);
-    await runtime.stop();
-  });
-});
-
-test("daemon materializer producer runs bounded batches under the lifetime global lock", async () => {
-  await withTempStoreAsync(async (rootDir) => {
-    initAuthoredGit(rootDir);
-    const sessionOne = makeJournaledWriteCoordinator({ rootDir, attribution: testAttribution, sessionId: "daemon-mat-1", autoMaterialize: false });
-    Effect.runSync(sessionOne.enqueue(docWrite("op-mat-1", "task-mat-1", "note.md", "one\n")));
-    Effect.runSync(sessionOne.flush("explicit"));
-    const sessionTwo = makeJournaledWriteCoordinator({ rootDir, attribution: testAttribution, sessionId: "daemon-mat-2", autoMaterialize: false });
-    Effect.runSync(sessionTwo.enqueue(docWrite("op-mat-2", "task-mat-2", "note.md", "two\n")));
-    Effect.runSync(sessionTwo.flush("explicit"));
-
-    const runtime = createDaemonRuntime({
-      rootDir,
-      materializerPollMs: false,
-      materializerMaxBranchesPerBatch: 1
-    });
-    await runtime.start();
-    const first = await runtime.enqueueMaterializerBatch();
-    const second = await runtime.enqueueMaterializerBatch();
-
-    assert.equal(first.merged, 1);
-    assert.equal(second.merged, 1);
-    assert.equal(git(rootDir, "branch", "--list", "sessions/daemon-mat-*"), "");
-    assert.equal(readGitFile(rootDir, "tasks/task-mat-1/note.md"), "one\n");
-    assert.equal(readGitFile(rootDir, "tasks/task-mat-2/note.md"), "two\n");
-    await runtime.stop();
-  });
-});
-
-test("daemon status exposes materializer merge conflicts", async () => {
-  await withTempStoreAsync(async (rootDir) => {
-    initAuthoredGit(rootDir);
-    const conflictPath = path.join(rootDir, "harness/conflict.txt");
-    git(rootDir, "checkout", "-b", "sessions/daemon-conflict");
-    writeFileSync(conflictPath, "session\n", "utf8");
-    git(rootDir, "add", "--", "conflict.txt");
-    git(rootDir, "commit", "-m", "session conflict");
-    git(rootDir, "checkout", "master");
-    writeFileSync(conflictPath, "trunk\n", "utf8");
-    git(rootDir, "add", "--", "conflict.txt");
-    git(rootDir, "commit", "-m", "trunk conflict");
-
-    const runtime = createMultiRepoDaemonRuntime({
-      repos: [{ repoId: "conflict-repo", rootDir }],
-      materializerPollMs: false,
-      materializerMaxBranchesPerBatch: 1
-    });
-    await runtime.start();
-    const report = await runtime.enqueueMaterializerBatch("conflict-repo");
-
-    assert.equal(report.branches[0]?.status, "conflict");
-    assert.match(runtime.status().repos[0]?.lastMaterializerError ?? "", /sessions\/daemon-conflict/u);
-    await runtime.stop();
-  });
-});
-
-test("daemon no-op materializer preserves the ready projection generation", async () => {
-  await withTempStoreAsync(async (rootDir) => {
-    writeExecutionEvidenceFixture(rootDir, "No-op materializer");
-    initAuthoredGit(rootDir);
-    commitAuthoredFixture(rootDir);
-    rebuildTaskProjection({ rootDir });
-    const runtime = createDaemonRuntime({
-      rootDir,
-      materializerPollMs: false,
-      projectionSourceFenceFactory: deterministicProjectionSourceFenceFactory
-    });
-    await runtime.start();
-    await runtime.queryExecutionEvidencePage({ limit: 1 });
-    const projectionPath = resolveHarnessLayout(createHarnessRuntimeContext(rootDir)).executionEvidenceProjectionPath;
-    const before = projectionDatabaseSignature(projectionPath);
-
-    const report = await runtime.enqueueMaterializerBatch();
-
-    assert.equal(report.merged, 0);
-    assert.equal(projectionDatabaseSignature(projectionPath), before);
-    assert.equal(runtime.status().projectionGeneration.invalidations, 0);
-    assert.equal(runtime.status().projectionGeneration.state, "ready");
     await runtime.stop();
   });
 });

--- a/packages/kernel/test/store/ledger-materializer.test.ts
+++ b/packages/kernel/test/store/ledger-materializer.test.ts
@@ -85,6 +85,41 @@ test("session write + materializer resolve the trunk on a main-trunk repo", () =
   });
 });
 
+test("a conflicted session branch does not starve a later mergeable branch in a bounded batch", () => {
+  withTempStore((rootDir) => {
+    initAuthoredGit(rootDir);
+    const harnessRoot = path.join(rootDir, "harness");
+    writeFileSync(path.join(harnessRoot, "shared.txt"), "base\n", "utf8");
+    git(rootDir, "add", "shared.txt");
+    git(rootDir, "commit", "-m", "add shared file");
+
+    git(rootDir, "checkout", "-b", "sessions/conflicted-old");
+    writeFileSync(path.join(harnessRoot, "shared.txt"), "session value\n", "utf8");
+    git(rootDir, "add", "shared.txt");
+    git(rootDir, "commit", "-m", "conflicting session write");
+    git(rootDir, "checkout", "master");
+    writeFileSync(path.join(harnessRoot, "shared.txt"), "trunk value\n", "utf8");
+    git(rootDir, "add", "shared.txt");
+    git(rootDir, "commit", "-m", "conflicting trunk write");
+
+    const coordinator = makeJournaledWriteCoordinator({
+      attribution: testWriteAttribution(),
+      rootDir,
+      sessionId: "mergeable-later",
+      autoMaterialize: false
+    });
+    Effect.runSync(coordinator.enqueue(docWrite("op-after-conflict", "task-after-conflict", "note.md", "visible\n")));
+    Effect.runSync(coordinator.flush("explicit"));
+
+    const report = runLedgerMaterializer(rootDir, { maxBranches: 1 });
+
+    assert.equal(report.branches.find((branch) => branch.branch === "sessions/conflicted-old")?.status, "conflict");
+    assert.equal(report.branches.find((branch) => branch.branch === "sessions/mergeable-later")?.status, "merged");
+    assert.equal(report.merged, 1);
+    assert.equal(readGitFile(rootDir, "tasks/task-after-conflict/note.md"), "visible\n");
+  });
+});
+
 function initAuthoredGit(rootDir: string, trunk = "master"): void {
   const harnessRoot = path.join(rootDir, "harness");
   mkdirSync(harnessRoot, { recursive: true });


### PR DESCRIPTION
# English

## Summary

**P0: the ledger silently stopped accepting writes for ~40 minutes while every receipt said `ok`.**

A write command returned `ok:true`, allocated an entity id, and printed a landing path — yet the entity did not exist on any read path. For a product that calls itself an accountability layer, "I recorded it" followed by "there is nothing there" is the worst failure mode there is.

Root cause: `ledger-materializer` counted a branch as *processed* whether the merge **succeeded or failed**. One conflicting session branch consumed the entire `maxBranches` budget, so every healthy session behind it was never materialized. Writes landed on their git session branch (the journal) and were never merged into `master`, while all read paths only look at `master`.

## What Changed

- `ledger-materializer.ts`: move `processed += 1` into the **success** branch, so a conflicting branch no longer eats a healthy branch's budget.
- `ledger-materializer.ts`: add a `sessionId` filter — a write now materializes **its own** session before returning, so an unrelated broken branch cannot block your write from becoming visible.
- `command-service.ts`: writes materialize their session synchronously before the receipt is returned.
- **Receipts stop lying**: when a write cannot be materialized, the receipt now carries `pending_materialization` **and the exact next command** (`ha materializer run --json`) — in JSON and in plain text. This implements principle #2 of the experience-design charter (`dec_01KXGDXZG03JZRGTW8V91H11ER`): *a refusal that does not tell you what to type next is itself a defect.*
- `materializer run`: no longer auto-starts a daemon that then rejects it with its own lock. Fixes the `data.warnings` receipt-contract mismatch that made the command fail its own validator **after it had already done the work**.
- Tests: new `materializer-recovery-cli.test.ts` (158 lines), plus materializer/daemon-runtime/receipt-contract coverage.

## Task And Scope

- Harness task: `task_01KXGFQTSBJ319VZ87J323SHPQ` (XD-3, under milestone `task_01KXGFHB32BZREHTY71F0AMSF6` / PLT-XD)
- Branch: `fix/materializer-p0`
- Public scope: `packages/kernel/src/store`, `packages/cli/src/daemon`, tests
- Private planning/evidence updated: yes
- Out of scope: registry namespacing, identity boundary, daemon stop/status semantics (routed to XD-2)

## Version Impact

- Version: no version change because this is a defect fix inside existing contracts
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KXGDXZG03JZRGTW8V91H11ER` (experience-design charter, standing policy)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: `5d563bf28b8ad33b993dfb0172d0fb4bae7e9f87`
- Branch merge-base with `origin/main`: `5d563bf28b8ad33b993dfb0172d0fb4bae7e9f87`
- Sync method: none needed
- Public diff command: `git diff origin/main..fix/materializer-p0`
- Private evidence commit/path: `harness/tasks/task_01KXGFQTSBJ319VZ87J323SHPQ-*/`
- [x] `npm run check:local` (28.7s, green)
- [x] 248 fast tests, 138 contract tests, 44/44 integration, 17/17 daemon runtime
- Not run: `npm run check:ci` on this branch — CI is authoritative and runs it here.

**End-to-end proof (no manual materializer run, no waiting, no retry):**

```
decision propose -> {"ok":true,"entity":{"id":"dec_p0_final_e2e"}}
decision show    -> {"ok":true,"entity":{"id":"dec_p0_final_e2e"}}   # immediately
filesystem       -> harness/decisions/decision-dec_p0_final_e2e/decision.md   # exists
ledger HEAD      -> 464750d  materializer: merge session ...
```

## Review Evidence

- Self-review: CEO reviewed the diff. The fix is a **moved line**, not an added layer — `processed += 1` belonged in the success branch all along.
- Blocking findings: none

## Residual Risk

The daemon lifecycle observation race (`stop`/`status` reporting different PIDs, autostart re-spawning immediately) is **not** fixed here and is routed to XD-2, along with the global registry's missing namespacing/CAS.

---

# 中文

## 概述

**P0：台账静默停止写入约 40 分钟，而每一条回执都在说 `ok`。**

写命令返回 `ok:true`、分配了 entity id、给出了落盘路径——而该实体在任何读路径上都不存在。对一个自称"问责层"的产品来说，"我记下来了"之后你去查、什么都没有，**这是最坏的一种失败**。

根因：`ledger-materializer` 把一个分支计为"已处理"时，**不区分 merge 成功还是失败**。于是一个冲突的 session 分支就把整个 `maxBranches` 额度吃光，排在它后面的健康 session 全部没被 materialize。写入落在自己的 git session 分支（journal）上，从未被 merge 回 `master`——而所有读路径只看 `master`。

## 变更内容

- `ledger-materializer.ts`：把 `processed += 1` 移进**成功分支**，冲突分支不再吃掉健康分支的额度。
- `ledger-materializer.ts`：新增 `sessionId` 过滤——写入在返回前只 materialize **自己的** session，别人的坏分支不再拖累你的写入变得可见。
- `command-service.ts`：写命令在返回回执前同步 materialize 自己的 session。
- **回执不再撒谎**：无法 materialize 时，回执明确带 `pending_materialization` **以及下一条该敲的命令**（`ha materializer run --json`），JSON 和纯文本都有。这兑现了体验设计宪章（`dec_01KXGDXZG03JZRGTW8V91H11ER`）第二原则：**任何拒绝性回执，若未告知"下一步敲什么"，它本身就是缺陷。**
- `materializer run`：不再 auto-start 一个 daemon 然后被那个 daemon 的锁拒绝（**它启动了那个会拒绝它的东西**）。修复 `data.warnings` 回执契约错误——正是它让这条命令**在干完活之后**被自己的校验器判为失败。
- 测试：新增 `materializer-recovery-cli.test.ts`（158 行），以及 materializer / daemon-runtime / 回执契约的覆盖。

## 任务与范围

- Harness 任务：`task_01KXGFQTSBJ319VZ87J323SHPQ`（XD-3，隶属 milestone `task_01KXGFHB32BZREHTY71F0AMSF6` / PLT-XD）
- 分支：`fix/materializer-p0`
- 公开范围：`packages/kernel/src/store`、`packages/cli/src/daemon`、测试
- 私有计划/证据已更新：是
- 范围外：registry 命名空间、身份边界、daemon stop/status 语义（路由至 XD-2）

## 版本影响

- 版本：无变更（既有契约内的缺陷修复）
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 权威依据：`dec_01KXGDXZG03JZRGTW8V91H11ER`（体验设计宪章，standing policy）
- Break-glass：否

## 验证

- `origin/main` 基线 SHA：`5d563bf28b8ad33b993dfb0172d0fb4bae7e9f87`
- 与 `origin/main` 的 merge-base：`5d563bf28b8ad33b993dfb0172d0fb4bae7e9f87`
- [x] `npm run check:local`（28.7 秒，全绿）
- [x] 248 fast tests / 138 contract tests / 44-44 integration / 17-17 daemon runtime
- 未跑：本分支上的 `npm run check:ci`——CI 是权威，由它在此运行。

**端到端证明（没有手动跑 materializer，没有等待，没有重试）：**

```
decision propose -> {"ok":true,"entity":{"id":"dec_p0_final_e2e"}}
decision show    -> {"ok":true,"entity":{"id":"dec_p0_final_e2e"}}   # 立刻
filesystem       -> harness/decisions/decision-dec_p0_final_e2e/decision.md   # 存在
ledger HEAD      -> 464750d  materializer: merge session ...
```

## 复核证据

- 自审：CEO 复核了 diff。这个修复是**移动一行**，不是**加一层**——`processed += 1` 本来就该在成功分支里。
- 阻塞性发现：无

## 残余风险

daemon 生命周期的观察竞态（`stop` 与 `status` 报不同 PID、autostart 立刻重生）**未在本 PR 修复**，连同全局 registry 缺失的命名空间与 CAS，一并路由至 XD-2。
