### PR TITLE
feat(tools): main-watch post-merge watcher + anchored flake registry

### DIFF
--- a/tools/fixtures/main-watch/run-29513133791-failed.txt
+++ b/tools/fixtures/main-watch/run-29513133791-failed.txt
@@ -1,0 +1,10 @@
+full-check (26)	Run npm run check	2026-07-16T16:12:21.1299210Z ✖ failing tests:
+full-check (26)	Run npm run check	2026-07-16T16:12:21.1299332Z
+full-check (26)	Run npm run check	2026-07-16T16:12:21.1299616Z test at packages/cli/test/daemon-thin-client-cli.test.ts:367:1
+full-check (26)	Run npm run check	2026-07-16T16:12:21.1300343Z ✖ daemon start service status and stop expose productized status contract (4321.767476ms)
+full-check (26)	Run npm run check	2026-07-16T16:12:21.1300974Z   AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+full-check (24)	Run npm run check	2026-07-16T16:13:53.4447897Z ✖ failing tests:
+full-check (24)	Run npm run check	2026-07-16T16:13:53.4448031Z
+full-check (24)	Run npm run check	2026-07-16T16:13:53.4448298Z test at packages/cli/test/daemon-thin-client-cli.test.ts:367:1
+full-check (24)	Run npm run check	2026-07-16T16:13:53.4449038Z ✖ daemon start service status and stop expose productized status contract (4752.456592ms)
+full-check (24)	Run npm run check	2026-07-16T16:13:53.4449671Z   AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

--- a/tools/flake-registry.json
+++ b/tools/flake-registry.json
@@ -1,0 +1,12 @@
+{
+  "schema": "harness-anything/flake-registry/v1",
+  "entries": [
+    {
+      "testName": "daemon start service status and stop expose productized status contract",
+      "file": "packages/cli/test/daemon-thin-client-cli.test.ts",
+      "anchoredTask": "task_01KXNQABV1XSQHPXVQQCQNGWVA",
+      "firstSeen": "2026-07-16",
+      "notes": "Known daemon lifecycle timing flake; observed failing main five times, including runs 29512159972 and 29513133791 on Node 24 and 26."
+    }
+  ]
+}

--- a/tools/flake-registry.test.mjs
+++ b/tools/flake-registry.test.mjs
@@ -1,0 +1,31 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { validateRegistry } from "./main-watch.mjs";
+
+test("the flake registry has the v1 schema and every entry anchors a repair task", () => {
+  const registry = JSON.parse(readFileSync(new URL("./flake-registry.json", import.meta.url), "utf8"));
+
+  assert.doesNotThrow(() => validateRegistry(registry));
+  assert.deepEqual(registry.entries[0], {
+    testName: "daemon start service status and stop expose productized status contract",
+    file: "packages/cli/test/daemon-thin-client-cli.test.ts",
+    anchoredTask: "task_01KXNQABV1XSQHPXVQQCQNGWVA",
+    firstSeen: "2026-07-16",
+    notes: "Known daemon lifecycle timing flake; observed failing main five times, including runs 29512159972 and 29513133791 on Node 24 and 26."
+  });
+});
+
+test("registry validation rejects an entry without an anchored repair task", () => {
+  assert.throws(() => validateRegistry({
+    schema: "harness-anything/flake-registry/v1",
+    entries: [{
+      testName: "known failure",
+      file: "tools/example.test.mjs",
+      anchoredTask: "",
+      firstSeen: "2026-07-17",
+      notes: "fixture"
+    }]
+  }), /requires non-empty anchoredTask/u);
+});

--- a/tools/main-watch.mjs
+++ b/tools/main-watch.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+
+const ansiEscapePattern = /\u001b\[[0-?]*[ -/]*[@-~]/gu;
+const durationSuffixPattern = / \(\d+(?:\.\d+)?ms\)$/u;
+const logTimestampPattern = /^\uFEFF?\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*/u;
+const registryEntryFields = Object.freeze(["testName", "file", "anchoredTask", "firstSeen", "notes"]);
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const registryPath = path.join(repoRoot, "tools/flake-registry.json");
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function validateRegistry(registry) {
+  if (registry?.schema !== "harness-anything/flake-registry/v1") {
+    throw new Error("flake registry schema must be harness-anything/flake-registry/v1");
+  }
+  if (!Array.isArray(registry.entries)) {
+    throw new Error("flake registry entries must be an array");
+  }
+
+  const testNames = new Set();
+  for (const [index, entry] of registry.entries.entries()) {
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`flake registry entry ${index} must be an object`);
+    }
+    for (const field of registryEntryFields) {
+      if (!nonEmptyString(entry[field])) {
+        throw new Error(`flake registry entry ${index} requires non-empty ${field}`);
+      }
+    }
+    if (!/^task_[A-Z0-9]+$/u.test(entry.anchoredTask)) {
+      throw new Error(`flake registry entry ${index} anchoredTask must be a task id`);
+    }
+    if (!/^\d{4}-\d{2}-\d{2}$/u.test(entry.firstSeen)) {
+      throw new Error(`flake registry entry ${index} firstSeen must be YYYY-MM-DD`);
+    }
+    if (testNames.has(entry.testName)) {
+      throw new Error(`flake registry has duplicate testName: ${entry.testName}`);
+    }
+    testNames.add(entry.testName);
+  }
+  return registry;
+}
+
+function parseLogLine(line) {
+  const columns = line.split("\t");
+  const hasGithubPrefix = columns.length >= 3;
+  const message = hasGithubPrefix ? columns.slice(2).join("\t").replace(logTimestampPattern, "") : line;
+  return {
+    job: hasGithubPrefix ? columns[0] : "__unprefixed__",
+    message: message.replace(ansiEscapePattern, "").replace(/^\uFEFF/u, "")
+  };
+}
+
+export function parseFailedLogs(log) {
+  const failingTests = [];
+  const jobs = new Map();
+
+  for (const line of log.split(/\r?\n/u)) {
+    if (!line) continue;
+    const { job, message: rawMessage } = parseLogLine(line);
+    const message = rawMessage.trim();
+    const state = jobs.get(job) ?? { inFailingTests: false, failingTestCount: 0 };
+    jobs.set(job, state);
+    if (message === "✖ failing tests:") {
+      state.inFailingTests = true;
+      continue;
+    }
+    if (message.startsWith("Slow test summary:") || message.startsWith("##[error]")) {
+      state.inFailingTests = false;
+    }
+    if (!state.inFailingTests || !message.startsWith("✖ ")) continue;
+    const testName = message.slice(2).replace(durationSuffixPattern, "").trim();
+    if (testName) {
+      failingTests.push(testName);
+      state.failingTestCount += 1;
+    }
+  }
+
+  return {
+    failingTests: [...new Set(failingTests)],
+    hasUnparsedFailedJob: jobs.size === 0 || [...jobs.values()].some((state) => state.failingTestCount === 0)
+  };
+}
+
+export function extractFailingTests(log) {
+  return parseFailedLogs(log).failingTests;
+}
+
+function result(code, classification, runUrl = "-", failingTests = []) {
+  return { code, classification, runUrl, failingTests };
+}
+
+async function classifyCompletedRun(run, registry, github) {
+  if (run.conclusion === "success") return result(0, "green", run.url);
+
+  const parsedLogs = parseFailedLogs(await github.readFailedLogs(run.databaseId));
+  const { failingTests } = parsedLogs;
+  const registeredNames = new Set(registry.entries.map((entry) => entry.testName));
+  const allRegistered = !parsedLogs.hasUnparsedFailedJob && failingTests.length > 0 &&
+    failingTests.every((testName) => registeredNames.has(testName));
+  return result(allRegistered ? 20 : 30, allRegistered ? "flake" : "regression", run.url, failingTests);
+}
+
+const defaultSleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+export async function watchMain({
+  commitSha,
+  registry,
+  github,
+  intervalMs = 60_000,
+  timeoutMs = 5_400_000,
+  dryRun = false,
+  now = Date.now,
+  sleep = defaultSleep
+}) {
+  const startedAt = now();
+  let lastRun;
+
+  while (true) {
+    const runs = await github.listRuns(commitSha);
+    lastRun = runs.find((candidate) => candidate.event === "push" && candidate.headSha === commitSha);
+    if (lastRun?.status === "completed") {
+      return classifyCompletedRun(lastRun, registry, github);
+    }
+    if (dryRun) {
+      return result(40, lastRun ? "pending" : "run-missing", lastRun?.url);
+    }
+
+    const elapsedMs = now() - startedAt;
+    if (elapsedMs >= timeoutMs) {
+      return result(40, "timeout", lastRun?.url);
+    }
+    await sleep(Math.min(intervalMs, timeoutMs - elapsedMs));
+  }
+}
+
+function flagValue(args, index, flag) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function positiveSeconds(value, flag) {
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds) || seconds <= 0) throw new Error(`${flag} must be a positive number`);
+  return seconds * 1_000;
+}
+
+export function parseMainWatchArgs(args) {
+  const commitSha = args[0];
+  if (!commitSha || commitSha.startsWith("--")) {
+    throw new Error("usage: node tools/main-watch.mjs <merge-commit-sha> [--repo owner/name] [--interval seconds] [--timeout seconds] [--dry-run]");
+  }
+  if (!/^[0-9a-f]{40}$/iu.test(commitSha)) throw new Error("merge commit SHA must be 40 hexadecimal characters");
+
+  const options = { commitSha, repo: null, intervalMs: 60_000, timeoutMs: 5_400_000, dryRun: false };
+  for (let index = 1; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = flagValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--interval") {
+      options.intervalMs = positiveSeconds(flagValue(args, index, arg), arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--timeout") {
+      options.timeoutMs = positiveSeconds(flagValue(args, index, arg), arg);
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown main-watch option: ${arg}`);
+  }
+  return options;
+}
+
+async function runGh(args) {
+  const { stdout } = await execFileAsync("gh", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024
+  });
+  return stdout;
+}
+
+export function createGithubClient(repo) {
+  const repoArgs = repo ? ["--repo", repo] : [];
+  return {
+    async listRuns(commitSha) {
+      const output = await runGh([
+        "run", "list",
+        "--workflow", "rewrite-ci",
+        "--branch", "main",
+        "--commit", commitSha,
+        "--limit", "20",
+        "--json", "databaseId,event,headSha,status,conclusion,url",
+        ...repoArgs
+      ]);
+      return JSON.parse(output);
+    },
+    async readFailedLogs(runId) {
+      return runGh(["run", "view", String(runId), "--log-failed", ...repoArgs]);
+    }
+  };
+}
+
+export function formatResultLine(watchResult) {
+  const failingTests = watchResult.failingTests.length > 0 ? watchResult.failingTests.join(" | ") : "-";
+  return `RESULT: ${watchResult.code} ${watchResult.classification} ${watchResult.runUrl} ${failingTests}`;
+}
+
+async function main(argv) {
+  try {
+    const options = parseMainWatchArgs(argv);
+    const registry = validateRegistry(JSON.parse(await readFile(registryPath, "utf8")));
+    const watchResult = await watchMain({
+      ...options,
+      registry,
+      github: createGithubClient(options.repo)
+    });
+    console.log(formatResultLine(watchResult));
+    return watchResult.code;
+  } catch (error) {
+    console.error(`main-watch failed: ${error instanceof Error ? error.message : String(error)}`);
+    console.log(formatResultLine(result(40, "unavailable")));
+    return 40;
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = await main(process.argv.slice(2));
+}

--- a/tools/main-watch.test.mjs
+++ b/tools/main-watch.test.mjs
@@ -1,0 +1,236 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { watchMain } from "./main-watch.mjs";
+
+const knownFlake = "daemon start service status and stop expose productized status contract";
+const failedLog = readFileSync(
+  new URL("./fixtures/main-watch/run-29513133791-failed.txt", import.meta.url),
+  "utf8"
+);
+
+test("a completed main run is a flake when every failing test exactly matches the registry", async () => {
+  const result = await watchMain({
+    commitSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+    registry: { entries: [{ testName: knownFlake }] },
+    github: {
+      listRuns: async () => [{
+        databaseId: 29513133791,
+        event: "push",
+        headSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+        status: "completed",
+        conclusion: "failure",
+        url: "https://github.com/FairladyZ625/harness-anything/actions/runs/29513133791"
+      }],
+      readFailedLogs: async () => failedLog
+    }
+  });
+
+  assert.deepEqual(result, {
+    code: 20,
+    classification: "flake",
+    runUrl: "https://github.com/FairladyZ625/harness-anything/actions/runs/29513133791",
+    failingTests: [knownFlake]
+  });
+});
+
+test("one unregistered failing test classifies the whole run as a regression", async () => {
+  const unknownFailure = "a newly introduced test failure";
+  const mixedLog = `${failedLog}\nfull-check (24)\tRun npm run check\t2026-07-16T16:13:54Z\t✖ failing tests:\n` +
+    `full-check (24)\tRun npm run check\t2026-07-16T16:13:54Z\ttest at tools/example.test.mjs:1:1\n` +
+    `full-check (24)\tRun npm run check\t2026-07-16T16:13:54Z\t✖ ${unknownFailure} (1.25ms)\n`;
+  const result = await watchMain({
+    commitSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+    registry: { entries: [{ testName: knownFlake }] },
+    github: {
+      listRuns: async () => [{
+        databaseId: 29513133791,
+        event: "push",
+        headSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+        status: "completed",
+        conclusion: "failure",
+        url: "https://github.com/FairladyZ625/harness-anything/actions/runs/29513133791"
+      }],
+      readFailedLogs: async () => mixedLog
+    }
+  });
+
+  assert.equal(result.code, 30);
+  assert.equal(result.classification, "regression");
+  assert.deepEqual(result.failingTests, [knownFlake, unknownFailure]);
+});
+
+test("a successful completed main run is green without reading failure logs", async () => {
+  const result = await watchMain({
+    commitSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+    registry: { entries: [{ testName: knownFlake }] },
+    github: {
+      listRuns: async () => [{
+        databaseId: 1,
+        event: "push",
+        headSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+        status: "completed",
+        conclusion: "success",
+        url: "https://github.com/example/repo/actions/runs/1"
+      }],
+      readFailedLogs: async () => assert.fail("green runs have no failed logs to read")
+    }
+  });
+
+  assert.deepEqual(result, {
+    code: 0,
+    classification: "green",
+    runUrl: "https://github.com/example/repo/actions/runs/1",
+    failingTests: []
+  });
+});
+
+test("a missing run is polled until timeout and exits unavailable", async () => {
+  let now = 0;
+  let polls = 0;
+  const result = await watchMain({
+    commitSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+    registry: { entries: [{ testName: knownFlake }] },
+    intervalMs: 50,
+    timeoutMs: 100,
+    now: () => now,
+    sleep: async (milliseconds) => { now += milliseconds; },
+    github: {
+      listRuns: async () => { polls += 1; return []; },
+      readFailedLogs: async () => assert.fail("a missing run has no logs")
+    }
+  });
+
+  assert.equal(polls, 3);
+  assert.deepEqual(result, {
+    code: 40,
+    classification: "timeout",
+    runUrl: "-",
+    failingTests: []
+  });
+});
+
+test("the CLI prints a machine-readable flake result and exits 20", { skip: process.platform === "win32" }, (t) => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-main-watch-"));
+  const binDir = path.join(rootDir, "bin");
+  const ghPath = path.join(binDir, "gh");
+  mkdirSync(binDir);
+  writeFileSync(ghPath, [
+    "#!/usr/bin/env node",
+    "const fs = require('node:fs');",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === 'run' && args[1] === 'list') {",
+    "  process.stdout.write(JSON.stringify([{ databaseId: 29513133791, event: 'push', headSha: '37d234863f1bb06b7fa33e511d1558bc1394dc77', status: 'completed', conclusion: 'failure', url: 'https://github.com/FairladyZ625/harness-anything/actions/runs/29513133791' }]));",
+    "} else if (args[0] === 'run' && args[1] === 'view') {",
+    "  process.stdout.write(fs.readFileSync(process.env.MAIN_WATCH_TEST_LOG, 'utf8'));",
+    "} else {",
+    "  process.stderr.write(`unexpected gh args: ${args.join(' ')}`);",
+    "  process.exitCode = 1;",
+    "}",
+    ""
+  ].join("\n"), "utf8");
+  chmodSync(ghPath, 0o755);
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+
+  const result = spawnSync(process.execPath, [
+    "tools/main-watch.mjs",
+    "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+    "--repo",
+    "FairladyZ625/harness-anything",
+    "--dry-run"
+  ], {
+    cwd: path.resolve(import.meta.dirname, ".."),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      MAIN_WATCH_TEST_LOG: path.resolve(import.meta.dirname, "fixtures/main-watch/run-29513133791-failed.txt"),
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`
+    }
+  });
+
+  assert.equal(result.status, 20, result.stderr);
+  assert.equal(result.stdout.trim().split("\n").at(-1),
+    `RESULT: 20 flake https://github.com/FairladyZ625/harness-anything/actions/runs/29513133791 ${knownFlake}`);
+});
+
+test("an opaque failed job keeps an otherwise registered run in regression classification", async () => {
+  const logWithOpaqueFailure = `${failedLog}\nboundaries\tRun checker\t2026-07-16T16:14:00Z\tchecker stopped before Node test output\n` +
+    "boundaries\tRun checker\t2026-07-16T16:14:01Z\t##[error]Process completed with exit code 1.\n";
+  const result = await watchMain({
+    commitSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+    registry: { entries: [{ testName: knownFlake }] },
+    github: {
+      listRuns: async () => [{
+        databaseId: 29513133791,
+        event: "push",
+        headSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+        status: "completed",
+        conclusion: "failure",
+        url: "https://github.com/FairladyZ625/harness-anything/actions/runs/29513133791"
+      }],
+      readFailedLogs: async () => logWithOpaqueFailure
+    }
+  });
+
+  assert.equal(result.code, 30);
+  assert.equal(result.classification, "regression");
+  assert.deepEqual(result.failingTests, [knownFlake]);
+});
+
+test("run selection ignores a pull request run even when it is listed first", async () => {
+  const commitSha = "37d234863f1bb06b7fa33e511d1558bc1394dc77";
+  const result = await watchMain({
+    commitSha,
+    registry: { entries: [{ testName: knownFlake }] },
+    github: {
+      listRuns: async () => [
+        {
+          databaseId: 1,
+          event: "pull_request",
+          headSha: commitSha,
+          status: "completed",
+          conclusion: "success",
+          url: "https://github.com/example/repo/actions/runs/1"
+        },
+        {
+          databaseId: 29513133791,
+          event: "push",
+          headSha: commitSha,
+          status: "completed",
+          conclusion: "failure",
+          url: "https://github.com/FairladyZ625/harness-anything/actions/runs/29513133791"
+        }
+      ],
+      readFailedLogs: async () => failedLog
+    }
+  });
+
+  assert.equal(result.code, 20);
+  assert.equal(result.runUrl, "https://github.com/FairladyZ625/harness-anything/actions/runs/29513133791");
+});
+
+test("dry-run reports a missing run after one read instead of polling", async () => {
+  let polls = 0;
+  const result = await watchMain({
+    commitSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+    registry: { entries: [{ testName: knownFlake }] },
+    dryRun: true,
+    sleep: async () => assert.fail("dry-run must not sleep"),
+    github: {
+      listRuns: async () => { polls += 1; return []; },
+      readFailedLogs: async () => assert.fail("a missing run has no logs")
+    }
+  });
+
+  assert.equal(polls, 1);
+  assert.deepEqual(result, {
+    code: 40,
+    classification: "run-missing",
+    runUrl: "-",
+    failingTests: []
+  });
+});


### PR DESCRIPTION
# English

## Summary

Machine face of the accepted post-merge red-handling protocol (dec_01KXNVNXQ369E1VFM5HXPGJ60P): `tools/main-watch.mjs` watches the main-branch `rewrite-ci` run for a given merge commit and exits with a classification code — 0 green / 20 flake (every failing test matches the flake registry) / 30 regression suspect (any failing test unmatched) / 40 timeout or run missing — emitting a machine-parseable `RESULT:` tail line (pr-watch family convention). `tools/flake-registry.json` is the machine-readable known-flake ledger; every entry must anchor an open fix task (schema test rejects entries without one). First real entry: the daemon attach/detach race, anchored to its fix task. Classification is strict by design: mixed failures classify as regression — better a false regression alarm than a masked one.

## What Changed

- `tools/main-watch.mjs` (new): locates the push run on main for a SHA via `gh`, polls to completion, extracts failing test names from the node test-runner `failing tests` section of failed job logs, matches against the registry, exits 0/20/30/40 with `RESULT: <code> <classification> <run-url> <failing-tests>`.
- `tools/main-watch.test.mjs` (new): classifier unit tests on fixtured run logs (all-matched=flake, partial=regression, none=green, timeout), no live GitHub API in tests (fetch function injected).
- `tools/flake-registry.json` (new): first entry — `daemon start service status and stop expose productized status contract` → anchoredTask task_01KXNQABV1XSQHPXVQQCQNGWVA (fixed by #823; entry retained for occurrence history and as schema exemplar).
- `tools/flake-registry.test.mjs` (new): schema validation; `anchoredTask` mandatory and non-empty.

## Task And Scope

- Harness task: task_01KXNW9FPEWBYQ8S2FM9M28443
- Branch: `codex/main-watch-flake-registry`
- Public scope: four new files under `tools/`; no existing gate or workflow touched
- Private planning/evidence updated: yes (progress; anchor-falsification evidence recorded before implementation)
- Out of scope: merge-freeze/quarantine enforcement (CEO discipline + loop tick per the decision's phase-1 ruling), CI workflow changes.

## Version Impact

- Version: no version change because this is orchestration tooling.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable (purely additive tooling; no existing gate semantics altered)
- Authority: dec_01KXNVNXQ369E1VFM5HXPGJ60P (accepted); task_01KXNW9FPEWBYQ8S2FM9M28443
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: bc86c7fd (rebased pre-PR)
- Branch merge-base with `origin/main`: bc86c7fd
- Last `git fetch origin` time: 2026-07-17 ~02:30 (pre-PR rebase)
- Sync method: rebase
- Public diff command: `git diff bc86c7fd...HEAD`
- Private evidence commit/path: task package progress (includes the worker's falsification of a wrong acceptance anchor supplied by the CEO, corrected to run 29513133791)
- Reviewer evidence path: worker report — read-only rehearsal against real red run 29513133791 classified 20/flake as expected
- GitHub Actions `rewrite-ci` run URL: pending on PR open
- [x] `npm run check` (worker `check:ci` green pre-rebase; targeted registry+watcher tests 10/10 re-run green post-rebase)
- [ ] GitHub Actions `rewrite-ci` passed (pending; merged only on green)
- Not run: live `gh` path exercised in the read-only rehearsal, not in unit tests (injected fetch by design).

## Review Evidence

- Self-review: worker falsified the CEO-supplied acceptance anchor before writing code (run was a PR-side success, not the main red) and halted for confirmation — evidence-first discipline.
- Reviewer subagent: not run; CEO reviewed exit-code contract and strict-classification rule.
- Human review: decision accepted by the user ("这两个 decision 我都 accept"); CEO fixed a truncated anchoredTask id to the full ULID before landing (single-field amend, 10/10 tests re-run).
- Blocking findings: none.

## Residual Risk

- Failing-test extraction is coupled to the node test-runner log format; a runner format change would degrade classification to 30/regression (fail-safe direction) — strictness means false regression alarms, never masked ones.
- Occurrence counting lives in ledger facts (per decision), not in the registry file; registry is identity + anchor only.

## References

- Task: task_01KXNW9FPEWBYQ8S2FM9M28443
- Evidence: task package progress + read-only rehearsal output
- Review: task package review.md

---

# 中文

## 概要

已 accept 的 post-merge 红处置协议(dec_01KXNVNXQ369E1VFM5HXPGJ60P)的机器面:`tools/main-watch.mjs` 观察指定 merge commit 在 main 上的 `rewrite-ci` run,按分类分码退出——0 绿 / 20 flake(失败测试**全部**命中 flake registry)/ 30 回归嫌疑(任一未命中)/ 40 超时或 run 缺失——尾行输出机器可解析的 `RESULT:`(pr-watch 同族约定)。`tools/flake-registry.json` 是机器可读的已知 flake 台账,每条必须锚定 open 修复 task(schema 测试拒绝无锚条目)。首条真实登记:daemon attach/detach 竞态,锚定其修复任务。分类宁严勿宽:混合失败一律按回归——宁可误报回归,不可漏报。

## 改动内容

- `tools/main-watch.mjs`(新增):经 `gh` 定位 SHA 在 main 的 push run,轮询至完成,从失败 job 日志的 node test-runner `failing tests` 段提取失败测试名,对 registry 匹配,按 0/20/30/40 退出并输出 `RESULT: <code> <classification> <run-url> <failing-tests>`。
- `tools/main-watch.test.mjs`(新增):基于 fixture 日志的分类器单测(全命中=flake/部分命中=回归/无失败=绿/超时),测试不打真实 GitHub API(注入抓取函数)。
- `tools/flake-registry.json`(新增):首条——`daemon start service status and stop expose productized status contract` → anchoredTask task_01KXNQABV1XSQHPXVQQCQNGWVA(已由 #823 修复;条目保留作 occurrence 史与 schema 范例)。
- `tools/flake-registry.test.mjs`(新增):schema 校验;`anchoredTask` 必填非空。

## 任务与范围

- Harness 任务:task_01KXNW9FPEWBYQ8S2FM9M28443
- 分支:`codex/main-watch-flake-registry`
- 公开范围:`tools/` 下四个新文件;不动任何既有 gate 或 workflow
- 私有计划 / 证据是否已更新:yes(progress;实现前先落了锚点证伪证据)
- 范围外:冻结/隔离的平台化执法(按决策第一版裁定归 CEO 纪律 + loop tick)、CI workflow 改动。

## 版本影响

- 版本:不改版本,原因是编排工具。
- 发布影响:不发布。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用(纯新增工具,未改任何既有门语义)
- 依据:dec_01KXNVNXQ369E1VFM5HXPGJ60P(accepted);task_01KXNW9FPEWBYQ8S2FM9M28443
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- `origin/main` 基准 SHA:bc86c7fd(开 PR 前 rebase)
- 当前分支与 `origin/main` 的 merge-base:bc86c7fd
- 最近一次 `git fetch origin` 时间:2026-07-17 约 02:30(开 PR 前 rebase)
- 同步方式:rebase
- 公开 diff 命令:`git diff bc86c7fd...HEAD`
- 私有证据 commit/path:任务包 progress(含 worker 对 CEO 给错的验收锚点的证伪记录,已更正为 run 29513133791)
- Reviewer 证据路径:worker 报告——对真实红 run 29513133791 的只读演练按预期分类 20/flake
- GitHub Actions `rewrite-ci` run URL:开 PR 后生成
- [x] `npm run check`(worker rebase 前 `check:ci` 全绿;rebase 后 registry+watcher 定向测试 10/10 复跑绿)
- [ ] GitHub Actions `rewrite-ci` passed(待跑;绿后才合并)
- 未运行:真实 `gh` 路径由只读演练覆盖,单测按设计用注入抓取。

## 审查证据

- 自查:worker 动手前证伪了 CEO 给的验收锚点(那是 PR 侧成功 run,不是 main 红)并停下求确认——证据先行。
- Reviewer subagent:未运行;CEO 审退出码契约与宁严勿宽分类规则。
- 人工审查:决策由用户 accept(「这两个 decision 我都 accept」);落地前 CEO 把截断的 anchoredTask id 修正为全长 ULID(单字段 amend,10/10 测试复跑)。
- 阻塞发现:无。

## 残余风险

- 失败测试提取耦合 node test-runner 日志格式;格式变化会退化为 30/回归(fail-safe 方向)——严格性意味着可能误报回归,绝不掩蔽。
- occurrence 计数按决策归台账 fact,不在 registry 文件里;registry 只管身份+锚。

## 关联材料

- 任务:task_01KXNW9FPEWBYQ8S2FM9M28443
- 证据:任务包 progress + 只读演练输出
- 审查:任务包 review.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
