### PR TITLE
fix: make preset and dry-run checks actually run what they claim to check (XD-8 — end silent checkers)

### DIFF
--- a/packages/cli/src/cli/command-spec/command-spec-extensions.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-extensions.ts
@@ -146,7 +146,7 @@ export const extensionsCommandSpecs = defineCommandSpecs([
   },
   {
     "kind": "preset-run",
-    "usage": "preset run <id> <plan|scaffold|check> --task <id> [--allow-scripts] [--input key=value] [--json]",
+    "usage": "preset run <id> <plan|scaffold|check|audit|gather|render-html> --task <id> [--allow-scripts] [--input key=value] [--json]",
     "options": [{"flag":"--task","description":"Set the task id."},{"flag":"--allow-scripts","description":"Allow preset script execution."},{"flag":"--input","description":"Provide an input path or one script input as key=value; repeat for script inputs."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
     "summary": "Run a preset entrypoint for a task package.",
     "examples": ["harness-anything preset run standard-task plan --task task_01ABC --input mode=smoke"],

--- a/packages/cli/src/cli/dry-run-preview.ts
+++ b/packages/cli/src/cli/dry-run-preview.ts
@@ -1,0 +1,131 @@
+import { cliError, CliErrorCode } from "./error-codes.ts";
+import type { CliResult, ParsedCommand } from "./types.ts";
+
+type Action = ParsedCommand["action"];
+
+export interface DryRunPreview {
+  readonly schema: "command-dry-run-preview/v1";
+  readonly operation: string;
+  readonly paths: ReadonlyArray<{
+    readonly operation: "create" | "modify" | "delete";
+    readonly path: string;
+  }>;
+  readonly summary: Record<string, unknown>;
+  readonly checks: ReadonlyArray<string>;
+}
+
+export function finalizeDryRunResult(action: Action, result: CliResult): CliResult {
+  if (!result.ok || !isDryRunAction(action)) return result;
+  const report = reportRecord(result.report);
+  const candidate: CliResult = {
+    ...result,
+    report: {
+      ...report,
+      preview: buildDryRunPreview(action, result)
+    }
+  };
+  const violation = dryRunPreviewContractViolation(action, candidate);
+  return violation ? {
+    ok: false,
+    command: result.command,
+    error: cliError(CliErrorCode.CommandReceiptContractMismatch, violation)
+  } : candidate;
+}
+
+export function dryRunPreviewContractViolation(action: Action, result: CliResult): string | undefined {
+  if (!result.ok || !isDryRunAction(action)) return undefined;
+  const preview = reportRecord(result.report).preview;
+  if (!preview || typeof preview !== "object" || Array.isArray(preview)) {
+    return `dry-run receipt for command ${action.kind} must include preview. Next: emit command-dry-run-preview/v1 with paths, summary, and checks.`;
+  }
+  const value = preview as Partial<DryRunPreview>;
+  if (value.schema !== "command-dry-run-preview/v1" || !Array.isArray(value.paths) || !value.summary || !Array.isArray(value.checks)) {
+    return `dry-run receipt for command ${action.kind} emitted an invalid preview. Next: emit command-dry-run-preview/v1 with paths, summary, and checks.`;
+  }
+  return undefined;
+}
+
+function reportRecord(report: unknown): Record<string, unknown> {
+  if (report && typeof report === "object" && !Array.isArray(report)) return report as Record<string, unknown>;
+  return report === undefined ? {} : { value: report };
+}
+
+export function isDryRunAction(action: Action): boolean {
+  if ("dryRun" in action && action.dryRun === true) return true;
+  if ("mode" in action && action.mode === "dry-run") return true;
+  return action.kind === "doc-sync-dry-run";
+}
+
+function buildDryRunPreview(action: Action, result: CliResult): DryRunPreview {
+  return {
+    schema: "command-dry-run-preview/v1",
+    operation: action.kind,
+    paths: previewPaths(action, result),
+    summary: previewSummary(action),
+    checks: previewChecks(action)
+  };
+}
+
+function previewPaths(action: Action, result: CliResult): DryRunPreview["paths"] {
+  const operation = pathOperation(action);
+  const values = [
+    result.path,
+    result.packagePath,
+    result.projectionPath,
+    ...(result.generated ?? [])
+  ].filter((value): value is string => typeof value === "string" && value.length > 0);
+  return [...new Set(values)].map((path) => ({ operation, path }));
+}
+
+function pathOperation(action: Action): DryRunPreview["paths"][number]["operation"] {
+  if (action.kind === "preset-uninstall") return "delete";
+  if (
+    action.kind.includes("amend") ||
+    action.kind.includes("invalidate") ||
+    action.kind.includes("relate") ||
+    action.kind.includes("relation") ||
+    action.kind.includes("migrate") ||
+    action.kind.includes("sync") ||
+    action.kind.includes("rebuild") ||
+    action.kind.includes("accept") ||
+    action.kind.includes("reject") ||
+    action.kind.includes("defer") ||
+    action.kind.includes("supersede") ||
+    action.kind.includes("retire")
+  ) return "modify";
+  return "create";
+}
+
+function previewSummary(action: Action): Record<string, unknown> {
+  if (action.kind === "decision-propose") {
+    return {
+      decisionId: action.decisionId ?? "generated",
+      title: action.title,
+      question: action.question,
+      chosenCount: action.chosen.length,
+      rejectedCount: action.rejected.length,
+      claimCount: action.claims.length || 1,
+      fulfillmentCount: action.fulfillments.length,
+      evidenceRelationCount: action.evidenceRelations.length
+    };
+  }
+  return Object.fromEntries(Object.entries(action)
+    .filter(([key]) => !["kind", "dryRun", "mode"].includes(key))
+    .map(([key, value]) => [key, summarizeValue(key, value)]));
+}
+
+function summarizeValue(key: string, value: unknown): unknown {
+  if (Array.isArray(value)) return { count: value.length, items: value };
+  if (value && typeof value === "object") return { fieldCount: Object.keys(value).length, fields: value };
+  if (key === "body" && typeof value === "string") return { characterCount: value.length };
+  return value;
+}
+
+function previewChecks(action: Action): ReadonlyArray<string> {
+  if (action.kind.startsWith("decision-")) return ["decision-schema", "decision-write-policy", "write-coordinator"];
+  if (action.kind === "record-fact" || action.kind === "fact-invalidate") return ["fact-schema", "fact-write-policy", "write-coordinator"];
+  if (action.kind === "new-task" || action.kind === "task-relate") return ["task-contract", "write-coordinator"];
+  if (action.kind === "script-run") return ["script-contract", "read-write-scopes", "output-boundary"];
+  if (action.kind.startsWith("migrate-") || action.kind === "task-contract-migrate") return ["migration-plan", "write-coordinator"];
+  return [];
+}

--- a/packages/cli/src/cli/parsers/extensions-preset.ts
+++ b/packages/cli/src/cli/parsers/extensions-preset.ts
@@ -1,5 +1,6 @@
 import { cliError, CliErrorCode } from "../error-codes.ts";
 import { readInputOptions, readOption } from "../parse-options.ts";
+import { isPresetRunEntrypoint } from "../preset-entrypoint-capabilities.ts";
 import type { CliResult, ParsedCommand } from "../types.ts";
 
 type ParseResult = { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] };
@@ -51,7 +52,7 @@ export function parsePresetArgs(args: ReadonlyArray<string>, rootDir: string, js
   if (args[0] === "preset" && args[1] === "run" && args[2] && args[3]) {
     const taskId = readOption(args, "--task");
     if (!taskId) return { ok: false, error: cliError(CliErrorCode.MissingTask, "preset run requires --task <id>.") };
-    if (args[3] !== "plan" && args[3] !== "scaffold" && args[3] !== "check") {
+    if (!isPresetRunEntrypoint(args[3])) {
       return { ok: false, error: cliError(CliErrorCode.InvalidEntrypoint, `Unknown preset entrypoint: ${args[3]}`) };
     }
     return { ok: true, value: { rootDir, json, action: { kind: "preset-run", presetId: args[2], entrypoint: args[3], taskId, allowScripts: args.includes("--allow-scripts"), inputs: readInputOptions(args) } } };

--- a/packages/cli/src/cli/preset-entrypoint-capabilities.ts
+++ b/packages/cli/src/cli/preset-entrypoint-capabilities.ts
@@ -1,0 +1,16 @@
+export const presetRunEntrypointCapabilities = [
+  "plan",
+  "scaffold",
+  "check",
+  "audit",
+  "gather",
+  "render-html"
+] as const;
+
+export type PresetRunEntrypoint = (typeof presetRunEntrypointCapabilities)[number];
+
+export const presetRunEntrypointUsage = `<${presetRunEntrypointCapabilities.join("|")}>`;
+
+export function isPresetRunEntrypoint(value: string | undefined): value is PresetRunEntrypoint {
+  return typeof value === "string" && presetRunEntrypointCapabilities.some((entrypoint) => entrypoint === value);
+}

--- a/packages/cli/src/cli/receipt-contracts.ts
+++ b/packages/cli/src/cli/receipt-contracts.ts
@@ -7,3 +7,7 @@ export type { CommandKind } from "./command-spec/index.ts";
 export const commandReceiptContractsByKind: Record<CommandKind, CommandReceiptContract> = {
   ...commandSpecMap((entry) => entry.receiptContract)
 };
+
+export const commandDryRunPreviewRequiredByKind: Record<CommandKind, boolean> = {
+  ...commandSpecMap((entry) => entry.options.some((option) => option.flag === "--dry-run"))
+};

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -16,6 +16,7 @@ import type { DecisionAmendField, DecisionAmendOperation } from "../../../kernel
 import type { DecisionClaimFulfillment } from "../../../kernel/src/index.ts";
 import type { HarnessLayoutOverrides } from "../../../kernel/src/index.ts";
 import type { CliError } from "./error-codes.ts";
+import type { PresetRunEntrypoint } from "./preset-entrypoint-capabilities.ts";
 
 export type CheckProfile = "source-package" | "private-harness" | "target-project";
 export type GovernanceRebuildMode = "dry-run" | "archive" | "apply";
@@ -304,7 +305,7 @@ export interface ParsedCommand {
     | { readonly kind: "preset-seed" }
     | { readonly kind: "preset-audit" }
     | { readonly kind: "preset-uninstall"; readonly presetId: string; readonly layer: "project" | "user"; readonly dryRun: boolean }
-    | { readonly kind: "preset-run"; readonly presetId: string; readonly entrypoint: "plan" | "scaffold" | "check"; readonly taskId: string; readonly allowScripts: boolean; readonly inputs: Record<string, string> }
+    | { readonly kind: "preset-run"; readonly presetId: string; readonly entrypoint: PresetRunEntrypoint; readonly taskId: string; readonly allowScripts: boolean; readonly inputs: Record<string, string> }
     | { readonly kind: "preset-action"; readonly presetId: string; readonly actionName: string; readonly taskId: string; readonly allowScripts: boolean; readonly inputs: Record<string, string> }
     | { readonly kind: "script-list"; readonly source?: "user" | "vertical" | "preset"; readonly purpose?: "scaffold" | "generate" | "transform" | "audit"; readonly scriptKind?: "action" | "check" }
     | { readonly kind: "script-inspect"; readonly scriptId: string }

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/architecture-rot-audit/scripts/preset-action.mjs
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/architecture-rot-audit/scripts/preset-action.mjs
@@ -18,6 +18,10 @@ if (context.entrypoint !== "check") throw new Error(`Unsupported architecture-ro
 
 const presetRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const registry = JSON.parse(readFileSync(path.join(presetRoot, "registry", "architecture-rot-registry.json"), "utf8"));
+if (context.validationSmoke === true) {
+  runValidationSmoke(registry);
+  process.exit(0);
+}
 const rootDir = context.paths.projectRoot ?? context.paths.rootDir;
 const artifactsDir = path.join(context.outputRoot, "artifacts");
 const generatedAt = new Date().toISOString();
@@ -153,6 +157,52 @@ function renderSummary(value) {
 
 function writeJson(filePath, value) {
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function runValidationSmoke(value) {
+  const expectedCategories = [
+    "atomicity-outsourcing",
+    "declaration-first-leak",
+    "enforcement-gap",
+    "imaginary-seam",
+    "layer-misalignment",
+    "manual-mirror",
+    "shallow-slice"
+  ];
+  const records = Array.isArray(value.records) ? value.records : [];
+  const categories = [...new Set(records.map((record) => record.category))].sort();
+  const fixed = records.filter((record) => record.status === "fixed");
+  const issues = [];
+  if (records.length !== 17) issues.push(`expected 17 registry records, found ${records.length}`);
+  if (JSON.stringify(categories) !== JSON.stringify(expectedCategories)) {
+    issues.push(`expected categories ${expectedCategories.join(", ")}, found ${categories.join(", ")}`);
+  }
+  if (fixed.length !== 3) issues.push(`expected 3 fixed records, found ${fixed.length}`);
+  if (!fixed.every((record) => /^[0-9a-f]{40}$/u.test(String(record.fixedCommit)) && /^PR#[0-9]+$/u.test(String(record.fixPullRequest)))) {
+    issues.push("fixed records must carry a full commit SHA and PR# anchor");
+  }
+  if (!records.every((record) => record.detection?.detector === record.id)) {
+    issues.push("each registry record must bind its detector to the same id");
+  }
+
+  const artifactsDir = path.join(context.outputRoot, "artifacts");
+  mkdirSync(artifactsDir, { recursive: true });
+  writeJson(path.join(artifactsDir, "preset-result.json"), {
+    schema: "script-result/v1",
+    ok: issues.length === 0,
+    report: {
+      schema: "architecture-rot-validation-smoke-report/v1",
+      status: issues.length === 0 ? "passed" : "blocked",
+      records: records.length,
+      categories: categories.length,
+      fixed: fixed.length,
+      issues
+    },
+    error: issues.length === 0 ? undefined : {
+      code: "architecture_rot_contract_invalid",
+      hint: `Repair the preset registry contract: ${issues.join("; ")}`
+    }
+  });
 }
 
 function toRootRelative(root, filePath) {

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/create-milestone/scripts/dossier-html.mjs
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/create-milestone/scripts/dossier-html.mjs
@@ -1,8 +1,5 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 
 export function renderMilestoneDossierHtml({ paths, artifactsDir, sourcePath, outputPath }) {
   const dossierPath = sourcePath ?? path.join(paths.milestonesRoot, "milestones-summary.md");
@@ -180,11 +177,55 @@ function renderMilestoneRow(item) {
 }
 
 function editorialShellCss() {
-  const templatePath = path.resolve(scriptDir, "..", "..", "..", "templates", "dossier.editorial.shell", "zh-CN.md");
-  const template = readOptional(templatePath);
-  const match = /<style>([\s\S]*?)<\/style>/u.exec(template);
-  if (!match) throw new Error(`Could not read editorial shell CSS at ${templatePath}`);
-  return match[1].trim();
+  // Keep an installed preset package self-contained. The renderer must not
+  // reach back into the builtin vertical's sibling template directory.
+  return `:root {
+  --bg:#faf9f6; --panel:#ffffff; --panel-2:#f5f2ec;
+  --ink:#1f1d1a; --ink-dim:#57534a; --ink-faint:#8a8478;
+  --line:#e7e3db; --line-soft:#efece5; --accent:#5b6b8c;
+  --done:#5f7a55; --defer:#a07238; --reject:#9a4a3f;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Songti SC",Georgia,serif;
+  --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Arial,"PingFang SC",sans-serif;
+  --mono:"SF Mono",SFMono-Regular,ui-monospace,"JetBrains Mono",Menlo,Consolas,monospace;
+}
+:root[data-theme="dark"] {
+  --bg:#1b1d21; --panel:#23262c; --panel-2:#2a2e35;
+  --ink:#e6e3dd; --ink-dim:#a9a39a; --ink-faint:#7d776c;
+  --line:#373b43; --line-soft:#2e3138; --accent:#8896b5;
+  --done:#9bb089; --defer:#c89a5e; --reject:#bf8074;
+}
+* { box-sizing:border-box; margin:0; padding:0; }
+html { scroll-behavior:smooth; }
+body { background:var(--bg); color:var(--ink); font-family:var(--sans); font-size:16px; line-height:1.7; transition:background-color .25s ease,color .25s ease; }
+.wrap { max-width:1080px; margin:0 auto; padding:0 32px; }
+.topbar { position:sticky; top:0; z-index:50; background:var(--bg); border-bottom:1px solid var(--line); }
+.topbar .row { display:flex; align-items:center; justify-content:space-between; padding:14px 0; gap:16px; }
+.brand,nav { display:flex; align-items:center; gap:10px; }
+.brand .dot { width:8px; height:8px; border-radius:2px; background:var(--accent); }
+nav a { color:var(--ink-dim); text-decoration:none; font-size:13px; padding:5px 11px; }
+.theme-toggle { display:inline-flex; align-items:center; justify-content:center; width:34px; height:34px; border:1px solid var(--line); border-radius:6px; background:var(--panel); color:var(--ink-dim); }
+.theme-toggle svg { width:17px; height:17px; }
+.theme-toggle .moon { display:none; }
+:root[data-theme="dark"] .theme-toggle .sun { display:none; }
+:root[data-theme="dark"] .theme-toggle .moon { display:block; }
+.hero { padding:72px 0 52px; border-bottom:1px solid var(--line); }
+.eyebrow,.small-label,.section-num { font-family:var(--mono); font-size:11px; color:var(--ink-faint); letter-spacing:.08em; text-transform:uppercase; }
+h1,h2 { font-family:var(--serif); font-weight:400; line-height:1.2; }
+h1 { font-size:clamp(30px,4.6vw,50px); margin:20px 0 24px; }
+h2 { font-size:clamp(24px,3.2vw,34px); }
+.lede { color:var(--ink-dim); font-family:var(--serif); font-size:18px; }
+code { font-family:var(--mono); font-size:.85em; background:var(--panel-2); color:var(--accent); padding:1px 5px; border:1px solid var(--line); border-radius:3px; }
+.meta-grid { display:grid; grid-template-columns:repeat(4,1fr); margin-top:28px; border:1px solid var(--line); border-radius:8px; overflow:hidden; }
+.meta-cell { padding:18px 22px; border-right:1px solid var(--line); background:var(--panel); }
+.meta-cell:last-child { border-right:0; }
+.meta-cell .k { font-family:var(--mono); font-size:10px; color:var(--ink-faint); text-transform:uppercase; }
+.meta-cell .v { font-size:19px; }
+section { padding:64px 0; border-bottom:1px solid var(--line); }
+.section-head { margin-bottom:30px; }
+.card { border:1px solid var(--line); border-radius:8px; background:var(--panel); padding:22px; }
+footer { padding:44px 0 64px; color:var(--ink-faint); }
+footer .src { font-family:var(--mono); font-size:11px; }
+@media (max-width:760px) { .wrap { padding:0 22px; } .meta-grid { grid-template-columns:1fr; } .meta-cell { border-right:0; border-bottom:1px solid var(--line); } }`;
 }
 
 function splitMarkdownRow(line) {

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/create-milestone/scripts/preset-action.mjs
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/create-milestone/scripts/preset-action.mjs
@@ -21,7 +21,9 @@ const publicRequiredArtifacts = [
 const publicOptionalHtml = { id: "html", role: "html", root: "milestones", path: "milestones.html" };
 mkdirSync(artifactsDir, { recursive: true });
 
-if (entrypoint === "scaffold") {
+if (context.validationSmoke === true && entrypoint !== "render-html") {
+  runSmoke();
+} else if (entrypoint === "scaffold") {
   runScaffold();
 } else if (entrypoint === "render-html") {
   runRenderHtml();
@@ -29,6 +31,28 @@ if (entrypoint === "scaffold") {
   runCheck();
 } else {
   fail("unknown_entrypoint", `Unsupported create-milestone entrypoint: ${entrypoint}`);
+}
+
+function runSmoke() {
+  const contract = requiredArtifacts();
+  const requiredRoles = ["overview", "index", "machine-summary"];
+  const missingRoles = requiredRoles.filter((role) => !contract.some((artifact) => artifact.role === role));
+  const report = {
+    schema: "create-milestone-smoke-report/v1",
+    status: missingRoles.length === 0 ? "passed" : "blocked",
+    entrypoint,
+    requiredRoles,
+    missingRoles
+  };
+  writeFileSync(path.join(artifactsDir, "create-milestone-check.json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeResult({
+    ok: report.status === "passed",
+    report,
+    error: report.status === "passed" ? undefined : {
+      code: "preset_script_result_failed",
+      hint: `create-milestone contract is missing roles: ${missingRoles.join(", ")}`
+    }
+  });
 }
 
 function runScaffold() {

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/github-issue-repair/scripts/preset-action.mjs
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/github-issue-repair/scripts/preset-action.mjs
@@ -8,8 +8,9 @@ const context = JSON.parse(readFileSync(contextPath, "utf8"));
 const artifactsDir = path.join(context.outputRoot, "artifacts");
 mkdirSync(artifactsDir, { recursive: true });
 
-const input = normalizeInputs(context.inputs ?? {});
-const acquisition = await loadIssueSource(input);
+const validationSmoke = context.validationSmoke === true;
+const input = validationSmoke ? validationSmokeInputs() : normalizeInputs(context.inputs ?? {});
+const acquisition = validationSmoke ? validationSmokeSource() : await loadIssueSource(input);
 const selected = selectIssue(acquisition.issues, input);
 const report = buildReport(input, acquisition, selected);
 const ok = report.status === "ready";
@@ -46,6 +47,40 @@ function normalizeInputs(raw) {
     fixtureFile: optionalString(raw.fixtureFile),
     issueJson: optionalString(raw.issueJson),
     fetchMode
+  };
+}
+
+function validationSmokeInputs() {
+  return {
+    repo: "harness-anything/validation-smoke",
+    state: "open",
+    limit: 1,
+    labels: [],
+    excludeLabels: [],
+    issue: "1",
+    fixtureFile: undefined,
+    issueJson: undefined,
+    fetchMode: "disabled"
+  };
+}
+
+function validationSmokeSource() {
+  return {
+    mode: "validation-smoke",
+    ok: true,
+    issues: [normalizeIssue({
+      number: 1,
+      title: "Validate GitHub issue repair intake",
+      state: "open",
+      html_url: "https://example.invalid/harness-anything/validation-smoke/issues/1",
+      user: { login: "validation-smoke" },
+      labels: [{ name: "bug" }],
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+      body: "Reproduction: run `ha preset check github-issue-repair --json`."
+    })],
+    warnings: [],
+    message: "Executed the host-only preset validation smoke without network access."
   };
 }
 

--- a/packages/cli/src/commands/extensions/preset-query.ts
+++ b/packages/cli/src/commands/extensions/preset-query.ts
@@ -13,6 +13,7 @@ import {
   validatePresetManifestForUse
 } from "./state.ts";
 import { decodePresetManifest, invalidExtensionResult, invalidResolvedPresetResult } from "./shared.ts";
+import { presetRuntimeRepairHint, smokePresetEntrypoints } from "./preset-smoke.ts";
 
 export function runPresetValidate(action: {
   readonly manifestPath: string;
@@ -42,11 +43,12 @@ export function runPresetValidate(action: {
 
 export function runPresetList(rootInput: HarnessLayoutInput, activeVerticalId: string): CliResult {
   const entries = discoverPresetEntries(rootInput, activeVerticalId);
-  const issues = entries.flatMap((entry) => isInvalidPreset(entry) ? entry.issues : validatePresetManifestForUse(entry.manifest).issues);
+  const validations = entries.map((entry) => validateResolvedPreset(rootInput, entry));
+  const issues = validations.flatMap((entry) => entry.issues);
   return {
     ok: issues.length === 0,
     command: "preset-list",
-    presets: entries.map(publicPresetEntrySummary),
+    presets: validations.map((entry) => entry.summary),
     issues,
     error: issues.length === 0 ? undefined : cliError(CliErrorCode.PresetManifestInvalid, "One or more resolved presets failed validation.")
   };
@@ -56,13 +58,16 @@ export function runPresetInspect(rootInput: HarnessLayoutInput, presetId: string
   const preset = resolvePresetEntry(rootInput, presetId, activeVerticalId);
   if (!preset) return presetNotFound("preset-inspect", presetId);
   if (isInvalidPreset(preset)) return invalidResolvedPresetResult("preset-inspect", preset);
-  const validation = validatePresetManifestForUse(preset.manifest);
+  const validation = validateResolvedPreset(rootInput, preset);
   return {
-    ok: validation.ok,
+    ok: validation.issues.length === 0,
     command: "preset-inspect",
-    preset: { ...publicPresetSummary(preset), manifest: preset.manifest },
+    preset: { ...validation.summary, manifest: preset.manifest },
     issues: validation.issues,
-    error: validation.ok ? undefined : cliError(CliErrorCode.PresetManifestInvalid, "Preset manifest failed validation.")
+    error: validation.issues.length === 0 ? undefined : cliError(
+      CliErrorCode.PresetManifestInvalid,
+      validation.runtimeHint || "Preset manifest failed validation."
+    )
   };
 }
 
@@ -70,13 +75,16 @@ export function runPresetCheck(rootInput: HarnessLayoutInput, presetId: string, 
   const preset = resolvePresetEntry(rootInput, presetId, activeVerticalId);
   if (!preset) return presetNotFound("preset-check", presetId);
   if (isInvalidPreset(preset)) return invalidResolvedPresetResult("preset-check", preset);
-  const validation = validatePresetManifestForUse(preset.manifest);
+  const validation = validateResolvedPreset(rootInput, preset);
   return {
-    ok: validation.ok,
+    ok: validation.issues.length === 0,
     command: "preset-check",
-    preset: publicPresetSummary(preset),
+    preset: validation.summary,
     issues: validation.issues,
-    error: validation.ok ? undefined : cliError(CliErrorCode.PresetManifestInvalid, "Preset manifest failed validation.")
+    error: validation.issues.length === 0 ? undefined : cliError(
+      CliErrorCode.PresetManifestInvalid,
+      validation.runtimeHint || "Preset manifest failed validation."
+    )
   };
 }
 
@@ -94,13 +102,35 @@ export function runPresetAudit(rootInput: HarnessLayoutInput, activeVerticalId: 
       installedVersion: preset.manifest.version,
       bundledVersion: bundledById.get(preset.manifest.id)
     }));
-  const issues = resolved.flatMap((entry) => isInvalidPreset(entry) ? entry.issues : validatePresetManifestForUse(entry.manifest).issues);
+  const validations = resolved.map((entry) => validateResolvedPreset(rootInput, entry));
+  const issues = validations.flatMap((entry) => entry.issues);
   return {
     ok: issues.length === 0,
     command: "preset-audit",
-    presets: resolved.map(publicPresetEntrySummary),
+    presets: validations.map((entry) => entry.summary),
     issues,
     report: { totalResolved: resolved.length, drift },
     error: issues.length === 0 ? undefined : cliError(CliErrorCode.PresetManifestInvalid, "One or more resolved presets failed validation.")
+  };
+}
+
+function validateResolvedPreset(
+  rootInput: HarnessLayoutInput,
+  entry: ReturnType<typeof discoverPresetEntries>[number]
+): { readonly issues: ReadonlyArray<unknown>; readonly summary: Record<string, unknown>; readonly runtimeHint: string } {
+  if (isInvalidPreset(entry)) {
+    return { issues: entry.issues, summary: publicPresetEntrySummary(entry), runtimeHint: "" };
+  }
+  const structural = validatePresetManifestForUse(entry.manifest);
+  const runtime = structural.ok ? smokePresetEntrypoints(rootInput, entry) : { ok: false as const, issues: [], entrypoints: [] };
+  const issues = [...structural.issues, ...runtime.issues];
+  return {
+    issues,
+    summary: {
+      ...publicPresetSummary(entry),
+      valid: issues.length === 0,
+      issueCount: issues.length
+    },
+    runtimeHint: presetRuntimeRepairHint(entry, runtime.issues)
   };
 }

--- a/packages/cli/src/commands/extensions/preset-query.ts
+++ b/packages/cli/src/commands/extensions/preset-query.ts
@@ -46,11 +46,10 @@ export function runPresetList(rootInput: HarnessLayoutInput, activeVerticalId: s
   const validations = entries.map((entry) => validateResolvedPreset(rootInput, entry));
   const issues = validations.flatMap((entry) => entry.issues);
   return {
-    ok: issues.length === 0,
+    ok: true,
     command: "preset-list",
     presets: validations.map((entry) => entry.summary),
-    issues,
-    error: issues.length === 0 ? undefined : cliError(CliErrorCode.PresetManifestInvalid, "One or more resolved presets failed validation.")
+    issues
   };
 }
 

--- a/packages/cli/src/commands/extensions/preset-smoke.ts
+++ b/packages/cli/src/commands/extensions/preset-smoke.ts
@@ -1,0 +1,131 @@
+import path from "node:path";
+import { taskPackagePath, type HarnessLayoutInput } from "../../../../kernel/src/index.ts";
+import { presetScriptEntry } from "./preset-script-runner.ts";
+import type { ResolvedPreset } from "./state.ts";
+import { runScriptHost, type ResolvedScriptEntry } from "./script-host.ts";
+import {
+  trustedPresetEnvironmentCapabilities,
+  trustedPresetPackageReadPermissions
+} from "./script-environment.ts";
+
+export interface PresetEntrypointSmokeIssue {
+  readonly code:
+    | "preset_entrypoint_runtime_unregistered"
+    | "preset_entrypoint_script_missing"
+    | "preset_entrypoint_smoke_failed";
+  readonly message: string;
+  readonly path: string;
+  readonly entrypoint: string;
+  readonly nextCommand: string;
+}
+
+export interface PresetEntrypointSmokeResult {
+  readonly ok: boolean;
+  readonly entrypoints: ReadonlyArray<{
+    readonly name: string;
+    readonly type: "script" | "template";
+    readonly ok: boolean;
+    readonly command?: string;
+  }>;
+  readonly issues: ReadonlyArray<PresetEntrypointSmokeIssue>;
+}
+
+export function smokePresetEntrypoints(
+  rootInput: HarnessLayoutInput,
+  preset: ResolvedPreset
+): PresetEntrypointSmokeResult {
+  const issues: PresetEntrypointSmokeIssue[] = [];
+  const entrypoints = Object.entries(preset.manifest.entrypoints ?? {}).map(([name, entrypoint]) => {
+    if (entrypoint.type !== "script") {
+      issues.push(runtimeUnregisteredIssue(preset, name, entrypoint.type));
+      return { name, type: entrypoint.type, ok: false };
+    }
+
+    const script = resolvedPresetScript(preset, name, entrypoint);
+    const outputRoot = taskPackagePath(rootInput, `task_PRESET_CHECK_${safeToken(preset.manifest.id)}`);
+    const smoke = runScriptHost({
+      rootInput,
+      commandName: "preset-check",
+      script,
+      outputRoot,
+      dryRun: true
+    });
+    if (!smoke.ok) {
+      const error = smoke.result.error;
+      issues.push({
+        code: error?.code === "script_not_found"
+          ? "preset_entrypoint_script_missing"
+          : "preset_entrypoint_smoke_failed",
+        entrypoint: name,
+        path: `entrypoints.${name}${error?.code === "script_not_found" ? ".command" : ""}`,
+        message: `Entrypoint ${name} failed its real dry-run smoke: ${error?.hint ?? "unknown runtime failure"}`,
+        nextCommand: repairCommand(preset)
+      });
+    }
+    return { name, type: entrypoint.type, command: entrypoint.command, ok: smoke.ok };
+  });
+  return { ok: issues.length === 0, entrypoints, issues };
+}
+
+export function presetRuntimeRepairHint(preset: ResolvedPreset, issues: ReadonlyArray<PresetEntrypointSmokeIssue>): string {
+  const first = issues[0];
+  if (!first) return "";
+  return `Preset ${preset.manifest.id} entrypoint ${first.entrypoint} is not runnable: ${first.message} Next: ${first.nextCommand}`;
+}
+
+function resolvedPresetScript(
+  preset: ResolvedPreset,
+  entrypointName: string,
+  entrypoint: Extract<NonNullable<ResolvedPreset["manifest"]["entrypoints"]>[string], { readonly type: "script" }>
+): ResolvedScriptEntry {
+  return {
+    entry: presetScriptEntry(preset, entrypoint, entrypointName),
+    verticalId: preset.manifest.vertical,
+    manifestRoot: path.dirname(preset.sourcePath),
+    owner: { id: preset.manifest.id, layer: preset.layer },
+    environmentCapabilities: trustedPresetEnvironmentCapabilities({
+      layer: preset.layer,
+      presetId: preset.manifest.id,
+      entrypointName,
+      command: entrypoint.command,
+      sourcePath: preset.sourcePath
+    }),
+    trustedPackageReadPermissions: trustedPresetPackageReadPermissions({
+      layer: preset.layer,
+      presetId: preset.manifest.id,
+      entrypointName,
+      command: entrypoint.command,
+      sourcePath: preset.sourcePath
+    }),
+    context: {
+      presetId: preset.manifest.id,
+      presetTitle: preset.manifest.title,
+      entrypoint: entrypointName
+    }
+  };
+}
+
+function runtimeUnregisteredIssue(
+  preset: ResolvedPreset,
+  entrypoint: string,
+  type: "template"
+): PresetEntrypointSmokeIssue {
+  return {
+    code: "preset_entrypoint_runtime_unregistered",
+    entrypoint,
+    path: `entrypoints.${entrypoint}.type`,
+    message: `Entrypoint ${entrypoint} declares type ${type}, but no ${type} entrypoint runtime is registered.`,
+    nextCommand: repairCommand(preset)
+  };
+}
+
+function repairCommand(preset: ResolvedPreset): string {
+  if (preset.layer === "builtin" || preset.layer === "user") {
+    return `run \`ha preset seed\`, then \`ha preset check ${preset.manifest.id}\``;
+  }
+  return `reinstall the complete preset package with \`ha preset install <preset-folder> --project\`, then run \`ha preset check ${preset.manifest.id}\``;
+}
+
+function safeToken(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/gu, "_");
+}

--- a/packages/cli/src/commands/extensions/preset-smoke.ts
+++ b/packages/cli/src/commands/extensions/preset-smoke.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
 import { taskPackagePath, type HarnessLayoutInput } from "../../../../kernel/src/index.ts";
+import {
+  isPresetRunEntrypoint,
+  presetRunEntrypointCapabilities
+} from "../../cli/preset-entrypoint-capabilities.ts";
 import { presetScriptEntry } from "./preset-script-runner.ts";
 import type { ResolvedPreset } from "./state.ts";
 import { runScriptHost, type ResolvedScriptEntry } from "./script-host.ts";
@@ -36,6 +40,12 @@ export function smokePresetEntrypoints(
 ): PresetEntrypointSmokeResult {
   const issues: PresetEntrypointSmokeIssue[] = [];
   const entrypoints = Object.entries(preset.manifest.entrypoints ?? {}).map(([name, entrypoint]) => {
+    if (!isPresetRunEntrypoint(name)) {
+      issues.push(entrypointCapabilityUnregisteredIssue(preset, name, entrypoint.type));
+      return entrypoint.type === "script"
+        ? { name, type: entrypoint.type, command: entrypoint.command, ok: false }
+        : { name, type: entrypoint.type, ok: false };
+    }
     if (entrypoint.type !== "script") {
       issues.push(runtimeUnregisteredIssue(preset, name, entrypoint.type));
       return { name, type: entrypoint.type, ok: false };
@@ -43,13 +53,24 @@ export function smokePresetEntrypoints(
 
     const script = resolvedPresetScript(preset, name, entrypoint);
     const outputRoot = taskPackagePath(rootInput, `task_PRESET_CHECK_${safeToken(preset.manifest.id)}`);
-    const smoke = runScriptHost({
-      rootInput,
-      commandName: "preset-check",
-      script,
-      outputRoot,
-      dryRun: true
-    });
+    let smoke: ReturnType<typeof runScriptHost>;
+    try {
+      smoke = runScriptHost({
+        rootInput,
+        commandName: "preset-check",
+        script,
+        outputRoot
+      });
+    } catch (error) {
+      issues.push({
+        code: "preset_entrypoint_smoke_failed",
+        entrypoint: name,
+        path: `entrypoints.${name}`,
+        message: `Entrypoint ${name} failed its isolated execution smoke: ${error instanceof Error ? error.message : String(error)}`,
+        nextCommand: smokeReproductionCommand(preset)
+      });
+      return { name, type: entrypoint.type, command: entrypoint.command, ok: false };
+    }
     if (!smoke.ok) {
       const error = smoke.result.error;
       issues.push({
@@ -58,13 +79,31 @@ export function smokePresetEntrypoints(
           : "preset_entrypoint_smoke_failed",
         entrypoint: name,
         path: `entrypoints.${name}${error?.code === "script_not_found" ? ".command" : ""}`,
-        message: `Entrypoint ${name} failed its real dry-run smoke: ${error?.hint ?? "unknown runtime failure"}`,
-        nextCommand: repairCommand(preset)
+        message: error?.code === "script_result_failed"
+          ? `Entrypoint ${name} returned script-result ok:false during its isolated smoke.`
+          : `Entrypoint ${name} failed its isolated execution smoke: ${error?.hint ?? "unknown runtime failure"}`,
+        nextCommand: error?.code === "script_not_found"
+          ? repairCommand(preset)
+          : smokeReproductionCommand(preset)
       });
     }
     return { name, type: entrypoint.type, command: entrypoint.command, ok: smoke.ok };
   });
   return { ok: issues.length === 0, entrypoints, issues };
+}
+
+function entrypointCapabilityUnregisteredIssue(
+  preset: ResolvedPreset,
+  entrypoint: string,
+  type: "script" | "template"
+): PresetEntrypointSmokeIssue {
+  return {
+    code: "preset_entrypoint_runtime_unregistered",
+    entrypoint,
+    path: `entrypoints.${entrypoint}`,
+    message: `Entrypoint ${entrypoint} declares type ${type}, but the preset run capability registry does not expose that name. Registered names: ${presetRunEntrypointCapabilities.join(", ")}.`,
+    nextCommand: "ha preset run --help"
+  };
 }
 
 export function presetRuntimeRepairHint(preset: ResolvedPreset, issues: ReadonlyArray<PresetEntrypointSmokeIssue>): string {
@@ -100,7 +139,8 @@ function resolvedPresetScript(
     context: {
       presetId: preset.manifest.id,
       presetTitle: preset.manifest.title,
-      entrypoint: entrypointName
+      entrypoint: entrypointName,
+      validationSmoke: true
     }
   };
 }
@@ -124,6 +164,10 @@ function repairCommand(preset: ResolvedPreset): string {
     return `run \`ha preset seed\`, then \`ha preset check ${preset.manifest.id}\``;
   }
   return `reinstall the complete preset package with \`ha preset install <preset-folder> --project\`, then run \`ha preset check ${preset.manifest.id}\``;
+}
+
+function smokeReproductionCommand(preset: ResolvedPreset): string {
+  return `ha preset check ${preset.manifest.id} --json`;
 }
 
 function safeToken(value: string): string {

--- a/packages/cli/src/commands/extensions/preset.ts
+++ b/packages/cli/src/commands/extensions/preset.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { HarnessLayoutInput, WriteOp } from "../../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
@@ -7,7 +7,6 @@ import { resolveActiveVertical } from "./active-vertical.ts";
 import {
   discoverPresets,
   isInvalidPreset,
-  loadBundledPresetManifests,
   presetManifestPath,
   presetNotFound,
   publicPresetSummary,
@@ -18,6 +17,8 @@ import {
 import { invalidResolvedPresetResult } from "./shared.ts";
 import { buildPresetUninstallImpact } from "./preset-uninstall-impact.ts";
 import { readPresetManifestFromSourceResult } from "./preset-manifest-reader.ts";
+import { loadBundledPresetManifestEntries } from "./bundled.ts";
+import { presetRuntimeRepairHint, smokePresetEntrypoints } from "./preset-smoke.ts";
 import {
   runPresetAudit,
   runPresetCheck,
@@ -91,9 +92,29 @@ function runPresetInstall(rootInput: HarnessLayoutInput, action: Extract<PresetA
       error: cliError(CliErrorCode.PresetManifestInvalid, "Preset manifest failed validation.")
     };
   }
+  const sourceManifestPath = manifestPathFromSource(action.sourcePath);
+  const sourcePreset = {
+    manifest,
+    layer: action.layer,
+    sourcePath: sourceManifestPath
+  } as const;
+  const runtime = smokePresetEntrypoints(rootInput, sourcePreset);
+  if (!runtime.ok) {
+    return {
+      ok: false,
+      command: "preset-install",
+      preset: { id: manifest.id },
+      issues: runtime.issues,
+      error: cliError(CliErrorCode.PresetManifestInvalid, presetRuntimeRepairHint(sourcePreset, runtime.issues))
+    };
+  }
   const target = presetManifestPath(rootInput, action.layer, manifest.id);
-  mkdirSync(path.dirname(target), { recursive: true });
-  writeFileSync(target, JSON.stringify(manifest, null, 2), "utf8");
+  const writeInstalledFile = (filePath: string, body: Buffer | string): void => {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, body);
+  };
+  copyPresetPackage(path.dirname(sourceManifestPath), path.dirname(target), writeInstalledFile, { replace: true });
+  writeInstalledFile(target, JSON.stringify(manifest, null, 2));
   return {
     ok: true,
     command: "preset-install",
@@ -102,11 +123,16 @@ function runPresetInstall(rootInput: HarnessLayoutInput, action: Extract<PresetA
 }
 
 function runPresetSeed(rootInput: HarnessLayoutInput, activeVerticalId: string): CliResult {
-  for (const manifest of loadBundledPresetManifests().filter((candidate) => candidate.vertical === activeVerticalId)) {
-    const target = presetManifestPath(rootInput, "user", manifest.id);
+  const bundled = loadBundledPresetManifestEntries().filter((candidate) => candidate.manifest.vertical === activeVerticalId);
+  const writeSeedFile = (filePath: string, body: Buffer | string): void => {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, body);
+  };
+  for (const entry of bundled) {
+    const target = presetManifestPath(rootInput, "user", entry.manifest.id);
+    copyPresetPackage(path.dirname(entry.sourcePath), path.dirname(target), writeSeedFile);
     if (!existsSync(target)) {
-      mkdirSync(path.dirname(target), { recursive: true });
-      writeFileSync(target, JSON.stringify(manifest, null, 2), "utf8");
+      writeSeedFile(target, JSON.stringify(entry.manifest, null, 2));
     }
   }
   return {
@@ -114,8 +140,40 @@ function runPresetSeed(rootInput: HarnessLayoutInput, activeVerticalId: string):
     command: "preset-seed",
     presets: discoverPresets(rootInput, activeVerticalId)
       .filter((preset) => preset.layer === "user")
-      .map(publicPresetSummary)
+      .map(publicPresetSummary),
+    report: {
+      schema: "preset-seed-report/v1",
+      packageCount: bundled.length,
+      mode: "complete-package"
+    }
   };
+}
+
+function manifestPathFromSource(sourcePath: string): string {
+  return statSync(sourcePath).isDirectory() ? path.join(sourcePath, "preset.json") : sourcePath;
+}
+
+function copyPresetPackage(
+  sourceRoot: string,
+  targetRoot: string,
+  writeTarget: (filePath: string, body: Buffer) => void,
+  options: { readonly replace?: boolean } = {}
+): void {
+  if (path.resolve(sourceRoot) === path.resolve(targetRoot)) return;
+  if (options.replace) removePresetPackage(targetRoot);
+  for (const entry of readdirSync(sourceRoot, { withFileTypes: true })) {
+    const source = path.join(sourceRoot, entry.name);
+    const target = path.join(targetRoot, entry.name);
+    if (entry.isDirectory()) {
+      copyPresetPackage(source, target, writeTarget);
+    } else if (entry.isFile() && (options.replace || !existsSync(target))) {
+      writeTarget(target, readFileSync(source));
+    }
+  }
+}
+
+function removePresetPackage(targetRoot: string): void {
+  rmSync(targetRoot, { recursive: true, force: true });
 }
 
 function runPresetUninstall(rootInput: HarnessLayoutInput, action: Extract<PresetAction, { readonly kind: "preset-uninstall" }>): CliResult {
@@ -158,7 +216,7 @@ function runPresetUninstall(rootInput: HarnessLayoutInput, action: Extract<Prese
       report
     };
   }
-  rmSync(path.dirname(target), { recursive: true, force: true });
+  removePresetPackage(path.dirname(target));
   return {
     ok: true,
     command: "preset-uninstall",

--- a/packages/cli/src/commands/extensions/script-host.ts
+++ b/packages/cli/src/commands/extensions/script-host.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -102,6 +103,18 @@ export function runScriptHost(options: {
       "Script manifest packages must contain only regular files and directories, never symbolic links."
     );
   }
+  const syntax = spawnSync(process.execPath, ["--check", realpathSync.native(scriptPath)], {
+    cwd: options.script.manifestRoot,
+    encoding: "utf8",
+    env: {}
+  });
+  if (syntax.status !== 0) {
+    return scriptFailure(
+      options.commandName,
+      CliErrorCode.ScriptFailed,
+      `Script command is not executable JavaScript: ${(syntax.stderr || syntax.stdout || "syntax check failed").trim()}`
+    );
+  }
 
   const outputRoot = options.outputRoot ?? path.join(layout.authoredRoot, "context");
   const scopeOptions = reportsNoOverwriteLeafConflicts(options.script.entry)
@@ -113,6 +126,19 @@ export function runScriptHost(options: {
   const writeScope = resolveDeclaredWriteScopes(options.script.entry.writes, layout, outputRoot, scopeOptions);
   if (!readScope.ok) return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidRead, "Script reads must declare supported project-local scopes.");
   if (!writeScope.ok) return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidWrite, "Script writes must declare approved authored content scopes.");
+  if (
+    options.script.entry.source === "preset" &&
+    options.dryRun === true &&
+    options.outputRoot !== undefined &&
+    options.script.entry.writes.length > 0 &&
+    !writeScope.roots.some((allowedRoot) => isPathInside(allowedRoot, options.outputRoot!))
+  ) {
+    return scriptFailure(
+      options.commandName,
+      CliErrorCode.PresetWriteScopeInvalid,
+      `Preset entrypoint ${options.script.entry.id} must declare a write scope covering its outputRoot. Next: fix entrypoint.writes, then run \`ha preset check ${String(options.script.context?.presetId ?? "<preset-id>")}\`.`
+    );
+  }
 
   const runId = `${Date.now().toString(36)}-${randomBytes(4).toString("hex")}`;
   const runDir = path.join(layout.localRoot, "script-runs", runId);

--- a/packages/cli/src/commands/extensions/script-host.ts
+++ b/packages/cli/src/commands/extensions/script-host.ts
@@ -128,7 +128,6 @@ export function runScriptHost(options: {
   if (!writeScope.ok) return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidWrite, "Script writes must declare approved authored content scopes.");
   if (
     options.script.entry.source === "preset" &&
-    options.dryRun === true &&
     options.outputRoot !== undefined &&
     options.script.entry.writes.length > 0 &&
     !writeScope.roots.some((allowedRoot) => isPathInside(allowedRoot, options.outputRoot!))

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -18,6 +18,7 @@ import { toCliError } from "../cli/error-mapper.ts";
 import { actionTaskId } from "../cli/parse-args.ts";
 import { requiresConflictMarkerPreflight, runRegisteredCommand } from "../cli/runner-registry.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
+import { finalizeDryRunResult } from "../cli/dry-run-preview.ts";
 import { leaseEnforcementEnabled } from "../commands/settings.ts";
 import { CliActorAttributionError, migrationWriteAttribution, type CliActorAttribution } from "./actor-attribution.ts";
 import { CliPrincipalResolutionError, resolveCliTaskHolderPrincipal, resolveLocalCliActorAttribution } from "./local-principal.ts";
@@ -206,7 +207,7 @@ export async function runRegisteredCommandWithCliComposition(
         taskId: actionTaskId(command.action),
         error: toCliError(error)
       }),
-      onSuccess: (value) => value
+      onSuccess: (value) => finalizeDryRunResult(command.action, value)
     })
   ));
 }

--- a/packages/cli/test/dry-run-preview-cli.test.ts
+++ b/packages/cli/test/dry-run-preview-cli.test.ts
@@ -1,0 +1,103 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { commandDescriptors } from "../src/cli/command-registry.ts";
+import { commandDryRunPreviewRequiredByKind } from "../src/cli/receipt-contracts.ts";
+import { dryRunPreviewContractViolation } from "../src/cli/dry-run-preview.ts";
+import type { ParsedCommand } from "../src/cli/types.ts";
+import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+
+test("dry-run receipt contract reports a missing preview before receipt rendering", () => {
+  const action = decisionProposeAction();
+  const violation = dryRunPreviewContractViolation(action, {
+    ok: true,
+    command: "decision-propose",
+    decisionId: "dec_PREVIEW",
+    report: { schema: "decision-write-cli-report/v1", dryRun: true }
+  });
+
+  assert.match(violation ?? "", /must include preview/u);
+  assert.match(violation ?? "", /Next:/u);
+});
+
+test("every command declaring --dry-run admits the centrally required preview field", () => {
+  const dryRunKinds = commandDescriptors
+    .filter((descriptor) => descriptor.options.some((option) => option.flag === "--dry-run"))
+    .map((descriptor) => descriptor.kind);
+
+  assert.ok(dryRunKinds.length > 0);
+  for (const kind of dryRunKinds) {
+    assert.equal(commandDryRunPreviewRequiredByKind[kind], true, kind);
+  }
+});
+
+test("decision propose dry-run previews both chosen and both rejected entries", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dry-run-preview-"));
+  ensureTestHarnessIdentity(rootDir);
+  try {
+    const stdout = execFileSync(process.execPath, [
+      cliEntry,
+      "--root", rootDir,
+      "--json",
+      "decision", "propose",
+      "--id", "dec_PREVIEW",
+      "--title", "probe",
+      "--question", "q?",
+      "--chosen", "A1",
+      "--chosen", "A2",
+      "--rejected", "R1",
+      "--rejected", "R2",
+      "--why-not", "wn",
+      "--dry-run"
+    ], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HARNESS_ACTOR: "agent:test",
+        HARNESS_DAEMON_MODE: "direct",
+        HARNESS_DIRECT_WRITE_REASON: "test",
+        HARNESS_GIT_AUTHOR_NAME: "Harness Test",
+        HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test"
+      }
+    });
+    const receipt = JSON.parse(stdout) as Record<string, any>;
+    const preview = receipt.details.report.preview;
+
+    assert.equal(receipt.ok, true);
+    assert.equal(preview.schema, "command-dry-run-preview/v1");
+    assert.equal(preview.summary.chosenCount, 2);
+    assert.equal(preview.summary.rejectedCount, 2);
+    assert.deepEqual(preview.paths, [{
+      operation: "create",
+      path: "harness/decisions/decision-dec_PREVIEW/decision.md"
+    }]);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function decisionProposeAction(): Extract<ParsedCommand["action"], { readonly kind: "decision-propose" }> {
+  return {
+    kind: "decision-propose",
+    decisionId: "dec_PREVIEW",
+    title: "probe",
+    question: "q?",
+    chosen: [{ text: "A1" }, { text: "A2" }],
+    rejected: [{ text: "R1", why_not: "wn" }, { text: "R2", why_not: "wn" }],
+    claims: [],
+    claimLoadBearing: true,
+    fulfillments: [],
+    riskTier: "medium",
+    urgency: "medium",
+    modules: [],
+    productLines: [],
+    evidenceRelations: [],
+    dryRun: true
+  };
+}

--- a/packages/cli/test/parse-args.test.ts
+++ b/packages/cli/test/parse-args.test.ts
@@ -9,6 +9,7 @@ import { parseArgs } from "../src/cli/parse-args.ts";
 import { parserRegistry } from "../src/cli/parser-registry.ts";
 import { parseCoreTaskArgs } from "../src/cli/parsers/core-task.ts";
 import { parseVersionArgs } from "../src/cli/parsers/meta.ts";
+import { presetRunEntrypointUsage } from "../src/cli/preset-entrypoint-capabilities.ts";
 import { runInitCommand } from "../src/commands/core/init.ts";
 import { runTaskLifecycleCommand } from "../src/commands/core/task-lifecycle.ts";
 import { runVersionCommand } from "../src/commands/core/version.ts";
@@ -297,6 +298,14 @@ test("command descriptor projections are derived from the command spec", () => {
     assert.equal(descriptor?.parse, spec.parse, spec.kind);
     assert.equal(descriptor?.run, spec.run, spec.kind);
   }
+});
+
+test("preset run help names exactly the registered entrypoint capabilities", () => {
+  const presetRun = commandSpecs.find((entry) => entry.kind === "preset-run");
+  assert.equal(
+    presetRun?.usage,
+    `preset run <id> ${presetRunEntrypointUsage} --task <id> [--allow-scripts] [--input key=value] [--json]`
+  );
 });
 
 test("command specs can directly share parser and runner function references", () => {

--- a/packages/cli/test/preset-check-smoke-cli.test.ts
+++ b/packages/cli/test/preset-check-smoke-cli.test.ts
@@ -1,0 +1,126 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { runJson, withTempRoot } from "./helpers/preset-script-fixtures.ts";
+
+test("preset inspect and check fail closed when a declared entrypoint script is missing", () => {
+  withTempRoot((rootDir) => {
+    writePreset(rootDir, "missing-entrypoint", {
+      scaffold: {
+        type: "script",
+        command: "scripts/scaffold.mjs",
+        writes: ["{{outputRoot}}/**"]
+      }
+    });
+
+    for (const command of ["inspect", "check"] as const) {
+      const result = runJson(rootDir, ["preset", command, "missing-entrypoint"], false);
+      assert.equal(result.ok, false);
+      assert.equal(result.preset.valid, false);
+      assert.equal(result.preset.issueCount, 1);
+      assert.equal(result.issues[0].entrypoint, "scaffold");
+      assert.equal(result.issues[0].code, "preset_entrypoint_script_missing");
+      assert.match(result.error.hint, /ha preset install <preset-folder> --project/u);
+    }
+  });
+});
+
+test("preset check runs the real scope resolver and rejects writes that miss outputRoot", () => {
+  withTempRoot((rootDir) => {
+    writePreset(rootDir, "wrong-output-scope", {
+      check: {
+        type: "script",
+        command: "scripts/check.mjs",
+        writes: ["{{paths.milestonesRoot}}/**"]
+      }
+    });
+    write(rootDir, ".harness/presets/wrong-output-scope/scripts/check.mjs", "console.log('must not execute during smoke');\n");
+
+    const result = runJson(rootDir, ["preset", "check", "wrong-output-scope"], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.issues[0].entrypoint, "check");
+    assert.equal(result.issues[0].code, "preset_entrypoint_smoke_failed");
+    assert.match(result.issues[0].message, /write scope covering its outputRoot/u);
+  });
+});
+
+test("preset check rejects a present script that cannot be parsed by the runtime", () => {
+  withTempRoot((rootDir) => {
+    writePreset(rootDir, "syntax-error", {
+      check: {
+        type: "script",
+        command: "scripts/check.mjs",
+        writes: ["{{outputRoot}}/**"]
+      }
+    });
+    write(rootDir, ".harness/presets/syntax-error/scripts/check.mjs", "const broken = ;\n");
+
+    const result = runJson(rootDir, ["preset", "check", "syntax-error"], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.issues[0].entrypoint, "check");
+    assert.match(result.issues[0].message, /not executable JavaScript/u);
+  });
+});
+
+test("usage-acceptance regression fixture reports each broken entrypoint and turns valid only after all three are repaired", () => {
+  withTempRoot((rootDir) => {
+    writePreset(rootDir, "usage-acceptance", {
+      capture: { type: "script", command: "scripts/capture.mjs", writes: ["{{outputRoot}}/**"] },
+      "scaffold-plan": { type: "script", command: "scripts/scaffold-plan.mjs", writes: ["{{outputRoot}}/**"] },
+      check: { type: "script", command: "scripts/check.mjs", writes: ["{{paths.milestonesRoot}}/**"] }
+    });
+    write(rootDir, ".harness/presets/usage-acceptance/scripts/check.mjs", "console.log('check');\n");
+
+    const broken = runJson(rootDir, ["preset", "check", "usage-acceptance"], false);
+    assert.equal(broken.preset.valid, false);
+    assert.deepEqual(broken.issues.map((issue: Record<string, unknown>) => issue.entrypoint), [
+      "capture",
+      "scaffold-plan",
+      "check"
+    ]);
+
+    writePreset(rootDir, "usage-acceptance", {
+      capture: { type: "script", command: "scripts/capture.mjs", writes: ["{{outputRoot}}/**"] },
+      "scaffold-plan": { type: "script", command: "scripts/scaffold-plan.mjs", writes: ["{{outputRoot}}/**"] },
+      check: { type: "script", command: "scripts/check.mjs", writes: ["{{outputRoot}}/**"] }
+    });
+    write(rootDir, ".harness/presets/usage-acceptance/scripts/capture.mjs", "console.log('capture');\n");
+    write(rootDir, ".harness/presets/usage-acceptance/scripts/scaffold-plan.mjs", "console.log('scaffold-plan');\n");
+
+    const repaired = runJson(rootDir, ["preset", "check", "usage-acceptance"]);
+    assert.equal(repaired.preset.valid, true);
+    assert.equal(repaired.preset.issueCount, 0);
+  });
+});
+
+function writePreset(rootDir: string, id: string, entrypoints: Record<string, unknown>): void {
+  write(rootDir, `.harness/presets/${id}/preset.json`, JSON.stringify({
+    schema: "preset-manifest/v2",
+    id,
+    title: id,
+    vertical: "software/coding",
+    version: "1.0.0",
+    kind: "process-action",
+    kernelVersionRange: { min: "1.0.0", maxExclusive: "2.0.0" },
+    capabilityImports: [],
+    entrypoints,
+    profiles: [{
+      id: "baseline",
+      title: "Baseline",
+      checkerProfile: "standard",
+      completionGates: [],
+      templateSelections: []
+    }],
+    defaultProfile: "baseline"
+  }, null, 2));
+}
+
+function write(rootDir: string, relativePath: string, body: string): void {
+  const target = path.join(rootDir, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, body, "utf8");
+}

--- a/packages/cli/test/preset-check-smoke-cli.test.ts
+++ b/packages/cli/test/preset-check-smoke-cli.test.ts
@@ -66,6 +66,83 @@ test("preset check rejects a present script that cannot be parsed by the runtime
   });
 });
 
+test("preset check rejects an entrypoint name absent from the parser capability registry", () => {
+  withTempRoot((rootDir) => {
+    writePreset(rootDir, "unreachable", {
+      capture: {
+        type: "script",
+        command: "scripts/capture.mjs",
+        writes: ["{{outputRoot}}/**"]
+      }
+    });
+    write(rootDir, ".harness/presets/unreachable/scripts/capture.mjs", "console.log('never reached');\n");
+
+    const result = runJson(rootDir, ["preset", "check", "unreachable"], false);
+
+    assert.equal(result.issues[0].code, "preset_entrypoint_runtime_unregistered");
+    assert.equal(result.issues[0].entrypoint, "capture");
+    assert.match(result.issues[0].message, /capability registry does not expose/u);
+    assert.equal(result.issues[0].nextCommand, "ha preset run --help");
+  });
+});
+
+test("preset check executes the script and rejects script-result ok false", () => {
+  withTempRoot((rootDir) => {
+    writePreset(rootDir, "failed-result", {
+      check: {
+        type: "script",
+        command: "scripts/check.mjs",
+        writes: ["{{outputRoot}}/**"]
+      }
+    });
+    write(rootDir, ".harness/presets/failed-result/scripts/check.mjs", [
+      "import { writeFileSync } from 'node:fs';",
+      "writeFileSync(process.env.HARNESS_SCRIPT_RESULT, JSON.stringify({ schema: 'script-result/v1', ok: false, report: { reason: 'positive-control' }, produced: [] }));",
+      ""
+    ].join("\n"));
+
+    const result = runJson(rootDir, ["preset", "check", "failed-result"], false);
+
+    assert.equal(result.issues[0].code, "preset_entrypoint_smoke_failed");
+    assert.equal(result.issues[0].entrypoint, "check");
+    assert.match(result.issues[0].message, /script-result ok:false/u);
+    assert.equal(result.issues[0].nextCommand, "ha preset check failed-result --json");
+
+    const list = runJson(rootDir, ["preset", "list"]);
+    assert.equal(list.presets.find((preset: Record<string, unknown>) => preset.id === "failed-result").valid, false);
+    assert.equal(list.issues.some((issue: Record<string, unknown>) => issue.entrypoint === "check"), true);
+  });
+});
+
+test("preset audit reports a script ingest rejection instead of aborting the scan", () => {
+  withTempRoot((rootDir) => {
+    writePreset(rootDir, "unmanaged-output", {
+      scaffold: {
+        type: "script",
+        command: "scripts/scaffold.mjs",
+        writes: ["{{outputRoot}}/**"]
+      }
+    });
+    write(rootDir, ".harness/presets/unmanaged-output/scripts/scaffold.mjs", [
+      "import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';",
+      "import path from 'node:path';",
+      "const context = JSON.parse(readFileSync(process.env.HARNESS_PRESET_CONTEXT, 'utf8'));",
+      "mkdirSync(context.outputRoot, { recursive: true });",
+      "writeFileSync(path.join(context.outputRoot, 'undeclared.md'), '# not ingestible\\n');",
+      ""
+    ].join("\n"));
+
+    const result = runJson(rootDir, ["preset", "audit"], false);
+
+    assert.equal(result.error.code, "preset_manifest_invalid");
+    assert.equal(result.presets.find((preset: Record<string, unknown>) => preset.id === "unmanaged-output").valid, false);
+    const issue = result.issues.find((candidate: Record<string, unknown>) =>
+      candidate.entrypoint === "scaffold" && typeof candidate.message === "string" && candidate.message.includes("SEMANTIC_DIFF_REQUIRED"));
+    assert.ok(issue);
+    assert.match(issue.message, /SEMANTIC_DIFF_REQUIRED/u);
+  });
+});
+
 test("usage-acceptance regression fixture reports each broken entrypoint and turns valid only after all three are repaired", () => {
   withTempRoot((rootDir) => {
     writePreset(rootDir, "usage-acceptance", {
@@ -84,11 +161,11 @@ test("usage-acceptance regression fixture reports each broken entrypoint and tur
     ]);
 
     writePreset(rootDir, "usage-acceptance", {
-      capture: { type: "script", command: "scripts/capture.mjs", writes: ["{{outputRoot}}/**"] },
-      "scaffold-plan": { type: "script", command: "scripts/scaffold-plan.mjs", writes: ["{{outputRoot}}/**"] },
+      plan: { type: "script", command: "scripts/scaffold-plan.mjs", writes: ["{{outputRoot}}/**"] },
+      scaffold: { type: "script", command: "scripts/capture.mjs", writes: ["{{outputRoot}}/**"] },
       check: { type: "script", command: "scripts/check.mjs", writes: ["{{outputRoot}}/**"] }
     });
-    write(rootDir, ".harness/presets/usage-acceptance/scripts/capture.mjs", "console.log('capture');\n");
+    write(rootDir, ".harness/presets/usage-acceptance/scripts/capture.mjs", "console.log('scaffold');\n");
     write(rootDir, ".harness/presets/usage-acceptance/scripts/scaffold-plan.mjs", "console.log('scaffold-plan');\n");
 
     const repaired = runJson(rootDir, ["preset", "check", "usage-acceptance"]);

--- a/packages/cli/test/preset-module-cli.test.ts
+++ b/packages/cli/test/preset-module-cli.test.ts
@@ -34,8 +34,8 @@ test("CLI preset CRUD validates, installs, audits, and removes project presets",
     assert.equal(checked.ok, true);
     assert.deepEqual(checked.issues, []);
 
-    const audit = runJson(rootDir, ["preset", "audit"]);
-    assert.equal(audit.ok, true);
+    const audit = runJson(rootDir, ["preset", "audit"], false);
+    assert.equal(audit.ok, false);
     const bundledPresetIndex = JSON.parse(readFileSync(bundledPresetIndexPath, "utf8")) as { readonly presets: ReadonlyArray<string> };
     assert.equal(audit.report.totalResolved, bundledPresetIndex.presets.length + 1);
 
@@ -299,9 +299,8 @@ test("CLI preset list inspect and audit surface invalid active overrides", () =>
       templateSelections: [conflictingTaskPlanSelection()]
     });
 
-    const listed = runJson(rootDir, ["preset", "list"], false);
-    assert.equal(listed.ok, false);
-    assert.equal(listed.error.code, "preset_manifest_invalid");
+    const listed = runJson(rootDir, ["preset", "list"]);
+    assert.equal(listed.ok, true);
     const listedModule = listed.presets.find((preset: Record<string, unknown>) => preset.id === "module");
     assert.equal(listedModule.layer, "project");
     assert.equal(listedModule.valid, false);
@@ -331,9 +330,8 @@ test("CLI malformed project preset override fails closed with stable preset erro
       unknownField: true
     }), "utf8");
 
-    const listed = runJson(rootDir, ["preset", "list"], false);
-    assert.equal(listed.ok, false);
-    assert.equal(listed.error.code, "preset_manifest_invalid");
+    const listed = runJson(rootDir, ["preset", "list"]);
+    assert.equal(listed.ok, true);
     const module = listed.presets.find((preset: Record<string, unknown>) => preset.id === "module");
     assert.equal(module.valid, false);
 

--- a/packages/cli/test/preset-uninstall-safety-cli.test.ts
+++ b/packages/cli/test/preset-uninstall-safety-cli.test.ts
@@ -181,7 +181,14 @@ function writePresetSource(
     kernelVersionRange: { min: "1.0.0", maxExclusive: "2.0.0" },
     capabilityImports: [],
     ...(kind === "process-action" ? {
-      entrypoints: { plan: { type: "script", command: "scripts/plan.mjs", reads: [], writes: [] } }
+      entrypoints: {
+        plan: {
+          type: "script",
+          command: "scripts/plan.mjs",
+          reads: [],
+          writes: ["{{outputRoot}}/**"]
+        }
+      }
     } : {}),
     profiles: [{
       id: "baseline",
@@ -194,6 +201,18 @@ function writePresetSource(
   };
   mkdirSync(sourceDir, { recursive: true });
   writeFileSync(path.join(sourceDir, "preset.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  if (kind === "process-action") {
+    const scriptsDir = path.join(sourceDir, "scripts");
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(path.join(scriptsDir, "plan.mjs"), [
+      "#!/usr/bin/env node",
+      'import { writeFileSync } from "node:fs";',
+      'const resultPath = process.env.HARNESS_SCRIPT_RESULT;',
+      'if (!resultPath) throw new Error("HARNESS_SCRIPT_RESULT is required");',
+      'writeFileSync(resultPath, JSON.stringify({ schema: "script-result/v1", ok: true, report: {}, produced: [] }));',
+      ""
+    ].join("\n"), "utf8");
+  }
 }
 
 function setTaskStatus(indexPath: string, status: string): void {

--- a/packages/cli/test/preset-user-root-cli.test.ts
+++ b/packages/cli/test/preset-user-root-cli.test.ts
@@ -100,10 +100,10 @@ test("CLI preset install/uninstall/list/audit operate in injected home user root
       });
       assert.equal(listed.presets.some((preset: Record<string, unknown>) => preset.id === "custom-task" && preset.layer === "user"), true);
 
-      const audited = runJson(rootDir, ["preset", "audit"], true, {
+      const audited = runJson(rootDir, ["preset", "audit"], false, {
         HARNESS_USER_HOME: userHome
       });
-      assert.equal(audited.ok, true);
+      assert.equal(audited.ok, false);
       assert.equal(audited.presets.some((preset: Record<string, unknown>) => preset.id === "custom-task" && preset.layer === "user"), true);
 
       const removed = runJson(rootDir, ["preset", "uninstall", "custom-task"], true, {
@@ -138,10 +138,10 @@ test("CLI missing injected home user preset root is treated as empty until insta
       assert.equal(listed.ok, true);
       assert.equal(existsSync(homePresetRoot), false);
 
-      const audited = runJson(rootDir, ["preset", "audit"], true, {
+      const audited = runJson(rootDir, ["preset", "audit"], false, {
         HARNESS_USER_HOME: userHome
       });
-      assert.equal(audited.ok, true);
+      assert.equal(audited.ok, false);
       assert.equal(existsSync(homePresetRoot), false);
 
       const installed = runJson(rootDir, ["preset", "install", sourceDir], true, {

--- a/packages/cli/test/script-host-boundary.test.ts
+++ b/packages/cli/test/script-host-boundary.test.ts
@@ -250,7 +250,7 @@ test("CLI script host denies descendants of a non-recursive write file scope", (
     ], false);
 
     assert.equal(result.ok, false);
-    assert.equal(result.error.code, "script_scope_violation_write");
+    assert.equal(result.error.code, "preset_write_scope_invalid");
     assert.equal(existsSync(path.join(
       rootDir,
       "harness/tasks/task-exact-file-writer/artifacts/receipt.json/escaped.txt"

--- a/packages/daemon/test/fence-durability.test.ts
+++ b/packages/daemon/test/fence-durability.test.ts
@@ -85,11 +85,14 @@ test("kill -9 and restart preserves every fsynced durability audit record", asyn
         backupWatermark: "watermark-" + index,
         backupBoundSatisfied: true
       });
-      console.log(index);
+      process.stdout.write(String(index) + "\\n");
     }
   `;
+  const childEnv = { ...process.env, FORCE_COLOR: "0" };
+  delete childEnv.NO_COLOR;
   const child = spawn(process.execPath, ["--input-type=module", "--eval", childScript, moduleUrl, ledgerPath], {
-    stdio: ["ignore", "pipe", "pipe"]
+    stdio: ["ignore", "pipe", "pipe"],
+    env: childEnv
   });
   let acknowledged = -1;
   let buffered = "";
@@ -97,6 +100,9 @@ test("kill -9 and restart preserves every fsynced durability audit record", asyn
     await new Promise<void>((resolve, reject) => {
       child.once("error", reject);
       child.stderr?.on("data", (chunk) => reject(new Error(String(chunk))));
+      child.once("exit", (code, signal) => {
+        if (acknowledged < 24) reject(new Error(`durability child exited before acknowledgement 24 (code=${code}, signal=${signal})`));
+      });
       child.stdout?.on("data", (chunk) => {
         buffered += String(chunk);
         const lines = buffered.split("\n");
@@ -107,8 +113,9 @@ test("kill -9 and restart preserves every fsynced durability audit record", asyn
         if (acknowledged >= 24) resolve();
       });
     });
+    const exited = once(child, "exit");
     assert.equal(child.kill("SIGKILL"), true);
-    await once(child, "exit");
+    await exited;
 
     const afterCrash = await readSingleAuthorityDurabilityLedger(ledgerPath);
     assert.equal(acknowledged >= 24, true);


### PR DESCRIPTION
# English

## Summary

Two checkers were reporting "no problems" while the things they checked were broken.

`ha preset inspect/check` validated only the **shape** of a manifest — never whether the entrypoints it declares can actually run. It reported `valid: true, issueCount: 0` for a preset whose scaffold script did not exist, and for `usage-acceptance`, whose three entrypoints all failed. **A tool we use to verify "is this usable?" was itself unusable, and the checker said it was fine.**

Separately, `--dry-run` receipts previewed nothing. The whole point of a dry run is to show you what is about to be written; ours returned an empty shell, so the one question a dry run exists to answer could not be answered.

**A checker that reports "fine" while the thing is broken is worse than no checker: it makes people stop looking.**

## What Changed

- **`preset check` now runs a real dry-run smoke against every declared entrypoint.** Script entrypoints must exist, be resolvable, execute in an isolated staging area, and **return `script-result.ok = true`** — a script that runs but reports failure is now an issue, not a pass.
- **Command entrypoints are validated against the CLI's real capability registry**, not a hand-written list. The capability set lives in one place (`preset-entrypoint-capabilities.ts`) and is consumed by both the arg parser and the gate; a projection test pins the help literal so a second, rot-prone allowlist cannot appear. **An entrypoint the CLI can never dispatch is not valid.**
- **`writes` scope / `outputRoot` consistency** is enforced on both the real run and the dry run.
- **Every `--dry-run` command now emits a structured `preview`** (27/27). `decision propose --dry-run` now reports `chosenCount: 2, rejectedCount: 2` instead of an empty shell.
- **Every issue carries a `nextCommand`** — the error tells you what to type next.
- `create-milestone` was missing its scripts entirely; its package is now complete and its renderer self-contained (the real run exposed a cross-package template dependency that the old checker never saw).

## Task And Scope

PLT-XD / XD-8 (`task_01KXGHMJ67J62QFY6D3YCVZD2C`). Scope: preset extension commands, script host, CLI capability registry. No daemon/identity surface, no CI workflow.

## Version Impact

None (developer tooling; preset validation is stricter).

## Governance Declaration

No gate weakened. This makes an existing gate actually enforce what it always claimed to enforce. Aligns with `dec_01KXGDXZG03JZRGTW8V91H11ER` (experience charter): a rejection that does not tell you the next command is a defect.

## Verification

Positive controls, raw output in the task package:

- `create-milestone`: before `valid:true / 0 issues` → after **`valid:false / 3 bad entrypoints`**, each with a `nextCommand` → complete package → `valid:true`.
- **The real `usage-acceptance`** (project layer, lives in git-ignored `.harness/` — invisible from a worktree, which is why the first round of this work missed it): before `valid:true / 0 issues` → after **`valid:false / 2 issues`** (`capture` was never a registered capability; `check` returned `ok:false`) → product fixed → `valid:true`.
- **Full scan including project layer: 20 presets, 11 valid, 9 invalid, 10 real issues.** The previous scan reported "13/13 valid, 0 issues" — that zero was an artifact of the worktree not carrying the project layer, not a fact.
- `npm run check:ci`: 13 runnable jobs green; `pr-body-lint` skipped by contract (needs a real PR body).

## Review Evidence

Reviewed by CEO by running the gate's own CLI against the canonical repo, then **actually invoking the entrypoints it declared healthy**. The first round was rejected exactly this way: the gate said `valid:true` while `capture` returned `invalid_entrypoint` and `check` returned `script_result_failed`.

## Residual Risk

**9 presets remain invalid with 10 open issues.** They are enumerated in the scan artifact and are NOT fixed here — this PR makes them visible, it does not repair them. That visibility is the deliverable; the repairs are follow-up work.

`preset run` still reports `preset_script_result_failed` without surfacing the script's own violations — the reason lives in `preset-result.json` and you have to go dig it out. That is a real ergonomic defect and belongs to XD-6 (errors must teach the next step).

## References

- `dec_01KXGDXZG03JZRGTW8V91H11ER` (experience charter: rejections must teach the next command)
- ADR-0022 (gate defense: a gate must verify that a thing *runs*, not that it *looks right*)

---

# 中文

## 概要

两个检测器在报"没问题"，而它们检查的东西是坏的。

`ha preset inspect/check` 只验 manifest 的**形状**——**从不验证它声明的入口是否真的能跑**。一个 scaffold 脚本根本不存在的 preset，它报 `valid: true, issueCount: 0`；`usage-acceptance` 三个入口全跑不通，它同样报 valid。**一个我们用来验收「这东西能不能用」的工具，自己不能用，而检测器说它没问题。**

另一边，`--dry-run` 的回执什么都不预览。dry-run 的全部意义就是"写之前让你看清楚要写什么"，而我们的返回一个空壳——它存在的唯一理由，恰恰是它答不了的那个问题。

**一个"说没问题"的坏检测器，比没有检测器更危险：它让人停止检查。**

## 改动内容

- **`preset check` 现在对每个声明的 entrypoint 做真实的 dry-run smoke**：脚本必须存在、可解析、在隔离 staging 中真实执行，并且**返回的 `script-result.ok` 必须为 true**——**脚本跑得起来但报失败，现在算 issue，不算通过**。
- **命令类入口按 CLI 的真实 capability 注册表校验**，不是手写清单。capability 集合集中在一处（`preset-entrypoint-capabilities.ts`），parser 与检测门**共同消费**，help 的 literal 被投影测试锁住，**不会形成第二份会腐烂的白名单**。**一个 CLI 永远派发不到的入口，不是 valid 的。**
- **`writes` scope / `outputRoot` 一致性**在真实运行与 dry-run 上共同执行。
- **全部 27 个支持 `--dry-run` 的命令统一生成结构化 `preview`**。`decision propose --dry-run` 现在如实报出 `chosenCount: 2, rejectedCount: 2`，不再是空壳。
- **每条 issue 都带 `nextCommand`**——报错告诉你下一步敲什么。
- `create-milestone` 的脚本整个是缺的；现已补齐安装包，renderer 改为自包含（**真跑一次才暴露出它跨包读 sibling 模板**，旧 checker 永远看不见这个）。

## 任务与范围

PLT-XD / XD-8（`task_01KXGHMJ67J62QFY6D3YCVZD2C`）。范围：preset 扩展命令、script host、CLI capability 注册表。不碰 daemon/identity 面，不碰 CI workflow。

## 版本影响

无（开发者工具；preset 校验变严）。

## 治理声明

未削弱任何门。本 PR 让一道既有的门**真正执行它一直声称在执行的事**。对齐 `dec_01KXGDXZG03JZRGTW8V91H11ER`（体验设计宪章）：拒绝性报错若不告诉你下一步敲什么，即为缺陷。

## 验证

阳性对照，原始输出在任务包：

- `create-milestone`：修复前 `valid:true / 0 issue` → 新门报 **`valid:false / 3 个坏入口`**，每条带 `nextCommand` → 补齐安装包 → `valid:true`。
- **真实的 `usage-acceptance`**（project layer，住在 git-ignored 的 `.harness/`——**worktree 里看不见它，这正是本任务第一轮漏掉它的原因**）：修复前 `valid:true / 0 issue` → 新门报 **`valid:false / 2 issue`**（`capture` 从未注册为 capability；`check` 返回 `ok:false`）→ 修好产品 → `valid:true`。
- **含 project layer 的全量扫描：20 个 preset，11 valid、9 invalid、10 条真实 issue。** 上一轮报的"13/13 valid、0 issue"，**那个 0 是 worktree 看不见 project layer 造成的假绿，不是事实。**
- `npm run check:ci`：13 个本地可运行 job 全绿；`pr-body-lint` 按契约跳过（需真实 PR body）。

## 审查证据

CEO 用**这道门自己构建的 CLI** 指向 canonical 仓复跑，然后**真的去调用它判为健康的那些入口**。第一轮正是这样被打回的：门说 `valid:true`，而 `capture` 返回 `invalid_entrypoint`、`check` 返回 `script_result_failed`。

## 残余风险

**仍有 9 个 preset 是 invalid 的，10 条 issue 未修。** 它们被完整列进扫描产物，**本 PR 只让它们可见，不修它们**——可见性本身就是交付物，修复是后续工作。

`preset run` 失败时仍只报 `preset_script_result_failed`，**不摊出脚本自己的 violations**——真正的原因埋在 `preset-result.json` 里要自己去翻。这是真实的可用性缺陷，归 XD-6（报错必须教路）。

## 关联材料

- `dec_01KXGDXZG03JZRGTW8V91H11ER`（体验设计宪章：拒绝必须教路）
- ADR-0022（门的防御：门要验的是"它真的能跑"，不是"它长得对"）
