### PR TITLE
fix(cli): resolve portable path CAS for slugged task packages

### DIFF
--- a/packages/application/src/authority/semantic-authority-helpers-v2.ts
+++ b/packages/application/src/authority/semantic-authority-helpers-v2.ts
@@ -71,20 +71,24 @@ export async function verifySemanticBaseCasV2(
   requiredRefs: ReadonlyArray<RegistryEntityRefV2>
 ): Promise<void> {
   const required = uniqueRegistryEntityRefsV2(requiredRefs);
-  if (claimed.length !== required.length) throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+  if (claimed.length !== required.length) {
+    throw semanticAdmissionV2(`ENTITY_BASE_CAS_CONFLICT:claimed=${claimed.length};required=${required.length}`);
+  }
   const byRef = new Map(claimed.map((entry) => [registryEntityRefKeyV2(entry.entityRef), entry]));
-  if (byRef.size !== claimed.length) throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+  if (byRef.size !== claimed.length) throw semanticAdmissionV2("ENTITY_BASE_CAS_CONFLICT:duplicate-claimed-ref");
   for (const entityRef of required) {
-    const row = byRef.get(registryEntityRefKeyV2(entityRef));
-    if (!row) throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+    const refKey = registryEntityRefKeyV2(entityRef);
+    const refLabel = `${entityRef.entityKind}:${entityRef.canonicalRef}`;
+    const row = byRef.get(refKey);
+    if (!row) throw semanticAdmissionV2(`ENTITY_BASE_CAS_CONFLICT:missing=${refLabel}`);
     const actual = await state.readEntityBase(entityRef);
     if (!actual) {
       if (row.expectedSemanticVersion !== null || row.expectedStateDigest !== null) {
-        throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+        throw semanticAdmissionV2(`ENTITY_BASE_CAS_CONFLICT:expected-absent=${refLabel}`);
       }
     } else if (row.expectedSemanticVersion !== actual.semanticVersion
       || !nullableSemanticBytesEqualV2(row.expectedStateDigest, actual.stateDigest)) {
-      throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+      throw semanticAdmissionV2(`ENTITY_BASE_CAS_CONFLICT:snapshot-mismatch=${refLabel}`);
     }
   }
 }
@@ -93,14 +97,16 @@ export function verifySemanticPathCasV2(
   claimed: ReadonlyArray<PathCasV2>,
   required: ReadonlyArray<{ readonly path: string; readonly snapshot: SemanticHostedDocumentSnapshotV2 }>
 ): void {
-  if (claimed.length !== required.length) throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+  if (claimed.length !== required.length) {
+    throw semanticAdmissionV2(`PATH_CAS_CONFLICT:claimed=${claimed.length};required=${required.length}`);
+  }
   const byPath = new Map(claimed.map((entry) => [entry.path, entry]));
-  if (byPath.size !== claimed.length) throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+  if (byPath.size !== claimed.length) throw semanticAdmissionV2("PATH_CAS_CONFLICT:duplicate-claimed-path");
   for (const { path, snapshot } of required) {
     const row = byPath.get(path);
     if (!row || row.expectedEpoch !== snapshot.epoch || row.expectedRevision !== snapshot.revision
       || !bytesEqual(row.expectedBlobDigest, snapshot.blobDigest)) {
-      throw semanticAdmissionV2("BASE_CAS_CONFLICT");
+      throw semanticAdmissionV2(`PATH_CAS_CONFLICT:${row ? "snapshot-mismatch" : "missing"}=${path}`);
     }
   }
 }

--- a/packages/application/test/fact-relation-authority-admission-v2.test.ts
+++ b/packages/application/test/fact-relation-authority-admission-v2.test.ts
@@ -149,7 +149,7 @@ test("six W2 negative controls are REJECTED before PREPARED, enqueue, or token c
       reason: "SEMANTIC_MUTATION_DIGEST_MISMATCH"
     },
     { name: "scope", envelope: requestEnvelope(6, correctBase, exact), reason: "TOKEN_ENTITY_KIND_SCOPE_DENIED" },
-    { name: "base-CAS", envelope: requestEnvelope(7, wrongBase, exact), reason: "BASE_CAS_CONFLICT" }
+    { name: "base-CAS", envelope: requestEnvelope(7, wrongBase, exact), reason: "ENTITY_BASE_CAS_CONFLICT" }
   ];
 
   for (const fixture of cases) {
@@ -160,7 +160,9 @@ test("six W2 negative controls are REJECTED before PREPARED, enqueue, or token c
       envelope: encodeSemanticMutationEnvelopeV2(envelope)
     });
     assert.equal(receipt.tag, "REJECTED", fixture.name);
-    assert.equal(receipt.tag === "REJECTED" ? receipt.reason : "", fixture.reason, fixture.name);
+    const reason = receipt.tag === "REJECTED" ? receipt.reason : "";
+    if (fixture.name === "base-CAS") assert.match(reason, /^ENTITY_BASE_CAS_CONFLICT:/u, fixture.name);
+    else assert.equal(reason, fixture.reason, fixture.name);
     const stored = await operationRegistry.get(claims.workspaceId, receipt.opId);
     assert.equal(stored?.state, "REJECTED", `${fixture.name} must never reach PREPARED`);
   }

--- a/packages/application/test/fact-relation-semantic-compiler-v2.test.ts
+++ b/packages/application/test/fact-relation-semantic-compiler-v2.test.ts
@@ -231,7 +231,7 @@ test("six admission controls reject omission, addition, relabel, digest, scope, 
   const wrongBase = baseCas.map((entry, index) => index === 0
     ? { ...entry, expectedStateDigest: Buffer.alloc(32, 0xee) }
     : entry);
-  await assert.rejects(compiler.compile(envelope(factInvalidatePayload(), wrongBase)), /BASE_CAS_CONFLICT/u);
+  await assert.rejects(compiler.compile(envelope(factInvalidatePayload(), wrongBase)), /ENTITY_BASE_CAS_CONFLICT/u);
 
   const digestEnvelope = envelope(factInvalidatePayload(), baseCas);
   if (digestEnvelope.intent.kind !== "typed") throw new Error("fixture must be typed");

--- a/packages/application/test/session-execution-review-authority-admission-v2.test.ts
+++ b/packages/application/test/session-execution-review-authority-admission-v2.test.ts
@@ -121,7 +121,7 @@ test("six W4 negative controls reject before PREPARED, enqueue, or token consump
     { name: "relabel", envelope: requestEnvelope(4, correctBase, relabel), reason: "SEMANTIC_MUTATION_MISMATCH" },
     { name: "digest", envelope: requestEnvelope(5, correctBase, exact, Buffer.alloc(32, 0xdd)), reason: "SEMANTIC_MUTATION_DIGEST_MISMATCH" },
     { name: "scope", envelope: requestEnvelope(6, correctBase, exact), reason: "TOKEN_ENTITY_KIND_SCOPE_DENIED" },
-    { name: "base-CAS", envelope: requestEnvelope(7, wrongBase, exact), reason: "BASE_CAS_CONFLICT" }
+    { name: "base-CAS", envelope: requestEnvelope(7, wrongBase, exact), reason: "ENTITY_BASE_CAS_CONFLICT" }
   ];
   for (const fixture of cases) {
     const envelope = bindEnvelope(fixture.envelope, claims, tokenDigest);
@@ -131,7 +131,9 @@ test("six W4 negative controls reject before PREPARED, enqueue, or token consump
       envelope: encodeSemanticMutationEnvelopeV2(envelope)
     });
     assert.equal(receipt.tag, "REJECTED", fixture.name);
-    assert.equal(receipt.tag === "REJECTED" ? receipt.reason : "", fixture.reason, fixture.name);
+    const reason = receipt.tag === "REJECTED" ? receipt.reason : "";
+    if (fixture.name === "base-CAS") assert.match(reason, /^ENTITY_BASE_CAS_CONFLICT:/u, fixture.name);
+    else assert.equal(reason, fixture.reason, fixture.name);
     assert.equal((await operationRegistry.get(claims.workspaceId, receipt.opId))?.state, "REJECTED");
   }
   assert.equal(enqueued, 0);

--- a/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
+++ b/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
@@ -340,7 +340,7 @@ test("unknown command, transparent fallback, base-CAS, and mutation claim mismat
     ...draft,
     intent: { kind: "transparent-file", interpretation: "full-semantic", files: [] }
   })), /TYPED_COMMAND_REQUIRED/u);
-  await assert.rejects(compiler.compile(envelope(payload, [present(moduleRef, "wrong-version")])), /BASE_CAS_CONFLICT/u);
+  await assert.rejects(compiler.compile(envelope(payload, [present(moduleRef, "wrong-version")])), /ENTITY_BASE_CAS_CONFLICT/u);
 });
 
 test("module journal mutation appears in registry-derived attribution read surface with cross-layer digests", () => {

--- a/packages/cli/src/daemon/production-authority-observed-write-intents.ts
+++ b/packages/cli/src/daemon/production-authority-observed-write-intents.ts
@@ -1,5 +1,3 @@
-import { existsSync, readFileSync } from "node:fs";
-import path from "node:path";
 import {
   encodeTaskDecisionModuleCommandPayloadV2,
   type TaskDecisionModuleCommandPayloadV2
@@ -8,7 +6,6 @@ import {
   decisionEntityId,
   decisionSemanticMutationActions,
   deriveRelationId,
-  sha256Text,
   taskEntityId,
   type DecisionPackage,
   type EntityRelationRecord,
@@ -17,6 +14,7 @@ import {
 } from "../../../kernel/src/index.ts";
 import type { ParsedCommand } from "../cli/types.ts";
 import type { CanonicalAttemptIntent } from "./production-authority-attempt-compiler.ts";
+import { resolveHostedDocument } from "./production-authority-semantic-state.ts";
 
 export function productionObservedWriteAttemptIntent(
   command: ParsedCommand,
@@ -32,6 +30,7 @@ export function productionObservedWriteAttemptIntent(
       mutations: [{ entity: observedWriteRef("decision", `decision/${action.decisionId}`), action: decisionSemanticMutationActions.amend }],
       baseRefs: [observedWriteRef("decision", `decision/${action.decisionId}`)],
       portablePaths: [`decisions/decision-${action.decisionId}/decision.md`],
+      requiredPathCasPaths: [`decisions/decision-${action.decisionId}/decision.md`],
       physicalEntityId: decisionEntityId(action.decisionId),
       authoredRoot
     });
@@ -47,6 +46,7 @@ export function productionObservedWriteAttemptIntent(
       ],
       baseRefs: [observedWriteRef("decision", `decision/${action.decisionId}`), observedWriteRef("relation", `relation/${action.relationId}`)],
       portablePaths: [`decisions/decision-${action.decisionId}/decision.md`],
+      requiredPathCasPaths: [`decisions/decision-${action.decisionId}/decision.md`],
       physicalEntityId: decisionEntityId(action.decisionId),
       authoredRoot
     });
@@ -77,6 +77,7 @@ export function productionObservedWriteAttemptIntent(
         observedWriteRef("relation", `relation/${replacement.relation_id}`), ...taskWrites.map((write) => observedWriteRef("task", `task/${write.taskId}`))
       ],
       portablePaths: [`decisions/decision-${action.decisionId}/decision.md`, ...taskWrites.map((write) => `tasks/${write.taskId}/${write.path}`)],
+      requiredPathCasPaths: [`decisions/decision-${action.decisionId}/decision.md`, ...taskWrites.map((write) => `tasks/${write.taskId}/${write.path}`)],
       physicalEntityId: decisionEntityId(action.decisionId),
       authoredRoot
     });
@@ -133,6 +134,7 @@ export function productionObservedWriteAttemptIntent(
       ],
       baseRefs: [observedWriteRef("task", `task/${action.oldTaskId}`), observedWriteRef("task", `task/${replacement}`)],
       portablePaths: writes.map((write) => `tasks/${write.taskId}/${write.path}`),
+      requiredPathCasPaths: [`tasks/${action.oldTaskId}/INDEX.md`],
       physicalEntityId: taskEntityId(action.oldTaskId),
       authoredRoot
     });
@@ -155,6 +157,7 @@ function taskIntent(
     mutations: [{ entity: observedWriteRef("task", `task/${taskId}`), action }, ...extraMutations],
     baseRefs: [...taskIds.map((id) => observedWriteRef("task", `task/${id}`)), ...extraMutations.map((mutation) => mutation.entity)],
     portablePaths: taskIds.map((id) => `tasks/${id}/INDEX.md`),
+    requiredPathCasPaths: taskIds.map((id) => `tasks/${id}/INDEX.md`),
     physicalEntityId: taskEntityId(taskId),
     authoredRoot
   });
@@ -166,15 +169,16 @@ function observedIntent(input: {
   readonly mutations: CanonicalAttemptIntent["mutations"];
   readonly baseRefs: CanonicalAttemptIntent["baseRefs"];
   readonly portablePaths: CanonicalAttemptIntent["portablePaths"];
+  readonly requiredPathCasPaths: ReadonlyArray<string>;
   readonly physicalEntityId: string;
   readonly authoredRoot: string;
 }): CanonicalAttemptIntent {
-  const snapshots = input.portablePaths.flatMap((portablePath) => {
-    const absolute = path.join(input.authoredRoot, portablePath);
-    if (!existsSync(absolute)) return [];
-    const body = readFileSync(absolute, "utf8");
-    const digest = sha256Text(body);
-    return [{ path: portablePath, expectedEpoch: digest, expectedRevision: 0n, expectedBlobDigest: Buffer.from(digest, "hex") }];
+  const snapshots = input.requiredPathCasPaths.map((portablePath) => {
+    const resolved = resolveHostedDocument(input.authoredRoot, portablePath);
+    if (!resolved) {
+      throw new Error(`AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED:path=${portablePath}`);
+    }
+    return { path: resolved.portablePath, ...resolved.snapshot.cas };
   });
   return {
     commandName: input.commandName,

--- a/packages/cli/src/daemon/production-authority-semantic-state.ts
+++ b/packages/cli/src/daemon/production-authority-semantic-state.ts
@@ -16,6 +16,17 @@ export function hostedSnapshot(authoredRoot: string, portablePath: string): {
   readonly body: string;
   readonly cas: { readonly expectedEpoch: string; readonly expectedRevision: bigint; readonly expectedBlobDigest: Uint8Array };
 } | null {
+  return resolveHostedDocument(authoredRoot, portablePath)?.snapshot ?? null;
+}
+
+export function resolveHostedDocument(authoredRoot: string, portablePath: string): {
+  readonly portablePath: string;
+  readonly physicalPath: string;
+  readonly snapshot: {
+    readonly body: string;
+    readonly cas: { readonly expectedEpoch: string; readonly expectedRevision: bigint; readonly expectedBlobDigest: Uint8Array };
+  };
+} | null {
   const taskDocument = /^tasks\/([^/]+)\/(.+)$/u.exec(portablePath);
   const rootDir = path.dirname(authoredRoot);
   const absolute = taskDocument
@@ -23,5 +34,10 @@ export function hostedSnapshot(authoredRoot: string, portablePath: string): {
     : path.join(authoredRoot, portablePath);
   if (!existsSync(absolute)) return null;
   const body = readFileSync(absolute, "utf8");
-  return { body, cas: { expectedEpoch: sha256Text(body), expectedRevision: 0n, expectedBlobDigest: Buffer.from(sha256Text(body), "hex") } };
+  const digest = sha256Text(body);
+  return {
+    portablePath,
+    physicalPath: absolute,
+    snapshot: { body, cas: { expectedEpoch: digest, expectedRevision: 0n, expectedBlobDigest: Buffer.from(digest, "hex") } }
+  };
 }

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -51,6 +51,7 @@ import { verifyProductionCommandParity } from "./production-parity.ts";
 import { verifyTypedMinimalParameterMatrix } from "./minimal-parameter-matrix.ts";
 import { verifyProductionPresetIngress } from "./preset-ingress.ts";
 import { verifyOmittedIngressRegressions } from "./omitted-ingress-regressions.ts";
+import { verifySluggedTaskRelatePathCas } from "./slugged-path-cas.ts";
 
 test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 240_000 }, async () => {
   const fixture = createFixture();
@@ -138,6 +139,7 @@ test("production service route preserves progress dry-run and publishes canonica
       "task", "claim", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8", "--execution-id", "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG7"
     ], initialLeaseEnv);
     assert.equal(initialSluggedClaim.status, 0, JSON.stringify(initialSluggedClaim.receipt));
+    verifySluggedTaskRelatePathCas(fixture, initialLeaseEnv);
 
     const dryRunHead = git(fixture.authoredRoot, "rev-parse", "HEAD");
     const dryRun = runRawJsonMaybeFail(fixture.repoRoot, [

--- a/packages/cli/test/production-authority-canonical-ingress/slugged-path-cas.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/slugged-path-cas.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import type { ProductionCanonicalIngressFixture } from "./fixture.ts";
+import { runRawJsonMaybeFail } from "../helpers/daemon-cli.ts";
+
+export function verifySluggedTaskRelatePathCas(
+  fixture: ProductionCanonicalIngressFixture,
+  env: Readonly<Record<string, string>>
+): void {
+  const result = runRawJsonMaybeFail(fixture.repoRoot, [
+    "task", "relate", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8", "depends-on",
+    "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "--rationale", "Slugged portable-path CAS parity."
+  ], env);
+  assert.equal(result.status, 0, JSON.stringify(result.receipt));
+  assert.equal(result.receipt.ok, true, JSON.stringify(result.receipt));
+}

--- a/packages/cli/test/production-authority-observed-write-path-cas.test.ts
+++ b/packages/cli/test/production-authority-observed-write-path-cas.test.ts
@@ -68,7 +68,13 @@ test("observed-write path CAS matches the authority read set for slugged task pa
     const resolved = resolveHostedDocument(fixture.authoredRoot, one);
     assert.ok(resolved);
     assert.equal(resolved.portablePath, one);
-    assert.match(resolved.physicalPath, new RegExp(`${fixture.sourceTaskId}-source/INDEX\\.md$`, "u"));
+    // portablePath stays logical (forward slashes, asserted above); physicalPath is a native
+    // path, so build the expected suffix with path.join rather than hard-coding a separator.
+    const sluggedSuffix = path.join(`${fixture.sourceTaskId}-source`, "INDEX.md");
+    assert.ok(
+      resolved.physicalPath.endsWith(sluggedSuffix),
+      `physicalPath should resolve into the slugged package (expected suffix ${sluggedSuffix}): ${resolved.physicalPath}`
+    );
   } finally {
     rmSync(fixture.rootDir, { recursive: true, force: true });
   }

--- a/packages/cli/test/production-authority-observed-write-path-cas.test.ts
+++ b/packages/cli/test/production-authority-observed-write-path-cas.test.ts
@@ -1,0 +1,111 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { decisionEntityId, taskEntityId, type WriteOp } from "../../kernel/src/index.ts";
+import type { ParsedCommand } from "../src/cli/types.ts";
+import { productionObservedWriteAttemptIntent } from "../src/daemon/production-authority-observed-write-intents.ts";
+import { resolveHostedDocument } from "../src/daemon/production-authority-semantic-state.ts";
+
+test("observed-write path CAS matches the authority read set for slugged task packages", () => {
+  const fixture = createPathCasFixture();
+  try {
+    const one = `tasks/${fixture.sourceTaskId}/INDEX.md`;
+    const two = [one, `tasks/${fixture.targetTaskId}/INDEX.md`];
+    const operation = (kind: WriteOp["kind"], entityId = taskEntityId(fixture.sourceTaskId), payload: unknown = {
+      path: "INDEX.md", body: fixture.body
+    }) => ({ opId: "path-cas-test", entityId, kind, payload }) as WriteOp;
+    const taskCommand = (action: object) => ({ action } as unknown as ParsedCommand);
+
+    const cases = [
+      ["task-amend", taskCommand({ kind: "task-amend", taskId: fixture.sourceTaskId, patches: [] }), operation("doc_write"), [one]],
+      ["task-archive", taskCommand({ kind: "task-archive", taskId: fixture.sourceTaskId, reason: "done" }), operation("package_archive"), [one]],
+      ["task-delete soft", taskCommand({ kind: "task-delete", taskId: fixture.sourceTaskId, mode: "soft", reason: "cleanup" }), operation("package_tombstone"), [one]],
+      ["task-reopen", taskCommand({ kind: "task-reopen", taskId: fixture.sourceTaskId, reason: "needed" }), operation("package_reopen"), [one]],
+      ["task-relate", taskCommand({
+        kind: "task-relate", sourceTaskId: fixture.sourceTaskId, targetTaskId: fixture.targetTaskId,
+        relationType: "depends-on", rationale: "needs target", dryRun: false
+      }), operation("doc_write"), two],
+      ["task-supersede existing", taskCommand({
+        kind: "task-supersede", oldTaskId: fixture.sourceTaskId, byTaskId: fixture.targetTaskId
+      }), operation("package_archive"), two],
+      ["task-supersede writes", taskCommand({ kind: "task-supersede", oldTaskId: fixture.sourceTaskId }), operation(
+        "package_supersede", taskEntityId(fixture.sourceTaskId), {
+          writes: [
+            { taskId: fixture.sourceTaskId, path: "INDEX.md", body: fixture.body },
+            { taskId: fixture.newTaskId, path: "INDEX.md", body: fixture.body, packageSlug: "replacement" },
+            { taskId: fixture.newTaskId, path: "relations.md", body: "replacement relation", packageSlug: "replacement" }
+          ]
+        }
+      ), [one]],
+      ["decision-relation-replace task write", taskCommand({
+        kind: "decision-relation-replace", decisionId: fixture.decisionId, relationId: "rel_old"
+      }), operation("relation_replace", decisionEntityId(fixture.decisionId), {
+        decision: {
+          schema: "decision-package/v1", decision_id: fixture.decisionId, title: "Path CAS", state: "proposed",
+          riskTier: "medium", urgency: "medium", vertical: "software/coding", preset: "architecture-decision",
+          applies_to: { modules: ["cli"], productLines: [] }, proposedAt: "2026-07-19T00:00:00.000Z",
+          provenance: [{ runtime: "codex", sessionId: "path-cas-test", boundAt: "2026-07-19T00:00:00.000Z" }],
+          question: "Does CAS resolve slugged tasks?", chosen: [{ id: "CH1", text: "Yes" }],
+          rejected: [{ id: "RJ1", text: "No", why_not: "The shared resolver finds them." }], claims: [],
+          relations: [{
+            relation_id: "rel_new", source: `decision/${fixture.decisionId}`, target: `task/${fixture.sourceTaskId}`,
+            type: "derives", strength: "strong", direction: "directed", origin: "declared",
+            rationale: "materialize task priority", state: "active"
+          }]
+        },
+        taskWrites: [{ taskId: fixture.sourceTaskId, path: "INDEX.md", body: fixture.body }]
+      }), [`decisions/decision-${fixture.decisionId}/decision.md`, one]]
+    ] as const;
+
+    for (const [label, command, write, expected] of cases) {
+      const intent = productionObservedWriteAttemptIntent(command, write, fixture.authoredRoot);
+      assert.deepEqual(intent.declaredPathCas.map((entry) => entry.path), expected, label);
+    }
+
+    const resolved = resolveHostedDocument(fixture.authoredRoot, one);
+    assert.ok(resolved);
+    assert.equal(resolved.portablePath, one);
+    assert.match(resolved.physicalPath, new RegExp(`${fixture.sourceTaskId}-source/INDEX\\.md$`, "u"));
+  } finally {
+    rmSync(fixture.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("observed-write attempt compilation fails explicitly when required path CAS cannot resolve", () => {
+  const fixture = createPathCasFixture();
+  try {
+    const missingTaskId = "task_01KXT3E1MN1VBS64DCNZ4VX99Z";
+    assert.throws(() => productionObservedWriteAttemptIntent({
+      action: { kind: "task-amend", taskId: missingTaskId, patches: [] }
+    } as unknown as ParsedCommand, {
+      opId: "path-cas-test", entityId: taskEntityId(missingTaskId), kind: "doc_write",
+      payload: { path: "INDEX.md", body: fixture.body }
+    }, fixture.authoredRoot), new RegExp(`AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED:path=tasks/${missingTaskId}/INDEX\\.md`, "u"));
+  } finally {
+    rmSync(fixture.rootDir, { recursive: true, force: true });
+  }
+});
+
+function createPathCasFixture() {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-observed-path-cas-"));
+  const authoredRoot = path.join(rootDir, "harness");
+  const sourceTaskId = "task_01KXT3E1MN1VBS64DCNZ4VX82B";
+  const targetTaskId = "task_01KXT3E1MN1VBS64DCNZ4VX82C";
+  const newTaskId = "task_01KXT3E1MN1VBS64DCNZ4VX82D";
+  const decisionId = "dec_01KXT3E1MN1VBS64DCNZ4VX82E";
+  const taskBody = (taskId: string) => `---\nschema: task-package/v2\ntask_id: ${taskId}\n---\n`;
+  mkdirSync(authoredRoot, { recursive: true });
+  writeFileSync(path.join(authoredRoot, "harness.yaml"), "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n");
+  for (const [taskId, slug] of [[sourceTaskId, "source"], [targetTaskId, "target"]]) {
+    const taskRoot = path.join(authoredRoot, "tasks", `${taskId}-${slug}`);
+    mkdirSync(taskRoot, { recursive: true });
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskBody(taskId));
+  }
+  const decisionRoot = path.join(authoredRoot, "decisions", `decision-${decisionId}`);
+  mkdirSync(decisionRoot, { recursive: true });
+  writeFileSync(path.join(decisionRoot, "decision.md"), "# Decision\n");
+  return { rootDir, authoredRoot, sourceTaskId, targetTaskId, newTaskId, decisionId, body: taskBody(sourceTaskId) };
+}

--- a/tools/check-cli-daemon-parity.mjs
+++ b/tools/check-cli-daemon-parity.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -7,14 +7,13 @@ import { parseArgs } from "../packages/cli/src/cli/parse-args.ts";
 import { productionAuthorityTypedIngressKinds } from "../packages/cli/src/cli/command-spec/index.ts";
 import { commandRunPayload } from "../packages/cli/src/daemon/client.ts";
 import { createCliCommandService } from "../packages/cli/src/daemon/command-service.ts";
+import { productionObservedWriteAttemptIntent } from "../packages/cli/src/daemon/production-authority-observed-write-intents.ts";
+import { resolveHostedDocument } from "../packages/cli/src/daemon/production-authority-semantic-state.ts";
+import { taskEntityId } from "../packages/kernel/src/index.ts";
 
 const missingTask = "task_01KXT3E1MN1VBS64DCNZ4VX81B";
 const missingExecution = "exe_01KXT3E1MN1VBS64DCNZ4VX81C";
 const missingDecision = "dec_01KXT3E1MN1VBS64DCNZ4VX81D";
-
-export const parityCoverageNotices = [
-  "S4 task-relate slugged portable-path CAS is not covered by this gate; deferred follow-up: harness/tasks/task_01KXVE678398194FA9YYKX95YJ-cli-daemon-parity-gate-b/artifacts/FOLLOWUP-S4-portable-path-cas.md"
-];
 
 const cases = {
   "session-export": ["session", "export"],
@@ -110,10 +109,45 @@ export async function checkCliDaemonParity() {
     }
 
     await checkDryRunWriteBarrier(findings);
+    checkSluggedTaskRelatePathCas(findings);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
   return findings;
+}
+
+function checkSluggedTaskRelatePathCas(findings) {
+  const rootDir = makeRoot();
+  try {
+    const authoredRoot = path.join(rootDir, "harness");
+    const sourceTaskId = "task_01KXT3E1MN1VBS64DCNZ4VX82B";
+    const targetTaskId = "task_01KXT3E1MN1VBS64DCNZ4VX82C";
+    seedTask(rootDir, sourceTaskId, "source-slug");
+    seedTask(rootDir, targetTaskId, "target-slug");
+    const sourcePath = `tasks/${sourceTaskId}/INDEX.md`;
+    const targetPath = `tasks/${targetTaskId}/INDEX.md`;
+    const intent = productionObservedWriteAttemptIntent({
+      action: {
+        kind: "task-relate", sourceTaskId, targetTaskId, relationType: "depends-on",
+        rationale: "slugged portable-path CAS parity", dryRun: false
+      }
+    }, {
+      opId: "parity-gate", entityId: taskEntityId(sourceTaskId), kind: "doc_write",
+      payload: { path: "INDEX.md", body: readFileSync(resolveHostedDocument(authoredRoot, sourcePath).physicalPath, "utf8") }
+    }, authoredRoot);
+    const declared = intent.declaredPathCas.map((entry) => entry.path);
+    if (JSON.stringify(declared) !== JSON.stringify([sourcePath, targetPath])) {
+      findings.push(`task-relate slugged path CAS: declared/required paths differ; declared=${JSON.stringify(declared)} required=${JSON.stringify([sourcePath, targetPath])}`);
+    }
+    for (const portablePath of [sourcePath, targetPath]) {
+      const resolved = resolveHostedDocument(authoredRoot, portablePath);
+      if (!resolved || path.basename(path.dirname(resolved.physicalPath)) === portablePath.split("/")[1]) {
+        findings.push(`task-relate slugged path CAS: shared resolver did not resolve ${portablePath} to a slugged physical task package`);
+      }
+    }
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
 }
 
 async function checkDryRunWriteBarrier(findings) {
@@ -152,8 +186,8 @@ async function checkDryRunWriteBarrier(findings) {
   }
 }
 
-function seedTask(rootDir, taskId) {
-  const taskDir = path.join(rootDir, "harness", "tasks", taskId);
+function seedTask(rootDir, taskId, slug = "") {
+  const taskDir = path.join(rootDir, "harness", "tasks", `${taskId}${slug ? `-${slug}` : ""}`);
   mkdirSync(taskDir, { recursive: true });
   writeFileSync(path.join(taskDir, "INDEX.md"), [
     "---",
@@ -271,7 +305,6 @@ async function main() {
     return;
   }
   console.log(`CLI-daemon executable parity check passed (${Object.keys(cases).length} live typed write commands, dual-arm; includes all 25 interface-snapshot rows).`);
-  for (const notice of parityCoverageNotices) console.warn(`CLI-daemon parity coverage notice: ${notice}`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main();

--- a/tools/check-cli-daemon-parity.test.mjs
+++ b/tools/check-cli-daemon-parity.test.mjs
@@ -1,7 +1,7 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import test from "node:test";
-import { checkCliDaemonParity, parityCoverageNotices, parityOutcome } from "./check-cli-daemon-parity.mjs";
+import { checkCliDaemonParity, parityOutcome } from "./check-cli-daemon-parity.mjs";
 
 test("CLI-daemon parity gate executes the complete typed write matrix", { timeout: 30_000 }, async () => {
   assert.deepEqual(await checkCliDaemonParity(), []);
@@ -11,10 +11,4 @@ test("CLI-daemon parity comparison preserves negative error codes", () => {
   const ordinary = parityOutcome({ ok: false, command: "decision amend", error: { code: "decision_read_failed" } });
   const masked = parityOutcome({ ok: false, command: "decision amend", error: { code: "command_receipt_contract_mismatch" } });
   assert.notDeepEqual(masked, ordinary);
-});
-
-test("CLI-daemon parity gate explicitly names the deferred S4 coverage", () => {
-  assert.equal(parityCoverageNotices.length, 1);
-  assert.match(parityCoverageNotices[0], /S4 task-relate slugged portable-path CAS is not covered/u);
-  assert.match(parityCoverageNotices[0], /FOLLOWUP-S4-portable-path-cas\.md/u);
 });


### PR DESCRIPTION
# English

## Summary

`ha task relate` was unconditionally broken in production with an opaque `BASE_CAS_CONFLICT`. Root cause: the CLI declared portable-path CAS by joining `tasks/<bare-id>/INDEX.md` onto the authored root, while the authority resolves task documents through the task package resolver, which honours the `-<slug>` suffix. Every canonical task package directory is slugged, so the CLI's paths resolved to nothing — and the code **silently dropped** unresolvable paths, turning "I cannot find this file" into "I declare zero paths". Declared 0 vs required N then surfaced downstream under a completely unrelated name.

## What Changed

- **One shared resolver.** `resolveHostedDocument` maps logical portable path → physical path → snapshot. The authority semantic state and the CLI attempt compiler now both read task packages through it, so the two ends cannot drift again.
- **CAS declared from the authority's actual read set**, not from a guess: task amend/archive/soft-delete/reopen 1 each, task relate 2, supersede-with-existing-replacement 2, supersede creating a replacement 1 (old task only), decision relation replace adds a snapshot only when it really writes a task.
- **Unresolvable required documents now fail explicitly** (`AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED:path=…`) instead of being dropped.
- **The opaque error string is split**: `ENTITY_BASE_CAS_CONFLICT` vs `PATH_CAS_CONFLICT`, each carrying the claimed/required counts or the specific ref/path.
- **The parity gate grew a slugged task fixture** covering `task-relate`'s declared and required paths plus physical resolution.

## Task And Scope

Task `task_01KXVHHG2RGTDS0S61WRYYSX5Q`. Scope is the S4 divergence carried over from PR #922, which detected it and explicitly deferred it. No CI config, gate manifest, or production authority state was touched.

## Version Impact

No public API or schema version change. `PATH_CAS_CONFLICT` / `ENTITY_BASE_CAS_CONFLICT` are narrower admission reasons replacing one `BASE_CAS_CONFLICT` string; in-repo assertions are updated.

## Governance Declaration

Authorization: `dec_01KXVGK39C0K0WVGYT1Z3APX1J` (S4 ruling, active — amendment `CH2` corrects the root cause from entity-base CAS to path CAS) and `task_01KXVHHG2RGTDS0S61WRYYSX5Q`. This change is confined to the CLI write-intent declaration and the authority helper error naming; it neither widens the write road nor relaxes any gate.

## Verification

**Mutation test run by the reviewer, not read from a report.** Removing the protected mechanism — the slug-aware branch in `resolveHostedDocument`, replaced by the old bare join — turns the fixture red, and it fails *by name*:

```
✖ observed-write path CAS matches the authority read set for slugged task packages
  Error: AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED:path=tasks/task_01KXT3E1MN1VBS64DCNZ4VX82B/INDEX.md
```

Restoring the file byte-identically returns 4/4 green. The check can fail for the thing it claims to check.

- Red/green regression by the implementer: baseline bare `path.join` restored → 2/2 fail, first divergence stable at `task-amend actual=[]`.
- Production-authority integration runner 2/2, including a real claim-then-slugged-`task relate` submission.
- `npm run check:local` after rebase onto `ee1cc8e0`: 33/33 manifest gates green, affected fast 394/394, affected contract 457/457.

## Review Evidence

The obvious one-line fix was a trap, and it was flagged as such before dispatch: swapping in the shared resolver and snapshotting every `portablePath` moves `task.supersede`'s writes branch from claimed 0 to claimed 3 against a required 1 — trading one failure for another. The implementer derived the declaration from the authority's actual read set instead, and a contract test pins the supersede branch at 1.

The reviewer's own earlier root-cause ruling was wrong: it named entity-base CAS, but production's `readEntityBase` also returns `null` unconditionally, so that comparison never throws. The ruling was corrected by amendment `CH2` on the decision rather than silently rewritten, and the specimen document keeps the falsified reasoning visible.

## Residual Risk

1. Entity-base semantics are unchanged — `readEntityBase` still returns `null` in production, so entity-base CAS remains inert. That is pre-existing and out of scope here.
2. Callers outside this repository that match on the literal `BASE_CAS_CONFLICT` need the release note; in-repo assertions are migrated.
3. No write command was executed against real production authority; behaviour is evidenced by the isolated-root integration fixture. A live production `task relate` is the intended post-merge proof.

## References

- PR #922 (parity gate B) — detected S4 and deferred it
- `harness/tasks/task_01KXVHHG2RGTDS0S61WRYYSX5Q-…/artifacts/REPORT-s4.md`

---

# 中文

## 概要

`ha task relate` 在生产上恒定失败,只报一个不透明的 `BASE_CAS_CONFLICT`。根因:CLI 声明 portable path CAS 时把 `tasks/<裸 id>/INDEX.md` 直接拼到 authored root 上,而服务端走 task package resolver、认 `-<slug>` 后缀。所有 canonical 任务包目录都带 slug,于是 CLI 拼出的路径全部落空——而代码对无法解析的路径**静默丢弃**,把"我找不到这个文件"伪装成"我声明了 0 条路径"。declared 0 vs required N 随后在下游以一个毫不相干的名字爆出来。

## 改动内容

- **一套共享 resolver**:`resolveHostedDocument` 完成 logical portable path → physical path → snapshot 的映射。authority semantic state 与 CLI attempt 编译器现在都经它读任务包,两端不可能再各说各话。
- **按 authority 的实际读取集声明 CAS**,不靠猜:task amend/archive/软删除/reopen 各 1 条,task relate 2 条,已有 replacement 的 supersede 2 条,新建 replacement 的 supersede 只声明旧任务 1 条,decision relation replace 仅在真的写任务时追加。
- **必需文档解析不出来时显式失败**(`AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED:path=…`),不再丢弃。
- **拆开那个不透明的错误字符串**:`ENTITY_BASE_CAS_CONFLICT` 与 `PATH_CAS_CONFLICT`,各自带上 claimed/required 数量或具体 ref/path。
- **parity gate 新增 slugged 任务 fixture**,覆盖 `task-relate` 的 declared / required 两条路径及物理解析结果。

## 任务与范围

任务 `task_01KXVHHG2RGTDS0S61WRYYSX5Q`。范围是 PR #922 检出并显式推迟的 S4 发散。未触碰 CI 配置、gate manifest 与生产 authority 状态。

## 版本影响

无公开 API 或 schema 版本变更。`PATH_CAS_CONFLICT` / `ENTITY_BASE_CAS_CONFLICT` 是替代单一 `BASE_CAS_CONFLICT` 的更窄 admission reason,仓库内断言已同步迁移。

## 治理声明

授权来源:`dec_01KXVGK39C0K0WVGYT1Z3APX1J`(S4 裁决,active——修订 `CH2` 把根因从 entity base CAS 更正为 path CAS)与 `task_01KXVHHG2RGTDS0S61WRYYSX5Q`。本改动只限于 CLI 写意图声明与 authority helper 的错误命名,既不拓宽写路,也不放松任何门。

## 验证

**验收者亲跑的突变测试,不是读报告。** 移除被保护的机制——`resolveHostedDocument` 里那条 slug-aware 分支,换回旧的裸 join——fixture 立刻变红,而且**是按名字红的**:

```
✖ observed-write path CAS matches the authority read set for slugged task packages
  Error: AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED:path=tasks/task_01KXT3E1MN1VBS64DCNZ4VX82B/INDEX.md
```

逐字节还原后回到 4/4 全绿。这个检查能因它所声称检查的那件事而失败。

- 实现者的 red/green 回归:恢复基线裸 `path.join` → 2/2 失败,首个差异稳定为 `task-amend actual=[]`。
- 正式 production-authority integration runner 2/2,其中含先 claim 后 slugged `task relate` 的真实提交。
- rebase 到 `ee1cc8e0` 后 `npm run check:local`:33/33 manifest gate 全绿,affected fast 394/394,affected contract 457/457。

## 审查证据

那个显而易见的一行修复是陷阱,派活前已被点名:把裸 join 换成共享 resolver 再对全部 `portablePath` 取 snapshot,会让 `task.supersede` 的 writes 分支从 claimed 0 变 claimed 3 而 required 是 1——从一个失败换成另一个失败。实现者改为从 authority 的实际读取集派生声明,并用契约测试把 supersede 分支钉在 1 条。

验收者自己早先的根因裁定是**错的**:它指向 entity base CAS,但生产侧 `readEntityBase` 同样无条件返回 `null`,那个比较根本不会抛。该裁定通过决策的 `CH2` 修订更正,而非静默改写;标本文档保留了被证伪的推理过程。

## 残余风险

1. entity base 语义未变——生产上 `readEntityBase` 仍返回 `null`,entity base CAS 依然是空转。这是既有状况,不在本次范围。
2. 仓库外硬编码 `BASE_CAS_CONFLICT` 字面量的调用方需要发布说明;仓库内断言已迁移。
3. 未对真实生产 authority 执行写命令,行为由隔离临时根的 integration fixture 佐证。合并后在生产上真跑一次 `task relate` 是既定的验证动作。

## 关联材料

- PR #922(parity gate B)——检出 S4 并推迟
- `harness/tasks/task_01KXVHHG2RGTDS0S61WRYYSX5Q-…/artifacts/REPORT-s4.md`
