### PR TITLE
fix(cli): admit task claims through authority v2 (D22)

### DIFF
--- a/packages/cli/src/daemon/authority-command-submission.ts
+++ b/packages/cli/src/daemon/authority-command-submission.ts
@@ -44,6 +44,12 @@ export interface DaemonAuthorityAttemptCompilerV2 {
     readonly currentSession: CurrentSessionRef;
     readonly operation: WriteOp;
   }) => Promise<AuthorizedOperationAttemptV2>;
+  readonly compileTaskClaim?: (input: {
+    readonly command: ParsedCommand;
+    readonly attribution: CliActorAttribution;
+    readonly currentSession: CurrentSessionRef;
+    readonly operation: WriteOp;
+  }) => Promise<AuthorizedOperationAttemptV2>;
 }
 
 export interface DaemonAuthorityCommandSubmissionV2 {
@@ -60,6 +66,12 @@ export interface DaemonAuthorityCommandSubmissionV2 {
     readonly operation: WriteOp;
   }) => Promise<AuthorityOperationReceipt>;
   readonly submitDecisionTransition?: (input: {
+    readonly command: ParsedCommand;
+    readonly attribution: CliActorAttribution;
+    readonly currentSession: CurrentSessionRef;
+    readonly operation: WriteOp;
+  }) => Promise<AuthorityOperationReceipt>;
+  readonly submitTaskClaim?: (input: {
     readonly command: ParsedCommand;
     readonly attribution: CliActorAttribution;
     readonly currentSession: CurrentSessionRef;
@@ -89,6 +101,10 @@ export function createDaemonAuthorityCommandSubmissionV2(options: {
     ...(options.attemptCompiler.compileDecisionTransition ? {
       submitDecisionTransition: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileDecisionTransition"]>>[0]) =>
         submitAttempt(await options.attemptCompiler.compileDecisionTransition!(input))
+    } : {}),
+    ...(options.attemptCompiler.compileTaskClaim ? {
+      submitTaskClaim: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileTaskClaim"]>>[0]) =>
+        submitAttempt(await options.attemptCompiler.compileTaskClaim!(input))
     } : {})
   };
 }
@@ -174,10 +190,16 @@ export function makeDaemonAuthorityWriteCoordinator(
         if (decisionTransition && !submission.submitDecisionTransition) {
           throw authorityWriteRejected("AUTHORITY_DECISION_TRANSITION_SUBMISSION_UNAVAILABLE");
         }
+        const taskClaim = input.command.action.kind === "task-claim";
+        if (taskClaim && !submission.submitTaskClaim) {
+          throw authorityWriteRejected("AUTHORITY_TASK_CLAIM_SUBMISSION_UNAVAILABLE");
+        }
         settled ??= provenanceSession
           ? submission.submitProvenanceSession!({ ...input, operation: pending })
           : decisionTransition
             ? submission.submitDecisionTransition!({ ...input, operation: pending })
+          : taskClaim
+            ? submission.submitTaskClaim!({ ...input, operation: pending })
           : submission.submit({
             ...input,
             canonicalEntityId: commandMainEntityId(input.command) ?? pending.entityId

--- a/packages/cli/src/daemon/authority-submission-dispatch.ts
+++ b/packages/cli/src/daemon/authority-submission-dispatch.ts
@@ -26,6 +26,12 @@ export function bindAuthoritySubmissionForDispatch(
         dispatch.assertActive();
         return bound.submitDecisionTransition!(submission);
       }
+    } : {}),
+    ...(bound.submitTaskClaim ? {
+      submitTaskClaim: async (submission: Parameters<NonNullable<typeof bound.submitTaskClaim>>[0]) => {
+        dispatch.assertActive();
+        return bound.submitTaskClaim!(submission);
+      }
     } : {})
   };
 }

--- a/packages/cli/src/daemon/production-authority-attempt-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-attempt-compiler.ts
@@ -49,6 +49,7 @@ import { defaultCliAdapterProvider } from "../composition/adapter-registry.ts";
 import { buildAuthorityPresetTaskCreateWrites, shouldUsePresetAwareNewTask } from "../commands/preset-task.ts";
 import { readProjectHarnessSettings, shouldUseSettingsPresetAwareNewTask } from "../commands/settings.ts";
 import { provenanceSessionAttemptIntent } from "./production-authority-provenance-session-intent.ts";
+import { taskClaimAttemptIntent } from "./production-authority-task-claim-intent.ts";
 
 type KeyMaterial = ReturnType<typeof openAuthorityProductionKeyMaterial>;
 
@@ -212,6 +213,13 @@ export function createProductionCanonicalAttemptCompiler(input: {
       currentSession,
       operation.entityId,
       decisionTransitionAttemptIntent(command, operation, input.authoredRoot)
+    ),
+    compileTaskClaim: async ({ command, attribution, currentSession, operation }) => compileIntent(
+      command,
+      attribution,
+      currentSession,
+      operation.entityId,
+      taskClaimAttemptIntent(command, attribution, currentSession, operation)
     )
   };
 }
@@ -445,19 +453,6 @@ async function canonicalAttemptIntent(
     };
     const entity = ref("session", `session/${action.sessionId}`);
     return canonicalIntent("session.export", encodeSessionExecutionReviewCommandPayloadV2(payload), [{ entity, action: "export" }], [entity], [`sessions/${action.sessionId}.md`, `objects/sha256/${digest.slice(0, 2)}/${digest.slice(2)}`], `entity/session/${action.sessionId}`);
-  }
-  if (action.kind === "task-claim" && action.executionId) {
-    const executionId = action.executionId;
-    const payload: SessionExecutionReviewCommandPayloadV2 = {
-      schema: "execution.claim/v1", taskId: action.taskId,
-      execution: {
-        schema: "execution/v2", execution_id: executionId, task_ref: `task/${action.taskId}`, state: "active",
-        primary_actor: executionActor, claimed_at: currentSession.detectedAt, submitted_at: null, closed_at: null,
-        session_bindings: [], outputs: [], submission: null
-      }
-    };
-    const entity = ref("execution", `execution/${action.taskId}/${executionId}`);
-    return canonicalIntent("execution.claim", encodeSessionExecutionReviewCommandPayloadV2(payload), [{ entity, action: "claim" }], [entity], [`tasks/${action.taskId}/executions/${executionId}.md`], `execution/${executionId}`);
   }
   if (action.kind === "task-review-execution" && !action.consentId && action.verdict !== "approved") {
     const reviewId = canonicalEntityId.replace(/^(?:entity\/)?review\//u, "");

--- a/packages/cli/src/daemon/production-authority-lifecycle.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle.ts
@@ -373,6 +373,9 @@ function createRepoComponent(
         ...(commandSubmission.submitDecisionTransition ? {
           submitDecisionTransition: commandSubmission.submitDecisionTransition
         } : {}),
+        ...(commandSubmission.submitTaskClaim ? {
+          submitTaskClaim: commandSubmission.submitTaskClaim
+        } : {}),
         serveForcedCommand: ({ input: readable, output }) => {
           const session = serveAuthorityForcedCommand({
             input: readable,

--- a/packages/cli/src/daemon/production-authority-task-claim-intent.ts
+++ b/packages/cli/src/daemon/production-authority-task-claim-intent.ts
@@ -1,0 +1,116 @@
+import { isDeepStrictEqual } from "node:util";
+import { Schema } from "effect";
+import { encodeSessionExecutionReviewCommandPayloadV2 } from "../../../application/src/index.ts";
+import {
+  executionDeclaration,
+  taskHolderActor,
+  type CurrentSessionRef,
+  type ExecutionRecord,
+  type WriteOp
+} from "../../../kernel/src/index.ts";
+import type { ParsedCommand } from "../cli/types.ts";
+import type { CliActorAttribution } from "../composition/actor-attribution.ts";
+import type { CanonicalAttemptIntent } from "./production-authority-attempt-compiler.ts";
+
+export function taskClaimAttemptIntent(
+  command: ParsedCommand,
+  attribution: CliActorAttribution,
+  currentSession: CurrentSessionRef,
+  operation: WriteOp
+): CanonicalAttemptIntent {
+  const action = command.action;
+  if (action.kind !== "task-claim") throw new Error("AUTHORITY_TASK_CLAIM_COMMAND_REQUIRED");
+  if (operation.kind !== "doc_write") throw new Error("AUTHORITY_TASK_CLAIM_OPERATION_MISMATCH");
+  const payload = exactRecord(operation.payload, ["entityDocument", "companionWrites", "preconditions"], "AUTHORITY_TASK_CLAIM_PAYLOAD_INVALID");
+  if (!Array.isArray(payload.companionWrites) || payload.companionWrites.length !== 0
+    || !Array.isArray(payload.preconditions) || payload.preconditions.length !== 0) {
+    throw new Error("AUTHORITY_TASK_CLAIM_WRITE_SET_INVALID");
+  }
+  const document = exactRecord(payload.entityDocument, ["declaration", "identity", "body"], "AUTHORITY_TASK_CLAIM_DOCUMENT_INVALID");
+  const declaration = exactRecord(document.declaration, ["kind", "storageForm", "rootResolver"], "AUTHORITY_TASK_CLAIM_DECLARATION_INVALID");
+  const expectedDeclaration = {
+    kind: executionDeclaration.kind,
+    storageForm: executionDeclaration.storageForm,
+    rootResolver: executionDeclaration.rootResolver
+  };
+  if (!isDeepStrictEqual(declaration, expectedDeclaration)) throw new Error("AUTHORITY_TASK_CLAIM_DECLARATION_MISMATCH");
+  const identity = exactRecord(document.identity, ["taskId", "executionId"], "AUTHORITY_TASK_CLAIM_IDENTITY_INVALID");
+  if (identity.taskId !== action.taskId || typeof identity.executionId !== "string" || !identity.executionId) {
+    throw new Error("AUTHORITY_TASK_CLAIM_IDENTITY_MISMATCH");
+  }
+  if (action.executionId !== undefined && action.executionId !== identity.executionId) {
+    throw new Error("AUTHORITY_TASK_CLAIM_EXPLICIT_EXECUTION_MISMATCH");
+  }
+  if (typeof document.body !== "string") throw new Error("AUTHORITY_TASK_CLAIM_BODY_INVALID");
+  const execution = decodeExecution(document.body);
+  if (operation.entityId !== `entity/execution/${execution.execution_id}`
+    || execution.execution_id !== identity.executionId
+    || execution.task_ref !== `task/${action.taskId}`) {
+    throw new Error("AUTHORITY_TASK_CLAIM_ENTITY_MISMATCH");
+  }
+  if (execution.state !== "active" || execution.submitted_at !== null || execution.closed_at !== null
+    || execution.submission !== null || execution.outputs.length !== 0) {
+    throw new Error("AUTHORITY_TASK_CLAIM_STATE_INVALID");
+  }
+  const expectedActor = taskHolderActor(attribution.taskHolderPrincipal, attribution.executor);
+  if (!isDeepStrictEqual(execution.primary_actor, expectedActor)) throw new Error("AUTHORITY_TASK_CLAIM_ACTOR_MISMATCH");
+  assertSessionBinding(execution, currentSession);
+  const executionId = execution.execution_id;
+  const entity = {
+    registryVersion: 1 as const,
+    entityKind: "execution",
+    canonicalRef: `execution/${action.taskId}/${executionId}`
+  };
+  const typedPayload = { schema: "execution.claim/v1" as const, taskId: action.taskId, execution };
+  return {
+    commandName: "execution.claim",
+    payload: encodeSessionExecutionReviewCommandPayloadV2(typedPayload),
+    mutations: [{ entity, action: "claim" }],
+    baseRefs: [entity],
+    portablePaths: [`tasks/${action.taskId}/executions/${executionId}.md`],
+    declaredPathCas: [],
+    physicalEntityId: operation.entityId
+  };
+}
+
+function decodeExecution(body: string): ExecutionRecord {
+  let execution: ExecutionRecord;
+  try {
+    execution = Schema.decodeUnknownSync(executionDeclaration.schema)(
+      executionDeclaration.documentCodec.decode(body)
+    ) as ExecutionRecord;
+  } catch {
+    throw new Error("AUTHORITY_TASK_CLAIM_BODY_INVALID");
+  }
+  if (executionDeclaration.documentCodec.encode(execution) !== body) {
+    throw new Error("AUTHORITY_TASK_CLAIM_BODY_NON_CANONICAL");
+  }
+  return execution;
+}
+
+function assertSessionBinding(execution: ExecutionRecord, currentSession: CurrentSessionRef): void {
+  if (execution.session_bindings.length !== 1) throw new Error("AUTHORITY_TASK_CLAIM_SESSION_BINDING_INVALID");
+  const binding = execution.session_bindings[0]!;
+  const expectedSession = currentSession.runtime === "human" ? null : currentSession;
+  const expectedSessionRef = expectedSession ? `session/${currentSession.sessionId}` : null;
+  const expectedBindingId = expectedSession ? `primary:${currentSession.sessionId}` : "primary:pending";
+  if (binding.role !== "primary" || binding.archive_status !== "pending"
+    || binding.binding_id !== expectedBindingId || binding.session_ref !== expectedSessionRef
+    || !isDeepStrictEqual(binding.session, expectedSession)) {
+    throw new Error("AUTHORITY_TASK_CLAIM_SESSION_BINDING_MISMATCH");
+  }
+  const range = binding.capture_range;
+  if (!range || range.coordinate !== "timestamp" || range.start_at !== binding.attached_at
+    || range.end_at !== null || range.bounds !== "inclusive"
+    || range.range_id !== `primary:${expectedSession?.sessionId ?? "pending"}:${binding.attached_at}`) {
+    throw new Error("AUTHORITY_TASK_CLAIM_CAPTURE_RANGE_INVALID");
+  }
+}
+
+function exactRecord(value: unknown, keys: ReadonlyArray<string>, error: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+    || !isDeepStrictEqual(Object.keys(value).sort(), [...keys].sort())) {
+    throw new Error(error);
+  }
+  return value as Record<string, unknown>;
+}

--- a/packages/cli/test/authority-amendment3-seam.test.ts
+++ b/packages/cli/test/authority-amendment3-seam.test.ts
@@ -2,9 +2,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { Effect } from "effect";
-import { taskEntityId } from "../../kernel/src/index.ts";
+import { executionDeclaration, taskEntityId, taskHolderActor, type ExecutionRecord, type WriteOp } from "../../kernel/src/index.ts";
 import { daemonActorAttribution } from "../src/composition/actor-attribution.ts";
 import { makeDaemonAuthorityWriteCoordinator } from "../src/daemon/authority-command-submission.ts";
+import { taskClaimAttemptIntent } from "../src/daemon/production-authority-task-claim-intent.ts";
 import {
   makeHeldLockAttributedCoordinatorFactory,
   type AuthorityLifecycleRuntime
@@ -77,6 +78,122 @@ test("cold task create submits provenance session and task as two ordered canoni
     entityId: taskEntityId(taskId),
     kind: "package_create"
   })), /AUTHORITY_COMMAND_REQUIRES_SINGLE_CANONICAL_OPERATION/u);
+});
+
+test("task claim submits the observed execution write through its narrow typed ingress", async () => {
+  const executionId = "exe_01KXSVW65Q5QK3M8382FK4C0DR";
+  let submittedOperation: unknown;
+  const coordinator = makeDaemonAuthorityWriteCoordinator({
+    submit: async () => { throw new Error("generic authority submission must not compile task claim"); },
+    submitTaskClaim: async (input) => {
+      submittedOperation = input.operation;
+      return committedReceipt("fixture-task-claim-op", 1);
+    }
+  }, {
+    command: {
+      rootDir: "/fixture",
+      json: true,
+      action: { kind: "task-claim", taskId: "task_01KXSVW65Q5QK3M8382FK4C0DR", execution: true }
+    },
+    attribution: daemonActorAttribution({
+      personId: "person_alice",
+      displayName: "Alice",
+      primaryEmail: "alice@example.test",
+      roles: ["owner"],
+      providerId: "test",
+      resolvedCredential: { kind: "unix-socket-owner-boundary", issuer: "test", subject: "person_alice" }
+    }, { kind: "agent", id: "codex" }),
+    currentSession: {
+      runtime: "codex",
+      sessionId: "session-task-claim",
+      source: "runtime",
+      detectedAt: "2026-07-18T00:00:00.000Z"
+    }
+  });
+  const operation = {
+    opId: "observed-task-claim-op",
+    entityId: `entity/execution/${executionId}` as const,
+    kind: "doc_write" as const,
+    payload: { entityDocument: "observed" }
+  };
+
+  await runEffect(coordinator.enqueue(operation));
+  const report = await runEffect(coordinator.flush("explicit"));
+
+  assert.equal(submittedOperation, operation);
+  assert.equal(report.committed, true);
+  assert.equal(report.watermark, "fixture-task-claim-op");
+});
+
+test("task claim typed ingress rejects forged entity, actor, and write-set data", () => {
+  const taskId = "task_01KXSVW65Q5QK3M8382FK4C0DR";
+  const executionId = "exe_01KXSVW65Q5QK3M8382FK4C0DR";
+  const attribution = daemonActorAttribution({
+    personId: "person_alice",
+    displayName: "Alice",
+    primaryEmail: "alice@example.test",
+    roles: ["owner"],
+    providerId: "test",
+    resolvedCredential: { kind: "unix-socket-owner-boundary", issuer: "test", subject: "person_alice" }
+  }, { kind: "agent", id: "codex" });
+  const currentSession = {
+    runtime: "codex" as const,
+    sessionId: "session-task-claim-strict",
+    source: "runtime" as const,
+    detectedAt: "2026-07-18T00:00:00.000Z"
+  };
+  const command = {
+    rootDir: "/fixture",
+    json: true,
+    action: { kind: "task-claim" as const, taskId, execution: true }
+  };
+  const execution: ExecutionRecord = {
+    schema: "execution/v2",
+    execution_id: executionId,
+    task_ref: `task/${taskId}`,
+    state: "active",
+    primary_actor: taskHolderActor(attribution.taskHolderPrincipal, attribution.executor),
+    claimed_at: "2026-07-18T00:00:00.001Z",
+    submitted_at: null,
+    closed_at: null,
+    session_bindings: [{
+      binding_id: `primary:${currentSession.sessionId}`,
+      session_ref: `session/${currentSession.sessionId}`,
+      role: "primary",
+      archive_status: "pending",
+      attached_at: "2026-07-18T00:00:00.002Z",
+      session: currentSession,
+      capture_range: {
+        range_id: `primary:${currentSession.sessionId}:2026-07-18T00:00:00.002Z`,
+        coordinate: "timestamp",
+        start_at: "2026-07-18T00:00:00.002Z",
+        end_at: null,
+        bounds: "inclusive"
+      }
+    }],
+    outputs: [],
+    submission: null
+  };
+  const operation = claimOperation(taskId, execution);
+
+  const intent = taskClaimAttemptIntent(command, attribution, currentSession, operation);
+  assert.equal(intent.commandName, "execution.claim");
+  assert.equal(intent.physicalEntityId, `entity/execution/${executionId}`);
+  assert.throws(() => taskClaimAttemptIntent(command, attribution, currentSession, {
+    ...operation,
+    entityId: "entity/execution/exe_forged"
+  }), /AUTHORITY_TASK_CLAIM_ENTITY_MISMATCH/u);
+  assert.throws(() => taskClaimAttemptIntent(command, attribution, currentSession, claimOperation(taskId, {
+    ...execution,
+    primary_actor: { ...execution.primary_actor, responsibleHuman: "person_forged" }
+  })), /AUTHORITY_TASK_CLAIM_ACTOR_MISMATCH/u);
+  assert.throws(() => taskClaimAttemptIntent(command, attribution, currentSession, {
+    ...operation,
+    payload: {
+      ...(operation.payload as Record<string, unknown>),
+      companionWrites: [{ taskId, path: "INDEX.md", body: "forged" }]
+    }
+  }), /AUTHORITY_TASK_CLAIM_WRITE_SET_INVALID/u);
 });
 
 test("held-lock authority flush uses one atomic publication instead of direct materialization", async () => {
@@ -180,5 +297,26 @@ function committedReceipt(opId: string, revision: number) {
     revision,
     commitSha: String(revision).repeat(40),
     previousCommit: revision === 1 ? null : "1".repeat(40)
+  };
+}
+
+function claimOperation(taskId: string, execution: ExecutionRecord): WriteOp {
+  return {
+    opId: "observed-strict-task-claim-op",
+    entityId: `entity/execution/${execution.execution_id}`,
+    kind: "doc_write",
+    payload: {
+      entityDocument: {
+        declaration: {
+          kind: executionDeclaration.kind,
+          storageForm: executionDeclaration.storageForm,
+          rootResolver: executionDeclaration.rootResolver
+        },
+        identity: { taskId, executionId: execution.execution_id },
+        body: executionDeclaration.documentCodec.encode(execution)
+      },
+      companionWrites: [],
+      preconditions: []
+    }
   };
 }

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -41,6 +41,7 @@ import {
   latestAuthorityOperation,
   writeColdCodexSessionLog
 } from "./fixture.ts";
+import { verifyD22ClaimChain } from "./d22-claim-chain.ts";
 
 test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 120_000 }, async () => {
   const fixture = createFixture();
@@ -118,6 +119,18 @@ test("production service route preserves progress dry-run and publishes canonica
     assert.match(readFileSync(path.join(
       fixture.authoredRoot, `decisions/decision-${decisionId}/decision.md`
     ), "utf8"), /^state: active$/mu);
+
+    const initialLeaseSessionId = "service-initial-task-leases";
+    writeColdCodexSessionLog(fixture.repoRoot, initialLeaseSessionId);
+    const initialLeaseEnv = { ...env, CODEX_THREAD_ID: initialLeaseSessionId };
+    const initialTaskClaim = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "claim", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"
+    ], initialLeaseEnv);
+    assert.equal(initialTaskClaim.status, 0, JSON.stringify(initialTaskClaim.receipt));
+    const initialSluggedClaim = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "claim", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8", "--execution-id", "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG7"
+    ], initialLeaseEnv);
+    assert.equal(initialSluggedClaim.status, 0, JSON.stringify(initialSluggedClaim.receipt));
 
     const dryRunHead = git(fixture.authoredRoot, "rev-parse", "HEAD");
     const dryRun = runRawJsonMaybeFail(fixture.repoRoot, [
@@ -261,6 +274,13 @@ test("production service route preserves progress dry-run and publishes canonica
     assert.equal(existsSync(path.join(fixture.authoredRoot, `sessions/${bareSessionId}.md`)), true);
     assert.equal(authorityOperationRecords(fixture.serviceRoot).length, beforeColdBare + 2, "cold bare create must commit session.export then task.create");
 
+    await verifyD22ClaimChain({
+      fixture,
+      env,
+      taskId: String(createDetails.taskId),
+      packagePath: createPackagePath
+    });
+
     const beforeHotBare = authorityOperationRecords(fixture.serviceRoot).length;
     const hotCreated = runRawJsonMaybeFail(fixture.repoRoot, [
       "task", "create", "--title", "Service route hot-session task create"
@@ -318,7 +338,7 @@ test("production service route preserves progress dry-run and publishes canonica
   }
 });
 
-test("production canonical ingress accepts and journals one write for every canonical kind", async () => {
+test("production generic canonical ingress accepts and journals one write for every directly compiled kind", async () => {
   const fixture = createFixture();
   const daemon = defaultCliAdapterProvider().createMultiRepoDaemonRuntime({
     repos: [{ repoId: "canonical", rootDir: fixture.repoRoot }],
@@ -406,12 +426,6 @@ test("production canonical ingress accepts and journals one write for every cano
       authoredPath: "sessions/session-ingress.md",
       authoredMarker: /session-ingress/u
     }, {
-      kind: "execution",
-      action: { kind: "task-claim", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", execution: true, executionId: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG1" },
-      canonicalEntityId: "execution/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG1" as EntityId,
-      authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/executions/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG1.md",
-      authoredMarker: /exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG1/u
-    }, {
       kind: "review",
       action: {
         kind: "task-review-execution", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", executionId: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5",
@@ -484,7 +498,7 @@ test("production canonical ingress accepts and journals one write for every cano
       authoredMarker: /status: done/u
     }];
     const coveredKinds = new Set(cases.map((fixtureCase) => fixtureCase.kind));
-    assert.equal(["consent", "decision", "execution", "fact", "module", "relation", "review", "session", "task"]
+    assert.equal(["consent", "decision", "fact", "module", "relation", "review", "session", "task"]
       .every((kind) => coveredKinds.has(kind)), true);
     for (const [index, fixtureCase] of cases.entries()) {
       const sessionId = `real-cli-session-${index + 1}`;

--- a/packages/cli/test/production-authority-canonical-ingress/d22-claim-chain.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/d22-claim-chain.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { sha256Text } from "../../../kernel/src/index.ts";
+import { createGitCanonicalPublicationInspector } from "../../src/daemon/authority-publication-evidence.ts";
+import { runRawJsonMaybeFail } from "../helpers/daemon-cli.ts";
+import {
+  authorityEventBodies,
+  authorityOperationRecords,
+  latestAuthorityOperation,
+  writeColdCodexSessionLog,
+  type ProductionCanonicalIngressFixture
+} from "./fixture.ts";
+
+export async function verifyD22ClaimChain(input: {
+  readonly fixture: ProductionCanonicalIngressFixture;
+  readonly env: NodeJS.ProcessEnv;
+  readonly taskId: string;
+  readonly packagePath: string;
+}): Promise<void> {
+  const { fixture, taskId } = input;
+  const claimSessionId = "service-task-claim-cold-session";
+  const claimEnv = { ...input.env, CODEX_THREAD_ID: claimSessionId };
+  writeColdCodexSessionLog(fixture.repoRoot, claimSessionId);
+  assert.equal(existsSync(path.join(fixture.authoredRoot, `sessions/${claimSessionId}.md`)), false);
+  const blockedBeforeClaim = runRawJsonMaybeFail(fixture.repoRoot, [
+    "task", "progress", "append", taskId, "--text", "must remain blocked before claim"
+  ], claimEnv);
+  assert.equal(blockedBeforeClaim.status, 1, JSON.stringify(blockedBeforeClaim.receipt));
+  assert.match(JSON.stringify(blockedBeforeClaim.receipt), /TASK_LEASE_REQUIRED|active lease/iu);
+
+  const beforeColdClaim = authorityOperationRecords(fixture.serviceRoot).length;
+  const coldClaimed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "claim", taskId], claimEnv);
+  assert.equal(coldClaimed.status, 0, JSON.stringify(coldClaimed.receipt));
+  assert.equal(coldClaimed.receipt.ok, true, JSON.stringify(coldClaimed.receipt));
+  const coldClaimReport = claimReport(coldClaimed.receipt.details);
+  const executionId = String(coldClaimReport.executionId ?? "");
+  const coldLeaseToken = String(coldClaimReport.leaseToken ?? "");
+  assert.match(executionId, /^exe_[0-9A-HJKMNP-TV-Z]{26}$/u, JSON.stringify(coldClaimed.receipt));
+  assert.equal(coldClaimReport.reused, false, JSON.stringify(coldClaimed.receipt));
+  assert.match(coldLeaseToken, /^[0-9a-f]{64}$/u, JSON.stringify(coldClaimed.receipt));
+  const claimOperation = latestAuthorityOperation(fixture.serviceRoot);
+  assert.equal(claimOperation.state, "COMMITTED", JSON.stringify(claimOperation));
+  assert.equal(claimOperation.receipt?.tag, "COMMITTED", JSON.stringify(claimOperation));
+  assert.equal(authorityOperationRecords(fixture.serviceRoot).length, beforeColdClaim + 1);
+  const publication = await createGitCanonicalPublicationInspector(fixture.authoredRoot)
+    .findPublicationForOperation(claimOperation.opId!);
+  assert.equal(publication.commitSha, claimOperation.commitSha);
+  assert.equal(publication.parentCommits.length, 2);
+  assert.deepEqual(publication.physicalChanges.map((change) => change.path).sort(), [
+    `attribution-events/${sha256Text(claimOperation.opId!)}.jsonl`,
+    `${path.relative(fixture.authoredRoot, path.join(fixture.repoRoot, input.packagePath))}/executions/${executionId}.md`
+  ].sort());
+  assert.equal(publication.pipelineGeneratedPaths.length, 1);
+  assert.equal(authorityEventBodies(fixture.authoredRoot).filter((body) => body.includes(claimOperation.opId!)).length, 1);
+  const executionBody = readFileSync(path.join(fixture.repoRoot, input.packagePath, "executions", `${executionId}.md`), "utf8");
+  assert.match(executionBody, new RegExp(`"session_ref": "session/${claimSessionId}"`, "u"));
+  assert.equal(existsSync(path.join(fixture.authoredRoot, `sessions/${claimSessionId}.md`)), false,
+    "claim binds the cold runtime session but must not fabricate a Session export");
+
+  const progressed = runRawJsonMaybeFail(fixture.repoRoot, [
+    "task", "progress", "append", taskId, "--text", "D22 create claim progress release chain"
+  ], claimEnv);
+  assert.equal(progressed.status, 0, JSON.stringify(progressed.receipt));
+  assert.equal(progressed.receipt.ok, true, JSON.stringify(progressed.receipt));
+  const exported = runRawJsonMaybeFail(fixture.repoRoot, [
+    "session", "export", "--session", claimSessionId, "--runtime", "codex", "--source", "runtime",
+    "--detected-at", "2026-07-17T00:00:00.000Z", "--transcript-file", fixture.transcriptPath
+  ], claimEnv);
+  assert.equal(exported.status, 0, JSON.stringify(exported.receipt));
+
+  const beforeHotClaim = authorityOperationRecords(fixture.serviceRoot).length;
+  const hotClaimed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "claim", taskId, "--execution"], claimEnv);
+  assert.equal(hotClaimed.status, 0, JSON.stringify(hotClaimed.receipt));
+  const hotReport = claimReport(hotClaimed.receipt.details);
+  assert.equal(hotReport.executionId, executionId);
+  assert.equal(hotReport.reused, true);
+  assert.notEqual(hotReport.leaseToken, coldLeaseToken, "renewal must rotate the lease token");
+  assert.equal(authorityOperationRecords(fixture.serviceRoot).length, beforeHotClaim,
+    "lease renewal must not fabricate a canonical mutation");
+
+  const wrongRelease = runRawJsonMaybeFail(fixture.repoRoot, ["task", "release", taskId], {
+    ...claimEnv,
+    HARNESS_ACTOR: "agent:other-executor"
+  });
+  assert.equal(wrongRelease.status, 1, JSON.stringify(wrongRelease.receipt));
+  assert.match(JSON.stringify(wrongRelease.receipt), /TASK_RELEASE_NOT_HOLDER|not the active holder/iu);
+  const beforeRelease = authorityOperationRecords(fixture.serviceRoot).length;
+  const released = runRawJsonMaybeFail(fixture.repoRoot, ["task", "release", taskId], claimEnv);
+  assert.equal(released.status, 0, JSON.stringify(released.receipt));
+  assert.equal(authorityOperationRecords(fixture.serviceRoot).length, beforeRelease,
+    "lease release must remain in the operational flush domain");
+  const rejectedProgress = runRawJsonMaybeFail(fixture.repoRoot, [
+    "task", "progress", "append", taskId, "--text", "must remain blocked after release"
+  ], claimEnv);
+  assert.equal(rejectedProgress.status, 1, JSON.stringify(rejectedProgress.receipt));
+  assert.match(JSON.stringify(rejectedProgress.receipt), /TASK_LEASE_REQUIRED|active lease/iu);
+
+  const beforeReclaim = authorityOperationRecords(fixture.serviceRoot).length;
+  const reclaimed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "claim", taskId, "--execution-id", executionId], claimEnv);
+  assert.equal(reclaimed.status, 0, JSON.stringify(reclaimed.receipt));
+  const reclaimReport = claimReport(reclaimed.receipt.details);
+  assert.equal(reclaimReport.executionId, executionId);
+  assert.equal(reclaimReport.reused, true);
+  assert.notEqual(reclaimReport.leaseToken, hotReport.leaseToken);
+  assert.equal(authorityOperationRecords(fixture.serviceRoot).length, beforeReclaim,
+    "upgrade reclaim of an existing execution must not create a second authored execution");
+  const finalRelease = runRawJsonMaybeFail(fixture.repoRoot, ["task", "release", taskId], claimEnv);
+  assert.equal(finalRelease.status, 0, JSON.stringify(finalRelease.receipt));
+}
+
+function claimReport(details: unknown): Record<string, unknown> {
+  return (details as { readonly data?: { readonly report?: Record<string, unknown> } } | undefined)?.data?.report ?? {};
+}

--- a/packages/cli/test/production-authority-canonical-ingress/fixture.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/fixture.ts
@@ -9,6 +9,8 @@ import { openLocalAuthorityKeyStore } from "../../../daemon/src/index.ts";
 import { executionDeclaration, type ExecutionRecord } from "../../../kernel/src/index.ts";
 import { authorityNamespaceProofBytes } from "../../src/daemon/authority-production-state.ts";
 
+export type ProductionCanonicalIngressFixture = ReturnType<typeof createFixture>;
+
 export function createFixture() {
   const root = realpathSync(mkdtempSync(path.join(tmpdir(), "ha-production-canonical-ingress-")));
   const repoRoot = path.join(root, "repo");
@@ -122,6 +124,8 @@ export function enablePresetAwareTaskCreate(authoredRoot: string): void {
     "  defaultVertical: software/coding",
     "  defaultPreset: docs-task",
     "  locale: en-US",
+    "  tasks:",
+    "    leaseEnforcement: true",
     ""
   ].join("\n"));
   git(authoredRoot, "add", "harness.yaml");


### PR DESCRIPTION
# English

## Summary

W6 defect D22: the production canonical ingress rejected `task claim` (`AUTHORITY_TYPED_COMMAND_UNSUPPORTED`) while `task progress append` requires an active lease — so every newly created task fell into a lifecycle dead zone (create → cannot claim → cannot progress). Reproduced live on task_01KXSVW65Q5QK3M8382FK4C0DR.

## What Changed

- `task claim` is admitted through a strictly validated typed V2 ingress (`production-authority-task-claim-intent.ts`), following the same pattern as D19's `decision transition` ingress: full entity/tree/commit/mutation-set proofs, negative controls for wrong actor/entity/write-set.
- Lease renewal and release stay in the daemon-private lease domain with strict owner/executor validation; no canonical commits are fabricated for lease state, preserving the D16 domain separation and active-execution reuse semantics.

## Task And Scope

- W6 cutover line task_01KXMN5BRWQH93976XBZSHSCN4; based on latest main 622fba79. Production state untouched; deploy + restart + live claim-chain smoke remain operator actions.
- Successor root fix authorized and queued: dec_01KXSWKWTEXB751A30TRRCQWDG derives typed-ingress coverage from command-spec with a completeness gate, ending the per-command D-series pattern; this PR closes the live dead zone now.

## Version Impact

- No published package version change.

## Governance Declaration

- Authority anchor: task_01KXMN5BRWQH93976XBZSHSCN4; standing W6 fix-then-cut authorization.
- Protected paths touched: none (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `tools/test-tier-manifest.mjs`, `harness/**` untouched).
- No gate weakening: unsupported typed commands still fail closed; claim admission carries full proofs; lease-domain writes never masquerade as canonical commits.

## Verification

- Full-chain regression on the real CLI→socket→daemon road: new-task cold-session claim → progress append → warm-session lease renewal → release → post-release progress rejection → `--execution-id` reuse.
- Proof assertions: COMMITTED registry state, dual-parent publication, inner tree, mutation set, exactly one attribution event per op; negative controls for wrong actor/entity/write-set.
- Focused suites: canonical ingress 7/7, execution/lease 18/18; root `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 (32/32 gates green).

## Review Evidence

- CEO semantic acceptance: claim enters the typed authority road while lease liveness stays daemon-private (runtime state, not ledger truth) — the correct ownership split; no proof shortcuts — confirmed in diff and report.

## Residual Risk

- The typed-command allowlist remains hand-maintained until the command-spec derivation (dec_01KXSWKWTEXB751A30TRRCQWDG) lands; the same worker starts that mission immediately after this PR.
- Live production claim-chain smoke is the operator's post-deploy gate.

## References

- PRs #883–#902 (D14–D21 chain + flake root fix).
- Worker report: `tmp/orch/w6-d15-perf/REPORT.md` § D22.

---

# 中文

## 概要

W6 缺陷 D22:生产 canonical ingress 拒绝 `task claim`(`AUTHORITY_TYPED_COMMAND_UNSUPPORTED`),而 `task progress append` 又要求活跃 lease——所有新建任务陷入生命周期死区(建任务→无法 claim→无法写进展)。已在 task_01KXSVW65Q5QK3M8382FK4C0DR 上真实复现。

## 改动内容

- `task claim` 经严格校验的 typed V2 ingress 准入(`production-authority-task-claim-intent.ts`),沿用 D19 给 `decision transition` 加 ingress 的同一模式:完整 entity/tree/commit/mutation-set 证明,错误 actor/entity/write-set 阴性对照。
- lease 的续租与释放保持在 daemon 私有 lease 域,严格校验 owner/executor;不为 lease 状态伪造 canonical commit,保住 D16 分域与 active execution 复用语义。

## 任务与范围

- W6 cutover 线 task_01KXMN5BRWQH93976XBZSHSCN4;基于最新 main 622fba79。生产状态未触碰;部署、重启与真实 claim 链冒烟归 operator。
- 根治后继已授权排队:dec_01KXSWKWTEXB751A30TRRCQWDG 将 typed ingress 覆盖面从 command-spec 派生并加完备性 gate,终结逐命令补洞的 D 系列模式;本 PR 先关闭眼前的死区。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 授权锚:task_01KXMN5BRWQH93976XBZSHSCN4;W6 fix-then-cut 常设授权。
- 未触碰受保护路径(`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`tools/test-tier-manifest.mjs`、`harness/**` 均未动)。
- 无门禁削弱:不支持的 typed 命令仍 fail-closed;claim 准入携带完整证明;lease 域写入绝不伪装 canonical commit。

## 验证

- 真实 CLI→socket→daemon 路全链回归:新任务冷 session claim→progress append→热 session 续租→release→释放后 progress 拒绝→`--execution-id` 复用。
- 证明断言:COMMITTED registry、双 parent 发布、inner tree、mutation set、每操作恰一 attribution event;错误 actor/entity/write-set 阴性对照。
- 聚焦套件:canonical ingress 7/7、execution/lease 18/18;根 `HARNESS_DAEMON_MODE=direct npm run check:local` exit 0(32/32 门绿)。

## 审查证据

- CEO 语义验收:claim 走 typed authority 路而 lease 存活性留在 daemon 私有域(运行时状态,不是台账真相)——所有权切分正确;无证明捷径——已对照 diff 与报告确认。

## 残余风险

- 在 command-spec 派生方案(dec_01KXSWKWTEXB751A30TRRCQWDG)落地前,typed 命令白名单仍是手维护;同一 worker 在本 PR 后立即开工该任务。
- 生产 claim 链真实冒烟是部署后 operator 的门。

## 关联材料

- PR #883–#902(D14–D21 链+flake 根治)。
- Worker 报告:`tmp/orch/w6-d15-perf/REPORT.md` § D22。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
