### PR TITLE
fix(bootstrap): actionable cold-start + one-shot completion requirements (XD-4)

### DIFF
--- a/packages/application/src/execution-completion-service.ts
+++ b/packages/application/src/execution-completion-service.ts
@@ -14,10 +14,31 @@ import {
 import { assertExecutionTaskInReview, executionActorsShareExecutor, executionHasArchiveWarnings } from "./execution-review-helpers.ts";
 
 export interface ExecutionCompletionService {
+  readonly inspectTaskExecutionCompletion?: (input: {
+    readonly taskId: string;
+    readonly actor: TaskHolderPrincipal;
+    readonly documents: ReadonlyArray<{ readonly path: string; readonly body: string }>;
+  }) => ExecutionCompletionReadiness;
   readonly completeTaskExecution: (input: {
     readonly taskId: string;
     readonly actor: TaskHolderPrincipal;
   }) => Promise<{ readonly executionId: string } | null>;
+}
+
+export interface ExecutionCompletionReadinessIssue {
+  readonly code:
+    | "execution_submission_required"
+    | "execution_task_not_in_review"
+    | "execution_actor_cannot_complete"
+    | "execution_review_required"
+    | "archive_warnings_acknowledgement_required";
+  readonly message: string;
+}
+
+export interface ExecutionCompletionReadiness {
+  readonly ok: boolean;
+  readonly executionId?: string;
+  readonly issues: ReadonlyArray<ExecutionCompletionReadinessIssue>;
 }
 
 export function makeExecutionCompletionService(options: {
@@ -28,51 +49,16 @@ export function makeExecutionCompletionService(options: {
 }): ExecutionCompletionService {
   const now = options.now ?? (() => new Date().toISOString());
   return {
+    inspectTaskExecutionCompletion: inspectExecutionCompletionReadiness,
     completeTaskExecution: async ({ taskId, actor }) => {
       const task = await Effect.runPromise(options.artifactStore.readTaskPackage(taskId));
-      const executionDocuments = task.documents.filter((document) => /^executions\/[^/]+\.md$/u.test(document.path));
-      if (executionDocuments.length === 0) return null;
-      const executions = executionDocuments.map((document) => {
-        const execution = Schema.decodeUnknownSync(executionDeclaration.schema)(
-          executionDeclaration.documentCodec.decode(document.body)
-        ) as ExecutionRecord;
-        if (document.path !== `executions/${execution.execution_id}.md` || execution.task_ref !== `task/${taskId}`) {
-          throw new Error(`execution identity does not match its host path: ${document.path}`);
-        }
-        return execution;
-      });
-      const submitted = executions.filter((candidate) => candidate.state === "submitted");
-      if (submitted.length !== 1) {
-        throw new Error(`task ${taskId} requires exactly one submitted Execution; found ${submitted.length}`);
+      const readiness = resolveExecutionCompletionReadiness({ taskId, actor, documents: task.documents });
+      if (!readiness.execution) {
+        if (!task.documents.some((document) => /^executions\/[^/]+\.md$/u.test(document.path))) return null;
+        throw new Error(readiness.issues[0]?.message ?? `task ${taskId} requires exactly one submitted Execution`);
       }
-      const execution = submitted[0]!;
-      assertExecutionTaskInReview(task.documents, taskId);
-      if (executionActorsShareExecutor(execution.primary_actor.executor, actor.executor)) {
-        throw new Error(`execution executor cannot complete its own delivery: ${execution.execution_id}`);
-      }
-
-      const reviews = task.documents
-        .filter((document) => /^reviews\/[^/]+\.md$/u.test(document.path))
-        .map((document) => {
-          const review = Schema.decodeUnknownSync(reviewDeclaration.schema)(
-            reviewDeclaration.documentCodec.decode(document.body)
-          ) as ReviewRecord;
-          if (document.path !== `reviews/${review.review_id}.md` || review.task_ref !== `task/${taskId}`) {
-            throw new Error(`review identity does not match its host path: ${document.path}`);
-          }
-          return review;
-        });
-      const executionRef = `execution/${taskId}/${execution.execution_id}`;
-      const approved = reviews.filter((review) =>
-        review.task_ref === `task/${taskId}` &&
-        review.execution_ref === executionRef &&
-        review.verdict === "approved" &&
-        !executionActorsShareExecutor(execution.primary_actor.executor, review.reviewer_actor.executor)
-      );
-      if (approved.length === 0) throw new Error(`submitted Execution ${execution.execution_id} requires at least one approved Review`);
-      if (executionHasArchiveWarnings(execution) && !approved.some((review) => review.archive_warnings_acknowledged)) {
-        throw new Error(`approved Review must acknowledge archive warnings for Execution ${execution.execution_id}`);
-      }
+      if (!readiness.ok) throw new Error(readiness.issues[0]?.message ?? `task ${taskId} is not ready for Execution completion`);
+      const execution = readiness.execution;
 
       const completedAt = now();
       await Effect.runPromise(writeDeclaredEntityTransaction(
@@ -86,6 +72,96 @@ export function makeExecutionCompletionService(options: {
       return { executionId: execution.execution_id };
     }
   };
+}
+
+export function inspectExecutionCompletionReadiness(input: {
+  readonly taskId: string;
+  readonly actor: TaskHolderPrincipal;
+  readonly documents: ReadonlyArray<{ readonly path: string; readonly body: string }>;
+}): ExecutionCompletionReadiness {
+  const readiness = resolveExecutionCompletionReadiness(input);
+  return {
+    ok: readiness.ok,
+    ...(readiness.execution ? { executionId: readiness.execution.execution_id } : {}),
+    issues: readiness.issues
+  };
+}
+
+function resolveExecutionCompletionReadiness(input: {
+  readonly taskId: string;
+  readonly actor: TaskHolderPrincipal;
+  readonly documents: ReadonlyArray<{ readonly path: string; readonly body: string }>;
+}): ExecutionCompletionReadiness & { readonly execution?: ExecutionRecord } {
+  const executions = input.documents
+    .filter((document) => /^executions\/[^/]+\.md$/u.test(document.path))
+    .map((document) => {
+      const execution = Schema.decodeUnknownSync(executionDeclaration.schema)(
+        executionDeclaration.documentCodec.decode(document.body)
+      ) as ExecutionRecord;
+      if (document.path !== `executions/${execution.execution_id}.md` || execution.task_ref !== `task/${input.taskId}`) {
+        throw new Error(`execution identity does not match its host path: ${document.path}`);
+      }
+      return execution;
+    });
+  const submitted = executions.filter((candidate) => candidate.state === "submitted");
+  if (submitted.length !== 1) {
+    return {
+      ok: false,
+      issues: [{
+        code: "execution_submission_required",
+        message: `Task completion requires exactly one submitted Execution; found ${submitted.length}.`
+      }]
+    };
+  }
+
+  const execution = submitted[0]!;
+  const issues: ExecutionCompletionReadinessIssue[] = [];
+  try {
+    assertExecutionTaskInReview(input.documents, input.taskId);
+  } catch (error) {
+    issues.push({
+      code: "execution_task_not_in_review",
+      message: error instanceof Error ? error.message : String(error)
+    });
+  }
+  if (executionActorsShareExecutor(execution.primary_actor.executor, input.actor.executor)) {
+    issues.push({
+      code: "execution_actor_cannot_complete",
+      message: `Execution executor cannot complete its own delivery: ${execution.execution_id}. Use a different authenticated executor.`
+    });
+  }
+
+  const reviews = input.documents
+    .filter((document) => /^reviews\/[^/]+\.md$/u.test(document.path))
+    .map((document) => {
+      const review = Schema.decodeUnknownSync(reviewDeclaration.schema)(
+        reviewDeclaration.documentCodec.decode(document.body)
+      ) as ReviewRecord;
+      if (document.path !== `reviews/${review.review_id}.md` || review.task_ref !== `task/${input.taskId}`) {
+        throw new Error(`review identity does not match its host path: ${document.path}`);
+      }
+      return review;
+    });
+  const executionRef = `execution/${input.taskId}/${execution.execution_id}`;
+  const approved = reviews.filter((review) =>
+    review.task_ref === `task/${input.taskId}` &&
+    review.execution_ref === executionRef &&
+    review.verdict === "approved" &&
+    !executionActorsShareExecutor(execution.primary_actor.executor, review.reviewer_actor.executor)
+  );
+  if (approved.length === 0) {
+    issues.push({
+      code: "execution_review_required",
+      message: `Submitted Execution ${execution.execution_id} requires at least one approved Review from a different executor.`
+    });
+  } else if (executionHasArchiveWarnings(execution) && !approved.some((review) => review.archive_warnings_acknowledged)) {
+    issues.push({
+      code: "archive_warnings_acknowledgement_required",
+      message: `Approved Review must acknowledge archive warnings for Execution ${execution.execution_id}.`
+    });
+  }
+
+  return { ok: issues.length === 0, executionId: execution.execution_id, execution, issues };
 }
 
 function completedTaskIndex(documents: ReadonlyArray<{ readonly path: string; readonly body: string }>, taskId: string): string {

--- a/packages/application/src/task-completion-requirements.ts
+++ b/packages/application/src/task-completion-requirements.ts
@@ -1,0 +1,143 @@
+import { Effect } from "effect";
+import type { ArtifactStore, TaskId } from "../../kernel/src/index.ts";
+import type { ExecutionCompletionReadiness } from "./execution-completion-service.ts";
+import { isCloseoutPlaceholderMarkdown } from "./task-lifecycle-gates.ts";
+import type { evaluateCompletionGate, TaskDocumentPlaceholderPolicy } from "./task-lifecycle-gates.ts";
+import type { TaskLifecycleFailure } from "./task-lifecycle-orchestrator.ts";
+
+type CompletionGateResult = ReturnType<typeof evaluateCompletionGate>;
+
+export interface TaskCompletionRequirementIssue {
+  readonly code: string;
+  readonly gateCode?: string;
+  readonly message: string;
+  readonly nextCommand?: string;
+}
+
+export function collectCompletionRequirementIssues(input: {
+  readonly taskId: string;
+  readonly legacyReviewBlocker: TaskLifecycleFailure | null;
+  readonly documentPlaceholder: TaskLifecycleFailure | null;
+  readonly codeDocReconciliation: TaskLifecycleFailure | null;
+  readonly completionGate: CompletionGateResult;
+  readonly executionReadiness: ExecutionCompletionReadiness;
+}): ReadonlyArray<TaskCompletionRequirementIssue> {
+  const issues: TaskCompletionRequirementIssue[] = [];
+  if (input.legacyReviewBlocker) {
+    issues.push(requirementFromFailure(input.legacyReviewBlocker, "Repair review.md, then rerun ha task complete."));
+  }
+  if (input.documentPlaceholder) {
+    issues.push(requirementFromFailure(input.documentPlaceholder, "Replace closeout.md placeholders with Summary, Verification, and Residual Risk."));
+  }
+  if (input.codeDocReconciliation) {
+    issues.push(requirementFromFailure(
+      input.codeDocReconciliation,
+      `ha task code-doc reconcile ${input.taskId} --commit <full-sha> [--path <repo-relative-path>]...`
+    ));
+  }
+  for (const issue of input.completionGate.issues) {
+    if (issue.code === "closeout_not_ready" && input.documentPlaceholder) continue;
+    issues.push({
+      code: issue.code,
+      message: issue.message,
+      ...(issue.code === "missing_ci_gate" || issue.code === "ci_not_passed"
+        ? { nextCommand: `ha task complete ${input.taskId} --ci passed` }
+        : issue.code === "closeout_not_ready"
+          ? { nextCommand: "Complete closeout.md and let the projection reach ready, then rerun ha task complete." }
+          : {})
+    });
+  }
+  for (const issue of input.executionReadiness.issues) {
+    issues.push({
+      code: issue.code,
+      message: issue.message,
+      ...(issue.code === "execution_review_required" && input.executionReadiness.executionId
+        ? { nextCommand: `ha task review-execution ${input.taskId} --execution-id ${input.executionReadiness.executionId} --verdict approved --findings <text> --rationale <text>` }
+        : issue.code === "execution_submission_required"
+          ? { nextCommand: `Claim and submit one Execution for ${input.taskId}, then rerun ha task complete.` }
+          : issue.code === "archive_warnings_acknowledgement_required" && input.executionReadiness.executionId
+            ? { nextCommand: `Review Execution ${input.executionReadiness.executionId} with --acknowledge-archive-warnings.` }
+            : {})
+    });
+  }
+  return issues;
+}
+
+export function completionRequirementsFailure(
+  taskId: string,
+  issues: ReadonlyArray<TaskCompletionRequirementIssue>,
+  completionGate: CompletionGateResult
+): TaskLifecycleFailure {
+  return {
+    ok: false,
+    taskId,
+    completionGate,
+    issues,
+    error: {
+      code: completionRequirementErrorCode(issues[0]),
+      hint: `Task completion has ${issues.length} unmet requirement${issues.length === 1 ? "" : "s"}: ${issues.map(renderCompletionRequirement).join(" | ")}`
+    }
+  };
+}
+
+export function isExecutionCompletionRequirement(code: string): boolean {
+  return code === "execution_submission_required"
+    || code === "execution_task_not_in_review"
+    || code === "execution_actor_cannot_complete"
+    || code === "execution_review_required"
+    || code === "archive_warnings_acknowledgement_required";
+}
+
+export function validateCompletionDocumentPlaceholders(
+  artifactStore: Pick<ArtifactStore, "readTaskPackage">,
+  taskId: string,
+  policy: TaskDocumentPlaceholderPolicy | undefined
+): Effect.Effect<TaskLifecycleFailure | null> {
+  return Effect.gen(function* () {
+    const taskPackage = policy
+      ? yield* artifactStore.readTaskPackage(taskId as TaskId).pipe(Effect.catchAll(() => Effect.succeed(null)))
+      : null;
+    const closeout = taskPackage?.documents.find((document) => document.path === "closeout.md")?.body ?? null;
+    if (!policy || closeout === null || !isCloseoutPlaceholderMarkdown(closeout, policy.closeoutPlaceholderFingerprints)) return null;
+    return {
+      ok: false,
+      taskId,
+      error: {
+        code: "closeout_placeholder",
+        hint: `closeout.md is missing real Summary, Verification, and Residual Risk; replace its template placeholders before completing the task. Actual task directory read: ${taskPackage?.rootPath ?? "unavailable"}.`
+      }
+    };
+  });
+}
+
+function requirementFromFailure(failure: TaskLifecycleFailure, nextCommand: string): TaskCompletionRequirementIssue {
+  const detailedIssues = (failure.issues ?? []).flatMap((issue) => {
+    if (!issue || typeof issue !== "object" || Array.isArray(issue)) return [];
+    const code = (issue as { readonly code?: unknown }).code;
+    const message = (issue as { readonly message?: unknown }).message;
+    return typeof code === "string" && typeof message === "string" ? [{ code, message }] : [];
+  });
+  const detail = detailedIssues[0];
+  return {
+    code: detail?.code ?? failure.error.code,
+    ...(detail && detail.code !== failure.error.code ? { gateCode: failure.error.code } : {}),
+    message: detailedIssues.length > 0 ? detailedIssues.map((issue) => issue.message).join(" ") : failure.error.hint,
+    nextCommand
+  };
+}
+
+function renderCompletionRequirement(issue: TaskCompletionRequirementIssue): string {
+  const label = issue.gateCode && issue.gateCode !== issue.code ? `${issue.gateCode}:${issue.code}` : issue.code;
+  return `[${label}] ${issue.message}${issue.nextCommand ? ` Next: ${issue.nextCommand}` : ""}`;
+}
+
+function completionRequirementErrorCode(issue: TaskCompletionRequirementIssue | undefined): string {
+  const code = issue?.gateCode ?? issue?.code;
+  if (code === "execution_actor_cannot_complete" || code === "execution_review_required" || code === "archive_warnings_acknowledgement_required") {
+    return "write_rejected";
+  }
+  if (code === "execution_submission_required" || code === "execution_task_not_in_review") {
+    return "execution_completion_required";
+  }
+  return code ?? "completion_gate_failed";
+}

--- a/packages/application/src/task-lifecycle-orchestrator.ts
+++ b/packages/application/src/task-lifecycle-orchestrator.ts
@@ -5,9 +5,10 @@ import type { HarnessLayoutOverrides } from "../../kernel/src/index.ts";
 import { readFrontmatter, readScalar } from "../../kernel/src/index.ts";
 import { evaluateCodeDocReconciliationGate } from "./code-doc-reconciliation.ts";
 import { parseTaskContractSnapshot, resolveTaskCompletionGates } from "./task-contract-snapshot.ts";
-import { evaluateCompletionGate, evaluateReviewGate, isCloseoutPlaceholderMarkdown, isReviewPlaceholderMarkdown, isTaskDocumentPlaceholderMarkdown, parseReviewMarkdown } from "./task-lifecycle-gates.ts";
+import { evaluateCompletionGate, evaluateReviewGate, isReviewPlaceholderMarkdown, isTaskDocumentPlaceholderMarkdown, parseReviewMarkdown } from "./task-lifecycle-gates.ts";
 import type { TaskDocumentPlaceholderPolicy, VerifierBackedReviewContract } from "./task-lifecycle-gates.ts";
-import type { ExecutionCompletionService } from "./execution-completion-service.ts";
+import type { ExecutionCompletionReadiness, ExecutionCompletionService } from "./execution-completion-service.ts";
+import { collectCompletionRequirementIssues, completionRequirementsFailure, isExecutionCompletionRequirement, validateCompletionDocumentPlaceholders } from "./task-completion-requirements.ts";
 
 type CompletionGateResult = ReturnType<typeof evaluateCompletionGate>;
 
@@ -161,12 +162,15 @@ export function makeTaskLifecycleOrchestrator(options: TaskLifecycleOrchestrator
         payload.reviewerId,
         options.now
       );
-      if (legacyReviewBlocker) return legacyReviewBlocker;
 
       const projection = readTaskProjection({ rootDir: options.rootDir, layoutOverrides: options.layoutOverrides });
       const row = projection.rows.find((item) => item.taskId === payload.taskId);
       if (!row) return taskFailure(payload.taskId, "task_not_found", `task not found: ${payload.taskId}`);
-      const contractBody = yield* readTaskDocument(options.artifactStore, payload.taskId, "task-contract.json");
+      const taskPackage = yield* options.artifactStore.readTaskPackage(payload.taskId as TaskId).pipe(
+        Effect.catchAll(() => Effect.succeed(null))
+      );
+      if (!taskPackage) return taskFailure(payload.taskId, "task_not_found", `task package not found: ${payload.taskId}`);
+      const contractBody = taskPackage.documents.find((document) => document.path === "task-contract.json")?.body ?? null;
       let contractSnapshot;
       try {
         contractSnapshot = contractBody === null ? undefined : parseTaskContractSnapshot(contractBody);
@@ -191,17 +195,15 @@ export function makeTaskLifecycleOrchestrator(options: TaskLifecycleOrchestrator
         payload.taskId,
         options.documentPlaceholderPolicy
       );
-      if (documentPlaceholder) return documentPlaceholder;
-
+      let codeDocReconciliation: TaskLifecycleFailure | null = null;
       if (completionGates.gates.includes("code-doc-reconciliation")) {
-        const codeDocReconciliation = yield* validateCodeDocReconciliation(
+        codeDocReconciliation = yield* validateCodeDocReconciliation(
           options.artifactStore,
           options.rootDir,
           resolveHarnessLayout({ rootDir: options.rootDir, layoutOverrides: options.layoutOverrides }).authoredRoot,
           payload.taskId,
           options.codeDocVersionControlSystem
         );
-        if (codeDocReconciliation) return codeDocReconciliation;
       }
 
       const completionGate = evaluateCompletionGate({
@@ -213,32 +215,36 @@ export function makeTaskLifecycleOrchestrator(options: TaskLifecycleOrchestrator
         ciGate: payload.ciGate,
         applicableGates: completionGates.gates
       });
-      if (!completionGate.ok) {
-        return {
-          ok: false,
-          taskId: payload.taskId,
-          completionGate,
-          issues: completionGate.issues,
-          error: {
-            code: completionGateErrorCode(completionGate.issues),
-            hint: "Task completion gate failed."
-          }
-        } satisfies TaskLifecycleResult;
+      let executionReadiness: ExecutionCompletionReadiness = { ok: true, issues: [] };
+      try {
+        executionReadiness = options.executionCompletionService.inspectTaskExecutionCompletion
+          ? options.executionCompletionService.inspectTaskExecutionCompletion({
+            taskId: payload.taskId,
+            actor: payload.actor,
+            documents: taskPackage.documents
+          })
+          : executionReadiness;
+      } catch (error) {
+        return taskFailure(payload.taskId, "write_rejected", error instanceof Error ? error.message : String(error));
+      }
+      const requirementIssues = collectCompletionRequirementIssues({
+        taskId: payload.taskId,
+        legacyReviewBlocker,
+        documentPlaceholder,
+        codeDocReconciliation,
+        completionGate,
+        executionReadiness
+      });
+      if (requirementIssues.length > 0) {
+        if (requirementIssues.every((issue) => isExecutionCompletionRequirement(issue.code))) {
+          const taskTreeFailure = yield* prepareCompletionTaskTree(options.taskWriter, payload.taskId, completionGate);
+          if (taskTreeFailure) return taskTreeFailure;
+        }
+        return completionRequirementsFailure(payload.taskId, requirementIssues, completionGate);
       }
 
-      const staged = yield* stageTaskTree(options.taskWriter, payload.taskId, "Completion task-tree staging failed.");
-      if (!staged.ok) return staged;
-      const taskTreeStatus = yield* options.taskWriter.taskTreeStatus({ taskId: payload.taskId }).pipe(
-        Effect.match({
-          onFailure: (error): TaskLifecycleResult => writeFailure(payload.taskId, error, "Completion task-tree dirty check failed."),
-          onSuccess: (result): TaskLifecycleResult => result.dirty
-            ? taskTreeDirtyFailure(payload.taskId, result.entries, completionGate)
-            : ({ ok: true, taskId: result.taskId } satisfies TaskLifecycleResult)
-        })
-      );
-      if (!taskTreeStatus.ok) {
-        return taskTreeStatus;
-      }
+      const taskTreeFailure = yield* prepareCompletionTaskTree(options.taskWriter, payload.taskId, completionGate);
+      if (taskTreeFailure) return taskTreeFailure;
       const completion = yield* Effect.tryPromise({
         try: () => options.executionCompletionService!.completeTaskExecution({ taskId: payload.taskId, actor: payload.actor! }),
         catch: (error) => error
@@ -267,6 +273,25 @@ export function makeTaskLifecycleOrchestrator(options: TaskLifecycleOrchestrator
   };
 }
 
+function prepareCompletionTaskTree(
+  writer: TaskLifecycleWriter,
+  taskId: string,
+  completionGate: CompletionGateResult
+): Effect.Effect<TaskLifecycleFailure | null> {
+  return Effect.gen(function* () {
+    const staged = yield* stageTaskTree(writer, taskId, "Completion task-tree staging failed.");
+    if (!staged.ok) return staged;
+    return yield* writer.taskTreeStatus({ taskId }).pipe(
+      Effect.match({
+        onFailure: (error): TaskLifecycleFailure => writeFailure(taskId, error, "Completion task-tree dirty check failed."),
+        onSuccess: (result): TaskLifecycleFailure | null => result.dirty
+          ? taskTreeDirtyFailure(taskId, result.entries, completionGate)
+          : null
+      })
+    );
+  });
+}
+
 function stageTaskTree(
   writer: TaskLifecycleWriter,
   taskId: string,
@@ -278,24 +303,6 @@ function stageTaskTree(
       onSuccess: (result): TaskLifecycleResult => ({ ok: true, taskId: result.taskId, path: result.path })
     })
   );
-}
-
-function validateCompletionDocumentPlaceholders(
-  artifactStore: Pick<ArtifactStore, "readTaskPackage">,
-  taskId: string,
-  policy: TaskDocumentPlaceholderPolicy | undefined
-): Effect.Effect<TaskLifecycleFailure | null> {
-  return Effect.gen(function* () {
-    const taskPackage = policy
-      ? yield* artifactStore.readTaskPackage(taskId as TaskId).pipe(Effect.catchAll(() => Effect.succeed(null)))
-      : null;
-    const closeout = taskPackage?.documents.find((document) => document.path === "closeout.md")?.body ?? null;
-    if (policy && closeout !== null && isCloseoutPlaceholderMarkdown(closeout, policy.closeoutPlaceholderFingerprints)) {
-      return taskFailure(taskId, "closeout_placeholder", `Replace closeout.md template placeholders before completing the task. Actual task directory read: ${taskPackage?.rootPath ?? "unavailable"}.`);
-    }
-
-    return null;
-  });
 }
 
 function validateLegacyReviewCompatibilityBlockers(
@@ -514,10 +521,6 @@ function taskTreeDirtyFailure(
 
 function writeFailure(taskId: string, error: EngineError | WriteError, fallbackHint: string): TaskLifecycleFailure {
   return taskFailure(taskId, writeFailureCode(error), `${fallbackHint} ${writeFailureCauseHint(error)}`);
-}
-
-function completionGateErrorCode(issues: ReadonlyArray<{ readonly code: string }>): string {
-  return issues[0]?.code ?? "completion_gate_failed";
 }
 
 // Canonical kernel-tag -> CLI error-code mapping. Kept exhaustive by the mapped

--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -283,9 +283,10 @@ function initSummary(path: string, report: unknown): string {
   const boundary = isolation && typeof isolation === "object" && !Array.isArray(isolation)
     ? (isolation as { readonly boundary?: unknown }).boundary
     : undefined;
-  return typeof boundary === "string"
+  const summary = typeof boundary === "string"
     ? `initialized harness at ${path}; ${boundary}`
     : `initialized harness at ${path}`;
+  return `${summary} Next: ha daemon repo register --root .; then ha daemon start --service; verify with ha doctor --json.`;
 }
 
 function displayCommand(command: string): { readonly command: string; readonly entity?: string; readonly action: string } {

--- a/packages/cli/src/commands/core/capabilities.ts
+++ b/packages/cli/src/commands/core/capabilities.ts
@@ -5,6 +5,7 @@ import { cliCommandAlias } from "../../cli/command-names.ts";
 import { actionForCommand, commandInputDescriptorFor, entityForCommand } from "../../cli/command-input-descriptors.ts";
 import type { CommandRunner } from "../../cli/runner-registry.ts";
 import type { CliResult, ParsedCommand } from "../../cli/types.ts";
+import { daemonCapabilityOperations } from "../daemon/help.ts";
 
 export { capabilityExcludedCommandKinds };
 
@@ -76,6 +77,7 @@ function entities(context: Parameters<CommandRunner>[0]): Map<string, { readonly
   for (const kind of capabilityEntityKinds(context.commandDescriptors)) {
     if (!byEntity.has(kind)) byEntity.set(kind, []);
   }
+  byEntity.set("daemon", [...daemonCapabilityOperations]);
   return new Map([...byEntity.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([kind, ops]) => [kind, { kind, ops }]));
 }
 
@@ -109,7 +111,8 @@ function descriptionForEntity(kind: string): string {
     session: "Managed exported runtime session markdown documents.",
     doc: "Canonical document manifest and module read-set derivation.",
     graph: "Generated relation graph inspection artifacts over the SQLite projection.",
-    module: "Registered project module metadata."
+    module: "Registered project module metadata.",
+    daemon: "Persistent local service and repository registration needed by daemon-backed commands."
   };
   return descriptions[kind] ?? `Capabilities for ${kind} commands.`;
 }

--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -226,6 +226,7 @@ function isCliReportRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function taskGateHint(code: string, hint: string, taskId: string): string {
+  if (hint.startsWith("Task completion has ")) return hint;
   if (/review\.md material findings table failed validation/i.test(hint)) return `${hint} Valid severity values: P0, P1, P2, P3.`;
   if (code === CliErrorCode.CodeDocReconciliationFailed) {
     return `${hint} Generate the required file with ha task code-doc reconcile ${taskId} --commit <full-sha> [--path <repo-relative-path>]... [--pr <url>].`;

--- a/packages/cli/src/commands/daemon/help.ts
+++ b/packages/cli/src/commands/daemon/help.ts
@@ -1,3 +1,43 @@
+import type { CommandRegistryEntry } from "../../cli/types.ts";
+
+export const daemonHelpRegistryEntry = {
+  kind: "daemon",
+  primary: "harness-anything daemon <subcommand> [options]",
+  aliases: ["ha daemon <subcommand> [options]"],
+  commandPath: ["daemon"],
+  summary: "Register repositories and manage the persistent local daemon.",
+  options: [],
+  examples: [
+    "ha daemon repo register --root .",
+    "ha daemon start --service",
+    "ha daemon status --json"
+  ],
+  resultEnvelope: "command-receipt/v2"
+} as const satisfies CommandRegistryEntry;
+
+export const daemonCapabilityOperations = [
+  daemonCapabilityOperation(
+    "register",
+    "ha daemon repo register --root .",
+    "Register the current initialized repository with the user daemon."
+  ),
+  daemonCapabilityOperation(
+    "start",
+    "ha daemon start --service",
+    "Start the persistent local daemon service."
+  ),
+  daemonCapabilityOperation(
+    "status",
+    "ha daemon status --json",
+    "Inspect daemon availability and registered repository state."
+  ),
+  daemonCapabilityOperation(
+    "stop",
+    "ha daemon stop",
+    "Stop the persistent local daemon after draining queued writes."
+  )
+] as const;
+
 export function renderDaemonHelp(): string {
   return [
     "Usage: harness-anything daemon <start|status|stop|connect|bootstrap-server|install-templates> [options]",
@@ -13,4 +53,24 @@ export function renderDaemonHelp(): string {
     "  bootstrap-server             Initialize a canonical team server repository.",
     "  install-templates --out DIR  Copy systemd, launchd, and Windows Service templates."
   ].join("\n");
+}
+
+function daemonCapabilityOperation(action: string, command: string, description: string) {
+  return {
+    commandKind: `daemon-${action}`,
+    name: action,
+    action,
+    command,
+    description,
+    input: {
+      schema: "json-schema",
+      schemaId: `harness://schema/cli/daemon-${action}-input/v1`,
+      type: "object",
+      required: [],
+      properties: {}
+    },
+    shortcuts: [],
+    output: { receiptSchema: "daemon-command/v1", itemKind: "daemon" },
+    examples: [command]
+  } as const;
 }

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -1,4 +1,5 @@
 import type { CliResult, CommandRegistryEntry, ParsedCommand } from "../cli/types.ts";
+import { daemonHelpRegistryEntry } from "./daemon/help.ts";
 
 type HelpAction = Extract<ParsedCommand["action"], { readonly kind: "help" }>;
 
@@ -19,7 +20,7 @@ function helpCommands(action: HelpAction, commandRegistry: ReadonlyArray<Command
   if (action.commandPrefix) {
     return commandRegistry.filter((entry) => action.commandPrefix!.every((token, index) => entry.commandPath[index] === token));
   }
-  return commandRegistry;
+  return [...commandRegistry, daemonHelpRegistryEntry];
 }
 
 function helpReport(action: HelpAction): CliResult["report"] {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -117,6 +117,9 @@ function ensureHarnessRepositoryIsolation(rootDir: string, authoredRoot: string,
       outerGitignore: gitignore.report,
       boundary: "Code PRs must not include harness/ changes; commit ledger changes inside harness/ as its own private git repository.",
       nextSteps: [
+        "ha daemon repo register --root .",
+        "ha daemon start --service",
+        "ha doctor --json",
         `git -C ${authoredRootRelative} status`,
         `git -C ${authoredRootRelative} add . && git -C ${authoredRootRelative} commit`
       ]

--- a/packages/cli/test/doctor-cli.test.ts
+++ b/packages/cli/test/doctor-cli.test.ts
@@ -32,7 +32,13 @@ test("doctor reports read-only environment and harness diagnostics without writi
 
 test("doctor sees initialized authored and generated harness roots without repairing them", () => {
   withTempRoot((rootDir) => {
-    runJson(rootDir, ["init"]);
+    const initialized = runJson(rootDir, ["init"]);
+
+    assert.deepEqual(initialized.report.isolation.nextSteps.slice(0, 3), [
+      "ha daemon repo register --root .",
+      "ha daemon start --service",
+      "ha doctor --json"
+    ]);
 
     const result = runJson(rootDir, ["doctor"]);
 
@@ -92,6 +98,33 @@ test("CLI help prints canonical command and alias", () => {
     assert.match(stdout, /Usage: harness-anything <command> \[options\]/u);
     assert.match(stdout, /Alias: ha <command> \[options\]/u);
     assert.match(stdout, /harness-anything doctor --json/u);
+    assert.match(stdout, /harness-anything daemon <subcommand> \[options\]/u);
+  });
+});
+
+test("init text receipt gives the daemon registration and startup path", () => {
+  withTempRoot((rootDir) => {
+    const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "init"], {
+      encoding: "utf8"
+    });
+
+    assert.match(stdout, /Next: ha daemon repo register --root \.; then ha daemon start --service; verify with ha doctor --json\./u);
+  });
+});
+
+test("CLI capabilities exposes daemon onboarding operations", () => {
+  withTempRoot((rootDir) => {
+    const index = runJson(rootDir, ["capabilities"]);
+    const daemon = runJson(rootDir, ["capabilities", "--kind", "daemon"]);
+
+    assert.equal(index.report.items.some((item: Record<string, unknown>) => item.kind === "daemon"), true);
+    assert.deepEqual(daemon.report.ops.map((operation: Record<string, unknown>) => operation.action), [
+      "register",
+      "start",
+      "status",
+      "stop"
+    ]);
+    assert.equal(daemon.report.ops[0]?.command, "ha daemon repo register --root .");
   });
 });
 

--- a/packages/cli/test/task-document-gates-cli.test.ts
+++ b/packages/cli/test/task-document-gates-cli.test.ts
@@ -141,6 +141,38 @@ test("CLI task-complete without Execution fails closed and leaves INDEX byte-exa
   });
 });
 
+test("CLI task-complete reports every currently unmet completion requirement", () => {
+  withTempRoot((rootDir) => {
+    writeIndex(rootDir, executionTaskId, "Aggregate Completion Gates", "in_review");
+    writeCloseout(rootDir, executionTaskId, [
+      "## Summary", "", "Summarize the completed behavior change.", "",
+      "## Verification", "", "List passing checks and CI.", "",
+      "## Residual Risk", "", "Record accepted non-blocking risks."
+    ]);
+    writeExecution(rootDir, executionTaskId, executionId, "test");
+
+    const blocked = runJson(rootDir, [
+      "task", "complete", executionTaskId, "--reviewer", "reviewer-a"
+    ], false, testActorEnv);
+    const issueCodes = blocked.issues.map((issue: Record<string, unknown>) => issue.code);
+
+    assert.equal(blocked.ok, false);
+    assert.equal(blocked.error?.code, "closeout_placeholder");
+    assert.deepEqual(issueCodes, [
+      "closeout_placeholder",
+      "code_doc_anchors_missing",
+      "missing_ci_gate",
+      "execution_actor_cannot_complete",
+      "execution_review_required"
+    ]);
+    assert.match(blocked.error?.hint ?? "", /5 unmet requirements/u);
+    assert.match(blocked.error?.hint ?? "", /ha task code-doc reconcile/u);
+    assert.match(blocked.error?.hint ?? "", /--ci passed/u);
+    assert.match(blocked.error?.hint ?? "", /different authenticated executor/u);
+    assert.match(blocked.error?.hint ?? "", /ha task review-execution/u);
+  });
+});
+
 test("CLI typed completion does not require filling the legacy review placeholder", () => {
   withTempRoot((rootDir) => {
     writeIndex(rootDir, executionTaskId, "Complete Task", "in_review");


### PR DESCRIPTION
# English

## Summary

A stranger's agent could not bootstrap harness and run a task's first life. XD-4 fixes the bootstrap layer (its blockers XD-1/XD-2/XD-3 already landed): `ha init` now tells you the next step, `ha --help` surfaces the daemon, and `task complete` stops making you hit its gates one at a time.

## What Changed

- **Item 1 — `ha init` is actionable**: the JSON `nextSteps` and text receipt now spell out `repo register → daemon start → doctor` instead of leaving the user to guess. (`init.ts`, `receipt.ts`)
- **Item 2 — `task complete` computes all unmet gates at once**: new `task-completion-requirements.ts` aggregates closeout, code-doc, CI, Execution actor, and Review requirements into one list, each with its own next command (`ha task code-doc reconcile …`, `ha task review-execution …`, `ha task complete --ci passed`). No more hitting a hidden door, fixing it, and discovering the next one. (`task-completion-requirements.ts`, `task-lifecycle-orchestrator.ts`, `execution-completion-service.ts`)
- **Item 4 — daemon is discoverable**: top-level `ha --help` now shows `daemon`; `capabilities` exposes register/start/status/stop. (`daemon/help.ts`, `help.ts`, `capabilities.ts`)

## Scope note

- **Item 3 (docs/chore lightweight profile) is deferred to a finding, not implemented here**: the correct implementation requires declaring a lighter profile inside the preset manifest, and the preset system is being reworked in a concurrent stream. Bypassing the authoritative task-contract snapshot to strip gates would weaken enforcement, so it was left untouched. Finding recorded for the task.
- The generic hint-length gate belongs to XD-6 and is not implemented here.

## Task And Scope

PLT-XD XD-4, task `task_01KXGFQYXY4H8EA3F2H7D6S0Q3`. Bootstrap-layer usability + completion-requirement aggregation. No CI workflow, no required-check removal, no branch protection.

## Version Impact

None.

## Governance Declaration

- Authorized by: charter decision `dec_01KXGDXZG03JZRGTW8V91H11ER` (experience-design: the system must not require a caller to restate what it can derive, and a rejection error must teach the next step) and task `task_01KXGFQYXY4H8EA3F2H7D6S0Q3` (PLT-XD XD-4).
- Protected surface touched: task completion / lifecycle orchestration (`task-lifecycle-orchestrator.ts`, `execution-completion-service.ts`). Change is additive and usability-only: it aggregates and explains existing gates; it removes or weakens no completion gate. The set of required gates is unchanged — only their reporting is now complete and actionable.
- Break-glass: no.

## Verification

- `npm run check:local`: 31 local manifest gates green, affected contract tests 191/191, `git diff --check` clean.
- Real new git project completed `init → daemon register → daemon start → doctor`.
- A real `task complete` returned both the actor-conflict and missing-Review gates in one response, each with its next command.
- GitHub CI runs the full suite for the authoritative result.

## Review Evidence

- CEO semantic acceptance: verified `task-completion-requirements.ts` genuinely aggregates all unmet requirements (closeout / code-doc / CI / execution / review) each with an actionable next command — the direct fix for the "one hidden door at a time" pain. No overlap with the concurrently-landed F4 lease fix or XD-6 error gate. Item 3 correctly deferred. Passed.
- Blocking findings: none.

## Residual Risk

Item 3 (docs/chore lightweight profile) remains open, blocked on the concurrent preset-system rework; recorded as a finding on the task.

## References

- Charter: `dec_01KXGDXZG03JZRGTW8V91H11ER`
- Task: PLT-XD XD-4 (`task_01KXGFQYXY4H8EA3F2H7D6S0Q3`)

---

# 中文

## 概要

陌生仓库的 agent 装不上 harness、走不完第一个任务的一生。XD-4 修引导层（它的 blocker XD-1/XD-2/XD-3 已先合）：`ha init` 现在告诉你下一步，`ha --help` 让 daemon 可见，`task complete` 不再让你一道道撞门。

## 改动内容

- **item 1 — `ha init` 可执行**：JSON `nextSteps` 和文本回执现在直接给出 `repo register → daemon start → doctor`，不再让用户猜。（`init.ts`、`receipt.ts`）
- **item 2 — `task complete` 一次算出所有未满足门**：新增 `task-completion-requirements.ts`，把 closeout、code-doc、CI、Execution actor、Review 全部聚合成一个清单，每项带自己的下一步命令（`ha task code-doc reconcile …`、`ha task review-execution …`、`ha task complete --ci passed`）。不再撞一道暗门、修好、又发现下一道。（`task-completion-requirements.ts`、`task-lifecycle-orchestrator.ts`、`execution-completion-service.ts`）
- **item 4 — daemon 可发现**：顶层 `ha --help` 现在显示 `daemon`；`capabilities` 暴露 register/start/status/stop。（`daemon/help.ts`、`help.ts`、`capabilities.ts`）

## 范围说明

- **item 3（docs/chore 轻量 profile）降为 finding、本 PR 不实现**：正解须在 preset manifest 里声明轻量 profile，而 preset 系统正被并发返工。绕过权威 task-contract 快照删门会削弱执法，故不碰。已在任务上记 finding。
- 通用 hint 长度门归 XD-6，本 PR 不做。

## 任务与范围

PLT-XD XD-4，任务 `task_01KXGFQYXY4H8EA3F2H7D6S0Q3`。引导层可用性 + 完成要求聚合。不动 CI workflow、不删 required check、不碰分支保护。

## 版本影响

无。

## 治理声明

- 授权来源：宪章决策 `dec_01KXGDXZG03JZRGTW8V91H11ER`（体验设计：系统能自己推出来的不许要求调用方复述，拒绝性报错必须教下一步）与任务 `task_01KXGFQYXY4H8EA3F2H7D6S0Q3`（PLT-XD XD-4）。
- 触碰 protected surface：任务完成/生命周期编排（`task-lifecycle-orchestrator.ts`、`execution-completion-service.ts`）。改动为增量、纯可用性：聚合并解释既有门，不删除/削弱任何完成门。必需门集合不变——只是现在把它们**报全、报到可执行**。
- Break-glass：no。

## 验证

- `npm run check:local`：31 个本地 manifest 门全绿，affected contract 191/191，`git diff --check` 干净。
- 真实新 git 项目走通 `init → daemon register → daemon start → doctor`。
- 真实 `task complete` 一次返回 actor 冲突和缺 Review 两个门，各带下一步命令。
- GitHub CI 跑全套作权威结果。

## 审查证据

- CEO 语义验收：确认 `task-completion-requirements.ts` 真把所有未满足要求（closeout/code-doc/CI/execution/review）聚合、每条带可执行下一步——正是"一次一道暗门"痛点的直接修复。与并发合入的 F4 lease 修复、XD-6 错误门均无交集。item 3 正确延后。通过。
- 阻塞发现：无。

## 残余风险

item 3（docs/chore 轻量 profile）仍开放，卡在并发的 preset 系统返工上；已在任务上记 finding。

## 关联材料

- 宪章：`dec_01KXGDXZG03JZRGTW8V91H11ER`
- 任务：PLT-XD XD-4（`task_01KXGFQYXY4H8EA3F2H7D6S0Q3`）
