### PR TITLE
test(gui): widen daemon autostart window in hermetic env

### DIFF
--- a/packages/gui/test/catalog-decision-ipc.test.ts
+++ b/packages/gui/test/catalog-decision-ipc.test.ts
@@ -109,13 +109,19 @@ test("GUI decision propose performs a real authenticated write through daemon IP
 async function withGuiDaemonEnv<T>(rootDir: string, run: () => Promise<T>): Promise<T> {
   const previousUserRoot = process.env.HARNESS_DAEMON_USER_ROOT;
   const previousIdleMs = process.env.HARNESS_DAEMON_IDLE_MS;
+  const previousAutostartTimeout = process.env.HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS;
   process.env.HARNESS_DAEMON_USER_ROOT = path.join(rootDir, "user-daemon");
   process.env.HARNESS_DAEMON_IDLE_MS = "250";
+  // Cold daemon spawn on a loaded CI runner regularly exceeds the 6s
+  // interactive default; the hermetic tests care about correctness, not
+  // interactive latency.
+  process.env.HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS ||= "30000";
   try {
     return await run();
   } finally {
     restoreEnv("HARNESS_DAEMON_USER_ROOT", previousUserRoot);
     restoreEnv("HARNESS_DAEMON_IDLE_MS", previousIdleMs);
+    restoreEnv("HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS", previousAutostartTimeout);
   }
 }
 

--- a/packages/gui/test/helpers/daemon-generation-lifecycle.ts
+++ b/packages/gui/test/helpers/daemon-generation-lifecycle.ts
@@ -16,13 +16,19 @@ export async function withGuiDaemonEnv<T>(
 ): Promise<T> {
   const previousUserRoot = process.env.HARNESS_DAEMON_USER_ROOT;
   const previousIdleMs = process.env.HARNESS_DAEMON_IDLE_MS;
+  const previousAutostartTimeout = process.env.HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS;
   process.env.HARNESS_DAEMON_USER_ROOT = path.join(rootDir, "user-daemon");
   process.env.HARNESS_DAEMON_IDLE_MS = options.idleMs ?? "250";
+  // Cold daemon spawn on a loaded CI runner regularly exceeds the 6s
+  // interactive default; the hermetic tests care about correctness, not
+  // interactive latency.
+  process.env.HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS ||= "30000";
   try {
     return await run();
   } finally {
     restoreEnv("HARNESS_DAEMON_USER_ROOT", previousUserRoot);
     restoreEnv("HARNESS_DAEMON_IDLE_MS", previousIdleMs);
+    restoreEnv("HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS", previousAutostartTimeout);
   }
 }
 


### PR DESCRIPTION
# English

## Summary

Root-causes and fixes the recurring GUI service-bridge CI flake (7 hits across #883/#894/#899/#901): the GUI daemon autostart deadline defaults to 6 seconds (`defaultDaemonAutostartTimeoutMs`), tuned for interactive latency. A cold daemon spawn on a loaded CI runner regularly exceeds that — the failing tests ran 8.6–9.7s before asserting — so the bridge reported `daemon_unavailable` (connect ENOENT) and the test failed before the daemon finished booting.

## What Changed

- Both hermetic GUI daemon test envs (`packages/gui/test/helpers/daemon-generation-lifecycle.ts` and the local helper in `catalog-decision-ipc.test.ts`) now set `HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS=30000` unless the variable is already set, and restore it afterward.
- No assertion changes; no production-default change — the interactive 6s policy stays as is, only the hermetic test environment declares a CI-realistic startup window through the existing override.

## Task And Scope

- Post-merge red-triage line: this flake was rerun-classified three times today on the W6 critical path; fixing the instrument beats re-running it.
- Test files only; no runtime code touched.

## Version Impact

- No published package version change.

## Governance Declaration

- No protected paths touched (`.github/**`, `tools/**`, `harness/**` untouched).
- Not a gate weakening: the tests still fail if the daemon genuinely cannot start; only the startup grace window in the hermetic env changed, via the pre-existing env override.

## Verification

- `service-bridge.test.ts` + `catalog-decision-ipc.test.ts`: 25/25 locally.
- Root `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 — 33 manifest gates green.

## Review Evidence

- CEO review: timeout resolution confirmed at `local-composition-root.ts` `daemonAutostartTimeoutMs()` reading the env at call time, so the in-process bridge picks it up; both helper definitions patched (verified the repo has exactly these two).

## Residual Risk

- If CI runners degrade beyond 30s cold-start, the flake signature returns; the window is env-tunable without code change.

## References

- Flake occurrences: #883, #894, #899, #901 check reruns (same `daemon_unavailable` ENOENT signature at `service-bridge.test.ts`).

---

# 中文

## 概要

根治反复出现的 GUI service-bridge CI flake（#883/#894/#899/#901 共 7 次）：GUI daemon 自动启动的截止时间默认 6 秒（`defaultDaemonAutostartTimeoutMs`），为交互延迟调校。负载重的 CI runner 上冷启动 daemon 经常超过该窗口——失败用例断言前已跑 8.6–9.7 秒——于是 bridge 报 `daemon_unavailable`（connect ENOENT），测试在 daemon 完成启动前就失败。

## 改动内容

- 两处 hermetic GUI daemon 测试环境（`packages/gui/test/helpers/daemon-generation-lifecycle.ts` 与 `catalog-decision-ipc.test.ts` 内的本地 helper）在变量未设置时设 `HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS=30000`，用后恢复。
- 断言零改动；生产默认零改动——交互 6 秒策略不变，只是 hermetic 测试环境通过既有覆盖变量声明一个符合 CI 现实的启动窗口。

## 任务与范围

- post-merge 红色处置线：该 flake 今天在 W6 关键路径上被 rerun 分类三次；修仪器胜过反复重跑。
- 仅测试文件；未触碰运行时代码。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 未触碰受保护路径（`.github/**`、`tools/**`、`harness/**` 均未动）。
- 非门禁削弱：daemon 真起不来时测试照样失败；只经由既有 env 覆盖改变了 hermetic 环境的启动宽限窗口。

## 验证

- `service-bridge.test.ts` + `catalog-decision-ipc.test.ts`：本地 25/25。
- 根 `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0——33 个 manifest gate 全绿。

## 审查证据

- CEO 复核：确认 `local-composition-root.ts` 的 `daemonAutostartTimeoutMs()` 在调用时读取该 env，进程内 bridge 能接收；两处 helper 定义均已修补（已核实全仓只有这两处）。

## 残余风险

- 若 CI runner 劣化到冷启动超 30 秒，该 flake 特征会回归；窗口可经 env 调整、无需改代码。

## 关联材料

- flake 记录：#883、#894、#899、#901 的 check 重跑（`service-bridge.test.ts` 同一 `daemon_unavailable` ENOENT 特征）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
