### PR TITLE
refactor(cli): derive authority ingress coverage from command specs

### DIFF
--- a/packages/cli/src/cli/command-spec/index.ts
+++ b/packages/cli/src/cli/command-spec/index.ts
@@ -8,6 +8,10 @@ import { completionCommandSpecs } from "./command-spec-completion.ts";
 import { githubIssuesCommandSpecs } from "./command-spec-github-issues.ts";
 import { authorityCutoverCommandSpecs } from "./command-spec-authority-cutover.ts";
 import type { CommandSpecDefinition, ParsedCommandKind } from "./types.ts";
+import {
+  attachProductionAuthorityIngress,
+  type CommandSpecWithProductionAuthorityIngress
+} from "./production-authority-ingress.ts";
 
 export const commandSpecs = [
   ...authorityCutoverCommandSpecs,
@@ -21,7 +25,10 @@ export const commandSpecs = [
   ...extensionsCommandSpecs
 ] as const satisfies ReadonlyArray<CommandSpecDefinition>;
 
+export const productionAuthorityCommandSpecs = attachProductionAuthorityIngress(commandSpecs);
+
 export type CommandSpec = (typeof commandSpecs)[number];
+export type ProductionAuthorityCommandSpec = CommandSpecWithProductionAuthorityIngress<CommandSpec>;
 export type CommandKind = CommandSpec["kind"];
 
 type MissingParsedCommandSpec = Exclude<ParsedCommandKind, CommandKind>;
@@ -33,3 +40,25 @@ export function commandSpecMap<Value>(
 ): Record<CommandKind, Value> {
   return Object.fromEntries(commandSpecs.map((spec) => [spec.kind, select(spec)])) as Record<CommandKind, Value>;
 }
+
+export function productionAuthorityIngressFor(kind: string) {
+  return productionAuthorityCommandSpecs.find((spec) => spec.kind === kind)?.productionAuthorityIngress;
+}
+
+export function productionAuthorityTypedIngressKinds(): ReadonlyArray<string> {
+  return productionAuthorityCommandSpecs
+    .filter((spec) => spec.productionAuthorityIngress?.status === "typed-v2")
+    .map((spec) => spec.kind)
+    .sort();
+}
+
+export function productionAuthorityUnsupportedHint(rejectedKind: string): string {
+  return `production canonical ingress rejected ${rejectedKind}; typed V2 command kinds from command-spec: ${productionAuthorityTypedIngressKinds().join(", ")}`;
+}
+
+export {
+  assertProductionAuthorityIngressCompleteness,
+  productionAuthorityIngressDecisionRef,
+  type ProductionAuthorityIngressAdapter,
+  type ProductionAuthorityIngressDisposition
+} from "./production-authority-ingress.ts";

--- a/packages/cli/src/cli/command-spec/production-authority-ingress.ts
+++ b/packages/cli/src/cli/command-spec/production-authority-ingress.ts
@@ -1,0 +1,137 @@
+import type { CommandSpecDefinition } from "./types.ts";
+
+export const productionAuthorityIngressDecisionRef =
+  "decision/dec_01KXSWKWTEXB751A30TRRCQWDG" as const;
+
+export type ProductionAuthorityIngressAdapter = "generic" | "decision-transition" | "task-claim";
+
+export type ProductionAuthorityIngressDisposition =
+  | {
+      readonly status: "typed-v2";
+      readonly adapter: ProductionAuthorityIngressAdapter;
+    }
+  | {
+      readonly status: "excluded";
+      readonly decisionRef: typeof productionAuthorityIngressDecisionRef;
+      readonly reason: string;
+    };
+
+export type CommandSpecWithProductionAuthorityIngress<Spec extends CommandSpecDefinition = CommandSpecDefinition> = Spec & {
+  readonly productionAuthorityIngress?: ProductionAuthorityIngressDisposition;
+};
+
+const typed = (adapter: ProductionAuthorityIngressAdapter): ProductionAuthorityIngressDisposition => ({
+  status: "typed-v2",
+  adapter
+});
+
+const excluded = (reason: string): ProductionAuthorityIngressDisposition => ({
+  status: "excluded",
+  decisionRef: productionAuthorityIngressDecisionRef,
+  reason
+});
+
+const dispositions = {
+  "new-task": typed("generic"),
+  "task-claim": typed("task-claim"),
+  "status-set": typed("generic"),
+  "progress-append": typed("generic"),
+  "task-code-doc-reconcile": typed("generic"),
+  "task-consent-record": typed("generic"),
+  "task-review-execution": typed("generic"),
+  "task-complete": typed("generic"),
+  "decision-propose": typed("generic"),
+  "decision-transition": typed("decision-transition"),
+  "decision-relate": typed("generic"),
+  "record-fact": typed("generic"),
+  "fact-invalidate": typed("generic"),
+  "session-export": typed("generic"),
+  "module-register": typed("generic"),
+
+  "init": excluded("repository bootstrap writes precede production authority attachment"),
+  "task-release": excluded("lease release mutates daemon-private holder state in the operational domain"),
+  "task-amend": excluded("task extension amendment has no production typed semantic compiler"),
+  "task-contract-migrate": excluded("task contract migration is an explicit local migration write road"),
+  "task-archive": excluded("task archival has no production typed semantic compiler"),
+  "task-supersede": excluded("task supersession has no production typed semantic compiler"),
+  "task-delete": excluded("task deletion has no production typed semantic compiler"),
+  "task-reopen": excluded("task reopen has no production typed semantic compiler"),
+  "task-review": excluded("legacy task review is superseded by typed execution review"),
+  "task-relate": excluded("task-hosted relation writes have no production typed semantic compiler"),
+  "decision-repin": excluded("decision repin is restricted to the migration write road"),
+  "decision-amend": excluded("decision amendment has no production typed semantic compiler"),
+  "decision-reckon": excluded("decision reckoning is a local derived-write workflow"),
+  "decision-relation-retire": excluded("relation retirement has no production typed semantic compiler"),
+  "decision-relation-replace": excluded("relation replacement has no production typed semantic compiler"),
+  "distill-candidate": excluded("distillation candidates use the local derived-memory write road"),
+  "distill-commit": excluded("distillation commit uses the local derived-memory write road"),
+  "runtime-event-append": excluded("runtime events use the operational flush domain"),
+  "materializer-run": excluded("materializer control is daemon-local orchestration"),
+  "session-backfill": excluded("session backfill is an explicit migration workflow"),
+  "session-sync": excluded("session sync has no production command adapter despite a typed semantic vocabulary"),
+  "governance-rebuild": excluded("governance rebuild is an explicit local derived-write workflow"),
+  "lesson-promote": excluded("lesson promotion has no production typed semantic compiler"),
+  "lesson-sediment": excluded("lesson sedimentation has no production typed semantic compiler"),
+  "adopt-multica": excluded("multi-CA adoption is an explicit migration workflow"),
+  "migrate-structure": excluded("structure migration uses the migration write road"),
+  "migrate-anchors": excluded("anchor migration uses the migration write road"),
+  "migrate-fact-execution": excluded("fact execution migration uses the migration write road"),
+  "migrate-retired-attribution-fields": excluded("attribution migration uses the migration write road"),
+  "migrate-provenance": excluded("provenance migration uses the migration write road"),
+  "migrate-run": excluded("generic migration execution uses the migration write road"),
+  "legacy-intake-plan": excluded("legacy intake planning writes migration-local artifacts"),
+  "legacy-copy-safe-docs": excluded("legacy document copy uses the migration write road"),
+  "legacy-index": excluded("legacy indexing uses the migration write road"),
+  "git-diff": excluded("git diff writes only local diagnostic artifacts"),
+  "worktree-create": excluded("worktree creation is repository orchestration outside authored authority"),
+  "graph": excluded("graph generation writes derived local presentation artifacts"),
+  "preset-install": excluded("preset installation mutates local extension state"),
+  "preset-seed": excluded("preset seeding mutates local extension state"),
+  "preset-uninstall": excluded("preset removal mutates local extension state"),
+  "preset-entrypoint": excluded("preset entrypoints delegate to separately admitted command write roads"),
+  "script-run": excluded("script execution uses declared script scopes rather than canonical typed ingress"),
+  "module-scaffold": excluded("module scaffolding writes local source and template assets"),
+  "module-unregister": excluded("module removal has no production typed semantic compiler"),
+  "module-step": excluded("module step mutation has no production typed semantic compiler"),
+  "gui": excluded("GUI launch is daemon orchestration and does not author a canonical entity")
+} as const satisfies Readonly<Record<string, ProductionAuthorityIngressDisposition>>;
+
+export function attachProductionAuthorityIngress<const Specs extends ReadonlyArray<CommandSpecDefinition>>(
+  specs: Specs
+): { readonly [Index in keyof Specs]: CommandSpecWithProductionAuthorityIngress<Specs[Index]> } {
+  const specKinds = new Set(specs.map((spec) => spec.kind));
+  const unknownKinds = Object.keys(dispositions).filter((kind) => !specKinds.has(kind));
+  if (unknownKinds.length > 0) {
+    throw new Error(`PRODUCTION_AUTHORITY_INGRESS_UNKNOWN_COMMAND\n${unknownKinds.join("\n")}`);
+  }
+  return specs.map((spec) => ({
+    ...spec,
+    ...(spec.kind in dispositions
+      ? { productionAuthorityIngress: dispositions[spec.kind as keyof typeof dispositions] }
+      : {})
+  })) as { readonly [Index in keyof Specs]: CommandSpecWithProductionAuthorityIngress<Specs[Index]> };
+}
+
+export function assertProductionAuthorityIngressCompleteness(
+  specs: ReadonlyArray<CommandSpecWithProductionAuthorityIngress>,
+  classify: (kind: string) => string | undefined
+): void {
+  const errors: string[] = [];
+  for (const spec of specs) {
+    const commandClass = classify(spec.kind);
+    const requiresDisposition = commandClass === "repo-write" || commandClass === "arbiter";
+    const disposition = spec.productionAuthorityIngress;
+    if (requiresDisposition && !disposition) {
+      errors.push(`${spec.kind}: ${commandClass} command lacks productionAuthorityIngress`);
+      continue;
+    }
+    if (!requiresDisposition && disposition) {
+      errors.push(`${spec.kind}: ${commandClass ?? "unclassified"} command must not declare productionAuthorityIngress`);
+      continue;
+    }
+    if (disposition?.status === "excluded" && (!disposition.reason.trim() || !/^decision\/dec_[A-Z0-9]+$/u.test(disposition.decisionRef))) {
+      errors.push(`${spec.kind}: excluded ingress requires a reason and decision reference`);
+    }
+  }
+  if (errors.length > 0) throw new Error(`PRODUCTION_AUTHORITY_INGRESS_INCOMPLETE\n${errors.join("\n")}`);
+}

--- a/packages/cli/src/daemon/authority-command-submission.ts
+++ b/packages/cli/src/daemon/authority-command-submission.ts
@@ -19,6 +19,7 @@ import type {
 } from "../../../kernel/src/index.ts";
 import { taskEntityId } from "../../../kernel/src/index.ts";
 import type { ParsedCommand } from "../cli/types.ts";
+import { productionAuthorityIngressFor } from "../cli/command-spec/index.ts";
 import type { CliActorAttribution } from "../composition/actor-attribution.ts";
 
 export interface DaemonAuthorityAttemptCompilerV2 {
@@ -186,11 +187,13 @@ export function makeDaemonAuthorityWriteCoordinator(
         if (provenanceSession && !submission.submitProvenanceSession) {
           throw authorityWriteRejected("AUTHORITY_PROVENANCE_SESSION_SUBMISSION_UNAVAILABLE");
         }
-        const decisionTransition = input.command.action.kind === "decision-transition";
+        const ingress = productionAuthorityIngressFor(input.command.action.kind);
+        const ingressAdapter = ingress?.status === "typed-v2" ? ingress.adapter : undefined;
+        const decisionTransition = ingressAdapter === "decision-transition";
         if (decisionTransition && !submission.submitDecisionTransition) {
           throw authorityWriteRejected("AUTHORITY_DECISION_TRANSITION_SUBMISSION_UNAVAILABLE");
         }
-        const taskClaim = input.command.action.kind === "task-claim";
+        const taskClaim = ingressAdapter === "task-claim";
         if (taskClaim && !submission.submitTaskClaim) {
           throw authorityWriteRejected("AUTHORITY_TASK_CLAIM_SUBMISSION_UNAVAILABLE");
         }

--- a/packages/cli/src/daemon/production-authority-attempt-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-attempt-compiler.ts
@@ -37,6 +37,10 @@ import {
   type WriteOp
 } from "../../../kernel/src/index.ts";
 import type { ParsedCommand } from "../cli/types.ts";
+import {
+  productionAuthorityIngressFor,
+  productionAuthorityUnsupportedHint
+} from "../cli/command-spec/index.ts";
 import type { AuthorityConnectionContext } from "../../../daemon/src/index.ts";
 import type { DaemonAuthorityAttemptCompilerV2 } from "./authority-command-submission.ts";
 import {
@@ -88,10 +92,7 @@ export function createProductionCanonicalAttemptCompiler(input: {
   ) => {
       if (!intent) {
         throw new Error(
-          `AUTHORITY_TYPED_COMMAND_UNSUPPORTED: production canonical ingress rejected ${command.action.kind}; ` +
-          "use progress-append, decision-propose, module-register, record-fact, decision-relate, " +
-          "session-export with an explicit transcript, task-claim with an execution id, " +
-          "task lifecycle closeout commands, task-consent-record, or fact-invalidate"
+          `AUTHORITY_TYPED_COMMAND_UNSUPPORTED: ${productionAuthorityUnsupportedHint(command.action.kind)}`
         );
       }
       if (canonicalEntityId !== intent.physicalEntityId) {
@@ -197,31 +198,35 @@ export function createProductionCanonicalAttemptCompiler(input: {
   };
   return {
     compile: async ({ command, attribution, currentSession, canonicalEntityId }) => {
-      const intent = await canonicalAttemptIntent(command, currentSession, canonicalEntityId, input.authoredRoot, attribution.writeAttribution.actor);
+      const disposition = productionAuthorityIngressFor(command.action.kind);
+      const intent = disposition?.status === "typed-v2" && disposition.adapter === "generic"
+        ? await canonicalAttemptIntent(command, currentSession, canonicalEntityId, input.authoredRoot, attribution.writeAttribution.actor)
+        : null;
       return compileIntent(command, attribution, currentSession, canonicalEntityId, intent);
     },
-    compileProvenanceSession: async ({ command, attribution, currentSession, operation }) => compileIntent(
-      command,
-      attribution,
-      currentSession,
-      operation.entityId,
-      provenanceSessionAttemptIntent(command, currentSession, operation)
-    ),
-    compileDecisionTransition: async ({ command, attribution, currentSession, operation }) => compileIntent(
-      command,
-      attribution,
-      currentSession,
-      operation.entityId,
-      decisionTransitionAttemptIntent(command, operation, input.authoredRoot)
-    ),
-    compileTaskClaim: async ({ command, attribution, currentSession, operation }) => compileIntent(
-      command,
-      attribution,
-      currentSession,
-      operation.entityId,
-      taskClaimAttemptIntent(command, attribution, currentSession, operation)
-    )
+    compileProvenanceSession: async ({ command, attribution, currentSession, operation }) => {
+      assertTypedIngressAdapter(command.action.kind, "generic");
+      return compileIntent(command, attribution, currentSession, operation.entityId,
+        provenanceSessionAttemptIntent(command, currentSession, operation));
+    },
+    compileDecisionTransition: async ({ command, attribution, currentSession, operation }) => {
+      assertTypedIngressAdapter(command.action.kind, "decision-transition");
+      return compileIntent(command, attribution, currentSession, operation.entityId,
+        decisionTransitionAttemptIntent(command, operation, input.authoredRoot));
+    },
+    compileTaskClaim: async ({ command, attribution, currentSession, operation }) => {
+      assertTypedIngressAdapter(command.action.kind, "task-claim");
+      return compileIntent(command, attribution, currentSession, operation.entityId,
+        taskClaimAttemptIntent(command, attribution, currentSession, operation));
+    }
   };
+}
+
+function assertTypedIngressAdapter(kind: string, expected: "generic" | "decision-transition" | "task-claim"): void {
+  const disposition = productionAuthorityIngressFor(kind);
+  if (disposition?.status !== "typed-v2" || disposition.adapter !== expected) {
+    throw new Error(`AUTHORITY_TYPED_INGRESS_REGISTRY_MISMATCH:${kind}:${expected}`);
+  }
 }
 
 function decisionTransitionAttemptIntent(

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -18,6 +18,7 @@ import {
 import { defaultCliAdapterProvider } from "../../src/composition/adapter-registry.ts";
 import type { EntityId } from "../../../kernel/src/index.ts";
 import type { ParsedCommand } from "../../src/cli/types.ts";
+import { productionAuthorityUnsupportedHint } from "../../src/cli/command-spec/index.ts";
 import { daemonActorAttribution } from "../../src/composition/actor-attribution.ts";
 import { parseRecordArgs } from "../../src/cli/parsers/record.ts";
 import { parseNewTaskArgs } from "../../src/cli/parsers/new-task.ts";
@@ -603,7 +604,8 @@ test("production generic canonical ingress accepts and journals one write for ev
       attribution: daemonActorAttribution(actor, { kind: "agent", id: "codex" }),
       currentSession: { runtime: "codex", sessionId: "session-production", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z" },
       canonicalEntityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0")
-    }), /AUTHORITY_TYPED_COMMAND_UNSUPPORTED.*task lifecycle closeout/u);
+    }), (error: unknown) => error instanceof Error
+      && error.message === `AUTHORITY_TYPED_COMMAND_UNSUPPORTED: ${productionAuthorityUnsupportedHint("help")}`);
     await assert.rejects(submission.submit({
       command: {
         rootDir: fixture.repoRoot,

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -5,13 +5,21 @@ import test from "node:test";
 import type { RuntimeEventAppendInput } from "../../application/src/index.ts";
 import { apiRouteContracts } from "../../gui/src/api/api-contract-registry.ts";
 import { createInMemoryTerminalSessionService } from "../src/terminal/session-registry.ts";
-import { commandSpecs } from "../../cli/src/cli/command-spec/index.ts";
+import {
+  assertProductionAuthorityIngressCompleteness,
+  commandSpecs,
+  productionAuthorityCommandSpecs,
+  productionAuthorityIngressDecisionRef,
+  productionAuthorityTypedIngressKinds,
+  productionAuthorityUnsupportedHint
+} from "../../cli/src/cli/command-spec/index.ts";
 import {
   composeIdentityProvider,
   currentDaemonProtocolVersion,
   jsonRpcServiceMethodContracts,
   jsonRpcMethodContracts,
   repoCommandRunClassifiedActionKinds,
+  commandClassForCliActionKind,
   makePeopleRosterAuthorizationProvider,
   makeTransportDerivedIdentityProvider,
   type IdentityProvider,
@@ -70,6 +78,48 @@ test("repo.command.run classification covers every parsed CLI action kind", () =
       .map((spec) => spec.kind)
       .filter((kind) => kind !== "doc-sync-submit") // Uses the dedicated repo.doc.sync.submit method.
       .sort()
+  );
+});
+
+test("production authority ingress covers or explicitly excludes every write-class command spec", () => {
+  assert.doesNotThrow(() => assertProductionAuthorityIngressCompleteness(productionAuthorityCommandSpecs, commandClassForCliActionKind));
+  const typedKinds = productionAuthorityTypedIngressKinds();
+  assert.deepEqual(typedKinds, [
+    "decision-propose",
+    "decision-relate",
+    "decision-transition",
+    "fact-invalidate",
+    "module-register",
+    "new-task",
+    "progress-append",
+    "record-fact",
+    "session-export",
+    "status-set",
+    "task-claim",
+    "task-code-doc-reconcile",
+    "task-complete",
+    "task-consent-record",
+    "task-review-execution"
+  ]);
+  const exclusions = productionAuthorityCommandSpecs.filter((spec) => spec.productionAuthorityIngress?.status === "excluded");
+  assert.equal(exclusions.length > 0, true);
+  assert.equal(exclusions.every((spec) => spec.productionAuthorityIngress?.status === "excluded"
+    && spec.productionAuthorityIngress.decisionRef === productionAuthorityIngressDecisionRef
+    && spec.productionAuthorityIngress.reason.trim().length > 0), true);
+  const hint = productionAuthorityUnsupportedHint("fixture-unsupported");
+  assert.equal(hint,
+    `production canonical ingress rejected fixture-unsupported; typed V2 command kinds from command-spec: ${typedKinds.join(", ")}`);
+});
+
+test("production authority ingress completeness fails for a newly registered write command without a disposition", () => {
+  const fixture = productionAuthorityCommandSpecs.find((spec) => spec.kind === "help")!;
+  const fakeRepoWriteSpec = { ...fixture, kind: "fixture-repo-write", productionAuthorityIngress: undefined };
+  assert.throws(
+    () => assertProductionAuthorityIngressCompleteness(
+      [...productionAuthorityCommandSpecs, fakeRepoWriteSpec],
+      (kind) => kind === fakeRepoWriteSpec.kind ? "repo-write" : commandClassForCliActionKind(kind)
+    ),
+    /PRODUCTION_AUTHORITY_INGRESS_INCOMPLETE[\s\S]*fixture-repo-write: repo-write command lacks productionAuthorityIngress/u
   );
 });
 


### PR DESCRIPTION
# English

## Summary

Root fix ending the D-series pattern (decision dec_01KXSWKWTEXB751A30TRRCQWDG, 泽宇 2026-07-18 top-priority adjudication): the production authority ingress coverage was a hand-maintained allowlist, so every repo-write command it missed became a production dead-zone defect (D19 `decision transition`, D22 `task claim`). Coverage is now derived from the command-spec registry with a completeness gate — a new write command that forgets its ingress disposition turns CI red instead of shipping a D23.

## What Changed

- New `production-authority-ingress.ts` in the command-spec layer: every command kind carries an explicit `productionAuthorityIngress` disposition — `typed-v2` (with adapter: generic / decision-transition / task-claim, 15 commands) or `excluded` (46 commands, each with a concrete reason and the authorizing decision reference).
- The daemon coordinator, attempt compiler, and the `AUTHORITY_TYPED_COMMAND_UNSUPPORTED` hint all consume the same derived table; the hint now lists the real supported surface instead of a hand-written list.
- The completeness gate rejects: repo-write/arbiter commands without a disposition, non-write commands wrongly declaring one, empty exclusion reasons or invalid decision references, and dangling dispositions for nonexistent commands.
- `doc-sync-submit` documented as an independent daemon RPC, not masqueraded as a command-spec command.

## Task And Scope

- Task task_01KXSWSR00SVK1MZRCP8PRBSK0; stacked on merged D22 (#903) and rebased onto latest main including #904.
- The 46 exclusions are an initial classification under the umbrella decision; narrowing individual exclusions into their own decisions is follow-up governance work, not a blocker.

## Version Impact

- No published package version change.

## Governance Declaration

- Decision anchor: dec_01KXSWKWTEXB751A30TRRCQWDG (accepted).
- Protected paths touched: none (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `harness/**` untouched); the completeness gate lives in the test tier.
- No gate weakening: unsupported commands still fail closed; the change makes the fail-closed surface derivable and auditable instead of hand-grown.

## Verification

- Red control: registering a fixture repo-write command without a disposition fails the gate with `PRODUCTION_AUTHORITY_INGRESS_INCOMPLETE`.
- Real CLI argv→socket→daemon same-path plus upgrade fixtures: 25/25; affected contract tests 145/145.
- Root `env -u FORCE_COLOR HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 after rebase — 33 manifest gates green.

## Review Evidence

- CEO semantic acceptance: single source of truth confirmed (coordinator, compiler, and error hint all read the derived table; no residual hand list); exclusions are explicit and enumerable with reasons; the gate's four rejection classes match the decision's invariant — confirmed in diff and report.

## Residual Risk

- The gate guarantees every write command has an explicit disposition; it does not guarantee behavioral coverage of every flag combination within a command — production-same-path behavior tests remain the standard for those.
- Exclusion reasons are initial-classification granularity; per-class narrowing decisions are queued governance work.

## References

- Defect lineage: D19 (#901), D22 (#903) — the pattern this ends.
- Worker report: `tmp/orch/ingress-derivation/REPORT.md`.

---

# 中文

## 概要

终结 D 系列模式的根治(决策 dec_01KXSWKWTEXB751A30TRRCQWDG,泽宇 2026-07-18 最高优先级亲裁):生产 authority ingress 覆盖面原是手维护白名单,每漏一个 repo-write 命令就是一个生产死区缺陷(D19 `decision transition`、D22 `task claim`)。现在覆盖面从 command-spec registry 派生并由完备性 gate 断言——新写命令忘配 ingress disposition 会直接 CI 红,而不是变成 D23。

## 改动内容

- command-spec 层新增 `production-authority-ingress.ts`:每个命令 kind 携带显式 `productionAuthorityIngress` disposition——`typed-v2`(adapter:generic / decision-transition / task-claim,共 15 个命令)或 `excluded`(46 个命令,每条带具体理由与授权决策引用)。
- daemon coordinator、attempt compiler 与 `AUTHORITY_TYPED_COMMAND_UNSUPPORTED` 的 hint 消费同一张派生表;hint 列出的支持面来自派生而非手写。
- 完备性 gate 拒绝四类破坏:repo-write/arbiter 命令缺 disposition;非写命令错误声明 disposition;空排除理由或无效决策引用;指向不存在命令的悬空 disposition。
- `doc-sync-submit` 明确为独立 daemon RPC,不伪装成 command-spec 命令。

## 任务与范围

- 任务 task_01KXSWSR00SVK1MZRCP8PRBSK0;堆叠在已合入的 D22(#903)之上,并已 rebase 到含 #904 的最新 main。
- 46 条排除是伞形决策下的初始分类;逐类收窄为独立决策是后续治理工作,不构成阻塞。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 决策锚:dec_01KXSWKWTEXB751A30TRRCQWDG(已 accept)。
- 未触碰受保护路径(`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`harness/**` 均未动);完备性 gate 落在测试层。
- 无门禁削弱:不支持的命令仍 fail-closed;本变更让 fail-closed 面可派生、可审计,不再手养。

## 验证

- 红对照:注册一个不配 disposition 的 fixture repo-write 命令,gate 以 `PRODUCTION_AUTHORITY_INGRESS_INCOMPLETE` 失败。
- 真实 CLI argv→socket→daemon 同路径+升级夹具:25/25;受影响 contract 测试 145/145。
- rebase 后根 `env -u FORCE_COLOR HARNESS_DAEMON_MODE=direct npm run check:local` exit 0——33 个 manifest gate 全绿。

## 审查证据

- CEO 语义验收:单一事实源确认(coordinator/compiler/报错 hint 均读派生表,无残留手写清单);排除项显式可枚举且带理由;gate 四类拒绝与决策不变量一致——已对照 diff 与报告确认。

## 残余风险

- gate 保证每个写命令有显式 disposition,不保证命令内部所有 flag 组合的行为覆盖——那仍由生产同路径行为测试承担。
- 排除理由为初始分类粒度;逐类收窄决策列入治理队列。

## 关联材料

- 缺陷谱系:D19(#901)、D22(#903)——本 PR 终结的模式。
- Worker 报告:`tmp/orch/ingress-derivation/REPORT.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
