### PR TITLE
fix: replay journal writes by integrity domain (W6 D17 upgrade path)

### DIFF
--- a/packages/cli/test/production-authority-journal-upgrade.test.ts
+++ b/packages/cli/test/production-authority-journal-upgrade.test.ts
@@ -1,0 +1,112 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import {
+  makeJournaledWriteCoordinator,
+  makeOperationalJournaledWriteCoordinator,
+  moduleEntityId,
+  taskEntityId
+} from "../../kernel/src/index.ts";
+import {
+  defaultDaemonUserRoot,
+  pollUntil,
+  runDaemonCommand,
+  stopDaemon
+} from "./helpers/daemon-cli.ts";
+import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
+
+test("production service upgrades a pre-domain mixed journal before canonical attach", { timeout: 60_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const env = {
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"
+  };
+  try {
+    seedPreDomainJournal(fixture.repoRoot);
+    const registered = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical", "--canonical-root", fixture.repoRoot,
+      "--user-root", userRoot, "--no-link", "--json"
+    ], env);
+    assert.equal(registered.ok, true, JSON.stringify(registered));
+    try {
+      runDaemonCommand(fixture.repoRoot, [
+        "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+      ], env);
+    } catch {
+      // Observe the detached service when startup outlives the CLI reachability wait.
+    }
+    const status = await pollUntil(
+      () => runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env),
+      (candidate) => candidate.reachable === true
+        && Array.isArray(candidate.repos)
+        && candidate.repos.some((repo) => repo.repoId === "canonical" && repo.state === "attached"),
+      (candidate, error) => JSON.stringify({ candidate, error: String(error ?? "") }),
+      { timeoutMs: 20_000 }
+    );
+    assert.equal(status.reachable, true, JSON.stringify(status));
+    assert.equal(readFileSync(path.join(fixture.authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/upgrade.md"), "utf8"), "authority upgraded\n");
+    assert.match(readFileSync(path.join(fixture.repoRoot, ".harness/generated/runtime-events/upgrade.jsonl"), "utf8"), /evt-upgrade/u);
+    assert.equal(readFileSync(path.join(fixture.repoRoot, ".harness/write-journal/writes.jsonl"), "utf8"), "");
+  } finally {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+function seedPreDomainJournal(rootDir: string): void {
+  const legacy = makeOperationalJournaledWriteCoordinator({
+    rootDir,
+    operationalActor: { scope: "operational", kind: "system", id: "legacy-runtime" },
+    autoMaterialize: false
+  });
+  const authority = makeJournaledWriteCoordinator({
+    rootDir,
+    attribution: {
+      actor: { principal: { kind: "person", personId: "person_alice" }, executor: { kind: "agent", id: "codex" } },
+      principalSource: { kind: "daemon-authenticated", providerId: "fixture-provider", credentialFingerprint: "fixture-credential" },
+      executorSource: "client-asserted"
+    },
+    autoMaterialize: false
+  });
+  Effect.runSync(legacy.enqueue({
+    opId: "runtime-event-upgrade",
+    entityId: moduleEntityId("runtime-event-ledger"),
+    kind: "machine_artifact_append_jsonl",
+    payload: {
+      boundary: "runtime-event-ledger",
+      path: ".harness/generated/runtime-events/upgrade.jsonl",
+      value: { schema: "runtime-event/v1", eventId: "evt-upgrade" }
+    }
+  }));
+  Effect.runSync(authority.enqueue({
+    opId: "op-authority-upgrade",
+    entityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"),
+    kind: "doc_write",
+    payload: { path: "upgrade.md", body: "authority upgraded\n" },
+    authorityIntegrity: authorityIntegrity()
+  }));
+}
+
+function authorityIntegrity() {
+  return {
+    schema: "authority-operation-integrity/v2" as const,
+    semanticRequestDigest: "1".repeat(64),
+    semanticMutationSetDigest: "2".repeat(64),
+    mutationRegistryVersion: 1,
+    actorAxesBindingDigest: "3".repeat(64),
+    canonicalMutationSet: {
+      registryVersion: 1,
+      mutations: [{
+        entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4" },
+        action: { registryVersion: 1, action: "append" }
+      }]
+    }
+  } as const;
+}

--- a/packages/cli/test/production-authority-journal-upgrade.test.ts
+++ b/packages/cli/test/production-authority-journal-upgrade.test.ts
@@ -16,7 +16,7 @@ import {
   runDaemonCommand,
   stopDaemon
 } from "./helpers/daemon-cli.ts";
-import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
+import { createFixture, git } from "./production-authority-canonical-ingress/fixture.ts";
 
 test("production service upgrades a pre-domain mixed journal before canonical attach", { timeout: 60_000 }, async () => {
   const fixture = createFixture();
@@ -29,6 +29,8 @@ test("production service upgrades a pre-domain mixed journal before canonical at
     HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"
   };
   try {
+    git(fixture.authoredRoot, "config", "user.name", "Harness Upgrade Test");
+    git(fixture.authoredRoot, "config", "user.email", "harness-upgrade@example.test");
     seedPreDomainJournal(fixture.repoRoot);
     const registered = runDaemonCommand(fixture.repoRoot, [
       "daemon", "repo", "register", "--repo-id", "canonical", "--canonical-root", fixture.repoRoot,
@@ -53,6 +55,7 @@ test("production service upgrades a pre-domain mixed journal before canonical at
     assert.equal(status.reachable, true, JSON.stringify(status));
     assert.equal(readFileSync(path.join(fixture.authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/upgrade.md"), "utf8"), "authority upgraded\n");
     assert.match(readFileSync(path.join(fixture.repoRoot, ".harness/generated/runtime-events/upgrade.jsonl"), "utf8"), /evt-upgrade/u);
+    assert.match(git(fixture.authoredRoot, "log", "-2", "--format=%B"), /Harness-Authority-Batch:/u);
     assert.equal(readFileSync(path.join(fixture.repoRoot, ".harness/write-journal/writes.jsonl"), "utf8"), "");
   } finally {
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);

--- a/packages/kernel/src/ports/write-coordinator.ts
+++ b/packages/kernel/src/ports/write-coordinator.ts
@@ -112,6 +112,7 @@ export interface FlushReport {
 export interface RecoveryReport {
   readonly replayedOps: number;
   readonly recoveredWatermark?: string;
+  readonly deferredOps?: number;
 }
 
 export interface WriteCoordinator {

--- a/packages/kernel/src/store/daemon-runtime-queue.ts
+++ b/packages/kernel/src/store/daemon-runtime-queue.ts
@@ -5,6 +5,7 @@ import type { WriteError } from "../domain/index.ts";
 import type { FlushReport, WriteOp } from "../ports/write-coordinator.ts";
 import type { WriteAttribution } from "../schemas/actor-attribution.ts";
 import type { GitCommitAuthor, OperationalActor } from "./write-journal-types.ts";
+import { singleWriteIntegrityDomain, type WriteIntegrityDomain } from "./write-integrity-domain.ts";
 import type { makeJournaledWriteCoordinator } from "./write-journal-coordinator.ts";
 
 export type DaemonWritePriority = "interactive" | "normal" | "background" | "maintenance";
@@ -51,7 +52,7 @@ type InteractiveQueueItem = InteractiveWriteAttribution & {
   readonly ops: ReadonlyArray<WriteOp>;
   readonly commitAuthor?: GitCommitAuthor;
   readonly sessionId?: string;
-  readonly integrityDomain: "authority" | "legacy";
+  readonly integrityDomain: WriteIntegrityDomain;
   readonly enqueuedAt: number;
   started: boolean;
   timeout?: ReturnType<typeof setTimeout>;
@@ -106,7 +107,7 @@ export class DaemonWriteQueue {
     coordinatorFor: (batch: InteractiveCoordinatorBatch) => JournaledWriteCoordinator
   ): Promise<InteractiveWriteReceipt> {
     if (this.closed) return Promise.reject({ _tag: "JournalUnavailable", cause: new Error("daemon write queue is closed") } satisfies WriteError);
-    const integrityDomain = requestIntegrityDomain(request.ops);
+    const integrityDomain = singleWriteIntegrityDomain(request.ops);
     if (!integrityDomain) {
       return Promise.reject({
         _tag: "WriteRejected",
@@ -349,12 +350,6 @@ function sameAttribution(left: InteractiveQueueItem, right: InteractiveQueueItem
     && authorKey(left.commitAuthor) === authorKey(right.commitAuthor)
     && sessionKey(left.sessionId) === sessionKey(right.sessionId)
     && left.integrityDomain === right.integrityDomain;
-}
-
-function requestIntegrityDomain(ops: ReadonlyArray<WriteOp>): "authority" | "legacy" | undefined {
-  const authorityCount = ops.filter((op) => op.authorityIntegrity !== undefined).length;
-  if (authorityCount === 0) return "legacy";
-  return authorityCount === ops.length ? "authority" : undefined;
 }
 
 function attributionKey(input: InteractiveWriteAttribution): string {

--- a/packages/kernel/src/store/write-integrity-domain.ts
+++ b/packages/kernel/src/store/write-integrity-domain.ts
@@ -1,0 +1,33 @@
+export type WriteIntegrityDomain = "authority" | "legacy";
+
+type IntegrityDomainMember = { readonly authorityIntegrity?: unknown };
+
+export function writeIntegrityDomain(member: IntegrityDomainMember): WriteIntegrityDomain {
+  return member.authorityIntegrity === undefined ? "legacy" : "authority";
+}
+
+export function singleWriteIntegrityDomain(
+  members: ReadonlyArray<IntegrityDomainMember>
+): WriteIntegrityDomain | undefined {
+  const first = members[0];
+  if (!first) return undefined;
+  const domain = writeIntegrityDomain(first);
+  return members.every((member) => writeIntegrityDomain(member) === domain) ? domain : undefined;
+}
+
+export function writeIntegrityDomainsInOrder(
+  members: ReadonlyArray<IntegrityDomainMember>
+): ReadonlyArray<WriteIntegrityDomain> {
+  const domains = new Set<WriteIntegrityDomain>();
+  for (const member of members) {
+    domains.add(writeIntegrityDomain(member));
+  }
+  return [...domains];
+}
+
+export function recordsForWriteIntegrityDomain<Member extends IntegrityDomainMember>(
+  members: ReadonlyArray<Member>,
+  domain: WriteIntegrityDomain | undefined
+): ReadonlyArray<Member> {
+  return domain ? members.filter((member) => writeIntegrityDomain(member) === domain) : members;
+}

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -49,6 +49,8 @@ import {
 } from "./write-journal-operations.ts";
 import { reconcileDurableFlush, shouldWaitForForeignCommitter } from "./write-journal-receipt.ts";
 import { semanticCommitMessage } from "./write-journal-authority-trailer.ts";
+import { recoverJournalIntegrityDomains } from "./write-journal-domain-recovery.ts";
+import { recordsForWriteIntegrityDomain, singleWriteIntegrityDomain } from "./write-integrity-domain.ts";
 import { memoizePublicationVcs } from "./write-journal-publication-vcs.ts";
 import type { ApplyMarkerRecord, DeleteAuditRecord, GitCommitAuthor, JournaledWriteCoordinatorOptions, JournalRecoveryOptions, LockConflictRetryOptions, LockTakeoverRecord, OperationalActor, OperationalJournaledWriteCoordinatorOptions, ReadableJournalRecord, WriteWatermark } from "./write-journal-types.ts";
 export type {
@@ -106,21 +108,37 @@ function makeJournaledWriteCoordinatorInternal(
   const flushOnce = (reason: FlushReason): Effect.Effect<FlushReport, WriteError> => Effect.try({
     try: () => withRepoLocks(rootDir, runtimeContext, journalPath, operationalActor, lockTtlMs, pending.map((op) => op.entityId), () => {
       const state = readDurableState(journalPath, watermarkPath, rootDir);
+      const requestedDomain = singleWriteIntegrityDomain(pending);
       pending.splice(0, pending.length);
-      const pendingRecords = uniquePendingRecords(state.records, state.applied);
+      const pendingRecords = recordsForWriteIntegrityDomain(
+        uniquePendingRecords(state.records, state.applied),
+        requestedDomain
+      );
       return flushRecords(reason, rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor, versionControlSystem, attributionEventStore);
     }, { heldGlobalLock }),
     catch: (cause): WriteError => toJournalError(cause)
   });
   const recoverOnce: Effect.Effect<RecoveryReport, WriteError> = Effect.try({
     try: (): RecoveryReport => withRepoLocks(rootDir, runtimeContext, journalPath, operationalActor, lockTtlMs, [], () => {
-      const state = readDurableState(journalPath, watermarkPath, rootDir);
-      const pendingRecords = uniquePendingRecords(state.records, state.applied);
-      const report = flushRecords("recovery", rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor, versionControlSystem, attributionEventStore);
-      return {
-        replayedOps: report.opCount,
-        recoveredWatermark: report.watermark
-      };
+      return recoverJournalIntegrityDomains({
+        rootDir,
+        journalPath,
+        watermarkPath,
+        flushDomain: (state, records) => flushRecords(
+          "recovery",
+          rootDir,
+          runtimeContext,
+          journalPath,
+          watermarkPath,
+          state.watermark,
+          records,
+          state.fileApplied,
+          sessionId,
+          commitAuthor,
+          versionControlSystem,
+          attributionEventStore
+        )
+      });
     }, { heldGlobalLock }),
     catch: (cause): WriteError => toJournalError(cause)
   });

--- a/packages/kernel/src/store/write-journal-domain-recovery.ts
+++ b/packages/kernel/src/store/write-journal-domain-recovery.ts
@@ -1,0 +1,41 @@
+import type { FlushReport, RecoveryReport } from "../ports/write-coordinator.ts";
+import { readDurableState } from "./write-journal-durable.ts";
+import { uniquePendingRecords } from "./write-journal-records.ts";
+import type { ReadableJournalRecord } from "./write-journal-types.ts";
+import { writeIntegrityDomain, writeIntegrityDomainsInOrder } from "./write-integrity-domain.ts";
+
+type DurableState = ReturnType<typeof readDurableState>;
+
+export function recoverJournalIntegrityDomains(input: {
+  readonly rootDir: string;
+  readonly journalPath: string;
+  readonly watermarkPath: string;
+  readonly flushDomain: (
+    state: DurableState,
+    records: ReadonlyArray<ReadableJournalRecord>
+  ) => FlushReport;
+}): RecoveryReport {
+  const initialState = readDurableState(input.journalPath, input.watermarkPath, input.rootDir);
+  const initialPending = uniquePendingRecords(initialState.records, initialState.applied);
+  let replayedOps = 0;
+  let deferredOps = 0;
+  let recoveredWatermark: string | undefined;
+  for (const domain of writeIntegrityDomainsInOrder(initialPending)) {
+    const state = readDurableState(input.journalPath, input.watermarkPath, input.rootDir);
+    const records = uniquePendingRecords(state.records, state.applied)
+      .filter((record) => writeIntegrityDomain(record) === domain);
+    if (records.length === 0) continue;
+    try {
+      const report = input.flushDomain(state, records);
+      replayedOps += report.opCount;
+      recoveredWatermark = report.watermark ?? recoveredWatermark;
+    } catch {
+      deferredOps += records.length;
+    }
+  }
+  return {
+    replayedOps,
+    ...(recoveredWatermark ? { recoveredWatermark } : {}),
+    ...(deferredOps > 0 ? { deferredOps } : {})
+  };
+}

--- a/packages/kernel/test/store/daemon-runtime-authority-domains.test.ts
+++ b/packages/kernel/test/store/daemon-runtime-authority-domains.test.ts
@@ -1,11 +1,12 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
 import { createDaemonRuntime } from "../../../adapters/local/src/index.ts";
 import { moduleEntityId } from "../../src/domain/index.ts";
+import { makeJournaledWriteCoordinator, makeOperationalJournaledWriteCoordinator } from "../../src/store/index.ts";
 import { docWrite, runEffect, withTempStoreAsync } from "./helpers.ts";
 import { daemonAttribution, git, initAuthoredGit } from "./helpers/daemon-runtime.ts";
 
@@ -58,6 +59,76 @@ test("daemon interactive queue keeps matching attribution in separate integrity 
     assert.equal(legacy.flush.opCount, 1);
     assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-domain-authority/note.md"), "utf8"), "authority domain\n");
     assert.match(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/matching-attribution.jsonl"), "utf8"), /evt-matching-attribution/u);
+    await runtime.stop();
+  });
+});
+
+test("daemon upgrade attach replays a pre-domain journal in separate integrity batches", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const legacy = makeOperationalJournaledWriteCoordinator({
+      rootDir,
+      operationalActor: { scope: "operational", kind: "system", id: "legacy-runtime" },
+      autoMaterialize: false
+    });
+    const authority = makeJournaledWriteCoordinator({
+      rootDir,
+      attribution: testAttribution,
+      sessionId: "upgrade-authority",
+      autoMaterialize: false
+    });
+    Effect.runSync(legacy.enqueue(runtimeEventOp(
+      "runtime-event-pre-domain",
+      "pre-domain.jsonl",
+      "evt-pre-domain"
+    )));
+    Effect.runSync(authority.enqueue({
+      ...docWrite("op-authority-pre-domain", "task-authority-pre-domain", "note.md", "authority upgrade\n"),
+      authorityIntegrity: authorityIntegrity("77", "88", "99", "task-authority-pre-domain")
+    }));
+
+    const runtime = createDaemonRuntime({ rootDir, materializerPollMs: false });
+    const status = await runtime.start();
+
+    assert.equal(status.started, true);
+    assert.equal(status.lastRecovery?.replayedOps, 2);
+    assert.match(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/pre-domain.jsonl"), "utf8"), /evt-pre-domain/u);
+    assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-authority-pre-domain/note.md"), "utf8"), "authority upgrade\n");
+    assert.match(git(rootDir, "log", "-2", "--format=%B"), /Harness-Authority-Batch:/u);
+    await runtime.stop();
+  });
+});
+
+test("daemon upgrade attach defers an unsafe domain without discarding a recoverable legacy domain", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const legacy = makeOperationalJournaledWriteCoordinator({
+      rootDir,
+      operationalActor: { scope: "operational", kind: "system", id: "legacy-runtime" },
+      autoMaterialize: false
+    });
+    const authority = makeJournaledWriteCoordinator({ rootDir, attribution: testAttribution, autoMaterialize: false });
+    Effect.runSync(legacy.enqueue(runtimeEventOp("runtime-event-safe-domain", "safe-domain.jsonl", "evt-safe-domain")));
+    Effect.runSync(authority.enqueue({
+      ...docWrite("op-unsafe-authority-domain", "task-unsafe-authority", "note.md", "must remain deferred\n"),
+      authorityIntegrity: authorityIntegrity("aa", "bb", "cc", "task-unsafe-authority")
+    }));
+    const journalPath = path.join(rootDir, ".harness/write-journal/writes.jsonl");
+    const oldLines = readFileSync(journalPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    const unsafe = oldLines.find((record) => record.opId === "op-unsafe-authority-domain");
+    unsafe.payload.payloadHash = "sha256:unsafe-upgrade-record";
+    writeFileSync(journalPath, `${oldLines.map((record) => JSON.stringify(record)).join("\n")}\n`, "utf8");
+
+    const runtime = createDaemonRuntime({ rootDir, materializerPollMs: false });
+    const status = await runtime.start();
+
+    assert.equal(status.started, true);
+    assert.equal(status.lastRecovery?.replayedOps, 1);
+    assert.equal(status.lastRecovery?.deferredOps, 1);
+    assert.match(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/safe-domain.jsonl"), "utf8"), /evt-safe-domain/u);
+    const retained = readFileSync(journalPath, "utf8");
+    assert.doesNotMatch(retained, /runtime-event-safe-domain/u);
+    assert.match(retained, /op-unsafe-authority-domain/u);
     await runtime.stop();
   });
 });

--- a/packages/kernel/test/store/daemon-runtime-authority-domains.test.ts
+++ b/packages/kernel/test/store/daemon-runtime-authority-domains.test.ts
@@ -129,6 +129,14 @@ test("daemon upgrade attach defers an unsafe domain without discarding a recover
     const retained = readFileSync(journalPath, "utf8");
     assert.doesNotMatch(retained, /runtime-event-safe-domain/u);
     assert.match(retained, /op-unsafe-authority-domain/u);
+    const liveLegacy = await runtime.enqueueInteractiveWrite({
+      commandId: "legacy-after-deferred-authority",
+      operationalActor: { scope: "operational", kind: "system", id: "daemon-runtime" },
+      ops: [runtimeEventOp("runtime-event-after-deferred", "after-deferred.jsonl", "evt-after-deferred")]
+    });
+    assert.equal(liveLegacy.flush.opCount, 1);
+    assert.match(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/after-deferred.jsonl"), "utf8"), /evt-after-deferred/u);
+    assert.match(readFileSync(journalPath, "utf8"), /op-unsafe-authority-domain/u);
     await runtime.stop();
   });
 });


### PR DESCRIPTION
# English

## Summary

W6 defect D17, an upgrade-path blocker found deploying #889: attach-time journal recovery still replayed every pending record through one flush call, so a write journal persisted before the integrity-domain separation (the real production state — interleaved legacy runtime-event records plus no-commit authority records from the D16 era) tripped the retained kernel mix defense, the repo never attached, and the daemon exited with "no repo bindings". Production daemon was down until this fix. Replay now classifies and flushes by integrity domain, and an unsafe domain defers without blocking attach.

## What Changed

- Live queue admission and journal replay share one integrity-domain classifier (presence of `authorityIntegrity`); recovery discovers domains in durable journal order and flushes each domain separately.
- After each domain's flush, recovery rereads the durable journal, apply markers, and watermark, so compaction/watermark advancement from one domain cannot be clobbered by a stale snapshot of the next.
- Normal flushes select pending records from the request's own domain, so a deferred old-domain record cannot contaminate later traffic.
- If a classified domain cannot be safely replayed, its records and apply markers stay in the journal, `RecoveryReport.deferredOps` counts them, other domains proceed, and repo attach succeeds; undecodable/unclassifiable state still fails closed before replay. The mix/trailer proof is unchanged.
- One follow-up test commit covers a live legacy write succeeding while an unsafe authority record remains deferred in the WAL.

## Task And Scope

- W6 cutover line task_01KXMN5BRWQH93976XBZSHSCN4 (ProdCutover line-S); found deploying #889 (production daemon failed to start); fifth freeze `freeze_03ab13823a1cd7af46ba8b9e` still in effect.
- Production state untouched; deploy + daemon restart + sixth re-enable remain operator actions after merge.

## Version Impact

- No published package version change.

## Governance Declaration

- Authority anchor: task_01KXMN5BRWQH93976XBZSHSCN4; ledger closeout deferred (authority writes frozen).
- Protected paths touched: none (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `tools/test-tier-manifest.mjs`, `harness/**` untouched).
- No gate weakening: the kernel mix/trailer defense is unchanged; unsafe records defer fail-closed instead of being dropped or force-replayed.

## Verification

- Root `env -u FORCE_COLOR HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 (31.5 s) — 32 local manifest gates green; D17 recovery/runtime/production-service suite 24/24.
- Upgrade-path regression (old state + new code): a pre-existing mixed-domain journal reproduced `JournalUnavailable: authority publication cannot mix integrity-bearing and legacy operations` before the fix; after, the runtime starts, both domains replay, and the authority batch trailer is retained.
- Negative fixture: a corrupted authority payload leaves attach available, the legacy domain converges, `deferredOps=1`, and the unsafe record remains in the WAL.
- Production-same-path fixture (`daemon start --service --authority-manifest`, isolated state, registry pointer, real inner git): canonical repo reaches `attached`, both old-domain records converge, journal compacts cleanly.

## Review Evidence

- CEO semantic acceptance: replay and live admission share one classifier (no second divergent rule); per-domain flush with durable-state reread between domains; deferral is per-domain and non-blocking for attach; mix proof untouched — confirmed in diff and report.

## Residual Risk

- Real production daemon restart and the sixth re-enable remain operator-owned.
- A deferred unsafe record stays in the WAL until the recovery path resolves it; it no longer blocks attach or other domains.
- Every future write-path change should carry an old-state-plus-new-code upgrade regression of this class — adopted as the standard from this defect.

## References

- PR #889 (D15/D16 + startup performance); PRs #865/#872/#876/#878/#881/#883 (D0–D14).
- Worker report: `tmp/orch/w6-d15-perf/REPORT.md` (D17 section; local orchestration artifact).

---

# 中文

## 概要

W6 缺陷 D17，部署 #889 时发现的升级路径阻断：attach 阶段的 journal 恢复仍把所有待重放记录塞进同一次 flush，因此在域分离之前落盘的 write journal（真实生产形态——D16 时代交错的 legacy runtime-event 记录 + 无 commit 的 authority 记录）撞上保留的 kernel mix 防线，repo 永不 attach，daemon 以「no repo bindings」退出。生产 daemon 停机直至本修复。现重放按 integrity 域分类分批 flush，不可安全重放的域 defer 而不阻塞 attach。

## 改动内容

- 活路准入与 journal 重放共用同一 integrity 域分类器（以 `authorityIntegrity` 有无为准）；恢复按 durable journal 顺序发现域并逐域独立 flush。
- 每域 flush 后重读 durable journal、apply 标记与水位，前一域的 compaction/水位推进不会被下一域的陈旧快照覆盖。
- 常规 flush 只取本请求所属域的待处理记录，被 defer 的旧域记录不会污染后续流量。
- 某个已分类域无法安全重放时，其记录与 apply 标记留在 journal，`RecoveryReport.deferredOps` 计数，其他域继续、repo attach 成功；无法解码/分类的状态仍在重放前 fail-closed。mix/trailer 防线不变。
- 追加一个测试 commit：unsafe authority 记录仍 defer 在 WAL 时，活的 legacy 写照常成功。

## 任务与范围

- W6 cutover 线 task_01KXMN5BRWQH93976XBZSHSCN4（ProdCutover line-S）；部署 #889 时发现（生产 daemon 起不来）；五冻 `freeze_03ab13823a1cd7af46ba8b9e` 仍生效。
- 生产状态未触碰；部署 + daemon 重启 + 第六轮 re-enable 为合并后 operator 动作。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 授权锚：task_01KXMN5BRWQH93976XBZSHSCN4；台账销账押后（authority 写冻结中）。
- 触碰的 protected 路径：无（`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`tools/test-tier-manifest.mjs`、`harness/**` 均未动）。
- 无削 gate：kernel mix/trailer 防线不变；不安全记录 fail-closed defer，不丢弃、不强行重放。

## 验证

- 根 `env -u FORCE_COLOR HARNESS_DAEMON_MODE=direct npm run check:local` exit 0（31.5 秒）——32 个 local manifest gates 全绿；D17 恢复/runtime/生产 service 套件 24/24。
- 升级路径回归（老状态 + 新代码）：预置混域 journal 在补丁前复现 `JournalUnavailable: authority publication cannot mix integrity-bearing and legacy operations`；补丁后 runtime 启动、两域各自重放、authority batch trailer 保留。
- 阴性夹具：authority payload 损坏时 attach 可用、legacy 域收敛、`deferredOps=1`、unsafe 记录留在 WAL。
- 生产同路径夹具（`daemon start --service --authority-manifest`、隔离状态、registry pointer、真实 inner git）：canonical repo 达 `attached`，两条旧域记录收敛，journal 干净 compact。

## 审查证据

- CEO 语义验收：重放与活路准入共用一个分类器（不存在第二套发散规则）；逐域 flush 且域间重读 durable 状态；defer 按域且不阻 attach；mix 防线未动——diff 与报告中逐项确认。

## 残余风险

- 真实生产 daemon 重启与第六轮 re-enable 归 operator。
- defer 的 unsafe 记录留在 WAL 直到恢复路径处理；但不再阻塞 attach 或其他域。
- 今后每个动写路的包都应携带「老状态 + 新代码」升级回归——自本缺陷起定为标准。

## 关联材料

- PR #889（D15/D16 + 启动性能）；PR #865/#872/#876/#878/#881/#883（D0–D14）。
- worker 报告：`tmp/orch/w6-d15-perf/REPORT.md`（D17 节；本机编排产物）。
