### PR TITLE
fix(tools): main-watch v1.1 — accept short SHAs, classify cancelled runs as superseded

### DIFF
--- a/tools/main-watch.mjs
+++ b/tools/main-watch.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execFile } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -101,6 +101,15 @@ function result(code, classification, runUrl = "-", failingTests = []) {
 
 async function classifyCompletedRun(run, registry, github) {
   if (run.conclusion === "success") return result(0, "green", run.url);
+  if (run.conclusion === "cancelled") {
+    const newerRuns = await github.listNewerMainRuns();
+    const supersedingRun = newerRuns.find((candidate) => candidate.createdAt > run.createdAt);
+    return {
+      ...result(50, "superseded", run.url),
+      supersedingRunUrl: supersedingRun?.url ?? "-"
+    };
+  }
+  if (run.conclusion !== "failure") return result(40, "unavailable", run.url);
 
   const parsedLogs = parseFailedLogs(await github.readFailedLogs(run.databaseId));
   const { failingTests } = parsedLogs;
@@ -160,7 +169,7 @@ export function parseMainWatchArgs(args) {
   if (!commitSha || commitSha.startsWith("--")) {
     throw new Error("usage: node tools/main-watch.mjs <merge-commit-sha> [--repo owner/name] [--interval seconds] [--timeout seconds] [--dry-run]");
   }
-  if (!/^[0-9a-f]{40}$/iu.test(commitSha)) throw new Error("merge commit SHA must be 40 hexadecimal characters");
+  if (!/^[0-9a-f]{7,40}$/iu.test(commitSha)) throw new Error("merge commit SHA must be 7 to 40 hexadecimal characters");
 
   const options = { commitSha, repo: null, intervalMs: 60_000, timeoutMs: 5_400_000, dryRun: false };
   for (let index = 1; index < args.length; index += 1) {
@@ -189,6 +198,18 @@ export function parseMainWatchArgs(args) {
   return options;
 }
 
+export function resolveCommitSha(commitSha) {
+  const resolved = spawnSync("git", ["rev-parse", `${commitSha}^{commit}`], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+  const fullSha = resolved.stdout?.trim();
+  if (resolved.status !== 0 || !/^[0-9a-f]{40}$/iu.test(fullSha ?? "")) {
+    throw new Error(`merge commit SHA ${commitSha} could not be resolved locally; run git fetch and try again`);
+  }
+  return fullSha;
+}
+
 async function runGh(args) {
   const { stdout } = await execFileAsync("gh", args, {
     cwd: repoRoot,
@@ -208,7 +229,18 @@ export function createGithubClient(repo) {
         "--branch", "main",
         "--commit", commitSha,
         "--limit", "20",
-        "--json", "databaseId,event,headSha,status,conclusion,url",
+        "--json", "databaseId,event,headSha,status,conclusion,createdAt,url",
+        ...repoArgs
+      ]);
+      return JSON.parse(output);
+    },
+    async listNewerMainRuns() {
+      const output = await runGh([
+        "run", "list",
+        "--workflow", "rewrite-ci",
+        "--branch", "main",
+        "--limit", "20",
+        "--json", "databaseId,headSha,createdAt,url",
         ...repoArgs
       ]);
       return JSON.parse(output);
@@ -220,6 +252,9 @@ export function createGithubClient(repo) {
 }
 
 export function formatResultLine(watchResult) {
+  if (watchResult.classification === "superseded") {
+    return `RESULT: ${watchResult.code} ${watchResult.classification} ${watchResult.runUrl} ${watchResult.supersedingRunUrl}`;
+  }
   const failingTests = watchResult.failingTests.length > 0 ? watchResult.failingTests.join(" | ") : "-";
   return `RESULT: ${watchResult.code} ${watchResult.classification} ${watchResult.runUrl} ${failingTests}`;
 }
@@ -227,6 +262,7 @@ export function formatResultLine(watchResult) {
 async function main(argv) {
   try {
     const options = parseMainWatchArgs(argv);
+    options.commitSha = resolveCommitSha(options.commitSha);
     const registry = validateRegistry(JSON.parse(await readFile(registryPath, "utf8")));
     const watchResult = await watchMain({
       ...options,

--- a/tools/main-watch.test.mjs
+++ b/tools/main-watch.test.mjs
@@ -5,13 +5,21 @@ import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync 
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { watchMain } from "./main-watch.mjs";
+import { formatResultLine, parseMainWatchArgs, resolveCommitSha, watchMain } from "./main-watch.mjs";
 
 const knownFlake = "daemon start service status and stop expose productized status contract";
 const failedLog = readFileSync(
   new URL("./fixtures/main-watch/run-29513133791-failed.txt", import.meta.url),
   "utf8"
 );
+
+test("a short merge SHA resolves to its full local commit SHA", () => {
+  const fullSha = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).stdout.trim();
+  const shortSha = fullSha.slice(0, 8);
+
+  assert.equal(parseMainWatchArgs([shortSha]).commitSha, shortSha);
+  assert.equal(resolveCommitSha(shortSha), fullSha);
+});
 
 test("a completed main run is a flake when every failing test exactly matches the registry", async () => {
   const result = await watchMain({
@@ -85,6 +93,66 @@ test("a successful completed main run is green without reading failure logs", as
     code: 0,
     classification: "green",
     runUrl: "https://github.com/example/repo/actions/runs/1",
+    failingTests: []
+  });
+});
+
+test("a cancelled completed main run is superseded instead of a regression", async () => {
+  const result = await watchMain({
+    commitSha: "9e447b2a9b1726d8e81c91105e41699599c0b789",
+    registry: { entries: [] },
+    github: {
+      listRuns: async () => [{
+        databaseId: 29544075307,
+        event: "push",
+        headSha: "9e447b2a9b1726d8e81c91105e41699599c0b789",
+        status: "completed",
+        conclusion: "cancelled",
+        createdAt: "2026-07-17T01:00:00Z",
+        url: "https://github.com/example/repo/actions/runs/29544075307"
+      }],
+      listNewerMainRuns: async () => [{
+        databaseId: 29544075308,
+        createdAt: "2026-07-17T01:01:00Z",
+        url: "https://github.com/example/repo/actions/runs/29544075308"
+      }],
+      readFailedLogs: async () => assert.fail("cancelled runs have no failure logs to read")
+    }
+  });
+
+  assert.deepEqual(result, {
+    code: 50,
+    classification: "superseded",
+    runUrl: "https://github.com/example/repo/actions/runs/29544075307",
+    failingTests: [],
+    supersedingRunUrl: "https://github.com/example/repo/actions/runs/29544075308"
+  });
+  assert.equal(formatResultLine(result),
+    "RESULT: 50 superseded https://github.com/example/repo/actions/runs/29544075307 https://github.com/example/repo/actions/runs/29544075308");
+});
+
+test("a startup failure is unavailable instead of a regression", async () => {
+  const result = await watchMain({
+    commitSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+    registry: { entries: [] },
+    github: {
+      listRuns: async () => [{
+        databaseId: 9,
+        event: "push",
+        headSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+        status: "completed",
+        conclusion: "startup_failure",
+        url: "https://github.com/example/repo/actions/runs/9"
+      }],
+      listNewerMainRuns: async () => assert.fail("only cancelled runs look for a superseding run"),
+      readFailedLogs: async () => assert.fail("startup failures have no failure logs to read")
+    }
+  });
+
+  assert.deepEqual(result, {
+    code: 40,
+    classification: "unavailable",
+    runUrl: "https://github.com/example/repo/actions/runs/9",
     failingTests: []
   });
 });


### PR DESCRIPTION
# English

## Summary

First real dogfood of `tools/main-watch.mjs` (landed last night in #826) exposed two defects, both with live evidence: (1) it rejected short SHAs (`merge commit SHA must be 40 hexadecimal characters`) even though merge receipts and `gh` output naturally produce short SHAs; (2) it classified a **cancelled** main run as `30 regression` with an empty failing-test list — run 29544075307 was cancelled by the subsequent main push's concurrency group (ground truth `{"conclusion":"cancelled","failed":[]}`), which is supersession, not regression, and a false 30 would trigger an unwarranted merge freeze. This PR fixes both: short SHAs (≥7 hex) are resolved locally via `git rev-parse`, and cancelled runs classify as a new exit code **50 superseded**, with the superseding run's URL in the `RESULT:` tail line when found. Existing exit codes 0/20/30/40 are contract and remain untouched; other non-success non-failure conclusions (e.g. `startup_failure`) now classify strictly as 40 unavailable instead of falling into 30.

## What Changed

- `tools/main-watch.mjs`: accept 7–40 hex SHA and resolve to full SHA via `git rev-parse <sha>^{commit}` (absolute repo-root cwd; unresolvable SHA errors with a `git fetch` hint); `conclusion=cancelled` → exit 50 `superseded` with superseding-run lookup (`gh run list`, newer `createdAt` on main's rewrite-ci); non-success/failure/cancelled conclusions → 40 unavailable; `RESULT:` line for superseded carries `<runUrl> <supersedingRunUrl|->`.
- `tools/main-watch.test.mjs`: new cases — short-SHA resolution, cancelled→50 with superseding URL, startup_failure→40, true failure still→30; 11 tests total, all green.

## Task And Scope

- Harness task: task_01KXPPYGZ5PNG00WJYGHMYE6GC
- Branch: `codex/main-watch-v11`
- Public scope: `tools/main-watch.mjs` + its test only; flake-registry content, workflows, and all gates untouched
- Private planning/evidence updated: yes (task progress with manual dogfood output)
- Out of scope: exit-code changes to 0/20/30/40 (external contract), merge-freeze/quarantine enforcement.

## Version Impact

- Version: no version change because this is orchestration tooling.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable (main-watch is a post-merge tail-check tool, not a CI required check; no gate semantics altered)
- Authority: task_01KXPPYGZ5PNG00WJYGHMYE6GC (defect fix under dec_01KXNVNXQ369E1VFM5HXPGJ60P's protocol, protocol semantics unchanged)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 77991de1
- Branch merge-base with `origin/main`: 77991de1
- Last `git fetch origin` time: 2026-07-17 ~08:24 (worktree created from fresh origin/main)
- Sync method: branched from origin/main HEAD
- Public diff command: `git diff 77991de1...HEAD`
- Private evidence commit/path: task package progress (manual dogfood receipt)
- Reviewer evidence path: worker report — manual rerun on the live misclassification case now yields `RESULT: 50 superseded https://.../runs/29544075307 https://.../runs/29544231444`
- GitHub Actions `rewrite-ci` run URL: pending on PR open
- [x] `npm run check` (worker `check:local` stop point green, 32 manifest gates; 11/11 unit tests)
- [ ] GitHub Actions `rewrite-ci` passed (pending; merged only on green)
- Not run: live `gh` path in unit tests (injected client by design); manual dogfood exercised it instead.

## Review Evidence

- Self-review: worker reproduced both defects from the live evidence anchors before fixing (TDD: fixtures first).
- Reviewer subagent: not run; CEO reviewed the full diff — conclusion→exit-code mapping table, strict 30 precondition preserved, spawnSync cwd uses absolute repo root.
- Human review: standing authorization ("流转缺陷最高优先" — defects found during operation are fixed first); CEO semantic acceptance done pre-PR.
- Blocking findings: none.

## Residual Risk

- Superseding-run lookup hardcodes the `rewrite-ci` workflow name; a workflow rename would degrade the fourth field to `-` (informational only, classification unaffected).
- Exit 50 is a new code; skill-side triage docs referencing 0/20/30/40 will be updated post-merge (orchestration doc, not in this repo).

## References

- Task: task_01KXPPYGZ5PNG00WJYGHMYE6GC
- Evidence: task package progress + manual dogfood output above
- Review: this PR review thread

---

# 中文

## 概要

`tools/main-watch.mjs`(昨夜 #826 刚合入)首次真实 dogfood 即暴露两个缺陷,均有现场实证:(1) 拒收短 SHA(`merge commit SHA must be 40 hexadecimal characters`),而合并回执与 `gh` 输出天然是短 SHA;(2) 把 **cancelled** 的 main run 误判为 `30 regression` 且失败清单为空——run 29544075307 是被后续 main push 的 concurrency 组取消(ground truth `{"conclusion":"cancelled","failed":[]}`),这是被取代不是回归,误报 30 会触发不该有的 merge freeze。本 PR 修复两者:短 SHA(≥7 位十六进制)经 `git rev-parse` 本地解析;cancelled run 归入新退出码 **50 superseded**,找得到后继 run 时在 `RESULT:` 尾行给出其 URL。既有 0/20/30/40 是对外契约,一律不动;其他既非 success 也非 failure 的 conclusion(如 `startup_failure`)严格归 40 unavailable,不再落入 30。

## 改动内容

- `tools/main-watch.mjs`:接受 7–40 位十六进制 SHA 并经 `git rev-parse <sha>^{commit}` 解析为全 SHA(cwd 用仓库根绝对路径;解析不了报错并提示 `git fetch`);`conclusion=cancelled` → exit 50 `superseded`,经 `gh run list` 找 main 上 rewrite-ci 中 `createdAt` 更晚的后继 run;非 success/failure/cancelled 的 conclusion → 40 unavailable;superseded 的 `RESULT:` 行为 `<runUrl> <supersedingRunUrl|->`。
- `tools/main-watch.test.mjs`:新增用例——短 SHA 解析、cancelled→50 带后继 URL、startup_failure→40、真 failure 仍判 30;共 11 项全绿。

## 任务与范围

- Harness 任务:task_01KXPPYGZ5PNG00WJYGHMYE6GC
- 分支:`codex/main-watch-v11`
- 公开范围:仅 `tools/main-watch.mjs` 及其测试;flake-registry 内容、workflow、所有 gate 不动
- 私有计划 / 证据是否已更新:yes(task progress 含手工 dogfood 输出)
- 范围外:0/20/30/40 退出码变更(对外契约)、merge-freeze/隔离执法。

## 版本影响

- 版本:无版本变化,因为这是编排工具面。
- 发布影响:不发布。

## 治理声明

- 是否触碰受保护面:否
- 受保护面范围:不适用(main-watch 是合并后验尾工具,非 CI required check;不改任何 gate 语义)
- 授权依据:task_01KXPPYGZ5PNG00WJYGHMYE6GC(dec_01KXNVNXQ369E1VFM5HXPGJ60P 协议下的缺陷修复,协议语义不变)
- 机器校验边界:本 PR 仅断言声明存在;声明是否为真、是否充分由 reviewer 判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- 基线 `origin/main` SHA:77991de1
- 分支与 `origin/main` 的 merge-base:77991de1
- 最近一次 `git fetch origin` 时间:2026-07-17 ~08:24(worktree 从最新 origin/main 创建)
- 同步方式:自 origin/main HEAD 开分支
- 公开 diff 命令:`git diff 77991de1...HEAD`
- 私有证据 commit/路径:task package progress(手工 dogfood 回执)
- Reviewer 证据路径:worker 报告——对现场误判用例重跑,现输出 `RESULT: 50 superseded https://.../runs/29544075307 https://.../runs/29544231444`
- GitHub Actions `rewrite-ci` run URL:开 PR 后待填
- [x] `npm run check`(worker `check:local` 停止点全绿,32 个 manifest gate;单测 11/11)
- [ ] GitHub Actions `rewrite-ci` 通过(待跑;仅绿后合并)
- 未运行:单测不打真实 `gh`(注入 client 是设计);由手工 dogfood 覆盖真实路径。

## Review 证据

- 自查:worker 先按现场实证锚复现两个缺陷再修(TDD:先写 fixture)。
- Reviewer 子代理:未跑;CEO 全量 diff 审阅——conclusion→退出码映射表、30 的严格前提保持、spawnSync cwd 用绝对仓库根。
- 人工 review:常设授权(「流转缺陷最高优先」——运行中暴露的系统缺陷先修);CEO 语义验收已在发 PR 前完成。
- 阻塞发现:无。

## 残余风险

- 后继 run 查找硬编码 `rewrite-ci` workflow 名;若 workflow 改名,第四字段退化为 `-`(仅信息性,不影响分类)。
- exit 50 是新码;skill 侧引用 0/20/30/40 的处置文档合并后更新(编排文档,不在本仓)。

## 参考

- 任务:task_01KXPPYGZ5PNG00WJYGHMYE6GC
- 证据:task package progress + 上文手工 dogfood 输出
- Review:本 PR review 线程
