### PR TITLE
fix(gui): make Task server-state single-owned by useTasksQuery (deep-review P1 ROT-014)

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -55,21 +55,18 @@ function AppShell() {
   const tasksQuery = useTasksQuery();
   const triadicQuery = useTriadicProjectionQuery();
   const catalogQuery = useCatalogQuery();
-  const realTasks = useMemo(
+  // ROT-014: TanStack Query is the sole Task server-state owner.
+  // Board/sidebar/selection read the adapted projection directly — no App useState mirror.
+  const tasks = useMemo(
     () => adaptProjectionRows(tasksQuery.data?.tasks ?? []),
     [tasksQuery.data],
   );
-  const [tasks, setTasks] = useState<import("./model/types.ts").TaskRow[]>([]);
-  // 台账投影是权威真数据源;查询刷新时重播到本地态(拖拽等乐观更新为原型内交互)。
-  useEffect(() => {
-    setTasks(realTasks);
-  }, [realTasks]);
 
   const project = useMemo(() => ({
-    ...buildRealProject(realTasks),
+    ...buildRealProject(tasks),
     preset: catalogQuery.data?.activePresetId ?? t("renderer.app.notConfigured"),
     engines: catalogQuery.data?.adapters.map((adapter) => adapter.engine) ?? ["local"]
-  }), [catalogQuery.data, locale, realTasks]);
+  }), [catalogQuery.data, locale, tasks]);
   const projectId = project.id;
   const projects = useMemo(() => [project], [project]);
   const { favorites, toggleFavorite } = useFavorites(projectId);

--- a/packages/gui/test/task-server-state-owner.vitest.ts
+++ b/packages/gui/test/task-server-state-owner.vitest.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import ts from "typescript";
+
+/**
+ * ROT-014 / F-L7-02: Task server-state must have a single owner.
+ * TanStack Query (`useTasksQuery`) is the sole owner; App.tsx must not mirror
+ * the projection into a second `const [tasks, setTasks] = useState(...)`.
+ *
+ * Detector mirrors architecture-rot-registry.json ROT-014 command.
+ */
+function countTaskServerStateOwners(appSource: string, fileName: string) {
+  const source = ts.createSourceFile(
+    fileName,
+    appSource,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  let queryOwner = false;
+  let localTaskOwners = 0;
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node)
+      && ts.isIdentifier(node.expression)
+      && node.expression.text === "useTasksQuery"
+    ) {
+      queryOwner = true;
+    }
+    if (
+      ts.isVariableDeclaration(node)
+      && ts.isArrayBindingPattern(node.name)
+      && node.name.elements[0]
+      && ts.isBindingElement(node.name.elements[0])
+      && ts.isIdentifier(node.name.elements[0].name)
+      && node.name.elements[0].name.text === "tasks"
+      && node.initializer
+      && ts.isCallExpression(node.initializer)
+      && ts.isIdentifier(node.initializer.expression)
+      && node.initializer.expression.text === "useState"
+    ) {
+      localTaskOwners += 1;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return {
+    queryOwner,
+    localTaskOwners,
+    totalServerStateOwners: (queryOwner ? 1 : 0) + localTaskOwners,
+  };
+}
+
+describe("ROT-014 Task server-state single owner", () => {
+  const appPath = path.resolve(import.meta.dirname, "../src/renderer/App.tsx");
+  const appSource = readFileSync(appPath, "utf-8");
+
+  it("keeps useTasksQuery as the sole Task server-state owner in App.tsx", () => {
+    const owners = countTaskServerStateOwners(appSource, appPath);
+    expect(owners).toEqual({
+      queryOwner: true,
+      localTaskOwners: 0,
+      totalServerStateOwners: 1,
+    });
+  });
+
+  it("does not reintroduce a tasks useState mirror or setTasks replay effect", () => {
+    expect(appSource).not.toMatch(/const\s*\[\s*tasks\s*,\s*setTasks\s*\]\s*=\s*useState/);
+    expect(appSource).not.toMatch(/setTasks\s*\(/);
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -6,6 +6,7 @@ export const guiVitestManifest = [
   "packages/gui/test/fact-triage.vitest.ts",
   "packages/gui/test/taskFilters.vitest.ts",
   "packages/gui/test/task-adapter.vitest.ts",
+  "packages/gui/test/task-server-state-owner.vitest.ts",
   "packages/gui/test/graphLayout.vitest.ts",
   "packages/gui/test/genealogy-timeline.vitest.ts",
   "packages/gui/test/graphNavigation.vitest.ts",


### PR DESCRIPTION
# English

## Summary

Fixes deep-review P1 finding F-L7-02 / ROT-014: `App.tsx` held Task server-state in two owners — `useTasksQuery` (TanStack Query, the ledger projection) plus a local `useState` mirror replayed via `useEffect` — so board/sidebar/selection could render a stale mirror that drifts from the authoritative projection between refreshes. The fix makes TanStack Query the sole Task server-state owner: the `useState`/`useEffect` mirror is deleted and all consumers read the adapted projection directly through `useMemo`. A new detector vitest counts Task server-state owners in the renderer and fails if a second owner (local mirror of the tasks projection) reappears; it is registered in the GUI test manifest.

## What Changed

- `packages/gui/src/renderer/App.tsx` (13 ±): removed the `tasks` `useState` mirror and its replay `useEffect`; `tasks` is now the memoized adapter over `useTasksQuery.data` (single owner, ROT-014 comment states the constraint).
- `packages/gui/test/task-server-state-owner.vitest.ts` (+72): detector — asserts `totalServerStateOwners === 1` and no local `useState` task mirror in the renderer source.
- `tools/gui-test-manifest.mjs` (+1): registers the new vitest in the GUI test manifest (sibling-entry list registration; no gate logic touched).

## Task And Scope

- Harness task: task_01KXPZJ6M8C9M36H4AGYDA6B4A
- Branch: `grok/p1-gui-task-owner`
- Public scope: the dual-owner face in the renderer + its detector test; authoritative spec is review finding F-L7-02 (`review-gui-wiring.md`).
- Private planning/evidence updated: yes (rerun-flip table and check receipts in worker report, appended to task progress at closeout)
- Out of scope: optimistic local write-back for drag interactions (intentionally none — writes go through `useSetTaskStatusMutation` + invalidate); non-Task UI `useState` (projectSwitcher/palette/terminal are not server-state); adjacent P2 findings F-L7-01, F-L7-03.

## Version Impact

- Version: no version change because this is a renderer state-ownership fix.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable (`tools/gui-test-manifest.mjs` is a test-list registration file, not gate authority logic; no workflow or gate changes)
- Authority: task_01KXPZJ6M8C9M36H4AGYDA6B4A; dec_01KXPZF5RXWE0ZTDRW4QP1N4Y7 (deep-review NO-GO decision — accepted by 泽宇 2026-07-17 — P1 root, GUI wiring class)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: af89bef4
- Branch merge-base with `origin/main`: af89bef4
- Last `git fetch origin` time: 2026-07-17 ~13:40 (pre-PR rebase)
- Sync method: rebase
- Public diff command: `git diff af89bef4...HEAD`
- Private evidence commit/path: task progress (worker rerun-flip table + check:ci receipt JSON)
- Reviewer evidence path: worker report — detector flip `totalServerStateOwners` 2→1, detector exit 1→0, `localTaskOwners` 1→0; check:ci greens include typecheck, fast-contract, boundaries (with credentials), gui-build, node26; two reds triaged as environmental (supply-chain: local node_modules drift, reproduced on clean main) and flake (integration-shard 2 `materializer-recovery-cli` — isolated rerun 146/146 pass); CEO read the App.tsx hunks directly.
- GitHub Actions `rewrite-ci` run URL: pending on PR open
- [x] `npm run check` (worker `check:ci`; two non-code reds triaged above, all code-facing jobs green)
- [ ] GitHub Actions `rewrite-ci` passed (pending; merged only on green)
- Not run: nothing — PR CI is the final arbiter for the two environmentally-red jobs.

## Review Evidence

- Self-review: worker reproduced the dual-owner state (RED: detector exit 1, owners=2) before fixing.
- Reviewer subagent: not run; CEO read the full App.tsx diff (mirror deletion, single-owner memo) and the manifest registration hunk.
- Human review: executed under the accepted NO-GO decision's fix mandate (泽宇 2026-07-17: "accept 所有的 全部修完再进入 remote 线").
- Blocking findings: none.

## Residual Risk

- No optimistic local write-back: drag/status changes wait for query invalidation to reflect — accepted as the designed single-owner behavior.
- Adjacent GUI P2 findings (daemon logs without UI, home mock banner) remain tracked separately.

## References

- Task: task_01KXPZJ6M8C9M36H4AGYDA6B4A
- Evidence: review-gui-wiring.md F-L7-02 + task progress receipts
- Review: this PR review thread

---

# 中文

## 概要

修复深度审查 P1 发现 F-L7-02 / ROT-014:`App.tsx` 对 Task server-state 双持 owner——`useTasksQuery`(TanStack Query,台账投影)之外还有一份本地 `useState` 镜像经 `useEffect` 重播——board/侧栏/选中态可能渲染刷新间隙里漂移的旧镜像。修复使 TanStack Query 成为 Task server-state 唯一 owner:删除 `useState`/`useEffect` 镜像,所有消费方经 `useMemo` 直读适配后的投影。新增 detector vitest 统计 renderer 内 Task server-state owner 数量,第二 owner(tasks 投影的本地镜像)一旦复现即红,并登记进 GUI 测试 manifest。

## 改动内容

- `packages/gui/src/renderer/App.tsx`(13 ±):删除 `tasks` 的 `useState` 镜像及其重播 `useEffect`;`tasks` 现为对 `useTasksQuery.data` 的 memo 适配(单一 owner,ROT-014 注释写明约束)。
- `packages/gui/test/task-server-state-owner.vitest.ts`(+72):detector——断言 `totalServerStateOwners === 1` 且 renderer 源码无本地 useState task 镜像。
- `tools/gui-test-manifest.mjs`(+1):新 vitest 登记进 GUI 测试 manifest(兄弟条目清单登记,不动门逻辑)。

## 任务与范围

- Harness 任务:task_01KXPZJ6M8C9M36H4AGYDA6B4A
- 分支:`grok/p1-gui-task-owner`
- 公开范围:renderer 双 owner 面+其 detector 测试;权威规格=审查发现 F-L7-02(`review-gui-wiring.md`)。
- 私有计划 / 证据是否已更新:yes(rerun 翻转表与 check 回执在 worker 报告,收口时 append 进任务 progress)
- 范围外:拖拽交互的乐观本地写回(有意不做——写走 `useSetTaskStatusMutation`+invalidate);非 Task 的 UI `useState`(projectSwitcher/palette/terminal 非 server-state);邻接 P2 发现 F-L7-01、F-L7-03。

## 版本影响

- 版本:无版本变化,因为这是 renderer 状态所有权修复。
- 发布影响:不发布。

## 治理声明

- 是否触碰受保护面:否
- 受保护面范围:不适用(`tools/gui-test-manifest.mjs` 是测试清单登记文件,非门权威逻辑;不动 workflow、gate)
- 授权依据:task_01KXPZJ6M8C9M36H4AGYDA6B4A;dec_01KXPZF5RXWE0ZTDRW4QP1N4Y7(深审 NO-GO 决策,泽宇 2026-07-17 已 accept,本项属 P1 GUI 接线根类)
- 机器校验边界:本 PR 仅断言声明存在;声明是否为真、是否充分由 reviewer 判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- 基线 `origin/main` SHA:af89bef4
- 分支与 `origin/main` 的 merge-base:af89bef4
- 最近一次 `git fetch origin` 时间:2026-07-17 ~13:40(发 PR 前 rebase)
- 同步方式:rebase
- 公开 diff 命令:`git diff af89bef4...HEAD`
- 私有证据 commit/路径:任务 progress(worker rerun 翻转表+check:ci 回执 JSON)
- Reviewer 证据路径:worker 报告——detector 翻转 `totalServerStateOwners` 2→1、detector exit 1→0、`localTaskOwners` 1→0;check:ci 绿含 typecheck、fast-contract、boundaries(带凭证)、gui-build、node26;两红定性为环境(supply-chain:本地 node_modules 漂移,干净 main 同样复现)与 flake(integration-shard 2 `materializer-recovery-cli`——单独重跑 146/146 通过);CEO 直读 App.tsx hunks。
- GitHub Actions `rewrite-ci` run URL:开 PR 后待填
- [x] `npm run check`(worker check:ci;两个非代码红已定性,代码面 job 全绿)
- [ ] GitHub Actions `rewrite-ci` 通过(待跑;仅绿后合并)
- 未运行:无——两个环境红以 PR CI 为最终仲裁。

## 审查证据

- 自查:worker 修复前先复现双 owner(RED:detector exit 1,owners=2)。
- Reviewer 子代理:未跑;CEO 通读 App.tsx diff(镜像删除、单 owner memo)与 manifest 登记 hunk。
- 人工 review:在已 accept 的 NO-GO 决策修复授权下执行(泽宇 2026-07-17:"accept 所有的 全部修完再进入 remote 线")。
- 阻塞发现:无。

## 残余风险

- 无乐观本地写回:拖拽/状态变更等待 query invalidation 后反映——为设计上的单 owner 行为,接受。
- 邻接 GUI P2 发现(daemon logs 无 UI、home mock banner)另行跟踪。

## 关联材料

- 任务:task_01KXPZJ6M8C9M36H4AGYDA6B4A
- 证据:review-gui-wiring.md F-L7-02 + 任务 progress 回执
- Review:本 PR review 线程
