### PR TITLE
feat(gui): one-hop spotlight highlight on node select

### DIFF
--- a/packages/gui/src/renderer/graph/canvasEgoLayout.ts
+++ b/packages/gui/src/renderer/graph/canvasEgoLayout.ts
@@ -137,6 +137,20 @@ export function neighborsOf(graph: EgoGraph, id: string, axes: AxisFilter): stri
   return [...out];
 }
 
+/**
+ * 聚光灯单击选中的单跳高亮集合:{selectId} ∪ 其一跳邻居(入+出,经轴过滤)。
+ * selectId 为空时返回 null,表示「无选中高亮态」——布局层应保持全亮、不灰化。
+ * 复用 neighborsOf,不重算邻接。
+ */
+export function oneHopHighlightIds(
+  graph: EgoGraph,
+  selectId: string | null,
+  axes: AxisFilter,
+): Set<string> | null {
+  if (!selectId) return null;
+  return new Set([selectId, ...neighborsOf(graph, selectId, axes)]);
+}
+
 export interface CanvasEgoInput {
   focusId: string;
   tasks: TaskRow[];

--- a/packages/gui/src/renderer/graph/nodes/EgoNode.tsx
+++ b/packages/gui/src/renderer/graph/nodes/EgoNode.tsx
@@ -54,6 +54,9 @@ export function EgoNode({ data, selected }: any) {
   const entity: Entity = data.entity;
   const axis = AXIS_VAR[entity];
   const focus = Boolean(data.focus);
+  // 聚光灯单击单跳高亮:非 {select}∪邻居 的节点降透明度(保持配色可读,不纯灰替换)。
+  const isDimmed = Boolean(data.dimmed);
+  const dimOpacity = isDimmed ? 0.22 : 1;
 
   if (!data.expanded) {
     // ── chip ──
@@ -62,8 +65,13 @@ export function EgoNode({ data, selected }: any) {
         className="flex h-full w-full items-center gap-2 overflow-hidden rounded-lg border bg-surface-raised pl-0 pr-2.5 cursor-pointer transition-shadow duration-150 hover:shadow-md"
         style={{
           borderColor: focus ? axis : selected ? axis : "var(--color-border-strong)",
-          borderWidth: focus ? 2 : 1,
-          boxShadow: focus ? `0 0 0 2px ${axis}` : undefined,
+          borderWidth: focus ? 2 : selected ? 1.5 : 1,
+          boxShadow: focus
+            ? `0 0 0 2px ${axis}`
+            : selected
+              ? `0 0 0 2px color-mix(in srgb, ${axis} 45%, transparent)`
+              : undefined,
+          opacity: dimOpacity,
         }}
       >
         <Handles />
@@ -100,9 +108,14 @@ export function EgoNode({ data, selected }: any) {
     <div
       className="flex h-full w-full flex-col overflow-hidden rounded-xl border bg-surface shadow-lg"
       style={{
-        borderColor: focus ? axis : "var(--color-border-strong)",
-        borderWidth: focus ? 2 : 1,
-        boxShadow: focus ? `0 0 0 2px ${axis}, 0 8px 28px rgba(0,0,0,0.28)` : undefined,
+        borderColor: focus ? axis : selected ? axis : "var(--color-border-strong)",
+        borderWidth: focus ? 2 : selected ? 1.5 : 1,
+        boxShadow: focus
+          ? `0 0 0 2px ${axis}, 0 8px 28px rgba(0,0,0,0.28)`
+          : selected
+            ? `0 0 0 2px color-mix(in srgb, ${axis} 45%, transparent)`
+            : undefined,
+        opacity: dimOpacity,
       }}
     >
       {/* D4:NodeResizer —— 用户「手动拖放大缩小组件」的入口。只在展开卡片上显示。

--- a/packages/gui/src/renderer/graph/useEgoCanvas.ts
+++ b/packages/gui/src/renderer/graph/useEgoCanvas.ts
@@ -3,7 +3,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TaskRow, RelationEdge, DecisionRow, FactRef } from "../model/types";
 import type { AxisFilter } from "./graphLayoutTypes";
 import { endpointToNodeId } from "./endpoint";
-import { buildEgoGraph, bfsShown, neighborsOf, egoFocusIdOf, type EgoGraph } from "./canvasEgoLayout";
+import {
+  buildEgoGraph,
+  bfsShown,
+  neighborsOf,
+  oneHopHighlightIds,
+  egoFocusIdOf,
+  type EgoGraph,
+} from "./canvasEgoLayout";
 import { pickDefaultFocus } from "./graphLayoutShared";
 import {
   createFocusHistory,
@@ -24,9 +31,10 @@ import {
  *   shown    — 累积可见集 node id → 距焦点跳数。openFocus 铺 ±2;展开卡片时长出
  *              它的一跳邻居;收起**不撤**任何节点(累计保留)。
  *   expanded — 渲染为详情卡片的 node id,其余是紧凑 chip。
+ *   selectId — 单击选中的节点(与 focus 正交)。派生 oneHopHighlight 供灰化非单跳邻居。
  *
  * 不变量:只有 openFocus / 历史前进后退会重排画布(resetCanvasTo);单击展开、
- * 收起都只增不减,永不重排已铺开的画布。
+ * 收起都只增不减,永不重排已铺开的画布。单击 select ≠ 双击 setFocus。
  */
 
 // openFocus 默认铺开的跳数(上游 2 跳 + 下游 2 跳)。
@@ -38,6 +46,16 @@ export interface EgoCanvas {
   expanded: Set<string>;
   canBack: boolean;
   canForward: boolean;
+  /**
+   * 单击选中的节点 id(与 focusId 正交)。null = 无选中高亮。
+   * 再点同节点 / 点空白 / 换焦点 → 清空。
+   */
+  selectId: string | null;
+  /**
+   * 单跳高亮集合:{selectId}∪一跳邻居;null = 全亮(无选中)。
+   * 节点 dimmed 判定 / 边淡化判定都读它。
+   */
+  oneHopHighlight: Set<string> | null;
   /** 设为画布中心:切焦点 + 推历史 + 重排 ±2 跳。 */
   openFocus: (id: string) => void;
   /** chip 就地展开成卡片,并把它的一跳邻居加入 shown(长出下一环,累积)。 */
@@ -46,6 +64,10 @@ export interface EgoCanvas {
   collapseNode: (id: string) => void;
   /** 退出聚焦:清空焦点与累积态(不脚印化,不动历史)。 */
   clearFocus: () => void;
+  /** 单击选中/再点同节点取消(toggle)。不改 focus、不重排。 */
+  selectNode: (id: string) => void;
+  /** 清空单击选中高亮(点空白 / Esc / 换焦点时调用)。 */
+  clearSelect: () => void;
   goBack: () => void;
   goForward: () => void;
 }
@@ -81,6 +103,8 @@ export function useEgoCanvas({
   const [history, setHistory] = useState<FocusHistoryState>(createFocusHistory);
   const [shown, setShown] = useState<Map<string, number>>(() => new Map());
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  // 单击选中高亮(与 focus 正交):再点同节点 / 点空白 / 换焦点时清空。
+  const [selectId, setSelectId] = useState<string | null>(null);
 
   // 统一图(byId + adj,含合成 task 父子边),供 openFocus / 展开的 BFS 遍历复用。
   const egoGraph: EgoGraph = useMemo(
@@ -88,11 +112,19 @@ export function useEgoCanvas({
     [tasks, decisions, facts, relations],
   );
 
+  // 单跳高亮集合:selectId 自身 + neighborsOf(入+出,轴过滤)。null = 全亮。
+  const oneHopHighlight = useMemo(
+    () => oneHopHighlightIds(egoGraph, selectId, axes),
+    [egoGraph, selectId, axes],
+  );
+
   // 重排画布到某焦点:铺开前后各 2 跳、只展开焦点自身(累积态重置)。
+  // 换焦点时清空单击选中 —— 画布已重排,旧 select 语义失效。
   const resetCanvasTo = useCallback(
     (id: string) => {
       setShown(bfsShown(egoGraph, id, DEFAULT_HOPS, axes));
       setExpanded(new Set([id]));
+      setSelectId(null);
     },
     [egoGraph, axes],
   );
@@ -106,7 +138,7 @@ export function useEgoCanvas({
       const canonical = egoFocusIdOf(id);
       setFocusId(canonical);
       setHistory((prev) => pushFocus(prev, canonical)); // 重复推同 id 会被 pushFocus 折叠
-      resetCanvasTo(canonical);
+      resetCanvasTo(canonical); // 内部清空 selectId
       // G3 §④2:上行同步 AppLocation.focusedEntityRef。换焦点不只改本地,还要让
       // EntityWorkspace 的 facet 切换(关系↔演化)能拿到最新焦点。
       if (onFocusChange) onFocusChange(canonical);
@@ -144,14 +176,25 @@ export function useEgoCanvas({
     setFocusId(null);
     setShown(new Map());
     setExpanded(new Set());
+    setSelectId(null);
     // 不动历史:用户「退出聚焦」不脚印化。清空后 bootstrap 会重开默认焦点。
     // D6:同步清空 AppLocation.focusedEntityRef,否则切到演化史仍显示旧 decision。
     if (onFocusChange) onFocusChange(null);
   }, [onFocusChange]);
 
+  // 单击选中 / 再点同节点取消。不碰 focus、不重排画布。
+  const selectNode = useCallback((id: string) => {
+    setSelectId((prev) => (prev === id ? null : id));
+  }, []);
+
+  const clearSelect = useCallback(() => {
+    setSelectId(null);
+  }, []);
+
   // 历史前进 / 后退:切焦点 + 重排画布(不重复推栈)。
   // D6:必须与 openFocus 一样上行 onFocusChange —— FocusHistoryBar 的 back/forward
   // 只改本地 history 时,AppLocation.focusedEntityRef 会停在旧 decision,演化史开错谱系。
+  // resetCanvasTo 会清空 selectId。
   const stepHistory = useCallback(
     (step: (prev: FocusHistoryState) => FocusHistoryState) => {
       setHistory((prev) => {
@@ -189,10 +232,14 @@ export function useEgoCanvas({
     expanded,
     canBack: historyCanGoBack(history),
     canForward: historyCanGoForward(history),
+    selectId,
+    oneHopHighlight,
     openFocus,
     expandNode,
     collapseNode,
     clearFocus,
+    selectNode,
+    clearSelect,
     goBack,
     goForward,
   };

--- a/packages/gui/src/renderer/views/GraphView.tsx
+++ b/packages/gui/src/renderer/views/GraphView.tsx
@@ -163,17 +163,22 @@ function GraphViewInner({
     });
   }, [availableModules]);
 
-  // 无限画布 ego 状态机(焦点 / 累积可见集 / 已展开卡片 / 焦点历史 / 换焦点即居中)。
+  // 无限画布 ego 状态机(焦点 / 累积可见集 / 已展开卡片 / 焦点历史 / 换焦点即居中 /
+  // 单击单跳高亮 selectId+oneHopHighlight)。
   const {
     focusId,
     shown,
     expanded,
     canBack,
     canForward,
+    selectId,
+    oneHopHighlight,
     openFocus,
     expandNode,
     collapseNode,
     clearFocus,
+    selectNode,
+    clearSelect,
     goBack,
     goForward,
   } = useEgoCanvas({
@@ -235,9 +240,12 @@ function GraphViewInner({
   // 从 useEgoCanvas 抽出来放这儿,因为此 hook 在 useGraphLayout 之后调用,能拿到真实节点盒子。
   useCenterOnFocus(nodes, resolvedFocusId);
 
-  // 单击 chip = 就地展开成卡片并长出邻居(累积,永不重排已有画布)。
-  // territory 模式下 territoryChip 单击 → 切到聚光灯(enterSpotlight);fold chip → toggleZone。
-  // unified(全域)模式下 ego 节点单击 → enterSpotlight(整图是总览,深入靠聚光灯)。
+  // 单击:
+  //   territoryChip / territoryZone / unified ego → 既有领地行为(不变)。
+  //   聚光灯 ego:
+  //     - 始终写入 selectNode(单跳高亮/灰化);再点同节点 = 取消。
+  //     - 未展开 chip 另 expandNode(就地展开+长邻居),已展开卡片只高亮不收起。
+  // 双击 = 设焦点(onNodeDoubleClick),与本单击 select 正交。
   const onNodeClick = useCallback(
     (_evt: any, node: any) => {
       if (node.type === "territoryChip") {
@@ -261,10 +269,14 @@ function GraphViewInner({
         if (navRef) enterSpotlight(navRef);
         return;
       }
+      // 聚光灯:单击 = select 高亮单跳邻居(与 expand 叠加,不互斥)。
+      if (viewMode === "spotlight") {
+        selectNode(node.id);
+      }
       if (node.data?.expanded) return;
       expandNode(node.id);
     },
-    [expandNode, toggleZone, enterSpotlight, viewMode, skel],
+    [expandNode, toggleZone, enterSpotlight, viewMode, skel, selectNode],
   );
 
   // 双击 = 设为画布中心(openFocus:重排前后各 2 跳,推历史)。
@@ -288,18 +300,21 @@ function GraphViewInner({
 
   const onPaneClick = useCallback(() => {
     setDrawerState((prev) => ({ ...prev, selectedId: null, focusEdgeId: null }));
-  }, []);
+    // 点空白取消单击单跳高亮。
+    clearSelect();
+  }, [clearSelect]);
 
-  // Esc = 关抽屉(不退焦点;焦点有显式「退出聚焦」按钮)。
+  // Esc = 关抽屉 + 取消单击单跳高亮(不退焦点;焦点有显式「退出聚焦」按钮)。
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
       if (e.target instanceof HTMLElement && e.target.closest("input,textarea,select")) return;
       setDrawerState((prev) => ({ ...prev, selectedId: null, focusEdgeId: null }));
+      clearSelect();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [clearSelect]);
 
   // 抽屉状态(节点选中 / 边选中)+ 派生数据 + 回调,外置到 useGraphDrawer。
   // onEdgeClick / onPaneClick / Esc 通过 setDrawerState 原子更新两个 id(避免竞态)。
@@ -345,16 +360,21 @@ function GraphViewInner({
   );
 
   // 注入卡片交互回调(收起 / 设为中心 / 详情跳转 / 拖拽 resize)+ id 到 ego 节点 data。
+  // 聚光灯单击高亮:oneHopHighlight 非 null 时,不在集合内的节点 dimmed=true(降透明度)。
   // territory 节点注入 onOpen(chip → 聚光灯)+ onFold(zone 折叠)。
   const displayNodes = useMemo(
     () =>
       nodes.map((n) => {
         if (n.type === "ego") {
+          const dimmed =
+            oneHopHighlight !== null && !oneHopHighlight.has(n.id);
           return {
             ...n,
+            selected: selectId !== null && n.id === selectId,
             data: {
               ...n.data,
               id: n.id,
+              dimmed,
               onCollapse: collapseNode,
               onRefocus: openFocus,
               onNavigate: onNavigateEntity,
@@ -370,8 +390,36 @@ function GraphViewInner({
         }
         return n;
       }),
-    [nodes, collapseNode, openFocus, onNavigateEntity, setSizeOverride, enterSpotlight, toggleZone],
+    [
+      nodes,
+      collapseNode,
+      openFocus,
+      onNavigateEntity,
+      setSizeOverride,
+      enterSpotlight,
+      toggleZone,
+      oneHopHighlight,
+      selectId,
+    ],
   );
+
+  // 边:两端都在高亮集合 → 保持醒目;否则淡化(opacity 0.18)。
+  // 无选中(oneHopHighlight=null)时全部保持原样。
+  const displayEdges = useMemo(() => {
+    if (oneHopHighlight === null) return edges;
+    return edges.map((e) => {
+      const keep =
+        oneHopHighlight.has(e.source) && oneHopHighlight.has(e.target);
+      if (keep) return e;
+      return {
+        ...e,
+        style: {
+          ...(e.style ?? {}),
+          opacity: 0.18,
+        },
+      };
+    });
+  }, [edges, oneHopHighlight]);
 
   // Switcher 入口:点选 = 设为画布中心(openFocus 重排 ±2)。
   const switchFocusFromList = useCallback(
@@ -455,7 +503,7 @@ function GraphViewInner({
         />
         <ReactFlow
           nodes={displayNodes}
-          edges={edges}
+          edges={displayEdges}
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           onNodeClick={onNodeClick}

--- a/packages/gui/test/canvas-ego-layout.vitest.ts
+++ b/packages/gui/test/canvas-ego-layout.vitest.ts
@@ -3,6 +3,8 @@ import {
   layoutCanvasEgo,
   buildEgoGraph,
   bfsShown,
+  neighborsOf,
+  oneHopHighlightIds,
   egoFocusIdOf,
   estimateCardHeight,
 } from "../src/renderer/graph/canvasEgoLayout";
@@ -566,5 +568,90 @@ describe("D3/G1 · 聚焦 3:4 竖卡 + 内容驱动高度", () => {
     // B2:不再写 style.width / style.height —— 让 NodeResizer 控盒子。
     expect(node.style?.width).toBeUndefined();
     expect(node.style?.height).toBeUndefined();
+  });
+});
+
+// ══ 聚光灯单击单跳高亮 ══
+// 需求:单击节点 → {node}∪一跳邻居保持高亮,其余灰化;边两端都在集合才醒目。
+// 复用 neighborsOf(入+出,轴过滤),不重造邻接;selectId=null 时全亮。
+describe("oneHopHighlightIds (聚光灯单击单跳高亮集合)", () => {
+  // A --refines--> B --derives--> C
+  // A --evidenced-by--> F
+  // (无 A-C 直接边 → C 不在 A 的单跳邻居里)
+  function hopScene() {
+    const tasks = [task("task_C")];
+    const decisions = [decision("dec_A"), decision("dec_B")];
+    const facts = [fact("task_x", "F1")];
+    const relations = [
+      rel("decision/dec_A", "decision/dec_B", "refines"),
+      rel("decision/dec_B", "task/task_C", "derives"),
+      rel("decision/dec_A", "fact/task_x/F1", "evidenced-by"),
+    ];
+    return { tasks, decisions, facts, relations };
+  }
+
+  it("selectId=null → null(全亮,无灰化)", () => {
+    const { tasks, decisions, facts, relations } = hopScene();
+    const graph = buildEgoGraph(tasks, decisions, facts, relations);
+    expect(oneHopHighlightIds(graph, null, ALL_AXES)).toBeNull();
+  });
+
+  it("选中 A → 含 A 自身 + 直接邻居 B、F1,不含二跳 C", () => {
+    const { tasks, decisions, facts, relations } = hopScene();
+    const graph = buildEgoGraph(tasks, decisions, facts, relations);
+    const hl = oneHopHighlightIds(graph, "decision/dec_A", ALL_AXES)!;
+    expect(hl.has("decision/dec_A")).toBe(true);
+    expect(hl.has("decision/dec_B")).toBe(true); // 出边
+    expect(hl.has("fact/task_x/F1")).toBe(true); // 出边
+    expect(hl.has("task_C")).toBe(false); // 二跳,不算
+  });
+
+  it("选中 B → 含入边邻居 A + 出边邻居 C(方向无关)", () => {
+    const { tasks, decisions, facts, relations } = hopScene();
+    const graph = buildEgoGraph(tasks, decisions, facts, relations);
+    const hl = oneHopHighlightIds(graph, "decision/dec_B", ALL_AXES)!;
+    expect(hl.has("decision/dec_B")).toBe(true);
+    expect(hl.has("decision/dec_A")).toBe(true); // 入边
+    expect(hl.has("task_C")).toBe(true); // 出边
+    expect(hl.has("fact/task_x/F1")).toBe(false); // 与 B 无直接边
+  });
+
+  it("轴过滤:关掉 evidence 后 F1 不进高亮集合", () => {
+    const { tasks, decisions, facts, relations } = hopScene();
+    const graph = buildEgoGraph(tasks, decisions, facts, relations);
+    const axesNoEvidence: AxisFilter = {
+      authority: true,
+      evidence: false,
+      execution: true,
+      assoc: true,
+    };
+    const hl = oneHopHighlightIds(graph, "decision/dec_A", axesNoEvidence)!;
+    expect(hl.has("decision/dec_B")).toBe(true);
+    expect(hl.has("fact/task_x/F1")).toBe(false);
+  });
+
+  it("与 neighborsOf 契约一致(高亮 = {id}∪neighborsOf)", () => {
+    const { tasks, decisions, facts, relations } = hopScene();
+    const graph = buildEgoGraph(tasks, decisions, facts, relations);
+    const id = "decision/dec_A";
+    const hl = oneHopHighlightIds(graph, id, ALL_AXES)!;
+    const nbs = new Set(neighborsOf(graph, id, ALL_AXES));
+    expect(hl.size).toBe(nbs.size + 1);
+    expect(hl.has(id)).toBe(true);
+    for (const nb of nbs) expect(hl.has(nb)).toBe(true);
+  });
+
+  it("边淡化判定:两端都在高亮集合才 keep(消费层契约)", () => {
+    // 纯函数层不改边;这里固定消费层的 keep 谓词,防回归。
+    const { tasks, decisions, facts, relations } = hopScene();
+    const graph = buildEgoGraph(tasks, decisions, facts, relations);
+    const hl = oneHopHighlightIds(graph, "decision/dec_A", ALL_AXES)!;
+    const keep = (src: string, tgt: string) => hl.has(src) && hl.has(tgt);
+    // A-B 两端都在 → keep
+    expect(keep("decision/dec_A", "decision/dec_B")).toBe(true);
+    // A-F1 两端都在 → keep
+    expect(keep("decision/dec_A", "fact/task_x/F1")).toBe(true);
+    // B-C:B 在、C 不在 → 淡化
+    expect(keep("decision/dec_B", "task_C")).toBe(false);
   });
 });


### PR DESCRIPTION
# English

## Summary

One-hop spotlight highlight in the ego graph: single-clicking a node keeps that node and its direct (one-hop, in+out, axis-filtered) neighbors at full opacity while dimming everything else; edges fade unless both endpoints are in the highlight set. Clicking the same node again, clicking empty canvas, pressing Esc, or changing focus clears the highlight. Double-click set-focus semantics are untouched. Pure renderer change, zero backend.

## What Changed

- `packages/gui/src/renderer/graph/canvasEgoLayout.ts`: new `oneHopHighlightIds(graph, selectId, axes)` = `{selectId} ∪ neighborsOf(...)`; `null` means no selection (all bright).
- `packages/gui/src/renderer/graph/useEgoCanvas.ts`: new orthogonal `selectId` state + memoized `oneHopHighlight`, `selectNode` (toggle) / `clearSelect`; cleared on focus change, clearFocus, and history navigation.
- `packages/gui/src/renderer/views/GraphView.tsx`: single-click routes to `selectNode` (plus existing expand when collapsed); empty-canvas click and Esc clear; `displayNodes`/`displayEdges` carry the dimmed flags.
- `packages/gui/src/renderer/graph/nodes/EgoNode.tsx`: nodes render `data.dimmed` as opacity 0.22 (opacity-based, readable in both themes); selected node gets a heavier border.
- `packages/gui/test/canvas-ego-layout.vitest.ts`: 6 new one-hop unit tests (axis filtering, edge keep predicate, toggle semantics).

## Task And Scope

- Harness task: task_01KXNRQRZTPHCX7X5MRMWKXER2 (G line: one-hop spotlight highlight)
- Branch: `codex/g-spotlight-onehop`
- Public scope: `packages/gui` renderer + tests (5 files), zero backend
- Private planning/evidence updated: yes (task progress + submitted execution)
- Out of scope: multi-hop highlighting, IPC/data-contract changes (edges already present in renderer), daemon status panel (separate merged line).

## Version Impact

- Version: no version change because this is pre-release trunk work.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_01KXNRQRZTPHCX7X5MRMWKXER2
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 37d23486
- Branch merge-base with `origin/main`: 37d23486
- Last `git fetch origin` time: 2026-07-17 ~00:10 (worktree created off latest main)
- Sync method: none needed (branched from current main tip)
- Public diff command: `git diff 37d23486...5d5a735f`
- Private evidence commit/path: private ledger task package (progress + execution)
- Reviewer evidence path: task package review.md (CEO semantic review of select/focus orthogonality)
- GitHub Actions `rewrite-ci` run URL: pending on PR open (required subset)
- [x] `npm run check` (worker-local: gui vitest 34/34 incl. 6 new tests, `tsc -b packages/gui`, file-complexity gate)
- [ ] GitHub Actions `rewrite-ci` passed (pending; merged only on green)
- Not run: full local `check:ci` aggregator on the loaded host; covered by the PR-side required checks before merge.

## Review Evidence

- Self-review: Grok worker report (interaction matrix + cancel paths).
- Reviewer subagent: not run; CEO reviewed core hunks directly.
- Human review: CEO semantic acceptance (select orthogonal to focus, neighborsOf reuse, no relayout); user dogfood scheduled as first-use proof.
- Blocking findings: none.

## Residual Risk

- Dimming constants (0.22 node / 0.18 edge) may need taste tuning after dogfood.
- Usability acceptance (real click-through in the running GUI) deferred to the morning dogfood pass — flagged, not silently skipped.

## References

- Task: task_01KXNRQRZTPHCX7X5MRMWKXER2
- Evidence: task package progress + execution outputs
- Review: task package review.md

---

# 中文

## 概要

ego 图聚光灯单跳高亮:单击节点后,该节点与其直接(单跳,入+出,按当前轴过滤)邻居保持全亮,其余节点灰化(降透明度);边只有两端都在高亮集合内才保持醒目,否则淡化。再点同节点、点空白、Esc、换焦点均清除。双击设焦语义不动。纯 renderer 改动,零后端。

## 改动内容

- `packages/gui/src/renderer/graph/canvasEgoLayout.ts`:新增 `oneHopHighlightIds(graph, selectId, axes)` = `{selectId} ∪ neighborsOf(...)`;`null`=无选中(全亮)。
- `packages/gui/src/renderer/graph/useEgoCanvas.ts`:新增与 focus 正交的 `selectId` 态 + memoized `oneHopHighlight`、`selectNode`(toggle)/`clearSelect`;换焦点/clearFocus/历史步进时清空。
- `packages/gui/src/renderer/views/GraphView.tsx`:单击路由到 `selectNode`(保留原折叠展开);空白点击与 Esc 清除;`displayNodes`/`displayEdges` 携带 dimmed 标志。
- `packages/gui/src/renderer/graph/nodes/EgoNode.tsx`:节点按 `data.dimmed` 渲染 opacity 0.22(透明度实现,深浅主题都可读);选中节点边框加粗。
- `packages/gui/test/canvas-ego-layout.vitest.ts`:新增 6 个单跳单测(轴过滤、边 keep 谓词、toggle 语义)。

## 任务与范围

- Harness 任务:task_01KXNRQRZTPHCX7X5MRMWKXER2(G 线:聚光灯单跳高亮)
- 分支:`codex/g-spotlight-onehop`
- 公开范围:`packages/gui` renderer + 测试(5 文件),零后端
- 私有计划 / 证据是否已更新:yes(task progress + 已提交 execution)
- 范围外:多跳高亮、IPC/数据契约改动(edges 已在 renderer)、daemon 状态面板(已独立合入)。

## 版本影响

- 版本:不改版本,原因是 pre-release 主干工作。
- 发布影响:不发布。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:task_01KXNRQRZTPHCX7X5MRMWKXER2
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- `origin/main` 基准 SHA:37d23486
- 当前分支与 `origin/main` 的 merge-base:37d23486
- 最近一次 `git fetch origin` 时间:2026-07-17 约 00:10(worktree 基于最新 main 创建)
- 同步方式:不需要(直接分自 main tip)
- 公开 diff 命令:`git diff 37d23486...5d5a735f`
- 私有证据 commit/path:私有台账任务包(progress + execution)
- Reviewer 证据路径:任务包 review.md(CEO 对 select/focus 正交性的语义审查)
- GitHub Actions `rewrite-ci` run URL:开 PR 后生成(required 子集)
- [x] `npm run check`(worker 本地:gui vitest 34/34 含 6 个新测试、`tsc -b packages/gui`、file-complexity 门)
- [ ] GitHub Actions `rewrite-ci` passed(待跑;绿后才合并)
- 未运行:高载主机上未跑完整本地 `check:ci` 聚合;由合并前的 PR required checks 覆盖。

## 审查证据

- 自查:Grok worker 报告(交互矩阵 + 取消路径)。
- Reviewer subagent:未运行;CEO 直接审核核心 hunks。
- 人工审查:CEO 语义验收通过(select 与 focus 正交、复用 neighborsOf、不重排);用户 dogfood 作为首用证明排在晨间。
- 阻塞发现:无。

## 残余风险

- 灰化常数(节点 0.22/边 0.18)可能需按 dogfood 品味微调。
- 使用性验收(真实 GUI 点按)延到晨间 dogfood——已标注,非静默跳过。

## 关联材料

- 任务:task_01KXNRQRZTPHCX7X5MRMWKXER2
- 证据:任务包 progress + execution outputs
- 审查:任务包 review.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
