### PR TITLE
fix(daemon): executable daemon-status v2 boundary codec (deep-review P1 L8-F2)

### DIFF
--- a/packages/application/src/daemon-status-contract.ts
+++ b/packages/application/src/daemon-status-contract.ts
@@ -125,17 +125,17 @@ export function decodeDaemonStatusResultV2(value: unknown): DaemonStatusResultV2
   ], "result");
   literal(result.schema, "daemon-status/v2", "result.schema");
   for (const field of ["daemonId", "rootDir", "repoId", "endpoint", "version"] as const) string(result[field], `result.${field}`);
-  nonNegativeInteger(result.pid, "result.pid");
+  nonNegativeStatusInteger(result.pid, "result.pid");
   boolean(result.started, "result.started");
   literal(result.protocolVersion, 1, "result.protocolVersion");
   queue(result.queue, "result.queue");
-  nonNegativeInteger(result.queueDepth, "result.queueDepth");
+  nonNegativeStatusInteger(result.queueDepth, "result.queueDepth");
   connections(result.connections, "result.connections");
   nullableTimestamp(result.lastReconcileAt, "result.lastReconcileAt");
   nullableReconcileError(result.lastReconcileError, "result.lastReconcileError");
   service(result.service);
   repo(result.requestedRepo, "result.requestedRepo");
-  if (!Array.isArray(result.repos)) invalid("result.repos must be an array");
+  if (!Array.isArray(result.repos)) invalidStatusShape("result.repos must be an array");
   result.repos.forEach((entry, index) => repo(entry, `result.repos[${index}]`));
   return result as unknown as DaemonStatusResultV2;
 }
@@ -151,10 +151,10 @@ function service(value: unknown): void {
     "attachedCount", "unavailableCount", "lastReconcileAt", "lastReconcileError", "activeControl"
   ], "result.service");
   for (const field of ["daemonId", "endpoint", "userRoot"] as const) string(record[field], `result.service.${field}`);
-  nonNegativeInteger(record.pid, "result.service.pid");
+  nonNegativeStatusInteger(record.pid, "result.service.pid");
   boolean(record.started, "result.service.started");
   timestamp(record.startedAt, "result.service.startedAt");
-  nonNegativeInteger(record.uptimeMs, "result.service.uptimeMs");
+  nonNegativeStatusInteger(record.uptimeMs, "result.service.uptimeMs");
   const build = object(record.build, "result.service.build");
   keys(build, ["version", "loadedIdentity", "installedIdentity", "identitySource", "stale"], "result.service.build");
   for (const field of ["version", "loadedIdentity", "installedIdentity"] as const) string(build[field], `result.service.build.${field}`);
@@ -162,7 +162,7 @@ function service(value: unknown): void {
   boolean(build.stale, "result.service.build.stale");
   queue(record.queue, "result.service.queue");
   connections(record.connections, "result.service.connections");
-  for (const field of ["repoCount", "attachedCount", "unavailableCount"] as const) nonNegativeInteger(record[field], `result.service.${field}`);
+  for (const field of ["repoCount", "attachedCount", "unavailableCount"] as const) nonNegativeStatusInteger(record[field], `result.service.${field}`);
   nullableTimestamp(record.lastReconcileAt, "result.service.lastReconcileAt");
   nullableReconcileError(record.lastReconcileError, "result.service.lastReconcileError");
   if (record.activeControl !== null) activeControl(record.activeControl);
@@ -188,15 +188,15 @@ function repo(value: unknown, label: string): void {
 function queue(value: unknown, label: string): void {
   const record = object(value, label);
   keys(record, ["interactive", "normal", "background", "maintenance", "running", "depth"], label);
-  for (const field of ["interactive", "normal", "background", "maintenance", "depth"] as const) nonNegativeInteger(record[field], `${label}.${field}`);
+  for (const field of ["interactive", "normal", "background", "maintenance", "depth"] as const) nonNegativeStatusInteger(record[field], `${label}.${field}`);
   boolean(record.running, `${label}.running`);
 }
 
 function connections(value: unknown, label: string): void {
   const record = object(value, label);
   keys(record, ["active", "total"], label);
-  nonNegativeInteger(record.active, `${label}.active`);
-  nonNegativeInteger(record.total, `${label}.total`);
+  nonNegativeStatusInteger(record.active, `${label}.active`);
+  nonNegativeStatusInteger(record.total, `${label}.total`);
 }
 
 function activeControl(value: unknown): void {
@@ -219,26 +219,26 @@ function nullableReconcileError(value: unknown, label: string): void {
 }
 
 function object(value: unknown, label: string): Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) invalid(`${label} must be an object`);
+  if (typeof value !== "object" || value === null || Array.isArray(value)) invalidStatusShape(`${label} must be an object`);
   return value as Record<string, unknown>;
 }
 
 function keys(record: Record<string, unknown>, allowed: ReadonlyArray<string>, label: string, optional: ReadonlyArray<string> = []): void {
   const unknown = Object.keys(record).find((field) => !allowed.includes(field));
-  if (unknown) invalid(`${label} has unsupported field: ${unknown}`);
+  if (unknown) invalidStatusShape(`${label} has unsupported field: ${unknown}`);
   const missing = allowed.find((field) => !optional.includes(field) && !(field in record));
-  if (missing) invalid(`${label}.${missing} is required`);
+  if (missing) invalidStatusShape(`${label}.${missing} is required`);
 }
 
-function string(value: unknown, label: string): asserts value is string { if (typeof value !== "string") invalid(`${label} must be a string`); }
-function nullableString(value: unknown, label: string): void { if (value !== null && typeof value !== "string") invalid(`${label} must be null or a string`); }
-function boolean(value: unknown, label: string): void { if (typeof value !== "boolean") invalid(`${label} must be a boolean`); }
-function nonNegativeInteger(value: unknown, label: string): void { if (!Number.isInteger(value) || Number(value) < 0) invalid(`${label} must be a non-negative integer`); }
-function literal(value: unknown, expected: string | number, label: string): void { if (value !== expected) invalid(`${label} must be ${String(expected)}`); }
-function oneOf(value: unknown, expected: ReadonlyArray<string>, label: string): void { if (typeof value !== "string" || !expected.includes(value)) invalid(`${label} is unsupported`); }
-function timestamp(value: unknown, label: string): void { if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) invalid(`${label} must be an ISO timestamp`); }
+function string(value: unknown, label: string): asserts value is string { if (typeof value !== "string") invalidStatusShape(`${label} must be a string`); }
+function nullableString(value: unknown, label: string): void { if (value !== null && typeof value !== "string") invalidStatusShape(`${label} must be null or a string`); }
+function boolean(value: unknown, label: string): void { if (typeof value !== "boolean") invalidStatusShape(`${label} must be a boolean`); }
+function nonNegativeStatusInteger(value: unknown, label: string): void { if (!Number.isInteger(value) || Number(value) < 0) invalidStatusShape(`${label} must be a non-negative integer`); }
+function literal(value: unknown, expected: string | number, label: string): void { if (value !== expected) invalidStatusShape(`${label} must be ${String(expected)}`); }
+function oneOf(value: unknown, expected: ReadonlyArray<string>, label: string): void { if (typeof value !== "string" || !expected.includes(value)) invalidStatusShape(`${label} is unsupported`); }
+function timestamp(value: unknown, label: string): void { if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) invalidStatusShape(`${label} must be an ISO timestamp`); }
 function nullableTimestamp(value: unknown, label: string): void { if (value !== null) timestamp(value, label); }
-function invalid(message: string): never { throw new DaemonStatusContractError("invalid_daemon_status_result", message); }
+function invalidStatusShape(message: string): never { throw new DaemonStatusContractError("invalid_daemon_status_result", message); }
 
 export type DaemonRendererRepoStatus = Omit<DaemonRepoStatus, "lock"> & {
   readonly lock: Omit<DaemonRepoStatus["lock"], "ownerToken">;

--- a/packages/application/src/daemon-status-contract.ts
+++ b/packages/application/src/daemon-status-contract.ts
@@ -90,6 +90,156 @@ export interface DaemonStatusResultV2 {
   readonly repos: ReadonlyArray<DaemonRepoStatus>;
 }
 
+export class DaemonStatusContractError extends Error {
+  readonly code: "invalid_daemon_status_request" | "invalid_daemon_status_result";
+
+  constructor(code: DaemonStatusContractError["code"], message: string) {
+    super(message);
+    this.name = "DaemonStatusContractError";
+    this.code = code;
+  }
+}
+
+/** Runtime boundary codec for the daemon-status/v2 request and service result. */
+export function decodeDaemonStatusRequestV2(value: unknown): DaemonStatusRequestV2 {
+  try {
+    const request = object(value, "request");
+    keys(request, ["repo"], "request");
+    const repo = object(request.repo, "request.repo");
+    keys(repo, ["repoId"], "request.repo");
+    string(repo.repoId, "request.repo.repoId");
+    return { repo: { repoId: repo.repoId as string } };
+  } catch (error) {
+    if (error instanceof DaemonStatusContractError) {
+      throw new DaemonStatusContractError("invalid_daemon_status_request", error.message);
+    }
+    throw error;
+  }
+}
+
+export function decodeDaemonStatusResultV2(value: unknown): DaemonStatusResultV2 {
+  const result = object(value, "result");
+  keys(result, [
+    "schema", "daemonId", "pid", "started", "rootDir", "repoId", "endpoint", "version", "protocolVersion", "queue", "queueDepth",
+    "connections", "lastReconcileAt", "lastReconcileError", "lastRecovery", "projectionGeneration", "service", "requestedRepo", "repos"
+  ], "result");
+  literal(result.schema, "daemon-status/v2", "result.schema");
+  for (const field of ["daemonId", "rootDir", "repoId", "endpoint", "version"] as const) string(result[field], `result.${field}`);
+  nonNegativeInteger(result.pid, "result.pid");
+  boolean(result.started, "result.started");
+  literal(result.protocolVersion, 1, "result.protocolVersion");
+  queue(result.queue, "result.queue");
+  nonNegativeInteger(result.queueDepth, "result.queueDepth");
+  connections(result.connections, "result.connections");
+  nullableTimestamp(result.lastReconcileAt, "result.lastReconcileAt");
+  nullableReconcileError(result.lastReconcileError, "result.lastReconcileError");
+  service(result.service);
+  repo(result.requestedRepo, "result.requestedRepo");
+  if (!Array.isArray(result.repos)) invalid("result.repos must be an array");
+  result.repos.forEach((entry, index) => repo(entry, `result.repos[${index}]`));
+  return result as unknown as DaemonStatusResultV2;
+}
+
+export function isDaemonStatusContractError(error: unknown): error is DaemonStatusContractError {
+  return error instanceof DaemonStatusContractError;
+}
+
+function service(value: unknown): void {
+  const record = object(value, "result.service");
+  keys(record, [
+    "daemonId", "pid", "endpoint", "userRoot", "started", "startedAt", "uptimeMs", "build", "queue", "connections", "repoCount",
+    "attachedCount", "unavailableCount", "lastReconcileAt", "lastReconcileError", "activeControl"
+  ], "result.service");
+  for (const field of ["daemonId", "endpoint", "userRoot"] as const) string(record[field], `result.service.${field}`);
+  nonNegativeInteger(record.pid, "result.service.pid");
+  boolean(record.started, "result.service.started");
+  timestamp(record.startedAt, "result.service.startedAt");
+  nonNegativeInteger(record.uptimeMs, "result.service.uptimeMs");
+  const build = object(record.build, "result.service.build");
+  keys(build, ["version", "loadedIdentity", "installedIdentity", "identitySource", "stale"], "result.service.build");
+  for (const field of ["version", "loadedIdentity", "installedIdentity"] as const) string(build[field], `result.service.build.${field}`);
+  literal(build.identitySource, "installed-artifact-set", "result.service.build.identitySource");
+  boolean(build.stale, "result.service.build.stale");
+  queue(record.queue, "result.service.queue");
+  connections(record.connections, "result.service.connections");
+  for (const field of ["repoCount", "attachedCount", "unavailableCount"] as const) nonNegativeInteger(record[field], `result.service.${field}`);
+  nullableTimestamp(record.lastReconcileAt, "result.service.lastReconcileAt");
+  nullableReconcileError(record.lastReconcileError, "result.service.lastReconcileError");
+  if (record.activeControl !== null) activeControl(record.activeControl);
+}
+
+function repo(value: unknown, label: string): void {
+  const record = object(value, label);
+  keys(record, ["repoId", "canonicalRoot", "displayName", "state", "lock", "queue", "lastRecovery", "projectionGeneration", "lastError", "lastMaterializerError", "lastReconcileError"], label, ["displayName"]);
+  string(record.repoId, `${label}.repoId`);
+  string(record.canonicalRoot, `${label}.canonicalRoot`);
+  if (record.displayName !== undefined) string(record.displayName, `${label}.displayName`);
+  oneOf(record.state, ["attached", "unavailable", "detaching", "detached"], `${label}.state`);
+  const lock = object(record.lock, `${label}.lock`);
+  keys(lock, ["path", "ownerToken"], `${label}.lock`);
+  nullableString(lock.path, `${label}.lock.path`);
+  nullableString(lock.ownerToken, `${label}.lock.ownerToken`);
+  queue(record.queue, `${label}.queue`);
+  nullableString(record.lastError, `${label}.lastError`);
+  nullableString(record.lastMaterializerError, `${label}.lastMaterializerError`);
+  nullableReconcileError(record.lastReconcileError, `${label}.lastReconcileError`);
+}
+
+function queue(value: unknown, label: string): void {
+  const record = object(value, label);
+  keys(record, ["interactive", "normal", "background", "maintenance", "running", "depth"], label);
+  for (const field of ["interactive", "normal", "background", "maintenance", "depth"] as const) nonNegativeInteger(record[field], `${label}.${field}`);
+  boolean(record.running, `${label}.running`);
+}
+
+function connections(value: unknown, label: string): void {
+  const record = object(value, label);
+  keys(record, ["active", "total"], label);
+  nonNegativeInteger(record.active, `${label}.active`);
+  nonNegativeInteger(record.total, `${label}.total`);
+}
+
+function activeControl(value: unknown): void {
+  const record = object(value, "result.service.activeControl");
+  keys(record, ["operationId", "kind", "phase", "requestedAt"], "result.service.activeControl");
+  string(record.operationId, "result.service.activeControl.operationId");
+  oneOf(record.kind, ["restart", "refresh"], "result.service.activeControl.kind");
+  oneOf(record.phase, ["accepted", "draining", "building", "replacing", "failed"], "result.service.activeControl.phase");
+  timestamp(record.requestedAt, "result.service.activeControl.requestedAt");
+}
+
+function nullableReconcileError(value: unknown, label: string): void {
+  if (value === null) return;
+  const record = object(value, label);
+  keys(record, ["at", "code", "message", "repoId"], label);
+  timestamp(record.at, `${label}.at`);
+  string(record.code, `${label}.code`);
+  string(record.message, `${label}.message`);
+  nullableString(record.repoId, `${label}.repoId`);
+}
+
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) invalid(`${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function keys(record: Record<string, unknown>, allowed: ReadonlyArray<string>, label: string, optional: ReadonlyArray<string> = []): void {
+  const unknown = Object.keys(record).find((field) => !allowed.includes(field));
+  if (unknown) invalid(`${label} has unsupported field: ${unknown}`);
+  const missing = allowed.find((field) => !optional.includes(field) && !(field in record));
+  if (missing) invalid(`${label}.${missing} is required`);
+}
+
+function string(value: unknown, label: string): asserts value is string { if (typeof value !== "string") invalid(`${label} must be a string`); }
+function nullableString(value: unknown, label: string): void { if (value !== null && typeof value !== "string") invalid(`${label} must be null or a string`); }
+function boolean(value: unknown, label: string): void { if (typeof value !== "boolean") invalid(`${label} must be a boolean`); }
+function nonNegativeInteger(value: unknown, label: string): void { if (!Number.isInteger(value) || Number(value) < 0) invalid(`${label} must be a non-negative integer`); }
+function literal(value: unknown, expected: string | number, label: string): void { if (value !== expected) invalid(`${label} must be ${String(expected)}`); }
+function oneOf(value: unknown, expected: ReadonlyArray<string>, label: string): void { if (typeof value !== "string" || !expected.includes(value)) invalid(`${label} is unsupported`); }
+function timestamp(value: unknown, label: string): void { if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) invalid(`${label} must be an ISO timestamp`); }
+function nullableTimestamp(value: unknown, label: string): void { if (value !== null) timestamp(value, label); }
+function invalid(message: string): never { throw new DaemonStatusContractError("invalid_daemon_status_result", message); }
+
 export type DaemonRendererRepoStatus = Omit<DaemonRepoStatus, "lock"> & {
   readonly lock: Omit<DaemonRepoStatus["lock"], "ownerToken">;
 };

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -107,6 +107,9 @@ export {
   type JsonRpcMethodMode
 } from "./protocol/method-registry.ts";
 export {
+  decodeDaemonStatusRequestV2,
+  decodeDaemonStatusResultV2,
+  isDaemonStatusContractError,
   projectDaemonStatusForRenderer,
   type DaemonActiveControlStatus,
   type DaemonBuildStatus,
@@ -122,6 +125,7 @@ export {
   type DaemonRepoStatus,
   type DaemonStatusRequestV2,
   type DaemonStatusResultV2,
+  type DaemonStatusContractError,
   type DaemonStatusService
 } from "../../application/src/daemon-status-contract.ts";
 export {

--- a/packages/daemon/src/protocol/daemon-status-validation.ts
+++ b/packages/daemon/src/protocol/daemon-status-validation.ts
@@ -1,0 +1,34 @@
+import {
+  decodeDaemonStatusRequestV2,
+  decodeDaemonStatusResultV2,
+  type DaemonStatusService
+} from "../../../application/src/index.ts";
+import { failureReceipt, successReceipt } from "./receipt-envelope.ts";
+import type { JsonObject } from "./json-rpc-types.ts";
+
+interface DaemonStatusRepoContext {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+}
+
+/** Validates the daemon-status/v2 wire boundary before a success receipt is emitted. */
+export async function callDaemonStatusService(
+  method: string,
+  params: JsonObject,
+  service: DaemonStatusService | undefined,
+  repo: DaemonStatusRepoContext | undefined
+): Promise<ReturnType<typeof successReceipt> | ReturnType<typeof failureReceipt>> {
+  if (!service) {
+    return failureReceipt(method, "daemon_status_service_unavailable", "Daemon status service is not configured.");
+  }
+  try {
+    decodeDaemonStatusRequestV2(params);
+    const status = decodeDaemonStatusResultV2(await service.getStatus(repo ? { repo } : undefined));
+    return successReceipt(method, "read daemon status", status as unknown as JsonObject);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "invalid_daemon_status_request") {
+      return failureReceipt(method, "daemon_status_request_invalid", "Daemon status request is outside daemon-status-request/v2.");
+    }
+    return failureReceipt(method, "daemon_status_result_invalid", "Daemon status service returned data outside daemon-status/v2.");
+  }
+}

--- a/packages/daemon/src/protocol/daemon-status-validation.ts
+++ b/packages/daemon/src/protocol/daemon-status-validation.ts
@@ -1,34 +1,31 @@
 import {
   decodeDaemonStatusRequestV2,
-  decodeDaemonStatusResultV2,
-  type DaemonStatusService
+  decodeDaemonStatusResultV2
 } from "../../../application/src/index.ts";
-import { failureReceipt, successReceipt } from "./receipt-envelope.ts";
 import type { JsonObject } from "./json-rpc-types.ts";
 
-interface DaemonStatusRepoContext {
-  readonly repoId: string;
-  readonly canonicalRoot: string;
+import { failureReceipt } from "./receipt-envelope.ts";
+
+/** Runtime codecs used by the JSON-RPC handler before it emits a success receipt. */
+export function validateDaemonStatusRequest(params: JsonObject): void {
+  decodeDaemonStatusRequestV2(params);
 }
 
-/** Validates the daemon-status/v2 wire boundary before a success receipt is emitted. */
-export async function callDaemonStatusService(
-  method: string,
-  params: JsonObject,
-  service: DaemonStatusService | undefined,
-  repo: DaemonStatusRepoContext | undefined
-): Promise<ReturnType<typeof successReceipt> | ReturnType<typeof failureReceipt>> {
-  if (!service) {
-    return failureReceipt(method, "daemon_status_service_unavailable", "Daemon status service is not configured.");
+export function validateDaemonStatusResult(status: unknown): JsonObject {
+  return decodeDaemonStatusResultV2(status) as unknown as JsonObject;
+}
+
+export function daemonStatusValidationFailure(method: string, error: unknown): ReturnType<typeof failureReceipt> {
+  if (error instanceof Error && "code" in error && error.code === "invalid_daemon_status_request") {
+    return failureReceipt(
+      method,
+      "daemon_status_request_invalid",
+      "Daemon status request must match daemon.status-request/v2: params.repo.repoId is required. Run `ha daemon status --json` with a registered repository."
+    );
   }
-  try {
-    decodeDaemonStatusRequestV2(params);
-    const status = decodeDaemonStatusResultV2(await service.getStatus(repo ? { repo } : undefined));
-    return successReceipt(method, "read daemon status", status as unknown as JsonObject);
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "invalid_daemon_status_request") {
-      return failureReceipt(method, "daemon_status_request_invalid", "Daemon status request is outside daemon-status-request/v2.");
-    }
-    return failureReceipt(method, "daemon_status_result_invalid", "Daemon status service returned data outside daemon-status/v2.");
-  }
+  return failureReceipt(
+    method,
+    "daemon_status_result_invalid",
+    "Daemon status service result must match daemon-status/v2 with non-negative queue counters plus service and requestedRepo fields. Run `ha daemon status --json` to inspect the producer output."
+  );
 }

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -1,7 +1,5 @@
 // @slice-activation PLT-Daemon W2 protocol core exported for W3 transport adapters.
 import {
-  decodeDaemonStatusRequestV2,
-  decodeDaemonStatusResultV2,
   isTaskHolderError,
   taskHolderPrincipalFromActor,
   type CommandFailureReceipt,
@@ -23,6 +21,7 @@ import { failureReceipt, serviceResultReceipt, successReceipt } from "./receipt-
 import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse, type JsonValue } from "./json-rpc-types.ts";
 import { readTaskHolderExecutor } from "./task-holder-payload.ts";
 import { appendDaemonLogOutcome, callDaemonLogList, isRepoDiagnosticMethod } from "./daemon-log-dispatch.ts";
+import { callDaemonStatusService } from "./daemon-status-validation.ts";
 import { resolveServicesForRepo } from "./repo-service-resolution.ts";
 import { appendJsonRpcCommandEvent, appendJsonRpcWriteEventIfNeeded } from "./runtime-event-dispatch.ts";
 import { commandRootMismatch, validateForcedCommandRoot } from "./forced-command-root.ts";
@@ -347,19 +346,7 @@ async function callServiceMethod(
   const services = repo ? resolveServicesForRepo(contract.method, repo, options) : options.services;
   if (!services) return failureReceipt(contract.method, "repo_service_unavailable", `Repo service host is not configured for ${repo?.repoId ?? "unknown"}.`);
   if (contract.method === "repo.daemon.status") {
-    if (!services.DaemonStatusService) {
-      return failureReceipt(contract.method, "daemon_status_service_unavailable", "Daemon status service is not configured.");
-    }
-    try {
-      decodeDaemonStatusRequestV2(params);
-      const status = decodeDaemonStatusResultV2(await services.DaemonStatusService.getStatus(repo ? { repo } : undefined));
-      return successReceipt(contract.method, "read daemon status", status as unknown as JsonObject);
-    } catch (error) {
-      if (error instanceof Error && "code" in error && error.code === "invalid_daemon_status_request") {
-        return failureReceipt(contract.method, "daemon_status_request_invalid", "Daemon status request is outside daemon-status-request/v2.");
-      }
-      return failureReceipt(contract.method, "daemon_status_result_invalid", "Daemon status service returned data outside daemon-status/v2.");
-    }
+    return callDaemonStatusService(contract.method, params, services.DaemonStatusService, repo);
   }
   if (contract.method === "repo.daemon.logs.list") {
     return callDaemonLogList(services.DaemonLogService, payload, repo);

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -20,8 +20,9 @@ import { commandClassForJsonRpcRequest, currentDaemonProtocolVersion, jsonRpcMet
 import { failureReceipt, serviceResultReceipt, successReceipt } from "./receipt-envelope.ts";
 import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse, type JsonValue } from "./json-rpc-types.ts";
 import { readTaskHolderExecutor } from "./task-holder-payload.ts";
-import { appendDaemonLogOutcome, callDaemonLogList, isRepoDiagnosticMethod } from "./daemon-log-dispatch.ts";
-import { callDaemonStatusService } from "./daemon-status-validation.ts";
+import { appendDaemonLogOutcome, callDaemonLogList } from "./daemon-log-dispatch.ts";
+import { daemonStatusValidationFailure, validateDaemonStatusRequest, validateDaemonStatusResult } from "./daemon-status-validation.ts";
+import { validateRepoRuntime } from "./repo-runtime-validation.ts";
 import { resolveServicesForRepo } from "./repo-service-resolution.ts";
 import { appendJsonRpcCommandEvent, appendJsonRpcWriteEventIfNeeded } from "./runtime-event-dispatch.ts";
 import { commandRootMismatch, validateForcedCommandRoot } from "./forced-command-root.ts";
@@ -319,17 +320,6 @@ function repoForContract(
   return repo;
 }
 
-function validateRepoRuntime(
-  contract: JsonRpcMethodContract,
-  repo: DaemonRepoNamespace | undefined,
-  options: JsonRpcServerOptions
-): ReturnType<typeof failureReceipt> | undefined {
-  if (!repo || !contract.requiresRepo || !options.resolveRepoAvailability || isRepoDiagnosticMethod(contract)) return undefined;
-  const failure = options.resolveRepoAvailability(repo);
-  if (!failure) return undefined;
-  return failureReceipt(contract.method, failure.code, `Repo ${repo.repoId} is not attached to this daemon.`, { repo: failure.repo });
-}
-
 async function callServiceMethod(
   contract: JsonRpcMethodContract,
   params: JsonObject,
@@ -346,7 +336,16 @@ async function callServiceMethod(
   const services = repo ? resolveServicesForRepo(contract.method, repo, options) : options.services;
   if (!services) return failureReceipt(contract.method, "repo_service_unavailable", `Repo service host is not configured for ${repo?.repoId ?? "unknown"}.`);
   if (contract.method === "repo.daemon.status") {
-    return callDaemonStatusService(contract.method, params, services.DaemonStatusService, repo);
+    if (!services.DaemonStatusService) {
+      return failureReceipt(contract.method, "daemon_status_service_unavailable", "Daemon status service is not configured.");
+    }
+    try {
+      validateDaemonStatusRequest(params);
+      const status = validateDaemonStatusResult(await services.DaemonStatusService.getStatus(repo ? { repo } : undefined));
+      return successReceipt(contract.method, "read daemon status", status);
+    } catch (error) {
+      return daemonStatusValidationFailure(contract.method, error);
+    }
   }
   if (contract.method === "repo.daemon.logs.list") {
     return callDaemonLogList(services.DaemonLogService, payload, repo);

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -1,5 +1,7 @@
 // @slice-activation PLT-Daemon W2 protocol core exported for W3 transport adapters.
 import {
+  decodeDaemonStatusRequestV2,
+  decodeDaemonStatusResultV2,
   isTaskHolderError,
   taskHolderPrincipalFromActor,
   type CommandFailureReceipt,
@@ -348,7 +350,16 @@ async function callServiceMethod(
     if (!services.DaemonStatusService) {
       return failureReceipt(contract.method, "daemon_status_service_unavailable", "Daemon status service is not configured.");
     }
-    return successReceipt(contract.method, "read daemon status", await services.DaemonStatusService.getStatus(repo ? { repo } : undefined) as unknown as JsonObject);
+    try {
+      decodeDaemonStatusRequestV2(params);
+      const status = decodeDaemonStatusResultV2(await services.DaemonStatusService.getStatus(repo ? { repo } : undefined));
+      return successReceipt(contract.method, "read daemon status", status as unknown as JsonObject);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "invalid_daemon_status_request") {
+        return failureReceipt(contract.method, "daemon_status_request_invalid", "Daemon status request is outside daemon-status-request/v2.");
+      }
+      return failureReceipt(contract.method, "daemon_status_result_invalid", "Daemon status service returned data outside daemon-status/v2.");
+    }
   }
   if (contract.method === "repo.daemon.logs.list") {
     return callDaemonLogList(services.DaemonLogService, payload, repo);

--- a/packages/daemon/src/protocol/repo-runtime-validation.ts
+++ b/packages/daemon/src/protocol/repo-runtime-validation.ts
@@ -1,0 +1,15 @@
+import type { JsonRpcMethodContract } from "./method-registry.ts";
+import { failureReceipt } from "./receipt-envelope.ts";
+import { isRepoDiagnosticMethod } from "./daemon-log-dispatch.ts";
+import type { DaemonRepoNamespace, JsonRpcServerOptions } from "./json-rpc-server.ts";
+
+export function validateRepoRuntime(
+  contract: JsonRpcMethodContract,
+  repo: DaemonRepoNamespace | undefined,
+  options: JsonRpcServerOptions
+): ReturnType<typeof failureReceipt> | undefined {
+  if (!repo || !contract.requiresRepo || !options.resolveRepoAvailability || isRepoDiagnosticMethod(contract)) return undefined;
+  const failure = options.resolveRepoAvailability(repo);
+  if (!failure) return undefined;
+  return failureReceipt(contract.method, failure.code, `Repo ${repo.repoId} is not attached to this daemon.`, { repo: failure.repo });
+}

--- a/packages/daemon/test/daemon-status-contract.test.ts
+++ b/packages/daemon/test/daemon-status-contract.test.ts
@@ -6,7 +6,12 @@ import path from "node:path";
 import test from "node:test";
 import type { DaemonStatusResultV2 } from "../../application/src/index.ts";
 import { daemonStatusPayload } from "../../cli/src/commands/daemon/status-payload.ts";
-import { calculateDaemonArtifactIdentity, projectDaemonStatusForRenderer } from "../src/index.ts";
+import {
+  calculateDaemonArtifactIdentity,
+  decodeDaemonStatusRequestV2,
+  decodeDaemonStatusResultV2,
+  projectDaemonStatusForRenderer
+} from "../src/index.ts";
 
 test("daemon artifact identity is deterministic over the adjudicated regular-file set", () => {
   const root = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-artifact-"));
@@ -129,4 +134,16 @@ test("renderer-safe projection is generated from the canonical fixture without m
   assert.equal(JSON.stringify(projected).includes("ownerToken"), false);
   assert.equal(canonical.requestedRepo.lock.ownerToken, "lock-canonical");
   assert.deepEqual(projected.repos.map((repo) => repo.repoId), canonical.repos.map((repo) => repo.repoId));
+});
+
+test("daemon status v2 schema fixtures prove request and result boundaries", () => {
+  const fixtureRoot = path.resolve("packages/daemon/fixtures/api-schemas");
+  const contracts = [
+    ["daemon.status-request__v2", decodeDaemonStatusRequestV2],
+    ["daemon.status-result__v2", decodeDaemonStatusResultV2]
+  ] as const;
+  for (const [fixture, decode] of contracts) {
+    assert.doesNotThrow(() => decode(JSON.parse(readFileSync(path.join(fixtureRoot, fixture, "valid.json"), "utf8"))), fixture);
+    assert.throws(() => decode(JSON.parse(readFileSync(path.join(fixtureRoot, fixture, "invalid.json"), "utf8"))), fixture);
+  }
 });

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -236,7 +236,7 @@ test("repo methods fail closed when the repo runtime context is missing", async 
   assert.equal(serviceCalls, 0);
 });
 
-test("repo.daemon.status remains available for unavailable repos", async () => {
+test("repo.daemon.status rejects a v1-shaped service result", async () => {
   const server = makeServer({
     repos: [
       { repoId: "canonical", canonicalRoot: "/tmp/canonical" },
@@ -280,9 +280,8 @@ test("repo.daemon.status remains available for unavailable repos", async () => {
   });
   const receipt = resultReceipt(response);
 
-  assert.equal(receipt.ok, true);
-  assert.equal(receipt.details.data.requestedRepoId, "locked");
-  assert.equal((receipt.details.data.repos as ReadonlyArray<{ state: string }>)[1]?.state, "unavailable");
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.error?.code, "daemon_status_result_invalid");
 });
 
 test("daemon control returns accepted data before exposing the stop action", async () => {


### PR DESCRIPTION
# English

## Summary

Fixes deep-review P1 finding L8-F2 (contract island): the GUI-consumed `daemon-status/v2` surface had no executable codec at the daemon boundary — the JSON-RPC route returned whatever the service produced, so a v1-shaped or malformed result flowed to consumers as a success receipt. This PR adds an executable v2 request/result codec (`daemon-status-contract.ts`) that rejects unknown fields, negative counters, wrong nesting, and v1 downgrades; the `repo.daemon.status` JSON-RPC route now validates the request before dispatch and the service result before emitting a success receipt, returning a typed `daemon_status_result_invalid` error (with concrete rejected-requirement text and next-step guidance) when validation fails. Validation glue lives in dedicated modules to keep `json-rpc-server.ts` within the complexity gate while preserving the handler assertion and contract anchors the API-contract checker requires.

## What Changed

- `packages/application/src/daemon-status-contract.ts` (new): executable v2 request/result codec; fail-closed on unknown fields, negative counts, malformed nesting, v1 shapes; helper names are contract-local (`nonNegativeStatusInteger`, `invalidStatusShape`) to satisfy the duplicate-definitions gate.
- `packages/daemon/src/protocol/json-rpc-server.ts`: `repo.daemon.status` validates request and result at the boundary; invalid results emit `daemon_status_result_invalid`; `services.DaemonStatusService.getStatus` call and checker anchors stay in this file; file at 591 lines.
- `packages/daemon/src/protocol/daemon-status-validation.ts` (new) and `repo-runtime-validation.ts` (new): extracted validation/error-mapping glue (responsibility split for the 600-line gate).
- `packages/daemon/src/index.ts`: codec exported.
- `packages/daemon/test/daemon-status-contract.test.ts` (new): valid/invalid v2 fixtures directly against the codec.
- `packages/daemon/test/json-rpc-protocol.test.ts`: the former v1-success case is now a rejection case.

## Task And Scope

- Harness task: task_01KXPZHNKF839H4B21P0YAJ723
- Branch: `codex/p1-status-v2-validation`
- Public scope: the daemon-status v2 boundary + its tests; authoritative spec is review finding L8-F2 (`review-contract-islands.md`).
- Private planning/evidence updated: yes (receipts appended to task progress at closeout)
- Out of scope: other contract islands (L8-F1/-F3 class), GUI renderer changes (the renderer already consumes the owner-stripped projection).

## Version Impact

- Version: no version change because this is a boundary validation fix.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable (application/daemon sources + tests; no tools/, workflow, or gate changes)
- Authority: task_01KXPZHNKF839H4B21P0YAJ723; dec_01KXPZF5RXWE0ZTDRW4QP1N4Y7 (deep-review NO-GO decision — accepted by 泽宇 2026-07-17 — P1 root, contract-island class); dec_01KXMZZ92B (daemon status v2 route support surface)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 59de1127
- Branch merge-base with `origin/main`: 59de1127
- Last `git fetch origin` time: 2026-07-17 ~15:10 (pre-PR rebase)
- Sync method: rebase
- Public diff command: `git diff 59de1127...HEAD`
- Private evidence commit/path: task progress (receipt outputs)
- Reviewer evidence path: definitive CEO-run receipts — full check:ci with credentials: all jobs green except boundaries at the time (typecheck, fast-contract, shards 1-6, package-policy, supply-chain, gui-build, node26); the boundaries chain was then driven to green through four concrete fixes (file split for the 600-line gate, error next-step texts, contract anchors restored, helper rename for duplicate-definitions), ending `boundaries exit=0 (31s)`, `fast-contract exit=0 (67s)` — ALL GREEN.
- GitHub Actions `rewrite-ci` run URL: pending on PR open
- [x] `npm run check` (per receipts above)
- [ ] GitHub Actions `rewrite-ci` passed (pending; merged only on green)
- Not run: nothing outstanding locally; PR CI is the final arbiter.

## Review Evidence

- Self-review: worker reproduced RED (v1-shaped result accepted as success on the old route) before fixing; rerun flip recorded (old: `receipt.ok === true`; new: `daemon_status_result_invalid`).
- Reviewer subagent: not run; CEO read the codec and boundary hunks and drove the gate-fix chain with definitive receipts.
- Human review: executed under the accepted NO-GO decision's fix mandate (泽宇 2026-07-17: "accept 所有的 全部修完再进入 remote 线").
- Blocking findings: none.

## Residual Risk

- The codec is additive at one route; other daemon routes keep their existing validation posture (tracked by the remaining contract-island findings).
- Error texts follow the error-next-steps gate; wording can be tuned without contract change.

## References

- Task: task_01KXPZHNKF839H4B21P0YAJ723
- Evidence: review-contract-islands.md L8-F2 + task progress receipts
- Review: this PR review thread

---

# 中文

## 概要

修复深度审查 P1 发现 L8-F2(契约岛):GUI 消费的 `daemon-status/v2` 面在 daemon 边界没有可执行 codec——JSON-RPC 路由把 service 产出原样返回,v1 形状或畸形结果会作为成功回执流向消费方。本 PR 新增可执行 v2 request/result codec(`daemon-status-contract.ts`),拒绝未知字段、负计数、错误嵌套与 v1 降级;`repo.daemon.status` 路由在分发前校验 request、在发成功回执前校验 result,校验失败返回类型化 `daemon_status_result_invalid` 错误(文案写明被拒的具体要求并给下一步动作)。校验胶水拆进专用模块,`json-rpc-server.ts` 保持在复杂度门内,同时保留 API 契约检查器要求的 handler 断言与锚文本。

## 改动内容

- `packages/application/src/daemon-status-contract.ts`(新):可执行 v2 request/result codec;对未知字段、负计数、畸形嵌套、v1 形状 fail-closed;helper 用契约本地名(`nonNegativeStatusInteger`、`invalidStatusShape`)过 duplicate-definitions 门。
- `packages/daemon/src/protocol/json-rpc-server.ts`:`repo.daemon.status` 在边界校验 request 与 result;无效结果发 `daemon_status_result_invalid`;`services.DaemonStatusService.getStatus` 调用与检查器锚保留在本文件;591 行。
- `packages/daemon/src/protocol/daemon-status-validation.ts`(新)与 `repo-runtime-validation.ts`(新):按职责外移校验/错误映射胶水(600 行门)。
- `packages/daemon/src/index.ts`:导出 codec。
- `packages/daemon/test/daemon-status-contract.test.ts`(新):valid/invalid v2 fixture 直接过 codec。
- `packages/daemon/test/json-rpc-protocol.test.ts`:原 v1 成功用例改为拒绝用例。

## 任务与范围

- Harness 任务:task_01KXPZHNKF839H4B21P0YAJ723
- 分支:`codex/p1-status-v2-validation`
- 公开范围:daemon-status v2 边界+其测试;权威规格=审查发现 L8-F2(`review-contract-islands.md`)。
- 私有计划 / 证据是否已更新:yes(回执在收口时 append 进任务 progress)
- 范围外:其他契约岛(L8-F1/-F3 类)、GUI renderer 改动(renderer 已消费 owner-stripped 投影)。

## 版本影响

- 版本:无版本变化,因为这是边界校验修复。
- 发布影响:不发布。

## 治理声明

- 是否触碰受保护面:否
- 受保护面范围:不适用(application/daemon 源码+测试;不动 tools/、workflow、gate)
- 授权依据:task_01KXPZHNKF839H4B21P0YAJ723;dec_01KXPZF5RXWE0ZTDRW4QP1N4Y7(深审 NO-GO 决策,泽宇 2026-07-17 已 accept,本项属 P1 契约岛根类);dec_01KXMZZ92B(daemon status v2 路由支持面)
- 机器校验边界:本 PR 仅断言声明存在;声明是否为真、是否充分由 reviewer 判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- 基线 `origin/main` SHA:59de1127
- 分支与 `origin/main` 的 merge-base:59de1127
- 最近一次 `git fetch origin` 时间:2026-07-17 ~15:10(发 PR 前 rebase)
- 同步方式:rebase
- 公开 diff 命令:`git diff 59de1127...HEAD`
- 私有证据 commit/路径:任务 progress(回执输出)
- Reviewer 证据路径:CEO 亲跑确定性回执——带凭证全量 check:ci 除 boundaries 外全绿(typecheck、fast-contract、shard 1-6、package-policy、supply-chain、gui-build、node26);随后以四个具体修复把 boundaries 链推到绿(600 行门拆文件、error next-step 文案、契约锚回位、helper 改名过 duplicate-definitions),终态 `boundaries exit=0 (31s)`、`fast-contract exit=0 (67s)`——ALL GREEN。
- GitHub Actions `rewrite-ci` run URL:开 PR 后待填
- [x] `npm run check`(回执如上)
- [ ] GitHub Actions `rewrite-ci` 通过(待跑;仅绿后合并)
- 未运行:本地无遗留;以 PR CI 为最终仲裁。

## 审查证据

- 自查:worker 修复前复现 RED(旧路由把 v1 形状 result 判成功);翻转记录在案(旧:`receipt.ok === true`;新:`daemon_status_result_invalid`)。
- Reviewer 子代理:未跑;CEO 通读 codec 与边界 hunks,并以确定性回执驱动门修复链。
- 人工 review:在已 accept 的 NO-GO 决策修复授权下执行(泽宇 2026-07-17:"accept 所有的 全部修完再进入 remote 线")。
- 阻塞发现:无。

## 残余风险

- codec 只加在这一条路由;其他 daemon 路由维持既有校验姿态(由其余契约岛发现跟踪)。
- 错误文案符合 error-next-steps 门;措辞可调,不动契约。

## 关联材料

- 任务:task_01KXPZHNKF839H4B21P0YAJ723
- 证据:review-contract-islands.md L8-F2 + 任务 progress 回执
- Review:本 PR review 线程
