### PR TITLE
fix(cli): commit review verdict companions atomically

### DIFF
--- a/packages/application/src/authority/session-execution-review-command-v2.ts
+++ b/packages/application/src/authority/session-execution-review-command-v2.ts
@@ -49,6 +49,8 @@ export type ReviewActionPayloadV2 = {
   readonly schema: "review.create/v1" | "review.dismiss/v1" | "review.record/v1";
   readonly taskId: string;
   readonly review: ReviewRecord;
+  readonly execution?: ExecutionRecord;
+  readonly taskIndexBody?: string;
 };
 
 export type SessionExecutionReviewCommandPayloadV2 =
@@ -126,11 +128,17 @@ function decodeStrictSessionExecutionReviewPayloadV2(value: unknown): SessionExe
     case "review.create/v1":
     case "review.dismiss/v1":
     case "review.record/v1": {
-      const row = exactSemanticObjectV2(value, ["schema", "taskId", "review"]);
+      const row = exactSemanticObjectV2(value, ["schema", "taskId", "review"], { allowAdditional: true });
+      const actual = Object.keys(row);
+      if (actual.some((key) => !["schema", "taskId", "review", "execution", "taskIndexBody"].includes(key))) {
+        throw semanticAdmissionV2("TYPED_PAYLOAD_UNKNOWN_OR_MISSING_FIELD");
+      }
       return {
         schema: discriminator.schema,
         taskId: nonBlankText(row.taskId),
-        review: decodeReview(row.review)
+        review: decodeReview(row.review),
+        ...(row.execution === undefined ? {} : { execution: decodeExecution(row.execution) }),
+        ...(row.taskIndexBody === undefined ? {} : { taskIndexBody: semanticStringValueV2(row.taskIndexBody) })
       };
     }
     default:

--- a/packages/application/src/authority/session-execution-review-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/session-execution-review-semantic-compiler-v2.ts
@@ -202,22 +202,155 @@ async function compileReview(
   const path = storagePath("review", { taskId: payload.taskId, reviewId: review.review_id });
   const snapshot = await state.readHostedDocument(path);
   if (snapshot) throw admission("REVIEW_ALREADY_EXISTS");
+  const companion = await reviewCompanionTransaction(state, payload);
   return {
     mutationPlan: plan([{
       entityKind: "review",
       identity: { taskId: payload.taskId, reviewId: review.review_id },
       action
-    }]),
+    }, ...companion.mutations]),
     operation: declaredDocumentOperation(
       "review",
       review.review_id,
       reviewDeclaration,
       { taskId: payload.taskId, reviewId: review.review_id },
-      reviewDeclaration.documentCodec.encode(review)
+      reviewDeclaration.documentCodec.encode(review),
+      undefined,
+      companion.transaction
     ),
-    requiredBaseRefs: [ref("review", `review/${encodeURIComponent(payload.taskId)}/${encodeURIComponent(review.review_id)}`)],
-    requiredPathSnapshots: []
+    requiredBaseRefs: [
+      ref("review", `review/${encodeURIComponent(payload.taskId)}/${encodeURIComponent(review.review_id)}`),
+      ...companion.baseRefs
+    ],
+    requiredPathSnapshots: companion.pathSnapshots
   };
+}
+
+async function reviewCompanionTransaction(
+  state: SessionExecutionReviewAuthorityStateV2,
+  payload: ReviewActionPayloadV2
+): Promise<{
+  readonly mutations: RegistryMutationPlanInput["mutations"];
+  readonly baseRefs: ReadonlyArray<RegistryEntityRefV2>;
+  readonly pathSnapshots: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }>;
+  readonly transaction?: {
+    readonly companionWrites: ReadonlyArray<{ readonly taskId: string; readonly path: string; readonly body: string }>;
+    readonly preconditions: ReadonlyArray<{ readonly taskId: string; readonly path: string; readonly bodySha256: string | null }>;
+  };
+}> {
+  const lifecycleChangesRequested = payload.schema === "review.create/v1"
+    && payload.review.verdict === "changes_requested";
+  if (!lifecycleChangesRequested) {
+    if (payload.execution !== undefined || payload.taskIndexBody !== undefined) {
+      throw admission("REVIEW_COMPANION_VERDICT_INVALID");
+    }
+    if (payload.schema === "review.dismiss/v1" && payload.review.verdict === "dismissed") {
+      return dismissedReviewCompanion(state, payload);
+    }
+    return { mutations: [], baseRefs: [], pathSnapshots: [] };
+  }
+  if (!payload.execution || payload.taskIndexBody === undefined) {
+    throw admission("REVIEW_CHANGES_REQUESTED_COMPANION_REQUIRED");
+  }
+  const executionId = payload.review.execution_ref.slice(`execution/${payload.taskId}/`.length);
+  if (!executionId || payload.execution.execution_id !== executionId) throw admission("REVIEW_EXECUTION_REF_MISMATCH");
+  const executionPath = storagePath("execution", { taskId: payload.taskId, executionId });
+  const executionSnapshot = await state.readHostedDocument(executionPath);
+  if (!executionSnapshot) throw admission("EXECUTION_DOCUMENT_NOT_FOUND");
+  const current = decodeExecutionDocument(executionSnapshot.body);
+  assertChangesRequestedExecution(current, payload.execution, payload.review.reviewed_at);
+  const taskPath = `tasks/${encodeURIComponent(payload.taskId)}/INDEX.md`;
+  const taskSnapshot = await state.readHostedDocument(taskPath);
+  if (!taskSnapshot) throw admission("REVIEW_TASK_DOCUMENT_NOT_FOUND");
+  const activeBody = taskSnapshot.body.replace(/^(  status:\s*)in_review$/mu, "$1active");
+  if (!/^  status:\s*in_review$/mu.test(taskSnapshot.body)
+    || (payload.taskIndexBody !== activeBody && payload.taskIndexBody !== taskSnapshot.body)) {
+    throw admission("REVIEW_CHANGES_REQUESTED_TASK_TRANSITION_INVALID");
+  }
+  const taskChanges = payload.taskIndexBody !== taskSnapshot.body;
+  return {
+    mutations: [{
+      entityKind: "execution", identity: { taskId: payload.taskId, executionId }, action: "close"
+    }, ...(taskChanges ? [{
+      entityKind: "task", identity: { taskId: payload.taskId }, action: "transition",
+      storageContext: { documentPath: "INDEX.md" }
+    }] : [])],
+    baseRefs: [
+      ref("execution", `execution/${encodeURIComponent(payload.taskId)}/${encodeURIComponent(executionId)}`),
+      ref("task", `task/${payload.taskId}`)
+    ],
+    pathSnapshots: [
+      { path: executionPath, snapshot: executionSnapshot },
+      { path: taskPath, snapshot: taskSnapshot }
+    ],
+    transaction: {
+      companionWrites: [
+        { taskId: payload.taskId, path: `executions/${executionId}.md`, body: executionDeclaration.documentCodec.encode(payload.execution) },
+        { taskId: payload.taskId, path: "INDEX.md", body: payload.taskIndexBody }
+      ],
+      preconditions: [
+        { taskId: payload.taskId, path: executionPath.slice(`tasks/${encodeURIComponent(payload.taskId)}/`.length), bodySha256: sha256Text(executionSnapshot.body) },
+        { taskId: payload.taskId, path: `reviews/${payload.review.review_id}.md`, bodySha256: null },
+        { taskId: payload.taskId, path: "INDEX.md", bodySha256: sha256Text(taskSnapshot.body) }
+      ]
+    }
+  };
+}
+
+async function dismissedReviewCompanion(
+  state: SessionExecutionReviewAuthorityStateV2,
+  payload: ReviewActionPayloadV2
+): Promise<{
+  readonly mutations: RegistryMutationPlanInput["mutations"];
+  readonly baseRefs: ReadonlyArray<RegistryEntityRefV2>;
+  readonly pathSnapshots: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }>;
+  readonly transaction: {
+    readonly companionWrites: ReadonlyArray<{ readonly taskId: string; readonly path: string; readonly body: string }>;
+    readonly preconditions: ReadonlyArray<{ readonly taskId: string; readonly path: string; readonly bodySha256: string | null }>;
+  };
+}> {
+  const executionId = payload.review.execution_ref.slice(`execution/${payload.taskId}/`.length);
+  if (!executionId) throw admission("REVIEW_EXECUTION_REF_MISMATCH");
+  const executionPath = storagePath("execution", { taskId: payload.taskId, executionId });
+  const executionSnapshot = await state.readHostedDocument(executionPath);
+  if (!executionSnapshot) throw admission("EXECUTION_DOCUMENT_NOT_FOUND");
+  const execution = decodeExecutionDocument(executionSnapshot.body);
+  if (execution.execution_id !== executionId || execution.state !== "submitted") {
+    throw admission("REVIEW_EXECUTION_NOT_SUBMITTED");
+  }
+  const taskPath = `tasks/${encodeURIComponent(payload.taskId)}/INDEX.md`;
+  const taskSnapshot = await state.readHostedDocument(taskPath);
+  if (!taskSnapshot || !/^  status:\s*in_review$/mu.test(taskSnapshot.body)) {
+    throw admission("REVIEW_TASK_NOT_IN_REVIEW");
+  }
+  return {
+    mutations: [],
+    baseRefs: [
+      ref("execution", `execution/${encodeURIComponent(payload.taskId)}/${encodeURIComponent(executionId)}`),
+      ref("task", `task/${payload.taskId}`)
+    ],
+    pathSnapshots: [
+      { path: executionPath, snapshot: executionSnapshot },
+      { path: taskPath, snapshot: taskSnapshot }
+    ],
+    transaction: {
+      companionWrites: [{ taskId: payload.taskId, path: "INDEX.md", body: taskSnapshot.body }],
+      preconditions: [
+        { taskId: payload.taskId, path: `executions/${executionId}.md`, bodySha256: sha256Text(executionSnapshot.body) },
+        { taskId: payload.taskId, path: `reviews/${payload.review.review_id}.md`, bodySha256: null },
+        { taskId: payload.taskId, path: "INDEX.md", bodySha256: sha256Text(taskSnapshot.body) }
+      ]
+    }
+  };
+}
+
+function assertChangesRequestedExecution(current: ExecutionRecord, next: ExecutionRecord, reviewedAt: string): void {
+  assertSameExecution(current, next);
+  if (current.state !== "submitted" || next.state !== "changes_requested" || next.closed_at !== reviewedAt
+    || next.submitted_at !== current.submitted_at || !same(current.session_bindings, next.session_bindings)
+    || !same(current.outputs, next.outputs) || !same(current.submission, next.submission)) {
+    throw admission("REVIEW_CHANGES_REQUESTED_EXECUTION_INVALID");
+  }
 }
 
 function assertSessionBody(manifest: SessionManifest, body: string): void {

--- a/packages/application/test/review-execution-companion-atomicity.test.ts
+++ b/packages/application/test/review-execution-companion-atomicity.test.ts
@@ -1,0 +1,97 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeJournaledWriteCoordinator, taskHolderActor } from "../src/index.ts";
+import {
+  executionDeclaration,
+  reviewDeclaration,
+  sha256Text,
+  stablePayloadHash,
+  writeDeclaredEntityTransaction,
+  type ExecutionRecord,
+  type ReviewRecord
+} from "../../kernel/src/index.ts";
+import { runEffect } from "./effect-test-helpers.ts";
+import { writeAttribution } from "./test-attribution.ts";
+import { taskIndex } from "./execution-saga-fixtures.ts";
+
+const taskId = "task_01KXT7PXRADN9575XFZC321PRV";
+const executionId = "exe_01KXT7PXRADN9575XFZC321PRW";
+const reviewId = "rev_01KXT7PXRADN9575XFZC321PRX";
+const reviewedAt = "2026-07-18T09:00:00.000Z";
+const actor = taskHolderActor({ personId: "alice", displayName: "Alice" }, { kind: "agent", id: "codex" });
+
+test("changes_requested review rolls back review and prior companions when either companion write fails", async () => {
+  for (const killpoint of ["execution-companion", "task-companion"] as const) {
+    const rootDir = mkdtempSync(path.join(tmpdir(), `ha-review-cr-${killpoint}-`));
+    const taskRoot = path.join(rootDir, "harness/tasks", taskId);
+    const executionRoot = path.join(taskRoot, "executions");
+    const reviewRoot = path.join(taskRoot, "reviews");
+    try {
+      mkdirSync(executionRoot, { recursive: true });
+      mkdirSync(reviewRoot, { recursive: true });
+      const currentExecution = execution("submitted");
+      const nextExecution = execution("changes_requested");
+      const executionPath = path.join(executionRoot, `${executionId}.md`);
+      const indexPath = path.join(taskRoot, "INDEX.md");
+      const reviewPath = path.join(reviewRoot, `${reviewId}.md`);
+      const currentExecutionBody = executionDeclaration.documentCodec.encode(currentExecution);
+      const currentIndex = taskIndex(taskId, "in_review");
+      writeFileSync(executionPath, currentExecutionBody, "utf8");
+      writeFileSync(indexPath, currentIndex, "utf8");
+      const coordinator = makeJournaledWriteCoordinator({ rootDir, attribution: writeAttribution("alice", "codex") });
+      if (killpoint === "execution-companion") chmodSync(executionRoot, 0o500);
+      if (killpoint === "task-companion") chmodSync(taskRoot, 0o500);
+
+      await assert.rejects(runEffect(writeDeclaredEntityTransaction(
+        coordinator,
+        stablePayloadHash,
+        reviewDeclaration,
+        { taskId, reviewId },
+        review(),
+        [
+          { taskId, path: `executions/${executionId}.md`, body: executionDeclaration.documentCodec.encode(nextExecution) },
+          { taskId, path: "INDEX.md", body: currentIndex.replace(/^(  status:\s*).+$/mu, "$1active") }
+        ],
+        [
+          { taskId, path: `executions/${executionId}.md`, bodySha256: sha256Text(currentExecutionBody) },
+          { taskId, path: `reviews/${reviewId}.md`, bodySha256: null },
+          { taskId, path: "INDEX.md", bodySha256: sha256Text(currentIndex) }
+        ]
+      )), /EACCES|permission denied|operation not permitted/iu);
+
+      if (killpoint === "execution-companion") chmodSync(executionRoot, 0o700);
+      if (killpoint === "task-companion") chmodSync(taskRoot, 0o700);
+      assert.equal(existsSync(reviewPath), false, killpoint);
+      assert.equal(readFileSync(executionPath, "utf8"), currentExecutionBody, killpoint);
+      assert.equal(readFileSync(indexPath, "utf8"), currentIndex, killpoint);
+    } finally {
+      chmodSync(taskRoot, 0o700);
+      if (existsSync(executionRoot)) chmodSync(executionRoot, 0o700);
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  }
+});
+
+function execution(state: "submitted" | "changes_requested"): ExecutionRecord {
+  return {
+    schema: "execution/v2", execution_id: executionId, task_ref: `task/${taskId}`, state,
+    primary_actor: actor, claimed_at: "2026-07-18T08:00:00.000Z",
+    submitted_at: "2026-07-18T08:30:00.000Z", closed_at: state === "changes_requested" ? reviewedAt : null,
+    session_bindings: [], outputs: [],
+    submission: { completion_claim: "Probe delivery", deliverables: [], evidence_refs: [], verification_notes: [], known_gaps: [], residual_risks: [] }
+  };
+}
+
+function review(): ReviewRecord {
+  return {
+    schema: "review/v3", review_id: reviewId, task_ref: `task/${taskId}`,
+    execution_ref: `execution/${taskId}/${executionId}`, reviewer_actor: actor,
+    reviewer_session_ref: "session/reviewer", findings: "Changes required", evidence_checked: [],
+    rationale: "The delivery needs another round.", verdict: "changes_requested",
+    archive_warnings_acknowledged: false, approval_basis: null, reviewed_at: reviewedAt
+  };
+}

--- a/packages/application/test/session-execution-review-authority-positive-v2.test.ts
+++ b/packages/application/test/session-execution-review-authority-positive-v2.test.ts
@@ -33,8 +33,10 @@ import {
 } from "../src/index.ts";
 import {
   entityRegistry,
+  encodeCanonicalCbor,
   makeJournaledWriteCoordinator,
   readUnionAttributionEvents,
+  semanticMutationWireV2,
   sha256Text,
   type ExecutionRecord,
   type ReviewRecord,
@@ -66,36 +68,64 @@ test("all W4 actions publish exact refs through one composite/hosted op with cro
     const syncedSessionBody = `${sessionBody}\nSynced snapshot.\n`;
     const active = executionRecord("active");
     const submitted = executionRecord("submitted");
+    const changesRequestedReview = reviewRecord(reviewId(1), "changes_requested");
+    const changesRequested: ExecutionRecord = {
+      ...submitted,
+      state: "changes_requested",
+      closed_at: changesRequestedReview.reviewed_at
+    };
     const accepted = executionRecord("accepted");
+    const executionRef = ref("execution", `execution/${taskId}/${executionId}`);
+    const taskRef = ref("task", `task/${taskId}`);
+    const executionPath = `tasks/${taskId}/executions/${executionId}.md`;
+    const taskPath = `tasks/${taskId}/INDEX.md`;
+    const activeIndex = "---\n  status: active\n---\n";
     const fixtures: ReadonlyArray<{
       readonly payload: SessionExecutionReviewCommandPayloadV2;
       readonly ref: RegistryEntityRefV2;
       readonly action: string;
       readonly path: string;
+      readonly baseRefs?: ReadonlyArray<RegistryEntityRefV2>;
+      readonly casPaths?: ReadonlyArray<string>;
+      readonly mutationSet?: SemanticMutationSetV2;
+      readonly projectedAction?: string;
     }> = [
       { payload: { schema: "session.export/v1", manifest: sessionManifest(sessionBody, "sealed"), body: sessionBody }, ref: ref("session", `session/${sessionId}`), action: "export", path: `sessions/${sessionId}.md` },
       { payload: { schema: "session.sync/v1", manifest: sessionManifest(syncedSessionBody, "sealed"), body: syncedSessionBody }, ref: ref("session", `session/${sessionId}`), action: "sync", path: `sessions/${sessionId}.md` },
       { payload: { schema: "session.archive/v1", manifest: sessionManifest(syncedSessionBody, "archived"), body: syncedSessionBody }, ref: ref("session", `session/${sessionId}`), action: "archive", path: `sessions/${sessionId}.md` },
-      { payload: { schema: "execution.claim/v1", taskId, execution: active }, ref: ref("execution", `execution/${taskId}/${executionId}`), action: "claim", path: `tasks/${taskId}/executions/${executionId}.md` },
-      { payload: { schema: "execution.submit/v1", taskId, execution: submitted }, ref: ref("execution", `execution/${taskId}/${executionId}`), action: "submit", path: `tasks/${taskId}/executions/${executionId}.md` },
-      { payload: { schema: "execution.close/v1", taskId, execution: accepted }, ref: ref("execution", `execution/${taskId}/${executionId}`), action: "close", path: `tasks/${taskId}/executions/${executionId}.md` },
-      ...(["create", "dismiss", "record"] as const).map((action, index) => {
-        const id = reviewId(index);
-        const verdict = action === "dismiss" ? "dismissed" : "changes_requested";
-        return {
-          payload: { schema: `review.${action}/v1`, taskId, review: reviewRecord(id, verdict) } as SessionExecutionReviewCommandPayloadV2,
-          ref: ref("review", `review/${taskId}/${id}`), action,
-          path: `tasks/${taskId}/reviews/${id}.md`
-        };
-      })
+      { payload: { schema: "execution.claim/v1", taskId, execution: active }, ref: executionRef, action: "claim", path: executionPath },
+      { payload: { schema: "execution.submit/v1", taskId, execution: submitted }, ref: executionRef, action: "submit", path: executionPath },
+      reviewFixture("dismiss", reviewId(0), "dismissed", [
+        ref("review", `review/${taskId}/${reviewId(0)}`), executionRef, taskRef
+      ], [executionPath, taskPath]),
+      {
+        ...reviewFixture("create", reviewId(1), "changes_requested", [
+          ref("review", `review/${taskId}/${reviewId(1)}`), executionRef, taskRef
+        ], [executionPath, taskPath]),
+        payload: {
+          schema: "review.create/v1", taskId, review: changesRequestedReview,
+          execution: changesRequested, taskIndexBody: activeIndex
+        },
+        mutationSet: setMany([
+          [ref("review", `review/${taskId}/${reviewId(1)}`), "create"],
+          [executionRef, "close"],
+          [taskRef, "transition"]
+        ]),
+        projectedAction: "close"
+      },
+      { payload: { schema: "execution.close/v1", taskId, execution: accepted }, ref: executionRef, action: "close", path: executionPath },
+      reviewFixture("record", reviewId(2), "changes_requested")
     ];
 
     const receipts = [];
     for (const [index, fixture] of fixtures.entries()) {
-      const snapshot = documentSnapshot(harnessRoot, fixture.path);
-      const baseCas = [baseCasFor(fixture.ref, bases.get(key(fixture.ref)) ?? null)];
-      const pathCas = snapshot ? [pathCasFor(fixture.path, snapshot)] : [];
-      const mutationSet = set(fixture.ref, fixture.action);
+      const baseRefs = fixture.baseRefs ?? [fixture.ref];
+      const baseCas = baseRefs.map((entityRef) => baseCasFor(entityRef, bases.get(key(entityRef)) ?? null));
+      const pathCas = (fixture.casPaths ?? [fixture.path]).flatMap((documentPath) => {
+        const snapshot = documentSnapshot(harnessRoot, documentPath);
+        return snapshot ? [pathCasFor(documentPath, snapshot)] : [];
+      });
+      const mutationSet = fixture.mutationSet ?? set(fixture.ref, fixture.action);
       const envelope = bindEnvelope(requestEnvelope(index + 1, fixture.payload, baseCas, pathCas, mutationSet), claims, tokenDigest);
       const receipt = await service.submitV2!({
         requestId: `w4-positive-${index}`,
@@ -106,8 +136,18 @@ test("all W4 actions publish exact refs through one composite/hosted op with cro
       if (receipt.tag !== "COMMITTED") continue;
       assert.equal(existsSync(path.join(harnessRoot, fixture.path)), true, fixture.path);
       const body = readFileSync(path.join(harnessRoot, fixture.path), "utf8");
-      bases.set(key(fixture.ref), { semanticVersion: `w4-v${index + 1}`, stateDigest: Buffer.from(sha256Text(body), "hex") });
-      receipts.push({ receipt, mutationSet, action: fixture.action, path: fixture.path });
+      for (const mutation of mutationSet.mutations) {
+        bases.set(key(mutation.entity), {
+          semanticVersion: `w4-v${index + 1}`,
+          stateDigest: Buffer.from(sha256Text(body), "hex")
+        });
+      }
+      receipts.push({
+        receipt,
+        mutationSet,
+        action: fixture.projectedAction ?? fixture.action,
+        path: fixture.path
+      });
     }
     assert.equal(receipts.length, 9);
 
@@ -209,7 +249,7 @@ function authority(
         consumeOperation: async () => true,
         validateAdmissionTokenRef: async (input) => input.tokenId === claims.tokenId && bytesEqual(input.tokenDigest, tokenDigest)
       },
-      entityRegistrations: [entityRegistry.session, entityRegistry.execution, entityRegistry.review],
+      entityRegistrations: [entityRegistry.session, entityRegistry.execution, entityRegistry.review, entityRegistry.task],
       semanticCompiler,
       operationNamespaceVerifier: { verify: async () => undefined },
       committedEventPublisher: {
@@ -282,8 +322,8 @@ function actorClaims(): ActorAxesBindingClaimsV2 {
   return {
     tokenId: "token-w4", bindingId: "binding-w4", principalPersonId: "person_zeyu", executorAgentId: "agent_w4",
     workspaceId: "workspace-w4-positive", deviceId: "device-w4", viewId: "view-w4", sessionId: "session-w4",
-    allowedEntityKinds: ["review", "session", "execution"],
-    allowedActions: ["sync", "claim", "close", "create", "export", "record", "submit", "archive", "dismiss"],
+    allowedEntityKinds: ["task", "review", "session", "execution"],
+    allowedActions: ["sync", "claim", "close", "create", "export", "record", "submit", "archive", "dismiss", "transition"],
     resourceScopes: [{ kind: "workspace" }], pathFootprint: null,
     maxBytes: 256n * 1024n, maxMutations: 16, maxOperations: 16,
     authorityGeneration: 1n, channelNonceDigest, schemaTuple,
@@ -308,7 +348,7 @@ async function withHermeticGit(body: (input: {
     execFileSync("git", ["-C", rootDir, "init", "-q"], { env });
     writeFileSync(path.join(rootDir, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
     mkdirSync(path.join(harnessRoot, "tasks", taskId), { recursive: true });
-    writeFileSync(path.join(harnessRoot, "tasks", taskId, "INDEX.md"), "# W4 host task\n", "utf8");
+    writeFileSync(path.join(harnessRoot, "tasks", taskId, "INDEX.md"), "---\n  status: in_review\n---\n", "utf8");
     execFileSync("git", ["-C", harnessRoot, "init", "-q"], { env });
     execFileSync("git", ["-C", harnessRoot, "add", "."], { env });
     execFileSync("git", ["-C", harnessRoot, "commit", "-m", "test: initialize W4 positive control"], { env });
@@ -337,6 +377,36 @@ function pathCasFor(documentPath: string, value: HostedDocumentSnapshotV2) {
 
 function set(entityRef: RegistryEntityRefV2, action: string): SemanticMutationSetV2 {
   return { registryVersion: 1, mutations: [{ entity: entityRef, action: { registryVersion: 1, action } }] };
+}
+
+function setMany(entries: ReadonlyArray<readonly [RegistryEntityRefV2, string]>): SemanticMutationSetV2 {
+  return {
+    registryVersion: 1,
+    mutations: entries.map(([entity, action]) => ({
+      entity,
+      action: { registryVersion: 1, action }
+    })).sort((left, right) => Buffer.compare(
+      Buffer.from(encodeCanonicalCbor(semanticMutationWireV2(left))),
+      Buffer.from(encodeCanonicalCbor(semanticMutationWireV2(right)))
+    ))
+  };
+}
+
+function reviewFixture(
+  action: "create" | "dismiss" | "record",
+  id: string,
+  verdict: ReviewRecord["verdict"],
+  baseRefs?: ReadonlyArray<RegistryEntityRefV2>,
+  casPaths?: ReadonlyArray<string>
+) {
+  return {
+    payload: { schema: `review.${action}/v1`, taskId, review: reviewRecord(id, verdict) } as SessionExecutionReviewCommandPayloadV2,
+    ref: ref("review", `review/${taskId}/${id}`),
+    action,
+    path: `tasks/${taskId}/reviews/${id}.md`,
+    ...(baseRefs ? { baseRefs } : {}),
+    ...(casPaths ? { casPaths } : {})
+  };
 }
 
 function ref(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {

--- a/packages/application/test/session-execution-review-semantic-compiler-v2.test.ts
+++ b/packages/application/test/session-execution-review-semantic-compiler-v2.test.ts
@@ -26,6 +26,7 @@ import {
   compileRegistryMutationPlan,
   createWritableEntityRegistry,
   entityRegistry,
+  executionDeclaration,
   sha256Text,
   type EntityRegistration,
   type ExecutionRecord,
@@ -174,24 +175,83 @@ test("execution submit atomically transitions the task index to in_review", asyn
   ]);
 });
 
-test("review create/dismiss/record compile immutable hosted review documents without task-host attribution", async () => {
+test("review dismiss/record compile immutable hosted review documents without task-host attribution", async () => {
   const cases: ReadonlyArray<{ readonly schema: ReviewActionPayloadV2["schema"]; readonly verdict: ReviewRecord["verdict"]; readonly action: string }> = [
-    { schema: "review.create/v1", verdict: "changes_requested", action: "create" },
     { schema: "review.dismiss/v1", verdict: "dismissed", action: "dismiss" },
     { schema: "review.record/v1", verdict: "changes_requested", action: "record" }
   ];
   for (const fixture of cases) {
     const review = reviewRecord(fixture.verdict);
     const reviewRef = ref("review", `review/${taskId}/${reviewId}`);
-    const compiled = await makeSessionExecutionReviewSemanticCompilerV2({ state: authorityState() }).compile(envelope({
+    const executionRef = ref("execution", `execution/${taskId}/${executionId}`);
+    const taskRef = ref("task", `task/${taskId}`);
+    const executionPath = `tasks/${taskId}/executions/${executionId}.md`;
+    const taskPath = `tasks/${taskId}/INDEX.md`;
+    const executionSnapshot = snapshot(JSON.stringify(executionRecord("submitted")));
+    const taskSnapshot = snapshot("---\n  status: in_review\n---\n");
+    const dismissed = fixture.schema === "review.dismiss/v1";
+    const compiled = await makeSessionExecutionReviewSemanticCompilerV2({
+      state: dismissed
+        ? authorityState(
+            new Map([[key(executionRef), base("execution-v1")], [key(taskRef), base("task-v1")]]),
+            new Map([[executionPath, executionSnapshot], [taskPath, taskSnapshot]])
+          )
+        : authorityState()
+    }).compile(envelope({
       schema: fixture.schema, taskId, review
-    }, [absent(reviewRef)]));
+    }, dismissed ? [
+      absent(reviewRef), present(executionRef, "execution-v1"), present(taskRef, "task-v1")
+    ] : [absent(reviewRef)], dismissed ? [
+      cas(executionPath, executionSnapshot), cas(taskPath, taskSnapshot)
+    ] : []));
     const planned = compileRegistryMutationPlan(registry, compiled.mutationPlan);
     assert.deepEqual(planned.mutationSet.mutations.map(pair), [`review/${taskId}/${reviewId}:${fixture.action}`]);
     assert.equal(planned.mutationSet.mutations.some((mutation) => mutation.entity.entityKind === "task"), false);
     assert.deepEqual(planned.storagePlan.touchedPaths, [`tasks/${taskId}/reviews/${reviewId}.md`]);
     assert.equal(operationDocument(compiled.operation.payload).identity.reviewId, reviewId);
   }
+});
+
+test("changes_requested review compiles review, execution, and task companions into one operation", async () => {
+  const review = reviewRecord("changes_requested");
+  const submitted = executionRecord("submitted");
+  const changed = { ...submitted, state: "changes_requested" as const, closed_at: review.reviewed_at };
+  const executionPath = `tasks/${taskId}/executions/${executionId}.md`;
+  const taskPath = `tasks/${taskId}/INDEX.md`;
+  const executionSnapshot = snapshot(JSON.stringify(submitted));
+  const taskSnapshot = snapshot("---\n  status: in_review\n---\n");
+  const activeIndex = taskSnapshot.body.replace("status: in_review", "status: active");
+  const reviewRef = ref("review", `review/${taskId}/${reviewId}`);
+  const executionRef = ref("execution", `execution/${taskId}/${executionId}`);
+  const taskRef = ref("task", `task/${taskId}`);
+  const compiled = await makeSessionExecutionReviewSemanticCompilerV2({
+    state: authorityState(
+      new Map([[key(executionRef), base("execution-v1")], [key(taskRef), base("task-v1")]]),
+      new Map([[executionPath, executionSnapshot], [taskPath, taskSnapshot]])
+    )
+  }).compile(envelope({
+    schema: "review.create/v1", taskId, review, execution: changed, taskIndexBody: activeIndex
+  }, [absent(reviewRef), present(executionRef, "execution-v1"), present(taskRef, "task-v1")], [
+    cas(executionPath, executionSnapshot), cas(taskPath, taskSnapshot)
+  ]));
+
+  const planned = compileRegistryMutationPlan(registry, compiled.mutationPlan);
+  assert.deepEqual(planned.mutationSet.mutations.map(pair).sort(), [
+    `review/${taskId}/${reviewId}:create`,
+    `execution/${taskId}/${executionId}:close`,
+    `task/${taskId}:transition`
+  ].sort());
+  assert.deepEqual((compiled.operation.payload as { readonly companionWrites?: unknown }).companionWrites, [
+    { taskId, path: `executions/${executionId}.md`, body: executionDeclaration.documentCodec.encode(changed) },
+    { taskId, path: "INDEX.md", body: activeIndex }
+  ]);
+});
+
+test("changes_requested review rejects an incomplete companion transaction", async () => {
+  const reviewRef = ref("review", `review/${taskId}/${reviewId}`);
+  await assert.rejects(makeSessionExecutionReviewSemanticCompilerV2({ state: authorityState() }).compile(envelope({
+    schema: "review.create/v1", taskId, review: reviewRecord("changes_requested")
+  }, [absent(reviewRef)])), /REVIEW_CHANGES_REQUESTED_COMPANION_REQUIRED/u);
 });
 
 test("authority review writes cannot bypass the consent-aware approved Review transaction", async () => {

--- a/packages/cli/src/daemon/production-authority-attempt-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-attempt-compiler.ts
@@ -462,24 +462,6 @@ async function canonicalAttemptIntent(
     const entity = ref("session", `session/${action.sessionId}`);
     return canonicalIntent("session.export", encodeSessionExecutionReviewCommandPayloadV2(payload), [{ entity, action: "export" }], [entity], [`sessions/${action.sessionId}.md`, `objects/sha256/${digest.slice(0, 2)}/${digest.slice(2)}`], `entity/session/${action.sessionId}`);
   }
-  if (action.kind === "task-review-execution" && !action.consentId && action.verdict !== "approved") {
-    const reviewId = canonicalEntityId.replace(/^(?:entity\/)?review\//u, "");
-    const payload: SessionExecutionReviewCommandPayloadV2 = {
-      schema: action.verdict === "dismissed" ? "review.dismiss/v1" : "review.create/v1",
-      taskId: action.taskId,
-      review: {
-        schema: "review/v3", review_id: reviewId, task_ref: `task/${action.taskId}`,
-        execution_ref: `execution/${action.taskId}/${action.executionId}`, reviewer_actor: executionActor,
-        reviewer_session_ref: `session/${currentSession.sessionId}`, findings: action.findings,
-        evidence_checked: action.evidenceChecked, rationale: action.rationale, verdict: action.verdict,
-        archive_warnings_acknowledged: action.archiveWarningsAcknowledged,
-        reviewed_at: currentSession.detectedAt, approval_basis: null
-      }
-    };
-    const mutationAction = action.verdict === "dismissed" ? "dismiss" : "create";
-    const entity = ref("review", `review/${action.taskId}/${reviewId}`);
-    return canonicalIntent(`review.${mutationAction}`, encodeSessionExecutionReviewCommandPayloadV2(payload), [{ entity, action: mutationAction }], [entity], [`tasks/${action.taskId}/reviews/${reviewId}.md`], canonicalEntityId);
-  }
   if (action.kind === "task-consent-record") {
     const consentId = canonicalEntityId.replace(/^(?:entity\/)?consent\//u, "");
     const executionPath = `tasks/${action.taskId}/executions/${action.executionId}.md`;
@@ -496,7 +478,7 @@ async function canonicalAttemptIntent(
       declaredPathCas: [{ path: executionPath, ...snapshot.cas }]
     };
   }
-  return productionLifecycleAttemptIntent({ command, currentSession, canonicalEntityId, authoredRoot });
+  return productionLifecycleAttemptIntent({ command, currentSession, canonicalEntityId, authoredRoot, actor: executionActor });
 }
 
 function canonicalIntent(

--- a/packages/cli/src/daemon/production-authority-lifecycle-intents.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle-intents.ts
@@ -31,6 +31,7 @@ export function productionLifecycleAttemptIntent(input: {
   readonly currentSession: CompileInput["currentSession"];
   readonly canonicalEntityId: string;
   readonly authoredRoot: string;
+  readonly actor: ExecutionRecord["primary_actor"];
 }): CanonicalAttemptIntent | null {
   const { action } = input.command;
   if (action.kind === "status-set") {
@@ -70,6 +71,26 @@ export function productionLifecycleAttemptIntent(input: {
   if (action.kind === "task-code-doc-reconcile") return codeDocIntent(input.authoredRoot, action);
   if (action.kind === "task-review-execution" && action.verdict === "approved") {
     return approvedReviewIntent(input.authoredRoot, input.canonicalEntityId, action);
+  }
+  if (action.kind === "task-review-execution" && action.verdict === "changes_requested") {
+    return changesRequestedReviewIntent(
+      input.authoredRoot,
+      input.currentSession.detectedAt,
+      input.currentSession.sessionId,
+      input.canonicalEntityId,
+      action,
+      input.actor
+    );
+  }
+  if (action.kind === "task-review-execution" && action.verdict === "dismissed") {
+    return dismissedReviewIntent(
+      input.authoredRoot,
+      input.currentSession.detectedAt,
+      input.currentSession.sessionId,
+      input.canonicalEntityId,
+      action,
+      input.actor
+    );
   }
   if (action.kind === "task-complete") {
     return taskCompletionIntent(input.authoredRoot, input.currentSession.detectedAt, action.taskId, input.canonicalEntityId);
@@ -195,6 +216,97 @@ function approvedReviewIntent(
     requiredLifecycleSnapshot(authoredRoot, taskPath.logical, taskPath.physical),
     ...(storedConsent ? [storedConsent] : [])
   ]);
+}
+
+function changesRequestedReviewIntent(
+  authoredRoot: string,
+  reviewedAt: string,
+  reviewerSessionId: string,
+  canonicalEntityId: string,
+  action: Extract<ParsedCommand["action"], { readonly kind: "task-review-execution" }>,
+  reviewerActor: ExecutionRecord["primary_actor"]
+): CanonicalAttemptIntent {
+  const reviewId = canonicalEntityId.replace(/^(?:entity\/)?review\//u, "");
+  const executionPath = taskLifecyclePath(authoredRoot, action.taskId, `executions/${action.executionId}.md`);
+  const executionSnapshot = requiredLifecycleSnapshot(authoredRoot, executionPath.logical, executionPath.physical);
+  const current = executionDeclaration.documentCodec.decode(executionSnapshot.body) as ExecutionRecord;
+  const execution: ExecutionRecord = { ...current, state: "changes_requested", closed_at: reviewedAt };
+  const taskPath = taskLifecyclePath(authoredRoot, action.taskId, "INDEX.md");
+  const taskSnapshot = requiredLifecycleSnapshot(authoredRoot, taskPath.logical, taskPath.physical);
+  const taskIndexBody = hasOtherSubmittedExecution(authoredRoot, action.taskId, action.executionId)
+    ? taskSnapshot.body
+    : taskSnapshot.body.replace(/^(  status:\s*)in_review$/mu, "$1active");
+  const reviewPath = taskLifecyclePath(authoredRoot, action.taskId, `reviews/${reviewId}.md`);
+  const payload: SessionExecutionReviewCommandPayloadV2 = {
+    schema: "review.create/v1",
+    taskId: action.taskId,
+    review: {
+      schema: "review/v3", review_id: reviewId, task_ref: `task/${action.taskId}`,
+      execution_ref: `execution/${action.taskId}/${action.executionId}`,
+      reviewer_actor: reviewerActor,
+      reviewer_session_ref: `session/${reviewerSessionId}`,
+      findings: action.findings, evidence_checked: action.evidenceChecked, rationale: action.rationale,
+      verdict: "changes_requested", archive_warnings_acknowledged: action.archiveWarningsAcknowledged,
+      reviewed_at: reviewedAt, approval_basis: null
+    },
+    execution,
+    taskIndexBody
+  };
+  const taskChanges = taskIndexBody !== taskSnapshot.body;
+  return lifecycleIntent("review.create", encodeSessionExecutionReviewCommandPayloadV2(payload), [
+    lifecycleMutation("review", `review/${action.taskId}/${reviewId}`, "create"),
+    lifecycleMutation("execution", `execution/${action.taskId}/${action.executionId}`, "close"),
+    ...(taskChanges ? [lifecycleMutation("task", `task/${action.taskId}`, "transition")] : [])
+  ], [
+    lifecycleRef("review", `review/${action.taskId}/${reviewId}`),
+    lifecycleRef("execution", `execution/${action.taskId}/${action.executionId}`),
+    lifecycleRef("task", `task/${action.taskId}`)
+  ], portableLifecyclePaths(reviewPath, executionPath, taskPath), canonicalEntityId, [executionSnapshot, taskSnapshot]);
+}
+
+function hasOtherSubmittedExecution(authoredRoot: string, taskId: string, reviewedExecutionId: string): boolean {
+  const executionRoot = path.join(resolvedTaskRoot(authoredRoot, taskId), "executions");
+  if (!existsSync(executionRoot)) return false;
+  return readdirSync(executionRoot).filter((name) => name.endsWith(".md") && name !== `${reviewedExecutionId}.md`)
+    .some((name) => {
+      const record = executionDeclaration.documentCodec.decode(readFileSync(path.join(executionRoot, name), "utf8")) as ExecutionRecord;
+      return record.state === "submitted";
+    });
+}
+
+function dismissedReviewIntent(
+  authoredRoot: string,
+  reviewedAt: string,
+  reviewerSessionId: string,
+  canonicalEntityId: string,
+  action: Extract<ParsedCommand["action"], { readonly kind: "task-review-execution" }>,
+  reviewerActor: ExecutionRecord["primary_actor"]
+): CanonicalAttemptIntent {
+  const reviewId = canonicalEntityId.replace(/^(?:entity\/)?review\//u, "");
+  const executionPath = taskLifecyclePath(authoredRoot, action.taskId, `executions/${action.executionId}.md`);
+  const taskPath = taskLifecyclePath(authoredRoot, action.taskId, "INDEX.md");
+  const reviewPath = taskLifecyclePath(authoredRoot, action.taskId, `reviews/${reviewId}.md`);
+  const executionSnapshot = requiredLifecycleSnapshot(authoredRoot, executionPath.logical, executionPath.physical);
+  const taskSnapshot = requiredLifecycleSnapshot(authoredRoot, taskPath.logical, taskPath.physical);
+  const payload: SessionExecutionReviewCommandPayloadV2 = {
+    schema: "review.dismiss/v1",
+    taskId: action.taskId,
+    review: {
+      schema: "review/v3", review_id: reviewId, task_ref: `task/${action.taskId}`,
+      execution_ref: `execution/${action.taskId}/${action.executionId}`,
+      reviewer_actor: reviewerActor, reviewer_session_ref: `session/${reviewerSessionId}`,
+      findings: action.findings, evidence_checked: action.evidenceChecked, rationale: action.rationale,
+      verdict: "dismissed", archive_warnings_acknowledged: action.archiveWarningsAcknowledged,
+      reviewed_at: reviewedAt, approval_basis: null
+    }
+  };
+  return lifecycleIntent("review.dismiss", encodeSessionExecutionReviewCommandPayloadV2(payload), [
+    lifecycleMutation("review", `review/${action.taskId}/${reviewId}`, "dismiss")
+  ], [
+    lifecycleRef("review", `review/${action.taskId}/${reviewId}`),
+    lifecycleRef("execution", `execution/${action.taskId}/${action.executionId}`),
+    lifecycleRef("task", `task/${action.taskId}`)
+  ], portableLifecyclePaths(reviewPath, executionPath, taskPath), canonicalEntityId, [executionSnapshot, taskSnapshot]);
 }
 
 function taskCompletionIntent(authoredRoot: string, completedAt: string, taskId: string, canonicalEntityId: string): CanonicalAttemptIntent {

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -43,7 +43,7 @@ import {
   writeColdCodexSessionLog
 } from "./fixture.ts";
 import { verifyD22ClaimChain } from "./d22-claim-chain.ts";
-import { verifyDecisionProposeParity } from "./propose-parity.ts";
+import { verifyProductionCommandParity } from "./production-parity.ts";
 
 test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 120_000 }, async () => {
   const fixture = createFixture();
@@ -83,7 +83,7 @@ test("production service route preserves progress dry-run and publishes canonica
     );
     assert.equal(status.repoCount, 2, JSON.stringify(status));
 
-    verifyDecisionProposeParity(fixture, env);
+    verifyProductionCommandParity(fixture, env);
 
     const decisionId = "dec_01KXQ4WTA7Q4XJ5GDDRS1YXND9";
     const proposed = runRawJsonMaybeFail(fixture.repoRoot, [
@@ -495,12 +495,12 @@ test("production generic canonical ingress accepts and journals one write for ev
     }, {
       kind: "review",
       action: {
-        kind: "task-review-execution", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", executionId: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5",
-        verdict: "changes_requested", findings: "Ingress review coverage.", evidenceChecked: ["journal"],
-        rationale: "A non-approved review exercises the standalone review compiler.", archiveWarningsAcknowledged: true
+        kind: "task-review-execution", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNH2", executionId: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNH3",
+        verdict: "dismissed", findings: "Ingress review coverage.", evidenceChecked: ["journal"],
+        rationale: "A dismissed review exercises the standalone review compiler.", archiveWarningsAcknowledged: true
       },
       canonicalEntityId: "review/rev_01KXQ4WTA7Q4XJ5GDDRS1YXNG2" as EntityId,
-      authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/reviews/rev_01KXQ4WTA7Q4XJ5GDDRS1YXNG2.md",
+      authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNH2/reviews/rev_01KXQ4WTA7Q4XJ5GDDRS1YXNG2.md",
       authoredMarker: /rev_01KXQ4WTA7Q4XJ5GDDRS1YXNG2/u
     }, {
       kind: "consent",

--- a/packages/cli/test/production-authority-canonical-ingress/fixture.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/fixture.ts
@@ -45,6 +45,18 @@ export function createFixture() {
   };
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/executions"), { recursive: true });
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/executions/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5.md"), executionDeclaration.documentCodec.encode(submittedExecution));
+  writeReviewVerdictTask(
+    authoredRoot,
+    "task_01KXQ4WTA7Q4XJ5GDDRS1YXNH0",
+    "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNH1",
+    submittedExecution
+  );
+  writeReviewVerdictTask(
+    authoredRoot,
+    "task_01KXQ4WTA7Q4XJ5GDDRS1YXNH2",
+    "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNH3",
+    submittedExecution
+  );
   const sluggedExecution: ExecutionRecord = {
     ...submittedExecution,
     execution_id: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG7",
@@ -208,6 +220,26 @@ function operationPath(serviceRoot: string): string {
 
 function taskIndexBody(taskId: string): string {
   return ["---", "schema: task-package/v2", `task_id: ${taskId}`, "title: Production ingress", "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", "  status: active", "  ref: ", "  titleSnapshot: Production ingress", "  url: ", "  bindingCreatedAt: 2026-07-17T00:00:00.000Z", `  bindingFingerprint: sha256:${"b".repeat(64)}`, "packageDisposition: active", "vertical: default", "preset: default", "provenance:", "  - {runtime: \"human\", sessionId: \"fixture\", boundAt: \"2026-07-17T00:00:00.000Z\"}", "---", "", "# Production ingress", ""].join("\n");
+}
+
+function writeReviewVerdictTask(
+  authoredRoot: string,
+  taskId: string,
+  executionId: string,
+  source: ExecutionRecord
+): void {
+  const taskRoot = path.join(authoredRoot, "tasks", taskId);
+  mkdirSync(path.join(taskRoot, "executions"), { recursive: true });
+  writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndexBody(taskId).replace("  status: active", "  status: in_review"));
+  writeFileSync(path.join(taskRoot, "executions", `${executionId}.md`), executionDeclaration.documentCodec.encode({
+    ...source,
+    execution_id: executionId,
+    task_ref: `task/${taskId}`,
+    outputs: source.outputs.map((evidence) => ({
+      ...evidence,
+      execution_ref: `execution/${taskId}/${executionId}`
+    }))
+  }));
 }
 
 function productionTuple() {

--- a/packages/cli/test/production-authority-canonical-ingress/production-parity.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/production-parity.ts
@@ -1,0 +1,11 @@
+import type { ProductionCanonicalIngressFixture } from "./fixture.ts";
+import { verifyDecisionProposeParity } from "./propose-parity.ts";
+import { verifyReviewVerdictCompanions } from "./review-verdict-companions.ts";
+
+export function verifyProductionCommandParity(
+  fixture: ProductionCanonicalIngressFixture,
+  env: NodeJS.ProcessEnv
+): void {
+  verifyDecisionProposeParity(fixture, env);
+  verifyReviewVerdictCompanions(fixture, env);
+}

--- a/packages/cli/test/production-authority-canonical-ingress/review-verdict-companions.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/review-verdict-companions.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { runRawJsonMaybeFail } from "../helpers/daemon-cli.ts";
+import type { ProductionCanonicalIngressFixture } from "./fixture.ts";
+
+export function verifyReviewVerdictCompanions(
+  fixture: ProductionCanonicalIngressFixture,
+  env: NodeJS.ProcessEnv
+): void {
+  verifyChangesRequested(fixture, env);
+  verifyDismissed(fixture, env);
+}
+
+function verifyChangesRequested(fixture: ProductionCanonicalIngressFixture, env: NodeJS.ProcessEnv): void {
+  const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNH0";
+  const executionId = "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNH1";
+  const reviewed = runRawJsonMaybeFail(fixture.repoRoot, [
+    "task", "review-execution", taskId, "--execution-id", executionId,
+    "--verdict", "changes_requested", "--findings", "Companion writes must be atomic.",
+    "--rationale", "The submitted round needs another delivery."
+  ], env);
+  assert.equal(reviewed.status, 0, JSON.stringify(reviewed.receipt));
+  assert.equal(reviewed.receipt.ok, true, JSON.stringify(reviewed.receipt));
+  const reviewId = receiptReviewId(reviewed.receipt);
+  const taskRoot = path.join(fixture.authoredRoot, "tasks", taskId);
+  assert.equal(existsSync(path.join(taskRoot, "reviews", `${reviewId}.md`)), true);
+  const execution = JSON.parse(readFileSync(path.join(taskRoot, "executions", `${executionId}.md`), "utf8")) as {
+    readonly state?: string;
+    readonly closed_at?: string | null;
+  };
+  assert.equal(execution.state, "changes_requested");
+  assert.equal(typeof execution.closed_at, "string");
+  assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: active$/mu);
+  const executionProjection = runRawJsonMaybeFail(fixture.repoRoot, ["execution", "show", executionId], env);
+  assert.equal(executionProjection.status, 0, JSON.stringify(executionProjection.receipt));
+  assert.match(JSON.stringify(executionProjection.receipt), /"state":"changes_requested"/u);
+  const taskProjection = runRawJsonMaybeFail(fixture.repoRoot, ["task", "show", taskId], env);
+  assert.equal(taskProjection.status, 0, JSON.stringify(taskProjection.receipt));
+  assert.match(JSON.stringify(taskProjection.receipt), /active/u);
+}
+
+function verifyDismissed(fixture: ProductionCanonicalIngressFixture, env: NodeJS.ProcessEnv): void {
+  const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNH2";
+  const executionId = "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNH3";
+  const reviewed = runRawJsonMaybeFail(fixture.repoRoot, [
+    "task", "review-execution", taskId, "--execution-id", executionId,
+    "--verdict", "dismissed", "--findings", "This review round is not authoritative.",
+    "--rationale", "Dismissal leaves the submitted delivery reviewable."
+  ], env);
+  assert.equal(reviewed.status, 0, JSON.stringify(reviewed.receipt));
+  assert.equal(reviewed.receipt.ok, true, JSON.stringify(reviewed.receipt));
+  const reviewId = receiptReviewId(reviewed.receipt);
+  const taskRoot = path.join(fixture.authoredRoot, "tasks", taskId);
+  assert.equal(existsSync(path.join(taskRoot, "reviews", `${reviewId}.md`)), true);
+  const execution = JSON.parse(readFileSync(path.join(taskRoot, "executions", `${executionId}.md`), "utf8")) as {
+    readonly state?: string;
+    readonly closed_at?: string | null;
+  };
+  assert.equal(execution.state, "submitted");
+  assert.equal(execution.closed_at, null);
+  assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: in_review$/mu);
+  const executionProjection = runRawJsonMaybeFail(fixture.repoRoot, ["execution", "show", executionId], env);
+  assert.equal(executionProjection.status, 0, JSON.stringify(executionProjection.receipt));
+  assert.match(JSON.stringify(executionProjection.receipt), /"state":"submitted"/u);
+  const taskProjection = runRawJsonMaybeFail(fixture.repoRoot, ["task", "show", taskId], env);
+  assert.equal(taskProjection.status, 0, JSON.stringify(taskProjection.receipt));
+  assert.match(JSON.stringify(taskProjection.receipt), /in_review/u);
+}
+
+function receiptReviewId(receipt: { readonly details?: unknown }): string {
+  const reviewId = String((receipt.details as { readonly data?: { readonly reviewId?: string } } | undefined)?.data?.reviewId ?? "");
+  assert.match(reviewId, /^rev_[0-9A-HJKMNP-TV-Z]{26}$/u, JSON.stringify(receipt));
+  return reviewId;
+}


### PR DESCRIPTION
# English

## Summary

Fourth instance of the wire-parity defect family, exposed by CEO dogfooding right after #908: `task review-execution --verdict changes_requested` on the production authority road returned a successful receipt and wrote the Review round document, but the two companion writes the application semantics require (Execution → `changes_requested`/`closed_at`, Task INDEX → `active`) never entered the authority transaction. Any changes-requested task wedged in `in_review` — the guard's suggested exit was the broken road itself.

## What Changed

- `review.create/v1` payload carries optional Execution/INDEX companion sections; the production attempt compiler declares and commits Review + Execution close + INDEX transition as one canonical transaction with path CAS on all documents.
- Semantic compiler enforces completeness fail-closed: a `changes_requested` create attempt missing any companion is rejected with `REVIEW_CHANGES_REQUESTED_COMPANION_REQUIRED`, with strict validation of identity alignment, immutable Execution fields, allowed state targets, and mutation-set/base-ref/CAS consistency.
- All three verdicts are now symmetric in the review domain of the lifecycle intents: `approved` keeps the consent-compiler transaction; `dismissed` binds Execution/INDEX as CAS no-op companions (states must remain submitted/in_review); the hand-written dismissed intent in the generic compiler is retired.

## Task And Scope

- Task task_01KXT7PXRADN9575XFZC321PRV; same defect family as #908 (decision anchor dec_01KXSWKWTEXB751A30TRRCQWDG umbrella).
- Live probe wedge (task_01KXT7DQRS / exe_01KXT7DZCZ) left read-only; it retries naturally post-deploy. The older wedge task_01KXT2DT7H remains untouched pending a governed repair command.

## Version Impact

- No published package version change.

## Governance Declaration

- Decision anchor: dec_01KXSWKWTEXB751A30TRRCQWDG (accepted).
- Protected paths untouched (`.github/**`, `tools/gate-manifest.json`, `tools/check-*.mjs`, `harness/**`).
- No gate weakening: guards are not relaxed and no bypass is added; incomplete legacy-format attempts fail closed for authority recovery/governance to disposition explicitly.

## Verification

- Red control: real same-path production test (CLI argv→socket→daemon→V2 authority) reproduced "receipt ok + Review written + Execution still submitted" before the fix.
- Green: production same-path asserts CR receipt truth, raw Execution `changes_requested` with `closed_at`, raw INDEX `active`, projections consistent; dismissed leaves states untouched with raw/projection parity; existing approved consent→review→complete chain still passes.
- Atomicity: 12/12 semantic tests including both killpoint directions (execution-companion failure rolls back Review+Task; task-companion failure rolls back Review+Execution) — no one-sided state.
- Root `env -u FORCE_COLOR HARNESS_DAEMON_MODE=direct npm run check:local` exit 0 — 32 manifest gates green; affected contract tests 247/247.

## Review Evidence

- CEO semantic acceptance: verdict symmetry table checked against application semantics (review-execution-service.ts); fail-closed completeness matches the family's invariant (no silent downgrade); wedge discipline honored (read-only, natural retry).

## Residual Risk

- Multi-round tasks: CR closes the reviewed Execution but INDEX stays `in_review` when another submitted round exists — existing local semantics, covered by application tests.
- A pre-existing non-terminal semantic attempt in the old incomplete format would fail closed and needs explicit authority-recovery disposition.
- Post-deploy probe retry and cancel are operator steps after this PR merges.

## References

- Worker report: `tmp/orch/ingress-derivation/REPORT-cr-companion.md`.
- Defect lineage: #905 (coverage derivation) → #908 (semantic parity) → this PR (verdict companion atomicity).

---

# 中文

## 概要

wire-parity 缺陷族第四实例,#908 合入后 CEO dogfood 当场暴露:生产 authority 路上 `task review-execution --verdict changes_requested` 回执成功且 Review round 文档落盘,但应用语义要求的两个伴随写(Execution → `changes_requested`/`closed_at`、Task INDEX → `active`)从未进入 authority 事务。被 CR 的任务楔死在 `in_review`——guard 提示的出路正是坏的那条。

## 改动内容

- `review.create/v1` payload 携带可选 Execution/INDEX companion 段;生产 attempt compiler 把 Review + Execution 收口 + INDEX 转移声明进**同一个** canonical 事务,全部文档带 path CAS。
- semantic compiler 完备性 fail-closed:`changes_requested` create 缺任一 companion 直接拒绝(`REVIEW_CHANGES_REQUESTED_COMPANION_REQUIRED`),并严格校验 identity 对齐、Execution 不可变字段、允许的目标状态、mutation-set/base-ref/CAS 一致性。
- 三 verdict 在 lifecycle intents 的 review domain 内对称:`approved` 沿用 consent compiler 事务;`dismissed` 把 Execution/INDEX 绑定为 CAS no-op companion(状态必须保持 submitted/in_review);通用 compiler 手写的 dismissed intent 退役。

## 任务与范围

- 任务 task_01KXT7PXRADN9575XFZC321PRV;与 #908 同缺陷族(伞形决策锚 dec_01KXSWKWTEXB751A30TRRCQWDG)。
- 现场 probe wedge(task_01KXT7DQRS / exe_01KXT7DZCZ)只读保留,部署后自然重试;老 wedge task_01KXT2DT7H 未触碰,等受治理 repair 命令。

## 版本影响

- 无已发布包版本变更。

## 治理声明

- 决策锚:dec_01KXSWKWTEXB751A30TRRCQWDG(已 accept)。
- 未触碰受保护路径(`.github/**`、`tools/gate-manifest.json`、`tools/check-*.mjs`、`harness/**`)。
- 无门禁削弱:guard 未放宽、未加 bypass;旧格式不完整 attempt fail-closed,由 authority recovery/治理显式处置,不静默按旧语义提交。

## 验证

- 红对照:真实同路径生产测试(CLI argv→socket→daemon→V2 authority)修复前复现「回执 ok+Review 落盘+Execution 仍 submitted」。
- 绿:生产同路径断言 CR 回执真实、raw Execution `changes_requested` 带 `closed_at`、raw INDEX `active`、projection 一致;dismissed 状态不动且 raw/projection 一致;既有 approved consent→review→complete 链继续通过。
- 原子性:语义测试 12/12,含双向 killpoint(execution companion 失败回滚 Review+Task;task companion 失败回滚 Review+Execution),无单边状态。
- 根 `env -u FORCE_COLOR HARNESS_DAEMON_MODE=direct npm run check:local` exit 0——32 个 manifest gate 绿;受影响 contract 测试 247/247。

## 审查证据

- CEO 语义验收:三 verdict 对称表对照应用语义(review-execution-service.ts)核过;完备性 fail-closed 符合缺陷族不变量(禁静默降级);wedge 纪律遵守(只读、自然重试)。

## 残余风险

- 多 round 任务:存在其他 submitted round 时 CR 收口被 review 的 Execution 而 INDEX 保持 `in_review`——既有本地语义,应用层测试覆盖。
- 若存在旧不完整格式的未终态 semantic attempt,会 fail-closed,需 authority recovery 显式处置。
- 部署后 probe 重试与 cancel 属合入后的 operator 步骤。

## 关联材料

- Worker 报告:`tmp/orch/ingress-derivation/REPORT-cr-companion.md`。
- 缺陷谱系:#905(覆盖面派生)→ #908(语义平价)→ 本 PR(verdict companion 原子性)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
