### PR TITLE
feat: add harness-install skill for onboarding verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,25 @@ npm run quickstart:demo
 The demo builds the CLI, creates a throwaway project, runs a real task loop, and
 shows the records that remain after the agent work is over.
 
-Ready to use it on a project? Continue with the
+### Let your agent install it for you
+
+You do not have to learn the CLI first. Paste one prompt into your coding agent
+(Claude Code, Codex, or similar) inside the repository you want to harness:
+
+```text
+Install the harness-install skill from
+https://github.com/FairladyZ625/harness-anything/tree/main/skills/harness-install
+into your skills directory, then follow it to install Harness Anything into
+this repository and verify the init flow end to end.
+```
+
+The skill walks the agent through the whole thing: install the package, run an
+attributed `ha init`, start the daemon, create a first real task — and then
+prove the installation by watching the completion gate reject an evidence-free
+"done". The rejection is the success signal: your repository now tells the
+difference between claimed and verified work.
+
+Ready to go deeper? Continue with the
 [Start guide](./docs-release/start/en/00-what-is-this.md).
 
 ## How It Works

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,7 +97,23 @@ npm run quickstart:demo
 Demo 会构建 CLI、创建一个临时项目、跑通一条真实任务循环，并展示 agent 工作结束后
 真正留在仓库里的记录。
 
-准备在自己的项目里使用？继续阅读[上手指南](./docs-release/start/zh/00-what-is-this.md)。
+### 让你的 agent 帮你装
+
+你不需要先学会 CLI。在你想接入 harness 的仓库里，把这一段 prompt 粘给你的
+coding agent（Claude Code、Codex 或同类工具）：
+
+```text
+Install the harness-install skill from
+https://github.com/FairladyZ625/harness-anything/tree/main/skills/harness-install
+into your skills directory, then follow it to install Harness Anything into
+this repository and verify the init flow end to end.
+```
+
+这个 skill 会带着 agent 走完全程：安装包、执行带归属的 `ha init`、启动
+daemon、创建第一条真实任务——最后用完成门拒绝一次没有证据的「做完了」来证明
+安装成功。被拒绝就是成功信号：你的仓库从此分得清「声称完成」和「验证完成」。
+
+想深入了解？继续阅读[上手指南](./docs-release/start/zh/00-what-is-this.md)。
 
 ## 它如何工作
 

--- a/skills/harness-install/SKILL.md
+++ b/skills/harness-install/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: harness-install
+description: Install Harness Anything into a project and verify the full init flow end to end. Use whenever a user asks to install, set up, onboard, or initialize Harness Anything in a repository, or to verify that a fresh install actually works (init, daemon, first task, gate blocking a fake completion).
+---
+
+# Harness Install
+
+## Goal
+
+Take a repository from "no harness" to "harness working, verified" — and prove
+it by watching the completion gate block an evidence-free completion. Do not
+report success from command exit codes alone; the verification step below is
+the definition of installed.
+
+## Preconditions
+
+1. Node.js >= 24 (`node --version`).
+2. The target directory is a git repository (`git rev-parse --show-toplevel`).
+   If it is not, ask before running `git init`.
+3. The environment must NOT define `HARNESS_AUTHORITY_MANIFEST`. That variable
+   binds a daemon to one specific production repository; if it leaks into a
+   fresh project the daemon autostart fails with "Daemon unavailable". Check
+   with `env | grep HARNESS_AUTHORITY_MANIFEST` and unset it for this shell if
+   present.
+
+## Install
+
+Published package (preferred once available on npm):
+
+```bash
+npm install --save-dev harness-anything
+npx harness-anything --help
+```
+
+From a source checkout (before the npm release, or for development builds):
+
+```bash
+# in the harness-anything checkout
+npm install && npm run build
+npm pack --workspace @harness-anything/cli
+# in the target project
+npm install --save-dev <path-to-generated-tarball>
+```
+
+Either way, `npx ha --help` (alias of `npx harness-anything --help`) must print
+the command surface before you continue.
+
+## Initialize
+
+Writes to the ledger require explicit actor attribution. Set it before init
+and keep it set for every subsequent command:
+
+```bash
+export HARNESS_ACTOR="agent:<your-agent-id>"      # or pass --actor human:<person-id>
+export HARNESS_GIT_AUTHOR_NAME="<committer name>"
+export HARNESS_GIT_AUTHOR_EMAIL="<committer email>"
+
+npx ha init --name <project-name> --add-npm-scripts
+```
+
+`init` scaffolds `harness/` (the authored ledger, its own git history) and
+`.harness/` (machine state, git-ignored). If the receipt reports a missing
+machine identity, re-run `ha init` with the two GIT author variables set — it
+registers the current host/uid credential in `~/.harness/people.yaml`.
+
+## Daemon
+
+The daemon starts automatically on the first write. To manage it explicitly:
+
+```bash
+npx ha daemon status --json
+npx ha daemon start --service     # if status reports unreachable
+```
+
+## Verify (this step defines "installed")
+
+1. Create a real task through a preset:
+
+   ```bash
+   npx ha task create --title "Install verification" --vertical software/coding --preset standard-task
+   ```
+
+2. Prove the accountability gate works — claim the task, then try to complete
+   it with no submitted execution and no evidence:
+
+   ```bash
+   npx ha task claim <task-id>
+   npx ha task complete <task-id>
+   ```
+
+   The completion MUST be rejected (missing submitted execution / review).
+   A rejection here is the success signal: the gate blocked a fake completion.
+
+3. Confirm reads work: `npx ha task show <task-id> --json` returns the task
+   with `status` unchanged.
+
+Report the three receipts (create ok, complete rejected with reason, show ok)
+to the user as the installation proof.
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+| --- | --- |
+| `Local CLI writes require explicit actor attribution` | `HARNESS_ACTOR` (or `--actor`) plus both `HARNESS_GIT_AUTHOR_*` variables are missing. Set them and retry. |
+| `Local writes require a machine identity` | `ha init` ran without the GIT author variables. Re-run `ha init` with them set, or add the host/uid credential to `~/.harness/people.yaml`. |
+| `Daemon unavailable ... connect ENOENT` on a fresh project | Almost always `HARNESS_AUTHORITY_MANIFEST` leaking from the environment (see Preconditions). Unset it, then retry; the isolated daemon autostarts. |
+| Writes hang or report a held lock | Another daemon owns the global lock. `npx ha daemon status --json` shows the holder; do not delete lock files by hand. |

--- a/skills/harness-install/agents/openai.yaml
+++ b/skills/harness-install/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Install"
+  short_description: "Install Harness Anything into a project and verify the init flow"
+  default_prompt: "Use $harness-install to install Harness Anything in this repository, run ha init, and verify the completion gate blocks an evidence-free completion."

--- a/tools/skill-contracts.test.mjs
+++ b/tools/skill-contracts.test.mjs
@@ -15,8 +15,16 @@ test("repository skills are discoverable with agent metadata", () => {
     .map((entry) => entry.name)
     .sort();
 
-  assert.deepEqual(skillNames, ["decision", "decisions", "graph-panorama", "preset-creator", "preset-trigger", "vertical-creator"]);
-  for (const skillName of ["decision", "decisions", "graph-panorama", "preset-trigger"]) {
+  assert.deepEqual(skillNames, [
+    "decision",
+    "decisions",
+    "graph-panorama",
+    "harness-install",
+    "preset-creator",
+    "preset-trigger",
+    "vertical-creator",
+  ]);
+  for (const skillName of ["decision", "decisions", "graph-panorama", "harness-install", "preset-trigger"]) {
     assert.equal(existsSync(path.join(skillsRoot, skillName, "SKILL.md")), true, skillName);
     assert.equal(existsSync(path.join(skillsRoot, skillName, "agents", "openai.yaml")), true, skillName);
   }


### PR DESCRIPTION
# English

## Summary

Adds `skills/harness-install` — the onboarding skill for the single-machine release closeout. It guides an agent through installing Harness Anything into a target repository and defines installed as verified behavior, not an exit code: attributed `ha init`, daemon status, then a verification step where `ha task complete` with no submitted execution MUST be rejected by the completion gate; the rejection is the success signal.

## What Changed

- `skills/harness-install/SKILL.md` (new): preconditions (Node >= 24, git repo, no leaked HARNESS_AUTHORITY_MANIFEST in the environment), install paths (npm package or source tarball), attributed init, daemon, gate-verification workflow, troubleshooting table for the four failure modes hit in real fresh-project runs.
- `skills/harness-install/agents/openai.yaml` (new): interface metadata matching the existing preset-trigger skill convention.
- `README.md` / `README.zh-CN.md`: Quickstart gains a "Let your agent install it for you" section with a copy-paste prompt that installs this skill and drives a verified install (release onboarding path).
- `tools/skill-contracts.test.mjs`: golden skill list and agents-metadata loop now include `harness-install` (fixes the fast-contract/node26 failures on this PR).

## Task And Scope

- Harness task: M6 singleplayer release closeout (private ledger; packet to be created when ledger writes re-enable)
- Branch: feat/harness-install-skill
- Public scope: skills/harness-install, README onboarding section, skill-contracts golden list
- Private planning/evidence updated: yes
- Out of scope: runtime code changes; npm publishing itself

## Version Impact

- Version: no version change because this adds a documentation/skill asset only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable (skill asset; no manifest-derived surface)
- Authority: operator direction 2026-07-17: single-machine release closeout requires an install skill
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 4d8730d42a375c54f130f7e277d25a711c6fbc6c
- Branch merge-base with `origin/main`: 4d8730d42a375c54f130f7e277d25a711c6fbc6c
- Last `git fetch origin` time: 2026-07-17T13:50Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness ledger task artifacts (private repo)
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: attached to this PR's checks
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local check suite; per operator direction the PR merge queue full-check on GitHub Actions is the arbiter for this change; targeted verification listed above was run locally.
- Full flow executed today on a fresh temp project with the source CLI: init, task create, claim, then `task complete` rejected with 4 unmet requirements; quickstart demo (init to task to fact to graph) green once the manifest env leak was removed.

## Review Evidence

- Self-review: operator (CEO session) executed every command in the skill on a fresh project before writing it down.
- Reviewer subagent: none (documentation asset verified by execution)
- Human review: repository owner will run the skill during release verification
- Blocking findings: none

## Residual Risk

- The npm-package install path cannot be fully exercised until 0.1 publishes; the source-tarball path is exercised now and the npm path re-verifies at release.

## References

- Task: M6 singleplayer release closeout prep (private ledger artifact)
- Evidence: fresh-project verification run recorded in the private ledger prep artifact
- Review: this PR thread

---

# 中文

## 概要

新增 `skills/harness-install`——单机发布收口的安装 skill。它引导 agent 把 Harness Anything 装进目标仓库，并把「装好了」定义为被验证的行为而非退出码：带归属的 `ha init`、daemon 状态，然后验证步骤要求在没有 submitted execution 时 `ha task complete` 必须被完成门拒绝；拒绝即成功信号。

## 改动内容

- `skills/harness-install/SKILL.md`（新）：前置条件（Node >= 24、git 仓库、环境无 HARNESS_AUTHORITY_MANIFEST 泄漏）、安装路径（npm 包或源码 tarball）、带归属 init、daemon、门验证工作流、覆盖真实 fresh 项目实跑四种失败模式的排障表。
- `skills/harness-install/agents/openai.yaml`（新）：接口元数据，对齐既有 preset-trigger skill 约定。
- `README.md` / `README.zh-CN.md`：快速开始新增「让你的 agent 帮你装」小节，附一段可直接粘贴的 prompt，先装本 skill 再驱动一次被验证的安装（发布 onboarding 路径）。
- `tools/skill-contracts.test.mjs`：golden skill 列表与 agents 元数据循环纳入 `harness-install`（修复本 PR 的 fast-contract/node26 红）。

## 任务与范围

- Harness 任务：M6 singleplayer release closeout (private ledger; packet to be created when ledger writes re-enable)
- 分支：feat/harness-install-skill
- 公开范围：skills/harness-install、README onboarding 小节、skill-contracts golden 列表
- 私有计划 / 证据是否已更新：yes
- 范围外：运行时代码改动；npm 发布本身

## 版本影响

- 版本：no version change because this adds a documentation/skill asset only
- 发布影响：no publish

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：not applicable (skill asset; no manifest-derived surface)
- 依据：operator direction 2026-07-17: single-machine release closeout requires an install skill
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：4d8730d42a375c54f130f7e277d25a711c6fbc6c
- 当前分支与 `origin/main` 的 merge-base：4d8730d42a375c54f130f7e277d25a711c6fbc6c
- 最近一次 `git fetch origin` 时间：2026-07-17T13:50Z
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：harness ledger 任务 artifacts（私有仓）
- Reviewer 证据路径：见审查证据
- GitHub Actions `rewrite-ci` run URL：见本 PR checks
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：完整本地检查套件；按操作者指示，本变更以 GitHub Actions merge queue full-check 为仲裁；上面列出的定向验证已在本地执行。
- 今日在全新临时项目用源码 CLI 跑通全流程：init、task create、claim，然后 `task complete` 被 4 项未满足要求拒绝；移除 manifest 环境泄漏后 quickstart demo（init 到 task 到 fact 到 graph）全绿。

## 审查证据

- 自查：操作者（CEO 会话）先在全新项目逐条执行 skill 中每个命令再落笔。
- Reviewer subagent：无（文档资产以执行验证）
- 人工审查：仓库所有者将在发布验证时亲跑本 skill
- 阻塞发现：无

## 残余风险

- npm 包安装路径在 0.1 发布前无法完整演练；源码 tarball 路径现已演练，npm 路径在发布时复验。

## 关联材料

- 任务：M6 单机发布收口预备（私有台账 artifact）
- 证据：fresh 项目验证实跑记录于私有台账预备文档
- 审查：本 PR 线程
