### PR TITLE
fix(cli): sanitize Electron GUI launch environment

### DIFF
--- a/packages/cli/src/commands/core/gui.ts
+++ b/packages/cli/src/commands/core/gui.ts
@@ -43,25 +43,18 @@ function launchGui(rootDir: string, authoredRoot?: string): CliResult {
   }
 
   const detached = process.env.HARNESS_GUI_NPM_MARKER === undefined;
+  const launchEnvironment = guiLaunchEnvironment(rootDir, authoredRoot);
   const child = process.platform === "win32" ? spawn(windowsShellCommand(command), {
     cwd: workspaceRoot,
     detached,
     stdio: "ignore",
     shell: true,
-    env: {
-      ...process.env,
-      HARNESS_GUI_ROOT: path.resolve(rootDir),
-      ...(authoredRoot ? { HARNESS_AUTHORED_ROOT: authoredRoot } : {})
-    }
+    env: launchEnvironment
   }) : spawn(command[0], command.slice(1), {
     cwd: workspaceRoot,
     detached,
     stdio: "ignore",
-    env: {
-      ...process.env,
-      HARNESS_GUI_ROOT: path.resolve(rootDir),
-      ...(authoredRoot ? { HARNESS_AUTHORED_ROOT: authoredRoot } : {})
-    }
+    env: launchEnvironment
   });
   if (detached) child.unref();
 
@@ -77,6 +70,16 @@ function launchGui(rootDir: string, authoredRoot?: string): CliResult {
       command,
       pid: child.pid
     }
+  };
+}
+
+function guiLaunchEnvironment(rootDir: string, authoredRoot?: string): NodeJS.ProcessEnv {
+  const environment = { ...process.env };
+  delete environment.ELECTRON_RUN_AS_NODE;
+  return {
+    ...environment,
+    HARNESS_GUI_ROOT: path.resolve(rootDir),
+    ...(authoredRoot ? { HARNESS_AUTHORED_ROOT: authoredRoot } : {})
   };
 }
 

--- a/packages/cli/test/gui-cli.test.ts
+++ b/packages/cli/test/gui-cli.test.ts
@@ -50,7 +50,7 @@ test("CLI gui command launches npm from the trusted package workspace, not the c
     const fakeNpmJs = [
       "#!/usr/bin/env node",
       "const { writeFileSync } = require('node:fs');",
-      "writeFileSync(process.env.HARNESS_GUI_NPM_MARKER, JSON.stringify({ cwd: process.cwd(), argv: process.argv.slice(2) }));"
+      "writeFileSync(process.env.HARNESS_GUI_NPM_MARKER, JSON.stringify({ cwd: process.cwd(), argv: process.argv.slice(2), electronRunAsNode: process.env.ELECTRON_RUN_AS_NODE ?? null }));"
     ].join("\n");
     if (process.platform === "win32") {
       writeFileSync(path.join(binDir, "fake-npm.js"), fakeNpmJs);
@@ -62,7 +62,8 @@ test("CLI gui command launches npm from the trusted package workspace, not the c
 
     const result = runJson(rootDir, ["gui"], true, {
       [pathEnvName()]: `${binDir}${path.delimiter}${process.env[pathEnvName()] ?? ""}`,
-      HARNESS_GUI_NPM_MARKER: npmMarkerPath
+      HARNESS_GUI_NPM_MARKER: npmMarkerPath,
+      ELECTRON_RUN_AS_NODE: "1"
     }, callerDir);
 
     assert.equal(result.ok, true);
@@ -70,6 +71,7 @@ test("CLI gui command launches npm from the trusted package workspace, not the c
     const marker = waitForJsonMarker(npmMarkerPath);
     assert.equal(marker.cwd, process.cwd());
     assert.deepEqual(marker.argv, ["--workspace", "@harness-anything/gui", "run", "dev:electron"]);
+    assert.equal(marker.electronRunAsNode, null);
     assert.equal(existsSync(evilMarkerPath), false);
   });
 });


### PR DESCRIPTION
# English

## Summary

Prevent `ha gui` from inheriting `ELECTRON_RUN_AS_NODE` from a long-lived local daemon, which previously caused Electron to run as plain Node.js and exit while the CLI still printed a delegated success receipt.

## What Changed

- Sanitize the desktop-controller child environment by removing `ELECTRON_RUN_AS_NODE` before invoking the GUI workspace script.
- Preserve the trusted workspace, root overrides, detached launch behavior, and Windows/POSIX branches.
- Extend the existing CLI integration test to inject the contaminated environment and verify that the delegated npm process cannot observe it.

## Task And Scope

- Harness task: `task_01KXQKZ85Y7AZQXRAPN4RCNV3B`
- Branch: `codex/fix-ha-gui-electron-env`
- Public scope: CLI GUI launcher and its integration regression test.
- Private planning/evidence updated: yes; the private task package records reproduction, TDD evidence, smoke evidence, and local verification, but is not included in this PR.
- Out of scope: generic GUI readiness handshakes, daemon lifecycle changes, GUI feature work, and unrelated architecture drift.

## Version Impact

- Version: no version change because this is an unreleased source-level bug fix.
- Publish impact: no publish; release packaging remains a separate release concern.

## Governance Declaration

- Protected surface touched: no.
- Protected surface scope: not applicable; only CLI source and an existing CLI integration test changed.
- Authority: Harness task `task_01KXQKZ85Y7AZQXRAPN4RCNV3B`; no CI/gate authority change.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no.
- Break-glass reason: not applicable.
- Break-glass scope: not applicable.
- Follow-up governance task: not applicable.

## Verification

- Base `origin/main` SHA: `525c2e0ad9ff6844a8f752633f155dca3d9942b3`
- Branch merge-base with `origin/main`: `525c2e0ad9ff6844a8f752633f155dca3d9942b3`
- Last `git fetch origin` time: `2026-07-17T09:20:58Z`
- Sync method: none needed; the branch is zero commits behind and one commit ahead.
- Public diff command: `git diff --check origin/main...HEAD` and `git diff --stat origin/main...HEAD`
- Private evidence commit/path: private task package for `task_01KXQKZ85Y7AZQXRAPN4RCNV3B`; not published.
- Reviewer evidence path: self-review recorded in this PR and the private task review record.
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/29569762429
- [x] `npm ci` (executed by GitHub CI jobs)
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (executed by `npm run check:local`)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (executed by `npm run check:local`)
- [x] `npm run harness:scan-forbidden-symbols` (executed by `npm run check:local`)
- [x] `npm run harness:check-private-boundary` (executed by `npm run check:local`)
- [x] `npm run harness:check-package-policy` (executed by `npm run check:local`)
- [x] `npm run harness:check-implementation-contracts` (executed by `npm run check:local`)
- [x] `npm run harness:check-schema-contracts` (executed by `npm run check:local`)
- [x] `npm run harness:check-legacy-intake-readiness` (executed by `npm run check:local`)
- [ ] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- Not run locally: `npm ci`, aggregate `npm run check`, full `npm test`, and CLI package smoke. The repository's current local stop point is `npm run check:local`; GitHub CI ran `npm ci` and the broader manifest lanes. Additional focused verification ran `HARNESS_DAEMON_MODE=direct node --test packages/cli/test/gui-cli.test.ts` (3/3 passed), `npm run build -w @harness-anything/cli`, and a contaminated-environment desktop smoke.

## Review Evidence

- Self-review: confirmed the two-file diff only removes one Electron-special environment variable at the desktop boundary and retains all existing root and platform behavior.
- Reviewer subagent: not run; the change is a focused two-file fix with an integration regression test.
- Human review: the task owner requested the diagnosis, implementation, regression coverage, and PR publication.
- Blocking findings: none in local review; remote bot/reviewer comments will be triaged before merge.

## Residual Risk

- The CLI receipt remains a delegation receipt rather than a long-term GUI health guarantee. This change eliminates the reproduced daemon-environment failure; unrelated later renderer or Electron crashes remain observable through normal runtime diagnostics.
- Merge plan: use the repository's standard squash/merge queue only after required CI and review triage are green, then delete the remote branch and local worktree.

## References

- Task: `task_01KXQKZ85Y7AZQXRAPN4RCNV3B`
- Evidence: commit `96e4b278`; focused integration test, CLI build, contaminated-environment smoke, and `npm run check:local`.
- Review: local self-review; GitHub review and CI pending.

---

# 中文

## 概要

修复 `ha gui` 从常驻本地 daemon 继承 `ELECTRON_RUN_AS_NODE` 的问题。此前该变量会让 Electron 退化为普通 Node.js 运行并退出，而 CLI 已经打印 delegated success 回执，造成“显示成功但没有窗口”。

## 改动内容

- 在 desktop-controller 子进程启动边界删除 `ELECTRON_RUN_AS_NODE`。
- 保持受信 workspace 校验、root overrides、detached 启动方式以及 Windows/POSIX 分支不变。
- 扩展现有 CLI 集成测试，主动注入污染环境，并验证被委托的 npm 进程无法再看到该变量。

## 任务与范围

- Harness 任务：`task_01KXQKZ85Y7AZQXRAPN4RCNV3B`
- 分支：`codex/fix-ha-gui-electron-env`
- 公开范围：CLI GUI launcher 与对应集成回归测试。
- 私有计划 / 证据是否已更新：yes；私有 Task 已记录复现、TDD、真实 smoke 与本地验证证据，但不会进入公开 PR。
- 范围外：通用 GUI readiness handshake、daemon 生命周期改造、GUI 功能开发以及无关的架构漂移。

## 版本影响

- 版本：不改版本，因为这是尚未发布源码中的定点缺陷修复。
- 发布影响：不发布；发布与打包仍由独立 release 流程负责。

## 治理声明

- 是否触碰 protected surface：no。
- protected surface 范围：不适用；只修改 CLI 源码与既有 CLI 集成测试。
- 依据：Harness Task `task_01KXQKZ85Y7AZQXRAPN4RCNV3B`；未修改 CI/gate 权威面。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no。
- Break-glass 原因：不适用。
- Break-glass 范围：不适用。
- 后续治理任务：不适用。

## 验证

- `origin/main` 基准 SHA：`525c2e0ad9ff6844a8f752633f155dca3d9942b3`
- 当前分支与 `origin/main` 的 merge-base：`525c2e0ad9ff6844a8f752633f155dca3d9942b3`
- 最近一次 `git fetch origin` 时间：`2026-07-17T09:20:58Z`
- 同步方式：不需要；当前分支落后 0 个 commit、领先 1 个 commit。
- 公开 diff 命令：`git diff --check origin/main...HEAD` 与 `git diff --stat origin/main...HEAD`
- 私有证据 commit/path：`task_01KXQKZ85Y7AZQXRAPN4RCNV3B` 私有 Task 包；不公开。
- Reviewer 证据路径：本 PR 自查记录与私有 Task review 记录。
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/29569762429
- [x] `npm ci`（由 GitHub CI jobs 执行）
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`（由 `npm run check:local` 执行）
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`（由 `npm run check:local` 执行）
- [x] `npm run harness:scan-forbidden-symbols`（由 `npm run check:local` 执行）
- [x] `npm run harness:check-private-boundary`（由 `npm run check:local` 执行）
- [x] `npm run harness:check-package-policy`（由 `npm run check:local` 执行）
- [x] `npm run harness:check-implementation-contracts`（由 `npm run check:local` 执行）
- [x] `npm run harness:check-schema-contracts`（由 `npm run check:local` 执行）
- [x] `npm run harness:check-legacy-intake-readiness`（由 `npm run check:local` 执行）
- [ ] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed
- 本地未运行：`npm ci`、聚合 `npm run check`、完整 `npm test` 与 CLI package smoke。仓库当前本地停止点是 `npm run check:local`；GitHub CI 已运行 `npm ci` 与更广的 manifest lanes。额外运行了 GUI CLI 聚焦测试（3/3）、CLI build、污染环境 desktop smoke。

## 审查证据

- 自查：确认两文件 diff 只在 desktop 边界删除一个 Electron 特殊变量，并保留既有 root 与平台行为。
- Reviewer subagent：未运行；这是带集成回归测试的两文件定点修复。
- 人工审查：Task owner 已明确要求诊断、修复、回归测试与发布 PR。
- 阻塞发现：本地自查无阻塞项；合并前会继续处置远端 bot/reviewer 评论。

## 残余风险

- CLI 回执仍表示“启动请求已委托”，不是 GUI 长期健康保证。本改动消除了已复现的 daemon 环境污染故障；后续无关的 renderer/Electron 运行时崩溃仍需通过正常诊断观察。
- 合并计划：只有 required CI 全绿且 review triage 完成后才进入标准 squash/merge queue；合并后删除远端分支和本地 worktree。

## 关联材料

- 任务：`task_01KXQKZ85Y7AZQXRAPN4RCNV3B`
- 证据：commit `96e4b278`、聚焦集成测试、CLI build、污染环境 smoke 与 `npm run check:local`。
- 审查：本地自查；GitHub review 与 CI 待运行。

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，然后 `# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
