### PR TITLE
fix(lease): let the current holder rotate its execution lease token

### DIFF
--- a/packages/application/src/execution-saga-service.ts
+++ b/packages/application/src/execution-saga-service.ts
@@ -98,6 +98,21 @@ export function makeExecutionSagaService(options: ExecutionSagaServiceOptions): 
   return {
     claim: async (input) => {
       await reconcileTask(options, input.taskId);
+      const renewed = await options.taskHolderService.renewExecution({
+        taskId: input.taskId,
+        principal: input.principal,
+        ttlMs: input.ttlMs
+      });
+      if (renewed) {
+        const execution = await options.authoredStore.readExecution({
+          taskId: input.taskId,
+          executionId: renewed.executionId
+        });
+        if (!execution || execution.state !== "active") {
+          throw new Error(`active execution is unavailable for renewed lease: ${renewed.executionId}`);
+        }
+        return { ...renewed, execution };
+      }
       const executionId = generateExecutionId();
       const reservation = await options.taskHolderService.reserveExecution({
         taskId: input.taskId,

--- a/packages/application/test/execution-lease-renewal.test.ts
+++ b/packages/application/test/execution-lease-renewal.test.ts
@@ -1,0 +1,85 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  ExecutionLeaseCollisionError,
+  makeExecutionSagaService,
+  makeTaskHolderService,
+  taskHolderActor
+} from "../src/index.ts";
+import { memoryAuthoredStore } from "./execution-saga-fixtures.ts";
+
+const taskId = "task_01KX19GEKWMEJNGSMRT6JJH6HY";
+const executionId = "exe_01KX7H00000000000000000001";
+const aliceCodex = taskHolderActor(
+  { personId: "alice", displayName: "Alice" },
+  { kind: "agent", id: "codex" }
+);
+const aliceClaude = taskHolderActor(
+  { personId: "alice", displayName: "Alice" },
+  { kind: "agent", id: "claude-code" }
+);
+
+test("the active execution holder can renew its token while other holders and stale tokens are rejected", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-execution-renew-"));
+  const leaseActions: string[] = [];
+  let generatedExecutionIds = 0;
+  try {
+    const holder = makeTaskHolderService({
+      rootInput: rootDir,
+      now: () => new Date("2026-07-11T00:00:00.000Z"),
+      appendLeaseEvent: async (event) => { leaseActions.push(event.lease.action); }
+    });
+    const authored = memoryAuthoredStore();
+    const saga = makeExecutionSagaService({
+      taskHolderService: holder,
+      authoredStore: authored,
+      generateExecutionId: () => {
+        generatedExecutionIds += 1;
+        return executionId;
+      },
+      now: () => "2026-07-11T00:00:00.000Z"
+    });
+
+    const claimed = await saga.claim({ taskId, principal: aliceCodex });
+    const renewed = await saga.claim({ taskId, principal: aliceCodex });
+
+    assert.equal(renewed.executionId, claimed.executionId);
+    assert.equal(renewed.execution.execution_id, claimed.execution.execution_id);
+    assert.notEqual(renewed.leaseToken, claimed.leaseToken);
+    assert.equal(generatedExecutionIds, 1);
+    assert.equal(authored.executions.size, 1);
+    assert.deepEqual(leaseActions, ["reserved", "activated", "renewed"]);
+
+    await assert.rejects(holder.assertExecutionLease({
+      taskId,
+      executionId,
+      leaseToken: claimed.leaseToken,
+      principal: aliceCodex
+    }), /requires an active lease/u);
+    await holder.assertExecutionLease({
+      taskId,
+      executionId,
+      leaseToken: renewed.leaseToken,
+      principal: aliceCodex
+    });
+    await assert.rejects(saga.claim({ taskId, principal: aliceClaude }), ExecutionLeaseCollisionError);
+    await assert.rejects(holder.assertExecutionLease({
+      taskId,
+      executionId,
+      leaseToken: renewed.leaseToken,
+      principal: aliceClaude
+    }), /requires an active lease/u);
+    await assert.rejects(holder.assertExecutionLease({
+      taskId,
+      executionId,
+      leaseToken: "missing",
+      principal: aliceCodex
+    }), /requires an active lease/u);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/src/cli/command-spec/command-spec-core.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-core.ts
@@ -129,9 +129,9 @@ export const coreCommandSpecs = defineCommandSpecs([
   {
     "kind": "task-claim",
     "usage": "task claim <id> [--execution] [--ttl-ms <ms>] [--json]",
-    "options": [{"flag":"--execution","description":"Open a new Execution round with a Holder V2 credential."},{"flag":"--ttl-ms","description":"Set the task holder lease duration in milliseconds."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
-    "summary": "Claim a task holder lease for the authenticated principal.",
-    "examples": ["harness-anything task claim task_01ABC --ttl-ms 1800000"],
+    "options": [{"flag":"--execution","description":"Open a new Execution round, or rotate the active holder's credential."},{"flag":"--ttl-ms","description":"Set the task holder lease duration in milliseconds."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
+    "summary": "Claim a task holder lease; repeating an Execution claim as its current holder rotates the lease token.",
+    "examples": ["harness-anything task claim task_01ABC --ttl-ms 1800000", "harness-anything task claim task_01ABC --execution --json"],
     "parse": parseCoreTaskArgs,
     "run": runTaskLifecycleCommand,
     "receiptContract": {

--- a/packages/cli/src/commands/core/task-holder.ts
+++ b/packages/cli/src/commands/core/task-holder.ts
@@ -20,25 +20,31 @@ function runExecutionClaim(
 ): Effect.Effect<CliResult> {
   const saga = executionSaga(context);
   return context.currentSessionProbe.currentSession.pipe(
-    Effect.flatMap((session) => Effect.promise(() => saga.claim({
-      taskId: action.taskId,
-      principal,
-      ttlMs: action.ttlMs,
-      primarySession: session.runtime === "human" ? null : session
-    }))),
-    Effect.map((result): CliResult => ({
-      ok: true,
-      command: "task-claim",
-      taskId: action.taskId,
-      executionId: result.executionId,
-      report: {
-        schema: "execution-claim-result/v1",
+    Effect.flatMap((session) => Effect.tryPromise({
+      try: () => saga.claim({
+        taskId: action.taskId,
+        principal,
+        ttlMs: action.ttlMs,
+        primarySession: session.runtime === "human" ? null : session
+      }),
+      catch: taskHolderCommandFailure
+    })),
+    Effect.match({
+      onFailure: (result): CliResult => resultForTaskHolderFailure("task-claim", action.taskId, result),
+      onSuccess: (result): CliResult => ({
+        ok: true,
+        command: "task-claim",
+        taskId: action.taskId,
         executionId: result.executionId,
-        leaseToken: result.leaseToken,
-        leaseExpiresAt: result.leaseExpiresAt,
-        actor: result.execution.primary_actor
-      }
-    }))
+        report: {
+          schema: "execution-claim-result/v1",
+          executionId: result.executionId,
+          leaseToken: result.leaseToken,
+          leaseExpiresAt: result.leaseExpiresAt,
+          actor: result.execution.primary_actor
+        }
+      })
+    })
   );
 }
 export function runExecutionSubmit(

--- a/packages/cli/test/daemon-execution-claim-cli.test.ts
+++ b/packages/cli/test/daemon-execution-claim-cli.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import test from "node:test";
 import { receiptDataString, writePeopleRoster } from "./helpers/forced-command-daemon.ts";
-import { runRawJson, withTempRootAsync } from "./helpers/daemon-cli.ts";
+import { runRawJson, runRawJsonMaybeFail, withTempRootAsync } from "./helpers/daemon-cli.ts";
 import { git, receiptPath } from "./helpers/daemon-thin-client-fixtures.ts";
 
 test("daemon-backed Execution claim upgrades Holder V1 and preserves the caller session binding", async () => {
@@ -53,6 +53,35 @@ test("daemon-backed Execution claim upgrades Holder V1 and preserves the caller 
       readonly leaseToken?: unknown;
     });
     assert.match(String(claimReport.leaseToken), /^[0-9a-f]{64}$/u, JSON.stringify(claimed));
+
+    const otherHolder = runRawJsonMaybeFail(rootDir, ["task", "claim", taskId, "--execution"], {
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_IDLE_MS: "10000",
+      HARNESS_ACTOR: "agent:other-worker",
+      CLAUDE_SESSION_ID: "",
+      CLAUDE_CODE_SESSION_ID: "",
+      CODEX_THREAD_ID: "other-worker-session",
+      CODEX_SESSION_ID: "other-worker-session"
+    });
+    assert.equal(otherHolder.status, 1);
+    assert.equal(otherHolder.receipt.ok, false, JSON.stringify(otherHolder.receipt));
+    assert.match(String((otherHolder.receipt.error as { readonly hint?: string } | undefined)?.hint), /current holder principal=person_execution, executor=agent:daemon-cli-test/u);
+
+    const renewed = runRawJson(rootDir, ["task", "claim", taskId, "--execution"], {
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_IDLE_MS: "10000",
+      CLAUDE_SESSION_ID: "",
+      CLAUDE_CODE_SESSION_ID: "",
+      CODEX_THREAD_ID: "claiming-codex-session",
+      CODEX_SESSION_ID: "claiming-codex-session"
+    });
+    assert.equal(receiptDataString(renewed, "executionId"), executionId);
+    const renewedReport = (((renewed.details as Record<string, unknown>).data as Record<string, unknown>).report as {
+      readonly leaseToken?: unknown;
+    });
+    assert.match(String(renewedReport.leaseToken), /^[0-9a-f]{64}$/u, JSON.stringify(renewed));
+    assert.notEqual(renewedReport.leaseToken, claimReport.leaseToken);
+
     const executionPath = path.posix.join(
       receiptPath(created, "package").replace(/^harness\//u, ""),
       "executions",

--- a/packages/cli/test/task-lease-cli.test.ts
+++ b/packages/cli/test/task-lease-cli.test.ts
@@ -197,6 +197,47 @@ test("default claim and submit use Holder V2 without requiring an execution id",
     assert.equal(execution.session_bindings[0]?.session_ref, "session/codex-primary-session");
     assert.equal(execution.session_bindings[0]?.archive_status, "pending");
 
+    const otherHolder = runJson(rootDir, ["task", "claim", created.taskId], false, {
+      HARNESS_ACTOR: "agent:other-worker",
+      CLAUDE_SESSION_ID: "",
+      CLAUDE_CODE_SESSION_ID: "",
+      CODEX_THREAD_ID: "other-worker-session",
+      CODEX_SESSION_ID: "other-worker-session"
+    });
+    assert.equal(otherHolder.ok, false);
+    assert.equal(otherHolder.report.code, "execution_lease_collision");
+
+    const renewed = runJson(rootDir, ["task", "claim", created.taskId], true, {
+      HARNESS_ACTOR: "agent:test",
+      CLAUDE_SESSION_ID: "",
+      CLAUDE_CODE_SESSION_ID: "",
+      CODEX_THREAD_ID: "codex-primary-session",
+      CODEX_SESSION_ID: "codex-primary-session"
+    });
+    assert.equal(renewed.executionId, claimed.executionId);
+    assert.notEqual(renewed.report.leaseToken, claimed.report.leaseToken);
+    const renewedLeaseLedgerBody = readFileSync(path.join(
+      rootDir,
+      `.harness/generated/runtime-events/lease-${claimed.executionId}.jsonl`
+    ), "utf8");
+    const renewedLeaseEvents = renewedLeaseLedgerBody.trim().split("\n").map((line) => JSON.parse(line));
+    assert.deepEqual(renewedLeaseEvents.map((event) => event.lease.action), ["reserved", "activated", "renewed"]);
+    assert.doesNotMatch(renewedLeaseLedgerBody, /token|hash|credential/iu);
+
+    const staleToken = runJson(rootDir, [
+      "task", "transition", created.taskId, "in_review",
+      "--lease-token", claimed.report.leaseToken,
+      "--summary", "stale credential must be rejected"
+    ], false, {
+      HARNESS_ACTOR: "agent:test",
+      CLAUDE_SESSION_ID: "",
+      CLAUDE_CODE_SESSION_ID: "",
+      CODEX_THREAD_ID: "codex-primary-session",
+      CODEX_SESSION_ID: "codex-primary-session"
+    });
+    assert.equal(staleToken.ok, false);
+    assert.match(staleToken.error.hint, /requires an active lease/u);
+
     const homeDir = path.join(rootDir, "home");
     const codexLogs = path.join(homeDir, ".codex/sessions");
     mkdirSync(codexLogs, { recursive: true });
@@ -215,7 +256,7 @@ test("default claim and submit use Holder V2 without requiring an execution id",
 
     const submitted = runJson(rootDir, [
       "task", "transition", created.taskId, "in_review",
-      "--lease-token", claimed.report.leaseToken,
+      "--lease-token", renewed.report.leaseToken,
       "--summary", "ready for review",
       "--verification", "node:test",
       "--output", "commit:abc123"

--- a/packages/kernel/src/local/execution-lease-credential.ts
+++ b/packages/kernel/src/local/execution-lease-credential.ts
@@ -1,5 +1,8 @@
-import { createHash } from "node:crypto";
-import type { TaskHolderPrincipal } from "./task-holder-state.ts";
+import { createHash, randomBytes } from "node:crypto";
+import { ExecutionLeaseCollisionError, TaskLeaseRequiredError } from "./task-holder-errors.ts";
+import type { ExecutionLeaseRecord, TaskHolderPrincipal, TaskHolderRecord } from "./task-holder-state.ts";
+
+type AnyTaskHolderRecord = TaskHolderRecord | ExecutionLeaseRecord;
 
 export function sameTaskHolderPrincipal(left: TaskHolderPrincipal, right: TaskHolderPrincipal): boolean {
   return left.principal.personId === right.principal.personId;
@@ -13,4 +16,68 @@ export function sameExecutionLeaseActor(left: TaskHolderPrincipal, right: TaskHo
 
 export function hashExecutionLeaseToken(token: string): string {
   return createHash("sha256").update(token).digest("hex");
+}
+
+export function leaseDurationMs(
+  record: Pick<AnyTaskHolderRecord, "leaseExpiresAt" | "updatedAt">,
+  fallback: number
+): number {
+  if (!record.leaseExpiresAt) return fallback;
+  const duration = Date.parse(record.leaseExpiresAt) - Date.parse(record.updatedAt);
+  return Number.isFinite(duration) && duration > 0 ? duration : fallback;
+}
+
+export function renewExecutionLeaseCredential(
+  record: ExecutionLeaseRecord,
+  input: { readonly principal: TaskHolderPrincipal; readonly leaseDurationMs: number },
+  at: Date
+): { readonly record: ExecutionLeaseRecord; readonly leaseToken: string } {
+  if (record.phase !== "active" ||
+      Date.parse(record.leaseExpiresAt) <= at.getTime() ||
+      !sameExecutionLeaseActor(record.holder, input.principal)) {
+    throw new ExecutionLeaseCollisionError({
+      taskId: record.taskId,
+      principal: input.principal,
+      executionId: record.executionId,
+      holder: record.holder,
+      leaseExpiresAt: record.leaseExpiresAt
+    });
+  }
+  const updatedAt = at.toISOString();
+  const leaseToken = randomBytes(32).toString("hex");
+  return {
+    leaseToken,
+    record: {
+      ...record,
+      tokenHash: hashExecutionLeaseToken(leaseToken),
+      leaseExpiresAt: new Date(at.getTime() + input.leaseDurationMs).toISOString(),
+      updatedAt,
+      version: `${updatedAt}-${randomBytes(6).toString("hex")}`
+    }
+  };
+}
+
+export function requireExecutionCredential(
+  record: AnyTaskHolderRecord | null,
+  input: { readonly taskId: string; readonly executionId: string; readonly leaseToken: string; readonly principal: TaskHolderPrincipal },
+  at: Date
+): ExecutionLeaseRecord {
+  const valid = record?.schema === "task-holder/v2" &&
+    Date.parse(record.leaseExpiresAt) > at.getTime() &&
+    record.executionId === input.executionId &&
+    record.tokenHash === hashExecutionLeaseToken(input.leaseToken) &&
+    sameExecutionLeaseActor(record.holder, input.principal);
+  if (!valid) throw new TaskLeaseRequiredError({
+    taskId: input.taskId,
+    principal: input.principal,
+    holder: record?.holder ?? null,
+    leaseExpiresAt: record?.leaseExpiresAt ?? null,
+    orphan: Boolean(record?.holder && !effectiveLeaseCredentialHolder(record, at))
+  });
+  return record;
+}
+
+function effectiveLeaseCredentialHolder(record: AnyTaskHolderRecord, at: Date): TaskHolderPrincipal | null {
+  if (!record.holder || !record.leaseExpiresAt || record.releasedAt) return null;
+  return Date.parse(record.leaseExpiresAt) > at.getTime() ? record.holder : null;
 }

--- a/packages/kernel/src/local/task-holder-state.ts
+++ b/packages/kernel/src/local/task-holder-state.ts
@@ -5,7 +5,8 @@ import path from "node:path";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
 import { localRuntimeStateFileSystem } from "./local-layout-file-system.ts";
 import { listExecutionLeaseRefs } from "./task-holder-state-source.ts";
-import { hashExecutionLeaseToken, sameExecutionLeaseActor, sameTaskHolderPrincipal } from "./execution-lease-credential.ts";
+import { hashExecutionLeaseToken, leaseDurationMs, renewExecutionLeaseCredential, requireExecutionCredential,
+  sameExecutionLeaseActor, sameTaskHolderPrincipal } from "./execution-lease-credential.ts";
 import {
   emitExecutionLeaseEvents,
   executionLeaseRuntimeEvent,
@@ -120,6 +121,7 @@ export interface TaskHolderService {
   readonly release: (input: { readonly taskId: string; readonly principal: TaskHolderPrincipal }) => Promise<TaskHolderReleaseResult>;
   readonly assertActiveLease: (input: { readonly taskId: string; readonly principal: TaskHolderPrincipal }) => Promise<void>;
   readonly reserveExecution: (input: { readonly taskId: string; readonly executionId: string; readonly principal: TaskHolderPrincipal; readonly ttlMs?: number }) => Promise<ExecutionLeaseReservation>;
+  readonly renewExecution: (input: { readonly taskId: string; readonly principal: TaskHolderPrincipal; readonly ttlMs?: number }) => Promise<ExecutionLeaseContext | null>;
   readonly activateExecution: (input: { readonly taskId: string; readonly executionId: string; readonly leaseToken: string; readonly principal: TaskHolderPrincipal }) => Promise<ExecutionLeaseContext>;
   readonly releaseExecution: (input: { readonly taskId: string; readonly executionId: string; readonly leaseToken: string; readonly principal: TaskHolderPrincipal }) => Promise<TaskHolderReleaseResult>;
   readonly assertExecutionLease: (input: { readonly taskId: string; readonly executionId: string; readonly leaseToken: string; readonly principal: TaskHolderPrincipal }) => Promise<void>;
@@ -274,6 +276,30 @@ export function makeTaskHolderService(options: TaskHolderServiceOptions): TaskHo
         return {
           result: { ...holderSnapshot(input.taskId, record, at), executionId: input.executionId, leaseToken, phase: "reserving" } as ExecutionLeaseReservation,
           events
+        };
+      });
+      await emitExecutionLeaseEvents(options.appendLeaseEvent, mutation.events);
+      return mutation.result;
+    },
+    renewExecution: async (input) => {
+      const mutation = await withTaskHolderMutationLock(options.rootInput, input.taskId, () => {
+        const at = now();
+        const current = readHolderRecord(options.rootInput, input.taskId);
+        if (current?.schema !== "task-holder/v2" || Date.parse(current.leaseExpiresAt) <= at.getTime()) {
+          return { result: null, events: [] };
+        }
+        const leaseDuration = input.ttlMs === undefined
+          ? leaseDurationMs(current, ttl(undefined))
+          : ttl(input.ttlMs);
+        const { record, leaseToken } = renewExecutionLeaseCredential(
+          current,
+          { principal: input.principal, leaseDurationMs: leaseDuration },
+          at
+        );
+        writeHolderRecord(options.rootInput, record);
+        return {
+          result: { ...holderSnapshot(input.taskId, record, at), executionId: record.executionId, leaseToken, phase: "active" } as ExecutionLeaseContext,
+          events: [executionLeaseRuntimeEvent(record, "renewed", "active")]
         };
       });
       await emitExecutionLeaseEvents(options.appendLeaseEvent, mutation.events);
@@ -564,32 +590,6 @@ function emptyHolderRecord(taskId: string, at: string): TaskHolderRecord {
 function normalizeTtlMs(value: number): number {
   if (!Number.isFinite(value) || value <= 0) throw new Error("ttlMs must be a positive number");
   return Math.floor(value);
-}
-
-function leaseDurationMs(record: TaskHolderRecord, fallback: number): number {
-  if (!record.leaseExpiresAt) return fallback;
-  const duration = Date.parse(record.leaseExpiresAt) - Date.parse(record.updatedAt);
-  return Number.isFinite(duration) && duration > 0 ? duration : fallback;
-}
-
-function requireExecutionCredential(
-  record: AnyTaskHolderRecord | null,
-  input: { readonly taskId: string; readonly executionId: string; readonly leaseToken: string; readonly principal: TaskHolderPrincipal },
-  at: Date
-): ExecutionLeaseRecord {
-  const valid = record?.schema === "task-holder/v2" &&
-    Date.parse(record.leaseExpiresAt) > at.getTime() &&
-    record.executionId === input.executionId &&
-    record.tokenHash === hashExecutionLeaseToken(input.leaseToken) &&
-    sameExecutionLeaseActor(record.holder, input.principal);
-  if (!valid) throw new TaskLeaseRequiredError({
-    taskId: input.taskId,
-    principal: input.principal,
-    holder: record?.holder ?? null,
-    leaseExpiresAt: record?.leaseExpiresAt ?? null,
-    orphan: Boolean(record?.holder && !effectiveHolder(record, at))
-  });
-  return record;
 }
 
 function holderVersion(at: string): string {


### PR DESCRIPTION
# English

## Summary

An execution lease token is issued once (plaintext, in the claim receipt) and could never be retrieved afterward. A legitimate holder who did not save that one plaintext was locked out of its own `transition in_review` / `complete` — the friction that pushed workers toward impersonating `HARNESS_ACTOR` or making the token check optional.

This restores retrievability **without weakening the check**: the current holder can rotate its lease by re-claiming (a fresh token is minted, the old one invalidated immediately); the plaintext still never persists. The token check on every operation path stays strict.

## What Changed

- New `renewExecutionLeaseCredential`: the same actor (gated on `sameExecutionLeaseActor` + active phase + not expired) can rotate to a fresh token. Wired through a new `renewExecution` saga path, which returns the renewed lease only when the active execution still exists.
- `requireExecutionCredential` (the operation-path guard for transition/complete/release) is exported and reused unchanged in strictness: it still requires `record.tokenHash === hashExecutionLeaseToken(input.leaseToken)` **and** holder-actor match. No `leaseToken === undefined` escape hatch. Added an `orphan` diagnostic field only.
- Negative tests assert isolation is not weakened: a different executor, an old (rotated-out) token, and an invalid token are all rejected on both the in-process and daemon-backed paths.

## Why this, not the rejected approach

An earlier branch (`fix/blocked-lifecycle-deadlock`) solved the same deadlock by making the token check optional (`input.leaseToken === undefined || tokenHash === …`). In this repo's real config every worker shares `principal + executor`, so that change erased concurrent-worker protection entirely. It was rejected in semantic acceptance. The correct fix lets the legitimate holder retrieve/rotate its own token; it does not make the check optional.

## Task And Scope

PLT-XD F4, task `task_01KXG6A5XFG4EWSVJKVKF210M8`. Scope: execution lease credential + task-holder state + saga wiring + CLI holder + tests. No CI workflow, no required-check list, no branch protection.

## Version Impact

None.

## Governance Declaration

- Protected surface touched: yes — execution lease enforcement (accountability / concurrency isolation).
- Scope: strengthens usability without weakening the guard. The strict token match and holder-actor check on all operation paths are preserved; rotation is gated on holder identity.
- Break-glass: no.

## Verification

- `npm run check:local`: exit 0 (31 manifest gates, affected fast 256/256, contract 263/263, targeted application 13/13, CLI 13/13, daemon integration 1/1).
- Negative isolation tests: `execution-lease-renewal.test.ts`, `task-lease-cli.test.ts`, `daemon-execution-claim-cli.test.ts` — non-holder / old-token / invalid-token rejected.
- GitHub CI runs the full suite for the authoritative result.

## Review Evidence

- CEO semantic acceptance: verified the diff directly (this surface previously received a "make-it-pass" fix). Confirmed the token check stays strict on operation paths and rotation is holder-gated. Passed.
- Blocking findings: none.

## Residual Risk

Two processes sharing one executor identity can rotate each other's lease — inherent to the existing `principal + executor` identity granularity, not introduced here. Finer per-process isolation would require an identity-model change, out of scope.

## References

- Corrects the rejected approach on `fix/blocked-lifecycle-deadlock`.
- Task: PLT-XD F4 (`task_01KXG6A5XFG4EWSVJKVKF210M8`)

---

# 中文

## 概要

execution lease token 只在 claim 那一刻以纯文本发一次（回执里），之后无法再取回。没保存好那次纯文本的合法持有者，会被自己的 `transition in_review` / `complete` 挡在门外——这正是逼 worker 去伪装 `HARNESS_ACTOR` 或把 token 校验改可选的摩擦源。

本 PR 恢复可取回性、**但不削弱校验**：当前持有者可通过重新 claim 轮换租约（铸新 token、旧的立即失效），明文仍不落盘。所有操作路径上的 token 校验保持严格。

## 改动内容

- 新增 `renewExecutionLeaseCredential`：同一 actor（受 `sameExecutionLeaseActor` + phase active + 未过期 三重限制）可轮换到新 token。经新的 `renewExecution` saga 路径接线，仅当 active execution 仍存在时才返回续租。
- `requireExecutionCredential`（transition/complete/release 的操作路径守卫）导出后原样复用、严格性不变：仍要求 `record.tokenHash === hashExecutionLeaseToken(input.leaseToken)` **且** 持有者 actor 匹配。**无 `leaseToken === undefined` 逃生门**，仅增加一个 `orphan` 诊断字段。
- 负向测试断言隔离未被削弱：不同 executor、旧（已轮换）token、无效 token，在进程内与 daemon-backed 两条路径上全部被拒绝。

## 为什么是这个方案，而非被拒的那个

早前分支 `fix/blocked-lifecycle-deadlock` 用"把 token 校验改成可选"（`input.leaseToken === undefined || tokenHash === …`）解同一个死锁。而本仓真实配置下所有 worker 共享 `principal + executor`，那改动等于把并发保护整个抹掉，语义验收已打回。正解是让合法持有者取回/轮换自己的 token，而不是让校验可选。

## 任务与范围

PLT-XD F4，任务 `task_01KXG6A5XFG4EWSVJKVKF210M8`。范围：execution lease 凭证 + task-holder 状态 + saga 接线 + CLI holder + 测试。不动 CI workflow、required check 清单、分支保护。

## 版本影响

无。

## 治理声明

- 是否触碰 protected surface：是——execution lease 执法（问责 / 并发隔离）。
- 范围：增强可用性而不削弱守卫。所有操作路径上的严格 token 匹配与持有者 actor 校验保留；轮换锚持有者身份。
- Break-glass：no。

## 验证

- `npm run check:local`：exit 0（31 manifest 门，affected fast 256/256、contract 263/263、targeted application 13/13、CLI 13/13、daemon integration 1/1）。
- 负向隔离测试：`execution-lease-renewal.test.ts`、`task-lease-cli.test.ts`、`daemon-execution-claim-cli.test.ts`——非持有者/旧 token/无效 token 均被拒。
- GitHub CI 跑全套作权威结果。

## 审查证据

- CEO 语义验收：直接亲验 diff（这个面此前收过一次"修向跑通"）。确认操作路径 token 校验仍严格、轮换锚持有者身份。通过。
- 阻塞发现：无。

## 残余风险

共享同一 executor 身份的两个进程可互相轮换租约——这是既有 `principal + executor` 身份粒度固有的，非本改动引入。更细的按进程隔离需改身份模型，超范围。

## 关联材料

- 修正 `fix/blocked-lifecycle-deadlock` 被拒方案。
- 任务：PLT-XD F4（`task_01KXG6A5XFG4EWSVJKVKF210M8`）
