### PR TITLE
fix: bound local node test execution (XD-9 — no silent hang)

### DIFF
--- a/tools/node-test-runner-lib.mjs
+++ b/tools/node-test-runner-lib.mjs
@@ -4,6 +4,7 @@ import { DEFAULT_LOCAL_TEST_CONCURRENCY } from "./local-resource-governance.mjs"
 
 export const testFilePattern = /\.(test|spec)\.(?:mjs|js|ts)$/u;
 export const ignoredDirectoryNames = new Set(["node_modules", "dist", "out", "coverage", ".git"]);
+export const DEFAULT_TEST_TIMEOUT_MS = 180_000;
 
 export function parseRunnerArgs(args, tierNames) {
   const options = {
@@ -11,6 +12,7 @@ export function parseRunnerArgs(args, tierNames) {
     list: false,
     slowThresholdMs: 1000,
     slowLimit: 10,
+    testTimeoutMs: DEFAULT_TEST_TIMEOUT_MS,
     concurrency: undefined,
     shard: undefined,
     prefixes: []
@@ -53,6 +55,17 @@ export function parseRunnerArgs(args, tierNames) {
     }
     if (arg.startsWith("--slow-limit=")) {
       options.slowLimit = parsePositiveInteger(arg.slice("--slow-limit=".length), "--slow-limit");
+      continue;
+    }
+    if (arg === "--test-timeout") {
+      const value = args[index + 1];
+      if (value === undefined) throw new Error("--test-timeout requires a value");
+      options.testTimeoutMs = parseStrictPositiveInteger(value, "--test-timeout");
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--test-timeout=")) {
+      options.testTimeoutMs = parseStrictPositiveInteger(arg.slice("--test-timeout=".length), "--test-timeout");
       continue;
     }
     if (arg === "--concurrency") {
@@ -114,6 +127,12 @@ function parsePositiveInteger(value, label) {
   if (!Number.isInteger(parsed) || parsed < 0) {
     throw new Error(`${label} must be a non-negative integer`);
   }
+  return parsed;
+}
+
+function parseStrictPositiveInteger(value, label) {
+  const parsed = parsePositiveInteger(value, label);
+  if (parsed === 0) throw new Error(`${label} must be a positive integer`);
   return parsed;
 }
 
@@ -256,4 +275,35 @@ export function formatSlowTestSummary(slowTests, thresholdMs, limit) {
     `Slow test summary: top ${visible.length} tests at or above ${thresholdMs}ms`,
     ...visible.map((test, index) => `${index + 1}. ${test.durationMs.toFixed(3)}ms ${test.name}`)
   ].join("\n");
+}
+
+export function formatTestTimeoutGuidance(output, timeoutMs) {
+  const timedOutTests = collectTimedOutTestNames(output);
+  if (timedOutTests.length === 0) return null;
+
+  return [
+    "Timeout next steps:",
+    `Timed out ${timedOutTests.length === 1 ? "test" : "tests"}: ${timedOutTests.join(", ")}`,
+    "A daemon test may be blocked by another local daemon using its socket.",
+    "Inspect lingering daemon processes:",
+    "  ps -axo pid,ppid,etime,command | rg '[h]arness-anything.*daemon serve'",
+    "Re-run the timed-out file with an isolated daemon profile:",
+    `  env -u HARNESS_DAEMON_USER_ROOT HARNESS_DAEMON_PROFILE=isolated node --test --test-timeout=${timeoutMs} <test-file>`
+  ].join("\n");
+}
+
+function collectTimedOutTestNames(output) {
+  const lines = output.split(/\r?\n/u).map((line) => stripAnsi(line).trim());
+  const names = new Set();
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/test timed out after \d+ms/u.test(lines[index] ?? "")) continue;
+    for (let candidate = index - 1; candidate >= Math.max(0, index - 3); candidate -= 1) {
+      const match = lines[candidate]?.match(/^✖ (.+) \(\d+(?:\.\d+)?ms\)$/u);
+      if (match !== null && match !== undefined) {
+        names.add(match[1]);
+        break;
+      }
+    }
+  }
+  return [...names];
 }

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -4,7 +4,15 @@ import { spawn } from "node:child_process";
 import { resolve } from "node:path";
 import { selectIntegrationShardFiles } from "./integration-test-shards.mjs";
 import { discoverQosPrefix, prefixCommand, withLocalHeavySlot } from "./local-resource-governance.mjs";
-import { collectSlowTests, filterTestFilesByPrefixes, formatSlowTestSummary, parseRunnerArgs, resolveTestConcurrency, selectTestFiles } from "./node-test-runner-lib.mjs";
+import {
+  collectSlowTests,
+  filterTestFilesByPrefixes,
+  formatSlowTestSummary,
+  formatTestTimeoutGuidance,
+  parseRunnerArgs,
+  resolveTestConcurrency,
+  selectTestFiles
+} from "./node-test-runner-lib.mjs";
 import { discoverTestTierManifest, testTierNames } from "./test-tier-manifest.mjs";
 import { createHermeticTestEnvironment, gitFixtureIdentityGuidance } from "./test-process-environment.mjs";
 
@@ -75,10 +83,16 @@ const concurrency = resolveTestConcurrency({
 });
 const concurrencyArgs =
   concurrency && Number.isInteger(concurrency) && concurrency > 0 ? [`--test-concurrency=${concurrency}`] : [];
+const timeoutArgs = [`--test-timeout=${options.testTimeoutMs}`];
 
 process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}` }, async (lease) => {
   const qosPrefix = lease.inherited ? [] : discoverQosPrefix();
-  const invocation = prefixCommand(qosPrefix, process.execPath, ["--test", ...concurrencyArgs, ...selection.files]);
+  const invocation = prefixCommand(qosPrefix, process.execPath, [
+    "--test",
+    ...concurrencyArgs,
+    ...timeoutArgs,
+    ...selection.files
+  ]);
   const testEnvironment = createHermeticTestEnvironment(lease.childEnv);
   const child = spawn(invocation.command, invocation.args, {
     cwd: repoRoot,
@@ -112,6 +126,8 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
         return;
       }
       if (code !== 0) {
+        const timeoutGuidance = formatTestTimeoutGuidance(output, options.testTimeoutMs);
+        if (timeoutGuidance !== null) console.error(`\n${timeoutGuidance}`);
         const guidance = gitFixtureIdentityGuidance(output);
         if (guidance !== null) console.error(`\n${guidance}`);
       }

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import test from "node:test";
-import { collectSlowTests, filterTestFilesByPrefixes, formatSlowTestSummary, parseCompletedTestLine, parseRunnerArgs, resolveTestConcurrency, selectTestFiles, validateManifest } from "./node-test-runner-lib.mjs";
+import { collectSlowTests, DEFAULT_TEST_TIMEOUT_MS, filterTestFilesByPrefixes, formatSlowTestSummary, parseCompletedTestLine, parseRunnerArgs, resolveTestConcurrency, selectTestFiles, validateManifest } from "./node-test-runner-lib.mjs";
 import { deriveTestTierManifest, discoverTestTierManifest, parseTestTierMarker, testTierNames } from "./test-tier-manifest.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
@@ -14,6 +14,7 @@ test("parseRunnerArgs accepts tier and slow summary options", () => {
     list: false,
     slowThresholdMs: 250,
     slowLimit: 3,
+    testTimeoutMs: DEFAULT_TEST_TIMEOUT_MS,
     concurrency: undefined,
     shard: undefined,
     prefixes: []
@@ -24,6 +25,47 @@ test("parseRunnerArgs accepts a concurrency cap", () => {
   assert.equal(parseRunnerArgs(["--concurrency", "4"], testTierNames).concurrency, 4);
   assert.equal(parseRunnerArgs(["--concurrency=2"], testTierNames).concurrency, 2);
   assert.throws(() => parseRunnerArgs(["--concurrency", "x"], testTierNames), /--concurrency/u);
+});
+
+test("test timeout defaults to three minutes and cannot be disabled", () => {
+  assert.equal(DEFAULT_TEST_TIMEOUT_MS, 180_000);
+  assert.equal(parseRunnerArgs(["--test-timeout", "240000"], testTierNames).testTimeoutMs, 240_000);
+  assert.equal(parseRunnerArgs(["--test-timeout=360000"], testTierNames).testTimeoutMs, 360_000);
+  assert.throws(() => parseRunnerArgs(["--test-timeout", "0"], testTierNames), /positive integer/u);
+  assert.throws(() => parseRunnerArgs(["--test-timeout=x"], testTierNames), /--test-timeout/u);
+});
+
+test("runner bounds a non-terminating test and prints timeout next steps", () => {
+  const startedAt = Date.now();
+  const childEnv = {
+    ...process.env,
+    HARNESS_RUNNER_TIMEOUT_FIXTURE: "hang",
+    HARNESS_TEST_CONCURRENCY: "1"
+  };
+  delete childEnv.NODE_TEST_CONTEXT;
+  const result = spawnSync(process.execPath, [
+    "tools/run-node-tests.mjs",
+    "--tier", "fast",
+    "--prefix", "tools/test-fixtures/runner-timeout",
+    "--test-timeout", "1000"
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: childEnv,
+    timeout: 15_000
+  });
+  const elapsedMs = Date.now() - startedAt;
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.status, 1, output);
+  assert.equal(result.signal, null, output);
+  assert.equal(result.error, undefined, output);
+  assert.equal(elapsedMs < 10_000, true, `runner took ${elapsedMs}ms\n${output}`);
+  assert.match(output, /runner timeout fixture becomes intentionally non-terminating/u);
+  assert.match(output, /Timeout next steps:/u);
+  assert.match(output, /ps -axo pid,ppid,etime,command/u);
+  assert.match(output, /HARNESS_DAEMON_PROFILE=isolated/u);
+  assert.match(output, /--test-timeout=1000/u);
 });
 
 test("parseRunnerArgs accepts safe repository-relative test prefixes", () => {

--- a/tools/test-fixtures/runner-timeout/intentional-hang.test.mjs
+++ b/tools/test-fixtures/runner-timeout/intentional-hang.test.mjs
@@ -1,0 +1,7 @@
+// harness-test-tier: fast
+import test from "node:test";
+
+test("runner timeout fixture becomes intentionally non-terminating", async () => {
+  if (process.env.HARNESS_RUNNER_TIMEOUT_FIXTURE !== "hang") return;
+  await new Promise(() => {});
+});


### PR DESCRIPTION
# English

## Summary

A local gate could hang forever: the test runner ran with `--test-timeout=0`, so a stuck test never failed — it just kept running (one real session's `transport-integration` survived 70+ minutes). XD-9 makes the local test runner bound every test and teach the next step when one times out.

## What Changed

- **Runner always injects a bounded per-test timeout**: default `180000ms` (~3.3× the slowest measured local test, 54.76s), always passed to `node --test`. A positive-integer override is allowed; `--test-timeout=0` is **rejected** so unbounded mode cannot be restored. (`tools/node-test-runner-lib.mjs`, `tools/run-node-tests.mjs`)
- **Timeout teaches the next step**: on a timeout the runner parses the stuck test name and appends how to inspect lingering daemons (`ps … | rg 'daemon serve'`) and how to re-run the file in an isolated daemon profile. (`tools/node-test-runner-lib.mjs`)
- **Regression test proves the hang is now caught**: a fixture that `await new Promise(() => {})` (never resolves) is driven through the real runner with a `1000ms` timeout; it fails at ~1.003s and the runner returns exit 1 with the teach-path text. (`tools/run-node-tests.test.mjs`, `tools/test-fixtures/runner-timeout/intentional-hang.test.mjs`)

## Scope note

This is a **strengthening** change, not a loosening: the prior state (`--test-timeout=0`) was unbounded (the defect itself); this bounds it. The task's original target (`fence-durability.test.ts` hangs) did **not** reproduce (1.2s pass, no socket use) — ground-truth relocated the real defect to the runner level. The socket-isolation hypothesis was falsified (fence-durability creates no socket; daemon helpers already isolate per temp root) and is left as a finding.

## Task And Scope

PLT-XD XD-9, task `task_01KXH79PMRK415B5GJ0MRT91T6`. Test-runner robustness only. `gate-manifest` unchanged.

## Version Impact

None.

## Governance Declaration

- Authorized by: decision `dec_01KXJ0EYC9PV1NT7W8GDJ9XEBB` (accepted, standing policy: local gates must reach a definite verdict in bounded time; unbounded `--test-timeout=0` is a defect; the runner must provide a bounded per-test timeout and teach the next step on timeout) and task `task_01KXH79PMRK415B5GJ0MRT91T6` (PLT-XD XD-9). Charter `dec_01KXGDXZG03JZRGTW8V91H11ER` (a rejection/failure that does not teach the next step is a defect).
- Protected surface touched: the local test runner (`tools/run-node-tests.mjs`, `tools/node-test-runner-lib.mjs`). The change is strengthening — it replaces unbounded `0` with a bounded `180000ms` and rejects `0` — and adds a teach-path on timeout. No gate is weakened, skipped, or given `continue-on-error`; `gate-manifest` is unchanged.
- Break-glass: no.

## Verification

- `npm run check:local`: exit 0, 39.6s; 32 stop-point manifest gates green; affected fast 94/94; affected contract 184/184.
- TDD: RED (runner rejected unknown `--test-timeout`, 17 pass / 1 fail) → GREEN (intentional-hang fixture fails ~1.003s under a 1000ms timeout; runner returns exit 1); targeted 19/19.
- GitHub CI runs the full suite for the authoritative result.

## Review Evidence

- CEO semantic acceptance: verified the diff genuinely bounds and cannot be disabled (`parsed === 0` throws), the teach-path is emitted on timeout, and the regression test drives a real never-resolving fixture to a bounded failure. Faithful to `dec_01KXJ0EYC9PV1NT7W8GDJ9XEBB`. Passed.
- Blocking findings: none. One informational finding: another session's `transport-integration` 70-min survival could not be attributed to shared sockets (temp socket, ~0 CPU, stuck in `kevent`) — likely an env-related wait or post-completion handle leak; a file/process-level watchdog is noted as a possible future defense.

## Residual Risk

Per-test timeout may not cover a post-completion handle leak (the test passes but the process lingers); an outer file/process watchdog would close that gap and is left as a follow-up finding.

## References

- Decision: `dec_01KXJ0EYC9PV1NT7W8GDJ9XEBB`
- Charter: `dec_01KXGDXZG03JZRGTW8V91H11ER`
- Task: PLT-XD XD-9 (`task_01KXH79PMRK415B5GJ0MRT91T6`)

---

# 中文

## 概要

一个本地门可以永远挂死：测试 runner 跑在 `--test-timeout=0` 下，卡住的测试永不失败、只是一直跑（某个真实会话的 `transport-integration` 活了 70+ 分钟）。XD-9 让本地测试 runner 给每个测试加有界超时，并在超时时教下一步。

## 改动内容

- **runner 始终注入有界每测试超时**：默认 `180000ms`（约实测最慢本地测试 54.76s 的 3.3×），始终传给 `node --test`。允许正整数覆盖；`--test-timeout=0` 被**拒绝**，无法恢复无界模式。（`tools/node-test-runner-lib.mjs`、`tools/run-node-tests.mjs`）
- **超时教下一步**：超时时 runner 解析卡住的测试名，追加如何查残留 daemon（`ps … | rg 'daemon serve'`）和如何用隔离 daemon profile 重跑该文件。（`tools/node-test-runner-lib.mjs`）
- **回归测试证明挂死现在被拦**：一个 `await new Promise(() => {})`（永不 resolve）的 fixture 经真实 runner 以 `1000ms` 超时驱动，约 1.003s 失败、runner 返回 exit 1 并带教路文案。（`tools/run-node-tests.test.mjs`、`tools/test-fixtures/runner-timeout/intentional-hang.test.mjs`）

## 范围说明

这是**加严**不是放松：原状态 `--test-timeout=0` 是无界（缺陷本身），现在给它加界。任务原定目标（`fence-durability.test.ts` 挂死）**未复现**（1.2s 通过、不建 socket）——ground-truth 把真正缺陷重定位到 runner 级。socket 隔离假说被证伪（fence-durability 不建 socket；daemon helper 已按临时 root 隔离），记为 finding。

## 任务与范围

PLT-XD XD-9，任务 `task_01KXH79PMRK415B5GJ0MRT91T6`。仅测试 runner 健壮性。`gate-manifest` 不改。

## 版本影响

无。

## 治理声明

- 授权来源：决策 `dec_01KXJ0EYC9PV1NT7W8GDJ9XEBB`（accepted，standing policy：本地门必须在有限时间内得出确定结论；无界 `--test-timeout=0` 是缺陷；runner 须提供有界每测试超时且超时须教下一步）与任务 `task_01KXH79PMRK415B5GJ0MRT91T6`（PLT-XD XD-9）。宪章 `dec_01KXGDXZG03JZRGTW8V91H11ER`（拒绝/失败不教下一步即缺陷）。
- 触碰 protected surface：本地测试 runner（`tools/run-node-tests.mjs`、`tools/node-test-runner-lib.mjs`）。改动为加严——把无界 `0` 换成有界 `180000ms` 并拒绝 `0`——并在超时时加教路。不削弱/跳过任何门、不加 `continue-on-error`；`gate-manifest` 不变。
- Break-glass：no。

## 验证

- `npm run check:local`：exit 0，39.6s；32 个 stop-point manifest 门全绿；affected fast 94/94；affected contract 184/184。
- TDD：RED（runner 拒绝未知 `--test-timeout`，17 pass / 1 fail）→ GREEN（故意挂死 fixture 在 1000ms 超时下约 1.003s 失败；runner 返回 exit 1）；定向 19/19。
- GitHub CI 跑全套作权威结果。

## 审查证据

- CEO 语义验收：确认 diff 真的加界且无法禁用（`parsed === 0` throw）、超时时吐教路、回归测试用真实永不 resolve 的 fixture 驱动到有界失败。忠于 `dec_01KXJ0EYC9PV1NT7W8GDJ9XEBB`。通过。
- 阻塞发现：无。一条信息 finding：另一会话 `transport-integration` 70 分钟存活无法归因于共享 socket（临时 socket、~0 CPU、停在 `kevent`）——更像环境相关等待或测试完成后 handle 泄漏；file/process 级 watchdog 记为可能的后续防线。

## 残余风险

每测试超时未必覆盖"测试完成后 handle 泄漏"（测试通过但进程滞留）；外层 file/process watchdog 可补这个缺口，记为后续 finding。

## 关联材料

- 决策：`dec_01KXJ0EYC9PV1NT7W8GDJ9XEBB`
- 宪章：`dec_01KXGDXZG03JZRGTW8V91H11ER`
- 任务：PLT-XD XD-9（`task_01KXH79PMRK415B5GJ0MRT91T6`）
