### PR TITLE
fix(authority): close decision vocabulary and slugged lifecycle gaps (D19/D20)

### DIFF
--- a/packages/application/src/authority/session-execution-review-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/session-execution-review-semantic-compiler-v2.ts
@@ -139,11 +139,16 @@ async function compileExecution(
   const taskPath = `tasks/${encodeURIComponent(payload.taskId)}/INDEX.md`;
   const taskSnapshot = payload.taskIndexBody === undefined ? null : await state.readHostedDocument(taskPath);
   if (payload.taskIndexBody !== undefined) {
-    if (action !== "close" || execution.state !== "accepted" || !taskSnapshot) {
+    if (!taskSnapshot || !(
+      (action === "close" && execution.state === "accepted")
+      || (action === "submit" && execution.state === "submitted")
+    )) {
       throw admission("EXECUTION_COMPLETION_TRANSACTION_INVALID");
     }
-    const expected = taskSnapshot.body.replace(/^(  status:\s*).+$/mu, "$1done");
-    if (!/^  status:\s*in_review$/mu.test(taskSnapshot.body) || payload.taskIndexBody !== expected) {
+    const fromStatus = action === "close" ? "in_review" : "active";
+    const toStatus = action === "close" ? "done" : "in_review";
+    const expected = taskSnapshot.body.replace(/^(  status:\s*).+$/mu, `$1${toStatus}`);
+    if (!new RegExp(`^  status:\\s*${fromStatus}$`, "mu").test(taskSnapshot.body) || payload.taskIndexBody !== expected) {
       throw admission("EXECUTION_COMPLETION_TASK_TRANSITION_INVALID");
     }
   }

--- a/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
@@ -1,6 +1,7 @@
 import {
   DecisionPackageSchema,
   decisionEntityId,
+  decisionSemanticMutationActions,
   decisionFieldContracts,
   deriveRelationId,
   entityRegistry,
@@ -212,7 +213,7 @@ function compileDecisionPropose(payload: DecisionProposePayloadV2): CompiledTask
   const relationMutations = decision.relations.map(relationCreateIntent);
   return {
     mutationPlan: taskDecisionModulePlan([
-      { entityKind: "decision", identity: { decisionId: decision.decision_id }, action: "propose" },
+      { entityKind: "decision", identity: { decisionId: decision.decision_id }, action: decisionSemanticMutationActions.propose },
       ...relationMutations
     ]),
     operation: decisionOperation("decision_propose", decision, payload.body),
@@ -244,7 +245,7 @@ async function compileDecisionState(
   if (payload.transition === "accept") allowedStateFields.push("claims", "decisionClass");
   assertOnlyDecisionFieldsChanged(current, next, new Set(allowedStateFields));
   return {
-    mutationPlan: taskDecisionModulePlan([{ entityKind: "decision", identity: { decisionId: next.decision_id }, action: "state" }]),
+    mutationPlan: taskDecisionModulePlan([{ entityKind: "decision", identity: { decisionId: next.decision_id }, action: decisionSemanticMutationActions.state }]),
     operation: decisionOperation(`decision_${payload.transition}` as WriteOpKind, next, payload.body, current),
     requiredBaseRefs: [taskDecisionModuleEntityRef("decision", `decision/${next.decision_id}`)],
     requiredPathSnapshots: [{ path, snapshot }]
@@ -265,7 +266,7 @@ async function compileDecisionAmend(
     throw admission("DECISION_AMEND_FIELD_INVALID");
   }
   return {
-    mutationPlan: taskDecisionModulePlan([{ entityKind: "decision", identity: { decisionId: next.decision_id }, action: "amend" }]),
+    mutationPlan: taskDecisionModulePlan([{ entityKind: "decision", identity: { decisionId: next.decision_id }, action: decisionSemanticMutationActions.amend }]),
     operation: decisionOperation("decision_amend", next, payload.body, current),
     requiredBaseRefs: [taskDecisionModuleEntityRef("decision", `decision/${next.decision_id}`)],
     requiredPathSnapshots: [{ path, snapshot }]

--- a/packages/application/src/decision-write-service.ts
+++ b/packages/application/src/decision-write-service.ts
@@ -6,6 +6,7 @@ import {
   decisionContentDigestFields,
   decisionFieldContracts,
   decisionEntityId,
+  decisionSemanticMutationActions,
   evaluateEntityDisposition,
   explainDecisionStateTransition,
   validateRelationRecordsForHost,
@@ -481,7 +482,8 @@ function assertIndependentJudgmentActor(options: DecisionWriteServiceOptions, de
     const propose = events.find((event) => event.schema === "attribution-event/v1"
       ? event.kind === "decision_propose" && (event.entityId === decisionId || event.entityId === `decision/${decisionId}`)
       : event.mutationSet.mutations.some((mutation) =>
-          mutation.action.action === "decision_propose" && mutation.entity.canonicalRef === `decision/${decisionId}`));
+          mutation.action.action === decisionSemanticMutationActions.propose
+          && mutation.entity.canonicalRef === `decision/${decisionId}`));
     // 溯源仍然 fail-closed,对谁都一样:判定前必须能验到那条不可变的 propose 事件。
     // 下面豁免的只是「判定者与提议者不得同一」,不是「提议事件必须存在」。
     if (!propose) return rejection(decisionId, "decision judgment requires an immutable decision_propose attribution event");

--- a/packages/application/test/decision-v2-attribution.test.ts
+++ b/packages/application/test/decision-v2-attribution.test.ts
@@ -1,0 +1,91 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Effect } from "effect";
+import { makeDecisionWriteService } from "../src/index.ts";
+import type {
+  DecisionPackage,
+  UnionAttributionEvent,
+  WriteAttribution,
+  WriteCoordinator,
+  WriteOp
+} from "../../kernel/src/index.ts";
+
+const humanAttribution: WriteAttribution = {
+  actor: { principal: { kind: "person", personId: "person_zeyu" }, executor: null },
+  principalSource: { kind: "migration", evidenceRef: "v2-upgrade-fixture" },
+  executorSource: "none"
+};
+
+test("a human may judge from an existing V2 propose mutation event", () => {
+  const enqueued: WriteOp[] = [];
+  const service = serviceForAction("propose", enqueued);
+
+  const result = Effect.runSync(service.accept({
+    current: decision(),
+    judgmentOnlyRationale: "The existing V2 event proves the proposal origin.",
+    opIdPrefix: "accept"
+  }));
+
+  assert.deepEqual(result, { decisionId: "dec_TEST", state: "active" });
+  assert.equal(enqueued.length, 1);
+});
+
+test("V2 judgment does not accept the legacy decision_propose WriteOp kind as a mutation action", () => {
+  const result = Effect.runSync(serviceForAction("decision_propose", []).accept({
+    current: decision(),
+    judgmentOnlyRationale: "Aliases must not widen V2 admission."
+  }).pipe(Effect.either));
+
+  assert.equal(result._tag, "Left");
+  if (result._tag === "Left") {
+    assert.match(result.left.reason, /requires an immutable decision_propose attribution event/u);
+  }
+});
+
+function serviceForAction(action: string, enqueued: WriteOp[]) {
+  const event = {
+    schema: "attribution-event/v2",
+    actorAxesBinding: { principalPersonId: "person_author", executorAgentId: "claude" },
+    mutationSet: {
+      mutations: [{ entity: { canonicalRef: "decision/dec_TEST" }, action: { action } }]
+    }
+  } as unknown as UnionAttributionEvent;
+  return makeDecisionWriteService({
+    coordinator: coordinator(enqueued),
+    attribution: humanAttribution,
+    readUnionAttributionEvents: () => [event]
+  });
+}
+
+function coordinator(enqueued: WriteOp[]): WriteCoordinator {
+  return {
+    enqueue: (operation) => Effect.sync(() => {
+      enqueued.push(operation);
+      return { opId: operation.opId, entityId: operation.entityId, accepted: true as const };
+    }),
+    flush: (reason) => Effect.succeed({ reason, opCount: enqueued.length, committed: true }),
+    recover: Effect.succeed({ replayedOps: 0 })
+  };
+}
+
+function decision(): DecisionPackage {
+  return {
+    schema: "decision-package/v1",
+    decision_id: "dec_TEST",
+    title: "V2 attribution vocabulary",
+    state: "proposed",
+    riskTier: "medium",
+    urgency: "medium",
+    vertical: "software/coding",
+    preset: "architecture-decision",
+    applies_to: { modules: ["cli"], productLines: [] },
+    proposedAt: "2026-07-18T00:00:00.000Z",
+    provenance: [{ runtime: "human", sessionId: "upgrade", boundAt: "2026-07-18T00:00:00.000Z" }],
+    question: "Should V2 use semantic actions?",
+    chosen: [{ id: "CH1", text: "Use propose" }],
+    rejected: [{ id: "RJ1", text: "Use decision_propose", why_not: "That is a V1 WriteOp kind" }],
+    claims: [{ id: "C1", text: "The event action is registry-defined" }],
+    relations: []
+  };
+}

--- a/packages/application/test/session-execution-review-semantic-compiler-v2.test.ts
+++ b/packages/application/test/session-execution-review-semantic-compiler-v2.test.ts
@@ -41,7 +41,8 @@ const stateDigest = Buffer.alloc(32, 0x11);
 const registry = createWritableEntityRegistry([
   entityRegistry.session,
   entityRegistry.execution,
-  entityRegistry.review
+  entityRegistry.review,
+  entityRegistry.task
 ]);
 
 test("session/execution/review register only OQ-3 actions and remain DEFER-TYPED-ONLY", () => {
@@ -140,6 +141,37 @@ test("execution claim/submit/close compile exact hosted execution document plans
     assert.deepEqual(planned.storagePlan.consistencyScopes, [`path:${path}`]);
     assert.equal(operationDocument(compiled.operation.payload).identity.executionId, executionId);
   }
+});
+
+test("execution submit atomically transitions the task index to in_review", async () => {
+  const executionRef = ref("execution", `execution/${taskId}/${executionId}`);
+  const taskRef = ref("task", `task/${taskId}`);
+  const executionPath = `tasks/${taskId}/executions/${executionId}.md`;
+  const taskPath = `tasks/${taskId}/INDEX.md`;
+  const active = snapshot(JSON.stringify(executionRecord("active")));
+  const activeIndex = snapshot("---\n  status: active\n---\n");
+  const inReviewIndex = activeIndex.body.replace("status: active", "status: in_review");
+  const compiled = await makeSessionExecutionReviewSemanticCompilerV2({
+    state: authorityState(
+      new Map([[key(executionRef), base("execution-v1")], [key(taskRef), base("task-v1")]]),
+      new Map([[executionPath, active], [taskPath, activeIndex]])
+    )
+  }).compile(envelope({
+    schema: "execution.submit/v1",
+    taskId,
+    execution: executionRecord("submitted"),
+    taskIndexBody: inReviewIndex
+  }, [present(executionRef, "execution-v1"), present(taskRef, "task-v1")], [
+    cas(executionPath, active), cas(taskPath, activeIndex)
+  ]));
+
+  const planned = compileRegistryMutationPlan(registry, compiled.mutationPlan);
+  assert.deepEqual(planned.mutationSet.mutations.map(pair).sort(), [
+    `execution/${taskId}/${executionId}:submit`, `task/${taskId}:transition`
+  ].sort());
+  assert.deepEqual((compiled.operation.payload as { readonly companionWrites?: unknown }).companionWrites, [
+    { taskId, path: "INDEX.md", body: inReviewIndex }
+  ]);
 });
 
 test("review create/dismiss/record compile immutable hosted review documents without task-host attribution", async () => {

--- a/packages/cli/src/daemon/authority-command-submission.ts
+++ b/packages/cli/src/daemon/authority-command-submission.ts
@@ -38,6 +38,12 @@ export interface DaemonAuthorityAttemptCompilerV2 {
     readonly currentSession: CurrentSessionRef;
     readonly operation: WriteOp;
   }) => Promise<AuthorizedOperationAttemptV2>;
+  readonly compileDecisionTransition?: (input: {
+    readonly command: ParsedCommand;
+    readonly attribution: CliActorAttribution;
+    readonly currentSession: CurrentSessionRef;
+    readonly operation: WriteOp;
+  }) => Promise<AuthorizedOperationAttemptV2>;
 }
 
 export interface DaemonAuthorityCommandSubmissionV2 {
@@ -48,6 +54,12 @@ export interface DaemonAuthorityCommandSubmissionV2 {
     readonly canonicalEntityId: WriteOp["entityId"];
   }) => Promise<AuthorityOperationReceipt>;
   readonly submitProvenanceSession?: (input: {
+    readonly command: ParsedCommand;
+    readonly attribution: CliActorAttribution;
+    readonly currentSession: CurrentSessionRef;
+    readonly operation: WriteOp;
+  }) => Promise<AuthorityOperationReceipt>;
+  readonly submitDecisionTransition?: (input: {
     readonly command: ParsedCommand;
     readonly attribution: CliActorAttribution;
     readonly currentSession: CurrentSessionRef;
@@ -73,6 +85,10 @@ export function createDaemonAuthorityCommandSubmissionV2(options: {
     ...(options.attemptCompiler.compileProvenanceSession ? {
       submitProvenanceSession: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileProvenanceSession"]>>[0]) =>
         submitAttempt(await options.attemptCompiler.compileProvenanceSession!(input))
+    } : {}),
+    ...(options.attemptCompiler.compileDecisionTransition ? {
+      submitDecisionTransition: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileDecisionTransition"]>>[0]) =>
+        submitAttempt(await options.attemptCompiler.compileDecisionTransition!(input))
     } : {})
   };
 }
@@ -124,17 +140,29 @@ export function makeDaemonAuthorityWriteCoordinator(
   let settled: Promise<AuthorityOperationReceipt> | undefined;
   let provenanceCommitted = false;
   let mainCommitted = false;
+  let coveredByMainSubmission = false;
+  let mainWatermark: string | undefined;
 
   return {
-    enqueue: (operation) => pending || mainCommitted
-      ? Effect.fail(authorityWriteRejected("AUTHORITY_COMMAND_REQUIRES_SINGLE_CANONICAL_OPERATION"))
-      : Effect.sync(() => {
+    enqueue: (operation) => isAuthorityCoveredTaskTreeStage(input.command, operation)
+      ? Effect.succeed({ opId: operation.opId, entityId: operation.entityId, accepted: true as const })
+      : pending && authorityCommandCoversLocalWritePhases(input.command)
+      ? Effect.succeed({ opId: operation.opId, entityId: operation.entityId, accepted: true as const })
+      : pending || (mainCommitted && !authorityCommandCoversLocalWritePhases(input.command))
+        ? Effect.fail(authorityWriteRejected("AUTHORITY_COMMAND_REQUIRES_SINGLE_CANONICAL_OPERATION"))
+        : Effect.sync(() => {
         pending = operation;
+        coveredByMainSubmission = mainCommitted;
         return { opId: operation.opId, entityId: operation.entityId, accepted: true as const };
       }),
     flush: (reason) => Effect.tryPromise({
       try: async (): Promise<FlushReport> => {
         if (!pending) return { reason, opCount: 0, committed: false };
+        if (coveredByMainSubmission) {
+          pending = undefined;
+          coveredByMainSubmission = false;
+          return { reason, opCount: 1, committed: true, ...(mainWatermark ? { watermark: mainWatermark } : {}) };
+        }
         const provenanceSession = isCreateProvenanceSessionOperation(input, pending);
         if (provenanceSession && provenanceCommitted) {
           throw authorityWriteRejected("AUTHORITY_COMMAND_REQUIRES_SINGLE_PROVENANCE_SESSION");
@@ -142,8 +170,14 @@ export function makeDaemonAuthorityWriteCoordinator(
         if (provenanceSession && !submission.submitProvenanceSession) {
           throw authorityWriteRejected("AUTHORITY_PROVENANCE_SESSION_SUBMISSION_UNAVAILABLE");
         }
+        const decisionTransition = input.command.action.kind === "decision-transition";
+        if (decisionTransition && !submission.submitDecisionTransition) {
+          throw authorityWriteRejected("AUTHORITY_DECISION_TRANSITION_SUBMISSION_UNAVAILABLE");
+        }
         settled ??= provenanceSession
           ? submission.submitProvenanceSession!({ ...input, operation: pending })
+          : decisionTransition
+            ? submission.submitDecisionTransition!({ ...input, operation: pending })
           : submission.submit({
             ...input,
             canonicalEntityId: commandMainEntityId(input.command) ?? pending.entityId
@@ -153,13 +187,27 @@ export function makeDaemonAuthorityWriteCoordinator(
         pending = undefined;
         settled = undefined;
         if (provenanceSession) provenanceCommitted = true;
-        else mainCommitted = true;
+        else {
+          mainCommitted = true;
+          mainWatermark = receipt.opId;
+        }
         return report;
       },
       catch: authoritySubmissionWriteError
     }),
     recover: Effect.succeed({ replayedOps: 0 } satisfies RecoveryReport)
   };
+}
+
+function isAuthorityCoveredTaskTreeStage(command: ParsedCommand, operation: WriteOp): boolean {
+  return command.action.kind === "task-complete" && operation.kind === "task_tree_stage";
+}
+
+function authorityCommandCoversLocalWritePhases(command: ParsedCommand): boolean {
+  const action = command.action;
+  return action.kind === "status-set"
+    || action.kind === "task-complete"
+    || (action.kind === "task-review-execution" && action.verdict === "approved");
 }
 
 function isCreateProvenanceSessionOperation(
@@ -172,9 +220,11 @@ function isCreateProvenanceSessionOperation(
 
 function commandMainEntityId(command: ParsedCommand): WriteOp["entityId"] | undefined {
   const action = command.action;
-  return action.kind === "new-task" && action.taskId
-    ? taskEntityId(action.taskId)
-    : undefined;
+  if (action.kind === "new-task" && action.taskId) return taskEntityId(action.taskId);
+  if (action.kind === "status-set" && action.executionSubmission?.executionId) {
+    return `execution/${action.executionSubmission.executionId}`;
+  }
+  return undefined;
 }
 
 export class AuthorityProtocolDamagedError extends Error {

--- a/packages/cli/src/daemon/authority-submission-dispatch.ts
+++ b/packages/cli/src/daemon/authority-submission-dispatch.ts
@@ -1,0 +1,41 @@
+import type { AuthorityConnectionDispatch } from "../../../daemon/src/index.ts";
+import type { AuthorityRepoComponent } from "./authority-lifecycle.ts";
+
+export function bindAuthoritySubmissionForDispatch(
+  component: AuthorityRepoComponent,
+  repoId: string,
+  dispatch: AuthorityConnectionDispatch | undefined
+): ReturnType<AuthorityRepoComponent["bindConnection"]> | undefined {
+  if (!dispatch?.available) return undefined;
+  if (dispatch.context.repoId !== repoId) throw new Error("AUTHORITY_CONNECTION_REPO_MISMATCH");
+  dispatch.assertActive();
+  const bound = component.bindConnection(dispatch.context);
+  return {
+    submit: async (submission) => {
+      dispatch.assertActive();
+      return bound.submit(submission);
+    },
+    ...(bound.submitProvenanceSession ? {
+      submitProvenanceSession: async (submission: Parameters<NonNullable<typeof bound.submitProvenanceSession>>[0]) => {
+        dispatch.assertActive();
+        return bound.submitProvenanceSession!(submission);
+      }
+    } : {}),
+    ...(bound.submitDecisionTransition ? {
+      submitDecisionTransition: async (submission: Parameters<NonNullable<typeof bound.submitDecisionTransition>>[0]) => {
+        dispatch.assertActive();
+        return bound.submitDecisionTransition!(submission);
+      }
+    } : {})
+  };
+}
+
+export function requireAuthoritySubmissionForDispatch(
+  component: AuthorityRepoComponent,
+  repoId: string,
+  dispatch: AuthorityConnectionDispatch | undefined
+): ReturnType<AuthorityRepoComponent["bindConnection"]> {
+  const bound = bindAuthoritySubmissionForDispatch(component, repoId, dispatch);
+  if (!bound) throw new Error("AUTHORITY_CONNECTION_REQUIRED");
+  return bound;
+}

--- a/packages/cli/src/daemon/production-authority-attempt-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-attempt-compiler.ts
@@ -22,12 +22,14 @@ import {
 } from "../../../application/src/index.ts";
 import {
   decisionEntityId,
+  decisionSemanticMutationActions,
   deriveRelationId,
   encodeCanonicalCbor,
   moduleEntityId,
   sha256Text,
   semanticMutationWireV2,
   taskEntityId,
+  taskPackagePath,
   type CanonicalCborValue,
   type DecisionPackage,
   type EntityRelationRecord,
@@ -203,7 +205,60 @@ export function createProductionCanonicalAttemptCompiler(input: {
       currentSession,
       operation.entityId,
       provenanceSessionAttemptIntent(command, currentSession, operation)
+    ),
+    compileDecisionTransition: async ({ command, attribution, currentSession, operation }) => compileIntent(
+      command,
+      attribution,
+      currentSession,
+      operation.entityId,
+      decisionTransitionAttemptIntent(command, operation, input.authoredRoot)
     )
+  };
+}
+
+function decisionTransitionAttemptIntent(
+  command: ParsedCommand,
+  operation: WriteOp,
+  authoredRoot: string
+): CanonicalAttemptIntent {
+  const action = command.action;
+  if (action.kind !== "decision-transition") throw new Error("AUTHORITY_DECISION_TRANSITION_COMMAND_REQUIRED");
+  const expectedKind = `decision_${action.transition}`;
+  if (operation.entityId !== decisionEntityId(action.decisionId) || operation.kind !== expectedKind) {
+    throw new Error("AUTHORITY_DECISION_TRANSITION_OPERATION_MISMATCH");
+  }
+  const raw = operation.payload;
+  if (!raw || typeof raw !== "object" || !("decision" in raw)) {
+    throw new Error("AUTHORITY_DECISION_TRANSITION_PAYLOAD_INVALID");
+  }
+  const decision = (raw as { readonly decision?: DecisionPackage }).decision;
+  if (!decision || decision.decision_id !== action.decisionId) {
+    throw new Error("AUTHORITY_DECISION_TRANSITION_ENTITY_MISMATCH");
+  }
+  const body = (raw as { readonly body?: unknown }).body;
+  if (body !== undefined && typeof body !== "string") {
+    throw new Error("AUTHORITY_DECISION_TRANSITION_BODY_INVALID");
+  }
+  const documentPath = `decisions/decision-${action.decisionId}/decision.md`;
+  const snapshot = hostedSnapshot(authoredRoot, documentPath);
+  if (!snapshot) throw new Error("AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED: decision transition requires the current Decision document");
+  const entity = ref("decision", `decision/${action.decisionId}`);
+  const payload: TaskDecisionModuleCommandPayloadV2 = {
+    schema: "decision.state/v1",
+    transition: action.transition,
+    decision,
+    ...(body === undefined ? {} : { body })
+  };
+  return {
+    ...canonicalIntent(
+      "decision.state",
+      encodeTaskDecisionModuleCommandPayloadV2(payload),
+      [{ entity, action: decisionSemanticMutationActions.state }],
+      [entity],
+      [documentPath],
+      decisionEntityId(action.decisionId)
+    ),
+    declaredPathCas: [{ path: documentPath, ...snapshot.cas }]
   };
 }
 
@@ -335,7 +390,7 @@ async function canonicalAttemptIntent(
     };
     const entity = ref("decision", `decision/${action.decisionId}`);
     const payload: TaskDecisionModuleCommandPayloadV2 = { schema: "decision.propose/v1", decision, ...(action.body === undefined ? {} : { body: action.body }) };
-    return canonicalIntent("decision.propose", encodeTaskDecisionModuleCommandPayloadV2(payload), [{ entity, action: "propose" }], [entity], [`decisions/decision-${action.decisionId}/decision.md`], decisionEntityId(action.decisionId));
+    return canonicalIntent("decision.propose", encodeTaskDecisionModuleCommandPayloadV2(payload), [{ entity, action: decisionSemanticMutationActions.propose }], [entity], [`decisions/decision-${action.decisionId}/decision.md`], decisionEntityId(action.decisionId));
   }
   if (action.kind === "module-register") {
     const entity = ref("module", `module/${action.moduleKey}`);
@@ -405,7 +460,7 @@ async function canonicalAttemptIntent(
     return canonicalIntent("execution.claim", encodeSessionExecutionReviewCommandPayloadV2(payload), [{ entity, action: "claim" }], [entity], [`tasks/${action.taskId}/executions/${executionId}.md`], `execution/${executionId}`);
   }
   if (action.kind === "task-review-execution" && !action.consentId && action.verdict !== "approved") {
-    const reviewId = canonicalEntityId.replace(/^review\//u, "");
+    const reviewId = canonicalEntityId.replace(/^(?:entity\/)?review\//u, "");
     const payload: SessionExecutionReviewCommandPayloadV2 = {
       schema: action.verdict === "dismissed" ? "review.dismiss/v1" : "review.create/v1",
       taskId: action.taskId,
@@ -420,10 +475,10 @@ async function canonicalAttemptIntent(
     };
     const mutationAction = action.verdict === "dismissed" ? "dismiss" : "create";
     const entity = ref("review", `review/${action.taskId}/${reviewId}`);
-    return canonicalIntent(`review.${mutationAction}`, encodeSessionExecutionReviewCommandPayloadV2(payload), [{ entity, action: mutationAction }], [entity], [`tasks/${action.taskId}/reviews/${reviewId}.md`], `review/${reviewId}`);
+    return canonicalIntent(`review.${mutationAction}`, encodeSessionExecutionReviewCommandPayloadV2(payload), [{ entity, action: mutationAction }], [entity], [`tasks/${action.taskId}/reviews/${reviewId}.md`], canonicalEntityId);
   }
   if (action.kind === "task-consent-record") {
-    const consentId = canonicalEntityId.replace(/^consent\//u, "");
+    const consentId = canonicalEntityId.replace(/^(?:entity\/)?consent\//u, "");
     const executionPath = `tasks/${action.taskId}/executions/${action.executionId}.md`;
     const snapshot = hostedSnapshot(authoredRoot, executionPath);
     if (!snapshot) throw new Error("AUTHORITY_CONSENT_EXECUTION_REQUIRED: submit the Execution before recording consent");
@@ -434,7 +489,7 @@ async function canonicalAttemptIntent(
     const execution = ref("execution", `execution/${action.taskId}/${action.executionId}`);
     const consent = ref("consent", `consent/${action.taskId}/${consentId}`);
     return {
-      ...canonicalIntent("consent.grant", encodeConsentCommandPayloadV2(payload), [{ entity: consent, action: "grant" }], [execution, consent], [`tasks/${action.taskId}/consents/${consentId}.md`, executionPath], `consent/${consentId}`),
+      ...canonicalIntent("consent.grant", encodeConsentCommandPayloadV2(payload), [{ entity: consent, action: "grant" }], [execution, consent], [`tasks/${action.taskId}/consents/${consentId}.md`, executionPath], canonicalEntityId),
       declaredPathCas: [{ path: executionPath, ...snapshot.cas }]
     };
   }
@@ -485,7 +540,14 @@ function hostedSnapshot(authoredRoot: string, portablePath: string): {
   readonly body: string;
   readonly cas: { readonly expectedEpoch: string; readonly expectedRevision: bigint; readonly expectedBlobDigest: Uint8Array };
 } | null {
-  const absolute = path.join(authoredRoot, portablePath);
+  const taskDocument = /^tasks\/([^/]+)\/(.+)$/u.exec(portablePath);
+  const rootDir = path.dirname(authoredRoot);
+  const absolute = taskDocument
+    ? path.join(taskPackagePath({
+      rootDir,
+      layoutOverrides: { authoredRoot: path.relative(rootDir, authoredRoot) }
+    }, taskDocument[1]!), taskDocument[2]!)
+    : path.join(authoredRoot, portablePath);
   if (!existsSync(absolute)) return null;
   const body = readFileSync(absolute, "utf8");
   return {

--- a/packages/cli/src/daemon/production-authority-lifecycle-intents.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle-intents.ts
@@ -16,6 +16,7 @@ import {
   deriveRelationId,
   sha256Text,
   taskEntityId,
+  taskPackagePath,
   type ExecutionRecord,
   type RegistryEntityRefV2
 } from "../../../kernel/src/index.ts";
@@ -33,13 +34,17 @@ export function productionLifecycleAttemptIntent(input: {
 }): CanonicalAttemptIntent | null {
   const { action } = input.command;
   if (action.kind === "status-set") {
+    const taskPath = taskLifecyclePath(input.authoredRoot, action.taskId, "INDEX.md");
+    if (action.executionSubmission?.executionId) {
+      return executionSubmitIntent(input.authoredRoot, input.currentSession.detectedAt, action, taskPath);
+    }
     const payload: TaskDecisionModuleCommandPayloadV2 = {
       schema: "task.transition/v1", taskId: action.taskId, to: action.status
     };
     return lifecycleIntent("task.transition", encodeTaskDecisionModuleCommandPayloadV2(payload), [
       lifecycleMutation("task", `task/${action.taskId}`, "transition")
-    ], [lifecycleRef("task", `task/${action.taskId}`)], [`tasks/${action.taskId}/INDEX.md`], taskEntityId(action.taskId), [
-      requiredLifecycleSnapshot(input.authoredRoot, `tasks/${action.taskId}/INDEX.md`)
+    ], [lifecycleRef("task", `task/${action.taskId}`)], portableLifecyclePaths(taskPath), taskEntityId(action.taskId), [
+      requiredLifecycleSnapshot(input.authoredRoot, taskPath.logical, taskPath.physical)
     ]);
   }
   if (action.kind === "fact-invalidate") {
@@ -60,23 +65,83 @@ export function productionLifecycleAttemptIntent(input: {
       lifecycleRef("fact", `fact/${action.taskId}/${action.factId}`),
       lifecycleRef("fact", `fact/${action.taskId}/${action.invalidatedByFactId}`),
       lifecycleRef("relation", `relation/${relationId}`)
-    ], [`tasks/${action.taskId}/facts.md`], taskEntityId(action.taskId));
+    ], portableLifecyclePaths(taskLifecyclePath(input.authoredRoot, action.taskId, "facts.md")), taskEntityId(action.taskId));
   }
   if (action.kind === "task-code-doc-reconcile") return codeDocIntent(input.authoredRoot, action);
   if (action.kind === "task-review-execution" && action.verdict === "approved") {
     return approvedReviewIntent(input.authoredRoot, input.canonicalEntityId, action);
   }
   if (action.kind === "task-complete") {
-    return taskCompletionIntent(input.authoredRoot, input.currentSession.detectedAt, action.taskId);
+    return taskCompletionIntent(input.authoredRoot, input.currentSession.detectedAt, action.taskId, input.canonicalEntityId);
   }
   return null;
+}
+
+function executionSubmitIntent(
+  authoredRoot: string,
+  submittedAt: string,
+  action: Extract<ParsedCommand["action"], { readonly kind: "status-set" }>,
+  taskPath: ReturnType<typeof taskLifecyclePath>
+): CanonicalAttemptIntent {
+  const submission = action.executionSubmission!;
+  const executionId = submission.executionId!;
+  const executionPath = taskLifecyclePath(authoredRoot, action.taskId, `executions/${executionId}.md`);
+  const executionSnapshot = requiredLifecycleSnapshot(authoredRoot, executionPath.logical, executionPath.physical);
+  const taskSnapshot = requiredLifecycleSnapshot(authoredRoot, taskPath.logical, taskPath.physical);
+  const current = executionDeclaration.documentCodec.decode(executionSnapshot.body) as ExecutionRecord;
+  const next: ExecutionRecord = {
+    ...current,
+    state: "submitted",
+    submitted_at: submittedAt,
+    outputs: [
+      ...current.outputs,
+      ...submission.outputs.map((text, index) => ({
+        evidence_id: `ev_cli_${index + 1}`,
+        execution_ref: `execution/${action.taskId}/${executionId}`,
+        locator: { substrate: "inline" as const, text }
+      }))
+    ],
+    submission: {
+      completion_claim: submission.completionClaim,
+      deliverables: submission.deliverables,
+      evidence_refs: submission.outputs.map((_, index) => `ev_cli_${index + 1}`),
+      verification_notes: submission.verificationNotes,
+      known_gaps: submission.knownGaps,
+      residual_risks: submission.residualRisks
+    }
+  };
+  const taskIndexBody = taskSnapshot.body.replace(/^(  status:\s*).+$/mu, "$1in_review");
+  const payload: SessionExecutionReviewCommandPayloadV2 = {
+    schema: "execution.submit/v1",
+    taskId: action.taskId,
+    execution: next,
+    taskIndexBody
+  };
+  return lifecycleIntent(
+    "execution.submit",
+    encodeSessionExecutionReviewCommandPayloadV2(payload),
+    [
+      lifecycleMutation("execution", `execution/${action.taskId}/${executionId}`, "submit"),
+      lifecycleMutation("task", `task/${action.taskId}`, "transition")
+    ],
+    [
+      lifecycleRef("execution", `execution/${action.taskId}/${executionId}`),
+      lifecycleRef("task", `task/${action.taskId}`)
+    ],
+    [
+      ...portableLifecyclePaths(executionPath),
+      ...portableLifecyclePaths(taskPath)
+    ],
+    `execution/${executionId}`,
+    [executionSnapshot, taskSnapshot]
+  );
 }
 
 function codeDocIntent(
   authoredRoot: string,
   action: Extract<ParsedCommand["action"], { readonly kind: "task-code-doc-reconcile" }>
 ): CanonicalAttemptIntent {
-  const taskRoot = path.join(authoredRoot, "tasks", action.taskId);
+  const taskRoot = resolvedTaskRoot(authoredRoot, action.taskId);
   const documents = ["closeout.md", "review.md"]
     .filter((name) => existsSync(path.join(taskRoot, name)))
     .map((name) => ({ path: name, body: readFileSync(path.join(taskRoot, name), "utf8") }));
@@ -86,11 +151,11 @@ function codeDocIntent(
   const payload: TaskDecisionModuleCommandPayloadV2 = {
     schema: "task.document/v1", taskId: action.taskId, path: "code-doc-anchors.json", body: draft.body
   };
-  const portablePath = `tasks/${action.taskId}/code-doc-anchors.json`;
-  const existing = optionalLifecycleSnapshot(authoredRoot, portablePath);
+  const portablePath = taskLifecyclePath(authoredRoot, action.taskId, "code-doc-anchors.json");
+  const existing = optionalLifecycleSnapshot(authoredRoot, portablePath.logical, portablePath.physical);
   return lifecycleIntent("task.document", encodeTaskDecisionModuleCommandPayloadV2(payload), [
     lifecycleMutation("task", `task/${action.taskId}`, "document")
-  ], [lifecycleRef("task", `task/${action.taskId}`)], [portablePath], taskEntityId(action.taskId), existing ? [existing] : []);
+  ], [lifecycleRef("task", `task/${action.taskId}`)], portableLifecyclePaths(portablePath), taskEntityId(action.taskId), existing ? [existing] : []);
 }
 
 function approvedReviewIntent(
@@ -101,9 +166,9 @@ function approvedReviewIntent(
   if (!action.consentId) {
     throw new Error("AUTHORITY_APPROVED_REVIEW_CONSENT_ID_REQUIRED: record consent first and retry with --consent-id");
   }
-  const reviewId = canonicalEntityId.replace(/^review\//u, "");
-  const consentPath = `tasks/${action.taskId}/consents/${action.consentId}.md`;
-  const storedConsent = optionalLifecycleSnapshot(authoredRoot, consentPath);
+  const reviewId = canonicalEntityId.replace(/^(?:entity\/)?review\//u, "");
+  const consentPath = taskLifecyclePath(authoredRoot, action.taskId, `consents/${action.consentId}.md`);
+  const storedConsent = optionalLifecycleSnapshot(authoredRoot, consentPath.logical, consentPath.physical);
   const payload: ConsentCommandPayloadV2 = {
     schema: "consent.consume/v1", taskId: action.taskId, executionId: action.executionId,
     consentId: action.consentId,
@@ -114,8 +179,9 @@ function approvedReviewIntent(
       rationale: action.rationale, archiveWarningsAcknowledged: action.archiveWarningsAcknowledged
     }
   };
-  const executionPath = `tasks/${action.taskId}/executions/${action.executionId}.md`;
-  const taskPath = `tasks/${action.taskId}/INDEX.md`;
+  const executionPath = taskLifecyclePath(authoredRoot, action.taskId, `executions/${action.executionId}.md`);
+  const taskPath = taskLifecyclePath(authoredRoot, action.taskId, "INDEX.md");
+  const reviewPath = taskLifecyclePath(authoredRoot, action.taskId, `reviews/${reviewId}.md`);
   return lifecycleIntent("consent.consume", encodeConsentCommandPayloadV2(payload), [
     ...(storedConsent ? [] : [lifecycleMutation("consent", `consent/${action.taskId}/${action.consentId}`, "grant")]),
     lifecycleMutation("consent", `consent/${action.taskId}/${action.consentId}`, "consume"),
@@ -124,15 +190,15 @@ function approvedReviewIntent(
     lifecycleRef("execution", `execution/${action.taskId}/${action.executionId}`),
     lifecycleRef("consent", `consent/${action.taskId}/${action.consentId}`),
     lifecycleRef("review", `review/${action.taskId}/${reviewId}`)
-  ], [executionPath, taskPath, consentPath, `tasks/${action.taskId}/reviews/${reviewId}.md`], `review/${reviewId}`, [
-    requiredLifecycleSnapshot(authoredRoot, executionPath),
-    requiredLifecycleSnapshot(authoredRoot, taskPath),
+  ], portableLifecyclePaths(executionPath, taskPath, consentPath, reviewPath), canonicalEntityId, [
+    requiredLifecycleSnapshot(authoredRoot, executionPath.logical, executionPath.physical),
+    requiredLifecycleSnapshot(authoredRoot, taskPath.logical, taskPath.physical),
     ...(storedConsent ? [storedConsent] : [])
   ]);
 }
 
-function taskCompletionIntent(authoredRoot: string, completedAt: string, taskId: string): CanonicalAttemptIntent {
-  const executionRoot = path.join(authoredRoot, "tasks", taskId, "executions");
+function taskCompletionIntent(authoredRoot: string, completedAt: string, taskId: string, canonicalEntityId: string): CanonicalAttemptIntent {
+  const executionRoot = path.join(resolvedTaskRoot(authoredRoot, taskId), "executions");
   const executions = existsSync(executionRoot)
     ? readdirSync(executionRoot).filter((name) => name.endsWith(".md")).map((name) => ({
       name,
@@ -145,21 +211,21 @@ function taskCompletionIntent(authoredRoot: string, completedAt: string, taskId:
   }
   const current = submitted[0]!.record;
   const execution: ExecutionRecord = { ...current, state: "accepted", closed_at: completedAt };
-  const taskPath = `tasks/${taskId}/INDEX.md`;
-  const taskSnapshot = requiredLifecycleSnapshot(authoredRoot, taskPath);
+  const taskPath = taskLifecyclePath(authoredRoot, taskId, "INDEX.md");
+  const taskSnapshot = requiredLifecycleSnapshot(authoredRoot, taskPath.logical, taskPath.physical);
   const taskBody = taskSnapshot.body.replace(/^(  status:\s*).+$/mu, "$1done");
   const payload: SessionExecutionReviewCommandPayloadV2 = {
     schema: "execution.close/v1", taskId, execution, taskIndexBody: taskBody
   };
-  const executionPath = `tasks/${taskId}/executions/${execution.execution_id}.md`;
+  const executionPath = taskLifecyclePath(authoredRoot, taskId, `executions/${execution.execution_id}.md`);
   return lifecycleIntent("execution.close", encodeSessionExecutionReviewCommandPayloadV2(payload), [
     lifecycleMutation("execution", `execution/${taskId}/${execution.execution_id}`, "close"),
     lifecycleMutation("task", `task/${taskId}`, "transition")
   ], [
     lifecycleRef("execution", `execution/${taskId}/${execution.execution_id}`),
     lifecycleRef("task", `task/${taskId}`)
-  ], [executionPath, taskPath], `execution/${execution.execution_id}`, [
-    requiredLifecycleSnapshot(authoredRoot, executionPath), taskSnapshot
+  ], portableLifecyclePaths(executionPath, taskPath), canonicalEntityId, [
+    requiredLifecycleSnapshot(authoredRoot, executionPath.logical, executionPath.physical), taskSnapshot
   ]);
 }
 
@@ -183,22 +249,40 @@ function lifecycleRef(entityKind: string, canonicalRef: string): RegistryEntityR
   return { registryVersion: 1, entityKind, canonicalRef };
 }
 
-function requiredLifecycleSnapshot(authoredRoot: string, portablePath: string) {
-  const snapshot = optionalLifecycleSnapshot(authoredRoot, portablePath);
-  if (!snapshot) throw new Error(`AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED:${portablePath}`);
+function requiredLifecycleSnapshot(authoredRoot: string, logicalPath: string, physicalPath = logicalPath) {
+  const snapshot = optionalLifecycleSnapshot(authoredRoot, logicalPath, physicalPath);
+  if (!snapshot) throw new Error(`AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED:${physicalPath}`);
   return snapshot;
 }
 
-function optionalLifecycleSnapshot(authoredRoot: string, portablePath: string) {
-  const absolute = path.join(authoredRoot, portablePath);
+function optionalLifecycleSnapshot(authoredRoot: string, logicalPath: string, physicalPath = logicalPath) {
+  const absolute = path.join(authoredRoot, physicalPath);
   if (!existsSync(absolute)) return null;
   const body = readFileSync(absolute, "utf8");
   const digest = sha256Text(body);
   return {
-    path: portablePath,
+    path: logicalPath,
     body,
     expectedEpoch: digest,
     expectedRevision: 0n,
     expectedBlobDigest: Buffer.from(digest, "hex")
   };
+}
+
+function resolvedTaskRoot(authoredRoot: string, taskId: string): string {
+  const rootDir = path.dirname(authoredRoot);
+  return taskPackagePath({
+    rootDir,
+    layoutOverrides: { authoredRoot: path.relative(rootDir, authoredRoot) }
+  }, taskId);
+}
+
+function taskLifecyclePath(authoredRoot: string, taskId: string, documentPath: string) {
+  const physical = path.relative(authoredRoot, path.join(resolvedTaskRoot(authoredRoot, taskId), documentPath))
+    .split(path.sep).join("/");
+  return { logical: `tasks/${taskId}/${documentPath}`, physical };
+}
+
+function portableLifecyclePaths(...paths: ReadonlyArray<ReturnType<typeof taskLifecyclePath>>): ReadonlyArray<string> {
+  return [...new Set(paths.flatMap((entry) => [entry.logical, entry.physical]))];
 }

--- a/packages/cli/src/daemon/production-authority-lifecycle.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle.ts
@@ -370,6 +370,9 @@ function createRepoComponent(
         ...(commandSubmission.submitProvenanceSession ? {
           submitProvenanceSession: commandSubmission.submitProvenanceSession
         } : {}),
+        ...(commandSubmission.submitDecisionTransition ? {
+          submitDecisionTransition: commandSubmission.submitDecisionTransition
+        } : {}),
         serveForcedCommand: ({ input: readable, output }) => {
           const session = serveAuthorityForcedCommand({
             input: readable,

--- a/packages/cli/src/daemon/service-host.ts
+++ b/packages/cli/src/daemon/service-host.ts
@@ -10,7 +10,6 @@ import {
   createJsonRpcProtocolServer,
   calculateDaemonArtifactIdentity,
   type AcceptedConnectionBinding,
-  type AuthorityConnectionDispatch,
   type AuthorityWireIngressHandler,
   type DaemonActiveControlStatus,
   type DaemonControlService,
@@ -56,6 +55,9 @@ import type {
   AuthorityRepoLifecycleController
 } from "./authority-lifecycle.ts";
 import { makeLocalAgentHolderServices } from "./agent-holder-projection-host.ts";
+import { requireAuthoritySubmissionForDispatch } from "./authority-submission-dispatch.ts";
+
+export { bindAuthoritySubmissionForDispatch } from "./authority-submission-dispatch.ts";
 
 type HarnessDaemonRuntime = ReturnType<CliCompositionAdapterProvider["createDaemonRuntime"]>;
 type MultiRepoHarnessDaemonRuntime = ReturnType<CliCompositionAdapterProvider["createMultiRepoDaemonRuntime"]>;
@@ -490,39 +492,6 @@ function createRepoServiceBinding(
     },
     appendRuntimeEvent
   };
-}
-
-export function bindAuthoritySubmissionForDispatch(
-  component: AuthorityRepoComponent,
-  repoId: string,
-  dispatch: AuthorityConnectionDispatch | undefined
-): ReturnType<AuthorityRepoComponent["bindConnection"]> | undefined {
-  if (!dispatch?.available) return undefined;
-  if (dispatch.context.repoId !== repoId) throw new Error("AUTHORITY_CONNECTION_REPO_MISMATCH");
-  dispatch.assertActive();
-  const bound = component.bindConnection(dispatch.context);
-  return {
-    submit: async (submission) => {
-      dispatch.assertActive();
-      return bound.submit(submission);
-    },
-    ...(bound.submitProvenanceSession ? {
-      submitProvenanceSession: async (submission: Parameters<NonNullable<typeof bound.submitProvenanceSession>>[0]) => {
-        dispatch.assertActive();
-        return bound.submitProvenanceSession!(submission);
-      }
-    } : {})
-  };
-}
-
-function requireAuthoritySubmissionForDispatch(
-  component: AuthorityRepoComponent,
-  repoId: string,
-  dispatch: AuthorityConnectionDispatch | undefined
-): ReturnType<AuthorityRepoComponent["bindConnection"]> {
-  const bound = bindAuthoritySubmissionForDispatch(component, repoId, dispatch);
-  if (!bound) throw new Error("AUTHORITY_CONNECTION_REQUIRED");
-  return bound;
 }
 
 function loadRepoIdentity(

--- a/packages/cli/test/authority-lifecycle-contract-gate.test.ts
+++ b/packages/cli/test/authority-lifecycle-contract-gate.test.ts
@@ -66,8 +66,9 @@ test("approved authority lifecycle seam keeps all 19 fixture and production-comp
 
   const serviceHost = read("packages/cli/src/daemon/service-host.ts");
   assert.match(serviceHost, /authorityPeerPolicy: localAuthorityPeerPolicy/u);
-  assert.match(serviceHost, /component\.bindConnection\(dispatch\.context\)/u);
-  assert.match(serviceHost, /dispatch\.assertActive\(\)/u);
+  const submissionDispatch = read("packages/cli/src/daemon/authority-submission-dispatch.ts");
+  assert.match(submissionDispatch, /component\.bindConnection\(dispatch\.context\)/u);
+  assert.match(submissionDispatch, /dispatch\.assertActive\(\)/u);
   const commandService = read("packages/cli/src/daemon/command-service.ts");
   assert.match(commandService, /resolveAuthoritySubmissionV2\?\.\(context\?\.authorityConnection\)/u);
 

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -42,7 +42,7 @@ import {
   writeColdCodexSessionLog
 } from "./fixture.ts";
 
-test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 90_000 }, async () => {
+test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 120_000 }, async () => {
   const fixture = createFixture();
   const userRoot = defaultDaemonUserRoot(fixture.root);
   const env = {
@@ -80,6 +80,45 @@ test("production service route preserves progress dry-run and publishes canonica
     );
     assert.equal(status.repoCount, 2, JSON.stringify(status));
 
+    const decisionId = "dec_01KXQ4WTA7Q4XJ5GDDRS1YXND9";
+    const proposed = runRawJsonMaybeFail(fixture.repoRoot, [
+      "decision", "propose", "--id", decisionId,
+      "--title", "V2 attribution vocabulary",
+      "--question", "Should V2 judgment resolve the persisted propose event?",
+      "--chosen", "Use the registry action vocabulary",
+      "--rejected", "Use the legacy WriteOp kind",
+      "--why-not", "That is not the V2 mutation action",
+      "--claim", "The V2 propose event is the immutable attribution source",
+      "--risk-tier", "medium", "--urgency", "medium", "--module", "cli"
+    ], env);
+    assert.equal(proposed.status, 0, JSON.stringify(proposed.receipt));
+    assert.equal(proposed.receipt.ok, true, JSON.stringify(proposed.receipt));
+    const proposeEvent = authorityEventBodies(fixture.authoredRoot).find((body) => body.includes(`decision/${decisionId}`));
+    assert.ok(proposeEvent, "V2 propose must persist an attribution event before restart");
+    assert.match(proposeEvent, /"action"\s*:\s*"propose"/u);
+    assert.doesNotMatch(proposeEvent, /"action"\s*:\s*"decision_propose"/u);
+
+    await stopDaemon(fixture.repoRoot, userRoot);
+    runDaemonCommand(fixture.repoRoot, [
+      "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+    ], env);
+    await pollUntil(
+      () => runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env),
+      (daemonStatus) => daemonStatus.reachable === true,
+      (daemonStatus, error) => JSON.stringify({ daemonStatus, error: error instanceof Error ? error.message : String(error ?? "") }),
+      { timeoutMs: 20_000 }
+    );
+    const { HARNESS_ACTOR: _agentActor, ...humanEnv } = env;
+    const accepted = runRawJsonMaybeFail(fixture.repoRoot, [
+      "--actor", "human:person_alice", "decision", "transition", "active", decisionId,
+      "--judgment-only", "A human verified the persisted V2 propose attribution after restart."
+    ], humanEnv);
+    assert.equal(accepted.status, 0, JSON.stringify(accepted.receipt));
+    assert.equal(accepted.receipt.ok, true, JSON.stringify(accepted.receipt));
+    assert.match(readFileSync(path.join(
+      fixture.authoredRoot, `decisions/decision-${decisionId}/decision.md`
+    ), "utf8"), /^state: active$/mu);
+
     const dryRunHead = git(fixture.authoredRoot, "rev-parse", "HEAD");
     const dryRun = runRawJsonMaybeFail(fixture.repoRoot, [
       "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4",
@@ -116,6 +155,84 @@ test("production service route preserves progress dry-run and publishes canonica
     assert.equal(publication.pipelineGeneratedPaths[0], publication.physicalChanges.find((change) => change.path.startsWith("attribution-events/"))?.path);
     git(fixture.authoredRoot, "diff", "--quiet", publication.commitSha, publication.parentCommits[1]!);
     assert.equal(dryRunHeadAfter, dryRunHead, "typed service dry-run must not create a commit");
+
+    const sluggedLifecycleTaskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8";
+    const sluggedExecutionId = "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG7";
+    const sluggedSessionId = "service-slugged-lifecycle-session";
+    writeColdCodexSessionLog(fixture.repoRoot, sluggedSessionId);
+    const sluggedLifecycleEnv = { ...env, CODEX_THREAD_ID: sluggedSessionId };
+    const exportedLifecycleSession = runRawJsonMaybeFail(fixture.repoRoot, [
+      "session", "export", "--session", sluggedSessionId, "--runtime", "codex", "--source", "runtime",
+      "--detected-at", "2026-07-17T00:00:00.000Z", "--transcript-file", fixture.transcriptPath
+    ], sluggedLifecycleEnv);
+    assert.equal(exportedLifecycleSession.status, 0, JSON.stringify(exportedLifecycleSession.receipt));
+    assert.equal(exportedLifecycleSession.receipt.ok, true, JSON.stringify(exportedLifecycleSession.receipt));
+    const claimed = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "claim", sluggedLifecycleTaskId, "--execution-id", sluggedExecutionId
+    ], sluggedLifecycleEnv);
+    assert.equal(claimed.status, 0, JSON.stringify(claimed.receipt));
+    assert.equal(claimed.receipt.ok, true, JSON.stringify(claimed.receipt));
+
+    const reconciled = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "code-doc", "reconcile", sluggedLifecycleTaskId,
+      "--commit", fixture.publicHead, "--path", "README.md"
+    ], sluggedLifecycleEnv);
+    assert.equal(reconciled.status, 0, JSON.stringify(reconciled.receipt));
+    assert.equal(reconciled.receipt.ok, true, JSON.stringify(reconciled.receipt));
+    assert.equal(existsSync(path.join(
+      fixture.authoredRoot,
+      `tasks/${sluggedLifecycleTaskId}-production-route/code-doc-anchors.json`
+    )), true);
+    assert.equal(existsSync(path.join(fixture.authoredRoot, `tasks/${sluggedLifecycleTaskId}`)), false);
+
+    const transitioned = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "transition", sluggedLifecycleTaskId, "in_review",
+      "--execution-id", sluggedExecutionId,
+      "--completion-claim", "Slugged production lifecycle is complete.",
+      "--deliverable", "Canonical slug-aware lifecycle intents.",
+      "--verification", "Production daemon route passed.",
+      "--output", "slugged lifecycle passed"
+    ], sluggedLifecycleEnv);
+    assert.equal(transitioned.status, 0, JSON.stringify(transitioned.receipt));
+    assert.equal(transitioned.receipt.ok, true, JSON.stringify(transitioned.receipt));
+
+    const consented = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "consent-record", sluggedLifecycleTaskId,
+      "--execution-id", sluggedExecutionId,
+      "--utterance", "Approve and complete the slugged production execution.",
+      "--consent-action", "approve_execution", "--consent-action", "complete_task"
+    ], sluggedLifecycleEnv);
+    assert.equal(consented.status, 0, JSON.stringify(consented.receipt));
+    assert.equal(consented.receipt.ok, true, JSON.stringify(consented.receipt));
+    const sluggedConsentId = String((consented.receipt.details as { readonly data?: { readonly consentId?: string } } | undefined)?.data?.consentId ?? "");
+    assert.match(sluggedConsentId, /^cns_/u, JSON.stringify(consented.receipt));
+
+    const reviewed = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "review-execution", sluggedLifecycleTaskId,
+      "--execution-id", sluggedExecutionId,
+      "--verdict", "approved",
+      "--findings", "Slugged production evidence is complete.",
+      "--evidence-checked", "ev_cli_1",
+      "--rationale", "The submitted execution and closeout evidence support approval.",
+      "--acknowledge-archive-warnings", "--consent", sluggedConsentId
+    ], sluggedLifecycleEnv);
+    assert.equal(reviewed.status, 0, JSON.stringify(reviewed.receipt));
+    assert.equal(reviewed.receipt.ok, true, JSON.stringify(reviewed.receipt));
+    assert.match(readFileSync(path.join(
+      fixture.authoredRoot,
+      `tasks/${sluggedLifecycleTaskId}-production-route/executions/${sluggedExecutionId}.md`
+    ), "utf8"), /^  "state": "submitted",$/mu);
+
+    const completed = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "complete", sluggedLifecycleTaskId, "--ci", "passed", "--reviewer", "person_alice"
+    ], sluggedLifecycleEnv);
+    assert.equal(completed.status, 0, JSON.stringify(completed.receipt));
+    assert.equal(completed.receipt.ok, true, JSON.stringify(completed.receipt));
+    const sluggedTaskRoot = path.join(fixture.authoredRoot, `tasks/${sluggedLifecycleTaskId}-production-route`);
+    assert.match(readFileSync(path.join(sluggedTaskRoot, "INDEX.md"), "utf8"), /^  status: done$/mu);
+    assert.equal(existsSync(path.join(sluggedTaskRoot, `consents/${sluggedConsentId}.md`)), true);
+    assert.equal(existsSync(path.join(sluggedTaskRoot, "reviews")), true);
+    assert.equal(existsSync(path.join(fixture.authoredRoot, `tasks/${sluggedLifecycleTaskId}`)), false);
 
     const bareSessionId = "service-task-create-session";
     writeColdCodexSessionLog(fixture.repoRoot, bareSessionId);

--- a/packages/cli/test/production-authority-canonical-ingress/fixture.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/fixture.ts
@@ -26,6 +26,8 @@ export function createFixture() {
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"));
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route"), { recursive: true });
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8"));
+  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/closeout.md"), "# Closeout\n\nSlugged production lifecycle is ready.\n");
+  writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/review.md"), "# Review\n\nNo open findings.\n");
   const actor = {
     personId: "person_alice", displayName: "Alice", primaryEmail: "alice@example.test", providerId: "transport-derived/v1",
     resolvedCredential: { kind: "unix-socket-owner-boundary" as const, issuer: `host:${hostname()}`, subject: String(process.getuid?.() ?? 0) }
@@ -39,6 +41,34 @@ export function createFixture() {
   };
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/executions"), { recursive: true });
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/executions/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5.md"), executionDeclaration.documentCodec.encode(submittedExecution));
+  const sluggedExecution: ExecutionRecord = {
+    ...submittedExecution,
+    execution_id: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG7",
+    task_ref: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8",
+    state: "active",
+    submitted_at: null,
+    session_bindings: [{
+      binding_id: "primary:service-slugged-lifecycle-session",
+      session_ref: "session/service-slugged-lifecycle-session",
+      role: "primary",
+      archive_status: "complete",
+      attached_at: "2026-07-17T00:00:00.000Z",
+      session: {
+        runtime: "codex",
+        sessionId: "service-slugged-lifecycle-session",
+        source: "runtime",
+        detectedAt: "2026-07-17T00:00:00.000Z"
+      },
+      capture_range: null
+    }],
+    outputs: [],
+    submission: null
+  };
+  mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/executions"), { recursive: true });
+  writeFileSync(
+    path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/executions/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG7.md"),
+    executionDeclaration.documentCodec.encode(sluggedExecution)
+  );
   const transcriptPath = path.join(root, "session-transcript.md");
   writeFileSync(transcriptPath, `${JSON.stringify({ timestamp: "2026-07-17T00:00:00.000Z", type: "event_msg", payload: { type: "user_message", message: "Production session ingress." } })}\n`);
   writeFileSync(path.join(authoredRoot, "people.yaml"), [

--- a/packages/kernel/src/entity/registry.ts
+++ b/packages/kernel/src/entity/registry.ts
@@ -57,6 +57,12 @@ export type {
 } from "./registry-contract.ts";
 export type KernelEntityKind = CanonicalEntityKind;
 export const entityRegistryVersion = 1 as const;
+export const decisionSemanticMutationActions = {
+  propose: "propose",
+  state: "state",
+  amend: "amend",
+  relation: "relation"
+} as const;
 
 export type EntityRegistryShape = {
   readonly decision: EntityRegistration<DecisionFieldKey>;
@@ -104,7 +110,7 @@ export const entityRegistry = {
         };
       }
     }),
-    mutationContract: { status: "ready", actions: ["propose", "state", "amend", "relation"] },
+    mutationContract: { status: "ready", actions: Object.values(decisionSemanticMutationActions) },
     semanticDiff: readyManagedSemanticDiff("decision"),
   },
   task: {

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -15,6 +15,7 @@ export {
   assertManagedSemanticRegions,
   compileRegistryMutationPlan,
   createWritableEntityRegistry,
+  decisionSemanticMutationActions,
   entityRegistry,
   entityRegistryKinds,
   entityStorageForms,

--- a/packages/kernel/src/projection/sqlite-attribution-projection.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-projection.ts
@@ -436,7 +436,7 @@ function legacyTargetId(subjectRef: string, kind: CanonicalEntityKind): string |
 
 function eventAttribution(rows: ReadonlyArray<AttributionProjectionRow>): EntityAttributionProjection {
   const ordered = [...rows].sort(compareProjectionRows);
-  const origin = ordered.find((row) => row.operation === "package_create" || row.operation === "decision_propose") ?? ordered[0]!;
+  const origin = ordered.find(isOriginAttributionOperation) ?? ordered[0]!;
   const completeness = ordered.every((row) => row.completeness === "complete")
     ? "complete"
     : ordered.some((row) => row.completeness === "legacy-partial")
@@ -448,6 +448,12 @@ function eventAttribution(rows: ReadonlyArray<AttributionProjectionRow>): Entity
     trailCount: ordered.length,
     completeness
   };
+}
+
+function isOriginAttributionOperation(row: AttributionProjectionRow): boolean {
+  return row.eventSchemaVersion === 1
+    ? row.operation === "package_create" || row.operation === "decision_propose"
+    : row.operation === "create" || (row.entityKind === "decision" && row.operation === "propose");
 }
 
 function compareProjectionRows(left: AttributionProjectionRow, right: AttributionProjectionRow): number {

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -102,6 +102,7 @@ const publicRuntimeSurface = [
   "decisionEntityId",
   "decisionFieldContracts",
   "decisionIdFromEntityId",
+  "decisionSemanticMutationActions",
   "decisionStates",
   "decodeAndVerifyAttributionEventV2",
   "decodeCanonicalCbor",

--- a/packages/kernel/test/store/attribution-union-projection.test.ts
+++ b/packages/kernel/test/store/attribution-union-projection.test.ts
@@ -358,6 +358,34 @@ test("entity attribution is stored once in the unified summary projection", () =
   });
 });
 
+test("V2 entity origin uses semantic create vocabulary when an older append row already exists", () => {
+  withTempStore((rootDir) => {
+    const taskId = "task_T";
+    const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+    mkdirSync(taskRoot, { recursive: true });
+    writeFileSync(path.join(taskRoot, "INDEX.md"), [
+      "---", "schema: task-package/v2", `task_id: ${taskId}`, "title: V2 origin vocabulary",
+      "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", "  status: active",
+      "  ref: ", "  titleSnapshot: V2 origin vocabulary", "  url: ",
+      "  bindingCreatedAt: 2026-07-13T00:00:00.000Z", "  bindingFingerprint: sha256:fixture",
+      "packageDisposition: active", "---", ""
+    ].join("\n"), "utf8");
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    materializeAttributionProjectionFromEvents(projectionPath, [
+      v2Event([mutation("task", `task/${taskId}`, "append")], {
+        workspaceId: "workspace-1", opId: "append-first", revision: 1, principalPersonId: "person_append"
+      }),
+      v2Event([mutation("task", `task/${taskId}`, "create")], {
+        workspaceId: "workspace-1", opId: "create-imported-later", revision: 2, principalPersonId: "person_create"
+      })
+    ]);
+    const [task] = queryTaskProjectionRows(projectionPath, {});
+    assert.equal(task?.attribution.originator?.principal.personId, "person_create");
+    assert.equal(task?.attribution.latestActor?.principal.personId, "person_create");
+  });
+});
+
 function v1Event(extra: Readonly<Record<string, unknown>> = {}): Record<string, unknown> {
   return {
     schema: "attribution-event/v1",
@@ -382,7 +410,7 @@ function v1Event(extra: Readonly<Record<string, unknown>> = {}): Record<string, 
 
 function v2Event(
   mutations: ReadonlyArray<SemanticMutationV2>,
-  identity: { readonly workspaceId: string; readonly opId: string; readonly revision: number } = {
+  identity: { readonly workspaceId: string; readonly opId: string; readonly revision: number; readonly principalPersonId?: string } = {
     workspaceId: "workspace-1", opId: "v2-op", revision: 1
   }
 ): AttributionEventV2 {
@@ -395,7 +423,7 @@ function v2Event(
   };
   const actorAxesBinding: ActorAxesBindingCoreV2 = {
     bindingId: "binding-1",
-    principalPersonId: "person_zeyu",
+    principalPersonId: identity.principalPersonId ?? "person_zeyu",
     executorAgentId: "agent-codex",
     workspaceId: identity.workspaceId,
     deviceId: "device-1",


### PR DESCRIPTION
# English

## Summary

Two W6 defects that broke the decision and task lifecycles on the V2 authority road: D19 — the V2 intent compiler records decision proposals with action `propose` while the judgment check in `decision-write-service.ts` matched the V1 literal `decision_propose`, so every decision transition (including pending accepts) failed to locate its own propose attribution event; D20 — lifecycle closeout intents built unslugged `tasks/<taskId>` paths while real task directories are slugged, so closeout.md/review.md were never found and the completion chain was dead on the real CLI road.

## What Changed

- **D19**: the V2 decision action vocabulary is a single shared constant set (`decisionSemanticMutationActions`: propose/state/amend/relation) consumed by both the compiler and the judgment check; V1 events still match only `decision_propose` — no dual-vocabulary acceptance. Added a strictly validated `decision transition` V2 ingress and fixed the V2 attribution projection's recognition of create/propose origins.
- **D20**: every lifecycle intent resolves the task package directory through a canonical task resolver that locates the real slugged directory; execution submit + task `in_review` and execution close + task `done` are now single atomic authority transactions, so no intermediate state can strand a bare task directory.

## Task And Scope

- W6 cutover line task_01KXMN5BRWQH93976XBZSHSCN4; based on merged main 97605ff3 (D21/T2/GUI landed). Production events were read-only confirmed: both pending target decisions' events carry action `propose`.
- Production state untouched; deploy + daemon restart + executing the pending accepts remain operator actions.

## Version Impact

- No published package version change.

## Governance Declaration

- Authority anchor: task_01KXMN5BRWQH93976XBZSHSCN4; standing W6 fix-then-cut authorization.
- Protected paths touched: none (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `tools/test-tier-manifest.mjs`, `harness/**` untouched).
- No gate weakening: judgment attribution remains fail-closed (a missing propose event still rejects); the multi-write guard remains active; V1 vocabulary is not widened.

## Verification

- D19 red/green: before the fix, a V2 `propose` event cannot satisfy judgment attribution; after, a daemon restart reads pre-existing events and `transition active` succeeds; a V2 event carrying the V1 literal `decision_propose` is negatively controlled and still rejected.
- D20 red/green: before, code-doc anchors found no records and then hit the multi-write guard; after, the full real slugged lifecycle chain (code-doc → transition → review → complete) succeeds via real CLI argv through the daemon socket, and no bare task directory is ever created.
- Focused suite 58/58; root `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 (32 gates green; fast 317/317, contract 329/329).

## Review Evidence

- CEO semantic acceptance: the vocabulary fix is a shared constant (single source of truth), not a both-words match; path resolution goes through one canonical resolver instead of per-intent string building; upgrade-path regression (existing events + new code) present — confirmed in diff and report.

## Residual Risk

- The atomic execution+task transactions serialize two entity mutations in one authority operation class; queue latency under large closeout batches should be observed.
- Executing the two pending accepts is the live proof and remains the operator's next action after deploy.

## References

- PRs #883–#898 (D14–D21 chain).
- Worker report: `tmp/orch/w6-d15-perf/REPORT.md` §§ D19, D20.

---

# 中文

## 概要

V2 authority 路上打断 decision 与 task 生命周期的两个 W6 缺陷：D19——V2 intent 编译器把决策提案记为 action `propose`，而 `decision-write-service.ts` 的判定检查匹配 V1 字面量 `decision_propose`，导致所有决策 transition（含待执行的两案 accept）找不到自己的 propose 归属事件；D20——生命周期收口 intents 拼接未 slug 的 `tasks/<taskId>` 路径，而真实任务目录是 slugged，closeout.md/review.md 永远找不到，完成链在真实 CLI 路上是死的。

## 改动内容

- **D19**：V2 decision action 词表统一为共享常量集（`decisionSemanticMutationActions`：propose/state/amend/relation），编译器与判定检查消费同一来源；V1 事件仍只认 `decision_propose`——不开双词兼容。新增严格校验的 `decision transition` V2 ingress，并修正 V2 attribution projection 对 create/propose origin 的识别。
- **D20**：所有生命周期 intent 通过 canonical task resolver 定位真实 slugged 目录；execution submit + task `in_review`、execution close + task `done` 改为单个原子 authority 事务，不会有中间态遗留裸 task 目录。

## 任务与范围

- W6 cutover 线 task_01KXMN5BRWQH93976XBZSHSCN4；基于已合并 main 97605ff3（D21/T2/GUI 已落）。生产事件仅只读确认：两笔待裁目标决策的事件 action 均为 `propose`。
- 生产状态未触碰；部署、daemon 重启与执行待办 accept 归 operator。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 授权锚：task_01KXMN5BRWQH93976XBZSHSCN4；W6 fix-then-cut 常设授权。
- 未触碰受保护路径（`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`tools/test-tier-manifest.mjs`、`harness/**` 均未动）。
- 无门禁削弱：判定归属保持 fail-closed（缺 propose 事件仍拒绝）；多写守卫继续生效；V1 词表未放宽。

## 验证

- D19 红/绿：修前 V2 `propose` 事件无法满足判定归属；修后 daemon 重启读取既存事件、`transition active` 成功；携带 V1 字面量 `decision_propose` 的 V2 事件做阴性对照、仍被拒绝。
- D20 红/绿：修前 code-doc anchors 无 records、随后撞多写守卫；修后真实 slugged 生命周期全链（code-doc → transition → review → complete）经真实 CLI argv 过 daemon socket 成功，且不会生成裸 task 目录。
- 聚焦套件 58/58；根 `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0（32 门全绿；fast 317/317，contract 329/329）。

## 审查证据

- CEO 语义验收：词表修复是共享常量（单一事实源）而非两头都认；路径解析收敛到一个 canonical resolver 而非各 intent 自拼字符串；升级路径回归（既存事件 + 新代码）在位——已对照 diff 与报告确认。

## 残余风险

- 原子 execution+task 事务把两个实体变更放进一个 authority 操作类；大批量收口下的队列延迟需观察。
- 执行两笔待办 accept 是活体证明，为部署后 operator 的下一步动作。

## 关联材料

- PR #883–#898（D14–D21 链）。
- Worker 报告：`tmp/orch/w6-d15-perf/REPORT.md` §§ D19、D20。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
