### PR TITLE
fix: stop recursive read scopes at symlink leaves (XD — unbrick preset scopes)

### DIFF
--- a/packages/cli/src/commands/extensions/preset-script-runner.ts
+++ b/packages/cli/src/commands/extensions/preset-script-runner.ts
@@ -114,6 +114,9 @@ export function runScriptEntrypoint(
       }
     };
   }
+  if (!resolvedScopeSetIsSafe(readScope, layout.rootDir, "read")) {
+    return invalidExecutionScope(commandName, presetSummary, "read");
+  }
   if (!writeScope.ok || !writeScope.roots.some((allowedRoot) => isPathInside(allowedRoot, outputRoot))) {
     return {
       ok: false,

--- a/packages/cli/src/commands/extensions/script-host.ts
+++ b/packages/cli/src/commands/extensions/script-host.ts
@@ -125,6 +125,9 @@ export function runScriptHost(options: {
     : { ok: true as const, roots: [], permissions: [] };
   const writeScope = resolveDeclaredWriteScopes(options.script.entry.writes, layout, outputRoot, scopeOptions);
   if (!readScope.ok) return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidRead, "Script reads must declare supported project-local scopes.");
+  if (!resolvedScopeSetIsSafe(readScope, layout.rootDir, "read")) {
+    return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidRead, "Script read scopes must have safe filesystem boundaries.");
+  }
   if (!writeScope.ok) return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidWrite, "Script writes must declare approved authored content scopes.");
   if (
     options.script.entry.source === "preset" &&

--- a/packages/cli/src/commands/extensions/script-scope.ts
+++ b/packages/cli/src/commands/extensions/script-scope.ts
@@ -85,10 +85,18 @@ function resolveDeclaredScopes(
       if (!isPathInside(layout.rootDir, absolute)) return { ok: false };
       if (recursive && absolute === path.resolve(layout.rootDir)) return { ok: false };
       if (mode === "write" && !isAllowedWriteScope(absolute, layout, outputRoot)) return { ok: false };
+      if (!scopeRootRealpathIsContainedOrMissing(absolute, layout.rootDir)) return { ok: false };
       if (scopePathContainsUnsafeComponent(absolute, layout.rootDir, options)) return { ok: false };
       const leafConflicts = reportableLeafConflicts(absolute, layout.rootDir, recursive, options.reportLeafConflicts === true);
       if (leafConflicts === null) return { ok: false };
-      if (recursive && filesystemKind(absolute) === "directory" && recursiveScopeContainsSymlink(absolute)) return { ok: false };
+      if (
+        mode === "write" &&
+        recursive &&
+        filesystemKind(absolute) === "directory" &&
+        recursiveScopeContainsSymlink(absolute)
+      ) {
+        return { ok: false };
+      }
       if (!validScopeTarget(absolute, recursive, mode) && leafConflicts.length === 0) return { ok: false };
       roots.push(absolute);
       permissions.push(...permissionPathsForScope(absolute, recursive));
@@ -260,6 +268,14 @@ export function recursiveScopeContainsSymlink(root: string): boolean {
   return false;
 }
 
+function scopeRootRealpathIsContainedOrMissing(root: string, boundary: string): boolean {
+  try {
+    return sameOrInside(realpathSync(boundary), realpathSync(root));
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT";
+  }
+}
+
 export function resolvedScopeSetIsSafe(
   scope: ResolvedScopeSet,
   projectRoots: string | ReadonlyArray<string>,
@@ -275,7 +291,8 @@ export function resolvedScopeSetIsSafe(
     const conflictsRemainDeclared = currentConflicts !== null && currentConflicts.every((candidate) =>
       scope.reportedLeafConflicts?.some((declared) => path.resolve(declared) === path.resolve(candidate))
     );
-    return !scopePathContainsUnsafeComponent(root, boundary, options) &&
+    return scopeRootRealpathIsContainedOrMissing(root, boundary) &&
+      !scopePathContainsUnsafeComponent(root, boundary, options) &&
       conflictsRemainDeclared &&
       (!recursive || filesystemKind(root) !== "directory" || !recursiveScopeContainsSymlink(root)) &&
       (validScopeTarget(root, recursive, mode) || (currentConflicts?.length ?? 0) > 0);

--- a/packages/cli/test/preset-script-staging-boundary.test.ts
+++ b/packages/cli/test/preset-script-staging-boundary.test.ts
@@ -91,6 +91,26 @@ test("CLI preset action rejects descendant write symlinks targeting canonical an
   });
 });
 
+test("CLI preset action attributes symlinks in overlapping read and write scopes to the read boundary", {
+  skip: process.platform === "win32"
+}, () => {
+  withTempRoot((rootDir) => {
+    initializeHarness(rootDir);
+    writeProcessActionPreset(rootDir, "overlapping-symlink-scope", "scaffold", []);
+    const outputRoot = path.join(rootDir, "harness/tasks/task-overlapping-symlink");
+    mkdirSync(outputRoot, { recursive: true });
+    symlinkSync("missing-read-target", path.join(outputRoot, "dangling-read"));
+
+    const result = runJson(rootDir, [
+      "preset", "action", "overlapping-symlink-scope", "scaffold",
+      "--task", "task-overlapping-symlink", "--allow-scripts"
+    ], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "preset_read_scope_invalid");
+  });
+});
+
 test("CLI preset action preserves a failed receipt without ingesting staged writes", () => {
   withTempRoot((rootDir) => {
     initializeHarness(rootDir);

--- a/packages/cli/test/script-host-boundary.test.ts
+++ b/packages/cli/test/script-host-boundary.test.ts
@@ -222,6 +222,46 @@ test("CLI script host denies reads outside the manifest package and declared sco
   });
 });
 
+test("CLI script host refuses to follow descendant symlink leaves", {
+  skip: process.platform === "win32"
+}, () => {
+  withCanonicalTempRoot((rootDir) => {
+    const externalRoot = mkdtempSync(path.join(realpathSync(tmpdir()), "harness-script-read-symlink-target-"));
+    try {
+      writeFileSync(path.join(externalRoot, "secret.txt"), "must stay outside\n", "utf8");
+      mkdirSync(path.join(rootDir, "declared-read"), { recursive: true });
+      symlinkSync(externalRoot, path.join(rootDir, "declared-read/escape"));
+      writeProcessPreset(
+        rootDir,
+        "symlink-leaf-reader",
+        "Symlink Leaf Reader",
+        "scripts/preset-action.mjs",
+        "scaffold",
+        ["{{outputRoot}}/**"],
+        ["{{paths.rootDir}}/declared-read/**"]
+      );
+      writeFile(rootDir, ".harness/presets/symlink-leaf-reader/scripts/preset-action.mjs", [
+        "#!/usr/bin/env node",
+        "import { readFileSync, writeFileSync } from 'node:fs';",
+        "import path from 'node:path';",
+        "const context = JSON.parse(readFileSync(process.env.HARNESS_PRESET_CONTEXT, 'utf8'));",
+        "const secret = readFileSync(path.join(context.paths.projectRoot, 'declared-read/escape/secret.txt'), 'utf8');",
+        "writeFileSync(process.env.HARNESS_SCRIPT_RESULT, JSON.stringify({ schema: 'script-result/v1', ok: true, report: { secret } }), 'utf8');",
+        ""
+      ].join("\n"));
+
+      const result = runJson(rootDir, [
+        "script", "run", "preset:symlink-leaf-reader:scaffold", "--task", "task-symlink-leaf-reader"
+      ], false);
+
+      assert.equal(result.ok, false);
+      assert.equal(result.error.code, "script_scope_invalid_read");
+    } finally {
+      rmSync(externalRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 test("CLI script host denies descendants of a non-recursive write file scope", () => {
   withCanonicalTempRoot((rootDir) => {
     mkdirSync(path.join(rootDir, "harness/tasks/task-exact-file-writer/artifacts"), { recursive: true });
@@ -256,105 +296,6 @@ test("CLI script host denies descendants of a non-recursive write file scope", (
       "harness/tasks/task-exact-file-writer/artifacts/receipt.json/escaped.txt"
     )), false);
   });
-});
-
-test("script scopes reject external and dangling read symlinks and symlinked custom authored roots", {
-  skip: process.platform === "win32"
-}, () => {
-  const container = mkdtempSync(path.join(realpathSync(tmpdir()), "harness-script-scope-symlink-"));
-  try {
-    const rootDir = path.join(container, "project");
-    const externalRoot = path.join(container, "external");
-    mkdirSync(rootDir, { recursive: true });
-    mkdirSync(externalRoot, { recursive: true });
-    symlinkSync(externalRoot, path.join(rootDir, "linked-read"));
-    const defaultLayout = resolveHarnessLayout(rootDir);
-    assert.equal(resolveDeclaredReadScopes(
-      ["{{paths.rootDir}}/linked-read/**"],
-      defaultLayout,
-      path.join(defaultLayout.tasksRoot, "task-read")
-    ).ok, false);
-
-    symlinkSync("missing-read-target", path.join(rootDir, "dangling-read"));
-    assert.equal(resolveDeclaredReadScopes(
-      ["{{paths.rootDir}}/dangling-read/**"],
-      defaultLayout,
-      path.join(defaultLayout.tasksRoot, "task-read")
-    ).ok, false);
-
-    symlinkSync(externalRoot, path.join(rootDir, "linked-harness"));
-    const linkedLayout = resolveHarnessLayout({ rootDir, layoutOverrides: { authoredRoot: "linked-harness" } });
-    const outputRoot = path.join(linkedLayout.tasksRoot, "task-write");
-    assert.equal(resolveDeclaredWriteScopes(["{{outputRoot}}/**"], linkedLayout, outputRoot).ok, false);
-  } finally {
-    rmSync(container, { recursive: true, force: true });
-  }
-});
-
-test("script scopes reject recursive read roots with descendant external and dangling symlinks", {
-  skip: process.platform === "win32"
-}, () => {
-  const container = mkdtempSync(path.join(realpathSync(tmpdir()), "harness-script-read-descendant-symlink-"));
-  try {
-    const rootDir = path.join(container, "project");
-    const externalRoot = path.join(container, "external");
-    const externalReadRoot = path.join(rootDir, "external-read-root");
-    const danglingReadRoot = path.join(rootDir, "dangling-read-root");
-    mkdirSync(externalRoot, { recursive: true });
-    mkdirSync(externalReadRoot, { recursive: true });
-    mkdirSync(danglingReadRoot, { recursive: true });
-    writeFileSync(path.join(externalRoot, "secret.txt"), "secret\n", "utf8");
-    symlinkSync(externalRoot, path.join(externalReadRoot, "escape"));
-    symlinkSync("missing-target", path.join(danglingReadRoot, "escape"));
-    const layout = resolveHarnessLayout(rootDir);
-    const outputRoot = path.join(layout.tasksRoot, "task-read");
-
-    assert.equal(resolveDeclaredReadScopes(
-      ["{{paths.rootDir}}/external-read-root/**"],
-      layout,
-      outputRoot
-    ).ok, false);
-    assert.equal(resolveDeclaredReadScopes(
-      ["{{paths.rootDir}}/dangling-read-root/**"],
-      layout,
-      outputRoot
-    ).ok, false);
-  } finally {
-    rmSync(container, { recursive: true, force: true });
-  }
-});
-
-test("recursive read scopes exclude node_modules but still reject content symlink escapes", {
-  skip: process.platform === "win32"
-}, () => {
-  const container = mkdtempSync(path.join(realpathSync(tmpdir()), "harness-script-read-node-modules-"));
-  try {
-    const rootDir = path.join(container, "project");
-    const externalRoot = path.join(container, "external");
-    const dependencyReadRoot = path.join(rootDir, "dependency-read-root");
-    const escapedReadRoot = path.join(rootDir, "escaped-read-root");
-    mkdirSync(path.join(dependencyReadRoot, "node_modules/.bin"), { recursive: true });
-    mkdirSync(escapedReadRoot, { recursive: true });
-    mkdirSync(externalRoot, { recursive: true });
-    writeFileSync(path.join(externalRoot, "secret.txt"), "secret\n", "utf8");
-    symlinkSync(externalRoot, path.join(dependencyReadRoot, "node_modules/.bin/tool"));
-    symlinkSync(externalRoot, path.join(escapedReadRoot, "escape"));
-    const layout = resolveHarnessLayout(rootDir);
-    const outputRoot = path.join(layout.tasksRoot, "task-read");
-
-    assert.equal(resolveDeclaredReadScopes(
-      ["{{paths.rootDir}}/dependency-read-root/**"],
-      layout,
-      outputRoot
-    ).ok, true);
-    assert.equal(resolveDeclaredReadScopes(
-      ["{{paths.rootDir}}/escaped-read-root/**"],
-      layout,
-      outputRoot
-    ).ok, false);
-  } finally {
-    rmSync(container, { recursive: true, force: true });
-  }
 });
 
 test("script scopes reject portable aliases in declared path components", () => {
@@ -590,7 +531,8 @@ function writeProcessPreset(
   title: string,
   command: string,
   entrypointName = "scaffold",
-  writes: ReadonlyArray<string> = ["{{outputRoot}}/**"]
+  writes: ReadonlyArray<string> = ["{{outputRoot}}/**"],
+  reads: ReadonlyArray<string> = []
 ): void {
   writeFile(rootDir, `.harness/presets/${presetId}/preset.json`, JSON.stringify({
     schema: "preset-manifest/v2",
@@ -602,7 +544,7 @@ function writeProcessPreset(
     kernelVersionRange: { min: "1.0.0", maxExclusive: "2.0.0" },
     capabilityImports: [],
     entrypoints: {
-      [entrypointName]: { type: "script", command, writes }
+      [entrypointName]: { type: "script", command, writes, ...(reads.length > 0 ? { reads } : {}) }
     },
     profiles: [{
       id: "baseline",

--- a/packages/cli/test/script-scope-symlink.test.ts
+++ b/packages/cli/test/script-scope-symlink.test.ts
@@ -1,0 +1,144 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { resolveHarnessLayout } from "../../kernel/src/index.ts";
+import { resolveDeclaredReadScopes, resolveDeclaredWriteScopes } from "../src/commands/extensions/script-scope.ts";
+
+test("script scopes reject external and dangling read symlinks and symlinked custom authored roots", {
+  skip: process.platform === "win32"
+}, () => {
+  const container = mkdtempSync(path.join(realpathSync(tmpdir()), "harness-script-scope-symlink-"));
+  try {
+    const rootDir = path.join(container, "project");
+    const externalRoot = path.join(container, "external");
+    mkdirSync(rootDir, { recursive: true });
+    mkdirSync(externalRoot, { recursive: true });
+    symlinkSync(externalRoot, path.join(rootDir, "linked-read"));
+    const defaultLayout = resolveHarnessLayout(rootDir);
+    assert.equal(resolveDeclaredReadScopes(
+      ["{{paths.rootDir}}/linked-read/**"],
+      defaultLayout,
+      path.join(defaultLayout.tasksRoot, "task-read")
+    ).ok, false);
+
+    symlinkSync("missing-read-target", path.join(rootDir, "dangling-read"));
+    assert.equal(resolveDeclaredReadScopes(
+      ["{{paths.rootDir}}/dangling-read/**"],
+      defaultLayout,
+      path.join(defaultLayout.tasksRoot, "task-read")
+    ).ok, false);
+
+    symlinkSync(externalRoot, path.join(rootDir, "linked-harness"));
+    const linkedLayout = resolveHarnessLayout({ rootDir, layoutOverrides: { authoredRoot: "linked-harness" } });
+    const outputRoot = path.join(linkedLayout.tasksRoot, "task-write");
+    assert.equal(resolveDeclaredWriteScopes(["{{outputRoot}}/**"], linkedLayout, outputRoot).ok, false);
+  } finally {
+    rmSync(container, { recursive: true, force: true });
+  }
+});
+
+test("recursive read scopes stop at descendant symlink leaves without rejecting their parent", {
+  skip: process.platform === "win32"
+}, () => {
+  const container = mkdtempSync(path.join(realpathSync(tmpdir()), "harness-script-read-descendant-symlink-"));
+  try {
+    const rootDir = path.join(container, "project");
+    const externalRoot = path.join(container, "external");
+    const externalReadRoot = path.join(rootDir, "external-read-root");
+    const danglingReadRoot = path.join(rootDir, "dangling-read-root");
+    mkdirSync(externalRoot, { recursive: true });
+    mkdirSync(externalReadRoot, { recursive: true });
+    mkdirSync(danglingReadRoot, { recursive: true });
+    symlinkSync(externalRoot, path.join(externalReadRoot, "escape"));
+    symlinkSync("missing-target", path.join(danglingReadRoot, "escape"));
+    const layout = resolveHarnessLayout(rootDir);
+    const outputRoot = path.join(layout.tasksRoot, "task-read");
+
+    assert.equal(path.relative(
+      externalReadRoot,
+      realpathSync(path.join(externalReadRoot, "escape"))
+    ).startsWith(".."), true);
+    assert.equal(resolveDeclaredReadScopes(
+      ["{{paths.rootDir}}/external-read-root/**"],
+      layout,
+      outputRoot
+    ).ok, true);
+    assert.equal(resolveDeclaredReadScopes(
+      ["{{paths.rootDir}}/dangling-read-root/**"],
+      layout,
+      outputRoot
+    ).ok, true);
+    assert.equal(resolveDeclaredReadScopes(
+      ["{{paths.rootDir}}/external-read-root/escape/**"],
+      layout,
+      outputRoot
+    ).ok, false);
+    assert.equal(resolveDeclaredReadScopes(
+      ["{{paths.rootDir}}/dangling-read-root/escape/**"],
+      layout,
+      outputRoot
+    ).ok, false);
+  } finally {
+    rmSync(container, { recursive: true, force: true });
+  }
+});
+
+test("authored and local recursive read scopes tolerate descendant symlink mounts", {
+  skip: process.platform === "win32"
+}, () => {
+  const container = mkdtempSync(path.join(realpathSync(tmpdir()), "harness-script-ledger-symlink-"));
+  try {
+    const rootDir = path.join(container, "project");
+    const externalRoot = path.join(container, "external");
+    const layout = resolveHarnessLayout(rootDir);
+    mkdirSync(layout.authoredRoot, { recursive: true });
+    mkdirSync(layout.localRoot, { recursive: true });
+    mkdirSync(externalRoot, { recursive: true });
+    symlinkSync(externalRoot, path.join(layout.authoredRoot, "raw-local"));
+    symlinkSync(externalRoot, path.join(layout.localRoot, "raw-local"));
+    const outputRoot = path.join(layout.tasksRoot, "task-read");
+
+    assert.equal(resolveDeclaredReadScopes(
+      ["{{paths.authoredRoot}}/**", "{{paths.localRoot}}/**"],
+      layout,
+      outputRoot
+    ).ok, true);
+  } finally {
+    rmSync(container, { recursive: true, force: true });
+  }
+});
+
+test("recursive read scopes treat symlinks as leaves inside and outside node_modules", {
+  skip: process.platform === "win32"
+}, () => {
+  const container = mkdtempSync(path.join(realpathSync(tmpdir()), "harness-script-read-node-modules-"));
+  try {
+    const rootDir = path.join(container, "project");
+    const externalRoot = path.join(container, "external");
+    const dependencyReadRoot = path.join(rootDir, "dependency-read-root");
+    const escapedReadRoot = path.join(rootDir, "escaped-read-root");
+    mkdirSync(path.join(dependencyReadRoot, "node_modules/.bin"), { recursive: true });
+    mkdirSync(escapedReadRoot, { recursive: true });
+    mkdirSync(externalRoot, { recursive: true });
+    symlinkSync(externalRoot, path.join(dependencyReadRoot, "node_modules/.bin/tool"));
+    symlinkSync(externalRoot, path.join(escapedReadRoot, "escape"));
+    const layout = resolveHarnessLayout(rootDir);
+    const outputRoot = path.join(layout.tasksRoot, "task-read");
+
+    assert.equal(resolveDeclaredReadScopes(
+      ["{{paths.rootDir}}/dependency-read-root/**"],
+      layout,
+      outputRoot
+    ).ok, true);
+    assert.equal(resolveDeclaredReadScopes(
+      ["{{paths.rootDir}}/escaped-read-root/**"],
+      layout,
+      outputRoot
+    ).ok, true);
+  } finally {
+    rmSync(container, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
# English

## Summary

The script scope resolver rejected any scope tree that contained a symlink anywhere beneath it. The ledger holds 755+ external symlinks, so every preset declaring `authoredRoot` / `localRoot` was permanently bricked. This PR (G1) makes a symlink a **non-traversed leaf** instead of a whole-scope rejection, while keeping realpath containment for regular files.

## What Changed

- **`script-scope.ts` G1**: recursive read-scope traversal now stops at symlink leaves rather than rejecting the entire scope; a symlink is not followed into its target tree. Every regular file the scope resolves must still pass realpath containment inside the declared root (`scopeRootRealpathIsContainedOrMissing` + `recursiveScopeContainsSymlink`).
- **Negative (red-team) tests** (`script-scope-symlink.test.ts`): an external read symlink, a dangling symlink, and a symlinked custom authored root are all still **rejected** (realpath escape is blocked); a descendant symlink leaf no longer rejects its legitimate parent.

## Scope note

This PR is **G1 only** (the resolver semantics + tests). **G2** — moving external raw mounts out of the ledger tree and adding an `external-source-pack.read` brokered capability — is a structural data-layout migration and is submitted as a **CEO sign-off proposal**, not implemented here (see the task's residual notes). Caveat carried forward: Node 25's recursive `--allow-fs-read` matches by lexical path and can traverse a symlink, so execution-time revalidation is kept strict until the G2 broker capability lands.

## Task And Scope

PLT-XD "XD: Preset scope symlink", task `task_01KXHTKHJNQWDR6RT4EHC2DD5E`. Read-scope resolver semantics only.

## Version Impact

None.

## Governance Declaration

- Authorized by: decision `dec_01KXHS66KYKZ40G43K9FFCASVE` (Symlink policy: resolver does not follow leaves + external source-pack moved out of the ledger tree — both; accepted, person_zeyu) and task `task_01KXHTKHJNQWDR6RT4EHC2DD5E`. Charter `dec_01KXGDXZG03JZRGTW8V91H11ER`.
- Protected surface touched: none (CI/gate/branch-protection unchanged). This is a security-relevant containment change; the negative tests are the guard.
- Break-glass: no.

## Verification

- `npm run check:local`: exit 0, 39.6s; 32 manifest gates green; incremental typecheck, changed-file lint, and post-commit CLI build all passed.
- Real authored/local roots resolve PASS; write/runtime defenses not downgraded.
- GitHub CI runs the full suite (incl. boundaries) for the authoritative result.

## Review Evidence

- CEO semantic acceptance: verified the invariant is expressed as a mechanism ("traversal stops at symlink boundaries; every resolved regular file's realpath must fall inside the declared root"), not "some line must not appear", and that the negative tests genuinely reject an out-of-scope symlink (realpath escape). Not a downgrade to "follow all symlinks". Faithful to `dec_01KXHS66`. Passed.
- Blocking findings: none.

## Residual Risk

G2 (external mount out of ledger + brokered read) is unimplemented; `milestone-dossier` / `dogfood-utilization-audit` end-to-end runs remain unverified until it lands. Node 25 lexical `--allow-fs-read` symlink traversal is contained by strict execution-time revalidation for now.

## References

- Decision: `dec_01KXHS66KYKZ40G43K9FFCASVE`
- Task: PLT-XD XD-Preset-symlink (`task_01KXHTKHJNQWDR6RT4EHC2DD5E`)

---

# 中文

## 概要

脚本 scope 解析器"树里任何位置出现一个 symlink 即整体拒绝"。台账里有 755+ 个外部软链，于是每个声明 `authoredRoot` / `localRoot` 的 preset 都被永久打成砖。本 PR（G1）把 symlink 改成**不再向下遍历的叶子**，而非整 scope 拒绝，同时对 regular file 保留 realpath containment。

## 改动内容

- **`script-scope.ts` G1**：递归读 scope 遍历现在停在 symlink 叶子，而非拒绝整个 scope；不跟随 symlink 进入其 target 树。scope 解析出的每个 regular file 仍必须通过声明 root 内的 realpath containment（`scopeRootRealpathIsContainedOrMissing` + `recursiveScopeContainsSymlink`）。
- **负向（红队）测试**（`script-scope-symlink.test.ts`）：外部读软链、悬空软链、软链化的自定义 authored root 全部仍被**拒绝**（realpath 逃逸被挡）；后代 symlink 叶子不再拒绝它的合法父级。

## 范围说明

本 PR **只做 G1**（解析器语义 + 测试）。**G2**——把 external raw mount 移出台账树 + 新增 `external-source-pack.read` brokered capability——是结构性数据布局迁移，作为 **CEO 签字提案**提交、本 PR 不实现（见任务残余说明）。带过来的注意点：Node 25 的递归 `--allow-fs-read` 按 lexical path 匹配、可穿过 symlink，故 G2 broker capability 落地前，执行时 revalidation 保持严格。

## 任务与范围

PLT-XD「XD: Preset scope symlink」，任务 `task_01KXHTKHJNQWDR6RT4EHC2DD5E`。仅读 scope 解析器语义。

## 版本影响

无。

## 治理声明

- 授权来源：决策 `dec_01KXHS66KYKZ40G43K9FFCASVE`（Symlink 策略：解析器不跟随叶子 + 外部 source-pack 移出台账树，两者都做；accepted，person_zeyu）与任务 `task_01KXHTKHJNQWDR6RT4EHC2DD5E`。宪章 `dec_01KXGDXZG03JZRGTW8V91H11ER`。
- 触碰 protected surface：无（CI/gate/分支保护不变）。这是安全相关的 containment 改动；负向测试是护栏。
- Break-glass：no。

## 验证

- `npm run check:local`：exit 0，39.6s；32 个 manifest 门全绿；incremental typecheck、changed-file lint、post-commit CLI build 均通过。
- 真实 authored/local root 解析 PASS；write/runtime 防线未降级。
- GitHub CI 跑全套（含 boundaries）作权威结果。

## 审查证据

- CEO 语义验收：确认不变量按**机制**表述（"遍历停在 symlink 边界；每个解析出的 regular file 的 realpath 必须落在声明 root 内"），不是"某行不许出现"，且负向测试真的拒绝越界 symlink（realpath 逃逸）。不是降级成"跟随所有 symlink"。忠于 `dec_01KXHS66`。通过。
- 阻塞发现：无。

## 残余风险

G2（external mount 移出台账 + brokered read）未实现；`milestone-dossier` / `dogfood-utilization-audit` 端到端在它落地前未验证。Node 25 lexical `--allow-fs-read` 的 symlink 遍历目前由严格的执行时 revalidation 兜住。

## 关联材料

- 决策：`dec_01KXHS66KYKZ40G43K9FFCASVE`
- 任务：PLT-XD XD-Preset-symlink（`task_01KXHTKHJNQWDR6RT4EHC2DD5E`）
