### PR TITLE
feat(cli): compile omitted production ingress commands

### DIFF
--- a/packages/application/src/authority/task-decision-module-command-v2.ts
+++ b/packages/application/src/authority/task-decision-module-command-v2.ts
@@ -13,16 +13,30 @@ import {
   semanticAdmissionV2,
   semanticStringValueV2
 } from "./semantic-authority-helpers-v2.ts";
+import {
+  taskDecisionModuleNonBlank,
+  taskDecisionModuleRegistryKey as registryKey,
+  taskDecisionModuleText,
+  taskDecisionModuleTextList as textList
+} from "./task-decision-module-payload-values-v2.ts";
 
 export const taskDecisionModuleTypedCommandsV2 = [
   "task.create",
   "task.transition",
   "task.append",
   "task.document",
+  "task.amend",
+  "task.archive",
+  "task.supersede",
+  "task.delete",
+  "task.reopen",
+  "task.relate",
   "decision.propose",
   "decision.state",
   "decision.amend",
   "decision.relation",
+  "decision.relation-retire",
+  "decision.relation-replace",
   "module.register",
   "module.unregister",
   "module.step"
@@ -62,6 +76,51 @@ export interface TaskDocumentPayloadV2 {
   readonly body: string;
 }
 
+export interface TaskAmendPayloadV2 {
+  readonly schema: "task.amend/v1";
+  readonly taskId: string;
+  readonly fields: ReadonlyArray<string>;
+  readonly body: string;
+}
+
+export interface TaskArchivePayloadV2 {
+  readonly schema: "task.archive/v1";
+  readonly taskId: string;
+  readonly reason: string;
+  readonly body: string;
+}
+
+export interface TaskSupersedePayloadV2 {
+  readonly schema: "task.supersede/v1";
+  readonly taskId: string;
+  readonly body?: string;
+  readonly replacementTaskId?: string;
+  readonly writes?: ReadonlyArray<{ readonly taskId: string; readonly path: string; readonly body: string; readonly packageSlug?: string }>;
+}
+
+export interface TaskDeletePayloadV2 {
+  readonly schema: "task.delete/v1";
+  readonly taskId: string;
+  readonly mode: "soft";
+  readonly reason: string;
+  readonly body: string;
+}
+
+export interface TaskReopenPayloadV2 {
+  readonly schema: "task.reopen/v1";
+  readonly taskId: string;
+  readonly reason: string;
+  readonly body: string;
+}
+
+export interface TaskRelatePayloadV2 {
+  readonly schema: "task.relate/v1";
+  readonly taskId: string;
+  readonly targetTaskId: string;
+  readonly relation: EntityRelationRecord;
+  readonly body: string;
+}
+
 export interface DecisionProposePayloadV2 {
   readonly schema: "decision.propose/v1";
   readonly decision: DecisionPackage;
@@ -88,6 +147,24 @@ export interface DecisionRelationPayloadV2 {
   readonly decisionId: string;
   readonly relation: EntityRelationRecord;
   readonly taskWrites?: ReadonlyArray<{ readonly taskId: string; readonly path: string; readonly body: string }>;
+}
+
+export interface DecisionRelationRetirePayloadV2 {
+  readonly schema: "decision.relation-retire/v1";
+  readonly decisionId: string;
+  readonly relationId: string;
+  readonly decision: DecisionPackage;
+  readonly body?: string;
+}
+
+export interface DecisionRelationReplacePayloadV2 {
+  readonly schema: "decision.relation-replace/v1";
+  readonly decisionId: string;
+  readonly relationId: string;
+  readonly replacement: EntityRelationRecord;
+  readonly decision: DecisionPackage;
+  readonly taskWrites?: ReadonlyArray<{ readonly taskId: string; readonly path: string; readonly body: string }>;
+  readonly body?: string;
 }
 
 export interface ModuleRecordV2 {
@@ -126,10 +203,18 @@ export type TaskDecisionModuleCommandPayloadV2 =
   | TaskTransitionPayloadV2
   | TaskAppendPayloadV2
   | TaskDocumentPayloadV2
+  | TaskAmendPayloadV2
+  | TaskArchivePayloadV2
+  | TaskSupersedePayloadV2
+  | TaskDeletePayloadV2
+  | TaskReopenPayloadV2
+  | TaskRelatePayloadV2
   | DecisionProposePayloadV2
   | DecisionStatePayloadV2
   | DecisionAmendPayloadV2
   | DecisionRelationPayloadV2
+  | DecisionRelationRetirePayloadV2
+  | DecisionRelationReplacePayloadV2
   | ModuleRegisterPayloadV2
   | ModuleUnregisterPayloadV2
   | ModuleStepPayloadV2;
@@ -199,6 +284,37 @@ function strictTaskDecisionModulePayload(value: unknown): TaskDecisionModuleComm
       const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "path", "body"]);
       return { schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), path: taskDecisionModuleText(row.path), body: semanticStringValueV2(row.body) };
     }
+    case "task.amend/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "fields", "body"]);
+      return { schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), fields: textList(row.fields, "TASK_AMEND_FIELDS_INVALID"), body: semanticStringValueV2(row.body) };
+    }
+    case "task.archive/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "reason", "body"]);
+      return { schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), reason: taskDecisionModuleNonBlank(row.reason), body: semanticStringValueV2(row.body) };
+    }
+    case "task.supersede/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "body", "replacementTaskId", "writes"], false, ["body", "replacementTaskId", "writes"]);
+      return {
+        schema: discriminator.schema,
+        taskId: taskDecisionModuleText(row.taskId),
+        ...(optionalString(row.body, "body")),
+        ...(row.replacementTaskId === undefined ? {} : { replacementTaskId: taskDecisionModuleText(row.replacementTaskId) }),
+        ...(row.writes === undefined ? {} : { writes: taskSupersedeWrites(row.writes) })
+      };
+    }
+    case "task.delete/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "mode", "reason", "body"]);
+      if (row.mode !== "soft") throw semanticAdmissionV2("TASK_HARD_DELETE_UNAVAILABLE");
+      return { schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), mode: "soft", reason: taskDecisionModuleNonBlank(row.reason), body: semanticStringValueV2(row.body) };
+    }
+    case "task.reopen/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "reason", "body"]);
+      return { schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), reason: taskDecisionModuleNonBlank(row.reason), body: semanticStringValueV2(row.body) };
+    }
+    case "task.relate/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "taskId", "targetTaskId", "relation", "body"]);
+      return { schema: discriminator.schema, taskId: taskDecisionModuleText(row.taskId), targetTaskId: taskDecisionModuleText(row.targetTaskId), relation: decodeRelationV2(row.relation), body: semanticStringValueV2(row.body) };
+    }
     case "decision.propose/v1": {
       const row = exactTaskDecisionModuleObject(value, ["schema", "decision", "body"], false, ["body"]);
       return { schema: discriminator.schema, decision: decision(row.decision), ...(optionalString(row.body, "body")) };
@@ -227,6 +343,22 @@ function strictTaskDecisionModulePayload(value: unknown): TaskDecisionModuleComm
         decisionId: taskDecisionModuleText(row.decisionId),
         relation: decodeRelationV2(row.relation),
         ...(row.taskWrites === undefined ? {} : { taskWrites: decisionRelationTaskWrites(row.taskWrites) })
+      };
+    }
+    case "decision.relation-retire/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "decisionId", "relationId", "decision", "body"], false, ["body"]);
+      return { schema: discriminator.schema, decisionId: taskDecisionModuleText(row.decisionId), relationId: taskDecisionModuleText(row.relationId), decision: decision(row.decision), ...(optionalString(row.body, "body")) };
+    }
+    case "decision.relation-replace/v1": {
+      const row = exactTaskDecisionModuleObject(value, ["schema", "decisionId", "relationId", "replacement", "decision", "taskWrites", "body"], false, ["taskWrites", "body"]);
+      return {
+        schema: discriminator.schema,
+        decisionId: taskDecisionModuleText(row.decisionId),
+        relationId: taskDecisionModuleText(row.relationId),
+        replacement: decodeRelationV2(row.replacement),
+        decision: decision(row.decision),
+        ...(row.taskWrites === undefined ? {} : { taskWrites: decisionRelationTaskWrites(row.taskWrites) }),
+        ...(optionalString(row.body, "body"))
       };
     }
     case "module.register/v1": {
@@ -269,6 +401,18 @@ function canonicalTaskDecisionModulePayloadWire(payload: TaskDecisionModuleComma
       return { schema: payload.schema, taskId: payload.taskId, text: payload.text };
     case "task.document/v1":
       return { schema: payload.schema, taskId: payload.taskId, path: payload.path, body: payload.body };
+    case "task.amend/v1":
+      return { schema: payload.schema, taskId: payload.taskId, fields: [...payload.fields], body: payload.body };
+    case "task.archive/v1":
+      return { schema: payload.schema, taskId: payload.taskId, reason: payload.reason, body: payload.body };
+    case "task.supersede/v1":
+      return { schema: payload.schema, taskId: payload.taskId, ...(payload.body === undefined ? {} : { body: payload.body }), ...(payload.replacementTaskId === undefined ? {} : { replacementTaskId: payload.replacementTaskId }), ...(payload.writes ? { writes: payload.writes.map((write) => ({ taskId: write.taskId, path: write.path, body: write.body, ...(write.packageSlug ? { packageSlug: write.packageSlug } : {}) })) } : {}) };
+    case "task.delete/v1":
+      return { schema: payload.schema, taskId: payload.taskId, mode: payload.mode, reason: payload.reason, body: payload.body };
+    case "task.reopen/v1":
+      return { schema: payload.schema, taskId: payload.taskId, reason: payload.reason, body: payload.body };
+    case "task.relate/v1":
+      return { schema: payload.schema, taskId: payload.taskId, targetTaskId: payload.targetTaskId, relation: relationWire(payload.relation), body: payload.body };
     case "decision.propose/v1":
       return { schema: payload.schema, decision: decisionWire(payload.decision), ...(payload.body === undefined ? {} : { body: payload.body }) };
     case "decision.state/v1":
@@ -280,6 +424,10 @@ function canonicalTaskDecisionModulePayloadWire(payload: TaskDecisionModuleComma
         schema: payload.schema, decisionId: payload.decisionId, relation: relationWire(payload.relation),
         ...(payload.taskWrites ? { taskWrites: payload.taskWrites.map((write) => ({ taskId: write.taskId, path: write.path, body: write.body })) } : {})
       };
+    case "decision.relation-retire/v1":
+      return { schema: payload.schema, decisionId: payload.decisionId, relationId: payload.relationId, decision: decisionWire(payload.decision), ...(payload.body === undefined ? {} : { body: payload.body }) };
+    case "decision.relation-replace/v1":
+      return { schema: payload.schema, decisionId: payload.decisionId, relationId: payload.relationId, replacement: relationWire(payload.replacement), decision: decisionWire(payload.decision), ...(payload.taskWrites ? { taskWrites: payload.taskWrites.map((write) => ({ taskId: write.taskId, path: write.path, body: write.body })) } : {}), ...(payload.body === undefined ? {} : { body: payload.body }) };
     case "module.register/v1":
       return { schema: payload.schema, module: moduleWire(payload.module) };
     case "module.unregister/v1":
@@ -306,6 +454,19 @@ function taskCreateWrites(value: unknown): NonNullable<TaskCreatePayloadV2["writ
   return value.map((entry) => {
     const row = exactTaskDecisionModuleObject(entry, ["path", "body", "packageSlug"], false, ["packageSlug"]);
     return {
+      path: taskDecisionModuleText(row.path),
+      body: semanticStringValueV2(row.body),
+      ...(row.packageSlug === undefined ? {} : { packageSlug: taskDecisionModuleText(row.packageSlug) })
+    };
+  });
+}
+
+function taskSupersedeWrites(value: unknown): NonNullable<TaskSupersedePayloadV2["writes"]> {
+  if (!Array.isArray(value) || value.length < 3) throw semanticAdmissionV2("TASK_SUPERSEDE_WRITES_INVALID");
+  return value.map((entry) => {
+    const row = exactTaskDecisionModuleObject(entry, ["taskId", "path", "body", "packageSlug"], false, ["packageSlug"]);
+    return {
+      taskId: taskDecisionModuleText(row.taskId),
       path: taskDecisionModuleText(row.path),
       body: semanticStringValueV2(row.body),
       ...(row.packageSlug === undefined ? {} : { packageSlug: taskDecisionModuleText(row.packageSlug) })
@@ -426,22 +587,4 @@ function taskDecisionModuleArray(value: unknown, name: string): ReadonlyArray<un
 
 function stringArray(value: unknown, name: string): ReadonlyArray<string> {
   return taskDecisionModuleArray(value, name).map(taskDecisionModuleText);
-}
-
-function taskDecisionModuleText(value: unknown): string {
-  const result = semanticStringValueV2(value);
-  if (!result || result.trim() !== result) throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
-  return result;
-}
-
-function taskDecisionModuleNonBlank(value: unknown): string {
-  const result = semanticStringValueV2(value);
-  if (!result.trim()) throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
-  return result;
-}
-
-function registryKey(value: unknown): string {
-  const result = taskDecisionModuleText(value);
-  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/u.test(result)) throw semanticAdmissionV2("MODULE_KEY_INVALID");
-  return result;
 }

--- a/packages/application/src/authority/task-decision-module-decision-mutations-v2.ts
+++ b/packages/application/src/authority/task-decision-module-decision-mutations-v2.ts
@@ -1,0 +1,202 @@
+import { Schema } from "effect";
+import {
+  DecisionPackageSchema,
+  computeDecisionContentDigest,
+  decisionContentCanonicalization,
+  decisionEntityId,
+  decisionFieldContracts,
+  deriveRelationId,
+  entityRegistry,
+  parseDecisionDocument,
+  readFrontmatter,
+  readScalar,
+  validateRelationRecordsForHost,
+  type DecisionPackage,
+  type EntityRelationRecord,
+  type RegistryMutationPlanInput,
+  type WriteOp
+} from "../../../kernel/src/index.ts";
+import type {
+  DecisionAmendPayloadV2,
+  DecisionRelationPayloadV2,
+  DecisionRelationReplacePayloadV2,
+  DecisionRelationRetirePayloadV2
+} from "./task-decision-module-command-v2.ts";
+import type {
+  CompiledTaskDecisionModuleCommandV2,
+  TaskDecisionModuleAuthorityStateV2
+} from "./task-decision-module-semantic-compiler-v2.ts";
+import type { HostedDocumentSnapshotV2 } from "./fact-relation-semantic-compiler-v2.ts";
+import type { RegistryEntityRefV2 } from "./semantic-mutation-envelope-v2.ts";
+import { semanticAdmissionV2 as admission, semanticMutationPlanV2 as plan } from "./semantic-authority-helpers-v2.ts";
+
+const registryVersion = 1;
+
+export async function compileDecisionAmendV2(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: DecisionAmendPayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const next = decodeIngressDecision(payload.decision);
+  const path = ingressDecisionPath(next.decision_id);
+  const snapshot = await requiredIngressDecisionDocument(state, path, "DECISION_DOCUMENT_NOT_FOUND");
+  const current = decodeIngressDecision(parseDecisionDocument(snapshot.body).decision);
+  if (current.decision_id !== next.decision_id) throw admission("DECISION_ID_MISMATCH");
+  const changed = changedFields(current, next);
+  if (changed.length === 0 || changed.some((field) => field !== "contentPins" && decisionFieldContracts[field].mutability !== "amendable")
+    || (changed.includes("contentPins") && !validContentPinAppend(current, next))) {
+    throw admission("DECISION_AMEND_FIELD_INVALID");
+  }
+  return {
+    mutationPlan: plan([{ entityKind: "decision", identity: { decisionId: next.decision_id }, action: "amend" }]),
+    operation: ingressDecisionOperation("decision_amend", next, payload.body, current),
+    requiredBaseRefs: [ingressDecisionRef("decision", `decision/${next.decision_id}`)],
+    requiredPathSnapshots: [{ path, snapshot }]
+  };
+}
+
+export async function compileDecisionRelationRetireV2(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: DecisionRelationRetirePayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const next = decodeIngressDecision(payload.decision);
+  const path = ingressDecisionPath(payload.decisionId);
+  const snapshot = await requiredIngressDecisionDocument(state, path, "DECISION_DOCUMENT_NOT_FOUND");
+  const current = decodeIngressDecision(parseDecisionDocument(snapshot.body).decision);
+  if (current.decision_id !== payload.decisionId || next.decision_id !== payload.decisionId) throw admission("DECISION_ID_MISMATCH");
+  const active = current.relations.find((relation) => relation.relation_id === payload.relationId);
+  if (!active || active.state !== "active") throw admission("RELATION_NOT_ACTIVE");
+  const relations = current.relations.map((relation) => relation.relation_id === payload.relationId ? { ...relation, state: "retired" as const } : relation);
+  if (JSON.stringify(next) !== JSON.stringify({ ...current, relations })) throw admission("RELATION_RETIRE_DECISION_MISMATCH");
+  return {
+    mutationPlan: plan([
+      { entityKind: "decision", identity: { decisionId: payload.decisionId }, action: "relation" },
+      { entityKind: "relation", identity: { relationId: payload.relationId }, action: "retire", storageContext: { sourceRef: active.source } }
+    ]),
+    operation: ingressDecisionOperation("relation_retire", next, payload.body, current),
+    requiredBaseRefs: [ingressDecisionRef("decision", `decision/${payload.decisionId}`), ingressDecisionRef("relation", `relation/${payload.relationId}`)],
+    requiredPathSnapshots: [{ path, snapshot }]
+  };
+}
+
+export async function compileDecisionRelationReplaceV2(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: DecisionRelationReplacePayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const next = decodeIngressDecision(payload.decision);
+  const path = ingressDecisionPath(payload.decisionId);
+  const snapshot = await requiredIngressDecisionDocument(state, path, "DECISION_DOCUMENT_NOT_FOUND");
+  const current = decodeIngressDecision(parseDecisionDocument(snapshot.body).decision);
+  if (current.decision_id !== payload.decisionId || next.decision_id !== payload.decisionId) throw admission("DECISION_ID_MISMATCH");
+  const active = current.relations.find((relation) => relation.relation_id === payload.relationId);
+  if (!active || active.state !== "active") throw admission("RELATION_NOT_ACTIVE");
+  const replacement = payload.replacement;
+  assertRelations(payload.decisionId, [replacement]);
+  const relations = [...current.relations.map((relation) => relation.relation_id === payload.relationId ? { ...relation, state: "retired" as const } : relation), replacement];
+  if (replacement.state !== "active" || JSON.stringify(next) !== JSON.stringify({ ...current, relations })) throw admission("RELATION_REPLACE_DECISION_MISMATCH");
+  const companion = await decisionRelationPriorityCompanionV2(state, current, replacement, payload.taskWrites ?? []);
+  return {
+    mutationPlan: plan([
+      { entityKind: "decision", identity: { decisionId: payload.decisionId }, action: "relation" },
+      { entityKind: "relation", identity: { relationId: payload.relationId }, action: "retire", storageContext: { sourceRef: active.source } },
+      relationCreate(replacement), ...companion.mutations
+    ]),
+    operation: {
+      ...ingressDecisionOperation("relation_replace", next, payload.body, current),
+      payload: { decision: next, writeMode: { kind: "snapshot", expectedWatermark: current._coordinatorWatermark ?? null }, ...(payload.body === undefined ? {} : { body: payload.body }), ...(payload.taskWrites?.length ? { taskWrites: payload.taskWrites } : {}) }
+    },
+    requiredBaseRefs: [ingressDecisionRef("decision", `decision/${payload.decisionId}`), ingressDecisionRef("relation", `relation/${payload.relationId}`), ingressDecisionRef("relation", `relation/${replacement.relation_id}`), ...companion.baseRefs],
+    requiredPathSnapshots: [{ path, snapshot }, ...companion.pathSnapshots]
+  };
+}
+
+export async function decisionRelationPriorityCompanionV2(
+  state: TaskDecisionModuleAuthorityStateV2,
+  decision: DecisionPackage,
+  relation: EntityRelationRecord,
+  taskWrites: NonNullable<DecisionRelationPayloadV2["taskWrites"]>
+): Promise<{
+  readonly mutations: RegistryMutationPlanInput["mutations"];
+  readonly baseRefs: ReadonlyArray<RegistryEntityRefV2>;
+  readonly pathSnapshots: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }>;
+}> {
+  const match = relation.state === "active" && relation.type === "derives" ? /^task\/([^/]+)$/u.exec(relation.target) : null;
+  if (!match) {
+    if (taskWrites.length > 0) throw admission("DECISION_RELATION_TASK_WRITES_FORBIDDEN");
+    return { mutations: [], baseRefs: [], pathSnapshots: [] };
+  }
+  const taskId = match[1]!;
+  const path = `tasks/${taskId}/INDEX.md`;
+  const snapshot = await requiredIngressDecisionDocument(state, path, "DECISION_RELATION_TASK_NOT_FOUND");
+  const expectedBody = seedTaskPriority(snapshot.body, decision);
+  if (expectedBody === null) {
+    if (taskWrites.length > 0) throw admission("DECISION_RELATION_TASK_WRITES_REDUNDANT");
+    return { mutations: [], baseRefs: [], pathSnapshots: [] };
+  }
+  if (taskWrites.length !== 1 || taskWrites[0]!.taskId !== taskId || taskWrites[0]!.path !== "INDEX.md" || taskWrites[0]!.body !== expectedBody) {
+    throw admission("DECISION_RELATION_TASK_WRITE_MISMATCH");
+  }
+  return {
+    mutations: [{ entityKind: "task", identity: { taskId }, action: "document", storageContext: { documentPath: "INDEX.md" } }],
+    baseRefs: [ingressDecisionRef("task", `task/${taskId}`)],
+    pathSnapshots: [{ path, snapshot }]
+  };
+}
+
+function decodeIngressDecision(value: unknown): DecisionPackage {
+  try { return Schema.decodeUnknownSync(DecisionPackageSchema)(value); } catch { throw admission("DECISION_PAYLOAD_INVALID"); }
+}
+
+function changedFields(current: DecisionPackage, next: DecisionPackage): ReadonlyArray<keyof DecisionPackage> {
+  return (Object.keys(decisionFieldContracts) as ReadonlyArray<keyof DecisionPackage>).filter((field) => JSON.stringify(current[field]) !== JSON.stringify(next[field]));
+}
+
+function validContentPinAppend(current: DecisionPackage, next: DecisionPackage): boolean {
+  const previous = current.contentPins ?? [];
+  const pins = next.contentPins ?? [];
+  const pin = pins.at(-1);
+  return pins.length === previous.length + 1 && JSON.stringify(pins.slice(0, -1)) === JSON.stringify(previous) && Boolean(pin
+    && pin.action === "amend" && pin.state === next.state && pin.canonicalization === decisionContentCanonicalization
+    && pin.digest === computeDecisionContentDigest(next));
+}
+
+function assertRelations(decisionId: string, relations: ReadonlyArray<EntityRelationRecord>): void {
+  for (const relation of relations) if (deriveRelationId(relation) !== relation.relation_id) throw admission("RELATION_ID_MISMATCH");
+  const issues = validateRelationRecordsForHost(`decision/${decisionId}`, relations);
+  if (issues.length > 0) throw admission(`RELATION_DOMAIN_INVALID:${issues[0]!.code}`);
+}
+
+function relationCreate(relation: EntityRelationRecord): RegistryMutationPlanInput["mutations"][number] {
+  return { entityKind: "relation", identity: { relationId: relation.relation_id }, action: "create", storageContext: { sourceRef: relation.source } };
+}
+
+function seedTaskPriority(body: string, decision: DecisionPackage): string | null {
+  const frontmatter = readFrontmatter(body);
+  if (!frontmatter) throw admission("DECISION_RELATION_TASK_FRONTMATTER_INVALID");
+  const additions = [...(readScalar(frontmatter, "riskTier") ? [] : [`riskTier: ${decision.riskTier}`]), ...(readScalar(frontmatter, "urgency") ? [] : [`urgency: ${decision.urgency}`])];
+  if (additions.length === 0) return null;
+  const next = frontmatter.replace(/^packageDisposition:[^\n]*(?:\n|$)/mu, (line) => `${line.endsWith("\n") ? line : `${line}\n`}${additions.join("\n")}\n`);
+  if (next === frontmatter) throw admission("DECISION_RELATION_TASK_FRONTMATTER_INVALID");
+  return body.replace(`---\n${frontmatter}\n---`, `---\n${next}\n---`);
+}
+
+function ingressDecisionOperation(kind: WriteOp["kind"], decision: DecisionPackage, body?: string, current?: DecisionPackage): WriteOp {
+  return { opId: "authority-overrides-this", entityId: decisionEntityId(decision.decision_id), kind, payload: { decision, ...(body === undefined ? {} : { body }), writeMode: { kind: "snapshot", expectedWatermark: current?._coordinatorWatermark ?? null } } };
+}
+
+async function requiredIngressDecisionDocument(state: TaskDecisionModuleAuthorityStateV2, path: string, code: string): Promise<HostedDocumentSnapshotV2> {
+  const snapshot = await state.readHostedDocument(path);
+  if (!snapshot) throw admission(code);
+  return snapshot;
+}
+
+function ingressDecisionPath(decisionId: string): string {
+  const locator = entityRegistry.decision.storageLocator;
+  if (locator.status !== "ready") throw admission("REGISTRY_FACET_NOT_WRITABLE");
+  const target = locator.locator.locate({ decisionId }, {}).targets[0];
+  if (!target?.path) throw admission("DECISION_STORAGE_TARGET_REQUIRED");
+  return target.path;
+}
+
+function ingressDecisionRef(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
+  return { registryVersion, entityKind, canonicalRef };
+}

--- a/packages/application/src/authority/task-decision-module-module-mutations-v2.ts
+++ b/packages/application/src/authority/task-decision-module-module-mutations-v2.ts
@@ -1,0 +1,95 @@
+import { moduleEntityId } from "../../../kernel/src/index.ts";
+import type { ModuleRecordV2, ModuleRegisterPayloadV2, ModuleStepPayloadV2, ModuleUnregisterPayloadV2 } from "./task-decision-module-command-v2.ts";
+import type { CompiledTaskDecisionModuleCommandV2, TaskDecisionModuleAuthorityStateV2 } from "./task-decision-module-semantic-compiler-v2.ts";
+import type { HostedDocumentSnapshotV2 } from "./fact-relation-semantic-compiler-v2.ts";
+import type { RegistryEntityRefV2 } from "./semantic-mutation-envelope-v2.ts";
+import { semanticAdmissionV2 as admission, semanticMutationPlanV2 as plan } from "./semantic-authority-helpers-v2.ts";
+
+interface ModuleRegistryV2 {
+  readonly schema: "module-registry/v1";
+  readonly modules: ReadonlyArray<ModuleRecordV2>;
+}
+
+export async function compileModuleRegisterV2(state: TaskDecisionModuleAuthorityStateV2, payload: ModuleRegisterPayloadV2): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const { registry, snapshot } = await moduleRegistry(state);
+  const modules = registry.modules.some((entry) => entry.key === payload.module.key)
+    ? registry.modules.map((entry) => entry.key === payload.module.key ? payload.module : entry)
+    : [...registry.modules, payload.module];
+  return moduleCompilation(payload.module.key, "register", { schema: "module-registry/v1", modules }, snapshot);
+}
+
+export async function compileModuleUnregisterV2(state: TaskDecisionModuleAuthorityStateV2, payload: ModuleUnregisterPayloadV2): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const { registry, snapshot } = await moduleRegistry(state);
+  if (!snapshot) throw admission("MODULE_REGISTRY_NOT_FOUND");
+  const current = registry.modules.find((entry) => entry.key === payload.moduleKey);
+  if (!current || current.status === "unregistered") throw admission("MODULE_NOT_FOUND");
+  return moduleCompilation(payload.moduleKey, "unregister", {
+    schema: "module-registry/v1",
+    modules: registry.modules.map((entry) => entry.key === payload.moduleKey ? { ...entry, status: "unregistered" } : entry)
+  }, snapshot);
+}
+
+export async function compileModuleStepV2(state: TaskDecisionModuleAuthorityStateV2, payload: ModuleStepPayloadV2): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const { registry, snapshot } = await moduleRegistry(state);
+  if (!snapshot) throw admission("MODULE_REGISTRY_NOT_FOUND");
+  const current = registry.modules.find((entry) => entry.key === payload.moduleKey);
+  if (!current || current.status === "unregistered") throw admission("MODULE_NOT_FOUND");
+  const step = { id: payload.stepId, state: payload.state };
+  const steps = current.steps.some((entry) => entry.id === payload.stepId)
+    ? current.steps.map((entry) => entry.id === payload.stepId ? step : entry)
+    : [...current.steps, step];
+  return moduleCompilation(payload.moduleKey, "step", {
+    schema: "module-registry/v1",
+    modules: registry.modules.map((entry) => entry.key === payload.moduleKey ? { ...entry, steps } : entry)
+  }, snapshot);
+}
+
+function moduleCompilation(moduleKey: string, action: "register" | "unregister" | "step", registry: ModuleRegistryV2, snapshot: HostedDocumentSnapshotV2 | null): CompiledTaskDecisionModuleCommandV2 {
+  return {
+    mutationPlan: plan([{ entityKind: "module", identity: { moduleKey }, action }]),
+    operation: { opId: "authority-overrides-this", entityId: moduleEntityId(moduleKey), kind: "module_registry_write", payload: { operation: action, registry } },
+    requiredBaseRefs: [moduleMutationRef("module", `module/${encodeURIComponent(moduleKey)}`)],
+    requiredPathSnapshots: snapshot ? [{ path: "modules.json", snapshot }] : []
+  };
+}
+
+async function moduleRegistry(state: TaskDecisionModuleAuthorityStateV2): Promise<{ readonly registry: ModuleRegistryV2; readonly snapshot: HostedDocumentSnapshotV2 | null }> {
+  const snapshot = await state.readHostedDocument("modules.json");
+  if (!snapshot) return { registry: { schema: "module-registry/v1", modules: [] }, snapshot: null };
+  let value: unknown;
+  try { value = JSON.parse(snapshot.body); } catch { throw admission("MODULE_REGISTRY_INVALID"); }
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw admission("MODULE_REGISTRY_INVALID");
+  const row = value as { readonly schema?: unknown; readonly modules?: unknown };
+  if (row.schema !== "module-registry/v1" || !Array.isArray(row.modules)) throw admission("MODULE_REGISTRY_INVALID");
+  const modules = row.modules.map(decodeModuleRecord);
+  if (new Set(modules.map((entry) => entry.key)).size !== modules.length) throw admission("MODULE_REGISTRY_DUPLICATE_KEY");
+  return { registry: { schema: "module-registry/v1", modules }, snapshot };
+}
+
+function decodeModuleRecord(value: unknown): ModuleRecordV2 {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw admission("MODULE_REGISTRY_INVALID");
+  const row = value as Record<string, unknown>;
+  if (typeof row.key !== "string" || typeof row.title !== "string" || typeof row.status !== "string" || !Array.isArray(row.scopes) || !Array.isArray(row.steps)) throw admission("MODULE_REGISTRY_INVALID");
+  const optional = (key: string): string | undefined => row[key] === undefined ? undefined : typeof row[key] === "string" ? row[key] : invalidModuleRegistry();
+  const stringArray = (key: string): ReadonlyArray<string> | undefined => row[key] === undefined ? undefined
+    : Array.isArray(row[key]) && row[key].every((entry) => typeof entry === "string") ? row[key] as ReadonlyArray<string> : invalidModuleRegistry();
+  const steps = row.steps.map((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) throw admission("MODULE_REGISTRY_INVALID");
+    const step = entry as Record<string, unknown>;
+    if (typeof step.id !== "string" || typeof step.state !== "string") throw admission("MODULE_REGISTRY_INVALID");
+    return { id: step.id, state: step.state };
+  });
+  return {
+    key: row.key, title: row.title,
+    ...(optional("prefix") === undefined ? {} : { prefix: optional("prefix")! }), status: row.status,
+    ...(optional("branch") === undefined ? {} : { branch: optional("branch")! }),
+    ...(optional("owner") === undefined ? {} : { owner: optional("owner")! }),
+    ...(optional("currentStep") === undefined ? {} : { currentStep: optional("currentStep")! }),
+    scopes: row.scopes as ReadonlyArray<string>,
+    ...(stringArray("shared") === undefined ? {} : { shared: stringArray("shared")! }),
+    ...(stringArray("dependsOn") === undefined ? {} : { dependsOn: stringArray("dependsOn")! }), steps
+  };
+}
+
+function invalidModuleRegistry(): never { throw admission("MODULE_REGISTRY_INVALID"); }
+function moduleMutationRef(entityKind: string, canonicalRef: string): RegistryEntityRefV2 { return { registryVersion: 1, entityKind, canonicalRef }; }

--- a/packages/application/src/authority/task-decision-module-payload-values-v2.ts
+++ b/packages/application/src/authority/task-decision-module-payload-values-v2.ts
@@ -1,0 +1,26 @@
+import { semanticAdmissionV2, semanticStringValueV2 } from "./semantic-authority-helpers-v2.ts";
+
+export function taskDecisionModuleText(value: unknown): string {
+  const result = semanticStringValueV2(value);
+  if (!result || result.trim() !== result) throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
+  return result;
+}
+
+export function taskDecisionModuleNonBlank(value: unknown): string {
+  const result = semanticStringValueV2(value);
+  if (!result.trim()) throw semanticAdmissionV2("TYPED_PAYLOAD_INVALID");
+  return result;
+}
+
+export function taskDecisionModuleTextList(value: unknown, code: string): ReadonlyArray<string> {
+  if (!Array.isArray(value)) throw semanticAdmissionV2(code);
+  const values = value.map(taskDecisionModuleText);
+  if (values.length === 0 || new Set(values).size !== values.length) throw semanticAdmissionV2(code);
+  return values;
+}
+
+export function taskDecisionModuleRegistryKey(value: unknown): string {
+  const result = taskDecisionModuleText(value);
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/u.test(result)) throw semanticAdmissionV2("MODULE_KEY_INVALID");
+  return result;
+}

--- a/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
@@ -7,10 +7,12 @@ import {
   entityRegistry,
   explainDecisionStateTransition,
   explainStatusTransition,
+  formatRelationFlowRecord,
   isDomainStatus,
-  moduleEntityId,
+  isPackageDisposition,
   normalizeRelativeDocumentPath,
   parseDecisionDocument,
+  parseRelationFlowRecords,
   readFrontmatter,
   readScalar,
   taskEntityId,
@@ -25,18 +27,19 @@ import {
 import { Schema } from "effect";
 import {
   decodeTaskDecisionModuleCommandPayloadV2,
-  type DecisionAmendPayloadV2,
   type DecisionProposePayloadV2,
   type DecisionRelationPayloadV2,
   type DecisionStatePayloadV2,
-  type ModuleRecordV2,
-  type ModuleRegisterPayloadV2,
-  type ModuleStepPayloadV2,
-  type ModuleUnregisterPayloadV2,
   type TaskAppendPayloadV2,
+  type TaskAmendPayloadV2,
+  type TaskArchivePayloadV2,
   type TaskCreatePayloadV2,
   type TaskDecisionModuleCommandPayloadV2,
   type TaskDocumentPayloadV2,
+  type TaskDeletePayloadV2,
+  type TaskRelatePayloadV2,
+  type TaskReopenPayloadV2,
+  type TaskSupersedePayloadV2,
   type TaskTransitionPayloadV2
 } from "./task-decision-module-command-v2.ts";
 import {
@@ -53,6 +56,17 @@ import type {
   HostedDocumentSnapshotV2,
   SemanticEntityBaseV2
 } from "./fact-relation-semantic-compiler-v2.ts";
+import {
+  compileDecisionAmendV2,
+  compileDecisionRelationReplaceV2,
+  compileDecisionRelationRetireV2,
+  decisionRelationPriorityCompanionV2
+} from "./task-decision-module-decision-mutations-v2.ts";
+import {
+  compileModuleRegisterV2,
+  compileModuleStepV2,
+  compileModuleUnregisterV2
+} from "./task-decision-module-module-mutations-v2.ts";
 
 export {
   encodeTaskDecisionModuleCommandPayloadV2,
@@ -60,6 +74,8 @@ export {
   type DecisionAmendPayloadV2,
   type DecisionProposePayloadV2,
   type DecisionRelationPayloadV2,
+  type DecisionRelationReplacePayloadV2,
+  type DecisionRelationRetirePayloadV2,
   type DecisionStatePayloadV2,
   type DecisionStateTransitionV2,
   type ModuleRecordV2,
@@ -67,10 +83,16 @@ export {
   type ModuleStepPayloadV2,
   type ModuleUnregisterPayloadV2,
   type TaskAppendPayloadV2,
+  type TaskAmendPayloadV2,
+  type TaskArchivePayloadV2,
   type TaskCreatePayloadV2,
   type TaskDecisionModuleCommandPayloadV2,
   type TaskDecisionModuleTypedCommandV2,
   type TaskDocumentPayloadV2,
+  type TaskDeletePayloadV2,
+  type TaskRelatePayloadV2,
+  type TaskReopenPayloadV2,
+  type TaskSupersedePayloadV2,
   type TaskTransitionPayloadV2
 } from "./task-decision-module-command-v2.ts";
 
@@ -83,16 +105,11 @@ export interface TaskDecisionModuleSemanticCompilerV2Options {
   readonly state: TaskDecisionModuleAuthorityStateV2;
 }
 
-interface CompiledTaskDecisionModuleCommandV2 {
+export interface CompiledTaskDecisionModuleCommandV2 {
   readonly mutationPlan: RegistryMutationPlanInput;
   readonly operation: WriteOp;
   readonly requiredBaseRefs: ReadonlyArray<RegistryEntityRefV2>;
   readonly requiredPathSnapshots: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }>;
-}
-
-interface ModuleRegistryV2 {
-  readonly schema: "module-registry/v1";
-  readonly modules: ReadonlyArray<ModuleRecordV2>;
 }
 
 const registryVersion = 1;
@@ -120,13 +137,21 @@ async function compileTaskDecisionModulePayload(
     case "task.transition/v1": return compileTaskTransition(state, payload);
     case "task.append/v1": return compileTaskAppend(payload);
     case "task.document/v1": return compileTaskDocument(state, payload);
+    case "task.amend/v1": return compileTaskAmend(state, payload);
+    case "task.archive/v1": return compileTaskDisposition(state, payload, "archived", "package_archive");
+    case "task.supersede/v1": return compileTaskSupersede(state, payload);
+    case "task.delete/v1": return compileTaskDisposition(state, payload, "tombstoned", "package_tombstone");
+    case "task.reopen/v1": return compileTaskDisposition(state, payload, "active", "package_reopen");
+    case "task.relate/v1": return compileTaskRelate(state, payload);
     case "decision.propose/v1": return compileDecisionPropose(payload);
     case "decision.state/v1": return compileDecisionState(state, payload);
-    case "decision.amend/v1": return compileDecisionAmend(state, payload);
+    case "decision.amend/v1": return compileDecisionAmendV2(state, payload);
     case "decision.relation/v1": return compileDecisionRelation(state, payload);
-    case "module.register/v1": return compileModuleRegister(state, payload);
-    case "module.unregister/v1": return compileModuleUnregister(state, payload);
-    case "module.step/v1": return compileModuleStep(state, payload);
+    case "decision.relation-retire/v1": return compileDecisionRelationRetireV2(state, payload);
+    case "decision.relation-replace/v1": return compileDecisionRelationReplaceV2(state, payload);
+    case "module.register/v1": return compileModuleRegisterV2(state, payload);
+    case "module.unregister/v1": return compileModuleUnregisterV2(state, payload);
+    case "module.step/v1": return compileModuleStepV2(state, payload);
   }
 }
 
@@ -188,6 +213,118 @@ async function compileTaskDocument(
     path: documentPath,
     body: payload.body
   }, [taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)], snapshot ? [{ path, snapshot }] : []);
+}
+
+async function compileTaskAmend(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: TaskAmendPayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const path = taskPath(payload.taskId, "INDEX.md");
+  const snapshot = await requiredTaskDecisionModuleDocument(state, path, "TASK_INDEX_NOT_FOUND");
+  const current = parseTaskIndex(snapshot.body);
+  const next = parseTaskIndex(payload.body);
+  if (current.taskId !== payload.taskId || next.taskId !== payload.taskId) throw admission("TASK_ID_MISMATCH");
+  const coreFields = new Set(["schema", "task_id", "title", "parent", "lifecycle", "packageDisposition", "workKind", "riskTier", "urgency", "vertical", "preset", "provenance", "profile"]);
+  if (payload.fields.some((field) => coreFields.has(field) || !/^[A-Za-z][A-Za-z0-9_]*$/u.test(field))) {
+    throw admission("TASK_AMEND_FIELD_INVALID");
+  }
+  if (stripTaskAmendFields(snapshot.body, payload.fields) !== stripTaskAmendFields(payload.body, payload.fields)
+    || payload.fields.some((field) => !new RegExp(`^${escapeRegExp(field)}:`, "mu").test(readFrontmatter(payload.body) ?? ""))) {
+    throw admission("TASK_AMEND_BODY_MISMATCH");
+  }
+  return taskCompilation(payload.taskId, "document", "doc_write", { path: "INDEX.md", body: payload.body }, [
+    taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)
+  ], [{ path, snapshot }]);
+}
+
+async function compileTaskDisposition(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: TaskArchivePayloadV2 | TaskDeletePayloadV2 | TaskReopenPayloadV2,
+  disposition: "active" | "archived" | "tombstoned",
+  kind: "package_archive" | "package_tombstone" | "package_reopen"
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const path = taskPath(payload.taskId, "INDEX.md");
+  const snapshot = await requiredTaskDecisionModuleDocument(state, path, "TASK_INDEX_NOT_FOUND");
+  const current = parseTaskIndex(snapshot.body);
+  const next = parseTaskIndex(payload.body);
+  if (current.taskId !== payload.taskId || next.taskId !== payload.taskId) throw admission("TASK_ID_MISMATCH");
+  if (next.packageDisposition !== disposition || !sameTaskLifecycleCore(current, next)) {
+    throw admission("TASK_DISPOSITION_BODY_INVALID");
+  }
+  if (!payload.body.includes(payload.reason)) throw admission("TASK_DISPOSITION_REASON_REQUIRED");
+  return taskCompilation(payload.taskId, "document", kind, { path: "INDEX.md", body: payload.body }, [
+    taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)
+  ], [{ path, snapshot }]);
+}
+
+async function compileTaskSupersede(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: TaskSupersedePayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  if (payload.body !== undefined) {
+    if (!payload.replacementTaskId || payload.writes) throw admission("TASK_SUPERSEDE_PAYLOAD_INVALID");
+    const compiled = await compileTaskDisposition(state, {
+      schema: "task.archive/v1", taskId: payload.taskId, reason: `supersededBy=${payload.replacementTaskId}`, body: payload.body
+    }, "archived", "package_archive");
+    const replacementPath = taskPath(payload.replacementTaskId, "INDEX.md");
+    const replacementSnapshot = await requiredTaskDecisionModuleDocument(state, replacementPath, "TASK_SUPERSEDE_TARGET_NOT_FOUND");
+    return {
+      ...compiled,
+      requiredBaseRefs: [...compiled.requiredBaseRefs, taskDecisionModuleEntityRef("task", `task/${payload.replacementTaskId}`)],
+      requiredPathSnapshots: [...compiled.requiredPathSnapshots, { path: replacementPath, snapshot: replacementSnapshot }]
+    };
+  }
+  if (!payload.replacementTaskId || !payload.writes) throw admission("TASK_SUPERSEDE_PAYLOAD_INVALID");
+  const oldPath = taskPath(payload.taskId, "INDEX.md");
+  const oldSnapshot = await requiredTaskDecisionModuleDocument(state, oldPath, "TASK_INDEX_NOT_FOUND");
+  const oldWrite = payload.writes.find((write) => write.taskId === payload.taskId && write.path === "INDEX.md");
+  const newWrite = payload.writes.find((write) => write.taskId === payload.replacementTaskId && write.path === "INDEX.md");
+  const relationWrite = payload.writes.find((write) => write.taskId === payload.replacementTaskId && write.path === "relations.md");
+  if (!oldWrite || !newWrite || !relationWrite || parseTaskIndex(oldWrite.body).packageDisposition !== "archived"
+    || parseTaskIndex(newWrite.body).status !== "planned"
+    || !relationWrite.body.includes(`task/${payload.replacementTaskId} supersedes task/${payload.taskId}`)) {
+    throw admission("TASK_SUPERSEDE_WRITES_INVALID");
+  }
+  return {
+    mutationPlan: taskDecisionModulePlan([
+      { entityKind: "task", identity: { taskId: payload.taskId }, action: "document", storageContext: { documentPath: "INDEX.md" } },
+      { entityKind: "task", identity: { taskId: payload.replacementTaskId }, action: "create" }
+    ]),
+    operation: { opId: "authority-overrides-this", entityId: taskEntityId(payload.taskId), kind: "package_supersede", payload: { writes: payload.writes } },
+    requiredBaseRefs: [taskDecisionModuleEntityRef("task", `task/${payload.taskId}`), taskDecisionModuleEntityRef("task", `task/${payload.replacementTaskId}`)],
+    requiredPathSnapshots: [{ path: oldPath, snapshot: oldSnapshot }]
+  };
+}
+
+async function compileTaskRelate(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: TaskRelatePayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const relation = payload.relation;
+  if (relation.source !== `task/${payload.taskId}` || relation.target !== `task/${payload.targetTaskId}`
+    || relation.type !== "depends-on" || relation.state !== "active" || deriveRelationId(relation) !== relation.relation_id) {
+    throw admission("TASK_RELATION_INVALID");
+  }
+  const issues = validateRelationRecordsForHost(`task/${payload.taskId}`, [relation]);
+  if (issues.length > 0) throw admission(`TASK_RELATION_INVALID:${issues[0]!.code}`);
+  const path = taskPath(payload.taskId, "INDEX.md");
+  const targetPath = taskPath(payload.targetTaskId, "INDEX.md");
+  const snapshot = await requiredTaskDecisionModuleDocument(state, path, "TASK_INDEX_NOT_FOUND");
+  const targetSnapshot = await requiredTaskDecisionModuleDocument(state, targetPath, "TASK_RELATION_TARGET_NOT_FOUND");
+  if (appendTaskRelation(snapshot.body, relation) !== payload.body) throw admission("TASK_RELATION_BODY_MISMATCH");
+  return {
+    mutationPlan: taskDecisionModulePlan([
+      { entityKind: "task", identity: { taskId: payload.taskId }, action: "document", storageContext: { documentPath: "INDEX.md" } },
+      relationCreateIntent(relation)
+    ]),
+    operation: { opId: "authority-overrides-this", entityId: taskEntityId(payload.taskId), kind: "doc_write", payload: { path: "INDEX.md", body: payload.body } },
+    requiredBaseRefs: [
+      taskDecisionModuleEntityRef("task", `task/${payload.taskId}`),
+      taskDecisionModuleEntityRef("task", `task/${payload.targetTaskId}`),
+      taskDecisionModuleEntityRef("relation", `relation/${relation.relation_id}`)
+    ],
+    requiredPathSnapshots: [{ path, snapshot }, { path: targetPath, snapshot: targetSnapshot }]
+  };
 }
 
 function taskCompilation(
@@ -256,28 +393,7 @@ async function compileDecisionState(
   };
 }
 
-async function compileDecisionAmend(
-  state: TaskDecisionModuleAuthorityStateV2,
-  payload: DecisionAmendPayloadV2
-): Promise<CompiledTaskDecisionModuleCommandV2> {
-  const next = decodeTaskDecisionModuleDecision(payload.decision);
-  const path = decisionPath(next.decision_id);
-  const snapshot = await requiredTaskDecisionModuleDocument(state, path, "DECISION_DOCUMENT_NOT_FOUND");
-  const current = decodeTaskDecisionModuleDecision(parseDecisionDocument(snapshot.body).decision);
-  assertSameDecision(current, next);
-  const changed = changedDecisionFields(current, next);
-  if (changed.length === 0 || changed.some((field) => decisionFieldContracts[field].mutability !== "amendable")) {
-    throw admission("DECISION_AMEND_FIELD_INVALID");
-  }
-  return {
-    mutationPlan: taskDecisionModulePlan([{ entityKind: "decision", identity: { decisionId: next.decision_id }, action: decisionSemanticMutationActions.amend }]),
-    operation: decisionOperation("decision_amend", next, payload.body, current),
-    requiredBaseRefs: [taskDecisionModuleEntityRef("decision", `decision/${next.decision_id}`)],
-    requiredPathSnapshots: [{ path, snapshot }]
-  };
-}
-
-async function compileDecisionRelation(
+ async function compileDecisionRelation(
   state: TaskDecisionModuleAuthorityStateV2,
   payload: DecisionRelationPayloadV2
 ): Promise<CompiledTaskDecisionModuleCommandV2> {
@@ -290,7 +406,7 @@ async function compileDecisionRelation(
   if (current.decision_id !== payload.decisionId) throw admission("DECISION_ID_MISMATCH");
   if (current.relations.some((entry) => entry.relation_id === relation.relation_id)) throw admission("RELATION_ALREADY_EXISTS");
   const next = { ...current, relations: [...current.relations, relation] };
-  const companion = await decisionRelationPriorityCompanion(state, current, relation, payload.taskWrites ?? []);
+  const companion = await decisionRelationPriorityCompanionV2(state, current, relation, payload.taskWrites ?? []);
   return {
     mutationPlan: taskDecisionModulePlan([
       { entityKind: "decision", identity: { decisionId: payload.decisionId }, action: "relation" },
@@ -314,53 +430,7 @@ async function compileDecisionRelation(
   };
 }
 
-async function decisionRelationPriorityCompanion(
-  state: TaskDecisionModuleAuthorityStateV2,
-  decision: DecisionPackage,
-  relation: EntityRelationRecord,
-  taskWrites: NonNullable<DecisionRelationPayloadV2["taskWrites"]>
-): Promise<{
-  readonly mutations: RegistryMutationPlanInput["mutations"];
-  readonly baseRefs: ReadonlyArray<RegistryEntityRefV2>;
-  readonly pathSnapshots: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }>;
-}> {
-  const match = relation.state === "active" && relation.type === "derives" ? /^task\/([^/]+)$/u.exec(relation.target) : null;
-  if (!match) {
-    if (taskWrites.length > 0) throw admission("DECISION_RELATION_TASK_WRITES_FORBIDDEN");
-    return { mutations: [], baseRefs: [], pathSnapshots: [] };
-  }
-  const taskId = match[1]!;
-  const path = taskPath(taskId, "INDEX.md");
-  const snapshot = await requiredTaskDecisionModuleDocument(state, path, "DECISION_RELATION_TASK_NOT_FOUND");
-  const expectedBody = seedTaskPriority(snapshot.body, decision);
-  if (expectedBody === null) {
-    if (taskWrites.length > 0) throw admission("DECISION_RELATION_TASK_WRITES_REDUNDANT");
-    return { mutations: [], baseRefs: [], pathSnapshots: [] };
-  }
-  if (taskWrites.length !== 1 || taskWrites[0]!.taskId !== taskId || taskWrites[0]!.path !== "INDEX.md" || taskWrites[0]!.body !== expectedBody) {
-    throw admission("DECISION_RELATION_TASK_WRITE_MISMATCH");
-  }
-  return {
-    mutations: [{ entityKind: "task", identity: { taskId }, action: "document", storageContext: { documentPath: "INDEX.md" } }],
-    baseRefs: [taskDecisionModuleEntityRef("task", `task/${taskId}`)],
-    pathSnapshots: [{ path, snapshot }]
-  };
-}
-
-function seedTaskPriority(body: string, decision: DecisionPackage): string | null {
-  const frontmatter = readFrontmatter(body);
-  if (!frontmatter) throw admission("DECISION_RELATION_TASK_FRONTMATTER_INVALID");
-  const additions = [
-    ...(readScalar(frontmatter, "riskTier") ? [] : [`riskTier: ${decision.riskTier}`]),
-    ...(readScalar(frontmatter, "urgency") ? [] : [`urgency: ${decision.urgency}`])
-  ];
-  if (additions.length === 0) return null;
-  const nextFrontmatter = frontmatter.replace(/^packageDisposition:[^\n]*(?:\n|$)/mu, (line) => `${line.endsWith("\n") ? line : `${line}\n`}${additions.join("\n")}\n`);
-  if (nextFrontmatter === frontmatter) throw admission("DECISION_RELATION_TASK_FRONTMATTER_INVALID");
-  return body.replace(`---\n${frontmatter}\n---`, `---\n${nextFrontmatter}\n---`);
-}
-
-function decisionOperation(
+ function decisionOperation(
   kind: WriteOpKind,
   decision: DecisionPackage,
   body?: string,
@@ -378,123 +448,14 @@ function decisionOperation(
   };
 }
 
-async function compileModuleRegister(
-  state: TaskDecisionModuleAuthorityStateV2,
-  payload: ModuleRegisterPayloadV2
-): Promise<CompiledTaskDecisionModuleCommandV2> {
-  const { registry, snapshot } = await moduleRegistry(state);
-  const modules = registry.modules.some((entry) => entry.key === payload.module.key)
-    ? registry.modules.map((entry) => entry.key === payload.module.key ? payload.module : entry)
-    : [...registry.modules, payload.module];
-  return moduleCompilation(payload.module.key, "register", { schema: "module-registry/v1", modules }, snapshot);
+ interface ParsedTaskIndexV2 {
+  readonly taskId: string;
+  readonly status: DomainStatus;
+  readonly packageDisposition: "active" | "archived" | "tombstoned";
+  readonly core: Readonly<Record<string, string>>;
 }
 
-async function compileModuleUnregister(
-  state: TaskDecisionModuleAuthorityStateV2,
-  payload: ModuleUnregisterPayloadV2
-): Promise<CompiledTaskDecisionModuleCommandV2> {
-  const { registry, snapshot } = await moduleRegistry(state);
-  if (!snapshot) throw admission("MODULE_REGISTRY_NOT_FOUND");
-  const current = registry.modules.find((entry) => entry.key === payload.moduleKey);
-  if (!current || current.status === "unregistered") throw admission("MODULE_NOT_FOUND");
-  return moduleCompilation(payload.moduleKey, "unregister", {
-    schema: "module-registry/v1",
-    modules: registry.modules.map((entry) => entry.key === payload.moduleKey ? { ...entry, status: "unregistered" } : entry)
-  }, snapshot);
-}
-
-async function compileModuleStep(
-  state: TaskDecisionModuleAuthorityStateV2,
-  payload: ModuleStepPayloadV2
-): Promise<CompiledTaskDecisionModuleCommandV2> {
-  const { registry, snapshot } = await moduleRegistry(state);
-  if (!snapshot) throw admission("MODULE_REGISTRY_NOT_FOUND");
-  const current = registry.modules.find((entry) => entry.key === payload.moduleKey);
-  if (!current || current.status === "unregistered") throw admission("MODULE_NOT_FOUND");
-  const step = { id: payload.stepId, state: payload.state };
-  const steps = current.steps.some((entry) => entry.id === payload.stepId)
-    ? current.steps.map((entry) => entry.id === payload.stepId ? step : entry)
-    : [...current.steps, step];
-  return moduleCompilation(payload.moduleKey, "step", {
-    schema: "module-registry/v1",
-    modules: registry.modules.map((entry) => entry.key === payload.moduleKey ? { ...entry, steps } : entry)
-  }, snapshot);
-}
-
-function moduleCompilation(
-  moduleKey: string,
-  action: "register" | "unregister" | "step",
-  registry: ModuleRegistryV2,
-  snapshot: HostedDocumentSnapshotV2 | null
-): CompiledTaskDecisionModuleCommandV2 {
-  return {
-    mutationPlan: taskDecisionModulePlan([{ entityKind: "module", identity: { moduleKey }, action }]),
-    operation: {
-      opId: "authority-overrides-this",
-      entityId: moduleEntityId(moduleKey),
-      kind: "module_registry_write",
-      payload: { operation: action, registry }
-    },
-    requiredBaseRefs: [taskDecisionModuleEntityRef("module", `module/${encodeURIComponent(moduleKey)}`)],
-    requiredPathSnapshots: snapshot ? [{ path: "modules.json", snapshot }] : []
-  };
-}
-
-async function moduleRegistry(state: TaskDecisionModuleAuthorityStateV2): Promise<{
-  readonly registry: ModuleRegistryV2;
-  readonly snapshot: HostedDocumentSnapshotV2 | null;
-}> {
-  const snapshot = await state.readHostedDocument("modules.json");
-  if (!snapshot) return { registry: { schema: "module-registry/v1", modules: [] }, snapshot: null };
-  let value: unknown;
-  try {
-    value = JSON.parse(snapshot.body);
-  } catch {
-    throw admission("MODULE_REGISTRY_INVALID");
-  }
-  if (!value || typeof value !== "object" || Array.isArray(value)) throw admission("MODULE_REGISTRY_INVALID");
-  const row = value as { readonly schema?: unknown; readonly modules?: unknown };
-  if (row.schema !== "module-registry/v1" || !Array.isArray(row.modules)) throw admission("MODULE_REGISTRY_INVALID");
-  const modules = row.modules.map(decodeModuleRecord);
-  if (new Set(modules.map((entry) => entry.key)).size !== modules.length) throw admission("MODULE_REGISTRY_DUPLICATE_KEY");
-  return { registry: { schema: "module-registry/v1", modules }, snapshot };
-}
-
-function decodeModuleRecord(value: unknown): ModuleRecordV2 {
-  if (!value || typeof value !== "object" || Array.isArray(value)) throw admission("MODULE_REGISTRY_INVALID");
-  const row = value as Record<string, unknown>;
-  if (typeof row.key !== "string" || typeof row.title !== "string" || typeof row.status !== "string"
-    || !Array.isArray(row.scopes) || !Array.isArray(row.steps)) throw admission("MODULE_REGISTRY_INVALID");
-  const optional = (key: string): string | undefined => row[key] === undefined
-    ? undefined
-    : typeof row[key] === "string" ? row[key] : (() => { throw admission("MODULE_REGISTRY_INVALID"); })();
-  const stringArray = (key: string): ReadonlyArray<string> | undefined => row[key] === undefined
-    ? undefined
-    : Array.isArray(row[key]) && row[key].every((entry) => typeof entry === "string")
-      ? row[key] as ReadonlyArray<string>
-      : (() => { throw admission("MODULE_REGISTRY_INVALID"); })();
-  const steps = row.steps.map((entry) => {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) throw admission("MODULE_REGISTRY_INVALID");
-    const step = entry as Record<string, unknown>;
-    if (typeof step.id !== "string" || typeof step.state !== "string") throw admission("MODULE_REGISTRY_INVALID");
-    return { id: step.id, state: step.state };
-  });
-  return {
-    key: row.key,
-    title: row.title,
-    ...(optional("prefix") === undefined ? {} : { prefix: optional("prefix")! }),
-    status: row.status,
-    ...(optional("branch") === undefined ? {} : { branch: optional("branch")! }),
-    ...(optional("owner") === undefined ? {} : { owner: optional("owner")! }),
-    ...(optional("currentStep") === undefined ? {} : { currentStep: optional("currentStep")! }),
-    scopes: row.scopes as ReadonlyArray<string>,
-    ...(stringArray("shared") === undefined ? {} : { shared: stringArray("shared")! }),
-    ...(stringArray("dependsOn") === undefined ? {} : { dependsOn: stringArray("dependsOn")! }),
-    steps
-  };
-}
-
-function parseTaskIndex(body: string): { readonly taskId: string; readonly status: string } {
+function parseTaskIndex(body: string): ParsedTaskIndexV2 {
   const frontmatter = readFrontmatter(body);
   if (!frontmatter || readScalar(frontmatter, "schema", { required: true }) !== "task-package/v2") {
     throw admission("TASK_INDEX_INVALID");
@@ -502,7 +463,45 @@ function parseTaskIndex(body: string): { readonly taskId: string; readonly statu
   const taskId = readScalar(frontmatter, "task_id", { required: true });
   const status = readScalar(frontmatter, "  status", { required: true });
   if (!isDomainStatus(status)) throw admission("TASK_INDEX_INVALID");
-  return { taskId, status };
+  const packageDisposition = readScalar(frontmatter, "packageDisposition", { required: true });
+  if (!isPackageDisposition(packageDisposition)) throw admission("TASK_INDEX_INVALID");
+  const keys = [
+    "schema", "task_id", "title", "parent", "  bindingSchema", "  engine", "  status", "  ref",
+    "  titleSnapshot", "  url", "  bindingCreatedAt", "  bindingFingerprint", "packageDisposition",
+    "workKind", "riskTier", "urgency", "vertical", "preset", "profile"
+  ];
+  return {
+    taskId,
+    status,
+    packageDisposition,
+    core: Object.fromEntries(keys.map((key) => [key, readScalar(frontmatter, key)]))
+  };
+}
+
+function sameTaskLifecycleCore(current: ParsedTaskIndexV2, next: ParsedTaskIndexV2): boolean {
+  return Object.entries(current.core).every(([key, value]) => key === "packageDisposition" || next.core[key] === value);
+}
+
+function stripTaskAmendFields(body: string, fields: ReadonlyArray<string>): string {
+  const frontmatter = readFrontmatter(body);
+  if (!frontmatter) throw admission("TASK_INDEX_INVALID");
+  const stripped = fields.reduce((current, field) => current.replace(new RegExp(`^${escapeRegExp(field)}:[^\\r\\n]*(?:\\r?\\n|$)`, "gmu"), ""), frontmatter);
+  return body.replace(frontmatter, stripped);
+}
+
+function appendTaskRelation(body: string, relation: EntityRelationRecord): string {
+  if (body.includes(`relation_id: ${relation.relation_id}`)) return body;
+  const frontmatter = readFrontmatter(body);
+  if (!frontmatter) throw admission("TASK_INDEX_INVALID");
+  const line = formatRelationFlowRecord(relation);
+  const nextFrontmatter = parseRelationFlowRecords(frontmatter).length > 0 || /^relations:\s*$/mu.test(frontmatter)
+    ? frontmatter.replace(/^(relations:\s*\n(?:\s*-\s*\{[^\n]*\}\n?)*)/mu, (block) => `${block.endsWith("\n") ? block : `${block}\n`}${line}\n`)
+    : `${frontmatter}\nrelations:\n${line}`;
+  return body.replace(`---\n${frontmatter}\n---`, `---\n${nextFrontmatter}\n---`);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function replaceTaskStatus(body: string, status: string): string {

--- a/packages/cli/src/cli/command-deprecations.ts
+++ b/packages/cli/src/cli/command-deprecations.ts
@@ -29,8 +29,6 @@ const aliasGrammarDeprecations = [
   alias("distill-commit", "distill commit --task <task-id>", "ha distill promote --task <task-id>", "distill", "commit"),
   alias("runtime-event-append", "runtime-event append", "ha event append", "runtime-event", "append"),
   alias("runtime-event-list", "runtime-event list", "ha event list", "runtime-event", "list"),
-  alias("lesson-promote", "lesson-promote <task-id> <candidate-id>", "ha lesson promote <task-id> <candidate-id>", "lesson-promote"),
-  alias("lesson-sediment", "lesson-sediment <task-id> <candidate-id>", "ha lesson sediment <task-id> <candidate-id>", "lesson-sediment"),
   alias("migrate-plan", "migrate-plan", "ha migrate plan", "migrate-plan"),
   alias("migrate-structure", "migrate-structure", "ha migrate structure", "migrate-structure"),
   alias("migrate-anchors", "migrate-anchors", "ha migrate anchors", "migrate-anchors"),

--- a/packages/cli/src/cli/command-spec/command-groups.ts
+++ b/packages/cli/src/cli/command-spec/command-groups.ts
@@ -35,7 +35,6 @@ export const commandGroups = [
   group("help", "Show CLI discovery help."),
   group("init", "Initialize a harness workspace."),
   group("legacy", "Intake legacy harness content."),
-  group("lesson", "Promote and sediment lessons."),
   group("materializer", "Merge session ledger branches."),
   group("migrate", "Run compatibility migrations."),
   group("module", "Manage project modules."),

--- a/packages/cli/src/cli/command-spec/command-spec-core.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-core.ts
@@ -335,9 +335,9 @@ export const coreCommandSpecs = defineCommandSpecs([
   },
   {
     "kind": "task-delete",
-    "usage": "task delete (--soft <id> | --hard <id> --confirm <id>) --reason <reason> [--deleted-by <actor>]",
-    "options": [{"flag":"--soft","description":"Soft-delete the selected task."},{"flag":"--hard","description":"Hard-delete the selected task."},{"flag":"--confirm","description":"Confirm a destructive or relation-changing action."},{"flag":"--reason","description":"Record the reason for the lifecycle change."},{"flag":"--deleted-by","description":"Record the actor deleting or superseding the task."}],
-    "summary": "Soft-delete or guarded hard-delete a task package. E79 makes hard delete rare: anchored facts or incoming relations block it; use task archive after distilling evidence into an anchor task.",
+    "usage": "task delete --soft <id> --reason <reason> [--deleted-by <actor>] (production); local-only compatibility: --hard <id> --confirm <id>",
+    "options": [{"flag":"--soft","description":"Soft-delete the selected task through the production typed write path."},{"flag":"--hard","description":"Local-only compatibility mode; production does not offer hard delete. Distill evidence, then use task archive or task supersede."},{"flag":"--confirm","description":"Confirm a local-only hard delete; this does not enable hard delete in production."},{"flag":"--reason","description":"Record the reason for the lifecycle change."},{"flag":"--deleted-by","description":"Record the actor deleting or superseding the task."}],
+    "summary": "Soft-delete a task package. Production does not offer hard delete; after distilling evidence, use task archive or task supersede instead.",
     "examples": ["harness-anything task delete --soft task_01ABC --reason \"duplicate\""],
     "parse": parseCoreTaskArgs,
     "run": runTaskLifecycleCommand,

--- a/packages/cli/src/cli/command-spec/command-spec-runtime-docs.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-runtime-docs.ts
@@ -259,43 +259,5 @@ export const runtimeDocsCommandSpecs = defineCommandSpecs([
       "conflictMarkerPreflight": true,
       "runtimeEvent": "deferred"
     }
-  },
-  {
-    "kind": "lesson-promote",
-    "usage": "lesson promote <task-id> <candidate-id> [--dry-run|--apply] [--json]",
-    "options": [{"flag":"--dry-run","description":"Preview the operation without writing changes."},{"flag":"--apply","description":"Apply the operation instead of planning it."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
-    "aliases": ["lesson-promote <task-id> <candidate-id> (deprecated, use lesson promote; retires at E77/F6 acceptance)"],
-    "aliasDisplay": {"lesson-promote <task-id> <candidate-id> (deprecated, use lesson promote; retires at E77/F6 acceptance)":"hidden"},
-    "summary": "Promote a lesson candidate from a completed task.",
-    "examples": ["harness-anything lesson promote task_01ABC candidate-1 --apply"],
-    "parse": parseStatusCheckArgs,
-    "run": runGovernanceCommand,
-    "receiptContract": {
-      "data": ["taskId", "mode", "generated", "report"],
-      "paths": []
-    },
-    "eventPolicy": {
-      "conflictMarkerPreflight": true,
-      "runtimeEvent": "deferred"
-    }
-  },
-  {
-    "kind": "lesson-sediment",
-    "usage": "lesson sediment <task-id> <candidate-id> [--dry-run] [--title <title>] [--json]",
-    "options": [{"flag":"--dry-run","description":"Preview the operation without writing changes."},{"flag":"--title","description":"Set the required task title used for generated package metadata and slug."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
-    "aliases": ["lesson-sediment <task-id> <candidate-id> (deprecated, use lesson sediment; retires at E77/F6 acceptance)"],
-    "aliasDisplay": {"lesson-sediment <task-id> <candidate-id> (deprecated, use lesson sediment; retires at E77/F6 acceptance)":"hidden"},
-    "summary": "Record a dry-run sedimentation result for a lesson candidate.",
-    "examples": ["harness-anything lesson sediment task_01ABC candidate-1 --title \"CLI help lesson\""],
-    "parse": parseStatusCheckArgs,
-    "run": runGovernanceCommand,
-    "receiptContract": {
-      "data": ["taskId", "mode", "generated", "report"],
-      "paths": []
-    },
-    "eventPolicy": {
-      "conflictMarkerPreflight": true,
-      "runtimeEvent": "deferred"
-    }
   }
 ]);

--- a/packages/cli/src/cli/command-spec/production-authority-ingress.ts
+++ b/packages/cli/src/cli/command-spec/production-authority-ingress.ts
@@ -3,12 +3,16 @@ import type { CommandSpecDefinition } from "./types.ts";
 export const productionAuthorityIngressDecisionRef =
   "decision/dec_01KXSWKWTEXB751A30TRRCQWDG" as const;
 
-export type ProductionAuthorityIngressAdapter = "generic" | "decision-transition" | "task-claim";
+export type ProductionAuthorityIngressAdapter = "generic" | "decision-transition" | "task-claim" | "observed-write";
 
 export type ProductionAuthorityIngressDisposition =
   | {
       readonly status: "typed-v2";
       readonly adapter: ProductionAuthorityIngressAdapter;
+      readonly excludedVariants?: Readonly<Record<string, {
+        readonly decisionRef: typeof productionAuthorityIngressDecisionRef;
+        readonly reason: string;
+      }>>;
     }
   | {
       readonly status: "excluded";
@@ -20,10 +24,10 @@ export type CommandSpecWithProductionAuthorityIngress<Spec extends CommandSpecDe
   readonly productionAuthorityIngress?: ProductionAuthorityIngressDisposition;
 };
 
-const typed = (adapter: ProductionAuthorityIngressAdapter): ProductionAuthorityIngressDisposition => ({
-  status: "typed-v2",
-  adapter
-});
+const typed = (
+  adapter: ProductionAuthorityIngressAdapter,
+  excludedVariants?: Readonly<Record<string, { readonly decisionRef: typeof productionAuthorityIngressDecisionRef; readonly reason: string }>>
+): ProductionAuthorityIngressDisposition => ({ status: "typed-v2", adapter, ...(excludedVariants ? { excludedVariants } : {}) });
 
 const excluded = (reason: string): ProductionAuthorityIngressDisposition => ({
   status: "excluded",
@@ -51,19 +55,24 @@ const dispositions = {
   "init": excluded("repository bootstrap writes precede production authority attachment"),
   "task-release": excluded("lease release mutates daemon-private holder state in the operational domain"),
   "task-submit": excluded("CLI facade decomposes into separately admitted task-code-doc-reconcile and status-set commands; a raw composite daemon action is rejected"),
-  "task-amend": excluded("task extension amendment has no production typed semantic compiler"),
+  "task-amend": typed("observed-write"),
   "task-contract-migrate": excluded("task contract migration is an explicit local migration write road"),
-  "task-archive": excluded("task archival has no production typed semantic compiler"),
-  "task-supersede": excluded("task supersession has no production typed semantic compiler"),
-  "task-delete": excluded("task deletion has no production typed semantic compiler"),
-  "task-reopen": excluded("task reopen has no production typed semantic compiler"),
+  "task-archive": typed("observed-write"),
+  "task-supersede": typed("observed-write"),
+  "task-delete": typed("observed-write", {
+    hard: {
+      decisionRef: productionAuthorityIngressDecisionRef,
+      reason: "production path does not offer hard delete; use task archive or task supersede after distilling evidence"
+    }
+  }),
+  "task-reopen": typed("observed-write"),
   "task-review": excluded("legacy task review is superseded by typed execution review"),
-  "task-relate": excluded("task-hosted relation writes have no production typed semantic compiler"),
+  "task-relate": typed("observed-write"),
   "decision-repin": excluded("decision repin is restricted to the migration write road"),
-  "decision-amend": excluded("decision amendment has no production typed semantic compiler"),
+  "decision-amend": typed("observed-write"),
   "decision-reckon": excluded("decision reckoning is a local derived-write workflow"),
-  "decision-relation-retire": excluded("relation retirement has no production typed semantic compiler"),
-  "decision-relation-replace": excluded("relation replacement has no production typed semantic compiler"),
+  "decision-relation-retire": typed("observed-write"),
+  "decision-relation-replace": typed("observed-write"),
   "distill-candidate": excluded("distillation candidates use the local derived-memory write road"),
   "distill-commit": excluded("distillation commit uses the local derived-memory write road"),
   "runtime-event-append": excluded("runtime events use the operational flush domain"),
@@ -71,8 +80,6 @@ const dispositions = {
   "session-backfill": excluded("session backfill is an explicit migration workflow"),
   "session-sync": excluded("session sync has no production command adapter despite a typed semantic vocabulary"),
   "governance-rebuild": excluded("governance rebuild is an explicit local derived-write workflow"),
-  "lesson-promote": excluded("lesson promotion has no production typed semantic compiler"),
-  "lesson-sediment": excluded("lesson sedimentation has no production typed semantic compiler"),
   "adopt-multica": excluded("multi-CA adoption is an explicit migration workflow"),
   "migrate-structure": excluded("structure migration uses the migration write road"),
   "migrate-anchors": excluded("anchor migration uses the migration write road"),
@@ -92,8 +99,8 @@ const dispositions = {
   "preset-entrypoint": excluded("preset entrypoints delegate to separately admitted command write roads"),
   "script-run": excluded("script execution uses declared script scopes rather than canonical typed ingress"),
   "module-scaffold": excluded("module scaffolding writes local source and template assets"),
-  "module-unregister": excluded("module removal has no production typed semantic compiler"),
-  "module-step": excluded("module step mutation has no production typed semantic compiler"),
+  "module-unregister": typed("generic"),
+  "module-step": typed("generic"),
   "gui": excluded("GUI launch is daemon orchestration and does not author a canonical entity")
 } as const satisfies Readonly<Record<string, ProductionAuthorityIngressDisposition>>;
 
@@ -132,6 +139,13 @@ export function assertProductionAuthorityIngressCompleteness(
     }
     if (disposition?.status === "excluded" && (!disposition.reason.trim() || !/^decision\/dec_[A-Z0-9]+$/u.test(disposition.decisionRef))) {
       errors.push(`${spec.kind}: excluded ingress requires a reason and decision reference`);
+    }
+    if (disposition?.status === "typed-v2" && disposition.excludedVariants) {
+      for (const [variant, exclusion] of Object.entries(disposition.excludedVariants)) {
+        if (!variant.trim() || !exclusion.reason.trim() || !/^decision\/dec_[A-Z0-9]+$/u.test(exclusion.decisionRef)) {
+          errors.push(`${spec.kind}: excluded ingress variant requires a name, reason, and decision reference`);
+        }
+      }
     }
   }
   if (errors.length > 0) throw new Error(`PRODUCTION_AUTHORITY_INGRESS_INCOMPLETE\n${errors.join("\n")}`);

--- a/packages/cli/src/cli/parsers/status-check.ts
+++ b/packages/cli/src/cli/parsers/status-check.ts
@@ -58,44 +58,5 @@ export function parseStatusCheckArgs(args: ReadonlyArray<string>, rootDir: strin
     };
   }
 
-  const lessonPromoteArgs = args[0] === "lesson" && args[1] === "promote" ? ["lesson-promote", ...args.slice(2)] : args;
-  if (lessonPromoteArgs[0] === "lesson-promote" && lessonPromoteArgs[1] && lessonPromoteArgs[2]) {
-    const mode = lessonPromoteArgs.includes("--apply") ? "apply" : "dry-run";
-    if (lessonPromoteArgs.includes("--apply") && lessonPromoteArgs.includes("--dry-run")) {
-      return { ok: false, error: cliError(CliErrorCode.ConflictingLessonMode, "Use either --dry-run or --apply.") };
-    }
-    return {
-      ok: true,
-      value: {
-        rootDir,
-        json,
-        action: {
-          kind: "lesson-promote",
-          taskId: lessonPromoteArgs[1],
-          candidateId: lessonPromoteArgs[2],
-          mode
-        }
-      }
-    };
-  }
-
-  const lessonSedimentArgs = args[0] === "lesson" && args[1] === "sediment" ? ["lesson-sediment", ...args.slice(2)] : args;
-  if (lessonSedimentArgs[0] === "lesson-sediment" && lessonSedimentArgs[1] && lessonSedimentArgs[2]) {
-    return {
-      ok: true,
-      value: {
-        rootDir,
-        json,
-        action: {
-          kind: "lesson-sediment",
-          taskId: lessonSedimentArgs[1],
-          candidateId: lessonSedimentArgs[2],
-          mode: "dry-run",
-          title: readOption(lessonSedimentArgs, "--title") ?? lessonSedimentArgs[2]
-        }
-      }
-    };
-  }
-
   return null;
 }

--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -335,8 +335,6 @@ function displayCommand(command: string): { readonly command: string; readonly e
     "distill-commit": "distill promote",
     "runtime-event-append": "event append",
     "runtime-event-list": "event list",
-    "lesson-promote": "lesson promote",
-    "lesson-sediment": "lesson sediment",
     "migrate-plan": "migrate plan",
     "migrate-structure": "migrate structure",
     "migrate-provenance": "migrate provenance",

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -20,6 +20,7 @@ import type { CliError } from "./error-codes.ts";
 
 export type CheckProfile = "source-package" | "private-harness" | "target-project";
 export type GovernanceRebuildMode = "dry-run" | "archive" | "apply";
+/** Dormant implementation compatibility type; lesson commands are not registered. */
 export type LessonCommandMode = "dry-run" | "apply";
 export type AnchorBackfillMode = "dry-run" | "apply";
 export type ProvenanceBackfillMode = "dry-run" | "apply";
@@ -272,8 +273,6 @@ export interface ParsedCommand {
     | { readonly kind: "completion"; readonly shell: "bash" | "zsh" }
     | { readonly kind: "check"; readonly profile: CheckProfile; readonly strict: boolean; readonly postMerge: boolean }
     | { readonly kind: "governance-rebuild"; readonly mode: GovernanceRebuildMode }
-    | { readonly kind: "lesson-promote"; readonly taskId: string; readonly candidateId: string; readonly mode: LessonCommandMode }
-    | { readonly kind: "lesson-sediment"; readonly taskId: string; readonly candidateId: string; readonly mode: "dry-run"; readonly title: string }
     | { readonly kind: "adopt-multica"; readonly taskId: string; readonly ref: string; readonly title: string; readonly status: string; readonly url: string }
     | { readonly kind: "external-snapshot"; readonly provider: "github"; readonly ref: string }
     | { readonly kind: "external-snapshot"; readonly provider: "multica"; readonly ref: string; readonly title: string; readonly status: string; readonly url: string }

--- a/packages/cli/src/commands/core/governance.ts
+++ b/packages/cli/src/commands/core/governance.ts
@@ -1,12 +1,11 @@
 import { Effect } from "effect";
 import { runCheckProfile } from "../check.ts";
 import { runGovernanceRebuild } from "../governance.ts";
-import { runLessonPromote, runLessonSediment } from "../lesson.ts";
 import type { CommandRunner } from "../../cli/runner-registry.ts";
 
 type GovernanceAction = Extract<
   Parameters<CommandRunner>[1]["action"],
-  { readonly kind: "check" | "governance-rebuild" | "lesson-promote" | "lesson-sediment" }
+  { readonly kind: "check" | "governance-rebuild" }
 >;
 
 export const runGovernanceCommand: CommandRunner = (context, command) => {
@@ -16,9 +15,5 @@ export const runGovernanceCommand: CommandRunner = (context, command) => {
       return Effect.sync(() => runCheckProfile(context.layoutInput, action, context.commandRegistry));
     case "governance-rebuild":
       return Effect.sync(() => runGovernanceRebuild(context.layoutInput, action.mode));
-    case "lesson-promote":
-      return Effect.sync(() => runLessonPromote(context.layoutInput, action.taskId, action.candidateId, action.mode));
-    case "lesson-sediment":
-      return Effect.sync(() => runLessonSediment(context.layoutInput, action.taskId, action.candidateId, action.title));
   }
 };

--- a/packages/cli/src/daemon/authority-command-submission.ts
+++ b/packages/cli/src/daemon/authority-command-submission.ts
@@ -51,6 +51,12 @@ export interface DaemonAuthorityAttemptCompilerV2 {
     readonly currentSession: CurrentSessionRef;
     readonly operation: WriteOp;
   }) => Promise<AuthorizedOperationAttemptV2>;
+  readonly compileObservedWrite?: (input: {
+    readonly command: ParsedCommand;
+    readonly attribution: CliActorAttribution;
+    readonly currentSession: CurrentSessionRef;
+    readonly operation: WriteOp;
+  }) => Promise<AuthorizedOperationAttemptV2>;
   readonly compileScriptIngest?: (input: {
     readonly command: ParsedCommand;
     readonly attribution: CliActorAttribution;
@@ -79,6 +85,12 @@ export interface DaemonAuthorityCommandSubmissionV2 {
     readonly operation: WriteOp;
   }) => Promise<AuthorityOperationReceipt>;
   readonly submitTaskClaim?: (input: {
+    readonly command: ParsedCommand;
+    readonly attribution: CliActorAttribution;
+    readonly currentSession: CurrentSessionRef;
+    readonly operation: WriteOp;
+  }) => Promise<AuthorityOperationReceipt>;
+  readonly submitObservedWrite?: (input: {
     readonly command: ParsedCommand;
     readonly attribution: CliActorAttribution;
     readonly currentSession: CurrentSessionRef;
@@ -129,6 +141,10 @@ export function createDaemonAuthorityCommandSubmissionV2(options: {
     ...(options.attemptCompiler.compileTaskClaim ? {
       submitTaskClaim: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileTaskClaim"]>>[0]) =>
         submitAttempt(await compileAttempt(() => options.attemptCompiler.compileTaskClaim!(input)))
+    } : {}),
+    ...(options.attemptCompiler.compileObservedWrite ? {
+      submitObservedWrite: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileObservedWrite"]>>[0]) =>
+        submitAttempt(await compileAttempt(() => options.attemptCompiler.compileObservedWrite!(input)))
     } : {}),
     ...(options.attemptCompiler.compileScriptIngest ? {
       submitScriptIngest: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileScriptIngest"]>>[0]) =>
@@ -224,6 +240,10 @@ export function makeDaemonAuthorityWriteCoordinator(
         if (taskClaim && !submission.submitTaskClaim) {
           throw authorityWriteRejected("AUTHORITY_TASK_CLAIM_SUBMISSION_UNAVAILABLE");
         }
+        const observedWrite = ingressAdapter === "observed-write";
+        if (observedWrite && !submission.submitObservedWrite) {
+          throw authorityWriteRejected("AUTHORITY_OBSERVED_WRITE_SUBMISSION_UNAVAILABLE");
+        }
         const scriptIngest = pending.kind === "script_ingest";
         if (scriptIngest && !submission.submitScriptIngest) {
           throw authorityWriteRejected("AUTHORITY_SCRIPT_SCOPE_SUBMISSION_UNAVAILABLE");
@@ -236,6 +256,8 @@ export function makeDaemonAuthorityWriteCoordinator(
             ? submission.submitDecisionTransition!({ ...input, operation: pending })
           : taskClaim
             ? submission.submitTaskClaim!({ ...input, operation: pending })
+          : observedWrite
+            ? submission.submitObservedWrite!({ ...input, operation: pending })
           : submission.submit({
             ...input,
             canonicalEntityId: commandMainEntityId(input.command) ?? pending.entityId

--- a/packages/cli/src/daemon/authority-submission-dispatch.ts
+++ b/packages/cli/src/daemon/authority-submission-dispatch.ts
@@ -33,6 +33,12 @@ export function bindAuthoritySubmissionForDispatch(
         return bound.submitTaskClaim!(submission);
       }
     } : {}),
+    ...(bound.submitObservedWrite ? {
+      submitObservedWrite: async (submission: Parameters<NonNullable<typeof bound.submitObservedWrite>>[0]) => {
+        dispatch.assertActive();
+        return bound.submitObservedWrite!(submission);
+      }
+    } : {}),
     ...(bound.submitScriptIngest ? {
       submitScriptIngest: async (submission: Parameters<NonNullable<typeof bound.submitScriptIngest>>[0]) => {
         dispatch.assertActive();

--- a/packages/cli/src/daemon/production-authority-attempt-compiler.ts
+++ b/packages/cli/src/daemon/production-authority-attempt-compiler.ts
@@ -1,6 +1,5 @@
 import { randomBytes, randomUUID } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
-import path from "node:path";
+import { readFileSync } from "node:fs";
 import {
   actorAxesBindingDigestV2,
   actorAxesBindingTokenDigestV2,
@@ -29,7 +28,6 @@ import {
   sha256Text,
   semanticMutationWireV2,
   taskEntityId,
-  taskPackagePath,
   type CanonicalCborValue,
   type DecisionPackage,
   type EntityRelationRecord,
@@ -60,6 +58,9 @@ import { taskClaimAttemptIntent } from "./production-authority-task-claim-intent
 import { executorDerivedFromPresetScript, productionScriptIngestAttemptIntent } from "./production-authority-script-ingest.ts";
 import { materializeProposedDecision } from "../commands/core/decision-propose.ts";
 import { materializedTaskPriorityWrites } from "../commands/core/decision-relate.ts";
+import { productionObservedWriteAttemptIntent } from "./production-authority-observed-write-intents.ts";
+import { hostedSnapshot } from "./production-authority-semantic-state.ts";
+export { createProductionCanonicalSemanticState } from "./production-authority-semantic-state.ts";
 
 type KeyMaterial = ReturnType<typeof openAuthorityProductionKeyMaterial>;
 
@@ -222,6 +223,11 @@ export function createProductionCanonicalAttemptCompiler(input: {
       return compileIntent(command, attribution, currentSession, operation.entityId,
         taskClaimAttemptIntent(command, attribution, currentSession, operation));
     },
+    compileObservedWrite: async ({ command, attribution, currentSession, operation }) => {
+      assertTypedIngressAdapter(command.action.kind, "observed-write");
+      return compileIntent(command, attribution, currentSession, operation.entityId,
+        productionObservedWriteAttemptIntent(command, operation, input.authoredRoot));
+    },
     compileScriptIngest: async ({ command, attribution, currentSession, operation }) => {
       return compileIntent(command, attribution, currentSession, operation.entityId,
         productionScriptIngestAttemptIntent(command, operation, input.authoredRoot));
@@ -229,7 +235,7 @@ export function createProductionCanonicalAttemptCompiler(input: {
   };
 }
 
-function assertTypedIngressAdapter(kind: string, expected: "generic" | "decision-transition" | "task-claim"): void {
+function assertTypedIngressAdapter(kind: string, expected: "generic" | "decision-transition" | "task-claim" | "observed-write"): void {
   const disposition = productionAuthorityIngressFor(kind);
   if (disposition?.status !== "typed-v2" || disposition.adapter !== expected) {
     throw new Error(`AUTHORITY_TYPED_INGRESS_REGISTRY_MISMATCH:${kind}:${expected}`);
@@ -424,7 +430,17 @@ async function canonicalAttemptIntent(
         ...(action.currentStep === undefined ? {} : { currentStep: action.currentStep })
       }
     };
-    return canonicalIntent("module.register", encodeTaskDecisionModuleCommandPayloadV2(payload), [{ entity, action: "register" }], [entity], ["modules.json"], moduleEntityId(action.moduleKey));
+    return moduleCanonicalIntent("module.register", encodeTaskDecisionModuleCommandPayloadV2(payload), entity, "register", action.moduleKey, authoredRoot);
+  }
+  if (action.kind === "module-unregister") {
+    const entity = ref("module", `module/${action.moduleKey}`);
+    const payload: TaskDecisionModuleCommandPayloadV2 = { schema: "module.unregister/v1", moduleKey: action.moduleKey };
+    return moduleCanonicalIntent("module.unregister", encodeTaskDecisionModuleCommandPayloadV2(payload), entity, "unregister", action.moduleKey, authoredRoot);
+  }
+  if (action.kind === "module-step") {
+    const entity = ref("module", `module/${action.moduleKey}`);
+    const payload: TaskDecisionModuleCommandPayloadV2 = { schema: "module.step/v1", moduleKey: action.moduleKey, stepId: action.stepId, state: action.state };
+    return moduleCanonicalIntent("module.step", encodeTaskDecisionModuleCommandPayloadV2(payload), entity, "step", action.moduleKey, authoredRoot);
   }
   if (action.kind === "decision-relate") {
     const relation: EntityRelationRecord = decisionRelationRecord({
@@ -515,6 +531,12 @@ function canonicalIntent(
   return { commandName, payload, mutations, baseRefs, portablePaths, declaredPathCas: [], physicalEntityId };
 }
 
+function moduleCanonicalIntent(commandName: string, payload: Uint8Array, entity: RegistryEntityRefV2, action: string, moduleKey: string, authoredRoot: string): CanonicalAttemptIntent {
+  const intent = canonicalIntent(commandName, payload, [{ entity, action }], [entity], ["modules.json"], moduleEntityId(moduleKey));
+  const snapshot = hostedSnapshot(authoredRoot, "modules.json");
+  return { ...intent, declaredPathCas: snapshot ? [{ path: "modules.json", ...snapshot.cas }] : [] };
+}
+
 function ref(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
   return { registryVersion: 1, entityKind, canonicalRef };
 }
@@ -554,39 +576,4 @@ function canonicalBindingTextSet(values: ReadonlyArray<string>): ReadonlyArray<s
     Buffer.from(encodeCanonicalCbor(left)),
     Buffer.from(encodeCanonicalCbor(right))
   ));
-}
-
-function hostedSnapshot(authoredRoot: string, portablePath: string): {
-  readonly body: string;
-  readonly cas: { readonly expectedEpoch: string; readonly expectedRevision: bigint; readonly expectedBlobDigest: Uint8Array };
-} | null {
-  const taskDocument = /^tasks\/([^/]+)\/(.+)$/u.exec(portablePath);
-  const rootDir = path.dirname(authoredRoot);
-  const absolute = taskDocument
-    ? path.join(taskPackagePath({
-      rootDir,
-      layoutOverrides: { authoredRoot: path.relative(rootDir, authoredRoot) }
-    }, taskDocument[1]!), taskDocument[2]!)
-    : path.join(authoredRoot, portablePath);
-  if (!existsSync(absolute)) return null;
-  const body = readFileSync(absolute, "utf8");
-  return {
-    body,
-    cas: { expectedEpoch: sha256Text(body), expectedRevision: 0n, expectedBlobDigest: Buffer.from(sha256Text(body), "hex") }
-  };
-}
-
-export function createProductionCanonicalSemanticState(authoredRoot: string) {
-  return {
-    readEntityBase: async () => null,
-    readHostedDocument: async (portablePath: string) => {
-      const snapshot = hostedSnapshot(authoredRoot, portablePath);
-      return snapshot ? {
-        body: snapshot.body,
-        epoch: snapshot.cas.expectedEpoch,
-        revision: snapshot.cas.expectedRevision,
-        blobDigest: snapshot.cas.expectedBlobDigest
-      } : null;
-    }
-  };
 }

--- a/packages/cli/src/daemon/production-authority-lifecycle.ts
+++ b/packages/cli/src/daemon/production-authority-lifecycle.ts
@@ -372,6 +372,9 @@ function createRepoComponent(
         ...(commandSubmission.submitTaskClaim ? {
           submitTaskClaim: commandSubmission.submitTaskClaim
         } : {}),
+        ...(commandSubmission.submitObservedWrite ? {
+          submitObservedWrite: commandSubmission.submitObservedWrite
+        } : {}),
         ...(commandSubmission.submitScriptIngest ? {
           submitScriptIngest: commandSubmission.submitScriptIngest
         } : {}),

--- a/packages/cli/src/daemon/production-authority-observed-write-intents.ts
+++ b/packages/cli/src/daemon/production-authority-observed-write-intents.ts
@@ -1,0 +1,244 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  encodeTaskDecisionModuleCommandPayloadV2,
+  type TaskDecisionModuleCommandPayloadV2
+} from "../../../application/src/index.ts";
+import {
+  decisionEntityId,
+  decisionSemanticMutationActions,
+  deriveRelationId,
+  sha256Text,
+  taskEntityId,
+  type DecisionPackage,
+  type EntityRelationRecord,
+  type RegistryEntityRefV2,
+  type WriteOp
+} from "../../../kernel/src/index.ts";
+import type { ParsedCommand } from "../cli/types.ts";
+import type { CanonicalAttemptIntent } from "./production-authority-attempt-compiler.ts";
+
+export function productionObservedWriteAttemptIntent(
+  command: ParsedCommand,
+  operation: WriteOp,
+  authoredRoot: string
+): CanonicalAttemptIntent {
+  const action = command.action;
+  if (action.kind === "decision-amend") {
+    const payload = decisionWritePayload(operation, "decision_amend", action.decisionId);
+    return observedIntent({
+      commandName: "decision.amend",
+      payload: { schema: "decision.amend/v1", decision: payload.decision, ...(payload.body === undefined ? {} : { body: payload.body }) },
+      mutations: [{ entity: observedWriteRef("decision", `decision/${action.decisionId}`), action: decisionSemanticMutationActions.amend }],
+      baseRefs: [observedWriteRef("decision", `decision/${action.decisionId}`)],
+      portablePaths: [`decisions/decision-${action.decisionId}/decision.md`],
+      physicalEntityId: decisionEntityId(action.decisionId),
+      authoredRoot
+    });
+  }
+  if (action.kind === "decision-relation-retire") {
+    const payload = decisionWritePayload(operation, "relation_retire", action.decisionId);
+    return observedIntent({
+      commandName: "decision.relation-retire",
+      payload: { schema: "decision.relation-retire/v1", decisionId: action.decisionId, relationId: action.relationId, decision: payload.decision, ...(payload.body === undefined ? {} : { body: payload.body }) },
+      mutations: [
+        { entity: observedWriteRef("decision", `decision/${action.decisionId}`), action: decisionSemanticMutationActions.relation },
+        { entity: observedWriteRef("relation", `relation/${action.relationId}`), action: "retire" }
+      ],
+      baseRefs: [observedWriteRef("decision", `decision/${action.decisionId}`), observedWriteRef("relation", `relation/${action.relationId}`)],
+      portablePaths: [`decisions/decision-${action.decisionId}/decision.md`],
+      physicalEntityId: decisionEntityId(action.decisionId),
+      authoredRoot
+    });
+  }
+  if (action.kind === "decision-relation-replace") {
+    const payload = decisionWritePayload(operation, "relation_replace", action.decisionId);
+    const replacement = payload.decision.relations.at(-1);
+    if (!replacement || replacement.relation_id === action.relationId || replacement.state !== "active") {
+      throw new Error("AUTHORITY_DECISION_RELATION_REPLACEMENT_REQUIRED");
+    }
+    const taskWrites = documentWrites(payload.taskWrites, "AUTHORITY_DECISION_RELATION_TASK_WRITES_INVALID");
+    return observedIntent({
+      commandName: "decision.relation-replace",
+      payload: {
+        schema: "decision.relation-replace/v1", decisionId: action.decisionId, relationId: action.relationId,
+        replacement, decision: payload.decision,
+        ...(taskWrites.length === 0 ? {} : { taskWrites }),
+        ...(payload.body === undefined ? {} : { body: payload.body })
+      },
+      mutations: [
+        { entity: observedWriteRef("decision", `decision/${action.decisionId}`), action: decisionSemanticMutationActions.relation },
+        { entity: observedWriteRef("relation", `relation/${action.relationId}`), action: "retire" },
+        { entity: observedWriteRef("relation", `relation/${replacement.relation_id}`), action: "create" },
+        ...taskWrites.map((write) => ({ entity: observedWriteRef("task", `task/${write.taskId}`), action: "document" }))
+      ],
+      baseRefs: [
+        observedWriteRef("decision", `decision/${action.decisionId}`), observedWriteRef("relation", `relation/${action.relationId}`),
+        observedWriteRef("relation", `relation/${replacement.relation_id}`), ...taskWrites.map((write) => observedWriteRef("task", `task/${write.taskId}`))
+      ],
+      portablePaths: [`decisions/decision-${action.decisionId}/decision.md`, ...taskWrites.map((write) => `tasks/${write.taskId}/${write.path}`)],
+      physicalEntityId: decisionEntityId(action.decisionId),
+      authoredRoot
+    });
+  }
+  if (action.kind === "task-delete" && action.mode === "hard") {
+    throw new Error("AUTHORITY_TASK_HARD_DELETE_UNAVAILABLE: production path does not offer hard delete; use task archive or task supersede after distilling evidence");
+  }
+  if (action.kind === "task-amend") {
+    const body = singleTaskBody(operation, "doc_write", action.taskId);
+    return taskIntent("task.amend", { schema: "task.amend/v1", taskId: action.taskId, fields: action.patches.map((patch) => patch.field), body }, action.taskId, "document", [action.taskId], authoredRoot);
+  }
+  if (action.kind === "task-archive") {
+    const taskId = singleArchiveTaskId(action, operation);
+    const body = singleTaskBody(operation, "package_archive", taskId);
+    return taskIntent("task.archive", { schema: "task.archive/v1", taskId, reason: action.reason, body }, taskId, "document", [taskId], authoredRoot);
+  }
+  if (action.kind === "task-delete") {
+    const body = singleTaskBody(operation, "package_tombstone", action.taskId);
+    return taskIntent("task.delete", { schema: "task.delete/v1", taskId: action.taskId, mode: "soft", reason: action.reason, body }, action.taskId, "document", [action.taskId], authoredRoot);
+  }
+  if (action.kind === "task-reopen") {
+    const body = singleTaskBody(operation, "package_reopen", action.taskId);
+    return taskIntent("task.reopen", { schema: "task.reopen/v1", taskId: action.taskId, reason: action.reason, body }, action.taskId, "document", [action.taskId], authoredRoot);
+  }
+  if (action.kind === "task-relate") {
+    const body = singleTaskBody(operation, "doc_write", action.sourceTaskId);
+    const relation = taskRelation(action);
+    return taskIntent("task.relate", {
+      schema: "task.relate/v1", taskId: action.sourceTaskId, targetTaskId: action.targetTaskId, relation, body
+    }, action.sourceTaskId, "document", [action.sourceTaskId, action.targetTaskId], authoredRoot, [
+      { entity: observedWriteRef("relation", `relation/${relation.relation_id}`), action: "create" }
+    ]);
+  }
+  if (action.kind === "task-supersede") {
+    if (action.byTaskId) {
+      const body = singleTaskBody(operation, "package_archive", action.oldTaskId);
+      return taskIntent("task.supersede", {
+        schema: "task.supersede/v1", taskId: action.oldTaskId, body, replacementTaskId: action.byTaskId
+      }, action.oldTaskId, "document", [action.oldTaskId, action.byTaskId], authoredRoot);
+    }
+    if (operation.kind !== "package_supersede" || operation.entityId !== taskEntityId(action.oldTaskId)) {
+      throw new Error("AUTHORITY_TASK_SUPERSEDE_OPERATION_MISMATCH");
+    }
+    const raw = exactObservedRecord(operation.payload, "AUTHORITY_TASK_SUPERSEDE_PAYLOAD_INVALID");
+    const writes = documentWrites(raw.writes, "AUTHORITY_TASK_SUPERSEDE_PAYLOAD_INVALID", true);
+    const replacement = writes.find((write) => write.taskId !== action.oldTaskId && write.path === "INDEX.md")?.taskId;
+    if (!replacement) throw new Error("AUTHORITY_TASK_SUPERSEDE_REPLACEMENT_REQUIRED");
+    return observedIntent({
+      commandName: "task.supersede",
+      payload: { schema: "task.supersede/v1", taskId: action.oldTaskId, replacementTaskId: replacement, writes },
+      mutations: [
+        { entity: observedWriteRef("task", `task/${action.oldTaskId}`), action: "document" },
+        { entity: observedWriteRef("task", `task/${replacement}`), action: "create" }
+      ],
+      baseRefs: [observedWriteRef("task", `task/${action.oldTaskId}`), observedWriteRef("task", `task/${replacement}`)],
+      portablePaths: writes.map((write) => `tasks/${write.taskId}/${write.path}`),
+      physicalEntityId: taskEntityId(action.oldTaskId),
+      authoredRoot
+    });
+  }
+  throw new Error(`AUTHORITY_OBSERVED_WRITE_COMMAND_UNSUPPORTED:${action.kind}`);
+}
+
+function taskIntent(
+  commandName: string,
+  payload: TaskDecisionModuleCommandPayloadV2,
+  taskId: string,
+  action: string,
+  taskIds: ReadonlyArray<string>,
+  authoredRoot: string,
+  extraMutations: CanonicalAttemptIntent["mutations"] = []
+): CanonicalAttemptIntent {
+  return observedIntent({
+    commandName,
+    payload,
+    mutations: [{ entity: observedWriteRef("task", `task/${taskId}`), action }, ...extraMutations],
+    baseRefs: [...taskIds.map((id) => observedWriteRef("task", `task/${id}`)), ...extraMutations.map((mutation) => mutation.entity)],
+    portablePaths: taskIds.map((id) => `tasks/${id}/INDEX.md`),
+    physicalEntityId: taskEntityId(taskId),
+    authoredRoot
+  });
+}
+
+function observedIntent(input: {
+  readonly commandName: string;
+  readonly payload: TaskDecisionModuleCommandPayloadV2;
+  readonly mutations: CanonicalAttemptIntent["mutations"];
+  readonly baseRefs: CanonicalAttemptIntent["baseRefs"];
+  readonly portablePaths: CanonicalAttemptIntent["portablePaths"];
+  readonly physicalEntityId: string;
+  readonly authoredRoot: string;
+}): CanonicalAttemptIntent {
+  const snapshots = input.portablePaths.flatMap((portablePath) => {
+    const absolute = path.join(input.authoredRoot, portablePath);
+    if (!existsSync(absolute)) return [];
+    const body = readFileSync(absolute, "utf8");
+    const digest = sha256Text(body);
+    return [{ path: portablePath, expectedEpoch: digest, expectedRevision: 0n, expectedBlobDigest: Buffer.from(digest, "hex") }];
+  });
+  return {
+    commandName: input.commandName,
+    payload: encodeTaskDecisionModuleCommandPayloadV2(input.payload),
+    mutations: input.mutations,
+    baseRefs: input.baseRefs,
+    portablePaths: input.portablePaths,
+    declaredPathCas: snapshots,
+    physicalEntityId: input.physicalEntityId
+  };
+}
+
+function decisionWritePayload(operation: WriteOp, kind: WriteOp["kind"], decisionId: string): {
+  readonly decision: DecisionPackage;
+  readonly body?: string;
+  readonly taskWrites?: unknown;
+} {
+  if (operation.kind !== kind || operation.entityId !== decisionEntityId(decisionId)) throw new Error("AUTHORITY_DECISION_WRITE_OPERATION_MISMATCH");
+  const raw = exactObservedRecord(operation.payload, "AUTHORITY_DECISION_WRITE_PAYLOAD_INVALID");
+  const decision = raw.decision as DecisionPackage | undefined;
+  if (!decision || typeof decision !== "object" || decision.decision_id !== decisionId) throw new Error("AUTHORITY_DECISION_WRITE_PAYLOAD_INVALID");
+  if (raw.body !== undefined && typeof raw.body !== "string") throw new Error("AUTHORITY_DECISION_WRITE_BODY_INVALID");
+  return { decision, ...(raw.body === undefined ? {} : { body: raw.body }), ...(raw.taskWrites === undefined ? {} : { taskWrites: raw.taskWrites }) };
+}
+
+function singleTaskBody(operation: WriteOp, kind: WriteOp["kind"], taskId: string): string {
+  if (operation.kind !== kind || operation.entityId !== taskEntityId(taskId)) throw new Error("AUTHORITY_TASK_WRITE_OPERATION_MISMATCH");
+  const raw = exactObservedRecord(operation.payload, "AUTHORITY_TASK_WRITE_PAYLOAD_INVALID");
+  if (raw.path !== "INDEX.md" || typeof raw.body !== "string") throw new Error("AUTHORITY_TASK_WRITE_PAYLOAD_INVALID");
+  return raw.body;
+}
+
+function singleArchiveTaskId(action: Extract<ParsedCommand["action"], { readonly kind: "task-archive" }>, operation: WriteOp): string {
+  const selected = action.taskId ? [action.taskId] : action.ids ? [...new Set(action.ids)] : [];
+  if (selected.length !== 1) throw new Error("AUTHORITY_TASK_ARCHIVE_SINGLE_SELECTOR_REQUIRED: production typed archive currently requires exactly one explicit task id");
+  if (operation.entityId !== taskEntityId(selected[0]!)) throw new Error("AUTHORITY_TASK_ARCHIVE_OPERATION_MISMATCH");
+  return selected[0]!;
+}
+
+function taskRelation(action: Extract<ParsedCommand["action"], { readonly kind: "task-relate" }>): EntityRelationRecord {
+  const base = {
+    source: `task/${action.sourceTaskId}`, target: `task/${action.targetTaskId}`, type: action.relationType,
+    strength: "strong", direction: "directed", origin: "declared", rationale: action.rationale, state: "active"
+  } as const;
+  return { relation_id: deriveRelationId(base), ...base };
+}
+
+function documentWrites(value: unknown, code: string, allowPackageSlug = false): ReadonlyArray<{ readonly taskId: string; readonly path: string; readonly body: string; readonly packageSlug?: string }> {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new Error(code);
+  return value.map((entry) => {
+    const row = exactObservedRecord(entry, code);
+    if (typeof row.taskId !== "string" || typeof row.path !== "string" || typeof row.body !== "string"
+      || (!allowPackageSlug && row.packageSlug !== undefined)
+      || (row.packageSlug !== undefined && typeof row.packageSlug !== "string")) throw new Error(code);
+    return { taskId: row.taskId, path: row.path, body: row.body, ...(row.packageSlug === undefined ? {} : { packageSlug: row.packageSlug }) };
+  });
+}
+
+function exactObservedRecord(value: unknown, code: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(code);
+  return value as Record<string, unknown>;
+}
+
+function observedWriteRef(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
+  return { registryVersion: 1, entityKind, canonicalRef };
+}

--- a/packages/cli/src/daemon/production-authority-semantic-state.ts
+++ b/packages/cli/src/daemon/production-authority-semantic-state.ts
@@ -1,0 +1,27 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { sha256Text, taskPackagePath } from "../../../kernel/src/index.ts";
+
+export function createProductionCanonicalSemanticState(authoredRoot: string) {
+  return {
+    readEntityBase: async () => null,
+    readHostedDocument: async (portablePath: string) => {
+      const snapshot = hostedSnapshot(authoredRoot, portablePath);
+      return snapshot ? { body: snapshot.body, epoch: snapshot.cas.expectedEpoch, revision: snapshot.cas.expectedRevision, blobDigest: snapshot.cas.expectedBlobDigest } : null;
+    }
+  };
+}
+
+export function hostedSnapshot(authoredRoot: string, portablePath: string): {
+  readonly body: string;
+  readonly cas: { readonly expectedEpoch: string; readonly expectedRevision: bigint; readonly expectedBlobDigest: Uint8Array };
+} | null {
+  const taskDocument = /^tasks\/([^/]+)\/(.+)$/u.exec(portablePath);
+  const rootDir = path.dirname(authoredRoot);
+  const absolute = taskDocument
+    ? path.join(taskPackagePath({ rootDir, layoutOverrides: { authoredRoot: path.relative(rootDir, authoredRoot) } }, taskDocument[1]!), taskDocument[2]!)
+    : path.join(authoredRoot, portablePath);
+  if (!existsSync(absolute)) return null;
+  const body = readFileSync(absolute, "utf8");
+  return { body, cas: { expectedEpoch: sha256Text(body), expectedRevision: 0n, expectedBlobDigest: Buffer.from(sha256Text(body), "hex") } };
+}

--- a/packages/cli/test/check-governance-cli.test.ts
+++ b/packages/cli/test/check-governance-cli.test.ts
@@ -64,7 +64,7 @@ test("CLI target-project check profile passes valid task material contracts", ()
     assert.equal(result.command, "check");
     assert.equal(result.report.summary.hardFailCount, 0);
     assert.equal(result.report.validators.some((validator: Record<string, unknown>) => validator.source === "task-plan-contract"), false);
-    assert.equal(result.commands.some((entry: Record<string, unknown>) => entry.kind === "lesson-promote"), true);
+    assert.equal(result.commands.some((entry: Record<string, unknown>) => entry.kind === "lesson-promote" || entry.kind === "lesson-sediment"), false);
     assert.equal(result.commands.some((entry: Record<string, unknown>) => entry.kind === "preset-validate" && entry.primary === "harness-anything preset validate <manifest> [--kernel-version <version>] [--json]"), true);
   });
 });
@@ -377,7 +377,7 @@ test("CLI governance rebuild supports dry-run, apply, and archive modes", () => 
   });
 });
 
-test("CLI lesson commands preserve task-local candidate routing", () => {
+test("CLI lesson promotion and sedimentation commands are retired from canonical and compatibility grammar", () => {
   withTempRoot((rootDir) => {
     runJson(rootDir, ["init"]);
     writeTaskPackage(rootDir, "task-1", {
@@ -388,24 +388,18 @@ test("CLI lesson commands preserve task-local candidate routing", () => {
       lessons: validLessonCandidates()
     });
 
-    const dryRun = runJson(rootDir, ["lesson-promote", "task-1", "LC-001", "--dry-run"]);
-    assert.equal(dryRun.ok, true);
-    assert.equal(dryRun.mode, "dry-run");
-    assert.equal(dryRun.generated.length, 0);
-    assert.equal(dryRun.report.plannedWrite, ".harness/generated/lessons/LC-001.json");
-
-    const applied = runJson(rootDir, ["lesson-promote", "task-1", "LC-001", "--apply"]);
-    assert.equal(applied.ok, true);
-    assert.equal(existsSync(path.join(rootDir, ".harness/generated/lessons/LC-001.json")), true);
-
-    const sediment = runJson(rootDir, ["lesson-sediment", "task-1", "LC-001", "--title", "Keep Task Lessons Local"]);
-    assert.equal(sediment.ok, true);
-    assert.equal(sediment.mode, "dry-run");
-    assert.equal(sediment.report.plannedWrite, "harness/lessons/LC-001.md");
-
-    const missing = runJson(rootDir, ["lesson-promote", "task-1", "LC-404"], false);
-    assert.equal(missing.ok, false);
-    assert.equal(missing.error.code, "lesson_candidate_not_found");
+    for (const argv of [
+      ["lesson", "promote", "task-1", "LC-001"],
+      ["lesson-promote", "task-1", "LC-001"],
+      ["lesson", "sediment", "task-1", "LC-001"],
+      ["lesson-sediment", "task-1", "LC-001"]
+    ]) {
+      const result = runJson(rootDir, argv, false);
+      assert.equal(result.ok, false, argv.join(" "));
+      assert.equal(result.error.code, "unknown_command", argv.join(" "));
+    }
+    assert.equal(existsSync(path.join(rootDir, ".harness/generated/lessons/LC-001.json")), false);
+    assert.equal(existsSync(path.join(rootDir, "harness/lessons/LC-001.md")), false);
   });
 });
 

--- a/packages/cli/test/conflict-preflight-cli.test.ts
+++ b/packages/cli/test/conflict-preflight-cli.test.ts
@@ -31,8 +31,6 @@ const expectedConflictPreflightKinds = [
   "legacy-copy-safe-docs",
   "legacy-index",
   "legacy-intake-plan",
-  "lesson-promote",
-  "lesson-sediment",
   "migrate-anchors",
   "migrate-fact-execution",
   "migrate-provenance",
@@ -116,8 +114,6 @@ const expectedDeferredRuntimeEventKinds = [
   "legacy-copy-safe-docs",
   "legacy-index",
   "legacy-intake-plan",
-  "lesson-promote",
-  "lesson-sediment",
   "migrate-anchors",
   "migrate-fact-execution",
   "migrate-provenance",
@@ -174,8 +170,7 @@ test("CLI conflict preflight blocks representative write commands before output"
       { args: ["preset", "run", "module", "check", "--task", "task-1"], missingPath: ".harness/evidence/presets/module" },
       { args: ["preset", "action", "module", "check", "--task", "task-1"], missingPath: ".harness/evidence/presets/module" },
       { args: ["script", "run", "missing-script", "--task", "task-1"], missingPath: ".harness" },
-      { args: ["migrate-run", "--plan-only", "--out-dir", "migration-session"], missingPath: "migration-session/session.json" },
-      { args: ["lesson-promote", "task-1", "candidate-1", "--apply"], missingPath: ".harness/generated/lessons" }
+      { args: ["migrate-run", "--plan-only", "--out-dir", "migration-session"], missingPath: "migration-session/session.json" }
     ];
 
     for (const entry of cases) {

--- a/packages/cli/test/doctor-cli.test.ts
+++ b/packages/cli/test/doctor-cli.test.ts
@@ -123,6 +123,18 @@ test("CLI task help lists every task leaf and declares --json only as a global o
   });
 });
 
+test("task delete help exposes production soft delete and hard-delete alternatives", () => {
+  withTempRoot((rootDir) => {
+    const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "task", "delete", "--help"], {
+      encoding: "utf8"
+    });
+
+    assert.match(stdout, /production does not offer hard delete/iu);
+    assert.match(stdout, /task archive or task supersede/iu);
+    assert.match(stdout, /--soft <id>/u);
+  });
+});
+
 test("init text receipt gives the daemon registration and startup path", () => {
   withTempRoot((rootDir) => {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "init"], {

--- a/packages/cli/test/helpers/receipt.ts
+++ b/packages/cli/test/helpers/receipt.ts
@@ -74,8 +74,6 @@ function legacyCommandForDisplay(command: string): string {
     "distill promote": "distill-commit",
     "event append": "runtime-event-append",
     "event list": "runtime-event-list",
-    "lesson promote": "lesson-promote",
-    "lesson sediment": "lesson-sediment",
     "migrate plan": "migrate-plan",
     "migrate structure": "migrate-structure",
     "migrate provenance": "migrate-provenance",

--- a/packages/cli/test/parse-args.test.ts
+++ b/packages/cli/test/parse-args.test.ts
@@ -189,8 +189,6 @@ const parseCases: ReadonlyArray<ParseCase> = [
   { name: "version", argv: ["version"], kind: "version" },
   { name: "check", argv: ["check", "--profile", "target-project", "--strict", "--post-merge"], kind: "check", fields: { profile: "target-project", strict: true, postMerge: true } },
   { name: "governance rebuild", argv: ["governance", "rebuild", "--archive"], kind: "governance-rebuild", fields: { mode: "archive" } },
-  { name: "lesson promote", argv: ["lesson", "promote", "task_1", "candidate-1", "--apply"], kind: "lesson-promote", fields: { taskId: "task_1", candidateId: "candidate-1", mode: "apply" } },
-  { name: "lesson sediment", argv: ["lesson", "sediment", "task_1", "candidate-1", "--title", "Learning"], kind: "lesson-sediment", fields: { taskId: "task_1", candidateId: "candidate-1", title: "Learning", mode: "dry-run" } },
   { name: "adopt multica", argv: ["adopt", "multica", "EXT-1", "--task", "task_1", "--title", "External", "--status", "todo"], kind: "adopt-multica", fields: { ref: "EXT-1", taskId: "task_1", title: "External", status: "todo" } },
   { name: "snapshot multica", argv: ["snapshot", "multica", "EXT-1", "--title", "External", "--status", "todo"], kind: "external-snapshot", fields: { provider: "multica", ref: "EXT-1", title: "External", status: "todo" } },
   { name: "snapshot github", argv: ["snapshot", "github", "Acme/Widgets#101"], kind: "external-snapshot", fields: { provider: "github", ref: "Acme/Widgets#101" } },
@@ -395,8 +393,6 @@ test("conflict marker preflight classifies extension and migration write command
     "module-step",
     "module-unregister",
     "init",
-    "lesson-promote",
-    "lesson-sediment",
     "migrate-run",
     "script-run"
   ] as const) {
@@ -509,8 +505,6 @@ test("parseArgs keeps deprecated command aliases during the E77/F6 transition", 
     { argv: ["distill", "commit", "--task", "task_1", "--candidate", "candidate.json", "--claim", "Claim"], kind: "distill-commit" },
     { argv: ["runtime-event", "append", "--session", "s1", "--kind", "interrupt"], kind: "runtime-event-append" },
     { argv: ["runtime-event", "list", "--session", "s1"], kind: "runtime-event-list" },
-    { argv: ["lesson-promote", "task_1", "candidate-1"], kind: "lesson-promote" },
-    { argv: ["lesson-sediment", "task_1", "candidate-1"], kind: "lesson-sediment" },
     { argv: ["migrate-plan"], kind: "migrate-plan" },
     { argv: ["migrate-structure", "--plan"], kind: "migrate-structure" },
     { argv: ["migrate-anchors", "--dry-run"], kind: "migrate-anchors" },
@@ -532,14 +526,14 @@ test("parseArgs keeps deprecated command aliases during the E77/F6 transition", 
   }
 });
 
-test("parseArgs marks all 20 alias grammars and seven migration commands for sunset telemetry", () => {
+test("parseArgs marks all 18 alias grammars and seven migration commands for sunset telemetry", () => {
   const aliasDefinitions = deprecatedCommandDefinitions.filter((entry) => entry.kind === "alias-grammar");
-  assert.equal(aliasDefinitions.length, 20);
+  assert.equal(aliasDefinitions.length, 18);
   assert.equal(deprecatedCommandDefinitions.filter((entry) => entry.kind === "migration-command").length, 7);
   const specifiedAliases = commandSpecs.flatMap((spec) => (spec.aliases ?? [])
     .filter((alias) => alias.includes("retires at E77/F6 acceptance"))
     .map((alias) => ({ commandKind: spec.kind, alias })));
-  assert.equal(specifiedAliases.length, 20);
+  assert.equal(specifiedAliases.length, 18);
   for (const specified of specifiedAliases) {
     const match = /^(.*?) \(deprecated, use (.*?); retires at E77\/F6 acceptance\)$/u.exec(specified.alias);
     assert.notEqual(match, null, specified.alias);

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -50,6 +50,7 @@ import { authorityOperationShape } from "./operation-shape.ts";
 import { verifyProductionCommandParity } from "./production-parity.ts";
 import { verifyTypedMinimalParameterMatrix } from "./minimal-parameter-matrix.ts";
 import { verifyProductionPresetIngress } from "./preset-ingress.ts";
+import { verifyOmittedIngressRegressions } from "./omitted-ingress-regressions.ts";
 
 test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 240_000 }, async () => {
   const fixture = createFixture();
@@ -457,10 +458,10 @@ test("production generic canonical ingress accepts and journals one write for ev
       authoredMarker: /dec_INGRESS/u
     }, {
       kind: "module",
-      action: { kind: "module-register", moduleKey: "ingress", title: "Ingress", scope: "packages/cli/**", shared: [], dependsOn: [] },
-      canonicalEntityId: moduleEntityId("ingress"),
+      action: { kind: "module-register", moduleKey: "registered-ingress", title: "Ingress", scope: "packages/cli/**", shared: [], dependsOn: [] },
+      canonicalEntityId: moduleEntityId("registered-ingress"),
       authoredPath: "modules.json",
-      authoredMarker: /ingress/u
+      authoredMarker: /registered-ingress/u
     }, {
       kind: "fact",
       action: {
@@ -589,6 +590,8 @@ test("production generic canonical ingress accepts and journals one write for ev
         detectedAt: "2026-07-17T00:10:00.000Z"
       }
     }, { actor: commandActor, executor: { kind: "agent", id: "codex" } });
+
+    await verifyOmittedIngressRegressions({ authoredRoot: fixture.authoredRoot, runCommand });
 
     const appendReceipt = await runCommand({
       kind: "progress-append",

--- a/packages/cli/test/production-authority-canonical-ingress/fixture.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/fixture.ts
@@ -32,6 +32,18 @@ export function createFixture() {
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"));
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6"), { recursive: true });
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6"));
+  for (const taskId of [
+    "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK0", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK1",
+    "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK2", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK3",
+    "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK4", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK5",
+    "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK6"
+  ]) {
+    mkdirSync(path.join(authoredRoot, `tasks/${taskId}`), { recursive: true });
+    const body = taskId.endsWith("NK0")
+      ? taskIndexBody(taskId).replace("vertical: default", "vertical: software/coding")
+      : taskIndexBody(taskId);
+    writeFileSync(path.join(authoredRoot, `tasks/${taskId}/INDEX.md`), body);
+  }
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route"), { recursive: true });
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8"));
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/closeout.md"), "# Closeout\n\nSlugged production lifecycle is ready.\n");
@@ -136,6 +148,13 @@ export function createFixture() {
     "      - kind: unix-socket-owner-boundary", `        issuer: host:${hostname()}`, `        subject: ${process.getuid?.() ?? 0}`,
     "roles:", "  - roleId: owner", "    commandClasses: [admin, repo-write, repo-read, arbiter]", ""
   ].join("\n"));
+  writeFileSync(path.join(authoredRoot, "modules.json"), `${JSON.stringify({
+    schema: "module-registry/v1",
+    modules: [
+      { key: "ingress-step", title: "Ingress Step", status: "active", scopes: ["packages/cli/**"], steps: [] },
+      { key: "ingress-unregister", title: "Ingress Unregister", status: "active", scopes: ["packages/cli/**"], steps: [] }
+    ]
+  }, null, 2)}\n`);
   const keyStore = openLocalAuthorityKeyStore({ serviceStateRoot: serviceRoot, stateDirectory: keyStateDirectory, workspaceRoot: repoRoot, authorityId: "authority.production", issuer: "authority.production" });
   const now = Date.now();
   const prepublished = keyStore.createPrepublishedKey({ generation: 1, nowMs: now - 1_000 });

--- a/packages/cli/test/production-authority-canonical-ingress/minimal-parameter-matrix.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/minimal-parameter-matrix.ts
@@ -21,6 +21,12 @@ export function verifyTypedMinimalParameterMatrix(
     "task-claim": { argv: ["task", "claim", missingTask], outcome: "guided-error" },
     "status-set": { argv: ["task", "transition", missingTask, "active"], outcome: "guided-error" },
     "progress-append": { argv: ["task", "progress", "append", missingTask, "--text", "minimal"], outcome: "guided-error" },
+    "task-amend": { argv: ["task", "amend", missingTask, "--set", "queue:ready"], outcome: "guided-error" },
+    "task-archive": { argv: ["task", "archive", missingTask, "--reason", "minimal"], outcome: "guided-error" },
+    "task-supersede": { argv: ["task", "supersede", missingTask, "--by", "task_01KXT3E1MN1VBS64DCNZ4VX81E", "--confirm", missingTask, "--reason", "minimal"], outcome: "guided-error" },
+    "task-delete": { argv: ["task", "delete", "--soft", missingTask, "--reason", "minimal"], outcome: "guided-error" },
+    "task-reopen": { argv: ["task", "reopen", missingTask, "--reason", "minimal"], outcome: "guided-error" },
+    "task-relate": { argv: ["task", "relate", missingTask, "depends-on", "task_01KXT3E1MN1VBS64DCNZ4VX81E", "--rationale", "minimal"], outcome: "guided-error" },
     "task-code-doc-reconcile": { argv: ["task", "code-doc", "reconcile", missingTask, "--commit", fixture.publicHead, "--path", "README.md"], outcome: "guided-error" },
     "task-consent-record": { argv: ["task", "consent-record", missingTask, "--execution-id", missingExecution, "--utterance", "Approved"], outcome: "guided-error" },
     "task-review-execution": { argv: ["task", "review-execution", missingTask, "--execution-id", missingExecution, "--verdict", "dismissed", "--findings", "none", "--rationale", "minimal"], outcome: "guided-error" },
@@ -28,9 +34,14 @@ export function verifyTypedMinimalParameterMatrix(
     "decision-propose": { argv: ["decision", "propose", "--title", "Minimal ingress decision", "--question", "Minimal?", "--chosen", "Yes", "--rejected", "No", "--why-not", "Not selected"], outcome: "success" },
     "decision-transition": { argv: ["decision", "transition", "rejected", missingDecision], outcome: "guided-error" },
     "decision-relate": { argv: ["decision", "relate", missingDecision, "--anchor", "CH1", "--type", "derives", "--target", `task/${missingTask}`, "--rationale", "minimal"], outcome: "guided-error" },
+    "decision-amend": { argv: ["decision", "amend", missingDecision, "--title", "Minimal amendment"], outcome: "guided-error" },
+    "decision-relation-retire": { argv: ["decision", "relation", "retire", missingDecision, "--relation", "rel_0123456789abcdef"], outcome: "guided-error" },
+    "decision-relation-replace": { argv: ["decision", "relation", "replace", missingDecision, "--relation", "rel_0123456789abcdef", "--anchor", "CH1", "--type", "relates", "--target", "decision/dec_MISSING", "--rationale", "minimal"], outcome: "guided-error" },
     "record-fact": { argv: ["fact", "record", "--task", missingTask, "--statement", "Minimal fact"], outcome: "guided-error" },
     "fact-invalidate": { argv: ["fact", "invalidate", "--task", missingTask, "--id", "F-DEADBEEF", "--by", "F-FEEDFACE", "--rationale", "minimal"], outcome: "guided-error" },
-    "module-register": { argv: ["module", "register", "minimal", "--title", "Minimal ingress", "--scope", "packages/minimal/**"], outcome: "success" }
+    "module-register": { argv: ["module", "register", "minimal", "--title", "Minimal ingress", "--scope", "packages/minimal/**"], outcome: "success" },
+    "module-unregister": { argv: ["module", "unregister", "missing"], outcome: "guided-error" },
+    "module-step": { argv: ["module", "step", "missing", "M-1", "--state", "done"], outcome: "guided-error" }
   };
   assert.deepEqual(Object.keys(cases).sort(), productionAuthorityTypedIngressKinds());
 
@@ -48,6 +59,6 @@ export function verifyTypedMinimalParameterMatrix(
     assert.equal(result.receipt.ok, false, `${kind}:${JSON.stringify(result.receipt)}`);
     const hint = result.receipt.error?.hint ?? "";
     assert.equal(hint.length >= 16, true, `${kind}: missing guided error: ${JSON.stringify(result.receipt)}`);
-    assert.match(hint, /(?:use|run|create|claim|record|submit|retry|requires?|not found|missing)/iu, `${kind}:${hint}`);
+    assert.match(hint, /(?:use|run|create|claim|record|submit|retry|requires?|not found|missing|resolve|existing)/iu, `${kind}:${hint}`);
   }
 }

--- a/packages/cli/test/production-authority-canonical-ingress/omitted-ingress-regressions.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/omitted-ingress-regressions.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { parseDecisionDocument } from "../../../kernel/src/index.ts";
+import type { ParsedCommand } from "../../src/cli/types.ts";
+
+interface RegressionReceipt {
+  readonly ok: boolean;
+  readonly error?: { readonly code?: string; readonly hint?: string };
+}
+
+export async function verifyOmittedIngressRegressions(input: {
+  readonly authoredRoot: string;
+  readonly runCommand: (action: ParsedCommand["action"], sessionId: string) => Promise<RegressionReceipt>;
+}): Promise<void> {
+  const receipts = new Map<string, RegressionReceipt>();
+  const run = async (kind: string, action: ParsedCommand["action"]) => {
+    const receipt = await input.runCommand(action, `regression-${kind}`);
+    receipts.set(kind, receipt);
+    assert.equal(receipt.ok, true, `${kind}:${JSON.stringify(receipt)}`);
+  };
+  await run("decision-amend", { kind: "decision-amend", decisionId: "dec_INGRESS", title: "Ingress decision amended", fulfillments: [], patches: [], dryRun: false });
+  const decisionPath = path.join(input.authoredRoot, "decisions/decision-dec_INGRESS/decision.md");
+  assert.match(readFileSync(decisionPath, "utf8"), /title: "Ingress decision amended"/u);
+  const initialRelationId = parseDecisionDocument(readFileSync(decisionPath, "utf8")).decision.relations.find((relation) => relation.state === "active")!.relation_id;
+  await run("decision-relation-retire", { kind: "decision-relation-retire", decisionId: "dec_INGRESS", relationId: initialRelationId, dryRun: false });
+  assert.equal(parseDecisionDocument(readFileSync(decisionPath, "utf8")).decision.relations.find((relation) => relation.relation_id === initialRelationId)?.state, "retired");
+  await run("decision-relate-replacement-seed", { kind: "decision-relate", decisionId: "dec_INGRESS", anchor: "C1", relationType: "relates", target: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNK4", rationale: "Seed replace regression.", dryRun: false });
+  const replaceRelationId = parseDecisionDocument(readFileSync(decisionPath, "utf8")).decision.relations.find((relation) => relation.state === "active")!.relation_id;
+  await run("decision-relation-replace", { kind: "decision-relation-replace", decisionId: "dec_INGRESS", relationId: replaceRelationId, anchor: "C1", relationType: "relates", target: "task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNK6", rationale: "Replace regression edge.", dryRun: false });
+  assert.match(readFileSync(decisionPath, "utf8"), /Replace regression edge/u);
+
+  await run("task-amend", { kind: "task-amend", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK0", patches: [{ field: "taskClass", value: "milestone" }] });
+  assert.match(readFileSync(path.join(input.authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNK0/INDEX.md"), "utf8"), /taskClass: milestone/u);
+  await run("task-archive", { kind: "task-archive", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK1", reason: "archive regression" });
+  await run("task-reopen", { kind: "task-reopen", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK1", reason: "reopen regression" });
+  assert.match(readFileSync(path.join(input.authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNK1/INDEX.md"), "utf8"), /packageDisposition: active/u);
+  await run("task-delete", { kind: "task-delete", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK2", mode: "soft", reason: "delete regression" });
+  assert.match(readFileSync(path.join(input.authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNK2/INDEX.md"), "utf8"), /packageDisposition: tombstoned/u);
+  await run("task-relate", { kind: "task-relate", sourceTaskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK3", relationType: "depends-on", targetTaskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK4", rationale: "relate regression", dryRun: false });
+  assert.match(readFileSync(path.join(input.authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNK3/INDEX.md"), "utf8"), /type: depends-on/u);
+  await run("task-supersede", { kind: "task-supersede", oldTaskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK5", byTaskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK6", confirm: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK5", reason: "supersede regression", allowOpenFindings: false });
+  assert.match(readFileSync(path.join(input.authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNK5/INDEX.md"), "utf8"), /packageDisposition: archived/u);
+  await run("module-step", { kind: "module-step", moduleKey: "ingress-step", stepId: "ING-1", state: "done" });
+  assert.match(readFileSync(path.join(input.authoredRoot, "modules.json"), "utf8"), /ING-1/u);
+  await run("module-unregister", { kind: "module-unregister", moduleKey: "ingress-unregister" });
+  assert.match(readFileSync(path.join(input.authoredRoot, "modules.json"), "utf8"), /"status": "unregistered"/u);
+  assert.deepEqual([...receipts.keys()].filter((kind) => kind !== "decision-relate-replacement-seed").sort(), ["decision-amend", "decision-relation-replace", "decision-relation-retire", "module-step", "module-unregister", "task-amend", "task-archive", "task-delete", "task-relate", "task-reopen", "task-supersede"]);
+
+  const hardDelete = await input.runCommand({ kind: "task-delete", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK0", mode: "hard", reason: "hard delete regression", confirm: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK0" }, "regression-task-delete-hard");
+  assert.equal(hardDelete.ok, false, JSON.stringify(hardDelete));
+  assert.equal(hardDelete.error?.code, "authority_ingress_rejected", JSON.stringify(hardDelete));
+  assert.match(hardDelete.error?.hint ?? "", /production path does not offer hard delete; use task archive or task supersede/u);
+}

--- a/packages/cli/test/production-authority-canonical-ingress/propose-parity.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/propose-parity.ts
@@ -42,12 +42,12 @@ export function verifyDecisionProposeParity(
   assert.equal(manual.receipt.error?.code, "authority_ingress_rejected", JSON.stringify(manual.receipt));
   assert.match(manual.receipt.error?.hint ?? "", /omit --id/u);
 
-  const unsupported = runRawJsonMaybeFail(fixture.repoRoot, [
-    "decision", "amend", fallbackId, "--title", "Unsupported ingress probe"
+  const amended = runRawJsonMaybeFail(fixture.repoRoot, [
+    "decision", "amend", fallbackId, "--title", "Typed ingress amend probe"
   ], env);
-  assert.equal(unsupported.status, 1, JSON.stringify(unsupported.receipt));
-  assert.equal(unsupported.receipt.error?.code, "authority_ingress_rejected", JSON.stringify(unsupported.receipt));
-  assert.doesNotMatch(JSON.stringify(unsupported.receipt), /JournalUnavailable/u);
+  assert.equal(amended.status, 0, JSON.stringify(amended.receipt));
+  assert.equal(amended.receipt.ok, true, JSON.stringify(amended.receipt));
+  assert.match(readFileSync(path.join(fixture.authoredRoot, `decisions/decision-${fallbackId}/decision.md`), "utf8"), /title: "Typed ingress amend probe"/u);
 
   const before = git(fixture.authoredRoot, "rev-parse", "HEAD");
   const dryRun = runRawJsonMaybeFail(fixture.repoRoot, [

--- a/packages/cli/test/snapshots/capabilities-command-kinds.json
+++ b/packages/cli/test/snapshots/capabilities-command-kinds.json
@@ -92,10 +92,6 @@
     "legacy-scan",
     "legacy-verify"
   ],
-  "lesson": [
-    "lesson-promote",
-    "lesson-sediment"
-  ],
   "materializer": [
     "materializer-run"
   ],

--- a/packages/cli/test/snapshots/global-help.txt
+++ b/packages/cli/test/snapshots/global-help.txt
@@ -29,7 +29,6 @@ Commands:
   help - Show CLI discovery help.
   init - Initialize a harness workspace.
   legacy - Intake legacy harness content.
-  lesson - Promote and sediment lessons.
   materializer - Merge session ledger branches.
   migrate - Run compatibility migrations.
   module - Manage project modules.

--- a/packages/cli/test/task-delete-disposition-cli.test.ts
+++ b/packages/cli/test/task-delete-disposition-cli.test.ts
@@ -98,7 +98,8 @@ test("CLI task delete hard path is guarded by F5 disposition semantics", () => {
     assert.equal(parentFailure.ok, false);
     assert.equal(parentFailure.error?.code, "related_task_hard_delete_forbidden");
     assert.match(parentFailure.error?.hint ?? "", /0 anchored fact\(s\), 0 active incoming relation\(s\), and 1 child task\(s\)/u);
-    assert.match(parentFailure.error?.hint ?? "", /archive\/delete\/supersede child tasks before hard delete/u);
+    assert.match(parentFailure.error?.hint ?? "", /archive\/delete\/supersede child tasks before (?:local compatibility )?hard delete/u);
+    assert.match(parentFailure.error?.hint ?? "", /ha task supersede <id> --by <replacement-id>/u);
     assert.equal(existsSync(parentPackagePath), true);
 
     const childResult = runJson(rootDir, ["task", "delete", "--hard", childTaskId, "--reason", "remove child", "--confirm", childTaskId]);

--- a/packages/daemon/src/protocol/method-registry.ts
+++ b/packages/daemon/src/protocol/method-registry.ts
@@ -275,8 +275,6 @@ const repoWriteCliActionKinds = new Set<string>([
   "legacy-copy-safe-docs",
   "legacy-index",
   "legacy-intake-plan",
-  "lesson-promote",
-  "lesson-sediment",
   "materializer-run",
   "migrate-anchors",
   "migrate-fact-execution",

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -86,21 +86,32 @@ test("production authority ingress covers or explicitly excludes every write-cla
   assert.doesNotThrow(() => assertProductionAuthorityIngressCompleteness(productionAuthorityCommandSpecs, commandClassForCliActionKind));
   const typedKinds = productionAuthorityTypedIngressKinds();
   assert.deepEqual(typedKinds, [
+    "decision-amend",
     "decision-propose",
     "decision-relate",
+    "decision-relation-replace",
+    "decision-relation-retire",
     "decision-transition",
     "fact-invalidate",
     "module-register",
+    "module-step",
+    "module-unregister",
     "new-task",
     "progress-append",
     "record-fact",
     "session-export",
     "status-set",
+    "task-amend",
+    "task-archive",
     "task-claim",
     "task-code-doc-reconcile",
     "task-complete",
     "task-consent-record",
-    "task-review-execution"
+    "task-delete",
+    "task-relate",
+    "task-reopen",
+    "task-review-execution",
+    "task-supersede"
   ]);
   const exclusions = productionAuthorityCommandSpecs.filter((spec) => spec.productionAuthorityIngress?.status === "excluded");
   assert.equal(exclusions.length > 0, true);

--- a/packages/kernel/src/entity/disposition.ts
+++ b/packages/kernel/src/entity/disposition.ts
@@ -75,7 +75,7 @@ export function evaluateEntityDisposition(request: EntityDispositionRequest): En
       false,
       [
         `${request.entityRef} has ${cascade.anchoredFacts.length} anchored fact(s), ${cascade.incoming.length} active incoming relation(s), and ${cascade.childTasks.length} child task(s); D3/D4 disposition is blocked by the lower-bound rule.`,
-        "E79 defines delete as stage containment: distill evidence into an anchor task, reconnect facts/decisions to that anchor, then run ha task archive <id> --reason <reason>; archive/delete/supersede child tasks before hard delete; hard delete has no --cascade escape hatch."
+        "Production does not offer hard delete. E79 defines delete as stage containment: distill evidence into an anchor task, reconnect facts/decisions to that anchor, then run ha task archive <id> --reason <reason> or ha task supersede <id> --by <replacement-id> --reason <reason>; archive/delete/supersede child tasks before local compatibility hard delete; hard delete has no --cascade escape hatch."
       ].join(" "),
       matrixEntry.writeOpKinds,
       cascade

--- a/packages/kernel/test/store/entity-disposition.test.ts
+++ b/packages/kernel/test/store/entity-disposition.test.ts
@@ -78,7 +78,8 @@ test("entity disposition lower-bound blocks D3 and D4 when task owns child tasks
     assert.equal(childHardDelete.allowed, true);
     assert.equal(hardDelete.lowerBound.childTaskCount, 1);
     assert.match(hardDelete.reason, /0 anchored fact\(s\), 0 active incoming relation\(s\), and 1 child task\(s\)/u);
-    assert.match(hardDelete.reason, /archive\/delete\/supersede child tasks before hard delete/u);
+    assert.match(hardDelete.reason, /archive\/delete\/supersede child tasks before (?:local compatibility )?hard delete/u);
+    assert.match(hardDelete.reason, /Production does not offer hard delete/u);
     assert.deepEqual(impact.childTasks.map((child) => child.taskId), ["task-child"]);
     assert.deepEqual(impact.impactedRefs, ["task/task-child"]);
   });

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -62,6 +62,7 @@
       "entry": [
         "cli",
         "daemon-rpc",
+        "production-authority",
         "gui-bridge"
       ],
       "writeKinds": [
@@ -98,7 +99,8 @@
         "packages/adapters/local/src/index.ts:182",
         "packages/adapters/local/src/index.ts:310",
         "packages/application/src/local-controller-service.ts:95",
-        "packages/cli/src/commands/core/task-submit-facade.ts:15"
+        "packages/cli/src/commands/core/task-submit-facade.ts:15",
+        "packages/cli/src/daemon/production-authority-observed-write-intents.ts:1"
       ],
       "freshness": "coordinator-conditional-task-state"
     },
@@ -293,6 +295,7 @@
       "entry": [
         "cli",
         "daemon-rpc",
+        "production-authority",
         "internal",
         "gui-review"
       ],
@@ -329,7 +332,8 @@
         "packages/adapters/local/src/task-writes.ts:67",
         "packages/application/src/task-lifecycle-orchestrator.ts:115",
         "packages/cli/src/commands/core/task-gates.ts:93",
-        "packages/cli/src/daemon/doc-sync-service.ts:166"
+        "packages/cli/src/daemon/doc-sync-service.ts:166",
+        "packages/cli/src/daemon/production-authority-observed-write-intents.ts:1"
       ],
       "freshness": "doc-sync-submit-cas-post-apply"
     },
@@ -642,7 +646,8 @@
       },
       "entry": [
         "cli",
-        "daemon-rpc"
+        "daemon-rpc",
+        "production-authority"
       ],
       "writeKinds": [
         "decision_propose"
@@ -709,7 +714,8 @@
       },
       "entry": [
         "cli",
-        "daemon-rpc"
+        "daemon-rpc",
+        "production-authority"
       ],
       "writeKinds": [
         "decision_amend"
@@ -723,7 +729,8 @@
       ],
       "evidence": [
         "packages/application/src/decision-write-service.ts:119",
-        "packages/application/src/decision-write-service.ts:267"
+        "packages/application/src/decision-write-service.ts:267",
+        "packages/cli/src/daemon/production-authority-observed-write-intents.ts:1"
       ],
       "freshness": "decision-watermark-cas"
     },
@@ -741,7 +748,8 @@
       },
       "entry": [
         "cli",
-        "daemon-rpc"
+        "daemon-rpc",
+        "production-authority"
       ],
       "writeKinds": [
         "decision_relate"
@@ -773,7 +781,8 @@
       },
       "entry": [
         "cli",
-        "daemon-rpc"
+        "daemon-rpc",
+        "production-authority"
       ],
       "writeKinds": [
         "relation_retire",
@@ -788,7 +797,8 @@
       ],
       "evidence": [
         "packages/application/src/decision-write-service.ts:134",
-        "packages/application/src/decision-write-service.ts:267"
+        "packages/application/src/decision-write-service.ts:267",
+        "packages/cli/src/daemon/production-authority-observed-write-intents.ts:1"
       ],
       "freshness": "decision-watermark-cas"
     },
@@ -805,7 +815,8 @@
         "zoneClass": "module-authored-structured"
       },
       "entry": [
-        "cli"
+        "cli",
+        "production-authority"
       ],
       "writeKinds": [
         "module_registry_write"
@@ -817,7 +828,8 @@
       ],
       "evidence": [
         "packages/cli/src/commands/extensions/module.ts:43",
-        "packages/cli/src/commands/extensions/state.ts:380"
+        "packages/cli/src/commands/extensions/state.ts:380",
+        "packages/cli/src/daemon/production-authority-attempt-compiler.ts:1"
       ],
       "freshness": "coordinator-registry-replace"
     },
@@ -967,9 +979,7 @@
         "distill-candidate"
       ],
       "cliActions": [
-        "distill-candidate",
-        "lesson-promote",
-        "lesson-sediment"
+        "distill-candidate"
       ],
       "directWrites": [
         {


### PR DESCRIPTION
# English

## Summary

Thirteen commands were present on the `ha --help` surface but unusable against the production daemon: the ingress table excluded them with the reason "has no production typed semantic compiler" — i.e. the compiler was never built. Users hit `AUTHORITY_TYPED_COMMAND_UNSUPPORTED` on commands the CLI advertises. A full audit of `production-authority-ingress.ts` separated deliberate design exclusions (facade decomposition, migration write roads, superseded commands) from this omission class. This lands the omission class: 11 commands get typed compilers, 1 is reclassified as a deliberate exclusion, and 2 are retired.

## What Changed

- **11 commands compiled into production typed ingress**: `decision-amend`, `decision-relation-retire`, `decision-relation-replace`, `task-amend`, `task-archive`, `task-supersede`, `task-reopen`, `task-relate`, `task-delete --soft`, `module-unregister`, `module-step`. These are mechanical ports of semantics that already existed at the application layer — no new semantics were authored and no fail-closed behaviour or field-mutability contract was relaxed.
- **`task-delete --hard` reclassified as a deliberate exclusion.** Production does not offer hard delete. Its exclusion reason now states design intent instead of "no compiler", and the disposition hint in `packages/kernel/src/entity/disposition.ts` points at the replacement path (`task archive` / `task supersede` after distilling evidence) rather than leaving the caller without a route.
- **`lesson-promote` / `lesson-sediment` retired** from CLI, parser, daemon protocol and capabilities/help. The line was shipped-unused: its charter task is still `planned` with a placeholder closeout, there are zero lesson artifacts under `harness/`, and `harness.yaml` carries no configuration. The charter task itself is untouched — it stays `planned`, marked as reference material for future evolution work.
- **write-road registry synchronized** for the new mutating roads. No exemption was added.

## Task And Scope

- Ledger task task_01KXTXDRBEX1QZFJHPVEX4YP3M. Scope: the ingress table, production typed semantic compilers, and the command-declaration surface (help text and error hints) for the reclassified and retired commands.

## Version Impact

- No schema or wire-format change. Commands that previously failed closed now succeed through the production path; two commands are removed from the surface. No version bump.

## Governance Declaration

- Authorizing decisions: **dec_01KXTXCT4MRSQDKR3NYWBD401A** (eight commands receive typed compilers) and **dec_01KXTZ092RJJ4GDNRTTQG907JK** (adjudication of the remaining five: `task-delete` soft-compile / hard-exclude, lesson retirement, module compile). Ledger task task_01KXTXDRBEX1QZFJHPVEX4YP3M. `tools/write-road-registry.json` was updated to declare the new mutating write roads — this is a declaration, not an exemption; no registry exemption was added. No gates, allowlists, CI configuration or protected surfaces were modified, and no fail-closed behaviour was relaxed. Break-glass: no.

## Verification

- RED control per command: before the change each command returned `AUTHORITY_TYPED_COMMAND_UNSUPPORTED` on the production path; after the change admission passes. Fixtures reuse `packages/cli/test/production-authority-canonical-ingress/`.
- Canonical generic integration 1/1; canonical service-route integration 1/1.
- Root `check:local` `FINAL_EXIT=0`, 605/605 affected tests passing.
- CEO diff review verified three properties directly: `task-delete --hard` retains its exclusion and now carries a design-intent reason; the write-road registry diff contains no exemption/bypass/skip entry; no file under `harness/**`, `.github/**` or `tools/gate-manifest.*` is touched.

## Review Evidence

- Implementation report `tmp/orch/ingress-compilers/REPORT-ingress-compilers.md` (moved into the task package at closeout). Source bug reports: `tmp/BUGREPORT-ingress-decision-amend-unsupported.md`, which additionally reported `task-relate` as blocking all milestone `depends-on` edges in production.

## Residual Risk

- `task archive` for the ordinary single-task case is green. The archive variant that auto-generates a distill artifact companion needs a new mixed canonical transaction contract and is therefore left fail-closed per the task checkpoint — deliberately not forced through by splitting operations.
- Production smoke against the live daemon (`ha decision amend` writing to disk) runs after merge and deploy, since the production daemon serves the merged build.

## References

- Decisions dec_01KXTXCT4MRSQDKR3NYWBD401A, dec_01KXTZ092RJJ4GDNRTTQG907JK. Same typed-ingress surface as #908, #909, #913, #916; decomposition pattern from #914; atomic sub-road pattern from #917.

---

# 中文

## 概要

十三个命令在 `ha --help` 声明面上存在,但生产 daemon 路不可用:ingress 表以"has no production typed semantic compiler"为由排除它们——即 compiler 从未建过。使用者在 CLI 自己宣传的命令上撞 `AUTHORITY_TYPED_COMMAND_UNSUPPORTED`。对 `production-authority-ingress.ts` 的全量审计把**有意设计的排除**(facade 分解、migration write road、被取代的命令)与这一**遗漏类**区分开。本 PR 落地遗漏类:11 个补 typed compiler,1 个改判为设计排除,2 个退役。

## 改动内容

- **11 个命令接入生产 typed ingress**:`decision-amend`、`decision-relation-retire`、`decision-relation-replace`、`task-amend`、`task-archive`、`task-supersede`、`task-reopen`、`task-relate`、`task-delete --soft`、`module-unregister`、`module-step`。这些是对**应用层已存在语义**的机械移植——未自造语义,未放松任何 fail-closed 行为或字段可变性契约。
- **`task-delete --hard` 改判为有意设计的排除。** 生产路不提供硬删。其排除理由改为陈述设计意图(不再写"没有 compiler"),且 `packages/kernel/src/entity/disposition.ts` 的处置提示指向替代路径(蒸馏证据后走 `task archive` / `task supersede`),而不是把调用者晾在没有出路的地方。
- **`lesson-promote` / `lesson-sediment` 退役**,从 CLI、parser、daemon protocol、capabilities/help 全面下线。该线属 shipped-unused:charter 任务至今 `planned` 且 closeout 为占位,`harness/` 下零 lesson 产物,`harness.yaml` 无配置。**charter 任务本身未动**——保持 `planned`,已标记为未来进化方向的参考材料。
- **write-road registry 同步**登记新增 mutating 写路。**未新增任何豁免。**

## 任务与范围

- 台账任务 task_01KXTXDRBEX1QZFJHPVEX4YP3M。范围:ingress 表、生产 typed semantic compiler,以及改判与退役命令的命令声明面(help 文案与错误提示)。

## 版本影响

- 无 schema / wire 格式变更。此前 fail-closed 的命令现在可经生产路成功;两个命令从声明面移除。无版本号变更。

## 治理声明

- 授权决策:**dec_01KXTXCT4MRSQDKR3NYWBD401A**(8 个命令补 typed compiler)与 **dec_01KXTZ092RJJ4GDNRTTQG907JK**(剩余 5 项裁决:`task-delete` soft 补 / hard 排除、lesson 退役、module 补)。台账任务 task_01KXTXDRBEX1QZFJHPVEX4YP3M。`tools/write-road-registry.json` 更新为**登记**新增 mutating 写路——这是声明,不是豁免;未新增任何 registry 豁免。未修改 gate、allowlist、CI 配置或受保护 surface,未放松任何 fail-closed。Break-glass:否。

## 验证

- 逐命令红对照:改前该命令走生产路返回 `AUTHORITY_TYPED_COMMAND_UNSUPPORTED`,改后准入通过。fixture 复用 `packages/cli/test/production-authority-canonical-ingress/`。
- canonical generic 集成 1/1;canonical service-route 集成 1/1。
- 根 `check:local` `FINAL_EXIT=0`,受影响测试 605/605 通过。
- CEO 亲验 diff 三条性质:`task-delete --hard` 保持排除且理由已改为陈述设计意图;write-road registry diff 中无任何 exemption/bypass/skip 条目;未触碰 `harness/**`、`.github/**`、`tools/gate-manifest.*` 下任何文件。

## 审查证据

- 实现报告 `tmp/orch/ingress-compilers/REPORT-ingress-compilers.md`(收口移入任务包)。来源缺陷报告:`tmp/BUGREPORT-ingress-decision-amend-unsupported.md`,其中另报告 `task-relate` 缺失导致所有 milestone 的 `depends-on` 排期边在生产环境无法建立。

## 残余风险

- 普通单任务 `task archive` 已绿。会自动生成 distill artifact companion 的 archive 变体需要新的混合 canonical 事务契约,按任务 checkpoint 保持 fail-closed——**刻意不通过拆分操作强行放行**。
- 针对在跑 daemon 的生产实测(`ha decision amend` 真实落盘)在合入并部署后进行,因为生产 daemon 服务的是合入后的构建。

## 关联材料

- 决策 dec_01KXTXCT4MRSQDKR3NYWBD401A、dec_01KXTZ092RJJ4GDNRTTQG907JK。与 #908、#909、#913、#916 同 typed-ingress 面;分解模式承 #914;原子子路模式承 #917。
