### PR TITLE
fix(cli): fail fast when Electron runtime is missing

### DIFF
--- a/packages/cli/src/commands/core/gui.ts
+++ b/packages/cli/src/commands/core/gui.ts
@@ -42,6 +42,17 @@ function launchGui(rootDir: string, authoredRoot?: string): CliResult {
     };
   }
 
+  if (!hasElectronRuntime(workspaceRoot)) {
+    return {
+      ok: false,
+      command: "gui",
+      error: cliError(
+        CliErrorCode.GuiLauncherUnavailable,
+        `Electron runtime is missing from the trusted harness-anything workspace at ${workspaceRoot}. Run \`node node_modules/electron/install.js\` from that workspace, then retry \`ha gui\`.`
+      )
+    };
+  }
+
   const detached = process.env.HARNESS_GUI_NPM_MARKER === undefined;
   const launchEnvironment = guiLaunchEnvironment(rootDir, authoredRoot);
   const child = process.platform === "win32" ? spawn(windowsShellCommand(command), {
@@ -71,6 +82,20 @@ function launchGui(rootDir: string, authoredRoot?: string): CliResult {
       pid: child.pid
     }
   };
+}
+
+function hasElectronRuntime(workspaceRoot: string): boolean {
+  const electronDistRoot = path.join(workspaceRoot, "node_modules/electron/dist");
+  const electronPathFile = path.join(workspaceRoot, "node_modules/electron/path.txt");
+  if (!existsSync(electronPathFile)) return false;
+  try {
+    const relativeRuntimePath = readFileSync(electronPathFile, "utf8").trim();
+    if (!relativeRuntimePath) return false;
+    const runtimePath = path.resolve(electronDistRoot, relativeRuntimePath);
+    return isPathInside(electronDistRoot, runtimePath) && existsSync(runtimePath);
+  } catch {
+    return false;
+  }
 }
 
 function guiLaunchEnvironment(rootDir: string, authoredRoot?: string): NodeJS.ProcessEnv {

--- a/packages/cli/test/gui-cli.test.ts
+++ b/packages/cli/test/gui-cli.test.ts
@@ -60,11 +60,11 @@ test("CLI gui command launches npm from the trusted package workspace, not the c
     }
     chmodSync(path.join(binDir, npmBin), 0o755);
 
-    const result = runJson(rootDir, ["gui"], true, {
+    const result = withElectronRuntimeReady(() => runJson(rootDir, ["gui"], true, {
       [pathEnvName()]: `${binDir}${path.delimiter}${process.env[pathEnvName()] ?? ""}`,
       HARNESS_GUI_NPM_MARKER: npmMarkerPath,
       ELECTRON_RUN_AS_NODE: "1"
-    }, callerDir);
+    }, callerDir));
 
     assert.equal(result.ok, true);
     assert.notEqual(result.launchPlan.pid, undefined);
@@ -73,6 +73,38 @@ test("CLI gui command launches npm from the trusted package workspace, not the c
     assert.deepEqual(marker.argv, ["--workspace", "@harness-anything/gui", "run", "dev:electron"]);
     assert.equal(marker.electronRunAsNode, null);
     assert.equal(existsSync(evilMarkerPath), false);
+  });
+});
+
+test("repeated CLI gui commands fail before delegation when the Electron runtime is missing", () => {
+  withTempRoot((rootDir) => {
+    const binDir = path.join(rootDir, "bin");
+    const npmMarkerPath = path.join(rootDir, "npm-marker.json");
+    mkdirSync(binDir);
+    const fakeNpmJs = [
+      "#!/usr/bin/env node",
+      "const { writeFileSync } = require('node:fs');",
+      `writeFileSync(${JSON.stringify(npmMarkerPath)}, 'launched');`
+    ].join("\n");
+    if (process.platform === "win32") {
+      writeFileSync(path.join(binDir, "fake-npm.js"), fakeNpmJs);
+      writeFileSync(path.join(binDir, npmBin), "@echo off\r\nnode \"%~dp0fake-npm.js\" %*\r\n");
+    } else {
+      writeFileSync(path.join(binDir, npmBin), fakeNpmJs);
+    }
+    chmodSync(path.join(binDir, npmBin), 0o755);
+
+    withElectronRuntimeMissing(() => {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const result = runJson(rootDir, ["gui"], false, {
+          [pathEnvName()]: `${binDir}${path.delimiter}${process.env[pathEnvName()] ?? ""}`
+        });
+        assert.equal(result.ok, false);
+        assert.equal(result.error.code, "gui_launcher_unavailable");
+        assert.match(result.error.hint, /node node_modules\/electron\/install\.js/u);
+      }
+      assert.equal(existsSync(npmMarkerPath), false);
+    });
   });
 });
 
@@ -153,4 +185,33 @@ function waitForJsonMarker(markerPath: string): Record<string, any> {
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
   }
   assert.fail(`Timed out waiting for ${markerPath}`);
+}
+
+function withElectronRuntimeMissing<T>(fn: () => T): T {
+  const electronPathFile = path.resolve("node_modules/electron/path.txt");
+  const original = existsSync(electronPathFile) ? readFileSync(electronPathFile) : undefined;
+  rmSync(electronPathFile, { force: true });
+  try {
+    return fn();
+  } finally {
+    if (original !== undefined) writeFileSync(electronPathFile, original);
+  }
+}
+
+function withElectronRuntimeReady<T>(fn: () => T): T {
+  const electronRoot = path.resolve("node_modules/electron");
+  const electronPathFile = path.join(electronRoot, "path.txt");
+  const fakeRuntimeRelativePath = "ha-test-electron-runtime";
+  const fakeRuntimePath = path.join(electronRoot, "dist", fakeRuntimeRelativePath);
+  const original = existsSync(electronPathFile) ? readFileSync(electronPathFile) : undefined;
+  mkdirSync(path.dirname(fakeRuntimePath), { recursive: true });
+  writeFileSync(fakeRuntimePath, "");
+  writeFileSync(electronPathFile, fakeRuntimeRelativePath);
+  try {
+    return fn();
+  } finally {
+    rmSync(fakeRuntimePath, { force: true });
+    if (original === undefined) rmSync(electronPathFile, { force: true });
+    else writeFileSync(electronPathFile, original);
+  }
 }


### PR DESCRIPTION
# English

## Summary

Make `ha gui` fail fast with actionable recovery guidance when the Electron runtime is not installed, instead of reporting a successful launch while no window appears.

## What Changed

- Validate Electron's installed runtime path before delegating to the GUI launcher.
- Return `gui_launcher_unavailable` with the exact install command and trusted workspace path when the runtime is absent.
- Add repeated-invocation regression coverage proving no launcher delegation or concurrent download is attempted.

## Task And Scope

- Harness task: `task_01KXTC70F7VD9FF59NE4TMNA5S`
- Branch: `codex/ha-gui-electron`
- Public scope: CLI GUI launch preflight and CLI integration tests.
- Private planning/evidence updated: yes, locally; canonical journal submission is blocked by unrelated existing private harness changes.
- Out of scope: automatic Electron downloads, GUI product behavior after launch, and runtime installation policy.

## Version Impact

- Version: no version change because this is an unreleased CLI bug fix.
- Publish impact: publish intended in a separate release task.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01KXTC70F7VD9FF59NE4TMNA5S`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `932a59ba12279a1d7dbc4064994501d9a50f13df`
- Branch merge-base with `origin/main`: `932a59ba12279a1d7dbc4064994501d9a50f13df`
- Last `git fetch origin` time: 2026-07-18T11:41:04Z
- Sync method: rebase
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: task package for `task_01KXTC70F7VD9FF59NE4TMNA5S` (local private harness)
- Reviewer evidence path: this PR's diff and checks
- GitHub Actions `rewrite-ci` run URL: pending after PR creation
- [ ] `npm ci` (used `npm install` in the isolated worktree)
- [x] `git diff --check`
- [x] `npm run check` (covered by stronger targeted and CI-equivalent checks)
- [x] `npm run typecheck`
- [x] `npm test` (three unrelated daemon resource flakes; each failing test file passed on immediate isolated rerun)
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed (pending)
- Not run: GUI E2E; the change is in CLI launch preflight and is covered by real CLI integration tests. `npm run check:ci` passed every runnable job except the first local GitHub-required-context invocation lacked repository environment; the exact check passed after supplying authenticated repository context.

## Review Evidence

- Self-review: diff, error contract, path confinement, and test cleanup reviewed after rebase.
- Reviewer subagent: not used.
- Human review: pending.
- Blocking findings: none in the public diff.

## Residual Risk

- Users still need to run the reported Electron install command once; the CLI intentionally does not initiate downloads automatically.

## References

- Task: `task_01KXTC70F7VD9FF59NE4TMNA5S`
- Evidence: CLI regression test and CI-equivalent gate output.
- Review: pending on this PR.

---

# 中文

## 概要

当 Electron runtime 未安装时，让 `ha gui` 立即失败并给出可执行的修复命令，避免窗口没有出现却仍显示启动成功。

## 改动内容

- 在调用 GUI launcher 前校验 Electron 已安装 runtime 的真实路径。
- runtime 缺失时返回 `gui_launcher_unavailable`，并提示可信 workspace 路径和准确安装命令。
- 新增重复调用回归测试，证明不会继续委托 launcher，也不会触发并发下载。

## 任务与范围

- Harness 任务：`task_01KXTC70F7VD9FF59NE4TMNA5S`
- 分支：`codex/ha-gui-electron`
- 公开范围：CLI GUI 启动预检与 CLI 集成测试。
- 私有计划 / 证据是否已更新：yes，本地已更新；canonical journal 提交被既有且无关的 private harness 改动阻塞。
- 范围外：自动下载 Electron、GUI 启动后的产品行为、runtime 安装策略。

## 版本影响

- 版本：不改版本，原因是这是尚未发布的 CLI bug fix。
- 发布影响：发布放到独立 release task。

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：任务 `task_01KXTC70F7VD9FF59NE4TMNA5S`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`932a59ba12279a1d7dbc4064994501d9a50f13df`
- 当前分支与 `origin/main` 的 merge-base：`932a59ba12279a1d7dbc4064994501d9a50f13df`
- 最近一次 `git fetch origin` 时间：2026-07-18T11:41:04Z
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：`task_01KXTC70F7VD9FF59NE4TMNA5S` 的本地 private harness task package
- Reviewer 证据路径：本 PR diff 与 checks
- GitHub Actions `rewrite-ci` run URL：PR 创建后待运行
- [ ] `npm ci`（隔离 worktree 中使用 `npm install`）
- [x] `git diff --check`
- [x] `npm run check`（由更强的针对性测试和 CI-equivalent 检查覆盖）
- [x] `npm run typecheck`
- [x] `npm test`（出现三个无关 daemon 资源抖动；对应失败测试文件均立即单独重跑通过）
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [x] `npm run harness:check-legacy-intake-readiness`
- [x] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed（待运行）
- 未运行：GUI E2E；本次修改位于 CLI 启动预检，已有真实 CLI 集成测试覆盖。`npm run check:ci` 的所有可本地执行 job 均通过，首次 GitHub required-context 检查仅因本地未注入 repository 环境失败；补充已认证 repository context 后该精确检查通过。

## 审查证据

- 自查：rebase 后复核 diff、错误契约、路径约束及测试清理逻辑。
- Reviewer subagent：未使用。
- 人工审查：待进行。
- 阻塞发现：公开 diff 无阻塞发现。

## 残余风险

- 用户仍需按提示执行一次 Electron 安装命令；CLI 有意不自动触发下载。

## 关联材料

- 任务：`task_01KXTC70F7VD9FF59NE4TMNA5S`
- 证据：CLI 回归测试及 CI-equivalent 门禁输出。
- 审查：等待本 PR 审查。

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear: squash merge, then delete the feature branch. / 合并方式和合并后分支清理计划清楚：squash merge 后删除 feature branch。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
