### PR TITLE
feat: add docs-task lightweight completion profile

### DIFF
--- a/packages/cli/src/commands/extensions/assets/software-coding/extension-contract.lock.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/extension-contract.lock.json
@@ -7,6 +7,7 @@
   },
   "presets": [
     { "id": "standard-task", "version": "1.0.0", "digest": "sha256:97ce758ed5f197b4b18effdd65a5e26642b7b767a33fdaa7b4d32c07a401c164" },
+    { "id": "docs-task", "version": "1.0.0", "digest": "sha256:84f6172941ee20ce9d4ba5454d92c9dcfe33a78895999ed344547d95584b7c6c" },
     { "id": "reference-task", "version": "1.0.0", "digest": "sha256:910b58f13ae5ef59c041776825d5a105466e214b0d419cca1e9117d819a3bf7e" },
     { "id": "long-running-task", "version": "1.0.0", "digest": "sha256:e5b341575b584658d87640b481ec42cf4ecd8d1a1bce1775126c1d38c4f908b8" },
     { "id": "module", "version": "1.0.0", "digest": "sha256:c884944f52d575c7fc8ee38233d023f4c7f9d9c001c138013fd3886961cbbc99" },

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/docs-task/PRESET.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/docs-task/PRESET.md
@@ -1,0 +1,11 @@
+---
+schema: preset-document/v1
+description: Create the planning, progress, review, evidence, and closeout package for design, documentation, or chore work that produces no code commit.
+whenToUse: Use for pure design, documentation, research, or chore tasks whose deliverable is a document or decision rather than code, so completion is gated on a real closeout and an approved review instead of CI or code-doc reconciliation.
+---
+
+# Documentation / Design Task
+
+A lightweight software-coding preset for work whose deliverable is a design, document, or chore rather than a code change.
+
+It carries the same substantive completion requirements as any task — a real closeout and an approved typed Review — but omits the `ci` and `code-doc-reconciliation` completion gates, which assume a code commit that design and documentation work does not produce.

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/docs-task/preset.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/docs-task/preset.json
@@ -1,0 +1,18 @@
+{
+  "schema": "preset-manifest/v2",
+  "id": "docs-task",
+  "title": "Documentation / Design Task",
+  "vertical": "software/coding",
+  "version": "1.0.0",
+  "kind": "template-content",
+  "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
+  "capabilityImports": [{ "id": "standard-task-check", "kind": "checker", "version": "1", "required": false }],
+  "profiles": [{
+    "id": "baseline",
+    "title": "Baseline",
+    "checkerProfile": "standard",
+    "completionGates": [],
+    "templateSelections": []
+  }],
+  "defaultProfile": "baseline"
+}

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/index.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/index.json
@@ -1,6 +1,7 @@
 {
   "presets": [
     "standard-task",
+    "docs-task",
     "reference-task",
     "long-running-task",
     "module",

--- a/packages/cli/test/package-surface.test.ts
+++ b/packages/cli/test/package-surface.test.ts
@@ -92,6 +92,7 @@ test("bundled software coding assets have consistent template and process-preset
   const selectedMaterializedPaths = new Set<string>();
   const bundledPresetIds = [
     "standard-task",
+    "docs-task",
     "reference-task",
     "long-running-task",
     "module",


### PR DESCRIPTION
# English

## Summary

Adds a `docs-task` lightweight completion profile for design, documentation, and chore work whose deliverable is a document or decision rather than code. Its completion gates omit `ci` and `code-doc-reconciliation` (which assume a code commit), while keeping the substantive gates every task has: a real closeout and an approved typed Review.

## What Changed

- New bundled preset `docs-task` (`preset.json` + `PRESET.md`), single `baseline` profile with `completionGates: []`, no entrypoints.
- Registered in `presets/index.json` (after `standard-task`), `extension-contract.lock.json` (id/version/digest), and the `package-surface` public-distribution allowlist.

## Task And Scope

- Harness task: docs/chore lightweight profile (XD-4 item 3); closes the gap where a pure design/doc task pinned to a coding profile cannot honestly complete (`code_doc_anchors_missing` demands a code commit it never produces).
- Branch: `wip/docs-task-profile`
- Public scope: `packages/cli/.../assets/software-coding/presets/**`, `extension-contract.lock.json`, `package-surface.test.ts`
- Out of scope: retrofitting existing immutable task contracts (a task's profile is frozen at creation; this profile serves tasks created with it going forward).

## Version Impact

- Version: no CLI version change; new preset pinned at `1.0.0`.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: yes (`extension-contract.lock.json` — bundled preset distribution manifest)
- Authority: task_01KXJA4E5K89Y3WZ72J841X770 (docs/chore lightweight profile, XD-4 item 3), dec_01KXGDXZG03JZRGTW8V91H11ER (PLT-XD charter). Adds one bundled preset; no existing preset digest/version changed.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: `688af2a9e4abc49320320a5bc99c77d486d6ba03`
- Sync method: none needed
- `npm run check:local`: passed, 32 complete manifest gates green (89.8s).
- Preset-enumeration tests (package-surface, preset-document-cli, preset-module-cli, new-task-cli): 36/36. `check-catalog-schema`: passed. `preset validate docs-task`: ok. Full docs-task lifecycle (create → closeout → execution → approved review → complete with no `--ci`) exercised locally.

---

# 中文

## 摘要

新增 `docs-task` 轻量完成 profile，用于交付物是文档/决策而非代码的设计、文档、杂务型任务。它的完成门省去 `ci` 与 `code-doc-reconciliation`（这两道假设有代码 commit），但保留每个任务都有的实质门：真实 closeout + approved typed Review。

## 变更内容

- 新增 bundled preset `docs-task`（`preset.json` + `PRESET.md`），单 `baseline` profile，`completionGates: []`，无 entrypoint。
- 登记进 `presets/index.json`（standard-task 之后）、`extension-contract.lock.json`（id/version/digest）与 `package-surface` 公开分发白名单。

## 任务与范围

- Harness 任务：docs/chore 轻量 profile（XD-4 item 3）；补上"纯设计/文档任务挂 coding profile 无法诚实收尾"的缺口（`code_doc_anchors_missing` 要它拿不出的代码 commit）。
- 分支：`wip/docs-task-profile`
- 公开范围：`packages/cli/.../assets/software-coding/presets/**`、`extension-contract.lock.json`、`package-surface.test.ts`
- 范围外：改造存量 immutable 任务契约（任务的 profile 建时冻结；本 profile 服务于将来用它创建的任务）。

## 版本影响

- 版本：CLI 版本不变；新 preset 定 `1.0.0`。
- 发布影响：不发布。

## 治理声明

- 触碰受保护面：是（`extension-contract.lock.json` —— bundled preset 分发清单）
- 授权：task_01KXJA4E5K89Y3WZ72J841X770（docs/chore 轻量 profile，XD-4 item 3）、dec_01KXGDXZG03JZRGTW8V91H11ER（PLT-XD charter）。仅新增一个 bundled preset；未改动任何既有 preset 的 digest/version。
- 机器检查边界：本 PR 仅断言声明存在；是否真实充分由审查者判定。
- Break-glass：否

## 验证

- Base `origin/main` SHA：`688af2a9e4abc49320320a5bc99c77d486d6ba03`
- 同步方式：无需
- `npm run check:local`：通过，32 门绿（89.8s）。
- preset 枚举测试（package-surface、preset-document-cli、preset-module-cli、new-task-cli）：36/36。`check-catalog-schema`：通过。`preset validate docs-task`：ok。docs-task 完整生命周期（create → closeout → execution → approved review → 无 `--ci` complete）本地跑通。
