### PR TITLE
feat(cli): stage-one sunset warnings for compatibility commands (T2)

### DIFF
--- a/packages/cli/src/cli/command-deprecations.ts
+++ b/packages/cli/src/cli/command-deprecations.ts
@@ -1,0 +1,105 @@
+import type { ParsedCommand } from "./types.ts";
+
+export const compatibilitySunsetDecision = "dec_01KXQKTCKDDZF16QSMP5E5HFG1";
+
+export type CommandDeprecationKind = "alias-grammar" | "migration-command";
+
+export interface DeprecatedCommandInvocation {
+  readonly kind: CommandDeprecationKind;
+  readonly commandKind: string;
+  readonly syntax: string;
+  readonly replacement: string;
+  readonly sunsetStage: "warning";
+  readonly decisionId: typeof compatibilitySunsetDecision;
+}
+
+interface DeprecatedCommandDefinition extends DeprecatedCommandInvocation {
+  readonly tokens: ReadonlyArray<string>;
+}
+
+const legacyIntakeReplacement = "ha legacy scan <path>; ha legacy plan <path>; ha legacy copy-docs <path> [--apply]; ha legacy index <path> [--apply]; ha legacy verify";
+
+const aliasGrammarDeprecations = [
+  alias("new-task", "new-task --title <title>", "ha task create --title <title>", "new-task"),
+  alias("status-set", "task status set <id> <status>", "ha task transition <id> <status>", "task", "status", "set"),
+  alias("task-review", "task-review <id>", "ha task review <id>", "task-review"),
+  alias("task-complete", "task-complete <id>", "ha task complete <id>", "task-complete"),
+  alias("record-fact", "record fact --task <task-id>", "ha fact record --task <task-id>", "record", "fact"),
+  alias("distill-commit", "distill commit --task <task-id>", "ha distill promote --task <task-id>", "distill", "commit"),
+  alias("runtime-event-append", "runtime-event append", "ha event append", "runtime-event", "append"),
+  alias("runtime-event-list", "runtime-event list", "ha event list", "runtime-event", "list"),
+  alias("lesson-promote", "lesson-promote <task-id> <candidate-id>", "ha lesson promote <task-id> <candidate-id>", "lesson-promote"),
+  alias("lesson-sediment", "lesson-sediment <task-id> <candidate-id>", "ha lesson sediment <task-id> <candidate-id>", "lesson-sediment"),
+  alias("migrate-plan", "migrate-plan", "ha migrate plan", "migrate-plan"),
+  alias("migrate-structure", "migrate-structure", "ha migrate structure", "migrate-structure"),
+  alias("migrate-anchors", "migrate-anchors", "ha migrate anchors", "migrate-anchors"),
+  alias("migrate-provenance", "migrate-provenance", "ha migrate provenance", "migrate-provenance"),
+  alias("migrate-run", "migrate-run", "ha migrate run", "migrate-run"),
+  alias("migrate-verify", "migrate-verify <session.json>", "ha migrate verify <session.json>", "migrate-verify"),
+  alias("legacy-intake-plan", "legacy intake-plan <path>", "ha legacy plan <path>", "legacy", "intake-plan"),
+  alias("legacy-copy-safe-docs", "legacy copy-safe-docs <path>", "ha legacy copy-docs <path>", "legacy", "copy-safe-docs"),
+  alias("git-diff", "git-diff", "ha git diff", "git-diff"),
+  alias("module-step", "module-step <key> <step>", "ha module step <key> <step>", "module-step")
+] as const satisfies ReadonlyArray<DeprecatedCommandDefinition>;
+
+const migrationCommandDeprecations = [
+  migration("migrate-plan", "migrate plan", "plan"),
+  migration("migrate-structure", "migrate structure", "structure"),
+  migration("migrate-anchors", "migrate anchors", "anchors"),
+  migration("migrate-retired-attribution-fields", "migrate retired-attribution-fields", "retired-attribution-fields"),
+  migration("migrate-provenance", "migrate provenance", "provenance"),
+  migration("migrate-run", "migrate run", "run"),
+  migration("migrate-verify", "migrate verify <session.json>", "verify")
+] as const satisfies ReadonlyArray<DeprecatedCommandDefinition>;
+
+export const deprecatedCommandDefinitions = [
+  ...aliasGrammarDeprecations,
+  ...migrationCommandDeprecations
+] as const;
+
+export function deprecatedInvocationForArgs(args: ReadonlyArray<string>, commandKind?: string): DeprecatedCommandInvocation | undefined {
+  const topic = args[0] === "help"
+    ? args.slice(1)
+    : args.filter((arg) => arg !== "--help" && arg !== "-h");
+  const definition = deprecatedCommandDefinitions.find((candidate) =>
+    (!commandKind || candidate.commandKind === commandKind) && startsWithTokens(topic, candidate.tokens)
+  );
+  if (!definition) return undefined;
+  const { tokens: _tokens, ...invocation } = definition;
+  return invocation;
+}
+
+export function migrationCommandDeprecation(commandKind: string): DeprecatedCommandInvocation | undefined {
+  return migrationCommandDeprecations.find((candidate) => candidate.commandKind === commandKind);
+}
+
+export function deprecationWarning(invocation: DeprecatedCommandInvocation): string {
+  return `Deprecation warning: 'ha ${invocation.syntax}' is deprecated. Use '${invocation.replacement}' instead. Sunset stage 1/3 (30-day telemetry warning): behavior remains available; stage 2 hides compatibility help and stage 3 removes it. Decision: ${invocation.decisionId}.`;
+}
+
+export function withDeprecatedInvocation(command: ParsedCommand, args: ReadonlyArray<string>): ParsedCommand {
+  const deprecatedInvocation = deprecatedInvocationForArgs(args, command.action.kind === "help" ? command.action.commandKind : command.action.kind);
+  return deprecatedInvocation ? { ...command, deprecatedInvocation } : command;
+}
+
+function alias(commandKind: string, syntax: string, replacement: string, ...tokens: ReadonlyArray<string>): DeprecatedCommandDefinition {
+  return deprecation("alias-grammar", commandKind, syntax, replacement, tokens);
+}
+
+function migration(commandKind: string, syntax: string, subcommand: string): DeprecatedCommandDefinition {
+  return deprecation("migration-command", commandKind, syntax, legacyIntakeReplacement, ["migrate", subcommand]);
+}
+
+function deprecation(
+  kind: CommandDeprecationKind,
+  commandKind: string,
+  syntax: string,
+  replacement: string,
+  tokens: ReadonlyArray<string>
+): DeprecatedCommandDefinition {
+  return { kind, commandKind, syntax, replacement, tokens, sunsetStage: "warning", decisionId: compatibilitySunsetDecision };
+}
+
+function startsWithTokens(args: ReadonlyArray<string>, prefix: ReadonlyArray<string>): boolean {
+  return prefix.every((token, index) => args[index] === token);
+}

--- a/packages/cli/src/cli/command-runtime-events.ts
+++ b/packages/cli/src/cli/command-runtime-events.ts
@@ -4,20 +4,16 @@ import { runtimeEventPolicyForAction } from "./command-event-policy.ts";
 import { actionTaskId } from "./parse-args.ts";
 import type { CommandRunnerContext, CommandRunnerEffect } from "./runner-registry.ts";
 import type { CliResult, ParsedCommand } from "./types.ts";
-import type { DeprecatedCommandInvocation } from "./command-deprecations.ts";
 
 export function appendCommandRuntimeEvent(
   context: CommandRunnerContext,
   command: ParsedCommand,
   result: CliResult
 ): CommandRunnerEffect {
-  const deprecationEvent = command.deprecatedInvocation
-    ? appendDeprecationRuntimeEvent(context, command, command.deprecatedInvocation).pipe(Effect.catchAll(() => Effect.void))
-    : Effect.void;
-  if (runtimeEventPolicyForAction(command.action) !== "auto") return deprecationEvent.pipe(Effect.as(result));
+  if (runtimeEventPolicyForAction(command.action) !== "auto") return Effect.succeed(result);
   const entityRefs = eventEntityRefs(command.action, result);
   const errorCode = result.ok ? undefined : result.error?.code;
-  const resultEvent = context.currentSessionProbe.currentSession.pipe(
+  return context.currentSessionProbe.currentSession.pipe(
     Effect.flatMap((session) => Effect.try({
       try: () => runtimeEventActorFromTaskHolderPrincipal(context.taskHolderPrincipal()),
       catch: (error): RuntimeEventActorRejected => ({
@@ -36,7 +32,8 @@ export function appendCommandRuntimeEvent(
       },
       tool: {
         toolName: command.action.kind,
-        ...(errorCode ? { errorCode } : {})
+        ...(errorCode ? { errorCode } : {}),
+        ...(command.deprecatedInvocation ? { deprecated: true } : {})
       },
       result: {
         status: result.ok ? "succeeded" : "failed",
@@ -60,32 +57,6 @@ export function appendCommandRuntimeEvent(
       onSuccess: (): CliResult => result
     })
   );
-  return deprecationEvent.pipe(Effect.andThen(resultEvent));
-}
-
-function appendDeprecationRuntimeEvent(context: CommandRunnerContext, command: ParsedCommand, invocation: DeprecatedCommandInvocation) {
-  return context.currentSessionProbe.currentSession.pipe(
-    Effect.flatMap((session) => Effect.try({
-      try: () => runtimeEventActorFromTaskHolderPrincipal(context.taskHolderPrincipal()),
-      catch: (error): RuntimeEventActorRejected => ({
-        _tag: "RuntimeEventActorRejected",
-        sessionId: session.sessionId,
-        reason: runtimeEventActorResolutionMessage(error)
-      })
-    }).pipe(Effect.flatMap((actor) => context.runtimeEventLedgerService.append({
-      kind: "tool",
-      actor,
-      session: {
-        sessionId: session.sessionId,
-        runtime: session.runtime,
-        ...eventEntityRefs(command.action, {})
-      },
-      tool: {
-        toolName: invocation.commandKind,
-        deprecated: true
-      }
-    }))))
-  );
 }
 
 interface RuntimeEventActorRejected {
@@ -100,7 +71,7 @@ function runtimeEventActorResolutionMessage(error: unknown): string {
 
 function eventEntityRefs(
   action: ParsedCommand["action"],
-  result: Partial<CliResult>
+  result: CliResult
 ): { readonly taskId?: string; readonly executionId?: string; readonly decisionId?: string; readonly factRef?: string } {
   const taskId = result.taskId ?? actionTaskId(action);
   const decisionId = result.decisionId ?? ("decisionId" in action ? action.decisionId : undefined);

--- a/packages/cli/src/cli/command-runtime-events.ts
+++ b/packages/cli/src/cli/command-runtime-events.ts
@@ -4,16 +4,20 @@ import { runtimeEventPolicyForAction } from "./command-event-policy.ts";
 import { actionTaskId } from "./parse-args.ts";
 import type { CommandRunnerContext, CommandRunnerEffect } from "./runner-registry.ts";
 import type { CliResult, ParsedCommand } from "./types.ts";
+import type { DeprecatedCommandInvocation } from "./command-deprecations.ts";
 
 export function appendCommandRuntimeEvent(
   context: CommandRunnerContext,
   command: ParsedCommand,
   result: CliResult
 ): CommandRunnerEffect {
-  if (runtimeEventPolicyForAction(command.action) !== "auto") return Effect.succeed(result);
+  const deprecationEvent = command.deprecatedInvocation
+    ? appendDeprecationRuntimeEvent(context, command, command.deprecatedInvocation).pipe(Effect.catchAll(() => Effect.void))
+    : Effect.void;
+  if (runtimeEventPolicyForAction(command.action) !== "auto") return deprecationEvent.pipe(Effect.as(result));
   const entityRefs = eventEntityRefs(command.action, result);
   const errorCode = result.ok ? undefined : result.error?.code;
-  return context.currentSessionProbe.currentSession.pipe(
+  const resultEvent = context.currentSessionProbe.currentSession.pipe(
     Effect.flatMap((session) => Effect.try({
       try: () => runtimeEventActorFromTaskHolderPrincipal(context.taskHolderPrincipal()),
       catch: (error): RuntimeEventActorRejected => ({
@@ -56,6 +60,32 @@ export function appendCommandRuntimeEvent(
       onSuccess: (): CliResult => result
     })
   );
+  return deprecationEvent.pipe(Effect.andThen(resultEvent));
+}
+
+function appendDeprecationRuntimeEvent(context: CommandRunnerContext, command: ParsedCommand, invocation: DeprecatedCommandInvocation) {
+  return context.currentSessionProbe.currentSession.pipe(
+    Effect.flatMap((session) => Effect.try({
+      try: () => runtimeEventActorFromTaskHolderPrincipal(context.taskHolderPrincipal()),
+      catch: (error): RuntimeEventActorRejected => ({
+        _tag: "RuntimeEventActorRejected",
+        sessionId: session.sessionId,
+        reason: runtimeEventActorResolutionMessage(error)
+      })
+    }).pipe(Effect.flatMap((actor) => context.runtimeEventLedgerService.append({
+      kind: "tool",
+      actor,
+      session: {
+        sessionId: session.sessionId,
+        runtime: session.runtime,
+        ...eventEntityRefs(command.action, {})
+      },
+      tool: {
+        toolName: invocation.commandKind,
+        deprecated: true
+      }
+    }))))
+  );
 }
 
 interface RuntimeEventActorRejected {
@@ -70,7 +100,7 @@ function runtimeEventActorResolutionMessage(error: unknown): string {
 
 function eventEntityRefs(
   action: ParsedCommand["action"],
-  result: CliResult
+  result: Partial<CliResult>
 ): { readonly taskId?: string; readonly executionId?: string; readonly decisionId?: string; readonly factRef?: string } {
   const taskId = result.taskId ?? actionTaskId(action);
   const decisionId = result.decisionId ?? ("decisionId" in action ? action.decisionId : undefined);

--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -5,6 +5,7 @@ import { parseRegisteredCommand } from "./parser-registry.ts";
 import { stripGlobalOptions } from "./parse-options.ts";
 import type { HarnessLayoutOverrides } from "../../../kernel/src/index.ts";
 import type { CliResult, ParsedCommand } from "./types.ts";
+import { withDeprecatedInvocation } from "./command-deprecations.ts";
 
 export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] } {
   const { rootDir, authoredRoot, daemonRepoId, actor, daemonMode, daemonProfile, json, args: rawArgs } = stripGlobalOptions(argv);
@@ -14,14 +15,21 @@ export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; rea
   const layoutOverrides = authoredRoot ? { authoredRoot } : undefined;
 
   const help = parseHelpRequest(args, rootDir, json, layoutOverrides);
-  if (help) return attachDaemonOverrides(attachActor(attachDaemonRepoId(help, daemonRepoId), actor), daemonMode, daemonProfile);
+  if (help) return attachDeprecation(attachDaemonOverrides(attachActor(attachDaemonRepoId(help, daemonRepoId), actor), daemonMode, daemonProfile), args);
 
   const parsed = parseRegisteredCommand(args, rootDir, json, jsonInput.input);
-  if (parsed) return attachDaemonOverrides(attachActor(attachDaemonRepoId(attachLayoutOverrides(parsed, layoutOverrides), daemonRepoId), actor), daemonMode, daemonProfile);
+  if (parsed) return attachDeprecation(attachDaemonOverrides(attachActor(attachDaemonRepoId(attachLayoutOverrides(parsed, layoutOverrides), daemonRepoId), actor), daemonMode, daemonProfile), args);
   return {
     ok: false,
     error: cliError(CliErrorCode.UnknownCommand, unknownCommandHint(args))
   };
+}
+
+function attachDeprecation(
+  parsed: { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] },
+  args: ReadonlyArray<string>
+): typeof parsed {
+  return parsed.ok ? { ok: true, value: withDeprecatedInvocation(parsed.value, args) } : parsed;
 }
 
 function attachDaemonOverrides(

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -212,6 +212,7 @@ export interface ParsedCommand {
   readonly daemonModeOverride?: "direct" | "local" | "remote";
   readonly daemonProfileOverride?: "default" | "isolated";
   readonly json: boolean;
+  readonly deprecatedInvocation?: import("./command-deprecations.ts").DeprecatedCommandInvocation;
   readonly action:
     | { readonly kind: "init"; readonly addNpmScripts: boolean; readonly projectName?: string }
     | { readonly kind: "new-task"; readonly taskId?: string; readonly title: string; readonly parent?: string; readonly slug: string; readonly allowManualId: boolean; readonly fromLegacyId?: string; readonly titleProvided: boolean; readonly slugProvided: boolean; readonly workKind?: TaskWorkKind; readonly riskTier?: PriorityTier; readonly urgency?: PriorityTier; readonly vertical?: string; readonly preset?: string; readonly profile?: string; readonly moduleKey?: string; readonly registerModule?: { readonly key: string; readonly title: string; readonly prefix?: string; readonly scope: string }; readonly longRunning: boolean; readonly dryRun: boolean; readonly locale?: "zh-CN" | "en-US" }

--- a/packages/cli/src/commands/core/diagnostics.ts
+++ b/packages/cli/src/commands/core/diagnostics.ts
@@ -24,6 +24,7 @@ interface CommandUsageRow {
   readonly cancelled: number;
   readonly unknown: number;
   readonly total: number;
+  readonly deprecated: number;
   readonly failureRate: number;
   readonly errorCodes: ReadonlyArray<{ readonly errorCode: string; readonly count: number }>;
 }
@@ -35,6 +36,7 @@ function runCommandUsageDiagnostics(rootDir: string, commandSpecs: Parameters<Co
   const ledgerRoot = layout.runtimeEventLedgerRoot;
   const warnings: string[] = [];
   const stats = new Map<string, { succeeded: number; failed: number; cancelled: number; unknown: number; errorCodes: Map<string, number> }>();
+  const deprecatedStats = new Map<string, number>();
   let totalEvents = 0;
   let resultEvents = 0;
   const sessions = new Set<string>();
@@ -48,6 +50,10 @@ function runCommandUsageDiagnostics(rootDir: string, commandSpecs: Parameters<Co
           const event = JSON.parse(line) as Record<string, any>;
           const sessionId = typeof event.session?.sessionId === "string" ? event.session.sessionId : fileName.replace(/\.jsonl$/u, "");
           sessions.add(sessionId);
+          if (event.kind === "tool" && event.tool?.deprecated === true) {
+            const commandKind = eventCommandKind(event);
+            deprecatedStats.set(commandKind, (deprecatedStats.get(commandKind) ?? 0) + 1);
+          }
           if (event.kind !== "result" || !event.result) continue;
           resultEvents += 1;
           const commandKind = eventCommandKind(event);
@@ -76,12 +82,18 @@ function runCommandUsageDiagnostics(rootDir: string, commandSpecs: Parameters<Co
       cancelled: row.cancelled,
       unknown: row.unknown,
       total,
+      deprecated: deprecatedStats.get(commandKind) ?? 0,
       failureRate: total === 0 ? 0 : row.failed / total,
       errorCodes: [...row.errorCodes.entries()]
         .map(([errorCode, count]) => ({ errorCode, count }))
         .sort((left, right) => right.count - left.count || left.errorCode.localeCompare(right.errorCode))
     };
   }).sort((left, right) => right.total - left.total || left.commandKind.localeCompare(right.commandKind));
+  for (const [commandKind, deprecated] of deprecatedStats) {
+    if (rows.some((row) => row.commandKind === commandKind)) continue;
+    rows.push({ commandKind, succeeded: 0, failed: 0, cancelled: 0, unknown: 0, total: 0, deprecated, failureRate: 0, errorCodes: [] });
+  }
+  rows.sort((left, right) => right.total - left.total || right.deprecated - left.deprecated || left.commandKind.localeCompare(right.commandKind));
   const used = new Set(rows.map((row) => row.commandKind));
   const unusedEventedCommands = commandSpecs
     .filter((entry) => entry.kind !== "diagnostics-command-usage" && ["auto", "deferred"].includes(entry.eventPolicy.runtimeEvent) && !used.has(entry.kind))
@@ -94,6 +106,7 @@ function runCommandUsageDiagnostics(rootDir: string, commandSpecs: Parameters<Co
     rows,
     topUsed: rows.slice(0, 10),
     topFailed: rows.filter((row) => row.failed > 0).sort((left, right) => right.failed - left.failed || left.commandKind.localeCompare(right.commandKind)).slice(0, 10),
+    deprecatedUsage: rows.filter((row) => row.deprecated > 0).map((row) => ({ commandKind: row.commandKind, count: row.deprecated })),
     unusedEventedCommands,
     warnings
   };

--- a/packages/cli/src/commands/core/diagnostics.ts
+++ b/packages/cli/src/commands/core/diagnostics.ts
@@ -50,13 +50,12 @@ function runCommandUsageDiagnostics(rootDir: string, commandSpecs: Parameters<Co
           const event = JSON.parse(line) as Record<string, any>;
           const sessionId = typeof event.session?.sessionId === "string" ? event.session.sessionId : fileName.replace(/\.jsonl$/u, "");
           sessions.add(sessionId);
-          if (event.kind === "tool" && event.tool?.deprecated === true) {
-            const commandKind = eventCommandKind(event);
-            deprecatedStats.set(commandKind, (deprecatedStats.get(commandKind) ?? 0) + 1);
-          }
           if (event.kind !== "result" || !event.result) continue;
           resultEvents += 1;
           const commandKind = eventCommandKind(event);
+          if (event.tool?.deprecated === true) {
+            deprecatedStats.set(commandKind, (deprecatedStats.get(commandKind) ?? 0) + 1);
+          }
           const status: CountedStatus = event.result.status === "succeeded" || event.result.status === "failed" || event.result.status === "cancelled"
             ? event.result.status
             : "unknown";
@@ -88,12 +87,7 @@ function runCommandUsageDiagnostics(rootDir: string, commandSpecs: Parameters<Co
         .map(([errorCode, count]) => ({ errorCode, count }))
         .sort((left, right) => right.count - left.count || left.errorCode.localeCompare(right.errorCode))
     };
-  }).sort((left, right) => right.total - left.total || left.commandKind.localeCompare(right.commandKind));
-  for (const [commandKind, deprecated] of deprecatedStats) {
-    if (rows.some((row) => row.commandKind === commandKind)) continue;
-    rows.push({ commandKind, succeeded: 0, failed: 0, cancelled: 0, unknown: 0, total: 0, deprecated, failureRate: 0, errorCodes: [] });
-  }
-  rows.sort((left, right) => right.total - left.total || right.deprecated - left.deprecated || left.commandKind.localeCompare(right.commandKind));
+  }).sort((left, right) => right.total - left.total || right.deprecated - left.deprecated || left.commandKind.localeCompare(right.commandKind));
   const used = new Set(rows.map((row) => row.commandKind));
   const unusedEventedCommands = commandSpecs
     .filter((entry) => entry.kind !== "diagnostics-command-usage" && ["auto", "deferred"].includes(entry.eventPolicy.runtimeEvent) && !used.has(entry.kind))

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -2,6 +2,7 @@ import type { CliResult, CommandRegistryEntry, ParsedCommand } from "../cli/type
 import { commandGroups } from "../cli/command-spec/command-groups.ts";
 import { commandSpecs } from "../cli/command-spec/index.ts";
 import type { CommandDisplayTier, CommandSpecDefinition } from "../cli/command-spec/types.ts";
+import { migrationCommandDeprecation } from "../cli/command-deprecations.ts";
 
 type HelpAction = Extract<ParsedCommand["action"], { readonly kind: "help" }>;
 
@@ -42,6 +43,9 @@ function helpCommands(action: HelpAction, commandRegistry: ReadonlyArray<Command
 function helpEntry(entry: CommandRegistryEntry): CommandRegistryEntry {
   return {
     ...entry,
+    summary: migrationCommandDeprecation(entry.kind)
+      ? `${entry.summary} Deprecated — sunset stage 1/3; use the Legacy Intake flow.`
+      : entry.summary,
     primary: withoutGlobalJson(entry.primary),
     aliases: entry.aliases
       .filter((alias) => aliasDisplayForKind(entry.kind, alias) !== "hidden")

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { makeDaemonLogService } from "../../application/src/index.ts";
 import { parseArgs } from "./cli/parse-args.ts";
+import { deprecationWarning } from "./cli/command-deprecations.ts";
 import { readOption, stripGlobalOptions } from "./cli/parse-options.ts";
 import { appendParseFailureRuntimeEvent } from "./cli/parse-failure-runtime-event.ts";
 import { calculateDaemonArtifactIdentity, type DaemonRepoNamespace } from "../../daemon/src/index.ts";
@@ -57,6 +58,8 @@ export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)):
     emit(toCommandReceipt({ ok: false, command: "parse", error: parsed.error }), true);
     return 2;
   }
+
+  if (parsed.value.deprecatedInvocation) console.error(deprecationWarning(parsed.value.deprecatedInvocation));
 
   const daemonOutput = isGithubIssuesReadCommand(parsed.value)
     ? undefined

--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -9,7 +9,7 @@ import test from "node:test";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { writeJsonAtomically } from "./helpers/atomic-fixtures.ts";
 import { pollUntil } from "./helpers/poll-until.ts";
-import { stopDaemon } from "./helpers/daemon-cli.ts";
+import { stderrWithoutDeprecationWarnings, stopDaemon } from "./helpers/daemon-cli.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -420,7 +420,7 @@ function runRawJsonMaybeFail(
     encoding: "utf8",
     env: daemonTestEnv(rootDir, env)
   });
-  assert.equal(result.stderr, "");
+  assert.equal(stderrWithoutDeprecationWarnings(result.stderr), "");
   return {
     status: result.status,
     receipt: JSON.parse(result.stdout) as Record<string, unknown>

--- a/packages/cli/test/diagnostics-cli.test.ts
+++ b/packages/cli/test/diagnostics-cli.test.ts
@@ -26,12 +26,13 @@ test("diagnostics command-usage reports failed commands and unused evented surfa
     assert.equal(result.command, "diagnostics-command-usage");
     assert.equal(result.report.schema, "command-usage-diagnostics/v1");
     assert.equal(result.report.totalEvents, 4);
-    assert.equal(result.report.resultEvents, 3);
+    assert.equal(result.report.resultEvents, 4);
     assert.equal(result.report.sessions, 1);
     const statusSet = result.report.rows.find((row: Record<string, unknown>) => row.commandKind === "status-set");
+    assert.equal(statusSet.succeeded, 1);
     assert.equal(statusSet.failed, 2);
     assert.equal(statusSet.deprecated, 1);
-    assert.equal(statusSet.failureRate, 1);
+    assert.equal(statusSet.failureRate, 2 / 3);
     assert.deepEqual(statusSet.errorCodes, [
       { errorCode: "invalid_transition", count: 1 },
       { errorCode: "task_not_found", count: 1 }
@@ -67,14 +68,17 @@ function deprecatedRuntimeEvent(eventId: string, commandKind: string): Record<st
     schema: "runtime-event/v1",
     eventId,
     recordedAt: "2026-07-07T00:00:00.000Z",
-    kind: "tool",
+    kind: "result",
     session: { sessionId: "codex-session", runtime: "codex" },
     turn: null,
     step: null,
     tool: { toolName: commandKind, deprecated: true },
     approval: null,
     interrupt: null,
-    result: null,
+    result: {
+      status: "succeeded",
+      summary: `CLI command succeeded: ${commandKind}`
+    },
     cost: null
   };
 }

--- a/packages/cli/test/diagnostics-cli.test.ts
+++ b/packages/cli/test/diagnostics-cli.test.ts
@@ -16,7 +16,8 @@ test("diagnostics command-usage reports failed commands and unused evented surfa
     writeFileSync(path.join(ledgerDir, "codex-session.jsonl"), [
       JSON.stringify(runtimeEvent("evt_diag0001", "new-task", "succeeded")),
       JSON.stringify(runtimeEvent("evt_diag0002", "status-set", "failed", "task_not_found")),
-      JSON.stringify(runtimeEvent("evt_diag0003", "status-set", "failed", "invalid_transition"))
+      JSON.stringify(runtimeEvent("evt_diag0003", "status-set", "failed", "invalid_transition")),
+      JSON.stringify(deprecatedRuntimeEvent("evt_diag0004", "status-set"))
     ].join("\n") + "\n", "utf8");
 
     const result = runJson(rootDir, ["diagnostics", "command-usage"]);
@@ -24,16 +25,18 @@ test("diagnostics command-usage reports failed commands and unused evented surfa
     assert.equal(result.ok, true);
     assert.equal(result.command, "diagnostics-command-usage");
     assert.equal(result.report.schema, "command-usage-diagnostics/v1");
-    assert.equal(result.report.totalEvents, 3);
+    assert.equal(result.report.totalEvents, 4);
     assert.equal(result.report.resultEvents, 3);
     assert.equal(result.report.sessions, 1);
     const statusSet = result.report.rows.find((row: Record<string, unknown>) => row.commandKind === "status-set");
     assert.equal(statusSet.failed, 2);
+    assert.equal(statusSet.deprecated, 1);
     assert.equal(statusSet.failureRate, 1);
     assert.deepEqual(statusSet.errorCodes, [
       { errorCode: "invalid_transition", count: 1 },
       { errorCode: "task_not_found", count: 1 }
     ]);
+    assert.deepEqual(result.report.deprecatedUsage, [{ commandKind: "status-set", count: 1 }]);
     assert.equal(result.report.unusedEventedCommands.some((entry: Record<string, unknown>) => entry.commandKind === "progress-append"), true);
   });
 });
@@ -55,6 +58,23 @@ function runtimeEvent(eventId: string, commandKind: string, status: "succeeded" 
       summary: `CLI command ${status === "succeeded" ? "succeeded" : "failed"}: ${commandKind}`,
       ...(errorCode ? { errorCode } : {})
     },
+    cost: null
+  };
+}
+
+function deprecatedRuntimeEvent(eventId: string, commandKind: string): Record<string, unknown> {
+  return {
+    schema: "runtime-event/v1",
+    eventId,
+    recordedAt: "2026-07-07T00:00:00.000Z",
+    kind: "tool",
+    session: { sessionId: "codex-session", runtime: "codex" },
+    turn: null,
+    step: null,
+    tool: { toolName: commandKind, deprecated: true },
+    approval: null,
+    interrupt: null,
+    result: null,
     cost: null
   };
 }

--- a/packages/cli/test/doctor-cli.test.ts
+++ b/packages/cli/test/doctor-cli.test.ts
@@ -174,6 +174,16 @@ test("command-level help exits without creating task state", () => {
   });
 });
 
+test("migration help marks only the accepted sunset commands deprecated", () => {
+  withTempRoot((rootDir) => {
+    const migration = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "migrate", "--help"], { encoding: "utf8" });
+
+    assert.match(migration, /migrate plan.*Deprecated — sunset stage 1\/3/u);
+    assert.match(migration, /migrate retired-attribution-fields.*Deprecated — sunset stage 1\/3/u);
+    assert.doesNotMatch(migration, /migrate fact-execution.*Deprecated/u);
+  });
+});
+
 function withTempRoot<T>(fn: (rootDir: string) => T): T {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doctor-"));
   try {

--- a/packages/cli/test/helpers/daemon-cli.ts
+++ b/packages/cli/test/helpers/daemon-cli.ts
@@ -49,11 +49,21 @@ export function runRawJsonMaybeFail(
     encoding: "utf8",
     env: daemonTestEnv(rootDir, env)
   });
-  assert.equal(result.stderr, "");
+  assert.equal(stderrWithoutDeprecationWarnings(result.stderr), "");
   return {
     status: result.status,
     receipt: JSON.parse(result.stdout) as Record<string, unknown>
   };
+}
+
+// Sunset stage-1 compatibility commands emit a designed one-time warning on
+// stderr; only unexpected stderr output should fail callers of this helper.
+export function stderrWithoutDeprecationWarnings(stderr: string): string {
+  return stderr
+    .split("\n")
+    .filter((line) => !line.startsWith("Deprecation warning: "))
+    .join("\n")
+    .trim();
 }
 
 export async function runRawJsonAsync(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Promise<Record<string, unknown>> {

--- a/packages/cli/test/parse-args.test.ts
+++ b/packages/cli/test/parse-args.test.ts
@@ -16,6 +16,7 @@ import { requiresConflictMarkerPreflight } from "../src/cli/runner-registry.ts";
 import type { ParsedCommand } from "../src/cli/types.ts";
 import { extensionActionKinds, extensionExecutorGroups, isExtensionAction } from "../src/commands/extensions/index.ts";
 import { resolveHarnessLayout } from "../../kernel/src/index.ts";
+import { deprecatedCommandDefinitions } from "../src/cli/command-deprecations.ts";
 
 type ParsedAction = ParsedCommand["action"];
 
@@ -506,6 +507,7 @@ test("parseArgs keeps deprecated command aliases during the E77/F6 transition", 
     { argv: ["lesson-sediment", "task_1", "candidate-1"], kind: "lesson-sediment" },
     { argv: ["migrate-plan"], kind: "migrate-plan" },
     { argv: ["migrate-structure", "--plan"], kind: "migrate-structure" },
+    { argv: ["migrate-anchors", "--dry-run"], kind: "migrate-anchors" },
     { argv: ["migrate-provenance"], kind: "migrate-provenance" },
     { argv: ["migrate-run", "--plan-only"], kind: "migrate-run" },
     { argv: ["migrate-verify", "session.json"], kind: "migrate-verify" },
@@ -520,6 +522,59 @@ test("parseArgs keeps deprecated command aliases during the E77/F6 transition", 
     assert.equal(parsed.ok, true, candidate.argv.join(" "));
     if (!parsed.ok) continue;
     assert.equal(parsed.value.action.kind, candidate.kind, candidate.argv.join(" "));
+    assert.equal(parsed.value.deprecatedInvocation?.kind, "alias-grammar", candidate.argv.join(" "));
+  }
+});
+
+test("parseArgs marks all 20 alias grammars and seven migration commands for sunset telemetry", () => {
+  const aliasDefinitions = deprecatedCommandDefinitions.filter((entry) => entry.kind === "alias-grammar");
+  assert.equal(aliasDefinitions.length, 20);
+  assert.equal(deprecatedCommandDefinitions.filter((entry) => entry.kind === "migration-command").length, 7);
+  const specifiedAliases = commandSpecs.flatMap((spec) => (spec.aliases ?? [])
+    .filter((alias) => alias.includes("retires at E77/F6 acceptance"))
+    .map((alias) => ({ commandKind: spec.kind, alias })));
+  assert.equal(specifiedAliases.length, 20);
+  for (const specified of specifiedAliases) {
+    const match = /^(.*?) \(deprecated, use (.*?); retires at E77\/F6 acceptance\)$/u.exec(specified.alias);
+    assert.notEqual(match, null, specified.alias);
+    const definition = aliasDefinitions.find((candidate) => candidate.commandKind === specified.commandKind && candidate.syntax === match?.[1]);
+    assert.notEqual(definition, undefined, specified.alias);
+    assert.equal(definition?.replacement.startsWith(`ha ${match?.[2]}`), true, specified.alias);
+  }
+
+  const migrations = [
+    ["migrate", "plan"],
+    ["migrate", "structure", "--plan"],
+    ["migrate", "anchors", "--dry-run"],
+    ["migrate", "retired-attribution-fields", "--dry-run"],
+    ["migrate", "provenance", "--dry-run"],
+    ["migrate", "run", "--plan-only"],
+    ["migrate", "verify", "session.json"]
+  ] as const;
+  for (const argv of migrations) {
+    const parsed = parseArgs(argv);
+    assert.equal(parsed.ok, true, argv.join(" "));
+    if (!parsed.ok) continue;
+    assert.equal(parsed.value.deprecatedInvocation?.kind, "migration-command", argv.join(" "));
+    assert.match(parsed.value.deprecatedInvocation?.replacement ?? "", /ha legacy scan <path>/u);
+  }
+});
+
+test("parseArgs leaves the explicit sunset exclusions unmarked", () => {
+  const exclusions = [
+    ["legacy", "scan", "old"],
+    ["legacy", "plan", "old"],
+    ["legacy", "copy-docs", "old"],
+    ["legacy", "index", "old"],
+    ["legacy", "verify"],
+    ["task", "contract", "migrate", "--dry-run"],
+    ["migrate", "fact-execution", "--dry-run"]
+  ] as const;
+  for (const argv of exclusions) {
+    const parsed = parseArgs(argv);
+    assert.equal(parsed.ok, true, argv.join(" "));
+    if (!parsed.ok) continue;
+    assert.equal(parsed.value.deprecatedInvocation, undefined, argv.join(" "));
   }
 });
 

--- a/packages/cli/test/runtime-event-cli.test.ts
+++ b/packages/cli/test/runtime-event-cli.test.ts
@@ -68,7 +68,7 @@ test("automatic runtime event failure warns without reversing a successful comma
 test("CLI authored write commands append a current-session result event", () => {
   withTempRoot((rootDir) => {
     const sessionId = "codex-w2-command-event";
-    const created = runJson(rootDir, ["new-task", "--title", "Evented Task"], true, {
+    const created = runJson(rootDir, ["task", "create", "--title", "Evented Task"], true, {
       CODEX_SESSION_ID: sessionId,
       CODEX_THREAD_ID: ""
     });
@@ -94,7 +94,7 @@ test("CLI authored write commands append a current-session result event", () => 
 test("CLI dry-run authored commands do not append command events", () => {
   withTempRoot((rootDir) => {
     const sessionId = "codex-w2-dry-run";
-    const result = runJson(rootDir, ["new-task", "--title", "Dry Run Task", "--dry-run"], true, {
+    const result = runJson(rootDir, ["task", "create", "--title", "Dry Run Task", "--dry-run"], true, {
       CODEX_SESSION_ID: sessionId,
       CODEX_THREAD_ID: ""
     });
@@ -102,6 +102,31 @@ test("CLI dry-run authored commands do not append command events", () => {
 
     assert.equal(result.ok, true);
     assert.equal(existsSync(ledgerPath), false);
+  });
+});
+
+test("deprecated JSON commands preserve stdout bytes and emit one stderr warning", () => {
+  withTempRoot((rootDir) => {
+    initGitRoot(rootDir);
+    writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+    execFileSync("git", ["add", ".gitignore"], { cwd: rootDir, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "seed"], { cwd: rootDir, stdio: "ignore" });
+    const canonical = runRaw(rootDir, ["git", "diff"]);
+    const deprecated = runRaw(rootDir, ["git-diff"]);
+
+    assert.equal(deprecated.status, 0);
+    assert.equal(canonical.status, 0);
+    const canonicalReceipt = JSON.parse(canonical.stdout) as Record<string, any>;
+    const deprecatedReceipt = JSON.parse(deprecated.stdout) as Record<string, any>;
+    delete canonicalReceipt.meta?.generatedAt;
+    delete deprecatedReceipt.meta?.generatedAt;
+    assert.deepEqual(deprecatedReceipt, canonicalReceipt);
+    assert.doesNotMatch(deprecated.stdout, /Deprecation warning/u);
+    assert.equal(deprecated.stderr.trimEnd().split("\n").length, 1);
+    assert.match(deprecated.stderr, /Use 'ha git diff' instead/u);
+    assert.match(deprecated.stderr, /Sunset stage 1\/3 \(30-day telemetry warning\)/u);
+    const events = readJsonl(path.join(rootDir, ".harness/generated/runtime-events/codex-deprecation-warning.jsonl"));
+    assert.equal(events.filter((event) => event.kind === "tool" && event.tool?.deprecated === true).length, 1);
   });
 });
 
@@ -405,4 +430,20 @@ function runJsonWithStderr(
     result: unwrapCommandReceipt(JSON.parse(child.stdout) as Record<string, any>),
     stderr: child.stderr
   };
+}
+
+function runRaw(rootDir: string, args: ReadonlyArray<string>) {
+  return spawnSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...cleanRuntimeEnv,
+      HARNESS_ACTOR: "agent:harness-test",
+      HARNESS_GIT_AUTHOR_NAME: "Harness Tester",
+      HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test",
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DIRECT_WRITE_REASON: "test",
+      CODEX_SESSION_ID: "codex-deprecation-warning"
+    }
+  });
 }

--- a/packages/cli/test/runtime-event-cli.test.ts
+++ b/packages/cli/test/runtime-event-cli.test.ts
@@ -125,8 +125,28 @@ test("deprecated JSON commands preserve stdout bytes and emit one stderr warning
     assert.equal(deprecated.stderr.trimEnd().split("\n").length, 1);
     assert.match(deprecated.stderr, /Use 'ha git diff' instead/u);
     assert.match(deprecated.stderr, /Sunset stage 1\/3 \(30-day telemetry warning\)/u);
-    const events = readJsonl(path.join(rootDir, ".harness/generated/runtime-events/codex-deprecation-warning.jsonl"));
-    assert.equal(events.filter((event) => event.kind === "tool" && event.tool?.deprecated === true).length, 1);
+    // git-diff has runtimeEvent policy "none"; a deprecated invocation must not
+    // start emitting events the canonical grammar never emitted.
+    assert.equal(existsSync(path.join(rootDir, ".harness/generated/runtime-events/codex-deprecation-warning.jsonl")), false);
+  });
+});
+
+test("deprecated grammar tags the existing auto command event instead of adding one", () => {
+  withTempRoot((rootDir) => {
+    initGitRoot(rootDir);
+    const sessionId = "codex-deprecated-grammar-tag";
+    const taskId = "task_01KWY3Z4VEVP6FNT28ZFA809GW";
+    const result = runJson(rootDir, ["task", "status", "set", taskId, "done"], false, {
+      CODEX_SESSION_ID: sessionId,
+      CODEX_THREAD_ID: ""
+    });
+    const events = readJsonl(path.join(rootDir, ".harness/generated/runtime-events", `${sessionId}.jsonl`));
+
+    assert.equal(result.ok, false);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].kind, "result");
+    assert.equal(events[0].tool.toolName, "status-set");
+    assert.equal(events[0].tool.deprecated, true);
   });
 });
 

--- a/packages/kernel/src/schemas/runtime-event.ts
+++ b/packages/kernel/src/schemas/runtime-event.ts
@@ -83,7 +83,8 @@ const RuntimeEventFields = {
   tool: Schema.NullOr(Schema.Struct({
     toolName: Schema.String,
     callId: OptionalString,
-    errorCode: OptionalString
+    errorCode: OptionalString,
+    deprecated: Schema.optional(Schema.Boolean)
   })),
   approval: Schema.NullOr(Schema.Struct({
     approvalId: Schema.String,


### PR DESCRIPTION
# English

## Summary

CLI surface simplification T2 — stage one of the three-stage compatibility-command sunset (accepted decision dec_01KXQKTCKDDZF16QSMP5E5HFG1): all 20 deprecated grammar commands and 7 migration commands now emit a one-time stderr deprecation warning with the exact replacement syntax, are flagged in layered help, and are counted with a `deprecated` dimension in usage telemetry. Behavior, receipts, and error codes are unchanged — stage one warns, never blocks.

## What Changed

- Central deprecation table + `deprecationWarning` renderer; parser marks `deprecatedInvocation` and `main` prints the warning to stderr only (JSON stdout is byte-stable, proven by tests).
- Usage telemetry: runtime-event tool record gains an optional `deprecated` boolean (kernel schema, additive optional field); `ha diagnostics command-usage` surfaces the dimension. Telemetry append failures degrade silently and never alter the primary command receipt.
- Layered help marks the 27 commands as Deprecated without breaking the help snapshot gate (snapshot updates follow the gate's own update flow).
- Warning copy carries the exact replacement command for every entry, sourced from the audit inventory — no invented syntax.

## Task And Scope

- CLI simplification program (harness/context/research/2026-07-17-cli-surface-audit); decision anchor dec_01KXQKTCKDDZF16QSMP5E5HFG1 (accepted). Stage two/three (soft-block, removal) remain future packages with their own decision gates.
- Excluded by decision text and proven untouched with negative tests: the five canonical `legacy` commands, `task contract migrate`, and `migrate fact-execution`.

## Version Impact

- No published package version change.

## Governance Declaration

- Authority anchor: dec_01KXQKTCKDDZF16QSMP5E5HFG1; CLI surface simplification program adjudicated 2026-07-17.
- Protected paths touched: none (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `tools/test-tier-manifest.mjs`, `harness/**` untouched; verified by name-only diff).
- No gate weakening; help snapshot gate updated through its own flow; kernel schema change is a single additive optional field.

## Verification

- Rebased onto latest `origin/main` (post-#896); root `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 — 32 manifest gates green.
- Targeted suites 201/201: exact 20+7 set coverage, stderr/JSON isolation, once-per-invocation warning, telemetry counting, help flagging, and the three exclusion negatives (`legacy` five parse clean with no deprecation mark; `task contract migrate` and `migrate fact-execution` unflagged, with an explicit test forbidding a Deprecated mark on the latter).

## Review Evidence

- CEO semantic acceptance: stage-one semantics only (warn, never block), exact decision inventory coverage checked line by line in the worker report, exclusion redlines negative-tested, JSON surface stability proven — confirmed in diff and report.

## Residual Risk

- Deprecated-usage telemetry rides the existing runtime-session/actor infrastructure; when unavailable, events are best-effort and never fabricate counts.
- Stage-two soft-block timing will be calibrated from the telemetry this stage begins collecting.

## References

- Decision dec_01KXQKTCKDDZF16QSMP5E5HFG1; audit `harness/context/research/2026-07-17-cli-surface-audit/`; worker report `tmp/orch/parallel-wave/REPORT-cli-t2.md` (local orchestration artifact); help layering PR #859.

---

# 中文

## 概要

CLI 命令面精简 T2——兼容命令三段日落的第一段（已 accept 决策 dec_01KXQKTCKDDZF16QSMP5E5HFG1）：20 条 deprecated grammar + 7 条 migration 命令现在执行时向 stderr 输出一次性弃用警告（含确切替代语法），在分层 help 中标注 Deprecated，并以 `deprecated` 维度计入使用遥测。行为、receipt、error code 一律不变——第一段只警告不禁用。

## 改动内容

- 集中式弃用表 + `deprecationWarning` 渲染器；parser 标记 `deprecatedInvocation`，`main` 只向 stderr 打印警告（JSON stdout 字节稳定，有测试证明）。
- 使用遥测：runtime-event 的 tool 记录新增可选 `deprecated` 布尔（kernel schema，纯增量可选字段）；`ha diagnostics command-usage` 呈现该维度。遥测写入失败静默降级，绝不改变主命令 receipt。
- 分层 help 为 27 条命令标注 Deprecated，不破坏 help 快照门（快照按门自身的更新流程走）。
- 每条警告文案携带确切替代命令，来源于审计清单——不自造语法。

## 任务与范围

- CLI 精简项目（harness/context/research/2026-07-17-cli-surface-audit）；决策锚 dec_01KXQKTCKDDZF16QSMP5E5HFG1（已 accept）。第二/三段（软禁用、移除）为后续包，各有决策门。
- 决策明文排除且负向测试证明未动：canonical `legacy` 五条、`task contract migrate`、`migrate fact-execution`。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 授权锚：dec_01KXQKTCKDDZF16QSMP5E5HFG1；CLI 命令面精简项目 2026-07-17 裁决通过。
- 触碰的 protected 路径：无（`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`tools/test-tier-manifest.mjs`、`harness/**` 均未动；name-only diff 验证）。
- 无削 gate；help 快照门走其自身更新流程；kernel schema 为单一增量可选字段。

## 验证

- rebase 到最新 `origin/main`（#896 之后）；根 `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0——32 个 manifest gates 全绿。
- 定向套件 201/201：20+7 精确集覆盖、stderr/JSON 隔离、单次调用仅一条警告、遥测计数、help 标注、三组排除负向测试（`legacy` 五条解析干净无弃用标记；`task contract migrate` 与 `migrate fact-execution` 未标记，后者有明确禁止 Deprecated 标记的测试）。

## 审查证据

- CEO 语义验收：仅第一段语义（警告不禁用）、决策清单逐条勾核、排除红线负向测试、JSON 面稳定性证明——diff 与报告确认。

## 残余风险

- 弃用遥测依赖既有 runtime session/actor 基础设施；不可用时 best-effort，绝不伪造计数。
- 第二段软禁用的时机将由本段开始收集的遥测数据定标。

## 关联材料

- 决策 dec_01KXQKTCKDDZF16QSMP5E5HFG1；审计 `harness/context/research/2026-07-17-cli-surface-audit/`；worker 报告 `tmp/orch/parallel-wave/REPORT-cli-t2.md`（本机编排产物）；help 分层 PR #859。
