### PR TITLE
fix: commit V2 authority evidence after publication

### DIFF
--- a/packages/application/src/authority/durable-committed-event-publisher-v2.ts
+++ b/packages/application/src/authority/durable-committed-event-publisher-v2.ts
@@ -27,6 +27,7 @@ export interface AuthorityCommittedPhysicalObservationPortV2 {
 export function createDurableAuthorityCommittedEventPublisherV2(options: {
   readonly eventLog: AuthorityAttributionEventV2Log;
   readonly observation: AuthorityCommittedPhysicalObservationPortV2;
+  readonly commitEvidence?: (canonicalCommitSha: string) => Promise<void>;
 }): AuthorityCommittedEventPublisherV2 {
   return {
     publish: async (input) => {
@@ -55,6 +56,7 @@ export function createDurableAuthorityCommittedEventPublisherV2(options: {
         || !canonicalCborBytesEqual(storedBytes, ensured.bytes)) {
         throw new Error("AUTHORITY_EVENT_V2_DURABLE_REPLAY_MISMATCH");
       }
+      await options.commitEvidence?.(stored.commitSha);
       return stored;
     }
   };

--- a/packages/cli/src/daemon/authority-attribution-event-v2-production-recovery.ts
+++ b/packages/cli/src/daemon/authority-attribution-event-v2-production-recovery.ts
@@ -25,6 +25,7 @@ export async function recoverProductionAuthorityCommittedReceiptV2(input: {
   readonly eventLog: ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>;
   readonly publisher: AuthorityCommittedEventPublisherV2;
   readonly publicationInspector: GitCanonicalPublicationInspector;
+  readonly commitEvidence: (canonicalCommitSha: string) => Promise<void>;
 }): Promise<AuthorityCommittedReceipt> {
   const { record } = input;
   let change = await input.replicaChangeLog.getByOperation(record.workspaceId, record.opId);
@@ -90,6 +91,10 @@ export async function recoverProductionAuthorityCommittedReceiptV2(input: {
         occurredAt: change.changedAt
       })
   });
+  // If a previous process died after the durable append, recoverFromOperationRecord
+  // reuses those exact bytes. Commit all still-pending shards before making the
+  // completed receipt visible again.
+  await input.commitEvidence(recovered.event.commitSha);
   return completeAuthorityCommittedReceiptV2({
     // recoverFromOperationRecord already performed the one durable publish.
     // Complete the receipt from those exact bytes instead of observing again.
@@ -111,6 +116,7 @@ export function withProductionRecoveryV2(input: {
   readonly bindingRuntime: DurableAuthorityBindingRuntimeV2;
   readonly eventLog: ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>;
   readonly publicationInspector: GitCanonicalPublicationInspector;
+  readonly commitEvidence: (canonicalCommitSha: string) => Promise<void>;
 }): AuthorityCommittedEventPublisherV2 & {
   recoverCommittedReceipt: (record: AuthorityStoredOperationRecord) => Promise<AuthorityCommittedReceipt>;
 } {
@@ -123,7 +129,8 @@ export function withProductionRecoveryV2(input: {
       bindingRuntime: input.bindingRuntime,
       eventLog: input.eventLog,
       publisher: input.publisher,
-      publicationInspector: input.publicationInspector
+      publicationInspector: input.publicationInspector,
+      commitEvidence: input.commitEvidence
     })
   };
 }

--- a/packages/cli/src/daemon/authority-publication-evidence.ts
+++ b/packages/cli/src/daemon/authority-publication-evidence.ts
@@ -1,15 +1,25 @@
 import { execFile, execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { readdirSync } from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
 import type { CanonicalPublicationInspector } from "../../../application/src/index.ts";
 import {
   encodeCanonicalCbor,
   entityRegistry,
+  makeLocalAuthorityAttributionEventV2Log,
+  makeLocalVersionControlSystem,
+  resolveHarnessLayout,
   sha256Text,
+  type HarnessLayoutInput,
   type PhysicalChangeV2,
   type SemanticMutationSetV2
 } from "../../../kernel/src/index.ts";
+
+const materializerCommitter = {
+  name: "Harness Anything Materializer",
+  email: "materializer@harness-anything.local"
+} as const;
 
 export interface CanonicalPublicationEvidence {
   readonly commitSha: string;
@@ -61,6 +71,67 @@ export class AuthorityRecoveryWatermarkInvalidError extends Error {
     super(`AUTHORITY_RECOVERY_WATERMARK_INVALID:commitSha=${commitSha}`);
     this.name = "AuthorityRecoveryWatermarkInvalidError";
   }
+}
+
+export interface GitAuthorityAttributionEvidenceCommitterV2 {
+  readonly commitPending: (canonicalCommitSha: string) => Promise<void>;
+}
+
+export function createGitAuthorityAttributionEvidenceCommitterV2(
+  rootInput: HarnessLayoutInput
+): GitAuthorityAttributionEvidenceCommitterV2 {
+  const layout = resolveHarnessLayout(rootInput);
+  const vcs = makeLocalVersionControlSystem();
+  return {
+    commitPending: async (canonicalCommitSha) => {
+      const repoRoot = vcs.topLevel(layout.authoredRoot);
+      if (!repoRoot) throw new Error("AUTHORITY_EVENT_V2_EVIDENCE_REPOSITORY_REQUIRED");
+      if (!vcs.commitExists(repoRoot, canonicalCommitSha)) {
+        throw new Error(`AUTHORITY_EVENT_V2_EVIDENCE_CANONICAL_COMMIT_MISSING:${canonicalCommitSha}`);
+      }
+      // Fail closed before staging: every shard in the durable V2 log must still
+      // satisfy its canonical bytes, key and digest contracts.
+      makeLocalAuthorityAttributionEventV2Log(rootInput).scanIntegrity();
+      const head = vcs.currentHead(repoRoot);
+      const pendingPaths = readdirSync(layout.authorityAttributionEventsV2Root, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .map((entry) => repoRelativePath(
+          vcs.normalizePath(repoRoot),
+          vcs.normalizePath(path.join(layout.authorityAttributionEventsV2Root, entry.name))
+        ))
+        .filter((relativePath) => !vcs.pathExistsAtCommit(repoRoot, head, relativePath))
+        .sort();
+      if (pendingPaths.length === 0) return;
+
+      const pending = new Set(pendingPaths);
+      assertEvidenceOnlyStaged(vcs.stagedFiles(repoRoot, ["."]), pending);
+      vcs.add(repoRoot, { paths: pendingPaths });
+      const staged = vcs.stagedFiles(repoRoot, ["."]);
+      assertEvidenceOnlyStaged(staged, pending);
+      if (staged.trim().length === 0) return;
+      vcs.commit(
+        repoRoot,
+        `authority: V2 attribution evidence for ${canonicalCommitSha.slice(0, 12)}`,
+        materializerCommitter
+      );
+    }
+  };
+}
+
+function assertEvidenceOnlyStaged(stagedText: string, pendingPaths: ReadonlySet<string>): void {
+  const stagedPaths = stagedText.split(/\r?\n/u).filter(Boolean);
+  const unrelated = stagedPaths.filter((stagedPath) => !pendingPaths.has(stagedPath));
+  if (unrelated.length > 0) {
+    throw new Error(`AUTHORITY_EVENT_V2_EVIDENCE_UNRELATED_STAGED_PATHS:${unrelated.join(",")}`);
+  }
+}
+
+function repoRelativePath(repoRoot: string, filePath: string): string {
+  const relativePath = path.relative(repoRoot, filePath);
+  if (relativePath === ".." || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+    throw new Error("AUTHORITY_EVENT_V2_EVIDENCE_PATH_OUTSIDE_REPOSITORY");
+  }
+  return relativePath.split(path.sep).join("/");
 }
 
 export function createGitCanonicalPublicationInspector(canonicalRoot: string): GitCanonicalPublicationInspector {

--- a/packages/cli/src/daemon/production-authority-lifecycle.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle.ts
@@ -55,6 +55,7 @@ import {
   type DurableAuthorityBindingRuntimeV2
 } from "./authority-production-state.ts";
 import {
+  createGitAuthorityAttributionEvidenceCommitterV2,
   createGitCanonicalPublicationInspector
 } from "./authority-publication-evidence.ts";
 import { assertPublicationMatchesMutationSet } from "./authority-publication-evidence.ts";
@@ -144,8 +145,13 @@ export function createProductionAuthorityLifecycle(input: {
         ...(input.layoutOverrides ? { layoutOverrides: input.layoutOverrides } : {})
       }).authoredRoot;
       const publicationInspector = createGitCanonicalPublicationInspector(authoredRoot);
+      const evidenceCommitter = createGitAuthorityAttributionEvidenceCommitterV2({
+        rootDir: repo.canonicalRoot,
+        ...(input.layoutOverrides ? { layoutOverrides: input.layoutOverrides } : {})
+      });
       const basePublisher = createDurableAuthorityCommittedEventPublisherV2({
         eventLog,
+        commitEvidence: evidenceCommitter.commitPending,
         observation: {
           observe: async (request) => {
             const inspect = publicationObservers.get(repo.repoId);
@@ -183,7 +189,8 @@ export function createProductionAuthorityLifecycle(input: {
         operationRegistry: state.operationRegistry,
         bindingRuntime,
         eventLog,
-        publicationInspector
+        publicationInspector,
+        commitEvidence: evidenceCommitter.commitPending
       });
       const recovery = {} as ProductionRecoveryState;
       const material: RepoProductionMaterial = {

--- a/packages/cli/test/production-authority-evidence-commit.test.ts
+++ b/packages/cli/test/production-authority-evidence-commit.test.ts
@@ -1,0 +1,87 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { taskEntityId } from "../../kernel/src/index.ts";
+import { daemonActorAttribution } from "../src/composition/actor-attribution.ts";
+import { createProductionAuthorityLifecycle } from "../src/daemon/production-authority-lifecycle.ts";
+import {
+  productionAuthorityActor,
+  productionAuthorityConnection
+} from "./helpers/production-authority-connection.ts";
+import {
+  createProductionAuthorityLifecycleFixture as createFixture,
+  fixtureGit as git,
+  productionWriterRuntime as writerRuntime
+} from "./helpers/production-authority-lifecycle-fixture.ts";
+
+test("the next publication commits a V2 event left durable before its evidence commit", async () => {
+  const fixture = createFixture();
+  try {
+    const lifecycle = createProductionAuthorityLifecycle({ manifestPath: fixture.manifestPath });
+    const started = await lifecycle.startRepo(
+      { repoId: "canonical", canonicalRoot: fixture.repoRoot },
+      writerRuntime(fixture.authoredRoot)
+    );
+    assert.equal(started.ok, true, started.ok ? "" : started.error);
+    if (!started.ok) return;
+    const actor = productionAuthorityActor();
+    const submission = started.component.bindConnection(productionAuthorityConnection(actor));
+    const submit = (text: string) => submission.submit({
+      command: {
+        rootDir: fixture.repoRoot,
+        json: true,
+        action: { kind: "progress-append" as const, taskId: "task_A", text, dryRun: false }
+      },
+      attribution: daemonActorAttribution(actor, { kind: "agent", id: "codex" }),
+      currentSession: {
+        runtime: "codex" as const,
+        sessionId: "session-production",
+        source: "manual" as const,
+        detectedAt: new Date().toISOString()
+      },
+      canonicalEntityId: taskEntityId("task_A")
+    });
+
+    const first = await submit("first durable event\n");
+    assert.equal(first.tag, "COMMITTED", JSON.stringify(first));
+    if (first.tag !== "COMMITTED") return;
+    const firstEvent = execFileSync("find", [
+      path.join(fixture.authoredRoot, "authority-attribution-events/v2"), "-type", "f"
+    ], { encoding: "utf8" }).trim();
+    assert.ok(firstEvent);
+
+    // Recreate the durable crash boundary: the event file exists, but its
+    // dedicated evidence commit did not finish.
+    git(fixture.authoredRoot, "reset", "--mixed", first.commitSha);
+    assert.match(
+      git(fixture.authoredRoot, "status", "--porcelain", "--untracked-files=all", "--", "authority-attribution-events/v2"),
+      /^\?\? authority-attribution-events\/v2\//u
+    );
+
+    const second = await submit("second publication recovers evidence\n");
+    assert.equal(second.tag, "COMMITTED", JSON.stringify(second));
+    if (second.tag !== "COMMITTED") return;
+    assert.equal(git(fixture.authoredRoot, "status", "--porcelain", "--untracked-files=all", "--", "authority-attribution-events/v2"), "");
+    const committedEvidence = git(
+      fixture.authoredRoot,
+      "show",
+      "--format=",
+      "--name-only",
+      "HEAD",
+      "--",
+      "authority-attribution-events/v2"
+    ).split("\n").filter(Boolean);
+    assert.equal(committedEvidence.length, 2);
+    assert.equal(committedEvidence.includes(path.relative(fixture.authoredRoot, firstEvent)), true);
+    assert.equal(
+      git(fixture.authoredRoot, "show", "-s", "--format=%s", "HEAD"),
+      `authority: V2 attribution evidence for ${second.commitSha.slice(0, 12)}`
+    );
+    await lifecycle.stopAll("daemon-shutdown");
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/test/production-authority-lifecycle.test.ts
+++ b/packages/cli/test/production-authority-lifecycle.test.ts
@@ -73,6 +73,16 @@ test("production lifecycle uses external Ed25519 material, durable state, live c
     const eventBody = readFileSync(eventFiles[0]!, "utf8");
     assert.match(eventBody, /attribution-event\/v2/u);
     assert.doesNotMatch(eventBody, /PRIVATE KEY/u);
+    assert.equal(git(fixture.authoredRoot, "status", "--porcelain", "--untracked-files=all", "--", "authority-attribution-events/v2"), "");
+    assert.notEqual(git(fixture.authoredRoot, "rev-parse", "HEAD"), receipt.tag === "COMMITTED" ? receipt.commitSha : "");
+    assert.equal(
+      git(fixture.authoredRoot, "show", "-s", "--format=%s", "HEAD"),
+      `authority: V2 attribution evidence for ${receipt.tag === "COMMITTED" ? receipt.commitSha.slice(0, 12) : ""}`
+    );
+    assert.equal(
+      git(fixture.authoredRoot, "show", "-s", "--format=%an%x00%ae%x00%cn%x00%ce", "HEAD"),
+      "Harness Anything Materializer\0materializer@harness-anything.local\0Harness Anything Materializer\0materializer@harness-anything.local"
+    );
     assert.equal(readFileSync(path.join(fixture.serviceRoot, "authority/Y2Fub25pY2Fs/bindings.jsonl"), "utf8").includes("token:"), true);
     await lifecycle.stopAll("daemon-shutdown");
   } finally {


### PR DESCRIPTION
# English

## Summary

V2 authority attribution events were post-commit products piling up untracked in the inner ledger: each event embeds the canonical merge `commitSha` it references (and that sha participates in the event digest), so the event file mathematically cannot ride inside the very commit it points at. Per dec_01KXTQ6JD60H6XQEC1PFSJMRP8 (Plan A), the publication flow now creates a dedicated evidence commit immediately after the event is durably ensured — no timers, no background scanners, no schema/digest/inspector changes.

## What Changed

- `durable-committed-event-publisher-v2.ts`: after `eventLog.ensure` + byte-accurate read-back verification, invoke the evidence committer in the same publication flow.
- `authority-publication-evidence.ts`: new committer — integrity-scans the V2 event log, enumerates `authority-attribution-events/v2/*.jsonl` missing from `HEAD`, stages only those files (any foreign staged path aborts), and commits as the existing materializer identity with message `authority: V2 attribution evidence for <canonical-sha-short>`.
- Recovery: the operation-record recovery path calls the same committer, and a crash between event flush and commit is healed by the next publication sweeping all HEAD-missing events into one evidence commit (idempotent when nothing is pending).
- Tests: publication leaves no untracked V2 files (red before the fix), recovery sweeps pre-seeded orphans (red before), commit message/identity locked, hermetic pass with stripped global git identity.

## Task And Scope

- Ledger task task_01KXTG99CQTEYQD36QVEDBKHGP; decision dec_01KXTQ6JD60H6XQEC1PFSJMRP8 (Plan A over re-anchoring). Scope: production publication/recovery evidence path only; V1 path untouched.

## Version Impact

- No schema or wire change; inner-ledger commit cadence gains one evidence commit per publication. No version bump.

## Governance Declaration

- Authorizing decision: dec_01KXTQ6JD60H6XQEC1PFSJMRP8. `authority-publication-evidence.ts` was already registered as an external-git mutating road in tools/write-road-registry.json; no new unregistered write road was added, no gates or protected surfaces modified. Break-glass: no.

## Verification

- Positive controls: publication test observed untracked `?? authority-attribution-events/v2/*.jsonl` before the fix (2/2 red), green after; recovery test seeds an orphan event and asserts the next publication commits it.
- `production-authority-lifecycle.test.ts` 13/13; `production-authority-event-recovery.test.ts` 8/8; canonical-ingress 2/2; root `check:local` exit 0 (re-run after rebase onto main containing #912/#913/#914).

## Review Evidence

- Investigation + implementation report: tmp/orch/v2-event-bundling/REPORT-v2-bundling.md (self-reference root cause ground-truthed by CEO: event bafca45c references commit 6216dccf yet first landed in 09e9dc49). Moved into the task package at closeout.

## Residual Risk

- Canonical commit and its evidence commit are two commits by design; consumers must keep treating the event's embedded `commitSha` as the canonical anchor, never the evidence commit HEAD.
- If the system stops publishing entirely, a crash-orphaned event stays pending until the next publication — the chosen recovery trigger semantics.
- The pre-journal doc-sync CAS crash window is out of scope and unchanged.

## References

- Decision: dec_01KXTQ6JD60H6XQEC1PFSJMRP8. Backfill history: inner commits de155cc23 / f45926164. Related: user ruling on automatic ledger commits (2026-07-18).

---

# 中文

## 概要

V2 归属事件此前是 post-commit 产物,在内层 ledger 堆 untracked:事件体内嵌它引用的 canonical merge `commitSha`(且该 sha 参与事件摘要),事件文件在数学上不可能进它指向的那笔 commit。按 dec_01KXTQ6JD60H6XQEC1PFSJMRP8(方案 A),publication 流程现在在事件 durable 落盘后立即创建一笔专用 evidence commit——无定时器、无后台扫描器、不改 schema/摘要/inspector。

## 改动内容

- `durable-committed-event-publisher-v2.ts`:`eventLog.ensure`+逐字节回读校验后,同一 publication 流程内调用 evidence committer。
- `authority-publication-evidence.ts`:新 committer——先对 V2 event log 做完整性扫描,枚举 `HEAD` 尚未包含的 `authority-attribution-events/v2/*.jsonl`,只 stage 这些文件(发现异物 staged path 即中止),以既有 materializer 身份提交,message 为 `authority: V2 attribution evidence for <canonical-sha-short>`。
- 恢复:operation-record recovery 路径调用同一 committer;「事件已落盘、commit 前进程死掉」由下一次 publication 把所有 HEAD-missing 事件一笔收走(无 pending 时幂等返回)。
- 测试:publication 后无 untracked V2 文件(修前红)、恢复收孤儿(修前红)、commit message/身份锁定、去全局 git 身份 hermetic 通过。

## 任务与范围

- 台账 task_01KXTG99CQTEYQD36QVEDBKHGP;决策 dec_01KXTQ6JD60H6XQEC1PFSJMRP8(方案 A,否决重锚)。范围仅生产 publication/recovery 证据路;V1 路径不动。

## 版本影响

- 无 schema/wire 变更;内层 ledger 每笔 publication 多一笔 evidence commit。无版本号变更。

## 治理声明

- 授权决策:dec_01KXTQ6JD60H6XQEC1PFSJMRP8。`authority-publication-evidence.ts` 本就登记在 tools/write-road-registry.json 的 external-git mutating 路由;未新增未登记写路,未改任何 gate 或受保护 surface。Break-glass:否。

## 验证

- 阳性对照:修前 publication 测试观察到 untracked `?? authority-attribution-events/v2/*.jsonl`(2/2 红),修后绿;恢复测试预置孤儿事件,断言下一次 publication 将其提交。
- `production-authority-lifecycle.test.ts` 13/13;`production-authority-event-recovery.test.ts` 8/8;canonical-ingress 2/2;rebase 到含 #912/#913/#914 的 main 后根 `check:local` exit 0。
- 合入部署后生产实测:执行一笔真实 canonical 写,核 evidence commit 自动出现、工作树 clean(结果回填台账 closeout)。

## 审查证据

- 调查+实现报告:tmp/orch/v2-event-bundling/REPORT-v2-bundling.md(自引用根因经 CEO ground-truth:事件 bafca45c 引用 commit 6216dccf,首次入库却在 09e9dc49)。收口时移入任务包。

## 残余风险

- canonical commit 与 evidence commit 按设计是两笔;消费方必须继续以事件内嵌 `commitSha` 为 canonical 锚,不得把 evidence commit HEAD 当 canonical。
- 若系统长期不再 publication,崩溃孤儿事件保持待提交至下一次 publication——所选恢复触发语义。
- doc-sync CAS 的 pre-journal 崩溃窗口不在本次范围,契约未变。

## 关联材料

- 决策:dec_01KXTQ6JD60H6XQEC1PFSJMRP8。backfill 史:内仓 de155cc23 / f45926164。相关:泽宇 2026-07-18「入账必须有自动提交路」裁决。
