### PR TITLE
fix: replay journal writes by integrity domain (W6 D17 upgrade path)

### DIFF
--- a/packages/cli/test/production-authority-journal-upgrade.test.ts
+++ b/packages/cli/test/production-authority-journal-upgrade.test.ts
@@ -1,0 +1,112 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import {
+  makeJournaledWriteCoordinator,
+  makeOperationalJournaledWriteCoordinator,
+  moduleEntityId,
+  taskEntityId
+} from "../../kernel/src/index.ts";
+import {
+  defaultDaemonUserRoot,
+  pollUntil,
+  runDaemonCommand,
+  stopDaemon
+} from "./helpers/daemon-cli.ts";
+import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
+
+test("production service upgrades a pre-domain mixed journal before canonical attach", { timeout: 60_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const env = {
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"
+  };
+  try {
+    seedPreDomainJournal(fixture.repoRoot);
+    const registered = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical", "--canonical-root", fixture.repoRoot,
+      "--user-root", userRoot, "--no-link", "--json"
+    ], env);
+    assert.equal(registered.ok, true, JSON.stringify(registered));
+    try {
+      runDaemonCommand(fixture.repoRoot, [
+        "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+      ], env);
+    } catch {
+      // Observe the detached service when startup outlives the CLI reachability wait.
+    }
+    const status = await pollUntil(
+      () => runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env),
+      (candidate) => candidate.reachable === true
+        && Array.isArray(candidate.repos)
+        && candidate.repos.some((repo) => repo.repoId === "canonical" && repo.state === "attached"),
+      (candidate, error) => JSON.stringify({ candidate, error: String(error ?? "") }),
+      { timeoutMs: 20_000 }
+    );
+    assert.equal(status.reachable, true, JSON.stringify(status));
+    assert.equal(readFileSync(path.join(fixture.authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/upgrade.md"), "utf8"), "authority upgraded\n");
+    assert.match(readFileSync(path.join(fixture.repoRoot, ".harness/generated/runtime-events/upgrade.jsonl"), "utf8"), /evt-upgrade/u);
+    assert.equal(readFileSync(path.join(fixture.repoRoot, ".harness/write-journal/writes.jsonl"), "utf8"), "");
+  } finally {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+function seedPreDomainJournal(rootDir: string): void {
+  const legacy = makeOperationalJournaledWriteCoordinator({
+    rootDir,
+    operationalActor: { scope: "operational", kind: "system", id: "legacy-runtime" },
+    autoMaterialize: false
+  });
+  const authority = makeJournaledWriteCoordinator({
+    rootDir,
+    attribution: {
+      actor: { principal: { kind: "person", personId: "person_alice" }, executor: { kind: "agent", id: "codex" } },
+      principalSource: { kind: "daemon-authenticated", providerId: "fixture-provider", credentialFingerprint: "fixture-credential" },
+      executorSource: "client-asserted"
+    },
+    autoMaterialize: false
+  });
+  Effect.runSync(legacy.enqueue({
+    opId: "runtime-event-upgrade",
+    entityId: moduleEntityId("runtime-event-ledger"),
+    kind: "machine_artifact_append_jsonl",
+    payload: {
+      boundary: "runtime-event-ledger",
+      path: ".harness/generated/runtime-events/upgrade.jsonl",
+      value: { schema: "runtime-event/v1", eventId: "evt-upgrade" }
+    }
+  }));
+  Effect.runSync(authority.enqueue({
+    opId: "op-authority-upgrade",
+    entityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"),
+    kind: "doc_write",
+    payload: { path: "upgrade.md", body: "authority upgraded\n" },
+    authorityIntegrity: authorityIntegrity()
+  }));
+}
+
+function authorityIntegrity() {
+  return {
+    schema: "authority-operation-integrity/v2" as const,
+    semanticRequestDigest: "1".repeat(64),
+    semanticMutationSetDigest: "2".repeat(64),
+    mutationRegistryVersion: 1,
+    actorAxesBindingDigest: "3".repeat(64),
+    canonicalMutationSet: {
+      registryVersion: 1,
+      mutations: [{
+        entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4" },
+        action: { registryVersion: 1, action: "append" }
+      }]
+    }
+  } as const;
+}

--- a/packages/cli/test/production-authority-journal-upgrade.test.ts
+++ b/packages/cli/test/production-authority-journal-upgrade.test.ts
@@ -16,7 +16,7 @@ import {
   runDaemonCommand,
   stopDaemon
 } from "./helpers/daemon-cli.ts";
-import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
+import { createFixture, git } from "./production-authority-canonical-ingress/fixture.ts";
 
 test("production service upgrades a pre-domain mixed journal before canonical attach", { timeout: 60_000 }, async () => {
   const fixture = createFixture();
@@ -29,6 +29,8 @@ test("production service upgrades a pre-domain mixed journal before canonical at
     HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"
   };
   try {
+    git(fixture.authoredRoot, "config", "user.name", "Harness Upgrade Test");
+    git(fixture.authoredRoot, "config", "user.email", "harness-upgrade@example.test");
     seedPreDomainJournal(fixture.repoRoot);
     const registered = runDaemonCommand(fixture.repoRoot, [
       "daemon", "repo", "register", "--repo-id", "canonical", "--canonical-root", fixture.repoRoot,
@@ -53,6 +55,7 @@ test("production service upgrades a pre-domain mixed journal before canonical at
     assert.equal(status.reachable, true, JSON.stringify(status));
     assert.equal(readFileSync(path.join(fixture.authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/upgrade.md"), "utf8"), "authority upgraded\n");
     assert.match(readFileSync(path.join(fixture.repoRoot, ".harness/generated/runtime-events/upgrade.jsonl"), "utf8"), /evt-upgrade/u);
+    assert.match(git(fixture.authoredRoot, "log", "-2", "--format=%B"), /Harness-Authority-Batch:/u);
     assert.equal(readFileSync(path.join(fixture.repoRoot, ".harness/write-journal/writes.jsonl"), "utf8"), "");
   } finally {
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);

--- a/packages/kernel/src/ports/write-coordinator.ts
+++ b/packages/kernel/src/ports/write-coordinator.ts
@@ -112,6 +112,7 @@ export interface FlushReport {
 export interface RecoveryReport {
   readonly replayedOps: number;
   readonly recoveredWatermark?: string;
+  readonly deferredOps?: number;
 }
 
 export interface WriteCoordinator {

--- a/packages/kernel/src/store/daemon-runtime-queue.ts
+++ b/packages/kernel/src/store/daemon-runtime-queue.ts
@@ -5,6 +5,7 @@ import type { WriteError } from "../domain/index.ts";
 import type { FlushReport, WriteOp } from "../ports/write-coordinator.ts";
 import type { WriteAttribution } from "../schemas/actor-attribution.ts";
 import type { GitCommitAuthor, OperationalActor } from "./write-journal-types.ts";
+import { singleWriteIntegrityDomain, type WriteIntegrityDomain } from "./write-integrity-domain.ts";
 import type { makeJournaledWriteCoordinator } from "./write-journal-coordinator.ts";
 
 export type DaemonWritePriority = "interactive" | "normal" | "background" | "maintenance";
@@ -51,7 +52,7 @@ type InteractiveQueueItem = InteractiveWriteAttribution & {
   readonly ops: ReadonlyArray<WriteOp>;
   readonly commitAuthor?: GitCommitAuthor;
   readonly sessionId?: string;
-  readonly integrityDomain: "authority" | "legacy";
+  readonly integrityDomain: WriteIntegrityDomain;
   readonly enqueuedAt: number;
   started: boolean;
   timeout?: ReturnType<typeof setTimeout>;
@@ -106,7 +107,7 @@ export class DaemonWriteQueue {
     coordinatorFor: (batch: InteractiveCoordinatorBatch) => JournaledWriteCoordinator
   ): Promise<InteractiveWriteReceipt> {
     if (this.closed) return Promise.reject({ _tag: "JournalUnavailable", cause: new Error("daemon write queue is closed") } satisfies WriteError);
-    const integrityDomain = requestIntegrityDomain(request.ops);
+    const integrityDomain = singleWriteIntegrityDomain(request.ops);
     if (!integrityDomain) {
       return Promise.reject({
         _tag: "WriteRejected",
@@ -349,12 +350,6 @@ function sameAttribution(left: InteractiveQueueItem, right: InteractiveQueueItem
     && authorKey(left.commitAuthor) === authorKey(right.commitAuthor)
     && sessionKey(left.sessionId) === sessionKey(right.sessionId)
     && left.integrityDomain === right.integrityDomain;
-}
-
-function requestIntegrityDomain(ops: ReadonlyArray<WriteOp>): "authority" | "legacy" | undefined {
-  const authorityCount = ops.filter((op) => op.authorityIntegrity !== undefined).length;
-  if (authorityCount === 0) return "legacy";
-  return authorityCount === ops.length ? "authority" : undefined;
 }
 
 function attributionKey(input: InteractiveWriteAttribution): string {

--- a/packages/kernel/src/store/write-integrity-domain.ts
+++ b/packages/kernel/src/store/write-integrity-domain.ts
@@ -1,0 +1,33 @@
+export type WriteIntegrityDomain = "authority" | "legacy";
+
+type IntegrityDomainMember = { readonly authorityIntegrity?: unknown };
+
+export function writeIntegrityDomain(member: IntegrityDomainMember): WriteIntegrityDomain {
+  return member.authorityIntegrity === undefined ? "legacy" : "authority";
+}
+
+export function singleWriteIntegrityDomain(
+  members: ReadonlyArray<IntegrityDomainMember>
+): WriteIntegrityDomain | undefined {
+  const first = members[0];
+  if (!first) return undefined;
+  const domain = writeIntegrityDomain(first);
+  return members.every((member) => writeIntegrityDomain(member) === domain) ? domain : undefined;
+}
+
+export function writeIntegrityDomainsInOrder(
+  members: ReadonlyArray<IntegrityDomainMember>
+): ReadonlyArray<WriteIntegrityDomain> {
+  const domains = new Set<WriteIntegrityDomain>();
+  for (const member of members) {
+    domains.add(writeIntegrityDomain(member));
+  }
+  return [...domains];
+}
+
+export function recordsForWriteIntegrityDomain<Member extends IntegrityDomainMember>(
+  members: ReadonlyArray<Member>,
+  domain: WriteIntegrityDomain | undefined
+): ReadonlyArray<Member> {
+  return domain ? members.filter((member) => writeIntegrityDomain(member) === domain) : members;
+}

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -49,6 +49,8 @@ import {
 } from "./write-journal-operations.ts";
 import { reconcileDurableFlush, shouldWaitForForeignCommitter } from "./write-journal-receipt.ts";
 import { semanticCommitMessage } from "./write-journal-authority-trailer.ts";
+import { recoverJournalIntegrityDomains } from "./write-journal-domain-recovery.ts";
+import { recordsForWriteIntegrityDomain, singleWriteIntegrityDomain } from "./write-integrity-domain.ts";
 import { memoizePublicationVcs } from "./write-journal-publication-vcs.ts";
 import type { ApplyMarkerRecord, DeleteAuditRecord, GitCommitAuthor, JournaledWriteCoordinatorOptions, JournalRecoveryOptions, LockConflictRetryOptions, LockTakeoverRecord, OperationalActor, OperationalJournaledWriteCoordinatorOptions, ReadableJournalRecord, WriteWatermark } from "./write-journal-types.ts";
 export type {
@@ -106,21 +108,37 @@ function makeJournaledWriteCoordinatorInternal(
   const flushOnce = (reason: FlushReason): Effect.Effect<FlushReport, WriteError> => Effect.try({
     try: () => withRepoLocks(rootDir, runtimeContext, journalPath, operationalActor, lockTtlMs, pending.map((op) => op.entityId), () => {
       const state = readDurableState(journalPath, watermarkPath, rootDir);
+      const requestedDomain = singleWriteIntegrityDomain(pending);
       pending.splice(0, pending.length);
-      const pendingRecords = uniquePendingRecords(state.records, state.applied);
+      const pendingRecords = recordsForWriteIntegrityDomain(
+        uniquePendingRecords(state.records, state.applied),
+        requestedDomain
+      );
       return flushRecords(reason, rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor, versionControlSystem, attributionEventStore);
     }, { heldGlobalLock }),
     catch: (cause): WriteError => toJournalError(cause)
   });
   const recoverOnce: Effect.Effect<RecoveryReport, WriteError> = Effect.try({
     try: (): RecoveryReport => withRepoLocks(rootDir, runtimeContext, journalPath, operationalActor, lockTtlMs, [], () => {
-      const state = readDurableState(journalPath, watermarkPath, rootDir);
-      const pendingRecords = uniquePendingRecords(state.records, state.applied);
-      const report = flushRecords("recovery", rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor, versionControlSystem, attributionEventStore);
-      return {
-        replayedOps: report.opCount,
-        recoveredWatermark: report.watermark
-      };
+      return recoverJournalIntegrityDomains({
+        rootDir,
+        journalPath,
+        watermarkPath,
+        flushDomain: (state, records) => flushRecords(
+          "recovery",
+          rootDir,
+          runtimeContext,
+          journalPath,
+          watermarkPath,
+          state.watermark,
+          records,
+          state.fileApplied,
+          sessionId,
+          commitAuthor,
+          versionControlSystem,
+          attributionEventStore
+        )
+      });
     }, { heldGlobalLock }),
     catch: (cause): WriteError => toJournalError(cause)
   });

--- a/packages/kernel/src/store/write-journal-domain-recovery.ts
+++ b/packages/kernel/src/store/write-journal-domain-recovery.ts
@@ -1,0 +1,41 @@
+import type { FlushReport, RecoveryReport } from "../ports/write-coordinator.ts";
+import { readDurableState } from "./write-journal-durable.ts";
+import { uniquePendingRecords } from "./write-journal-records.ts";
+import type { ReadableJournalRecord } from "./write-journal-types.ts";
+import { writeIntegrityDomain, writeIntegrityDomainsInOrder } from "./write-integrity-domain.ts";
+
+type DurableState = ReturnType<typeof readDurableState>;
+
+export function recoverJournalIntegrityDomains(input: {
+  readonly rootDir: string;
+  readonly journalPath: string;
+  readonly watermarkPath: string;
+  readonly flushDomain: (
+    state: DurableState,
+    records: ReadonlyArray<ReadableJournalRecord>
+  ) => FlushReport;
+}): RecoveryReport {
+  const initialState = readDurableState(input.journalPath, input.watermarkPath, input.rootDir);
+  const initialPending = uniquePendingRecords(initialState.records, initialState.applied);
+  let replayedOps = 0;
+  let deferredOps = 0;
+  let recoveredWatermark: string | undefined;
+  for (const domain of writeIntegrityDomainsInOrder(initialPending)) {
+    const state = readDurableState(input.journalPath, input.watermarkPath, input.rootDir);
+    const records = uniquePendingRecords(state.records, state.applied)
+      .filter((record) => writeIntegrityDomain(record) === domain);
+    if (records.length === 0) continue;
+    try {
+      const report = input.flushDomain(state, records);
+      replayedOps += report.opCount;
+      recoveredWatermark = report.watermark ?? recoveredWatermark;
+    } catch {
+      deferredOps += records.length;
+    }
+  }
+  return {
+    replayedOps,
+    ...(recoveredWatermark ? { recoveredWatermark } : {}),
+    ...(deferredOps > 0 ? { deferredOps } : {})
+  };
+}

--- a/packages/kernel/test/store/daemon-runtime-authority-domains.test.ts
+++ b/packages/kernel/test/store/daemon-runtime-authority-domains.test.ts
@@ -1,11 +1,12 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
 import { createDaemonRuntime } from "../../../adapters/local/src/index.ts";
 import { moduleEntityId } from "../../src/domain/index.ts";
+import { makeJournaledWriteCoordinator, makeOperationalJournaledWriteCoordinator } from "../../src/store/index.ts";
 import { docWrite, runEffect, withTempStoreAsync } from "./helpers.ts";
 import { daemonAttribution, git, initAuthoredGit } from "./helpers/daemon-runtime.ts";
 
@@ -58,6 +59,76 @@ test("daemon interactive queue keeps matching attribution in separate integrity 
     assert.equal(legacy.flush.opCount, 1);
     assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-domain-authority/note.md"), "utf8"), "authority domain\n");
     assert.match(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/matching-attribution.jsonl"), "utf8"), /evt-matching-attribution/u);
+    await runtime.stop();
+  });
+});
+
+test("daemon upgrade attach replays a pre-domain journal in separate integrity batches", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const legacy = makeOperationalJournaledWriteCoordinator({
+      rootDir,
+      operationalActor: { scope: "operational", kind: "system", id: "legacy-runtime" },
+      autoMaterialize: false
+    });
+    const authority = makeJournaledWriteCoordinator({
+      rootDir,
+      attribution: testAttribution,
+      sessionId: "upgrade-authority",
+      autoMaterialize: false
+    });
+    Effect.runSync(legacy.enqueue(runtimeEventOp(
+      "runtime-event-pre-domain",
+      "pre-domain.jsonl",
+      "evt-pre-domain"
+    )));
+    Effect.runSync(authority.enqueue({
+      ...docWrite("op-authority-pre-domain", "task-authority-pre-domain", "note.md", "authority upgrade\n"),
+      authorityIntegrity: authorityIntegrity("77", "88", "99", "task-authority-pre-domain")
+    }));
+
+    const runtime = createDaemonRuntime({ rootDir, materializerPollMs: false });
+    const status = await runtime.start();
+
+    assert.equal(status.started, true);
+    assert.equal(status.lastRecovery?.replayedOps, 2);
+    assert.match(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/pre-domain.jsonl"), "utf8"), /evt-pre-domain/u);
+    assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-authority-pre-domain/note.md"), "utf8"), "authority upgrade\n");
+    assert.match(git(rootDir, "log", "-2", "--format=%B"), /Harness-Authority-Batch:/u);
+    await runtime.stop();
+  });
+});
+
+test("daemon upgrade attach defers an unsafe domain without discarding a recoverable legacy domain", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const legacy = makeOperationalJournaledWriteCoordinator({
+      rootDir,
+      operationalActor: { scope: "operational", kind: "system", id: "legacy-runtime" },
+      autoMaterialize: false
+    });
+    const authority = makeJournaledWriteCoordinator({ rootDir, attribution: testAttribution, autoMaterialize: false });
+    Effect.runSync(legacy.enqueue(runtimeEventOp("runtime-event-safe-domain", "safe-domain.jsonl", "evt-safe-domain")));
+    Effect.runSync(authority.enqueue({
+      ...docWrite("op-unsafe-authority-domain", "task-unsafe-authority", "note.md", "must remain deferred\n"),
+      authorityIntegrity: authorityIntegrity("aa", "bb", "cc", "task-unsafe-authority")
+    }));
+    const journalPath = path.join(rootDir, ".harness/write-journal/writes.jsonl");
+    const oldLines = readFileSync(journalPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    const unsafe = oldLines.find((record) => record.opId === "op-unsafe-authority-domain");
+    unsafe.payload.payloadHash = "sha256:unsafe-upgrade-record";
+    writeFileSync(journalPath, `${oldLines.map((record) => JSON.stringify(record)).join("\n")}\n`, "utf8");
+
+    const runtime = createDaemonRuntime({ rootDir, materializerPollMs: false });
+    const status = await runtime.start();
+
+    assert.equal(status.started, true);
+    assert.equal(status.lastRecovery?.replayedOps, 1);
+    assert.equal(status.lastRecovery?.deferredOps, 1);
+    assert.match(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/safe-domain.jsonl"), "utf8"), /evt-safe-domain/u);
+    const retained = readFileSync(journalPath, "utf8");
+    assert.doesNotMatch(retained, /runtime-event-safe-domain/u);
+    assert.match(retained, /op-unsafe-authority-domain/u);
     await runtime.stop();
   });
 });

--- a/packages/kernel/test/store/daemon-runtime-authority-domains.test.ts
+++ b/packages/kernel/test/store/daemon-runtime-authority-domains.test.ts
@@ -129,6 +129,14 @@ test("daemon upgrade attach defers an unsafe domain without discarding a recover
     const retained = readFileSync(journalPath, "utf8");
     assert.doesNotMatch(retained, /runtime-event-safe-domain/u);
     assert.match(retained, /op-unsafe-authority-domain/u);
+    const liveLegacy = await runtime.enqueueInteractiveWrite({
+      commandId: "legacy-after-deferred-authority",
+      operationalActor: { scope: "operational", kind: "system", id: "daemon-runtime" },
+      ops: [runtimeEventOp("runtime-event-after-deferred", "after-deferred.jsonl", "evt-after-deferred")]
+    });
+    assert.equal(liveLegacy.flush.opCount, 1);
+    assert.match(readFileSync(path.join(rootDir, ".harness/generated/runtime-events/after-deferred.jsonl"), "utf8"), /evt-after-deferred/u);
+    assert.match(readFileSync(journalPath, "utf8"), /op-unsafe-authority-domain/u);
     await runtime.stop();
   });
 });


### PR DESCRIPTION
# English

## Summary

W6 defect D17, found deploying PR #889: attach-time journal recovery still flushed every pending record in one batch, so a journal persisted before the flush-domain separation (the real production state — legacy runtime-event records interleaved with three deferred authority records from the D16 outage) tripped the retained mix defense during replay, leaving the canonical repo unavailable and the daemon unable to start at all ("daemon service host has no repo bindings"). The live path was fixed by #889; this fixes the upgrade/replay path.

## What Changed

- Live queue admission and journal replay now share one integrity-domain classifier (presence of `authorityIntegrity`); recovery discovers domains in durable journal order and flushes each domain separately.
- After each domain, recovery rereads the durable journal, apply markers, and watermark so compaction/watermark advancement from one domain cannot be clobbered by a stale snapshot for the next.
- Normal flushes select pending records from the request's own domain, so a deferred old-domain record cannot contaminate later traffic.
- Failure isolation: an unsafe record defers its whole domain (kept in WAL for the recovery path) while the other domain converges and the daemon stays attached — replay never takes the whole attach down again.

## Task And Scope

- W6 cutover line task_01KXMN5BRWQH93976XBZSHSCN4; deploy-blocking regression discovered by the operator during the #889 production deploy; stacked directly on merged #889.
- Production state untouched; deploy + daemon restart + sixth re-enable remain operator actions after merge.

## Version Impact

- No published package version change.

## Governance Declaration

- Authority anchor: task_01KXMN5BRWQH93976XBZSHSCN4; standing W6 fix-then-cut authorization.
- Protected paths touched: none (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `tools/test-tier-manifest.mjs`, `harness/**` untouched).
- No gate weakening: the trailer mix defense stays exactly as-is; replay is re-bucketed around it, and unsafe records fail closed into the WAL instead of failing open.

## Verification

- Root `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 (32 local manifest gates green).
- Upgrade-path regression: a pre-domain mixed journal + new code reproduces the attach failure before the fix; after, the kernel fixture starts, replays both domains (two ops), and retains the authority batch trailer.
- Negative fixture: a corrupted authority payload leaves attach available, converges the legacy domain, reports `deferredOps=1`, and keeps the unsafe record in WAL.
- Production-same-path fixture (`daemon start --service --authority-manifest`, isolated state, real inner git): canonical repo reaches `attached`, both old-domain records converge, journal compacts cleanly.

## Review Evidence

- CEO semantic acceptance: shared classifier between live and replay paths, per-domain flush with inter-domain journal reread, domain-granularity failure isolation with fail-closed WAL retention — confirmed in diff; this closes the "old state + new code" fixture blind spot that let D17 through.

## Residual Risk

- Failure isolation granularity is the whole integrity domain: one unsafe record defers its domain's remaining records to the next recovery pass (deliberate, avoids in-domain reordering).
- Real production upgrade restart remains operator-owned; the sixth re-enable and interleaved-write smoke matrix remain the gate.

## References

- PR #889 (D15/D16/startup performance); PRs #865–#883 (D0–D14 chain).
- Worker report addendum: `tmp/orch/w6-d15-perf/REPORT.md` § D17.

---

# 中文

## 概要

W6 缺陷 D17，部署 PR #889 时发现：attach 阶段的 journal 恢复仍把全部待重放记录合成一批 flush，因此在域分离落地之前持久化的 journal（真实生产状态——legacy runtime-event 记录与 D16 outage 留下的 3 笔延期 authority 记录交错）在重放时撞上保留的 mix 防线，canonical repo unavailable，daemon 完全起不来（"daemon service host has no repo bindings"）。#889 修了活路，本 PR 修升级/重放路。

## 改动内容

- 活路准入与 journal 重放共用同一个完整性域分类器（按 `authorityIntegrity` 有无）；恢复按 durable journal 顺序发现域，逐域分别 flush。
- 每个域完成后重读 durable journal、apply 标记与水位，防止前一域的 compaction/水位推进被后一域的陈旧快照覆盖。
- 常规 flush 只取本请求所属域的待处理记录，延期的旧域记录不会污染后续流量。
- 失败隔离：不安全记录使其整个域延期（留在 WAL 交恢复路径），另一域正常收敛、daemon 保持 attached——重放不再把整个 attach 打挂。

## 任务与范围

- W6 cutover 线 task_01KXMN5BRWQH93976XBZSHSCN4；operator 在 #889 生产部署中发现的部署阻断回归；直接押栈于已合并的 #889。
- 生产状态未触碰；部署 + daemon 重启 + 第六轮 re-enable 为合并后 operator 动作。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 授权锚：task_01KXMN5BRWQH93976XBZSHSCN4；W6 修完即 cut 常设授权。
- 触碰的 protected 路径：无（`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`tools/test-tier-manifest.mjs`、`harness/**` 均未动）。
- 无削 gate：trailer mix 防线原样保留；重放在其外围按域重组，不安全记录 fail-closed 留在 WAL 而非放行。

## 验证

- 根 `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0（32 个本地 manifest gates 全绿）。
- 升级路径回归：「域分离前的混域 journal + 新代码」补丁前复现 attach 失败；补丁后 kernel 夹具启动、两域各自重放（两笔 op）、authority 批次 trailer 保留。
- 负夹具：损坏的 authority payload 下 attach 保持可用、legacy 域收敛、`deferredOps=1`、不安全记录留在 WAL。
- 生产同路径夹具（`daemon start --service --authority-manifest`、隔离状态、真实 inner git）：canonical repo 达到 attached、两笔旧域记录收敛、journal 干净压实。

## 审查证据

- CEO 语义验收：活路与重放路共用分类器、逐域 flush 且域间重读 journal、域粒度失败隔离且 fail-closed 留 WAL——diff 中确认；同时补上了放走 D17 的「旧状态 + 新代码」夹具盲区。

## 残余风险

- 失败隔离粒度为整个完整性域：一笔不安全记录使同域其余记录延期到下次恢复（有意为之，避免域内重排）。
- 真实生产升级重启归 operator；第六轮 re-enable 与并发交错写冒烟矩阵仍是门。

## 关联材料

- PR #889（D15/D16/启动性能）；PR #865–#883（D0–D14 链）。
- worker 报告增补：`tmp/orch/w6-d15-perf/REPORT.md` § D17。
