### PR TITLE
refactor(cli): template lifecycle wave 0 — lazy progress, retire root review

### DIFF
--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -283,8 +283,6 @@ function validateTaskPackageContracts(
     for (const issue of parsed.issues) {
       issues.push(profileIssue("review-schema", "review_schema_invalid", "hard-fail", `${relativeTaskDir}/review.md failed review schema validation.`, `${JSON.stringify(issue)} Valid severity values: P0, P1, P2, P3.`));
     }
-  } else if (profile !== "source-package") {
-    issues.push(profileIssue("review-schema", "review_missing", strictSeverity(strict), `${relativeTaskDir}/review.md is missing.`, "Add review.md before strict private-harness/target-project validation."));
   }
 
   const visualPath = path.join(taskDir, "visual_map.md");

--- a/packages/cli/src/commands/extensions/assets/software-coding/vertical.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/vertical.json
@@ -57,27 +57,9 @@
           }
         },
         {
-          "slot": "task.progress",
-          "templateRef": "template://planning/progress@1",
-          "materializeAs": "progress.md",
-          "localePolicy": {
-            "prefer": "project",
-            "fallback": "en-US"
-          }
-        },
-        {
           "slot": "task.facts",
           "templateRef": "template://planning/facts@1",
           "materializeAs": "facts.md",
-          "localePolicy": {
-            "prefer": "project",
-            "fallback": "en-US"
-          }
-        },
-        {
-          "slot": "task.review",
-          "templateRef": "template://planning/review@1",
-          "materializeAs": "review.md",
           "localePolicy": {
             "prefer": "project",
             "fallback": "en-US"

--- a/packages/cli/test/check-governance-cli.test.ts
+++ b/packages/cli/test/check-governance-cli.test.ts
@@ -120,9 +120,11 @@ test("CLI task supersede preserves selected preset profile metadata", () => {
     assert.match(index, /vertical: software\/coding/);
     assert.match(index, /preset: profiled-task/);
     assert.match(index, /profile: extra/);
-    for (const documentPath of ["task_plan.md", "progress.md", "facts.md", "review.md", "closeout.md", "artifacts/.gitkeep", "extra.md"]) {
+    for (const documentPath of ["task_plan.md", "facts.md", "closeout.md", "artifacts/.gitkeep", "extra.md"]) {
       assert.equal(existsSync(path.join(rootDir, superseded.packagePath, documentPath)), true, documentPath);
     }
+    assert.equal(existsSync(path.join(rootDir, superseded.packagePath, "progress.md")), false);
+    assert.equal(existsSync(path.join(rootDir, superseded.packagePath, "review.md")), false);
 
     const checked = runJson(rootDir, ["check", "--profile", "target-project", "--strict"]);
     assert.equal(checked.ok, true);
@@ -137,7 +139,7 @@ test("CLI metadata check fails closed on missing preset-selected document and an
     runJson(rootDir, ["init"]);
     const created = runJson(rootDir, ["new-task", "--title", "Coding Task", "--vertical", "software/coding", "--preset", "standard-task"]);
     writeSubstantiveTaskPlan(rootDir, String(created.packagePath));
-    rmSync(path.join(rootDir, created.packagePath, "progress.md"));
+    rmSync(path.join(rootDir, created.packagePath, "facts.md"));
 
     const missingDocument = runJson(rootDir, ["check", "--profile", "target-project", "--strict"], false);
 
@@ -160,7 +162,13 @@ test("CLI metadata check fails closed on missing preset-selected document and an
 test("CLI metadata check applies live section policy to frozen task contract documents", () => {
   withTempRoot((rootDir) => {
     runJson(rootDir, ["init"]);
-    const created = runJson(rootDir, ["new-task", "--title", "Frozen Policy Task", "--vertical", "software/coding", "--preset", "standard-task"]);
+    writePreset(rootDir, ".harness/presets/legacy-review-task/preset.json", {
+      id: "legacy-review-task",
+      title: "Legacy Review Compatibility Task",
+      version: "1.0.0",
+      templateSelections: [legacyReviewSelection()]
+    });
+    const created = runJson(rootDir, ["new-task", "--title", "Frozen Policy Task", "--vertical", "software/coding", "--preset", "legacy-review-task"]);
     writeSubstantiveTaskPlan(rootDir, String(created.packagePath));
     assert.equal(existsSync(path.join(rootDir, created.packagePath, "task-contract.json")), true);
 
@@ -545,6 +553,18 @@ function invalidPathSelection(): Record<string, unknown> {
   };
 }
 
+function legacyReviewSelection(): Record<string, unknown> {
+  return {
+    slot: "task.review",
+    templateRef: "template://planning/review@1",
+    materializeAs: "review.md",
+    localePolicy: {
+      prefer: "project",
+      fallback: "en-US"
+    }
+  };
+}
+
 function makeMultiProfilePreset(): Record<string, unknown> {
   return {
     schema: "preset-manifest/v1",
@@ -642,7 +662,8 @@ function validLessonCandidates(): string {
 function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, any> {
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
-      encoding: "utf8"
+      encoding: "utf8",
+      env: { ...process.env, HARNESS_ACTOR: "agent:check-governance-test" }
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/local-lifecycle-cli.test.ts
+++ b/packages/cli/test/local-lifecycle-cli.test.ts
@@ -214,10 +214,24 @@ test("CLI appends progress through the write journal", () => {
 
     assert.equal(result.ok, true);
     assert.equal(result.path, "progress.md");
-    assert.equal(readFileSync(path.join(rootDir, `harness/tasks/${taskId}-task-one/progress.md`), "utf8"), "Implemented local CLI\n");
+    assert.equal(readFileSync(path.join(rootDir, `harness/tasks/${taskId}-task-one/progress.md`), "utf8"), "# Progress\n\n## Entries\n\nImplemented local CLI\n");
     const payloadBodies = readdirSync(path.join(rootDir, ".harness/write-journal/payloads"))
       .map((entry) => readFileSync(path.join(rootDir, ".harness/write-journal/payloads", entry), "utf8"));
     assert.equal(payloadBodies.some((body) => body.includes("\"path\":\"progress.md\"")), true);
+  });
+});
+
+test("CLI appends progress to an existing progress@1 document without rewriting its legacy structure", () => {
+  withTempRoot((rootDir) => {
+    const created = runJson(rootDir, ["new-task", "--title", "Task One"]);
+    const taskId = assertGeneratedTaskId(created.taskId);
+    const progressPath = path.join(rootDir, `harness/tasks/${taskId}-task-one/progress.md`);
+    const legacyBody = "# Progress\n\n## Log\n\n- Historical entry.\n\n## Evidence\n\n| Type | Path | Summary | Command |\n| --- | --- | --- | --- |\n";
+    writeFileSync(progressPath, legacyBody, "utf8");
+
+    runJson(rootDir, ["task", "progress", "append", taskId, "--text", "Compatible append"]);
+
+    assert.equal(readFileSync(progressPath, "utf8"), `${legacyBody}Compatible append\n`);
   });
 });
 

--- a/packages/cli/test/new-task-cli.test.ts
+++ b/packages/cli/test/new-task-cli.test.ts
@@ -40,6 +40,12 @@ test("CLI init dogfoods coding vertical defaults for new tasks", () => {
     assert.equal(result.report.profile, "baseline");
     assert.equal(result.generated.includes("task_plan.md"), true);
     assert.equal(result.generated.includes("task-contract.json"), true);
+    assert.equal(result.generated.includes("progress.md"), false);
+    assert.equal(result.generated.includes("review.md"), false);
+    assert.equal(existsSync(path.join(rootDir, result.packagePath, "progress.md")), false);
+    assert.equal(existsSync(path.join(rootDir, result.packagePath, "review.md")), false);
+    assert.equal(contract.documents.some((document: { materializeAs: string }) => document.materializeAs === "progress.md"), false);
+    assert.equal(contract.documents.some((document: { materializeAs: string }) => document.materializeAs === "review.md"), false);
     assert.equal(result.generated.includes("read_set.md"), false);
     assert.equal(result.generated.some((entry: string) => entry.startsWith("references/")), false);
     assert.equal(existsSync(path.join(rootDir, result.packagePath, "read_set.md")), false);

--- a/packages/cli/test/package-surface.test.ts
+++ b/packages/cli/test/package-surface.test.ts
@@ -114,6 +114,10 @@ test("bundled software coding assets have consistent template and process-preset
 
   assert.equal(vertical.templateSelections.length, 0, "vertical top-level templateSelections stay deduplicated");
   const taskScaffoldSelections = vertical.packageScaffolds.find((scaffold) => scaffold.entityKind === "task")?.templateSelections ?? [];
+  assert.equal(taskScaffoldSelections.some((selection) => selection.templateRef === "template://planning/progress@1"), false, "new tasks lazily create progress.md on first append");
+  assert.equal(taskScaffoldSelections.some((selection) => selection.templateRef === "template://planning/review@1"), false, "new tasks use typed reviews instead of root review.md");
+  assert.equal(catalogIds.has("planning/progress"), true, "frozen progress@1 remains cataloged for historical task contracts");
+  assert.equal(catalogIds.has("planning/review"), true, "legacy review@1 remains cataloged for historical task contracts");
 
   for (const selection of taskScaffoldSelections) {
     assertKnownTemplateRef(catalogIds, selection.templateRef);

--- a/packages/cli/test/task-document-gates-cli.test.ts
+++ b/packages/cli/test/task-document-gates-cli.test.ts
@@ -106,6 +106,21 @@ test("CLI check and active transition agree on scaffold and substantive task pla
   });
 });
 
+test("CLI strict checker accepts a new-contract task without root review.md", () => {
+  withTempRoot((rootDir) => {
+    const created = runJson(rootDir, ["task", "create", "--title", "Typed Review Contract", "--vertical", "software/coding", "--preset", "standard-task"]);
+    writeSubstantiveTaskPlan(rootDir, created.packagePath);
+    rmSync(path.join(rootDir, created.packagePath, "review.md"), { force: true });
+    writeFileSync(path.join(rootDir, "AGENTS.md"), "# Agent instructions\n", "utf8");
+    writeFileSync(path.join(rootDir, "CLAUDE.md"), "# Claude instructions\n", "utf8");
+
+    const checked = runJson(rootDir, ["check", "--profile", "target-project", "--strict"]);
+
+    assert.equal(checked.report.summary.hardFailCount, 0);
+    assert.equal(checked.warnings.some((warning: Record<string, unknown>) => warning.code === "review_missing"), false);
+  });
+});
+
 test("CLI task-complete without Execution fails closed and leaves INDEX byte-exact", () => {
   withTempRoot((rootDir) => {
     writeIndex(rootDir, "task-1", "Complete Task", "in_review");
@@ -468,6 +483,8 @@ test("CLI complete accepts an approved Execution Review without facts under dec_
 test("CLI default claim carries one person's task through submit, review, and complete", () => {
   withTempRoot((rootDir) => {
     const created = runJson(rootDir, ["task", "create", "--title", "Single Person Closeout", "--vertical", "software/coding", "--preset", "standard-task"]);
+    assert.equal(existsSync(path.join(rootDir, created.packagePath, "progress.md")), false);
+    assert.equal(existsSync(path.join(rootDir, created.packagePath, "review.md")), false);
     writeSubstantiveTaskPlan(rootDir, created.packagePath);
     const sessionId = "codex-single-person-closeout";
     const homeDir = path.join(rootDir, "home");
@@ -485,6 +502,13 @@ test("CLI default claim carries one person's task through submit, review, and co
       "task", "transition", created.taskId, "active"
     ], true, { ...sessionEnv, HARNESS_ACTOR: "agent:worker" });
     assert.equal(activated.status, "active");
+    runJson(rootDir, [
+      "task", "progress", "append", created.taskId, "--text", "Implementation and verification are ready for review."
+    ], true, { ...sessionEnv, HARNESS_ACTOR: "agent:worker" });
+    assert.equal(
+      readFileSync(path.join(rootDir, created.packagePath, "progress.md"), "utf8"),
+      "# Progress\n\n## Entries\n\nImplementation and verification are ready for review.\n"
+    );
     writeCloseout(rootDir, path.basename(created.packagePath), [
       "## Summary", "", "Implemented the single-person closeout flow.", "",
       "## Verification", "", "node --test passed.", "",
@@ -510,6 +534,7 @@ test("CLI default claim carries one person's task through submit, review, and co
     ], true, { HARNESS_ACTOR: "agent:commander" });
     assert.equal(completed.status, "done");
     assert.equal(completed.executionId, claimed.executionId);
+    assert.equal(existsSync(path.join(rootDir, created.packagePath, "review.md")), false);
   });
 });
 

--- a/packages/cli/test/write-lock-retry-cli.test.ts
+++ b/packages/cli/test/write-lock-retry-cli.test.ts
@@ -37,7 +37,7 @@ test("CLI waits through transient global write lock conflicts", async () => {
     if (!settled.ok) throw settled.error;
     assert.equal(settled.value.ok, true);
     assert.equal(settled.value.path, "progress.md");
-    assert.equal(readFileSync(path.join(rootDir, `harness/tasks/${taskId}-task-one/progress.md`), "utf8"), "after transient lock\n");
+    assert.equal(readFileSync(path.join(rootDir, `harness/tasks/${taskId}-task-one/progress.md`), "utf8"), "# Progress\n\n## Entries\n\nafter transient lock\n");
   });
 });
 

--- a/packages/kernel/src/store/write-journal-operations-internal.ts
+++ b/packages/kernel/src/store/write-journal-operations-internal.ts
@@ -182,7 +182,7 @@ function documentAppendRecordWrite(op: WriteOp, payload: DocumentAppendRecordPay
 
 function applyProgressAppendDelta(rootInput: HarnessLayoutInput, op: WriteOp, payload: ProgressAppendDeltaPayload): DocumentWrite {
   const targetPath = documentTargetPath(rootInput, progressAppendDeltaWrite(op, payload));
-  const existing = existsSync(targetPath) ? readFileSync(targetPath, "utf8") : "";
+  const existing = existsSync(targetPath) ? readFileSync(targetPath, "utf8") : "# Progress\n\n## Entries\n\n";
   const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
   const write: DocumentWrite = {
     taskId: taskIdForWriteOp(op),

--- a/packages/kernel/test/store/progress-append-delta.test.ts
+++ b/packages/kernel/test/store/progress-append-delta.test.ts
@@ -27,7 +27,7 @@ test("progress_append delta accumulates appends with correct separators", () => 
 
     assert.equal(
       readFileSync(progressPath(rootDir, "task-1"), "utf8"),
-      "line one\nline two\nline three\n"
+      "# Progress\n\n## Entries\n\nline one\nline two\nline three\n"
     );
   });
 });
@@ -90,7 +90,22 @@ test("progress_append delta appends text verbatim without formatting or normaliz
     Effect.runSync(coordinator.flush("explicit"));
 
     // Only a single trailing newline is added; every other byte is preserved as-is.
-    assert.equal(readFileSync(progressPath(rootDir, "task-1"), "utf8"), `${raw}\n`);
+    assert.equal(readFileSync(progressPath(rootDir, "task-1"), "utf8"), `# Progress\n\n## Entries\n\n${raw}\n`);
+  });
+});
+
+test("progress_append delta preserves an existing progress@1 document byte-for-byte before the appended delta", () => {
+  withTempStore((rootDir) => {
+    const coordinator = makeJournaledWriteCoordinator({ attribution: testWriteAttribution(), rootDir });
+    const filePath = progressPath(rootDir, "task-1");
+    const legacyBody = "# Progress\n\n## Log\n\n- Historical entry.\n\n## Evidence\n\n| Type | Path | Summary | Command |\n| --- | --- | --- | --- |\n";
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, legacyBody, "utf8");
+
+    Effect.runSync(coordinator.enqueue(progressAppendDelta("op-legacy-compatible", "task-1", "new entry")));
+    Effect.runSync(coordinator.flush("explicit"));
+
+    assert.equal(readFileSync(filePath, "utf8"), `${legacyBody}new entry\n`);
   });
 });
 
@@ -107,7 +122,7 @@ test("recovery applies multiple pending deltas from separate writers in journal 
     const report = Effect.runSync(recovered.recover);
 
     assert.equal(report.replayedOps, 2);
-    assert.equal(readFileSync(progressPath(rootDir, "task-1"), "utf8"), "first\nsecond\n");
+    assert.equal(readFileSync(progressPath(rootDir, "task-1"), "utf8"), "# Progress\n\n## Entries\n\nfirst\nsecond\n");
   });
 });
 
@@ -122,7 +137,7 @@ test("recover after successful flush does not re-append a committed delta", () =
     const report = Effect.runSync(recovered.recover);
 
     assert.equal(report.replayedOps, 0);
-    assert.equal(readFileSync(progressPath(rootDir, "task-1"), "utf8"), "once only\n");
+    assert.equal(readFileSync(progressPath(rootDir, "task-1"), "utf8"), "# Progress\n\n## Entries\n\nonce only\n");
   });
 });
 


### PR DESCRIPTION
# English

## Summary

First authorized slice of the template lifecycle remediation (decision dec_01KXSWP9FHCE20BMA6R1M3QDZM, from the 2026-07-18 template lifecycle audit): Wave 0 contract tests pin scaffold/parser/checker behavior on both the new-task and frozen-task sides; F2 makes `progress.md` lazily created on first append instead of pre-materialized with a dead Evidence table; F3 retires the root `review.md` from new scaffolds while keeping the legacy lint for historical files. The audit findings were live-confirmed during the first production V2 task closeout (legacy severity gate friction, appends landing under a stale Evidence heading).

## What Changed

- `vertical.json` default scaffold no longer selects `template://planning/progress@1` or `template://planning/review@1`; both catalog entries remain untouched for frozen tasks (retire-from-scaffold ≠ delete-from-catalog, per the audit matrix).
- `progress_append` delta apply in the canonical write journal lazily initializes `# Progress / ## Entries` when the file is missing; existing files (including progress@1 shapes) are preserved byte-for-byte as the append prefix — no normalization, no migration. Lazy-init lives at the journal layer so normal flush, pending-op recovery, and journal-order replay share one semantics.
- Strict/private-harness/target-project checkers no longer report a missing root `review.md`; when the file exists, the legacy schema/blocking lint still hard-fails on malformed rows.
- Wave 0 contract tests across five layers: bundled asset surface, clean init/new-task, write-journal delta, strict checker, and the full task lifecycle chain under the new contract.

## Task And Scope

- Task task_01KXSWT14637F7HFN3WB2AW7Z2; decision dec_01KXSWP9FHCE20BMA6R1M3QDZM authorizes exactly these three slices; remaining audit waves need separate approval.
- Research package under `harness/context/research/2026-07-18-template-lifecycle-audit/` is read-only source material; not modified.

## Version Impact

- No published package version change.

## Governance Declaration

- Decision anchor: dec_01KXSWP9FHCE20BMA6R1M3QDZM (accepted; 泽宇 2026-07-18 full roadmap authorization).
- Protected paths touched: none (`harness/**`, `.github/**`, `tools/gate-manifest.json`, `packages/cli/src/daemon/**` untouched).
- No gate weakening: malformed legacy review rows still hard-fail; frozen-task contracts are pinned by new tests rather than loosened.

## Verification

- New-contract full chain green: create → lazy progress append → code-doc reconcile → review → complete.
- Frozen-side pins: catalog must still contain both v1 entries; existing progress@1 files keep byte-identical prefixes and EOF-append behavior; legacy snapshot-shaped journal ops keep their overwrite semantics.
- Root `env -u FORCE_COLOR HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 — 32 gates green; affected fast 311/311, contract 155/155.

## Review Evidence

- CEO semantic acceptance: lazy-init placed at the canonical journal layer (not the CLI surface) so all replay paths share it; scaffold retirement implemented as selection removal, not catalog deletion; checker change is missing-file-only — confirmed against the audit's F2/F3 sections and the decision text.

## Residual Risk

- Historical tasks keep the dual review model until later waves; the legacy lint remains their gate.
- Owner-class boundary (audit F1) and producer/consumer contract mismatches are explicitly out of scope pending separate authorization.

## References

- Audit package: `harness/context/research/2026-07-18-template-lifecycle-audit/` (findings F2, F3; roadmap Wave 0).
- Worker report: `tmp/orch/template-wave0/REPORT.md`.

---

# 中文

## 概要

template 生命周期整改的首批授权切片(决策 dec_01KXSWP9FHCE20BMA6R1M3QDZM,源自 2026-07-18 template lifecycle 审计):Wave 0 契约测试把 scaffold/parser/checker 在新任务与 frozen 任务两侧的行为钉住;F2 让 `progress.md` 改为首次 append 时懒建,不再预生成带死 Evidence 表的占位;F3 让根 `review.md` 退出新 scaffold,历史文件的 legacy lint 保留。审计发现已在首个生产 V2 任务收口中活体验证(legacy severity 门摩擦、append 落在陈旧 Evidence 表头下)。

## 改动内容

- `vertical.json` 默认 scaffold 不再选择 `template://planning/progress@1` 与 `template://planning/review@1`;两个 catalog 条目原样保留服务 frozen 任务(按审计矩阵:退出 scaffold ≠ 删除 catalog 条目)。
- canonical write journal 的 `progress_append` delta apply 在文件缺失时懒建 `# Progress / ## Entries`;既存文件(含 progress@1 形态)按 byte-for-byte 保留为 append 前缀——不 normalize、不迁移。懒建放在 journal 层,正常 flush、pending-op 恢复、journal 顺序重放共享同一语义。
- strict/private-harness/target-project checker 不再把根 `review.md` 缺失报错;文件存在时 legacy schema/blocking lint 照常 hard-fail。
- Wave 0 契约测试覆盖五层:bundled asset 面、clean init/new-task、write-journal delta、strict checker、新契约下完整任务生命周期链。

## 任务与范围

- 任务 task_01KXSWT14637F7HFN3WB2AW7Z2;决策 dec_01KXSWP9FHCE20BMA6R1M3QDZM 恰好授权这三片;审计其余波次另批。
- `harness/context/research/2026-07-18-template-lifecycle-audit/` 研究包为只读材料,未修改。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 决策锚:dec_01KXSWP9FHCE20BMA6R1M3QDZM(已 accept;泽宇 2026-07-18 路线图完全授权)。
- 未触碰受保护路径(`harness/**`、`.github/**`、`tools/gate-manifest.json`、`packages/cli/src/daemon/**` 均未动)。
- 无门禁削弱:legacy review 坏行仍 hard-fail;frozen 契约由新增测试钉住而非放松。

## 验证

- 新契约全链绿:create→懒建 progress append→code-doc reconcile→review→complete。
- frozen 侧钉住:catalog 必须仍含两个 v1 条目;既存 progress@1 文件保持 byte 级前缀与 EOF append 行为;legacy snapshot 形态 journal op 保持覆盖语义。
- 根 `env -u FORCE_COLOR HARNESS_DAEMON_MODE=direct npm run check:local` exit 0——32 门绿;affected fast 311/311,contract 155/155。

## 审查证据

- CEO 语义验收:懒建放在 canonical journal 层(而非 CLI 表层)使所有重放路径共享;scaffold 退休以选择集移除实现而非删 catalog;checker 改动仅限缺失文件分支——已对照审计 F2/F3 原文与决策文本确认。

## 残余风险

- 历史任务在后续波次前保持双 review 模型,legacy lint 仍是其门。
- owner-class 边界(审计 F1)与生产者/消费者契约错配显式不在本片范围,待另批。

## 关联材料

- 审计包:`harness/context/research/2026-07-18-template-lifecycle-audit/`(F2、F3、Wave 0)。
- Worker 报告:`tmp/orch/template-wave0/REPORT.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
