### PR TITLE
feat: unify workspace versions at 0.1.0 for release planning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-anything",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "description": "The accountability layer for AI agents — every decision, task, and fact becomes auditable structure on git, and \"done\" has to get past a gate with evidence.",

--- a/packages/adapters/github-issues/package.json
+++ b/packages/adapters/github-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-anything/adapter-github-issues",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Read-only GitHub Issues snapshot and repository list adapter.",
   "private": true,
   "license": "AGPL-3.0-or-later",

--- a/packages/adapters/linear/package.json
+++ b/packages/adapters/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-anything/adapter-linear",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Placeholder Linear adapter package; not shipped.",
   "private": true,
   "license": "AGPL-3.0-or-later",

--- a/packages/adapters/local/package.json
+++ b/packages/adapters/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-anything/adapter-local",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module"

--- a/packages/adapters/multica/package.json
+++ b/packages/adapters/multica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-anything/adapter-multica",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module"

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-anything/application",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module"

--- a/packages/cli/src/commands/legacy-intake-readiness.ts
+++ b/packages/cli/src/commands/legacy-intake-readiness.ts
@@ -7,7 +7,7 @@ export interface LegacyIntakeReadinessEvidence {
   readonly packageReleaseDecision: {
     readonly publishState: "not-published";
     readonly packageBoundary: "cli-dry-run-only";
-    readonly privatePackageVersionPolicy: "0.0.0";
+    readonly privatePackageVersionPolicy: "0.1.0";
     readonly cliDryRunVersion: "0.1.0";
   };
   readonly behaviorCorpus: {
@@ -32,7 +32,7 @@ export function evaluateLegacyIntakeReadinessEvidence(rootDir: string): LegacyIn
     packageReleaseDecision: {
       publishState: "not-published",
       packageBoundary: "cli-dry-run-only",
-      privatePackageVersionPolicy: "0.0.0",
+      privatePackageVersionPolicy: "0.1.0",
       cliDryRunVersion: "0.1.0"
     },
     behaviorCorpus,
@@ -62,8 +62,8 @@ function checkPackageDecision(rootDir: string, violations: string[]): void {
       if (asObject(json.publishConfig).access !== "public") violations.push(`${packagePath}: publishConfig.access must be public for npm publish dry-run preflight`);
     } else {
       if (json.private !== true) violations.push(`${packagePath}: package must remain private for M2 Legacy Intake readiness`);
-      if (packagePath !== "package.json" && json.version !== "0.0.0") {
-        violations.push(`${packagePath}: version must remain 0.0.0 before publish planning`);
+      if (packagePath !== "package.json" && json.version !== "0.1.0") {
+        violations.push(`${packagePath}: version must match the unified 0.1.0 release version`);
       }
       if (json.publishConfig) violations.push(`${packagePath}: publishConfig is not allowed before publish planning`);
     }

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-anything/daemon",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/packages/gui/electron-builder.config.mjs
+++ b/packages/gui/electron-builder.config.mjs
@@ -15,7 +15,7 @@ const config = {
   },
   extraMetadata: {
     name: "harness-anything-gui",
-    version: "0.0.0",
+    version: "0.1.0",
     main: "packages/gui/src/main/electron-main.ts"
   },
   files: [

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-anything/gui",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/packages/gui/src/distribution/runtime-release-readiness.ts
+++ b/packages/gui/src/distribution/runtime-release-readiness.ts
@@ -10,7 +10,7 @@ export interface RuntimeCommandContract {
 
 export interface ReleaseBoundaryContract {
   readonly packagesPrivateExceptCli: true;
-  readonly privateWorkspaceVersion: "0.0.0";
+  readonly privateWorkspaceVersion: "0.1.0";
   readonly cliPublishDryRunVersion: "0.1.0";
   readonly npmReleaseClaimed: false;
   readonly signedInstallersShipped: false;
@@ -87,7 +87,7 @@ export const harnessRuntimeReleaseReadiness: RuntimeReleaseReadinessPolicy = {
   ],
   releaseBoundary: {
     packagesPrivateExceptCli: true,
-    privateWorkspaceVersion: "0.0.0",
+    privateWorkspaceVersion: "0.1.0",
     cliPublishDryRunVersion: "0.1.0",
     npmReleaseClaimed: false,
     signedInstallersShipped: false,
@@ -118,7 +118,7 @@ export function validateRuntimeReleaseReadiness(
   const boundary = policy.releaseBoundary;
   if (
     boundary.packagesPrivateExceptCli !== true ||
-    boundary.privateWorkspaceVersion !== "0.0.0" ||
+    boundary.privateWorkspaceVersion !== "0.1.0" ||
     boundary.cliPublishDryRunVersion !== "0.1.0" ||
     boundary.npmReleaseClaimed !== false ||
     boundary.signedInstallersShipped !== false ||

--- a/packages/gui/src/distribution/supply-chain-release-readiness.ts
+++ b/packages/gui/src/distribution/supply-chain-release-readiness.ts
@@ -72,7 +72,7 @@ export interface ElectronUpgradeContract {
 
 export interface SupplyChainReleaseBoundaryContract {
   readonly packagesPrivateExceptCli: true;
-  readonly privateWorkspaceVersion: "0.0.0";
+  readonly privateWorkspaceVersion: "0.1.0";
   readonly cliPublishDryRunVersion: "0.1.0";
   readonly npmReleaseClaimed: false;
   readonly releaseArtifactsPublished: false;
@@ -263,7 +263,7 @@ export const harnessSupplyChainReleaseReadiness: SupplyChainReleaseReadinessPoli
   },
   releaseBoundary: {
     packagesPrivateExceptCli: true,
-    privateWorkspaceVersion: "0.0.0",
+    privateWorkspaceVersion: "0.1.0",
     cliPublishDryRunVersion: "0.1.0",
     npmReleaseClaimed: false,
     releaseArtifactsPublished: false,
@@ -357,7 +357,7 @@ export function validateSupplyChainReleaseReadiness(
   const boundary = policy.releaseBoundary;
   if (
     boundary.packagesPrivateExceptCli !== true ||
-    boundary.privateWorkspaceVersion !== "0.0.0" ||
+    boundary.privateWorkspaceVersion !== "0.1.0" ||
     boundary.cliPublishDryRunVersion !== "0.1.0" ||
     boundary.npmReleaseClaimed !== false ||
     boundary.releaseArtifactsPublished !== false ||

--- a/packages/gui/test/runtime-release-readiness.test.ts
+++ b/packages/gui/test/runtime-release-readiness.test.ts
@@ -28,7 +28,7 @@ test("runtime release readiness policy covers source, check, package smoke and G
   );
   assert.deepEqual(harnessRuntimeReleaseReadiness.releaseBoundary, {
     packagesPrivateExceptCli: true,
-    privateWorkspaceVersion: "0.0.0",
+    privateWorkspaceVersion: "0.1.0",
     cliPublishDryRunVersion: "0.1.0",
     npmReleaseClaimed: false,
     signedInstallersShipped: false,

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-anything/kernel",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/tools/check-package-policy.mjs
+++ b/tools/check-package-policy.mjs
@@ -42,7 +42,7 @@ for (const [relativePath, expectedName] of expectedPackages.entries()) {
     if (packageJson.engines?.node !== ">=24") record(`${relativePath} must declare Node >=24 runtime support`);
   } else {
     if (packageJson.private !== true) record(`${relativePath} must stay private until npm ownership is explicitly confirmed`);
-    if (packageJson.version !== "0.0.0") record(`${relativePath} must stay version 0.0.0 before first release planning`);
+    if (packageJson.version !== "0.1.0") record(`${relativePath} must match the unified 0.1.0 release version (operator decision 2026-07-17)`);
     if (packageJson.publishConfig) record(`${relativePath} must not define publishConfig before the npm publish decision`);
   }
 }

--- a/tools/check-runtime-release-readiness.test.mjs
+++ b/tools/check-runtime-release-readiness.test.mjs
@@ -94,7 +94,7 @@ async function withFixtureRepo(fn) {
 function writeValidRuntimeReleaseFixture(root, options = {}) {
   const packageJson = {
     name: "harness-anything",
-    version: "0.0.0",
+    version: "0.1.0",
     private: true,
     engines: { node: ">=24" },
     scripts: {
@@ -121,7 +121,7 @@ function writeValidRuntimeReleaseFixture(root, options = {}) {
   ]) {
     const packageJson = packagePath === "packages/cli/package.json"
       ? { name: "@harness-anything/cli", version: "0.1.0", publishConfig: { access: "public" } }
-      : { name: packagePath, version: "0.0.0", private: true };
+      : { name: packagePath, version: "0.1.0", private: true };
     writeJson(root, packagePath, packageJson);
   }
 

--- a/tools/check-supply-chain.test.mjs
+++ b/tools/check-supply-chain.test.mjs
@@ -229,7 +229,7 @@ async function withFixtureRepo(fn) {
 function writeValidSupplyChainFixture(root, options = {}) {
   const packageJson = {
     name: "harness-anything",
-    version: "0.0.0",
+    version: "0.1.0",
     private: true,
     license: "AGPL-3.0-or-later",
     scripts: {
@@ -252,7 +252,7 @@ function writeValidSupplyChainFixture(root, options = {}) {
     "packages/adapters/github-issues/package.json",
     "packages/adapters/linear/package.json"
   ]) {
-    workspacePackages[packagePath] = { name: packagePath, version: "0.0.0", private: true, license: "AGPL-3.0-or-later" };
+    workspacePackages[packagePath] = { name: packagePath, version: "0.1.0", private: true, license: "AGPL-3.0-or-later" };
   }
   workspacePackages["packages/cli/package.json"] = {
     ...workspacePackages["packages/cli/package.json"],
@@ -272,13 +272,13 @@ function writeValidSupplyChainFixture(root, options = {}) {
 
   const lock = {
     name: "harness-anything",
-    version: "0.0.0",
+    version: "0.1.0",
     lockfileVersion: 3,
     requires: true,
     packages: {
       "": {
         name: "harness-anything",
-        version: "0.0.0",
+        version: "0.1.0",
         license: "AGPL-3.0-or-later"
       },
       "node_modules/electron": {
@@ -392,7 +392,7 @@ function validSbom() {
       },
       {
         name: "gui",
-        purl: "pkg:npm/%40harness-anything/gui@0.0.0",
+        purl: "pkg:npm/%40harness-anything/gui@0.1.0",
         licenses: [{ license: { id: "AGPL-3.0-or-later" } }]
       }
     ]


### PR DESCRIPTION
# English

## Summary

Unifies every workspace package at version 0.1.0 per the operator's release-planning decision (2026-07-17): release 0.1 starts now, the CLI remains the only publishable artifact, and all private flags stay unchanged. The release-boundary enforcement is updated in the same commit so the unified version is machine-enforced, not aspirational.

## What Changed

- Version bump 0.0.0 -> 0.1.0: root, kernel, application, daemon, gui, and all four adapter packages (CLI already at 0.1.0).
- `tools/check-package-policy.mjs`: non-CLI packages now must match the unified 0.1.0 (previously locked to 0.0.0).
- `packages/gui/src/distribution/runtime-release-readiness.ts` and `supply-chain-release-readiness.ts`: `privateWorkspaceVersion` type-level constant moves to "0.1.0" (three sites each).
- `packages/cli/src/commands/legacy-intake-readiness.ts`: private-package version policy updated to 0.1.0.
- `packages/gui/electron-builder.config.mjs`: desktop artifact metadata version 0.1.0.
- Test fixtures updated: `tools/check-supply-chain.test.mjs`, `tools/check-runtime-release-readiness.test.mjs`, `packages/gui/test/runtime-release-readiness.test.ts`.
- Private flags and publishConfig rules unchanged: only the CLI is publishable.

## Task And Scope

- Harness task: M6 singleplayer release closeout (private ledger; version-unification decision queued for the ledger when authority writes re-enable)
- Branch: release/version-unify-0.1.0
- Public scope: package.json versions + release-boundary checkers + distribution constants + their test fixtures
- Private planning/evidence updated: yes
- Out of scope: actually publishing anything; changing private flags or publishConfig; daemon/kernel runtime logic

## Version Impact

- Version: `0.0.0` -> `0.1.0` for root and all private workspace packages (CLI already 0.1.0)
- Publish impact: publish readiness only

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: release-policy gate `check-package-policy` and the release-readiness constants (category release-policy in the gate manifest)
- Authority: operator decision 2026-07-17 (unify at 0.1.0, start release 0.1 planning); ledger decision entry queued for when authority writes re-enable; standard ci-cd-standard.md updated in the private ledger in the same change set
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 4d8730d42a375c54f130f7e277d25a711c6fbc6c
- Branch merge-base with `origin/main`: 4d8730d42a375c54f130f7e277d25a711c6fbc6c
- Last `git fetch origin` time: 2026-07-17T13:50Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness ledger task artifacts (private repo)
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: attached to this PR's checks
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local check suite; per operator direction the PR merge queue full-check on GitHub Actions is the arbiter for this change; targeted verification listed above was run locally.
- Ran locally: `npm run harness:check-package-policy`, `node tools/check-runtime-release-readiness.mjs`, `node tools/check-supply-chain.mjs` (all pass), `npm run harness:check-legacy-intake-readiness` (pass), checker test suites 15/15, GUI test suite 89/0, `tsc -b` green.

## Review Evidence

- Self-review: operator (CEO session) enumerated every 0.0.0 anchor by repository-wide scan and updated checkers, constants, and fixtures coherently.
- Reviewer subagent: none (mechanical, machine-verified change)
- Human review: repository owner made the version decision and drives merge via queue
- Blocking findings: none

## Residual Risk

- The daemon protocol fixture clientVersion and the `ha --version` walk-up fallback intentionally stay 0.0.0 (protocol compat fixture and unknown-version sentinel, unrelated to release versioning).

## References

- Task: M6 singleplayer release closeout prep (private ledger artifact)
- Evidence: local checker/test runs recorded above; ledger standard update committed privately
- Review: this PR thread

---

# 中文

## 概要

按操作者 2026-07-17 发布规划裁定把全部 workspace 包版本统一为 0.1.0：release 0.1 正式启动，CLI 仍是唯一可发布工件，所有 private 标志不变。发布边界执法在同一提交内同步更新，使统一版本被机器强制而非口头约定。

## 改动内容

- 版本 0.0.0 -> 0.1.0：root、kernel、application、daemon、gui 与四个 adapter 包（CLI 已是 0.1.0）。
- `tools/check-package-policy.mjs`：非 CLI 包改为必须匹配统一 0.1.0（此前锁 0.0.0）。
- `packages/gui/src/distribution/runtime-release-readiness.ts` 与 `supply-chain-release-readiness.ts`：类型级常量 `privateWorkspaceVersion` 改 "0.1.0"（各三处）。
- `packages/cli/src/commands/legacy-intake-readiness.ts`：private 包版本政策更新为 0.1.0。
- `packages/gui/electron-builder.config.mjs`：桌面产物元数据版本 0.1.0。
- 测试 fixture 同步：`tools/check-supply-chain.test.mjs`、`tools/check-runtime-release-readiness.test.mjs`、`packages/gui/test/runtime-release-readiness.test.ts`。
- private 标志与 publishConfig 规则不变：仅 CLI 可发布。

## 任务与范围

- Harness 任务：M6 singleplayer release closeout (private ledger; version-unification decision queued for the ledger when authority writes re-enable)
- 分支：release/version-unify-0.1.0
- 公开范围：package.json versions + release-boundary checkers + distribution constants + their test fixtures
- 私有计划 / 证据是否已更新：yes
- 范围外：actually publishing anything; changing private flags or publishConfig; daemon/kernel runtime logic

## 版本影响

- 版本：`0.0.0` -> `0.1.0` for root and all private workspace packages (CLI already 0.1.0)
- 发布影响：publish readiness only

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：release-policy gate `check-package-policy` and the release-readiness constants (category release-policy in the gate manifest)
- 依据：operator decision 2026-07-17 (unify at 0.1.0, start release 0.1 planning); ledger decision entry queued for when authority writes re-enable; standard ci-cd-standard.md updated in the private ledger in the same change set
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：4d8730d42a375c54f130f7e277d25a711c6fbc6c
- 当前分支与 `origin/main` 的 merge-base：4d8730d42a375c54f130f7e277d25a711c6fbc6c
- 最近一次 `git fetch origin` 时间：2026-07-17T13:50Z
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：harness ledger 任务 artifacts（私有仓）
- Reviewer 证据路径：见审查证据
- GitHub Actions `rewrite-ci` run URL：见本 PR checks
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：完整本地检查套件；按操作者指示，本变更以 GitHub Actions merge queue full-check 为仲裁；上面列出的定向验证已在本地执行。
- 本地已跑：`npm run harness:check-package-policy`、`node tools/check-runtime-release-readiness.mjs`、`node tools/check-supply-chain.mjs`（全过）、`npm run harness:check-legacy-intake-readiness`（过）、checker 测试 15/15、GUI 测试 89/0、`tsc -b` 绿。

## 审查证据

- 自查：操作者（CEO 会话）全仓扫描枚举所有 0.0.0 锚点，一致性更新 checker、常量与 fixture。
- Reviewer subagent：无（机械且被机器验证的变更）
- 人工审查：版本决策由仓库所有者作出并经队列合并
- 阻塞发现：无

## 残余风险

- daemon 协议 fixture 的 clientVersion 与 `ha --version` 兜底哨兵值故意保留 0.0.0（协议兼容 fixture 与未知版本哨兵，与发布版本无关）。

## 关联材料

- 任务：M6 单机发布收口预备（私有台账 artifact）
- 证据：上列本地 checker/测试记录；标准文档更新已提交私有台账
- 审查：本 PR 线程
