### PR TITLE
fix: a local client can no longer declare who it is (XD-1/XD-2 — R14, R17, identity chain, daemon scope)

### DIFF
--- a/docs-release/operations-server-daemon.md
+++ b/docs-release/operations-server-daemon.md
@@ -17,9 +17,10 @@ in [Team onboarding with SSH forced commands](#team-onboarding-with-ssh-forced-c
 - Local daemon, multiple repositories on one machine: register each repository
   in the user daemon registry, start one daemon, and route commands with
   `--repo <id>`.
-- Remote SSH relay: use `HARNESS_DAEMON_MODE=remote` for one CLI command at a
-  time. The client runs `ssh <host> ha daemon connect --stdio`; sshd's forced
-  command connects that stdio stream to the persistent local daemon.
+- Remote SSH relay: persist `settings.identity.mode: remote` for that repository.
+  The client runs `ssh <host> ha daemon connect --stdio`; sshd's forced command
+  connects that stdio stream to the persistent daemon. A repository cannot be
+  both local and remote, and an unreachable remote fails closed.
 
 Unsupported deployments:
 
@@ -88,6 +89,26 @@ Use `HARNESS_DAEMON_MODE=direct` only for explicit initialization, recovery, or
 test fixtures that cannot yet have a daemon. Do not advertise it as a lock
 conflict workaround.
 
+`ha init` declares `settings.identity.mode: local` by default and creates the
+machine roster at `~/.harness/people.yaml` when it is absent. A project may add
+`harness/people.yaml` as an overlay, but it cannot bind a machine credential to
+a different person. Daemon and direct recovery resolution use the same chain:
+machine roster, then project overlay, then the remote authority for remote-mode
+repositories.
+
+For CI or a filesystem sandbox, select an isolated profile explicitly. Its
+registry, machine roster, and endpoint identity live below the repository's
+`.harness/daemon-profile` instead of `~/.harness`:
+
+```bash
+ha --daemon-profile isolated init
+ha --daemon-profile isolated daemon repo register --repo-id ci --root "$PWD"
+ha --daemon-profile isolated task list
+```
+
+`--daemon-profile default|isolated` and `--daemon-mode direct|local|remote` are
+one-process overrides; repository mode remains the persistent declaration.
+
 ## Multi-Repository Registry
 
 Register every local canonical repository that one daemon should serve:
@@ -131,18 +152,18 @@ closed instead of treating an unknown Markdown file as prose.
 
 ## Remote SSH Relay
 
-Remote mode is a single-command client of a persistent remote daemon. It opens
-an SSH stdio session, which the server's forced command relays to the daemon:
+Remote mode is a client of a persistent remote daemon. Declare the repository
+mode in `harness/harness.yaml`, then provide the connection coordinates. It
+opens an SSH stdio session, which the server's forced command relays to the daemon:
 
 ```bash
-HARNESS_DAEMON_MODE=remote \
 HARNESS_DAEMON_SSH_HOST=team-host \
 HARNESS_DAEMON_REMOTE_ROOT=/srv/harness/team \
 HARNESS_DAEMON_REMOTE_HA=ha \
 ha task list
 ```
 
-`HARNESS_DAEMON_MODE`, `HARNESS_DAEMON_SSH_HOST`, and
+`settings.identity.mode: remote`, `HARNESS_DAEMON_SSH_HOST`, and
 `HARNESS_DAEMON_REMOTE_ROOT` are required. `HARNESS_DAEMON_REMOTE_HA` defaults
 to `ha`; set it when the remote binary path is different. Set
 `HARNESS_DAEMON_REPO_ID` when the remote side should serve a registered repo id
@@ -236,8 +257,12 @@ the `0700` directory and `0600` socket permit only the owner to connect. Widenin
 either permission invalidates this boundary and requires a different identity
 source.
 
-`harness/people.yaml` enables roster-based authorization when it exists. Without
-that roster, local connections are trusted by the transport boundary.
+`~/.harness/people.yaml` is the machine identity authority. A repository-level
+`harness/people.yaml` overlays it without silently rebinding credentials. If no
+usable roster exists, writes fail with setup instructions rather than inventing
+a principal. A forced-command bootstrap principal is honored only for a repo
+declared `remote`; local mode consumes and ignores it, then uses the socket-owner
+boundary.
 
 ## Service Templates
 

--- a/docs-release/operations-server-daemon.zh-CN.md
+++ b/docs-release/operations-server-daemon.zh-CN.md
@@ -77,6 +77,23 @@ ha task list
 只有初始化、恢复或无法启动 daemon 的测试 fixture 才显式使用
 `HARNESS_DAEMON_MODE=direct`；不要把它写成锁冲突的绕行方案。
 
+`ha init` 默认显式写入 `settings.identity.mode: local`，并在缺失时创建机器级
+`~/.harness/people.yaml`。项目可用 `harness/people.yaml` 覆盖资料和权限，但不得把机器级
+credential 静默改绑给另一个 person。daemon 与 direct recovery 共用同一条解析链：机器级
+roster → 项目覆盖 → remote 项目的远程权威。
+
+CI / sandbox 必须显式选择 isolated profile；registry、机器 roster 与 endpoint identity 会落在
+项目 `.harness/daemon-profile` 下，不写 `~/.harness`：
+
+```bash
+ha --daemon-profile isolated init
+ha --daemon-profile isolated daemon repo register --repo-id ci --root "$PWD"
+ha --daemon-profile isolated task list
+```
+
+`--daemon-profile default|isolated` 与 `--daemon-mode direct|local|remote` 只覆盖当前进程；
+repo config 仍是持久 mode 声明。remote 不可达时 fail-closed，不会降级成本地身份。
+
 ## 多仓 Registry
 
 把同一个 daemon 要服务的每个本地 canonical 仓库都注册进去：
@@ -117,18 +134,17 @@ Markdown fail closed，不会因为扩展名像 prose 就擅自放行。
 
 ## Remote SSH Relay
 
-Remote 模式是持久远程 daemon 的单命令客户端。它打开一个 SSH stdio 会话，服务器的 forced
-command 会把该会话 relay 到 daemon：
+Remote 模式连接持久远程 daemon。先在 repo config 声明 `settings.identity.mode: remote`，
+再提供连接坐标。客户端会打开 SSH stdio 会话，服务器的 forced command 把它 relay 到 daemon：
 
 ```bash
-HARNESS_DAEMON_MODE=remote \
 HARNESS_DAEMON_SSH_HOST=team-host \
 HARNESS_DAEMON_REMOTE_ROOT=/srv/harness/team \
 HARNESS_DAEMON_REMOTE_HA=ha \
 ha task list
 ```
 
-`HARNESS_DAEMON_MODE`、`HARNESS_DAEMON_SSH_HOST` 和
+repo 的 `settings.identity.mode: remote`、`HARNESS_DAEMON_SSH_HOST` 和
 `HARNESS_DAEMON_REMOTE_ROOT` 是必需项。`HARNESS_DAEMON_REMOTE_HA` 默认是
 `ha`；远端二进制路径不是 `ha` 时再设置。远端需要服务非 `canonical` 的已注册仓库
 id 时，设置 `HARNESS_DAEMON_REPO_ID`。
@@ -206,8 +222,10 @@ Unix transport 不读取连接进程的身份。它记录
 的客户端之所以归属该 owner，只因为 `0700` 目录与 `0600` socket 仅允许 owner
 连接。放宽任一权限都会使这个边界失效，届时必须改用其他身份来源。
 
-存在 `harness/people.yaml` 时会启用基于 roster 的授权。没有这份 roster 时，本地连接
-完全信任 transport 边界。
+`~/.harness/people.yaml` 是机器级身份权威；项目 `harness/people.yaml` 在其上覆盖且不得
+静默改绑 credential。没有可用 roster 时，写入会带配置命令 fail-closed。本地 repo 即使收到
+forced-command 首帧也会忽略其中的 personId，仍按 socket owner boundary 解析；只有显式
+`remote` 的 repo 才采信该帧。
 
 ## 服务模板
 

--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -7,20 +7,36 @@ import type { HarnessLayoutOverrides } from "../../../kernel/src/index.ts";
 import type { CliResult, ParsedCommand } from "./types.ts";
 
 export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] } {
-  const { rootDir, authoredRoot, daemonRepoId, actor, json, args: rawArgs } = stripGlobalOptions(argv);
+  const { rootDir, authoredRoot, daemonRepoId, actor, daemonMode, daemonProfile, json, args: rawArgs } = stripGlobalOptions(argv);
   const jsonInput = applyJsonInputLayer(rawArgs, process.cwd());
   if (!jsonInput.ok) return { ok: false, error: jsonInput.error };
   const args = jsonInput.args;
   const layoutOverrides = authoredRoot ? { authoredRoot } : undefined;
 
   const help = parseHelpRequest(args, rootDir, json, layoutOverrides);
-  if (help) return attachActor(attachDaemonRepoId(help, daemonRepoId), actor);
+  if (help) return attachDaemonOverrides(attachActor(attachDaemonRepoId(help, daemonRepoId), actor), daemonMode, daemonProfile);
 
   const parsed = parseRegisteredCommand(args, rootDir, json, jsonInput.input);
-  if (parsed) return attachActor(attachDaemonRepoId(attachLayoutOverrides(parsed, layoutOverrides), daemonRepoId), actor);
+  if (parsed) return attachDaemonOverrides(attachActor(attachDaemonRepoId(attachLayoutOverrides(parsed, layoutOverrides), daemonRepoId), actor), daemonMode, daemonProfile);
   return {
     ok: false,
     error: cliError(CliErrorCode.UnknownCommand, `Supported commands: ${commandRegistry.map((entry) => entry.primary).join("; ")}, template list, template render, preset validate, vertical validate.`)
+  };
+}
+
+function attachDaemonOverrides(
+  parsed: { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] },
+  daemonMode: ParsedCommand["daemonModeOverride"],
+  daemonProfile: ParsedCommand["daemonProfileOverride"]
+): typeof parsed {
+  if (!parsed.ok) return parsed;
+  return {
+    ok: true,
+    value: {
+      ...parsed.value,
+      ...(daemonMode ? { daemonModeOverride: daemonMode } : {}),
+      ...(daemonProfile ? { daemonProfileOverride: daemonProfile } : {})
+    }
   };
 }
 

--- a/packages/cli/src/cli/parse-options.ts
+++ b/packages/cli/src/cli/parse-options.ts
@@ -6,6 +6,8 @@ export interface GlobalParseOptions {
   readonly authoredRoot?: string;
   readonly daemonRepoId?: string;
   readonly actor?: string;
+  readonly daemonMode?: "direct" | "local" | "remote";
+  readonly daemonProfile?: "default" | "isolated";
   readonly json: boolean;
   readonly args: ReadonlyArray<string>;
 }
@@ -15,6 +17,8 @@ export function stripGlobalOptions(argv: ReadonlyArray<string>, cwd = process.cw
   const authoredRoot = readOption(argv, "--authored-root") ?? readNonEmptyProcessEnv("HARNESS_AUTHORED_ROOT");
   const daemonRepoId = readOption(argv, "--repo") ?? readNonEmptyProcessEnv("HARNESS_DAEMON_REPO_ID");
   const actor = readOption(argv, "--actor");
+  const daemonMode = readDaemonMode(readOption(argv, "--daemon-mode"));
+  const daemonProfile = readDaemonProfile(readOption(argv, "--daemon-profile"));
   const json = argv.includes("--json");
   const args = argv.filter((arg, index) => {
     const previous = argv[index - 1];
@@ -26,9 +30,25 @@ export function stripGlobalOptions(argv: ReadonlyArray<string>, cwd = process.cw
       && arg !== "--repo"
       && previous !== "--repo"
       && arg !== "--actor"
-      && previous !== "--actor";
+      && previous !== "--actor"
+      && arg !== "--daemon-mode"
+      && previous !== "--daemon-mode"
+      && arg !== "--daemon-profile"
+      && previous !== "--daemon-profile";
   });
-  return { rootDir, authoredRoot, daemonRepoId, actor, json, args };
+  return { rootDir, authoredRoot, daemonRepoId, actor, daemonMode, daemonProfile, json, args };
+}
+
+function readDaemonMode(value: string | undefined): GlobalParseOptions["daemonMode"] {
+  if (value === undefined) return undefined;
+  if (value === "direct" || value === "local" || value === "remote") return value;
+  throw new Error("--daemon-mode must be direct, local, or remote.");
+}
+
+function readDaemonProfile(value: string | undefined): GlobalParseOptions["daemonProfile"] {
+  if (value === undefined) return undefined;
+  if (value === "default" || value === "isolated") return value;
+  throw new Error("--daemon-profile must be default or isolated.");
 }
 
 function readNonEmptyProcessEnv(name: string): string | undefined {

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -187,6 +187,8 @@ export interface ParsedCommand {
   readonly layoutOverrides?: HarnessLayoutOverrides;
   readonly daemonRepoId?: string;
   readonly actor?: string;
+  readonly daemonModeOverride?: "direct" | "local" | "remote";
+  readonly daemonProfileOverride?: "default" | "isolated";
   readonly json: boolean;
   readonly action:
     | { readonly kind: "init"; readonly addNpmScripts: boolean; readonly projectName?: string }

--- a/packages/cli/src/commands/core/init.ts
+++ b/packages/cli/src/commands/core/init.ts
@@ -7,6 +7,7 @@ import { initializeHarness } from "../init.ts";
 import type { CommandRunner } from "../../cli/runner-registry.ts";
 import type { CliResult } from "../../cli/types.ts";
 import { resolveLocalCliBootstrapAuthor } from "../../composition/actor-attribution.ts";
+import { daemonUserRootForRepo, ensureMachinePeopleRoster } from "../../../../daemon/src/index.ts";
 
 const initSmokeTitle = "Harness onboarding smoke";
 const initSmokeSlug = "harness-onboarding-smoke";
@@ -15,7 +16,12 @@ export const runInitCommand: CommandRunner = (context, command) => {
   const action = command.action as Extract<typeof command.action, { readonly kind: "init" }>;
   return Effect.sync(() => {
     try {
-      return initializeHarness(context.layoutInput, action.addNpmScripts, action.projectName, resolveLocalCliBootstrapAuthor(process.env, command.actor));
+      const author = resolveLocalCliBootstrapAuthor(process.env, command.actor);
+      const result = initializeHarness(context.layoutInput, action.addNpmScripts, action.projectName, author);
+      if (result.ok && (!process.env.NODE_TEST_CONTEXT || process.env.HARNESS_BOOTSTRAP_MACHINE_IDENTITY === "1")) {
+        ensureMachinePeopleRoster(daemonUserRootForRepo(context.rootDir, process.env), author);
+      }
+      return result;
     } catch (error) {
       return {
         ok: false,

--- a/packages/cli/src/commands/daemon/identity.ts
+++ b/packages/cli/src/commands/daemon/identity.ts
@@ -8,10 +8,12 @@ import {
   hasPersonRegistry,
   loadPersonRegistry,
   loadPeopleRoster,
+  loadPeopleRosterFile,
   makePeopleRosterIdentityAdminSnapshot,
   makePersonAuthorizationProvider,
   makeTransportDerivedAuthenticationProvider,
   makeTransportDerivedIdentityProvider,
+  mergePeopleRosters,
   personRegistryFromLegacyRoster,
   personRegistryFromRecords,
   validatePeopleRosterReferences,
@@ -28,8 +30,10 @@ export function loadDaemonIdentityWithEmail(
   rootDir: string,
   layoutOverrides: { readonly authoredRoot?: string } | undefined,
   primaryEmail: string | undefined,
-  endpoint?: string
+  endpoint?: string,
+  userRoot?: string
 ): {
+  readonly mode: "local" | "remote";
   readonly personRegistry?: PersonRegistry;
   readonly identityProvider?: IdentityProvider;
   readonly identityAdminSnapshot?: IdentityAdminSnapshot;
@@ -38,30 +42,75 @@ export function loadDaemonIdentityWithEmail(
   const runtimeContext = createHarnessRuntimeContext(rootDir, layoutOverrides);
   const layout = resolveHarnessLayout(runtimeContext);
   const peoplePath = path.join(layout.authoredRoot, "people.yaml");
+  const machinePeoplePath = userRoot ? path.join(userRoot, "people.yaml") : undefined;
   const transportOptions = {
     localUnixIssuer: `host:${os.hostname()}`,
     sshExecIssuer: `host:${os.hostname()}`,
     namedPipeIssuer: `host:${os.hostname()}:named-pipe`
   };
-  if (!existsSync(peoplePath)) {
+  const mode = daemonIdentityMode(runtimeContext);
+  const hasProjectRoster = existsSync(peoplePath);
+  const hasMachineRoster = machinePeoplePath !== undefined && existsSync(machinePeoplePath);
+  if (!hasProjectRoster && !hasMachineRoster) {
+    if (mode === "remote") return { mode };
     const configured = configuredLocalIdentity(runtimeContext, primaryEmail, endpoint, transportOptions);
-    if (!configured) return {};
+    if (!configured) return { mode };
     return {
+      mode,
       ...configured,
       appendRuntimeEvent: makeRuntimeEventAppendPromise(makeRuntimeEventLedgerService({ rootInput: runtimeContext }))
     };
   }
-  const peopleRoster = loadPeopleRoster(runtimeContext);
+  const projectRoster = hasProjectRoster ? loadPeopleRoster(runtimeContext) : undefined;
+  const machineRoster = hasMachineRoster ? loadPeopleRosterFile(machinePeoplePath) : undefined;
+  const peopleRoster = machineRoster && projectRoster
+    ? mergePeopleRosters(machineRoster, projectRoster)
+    : machineRoster ?? projectRoster!;
   const personRegistry = hasPersonRegistry(runtimeContext)
-    ? loadPersonRegistry(runtimeContext)
+    ? mergedPersonRegistry(loadPersonRegistry(runtimeContext), peopleRoster)
     : personRegistryFromLegacyRoster(peopleRoster);
   validatePeopleRosterReferences(personRegistry, peopleRoster);
+  const identityProvider = makeTransportDerivedIdentityProvider(peopleRoster, transportOptions);
   return {
+    mode,
     personRegistry,
-    identityProvider: makeTransportDerivedIdentityProvider(peopleRoster, transportOptions),
+    identityProvider: mode === "remote" ? requireRemoteForcedCommand(identityProvider) : identityProvider,
     identityAdminSnapshot: makePeopleRosterIdentityAdminSnapshot(peopleRoster, personRegistry),
     appendRuntimeEvent: makeRuntimeEventAppendPromise(makeRuntimeEventLedgerService({ rootInput: runtimeContext }))
   };
+}
+
+function requireRemoteForcedCommand(provider: IdentityProvider): IdentityProvider {
+  return {
+    providerId: provider.providerId,
+    authenticate: (evidence) => evidence.sshForcedCommand
+      ? provider.authenticate(evidence)
+      : Promise.resolve({
+        ok: false,
+        code: "credential_unavailable",
+        providerId: provider.providerId,
+        message: "Remote repo identity requires an SSH authorized_keys forced-command connection; local socket-owner identity is disabled for mode: remote."
+      }),
+    authorize: (input) => provider.authorize(input)
+  };
+}
+
+function mergedPersonRegistry(
+  projectRegistry: PersonRegistry,
+  roster: ReturnType<typeof loadPeopleRoster>
+): PersonRegistry {
+  const records = new Map(roster.people.map((person) => [person.personId, {
+    personId: person.personId,
+    displayName: person.displayName ?? person.personId,
+    ...(person.disabled ? { disabled: true } : {})
+  }]));
+  for (const person of projectRegistry.people) records.set(person.personId, person);
+  return personRegistryFromRecords([...records.values()]);
+}
+
+function daemonIdentityMode(rootInput: ReturnType<typeof createHarnessRuntimeContext>): "local" | "remote" {
+  const settings = readProjectHarnessSettings(rootInput, "daemon-identity-mode");
+  return settings.ok ? settings.settings.identity?.mode ?? "local" : "local";
 }
 
 function configuredLocalIdentity(
@@ -77,6 +126,8 @@ function configuredLocalIdentity(
   const settings = readProjectHarnessSettings(rootInput, "daemon-identity");
   if (!settings.ok || !settings.settings.identity) return undefined;
   const identity = settings.settings.identity;
+  if (!identity.personId) return undefined;
+  const personId = identity.personId;
   if (!primaryEmail) return undefined;
   const credentials: CredentialRef[] = [
     {
@@ -93,12 +144,12 @@ function configuredLocalIdentity(
   const personRegistry = hasPersonRegistry(rootInput)
     ? loadPersonRegistry(rootInput)
     : personRegistryFromRecords([{
-      personId: identity.personId,
-      displayName: identity.displayName ?? identity.personId
+      personId,
+      displayName: identity.displayName ?? personId
     }]);
-  const person = personRegistry.find(identity.personId);
-  if (!person) throw new Error(`Configured identity is not registered: ${identity.personId}`);
-  if (person.disabled) throw new Error(`Configured identity is disabled: ${identity.personId}`);
+  const person = personRegistry.find(personId);
+  if (!person) throw new Error(`Configured identity is not registered: ${personId}`);
+  if (person.disabled) throw new Error(`Configured identity is disabled: ${personId}`);
   const credentialKeys = new Set(credentials.map(credentialKey));
   const authentication = makeTransportDerivedAuthenticationProvider((credential, providerId) => {
     if (!credentialKeys.has(credentialKey(credential))) {

--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -44,13 +44,13 @@ export interface DaemonServeHooks {
   readonly onStarted?: (status: Record<string, unknown>) => void;
 }
 
-export function loadDaemonIdentity(rootDir: string, layoutOverrides: { readonly authoredRoot?: string } | undefined, endpoint?: string) {
+export function loadDaemonIdentity(rootDir: string, layoutOverrides: { readonly authoredRoot?: string } | undefined, endpoint?: string, userRoot?: string) {
   const runtimeContext = createHarnessRuntimeContext(rootDir, layoutOverrides);
   const authoredRoot = resolveHarnessLayout(runtimeContext).authoredRoot;
   const primaryEmail = process.env.HARNESS_GIT_AUTHOR_EMAIL?.trim()
     || process.env.GIT_AUTHOR_EMAIL?.trim()
     || readGitConfigEmail(authoredRoot);
-  return loadDaemonIdentityWithEmail(rootDir, layoutOverrides, primaryEmail, endpoint);
+  return loadDaemonIdentityWithEmail(rootDir, layoutOverrides, primaryEmail, endpoint, userRoot);
 }
 
 function readGitConfigEmail(authoredRoot: string): string | undefined {
@@ -166,14 +166,18 @@ async function stopDaemon(input: DaemonCommandInput): Promise<number> {
   });
   const layout = resolveHarnessLayout(createHarnessRuntimeContext(target.canonicalRoot, input.layoutOverrides));
   const lockPath = path.join(layout.locksRoot, "global.lock");
-  const before = readDaemonLock(lockPath);
-  if (before.started && typeof before.pid === "number") {
-    process.kill(before.pid, "SIGTERM");
+  const lockStatus = readDaemonLock(lockPath);
+  const rpcStatus = await readReachableDaemonStatus(target);
+  const before = { ...lockStatus, ...rpcStatus };
+  const daemonPid = typeof rpcStatus?.pid === "number" ? rpcStatus.pid : undefined;
+  if (daemonPid !== undefined) {
+    process.kill(daemonPid, "SIGTERM");
   }
-  const stopped = before.started ? await waitForStopped(lockPath, timeoutMs) : true;
+  const stopped = daemonPid !== undefined ? await waitForEndpointStopped(target, timeoutMs) : true;
   emitDaemonResult("daemon-stop", {
     ...before,
-    signaled: before.started,
+    pid: daemonPid ?? null,
+    signaled: daemonPid !== undefined,
     drained: stopped,
     stopped
   }, input.json);
@@ -419,13 +423,13 @@ async function waitForReachableStatus(target: LocalDaemonTarget, timeoutMs: numb
   throw new Error("daemon service did not become reachable before timeout");
 }
 
-async function waitForStopped(lockPath: string, timeoutMs: number): Promise<boolean> {
+async function waitForEndpointStopped(target: LocalDaemonTarget, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
-    if (!readDaemonLock(lockPath).started) return true;
+    if (!await readReachableDaemonStatus(target)) return true;
     await waitDaemonPollInterval(100);
   }
-  return !readDaemonLock(lockPath).started;
+  return !await readReachableDaemonStatus(target);
 }
 
 function emitDaemonResult(command: string, result: Record<string, unknown>, json: boolean): void {
@@ -434,7 +438,7 @@ function emitDaemonResult(command: string, result: Record<string, unknown>, json
     return;
   }
   const parts = [`ok`, `command=${command}`];
-  for (const key of ["started", "reachable", "mode", "queueDepth", "version", "protocolVersion", "pid", "drained", "stopped", "reportPath", "outputDir"] as const) {
+  for (const key of ["started", "reachable", "mode", "queueDepth", "version", "protocolVersion", "pid", "rootDir", "repoId", "endpoint", "drained", "stopped", "reportPath", "outputDir"] as const) {
     if (result[key] !== undefined) parts.push(`${key}=${JSON.stringify(result[key])}`);
   }
   if (typeof result.lockPath === "string") parts.push(`lock=${result.lockPath}`);

--- a/packages/cli/src/commands/daemon/repo-registry.ts
+++ b/packages/cli/src/commands/daemon/repo-registry.ts
@@ -4,6 +4,7 @@ import {
   unregisterDaemonRepo,
   type DaemonRegistryRepo
 } from "../../../../kernel/src/index.ts";
+import { daemonUserRootForRepo } from "../../../../daemon/src/index.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import { readOption } from "../../cli/parse-options.ts";
 
@@ -19,10 +20,9 @@ export function runDaemonRepoCommand(input: DaemonRepoCommandInput): number {
     console.log(renderDaemonRepoHelp());
     return 0;
   }
-  const envUserRoot = process.env.HARNESS_DAEMON_USER_ROOT;
-  const userRoot = readOption(input.args, "--user-root") ?? (envUserRoot && envUserRoot.length > 0 ? envUserRoot : undefined);
+  const userRoot = readOption(input.args, "--user-root") ?? daemonUserRootForRepo(input.rootDir, process.env);
   const options = {
-    ...(userRoot ? { userRoot } : {}),
+    userRoot,
     createConvenienceLinks: !input.args.includes("--no-link")
   };
   try {

--- a/packages/cli/src/commands/daemon/serve-transport.ts
+++ b/packages/cli/src/commands/daemon/serve-transport.ts
@@ -10,6 +10,7 @@ import {
   type DaemonTransportConnection,
   type JsonRpcProtocolServer,
   type NamedPipeTransportServer,
+  type SshForcedCommandBootstrapFrame,
   type UnixSocketTransportServer
 } from "../../../../daemon/src/index.ts";
 
@@ -35,6 +36,7 @@ export interface DaemonLocalTransportOptions {
   readonly endpoint: string;
   readonly platform?: NodeJS.Platform;
   readonly createProtocolServer: (authContext: DaemonAuthenticationContext) => JsonRpcProtocolServer;
+  readonly acceptSshForcedCommand: (frame: SshForcedCommandBootstrapFrame) => boolean;
   readonly onConnection?: (connection: DaemonTransportConnection) => void;
   readonly onConnectionClosed?: (connection: DaemonTransportConnection) => void;
 }
@@ -46,7 +48,7 @@ export function createDaemonLocalTransport(
     return createNamedPipeTransportServer({
       daemonId: options.daemonId,
       pipePath: options.endpoint,
-      acceptSshForcedCommand: true,
+      acceptSshForcedCommand: options.acceptSshForcedCommand,
       createProtocolServer: options.createProtocolServer,
       onConnection: options.onConnection,
       onConnectionClosed: options.onConnectionClosed
@@ -55,7 +57,7 @@ export function createDaemonLocalTransport(
   return createUnixSocketTransportServer({
     daemonId: options.daemonId,
     socketPath: options.endpoint,
-    acceptSshForcedCommand: true,
+    acceptSshForcedCommand: options.acceptSshForcedCommand,
     createProtocolServer: options.createProtocolServer,
     onConnection: options.onConnection,
     onConnectionClosed: options.onConnectionClosed

--- a/packages/cli/src/commands/daemon/status-payload.ts
+++ b/packages/cli/src/commands/daemon/status-payload.ts
@@ -68,6 +68,7 @@ export function daemonStatusPayload(input: {
     schema: "daemon-status/v1",
     started: input.runtimeStatus.started,
     daemonId: input.daemonId,
+    pid: process.pid,
     rootDir,
     repoId,
     endpoint: input.endpoint,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -282,6 +282,8 @@ function writeHarnessYaml(filePath: string, projectName: string, forceNameUpdate
     "  defaultVertical: software/coding",
     "  defaultPreset: standard-task",
     "  defaultProfile: baseline",
+    "  identity:",
+    "    mode: local",
     "  customVerticals:",
     "    enabled: false",
     ""

--- a/packages/cli/src/commands/settings.ts
+++ b/packages/cli/src/commands/settings.ts
@@ -8,7 +8,8 @@ import type { CliResult } from "../cli/types.ts";
 export type HarnessLocale = "zh-CN" | "en-US";
 
 export interface ProjectHarnessIdentity {
-  readonly personId: string;
+  readonly mode: "local" | "remote";
+  readonly personId?: string;
   readonly displayName?: string;
 }
 
@@ -268,7 +269,7 @@ function parseYamlSettings(body: string): { readonly present: boolean; readonly 
     }
     if (inIdentity && customNested) {
       const [, key, rawValue = ""] = customNested;
-      if (key !== "personId" && key !== "displayName") throw new Error(`Unknown settings.identity key: ${key}`);
+      if (key !== "mode" && key !== "personId" && key !== "displayName") throw new Error(`Unknown settings.identity key: ${key}`);
       const value = rawValue.trim();
       if (!value) throw new Error(`settings.identity.${key} must be a scalar value.`);
       settings.identity = { ...(isRecord(settings.identity) ? settings.identity : {}), [key]: unquoteScalar(value) };
@@ -342,11 +343,17 @@ function validateIdentity(command: string, value: unknown):
   if (value === undefined) return { ok: true };
   if (!isRecord(value)) return invalid(command, "settings.identity must be a mapping.");
   const keys = Object.keys(value).sort();
-  if (keys.some((key) => key !== "displayName" && key !== "personId")) {
-    return invalid(command, "settings.identity supports only personId and displayName.");
+  if (keys.some((key) => key !== "displayName" && key !== "mode" && key !== "personId")) {
+    return invalid(command, "settings.identity supports only mode, personId, and displayName.");
   }
-  if (typeof value.personId !== "string" || !SETTINGS_ID_PATTERN.test(value.personId)) {
-    return invalid(command, "settings.identity.personId must be a non-empty identifier.");
+  if (value.mode !== undefined && value.mode !== "local" && value.mode !== "remote") {
+    return invalid(command, "settings.identity.mode must be local or remote.");
+  }
+  if (value.personId !== undefined && (typeof value.personId !== "string" || !SETTINGS_ID_PATTERN.test(value.personId))) {
+    return invalid(command, "settings.identity.personId must be a non-empty identifier when provided.");
+  }
+  if (value.personId === undefined && value.displayName !== undefined) {
+    return invalid(command, "settings.identity.displayName requires settings.identity.personId.");
   }
   if (value.displayName !== undefined && (typeof value.displayName !== "string" || !value.displayName.trim())) {
     return invalid(command, "settings.identity.displayName must be a non-empty string when provided.");
@@ -354,7 +361,8 @@ function validateIdentity(command: string, value: unknown):
   return {
     ok: true,
     value: {
-      personId: value.personId,
+      mode: value.mode === "remote" ? "remote" : "local",
+      ...(typeof value.personId === "string" ? { personId: value.personId } : {}),
       ...(typeof value.displayName === "string" ? { displayName: value.displayName.trim() } : {})
     }
   };

--- a/packages/cli/src/composition/local-principal.ts
+++ b/packages/cli/src/composition/local-principal.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import {
   taskHolderActor,
@@ -6,9 +7,12 @@ import {
   type TaskHolderPrincipal
 } from "../../../application/src/index.ts";
 import {
+  daemonUserRootForRepo,
   hasPersonRegistry,
   loadPeopleRoster,
+  loadPeopleRosterFile,
   loadPersonRegistry,
+  mergePeopleRosters,
   personRegistryFromLegacyRoster,
   validatePeopleRosterReferences
 } from "../../../daemon/src/index.ts";
@@ -67,7 +71,7 @@ export function resolveLocalCliActorAttribution(
     throw new CliActorAttributionError("Local CLI writes require explicit actor attribution.");
   }
 
-  const configured = readConfiguredLocalPrincipalWithSource(rootInput, personRegistry);
+  const configured = readConfiguredLocalPrincipalWithSource(rootInput, personRegistry, env);
   if (assertedActor.kind === "human" && assertedActor.id !== configured.principal.personId) {
     throw new CliActorAttributionError(
       `--actor human:${assertedActor.id} does not match configured principal ${configured.principal.personId}.`
@@ -89,11 +93,11 @@ export function resolveLocalCliActorAttribution(
   };
 }
 
-export function readConfiguredLocalPrincipal(rootInput: HarnessLayoutInput): TaskHolderPersonPrincipal {
-  return readConfiguredLocalPrincipalWithSource(rootInput).principal;
+export function readConfiguredLocalPrincipal(rootInput: HarnessLayoutInput, env: NodeJS.ProcessEnv = process.env): TaskHolderPersonPrincipal {
+  return readConfiguredLocalPrincipalWithSource(rootInput, undefined, env).principal;
 }
 
-function readConfiguredLocalPrincipalWithSource(rootInput: HarnessLayoutInput, registryInput?: PersonRegistry): {
+function readConfiguredLocalPrincipalWithSource(rootInput: HarnessLayoutInput, registryInput?: PersonRegistry, env: NodeJS.ProcessEnv = process.env): {
   readonly principal: TaskHolderPersonPrincipal;
   readonly source: PrincipalSource;
 } {
@@ -101,39 +105,49 @@ function readConfiguredLocalPrincipalWithSource(rootInput: HarnessLayoutInput, r
   if (!settings.ok) {
     throw new CliPrincipalResolutionError(settings.result.error?.hint ?? "Unable to read settings.identity from harness/harness.yaml.");
   }
-  const identity = settings.settings.identity;
-  if (!identity) {
-    throw new CliPrincipalResolutionError(
-      "Local writes require a configured person identity; set settings.identity.personId in harness/harness.yaml."
-    );
-  }
-
   const layout = resolveHarnessLayout(rootInput);
   const peoplePath = path.join(layout.authoredRoot, "people.yaml");
-  const registry = registryInput ?? authoredPersonRegistry(rootInput, peoplePath);
+  const machineUserRoot = localMachineIdentityRoot(layout.rootDir, env);
+  const resolvedRegistry = registryInput
+    ? undefined
+    : resolvedPersonRegistry(rootInput, peoplePath, machineUserRoot);
+  const registry = registryInput ?? resolvedRegistry;
+  const identity = settings.settings.identity;
+  const credentialPersonId = resolvedRegistry?.localCredentialPersonId;
+  if (credentialPersonId && identity?.personId && identity.personId !== credentialPersonId) {
+    throw new CliPrincipalResolutionError(
+      `settings.identity.personId '${identity.personId}' cannot rebind this machine credential from '${credentialPersonId}'.`
+    );
+  }
+  const personId = credentialPersonId ?? identity?.personId;
+  if (!personId) {
+    throw new CliPrincipalResolutionError(
+      "Local writes require a machine identity. Run: ha init with HARNESS_GIT_AUTHOR_NAME and HARNESS_GIT_AUTHOR_EMAIL set, or add the current host/uid credential to ~/.harness/people.yaml."
+    );
+  }
   if (!registry) {
     const authorityPath = layout.configPath ?? path.join(layout.authoredRoot, "harness.yaml");
     return {
       principal: {
-        personId: identity.personId,
-        ...(identity.displayName ? { displayName: identity.displayName } : {})
+        personId,
+        ...(identity?.displayName ? { displayName: identity.displayName } : {})
       },
       source: localPrincipalSource("harness.yaml", authorityPath)
     };
   }
 
-  const profile = registry.find(identity.personId);
+  const profile = registry.find(personId);
   if (!profile) {
     throw new CliPrincipalResolutionError(
-      `settings.identity.personId '${identity.personId}' is not present in ${registry.authority}.`
+      `settings.identity.personId '${personId}' is not present in ${registry.authority}.`
     );
   }
   if (profile.disabled) {
-    throw new CliPrincipalResolutionError(`settings.identity.personId '${identity.personId}' is disabled in ${registry.authority}.`);
+    throw new CliPrincipalResolutionError(`settings.identity.personId '${personId}' is disabled in ${registry.authority}.`);
   }
-  if (identity.displayName && identity.displayName !== profile.displayName) {
+  if (identity?.displayName && identity.displayName !== profile.displayName) {
     throw new CliPrincipalResolutionError(
-      `settings.identity.displayName does not match ${registry.authority} for '${identity.personId}'.`
+      `settings.identity.displayName does not match ${registry.authority} for '${personId}'.`
     );
   }
   return {
@@ -146,25 +160,36 @@ function readConfiguredLocalPrincipalWithSource(rootInput: HarnessLayoutInput, r
   };
 }
 
-function authoredPersonRegistry(rootInput: HarnessLayoutInput, peoplePath: string): PersonRegistry | undefined {
+function resolvedPersonRegistry(rootInput: HarnessLayoutInput, peoplePath: string, userRoot: string | undefined): (PersonRegistry & { readonly localCredentialPersonId?: string }) | undefined {
   const personsPath = path.join(resolveHarnessLayout(rootInput).authoredRoot, "persons.yaml");
-  if (!existsSync(peoplePath) && !existsSync(personsPath)) return undefined;
+  const machinePeoplePath = userRoot ? path.join(userRoot, "people.yaml") : undefined;
+  if (!existsSync(peoplePath) && !existsSync(personsPath) && (!machinePeoplePath || !existsSync(machinePeoplePath))) return undefined;
   let roster: ReturnType<typeof loadPeopleRoster> | undefined;
   try {
-    roster = existsSync(peoplePath) ? loadPeopleRoster(rootInput) : undefined;
-    const registry = hasPersonRegistry(rootInput)
-      ? loadPersonRegistry(rootInput)
+    const projectRoster = existsSync(peoplePath) ? loadPeopleRoster(rootInput) : undefined;
+    const machineRoster = machinePeoplePath && existsSync(machinePeoplePath) ? loadPeopleRosterFile(machinePeoplePath) : undefined;
+    roster = projectRoster && machineRoster ? mergePeopleRosters(machineRoster, projectRoster) : projectRoster ?? machineRoster;
+    const projectRegistry = hasPersonRegistry(rootInput) ? loadPersonRegistry(rootInput) : undefined;
+    const registry = projectRegistry
+      ? projectRegistry
       : roster
         ? personRegistryFromLegacyRoster(roster)
         : undefined;
     if (!registry) return undefined;
-    if (roster) validatePeopleRosterReferences(registry, roster);
-    const authority = hasPersonRegistry(rootInput) ? "persons.yaml" as const : "people.yaml-legacy" as const;
+    const legacyRegistry = roster ? personRegistryFromLegacyRoster(roster) : undefined;
+    if (projectRegistry && projectRoster) validatePeopleRosterReferences(projectRegistry, projectRoster);
+    const authority = projectRegistry ? "persons.yaml" as const : "people.yaml-legacy" as const;
+    const localCredential = roster?.resolveCredential({
+      kind: "unix-socket-owner-boundary",
+      issuer: `host:${os.hostname()}`,
+      subject: String(process.getuid?.() ?? 0)
+    }, "local-configured/v1");
     return {
       authority,
-      authorityPath: authority === "persons.yaml" ? personsPath : peoplePath,
+      authorityPath: authority === "persons.yaml" ? personsPath : (existsSync(peoplePath) ? peoplePath : machinePeoplePath!),
+      ...(localCredential?.ok ? { localCredentialPersonId: localCredential.personId } : {}),
       find: (personId) => {
-        const person = registry.find(personId);
+        const person = registry.find(personId) ?? legacyRegistry?.find(personId);
         if (!person) return undefined;
         const binding = roster?.people.find((candidate) => candidate.personId === personId);
         return {
@@ -180,6 +205,13 @@ function authoredPersonRegistry(rootInput: HarnessLayoutInput, peoplePath: strin
       `Unable to validate settings.identity against the person registry: ${error instanceof Error ? error.message : String(error)}`
     );
   }
+}
+
+function localMachineIdentityRoot(rootDir: string, env: NodeJS.ProcessEnv): string | undefined {
+  const explicitRoot = env.HARNESS_DAEMON_USER_ROOT?.trim();
+  if (explicitRoot) return daemonUserRootForRepo(rootDir, env);
+  if (env.NODE_TEST_CONTEXT && env.HARNESS_BOOTSTRAP_MACHINE_IDENTITY !== "1") return undefined;
+  return daemonUserRootForRepo(rootDir, env);
 }
 
 function localPrincipalSource(authority: "persons.yaml" | "people.yaml-legacy" | "harness.yaml", authorityPath: string): PrincipalSource {

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../application/src/index.ts";
 import {
   daemonIdFromEnv,
-  daemonUserRoot,
+  daemonUserRootForRepo,
   DaemonJsonRpcResponseError,
   defaultDaemonAutostartTimeoutMs,
   defaultDaemonIdleExitMs,
@@ -35,6 +35,7 @@ import { CliActorAttributionError, readCliJournalActorFromEnv, readCliJournalAct
 import { parsePositiveIntegerOr } from "../cli/value-utils.ts";
 import { buildDocSyncSubmitRequest } from "./doc-sync-service.ts";
 import { resolveCanonicalHarnessRoot } from "./canonical-harness-root.ts";
+import { readProjectHarnessSettings } from "../commands/settings.ts";
 
 export {
   daemonIdForRoot,
@@ -73,14 +74,25 @@ type TaskHolderParsedCommand = ParsedCommand & {
   readonly action: { readonly kind: "task-holder"; readonly taskId: string };
 };
 
-export function readDaemonClientConfig(env: NodeJS.ProcessEnv = process.env): DaemonClientConfig {
-  const mode = readMode(env.HARNESS_DAEMON_MODE);
-  const userRoot = daemonUserRoot(env);
+export function readDaemonClientConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  rootDir = process.cwd(),
+  modeOverride?: DaemonClientMode,
+  profileOverride?: "default" | "isolated"
+): DaemonClientConfig {
+  env = {
+    ...env,
+    ...(modeOverride ? { HARNESS_DAEMON_MODE: modeOverride } : {}),
+    ...(profileOverride ? { HARNESS_DAEMON_PROFILE: profileOverride } : {})
+  };
+  const projectMode = readProjectDaemonMode(rootDir);
+  const mode = readMode(env.HARNESS_DAEMON_MODE ?? projectMode);
+  const userRoot = daemonUserRootForRepo(rootDir, env);
   const directWriteReason = readDirectWriteReason(env.HARNESS_DIRECT_WRITE_REASON)
     ?? (env.NODE_TEST_CONTEXT ? "test" : undefined);
   return {
     mode,
-    modeExplicit: typeof env.HARNESS_DAEMON_MODE === "string" && env.HARNESS_DAEMON_MODE.trim().length > 0,
+    modeExplicit: (typeof env.HARNESS_DAEMON_MODE === "string" && env.HARNESS_DAEMON_MODE.trim().length > 0) || projectMode !== undefined,
     idleExitMs: parsePositiveIntegerOr(env.HARNESS_DAEMON_IDLE_MS, defaultDaemonIdleExitMs),
     autostartTimeoutMs: parsePositiveIntegerOr(env.HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS, defaultDaemonAutostartTimeoutMs),
     userRoot,
@@ -90,10 +102,20 @@ export function readDaemonClientConfig(env: NodeJS.ProcessEnv = process.env): Da
   };
 }
 
+function readProjectDaemonMode(rootDir: string): "local" | "remote" | undefined {
+  try {
+    const settings = readProjectHarnessSettings(rootDir, "daemon-client-mode");
+    return settings.ok ? settings.settings.identity?.mode : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function runCommandThroughDaemon(
   command: ParsedCommand,
-  config: DaemonClientConfig = readDaemonClientConfig()
+  config?: DaemonClientConfig
 ): Promise<CommandReceipt | CommandFailureReceipt | undefined> {
+  config ??= readDaemonClientConfig(process.env, command.rootDir, command.daemonModeOverride, command.daemonProfileOverride);
   if (config.mode === "direct") {
     const rejection = directModeRejection(command, config);
     return rejection ?? undefined;
@@ -286,9 +308,13 @@ function directModeRejection(command: ParsedCommand, config: DaemonClientConfig)
 }
 
 function isInitializedHarness(command: ParsedCommand): boolean {
-  const canonicalRoot = resolveCanonicalHarnessRoot(createHarnessRuntimeContext(command.rootDir, command.layoutOverrides));
-  const layout = resolveHarnessLayout(createHarnessRuntimeContext(canonicalRoot, command.layoutOverrides));
-  return existsSync(path.join(layout.authoredRoot, "harness.yaml"));
+  try {
+    const canonicalRoot = resolveCanonicalHarnessRoot(createHarnessRuntimeContext(command.rootDir, command.layoutOverrides));
+    const layout = resolveHarnessLayout(createHarnessRuntimeContext(canonicalRoot, command.layoutOverrides));
+    return existsSync(path.join(layout.authoredRoot, "harness.yaml"));
+  } catch {
+    return false;
+  }
 }
 
 export function remoteDaemonSshArgs(remote: RemoteDaemonConfig): ReadonlyArray<string> {

--- a/packages/cli/src/daemon/service-host.ts
+++ b/packages/cli/src/daemon/service-host.ts
@@ -4,6 +4,8 @@ import {
   makeRuntimeEventLedgerService,
   makeTaskHolderService
 } from "../../../application/src/index.ts";
+import path from "node:path";
+import { realpathSync } from "node:fs";
 import {
   createPtyTerminalSessionService,
   createJsonRpcProtocolServer,
@@ -38,6 +40,7 @@ import {
 type HarnessDaemonRuntime = ReturnType<CliCompositionAdapterProvider["createDaemonRuntime"]>;
 type MultiRepoHarnessDaemonRuntime = ReturnType<CliCompositionAdapterProvider["createMultiRepoDaemonRuntime"]>;
 type RepoServiceBinding = ReturnType<typeof createRepoServiceBinding>;
+type RepoIdentity = ReturnType<typeof loadDaemonIdentity> & { readonly loadError?: string };
 
 export function createDaemonServiceHost(
   runtime: MultiRepoHarnessDaemonRuntime,
@@ -46,10 +49,12 @@ export function createDaemonServiceHost(
   layoutOverrides: { readonly authoredRoot?: string } | undefined,
   idleMs: number,
   endpoint: string,
-  connections: DaemonConnectionStats
+  connections: DaemonConnectionStats,
+  userRoot: string
 ): {
   readonly daemonId: string;
   readonly createProtocolServer: (authContext: DaemonAuthenticationContext) => ReturnType<typeof createJsonRpcProtocolServer>;
+  readonly acceptsSshForcedCommand: (canonicalRoot: string) => boolean;
   readonly status: () => Record<string, unknown>;
   readonly onConnectionStart: () => void;
   readonly onConnectionSettled: () => void;
@@ -103,7 +108,7 @@ export function createDaemonServiceHost(
       runtime,
       layoutOverrides,
       commandOptions,
-      { daemonId, endpoint, connections }
+      { daemonId, endpoint, connections, userRoot }
     )] as const;
   }));
   return {
@@ -113,6 +118,7 @@ export function createDaemonServiceHost(
       repos: sortedDaemonRepos([...reposById.values()]),
       services: defaultRepoBinding().services,
       resolveRepoServices: (repo) => repoBindings.get(repo.repoId)?.services,
+      resolveRepoIdentity: (repo) => repoBindings.get(repo.repoId)?.identity,
       resolveRepoAvailability: (repo) => repoAvailabilityFailure(runtime, repo),
       leaseEnforcementEnabled: (repo) => leaseEnforcementEnabled({ rootDir: repo.canonicalRoot, layoutOverrides }),
       authContext,
@@ -124,6 +130,9 @@ export function createDaemonServiceHost(
         return repoBindings.get(targetRepoId)?.appendRuntimeEvent(input) ?? Promise.resolve();
       }
     }),
+    acceptsSshForcedCommand: (canonicalRoot) => [...repoBindings.values()].some((binding) =>
+      binding.identity.mode === "remote" && sameCanonicalRoot(binding.repo.canonicalRoot, canonicalRoot)
+    ),
     status: () => daemonStatusPayload({
       daemonId,
       rootDir: defaultRepoBinding().repo.canonicalRoot,
@@ -193,7 +202,7 @@ export function createDaemonServiceHost(
             runtime,
             layoutOverrides,
             commandOptions,
-            { daemonId, endpoint, connections }
+            { daemonId, endpoint, connections, userRoot }
           ));
         }
       }
@@ -214,15 +223,15 @@ function createRepoServiceBinding(
   managerRuntime: MultiRepoHarnessDaemonRuntime,
   layoutOverrides: { readonly authoredRoot?: string } | undefined,
   commandOptions: { readonly onCommandStart: () => void; readonly onCommandSettled: () => void },
-  statusOptions?: { readonly daemonId?: string; readonly endpoint?: string; readonly connections?: DaemonConnectionStats }
+  statusOptions?: { readonly daemonId?: string; readonly endpoint?: string; readonly connections?: DaemonConnectionStats; readonly userRoot?: string }
 ): {
   readonly repo: DaemonRepoNamespace;
-  readonly identity: ReturnType<typeof loadDaemonIdentity>;
+  readonly identity: RepoIdentity;
   readonly services: Parameters<typeof createJsonRpcProtocolServer>[0]["services"];
   readonly appendRuntimeEvent: ReturnType<typeof makeRuntimeEventAppendPromise>;
 } {
   const rootDir = repo.canonicalRoot;
-  const identity = loadDaemonIdentity(rootDir, layoutOverrides, statusOptions?.endpoint);
+  const identity = loadRepoIdentity(rootDir, layoutOverrides, statusOptions?.endpoint, statusOptions?.userRoot);
   const taskWriter = selectCliAdapterProvider("task.lifecycle").createLifecycleEngine({
     rootDir,
     layoutOverrides,
@@ -298,6 +307,22 @@ function createRepoServiceBinding(
   };
 }
 
+function loadRepoIdentity(
+  rootDir: string,
+  layoutOverrides: { readonly authoredRoot?: string } | undefined,
+  endpoint: string | undefined,
+  userRoot: string | undefined
+): RepoIdentity {
+  try {
+    return loadDaemonIdentity(rootDir, layoutOverrides, endpoint, userRoot);
+  } catch (error) {
+    return {
+      mode: "local",
+      loadError: error instanceof Error ? error.message : String(error)
+    };
+  }
+}
+
 function repoAvailabilityFailure(
   runtime: MultiRepoHarnessDaemonRuntime,
   repo: DaemonRepoNamespace
@@ -333,4 +358,16 @@ function repoAvailabilityFailure(
 
 function sortedDaemonRepos(repos: ReadonlyArray<DaemonRepoNamespace>): ReadonlyArray<DaemonRepoNamespace> {
   return [...repos].sort((left, right) => left.repoId.localeCompare(right.repoId) || left.canonicalRoot.localeCompare(right.canonicalRoot));
+}
+
+function sameCanonicalRoot(left: string, right: string): boolean {
+  return canonicalRootIdentity(left) === canonicalRootIdentity(right);
+}
+
+function canonicalRootIdentity(value: string): string {
+  try {
+    return realpathSync(value);
+  } catch {
+    return path.resolve(value);
+  }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,6 +33,9 @@ type DaemonServeRepo = DaemonRepoNamespace & Pick<DaemonRegistryRepo, "displayNa
 const createMultiRepoDaemonRuntime = daemonRuntimeProvider.createMultiRepoDaemonRuntime;
 
 export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)): Promise<number> {
+  const daemonOverrides = stripGlobalOptions(argv);
+  if (daemonOverrides.daemonMode) process.env.HARNESS_DAEMON_MODE = daemonOverrides.daemonMode;
+  if (daemonOverrides.daemonProfile) process.env.HARNESS_DAEMON_PROFILE = daemonOverrides.daemonProfile;
   const daemonExit = await maybeRunDaemonCommand(argv);
   if (daemonExit !== undefined) return daemonExit;
 
@@ -111,11 +114,12 @@ async function runDaemonServe(
       }
       const idleMs = parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true });
       const connections: DaemonConnectionStats = { active: 0, total: 0 };
-      serviceHost = createDaemonServiceHost(runtime, serveRepos, defaultRepoId, layoutOverrides, idleMs, endpoint, connections);
+      serviceHost = createDaemonServiceHost(runtime, serveRepos, defaultRepoId, layoutOverrides, idleMs, endpoint, connections, userRoot);
       serviceHost.startRegistryReconcile(userRoot);
       const transport = createDaemonLocalTransport({
         daemonId: serviceHost.daemonId,
         endpoint,
+        acceptSshForcedCommand: (frame) => serviceHost?.acceptsSshForcedCommand(frame.canonicalRoot) ?? false,
         createProtocolServer: serviceHost.createProtocolServer,
         onConnection: () => {
           connections.active += 1;

--- a/packages/cli/test/actor-attribution-cli.test.ts
+++ b/packages/cli/test/actor-attribution-cli.test.ts
@@ -206,7 +206,10 @@ test("local resolver combines configured principal and asserted executor once", 
   withTempRoot((rootDir) => {
     const attribution = resolveLocalCliActorAttribution(
       { rootDir },
-      actorEnv("agent:codex", "Harness Writer", "writer@example.test")
+      {
+        ...actorEnv("agent:codex", "Harness Writer", "writer@example.test"),
+        HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user")
+      }
     );
     assert.deepEqual(attribution.writeAttribution.actor, {
       principal: { kind: "person", personId: "person_test" },
@@ -239,7 +242,10 @@ test("local resolver rejects a disabled configured person", () => {
     assert.throws(
       () => resolveLocalCliActorAttribution(
         { rootDir },
-        actorEnv("agent:codex", "Harness Writer", "writer@example.test")
+        {
+          ...actorEnv("agent:codex", "Harness Writer", "writer@example.test"),
+          HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user")
+        }
       ),
       /person_test.*disabled/u
     );
@@ -340,7 +346,12 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...env }
+      env: {
+        ...process.env,
+        HARNESS_DAEMON_MODE: "direct",
+        HARNESS_DIRECT_WRITE_REASON: "test",
+        ...env
+      }
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/anchor-backfill-cli.test.ts
+++ b/packages/cli/test/anchor-backfill-cli.test.ts
@@ -187,6 +187,8 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
       encoding: "utf8",
       env: {
         ...process.env,
+        HARNESS_DAEMON_MODE: "direct",
+        HARNESS_DIRECT_WRITE_REASON: "test",
         CLAUDE_SESSION_ID: "",
         CLAUDE_CODE_SESSION_ID: "",
         CODEX_THREAD_ID: "",
@@ -214,10 +216,12 @@ function configureTestIdentity(rootDir: string): void {
   const harnessRoot = path.join(rootDir, "harness");
   const configPath = path.join(harnessRoot, "harness.yaml");
   const config = readFileSync(configPath, "utf8");
-  writeFileSync(configPath, config.replace(
-    /^settings:$/mu,
-    "settings:\n  identity:\n    personId: person_test\n    displayName: Harness Test"
-  ), "utf8");
+  writeFileSync(configPath, config.includes("  identity:\n")
+    ? config.replace("  identity:\n", "  identity:\n    personId: person_test\n    displayName: Harness Test\n")
+    : config.replace(
+      /^settings:$/mu,
+      "settings:\n  identity:\n    personId: person_test\n    displayName: Harness Test"
+    ), "utf8");
   execFileSync("git", ["-C", harnessRoot, "add", "harness.yaml"], { stdio: "ignore" });
   execFileSync("git", ["-C", harnessRoot, "-c", "user.name=Harness Test", "-c", "user.email=harness@example.test", "commit", "-m", "test: configure identity"], { stdio: "ignore" });
 }

--- a/packages/cli/test/attribution-diff-cli.test.ts
+++ b/packages/cli/test/attribution-diff-cli.test.ts
@@ -130,7 +130,13 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
       maxBuffer: 256 * 1024 * 1024,
-      env: { ...process.env, ...env }
+      env: {
+        ...process.env,
+        HARNESS_ACTOR: "agent:attribution-diff-test",
+        HARNESS_DAEMON_MODE: "direct",
+        HARNESS_DIRECT_WRITE_REASON: "test",
+        ...env
+      }
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/catalog-snapshot-cli.test.ts
+++ b/packages/cli/test/catalog-snapshot-cli.test.ts
@@ -8,6 +8,8 @@ import { readCatalogSnapshot } from "../src/commands/extensions/catalog-snapshot
 
 test("catalog snapshot reuses project-over-user-over-builtin preset resolution and real registries", () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-catalog-snapshot-"));
+  const previousUserHome = process.env.HARNESS_USER_HOME;
+  process.env.HARNESS_USER_HOME = path.join(rootDir, ".empty-user-home");
   try {
     writeHarnessConfig(rootDir);
     writePreset(rootDir, ".harness/user-presets/standard-task/preset.json", "standard-task", "User Standard", "1.5.0");
@@ -30,6 +32,8 @@ test("catalog snapshot reuses project-over-user-over-builtin preset resolution a
     assert.deepEqual(snapshot.adapters.map((adapter) => adapter.id), ["local", "multica"]);
     assert.deepEqual(snapshot.adapters.map((adapter) => adapter.writable), [true, false]);
   } finally {
+    if (previousUserHome === undefined) delete process.env.HARNESS_USER_HOME;
+    else process.env.HARNESS_USER_HOME = previousUserHome;
     rmSync(rootDir, { recursive: true, force: true });
   }
 });

--- a/packages/cli/test/daemon-connect.test.ts
+++ b/packages/cli/test/daemon-connect.test.ts
@@ -57,13 +57,15 @@ test("daemon serve transport wires the selected endpoint to the platform adapter
     daemonId: "daemon-test",
     endpoint: "\\\\.\\pipe\\daemon-test",
     platform: "win32",
-    createProtocolServer
+    createProtocolServer,
+    acceptSshForcedCommand: () => false
   });
   const posix = createDaemonLocalTransport({
     daemonId: "daemon-test",
     endpoint: "/tmp/daemon-test.sock",
     platform: "linux",
-    createProtocolServer
+    createProtocolServer,
+    acceptSshForcedCommand: () => false
   });
 
   assert.equal(windows.kind, "named-pipe");
@@ -122,7 +124,7 @@ test("forced-command principal requires an unforgeable sshd process witness", ()
   }), /root-owned sshd ancestor/iu);
 });
 
-test("forced-command principal is static argv and never comes from SSH_ORIGINAL_COMMAND or USER", () => {
+test("after an independently tested sshd witness passes, principal comes from static argv rather than SSH_ORIGINAL_COMMAND or USER", () => {
   const authentication = resolveSshForcedCommandAuthentication({
     args: ["daemon", "connect", "--stdio", "--principal", "person_alice", "--expect-original-command", "ha daemon connect --stdio"],
     rootDir: "/srv/canonical",

--- a/packages/cli/test/daemon-execution-claim-cli.test.ts
+++ b/packages/cli/test/daemon-execution-claim-cli.test.ts
@@ -58,6 +58,8 @@ test("daemon-backed Execution claim upgrades Holder V1 and preserves the caller 
       "executions",
       `${executionId}.md`
     );
+    const branches = git(path.join(rootDir, "harness"), "branch", "--format=%(refname:short)");
+    assert.doesNotMatch(branches, /^sessions\/claiming-codex-session$/mu, JSON.stringify({ claimed, branches }));
     const execution = JSON.parse(git(
       harnessRoot,
       "show",

--- a/packages/cli/test/daemon-local-identity-cli.test.ts
+++ b/packages/cli/test/daemon-local-identity-cli.test.ts
@@ -109,7 +109,7 @@ test("linked worktree writes route to the canonical daemon with transport-derive
     assert.equal((directFallback.receipt.error as { readonly code?: string }).code, "task_not_found");
     assert.equal(
       (directFallback.receipt.warnings as ReadonlyArray<{ readonly message?: string }> | undefined)
-        ?.some((warning) => /settings\.identity\.personId/u.test(warning.message ?? "")),
+        ?.some((warning) => /machine identity|people\.yaml/u.test(warning.message ?? "")),
       true
     );
 
@@ -123,7 +123,7 @@ test("linked worktree writes route to the canonical daemon with transport-derive
     });
     assert.notEqual(localWrite.status, 0);
     assert.equal((localWrite.receipt.error as { readonly code?: string }).code, "write_rejected");
-    assert.match((localWrite.receipt.error as { readonly hint?: string }).hint ?? "", /settings\.identity\.personId/u);
+    assert.match((localWrite.receipt.error as { readonly hint?: string }).hint ?? "", /machine identity|people\.yaml/u);
   });
 });
 

--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -28,6 +28,8 @@ test("daemon client routes writes for two registered repos through one user-leve
 
       assert.equal(alphaCreated.ok, true);
       assert.equal(betaCreated.ok, true);
+      assert.equal(receiptActorPersonId(alphaCreated), "person_alpha");
+      assert.equal(receiptActorPersonId(betaCreated), "person_beta");
       const alphaTaskId = receiptTaskId(alphaCreated);
       const betaTaskId = receiptTaskId(betaCreated);
       assertTaskIndexContains(alphaRoot, alphaTaskId, "alpha-routed-write", "Alpha Routed Write");
@@ -49,6 +51,84 @@ test("daemon client routes writes for two registered repos through one user-leve
       stopDaemonQuietly(betaRoot, userRoot);
     }
   });
+});
+
+test("isolated profile bootstraps machine identity and writes the first task in a new repo", () => {
+  withTempRoot((rootDir) => {
+    mkdirSync(rootDir, { recursive: true });
+    const isolatedEnv = {
+      HARNESS_BOOTSTRAP_MACHINE_IDENTITY: "1",
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DAEMON_PROFILE: "isolated",
+      HARNESS_DAEMON_USER_ROOT: ""
+    };
+    runRawJson(rootDir, ["--daemon-profile", "isolated", "init"], isolatedEnv);
+    const userRoot = path.join(rootDir, ".harness/daemon-profile");
+    assert.equal(existsSync(path.join(userRoot, "people.yaml")), true);
+    runDaemonCommand(rootDir, [
+      "--daemon-profile", "isolated", "daemon", "repo", "register",
+      "--repo-id", "coldstart", "--root", rootDir, "--no-link", "--json"
+    ], { HARNESS_DAEMON_PROFILE: "isolated", HARNESS_DAEMON_USER_ROOT: "" });
+    assert.equal(existsSync(path.join(userRoot, "registry.json")), true);
+
+    try {
+      const created = runRawJson(rootDir, ["--daemon-profile", "isolated", "new-task", "--title", "Cold Start First Task"], {
+        HARNESS_DAEMON_MODE: "local",
+        HARNESS_DAEMON_PROFILE: "isolated",
+        HARNESS_DAEMON_USER_ROOT: "",
+        HARNESS_DAEMON_IDLE_MS: "60000"
+      });
+      assert.equal(created.ok, true);
+      assert.equal(typeof receiptActorPersonId(created), "string");
+      assertTaskIndexContains(rootDir, receiptTaskId(created), "cold-start-first-task", "Cold Start First Task");
+    } finally {
+      stopDaemonQuietly(rootDir, userRoot);
+    }
+  });
+});
+
+test("registering a new tmp repo cannot replace the canonical daemon or break canonical writes", { skip: process.platform === "win32" }, async () => {
+  await withTempRootAsync(async (workspaceRoot) => {
+    const userRoot = path.join(workspaceRoot, "user-daemon");
+    const canonicalRoot = path.join(workspaceRoot, "canonical");
+    const experimentRoot = path.join(workspaceRoot, "coldstart-experiment");
+    mkdirSync(canonicalRoot, { recursive: true });
+    ensureTestHarnessIdentity(canonicalRoot);
+    runRawJson(canonicalRoot, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    writePeopleRoster(canonicalRoot, "person_canonical");
+    runDaemonCommand(canonicalRoot, ["daemon", "repo", "register", "--repo-id", "canonical", "--root", canonicalRoot, "--user-root", userRoot, "--no-link", "--json"], {
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+
+    try {
+      const before = runRawJson(canonicalRoot, ["new-task", "--title", "Canonical Before Experiment"], {
+        HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_USER_ROOT: userRoot, HARNESS_DAEMON_IDLE_MS: "60000"
+      });
+      const beforeStatus = runDaemonCommand(canonicalRoot, ["daemon", "status", "--user-root", userRoot, "--json"], {
+        HARNESS_DAEMON_USER_ROOT: userRoot
+      });
+
+      mkdirSync(experimentRoot, { recursive: true });
+      ensureTestHarnessIdentity(experimentRoot);
+      runRawJson(experimentRoot, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+      writePeopleRoster(experimentRoot, "person_experiment");
+      runDaemonCommand(experimentRoot, ["daemon", "repo", "register", "--repo-id", "experiment", "--root", experimentRoot, "--user-root", userRoot, "--no-link", "--json"], {
+        HARNESS_DAEMON_USER_ROOT: userRoot
+      });
+      const reconciled = await waitForRepoState(canonicalRoot, userRoot, "canonical", "experiment", "attached");
+      const after = runRawJson(canonicalRoot, ["new-task", "--title", "Canonical After Experiment"], {
+        HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_USER_ROOT: userRoot, HARNESS_DAEMON_IDLE_MS: "60000"
+      });
+
+      assert.equal(before.ok, true);
+      assert.equal(after.ok, true);
+      assert.equal(receiptActorPersonId(after), "person_canonical");
+      assert.equal(reconciled.pid, beforeStatus.pid);
+      assertTaskIndexContains(canonicalRoot, receiptTaskId(after), "canonical-after-experiment", "Canonical After Experiment");
+    } finally {
+      stopDaemonQuietly(canonicalRoot, userRoot);
+    }
+  }, "/tmp");
 });
 
 test("daemon service isolates held repo locks, retries after release, and preserves per-repo fail-closed writes", async () => {
@@ -135,8 +215,8 @@ function withTempRoot<T>(fn: (rootDir: string) => T): T {
   }
 }
 
-async function withTempRootAsync<T>(fn: (rootDir: string) => Promise<T>): Promise<T> {
-  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-cli-daemon-"));
+async function withTempRootAsync<T>(fn: (rootDir: string) => Promise<T>, parent = tmpdir()): Promise<T> {
+  const rootDir = mkdtempSync(path.join(parent, "ha-cli-daemon-"));
   try {
     return await fn(rootDir);
   } finally {
@@ -156,7 +236,7 @@ function setupRegisteredRepos(workspaceRoot: string): {
     mkdirSync(rootDir, { recursive: true });
     ensureTestHarnessIdentity(rootDir);
     runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
-    writePeopleRoster(rootDir);
+    writePeopleRoster(rootDir, rootDir === alphaRoot ? "person_alpha" : "person_beta");
   }
   runDaemonCommand(alphaRoot, ["daemon", "repo", "register", "--repo-id", "alpha", "--root", alphaRoot, "--user-root", userRoot, "--no-link", "--json"], {
     HARNESS_DAEMON_USER_ROOT: userRoot
@@ -167,14 +247,18 @@ function setupRegisteredRepos(workspaceRoot: string): {
   return { userRoot, alphaRoot, betaRoot };
 }
 
-function writePeopleRoster(rootDir: string): void {
+function writePeopleRoster(rootDir: string, personId: string): void {
   const harnessRoot = path.join(rootDir, "harness");
   mkdirSync(harnessRoot, { recursive: true });
+  const configPath = path.join(harnessRoot, "harness.yaml");
+  writeFileSync(configPath, readFileSync(configPath, "utf8")
+    .replace("personId: person_test", `personId: ${personId}`)
+    .replace("displayName: Harness Test", `displayName: ${personId}`), "utf8");
   writeFileSync(path.join(harnessRoot, "people.yaml"), [
     "schema: harness-people/v1",
     "people:",
-    "  - personId: person_test",
-    "    displayName: Harness Test",
+    `  - personId: ${personId}`,
+    `    displayName: ${personId}`,
     "    primaryEmail: daemon-tester@example.test",
     "    roles: [owner]",
     "    credentials:",
@@ -187,12 +271,18 @@ function writePeopleRoster(rootDir: string): void {
     ""
   ].join("\n"), "utf8");
   if (existsSync(path.join(harnessRoot, ".git"))) {
-    execFileSync("git", ["-C", harnessRoot, "add", "--", "people.yaml"], { stdio: "ignore" });
+    execFileSync("git", ["-C", harnessRoot, "add", "--", "harness.yaml", "people.yaml"], { stdio: "ignore" });
     execFileSync("git", ["-C", harnessRoot, "commit", "-m", "chore: configure daemon people roster"], {
       stdio: "ignore",
       env: gitAuthorEnv(rootDir)
     });
   }
+}
+
+function receiptActorPersonId(receipt: Record<string, unknown>): unknown {
+  const details = isRecord(receipt.details) ? receipt.details : {};
+  const actor = isRecord(details.actor) ? details.actor : {};
+  return actor.personId;
 }
 
 function gitAuthorEnv(rootDir: string): NodeJS.ProcessEnv {
@@ -202,6 +292,7 @@ function gitAuthorEnv(rootDir: string): NodeJS.ProcessEnv {
     ...process.env,
     HOME: path.join(rootDir, ".home"),
     GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
     GIT_AUTHOR_NAME: name,
     GIT_AUTHOR_EMAIL: email,
     GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? name,
@@ -246,6 +337,14 @@ function daemonTestEnv(rootDir: string, env: Readonly<Record<string, string>>): 
     ...process.env,
     HOME: path.join(rootDir, ".home"),
     GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    HARNESS_ACTOR: "agent:daemon-multi-repo-test",
+    HARNESS_GIT_AUTHOR_NAME: "Harness Test",
+    HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
+    GIT_AUTHOR_NAME: "Harness Test",
+    GIT_AUTHOR_EMAIL: "harness@example.test",
+    GIT_COMMITTER_NAME: "Harness Test",
+    GIT_COMMITTER_EMAIL: "harness@example.test",
     HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user"),
     CLAUDE_SESSION_ID: "",
     CLAUDE_CODE_SESSION_ID: "",
@@ -341,8 +440,9 @@ async function waitForRepoState(
     lastStatus = runDaemonCommand(rootDir, ["--repo", statusRepoId, "daemon", "status", "--user-root", userRoot, "--json"], {
       HARNESS_DAEMON_USER_ROOT: userRoot
     });
-    const repo = requireStatusRepo(lastStatus, targetRepoId);
-    if (repo.state === state) return lastStatus;
+    const repos = Array.isArray(lastStatus.repos) ? lastStatus.repos as Array<Record<string, unknown>> : [];
+    const repo = repos.find((candidate) => candidate.repoId === targetRepoId);
+    if (repo?.state === state) return lastStatus;
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   assert.equal(requireStatusRepo(lastStatus ?? {}, targetRepoId).state, state);

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -179,6 +179,37 @@ test("forced-command relay attributes two shared-account members without collaps
   });
 });
 
+test("local repo mode ignores a forced-command personId and keeps the socket-owner principal", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = defaultDaemonUserRoot(rootDir);
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: userRoot });
+    const task = runRawJson(rootDir, ["new-task", "--title", "Local Forced Frame Rejected"], {
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    writeForcedCommandTeamRoster(rootDir);
+    const configPath = path.join(rootDir, "harness/harness.yaml");
+    writeFileSync(configPath, readFileSync(configPath, "utf8").replace("mode: remote", "mode: local"), "utf8");
+    git(path.join(rootDir, "harness"), "add", "harness.yaml");
+    git(path.join(rootDir, "harness"), "commit", "-m", "test: select local identity mode");
+
+    try {
+      runDaemonCommand(rootDir, ["daemon", "start", "--service", "--json"], { HARNESS_DAEMON_USER_ROOT: userRoot });
+      const claimed = await forcedCommandRequest(rootDir, userRoot, "person_bob", "repo.task.claim", {
+        repo: { repoId: "canonical", canonicalRoot: rootDir },
+        payload: { taskId: receiptDataString(task, "taskId"), executor: { kind: "agent", id: "spoof-client" } }
+      });
+
+      assert.equal(claimed.ok, true, JSON.stringify(claimed));
+      const holder = (((claimed.details as Record<string, unknown>).data as Record<string, unknown>).effectiveHolder as Record<string, unknown>);
+      assert.equal((holder.principal as { personId?: string }).personId, "person_alice");
+      assert.deepEqual(holder.executor, { kind: "agent", id: "spoof-client" });
+    } finally {
+      stopDaemonQuietly(rootDir, userRoot);
+    }
+  });
+});
+
 test("daemon serve --stdio is rejected before runtime attachment", async () => {
   await withTempRootAsync(async (rootDir) => {
     const result = await runDaemonCliProcess(rootDir, ["daemon", "serve", "--stdio"]);
@@ -352,6 +383,7 @@ test("daemon start service status and stop expose productized status contract", 
       assert.equal((status.repos as Array<{ repoId?: string; state?: string }>)[0]?.state, "attached");
 
       const stop = runDaemonCommand(rootDir, ["daemon", "stop", "--timeout-ms", "5000", "--json"]);
+      assert.equal(stop.pid, status.pid);
       assert.equal(stop.signaled, true);
       assert.equal(stop.drained, true);
       assert.equal(stop.stopped, true);

--- a/packages/cli/test/helpers/daemon-thin-client-fixtures.ts
+++ b/packages/cli/test/helpers/daemon-thin-client-fixtures.ts
@@ -58,7 +58,15 @@ export function hermeticGitEnv(rootDir: string): NodeJS.ProcessEnv {
   return {
     ...process.env,
     HOME: path.join(rootDir, ".home"),
-    GIT_CONFIG_GLOBAL: "/dev/null"
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    // The fixture carries its own identity. Blanking the config files is not enough:
+    // macOS Git synthesizes a `user@host` author when none is configured, so these
+    // commits pass on a developer machine and fail on CI with "Author identity unknown".
+    GIT_AUTHOR_NAME: "Harness Test",
+    GIT_AUTHOR_EMAIL: "harness@example.test",
+    GIT_COMMITTER_NAME: "Harness Test",
+    GIT_COMMITTER_EMAIL: "harness@example.test"
   };
 }
 

--- a/packages/cli/test/helpers/forced-command-daemon.ts
+++ b/packages/cli/test/helpers/forced-command-daemon.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { hostname } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -39,6 +39,11 @@ export function writePeopleRoster(rootDir: string, person: {
 export function writeForcedCommandTeamRoster(rootDir: string): void {
   const harnessRoot = path.join(rootDir, "harness");
   mkdirSync(harnessRoot, { recursive: true });
+  const configPath = path.join(harnessRoot, "harness.yaml");
+  const config = readFileSync(configPath, "utf8");
+  writeFileSync(configPath, /settings:\n(?:[\s\S]*?)  identity:\n/u.test(config)
+    ? (config.includes("    mode: local") ? config.replace("    mode: local", "    mode: remote") : config.replace("  identity:\n", "  identity:\n    mode: remote\n"))
+    : config.replace("settings:\n", "settings:\n  identity:\n    mode: remote\n"), "utf8");
   writeFileSync(path.join(harnessRoot, "people.yaml"), [
     "schema: harness-people/v1",
     "people:",
@@ -97,6 +102,8 @@ export async function forcedCommandRequest(
       USER: "shared-harness"
     },
     streams: { input, output, error },
+    // This fixture exercises forced-command framing after sshd verification.
+    // daemon-connect.test.ts owns the process-witness contract itself.
     verifySshdContext: () => true
   });
   const client = new JsonRpcLineClient(output, input);
@@ -119,7 +126,7 @@ export function receiptDataString(receipt: Record<string, unknown>, key: string)
 
 function commitPeopleRoster(harnessRoot: string): void {
   if (!existsSync(path.join(harnessRoot, ".git"))) return;
-  execFileSync("git", ["-C", harnessRoot, "add", "--", "people.yaml"], { stdio: "ignore" });
+  execFileSync("git", ["-C", harnessRoot, "add", "--", "harness.yaml", "people.yaml"], { stdio: "ignore" });
   execFileSync("git", ["-C", harnessRoot, "commit", "-m", "chore: configure daemon people roster"], {
     stdio: "ignore",
     env: gitAuthorEnv(harnessRoot)

--- a/packages/cli/test/new-task-cli.test.ts
+++ b/packages/cli/test/new-task-cli.test.ts
@@ -308,7 +308,13 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...testActorEnv, ...env }
+      env: {
+        ...process.env,
+        HARNESS_DAEMON_MODE: "direct",
+        HARNESS_DIRECT_WRITE_REASON: "test",
+        ...testActorEnv,
+        ...env
+      }
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
@@ -322,7 +328,12 @@ function runText(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...testActorEnv },
+      env: {
+        ...process.env,
+        HARNESS_DAEMON_MODE: "direct",
+        HARNESS_DIRECT_WRITE_REASON: "test",
+        ...testActorEnv
+      },
       stdio: ["ignore", "pipe", "pipe"]
     });
     return stdout;
@@ -346,10 +357,12 @@ function configureTestIdentity(rootDir: string): void {
   const harnessRoot = path.join(rootDir, "harness");
   const configPath = path.join(harnessRoot, "harness.yaml");
   const config = readFileSync(configPath, "utf8");
-  writeFileSync(configPath, config.replace(
-    /^settings:$/mu,
-    "settings:\n  identity:\n    personId: person_test\n    displayName: Harness Test"
-  ), "utf8");
+  writeFileSync(configPath, config.includes("  identity:\n")
+    ? config.replace("  identity:\n", "  identity:\n    personId: person_test\n    displayName: Harness Test\n")
+    : config.replace(
+      /^settings:$/mu,
+      "settings:\n  identity:\n    personId: person_test\n    displayName: Harness Test"
+    ), "utf8");
   execFileSync("git", ["-C", harnessRoot, "add", "harness.yaml"], { stdio: "ignore" });
   execFileSync("git", ["-C", harnessRoot, "-c", "user.name=Harness Test", "-c", "user.email=harness@example.test", "commit", "-m", "test: configure identity"], { stdio: "ignore" });
 }

--- a/packages/cli/test/parse-args.test.ts
+++ b/packages/cli/test/parse-args.test.ts
@@ -239,6 +239,14 @@ test("parseArgs strips explicit authored root global override", () => {
   assert.equal(resolveHarnessLayout(rootDir).authoredRoot, path.join(rootDir, "harness"));
 });
 
+test("parseArgs carries one-shot daemon mode and isolated profile overrides", () => {
+  const parsed = parseArgs(["--daemon-mode", "local", "--daemon-profile", "isolated", "task", "list"]);
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.equal(parsed.value.daemonModeOverride, "local");
+  assert.equal(parsed.value.daemonProfileOverride, "isolated");
+});
+
 test("parseArgs carries the explicit actor global flag without exposing it to command parsers", () => {
   const parsed = parseArgs(["task", "claim", "task_1", "--actor", "human:person_zeyu"]);
 

--- a/packages/cli/test/preset-create-milestone-render-html-cli.test.ts
+++ b/packages/cli/test/preset-create-milestone-render-html-cli.test.ts
@@ -48,7 +48,15 @@ test("CLI create-milestone render-html derives a deterministic self-contained do
 function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, any> {
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
-      encoding: "utf8"
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HARNESS_ACTOR: "agent:create-milestone-render-test",
+        HARNESS_GIT_AUTHOR_NAME: "Harness Test",
+        HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
+        HARNESS_DAEMON_MODE: "direct",
+        HARNESS_DIRECT_WRITE_REASON: "test"
+      }
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/preset-github-issue-repair-cli.test.ts
+++ b/packages/cli/test/preset-github-issue-repair-cli.test.ts
@@ -154,7 +154,16 @@ test("CLI github issue repair preset requires an explicit repository input", () 
 function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, any> {
   try {
     const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
-      encoding: "utf8"
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HARNESS_ACTOR: "agent:github-issue-repair-test",
+        HARNESS_GIT_AUTHOR_NAME: "Harness Test",
+        HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
+        HARNESS_DAEMON_MODE: "direct",
+        HARNESS_DIRECT_WRITE_REASON: "test",
+        HARNESS_USER_HOME: path.join(rootDir, ".empty-user-home")
+      }
     });
     const parsed = JSON.parse(output) as Record<string, any>;
     if (expectSuccess) assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/runtime-event-cli.test.ts
+++ b/packages/cli/test/runtime-event-cli.test.ts
@@ -164,7 +164,7 @@ test("CLI entity write fails closed before runtime event append when principal c
 
     assert.equal(output.result.ok, false);
     assert.equal(existsSync(ledgerPath), false);
-    assert.match(output.result.warnings?.[0]?.message ?? "", /Local writes require a configured person identity/u);
+    assert.match(output.result.warnings?.[0]?.message ?? "", /Local writes require a machine identity/u);
   });
 });
 

--- a/packages/cli/test/settings-cli.test.ts
+++ b/packages/cli/test/settings-cli.test.ts
@@ -503,6 +503,8 @@ function runJson(
         HARNESS_ACTOR: "agent:settings-test",
         HARNESS_GIT_AUTHOR_NAME: "Settings Tester",
         HARNESS_GIT_AUTHOR_EMAIL: "settings@example.test",
+        HARNESS_DAEMON_MODE: "direct",
+        HARNESS_DIRECT_WRITE_REASON: "test",
         ...extraEnv
       }
     });
@@ -545,10 +547,12 @@ function configureTestIdentity(rootDir: string): void {
   const harnessRoot = path.join(rootDir, "harness");
   const configPath = path.join(harnessRoot, "harness.yaml");
   const config = readFileSync(configPath, "utf8");
-  writeFileSync(configPath, config.replace(
-    /^settings:$/mu,
-    "settings:\n  identity:\n    personId: person_test\n    displayName: Harness Test"
-  ), "utf8");
+  writeFileSync(configPath, config.includes("  identity:\n")
+    ? config.replace("  identity:\n", "  identity:\n    personId: person_test\n    displayName: Harness Test\n")
+    : config.replace(
+      /^settings:$/mu,
+      "settings:\n  identity:\n    personId: person_test\n    displayName: Harness Test"
+    ), "utf8");
   execFileSync("git", ["-C", harnessRoot, "add", "harness.yaml"], { stdio: "ignore" });
   execFileSync("git", ["-C", harnessRoot, "-c", "user.name=Harness Test", "-c", "user.email=harness@example.test", "commit", "-m", "test: configure identity"], { stdio: "ignore" });
 }

--- a/packages/cli/test/task-lease-cli.test.ts
+++ b/packages/cli/test/task-lease-cli.test.ts
@@ -97,7 +97,7 @@ test("explicit true environment override enables lease enforcement without confi
   });
 });
 
-test("task claim fails closed when HARNESS_ACTOR names an agent but settings.identity is missing", () => {
+test("task claim fails closed when HARNESS_ACTOR names an agent but machine identity is missing", () => {
   withTempRoot((rootDir) => {
     writeHarnessIdentity(rootDir, "person_zeyu", "Zeyu Li");
     const created = runJson(rootDir, ["new-task", "--title", "Missing Identity Claim"]);
@@ -109,13 +109,13 @@ test("task claim fails closed when HARNESS_ACTOR names an agent but settings.ide
 
     assert.equal(rejected.ok, false);
     assert.equal(rejected.error?.code, "AuthMissing");
-    assert.match(rejected.error?.hint ?? "", /settings\.identity\.personId/u);
+    assert.match(rejected.error?.hint ?? "", /machine identity|people\.yaml/u);
     assert.equal(existsTaskHolder(rootDir, created.taskId), false);
     assert.equal(JSON.stringify(rejected).includes("person:claude-code"), false);
   });
 });
 
-test("lease enforcement reports missing configured identity instead of journal failure", () => {
+test("lease enforcement reports missing machine identity instead of journal failure", () => {
   withTempRoot((rootDir) => {
     writeHarnessIdentity(rootDir, "person_zeyu", "Zeyu Li");
     const created = runJson(rootDir, ["new-task", "--title", "Missing Identity Lease"]);
@@ -128,7 +128,7 @@ test("lease enforcement reports missing configured identity instead of journal f
 
     assert.equal(rejected.ok, false);
     assert.equal(rejected.error?.code, "write_rejected");
-    assert.match(rejected.error?.hint ?? "", /settings\.identity\.personId/u);
+    assert.match(rejected.error?.hint ?? "", /machine identity|people\.yaml/u);
     assert.equal((rejected.error?.hint ?? "").includes("Journal is unavailable"), false);
   });
 });
@@ -412,6 +412,8 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
       HARNESS_ACTOR: "agent:harness-test",
       HARNESS_GIT_AUTHOR_NAME: "Harness Tester",
       HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test",
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DIRECT_WRITE_REASON: "test",
       CLAUDE_SESSION_ID: "",
       CLAUDE_CODE_SESSION_ID: "",
       CODEX_THREAD_ID: "",

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -111,7 +111,17 @@ export function localUserDaemonEndpoint(
 }
 
 export function daemonUserRoot(env: NodeJS.ProcessEnv = process.env): string {
-  return path.resolve(readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_USER_ROOT") ?? path.join(os.homedir(), ".harness"));
+  const home = readNonEmptyDaemonEnv(env, "HOME") ?? os.homedir();
+  return path.resolve(readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_USER_ROOT") ?? path.join(home, ".harness"));
+}
+
+export function daemonUserRootForRepo(rootDir: string, env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_USER_ROOT");
+  if (explicit) return path.resolve(explicit);
+  const profile = readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_PROFILE") ?? "default";
+  if (profile === "default") return daemonUserRoot(env);
+  if (profile === "isolated") return path.resolve(rootDir, ".harness", "daemon-profile");
+  throw new Error("HARNESS_DAEMON_PROFILE must be default or isolated.");
 }
 
 export function daemonIdFromEnv(env: NodeJS.ProcessEnv = process.env): string {
@@ -127,7 +137,7 @@ export function resolveLocalDaemonTarget(input: {
   readonly env?: NodeJS.ProcessEnv;
 }): LocalDaemonTarget {
   const env = input.env ?? process.env;
-  const userRoot = path.resolve(input.userRoot ?? daemonUserRoot(env));
+  const userRoot = path.resolve(input.userRoot ?? daemonUserRootForRepo(input.rootDir, env));
   const daemonId = input.daemonId ?? daemonIdFromEnv(env);
   const repoIdOverride = input.repoIdOverride ?? readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_REPO_ID");
   const registry = readDaemonRegistry({ userRoot });

--- a/packages/daemon/src/identity/machine-people.ts
+++ b/packages/daemon/src/identity/machine-people.ts
@@ -1,0 +1,37 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export function ensureMachinePeopleRoster(
+  userRoot: string,
+  author: { readonly name: string; readonly email: string }
+): string {
+  const peoplePath = path.join(userRoot, "people.yaml");
+  if (existsSync(peoplePath)) return peoplePath;
+  const personId = machinePersonId(author);
+  mkdirSync(userRoot, { recursive: true, mode: 0o700 });
+  writeFileSync(peoplePath, [
+    "schema: harness-people/v1",
+    "people:",
+    `  - personId: ${personId}`,
+    `    displayName: ${JSON.stringify(author.name)}`,
+    `    primaryEmail: ${JSON.stringify(author.email)}`,
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: unix-socket-owner-boundary",
+    `        issuer: host:${os.hostname()}`,
+    `        subject: ${process.getuid?.() ?? 0}`,
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    ""
+  ].join("\n"), { encoding: "utf8", mode: 0o600 });
+  return peoplePath;
+}
+
+function machinePersonId(author: { readonly name: string; readonly email: string }): string {
+  const name = author.name.normalize("NFKD").replace(/[^A-Za-z0-9]+/gu, "_").replace(/^_+|_+$/gu, "").toLowerCase() || "local";
+  const suffix = createHash("sha256").update(author.email.trim().toLowerCase()).digest("hex").slice(0, 10);
+  return `person_${name}_${suffix}`;
+}

--- a/packages/daemon/src/identity/people-roster.ts
+++ b/packages/daemon/src/identity/people-roster.ts
@@ -34,24 +34,62 @@ export function loadPeopleRoster(rootInput: HarnessLayoutInput): PeopleRoster {
   if (!existsSync(filePath)) {
     throw new Error(`people.yaml not found: ${path.relative(layout.rootDir, filePath)}`);
   }
+  return loadPeopleRosterFile(filePath);
+}
+
+export function loadPeopleRosterFile(filePath: string): PeopleRoster {
   return peopleRosterFromDocument(readFileSync(filePath, "utf8"));
 }
 
 export function peopleRosterFromDocument(body: string): PeopleRoster {
   const raw = parsePeopleYaml(body);
   if (raw.schema !== "harness-people/v1") throw new Error("people.yaml schema must be harness-people/v1");
-  validateRoster(raw.people, raw.roles);
+  return peopleRosterFromRecords(raw.people, raw.roles);
+}
+
+export function mergePeopleRosters(machine: PeopleRoster, project: PeopleRoster): PeopleRoster {
+  const machineCredentialOwners = new Map<string, string>();
+  for (const person of machine.people) {
+    for (const credential of person.credentials) machineCredentialOwners.set(credentialKey(credential), person.personId);
+  }
+  for (const person of project.people) {
+    for (const credential of person.credentials) {
+      const machinePersonId = machineCredentialOwners.get(credentialKey(credential));
+      if (machinePersonId && machinePersonId !== person.personId) {
+        throw new Error(`project people.yaml cannot rebind machine credential from ${machinePersonId} to ${person.personId}`);
+      }
+    }
+  }
+
+  const people = new Map(machine.people.map((person) => [person.personId, person]));
+  for (const projectPerson of project.people) {
+    const machinePerson = people.get(projectPerson.personId);
+    const credentials = new Map((machinePerson?.credentials ?? []).map((credential) => [credentialKey(credential), credential]));
+    for (const credential of projectPerson.credentials) credentials.set(credentialKey(credential), credential);
+    people.set(projectPerson.personId, {
+      ...machinePerson,
+      ...projectPerson,
+      credentials: [...credentials.values()]
+    });
+  }
+  const roles = new Map(machine.roles.map((role) => [role.roleId, role]));
+  for (const role of project.roles) roles.set(role.roleId, role);
+  return peopleRosterFromRecords([...people.values()], [...roles.values()]);
+}
+
+function peopleRosterFromRecords(people: ReadonlyArray<PersonProfile>, roles: ReadonlyArray<RolePolicy>): PeopleRoster {
+  validateRoster(people, roles);
   const peopleByCredential = new Map<string, PersonProfile>();
-  for (const person of raw.people) {
+  for (const person of people) {
     for (const credential of person.credentials) {
       peopleByCredential.set(credentialKey(credential), person);
     }
   }
-  const rolesById = new Map(raw.roles.map((role) => [role.roleId, role]));
+  const rolesById = new Map(roles.map((role) => [role.roleId, role]));
   return {
     schema: "harness-people/v1",
-    people: raw.people,
-    roles: raw.roles,
+    people,
+    roles,
     resolveCredential: (credential, providerId) => {
       const person = peopleByCredential.get(credentialKey(credential));
       if (!person) return credentialResolutionFailure(providerId, "credential_unknown", "Credential is not bound to a person.", credential);

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,10 +1,14 @@
 // TW-04 platform
 export * from "./platform/index.ts";
 export {
+  ensureMachinePeopleRoster
+} from "./identity/machine-people.ts";
+export {
   daemonIdForRoot,
   daemonIdForUserRoot,
   daemonIdFromEnv,
   daemonUserRoot,
+  daemonUserRootForRepo,
   DaemonJsonRpcResponseError,
   defaultDaemonAutostartTimeoutMs,
   defaultDaemonIdleExitMs,
@@ -62,6 +66,8 @@ export {
 } from "./identity/types.ts";
 export {
   loadPeopleRoster,
+  loadPeopleRosterFile,
+  mergePeopleRosters,
   makePeopleRosterIdentityAdminSnapshot,
   peopleRosterFromDocument
 } from "./identity/people-roster.ts";

--- a/packages/daemon/src/protocol/identity-dispatch.ts
+++ b/packages/daemon/src/protocol/identity-dispatch.ts
@@ -23,7 +23,7 @@ export async function resolveIdentityActorForMethod(
       ? identityFailure(
           "identity-provider/unavailable",
           "provider_unavailable",
-          "Daemon writes require an identity provider to authenticate the principal."
+          "Daemon writes require an identity provider to authenticate the principal. Local: run ha init with HARNESS_GIT_AUTHOR_NAME and HARNESS_GIT_AUTHOR_EMAIL set, or configure the current host/uid in ~/.harness/people.yaml. Remote: configure the repo roster and connect through the authorized_keys forced command."
         )
       : undefined;
   }

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -85,6 +85,11 @@ export interface JsonRpcServerOptions {
   readonly identityProvider?: IdentityProvider;
   readonly personRegistry?: PersonRegistry;
   readonly identityAdminSnapshot?: IdentityAdminSnapshot;
+  readonly resolveRepoIdentity?: (repo: DaemonRepoNamespace) => {
+    readonly identityProvider?: IdentityProvider;
+    readonly personRegistry?: PersonRegistry;
+    readonly identityAdminSnapshot?: IdentityAdminSnapshot;
+  } | undefined;
   readonly appendRuntimeEvent?: (input: RuntimeEventAppendInput, context?: DaemonRepoServiceContext) => Promise<void>;
 }
 
@@ -145,13 +150,14 @@ async function handleRequest(
   const repoFailure = validateRepoNamespace(contract, params, repos);
   if (repoFailure) return response(failureReceipt(request.method, repoFailure.code, repoFailure.hint));
   const repo = repoForContract(contract, params, repos);
+  const identityOptions = repoIdentityOptions(repo, options);
   const effectiveContract = withEffectiveCommandClass(contract, params);
   const forcedRootFailure = validateForcedCommandRoot(effectiveContract, params, repo, options.authContext);
   if (forcedRootFailure) return response(forcedRootFailure);
   const repoRuntimeFailure = validateRepoRuntime(effectiveContract, repo, options);
   if (repoRuntimeFailure) return response(repoRuntimeFailure);
 
-  const actorResult = await resolveIdentityActorForMethod(effectiveContract, options);
+  const actorResult = await resolveIdentityActorForMethod(effectiveContract, identityOptions);
   if (actorResult && !actorResult.ok) {
     const receipt = failureReceipt(request.method, actorResult.code, actorResult.message, {
       providerId: actorResult.providerId,
@@ -161,8 +167,8 @@ async function handleRequest(
     return response(receipt);
   }
   const actor = actorResult?.actor;
-  if (actor && options.identityProvider) {
-    const authz = await options.identityProvider.authorize({
+  if (actor && identityOptions.identityProvider) {
+    const authz = await identityOptions.identityProvider.authorize({
       personId: actor.personId,
       action: { method: effectiveContract.method, commandClass: effectiveContract.commandClass },
       ...(repo ? { resource: { repoId: repo.repoId, canonicalRoot: repo.canonicalRoot } } : {})
@@ -183,7 +189,7 @@ async function handleRequest(
   }
 
   if (contract.namespace === "admin") {
-    const result = handleAdminMethod(contract, options);
+    const result = handleAdminMethod(contract, identityOptions);
     const receipt = stampReceipt(result, actor);
     await appendWriteEventIfNeeded(options, params, effectiveContract, receipt.ok ? "succeeded" : "failed", receipt.summary, receipt.ok ? undefined : receipt.error?.code, actor, repo);
     return response(receipt);
@@ -193,6 +199,23 @@ async function handleRequest(
   const receipt = stampReceipt(result, actor);
   await appendWriteEventIfNeeded(options, params, effectiveContract, receipt.ok ? "succeeded" : "failed", receipt.summary, receipt.ok ? undefined : receipt.error?.code, actor, repo);
   return response(receipt);
+}
+
+function repoIdentityOptions(
+  repo: DaemonRepoNamespace | undefined,
+  options: JsonRpcServerOptions
+): JsonRpcServerOptions {
+  if (!repo || !options.resolveRepoIdentity) return options;
+  const identity = options.resolveRepoIdentity(repo);
+  if (!identity) {
+    return {
+      ...options,
+      identityProvider: undefined,
+      personRegistry: undefined,
+      identityAdminSnapshot: undefined
+    };
+  }
+  return { ...options, ...identity };
 }
 
 function handleHello(

--- a/packages/daemon/src/transport/named-pipe.ts
+++ b/packages/daemon/src/transport/named-pipe.ts
@@ -2,7 +2,7 @@
 import net from "node:net";
 import type { DaemonAuthenticationContext } from "./auth-context.ts";
 import { serveJsonRpcStream, type DaemonTransportConnection } from "./json-rpc-stream.ts";
-import { authenticateSshForcedCommandFrame } from "./ssh-forced-command.ts";
+import { authenticateSshForcedCommandFrame, type AcceptSshForcedCommand } from "./ssh-forced-command.ts";
 import type { JsonRpcProtocolServer } from "../protocol/json-rpc-server.ts";
 
 export interface NamedPipeTransportOptions {
@@ -12,7 +12,7 @@ export interface NamedPipeTransportOptions {
   readonly createProtocolServer: (authContext: DaemonAuthenticationContext) => JsonRpcProtocolServer;
   readonly onConnection?: (connection: DaemonTransportConnection) => void;
   readonly onConnectionClosed?: (connection: DaemonTransportConnection) => void;
-  readonly acceptSshForcedCommand?: boolean;
+  readonly acceptSshForcedCommand?: boolean | AcceptSshForcedCommand;
 }
 
 export interface NamedPipeTransportServer {
@@ -56,7 +56,13 @@ export function createNamedPipeTransportServer(options: NamedPipeTransportOption
       output: socket,
       transportKind: "named-pipe",
       authContext,
-      ...(options.acceptSshForcedCommand ? { authenticateFirstFrame: authenticateSshForcedCommandFrame } : {}),
+      ...(options.acceptSshForcedCommand ? {
+        authenticateFirstFrame: (frame: unknown, context: DaemonAuthenticationContext) => authenticateSshForcedCommandFrame(
+          frame,
+          context,
+          typeof options.acceptSshForcedCommand === "function" ? options.acceptSshForcedCommand : undefined
+        )
+      } : {}),
       createProtocolServer: options.createProtocolServer
     });
     options.onConnection?.(connection);

--- a/packages/daemon/src/transport/ssh-forced-command.ts
+++ b/packages/daemon/src/transport/ssh-forced-command.ts
@@ -10,6 +10,8 @@ export interface SshForcedCommandBootstrapFrame extends SshForcedCommandBootstra
   readonly type: "harness-daemon.ssh-forced-command/v1";
 }
 
+export type AcceptSshForcedCommand = (frame: SshForcedCommandBootstrapFrame) => boolean;
+
 export function sshForcedCommandBootstrapFrame(
   input: SshForcedCommandBootstrapInput
 ): SshForcedCommandBootstrapFrame {
@@ -22,7 +24,8 @@ export function sshForcedCommandBootstrapFrame(
 
 export function authenticateSshForcedCommandFrame(
   frame: unknown,
-  authContext: DaemonAuthenticationContext
+  authContext: DaemonAuthenticationContext,
+  accept: AcceptSshForcedCommand = () => true
 ): TransportAuthenticationResult {
   if (!isSshForcedCommandBootstrapFrame(frame)) {
     if (isForcedCommandFrameType(frame)) {
@@ -30,6 +33,7 @@ export function authenticateSshForcedCommandFrame(
     }
     return { ok: true, authContext, forwardFrame: true };
   }
+  if (!accept(frame)) return { ok: true, authContext };
   return {
     ok: true,
     authContext: {

--- a/packages/daemon/src/transport/unix-socket.ts
+++ b/packages/daemon/src/transport/unix-socket.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import type { DaemonAuthenticationContext } from "./auth-context.ts";
 import { serveJsonRpcStream, type DaemonTransportConnection } from "./json-rpc-stream.ts";
-import { authenticateSshForcedCommandFrame } from "./ssh-forced-command.ts";
+import { authenticateSshForcedCommandFrame, type AcceptSshForcedCommand } from "./ssh-forced-command.ts";
 import type { JsonRpcProtocolServer } from "../protocol/json-rpc-server.ts";
 
 export interface UnixSocketTransportOptions {
@@ -14,7 +14,7 @@ export interface UnixSocketTransportOptions {
   readonly createProtocolServer: (authContext: DaemonAuthenticationContext) => JsonRpcProtocolServer;
   readonly onConnection?: (connection: DaemonTransportConnection) => void;
   readonly onConnectionClosed?: (connection: DaemonTransportConnection) => void;
-  readonly acceptSshForcedCommand?: boolean;
+  readonly acceptSshForcedCommand?: boolean | AcceptSshForcedCommand;
 }
 
 export interface UnixSocketPathOptions {
@@ -109,7 +109,13 @@ export function createUnixSocketTransportServer(options: UnixSocketTransportOpti
       output: socket,
       transportKind: "unix-socket",
       authContext,
-      ...(options.acceptSshForcedCommand ? { authenticateFirstFrame: authenticateSshForcedCommandFrame } : {}),
+      ...(options.acceptSshForcedCommand ? {
+        authenticateFirstFrame: (frame: unknown, context: DaemonAuthenticationContext) => authenticateSshForcedCommandFrame(
+          frame,
+          context,
+          typeof options.acceptSshForcedCommand === "function" ? options.acceptSshForcedCommand : undefined
+        )
+      } : {}),
       createProtocolServer: options.createProtocolServer
     });
     options.onConnection?.(connection);

--- a/packages/daemon/test/identity-provider-contract.test.ts
+++ b/packages/daemon/test/identity-provider-contract.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 import type { LocalControllerService } from "../../application/src/index.ts";
 import { loadDaemonIdentityWithEmail } from "../../cli/src/commands/daemon/identity.ts";
+import { readConfiguredLocalPrincipal } from "../../cli/src/composition/local-principal.ts";
 import { createInMemoryTerminalSessionService } from "../../gui/src/terminal/session-registry.ts";
 import {
   composeIdentityProvider,
@@ -186,6 +187,125 @@ test("an existing people.yaml stays authoritative and empty credentials fail as 
   if (result && !result.ok) assert.equal(result.code, "credential_unknown");
 });
 
+test("a repo without people.yaml inherits the machine people roster", async (t) => {
+  const rootDir = createIdentityRoot("person_machine");
+  const userRoot = mkdtempSync(path.join(os.tmpdir(), "ha-machine-identity-"));
+  t.after(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(userRoot, { recursive: true, force: true });
+  });
+  writeFileSync(path.join(userRoot, "people.yaml"), ownerRoster("person_machine"), "utf8");
+
+  const identity = loadDaemonIdentityWithEmail(rootDir, undefined, undefined, undefined, userRoot);
+  const authenticated = await identity.identityProvider?.authenticate({
+    transportKind: "unix-socket",
+    unixSocketOwnerBoundary: {
+      ownerUid: process.getuid?.() ?? 0,
+      source: "unix-socket-filesystem-owner-boundary"
+    }
+  });
+
+  assert.equal(authenticated?.ok && authenticated.personId, "person_machine");
+});
+
+test("remote mode rejects socket-owner identity and accepts only a forced-command person", async (t) => {
+  const rootDir = createIdentityRoot("person_remote");
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  const configPath = path.join(rootDir, "harness/harness.yaml");
+  writeFileSync(configPath, [
+    "schema: harness-anything/v1",
+    "layout:",
+    "  authoredRoot: harness",
+    "settings:",
+    "  identity:",
+    "    mode: remote",
+    ""
+  ].join("\n"), "utf8");
+  writeFileSync(path.join(rootDir, "harness/people.yaml"), remoteRoster("person_remote"), "utf8");
+
+  const identity = loadDaemonIdentityWithEmail(rootDir, undefined, undefined);
+  const local = await identity.identityProvider?.authenticate({
+    transportKind: "unix-socket",
+    unixSocketOwnerBoundary: {
+      ownerUid: process.getuid?.() ?? 0,
+      source: "unix-socket-filesystem-owner-boundary"
+    }
+  });
+  const remote = await identity.identityProvider?.authenticate({
+    transportKind: "unix-socket",
+    unixSocketOwnerBoundary: {
+      ownerUid: process.getuid?.() ?? 0,
+      source: "unix-socket-filesystem-owner-boundary"
+    },
+    sshForcedCommand: {
+      personId: "person_remote",
+      canonicalRoot: rootDir,
+      source: "sshd-authorized-keys-forced-command"
+    }
+  });
+
+  assert.equal(identity.mode, "remote");
+  assert.equal(local?.ok, false);
+  if (local && !local.ok) {
+    assert.equal(local.code, "credential_unavailable");
+    assert.match(local.message, /local socket-owner identity is disabled/u);
+  }
+  assert.equal(remote?.ok && remote.personId, "person_remote");
+});
+
+test("direct recovery resolves the same machine roster when the project declares only local mode", (t) => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-direct-machine-identity-"));
+  const home = mkdtempSync(path.join(os.tmpdir(), "ha-direct-machine-home-"));
+  t.after(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  });
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  writeFileSync(path.join(rootDir, "harness/harness.yaml"), [
+    "schema: harness-anything/v1",
+    "layout:",
+    "  authoredRoot: harness",
+    "settings:",
+    "  identity:",
+    "    mode: local",
+    ""
+  ].join("\n"), "utf8");
+  mkdirSync(path.join(home, ".harness"), { recursive: true });
+  writeFileSync(path.join(home, ".harness/people.yaml"), ownerRoster("person_machine"), "utf8");
+  assert.equal(readConfiguredLocalPrincipal(rootDir, { HOME: home }).personId, "person_machine");
+
+  writeFileSync(path.join(rootDir, "harness/harness.yaml"), [
+    "schema: harness-anything/v1",
+    "layout:",
+    "  authoredRoot: harness",
+    "settings:",
+    "  identity:",
+    "    mode: local",
+    "    personId: person_project",
+    ""
+  ].join("\n"), "utf8");
+  assert.throws(
+    () => readConfiguredLocalPrincipal(rootDir, { HOME: home }),
+    /cannot rebind this machine credential from 'person_machine'/u
+  );
+});
+
+test("a project overlay cannot silently rebind a machine credential", (t) => {
+  const rootDir = createIdentityRoot("person_project");
+  const userRoot = mkdtempSync(path.join(os.tmpdir(), "ha-machine-identity-"));
+  t.after(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(userRoot, { recursive: true, force: true });
+  });
+  writeFileSync(path.join(userRoot, "people.yaml"), ownerRoster("person_machine"), "utf8");
+  writeFileSync(path.join(rootDir, "harness/people.yaml"), ownerRoster("person_project"), "utf8");
+
+  assert.throws(
+    () => loadDaemonIdentityWithEmail(rootDir, undefined, undefined, undefined, userRoot),
+    /cannot rebind machine credential from person_machine to person_project/u
+  );
+});
+
 test("a roster person with matching credentials but no roles fails as rbac_forbidden", async (t) => {
   const rootDir = createIdentityRoot("person_zeyu");
   t.after(() => rmSync(rootDir, { recursive: true, force: true }));
@@ -280,6 +400,45 @@ function createIdentityRoot(personId: string): string {
     ""
   ].join("\n"), "utf8");
   return rootDir;
+}
+
+function ownerRoster(personId: string): string {
+  return [
+    "schema: harness-people/v1",
+    "people:",
+    `  - personId: ${personId}`,
+    `    displayName: ${personId}`,
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: unix-socket-owner-boundary",
+    `        issuer: host:${os.hostname()}`,
+    `        subject: ${process.getuid?.() ?? 0}`,
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    ""
+  ].join("\n");
+}
+
+function remoteRoster(personId: string): string {
+  return [
+    "schema: harness-people/v1",
+    "people:",
+    `  - personId: ${personId}`,
+    `    displayName: ${personId}`,
+    "    roles: [owner]",
+    "    credentials:",
+    "      - kind: ssh-forced-command-person",
+    `        issuer: host:${os.hostname()}`,
+    `        subject: ${personId}`,
+    "      - kind: unix-socket-owner-boundary",
+    `        issuer: host:${os.hostname()}`,
+    `        subject: ${process.getuid?.() ?? 0}`,
+    "roles:",
+    "  - roleId: owner",
+    "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+    ""
+  ].join("\n");
 }
 
 function makeServer(overrides: Partial<Parameters<typeof createJsonRpcProtocolServer>[0]> = {}) {

--- a/packages/daemon/test/transport-integration.test.ts
+++ b/packages/daemon/test/transport-integration.test.ts
@@ -244,6 +244,65 @@ test("forced-command bootstrap is consumed before JSON-RPC and becomes authConte
   await connection.close();
 });
 
+test("local repo mode consumes a forged forced-command frame and authenticates the socket owner", async () => {
+  const clientToServer = new PassThrough();
+  const serverToClient = new PassThrough();
+  let seenAuthContext: DaemonAuthenticationContext | undefined;
+  const connection = serveJsonRpcStream({
+    input: clientToServer,
+    output: serverToClient,
+    transportKind: "unix-socket",
+    authContext: {
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" }
+    },
+    authenticateFirstFrame: (frame, context) => authenticateSshForcedCommandFrame(frame, context, () => false),
+    createProtocolServer: (authContext) => {
+      seenAuthContext = authContext;
+      return makeProtocolServerFactory()(authContext);
+    }
+  });
+  const client = frameClient(serverToClient, clientToServer);
+
+  client.send(sshForcedCommandBootstrapFrame({ personId: "person_alice", canonicalRoot: "/srv/local" }));
+  client.send(hello("local-forged-hello"));
+  assert.equal(resultReceipt(await client.read()).ok, true);
+  assert.equal(seenAuthContext?.sshForcedCommand, undefined);
+  const authenticated = await makeTransportDerivedIdentityProvider(localBoundaryRoster(), {
+    localUnixIssuer: "host:team-host"
+  }).authenticate(seenAuthContext!);
+  assert.equal(authenticated.ok && authenticated.personId, "person_socket_owner");
+  await connection.close();
+});
+
+test("remote repo mode accepts the forced-command principal while the same socket owner is present", async () => {
+  const clientToServer = new PassThrough();
+  const serverToClient = new PassThrough();
+  let seenAuthContext: DaemonAuthenticationContext | undefined;
+  const connection = serveJsonRpcStream({
+    input: clientToServer,
+    output: serverToClient,
+    transportKind: "unix-socket",
+    authContext: {
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" }
+    },
+    authenticateFirstFrame: (frame, context) => authenticateSshForcedCommandFrame(frame, context, (bootstrap) => bootstrap.canonicalRoot === "/srv/remote"),
+    createProtocolServer: (authContext) => {
+      seenAuthContext = authContext;
+      return makeProtocolServerFactory()(authContext);
+    }
+  });
+  const client = frameClient(serverToClient, clientToServer);
+
+  client.send(sshForcedCommandBootstrapFrame({ personId: "person_alice", canonicalRoot: "/srv/remote" }));
+  client.send(hello("remote-forced-hello"));
+  assert.equal(resultReceipt(await client.read()).ok, true);
+  assert.equal(seenAuthContext?.sshForcedCommand?.personId, "person_alice");
+  assert.equal(seenAuthContext?.unixSocketOwnerBoundary?.ownerUid, 501);
+  await connection.close();
+});
+
 test("JSON-RPC handler failures preserve the request id and connection", async () => {
   const clientToServer = new PassThrough();
   const serverToClient = new PassThrough();

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -89,7 +89,8 @@ export const HarnessConfigSchema = Schema.Struct({
     defaultPreset: Schema.optional(ConfigIdentifierSchema),
     defaultProfile: Schema.optional(ConfigIdentifierSchema),
     identity: Schema.optional(Schema.Struct({
-      personId: ConfigIdentifierSchema,
+      mode: Schema.optional(Schema.Literal("local", "remote")),
+      personId: Schema.optional(ConfigIdentifierSchema),
       displayName: Schema.optional(Schema.String)
     })),
     tasks: Schema.optional(Schema.Struct({

--- a/packages/kernel/test/store/daemon-materializer-conflict.test.ts
+++ b/packages/kernel/test/store/daemon-materializer-conflict.test.ts
@@ -1,0 +1,35 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { createMultiRepoDaemonRuntime } from "../../../adapters/local/src/index.ts";
+import { withTempStoreAsync } from "./helpers.ts";
+import { git, initAuthoredGit } from "./helpers/daemon-runtime.ts";
+
+test("daemon status exposes materializer merge conflicts", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const conflictPath = path.join(rootDir, "harness/conflict.txt");
+    git(rootDir, "checkout", "-b", "sessions/daemon-conflict");
+    writeFileSync(conflictPath, "session\n", "utf8");
+    git(rootDir, "add", "--", "conflict.txt");
+    git(rootDir, "commit", "-m", "session conflict");
+    git(rootDir, "checkout", "master");
+    writeFileSync(conflictPath, "trunk\n", "utf8");
+    git(rootDir, "add", "--", "conflict.txt");
+    git(rootDir, "commit", "-m", "trunk conflict");
+
+    const runtime = createMultiRepoDaemonRuntime({
+      repos: [{ repoId: "conflict-repo", rootDir }],
+      materializerPollMs: false,
+      materializerMaxBranchesPerBatch: 1
+    });
+    await runtime.start();
+    const report = await runtime.enqueueMaterializerBatch("conflict-repo");
+
+    assert.equal(report.branches[0]?.status, "conflict");
+    assert.match(runtime.status().repos[0]?.lastMaterializerError ?? "", /sessions\/daemon-conflict/u);
+    await runtime.stop();
+  });
+});

--- a/scripts/quickstart-demo.mjs
+++ b/scripts/quickstart-demo.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -31,7 +31,6 @@ try {
   const init = runCli(["init", "--name", "quickstart-demo", "--add-npm-scripts"]);
   assertEqual(init.command, "init", "init command");
   assertEqual(init.report?.configureVerify?.smokeTaskFound, true, "init smoke task query");
-  configureDemoIdentity();
 
   step = "task create";
   const task = runCli([
@@ -137,6 +136,8 @@ function runCliProcess(args) {
         HARNESS_ACTOR: demoAttribution.actor,
         HARNESS_GIT_AUTHOR_NAME: demoAttribution.gitAuthorName,
         HARNESS_GIT_AUTHOR_EMAIL: demoAttribution.gitAuthorEmail,
+        HARNESS_DAEMON_PROFILE: "isolated",
+        HARNESS_BOOTSTRAP_MACHINE_IDENTITY: "1",
         ANTIGRAVITY_SESSION_ID: "",
         CLAUDE_CODE_SESSION_ID: "",
         CLAUDE_SESSION_ID: "",
@@ -169,27 +170,6 @@ function ensureGitWorkspace(rootDir) {
       stdio: "ignore"
     });
   }
-}
-
-function configureDemoIdentity() {
-  const harnessRoot = path.join(workspace, "harness");
-  const configPath = path.join(harnessRoot, "harness.yaml");
-  const config = readFileSync(configPath, "utf8");
-  writeFileSync(configPath, config.replace(
-    /^settings:$/mu,
-    "settings:\n  identity:\n    personId: person_quickstart\n    displayName: Harness Quickstart Demo"
-  ), "utf8");
-  execFileSync("git", ["-C", harnessRoot, "add", "harness.yaml"], { stdio: "ignore" });
-  execFileSync("git", ["-C", harnessRoot, "commit", "-m", "chore: configure quickstart identity"], {
-    stdio: "ignore",
-    env: {
-      ...process.env,
-      GIT_AUTHOR_NAME: demoAttribution.gitAuthorName,
-      GIT_AUTHOR_EMAIL: demoAttribution.gitAuthorEmail,
-      GIT_COMMITTER_NAME: demoAttribution.gitAuthorName,
-      GIT_COMMITTER_EMAIL: demoAttribution.gitAuthorEmail
-    }
-  });
 }
 
 function unwrapReceipt(value) {

--- a/tools/smoke-cli-package.mjs
+++ b/tools/smoke-cli-package.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -63,8 +63,6 @@ export function runCliPackageSmoke(root = process.cwd()) {
     if (init.ok !== true || init.path !== "harness/harness.yaml") {
       throw new Error(`unexpected init smoke output: ${JSON.stringify(init)}`);
     }
-    configureSmokeIdentity(projectDir);
-
     const created = runJson(binPath, ["--json", "new-task", "--title", "Smoke Task"], projectDir);
     if (created.ok !== true || typeof created.taskId !== "string" || !created.taskId.startsWith("task_") || created.report?.vertical !== "software/coding" || created.report?.preset !== "standard-task") {
       throw new Error(`unexpected new-task smoke output: ${JSON.stringify(created)}`);
@@ -94,15 +92,6 @@ export function runCliPackageSmoke(root = process.cwd()) {
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
   }
-}
-
-function configureSmokeIdentity(projectDir) {
-  const configPath = path.join(projectDir, "harness/harness.yaml");
-  const config = readFileSync(configPath, "utf8");
-  writeFileSync(configPath, config.replace(
-    /^settings:$/mu,
-    "settings:\n  identity:\n    personId: person_harness_smoke\n    displayName: Harness Smoke"
-  ), "utf8");
 }
 
 export function buildCliPackageArtifact(root, options = {}) {
@@ -136,6 +125,9 @@ function smokeCliWriteEnv() {
     // Package smoke exercises the packaged in-process boundary; daemon
     // transport is covered by the dedicated daemon integration suite.
     HARNESS_DAEMON_MODE: "direct",
+    // Keep package smoke identity and registry state out of the developer's
+    // user-global profile while exercising the production init bootstrap.
+    HARNESS_DAEMON_PROFILE: "isolated",
     HARNESS_DIRECT_WRITE_REASON: "test",
     // Test-only actor attribution for package smoke writes; real env wins.
     HARNESS_ACTOR: process.env.HARNESS_ACTOR || "agent:harness-smoke",

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -12,8 +12,8 @@
   ],
   "rowCountReconciliation": {
     "phase1FunctionalRows": 26,
-    "registryRows": 45,
-    "difference": "One phase 1 feature row is retired. Six additional rows split mixed write functions and infrastructure: module canonical/view, script declared writes/produces, worktree code/binding, task-holder runtime state, one WriteCoordinator runtime substrate row, and the Fact-to-Execution administrative migration road. Two hosted typed-authority rows keep Execution and execution-scoped Review records RPC-only. Two further ADR-0028 P4 rows register the attributed doc_sync_submit coordinator road and the preset script staging-mirror ingest road. One ADR-0028 P5 row registers the coordinator-owned immutable attribution event trail. One dedicated T4 administrative migration row registers the attributed, confirmed-plan, key-only retirement of historical ownership fields. One ADR-0029 TW-01 row registers the authority replication submission road (attributed-coordinator entry over forced-command SSH). One ADR-0029 TW-02 row registers the compound receipt durable store (client-side crash-recovery receipt records, fsync + atomic rename). One ADR-0029 TW-03 row registers the broker local-view native applier (crash-safe transparent view materialization). One ADR-0029 TW-04 row registers the platform semantic-probe scratch writes (temporary qualification probes, created and removed inside one probe run). One ADR-0029 TW-06 row registers the authority fence enrollment anchor and durability boundary stores. One daemon transport row registers the socket owner-lock lifecycle state (task_01KXD0A37NN8ZQEJ2ENG5K313V): ephemeral single-instance mutex outside SoT, not entity data. Two GUI decision rows register proposal and judgment transitions through the authenticated daemon IPC write road (dec_01KXDR0A9AR1Z57Q3M1JEDMBVR)."
+    "registryRows": 46,
+    "difference": "One phase 1 feature row is retired. Six additional rows split mixed write functions and infrastructure: module canonical/view, script declared writes/produces, worktree code/binding, task-holder runtime state, one WriteCoordinator runtime substrate row, and the Fact-to-Execution administrative migration road. Two hosted typed-authority rows keep Execution and execution-scoped Review records RPC-only. Two further ADR-0028 P4 rows register the attributed doc_sync_submit coordinator road and the preset script staging-mirror ingest road. One ADR-0028 P5 row registers the coordinator-owned immutable attribution event trail. One dedicated T4 administrative migration row registers the attributed, confirmed-plan, key-only retirement of historical ownership fields. One ADR-0029 TW-01 row registers the authority replication submission road (attributed-coordinator entry over forced-command SSH). One ADR-0029 TW-02 row registers the compound receipt durable store (client-side crash-recovery receipt records, fsync + atomic rename). One ADR-0029 TW-03 row registers the broker local-view native applier (crash-safe transparent view materialization). One ADR-0029 TW-04 row registers the platform semantic-probe scratch writes (temporary qualification probes, created and removed inside one probe run). One ADR-0029 TW-06 row registers the authority fence enrollment anchor and durability boundary stores. One daemon transport row registers the socket owner-lock lifecycle state (task_01KXD0A37NN8ZQEJ2ENG5K313V): ephemeral single-instance mutex outside SoT, not entity data. One identity bootstrap row registers the user-profile people roster boundary (XD-1/XD-2). Two GUI decision rows register proposal and judgment transitions through the authenticated daemon IPC write road (dec_01KXDR0A9AR1Z57Q3M1JEDMBVR)."
   },
   "rows": [
     {
@@ -1505,6 +1505,31 @@
         "packages/cli/src/commands/daemon/serve-transport.ts:1"
       ],
       "freshness": "daemon-socket-owner-lock"
+    },
+    {
+      "id": "identity.machine-people.bootstrap",
+      "sourceInventoryRows": [
+        26
+      ],
+      "road": "D",
+      "bearing": "identity-config",
+      "leaseRequired": false,
+      "channel": {
+        "pathClass": "admin-config",
+        "zoneClass": "user-profile"
+      },
+      "entry": [
+        "cli"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/daemon/src/identity/machine-people.ts"
+        }
+      ],
+      "evidence": [
+        "packages/daemon/src/identity/machine-people.ts:7"
+      ],
+      "freshness": "create-once-machine-credential"
     },
     {
       "id": "decision.propose.gui-ipc",


### PR DESCRIPTION
# English

## Summary

Any local socket client could **declare who it was** in its first frame, and the daemon believed it — marking the connection `sshd-authorized-keys-forced-command` and **preferring that self-declared identity over the socket owner**, without ever verifying that sshd was involved (R14). Separately, the protocol server handed **the default repo's** identity provider, person registry and RBAC to **every** repo it served (R17), so identity bled across repositories.

This closes both, and lands the identity chain: **machine roster → project override → remote**.

## What Changed

- **R14 — a repo in `local` mode never accepts a self-declared principal.** Trust is now decided per repo, by mode:
  ```ts
  acceptsSshForcedCommand: (canonicalRoot) => [...repoBindings.values()].some(binding =>
    binding.identity.mode === "remote" && sameCanonicalRoot(binding.repo.canonicalRoot, canonicalRoot))
  ```
  The top-level caller fails safe (`?? false`), and the transport layer makes this parameter **required**, so a caller cannot forget it. In `local` mode the first frame's `personId` is ignored and the principal falls back to the socket owner.

  **This is what removed the need for a native module.** The original design required the server to distinguish a local CLI from an sshd forced-command *at runtime* (peer PID → sshd ancestry), because both could share one endpoint. The product ruling — *a project is either remote or local, never both* — means they never share an endpoint, so the distinction is configuration, not runtime forensics.

- **R17 — identity is resolved per target repo, and fails closed.** If the target repo has no identity binding, the provider/registry/RBAC are set to `undefined` rather than falling back to the default repo's. The multi-repo regression now uses **two rosters and two distinct persons** (the old test wrote the same person to both repos, so it was structurally blind to the bleed).

- **Identity chain**: machine roster (`~/.harness`) → project override → remote. A project cannot silently rebind a machine credential.

- **Daemon is user-global by default**: one process serves many repos; CI/sandbox can opt into an explicit isolated profile. A `/tmp` throwaway project can no longer squat the canonical daemon's socket.

- **A brand-new empty repo can bootstrap its identity through `ha` and write its first task** — the exact wall a cold-start agent hit.

## Task And Scope

PLT-XD / XD-1 (`task_01KXGFQJWBWRQEPH2Z5F02P0EE`) + XD-2 (`task_01KXGFQQ7E3SGNTF5YGKASP5GB`). Scope: daemon transport/identity/protocol, CLI daemon composition.

## Version Impact

Behavioral: a `local`-mode repo now ignores a client-declared principal. This is the intended tightening; no config migration required (mode defaults to `local`, fail-safe).

## Governance Declaration

Tightens a trust boundary. **No gate weakened.**

Protected paths touched, and their authorization:

- **`tools/write-road-registry.json`** — new mutating routes / fs writes introduced by the identity chain must be **declared** in the write-road registry. This is a *declaration, not an exemption*: the entries are added, no gate is bypassed. Authorized by task `task_01KXGFQJWBWRQEPH2Z5F02P0EE` (XD-1) and `task_01KXGFQQ7E3SGNTF5YGKASP5GB` (XD-2), under decision `dec_01KXGDXZG03JZRGTW8V91H11ER` (experience charter).
- **`tools/smoke-cli-package.mjs`** — the CLI package smoke must exercise the new identity bootstrap path (an empty repo self-bootstrapping its people roster). Same authorizing tasks.

No break-glass used.

## Verification

- `npm run check:ci` on the worker's pre-rebase base: 13 runnable jobs green.
- After CEO rebase onto `3c3d2ffc` and manual conflict resolution (3 files, see below), **CI on this PR is the authoritative signal** — the local gate run was invalidated by a polluted local environment (see Residual Risk).
- New negative tests: `remote mode rejects socket-owner identity and accepts only a forced-command person`; `a repo without people.yaml inherits the machine people roster`; identity-provider contract suite (+159 lines).

## Review Evidence

CEO semantic review traced the trust decision from `index.ts:122` → `service-host.ts:133` → `json-rpc-server.ts:208`, confirming both the per-repo mode gate and the fail-closed identity resolution.

**Rebase conflicts (3, resolved by CEO):**
1. `ledger-materializer.ts` — this branch and #781 independently fixed the same latent bug. Kept main's version (shared `sessionBranchName` + explicit loud failure) and dropped this branch's re-introduced private duplicate, preserving #781's de-duplication.
2. `daemon-runtime.test.ts` — the conflicting test was **moved** to `daemon-materializer-runtime.test.ts` by #781 (file-length gate). Took main.
3. `daemon-execution-claim-cli.test.ts` — `master:` vs `HEAD:`. Kept `master:`: read paths only trust master, and the assertion exists to prove the materializer actually merged the write out of its session branch. `HEAD:` would pass even if it were still stranded — which is precisely the P0 #781 fixed.

## Residual Risk

**The local gate could not be trusted for this branch.** `packages/daemon/test/fence-durability.test.ts` (`kill -9 and restart preserves every fsynced durability audit record`) hangs forever on this machine — **and it hangs identically on clean `main`** (negative control), because five daemons from other worktrees/sessions are holding sockets, and the test runner uses `--test-timeout=0`, so a stuck test never times out; the gate simply says "still running" for an hour. **This is a pre-existing local-environment defect, not a regression in this PR**, and it is filed as follow-up (it is a sibling of XD-7: a local gate that can hang silently is not a gate).

Windows named-pipe E2E deferred (approved follow-up).

## References

- Identity audit (`artifacts/identity-audit-2026-07-14.md`): R14, R17, and the finding that the machine `~/.harness` layer did not exist.
- `dec_01KXGDXZG03JZRGTW8V91H11ER` (experience charter).

---

# 中文

## 概要

**任何本地 socket 客户端都可以在首帧里自己声明"我是谁"，而 daemon 会信它**——把连接标记为 `sshd-authorized-keys-forced-command`，并且**优先采用这个自称的身份而不是 socket 属主**，全程从不验证 sshd 是否真的参与（R14）。另一边，protocol server 把**默认 repo 的** identity provider、person registry 与 RBAC 交给它服务的**每一个** repo（R17），于是身份跨仓泄漏。

本 PR 关闭这两个，并落地身份链：**机器 roster → 项目覆盖 → 远程**。

## 改动内容

- **R14 — `local` 模式的 repo 永不接受自称的 principal。** 信任现在按 repo、按 mode 判定：
  ```ts
  acceptsSshForcedCommand: (canonicalRoot) => [...repoBindings.values()].some(binding =>
    binding.identity.mode === "remote" && sameCanonicalRoot(binding.repo.canonicalRoot, canonicalRoot))
  ```
  最上层调用点 fail-safe（`?? false`），transport 层把这个参数改成**必填**，调用方不能忘。`local` 模式下首帧的 `personId` 被忽略，principal 回落到 socket 属主。

  **正是这一条消灭了对原生模块的需求。** 原方案要求服务端在**运行时**区分"本地 CLI"与"sshd forced-command"（取 peer PID 查 sshd 祖先），因为两者可能共用一个端点。而产品裁决——**一个项目要么远程要么本地，不能既是又是**——意味着它们**永不共用端点**，于是这个区分是**配置问题，不是运行时取证问题**。

- **R17 — 身份按目标 repo 解析，且 fail-closed。** 目标 repo 没有身份绑定时，provider/registry/RBAC 被置为 `undefined`，**而不是回退到默认 repo 的**。多仓回归测试现在用**两份 roster、两个不同的 person**（旧测试给两个 repo 写同一个 person，对这种泄漏结构性失明）。

- **身份链**：机器 roster（`~/.harness`）→ 项目覆盖 → 远程。项目不能静默改绑机器 credential。

- **daemon 默认 user-global**：一个进程服务多个仓库；CI/sandbox 可显式选择隔离 profile。`/tmp` 里的实验项目**再也不能顶替 canonical daemon 的 socket**。

- **全新空仓可以通过 `ha` 自举身份并写入第一条 task**——那正是冷启动 agent 撞死的那堵墙。

## 任务与范围

PLT-XD / XD-1（`task_01KXGFQJWBWRQEPH2Z5F02P0EE`）+ XD-2（`task_01KXGFQQ7E3SGNTF5YGKASP5GB`）。范围：daemon transport/identity/protocol、CLI daemon 组装。

## 版本影响

行为变更：`local` 模式的 repo 现在忽略客户端自称的 principal。这是有意收紧；无需配置迁移（mode 默认 `local`，fail-safe）。

## 治理声明

收紧信任边界，**未削弱任何门**。

触碰的受保护路径及其授权：

- **`tools/write-road-registry.json`** —— 身份链新增的 mutating 路由 / 文件系统写入必须在写道登记表里**补声明**。这是**补声明，不是加豁免**：只增条目，不绕任何门。授权：task `task_01KXGFQJWBWRQEPH2Z5F02P0EE`（XD-1）与 `task_01KXGFQQ7E3SGNTF5YGKASP5GB`（XD-2），依据 decision `dec_01KXGDXZG03JZRGTW8V91H11ER`（体验设计宪章）。
- **`tools/smoke-cli-package.mjs`** —— CLI 包冒烟必须覆盖新的身份自举路径（空仓自举 people roster）。同上授权。

未使用 break-glass。

## 验证

- worker 在 rebase 前的 base 上跑 `npm run check:ci`：13 个可运行 job 全绿。
- CEO rebase 到 `3c3d2ffc` 并手工解了 3 处冲突后，**本 PR 的 CI 才是权威信号**——本地门跑不出真相，本机环境已被污染（见残余风险）。
- 新增负向测试：`remote mode rejects socket-owner identity and accepts only a forced-command person`；`a repo without people.yaml inherits the machine people roster`；identity-provider 契约套件（+159 行）。

## 审查证据

CEO 语义验收沿信任判定链逐层核对：`index.ts:122` → `service-host.ts:133` → `json-rpc-server.ts:208`，确认了 per-repo 的 mode 门与 fail-closed 的身份解析。

**Rebase 冲突（3 处，CEO 解决）：**
1. `ledger-materializer.ts` —— 本分支与 #781 **各自独立修了同一个潜伏 bug**。取 main 的版本（共享 `sessionBranchName` + 显式响亮失败），丢弃本分支重新引入的私有重复函数，**保住 #781 的去重**。
2. `daemon-runtime.test.ts` —— 冲突的那个测试被 #781 **移到了** `daemon-materializer-runtime.test.ts`（文件行数门）。取 main。
3. `daemon-execution-claim-cli.test.ts` —— `master:` vs `HEAD:`。**取 `master:`**：读路径只认 master，而这条断言的意义正是证明 materializer 真的把写入从 session 分支合出来了。用 `HEAD:` 的话，**即使它还搁浅在 session 分支上也会通过**——那恰恰是 #781 修的那个 P0。

## 残余风险

**本分支的本地门不可信。** `packages/daemon/test/fence-durability.test.ts`（`kill -9 and restart preserves every fsynced durability audit record`）在本机永久挂死——**而它在干净的 `main` 上同样挂死**（阴性对照）：本机有五个来自其他 worktree/session 的 daemon 占着 socket，而测试 runner 用 `--test-timeout=0`，**卡住的测试永不超时**，门只会一直说"还在跑"，跑了一个小时。**这是既有的本地环境缺陷，不是本 PR 的回归**，已记为后续项（它是 XD-7 的近亲：**一个会静默挂死的本地门，不是门**）。

Windows named-pipe E2E 延后（已批准的 follow-up）。

## 关联材料

- 身份审计（`artifacts/identity-audit-2026-07-14.md`）：R14、R17，以及"机器级 `~/.harness` 层根本不存在"这一发现。
- `dec_01KXGDXZG03JZRGTW8V91H11ER`（体验设计宪章）。
