### PR TITLE
fix(cli): resolve Windows daemon autostart entrypoint

### DIFF
--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -338,8 +338,13 @@ function commandForCanonicalHarness(command: ParsedCommand): ParsedCommand {
     : { ...command, rootDir: canonicalRoot };
 }
 
-function daemonClientCliEntrypointPath(): string {
-  return fileURLToPath(import.meta.url).replace(/\/daemon\/client\.(ts|js)$/u, "/index.$1");
+export function daemonClientCliEntrypointPath(moduleUrl: string | URL = import.meta.url): string {
+  const clientUrl = new URL(moduleUrl);
+  const extension = path.posix.extname(clientUrl.pathname);
+  if (extension !== ".ts" && extension !== ".js") {
+    throw new Error(`unsupported daemon client module extension: ${extension || "<none>"}`);
+  }
+  return fileURLToPath(new URL(`../index${extension}`, clientUrl));
 }
 
 function readRemoteConfig(env: NodeJS.ProcessEnv): RemoteDaemonConfig {

--- a/packages/cli/test/daemon-connect.test.ts
+++ b/packages/cli/test/daemon-connect.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   daemonIdForUserRoot,
   defaultNamedPipePath,
@@ -13,11 +14,23 @@ import { createDaemonLocalTransport } from "../src/commands/daemon/serve-transpo
 import { hasPrivilegedSshdAncestor } from "../src/commands/daemon/sshd-witness.ts";
 import {
   commandRunPayload,
+  daemonClientCliEntrypointPath,
   remoteDaemonUnavailableHint,
   remoteDaemonSshArgs,
   type RemoteDaemonConfig
 } from "../src/daemon/client.ts";
 import { parseArgs } from "../src/cli/parse-args.ts";
+
+test("daemon client resolves its CLI entrypoint across native path separators", () => {
+  const clientPath = fileURLToPath(new URL("../src/daemon/client.ts", import.meta.url));
+  const expectedEntrypoint = path.resolve(path.dirname(clientPath), "../index.ts");
+
+  assert.equal(daemonClientCliEntrypointPath(), expectedEntrypoint);
+  assert.equal(
+    daemonClientCliEntrypointPath("file:///C:/workspace/packages/cli/dist/daemon/client.js"),
+    fileURLToPath("file:///C:/workspace/packages/cli/dist/index.js")
+  );
+});
 
 test("daemon endpoint selection uses a named pipe on Windows and a unix socket on POSIX", () => {
   const userRoot = "/srv/harness-user";

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -501,7 +501,7 @@ test("daemon client resolves an existing single-repo registry without requiring 
       displayName: "Registered User",
       email: "registered@example.test",
       role: "owner"
-    });
+    }, { userRoot });
     const registered = runDaemonCommand(rootDir, ["daemon", "repo", "register", "--repo-id", "canonical", "--user-root", userRoot, "--no-link", "--json"], {
       HARNESS_DAEMON_USER_ROOT: userRoot
     });

--- a/packages/cli/test/helpers/daemon-cli.ts
+++ b/packages/cli/test/helpers/daemon-cli.ts
@@ -168,9 +168,11 @@ function removeTempRootSync(rootDir: string): void {
 }
 
 function daemonTestEnv(rootDir: string, env: Readonly<Record<string, string>>): NodeJS.ProcessEnv {
+  const homeDir = path.join(rootDir, ".home");
   return {
     ...process.env,
-    HOME: path.join(rootDir, ".home"),
+    HOME: homeDir,
+    USERPROFILE: homeDir,
     GIT_CONFIG_GLOBAL: "/dev/null",
     HARNESS_ACTOR: "agent:daemon-cli-test",
     HARNESS_GIT_AUTHOR_NAME: "Harness Test",

--- a/packages/cli/test/helpers/forced-command-daemon.ts
+++ b/packages/cli/test/helpers/forced-command-daemon.ts
@@ -4,7 +4,11 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { hostname } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
-import { JsonRpcLineClient } from "../../../daemon/src/index.ts";
+import {
+  daemonIdFromEnv,
+  JsonRpcLineClient,
+  localUserDaemonEndpoint
+} from "../../../daemon/src/index.ts";
 import { runDaemonConnect } from "../../src/commands/daemon/connect.ts";
 
 export function writePeopleRoster(rootDir: string, person: {
@@ -12,8 +16,16 @@ export function writePeopleRoster(rootDir: string, person: {
   readonly displayName: string;
   readonly email: string;
   readonly role: "owner" | "maintainer";
-}): void {
+}, options: {
+  readonly userRoot?: string;
+  readonly daemonId?: string;
+} = {}): void {
   const harnessRoot = path.join(rootDir, "harness");
+  const namedPipeEndpoint = localUserDaemonEndpoint(
+    options.userRoot ?? path.join(rootDir, ".daemon-user"),
+    options.daemonId ?? daemonIdFromEnv(),
+    "win32"
+  );
   mkdirSync(harnessRoot, { recursive: true });
   writeFileSync(path.join(harnessRoot, "people.yaml"), [
     "schema: harness-people/v1",
@@ -26,6 +38,9 @@ export function writePeopleRoster(rootDir: string, person: {
     "      - kind: unix-socket-owner-boundary",
     `        issuer: host:${hostname()}`,
     `        subject: ${process.getuid?.() ?? 0}`,
+    "      - kind: windows-named-pipe-client",
+    `        issuer: host:${hostname()}:named-pipe`,
+    `        subject: ${namedPipeEndpoint}`,
     "roles:",
     "  - roleId: owner",
     "    commandClasses: [admin, repo-write, repo-read, arbiter]",


### PR DESCRIPTION
# English

## Summary

Fixes #811. Windows daemon auto-start now resolves the CLI entrypoint from the module URL before converting it to a native filesystem path, so a first daemon-backed command can start the local named-pipe server instead of executing the client module as a no-op child.

## What Changed

- Replace the slash-sensitive post-`fileURLToPath()` regex with URL-relative `../index.ts` / `../index.js` resolution.
- Add a focused source/compiled entrypoint regression test.
- Make native Windows daemon E2E fixtures hermetic for `os.homedir()` and named-pipe identity without changing product identity rules.

## Task And Scope

- Harness task: private local Harness task; its identifier is intentionally not published.
- Branch: `17-use:codex/fix-windows-daemon-entry`
- Public scope: five CLI source/test files for Windows daemon entrypoint resolution and native test fixtures.
- Private planning/evidence updated: yes, outside the public repository.
- Out of scope: the existing concurrent multi-client cold-start race and unrelated Windows symlink privileges.

## Version Impact

- Version: no version change because this is an unreleased CLI bug fix with no package manifest change.
- Publish impact: no publish; release timing remains a maintainer decision.

## Governance Declaration

- Protected surface touched: no.
- Protected surface scope: not applicable; the public diff does not match a manifest-derived protected surface.
- Authority: not applicable.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no.
- Break-glass reason: not applicable.
- Break-glass scope: not applicable.
- Follow-up governance task: not applicable.
- Merge plan: maintainer-managed squash merge after required review and CI; delete the contributor branch only after merge is confirmed.
- Admin bypass: none planned.

## Verification

- Base `origin/main` SHA: `98a179415c1ec9fd5f3de09ffe800722f3d44eb7`
- Branch merge-base with `origin/main`: `98a179415c1ec9fd5f3de09ffe800722f3d44eb7`
- Last `git fetch origin` time: `2026-07-16T09:28:32Z`
- Sync method: rebase onto the latest `origin/main` before the final regression run.
- Public diff command: `git diff --check origin/main...HEAD`
- Private evidence commit/path: recorded in the local task ledger; not published.
- Reviewer evidence path: independent read-only reviewer summary recorded outside the public repository.
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/29487470784 (`action_required`; the maintainer must approve workflow execution for this fork contribution).
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Focused tests passed on native Windows after rebasing: `daemon-connect.test.ts` 12/12; local daemon owner derivation 1/1; thin-client auto-start/persistence 1/1; full `daemon-execution-claim-cli.test.ts` 2/2.
- Partial `npm run check:local`: typecheck and all 31 local static gates passed; affected fast tests reported 201 passed, 4 skipped, and 2 unrelated existing broken-symlink fixtures failed with Windows `EPERM` because this account cannot create symbolic links.
- Not run: `npm ci` reused an existing lock-matched install because dependency files are unchanged; full `npm run check` / `npm test` are delegated to the repository's complete GitHub CI authority.

## Review Evidence

- Self-review: diff, URL/path behavior, fixture identity, and public/private boundary reviewed; no blocking finding.
- Reviewer subagent: independent read-only review found no P0-P2 or blocking finding and independently reran `daemon-connect.test.ts` at 12/12.
- Human review: pending maintainer review.
- Blocking findings: none.

## Residual Risk

- The repository's already-skipped eight-client concurrent cold-start case can still produce transient `ENOENT`; this is a separate cross-process race and is not claimed fixed here.
- Two unrelated symlink fixture tests require Windows symbolic-link privileges not available to the local account; GitHub CI remains the complete gate.
- The `.js` entrypoint shape is covered by the focused regression test; packaged Windows execution remains CI evidence.

## References

- Task: Fixes #811.
- Evidence: #811 source-level triage and the verification results above.
- Review: independent read-only review; no P0-P2 findings.

---

# 中文

## 概要

修复 #811。Windows 下守护进程自动启动现在先基于模块 URL 解析 CLI 入口，再转换成本机文件系统路径，首次执行 daemon-backed 命令时会真正启动命名管道服务，不再误执行 `client.ts` 后静默退出。

## 改动内容

- 用 URL 相对解析 `../index.ts` / `../index.js`，替代依赖正斜杠的 `fileURLToPath()` 后置正则替换。
- 增加源码态和构建态 CLI 入口解析回归测试。
- 完善 Windows daemon 端到端测试夹具对 `os.homedir()` 和命名管道身份的隔离，不改变产品身份规则。

## 任务与范围

- Harness 任务：使用本地私有 Harness 任务管理；标识不发布到公开仓库。
- 分支：`17-use:codex/fix-windows-daemon-entry`
- 公开范围：五个 CLI 源码/测试文件，只处理 Windows daemon 入口解析与本机测试夹具。
- 私有计划 / 证据是否已更新：是，记录在公开仓库之外。
- 范围外：既有多客户端并发冷启动竞态，以及与本次 diff 无关的 Windows 符号链接权限。

## 版本影响

- 版本：不修改版本；这是未发布 CLI 的缺陷修复，未改变 package manifest。
- 发布影响：本 PR 不发布，发布时间由维护者决定。

## 治理声明

- 是否触碰 protected surface：否。
- protected surface 范围：不适用；公开 diff 不匹配 manifest 派生的受保护范围。
- 依据：不适用。
- 机器检查边界：本 PR 只声明该字段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no。
- Break-glass 原因：不适用。
- Break-glass 范围：不适用。
- 后续治理任务：不适用。
- 合并计划：通过必需审查与 CI 后由维护者 squash merge；确认合并后再删除贡献分支。
- Admin bypass：不计划使用。

## 验证

- `origin/main` 基准 SHA：`98a179415c1ec9fd5f3de09ffe800722f3d44eb7`
- 当前分支与 `origin/main` 的 merge-base：`98a179415c1ec9fd5f3de09ffe800722f3d44eb7`
- 最近一次 `git fetch origin` 时间：`2026-07-16T09:28:32Z`
- 同步方式：最终回归前 rebase 到最新 `origin/main`。
- 公开 diff 命令：`git diff --check origin/main...HEAD`
- 私有证据 commit/path：已记录在本地任务账本，不公开。
- Reviewer 证据路径：独立只读 reviewer 结论记录在公开仓库之外。
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/29487470784（`action_required`；该 fork 贡献需要维护者批准工作流执行）。
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 重放到最新基线后的 Windows 聚焦测试：`daemon-connect.test.ts` 12/12；本地 daemon owner 推导 1/1；thin-client 自动启动与持久化 1/1；完整 `daemon-execution-claim-cli.test.ts` 2/2，全部通过。
- `npm run check:local` 部分结果：typecheck 与 31 个本地静态门禁全部通过；受影响快速测试中 201 个通过、4 个跳过，另有 2 个既有 broken-symlink 夹具因当前 Windows 账号不能创建符号链接而报 `EPERM`，与本次 diff 无关。
- 未运行：依赖文件未变，因此未执行 `npm ci`，复用已有 lock-matched 安装；完整 `npm run check` / `npm test` 交由仓库声明的 GitHub CI 完整权威门禁执行。

## 审查证据

- 自查：已检查 diff、URL/路径行为、测试身份夹具与公开/私有边界；无阻断发现。
- Reviewer subagent：独立只读复核未发现 P0-P2 或阻断项，并独立重跑 `daemon-connect.test.ts`，12/12 通过。
- 人工审查：等待维护者审查。
- 阻断发现：无。

## 残余风险

- 仓库中原本跳过的八客户端并发冷启动用例仍可能瞬时出现 `ENOENT`；它属于独立跨进程竞态，本 PR 不声称修复。
- 两个无关 symlink 夹具需要当前账号不具备的 Windows 符号链接权限；最终以 GitHub CI 完整门禁为准。
- `.js` 入口由聚焦回归测试覆盖；Windows 打包态执行以 CI 证据为准。

## 关联材料

- 任务：Fixes #811。
- 证据：#811 的源码级分析与上方验证结果。
- 审查：独立只读复核，无 P0-P2 发现。

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述中不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已说明为待 PR 创建后执行。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻断。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清晰。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
