### PR TITLE
test(cli): stabilize daemon attachment status contract (kills main-painting flake)

### DIFF
--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -364,8 +364,9 @@ test("concurrent daemon client writes serialize into linear git history", async 
   });
 });
 
-test("daemon start service status and stop expose productized status contract", () => {
-  withTempRoot((rootDir) => {
+test("daemon start service status and stop expose productized status contract", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "direct" });
     try {
       const start = runDaemonCommand(rootDir, ["daemon", "start", "--service", "--json"]);
       assert.equal(start.started, true);
@@ -373,7 +374,12 @@ test("daemon start service status and stop expose productized status contract", 
       assert.equal(start.version, expectedCliVersion);
       assert.equal(typeof start.queueDepth, "number");
 
-      const status = runDaemonCommand(rootDir, ["daemon", "status", "--json"]);
+      let status = runDaemonCommand(rootDir, ["daemon", "status", "--json"]);
+      await waitForCondition(() => {
+        status = runDaemonCommand(rootDir, ["daemon", "status", "--json"]);
+        return status.lastReconcileAt !== null
+          && (status.repos as Array<{ repoId?: string; state?: string }>)[0]?.state === "attached";
+      });
       assert.equal(status.started, true);
       assert.equal(status.reachable, true);
       assert.equal(typeof status.pid, "number");


### PR DESCRIPTION
# English

## Summary

Kill the main-painting flake: `daemon start service status and stop expose productized status contract` (daemon-thin-client-cli.test.ts) asserted `attached` while sampling across the daemon's first registry reconcile. On an uninitialized temp root the reconcile correctly converges the startup fallback to `detached` (empty-registry semantics), so the assertion raced the reconcile — 5 of the last 7 main full-check runs went red on exactly this test. Test-side fix only; no product state-machine changes.

## What Changed

- `packages/cli/test/daemon-thin-client-cli.test.ts`: the test now initializes the fixture root (`init` under `HARNESS_DAEMON_MODE=direct`) so a canonical repo is actually registered, then uses the existing `waitForCondition` helper to wait until `lastReconcileAt` is set and the repo state is stably `attached` before asserting. No sleeps, no retries-until-green.

## Task And Scope

- Harness task: task_01KXNQABV1XSQHPXVQQCQNGWVA (main flake: daemon status attach race)
- Branch: `codex/flake-daemon-attach`
- Public scope: one test file in `packages/cli/test`
- Private planning/evidence updated: yes (progress + execution being recorded)
- Out of scope: daemon attach/status product code (root cause proven test-side), flake registry tooling (separate task in flight).

## Version Impact

- Version: no version change because this is a test-only stabilization.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_01KXNQABV1XSQHPXVQQCQNGWVA
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none (flake-registry/main-watch tooling already tasked separately)

## Verification

- Base `origin/main` SHA: 37d23486
- Branch merge-base with `origin/main`: 37d23486
- Last `git fetch origin` time: 2026-07-17 ~01:43 (pre-commit freshness check by the worker)
- Sync method: none needed (main had not advanced)
- Public diff command: `git diff 37d23486...92d4ad1e`
- Private evidence commit/path: private ledger task package (progress + execution)
- Reviewer evidence path: worker report — 20/20 isolated consecutive runs of the target test, target file 23/23, full `check:ci` exit 0 (13 local jobs green)
- GitHub Actions `rewrite-ci` run URL: pending on PR open
- [x] `npm run check` (full local `check:ci` aggregate exit 0; target test passes in the full shard at 7.185s)
- [ ] GitHub Actions `rewrite-ci` passed (pending; merged only on green)
- Not run: none beyond the above.

## Review Evidence

- Self-review: worker proved the race mechanism (assertion sampling across first reconcile) rather than patching symptoms.
- Reviewer subagent: not run; CEO reviewed the full hunk directly (init + waitForCondition, no sleeps).
- Human review: CEO semantic acceptance — fix establishes the precondition the assertion always assumed; 20-run determinism evidence, not luck.
- Blocking findings: none.

## Residual Risk

- If a different test in the same suite has its own reconcile-sampling assumption, it would be a separate occurrence — flake registry (in-flight task) will catch and anchor it.

## References

- Task: task_01KXNQABV1XSQHPXVQQCQNGWVA
- Evidence: task package progress + execution outputs
- Review: task package review.md

---

# 中文

## 概要

根治染红 main 的 flake:`daemon start service status and stop expose productized status contract`(daemon-thin-client-cli.test.ts)在 daemon 首轮 registry reconcile 前后采样断言 `attached`。未初始化的临时 root 没有注册 canonical repo,reconcile 按 empty-registry 语义把启动 fallback 正确收敛为 `detached`——断言与 reconcile 赛跑,最近 7 个 main full-check run 有 5 个红在这一个测试上。纯测试侧修复,不动产品状态机。

## 改动内容

- `packages/cli/test/daemon-thin-client-cli.test.ts`:测试先初始化 fixture root(`HARNESS_DAEMON_MODE=direct` 下 `init`)使 canonical repo 真实注册,再用既有 `waitForCondition` 等到 `lastReconcileAt` 已置且 repo 状态稳定为 `attached` 才断言。无 sleep、无重试凑绿。

## 任务与范围

- Harness 任务:task_01KXNQABV1XSQHPXVQQCQNGWVA(main 存量 flake:daemon status attach 竞态)
- 分支:`codex/flake-daemon-attach`
- 公开范围:`packages/cli/test` 一个测试文件
- 私有计划 / 证据是否已更新:yes(progress + execution 正在补录)
- 范围外:daemon attach/status 产品代码(根因已证明在测试侧)、flake registry 工具(独立任务在飞)。

## 版本影响

- 版本:不改版本,原因是纯测试稳定化。
- 发布影响:不发布。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:task_01KXNQABV1XSQHPXVQQCQNGWVA
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无(flake-registry/main-watch 工具已另行立任务)

## 验证

- `origin/main` 基准 SHA:37d23486
- 当前分支与 `origin/main` 的 merge-base:37d23486
- 最近一次 `git fetch origin` 时间:2026-07-17 约 01:43(worker 提交前新鲜度检查)
- 同步方式:不需要(main 未前进)
- 公开 diff 命令:`git diff 37d23486...92d4ad1e`
- 私有证据 commit/path:私有台账任务包(progress + execution)
- Reviewer 证据路径:worker 报告——目标测试独立连跑 20/20 全绿,目标文件 23/23,完整 `check:ci` 退出 0(13 个本地 job 全绿)
- GitHub Actions `rewrite-ci` run URL:开 PR 后生成
- [x] `npm run check`(完整本地 `check:ci` 聚合退出 0;目标测试在全量分片中 7.185s 通过)
- [ ] GitHub Actions `rewrite-ci` passed(待跑;绿后才合并)
- 未运行:无。

## 审查证据

- 自查:worker 证明了竞态机制(断言采样跨首轮 reconcile),不是修症状。
- Reviewer subagent:未运行;CEO 直接审全量 hunk(init + waitForCondition,无 sleep)。
- 人工审查:CEO 语义验收——修复补齐断言一直默认的前置条件;20 连跑是确定性证据不是运气。
- 阻塞发现:无。

## 残余风险

- 同套件其他测试若有各自的 reconcile 采样假设,属独立 occurrence——flake registry(在飞任务)会捕捉并锚定。

## 关联材料

- 任务:task_01KXNQABV1XSQHPXVQQCQNGWVA
- 证据:任务包 progress + execution outputs
- 审查:任务包 review.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
