### PR TITLE
fix: isolate authority flush domains, admit task creation, and move recovery off daemon startup (W6 D15/D16 + perf)

### DIFF
--- a/packages/cli/src/commands/preset-task.ts
+++ b/packages/cli/src/commands/preset-task.ts
@@ -14,6 +14,7 @@ import {
   type HarnessLayoutInput,
   type MaterializedTemplatePlan,
   type OperationalActor,
+  type ProvenancePayload,
   type WriteCoordinator,
   type WriteError
 } from "../../../kernel/src/index.ts";
@@ -311,6 +312,64 @@ export function materializePresetTaskScaffold(
       issues: materialized.issues
     }
   };
+}
+
+export function buildAuthorityPresetTaskCreateWrites(
+  rootInput: HarnessLayoutInput,
+  action: NewTaskAction,
+  settings: ProjectHarnessSettings,
+  createdAt: string,
+  provenance: ProvenancePayload
+): ReadonlyArray<{ readonly path: string; readonly body: string; readonly packageSlug?: string }> {
+  if (!action.taskId || action.fromLegacyId || action.moduleKey || action.registerModule) {
+    throw new Error("AUTHORITY_PRESET_TASK_CREATE_SHAPE_UNSUPPORTED");
+  }
+  const vertical = action.vertical ?? settings.defaultVertical ?? "software/coding";
+  const presetId = action.preset ?? (action.longRunning ? "long-running-task" : settings.defaultPreset ?? "standard-task");
+  const scaffold = materializePresetTaskScaffold(rootInput, {
+    command: "new-task",
+    vertical,
+    presetId,
+    profileId: action.profile ?? settings.defaultProfile,
+    locale: action.locale ?? settings.locale ?? "zh-CN"
+  }, settings);
+  if (!scaffold.ok) {
+    throw new Error(`AUTHORITY_PRESET_TASK_CREATE_INVALID:${scaffold.result.error?.code ?? "unknown"}`);
+  }
+  const catalog = bundledTemplateCatalog(vertical);
+  if (!catalog) throw new Error(`AUTHORITY_PRESET_TASK_CREATE_CATALOG_REQUIRED:${vertical}`);
+  const contractSnapshot = compileTaskContractSnapshot({
+    vertical,
+    preset: scaffold.preset.manifest,
+    profileId: scaffold.materialized.profile.id,
+    catalog,
+    documents: scaffold.materialized.documents,
+    capturedAt: createdAt,
+    capturedBy: "task-create"
+  });
+  const index = makeIndex({
+    taskId: action.taskId,
+    title: action.title,
+    parent: action.parent,
+    status: "planned",
+    bindingCreatedAt: createdAt,
+    workKind: action.workKind,
+    riskTier: action.riskTier,
+    urgency: action.urgency,
+    vertical,
+    preset: scaffold.preset.manifest.id,
+    profile: scaffold.materialized.profile.id,
+    provenance: [provenance]
+  }, stablePayloadHash);
+  return [
+    { path: "INDEX.md", body: renderIndex(index), packageSlug: action.slug },
+    { path: "task-contract.json", body: `${JSON.stringify(contractSnapshot, null, 2)}\n`, packageSlug: action.slug },
+    ...scaffold.materialized.documents.map((document) => ({
+      path: document.materializeAs,
+      body: renderTemplateBody(document.body, action.title),
+      packageSlug: action.slug
+    }))
+  ];
 }
 
 function renderModuleSelection(module: { readonly key: string; readonly title: string; readonly scopes: ReadonlyArray<string> }): string {

--- a/packages/cli/src/daemon/authority-command-submission.ts
+++ b/packages/cli/src/daemon/authority-command-submission.ts
@@ -3,6 +3,7 @@ import {
   decodeSemanticMutationEnvelopeV2,
   isCompleteAuthorityCommittedReceiptV2,
   operationIdDiagnosticV2,
+  semanticRequestDigestV2,
   type AuthorityOperationReceipt,
   type AuthoritySubmissionService,
   type AuthorizedOperationAttemptV2
@@ -49,12 +50,48 @@ export function createDaemonAuthorityCommandSubmissionV2(options: {
   return {
     submit: async (input) => {
       const attempt = await options.attemptCompiler.compile(input);
-      const expectedOpId = operationIdDiagnosticV2(decodeSemanticMutationEnvelopeV2(attempt.envelope).operationId);
+      const envelope = decodeSemanticMutationEnvelopeV2(attempt.envelope);
+      const expectedOpId = operationIdDiagnosticV2(envelope.operationId);
       const receipt = await options.authorityService.submitV2!(attempt);
       assertCompleteAuthorityReceiptV2(receipt);
       assertAuthorityReceiptOperation(receipt, expectedOpId);
       return receipt;
     }
+  };
+}
+
+export function gateAuthoritySubmissionForRecovery(
+  service: AuthoritySubmissionService,
+  unavailableReason: () => string | undefined
+): AuthoritySubmissionService {
+  return {
+    getOperation: service.getOperation,
+    submit: async (envelope) => {
+      const reason = unavailableReason();
+      return reason
+        ? {
+          tag: "RETRYABLE_NOT_COMMITTED",
+          workspaceId: envelope.workspaceId,
+          opId: envelope.opId,
+          semanticDigest: envelope.claimedDigest,
+          reason
+        }
+        : service.submit(envelope);
+    },
+    ...(service.submitV2 ? {
+      submitV2: async (attempt) => {
+        const reason = unavailableReason();
+        if (!reason) return service.submitV2!(attempt);
+        const envelope = decodeSemanticMutationEnvelopeV2(attempt.envelope);
+        return {
+          tag: "RETRYABLE_NOT_COMMITTED",
+          workspaceId: envelope.workspaceId,
+          opId: operationIdDiagnosticV2(envelope.operationId),
+          semanticDigest: Buffer.from(semanticRequestDigestV2(envelope)).toString("hex"),
+          reason
+        };
+      }
+    } : {})
   };
 }
 

--- a/packages/cli/src/daemon/authority-publication-evidence.ts
+++ b/packages/cli/src/daemon/authority-publication-evidence.ts
@@ -1,6 +1,7 @@
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import path from "node:path";
+import { promisify } from "node:util";
 import type { CanonicalPublicationInspector } from "../../../application/src/index.ts";
 import {
   encodeCanonicalCbor,
@@ -27,6 +28,22 @@ export interface GitCanonicalPublicationInspector extends CanonicalPublicationIn
   ) => Promise<CanonicalPublicationEvidence>;
   readonly findPublication: (expectedOpIds: ReadonlyArray<string>) => Promise<CanonicalPublicationEvidence>;
   readonly findPublicationForOperation: (opId: string) => Promise<CanonicalPublicationEvidence>;
+  readonly scanFirstParentOperationAnchors: (input: {
+    readonly exclusiveCommit?: string;
+    readonly interestedOpIds: ReadonlySet<string>;
+  }) => Promise<FirstParentOperationAnchorScan>;
+}
+
+export interface FirstParentOperationAnchor {
+  readonly commitSha: string;
+  readonly previousCommit: string;
+  readonly opIds: ReadonlyArray<string>;
+}
+
+export interface FirstParentOperationAnchorScan {
+  readonly headCommit: string | null;
+  readonly scannedCommitCount: number;
+  readonly anchors: ReadonlyArray<FirstParentOperationAnchor>;
 }
 
 export class AuthorityCanonicalPublicationNotFoundError extends Error {
@@ -39,9 +56,63 @@ export class AuthorityCanonicalPublicationNotFoundError extends Error {
   }
 }
 
+export class AuthorityRecoveryWatermarkInvalidError extends Error {
+  constructor(commitSha: string) {
+    super(`AUTHORITY_RECOVERY_WATERMARK_INVALID:commitSha=${commitSha}`);
+    this.name = "AuthorityRecoveryWatermarkInvalidError";
+  }
+}
+
 export function createGitCanonicalPublicationInspector(canonicalRoot: string): GitCanonicalPublicationInspector {
   const rootDir = path.resolve(canonicalRoot);
   const currentHead = async (): Promise<string | null> => gitOptional(rootDir, "rev-parse", "--verify", "HEAD");
+  const scanFirstParentOperationAnchors = async (input: {
+    readonly exclusiveCommit?: string;
+    readonly interestedOpIds: ReadonlySet<string>;
+  }): Promise<FirstParentOperationAnchorScan> => {
+    const headCommit = await currentHead();
+    if (!headCommit) return { headCommit: null, scannedCommitCount: 0, anchors: [] };
+    let commits: string[];
+    try {
+      commits = input.exclusiveCommit === headCommit
+        ? []
+        : (await publicationGitTextAsync(
+          rootDir,
+          "rev-list",
+          "--first-parent",
+          input.exclusiveCommit ? `${input.exclusiveCommit}..${headCommit}` : headCommit
+        )).split("\n").filter(Boolean);
+    } catch (error) {
+      if (input.exclusiveCommit) throw new AuthorityRecoveryWatermarkInvalidError(input.exclusiveCommit);
+      throw error;
+    }
+    const recoveryWatermark = input.exclusiveCommit;
+    if (recoveryWatermark && headCommit !== recoveryWatermark) {
+      const oldest = commits.at(-1);
+      const oldestParents = await (async () => {
+        try {
+          return oldest
+            ? (await publicationGitTextAsync(rootDir, "rev-list", "--parents", "-n", "1", oldest)).split(" ").slice(1)
+            : [];
+        } catch {
+          throw new AuthorityRecoveryWatermarkInvalidError(recoveryWatermark);
+        }
+      })();
+      if (!oldest || oldestParents[0] !== recoveryWatermark) {
+        throw new AuthorityRecoveryWatermarkInvalidError(recoveryWatermark);
+      }
+    }
+    const anchors: FirstParentOperationAnchor[] = [];
+    for (const commitSha of commits) {
+      const parents = (await publicationGitTextAsync(rootDir, "rev-list", "--parents", "-n", "1", commitSha)).split(" ").slice(1);
+      if (parents.length !== 2) continue;
+      const sessionSubject = await publicationGitTextAsync(rootDir, "show", "-s", "--format=%s", parents[1]!);
+      const opIds = commitSubjectOpIds(sessionSubject);
+      if (!opIds.some((opId) => input.interestedOpIds.has(opId))) continue;
+      anchors.push({ commitSha, previousCommit: parents[0]!, opIds });
+    }
+    return { headCommit, scannedCommitCount: commits.length, anchors };
+  };
   const inspectPublication = async (
     expectedPreviousHead: string | null,
     expectedOpIds: ReadonlyArray<string>,
@@ -128,6 +199,7 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
       return { commitSha: evidence.commitSha, parentCommits: evidence.parentCommits };
     },
     inspectPublication,
+    scanFirstParentOperationAnchors,
     findPublication: async (expectedOpIds) => {
       const expectedSessionSubjectSuffix = `[${expectedOpIds.join(",")}]`;
       const firstParentCommits = publicationGitText(rootDir, "rev-list", "--first-parent", "HEAD")
@@ -301,6 +373,17 @@ function gitOptional(rootDir: string, ...args: ReadonlyArray<string>): string | 
 
 function publicationGitText(rootDir: string, ...args: ReadonlyArray<string>): string {
   return readAuthorityGitBytes(rootDir, ...args).toString("utf8").trim();
+}
+
+const execFileAsync = promisify(execFile);
+
+async function publicationGitTextAsync(rootDir: string, ...args: ReadonlyArray<string>): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    windowsHide: true,
+    maxBuffer: 64 * 1024 * 1024
+  });
+  return stdout.trim();
 }
 
 function gitExitCode(rootDir: string, ...args: ReadonlyArray<string>): number {

--- a/packages/cli/src/daemon/authority-publication-evidence.ts
+++ b/packages/cli/src/daemon/authority-publication-evidence.ts
@@ -29,6 +29,16 @@ export interface GitCanonicalPublicationInspector extends CanonicalPublicationIn
   readonly findPublicationForOperation: (opId: string) => Promise<CanonicalPublicationEvidence>;
 }
 
+export class AuthorityCanonicalPublicationNotFoundError extends Error {
+  readonly opId: string;
+
+  constructor(opId: string) {
+    super(`AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND:expectedOpId=${opId}`);
+    this.name = "AuthorityCanonicalPublicationNotFoundError";
+    this.opId = opId;
+  }
+}
+
 export function createGitCanonicalPublicationInspector(canonicalRoot: string): GitCanonicalPublicationInspector {
   const rootDir = path.resolve(canonicalRoot);
   const currentHead = async (): Promise<string | null> => gitOptional(rootDir, "rev-parse", "--verify", "HEAD");
@@ -151,6 +161,7 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
         if (!opIds.includes(opId)) continue;
         matches.push(await inspectPublication(parents[0]!, opIds, commitSha));
       }
+      if (matches.length === 0) throw new AuthorityCanonicalPublicationNotFoundError(opId);
       if (matches.length !== 1) {
         throw new Error(
           `AUTHORITY_CANONICAL_PUBLICATION_NOT_UNIQUE:expectedOpId=${opId};matches=${matches.map((entry) => entry.commitSha).join(",") || "none"}`

--- a/packages/cli/src/daemon/production-authority-attempt-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-attempt-compiler.ts
@@ -43,6 +43,8 @@ import {
 } from "./authority-production-state.ts";
 import { productionLifecycleAttemptIntent } from "./production-authority-lifecycle-intents.ts";
 import { defaultCliAdapterProvider } from "../composition/adapter-registry.ts";
+import { buildAuthorityPresetTaskCreateWrites, shouldUsePresetAwareNewTask } from "../commands/preset-task.ts";
+import { readProjectHarnessSettings, shouldUseSettingsPresetAwareNewTask } from "../commands/settings.ts";
 
 type KeyMaterial = ReturnType<typeof openAuthorityProductionKeyMaterial>;
 
@@ -201,23 +203,32 @@ async function canonicalAttemptIntent(
     responsibleHuman: actor.principal.personId
   };
   if (action.kind === "new-task" && action.taskId
-    && !action.fromLegacyId && !action.vertical && !action.preset && !action.profile
-    && !action.moduleKey && !action.registerModule) {
+    && !action.fromLegacyId && !action.moduleKey && !action.registerModule) {
     const provenance = {
       runtime: currentSession.runtime,
       sessionId: currentSession.sessionId,
       boundAt: currentSession.detectedAt
     };
-    const writes = defaultCliAdapterProvider().buildLocalTaskCreateWrites({
-      taskId: action.taskId,
-      title: action.title,
-      allowManualId: action.allowManualId,
-      slug: action.slug,
-      parent: action.parent,
-      workKind: action.workKind,
-      riskTier: action.riskTier,
-      urgency: action.urgency
-    }, currentSession.detectedAt, provenance);
+    const settingsResult = readProjectHarnessSettings({ rootDir: command.rootDir, layoutOverrides: command.layoutOverrides }, "new-task");
+    if (!settingsResult.ok) throw new Error(`AUTHORITY_TASK_CREATE_SETTINGS_INVALID:${settingsResult.result.error?.code ?? "unknown"}`);
+    const writes = shouldUsePresetAwareNewTask(action) || shouldUseSettingsPresetAwareNewTask(settingsResult.settings)
+      ? buildAuthorityPresetTaskCreateWrites(
+        { rootDir: command.rootDir, layoutOverrides: command.layoutOverrides },
+        action,
+        settingsResult.settings,
+        currentSession.detectedAt,
+        provenance
+      )
+      : defaultCliAdapterProvider().buildLocalTaskCreateWrites({
+        taskId: action.taskId,
+        title: action.title,
+        allowManualId: action.allowManualId,
+        slug: action.slug,
+        parent: action.parent,
+        workKind: action.workKind,
+        riskTier: action.riskTier,
+        urgency: action.urgency
+      }, currentSession.detectedAt, provenance);
     const indexBody = writes.find((write) => write.path === "INDEX.md")!.body;
     const entity = ref("task", `task/${action.taskId}`);
     const payload: TaskDecisionModuleCommandPayloadV2 = {

--- a/packages/cli/src/daemon/production-authority-lifecycle.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle.ts
@@ -51,7 +51,10 @@ import {
   type AuthorityProductionRepoConfigV1,
   type DurableAuthorityBindingRuntimeV2
 } from "./authority-production-state.ts";
-import { createGitCanonicalPublicationInspector } from "./authority-publication-evidence.ts";
+import {
+  AuthorityCanonicalPublicationNotFoundError,
+  createGitCanonicalPublicationInspector
+} from "./authority-publication-evidence.ts";
 import { assertPublicationMatchesMutationSet } from "./authority-publication-evidence.ts";
 import { createAuthorityProductionScanner } from "./authority-production-scanner.ts";
 import { createProductionCompoundReceiptComposition } from "./compound-receipt-composition.ts";
@@ -290,6 +293,24 @@ export async function recoverPendingProductionEvents(input: {
         await input.operationRegistry.put({ ...indexed, state: "COMMITTED", receipt, commitSha: receipt.commitSha });
         progressed = true;
       } catch (error) {
+        if (error instanceof AuthorityCanonicalPublicationNotFoundError
+          && error.opId === record.opId
+          && record.state === "INDETERMINATE"
+          && !record.commitSha) {
+          const originalReason = record.receipt?.tag === "INDETERMINATE"
+            ? record.receipt.reason
+            : "missing indeterminate receipt reason";
+          const receipt = {
+            tag: "REJECTED" as const,
+            workspaceId: record.workspaceId,
+            opId: record.opId,
+            semanticDigest: record.semanticDigest,
+            reason: `AUTHORITY_RECOVERY_CONFIRMED_NOT_PUBLISHED:originalReason=${originalReason}`
+          };
+          await input.operationRegistry.put({ ...record, state: "REJECTED", receipt });
+          progressed = true;
+          continue;
+        }
         // Fail closed: unverifiable historical effects remain indeterminate.
         await input.onDeferred?.(record, error);
         deferred.push(record);

--- a/packages/cli/src/daemon/production-authority-lifecycle.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle.ts
@@ -35,7 +35,10 @@ import {
   type EntityRegistration
 } from "../../../kernel/src/index.ts";
 import { loadDaemonIdentity } from "../commands/daemon/productization.ts";
-import { createDaemonAuthorityCommandSubmissionV2 } from "./authority-command-submission.ts";
+import {
+  createDaemonAuthorityCommandSubmissionV2,
+  gateAuthoritySubmissionForRecovery
+} from "./authority-command-submission.ts";
 import {
   createAuthorityRepoLifecycleController,
   type AuthorityRepoComponent,
@@ -52,7 +55,6 @@ import {
   type DurableAuthorityBindingRuntimeV2
 } from "./authority-production-state.ts";
 import {
-  AuthorityCanonicalPublicationNotFoundError,
   createGitCanonicalPublicationInspector
 } from "./authority-publication-evidence.ts";
 import { assertPublicationMatchesMutationSet } from "./authority-publication-evidence.ts";
@@ -64,6 +66,13 @@ import {
   createProductionCanonicalSemanticState
 } from "./production-authority-attempt-compiler.ts";
 import { gateCutoverAdmission } from "./authority-cutover-admission.ts";
+import {
+  recoverPendingProductionEvents,
+  recoveryErrorCode,
+  recoveryErrorSummary
+} from "./production-authority-recovery.ts";
+
+export { recoverPendingProductionEvents } from "./production-authority-recovery.ts";
 
 interface RepoProductionMaterial {
   readonly config: AuthorityProductionRepoConfigV1;
@@ -73,6 +82,13 @@ interface RepoProductionMaterial {
   readonly authoredRoot: string;
   readonly configurationDigest: string;
   readonly serviceStateRoot: string;
+  readonly recovery: ProductionRecoveryState;
+}
+
+interface ProductionRecoveryState {
+  status: "recovering" | "complete" | "failed";
+  error?: string;
+  promise: Promise<void>;
 }
 
 const productionAuthorityV2EntityKinds = [
@@ -83,6 +99,7 @@ export function createProductionAuthorityLifecycle(input: {
   readonly manifestPath: string;
   readonly layoutOverrides?: { readonly authoredRoot?: string };
   readonly daemonLogService?: DaemonLogService;
+  readonly backgroundRecovery?: true;
 }): AuthorityRepoLifecycleController {
   const manifest = loadAuthorityProductionManifest(input.manifestPath);
   const materials = new Map<string, RepoProductionMaterial>();
@@ -168,7 +185,8 @@ export function createProductionAuthorityLifecycle(input: {
         eventLog,
         publicationInspector
       });
-      materials.set(repo.repoId, {
+      const recovery = {} as ProductionRecoveryState;
+      const material: RepoProductionMaterial = {
         config,
         keyStore: keyMaterial.keyStore,
         keyRegistry: keyMaterial.registry,
@@ -178,19 +196,22 @@ export function createProductionAuthorityLifecycle(input: {
           ...(input.layoutOverrides ? { layoutOverrides: input.layoutOverrides } : {})
         }).authoredRoot,
         configurationDigest: authorityManifestSourceDigest(input.manifestPath),
-        serviceStateRoot: manifest.serviceStateRoot
-      });
+        serviceStateRoot: manifest.serviceStateRoot,
+        recovery
+      };
+      materials.set(repo.repoId, material);
       publicationObservers.set(repo.repoId, async (previousCommit, expectedOpIds, expectedCommitSha) => {
         const inspector = publicationInspector;
         return inspector.inspectPublication(previousCommit, expectedOpIds, expectedCommitSha);
       });
-      await recoverPendingProductionEvents({
+      const runRecovery = async () => recoverPendingProductionEvents({
         workspaceId: config.workspaceId,
         operationRegistry: state.operationRegistry,
         replicaChangeLog: state.replicaChangeLog,
         eventLog,
         publicationInspector,
         recover: committedEventPublisher.recoverCommittedReceipt,
+        watermarkPath: `${state.stateDirectory}/recovery-watermark.json`,
         ...(input.daemonLogService ? {
           onDeferred: (record: import("../../../application/src/index.ts").AuthorityStoredOperationRecord, error: unknown) =>
             input.daemonLogService!.append({
@@ -204,6 +225,15 @@ export function createProductionAuthorityLifecycle(input: {
             }, { repo: { repoId: config.repoId, canonicalRoot: config.canonicalRoot } }).then(() => undefined)
         } : {})
       });
+      recovery.status = "recovering";
+      recovery.promise = input.backgroundRecovery
+        ? new Promise<void>((resolve) => {
+          setImmediate(() => {
+            void settleProductionRecovery(recovery, runRecovery).finally(resolve);
+          });
+        })
+        : settleProductionRecovery(recovery, runRecovery);
+      if (!input.backgroundRecovery) await recovery.promise;
       return {
         authenticatedPersonRegistry: identity.personRegistry,
         deriveExecutorFromParsedPreset: (presetId) => `preset:${presetId}`,
@@ -239,8 +269,10 @@ export function createProductionAuthorityLifecycle(input: {
         (component as ProductionAuthorityRepoComponent).setServing(true);
       },
       stop: async ({ repo, component, reason }) => {
+        const material = options.materials.get(repo.repoId);
         try {
           await component.stop(reason);
+          await material?.recovery.promise;
         } finally {
           materials.delete(repo.repoId);
           publicationObservers.delete(repo.repoId);
@@ -248,87 +280,6 @@ export function createProductionAuthorityLifecycle(input: {
       }
     };
   }
-}
-
-export async function recoverPendingProductionEvents(input: {
-  readonly workspaceId: string;
-  readonly operationRegistry: import("../../../application/src/index.ts").AuthorityOperationRegistry;
-  readonly replicaChangeLog: import("../../../application/src/index.ts").ReplicaChangeLog;
-  readonly eventLog: ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>;
-  readonly publicationInspector: ReturnType<typeof createGitCanonicalPublicationInspector>;
-  readonly recover: (record: import("../../../application/src/index.ts").AuthorityStoredOperationRecord) => Promise<import("../../../application/src/index.ts").AuthorityCommittedReceipt>;
-  readonly onDeferred?: (
-    record: import("../../../application/src/index.ts").AuthorityStoredOperationRecord,
-    error: unknown
-  ) => Promise<void>;
-}): Promise<void> {
-  const records = await input.operationRegistry.list(input.workspaceId);
-  const pending = records.filter((record) => {
-    if ((record.state !== "INDEXED" && record.state !== "INDETERMINATE")
-      || record.recordedProtocol?.kind !== "semantic-mutation-envelope/v2"
-      || !record.authorityIntegrity || !record.canonicalRequestEnvelope) return false;
-    return true;
-  });
-  let remaining = [...pending];
-  while (remaining.length > 0) {
-    let progressed = false;
-    const deferred: typeof remaining = [];
-    for (const record of remaining) {
-      try {
-        const evidence = await input.publicationInspector.findPublicationForOperation(record.opId);
-        if (record.commitSha && record.commitSha !== evidence.commitSha) {
-          throw new Error("AUTHORITY_V2_RECOVERY_COMMIT_MISMATCH");
-        }
-        assertPublicationMatchesMutationSet(evidence, record.authorityIntegrity!.canonicalMutationSet);
-        const change = await input.replicaChangeLog.getByOperation(record.workspaceId, record.opId);
-        if (change && (change.commitSha !== evidence.commitSha
-          || change.previousCommit !== evidence.previousCommit
-          || change.semanticDigest !== record.semanticDigest
-          || change.authorityIntegrity?.semanticMutationSetDigest !== record.authorityIntegrity!.semanticMutationSetDigest)) {
-          throw new Error("AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH");
-        }
-        const indexed = { ...record, state: "INDEXED" as const, commitSha: evidence.commitSha };
-        await input.operationRegistry.put(indexed);
-        const receipt = await input.recover(indexed);
-        await input.operationRegistry.put({ ...indexed, state: "COMMITTED", receipt, commitSha: receipt.commitSha });
-        progressed = true;
-      } catch (error) {
-        if (error instanceof AuthorityCanonicalPublicationNotFoundError
-          && error.opId === record.opId
-          && record.state === "INDETERMINATE"
-          && !record.commitSha) {
-          const originalReason = record.receipt?.tag === "INDETERMINATE"
-            ? record.receipt.reason
-            : "missing indeterminate receipt reason";
-          const receipt = {
-            tag: "REJECTED" as const,
-            workspaceId: record.workspaceId,
-            opId: record.opId,
-            semanticDigest: record.semanticDigest,
-            reason: `AUTHORITY_RECOVERY_CONFIRMED_NOT_PUBLISHED:originalReason=${originalReason}`
-          };
-          await input.operationRegistry.put({ ...record, state: "REJECTED", receipt });
-          progressed = true;
-          continue;
-        }
-        // Fail closed: unverifiable historical effects remain indeterminate.
-        await input.onDeferred?.(record, error);
-        deferred.push(record);
-      }
-    }
-    if (!progressed) return;
-    remaining = deferred;
-  }
-}
-
-function recoveryErrorSummary(error: unknown): string {
-  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
-}
-
-function recoveryErrorCode(error: unknown): string {
-  if (!(error instanceof Error)) return "AUTHORITY_RECOVERY_UNKNOWN_ERROR";
-  const messageCode = /^([A-Z][A-Z0-9_]+)/u.exec(error.message)?.[1];
-  return messageCode ?? error.name;
 }
 
 interface ProductionAuthorityRepoComponent extends AuthorityRepoComponent {
@@ -396,9 +347,12 @@ function createRepoComponent(
     bindConnection: (context) => {
       if (!serving || stopped) throw new Error("AUTHORITY_REPO_COMPONENT_NOT_SERVING");
       assertConnectionContext(input, material.config, context);
-      const authorityService = gateCutoverAdmission(
-        attestSubmissionService(createConnectionAuthorityService(input, material, context, publicationExecutor), context),
-        cutoverControl
+      const authorityService = gateAuthoritySubmissionForRecovery(
+        gateCutoverAdmission(
+          attestSubmissionService(createConnectionAuthorityService(input, material, context, publicationExecutor), context),
+          cutoverControl
+        ),
+        () => recoveryUnavailableReason(material)
       );
       const commandSubmission = createDaemonAuthorityCommandSubmissionV2({
         authorityService,
@@ -438,6 +392,28 @@ function createRepoComponent(
       sessions.clear();
     }
   };
+}
+
+async function settleProductionRecovery(
+  recovery: ProductionRecoveryState,
+  run: () => Promise<void>
+): Promise<void> {
+  try {
+    await run();
+    recovery.status = "complete";
+    recovery.error = undefined;
+  } catch (error) {
+    recovery.status = "failed";
+    recovery.error = recoveryErrorSummary(error);
+  }
+}
+
+function recoveryUnavailableReason(material: RepoProductionMaterial): string | undefined {
+  if (material.recovery.status === "complete") return undefined;
+  if (material.recovery.status === "recovering") {
+    return `AUTHORITY_RECOVERY_IN_PROGRESS:repoId=${material.config.repoId}; retry after daemon recovery completes`;
+  }
+  return `AUTHORITY_RECOVERY_FAILED:repoId=${material.config.repoId};error=${material.recovery.error ?? "unknown"}`;
 }
 
 function createConnectionAuthorityService(

--- a/packages/cli/src/daemon/production-authority-recovery.ts
+++ b/packages/cli/src/daemon/production-authority-recovery.ts
@@ -1,0 +1,229 @@
+import { closeSync, fsyncSync, openSync, readFileSync, renameSync, writeSync } from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import type {
+  AuthorityCommittedReceipt,
+  AuthorityOperationRegistry,
+  AuthorityStoredOperationRecord,
+  ReplicaChangeLog
+} from "../../../application/src/index.ts";
+import type { makeLocalAuthorityAttributionEventV2Log } from "../../../kernel/src/index.ts";
+import {
+  assertPublicationMatchesMutationSet,
+  AuthorityCanonicalPublicationNotFoundError,
+  AuthorityRecoveryWatermarkInvalidError,
+  type GitCanonicalPublicationInspector
+} from "./authority-publication-evidence.ts";
+
+interface ProductionRecoveryInput {
+  readonly workspaceId: string;
+  readonly operationRegistry: AuthorityOperationRegistry;
+  readonly replicaChangeLog: ReplicaChangeLog;
+  readonly eventLog: ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>;
+  readonly publicationInspector: GitCanonicalPublicationInspector;
+  readonly recover: (record: AuthorityStoredOperationRecord) => Promise<AuthorityCommittedReceipt>;
+  readonly watermarkPath?: string;
+  readonly onDeferred?: (record: AuthorityStoredOperationRecord, error: unknown) => Promise<void>;
+}
+
+export async function recoverPendingProductionEvents(input: ProductionRecoveryInput): Promise<void> {
+  if (input.watermarkPath && typeof input.publicationInspector.scanFirstParentOperationAnchors === "function") {
+    await recoverIncrementally(input, input.watermarkPath);
+    return;
+  }
+  await recoverByOperationLookup(input);
+}
+
+async function recoverIncrementally(input: ProductionRecoveryInput, watermarkPath: string): Promise<void> {
+  const records = await input.operationRegistry.list(input.workspaceId);
+  const pending = records.filter(isRecoverablePendingRecord);
+  const interestedOpIds = new Set(pending.map((record) => record.opId));
+  const storedWatermark = readRecoveryWatermark(watermarkPath, input.workspaceId);
+  let scan;
+  try {
+    scan = await input.publicationInspector.scanFirstParentOperationAnchors({
+      ...(storedWatermark ? { exclusiveCommit: storedWatermark } : {}),
+      interestedOpIds
+    });
+  } catch (error) {
+    if (!(error instanceof AuthorityRecoveryWatermarkInvalidError)) throw error;
+    scan = await input.publicationInspector.scanFirstParentOperationAnchors({ interestedOpIds });
+  }
+  const anchorsByOpId = new Map<string, typeof scan.anchors>();
+  for (const anchor of scan.anchors) {
+    for (const opId of anchor.opIds) {
+      if (!interestedOpIds.has(opId)) continue;
+      const known = anchorsByOpId.get(opId) ?? [];
+      anchorsByOpId.set(opId, [...known, anchor]);
+    }
+  }
+  const scanOrder = new Map(scan.anchors.map((anchor, index) => [anchor.commitSha, index]));
+  const ordered = [...pending].sort((left, right) => {
+    const leftIndex = scanOrder.get(anchorsByOpId.get(left.opId)?.[0]?.commitSha ?? "") ?? -1;
+    const rightIndex = scanOrder.get(anchorsByOpId.get(right.opId)?.[0]?.commitSha ?? "") ?? -1;
+    return rightIndex - leftIndex || left.opId.localeCompare(right.opId);
+  });
+  for (const record of ordered) {
+    const anchors = anchorsByOpId.get(record.opId) ?? [];
+    if (anchors.length === 0) {
+      if (record.state === "INDETERMINATE" && !record.commitSha) {
+        await terminalizeConfirmedAbsent(input.operationRegistry, record);
+      } else {
+        await input.onDeferred?.(record, new AuthorityCanonicalPublicationNotFoundError(record.opId));
+      }
+      continue;
+    }
+    if (anchors.length !== 1) {
+      await input.onDeferred?.(record, new Error(
+        `AUTHORITY_CANONICAL_PUBLICATION_NOT_UNIQUE:expectedOpId=${record.opId};matches=${anchors.map((anchor) => anchor.commitSha).join(",")}`
+      ));
+      continue;
+    }
+    const anchor = anchors[0]!;
+    try {
+      const evidence = await input.publicationInspector.inspectPublication(
+        anchor.previousCommit,
+        anchor.opIds,
+        anchor.commitSha
+      );
+      await recoverPublishedRecord(input, record, evidence);
+    } catch (error) {
+      await input.onDeferred?.(record, error);
+    }
+  }
+  const unsettled = (await input.operationRegistry.list(input.workspaceId)).filter(isUnsettledV2Record);
+  if (unsettled.length === 0 && scan.headCommit) {
+    writeRecoveryWatermark(watermarkPath, input.workspaceId, scan.headCommit);
+  }
+}
+
+async function recoverByOperationLookup(input: ProductionRecoveryInput): Promise<void> {
+  const records = await input.operationRegistry.list(input.workspaceId);
+  let remaining = records.filter(isRecoverablePendingRecord);
+  while (remaining.length > 0) {
+    let progressed = false;
+    const deferred: typeof remaining = [];
+    for (const record of remaining) {
+      try {
+        const evidence = await input.publicationInspector.findPublicationForOperation(record.opId);
+        await recoverPublishedRecord(input, record, evidence);
+        progressed = true;
+      } catch (error) {
+        if (error instanceof AuthorityCanonicalPublicationNotFoundError
+          && error.opId === record.opId
+          && record.state === "INDETERMINATE"
+          && !record.commitSha) {
+          await terminalizeConfirmedAbsent(input.operationRegistry, record);
+          progressed = true;
+          continue;
+        }
+        await input.onDeferred?.(record, error);
+        deferred.push(record);
+      }
+    }
+    if (!progressed) return;
+    remaining = deferred;
+  }
+}
+
+async function recoverPublishedRecord(
+  input: ProductionRecoveryInput,
+  record: AuthorityStoredOperationRecord,
+  evidence: Awaited<ReturnType<GitCanonicalPublicationInspector["inspectPublication"]>>
+): Promise<void> {
+  if (record.commitSha && record.commitSha !== evidence.commitSha) {
+    throw new Error("AUTHORITY_V2_RECOVERY_COMMIT_MISMATCH");
+  }
+  assertPublicationMatchesMutationSet(evidence, record.authorityIntegrity!.canonicalMutationSet);
+  const change = await input.replicaChangeLog.getByOperation(record.workspaceId, record.opId);
+  if (change && (change.commitSha !== evidence.commitSha
+    || change.previousCommit !== evidence.previousCommit
+    || change.semanticDigest !== record.semanticDigest
+    || change.authorityIntegrity?.semanticMutationSetDigest !== record.authorityIntegrity!.semanticMutationSetDigest)) {
+    throw new Error("AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH");
+  }
+  const indexed = { ...record, state: "INDEXED" as const, commitSha: evidence.commitSha };
+  await input.operationRegistry.put(indexed);
+  const receipt = await input.recover(indexed);
+  await input.operationRegistry.put({ ...indexed, state: "COMMITTED", receipt, commitSha: receipt.commitSha });
+}
+
+async function terminalizeConfirmedAbsent(
+  operationRegistry: AuthorityOperationRegistry,
+  record: AuthorityStoredOperationRecord
+): Promise<void> {
+  const originalReason = record.receipt?.tag === "INDETERMINATE"
+    ? record.receipt.reason
+    : "missing indeterminate receipt reason";
+  const receipt = {
+    tag: "REJECTED" as const,
+    workspaceId: record.workspaceId,
+    opId: record.opId,
+    semanticDigest: record.semanticDigest,
+    reason: `AUTHORITY_RECOVERY_CONFIRMED_NOT_PUBLISHED:originalReason=${originalReason}`
+  };
+  await operationRegistry.put({ ...record, state: "REJECTED", receipt });
+}
+
+function isRecoverablePendingRecord(record: AuthorityStoredOperationRecord): boolean {
+  return (record.state === "INDEXED" || record.state === "INDETERMINATE")
+    && record.recordedProtocol?.kind === "semantic-mutation-envelope/v2"
+    && Boolean(record.authorityIntegrity)
+    && Boolean(record.canonicalRequestEnvelope);
+}
+
+function isUnsettledV2Record(record: AuthorityStoredOperationRecord): boolean {
+  return record.recordedProtocol?.kind === "semantic-mutation-envelope/v2"
+    && record.state !== "COMMITTED"
+    && record.state !== "REJECTED"
+    && record.state !== "RETRYABLE_NOT_COMMITTED";
+}
+
+function readRecoveryWatermark(filePath: string, workspaceId: string): string | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf8")) as Record<string, unknown>;
+    return parsed.schema === "authority-recovery-watermark/v1"
+      && parsed.workspaceId === workspaceId
+      && typeof parsed.commitSha === "string"
+      && /^[a-f0-9]{40}$/u.test(parsed.commitSha)
+      ? parsed.commitSha
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeRecoveryWatermark(filePath: string, workspaceId: string, commitSha: string): void {
+  const body = `${JSON.stringify({
+    schema: "authority-recovery-watermark/v1",
+    workspaceId,
+    commitSha,
+    scannedAt: new Date().toISOString()
+  })}\n`;
+  const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  const file = openSync(temporaryPath, "wx", 0o600);
+  try {
+    writeSync(file, body);
+    fsyncSync(file);
+  } finally {
+    closeSync(file);
+  }
+  renameSync(temporaryPath, filePath);
+  if (process.platform === "win32") return;
+  const directory = openSync(path.dirname(filePath), "r");
+  try {
+    fsyncSync(directory);
+  } finally {
+    closeSync(directory);
+  }
+}
+
+export function recoveryErrorSummary(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+}
+
+export function recoveryErrorCode(error: unknown): string {
+  if (!(error instanceof Error)) return "AUTHORITY_RECOVERY_UNKNOWN_ERROR";
+  const messageCode = /^([A-Z][A-Z0-9_]+)/u.exec(error.message)?.[1];
+  return messageCode ?? error.name;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -151,6 +151,7 @@ async function runDaemonServe(
         ? createProductionAuthorityLifecycle({
           manifestPath: authorityManifest,
           daemonLogService,
+          backgroundRecovery: true,
           ...(layoutOverrides ? { layoutOverrides } : {})
         })
         : undefined);

--- a/packages/cli/test/authority-submission-error.test.ts
+++ b/packages/cli/test/authority-submission-error.test.ts
@@ -1,7 +1,11 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
-import { authoritySubmissionWriteError } from "../src/daemon/authority-command-submission.ts";
+import {
+  authoritySubmissionWriteError,
+  gateAuthoritySubmissionForRecovery
+} from "../src/daemon/authority-command-submission.ts";
+import { authorityCommandAttemptFixture } from "./helpers/authority-command-adapter-v2.ts";
 
 test("authority JournalUnavailable errors serialize diagnostic fields without stacks", () => {
   const failure = new Error("AUTHORITY_PRODUCTION_PUBLICATION_OBSERVATION_MISMATCH") as Error & { code: string };
@@ -16,4 +20,36 @@ test("authority JournalUnavailable errors serialize diagnostic fields without st
     }
   });
   assert.doesNotMatch(JSON.stringify(writeError), /stack/u);
+});
+
+test("recovery gate returns retryable receipts on both legacy and V2 authority ingress", async () => {
+  let submissions = 0;
+  const service = gateAuthoritySubmissionForRecovery({
+    submit: async () => {
+      submissions += 1;
+      throw new Error("legacy submission must stay gated");
+    },
+    submitV2: async () => {
+      submissions += 1;
+      throw new Error("V2 submission must stay gated");
+    },
+    getOperation: async () => undefined
+  }, () => "AUTHORITY_RECOVERY_IN_PROGRESS:retry");
+  const legacy = await service.submit({
+    workspaceId: "workspace-recovery",
+    opId: "op-recovery",
+    claimedDigest: "a".repeat(64),
+    command: "task.append",
+    operation: { opId: "op-recovery", entityId: "task/task_RECOVERY", kind: "progress_append", payload: { path: "progress.md", append: "x" } },
+    delegationToken: "token",
+    channelNonceDigest: "b".repeat(64),
+    protocol: { wire: 1, event: 1, receipt: 1, digest: 1, commandRegistry: 1 }
+  });
+  const fixture = authorityCommandAttemptFixture();
+  const v2 = await service.submitV2!(fixture.attempt);
+
+  assert.equal(legacy.tag, "RETRYABLE_NOT_COMMITTED");
+  assert.equal(v2.tag, "RETRYABLE_NOT_COMMITTED");
+  assert.equal(v2.opId, fixture.expectedOpId);
+  assert.equal(submissions, 0);
 });

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -38,7 +38,7 @@ import {
   stopDaemon
 } from "../helpers/daemon-cli.ts";
 
-test("production service route preserves progress dry-run and publishes a slugged task append", { timeout: 30_000 }, async () => {
+test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 60_000 }, async () => {
   const fixture = createFixture();
   const userRoot = defaultDaemonUserRoot(fixture.root);
   const env = {
@@ -111,6 +111,44 @@ test("production service route preserves progress dry-run and publishes a slugge
     assert.equal(publication.pipelineGeneratedPaths[0], publication.physicalChanges.find((change) => change.path.startsWith("attribution-events/"))?.path);
     git(fixture.authoredRoot, "diff", "--quiet", publication.commitSha, publication.parentCommits[1]!);
     assert.equal(dryRunHeadAfter, dryRunHead, "typed service dry-run must not create a commit");
+
+    const created = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "create", "--title", "Service route task create"
+    ], { ...env, CODEX_THREAD_ID: "service-task-create-session" });
+    assert.equal(created.status, 0, JSON.stringify(created.receipt));
+    assert.equal(created.receipt.ok, true, JSON.stringify(created.receipt));
+    const createDetails = (created.receipt.details as { readonly data?: Record<string, unknown> } | undefined)?.data ?? {};
+    const createPackagePath = (created.receipt.paths as ReadonlyArray<{ readonly role?: string; readonly path?: string }> | undefined)
+      ?.find((entry) => entry.role === "package")?.path ?? "";
+    assert.match(String(createDetails.taskId ?? ""), /^task_[0-9A-HJKMNP-TV-Z]{26}$/u, JSON.stringify(created.receipt));
+    assert.equal(existsSync(path.join(fixture.repoRoot, createPackagePath, "INDEX.md")), true);
+    assert.equal(existsSync(path.join(fixture.repoRoot, createPackagePath, "task-contract.json")), true);
+    const createOperation = latestAuthorityOperation(fixture.serviceRoot);
+    assert.equal(createOperation.state, "COMMITTED", JSON.stringify(createOperation));
+    assert.equal(createOperation.receipt?.tag, "COMMITTED", JSON.stringify(createOperation));
+    assert.equal(typeof createOperation.opId, "string", JSON.stringify(createOperation));
+    const createPublication = await createGitCanonicalPublicationInspector(fixture.authoredRoot)
+      .findPublicationForOperation(createOperation.opId!);
+    assert.equal(createPublication.commitSha, createOperation.commitSha);
+    assert.equal(createPublication.physicalChanges.filter((change) => change.path.startsWith("attribution-events/")).length, 1);
+    assert.equal(authorityEventBodies(fixture.authoredRoot).filter((body) => body.includes(createOperation.opId!)).length, 1);
+
+    const presetCreated = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "create", "--title", "Service route preset task", "--preset", "docs-task", "--locale", "en-US"
+    ], { ...env, CODEX_THREAD_ID: "service-preset-task-create-session" });
+    assert.equal(presetCreated.status, 0, JSON.stringify(presetCreated.receipt));
+    assert.equal(presetCreated.receipt.ok, true, JSON.stringify(presetCreated.receipt));
+    const presetDetails = (presetCreated.receipt.details as { readonly data?: Record<string, unknown> } | undefined)?.data ?? {};
+    const presetPackagePath = (presetCreated.receipt.paths as ReadonlyArray<{ readonly role?: string; readonly path?: string }> | undefined)
+      ?.find((entry) => entry.role === "package")?.path ?? "";
+    assert.match(String(presetDetails.taskId ?? ""), /^task_[0-9A-HJKMNP-TV-Z]{26}$/u, JSON.stringify(presetCreated.receipt));
+    assert.equal(existsSync(path.join(fixture.repoRoot, presetPackagePath, "INDEX.md")), true);
+    assert.equal(existsSync(path.join(fixture.repoRoot, presetPackagePath, "task-contract.json")), true);
+    assert.match(readFileSync(path.join(fixture.repoRoot, presetPackagePath, "INDEX.md"), "utf8"), /^preset: docs-task$/mu);
+    const presetOperation = latestAuthorityOperation(fixture.serviceRoot);
+    assert.equal(presetOperation.state, "COMMITTED", JSON.stringify(presetOperation));
+    assert.equal(presetOperation.receipt?.tag, "COMMITTED", JSON.stringify(presetOperation));
+    assert.equal(authorityEventBodies(fixture.authoredRoot).filter((body) => body.includes(presetOperation.opId!)).length, 1);
   } finally {
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
     if (process.env.KEEP_AUTHORITY_SERVICE_FIXTURE !== "1") rmSync(fixture.root, { recursive: true, force: true });
@@ -547,6 +585,14 @@ function latestAuthorityOperation(serviceRoot: string): {
     readonly commitSha?: string;
     readonly receipt?: { readonly tag?: string };
   };
+}
+
+function authorityEventBodies(authoredRoot: string): ReadonlyArray<string> {
+  const eventRoot = path.join(authoredRoot, "authority-attribution-events/v2");
+  if (!existsSync(eventRoot)) return [];
+  return execFileSync("find", [eventRoot, "-type", "f"], { encoding: "utf8" })
+    .trim().split("\n").filter(Boolean)
+    .map((eventPath) => readFileSync(eventPath, "utf8"));
 }
 
 function taskIndexBody(taskId: string): string {

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -30,10 +30,12 @@ import { createCliCommandService } from "../../src/daemon/command-service.ts";
 import { authorityNamespaceProofBytes } from "../../src/daemon/authority-production-state.ts";
 import { createGitCanonicalPublicationInspector } from "../../src/daemon/authority-publication-evidence.ts";
 import { createProductionAuthorityLifecycle } from "../../src/daemon/production-authority-lifecycle.ts";
+import { openDurableAuthorityServiceState } from "../../src/daemon/authority-service-state.ts";
 import {
   defaultDaemonUserRoot,
   pollUntil,
   runDaemonCommand,
+  runRawJsonAsync,
   runRawJsonMaybeFail,
   stopDaemon
 } from "../helpers/daemon-cli.ts";
@@ -149,9 +151,111 @@ test("production service route preserves progress dry-run and publishes canonica
     assert.equal(presetOperation.state, "COMMITTED", JSON.stringify(presetOperation));
     assert.equal(presetOperation.receipt?.tag, "COMMITTED", JSON.stringify(presetOperation));
     assert.equal(authorityEventBodies(fixture.authoredRoot).filter((body) => body.includes(presetOperation.opId!)).length, 1);
+
+    const interleaved = await Promise.all(Array.from({ length: 4 }, (_, index) => runRawJsonAsync(fixture.repoRoot, [
+      "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4",
+      "--text", `interleaved authority and runtime event ${index}`
+    ], { ...env, CODEX_THREAD_ID: `service-interleaved-${index}` })));
+    assert.equal(interleaved.every((receipt) => receipt.ok === true), true, JSON.stringify(interleaved));
+    const settledOperations = authorityOperationRecords(fixture.serviceRoot);
+    assert.equal(settledOperations.every((record) => record.state === "COMMITTED"), true, JSON.stringify(settledOperations));
+    const eventBodies = authorityEventBodies(fixture.authoredRoot);
+    for (const record of settledOperations) {
+      assert.equal(eventBodies.filter((body) => body.includes(record.opId ?? "missing-op")).length, 1, JSON.stringify(record));
+    }
   } finally {
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
     if (process.env.KEEP_AUTHORITY_SERVICE_FIXTURE !== "1") rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("production service exposes its socket while authority recovery scans history, then uses the persisted increment", { timeout: 120_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const env = {
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    CODEX_THREAD_ID: "service-recovery-session"
+  };
+  const watermarkPath = path.join(
+    fixture.serviceRoot,
+    "authority",
+    Buffer.from("canonical", "utf8").toString("base64url"),
+    "recovery-watermark.json"
+  );
+  try {
+    for (let index = 0; index < 800; index += 1) {
+      git(fixture.authoredRoot, "commit", "-q", "--allow-empty", "-m", `fixture history ${index}`);
+    }
+    const seededState = openDurableAuthorityServiceState({ serviceStateRoot: fixture.serviceRoot, repoId: "canonical" });
+    await seededState.operationRegistry.put(indeterminateWithoutPublication());
+    await seededState.close();
+    const registered = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical", "--canonical-root", fixture.repoRoot,
+      "--user-root", userRoot, "--no-link", "--json"
+    ], env);
+    assert.equal(registered.ok, true, JSON.stringify(registered));
+
+    const coldStartedAt = Date.now();
+    runDaemonCommand(fixture.repoRoot, [
+      "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+    ], env);
+    const coldSocketMs = Date.now() - coldStartedAt;
+    const statusDuringRecovery = runDaemonCommand(
+      fixture.repoRoot,
+      ["daemon", "status", "--user-root", userRoot, "--json"],
+      env
+    );
+    assert.equal(statusDuringRecovery.reachable, true, JSON.stringify(statusDuringRecovery));
+    assert.equal(existsSync(watermarkPath), false, "cold full scan must still be in progress when the socket is first reachable");
+
+    const gated = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "--text", "must wait for recovery"
+    ], env);
+    assert.notEqual(gated.status, 0, JSON.stringify(gated.receipt));
+    assert.match(JSON.stringify(gated.receipt), /AUTHORITY_RECOVERY_IN_PROGRESS/u);
+
+    await pollUntil(
+      () => existsSync(watermarkPath) ? JSON.parse(readFileSync(watermarkPath, "utf8")) as { readonly commitSha?: string } : undefined,
+      (watermark) => watermark?.commitSha === git(fixture.authoredRoot, "rev-parse", "HEAD"),
+      (watermark, error) => JSON.stringify({ watermark, error: String(error ?? "") }),
+      { timeoutMs: 30_000 }
+    );
+    const coldRecoveryMs = Date.now() - coldStartedAt;
+    assert.equal(authorityOperationRecords(fixture.serviceRoot).find((record) => record.opId === "namespace-production:unpublished-startup")?.state, "REJECTED");
+    const committed = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "--text", "recovery completed"
+    ], env);
+    assert.equal(committed.status, 0, JSON.stringify(committed.receipt));
+    assert.equal(committed.receipt.ok, true, JSON.stringify(committed.receipt));
+
+    await stopDaemon(fixture.repoRoot, userRoot);
+    for (let index = 0; index < 5; index += 1) {
+      git(fixture.authoredRoot, "commit", "-q", "--allow-empty", "-m", `fixture increment ${index}`);
+    }
+    const incrementalHead = git(fixture.authoredRoot, "rev-parse", "HEAD");
+    const incrementalStartedAt = Date.now();
+    runDaemonCommand(fixture.repoRoot, [
+      "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+    ], env);
+    const incrementalSocketMs = Date.now() - incrementalStartedAt;
+    await pollUntil(
+      () => JSON.parse(readFileSync(watermarkPath, "utf8")) as { readonly commitSha?: string },
+      (watermark) => watermark.commitSha === incrementalHead,
+      (watermark, error) => JSON.stringify({ watermark, error: String(error ?? "") }),
+      { timeoutMs: 10_000 }
+    );
+    const incrementalRecoveryMs = Date.now() - incrementalStartedAt;
+
+    assert.ok(coldSocketMs < coldRecoveryMs, JSON.stringify({ coldSocketMs, coldRecoveryMs }));
+    assert.ok(incrementalRecoveryMs < coldRecoveryMs, JSON.stringify({ incrementalRecoveryMs, coldRecoveryMs }));
+    console.log(JSON.stringify({ coldSocketMs, coldRecoveryMs, incrementalSocketMs, incrementalRecoveryMs }));
+  } finally {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
   }
 });
 
@@ -587,6 +691,24 @@ function latestAuthorityOperation(serviceRoot: string): {
   };
 }
 
+function authorityOperationRecords(serviceRoot: string): ReadonlyArray<{
+  readonly state?: string;
+  readonly opId?: string;
+}> {
+  const operationPath = path.join(
+    serviceRoot,
+    "authority",
+    Buffer.from("canonical", "utf8").toString("base64url"),
+    "operations.jsonl"
+  );
+  const latest = new Map<string, { readonly state?: string; readonly opId?: string }>();
+  for (const line of readFileSync(operationPath, "utf8").trim().split("\n").filter(Boolean)) {
+    const row = JSON.parse(line) as { readonly table?: string; readonly key?: string; readonly value?: { readonly state?: string; readonly opId?: string } };
+    if (row.table === "operation" && row.key && row.value) latest.set(row.key, row.value);
+  }
+  return [...latest.values()];
+}
+
 function authorityEventBodies(authoredRoot: string): ReadonlyArray<string> {
   const eventRoot = path.join(authoredRoot, "authority-attribution-events/v2");
   if (!existsSync(eventRoot)) return [];
@@ -605,6 +727,41 @@ function taskIndexBody(taskId: string): string {
     "provenance:", "  - {runtime: \"human\", sessionId: \"fixture\", boundAt: \"2026-07-17T00:00:00.000Z\"}",
     "---", "", "# Production ingress", ""
   ].join("\n");
+}
+
+function indeterminateWithoutPublication() {
+  return {
+    workspaceId: "workspace-production",
+    opId: "namespace-production:unpublished-startup",
+    semanticDigest: "a".repeat(64),
+    state: "INDETERMINATE" as const,
+    receipt: {
+      tag: "INDETERMINATE" as const,
+      workspaceId: "workspace-production",
+      opId: "namespace-production:unpublished-startup",
+      semanticDigest: "a".repeat(64),
+      reason: "PUBLICATION_OUTCOME_UNKNOWN:startup performance fixture"
+    },
+    authorityIntegrity: {
+      schema: "authority-operation-integrity/v2" as const,
+      semanticRequestDigest: "a".repeat(64),
+      semanticMutationSetDigest: "c".repeat(64),
+      mutationRegistryVersion: 1,
+      actorAxesBindingDigest: "d".repeat(64),
+      canonicalMutationSet: {
+        registryVersion: 1,
+        mutations: [{
+          entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4" },
+          action: { registryVersion: 1, action: "append" }
+        }]
+      }
+    },
+    recordedProtocol: {
+      kind: "semantic-mutation-envelope/v2" as const,
+      schemaTuple: productionTuple()
+    },
+    canonicalRequestEnvelope: "startup-performance-envelope"
+  };
 }
 
 function productionTuple() {

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -1,36 +1,29 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { sign } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import { hostname, tmpdir } from "node:os";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import {
   channelDigest32,
-  connectionGeneration,
-  openLocalAuthorityKeyStore
+  connectionGeneration
 } from "../../../daemon/src/index.ts";
-import { createAuthorityKeyRegistryV1, firstPinAuthorityKeyV1 } from "../../../application/src/index.ts";
 import {
   decisionEntityId,
   createTaskPackagePath,
-  executionDeclaration,
   moduleEntityId,
   sha256Text,
   taskEntityId
 } from "../../../kernel/src/index.ts";
 import { defaultCliAdapterProvider } from "../../src/composition/adapter-registry.ts";
-import type { EntityId, ExecutionRecord } from "../../../kernel/src/index.ts";
+import type { EntityId } from "../../../kernel/src/index.ts";
 import type { ParsedCommand } from "../../src/cli/types.ts";
 import { daemonActorAttribution } from "../../src/composition/actor-attribution.ts";
 import { parseRecordArgs } from "../../src/cli/parsers/record.ts";
 import { parseNewTaskArgs } from "../../src/cli/parsers/new-task.ts";
 import { createCliCommandService } from "../../src/daemon/command-service.ts";
-import { authorityNamespaceProofBytes } from "../../src/daemon/authority-production-state.ts";
 import { createGitCanonicalPublicationInspector } from "../../src/daemon/authority-publication-evidence.ts";
 import { createProductionAuthorityLifecycle } from "../../src/daemon/production-authority-lifecycle.ts";
-import { openDurableAuthorityServiceState } from "../../src/daemon/authority-service-state.ts";
 import {
   defaultDaemonUserRoot,
   pollUntil,
@@ -39,6 +32,13 @@ import {
   runRawJsonMaybeFail,
   stopDaemon
 } from "../helpers/daemon-cli.ts";
+import {
+  authorityEventBodies,
+  authorityOperationRecords,
+  createFixture,
+  git,
+  latestAuthorityOperation
+} from "./fixture.ts";
 
 test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 60_000 }, async () => {
   const fixture = createFixture();
@@ -166,96 +166,6 @@ test("production service route preserves progress dry-run and publishes canonica
   } finally {
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
     if (process.env.KEEP_AUTHORITY_SERVICE_FIXTURE !== "1") rmSync(fixture.root, { recursive: true, force: true });
-  }
-});
-
-test("production service exposes its socket while authority recovery scans history, then uses the persisted increment", { timeout: 120_000 }, async () => {
-  const fixture = createFixture();
-  const userRoot = defaultDaemonUserRoot(fixture.root);
-  const env = {
-    HARNESS_ACTOR: "agent:codex",
-    HARNESS_DAEMON_MODE: "local",
-    HARNESS_DAEMON_USER_ROOT: userRoot,
-    HARNESS_DAEMON_IDLE_MS: "60000",
-    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
-    CODEX_THREAD_ID: "service-recovery-session"
-  };
-  const watermarkPath = path.join(
-    fixture.serviceRoot,
-    "authority",
-    Buffer.from("canonical", "utf8").toString("base64url"),
-    "recovery-watermark.json"
-  );
-  try {
-    for (let index = 0; index < 800; index += 1) {
-      git(fixture.authoredRoot, "commit", "-q", "--allow-empty", "-m", `fixture history ${index}`);
-    }
-    const seededState = openDurableAuthorityServiceState({ serviceStateRoot: fixture.serviceRoot, repoId: "canonical" });
-    await seededState.operationRegistry.put(indeterminateWithoutPublication());
-    await seededState.close();
-    const registered = runDaemonCommand(fixture.repoRoot, [
-      "daemon", "repo", "register", "--repo-id", "canonical", "--canonical-root", fixture.repoRoot,
-      "--user-root", userRoot, "--no-link", "--json"
-    ], env);
-    assert.equal(registered.ok, true, JSON.stringify(registered));
-
-    const coldStartedAt = Date.now();
-    runDaemonCommand(fixture.repoRoot, [
-      "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
-    ], env);
-    const coldSocketMs = Date.now() - coldStartedAt;
-    const statusDuringRecovery = runDaemonCommand(
-      fixture.repoRoot,
-      ["daemon", "status", "--user-root", userRoot, "--json"],
-      env
-    );
-    assert.equal(statusDuringRecovery.reachable, true, JSON.stringify(statusDuringRecovery));
-    assert.equal(existsSync(watermarkPath), false, "cold full scan must still be in progress when the socket is first reachable");
-
-    const gated = runRawJsonMaybeFail(fixture.repoRoot, [
-      "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "--text", "must wait for recovery"
-    ], env);
-    assert.notEqual(gated.status, 0, JSON.stringify(gated.receipt));
-    assert.match(JSON.stringify(gated.receipt), /AUTHORITY_RECOVERY_IN_PROGRESS/u);
-
-    await pollUntil(
-      () => existsSync(watermarkPath) ? JSON.parse(readFileSync(watermarkPath, "utf8")) as { readonly commitSha?: string } : undefined,
-      (watermark) => watermark?.commitSha === git(fixture.authoredRoot, "rev-parse", "HEAD"),
-      (watermark, error) => JSON.stringify({ watermark, error: String(error ?? "") }),
-      { timeoutMs: 30_000 }
-    );
-    const coldRecoveryMs = Date.now() - coldStartedAt;
-    assert.equal(authorityOperationRecords(fixture.serviceRoot).find((record) => record.opId === "namespace-production:unpublished-startup")?.state, "REJECTED");
-    const committed = runRawJsonMaybeFail(fixture.repoRoot, [
-      "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "--text", "recovery completed"
-    ], env);
-    assert.equal(committed.status, 0, JSON.stringify(committed.receipt));
-    assert.equal(committed.receipt.ok, true, JSON.stringify(committed.receipt));
-
-    await stopDaemon(fixture.repoRoot, userRoot);
-    for (let index = 0; index < 5; index += 1) {
-      git(fixture.authoredRoot, "commit", "-q", "--allow-empty", "-m", `fixture increment ${index}`);
-    }
-    const incrementalHead = git(fixture.authoredRoot, "rev-parse", "HEAD");
-    const incrementalStartedAt = Date.now();
-    runDaemonCommand(fixture.repoRoot, [
-      "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
-    ], env);
-    const incrementalSocketMs = Date.now() - incrementalStartedAt;
-    await pollUntil(
-      () => JSON.parse(readFileSync(watermarkPath, "utf8")) as { readonly commitSha?: string },
-      (watermark) => watermark.commitSha === incrementalHead,
-      (watermark, error) => JSON.stringify({ watermark, error: String(error ?? "") }),
-      { timeoutMs: 10_000 }
-    );
-    const incrementalRecoveryMs = Date.now() - incrementalStartedAt;
-
-    assert.ok(coldSocketMs < coldRecoveryMs, JSON.stringify({ coldSocketMs, coldRecoveryMs }));
-    assert.ok(incrementalRecoveryMs < coldRecoveryMs, JSON.stringify({ incrementalRecoveryMs, coldRecoveryMs }));
-    console.log(JSON.stringify({ coldSocketMs, coldRecoveryMs, incrementalSocketMs, incrementalRecoveryMs }));
-  } finally {
-    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
-    rmSync(fixture.root, { recursive: true, force: true });
   }
 });
 
@@ -547,239 +457,3 @@ test("production canonical ingress accepts and journals one write for every cano
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
-
-function createFixture() {
-  const root = realpathSync(mkdtempSync(path.join(tmpdir(), "ha-production-canonical-ingress-")));
-  const repoRoot = path.join(root, "repo");
-  const authoredRoot = path.join(repoRoot, "harness");
-  const auxiliaryRoot = path.join(root, "auxiliary");
-  const auxiliaryAuthoredRoot = path.join(auxiliaryRoot, "harness");
-  const serviceRoot = path.join(root, "service-state");
-  const keyStateDirectory = path.join(serviceRoot, "keys/canonical");
-  mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"), { recursive: true });
-  mkdirSync(serviceRoot, { recursive: true, mode: 0o700 });
-  writeFileSync(path.join(authoredRoot, "harness.yaml"), "schema: harness-anything/v1\nproject: production-ingress\n");
-  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"));
-  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/closeout.md"), "# Closeout\n\nProduction fixture qualified.\n");
-  mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"), { recursive: true });
-  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"));
-  mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route"), { recursive: true });
-  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8"));
-  const actor = {
-    personId: "person_alice",
-    displayName: "Alice",
-    primaryEmail: "alice@example.test",
-    providerId: "transport-derived/v1",
-    resolvedCredential: {
-      kind: "unix-socket-owner-boundary" as const,
-      issuer: `host:${hostname()}`,
-      subject: String(process.getuid?.() ?? 0)
-    }
-  };
-  const submittedExecution: ExecutionRecord = {
-    schema: "execution/v2", execution_id: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5", task_ref: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", state: "submitted",
-    primary_actor: { principal: { personId: "person_alice" }, executor: { kind: "agent", id: "codex" }, responsibleHuman: "person_alice" },
-    claimed_at: "2026-07-17T00:00:00.000Z", submitted_at: "2026-07-17T00:01:00.000Z", closed_at: null,
-    session_bindings: [], outputs: [{ evidence_id: "evidence:ingress", execution_ref: "execution/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5", locator: { substrate: "inline", text: "passed" } }],
-    submission: { completion_claim: "Ingress qualified", deliverables: ["journal"], evidence_refs: ["evidence:ingress"], verification_notes: ["integration"], known_gaps: [], residual_risks: [] }
-  };
-  mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/executions"), { recursive: true });
-  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/executions/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5.md"), executionDeclaration.documentCodec.encode(submittedExecution));
-  const transcriptPath = path.join(root, "session-transcript.md");
-  writeFileSync(transcriptPath, `${JSON.stringify({
-    timestamp: "2026-07-17T00:00:00.000Z",
-    type: "event_msg",
-    payload: { type: "user_message", message: "Production session ingress." }
-  })}\n`);
-  writeFileSync(path.join(authoredRoot, "people.yaml"), [
-    "schema: harness-people/v1", "people:", "  - personId: person_alice", "    displayName: Alice",
-    "    primaryEmail: alice@example.test", "    roles: [owner]", "    credentials:",
-    "      - kind: unix-socket-owner-boundary", `        issuer: host:${hostname()}`,
-    `        subject: ${process.getuid?.() ?? 0}`, "roles:", "  - roleId: owner",
-    "    commandClasses: [admin, repo-write, repo-read, arbiter]", ""
-  ].join("\n"));
-  const keyStore = openLocalAuthorityKeyStore({
-    serviceStateRoot: serviceRoot,
-    stateDirectory: keyStateDirectory,
-    workspaceRoot: repoRoot,
-    authorityId: "authority.production",
-    issuer: "authority.production"
-  });
-  const now = Date.now();
-  const prepublished = keyStore.createPrepublishedKey({ generation: 1, nowMs: now - 1_000 });
-  const prepublishedRegistry = createAuthorityKeyRegistryV1({
-    authorityId: "authority.production", generation: 1, globalRevocationEpoch: 1, revision: 1,
-    entries: [prepublished]
-  });
-  const registry = firstPinAuthorityKeyV1({
-    registry: prepublishedRegistry,
-    keyId: prepublished.keyId,
-    expectedPinnedKeyId: prepublished.keyId,
-    pinEvidence: "fixture-out-of-band-pin",
-    verifierAcknowledgement: "fixture-verifier-ack",
-    activatedAtMs: now - 999
-  });
-  const registryPath = path.join(authoredRoot, "authority-key-registry.json");
-  writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
-  const unsignedNamespace = {
-    schema: "operation-namespace/v1" as const,
-    workspaceId: "workspace-production",
-    deviceId: "device-production",
-    authorityGeneration: 1n,
-    namespaceId: "namespace-production",
-    expiresAt: BigInt(now + 60 * 60_000),
-    issuer: "authority.production",
-    keyId: prepublished.keyId
-  };
-  const proof = sign(null, authorityNamespaceProofBytes(unsignedNamespace), keyStore.signingProfile(registry, now).privateKey);
-  const manifestPath = path.join(serviceRoot, "authority-production.json");
-  writeFileSync(manifestPath, `${JSON.stringify({
-    schema: "authority-production-composition/v1",
-    serviceStateRoot: serviceRoot,
-    repos: [{
-      repoId: "canonical", canonicalRoot: repoRoot, workspaceId: "workspace-production",
-      deviceId: "device-production", viewId: "view-production", sessionId: "session-production",
-      authorityId: "authority.production", issuer: "authority.production", keyRegistryPath: registryPath,
-      keyStateDirectory, schemaTuple: productionTuple(), authorityGeneration: 1,
-      revocationEpochs: { global: "1", workspace: "1", device: "1", view: "1", principal: "1", executor: "1" },
-      admissionTokenRef: "admission-production", allowedExecutorAgentIds: ["codex"],
-      operationNamespace: {
-        ...unsignedNamespace,
-        authorityGeneration: unsignedNamespace.authorityGeneration.toString(),
-        expiresAt: unsignedNamespace.expiresAt.toString(),
-        proof: proof.toString("base64url")
-      }
-    }]
-  }, null, 2)}\n`);
-  writeFileSync(path.join(repoRoot, "README.md"), "# Distinct public repository\n");
-  git(repoRoot, "init", "-q");
-  git(repoRoot, "add", "README.md");
-  git(repoRoot, "commit", "-q", "-m", "seed distinct public fixture");
-  const publicHead = git(repoRoot, "rev-parse", "HEAD");
-  git(authoredRoot, "init", "-q");
-  git(authoredRoot, "add", ".");
-  git(authoredRoot, "commit", "-q", "-m", "seed canonical ingress fixture");
-  mkdirSync(auxiliaryAuthoredRoot, { recursive: true });
-  writeFileSync(path.join(auxiliaryAuthoredRoot, "harness.yaml"), "schema: harness-anything/v1\nproject: auxiliary-ingress\n");
-  git(auxiliaryAuthoredRoot, "init", "-q");
-  git(auxiliaryAuthoredRoot, "add", ".");
-  git(auxiliaryAuthoredRoot, "commit", "-q", "-m", "seed auxiliary ingress fixture");
-  return { root, repoRoot, authoredRoot, auxiliaryRoot, serviceRoot, manifestPath, actor, transcriptPath, publicHead };
-}
-
-function latestAuthorityOperation(serviceRoot: string): {
-  readonly state?: string;
-  readonly opId?: string;
-  readonly commitSha?: string;
-  readonly receipt?: { readonly tag?: string };
-} {
-  const operationPath = path.join(
-    serviceRoot,
-    "authority",
-    Buffer.from("canonical", "utf8").toString("base64url"),
-    "operations.jsonl"
-  );
-  const rows = readFileSync(operationPath, "utf8").trim().split("\n")
-    .map((line) => JSON.parse(line) as { readonly table?: string; readonly value?: Record<string, unknown> })
-    .filter((row) => row.table === "operation" && row.value);
-  assert.ok(rows.length > 0, "service route must persist an authority operation");
-  return rows.at(-1)!.value as {
-    readonly state?: string;
-    readonly opId?: string;
-    readonly commitSha?: string;
-    readonly receipt?: { readonly tag?: string };
-  };
-}
-
-function authorityOperationRecords(serviceRoot: string): ReadonlyArray<{
-  readonly state?: string;
-  readonly opId?: string;
-}> {
-  const operationPath = path.join(
-    serviceRoot,
-    "authority",
-    Buffer.from("canonical", "utf8").toString("base64url"),
-    "operations.jsonl"
-  );
-  const latest = new Map<string, { readonly state?: string; readonly opId?: string }>();
-  for (const line of readFileSync(operationPath, "utf8").trim().split("\n").filter(Boolean)) {
-    const row = JSON.parse(line) as { readonly table?: string; readonly key?: string; readonly value?: { readonly state?: string; readonly opId?: string } };
-    if (row.table === "operation" && row.key && row.value) latest.set(row.key, row.value);
-  }
-  return [...latest.values()];
-}
-
-function authorityEventBodies(authoredRoot: string): ReadonlyArray<string> {
-  const eventRoot = path.join(authoredRoot, "authority-attribution-events/v2");
-  if (!existsSync(eventRoot)) return [];
-  return execFileSync("find", [eventRoot, "-type", "f"], { encoding: "utf8" })
-    .trim().split("\n").filter(Boolean)
-    .map((eventPath) => readFileSync(eventPath, "utf8"));
-}
-
-function taskIndexBody(taskId: string): string {
-  return [
-    "---", "schema: task-package/v2", `task_id: ${taskId}`, "title: Production ingress",
-    "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", "  status: active",
-    "  ref: ", "  titleSnapshot: Production ingress", "  url: ",
-    "  bindingCreatedAt: 2026-07-17T00:00:00.000Z", `  bindingFingerprint: sha256:${"b".repeat(64)}`,
-    "packageDisposition: active", "vertical: default", "preset: default",
-    "provenance:", "  - {runtime: \"human\", sessionId: \"fixture\", boundAt: \"2026-07-17T00:00:00.000Z\"}",
-    "---", "", "# Production ingress", ""
-  ].join("\n");
-}
-
-function indeterminateWithoutPublication() {
-  return {
-    workspaceId: "workspace-production",
-    opId: "namespace-production:unpublished-startup",
-    semanticDigest: "a".repeat(64),
-    state: "INDETERMINATE" as const,
-    receipt: {
-      tag: "INDETERMINATE" as const,
-      workspaceId: "workspace-production",
-      opId: "namespace-production:unpublished-startup",
-      semanticDigest: "a".repeat(64),
-      reason: "PUBLICATION_OUTCOME_UNKNOWN:startup performance fixture"
-    },
-    authorityIntegrity: {
-      schema: "authority-operation-integrity/v2" as const,
-      semanticRequestDigest: "a".repeat(64),
-      semanticMutationSetDigest: "c".repeat(64),
-      mutationRegistryVersion: 1,
-      actorAxesBindingDigest: "d".repeat(64),
-      canonicalMutationSet: {
-        registryVersion: 1,
-        mutations: [{
-          entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4" },
-          action: { registryVersion: 1, action: "append" }
-        }]
-      }
-    },
-    recordedProtocol: {
-      kind: "semantic-mutation-envelope/v2" as const,
-      schemaTuple: productionTuple()
-    },
-    canonicalRequestEnvelope: "startup-performance-envelope"
-  };
-}
-
-function productionTuple() {
-  return {
-    wire: 2, event: 2, receipt: 2, digest: 2, policy: 2,
-    commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
-  } as const;
-}
-
-function git(rootDir: string, ...args: ReadonlyArray<string>): string {
-  return execFileSync("git", ["-C", rootDir, ...args], {
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      GIT_AUTHOR_NAME: "ZeyuLi",
-      GIT_AUTHOR_EMAIL: "33339424+FairladyZ625@users.noreply.github.com",
-      GIT_COMMITTER_NAME: "ZeyuLi",
-      GIT_COMMITTER_EMAIL: "33339424+FairladyZ625@users.noreply.github.com"
-    }
-  }).trim();
-}

--- a/packages/cli/test/production-authority-canonical-ingress/fixture.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/fixture.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { sign } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
+import path from "node:path";
+import { createAuthorityKeyRegistryV1, firstPinAuthorityKeyV1 } from "../../../application/src/index.ts";
+import { openLocalAuthorityKeyStore } from "../../../daemon/src/index.ts";
+import { executionDeclaration, type ExecutionRecord } from "../../../kernel/src/index.ts";
+import { authorityNamespaceProofBytes } from "../../src/daemon/authority-production-state.ts";
+
+export function createFixture() {
+  const root = realpathSync(mkdtempSync(path.join(tmpdir(), "ha-production-canonical-ingress-")));
+  const repoRoot = path.join(root, "repo");
+  const authoredRoot = path.join(repoRoot, "harness");
+  const auxiliaryRoot = path.join(root, "auxiliary");
+  const auxiliaryAuthoredRoot = path.join(auxiliaryRoot, "harness");
+  const serviceRoot = path.join(root, "service-state");
+  const keyStateDirectory = path.join(serviceRoot, "keys/canonical");
+  mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"), { recursive: true });
+  mkdirSync(serviceRoot, { recursive: true, mode: 0o700 });
+  writeFileSync(path.join(authoredRoot, "harness.yaml"), "schema: harness-anything/v1\nproject: production-ingress\n");
+  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"));
+  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/closeout.md"), "# Closeout\n\nProduction fixture qualified.\n");
+  mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"), { recursive: true });
+  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"));
+  mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route"), { recursive: true });
+  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8"));
+  const actor = {
+    personId: "person_alice", displayName: "Alice", primaryEmail: "alice@example.test", providerId: "transport-derived/v1",
+    resolvedCredential: { kind: "unix-socket-owner-boundary" as const, issuer: `host:${hostname()}`, subject: String(process.getuid?.() ?? 0) }
+  };
+  const submittedExecution: ExecutionRecord = {
+    schema: "execution/v2", execution_id: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5", task_ref: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", state: "submitted",
+    primary_actor: { principal: { personId: "person_alice" }, executor: { kind: "agent", id: "codex" }, responsibleHuman: "person_alice" },
+    claimed_at: "2026-07-17T00:00:00.000Z", submitted_at: "2026-07-17T00:01:00.000Z", closed_at: null,
+    session_bindings: [], outputs: [{ evidence_id: "evidence:ingress", execution_ref: "execution/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5", locator: { substrate: "inline", text: "passed" } }],
+    submission: { completion_claim: "Ingress qualified", deliverables: ["journal"], evidence_refs: ["evidence:ingress"], verification_notes: ["integration"], known_gaps: [], residual_risks: [] }
+  };
+  mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/executions"), { recursive: true });
+  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/executions/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5.md"), executionDeclaration.documentCodec.encode(submittedExecution));
+  const transcriptPath = path.join(root, "session-transcript.md");
+  writeFileSync(transcriptPath, `${JSON.stringify({ timestamp: "2026-07-17T00:00:00.000Z", type: "event_msg", payload: { type: "user_message", message: "Production session ingress." } })}\n`);
+  writeFileSync(path.join(authoredRoot, "people.yaml"), [
+    "schema: harness-people/v1", "people:", "  - personId: person_alice", "    displayName: Alice",
+    "    primaryEmail: alice@example.test", "    roles: [owner]", "    credentials:",
+    "      - kind: unix-socket-owner-boundary", `        issuer: host:${hostname()}`, `        subject: ${process.getuid?.() ?? 0}`,
+    "roles:", "  - roleId: owner", "    commandClasses: [admin, repo-write, repo-read, arbiter]", ""
+  ].join("\n"));
+  const keyStore = openLocalAuthorityKeyStore({ serviceStateRoot: serviceRoot, stateDirectory: keyStateDirectory, workspaceRoot: repoRoot, authorityId: "authority.production", issuer: "authority.production" });
+  const now = Date.now();
+  const prepublished = keyStore.createPrepublishedKey({ generation: 1, nowMs: now - 1_000 });
+  const registry = firstPinAuthorityKeyV1({
+    registry: createAuthorityKeyRegistryV1({ authorityId: "authority.production", generation: 1, globalRevocationEpoch: 1, revision: 1, entries: [prepublished] }),
+    keyId: prepublished.keyId, expectedPinnedKeyId: prepublished.keyId, pinEvidence: "fixture-out-of-band-pin",
+    verifierAcknowledgement: "fixture-verifier-ack", activatedAtMs: now - 999
+  });
+  const registryPath = path.join(authoredRoot, "authority-key-registry.json");
+  writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+  const unsignedNamespace = {
+    schema: "operation-namespace/v1" as const, workspaceId: "workspace-production", deviceId: "device-production",
+    authorityGeneration: 1n, namespaceId: "namespace-production", expiresAt: BigInt(now + 60 * 60_000),
+    issuer: "authority.production", keyId: prepublished.keyId
+  };
+  const proof = sign(null, authorityNamespaceProofBytes(unsignedNamespace), keyStore.signingProfile(registry, now).privateKey);
+  const manifestPath = path.join(serviceRoot, "authority-production.json");
+  writeFileSync(manifestPath, `${JSON.stringify({
+    schema: "authority-production-composition/v1", serviceStateRoot: serviceRoot, repos: [{
+      repoId: "canonical", canonicalRoot: repoRoot, workspaceId: "workspace-production", deviceId: "device-production",
+      viewId: "view-production", sessionId: "session-production", authorityId: "authority.production", issuer: "authority.production",
+      keyRegistryPath: registryPath, keyStateDirectory, schemaTuple: productionTuple(), authorityGeneration: 1,
+      revocationEpochs: { global: "1", workspace: "1", device: "1", view: "1", principal: "1", executor: "1" },
+      admissionTokenRef: "admission-production", allowedExecutorAgentIds: ["codex"],
+      operationNamespace: { ...unsignedNamespace, authorityGeneration: "1", expiresAt: unsignedNamespace.expiresAt.toString(), proof: proof.toString("base64url") }
+    }]
+  }, null, 2)}\n`);
+  writeFileSync(path.join(repoRoot, "README.md"), "# Distinct public repository\n");
+  git(repoRoot, "init", "-q"); git(repoRoot, "add", "README.md"); git(repoRoot, "commit", "-q", "-m", "seed distinct public fixture");
+  const publicHead = git(repoRoot, "rev-parse", "HEAD");
+  git(authoredRoot, "init", "-q"); git(authoredRoot, "add", "."); git(authoredRoot, "commit", "-q", "-m", "seed canonical ingress fixture");
+  mkdirSync(auxiliaryAuthoredRoot, { recursive: true });
+  writeFileSync(path.join(auxiliaryAuthoredRoot, "harness.yaml"), "schema: harness-anything/v1\nproject: auxiliary-ingress\n");
+  git(auxiliaryAuthoredRoot, "init", "-q"); git(auxiliaryAuthoredRoot, "add", "."); git(auxiliaryAuthoredRoot, "commit", "-q", "-m", "seed auxiliary ingress fixture");
+  return { root, repoRoot, authoredRoot, auxiliaryRoot, serviceRoot, manifestPath, actor, transcriptPath, publicHead };
+}
+
+export function latestAuthorityOperation(serviceRoot: string): { readonly state?: string; readonly opId?: string; readonly commitSha?: string; readonly receipt?: { readonly tag?: string } } {
+  const rows = readFileSync(operationPath(serviceRoot), "utf8").trim().split("\n")
+    .map((line) => JSON.parse(line) as { readonly table?: string; readonly value?: Record<string, unknown> })
+    .filter((row) => row.table === "operation" && row.value);
+  assert.ok(rows.length > 0, "service route must persist an authority operation");
+  return rows.at(-1)!.value as ReturnType<typeof latestAuthorityOperation>;
+}
+
+export function authorityOperationRecords(serviceRoot: string): ReadonlyArray<{ readonly state?: string; readonly opId?: string }> {
+  const latest = new Map<string, { readonly state?: string; readonly opId?: string }>();
+  for (const line of readFileSync(operationPath(serviceRoot), "utf8").trim().split("\n").filter(Boolean)) {
+    const row = JSON.parse(line) as { readonly table?: string; readonly key?: string; readonly value?: { readonly state?: string; readonly opId?: string } };
+    if (row.table === "operation" && row.key && row.value) latest.set(row.key, row.value);
+  }
+  return [...latest.values()];
+}
+
+export function authorityEventBodies(authoredRoot: string): ReadonlyArray<string> {
+  const eventRoot = path.join(authoredRoot, "authority-attribution-events/v2");
+  if (!existsSync(eventRoot)) return [];
+  return execFileSync("find", [eventRoot, "-type", "f"], { encoding: "utf8" }).trim().split("\n").filter(Boolean)
+    .map((eventPath) => readFileSync(eventPath, "utf8"));
+}
+
+export function indeterminateWithoutPublication() {
+  return {
+    workspaceId: "workspace-production", opId: "namespace-production:unpublished-startup", semanticDigest: "a".repeat(64), state: "INDETERMINATE" as const,
+    receipt: { tag: "INDETERMINATE" as const, workspaceId: "workspace-production", opId: "namespace-production:unpublished-startup", semanticDigest: "a".repeat(64), reason: "PUBLICATION_OUTCOME_UNKNOWN:startup performance fixture" },
+    authorityIntegrity: {
+      schema: "authority-operation-integrity/v2" as const, semanticRequestDigest: "a".repeat(64), semanticMutationSetDigest: "c".repeat(64), mutationRegistryVersion: 1,
+      actorAxesBindingDigest: "d".repeat(64), canonicalMutationSet: { registryVersion: 1, mutations: [{ entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4" }, action: { registryVersion: 1, action: "append" } }] }
+    },
+    recordedProtocol: { kind: "semantic-mutation-envelope/v2" as const, schemaTuple: productionTuple() }, canonicalRequestEnvelope: "startup-performance-envelope"
+  };
+}
+
+export function git(rootDir: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, GIT_AUTHOR_NAME: "ZeyuLi", GIT_AUTHOR_EMAIL: "33339424+FairladyZ625@users.noreply.github.com", GIT_COMMITTER_NAME: "ZeyuLi", GIT_COMMITTER_EMAIL: "33339424+FairladyZ625@users.noreply.github.com" }
+  }).trim();
+}
+
+function operationPath(serviceRoot: string): string {
+  return path.join(serviceRoot, "authority", Buffer.from("canonical", "utf8").toString("base64url"), "operations.jsonl");
+}
+
+function taskIndexBody(taskId: string): string {
+  return ["---", "schema: task-package/v2", `task_id: ${taskId}`, "title: Production ingress", "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", "  status: active", "  ref: ", "  titleSnapshot: Production ingress", "  url: ", "  bindingCreatedAt: 2026-07-17T00:00:00.000Z", `  bindingFingerprint: sha256:${"b".repeat(64)}`, "packageDisposition: active", "vertical: default", "preset: default", "provenance:", "  - {runtime: \"human\", sessionId: \"fixture\", boundAt: \"2026-07-17T00:00:00.000Z\"}", "---", "", "# Production ingress", ""].join("\n");
+}
+
+function productionTuple() {
+  return { wire: 2, event: 2, receipt: 2, digest: 2, policy: 2, commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1 } as const;
+}

--- a/packages/cli/test/production-authority-event-recovery.test.ts
+++ b/packages/cli/test/production-authority-event-recovery.test.ts
@@ -1,5 +1,9 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import type {
   AuthorityCommittedReceipt,
@@ -10,8 +14,9 @@ import type { makeLocalAuthorityAttributionEventV2Log } from "../../kernel/src/i
 import { recoverPendingProductionEvents } from "../src/daemon/production-authority-lifecycle.ts";
 import {
   AuthorityCanonicalPublicationNotFoundError,
+  AuthorityRecoveryWatermarkInvalidError,
   assertPublicationMatchesMutationSet,
-  type createGitCanonicalPublicationInspector
+  createGitCanonicalPublicationInspector
 } from "../src/daemon/authority-publication-evidence.ts";
 
 test("publication proof accepts only the declared hosted path inside a slugged task package", () => {
@@ -270,6 +275,125 @@ test("restart recovery terminalizes only an indeterminate operation proven absen
   assert.equal(durable.receipt?.tag, "REJECTED");
   assert.match(durable.receipt?.tag === "REJECTED" ? durable.receipt.reason : "", /AUTHORITY_RECOVERY_CONFIRMED_NOT_PUBLISHED/u);
   assert.match(durable.receipt?.tag === "REJECTED" ? durable.receipt.reason : "", /authority publication cannot mix/u);
+});
+
+test("recovery watermark falls back on missing or corrupt state and then scans only the first-parent increment", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-authority-recovery-watermark-"));
+  const watermarkPath = path.join(root, "recovery-watermark.json");
+  const head = "b".repeat(40);
+  const scanInputs: Array<string | undefined> = [];
+  try {
+    const input = {
+      workspaceId: "workspace-production",
+      operationRegistry: {
+        get: async () => undefined,
+        list: async () => [],
+        put: async () => undefined
+      },
+      replicaChangeLog: {} as import("../../application/src/index.ts").ReplicaChangeLog,
+      eventLog: {} as ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>,
+      publicationInspector: {
+        scanFirstParentOperationAnchors: async ({ exclusiveCommit }: { readonly exclusiveCommit?: string }) => {
+          scanInputs.push(exclusiveCommit);
+          return { headCommit: head, scannedCommitCount: exclusiveCommit ? 0 : 400, anchors: [] };
+        }
+      } as ReturnType<typeof createGitCanonicalPublicationInspector>,
+      recover: async () => { throw new Error("no pending operation should recover"); },
+      watermarkPath
+    };
+
+    await recoverPendingProductionEvents(input);
+    assert.equal(JSON.parse(readFileSync(watermarkPath, "utf8")).commitSha, head);
+    await recoverPendingProductionEvents(input);
+    writeFileSync(watermarkPath, "{malformed\n");
+    await recoverPendingProductionEvents(input);
+
+    assert.deepEqual(scanInputs, [undefined, head, undefined]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("recovery watermark never advances past an unresolved indexed operation", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-authority-recovery-unsettled-"));
+  const watermarkPath = path.join(root, "recovery-watermark.json");
+  const record: AuthorityStoredOperationRecord = {
+    workspaceId: "workspace-production",
+    opId: "namespace-production:unsettled",
+    semanticDigest: "a".repeat(64),
+    state: "INDEXED",
+    authorityIntegrity: {
+      schema: "authority-operation-integrity/v2",
+      semanticRequestDigest: "a".repeat(64), semanticMutationSetDigest: "c".repeat(64),
+      mutationRegistryVersion: 1, actorAxesBindingDigest: "d".repeat(64),
+      canonicalMutationSet: { registryVersion: 1, mutations: [{
+        entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task_RECOVERY" },
+        action: { registryVersion: 1, action: "append" }
+      }] }
+    },
+    recordedProtocol: { kind: "semantic-mutation-envelope/v2", schemaTuple: {
+      wire: 2, event: 2, receipt: 2, digest: 2, policy: 2,
+      commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
+    } },
+    canonicalRequestEnvelope: "durable-envelope"
+  };
+  try {
+    await recoverPendingProductionEvents({
+      workspaceId: record.workspaceId,
+      operationRegistry: { get: async () => record, list: async () => [record], put: async () => undefined },
+      replicaChangeLog: {} as import("../../application/src/index.ts").ReplicaChangeLog,
+      eventLog: {} as ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>,
+      publicationInspector: {
+        scanFirstParentOperationAnchors: async () => ({ headCommit: "b".repeat(40), scannedCommitCount: 400, anchors: [] })
+      } as ReturnType<typeof createGitCanonicalPublicationInspector>,
+      recover: async () => { throw new Error("unanchored operation must not recover"); },
+      watermarkPath
+    });
+    assert.equal(existsSync(watermarkPath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("first-parent scanner rejects a watermark that exists only on a side branch", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-authority-recovery-first-parent-"));
+  const git = (...args: ReadonlyArray<string>) => execFileSync("git", ["-C", root, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Harness Test",
+      GIT_AUTHOR_EMAIL: "harness@example.test",
+      GIT_COMMITTER_NAME: "Harness Test",
+      GIT_COMMITTER_EMAIL: "harness@example.test"
+    }
+  }).trim();
+  try {
+    git("init", "-q");
+    writeFileSync(path.join(root, "seed.txt"), "seed\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "seed");
+    const base = git("rev-parse", "HEAD");
+    const trunk = git("branch", "--show-current");
+    git("checkout", "-q", "-b", "side");
+    git("commit", "-q", "--allow-empty", "-m", "side");
+    const side = git("rev-parse", "HEAD");
+    git("checkout", "-q", trunk);
+    git("commit", "-q", "--allow-empty", "-m", "trunk");
+    const inspector = createGitCanonicalPublicationInspector(root);
+
+    await assert.rejects(
+      inspector.scanFirstParentOperationAnchors({ exclusiveCommit: side, interestedOpIds: new Set() }),
+      (error: unknown) => error instanceof AuthorityRecoveryWatermarkInvalidError
+    );
+    await assert.rejects(
+      inspector.scanFirstParentOperationAnchors({ exclusiveCommit: "f".repeat(40), interestedOpIds: new Set() }),
+      (error: unknown) => error instanceof AuthorityRecoveryWatermarkInvalidError
+    );
+    const valid = await inspector.scanFirstParentOperationAnchors({ exclusiveCommit: base, interestedOpIds: new Set() });
+    assert.equal(valid.scannedCommitCount, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 function publicationEvidence() {

--- a/packages/cli/test/production-authority-event-recovery.test.ts
+++ b/packages/cli/test/production-authority-event-recovery.test.ts
@@ -9,6 +9,7 @@ import type {
 import type { makeLocalAuthorityAttributionEventV2Log } from "../../kernel/src/index.ts";
 import { recoverPendingProductionEvents } from "../src/daemon/production-authority-lifecycle.ts";
 import {
+  AuthorityCanonicalPublicationNotFoundError,
   assertPublicationMatchesMutationSet,
   type createGitCanonicalPublicationInspector
 } from "../src/daemon/authority-publication-evidence.ts";
@@ -205,6 +206,70 @@ test("restart recovery reports the opId and exception when fail-closed recovery 
   });
 
   assert.deepEqual(deferred, [{ opId: record.opId, error: failure }]);
+});
+
+test("restart recovery terminalizes only an indeterminate operation proven absent from publication history", async () => {
+  const record: AuthorityStoredOperationRecord = {
+    workspaceId: "workspace-production",
+    opId: "namespace-production:not-published",
+    semanticDigest: "a".repeat(64),
+    state: "INDETERMINATE",
+    receipt: {
+      tag: "INDETERMINATE",
+      workspaceId: "workspace-production",
+      opId: "namespace-production:not-published",
+      semanticDigest: "a".repeat(64),
+      reason: "PUBLICATION_OUTCOME_UNKNOWN:authority publication cannot mix integrity-bearing and legacy operations"
+    },
+    authorityIntegrity: {
+      schema: "authority-operation-integrity/v2",
+      semanticRequestDigest: "a".repeat(64),
+      semanticMutationSetDigest: "c".repeat(64),
+      mutationRegistryVersion: 1,
+      actorAxesBindingDigest: "d".repeat(64),
+      canonicalMutationSet: {
+        registryVersion: 1,
+        mutations: [{
+          entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task_RECOVERY" },
+          action: { registryVersion: 1, action: "append" }
+        }]
+      }
+    },
+    recordedProtocol: {
+      kind: "semantic-mutation-envelope/v2",
+      schemaTuple: {
+        wire: 2, event: 2, receipt: 2, digest: 2, policy: 2,
+        commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
+      }
+    },
+    canonicalRequestEnvelope: "durable-envelope"
+  };
+  let durable = record;
+  let recoveryCalled = false;
+
+  await recoverPendingProductionEvents({
+    workspaceId: record.workspaceId,
+    operationRegistry: {
+      get: async () => durable,
+      list: async () => [durable],
+      put: async (next) => { durable = next; }
+    },
+    replicaChangeLog: {} as import("../../application/src/index.ts").ReplicaChangeLog,
+    eventLog: {} as ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>,
+    publicationInspector: {
+      findPublicationForOperation: async () => { throw new AuthorityCanonicalPublicationNotFoundError(record.opId); }
+    } as ReturnType<typeof createGitCanonicalPublicationInspector>,
+    recover: async () => {
+      recoveryCalled = true;
+      throw new Error("recovery must not publish an operation proven absent");
+    }
+  });
+
+  assert.equal(recoveryCalled, false);
+  assert.equal(durable.state, "REJECTED");
+  assert.equal(durable.receipt?.tag, "REJECTED");
+  assert.match(durable.receipt?.tag === "REJECTED" ? durable.receipt.reason : "", /AUTHORITY_RECOVERY_CONFIRMED_NOT_PUBLISHED/u);
+  assert.match(durable.receipt?.tag === "REJECTED" ? durable.receipt.reason : "", /authority publication cannot mix/u);
 });
 
 function publicationEvidence() {

--- a/packages/cli/test/production-authority-startup-performance.test.ts
+++ b/packages/cli/test/production-authority-startup-performance.test.ts
@@ -1,0 +1,102 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { openDurableAuthorityServiceState } from "../src/daemon/authority-service-state.ts";
+import {
+  defaultDaemonUserRoot,
+  pollUntil,
+  runDaemonCommand,
+  runRawJsonMaybeFail,
+  stopDaemon
+} from "./helpers/daemon-cli.ts";
+import {
+  authorityOperationRecords,
+  createFixture,
+  git,
+  indeterminateWithoutPublication
+} from "./production-authority-canonical-ingress/fixture.ts";
+
+test("production service exposes its socket while authority recovery scans history, then uses the persisted increment", { timeout: 120_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const env = {
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    CODEX_THREAD_ID: "service-recovery-session"
+  };
+  const watermarkPath = path.join(
+    fixture.serviceRoot,
+    "authority",
+    Buffer.from("canonical", "utf8").toString("base64url"),
+    "recovery-watermark.json"
+  );
+  try {
+    for (let index = 0; index < 800; index += 1) {
+      git(fixture.authoredRoot, "commit", "-q", "--allow-empty", "-m", `fixture history ${index}`);
+    }
+    const seededState = openDurableAuthorityServiceState({ serviceStateRoot: fixture.serviceRoot, repoId: "canonical" });
+    await seededState.operationRegistry.put(indeterminateWithoutPublication());
+    await seededState.close();
+    const registered = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical", "--canonical-root", fixture.repoRoot,
+      "--user-root", userRoot, "--no-link", "--json"
+    ], env);
+    assert.equal(registered.ok, true, JSON.stringify(registered));
+
+    const coldStartedAt = Date.now();
+    runDaemonCommand(fixture.repoRoot, [
+      "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+    ], env);
+    const coldSocketMs = Date.now() - coldStartedAt;
+    const statusDuringRecovery = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
+    assert.equal(statusDuringRecovery.reachable, true, JSON.stringify(statusDuringRecovery));
+    assert.equal(existsSync(watermarkPath), false, "cold full scan must still be in progress when the socket is first reachable");
+    const gated = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "--text", "must wait for recovery"
+    ], env);
+    assert.notEqual(gated.status, 0, JSON.stringify(gated.receipt));
+    assert.match(JSON.stringify(gated.receipt), /AUTHORITY_RECOVERY_IN_PROGRESS/u);
+
+    await pollUntil(
+      () => existsSync(watermarkPath) ? JSON.parse(readFileSync(watermarkPath, "utf8")) as { readonly commitSha?: string } : undefined,
+      (watermark) => watermark?.commitSha === git(fixture.authoredRoot, "rev-parse", "HEAD"),
+      (watermark, error) => JSON.stringify({ watermark, error: String(error ?? "") }),
+      { timeoutMs: 30_000 }
+    );
+    const coldRecoveryMs = Date.now() - coldStartedAt;
+    assert.equal(authorityOperationRecords(fixture.serviceRoot).find((record) => record.opId === "namespace-production:unpublished-startup")?.state, "REJECTED");
+    const committed = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "--text", "recovery completed"
+    ], env);
+    assert.equal(committed.status, 0, JSON.stringify(committed.receipt));
+
+    await stopDaemon(fixture.repoRoot, userRoot);
+    for (let index = 0; index < 5; index += 1) {
+      git(fixture.authoredRoot, "commit", "-q", "--allow-empty", "-m", `fixture increment ${index}`);
+    }
+    const incrementalHead = git(fixture.authoredRoot, "rev-parse", "HEAD");
+    const incrementalStartedAt = Date.now();
+    runDaemonCommand(fixture.repoRoot, [
+      "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+    ], env);
+    const incrementalSocketMs = Date.now() - incrementalStartedAt;
+    await pollUntil(
+      () => JSON.parse(readFileSync(watermarkPath, "utf8")) as { readonly commitSha?: string },
+      (watermark) => watermark.commitSha === incrementalHead,
+      (watermark, error) => JSON.stringify({ watermark, error: String(error ?? "") }),
+      { timeoutMs: 10_000 }
+    );
+    const incrementalRecoveryMs = Date.now() - incrementalStartedAt;
+    assert.ok(coldSocketMs < coldRecoveryMs, JSON.stringify({ coldSocketMs, coldRecoveryMs }));
+    assert.ok(incrementalRecoveryMs < coldRecoveryMs, JSON.stringify({ incrementalRecoveryMs, coldRecoveryMs }));
+    console.log(JSON.stringify({ coldSocketMs, coldRecoveryMs, incrementalSocketMs, incrementalRecoveryMs }));
+  } finally {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/packages/kernel/src/store/daemon-runtime-authority-coordinator.ts
+++ b/packages/kernel/src/store/daemon-runtime-authority-coordinator.ts
@@ -1,0 +1,35 @@
+import { Effect } from "effect";
+import type { WriteCoordinator, WriteOp } from "../ports/write-coordinator.ts";
+
+interface ProjectionWriteHandle {
+  readonly settle: () => void;
+}
+
+export function makeDeferredAuthorityCoordinator(input: {
+  readonly beginProjectionWrite: (op: WriteOp) => ProjectionWriteHandle;
+  readonly makeDurableCoordinator: () => WriteCoordinator;
+}): WriteCoordinator {
+  const pending: WriteOp[] = [];
+  const projectionWrites: ProjectionWriteHandle[] = [];
+  return {
+    enqueue: (op) => Effect.sync(() => {
+      projectionWrites.push(input.beginProjectionWrite(op));
+      pending.push(op);
+      return { opId: op.opId, entityId: op.entityId, accepted: true as const };
+    }),
+    flush: (reason) => {
+      if (pending.length === 0) return Effect.succeed({ reason, opCount: 0, committed: false });
+      const ops = pending.splice(0, pending.length);
+      const coordinator = input.makeDurableCoordinator();
+      return Effect.forEach(ops, (op) => coordinator.enqueue(op), { discard: true }).pipe(
+        Effect.flatMap(() => coordinator.flush(reason)),
+        Effect.ensuring(Effect.sync(() => {
+          for (const projectionWrite of projectionWrites.splice(0, projectionWrites.length)) {
+            projectionWrite.settle();
+          }
+        }))
+      );
+    },
+    recover: Effect.suspend(() => input.makeDurableCoordinator().recover)
+  };
+}

--- a/packages/kernel/src/store/daemon-runtime-queue.ts
+++ b/packages/kernel/src/store/daemon-runtime-queue.ts
@@ -51,6 +51,7 @@ type InteractiveQueueItem = InteractiveWriteAttribution & {
   readonly ops: ReadonlyArray<WriteOp>;
   readonly commitAuthor?: GitCommitAuthor;
   readonly sessionId?: string;
+  readonly integrityDomain: "authority" | "legacy";
   readonly enqueuedAt: number;
   started: boolean;
   timeout?: ReturnType<typeof setTimeout>;
@@ -105,6 +106,13 @@ export class DaemonWriteQueue {
     coordinatorFor: (batch: InteractiveCoordinatorBatch) => JournaledWriteCoordinator
   ): Promise<InteractiveWriteReceipt> {
     if (this.closed) return Promise.reject({ _tag: "JournalUnavailable", cause: new Error("daemon write queue is closed") } satisfies WriteError);
+    const integrityDomain = requestIntegrityDomain(request.ops);
+    if (!integrityDomain) {
+      return Promise.reject({
+        _tag: "WriteRejected",
+        reason: "daemon interactive request cannot mix integrity-bearing and legacy operations"
+      } satisfies WriteError);
+    }
     const admission = this.admissionBudget.reserve({
       plane: "json-rpc",
       operations: request.ops.length,
@@ -120,6 +128,7 @@ export class DaemonWriteQueue {
         ...(request.attribution ? { attribution: request.attribution } : { operationalActor: request.operationalActor }),
         ...(request.commitAuthor ? { commitAuthor: request.commitAuthor } : {}),
         ...(request.sessionId ? { sessionId: request.sessionId } : {}),
+        integrityDomain,
         enqueuedAt: Date.now(),
         started: false,
         resolve,
@@ -338,7 +347,14 @@ function attributionFor(item: InteractiveQueueItem | undefined): InteractiveCoor
 function sameAttribution(left: InteractiveQueueItem, right: InteractiveQueueItem): boolean {
   return attributionKey(left) === attributionKey(right)
     && authorKey(left.commitAuthor) === authorKey(right.commitAuthor)
-    && sessionKey(left.sessionId) === sessionKey(right.sessionId);
+    && sessionKey(left.sessionId) === sessionKey(right.sessionId)
+    && left.integrityDomain === right.integrityDomain;
+}
+
+function requestIntegrityDomain(ops: ReadonlyArray<WriteOp>): "authority" | "legacy" | undefined {
+  const authorityCount = ops.filter((op) => op.authorityIntegrity !== undefined).length;
+  if (authorityCount === 0) return "legacy";
+  return authorityCount === ops.length ? "authority" : undefined;
 }
 
 function attributionKey(input: InteractiveWriteAttribution): string {

--- a/packages/kernel/src/store/daemon-runtime.ts
+++ b/packages/kernel/src/store/daemon-runtime.ts
@@ -428,26 +428,33 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
   createAttributedCoordinator(input: {
     readonly attribution: WriteAttribution;
     readonly sessionId: string;
+    readonly commitAuthor?: InteractiveWriteRequest["commitAuthor"];
   }): WriteCoordinator {
-    const started = this.requireAttached();
-    const coordinator = this.makeStartedCoordinator(started, input);
+    this.requireAttached();
+    const pending: InteractiveWriteRequest["ops"][number][] = [];
     const projectionWrites: Array<ReturnType<DaemonProjectionGenerationManager["beginCanonicalWrite"]>> = [];
     return {
-      enqueue: (op) => Effect.suspend(() => {
+      enqueue: (op) => Effect.sync(() => {
         const touchedPaths = writeOpTouchedPaths(this.runtimeContext, op);
         const projectionWrite = this.projectionGeneration.beginCanonicalWrite(touchedPaths);
         projectionWrites.push(projectionWrite);
-        return coordinator.enqueue(op);
+        pending.push(op);
+        return { opId: op.opId, entityId: op.entityId, accepted: true as const };
       }),
-      flush: (reason) => Effect.ensuring(
-        coordinator.flush(reason),
-        Effect.sync(() => {
-          for (const projectionWrite of projectionWrites.splice(0, projectionWrites.length)) {
-            projectionWrite.settle();
-          }
-        })
-      ),
-      recover: coordinator.recover
+      flush: (reason) => {
+        if (pending.length === 0) return Effect.succeed({ reason, opCount: 0, committed: false });
+        const ops = pending.splice(0, pending.length);
+        const coordinator = this.makeStartedCoordinator(this.requireAttached(), input);
+        return Effect.forEach(ops, (op) => coordinator.enqueue(op), { discard: true }).pipe(
+          Effect.flatMap(() => coordinator.flush(reason)),
+          Effect.ensuring(Effect.sync(() => {
+            for (const projectionWrite of projectionWrites.splice(0, projectionWrites.length)) {
+              projectionWrite.settle();
+            }
+          }))
+        );
+      },
+      recover: Effect.suspend(() => this.makeStartedCoordinator(this.requireAttached(), input).recover)
     };
   }
 

--- a/packages/kernel/src/store/daemon-runtime.ts
+++ b/packages/kernel/src/store/daemon-runtime.ts
@@ -22,6 +22,7 @@ import {
   type InteractiveWriteRequest
 } from "./daemon-runtime-queue.ts";
 import { waitForDaemonQueueIdle } from "./daemon-drain.ts";
+import { makeDeferredAuthorityCoordinator } from "./daemon-runtime-authority-coordinator.ts";
 import { acquireDaemonGlobalLock, assertDaemonGlobalLockHeld, type DaemonGlobalLock } from "./write-journal-locks.ts";
 import { makeJournaledWriteCoordinator, makeOperationalJournaledWriteCoordinator, recoverJournaledWrites } from "./write-journal-coordinator.ts";
 import type { OperationalActor } from "./write-journal-types.ts";
@@ -431,31 +432,13 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
     readonly commitAuthor?: InteractiveWriteRequest["commitAuthor"];
   }): WriteCoordinator {
     this.requireAttached();
-    const pending: InteractiveWriteRequest["ops"][number][] = [];
-    const projectionWrites: Array<ReturnType<DaemonProjectionGenerationManager["beginCanonicalWrite"]>> = [];
-    return {
-      enqueue: (op) => Effect.sync(() => {
+    return makeDeferredAuthorityCoordinator({
+      beginProjectionWrite: (op) => {
         const touchedPaths = writeOpTouchedPaths(this.runtimeContext, op);
-        const projectionWrite = this.projectionGeneration.beginCanonicalWrite(touchedPaths);
-        projectionWrites.push(projectionWrite);
-        pending.push(op);
-        return { opId: op.opId, entityId: op.entityId, accepted: true as const };
-      }),
-      flush: (reason) => {
-        if (pending.length === 0) return Effect.succeed({ reason, opCount: 0, committed: false });
-        const ops = pending.splice(0, pending.length);
-        const coordinator = this.makeStartedCoordinator(this.requireAttached(), input);
-        return Effect.forEach(ops, (op) => coordinator.enqueue(op), { discard: true }).pipe(
-          Effect.flatMap(() => coordinator.flush(reason)),
-          Effect.ensuring(Effect.sync(() => {
-            for (const projectionWrite of projectionWrites.splice(0, projectionWrites.length)) {
-              projectionWrite.settle();
-            }
-          }))
-        );
+        return this.projectionGeneration.beginCanonicalWrite(touchedPaths);
       },
-      recover: Effect.suspend(() => this.makeStartedCoordinator(this.requireAttached(), input).recover)
-    };
+      makeDurableCoordinator: () => this.makeStartedCoordinator(this.requireAttached(), input)
+    });
   }
 
   async assertWriteFenceHeld(): Promise<void> {

--- a/packages/kernel/test/store/daemon-runtime-authority-domains.test.ts
+++ b/packages/kernel/test/store/daemon-runtime-authority-domains.test.ts
@@ -6,7 +6,7 @@ import test from "node:test";
 import { Effect } from "effect";
 import { createDaemonRuntime } from "../../../adapters/local/src/index.ts";
 import { moduleEntityId } from "../../src/domain/index.ts";
-import { docWrite, withTempStoreAsync } from "./helpers.ts";
+import { docWrite, runEffect, withTempStoreAsync } from "./helpers.ts";
 import { daemonAttribution, git, initAuthoredGit } from "./helpers/daemon-runtime.ts";
 
 const testAttribution = daemonAttribution("person_test", "test", "credential-test");
@@ -26,7 +26,7 @@ test("daemon serializes authority and runtime-event flush domains before either 
       operationalActor: { scope: "operational", kind: "system", id: "daemon-runtime" },
       ops: [runtimeEventOp("runtime-event-domain", "authority-domain.jsonl", "evt-domain")]
     });
-    const authorityReceipt = await Effect.runPromise(authority.flush("explicit"));
+    const authorityReceipt = await runEffect(authority.flush("explicit"));
 
     assert.equal(runtimeEventReceipt.flush.opCount, 1);
     assert.equal(authorityReceipt.opCount, 1);

--- a/packages/kernel/test/store/daemon-runtime-authority-domains.test.ts
+++ b/packages/kernel/test/store/daemon-runtime-authority-domains.test.ts
@@ -1,0 +1,93 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import { createDaemonRuntime } from "../../../adapters/local/src/index.ts";
+import { moduleEntityId } from "../../src/domain/index.ts";
+import { docWrite, withTempStoreAsync } from "./helpers.ts";
+import { daemonAttribution, git, initAuthoredGit } from "./helpers/daemon-runtime.ts";
+
+const testAttribution = daemonAttribution("person_test", "test", "credential-test");
+
+test("daemon serializes authority and runtime-event flush domains before either enters the durable journal", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const runtime = createDaemonRuntime({ rootDir, materializerPollMs: false, interactiveMicroBatchMs: 20 });
+    await runtime.start();
+    const authority = runtime.createAttributedCoordinator({ attribution: testAttribution, sessionId: "authority-domain" });
+    Effect.runSync(authority.enqueue({
+      ...docWrite("op-authority-domain", "task-authority-domain", "note.md", "authority\n"),
+      authorityIntegrity: authorityIntegrity("11", "22", "33", "task-authority-domain")
+    }));
+    const runtimeEventReceipt = await runtime.enqueueInteractiveWrite({
+      commandId: "runtime-event-domain",
+      operationalActor: { scope: "operational", kind: "system", id: "daemon-runtime" },
+      ops: [runtimeEventOp("runtime-event-domain", "authority-domain.jsonl", "evt-domain")]
+    });
+    const authorityReceipt = await Effect.runPromise(authority.flush("explicit"));
+
+    assert.equal(runtimeEventReceipt.flush.opCount, 1);
+    assert.equal(authorityReceipt.opCount, 1);
+    assert.match(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/authority-domain.jsonl"), "utf8"), /evt-domain/u);
+    assert.equal(git(rootDir, "show", "sessions/authority-domain:tasks/task-authority-domain/note.md"), "authority");
+    await runtime.stop();
+  });
+});
+
+test("daemon interactive queue keeps matching attribution in separate integrity domains", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const runtime = createDaemonRuntime({ rootDir, materializerPollMs: false, interactiveMicroBatchMs: 20 });
+    await runtime.start();
+    const authorityOp = {
+      ...docWrite("op-domain-authority", "task-domain-authority", "note.md", "authority domain\n"),
+      authorityIntegrity: authorityIntegrity("44", "55", "66", "task-domain-authority")
+    };
+    const [authority, legacy] = await Promise.all([
+      runtime.enqueueInteractiveWrite({ commandId: "authority-domain", attribution: testAttribution, ops: [authorityOp] }),
+      runtime.enqueueInteractiveWrite({
+        commandId: "legacy-domain",
+        attribution: testAttribution,
+        ops: [runtimeEventOp("runtime-event-matching-attribution", "matching-attribution.jsonl", "evt-matching-attribution")]
+      })
+    ]);
+
+    assert.equal(authority.flush.opCount, 1);
+    assert.equal(legacy.flush.opCount, 1);
+    assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-domain-authority/note.md"), "utf8"), "authority domain\n");
+    assert.match(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/matching-attribution.jsonl"), "utf8"), /evt-matching-attribution/u);
+    await runtime.stop();
+  });
+});
+
+function authorityIntegrity(requestByte: string, mutationByte: string, actorByte: string, taskId: string) {
+  return {
+    schema: "authority-operation-integrity/v2" as const,
+    semanticRequestDigest: requestByte.repeat(32),
+    semanticMutationSetDigest: mutationByte.repeat(32),
+    mutationRegistryVersion: 1,
+    actorAxesBindingDigest: actorByte.repeat(32),
+    canonicalMutationSet: {
+      registryVersion: 1,
+      mutations: [{
+        entity: { registryVersion: 1, entityKind: "task", canonicalRef: `task/${taskId}` },
+        action: { registryVersion: 1, action: "append" }
+      }]
+    }
+  } as const;
+}
+
+function runtimeEventOp(opId: string, fileName: string, eventId: string) {
+  return {
+    opId,
+    entityId: moduleEntityId("runtime-event-ledger"),
+    kind: "machine_artifact_append_jsonl" as const,
+    payload: {
+      boundary: "runtime-event-ledger",
+      path: `.harness/generated/runtime-events/${fileName}`,
+      value: { schema: "runtime-event/v1", eventId }
+    }
+  };
+}

--- a/packages/kernel/test/store/daemon-runtime.test.ts
+++ b/packages/kernel/test/store/daemon-runtime.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
 import { createHarnessRuntimeContext, resolveHarnessLayout } from "../../src/layout/index.ts";
+import { moduleEntityId } from "../../src/domain/index.ts";
 import { makeTaskHolderService, taskHolderActor } from "../../src/local/task-holder-state.ts";
 import type { ProjectionSourceFence, ProjectionSourceFenceFactory } from "../../src/ports/projection-source-fence.ts";
 import { queryExecutionEvidencePage } from "../../src/projection/sqlite-execution-evidence-reader.ts";
@@ -552,6 +553,114 @@ test("authority attributed coordinator is backed by the current daemon held-lock
       && error !== null
       && "_tag" in error
       && error._tag === "JournalUnavailable");
+  });
+});
+
+test("daemon serializes authority and runtime-event flush domains before either enters the durable journal", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: false,
+      interactiveMicroBatchMs: 20
+    });
+    await runtime.start();
+
+    const authority = runtime.createAttributedCoordinator({
+      attribution: testAttribution,
+      sessionId: "authority-domain"
+    });
+    const authorityOp = {
+      ...docWrite("op-authority-domain", "task-authority-domain", "note.md", "authority\n"),
+      authorityIntegrity: {
+        schema: "authority-operation-integrity/v2" as const,
+        semanticRequestDigest: "11".repeat(32),
+        semanticMutationSetDigest: "22".repeat(32),
+        mutationRegistryVersion: 1,
+        actorAxesBindingDigest: "33".repeat(32),
+        canonicalMutationSet: {
+          registryVersion: 1,
+          mutations: [{
+            entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task-authority-domain" },
+            action: { registryVersion: 1, action: "append" }
+          }]
+        }
+      }
+    } as const;
+    Effect.runSync(authority.enqueue(authorityOp));
+
+    const runtimeEvent = runtime.enqueueInteractiveWrite({
+      commandId: "runtime-event-domain",
+      operationalActor: { scope: "operational", kind: "system", id: "daemon-runtime" },
+      ops: [{
+        opId: "runtime-event-domain",
+        entityId: moduleEntityId("runtime-event-ledger"),
+        kind: "machine_artifact_append_jsonl",
+        payload: {
+          boundary: "runtime-event-ledger",
+          path: ".harness/generated/runtime-events/authority-domain.jsonl",
+          value: { schema: "runtime-event/v1", eventId: "evt-domain" }
+        }
+      }]
+    });
+    const runtimeEventReceipt = await runtimeEvent;
+    const authorityReceipt = await Effect.runPromise(authority.flush("explicit"));
+    assert.equal(runtimeEventReceipt.flush.opCount, 1);
+    assert.equal(authorityReceipt.opCount, 1);
+    assert.equal(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/authority-domain.jsonl"), "utf8").includes("evt-domain"), true);
+    assert.equal(git(rootDir, "show", "sessions/authority-domain:tasks/task-authority-domain/note.md"), "authority");
+
+    await runtime.stop();
+  });
+});
+
+test("daemon interactive queue keeps matching attribution in separate integrity domains", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: false,
+      interactiveMicroBatchMs: 20
+    });
+    await runtime.start();
+    const authorityOp = {
+      ...docWrite("op-domain-authority", "task-domain-authority", "note.md", "authority domain\n"),
+      authorityIntegrity: {
+        schema: "authority-operation-integrity/v2" as const,
+        semanticRequestDigest: "44".repeat(32),
+        semanticMutationSetDigest: "55".repeat(32),
+        mutationRegistryVersion: 1,
+        actorAxesBindingDigest: "66".repeat(32),
+        canonicalMutationSet: {
+          registryVersion: 1,
+          mutations: [{
+            entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task-domain-authority" },
+            action: { registryVersion: 1, action: "append" }
+          }]
+        }
+      }
+    } as const;
+    const legacyOp = {
+      opId: "runtime-event-matching-attribution",
+      entityId: moduleEntityId("runtime-event-ledger"),
+      kind: "machine_artifact_append_jsonl" as const,
+      payload: {
+        boundary: "runtime-event-ledger",
+        path: ".harness/generated/runtime-events/matching-attribution.jsonl",
+        value: { schema: "runtime-event/v1", eventId: "evt-matching-attribution" }
+      }
+    };
+
+    const [authority, legacy] = await Promise.all([
+      runtime.enqueueInteractiveWrite({ commandId: "authority-domain", attribution: testAttribution, ops: [authorityOp] }),
+      runtime.enqueueInteractiveWrite({ commandId: "legacy-domain", attribution: testAttribution, ops: [legacyOp] })
+    ]);
+
+    assert.equal(authority.flush.opCount, 1);
+    assert.equal(legacy.flush.opCount, 1);
+    assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-domain-authority/note.md"), "utf8"), "authority domain\n");
+    assert.match(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/matching-attribution.jsonl"), "utf8"), /evt-matching-attribution/u);
+    await runtime.stop();
   });
 });
 

--- a/packages/kernel/test/store/daemon-runtime.test.ts
+++ b/packages/kernel/test/store/daemon-runtime.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
 import { createHarnessRuntimeContext, resolveHarnessLayout } from "../../src/layout/index.ts";
-import { moduleEntityId } from "../../src/domain/index.ts";
 import { makeTaskHolderService, taskHolderActor } from "../../src/local/task-holder-state.ts";
 import type { ProjectionSourceFence, ProjectionSourceFenceFactory } from "../../src/ports/projection-source-fence.ts";
 import { queryExecutionEvidencePage } from "../../src/projection/sqlite-execution-evidence-reader.ts";
@@ -553,114 +552,6 @@ test("authority attributed coordinator is backed by the current daemon held-lock
       && error !== null
       && "_tag" in error
       && error._tag === "JournalUnavailable");
-  });
-});
-
-test("daemon serializes authority and runtime-event flush domains before either enters the durable journal", async () => {
-  await withTempStoreAsync(async (rootDir) => {
-    initAuthoredGit(rootDir);
-    const runtime = createDaemonRuntime({
-      rootDir,
-      materializerPollMs: false,
-      interactiveMicroBatchMs: 20
-    });
-    await runtime.start();
-
-    const authority = runtime.createAttributedCoordinator({
-      attribution: testAttribution,
-      sessionId: "authority-domain"
-    });
-    const authorityOp = {
-      ...docWrite("op-authority-domain", "task-authority-domain", "note.md", "authority\n"),
-      authorityIntegrity: {
-        schema: "authority-operation-integrity/v2" as const,
-        semanticRequestDigest: "11".repeat(32),
-        semanticMutationSetDigest: "22".repeat(32),
-        mutationRegistryVersion: 1,
-        actorAxesBindingDigest: "33".repeat(32),
-        canonicalMutationSet: {
-          registryVersion: 1,
-          mutations: [{
-            entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task-authority-domain" },
-            action: { registryVersion: 1, action: "append" }
-          }]
-        }
-      }
-    } as const;
-    Effect.runSync(authority.enqueue(authorityOp));
-
-    const runtimeEvent = runtime.enqueueInteractiveWrite({
-      commandId: "runtime-event-domain",
-      operationalActor: { scope: "operational", kind: "system", id: "daemon-runtime" },
-      ops: [{
-        opId: "runtime-event-domain",
-        entityId: moduleEntityId("runtime-event-ledger"),
-        kind: "machine_artifact_append_jsonl",
-        payload: {
-          boundary: "runtime-event-ledger",
-          path: ".harness/generated/runtime-events/authority-domain.jsonl",
-          value: { schema: "runtime-event/v1", eventId: "evt-domain" }
-        }
-      }]
-    });
-    const runtimeEventReceipt = await runtimeEvent;
-    const authorityReceipt = await Effect.runPromise(authority.flush("explicit"));
-    assert.equal(runtimeEventReceipt.flush.opCount, 1);
-    assert.equal(authorityReceipt.opCount, 1);
-    assert.equal(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/authority-domain.jsonl"), "utf8").includes("evt-domain"), true);
-    assert.equal(git(rootDir, "show", "sessions/authority-domain:tasks/task-authority-domain/note.md"), "authority");
-
-    await runtime.stop();
-  });
-});
-
-test("daemon interactive queue keeps matching attribution in separate integrity domains", async () => {
-  await withTempStoreAsync(async (rootDir) => {
-    initAuthoredGit(rootDir);
-    const runtime = createDaemonRuntime({
-      rootDir,
-      materializerPollMs: false,
-      interactiveMicroBatchMs: 20
-    });
-    await runtime.start();
-    const authorityOp = {
-      ...docWrite("op-domain-authority", "task-domain-authority", "note.md", "authority domain\n"),
-      authorityIntegrity: {
-        schema: "authority-operation-integrity/v2" as const,
-        semanticRequestDigest: "44".repeat(32),
-        semanticMutationSetDigest: "55".repeat(32),
-        mutationRegistryVersion: 1,
-        actorAxesBindingDigest: "66".repeat(32),
-        canonicalMutationSet: {
-          registryVersion: 1,
-          mutations: [{
-            entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task-domain-authority" },
-            action: { registryVersion: 1, action: "append" }
-          }]
-        }
-      }
-    } as const;
-    const legacyOp = {
-      opId: "runtime-event-matching-attribution",
-      entityId: moduleEntityId("runtime-event-ledger"),
-      kind: "machine_artifact_append_jsonl" as const,
-      payload: {
-        boundary: "runtime-event-ledger",
-        path: ".harness/generated/runtime-events/matching-attribution.jsonl",
-        value: { schema: "runtime-event/v1", eventId: "evt-matching-attribution" }
-      }
-    };
-
-    const [authority, legacy] = await Promise.all([
-      runtime.enqueueInteractiveWrite({ commandId: "authority-domain", attribution: testAttribution, ops: [authorityOp] }),
-      runtime.enqueueInteractiveWrite({ commandId: "legacy-domain", attribution: testAttribution, ops: [legacyOp] })
-    ]);
-
-    assert.equal(authority.flush.opCount, 1);
-    assert.equal(legacy.flush.opCount, 1);
-    assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-domain-authority/note.md"), "utf8"), "authority domain\n");
-    assert.match(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/matching-attribution.jsonl"), "utf8"), /evt-matching-attribution/u);
-    await runtime.stop();
   });
 });
 

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -366,7 +366,7 @@
       ],
       "callsiteFiles": [
         "packages/cli/src/commands/core/coordinated-machine-write.ts",
-        "packages/kernel/src/store/daemon-runtime.ts",
+        "packages/kernel/src/store/daemon-runtime-authority-coordinator.ts",
         "packages/kernel/src/store/daemon-runtime-queue.ts",
         "packages/kernel/src/write-coordination/write-helpers.ts"
       ],
@@ -1653,12 +1653,16 @@
       "directWrites": [
         {
           "file": "packages/cli/src/daemon/authority-service-state.ts"
+        },
+        {
+          "file": "packages/cli/src/daemon/production-authority-recovery.ts"
         }
       ],
       "evidence": [
-        "packages/cli/src/daemon/authority-service-state.ts:167"
+        "packages/cli/src/daemon/authority-service-state.ts:167",
+        "packages/cli/src/daemon/production-authority-recovery.ts:199"
       ],
-      "freshness": "append-only-fsync-restart-replayed"
+      "freshness": "append-only-state-plus-fsync-atomic-recovery-watermark"
     },
     {
       "id": "daemon.socket-ownership.lock",


### PR DESCRIPTION
# English

## Summary

Three production defects on the W6 authority write path, all found by the fifth re-enable smoke matrix and its aftermath: D16 — legacy runtime-event machine writes could share a flush batch with integrity-bearing authority operations, tripping the kernel mix rejection and intermittently killing every authority write (the smoke matrix's earlier greens were batch-timing luck); D15 — `task create` through V2 ingress bound the session entity instead of the task entity (the D8 defect class, unfixed on the new-task road), and preset-shaped creation was rejected outright; and the daemon startup recovery scan ran synchronously over the full inner-ledger first-parent history on every start, blocking the socket for 8–19 minutes in production (CEO-adjudicated unacceptable). This PR isolates flush integrity domains, fixes task creation end to end including task-only presets, terminalizes unrecoverable no-commit operations, and moves recovery off the startup critical path behind a watermark.

## What Changed

- D16: the daemon now runs two explicit integrity domains (`authority` / `legacy`); batches coalesce only within one domain, mixed-domain requests are rejected, and authority journal enqueue+flush defers until the authority coordinator owns the serialized flush boundary. The kernel mix check itself is retained as the last line of defense; scheduling changed, admission semantics did not.
- No-commit recovery: an INDETERMINATE typed operation with no commitSha is terminalized as REJECTED (preserving its original reason) only when a successfully completed first-parent publication scan finds no anchor for its opId; inspector failures and ambiguous matches stay deferred fail-closed.
- D15: bare `task create` binds the task entity through the D8 inline-create provenance road — inner commit, exactly one event, registry COMMITTED. Task-only presets (e.g. docs-task) are admitted: the compiler resolves the preset from the daemon's bundled catalog, materializes canonical task documents server-side, and submits one multi-file `task.create` mutation. Module-registering presets remain intentionally fail-closed pending a multi-entity mutation model.
- Startup performance: recovery persists a `recovery-watermark.json` in daemon-private service state (fsync + atomic rename), advancing only when every operation in the scanned range is terminal; startup scans only the post-watermark first-parent increment, with full-scan fallback on missing/corrupt/non-first-parent watermarks. The socket starts first; non-authority surfaces serve immediately; authority writes return retryable `AUTHORITY_RECOVERY_IN_PROGRESS` until background recovery completes; git subprocesses are asynchronous.
- `tools/write-road-registry.json`: declarative row updates only (coordinator callsite move; watermark write road registration).

## Task And Scope

- W6 cutover line task_01KXMN5BRWQH93976XBZSHSCN4 (ProdCutover line-S); fifth-freeze receipt `freeze_03ab13823a1cd7af46ba8b9e`; standing W6 fix-then-cut authorization plus CEO adjudication that startup latency was unacceptable.
- Production state untouched; deploy + daemon restart + sixth re-enable remain operator actions after merge.

## Version Impact

- No published package version change.

## Governance Declaration

- Authority anchor: task_01KXMN5BRWQH93976XBZSHSCN4; ledger closeout deferred (authority writes frozen).
- Governance-adjacent path touched: `tools/write-road-registry.json` — pure declarative row updates (callsite relocation plus one new watermark write road); no checker script modified.
- Protected surfaces untouched (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `tools/test-tier-manifest.mjs`, `harness/**`).
- No gate weakening: the kernel mix rejection, publication proof, admission semantics, and fail-closed recovery deferrals all remain; module-registering presets stay rejected rather than weakly admitted.

## Verification

- Root `env -u FORCE_COLOR HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 (40.3 s) — 32 local manifest gates green; affected fast 428/428, contract 355/355.
- D16 regression: deterministic pre-fix concurrency test reproduced `authority publication cannot mix integrity-bearing and legacy operations`; post-fix, concurrent authority + runtime-event writes all commit (including a same-attribution negative control), and a production service-path regression proves four concurrent authority writes with runtime events emitted all reach COMMITTED with exactly one event each.
- D15 regressions: bare create and docs-task preset create both green on the production service path with generated files and metadata validated.
- Performance fixture (same `daemon start --service --authority-manifest` path, isolated root/registry pointer, real inner git, 800 first-parent commits + one no-publication INDETERMINATE op): startup-to-reachable-socket 9.217 s pre-patch → 1.410 s patched; background recovery completes at 9.820 s; restart after 5 new commits fully recovers in 1.420 s.
- Watermark regressions cover missing/corrupt state, valid incremental scan, unresolved-op no-advance, and side-branch rejection.

## Review Evidence

- CEO semantic acceptance: mix check retained at `write-journal-authority-trailer.ts`; no-commit terminalization gated on completed-scan-plus-no-anchor with ambiguity deferred; preset admission bounded to task-only shapes; watermark advance blocked by any unresolved operation; recovery gate returns retryable rather than hanging or admitting — confirmed in diff.

## Residual Risk

- Real production restart timing and the sixth re-enable remain operator-owned; the 8–19 minute production observation is operator-measured, not fixture-derived.
- Watermark loss/corruption safely falls back to a full background scan: socket stays fast, authority writes stay gated for the cold-scan duration.
- Module-registering presets stay fail-closed until a multi-entity authority mutation model exists (follow-up).
- The smoke matrix standard is upgraded: only concurrent interleaved runtime-event + authority writes count as green.

## References

- PRs #865 (D0–D5), #872 (D6–D9), #876 (D10–D11), #878 (D12), #881 (D12b), #883 (D14).
- Worker report: `tmp/orch/w6-d15-perf/REPORT.md` (local orchestration artifact).

---

# 中文

## 概要

W6 authority 写路的三个生产缺陷，均由第五轮 re-enable 冒烟矩阵及其后续暴露：D16——legacy runtime-event 机器写可与携带 integrity 的 authority 操作混入同一 flush 批次，触发 kernel mix 拒绝、authority 写间歇性全灭（此前冒烟全绿只是批次时机运气）；D15——`task create` 走 V2 ingress 绑定了 session entity 而非 task entity（D8 缺陷类在 new-task 路未修），preset 形态创建更被整体拒绝；以及 daemon 启动恢复每次同步全量扫描内层台账 first-parent 历史、阻塞 socket 8–19 分钟（CEO 裁决不可接受）。本 PR 分离 flush integrity 域、端到端修复 task 创建（含 task-only preset）、终态化不可恢复的无 commit 操作、并以水位线把恢复移出启动关键路径。

## 改动内容

- D16：daemon 显式区分两个 integrity 域（`authority` / `legacy`）；批次仅在同域内聚合，混域请求被拒绝，authority 的 journal 入队+flush 推迟到 authority coordinator 持有串行 flush 边界之后。kernel mix 检查保留为最后防线；改的是调度，不是 admission 语义。
- 无 commit 恢复：INDETERMINATE 且无 commitSha 的 typed 操作，仅当一次成功完成的 first-parent publication 扫描确认无该 opId 锚时才终态化为 REJECTED（保留原始 reason）；inspector 失败与多锚歧义保持 deferred fail-closed。
- D15：裸 `task create` 经 D8 inline-create provenance 路绑定 task entity——inner commit 落盘、恰一 event、registry COMMITTED。task-only preset（如 docs-task）获准入：compiler 从 daemon 内置目录解析 preset、服务端物化 canonical 任务文档、以单个多文件 `task.create` mutation 提交。注册/改动 module 的 preset 有意保持 fail-closed，待多实体 mutation 模型。
- 启动性能：恢复在 daemon 私有服务状态持久化 `recovery-watermark.json`（fsync + 原子重命名），仅当扫描范围内全部操作终态后推进；启动只扫水位后增量，水位缺失/损坏/非一等亲链回退全量。socket 先起；非 authority 面立即可用；authority 写在后台恢复完成前返回可重试的 `AUTHORITY_RECOVERY_IN_PROGRESS`；git 子进程异步化。
- `tools/write-road-registry.json`：纯声明行更新（coordinator callsite 迁移；新增水位写路登记）。

## 任务与范围

- W6 cutover 线 task_01KXMN5BRWQH93976XBZSHSCN4（ProdCutover line-S）；五冻回执 `freeze_03ab13823a1cd7af46ba8b9e`；W6 修完即 cut 常设授权 + CEO 对启动延迟不可接受的裁决。
- 生产状态未触碰；部署 + daemon 重启 + 第六轮 re-enable 为合并后 operator 动作。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 授权锚：task_01KXMN5BRWQH93976XBZSHSCN4；台账销账押后（authority 写冻结中）。
- 触碰的治理相邻路径：`tools/write-road-registry.json`——纯声明行更新（callsite 迁移 + 新增一条水位写路）；未改任何 checker 脚本。
- protected 面未触碰（`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`tools/test-tier-manifest.mjs`、`harness/**`）。
- 无削 gate：kernel mix 拒绝、publication proof、admission 语义与 fail-closed 恢复延迟全部保留；module 类 preset 保持拒绝而非弱化准入。

## 验证

- 根 `env -u FORCE_COLOR HARNESS_DAEMON_MODE=direct npm run check:local` exit 0（40.3 秒）——32 个 local manifest gates 全绿；affected fast 428/428、contract 355/355。
- D16 回归：确定性并发回归在补丁前复现 `authority publication cannot mix integrity-bearing and legacy operations`；补丁后并发 authority + runtime-event 写全部落盘（含同归属阴性对照），生产 service-path 回归证明四路并发 authority 写夹杂 runtime event 全部 COMMITTED 且各恰一 event。
- D15 回归：裸 create 与 docs-task preset create 在生产 service path 全绿，生成文件与 metadata 已验。
- 性能夹具（与生产同一条 `daemon start --service --authority-manifest` 路径、隔离 root/registry pointer、真实 inner git、800 一等亲 commit + 一笔无 publication 的 INDETERMINATE op）：启动到 socket 可达 9.217 秒（补丁前）→ 1.410 秒（补丁后）；后台恢复 9.820 秒完成；新增 5 commit 后重启 1.420 秒全恢复。
- 水位回归覆盖缺失/损坏状态、有效增量扫描、未决 op 不推进、侧枝拒绝。

## 审查证据

- CEO 语义验收：mix 检查保留于 `write-journal-authority-trailer.ts`；无 commit 终态化以「扫描完成 + 无锚」为门、歧义延迟；preset 准入限定 task-only 形态；任一未决操作阻止水位推进；恢复 gate 返回可重试而非挂死或放行——diff 中逐项确认。

## 残余风险

- 真实生产重启计时与第六轮 re-enable 归 operator；8–19 分钟为生产实测非夹具推断。
- 水位丢失/损坏安全回退全量后台扫描：socket 保持快速，authority 写在冷扫描期间保持 gated。
- module 类 preset 在多实体 authority mutation 模型落地前保持 fail-closed（后续项）。
- 冒烟矩阵标准升级：仅并发交错 runtime-event 与 authority 写的结果才算绿。

## 关联材料

- PR #865（D0–D5）、#872（D6-D9）、#876（D10-D11）、#878（D12）、#881（D12b）、#883（D14）。
- worker 报告：`tmp/orch/w6-d15-perf/REPORT.md`（本机编排产物）。
