### PR TITLE
fix: prove materialized authority publications (W6 D6-D9 forward fix)

### DIFF
--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
-import type { EngineError, TaskContractSnapshot, WriteError } from "../../../kernel/src/index.ts";
+import type { EngineError, ProvenancePayload, TaskContractSnapshot, WriteError } from "../../../kernel/src/index.ts";
 import { explainStatusTransition, isTerminalStatus } from "../../../kernel/src/index.ts";
 import { evaluateEntityDisposition } from "../../../kernel/src/index.ts";
 import { stablePayloadHash } from "../../../kernel/src/index.ts";
@@ -174,6 +174,17 @@ function createTask(
     const provenance = yield* bindProvenance(createdAt).pipe(
       Effect.mapError((error) => ({ _tag: "WriteRejected", taskId: input.taskId, reason: error.reason } satisfies WriteError))
     );
+    const writes = buildLocalTaskCreateWrites(input, createdAt, provenance);
+    yield* writeTaskPackageDocuments(coordinator, stablePayloadHash, input.taskId, writes);
+    return { taskId: input.taskId, status: "planned", engine: "local" } satisfies LocalTaskResult;
+  });
+}
+
+export function buildLocalTaskCreateWrites(
+  input: CreateLocalTaskInput,
+  createdAt: string,
+  provenance: ProvenancePayload | undefined
+): ReadonlyArray<{ readonly path: string; readonly body: string; readonly packageSlug?: string }> {
     const index = makeIndex({
       taskId: input.taskId,
       title: input.title,
@@ -211,13 +222,10 @@ function createTask(
       },
       documents: []
     } as const satisfies TaskContractSnapshot;
-    const writes = [
+    return [
       { path: "INDEX.md", body: renderIndex(index), packageSlug: input.slug },
       { path: "task-contract.json", body: `${JSON.stringify(contractSnapshot, null, 2)}\n`, packageSlug: input.slug }
     ];
-    yield* writeTaskPackageDocuments(coordinator, stablePayloadHash, input.taskId, writes);
-    return { taskId: input.taskId, status: "planned", engine: "local" } satisfies LocalTaskResult;
-  });
 }
 
 function defaultCreateProvenance(boundAt: string) {

--- a/packages/application/src/authority/service.ts
+++ b/packages/application/src/authority/service.ts
@@ -399,13 +399,10 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
     let commitSha: string;
     try {
       await options.fenceWitness.assertHeld();
-      const publication = await options.publicationInspector.inspectPublishedHead(previousHead);
-      if (publication.parentCommits.length !== (previousHead ? 1 : 0)
-        || (previousHead && publication.parentCommits[0] !== previousHead)) {
-        await settlePrepared(candidates, receipts, "INDETERMINATE", (entry) =>
-          indeterminate(entry, entry.semanticDigest, "NON_LINEAR_CANONICAL_PUBLICATION", publication.commitSha));
-        return batchReceipts(admissions, receipts);
-      }
+      const publication = await options.publicationInspector.inspectPublishedHead(
+        previousHead,
+        candidates.map((entry) => entry.opId)
+      );
       commitSha = publication.commitSha;
       for (const entry of candidates) {
         await put(entry, entry.semanticDigest, "PUBLISHED", undefined, commitSha, entry.authorityIntegrity, entry.canonicalRequestEnvelope);

--- a/packages/application/src/authority/task-decision-module-command-v2.ts
+++ b/packages/application/src/authority/task-decision-module-command-v2.ts
@@ -35,6 +35,11 @@ export interface TaskCreatePayloadV2 {
   readonly taskId: string;
   readonly packageSlug?: string;
   readonly indexBody: string;
+  readonly writes?: ReadonlyArray<{
+    readonly path: string;
+    readonly body: string;
+    readonly packageSlug?: string;
+  }>;
 }
 
 export interface TaskTransitionPayloadV2 {
@@ -168,12 +173,13 @@ function strictTaskDecisionModulePayload(value: unknown): TaskDecisionModuleComm
   const discriminator = exactTaskDecisionModuleObject(value, ["schema"], true);
   switch (discriminator.schema) {
     case "task.create/v1": {
-      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "packageSlug", "indexBody"], false, ["packageSlug"]);
+      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "packageSlug", "indexBody", "writes"], false, ["packageSlug", "writes"]);
       return {
         schema: discriminator.schema,
         taskId: taskDecisionModuleText(row.taskId),
         ...(row.packageSlug === undefined ? {} : { packageSlug: taskDecisionModuleText(row.packageSlug) }),
-        indexBody: semanticStringValueV2(row.indexBody)
+        indexBody: semanticStringValueV2(row.indexBody),
+        ...(row.writes === undefined ? {} : { writes: taskCreateWrites(row.writes) })
       };
     }
     case "task.transition/v1": {
@@ -240,7 +246,13 @@ function strictTaskDecisionModulePayload(value: unknown): TaskDecisionModuleComm
 function canonicalTaskDecisionModulePayloadWire(payload: TaskDecisionModuleCommandPayloadV2): object {
   switch (payload.schema) {
     case "task.create/v1":
-      return { schema: payload.schema, taskId: payload.taskId, ...(payload.packageSlug ? { packageSlug: payload.packageSlug } : {}), indexBody: payload.indexBody };
+      return {
+        schema: payload.schema,
+        taskId: payload.taskId,
+        ...(payload.packageSlug ? { packageSlug: payload.packageSlug } : {}),
+        indexBody: payload.indexBody,
+        ...(payload.writes ? { writes: payload.writes.map((write) => ({ path: write.path, body: write.body, ...(write.packageSlug ? { packageSlug: write.packageSlug } : {}) })) } : {})
+      };
     case "task.transition/v1":
       return { schema: payload.schema, taskId: payload.taskId, to: payload.to };
     case "task.append/v1":
@@ -262,6 +274,18 @@ function canonicalTaskDecisionModulePayloadWire(payload: TaskDecisionModuleComma
     case "module.step/v1":
       return { schema: payload.schema, moduleKey: payload.moduleKey, stepId: payload.stepId, state: payload.state };
   }
+}
+
+function taskCreateWrites(value: unknown): NonNullable<TaskCreatePayloadV2["writes"]> {
+  if (!Array.isArray(value) || value.length === 0) throw semanticAdmissionV2("TASK_CREATE_WRITES_INVALID");
+  return value.map((entry) => {
+    const row = exactTaskDecisionModuleObject(entry, ["path", "body", "packageSlug"], false, ["packageSlug"]);
+    return {
+      path: taskDecisionModuleText(row.path),
+      body: semanticStringValueV2(row.body),
+      ...(row.packageSlug === undefined ? {} : { packageSlug: taskDecisionModuleText(row.packageSlug) })
+    };
+  });
 }
 
 function decision(value: unknown): DecisionPackage {

--- a/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
@@ -133,11 +133,16 @@ function compileTaskCreate(payload: TaskCreatePayloadV2): CompiledTaskDecisionMo
   const task = parseTaskIndex(payload.indexBody);
   if (task.taskId !== payload.taskId) throw admission("TASK_ID_MISMATCH");
   if (task.status !== "planned") throw admission("TASK_CREATE_REQUIRES_PLANNED_STATUS");
-  return taskCompilation(payload.taskId, "create", "package_create", {
+  const operationPayload = payload.writes ? { writes: payload.writes.map((write) => ({ taskId: payload.taskId, ...write })) } : {
     path: "INDEX.md",
     body: payload.indexBody,
     ...(payload.packageSlug ? { packageSlug: payload.packageSlug } : {})
-  }, [taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)]);
+  };
+  if (payload.writes) {
+    const indexWrite = payload.writes.find((write) => write.path === "INDEX.md");
+    if (!indexWrite || indexWrite.body !== payload.indexBody) throw admission("TASK_CREATE_INDEX_WRITE_MISMATCH");
+  }
+  return taskCompilation(payload.taskId, "create", "package_create", operationPayload, [taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)]);
 }
 
 async function compileTaskTransition(
@@ -188,7 +193,9 @@ function taskCompilation(
   requiredBaseRefs: ReadonlyArray<RegistryEntityRefV2>,
   requiredPathSnapshots: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }> = []
 ): CompiledTaskDecisionModuleCommandV2 {
-  const documentPath = (payload as { readonly path: string }).path;
+  const documentPath = "path" in (payload as object)
+    ? (payload as { readonly path: string }).path
+    : "INDEX.md";
   return {
     mutationPlan: taskDecisionModulePlan([{ entityKind: "task", identity: { taskId }, action, storageContext: { documentPath } }]),
     operation: { opId: "authority-overrides-this", entityId: taskEntityId(taskId), kind, payload },

--- a/packages/application/src/authority/types.ts
+++ b/packages/application/src/authority/types.ts
@@ -196,7 +196,10 @@ export interface CanonicalPublication {
 
 export interface CanonicalPublicationInspector {
   readonly currentHead: () => Promise<string | null>;
-  readonly inspectPublishedHead: (expectedPreviousHead: string | null) => Promise<CanonicalPublication>;
+  readonly inspectPublishedHead: (
+    expectedPreviousHead: string | null,
+    expectedOpIds: ReadonlyArray<string>
+  ) => Promise<CanonicalPublication>;
 }
 
 export interface AuthorityFenceWitness {

--- a/packages/application/src/fact-write-service.ts
+++ b/packages/application/src/fact-write-service.ts
@@ -80,7 +80,7 @@ export interface FactWriteService {
 export function makeFactWriteService(options: FactWriteServiceOptions): FactWriteService {
   const hashPayload = options.hashPayload ?? stablePayloadHash;
   const timestamp = () => options.now?.() ?? new Date().toISOString();
-  const generateFactId = options.generateFactId ?? randomFactId;
+  const generateFactId = options.generateFactId ?? generateFactIdV1;
   return {
     record: (request) => Effect.gen(function* () {
       const layout = resolveHarnessLayout(options.rootInput);
@@ -209,7 +209,7 @@ function validateFactRecord(taskId: TaskId, record: FactRecord): FactWriteReject
   }
 }
 
-function randomFactId(): string {
+export function generateFactIdV1(): string {
   const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
   const bytes = randomBytes(8);
   let suffix = "";

--- a/packages/application/src/public-exports.ts
+++ b/packages/application/src/public-exports.ts
@@ -147,6 +147,7 @@ export type {
 export { CODE_DOC_RECONCILIATION_DOCUMENT, evaluateCodeDocReconciliationGate, renderCodeDocReconciliationDraft } from "./code-doc-reconciliation.ts";
 export { currentSessionToProvenancePayload, defaultRuntimeSessionEnvCandidates, makeEnvironmentCurrentSessionProbe, makeHumanFallbackSessionProbe } from "./current-session-probe.ts";
 export { bindCreateProvenance } from "./provenance-binding.ts";
+export { generateFactIdV1 } from "./fact-write-service.ts";
 export { makeDecisionWriteService } from "./decision-write-service.ts";
 export { makeExecutionReservationReconciler, makeExecutionSagaService } from "./execution-saga-service.ts";
 export { makeCoordinatedExecutionAuthoredStore } from "./coordinated-execution-authored-store.ts";

--- a/packages/cli/src/cli/dry-run-preview.ts
+++ b/packages/cli/src/cli/dry-run-preview.ts
@@ -32,6 +32,20 @@ export function finalizeDryRunResult(action: Action, result: CliResult): CliResu
   } : candidate;
 }
 
+/** Daemon dry-runs stop before canonical ingress, so they cannot enqueue or commit. */
+export function dryRunResult(action: Action): CliResult {
+  return finalizeDryRunResult(action, {
+    ok: true,
+    command: action.kind,
+    ...(dryRunTaskId(action) ? { taskId: dryRunTaskId(action) } : {}),
+    ...(action.kind === "progress-append" ? { path: "progress.md" } : {})
+  });
+}
+
+function dryRunTaskId(action: Action): string | undefined {
+  return "taskId" in action && typeof action.taskId === "string" ? action.taskId : undefined;
+}
+
 export function dryRunPreviewContractViolation(action: Action, result: CliResult): string | undefined {
   if (!result.ok || !isDryRunAction(action)) return undefined;
   const preview = reportRecord(result.report).preview;

--- a/packages/cli/src/cli/parsers/new-task.ts
+++ b/packages/cli/src/cli/parsers/new-task.ts
@@ -1,4 +1,4 @@
-import { slugifyTaskTitle } from "../../../../kernel/src/index.ts";
+import { generateTaskId, slugifyTaskTitle } from "../../../../kernel/src/index.ts";
 import type { CommandDescriptorIdentity } from "../command-spec/types.ts";
 import { cliError, CliErrorCode } from "../error-codes.ts";
 import type { CommandJsonInput } from "../json-input.ts";
@@ -92,7 +92,7 @@ export function parseNewTaskArgs(
       json,
       action: {
         kind: "new-task",
-        taskId: manualId,
+        taskId: manualId ?? generateTaskId(),
         title,
         parent,
         slug: explicitSlug ?? slugifyTaskTitle(title),

--- a/packages/cli/src/cli/parsers/record.ts
+++ b/packages/cli/src/cli/parsers/record.ts
@@ -5,6 +5,7 @@ import { readOption } from "../parse-options.ts";
 import type { CliResult, ParsedCommand } from "../types.ts";
 import { isFactMemoryClass, isFactMemoryTag, type FactMemoryTag } from "../../../../kernel/src/index.ts";
 import { jsonBoolean, jsonPayloadFor, jsonString, jsonStringList, type JsonPayload } from "./json-values.ts";
+import { generateFactIdV1 } from "../../../../application/src/index.ts";
 
 type ParseResult = { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] };
 
@@ -99,7 +100,7 @@ function parseFactRecord(args: ReadonlyArray<string>, rootDir: string, json: boo
   if (memoryTags === null) {
     return { ok: false, error: cliError(CliErrorCode.InvalidFactMemoryTag, "Use known fact memory tags with --memory-tag.") };
   }
-  const factId = readOption(normalizedArgs, "--id") ?? jsonString(payload, "factId");
+  const factId = readOption(normalizedArgs, "--id") ?? jsonString(payload, "factId") ?? generateFactIdV1();
   if (factId && !/^F-[0-9A-HJKMNP-TV-Z]{8}$/u.test(factId)) {
     return { ok: false, error: cliError(CliErrorCode.InvalidFactId, "Use fact ids as F-<8 Crockford base32 chars>.") };
   }

--- a/packages/cli/src/composition/adapter-registry.ts
+++ b/packages/cli/src/composition/adapter-registry.ts
@@ -1,5 +1,6 @@
 import {
   localAdapterProviderMetadata,
+  buildLocalTaskCreateWrites,
   createDaemonRuntime,
   createMultiRepoDaemonRuntime,
   makeLocalLifecycleEngine,
@@ -51,6 +52,7 @@ export interface CliCompositionAdapterProvider {
   readonly createWriteCoordinator: typeof makeLocalWriteCoordinator;
   readonly createDaemonRuntime: typeof createDaemonRuntime;
   readonly createMultiRepoDaemonRuntime: typeof createMultiRepoDaemonRuntime;
+  readonly buildLocalTaskCreateWrites: typeof buildLocalTaskCreateWrites;
   readonly runLedgerMaterializer: (rootInput: HarnessLayoutInput, options: { readonly dryRun?: boolean }) => MaterializerCommandReport;
 }
 
@@ -61,6 +63,7 @@ const localProvider = {
   createWriteCoordinator: (options: LocalWriteCoordinatorOptions) => makeLocalWriteCoordinator(options),
   createDaemonRuntime: (options) => createDaemonRuntime(options),
   createMultiRepoDaemonRuntime: (options) => createMultiRepoDaemonRuntime(options),
+  buildLocalTaskCreateWrites: (input, createdAt, provenance) => buildLocalTaskCreateWrites(input, createdAt, provenance),
   runLedgerMaterializer
 } satisfies CliCompositionAdapterProvider;
 

--- a/packages/cli/src/composition/adapter-registry.ts
+++ b/packages/cli/src/composition/adapter-registry.ts
@@ -53,7 +53,10 @@ export interface CliCompositionAdapterProvider {
   readonly createDaemonRuntime: typeof createDaemonRuntime;
   readonly createMultiRepoDaemonRuntime: typeof createMultiRepoDaemonRuntime;
   readonly buildLocalTaskCreateWrites: typeof buildLocalTaskCreateWrites;
-  readonly runLedgerMaterializer: (rootInput: HarnessLayoutInput, options: { readonly dryRun?: boolean }) => MaterializerCommandReport;
+  readonly runLedgerMaterializer: (rootInput: HarnessLayoutInput, options: {
+    readonly dryRun?: boolean;
+    readonly sessionId?: string;
+  }) => MaterializerCommandReport;
 }
 
 const localProvider = {

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -37,6 +37,8 @@ export interface ParsedCommandExecutionOptions {
   readonly missingActorAttributionMessage?: string;
   readonly requireProvidedActorAttribution?: boolean;
   readonly currentSession?: CurrentSessionRef;
+  /** Typed authority intents already carry the current-session provenance inline. */
+  readonly inlineCreateProvenanceOnly?: boolean;
   readonly syncExportedSession?: (result: ProvenanceSessionExportResult) => Effect.Effect<void, ProvenanceSessionExporterRejected>;
 }
 
@@ -187,8 +189,10 @@ export async function runRegisteredCommandWithCliComposition(
     coordinator: makeWriteCoordinator(operationalActor("task-lifecycle")),
     bindCreateProvenance: (boundAt) => bindCreateProvenance({
       currentSessionProbe: getCurrentSessionProbe(),
-      provenanceSessionExporter: makeSessionExporter(),
-      syncExportedSession
+      ...(options.inlineCreateProvenanceOnly ? {} : {
+        provenanceSessionExporter: makeSessionExporter(),
+        syncExportedSession
+      })
     }, boundAt)
   }), enforceTaskLease(), makeTaskHolder, getTaskHolderPrincipal), makeArtifactStore, getCurrentSessionProbe, makeSessionExporter, syncExportedSession, makeWriteCoordinator, makeMigrationWriteCoordinator, getActorAttribution, getTaskHolderPrincipal, () => {
     const attribution = getActorAttribution().writeAttribution;
@@ -200,15 +204,19 @@ export async function runRegisteredCommandWithCliComposition(
         : makeWriteCoordinator(operationalActor("decision-cli")),
       attribution: repin ? migrationWriteAttribution(attribution, repin.migrationEvidence) : attribution,
       currentSessionProbe: getCurrentSessionProbe(),
-      provenanceSessionExporter: makeSessionExporter(),
-      syncExportedSession
+      ...(options.inlineCreateProvenanceOnly ? {} : {
+        provenanceSessionExporter: makeSessionExporter(),
+        syncExportedSession
+      })
     });
   }, () => withOptionalFactLeaseGuard(makeFactWriteService({
     rootInput: layoutInput,
     coordinator: makeWriteCoordinator(operationalActor("fact-cli")),
     currentSessionProbe: getCurrentSessionProbe(),
-    provenanceSessionExporter: makeSessionExporter(),
-    syncExportedSession
+    ...(options.inlineCreateProvenanceOnly ? {} : {
+      provenanceSessionExporter: makeSessionExporter(),
+      syncExportedSession
+    })
   }), enforceTaskLease(), makeTaskHolder, getTaskHolderPrincipal), makeTaskHolder, getRuntimeEventLedgerService, provider.runLedgerMaterializer).pipe(
     Effect.match({
       onFailure: (error): CliResult => ({

--- a/packages/cli/src/daemon/authority-lifecycle.ts
+++ b/packages/cli/src/daemon/authority-lifecycle.ts
@@ -84,7 +84,11 @@ export interface AuthorityRepoLifecycleHooks {
     readonly namespaceVerifier: OperationNamespaceVerifierV2;
     readonly fenceWitness: AuthorityFenceWitness;
     readonly committedEventPublisher: AuthorityCommittedEventPublisherV2;
-    readonly inspectPublication: (previousCommit: string | null) => Promise<CanonicalPublicationEvidence>;
+    readonly inspectPublication: (
+      previousCommit: string | null,
+      expectedOpIds: ReadonlyArray<string>,
+      expectedCommitSha?: string
+    ) => Promise<CanonicalPublicationEvidence>;
     readonly admissionBudget: DaemonAdmissionBudget;
   }) => Promise<AuthorityRepoComponent>;
   readonly serve: (input: { readonly repo: DaemonRepoNamespace; readonly component: AuthorityRepoComponent }) => Promise<void>;
@@ -101,6 +105,14 @@ export interface AuthorityLifecycleRuntime {
     readonly sessionId: string;
   }) => WriteCoordinator;
   readonly assertWriteFenceHeld: () => Promise<void>;
+  readonly enqueueMaterializerBatch: (options: { readonly sessionId: string }) => Promise<{
+    readonly branches: ReadonlyArray<{
+      readonly branch: string;
+      readonly commitCount: number;
+      readonly status: "merged" | "would_merge" | "skipped" | "conflict";
+      readonly warning?: string;
+    }>;
+  }>;
   readonly admissionBudget: DaemonAdmissionBudget;
 }
 
@@ -281,7 +293,20 @@ export function makeHeldLockAttributedCoordinatorFactory(
       const shared: WriteCoordinator = {
         enqueue: coordinator.enqueue,
         flush: (reason) => Effect.ensuring(
-          coordinator.flush(reason),
+          coordinator.flush(reason).pipe(Effect.flatMap((report) => Effect.tryPromise({
+            try: async () => {
+              if (!report.committed || report.opCount === 0) return report;
+              const materialized = await runtime.enqueueMaterializerBatch({ sessionId });
+              const branch = materialized.branches.find((entry) => entry.branch === `sessions/${sessionId}`);
+              if (!branch || branch.commitCount === 0 || branch.status !== "merged") {
+                throw new Error(
+                  `AUTHORITY_SESSION_MATERIALIZATION_FAILED:sessionId=${sessionId};status=${branch?.status ?? "missing"};commitCount=${branch?.commitCount ?? 0};warning=${branch?.warning ?? "none"}`
+                );
+              }
+              return report;
+            },
+            catch: (cause) => ({ _tag: "JournalUnavailable" as const, cause })
+          }))),
           Effect.sync(() => {
             if (active.get(key) === shared) active.delete(key);
           })

--- a/packages/cli/src/daemon/authority-lifecycle.ts
+++ b/packages/cli/src/daemon/authority-lifecycle.ts
@@ -103,6 +103,7 @@ export interface AuthorityLifecycleRuntime {
   readonly createAttributedCoordinator: (input: {
     readonly attribution: WriteAttribution;
     readonly sessionId: string;
+    readonly commitAuthor?: { readonly name: string; readonly email: string };
   }) => WriteCoordinator;
   readonly assertWriteFenceHeld: () => Promise<void>;
   readonly enqueueMaterializerBatch: (options: { readonly sessionId: string }) => Promise<{
@@ -289,7 +290,11 @@ export function makeHeldLockAttributedCoordinatorFactory(
       const key = stableStringify({ attribution, sessionId });
       const existing = active.get(key);
       if (existing) return existing;
-      const coordinator = runtime.createAttributedCoordinator({ attribution, sessionId });
+      const coordinator = runtime.createAttributedCoordinator({
+        attribution,
+        sessionId,
+        commitAuthor: authorityCommitter
+      });
       const shared: WriteCoordinator = {
         enqueue: coordinator.enqueue,
         flush: (reason) => Effect.ensuring(
@@ -305,7 +310,7 @@ export function makeHeldLockAttributedCoordinatorFactory(
               }
               return report;
             },
-            catch: (cause) => ({ _tag: "JournalUnavailable" as const, cause })
+            catch: (cause) => ({ _tag: "JournalUnavailable" as const, cause: diagnosticCause(cause) })
           }))),
           Effect.sync(() => {
             if (active.get(key) === shared) active.delete(key);
@@ -316,6 +321,23 @@ export function makeHeldLockAttributedCoordinatorFactory(
       active.set(key, shared);
       return shared;
     }
+  };
+}
+
+const authorityCommitter = {
+  name: "Harness Anything Authority",
+  email: "authority@harness-anything.local"
+} as const;
+
+function diagnosticCause(cause: unknown): unknown {
+  if (!(cause instanceof Error)) return cause;
+  const code = "code" in cause && (typeof cause.code === "string" || typeof cause.code === "number")
+    ? cause.code
+    : undefined;
+  return {
+    name: cause.name || "Error",
+    message: cause.message,
+    ...(code === undefined ? {} : { code })
   };
 }
 

--- a/packages/cli/src/daemon/authority-publication-evidence.ts
+++ b/packages/cli/src/daemon/authority-publication-evidence.ts
@@ -5,6 +5,7 @@ import type { CanonicalPublicationInspector } from "../../../application/src/ind
 import {
   encodeCanonicalCbor,
   entityRegistry,
+  sha256Text,
   type PhysicalChangeV2,
   type SemanticMutationSetV2
 } from "../../../kernel/src/index.ts";
@@ -14,25 +15,64 @@ export interface CanonicalPublicationEvidence {
   readonly previousCommit: string | null;
   readonly parentCommits: ReadonlyArray<string>;
   readonly physicalChanges: ReadonlyArray<PhysicalChangeV2>;
+  readonly pipelineGeneratedPaths: ReadonlyArray<string>;
+  readonly contentAddressedPaths: ReadonlyArray<string>;
 }
 
 export interface GitCanonicalPublicationInspector extends CanonicalPublicationInspector {
-  readonly inspectPublication: (expectedPreviousHead: string | null) => Promise<CanonicalPublicationEvidence>;
+  readonly inspectPublication: (
+    expectedPreviousHead: string | null,
+    expectedOpIds: ReadonlyArray<string>,
+    expectedCommitSha?: string
+  ) => Promise<CanonicalPublicationEvidence>;
+  readonly findPublication: (expectedOpIds: ReadonlyArray<string>) => Promise<CanonicalPublicationEvidence>;
+  readonly findPublicationForOperation: (opId: string) => Promise<CanonicalPublicationEvidence>;
 }
 
 export function createGitCanonicalPublicationInspector(canonicalRoot: string): GitCanonicalPublicationInspector {
   const rootDir = path.resolve(canonicalRoot);
   const currentHead = async (): Promise<string | null> => gitOptional(rootDir, "rev-parse", "--verify", "HEAD");
-  const inspectPublication = async (expectedPreviousHead: string | null): Promise<CanonicalPublicationEvidence> => {
-    const head = await currentHead();
+  const inspectPublication = async (
+    expectedPreviousHead: string | null,
+    expectedOpIds: ReadonlyArray<string>,
+    expectedCommitSha?: string
+  ): Promise<CanonicalPublicationEvidence> => {
+    const head = expectedCommitSha ?? await currentHead();
     if (!head) throw new Error("AUTHORITY_CANONICAL_PUBLICATION_MISSING");
     const row = publicationGitText(rootDir, "rev-list", "--parents", "-n", "1", head).split(" ");
     const parentCommits = row.slice(1);
-    if (parentCommits.length !== (expectedPreviousHead ? 1 : 0)
-      || (expectedPreviousHead && parentCommits[0] !== expectedPreviousHead)) {
-      throw new Error("AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR");
+    const sessionCommit = parentCommits[1];
+    const sessionParents = sessionCommit
+      ? publicationGitText(rootDir, "rev-list", "--parents", "-n", "1", sessionCommit).split(" ").slice(1)
+      : [];
+    const mergeSubject = publicationGitText(rootDir, "show", "-s", "--format=%s", head);
+    const sessionSubject = sessionCommit
+      ? publicationGitText(rootDir, "show", "-s", "--format=%s", sessionCommit)
+      : "";
+    const expectedSessionSubjectSuffix = `[${expectedOpIds.join(",")}]`;
+    const mergeTreeMatchesSession = sessionCommit
+      ? gitExitCode(rootDir, "diff", "--quiet", head, sessionCommit) === 0
+      : false;
+    if (!expectedPreviousHead
+      || parentCommits.length !== 2
+      || parentCommits[0] !== expectedPreviousHead
+      || sessionParents.length !== 1
+      || sessionParents[0] !== expectedPreviousHead
+      || !/^materializer: merge session [A-Za-z0-9][A-Za-z0-9._-]*$/u.test(mergeSubject)
+      || !sessionSubject.endsWith(expectedSessionSubjectSuffix)
+      || !mergeTreeMatchesSession) {
+      throw publicationTopologyError({
+        expectedPreviousHead,
+        expectedOpIds,
+        head,
+        parentCommits,
+        sessionParents,
+        mergeSubject,
+        sessionSubject,
+        mergeTreeMatchesSession
+      });
     }
-    const changedPaths = readAuthorityGitBytes(rootDir, "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", "-z", head)
+    const changedPaths = readAuthorityGitBytes(rootDir, "diff", "--name-only", "-z", expectedPreviousHead, head)
       .toString("utf8")
       .split("\0")
       .filter(Boolean)
@@ -46,21 +86,108 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
       Buffer.from(encodeCanonicalCbor(left)),
       Buffer.from(encodeCanonicalCbor(right))
     ));
+    const pipelineGeneratedPaths = expectedOpIds.map((opId) => `attribution-events/${sha256Text(opId)}.jsonl`);
+    const observedPipelinePaths = changedPaths.filter((changedPath) => changedPath.startsWith("attribution-events/"));
+    if (observedPipelinePaths.length !== pipelineGeneratedPaths.length
+      || observedPipelinePaths.some((changedPath) => !pipelineGeneratedPaths.includes(changedPath))) {
+      throw new Error(
+        `AUTHORITY_CANONICAL_PUBLICATION_PIPELINE_EVIDENCE_MISMATCH:expected=${pipelineGeneratedPaths.join(",") || "none"};actual=${observedPipelinePaths.join(",") || "none"};head=${head}`
+      );
+    }
+    const contentAddressedPaths = physicalChanges.filter((change) => {
+      const match = /^objects\/sha256\/([a-f0-9]{2})\/([a-f0-9]{62})$/u.exec(change.path);
+      if (!match) return false;
+      if (change.afterDigest !== `${match[1]}${match[2]}`) {
+        throw new Error(`AUTHORITY_CANONICAL_PUBLICATION_CONTENT_ADDRESS_MISMATCH:path=${change.path};afterDigest=${change.afterDigest ?? "null"}`);
+      }
+      return true;
+    }).map((change) => change.path);
     return {
       commitSha: head,
       previousCommit: expectedPreviousHead,
       parentCommits,
-      physicalChanges
+      physicalChanges,
+      pipelineGeneratedPaths,
+      contentAddressedPaths
     };
   };
   return {
     currentHead,
-    inspectPublishedHead: async (expectedPreviousHead) => {
-      const evidence = await inspectPublication(expectedPreviousHead);
+    inspectPublishedHead: async (expectedPreviousHead, expectedOpIds) => {
+      const evidence = await inspectPublication(expectedPreviousHead, expectedOpIds);
       return { commitSha: evidence.commitSha, parentCommits: evidence.parentCommits };
     },
-    inspectPublication
+    inspectPublication,
+    findPublication: async (expectedOpIds) => {
+      const expectedSessionSubjectSuffix = `[${expectedOpIds.join(",")}]`;
+      const firstParentCommits = publicationGitText(rootDir, "rev-list", "--first-parent", "HEAD")
+        .split("\n")
+        .filter(Boolean);
+      const matches: CanonicalPublicationEvidence[] = [];
+      for (const commitSha of firstParentCommits) {
+        const parents = publicationGitText(rootDir, "rev-list", "--parents", "-n", "1", commitSha).split(" ").slice(1);
+        if (parents.length !== 2) continue;
+        const sessionSubject = publicationGitText(rootDir, "show", "-s", "--format=%s", parents[1]!);
+        if (!sessionSubject.endsWith(expectedSessionSubjectSuffix)) continue;
+        matches.push(await inspectPublication(parents[0]!, expectedOpIds, commitSha));
+      }
+      if (matches.length !== 1) {
+        throw new Error(
+          `AUTHORITY_CANONICAL_PUBLICATION_NOT_UNIQUE:expectedOpIds=${expectedOpIds.join(",")};matches=${matches.map((entry) => entry.commitSha).join(",") || "none"}`
+        );
+      }
+      return matches[0]!;
+    },
+    findPublicationForOperation: async (opId) => {
+      const firstParentCommits = publicationGitText(rootDir, "rev-list", "--first-parent", "HEAD")
+        .split("\n")
+        .filter(Boolean);
+      const matches: CanonicalPublicationEvidence[] = [];
+      for (const commitSha of firstParentCommits) {
+        const parents = publicationGitText(rootDir, "rev-list", "--parents", "-n", "1", commitSha).split(" ").slice(1);
+        if (parents.length !== 2) continue;
+        const sessionSubject = publicationGitText(rootDir, "show", "-s", "--format=%s", parents[1]!);
+        const opIds = commitSubjectOpIds(sessionSubject);
+        if (!opIds.includes(opId)) continue;
+        matches.push(await inspectPublication(parents[0]!, opIds, commitSha));
+      }
+      if (matches.length !== 1) {
+        throw new Error(
+          `AUTHORITY_CANONICAL_PUBLICATION_NOT_UNIQUE:expectedOpId=${opId};matches=${matches.map((entry) => entry.commitSha).join(",") || "none"}`
+        );
+      }
+      return matches[0]!;
+    }
   };
+}
+
+function commitSubjectOpIds(subject: string): ReadonlyArray<string> {
+  const match = /\[([^\]]+)\]$/u.exec(subject);
+  if (!match?.[1]) return [];
+  return match[1].split(",").filter(Boolean);
+}
+
+function publicationTopologyError(input: {
+  readonly expectedPreviousHead: string | null;
+  readonly expectedOpIds: ReadonlyArray<string>;
+  readonly head: string;
+  readonly parentCommits: ReadonlyArray<string>;
+  readonly sessionParents: ReadonlyArray<string>;
+  readonly mergeSubject: string;
+  readonly sessionSubject: string;
+  readonly mergeTreeMatchesSession: boolean;
+}): Error {
+  return new Error([
+    "AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR",
+    `expectedPreviousHead=${input.expectedPreviousHead ?? "null"}`,
+    `expectedOpIds=${input.expectedOpIds.join(",")}`,
+    `head=${input.head}`,
+    `actualParents=${input.parentCommits.join(",") || "none"}`,
+    `actualSessionParents=${input.sessionParents.join(",") || "none"}`,
+    `mergeSubject=${JSON.stringify(input.mergeSubject)}`,
+    `sessionSubject=${JSON.stringify(input.sessionSubject)}`,
+    `mergeTreeMatchesSession=${String(input.mergeTreeMatchesSession)}`
+  ].join(";"));
 }
 
 /** Fail closed unless every observed tree change is covered by the canonical registry mutation set. */
@@ -74,23 +201,46 @@ export function assertPublicationMatchesMutationSet(
       throw new Error(`AUTHORITY_PUBLICATION_ENTITY_UNAVAILABLE:${mutation.entity.entityKind}`);
     }
     const identity = registration.projectionFacet.resolveCanonicalRef(mutation.entity.canonicalRef);
-    return registration.storageLocator.locator.locate(identity, {}).targets
-      .filter((target): target is typeof target & { readonly path: string } => Boolean(target.path));
+    try {
+      return registration.storageLocator.locator.locate(identity, {}).targets
+        .filter((target): target is typeof target & { readonly path: string } => Boolean(target.path));
+    } catch (error) {
+      if (mutation.entity.entityKind === "relation"
+        && error instanceof Error
+        && error.message === "RELATION_STORAGE_SOURCE_REQUIRED") return [];
+      throw error;
+    }
   });
+  const permitsContentAddressedBlob = mutationSet.mutations.some((mutation) => mutation.entity.entityKind === "session");
+  const permitsTaskCreateAlias = mutationSet.mutations.some((mutation) =>
+    mutation.entity.entityKind === "task" && mutation.action.action === "create"
+  );
   if (evidence.physicalChanges.length === 0) throw new Error("AUTHORITY_PUBLICATION_TREE_EMPTY");
   for (const change of evidence.physicalChanges) {
-    if (!targets.some((target) => target.access === "exact"
-      ? change.path === target.path
-      : change.path === target.path || change.path.startsWith(`${target.path}/`))) {
+    if (evidence.pipelineGeneratedPaths.includes(change.path)) continue;
+    if (permitsContentAddressedBlob && evidence.contentAddressedPaths.includes(change.path)) continue;
+    if (!targets.some((target) => publicationChangeMatchesTarget(change.path, target, permitsTaskCreateAlias))) {
       throw new Error(`AUTHORITY_PUBLICATION_TREE_MISMATCH:${change.path}`);
     }
   }
   for (const target of targets) {
-    const observed = evidence.physicalChanges.some((change) => target.access === "exact"
-      ? change.path === target.path
-      : change.path === target.path || change.path.startsWith(`${target.path}/`));
+    const observed = evidence.physicalChanges.some((change) =>
+      publicationChangeMatchesTarget(change.path, target, permitsTaskCreateAlias)
+    );
     if (!observed) throw new Error(`AUTHORITY_PUBLICATION_DECLARED_PATH_MISSING:${target.path}`);
   }
+}
+
+function publicationChangeMatchesTarget(
+  changedPath: string,
+  target: { readonly path: string; readonly access: string },
+  permitsTaskCreateAlias: boolean
+): boolean {
+  if (target.access === "exact") return changedPath === target.path;
+  if (changedPath === target.path || changedPath.startsWith(`${target.path}/`)) return true;
+  if (!permitsTaskCreateAlias || !target.path.startsWith("tasks/")) return false;
+  const relative = changedPath.slice(target.path.length);
+  return /^-[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\//u.test(relative);
 }
 
 function blobDigest(rootDir: string, revision: string, changedPath: string): string | null {
@@ -119,6 +269,20 @@ function gitOptional(rootDir: string, ...args: ReadonlyArray<string>): string | 
 
 function publicationGitText(rootDir: string, ...args: ReadonlyArray<string>): string {
   return readAuthorityGitBytes(rootDir, ...args).toString("utf8").trim();
+}
+
+function gitExitCode(rootDir: string, ...args: ReadonlyArray<string>): number {
+  try {
+    execFileSync("git", ["-C", rootDir, ...args], {
+      stdio: "ignore",
+      windowsHide: true
+    });
+    return 0;
+  } catch (error) {
+    return typeof error === "object" && error !== null && "status" in error && typeof error.status === "number"
+      ? error.status
+      : 1;
+  }
 }
 
 /** Read-only Git observation shared by authority publication and cutover scanners. */

--- a/packages/cli/src/daemon/command-service.ts
+++ b/packages/cli/src/daemon/command-service.ts
@@ -10,6 +10,7 @@ import type { CurrentSessionRef, WriteCoordinator } from "../../../kernel/src/in
 import { cliError, CliErrorCode } from "../cli/error-codes.ts";
 import { toCommandReceipt, type CommandFailureReceipt, type CommandReceipt } from "../cli/receipt.ts";
 import type { ParsedCommand } from "../cli/types.ts";
+import { dryRunResult, isDryRunAction } from "../cli/dry-run-preview.ts";
 import { isPlainRecord } from "../cli/value-utils.ts";
 import { CliActorAttributionError, daemonActorAttributionForParsedCommand, migrationWriteAttribution } from "../composition/actor-attribution.ts";
 import { runRegisteredCommandWithCliComposition } from "../composition/command-executor.ts";
@@ -56,6 +57,9 @@ export function createCliCommandService(runtime: CliDaemonRuntime, options: CliC
           const report = await runtime.enqueueMaterializerBatch({ dryRun: parsedCommand.action.dryRun });
           return toCommandReceipt(materializerCommandResult(report));
         }
+        if (isDryRunAction(parsedCommand.action)) {
+          return toCommandReceipt(dryRunResult(parsedCommand.action));
+        }
         const attribution = daemonActor
           ? daemonActorAttributionForParsedCommand(daemonActor, parsedCommand, context?.executor)
           : undefined;
@@ -77,6 +81,7 @@ export function createCliCommandService(runtime: CliDaemonRuntime, options: CliC
             missingActorAttributionMessage: "Daemon writes require a per-request authenticated actor from harness/people.yaml."
           }),
           ...(currentSession ? { currentSession } : {}),
+          ...(authorityCoordinator ? { inlineCreateProvenanceOnly: true } : {}),
           syncExportedSession: (exported) => materializeExportedSessionEffect(runtime, exported),
           makeWriteCoordinator: (actor) => attribution
             ? authorityCoordinator

--- a/packages/cli/src/daemon/production-authority-attempt-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-attempt-compiler.ts
@@ -42,6 +42,7 @@ import {
   type DurableAuthorityBindingRuntimeV2
 } from "./authority-production-state.ts";
 import { productionLifecycleAttemptIntent } from "./production-authority-lifecycle-intents.ts";
+import { defaultCliAdapterProvider } from "../composition/adapter-registry.ts";
 
 type KeyMaterial = ReturnType<typeof openAuthorityProductionKeyMaterial>;
 
@@ -82,7 +83,11 @@ export function createProductionCanonicalAttemptCompiler(input: {
           "task lifecycle closeout commands, task-consent-record, or fact-invalidate"
         );
       }
-      if (canonicalEntityId !== intent.physicalEntityId) throw new Error("AUTHORITY_CANONICAL_ENTITY_MISMATCH");
+      if (canonicalEntityId !== intent.physicalEntityId) {
+        throw new Error(
+          `AUTHORITY_CANONICAL_ENTITY_MISMATCH:submittedEntityId=${canonicalEntityId};intentEntityId=${intent.physicalEntityId}`
+        );
+      }
       const executorAgentId = attribution.executor?.id ?? null;
       if (executorAgentId && !input.config.allowedExecutorAgentIds.includes(executorAgentId)
         && !executorDerivedFromPreset(command, executorAgentId)) {
@@ -195,6 +200,42 @@ async function canonicalAttemptIntent(
     executor: actor.executor,
     responsibleHuman: actor.principal.personId
   };
+  if (action.kind === "new-task" && action.taskId
+    && !action.fromLegacyId && !action.vertical && !action.preset && !action.profile
+    && !action.moduleKey && !action.registerModule) {
+    const provenance = {
+      runtime: currentSession.runtime,
+      sessionId: currentSession.sessionId,
+      boundAt: currentSession.detectedAt
+    };
+    const writes = defaultCliAdapterProvider().buildLocalTaskCreateWrites({
+      taskId: action.taskId,
+      title: action.title,
+      allowManualId: action.allowManualId,
+      slug: action.slug,
+      parent: action.parent,
+      workKind: action.workKind,
+      riskTier: action.riskTier,
+      urgency: action.urgency
+    }, currentSession.detectedAt, provenance);
+    const indexBody = writes.find((write) => write.path === "INDEX.md")!.body;
+    const entity = ref("task", `task/${action.taskId}`);
+    const payload: TaskDecisionModuleCommandPayloadV2 = {
+      schema: "task.create/v1",
+      taskId: action.taskId,
+      packageSlug: action.slug,
+      indexBody,
+      writes
+    };
+    return canonicalIntent(
+      "task.create",
+      encodeTaskDecisionModuleCommandPayloadV2(payload),
+      [{ entity, action: "create" }],
+      [entity],
+      writes.map((write) => `tasks/${action.taskId}/${write.path}`),
+      taskEntityId(action.taskId)
+    );
+  }
   if (action.kind === "progress-append") {
     const evidence = action.evidence?.map((entry) => `Evidence: ${entry.type}:${entry.path}:${entry.summary}`).join("\n");
     const payload: TaskDecisionModuleCommandPayloadV2 = {
@@ -319,7 +360,7 @@ async function canonicalAttemptIntent(
       body
     };
     const entity = ref("session", `session/${action.sessionId}`);
-    return canonicalIntent("session.export", encodeSessionExecutionReviewCommandPayloadV2(payload), [{ entity, action: "export" }], [entity], [`sessions/${action.sessionId}.md`, `objects/sha256/${digest.slice(0, 2)}/${digest.slice(2)}`], `session/${action.sessionId}`);
+    return canonicalIntent("session.export", encodeSessionExecutionReviewCommandPayloadV2(payload), [{ entity, action: "export" }], [entity], [`sessions/${action.sessionId}.md`, `objects/sha256/${digest.slice(0, 2)}/${digest.slice(2)}`], `entity/session/${action.sessionId}`);
   }
   if (action.kind === "task-claim" && action.executionId) {
     const executionId = action.executionId;

--- a/packages/cli/src/daemon/production-authority-lifecycle.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle.ts
@@ -51,6 +51,7 @@ import {
   type DurableAuthorityBindingRuntimeV2
 } from "./authority-production-state.ts";
 import { createGitCanonicalPublicationInspector } from "./authority-publication-evidence.ts";
+import { assertPublicationMatchesMutationSet } from "./authority-publication-evidence.ts";
 import { createAuthorityProductionScanner } from "./authority-production-scanner.ts";
 import { createProductionCompoundReceiptComposition } from "./compound-receipt-composition.ts";
 import { withProductionRecoveryV2 } from "./authority-attribution-event-v2-production-recovery.ts";
@@ -122,10 +123,29 @@ export function createProductionAuthorityLifecycle(input: {
           observe: async (request) => {
             const inspect = publicationObservers.get(repo.repoId);
             if (!inspect) throw new Error("AUTHORITY_PRODUCTION_PUBLICATION_OBSERVER_UNAVAILABLE");
-            const evidence = await inspect(request.previousCommit);
+            const changes = await state.replicaChangeLog.changesAfter(request.workspaceId, 0);
+            const expectedOpIds = changes
+              .filter((change) => change.commitSha === request.commitSha)
+              .sort((left, right) => left.revision - right.revision)
+              .map((change) => change.opId);
+            if (!expectedOpIds.includes(request.opId)) {
+              throw new Error(`AUTHORITY_PRODUCTION_PUBLICATION_OPERATION_MISSING:opId=${request.opId};commitSha=${request.commitSha}`);
+            }
+            const evidence = await inspect(request.previousCommit, expectedOpIds, request.commitSha);
             if (evidence.commitSha !== request.commitSha || evidence.previousCommit !== request.previousCommit) {
               throw new Error("AUTHORITY_PRODUCTION_PUBLICATION_OBSERVATION_MISMATCH");
             }
+            const mutationSets = await Promise.all(expectedOpIds.map(async (opId) => {
+              const record = await state.operationRegistry.get(request.workspaceId, opId);
+              if (!record?.authorityIntegrity) {
+                throw new Error(`AUTHORITY_PRODUCTION_PUBLICATION_INTEGRITY_MISSING:opId=${opId}`);
+              }
+              return record.authorityIntegrity.canonicalMutationSet;
+            }));
+            assertPublicationMatchesMutationSet(evidence, {
+              registryVersion: 1,
+              mutations: mutationSets.flatMap((mutationSet) => mutationSet.mutations)
+            });
             return { ...evidence, recordedAt: new Date().toISOString() };
           }
         }
@@ -153,14 +173,17 @@ export function createProductionAuthorityLifecycle(input: {
         rootDir: repo.canonicalRoot,
         ...(input.layoutOverrides ? { layoutOverrides: input.layoutOverrides } : {})
       }).authoredRoot;
-      publicationObservers.set(repo.repoId, async (previousCommit) => {
-        const inspector = createGitCanonicalPublicationInspector(authoredRoot);
-        return inspector.inspectPublication(previousCommit);
+      const publicationInspector = createGitCanonicalPublicationInspector(authoredRoot);
+      publicationObservers.set(repo.repoId, async (previousCommit, expectedOpIds, expectedCommitSha) => {
+        const inspector = publicationInspector;
+        return inspector.inspectPublication(previousCommit, expectedOpIds, expectedCommitSha);
       });
       await recoverPendingProductionEvents({
         workspaceId: config.workspaceId,
         operationRegistry: state.operationRegistry,
+        replicaChangeLog: state.replicaChangeLog,
         eventLog,
+        publicationInspector,
         recover: committedEventPublisher.recoverCommittedReceipt
       });
       return {
@@ -212,17 +235,67 @@ export function createProductionAuthorityLifecycle(input: {
 export async function recoverPendingProductionEvents(input: {
   readonly workspaceId: string;
   readonly operationRegistry: import("../../../application/src/index.ts").AuthorityOperationRegistry;
+  readonly replicaChangeLog: import("../../../application/src/index.ts").ReplicaChangeLog;
   readonly eventLog: ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>;
+  readonly publicationInspector: ReturnType<typeof createGitCanonicalPublicationInspector>;
   readonly recover: (record: import("../../../application/src/index.ts").AuthorityStoredOperationRecord) => Promise<import("../../../application/src/index.ts").AuthorityCommittedReceipt>;
 }): Promise<void> {
   const records = await input.operationRegistry.list(input.workspaceId);
-  for (const record of records) {
+  const pending = records.filter((record) => {
     if ((record.state !== "INDEXED" && record.state !== "INDETERMINATE")
       || record.recordedProtocol?.kind !== "semantic-mutation-envelope/v2"
-      || !record.commitSha || !record.authorityIntegrity || !record.canonicalRequestEnvelope
-      || input.eventLog.read(record.workspaceId, record.opId)) continue;
-    const receipt = await input.recover(record);
-    await input.operationRegistry.put({ ...record, state: "COMMITTED", receipt, commitSha: receipt.commitSha });
+      || !record.authorityIntegrity || !record.canonicalRequestEnvelope) return false;
+    return true;
+  });
+  let remaining = [...pending];
+  while (remaining.length > 0) {
+    let progressed = false;
+    const deferred: typeof remaining = [];
+    for (const record of remaining) {
+      try {
+        const evidence = await input.publicationInspector.findPublicationForOperation(record.opId);
+        if (record.commitSha && record.commitSha !== evidence.commitSha) {
+          throw new Error("AUTHORITY_V2_RECOVERY_COMMIT_MISMATCH");
+        }
+        assertPublicationMatchesMutationSet(evidence, record.authorityIntegrity!.canonicalMutationSet);
+        let change = await input.replicaChangeLog.getByOperation(record.workspaceId, record.opId);
+        if (!change) {
+          const latest = await input.replicaChangeLog.latest(record.workspaceId);
+          if ((latest?.commitSha ?? null) !== evidence.previousCommit) {
+            deferred.push(record);
+            continue;
+          }
+          change = {
+            schema: "replica-change/v1",
+            workspaceId: record.workspaceId,
+            revision: (latest?.revision ?? 0) + 1,
+            opId: record.opId,
+            semanticDigest: record.semanticDigest,
+            commitSha: evidence.commitSha,
+            previousCommit: evidence.previousCommit,
+            changedAt: new Date().toISOString(),
+            authorityIntegrity: record.authorityIntegrity
+          };
+          await input.replicaChangeLog.append(change);
+        }
+        if (change.commitSha !== evidence.commitSha
+          || change.previousCommit !== evidence.previousCommit
+          || change.semanticDigest !== record.semanticDigest
+          || change.authorityIntegrity?.semanticMutationSetDigest !== record.authorityIntegrity!.semanticMutationSetDigest) {
+          throw new Error("AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH");
+        }
+        const indexed = { ...record, state: "INDEXED" as const, commitSha: evidence.commitSha };
+        await input.operationRegistry.put(indexed);
+        const receipt = await input.recover(indexed);
+        await input.operationRegistry.put({ ...indexed, state: "COMMITTED", receipt, commitSha: receipt.commitSha });
+        progressed = true;
+      } catch {
+        // Fail closed: unverifiable historical effects remain indeterminate.
+        deferred.push(record);
+      }
+    }
+    if (!progressed) return;
+    remaining = deferred;
   }
 }
 

--- a/packages/cli/test/authority-lifecycle-seam.test.ts
+++ b/packages/cli/test/authority-lifecycle-seam.test.ts
@@ -241,9 +241,11 @@ test("restart-durable-recovery restores operation, replica, binding and namespac
 test("held-lock attributed factory gives one exact coordinator to a same-attribution microbatch", () => {
   let created = 0;
   let pending = 0;
+  let commitAuthor: { readonly name: string; readonly email: string } | undefined;
   const runtime: AuthorityLifecycleRuntime = {
-    createAttributedCoordinator: () => {
+    createAttributedCoordinator: (input) => {
       created += 1;
+      commitAuthor = input.commitAuthor;
       return {
         enqueue: (op) => Effect.sync(() => {
           pending += 1;
@@ -268,7 +270,49 @@ test("held-lock attributed factory gives one exact coordinator to a same-attribu
   const second = factory.create({ attribution, sessionId: "session-test" });
   assert.equal(first, second);
   assert.equal(created, 1);
+  assert.deepEqual(commitAuthor, {
+    name: "Harness Anything Authority",
+    email: "authority@harness-anything.local"
+  });
 });
+
+test("held-lock attributed factory preserves materializer error name and message", async () => {
+  const runtime: AuthorityLifecycleRuntime = {
+    createAttributedCoordinator: () => ({
+      enqueue: (op) => Effect.succeed({ opId: op.opId, entityId: op.entityId, accepted: true as const }),
+      flush: (reason) => Effect.succeed({ reason, opCount: 1, committed: true }),
+      recover: Effect.succeed({ replayedOps: 0 })
+    }),
+    enqueueMaterializerBatch: async () => { throw new Error("materializer unavailable"); },
+    assertWriteFenceHeld: async () => undefined
+  };
+  const coordinator = makeHeldLockAttributedCoordinatorFactory(runtime).create({
+    attribution: {
+      actor: { principal: { kind: "person", personId: "person_test" }, executor: null },
+      principalSource: { kind: "daemon-authenticated", providerId: "test", credentialFingerprint: "sha256:test" },
+      executorSource: "none"
+    },
+    sessionId: "session-test"
+  });
+
+  const result = await runEffect(Effect.either(coordinator.flush("explicit")));
+
+  assert.equal(result._tag, "Left");
+  if (result._tag === "Left") {
+    assert.deepEqual(result.left, {
+      _tag: "JournalUnavailable",
+      cause: { name: "Error", message: "materializer unavailable" }
+    });
+  }
+});
+
+function runEffect<A, E>(effect: Effect.Effect<A, E>): Promise<A> {
+  return new Promise((resolve, reject) => {
+    Effect.runCallback(effect, {
+      onExit: (exit) => exit._tag === "Success" ? resolve(exit.value) : reject(new Error(String(exit.cause)))
+    });
+  });
+}
 
 test("publication-tree-mismatch uses real Git trees and rejects paths outside the canonical mutation target", async () => {
   await withRoots(async ({ alphaRoot }) => {

--- a/packages/cli/test/authority-lifecycle-seam.test.ts
+++ b/packages/cli/test/authority-lifecycle-seam.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
+import { sha256Text } from "../../kernel/src/index.ts";
 import type { AuthorityOperationReceipt } from "../../application/src/index.ts";
 import {
   channelDigest32,
@@ -252,6 +253,9 @@ test("held-lock attributed factory gives one exact coordinator to a same-attribu
         recover: Effect.succeed({ replayedOps: 0 })
       };
     },
+    enqueueMaterializerBatch: async ({ sessionId }) => ({
+      branches: [{ branch: `sessions/${sessionId}`, commitCount: 1, status: "merged" as const }]
+    }),
     assertWriteFenceHeld: async () => undefined
   };
   const factory = makeHeldLockAttributedCoordinatorFactory(runtime);
@@ -274,12 +278,18 @@ test("publication-tree-mismatch uses real Git trees and rejects paths outside th
     git(alphaRoot, "add", ".");
     git(alphaRoot, "commit", "-q", "-m", "seed");
     const before = git(alphaRoot, "rev-parse", "HEAD");
+    const trunk = git(alphaRoot, "branch", "--show-current");
+    git(alphaRoot, "checkout", "-q", "-b", "sessions/session-test");
     writeFileSync(path.join(alphaRoot, "tasks", "task_T", "INDEX.md"), "after\n");
+    mkdirSync(path.join(alphaRoot, "attribution-events"), { recursive: true });
+    writeFileSync(path.join(alphaRoot, "attribution-events", `${sha256Text("op-test")}.jsonl`), "{}\n");
     git(alphaRoot, "add", ".");
-    git(alphaRoot, "commit", "-q", "-m", "update task");
+    git(alphaRoot, "commit", "-q", "-m", "test write [op-test]");
+    git(alphaRoot, "checkout", "-q", trunk);
+    git(alphaRoot, "merge", "-q", "--no-ff", "sessions/session-test", "-m", "materializer: merge session session-test");
 
     const inspector = createGitCanonicalPublicationInspector(alphaRoot);
-    const evidence = await inspector.inspectPublication(before);
+    const evidence = await inspector.inspectPublication(before, ["op-test"]);
     const mutationSet = {
       registryVersion: 1,
       mutations: [{
@@ -288,7 +298,10 @@ test("publication-tree-mismatch uses real Git trees and rejects paths outside th
       }]
     } as const;
     assertPublicationMatchesMutationSet(evidence, mutationSet);
-    assert.deepEqual(evidence.physicalChanges.map((change) => change.path), ["tasks/task_T/INDEX.md"]);
+    assert.deepEqual(evidence.physicalChanges.map((change) => change.path), [
+      "tasks/task_T/INDEX.md",
+      `attribution-events/${sha256Text("op-test")}.jsonl`
+    ]);
     assert.match(evidence.physicalChanges[0]!.beforeDigest ?? "", /^[a-f0-9]{64}$/u);
     assert.match(evidence.physicalChanges[0]!.afterDigest ?? "", /^[a-f0-9]{64}$/u);
 
@@ -301,6 +314,14 @@ test("publication-tree-mismatch uses real Git trees and rejects paths outside th
       }]
     };
     assert.throws(() => assertPublicationMatchesMutationSet(mismatched, mutationSet), /AUTHORITY_PUBLICATION_TREE_MISMATCH/u);
+
+    writeFileSync(path.join(alphaRoot, "outside.txt"), "unowned\n");
+    git(alphaRoot, "add", ".");
+    git(alphaRoot, "commit", "-q", "-m", "external canonical write");
+    await assert.rejects(
+      inspector.inspectPublication(evidence.commitSha, ["op-external"]),
+      /AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR;expectedPreviousHead=.*;expectedOpIds=op-external;head=.*;actualParents=/u
+    );
   });
 });
 
@@ -313,14 +334,20 @@ test("production composition reads publication evidence from the repo's real aut
     git(authoredRoot, "add", ".");
     git(authoredRoot, "commit", "-q", "-m", "seed authored tree");
     const before = git(authoredRoot, "rev-parse", "HEAD");
+    const trunk = git(authoredRoot, "branch", "--show-current");
+    git(authoredRoot, "checkout", "-q", "-b", "sessions/session-test");
     writeFileSync(path.join(authoredRoot, "tasks", "task_T", "INDEX.md"), "after\n");
+    mkdirSync(path.join(authoredRoot, "attribution-events"), { recursive: true });
+    writeFileSync(path.join(authoredRoot, "attribution-events", `${sha256Text("op-test")}.jsonl`), "{}\n");
     git(authoredRoot, "add", ".");
-    git(authoredRoot, "commit", "-q", "-m", "publish authored tree");
+    git(authoredRoot, "commit", "-q", "-m", "test write [op-test]");
+    git(authoredRoot, "checkout", "-q", trunk);
+    git(authoredRoot, "merge", "-q", "--no-ff", "sessions/session-test", "-m", "materializer: merge session session-test");
     let observed: ReadonlyArray<string> = [];
     const hooks: AuthorityRepoLifecycleHooks = {
       ...hooksFixture([]),
       start: async ({ repo, inspectPublication }) => {
-        observed = (await inspectPublication(before)).physicalChanges.map((change) => change.path);
+        observed = (await inspectPublication(before, ["op-test"])).physicalChanges.map((change) => change.path);
         return componentFixture(repo.repoId);
       }
     };
@@ -331,7 +358,10 @@ test("production composition reads publication evidence from the repo's real aut
     });
     const result = await controller.startRepo({ repoId: "alpha", canonicalRoot: alphaRoot }, runtimeFixture());
     assert.equal(result.ok, true, result.ok ? "" : result.error);
-    assert.deepEqual(observed, ["tasks/task_T/INDEX.md"]);
+    assert.deepEqual(observed, [
+      "tasks/task_T/INDEX.md",
+      `attribution-events/${sha256Text("op-test")}.jsonl`
+    ]);
     await controller.stopAll("daemon-shutdown");
   });
 });
@@ -493,6 +523,9 @@ function runtimeFixture(): AuthorityLifecycleRuntime {
       enqueue: (op) => Effect.succeed({ opId: op.opId, entityId: op.entityId, accepted: true as const }),
       flush: (reason) => Effect.succeed({ reason, opCount: 1, committed: true }),
       recover: Effect.succeed({ replayedOps: 0 })
+    }),
+    enqueueMaterializerBatch: async ({ sessionId }) => ({
+      branches: [{ branch: `sessions/${sessionId}`, commitCount: 1, status: "merged" as const }]
     }),
     assertWriteFenceHeld: async () => undefined
   };

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -14,32 +14,36 @@ import {
 import { createAuthorityKeyRegistryV1, firstPinAuthorityKeyV1 } from "../../../application/src/index.ts";
 import {
   decisionEntityId,
+  createTaskPackagePath,
   executionDeclaration,
-  makeJournaledWriteCoordinator,
   moduleEntityId,
   taskEntityId
 } from "../../../kernel/src/index.ts";
+import { defaultCliAdapterProvider } from "../../src/composition/adapter-registry.ts";
 import type { EntityId, ExecutionRecord } from "../../../kernel/src/index.ts";
 import type { ParsedCommand } from "../../src/cli/types.ts";
 import { daemonActorAttribution } from "../../src/composition/actor-attribution.ts";
+import { parseRecordArgs } from "../../src/cli/parsers/record.ts";
+import { parseNewTaskArgs } from "../../src/cli/parsers/new-task.ts";
+import { createCliCommandService } from "../../src/daemon/command-service.ts";
 import { authorityNamespaceProofBytes } from "../../src/daemon/authority-production-state.ts";
 import { createProductionAuthorityLifecycle } from "../../src/daemon/production-authority-lifecycle.ts";
 
 test("production canonical ingress accepts and journals one write for every canonical kind", async () => {
   const fixture = createFixture();
+  const daemon = defaultCliAdapterProvider().createMultiRepoDaemonRuntime({
+    repos: [{ repoId: "canonical", rootDir: fixture.repoRoot }],
+    materializerPollMs: 5,
+    materializerMaxBranchesPerBatch: 1
+  });
   try {
+    await daemon.start();
+    const runtime = daemon.getRepoRuntime("canonical");
+    assert.ok(runtime);
     const lifecycle = createProductionAuthorityLifecycle({ manifestPath: fixture.manifestPath });
     const started = await lifecycle.startRepo(
       { repoId: "canonical", canonicalRoot: fixture.repoRoot },
-      {
-        createAttributedCoordinator: ({ attribution }) => makeJournaledWriteCoordinator({
-          rootDir: fixture.repoRoot,
-          attribution,
-          commitAuthor: { name: "ZeyuLi", email: "33339424+FairladyZ625@users.noreply.github.com" },
-          autoMaterialize: false
-        }),
-        assertWriteFenceHeld: async () => undefined
-      }
+      runtime
     );
     assert.equal(started.ok, true, started.ok ? "" : started.error);
     if (!started.ok) return;
@@ -109,7 +113,7 @@ test("production canonical ingress accepts and journals one write for every cano
     }, {
       kind: "session",
       action: { kind: "session-export", sessionId: "session-ingress", runtime: "codex", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z", transcriptFile: fixture.transcriptPath },
-      canonicalEntityId: "session/session-ingress" as EntityId,
+      canonicalEntityId: "entity/session/session-ingress" as EntityId,
       authoredPath: "sessions/session-ingress.md",
       authoredMarker: /session-ingress/u
     }, {
@@ -210,14 +214,106 @@ test("production canonical ingress accepts and journals one write for every cano
         .trim().split("\n").filter(Boolean);
       assert.equal(eventFiles.some((eventPath) => readFileSync(eventPath, "utf8").includes(sessionId)), true, `${fixtureCase.kind}:real-session-axis`);
     }
+    const commandService = createCliCommandService(runtime, {
+      resolveAuthoritySubmissionV2: () => submission
+    });
+    const commandActor = { ...actor, roles: ["owner"] };
+    const runCommand = async (action: ParsedCommand["action"], sessionId: string) => commandService.runCommand({
+      command: { rootDir: fixture.repoRoot, json: true, action },
+      session: {
+        runtime: "codex",
+        sessionId,
+        source: "runtime",
+        detectedAt: "2026-07-17T00:10:00.000Z"
+      }
+    }, { actor: commandActor, executor: { kind: "agent", id: "codex" } });
+
+    const appendReceipt = await runCommand({
+      kind: "progress-append",
+      taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4",
+      text: "daemon command-service append",
+      dryRun: false
+    }, "smoke-progress");
+    assert.equal(appendReceipt.ok, true, `progress-append:${JSON.stringify(appendReceipt)}`);
+
+    const dryRunHead = git(fixture.authoredRoot, "rev-parse", "HEAD");
+    const dryRunReceipt = await runCommand({
+      kind: "progress-append",
+      taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4",
+      text: "must remain a preview",
+      dryRun: true
+    }, "smoke-dry-run");
+    assert.equal(dryRunReceipt.ok, true, `progress-append-dry-run:${JSON.stringify(dryRunReceipt)}`);
+    assert.equal(git(fixture.authoredRoot, "rev-parse", "HEAD"), dryRunHead, "dry-run must not create a commit");
+
+    const explicitFact = parseRecordArgs([
+      "fact", "record", "--task", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "--id", "F-ABCD1234",
+      "--statement", "Explicit fact id smoke.", "--source", "production smoke"
+    ], fixture.repoRoot, true);
+    assert.ok(explicitFact?.ok);
+    if (explicitFact?.ok) {
+      const receipt = await runCommand(explicitFact.value.action, "smoke-fact-explicit");
+      assert.equal(receipt.ok, true, `fact-explicit:${JSON.stringify(receipt)}`);
+    }
+    const generatedFact = parseRecordArgs([
+      "fact", "record", "--task", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4",
+      "--statement", "Generated fact id smoke.", "--source", "production smoke"
+    ], fixture.repoRoot, true);
+    assert.ok(generatedFact?.ok);
+    if (generatedFact?.ok) {
+      assert.match(generatedFact.value.action.kind === "record-fact" ? generatedFact.value.action.factId ?? "" : "", /^F-[0-9A-HJKMNP-TV-Z]{8}$/u);
+      const receipt = await runCommand(generatedFact.value.action, "smoke-fact-generated");
+      assert.equal(receipt.ok, true, `fact-generated:${JSON.stringify(receipt)}`);
+    }
+
+    const decisionReceipt = await runCommand({
+      kind: "decision-propose", decisionId: "dec_SMOKE", title: "Smoke decision",
+      question: "Does typed provenance remain single-op?", chosen: [{ text: "Yes." }],
+      rejected: [{ text: "No.", why_not: "The authority submission must remain entity-aligned." }],
+      claims: [{ text: "The command settled cleanly." }], claimLoadBearing: false, fulfillments: [],
+      riskTier: "low", urgency: "low", modules: [], productLines: [], evidenceRelations: [], dryRun: false
+    }, "smoke-decision");
+    assert.equal(decisionReceipt.ok, true, `decision-propose:${JSON.stringify(decisionReceipt)}`);
+
+    const sessionReceipt = await runCommand({
+      kind: "session-export", sessionId: "session-smoke-explicit", runtime: "codex", source: "manual",
+      detectedAt: "2026-07-17T00:10:00.000Z", transcriptFile: fixture.transcriptPath
+    }, "smoke-session-export");
+    assert.equal(sessionReceipt.ok, true, `session-export:${JSON.stringify(sessionReceipt)}`);
+
+    const createdTask = parseNewTaskArgs([
+      "task", "create", "--title", "Production task create smoke"
+    ], fixture.repoRoot, true);
+    assert.ok(createdTask?.ok);
+    if (createdTask?.ok) {
+      assert.match(createdTask.value.action.kind === "new-task" ? createdTask.value.action.taskId ?? "" : "", /^task_[0-9A-HJKMNP-TV-Z]{26}$/u);
+      const receipt = await runCommand(createdTask.value.action, "smoke-task-create");
+      assert.equal(receipt.ok, true, `task-create:${JSON.stringify(receipt)}`);
+      if (createdTask.value.action.kind === "new-task") {
+        const taskRoot = createTaskPackagePath(fixture.repoRoot, createdTask.value.action.taskId!, createdTask.value.action.slug);
+        assert.equal(existsSync(path.join(taskRoot, "INDEX.md")), true);
+        assert.equal(existsSync(path.join(taskRoot, "task-contract.json")), true);
+      }
+    }
     await assert.rejects(submission.submit({
       command: { rootDir: fixture.repoRoot, json: true, action: { kind: "help" } },
       attribution: daemonActorAttribution(actor, { kind: "agent", id: "codex" }),
       currentSession: { runtime: "codex", sessionId: "session-production", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z" },
       canonicalEntityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0")
     }), /AUTHORITY_TYPED_COMMAND_UNSUPPORTED.*task lifecycle closeout/u);
+    await assert.rejects(submission.submit({
+      command: {
+        rootDir: fixture.repoRoot,
+        json: true,
+        action: { kind: "progress-append", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", text: "entity mismatch evidence" }
+      },
+      attribution: daemonActorAttribution(actor, { kind: "agent", id: "codex" }),
+      currentSession: { runtime: "codex", sessionId: "session-mismatch", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z" },
+      canonicalEntityId: moduleEntityId("wrong-entity")
+    }), /AUTHORITY_CANONICAL_ENTITY_MISMATCH:submittedEntityId=module\/wrong-entity;intentEntityId=task\/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/u);
     await lifecycle.stopAll("daemon-shutdown");
   } finally {
+    await daemon.stop().catch(() => undefined);
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
@@ -256,7 +352,11 @@ function createFixture() {
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/executions"), { recursive: true });
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/executions/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5.md"), executionDeclaration.documentCodec.encode(submittedExecution));
   const transcriptPath = path.join(root, "session-transcript.md");
-  writeFileSync(transcriptPath, "# Production session ingress\n");
+  writeFileSync(transcriptPath, `${JSON.stringify({
+    timestamp: "2026-07-17T00:00:00.000Z",
+    type: "event_msg",
+    payload: { type: "user_message", message: "Production session ingress." }
+  })}\n`);
   writeFileSync(path.join(authoredRoot, "people.yaml"), [
     "schema: harness-people/v1", "people:", "  - personId: person_alice", "    displayName: Alice",
     "    primaryEmail: alice@example.test", "    roles: [owner]", "    credentials:",
@@ -334,7 +434,9 @@ function taskIndexBody(taskId: string): string {
     "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", "  status: active",
     "  ref: ", "  titleSnapshot: Production ingress", "  url: ",
     "  bindingCreatedAt: 2026-07-17T00:00:00.000Z", `  bindingFingerprint: sha256:${"b".repeat(64)}`,
-    "packageDisposition: active", "vertical: default", "preset: default", "---", "", "# Production ingress", ""
+    "packageDisposition: active", "vertical: default", "preset: default",
+    "provenance:", "  - {runtime: \"human\", sessionId: \"fixture\", boundAt: \"2026-07-17T00:00:00.000Z\"}",
+    "---", "", "# Production ingress", ""
   ].join("\n");
 }
 

--- a/packages/cli/test/production-authority-event-recovery.test.ts
+++ b/packages/cli/test/production-authority-event-recovery.test.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../application/src/index.ts";
 import type { makeLocalAuthorityAttributionEventV2Log } from "../../kernel/src/index.ts";
 import { recoverPendingProductionEvents } from "../src/daemon/production-authority-lifecycle.ts";
+import type { createGitCanonicalPublicationInspector } from "../src/daemon/authority-publication-evidence.ts";
 
 test("restart recovery publishes one missing event for a committed effect without reapplying it", async () => {
   const record: AuthorityStoredOperationRecord = {
@@ -30,7 +31,13 @@ test("restart recovery publishes one missing event for a committed effect withou
       semanticMutationSetDigest: "c".repeat(64),
       mutationRegistryVersion: 1,
       actorAxesBindingDigest: "d".repeat(64),
-      canonicalMutationSet: { registryVersion: 1, mutations: [] }
+      canonicalMutationSet: {
+        registryVersion: 1,
+        mutations: [{
+          entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task_RECOVERY" },
+          action: { registryVersion: 1, action: "append" }
+        }]
+      }
     },
     recordedProtocol: {
       kind: "semantic-mutation-envelope/v2",
@@ -50,6 +57,20 @@ test("restart recovery publishes one missing event for a committed effect withou
     list: async () => [durable],
     put: async (next) => { durable = next; }
   };
+  let change: import("../../application/src/index.ts").ReplicaChangeRecord | undefined;
+  const replicaChangeLog: import("../../application/src/index.ts").ReplicaChangeLog = {
+    append: async (next) => { change = next; },
+    latest: async () => change,
+    getByOperation: async () => change,
+    changesAfter: async () => change ? [change] : []
+  };
+  const publicationInspector = {
+    currentHead: async () => "b".repeat(40),
+    inspectPublishedHead: async () => ({ commitSha: "b".repeat(40), parentCommits: ["a".repeat(40), "c".repeat(40)] }),
+    inspectPublication: async () => publicationEvidence(),
+    findPublication: async () => publicationEvidence(),
+    findPublicationForOperation: async () => publicationEvidence()
+  } as ReturnType<typeof createGitCanonicalPublicationInspector>;
   const eventLog = {
     read: () => eventPresent
       ? { workspaceId: record.workspaceId, opId: record.opId }
@@ -73,10 +94,10 @@ test("restart recovery publishes one missing event for a committed effect withou
   };
 
   await recoverPendingProductionEvents({
-    workspaceId: record.workspaceId, operationRegistry, eventLog, recover
+    workspaceId: record.workspaceId, operationRegistry, replicaChangeLog, eventLog, publicationInspector, recover
   });
   await recoverPendingProductionEvents({
-    workspaceId: record.workspaceId, operationRegistry, eventLog, recover
+    workspaceId: record.workspaceId, operationRegistry, replicaChangeLog, eventLog, publicationInspector, recover
   });
 
   assert.equal(publicationCount, 1);
@@ -84,3 +105,18 @@ test("restart recovery publishes one missing event for a committed effect withou
   assert.equal(durable.state, "COMMITTED");
   assert.deepEqual(durable.receipt, receipt);
 });
+
+function publicationEvidence() {
+  return {
+    commitSha: "b".repeat(40),
+    previousCommit: null,
+    parentCommits: ["a".repeat(40), "c".repeat(40)],
+    pipelineGeneratedPaths: [],
+    contentAddressedPaths: [],
+    physicalChanges: [{
+      path: "tasks/task_RECOVERY/progress.md",
+      beforeDigest: null,
+      afterDigest: "1".repeat(64)
+    }]
+  };
+}

--- a/packages/cli/test/production-authority-lifecycle.test.ts
+++ b/packages/cli/test/production-authority-lifecycle.test.ts
@@ -6,7 +6,6 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { Effect } from "effect";
 import {
   createAuthorityCutoverEntityRegistryQualification,
   createAuthorityCutoverControlService,
@@ -20,7 +19,13 @@ import {
   connectionGeneration,
   openLocalAuthorityKeyStore
 } from "../../daemon/src/index.ts";
-import { entityRegistry, entityRegistryKinds, taskEntityId, type WriteOp } from "../../kernel/src/index.ts";
+import {
+  entityRegistry,
+  entityRegistryKinds,
+  makeJournaledWriteCoordinator,
+  taskEntityId
+} from "../../kernel/src/index.ts";
+import { defaultCliAdapterProvider } from "../src/composition/adapter-registry.ts";
 import { daemonActorAttribution } from "../src/composition/actor-attribution.ts";
 import {
   authorityNamespaceProofBytes,
@@ -574,26 +579,12 @@ function productionTuple() {
 }
 
 function writerRuntime(authoredRoot: string) {
+  const repoRoot = path.dirname(authoredRoot);
   return {
-    createAttributedCoordinator: () => {
-      let pending: WriteOp | undefined;
-      return {
-        enqueue: (operation: WriteOp) => Effect.sync(() => {
-          pending = operation;
-          return { opId: operation.opId, entityId: operation.entityId, accepted: true as const };
-        }),
-        flush: (reason: "debounce" | "count" | "explicit" | "shutdown" | "recovery") => Effect.sync(() => {
-          if (!pending) return { reason, opCount: 0, committed: false };
-          const payload = pending.payload as { readonly append: string };
-          const progressPath = path.join(authoredRoot, "tasks/task_A/progress.md");
-          writeFileSync(progressPath, payload.append, { flag: "a" });
-          git(authoredRoot, "add", "tasks/task_A/progress.md");
-          git(authoredRoot, "commit", "-q", "-m", "append progress through authority");
-          return { reason, opCount: 1, committed: true, watermark: git(authoredRoot, "rev-parse", "HEAD") };
-        }),
-        recover: Effect.succeed({ replayedOps: 0 })
-      };
-    },
+    createAttributedCoordinator: (input: Omit<Parameters<typeof makeJournaledWriteCoordinator>[0], "rootDir">) =>
+      makeJournaledWriteCoordinator({ ...input, rootDir: repoRoot, autoMaterialize: false }),
+    enqueueMaterializerBatch: async ({ sessionId }: { readonly sessionId: string }) =>
+      defaultCliAdapterProvider().runLedgerMaterializer(repoRoot, { sessionId }),
     assertWriteFenceHeld: async () => undefined
   };
 }

--- a/packages/kernel/src/ports/version-control-system.ts
+++ b/packages/kernel/src/ports/version-control-system.ts
@@ -21,7 +21,7 @@ export interface VersionControlSystem {
   readonly pathExistsAtCommit: (repoRoot: string, sha: string, relativePath: string) => boolean;
   readonly checkout: (repoRoot: string, ref: string) => void;
   readonly createBranch: (repoRoot: string, branch: string) => void;
-  readonly mergeNoFf: (repoRoot: string, branch: string, message: string) => void;
+  readonly mergeNoFf: (repoRoot: string, branch: string, message: string, author?: VcsCommitAuthor) => void;
   readonly conflictedFiles: (repoRoot: string) => ReadonlyArray<string>;
   readonly readConflictStage: (repoRoot: string, stage: 2 | 3, relativePath: string) => Uint8Array | null;
   readonly checkoutConflictSide: (repoRoot: string, side: "ours" | "theirs", paths: ReadonlyArray<string>) => void;

--- a/packages/kernel/src/store/daemon-runtime.ts
+++ b/packages/kernel/src/store/daemon-runtime.ts
@@ -91,6 +91,7 @@ export interface HarnessDaemonRuntime {
   readonly createAttributedCoordinator: (input: {
     readonly attribution: WriteAttribution;
     readonly sessionId: string;
+    readonly commitAuthor?: InteractiveWriteRequest["commitAuthor"];
   }) => WriteCoordinator;
   readonly assertWriteFenceHeld: () => Promise<void>;
   readonly admissionBudget: DaemonAdmissionBudget;

--- a/packages/kernel/src/store/ledger-materializer-machine-recovery.ts
+++ b/packages/kernel/src/store/ledger-materializer-machine-recovery.ts
@@ -12,7 +12,7 @@ export type MachineArtifactRecoveryResult =
   | { readonly recovered: true; readonly artifacts: ReadonlyArray<PreservedMachineArtifact> }
   | { readonly recovered: false; readonly conflictPaths: ReadonlyArray<string> };
 
-const materializerCommitter = {
+export const materializerCommitter = {
   name: "Harness Anything Materializer",
   email: "materializer@harness-anything.local"
 } as const;

--- a/packages/kernel/src/store/ledger-materializer.ts
+++ b/packages/kernel/src/store/ledger-materializer.ts
@@ -8,6 +8,7 @@ import { rebuildTaskProjection } from "../projection/sqlite-task-projection.ts";
 import { captureAuthoredProjectionFingerprint } from "../projection/projection-source-baseline.ts";
 import { makeLocalVersionControlSystem } from "./local-version-control-system.ts";
 import {
+  materializerCommitter,
   recoverScriptIngestArtifactConflicts,
   type PreservedMachineArtifact
 } from "./ledger-materializer-machine-recovery.ts";
@@ -126,7 +127,7 @@ function materializeBranches(
     const beforeMergeHead = vcs.currentHead(repoRoot);
     let preservedArtifacts: ReadonlyArray<PreservedMachineArtifact> = [];
     try {
-      vcs.mergeNoFf(repoRoot, branch, mergeMessage);
+      vcs.mergeNoFf(repoRoot, branch, mergeMessage, materializerCommitter);
     } catch (error) {
       let conflictPaths: ReadonlyArray<string>;
       let recoveryError: unknown;

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -83,8 +83,8 @@ export function makeLocalVersionControlSystem(): VersionControlSystem {
     createBranch: (repoRoot, branch) => {
       runGit(repoRoot, "branch", branch);
     },
-    mergeNoFf: (repoRoot, branch, message) => {
-      runGit(repoRoot, "merge", "--no-ff", branch, "-m", message);
+    mergeNoFf: (repoRoot, branch, message, author) => {
+      runGitAs(repoRoot, author, "merge", "--no-ff", branch, "-m", message);
     },
     conflictedFiles: (repoRoot) => runGit(repoRoot, "diff", "--name-only", "--diff-filter=U", "-z")
       .split("\0")

--- a/packages/kernel/test/store/ledger-materializer.test.ts
+++ b/packages/kernel/test/store/ledger-materializer.test.ts
@@ -57,6 +57,10 @@ test("ledger materializer dry-runs and merges pending session branches", () => {
     assert.equal(readGitFile(rootDir, "tasks/task-2/note.md"), "materialized write\n");
     assert.equal(merged.attributionEventsProjected, 1);
     assert.equal(readAttributionProjection(rootDir)[0]?.opId, "op-materialize");
+    assert.equal(
+      git(rootDir, "show", "-s", "--format=%an <%ae>", "HEAD"),
+      "Harness Anything Materializer <materializer@harness-anything.local>"
+    );
   });
 });
 


### PR DESCRIPTION
# English

## Summary

Forward fix for the W6 second freeze (defects D6–D9): production authority publication proof now models the daemon's real write topology (session commit + materializer merge), dry-run stops before canonical ingress, provenance sub-writes align with their submission intent, and INDETERMINATE residuals become recoverable.

## What Changed

- **D6 (root cause)**: publication proof accepts exactly the daemon's own write+materialize pipeline — two-parent merge whose first parent is the pre-write canonical HEAD, second parent a single session commit off that same HEAD, exact materializer subject, session subject carrying the ordered authority op batch, merge tree equal to session tree, and changed paths matching canonical mutation storage targets. Authority flush synchronously materializes the session before proof. External linear commits and out-of-rule paths are rejected (fail-closed preserved).
- **D7**: `--dry-run` short-circuits before canonical ingress; zero mutation, zero commit.
- **D8**: provenance session-export sub-write is inlined into the typed path so every authority submission's intent matches its actual ops; `fact record` without `--id` now generates the fact ID inside the typed path (same ID in intent and physical write).
- **D9**: startup recovery re-proves INDEXED/INDETERMINATE records against the strict topology, appends the missing replica change exactly once, republishes the durable V2 event, and persists COMMITTED only with a complete receipt.
- NON_LINEAR / entity-mismatch errors now carry evidence fields (expected/actual heads, parents, subjects, entity IDs).

## Task And Scope

- Scope: `packages/application/src/authority/*`, `packages/cli/src/daemon/*` (lifecycle, publication evidence, attempt compiler, command service), `packages/cli/src/composition/command-executor.ts`, `packages/adapters/local`. Existing registered tests extended; no new test files, no test-tier changes.
- Production state under `~/.harness/authority/**` untouched; deployment, daemon restart, and re-enable are operator actions after merge.

## Version Impact

- No published package version change.

## Governance Declaration

- Authority anchor: W6 cutover line task_01KXMN5BRWQH93976XBZSHSCN4 (ProdCutover line-S); defect evidence in `harness/tasks/.../line-S/w6-second-freeze-2026-07-17.md`; standing W6 fix-then-cut authorization.
- Protected paths touched: none (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `tools/test-tier-manifest.mjs`, `harness/**` untouched).
- No gate weakening; proof strictness increased, all rejections remain fail-closed.

## Verification

- Root `npm run check:local` exit 0 (248 fast tests pass plus affected contract lanes) on base f31fb2d7 (latest `origin/main`).
- Canonical ingress smoke on the real daemon composition (`createMultiRepoDaemonRuntime` + production lifecycle + real materializer merge): 1/1 pass, asserting non-dry-run clean COMMITTED receipt, dry-run HEAD-unchanged, fact record with and without `--id`, decision propose, session export with explicit transcript, task create, and all nine canonical entity kinds COMMITTED.
- Negative case rejects an external linear canonical commit with NON_LINEAR evidence fields; recovery regression runs twice with exactly one event publication. Hermetic identity run 15/15.

## Review Evidence

- CEO semantic acceptance against the mission invariants: proof accepts exactly the daemon pipeline topology and nothing else; dry-run zero-commit; intent/op same-origin per submission; D9 exactly-once recovery — all confirmed in the diff and test assertions.
- The #865 lesson is addressed structurally: the regression fixture now runs the real materializer merge topology instead of a linear stand-in.

## Residual Risk

- The two real production INDETERMINATE ops (commits `4e984a7ed` / `5f676119d`) transition to COMMITTED only after deploy + daemon restart; unverified until the operator re-enable sequence runs.
- Preset-aware task create remains fail-closed at typed production ingress (default local task package is the verified path); preset payload modeling is follow-up work.
- Historical recovery scans first-parent history linearly; acceptable now, may warrant indexing on very large ledgers.

## References

- `harness/tasks/task_01KXMN5BRWQH93976XBZSHSCN4-prodcutover-s-sme-tw-a1-4-island-w6-cutover/artifacts/line-S/w6-second-freeze-2026-07-17.md` (D6–D9 evidence).
- PR #865 (first forward-fix wave, D0–D5); freeze receipt `freeze_e3af3d58facbe5c2bc34e0b6`.

---

# 中文

## 概要

W6 二度冻结（缺陷 D6–D9）的 forward fix：生产 authority publication proof 改为建模 daemon 真实写拓扑（session commit + materializer merge），dry-run 在进 canonical ingress 前短路，provenance 子写与其 submission intent 对齐，INDETERMINATE 残账可恢复。

## 改动内容

- **D6（根因）**：publication proof 只接受 daemon 自己的 write+materialize 流水线——双亲 merge 且第一亲为写前 canonical HEAD、第二亲为同一 HEAD 出来的单个 session commit、materializer subject 精确匹配、session subject 携带有序 authority op batch、merge tree 等于 session tree、变更路径匹配 canonical mutation 存储目标。authority flush 在 proof 前同步物化 session。外部线性 commit 与规则外路径一律拒绝（fail-closed 不削弱）。
- **D7**：`--dry-run` 在 canonical ingress 前短路；零 mutation、零 commit。
- **D8**：provenance 的 session-export 子写内联进 typed 路径，每个 authority submission 的 intent 与实际 op 同源；`fact record` 不带 `--id` 时在 typed 路径内生成 fact ID（intent 与物理写同一 ID）。
- **D9**：启动恢复按严格拓扑重证 INDEXED/INDETERMINATE 记录，恰一次补 replica change，重发 durable V2 event，仅在完整回执可得时落 COMMITTED。
- NON_LINEAR / entity-mismatch 错误带上证据字段（期望/实际 head、parents、subjects、两侧 entity id）。

## 任务与范围

- 范围：`packages/application/src/authority/*`、`packages/cli/src/daemon/*`（lifecycle、publication evidence、attempt compiler、command service）、`packages/cli/src/composition/command-executor.ts`、`packages/adapters/local`。扩展既有已注册测试；无新测试文件、不动 test-tier。
- 生产状态 `~/.harness/authority/**` 未触碰；部署、daemon 重启与 re-enable 是合并后的 operator 动作。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 授权锚：W6 cutover 线 task_01KXMN5BRWQH93976XBZSHSCN4（ProdCutover line-S）；缺陷实证在 `harness/tasks/.../line-S/w6-second-freeze-2026-07-17.md`；W6 修完即 cut 常设授权。
- 触碰的 protected 路径：无（`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`tools/test-tier-manifest.mjs`、`harness/**` 均未动）。
- 无削 gate；proof 严格性提高，所有拒绝路径保持 fail-closed。

## 验证

- 根 `npm run check:local` exit 0（248 fast 测试通过及受影响 contract lanes），基线 f31fb2d7（最新 `origin/main`）。
- 真实 daemon 组合（`createMultiRepoDaemonRuntime` + production lifecycle + 真实 materializer merge）上的 canonical ingress 冒烟 1/1 通过，断言：非 dry-run 干净 COMMITTED 回执、dry-run HEAD 不动、fact record 带/不带 `--id`、decision propose、session export 显式 transcript、task create、九种 canonical entity kind 全部 COMMITTED。
- 负向用例拒绝外部线性 canonical commit 并断言 NON_LINEAR 证据字段；恢复回归跑两遍恰一次 event 发布。hermetic 身份跑 15/15。

## 审查证据

- CEO 按 mission 不变量语义验收：proof 恰好接受 daemon 流水线拓扑并拒绝其外一切；dry-run 零 commit；每 submission intent 与 op 同源；D9 恰一次恢复——均在 diff 与测试断言中确认。
- #865 的教训已结构性解决：回归夹具改跑真实 materializer merge 拓扑，不再用线性替身。

## 残余风险

- 生产两笔真实 INDETERMINATE op（commit `4e984a7ed` / `5f676119d`）须部署+daemon 重启后才转 COMMITTED；operator re-enable 序列跑完前为 unverified。
- preset 感知的 task create 在 typed 生产 ingress 保持 fail-closed（已验证路径为默认 local task package）；preset payload 建模为后续工作。
- 历史恢复线性扫 first-parent history；当前可接受，超大台账未来或需索引。

## 关联材料

- `harness/tasks/task_01KXMN5BRWQH93976XBZSHSCN4-prodcutover-s-sme-tw-a1-4-island-w6-cutover/artifacts/line-S/w6-second-freeze-2026-07-17.md`（D6–D9 实证）。
- PR #865（第一波 forward-fix，D0–D5）；freeze receipt `freeze_e3af3d58facbe5c2bc34e0b6`。
