### PR TITLE
feat: v3 preset capability provider runtime + 4-canary equivalence proof (PLT-Preset-v3 Phase 1)

### DIFF
--- a/packages/cli/src/cli/command-spec/command-spec-extensions.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-extensions.ts
@@ -155,7 +155,9 @@ export const extensionsCommandSpecs = defineCommandSpecs([
     "receiptContract": {
       "data": ["taskId", "preset", "evidenceBundle", "generated", "report"],
       "optionalData": {
-        "rows": "Only emitted when a scripted preset run writes a numeric rows value in its result."
+        "rows": "Only emitted when a scripted preset run writes a numeric rows value in its result.",
+        "runId": "Only emitted by the semantic script host for an executable v3 entrypoint.",
+        "capabilityReceipt": "Only emitted by v3 semantic execution with its exact provider bindings."
       },
       "paths": []
     },
@@ -175,7 +177,9 @@ export const extensionsCommandSpecs = defineCommandSpecs([
     "receiptContract": {
       "data": ["taskId", "preset", "evidenceBundle", "generated", "report"],
       "optionalData": {
-        "rows": "Only emitted when a scripted preset action writes a numeric rows value in its result."
+        "rows": "Only emitted when a scripted preset action writes a numeric rows value in its result.",
+        "runId": "Only emitted by the semantic script host for an executable v3 entrypoint.",
+        "capabilityReceipt": "Only emitted by v3 semantic execution with its exact provider bindings."
       },
       "paths": []
     },

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -139,6 +139,7 @@ export interface CliResult {
   readonly generated?: ReadonlyArray<string>;
   readonly reviewContract?: unknown;
   readonly completionGate?: unknown;
+  readonly capabilityReceipt?: unknown;
   readonly forced?: boolean;
   readonly forceAudit?: {
     readonly path: string;

--- a/packages/cli/src/commands/extensions/preset-capability-providers.ts
+++ b/packages/cli/src/commands/extensions/preset-capability-providers.ts
@@ -1,0 +1,534 @@
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  findTaskPackagePath,
+  listTaskIndexPaths,
+  queryDecisionProjection,
+  readFrontmatter,
+  readRelationGraphProjection,
+  readScalar,
+  readTaskProjection,
+  resolveHarnessLayout,
+  type HarnessLayoutInput,
+  type HarnessLayoutOverrides,
+  type PresetCapabilityRequirement
+} from "../../../../kernel/src/index.ts";
+import { normalizeSlashes, relativePath } from "../../cli/path.ts";
+import { isPathInside } from "./script-scope.ts";
+
+export interface ScopeCandidate {
+  readonly root: string;
+  readonly recursive: boolean;
+}
+
+export function materializeRequirement(options: {
+  readonly request: PresetCapabilityRequirement;
+  readonly index: number;
+  readonly executionRootInput: HarnessLayoutInput;
+  readonly realRootInput: HarnessLayoutInput;
+  readonly inputs: Readonly<Record<string, unknown>>;
+  readonly currentTaskId: string;
+  readonly capabilitiesRoot: string;
+}): { readonly ok: true; readonly value: { readonly path: string; readonly extraReadPermissions: ReadonlyArray<string> } } | { readonly ok: false; readonly hint: string } {
+  const filename = `${String(options.index).padStart(2, "0")}-${options.request.capability}.json`;
+  const projectionPath = path.join(options.capabilitiesRoot, filename);
+  let value: unknown;
+  let extraReadPermissions: ReadonlyArray<string> = [];
+  try {
+    switch (options.request.capability) {
+      case "tasks":
+        value = taskProjection(options.executionRootInput, options.request, options.inputs);
+        break;
+      case "decisions":
+        value = decisionProjection(options.executionRootInput, options.request, options.inputs);
+        break;
+      case "adrs":
+        value = adrProjection(options.executionRootInput, options.request.select.states);
+        break;
+      case "operating-docs":
+        value = operatingDocsProjection(options.executionRootInput, options.request.select.collections);
+        break;
+      case "task-artifacts": {
+        const projection = taskArtifactsProjection(
+          options.executionRootInput,
+          options.request,
+          options.inputs,
+          options.currentTaskId,
+          path.join(options.capabilitiesRoot, `${String(options.index).padStart(2, "0")}-task-artifacts`)
+        );
+        value = projection.value;
+        extraReadPermissions = projection.readPermissions;
+        break;
+      }
+      case "relation-graph":
+        value = relationGraphProjection(options.executionRootInput, options.request, options.inputs);
+        break;
+      case "runtime-events":
+        // CanonicalScriptStage mirrors authoredRoot only. Operational ledgers are
+        // copied once from their protected real scope into this immutable run snapshot.
+        value = runtimeEventsProjection(options.realRootInput, options.inputs);
+        break;
+      case "generated-artifacts":
+        value = generatedArtifactsProjection(options.realRootInput, options.request.select.familiesFrom, options.inputs);
+        break;
+      case "write-journal":
+        value = presenceInventory(resolveHarnessLayout(options.realRootInput).writeJournalRoot, options.realRootInput, "write-journal-inventory/v1");
+        break;
+      case "docmap":
+        value = filePresence(path.join(resolveHarnessLayout(options.executionRootInput).authoredRoot, "docmap.json"), options.executionRootInput);
+        break;
+      default:
+        return providerUnavailable(`No semantic materializer is registered for ${options.request.capability}@${options.request.version}.`);
+    }
+  } catch (error) {
+    return providerUnavailable(`Capability ${options.request.capability}@${options.request.version} projection failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (projectionIsEmpty(options.request.capability, value)) {
+    return providerUnavailable(`Capability ${options.request.capability}@${options.request.version} resolved to an empty projection; raw-fs fallback is forbidden.`);
+  }
+  writeFileSync(projectionPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  return { ok: true, value: { path: projectionPath, extraReadPermissions } };
+}
+
+function taskProjection(
+  rootInput: HarnessLayoutInput,
+  request: Extract<PresetCapabilityRequirement, { readonly capability: "tasks" }>,
+  inputs: Readonly<Record<string, unknown>>
+): unknown {
+  const rows = readTaskProjection(taskProjectionOptions(rootInput)).rows;
+  let selected = rows;
+  if ("taskFrom" in request.select) {
+    const taskFrom = request.select.taskFrom;
+    selected = rows.filter((row) => row.taskId === inputs[taskFrom]);
+  }
+  return {
+    schema: "typed-task-projection/v1",
+    view: request.select.view,
+    tasks: selected.map((row) => ({
+      taskId: row.taskId,
+      title: row.title,
+      preset: row.preset ?? null,
+      sourcePath: row.sourcePath,
+      ...(request.select.view === "intent-summary" ? {
+        status: row.canonicalStatus,
+        parentTaskId: row.parentTaskId ?? null
+      } : {})
+    }))
+  };
+}
+
+function decisionProjection(
+  rootInput: HarnessLayoutInput,
+  request: Extract<PresetCapabilityRequirement, { readonly capability: "decisions" }>,
+  inputs: Readonly<Record<string, unknown>>
+): unknown {
+  const rows = queryDecisionProjection({ ...taskProjectionOptions(rootInput), filters: {} }).rows;
+  if ("states" in request.select) {
+    const states = request.select.states;
+    return {
+      schema: "typed-decision-projection/v1",
+      view: request.select.view,
+      decisions: rows.filter((row) => states.includes(row.state as "active")).map(canonDecision)
+    };
+  }
+  const taskId = String(inputs[request.select.relatedToTaskFrom] ?? "");
+  const layout = resolveHarnessLayout(rootInput);
+  return {
+    schema: "typed-decision-projection/v1",
+    view: request.select.view,
+    decisions: rows.filter((row) => {
+      const filename = path.resolve(layout.rootDir, row.path);
+      return isPathInside(layout.decisionsRoot, filename) && existsSync(filename) && readFileSync(filename, "utf8").includes(taskId);
+    }).map((row) => ({
+      decisionId: row.decisionId,
+      ref: `decision/${row.decisionId}`,
+      title: row.title,
+      sourcePath: row.path,
+      question: row.question
+    }))
+  };
+}
+
+function canonDecision(row: ReturnType<typeof queryDecisionProjection>["rows"][number]): Record<string, unknown> {
+  return {
+    kind: "decision",
+    canonicalId: row.decisionId,
+    title: row.title,
+    state: row.state,
+    date: row.decidedAt ?? row.proposedAt ?? "",
+    sourcePath: row.path
+  };
+}
+
+function adrProjection(rootInput: HarnessLayoutInput, states: ReadonlyArray<string>): unknown {
+  const layout = resolveHarnessLayout(rootInput);
+  const seen = new Set<string>();
+  const adrs = walkCapabilityFiles(layout.adrRoot).filter((filename) => filename.endsWith(".md")).flatMap((filename) => {
+    const body = readFileSync(filename, "utf8");
+    const frontmatter = readFrontmatter(body) ?? "";
+    const statusSection = /^##\s+Status\s*\r?\n+([\s\S]*?)(?:\r?\n##\s+|\s*$)/imu.exec(body)?.[1] ?? "";
+    const statusLine = statusSection.split(/\r?\n/u).map((line) => line.trim()).find(Boolean) ?? "";
+    const statusMatch = /^(Accepted|Active|Approved|Proposed|Deprecated|Superseded|Rejected)\b(?:\s+(\d{4}-\d{2}-\d{2}))?/iu.exec(statusLine);
+    const status = frontmatterScalar(frontmatter, "status") || statusMatch?.[1]?.toLowerCase() || "unknown";
+    const canonicalId = frontmatterScalar(frontmatter, "id") || /(?:^|\/)(ADR-\d{4,})/u.exec(normalizeSlashes(filename))?.[1] || "";
+    if (!canonicalId || !states.includes(status) || seen.has(canonicalId)) return [];
+    seen.add(canonicalId);
+    return [{
+      kind: "adr",
+      canonicalId,
+      title: frontmatterScalar(frontmatter, "title") || /^#\s+(.+)$/mu.exec(body)?.[1]?.trim() || canonicalId,
+      status,
+      date: frontmatterScalar(frontmatter, "date") || statusMatch?.[2] || "",
+      sourcePath: relativePath(layout.rootDir, filename)
+    }];
+  });
+  return { schema: "typed-adr-projection/v1", view: "canon-summary", adrs: adrs.sort(compareCanonical) };
+}
+
+function operatingDocsProjection(rootInput: HarnessLayoutInput, collections: ReadonlyArray<string>): unknown {
+  const layout = resolveHarnessLayout(rootInput);
+  const roots = collections.flatMap((collection) => {
+    if (collection === "agents-guide") return [path.join(layout.authoredRoot, "AGENTS.md")];
+    if (collection === "governance") return [path.join(layout.authoredRoot, "governance")];
+    if (collection === "standards") return [path.join(layout.authoredRoot, "standards")];
+    return [];
+  });
+  const documents = roots.flatMap(walkCapabilityFiles)
+    .filter((filename) => /\.(?:md|mdx|txt|ya?ml|json)$/iu.test(filename))
+    .map((filename) => ({ relativePath: relativePath(layout.rootDir, filename), body: readFileSync(filename, "utf8") }));
+  return { schema: "named-operating-docs/v1", view: "text", documents };
+}
+
+function taskArtifactsProjection(
+  rootInput: HarnessLayoutInput,
+  request: Extract<PresetCapabilityRequirement, { readonly capability: "task-artifacts" }>,
+  inputs: Readonly<Record<string, unknown>>,
+  currentTaskId: string,
+  snapshotRoot: string
+): { readonly value: unknown; readonly readPermissions: ReadonlyArray<string> } {
+  const layout = resolveHarnessLayout(rootInput);
+  const taskIds = "scope" in request.select
+    ? listTaskIndexPaths(rootInput).map((indexPath) => taskIdFromIndex(indexPath)).filter(Boolean)
+    : [String(inputs[request.select.taskFrom] ?? (request.select.taskFrom === "current-task" ? currentTaskId : ""))];
+  const artifacts: Array<Record<string, unknown>> = [];
+  const readPermissions: string[] = [];
+  for (const taskId of taskIds) {
+    const packageRoot = findTaskPackagePath(rootInput, taskId);
+    if (!packageRoot) continue;
+    const artifactsRoot = path.join(packageRoot, "artifacts");
+    for (const artifactId of request.select.artifactIds) {
+      for (const source of artifactFiles(artifactsRoot, artifactId)) {
+        const target = path.join(snapshotRoot, safeSegment(taskId), path.basename(source));
+        mkdirSync(path.dirname(target), { recursive: true });
+        cpSync(source, target);
+        readPermissions.push(target);
+        artifacts.push({
+          id: artifactId,
+          taskId,
+          mediaType: mediaTypeForPath(source),
+          sourcePath: relativePath(layout.rootDir, source),
+          path: target
+        });
+      }
+    }
+  }
+  return {
+    value: { schema: "logical-task-artifacts/v1", view: "immutable-handles", artifacts },
+    readPermissions
+  };
+}
+
+function relationGraphProjection(
+  rootInput: HarnessLayoutInput,
+  request: Extract<PresetCapabilityRequirement, { readonly capability: "relation-graph" }>,
+  inputs: Readonly<Record<string, unknown>>
+): unknown {
+  const graph = readRelationGraphProjection(taskProjectionOptions(rootInput));
+  const tasks = readTaskProjection(taskProjectionOptions(rootInput)).rows;
+  const decisions = queryDecisionProjection({ ...taskProjectionOptions(rootInput), filters: {} }).rows;
+  const decisionId = typeof inputs[request.select.decisionFrom] === "string" && inputs[request.select.decisionFrom]
+    ? String(inputs[request.select.decisionFrom])
+    : undefined;
+  const focusDecisionRef = decisionId ? `decision/${decisionId}` : undefined;
+  const coverageRows = focusDecisionRef
+    ? graph.coverageRows.filter((row) => row.decisionRef === focusDecisionRef)
+    : graph.coverageRows;
+  const selectedDecisionRefs = new Set(coverageRows.map((row) => row.decisionRef));
+  if (focusDecisionRef) selectedDecisionRefs.add(focusDecisionRef);
+  const relationIds = new Set(coverageRows.flatMap((row) => row.relationPath));
+  const relationEdges = graph.edges.filter((edge) => relationIds.has(edge.relationId) ||
+    selectedDecisionRefs.has(baseDecisionRef(edge.sourceRef)) || selectedDecisionRefs.has(baseDecisionRef(edge.targetRef)));
+  const selectedRefs = new Set<string>();
+  for (const row of coverageRows) {
+    selectedRefs.add(row.decisionRef);
+    selectedRefs.add(row.claimRef);
+    if (row.coveringFactRef) selectedRefs.add(row.coveringFactRef);
+  }
+  for (const edge of relationEdges) {
+    selectedRefs.add(edge.sourceRef);
+    selectedRefs.add(edge.targetRef);
+    selectedRefs.add(edge.ownerRef);
+  }
+  return {
+    schema: "typed-relation-graph-view/v1",
+    view: "dossier",
+    decisionId: decisionId ?? null,
+    tasks: tasks.filter((task) => selectedRefs.has(`task/${task.taskId}`)).map((task) => ({
+      taskId: task.taskId,
+      title: task.title,
+      canonicalStatus: task.canonicalStatus,
+      coordinationStatus: task.coordinationStatus,
+      sourcePath: task.sourcePath,
+      vertical: task.vertical ?? null,
+      preset: task.preset ?? null,
+      profile: task.profile ?? null
+    })),
+    decisions: decisions.filter((decision) => selectedDecisionRefs.has(`decision/${decision.decisionId}`)).map((decision) => ({
+      decisionId: decision.decisionId,
+      title: decision.title,
+      state: decision.state,
+      question: decision.question,
+      path: decision.path,
+      chosen: decision.chosen,
+      rejected: decision.rejected,
+      decidedAt: decision.decidedAt ?? null
+    })),
+    facts: graph.factAnchors.filter((fact) => selectedRefs.has(fact.factRef)),
+    relationEdges,
+    coverageRows,
+    provenanceRefs: [...selectedRefs].sort()
+  };
+}
+
+function runtimeEventsProjection(rootInput: HarnessLayoutInput, inputs: Readonly<Record<string, unknown>>): unknown {
+  const layout = resolveHarnessLayout(rootInput);
+  const files = walkCapabilityFiles(layout.runtimeEventLedgerRoot).filter((filename) => filename.endsWith(".jsonl"));
+  const trackedPresets = stringList(inputs.trackedPresets);
+  const commandCounts: Record<string, number> = {};
+  const mentions = Object.fromEntries(trackedPresets.map((presetId) => [presetId, { count: 0, evidence: [] as string[] }]));
+  let rows = 0;
+  for (const filename of files) {
+    for (const line of readFileSync(filename, "utf8").split(/\r?\n/u).filter(Boolean)) {
+      rows += 1;
+      let text = line;
+      try {
+        const parsed = JSON.parse(line) as Record<string, unknown>;
+        text = JSON.stringify(parsed);
+        const result = isCapabilityRecord(parsed.result) ? parsed.result : undefined;
+        const summary = typeof result?.summary === "string" ? result.summary : "";
+        const command = /CLI command succeeded: ([A-Za-z0-9_-]+)/u.exec(summary)?.[1];
+        if (command) commandCounts[command] = (commandCounts[command] ?? 0) + 1;
+      } catch {
+        // A malformed historical event remains countable but grants no structured command signal.
+      }
+      for (const presetId of trackedPresets) {
+        if (!text.includes(presetId)) continue;
+        const entry = mentions[presetId]!;
+        entry.count += 1;
+        if (entry.evidence.length < 5) entry.evidence.push(relativePath(layout.rootDir, filename));
+      }
+    }
+  }
+  return { schema: "runtime-command-usage/v1", files: files.length, rows, commandCounts, presetMentions: mentions };
+}
+
+function generatedArtifactsProjection(
+  rootInput: HarnessLayoutInput,
+  familiesFrom: string,
+  inputs: Readonly<Record<string, unknown>>
+): unknown {
+  const layout = resolveHarnessLayout(rootInput);
+  const known: Record<string, string> = {
+    "runtime-events": "runtime-events",
+    "distill-candidates": "distill",
+    "lesson-promotions": "lessons",
+    "graph-panorama": "graph-panorama"
+  };
+  const entries = stringList(inputs[familiesFrom]).flatMap((id) => {
+    const relative = known[id];
+    if (!relative) return [];
+    const root = path.join(layout.generatedRoot, relative);
+    const files = walkCapabilityFiles(root);
+    const jsonl = files.filter((filename) => filename.endsWith(".jsonl"));
+    const rows = jsonl.reduce((sum, filename) => sum + readFileSync(filename, "utf8").split(/\r?\n/u).filter(Boolean).length, 0);
+    return [{
+      id,
+      present: files.length > 0,
+      files: files.length,
+      ...(id === "runtime-events" ? { rows } : {}),
+      evidence: files.slice(0, 5).map((filename) => relativePath(layout.rootDir, filename))
+    }];
+  });
+  return { schema: "generated-artifact-inventory/v1", entries };
+}
+
+function presenceInventory(root: string, rootInput: HarnessLayoutInput, schema: string): unknown {
+  const layout = resolveHarnessLayout(rootInput);
+  const files = walkCapabilityFiles(root);
+  return {
+    schema,
+    present: files.length > 0,
+    files: files.length,
+    evidence: files.slice(0, 5).map((filename) => relativePath(layout.rootDir, filename))
+  };
+}
+
+function filePresence(filename: string, rootInput: HarnessLayoutInput): unknown {
+  const layout = resolveHarnessLayout(rootInput);
+  const present = existsSync(filename) && statSync(filename).isFile();
+  return {
+    schema: "docmap-presence/v1",
+    present,
+    files: present ? 1 : 0,
+    evidence: present ? [relativePath(layout.rootDir, filename)] : []
+  };
+}
+
+export function sourceScopesForRequirement(
+  layout: ReturnType<typeof resolveHarnessLayout>,
+  request: PresetCapabilityRequirement,
+  inputs: Readonly<Record<string, unknown>>,
+  currentTaskId: string,
+  dryRun: boolean
+): { readonly ok: true; readonly value: ReadonlyArray<ScopeCandidate> } | { readonly ok: false; readonly hint: string } {
+  switch (request.capability) {
+    case "tasks":
+      return { ok: true, value: [{ root: layout.tasksRoot, recursive: true }] };
+    case "decisions":
+      return { ok: true, value: [{ root: layout.decisionsRoot, recursive: true }] };
+    case "adrs":
+      return { ok: true, value: [{ root: layout.adrRoot, recursive: true }] };
+    case "operating-docs":
+      return { ok: true, value: request.select.collections.flatMap<ScopeCandidate>((collection) => {
+        if (collection === "agents-guide") {
+          const filename = path.join(layout.authoredRoot, "AGENTS.md");
+          return existsSync(filename) ? [{ root: filename, recursive: false }] : [];
+        }
+        return [{ root: path.join(layout.authoredRoot, collection), recursive: true }];
+      }) };
+    case "task-artifacts": {
+      if ("scope" in request.select) return { ok: true, value: [{ root: layout.tasksRoot, recursive: true }] };
+      const taskId = request.select.taskFrom === "current-task"
+        ? currentTaskId
+        : String(inputs[request.select.taskFrom] ?? "");
+      const packageRoot = findTaskPackagePath(layout.rootDir, taskId);
+      return packageRoot
+        ? { ok: true, value: [{ root: path.join(packageRoot, "artifacts"), recursive: true }] }
+        : dryRun
+          ? { ok: true, value: [{ root: path.join(layout.tasksRoot, safeSegment(taskId), "artifacts"), recursive: true }] }
+        : providerUnavailable(`task-artifacts/v1 selector could not resolve task input ${request.select.taskFrom}.`);
+    }
+    case "relation-graph":
+      return { ok: true, value: [
+        { root: layout.tasksRoot, recursive: true },
+        { root: layout.decisionsRoot, recursive: true }
+      ] };
+    case "runtime-events":
+      return { ok: true, value: [{ root: layout.runtimeEventLedgerRoot, recursive: true }] };
+    case "generated-artifacts": {
+      const known: Record<string, string> = {
+        "runtime-events": "runtime-events",
+        "distill-candidates": "distill",
+        "lesson-promotions": "lessons",
+        "graph-panorama": "graph-panorama"
+      };
+      return { ok: true, value: stringList(inputs[request.select.familiesFrom]).flatMap((id) => (
+        known[id] ? [{ root: path.join(layout.generatedRoot, known[id]), recursive: true }] : []
+      )) };
+    }
+    case "write-journal":
+      return { ok: true, value: [{ root: layout.writeJournalRoot, recursive: true }] };
+    case "docmap": {
+      const filename = path.join(layout.authoredRoot, "docmap.json");
+      return { ok: true, value: existsSync(filename) ? [{ root: filename, recursive: false }] : [] };
+    }
+    default:
+      return providerUnavailable(`No semantic source mapping is registered for ${request.capability}@${request.version}.`);
+  }
+}
+
+function projectionIsEmpty(capability: string, value: unknown): boolean {
+  if (!isCapabilityRecord(value)) return true;
+  if (capability === "tasks") return !Array.isArray(value.tasks) || value.tasks.length === 0;
+  if (capability === "decisions") return !Array.isArray(value.decisions) || value.decisions.length === 0;
+  if (capability === "adrs") return !Array.isArray(value.adrs) || value.adrs.length === 0;
+  if (capability === "operating-docs") return !Array.isArray(value.documents) || value.documents.length === 0;
+  if (capability === "task-artifacts") return !Array.isArray(value.artifacts) || value.artifacts.length === 0;
+  if (capability === "relation-graph") {
+    return [value.tasks, value.decisions, value.facts, value.relationEdges, value.coverageRows]
+      .every((entry) => !Array.isArray(entry) || entry.length === 0);
+  }
+  if (capability === "runtime-events") return typeof value.rows !== "number" || value.rows === 0;
+  if (capability === "generated-artifacts") return !Array.isArray(value.entries) || value.entries.length === 0;
+  return false;
+}
+
+function taskProjectionOptions(rootInput: HarnessLayoutInput): { readonly rootDir: string; readonly layoutOverrides?: HarnessLayoutOverrides } {
+  const layout = resolveHarnessLayout(rootInput);
+  return {
+    rootDir: layout.rootDir,
+    ...(typeof rootInput === "string" || !rootInput.layoutOverrides ? {} : { layoutOverrides: rootInput.layoutOverrides })
+  };
+}
+
+function artifactFiles(root: string, artifactId: string): ReadonlyArray<string> {
+  if (!existsSync(root)) return [];
+  return walkCapabilityFiles(root).filter((filename) => {
+    const basename = path.basename(filename);
+    return basename === artifactId || basename.startsWith(`${artifactId}.`) || basename.startsWith(`${artifactId}-`);
+  });
+}
+
+function taskIdFromIndex(indexPath: string): string {
+  const frontmatter = readFrontmatter(readFileSync(indexPath, "utf8")) ?? "";
+  return frontmatterScalar(frontmatter, "task_id") || path.basename(path.dirname(indexPath));
+}
+
+function frontmatterScalar(frontmatter: string, key: string): string {
+  return readScalar(frontmatter, key).trim().replace(/^["']|["']$/gu, "");
+}
+
+function walkCapabilityFiles(root: string): ReadonlyArray<string> {
+  if (!root || !existsSync(root)) return [];
+  const stat = statSync(root);
+  if (stat.isFile()) return [root];
+  if (!stat.isDirectory()) return [];
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.isSymbolicLink()) return [];
+    const candidate = path.join(root, entry.name);
+    return entry.isDirectory() ? walkCapabilityFiles(candidate) : entry.isFile() ? [candidate] : [];
+  }).sort();
+}
+
+function mediaTypeForPath(filename: string): string {
+  if (filename.endsWith(".json")) return "application/json";
+  if (filename.endsWith(".md")) return "text/markdown";
+  return "application/octet-stream";
+}
+
+function compareCanonical(left: { readonly date: string; readonly canonicalId: string }, right: { readonly date: string; readonly canonicalId: string }): number {
+  const byDate = (Date.parse(right.date) || 0) - (Date.parse(left.date) || 0);
+  return byDate !== 0 ? byDate : left.canonicalId.localeCompare(right.canonicalId);
+}
+
+function baseDecisionRef(ref: string): string {
+  return /^decision\/[A-Za-z0-9_-]+/u.exec(ref)?.[0] ?? "";
+}
+
+function safeSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.-]/gu, "_");
+}
+
+function stringList(value: unknown): ReadonlyArray<string> {
+  if (Array.isArray(value)) return value.map(String);
+  if (typeof value === "string") return value.split(",").map((entry) => entry.trim()).filter(Boolean);
+  return [];
+}
+
+function isCapabilityRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function providerUnavailable(hint: string): { readonly ok: false; readonly hint: string } {
+  return { ok: false, hint };
+}

--- a/packages/cli/src/commands/extensions/preset-capability-runtime.ts
+++ b/packages/cli/src/commands/extensions/preset-capability-runtime.ts
@@ -1,0 +1,483 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  resolveHarnessLayout,
+  taskPackagePath,
+  type HarnessLayoutInput,
+  type LogicalArtifactV1,
+  type PresetCapabilityProvider,
+  type PresetEntrypointV3,
+  type PresetInputV3,
+  type PresetManifestV3
+} from "../../../../kernel/src/index.ts";
+import type { ResolvedPreset } from "./state.ts";
+import type { ResolvedScriptEntry, ScriptEntry } from "./script-host.ts";
+import {
+  materializeRequirement,
+  sourceScopesForRequirement,
+  type ScopeCandidate
+} from "./preset-capability-providers.ts";
+import type { CanonicalScriptStage } from "./script-staging.ts";
+import {
+  permissionPathsForScope,
+  uniquePermissionPaths,
+  type ResolvedScopeSet
+} from "./script-scope.ts";
+
+type SemanticScriptEntrypoint = Extract<PresetEntrypointV3, { readonly type: "script" }>;
+type ResolvedSemanticPreset = Omit<ResolvedPreset, "manifest"> & { readonly manifest: PresetManifestV3 };
+
+export interface SemanticPresetExecution {
+  readonly preset: ResolvedSemanticPreset;
+  readonly entrypointName: string;
+  readonly entrypoint: SemanticScriptEntrypoint;
+}
+
+interface WritableRepresentation {
+  readonly mediaType: string;
+  readonly path: string;
+  readonly logicalPath: string;
+}
+
+interface WritableArtifact {
+  readonly id: string;
+  readonly schema: string;
+  readonly required: boolean;
+  readonly representations: ReadonlyArray<WritableRepresentation>;
+}
+
+export interface PreparedSemanticPresetExecution {
+  readonly execution: SemanticPresetExecution;
+  readonly inputs: Readonly<Record<string, unknown>>;
+  readonly currentTaskId: string;
+  readonly outputRoot: string;
+  readonly protectedSourceScopes: ResolvedScopeSet;
+  readonly stageEnvelope: ResolvedScopeSet;
+  readonly outputs: ReadonlyArray<WritableArtifact>;
+  readonly receipt: PresetCapabilityRuntimeReceipt;
+}
+
+export interface MaterializedSemanticPresetExecution {
+  readonly context: Readonly<Record<string, unknown>>;
+  readonly childReadPermissions: ReadonlyArray<string>;
+  readonly childWritePermissions: ReadonlyArray<string>;
+  readonly writerRoots: ReadonlyArray<string>;
+  readonly outputPatterns: ReadonlyArray<string>;
+  readonly outputs: ReadonlyArray<WritableArtifact>;
+}
+
+export interface PresetCapabilityRuntimeReceipt {
+  readonly schema: "preset-capability-runtime-receipt/v1";
+  readonly presetId: string;
+  readonly presetVersion: string;
+  readonly entrypoint: string;
+  readonly contextSchema: "preset-context/v2";
+  readonly semanticFailureFallback: "forbidden";
+  readonly bindings: ReadonlyArray<{
+    readonly capability: string;
+    readonly version: string;
+    readonly direction: "requires" | "produces";
+    readonly provider: string;
+    readonly mappedAs: "immutable-projection" | "staged-writer";
+  }>;
+}
+
+type PreparationResult =
+  | { readonly ok: true; readonly value: PreparedSemanticPresetExecution }
+  | { readonly ok: false; readonly hint: string };
+
+type MaterializationResult =
+  | { readonly ok: true; readonly value: MaterializedSemanticPresetExecution }
+  | { readonly ok: false; readonly hint: string };
+
+const semanticProviderId = "cli-semantic-capability-runtime/v1";
+
+export const registeredSemanticPresetCapabilityProviders: ReadonlyArray<PresetCapabilityProvider> = [
+  ...[
+    "tasks",
+    "decisions",
+    "adrs",
+    "operating-docs",
+    "relation-graph",
+    "runtime-events",
+    "generated-artifacts",
+    "write-journal",
+    "docmap"
+  ].map((capability) => ({ capability, version: "1", direction: "requires" as const })),
+  { capability: "task-artifacts", version: "1", direction: "requires" as const },
+  { capability: "task-artifacts", version: "1", direction: "produces" as const }
+];
+
+export function semanticPresetScriptEntry(
+  preset: ResolvedSemanticPreset,
+  entrypointName: string,
+  entrypoint: SemanticScriptEntrypoint
+): ResolvedScriptEntry {
+  const entry: ScriptEntry = {
+    id: `preset:${preset.manifest.id}:${entrypointName}`,
+    source: "preset",
+    type: "script",
+    command: entrypoint.command,
+    reads: [],
+    writes: [],
+    inputs: entrypoint.inputs,
+    metadata: {
+      description: `${preset.manifest.title} ${entrypointName}`,
+      purpose: semanticPurpose(entrypoint.intent.verb),
+      kind: entrypoint.intent.verb === "check" ? "check" : undefined,
+      contractVersion: "script-entry/v1",
+      produces: []
+    }
+  };
+  return {
+    entry,
+    verticalId: preset.manifest.vertical,
+    manifestRoot: path.dirname(preset.sourcePath),
+    owner: {
+      id: preset.manifest.id,
+      title: preset.manifest.title,
+      version: preset.manifest.version,
+      layer: preset.layer
+    },
+    context: {
+      presetId: preset.manifest.id,
+      presetTitle: preset.manifest.title,
+      entrypoint: entrypointName
+    },
+    semantic: { preset, entrypointName, entrypoint }
+  };
+}
+
+export function prepareSemanticPresetExecution(options: {
+  readonly rootInput: HarnessLayoutInput;
+  readonly execution: SemanticPresetExecution;
+  readonly taskId?: string;
+  readonly runtimeInputs?: Readonly<Record<string, string>>;
+  readonly fallbackOutputRoot: string;
+  readonly dryRun?: boolean;
+}): PreparationResult {
+  const { execution } = options;
+  if (execution.entrypoint.sideEffects.length > 0) {
+    return runtimeUnavailable("Semantic execution does not admit raw-fs or any other side effect without its independent grant and enforcement binding.");
+  }
+  const currentTaskId = options.taskId?.trim() ?? "";
+  if (!currentTaskId) return runtimeUnavailable("preset-context/v2 requires a current task binding.");
+  const inputs = bindSemanticInputs(execution.entrypoint.inputs, options.runtimeInputs ?? {}, currentTaskId);
+  if (!inputs.ok) return inputs;
+
+  const layout = resolveHarnessLayout(options.rootInput);
+  const sourceCandidates: ScopeCandidate[] = [];
+  for (const request of execution.entrypoint.requires) {
+    if (!providerRegistered(request.capability, "requires")) {
+      return runtimeUnavailable(`No semantic execution provider is registered for ${request.capability}@${request.version} requires; raw-fs fallback is forbidden.`);
+    }
+    const sources = sourceScopesForRequirement(layout, request, inputs.value, currentTaskId, options.dryRun === true);
+    if (!sources.ok) return sources;
+    sourceCandidates.push(...sources.value);
+  }
+
+  let targetTaskId: string | undefined;
+  const outputs: WritableArtifact[] = [];
+  for (const request of execution.entrypoint.produces) {
+    if (!providerRegistered(request.capability, "produces")) {
+      return runtimeUnavailable(`No semantic execution provider is registered for ${request.capability}@${request.version} produces; raw-fs fallback is forbidden.`);
+    }
+    if (request.capability !== "task-artifacts") {
+      return runtimeUnavailable(`The Phase 1 runtime has no staged writer for ${request.capability}@${request.version}.`);
+    }
+    const resolvedTarget = taskFrom(request.target.taskFrom, inputs.value, currentTaskId);
+    if (!resolvedTarget.ok) return resolvedTarget;
+    if (targetTaskId !== undefined && targetTaskId !== resolvedTarget.value) {
+      return runtimeUnavailable("One semantic execution cannot bind task-artifacts/v1 writers for multiple target tasks.");
+    }
+    targetTaskId = resolvedTarget.value;
+  }
+
+  const outputRoot = targetTaskId ? taskPackagePath(options.rootInput, targetTaskId) : options.fallbackOutputRoot;
+  for (const request of execution.entrypoint.produces) {
+    if (request.capability !== "task-artifacts") continue;
+    for (const artifact of request.artifacts) {
+      const writable = writableArtifact(layout.rootDir, outputRoot, artifact);
+      if (!writable.ok) return writable;
+      outputs.push(writable.value);
+    }
+  }
+  const writerRoots = outputs.length > 0 ? [{ root: path.join(outputRoot, "artifacts"), recursive: true }] : [];
+  const bindings = [
+    ...execution.entrypoint.requires.map((request) => ({
+      capability: request.capability,
+      version: request.version,
+      direction: "requires" as const,
+      provider: semanticProviderId,
+      mappedAs: "immutable-projection" as const
+    })),
+    ...execution.entrypoint.produces.map((request) => ({
+      capability: request.capability,
+      version: request.version,
+      direction: "produces" as const,
+      provider: semanticProviderId,
+      mappedAs: "staged-writer" as const
+    }))
+  ];
+  return {
+    ok: true,
+    value: {
+      execution,
+      inputs: inputs.value,
+      currentTaskId,
+      outputRoot,
+      protectedSourceScopes: resolvedSemanticScope(sourceCandidates),
+      stageEnvelope: resolvedSemanticScope(writerRoots),
+      outputs,
+      receipt: {
+        schema: "preset-capability-runtime-receipt/v1",
+        presetId: execution.preset.manifest.id,
+        presetVersion: execution.preset.manifest.version,
+        entrypoint: execution.entrypointName,
+        contextSchema: "preset-context/v2",
+        semanticFailureFallback: "forbidden",
+        bindings
+      }
+    }
+  };
+}
+
+export function materializeSemanticPresetExecution(options: {
+  readonly rootInput: HarnessLayoutInput;
+  readonly preparation: PreparedSemanticPresetExecution;
+  readonly stage?: CanonicalScriptStage;
+  readonly runDir: string;
+  readonly runId: string;
+  readonly resultPath: string;
+}): MaterializationResult {
+  const executionRootInput = options.stage?.rootInput ?? options.rootInput;
+  const capabilitiesRoot = path.join(options.runDir, "capabilities");
+  mkdirSync(capabilitiesRoot, { recursive: true });
+  const readBindings: Record<string, unknown[]> = {};
+  const childReadPermissions: string[] = [];
+
+  for (const [index, request] of options.preparation.execution.entrypoint.requires.entries()) {
+    const projection = materializeRequirement({
+      request,
+      index,
+      executionRootInput,
+      realRootInput: options.rootInput,
+      inputs: options.preparation.inputs,
+      currentTaskId: options.preparation.currentTaskId,
+      capabilitiesRoot
+    });
+    if (!projection.ok) return projection;
+    const existing = readBindings[request.capability] ?? [];
+    existing.push({
+      schema: "preset-capability-handle/v1",
+      capability: request.capability,
+      version: request.version,
+      provider: semanticProviderId,
+      path: projection.value.path
+    });
+    readBindings[request.capability] = existing;
+    childReadPermissions.push(projection.value.path, ...projection.value.extraReadPermissions);
+  }
+
+  const stagedOutputs = options.stage
+    ? remapWritableArtifacts(options.preparation.outputs, options.stage)
+    : options.preparation.outputs;
+  const writerRoots = uniquePermissionPaths(stagedOutputs.flatMap((artifact) => artifact.representations.map((entry) => path.dirname(entry.path))));
+  for (const root of writerRoots) mkdirSync(root, { recursive: true });
+  const writeBindings = stagedOutputs.length === 0 ? {} : {
+    "task-artifacts": [{
+      schema: "preset-capability-writer/v1",
+      capability: "task-artifacts",
+      version: "1",
+      provider: semanticProviderId,
+      artifacts: Object.fromEntries(stagedOutputs.map((artifact) => [artifact.id, {
+        schema: artifact.schema,
+        required: artifact.required,
+        representations: artifact.representations
+      }]))
+    }]
+  };
+  return {
+    ok: true,
+    value: {
+      context: {
+        schema: "preset-context/v2",
+        preset: {
+          id: options.preparation.execution.preset.manifest.id,
+          version: options.preparation.execution.preset.manifest.version,
+          entrypoint: options.preparation.execution.entrypointName
+        },
+        run: { id: options.runId, taskId: options.preparation.currentTaskId },
+        inputs: options.preparation.inputs,
+        capabilities: { reads: readBindings, writes: writeBindings },
+        result: { schema: "script-result/v1", path: options.resultPath },
+        receipt: options.preparation.receipt
+      },
+      childReadPermissions: uniquePermissionPaths(childReadPermissions),
+      childWritePermissions: writerRoots.flatMap((root) => permissionPathsForScope(root, true)),
+      writerRoots,
+      outputPatterns: stagedOutputs.flatMap((artifact) => artifact.representations.map((entry) => entry.path)),
+      outputs: stagedOutputs
+    }
+  };
+}
+
+export function verifySemanticPresetOutputs(
+  outputs: ReadonlyArray<WritableArtifact>
+): { readonly ok: true } | { readonly ok: false; readonly hint: string } {
+  for (const output of outputs) {
+    for (const representation of output.representations) {
+      if (!existsSync(representation.path)) {
+        if (output.required) return runtimeUnavailable(`Required logical artifact ${output.id} was not produced for ${representation.mediaType}.`);
+        continue;
+      }
+      const body = readFileSync(representation.path, "utf8");
+      if (body.trim().length === 0) return runtimeUnavailable(`Logical artifact ${output.id} produced an empty ${representation.mediaType} representation.`);
+      if (representation.mediaType === "application/json") {
+        try {
+          const parsed = JSON.parse(body) as unknown;
+          if (!isRuntimeRecord(parsed) || parsed.schema !== output.schema) {
+            return runtimeUnavailable(`Logical artifact ${output.id} must declare schema ${output.schema}.`);
+          }
+        } catch {
+          return runtimeUnavailable(`Logical artifact ${output.id} produced malformed application/json.`);
+        }
+      }
+    }
+  }
+  return { ok: true };
+}
+
+function bindSemanticInputs(
+  definitions: Readonly<Record<string, PresetInputV3>>,
+  runtime: Readonly<Record<string, string>>,
+  currentTaskId: string
+): { readonly ok: true; readonly value: Readonly<Record<string, unknown>> } | { readonly ok: false; readonly hint: string } {
+  for (const name of Object.keys(runtime)) {
+    if (!(name in definitions)) return runtimeUnavailable(`Runtime input ${name} is not declared by the v3 entrypoint.`);
+  }
+  const values: Record<string, unknown> = {};
+  for (const [name, definition] of Object.entries(definitions)) {
+    let value: unknown = runtime[name];
+    if (value === undefined && "defaultFrom" in definition && definition.defaultFrom === "current-task") value = currentTaskId;
+    if (value === undefined && "default" in definition) value = definition.default;
+    if (value === undefined) {
+      if (definition.required) return runtimeUnavailable(`Required runtime input ${name} is missing.`);
+      continue;
+    }
+    const decoded = decodeRuntimeInput(name, definition, value);
+    if (!decoded.ok) return decoded;
+    values[name] = decoded.value;
+  }
+  return { ok: true, value: values };
+}
+
+function decodeRuntimeInput(
+  name: string,
+  definition: PresetInputV3,
+  value: unknown
+): { readonly ok: true; readonly value: unknown } | { readonly ok: false; readonly hint: string } {
+  if (definition.type === "boolean") {
+    if (typeof value === "boolean") return { ok: true, value };
+    if (value === "true" || value === "false") return { ok: true, value: value === "true" };
+    return runtimeUnavailable(`Runtime input ${name} must be boolean.`);
+  }
+  if (definition.type === "integer") {
+    const integer = typeof value === "number" ? value : /^-?\d+$/u.test(String(value)) ? Number(value) : Number.NaN;
+    return Number.isInteger(integer) ? { ok: true, value: integer } : runtimeUnavailable(`Runtime input ${name} must be an integer.`);
+  }
+  if (["enum-list", "preset-ref-list", "artifact-ref-list"].includes(definition.type)) {
+    const list = Array.isArray(value) ? value.map(String) : String(value).split(",").map((entry) => entry.trim()).filter(Boolean);
+    if (definition.type === "enum-list" && list.some((entry) => !definition.values.includes(entry))) {
+      return runtimeUnavailable(`Runtime input ${name} contains a value outside its declared enum.`);
+    }
+    return { ok: true, value: list };
+  }
+  const scalarValue = String(value);
+  if (definition.type === "enum" && !definition.values.includes(scalarValue)) {
+    return runtimeUnavailable(`Runtime input ${name} is outside its declared enum.`);
+  }
+  if ((definition.type === "task-ref" || definition.type === "decision-ref") && scalarValue.trim().length === 0) {
+    return runtimeUnavailable(`Runtime input ${name} must be a non-empty ${definition.type}.`);
+  }
+  return { ok: true, value: scalarValue };
+}
+
+function taskFrom(
+  selector: string,
+  inputs: Readonly<Record<string, unknown>>,
+  currentTaskId: string
+): { readonly ok: true; readonly value: string } | { readonly ok: false; readonly hint: string } {
+  const value = selector === "current-task" ? currentTaskId : inputs[selector];
+  return typeof value === "string" && value.length > 0
+    ? { ok: true, value }
+    : runtimeUnavailable(`Task target ${selector} could not be resolved from bound inputs.`);
+}
+
+function writableArtifact(
+  rootDir: string,
+  outputRoot: string,
+  artifact: LogicalArtifactV1
+): { readonly ok: true; readonly value: WritableArtifact } | { readonly ok: false; readonly hint: string } {
+  const representations: WritableRepresentation[] = [];
+  for (const mediaType of artifact.mediaTypes) {
+    const extension = mediaType === "application/json" ? ".json" : mediaType === "text/markdown" ? ".md" : undefined;
+    if (!extension) return runtimeUnavailable(`task-artifacts/v1 has no representation mapping for media type ${mediaType}.`);
+    const representationPath = path.join(outputRoot, "artifacts", `${artifactBasename(artifact.id)}${extension}`);
+    representations.push({
+      mediaType,
+      path: representationPath,
+      logicalPath: path.relative(rootDir, representationPath).split(path.sep).join("/")
+    });
+  }
+  return { ok: true, value: { id: artifact.id, schema: artifact.schema, required: artifact.required, representations } };
+}
+
+function artifactBasename(id: string): string {
+  if (id === "milestone-dossier-data") return "dossier.data";
+  if (id === "dogfood-utilization-report") return "dogfood-utilization-audit";
+  return id;
+}
+
+function remapWritableArtifacts(outputs: ReadonlyArray<WritableArtifact>, stage: CanonicalScriptStage): ReadonlyArray<WritableArtifact> {
+  return outputs.map((output) => ({
+    ...output,
+    representations: output.representations.map((entry) => ({
+      ...entry,
+      path: path.join(stage.outputRoot, path.relative(stage.realOutputRoot, entry.path))
+    }))
+  }));
+}
+
+function resolvedSemanticScope(candidates: ReadonlyArray<ScopeCandidate>): ResolvedScopeSet {
+  const byRoot = new Map<string, ScopeCandidate>();
+  for (const candidate of candidates) {
+    const absolute = path.resolve(candidate.root);
+    const existing = byRoot.get(absolute);
+    byRoot.set(absolute, { root: absolute, recursive: existing?.recursive === true || candidate.recursive });
+  }
+  const values = [...byRoot.values()];
+  return {
+    roots: values.map((candidate) => candidate.root),
+    permissions: uniquePermissionPaths(values.flatMap((candidate) => permissionPathsForScope(candidate.root, candidate.recursive)))
+  };
+}
+
+function providerRegistered(capability: string, direction: "requires" | "produces"): boolean {
+  return registeredSemanticPresetCapabilityProviders.some((provider) => provider.capability === capability && provider.version === "1" && provider.direction === direction);
+}
+
+function semanticPurpose(verb: SemanticScriptEntrypoint["intent"]["verb"]): ScriptEntry["metadata"]["purpose"] {
+  if (verb === "audit" || verb === "check") return "audit";
+  if (verb === "capture" || verb === "scaffold") return "scaffold";
+  if (verb === "transform") return "transform";
+  return "generate";
+}
+
+function isRuntimeRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function runtimeUnavailable(hint: string): { readonly ok: false; readonly hint: string } {
+  return { ok: false, hint };
+}

--- a/packages/cli/src/commands/extensions/preset-entrypoint-runtime.ts
+++ b/packages/cli/src/commands/extensions/preset-entrypoint-runtime.ts
@@ -1,0 +1,200 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { resolveHarnessLayout, taskPackagePath, type HarnessLayoutInput, type WriteOp } from "../../../../kernel/src/index.ts";
+import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
+import type { CliResult } from "../../cli/types.ts";
+import { semanticPresetScriptEntry } from "./preset-capability-runtime.ts";
+import { presetScriptAuthorizationRequiredResult } from "./preset-evidence.ts";
+import { runLegacyPresetScriptEntrypoint, scriptCliResult, type LegacyPresetScriptEntrypoint } from "./preset-script-runner.ts";
+import { presetRuntimeUnavailableResult } from "./preset-runtime-availability.ts";
+import { withPresetRuntimeWarning } from "./preset-runtime-mode.ts";
+import { runScriptHost } from "./script-host.ts";
+import {
+  discoverPresets,
+  isInvalidPreset,
+  presetNotFound,
+  publicPresetSummary,
+  resolvePresetEntry,
+  validatePresetManifestForUse,
+  validateRegistryKey
+} from "./state.ts";
+
+export function runPresetEntrypoint(
+  rootInput: HarnessLayoutInput,
+  verticalId: string,
+  presetId: string,
+  entrypoint: string,
+  taskId: string,
+  commandName: "preset-run" | "preset-action",
+  pendingOps: WriteOp[],
+  allowScripts = false,
+  inputs: Record<string, string> = {}
+): CliResult {
+  const layout = resolveHarnessLayout(rootInput);
+  const rootDir = layout.rootDir;
+  validateRegistryKey(taskId, "task");
+  const preset = resolvePresetEntry(rootInput, presetId, verticalId);
+  const runtimeUnavailable = presetRuntimeUnavailableResult({
+    rootInput,
+    commandName,
+    presetId,
+    taskId,
+    ...(preset && !isInvalidPreset(preset) ? { installedPreset: preset.manifest } : {})
+  });
+  if (runtimeUnavailable) return runtimeUnavailable;
+  if (!preset) return presetNotFound("preset-run", presetId);
+  if (isInvalidPreset(preset)) {
+    return {
+      ok: false,
+      command: commandName,
+      preset: { id: preset.id, layer: preset.layer, valid: false },
+      issues: preset.issues,
+      error: cliError(CliErrorCode.PresetManifestInvalid, "Preset manifest failed validation.")
+    };
+  }
+  const finish = (result: CliResult): CliResult => withPresetRuntimeWarning(result, preset.manifest);
+  const validation = validatePresetManifestForUse(preset.manifest);
+  if (!validation.ok) {
+    return {
+      ok: false,
+      command: commandName,
+      preset: publicPresetSummary(preset),
+      issues: validation.issues,
+      error: cliError(CliErrorCode.PresetManifestInvalid, "Preset manifest failed validation.")
+    };
+  }
+  const evidenceDir = path.join(layout.localRoot, "evidence", "presets", presetId, timestampForPath());
+  const generated: string[] = [];
+  const declaredEntrypoint = preset.manifest.entrypoints?.[entrypoint];
+  if (preset.manifest.schema === "preset-manifest/v3") {
+    const semanticEntrypoint = preset.manifest.entrypoints?.[entrypoint];
+    if (semanticEntrypoint?.type !== "script") {
+      return {
+        ok: false,
+        command: commandName,
+        preset: publicPresetSummary(preset),
+        error: cliError(CliErrorCode.PresetActionForbidden, `Preset ${presetId} does not declare executable action ${entrypoint}.`)
+      };
+    }
+    const presetSummary = publicPresetSummary(preset);
+    if (!allowScripts) {
+      mkdirSync(evidenceDir, { recursive: true });
+      return presetScriptAuthorizationRequiredResult({
+        rootDir,
+        evidenceDir,
+        commandName,
+        presetSummary,
+        presetId,
+        layer: preset.layer,
+        taskId,
+        entrypoint
+      });
+    }
+    const run = runScriptHost({
+      rootInput,
+      commandName,
+      script: {
+        ...semanticPresetScriptEntry({ ...preset, manifest: preset.manifest }, entrypoint, semanticEntrypoint),
+        context: {
+          presetId,
+          presetTitle: preset.manifest.title,
+          entrypoint,
+          taskId
+        }
+      },
+      inputs,
+      outputRoot: taskPackagePath(rootInput, taskId),
+      requireScriptResult: true
+    });
+    if (run.ingestOp) pendingOps.push(run.ingestOp);
+    if (!run.ok) {
+      return {
+        ...run.result,
+        command: commandName,
+        preset: presetSummary,
+        taskId
+      };
+    }
+    return {
+      ok: true,
+      command: commandName,
+      preset: presetSummary,
+      taskId,
+      runId: run.runId,
+      evidenceBundle: path.relative(rootDir, run.runDir).split(path.sep).join("/"),
+      generated: run.generated,
+      warnings: Array.isArray(run.scriptedResult.warnings) ? run.scriptedResult.warnings : undefined,
+      rows: typeof run.scriptedResult.rows === "number" ? run.scriptedResult.rows : undefined,
+      report: run.scriptedResult.report ?? run.scriptedResult,
+      capabilityReceipt: run.capabilityReceipt
+    };
+  }
+  if (declaredEntrypoint?.type === "script") {
+    mkdirSync(evidenceDir, { recursive: true });
+    if (!allowScripts) {
+      return finish(presetScriptAuthorizationRequiredResult({
+        rootDir,
+        evidenceDir,
+        commandName,
+        presetSummary: publicPresetSummary(preset),
+        presetId,
+        layer: preset.layer,
+        taskId,
+        entrypoint
+      }));
+    }
+    const presetSummary = publicPresetSummary(preset);
+    const legacyEntrypoint = declaredEntrypoint as LegacyPresetScriptEntrypoint;
+    const scriptResult = runLegacyPresetScriptEntrypoint(rootInput, preset, discoverPresets(rootInput, verticalId), presetSummary, legacyEntrypoint, entrypoint, taskId, evidenceDir, commandName, inputs);
+    if (!scriptResult.ok) return finish(scriptResult.result);
+    generated.push(...scriptResult.generated);
+    if (scriptResult.ingestOp) pendingOps.push(scriptResult.ingestOp);
+    if (scriptResult.scriptedResult) {
+      return finish(scriptCliResult({
+        rootDir,
+        evidenceDir,
+        commandName,
+        preset: presetSummary,
+        taskId,
+        generated,
+        scriptedResult: scriptResult.scriptedResult
+      }));
+    }
+  } else if (preset.manifest.schema === "preset-manifest/v1" && entrypoint === "scaffold") {
+    const outputPath = path.join(layout.generatedRoot, "preset-scaffold", taskId, `${presetId}.md`);
+    mkdirSync(path.dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, `# ${preset.manifest.title}\n\nTask: ${taskId}\n`, "utf8");
+    generated.push(path.relative(rootDir, outputPath).split(path.sep).join("/"));
+  } else {
+    return finish({
+      ok: false,
+      command: commandName,
+      preset: publicPresetSummary(preset),
+      error: cliError(CliErrorCode.PresetActionForbidden, `Preset ${presetId} does not declare action ${entrypoint}.`)
+    });
+  }
+  const evidence = {
+    schema: "preset-evidence/v1",
+    presetId,
+    layer: preset.layer,
+    taskId,
+    entrypoint,
+    generated,
+    ok: true,
+    scriptAuthorized: declaredEntrypoint?.type === "script" ? allowScripts : false
+  };
+  writeFileSync(path.join(evidenceDir, "evidence.json"), JSON.stringify(evidence, null, 2), "utf8");
+  return finish({
+    ok: true,
+    command: commandName,
+    preset: publicPresetSummary(preset),
+    taskId,
+    evidenceBundle: path.relative(rootDir, evidenceDir).split(path.sep).join("/"),
+    generated,
+    report: evidence
+  });
+}
+
+function timestampForPath(now: Date = new Date()): string {
+  return now.toISOString().replace(/[:.]/gu, "-");
+}

--- a/packages/cli/src/commands/extensions/preset-preflight.ts
+++ b/packages/cli/src/commands/extensions/preset-preflight.ts
@@ -11,6 +11,7 @@ import {
   type PresetRawFsGrant
 } from "../../../../kernel/src/index.ts";
 import { presetRuntimeRepairHint, smokePresetEntrypoints, type PresetEntrypointSmokeIssue } from "./preset-smoke.ts";
+import { registeredSemanticPresetCapabilityProviders } from "./preset-capability-runtime.ts";
 import type { ResolvedPreset } from "./state.ts";
 
 export interface PresetPackagePreflightReceipt extends PresetPreflightReceipt {
@@ -35,10 +36,6 @@ interface PresetPackageAdmissionOptions {
   readonly now?: string;
 }
 
-// Phase 0 intentionally registers no semantic execution provider. A v3 package
-// cannot be reported runnable until its projection/writer bindings land.
-const registeredSemanticProviders: ReadonlyArray<PresetCapabilityProvider> = [];
-
 export function preflightPresetPackage(
   rootInput: HarnessLayoutInput,
   preset: ResolvedPreset,
@@ -48,7 +45,7 @@ export function preflightPresetPackage(
     layer: preset.layer,
     packageDigest: digestPresetPackage(preset.sourcePath),
     now: admission.now ?? new Date().toISOString(),
-    providers: admission.providers ?? registeredSemanticProviders,
+    providers: admission.providers ?? registeredSemanticPresetCapabilityProviders,
     rawFsGrants: admission.rawFsGrants ?? [],
     rawFsEnforcement: admission.rawFsEnforcement ?? []
   });

--- a/packages/cli/src/commands/extensions/preset-runtime-mode.ts
+++ b/packages/cli/src/commands/extensions/preset-runtime-mode.ts
@@ -1,17 +1,7 @@
 import { legacyPhysicalScopeWarning, type PresetManifest } from "../../../../kernel/src/index.ts";
-import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
 
 export function withPresetRuntimeWarning(result: CliResult, manifest: PresetManifest): CliResult {
   if (manifest.schema === "preset-manifest/v3") return result;
   return { ...result, warnings: [...(result.warnings ?? []), legacyPhysicalScopeWarning(manifest.id)] };
-}
-
-export function semanticPresetRuntimeUnavailable(command: string, preset: unknown): CliResult {
-  return {
-    ok: false,
-    command,
-    preset,
-    error: cliError(CliErrorCode.PresetRuntimeUnavailable, "Preset v3 semantic capability execution is not registered in this Phase 0 runtime.")
-  };
 }

--- a/packages/cli/src/commands/extensions/preset-smoke.ts
+++ b/packages/cli/src/commands/extensions/preset-smoke.ts
@@ -4,7 +4,8 @@ import {
   isPresetRunEntrypoint,
   presetRunEntrypointCapabilities
 } from "../../cli/preset-entrypoint-capabilities.ts";
-import type { PresetManifestV3 } from "../../../../kernel/src/index.ts";
+import type { PresetInputV3, PresetManifestV3 } from "../../../../kernel/src/index.ts";
+import { semanticPresetScriptEntry } from "./preset-capability-runtime.ts";
 import { legacyPresetScriptEntry, type LegacyPresetScriptEntrypoint } from "./preset-script-runner.ts";
 import type { ResolvedPreset } from "./state.ts";
 import { runScriptHost, type ResolvedScriptEntry } from "./script-host.ts";
@@ -41,7 +42,7 @@ export function smokePresetEntrypoints(
 ): PresetEntrypointSmokeResult {
   const manifest = preset.manifest;
   if (manifest.schema === "preset-manifest/v3") {
-    return smokePresetV3Entrypoints(manifest);
+    return smokePresetV3Entrypoints(rootInput, preset, manifest);
   }
   const issues: PresetEntrypointSmokeIssue[] = [];
   const entrypoints = Object.entries(manifest.entrypoints ?? {}).map(([name, entrypoint]) => {
@@ -99,21 +100,74 @@ export function smokePresetEntrypoints(
   return { ok: issues.length === 0, entrypoints, issues };
 }
 
-function smokePresetV3Entrypoints(manifest: PresetManifestV3): PresetEntrypointSmokeResult {
-  const entrypoints = Object.entries(manifest.entrypoints ?? {}).map(([name, entrypoint]) => ({
-    name,
-    type: entrypoint.type,
-    ...(entrypoint.type === "script" ? { command: entrypoint.command } : {}),
-    ok: false
-  }));
-  const issues = entrypoints.map((entrypoint): PresetEntrypointSmokeIssue => ({
-    code: "preset_entrypoint_runtime_unregistered",
-    entrypoint: entrypoint.name,
-    path: `entrypoints.${entrypoint.name}`,
-    message: `Entrypoint ${entrypoint.name} uses preset-manifest/v3 semantic capabilities, but the semantic script host is not registered in this Phase 0 runtime.`,
-    nextCommand: `ha preset check ${manifest.id} --json`
-  }));
+function smokePresetV3Entrypoints(
+  rootInput: HarnessLayoutInput,
+  preset: ResolvedPreset,
+  manifest: PresetManifestV3
+): PresetEntrypointSmokeResult {
+  const issues: PresetEntrypointSmokeIssue[] = [];
+  const semanticPreset = { ...preset, manifest };
+  const entrypoints = Object.entries(manifest.entrypoints ?? {}).map(([name, entrypoint]) => {
+    if (!isPresetRunEntrypoint(name)) {
+      issues.push(entrypointCapabilityUnregisteredIssue(preset, name, entrypoint.type));
+      return entrypoint.type === "script"
+        ? { name, type: entrypoint.type, command: entrypoint.command, ok: false }
+        : { name, type: entrypoint.type, ok: false };
+    }
+    if (entrypoint.type !== "script") {
+      issues.push(runtimeUnregisteredIssue(preset, name, entrypoint.type));
+      return { name, type: entrypoint.type, ok: false };
+    }
+    const taskId = `task_PRESET_CHECK_${safeToken(manifest.id)}`;
+    const smoke = runScriptHost({
+      rootInput,
+      commandName: "preset-check",
+      script: {
+        ...semanticPresetScriptEntry(semanticPreset, name, entrypoint),
+        context: {
+          presetId: manifest.id,
+          presetTitle: manifest.title,
+          entrypoint: name,
+          taskId,
+          validationSmoke: true
+        }
+      },
+      inputs: syntheticSmokeInputs(entrypoint.inputs),
+      outputRoot: taskPackagePath(rootInput, taskId),
+      dryRun: true,
+      allowFailedScriptResult: true,
+      requireScriptResult: true
+    });
+    if (!smoke.ok) {
+      const error = smoke.result.error;
+      issues.push({
+        code: error?.code === "script_not_found"
+          ? "preset_entrypoint_script_missing"
+          : error?.code === "preset_runtime_unavailable"
+            ? "preset_entrypoint_runtime_unregistered"
+            : "preset_entrypoint_smoke_failed",
+        entrypoint: name,
+        path: `entrypoints.${name}${error?.code === "script_not_found" ? ".command" : ""}`,
+        message: `Entrypoint ${name} failed its semantic startup smoke: ${error?.hint ?? "unknown runtime failure"}`,
+        nextCommand: error?.code === "script_not_found" ? repairCommand(preset) : smokeReproductionCommand(preset)
+      });
+    }
+    return { name, type: entrypoint.type, command: entrypoint.command, ok: smoke.ok };
+  });
   return { ok: issues.length === 0, entrypoints, issues };
+}
+
+function syntheticSmokeInputs(inputs: Readonly<Record<string, PresetInputV3>>): Record<string, string> {
+  return Object.fromEntries(Object.entries(inputs).flatMap(([name, input]) => {
+    if ("default" in input || "defaultFrom" in input) return [];
+    if (!input.required) return [];
+    if (input.type === "boolean") return [[name, "false"]];
+    if (input.type === "integer") return [[name, "0"]];
+    if (input.type === "enum" || input.type === "enum-list") return [[name, input.values[0] ?? ""]];
+    if (input.type === "decision-ref") return [[name, "dec_PRESET_CHECK"]];
+    if (input.type === "task-ref") return [[name, "task_PRESET_CHECK"]];
+    return [[name, "preset-check"]];
+  }));
 }
 
 function entrypointCapabilityUnregisteredIssue(

--- a/packages/cli/src/commands/extensions/preset.ts
+++ b/packages/cli/src/commands/extensions/preset.ts
@@ -11,9 +11,9 @@ import {
   presetNotFound,
   publicPresetSummary,
   resolvePresetEntry,
-  runPresetEntrypoint,
   validatePresetManifestForUse
 } from "./state.ts";
+import { runPresetEntrypoint } from "./preset-entrypoint-runtime.ts";
 import { invalidResolvedPresetResult } from "./shared.ts";
 import { buildPresetUninstallImpact } from "./preset-uninstall-impact.ts";
 import { readPresetManifestFromSourceResult } from "./preset-manifest-reader.ts";

--- a/packages/cli/src/commands/extensions/script-host-result.ts
+++ b/packages/cli/src/commands/extensions/script-host-result.ts
@@ -1,0 +1,23 @@
+import path from "node:path";
+import type { CliResult } from "../../cli/types.ts";
+import type { ScriptHostSuccess } from "./script-host.ts";
+
+export function scriptHostCliResult(options: {
+  readonly rootDir: string;
+  readonly commandName: string;
+  readonly script: unknown;
+  readonly run: ScriptHostSuccess;
+}): CliResult {
+  return {
+    ok: true,
+    command: options.commandName,
+    script: options.script,
+    runId: options.run.runId,
+    evidenceBundle: path.relative(options.rootDir, options.run.runDir).split(path.sep).join("/"),
+    generated: options.run.generated,
+    warnings: Array.isArray(options.run.scriptedResult.warnings) ? options.run.scriptedResult.warnings : undefined,
+    rows: typeof options.run.scriptedResult.rows === "number" ? options.run.scriptedResult.rows : undefined,
+    report: options.run.scriptedResult.report ?? options.run.scriptedResult,
+    ...(options.run.capabilityReceipt ? { capabilityReceipt: options.run.capabilityReceipt } : {})
+  };
+}

--- a/packages/cli/src/commands/extensions/script-host-validation.ts
+++ b/packages/cli/src/commands/extensions/script-host-validation.ts
@@ -1,0 +1,48 @@
+import path from "node:path";
+import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
+import type { CliResult } from "../../cli/types.ts";
+import type { PresetPolicyResolution } from "./preset-policy.ts";
+import type { ResolvedScriptEntry } from "./script-host.ts";
+
+export function validateResolvedScript(script: ResolvedScriptEntry): { readonly ok: true } | { readonly ok: false; readonly hint: string } {
+  const entry = script.entry;
+  if (entry.type !== "script") return { ok: false, hint: "Script entry type must be script." };
+  if (!entry.id || !entry.command) return { ok: false, hint: "Script entry id and command are required." };
+  if (!["user", "vertical", "preset"].includes(entry.source)) return { ok: false, hint: "Script source is invalid." };
+  if (entry.metadata.contractVersion !== "script-entry/v1") return { ok: false, hint: "Script metadata contractVersion must be script-entry/v1." };
+  if (!entry.metadata.description || !entry.metadata.purpose || !Array.isArray(entry.metadata.produces)) {
+    return { ok: false, hint: "Script metadata description, purpose, and produces are required." };
+  }
+  if (entry.metadata.kind !== undefined && !["action", "check"].includes(entry.metadata.kind)) {
+    return { ok: false, hint: "Script metadata kind must be action or check." };
+  }
+  return { ok: true };
+}
+
+export function invalidScriptOrPolicy(
+  command: string,
+  validation: { readonly ok: true } | { readonly ok: false; readonly hint: string },
+  policy: PresetPolicyResolution
+): { readonly ok: false; readonly result: CliResult } {
+  if (!validation.ok) return scriptFailure(command, CliErrorCode.ScriptContractInvalid, validation.hint);
+  if (!policy.ok) return scriptFailure(command, CliErrorCode.PresetPolicyInvalid, policy.error.hint);
+  throw new Error("Script and policy validation unexpectedly succeeded.");
+}
+
+export function scriptFailure(
+  command: string,
+  failureCode: CliErrorCode,
+  hint: string,
+  runDir?: string,
+  rootDir?: string
+): { readonly ok: false; readonly result: CliResult } {
+  return {
+    ok: false,
+    result: {
+      ok: false,
+      command,
+      evidenceBundle: runDir && rootDir ? path.relative(rootDir, runDir).split(path.sep).join("/") : undefined,
+      error: cliError(failureCode, hint)
+    }
+  };
+}

--- a/packages/cli/src/commands/extensions/script-host.ts
+++ b/packages/cli/src/commands/extensions/script-host.ts
@@ -5,14 +5,22 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { HarnessLayoutInput, WriteOp } from "../../../../kernel/src/index.ts";
 import { resolveHarnessLayout } from "../../../../kernel/src/index.ts";
-import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
+import { CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
-import { resolveScriptPolicy, type PresetPolicyResolution } from "./preset-policy.ts";
+import { resolveScriptPolicy } from "./preset-policy.ts";
 import { buildPresetContextProjections } from "./preset-script-context.ts";
 import { scriptChildEnvironment, type ScriptEnvironmentCapabilities } from "./script-environment.ts";
 import { executeScript } from "./script-executor.ts";
 import { trustedScriptRepositoryContext } from "./script-repository-context.ts";
+import { invalidScriptOrPolicy, scriptFailure, validateResolvedScript } from "./script-host-validation.ts";
 import { discoverPresets } from "./state.ts";
+import {
+  materializeSemanticPresetExecution,
+  prepareSemanticPresetExecution,
+  verifySemanticPresetOutputs,
+  type PresetCapabilityRuntimeReceipt,
+  type SemanticPresetExecution
+} from "./preset-capability-runtime.ts";
 import {
   isPathInside,
   permissionPathsForScope,
@@ -41,7 +49,7 @@ export interface ScriptEntry {
   readonly command: string;
   readonly reads: ReadonlyArray<string>;
   readonly writes: ReadonlyArray<string>;
-  readonly inputs: Record<string, string>;
+  readonly inputs: Record<string, unknown>;
   readonly metadata: {
     readonly description: string;
     readonly purpose: ScriptPurpose;
@@ -59,6 +67,7 @@ export interface ResolvedScriptEntry {
   readonly context?: Record<string, unknown>;
   readonly environmentCapabilities?: ScriptEnvironmentCapabilities;
   readonly trustedPackageReadPermissions?: ReadonlyArray<string>;
+  readonly semantic?: SemanticPresetExecution;
 }
 
 export interface ScriptHostSuccess {
@@ -67,6 +76,7 @@ export interface ScriptHostSuccess {
   readonly runDir: string;
   readonly generated: ReadonlyArray<string>;
   readonly scriptedResult: Record<string, unknown>;
+  readonly capabilityReceipt?: PresetCapabilityRuntimeReceipt;
   readonly ingestOp?: WriteOp;
 }
 
@@ -117,20 +127,40 @@ export function runScriptHost(options: {
     );
   }
 
-  const outputRoot = options.outputRoot ?? path.join(layout.authoredRoot, "context");
+  const fallbackOutputRoot = options.outputRoot ?? path.join(layout.authoredRoot, "context");
+  const semanticPreparation = options.script.semantic
+    ? prepareSemanticPresetExecution({
+      rootInput: options.rootInput,
+      execution: options.script.semantic,
+      taskId: typeof options.script.context?.taskId === "string" ? options.script.context.taskId : undefined,
+      runtimeInputs: options.inputs,
+      fallbackOutputRoot,
+      dryRun: options.dryRun
+    })
+    : undefined;
+  if (semanticPreparation && !semanticPreparation.ok) {
+    return scriptFailure(options.commandName, CliErrorCode.PresetRuntimeUnavailable, semanticPreparation.hint);
+  }
+  const preparedSemantic = semanticPreparation?.ok ? semanticPreparation.value : undefined;
+  const outputRoot = preparedSemantic?.outputRoot ?? fallbackOutputRoot;
   const scopeOptions = reportsNoOverwriteLeafConflicts(options.script.entry)
     ? { reportLeafConflicts: true as const }
     : {};
-  const readScope = options.script.entry.reads.length > 0
-    ? resolveDeclaredReadScopes(options.script.entry.reads, layout, outputRoot, scopeOptions)
-    : { ok: true as const, roots: [], permissions: [] };
-  const writeScope = resolveDeclaredWriteScopes(options.script.entry.writes, layout, outputRoot, scopeOptions);
+  const readScope = preparedSemantic
+    ? { ok: true as const, ...preparedSemantic.protectedSourceScopes }
+    : options.script.entry.reads.length > 0
+      ? resolveDeclaredReadScopes(options.script.entry.reads, layout, outputRoot, scopeOptions)
+      : { ok: true as const, roots: [], permissions: [] };
+  const writeScope = preparedSemantic
+    ? { ok: true as const, ...preparedSemantic.stageEnvelope }
+    : resolveDeclaredWriteScopes(options.script.entry.writes, layout, outputRoot, scopeOptions);
   if (!readScope.ok) return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidRead, "Script reads must declare supported project-local scopes.");
-  if (!resolvedScopeSetIsSafe(readScope, layout.rootDir, "read")) {
+  if (!options.dryRun && !resolvedScopeSetIsSafe(readScope, layout.rootDir, "read")) {
     return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidRead, "Script read scopes must have safe filesystem boundaries.");
   }
   if (!writeScope.ok) return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidWrite, "Script writes must declare approved authored content scopes.");
   if (
+    !preparedSemantic &&
     options.script.entry.source === "preset" &&
     options.outputRoot !== undefined &&
     options.script.entry.writes.length > 0 &&
@@ -182,45 +212,75 @@ export function runScriptHost(options: {
     return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidWrite, "Script staging scopes could not be resolved.");
   }
 
-  const mergedInputs = { ...options.script.entry.inputs, ...(options.inputs ?? {}) };
-  const presetContextProjections = options.script.entry.source === "preset"
-    ? buildPresetContextProjections({
-      layout: executionLayout,
-      outputRoot: executionOutputRoot,
-      readRoots: executionReadScope.roots
+  const semanticMaterialization = preparedSemantic && !options.dryRun
+    ? materializeSemanticPresetExecution({
+      rootInput: options.rootInput,
+      preparation: preparedSemantic,
+      stage,
+      runDir,
+      runId,
+      resultPath
     })
-    : {};
-  writeFileSync(contextPath, JSON.stringify({
-    ...(options.script.context ?? {}),
-    ...presetContextProjections,
-    schema: options.script.entry.source === "preset" ? "preset-context/v1" : "script-context/v1",
-    scriptId: options.script.entry.id,
-    source: options.script.entry.source,
-    runId,
-    paths: {
-      projectRoot: layout.rootDir,
-      rootDir: executionLayout.rootDir,
-      authoredRoot: executionLayout.authoredRoot,
-      tasksRoot: executionLayout.tasksRoot,
-      decisionsRoot: executionLayout.decisionsRoot,
-      sessionsRoot: executionLayout.sessionsRoot,
-      adrRoot: executionLayout.adrRoot,
-      milestonesRoot: executionLayout.milestonesRoot,
-      generatedRoot: executionLayout.generatedRoot,
-      localRoot: executionLayout.localRoot
-    },
-    repository: trustedScriptRepositoryContext(layout.rootDir),
-    inputs: mergedInputs,
-    readScopes: executionReadScope.roots,
-    writeScopes: executionWriteScope.roots,
-    declaredScopeConflicts: {
-      read: executionReadScope.reportedLeafConflicts ?? [],
-      write: executionWriteScope.reportedLeafConflicts ?? []
-    },
-    resultPath,
-    outputRoot: executionOutputRoot,
-    policy: policy.policy
-  }, null, 2), "utf8");
+    : undefined;
+  if (semanticMaterialization && !semanticMaterialization.ok) {
+    return scriptFailure(options.commandName, CliErrorCode.PresetRuntimeUnavailable, semanticMaterialization.hint, runDir, layout.rootDir);
+  }
+  const materializedSemantic = semanticMaterialization?.ok ? semanticMaterialization.value : undefined;
+  if (preparedSemantic) {
+    writeFileSync(contextPath, JSON.stringify(materializedSemantic?.context ?? {
+      schema: "preset-context/v2",
+      preset: {
+        id: preparedSemantic.execution.preset.manifest.id,
+        version: preparedSemantic.execution.preset.manifest.version,
+        entrypoint: preparedSemantic.execution.entrypointName
+      },
+      run: { id: runId, taskId: preparedSemantic.currentTaskId, dryRun: true },
+      inputs: preparedSemantic.inputs,
+      capabilities: { reads: {}, writes: {} },
+      result: { schema: "script-result/v1", path: resultPath },
+      receipt: preparedSemantic.receipt
+    }, null, 2), "utf8");
+  } else {
+    const mergedInputs = { ...options.script.entry.inputs, ...(options.inputs ?? {}) };
+    const presetContextProjections = options.script.entry.source === "preset"
+      ? buildPresetContextProjections({
+        layout: executionLayout,
+        outputRoot: executionOutputRoot,
+        readRoots: executionReadScope.roots
+      })
+      : {};
+    writeFileSync(contextPath, JSON.stringify({
+      ...(options.script.context ?? {}),
+      ...presetContextProjections,
+      schema: options.script.entry.source === "preset" ? "preset-context/v1" : "script-context/v1",
+      scriptId: options.script.entry.id,
+      source: options.script.entry.source,
+      runId,
+      paths: {
+        projectRoot: layout.rootDir,
+        rootDir: executionLayout.rootDir,
+        authoredRoot: executionLayout.authoredRoot,
+        tasksRoot: executionLayout.tasksRoot,
+        decisionsRoot: executionLayout.decisionsRoot,
+        sessionsRoot: executionLayout.sessionsRoot,
+        adrRoot: executionLayout.adrRoot,
+        milestonesRoot: executionLayout.milestonesRoot,
+        generatedRoot: executionLayout.generatedRoot,
+        localRoot: executionLayout.localRoot
+      },
+      repository: trustedScriptRepositoryContext(layout.rootDir),
+      inputs: mergedInputs,
+      readScopes: executionReadScope.roots,
+      writeScopes: executionWriteScope.roots,
+      declaredScopeConflicts: {
+        read: executionReadScope.reportedLeafConflicts ?? [],
+        write: executionWriteScope.reportedLeafConflicts ?? []
+      },
+      resultPath,
+      outputRoot: executionOutputRoot,
+      policy: policy.policy
+    }, null, 2), "utf8");
+  }
 
   if (options.dryRun) {
     return {
@@ -266,20 +326,24 @@ export function runScriptHost(options: {
       contextPath,
       ...checkScriptPackageReadPermissions(options.script.entry.metadata.kind, options.script.manifestRoot, scriptPath, layout),
       ...architectureToolPackageReadPermissions(options.script, scriptPath, layout),
-      ...executionReadScope.permissions
+      ...(materializedSemantic?.childReadPermissions ?? executionReadScope.permissions)
     ],
     writePermissions: [
       resultPath,
-      ...executionWriteScope.permissions,
-      ...checkScriptLocalWritePermissions(options.script.entry.metadata.kind, layout)
+      ...(materializedSemantic?.childWritePermissions ?? executionWriteScope.permissions),
+      ...(preparedSemantic ? [] : checkScriptLocalWritePermissions(options.script.entry.metadata.kind, layout))
     ],
     env: scriptChildEnvironment({
       HARNESS_SCRIPT_CONTEXT: contextPath,
       HARNESS_SCRIPT_RESULT: resultPath,
       HARNESS_PRESET_CONTEXT: contextPath
     }, options.script.environmentCapabilities),
-    artifactRoots: executionWriteScope.roots,
-    outputBoundary: { kind: "patterns", patterns: options.script.entry.metadata.produces, substitutions: producePatternSubstitutions(executionLayout, executionOutputRoot) }
+    artifactRoots: materializedSemantic?.writerRoots ?? executionWriteScope.roots,
+    outputBoundary: {
+      kind: "patterns",
+      patterns: materializedSemantic?.outputPatterns ?? options.script.entry.metadata.produces,
+      substitutions: materializedSemantic ? {} : producePatternSubstitutions(executionLayout, executionOutputRoot)
+    }
   });
   writeFileSync(path.join(runDir, "stdout.txt"), execution.stdout, "utf8");
   writeFileSync(path.join(runDir, "stderr.txt"), execution.stderr, "utf8");
@@ -310,6 +374,13 @@ export function runScriptHost(options: {
     );
   }
 
+  if (materializedSemantic) {
+    const outputVerification = verifySemanticPresetOutputs(materializedSemantic.outputs);
+    if (!outputVerification.ok) {
+      return scriptFailure(options.commandName, CliErrorCode.ScriptDeclaredProduceMismatch, outputVerification.hint, runDir, layout.rootDir);
+    }
+  }
+
   const scriptedResult = readScriptResult(resultPath, options.script.entry.source === "preset" ? path.join(executionOutputRoot, "artifacts", "preset-result.json") : undefined, {
     allowMissingPresetResult: options.script.entry.source === "preset" && options.requireScriptResult !== true,
     scriptId: options.script.entry.id
@@ -329,7 +400,7 @@ export function runScriptHost(options: {
     );
   }
   const generatedPaths = stage ? canonicalGeneratedPaths(stage, execution.generated) : execution.generated;
-  const ingestOp = stage ? scriptIngestOp(stage, executionWriteScope.roots, runId) : undefined;
+  const ingestOp = stage ? scriptIngestOp(stage, materializedSemantic?.writerRoots ?? executionWriteScope.roots, runId) : undefined;
   const canonicalResult = stage ? canonicalizeScriptResult(stage, scriptedResult.value) : scriptedResult.value;
   if (scriptedResult.value.ok !== true && options.allowFailedScriptResult !== true) {
     const failure = scriptFailure(options.commandName, CliErrorCode.ScriptResultFailed, "Script reported a failed result.", runDir, layout.rootDir);
@@ -355,6 +426,7 @@ export function runScriptHost(options: {
     runDir,
     generated: generatedPaths.map((filePath) => relativeToRoot(layout.rootDir, filePath)),
     scriptedResult: canonicalResult,
+    ...(preparedSemantic ? { capabilityReceipt: preparedSemantic.receipt } : {}),
     ...(ingestOp ? { ingestOp } : {})
   };
 }
@@ -363,62 +435,6 @@ function reportsNoOverwriteLeafConflicts(entry: ScriptEntry): boolean {
   return entry.metadata.purpose === "scaffold" &&
     entry.writes.length > 0 &&
     entry.writes.every((scope) => scope.endsWith("/**") && entry.reads.includes(scope));
-}
-
-export function scriptHostCliResult(options: {
-  readonly rootDir: string;
-  readonly commandName: string;
-  readonly script: unknown;
-  readonly run: ScriptHostSuccess;
-}): CliResult {
-  return {
-    ok: true,
-    command: options.commandName,
-    script: options.script,
-    runId: options.run.runId,
-    evidenceBundle: relativeToRoot(options.rootDir, options.run.runDir),
-    generated: options.run.generated,
-    warnings: Array.isArray(options.run.scriptedResult.warnings) ? options.run.scriptedResult.warnings : undefined,
-    rows: typeof options.run.scriptedResult.rows === "number" ? options.run.scriptedResult.rows : undefined,
-    report: options.run.scriptedResult.report ?? options.run.scriptedResult
-  };
-}
-
-function validateResolvedScript(script: ResolvedScriptEntry): { readonly ok: true } | { readonly ok: false; readonly hint: string } {
-  const entry = script.entry;
-  if (entry.type !== "script") return { ok: false, hint: "Script entry type must be script." };
-  if (!entry.id || !entry.command) return { ok: false, hint: "Script entry id and command are required." };
-  if (!["user", "vertical", "preset"].includes(entry.source)) return { ok: false, hint: "Script source is invalid." };
-  if (entry.metadata.contractVersion !== "script-entry/v1") return { ok: false, hint: "Script metadata contractVersion must be script-entry/v1." };
-  if (!entry.metadata.description || !entry.metadata.purpose || !Array.isArray(entry.metadata.produces)) {
-    return { ok: false, hint: "Script metadata description, purpose, and produces are required." };
-  }
-  if (entry.metadata.kind !== undefined && !["action", "check"].includes(entry.metadata.kind)) {
-    return { ok: false, hint: "Script metadata kind must be action or check." };
-  }
-  return { ok: true };
-}
-
-function invalidScriptOrPolicy(
-  command: string,
-  validation: { readonly ok: true } | { readonly ok: false; readonly hint: string },
-  policy: PresetPolicyResolution
-): { readonly ok: false; readonly result: CliResult } {
-  if (!validation.ok) return scriptFailure(command, CliErrorCode.ScriptContractInvalid, validation.hint);
-  if (!policy.ok) return scriptFailure(command, policy.error.code, policy.error.hint);
-  throw new Error("Script and policy validation unexpectedly succeeded.");
-}
-
-function scriptFailure(command: string, code: CliErrorCode, hint: string, runDir?: string, rootDir?: string): { readonly ok: false; readonly result: CliResult } {
-  return {
-    ok: false,
-    result: {
-      ok: false,
-      command,
-      evidenceBundle: runDir && rootDir ? relativeToRoot(rootDir, runDir) : undefined,
-      error: cliError(code, hint)
-    }
-  };
 }
 
 function readScriptResult(

--- a/packages/cli/src/commands/extensions/script.ts
+++ b/packages/cli/src/commands/extensions/script.ts
@@ -7,8 +7,10 @@ import type { CliResult, ParsedCommand } from "../../cli/types.ts";
 import { resolveActiveVertical } from "./active-vertical.ts";
 import { discoverPresets, publicPresetSummary } from "./state.ts";
 import { legacyPresetScriptEntry } from "./preset-script-runner.ts";
+import { semanticPresetScriptEntry } from "./preset-capability-runtime.ts";
 import { trustedPresetEnvironmentCapabilities, trustedPresetPackageReadPermissions } from "./script-environment.ts";
-import { runScriptHost, scriptHostCliResult, type ResolvedScriptEntry, type ScriptKind, type ScriptPurpose, type ScriptSource } from "./script-host.ts";
+import { runScriptHost, type ResolvedScriptEntry, type ScriptKind, type ScriptPurpose, type ScriptSource } from "./script-host.ts";
+import { scriptHostCliResult } from "./script-host-result.ts";
 
 type ScriptAction = Extract<ParsedCommand["action"], {
   readonly kind: "script-list" | "script-inspect" | "script-run";
@@ -108,6 +110,10 @@ function runScriptRun(rootInput: HarnessLayoutInput, action: Extract<ScriptActio
 }
 
 function scriptUsesTaskOwnedArtifacts(script: ResolvedScriptEntry): boolean {
+  if (script.semantic) {
+    return [...script.semantic.entrypoint.requires, ...script.semantic.entrypoint.produces]
+      .some((request) => request.capability === "task-artifacts" || request.capability === "tasks");
+  }
   return [
     ...script.entry.reads,
     ...script.entry.writes,
@@ -142,10 +148,13 @@ export function discoverScriptEntries(
     } : undefined
   }));
   const presetScripts = discoverPresets(rootInput, activeVertical.id)
-    .filter((preset) => preset.manifest.schema !== "preset-manifest/v3")
     .flatMap((preset) => Object.entries(preset.manifest.entrypoints ?? {})
-      .flatMap(([entrypointName, entrypoint]) => entrypoint.type === "script"
-        ? [{
+      .flatMap(([entrypointName, entrypoint]) => {
+        if (entrypoint.type !== "script") return [];
+        if (preset.manifest.schema === "preset-manifest/v3") {
+          return [semanticPresetScriptEntry({ ...preset, manifest: preset.manifest }, entrypointName, entrypoint)];
+        }
+        return [{
           entry: legacyPresetScriptEntry(preset, entrypoint, entrypointName),
           verticalId: activeVertical.id,
           manifestRoot: path.dirname(preset.sourcePath),
@@ -169,8 +178,8 @@ export function discoverScriptEntries(
             presetTitle: preset.manifest.title,
             entrypoint: entrypointName
           }
-        }]
-        : []));
+        }];
+      }));
   return {
     ok: true,
     scripts: [...verticalScripts, ...presetScripts].sort((left, right) => left.entry.id.localeCompare(right.entry.id))
@@ -193,6 +202,19 @@ function publicScriptSummary(script: ResolvedScriptEntry): Record<string, unknow
 }
 
 function publicScriptDetails(script: ResolvedScriptEntry): Record<string, unknown> {
+  if (script.semantic) {
+    return {
+      ...publicScriptSummary(script),
+      command: script.entry.command,
+      intent: script.semantic.entrypoint.intent,
+      inputs: script.semantic.entrypoint.inputs,
+      requires: script.semantic.entrypoint.requires,
+      produces: script.semantic.entrypoint.produces,
+      sideEffects: script.semantic.entrypoint.sideEffects,
+      metadata: script.entry.metadata,
+      owner: script.owner
+    };
+  }
   return {
     ...publicScriptSummary(script),
     command: script.entry.command,

--- a/packages/cli/src/commands/extensions/state.ts
+++ b/packages/cli/src/commands/extensions/state.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Effect, Schema } from "effect";
@@ -12,7 +12,7 @@ import {
   type WriteError,
   type MaterializedTemplatePlan
 } from "../../../../kernel/src/index.ts";
-import type { HarnessLayoutInput, WriteOp } from "../../../../kernel/src/index.ts";
+import type { HarnessLayoutInput } from "../../../../kernel/src/index.ts";
 import { normalizeRelativeDocumentPath, resolveHarnessLayout } from "../../../../kernel/src/index.ts";
 import type { WriteCoordinator } from "../../../../kernel/src/index.ts";
 import { stablePayloadHash, writeCoordinatedPayload } from "../../../../kernel/src/write-coordination/write-helpers.ts";
@@ -24,10 +24,6 @@ import {
   loadBundledPresetManifestEntries
 } from "./bundled.ts";
 import { writeModuleRegistryView } from "./module-registry-view.ts";
-import { presetScriptAuthorizationRequiredResult } from "./preset-evidence.ts";
-import { runLegacyPresetScriptEntrypoint, scriptCliResult, type LegacyPresetScriptEntrypoint } from "./preset-script-runner.ts";
-import { presetRuntimeUnavailableResult } from "./preset-runtime-availability.ts";
-import { semanticPresetRuntimeUnavailable, withPresetRuntimeWarning } from "./preset-runtime-mode.ts";
 import { resolveTemplateCatalogBody } from "./template-catalog-loader.ts";
 import { decodePresetManifestFileResult } from "./preset-manifest-reader.ts";
 import { loadPresetDocument, type PresetDocumentWarning } from "./preset-document-loader.ts";
@@ -290,121 +286,6 @@ export function presetManifestPath(rootInput: HarnessLayoutInput, layer: "projec
   return path.join(presetLayerRoot(rootInput, layer), presetId, "preset.json");
 }
 
-export function runPresetEntrypoint(
-  rootInput: HarnessLayoutInput,
-  verticalId: string,
-  presetId: string,
-  entrypoint: string,
-  taskId: string,
-  commandName: "preset-run" | "preset-action",
-  pendingOps: WriteOp[],
-  allowScripts = false,
-  inputs: Record<string, string> = {}
-): CliResult {
-  const layout = resolveHarnessLayout(rootInput);
-  const rootDir = layout.rootDir;
-  validateRegistryKey(taskId, "task");
-  const preset = resolvePresetEntry(rootInput, presetId, verticalId);
-  const runtimeUnavailable = presetRuntimeUnavailableResult({
-    rootInput,
-    commandName,
-    presetId,
-    taskId,
-    ...(preset && !isInvalidPreset(preset) ? { installedPreset: preset.manifest } : {})
-  });
-  if (runtimeUnavailable) return runtimeUnavailable;
-  if (!preset) return presetNotFound("preset-run", presetId);
-  if (isInvalidPreset(preset)) {
-    return {
-      ok: false,
-      command: commandName,
-      preset: { id: preset.id, layer: preset.layer, valid: false },
-      issues: preset.issues,
-      error: cliError(CliErrorCode.PresetManifestInvalid, "Preset manifest failed validation.")
-    };
-  }
-  const finish = (result: CliResult): CliResult => withPresetRuntimeWarning(result, preset.manifest);
-  const validation = validatePresetManifestForUse(preset.manifest);
-  if (!validation.ok) {
-    return {
-      ok: false,
-      command: commandName,
-      preset: publicPresetSummary(preset),
-      issues: validation.issues,
-      error: cliError(CliErrorCode.PresetManifestInvalid, "Preset manifest failed validation.")
-    };
-  }
-  const evidenceDir = path.join(layout.localRoot, "evidence", "presets", presetId, timestampForPath());
-  mkdirSync(evidenceDir, { recursive: true });
-  const generated: string[] = [];
-  const declaredEntrypoint = preset.manifest.entrypoints?.[entrypoint];
-  if (preset.manifest.schema === "preset-manifest/v3" && declaredEntrypoint) {
-    return semanticPresetRuntimeUnavailable(commandName, publicPresetSummary(preset));
-  }
-  if (declaredEntrypoint?.type === "script") {
-    if (!allowScripts) {
-      return finish(presetScriptAuthorizationRequiredResult({
-        rootDir,
-        evidenceDir,
-        commandName,
-        presetSummary: publicPresetSummary(preset),
-        presetId,
-        layer: preset.layer,
-        taskId,
-        entrypoint
-      }));
-    }
-    const presetSummary = publicPresetSummary(preset);
-    const legacyEntrypoint = declaredEntrypoint as LegacyPresetScriptEntrypoint;
-    const scriptResult = runLegacyPresetScriptEntrypoint(rootInput, preset, discoverPresets(rootInput, verticalId), presetSummary, legacyEntrypoint, entrypoint, taskId, evidenceDir, commandName, inputs);
-    if (!scriptResult.ok) return finish(scriptResult.result);
-    generated.push(...scriptResult.generated);
-    if (scriptResult.ingestOp) pendingOps.push(scriptResult.ingestOp);
-    if (scriptResult.scriptedResult) {
-      return finish(scriptCliResult({
-        rootDir,
-        evidenceDir,
-        commandName,
-        preset: presetSummary,
-        taskId,
-        generated,
-        scriptedResult: scriptResult.scriptedResult
-      }));
-    }
-  } else if (preset.manifest.schema === "preset-manifest/v1" && entrypoint === "scaffold") {
-    const outputPath = path.join(layout.generatedRoot, "preset-scaffold", taskId, `${presetId}.md`);
-    mkdirSync(path.dirname(outputPath), { recursive: true });
-    writeFileSync(outputPath, `# ${preset.manifest.title}\n\nTask: ${taskId}\n`, "utf8");
-    generated.push(path.relative(rootDir, outputPath).split(path.sep).join("/"));
-  } else {
-    return finish({
-      ok: false,
-      command: commandName,
-      preset: publicPresetSummary(preset),
-      error: cliError(CliErrorCode.PresetActionForbidden, `Preset ${presetId} does not declare action ${entrypoint}.`)
-    });
-  }
-  const evidence = {
-    schema: "preset-evidence/v1",
-    presetId,
-    layer: preset.layer,
-    taskId,
-    entrypoint,
-    generated,
-    ok: true,
-    scriptAuthorized: declaredEntrypoint?.type === "script" ? allowScripts : false
-  };
-  writeFileSync(path.join(evidenceDir, "evidence.json"), JSON.stringify(evidence, null, 2), "utf8");
-  return finish({
-    ok: true,
-    command: commandName,
-    preset: publicPresetSummary(preset),
-    taskId,
-    evidenceBundle: path.relative(rootDir, evidenceDir).split(path.sep).join("/"),
-    generated,
-    report: evidence
-  });
-}
 
 export function readModules(rootInput: HarnessLayoutInput): ModuleRegistry {
   const registryPath = modulesRegistryPath(rootInput);
@@ -470,14 +351,10 @@ export class InvalidRegistryKeyError extends Error {
   }
 }
 
-function validateRegistryKey(value: string, label: string): void {
+export function validateRegistryKey(value: string, label: string): void {
   if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/u.test(value)) {
     throw new InvalidRegistryKeyError(label);
   }
-}
-
-function timestampForPath(now: Date = new Date()): string {
-  return now.toISOString().replace(/[:.]/gu, "-");
 }
 
 function validateAdditiveSoftwareCodingPreset(manifest: PresetManifest): ReadonlyArray<ExtensionValidationIssue> {

--- a/packages/cli/test/fixtures/preset-v3-canaries/doc-canon-sync/v2/preset.json
+++ b/packages/cli/test/fixtures/preset-v3-canaries/doc-canon-sync/v2/preset.json
@@ -1,0 +1,30 @@
+{
+  "schema": "preset-manifest/v2",
+  "id": "doc-canon-sync",
+  "title": "Document Canon Sync",
+  "vertical": "software/coding",
+  "version": "1.0.0",
+  "kind": "process-action",
+  "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
+  "capabilityImports": [{ "id": "doc-canon-sync", "kind": "command", "version": "1", "required": false }],
+  "entrypoints": {
+    "check": {
+      "type": "script",
+      "command": "scripts/preset-action.mjs",
+      "reads": [
+        "{{paths.decisionsRoot}}/**",
+        "{{paths.adrRoot}}/**",
+        "{{paths.authoredRoot}}/context/architecture/adr/**",
+        "{{paths.authoredRoot}}/AGENTS.md",
+        "{{paths.authoredRoot}}/governance/**",
+        "{{paths.authoredRoot}}/standards/**"
+      ],
+      "writes": ["{{outputRoot}}/**"],
+      "inputs": {
+        "watermarkFile": "{{paths.authoredRoot}}/AGENTS.md"
+      }
+    }
+  },
+  "profiles": [{ "id": "baseline", "title": "Baseline", "checkerProfile": "standard", "completionGates": ["ci", "code-doc-reconciliation"], "templateSelections": [] }],
+  "defaultProfile": "baseline"
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/doc-canon-sync/v2/scripts/preset-action.mjs
+++ b/packages/cli/test/fixtures/preset-v3-canaries/doc-canon-sync/v2/scripts/preset-action.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const contextPath = process.env.HARNESS_PRESET_CONTEXT;
+if (!contextPath) throw new Error("HARNESS_PRESET_CONTEXT is required");
+const context = JSON.parse(readFileSync(contextPath, "utf8"));
+const artifactsDir = path.join(context.outputRoot, "artifacts");
+mkdirSync(artifactsDir, { recursive: true });
+
+const operatingDocs = readOperatingDocs();
+const operatingCorpus = operatingDocs.map((doc) => doc.body).join("\n\n");
+const watermark = readSyncWatermark(operatingDocs.find((doc) => doc.relativePath === "harness/AGENTS.md")?.body ?? "");
+const decisions = walkFiles(context.paths.decisionsRoot)
+  .filter((filePath) => path.basename(filePath) === "decision.md")
+  .map(readDecision)
+  .filter((entry) => entry && entry.state === "active");
+const adrRoots = uniquePaths([
+  context.paths.adrRoot,
+  path.join(context.paths.authoredRoot, "context/architecture/adr")
+]);
+const adrs = adrRoots.flatMap((root) => walkFiles(root))
+  .filter((filePath) => filePath.endsWith(".md"))
+  .map(readAdr)
+  .filter((entry) => entry && ["accepted", "active", "approved"].includes(entry.status));
+const canonical = [...decisions, ...adrs].sort(compareCanonical);
+const drift = canonical.flatMap((entry) => evaluateCanonical(entry, operatingCorpus, watermark));
+const warnings = detectWorkflowSmells(operatingDocs);
+const summary = {
+  green: drift.length === 0 ? canonical.length : Math.max(0, canonical.length - drift.length),
+  yellow: warnings.length,
+  red: drift.length,
+  total: canonical.length + warnings.length
+};
+const report = {
+  schema: "doc-canon-drift/v1",
+  taskId: context.taskId,
+  status: drift.length === 0 ? "passed" : "blocked",
+  generatedAt: new Date().toISOString(),
+  watermark,
+  summary,
+  sources: {
+    canonicalCount: canonical.length,
+    decisionCount: decisions.length,
+    adrCount: adrs.length,
+    operatingDocCount: operatingDocs.length
+  },
+  drift,
+  warnings
+};
+writeFileSync(path.join(artifactsDir, "doc-canon-drift.json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
+writeFileSync(path.join(artifactsDir, "doc-canon-drift.md"), renderMarkdown(report), "utf8");
+writeFileSync(path.join(artifactsDir, "preset-result.json"), `${JSON.stringify({
+  ok: drift.length === 0,
+  report,
+  error: drift.length === 0 ? undefined : {
+    code: "preset_script_result_failed",
+    hint: "Document canon drift found red items. Update operating docs or advance canon-synced-through after reconciliation."
+  }
+}, null, 2)}\n`, "utf8");
+
+function readOperatingDocs() {
+  const roots = [
+    path.join(context.paths.authoredRoot, "AGENTS.md"),
+    path.join(context.paths.authoredRoot, "governance"),
+    path.join(context.paths.authoredRoot, "standards")
+  ];
+  return roots.flatMap((root) => walkFiles(root))
+    .filter((filePath) => /\.(?:md|mdx|txt|ya?ml|json)$/iu.test(filePath))
+    .map((filePath) => ({
+      path: filePath,
+      relativePath: relative(filePath),
+      body: readFileSync(filePath, "utf8")
+    }));
+}
+
+function readDecision(filePath) {
+  const body = readFileSync(filePath, "utf8");
+  const frontmatter = parseFrontmatter(body);
+  const id = frontmatter.decision_id ?? frontmatter.id;
+  if (!id) return undefined;
+  return {
+    kind: "decision",
+    canonicalId: id,
+    title: frontmatter.title ?? firstMarkdownHeading(body) ?? id,
+    state: normalizeScalar(frontmatter.state ?? "unknown").toLowerCase(),
+    date: normalizeScalar(frontmatter.decidedAt ?? frontmatter.proposedAt ?? ""),
+    sourcePath: relative(filePath),
+    recommendedDocs: recommendDocs("decision", `${frontmatter.title ?? ""} ${body}`)
+  };
+}
+
+function readAdr(filePath) {
+  const body = readFileSync(filePath, "utf8");
+  const frontmatter = parseFrontmatter(body);
+  const status = readAdrStatus(body);
+  const id = frontmatter.id ?? /(?:^|\/)(ADR-\d{4,})/u.exec(toSlash(filePath))?.[1];
+  if (!id) return undefined;
+  return {
+    kind: "adr",
+    canonicalId: id,
+    title: frontmatter.title ?? firstMarkdownHeading(body) ?? id,
+    status: normalizeScalar(frontmatter.status ?? status.status ?? "unknown").toLowerCase(),
+    date: normalizeScalar(frontmatter.date ?? status.date ?? ""),
+    sourcePath: relative(filePath),
+    recommendedDocs: recommendDocs("adr", `${frontmatter.title ?? ""} ${body}`)
+  };
+}
+
+function evaluateCanonical(entry, corpus, watermark) {
+  const referenced = corpus.includes(entry.canonicalId);
+  const newerThanWatermark = isAfter(entry.date, watermark.syncedAt);
+  if (referenced && !newerThanWatermark) return [];
+  const reasons = [];
+  if (!referenced) reasons.push("missing_operating_reference");
+  if (newerThanWatermark) reasons.push("newer_than_sync_watermark");
+  return [{
+    canonicalId: entry.canonicalId,
+    kind: entry.kind,
+    title: entry.title,
+    date: entry.date,
+    sourcePath: entry.sourcePath,
+    recommendedDocs: entry.recommendedDocs,
+    reasons,
+    rationale: "Canonical item is not reflected by operating docs or is newer than the declared canon sync watermark."
+  }];
+}
+
+function detectWorkflowSmells(docs) {
+  return docs.filter((doc) => !/(?:^|\/)(?:archive|generated)(?:\/|$)/u.test(doc.relativePath)).flatMap((doc) => {
+    const warnings = [];
+    const lower = doc.body.toLowerCase();
+    if (/\bharness write <opid>\b/iu.test(doc.body)) {
+      warnings.push({
+        code: "stale_write_coordinator_commit_message",
+        sourcePath: doc.relativePath,
+        rationale: "Operating doc still describes opaque WriteCoordinator commit messages."
+      });
+    }
+    if (lower.includes("task") && !/\b(decision|fact|relation)\b/iu.test(doc.body)) {
+      warnings.push({
+        code: "task_only_workflow_smell",
+        sourcePath: doc.relativePath,
+        rationale: "Operating doc mentions task workflow without decision/fact/relation circulation."
+      });
+    }
+    return warnings;
+  });
+}
+
+function recommendDocs(kind, text) {
+  if (kind === "adr") return ["governance/standards/architecture-conformance-standard.md"];
+  if (/\b(cli|command|json|input|output|receipt|report|agent|ha)\b/iu.test(text)) return ["AGENTS.md"];
+  if (/\b(schema|crud|coordinator|write|projection|repository|model|delete|field)\b/iu.test(text)) {
+    return ["governance/standards/implementation-contract-standard.md"];
+  }
+  return ["AGENTS.md"];
+}
+
+function parseFrontmatter(body) {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/u.exec(body);
+  if (!match) return {};
+  const result = {};
+  for (const line of match[1].split(/\r?\n/u)) {
+    const scalar = /^([A-Za-z0-9_-]+):\s*(.*)$/u.exec(line);
+    if (!scalar) continue;
+    result[scalar[1]] = normalizeScalar(scalar[2]);
+  }
+  return result;
+}
+
+function readSyncWatermark(body) {
+  const match = /<!--\s*canon-synced-through:\s*([^\s]+)\s+@\s*([^>]+?)\s*-->/u.exec(body);
+  return {
+    canonicalId: match?.[1] ?? null,
+    syncedAt: normalizeScalar(match?.[2] ?? "1970-01-01T00:00:00.000Z")
+  };
+}
+
+function readAdrStatus(body) {
+  const statusSection = /^##\s+Status\s*\r?\n+([\s\S]*?)(?:\r?\n##\s+|\s*$)/imu.exec(body)?.[1] ?? "";
+  const firstStatusLine = statusSection.split(/\r?\n/u).map((line) => line.trim()).find(Boolean) ?? "";
+  const match = /^(Accepted|Active|Approved|Proposed|Deprecated|Superseded|Rejected)\b(?:\s+(\d{4}-\d{2}-\d{2}))?/iu.exec(firstStatusLine);
+  return {
+    status: match?.[1],
+    date: match?.[2]
+  };
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Document Canon Drift",
+    "",
+    `Status: ${report.status}`,
+    `Generated: ${report.generatedAt}`,
+    `Watermark: ${report.watermark.canonicalId ?? "none"} @ ${report.watermark.syncedAt}`,
+    "",
+    `Summary: ${report.summary.red} red, ${report.summary.yellow} yellow, ${report.summary.green} green`,
+    "",
+    "## Drift",
+    ""
+  ];
+  if (report.drift.length === 0) {
+    lines.push("- None");
+  } else {
+    for (const item of report.drift) {
+      lines.push(`- ${item.canonicalId} (${item.kind}) - ${item.title}`);
+      lines.push(`  - source: ${item.sourcePath}`);
+      lines.push(`  - update: ${item.recommendedDocs.join(", ")}`);
+      lines.push(`  - reasons: ${item.reasons.join(", ")}`);
+    }
+  }
+  lines.push("", "## Old Workflow Warnings", "");
+  if (report.warnings.length === 0) {
+    lines.push("- None");
+  } else {
+    for (const warning of report.warnings) {
+      lines.push(`- ${warning.code} in ${warning.sourcePath}: ${warning.rationale}`);
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function firstMarkdownHeading(body) {
+  return /^#\s+(.+)$/mu.exec(body)?.[1]?.trim();
+}
+
+function walkFiles(targetPath) {
+  if (!targetPath || !existsSync(targetPath)) return [];
+  const stats = statSync(targetPath);
+  if (stats.isFile()) return [targetPath];
+  if (!stats.isDirectory()) return [];
+  return readdirSync(targetPath, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.isSymbolicLink()) return [];
+    return walkFiles(path.join(targetPath, entry.name));
+  }).sort();
+}
+
+function compareCanonical(a, b) {
+  const byDate = (Date.parse(b.date) || 0) - (Date.parse(a.date) || 0);
+  if (byDate !== 0) return byDate;
+  return a.canonicalId.localeCompare(b.canonicalId);
+}
+
+function isAfter(date, watermarkDate) {
+  const value = Date.parse(date);
+  const watermarkValue = Date.parse(watermarkDate);
+  return Number.isFinite(value) && Number.isFinite(watermarkValue) && value > watermarkValue;
+}
+
+function normalizeScalar(value) {
+  return String(value ?? "").trim().replace(/^["']|["']$/gu, "");
+}
+
+function uniquePaths(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function relative(filePath) {
+  return toSlash(path.relative(context.paths.rootDir, filePath));
+}
+
+function toSlash(value) {
+  return value.split(path.sep).join("/");
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/doc-canon-sync/v3/preset.json
+++ b/packages/cli/test/fixtures/preset-v3-canaries/doc-canon-sync/v3/preset.json
@@ -1,0 +1,36 @@
+{
+  "schema": "preset-manifest/v3",
+  "id": "doc-canon-sync",
+  "title": "Document Canon Sync",
+  "vertical": "software/coding",
+  "version": "2.0.0",
+  "kind": "process-action",
+  "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
+  "capabilityImports": [],
+  "entrypoints": {
+    "check": {
+      "type": "script",
+      "command": "scripts/preset-action.mjs",
+      "intent": { "verb": "check", "subject": "document-canon-drift" },
+      "inputs": {
+        "watermarkSource": { "type": "enum", "required": false, "values": ["agents-guide"], "default": "agents-guide" }
+      },
+      "requires": [
+        { "capability": "decisions", "version": "1", "select": { "states": ["active"], "view": "canon-summary" } },
+        { "capability": "adrs", "version": "1", "select": { "states": ["accepted", "active", "approved"], "view": "canon-summary" } },
+        { "capability": "operating-docs", "version": "1", "select": { "collections": ["agents-guide", "governance", "standards"], "view": "text" } }
+      ],
+      "produces": [{
+        "capability": "task-artifacts",
+        "version": "1",
+        "target": { "taskFrom": "current-task" },
+        "artifacts": [
+          { "id": "doc-canon-drift", "schema": "doc-canon-drift/v1", "mediaTypes": ["application/json", "text/markdown"], "cardinality": "one", "required": true }
+        ]
+      }],
+      "sideEffects": []
+    }
+  },
+  "profiles": [{ "id": "baseline", "title": "Baseline", "checkerProfile": "standard", "completionGates": ["ci", "code-doc-reconciliation"], "templateSelections": [] }],
+  "defaultProfile": "baseline"
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/doc-canon-sync/v3/scripts/preset-action.mjs
+++ b/packages/cli/test/fixtures/preset-v3-canaries/doc-canon-sync/v3/scripts/preset-action.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+const context = readContext();
+const decisionsProjection = readCapability("decisions");
+const adrsProjection = readCapability("adrs");
+const docsProjection = readCapability("operating-docs");
+const operatingDocs = docsProjection.documents;
+const operatingCorpus = operatingDocs.map((doc) => doc.body).join("\n\n");
+const watermark = readSyncWatermark(operatingDocs.find((doc) => doc.relativePath.endsWith("/AGENTS.md"))?.body ?? "");
+const decisions = decisionsProjection.decisions.map((entry) => ({
+  ...entry,
+  recommendedDocs: recommendDocs("decision", entry.title)
+}));
+const adrs = adrsProjection.adrs.map((entry) => ({
+  ...entry,
+  recommendedDocs: recommendDocs("adr", entry.title)
+}));
+const canonical = [...decisions, ...adrs].sort(compareCanonical);
+const drift = canonical.flatMap((entry) => evaluateCanonical(entry, operatingCorpus, watermark));
+const warnings = detectWorkflowSmells(operatingDocs);
+const summary = {
+  green: drift.length === 0 ? canonical.length : Math.max(0, canonical.length - drift.length),
+  yellow: warnings.length,
+  red: drift.length,
+  total: canonical.length + warnings.length
+};
+const report = {
+  schema: "doc-canon-drift/v1",
+  taskId: context.run.taskId,
+  status: drift.length === 0 ? "passed" : "blocked",
+  generatedAt: new Date().toISOString(),
+  watermark,
+  summary,
+  sources: {
+    canonicalCount: canonical.length,
+    decisionCount: decisions.length,
+    adrCount: adrs.length,
+    operatingDocCount: operatingDocs.length
+  },
+  drift,
+  warnings
+};
+writeFileSync(outputPath("doc-canon-drift", "application/json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
+writeFileSync(outputPath("doc-canon-drift", "text/markdown"), renderMarkdown(report), "utf8");
+writeResult({
+  schema: "script-result/v1",
+  ok: drift.length === 0,
+  report,
+  produced: ["doc-canon-drift"],
+  error: drift.length === 0 ? undefined : {
+    code: "preset_script_result_failed",
+    hint: "Document canon drift found red items. Update operating docs or advance canon-synced-through after reconciliation."
+  }
+});
+
+function evaluateCanonical(entry, corpus, syncWatermark) {
+  const referenced = corpus.includes(entry.canonicalId);
+  const newerThanWatermark = isAfter(entry.date, syncWatermark.syncedAt);
+  if (referenced && !newerThanWatermark) return [];
+  const reasons = [];
+  if (!referenced) reasons.push("missing_operating_reference");
+  if (newerThanWatermark) reasons.push("newer_than_sync_watermark");
+  return [{
+    canonicalId: entry.canonicalId,
+    kind: entry.kind,
+    title: entry.title,
+    date: entry.date,
+    sourcePath: entry.sourcePath,
+    recommendedDocs: entry.recommendedDocs,
+    reasons,
+    rationale: "Canonical item is not reflected by operating docs or is newer than the declared canon sync watermark."
+  }];
+}
+
+function detectWorkflowSmells(docs) {
+  return docs.filter((doc) => !/(?:^|\/)(?:archive|generated)(?:\/|$)/u.test(doc.relativePath)).flatMap((doc) => {
+    const warnings = [];
+    const lower = doc.body.toLowerCase();
+    if (/\bharness write <opid>\b/iu.test(doc.body)) warnings.push({
+      code: "stale_write_coordinator_commit_message",
+      sourcePath: doc.relativePath,
+      rationale: "Operating doc still describes opaque WriteCoordinator commit messages."
+    });
+    if (lower.includes("task") && !/\b(decision|fact|relation)\b/iu.test(doc.body)) warnings.push({
+      code: "task_only_workflow_smell",
+      sourcePath: doc.relativePath,
+      rationale: "Operating doc mentions task workflow without decision/fact/relation circulation."
+    });
+    return warnings;
+  });
+}
+
+function recommendDocs(kind, text) {
+  if (kind === "adr") return ["governance/standards/architecture-conformance-standard.md"];
+  if (/\b(cli|command|json|input|output|receipt|report|agent|ha)\b/iu.test(text)) return ["AGENTS.md"];
+  if (/\b(schema|crud|coordinator|write|projection|repository|model|delete|field)\b/iu.test(text)) {
+    return ["governance/standards/implementation-contract-standard.md"];
+  }
+  return ["AGENTS.md"];
+}
+
+function readSyncWatermark(body) {
+  const match = /<!--\s*canon-synced-through:\s*([^\s]+)\s+@\s*([^>]+?)\s*-->/u.exec(body);
+  return { canonicalId: match?.[1] ?? null, syncedAt: normalizeScalar(match?.[2] ?? "1970-01-01T00:00:00.000Z") };
+}
+
+function renderMarkdown(value) {
+  const lines = [
+    "# Document Canon Drift", "", `Status: ${value.status}`, `Generated: ${value.generatedAt}`,
+    `Watermark: ${value.watermark.canonicalId ?? "none"} @ ${value.watermark.syncedAt}`, "",
+    `Summary: ${value.summary.red} red, ${value.summary.yellow} yellow, ${value.summary.green} green`, "", "## Drift", ""
+  ];
+  if (value.drift.length === 0) lines.push("- None");
+  else for (const item of value.drift) {
+    lines.push(`- ${item.canonicalId} (${item.kind}) - ${item.title}`);
+    lines.push(`  - source: ${item.sourcePath}`);
+    lines.push(`  - update: ${item.recommendedDocs.join(", ")}`);
+    lines.push(`  - reasons: ${item.reasons.join(", ")}`);
+  }
+  lines.push("", "## Old Workflow Warnings", "");
+  if (value.warnings.length === 0) lines.push("- None");
+  else for (const warning of value.warnings) lines.push(`- ${warning.code} in ${warning.sourcePath}: ${warning.rationale}`);
+  lines.push("");
+  return lines.join("\n");
+}
+
+function readContext() {
+  const filename = process.env.HARNESS_PRESET_CONTEXT;
+  if (!filename) throw new Error("HARNESS_PRESET_CONTEXT is required");
+  return JSON.parse(readFileSync(filename, "utf8"));
+}
+
+function readCapability(id) {
+  const handle = context.capabilities.reads[id]?.[0];
+  if (!handle) throw new Error(`missing ${id} capability handle`);
+  return JSON.parse(readFileSync(handle.path, "utf8"));
+}
+
+function outputPath(id, mediaType) {
+  const writer = context.capabilities.writes["task-artifacts"]?.[0];
+  const representation = writer?.artifacts?.[id]?.representations?.find((entry) => entry.mediaType === mediaType);
+  if (!representation) throw new Error(`missing ${id} ${mediaType} writer`);
+  return representation.path;
+}
+
+function writeResult(value) {
+  writeFileSync(context.result.path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function compareCanonical(left, right) {
+  const byDate = (Date.parse(right.date) || 0) - (Date.parse(left.date) || 0);
+  return byDate !== 0 ? byDate : left.canonicalId.localeCompare(right.canonicalId);
+}
+
+function isAfter(date, watermarkDate) {
+  const value = Date.parse(date);
+  const watermarkValue = Date.parse(watermarkDate);
+  return Number.isFinite(value) && Number.isFinite(watermarkValue) && value > watermarkValue;
+}
+
+function normalizeScalar(value) {
+  return String(value ?? "").trim().replace(/^["']|["']$/gu, "");
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/dogfood-utilization-audit/v2/preset.json
+++ b/packages/cli/test/fixtures/preset-v3-canaries/dogfood-utilization-audit/v2/preset.json
@@ -1,0 +1,29 @@
+{
+  "schema": "preset-manifest/v2",
+  "id": "dogfood-utilization-audit",
+  "title": "Dogfood Utilization Audit",
+  "vertical": "software/coding",
+  "version": "1.0.0",
+  "kind": "process-action",
+  "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
+  "capabilityImports": [{ "id": "dogfood-utilization-audit", "kind": "command", "version": "1", "required": false }],
+  "entrypoints": {
+    "audit": {
+      "type": "script",
+      "command": "scripts/preset-action.mjs",
+      "reads": [
+        "{{paths.tasksRoot}}/**",
+        "{{paths.generatedRoot}}/**",
+        "{{paths.localRoot}}/**",
+        "{{paths.authoredRoot}}/docmap.json"
+      ],
+      "writes": ["{{outputRoot}}/**"],
+      "inputs": {
+        "trackedPresets": "standard-task,module,legacy-migration,doc-canon-sync,milestone-closeout,lesson-sedimentation,milestone-dossier,version-upgrade,publish-standard,release-closeout,long-running-task,dogfood-utilization-audit",
+        "trackedArtifacts": "runtime-events,distill-candidates,lesson-promotions,graph-panorama,write-journal,docmap"
+      }
+    }
+  },
+  "profiles": [{ "id": "baseline", "title": "Baseline", "checkerProfile": "standard", "completionGates": ["ci", "code-doc-reconciliation"], "templateSelections": [] }],
+  "defaultProfile": "baseline"
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/dogfood-utilization-audit/v2/scripts/preset-action.mjs
+++ b/packages/cli/test/fixtures/preset-v3-canaries/dogfood-utilization-audit/v2/scripts/preset-action.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const contextPath = process.env.HARNESS_PRESET_CONTEXT;
+if (!contextPath) throw new Error("HARNESS_PRESET_CONTEXT is required");
+const context = JSON.parse(readFileSync(contextPath, "utf8"));
+const artifactsDir = path.join(context.outputRoot, "artifacts");
+mkdirSync(artifactsDir, { recursive: true });
+
+const trackedPresets = splitCsv(context.inputs.trackedPresets);
+const trackedArtifacts = splitCsv(context.inputs.trackedArtifacts);
+const taskPackages = readTaskPackages();
+const runtimeEvents = readRuntimeEvents(path.join(context.paths.generatedRoot, "runtime-events"));
+const presetEvidence = readPresetEvidence(context.paths.tasksRoot);
+const artifactItems = trackedArtifacts.map(evaluateArtifact);
+const presetItems = trackedPresets.map(evaluatePreset);
+const items = [...presetItems, ...artifactItems];
+const summary = {
+  green: items.filter((item) => item.status === "green").length,
+  yellow: items.filter((item) => item.status === "yellow").length,
+  red: items.filter((item) => item.status === "red").length,
+  total: items.length
+};
+const report = {
+  schema: "dogfood-utilization-audit/v1",
+  taskId: context.taskId,
+  status: summary.red === 0 ? "passed" : "blocked",
+  generatedAt: new Date().toISOString(),
+  summary,
+  sources: {
+    taskPackageCount: taskPackages.length,
+    runtimeEventFiles: runtimeEvents.files,
+    runtimeEventRows: runtimeEvents.rows,
+    presetEvidenceArtifacts: presetEvidence.length
+  },
+  items,
+  orphanCandidates: items.filter((item) => item.status === "red"),
+  weakSignals: items.filter((item) => item.status === "yellow")
+};
+
+writeFileSync(path.join(artifactsDir, "dogfood-utilization-audit.json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
+writeFileSync(path.join(artifactsDir, "dogfood-utilization-audit.md"), renderMarkdown(report), "utf8");
+writeFileSync(path.join(artifactsDir, "preset-result.json"), `${JSON.stringify({
+  ok: summary.red === 0,
+  rows: items.length,
+  report,
+  error: summary.red === 0 ? undefined : {
+    code: "preset_script_result_failed",
+    hint: "Dogfood utilization audit found features with no usage signal."
+  }
+}, null, 2)}\n`, "utf8");
+
+function evaluatePreset(presetId) {
+  const taskUses = taskPackages.filter((task) => task.preset === presetId);
+  const evidenceUses = presetEvidence.filter((artifact) => artifact.presetId === presetId);
+  const eventMentions = runtimeEvents.events.filter((event) => event.text.includes(presetId));
+  const genericPresetActions = runtimeEvents.commandCounts["preset-action"] ?? 0;
+  const signals = {
+    taskUses: taskUses.length,
+    presetEvidenceArtifacts: evidenceUses.length,
+    runtimeEventMentions: eventMentions.length
+  };
+  const totalSpecificSignals = signals.taskUses + signals.presetEvidenceArtifacts + signals.runtimeEventMentions;
+  const status = totalSpecificSignals > 0 ? "green" : "red";
+  return {
+    id: presetId,
+    kind: "preset",
+    status,
+    signals,
+    genericPresetActions,
+    evidence: [
+      ...taskUses.slice(0, 5).map((task) => task.sourcePath),
+      ...evidenceUses.slice(0, 5).map((artifact) => artifact.sourcePath),
+      ...eventMentions.slice(0, 5).map((event) => event.sourcePath)
+    ],
+    reason: status === "green"
+      ? "specific_usage_signal_found"
+      : genericPresetActions > 0
+        ? "no_specific_usage_signal_found_despite_generic_preset_events"
+        : "no_usage_signal_found"
+  };
+}
+
+function evaluateArtifact(id) {
+  const artifact = artifactDefinition(id);
+  const stat = artifactStats(artifact.path, artifact.mode);
+  const status = stat.count > 0 ? "green" : "red";
+  return {
+    id,
+    kind: "artifact",
+    status,
+    signals: stat.signals,
+    evidence: stat.evidence,
+    reason: status === "green" ? "artifact_usage_signal_found" : "no_artifact_usage_signal_found"
+  };
+}
+
+function artifactDefinition(id) {
+  const generated = context.paths.generatedRoot;
+  if (id === "runtime-events") return { path: path.join(generated, "runtime-events"), mode: "jsonl-lines" };
+  if (id === "distill-candidates") return { path: path.join(generated, "distill"), mode: "files" };
+  if (id === "lesson-promotions") return { path: path.join(generated, "lessons"), mode: "files" };
+  if (id === "graph-panorama") return { path: path.join(generated, "graph-panorama"), mode: "files" };
+  if (id === "write-journal") return { path: path.join(context.paths.localRoot, "write-journal"), mode: "files" };
+  if (id === "docmap") return { path: path.join(context.paths.authoredRoot, "docmap.json"), mode: "file" };
+  return { path: path.join(generated, id), mode: "files" };
+}
+
+function artifactStats(targetPath, mode) {
+  if (mode === "file") {
+    const exists = existsSync(targetPath) && statSync(targetPath).isFile();
+    return {
+      count: exists ? 1 : 0,
+      signals: { files: exists ? 1 : 0 },
+      evidence: exists ? [relative(targetPath)] : []
+    };
+  }
+  const files = walkFiles(targetPath);
+  if (mode === "jsonl-lines") {
+    const jsonl = files.filter((filePath) => filePath.endsWith(".jsonl"));
+    const rows = jsonl.reduce((sum, filePath) => sum + readLines(filePath).filter(Boolean).length, 0);
+    return {
+      count: rows,
+      signals: { files: jsonl.length, rows },
+      evidence: jsonl.slice(0, 5).map(relative)
+    };
+  }
+  return {
+    count: files.length,
+    signals: { files: files.length },
+    evidence: files.slice(0, 5).map(relative)
+  };
+}
+
+function readTaskPackages() {
+  if (!Array.isArray(context.taskIndex)) return [];
+  return context.taskIndex.map((task) => ({
+    taskId: task.taskId,
+    preset: task.preset ?? "",
+    sourcePath: task.indexPath ?? task.packagePath ?? ""
+  }));
+}
+
+function readRuntimeEvents(eventsRoot) {
+  const files = walkFiles(eventsRoot).filter((filePath) => filePath.endsWith(".jsonl"));
+  const events = [];
+  const commandCounts = {};
+  for (const filePath of files) {
+    for (const line of readLines(filePath).filter(Boolean)) {
+      try {
+        const parsed = JSON.parse(line);
+        const text = JSON.stringify(parsed);
+        const summary = parsed?.result?.summary;
+        const command = typeof summary === "string" ? /CLI command succeeded: ([A-Za-z0-9_-]+)/u.exec(summary)?.[1] : undefined;
+        if (command) commandCounts[command] = (commandCounts[command] ?? 0) + 1;
+        events.push({ sourcePath: relative(filePath), text, command });
+      } catch {
+        events.push({ sourcePath: relative(filePath), text: line, command: undefined });
+      }
+    }
+  }
+  return { files: files.length, rows: events.length, events, commandCounts };
+}
+
+function readPresetEvidence(tasksRoot) {
+  const result = [];
+  for (const filePath of walkFiles(tasksRoot)) {
+    if (!/(?:^|\/)artifacts\/(?:preset-result|evidence)\.json$/u.test(toSlash(filePath))) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(filePath, "utf8"));
+      const presetId = inferPresetId(parsed);
+      if (presetId) result.push({ presetId, sourcePath: relative(filePath) });
+    } catch {
+      // Ignore malformed historical artifacts; this audit only counts positive usage signals.
+    }
+  }
+  return result;
+}
+
+function inferPresetId(parsed) {
+  if (typeof parsed?.presetId === "string") return parsed.presetId;
+  const schema = parsed?.report?.schema ?? parsed?.schema;
+  if (schema === "doc-canon-drift/v1") return "doc-canon-sync";
+  if (schema === "legacy-migration-preset-plan/v1") return "legacy-migration";
+  if (schema === "milestone-closeout-parity/v1") return "milestone-closeout";
+  if (schema === "milestone-dossier-gather-report/v1") return "milestone-dossier";
+  if (schema === "dogfood-utilization-audit/v1") return "dogfood-utilization-audit";
+  return undefined;
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Dogfood Utilization Audit",
+    "",
+    `Status: ${report.status}`,
+    `Generated: ${report.generatedAt}`,
+    "",
+    `Summary: ${report.summary.red} red, ${report.summary.yellow} yellow, ${report.summary.green} green, ${report.summary.total} total`,
+    "",
+    "## Red",
+    ""
+  ];
+  pushItems(lines, report.orphanCandidates);
+  lines.push("", "## Yellow", "");
+  pushItems(lines, report.weakSignals);
+  lines.push("", "## All Items", "");
+  pushItems(lines, report.items);
+  return `${lines.join("\n")}\n`;
+}
+
+function pushItems(lines, items) {
+  if (items.length === 0) {
+    lines.push("- None");
+    return;
+  }
+  for (const item of items) {
+    lines.push(`- ${item.status.toUpperCase()} ${item.kind}:${item.id} - ${item.reason}`);
+    lines.push(`  - signals: ${JSON.stringify(item.signals)}`);
+    if (item.evidence.length > 0) lines.push(`  - evidence: ${item.evidence.join(", ")}`);
+  }
+}
+
+function walkFiles(root) {
+  if (!root || !existsSync(root)) return [];
+  const stat = statSync(root);
+  if (stat.isFile()) return [root];
+  if (!stat.isDirectory()) return [];
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) return walkFiles(entryPath);
+    return entry.isFile() ? [entryPath] : [];
+  }).sort();
+}
+
+function readLines(filePath) {
+  return readFileSync(filePath, "utf8").split(/\r?\n/u);
+}
+
+function splitCsv(value) {
+  return String(value ?? "").split(",").map((entry) => entry.trim()).filter(Boolean);
+}
+
+function relative(filePath) {
+  return toSlash(path.relative(context.paths.rootDir, filePath));
+}
+
+function toSlash(value) {
+  return value.split(path.sep).join("/");
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/dogfood-utilization-audit/v3/preset.json
+++ b/packages/cli/test/fixtures/preset-v3-canaries/dogfood-utilization-audit/v3/preset.json
@@ -1,0 +1,40 @@
+{
+  "schema": "preset-manifest/v3",
+  "id": "dogfood-utilization-audit",
+  "title": "Dogfood Utilization Audit",
+  "vertical": "software/coding",
+  "version": "2.0.0",
+  "kind": "process-action",
+  "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
+  "capabilityImports": [],
+  "entrypoints": {
+    "audit": {
+      "type": "script",
+      "command": "scripts/preset-action.mjs",
+      "intent": { "verb": "audit", "subject": "dogfood-utilization" },
+      "inputs": {
+        "trackedPresets": { "type": "preset-ref-list", "required": false, "default": ["standard-task", "module", "legacy-migration", "doc-canon-sync", "milestone-closeout", "lesson-sedimentation", "milestone-dossier", "version-upgrade", "publish-standard", "release-closeout", "long-running-task", "dogfood-utilization-audit"] },
+        "trackedArtifacts": { "type": "enum-list", "required": false, "values": ["runtime-events", "distill-candidates", "lesson-promotions", "graph-panorama", "write-journal", "docmap"], "default": ["runtime-events", "distill-candidates", "lesson-promotions", "graph-panorama", "write-journal", "docmap"] }
+      },
+      "requires": [
+        { "capability": "tasks", "version": "1", "select": { "scope": "all", "view": "identity-and-preset" } },
+        { "capability": "task-artifacts", "version": "1", "select": { "scope": "all-tasks", "artifactIds": ["preset-result", "evidence"] } },
+        { "capability": "runtime-events", "version": "1", "select": { "view": "command-usage" } },
+        { "capability": "generated-artifacts", "version": "1", "select": { "view": "presence-inventory", "familiesFrom": "trackedArtifacts" } },
+        { "capability": "write-journal", "version": "1", "select": { "view": "presence-inventory" } },
+        { "capability": "docmap", "version": "1", "select": { "view": "presence" } }
+      ],
+      "produces": [{
+        "capability": "task-artifacts",
+        "version": "1",
+        "target": { "taskFrom": "current-task" },
+        "artifacts": [
+          { "id": "dogfood-utilization-report", "schema": "dogfood-utilization-audit/v1", "mediaTypes": ["application/json", "text/markdown"], "cardinality": "one", "required": true }
+        ]
+      }],
+      "sideEffects": []
+    }
+  },
+  "profiles": [{ "id": "baseline", "title": "Baseline", "checkerProfile": "standard", "completionGates": ["ci", "code-doc-reconciliation"], "templateSelections": [] }],
+  "defaultProfile": "baseline"
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/dogfood-utilization-audit/v3/scripts/preset-action.mjs
+++ b/packages/cli/test/fixtures/preset-v3-canaries/dogfood-utilization-audit/v3/scripts/preset-action.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+const context = readContext();
+const trackedPresets = context.inputs.trackedPresets;
+const trackedArtifacts = context.inputs.trackedArtifacts;
+const taskPackages = readCapability("tasks").tasks;
+const artifactHandles = readCapability("task-artifacts").artifacts;
+const runtimeEvents = readCapability("runtime-events");
+const generatedInventory = readCapability("generated-artifacts");
+const writeJournal = readCapability("write-journal");
+const docmap = readCapability("docmap");
+const presetEvidence = artifactHandles.flatMap(readPresetEvidence);
+const artifactItems = trackedArtifacts.map(evaluateArtifact);
+const presetItems = trackedPresets.map(evaluatePreset);
+const items = [...presetItems, ...artifactItems];
+const summary = {
+  green: items.filter((item) => item.status === "green").length,
+  yellow: items.filter((item) => item.status === "yellow").length,
+  red: items.filter((item) => item.status === "red").length,
+  total: items.length
+};
+const report = {
+  schema: "dogfood-utilization-audit/v1",
+  taskId: context.run.taskId,
+  status: summary.red === 0 ? "passed" : "blocked",
+  generatedAt: new Date().toISOString(),
+  summary,
+  sources: {
+    taskPackageCount: taskPackages.length,
+    runtimeEventFiles: runtimeEvents.files,
+    runtimeEventRows: runtimeEvents.rows,
+    presetEvidenceArtifacts: presetEvidence.length
+  },
+  items,
+  orphanCandidates: items.filter((item) => item.status === "red"),
+  weakSignals: items.filter((item) => item.status === "yellow")
+};
+writeFileSync(outputPath("dogfood-utilization-report", "application/json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
+writeFileSync(outputPath("dogfood-utilization-report", "text/markdown"), renderMarkdown(report), "utf8");
+writeResult({
+  schema: "script-result/v1",
+  ok: summary.red === 0,
+  rows: items.length,
+  report,
+  produced: ["dogfood-utilization-report"],
+  error: summary.red === 0 ? undefined : {
+    code: "preset_script_result_failed",
+    hint: "Dogfood utilization audit found features with no usage signal."
+  }
+});
+
+function evaluatePreset(presetId) {
+  const taskUses = taskPackages.filter((task) => task.preset === presetId);
+  const evidenceUses = presetEvidence.filter((artifact) => artifact.presetId === presetId);
+  const eventMentions = runtimeEvents.presetMentions[presetId] ?? { count: 0, evidence: [] };
+  const genericPresetActions = runtimeEvents.commandCounts["preset-action"] ?? 0;
+  const signals = {
+    taskUses: taskUses.length,
+    presetEvidenceArtifacts: evidenceUses.length,
+    runtimeEventMentions: eventMentions.count
+  };
+  const totalSpecificSignals = signals.taskUses + signals.presetEvidenceArtifacts + signals.runtimeEventMentions;
+  const status = totalSpecificSignals > 0 ? "green" : "red";
+  return {
+    id: presetId,
+    kind: "preset",
+    status,
+    signals,
+    genericPresetActions,
+    evidence: [
+      ...taskUses.slice(0, 5).map((task) => task.sourcePath),
+      ...evidenceUses.slice(0, 5).map((artifact) => artifact.sourcePath),
+      ...eventMentions.evidence.slice(0, 5)
+    ],
+    reason: status === "green"
+      ? "specific_usage_signal_found"
+      : genericPresetActions > 0
+        ? "no_specific_usage_signal_found_despite_generic_preset_events"
+        : "no_usage_signal_found"
+  };
+}
+
+function evaluateArtifact(id) {
+  const inventory = id === "write-journal"
+    ? writeJournal
+    : id === "docmap"
+      ? docmap
+      : generatedInventory.entries.find((entry) => entry.id === id) ?? { files: 0, evidence: [] };
+  const signals = id === "runtime-events"
+    ? { files: inventory.files, rows: inventory.rows ?? 0 }
+    : { files: inventory.files };
+  const count = id === "runtime-events" ? signals.rows : signals.files;
+  const status = count > 0 ? "green" : "red";
+  return {
+    id,
+    kind: "artifact",
+    status,
+    signals,
+    evidence: inventory.evidence,
+    reason: status === "green" ? "artifact_usage_signal_found" : "no_artifact_usage_signal_found"
+  };
+}
+
+function readPresetEvidence(handle) {
+  try {
+    const parsed = JSON.parse(readFileSync(handle.path, "utf8"));
+    const presetId = inferPresetId(parsed);
+    return presetId ? [{ presetId, sourcePath: handle.sourcePath }] : [];
+  } catch {
+    return [];
+  }
+}
+
+function inferPresetId(parsed) {
+  if (typeof parsed?.presetId === "string") return parsed.presetId;
+  const schema = parsed?.report?.schema ?? parsed?.schema;
+  if (schema === "doc-canon-drift/v1") return "doc-canon-sync";
+  if (schema === "legacy-migration-preset-plan/v1") return "legacy-migration";
+  if (schema === "milestone-closeout-parity/v1") return "milestone-closeout";
+  if (schema === "milestone-dossier-gather-report/v1") return "milestone-dossier";
+  if (schema === "dogfood-utilization-audit/v1") return "dogfood-utilization-audit";
+  return undefined;
+}
+
+function renderMarkdown(value) {
+  const lines = [
+    "# Dogfood Utilization Audit", "", `Status: ${value.status}`, `Generated: ${value.generatedAt}`, "",
+    `Summary: ${value.summary.red} red, ${value.summary.yellow} yellow, ${value.summary.green} green, ${value.summary.total} total`,
+    "", "## Red", ""
+  ];
+  pushItems(lines, value.orphanCandidates);
+  lines.push("", "## Yellow", "");
+  pushItems(lines, value.weakSignals);
+  lines.push("", "## All Items", "");
+  pushItems(lines, value.items);
+  return `${lines.join("\n")}\n`;
+}
+
+function pushItems(lines, values) {
+  if (values.length === 0) return void lines.push("- None");
+  for (const item of values) {
+    lines.push(`- ${item.status.toUpperCase()} ${item.kind}:${item.id} - ${item.reason}`);
+    lines.push(`  - signals: ${JSON.stringify(item.signals)}`);
+    if (item.evidence.length > 0) lines.push(`  - evidence: ${item.evidence.join(", ")}`);
+  }
+}
+
+function readContext() {
+  const filename = process.env.HARNESS_PRESET_CONTEXT;
+  if (!filename) throw new Error("HARNESS_PRESET_CONTEXT is required");
+  return JSON.parse(readFileSync(filename, "utf8"));
+}
+
+function readCapability(id) {
+  const handle = context.capabilities.reads[id]?.[0];
+  if (!handle) throw new Error(`missing ${id} capability handle`);
+  return JSON.parse(readFileSync(handle.path, "utf8"));
+}
+
+function outputPath(id, mediaType) {
+  const writer = context.capabilities.writes["task-artifacts"]?.[0];
+  const representation = writer?.artifacts?.[id]?.representations?.find((entry) => entry.mediaType === mediaType);
+  if (!representation) throw new Error(`missing ${id} ${mediaType} writer`);
+  return representation.path;
+}
+
+function writeResult(value) {
+  writeFileSync(context.result.path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/milestone-dossier/v2/preset.json
+++ b/packages/cli/test/fixtures/preset-v3-canaries/milestone-dossier/v2/preset.json
@@ -1,0 +1,46 @@
+{
+  "schema": "preset-manifest/v2",
+  "id": "milestone-dossier",
+  "title": "Aggregation-Boundary Understanding Dossier",
+  "vertical": "software/coding",
+  "version": "1.0.0",
+  "kind": "process-action",
+  "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
+  "capabilityImports": [
+    { "id": "relation-graph-projection", "kind": "projection", "version": "1", "required": true },
+    { "id": "dossier-gate-checker", "kind": "checker", "version": "1", "required": true }
+  ],
+  "entrypoints": {
+    "gather": {
+      "type": "script",
+      "command": "scripts/dossier-data.mjs",
+      "reads": [
+        "{{paths.tasksRoot}}/**",
+        "{{paths.decisionsRoot}}/**",
+        "{{paths.localRoot}}/**"
+      ],
+      "writes": [
+        "{{outputRoot}}/artifacts/**"
+      ],
+      "inputs": {
+        "coordinationTaskId": "{{taskId}}",
+        "decisionId": ""
+      }
+    }
+  },
+  "profiles": [{
+    "id": "baseline",
+    "title": "Baseline",
+    "checkerProfile": "software-coding-standard",
+    "completionGates": ["ci", "code-doc-reconciliation"],
+    "templateSelections": [
+      {
+        "slot": "dossier-shell",
+        "templateRef": "template://dossier/editorial-shell@1",
+        "materializeAs": "artifacts/dossier.scaffold.html",
+        "localePolicy": { "prefer": "project", "fallback": "zh-CN" }
+      }
+    ]
+  }],
+  "defaultProfile": "baseline"
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/milestone-dossier/v2/scripts/dossier-data.mjs
+++ b/packages/cli/test/fixtures/preset-v3-canaries/milestone-dossier/v2/scripts/dossier-data.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import path from "node:path";
+
+const contextPath = process.env.HARNESS_SCRIPT_CONTEXT ?? process.env.HARNESS_PRESET_CONTEXT;
+if (!contextPath) throw new Error("HARNESS_SCRIPT_CONTEXT or HARNESS_PRESET_CONTEXT is required");
+
+const context = JSON.parse(readFileSync(contextPath, "utf8"));
+const paths = context.paths ?? {};
+const inputs = context.inputs ?? {};
+const outputRoot = context.outputRoot;
+const coordinationTaskId = inputs.coordinationTaskId && inputs.coordinationTaskId !== "{{taskId}}"
+  ? inputs.coordinationTaskId
+  : context.taskId;
+const decisionId = inputs.decisionId || undefined;
+
+if (!outputRoot) throw new Error("context.outputRoot is required");
+if (!coordinationTaskId) throw new Error("coordinationTaskId input or task context is required");
+
+const artifactsDir = path.join(outputRoot, "artifacts");
+mkdirSync(artifactsDir, { recursive: true });
+
+const projectionPath = path.join(paths.localRoot ?? ".harness", "cache", "projections.sqlite");
+if (!existsSync(projectionPath)) {
+  throw new Error(`Relation graph projection database not found: ${projectionPath}`);
+}
+
+const projection = readProjection(projectionPath);
+const focusDecisionRef = decisionId ? `decision/${decisionId}` : undefined;
+const selectedCoverage = focusDecisionRef
+  ? projection.coverageRows.filter((row) => row.decisionRef === focusDecisionRef)
+  : projection.coverageRows;
+const selectedDecisionRefs = new Set(selectedCoverage.map((row) => row.decisionRef));
+if (focusDecisionRef) selectedDecisionRefs.add(focusDecisionRef);
+
+const relationIds = new Set(selectedCoverage.flatMap((row) => Array.isArray(row.relationPath) ? row.relationPath : []));
+const selectedEdges = projection.relationEdges.filter((edge) =>
+  relationIds.has(edge.relationId) ||
+  selectedDecisionRefs.has(baseDecisionRef(edge.sourceRef)) ||
+  selectedDecisionRefs.has(baseDecisionRef(edge.targetRef))
+);
+
+const selectedRefs = new Set();
+for (const row of selectedCoverage) {
+  selectedRefs.add(row.decisionRef);
+  selectedRefs.add(row.claimRef);
+  if (row.coveringFactRef) selectedRefs.add(row.coveringFactRef);
+}
+for (const edge of selectedEdges) {
+  selectedRefs.add(edge.sourceRef);
+  selectedRefs.add(edge.targetRef);
+  selectedRefs.add(edge.ownerRef);
+}
+
+const tasks = projection.tasks.filter((task) => selectedRefs.has(`task/${task.taskId}`));
+const decisions = projection.decisions.filter((decision) => selectedDecisionRefs.has(`decision/${decision.decisionId}`));
+const facts = projection.factAnchors.filter((fact) => selectedRefs.has(fact.factRef));
+
+const data = {
+  schema: "milestone-dossier-data/v1",
+  generatedAt: new Date().toISOString(),
+  presetId: context.presetId ?? "milestone-dossier",
+  entrypoint: context.entrypoint ?? "gather",
+  coordinationTaskId,
+  decisionId: decisionId ?? null,
+  output: {
+    dossierHtml: "artifacts/dossier.html",
+    dossierScaffoldHtml: "artifacts/dossier.scaffold.html",
+    dataJson: "artifacts/dossier.data.json"
+  },
+  projection: {
+    path: projectionPath,
+    tables: ["task_projection", "decision_projection", "relation_edges", "relation_coverage", "task_fact_anchors"]
+  },
+  summary: {
+    decisions: decisions.length,
+    tasks: tasks.length,
+    facts: facts.length,
+    relationEdges: selectedEdges.length,
+    coverageRows: selectedCoverage.length,
+    uncoveredClaims: selectedCoverage.filter((row) => row.status !== "covered").length
+  },
+  decisions,
+  tasks,
+  facts,
+  relationEdges: selectedEdges,
+  coverageRows: selectedCoverage,
+  provenanceRefs: [...selectedRefs].sort()
+};
+
+const dataPath = path.join(artifactsDir, "dossier.data.json");
+writeFileSync(dataPath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+writeFileSync(path.join(artifactsDir, "preset-result.json"), `${JSON.stringify({
+  schema: "script-result/v1",
+  ok: true,
+  rows: data.summary.coverageRows,
+  report: {
+    schema: "milestone-dossier-gather-report/v1",
+    coordinationTaskId,
+    decisionId: decisionId ?? null,
+    dataPath: path.relative(paths.rootDir ?? process.cwd(), dataPath).split(path.sep).join("/"),
+    summary: data.summary
+  },
+  produced: ["artifacts/dossier.data.json"]
+}, null, 2)}\n`, "utf8");
+
+function readProjection(filename) {
+  const db = new DatabaseSync(filename, { readOnly: true });
+  try {
+    return {
+      tasks: safeAll(db, "SELECT task_id, title, canonical_status, coordination_status, source_path, vertical, preset, profile FROM task_projection ORDER BY task_id")
+        .map((row) => ({
+          taskId: String(row.task_id ?? ""),
+          title: String(row.title ?? ""),
+          canonicalStatus: String(row.canonical_status ?? ""),
+          coordinationStatus: String(row.coordination_status ?? ""),
+          sourcePath: String(row.source_path ?? ""),
+          vertical: nullableString(row.vertical),
+          preset: nullableString(row.preset),
+          profile: nullableString(row.profile)
+        })),
+      decisions: safeAll(db, "SELECT decision_id, title, state, question, path, chosen_json, rejected_json, decided_at FROM decision_projection ORDER BY decision_id")
+        .map((row) => ({
+          decisionId: String(row.decision_id ?? ""),
+          title: String(row.title ?? ""),
+          state: String(row.state ?? ""),
+          question: String(row.question ?? ""),
+          path: String(row.path ?? ""),
+          chosen: parseJson(row.chosen_json, []),
+          rejected: parseJson(row.rejected_json, []),
+          decidedAt: nullableString(row.decided_at)
+        })),
+      relationEdges: safeJsonRows(db, "SELECT row_json FROM relation_edges ORDER BY source_ref, target_ref, relation_id"),
+      coverageRows: safeJsonRows(db, "SELECT row_json FROM relation_coverage ORDER BY claim_ref"),
+      factAnchors: safeJsonRows(db, "SELECT row_json FROM task_fact_anchors ORDER BY fact_ref")
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function safeAll(db, sql) {
+  try {
+    return db.prepare(sql).all();
+  } catch {
+    return [];
+  }
+}
+
+function safeJsonRows(db, sql) {
+  return safeAll(db, sql).map((row) => parseJson(row.row_json, {}));
+}
+
+function parseJson(value, fallback) {
+  try {
+    return JSON.parse(String(value ?? ""));
+  } catch {
+    return fallback;
+  }
+}
+
+function nullableString(value) {
+  return value === null || value === undefined ? null : String(value);
+}
+
+function baseDecisionRef(ref) {
+  const match = /^decision\/[A-Za-z0-9_-]+/u.exec(String(ref ?? ""));
+  return match ? match[0] : "";
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/milestone-dossier/v3/preset.json
+++ b/packages/cli/test/fixtures/preset-v3-canaries/milestone-dossier/v3/preset.json
@@ -1,0 +1,37 @@
+{
+  "schema": "preset-manifest/v3",
+  "id": "milestone-dossier",
+  "title": "Aggregation-Boundary Understanding Dossier",
+  "vertical": "software/coding",
+  "version": "2.0.0",
+  "kind": "process-action",
+  "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
+  "capabilityImports": [],
+  "entrypoints": {
+    "gather": {
+      "type": "script",
+      "command": "scripts/dossier-data.mjs",
+      "intent": { "verb": "gather", "subject": "milestone-dossier-data" },
+      "inputs": {
+        "coordinationTaskId": { "type": "task-ref", "required": true, "defaultFrom": "current-task" },
+        "decisionId": { "type": "decision-ref", "required": false }
+      },
+      "requires": [{
+        "capability": "relation-graph",
+        "version": "1",
+        "select": { "scope": "decision-or-all", "decisionFrom": "decisionId", "view": "dossier" }
+      }],
+      "produces": [{
+        "capability": "task-artifacts",
+        "version": "1",
+        "target": { "taskFrom": "coordinationTaskId" },
+        "artifacts": [
+          { "id": "milestone-dossier-data", "schema": "milestone-dossier-data/v1", "mediaTypes": ["application/json"], "cardinality": "one", "required": true }
+        ]
+      }],
+      "sideEffects": []
+    }
+  },
+  "profiles": [{ "id": "baseline", "title": "Baseline", "checkerProfile": "software-coding-standard", "completionGates": ["ci", "code-doc-reconciliation"], "templateSelections": [{ "slot": "dossier-shell", "templateRef": "template://dossier/editorial-shell@1", "materializeAs": "artifacts/dossier.scaffold.html", "localePolicy": { "prefer": "project", "fallback": "zh-CN" } }] }],
+  "defaultProfile": "baseline"
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/milestone-dossier/v3/scripts/dossier-data.mjs
+++ b/packages/cli/test/fixtures/preset-v3-canaries/milestone-dossier/v3/scripts/dossier-data.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+const context = readContext();
+const projection = readCapability("relation-graph");
+const coordinationTaskId = context.inputs.coordinationTaskId;
+const decisionId = context.inputs.decisionId || undefined;
+const decisions = projection.decisions;
+const tasks = projection.tasks;
+const facts = projection.facts;
+const relationEdges = projection.relationEdges;
+const coverageRows = projection.coverageRows;
+const data = {
+  schema: "milestone-dossier-data/v1",
+  generatedAt: new Date().toISOString(),
+  presetId: context.preset.id,
+  entrypoint: context.preset.entrypoint,
+  coordinationTaskId,
+  decisionId: decisionId ?? null,
+  output: {
+    dossierHtml: "artifacts/dossier.html",
+    dossierScaffoldHtml: "artifacts/dossier.scaffold.html",
+    dataJson: "artifacts/dossier.data.json"
+  },
+  projection: {
+    path: "capability://relation-graph/v1/dossier",
+    tables: ["task_projection", "decision_projection", "relation_edges", "relation_coverage", "task_fact_anchors"]
+  },
+  summary: {
+    decisions: decisions.length,
+    tasks: tasks.length,
+    facts: facts.length,
+    relationEdges: relationEdges.length,
+    coverageRows: coverageRows.length,
+    uncoveredClaims: coverageRows.filter((row) => row.status !== "covered").length
+  },
+  decisions,
+  tasks,
+  facts,
+  relationEdges,
+  coverageRows,
+  provenanceRefs: projection.provenanceRefs
+};
+const dataRepresentation = outputRepresentation("milestone-dossier-data", "application/json");
+writeFileSync(dataRepresentation.path, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+writeResult({
+  schema: "script-result/v1",
+  ok: true,
+  rows: data.summary.coverageRows,
+  report: {
+    schema: "milestone-dossier-gather-report/v1",
+    coordinationTaskId,
+    decisionId: decisionId ?? null,
+    dataPath: dataRepresentation.logicalPath,
+    summary: data.summary
+  },
+  produced: ["milestone-dossier-data"]
+});
+
+function readContext() {
+  const filename = process.env.HARNESS_PRESET_CONTEXT;
+  if (!filename) throw new Error("HARNESS_PRESET_CONTEXT is required");
+  return JSON.parse(readFileSync(filename, "utf8"));
+}
+
+function readCapability(id) {
+  const handle = context.capabilities.reads[id]?.[0];
+  if (!handle) throw new Error(`missing ${id} capability handle`);
+  return JSON.parse(readFileSync(handle.path, "utf8"));
+}
+
+function outputRepresentation(id, mediaType) {
+  const writer = context.capabilities.writes["task-artifacts"]?.[0];
+  const representation = writer?.artifacts?.[id]?.representations?.find((entry) => entry.mediaType === mediaType);
+  if (!representation) throw new Error(`missing ${id} ${mediaType} writer`);
+  return representation;
+}
+
+function writeResult(value) {
+  writeFileSync(context.result.path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/usage-acceptance/v2/preset.json
+++ b/packages/cli/test/fixtures/preset-v3-canaries/usage-acceptance/v2/preset.json
@@ -1,0 +1,65 @@
+{
+  "schema": "preset-manifest/v2",
+  "id": "usage-acceptance",
+  "title": "Usage Acceptance",
+  "vertical": "software/coding",
+  "version": "1.0.0",
+  "kind": "process-action",
+  "kernelVersionRange": {
+    "min": "1.0.0",
+    "maxExclusive": "2.0.0"
+  },
+  "capabilityImports": [
+    {
+      "id": "usage-acceptance",
+      "kind": "command",
+      "version": "1",
+      "required": false
+    }
+  ],
+  "entrypoints": {
+    "scaffold": {
+      "type": "script",
+      "command": "scripts/usage-acceptance-capture.mjs",
+      "reads": [
+        "{{paths.tasksRoot}}/**",
+        "{{paths.decisionsRoot}}/**"
+      ],
+      "writes": [
+        "{{outputRoot}}/**"
+      ],
+      "inputs": {
+        "featureTaskId": "{{taskId}}",
+        "persona": "first-time collaborator joining the centralized repo",
+        "surface": "gui",
+        "scenario": ""
+      }
+    },
+    "check": {
+      "type": "script",
+      "command": "scripts/usage-acceptance-check.mjs",
+      "reads": [
+        "{{outputRoot}}/**"
+      ],
+      "writes": [
+        "{{outputRoot}}/**"
+      ],
+      "inputs": {
+        "featureTaskId": "{{taskId}}"
+      }
+    }
+  },
+  "defaultProfile": "baseline",
+  "profiles": [
+    {
+      "id": "baseline",
+      "title": "Baseline",
+      "checkerProfile": "standard",
+      "completionGates": [
+        "ci",
+        "code-doc-reconciliation"
+      ],
+      "templateSelections": []
+    }
+  ]
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/usage-acceptance/v2/scripts/usage-acceptance-capture.mjs
+++ b/packages/cli/test/fixtures/preset-v3-canaries/usage-acceptance/v2/scripts/usage-acceptance-capture.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+// usage-acceptance :: scaffold
+//
+// Deterministic HANDS-side of a usage-acceptance run. It does NOT judge — it
+// assembles the intent-context bundle a vision/eyes agent needs, then scaffolds
+// the findings artifacts the agent fills in. The split is deliberate
+// (hands = deterministic capture; eyes = agent semantic judgment).
+//
+// What it does now (real work, not a placeholder):
+//   1. resolve the feature task under review from context.taskIndex,
+//   2. collect the decisions that spawned it (intent authority, in priority
+//      order: task goal -> spawning decisions -> facts -> transcripts),
+//   3. emit artifacts/usage-acceptance-report.md   (editorial scaffold for humans),
+//      emit artifacts/usage-acceptance-findings.json (structured skeleton the
+//      eyes-agent fills; consumed by the `check` entrypoint / gate),
+//      emit artifacts/preset-result.json           (machine envelope).
+//
+// GUI capture guidance (the actual screenshots) is written INTO the report so
+// the eyes-agent drives packages/gui/e2e/harness-fixture.mjs against a REAL
+// persona ledger (never the hermetic smoke fixture) with HARNESS_GUI_E2E_SHOTS
+// pointed at artifacts/shots/. Driving is deferred to the agent step because it
+// is flaky/expensive and must run under a real scenario, not in this script.
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const contextPath = process.env.HARNESS_PRESET_CONTEXT ?? process.env.HARNESS_SCRIPT_CONTEXT;
+if (!contextPath) throw new Error("HARNESS_PRESET_CONTEXT is required");
+const context = JSON.parse(readFileSync(contextPath, "utf8"));
+const paths = context.paths ?? {};
+const inputs = context.inputs ?? {};
+const outputRoot = context.outputRoot;
+const artifactsDir = path.join(outputRoot, "artifacts");
+const shotsDir = path.join(artifactsDir, "shots");
+mkdirSync(shotsDir, { recursive: true });
+
+const featureTaskId = resolveInput(inputs.featureTaskId, context.taskId);
+const persona = String(inputs.persona ?? "").trim() || "first-time user of the feature under review";
+const surface = String(inputs.surface ?? "gui").trim() || "gui";
+const scenario = String(inputs.scenario ?? "").trim();
+
+const featureTask = findFeatureTask(featureTaskId);
+const intentSources = collectIntentSources(featureTaskId);
+
+const findings = {
+  schema: "usage-acceptance-findings/v1",
+  featureTaskId,
+  persona,
+  surface,
+  scenario: scenario || "(fill: the job-to-be-done, derived from intentSources — NOT from the implementation)",
+  intentSources: intentSources.map((source) => ({ ref: source.ref, title: source.title, path: source.sourcePath })),
+  // Eyes-agent fills the rest. `check` validates it.
+  findings: [],          // { id, severity: blocker|friction|nit, expected, actual, evidence: [".../shots/x.png"], resolution }
+  semanticQuestions: [], // { question, escalate: bool, reason }
+  verdict: "pending",    // pending | pass | blocked
+  capturedAt: new Date().toISOString()
+};
+
+writeFileSync(path.join(artifactsDir, "usage-acceptance-findings.json"), `${JSON.stringify(findings, null, 2)}\n`, "utf8");
+writeFileSync(path.join(artifactsDir, "usage-acceptance-report.md"), renderReport({ featureTask, findings, intentSources }), "utf8");
+
+const report = {
+  schema: "usage-acceptance-capture/v1",
+  taskId: context.taskId,
+  featureTaskId,
+  status: "captured",
+  generatedAt: new Date().toISOString(),
+  featureTaskTitle: featureTask?.title ?? null,
+  intentSourceCount: intentSources.length,
+  shotsDir: relative(shotsDir)
+};
+writeFileSync(path.join(artifactsDir, "preset-result.json"), `${JSON.stringify({
+  ok: true,
+  rows: intentSources.length,
+  report,
+  produced: [
+    "artifacts/usage-acceptance-findings.json",
+    "artifacts/usage-acceptance-report.md"
+  ]
+}, null, 2)}\n`, "utf8");
+
+function findFeatureTask(taskId) {
+  if (!Array.isArray(context.taskIndex)) return null;
+  const row = context.taskIndex.find((task) => task.taskId === taskId);
+  if (!row) return null;
+  return {
+    taskId: row.taskId,
+    title: row.title ?? row.goal ?? null,
+    preset: row.preset ?? null,
+    packagePath: row.packagePath ?? row.indexPath ?? null
+  };
+}
+
+// Intent authority (ADR: task goal -> spawning decisions -> facts -> transcripts).
+// We surface the decisions that mention this task so the eyes-agent reads the
+// real "why", instead of re-deriving intent from code.
+function collectIntentSources(taskId) {
+  const decisionsRoot = paths.decisionsRoot;
+  if (!decisionsRoot || !existsSync(decisionsRoot)) return [];
+  const sources = [];
+  for (const filePath of walkFiles(decisionsRoot)) {
+    if (!/\.(json|md)$/u.test(filePath)) continue;
+    let text;
+    try {
+      text = readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+    if (!text.includes(taskId)) continue;
+    sources.push({
+      ref: `decision/${path.basename(path.dirname(filePath))}`,
+      title: firstHeading(text) ?? path.basename(filePath),
+      sourcePath: relative(filePath)
+    });
+  }
+  return dedupeByRef(sources);
+}
+
+function renderReport({ featureTask, findings, intentSources }) {
+  const lines = [
+    "# Usage Acceptance Report",
+    "",
+    `- Feature task: ${findings.featureTaskId}${featureTask?.title ? ` — ${featureTask.title}` : ""}`,
+    `- Persona: ${findings.persona}`,
+    `- Surface: ${findings.surface}`,
+    `- Verdict: ${findings.verdict}`,
+    "",
+    "## Scenario",
+    "",
+    findings.scenario,
+    "",
+    "## Intent Sources (read these to reconstruct a satisfied user — do NOT read the implementation)",
+    ""
+  ];
+  if (intentSources.length === 0) {
+    lines.push("- (none auto-found; open the spawning decision(s) and task goal by hand)");
+  } else {
+    for (const source of intentSources) lines.push(`- ${source.ref} — ${source.title} (${source.sourcePath})`);
+  }
+  lines.push(
+    "",
+    "## How to capture (eyes-agent)",
+    "",
+    "- GUI: drive `packages/gui/e2e/harness-fixture.mjs` against a REAL persona ledger",
+    "  (never the hermetic smoke fixture), with `HARNESS_GUI_E2E_SHOTS` set to this",
+    "  package's `artifacts/shots/`. Walk the scenario as the persona would.",
+    "- CLI / multi-actor business flows: run the real end-to-end as distinct actors;",
+    "  tee the transcript into `artifacts/`.",
+    "- Read each screenshot; narrate friction from the USER's angle.",
+    "",
+    "## Findings (fill usage-acceptance-findings.json; severity: blocker | friction | nit)",
+    "",
+    "- Each finding needs: expected-vs-actual + an evidence anchor (a real shot/transcript path).",
+    "- Blocker = cannot complete the intended job. Friction = completes but confusing/mismatch.",
+    "- A report with zero friction and no off-happy-path attempts is treated as suspect by `check`.",
+    "",
+    "## Semantic Questions (escalate to human only when the ledger can't resolve intent)",
+    "",
+    "- Intent ambiguity / decision conflict / scope creep / cross-collaboration constraint.",
+    "",
+    "## Verdict",
+    "",
+    "- Set `verdict` to `pass` only after every blocker is fixed & re-walked; log residual friction as facts."
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+function resolveInput(value, fallback) {
+  if (typeof value !== "string") return fallback;
+  return /^\{\{.+\}\}$/u.test(value.trim()) || value.trim() === "" ? fallback : value.trim();
+}
+
+function firstHeading(text) {
+  const md = /^#\s+(.+)$/mu.exec(text);
+  if (md) return md[1].trim();
+  try {
+    const parsed = JSON.parse(text);
+    if (typeof parsed.title === "string") return parsed.title;
+  } catch {
+    // not json
+  }
+  return null;
+}
+
+function dedupeByRef(items) {
+  const seen = new Set();
+  const out = [];
+  for (const item of items) {
+    if (seen.has(item.ref)) continue;
+    seen.add(item.ref);
+    out.push(item);
+  }
+  return out;
+}
+
+function walkFiles(root) {
+  if (!root || !existsSync(root)) return [];
+  const stat = statSync(root);
+  if (stat.isFile()) return [root];
+  if (!stat.isDirectory()) return [];
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) return walkFiles(entryPath);
+    return entry.isFile() ? [entryPath] : [];
+  }).sort();
+}
+
+function relative(filePath) {
+  return path.relative(paths.rootDir ?? outputRoot, filePath).split(path.sep).join("/");
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/usage-acceptance/v2/scripts/usage-acceptance-check.mjs
+++ b/packages/cli/test/fixtures/preset-v3-canaries/usage-acceptance/v2/scripts/usage-acceptance-check.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// usage-acceptance :: check
+//
+// Deterministic gate-readable validator over the eyes-agent's findings. It is
+// the anti-foam lock: a run only passes when the report shows a real, evidenced,
+// user-angle walkthrough with every blocker resolved. This is what a future
+// `usage-acceptance` completion-gate axis (application layer) would invoke to
+// hard-block a feature task's completion.
+//
+// Pass conditions (ALL required):
+//   - findings.json exists and parses,
+//   - verdict === "pass",
+//   - zero blockers left unresolved (a blocker needs a non-empty `resolution`),
+//   - every finding carries at least one evidence anchor,
+//   - at least one finding OR one escalated semantic question exists
+//     (a zero-friction, zero-question report is treated as "did not really look").
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const contextPath = process.env.HARNESS_PRESET_CONTEXT ?? process.env.HARNESS_SCRIPT_CONTEXT;
+if (!contextPath) throw new Error("HARNESS_PRESET_CONTEXT is required");
+const context = JSON.parse(readFileSync(contextPath, "utf8"));
+const outputRoot = context.outputRoot;
+const artifactsDir = path.join(outputRoot, "artifacts");
+mkdirSync(artifactsDir, { recursive: true });
+
+const findingsPath = path.join(artifactsDir, "usage-acceptance-findings.json");
+const violations = [];
+const smokeMode = context.validationSmoke === true;
+let findings = smokeMode ? smokeFindings(context.taskId) : null;
+
+if (smokeMode) {
+  writeFileSync(path.join(artifactsDir, "usage-acceptance-smoke-evidence.txt"), "isolated usage-acceptance checker smoke\n", "utf8");
+} else if (!existsSync(findingsPath)) {
+  violations.push({ code: "findings_missing", detail: "run `scaffold` first, then have the eyes-agent fill it" });
+} else {
+  try {
+    findings = JSON.parse(readFileSync(findingsPath, "utf8"));
+  } catch (error) {
+    violations.push({ code: "findings_unparseable", detail: String(error?.message ?? error) });
+  }
+}
+
+if (findings) {
+  const list = Array.isArray(findings.findings) ? findings.findings : [];
+  const questions = Array.isArray(findings.semanticQuestions) ? findings.semanticQuestions : [];
+
+  if (findings.verdict !== "pass") {
+    violations.push({ code: "verdict_not_pass", detail: `verdict is "${findings.verdict ?? "missing"}"` });
+  }
+
+  const openBlockers = list.filter((item) => item.severity === "blocker" && !String(item.resolution ?? "").trim());
+  for (const blocker of openBlockers) {
+    violations.push({ code: "blocker_unresolved", detail: blocker.id ?? blocker.expected ?? "unnamed blocker" });
+  }
+
+  const noEvidence = list.filter((item) => !Array.isArray(item.evidence) || item.evidence.length === 0);
+  for (const item of noEvidence) {
+    violations.push({ code: "finding_without_evidence", detail: item.id ?? item.expected ?? "unnamed finding" });
+  }
+
+  const escalated = questions.filter((question) => question.escalate === true);
+  if (list.length === 0 && escalated.length === 0) {
+    violations.push({ code: "empty_walkthrough", detail: "zero findings and zero escalated questions — treated as 'did not really use it'" });
+  }
+}
+
+const status = violations.length === 0 ? "passed" : "blocked";
+const report = {
+  schema: "usage-acceptance-check/v1",
+  taskId: context.taskId,
+  featureTaskId: findings?.featureTaskId ?? resolveInput(context.inputs?.featureTaskId, context.taskId),
+  status,
+  generatedAt: new Date().toISOString(),
+  summary: {
+    findings: Array.isArray(findings?.findings) ? findings.findings.length : 0,
+    openBlockers: violations.filter((violation) => violation.code === "blocker_unresolved").length,
+    violations: violations.length
+  },
+  violations
+};
+
+writeFileSync(path.join(artifactsDir, "usage-acceptance-check.json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
+writeFileSync(path.join(artifactsDir, "preset-result.json"), `${JSON.stringify({
+  ok: status === "passed",
+  rows: report.summary.findings,
+  report,
+  error: status === "passed" ? undefined : {
+    code: "usage_acceptance_not_satisfied",
+    hint: `Usage acceptance is blocked: ${violations.map((violation) => violation.code).join(", ") || "unknown"}`
+  }
+}, null, 2)}\n`, "utf8");
+
+function resolveInput(value, fallback) {
+  if (typeof value !== "string") return fallback;
+  return /^\{\{.+\}\}$/u.test(value.trim()) || value.trim() === "" ? fallback : value.trim();
+}
+
+function smokeFindings(taskId) {
+  return {
+    schema: "usage-acceptance-findings/v1",
+    featureTaskId: taskId,
+    persona: "preset checker smoke",
+    surface: "cli",
+    scenario: "validate a passing, evidenced finding through the real checker",
+    intentSources: [],
+    findings: [{
+      id: "smoke-evidenced-friction",
+      severity: "friction",
+      expected: "the checker accepts an evidenced and resolved walkthrough",
+      actual: "the isolated fixture reached the validator",
+      evidence: ["artifacts/usage-acceptance-smoke-evidence.txt"],
+      resolution: "verified by the preset check smoke"
+    }],
+    semanticQuestions: [],
+    verdict: "pass",
+    capturedAt: new Date().toISOString()
+  };
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/usage-acceptance/v3/preset.json
+++ b/packages/cli/test/fixtures/preset-v3-canaries/usage-acceptance/v3/preset.json
@@ -1,0 +1,61 @@
+{
+  "schema": "preset-manifest/v3",
+  "id": "usage-acceptance",
+  "title": "Usage Acceptance",
+  "vertical": "software/coding",
+  "version": "2.0.0",
+  "kind": "process-action",
+  "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
+  "capabilityImports": [],
+  "entrypoints": {
+    "scaffold": {
+      "type": "script",
+      "command": "scripts/usage-acceptance-capture.mjs",
+      "intent": { "verb": "capture", "subject": "usage-acceptance-context" },
+      "inputs": {
+        "featureTaskId": { "type": "task-ref", "required": true, "defaultFrom": "current-task" },
+        "persona": { "type": "string", "required": true, "default": "first-time collaborator joining the centralized repo" },
+        "surface": { "type": "enum", "required": true, "values": ["gui", "cli", "multi-actor"], "default": "gui" },
+        "scenario": { "type": "string", "required": false, "default": "" }
+      },
+      "requires": [
+        { "capability": "tasks", "version": "1", "select": { "taskFrom": "featureTaskId", "view": "intent-summary" } },
+        { "capability": "decisions", "version": "1", "select": { "relatedToTaskFrom": "featureTaskId", "view": "intent-summary" } }
+      ],
+      "produces": [{
+        "capability": "task-artifacts",
+        "version": "1",
+        "target": { "taskFrom": "current-task" },
+        "artifacts": [
+          { "id": "usage-acceptance-findings", "schema": "usage-acceptance-findings/v1", "mediaTypes": ["application/json"], "cardinality": "one", "required": true },
+          { "id": "usage-acceptance-report", "schema": "usage-acceptance-report/v1", "mediaTypes": ["text/markdown"], "cardinality": "one", "required": true }
+        ]
+      }],
+      "sideEffects": []
+    },
+    "check": {
+      "type": "script",
+      "command": "scripts/usage-acceptance-check.mjs",
+      "intent": { "verb": "check", "subject": "usage-acceptance-evidence" },
+      "inputs": {
+        "featureTaskId": { "type": "task-ref", "required": true, "defaultFrom": "current-task" }
+      },
+      "requires": [{
+        "capability": "task-artifacts",
+        "version": "1",
+        "select": { "taskFrom": "current-task", "artifactIds": ["usage-acceptance-findings", "usage-acceptance-evidence"] }
+      }],
+      "produces": [{
+        "capability": "task-artifacts",
+        "version": "1",
+        "target": { "taskFrom": "current-task" },
+        "artifacts": [
+          { "id": "usage-acceptance-check", "schema": "usage-acceptance-check/v1", "mediaTypes": ["application/json"], "cardinality": "one", "required": true }
+        ]
+      }],
+      "sideEffects": []
+    }
+  },
+  "defaultProfile": "baseline",
+  "profiles": [{ "id": "baseline", "title": "Baseline", "checkerProfile": "standard", "completionGates": ["ci", "code-doc-reconciliation"], "templateSelections": [] }]
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/usage-acceptance/v3/scripts/usage-acceptance-capture.mjs
+++ b/packages/cli/test/fixtures/preset-v3-canaries/usage-acceptance/v3/scripts/usage-acceptance-capture.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+const context = readContext();
+const tasks = readCapability("tasks").tasks;
+const decisions = readCapability("decisions").decisions;
+const featureTaskId = context.inputs.featureTaskId;
+const persona = String(context.inputs.persona ?? "").trim() || "first-time user of the feature under review";
+const surface = String(context.inputs.surface ?? "gui").trim() || "gui";
+const scenario = String(context.inputs.scenario ?? "").trim();
+const featureTask = tasks.find((task) => task.taskId === featureTaskId) ?? null;
+const intentSources = decisions.map((decision) => ({
+  ref: decision.ref,
+  title: decision.title,
+  sourcePath: decision.sourcePath
+}));
+const findings = {
+  schema: "usage-acceptance-findings/v1",
+  featureTaskId,
+  persona,
+  surface,
+  scenario: scenario || "(fill: the job-to-be-done, derived from intentSources — NOT from the implementation)",
+  intentSources: intentSources.map((source) => ({ ref: source.ref, title: source.title, path: source.sourcePath })),
+  findings: [],
+  semanticQuestions: [],
+  verdict: "pending",
+  capturedAt: new Date().toISOString()
+};
+writeFileSync(outputRepresentation("usage-acceptance-findings", "application/json").path, `${JSON.stringify(findings, null, 2)}\n`, "utf8");
+const reportRepresentation = outputRepresentation("usage-acceptance-report", "text/markdown");
+writeFileSync(reportRepresentation.path, renderReport({ featureTask, findings, intentSources }), "utf8");
+const report = {
+  schema: "usage-acceptance-capture/v1",
+  taskId: context.run.taskId,
+  featureTaskId,
+  status: "captured",
+  generatedAt: new Date().toISOString(),
+  featureTaskTitle: featureTask?.title ?? null,
+  intentSourceCount: intentSources.length,
+  shotsDir: `${reportRepresentation.logicalPath.slice(0, reportRepresentation.logicalPath.lastIndexOf("/"))}/shots`
+};
+writeResult({
+  schema: "script-result/v1",
+  ok: true,
+  rows: intentSources.length,
+  report,
+  produced: ["usage-acceptance-findings", "usage-acceptance-report"]
+});
+
+function renderReport({ featureTask: task, findings: value, intentSources: sources }) {
+  const lines = [
+    "# Usage Acceptance Report", "",
+    `- Feature task: ${value.featureTaskId}${task?.title ? ` — ${task.title}` : ""}`,
+    `- Persona: ${value.persona}`, `- Surface: ${value.surface}`, `- Verdict: ${value.verdict}`,
+    "", "## Scenario", "", value.scenario, "",
+    "## Intent Sources (read these to reconstruct a satisfied user — do NOT read the implementation)", ""
+  ];
+  if (sources.length === 0) lines.push("- (none auto-found; open the spawning decision(s) and task goal by hand)");
+  else for (const source of sources) lines.push(`- ${source.ref} — ${source.title} (${source.sourcePath})`);
+  lines.push(
+    "", "## How to capture (eyes-agent)", "",
+    "- GUI: drive `packages/gui/e2e/harness-fixture.mjs` against a REAL persona ledger",
+    "  (never the hermetic smoke fixture), with `HARNESS_GUI_E2E_SHOTS` set to this",
+    "  package's `artifacts/shots/`. Walk the scenario as the persona would.",
+    "- CLI / multi-actor business flows: run the real end-to-end as distinct actors;",
+    "  tee the transcript into `artifacts/`.",
+    "- Read each screenshot; narrate friction from the USER's angle.",
+    "", "## Findings (fill usage-acceptance-findings.json; severity: blocker | friction | nit)", "",
+    "- Each finding needs: expected-vs-actual + an evidence anchor (a real shot/transcript path).",
+    "- Blocker = cannot complete the intended job. Friction = completes but confusing/mismatch.",
+    "- A report with zero friction and no off-happy-path attempts is treated as suspect by `check`.",
+    "", "## Semantic Questions (escalate to human only when the ledger can't resolve intent)", "",
+    "- Intent ambiguity / decision conflict / scope creep / cross-collaboration constraint.",
+    "", "## Verdict", "",
+    "- Set `verdict` to `pass` only after every blocker is fixed & re-walked; log residual friction as facts."
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+function readContext() {
+  const filename = process.env.HARNESS_PRESET_CONTEXT;
+  if (!filename) throw new Error("HARNESS_PRESET_CONTEXT is required");
+  return JSON.parse(readFileSync(filename, "utf8"));
+}
+
+function readCapability(id) {
+  const handle = context.capabilities.reads[id]?.[0];
+  if (!handle) throw new Error(`missing ${id} capability handle`);
+  return JSON.parse(readFileSync(handle.path, "utf8"));
+}
+
+function outputRepresentation(id, mediaType) {
+  const writer = context.capabilities.writes["task-artifacts"]?.[0];
+  const representation = writer?.artifacts?.[id]?.representations?.find((entry) => entry.mediaType === mediaType);
+  if (!representation) throw new Error(`missing ${id} ${mediaType} writer`);
+  return representation;
+}
+
+function writeResult(value) {
+  writeFileSync(context.result.path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/packages/cli/test/fixtures/preset-v3-canaries/usage-acceptance/v3/scripts/usage-acceptance-check.mjs
+++ b/packages/cli/test/fixtures/preset-v3-canaries/usage-acceptance/v3/scripts/usage-acceptance-check.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+const context = readContext();
+const artifacts = readCapability("task-artifacts").artifacts;
+const findingsHandle = artifacts.find((artifact) => artifact.id === "usage-acceptance-findings" && artifact.mediaType === "application/json");
+const violations = [];
+let findings = null;
+if (!findingsHandle) {
+  violations.push({ code: "findings_missing", detail: "run `scaffold` first, then have the eyes-agent fill it" });
+} else {
+  try {
+    findings = JSON.parse(readFileSync(findingsHandle.path, "utf8"));
+  } catch (error) {
+    violations.push({ code: "findings_unparseable", detail: String(error?.message ?? error) });
+  }
+}
+if (findings) {
+  const list = Array.isArray(findings.findings) ? findings.findings : [];
+  const questions = Array.isArray(findings.semanticQuestions) ? findings.semanticQuestions : [];
+  if (findings.verdict !== "pass") violations.push({ code: "verdict_not_pass", detail: `verdict is "${findings.verdict ?? "missing"}"` });
+  for (const blocker of list.filter((item) => item.severity === "blocker" && !String(item.resolution ?? "").trim())) {
+    violations.push({ code: "blocker_unresolved", detail: blocker.id ?? blocker.expected ?? "unnamed blocker" });
+  }
+  for (const item of list.filter((candidate) => !Array.isArray(candidate.evidence) || candidate.evidence.length === 0)) {
+    violations.push({ code: "finding_without_evidence", detail: item.id ?? item.expected ?? "unnamed finding" });
+  }
+  const escalated = questions.filter((question) => question.escalate === true);
+  if (list.length === 0 && escalated.length === 0) {
+    violations.push({ code: "empty_walkthrough", detail: "zero findings and zero escalated questions — treated as 'did not really use it'" });
+  }
+}
+const status = violations.length === 0 ? "passed" : "blocked";
+const report = {
+  schema: "usage-acceptance-check/v1",
+  taskId: context.run.taskId,
+  featureTaskId: findings?.featureTaskId ?? context.inputs.featureTaskId,
+  status,
+  generatedAt: new Date().toISOString(),
+  summary: {
+    findings: Array.isArray(findings?.findings) ? findings.findings.length : 0,
+    openBlockers: violations.filter((violation) => violation.code === "blocker_unresolved").length,
+    violations: violations.length
+  },
+  violations
+};
+writeFileSync(outputPath("usage-acceptance-check", "application/json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
+writeResult({
+  schema: "script-result/v1",
+  ok: status === "passed",
+  rows: report.summary.findings,
+  report,
+  produced: ["usage-acceptance-check"],
+  error: status === "passed" ? undefined : {
+    code: "usage_acceptance_not_satisfied",
+    hint: `Usage acceptance is blocked: ${violations.map((violation) => violation.code).join(", ") || "unknown"}`
+  }
+});
+
+function readContext() {
+  const filename = process.env.HARNESS_PRESET_CONTEXT;
+  if (!filename) throw new Error("HARNESS_PRESET_CONTEXT is required");
+  return JSON.parse(readFileSync(filename, "utf8"));
+}
+
+function readCapability(id) {
+  const handle = context.capabilities.reads[id]?.[0];
+  if (!handle) throw new Error(`missing ${id} capability handle`);
+  return JSON.parse(readFileSync(handle.path, "utf8"));
+}
+
+function outputPath(id, mediaType) {
+  const writer = context.capabilities.writes["task-artifacts"]?.[0];
+  const representation = writer?.artifacts?.[id]?.representations?.find((entry) => entry.mediaType === mediaType);
+  if (!representation) throw new Error(`missing ${id} ${mediaType} writer`);
+  return representation.path;
+}
+
+function writeResult(value) {
+  writeFileSync(context.result.path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/packages/cli/test/preset-preflight-cli.test.ts
+++ b/packages/cli/test/preset-preflight-cli.test.ts
@@ -157,8 +157,8 @@ function v3Manifest(): Record<string, unknown> {
         type: "script",
         command: "scripts/check.mjs",
         intent: { verb: "check", subject: "provider-readiness" },
-        inputs: {},
-        requires: [{ capability: "docmap", version: "1", select: { view: "presence" } }],
+        inputs: { sourcePack: { type: "string", required: true } },
+        requires: [{ capability: "external-source-pack", version: "1", select: { packFrom: "sourcePack", view: "files-with-provenance" } }],
         produces: [],
         sideEffects: []
       }

--- a/packages/cli/test/preset-v3-canary-equivalence-cli.test.ts
+++ b/packages/cli/test/preset-v3-canary-equivalence-cli.test.ts
@@ -1,0 +1,352 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { findTaskPackagePath, readTaskProjection, resolveHarnessLayout } from "../../kernel/src/index.ts";
+import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
+import { runJson, withTempRoot } from "./helpers/preset-script-fixtures.ts";
+
+process.env.HARNESS_DAEMON_MODE = "direct";
+process.env.HARNESS_DAEMON_PROFILE = "isolated";
+delete process.env.HARNESS_DAEMON_USER_ROOT;
+
+type CanaryId = "doc-canon-sync" | "usage-acceptance" | "milestone-dossier" | "dogfood-utilization-audit";
+type Version = "v2" | "v3";
+
+interface CanaryRun {
+  readonly taskId: string;
+  readonly result: Record<string, any>;
+  readonly reports: Readonly<Record<string, unknown>>;
+  readonly context?: Record<string, any>;
+}
+
+const fixtureRoot = path.resolve("packages/cli/test/fixtures/preset-v3-canaries");
+const trackedPresets = [
+  "standard-task", "module", "legacy-migration", "doc-canon-sync", "milestone-closeout",
+  "lesson-sedimentation", "milestone-dossier", "version-upgrade", "publish-standard",
+  "release-closeout", "long-running-task", "dogfood-utilization-audit"
+];
+
+for (const canary of ["doc-canon-sync", "usage-acceptance", "milestone-dossier", "dogfood-utilization-audit"] as const) {
+  test(`${canary} v3 semantic runtime preserves the v2 business report with narrower authority`, () => {
+    const legacy = runCanary(canary, "v2");
+    const semantic = runCanary(canary, "v3");
+
+    assert.deepEqual(
+      normalizeBusinessOutput(semantic.reports, semantic.taskId, canary),
+      normalizeBusinessOutput(legacy.reports, legacy.taskId, canary)
+    );
+    assert.equal(legacy.result.warnings.some((warning: Record<string, unknown>) => warning.code === "legacy-physical-scope"), true);
+    assert.equal(semantic.result.capabilityReceipt.schema, "preset-capability-runtime-receipt/v1");
+    assert.equal(semantic.result.capabilityReceipt.semanticFailureFallback, "forbidden");
+    assertV2ContextIsHandleOnly(semantic.context);
+    assertSemanticManifestHasNoPhysicalScopeTokens(canary);
+  });
+}
+
+test("v3 semantic execution fails closed when a required projection is empty", () => {
+  withTempRoot((rootDir) => {
+    seedRoot(rootDir);
+    installPreset(rootDir, "doc-canon-sync", "v3");
+    const created = runJson(rootDir, ["new-task", "--title", "Empty Projection", "--vertical", "software/coding", "--preset", "doc-canon-sync"]);
+    removeCanonicalSources(rootDir);
+    runJson(rootDir, ["governance", "rebuild"]);
+
+    const result = runJson(rootDir, [
+      "preset", "action", "doc-canon-sync", "check", "--task", created.taskId, "--allow-scripts"
+    ], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "preset_runtime_unavailable");
+    assert.match(result.error.hint, /empty projection; raw-fs fallback is forbidden/u);
+    assert.equal(result.warnings?.some((warning: Record<string, unknown>) => warning.code === "legacy-physical-scope") ?? false, false);
+  });
+});
+
+function runCanary(canary: CanaryId, version: Version): CanaryRun {
+  return withTempRoot((rootDir) => {
+    seedRoot(rootDir);
+    installPreset(rootDir, canary, version);
+    const created = runJson(rootDir, [
+      "new-task", "--title", `${canary} Canary`, "--vertical", "software/coding", "--preset", canary
+    ]);
+    const taskId = String(created.taskId);
+    if (canary === "usage-acceptance") writeDecision(rootDir, "dec_USAGE", "Usage Intent Decision", taskId);
+    runJson(rootDir, ["governance", "rebuild"]);
+
+    if (version === "v3") {
+      const validated = runJson(rootDir, ["preset", "validate", path.join(fixtureRoot, canary, version, "preset.json")]);
+      const checked = runJson(rootDir, ["preset", "check", canary]);
+      assert.equal(validated.report.preflight.valid, true);
+      assert.equal(checked.preset.valid, true);
+    }
+
+    if (canary === "usage-acceptance") return runUsageAcceptance(rootDir, taskId, version);
+    if (canary === "dogfood-utilization-audit") resetAuditInventories(rootDir);
+    const args = ["preset", "action", canary, entrypointFor(canary), "--task", taskId, "--allow-scripts"];
+    if (canary === "milestone-dossier") args.push("--input", "decisionId=dec_CANARY");
+    const result = version === "v2" && (canary === "milestone-dossier" || canary === "dogfood-utilization-audit")
+      ? runLegacyBaselineDirect(rootDir, canary, taskId)
+      : runJson(rootDir, args);
+    const artifactsRoot = taskArtifactsRoot(rootDir, taskId);
+    const reportName = canary === "doc-canon-sync"
+      ? "doc-canon-drift.json"
+      : canary === "milestone-dossier"
+        ? "dossier.data.json"
+        : "dogfood-utilization-audit.json";
+    return {
+      taskId,
+      result,
+      reports: {
+        business: readJson(path.join(artifactsRoot, reportName)),
+        receiptReport: result.report
+      },
+      ...(version === "v3" ? { context: readRunContext(rootDir, result) } : {})
+    };
+  });
+}
+
+function runUsageAcceptance(rootDir: string, taskId: string, version: Version): CanaryRun {
+  const captured = runJson(rootDir, [
+    "preset", "action", "usage-acceptance", "scaffold", "--task", taskId, "--allow-scripts"
+  ]);
+  const artifactsRoot = taskArtifactsRoot(rootDir, taskId);
+  const findingsPath = path.join(artifactsRoot, "usage-acceptance-findings.json");
+  const initialFindings = readJson(findingsPath);
+  const completedFindings = {
+    ...initialFindings,
+    findings: [{
+      id: "canary-friction",
+      severity: "friction",
+      expected: "semantic and legacy runs expose the same workflow",
+      actual: "both canaries completed",
+      evidence: ["artifacts/usage-acceptance-evidence.txt"],
+      resolution: "verified"
+    }],
+    verdict: "pass"
+  };
+  writeFileSync(findingsPath, `${JSON.stringify(completedFindings, null, 2)}\n`, "utf8");
+  writeFileSync(path.join(artifactsRoot, "usage-acceptance-evidence.txt"), "canary evidence\n", "utf8");
+  const checked = runJson(rootDir, [
+    "preset", "action", "usage-acceptance", "check", "--task", taskId, "--allow-scripts"
+  ]);
+  return {
+    taskId,
+    result: checked,
+    reports: {
+      capture: captured.report,
+      findings: initialFindings,
+      check: readJson(path.join(artifactsRoot, "usage-acceptance-check.json")),
+      checkReceiptReport: checked.report
+    },
+    ...(version === "v3" ? { context: readRunContext(rootDir, checked) } : {})
+  };
+}
+
+function seedRoot(rootDir: string): void {
+  writeTask(rootDir, "task_BASE_CANARY", "Base Canary Task", "standard-task");
+  writeDecision(rootDir, "dec_CANARY", "CLI Canon Decision", "task_BASE_CANARY");
+  writeText(rootDir, "harness/adr/ADR-0001-canary.md", [
+    "---", "id: ADR-0001", "title: Canary Architecture", "status: accepted", "date: 2026-07-01", "---", "",
+    "# Canary Architecture", "", "## Status", "", "Accepted 2026-07-01", ""
+  ].join("\n"));
+  writeText(rootDir, "harness/AGENTS.md", [
+    "# Operating Guide", "", "Tasks circulate through decision, fact, and relation records.",
+    "The CLI canon includes dec_CANARY and ADR-0001.",
+    "<!-- canon-synced-through: dec_CANARY @ 2026-12-01T00:00:00.000Z -->", ""
+  ].join("\n"));
+  writeText(rootDir, "harness/governance/guide.md", "# Governance\n\nDecision, fact, and relation circulation.\n");
+  writeText(rootDir, "harness/standards/guide.md", "# Standards\n\nCLI report and schema standards cover dec_CANARY and ADR-0001.\n");
+  writeText(rootDir, "harness/docmap.json", "{\"schema\":\"docmap/v1\"}\n");
+  writeText(rootDir, ".harness/generated/runtime-events/canary.jsonl", `${JSON.stringify({
+    schema: "runtime-event/v1",
+    result: { summary: "CLI command succeeded: preset-action" },
+    presets: trackedPresets
+  })}\n`);
+  writeText(rootDir, ".harness/generated/distill/candidate.json", "{}\n");
+  writeText(rootDir, ".harness/generated/lessons/promotion.json", "{}\n");
+  writeText(rootDir, ".harness/generated/graph-panorama/index.html", "<html></html>\n");
+  writeText(rootDir, ".harness/write-journal/canary.json", "{}\n");
+  writeText(rootDir, "harness/tasks/task_BASE_CANARY-fixture/artifacts/evidence.json", `${JSON.stringify({ presetId: "standard-task" })}\n`);
+  ensureTestHarnessIdentity(rootDir);
+  runJson(rootDir, ["governance", "rebuild"]);
+}
+
+function resetAuditInventories(rootDir: string): void {
+  rmSync(path.join(rootDir, ".harness/generated"), { recursive: true, force: true });
+  rmSync(path.join(rootDir, ".harness/write-journal"), { recursive: true, force: true });
+  writeText(rootDir, ".harness/generated/runtime-events/canary.jsonl", `${JSON.stringify({
+    schema: "runtime-event/v1",
+    result: { summary: "CLI command succeeded: preset-action" },
+    presets: trackedPresets
+  })}\n`);
+  writeText(rootDir, ".harness/generated/distill/candidate.json", "{}\n");
+  writeText(rootDir, ".harness/generated/lessons/promotion.json", "{}\n");
+  writeText(rootDir, ".harness/generated/graph-panorama/index.html", "<html></html>\n");
+  writeText(rootDir, ".harness/write-journal/canary.json", "{}\n");
+}
+
+function runLegacyBaselineDirect(
+  rootDir: string,
+  canary: "milestone-dossier" | "dogfood-utilization-audit",
+  taskId: string
+): Record<string, any> {
+  const layout = resolveHarnessLayout(rootDir);
+  const outputRoot = findTaskPackagePath(rootDir, taskId);
+  assert.ok(outputRoot);
+  const entrypoint = canary === "milestone-dossier" ? "gather" : "audit";
+  const scriptName = canary === "milestone-dossier" ? "dossier-data.mjs" : "preset-action.mjs";
+  const contextPath = path.join(layout.localRoot, "legacy-baseline", `${canary}.context.json`);
+  const taskIndex = readTaskProjection({ rootDir }).rows.map((task) => ({
+    taskId: task.taskId,
+    title: task.title,
+    preset: task.preset,
+    indexPath: task.sourcePath,
+    packagePath: path.posix.dirname(task.sourcePath)
+  }));
+  const context = {
+    schema: "preset-context/v1",
+    presetId: canary,
+    entrypoint,
+    taskId,
+    outputRoot,
+    paths: {
+      rootDir: layout.rootDir,
+      authoredRoot: layout.authoredRoot,
+      tasksRoot: layout.tasksRoot,
+      decisionsRoot: layout.decisionsRoot,
+      adrRoot: layout.adrRoot,
+      generatedRoot: layout.generatedRoot,
+      localRoot: layout.localRoot
+    },
+    taskIndex,
+    inputs: canary === "milestone-dossier"
+      ? { coordinationTaskId: taskId, decisionId: "dec_CANARY" }
+      : { trackedPresets: trackedPresets.join(","), trackedArtifacts: "runtime-events,distill-candidates,lesson-promotions,graph-panorama,write-journal,docmap" }
+  };
+  mkdirSync(path.dirname(contextPath), { recursive: true });
+  writeFileSync(contextPath, `${JSON.stringify(context, null, 2)}\n`, "utf8");
+  execFileSync(process.execPath, [path.join(fixtureRoot, canary, "v2/scripts", scriptName)], {
+    env: { ...process.env, HARNESS_PRESET_CONTEXT: contextPath, HARNESS_SCRIPT_CONTEXT: contextPath }
+  });
+  const scriptedResult = readJson(path.join(outputRoot, "artifacts/preset-result.json"));
+  return {
+    ok: scriptedResult.ok === true,
+    report: scriptedResult.report,
+    warnings: [{ code: "legacy-physical-scope" }]
+  };
+}
+
+function installPreset(rootDir: string, canary: CanaryId, version: Version): void {
+  if (version === "v2") {
+    cpSync(path.join(fixtureRoot, canary, version), path.join(rootDir, ".harness/presets", canary), { recursive: true });
+    return;
+  }
+  const installed = runJson(rootDir, ["preset", "install", path.join(fixtureRoot, canary, version), "--project"]);
+  assert.equal(installed.ok, true);
+}
+
+function writeTask(rootDir: string, taskId: string, title: string, preset: string): void {
+  writeText(rootDir, `harness/tasks/${taskId}-fixture/INDEX.md`, [
+    "---", "schema: task-package/v2", `task_id: ${taskId}`, `title: ${title}`,
+    "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", "  status: active", "  ref: ",
+    `  titleSnapshot: ${title}`, "  url: ", "  bindingCreatedAt: 2026-07-04T00:00:00.000Z",
+    "  bindingFingerprint: sha256:4d1771ef6e83619eb8a82f1593bf118383084665fc58f634072d379178d525d7",
+    "packageDisposition: active", "vertical: software/coding", `preset: ${preset}`, "---", "", `# ${title}`, ""
+  ].join("\n"));
+}
+
+function writeDecision(rootDir: string, decisionId: string, title: string, taskId: string): void {
+  writeText(rootDir, `harness/decisions/${decisionId}/decision.md`, [
+    "---", "schema: decision-package/v1", `decision_id: ${decisionId}`, `_coordinatorWatermark: wm-${decisionId}`,
+    `title: "${title}"`, "state: active", "riskTier: low", "urgency: low", "vertical: software/coding",
+    "preset: architecture-decision", "applies_to:", "  modules: []", "  productLines: []",
+    "proposedBy: { kind: agent, id: fixture }", "proposedAt: 2026-07-01T00:00:00.000Z",
+    "arbiter: { kind: human, id: fixture }", "decidedAt: 2026-07-01T00:00:00.000Z",
+    `question: "Should ${title} derive ${taskId}?"`, "chosen:", "  - { id: CH1, text: Yes }",
+    "rejected:", "  - { id: RJ1, text: No, why_not: Fixture }", "claims: []", "relations: []",
+    "---", "", `# ${title}`, "", `This decision derives ${taskId}.`, ""
+  ].join("\n"));
+}
+
+function removeCanonicalSources(rootDir: string): void {
+  const decisions = path.join(rootDir, "harness/decisions");
+  const adrs = path.join(rootDir, "harness/adr");
+  for (const target of [decisions, adrs]) {
+    if (!existsSync(target)) continue;
+    for (const entry of readdirSync(target)) rmSync(path.join(target, entry), { recursive: true, force: true });
+    mkdirSync(target, { recursive: true });
+  }
+}
+
+function entrypointFor(canary: Exclude<CanaryId, "usage-acceptance">): string {
+  if (canary === "doc-canon-sync") return "check";
+  if (canary === "milestone-dossier") return "gather";
+  return "audit";
+}
+
+function taskArtifactsRoot(rootDir: string, taskId: string): string {
+  const taskRoot = findTaskPackagePath(rootDir, taskId);
+  assert.ok(taskRoot, `task package ${taskId} must exist`);
+  return path.join(taskRoot, "artifacts");
+}
+
+function readRunContext(rootDir: string, result: Record<string, any>): Record<string, any> {
+  assert.equal(typeof result.evidenceBundle, "string");
+  return readJson(path.join(rootDir, result.evidenceBundle, "context.json"));
+}
+
+function assertV2ContextIsHandleOnly(context: Record<string, any> | undefined): void {
+  assert.ok(context);
+  assert.equal(context.schema, "preset-context/v2");
+  for (const forbidden of ["paths", "readScopes", "writeScopes", "outputRoot", "repository"]) {
+    assert.equal(Object.hasOwn(context, forbidden), false, `preset-context/v2 must not expose ${forbidden}`);
+  }
+  assert.equal(context.receipt.semanticFailureFallback, "forbidden");
+  assert.equal(typeof context.capabilities, "object");
+}
+
+function assertSemanticManifestHasNoPhysicalScopeTokens(canary: CanaryId): void {
+  const body = readFileSync(path.join(fixtureRoot, canary, "v3/preset.json"), "utf8");
+  for (const forbidden of ["\"reads\"", "\"writes\"", "{{paths", "{{outputRoot", ".harness/", "harness/tasks/"]) {
+    assert.equal(body.includes(forbidden), false, `${canary} v3 manifest contains ${forbidden}`);
+  }
+}
+
+function normalizeBusinessOutput(value: unknown, taskId: string, canary: CanaryId): unknown {
+  const cloned = JSON.parse(JSON.stringify(value).split(taskId).join("<task>")) as unknown;
+  walkMutable(cloned, (record) => {
+    delete record.generatedAt;
+    delete record.capturedAt;
+    if (canary === "milestone-dossier" && "projection" in record && isRecord(record.projection)) {
+      record.projection.path = "<relation-graph-projection>";
+    }
+  });
+  return cloned;
+}
+
+function walkMutable(value: unknown, visit: (record: Record<string, any>) => void): void {
+  if (Array.isArray(value)) {
+    for (const entry of value) walkMutable(entry, visit);
+    return;
+  }
+  if (!isRecord(value)) return;
+  visit(value);
+  for (const entry of Object.values(value)) walkMutable(entry, visit);
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readJson(filename: string): Record<string, any> {
+  return JSON.parse(readFileSync(filename, "utf8")) as Record<string, any>;
+}
+
+function writeText(rootDir: string, relativePath: string, body: string): void {
+  const filename = path.join(rootDir, relativePath);
+  mkdirSync(path.dirname(filename), { recursive: true });
+  writeFileSync(filename, body, "utf8");
+}

--- a/packages/cli/test/receipt-contracts.test.ts
+++ b/packages/cli/test/receipt-contracts.test.ts
@@ -269,9 +269,25 @@ test("optional receipt contract fields carry non-empty absence reasons", () => {
     field: "data.rows",
     reason: "Only emitted when a scripted preset run writes a numeric rows value in its result."
   }, {
+    command: "preset-run",
+    field: "data.runId",
+    reason: "Only emitted by the semantic script host for an executable v3 entrypoint."
+  }, {
+    command: "preset-run",
+    field: "data.capabilityReceipt",
+    reason: "Only emitted by v3 semantic execution with its exact provider bindings."
+  }, {
     command: "preset-action",
     field: "data.rows",
     reason: "Only emitted when a scripted preset action writes a numeric rows value in its result."
+  }, {
+    command: "preset-action",
+    field: "data.runId",
+    reason: "Only emitted by the semantic script host for an executable v3 entrypoint."
+  }, {
+    command: "preset-action",
+    field: "data.capabilityReceipt",
+    reason: "Only emitted by v3 semantic execution with its exact provider bindings."
   }, {
     command: "script-run",
     field: "data.rows",

--- a/packages/kernel/src/domain/preset-preflight.ts
+++ b/packages/kernel/src/domain/preset-preflight.ts
@@ -303,7 +303,7 @@ function validateSelectorInputReferences(
   const expected = new Map<string, PresetInputV3["type"]>();
   for (const request of entrypoint.requires) {
     const select = request.select as Readonly<Record<string, unknown>>;
-    if (typeof select.taskFrom === "string") expected.set(select.taskFrom, "task-ref");
+    if (typeof select.taskFrom === "string" && select.taskFrom !== "current-task") expected.set(select.taskFrom, "task-ref");
     if (typeof select.relatedToTaskFrom === "string") expected.set(select.relatedToTaskFrom, "task-ref");
     if (typeof select.decisionFrom === "string") expected.set(select.decisionFrom, "decision-ref");
     if (typeof select.familiesFrom === "string") expected.set(select.familiesFrom, "enum-list");

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -116,6 +116,12 @@ export {
 export type { EntityAttributionProjection } from "./projection/types.ts";
 export * from "./schemas/registry.ts";
 export * from "./schemas/common.ts";
+export type {
+  LogicalArtifactV1,
+  PresetCapabilityRequirement,
+  PresetEntrypointV3,
+  PresetInputV3
+} from "./schemas/preset-manifest-v3.ts";
 export { RuntimeEventRecordV2Schema } from "./schemas/runtime-event.ts";
 export type { RuntimeEventRecordDocument, RuntimeEventRecordV2 } from "./schemas/runtime-event.ts";
 export type {

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -287,6 +287,31 @@
         "value": "packages/cli/src/commands/extensions/script-staging.ts#cpSync@1",
         "ref": "task_01KXBBTQAWARR3A1B2RY8T7C0F",
         "reason": "P4 coordinator-governed script ingest copies authored state only into the isolated local staging mirror; canonical changes are later applied solely by attributed enqueue and flush."
+      },
+      {
+        "value": "packages/cli/src/commands/extensions/preset-capability-providers.ts#writeFileSync@1",
+        "ref": "task_01KXJ819W8TFCMPPP59ARRVRSS",
+        "reason": "Preset v3 provider writes an immutable capability projection inside the isolated script run directory; it has no canonical write authority."
+      },
+      {
+        "value": "packages/cli/src/commands/extensions/preset-capability-providers.ts#mkdirSync@1",
+        "ref": "task_01KXJ819W8TFCMPPP59ARRVRSS",
+        "reason": "Preset v3 provider creates only an immutable task-artifact snapshot directory inside the isolated script run directory."
+      },
+      {
+        "value": "packages/cli/src/commands/extensions/preset-capability-providers.ts#cpSync@1",
+        "ref": "task_01KXJ819W8TFCMPPP59ARRVRSS",
+        "reason": "Preset v3 provider copies selected task artifacts into the immutable run snapshot; the source and canonical authored state remain read-only."
+      },
+      {
+        "value": "packages/cli/src/commands/extensions/preset-capability-runtime.ts#mkdirSync@1",
+        "ref": "task_01KXJ819W8TFCMPPP59ARRVRSS",
+        "reason": "Preset v3 runtime creates the isolated capability projection directory under script evidence; it has no canonical write authority."
+      },
+      {
+        "value": "packages/cli/src/commands/extensions/preset-capability-runtime.ts#mkdirSync@2",
+        "ref": "task_01KXJ819W8TFCMPPP59ARRVRSS",
+        "reason": "Preset v3 runtime creates only staged writer directories; canonical changes are later applied solely by attributed script ingest and WriteCoordinator flush."
       }
     ],
     "exemptHumanOrBootstrap": [
@@ -466,24 +491,14 @@
         "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#mkdirSync@1",
-        "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
-        "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
+        "value": "packages/cli/src/commands/extensions/preset-entrypoint-runtime.ts#mkdirSync@3",
+        "ref": "task_01KXJ819W8TFCMPPP59ARRVRSS",
+        "reason": "Legacy v1 scaffold creates its human-facing generated output directory; this is the existing legacy behavior relocated from state.ts."
       },
       {
-        "value": "packages/cli/src/commands/extensions/state.ts#mkdirSync@2",
-        "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
-        "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
-      },
-      {
-        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@1",
-        "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
-        "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
-      },
-      {
-        "value": "packages/cli/src/commands/extensions/state.ts#writeFileSync@2",
-        "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
-        "reason": "Explicit W8 exemption for human-facing generated/bootstrap artifact writes; not a machine projection authority."
+        "value": "packages/cli/src/commands/extensions/preset-entrypoint-runtime.ts#writeFileSync@1",
+        "ref": "task_01KXJ819W8TFCMPPP59ARRVRSS",
+        "reason": "Legacy v1 scaffold writes its human-facing generated artifact; this is the existing legacy behavior relocated from state.ts."
       },
       {
         "value": "packages/cli/src/commands/governance.ts#mkdirSync@1",
@@ -673,6 +688,26 @@
         "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@1",
         "ref": "task_01KWW58383X74ZK28Y068CQ2TG",
         "reason": "C11 script evidence scratch/registry write; machine-consumed evidence is guarded by fresh hash registry checks."
+      },
+      {
+        "value": "packages/cli/src/commands/extensions/script-host.ts#writeFileSync@4",
+        "ref": "task_01KXJ819W8TFCMPPP59ARRVRSS",
+        "reason": "Preset v3 host writes preset-context/v2 only into the isolated script evidence directory before permission-constrained execution."
+      },
+      {
+        "value": "packages/cli/src/commands/extensions/preset-entrypoint-runtime.ts#mkdirSync@1",
+        "ref": "task_01KXJ819W8TFCMPPP59ARRVRSS",
+        "reason": "Preset v3 authorization failure creates only its local script evidence directory; it does not mutate canonical authored state."
+      },
+      {
+        "value": "packages/cli/src/commands/extensions/preset-entrypoint-runtime.ts#mkdirSync@2",
+        "ref": "task_01KXJ819W8TFCMPPP59ARRVRSS",
+        "reason": "Legacy preset authorization creates only its local script evidence directory; this is existing behavior relocated from state.ts."
+      },
+      {
+        "value": "packages/cli/src/commands/extensions/preset-entrypoint-runtime.ts#writeFileSync@2",
+        "ref": "task_01KXJ819W8TFCMPPP59ARRVRSS",
+        "reason": "Preset entrypoint runtime writes the existing local evidence receipt after execution; canonical script outputs still enter through WriteCoordinator ingest."
       }
     ],
     "daemonTransportLifecycle": [

--- a/tools/gate-allowlists/check-kernel-dead-exports.json
+++ b/tools/gate-allowlists/check-kernel-dead-exports.json
@@ -364,11 +364,6 @@
         "reason": "F8a first enforcement pass preserves the existing kernel public barrel zero-consumption export baseline; future additions must show a consumer or carry new governance evidence."
       },
       {
-        "value": "findTaskPackagePath",
-        "ref": "task_01KWWCBRSV0V3AWTCM3ZZ1J998",
-        "reason": "F8a first enforcement pass preserves the existing kernel public barrel zero-consumption export baseline; future additions must show a consumer or carry new governance evidence."
-      },
-      {
         "value": "FlushReason",
         "ref": "task_01KWWCBRSV0V3AWTCM3ZZ1J998",
         "reason": "F8a first enforcement pass preserves the existing kernel public barrel zero-consumption export baseline; future additions must show a consumer or carry new governance evidence."

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -1136,12 +1136,12 @@
           "file": "packages/cli/src/commands/extensions/preset-evidence.ts"
         },
         {
-          "file": "packages/cli/src/commands/extensions/state.ts"
+          "file": "packages/cli/src/commands/extensions/preset-entrypoint-runtime.ts"
         }
       ],
       "evidence": [
         "packages/cli/src/commands/extensions/preset.ts:135",
-        "packages/cli/src/commands/extensions/state.ts:348"
+        "packages/cli/src/commands/extensions/preset-entrypoint-runtime.ts:186"
       ],
       "freshness": "admin-config-or-evidence"
     },
@@ -1170,6 +1170,12 @@
         },
         {
           "file": "packages/cli/src/commands/extensions/script-host.ts"
+        },
+        {
+          "file": "packages/cli/src/commands/extensions/preset-capability-providers.ts"
+        },
+        {
+          "file": "packages/cli/src/commands/extensions/preset-capability-runtime.ts"
         },
         {
           "file": "packages/cli/src/commands/extensions/shared.ts"


### PR DESCRIPTION
# English

## Summary

PLT-Preset-v3 **Phase 1**: builds the declarative-capability provider runtime and proves the v2→v3 migration pattern on 4 representative canaries with an old/new **output-equivalence** proof. This is the engine (and the migration recipe) that Phases 2/3's remaining presets follow.

A v3 preset declares *semantic capabilities* (intent / typed inputs / requires / produces / sideEffects) instead of physical read/write scopes. At run time the provider materializes each declared capability into an isolated projection directory and hands the script capability *handles* — never raw filesystem paths — so the script cannot reach canonical authored state at all.

## What Changed

- New provider runtime: `preset-capability-runtime.ts`, `preset-capability-providers.ts`, `preset-entrypoint-runtime.ts` (the last relocates legacy v1 scaffold writes out of `state.ts`, which shrinks 129 lines).
- Per-capability materializers: tasks, task-artifacts, relation-graph, runtime-events, generated-artifacts, write-journal, docmap. Unknown capability or empty projection → `providerUnavailable` (fail-closed; raw-fs fallback is explicitly forbidden).
- 4 canary v2/v3 fixtures + `preset-v3-canary-equivalence-cli.test.ts` proving, per canary: identical business report (`deepEqual`), handle-only `preset-context/v2` (no paths/scopes/outputRoot), zero physical tokens in the v3 manifest, and fail-closed on empty projection.
- Write-governance registration: new isolated-projection write callsites added to `check-bypass-write-boundary.json` and `write-road-registry.json`; stale `state.ts` entries relocated. Net +7 callsites, all isolated run/snapshot/evidence/staged dirs — canonical changes still flow only through attributed WriteCoordinator ingest/flush.

## Task And Scope

- Milestone: PLT-Preset-v3 (`task_01KXJ819W8TFCMPPP59ARRVRSS`); Phase-1 task `task_01KXJGABN428PHY7ASPQE845ZB`.
- Design authority: `dec_01KXHS6A` (declarative semantic capabilities) + `design-codex.md` §3 (runtime mapping) / §5.3 (phased migration) / §5.4 (acceptance).
- Branch: `wip/v3-phase1`
- Out of scope: flipping the 4 production canary presets to v3 (proven on fixtures here; the flip is Phase 2/3 mechanical follow-on) and migrating the remaining 16 presets.

## Version Impact

- Version: no CLI version change.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: yes (`tools/gate-allowlists/check-bypass-write-boundary.json`, `tools/gate-allowlists/check-kernel-dead-exports.json`, `tools/write-road-registry.json`).
- Authority: `dec_01KXHS6A` (PLT-Preset-v3 declarative semantic capability design) and milestone `task_01KXJ819W8TFCMPPP59ARRVRSS`. Every added write-boundary allowlist entry references the milestone task and writes only into isolated run/snapshot/evidence/staged directories; no canonical write authority is granted and no existing safety invariant is relaxed. The `state.ts` removals are a refactor relocation, not new exemptions.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: `513bb913` (rebased clean onto #798).
- `preset-v3-canary-equivalence-cli.test.ts`: 5/5 pass (4 canary equivalence + fail-closed), 41.8s.
- `npm run check:local`: passed, 32 complete manifest gates green, 332 tests, 53.7s.
- `npm run harness:check-kernel-dead-exports`: passed (delta −1; 6 new kernel exports all consumed).
- No `design-codex.md` §8.3 ADR stop-line hit: no new kernel port, no global authority primitive, no live/external raw write.

---

# 中文

## 摘要

PLT-Preset-v3 **Phase 1**：建声明式能力 provider 运行时，并在 4 个代表性 canary 上以 v2→v3 **输出等价证明**验证迁移模式。这是 Phase 2/3 剩余 preset 迁移要沿用的引擎（与迁移配方）。

v3 preset 声明的是*语义能力*（intent / typed inputs / requires / produces / sideEffects），而非物理读写作用域。运行时 provider 把每个声明的能力物化进隔离投影目录，交给脚本的是能力*句柄*——绝不是文件系统路径——脚本因此根本触不到 canonical authored state。

## 变更内容

- 新增 provider 运行时：`preset-capability-runtime.ts`、`preset-capability-providers.ts`、`preset-entrypoint-runtime.ts`（后者把 legacy v1 脚手架写入从 `state.ts` 重定位出来，state.ts 缩减 129 行）。
- 每能力一个 materializer：tasks、task-artifacts、relation-graph、runtime-events、generated-artifacts、write-journal、docmap。未知能力或空投影 → `providerUnavailable`（fail-closed；raw-fs 回退明确禁止）。
- 4 canary 的 v2/v3 fixture + `preset-v3-canary-equivalence-cli.test.ts`，逐 canary 证明：业务报告 `deepEqual`、handle-only 的 `preset-context/v2`（无 paths/scopes/outputRoot）、v3 manifest 零物理令牌、空投影 fail-closed。
- 写治理登记：新增的隔离投影写 callsite 登记进 `check-bypass-write-boundary.json` 与 `write-road-registry.json`；旧 `state.ts` 条目重定位。净 +7 callsite，全部落隔离 run/snapshot/evidence/staged 目录——canonical 变更仍只经 attributed WriteCoordinator ingest/flush。

## 任务与范围

- Milestone：PLT-Preset-v3（`task_01KXJ819W8TFCMPPP59ARRVRSS`）；Phase-1 任务 `task_01KXJGABN428PHY7ASPQE845ZB`。
- 设计权威：`dec_01KXHS6A`（声明式语义能力）+ `design-codex.md` §3（运行时映射）/§5.3（分阶段迁移）/§5.4（验收）。
- 分支：`wip/v3-phase1`
- 范围外：把 4 个生产 canary preset 翻成 v3（本 PR 在 fixture 上证明，翻转是 Phase 2/3 机械后续）与剩余 16 个 preset 的迁移。

## 版本影响

- 版本：CLI 版本不变。
- 发布影响：不发布。

## 治理声明

- 触碰受保护面：是（`tools/gate-allowlists/check-bypass-write-boundary.json`、`tools/gate-allowlists/check-kernel-dead-exports.json`、`tools/write-road-registry.json`）。
- 授权：`dec_01KXHS6A`（PLT-Preset-v3 声明式语义能力设计）与 milestone `task_01KXJ819W8TFCMPPP59ARRVRSS`。每条新增 write-boundary allowlist entry 均引用该 milestone task，且只写入隔离 run/snapshot/evidence/staged 目录；未授予任何 canonical 写权威，未放宽任何既有安全不变量。`state.ts` 的移除是重构重定位，非新增豁免。
- 机器检查边界：本 PR 仅断言声明存在；是否真实充分由审查者判定。
- Break-glass：否

## 验证

- Base `origin/main` SHA：`513bb913`（干净 rebase 到 #798 之上）。
- `preset-v3-canary-equivalence-cli.test.ts`：5/5 通过（4 canary 等价 + fail-closed），41.8s。
- `npm run check:local`：通过，32 门绿，332 测试，53.7s。
- `npm run harness:check-kernel-dead-exports`：通过（delta −1；6 个新 kernel 导出均被消费）。
- 未命中 `design-codex.md` §8.3 ADR 停止线：无新增 kernel port、无全局 authority primitive、无 live/external raw write。
