### PR TITLE
fix(cli): admit preset script artifacts in production

### DIFF
--- a/packages/cli/src/cli/command-spec/command-spec-extensions.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-extensions.ts
@@ -213,7 +213,8 @@ export const extensionsCommandSpecs = defineCommandSpecs([
     "receiptContract": {
       "data": ["script", "runId", "evidenceBundle", "generated", "report"],
       "optionalData": {
-        "rows": "Only emitted when a script writes a numeric rows value in its script-result/v1 payload."
+        "rows": "Only emitted when a script writes a numeric rows value in its script-result/v1 payload.",
+        "capabilityReceipt": "Only emitted by v3 semantic execution with its exact provider bindings."
       },
       "paths": []
     },

--- a/packages/cli/src/composition/actor-attribution.ts
+++ b/packages/cli/src/composition/actor-attribution.ts
@@ -96,13 +96,18 @@ export function daemonActorAttributionForParsedCommand(
   reportedExecutor: TaskHolderExecutor | null = null
 ): CliActorAttribution {
   const action = command.action;
-  if (action.kind !== "preset-entrypoint") {
+  const presetId = action.kind === "preset-entrypoint"
+    ? action.presetId
+    : action.kind === "script-run"
+      ? /^preset:([^:]+):/u.exec(action.scriptId)?.[1]
+      : undefined;
+  if (!presetId) {
     return daemonActorAttribution(actor, reportedExecutor);
   }
-  if (typeof action.presetId !== "string" || action.presetId.trim() === "") {
+  if (presetId.trim() === "") {
     throw new CliActorAttributionError(`Daemon ${action.kind} requires a non-empty parsed preset id.`);
   }
-  return daemonActorAttribution(actor, { kind: "agent", id: `preset:${action.presetId}` });
+  return daemonActorAttribution(actor, { kind: "agent", id: `preset:${presetId}` });
 }
 
 export function readCliJournalActorFromEnv(env: NodeJS.ProcessEnv): CliJournalActor | undefined {

--- a/packages/cli/src/daemon/authority-command-submission.ts
+++ b/packages/cli/src/daemon/authority-command-submission.ts
@@ -51,6 +51,12 @@ export interface DaemonAuthorityAttemptCompilerV2 {
     readonly currentSession: CurrentSessionRef;
     readonly operation: WriteOp;
   }) => Promise<AuthorizedOperationAttemptV2>;
+  readonly compileScriptIngest?: (input: {
+    readonly command: ParsedCommand;
+    readonly attribution: CliActorAttribution;
+    readonly currentSession: CurrentSessionRef;
+    readonly operation: WriteOp;
+  }) => Promise<AuthorizedOperationAttemptV2>;
 }
 
 export interface DaemonAuthorityCommandSubmissionV2 {
@@ -73,6 +79,12 @@ export interface DaemonAuthorityCommandSubmissionV2 {
     readonly operation: WriteOp;
   }) => Promise<AuthorityOperationReceipt>;
   readonly submitTaskClaim?: (input: {
+    readonly command: ParsedCommand;
+    readonly attribution: CliActorAttribution;
+    readonly currentSession: CurrentSessionRef;
+    readonly operation: WriteOp;
+  }) => Promise<AuthorityOperationReceipt>;
+  readonly submitScriptIngest?: (input: {
     readonly command: ParsedCommand;
     readonly attribution: CliActorAttribution;
     readonly currentSession: CurrentSessionRef;
@@ -117,6 +129,10 @@ export function createDaemonAuthorityCommandSubmissionV2(options: {
     ...(options.attemptCompiler.compileTaskClaim ? {
       submitTaskClaim: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileTaskClaim"]>>[0]) =>
         submitAttempt(await compileAttempt(() => options.attemptCompiler.compileTaskClaim!(input)))
+    } : {}),
+    ...(options.attemptCompiler.compileScriptIngest ? {
+      submitScriptIngest: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileScriptIngest"]>>[0]) =>
+        submitAttempt(await compileAttempt(() => options.attemptCompiler.compileScriptIngest!(input)))
     } : {})
   };
 }
@@ -208,7 +224,13 @@ export function makeDaemonAuthorityWriteCoordinator(
         if (taskClaim && !submission.submitTaskClaim) {
           throw authorityWriteRejected("AUTHORITY_TASK_CLAIM_SUBMISSION_UNAVAILABLE");
         }
-        settled ??= provenanceSession
+        const scriptIngest = pending.kind === "script_ingest";
+        if (scriptIngest && !submission.submitScriptIngest) {
+          throw authorityWriteRejected("AUTHORITY_SCRIPT_SCOPE_SUBMISSION_UNAVAILABLE");
+        }
+        settled ??= scriptIngest
+          ? submission.submitScriptIngest!({ ...input, operation: pending })
+          : provenanceSession
           ? submission.submitProvenanceSession!({ ...input, operation: pending })
           : decisionTransition
             ? submission.submitDecisionTransition!({ ...input, operation: pending })

--- a/packages/cli/src/daemon/authority-submission-dispatch.ts
+++ b/packages/cli/src/daemon/authority-submission-dispatch.ts
@@ -32,6 +32,12 @@ export function bindAuthoritySubmissionForDispatch(
         dispatch.assertActive();
         return bound.submitTaskClaim!(submission);
       }
+    } : {}),
+    ...(bound.submitScriptIngest ? {
+      submitScriptIngest: async (submission: Parameters<NonNullable<typeof bound.submitScriptIngest>>[0]) => {
+        dispatch.assertActive();
+        return bound.submitScriptIngest!(submission);
+      }
     } : {})
   };
 }

--- a/packages/cli/src/daemon/production-authority-attempt-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-attempt-compiler.ts
@@ -57,6 +57,7 @@ import { buildAuthorityPresetTaskCreateWrites, shouldUsePresetAwareNewTask } fro
 import { readProjectHarnessSettings, shouldUseSettingsPresetAwareNewTask } from "../commands/settings.ts";
 import { provenanceSessionAttemptIntent } from "./production-authority-provenance-session-intent.ts";
 import { taskClaimAttemptIntent } from "./production-authority-task-claim-intent.ts";
+import { executorDerivedFromPresetScript, productionScriptIngestAttemptIntent } from "./production-authority-script-ingest.ts";
 import { materializeProposedDecision } from "../commands/core/decision-propose.ts";
 import { materializedTaskPriorityWrites } from "../commands/core/decision-relate.ts";
 
@@ -107,7 +108,7 @@ export function createProductionCanonicalAttemptCompiler(input: {
       }
       const executorAgentId = attribution.executor?.id ?? null;
       if (executorAgentId && !input.config.allowedExecutorAgentIds.includes(executorAgentId)
-        && !executorDerivedFromPreset(command, executorAgentId)) {
+        && !executorDerivedFromPresetScript(command, executorAgentId)) {
         throw new Error("AUTHORITY_EXECUTOR_NOT_SERVER_APPROVED");
       }
       const now = Date.now();
@@ -220,6 +221,10 @@ export function createProductionCanonicalAttemptCompiler(input: {
       assertTypedIngressAdapter(command.action.kind, "task-claim");
       return compileIntent(command, attribution, currentSession, operation.entityId,
         taskClaimAttemptIntent(command, attribution, currentSession, operation));
+    },
+    compileScriptIngest: async ({ command, attribution, currentSession, operation }) => {
+      return compileIntent(command, attribution, currentSession, operation.entityId,
+        productionScriptIngestAttemptIntent(command, operation, input.authoredRoot));
     }
   };
 }
@@ -584,10 +589,4 @@ export function createProductionCanonicalSemanticState(authoredRoot: string) {
       } : null;
     }
   };
-}
-
-function executorDerivedFromPreset(command: ParsedCommand, executorAgentId: string): boolean {
-  const action = command.action;
-  return action.kind === "preset-entrypoint"
-    && executorAgentId === `preset:${action.presetId}`;
 }

--- a/packages/cli/src/daemon/production-authority-lifecycle.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle.ts
@@ -1,18 +1,9 @@
 import { createHash } from "node:crypto";
 import { readFileSync, realpathSync } from "node:fs";
 import {
-  consentTypedCommandsV2,
   createAuthorityCutoverEntityRegistryQualification,
   createAuthorityCutoverControlService,
   createDurableAuthorityCommittedEventPublisherV2,
-  factRelationTypedCommandsV2,
-  makeCompositeAuthoritySemanticCompilerV2,
-  makeConsentSemanticCompilerV2,
-  makeFactRelationSemanticCompilerV2,
-  makeSessionExecutionReviewSemanticCompilerV2,
-  makeTaskDecisionModuleSemanticCompilerV2,
-  sessionExecutionReviewTypedCommandsV2,
-  taskDecisionModuleTypedCommandsV2,
   type ActorAxesBindingRuntimeV2,
   type AuthoritySubmissionV2Options,
   type AuthoritySubmissionService,
@@ -62,10 +53,8 @@ import { assertPublicationMatchesMutationSet } from "./authority-publication-evi
 import { createAuthorityProductionScanner } from "./authority-production-scanner.ts";
 import { createProductionCompoundReceiptComposition } from "./compound-receipt-composition.ts";
 import { withProductionRecoveryV2 } from "./authority-attribution-event-v2-production-recovery.ts";
-import {
-  createProductionCanonicalAttemptCompiler,
-  createProductionCanonicalSemanticState
-} from "./production-authority-attempt-compiler.ts";
+import { createProductionCanonicalAttemptCompiler } from "./production-authority-attempt-compiler.ts";
+import { createProductionAuthoritySemanticCompiler } from "./production-authority-semantic-compiler.ts";
 import { gateCutoverAdmission } from "./authority-cutover-admission.ts";
 import {
   recoverPendingProductionEvents,
@@ -383,6 +372,9 @@ function createRepoComponent(
         ...(commandSubmission.submitTaskClaim ? {
           submitTaskClaim: commandSubmission.submitTaskClaim
         } : {}),
+        ...(commandSubmission.submitScriptIngest ? {
+          submitScriptIngest: commandSubmission.submitScriptIngest
+        } : {}),
         serveForcedCommand: ({ input: readable, output }) => {
           const session = serveAuthorityForcedCommand({
             input: readable,
@@ -441,7 +433,6 @@ function createConnectionAuthorityService(
   }
 ): AuthoritySubmissionService {
   const publicationInspector = createGitCanonicalPublicationInspector(material.authoredRoot);
-  const semanticState = createProductionCanonicalSemanticState(material.authoredRoot);
   return createAuthoritySubmissionService({
     workspaceId: material.config.workspaceId,
     coordinatorFactory: input.attributedCoordinatorFactory,
@@ -459,28 +450,7 @@ function createConnectionAuthorityService(
       entityRegistrations: productionAuthorityV2EntityKinds.map((kind) =>
         entityRegistry[kind] as unknown as EntityRegistration<string, typeof kind>
       ),
-      semanticCompiler: makeCompositeAuthoritySemanticCompilerV2([{
-        commandNames: taskDecisionModuleTypedCommandsV2,
-        compiler: makeTaskDecisionModuleSemanticCompilerV2({ state: semanticState })
-      }, {
-        commandNames: factRelationTypedCommandsV2.filter((command) => command.startsWith("fact.")),
-        compiler: makeFactRelationSemanticCompilerV2({ state: semanticState })
-      }, {
-        commandNames: factRelationTypedCommandsV2.filter((command) => command.startsWith("relation.")),
-        compiler: makeFactRelationSemanticCompilerV2({ state: semanticState })
-      }, {
-        commandNames: sessionExecutionReviewTypedCommandsV2.filter((command) => command.startsWith("session.")),
-        compiler: makeSessionExecutionReviewSemanticCompilerV2({ state: semanticState })
-      }, {
-        commandNames: sessionExecutionReviewTypedCommandsV2.filter((command) => command.startsWith("execution.")),
-        compiler: makeSessionExecutionReviewSemanticCompilerV2({ state: semanticState })
-      }, {
-        commandNames: sessionExecutionReviewTypedCommandsV2.filter((command) => command.startsWith("review.")),
-        compiler: makeSessionExecutionReviewSemanticCompilerV2({ state: semanticState })
-      }, {
-        commandNames: consentTypedCommandsV2,
-        compiler: makeConsentSemanticCompilerV2({ state: semanticState })
-      }]),
+      semanticCompiler: createProductionAuthoritySemanticCompiler(material.authoredRoot),
       operationNamespaceVerifier: input.namespaceVerifier,
       committedEventPublisher: input.committedEventPublisher,
       recoverCommittedReceipt: (input.committedEventPublisher as typeof input.committedEventPublisher & {

--- a/packages/cli/src/daemon/production-authority-script-ingest.ts
+++ b/packages/cli/src/daemon/production-authority-script-ingest.ts
@@ -1,0 +1,208 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  decodeCanonicalCbor,
+  encodeCanonicalCbor,
+  normalizeRelativeDocumentPath,
+  sha256Text,
+  type CanonicalCborValue,
+  type RegistryMutationPlanInput,
+  type WriteOp
+} from "../../../kernel/src/index.ts";
+import {
+  canonicalPayloadDigestV2,
+  SemanticAdmissionErrorV2,
+  type AuthoritySemanticCompilerV2,
+  type SemanticMutationEnvelopeV2
+} from "../../../application/src/index.ts";
+import type { ParsedCommand } from "../cli/types.ts";
+import type { CanonicalAttemptIntent } from "./production-authority-attempt-compiler.ts";
+
+const commandName = "script.scope-ingest";
+const payloadSchema = "script-scope-ingest/v1";
+
+interface ScriptScopeWrite {
+  readonly path: string;
+  readonly body: string;
+  readonly baseBlobSha256: string | null;
+}
+
+interface ScriptScopePayload {
+  readonly schema: typeof payloadSchema;
+  readonly entityId: string;
+  readonly taskId: string;
+  readonly writes: ReadonlyArray<ScriptScopeWrite>;
+}
+
+export function productionScriptIngestAttemptIntent(
+  command: ParsedCommand,
+  operation: WriteOp,
+  authoredRoot: string
+): CanonicalAttemptIntent {
+  const taskId = scriptTaskId(command);
+  if (operation.kind !== "script_ingest") throw new Error("AUTHORITY_SCRIPT_SCOPE_OPERATION_REQUIRED");
+  const writes = scriptScopeWrites(operation.payload, taskId, authoredRoot);
+  assertScriptRunEntityId(operation.entityId);
+  const payload: ScriptScopePayload = {
+    schema: payloadSchema,
+    entityId: operation.entityId,
+    taskId,
+    writes
+  };
+  return {
+    commandName,
+    payload: encodeScriptScopePayload(payload),
+    mutations: [{
+      entity: { registryVersion: 1, entityKind: "task", canonicalRef: `task/${taskId}` },
+      action: "document"
+    }],
+    baseRefs: [{ registryVersion: 1, entityKind: "task", canonicalRef: `task/${taskId}` }],
+    portablePaths: writes.map((write) => write.path),
+    declaredPathCas: [],
+    physicalEntityId: operation.entityId
+  };
+}
+
+export function makeProductionScriptIngestSemanticCompiler(authoredRoot: string): AuthoritySemanticCompilerV2 {
+  return {
+    compile: async (envelope) => {
+      const payload = decodeScriptScopeEnvelope(envelope);
+      const writes = scriptScopeWrites({ writes: payload.writes }, payload.taskId, authoredRoot);
+      assertScriptRunEntityId(payload.entityId);
+      return {
+        mutationPlan: scriptScopeMutationPlan(payload.taskId, writes),
+        operation: {
+          opId: "authority-overrides-this",
+          entityId: payload.entityId as WriteOp["entityId"],
+          kind: "script_ingest",
+          payload: { writes }
+        },
+        decodedBytes: BigInt(writes.reduce((total, write) => total + Buffer.byteLength(write.body), 0))
+      };
+    }
+  };
+}
+
+export function executorDerivedFromPresetScript(command: ParsedCommand, executorAgentId: string): boolean {
+  const action = command.action;
+  if (action.kind === "preset-entrypoint") return executorAgentId === `preset:${action.presetId}`;
+  if (action.kind !== "script-run") return false;
+  const match = /^preset:([^:]+):/u.exec(action.scriptId);
+  return Boolean(match?.[1]) && executorAgentId === `preset:${match![1]}`;
+}
+
+function scriptTaskId(command: ParsedCommand): string {
+  const action = command.action;
+  if (action.kind !== "preset-entrypoint" && action.kind !== "script-run") {
+    throw new Error("AUTHORITY_SCRIPT_SCOPE_COMMAND_REQUIRED");
+  }
+  const taskId = action.taskId?.trim();
+  if (!taskId) throw new Error("AUTHORITY_SCRIPT_SCOPE_TASK_REQUIRED");
+  return taskId;
+}
+
+function scriptScopeWrites(payload: unknown, taskId: string, authoredRoot: string): ReadonlyArray<ScriptScopeWrite> {
+  if (!payload || typeof payload !== "object" || !Array.isArray((payload as { readonly writes?: unknown }).writes)) {
+    throw new Error("AUTHORITY_SCRIPT_SCOPE_PAYLOAD_INVALID");
+  }
+  const writes = (payload as { readonly writes: ReadonlyArray<unknown> }).writes.map((candidate) => {
+    if (!candidate || typeof candidate !== "object") throw new Error("AUTHORITY_SCRIPT_SCOPE_WRITE_INVALID");
+    const row = candidate as Partial<ScriptScopeWrite>;
+    if (typeof row.path !== "string" || typeof row.body !== "string"
+      || (row.baseBlobSha256 !== null && typeof row.baseBlobSha256 !== "string")) {
+      throw new Error("AUTHORITY_SCRIPT_SCOPE_WRITE_INVALID");
+    }
+    const normalized = normalizeRelativeDocumentPath(row.path);
+    const expectedPrefix = `tasks/${taskId}/artifacts/`;
+    if (!normalized.startsWith(expectedPrefix) || normalized.length === expectedPrefix.length) {
+      throw new Error(`AUTHORITY_SCRIPT_SCOPE_PATH_DENIED:${normalized}`);
+    }
+    const absolute = path.join(authoredRoot, normalized);
+    const currentHash = existsSync(absolute) ? sha256Text(readFileSync(absolute, "utf8")) : null;
+    if (currentHash !== row.baseBlobSha256) {
+      throw new Error(`AUTHORITY_SCRIPT_SCOPE_BASE_CAS_CONFLICT:${normalized}`);
+    }
+    return { path: normalized, body: row.body, baseBlobSha256: row.baseBlobSha256 };
+  });
+  if (writes.length === 0) throw new Error("AUTHORITY_SCRIPT_SCOPE_WRITES_REQUIRED");
+  if (new Set(writes.map((write) => write.path)).size !== writes.length) {
+    throw new Error("AUTHORITY_SCRIPT_SCOPE_DUPLICATE_PATH");
+  }
+  return writes;
+}
+
+function scriptScopeMutationPlan(taskId: string, writes: ReadonlyArray<ScriptScopeWrite>): RegistryMutationPlanInput {
+  const contexts = writes.map((write) => ({
+    packagePath: `tasks/${taskId}`,
+    documentPath: write.path.slice(`tasks/${taskId}/`.length)
+  }));
+  return {
+    registryVersion: 1,
+    mutations: [{
+      entityKind: "task",
+      identity: { taskId },
+      action: "document",
+      storageContext: contexts[0],
+      ...(contexts.length > 1 ? { additionalStorageContexts: contexts.slice(1) } : {})
+    }]
+  };
+}
+
+function assertScriptRunEntityId(entityId: string): void {
+  if (!/^entity\/script-run\/[a-f0-9]{32}$/u.test(entityId)) {
+    throw new Error("AUTHORITY_SCRIPT_SCOPE_ENTITY_INVALID");
+  }
+}
+
+function encodeScriptScopePayload(payload: ScriptScopePayload): Uint8Array {
+  return encodeCanonicalCbor({
+    schema: payload.schema,
+    entityId: payload.entityId,
+    taskId: payload.taskId,
+    writes: payload.writes.map((write) => ({ ...write }))
+  });
+}
+
+function decodeScriptScopeEnvelope(envelope: SemanticMutationEnvelopeV2): ScriptScopePayload {
+  if (envelope.intent.kind !== "typed" || envelope.intent.command.name !== commandName
+    || envelope.intent.canonicalPayload.kind !== "inline") {
+    throw new SemanticAdmissionErrorV2("SCRIPT_SCOPE_TYPED_COMMAND_REQUIRED");
+  }
+  const bytes = envelope.intent.canonicalPayload.bytes;
+  if (envelope.intent.canonicalPayload.size !== BigInt(bytes.byteLength)) {
+    throw new SemanticAdmissionErrorV2("REQUEST_SIZE_MISMATCH");
+  }
+  if (!Buffer.from(canonicalPayloadDigestV2(bytes)).equals(Buffer.from(envelope.intent.canonicalPayloadDigest))) {
+    throw new SemanticAdmissionErrorV2("REQUEST_DIGEST_MISMATCH");
+  }
+  const payload = decodeScriptScopePayload(decodeCanonicalCbor(bytes));
+  if (!Buffer.from(encodeScriptScopePayload(payload)).equals(Buffer.from(bytes))) {
+    throw new SemanticAdmissionErrorV2("TYPED_PAYLOAD_NON_CANONICAL");
+  }
+  return payload;
+}
+
+function decodeScriptScopePayload(value: CanonicalCborValue): ScriptScopePayload {
+  if (!value || typeof value !== "object" || Array.isArray(value) || value instanceof Uint8Array) {
+    throw new SemanticAdmissionErrorV2("SCRIPT_SCOPE_PAYLOAD_INVALID");
+  }
+  const row = value as Record<string, CanonicalCborValue>;
+  if (Object.keys(row).sort().join(",") !== "entityId,schema,taskId,writes"
+    || row.schema !== payloadSchema || typeof row.entityId !== "string" || typeof row.taskId !== "string"
+    || !Array.isArray(row.writes)) {
+    throw new SemanticAdmissionErrorV2("SCRIPT_SCOPE_PAYLOAD_INVALID");
+  }
+  const writes = row.writes.map((candidate) => {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate) || candidate instanceof Uint8Array) {
+      throw new SemanticAdmissionErrorV2("SCRIPT_SCOPE_WRITE_INVALID");
+    }
+    const write = candidate as Record<string, CanonicalCborValue>;
+    if (Object.keys(write).sort().join(",") !== "baseBlobSha256,body,path"
+      || typeof write.path !== "string" || typeof write.body !== "string"
+      || (write.baseBlobSha256 !== null && typeof write.baseBlobSha256 !== "string")) {
+      throw new SemanticAdmissionErrorV2("SCRIPT_SCOPE_WRITE_INVALID");
+    }
+    return { path: write.path, body: write.body, baseBlobSha256: write.baseBlobSha256 };
+  });
+  return { schema: payloadSchema, entityId: row.entityId, taskId: row.taskId, writes };
+}

--- a/packages/cli/src/daemon/production-authority-semantic-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-semantic-compiler.ts
@@ -1,0 +1,42 @@
+import {
+  consentTypedCommandsV2,
+  factRelationTypedCommandsV2,
+  makeCompositeAuthoritySemanticCompilerV2,
+  makeConsentSemanticCompilerV2,
+  makeFactRelationSemanticCompilerV2,
+  makeSessionExecutionReviewSemanticCompilerV2,
+  makeTaskDecisionModuleSemanticCompilerV2,
+  sessionExecutionReviewTypedCommandsV2,
+  taskDecisionModuleTypedCommandsV2
+} from "../../../application/src/index.ts";
+import { createProductionCanonicalSemanticState } from "./production-authority-attempt-compiler.ts";
+import { makeProductionScriptIngestSemanticCompiler } from "./production-authority-script-ingest.ts";
+
+export function createProductionAuthoritySemanticCompiler(authoredRoot: string) {
+  const semanticState = createProductionCanonicalSemanticState(authoredRoot);
+  return makeCompositeAuthoritySemanticCompilerV2([{
+    commandNames: ["script.scope-ingest"],
+    compiler: makeProductionScriptIngestSemanticCompiler(authoredRoot)
+  }, {
+    commandNames: taskDecisionModuleTypedCommandsV2,
+    compiler: makeTaskDecisionModuleSemanticCompilerV2({ state: semanticState })
+  }, {
+    commandNames: factRelationTypedCommandsV2.filter((command) => command.startsWith("fact.")),
+    compiler: makeFactRelationSemanticCompilerV2({ state: semanticState })
+  }, {
+    commandNames: factRelationTypedCommandsV2.filter((command) => command.startsWith("relation.")),
+    compiler: makeFactRelationSemanticCompilerV2({ state: semanticState })
+  }, {
+    commandNames: sessionExecutionReviewTypedCommandsV2.filter((command) => command.startsWith("session.")),
+    compiler: makeSessionExecutionReviewSemanticCompilerV2({ state: semanticState })
+  }, {
+    commandNames: sessionExecutionReviewTypedCommandsV2.filter((command) => command.startsWith("execution.")),
+    compiler: makeSessionExecutionReviewSemanticCompilerV2({ state: semanticState })
+  }, {
+    commandNames: sessionExecutionReviewTypedCommandsV2.filter((command) => command.startsWith("review.")),
+    compiler: makeSessionExecutionReviewSemanticCompilerV2({ state: semanticState })
+  }, {
+    commandNames: consentTypedCommandsV2,
+    compiler: makeConsentSemanticCompilerV2({ state: semanticState })
+  }]);
+}

--- a/packages/cli/test/preset-executor-attribution.test.ts
+++ b/packages/cli/test/preset-executor-attribution.test.ts
@@ -1,0 +1,31 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { daemonActorAttributionForParsedCommand } from "../src/composition/actor-attribution.ts";
+
+test("daemon derives preset ownership for a preset script-run id", () => {
+  const attribution = daemonActorAttributionForParsedCommand({
+    personId: "person_alice",
+    displayName: "Alice",
+    primaryEmail: "alice@example.test",
+    roles: ["writer"],
+    providerId: "forced-command",
+    resolvedCredential: {
+      kind: "ssh-forced-command-person",
+      issuer: "test",
+      subject: "person_alice"
+    }
+  }, {
+    rootDir: "/repo",
+    json: true,
+    action: {
+      kind: "script-run",
+      scriptId: "preset:usage-acceptance:scaffold",
+      taskId: "task_01TEST",
+      inputs: {},
+      dryRun: false
+    }
+  }, { kind: "agent", id: "client-self-report-must-be-ignored" });
+
+  assert.deepEqual(attribution.executor, { kind: "agent", id: "preset:usage-acceptance" });
+});

--- a/packages/cli/test/production-authority-canonical-ingress-direct.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress-direct.test.ts
@@ -1,0 +1,33 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { runRawJsonMaybeFail } from "./helpers/daemon-cli.ts";
+import {
+  createFixture,
+  installProductionArtifactPreset
+} from "./production-authority-canonical-ingress/fixture.ts";
+
+test("direct preset scaffold preserves its generated artifact bytes", () => {
+  const fixture = createFixture();
+  try {
+    installProductionArtifactPreset(fixture.repoRoot);
+    const result = runRawJsonMaybeFail(fixture.repoRoot, [
+      "preset", "action", "production-artifact-scaffold", "scaffold",
+      "--task", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "--allow-scripts"
+    ], {
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_ACTOR: "agent:harness-test",
+      HARNESS_GIT_AUTHOR_NAME: "Harness Test",
+      HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test"
+    });
+    assert.equal(result.status, 0, JSON.stringify(result.receipt));
+    assert.equal(readFileSync(path.join(
+      fixture.authoredRoot,
+      "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/artifacts/production-scaffold.md"
+    ), "utf8"), "# Production scaffold\n\nTask: task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4\n");
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -39,6 +39,7 @@ import {
   createFixture,
   enablePresetAwareTaskCreate,
   git,
+  installProductionArtifactPreset,
   latestAuthorityOperation,
   writeColdCodexSessionLog
 } from "./fixture.ts";
@@ -48,6 +49,7 @@ import { verifyDerivedFactSource } from "./fact-source-parity.ts";
 import { authorityOperationShape } from "./operation-shape.ts";
 import { verifyProductionCommandParity } from "./production-parity.ts";
 import { verifyTypedMinimalParameterMatrix } from "./minimal-parameter-matrix.ts";
+import { verifyProductionPresetIngress } from "./preset-ingress.ts";
 
 test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 240_000 }, async () => {
   const fixture = createFixture();
@@ -61,6 +63,7 @@ test("production service route preserves progress dry-run and publishes canonica
   };
   try {
     enablePresetAwareTaskCreate(fixture.authoredRoot);
+    installProductionArtifactPreset(fixture.repoRoot);
     for (const [repoId, canonicalRoot] of [
       ["canonical", fixture.repoRoot],
       ["auxiliary", fixture.auxiliaryRoot]
@@ -86,6 +89,8 @@ test("production service route preserves progress dry-run and publishes canonica
       { timeoutMs: 20_000 }
     );
     assert.equal(status.repoCount, 2, JSON.stringify(status));
+
+    verifyProductionPresetIngress(fixture, env);
 
     verifyTypedMinimalParameterMatrix(fixture, env);
     verifyProductionCommandParity(fixture, env);

--- a/packages/cli/test/production-authority-canonical-ingress/fixture.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/fixture.ts
@@ -189,6 +189,48 @@ export function enablePresetAwareTaskCreate(authoredRoot: string): void {
   git(authoredRoot, "commit", "-q", "-m", "configure preset-aware task create fixture");
 }
 
+export function installProductionArtifactPreset(repoRoot: string): void {
+  const presetRoot = path.join(repoRoot, ".harness/presets/production-artifact-scaffold");
+  mkdirSync(path.join(presetRoot, "scripts"), { recursive: true });
+  writeFileSync(path.join(presetRoot, "preset.json"), `${JSON.stringify({
+    schema: "preset-manifest/v3",
+    id: "production-artifact-scaffold",
+    title: "Production Artifact Scaffold",
+    vertical: "software/coding",
+    version: "1.0.0",
+    kind: "process-action",
+    kernelVersionRange: { min: "1.0.0", maxExclusive: "2.0.0" },
+    capabilityImports: [],
+    entrypoints: {
+      scaffold: {
+        type: "script",
+        command: "scripts/scaffold.mjs",
+        intent: { verb: "scaffold", subject: "production-artifact" },
+        inputs: { taskId: { type: "task-ref", required: true, defaultFrom: "current-task" } },
+        requires: [{ capability: "tasks", version: "1", select: { taskFrom: "taskId", view: "intent-summary" } }],
+        produces: [{
+          capability: "task-artifacts",
+          version: "1",
+          target: { taskFrom: "current-task" },
+          artifacts: [{ id: "production-scaffold", schema: "production-scaffold/v1", mediaTypes: ["text/markdown"], cardinality: "one", required: true }]
+        }],
+        sideEffects: []
+      }
+    },
+    defaultProfile: "baseline",
+    profiles: [{ id: "baseline", title: "Baseline", checkerProfile: "standard", completionGates: [], templateSelections: [] }]
+  }, null, 2)}\n`);
+  writeFileSync(path.join(presetRoot, "scripts/scaffold.mjs"), [
+    'import { readFileSync, writeFileSync } from "node:fs";',
+    'const context = JSON.parse(readFileSync(process.env.HARNESS_PRESET_CONTEXT, "utf8"));',
+    'const writer = context.capabilities.writes["task-artifacts"][0];',
+    'const output = writer.artifacts["production-scaffold"].representations[0].path;',
+    'writeFileSync(output, `# Production scaffold\\n\\nTask: ${context.run.taskId}\\n`, "utf8");',
+    'writeFileSync(context.result.path, JSON.stringify({ schema: "script-result/v1", ok: true, produced: ["production-scaffold"] }), "utf8");',
+    ''
+  ].join("\n"));
+}
+
 export function writeColdCodexSessionLog(repoRoot: string, sessionId: string): void {
   const logRoot = path.join(repoRoot, ".home", ".codex", "sessions", "2026", "07", "18");
   mkdirSync(logRoot, { recursive: true });
@@ -208,6 +250,7 @@ export function latestAuthorityOperation(serviceRoot: string): AuthorityStoredOp
 }
 
 export function authorityOperationRecords(serviceRoot: string): ReadonlyArray<{ readonly state?: string; readonly opId?: string }> {
+  if (!existsSync(operationPath(serviceRoot))) return [];
   const latest = new Map<string, { readonly state?: string; readonly opId?: string }>();
   for (const line of readFileSync(operationPath(serviceRoot), "utf8").trim().split("\n").filter(Boolean)) {
     const row = JSON.parse(line) as { readonly table?: string; readonly key?: string; readonly value?: { readonly state?: string; readonly opId?: string } };

--- a/packages/cli/test/production-authority-canonical-ingress/preset-ingress.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/preset-ingress.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { runRawJsonMaybeFail } from "../helpers/daemon-cli.ts";
+import {
+  authorityOperationRecords,
+  type ProductionCanonicalIngressFixture
+} from "./fixture.ts";
+
+export function verifyProductionPresetIngress(
+  fixture: ProductionCanonicalIngressFixture,
+  env: Readonly<Record<string, string>>
+): void {
+  const presetOperationCount = authorityOperationRecords(fixture.serviceRoot).length;
+  const presetEntrypoint = runRawJsonMaybeFail(fixture.repoRoot, [
+    "preset", "action", "production-artifact-scaffold", "scaffold",
+    "--task", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "--allow-scripts"
+  ], env);
+  assert.equal(presetEntrypoint.status, 0, JSON.stringify(presetEntrypoint.receipt));
+  assert.equal(presetEntrypoint.receipt.ok, true, JSON.stringify(presetEntrypoint.receipt));
+  assert.equal(authorityOperationRecords(fixture.serviceRoot).length, presetOperationCount + 1,
+    "one declared script ingest must remain one canonical authority operation");
+  assert.equal(existsSync(path.join(
+    fixture.authoredRoot,
+    "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/artifacts/production-scaffold.md"
+  )), true);
+
+  const scriptOperationCount = authorityOperationRecords(fixture.serviceRoot).length;
+  const scriptRun = runRawJsonMaybeFail(fixture.repoRoot, [
+    "script", "run", "preset:production-artifact-scaffold:scaffold",
+    "--task", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6"
+  ], env);
+  assert.equal(scriptRun.status, 0, JSON.stringify(scriptRun.receipt));
+  assert.equal(scriptRun.receipt.ok, true, JSON.stringify(scriptRun.receipt));
+  assert.equal(authorityOperationRecords(fixture.serviceRoot).length, scriptOperationCount + 1,
+    "script run must submit its declared artifact batch through one canonical operation");
+  assert.equal(readFileSync(path.join(
+    fixture.authoredRoot,
+    "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6/artifacts/production-scaffold.md"
+  ), "utf8"), "# Production scaffold\n\nTask: task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6\n");
+}

--- a/packages/cli/test/production-authority-script-ingest.test.ts
+++ b/packages/cli/test/production-authority-script-ingest.test.ts
@@ -1,0 +1,81 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { ParsedCommand } from "../src/cli/types.ts";
+import { productionScriptIngestAttemptIntent } from "../src/daemon/production-authority-script-ingest.ts";
+
+const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4";
+const command: ParsedCommand = {
+  rootDir: "/repo",
+  json: true,
+  action: {
+    kind: "preset-entrypoint",
+    presetId: "artifact-scaffold",
+    entrypointName: "scaffold",
+    entrypointType: "action",
+    taskId,
+    allowScripts: true,
+    inputs: {}
+  }
+};
+
+test("production script ingest admits one task-artifact batch as one semantic document mutation", () => {
+  const authoredRoot = mkdtempSync(path.join(tmpdir(), "ha-script-ingest-"));
+  try {
+    const intent = productionScriptIngestAttemptIntent(command, operation([
+      artifactWrite("report.md", "# Report\n"),
+      artifactWrite("data.json", "{}\n")
+    ]), authoredRoot);
+
+    assert.equal(intent.commandName, "script.scope-ingest");
+    assert.equal(intent.mutations.length, 1);
+    assert.equal(intent.mutations[0]?.entity.canonicalRef, `task/${taskId}`);
+    assert.equal(intent.mutations[0]?.action, "document");
+    assert.deepEqual(intent.portablePaths.sort(), [
+      `tasks/${taskId}/artifacts/data.json`,
+      `tasks/${taskId}/artifacts/report.md`
+    ]);
+  } finally {
+    rmSync(authoredRoot, { recursive: true, force: true });
+  }
+});
+
+test("production script ingest fails closed outside the bound task artifact scope and on stale CAS", () => {
+  const authoredRoot = mkdtempSync(path.join(tmpdir(), "ha-script-ingest-"));
+  try {
+    assert.throws(
+      () => productionScriptIngestAttemptIntent(command, operation([{
+        path: `tasks/${taskId}/INDEX.md`, body: "denied\n", baseBlobSha256: null
+      }]), authoredRoot),
+      /AUTHORITY_SCRIPT_SCOPE_PATH_DENIED/u
+    );
+
+    const artifactDir = path.join(authoredRoot, `tasks/${taskId}/artifacts`);
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(path.join(artifactDir, "report.md"), "current\n");
+    assert.throws(
+      () => productionScriptIngestAttemptIntent(command, operation([
+        artifactWrite("report.md", "replacement\n")
+      ]), authoredRoot),
+      /AUTHORITY_SCRIPT_SCOPE_BASE_CAS_CONFLICT/u
+    );
+  } finally {
+    rmSync(authoredRoot, { recursive: true, force: true });
+  }
+});
+
+function artifactWrite(name: string, body: string) {
+  return { path: `tasks/${taskId}/artifacts/${name}`, body, baseBlobSha256: null };
+}
+
+function operation(writes: ReadonlyArray<{ readonly path: string; readonly body: string; readonly baseBlobSha256: string | null }>) {
+  return {
+    opId: "script-test",
+    entityId: `entity/script-run/${"a".repeat(32)}`,
+    kind: "script_ingest" as const,
+    payload: { writes }
+  };
+}

--- a/packages/cli/test/receipt-contracts.test.ts
+++ b/packages/cli/test/receipt-contracts.test.ts
@@ -354,6 +354,10 @@ test("optional receipt contract fields carry non-empty absence reasons", () => {
     command: "script-run",
     field: "data.rows",
     reason: "Only emitted when a script writes a numeric rows value in its script-result/v1 payload."
+  }, {
+    command: "script-run",
+    field: "data.capabilityReceipt",
+    reason: "Only emitted by v3 semantic execution with its exact provider bindings."
   }].toSorted(byCommandAndField));
   assert.equal(optionalEntries.every((entry) => entry.reason.trim().length > 0), true);
 });

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -1208,6 +1208,8 @@
       },
       "entry": [
         "cli",
+        "daemon-rpc",
+        "production-authority",
         "preset-runner"
       ],
       "cliActions": [
@@ -1428,6 +1430,8 @@
       },
       "entry": [
         "cli",
+        "daemon-rpc",
+        "production-authority",
         "preset-runner"
       ],
       "writeKinds": [
@@ -1448,7 +1452,9 @@
       ],
       "evidence": [
         "packages/cli/src/commands/extensions/script-staging.ts:32",
-        "packages/cli/src/commands/core/extension.ts:10"
+        "packages/cli/src/commands/core/extension.ts:10",
+        "packages/cli/src/daemon/production-authority-script-ingest.ts:35",
+        "packages/cli/src/daemon/authority-command-submission.ts:227"
       ],
       "freshness": "staging-mirror-ingest"
     },


### PR DESCRIPTION
# English

## Summary

Preset entrypoints and preset-sourced scripts could not run against the production daemon: the coordinator submitted the facade command kind itself, and the attempt compiler rejected it with `AUTHORITY_TYPED_COMMAND_UNSUPPORTED` because `preset-entrypoint`/`script-run` are (correctly) excluded from typed ingress. Every preset script's production path was blocked; sessions were working around it by stopping the daemon and running direct+recovery. Per dec_01KXTVNPSM57P9MYS53YA2XQ2N this is fixed by routing the atomic `script_ingest` sub-operation through its own admitted sub-road — not by adding a composite compiler for the facade.

## What Changed

- New production sub-road `script.scope-ingest`: when the coordinator sees a single `script_ingest` operation it submits via `submitScriptIngest` instead of taking the facade kind into generic typed ingress.
- Admission recomputes and verifies every write server-side: path normalization, task binding, duplicate paths and base CAS are all rechecked; out-of-scope paths fail closed (`AUTHORITY_SCRIPT_SCOPE_PATH_DENIED`). Current production scope is task-bound `tasks/<taskId>/artifacts/**`, which is exactly what the v3 semantic preset runtime writes (`writerRoots = <outputRoot>/artifacts`).
- All companion writes from one script compile into a single task `document` mutation with additional storage contexts — one canonical operation, no op-splitting to bypass the single-operation constraint.
- Executor identity for preset entrypoints and preset-sourced scripts is derived daemon-side as `preset:<presetId>`; a client-declared executor is ignored.
- The ingress exclusion table is unchanged; only the atomic sub-road is registered with the production semantic compiler.

## Task And Scope

- Ledger task task_01KXTVPMV3BTSDQPJJCAXDA8ZT; decision dec_01KXTVNPSM57P9MYS53YA2XQ2N. Scope: daemon authority coordinator/submission plus the new sub-road; direct-mode runtime untouched.

## Version Impact

- No schema or wire-format change; a new atomic sub-road is admitted. No version bump.

## Governance Declaration

- Authorizing decision: dec_01KXTVNPSM57P9MYS53YA2XQ2N. Two write-road-registry rows were updated to describe the daemon/production authority entry points; no new mutating road was introduced and no registry exemption was added. No gates, allowlists, CI configuration, or protected surfaces were modified, and no fail-closed behaviour was relaxed. Break-glass: no.

## Verification

- RED control: before the change, the production fixture returned `authority_ingress_rejected` with `AUTHORITY_TYPED_COMMAND_UNSUPPORTED ... preset-entrypoint` (exit 1) — the defect was reproduced, not assumed.
- GREEN: six affected test files, 42/42 pass. Production fixture asserts preset-entrypoint and script-run each add exactly one authority operation and both canonical artifacts are readable.
- Fail-closed unit tests 2/2: out-of-scope `INDEX.md` and stale base CAS are both rejected while two artifacts still produce a single task/document mutation.
- Direct non-regression: the direct runtime, ScriptHost, staging and `scriptIngestOp` files carry zero changes; a direct integration test asserts the scaffold bytes exactly.
- write-road registry gate: 57 rows / 459 discovered surfaces, exit 0. Root `check:local` exit 0 (four file-length gates went red first and were resolved by splitting responsibilities, not by touching any gate).

## Review Evidence

- Implementation report tmp/orch/preset-ingress/REPORT-preset-ingress.md (moved into the task package at closeout). CEO verified the three hard constraints directly in the diff: ingress table zero-diff, direct runtime files zero-diff, single mutation with fail-closed throws.

## Residual Risk

- This stage admits task-bound artifacts only. Legacy or general scripts declaring authored scopes outside `tasks/<taskId>/artifacts/**` continue to be denied; opening ADRs, operating docs or cross-entity outputs needs an atomic sub-command or semantic capability provider for the corresponding canonical entity — deliberately not by widening this adapter into a raw composite compiler.
- Authority evidence integrity contracts, CI/gate surfaces and `harness/**` were not touched.

## References

- Decision dec_01KXTVNPSM57P9MYS53YA2XQ2N. Same typed-ingress surface as #908, #909, #913, #916; decomposition pattern from #914.

---

# 中文

## 概要

preset 入口与 preset 来源脚本在生产 daemon 路跑不通:coordinator 提交 facade 命令种类本身,attempt compiler 因 `preset-entrypoint`/`script-run` 被(正确地)排除在 typed ingress 外而报 `AUTHORITY_TYPED_COMMAND_UNSUPPORTED`。所有 preset 脚本的生产路被挡,各 session 只能停 daemon 走 direct+recovery 绕过。按 dec_01KXTVNPSM57P9MYS53YA2XQ2N,修法是把原子 `script_ingest` 子操作路由到它自己受准入的子路——而不是给 facade 加复合 compiler。

## 改动内容

- 新增生产子路 `script.scope-ingest`:coordinator 见到单个 `script_ingest` 操作时走 `submitScriptIngest`,不再把 facade 种类送进 generic typed ingress。
- 准入在服务端重算并复核每一笔写:路径规范化、task 绑定、重复 path、base CAS 全部重验;越界 fail-closed(`AUTHORITY_SCRIPT_SCOPE_PATH_DENIED`)。本阶段生产范围=task 绑定的 `tasks/<taskId>/artifacts/**`,正是 v3 语义 preset runtime 的真实写路(`writerRoots = <outputRoot>/artifacts`)。
- 同一次 script 的全部 companion writes 编译为**单个** task `document` mutation,其余文件走 additional storage contexts——一个 canonical operation,没有拆 op 绕单操作约束。
- preset 入口与 preset 来源脚本的 executor 由 daemon 侧解析为 `preset:<presetId>`,忽略客户端自报。
- ingress 排除表未改;只把原子子路注册进生产 semantic compiler。

## 任务与范围

- 台账 task_01KXTVPMV3BTSDQPJJCAXDA8ZT;决策 dec_01KXTVNPSM57P9MYS53YA2XQ2N。范围:daemon authority coordinator/submission + 新子路;direct 模式 runtime 零改动。

## 版本影响

- 无 schema/wire 格式变更;新增一条受准入的原子子路。无版本号变更。

## 治理声明

- 授权决策:dec_01KXTVNPSM57P9MYS53YA2XQ2N。write-road-registry 两行更新为描述 daemon/生产 authority 入口;未引入新 mutating road,未加任何 registry 豁免。未修改 gate、allowlist、CI 配置或受保护 surface,未放松任何 fail-closed。Break-glass:否。

## 验证

- 红对照:改前生产 fixture 返回 `authority_ingress_rejected`,hint 含 `AUTHORITY_TYPED_COMMAND_UNSUPPORTED ... preset-entrypoint`(exit 1)——缺陷是复现出来的,不是假设的。
- 绿:六个受影响测试文件 42/42 通过。生产 fixture 断言 preset-entrypoint 与 script-run 各自恰好 +1 authority operation,两条 canonical artifact 均可读。
- fail-closed 单测 2/2:越界 `INDEX.md` 与 stale base CAS 均被拒,双 artifact 仍只产生一个 task/document mutation。
- direct 不回归:direct runtime、ScriptHost、staging、`scriptIngestOp` 四类文件零改动;独立 direct 集成测试精确断言 scaffold 字节。
- write-road registry 门:57 rows / 459 surfaces,exit 0。根 `check:local` exit 0(首次四个文件行数门红,按职责拆分解决,未动任何 gate)。

## 审查证据

- 实现报告 tmp/orch/preset-ingress/REPORT-preset-ingress.md(收口移入任务包)。CEO 在 diff 中亲验三条硬约束:ingress 表零 diff、direct runtime 文件零 diff、单 mutation 且 fail-closed throw 齐备。

## 残余风险

- 本阶段只放通 task 绑定 artifacts。legacy/general script 若声明 `tasks/<taskId>/artifacts/**` 之外的 authored scope 继续被拒;要开放 ADR、operating docs 或跨实体输出,需为对应 canonical entity 设计原子子命令或语义能力 provider——刻意不把本适配器扩成 raw composite compiler。
- 未触碰 authority 证据完整性契约、CI/gate 面或 `harness/**`。

## 关联材料

- 决策 dec_01KXTVNPSM57P9MYS53YA2XQ2N。与 #908、#909、#913、#916 同 typed-ingress 面;分解模式承 #914。
