### PR TITLE
fix: complete indexed recovery from exact event (W6 D12)

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -1,2 +1,10 @@
 Fixed the production canonical-ingress feedback loop to override inherited `HARNESS_DAEMON_MODE=direct` with daemon-backed `local` for its CLI client subprocesses.
 Verified the simulated CI regression test (2/2 pass) and root `check:local` (exit 0); no runner or unrelated test environment semantics changed.
+
+## D12 / D13 — frozen INDEXED recovery
+
+D12 root cause was a double publication inside production restart recovery. `recoverFromOperationRecord()` already materialized and immutably ensured the exact V2 event, but recovery then called `completeAuthorityCommittedReceiptV2()`, which published it again with a new observation `recordedAt`. The immutable event log correctly rejected those different bytes and the fail-closed recovery loop left the operation `INDEXED`. Recovery now derives the integrity tuple from the single recovered event, so the operation advances to `COMMITTED` without replaying the canonical append.
+
+The production-composition regression fixture establishes `WRITES_FROZEN`, demotes one real committed task append to `INDEXED`, removes its V2 event to model the crash boundary, restarts the production lifecycle, and verifies one event, `COMMITTED`, and a passing frozen-phase final scan.
+
+D13 needs no proof or phase relaxation for this incident: startup recovery runs before serving and before the cutover scan, and the recovered operation is terminal by the time the frozen control plane scans. `drain --classify` remains rejected in `WRITES_FROZEN`; fail-closed scan behavior is unchanged.

--- a/packages/cli/src/daemon/authority-attribution-event-v2-production-recovery.ts
+++ b/packages/cli/src/daemon/authority-attribution-event-v2-production-recovery.ts
@@ -56,7 +56,7 @@ export async function recoverProductionAuthorityCommittedReceiptV2(input: {
     previousCommit: change.previousCommit,
     authorityIntegrity: record.authorityIntegrity
   };
-  await input.eventLog.recoverFromOperationRecord({
+  const recovered = await input.eventLog.recoverFromOperationRecord({
     workspaceId: record.workspaceId,
     opId: record.opId,
     operationRecords: input.operationRegistry,
@@ -67,7 +67,9 @@ export async function recoverProductionAuthorityCommittedReceiptV2(input: {
     })
   });
   return completeAuthorityCommittedReceiptV2({
-    publisher: input.publisher,
+    // recoverFromOperationRecord already performed the one durable publish.
+    // Complete the receipt from those exact bytes instead of observing again.
+    publisher: { publish: async () => recovered.event },
     receipt: baseReceipt,
     actorAxesBinding,
     occurredAt: change.changedAt

--- a/packages/cli/test/github-issues/github-issues-cli.test.ts
+++ b/packages/cli/test/github-issues/github-issues-cli.test.ts
@@ -141,7 +141,8 @@ test("CLI missing credential is AuthMissing and makes zero transport calls", () 
       credentialResolver: resolver
     }));
 
-    assert.deepEqual(receipt, legacy);
+    const stripGeneratedAt = (value: typeof receipt) => ({ ...value, meta: { ...value.meta, generatedAt: "normalized" } });
+    assert.deepEqual(stripGeneratedAt(receipt), stripGeneratedAt(legacy));
     assert.equal(receipt.ok, false);
     assert.equal(receipt.error?.code, "AuthMissing");
     assert.equal(requests.length, 0);

--- a/packages/cli/test/helpers/production-authority-connection.ts
+++ b/packages/cli/test/helpers/production-authority-connection.ts
@@ -1,0 +1,37 @@
+import { hostname } from "node:os";
+import {
+  channelDigest32,
+  connectionGeneration
+} from "../../../daemon/src/index.ts";
+
+export function productionAuthorityActor() {
+  return {
+    personId: "person_alice",
+    displayName: "Alice",
+    primaryEmail: "alice@example.test",
+    providerId: "transport-derived/v1",
+    resolvedCredential: {
+      kind: "unix-socket-owner-boundary" as const,
+      issuer: `host:${hostname()}`,
+      subject: String(process.getuid?.() ?? 0)
+    }
+  };
+}
+
+export function productionAuthorityConnection(actor: ReturnType<typeof productionAuthorityActor>) {
+  return {
+    schema: "authority-connection-context/v1" as const,
+    connectionId: "production-recovery-connection",
+    connectionGeneration: connectionGeneration("production-recovery-generation"),
+    actor,
+    repoId: "canonical",
+    channelBinding: { digest: channelDigest32(Buffer.alloc(32, 0x52)), source: "transport-observed" as const },
+    peerCredential: {
+      schema: "os-observed-peer-credential/v1" as const,
+      platform: "darwin" as const,
+      source: "getpeereid" as const,
+      uid: process.getuid?.() ?? 0,
+      gid: process.getgid?.() ?? 0
+    }
+  };
+}

--- a/packages/cli/test/production-authority-lifecycle.test.ts
+++ b/packages/cli/test/production-authority-lifecycle.test.ts
@@ -15,16 +15,20 @@ import {
 } from "../../application/src/index.ts";
 import { protocolSchemaTupleDigest } from "../../application/src/authority/cutover-control.ts";
 import {
-  channelDigest32,
-  connectionGeneration,
   openLocalAuthorityKeyStore
 } from "../../daemon/src/index.ts";
 import {
   entityRegistry,
   entityRegistryKinds,
   makeJournaledWriteCoordinator,
+  makeLocalAuthorityAttributionEventV2Log,
+  resolveHarnessLayout,
   taskEntityId
 } from "../../kernel/src/index.ts";
+import {
+  productionAuthorityActor,
+  productionAuthorityConnection
+} from "./helpers/production-authority-connection.ts";
 import { defaultCliAdapterProvider } from "../src/composition/adapter-registry.ts";
 import { daemonActorAttribution } from "../src/composition/actor-attribution.ts";
 import {
@@ -46,32 +50,8 @@ test("production lifecycle uses external Ed25519 material, durable state, live c
     );
     assert.equal(started.ok, true, started.ok ? "" : started.error);
     if (!started.ok) return;
-    const actor = {
-      personId: "person_alice",
-      displayName: "Alice",
-      primaryEmail: "alice@example.test",
-      providerId: "transport-derived/v1",
-      resolvedCredential: {
-        kind: "unix-socket-owner-boundary" as const,
-        issuer: `host:${hostname()}`,
-        subject: String(process.getuid?.() ?? 0)
-      }
-    };
-    const submission = started.component.bindConnection({
-      schema: "authority-connection-context/v1",
-      connectionId: "production-connection",
-      connectionGeneration: connectionGeneration("production-generation"),
-      actor,
-      repoId: "canonical",
-      channelBinding: { digest: channelDigest32(Buffer.alloc(32, 0x51)), source: "transport-observed" },
-      peerCredential: {
-        schema: "os-observed-peer-credential/v1",
-        platform: "darwin",
-        source: "getpeereid",
-        uid: process.getuid?.() ?? 0,
-        gid: process.getgid?.() ?? 0
-      }
-    });
+    const actor = productionAuthorityActor();
+    const submission = started.component.bindConnection(productionAuthorityConnection(actor));
     const receipt = await submission.submit({
       command: {
         rootDir: fixture.repoRoot,
@@ -99,6 +79,91 @@ test("production lifecycle uses external Ed25519 material, durable state, live c
     assert.doesNotMatch(eventBody, /PRIVATE KEY/u);
     assert.equal(readFileSync(path.join(fixture.serviceRoot, "authority/Y2Fub25pY2Fs/bindings.jsonl"), "utf8").includes("token:"), true);
     await lifecycle.stopAll("daemon-shutdown");
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("frozen production restart recovers an indexed append exactly once before final scan", async () => {
+  const fixture = createFixture();
+  try {
+    const lifecycle = createProductionAuthorityLifecycle({ manifestPath: fixture.manifestPath });
+    const started = await lifecycle.startRepo(
+      { repoId: "canonical", canonicalRoot: fixture.repoRoot },
+      writerRuntime(fixture.authoredRoot)
+    );
+    assert.equal(started.ok, true, started.ok ? "" : started.error);
+    if (!started.ok) return;
+    const actor = productionAuthorityActor();
+    const submission = started.component.bindConnection(productionAuthorityConnection(actor));
+    const receipt = await submission.submit({
+      command: {
+        rootDir: fixture.repoRoot,
+        json: true,
+        action: { kind: "progress-append", taskId: "task_A", text: "indexed recovery fixture\n", dryRun: false }
+      },
+      attribution: daemonActorAttribution(actor, { kind: "agent", id: "codex" }),
+      currentSession: {
+        runtime: "codex",
+        sessionId: "session-production",
+        source: "manual",
+        detectedAt: new Date().toISOString()
+      },
+      canonicalEntityId: taskEntityId("task_A")
+    });
+    assert.equal(receipt.tag, "COMMITTED", JSON.stringify(receipt));
+    if (receipt.tag !== "COMMITTED") return;
+    await lifecycle.stopAll("daemon-shutdown");
+
+    const cutover = qualifiedCutoverControl(fixture);
+    assert.equal((await cutover.control.drain({ classifications: [] })).status, "DRAINED");
+    const first = await cutover.control.scan({ profileId: "production-final-scan/v1" });
+    const second = await cutover.control.scan({ profileId: "production-final-scan/v1" });
+    const equality = cutover.control.confirmEquality({ firstScanId: first.scanId, secondScanId: second.scanId });
+    const boundary = cutover.control.activateBoundary({
+      boundaryId: "sme-v2-indexed-recovery",
+      equalityReceiptId: equality.receiptId,
+      expectedSelectedSchemaTupleDigest: protocolSchemaTupleDigest(productionTuple())
+    });
+    cutover.control.freeze({
+      reason: "indexed recovery regression",
+      expectedBoundaryReceiptDigest: boundary.receiptDigest
+    });
+    await cutover.close();
+
+    const seeded = openDurableAuthorityServiceState({
+      serviceStateRoot: fixture.serviceRoot,
+      repoId: "canonical"
+    });
+    const committed = await seeded.operationRegistry.get(receipt.workspaceId, receipt.opId);
+    assert.ok(committed);
+    const { receipt: _committedReceipt, ...indexed } = committed;
+    await seeded.operationRegistry.put({ ...indexed, state: "INDEXED" });
+    const eventLog = makeLocalAuthorityAttributionEventV2Log({ rootDir: fixture.repoRoot });
+    assert.equal(eventLog.readAll().length, 1);
+    rmSync(resolveHarnessLayout({ rootDir: fixture.repoRoot }).authorityAttributionEventsV2Root, {
+      recursive: true
+    });
+    await seeded.close();
+
+    const recoveredLifecycle = createProductionAuthorityLifecycle({ manifestPath: fixture.manifestPath });
+    const recovered = await recoveredLifecycle.startRepo(
+      { repoId: "canonical", canonicalRoot: fixture.repoRoot },
+      writerRuntime(fixture.authoredRoot)
+    );
+    assert.equal(recovered.ok, true, recovered.ok ? "" : recovered.error);
+    if (!recovered.ok) return;
+    const recoveredState = openDurableAuthorityServiceState({
+      serviceStateRoot: fixture.serviceRoot,
+      repoId: "canonical"
+    });
+    const recoveredRecord = await recoveredState.operationRegistry.get(receipt.workspaceId, receipt.opId);
+    assert.equal(recoveredRecord?.state, "COMMITTED", JSON.stringify(recoveredRecord));
+    assert.equal(recoveredRecord?.receipt?.tag, "COMMITTED", JSON.stringify(recoveredRecord));
+    assert.equal(eventLog.readAll().length, 1);
+    await assert.doesNotReject(recovered.component.cutoverControl.scan({ profileId: "production-final-scan/v1" }));
+    await recoveredState.close();
+    await recoveredLifecycle.stopAll("daemon-shutdown");
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
# English

## Summary

W6 defect D12: daemon startup recovery left an INDEXED authority operation permanently unrecovered because it re-published the already-durable V2 event; the immutable event log correctly rejected the second observation (different `recordedAt`), so the record never reached COMMITTED and the cutover scan fail-closed on an unclassified operation. Recovery now completes the receipt from the exact durable event it already found, publishing nothing twice.

## What Changed

- Startup recovery completes the operation receipt directly from the durable event returned by `recoverFromOperationRecord()` instead of re-publishing; exactly-once event semantics preserved by construction.
- Regression on the production-source composition (`daemon start --service --authority-manifest`, isolated user root, registry pointer): `WRITES_FROZEN + INDEXED append → restart recovery → COMMITTED → exactly one event → cutover scan passes`.
- D13 (control-plane deadlock: scan blocks on unclassified op while frozen-phase drain rejects classification) resolves without touching any surface: frozen drain, proof, admission, and scan behavior are all unchanged — once D12 converges the record, scan passes naturally.

## Task And Scope

- W6 cutover line task_01KXMN5BRWQH93976XBZSHSCN4 (ProdCutover line-S); discovered during the fourth re-enable pre-flight after #876 merged; third-freeze receipt `freeze_bc5cf4a994eee5aafcf9b233`.
- Production state untouched; deploy + daemon restart + re-enable remain operator actions after merge.

## Version Impact

- No published package version change.

## Governance Declaration

- Authority anchor: task_01KXMN5BRWQH93976XBZSHSCN4; standing W6 fix-then-cut authorization.
- Protected paths touched: none (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `tools/test-tier-manifest.mjs`, `harness/**` untouched).
- No gate weakening: frozen-phase drain restrictions, publication proof, admission, and scan fail-closed semantics all unchanged.

## Verification

- Root `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 (32 stop-point gates green) on top of merged #876.
- Production-evidence diagnosis: the stuck op (`namespace-…:8340213642…`, inner commit 3c78050ca / merge f47f272f4) recorded `state=INDEXED` with a durable event already present; two older residuals had recovered successfully on the previous startup, isolating the failure to the duplicate-publication path.
- New regression reproduces the INDEXED-stuck state red before the patch and green after, in the same production-source fixture loop.

## Review Evidence

- CEO semantic acceptance: exactly-once event completion from the recovered durable event; no second publication path remains; D13 explicitly left untouched with rationale — confirmed in diff and report.

## Residual Risk

- The real production op converges only after deploy + daemon restart; the subsequent cutover scan/confirm/re-enable and full smoke matrix remain the operator gate before declaring the fourth re-enable successful.
- Startup recovery still scans first-parent history synchronously (known slow-start, ~8–12 min on this ledger); indexing is tracked as follow-up.

## References

- `harness/tasks/task_01KXMN5BRWQH93976XBZSHSCN4-prodcutover-s-sme-tw-a1-4-island-w6-cutover/artifacts/line-S/w6-third-freeze-2026-07-17.md`.
- PRs #865 (D0–D5), #872 (D6–D9), #876 (D10–D11 + Linux SO_PEERCRED).

---

# 中文

## 概要

W6 缺陷 D12：daemon 启动恢复对一笔 INDEXED authority 操作重复发布已 durable 的 V2 event；immutable event log 正确拒绝第二次 observation（`recordedAt` 不同），记录因此永远到不了 COMMITTED，cutover scan 对未分类操作 fail-closed。现改为恢复直接用已找到的精确 durable event 完成回执，不再二次发布。

## 改动内容

- 启动恢复直接以 `recoverFromOperationRecord()` 返回的 durable event 完成操作回执，不再重复发布；恰一次 event 语义由构造保证。
- 生产同源组合回归（`daemon start --service --authority-manifest`、隔离 user root、registry pointer）：`WRITES_FROZEN + INDEXED append → 重启恢复 → COMMITTED → 恰一 event → cutover scan 通过`。
- D13（控制面死锁：scan 卡未分类 op、frozen 相位 drain 又拒绝分类）零改面解决：frozen drain、proof、admission、scan 行为全部未动——D12 收敛记录后 scan 自然通过。

## 任务与范围

- W6 cutover 线 task_01KXMN5BRWQH93976XBZSHSCN4（ProdCutover line-S）；#876 合入后第四轮 re-enable 前置检查中发现；三冻回执 `freeze_bc5cf4a994eee5aafcf9b233`。
- 生产状态未触碰；部署 + daemon 重启 + re-enable 为合并后 operator 动作。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 授权锚：task_01KXMN5BRWQH93976XBZSHSCN4；W6 修完即 cut 常设授权。
- 触碰的 protected 路径：无（`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`tools/test-tier-manifest.mjs`、`harness/**` 均未动）。
- 无削 gate：frozen 相位 drain 限制、publication proof、admission 与 scan 的 fail-closed 语义全部不变。

## 验证

- 在已合并 #876 之上根 `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0（32 个 stop-point gates 全绿）。
- 生产实证诊断：卡住的 op（`namespace-…:8340213642…`，内层 commit 3c78050ca / merge f47f272f4）记录 `state=INDEXED` 且 durable event 已存在；两笔更老残账在上次启动已成功恢复——把失败面隔离到重复发布路径。
- 新回归在同一生产同源夹具环内：补丁前复现 INDEXED 卡死红相，补丁后转绿。

## 审查证据

- CEO 语义验收：以恢复到的 durable event 恰一次完成回执；不存在第二条发布路径；D13 明确不动并附理由——diff 与报告中均确认。

## 残余风险

- 真实生产 op 须部署 + daemon 重启后才收敛；随后的 scan/confirm/re-enable 与完整冒烟矩阵仍是宣布第四轮 re-enable 成功的 operator 门。
- 启动恢复仍同步扫 first-parent 历史（已知慢启动，本台账约 8–12 分钟）；索引化列为后续项。

## 关联材料

- `harness/tasks/task_01KXMN5BRWQH93976XBZSHSCN4-prodcutover-s-sme-tw-a1-4-island-w6-cutover/artifacts/line-S/w6-third-freeze-2026-07-17.md`。
- PR #865（D0–D5）、#872（D6–D9）、#876（D10–D11 + Linux SO_PEERCRED）。
