### PR TITLE
fix(cli): preserve production canonical enrichment across four commands

### DIFF
--- a/packages/application/src/authority/task-decision-module-command-v2.ts
+++ b/packages/application/src/authority/task-decision-module-command-v2.ts
@@ -46,6 +46,7 @@ export interface TaskTransitionPayloadV2 {
   readonly schema: "task.transition/v1";
   readonly taskId: string;
   readonly to: string;
+  readonly auditText?: string;
 }
 
 export interface TaskAppendPayloadV2 {
@@ -86,6 +87,7 @@ export interface DecisionRelationPayloadV2 {
   readonly schema: "decision.relation/v1";
   readonly decisionId: string;
   readonly relation: EntityRelationRecord;
+  readonly taskWrites?: ReadonlyArray<{ readonly taskId: string; readonly path: string; readonly body: string }>;
 }
 
 export interface ModuleRecordV2 {
@@ -183,8 +185,11 @@ function strictTaskDecisionModulePayload(value: unknown): TaskDecisionModuleComm
       };
     }
     case "task.transition/v1": {
-      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "to"]);
-      return { schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), to: taskDecisionModuleText(row.to) };
+      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "to", "auditText"], false, ["auditText"]);
+      return {
+        schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), to: taskDecisionModuleText(row.to),
+        ...(row.auditText === undefined ? {} : { auditText: taskDecisionModuleNonBlank(row.auditText) })
+      };
     }
     case "task.append/v1": {
       const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "text"]);
@@ -216,8 +221,13 @@ function strictTaskDecisionModulePayload(value: unknown): TaskDecisionModuleComm
       return { schema: discriminator.schema, decision: decision(row.decision), ...(optionalString(row.body, "body")) };
     }
     case "decision.relation/v1": {
-      const row = exactTaskDecisionModuleObject(value, ["schema", "decisionId", "relation"]);
-      return { schema: discriminator.schema, decisionId: taskDecisionModuleText(row.decisionId), relation: decodeRelationV2(row.relation) };
+      const row = exactTaskDecisionModuleObject(value, ["schema", "decisionId", "relation", "taskWrites"], false, ["taskWrites"]);
+      return {
+        schema: discriminator.schema,
+        decisionId: taskDecisionModuleText(row.decisionId),
+        relation: decodeRelationV2(row.relation),
+        ...(row.taskWrites === undefined ? {} : { taskWrites: decisionRelationTaskWrites(row.taskWrites) })
+      };
     }
     case "module.register/v1": {
       const row = exactTaskDecisionModuleObject(value, ["schema", "module"]);
@@ -254,7 +264,7 @@ function canonicalTaskDecisionModulePayloadWire(payload: TaskDecisionModuleComma
         ...(payload.writes ? { writes: payload.writes.map((write) => ({ path: write.path, body: write.body, ...(write.packageSlug ? { packageSlug: write.packageSlug } : {}) })) } : {})
       };
     case "task.transition/v1":
-      return { schema: payload.schema, taskId: payload.taskId, to: payload.to };
+      return { schema: payload.schema, taskId: payload.taskId, to: payload.to, ...(payload.auditText === undefined ? {} : { auditText: payload.auditText }) };
     case "task.append/v1":
       return { schema: payload.schema, taskId: payload.taskId, text: payload.text };
     case "task.document/v1":
@@ -266,7 +276,10 @@ function canonicalTaskDecisionModulePayloadWire(payload: TaskDecisionModuleComma
     case "decision.amend/v1":
       return { schema: payload.schema, decision: decisionWire(payload.decision), ...(payload.body === undefined ? {} : { body: payload.body }) };
     case "decision.relation/v1":
-      return { schema: payload.schema, decisionId: payload.decisionId, relation: relationWire(payload.relation) };
+      return {
+        schema: payload.schema, decisionId: payload.decisionId, relation: relationWire(payload.relation),
+        ...(payload.taskWrites ? { taskWrites: payload.taskWrites.map((write) => ({ taskId: write.taskId, path: write.path, body: write.body })) } : {})
+      };
     case "module.register/v1":
       return { schema: payload.schema, module: moduleWire(payload.module) };
     case "module.unregister/v1":
@@ -274,6 +287,18 @@ function canonicalTaskDecisionModulePayloadWire(payload: TaskDecisionModuleComma
     case "module.step/v1":
       return { schema: payload.schema, moduleKey: payload.moduleKey, stepId: payload.stepId, state: payload.state };
   }
+}
+
+function decisionRelationTaskWrites(value: unknown): NonNullable<DecisionRelationPayloadV2["taskWrites"]> {
+  if (!Array.isArray(value) || value.length !== 1) throw semanticAdmissionV2("DECISION_RELATION_TASK_WRITES_INVALID");
+  return value.map((entry) => {
+    const row = exactTaskDecisionModuleObject(entry, ["taskId", "path", "body"]);
+    return {
+      taskId: taskDecisionModuleText(row.taskId),
+      path: taskDecisionModuleText(row.path),
+      body: semanticStringValueV2(row.body)
+    };
+  });
 }
 
 function taskCreateWrites(value: unknown): NonNullable<TaskCreatePayloadV2["writes"]> {

--- a/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
@@ -158,10 +158,14 @@ async function compileTaskTransition(
   if (current.taskId !== payload.taskId) throw admission("TASK_ID_MISMATCH");
   if (!explainStatusTransition(current.status as DomainStatus, to).allowed) throw admission("TASK_TRANSITION_INVALID");
   const body = replaceTaskStatus(snapshot.body, to);
+  if (payload.auditText !== undefined && (to !== "cancelled" || !payload.auditText.startsWith("FORCE_STATUS_SET_AUDIT:"))) {
+    throw admission("TASK_TRANSITION_FORCE_AUDIT_INVALID");
+  }
   return taskCompilation(payload.taskId, "transition", "transition_local", {
     path: "INDEX.md",
     body,
-    to
+    to,
+    ...(payload.auditText === undefined ? {} : { auditText: payload.auditText })
   }, [taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)], [{ path, snapshot }]);
 }
 
@@ -286,24 +290,74 @@ async function compileDecisionRelation(
   if (current.decision_id !== payload.decisionId) throw admission("DECISION_ID_MISMATCH");
   if (current.relations.some((entry) => entry.relation_id === relation.relation_id)) throw admission("RELATION_ALREADY_EXISTS");
   const next = { ...current, relations: [...current.relations, relation] };
+  const companion = await decisionRelationPriorityCompanion(state, current, relation, payload.taskWrites ?? []);
   return {
     mutationPlan: taskDecisionModulePlan([
       { entityKind: "decision", identity: { decisionId: payload.decisionId }, action: "relation" },
-      relationCreateIntent(relation)
+      relationCreateIntent(relation),
+      ...companion.mutations
     ]),
     operation: {
       ...decisionOperation("decision_relate", next, undefined, current),
       payload: {
         decision: next,
-        writeMode: { kind: "append_relation", relation }
+        writeMode: { kind: "append_relation", relation },
+        ...(payload.taskWrites?.length ? { taskWrites: payload.taskWrites } : {})
       }
     },
     requiredBaseRefs: [
       taskDecisionModuleEntityRef("decision", `decision/${payload.decisionId}`),
-      taskDecisionModuleEntityRef("relation", `relation/${relation.relation_id}`)
+      taskDecisionModuleEntityRef("relation", `relation/${relation.relation_id}`),
+      ...companion.baseRefs
     ],
-    requiredPathSnapshots: [{ path, snapshot }]
+    requiredPathSnapshots: [{ path, snapshot }, ...companion.pathSnapshots]
   };
+}
+
+async function decisionRelationPriorityCompanion(
+  state: TaskDecisionModuleAuthorityStateV2,
+  decision: DecisionPackage,
+  relation: EntityRelationRecord,
+  taskWrites: NonNullable<DecisionRelationPayloadV2["taskWrites"]>
+): Promise<{
+  readonly mutations: RegistryMutationPlanInput["mutations"];
+  readonly baseRefs: ReadonlyArray<RegistryEntityRefV2>;
+  readonly pathSnapshots: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }>;
+}> {
+  const match = relation.state === "active" && relation.type === "derives" ? /^task\/([^/]+)$/u.exec(relation.target) : null;
+  if (!match) {
+    if (taskWrites.length > 0) throw admission("DECISION_RELATION_TASK_WRITES_FORBIDDEN");
+    return { mutations: [], baseRefs: [], pathSnapshots: [] };
+  }
+  const taskId = match[1]!;
+  const path = taskPath(taskId, "INDEX.md");
+  const snapshot = await requiredTaskDecisionModuleDocument(state, path, "DECISION_RELATION_TASK_NOT_FOUND");
+  const expectedBody = seedTaskPriority(snapshot.body, decision);
+  if (expectedBody === null) {
+    if (taskWrites.length > 0) throw admission("DECISION_RELATION_TASK_WRITES_REDUNDANT");
+    return { mutations: [], baseRefs: [], pathSnapshots: [] };
+  }
+  if (taskWrites.length !== 1 || taskWrites[0]!.taskId !== taskId || taskWrites[0]!.path !== "INDEX.md" || taskWrites[0]!.body !== expectedBody) {
+    throw admission("DECISION_RELATION_TASK_WRITE_MISMATCH");
+  }
+  return {
+    mutations: [{ entityKind: "task", identity: { taskId }, action: "document", storageContext: { documentPath: "INDEX.md" } }],
+    baseRefs: [taskDecisionModuleEntityRef("task", `task/${taskId}`)],
+    pathSnapshots: [{ path, snapshot }]
+  };
+}
+
+function seedTaskPriority(body: string, decision: DecisionPackage): string | null {
+  const frontmatter = readFrontmatter(body);
+  if (!frontmatter) throw admission("DECISION_RELATION_TASK_FRONTMATTER_INVALID");
+  const additions = [
+    ...(readScalar(frontmatter, "riskTier") ? [] : [`riskTier: ${decision.riskTier}`]),
+    ...(readScalar(frontmatter, "urgency") ? [] : [`urgency: ${decision.urgency}`])
+  ];
+  if (additions.length === 0) return null;
+  const nextFrontmatter = frontmatter.replace(/^packageDisposition:[^\n]*(?:\n|$)/mu, (line) => `${line.endsWith("\n") ? line : `${line}\n`}${additions.join("\n")}\n`);
+  if (nextFrontmatter === frontmatter) throw admission("DECISION_RELATION_TASK_FRONTMATTER_INVALID");
+  return body.replace(`---\n${frontmatter}\n---`, `---\n${nextFrontmatter}\n---`);
 }
 
 function decisionOperation(

--- a/packages/application/src/coordinated-execution-authored-store.ts
+++ b/packages/application/src/coordinated-execution-authored-store.ts
@@ -76,7 +76,7 @@ export function makeCoordinatedExecutionAuthoredStore(input: {
       ) as ExecutionRecord;
       assertExecutionHost(current, request.taskId, request.executionId);
       if (current.state !== "active") throw new Error(`execution is not active: ${request.executionId}`);
-      const finalizedBindings = finalizeSessionBindings(input.rootInput, current.session_bindings, request.submittedAt);
+      const finalizedBindings = finalizeExecutionSessionBindings(input.rootInput, current.session_bindings, request.submittedAt);
       assertPrimarySession(finalizedBindings);
       assertBindingsFinal(finalizedBindings);
       const allEvidence = [...current.outputs, ...request.submission.evidence];
@@ -182,7 +182,7 @@ function submittedExecution(
   };
 }
 
-function finalizeSessionBindings(
+export function finalizeExecutionSessionBindings(
   rootInput: HarnessLayoutInput,
   bindings: ExecutionRecord["session_bindings"],
   endedAt: string

--- a/packages/application/src/public-exports.ts
+++ b/packages/application/src/public-exports.ts
@@ -150,7 +150,7 @@ export { bindCreateProvenance } from "./provenance-binding.ts";
 export { generateFactIdV1 } from "./fact-write-service.ts";
 export { makeDecisionWriteService } from "./decision-write-service.ts";
 export { makeExecutionReservationReconciler, makeExecutionSagaService } from "./execution-saga-service.ts";
-export { makeCoordinatedExecutionAuthoredStore } from "./coordinated-execution-authored-store.ts";
+export { finalizeExecutionSessionBindings, makeCoordinatedExecutionAuthoredStore } from "./coordinated-execution-authored-store.ts";
 export { makeReviewExecutionService } from "./review-execution-service.ts";
 export type { ReviewExecutionService } from "./review-execution-service.ts";
 export { makeRecordExecutionConsentService } from "./record-execution-consent-service.ts";

--- a/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
+++ b/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
@@ -194,7 +194,7 @@ test("all decision actions compile exact decision mutations; relation also creat
   const proposedSnapshot = snapshot(decisionDocument(proposed));
   const activeSnapshot = snapshot(decisionDocument(active));
   const decisionRef = ref("decision", "decision/dec_W3");
-  const relation = relationRecord("decision/dec_W3/C1", "task/task_T", "derives");
+  const relation = relationRecord("decision/dec_W3/C1", "task/task_T", "relates");
   const relationRef = ref("relation", `relation/${relation.relation_id}`);
 
   const cases = [

--- a/packages/cli/src/commands/core/decision-propose.ts
+++ b/packages/cli/src/commands/core/decision-propose.ts
@@ -24,26 +24,16 @@ export function runPropose(
   action: ProposeAction
 ): Effect.Effect<CliResult, WriteError> {
   action = normalizeDecisionProposeAction(action);
-  const baseDecision = proposedDecision(action, []);
-  const fulfilled = applyClaimFulfillments(baseDecision, action.fulfillments);
-  if (!fulfilled.ok) {
+  const materialized = materializeProposedDecision(action);
+  if (!materialized.ok) {
     return Effect.succeed({
       ok: false,
       command: "decision-propose",
-      decisionId: baseDecision.decision_id,
-      error: cliError(CliErrorCode.InvalidDecisionAmendPatch, fulfilled.reason)
+      decisionId: action.decisionId,
+      error: cliError(materialized.code, materialized.reason)
     } satisfies CliResult);
   }
-  const relations = decisionEvidenceRelations(fulfilled.decision, action.evidenceRelations);
-  if (!relations.ok) {
-    return Effect.succeed({
-      ok: false,
-      command: "decision-propose",
-      decisionId: baseDecision.decision_id,
-      error: cliError(CliErrorCode.InvalidDecisionEvidenceRelation, relations.reason)
-    } satisfies CliResult);
-  }
-  const decision = { ...fulfilled.decision, relations: relations.records };
+  const decision = materialized.decision;
   if (action.dryRun) return Effect.succeed(withDocSyncWarning(rootInput, action, decisionResult(rootInput, "decision-propose", decision.decision_id, decision.state, true)));
   return service.propose({ decision, body: action.body }).pipe(
     Effect.match({
@@ -51,6 +41,17 @@ export function runPropose(
       onSuccess: (result): CliResult => withDocSyncWarning(rootInput, action, decisionResult(rootInput, "decision-propose", result.decisionId, result.state, false))
     })
   );
+}
+
+export function materializeProposedDecision(action: ProposeAction):
+  | { readonly ok: true; readonly decision: DecisionCreateInput }
+  | { readonly ok: false; readonly code: CliErrorCode; readonly reason: string } {
+  const baseDecision = proposedDecision(action, []);
+  const fulfilled = applyClaimFulfillments(baseDecision, action.fulfillments);
+  if (!fulfilled.ok) return { ok: false, code: CliErrorCode.InvalidDecisionAmendPatch, reason: fulfilled.reason };
+  const relations = decisionEvidenceRelations(fulfilled.decision, action.evidenceRelations);
+  if (!relations.ok) return { ok: false, code: CliErrorCode.InvalidDecisionEvidenceRelation, reason: relations.reason };
+  return { ok: true, decision: { ...fulfilled.decision, relations: relations.records } };
 }
 
 function withDocSyncWarning(rootInput: HarnessLayoutInput, action: ProposeAction, result: CliResult): CliResult {
@@ -82,7 +83,7 @@ function proposedChosen(action: ProposeAction): DecisionCreateInput["chosen"] {
   return action.chosen.map((choice) => ({
       id: normalizedAnchorId(choice.id, "chosen"),
       text: choice.text,
-      ...(choice.load_bearing === false ? { load_bearing: false } : {})
+      ...(choice.load_bearing === undefined ? {} : { load_bearing: choice.load_bearing })
     }));
 }
 
@@ -98,7 +99,7 @@ function proposedClaims(action: ProposeAction): DecisionCreateInput["claims"] {
   return action.claims.map((claim) => ({
       id: normalizedAnchorId(claim.id, "claim"),
       text: claim.text,
-      ...(claim.load_bearing === false ? { load_bearing: false } : {}),
+      ...(claim.load_bearing === undefined ? {} : { load_bearing: claim.load_bearing }),
       ...(claim.fulfillment ? { fulfillment: claim.fulfillment } : {})
     }));
 }

--- a/packages/cli/src/commands/core/decision-relate.ts
+++ b/packages/cli/src/commands/core/decision-relate.ts
@@ -138,7 +138,7 @@ function readDecisionForCommand(
   );
 }
 
-function materializedTaskPriorityWrites(
+export function materializedTaskPriorityWrites(
   rootInput: HarnessLayoutInput,
   decision: DecisionPackage,
   relation: EntityRelationRecord

--- a/packages/cli/src/commands/core/task-lifecycle.ts
+++ b/packages/cli/src/commands/core/task-lifecycle.ts
@@ -238,6 +238,6 @@ function runTaskDelete(
   })));
 }
 
-function renderForceStatusAudit(status: string, reason: string): string {
-  return `${FORCE_STATUS_AUDIT_MARKER}: forced terminal status=${status}; reason=${reason}; recordedAt=${new Date().toISOString()}`;
+export function renderForceStatusAudit(status: string, reason: string, recordedAt = new Date().toISOString()): string {
+  return `${FORCE_STATUS_AUDIT_MARKER}: forced terminal status=${status}; reason=${reason}; recordedAt=${recordedAt}`;
 }

--- a/packages/cli/src/daemon/production-authority-attempt-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-attempt-compiler.ts
@@ -25,6 +25,7 @@ import {
   decisionSemanticMutationActions,
   encodeCanonicalCbor,
   moduleEntityId,
+  parseDecisionDocument,
   sha256Text,
   semanticMutationWireV2,
   taskEntityId,
@@ -56,6 +57,8 @@ import { buildAuthorityPresetTaskCreateWrites, shouldUsePresetAwareNewTask } fro
 import { readProjectHarnessSettings, shouldUseSettingsPresetAwareNewTask } from "../commands/settings.ts";
 import { provenanceSessionAttemptIntent } from "./production-authority-provenance-session-intent.ts";
 import { taskClaimAttemptIntent } from "./production-authority-task-claim-intent.ts";
+import { materializeProposedDecision } from "../commands/core/decision-propose.ts";
+import { materializedTaskPriorityWrites } from "../commands/core/decision-relate.ts";
 
 type KeyMaterial = ReturnType<typeof openAuthorityProductionKeyMaterial>;
 
@@ -388,27 +391,20 @@ async function canonicalAttemptIntent(
     if (action.rejected.some((entry) => !entry.why_not)) {
       throw new Error("AUTHORITY_DECISION_REJECTED_RATIONALE_REQUIRED: add why_not to every rejected alternative and retry decision propose");
     }
+    const materialized = materializeProposedDecision(action);
+    if (!materialized.ok) throw new Error(`AUTHORITY_DECISION_PROPOSE_ENRICHMENT_INVALID:${materialized.reason}`);
     const decision: DecisionPackage = {
-      schema: "decision-package/v1",
-      decision_id: action.decisionId,
-      title: action.title,
-      state: "proposed",
-      riskTier: action.riskTier,
-      urgency: action.urgency,
-      vertical: "software/coding",
-      preset: "architecture-decision",
-      applies_to: { modules: action.modules, productLines: action.productLines },
-      proposedAt: action.proposedAt,
-      provenance: [{ runtime: currentSession.runtime, sessionId: currentSession.sessionId, boundAt: currentSession.detectedAt }],
-      question: action.question,
-      chosen: action.chosen.map((entry, index) => ({ id: entry.id ?? `CH${index + 1}`, text: entry.text, ...(entry.load_bearing === undefined ? {} : { load_bearing: entry.load_bearing }) })),
-      rejected: action.rejected.map((entry, index) => ({ id: entry.id ?? `RJ${index + 1}`, text: entry.text, why_not: entry.why_not! })),
-      claims: action.claims.map((entry, index) => ({ id: entry.id ?? `C${index + 1}`, text: entry.text, ...(entry.load_bearing === undefined ? {} : { load_bearing: entry.load_bearing }), ...(entry.fulfillment === undefined ? {} : { fulfillment: entry.fulfillment }) })),
-      relations: []
+      ...materialized.decision,
+      provenance: [{ runtime: currentSession.runtime, sessionId: currentSession.sessionId, boundAt: currentSession.detectedAt }]
     };
     const entity = ref("decision", `decision/${action.decisionId}`);
     const payload: TaskDecisionModuleCommandPayloadV2 = { schema: "decision.propose/v1", decision, ...(action.body === undefined ? {} : { body: action.body }) };
-    return canonicalIntent("decision.propose", encodeTaskDecisionModuleCommandPayloadV2(payload), [{ entity, action: decisionSemanticMutationActions.propose }], [entity], [`decisions/decision-${action.decisionId}/decision.md`], decisionEntityId(action.decisionId));
+    const relationEntities = decision.relations.map((relation) => ref("relation", `relation/${relation.relation_id}`));
+    return canonicalIntent(
+      "decision.propose", encodeTaskDecisionModuleCommandPayloadV2(payload),
+      [{ entity, action: decisionSemanticMutationActions.propose }, ...relationEntities.map((relationEntity) => ({ entity: relationEntity, action: "create" }))],
+      [entity, ...relationEntities], [`decisions/decision-${action.decisionId}/decision.md`], decisionEntityId(action.decisionId)
+    );
   }
   if (action.kind === "module-register") {
     const entity = ref("module", `module/${action.moduleKey}`);
@@ -438,10 +434,33 @@ async function canonicalAttemptIntent(
     const documentPath = `decisions/decision-${action.decisionId}/decision.md`;
     const snapshot = hostedSnapshot(authoredRoot, documentPath);
     if (!snapshot) throw new Error("AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED: run decision show and repair the source Decision before decision relate");
-    const payload: TaskDecisionModuleCommandPayloadV2 = { schema: "decision.relation/v1", decisionId: action.decisionId, relation };
+    const current = parseDecisionDocument(snapshot.body).decision;
+    const materialized = materializedTaskPriorityWrites(
+      { rootDir: command.rootDir, layoutOverrides: command.layoutOverrides }, current, relation
+    );
+    if (!materialized.ok) throw new Error(`AUTHORITY_DECISION_RELATION_PRIORITY_INVALID:${materialized.error.hint}`);
+    const taskWrites = materialized.writes;
+    const taskSnapshots = taskWrites.map((write) => {
+      const taskPath = `tasks/${write.taskId}/${write.path}`;
+      const taskSnapshot = hostedSnapshot(authoredRoot, taskPath);
+      if (!taskSnapshot) throw new Error(`AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED:${taskPath}`);
+      return { write, taskPath, taskSnapshot };
+    });
+    const payload: TaskDecisionModuleCommandPayloadV2 = {
+      schema: "decision.relation/v1", decisionId: action.decisionId, relation,
+      ...(taskWrites.length === 0 ? {} : { taskWrites })
+    };
     return {
-      ...canonicalIntent("decision.relation", encodeTaskDecisionModuleCommandPayloadV2(payload), [{ entity: host, action: "relation" }, { entity, action: "create" }], [host, entity], [documentPath], decisionEntityId(action.decisionId)),
-      declaredPathCas: [{ path: documentPath, ...snapshot.cas }]
+      ...canonicalIntent(
+        "decision.relation", encodeTaskDecisionModuleCommandPayloadV2(payload),
+        [{ entity: host, action: "relation" }, { entity, action: "create" }, ...taskSnapshots.map(({ write }) => ({ entity: ref("task", `task/${write.taskId}`), action: "document" }))],
+        [host, entity, ...taskSnapshots.map(({ write }) => ref("task", `task/${write.taskId}`))],
+        [documentPath, ...taskSnapshots.map(({ taskPath }) => taskPath)], decisionEntityId(action.decisionId)
+      ),
+      declaredPathCas: [
+        { path: documentPath, ...snapshot.cas },
+        ...taskSnapshots.map(({ taskPath, taskSnapshot }) => ({ path: taskPath, ...taskSnapshot.cas }))
+      ]
     };
   }
   if (action.kind === "session-export" && action.sessionId && action.runtime && action.transcriptFile) {

--- a/packages/cli/src/daemon/production-authority-lifecycle-intents.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle-intents.ts
@@ -6,6 +6,7 @@ import {
   encodeFactRelationCommandPayloadV2,
   encodeSessionExecutionReviewCommandPayloadV2,
   encodeTaskDecisionModuleCommandPayloadV2,
+  finalizeExecutionSessionBindings,
   renderCodeDocReconciliationDraft,
   type ConsentCommandPayloadV2,
   type FactRelationCommandPayloadV2,
@@ -24,6 +25,7 @@ import {
 import type { ParsedCommand } from "../cli/types.ts";
 import type { DaemonAuthorityAttemptCompilerV2 } from "./authority-command-submission.ts";
 import type { CanonicalAttemptIntent } from "./production-authority-attempt-compiler.ts";
+import { renderForceStatusAudit } from "../commands/core/task-lifecycle.ts";
 
 type CompileInput = Parameters<DaemonAuthorityAttemptCompilerV2["compile"]>[0];
 
@@ -38,14 +40,27 @@ export function productionLifecycleAttemptIntent(input: {
   if (action.kind === "status-set") {
     const taskPath = taskLifecyclePath(input.authoredRoot, action.taskId, "INDEX.md");
     if (action.executionSubmission?.executionId) {
-      return executionSubmitIntent(input.authoredRoot, input.currentSession.detectedAt, action, taskPath);
+      return executionSubmitIntent(
+        input.authoredRoot,
+        { rootDir: input.command.rootDir, layoutOverrides: input.command.layoutOverrides },
+        input.currentSession.detectedAt,
+        action,
+        taskPath
+      );
     }
+    const auditText = action.force
+      ? renderForceStatusAudit(action.status, action.reason ?? "unspecified", input.currentSession.detectedAt)
+      : undefined;
     const payload: TaskDecisionModuleCommandPayloadV2 = {
-      schema: "task.transition/v1", taskId: action.taskId, to: action.status
+      schema: "task.transition/v1", taskId: action.taskId, to: action.status,
+      ...(auditText === undefined ? {} : { auditText })
     };
     return lifecycleIntent("task.transition", encodeTaskDecisionModuleCommandPayloadV2(payload), [
       lifecycleMutation("task", `task/${action.taskId}`, "transition")
-    ], [lifecycleRef("task", `task/${action.taskId}`)], portableLifecyclePaths(taskPath), taskEntityId(action.taskId), [
+    ], [lifecycleRef("task", `task/${action.taskId}`)], [
+      ...portableLifecyclePaths(taskPath),
+      ...(auditText === undefined ? [] : portableLifecyclePaths(taskLifecyclePath(input.authoredRoot, action.taskId, "progress.md")))
+    ], taskEntityId(action.taskId), [
       requiredLifecycleSnapshot(input.authoredRoot, taskPath.logical, taskPath.physical)
     ]);
   }
@@ -101,6 +116,7 @@ export function productionLifecycleAttemptIntent(input: {
 
 function executionSubmitIntent(
   authoredRoot: string,
+  rootInput: { readonly rootDir: string; readonly layoutOverrides?: { readonly authoredRoot?: string } },
   submittedAt: string,
   action: Extract<ParsedCommand["action"], { readonly kind: "status-set" }>,
   taskPath: ReturnType<typeof taskLifecyclePath>
@@ -111,10 +127,16 @@ function executionSubmitIntent(
   const executionSnapshot = requiredLifecycleSnapshot(authoredRoot, executionPath.logical, executionPath.physical);
   const taskSnapshot = requiredLifecycleSnapshot(authoredRoot, taskPath.logical, taskPath.physical);
   const current = executionDeclaration.documentCodec.decode(executionSnapshot.body) as ExecutionRecord;
+  const sessionBindings = finalizeExecutionSessionBindings(
+    rootInput,
+    current.session_bindings,
+    submittedAt
+  );
   const next: ExecutionRecord = {
     ...current,
     state: "submitted",
     submitted_at: submittedAt,
+    session_bindings: sessionBindings,
     outputs: [
       ...current.outputs,
       ...submission.outputs.map((text, index) => ({

--- a/packages/cli/test/production-authority-canonical-ingress/fixture.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/fixture.ts
@@ -71,7 +71,7 @@ export function createFixture() {
       binding_id: "primary:service-slugged-lifecycle-session",
       session_ref: "session/service-slugged-lifecycle-session",
       role: "primary",
-      archive_status: "complete",
+      archive_status: "pending",
       attached_at: "2026-07-17T00:00:00.000Z",
       session: {
         runtime: "codex",
@@ -79,7 +79,13 @@ export function createFixture() {
         source: "runtime",
         detectedAt: "2026-07-17T00:00:00.000Z"
       },
-      capture_range: null
+      capture_range: {
+        range_id: "primary:service-slugged-lifecycle-session:2026-07-17T00:00:00.000Z",
+        coordinate: "timestamp",
+        start_at: "2026-07-17T00:00:00.000Z",
+        end_at: null,
+        bounds: "inclusive"
+      }
     }],
     outputs: [],
     submission: null
@@ -88,6 +94,39 @@ export function createFixture() {
   writeFileSync(
     path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/executions/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG7.md"),
     executionDeclaration.documentCodec.encode(sluggedExecution)
+  );
+  const paritySubmitTaskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNJ0";
+  const paritySubmitExecutionId = "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNJ1";
+  const paritySubmitSessionId = "service-wave2-submit-session";
+  mkdirSync(path.join(authoredRoot, `tasks/${paritySubmitTaskId}/executions`), { recursive: true });
+  writeFileSync(path.join(authoredRoot, `tasks/${paritySubmitTaskId}/INDEX.md`), taskIndexBody(paritySubmitTaskId));
+  writeFileSync(
+    path.join(authoredRoot, `tasks/${paritySubmitTaskId}/executions/${paritySubmitExecutionId}.md`),
+    executionDeclaration.documentCodec.encode({
+      ...sluggedExecution,
+      execution_id: paritySubmitExecutionId,
+      task_ref: `task/${paritySubmitTaskId}`,
+      session_bindings: [{
+        binding_id: `primary:${paritySubmitSessionId}`,
+        session_ref: `session/${paritySubmitSessionId}`,
+        role: "primary",
+        archive_status: "pending",
+        attached_at: "2026-07-17T00:00:00.000Z",
+        session: {
+          runtime: "codex",
+          sessionId: paritySubmitSessionId,
+          source: "runtime",
+          detectedAt: "2026-07-17T00:00:00.000Z"
+        },
+        capture_range: {
+          range_id: `primary:${paritySubmitSessionId}:2026-07-17T00:00:00.000Z`,
+          coordinate: "timestamp",
+          start_at: "2026-07-17T00:00:00.000Z",
+          end_at: null,
+          bounds: "inclusive"
+        }
+      }]
+    })
   );
   const transcriptPath = path.join(root, "session-transcript.md");
   writeFileSync(transcriptPath, `${JSON.stringify({ timestamp: "2026-07-17T00:00:00.000Z", type: "event_msg", payload: { type: "user_message", message: "Production session ingress." } })}\n`);

--- a/packages/cli/test/production-authority-canonical-ingress/production-parity.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/production-parity.ts
@@ -1,6 +1,7 @@
 import type { ProductionCanonicalIngressFixture } from "./fixture.ts";
 import { verifyDecisionProposeParity } from "./propose-parity.ts";
 import { verifyReviewVerdictCompanions } from "./review-verdict-companions.ts";
+import { verifyWave2CanonicalParity } from "./wave2-parity.ts";
 
 export function verifyProductionCommandParity(
   fixture: ProductionCanonicalIngressFixture,
@@ -8,4 +9,5 @@ export function verifyProductionCommandParity(
 ): void {
   verifyDecisionProposeParity(fixture, env);
   verifyReviewVerdictCompanions(fixture, env);
+  verifyWave2CanonicalParity(fixture, env);
 }

--- a/packages/cli/test/production-authority-canonical-ingress/wave2-parity.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/wave2-parity.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { parseDecisionDocument } from "../../../kernel/src/index.ts";
+import { runRawJsonMaybeFail } from "../helpers/daemon-cli.ts";
+import { createFixture, type ProductionCanonicalIngressFixture } from "./fixture.ts";
+
+export function verifyWave2CanonicalParity(
+  daemonFixture: ProductionCanonicalIngressFixture,
+  daemonEnv: NodeJS.ProcessEnv
+): void {
+  const directFixture = createFixture();
+  const directEnv = { ...daemonEnv, HARNESS_DAEMON_MODE: "direct", HARNESS_AUTHORITY_MANIFEST: "" };
+  const failures: Error[] = [];
+  const check = (assertion: () => void): void => {
+    try { assertion(); } catch (error) { failures.push(error instanceof Error ? error : new Error(String(error))); }
+  };
+  try {
+    const directDecision = proposeRichPacket(directFixture, directEnv);
+    const daemonDecision = proposeRichPacket(daemonFixture, daemonEnv);
+    check(() => assert.deepEqual(normalizedDecision(daemonFixture, daemonDecision), normalizedDecision(directFixture, directDecision)));
+    check(() => assert.deepEqual(decisionEnrichment(daemonFixture, daemonDecision), decisionEnrichment(directFixture, directDecision)));
+    check(() => assert.deepEqual(decisionEnrichment(directFixture, directDecision), {
+      chosen: [{ id: "CH1", text: "Preserve explicit load bearing", load_bearing: true }],
+      claims: [{ id: "C1", text: "Rich packet survives ingress", load_bearing: true, fulfillment: "delivered" }],
+      relations: [{ sourceAnchor: "C1", target: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", type: "relates", rationale: "wave2 evidence" }]
+    }));
+
+    claimPriorityTask(directFixture, directEnv);
+    claimPriorityTask(daemonFixture, daemonEnv);
+    relateDerives(directFixture, directEnv, directDecision);
+    relateDerives(daemonFixture, daemonEnv, daemonDecision);
+    check(() => assert.equal(priorityLines(daemonFixture), priorityLines(directFixture)));
+    check(() => assert.equal(priorityLines(directFixture), "riskTier: high\nurgency: low"));
+
+    forceCancel(directFixture, directEnv);
+    forceCancel(daemonFixture, daemonEnv);
+    check(() => assert.match(progressBody(directFixture), /FORCE_STATUS_SET_AUDIT: forced terminal status=cancelled; reason=wave2 parity/u));
+    check(() => assert.match(progressBody(daemonFixture), /FORCE_STATUS_SET_AUDIT: forced terminal status=cancelled; reason=wave2 parity/u));
+
+    submitWithFinalizedBinding(directFixture, directEnv);
+    submitWithFinalizedBinding(daemonFixture, daemonEnv);
+    check(() => assert.equal(bindingFinalization(daemonFixture).archive_status, bindingFinalization(directFixture).archive_status));
+    check(() => assert.equal(typeof bindingFinalization(daemonFixture).capture_range?.end_at, typeof bindingFinalization(directFixture).capture_range?.end_at));
+    check(() => assert.equal(bindingFinalization(directFixture).archive_status, "complete"));
+    check(() => assert.equal(typeof bindingFinalization(directFixture).capture_range?.end_at, "string"));
+    if (failures.length > 0) throw new AggregateError(failures, "wave2 canonical parity mismatches");
+  } finally {
+    rmSync(directFixture.root, { recursive: true, force: true });
+  }
+}
+
+function claimPriorityTask(fixture: ProductionCanonicalIngressFixture, env: NodeJS.ProcessEnv): void {
+  const result = runRawJsonMaybeFail(fixture.repoRoot, ["task", "claim", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"], env);
+  assert.equal(result.status, 0, JSON.stringify(result.receipt));
+}
+
+function proposeRichPacket(fixture: ProductionCanonicalIngressFixture, env: NodeJS.ProcessEnv): string {
+  const result = runRawJsonMaybeFail(fixture.repoRoot, [
+    "decision", "propose", "--title", "Wave2 rich proposal", "--question", "Does enrichment cross canonical ingress?",
+    "--chosen", JSON.stringify({ id: "CH1", text: "Preserve explicit load bearing", load_bearing: true }),
+    "--rejected", "Drop daemon-only fields", "--why-not", "Canonical parity is required",
+    "--claim", JSON.stringify({ id: "C1", text: "Rich packet survives ingress", load_bearing: true }),
+    "--fulfillment", "C1:delivered", "--evidence-relation",
+    "C1:relates:task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4:wave2 evidence",
+    "--risk-tier", "high", "--urgency", "low"
+  ], env);
+  assert.equal(result.status, 0, JSON.stringify(result.receipt));
+  const decisionId = String((result.receipt.details as { readonly data?: { readonly decisionId?: string } } | undefined)?.data?.decisionId ?? "");
+  assert.match(decisionId, /^dec_[0-9A-HJKMNP-TV-Z]{26}$/u);
+  return decisionId;
+}
+
+function decisionEnrichment(fixture: ProductionCanonicalIngressFixture, decisionId: string) {
+  const decision = readDecision(fixture, decisionId);
+  return {
+    chosen: decision.chosen,
+    claims: decision.claims,
+    relations: decision.relations.map((relation) => ({
+      sourceAnchor: relation.source.split("/").at(-1), target: relation.target,
+      type: relation.type, rationale: relation.rationale
+    }))
+  };
+}
+
+function normalizedDecision(fixture: ProductionCanonicalIngressFixture, decisionId: string) {
+  const decision = readDecision(fixture, decisionId);
+  const { _coordinatorWatermark: _watermark, proposedAt: _proposedAt, provenance: _provenance, ...stable } = decision;
+  return {
+    ...stable,
+    decision_id: "<generated>",
+    relations: decision.relations.map(({ relation_id: _relationId, source, ...relation }) => ({
+      ...relation,
+      relation_id: "<derived>",
+      source: source.replace(`decision/${decisionId}/`, "decision/<generated>/")
+    }))
+  };
+}
+
+function readDecision(fixture: ProductionCanonicalIngressFixture, decisionId: string) {
+  return parseDecisionDocument(readFileSync(path.join(
+    fixture.authoredRoot, `decisions/decision-${decisionId}/decision.md`
+  ), "utf8")).decision;
+}
+
+function relateDerives(fixture: ProductionCanonicalIngressFixture, env: NodeJS.ProcessEnv, decisionId: string): void {
+  const result = runRawJsonMaybeFail(fixture.repoRoot, [
+    "decision", "relate", decisionId, "--anchor", "C1", "--type", "derives",
+    "--target", "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "--rationale", "materialize priority"
+  ], env);
+  assert.equal(result.status, 0, JSON.stringify(result.receipt));
+}
+
+function priorityLines(fixture: ProductionCanonicalIngressFixture): string {
+  const body = readFileSync(path.join(fixture.authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/INDEX.md"), "utf8");
+  return [...body.matchAll(/^(?:riskTier|urgency): .+$/gmu)].map((match) => match[0]).join("\n");
+}
+
+function forceCancel(fixture: ProductionCanonicalIngressFixture, env: NodeJS.ProcessEnv): void {
+  const result = runRawJsonMaybeFail(fixture.repoRoot, [
+    "task", "transition", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "cancelled", "--force", "--reason", "wave2 parity"
+  ], env);
+  assert.equal(result.status, 0, JSON.stringify(result.receipt));
+  assert.equal(result.receipt.ok, true, JSON.stringify(result.receipt));
+}
+
+function progressBody(fixture: ProductionCanonicalIngressFixture): string {
+  return readFileSync(path.join(fixture.authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/progress.md"), "utf8");
+}
+
+function submitWithFinalizedBinding(fixture: ProductionCanonicalIngressFixture, env: NodeJS.ProcessEnv): void {
+  const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNJ0";
+  const executionId = "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNJ1";
+  const sessionId = "service-wave2-submit-session";
+  const sessionEnv = { ...env, CODEX_THREAD_ID: sessionId };
+  const exported = runRawJsonMaybeFail(fixture.repoRoot, [
+    "session", "export", "--session", sessionId, "--runtime", "codex", "--source", "runtime",
+    "--detected-at", "2026-07-17T00:00:00.000Z", "--transcript-file", fixture.transcriptPath
+  ], sessionEnv);
+  assert.equal(exported.status, 0, JSON.stringify(exported.receipt));
+  const claimed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "claim", taskId, "--execution-id", executionId], sessionEnv);
+  assert.equal(claimed.status, 0, JSON.stringify(claimed.receipt));
+  const leaseToken = String((claimed.receipt.details as { readonly report?: { readonly leaseToken?: string } } | undefined)?.report?.leaseToken ?? "");
+  assert.notEqual(leaseToken, "", JSON.stringify(claimed.receipt));
+  const submitted = runRawJsonMaybeFail(fixture.repoRoot, [
+    "task", "transition", taskId, "in_review", "--execution-id", executionId, "--lease-token", leaseToken,
+    "--completion-claim", "Wave2 binding finalization", "--verification", "A/B parity"
+  ], sessionEnv);
+  assert.equal(submitted.status, 0, JSON.stringify(submitted.receipt));
+}
+
+function bindingFinalization(fixture: ProductionCanonicalIngressFixture) {
+  const execution = JSON.parse(readFileSync(path.join(
+    fixture.authoredRoot,
+    "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNJ0/executions/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNJ1.md"
+  ), "utf8")) as { readonly session_bindings: ReadonlyArray<{ readonly archive_status: string; readonly capture_range: { readonly end_at: string | null } | null }> };
+  return execution.session_bindings[0]!;
+}

--- a/packages/kernel/src/store/write-journal-operations.ts
+++ b/packages/kernel/src/store/write-journal-operations.ts
@@ -78,6 +78,23 @@ export function writeTransactionPlan(op: WriteOp): WriteTransactionPlan {
       validate: (rootInput) => validateRetiredAttributionFieldCleanup(rootInput, op)
     };
   }
+  if (op.kind === "transition_local" && transitionAuditText(op.payload) !== null) {
+    const indexWrite = toDocumentWrite(op);
+    const auditText = transitionAuditText(op.payload)!;
+    return {
+      touchedPaths: (rootInput) => [
+        documentTargetPath(rootInput, indexWrite),
+        documentTargetPath(rootInput, { taskId: indexWrite.taskId, path: "progress.md", body: "", packageSlug: indexWrite.packageSlug })
+      ],
+      documentWrites: () => [indexWrite],
+      apply: (rootInput) => {
+        const progressWrite = forceAuditProgressWrite(rootInput, indexWrite, auditText);
+        writeDocumentsAtomically(rootInput, [indexWrite, progressWrite]);
+        return indexWrite;
+      },
+      validate: () => { toDocumentWrite(op); }
+    };
+  }
   if (op.kind === "doc_sync_submit" || op.kind === "script_ingest") {
     return {
       touchedPaths: (rootInput) => canonicalAuthoredBatchPaths(rootInput, op),
@@ -327,6 +344,20 @@ export function writeTransactionPlan(op: WriteOp): WriteTransactionPlan {
       toDocumentWrite(op);
     }
   };
+}
+
+function transitionAuditText(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const value = (payload as { readonly auditText?: unknown }).auditText;
+  return typeof value === "string" && value.startsWith("FORCE_STATUS_SET_AUDIT:") ? value : null;
+}
+
+function forceAuditProgressWrite(rootInput: HarnessLayoutInput, indexWrite: DocumentWrite, auditText: string): DocumentWrite {
+  const probe = { taskId: indexWrite.taskId, path: "progress.md", body: "", packageSlug: indexWrite.packageSlug };
+  const targetPath = documentTargetPath(rootInput, probe);
+  const existing = existsSync(targetPath) ? readFileSync(targetPath, "utf8") : "# Progress\n\n## Entries\n\n";
+  const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+  return { ...probe, body: `${existing}${separator}${auditText}\n` };
 }
 
 function hasDeclaredEntityDocument(payload: unknown): payload is DeclaredEntityDocumentWritePayload {


### PR DESCRIPTION
# English

## Summary

A parity sweep of every production typed-ingress command surfaced four cases where the daemon path silently under-writes canonical documents while returning an `ok` receipt — worse than the earlier rejection-style wire-parity bugs, because the receipt lies. All four are fixed by sharing the exact application-layer materializer with the daemon compiler (the wire-parity discipline) and folding companions into a single canonical transaction (the #909 pattern). Wire-parity family instances #6–#9.

## What Changed

- **propose rich packet**: daemon now shares `materializeProposedDecision` with the CLI runner — fulfillments applied, evidence relations landed in `relations`, and explicit `load_bearing` booleans preserved in both directions (previously daemon hard-set `relations: []` and dropped fulfillments while keeping `true`).
- **relate `derives` priority companion**: daemon shares `materializedTaskPriorityWrites`; the target INDEX priority write rides the typed payload inside the single `decision_relate` canonical transaction, recomputed and byte-verified server-side (missing/redundant/mismatched companion all fail closed).
- **forced transition audit**: daemon shares `renderForceStatusAudit`; the `FORCE_STATUS_SET_AUDIT` progress marker rides the `task.transition/v1` payload and is written atomically with INDEX in the same single task-transition operation (no extra op).
- **submit binding finalization**: daemon shares `finalizeExecutionSessionBindings`; session archive-status/capture-end are finalized from the canonical session manifest before the execution-submit companion transaction (missing snapshot still fails closed).

## Task And Scope

- Ledger task task_01KXTQHS9ZRB6K67TP1B3V0ZZ7; source = enrichment sweep report (tmp/orch/enrichment-sweep). Scope: decision-propose / decision-relate / status-set(force) / execution-submit daemon compilers plus their shared application materializers and one kernel atomic-write path.

## Version Impact

- No schema or wire-format change; daemon canonical output now matches the direct path field-for-field. No version bump.

## Governance Declaration

- No gates, allowlists, CI configuration, or protected surfaces were modified. admission stays fail-closed for every companion; no fix sends a separate op to bypass the single-canonical-operation constraint. Break-glass: no.

## Verification

- A/B controls (direct vs production daemon, same inputs) in `wave2-parity.ts`: all four diffs red before, green after; `canonical-ingress.test.ts` 2/2.
- Affected unit tests 30/30 (decision CLI, task/decision/session/execution/review semantic compilers, kernel recovery).
- Root `check:local` exit 0 (rebased onto main containing #915).

## Review Evidence

- Sweep report tmp/orch/enrichment-sweep/REPORT-enrichment-sweep.md (15/15 commands covered); implementation report tmp/orch/parity-wave2/REPORT-parity-wave2.md (moved into task package at closeout). CEO ground-truthed the shared-function wiring and fail-closed admission checks in the diff.

## Residual Risk

- Time-family divergences (force-audit `recordedAt`, submit `submittedAt`/binding `end_at` use command wall-clock vs daemon server-observed session time) are left as-is by design and normalized in the A/B comparison; not silent under-writes. A follow-up adjudication is queued.
- module empty-string optional divergence untouched (low-confidence, unverified).

## References

- Wire-parity family: #908, #909, #910, #913 (parser/app layer), #915 (V2 evidence commit). This PR = application-layer silent under-write class.

---

# 中文

## 概要

对每个 production typed-ingress 命令做 parity 扫查,发现四条 daemon 路「回执 ok 但 canonical 文档静默少写」——比此前拒收式 wire-parity 更危险,因为回执在撒谎。四条均按 wire-parity 纪律修复:daemon compiler 与应用层共用同一 materializer,companion 并入单一 canonical 事务(#909 模式)。wire-parity 家族第 6–9 例。

## 改动内容

- **propose 富包**:daemon 改用共享 `materializeProposedDecision`——fulfillment 应用、evidence relation 落入 `relations`、显式 `load_bearing` boolean 双向保留(此前 daemon 硬置 `relations: []` 且丢 fulfillment,却保留 true)。
- **relate `derives` 优先级 companion**:daemon 共用 `materializedTaskPriorityWrites`;目标 INDEX priority write 随 typed payload 进入单一 `decision_relate` canonical 事务,服务端重算并逐字节校验(缺/冗余/不符 companion 均 fail-closed)。
- **forced transition 审计**:daemon 共用 `renderForceStatusAudit`;`FORCE_STATUS_SET_AUDIT` progress marker 随 `task.transition/v1` payload,与 INDEX 在同一单个 task-transition operation 内原子写(不加 op)。
- **submit binding finalization**:daemon 共用 `finalizeExecutionSessionBindings`;session archive-status/capture-end 在 execution-submit companion 事务前从 canonical session manifest finalize(缺 snapshot 仍 fail-closed)。

## 任务与范围

- 台账 task_01KXTQHS9ZRB6K67TP1B3V0ZZ7;来源=enrichment 扫查报告(tmp/orch/enrichment-sweep)。范围:decision-propose/decision-relate/status-set(force)/execution-submit 的 daemon compiler + 其共享应用层 materializer + 一处 kernel 原子写路。

## 版本影响

- 无 schema/wire 格式变更;daemon canonical 输出现与 direct 路逐字段一致。无版本号变更。

## 治理声明

- 未修改任何 gate、allowlist、CI 配置或受保护 surface。每个 companion 的 admission 保持 fail-closed;无任何修复通过发独立 op 绕过单 canonical operation 约束。Break-glass:否。

## 验证

- A/B 对照(direct vs production daemon,同输入)在 `wave2-parity.ts`:四条 diff 修前全红、修后全绿;`canonical-ingress.test.ts` 2/2。
- 受影响单测 30/30(decision CLI、task/decision/session/execution/review semantic compiler、kernel recovery)。
- rebase 到含 #915 的 main 后根 `check:local` exit 0。

## 审查证据

- 扫查报告 tmp/orch/enrichment-sweep/REPORT-enrichment-sweep.md(15/15 命令覆盖);实现报告 tmp/orch/parity-wave2/REPORT-parity-wave2.md(收口移入任务包)。CEO 在 diff 中亲验共享函数接线与 fail-closed admission。

## 残余风险

- 时间族分叉(force-audit `recordedAt`、submit `submittedAt`/binding `end_at` 用命令墙钟 vs daemon server-observed session time)按设计保留,A/B 比较中归一化;非静默少写。后续裁决已排队。
- module 空串 optional 分叉未触碰(低置信,unverified)。

## 关联材料

- wire-parity 家族:#908、#909、#910、#913(parser/应用层)、#915(V2 evidence commit)。本 PR = 应用层静默少写类。
