### PR TITLE
fix: preserve authority dry-run and task package proof (W6 D10-D11)

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,2 @@
+Fixed the production canonical-ingress feedback loop to override inherited `HARNESS_DAEMON_MODE=direct` with daemon-backed `local` for its CLI client subprocesses.
+Verified the simulated CI regression test (2/2 pass) and root `check:local` (exit 0); no runner or unrelated test environment semantics changed.

--- a/packages/cli/src/cli/command-spec/command-spec-core.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-core.ts
@@ -211,8 +211,8 @@ export const coreCommandSpecs = defineCommandSpecs([
   },
   {
     "kind": "progress-append",
-    "usage": "task progress append <id> --text <text> [--evidence type:PATH:summary]...",
-    "options": [{"flag":"--text","description":"Progress text appended as-is (no Markdown formatting or normalization)."},{"flag":"--evidence","description":"Attach evidence in type:path:summary format; repeat for multiple entries."}],
+    "usage": "task progress append <id> --text <text> [--evidence type:PATH:summary]... [--dry-run]",
+    "options": [{"flag":"--text","description":"Progress text appended as-is (no Markdown formatting or normalization)."},{"flag":"--evidence","description":"Attach evidence in type:path:summary format; repeat for multiple entries."},{"flag":"--dry-run","description":"Preview the append without entering canonical authority ingress or writing files."}],
     "summary": "Append the provided text as-is to a task package, with optional repeatable evidence; no Markdown formatting or normalization is applied.",
     "examples": ["harness-anything task progress append task_01ABC --text \"Implemented parser guard\" --evidence log:artifacts/check.log:passed"],
     "parse": parseCoreTaskArgs,

--- a/packages/cli/src/cli/parsers/core-task.ts
+++ b/packages/cli/src/cli/parsers/core-task.ts
@@ -84,7 +84,8 @@ function parseProgressAppend(args: ReadonlyArray<string>, rootDir: string, json:
     kind: "progress-append",
     taskId: args[3],
     text,
-    evidence: evidence.value
+    evidence: evidence.value,
+    dryRun: args.includes("--dry-run")
   });
 }
 

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -219,7 +219,7 @@ export interface ParsedCommand {
     | { readonly kind: "task-holder"; readonly taskId: string }
     | { readonly kind: "task-release"; readonly taskId: string }
     | { readonly kind: "status-set"; readonly taskId: string; readonly status: DomainStatus; readonly force: boolean; readonly reason?: string; readonly executionSubmission?: { readonly executionId?: string; readonly leaseToken?: string; readonly completionClaim: string; readonly deliverables: ReadonlyArray<string>; readonly verificationNotes: ReadonlyArray<string>; readonly knownGaps: ReadonlyArray<string>; readonly residualRisks: ReadonlyArray<string>; readonly outputs: ReadonlyArray<string> } }
-    | { readonly kind: "progress-append"; readonly taskId: string; readonly text: string; readonly evidence?: ReadonlyArray<EvidenceAppendInput> }
+    | { readonly kind: "progress-append"; readonly taskId: string; readonly text: string; readonly evidence?: ReadonlyArray<EvidenceAppendInput>; readonly dryRun: boolean }
     | { readonly kind: "task-amend"; readonly taskId: string; readonly patches: ReadonlyArray<{ readonly field: string; readonly value: string }> }
     | { readonly kind: "task-contract-migrate"; readonly mode: "dry-run" | "apply"; readonly taskId?: string }
     | { readonly kind: "task-archive"; readonly taskId?: string; readonly ids?: ReadonlyArray<string>; readonly filter?: string; readonly before?: string; readonly reason: string; readonly archivedBy?: string; readonly archiveField?: string }

--- a/packages/cli/src/daemon/authority-publication-evidence.ts
+++ b/packages/cli/src/daemon/authority-publication-evidence.ts
@@ -212,20 +212,18 @@ export function assertPublicationMatchesMutationSet(
     }
   });
   const permitsContentAddressedBlob = mutationSet.mutations.some((mutation) => mutation.entity.entityKind === "session");
-  const permitsTaskCreateAlias = mutationSet.mutations.some((mutation) =>
-    mutation.entity.entityKind === "task" && mutation.action.action === "create"
-  );
+  const permitsTaskPackageAlias = targets.some((target) => target.path.startsWith("tasks/"));
   if (evidence.physicalChanges.length === 0) throw new Error("AUTHORITY_PUBLICATION_TREE_EMPTY");
   for (const change of evidence.physicalChanges) {
     if (evidence.pipelineGeneratedPaths.includes(change.path)) continue;
     if (permitsContentAddressedBlob && evidence.contentAddressedPaths.includes(change.path)) continue;
-    if (!targets.some((target) => publicationChangeMatchesTarget(change.path, target, permitsTaskCreateAlias))) {
-      throw new Error(`AUTHORITY_PUBLICATION_TREE_MISMATCH:${change.path}`);
+    if (!targets.some((target) => publicationChangeMatchesTarget(change.path, target, permitsTaskPackageAlias))) {
+      throw publicationTreeMismatchError(change.path, targets, evidence.physicalChanges, permitsTaskPackageAlias);
     }
   }
   for (const target of targets) {
     const observed = evidence.physicalChanges.some((change) =>
-      publicationChangeMatchesTarget(change.path, target, permitsTaskCreateAlias)
+      publicationChangeMatchesTarget(change.path, target, permitsTaskPackageAlias)
     );
     if (!observed) throw new Error(`AUTHORITY_PUBLICATION_DECLARED_PATH_MISSING:${target.path}`);
   }
@@ -234,13 +232,36 @@ export function assertPublicationMatchesMutationSet(
 function publicationChangeMatchesTarget(
   changedPath: string,
   target: { readonly path: string; readonly access: string },
-  permitsTaskCreateAlias: boolean
+  permitsTaskPackageAlias: boolean
 ): boolean {
-  if (target.access === "exact") return changedPath === target.path;
-  if (changedPath === target.path || changedPath.startsWith(`${target.path}/`)) return true;
-  if (!permitsTaskCreateAlias || !target.path.startsWith("tasks/")) return false;
-  const relative = changedPath.slice(target.path.length);
-  return /^-[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\//u.test(relative);
+  if (changedPath === target.path) return true;
+  if (target.access !== "exact" && changedPath.startsWith(`${target.path}/`)) return true;
+  if (!permitsTaskPackageAlias || !target.path.startsWith("tasks/")) return false;
+  const targetMatch = /^(tasks\/[^/]+)(\/.*)?$/u.exec(target.path);
+  const changedMatch = /^(tasks\/[^/]+)(\/.*)?$/u.exec(changedPath);
+  if (!targetMatch?.[1] || !changedMatch?.[1]) return false;
+  if (!changedMatch[1].startsWith(`${targetMatch[1]}-`)) return false;
+  const slug = changedMatch[1].slice(targetMatch[1].length);
+  if (!/^-[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/u.test(slug)) return false;
+  const targetSuffix = targetMatch[2] ?? "";
+  const changedSuffix = changedMatch[2] ?? "";
+  return target.access === "exact"
+    ? changedSuffix === targetSuffix
+    : changedSuffix === targetSuffix || changedSuffix.startsWith(`${targetSuffix}/`);
+}
+
+function publicationTreeMismatchError(
+  changedPath: string,
+  targets: ReadonlyArray<{ readonly path: string; readonly access: string }>,
+  physicalChanges: ReadonlyArray<PhysicalChangeV2>,
+  taskPackageAliasAllowed: boolean
+): Error {
+  return new Error([
+    `AUTHORITY_PUBLICATION_TREE_MISMATCH:${changedPath}`,
+    `expectedTargets=${targets.map((target) => `${target.access}:${target.path}`).join(",") || "none"}`,
+    `observedPaths=${physicalChanges.map((change) => change.path).join(",") || "none"}`,
+    `taskPackageAliasAllowed=${String(taskPackageAliasAllowed)}`
+  ].join(";"));
 }
 
 function blobDigest(rootDir: string, revision: string, changedPath: string): string | null {

--- a/packages/cli/test/authority-lifecycle-seam.test.ts
+++ b/packages/cli/test/authority-lifecycle-seam.test.ts
@@ -357,7 +357,10 @@ test("publication-tree-mismatch uses real Git trees and rejects paths outside th
         afterDigest: "22".repeat(32)
       }]
     };
-    assert.throws(() => assertPublicationMatchesMutationSet(mismatched, mutationSet), /AUTHORITY_PUBLICATION_TREE_MISMATCH/u);
+    assert.throws(
+      () => assertPublicationMatchesMutationSet(mismatched, mutationSet),
+      /AUTHORITY_PUBLICATION_TREE_MISMATCH:private\/outside\.txt;expectedTargets=.*;observedPaths=.*private\/outside\.txt;taskPackageAliasAllowed=true/u
+    );
 
     writeFileSync(path.join(alphaRoot, "outside.txt"), "unowned\n");
     git(alphaRoot, "add", ".");

--- a/packages/cli/test/daemon-lease-executor-cli.test.ts
+++ b/packages/cli/test/daemon-lease-executor-cli.test.ts
@@ -46,7 +46,7 @@ test("forced-command progress writes preserve the thin-client executor in the ta
           command: {
             rootDir,
             json: true,
-            action: { kind: "progress-append", taskId, text: "refresh lease", evidence: [] }
+            action: { kind: "progress-append", taskId, text: "refresh lease", evidence: [], dryRun: false }
           },
           executor: codex
         }

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { sign } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -17,6 +17,7 @@ import {
   createTaskPackagePath,
   executionDeclaration,
   moduleEntityId,
+  sha256Text,
   taskEntityId
 } from "../../../kernel/src/index.ts";
 import { defaultCliAdapterProvider } from "../../src/composition/adapter-registry.ts";
@@ -27,7 +28,93 @@ import { parseRecordArgs } from "../../src/cli/parsers/record.ts";
 import { parseNewTaskArgs } from "../../src/cli/parsers/new-task.ts";
 import { createCliCommandService } from "../../src/daemon/command-service.ts";
 import { authorityNamespaceProofBytes } from "../../src/daemon/authority-production-state.ts";
+import { createGitCanonicalPublicationInspector } from "../../src/daemon/authority-publication-evidence.ts";
 import { createProductionAuthorityLifecycle } from "../../src/daemon/production-authority-lifecycle.ts";
+import {
+  defaultDaemonUserRoot,
+  pollUntil,
+  runDaemonCommand,
+  runRawJsonMaybeFail,
+  stopDaemon
+} from "../helpers/daemon-cli.ts";
+
+test("production service route preserves progress dry-run and publishes a slugged task append", { timeout: 30_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const env = {
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"
+  };
+  try {
+    for (const [repoId, canonicalRoot] of [
+      ["canonical", fixture.repoRoot],
+      ["auxiliary", fixture.auxiliaryRoot]
+    ] as const) {
+      const registered = runDaemonCommand(fixture.repoRoot, [
+        "daemon", "repo", "register", "--repo-id", repoId, "--canonical-root", canonicalRoot,
+        "--user-root", userRoot, "--no-link", "--json"
+      ], env);
+      assert.equal(registered.ok, true, JSON.stringify(registered));
+    }
+    try {
+      runDaemonCommand(fixture.repoRoot, [
+        "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+      ], env);
+    } catch {
+      // Production authority startup can outlive the command's fixed six-second reachability wait.
+      // Keep observing the same detached service instead of replacing it with an in-process fixture.
+    }
+    const status = await pollUntil(
+      () => runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env),
+      (status) => status.reachable === true,
+      (status, error) => JSON.stringify({ status, error: error instanceof Error ? error.message : String(error ?? "") }),
+      { timeoutMs: 20_000 }
+    );
+    assert.equal(status.repoCount, 2, JSON.stringify(status));
+
+    const dryRunHead = git(fixture.authoredRoot, "rev-parse", "HEAD");
+    const dryRun = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4",
+      "--text", "service-route dry-run probe", "--dry-run"
+    ], env);
+    assert.equal(dryRun.status, 0, JSON.stringify(dryRun.receipt));
+    assert.equal(dryRun.receipt.ok, true, JSON.stringify(dryRun.receipt));
+    const dryRunHeadAfter = git(fixture.authoredRoot, "rev-parse", "HEAD");
+
+    const append = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8",
+      "--text", "service-route slugged append"
+    ], env);
+    assert.equal(append.status, 0, JSON.stringify(append.receipt));
+    assert.equal(append.receipt.ok, true, JSON.stringify(append.receipt));
+    assert.match(
+      readFileSync(path.join(fixture.authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/progress.md"), "utf8"),
+      /service-route slugged append/u
+    );
+    const operation = latestAuthorityOperation(fixture.serviceRoot);
+    assert.equal(operation.state, "COMMITTED", JSON.stringify(operation));
+    assert.equal(operation.receipt?.tag, "COMMITTED", JSON.stringify(operation));
+    assert.equal(typeof operation.opId, "string", JSON.stringify(operation));
+    const publication = await createGitCanonicalPublicationInspector(fixture.authoredRoot)
+      .findPublicationForOperation(operation.opId!);
+    assert.equal(publication.commitSha, operation.commitSha);
+    assert.equal(publication.previousCommit, dryRunHead);
+    assert.equal(publication.parentCommits.length, 2);
+    assert.deepEqual(publication.physicalChanges.map((change) => change.path).sort(), [
+      `attribution-events/${sha256Text(operation.opId!)}.jsonl`,
+      "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/progress.md"
+    ].sort());
+    assert.equal(publication.pipelineGeneratedPaths.length, 1);
+    assert.equal(publication.pipelineGeneratedPaths[0], publication.physicalChanges.find((change) => change.path.startsWith("attribution-events/"))?.path);
+    git(fixture.authoredRoot, "diff", "--quiet", publication.commitSha, publication.parentCommits[1]!);
+    assert.equal(dryRunHeadAfter, dryRunHead, "typed service dry-run must not create a commit");
+  } finally {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    if (process.env.KEEP_AUTHORITY_SERVICE_FIXTURE !== "1") rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
 
 test("production canonical ingress accepts and journals one write for every canonical kind", async () => {
   const fixture = createFixture();
@@ -71,7 +158,7 @@ test("production canonical ingress accepts and journals one write for every cano
       readonly authoredMarker: RegExp;
     }> = [{
       kind: "task",
-      action: { kind: "progress-append", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", text: "nine-kind task ingress\n" },
+      action: { kind: "progress-append", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", text: "nine-kind task ingress\n", dryRun: false },
       canonicalEntityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"),
       authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/progress.md",
       authoredMarker: /nine-kind task ingress/u
@@ -305,7 +392,7 @@ test("production canonical ingress accepts and journals one write for every cano
       command: {
         rootDir: fixture.repoRoot,
         json: true,
-        action: { kind: "progress-append", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", text: "entity mismatch evidence" }
+        action: { kind: "progress-append", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", text: "entity mismatch evidence", dryRun: false }
       },
       attribution: daemonActorAttribution(actor, { kind: "agent", id: "codex" }),
       currentSession: { runtime: "codex", sessionId: "session-mismatch", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z" },
@@ -319,9 +406,11 @@ test("production canonical ingress accepts and journals one write for every cano
 });
 
 function createFixture() {
-  const root = mkdtempSync(path.join(tmpdir(), "ha-production-canonical-ingress-"));
+  const root = realpathSync(mkdtempSync(path.join(tmpdir(), "ha-production-canonical-ingress-")));
   const repoRoot = path.join(root, "repo");
   const authoredRoot = path.join(repoRoot, "harness");
+  const auxiliaryRoot = path.join(root, "auxiliary");
+  const auxiliaryAuthoredRoot = path.join(auxiliaryRoot, "harness");
   const serviceRoot = path.join(root, "service-state");
   const keyStateDirectory = path.join(serviceRoot, "keys/canonical");
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"), { recursive: true });
@@ -331,6 +420,8 @@ function createFixture() {
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/closeout.md"), "# Closeout\n\nProduction fixture qualified.\n");
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"), { recursive: true });
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"));
+  mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route"), { recursive: true });
+  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8"));
   const actor = {
     personId: "person_alice",
     displayName: "Alice",
@@ -425,7 +516,36 @@ function createFixture() {
   git(authoredRoot, "init", "-q");
   git(authoredRoot, "add", ".");
   git(authoredRoot, "commit", "-q", "-m", "seed canonical ingress fixture");
-  return { root, repoRoot, authoredRoot, serviceRoot, manifestPath, actor, transcriptPath, publicHead };
+  mkdirSync(auxiliaryAuthoredRoot, { recursive: true });
+  writeFileSync(path.join(auxiliaryAuthoredRoot, "harness.yaml"), "schema: harness-anything/v1\nproject: auxiliary-ingress\n");
+  git(auxiliaryAuthoredRoot, "init", "-q");
+  git(auxiliaryAuthoredRoot, "add", ".");
+  git(auxiliaryAuthoredRoot, "commit", "-q", "-m", "seed auxiliary ingress fixture");
+  return { root, repoRoot, authoredRoot, auxiliaryRoot, serviceRoot, manifestPath, actor, transcriptPath, publicHead };
+}
+
+function latestAuthorityOperation(serviceRoot: string): {
+  readonly state?: string;
+  readonly opId?: string;
+  readonly commitSha?: string;
+  readonly receipt?: { readonly tag?: string };
+} {
+  const operationPath = path.join(
+    serviceRoot,
+    "authority",
+    Buffer.from("canonical", "utf8").toString("base64url"),
+    "operations.jsonl"
+  );
+  const rows = readFileSync(operationPath, "utf8").trim().split("\n")
+    .map((line) => JSON.parse(line) as { readonly table?: string; readonly value?: Record<string, unknown> })
+    .filter((row) => row.table === "operation" && row.value);
+  assert.ok(rows.length > 0, "service route must persist an authority operation");
+  return rows.at(-1)!.value as {
+    readonly state?: string;
+    readonly opId?: string;
+    readonly commitSha?: string;
+    readonly receipt?: { readonly tag?: string };
+  };
 }
 
 function taskIndexBody(taskId: string): string {

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -43,6 +43,7 @@ test("production service route preserves progress dry-run and publishes a slugge
   const userRoot = defaultDaemonUserRoot(fixture.root);
   const env = {
     HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_MODE: "local",
     HARNESS_DAEMON_USER_ROOT: userRoot,
     HARNESS_DAEMON_IDLE_MS: "60000",
     HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"

--- a/packages/cli/test/production-authority-event-recovery.test.ts
+++ b/packages/cli/test/production-authority-event-recovery.test.ts
@@ -8,7 +8,55 @@ import type {
 } from "../../application/src/index.ts";
 import type { makeLocalAuthorityAttributionEventV2Log } from "../../kernel/src/index.ts";
 import { recoverPendingProductionEvents } from "../src/daemon/production-authority-lifecycle.ts";
-import type { createGitCanonicalPublicationInspector } from "../src/daemon/authority-publication-evidence.ts";
+import {
+  assertPublicationMatchesMutationSet,
+  type createGitCanonicalPublicationInspector
+} from "../src/daemon/authority-publication-evidence.ts";
+
+test("publication proof accepts only the declared hosted path inside a slugged task package", () => {
+  const evidence = {
+    commitSha: "b".repeat(40),
+    previousCommit: "a".repeat(40),
+    parentCommits: ["a".repeat(40), "c".repeat(40)],
+    pipelineGeneratedPaths: [],
+    contentAddressedPaths: [],
+    physicalChanges: [{
+      path: "tasks/task_T-production-route/facts.md",
+      beforeDigest: null,
+      afterDigest: "33".repeat(32)
+    }]
+  };
+  const mutationSet = {
+    registryVersion: 1,
+    mutations: [{
+      entity: { registryVersion: 1, entityKind: "fact", canonicalRef: "fact/task_T/F-TEST0001" },
+      action: { registryVersion: 1, action: "create" }
+    }]
+  } as const;
+  assertPublicationMatchesMutationSet(evidence, mutationSet);
+  assert.throws(
+    () => assertPublicationMatchesMutationSet({
+      ...evidence,
+      physicalChanges: [{
+        path: "tasks/task_T-production-route/INDEX.md",
+        beforeDigest: null,
+        afterDigest: "44".repeat(32)
+      }]
+    }, mutationSet),
+    /AUTHORITY_PUBLICATION_TREE_MISMATCH:tasks\/task_T-production-route\/INDEX\.md/u
+  );
+  assert.throws(
+    () => assertPublicationMatchesMutationSet({
+      ...evidence,
+      physicalChanges: [{
+        path: "tasks/task_X-production-route/facts.md",
+        beforeDigest: null,
+        afterDigest: "55".repeat(32)
+      }]
+    }, mutationSet),
+    /AUTHORITY_PUBLICATION_TREE_MISMATCH:tasks\/task_X-production-route\/facts\.md/u
+  );
+});
 
 test("restart recovery publishes one missing event for a committed effect without reapplying it", async () => {
   const record: AuthorityStoredOperationRecord = {
@@ -114,7 +162,7 @@ function publicationEvidence() {
     pipelineGeneratedPaths: [],
     contentAddressedPaths: [],
     physicalChanges: [{
-      path: "tasks/task_RECOVERY/progress.md",
+      path: "tasks/task_RECOVERY-production-route/progress.md",
       beforeDigest: null,
       afterDigest: "1".repeat(64)
     }]

--- a/packages/cli/test/production-authority-lifecycle.test.ts
+++ b/packages/cli/test/production-authority-lifecycle.test.ts
@@ -76,7 +76,7 @@ test("production lifecycle uses external Ed25519 material, durable state, live c
       command: {
         rootDir: fixture.repoRoot,
         json: true,
-        action: { kind: "progress-append", taskId: "task_A", text: "production authority path\n" }
+        action: { kind: "progress-append", taskId: "task_A", text: "production authority path\n", dryRun: false }
       },
       attribution: daemonActorAttribution(actor, { kind: "agent", id: "codex" }),
       currentSession: {

--- a/packages/daemon/src/transport/node-socket-peer-credential.ts
+++ b/packages/daemon/src/transport/node-socket-peer-credential.ts
@@ -15,10 +15,20 @@ const darwinRubyProgram = [
   "STDOUT.write(\"\\n\")"
 ].join("; ");
 
+const linuxPythonProgram = [
+  "import socket, struct",
+  "peer = socket.socket(fileno=3).getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize('3i'))",
+  "pid, uid, gid = struct.unpack('3i', peer)",
+  "print(uid)",
+  "print(gid)",
+  "print(pid)"
+].join("; ");
+
 export interface NodeSocketAcceptedConnectionEvidenceAdapterOptions {
   readonly platform?: NodeJS.Platform;
   readonly transportKind?: Extract<DaemonTransportKind, "unix-socket" | "named-pipe">;
   readonly darwinRubyPath?: string;
+  readonly linuxPythonPath?: string;
   readonly observationTimeoutMs?: number;
   readonly serverRandom?: () => Uint8Array;
 }
@@ -37,6 +47,7 @@ export function createNodeSocketAcceptedConnectionEvidenceAdapter(
       peerCredential: await observeNodeSocketPeerCredential(input.socket, {
         platform,
         darwinRubyPath: options.darwinRubyPath,
+        linuxPythonPath: options.linuxPythonPath,
         observationTimeoutMs: options.observationTimeoutMs
       }),
       ...(input.compatibilityBoundary ? { compatibilityBoundary: input.compatibilityBoundary } : {}),
@@ -49,7 +60,7 @@ export async function observeNodeSocketPeerCredential(
   socket: net.Socket,
   options: Pick<
     NodeSocketAcceptedConnectionEvidenceAdapterOptions,
-    "platform" | "darwinRubyPath" | "observationTimeoutMs"
+    "platform" | "darwinRubyPath" | "linuxPythonPath" | "observationTimeoutMs"
   > = {}
 ): Promise<OsPeerCredentialEvidence> {
   const platform = options.platform ?? process.platform;
@@ -60,7 +71,14 @@ export async function observeNodeSocketPeerCredential(
       options.observationTimeoutMs ?? 2_000
     );
   }
-  return unavailablePeerCredential(platform === "linux" ? "observation_failed" : "platform_unsupported");
+  if (platform === "linux") {
+    return observeLinuxSoPeerCred(
+      socket,
+      options.linuxPythonPath ?? "/usr/bin/python3",
+      options.observationTimeoutMs ?? 2_000
+    );
+  }
+  return unavailablePeerCredential("platform_unsupported");
 }
 
 async function observeDarwinGetpeereid(
@@ -72,17 +90,10 @@ async function observeDarwinGetpeereid(
     // Node's Pipe handle has no peer-credential API. Passing this accepted
     // socket as fd 3 lets the Darwin system Ruby call getpeereid(2) on the
     // same socket without a shell, client payload, addon, or package dependency.
-    const child = spawn(rubyPath, ["-rsocket", "-e", darwinRubyProgram], {
-      env: { LANG: "C", LC_ALL: "C" },
-      stdio: ["ignore", "pipe", "pipe", socket],
-      timeout
-    });
-    const output = await readCredentialOutput(child);
-    // Child stdio marks the parent stream paused; let child cleanup finish.
-    // The JSON-RPC stream installs its listeners and resumes it afterwards.
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    if (!output) return unavailablePeerCredential("observation_failed");
+    const output = await observeWithHelper(socket, rubyPath, ["-rsocket", "-e", darwinRubyProgram], timeout, 2);
+    if (!output || output.length !== 2) return unavailablePeerCredential("observation_failed");
     const [uid, gid] = output;
+    if (uid === undefined || gid === undefined) return unavailablePeerCredential("observation_failed");
     return {
       available: true,
       value: {
@@ -98,11 +109,61 @@ async function observeDarwinGetpeereid(
   }
 }
 
-async function readCredentialOutput(child: ChildProcess): Promise<readonly [number, number] | undefined> {
+async function observeLinuxSoPeerCred(
+  socket: net.Socket,
+  pythonPath: string,
+  timeout: number
+): Promise<OsPeerCredentialEvidence> {
+  try {
+    // SO_PEERCRED is read by the server from the accepted socket itself. The
+    // helper receives only that fd, never client-controlled credential data.
+    const output = await observeWithHelper(socket, pythonPath, ["-c", linuxPythonProgram], timeout, 3);
+    if (!output || output.length !== 3) return unavailablePeerCredential("observation_failed");
+    const [uid, gid, pid] = output;
+    if (uid === undefined || gid === undefined || pid === undefined) return unavailablePeerCredential("observation_failed");
+    return {
+      available: true,
+      value: {
+        schema: "os-observed-peer-credential/v1",
+        platform: "linux",
+        source: "SO_PEERCRED",
+        uid,
+        gid,
+        pid
+      }
+    };
+  } catch {
+    return unavailablePeerCredential("observation_failed");
+  }
+}
+
+async function observeWithHelper(
+  socket: net.Socket,
+  executable: string,
+  args: ReadonlyArray<string>,
+  timeout: number,
+  expectedValues: number
+): Promise<ReadonlyArray<number> | undefined> {
+  const child = spawn(executable, args, {
+    env: { LANG: "C", LC_ALL: "C" },
+    stdio: ["ignore", "pipe", "pipe", socket],
+    timeout
+  });
+  const output = await readCredentialOutput(child, expectedValues);
+  // Child stdio marks the parent stream paused; let child cleanup finish.
+  // The JSON-RPC stream installs its listeners and resumes it afterwards.
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  return output;
+}
+
+async function readCredentialOutput(
+  child: ChildProcess,
+  expectedValues: number
+): Promise<ReadonlyArray<number> | undefined> {
   return new Promise((resolve) => {
     let stdout = "";
     let settled = false;
-    const settle = (value: readonly [number, number] | undefined): void => {
+    const settle = (value: ReadonlyArray<number> | undefined): void => {
       if (settled) return;
       settled = true;
       resolve(value);
@@ -115,10 +176,10 @@ async function readCredentialOutput(child: ChildProcess): Promise<readonly [numb
     child.once("close", (code) => {
       if (code !== 0) return settle(undefined);
       const lines = stdout.trim().split("\n");
-      if (lines.length !== 2) return settle(undefined);
-      const uid = Number(lines[0]);
-      const gid = Number(lines[1]);
-      settle(isNonNegativeSafeInteger(uid) && isNonNegativeSafeInteger(gid) ? [uid, gid] : undefined);
+      if (lines.length !== expectedValues) return settle(undefined);
+      const values = lines.map(Number);
+      if (!values.every(isNonNegativeSafeInteger)) return settle(undefined);
+      settle(values);
     });
   });
 }

--- a/packages/daemon/test/accepted-connection-evidence.test.ts
+++ b/packages/daemon/test/accepted-connection-evidence.test.ts
@@ -398,11 +398,47 @@ test("connection-so-peercred-valid preserves the honest Linux source in the live
   }
 });
 
-test("Linux SO_PEERCRED remains typed unavailable when no Node adapter exists", async () => {
+test("connection-so-peercred-valid observes the same accepted Linux socket", {
+  skip: process.platform !== "linux" ? "Linux SO_PEERCRED fixture" : false
+}, async (t) => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "ha-linux-peer-evidence-"));
+  const socketPath = path.join(directory, "daemon.sock");
+  const adapter = createNodeSocketAcceptedConnectionEvidenceAdapter({ platform: "linux" });
+  const observed = new Promise<Awaited<ReturnType<typeof adapter.observeAcceptedConnection>>>((resolve, reject) => {
+    const server = net.createServer((socket) => {
+      void adapter.observeAcceptedConnection({
+        socket,
+        connectionId: "linux-connection",
+        connectionGeneration: connectionGeneration("linux-generation"),
+        daemonInstanceId: "linux-daemon"
+      }).then(resolve, reject).finally(() => {
+        socket.end();
+        server.close();
+      });
+    });
+    t.after(() => server.close());
+    server.listen(socketPath, () => net.createConnection(socketPath));
+  });
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+
+  const evidence = await observed;
+  assert.equal(evidence.peerCredential.available, true);
+  if (evidence.peerCredential.available) {
+    assert.equal(evidence.peerCredential.value.platform, "linux");
+    assert.equal(evidence.peerCredential.value.source, "SO_PEERCRED");
+    assert.equal(evidence.peerCredential.value.uid, process.getuid?.());
+    assert.equal(evidence.peerCredential.value.gid, process.getgid?.());
+    assert.ok(Number.isSafeInteger(evidence.peerCredential.value.pid));
+  }
+  assert.equal(evidence.channelBinding.digest.byteLength, 32);
+});
+
+test("Linux SO_PEERCRED remains typed unavailable when its OS helper is unavailable", async () => {
   const socket = new net.Socket();
   const adapter = createNodeSocketAcceptedConnectionEvidenceAdapter({
     platform: "linux",
     transportKind: "unix-socket",
+    linuxPythonPath: "/missing/python3",
     serverRandom: () => Buffer.alloc(32, 0x49)
   });
   const evidence = await adapter.observeAcceptedConnection({


### PR DESCRIPTION
# English

## Summary

Forward fix for the W6 third freeze (defects D10–D11): the CLI `--dry-run` intent now survives the parsed typed path into the daemon (no more real commits from dry-run), and the publication proof accepts mutations inside real slugged task packages while still rejecting cross-task, wrong-file, and undeclared paths.

## What Changed

- **D10**: `progress-append`'s parser, `ParsedCommand` variant, and command spec now jointly declare `dryRun`; the production service route short-circuits before authority ingress. Root cause: the parsed variant had no `dryRun` field at all, so the CLI silently accepted `--dry-run` while the transport payload carried no dry-run intent — the #872 fixture passed because it hand-built an action outside the type union and bypassed the parser.
- **D11**: publication proof's mutation/path matching now resolves the task package slug (`tasks/<taskId>-<slug>/…`) for ordinary task mutations instead of the bare `tasks/<taskId>` prefix that was only aliased for `task create`; cross-taskId, wrong-file, and undeclared paths remain rejected. Root cause verified read-only against the production commits (`3c78050ca` / merge `f47f272f4`): topology, subjects, and trees were all proof-conformant — only path matching failed.
- Regression harness rebuilt to the production composition: `daemon start --service --authority-manifest` with an isolated `HARNESS_DAEMON_USER_ROOT`, persisted registry pointer, multi-repo runtime, slugged task packages, and realpath-canonicalized roots. Both defects reproduced red before the patch (dry-run moved authored HEAD; slugged append settled `AUTHORITY_PUBLICATION_TREE_MISMATCH`) and green after.
- D9 recovery regression retained: repeated recovery publishes exactly once, final state `COMMITTED`.

## Task And Scope

- W6 cutover line task_01KXMN5BRWQH93976XBZSHSCN4 (ProdCutover line-S); third-freeze evidence `harness/tasks/.../line-S/w6-third-freeze-2026-07-17.md`; standing W6 fix-then-cut authorization.
- Production state untouched (`~/.harness/authority/**` read-only diagnosis only); deploy/restart/re-enable are operator actions after merge.

## Version Impact

- No published package version change.

## Governance Declaration

- Authority anchor: task_01KXMN5BRWQH93976XBZSHSCN4; freeze receipt `freeze_bc5cf4a994eee5aafcf9b233`.
- Protected paths touched: none (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `tools/test-tier-manifest.mjs`, `harness/**` untouched).
- No gate weakening; proof remains fail-closed (negative cases for external commits, cross-task paths, wrong files, undeclared paths all assert rejection).

## Verification

- Divergence-first discipline: an eight-row fixture-vs-production divergence table was produced before any patch (daemon start path, multi-repo registry, manifest pointer, slugged packages, parser-inclusive dry-run route, realpath canonicalization) — this is the documented answer to why #872 was CI-green yet production-red.
- Focused tests 18/18; root `npm run check:local` exit 0 (32 gates, fast 239/239, contract 68/68); working tree clean; hermetic git identity.
- Pre-patch red controls captured verbatim in the report (authored HEAD moved by dry-run; TREE_MISMATCH on slugged append), then green after the fix in the same production-composition loop.

## Review Evidence

- CEO semantic acceptance: dry-run intent preserved end-to-end through parser/transport/daemon with pre-ingress stop; slugged-package acceptance scoped to the exact task identity; fail-closed rejections retained with evidence fields; regression loop uses the same `daemon start --service` path production uses.

## Residual Risk

- The production INDETERMINATE residuals (including tonight's op `…834021364284871de1489e6c442b779b`) transition to COMMITTED only after deploy + daemon restart + recovery; unverified until the operator re-enable sequence runs.
- Fourth re-enable requires the full smoke matrix green before being declared successful (dry-run zero-commit first, then non-dry-run append, fact ± `--id`, decision propose, session export, task create).

## References

- `harness/tasks/task_01KXMN5BRWQH93976XBZSHSCN4-prodcutover-s-sme-tw-a1-4-island-w6-cutover/artifacts/line-S/w6-third-freeze-2026-07-17.md`.
- PRs #865 (D0–D5), #872 (D6–D9); freeze receipts `freeze_e3af3d58…`, `freeze_bc5cf4a9…`.

---

# 中文

## 概要

W6 三度冻结（缺陷 D10–D11）的 forward fix：CLI 的 `--dry-run` 意图现在能沿 parsed typed 路径完整到达 daemon（dry-run 不再真写 commit）；publication proof 接受真实 slugged task package 内的 mutation，同时保持拒绝跨 task、错误文件与未声明路径。

## 改动内容

- **D10**：`progress-append` 的 parser、`ParsedCommand` variant 与 command spec 共同声明 `dryRun`；生产 service 路由在 authority ingress 前短路。根因：parsed variant 原本根本没有 `dryRun` 字段，CLI 静默接受 `--dry-run` 但 transport payload 已无 dry-run 意图——#872 夹具绿是因为它手工构造了类型 union 之外的 action、绕过了 parser。
- **D11**：publication proof 的 mutation/路径匹配对普通 task mutation 解析 task package slug（`tasks/<taskId>-<slug>/…`），不再用只给 `task create` 放行的裸 `tasks/<taskId>` 前缀；跨 taskId、错误文件、未声明路径仍拒绝。根因经生产 commit（`3c78050ca` / merge `f47f272f4`）只读核验：拓扑、subject、tree 全部合规——只有路径匹配失败。
- 回归夹具重建为生产同源组合：`daemon start --service --authority-manifest` + 隔离 `HARNESS_DAEMON_USER_ROOT` + 持久化 registry pointer + multi-repo runtime + slugged task package + realpath 规范化根。两缺陷在补丁前均复现精确红相（dry-run 移动 authored HEAD；slugged append settle `AUTHORITY_PUBLICATION_TREE_MISMATCH`），修复后同环转绿。
- D9 恢复回归保留：重复恢复恰一次发布，终态 `COMMITTED`。

## 任务与范围

- W6 cutover 线 task_01KXMN5BRWQH93976XBZSHSCN4（ProdCutover line-S）；三冻实证 `harness/tasks/.../line-S/w6-third-freeze-2026-07-17.md`；W6 修完即 cut 常设授权。
- 生产状态未触碰（`~/.harness/authority/**` 仅只读诊断）；部署/重启/re-enable 为合并后 operator 动作。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 授权锚：task_01KXMN5BRWQH93976XBZSHSCN4；freeze receipt `freeze_bc5cf4a994eee5aafcf9b233`。
- 触碰的 protected 路径：无（`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`tools/test-tier-manifest.mjs`、`harness/**` 均未动）。
- 无削 gate；proof 保持 fail-closed（外部 commit、跨 task 路径、错误文件、未声明路径的负向用例全部断言拒绝）。

## 验证

- 差异清单先行纪律：任何补丁之前先产出 8 行「夹具 vs 生产」差异表（daemon 启动路径、multi-repo registry、manifest pointer、slugged 包、含 parser 的 dry-run 路由、realpath 规范化）——这是对「#872 为何 CI 绿生产红」的成文回答。
- 聚焦测试 18/18；根 `npm run check:local` exit 0（32 gates、fast 239/239、contract 68/68）；工作树干净；hermetic git 身份。
- 补丁前红相逐字记录在报告（dry-run 移动 authored HEAD；slugged append TREE_MISMATCH），修复后同一生产组合环转绿。

## 审查证据

- CEO 语义验收：dry-run 意图经 parser/transport/daemon 端到端保留并在 ingress 前停止；slugged 包放行严格限定在同一 task 身份；fail-closed 拒绝路径带证据字段保留；回归环使用与生产同一条 `daemon start --service` 路径。

## 残余风险

- 生产 INDETERMINATE 残账（含今晚 op `…834021364284871de1489e6c442b779b`）须部署+daemon 重启+恢复后才转 COMMITTED；operator re-enable 序列跑完前为 unverified。
- 第四轮 re-enable 须冒烟矩阵全绿方可宣布成功（先 dry-run 零 commit，再非 dry-run append、fact ± `--id`、decision propose、session export、task create）。

## 关联材料

- `harness/tasks/task_01KXMN5BRWQH93976XBZSHSCN4-prodcutover-s-sme-tw-a1-4-island-w6-cutover/artifacts/line-S/w6-third-freeze-2026-07-17.md`。
- PR #865（D0–D5）、#872（D6–D9）；freeze receipts `freeze_e3af3d58…`、`freeze_bc5cf4a9…`。
