### PR TITLE
fix(daemon): submit cold-session task provenance independently (D21)

### DIFF
--- a/packages/cli/src/daemon/authority-command-submission.ts
+++ b/packages/cli/src/daemon/authority-command-submission.ts
@@ -32,6 +32,12 @@ export interface DaemonAuthorityAttemptCompilerV2 {
     readonly currentSession: CurrentSessionRef;
     readonly canonicalEntityId: WriteOp["entityId"];
   }) => Promise<AuthorizedOperationAttemptV2>;
+  readonly compileProvenanceSession?: (input: {
+    readonly command: ParsedCommand;
+    readonly attribution: CliActorAttribution;
+    readonly currentSession: CurrentSessionRef;
+    readonly operation: WriteOp;
+  }) => Promise<AuthorizedOperationAttemptV2>;
 }
 
 export interface DaemonAuthorityCommandSubmissionV2 {
@@ -41,6 +47,12 @@ export interface DaemonAuthorityCommandSubmissionV2 {
     readonly currentSession: CurrentSessionRef;
     readonly canonicalEntityId: WriteOp["entityId"];
   }) => Promise<AuthorityOperationReceipt>;
+  readonly submitProvenanceSession?: (input: {
+    readonly command: ParsedCommand;
+    readonly attribution: CliActorAttribution;
+    readonly currentSession: CurrentSessionRef;
+    readonly operation: WriteOp;
+  }) => Promise<AuthorityOperationReceipt>;
 }
 
 export function createDaemonAuthorityCommandSubmissionV2(options: {
@@ -48,16 +60,20 @@ export function createDaemonAuthorityCommandSubmissionV2(options: {
   readonly attemptCompiler: DaemonAuthorityAttemptCompilerV2;
 }): DaemonAuthorityCommandSubmissionV2 {
   if (!options.authorityService.submitV2) throw new Error("DAEMON_AUTHORITY_V2_NOT_NEGOTIATED");
+  const submitAttempt = async (attempt: AuthorizedOperationAttemptV2): Promise<AuthorityOperationReceipt> => {
+    const envelope = decodeSemanticMutationEnvelopeV2(attempt.envelope);
+    const expectedOpId = operationIdDiagnosticV2(envelope.operationId);
+    const receipt = await options.authorityService.submitV2!(attempt);
+    assertCompleteAuthorityReceiptV2(receipt);
+    assertAuthorityReceiptOperation(receipt, expectedOpId);
+    return receipt;
+  };
   return {
-    submit: async (input) => {
-      const attempt = await options.attemptCompiler.compile(input);
-      const envelope = decodeSemanticMutationEnvelopeV2(attempt.envelope);
-      const expectedOpId = operationIdDiagnosticV2(envelope.operationId);
-      const receipt = await options.authorityService.submitV2!(attempt);
-      assertCompleteAuthorityReceiptV2(receipt);
-      assertAuthorityReceiptOperation(receipt, expectedOpId);
-      return receipt;
-    }
+    submit: async (input) => submitAttempt(await options.attemptCompiler.compile(input)),
+    ...(options.attemptCompiler.compileProvenanceSession ? {
+      submitProvenanceSession: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileProvenanceSession"]>>[0]) =>
+        submitAttempt(await options.attemptCompiler.compileProvenanceSession!(input))
+    } : {})
   };
 }
 
@@ -104,30 +120,54 @@ export function makeDaemonAuthorityWriteCoordinator(
     readonly currentSession: CurrentSessionRef;
   }
 ): WriteCoordinator {
-  let accepted: WriteOp["entityId"] | undefined;
+  let pending: WriteOp | undefined;
   let settled: Promise<AuthorityOperationReceipt> | undefined;
+  let provenanceCommitted = false;
+  let mainCommitted = false;
 
   return {
-    enqueue: (operation) => accepted
+    enqueue: (operation) => pending || mainCommitted
       ? Effect.fail(authorityWriteRejected("AUTHORITY_COMMAND_REQUIRES_SINGLE_CANONICAL_OPERATION"))
       : Effect.sync(() => {
-        accepted = operation.entityId;
+        pending = operation;
         return { opId: operation.opId, entityId: operation.entityId, accepted: true as const };
       }),
     flush: (reason) => Effect.tryPromise({
       try: async (): Promise<FlushReport> => {
-        if (!accepted) return { reason, opCount: 0, committed: false };
-        settled ??= submission.submit({
-          ...input,
-          canonicalEntityId: commandMainEntityId(input.command) ?? accepted
-        });
+        if (!pending) return { reason, opCount: 0, committed: false };
+        const provenanceSession = isCreateProvenanceSessionOperation(input, pending);
+        if (provenanceSession && provenanceCommitted) {
+          throw authorityWriteRejected("AUTHORITY_COMMAND_REQUIRES_SINGLE_PROVENANCE_SESSION");
+        }
+        if (provenanceSession && !submission.submitProvenanceSession) {
+          throw authorityWriteRejected("AUTHORITY_PROVENANCE_SESSION_SUBMISSION_UNAVAILABLE");
+        }
+        settled ??= provenanceSession
+          ? submission.submitProvenanceSession!({ ...input, operation: pending })
+          : submission.submit({
+            ...input,
+            canonicalEntityId: commandMainEntityId(input.command) ?? pending.entityId
+          });
         const receipt = await settled;
-        return receiptToFlushReport(receipt, reason);
+        const report = receiptToFlushReport(receipt, reason);
+        pending = undefined;
+        settled = undefined;
+        if (provenanceSession) provenanceCommitted = true;
+        else mainCommitted = true;
+        return report;
       },
       catch: authoritySubmissionWriteError
     }),
     recover: Effect.succeed({ replayedOps: 0 } satisfies RecoveryReport)
   };
+}
+
+function isCreateProvenanceSessionOperation(
+  input: { readonly command: ParsedCommand; readonly currentSession: CurrentSessionRef },
+  operation: WriteOp
+): boolean {
+  return input.command.action.kind === "new-task"
+    && operation.entityId === `entity/session/${input.currentSession.sessionId}`;
 }
 
 function commandMainEntityId(command: ParsedCommand): WriteOp["entityId"] | undefined {

--- a/packages/cli/src/daemon/production-authority-attempt-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-attempt-compiler.ts
@@ -31,7 +31,8 @@ import {
   type CanonicalCborValue,
   type DecisionPackage,
   type EntityRelationRecord,
-  type RegistryEntityRefV2
+  type RegistryEntityRefV2,
+  type WriteOp
 } from "../../../kernel/src/index.ts";
 import type { ParsedCommand } from "../cli/types.ts";
 import type { AuthorityConnectionContext } from "../../../daemon/src/index.ts";
@@ -45,6 +46,7 @@ import { productionLifecycleAttemptIntent } from "./production-authority-lifecyc
 import { defaultCliAdapterProvider } from "../composition/adapter-registry.ts";
 import { buildAuthorityPresetTaskCreateWrites, shouldUsePresetAwareNewTask } from "../commands/preset-task.ts";
 import { readProjectHarnessSettings, shouldUseSettingsPresetAwareNewTask } from "../commands/settings.ts";
+import { provenanceSessionAttemptIntent } from "./production-authority-provenance-session-intent.ts";
 
 type KeyMaterial = ReturnType<typeof openAuthorityProductionKeyMaterial>;
 
@@ -74,9 +76,13 @@ export function createProductionCanonicalAttemptCompiler(input: {
   readonly context: AuthorityConnectionContext;
   readonly authoredRoot: string;
 }): DaemonAuthorityAttemptCompilerV2 {
-  return {
-    compile: async ({ command, attribution, currentSession, canonicalEntityId }) => {
-      const intent = await canonicalAttemptIntent(command, currentSession, canonicalEntityId, input.authoredRoot, attribution.writeAttribution.actor);
+  const compileIntent = async (
+    command: ParsedCommand,
+    attribution: Parameters<DaemonAuthorityAttemptCompilerV2["compile"]>[0]["attribution"],
+    currentSession: Parameters<DaemonAuthorityAttemptCompilerV2["compile"]>[0]["currentSession"],
+    canonicalEntityId: WriteOp["entityId"],
+    intent: CanonicalAttemptIntent | null
+  ) => {
       if (!intent) {
         throw new Error(
           `AUTHORITY_TYPED_COMMAND_UNSUPPORTED: production canonical ingress rejected ${command.action.kind}; ` +
@@ -185,7 +191,19 @@ export function createProductionCanonicalAttemptCompiler(input: {
         presentationToken: token,
         envelope: encodeSemanticMutationEnvelopeV2(envelope)
       };
-    }
+  };
+  return {
+    compile: async ({ command, attribution, currentSession, canonicalEntityId }) => {
+      const intent = await canonicalAttemptIntent(command, currentSession, canonicalEntityId, input.authoredRoot, attribution.writeAttribution.actor);
+      return compileIntent(command, attribution, currentSession, canonicalEntityId, intent);
+    },
+    compileProvenanceSession: async ({ command, attribution, currentSession, operation }) => compileIntent(
+      command,
+      attribution,
+      currentSession,
+      operation.entityId,
+      provenanceSessionAttemptIntent(command, currentSession, operation)
+    )
   };
 }
 

--- a/packages/cli/src/daemon/production-authority-lifecycle.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle.ts
@@ -367,6 +367,9 @@ function createRepoComponent(
       });
       const binding: AuthorityRepoConnectionBinding = {
         submit: commandSubmission.submit,
+        ...(commandSubmission.submitProvenanceSession ? {
+          submitProvenanceSession: commandSubmission.submitProvenanceSession
+        } : {}),
         serveForcedCommand: ({ input: readable, output }) => {
           const session = serveAuthorityForcedCommand({
             input: readable,

--- a/packages/cli/src/daemon/production-authority-provenance-session-intent.ts
+++ b/packages/cli/src/daemon/production-authority-provenance-session-intent.ts
@@ -1,0 +1,117 @@
+import {
+  encodeSessionExecutionReviewCommandPayloadV2,
+  type SessionExecutionReviewCommandPayloadV2
+} from "../../../application/src/index.ts";
+import {
+  readContentAddressedTextBlob,
+  type CurrentSessionRef,
+  type RegistryEntityRefV2,
+  type SessionManifest,
+  type WriteOp
+} from "../../../kernel/src/index.ts";
+import type { ParsedCommand } from "../cli/types.ts";
+import type { CanonicalAttemptIntent } from "./production-authority-attempt-compiler.ts";
+
+export function provenanceSessionAttemptIntent(
+  command: ParsedCommand,
+  currentSession: CurrentSessionRef,
+  operation: WriteOp
+): CanonicalAttemptIntent {
+  const expectedEntityId = `entity/session/${currentSession.sessionId}`;
+  if (command.action.kind !== "new-task" || operation.entityId !== expectedEntityId || operation.kind !== "doc_write") {
+    throw new Error("AUTHORITY_CREATE_PROVENANCE_OPERATION_INVALID");
+  }
+  const payload = plainRecord(operation.payload);
+  const document = plainRecord(payload?.entityDocument);
+  const declaration = plainRecord(document?.declaration);
+  const rootResolver = plainRecord(declaration?.rootResolver);
+  const identity = plainRecord(document?.identity);
+  const blobRef = plainRecord(document?.blobRef);
+  if (!payload || !document || !declaration || !rootResolver || !identity || !blobRef
+    || Object.keys(payload).some((key) => key !== "entityDocument")
+    || Object.keys(document).some((key) => !["declaration", "identity", "body", "blobRef"].includes(key))
+    || declaration.kind !== "session"
+    || declaration.storageForm !== "composite-manifest-blob"
+    || rootResolver.pathTemplate !== "sessions/{sessionId}.md"
+    || !Array.isArray(rootResolver.identity)
+    || rootResolver.identity.length !== 1
+    || rootResolver.identity[0] !== "sessionId"
+    || Object.keys(identity).length !== 1
+    || identity.sessionId !== currentSession.sessionId
+    || typeof document.body !== "string") {
+    throw new Error("AUTHORITY_CREATE_PROVENANCE_OPERATION_INVALID");
+  }
+  let decodedManifest: unknown;
+  try {
+    decodedManifest = JSON.parse(document.body);
+  } catch {
+    throw new Error("AUTHORITY_CREATE_PROVENANCE_MANIFEST_INVALID");
+  }
+  const manifestRecord = plainRecord(decodedManifest);
+  const manifestBodyRef = plainRecord(manifestRecord?.bodyRef);
+  if (!manifestRecord || !manifestBodyRef
+    || manifestRecord.schema !== "session-entity/v1"
+    || manifestRecord.sessionId !== currentSession.sessionId
+    || manifestRecord.runtime !== currentSession.runtime
+    || manifestRecord.source !== currentSession.source
+    || manifestRecord.detectedAt !== currentSession.detectedAt
+    || (manifestRecord.user ?? undefined) !== (currentSession.user ?? undefined)
+    || manifestBodyRef.store !== "authored-cas/v1"
+    || manifestBodyRef.ref !== blobRef.ref
+    || manifestBodyRef.sha256 !== blobRef.sha256
+    || manifestBodyRef.size !== blobRef.size
+    || manifestBodyRef.mediaType !== blobRef.mediaType) {
+    throw new Error("AUTHORITY_CREATE_PROVENANCE_MANIFEST_INVALID");
+  }
+  const manifest = decodedManifest as SessionManifest;
+  const descriptor = {
+    ref: requiredString(blobRef.ref),
+    sha256: requiredString(blobRef.sha256),
+    size: requiredSafeSize(blobRef.size),
+    mediaType: requiredString(blobRef.mediaType)
+  };
+  const body = readContentAddressedTextBlob({
+    rootDir: command.rootDir,
+    ...(command.layoutOverrides ? { layoutOverrides: command.layoutOverrides } : {})
+  }, descriptor);
+  const entity = sessionRef(currentSession.sessionId);
+  const semanticPayload: SessionExecutionReviewCommandPayloadV2 = {
+    schema: "session.export/v1",
+    manifest,
+    body
+  };
+  return {
+    commandName: "session.export",
+    payload: encodeSessionExecutionReviewCommandPayloadV2(semanticPayload),
+    mutations: [{ entity, action: "export" }],
+    baseRefs: [entity],
+    portablePaths: [
+      `sessions/${currentSession.sessionId}.md`,
+      `objects/sha256/${descriptor.sha256.slice(0, 2)}/${descriptor.sha256.slice(2)}`
+    ],
+    declaredPathCas: [],
+    physicalEntityId: expectedEntityId
+  };
+}
+
+function sessionRef(sessionId: string): RegistryEntityRefV2 {
+  return { registryVersion: 1, entityKind: "session", canonicalRef: `session/${sessionId}` };
+}
+
+function plainRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function requiredString(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error("AUTHORITY_CREATE_PROVENANCE_BLOB_REF_INVALID");
+  return value;
+}
+
+function requiredSafeSize(value: unknown): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error("AUTHORITY_CREATE_PROVENANCE_BLOB_REF_INVALID");
+  }
+  return value;
+}

--- a/packages/cli/src/daemon/service-host.ts
+++ b/packages/cli/src/daemon/service-host.ts
@@ -505,7 +505,13 @@ export function bindAuthoritySubmissionForDispatch(
     submit: async (submission) => {
       dispatch.assertActive();
       return bound.submit(submission);
-    }
+    },
+    ...(bound.submitProvenanceSession ? {
+      submitProvenanceSession: async (submission: Parameters<NonNullable<typeof bound.submitProvenanceSession>>[0]) => {
+        dispatch.assertActive();
+        return bound.submitProvenanceSession!(submission);
+      }
+    } : {})
   };
 }
 

--- a/packages/cli/test/authority-amendment3-seam.test.ts
+++ b/packages/cli/test/authority-amendment3-seam.test.ts
@@ -10,19 +10,17 @@ import {
   type AuthorityLifecycleRuntime
 } from "../src/daemon/authority-lifecycle.ts";
 
-test("task create binds authority submission to command intent when a session provenance op arrives first", async () => {
+test("cold task create submits provenance session and task as two ordered canonical operations", async () => {
   const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG9";
-  let submittedEntityId: string | undefined;
+  const submittedEntityIds: string[] = [];
   const coordinator = makeDaemonAuthorityWriteCoordinator({
+    submitProvenanceSession: async (input) => {
+      submittedEntityIds.push(input.operation.entityId);
+      return committedReceipt("fixture-session-op", 1);
+    },
     submit: async (input) => {
-      submittedEntityId = input.canonicalEntityId;
-      return {
-        tag: "REJECTED",
-        workspaceId: "workspace-command-service",
-        opId: "fixture-op",
-        semanticDigest: "11".repeat(32),
-        reason: "fixture terminal receipt"
-      };
+      submittedEntityIds.push(input.canonicalEntityId);
+      return committedReceipt("fixture-task-op", 2);
     }
   }, {
     command: {
@@ -59,11 +57,26 @@ test("task create binds authority submission to command intent when a session pr
   await runEffect(coordinator.enqueue({
     opId: "session-provenance-op",
     entityId: "entity/session/session-provenance-first",
-    kind: "machine_artifact_write",
+    kind: "doc_write",
     payload: {}
   }));
-  await assert.rejects(runEffect(coordinator.flush("explicit")), /fixture terminal receipt/u);
-  assert.equal(submittedEntityId, taskEntityId(taskId));
+  const sessionFlush = await runEffect(coordinator.flush("explicit"));
+  await runEffect(coordinator.enqueue({
+    opId: "task-create-op",
+    entityId: taskEntityId(taskId),
+    kind: "package_create",
+    payload: {}
+  }));
+  const taskFlush = await runEffect(coordinator.flush("explicit"));
+
+  assert.deepEqual(submittedEntityIds, ["entity/session/session-provenance-first", taskEntityId(taskId)]);
+  assert.equal(sessionFlush.opCount, 1);
+  assert.equal(taskFlush.opCount, 1);
+  await assert.rejects(runEffect(coordinator.enqueue({
+    opId: "unexpected-third-op",
+    entityId: taskEntityId(taskId),
+    kind: "package_create"
+  })), /AUTHORITY_COMMAND_REQUIRES_SINGLE_CANONICAL_OPERATION/u);
 });
 
 test("held-lock authority flush uses one atomic publication instead of direct materialization", async () => {
@@ -156,4 +169,16 @@ function runEffect<A, E>(effect: Effect.Effect<A, E>): Promise<A> {
       onExit: (exit) => exit._tag === "Success" ? resolve(exit.value) : reject(new Error(String(exit.cause)))
     });
   });
+}
+
+function committedReceipt(opId: string, revision: number) {
+  return {
+    tag: "COMMITTED" as const,
+    workspaceId: "workspace-command-service",
+    opId,
+    semanticDigest: "11".repeat(32),
+    revision,
+    commitSha: String(revision).repeat(40),
+    previousCommit: revision === 1 ? null : "1".repeat(40)
+  };
 }

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -36,11 +36,13 @@ import {
   authorityEventBodies,
   authorityOperationRecords,
   createFixture,
+  enablePresetAwareTaskCreate,
   git,
-  latestAuthorityOperation
+  latestAuthorityOperation,
+  writeColdCodexSessionLog
 } from "./fixture.ts";
 
-test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 60_000 }, async () => {
+test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 90_000 }, async () => {
   const fixture = createFixture();
   const userRoot = defaultDaemonUserRoot(fixture.root);
   const env = {
@@ -51,6 +53,7 @@ test("production service route preserves progress dry-run and publishes canonica
     HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"
   };
   try {
+    enablePresetAwareTaskCreate(fixture.authoredRoot);
     for (const [repoId, canonicalRoot] of [
       ["canonical", fixture.repoRoot],
       ["auxiliary", fixture.auxiliaryRoot]
@@ -114,9 +117,13 @@ test("production service route preserves progress dry-run and publishes canonica
     git(fixture.authoredRoot, "diff", "--quiet", publication.commitSha, publication.parentCommits[1]!);
     assert.equal(dryRunHeadAfter, dryRunHead, "typed service dry-run must not create a commit");
 
+    const bareSessionId = "service-task-create-session";
+    writeColdCodexSessionLog(fixture.repoRoot, bareSessionId);
+    assert.equal(existsSync(path.join(fixture.authoredRoot, `sessions/${bareSessionId}.md`)), false);
+    const beforeColdBare = authorityOperationRecords(fixture.serviceRoot).length;
     const created = runRawJsonMaybeFail(fixture.repoRoot, [
       "task", "create", "--title", "Service route task create"
-    ], { ...env, CODEX_THREAD_ID: "service-task-create-session" });
+    ], { ...env, CODEX_THREAD_ID: bareSessionId });
     assert.equal(created.status, 0, JSON.stringify(created.receipt));
     assert.equal(created.receipt.ok, true, JSON.stringify(created.receipt));
     const createDetails = (created.receipt.details as { readonly data?: Record<string, unknown> } | undefined)?.data ?? {};
@@ -134,10 +141,24 @@ test("production service route preserves progress dry-run and publishes canonica
     assert.equal(createPublication.commitSha, createOperation.commitSha);
     assert.equal(createPublication.physicalChanges.filter((change) => change.path.startsWith("attribution-events/")).length, 1);
     assert.equal(authorityEventBodies(fixture.authoredRoot).filter((body) => body.includes(createOperation.opId!)).length, 1);
+    assert.equal(existsSync(path.join(fixture.authoredRoot, `sessions/${bareSessionId}.md`)), true);
+    assert.equal(authorityOperationRecords(fixture.serviceRoot).length, beforeColdBare + 2, "cold bare create must commit session.export then task.create");
 
+    const beforeHotBare = authorityOperationRecords(fixture.serviceRoot).length;
+    const hotCreated = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "create", "--title", "Service route hot-session task create"
+    ], { ...env, CODEX_THREAD_ID: bareSessionId });
+    assert.equal(hotCreated.status, 0, JSON.stringify(hotCreated.receipt));
+    assert.equal(hotCreated.receipt.ok, true, JSON.stringify(hotCreated.receipt));
+    assert.equal(authorityOperationRecords(fixture.serviceRoot).length, beforeHotBare + 1, "hot bare create must commit only task.create");
+
+    const presetSessionId = "service-preset-task-create-session";
+    writeColdCodexSessionLog(fixture.repoRoot, presetSessionId);
+    assert.equal(existsSync(path.join(fixture.authoredRoot, `sessions/${presetSessionId}.md`)), false);
+    const beforeColdPreset = authorityOperationRecords(fixture.serviceRoot).length;
     const presetCreated = runRawJsonMaybeFail(fixture.repoRoot, [
       "task", "create", "--title", "Service route preset task", "--preset", "docs-task", "--locale", "en-US"
-    ], { ...env, CODEX_THREAD_ID: "service-preset-task-create-session" });
+    ], { ...env, CODEX_THREAD_ID: presetSessionId });
     assert.equal(presetCreated.status, 0, JSON.stringify(presetCreated.receipt));
     assert.equal(presetCreated.receipt.ok, true, JSON.stringify(presetCreated.receipt));
     const presetDetails = (presetCreated.receipt.details as { readonly data?: Record<string, unknown> } | undefined)?.data ?? {};
@@ -151,6 +172,16 @@ test("production service route preserves progress dry-run and publishes canonica
     assert.equal(presetOperation.state, "COMMITTED", JSON.stringify(presetOperation));
     assert.equal(presetOperation.receipt?.tag, "COMMITTED", JSON.stringify(presetOperation));
     assert.equal(authorityEventBodies(fixture.authoredRoot).filter((body) => body.includes(presetOperation.opId!)).length, 1);
+    assert.equal(existsSync(path.join(fixture.authoredRoot, `sessions/${presetSessionId}.md`)), true);
+    assert.equal(authorityOperationRecords(fixture.serviceRoot).length, beforeColdPreset + 2, "cold preset create must commit session.export then task.create");
+
+    const beforeHotPreset = authorityOperationRecords(fixture.serviceRoot).length;
+    const hotPresetCreated = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "create", "--title", "Service route hot-session preset task", "--preset", "docs-task", "--locale", "en-US"
+    ], { ...env, CODEX_THREAD_ID: presetSessionId });
+    assert.equal(hotPresetCreated.status, 0, JSON.stringify(hotPresetCreated.receipt));
+    assert.equal(hotPresetCreated.receipt.ok, true, JSON.stringify(hotPresetCreated.receipt));
+    assert.equal(authorityOperationRecords(fixture.serviceRoot).length, beforeHotPreset + 1, "hot preset create must commit only task.create");
 
     const concurrentSessionId = "service-interleaved-shared-session";
     const interleaved = await Promise.all(Array.from({ length: 6 }, (_, index) => runRawJsonAsync(fixture.repoRoot, [

--- a/packages/cli/test/production-authority-canonical-ingress/fixture.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/fixture.ts
@@ -84,6 +84,30 @@ export function createFixture() {
   return { root, repoRoot, authoredRoot, auxiliaryRoot, serviceRoot, manifestPath, actor, transcriptPath, publicHead };
 }
 
+export function enablePresetAwareTaskCreate(authoredRoot: string): void {
+  writeFileSync(path.join(authoredRoot, "harness.yaml"), [
+    "schema: harness-anything/v1",
+    "project: production-ingress",
+    "settings:",
+    "  defaultVertical: software/coding",
+    "  defaultPreset: docs-task",
+    "  locale: en-US",
+    ""
+  ].join("\n"));
+  git(authoredRoot, "add", "harness.yaml");
+  git(authoredRoot, "commit", "-q", "-m", "configure preset-aware task create fixture");
+}
+
+export function writeColdCodexSessionLog(repoRoot: string, sessionId: string): void {
+  const logRoot = path.join(repoRoot, ".home", ".codex", "sessions", "2026", "07", "18");
+  mkdirSync(logRoot, { recursive: true });
+  writeFileSync(path.join(logRoot, `rollout-2026-07-18T00-00-00-${sessionId}.jsonl`), `${JSON.stringify({
+    timestamp: "2026-07-18T00:00:00.000Z",
+    type: "event_msg",
+    payload: { type: "user_message", message: `Cold production session ${sessionId}.` }
+  })}\n`);
+}
+
 export function latestAuthorityOperation(serviceRoot: string): { readonly state?: string; readonly opId?: string; readonly commitSha?: string; readonly receipt?: { readonly tag?: string } } {
   const rows = readFileSync(operationPath(serviceRoot), "utf8").trim().split("\n")
     .map((line) => JSON.parse(line) as { readonly table?: string; readonly value?: Record<string, unknown> })

--- a/packages/cli/test/production-authority-event-recovery.test.ts
+++ b/packages/cli/test/production-authority-event-recovery.test.ts
@@ -277,6 +277,69 @@ test("restart recovery terminalizes only an indeterminate operation proven absen
   assert.match(durable.receipt?.tag === "REJECTED" ? durable.receipt.reason : "", /authority publication cannot mix/u);
 });
 
+test("incremental recovery advances its watermark only after an absent indeterminate op is terminal", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-authority-recovery-terminal-watermark-"));
+  const watermarkPath = path.join(root, "recovery-watermark.json");
+  const head = "b".repeat(40);
+  let durable: AuthorityStoredOperationRecord = {
+    workspaceId: "workspace-production",
+    opId: "namespace-production:absent-before-watermark",
+    semanticDigest: "a".repeat(64),
+    state: "INDETERMINATE",
+    receipt: {
+      tag: "INDETERMINATE",
+      workspaceId: "workspace-production",
+      opId: "namespace-production:absent-before-watermark",
+      semanticDigest: "a".repeat(64),
+      reason: "PUBLICATION_OUTCOME_UNKNOWN:test"
+    },
+    authorityIntegrity: {
+      schema: "authority-operation-integrity/v2",
+      semanticRequestDigest: "a".repeat(64), semanticMutationSetDigest: "c".repeat(64),
+      mutationRegistryVersion: 1, actorAxesBindingDigest: "d".repeat(64),
+      canonicalMutationSet: { registryVersion: 1, mutations: [{
+        entity: { registryVersion: 1, entityKind: "task", canonicalRef: "task/task_RECOVERY" },
+        action: { registryVersion: 1, action: "append" }
+      }] }
+    },
+    recordedProtocol: { kind: "semantic-mutation-envelope/v2", schemaTuple: {
+      wire: 2, event: 2, receipt: 2, digest: 2, policy: 2,
+      commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
+    } },
+    canonicalRequestEnvelope: "durable-envelope"
+  };
+  let terminalized = false;
+  try {
+    await recoverPendingProductionEvents({
+      workspaceId: durable.workspaceId,
+      operationRegistry: {
+        get: async () => durable,
+        list: async () => [durable],
+        put: async (next) => {
+          if (next.state === "REJECTED") {
+            assert.equal(existsSync(watermarkPath), false, "watermark must not precede terminalization");
+            terminalized = true;
+          }
+          durable = next;
+        }
+      },
+      replicaChangeLog: {} as import("../../application/src/index.ts").ReplicaChangeLog,
+      eventLog: {} as ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>,
+      publicationInspector: {
+        scanFirstParentOperationAnchors: async () => ({ headCommit: head, scannedCommitCount: 400, anchors: [] })
+      } as ReturnType<typeof createGitCanonicalPublicationInspector>,
+      recover: async () => { throw new Error("absent operation must not recover"); },
+      watermarkPath
+    });
+
+    assert.equal(terminalized, true);
+    assert.equal(durable.state, "REJECTED");
+    assert.equal(JSON.parse(readFileSync(watermarkPath, "utf8")).commitSha, head);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("recovery watermark falls back on missing or corrupt state and then scans only the first-parent increment", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-authority-recovery-watermark-"));
   const watermarkPath = path.join(root, "recovery-watermark.json");


### PR DESCRIPTION
# English

## Summary

W6 defect D21, exposed by the cold-session regression matrix after #895: `task create` in a session with no prior provenance export failed because the provenance sub-write hit the daemon coordinator's `AUTHORITY_COMMAND_REQUIRES_SINGLE_CANONICAL_OPERATION` guard when it enqueued alongside the task-create operation. Warm sessions (provenance already exported) worked, so the worker fixture matrix missed it until cold-session state became a standard regression requirement.

## What Changed

- Cold-session provenance is now compiled and submitted as an independent `session.export` V2 operation with its own complete entity/tree/commit/mutation-set proofs (`production-authority-provenance-session-intent.ts`); the `task.create` operation submits only after it succeeds.
- The coordinator accepts the ordered pair (provenance session operation, then main operation) while rejecting any second operation of the same class: `AUTHORITY_COMMAND_REQUIRES_SINGLE_PROVENANCE_SESSION` guards double provenance submission, and the original single-canonical-operation guard still protects the main slot.
- 232s startup observation investigated, not reproduced: the 800-commit fixture reaches the socket in 1.374s cold and 1.389s on incremental restart; the observation is consistent with a one-time full cold scan before the recovery watermark first existed, or with reading authority write-gate release time as socket availability.

## Task And Scope

- W6 cutover line task_01KXMN5BRWQH93976XBZSHSCN4; sixth re-enable remains open (admission open, failures clean-rejecting). Stacked on merged #896 main.
- Production state untouched; deploy + daemon restart + cold-session smoke remain operator actions.

## Version Impact

- No published package version change.

## Governance Declaration

- Authority anchor: task_01KXMN5BRWQH93976XBZSHSCN4; standing W6 fix-then-cut authorization.
- Protected paths touched: none (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `tools/test-tier-manifest.mjs`, `harness/**` untouched).
- No gate weakening: entity/commit/tree/mutation-set proofs unchanged; each of the two operations carries full proofs; the single-operation guard remains active per operation class.

## Verification

- Real CLI→daemon production-same-path regressions cover bare and `--preset docs-task` creates in both cold and warm sessions: cold sessions produce exactly two `COMMITTED` operations (session.export then task.create), warm sessions exactly one, and every operation emits exactly one authority event.
- Red control: with the guard change reverted, the cold-session bare create reproduces `AUTHORITY_COMMAND_REQUIRES_SINGLE_CANONICAL_OPERATION`.
- Focused suite 14/14; root `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 (32 manifest gates green; fast 253/253, contract 71/71).

## Review Evidence

- CEO semantic acceptance: the fix preserves one-canonical-entity-per-operation rather than widening a submission to multiple entities; provenance becomes a first-class operation instead of a piggybacked sub-write; double-submission guards retained — confirmed in diff and report.

## Residual Risk

- A cold-session create now performs two serialized authority publications; latency of the first create in a fresh session doubles (bounded, observed sub-second in fixtures).
- If the provenance operation commits but the task operation fails, the session export remains durably committed — harmless and idempotent for later creates.
- Production restart timing validation remains operator-owned.

## References

- PRs #883, #889, #894, #895 (D14–D18 chain).
- Worker report: `tmp/orch/w6-d15-perf/REPORT.md` § D21.

---

# 中文

## 概要

W6 缺陷 D21，由 #895 之后的冷 session 回归矩阵暴露：在没有先行 provenance 导出的 session 里执行 `task create` 会失败——provenance 子写与 task-create 操作同时入队时，撞上 daemon coordinator 的 `AUTHORITY_COMMAND_REQUIRES_SINGLE_CANONICAL_OPERATION` 守卫。热 session（provenance 已导出）正常，所以在冷 session 状态成为标准回归要求之前，worker 夹具矩阵一直漏掉它。

## 改动内容

- 冷 session 的 provenance 现在编译并提交为独立的 `session.export` V2 操作，携带自身完整的 entity/tree/commit/mutation-set 证明（`production-authority-provenance-session-intent.ts`）；`task.create` 操作在其成功后才提交。
- coordinator 接受有序对（provenance session 操作在前、主操作在后），同类第二个操作仍被拒绝：`AUTHORITY_COMMAND_REQUIRES_SINGLE_PROVENANCE_SESSION` 防止 provenance 重复提交，原有单 canonical 操作守卫继续保护主槽位。
- 232s 启动观测已调查、未复现：800-commit 夹具冷启动 1.374s 达 socket、增量重启 1.389s；该观测与恢复水位首次建立前的一次性全量冷扫一致，或是把 authority 写闸释放时间误读为 socket 可达时间。

## 任务与范围

- W6 cutover 线 task_01KXMN5BRWQH93976XBZSHSCN4；第六轮 re-enable 保持开启（admission 开放，失败均为干净拒绝）。基于已合并的 #896 main。
- 生产状态未触碰；部署、daemon 重启与冷 session 冒烟归 operator。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 授权锚：task_01KXMN5BRWQH93976XBZSHSCN4；W6 fix-then-cut 常设授权。
- 未触碰受保护路径（`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`tools/test-tier-manifest.mjs`、`harness/**` 均未动）。
- 无门禁削弱：entity/commit/tree/mutation-set 证明不变；两个操作各自携带完整证明；单操作守卫按操作类别继续生效。

## 验证

- 真实 CLI→daemon 生产同路径回归覆盖裸建与 `--preset docs-task` 建任务的冷/热两种 session：冷 session 恰好产生两个 `COMMITTED` 操作（先 session.export 后 task.create），热 session 恰好一个，且每个操作恰好发出一条 authority event。
- 红对照：还原守卫改动后，冷 session 裸建复现 `AUTHORITY_COMMAND_REQUIRES_SINGLE_CANONICAL_OPERATION`。
- 聚焦套件 14/14；根 `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0（32 个本地 manifest gate 全绿；fast 253/253，contract 71/71）。

## 审查证据

- CEO 语义验收：修复保持"每操作一个 canonical entity"而非把一次提交扩成多实体；provenance 升为一等操作而非搭车子写；重复提交守卫保留——已对照 diff 与报告确认。

## 残余风险

- 冷 session 建任务现在执行两次串行 authority 发布；新 session 首次建任务延迟翻倍（有界，夹具内亚秒级）。
- 若 provenance 操作已提交而 task 操作失败，session export 保持已提交状态——无害且对后续建任务幂等。
- 生产重启计时验证归 operator。

## 关联材料

- PR #883、#889、#894、#895（D14–D18 链）。
- Worker 报告：`tmp/orch/w6-d15-perf/REPORT.md` § D21。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
