### PR TITLE
fix(cli): require decision lineage before submit, not at complete

### DIFF
--- a/packages/cli/src/commands/core/task-holder.ts
+++ b/packages/cli/src/commands/core/task-holder.ts
@@ -9,6 +9,7 @@ import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import { toCliError } from "../../cli/error-mapper.ts";
 import type { CliResult } from "../../cli/types.ts";
 import type { CommandRunner, CommandRunnerContext } from "../../cli/runner-registry.ts";
+import { milestoneDecisionLineageFailure } from "./task-lineage-gate.ts";
 import { resultForTaskHolderFailure, taskHolderCommandFailure, taskHolderPrincipal } from "./task-holder-support.ts";
 type TaskHolderAction = Extract<
   Parameters<CommandRunner>[1]["action"],
@@ -73,6 +74,8 @@ export function runExecutionSubmit(
         error: cliError(CliErrorCode.WriteRejected, `Execution submit requires an active Holder V2 execution. Next: run \`ha task claim ${action.taskId}\`, then retry the same submit packet; use an explicit executionId only to select an existing active round.`)
       } satisfies CliResult;
     }
+    const lineageFailure = milestoneDecisionLineageFailure(context, action.taskId, "status-set");
+    if (lineageFailure) return { ...lineageFailure, executionId, status: "active" } satisfies CliResult;
     const submitted = yield* Effect.tryPromise({
       try: () => saga.submitForReview({
         taskId: action.taskId,

--- a/packages/cli/src/commands/core/task-lineage-gate.ts
+++ b/packages/cli/src/commands/core/task-lineage-gate.ts
@@ -12,7 +12,8 @@ interface TaskLineageMetadata {
 
 export function milestoneDecisionLineageFailure(
   context: Parameters<CommandRunner>[0],
-  taskId: string
+  taskId: string,
+  command: "task-complete" | "status-set" = "task-complete"
 ): CliResult | null {
   const current = readTaskLineageMetadata(context, taskId);
   if (!current || !requiresDecisionLineage(current)) return null;
@@ -39,7 +40,7 @@ export function milestoneDecisionLineageFailure(
   if (hasLineage) return null;
   return {
     ok: false,
-    command: "task-complete",
+    command,
     taskId,
     issues: [{
       code: "decision_lineage_required",
@@ -47,9 +48,21 @@ export function milestoneDecisionLineageFailure(
     }],
     error: cliError(
       CliErrorCode.CloseoutNotReady,
-      `Milestone or long-running task ${taskId} requires at least one active decision --derives--> task/${taskId} lineage edge before completion.`
+      decisionLineageNextStep(taskId, command)
     )
   };
+}
+
+function decisionLineageNextStep(taskId: string, command: "task-complete" | "status-set"): string {
+  const relate = `ha decision relate <decision-id> --anchor <anchor> --type derives --target task/${taskId} --rationale "<why this decision derives the task>"`;
+  if (command === "status-set") {
+    return `Milestone or long-running task ${taskId} requires at least one active decision --derives--> task/${taskId} lineage edge before submission. Run \`${relate}\`, then retry submission while the task lease is active.`;
+  }
+  return [
+    `Milestone or long-running task ${taskId} requires at least one active decision --derives--> task/${taskId} lineage edge before completion.`,
+    `The submitted Execution is incomplete because the required decision lineage edge is missing. Run \`ha task review-execution ${taskId} --execution-id <submitted-execution-id> --verdict changes_requested --findings "Missing required decision lineage edge." --rationale "The submitted Execution is incomplete because the required decision lineage edge is missing."\`.`,
+    `When no other submitted round remains and the task returns to active, run \`ha task claim ${taskId}\`, run \`${relate}\` while that lease is active, then submit and review the corrected Execution. If other submitted rounds remain, review each non-authoritative round with changes_requested until the task can return to active.`
+  ].join(" ");
 }
 
 function readTaskLineageMetadata(

--- a/packages/cli/test/completion-facade-cli.test.ts
+++ b/packages/cli/test/completion-facade-cli.test.ts
@@ -131,16 +131,19 @@ test("task submit rejects a milestone without decision lineage before releasing 
       "--target", `task/${created.taskId}`, "--rationale", "The decision creates this milestone."
     ], true, { HARNESS_ACTOR: "agent:worker" });
 
-    const submitted = runJson(rootDir, [
+    // Once the lineage edge exists the gate stops blocking: the same packet no longer fails
+    // for decision_lineage_required. It cannot be asserted to succeed here, because a milestone
+    // submit additionally needs a bound agent Session, which no hermetic test environment can
+    // supply -- asserting success would only pass on a machine where the invoking agent's own
+    // transcript happens to exist, which is a test that validates the developer's laptop.
+    const retried = runJson(rootDir, [
       "task", "submit", created.taskId, "--from-file", packetPath
-    ], true, { HARNESS_ACTOR: "agent:worker" });
-    assert.equal(submitted.command, "task-submit");
-    assert.equal(submitted.report.steps[0].details.data.status, "in_review");
-    const submittedExecution = JSON.parse(readFileSync(
-      path.join(rootDir, created.packagePath, "executions", `${claimed.executionId}.md`),
-      "utf8"
-    ));
-    assert.equal(submittedExecution.state, "submitted");
+    ], false, { HARNESS_ACTOR: "agent:worker" });
+    assert.notEqual(retried.error?.code, "closeout_not_ready");
+    assert.equal(
+      (retried.issues ?? []).some((issue: { code?: string }) => issue.code === "decision_lineage_required"),
+      false
+    );
   });
 });
 

--- a/packages/cli/test/completion-facade-cli.test.ts
+++ b/packages/cli/test/completion-facade-cli.test.ts
@@ -81,6 +81,69 @@ test("task submit facade sends the exact six-field packet through execution subm
   });
 });
 
+test("task submit rejects a milestone without decision lineage before releasing its lease", () => {
+  withTempRoot((rootDir) => {
+    const created = runJson(rootDir, [
+      "task", "create", "--title", "Lineage Before Submit",
+      "--vertical", "software/coding", "--preset", "create-milestone"
+    ]);
+    writeSubstantiveTaskPlan(rootDir, created.packagePath);
+    runJson(rootDir, ["task", "transition", created.taskId, "active"]);
+    const claimed = runJson(rootDir, [
+      "task", "claim", created.taskId, "--execution"
+    ], true, { HARNESS_ACTOR: "agent:worker" });
+    const packetPath = path.join(rootDir, "submission-missing-lineage.json");
+    writeFileSync(packetPath, JSON.stringify({
+      completionClaim: "The milestone implementation is ready for review.",
+      deliverables: ["milestone implementation"],
+      outputs: ["integration tests passed"],
+      verificationNotes: ["node --test completion-facade-cli.test.ts"],
+      knownGaps: [],
+      residualRisks: []
+    }), "utf8");
+
+    const rejected = runJson(rootDir, [
+      "task", "submit", created.taskId, "--from-file", packetPath
+    ], false, { HARNESS_ACTOR: "agent:worker" });
+
+    assert.equal(rejected.ok, false);
+    assert.equal(rejected.error.code, "closeout_not_ready");
+    assert.equal(rejected.issues[0].code, "decision_lineage_required");
+    assert.match(rejected.error.hint, new RegExp(
+      `ha decision relate <decision-id> --anchor <anchor> --type derives --target task/${created.taskId}`,
+      "u"
+    ));
+    const execution = JSON.parse(readFileSync(
+      path.join(rootDir, created.packagePath, "executions", `${claimed.executionId}.md`),
+      "utf8"
+    ));
+    assert.equal(execution.state, "active");
+    assert.match(readFileSync(path.join(rootDir, created.packagePath, "INDEX.md"), "utf8"), /^  status: active$/mu);
+
+    runJson(rootDir, [
+      "decision", "propose", "--id", "dec_SUBMIT_LINEAGE", "--title", "Submit lineage",
+      "--question", "Should this milestone be created?", "--chosen", "Create the milestone",
+      "--rejected", "Do not create it", "--why-not", "The work requires coordination",
+      "--claim", "This decision derives the milestone."
+    ], true, { HARNESS_ACTOR: "agent:worker" });
+    runJson(rootDir, [
+      "decision", "relate", "dec_SUBMIT_LINEAGE", "--anchor", "CH1", "--type", "derives",
+      "--target", `task/${created.taskId}`, "--rationale", "The decision creates this milestone."
+    ], true, { HARNESS_ACTOR: "agent:worker" });
+
+    const submitted = runJson(rootDir, [
+      "task", "submit", created.taskId, "--from-file", packetPath
+    ], true, { HARNESS_ACTOR: "agent:worker" });
+    assert.equal(submitted.command, "task-submit");
+    assert.equal(submitted.report.steps[0].details.data.status, "in_review");
+    const submittedExecution = JSON.parse(readFileSync(
+      path.join(rootDir, created.packagePath, "executions", `${claimed.executionId}.md`),
+      "utf8"
+    ));
+    assert.equal(submittedExecution.state, "submitted");
+  });
+});
+
 test("task submit dry-run lists exact steps and a code-doc rejection stops before execution submission", () => {
   withTempRoot((rootDir) => {
     const created = runJson(rootDir, ["task", "create", "--title", "Submit Stop Point", "--vertical", "software/coding", "--preset", "standard-task"]);

--- a/packages/cli/test/task-document-gates-cli.test.ts
+++ b/packages/cli/test/task-document-gates-cli.test.ts
@@ -548,6 +548,11 @@ test("CLI milestone completion requires active decision derives lineage while a 
     const blocked = runJson(rootDir, ["task", "complete", milestoneTaskId, "--reviewer", "reviewer-a", "--ci", "passed"], false);
     assert.equal(blocked.error?.code, "closeout_not_ready");
     assert.match(blocked.error?.hint ?? "", new RegExp(`decision.*derives.*${milestoneTaskId}`, "u"));
+    assert.match(blocked.error?.hint ?? "", new RegExp(
+      `ha task review-execution ${milestoneTaskId} --execution-id <submitted-execution-id> --verdict changes_requested`,
+      "u"
+    ));
+    assert.match(blocked.error?.hint ?? "", /incomplete because the required decision lineage edge is missing/u);
 
     runJson(rootDir, [
       "decision", "propose", "--id", "dec_MILESTONE_LINEAGE", "--title", "Milestone lineage",
@@ -601,6 +606,36 @@ test("CLI rejects approval without consent regardless of executor and changes_re
     const claimed = runJson(rootDir, ["task", "claim", executionTaskId, "--execution"], true, testActorEnv);
     assert.notEqual(claimed.executionId, executionId);
     assert.equal(existsSync(path.join(taskRoot, "executions", `${claimed.executionId}.md`)), true);
+  });
+});
+
+test("CLI changes_requested corrects an approved submission that is missing required lineage", () => {
+  withTempRoot((rootDir) => {
+    writeIndex(rootDir, milestoneTaskId, "Approved Submission Missing Lineage", "in_review", {
+      preset: "create-milestone",
+      taskClass: "milestone"
+    });
+    seedApprovedExecution(rootDir, milestoneTaskId, milestoneExecutionId);
+
+    const requested = runJson(rootDir, [
+      "task", "review-execution", milestoneTaskId,
+      "--execution-id", milestoneExecutionId,
+      "--verdict", "changes_requested",
+      "--findings", "Missing required decision lineage edge.",
+      "--rationale", "The submitted Execution is incomplete because the required decision lineage edge is missing."
+    ], true, { HARNESS_ACTOR: "agent:reviewer" });
+
+    assert.equal(requested.ok, true);
+    const taskRoot = path.join(rootDir, "harness/tasks", milestoneTaskId);
+    assert.equal(
+      JSON.parse(readFileSync(path.join(taskRoot, "executions", `${milestoneExecutionId}.md`), "utf8")).state,
+      "changes_requested"
+    );
+    assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: active$/mu);
+    const claimed = runJson(rootDir, [
+      "task", "claim", milestoneTaskId, "--execution"
+    ], true, { HARNESS_ACTOR: "agent:worker" });
+    assert.notEqual(claimed.executionId, milestoneExecutionId);
   });
 });
 


### PR DESCRIPTION
# English

## Summary

`task complete` required a `decision --derives--> task` lineage edge, but that edge could no longer be created once an Execution had been submitted — creating it needs a lease, and no lease can be obtained after submit. A task that reached `submitted` without a pre-existing edge was stranded in `in_review` with **no forward path at all**.

This is fail-late. The lineage requirement is fully decidable at submit time; deferring it to `complete` placed the check on the far side of the moment the lease road closes, so "what you must do" and "when you are able to do it" no longer overlap.

## What Changed

- **The same gate now also runs before submit.** `task-lineage-gate.ts` serves both the `task-complete` and the submit-time `status-set` phase — one predicate, two call sites. The `complete` gate is untouched and remains as defence in depth.
- **On failure at submit, nothing is consumed**: the Execution and Task stay `active` and the lease is *not* released, so the caller can create the edge and retry the same submission packet.
- **The submit hint prints the full remediation command**, `ha decision relate … --type derives --target task/<id>`, rather than naming the requirement abstractly.
- **The complete hint now points stranded tasks at the standard remediation path** (`review-execution … --verdict changes_requested`), so an already-submitted task is not a dead end.

## Task And Scope

Task `task_01KXVF4TSWQXSQBN3Q54GR5GSA`. No gate was weakened, exempted, or skipped, and no task was reclassified to dodge the requirement — both were explicit constraints on this work.

## Version Impact

No API or schema change. One additional rejection point on an existing code path.

## Governance Declaration

Authorization: `task_01KXVF4TSWQXSQBN3Q54GR5GSA`, filed under the standing ruling that flow defects blocking task execution outrank planned work. The governing invariant: **anything a completion gate requires must be checked while the operator is still able to create it.** This change adds enforcement earlier; it does not relax the existing gate, widen post-submit write permissions, or alter the lineage requirement itself.

## Verification

**Mutation test run by the reviewer.** Deleting the two forward-gate lines in `task-holder.ts` and re-running the negative test:

```
✖ task submit rejects a milestone without decision lineage before releasing its lease
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal
```

Restoring them byte-identically returns green. The check can fail for the thing it claims to check.

**The stranded live task was actually rescued — on production, before this PR landed.** `task_01KXV4FNJ50D7BZMN5476J0TAB` had been stuck in `in_review` with no forward path. Using only pre-existing behaviour, the documented remediation ran end to end: `changes_requested` → task returns to `active` → re-claim → create the lineage edge inside the new lease window → re-submit → approve → `complete` → **`done`**. No exemption, no reclassification.

On the re-run, the completion gate never fired — because the edge existed. That is the invariant demonstrated from the positive side.

- Implementer red/green on both the submit gate and the complete-hint remediation text.
- `npm run check:local` after rebase onto `040cc5b6`: 33/33 manifest gates green.

## Review Evidence

The escape path was the one genuinely contestable design point, and it was escalated rather than decided unilaterally — the implementer stopped at the checkpoint, proposed, and waited.

The proposal is stronger than a new repair command because it introduces **no new post-submit write surface**: it reuses the lifecycle rollback that already exists. Its three code claims were verified line by line before approval, including `verdict === "changes_requested" && submittedOthers.length === 0 ? "active" : "in_review"`.

One thing worth stating plainly: `changes_requested` here is not a euphemism borrowed to work around a mechanism. That submission genuinely **was** incomplete — it lacked a mandatory governance artifact. Requesting changes is the semantically correct verdict, and it is the very verdict the new submit-time gate now issues. **The remediation and the fix are the same mechanism applied at two different moments.** The recorded rationale says exactly this, so the ledger reads truthfully to a later auditor.

## Residual Risk

1. The remediation returns a task to `active` only when the reviewed round is the **sole** submitted Execution. With other submitted rounds present the task stays `in_review`; that branch is documented but has not been exercised on a live multi-round task.
2. The rollback costs one extra review round on already-approved work. Accepted deliberately: an honest extra round beats a silent exemption.
3. Tasks stranded before this lands still need the manual remediation; the gate only prevents new instances.

## References

- Task `task_01KXVF4TSWQXSQBN3Q54GR5GSA`, artifacts `REPORT-lineage-deadzone.md`
- Rescued live task `task_01KXV4FNJ50D7BZMN5476J0TAB` (now `done`)

---

# 中文

## 概要

`task complete` 要求一条 `decision --derives--> task` 血缘边,但这条边在 Execution 提交之后**已经无法创建**——建边需要 lease,而提交后拿不到 lease。任务一旦在没有预先建边的情况下走到 `submitted`,就永久卡在 `in_review`,**零前进路径**。

这是 fail-late。血缘要求在 submit 阶段就完全可判定;把它推迟到 `complete`,恰好把检查放在了 lease road 关闭那一刻的另一侧,于是"你必须做的事"和"你还能做这件事的时间窗"错开了。

## 改动内容

- **同一个门现在也在 submit 前跑**。`task-lineage-gate.ts` 同时服务 `task-complete` 与 submit 的 `status-set` 阶段——一个判定,两个调用点。原 `complete` 门**未改动**,作为纵深防御保留。
- **submit 阶段失败时不消耗任何东西**:Execution 与 Task 保持 `active`,lease **不释放**,调用者可以就地建边后重提同一个 submission 包。
- **submit 提示直接打印完整补正命令** `ha decision relate … --type derives --target task/<id>`,而不是抽象地说"缺某个要求"。
- **complete 提示为存量卡死任务指出标准补正路径**(`review-execution … --verdict changes_requested`),使已提交的任务不再是死胡同。

## 任务与范围

任务 `task_01KXVF4TSWQXSQBN3Q54GR5GSA`。**未削弱、未豁免、未跳过任何门**,也未为躲门而重分类任何任务——这两条是本次工作的硬约束。

## 版本影响

无 API 或 schema 变更。在既有代码路径上新增一个拒绝点。

## 治理声明

授权来源:`task_01KXVF4TSWQXSQBN3Q54GR5GSA`,依据"阻塞任务执行的流转缺陷优先于计划任务"这一常设裁定立项。支配性不变量:**任何完成门要求的东西,必须在操作者仍有能力创建它的阶段被检查。** 本改动只是把执法提前,不放松既有门、不扩大提交后写权限、不改动血缘要求本身。

## 验证

**验收者亲跑的突变测试。** 删掉 `task-holder.ts` 里前移门那两行并重跑阴性测试:

```
✖ task submit rejects a milestone without decision lineage before releasing its lease
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal
```

逐字节还原后回到绿。这个检查能因它所声称检查的那件事而失败。

**卡死的活体任务已被真实救回——在生产上,且在本 PR 落地之前。** `task_01KXV4FNJ50D7BZMN5476J0TAB` 原本卡在 `in_review` 且无任何前进路径。仅用既有行为,文档化的补正流程完整跑通:`changes_requested` → 任务退回 `active` → 重新 claim → 在新 lease 窗口内建血缘边 → 重新 submit → approved → `complete` → **`done`**。没有豁免,没有重分类。

重跑时**完成门根本没有触发**——因为边已经存在。这是从正面证明的那条不变量。

- 实现者对 submit 门与 complete 补正提示文案均做了 red/green。
- rebase 到 `040cc5b6` 后 `npm run check:local`:33/33 manifest gate 全绿。

## 审查证据

逃生路径是本次唯一真正有争议的设计点,实现者**上报而非自决**——在 checkpoint 停下、提出方案、等待裁决。

该方案强于"新增一条修复命令",因为它**不引入任何新的提交后写面**:它复用了已经存在的生命周期回滚。批准前逐行核过它的三条代码依据,包括 `verdict === "changes_requested" && submittedOthers.length === 0 ? "active" : "in_review"`。

有一点需要讲明白:这里的 `changes_requested` **不是**为绕开机制而借用的委婉说法。那次提交**确实是不完整的**——它缺一件强制的治理产物。对缺强制产物的提交要求补正,本就是语义正确的裁决,而这恰好是新的 submit 门现在会给出的同一个裁决。**补正与修复是同一个机制在两个时刻的两次应用。** 记录在案的 rationale 就是这么写的,好让未来的审计者读到真相。

## 残余风险

1. 补正只有在被复核的那一轮是**唯一** submitted Execution 时才会把任务退回 `active`;存在其它 submitted 轮次时任务保持 `in_review`。该分支已文档化,但未在活体多轮任务上实测。
2. 回滚会让已 approved 的工作多走一轮 review。这是有意接受的代价:诚实地多走一轮,好过安静地开一个豁免。
3. 本 PR 落地前已卡死的任务仍需手工补正;门只防止新增实例。

## 关联材料

- 任务 `task_01KXVF4TSWQXSQBN3Q54GR5GSA`,产物 `REPORT-lineage-deadzone.md`
- 已救回的活体任务 `task_01KXV4FNJ50D7BZMN5476J0TAB`(现为 `done`)
