### PR TITLE
fix: bind task-create canonical entity and make authority publication atomic (W6 D15-residual/D18)

### DIFF
--- a/packages/cli/src/daemon/authority-command-submission.ts
+++ b/packages/cli/src/daemon/authority-command-submission.ts
@@ -17,6 +17,7 @@ import type {
   WriteError,
   WriteOp
 } from "../../../kernel/src/index.ts";
+import { taskEntityId } from "../../../kernel/src/index.ts";
 import type { ParsedCommand } from "../cli/types.ts";
 import type { CliActorAttribution } from "../composition/actor-attribution.ts";
 
@@ -116,7 +117,10 @@ export function makeDaemonAuthorityWriteCoordinator(
     flush: (reason) => Effect.tryPromise({
       try: async (): Promise<FlushReport> => {
         if (!accepted) return { reason, opCount: 0, committed: false };
-        settled ??= submission.submit({ ...input, canonicalEntityId: accepted });
+        settled ??= submission.submit({
+          ...input,
+          canonicalEntityId: commandMainEntityId(input.command) ?? accepted
+        });
         const receipt = await settled;
         return receiptToFlushReport(receipt, reason);
       },
@@ -124,6 +128,13 @@ export function makeDaemonAuthorityWriteCoordinator(
     }),
     recover: Effect.succeed({ replayedOps: 0 } satisfies RecoveryReport)
   };
+}
+
+function commandMainEntityId(command: ParsedCommand): WriteOp["entityId"] | undefined {
+  const action = command.action;
+  return action.kind === "new-task" && action.taskId
+    ? taskEntityId(action.taskId)
+    : undefined;
 }
 
 export class AuthorityProtocolDamagedError extends Error {

--- a/packages/cli/src/daemon/authority-lifecycle.ts
+++ b/packages/cli/src/daemon/authority-lifecycle.ts
@@ -17,6 +17,7 @@ import {
   resolveHarnessLayout,
   stableStringify,
   type DaemonAdmissionBudget,
+  type FlushReport,
   type WriteAttribution,
   type WriteCoordinator
 } from "../../../kernel/src/index.ts";
@@ -113,6 +114,13 @@ export interface AuthorityLifecycleRuntime {
       readonly status: "merged" | "would_merge" | "skipped" | "conflict";
       readonly warning?: string;
     }>;
+  }>;
+  readonly enqueueAuthorityPublication: (options: {
+    readonly sessionId: string;
+    readonly publish: () => Promise<FlushReport>;
+  }) => Promise<{
+    readonly flush: FlushReport;
+    readonly materialization?: Awaited<ReturnType<AuthorityLifecycleRuntime["enqueueMaterializerBatch"]>>;
   }>;
   readonly admissionBudget: DaemonAdmissionBudget;
 }
@@ -298,11 +306,15 @@ export function makeHeldLockAttributedCoordinatorFactory(
       const shared: WriteCoordinator = {
         enqueue: coordinator.enqueue,
         flush: (reason) => Effect.ensuring(
-          coordinator.flush(reason).pipe(Effect.flatMap((report) => Effect.tryPromise({
+          Effect.tryPromise({
             try: async () => {
+              const publication = await runtime.enqueueAuthorityPublication({
+                sessionId,
+                publish: () => Effect.runPromise(coordinator.flush(reason))
+              });
+              const { flush: report, materialization: materialized } = publication;
               if (!report.committed || report.opCount === 0) return report;
-              const materialized = await runtime.enqueueMaterializerBatch({ sessionId });
-              const branch = materialized.branches.find((entry) => entry.branch === `sessions/${sessionId}`);
+              const branch = materialized?.branches.find((entry) => entry.branch === `sessions/${sessionId}`);
               if (!branch || branch.commitCount === 0 || branch.status !== "merged") {
                 throw new Error(
                   `AUTHORITY_SESSION_MATERIALIZATION_FAILED:sessionId=${sessionId};status=${branch?.status ?? "missing"};commitCount=${branch?.commitCount ?? 0};warning=${branch?.warning ?? "none"}`
@@ -311,7 +323,7 @@ export function makeHeldLockAttributedCoordinatorFactory(
               return report;
             },
             catch: (cause) => ({ _tag: "JournalUnavailable" as const, cause: diagnosticCause(cause) })
-          }))),
+          }),
           Effect.sync(() => {
             if (active.get(key) === shared) active.delete(key);
           })

--- a/packages/cli/test/authority-amendment3-seam.test.ts
+++ b/packages/cli/test/authority-amendment3-seam.test.ts
@@ -1,0 +1,159 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Effect } from "effect";
+import { taskEntityId } from "../../kernel/src/index.ts";
+import { daemonActorAttribution } from "../src/composition/actor-attribution.ts";
+import { makeDaemonAuthorityWriteCoordinator } from "../src/daemon/authority-command-submission.ts";
+import {
+  makeHeldLockAttributedCoordinatorFactory,
+  type AuthorityLifecycleRuntime
+} from "../src/daemon/authority-lifecycle.ts";
+
+test("task create binds authority submission to command intent when a session provenance op arrives first", async () => {
+  const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG9";
+  let submittedEntityId: string | undefined;
+  const coordinator = makeDaemonAuthorityWriteCoordinator({
+    submit: async (input) => {
+      submittedEntityId = input.canonicalEntityId;
+      return {
+        tag: "REJECTED",
+        workspaceId: "workspace-command-service",
+        opId: "fixture-op",
+        semanticDigest: "11".repeat(32),
+        reason: "fixture terminal receipt"
+      };
+    }
+  }, {
+    command: {
+      rootDir: "/fixture",
+      json: true,
+      action: {
+        kind: "new-task",
+        taskId,
+        title: "Intent-bound task",
+        titleProvided: true,
+        slug: "intent-bound-task",
+        slugProvided: false,
+        allowManualId: false,
+        longRunning: false,
+        dryRun: false
+      }
+    },
+    attribution: daemonActorAttribution({
+      personId: "person_alice",
+      displayName: "Alice",
+      primaryEmail: "alice@example.test",
+      roles: ["owner"],
+      providerId: "test",
+      resolvedCredential: { kind: "unix-socket-owner-boundary", issuer: "test", subject: "person_alice" }
+    }, { kind: "agent", id: "codex" }),
+    currentSession: {
+      runtime: "codex",
+      sessionId: "session-provenance-first",
+      source: "runtime",
+      detectedAt: "2026-07-18T00:00:00.000Z"
+    }
+  });
+
+  await runEffect(coordinator.enqueue({
+    opId: "session-provenance-op",
+    entityId: "entity/session/session-provenance-first",
+    kind: "machine_artifact_write",
+    payload: {}
+  }));
+  await assert.rejects(runEffect(coordinator.flush("explicit")), /fixture terminal receipt/u);
+  assert.equal(submittedEntityId, taskEntityId(taskId));
+});
+
+test("held-lock authority flush uses one atomic publication instead of direct materialization", async () => {
+  let pending = 0;
+  let atomicPublications = 0;
+  let directMaterializations = 0;
+  const runtime: AuthorityLifecycleRuntime = {
+    createAttributedCoordinator: () => ({
+      enqueue: (op) => Effect.sync(() => {
+        pending += 1;
+        return { opId: op.opId, entityId: op.entityId, accepted: true as const };
+      }),
+      flush: (reason) => Effect.sync(() => ({ reason, opCount: pending, committed: true })),
+      recover: Effect.succeed({ replayedOps: 0 })
+    }),
+    enqueueMaterializerBatch: async ({ sessionId }) => {
+      directMaterializations += 1;
+      return { branches: [{ branch: `sessions/${sessionId}`, commitCount: 1, status: "merged" as const }] };
+    },
+    enqueueAuthorityPublication: async ({ sessionId, publish }) => {
+      atomicPublications += 1;
+      const flush = await publish();
+      return {
+        flush,
+        materialization: {
+          branches: [{ branch: `sessions/${sessionId}`, commitCount: 1, status: "merged" as const }]
+        }
+      };
+    },
+    assertWriteFenceHeld: async () => undefined
+  };
+  const coordinator = makeHeldLockAttributedCoordinatorFactory(runtime).create({
+    attribution: {
+      actor: { principal: { kind: "person", personId: "person_test" }, executor: { kind: "agent", id: "codex" } },
+      principalSource: { kind: "daemon-authenticated", providerId: "test", credentialFingerprint: "sha256:test" },
+      executorSource: "client-asserted"
+    },
+    sessionId: "session-test"
+  });
+  await runEffect(coordinator.enqueue({
+    opId: "authority-atomic-op",
+    entityId: "task/task-test",
+    kind: "progress_append"
+  }));
+
+  const flush = await runEffect(coordinator.flush("explicit"));
+
+  assert.equal(flush.opCount, 1);
+  assert.equal(atomicPublications, 1);
+  assert.equal(directMaterializations, 0);
+});
+
+test("held-lock authority publication preserves materializer error name and message", async () => {
+  const runtime: AuthorityLifecycleRuntime = {
+    createAttributedCoordinator: () => ({
+      enqueue: (op) => Effect.succeed({ opId: op.opId, entityId: op.entityId, accepted: true as const }),
+      flush: (reason) => Effect.succeed({ reason, opCount: 1, committed: true }),
+      recover: Effect.succeed({ replayedOps: 0 })
+    }),
+    enqueueMaterializerBatch: async () => { throw new Error("materializer unavailable"); },
+    enqueueAuthorityPublication: async ({ publish }) => {
+      await publish();
+      throw new Error("materializer unavailable");
+    },
+    assertWriteFenceHeld: async () => undefined
+  };
+  const coordinator = makeHeldLockAttributedCoordinatorFactory(runtime).create({
+    attribution: {
+      actor: { principal: { kind: "person", personId: "person_test" }, executor: null },
+      principalSource: { kind: "daemon-authenticated", providerId: "test", credentialFingerprint: "sha256:test" },
+      executorSource: "none"
+    },
+    sessionId: "session-test"
+  });
+
+  const result = await runEffect(Effect.either(coordinator.flush("explicit")));
+
+  assert.equal(result._tag, "Left");
+  if (result._tag === "Left") {
+    assert.deepEqual(result.left, {
+      _tag: "JournalUnavailable",
+      cause: { name: "Error", message: "materializer unavailable" }
+    });
+  }
+});
+
+function runEffect<A, E>(effect: Effect.Effect<A, E>): Promise<A> {
+  return new Promise((resolve, reject) => {
+    Effect.runCallback(effect, {
+      onExit: (exit) => exit._tag === "Success" ? resolve(exit.value) : reject(new Error(String(exit.cause)))
+    });
+  });
+}

--- a/packages/cli/test/authority-lifecycle-seam.test.ts
+++ b/packages/cli/test/authority-lifecycle-seam.test.ts
@@ -258,6 +258,7 @@ test("held-lock attributed factory gives one exact coordinator to a same-attribu
     enqueueMaterializerBatch: async ({ sessionId }) => ({
       branches: [{ branch: `sessions/${sessionId}`, commitCount: 1, status: "merged" as const }]
     }),
+    enqueueAuthorityPublication: successfulAuthorityPublication,
     assertWriteFenceHeld: async () => undefined
   };
   const factory = makeHeldLockAttributedCoordinatorFactory(runtime);
@@ -275,44 +276,6 @@ test("held-lock attributed factory gives one exact coordinator to a same-attribu
     email: "authority@harness-anything.local"
   });
 });
-
-test("held-lock attributed factory preserves materializer error name and message", async () => {
-  const runtime: AuthorityLifecycleRuntime = {
-    createAttributedCoordinator: () => ({
-      enqueue: (op) => Effect.succeed({ opId: op.opId, entityId: op.entityId, accepted: true as const }),
-      flush: (reason) => Effect.succeed({ reason, opCount: 1, committed: true }),
-      recover: Effect.succeed({ replayedOps: 0 })
-    }),
-    enqueueMaterializerBatch: async () => { throw new Error("materializer unavailable"); },
-    assertWriteFenceHeld: async () => undefined
-  };
-  const coordinator = makeHeldLockAttributedCoordinatorFactory(runtime).create({
-    attribution: {
-      actor: { principal: { kind: "person", personId: "person_test" }, executor: null },
-      principalSource: { kind: "daemon-authenticated", providerId: "test", credentialFingerprint: "sha256:test" },
-      executorSource: "none"
-    },
-    sessionId: "session-test"
-  });
-
-  const result = await runEffect(Effect.either(coordinator.flush("explicit")));
-
-  assert.equal(result._tag, "Left");
-  if (result._tag === "Left") {
-    assert.deepEqual(result.left, {
-      _tag: "JournalUnavailable",
-      cause: { name: "Error", message: "materializer unavailable" }
-    });
-  }
-});
-
-function runEffect<A, E>(effect: Effect.Effect<A, E>): Promise<A> {
-  return new Promise((resolve, reject) => {
-    Effect.runCallback(effect, {
-      onExit: (exit) => exit._tag === "Success" ? resolve(exit.value) : reject(new Error(String(exit.cause)))
-    });
-  });
-}
 
 test("publication-tree-mismatch uses real Git trees and rejects paths outside the canonical mutation target", async () => {
   await withRoots(async ({ alphaRoot }) => {
@@ -574,7 +537,21 @@ function runtimeFixture(): AuthorityLifecycleRuntime {
     enqueueMaterializerBatch: async ({ sessionId }) => ({
       branches: [{ branch: `sessions/${sessionId}`, commitCount: 1, status: "merged" as const }]
     }),
+    enqueueAuthorityPublication: successfulAuthorityPublication,
     assertWriteFenceHeld: async () => undefined
+  };
+}
+
+async function successfulAuthorityPublication(input: {
+  readonly sessionId: string;
+  readonly publish: () => Promise<import("../../kernel/src/index.ts").FlushReport>;
+}) {
+  const flush = await input.publish();
+  return {
+    flush,
+    materialization: {
+      branches: [{ branch: `sessions/${input.sessionId}`, commitCount: 1, status: "merged" as const }]
+    }
   };
 }
 

--- a/packages/cli/test/helpers/production-authority-lifecycle-fixture.ts
+++ b/packages/cli/test/helpers/production-authority-lifecycle-fixture.ts
@@ -133,11 +133,19 @@ export function productionTuple() {
 
 export function productionWriterRuntime(authoredRoot: string) {
   const repoRoot = path.dirname(authoredRoot);
+  const materialize = ({ sessionId }: { readonly sessionId: string }) =>
+    defaultCliAdapterProvider().runLedgerMaterializer(repoRoot, { sessionId });
   return {
     createAttributedCoordinator: (input: Omit<Parameters<typeof makeJournaledWriteCoordinator>[0], "rootDir">) =>
       makeJournaledWriteCoordinator({ ...input, rootDir: repoRoot, autoMaterialize: false }),
-    enqueueMaterializerBatch: async ({ sessionId }: { readonly sessionId: string }) =>
-      defaultCliAdapterProvider().runLedgerMaterializer(repoRoot, { sessionId }),
+    enqueueMaterializerBatch: materialize,
+    enqueueAuthorityPublication: async (input: {
+      readonly sessionId: string;
+      readonly publish: () => Promise<import("../../../kernel/src/index.ts").FlushReport>;
+    }) => {
+      const flush = await input.publish();
+      return { flush, ...(flush.committed && flush.opCount > 0 ? { materialization: materialize(input) } : {}) };
+    },
     assertWriteFenceHeld: async () => undefined
   };
 }

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -152,10 +152,11 @@ test("production service route preserves progress dry-run and publishes canonica
     assert.equal(presetOperation.receipt?.tag, "COMMITTED", JSON.stringify(presetOperation));
     assert.equal(authorityEventBodies(fixture.authoredRoot).filter((body) => body.includes(presetOperation.opId!)).length, 1);
 
-    const interleaved = await Promise.all(Array.from({ length: 4 }, (_, index) => runRawJsonAsync(fixture.repoRoot, [
+    const concurrentSessionId = "service-interleaved-shared-session";
+    const interleaved = await Promise.all(Array.from({ length: 6 }, (_, index) => runRawJsonAsync(fixture.repoRoot, [
       "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4",
       "--text", `interleaved authority and runtime event ${index}`
-    ], { ...env, CODEX_THREAD_ID: `service-interleaved-${index}` })));
+    ], { ...env, CODEX_THREAD_ID: concurrentSessionId })));
     assert.equal(interleaved.every((receipt) => receipt.ok === true), true, JSON.stringify(interleaved));
     const settledOperations = authorityOperationRecords(fixture.serviceRoot);
     assert.equal(settledOperations.every((record) => record.state === "COMMITTED"), true, JSON.stringify(settledOperations));

--- a/packages/cli/test/production-authority-canonical-ingress/fixture.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/fixture.ts
@@ -127,6 +127,21 @@ export function git(rootDir: string, ...args: ReadonlyArray<string>): string {
   }).trim();
 }
 
+export function prepareLongHistoryFixture(authoredRoot: string): void {
+  git(authoredRoot, "config", "--local", "gc.auto", "0");
+  git(authoredRoot, "config", "--local", "maintenance.auto", "false");
+}
+
+export function sealLongHistoryFixture(authoredRoot: string): string {
+  git(authoredRoot, "repack", "-a", "-d");
+  git(authoredRoot, "fsck", "--full", "--strict");
+  const head = git(authoredRoot, "rev-parse", "HEAD");
+  const commits = git(authoredRoot, "rev-list", "--first-parent", head).split("\n").filter(Boolean);
+  assert.ok(commits.length > 0, "sealed fixture history must contain a readable first-parent chain");
+  assert.equal(commits[0], head, "sealed fixture history must start at the observed HEAD");
+  return head;
+}
+
 function operationPath(serviceRoot: string): string {
   return path.join(serviceRoot, "authority", Buffer.from("canonical", "utf8").toString("base64url"), "operations.jsonl");
 }

--- a/packages/cli/test/production-authority-startup-performance.test.ts
+++ b/packages/cli/test/production-authority-startup-performance.test.ts
@@ -15,7 +15,9 @@ import {
   authorityOperationRecords,
   createFixture,
   git,
-  indeterminateWithoutPublication
+  indeterminateWithoutPublication,
+  prepareLongHistoryFixture,
+  sealLongHistoryFixture
 } from "./production-authority-canonical-ingress/fixture.ts";
 
 test("production service exposes its socket while authority recovery scans history, then uses the persisted increment", { timeout: 120_000 }, async () => {
@@ -36,9 +38,11 @@ test("production service exposes its socket while authority recovery scans histo
     "recovery-watermark.json"
   );
   try {
+    prepareLongHistoryFixture(fixture.authoredRoot);
     for (let index = 0; index < 800; index += 1) {
       git(fixture.authoredRoot, "commit", "-q", "--allow-empty", "-m", `fixture history ${index}`);
     }
+    const coldHead = sealLongHistoryFixture(fixture.authoredRoot);
     const seededState = openDurableAuthorityServiceState({ serviceStateRoot: fixture.serviceRoot, repoId: "canonical" });
     await seededState.operationRegistry.put(indeterminateWithoutPublication());
     await seededState.close();
@@ -64,7 +68,7 @@ test("production service exposes its socket while authority recovery scans histo
 
     await pollUntil(
       () => existsSync(watermarkPath) ? JSON.parse(readFileSync(watermarkPath, "utf8")) as { readonly commitSha?: string } : undefined,
-      (watermark) => watermark?.commitSha === git(fixture.authoredRoot, "rev-parse", "HEAD"),
+      (watermark) => watermark?.commitSha === coldHead,
       (watermark, error) => JSON.stringify({ watermark, error: String(error ?? "") }),
       { timeoutMs: 30_000 }
     );
@@ -79,7 +83,7 @@ test("production service exposes its socket while authority recovery scans histo
     for (let index = 0; index < 5; index += 1) {
       git(fixture.authoredRoot, "commit", "-q", "--allow-empty", "-m", `fixture increment ${index}`);
     }
-    const incrementalHead = git(fixture.authoredRoot, "rev-parse", "HEAD");
+    const incrementalHead = sealLongHistoryFixture(fixture.authoredRoot);
     const incrementalStartedAt = Date.now();
     runDaemonCommand(fixture.repoRoot, [
       "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"

--- a/packages/kernel/src/store/daemon-runtime-authority-publication.ts
+++ b/packages/kernel/src/store/daemon-runtime-authority-publication.ts
@@ -1,0 +1,29 @@
+import type { FlushReport } from "../ports/write-coordinator.ts";
+import type { DaemonWriteQueue } from "./daemon-runtime-queue.ts";
+import type { LedgerMaterializerReport } from "./ledger-materializer.ts";
+
+export interface DaemonAuthorityPublicationOptions {
+  readonly sessionId: string;
+  readonly publish: () => Promise<FlushReport>;
+}
+
+export interface DaemonAuthorityPublicationReport {
+  readonly flush: FlushReport;
+  readonly materialization?: LedgerMaterializerReport;
+}
+
+export function enqueueDaemonAuthorityPublication(
+  queue: DaemonWriteQueue,
+  options: DaemonAuthorityPublicationOptions,
+  materialize: (sessionId: string) => LedgerMaterializerReport
+): Promise<DaemonAuthorityPublicationReport> {
+  return queue.enqueueBackground({
+    source: "authority-publication",
+    priority: "normal",
+    run: async () => {
+      const flush = await options.publish();
+      if (!flush.committed || flush.opCount === 0) return { flush };
+      return { flush, materialization: materialize(options.sessionId) };
+    }
+  });
+}

--- a/packages/kernel/src/store/daemon-runtime-options.ts
+++ b/packages/kernel/src/store/daemon-runtime-options.ts
@@ -1,0 +1,8 @@
+export interface DaemonMaterializerBatchOptions {
+  readonly dryRun?: boolean;
+  readonly sessionId?: string;
+}
+
+export interface DaemonDrainOptions {
+  readonly drainTimeoutMs?: number;
+}

--- a/packages/kernel/src/store/daemon-runtime.ts
+++ b/packages/kernel/src/store/daemon-runtime.ts
@@ -23,6 +23,13 @@ import {
 } from "./daemon-runtime-queue.ts";
 import { waitForDaemonQueueIdle } from "./daemon-drain.ts";
 import { makeDeferredAuthorityCoordinator } from "./daemon-runtime-authority-coordinator.ts";
+import {
+  enqueueDaemonAuthorityPublication,
+  type DaemonAuthorityPublicationOptions,
+  type DaemonAuthorityPublicationReport
+} from "./daemon-runtime-authority-publication.ts";
+import type { DaemonDrainOptions, DaemonMaterializerBatchOptions } from "./daemon-runtime-options.ts";
+export type { DaemonDrainOptions, DaemonMaterializerBatchOptions } from "./daemon-runtime-options.ts";
 import { acquireDaemonGlobalLock, assertDaemonGlobalLockHeld, type DaemonGlobalLock } from "./write-journal-locks.ts";
 import { makeJournaledWriteCoordinator, makeOperationalJournaledWriteCoordinator, recoverJournaledWrites } from "./write-journal-coordinator.ts";
 import type { OperationalActor } from "./write-journal-types.ts";
@@ -87,6 +94,7 @@ export interface HarnessDaemonRuntime {
   readonly enqueueInteractiveWrite: (request: InteractiveWriteRequest) => Promise<InteractiveWriteReceipt>;
   readonly enqueueBackgroundBatch: <Result>(request: BackgroundBatchRequest<Result>) => Promise<Result>;
   readonly enqueueMaterializerBatch: (options?: DaemonMaterializerBatchOptions) => Promise<LedgerMaterializerReport>;
+  readonly enqueueAuthorityPublication: (options: DaemonAuthorityPublicationOptions) => Promise<DaemonAuthorityPublicationReport>;
   readonly queryExecutionEvidencePage: (query: ExecutionEvidencePageQuery) => Promise<ExecutionEvidencePage>;
   /** Authority/application port backed by this runtime's current held global lock. */
   readonly createAttributedCoordinator: (input: {
@@ -98,13 +106,6 @@ export interface HarnessDaemonRuntime {
   readonly admissionBudget: DaemonAdmissionBudget;
 }
 
-export interface DaemonMaterializerBatchOptions {
-  readonly dryRun?: boolean;
-  readonly sessionId?: string;
-}
-export interface DaemonDrainOptions {
-  readonly drainTimeoutMs?: number;
-}
 export type DaemonRepoRuntimeState = "attached" | "unavailable" | "detaching" | "detached";
 
 export interface DaemonRepoRuntimeOptions extends DaemonRuntimeOptions {
@@ -155,6 +156,7 @@ export function createDaemonRuntime(options: DaemonRuntimeOptions): HarnessDaemo
     enqueueInteractiveWrite: (request) => context.enqueueInteractiveWrite(request),
     enqueueBackgroundBatch: (request) => context.enqueueBackgroundBatch(request),
     enqueueMaterializerBatch: (batchOptions) => context.enqueueMaterializerBatch(batchOptions),
+    enqueueAuthorityPublication: (publication) => context.enqueueAuthorityPublication(publication),
     queryExecutionEvidencePage: (query) => context.queryExecutionEvidencePage(query),
     createAttributedCoordinator: (input) => context.createAttributedCoordinator(input),
     assertWriteFenceHeld: () => context.assertWriteFenceHeld(),
@@ -395,28 +397,22 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
     return this.enqueueBackgroundBatch({
       source: "ledger-materializer",
       priority: "background",
-      run: () => {
-        const started = this.requireAttached();
-        const report = runLedgerMaterializer(this.runtimeContext, {
-          heldGlobalLock: started.lock,
-          ...(batchOptions.dryRun ? { dryRun: true } : {}),
-          ...(batchOptions.sessionId
-            ? { sessionId: batchOptions.sessionId }
-            : { maxBranches: this.materializerMaxBranchesPerBatch })
-        });
-        if (report.projectionRebuilt) {
-          this.projectionGeneration.invalidate();
-        }
-        if (report.warnings.length > 0) {
-          this.lastMaterializerError = report.warnings.join("; ");
-        } else if (!batchOptions.sessionId) {
-          this.lastMaterializerError = undefined;
-        }
-        return report;
-      }
+      run: () => this.runMaterializerBatch(batchOptions)
     }).catch((error: unknown) => {
       this.lastMaterializerError = describeError(error);
       this.projectionGeneration.invalidate();
+      throw error;
+    });
+  }
+
+  enqueueAuthorityPublication(options: DaemonAuthorityPublicationOptions): Promise<DaemonAuthorityPublicationReport> {
+    this.requireAttached();
+    return enqueueDaemonAuthorityPublication(
+      this.queue,
+      options,
+      (sessionId) => this.runMaterializerBatch({ sessionId })
+    ).catch((error: unknown) => {
+      this.lastError = describeError(error);
       throw error;
     });
   }
@@ -482,6 +478,24 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       void this.enqueueMaterializerBatch().catch(() => undefined);
     }, this.options.materializerPollMs);
     this.materializerTimer.unref();
+  }
+
+  private runMaterializerBatch(batchOptions: DaemonMaterializerBatchOptions): LedgerMaterializerReport {
+    const started = this.requireAttached();
+    const report = runLedgerMaterializer(this.runtimeContext, {
+      heldGlobalLock: started.lock,
+      ...(batchOptions.dryRun ? { dryRun: true } : {}),
+      ...(batchOptions.sessionId
+        ? { sessionId: batchOptions.sessionId }
+        : { maxBranches: this.materializerMaxBranchesPerBatch })
+    });
+    if (report.projectionRebuilt) this.projectionGeneration.invalidate();
+    if (report.warnings.length > 0) {
+      this.lastMaterializerError = report.warnings.join("; ");
+    } else if (!batchOptions.sessionId) {
+      this.lastMaterializerError = undefined;
+    }
+    return report;
   }
 
   private enqueueReservationReconciler(): Promise<void> {

--- a/packages/kernel/test/store/daemon-materializer-runtime.test.ts
+++ b/packages/kernel/test/store/daemon-materializer-runtime.test.ts
@@ -56,6 +56,41 @@ test("daemon materializer producer runs bounded batches under the lifetime globa
   });
 });
 
+test("authority publication materializes its session before a queued timer batch can observe it", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const runtime = createDaemonRuntime({ rootDir, materializerPollMs: false });
+    await runtime.start();
+    const coordinator = runtime.createAttributedCoordinator({
+      attribution: testAttribution,
+      sessionId: "authority-atomic-materialization"
+    });
+    let competingMaterializer: ReturnType<typeof runtime.enqueueMaterializerBatch> | undefined;
+
+    const publication = await runtime.enqueueAuthorityPublication({
+      sessionId: "authority-atomic-materialization",
+      publish: async () => {
+        Effect.runSync(coordinator.enqueue(docWrite(
+          "op-authority-atomic",
+          "task-authority-atomic",
+          "note.md",
+          "authority\n"
+        )));
+        const flush = Effect.runSync(coordinator.flush("explicit"));
+        competingMaterializer = runtime.enqueueMaterializerBatch();
+        return flush;
+      }
+    });
+    const competing = await competingMaterializer!;
+
+    assert.equal(publication.materialization?.branches[0]?.status, "merged");
+    assert.equal(publication.materialization?.branches[0]?.commitCount, 1);
+    assert.equal(competing.merged, 0);
+    assert.equal(readGitFile(rootDir, "tasks/task-authority-atomic/note.md"), "authority\n");
+    await runtime.stop();
+  });
+});
+
 test("daemon status exposes materializer merge conflicts", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initAuthoredGit(rootDir);


### PR DESCRIPTION
# English

## Summary

Two residual W6 defects found by the sixth re-enable's interleaved smoke matrix: D15-residual — the CLI-side write coordinator bound `canonicalEntityId` from whichever WriteOp enqueued first, so a task create (whose provenance exporter emits a session write first) submitted the session entity while the typed intent correctly claimed the task entity, failing every create on the real CLI road even after #889; and D18 — the daemon's periodic materializer could merge and delete a session branch between an authority flush and that publication's targeted materialization check, terminalizing an otherwise published operation as INDETERMINATE under same-session concurrency.

## What Changed

- **D15-residual**: for `new-task`, the coordinator binds `canonicalEntityId` from the daemon-observed parsed command's generated task id instead of first-enqueue order; all other command kinds keep their existing WriteOp-derived binding. The compiler still derives the typed intent independently and the entity-mismatch check is retained unchanged.
- **D18**: authority publication is now one atomic daemon-queue operation — the held-lock authority flush and the targeted session materialization run inside a single normal-priority queue item; periodic/background materializer batches can queue concurrently but can never interleave between those two steps. Targeted materialization still requires the expected branch, nonzero commit count, and `merged`; missing/conflict/error stays fail-closed.

## Task And Scope

- W6 cutover line task_01KXMN5BRWQH93976XBZSHSCN4; defects surfaced by the sixth re-enable smoke (admission open, no freeze required — failures were clean-rejecting or self-healing); stacked on merged #894.
- Production state untouched; deploy + daemon restart + final smoke remain operator actions.

## Version Impact

- No published package version change.

## Governance Declaration

- Authority anchor: task_01KXMN5BRWQH93976XBZSHSCN4; standing W6 fix-then-cut authorization.
- Protected paths touched: none (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `tools/test-tier-manifest.mjs`, `harness/**` untouched).
- No gate weakening: entity/commit/tree/mutation-set proofs unchanged; the entity-mismatch defense that exposed D15 remains active; materialization failure modes stay fail-closed.

## Verification

- Root `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 (32 manifest gates green).
- D15 red/green controls: restoring first-enqueue binding reproduces the session-vs-task mismatch; command-intent binding passes. Production-same-path regression drives real CLI argv through the daemon socket and `makeDaemonAuthorityWriteCoordinator`: bare and `--preset docs-task` creates land inner commits, reach COMMITTED, and emit one event each — closing the fixture blind spot that let the residual through.
- D18 red/green controls: the restored two-step lifecycle shows the race seam; the atomic path reports exactly one atomic publication. A deterministic real-git test queues a competing timer materializer from inside authority flush — the authority batch merges first, the competitor merges zero. Production service fixture: six concurrent real-CLI same-session writes interleaved with runtime events, all COMMITTED without retry, one event each.
- Focused suites: 41/41 pre-split, 20/20 post-split, fresh production-service pass.

## Review Evidence

- CEO semantic acceptance: binding change scoped to `new-task` only with the mismatch check retained as independent defense; atomicity implemented as a real-consumer queue operation rather than lock-widening; both defects carry red controls — confirmed in diff and report.

## Residual Risk

- Authority publication serialization is repo-wide at the daemon queue: a slow authority git publication delays later queued work for that repo (preserves the single-writer model; watch queue latency under unusually large batches).
- Production restart and live concurrency validation remain operator-owned; the final interleaved smoke after deploy is the gate.
- Known follow-up (next round): decision lifecycle transitions cannot locate V2 propose attribution events (D19 candidate).

## References

- PRs #889, #894 (D15/D16/D17/perf); #865–#883 (D0–D14 chain).
- Worker report: `tmp/orch/w6-d15-perf/REPORT.md` §§ D15-residual, D18.

---

# 中文

## 概要

第六轮 re-enable 的交错冒烟矩阵暴露的两个残余缺陷：D15-residual——CLI 侧写协调器把**第一笔入队的 WriteOp** 的 entity 当 `canonicalEntityId` 提交，task create 的 provenance 导出器先发 session 子写，于是提交面绑了 session entity 而 typed intent 正确声明 task entity——#889 之后真实 CLI 路上的 create 仍然全灭；D18——daemon 的周期 materializer 可能在 authority flush 与该次发布的定向 materialization 检查之间合并**并删除** session 分支，同 session 并发下把已实际发布的操作打成 INDETERMINATE。

## 改动内容

- **D15-residual**：`new-task` 的 `canonicalEntityId` 改为绑定 daemon 观察到的解析命令生成的 task id，不再按先到先绑；其他命令种类保持既有 WriteOp 派生绑定。compiler 仍独立推导 typed intent，entity-mismatch 检查原样保留。
- **D18**：authority 发布改为一个原子 daemon 队列操作——持锁 authority flush 与定向 session materialization 在同一个 normal 优先级队列项内执行；周期/后台 materializer 批可以并发排队但永远无法插进这两步之间。定向 materialization 仍要求预期分支、非零 commit 数与 `merged`；missing/conflict/error 保持 fail-closed。

## 任务与范围

- W6 cutover 线 task_01KXMN5BRWQH93976XBZSHSCN4；缺陷由第六轮 re-enable 冒烟暴露（admission open，无需冻结——失格形态为干净拒绝或自愈）；押栈于已合并 #894。
- 生产状态未触碰；部署 + daemon 重启 + 最终冒烟为 operator 动作。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 授权锚：task_01KXMN5BRWQH93976XBZSHSCN4；W6 修完即 cut 常设授权。
- 触碰的 protected 路径：无（`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`tools/test-tier-manifest.mjs`、`harness/**` 均未动）。
- 无削 gate：entity/commit/tree/mutation-set 证明不变；暴露 D15 的 entity-mismatch 防线继续生效；materialization 失败形态保持 fail-closed。

## 验证

- 根 `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0（32 个 manifest gates 全绿）。
- D15 红绿对照：恢复先到先绑复现 session-vs-task mismatch；命令意图绑定通过。生产同路径回归以真实 CLI argv 走 daemon socket 与 `makeDaemonAuthorityWriteCoordinator`：裸形态与 `--preset docs-task` create 落 inner commit、达 COMMITTED、各发一 event——补上放走残余缺陷的夹具盲区。
- D18 红绿对照：恢复两步生命周期显现竞态缝；原子路径报告恰一原子发布。确定性真 git 测试从 authority flush 内部排入竞争 materializer——authority 批先合并、竞争者零合并。生产 service 夹具：同 session 六路真 CLI 并发写交错 runtime event，全部一次 COMMITTED 无重试、各恰一 event。
- 聚焦套件：拆分前 41/41、拆分后 20/20、生产 service 回归复跑通过。

## 审查证据

- CEO 语义验收：绑定改动仅限 `new-task` 且 mismatch 检查保留为独立防线；原子性以真实消费者队列操作实现而非扩大锁面；两缺陷均有红对照——diff 与报告中确认。

## 残余风险

- authority 发布在 daemon 队列层 repo 级串行：大批量发布会延迟该 repo 后续排队工作（保持单写者模型；超大批次下观察队列延迟）。
- 生产重启与真并发验证归 operator；部署后的最终交错冒烟是门。
- 已知后续（下一轮）：decision 生命周期 transition 找不到 V2 propose 归属事件（D19 候选）。

## 关联材料

- PR #889、#894（D15/D16/D17/性能）；#865–#883（D0–D14 链）。
- worker 报告：`tmp/orch/w6-d15-perf/REPORT.md` §§ D15-residual、D18。
