### PR TITLE
fix: share decision relation record between CLI and daemon compiler

### DIFF
--- a/packages/cli/src/commands/core/decision-relate.ts
+++ b/packages/cli/src/commands/core/decision-relate.ts
@@ -2,10 +2,11 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import { readDecisionDocument, type DecisionWriteService, type DecisionWriteRejected } from "../../../../application/src/index.ts";
-import { deriveRelationId, type DecisionPackage, type EntityRelationRecord, type WriteError } from "../../../../kernel/src/index.ts";
+import { type DecisionPackage, type EntityRelationRecord, type WriteError } from "../../../../kernel/src/index.ts";
 import { resolveHarnessLayout, taskDocumentPath, type HarnessLayoutInput } from "../../../../kernel/src/index.ts";
 import { readFrontmatter, readScalar } from "../../../../kernel/src/index.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
+import { decisionRelationRecord } from "./decision-relation-record.ts";
 import type { CommandRunnerContext } from "../../cli/runner-registry.ts";
 import type { CliResult, ParsedCommand } from "../../cli/types.ts";
 import { activeTaskLeaseFailure } from "./task-lease-guard.ts";
@@ -193,22 +194,15 @@ function decisionRelation(
   if (!anchorIds.has(action.anchor)) {
     return { ok: false, reason: `decision relation source anchor does not exist: ${action.anchor}` };
   }
-  const base = {
-    source: `decision/${decision.decision_id}/${action.anchor}`,
-    target: action.target,
-    type: action.relationType,
-    strength: "strong",
-    direction: "directed",
-    origin: "declared",
-    rationale: action.rationale,
-    state: "active"
-  } satisfies Omit<EntityRelationRecord, "relation_id">;
   return {
     ok: true,
-    record: {
-      relation_id: deriveRelationId(base),
-      ...base
-    }
+    record: decisionRelationRecord({
+      decisionId: decision.decision_id,
+      anchor: action.anchor,
+      target: action.target,
+      relationType: action.relationType,
+      rationale: action.rationale
+    })
   };
 }
 

--- a/packages/cli/src/commands/core/decision-relation-record.ts
+++ b/packages/cli/src/commands/core/decision-relation-record.ts
@@ -1,0 +1,27 @@
+import { deriveRelationId, type EntityRelationRecord } from "../../../../kernel/src/index.ts";
+
+export interface DecisionRelationInput {
+  readonly decisionId: string;
+  readonly anchor: string;
+  readonly target: string;
+  readonly relationType: EntityRelationRecord["type"];
+  readonly rationale: string;
+}
+
+// Single source of truth for how a decision anchor relation is materialized.
+// The CLI application layer and the daemon attempt compiler must build the
+// exact same record from the same action, or admission rejects the wire
+// payload (RELATION_PAYLOAD_INVALID) — the wire-parity invariant.
+export function decisionRelationRecord(input: DecisionRelationInput): EntityRelationRecord {
+  const base = {
+    source: `decision/${input.decisionId}/${input.anchor}`,
+    target: input.target,
+    type: input.relationType,
+    strength: "strong",
+    direction: "directed",
+    origin: "declared",
+    rationale: input.rationale,
+    state: "active"
+  } satisfies Omit<EntityRelationRecord, "relation_id">;
+  return { relation_id: deriveRelationId(base), ...base };
+}

--- a/packages/cli/src/daemon/production-authority-attempt-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-attempt-compiler.ts
@@ -23,7 +23,6 @@ import {
 import {
   decisionEntityId,
   decisionSemanticMutationActions,
-  deriveRelationId,
   encodeCanonicalCbor,
   moduleEntityId,
   sha256Text,
@@ -50,6 +49,7 @@ import {
   type AuthorityProductionRepoConfigV1,
   type DurableAuthorityBindingRuntimeV2
 } from "./authority-production-state.ts";
+import { decisionRelationRecord } from "../commands/core/decision-relation-record.ts";
 import { productionLifecycleAttemptIntent } from "./production-authority-lifecycle-intents.ts";
 import { defaultCliAdapterProvider } from "../composition/adapter-registry.ts";
 import { buildAuthorityPresetTaskCreateWrites, shouldUsePresetAwareNewTask } from "../commands/preset-task.ts";
@@ -429,16 +429,13 @@ async function canonicalAttemptIntent(
     return canonicalIntent("module.register", encodeTaskDecisionModuleCommandPayloadV2(payload), [{ entity, action: "register" }], [entity], ["modules.json"], moduleEntityId(action.moduleKey));
   }
   if (action.kind === "decision-relate") {
-    const identity = {
-      source: action.anchor,
+    const relation: EntityRelationRecord = decisionRelationRecord({
+      decisionId: action.decisionId,
+      anchor: action.anchor,
       target: action.target,
-      type: action.relationType,
-      direction: "directed" as const
-    };
-    const relation: EntityRelationRecord = {
-      relation_id: deriveRelationId(identity), ...identity, strength: "strong", origin: "declared",
-      rationale: action.rationale, state: "active"
-    };
+      relationType: action.relationType,
+      rationale: action.rationale
+    });
     const entity = ref("relation", `relation/${relation.relation_id}`);
     const host = ref("decision", `decision/${action.decisionId}`);
     const documentPath = `decisions/decision-${action.decisionId}/decision.md`;

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -465,10 +465,10 @@ test("production generic canonical ingress accepts and journals one write for ev
       authoredMarker: /F-A11CE001/u
     }, {
       kind: "relation",
-      action: { kind: "decision-relate", decisionId: "dec_INGRESS", anchor: "decision/dec_INGRESS", relationType: "derives", target: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", rationale: "Ingress relation coverage.", dryRun: false },
+      action: { kind: "decision-relate", decisionId: "dec_INGRESS", anchor: "C1", relationType: "derives", target: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", rationale: "Ingress relation coverage.", dryRun: false },
       canonicalEntityId: decisionEntityId("dec_INGRESS"),
       authoredPath: "decisions/decision-dec_INGRESS/decision.md",
-      authoredMarker: /derives/u
+      authoredMarker: /decision\/dec_INGRESS\/C1/u
     }, {
       kind: "session",
       action: { kind: "session-export", sessionId: "session-ingress", runtime: "codex", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z", transcriptFile: fixture.transcriptPath },


### PR DESCRIPTION
# English

## Summary

`ha decision relate` failed in production with `RELATION_PAYLOAD_INVALID`: the CLI application layer qualifies the relation source as `decision/<decisionId>/<anchor>`, while the daemon attempt compiler built the record from the raw anchor (e.g. `C1`). Admission then rejected the wire payload. This is wire-parity defect family instance #5 — the first found in the application layer rather than the parser layer, which is why the earlier parity audit missed it.

## What Changed

- New `decision-relation-record.ts`: single shared builder that materializes a decision anchor relation (`source`, invariants, `relation_id`) once for both sides.
- `decision-relate.ts` (CLI application layer) and `production-authority-attempt-compiler.ts` (daemon) both call the shared builder — no independently duplicated record construction remains.
- Regression: the canonical-ingress relate fixture previously used a pre-qualified anchor (`decision/dec_INGRESS`) that masked the divergence; it now uses the real CLI shape (bare anchor `C1`) and asserts the qualified source form. Red control verified: with the compiler fix reverted, the updated test fails with the exact production error `RELATION_PAYLOAD_INVALID`.

## Task And Scope

- Follows the wire-parity fix line of #908/#909/#910. Scope: decision-relate command only.

## Version Impact

- No schema or wire-format change; bug fix in record construction parity. No version bump.

## Governance Declaration

- No gates, allowlists, CI configuration, or protected surfaces were modified.

## Verification

- `packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts`: 2/2 pass (full CLI→socket→daemon path).
- Red control: unfixed compiler + updated fixture → `RELATION_PAYLOAD_INVALID` (exact production symptom).
- `env -u FORCE_COLOR HARNESS_DAEMON_MODE=direct npm run check:local`: exit 0.

## Review Evidence

- Root cause reproduced from the live production report before the fix was designed.

## Residual Risk

- Other commands may still carry application-layer (post-parser) enrichment not covered by the parser-focused parity audit; a follow-up sweep is queued.

## References

- Wire-parity family: #908, #909, #910.

---

# 中文

## 概要

生产环境 `ha decision relate` 报 `RELATION_PAYLOAD_INVALID`:CLI 应用层把 relation source 限定为 `decision/<decisionId>/<anchor>`,而 daemon attempt compiler 用裸 anchor(如 `C1`)构造记录,admission 校验拒绝 wire 载荷。这是 wire-parity 缺陷家族第 5 例——首个出现在应用层(而非 parser 层)的实例,此前的 parity 审计因此漏判。

## 改动内容

- 新增 `decision-relation-record.ts`:共享构造器,单点生成 decision 锚点关系记录(source/不变量/relation_id),两侧共用。
- `decision-relate.ts`(CLI 应用层)与 `production-authority-attempt-compiler.ts`(daemon)均改为调用共享构造器,不再各自重复构造。
- 回归:canonical-ingress 的 relate 夹具此前用了预限定 anchor(`decision/dec_INGRESS`),掩盖了分叉;现改为真实 CLI 形态(裸 anchor `C1`)并断言限定后的 source 形态。红对照已验证:回退 compiler 修复后,更新的测试以生产同款错误 `RELATION_PAYLOAD_INVALID` 失败。

## 任务与范围

- 延续 #908/#909/#910 的 wire-parity 修复线。范围仅 decision-relate 命令。

## 版本影响

- 无 schema 或 wire 格式变更;为记录构造一致性 bug 修复。无版本号变更。

## 治理声明

- 未修改任何 gate、allowlist、CI 配置或受保护 surface。

## 验证

- `packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts`:2/2 通过(完整 CLI→socket→daemon 路径)。
- 红对照:未修复 compiler + 新夹具 → `RELATION_PAYLOAD_INVALID`(生产同款症状)。
- `env -u FORCE_COLOR HARNESS_DAEMON_MODE=direct npm run check:local`:exit 0。

## 审查证据

- 修复设计前已从生产实报复现根因。

## 残余风险

- 其他命令可能仍存在 parser 之后的应用层补全未被 parity 审计覆盖;后续排查已排入队列。

## 关联材料

- wire-parity 家族:#908、#909、#910。
