### PR TITLE
fix: reuse durable event during production recovery (W6 D12b)

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -8,3 +8,23 @@ D12 root cause was a double publication inside production restart recovery. `rec
 The production-composition regression fixture establishes `WRITES_FROZEN`, demotes one real committed task append to `INDEXED`, removes its V2 event to model the crash boundary, restarts the production lifecycle, and verifies one event, `COMMITTED`, and a passing frozen-phase final scan.
 
 D13 needs no proof or phase relaxation for this incident: startup recovery runs before serving and before the cutover scan, and the recovered operation is terminal by the time the frozen control plane scans. `drain --classify` remains rejected in `WRITES_FROZEN`; fail-closed scan behavior is unchanged.
+
+## D12b — production exception and root cause
+
+The production-shaped probe used a read-only copy of `~/.harness/authority/harness-anything-production/authority/`, a fresh clone of `ROOT/harness` at `f9fa45ac8d5f5e1c7fbb2646ccac948513c2382e`, and a read-only copy of the existing runtime V2 event. The authority state copy matched all five production source-file SHA-256 digests. The real `findPublicationForOperation` crossed the direct docs commit and found merge `f47f272f42251c1135cfa7ffcfacc19f410f19c3`; `assertPublicationMatchesMutationSet` and the rev-1 replica change checks both passed.
+
+The real recovery function produced the following verbatim exception message and stack; only the absolute worktree prefix is normalized to `ROOT` for release hygiene:
+
+```text
+AuthorityAttributionEventV2ProtocolDamageError: different bytes already exist for (workspace-harness-anything-production, namespace-harness-anything-production:834021364284871de1489e6c442b779b)
+    at authorityAttributionEventV2ProtocolDamage (file:///ROOT/.worktrees/authority-pubproof-fix/packages/kernel/src/integrity/authority-attribution-event-v2-log.ts:59:17)
+    at ensureAuthorityAttributionEventV2 (file:///ROOT/.worktrees/authority-pubproof-fix/packages/kernel/src/store/authority-attribution-event-v2-log.ts:87:11)
+    at Object.ensure (file:///ROOT/.worktrees/authority-pubproof-fix/packages/kernel/src/store/authority-attribution-event-v2-log.ts:56:24)
+    at Object.publish (file:///ROOT/.worktrees/authority-pubproof-fix/packages/application/src/authority/durable-committed-event-publisher-v2.ts:50:40)
+```
+
+The existing immutable event was valid and had `recordedAt=2026-07-17T19:32:42.594Z`. Restart recovery nevertheless called the publisher from `recoverFromOperationRecord`, which performed a fresh observation with a new `recordedAt`; `eventLog.ensure` correctly rejected those different canonical bytes. D12 had removed only the second publication performed while completing the receipt, leaving this first replay publication intact.
+
+Recovery now uses the already durable event as `materializeExactEvent` when present and invokes the publisher only when the event is actually missing. The production-shaped post-fix replay returned `COMMITTED` with canonical event digest `51fe566be9cc86face924744d8cf54c6da6001a2a5648f1043f9b49f9e8a33a5`, made zero publisher calls, and preserved the event file SHA-256 `2ea391ba34b9738f3b3a79b9be0e61ea830bf8ee02079fab29c87c3ecd30700f` byte-for-byte.
+
+The regression fixture keeps the existing V2 event, demotes the operation to `INDEXED`, adds a non-authority direct docs commit above the operation merge, restarts, and verifies `COMMITTED` plus a passing frozen final scan. Fail-closed deferrals now emit a structured daemon log entry with event `authority.recovery.deferred`, the opId in `requestId` and message, an `errorCode`, and the exception summary; logging failures are no longer swallowed by the recovery catch.

--- a/packages/cli/src/daemon/authority-attribution-event-v2-production-recovery.ts
+++ b/packages/cli/src/daemon/authority-attribution-event-v2-production-recovery.ts
@@ -60,11 +60,12 @@ export async function recoverProductionAuthorityCommittedReceiptV2(input: {
     workspaceId: record.workspaceId,
     opId: record.opId,
     operationRecords: input.operationRegistry,
-    materializeExactEvent: async () => input.publisher.publish({
-      receipt: baseReceipt,
-      actorAxesBinding,
-      occurredAt: change.changedAt
-    })
+    materializeExactEvent: async () => input.eventLog.read(record.workspaceId, record.opId)
+      ?? input.publisher.publish({
+        receipt: baseReceipt,
+        actorAxesBinding,
+        occurredAt: change.changedAt
+      })
   });
   return completeAuthorityCommittedReceiptV2({
     // recoverFromOperationRecord already performed the one durable publish.

--- a/packages/cli/src/daemon/production-authority-lifecycle.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle.ts
@@ -16,6 +16,7 @@ import {
   type ActorAxesBindingRuntimeV2,
   type AuthoritySubmissionV2Options,
   type AuthoritySubmissionService,
+  type DaemonLogService,
 } from "../../../application/src/index.ts";
 import { createAuthoritySubmissionService } from "../../../application/src/authority/service.ts";
 import {
@@ -78,6 +79,7 @@ const productionAuthorityV2EntityKinds = [
 export function createProductionAuthorityLifecycle(input: {
   readonly manifestPath: string;
   readonly layoutOverrides?: { readonly authoredRoot?: string };
+  readonly daemonLogService?: DaemonLogService;
 }): AuthorityRepoLifecycleController {
   const manifest = loadAuthorityProductionManifest(input.manifestPath);
   const materials = new Map<string, RepoProductionMaterial>();
@@ -184,7 +186,19 @@ export function createProductionAuthorityLifecycle(input: {
         replicaChangeLog: state.replicaChangeLog,
         eventLog,
         publicationInspector,
-        recover: committedEventPublisher.recoverCommittedReceipt
+        recover: committedEventPublisher.recoverCommittedReceipt,
+        ...(input.daemonLogService ? {
+          onDeferred: (record: import("../../../application/src/index.ts").AuthorityStoredOperationRecord, error: unknown) =>
+            input.daemonLogService!.append({
+              level: "error",
+              source: "daemon",
+              component: "authority-recovery",
+              event: "authority.recovery.deferred",
+              message: `Deferred production authority recovery for opId=${record.opId}: ${recoveryErrorSummary(error)}`,
+              errorCode: recoveryErrorCode(error),
+              requestId: record.opId
+            }, { repo: { repoId: config.repoId, canonicalRoot: config.canonicalRoot } }).then(() => undefined)
+        } : {})
       });
       return {
         authenticatedPersonRegistry: identity.personRegistry,
@@ -239,6 +253,10 @@ export async function recoverPendingProductionEvents(input: {
   readonly eventLog: ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>;
   readonly publicationInspector: ReturnType<typeof createGitCanonicalPublicationInspector>;
   readonly recover: (record: import("../../../application/src/index.ts").AuthorityStoredOperationRecord) => Promise<import("../../../application/src/index.ts").AuthorityCommittedReceipt>;
+  readonly onDeferred?: (
+    record: import("../../../application/src/index.ts").AuthorityStoredOperationRecord,
+    error: unknown
+  ) => Promise<void>;
 }): Promise<void> {
   const records = await input.operationRegistry.list(input.workspaceId);
   const pending = records.filter((record) => {
@@ -262,8 +280,9 @@ export async function recoverPendingProductionEvents(input: {
         if (!change) {
           const latest = await input.replicaChangeLog.latest(record.workspaceId);
           if ((latest?.commitSha ?? null) !== evidence.previousCommit) {
-            deferred.push(record);
-            continue;
+            throw new Error(
+              `AUTHORITY_V2_RECOVERY_PREDECESSOR_PENDING:expected=${evidence.previousCommit ?? "null"};actual=${latest?.commitSha ?? "null"}`
+            );
           }
           change = {
             schema: "replica-change/v1",
@@ -289,14 +308,25 @@ export async function recoverPendingProductionEvents(input: {
         const receipt = await input.recover(indexed);
         await input.operationRegistry.put({ ...indexed, state: "COMMITTED", receipt, commitSha: receipt.commitSha });
         progressed = true;
-      } catch {
+      } catch (error) {
         // Fail closed: unverifiable historical effects remain indeterminate.
+        await input.onDeferred?.(record, error);
         deferred.push(record);
       }
     }
     if (!progressed) return;
     remaining = deferred;
   }
+}
+
+function recoveryErrorSummary(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+}
+
+function recoveryErrorCode(error: unknown): string {
+  if (!(error instanceof Error)) return "AUTHORITY_RECOVERY_UNKNOWN_ERROR";
+  const messageCode = /^([A-Z][A-Z0-9_]+)/u.exec(error.message)?.[1];
+  return messageCode ?? error.name;
 }
 
 interface ProductionAuthorityRepoComponent extends AuthorityRepoComponent {

--- a/packages/cli/src/daemon/service-host.ts
+++ b/packages/cli/src/daemon/service-host.ts
@@ -76,7 +76,8 @@ export async function createDaemonServiceHost(
     readonly loadedIdentity: string;
     readonly startedAt: string;
   },
-  authorityLifecycle?: AuthorityRepoLifecycleController
+  authorityLifecycle?: AuthorityRepoLifecycleController,
+  providedDaemonLogService?: DaemonLogService
 ): Promise<{
   readonly daemonId: string;
   readonly createProtocolServer: (
@@ -96,7 +97,8 @@ export async function createDaemonServiceHost(
   readonly stop: () => Promise<void>;
 }> {
   const daemonId = `ha-${process.pid}`;
-  const daemonLogService = makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot }) });
+  const daemonLogService = providedDaemonLogService
+    ?? makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot }) });
   const stopHandlers: Array<() => Promise<void>> = [];
   const reposById = new Map(repos.map((repo) => [repo.repoId, repo]));
   let requestStop: (() => void) | undefined;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import {
   registerDaemonRepo,
   type DaemonRegistryRepo
 } from "../../kernel/src/index.ts";
+import { makeDaemonLogService } from "../../application/src/index.ts";
 import { parseArgs } from "./cli/parse-args.ts";
 import { readOption, stripGlobalOptions } from "./cli/parse-options.ts";
 import { appendParseFailureRuntimeEvent } from "./cli/parse-failure-runtime-event.ts";
@@ -28,6 +29,7 @@ import { daemonIdFromEnv, daemonUserRoot, localUserDaemonEndpoint, runCommandThr
 import { createDaemonServiceHost } from "./daemon/service-host.ts";
 import { makeDaemonReservationReconciler } from "./composition/reservation-reconciler.ts";
 import { createProductionAuthorityLifecycle } from "./daemon/production-authority-lifecycle.ts";
+import { makeDaemonLogFileStore } from "./daemon/daemon-log-file-store.ts";
 import { loadAuthorityProductionManifest } from "./daemon/authority-production-state.ts";
 import { runCompoundReceiptExitCommand } from "./daemon/compound-receipt-runner.ts";
 import { runAgentRuntimeCommand } from "./commands/agent-runtime.ts";
@@ -144,9 +146,11 @@ async function runDaemonServe(
       }
       const idleMs = parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true });
       const connections: DaemonConnectionStats = { active: 0, total: 0 };
+      const daemonLogService = makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot }) });
       const authorityLifecycle = hooks.authorityLifecycle ?? (authorityManifest
         ? createProductionAuthorityLifecycle({
           manifestPath: authorityManifest,
+          daemonLogService,
           ...(layoutOverrides ? { layoutOverrides } : {})
         })
         : undefined);
@@ -154,7 +158,7 @@ async function runDaemonServe(
         entrypoint,
         loadedIdentity: loadedBuild.identity,
         startedAt
-      }, authorityLifecycle);
+      }, authorityLifecycle, daemonLogService);
       serviceHost.startRegistryReconcile(userRoot);
       const transport = createDaemonLocalTransport({
         daemonId: serviceHost.daemonId,

--- a/packages/cli/test/production-authority-event-recovery.test.ts
+++ b/packages/cli/test/production-authority-event-recovery.test.ts
@@ -154,6 +154,59 @@ test("restart recovery publishes one missing event for a committed effect withou
   assert.deepEqual(durable.receipt, receipt);
 });
 
+test("restart recovery reports the opId and exception when fail-closed recovery is deferred", async () => {
+  const record: AuthorityStoredOperationRecord = {
+    workspaceId: "workspace-production",
+    opId: "namespace-production:deferred-operation",
+    semanticDigest: "a".repeat(64),
+    state: "INDEXED",
+    authorityIntegrity: {
+      schema: "authority-operation-integrity/v2",
+      semanticRequestDigest: "a".repeat(64),
+      semanticMutationSetDigest: "c".repeat(64),
+      mutationRegistryVersion: 1,
+      actorAxesBindingDigest: "d".repeat(64),
+      canonicalMutationSet: {
+        registryVersion: 1,
+        mutations: [{
+          entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task_RECOVERY" },
+          action: { registryVersion: 1, action: "append" }
+        }]
+      }
+    },
+    recordedProtocol: {
+      kind: "semantic-mutation-envelope/v2",
+      schemaTuple: {
+        wire: 2, event: 2, receipt: 2, digest: 2, policy: 2,
+        commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
+      }
+    },
+    canonicalRequestEnvelope: "durable-envelope"
+  };
+  const deferred: Array<{ readonly opId: string; readonly error: unknown }> = [];
+  const failure = new Error("AUTHORITY_TEST_PUBLICATION_LOOKUP_FAILED");
+
+  await recoverPendingProductionEvents({
+    workspaceId: record.workspaceId,
+    operationRegistry: {
+      get: async () => record,
+      list: async () => [record],
+      put: async () => undefined
+    },
+    replicaChangeLog: {} as import("../../application/src/index.ts").ReplicaChangeLog,
+    eventLog: {} as ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>,
+    publicationInspector: {
+      findPublicationForOperation: async () => { throw failure; }
+    } as ReturnType<typeof createGitCanonicalPublicationInspector>,
+    recover: async () => { throw new Error("recovery must not run after publication lookup fails"); },
+    onDeferred: async (candidate, error) => {
+      deferred.push({ opId: candidate.opId, error });
+    }
+  });
+
+  assert.deepEqual(deferred, [{ opId: record.opId, error: failure }]);
+});
+
 function publicationEvidence() {
   return {
     commitSha: "b".repeat(40),

--- a/packages/cli/test/production-authority-lifecycle.test.ts
+++ b/packages/cli/test/production-authority-lifecycle.test.ts
@@ -22,7 +22,6 @@ import {
   entityRegistryKinds,
   makeJournaledWriteCoordinator,
   makeLocalAuthorityAttributionEventV2Log,
-  resolveHarnessLayout,
   taskEntityId
 } from "../../kernel/src/index.ts";
 import {
@@ -84,7 +83,7 @@ test("production lifecycle uses external Ed25519 material, durable state, live c
   }
 });
 
-test("frozen production restart recovers an indexed append exactly once before final scan", async () => {
+test("frozen production restart reuses an indexed append event below a direct docs commit", async () => {
   const fixture = createFixture();
   try {
     const lifecycle = createProductionAuthorityLifecycle({ manifestPath: fixture.manifestPath });
@@ -141,10 +140,13 @@ test("frozen production restart recovers an indexed append exactly once before f
     await seeded.operationRegistry.put({ ...indexed, state: "INDEXED" });
     const eventLog = makeLocalAuthorityAttributionEventV2Log({ rootDir: fixture.repoRoot });
     assert.equal(eventLog.readAll().length, 1);
-    rmSync(resolveHarnessLayout({ rootDir: fixture.repoRoot }).authorityAttributionEventsV2Root, {
-      recursive: true
-    });
     await seeded.close();
+
+    mkdirSync(path.join(fixture.authoredRoot, "docs"), { recursive: true });
+    writeFileSync(path.join(fixture.authoredRoot, "docs/recovery-containment.md"), "# Recovery containment\n");
+    git(fixture.authoredRoot, "add", "docs/recovery-containment.md");
+    git(fixture.authoredRoot, "commit", "-q", "-m", "docs: record recovery containment");
+    assert.notEqual(git(fixture.authoredRoot, "rev-parse", "HEAD"), receipt.commitSha);
 
     const recoveredLifecycle = createProductionAuthorityLifecycle({ manifestPath: fixture.manifestPath });
     const recovered = await recoveredLifecycle.startRepo(


### PR DESCRIPTION
# English

## Summary

W6 defect D12b (follow-up to #878): production recovery still failed because `recoverFromOperationRecord` re-published when the V2 event was ALREADY durable from the original attempt — the immutable log rejected the second observation (`AuthorityAttributionEventV2ProtocolDamageError: different bytes already exist`, captured verbatim by an isolated probe over a copy of the real production state). Recovery now reuses the existing durable event and publishes only when missing. The isolated replay of the real stuck op returns COMMITTED with zero publisher calls and unchanged event hashes.

## What Changed

- `recoverFromOperationRecord` reuses the pre-existing durable V2 event when present; the publisher is invoked only when the event is genuinely missing — exactly-once by construction on both paths.
- The recovery loop's silent `catch {}` now emits structured daemon-log evidence on deferral (opId, errorCode, exception summary) — same transparency discipline as D0/D8.
- New regression covers the exact production shape: op merge with a non-authority docs commit stacked above it AND a pre-existing durable V2 event.
- Regression on the production-source composition (`daemon start --service --authority-manifest`, isolated user root, registry pointer): `WRITES_FROZEN + INDEXED append → restart recovery → COMMITTED → exactly one event → cutover scan passes`.
- D13 (control-plane deadlock: scan blocks on unclassified op while frozen-phase drain rejects classification) resolves without touching any surface: frozen drain, proof, admission, and scan behavior are all unchanged — once D12 converges the record, scan passes naturally.

## Task And Scope

- W6 cutover line task_01KXMN5BRWQH93976XBZSHSCN4 (ProdCutover line-S); discovered during the fourth re-enable pre-flight after #876 merged; third-freeze receipt `freeze_bc5cf4a994eee5aafcf9b233`.
- Production state untouched; deploy + daemon restart + re-enable remain operator actions after merge.

## Version Impact

- No published package version change.

## Governance Declaration

- Authority anchor: task_01KXMN5BRWQH93976XBZSHSCN4; standing W6 fix-then-cut authorization.
- Protected paths touched: none (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `tools/test-tier-manifest.mjs`, `harness/**` untouched).
- No gate weakening: frozen-phase drain restrictions, publication proof, admission, and scan fail-closed semantics all unchanged.

## Verification

- Root `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 (32 stop-point gates green) on top of merged #876.
- Production-evidence diagnosis: the stuck op (`namespace-…:8340213642…`, inner commit 3c78050ca / merge f47f272f4) recorded `state=INDEXED` with a durable event already present; two older residuals had recovered successfully on the previous startup, isolating the failure to the duplicate-publication path.
- New regression reproduces the INDEXED-stuck state red before the patch and green after, in the same production-source fixture loop.

## Review Evidence

- CEO semantic acceptance: exactly-once event completion from the recovered durable event; no second publication path remains; D13 explicitly left untouched with rationale — confirmed in diff and report.

## Residual Risk

- The real production op converges only after deploy + daemon restart; the subsequent cutover scan/confirm/re-enable and full smoke matrix remain the operator gate before declaring the fourth re-enable successful.
- Startup recovery still scans first-parent history synchronously (known slow-start, ~8–12 min on this ledger); indexing is tracked as follow-up.

## References

- `harness/tasks/task_01KXMN5BRWQH93976XBZSHSCN4-prodcutover-s-sme-tw-a1-4-island-w6-cutover/artifacts/line-S/w6-third-freeze-2026-07-17.md`.
- PRs #865 (D0–D5), #872 (D6–D9), #876 (D10–D11 + Linux SO_PEERCRED).

---

# 中文

## 概要

W6 缺陷 D12b（#878 的追修）：生产恢复仍失败，因 `recoverFromOperationRecord` 在 V2 event **已经 durable**（初次尝试时落盘）的情况下再次发布——immutable log 拒绝第二次 observation（隔离探针在生产状态副本上抓到异常原文 `AuthorityAttributionEventV2ProtocolDamageError: different bytes already exist`）。现改为已有 durable event 直接复用、仅缺失时发布。真实卡死 op 在隔离副本重放收敛为 COMMITTED、publisher 零调用、event 哈希不变。

## 改动内容

- `recoverFromOperationRecord` 在既存 durable V2 event 存在时直接复用；仅真正缺失时才调用 publisher——两条路径均由构造保证恰一次。
- 恢复循环的静默 `catch {}` 改为 defer 时写结构化 daemon log 证据（opId、errorCode、异常摘要）——与 D0/D8 同一透明化纪律。
- 新回归覆盖生产精确形状：op merge 之上叠非 authority docs 直提交，且 V2 event 预先 durable。
- 生产同源组合回归（`daemon start --service --authority-manifest`、隔离 user root、registry pointer）：`WRITES_FROZEN + INDEXED append → 重启恢复 → COMMITTED → 恰一 event → cutover scan 通过`。
- D13（控制面死锁：scan 卡未分类 op、frozen 相位 drain 又拒绝分类）零改面解决：frozen drain、proof、admission、scan 行为全部未动——D12 收敛记录后 scan 自然通过。

## 任务与范围

- W6 cutover 线 task_01KXMN5BRWQH93976XBZSHSCN4（ProdCutover line-S）；#876 合入后第四轮 re-enable 前置检查中发现；三冻回执 `freeze_bc5cf4a994eee5aafcf9b233`。
- 生产状态未触碰；部署 + daemon 重启 + re-enable 为合并后 operator 动作。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 授权锚：task_01KXMN5BRWQH93976XBZSHSCN4；W6 修完即 cut 常设授权。
- 触碰的 protected 路径：无（`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`tools/test-tier-manifest.mjs`、`harness/**` 均未动）。
- 无削 gate：frozen 相位 drain 限制、publication proof、admission 与 scan 的 fail-closed 语义全部不变。

## 验证

- 在已合并 #876 之上根 `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0（32 个 stop-point gates 全绿）。
- 生产实证诊断：卡住的 op（`namespace-…:8340213642…`，内层 commit 3c78050ca / merge f47f272f4）记录 `state=INDEXED` 且 durable event 已存在；两笔更老残账在上次启动已成功恢复——把失败面隔离到重复发布路径。
- 新回归在同一生产同源夹具环内：补丁前复现 INDEXED 卡死红相，补丁后转绿。

## 审查证据

- CEO 语义验收：以恢复到的 durable event 恰一次完成回执；不存在第二条发布路径；D13 明确不动并附理由——diff 与报告中均确认。

## 残余风险

- 真实生产 op 须部署 + daemon 重启后才收敛；随后的 scan/confirm/re-enable 与完整冒烟矩阵仍是宣布第四轮 re-enable 成功的 operator 门。
- 启动恢复仍同步扫 first-parent 历史（已知慢启动，本台账约 8–12 分钟）；索引化列为后续项。

## 关联材料

- `harness/tasks/task_01KXMN5BRWQH93976XBZSHSCN4-prodcutover-s-sme-tw-a1-4-island-w6-cutover/artifacts/line-S/w6-third-freeze-2026-07-17.md`。
- PR #865（D0–D5）、#872（D6–D9）、#876（D10–D11 + Linux SO_PEERCRED）。
