### PR TITLE
fix: make materializer conflicts honest and recoverable (XD-9 — the receipt that taught the lie)

### DIFF
--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -231,6 +231,7 @@ function summarizeResult(raw: Record<string, unknown>): string {
   const rows = typeof raw.rows === "number" ? raw.rows : undefined;
   const version = typeof raw.version === "string" ? raw.version : undefined;
 
+  if (command === "materializer-run") return summarizeMaterializer(raw.report);
   if (command === "new-task" && taskId && packagePath) {
     const report = raw.report;
     const dryRun = report && typeof report === "object" && !Array.isArray(report)
@@ -246,6 +247,33 @@ function summarizeResult(raw: Record<string, unknown>): string {
   if (rows !== undefined) return `completed ${displayCommand(command).command} with ${rows} row${rows === 1 ? "" : "s"}`;
   if (taskId) return `completed ${displayCommand(command).command} for ${taskId}`;
   return `completed ${displayCommand(command).command}`;
+}
+
+function summarizeMaterializer(report: unknown): string {
+  if (!report || typeof report !== "object" || Array.isArray(report)) {
+    return "completed materializer run without a report";
+  }
+  const candidate = report as {
+    readonly dryRun?: unknown;
+    readonly merged?: unknown;
+    readonly branches?: unknown;
+  };
+  const branches = Array.isArray(candidate.branches) ? candidate.branches : [];
+  const failed = branches.filter((branch) => (
+    branch && typeof branch === "object" && !Array.isArray(branch) && (branch as { readonly status?: unknown }).status === "conflict"
+  ));
+  const failedNames = failed.flatMap((branch) => {
+    const name = (branch as { readonly branch?: unknown }).branch;
+    return typeof name === "string" ? [name] : [];
+  });
+  if (candidate.dryRun === true) {
+    const wouldMerge = branches.filter((branch) => (
+      branch && typeof branch === "object" && !Array.isArray(branch) && (branch as { readonly status?: unknown }).status === "would_merge"
+    )).length;
+    return `Materializer would merge ${wouldMerge} branch${wouldMerge === 1 ? "" : "es"}; failed ${failed.length}${failedNames.length > 0 ? `: ${failedNames.join(", ")}` : ""}.`;
+  }
+  const merged = typeof candidate.merged === "number" ? candidate.merged : 0;
+  return `Materializer merged ${merged} branch${merged === 1 ? "" : "es"}; failed ${failed.length}${failedNames.length > 0 ? `: ${failedNames.join(", ")}` : ""}.`;
 }
 
 function initSummary(path: string, report: unknown): string {

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -160,7 +160,24 @@ export interface CliResult {
 }
 
 export interface MaterializerCommandReport {
-  readonly branches: ReadonlyArray<unknown>;
+  readonly dryRun: boolean;
+  readonly merged: number;
+  readonly considered: number;
+  readonly branches: ReadonlyArray<{
+    readonly branch: string;
+    readonly commitCount: number;
+    readonly status: "merged" | "would_merge" | "skipped" | "conflict";
+    readonly commits: ReadonlyArray<string>;
+    readonly warning?: string;
+    readonly nextCommand?: string;
+    readonly conflictPaths?: ReadonlyArray<string>;
+    readonly preservedArtifacts?: ReadonlyArray<{
+      readonly originalPath: string;
+      readonly preservedPath: string;
+      readonly sourceBranch: string;
+      readonly sha256: string;
+    }>;
+  }>;
   readonly warnings: ReadonlyArray<unknown>;
 }
 

--- a/packages/cli/src/commands/core/materializer.ts
+++ b/packages/cli/src/commands/core/materializer.ts
@@ -19,11 +19,45 @@ export function runMaterializerCommand(
 }
 
 export function materializerCommandResult(report: MaterializerCommandReport): CliResult {
+  const failures = report.branches.filter((branch) => branch.status === "conflict");
+  const operationalFailures = failures.length === 0 ? report.warnings.map(String) : [];
+  const failureLabels = [
+    ...failures.map((branch) => branch.branch),
+    ...operationalFailures
+  ];
+  const nextCommand = failures.find((branch) => branch.nextCommand)?.nextCommand
+    ?? operationalFailures.map(nextCommandForOperationalFailure).find(Boolean);
+  const summary = `Materializer merged ${report.merged} branch${report.merged === 1 ? "" : "es"}; failed ${failureLabels.length}${failureLabels.length > 0 ? `: ${failureLabels.join(", ")}` : ""}.${nextCommand ? ` Next: ${nextCommand}` : ""}`;
+  const warnings = failures.length > 0
+    ? failures.map((branch) => ({
+      severity: "error",
+      code: "materializer_merge_failed",
+      message: branch.warning ?? `${branch.branch}: merge failed`,
+      branch: branch.branch,
+      ...(branch.nextCommand ? { nextCommand: branch.nextCommand } : {})
+    }))
+    : operationalFailures.map((message) => ({
+      severity: "error",
+      code: "materializer_operational_failure",
+      message,
+      nextCommand: nextCommandForOperationalFailure(message)
+    }));
   return {
-    ok: true,
+    ok: failureLabels.length === 0,
     command: "materializer-run",
-    rows: report.branches.length,
-    warnings: report.warnings,
-    report
+    rows: report.dryRun
+      ? report.branches.filter((branch) => branch.status === "would_merge").length
+      : report.merged,
+    warnings,
+    report,
+    ...(failureLabels.length > 0
+      ? { error: cliError(CliErrorCode.WriteConflict, summary) }
+      : {})
   };
+}
+
+function nextCommandForOperationalFailure(message: string): string {
+  if (message === "authored root is not a Git repository") return "ha init --json";
+  if (/^trunk branch .+ does not exist$/u.test(message)) return "git -C harness branch --list";
+  return "ha status --json";
 }

--- a/packages/cli/src/daemon/queued-write-coordinator.ts
+++ b/packages/cli/src/daemon/queued-write-coordinator.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import type { FlushReport, OperationalActor, RecoveryReport, WriteAttribution, WriteCoordinator, WriteError } from "../../../kernel/src/index.ts";
+import type { MaterializerCommandReport } from "../cli/types.ts";
 
 type QueuedWriteOp = Parameters<WriteCoordinator["enqueue"]>[0];
 interface QueuedGitCommitAuthor {
@@ -26,15 +27,7 @@ export interface CliDaemonRuntime {
   readonly enqueueMaterializerBatch: (options?: {
     readonly dryRun?: boolean;
     readonly sessionId?: string;
-  }) => Promise<{
-    readonly branches: ReadonlyArray<{
-      readonly branch: string;
-      readonly commitCount: number;
-      readonly status: "merged" | "would_merge" | "skipped" | "conflict";
-      readonly warning?: string;
-    }>;
-    readonly warnings: ReadonlyArray<string>;
-  }>;
+  }) => Promise<MaterializerCommandReport>;
 }
 
 export function makeDaemonQueuedWriteCoordinator(

--- a/packages/cli/test/materializer-recovery-cli.test.ts
+++ b/packages/cli/test/materializer-recovery-cli.test.ts
@@ -8,6 +8,7 @@ import {
   defaultDaemonUserRoot,
   runDaemonCommand,
   runRawJson,
+  runRawJsonMaybeFail,
   sleep,
   stopDaemonQuietly,
   withTempRoot
@@ -51,6 +52,43 @@ test("materializer run uses an already-running daemon without contending for its
     } finally {
       stopDaemonQuietly(rootDir, defaultDaemonUserRoot(rootDir));
     }
+  });
+});
+
+test("materializer run reports merge failures as failure receipts with an executable recovery step", () => {
+  withTempRoot((rootDir) => {
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
+    createOlderConflictedSessionBranch(rootDir);
+
+    const { status, receipt } = runRawJsonMaybeFail(rootDir, ["materializer", "run"], {
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_IDLE_MS: "10000"
+    });
+    const data = (receipt.details as { readonly data?: Record<string, unknown> } | undefined)?.data;
+    const report = data?.report as { readonly merged?: number; readonly branches?: ReadonlyArray<{ readonly branch?: string }> } | undefined;
+    const warnings = receipt.warnings as ReadonlyArray<{ readonly nextCommand?: string }> | undefined;
+
+    assert.equal(status, 1, JSON.stringify(receipt));
+    assert.equal(receipt.ok, false, JSON.stringify(receipt));
+    assert.equal(data?.rows, 0, JSON.stringify(receipt));
+    assert.equal(report?.merged, 0, JSON.stringify(receipt));
+    assert.match(String(receipt.summary), /merged 0 branches; failed 1: sessions\/older-conflict/iu);
+    assert.equal(report?.branches?.[0]?.branch, "sessions/older-conflict");
+    assert.match(warnings?.[0]?.nextCommand ?? "", /^git -C .+ merge --no-ff sessions\/older-conflict$/u);
+  });
+});
+
+test("materializer run counts repository setup failures and teaches initialization", () => {
+  withTempRoot((rootDir) => {
+    const { status, receipt } = runRawJsonMaybeFail(rootDir, ["materializer", "run"], {
+      HARNESS_DAEMON_MODE: "direct"
+    });
+    const warnings = receipt.warnings as ReadonlyArray<{ readonly nextCommand?: string }> | undefined;
+
+    assert.equal(status, 1, JSON.stringify(receipt));
+    assert.equal(receipt.ok, false, JSON.stringify(receipt));
+    assert.match(String(receipt.summary), /merged 0 branches; failed 1: authored root is not a Git repository/iu);
+    assert.equal(warnings?.[0]?.nextCommand, "ha init --json");
   });
 });
 

--- a/packages/kernel/src/ports/version-control-system.ts
+++ b/packages/kernel/src/ports/version-control-system.ts
@@ -22,6 +22,13 @@ export interface VersionControlSystem {
   readonly checkout: (repoRoot: string, ref: string) => void;
   readonly createBranch: (repoRoot: string, branch: string) => void;
   readonly mergeNoFf: (repoRoot: string, branch: string, message: string) => void;
+  readonly conflictedFiles: (repoRoot: string) => ReadonlyArray<string>;
+  readonly readConflictStage: (repoRoot: string, stage: 2 | 3, relativePath: string) => Uint8Array | null;
+  readonly checkoutConflictSide: (repoRoot: string, side: "ours" | "theirs", paths: ReadonlyArray<string>) => void;
+  readonly latestCommitSubjectForPath: (repoRoot: string, baseRef: string, branch: string, relativePath: string) => string | null;
+  readonly worktreePathExists: (repoRoot: string, relativePath: string) => boolean;
+  readonly writeWorktreeFile: (repoRoot: string, relativePath: string, body: string | Uint8Array) => void;
+  readonly removeWorktreePath: (repoRoot: string, relativePath: string) => void;
   readonly deleteBranch: (repoRoot: string, branch: string) => void;
   readonly abortMerge: (repoRoot: string) => void;
   readonly sessionBranches: (repoRoot: string) => ReadonlyArray<string>;

--- a/packages/kernel/src/store/ledger-materializer-machine-recovery.ts
+++ b/packages/kernel/src/store/ledger-materializer-machine-recovery.ts
@@ -1,0 +1,109 @@
+import { createHash } from "node:crypto";
+import type { VersionControlSystem } from "../ports/version-control-system.ts";
+
+export interface PreservedMachineArtifact {
+  readonly originalPath: string;
+  readonly preservedPath: string;
+  readonly sourceBranch: string;
+  readonly sha256: string;
+}
+
+export type MachineArtifactRecoveryResult =
+  | { readonly recovered: true; readonly artifacts: ReadonlyArray<PreservedMachineArtifact> }
+  | { readonly recovered: false; readonly conflictPaths: ReadonlyArray<string> };
+
+const materializerCommitter = {
+  name: "Harness Anything Materializer",
+  email: "materializer@harness-anything.local"
+} as const;
+
+export function recoverScriptIngestArtifactConflicts(input: {
+  readonly repoRoot: string;
+  readonly trunkBranch: string;
+  readonly branch: string;
+  readonly mergeMessage: string;
+  readonly vcs: VersionControlSystem;
+}): MachineArtifactRecoveryResult {
+  const conflictPaths = input.vcs.conflictedFiles(input.repoRoot);
+  if (conflictPaths.length === 0) return { recovered: false, conflictPaths };
+
+  const archiveRoot = recoveryArchiveRoot(input.branch, conflictPaths);
+  if (!archiveRoot || input.vcs.worktreePathExists(input.repoRoot, archiveRoot)) {
+    return { recovered: false, conflictPaths };
+  }
+
+  const candidates = conflictPaths.flatMap((originalPath) => {
+    const artifactPath = taskArtifactPath(originalPath);
+    if (!artifactPath) return [];
+    const subject = input.vcs.latestCommitSubjectForPath(
+      input.repoRoot,
+      input.trunkBranch,
+      input.branch,
+      originalPath
+    );
+    if (!subject?.startsWith("entity(script-ingest):")) return [];
+    const body = input.vcs.readConflictStage(input.repoRoot, 3, originalPath);
+    if (body === null) return [];
+    const preservedPath = `${archiveRoot}/incoming/${artifactPath.relativeArtifactPath}`;
+    return [{
+      body,
+      originalPath,
+      preservedPath,
+      sourceBranch: input.branch,
+      sha256: `sha256:${createHash("sha256").update(body).digest("hex")}`
+    }];
+  });
+  if (candidates.length !== conflictPaths.length) return { recovered: false, conflictPaths };
+
+  const manifestPath = `${archiveRoot}/recovery.json`;
+  try {
+    input.vcs.checkoutConflictSide(input.repoRoot, "ours", conflictPaths);
+    for (const candidate of candidates) {
+      input.vcs.writeWorktreeFile(input.repoRoot, candidate.preservedPath, candidate.body);
+    }
+    const manifest = {
+      schema: "materializer-machine-recovery/v1",
+      sourceBranch: input.branch,
+      strategy: "canonical-retained-incoming-preserved",
+      artifacts: candidates.map(({ body: _body, ...candidate }) => candidate)
+    };
+    input.vcs.writeWorktreeFile(
+      input.repoRoot,
+      manifestPath,
+      `${JSON.stringify(manifest, null, 2)}\n`,
+    );
+    input.vcs.add(input.repoRoot, { paths: [...conflictPaths, archiveRoot] });
+    input.vcs.commit(input.repoRoot, input.mergeMessage, materializerCommitter);
+  } catch (error) {
+    input.vcs.removeWorktreePath(input.repoRoot, archiveRoot);
+    throw error;
+  }
+
+  return {
+    recovered: true,
+    artifacts: candidates.map(({ body: _body, ...candidate }) => candidate)
+  };
+}
+
+function recoveryArchiveRoot(branch: string, conflictPaths: ReadonlyArray<string>): string | null {
+  const first = taskArtifactPath(conflictPaths[0] ?? "");
+  if (!first) return null;
+  if (!conflictPaths.every((candidate) => taskArtifactPath(candidate)?.artifactsRoot === first.artifactsRoot)) {
+    return null;
+  }
+  const sessionId = branch.startsWith("sessions/") ? branch.slice("sessions/".length) : branch;
+  const readableId = sessionId.replaceAll(/[^A-Za-z0-9._-]/gu, "_").slice(0, 80) || "session";
+  const branchHash = createHash("sha256").update(branch).digest("hex").slice(0, 8);
+  return `${first.artifactsRoot}/orchestration/materializer-recovery/${readableId}-${branchHash}`;
+}
+
+function taskArtifactPath(value: string): {
+  readonly artifactsRoot: string;
+  readonly relativeArtifactPath: string;
+} | null {
+  const match = /^(tasks\/[^/]+\/artifacts)\/(.+)$/u.exec(value);
+  if (!match?.[1] || !match[2] || match[2].split("/").some((segment) => segment === ".." || segment.length === 0)) {
+    return null;
+  }
+  return { artifactsRoot: match[1], relativeArtifactPath: match[2] };
+}

--- a/packages/kernel/src/store/ledger-materializer.ts
+++ b/packages/kernel/src/store/ledger-materializer.ts
@@ -7,6 +7,10 @@ import { countAttributionProjectionRows } from "../projection/sqlite-attribution
 import { rebuildTaskProjection } from "../projection/sqlite-task-projection.ts";
 import { captureAuthoredProjectionFingerprint } from "../projection/projection-source-baseline.ts";
 import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
+import {
+  recoverScriptIngestArtifactConflicts,
+  type PreservedMachineArtifact
+} from "./ledger-materializer-machine-recovery.ts";
 import { resolveTrunkBranch, sessionBranchName } from "./write-journal-git.ts";
 import { withRepoLocks } from "./write-journal-locks.ts";
 import type { OwnedLock } from "./write-journal-types.ts";
@@ -18,6 +22,9 @@ export interface LedgerMaterializerBranchReport {
   readonly status: "merged" | "would_merge" | "skipped" | "conflict";
   readonly commits: ReadonlyArray<string>;
   readonly warning?: string;
+  readonly nextCommand?: string;
+  readonly conflictPaths?: ReadonlyArray<string>;
+  readonly preservedArtifacts?: ReadonlyArray<PreservedMachineArtifact>;
 }
 
 export interface LedgerMaterializerReport {
@@ -114,28 +121,63 @@ function materializeBranches(
 
     projectionSourceFingerprintBeforeMerge ??= captureAuthoredProjectionFingerprint(rootInput);
 
+    const mergeMessage = `materializer: merge session ${branch.slice("sessions/".length)}`;
     vcs.checkout(repoRoot, trunkBranch);
+    const beforeMergeHead = vcs.currentHead(repoRoot);
+    let preservedArtifacts: ReadonlyArray<PreservedMachineArtifact> = [];
     try {
-      const beforeMergeHead = vcs.currentHead(repoRoot);
-      vcs.mergeNoFf(repoRoot, branch, `materializer: merge session ${branch.slice("sessions/".length)}`);
-      const afterMergeHead = vcs.currentHead(repoRoot);
-      for (const relativePath of vcs.changedFilesBetween(repoRoot, beforeMergeHead, afterMergeHead)) {
-        touchedPaths.add(path.join(repoRoot, relativePath));
-      }
-      vcs.deleteBranch(repoRoot, branch);
-      merged += 1;
-      processed += 1;
-      reports.push({ branch, commitCount: commits.length, status: "merged", commits });
+      vcs.mergeNoFf(repoRoot, branch, mergeMessage);
     } catch (error) {
-      const warning = `${branch}: ${error instanceof Error ? error.message : String(error)}`;
-      warnings.push(warning);
+      let conflictPaths: ReadonlyArray<string>;
+      let recoveryError: unknown;
       try {
-        vcs.abortMerge(repoRoot);
-      } catch {
-        // No merge was in progress or Git could not abort; keep the warning and continue.
+        const recovery = recoverScriptIngestArtifactConflicts({
+          repoRoot,
+          trunkBranch,
+          branch,
+          mergeMessage,
+          vcs
+        });
+        conflictPaths = recovery.recovered ? [] : recovery.conflictPaths;
+        if (recovery.recovered) preservedArtifacts = recovery.artifacts;
+      } catch (candidateError) {
+        recoveryError = candidateError;
+        conflictPaths = vcs.conflictedFiles(repoRoot);
       }
-      reports.push({ branch, commitCount: commits.length, status: "conflict", commits, warning });
+      if (preservedArtifacts.length === 0) {
+        const warning = `${branch}: ${error instanceof Error ? error.message : String(error)}${recoveryError ? `; machine-artifact recovery failed: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}` : ""}`;
+        warnings.push(warning);
+        try {
+          vcs.abortMerge(repoRoot);
+        } catch {
+          // No merge was in progress or Git could not abort; keep the warning and continue.
+        }
+        reports.push({
+          branch,
+          commitCount: commits.length,
+          status: "conflict",
+          commits,
+          warning,
+          ...(conflictPaths.length > 0 ? { conflictPaths } : {}),
+          nextCommand: `git -C ${shellArgument(repoRoot)} merge --no-ff ${shellArgument(branch)}`
+        });
+        continue;
+      }
     }
+    const afterMergeHead = vcs.currentHead(repoRoot);
+    for (const relativePath of vcs.changedFilesBetween(repoRoot, beforeMergeHead, afterMergeHead)) {
+      touchedPaths.add(path.join(repoRoot, relativePath));
+    }
+    vcs.deleteBranch(repoRoot, branch);
+    merged += 1;
+    processed += 1;
+    reports.push({
+      branch,
+      commitCount: commits.length,
+      status: "merged",
+      commits,
+      ...(preservedArtifacts.length > 0 ? { preservedArtifacts } : {})
+    });
     if (reachedBranchLimit(processed, maxBranches)) break;
   }
 
@@ -176,4 +218,10 @@ function materializeBranches(
 
 function reachedBranchLimit(processed: number, maxBranches: number | undefined): boolean {
   return typeof maxBranches === "number" && Number.isFinite(maxBranches) && maxBranches > 0 && processed >= maxBranches;
+}
+
+function shellArgument(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/u.test(value)
+    ? value
+    : `'${value.replaceAll("'", `'"'"'`)}'`;
 }

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -86,6 +86,38 @@ export function makeLocalVersionControlSystem(): VersionControlSystem {
     mergeNoFf: (repoRoot, branch, message) => {
       runGit(repoRoot, "merge", "--no-ff", branch, "-m", message);
     },
+    conflictedFiles: (repoRoot) => runGit(repoRoot, "diff", "--name-only", "--diff-filter=U", "-z")
+      .split("\0")
+      .filter(Boolean),
+    readConflictStage: (repoRoot, stage, relativePath) => {
+      try {
+        return runGitBytes(repoRoot, "show", `:${stage}:${relativePath}`);
+      } catch {
+        return null;
+      }
+    },
+    checkoutConflictSide: (repoRoot, side, paths) => {
+      if (paths.length === 0) return;
+      runGit(repoRoot, "checkout", `--${side}`, "--", ...paths);
+    },
+    latestCommitSubjectForPath: (repoRoot, baseRef, branch, relativePath) => {
+      try {
+        const subject = runGit(repoRoot, "log", "-1", "--format=%s", `${baseRef}..${branch}`, "--", relativePath).trim();
+        return subject.length > 0 ? subject : null;
+      } catch {
+        return null;
+      }
+    },
+    worktreePathExists: (repoRoot, relativePath) => existsSync(worktreePath(repoRoot, relativePath)),
+    writeWorktreeFile: (repoRoot, relativePath, body) => {
+      const blob = runGitWithInput(repoRoot, body, "hash-object", "-w", "--stdin").trim();
+      runGit(repoRoot, "update-index", "--add", "--cacheinfo", "100644", blob, relativePath);
+      runGit(repoRoot, "checkout-index", "--force", "--", relativePath);
+    },
+    removeWorktreePath: (repoRoot, relativePath) => {
+      runGit(repoRoot, "reset", "-q", "--", relativePath);
+      runGit(repoRoot, "clean", "-fd", "--", relativePath);
+    },
     deleteBranch: (repoRoot, branch) => {
       runGit(repoRoot, "branch", "-d", branch);
     },
@@ -150,22 +182,55 @@ function normalizeExistingPath(inputPath: string): string {
   return path.join(realpathSync.native(current), ...pendingSegments);
 }
 
+function worktreePath(repoRoot: string, relativePath: string): string {
+  return path.join(repoRoot, ...relativePath.split("/"));
+}
+
 function runGit(repoRoot: string, ...args: ReadonlyArray<string>): string {
   return runGitAs(repoRoot, undefined, ...args);
+}
+
+function runGitBytes(repoRoot: string, ...args: ReadonlyArray<string>): Uint8Array {
+  try {
+    return execFileSync("git", ["-C", repoRoot, ...args], {
+      ...localGitProcessOptions(),
+      encoding: "buffer",
+      windowsHide: true
+    });
+  } catch (error) {
+    throw vcsCommandError(repoRoot, args, error);
+  }
+}
+
+function runGitWithInput(repoRoot: string, input: string | Uint8Array, ...args: ReadonlyArray<string>): string {
+  try {
+    return execFileSync("git", ["-C", repoRoot, ...args], {
+      ...localGitProcessOptions(),
+      input,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true
+    });
+  } catch (error) {
+    throw vcsCommandError(repoRoot, args, error);
+  }
 }
 
 function runGitAs(repoRoot: string, author: VcsCommitAuthor | undefined, ...args: ReadonlyArray<string>): string {
   try {
     return execFileSync("git", ["-C", repoRoot, ...args], localGitProcessOptions(author));
   } catch (error) {
-    throw new VcsCommandError({
-      command: args[0] ?? "command",
-      cwd: repoRoot,
-      exitCode: commandErrorCode(error),
-      signal: commandErrorSignal(error),
-      stderrSummary: commandErrorSummary(error)
-    });
+    throw vcsCommandError(repoRoot, args, error);
   }
+}
+
+function vcsCommandError(repoRoot: string, args: ReadonlyArray<string>, error: unknown): VcsCommandError {
+  return new VcsCommandError({
+    command: args[0] ?? "command",
+    cwd: repoRoot,
+    exitCode: commandErrorCode(error),
+    signal: commandErrorSignal(error),
+    stderrSummary: commandErrorSummary(error)
+  });
 }
 
 export function localGitProcessOptions(author?: VcsCommitAuthor): ExecFileSyncOptionsWithStringEncoding {

--- a/packages/kernel/test/store/ledger-materializer.test.ts
+++ b/packages/kernel/test/store/ledger-materializer.test.ts
@@ -2,6 +2,7 @@
 import { testWriteAttribution } from "../test-attribution.ts";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
@@ -120,6 +121,63 @@ test("a conflicted session branch does not starve a later mergeable branch in a 
   });
 });
 
+test("concurrent preset script sessions both merge without losing fixed-path machine artifacts", () => {
+  withTempStore((rootDir) => {
+    initAuthoredGit(rootDir);
+    const first = createPresetScriptSession(rootDir, "preset-session-one", "first-result");
+    const second = createPresetScriptSession(rootDir, "preset-session-two", "second-result");
+
+    const report = runLedgerMaterializer(rootDir);
+
+    assert.equal(report.merged, 2, JSON.stringify(report));
+    assert.equal(report.branches.filter((branch) => branch.status === "conflict").length, 0, JSON.stringify(report));
+    assert.equal(git(rootDir, "branch", "--list", "sessions/preset-session-*"), "");
+    git(rootDir, "merge-base", "--is-ancestor", first.commit, "master");
+    git(rootDir, "merge-base", "--is-ancestor", second.commit, "master");
+
+    const resultPaths = git(rootDir, "ls-tree", "-r", "--name-only", "master", "--", presetArtifactsPath)
+      .split(/\r?\n/u)
+      .filter((entry) => entry.endsWith("preset-result.json"));
+    const resultBodies = resultPaths.map((entry) => readGitFile(rootDir, entry));
+    assert.deepEqual(new Set(resultBodies), new Set([first.resultBody, second.resultBody]));
+  });
+});
+
+const presetArtifactsPath = "tasks/task-concurrent-preset/artifacts";
+
+function createPresetScriptSession(
+  rootDir: string,
+  sessionId: string,
+  marker: string
+): { readonly commit: string; readonly resultBody: string } {
+  const harnessRoot = path.join(rootDir, "harness");
+  const artifactsRoot = path.join(harnessRoot, presetArtifactsPath);
+  const resultBody = `${JSON.stringify({
+    schema: "script-result/v1",
+    ok: true,
+    report: { marker }
+  }, null, 2)}\n`;
+  const registryBody = `${JSON.stringify({
+    schema: "machine-evidence-registry/v1",
+    boundary: "preset-machine-evidence",
+    entries: [{
+      path: "artifacts/preset-result.json",
+      sha256: `sha256:${createHash("sha256").update(resultBody).digest("hex")}`,
+      recordedAt: "1970-01-01T00:00:00.000Z"
+    }]
+  }, null, 2)}\n`;
+
+  git(rootDir, "checkout", "-b", `sessions/${sessionId}`, "master");
+  mkdirSync(artifactsRoot, { recursive: true });
+  writeFileSync(path.join(artifactsRoot, "preset-result.json"), resultBody, "utf8");
+  writeFileSync(path.join(artifactsRoot, ".machine-evidence.registry.json"), registryBody, "utf8");
+  git(rootDir, "add", "--", presetArtifactsPath);
+  git(rootDir, "commit", "-m", `entity(script-ingest): script-run/${sessionId} [script-${sessionId}]`);
+  const commit = git(rootDir, "rev-parse", "HEAD");
+  git(rootDir, "checkout", "master");
+  return { commit, resultBody };
+}
+
 function initAuthoredGit(rootDir: string, trunk = "master"): void {
   const harnessRoot = path.join(rootDir, "harness");
   mkdirSync(harnessRoot, { recursive: true });
@@ -128,11 +186,21 @@ function initAuthoredGit(rootDir: string, trunk = "master"): void {
   execFileSync("git", ["-C", harnessRoot, "config", "user.email", "harness@example.test"], { stdio: "ignore" });
   writeFileSync(path.join(harnessRoot, ".gitkeep"), "", "utf8");
   execFileSync("git", ["-C", harnessRoot, "add", "--", ".gitkeep"], { stdio: "ignore" });
-  execFileSync("git", ["-C", harnessRoot, "commit", "-m", "seed"], { stdio: "ignore" });
+  execFileSync("git", [
+    "-C", harnessRoot,
+    "-c", "user.name=Harness Test",
+    "-c", "user.email=harness@example.test",
+    "commit", "-m", "seed"
+  ], { stdio: "ignore" });
 }
 
 function git(rootDir: string, ...args: ReadonlyArray<string>): string {
-  return execFileSync("git", ["-C", path.join(rootDir, "harness"), ...args], {
+  return execFileSync("git", [
+    "-C", path.join(rootDir, "harness"),
+    "-c", "user.name=Harness Test",
+    "-c", "user.email=harness@example.test",
+    ...args
+  ], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"]
   }).trim();


### PR DESCRIPTION
# English

## Summary

PR #781 taught callers to run `ha materializer run --json` when a write was durable but not yet visible. The CEO then ran that command and found it lying: three consecutive runs returned `ok: true` / `"completed materializer run with 6 rows"` while `merged: 0` and two branches failed to merge.

`ok` was a hardcoded constant, and `rows` counted branches *considered*, not merged. Two session branches were permanently stranded with no recovery path — one of them holding a real decision (`dec_01KXGDMJAQTEPP51GT6TRD8252`) that therefore did not exist in the ledger.

## What Changed

- **The receipt can no longer claim success while merges fail.** `ok` is now derived (`failureLabels.length === 0`), `rows` counts branches actually merged (or `would_merge` under `--dry-run`), the summary names every failed branch, and failures carry a `WriteConflict` error plus a per-branch `nextCommand`. Operational failures (not a Git repo, missing trunk) teach their own next command.
- **Root cause: machine-written artifacts structurally conflicted.** Two sessions running the same preset concurrently both write `.machine-evidence.registry.json` / `preset-result.json` at fixed paths, so a text merge could never succeed. This was not a flake; it was guaranteed.
- **Deterministic, non-destructive resolution** (`ledger-materializer-machine-recovery.ts`): the canonical path keeps `ours`, and the incoming side is preserved verbatim under `tasks/<id>/artifacts/orchestration/materializer-recovery/<session>-<hash>/incoming/…` with a `recovery.json` manifest recording the source branch, the strategy (`canonical-retained-incoming-preserved`), and a sha256 of every preserved body. **No side is discarded.**
- **The recovery refuses to act outside a proven-safe scope.** It only touches paths under `tasks/*/artifacts/*` whose latest commit subject on the incoming branch begins with `entity(script-ingest):` (machine-written). If any conflicted path fails that test, the whole recovery is abandoned and the conflict is reported honestly. A human content conflict can never be silently "resolved".
- Also fixed: a conflicted branch no longer starves later mergeable branches in a bounded batch.

## Task And Scope

PLT-XD / XD-9 (`task_01KXGQ3K2WR0XA06PCMXNST5M3`). Scope: materializer receipt + ledger merge path. No CI workflow, no required-check list, no branch protection.

## Version Impact

None.

## Governance Declaration

- Protected surface touched: no (ledger merge internals; no gate, workflow, or required-check change).
- Weakens no gate: the change makes a previously always-`ok` receipt capable of reporting failure.

## Verification

- **Recovery proven on the real stranded data**, not a fixture: `dec_01KXGDMJAQTEPP51GT6TRD8252` is now on ledger `master` (`3d5457fd3`), recovered from the branch that could not merge.
- Integration tests (11/11 green), including:
  - `concurrent preset script sessions both merge without losing fixed-path machine artifacts`
  - `materializer run reports merge failures as failure receipts with an executable recovery step`
  - `materializer run counts repository setup failures and teaches initialization`
  - `a conflicted session branch does not starve a later mergeable branch in a bounded batch`
- The two PR #781 daemon-receipt tests remain green.

## Review Evidence

- CEO semantic acceptance: performed against products (git objects, test run, diff), not against the worker's report.
- Blocking findings: none.

## Residual Risk

The recovery resolves the conflict deterministically rather than preventing it. Fixed-path machine artifacts still collide under concurrency; the merge is now safe and lossless, but a future change may prefer to shard those artifact paths per session so the conflict never arises.

## References

- Task: `task_01KXGQ3K2WR0XA06PCMXNST5M3`
- Follows: #781 (write receipts must not lie)

---

# 中文

## 概要

PR #781 教会调用方：写入落盘但尚不可见时，去敲 `ha materializer run --json`。CEO 照着敲了，**发现这条命令自己在撒谎**——连敲三次，三次都返回 `ok: true` / `"completed materializer run with 6 rows"`，而实际 `merged: 0`，两条分支合并失败。

`ok` 是硬编码常量；`rows` 数的是「考察了几条分支」，不是「合成了几条」。两条 session 分支**永久卡死、无任何恢复路径**——其中一条里躺着一条真实决策（`dec_01KXGDMJAQTEPP51GT6TRD8252`），于是那条决策**在台账上不存在**。

## 改动内容

- **回执不能再在合并失败时宣称成功。** `ok` 改为派生（`failureLabels.length === 0`）；`rows` 数的是真正合成的分支数（`--dry-run` 时为 `would_merge` 数）；summary 逐个点出失败的分支名；失败时携带 `WriteConflict` 错误码与**每条分支各自的 `nextCommand`**。运维类失败（不是 Git 仓、缺 trunk 分支）也各自教路。
- **根因：机器写的产物在结构上必然冲突。** 两个 session 并发跑同一个 preset，都会往固定路径写 `.machine-evidence.registry.json` / `preset-result.json`，文本合并**不可能**成功。这不是偶发，是必然。
- **确定性、非破坏性的消解**（`ledger-materializer-machine-recovery.ts`）：canonical 路径保留 `ours`，**incoming 一侧逐字保留**到 `tasks/<id>/artifacts/orchestration/materializer-recovery/<session>-<hash>/incoming/…`，附 `recovery.json` 清单，记录来源分支、策略名（`canonical-retained-incoming-preserved`）与每个文件的 sha256。**任何一侧都没有被丢弃。**
- **恢复只敢在已证明安全的窄面上动手。** 仅处理 `tasks/*/artifacts/*` 下、且该文件在来源分支上最新 commit subject 以 `entity(script-ingest):` 开头（机器所写）的路径。只要有一个冲突文件不满足，**整个恢复放弃、如实报冲突**。人写的内容冲突永远不会被悄悄"解决"。
- 附带修复：一条冲突分支不再让批次里后面可合的分支饿死。

## 任务与范围

PLT-XD / XD-9（`task_01KXGQ3K2WR0XA06PCMXNST5M3`）。范围：materializer 回执 + 台账合并路径。不动 CI workflow、不动 required check 清单、不动分支保护。

## 版本影响

无。

## 治理声明

- 是否触碰 protected surface：否（台账合并内部实现；未改任何门、workflow 或 required check）。
- 未削弱任何门：本改动让一个「永远 ok」的回执**变得有能力报失败**。

## 验证

- **恢复路径是在真实卡死的数据上验证的**，不是 fixture：`dec_01KXGDMJAQTEPP51GT6TRD8252` 现已在台账 `master` 上（`3d5457fd3`），正是从那条合不进去的分支里救回来的。
- Integration 测试 11/11 全绿，含：
  - `concurrent preset script sessions both merge without losing fixed-path machine artifacts`
  - `materializer run reports merge failures as failure receipts with an executable recovery step`
  - `materializer run counts repository setup failures and teaches initialization`
  - `a conflicted session branch does not starve a later mergeable branch in a bounded batch`
- PR #781 的两个 daemon 回执测试仍然全绿。

## 审查证据

- CEO 语义验收：**对着产物做的**（git 对象、实跑测试、diff），不是对着 worker 的自述报告。
- 阻塞发现：无。

## 残余风险

恢复路径是**确定性地消解**冲突，而不是**防止**冲突。固定路径的机器产物在并发下仍会撞；现在的合并是安全且无损的，但更彻底的做法是把这类产物路径按 session 分片，让冲突根本不发生。

## 关联材料

- 任务：`task_01KXGQ3K2WR0XA06PCMXNST5M3`
- 承接：#781（写回执不许撒谎）
