### PR TITLE
fix: restore post-boundary authority write path

### DIFF
--- a/packages/application/src/authority/session-execution-review-command-v2.ts
+++ b/packages/application/src/authority/session-execution-review-command-v2.ts
@@ -42,6 +42,7 @@ export type ExecutionActionPayloadV2 = {
   readonly schema: "execution.claim/v1" | "execution.submit/v1" | "execution.close/v1";
   readonly taskId: string;
   readonly execution: ExecutionRecord;
+  readonly taskIndexBody?: string;
 };
 
 export type ReviewActionPayloadV2 = {
@@ -110,11 +111,16 @@ function decodeStrictSessionExecutionReviewPayloadV2(value: unknown): SessionExe
     case "execution.claim/v1":
     case "execution.submit/v1":
     case "execution.close/v1": {
-      const row = exactSemanticObjectV2(value, ["schema", "taskId", "execution"]);
+      const row = exactSemanticObjectV2(value, ["schema", "taskId", "execution"], { allowAdditional: true });
+      const actual = Object.keys(row);
+      if (actual.some((key) => !["schema", "taskId", "execution", "taskIndexBody"].includes(key))) {
+        throw semanticAdmissionV2("TYPED_PAYLOAD_UNKNOWN_OR_MISSING_FIELD");
+      }
       return {
         schema: discriminator.schema,
         taskId: nonBlankText(row.taskId),
-        execution: decodeExecution(row.execution)
+        execution: decodeExecution(row.execution),
+        ...(row.taskIndexBody === undefined ? {} : { taskIndexBody: semanticStringValueV2(row.taskIndexBody) })
       };
     }
     case "review.create/v1":

--- a/packages/application/src/authority/session-execution-review-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/session-execution-review-semantic-compiler-v2.ts
@@ -136,21 +136,48 @@ async function compileExecution(
   const snapshot = await state.readHostedDocument(path);
   const current = snapshot ? decodeExecutionDocument(snapshot.body) : null;
   assertExecutionTransition(action, current, execution);
+  const taskPath = `tasks/${encodeURIComponent(payload.taskId)}/INDEX.md`;
+  const taskSnapshot = payload.taskIndexBody === undefined ? null : await state.readHostedDocument(taskPath);
+  if (payload.taskIndexBody !== undefined) {
+    if (action !== "close" || execution.state !== "accepted" || !taskSnapshot) {
+      throw admission("EXECUTION_COMPLETION_TRANSACTION_INVALID");
+    }
+    const expected = taskSnapshot.body.replace(/^(  status:\s*).+$/mu, "$1done");
+    if (!/^  status:\s*in_review$/mu.test(taskSnapshot.body) || payload.taskIndexBody !== expected) {
+      throw admission("EXECUTION_COMPLETION_TASK_TRANSITION_INVALID");
+    }
+  }
+  const mutations: RegistryMutationPlanInput["mutations"] = [{
+    entityKind: "execution", identity: { taskId: payload.taskId, executionId: execution.execution_id }, action
+  }, ...(payload.taskIndexBody === undefined ? [] : [{
+    entityKind: "task", identity: { taskId: payload.taskId }, action: "transition",
+    storageContext: { documentPath: "INDEX.md" }
+  }])];
   return {
-    mutationPlan: plan([{
-      entityKind: "execution",
-      identity: { taskId: payload.taskId, executionId: execution.execution_id },
-      action
-    }]),
+    mutationPlan: plan(mutations),
     operation: declaredDocumentOperation(
       "execution",
       execution.execution_id,
       executionDeclaration,
       { taskId: payload.taskId, executionId: execution.execution_id },
-      executionDeclaration.documentCodec.encode(execution)
+      executionDeclaration.documentCodec.encode(execution),
+      undefined,
+      payload.taskIndexBody === undefined ? undefined : {
+        companionWrites: [{ taskId: payload.taskId, path: "INDEX.md", body: payload.taskIndexBody }],
+        preconditions: [
+          { taskId: payload.taskId, path: `executions/${execution.execution_id}.md`, bodySha256: sha256Text(snapshot!.body) },
+          { taskId: payload.taskId, path: "INDEX.md", bodySha256: sha256Text(taskSnapshot!.body) }
+        ]
+      }
     ),
-    requiredBaseRefs: [ref("execution", `execution/${encodeURIComponent(payload.taskId)}/${encodeURIComponent(execution.execution_id)}`)],
-    requiredPathSnapshots: snapshot ? [{ path, snapshot }] : []
+    requiredBaseRefs: [
+      ref("execution", `execution/${encodeURIComponent(payload.taskId)}/${encodeURIComponent(execution.execution_id)}`),
+      ...(payload.taskIndexBody === undefined ? [] : [ref("task", `task/${payload.taskId}`)])
+    ],
+    requiredPathSnapshots: [
+      ...(snapshot ? [{ path, snapshot }] : []),
+      ...(taskSnapshot ? [{ path: taskPath, snapshot: taskSnapshot }] : [])
+    ]
   };
 }
 
@@ -263,7 +290,11 @@ function declaredDocumentOperation(
   },
   identity: Readonly<Record<string, string>>,
   body: string,
-  blob?: { readonly blobRef: SessionManifest["bodyRef"]; readonly blobBody: string }
+  blob?: { readonly blobRef: SessionManifest["bodyRef"]; readonly blobBody: string },
+  transaction?: {
+    readonly companionWrites: ReadonlyArray<{ readonly taskId: string; readonly path: string; readonly body: string }>;
+    readonly preconditions: ReadonlyArray<{ readonly taskId: string; readonly path: string; readonly bodySha256: string | null }>;
+  }
 ): WriteOp {
   if (!declaration.rootResolver) throw admission("ENTITY_ROOT_RESOLVER_REQUIRED");
   return {
@@ -276,7 +307,8 @@ function declaredDocumentOperation(
         identity,
         body,
         ...(blob ? blob : {})
-      }
+      },
+      ...(transaction ?? {})
     }
   };
 }

--- a/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
@@ -174,7 +174,7 @@ async function compileTaskDocument(
   assertTaskDocumentSurface(documentPath);
   const path = taskPath(payload.taskId, documentPath);
   const snapshot = await state.readHostedDocument(path);
-  return taskCompilation(payload.taskId, "document", "doc_write", {
+  return taskCompilation(payload.taskId, "document", documentPath === "code-doc-anchors.json" ? "code_doc_reconcile" : "doc_write", {
     path: documentPath,
     body: payload.body
   }, [taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)], snapshot ? [{ path, snapshot }] : []);

--- a/packages/application/src/provenance-session-exporter.ts
+++ b/packages/application/src/provenance-session-exporter.ts
@@ -341,7 +341,11 @@ function writeErrorMessage(error: WriteError): string {
   if (error._tag === "WriteRejected") return error.reason;
   if (error._tag === "WriteConflict") return error.owner ? `write conflict for ${error.taskId}: ${error.owner}` : `write conflict for ${error.taskId}`;
   if (error._tag === "GlobalWriteConflict") return error.owner ? `global write conflict: ${error.owner}` : "global write conflict";
-  return error.cause instanceof Error ? error.cause.message : "session export failed";
+  if (error.cause instanceof Error) return error.cause.message;
+  if (error.cause && typeof error.cause === "object" && "message" in error.cause && typeof error.cause.message === "string") {
+    return error.cause.message;
+  }
+  return "session export failed";
 }
 
 function isMissingFileError(error: unknown): boolean {

--- a/packages/application/src/task-lifecycle-orchestrator.ts
+++ b/packages/application/src/task-lifecycle-orchestrator.ts
@@ -587,5 +587,8 @@ function writeFailureCauseHint(error: EngineError | WriteError): string {
 function journalCause(cause: unknown): string {
   if (cause instanceof Error) return cause.message.trim().split(/\r?\n/u)[0] ?? "journal unavailable";
   if (typeof cause === "string" && cause.trim().length > 0) return cause.trim().split(/\r?\n/u)[0] ?? "journal unavailable";
+  if (cause && typeof cause === "object" && "message" in cause && typeof cause.message === "string" && cause.message.trim().length > 0) {
+    return cause.message.trim().split(/\r?\n/u)[0] ?? "journal unavailable";
+  }
   return "journal unavailable";
 }

--- a/packages/cli/src/cli/error-mapper.ts
+++ b/packages/cli/src/cli/error-mapper.ts
@@ -61,6 +61,9 @@ export function toCliError(error: CliReachableKernelError): CliResult["error"] {
 function journalUnavailableCause(cause: unknown): string {
   if (cause instanceof Error) return firstLine(cause.message);
   if (typeof cause === "string") return firstLine(cause);
+  if (cause && typeof cause === "object" && "message" in cause && typeof cause.message === "string") {
+    return firstLine(cause.message);
+  }
   return "";
 }
 

--- a/packages/cli/src/daemon/authority-command-submission.ts
+++ b/packages/cli/src/daemon/authority-command-submission.ts
@@ -121,12 +121,24 @@ function receiptToFlushReport(receipt: AuthorityOperationReceipt, reason: FlushR
   }
 }
 
-function authoritySubmissionWriteError(cause: unknown): WriteError {
+export function authoritySubmissionWriteError(cause: unknown): WriteError {
   if (isAuthorityWriteError(cause)) return cause;
   if (cause instanceof AuthorityProtocolDamagedError) {
     return authorityWriteRejected(cause.message, false, "PROTOCOL_DAMAGED");
   }
-  return { _tag: "JournalUnavailable", cause };
+  return { _tag: "JournalUnavailable", cause: authorityJournalFailureCause(cause) };
+}
+
+function authorityJournalFailureCause(cause: unknown): unknown {
+  if (!(cause instanceof Error)) return cause;
+  const code = "code" in cause && (typeof cause.code === "string" || typeof cause.code === "number")
+    ? cause.code
+    : undefined;
+  return {
+    name: cause.name || "Error",
+    message: cause.message,
+    ...(code === undefined ? {} : { code })
+  };
 }
 
 function authorityWriteRejected(reason: string, retryable = false, code?: string): WriteError {

--- a/packages/cli/src/daemon/authority-production-state.ts
+++ b/packages/cli/src/daemon/authority-production-state.ts
@@ -171,7 +171,9 @@ export function createDurableAuthorityBindingRuntimeV2(input: {
       .map(([, row]) => row)
       .find((row) => row.record.bindingId === bindingId)?.record,
     currentAuthorityGeneration: () => BigInt(input.config.authorityGeneration),
-    currentRevocationEpochs: async () => input.config.revocationEpochs,
+    currentRevocationEpochs: async (claims) => claims.executorAgentId === null
+      ? { ...input.config.revocationEpochs, executor: 0n }
+      : input.config.revocationEpochs,
     nowMs: () => BigInt(nowMs()),
     consumeOperation: async (tokenId, maximum) => {
       const row = input.table.get<DurableBindingRowV1>(bindingKey(tokenId));

--- a/packages/cli/src/daemon/authority-publication-evidence.ts
+++ b/packages/cli/src/daemon/authority-publication-evidence.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import type { CanonicalPublicationInspector } from "../../../application/src/index.ts";
 import {
+  encodeCanonicalCbor,
   entityRegistry,
   type PhysicalChangeV2,
   type SemanticMutationSetV2
@@ -37,15 +38,19 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
       .filter(Boolean)
       .map(canonicalGitPath)
       .sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)));
+    const physicalChanges = changedPaths.map((changedPath) => ({
+      path: changedPath,
+      beforeDigest: expectedPreviousHead ? blobDigest(rootDir, expectedPreviousHead, changedPath) : null,
+      afterDigest: blobDigest(rootDir, head, changedPath)
+    })).sort((left, right) => Buffer.compare(
+      Buffer.from(encodeCanonicalCbor(left)),
+      Buffer.from(encodeCanonicalCbor(right))
+    ));
     return {
       commitSha: head,
       previousCommit: expectedPreviousHead,
       parentCommits,
-      physicalChanges: changedPaths.map((changedPath) => ({
-        path: changedPath,
-        beforeDigest: expectedPreviousHead ? blobDigest(rootDir, expectedPreviousHead, changedPath) : null,
-        afterDigest: blobDigest(rootDir, head, changedPath)
-      }))
+      physicalChanges
     };
   };
   return {

--- a/packages/cli/src/daemon/production-authority-attempt-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-attempt-compiler.ts
@@ -41,10 +41,11 @@ import {
   type AuthorityProductionRepoConfigV1,
   type DurableAuthorityBindingRuntimeV2
 } from "./authority-production-state.ts";
+import { productionLifecycleAttemptIntent } from "./production-authority-lifecycle-intents.ts";
 
 type KeyMaterial = ReturnType<typeof openAuthorityProductionKeyMaterial>;
 
-interface CanonicalAttemptIntent {
+export interface CanonicalAttemptIntent {
   readonly commandName: string;
   readonly payload: Uint8Array;
   readonly mutations: ReadonlyArray<{
@@ -78,10 +79,9 @@ export function createProductionCanonicalAttemptCompiler(input: {
           `AUTHORITY_TYPED_COMMAND_UNSUPPORTED: production canonical ingress rejected ${command.action.kind}; ` +
           "use progress-append, decision-propose, module-register, record-fact, decision-relate, " +
           "session-export with an explicit transcript, task-claim with an execution id, " +
-          "a non-approved task-review-execution, or task-consent-record"
+          "task lifecycle closeout commands, task-consent-record, or fact-invalidate"
         );
       }
-      if (currentSession.sessionId !== input.config.sessionId) throw new Error("AUTHORITY_SESSION_AXIS_MISMATCH");
       if (canonicalEntityId !== intent.physicalEntityId) throw new Error("AUTHORITY_CANONICAL_ENTITY_MISMATCH");
       const executorAgentId = attribution.executor?.id ?? null;
       if (executorAgentId && !input.config.allowedExecutorAgentIds.includes(executorAgentId)
@@ -89,8 +89,8 @@ export function createProductionCanonicalAttemptCompiler(input: {
         throw new Error("AUTHORITY_EXECUTOR_NOT_SERVER_APPROVED");
       }
       const now = Date.now();
-      const allowedEntityKinds = [...new Set(intent.mutations.map((mutation) => mutation.entity.entityKind))].sort();
-      const allowedActions = [...new Set(intent.mutations.map((mutation) => mutation.action))].sort();
+      const allowedEntityKinds = canonicalBindingTextSet(intent.mutations.map((mutation) => mutation.entity.entityKind));
+      const allowedActions = canonicalBindingTextSet(intent.mutations.map((mutation) => mutation.action));
       const resourceScopes = [...intent.mutations.map((mutation) => ({
         kind: "entity-ref" as const,
         entityRef: mutation.entity
@@ -109,7 +109,7 @@ export function createProductionCanonicalAttemptCompiler(input: {
         workspaceId: input.config.workspaceId,
         deviceId: input.config.deviceId,
         viewId: input.config.viewId,
-        sessionId: input.config.sessionId,
+        sessionId: currentSession.sessionId,
         allowedEntityKinds,
         allowedActions,
         resourceScopes,
@@ -123,7 +123,9 @@ export function createProductionCanonicalAttemptCompiler(input: {
         issuedAt: BigInt(now),
         notBefore: BigInt(now),
         expiresAt: BigInt(now + 5 * 60_000),
-        revocationEpochs: input.config.revocationEpochs
+        revocationEpochs: executorAgentId === null
+          ? { ...input.config.revocationEpochs, executor: 0n }
+          : input.config.revocationEpochs
       };
       const token = issueActorAxesBindingV2(
         claims,
@@ -366,7 +368,7 @@ async function canonicalAttemptIntent(
       declaredPathCas: [{ path: executionPath, ...snapshot.cas }]
     };
   }
-  return null;
+  return productionLifecycleAttemptIntent({ command, currentSession, canonicalEntityId, authoredRoot });
 }
 
 function canonicalIntent(
@@ -400,6 +402,13 @@ function resourceScopeWire(scope: {
       canonicalRef: scope.entityRef.canonicalRef
     }
   };
+}
+
+function canonicalBindingTextSet(values: ReadonlyArray<string>): ReadonlyArray<string> {
+  return [...new Set(values)].sort((left, right) => Buffer.compare(
+    Buffer.from(encodeCanonicalCbor(left)),
+    Buffer.from(encodeCanonicalCbor(right))
+  ));
 }
 
 function hostedSnapshot(authoredRoot: string, portablePath: string): {

--- a/packages/cli/src/daemon/production-authority-lifecycle-intents.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle-intents.ts
@@ -1,0 +1,204 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import {
+  encodeConsentCommandPayloadV2,
+  encodeFactRelationCommandPayloadV2,
+  encodeSessionExecutionReviewCommandPayloadV2,
+  encodeTaskDecisionModuleCommandPayloadV2,
+  renderCodeDocReconciliationDraft,
+  type ConsentCommandPayloadV2,
+  type FactRelationCommandPayloadV2,
+  type SessionExecutionReviewCommandPayloadV2,
+  type TaskDecisionModuleCommandPayloadV2
+} from "../../../application/src/index.ts";
+import {
+  executionDeclaration,
+  deriveRelationId,
+  sha256Text,
+  taskEntityId,
+  type ExecutionRecord,
+  type RegistryEntityRefV2
+} from "../../../kernel/src/index.ts";
+import type { ParsedCommand } from "../cli/types.ts";
+import type { DaemonAuthorityAttemptCompilerV2 } from "./authority-command-submission.ts";
+import type { CanonicalAttemptIntent } from "./production-authority-attempt-compiler.ts";
+
+type CompileInput = Parameters<DaemonAuthorityAttemptCompilerV2["compile"]>[0];
+
+export function productionLifecycleAttemptIntent(input: {
+  readonly command: ParsedCommand;
+  readonly currentSession: CompileInput["currentSession"];
+  readonly canonicalEntityId: string;
+  readonly authoredRoot: string;
+}): CanonicalAttemptIntent | null {
+  const { action } = input.command;
+  if (action.kind === "status-set") {
+    const payload: TaskDecisionModuleCommandPayloadV2 = {
+      schema: "task.transition/v1", taskId: action.taskId, to: action.status
+    };
+    return lifecycleIntent("task.transition", encodeTaskDecisionModuleCommandPayloadV2(payload), [
+      lifecycleMutation("task", `task/${action.taskId}`, "transition")
+    ], [lifecycleRef("task", `task/${action.taskId}`)], [`tasks/${action.taskId}/INDEX.md`], taskEntityId(action.taskId), [
+      requiredLifecycleSnapshot(input.authoredRoot, `tasks/${action.taskId}/INDEX.md`)
+    ]);
+  }
+  if (action.kind === "fact-invalidate") {
+    const payload: FactRelationCommandPayloadV2 = {
+      schema: "fact.invalidate/v1", ownerTaskId: action.taskId, factId: action.factId,
+      invalidatedByFactId: action.invalidatedByFactId, rationale: action.rationale
+    };
+  const relationId = deriveRelationId({
+    source: `fact/${action.taskId}/${action.invalidatedByFactId}`,
+    target: `fact/${action.taskId}/${action.factId}`,
+    type: "supersedes-fact",
+    direction: "directed"
+  });
+    return lifecycleIntent("fact.invalidate", encodeFactRelationCommandPayloadV2(payload), [
+      lifecycleMutation("fact", `fact/${action.taskId}/${action.factId}`, "invalidate"),
+      lifecycleMutation("relation", `relation/${relationId}`, "create")
+    ], [
+      lifecycleRef("fact", `fact/${action.taskId}/${action.factId}`),
+      lifecycleRef("fact", `fact/${action.taskId}/${action.invalidatedByFactId}`),
+      lifecycleRef("relation", `relation/${relationId}`)
+    ], [`tasks/${action.taskId}/facts.md`], taskEntityId(action.taskId));
+  }
+  if (action.kind === "task-code-doc-reconcile") return codeDocIntent(input.authoredRoot, action);
+  if (action.kind === "task-review-execution" && action.verdict === "approved") {
+    return approvedReviewIntent(input.authoredRoot, input.canonicalEntityId, action);
+  }
+  if (action.kind === "task-complete") {
+    return taskCompletionIntent(input.authoredRoot, input.currentSession.detectedAt, action.taskId);
+  }
+  return null;
+}
+
+function codeDocIntent(
+  authoredRoot: string,
+  action: Extract<ParsedCommand["action"], { readonly kind: "task-code-doc-reconcile" }>
+): CanonicalAttemptIntent {
+  const taskRoot = path.join(authoredRoot, "tasks", action.taskId);
+  const documents = ["closeout.md", "review.md"]
+    .filter((name) => existsSync(path.join(taskRoot, name)))
+    .map((name) => ({ path: name, body: readFileSync(path.join(taskRoot, name), "utf8") }));
+  const draft = renderCodeDocReconciliationDraft({
+    taskId: action.taskId, documents, sha: action.sha, paths: action.paths, prRef: action.prRef
+  });
+  const payload: TaskDecisionModuleCommandPayloadV2 = {
+    schema: "task.document/v1", taskId: action.taskId, path: "code-doc-anchors.json", body: draft.body
+  };
+  const portablePath = `tasks/${action.taskId}/code-doc-anchors.json`;
+  const existing = optionalLifecycleSnapshot(authoredRoot, portablePath);
+  return lifecycleIntent("task.document", encodeTaskDecisionModuleCommandPayloadV2(payload), [
+    lifecycleMutation("task", `task/${action.taskId}`, "document")
+  ], [lifecycleRef("task", `task/${action.taskId}`)], [portablePath], taskEntityId(action.taskId), existing ? [existing] : []);
+}
+
+function approvedReviewIntent(
+  authoredRoot: string,
+  canonicalEntityId: string,
+  action: Extract<ParsedCommand["action"], { readonly kind: "task-review-execution" }>
+): CanonicalAttemptIntent {
+  if (!action.consentId) {
+    throw new Error("AUTHORITY_APPROVED_REVIEW_CONSENT_ID_REQUIRED: record consent first and retry with --consent-id");
+  }
+  const reviewId = canonicalEntityId.replace(/^review\//u, "");
+  const consentPath = `tasks/${action.taskId}/consents/${action.consentId}.md`;
+  const storedConsent = optionalLifecycleSnapshot(authoredRoot, consentPath);
+  const payload: ConsentCommandPayloadV2 = {
+    schema: "consent.consume/v1", taskId: action.taskId, executionId: action.executionId,
+    consentId: action.consentId,
+    utterance: storedConsent ? null : action.consentUtterance ?? null,
+    actions: storedConsent ? [] : action.consentActions ?? ["approve_execution", "complete_task"],
+    review: {
+      reviewId, findings: action.findings, evidenceChecked: action.evidenceChecked,
+      rationale: action.rationale, archiveWarningsAcknowledged: action.archiveWarningsAcknowledged
+    }
+  };
+  const executionPath = `tasks/${action.taskId}/executions/${action.executionId}.md`;
+  const taskPath = `tasks/${action.taskId}/INDEX.md`;
+  return lifecycleIntent("consent.consume", encodeConsentCommandPayloadV2(payload), [
+    ...(storedConsent ? [] : [lifecycleMutation("consent", `consent/${action.taskId}/${action.consentId}`, "grant")]),
+    lifecycleMutation("consent", `consent/${action.taskId}/${action.consentId}`, "consume"),
+    lifecycleMutation("review", `review/${action.taskId}/${reviewId}`, "record")
+  ], [
+    lifecycleRef("execution", `execution/${action.taskId}/${action.executionId}`),
+    lifecycleRef("consent", `consent/${action.taskId}/${action.consentId}`),
+    lifecycleRef("review", `review/${action.taskId}/${reviewId}`)
+  ], [executionPath, taskPath, consentPath, `tasks/${action.taskId}/reviews/${reviewId}.md`], `review/${reviewId}`, [
+    requiredLifecycleSnapshot(authoredRoot, executionPath),
+    requiredLifecycleSnapshot(authoredRoot, taskPath),
+    ...(storedConsent ? [storedConsent] : [])
+  ]);
+}
+
+function taskCompletionIntent(authoredRoot: string, completedAt: string, taskId: string): CanonicalAttemptIntent {
+  const executionRoot = path.join(authoredRoot, "tasks", taskId, "executions");
+  const executions = existsSync(executionRoot)
+    ? readdirSync(executionRoot).filter((name) => name.endsWith(".md")).map((name) => ({
+      name,
+      record: executionDeclaration.documentCodec.decode(readFileSync(path.join(executionRoot, name), "utf8")) as ExecutionRecord
+    }))
+    : [];
+  const submitted = executions.filter(({ record }) => record.state === "submitted");
+  if (submitted.length !== 1 || executions.some(({ record }) => record.state === "active")) {
+    throw new Error("AUTHORITY_TASK_COMPLETE_EXECUTION_SET_UNSUPPORTED: completion requires exactly one submitted execution and no stale active execution");
+  }
+  const current = submitted[0]!.record;
+  const execution: ExecutionRecord = { ...current, state: "accepted", closed_at: completedAt };
+  const taskPath = `tasks/${taskId}/INDEX.md`;
+  const taskSnapshot = requiredLifecycleSnapshot(authoredRoot, taskPath);
+  const taskBody = taskSnapshot.body.replace(/^(  status:\s*).+$/mu, "$1done");
+  const payload: SessionExecutionReviewCommandPayloadV2 = {
+    schema: "execution.close/v1", taskId, execution, taskIndexBody: taskBody
+  };
+  const executionPath = `tasks/${taskId}/executions/${execution.execution_id}.md`;
+  return lifecycleIntent("execution.close", encodeSessionExecutionReviewCommandPayloadV2(payload), [
+    lifecycleMutation("execution", `execution/${taskId}/${execution.execution_id}`, "close"),
+    lifecycleMutation("task", `task/${taskId}`, "transition")
+  ], [
+    lifecycleRef("execution", `execution/${taskId}/${execution.execution_id}`),
+    lifecycleRef("task", `task/${taskId}`)
+  ], [executionPath, taskPath], `execution/${execution.execution_id}`, [
+    requiredLifecycleSnapshot(authoredRoot, executionPath), taskSnapshot
+  ]);
+}
+
+function lifecycleIntent(
+  commandName: string,
+  payload: Uint8Array,
+  mutations: CanonicalAttemptIntent["mutations"],
+  baseRefs: ReadonlyArray<RegistryEntityRefV2>,
+  portablePaths: ReadonlyArray<string>,
+  physicalEntityId: string,
+  declaredPathCas: CanonicalAttemptIntent["declaredPathCas"] = []
+): CanonicalAttemptIntent {
+  return { commandName, payload, mutations, baseRefs, portablePaths, physicalEntityId, declaredPathCas };
+}
+
+function lifecycleMutation(entityKind: string, canonicalRef: string, action: string) {
+  return { entity: lifecycleRef(entityKind, canonicalRef), action };
+}
+
+function lifecycleRef(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
+  return { registryVersion: 1, entityKind, canonicalRef };
+}
+
+function requiredLifecycleSnapshot(authoredRoot: string, portablePath: string) {
+  const snapshot = optionalLifecycleSnapshot(authoredRoot, portablePath);
+  if (!snapshot) throw new Error(`AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED:${portablePath}`);
+  return snapshot;
+}
+
+function optionalLifecycleSnapshot(authoredRoot: string, portablePath: string) {
+  const absolute = path.join(authoredRoot, portablePath);
+  if (!existsSync(absolute)) return null;
+  const body = readFileSync(absolute, "utf8");
+  const digest = sha256Text(body);
+  return {
+    path: portablePath,
+    body,
+    expectedEpoch: digest,
+    expectedRevision: 0n,
+    expectedBlobDigest: Buffer.from(digest, "hex")
+  };
+}

--- a/packages/cli/src/daemon/production-authority-lifecycle.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle.ts
@@ -149,11 +149,19 @@ export function createProductionAuthorityLifecycle(input: {
         configurationDigest: authorityManifestSourceDigest(input.manifestPath),
         serviceStateRoot: manifest.serviceStateRoot
       });
+      const authoredRoot = resolveHarnessLayout({
+        rootDir: repo.canonicalRoot,
+        ...(input.layoutOverrides ? { layoutOverrides: input.layoutOverrides } : {})
+      }).authoredRoot;
       publicationObservers.set(repo.repoId, async (previousCommit) => {
-        const inspector = createGitCanonicalPublicationInspector(
-          input.layoutOverrides?.authoredRoot ?? repo.canonicalRoot
-        );
+        const inspector = createGitCanonicalPublicationInspector(authoredRoot);
         return inspector.inspectPublication(previousCommit);
+      });
+      await recoverPendingProductionEvents({
+        workspaceId: config.workspaceId,
+        operationRegistry: state.operationRegistry,
+        eventLog,
+        recover: committedEventPublisher.recoverCommittedReceipt
       });
       return {
         authenticatedPersonRegistry: identity.personRegistry,
@@ -198,6 +206,23 @@ export function createProductionAuthorityLifecycle(input: {
         }
       }
     };
+  }
+}
+
+export async function recoverPendingProductionEvents(input: {
+  readonly workspaceId: string;
+  readonly operationRegistry: import("../../../application/src/index.ts").AuthorityOperationRegistry;
+  readonly eventLog: ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>;
+  readonly recover: (record: import("../../../application/src/index.ts").AuthorityStoredOperationRecord) => Promise<import("../../../application/src/index.ts").AuthorityCommittedReceipt>;
+}): Promise<void> {
+  const records = await input.operationRegistry.list(input.workspaceId);
+  for (const record of records) {
+    if ((record.state !== "INDEXED" && record.state !== "INDETERMINATE")
+      || record.recordedProtocol?.kind !== "semantic-mutation-envelope/v2"
+      || !record.commitSha || !record.authorityIntegrity || !record.canonicalRequestEnvelope
+      || input.eventLog.read(record.workspaceId, record.opId)) continue;
+    const receipt = await input.recover(record);
+    await input.operationRegistry.put({ ...record, state: "COMMITTED", receipt, commitSha: receipt.commitSha });
   }
 }
 
@@ -390,7 +415,6 @@ function connectionBoundRuntime(
         || record.workspaceId !== config.workspaceId
         || record.deviceId !== config.deviceId
         || record.viewId !== config.viewId
-        || record.sessionId !== config.sessionId
         || record.attribution.actor.principal.personId !== context.actor.personId) return undefined;
       return record;
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   readDaemonRegistry,
+  registerDaemonRepo,
   type DaemonRegistryRepo
 } from "../../kernel/src/index.ts";
 import { parseArgs } from "./cli/parse-args.ts";
@@ -26,12 +27,13 @@ import { daemonIdFromEnv, daemonUserRoot, localUserDaemonEndpoint, runCommandThr
 import { createDaemonServiceHost } from "./daemon/service-host.ts";
 import { makeDaemonReservationReconciler } from "./composition/reservation-reconciler.ts";
 import { createProductionAuthorityLifecycle } from "./daemon/production-authority-lifecycle.ts";
+import { loadAuthorityProductionManifest } from "./daemon/authority-production-state.ts";
 import { runCompoundReceiptExitCommand } from "./daemon/compound-receipt-runner.ts";
 
 const runRegisteredCommand = runRegisteredCommandWithCliComposition;
 const daemonRuntimeProvider = selectCliAdapterProvider("daemon.runtime");
 type MultiRepoHarnessDaemonRuntime = ReturnType<typeof daemonRuntimeProvider.createMultiRepoDaemonRuntime>;
-type DaemonServeRepo = DaemonRepoNamespace & Pick<DaemonRegistryRepo, "displayName">;
+export type DaemonServeRepo = DaemonRepoNamespace & Pick<DaemonRegistryRepo, "displayName" | "authorityManifestPath">;
 const createMultiRepoDaemonRuntime = daemonRuntimeProvider.createMultiRepoDaemonRuntime;
 
 export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)): Promise<number> {
@@ -105,7 +107,11 @@ async function runDaemonServe(
     let runtime: MultiRepoHarnessDaemonRuntime | undefined;
     let serviceHost: Awaited<ReturnType<typeof createDaemonServiceHost>> | undefined;
     try {
+      const requestedAuthorityManifest = readOption(args, "--authority-manifest")
+        ?? process.env.HARNESS_AUTHORITY_MANIFEST?.trim();
+      if (requestedAuthorityManifest) persistAuthorityManifestPointer(requestedAuthorityManifest, userRoot);
       const serveRepos = daemonServeRepos(rootDir, layoutOverrides, requestedRepoId, userRoot);
+      const authorityManifest = requestedAuthorityManifest ?? authorityManifestFromRegistry(serveRepos);
       const defaultRepoId = defaultDaemonServeRepoId(serveRepos, rootDir, requestedRepoId);
       runtime = createMultiRepoDaemonRuntime({
         materializerPollMs: 5_000,
@@ -127,8 +133,6 @@ async function runDaemonServe(
       }
       const idleMs = parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true });
       const connections: DaemonConnectionStats = { active: 0, total: 0 };
-      const authorityManifest = readOption(args, "--authority-manifest")
-        ?? process.env.HARNESS_AUTHORITY_MANIFEST?.trim();
       const authorityLifecycle = hooks.authorityLifecycle ?? (authorityManifest
         ? createProductionAuthorityLifecycle({
           manifestPath: authorityManifest,
@@ -191,7 +195,8 @@ function daemonServeRepos(
     return enabledRepos.map((repo) => ({
       repoId: repo.repoId,
       canonicalRoot: repo.canonicalRoot,
-      displayName: repo.displayName
+      displayName: repo.displayName,
+      ...(repo.authorityManifestPath ? { authorityManifestPath: repo.authorityManifestPath } : {})
     }));
   }
   return [{
@@ -199,6 +204,30 @@ function daemonServeRepos(
     canonicalRoot: rootDir,
     displayName: layoutOverrides?.authoredRoot ?? requestedRepoId
   }];
+}
+
+function persistAuthorityManifestPointer(manifestPath: string, userRoot: string): void {
+  const manifest = loadAuthorityProductionManifest(manifestPath);
+  for (const repo of manifest.repos) {
+    registerDaemonRepo({
+      userRoot,
+      repoId: repo.repoId,
+      canonicalRoot: repo.canonicalRoot,
+      authorityManifestPath: manifestPath
+    });
+  }
+}
+
+export function authorityManifestFromRegistry(repos: ReadonlyArray<DaemonServeRepo>): string | undefined {
+  const pointers = [...new Set(repos.flatMap((repo) => repo.authorityManifestPath ? [repo.authorityManifestPath] : []))];
+  if (pointers.length > 1) {
+    throw new Error("AUTHORITY_MANIFEST_REGISTRY_CONFLICT: registered repositories require different authority manifests; start separate daemon user roots or pass --authority-manifest explicitly");
+  }
+  const protectedRepos = repos.filter((repo) => repo.authorityManifestPath);
+  if (protectedRepos.length > 0 && protectedRepos.length !== repos.length) {
+    throw new Error("AUTHORITY_MANIFEST_REGISTRY_INCOMPLETE: authority-protected and classic repositories cannot share a daemon without an explicit manifest covering every repo");
+  }
+  return pointers[0];
 }
 
 function defaultDaemonServeRepoId(repos: ReadonlyArray<DaemonServeRepo>, rootDir: string, requestedRepoId: string): string {

--- a/packages/cli/test/authority-manifest-rehydration.test.ts
+++ b/packages/cli/test/authority-manifest-rehydration.test.ts
@@ -1,0 +1,33 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { authorityManifestFromRegistry, type DaemonServeRepo } from "../src/index.ts";
+import { createProductionAuthorityLifecycle } from "../src/daemon/production-authority-lifecycle.ts";
+
+const protectedRepo: DaemonServeRepo = {
+  repoId: "canonical",
+  canonicalRoot: "/fixture/canonical",
+  displayName: "Canonical",
+  authorityManifestPath: "/fixture/service/authority-production.json"
+};
+
+test("daemon restart rehydrates the persisted production authority manifest", () => {
+  assert.equal(
+    authorityManifestFromRegistry([protectedRepo]),
+    "/fixture/service/authority-production.json"
+  );
+});
+
+test("daemon restart fails closed for mixed or conflicting authority registry pointers", () => {
+  assert.throws(() => authorityManifestFromRegistry([protectedRepo, {
+    repoId: "classic", canonicalRoot: "/fixture/classic", displayName: "Classic"
+  }]), /AUTHORITY_MANIFEST_REGISTRY_INCOMPLETE/u);
+  assert.throws(() => authorityManifestFromRegistry([protectedRepo, {
+    repoId: "other", canonicalRoot: "/fixture/other", displayName: "Other",
+    authorityManifestPath: "/fixture/service/other-authority.json"
+  }]), /AUTHORITY_MANIFEST_REGISTRY_CONFLICT/u);
+  assert.throws(
+    () => createProductionAuthorityLifecycle({ manifestPath: "/fixture/service/missing-authority.json" }),
+    /ENOENT/u
+  );
+});

--- a/packages/cli/test/authority-submission-error.test.ts
+++ b/packages/cli/test/authority-submission-error.test.ts
@@ -1,0 +1,19 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { authoritySubmissionWriteError } from "../src/daemon/authority-command-submission.ts";
+
+test("authority JournalUnavailable errors serialize diagnostic fields without stacks", () => {
+  const failure = new Error("AUTHORITY_PRODUCTION_PUBLICATION_OBSERVATION_MISMATCH") as Error & { code: string };
+  failure.code = "EOBSERVE";
+  const writeError = authoritySubmissionWriteError(failure);
+  assert.deepEqual(writeError, {
+    _tag: "JournalUnavailable",
+    cause: {
+      name: "Error",
+      message: "AUTHORITY_PRODUCTION_PUBLICATION_OBSERVATION_MISMATCH",
+      code: "EOBSERVE"
+    }
+  });
+  assert.doesNotMatch(JSON.stringify(writeError), /stack/u);
+});

--- a/packages/cli/test/error-mapper.test.ts
+++ b/packages/cli/test/error-mapper.test.ts
@@ -23,4 +23,11 @@ test("journal failures always retain their cause and teach a concrete diagnostic
     code: "journal_unavailable",
     hint: "Journal is unavailable. Run 'ha doctor --json' to inspect journal and daemon health, then retry the command."
   });
+  assert.deepEqual(toCliError({
+    _tag: "JournalUnavailable",
+    cause: { name: "Error", message: "publisher observation mismatched", code: "EIO" }
+  }), {
+    code: "journal_unavailable",
+    hint: "Journal is unavailable: publisher observation mismatched. Run 'ha doctor --json' to inspect journal and daemon health, then retry the command."
+  });
 });

--- a/packages/cli/test/helpers/daemon-cli.ts
+++ b/packages/cli/test/helpers/daemon-cli.ts
@@ -195,6 +195,7 @@ function daemonTestEnv(rootDir: string, env: Readonly<Record<string, string>>): 
     HARNESS_GIT_AUTHOR_NAME: "Harness Test",
     HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
     HARNESS_DAEMON_USER_ROOT: defaultDaemonUserRoot(rootDir),
+    HARNESS_AUTHORITY_MANIFEST: "",
     CLAUDE_SESSION_ID: "",
     CLAUDE_CODE_SESSION_ID: "",
     CODEX_THREAD_ID: "",

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -114,9 +114,9 @@ test("production canonical ingress accepts and journals one write for every cano
       authoredMarker: /session-ingress/u
     }, {
       kind: "execution",
-      action: { kind: "task-claim", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", execution: true, executionId: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG1" },
+      action: { kind: "task-claim", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", execution: true, executionId: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG1" },
       canonicalEntityId: "execution/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG1" as EntityId,
-      authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/executions/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG1.md",
+      authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/executions/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG1.md",
       authoredMarker: /exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG1/u
     }, {
       kind: "review",
@@ -132,34 +132,90 @@ test("production canonical ingress accepts and journals one write for every cano
       kind: "consent",
       action: {
         kind: "task-consent-record", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", executionId: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5",
-        utterance: "Approve this exact submitted execution.", consentActions: ["approve_execution"]
+        utterance: "Approve and complete this exact submitted execution.", consentActions: ["approve_execution", "complete_task"]
       },
       canonicalEntityId: "consent/cns_01KXQ4WTA7Q4XJ5GDDRS1YXNG3" as EntityId,
       authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/consents/cns_01KXQ4WTA7Q4XJ5GDDRS1YXNG3.md",
       authoredMarker: /cns_01KXQ4WTA7Q4XJ5GDDRS1YXNG3/u
+    }, {
+      kind: "fact-create-invalidator",
+      action: {
+        kind: "record-fact", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", factId: "F-A11CE002",
+        statement: "Replacement production fact.", source: "production canonical ingress integration",
+        observedAt: "2026-07-17T00:02:00.000Z", confidence: "high", memoryClass: "episodic",
+        memoryTags: [], dryRun: false
+      },
+      canonicalEntityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"),
+      authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/facts.md",
+      authoredMarker: /F-A11CE002/u
+    }, {
+      kind: "fact-invalidate",
+      action: {
+        kind: "fact-invalidate", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", factId: "F-A11CE001",
+        invalidatedByFactId: "F-A11CE002", rationale: "Replacement fact supersedes the original.", dryRun: false
+      },
+      canonicalEntityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"),
+      authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/facts.md",
+      authoredMarker: /supersedes-fact/u
+    }, {
+      kind: "code-doc-reconcile",
+      action: {
+        kind: "task-code-doc-reconcile", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0",
+        sha: fixture.publicHead, paths: ["README.md"], force: false
+      },
+      canonicalEntityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"),
+      authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/code-doc-anchors.json",
+      authoredMarker: /code-doc-reconciliation\/v1/u
+    }, {
+      kind: "task-transition",
+      action: { kind: "status-set", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", status: "in_review", force: false },
+      canonicalEntityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"),
+      authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/INDEX.md",
+      authoredMarker: /status: in_review/u
+    }, {
+      kind: "approved-review",
+      action: {
+        kind: "task-review-execution", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", executionId: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5",
+        verdict: "approved", findings: "All production evidence verified.", evidenceChecked: ["evidence:ingress"],
+        rationale: "Consent-backed evidence satisfies the closeout contract.", archiveWarningsAcknowledged: true,
+        consentId: "cns_01KXQ4WTA7Q4XJ5GDDRS1YXNG3"
+      },
+      canonicalEntityId: "review/rev_01KXQ4WTA7Q4XJ5GDDRS1YXNG6" as EntityId,
+      authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/reviews/rev_01KXQ4WTA7Q4XJ5GDDRS1YXNG6.md",
+      authoredMarker: /"verdict": "approved"/u
+    }, {
+      kind: "task-complete",
+      action: { kind: "task-complete", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", reviewerId: "person_alice" },
+      canonicalEntityId: "execution/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5" as EntityId,
+      authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/INDEX.md",
+      authoredMarker: /status: done/u
     }];
-    assert.deepEqual(cases.map((fixtureCase) => fixtureCase.kind).sort(), [
-      "consent", "decision", "execution", "fact", "module", "relation", "review", "session", "task"
-    ]);
-    for (const fixtureCase of cases) {
+    const coveredKinds = new Set(cases.map((fixtureCase) => fixtureCase.kind));
+    assert.equal(["consent", "decision", "execution", "fact", "module", "relation", "review", "session", "task"]
+      .every((kind) => coveredKinds.has(kind)), true);
+    for (const [index, fixtureCase] of cases.entries()) {
+      const sessionId = `real-cli-session-${index + 1}`;
       const receipt = await submission.submit({
         command: { rootDir: fixture.repoRoot, json: true, action: fixtureCase.action },
-        attribution: daemonActorAttribution(actor, { kind: "agent", id: "codex" }),
-        currentSession: { runtime: "codex", sessionId: "session-production", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z" },
+        attribution: daemonActorAttribution(actor, index === 0 ? null : { kind: "agent", id: "codex" }),
+        currentSession: { runtime: "codex", sessionId, source: "runtime", detectedAt: "2026-07-17T00:00:00.000Z" },
         canonicalEntityId: fixtureCase.canonicalEntityId
       });
-      assert.notEqual(receipt.tag, "REJECTED", `${fixtureCase.kind}:${JSON.stringify(receipt)}`);
+      assert.equal(receipt.tag, "COMMITTED", `${fixtureCase.kind}:${JSON.stringify(receipt)}`);
       const watermarkPath = path.join(fixture.repoRoot, ".harness/write-journal/watermark.json");
       assert.equal(existsSync(watermarkPath), true, `${fixtureCase.kind}:${JSON.stringify(receipt)}`);
       assert.equal(readFileSync(watermarkPath, "utf8").includes(receipt.opId), true, `${fixtureCase.kind}:journal-watermark:${JSON.stringify(receipt)}`);
       assert.match(readFileSync(path.join(fixture.authoredRoot, fixtureCase.authoredPath), "utf8"), fixtureCase.authoredMarker, fixtureCase.kind);
+      const eventFiles = execFileSync("find", [path.join(fixture.authoredRoot, "authority-attribution-events/v2"), "-type", "f"], { encoding: "utf8" })
+        .trim().split("\n").filter(Boolean);
+      assert.equal(eventFiles.some((eventPath) => readFileSync(eventPath, "utf8").includes(sessionId)), true, `${fixtureCase.kind}:real-session-axis`);
     }
     await assert.rejects(submission.submit({
       command: { rootDir: fixture.repoRoot, json: true, action: { kind: "help" } },
       attribution: daemonActorAttribution(actor, { kind: "agent", id: "codex" }),
       currentSession: { runtime: "codex", sessionId: "session-production", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z" },
       canonicalEntityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0")
-    }), /AUTHORITY_TYPED_COMMAND_UNSUPPORTED.*use progress-append/u);
+    }), /AUTHORITY_TYPED_COMMAND_UNSUPPORTED.*task lifecycle closeout/u);
     await lifecycle.stopAll("daemon-shutdown");
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
@@ -174,9 +230,11 @@ function createFixture() {
   const keyStateDirectory = path.join(serviceRoot, "keys/canonical");
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"), { recursive: true });
   mkdirSync(serviceRoot, { recursive: true, mode: 0o700 });
-  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/INDEX.md"), "---\ntask_id: task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0\nstatus: active\n---\n");
+  writeFileSync(path.join(authoredRoot, "harness.yaml"), "schema: harness-anything/v1\nproject: production-ingress\n");
+  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"));
+  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/closeout.md"), "# Closeout\n\nProduction fixture qualified.\n");
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"), { recursive: true });
-  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/INDEX.md"), "---\ntask_id: task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4\nstatus: active\n---\n");
+  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"));
   const actor = {
     personId: "person_alice",
     displayName: "Alice",
@@ -259,10 +317,25 @@ function createFixture() {
       }
     }]
   }, null, 2)}\n`);
+  writeFileSync(path.join(repoRoot, "README.md"), "# Distinct public repository\n");
+  git(repoRoot, "init", "-q");
+  git(repoRoot, "add", "README.md");
+  git(repoRoot, "commit", "-q", "-m", "seed distinct public fixture");
+  const publicHead = git(repoRoot, "rev-parse", "HEAD");
   git(authoredRoot, "init", "-q");
   git(authoredRoot, "add", ".");
   git(authoredRoot, "commit", "-q", "-m", "seed canonical ingress fixture");
-  return { root, repoRoot, authoredRoot, serviceRoot, manifestPath, actor, transcriptPath };
+  return { root, repoRoot, authoredRoot, serviceRoot, manifestPath, actor, transcriptPath, publicHead };
+}
+
+function taskIndexBody(taskId: string): string {
+  return [
+    "---", "schema: task-package/v2", `task_id: ${taskId}`, "title: Production ingress",
+    "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", "  status: active",
+    "  ref: ", "  titleSnapshot: Production ingress", "  url: ",
+    "  bindingCreatedAt: 2026-07-17T00:00:00.000Z", `  bindingFingerprint: sha256:${"b".repeat(64)}`,
+    "packageDisposition: active", "vertical: default", "preset: default", "---", "", "# Production ingress", ""
+  ].join("\n");
 }
 
 function productionTuple() {

--- a/packages/cli/test/production-authority-event-recovery.test.ts
+++ b/packages/cli/test/production-authority-event-recovery.test.ts
@@ -1,0 +1,86 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  AuthorityCommittedReceipt,
+  AuthorityOperationRegistry,
+  AuthorityStoredOperationRecord
+} from "../../application/src/index.ts";
+import type { makeLocalAuthorityAttributionEventV2Log } from "../../kernel/src/index.ts";
+import { recoverPendingProductionEvents } from "../src/daemon/production-authority-lifecycle.ts";
+
+test("restart recovery publishes one missing event for a committed effect without reapplying it", async () => {
+  const record: AuthorityStoredOperationRecord = {
+    workspaceId: "workspace-production",
+    opId: "namespace-production:91f592f6c440131096fbc9341dcf70ed",
+    semanticDigest: "a".repeat(64),
+    state: "INDETERMINATE",
+    receipt: {
+      tag: "INDETERMINATE",
+      workspaceId: "workspace-production",
+      opId: "namespace-production:91f592f6c440131096fbc9341dcf70ed",
+      semanticDigest: "a".repeat(64),
+      reason: "PROTOCOL_DAMAGED:V2_EVENT_PUBLICATION_FAILED",
+      commitSha: "b".repeat(40)
+    },
+    commitSha: "b".repeat(40),
+    authorityIntegrity: {
+      schema: "authority-operation-integrity/v2",
+      semanticRequestDigest: "a".repeat(64),
+      semanticMutationSetDigest: "c".repeat(64),
+      mutationRegistryVersion: 1,
+      actorAxesBindingDigest: "d".repeat(64),
+      canonicalMutationSet: { registryVersion: 1, mutations: [] }
+    },
+    recordedProtocol: {
+      kind: "semantic-mutation-envelope/v2",
+      schemaTuple: {
+        wire: 2, event: 2, receipt: 2, digest: 2, policy: 2,
+        commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
+      }
+    },
+    canonicalRequestEnvelope: "durable-envelope"
+  };
+  let durable = record;
+  let eventPresent = false;
+  let publicationCount = 0;
+  const effectApplyCount = 1;
+  const operationRegistry: AuthorityOperationRegistry = {
+    get: async () => durable,
+    list: async () => [durable],
+    put: async (next) => { durable = next; }
+  };
+  const eventLog = {
+    read: () => eventPresent
+      ? { workspaceId: record.workspaceId, opId: record.opId }
+      : undefined
+  } as unknown as ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>;
+  const receipt: AuthorityCommittedReceipt = {
+    tag: "COMMITTED", workspaceId: record.workspaceId, opId: record.opId,
+    semanticDigest: record.semanticDigest, revision: 1,
+    commitSha: record.commitSha!, previousCommit: null,
+    authorityIntegrity: record.authorityIntegrity,
+    integrityTuple: {
+      schema: "authority-integrity-tuple/v2", canonicalEventDigest: "e".repeat(64),
+      changeSetDigest: "f".repeat(64), semanticMutationSetDigest: "c".repeat(64),
+      actorAxesBindingDigest: "d".repeat(64)
+    }
+  };
+  const recover = async () => {
+    publicationCount += 1;
+    eventPresent = true;
+    return receipt;
+  };
+
+  await recoverPendingProductionEvents({
+    workspaceId: record.workspaceId, operationRegistry, eventLog, recover
+  });
+  await recoverPendingProductionEvents({
+    workspaceId: record.workspaceId, operationRegistry, eventLog, recover
+  });
+
+  assert.equal(publicationCount, 1);
+  assert.equal(effectApplyCount, 1);
+  assert.equal(durable.state, "COMMITTED");
+  assert.deepEqual(durable.receipt, receipt);
+});

--- a/packages/kernel/src/daemon/registry.ts
+++ b/packages/kernel/src/daemon/registry.ts
@@ -24,6 +24,7 @@ export interface DaemonRegistryRepo {
   readonly displayName: string;
   readonly state: DaemonRepoState;
   readonly registeredAt: string;
+  readonly authorityManifestPath?: string;
 }
 
 export interface DaemonRegistry {
@@ -48,6 +49,7 @@ export interface DaemonRegistryRegisterInput extends DaemonRegistryOptions {
   readonly canonicalRoot: string;
   readonly repoId?: string;
   readonly displayName?: string;
+  readonly authorityManifestPath?: string;
 }
 
 export interface DaemonRegistryMutationResult {
@@ -90,7 +92,8 @@ export function registerDaemonRepo(input: DaemonRegistryRegisterInput): DaemonRe
     const repo = {
       ...existingByRoot,
       displayName,
-      state: "enabled" as const
+      state: "enabled" as const,
+      ...(input.authorityManifestPath ? { authorityManifestPath: canonicalAuthorityManifestPath(input.authorityManifestPath) } : {})
     };
     const next = replaceRepo(registry, repo);
     const changed = !daemonRepoEquals(existingByRoot, repo);
@@ -110,7 +113,8 @@ export function registerDaemonRepo(input: DaemonRegistryRegisterInput): DaemonRe
     canonicalRoot,
     displayName,
     state: "enabled",
-    registeredAt: (input.now ?? (() => new Date()))().toISOString()
+    registeredAt: (input.now ?? (() => new Date()))().toISOString(),
+    ...(input.authorityManifestPath ? { authorityManifestPath: canonicalAuthorityManifestPath(input.authorityManifestPath) } : {})
   };
   const next = sortDaemonRegistry({ schema: daemonRegistrySchema, repos: [...registry.repos, repo] });
   writeDaemonRegistry(next, input);
@@ -158,10 +162,21 @@ function decodeDaemonRegistryRepo(value: unknown, source: string): DaemonRegistr
   const displayName = typeof value.displayName === "string" && value.displayName.length > 0 ? value.displayName : undefined;
   const state = value.state === "enabled" || value.state === "disabled" ? value.state : undefined;
   const registeredAt = typeof value.registeredAt === "string" && value.registeredAt.length > 0 ? value.registeredAt : undefined;
-  if (!repoId || !canonicalRoot || !displayName || !state || !registeredAt) {
+  const authorityManifestPath = value.authorityManifestPath === undefined
+    ? undefined
+    : typeof value.authorityManifestPath === "string" && path.isAbsolute(value.authorityManifestPath)
+      ? value.authorityManifestPath
+      : null;
+  if (!repoId || !canonicalRoot || !displayName || !state || !registeredAt || authorityManifestPath === null) {
     throw new Error(`invalid daemon registry repo entry at ${source}`);
   }
-  return { repoId, canonicalRoot, displayName, state, registeredAt };
+  return { repoId, canonicalRoot, displayName, state, registeredAt, ...(authorityManifestPath ? { authorityManifestPath } : {}) };
+}
+
+function canonicalAuthorityManifestPath(manifestPath: string): string {
+  const absolute = path.resolve(manifestPath);
+  if (!existsSync(absolute)) throw new Error(`authority manifest is missing: ${absolute}`);
+  return realpathSync.native(absolute);
 }
 
 function writeDaemonRegistry(registry: DaemonRegistry, options: DaemonRegistryOptions): void {
@@ -261,7 +276,8 @@ function daemonRepoEquals(left: DaemonRegistryRepo, right: DaemonRegistryRepo): 
     && left.canonicalRoot === right.canonicalRoot
     && left.displayName === right.displayName
     && left.state === right.state
-    && left.registeredAt === right.registeredAt;
+    && left.registeredAt === right.registeredAt
+    && left.authorityManifestPath === right.authorityManifestPath;
 }
 
 function isDaemonRegistryRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -516,7 +516,19 @@ function toJournalError(cause: unknown, context: { readonly entityId?: EntityId 
   if (isJournalMappedError(cause)) return mapJournalError(cause, context);
   return {
     _tag: "JournalUnavailable",
-    cause
+    cause: journalFailureCause(cause)
+  };
+}
+
+function journalFailureCause(cause: unknown): unknown {
+  if (!(cause instanceof Error)) return cause;
+  const code = "code" in cause && (typeof cause.code === "string" || typeof cause.code === "number")
+    ? cause.code
+    : undefined;
+  return {
+    name: cause.name || "Error",
+    message: cause.message,
+    ...(code === undefined ? {} : { code })
   };
 }
 

--- a/packages/kernel/test/store/daemon-registry.test.ts
+++ b/packages/kernel/test/store/daemon-registry.test.ts
@@ -125,6 +125,24 @@ test("daemon registry unregister disables a repo without deleting registry histo
   });
 });
 
+test("daemon registry durably preserves the authority manifest pointer across ordinary re-registration", () => {
+  withTempDir((root) => {
+    const userRoot = path.join(root, "user-harness");
+    const canonicalRoot = createHarnessRepo(path.join(root, "project"));
+    const authorityManifestPath = path.join(root, "authority-production.json");
+    writeFileSync(authorityManifestPath, "{}\n", "utf8");
+
+    registerDaemonRepo({
+      userRoot, canonicalRoot, repoId: "canonical", authorityManifestPath, createConvenienceLinks: false
+    });
+    registerDaemonRepo({
+      userRoot, canonicalRoot, repoId: "canonical", displayName: "Renamed", createConvenienceLinks: false
+    });
+
+    assert.equal(readDaemonRegistry({ userRoot }).repos[0]?.authorityManifestPath, realpathSync.native(authorityManifestPath));
+  });
+});
+
 test("daemon registry fails closed for malformed registries and uninitialized roots", () => {
   withTempDir((root) => {
     const userRoot = path.join(root, "user-harness");

--- a/packages/kernel/test/store/journal-idempotency.test.ts
+++ b/packages/kernel/test/store/journal-idempotency.test.ts
@@ -126,8 +126,9 @@ test("WriteCoordinator retains the underlying journal read failure", () => {
     assert.equal(result._tag, "Left");
     if (result._tag === "Left") {
       assert.equal(result.left._tag, "JournalUnavailable");
-      assert.equal(result.left.cause instanceof Error, true);
-      assert.match((result.left.cause as Error).message, /malformed journal record: schema decode failed/);
+      const cause = result.left.cause as { readonly name: string; readonly message: string };
+      assert.equal(typeof cause.message, "string");
+      assert.match(cause.message, /malformed journal record: schema decode failed/);
     }
   });
 });


### PR DESCRIPTION
# English

## Summary

Forward fix for the six defects found by post-boundary qualification after the W6 production cutover (boundary active, V1 fresh writer retired, authority admission currently frozen as containment). Restores the post-boundary authority write path so the ledger becomes operable again through V2: diagnosable errors, person-only writes, real session axes, the daily closeout command chain, correct publication repository observation, restart fail-closed manifest rehydration, and exactly-once recovery of committed-but-unpublished events.

## What Changed

- D0: `JournalUnavailable` causes carry name/message/code as plain data through daemon receipts and logs (kernel write-journal coordinator, authority submission, CLI error mapper).
- D1: person-only attempts issue a zero executor revocation epoch; agent attempts keep the configured epoch (attempt compiler + durable runtime comparison).
- D2: signed claims, durable binding, envelope, event, and coordinator session bind the authenticated request's real `CurrentSessionRef.sessionId`; the manifest sessionId is composition metadata only.
- D3: typed ingress now covers `status-set` (task.transition), `fact-invalidate`, `task-code-doc-reconcile`, consent-backed approved `task-review-execution`, and `task-complete` as compound execution.close + transition; ambiguous execution sets refuse; no generic fallback added.
- D4: publication observation resolves the authored ledger root via the harness layout (matching scanner and journal), with a distinct public/authored two-repo regression fixture.
- D5: daemon registry persists an absolute authority-manifest pointer per protected repo and rehydrates fail-closed on restart; conflicting or missing manifests refuse startup instead of falling back to classic writes.
- Reconciliation: lifecycle startup republishes exactly-once V2 events for committed operations whose event append crashed, then persists the completed receipt.
- Follow-up (9b6b5081): the D0 cause normalization degraded two consumers that read cause.message only via instanceof Error — the provenance session exporter (its rejection reason lost the actionable isolation text, breaking the error-mapper remap to journal_unavailable) and the task lifecycle cause hint. Both now read the normalized object shape; the journal-idempotency coordinator test asserts on the normalized cause.

## Task And Scope

- Harness task: W6 cutover line (private ledger, prodcutover S line); forward-fix packet dispatched under the freeze containment
- Branch: w6/authority-forward-fix
- Public scope: cli daemon authority path, application semantic compilers, kernel write-journal + daemon registry, tests
- Private planning/evidence updated: yes
- Out of scope: the residual D3 surface (task creation, archive/supersede, execution submit, inline consent approval - enumerated in the private ledger summary); the live re-enable itself (operator-run after merge)

## Version Impact

- Version: no version change because this is a production write-path fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: production authority composition (command-receipt behavior for authority writes); changes keep fail-closed semantics and are covered by the targeted authority suite
- Authority: W6 runbook containment/forward-fix discipline + freeze receipt (private ledger); operator standing authorization for the cutover line
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 4d8730d42a375c54f130f7e277d25a711c6fbc6c
- Branch merge-base with `origin/main`: 4d8730d42a375c54f130f7e277d25a711c6fbc6c
- Last `git fetch origin` time: 2026-07-17T13:50Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness ledger task artifacts (private repo)
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: attached to this PR's checks
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local check suite; per operator direction the PR merge queue full-check on GitHub Actions is the arbiter for this change; targeted verification listed above was run locally.
- Implementing worker ran root `npm run check:local` green in 38.2s (31 static gates, fast 300/300, contract 312/312) plus targeted production authority suite 22/22 and D5/error/recovery 12/12; typecheck and lint pass. The isolated fixture validates the full drain-scan-confirm-boundary-freeze-fix-frozen-scans-re-enable sequence.

## Review Evidence

- Self-review: operator (CEO session) root-caused all six defects with an isolated reproduction probe before dispatch, then reviewed the returned diff against each defect and the summary's residual notes.
- Reviewer subagent: implementing worker's summary document reviewed line by line
- Human review: repository owner drives merge via queue; live re-enable is operator-run with durable receipts
- Blocking findings: none

## Residual Risk

- Residual typed-ingress surface (task creation, archive/supersede family, execution submit, inline consent approval) remains unsupported by design until a typed package/id-allocation contract exists; enumerated in the private ledger summary with rationale.
- Live re-enable still requires two frozen production scans with exact equality before admission reopens; performed by the operator after this merges.

## References

- Task: W6 cutover line (private ledger)
- Evidence: forward-fix summary + cutover/freeze receipts in the private ledger W6 artifacts
- Review: this PR thread

---

# 中文

## 概要

W6 生产 cutover 后（boundary 已激活、V1 fresh writer 已退役、authority 准入当前处于收容冻结）post-boundary 验证发现六项缺陷的前滚修复。恢复 boundary 后的 authority 写路径，使台账经 V2 重新可用：错误可诊断、纯人类写可行、真实会话轴、日常闭环命令链、正确的发布仓观察、重启 fail-closed manifest 复水、以及 committed-but-unpublished 事件的 exactly-once 恢复。

## 改动内容

- D0：`JournalUnavailable` 的 cause 以 name/message/code 纯数据穿透 daemon 回执与日志（kernel write-journal coordinator、authority submission、CLI error mapper）。
- D1：纯 person 提交签发 executor 撤销纪元 0；agent 提交保留配置纪元（attempt compiler + durable runtime 对比）。
- D2：签名 claims、durable binding、envelope、event 与 coordinator 会话绑定认证请求的真实 `CurrentSessionRef.sessionId`；manifest sessionId 降为组合元数据。
- D3：typed ingress 覆盖 `status-set`（task.transition）、`fact-invalidate`、`task-code-doc-reconcile`、consent 背书的 approved `task-review-execution`、以及 `task-complete`（execution.close+transition 复合）；执行集歧义即拒绝；不加通用回退。
- D4：发布观察经 harness layout 解析 authored 台账根（与 scanner/journal 一致），新增公开仓/台账仓分离的双仓回归夹具。
- D5：daemon registry 为受保护 repo 持久化 authority manifest 绝对路径指针，重启 fail-closed 复水；缺失或冲突即拒绝启动，不回退经典写。
- 追加（9b6b5081）：D0 cause 规范化后，两处只用 instanceof Error 读 cause.message 的消费点退化——provenance session exporter 的拒绝理由丢失可行动的隔离提示文本（破坏 error-mapper 重映射回 journal_unavailable）、task lifecycle 的 cause 提示。两处改为读取规范化对象形态；journal-idempotency coordinator 测试改为断言规范化 cause。
- 补账：lifecycle 启动对「已提交但事件未落」的操作 exactly-once 补发 V2 事件并持久化完整回执。

## 任务与范围

- Harness 任务：W6 cutover line (private ledger, prodcutover S line); forward-fix packet dispatched under the freeze containment
- 分支：w6/authority-forward-fix
- 公开范围：cli daemon authority path, application semantic compilers, kernel write-journal + daemon registry, tests
- 私有计划 / 证据是否已更新：yes
- 范围外：the residual D3 surface (task creation, archive/supersede, execution submit, inline consent approval - enumerated in the private ledger summary); the live re-enable itself (operator-run after merge)

## 版本影响

- 版本：no version change because this is a production write-path fix
- 发布影响：no publish

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：production authority composition (command-receipt behavior for authority writes); changes keep fail-closed semantics and are covered by the targeted authority suite
- 依据：W6 runbook containment/forward-fix discipline + freeze receipt (private ledger); operator standing authorization for the cutover line
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：4d8730d42a375c54f130f7e277d25a711c6fbc6c
- 当前分支与 `origin/main` 的 merge-base：4d8730d42a375c54f130f7e277d25a711c6fbc6c
- 最近一次 `git fetch origin` 时间：2026-07-17T13:50Z
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：harness ledger 任务 artifacts（私有仓）
- Reviewer 证据路径：见审查证据
- GitHub Actions `rewrite-ci` run URL：见本 PR checks
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：完整本地检查套件；按操作者指示，本变更以 GitHub Actions merge queue full-check 为仲裁；上面列出的定向验证已在本地执行。
- 实现 worker 在 worktree 跑根门 `npm run check:local` 38.2s 全绿（31 静态门、fast 300/300、contract 312/312），另有 production authority 定向套件 22/22 与 D5/错误/恢复 12/12；typecheck 与 lint 过。隔离夹具验证了 drain-scan-confirm-boundary-freeze-fix-frozen-scans-re-enable 完整序列。

## 审查证据

- 自查：操作者（CEO 会话）派发前已用隔离探针复现并定位全部六缺陷，收货后逐缺陷核对 diff 与 summary 残留说明。
- Reviewer subagent：逐行审阅实现 worker 的总结文档
- 人工审查：仓库所有者经队列合并；真实 re-enable 由操作者执行并留持久回执
- 阻塞发现：无

## 残余风险

- typed ingress 残留面（task 创建、archive/supersede 族、execution submit、内联 consent 审批）按设计暂不支持，待 typed package/id 分配契约；私有台账 summary 已枚举并给出理由。
- 真实 re-enable 仍需两次 frozen production scan exact equal 后才重开准入；合并后由操作者执行。

## 关联材料

- 任务：W6 cutover line（私有台账）
- 证据：forward-fix 总结 + cutover/freeze 回执在私有台账 W6 artifacts
- 审查：本 PR 线程
