### PR TITLE
feat(daemon): publish projection change notifications over JSON-RPC

### DIFF
--- a/packages/cli/src/commands/daemon/serve-transport.ts
+++ b/packages/cli/src/commands/daemon/serve-transport.ts
@@ -10,6 +10,7 @@ import {
   type AcceptedConnectionBinding,
   type AuthorityWireIngressHandler,
   type DaemonAuthenticationContext,
+  type JsonRpcNotification,
   type DaemonTransportConnection,
   type JsonRpcProtocolServer,
   type NamedPipeTransportServer,
@@ -40,7 +41,8 @@ export interface DaemonLocalTransportOptions {
   readonly platform?: NodeJS.Platform;
   readonly createProtocolServer: (
     authContext: DaemonAuthenticationContext,
-    acceptedConnection?: AcceptedConnectionBinding
+    acceptedConnection: AcceptedConnectionBinding | undefined,
+    notificationSink: (notification: JsonRpcNotification) => void
   ) => JsonRpcProtocolServer;
   readonly acceptSshForcedCommand: (frame: SshAuthenticatedBootstrapFrame) => boolean;
   readonly authorityWireIngress?: AuthorityWireIngressHandler;

--- a/packages/cli/src/daemon/service-host.ts
+++ b/packages/cli/src/daemon/service-host.ts
@@ -15,6 +15,7 @@ import {
   type DaemonControlService,
   type DaemonStatusResultV2,
   type DaemonAuthenticationContext,
+  type JsonRpcNotification,
   type DaemonRepoAvailabilityFailure,
   type DaemonRepoNamespace
 } from "../../../daemon/src/index.ts";
@@ -84,7 +85,8 @@ export async function createDaemonServiceHost(
   readonly daemonId: string;
   readonly createProtocolServer: (
     authContext: DaemonAuthenticationContext,
-    acceptedConnection?: AcceptedConnectionBinding
+    acceptedConnection: AcceptedConnectionBinding | undefined,
+    notificationSink: (notification: JsonRpcNotification) => void
   ) => ReturnType<typeof createJsonRpcProtocolServer>;
   readonly acceptsSshForcedCommand: (canonicalRoot: string) => boolean;
   readonly authorityWireIngress: AuthorityWireIngressHandler;
@@ -224,7 +226,7 @@ export async function createDaemonServiceHost(
   const serviceFallbackBinding: RepoServiceBinding = selectedFallbackBinding;
   return {
     daemonId,
-    createProtocolServer: (authContext, acceptedConnection) => createJsonRpcProtocolServer({
+    createProtocolServer: (authContext, acceptedConnection, notificationSink) => createJsonRpcProtocolServer({
       daemonId,
       repos: protocolRepos(),
       services: defaultRepoBinding().services,
@@ -239,6 +241,11 @@ export async function createDaemonServiceHost(
       authContext,
       ...(acceptedConnection ? { acceptedConnection } : {}),
       ...(authorityLifecycle ? { authorityPeerPolicy: localAuthorityPeerPolicy } : {}),
+      notificationSink,
+      subscribeProjectionChanges: (repo, listener) => {
+        const repoRuntime = runtime.getRepoRuntime(repo.repoId);
+        return repoRuntime?.subscribeProjectionChanges(listener) ?? (() => undefined);
+      },
       ...(defaultRepoBinding().identity.identityProvider ? { identityProvider: defaultRepoBinding().identity.identityProvider } : {}),
       ...(defaultRepoBinding().identity.personRegistry ? { personRegistry: defaultRepoBinding().identity.personRegistry } : {}),
       ...(defaultRepoBinding().identity.identityAdminSnapshot ? { identityAdminSnapshot: defaultRepoBinding().identity.identityAdminSnapshot } : {}),

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -171,6 +171,7 @@ export type {
   JsonRpcId,
   JsonObject,
   JsonValue,
+  JsonRpcNotification,
   JsonRpcRequest,
   JsonRpcResponse,
   JsonRpcSuccessResponse

--- a/packages/daemon/src/protocol/daemon-log-dispatch.ts
+++ b/packages/daemon/src/protocol/daemon-log-dispatch.ts
@@ -7,7 +7,7 @@ import { isJsonObject, type JsonObject, type JsonRpcRequest } from "./json-rpc-t
 export function isRepoDiagnosticMethod(contract: JsonRpcMethodContract): boolean {
   return contract.method === "repo.daemon.status"
     || contract.method === "repo.daemon.logs.list"
-    || contract.mode === "notification-stub";
+    || contract.mode === "notification";
 }
 
 export async function callDaemonLogList(

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -25,6 +25,11 @@ import { daemonStatusValidationFailure, validateDaemonStatusRequest, validateDae
 import { validateRepoRuntime } from "./repo-runtime-validation.ts";
 import { resolveServicesForRepo } from "./repo-service-resolution.ts";
 import { appendJsonRpcCommandEvent, appendJsonRpcWriteEventIfNeeded } from "./runtime-event-dispatch.ts";
+import {
+  createProjectionNotificationSession,
+  handleProjectionNotificationSubscription,
+  type ProjectionNotificationOptions
+} from "./projection-notification-subscription.ts";
 import { commandRootMismatch, validateForcedCommandRoot } from "./forced-command-root.ts";
 import { resolveIdentityActorForMethod } from "./identity-dispatch.ts";
 import {
@@ -92,7 +97,7 @@ export interface DaemonServiceHost {
   };
 }
 
-export interface JsonRpcServerOptions {
+export interface JsonRpcServerOptions extends ProjectionNotificationOptions {
   readonly daemonId: string;
   readonly repos: ReadonlyArray<DaemonRepoNamespace>;
   readonly services: DaemonServiceHost;
@@ -119,6 +124,7 @@ export interface JsonRpcProtocolServer {
   readonly handle: (message: JsonRpcRequest | JsonRpcRequest[]) =>
     Promise<JsonRpcResponse | JsonRpcResponse[] | undefined>;
   readonly afterResponse?: () => void;
+  readonly close?: () => Promise<void>;
 }
 
 interface ProtocolSession {
@@ -135,18 +141,20 @@ export function createJsonRpcProtocolServer(options: JsonRpcServerOptions): Json
     ...options,
     enqueueAfterResponse: (action) => afterResponseActions.push(action)
   };
+  const notificationSession = createProjectionNotificationSession();
 
   return {
     handle: async (message) => {
       if (Array.isArray(message)) {
-        const responses = await Promise.all(message.map((request) => handleRequest(request, session, repos, requestOptions)));
+        const responses = await Promise.all(message.map((request) => handleRequest(request, session, repos, requestOptions, notificationSession.subscriptions)));
         return responses.filter((response): response is JsonRpcResponse => response !== undefined);
       }
-      return handleRequest(message, session, repos, requestOptions);
+      return handleRequest(message, session, repos, requestOptions, notificationSession.subscriptions);
     },
     afterResponse: () => {
       for (const action of afterResponseActions.splice(0, afterResponseActions.length)) action();
-    }
+    },
+    close: notificationSession.close
   };
 }
 
@@ -154,7 +162,8 @@ async function handleRequest(
   request: JsonRpcRequest,
   session: ProtocolSession,
   repos: ReadonlyMap<string, DaemonRepoNamespace>,
-  options: JsonRpcServerOptions
+  options: JsonRpcServerOptions,
+  subscriptions: Map<string, () => void>
 ): Promise<JsonRpcResponse | undefined> {
   const id = request.id ?? null;
   if (!isJsonRpcRequest(request)) return errorResponse(id, -32600, "Invalid Request");
@@ -227,10 +236,9 @@ async function handleRequest(
     peerPolicy: identityOptions.authorityPeerPolicy
   });
 
-  if (contract.mode === "notification-stub") {
-    return response(stampReceipt(successReceipt(request.method, `registered no-op notification stub for ${request.method}`, {
-      subscription: "noop"
-    }), actor));
+  if (contract.mode === "notification") {
+    if (!repo) throw new Error(`validated repo namespace missing for ${request.method}`);
+    return response(stampReceipt(handleProjectionNotificationSubscription(request.method, repo, options, subscriptions), actor));
   }
 
   if (contract.namespace === "admin") {

--- a/packages/daemon/src/protocol/json-rpc-types.ts
+++ b/packages/daemon/src/protocol/json-rpc-types.ts
@@ -12,6 +12,12 @@ export interface JsonRpcRequest {
   readonly id?: JsonRpcId;
 }
 
+export interface JsonRpcNotification {
+  readonly jsonrpc: "2.0";
+  readonly method: string;
+  readonly params?: JsonObject;
+}
+
 export interface JsonRpcSuccessResponse<Result = unknown> {
   readonly jsonrpc: "2.0";
   readonly id: JsonRpcId;

--- a/packages/daemon/src/protocol/method-registry.ts
+++ b/packages/daemon/src/protocol/method-registry.ts
@@ -4,7 +4,7 @@ import type { DaemonCommandClass } from "../identity/types.ts";
 
 export const currentDaemonProtocolVersion = 1 as const;
 
-export type JsonRpcMethodMode = "active" | "notification-stub" | "reserved";
+export type JsonRpcMethodMode = "active" | "notification" | "reserved";
 export type { DaemonCommandClass };
 
 export interface JsonRpcMethodContract {
@@ -101,10 +101,10 @@ const taskHolderContracts = [
   }
 ] as const satisfies ReadonlyArray<JsonRpcMethodContract>;
 
-const notificationStubContracts = [
+const notificationContracts = [
   {
     method: "repo.notifications.subscribe",
-    mode: "notification-stub",
+    mode: "notification",
     namespace: "repo",
     inputSchemaId: "daemon.notification-subscription/v1",
     outputSchemaId: "daemon.notification-subscription-result/v1",
@@ -115,7 +115,7 @@ const notificationStubContracts = [
   },
   {
     method: "repo.notifications.unsubscribe",
-    mode: "notification-stub",
+    mode: "notification",
     namespace: "repo",
     inputSchemaId: "daemon.notification-subscription/v1",
     outputSchemaId: "daemon.notification-subscription-result/v1",
@@ -365,6 +365,6 @@ export const jsonRpcMethodContracts = [
   ...docSyncContracts,
   ...taskHolderContracts,
   ...jsonRpcServiceMethodContracts,
-  ...notificationStubContracts,
+  ...notificationContracts,
   ...adminReservedContracts
 ] as const satisfies ReadonlyArray<JsonRpcMethodContract>;

--- a/packages/daemon/src/protocol/projection-notification-subscription.ts
+++ b/packages/daemon/src/protocol/projection-notification-subscription.ts
@@ -1,0 +1,70 @@
+import { failureReceipt, successReceipt } from "./receipt-envelope.ts";
+import type { JsonRpcNotification, JsonValue } from "./json-rpc-types.ts";
+import type { DaemonRepoNamespace } from "./json-rpc-server.ts";
+
+export interface ProjectionChangeEvent {
+  readonly schema: "projection-change/v1";
+  readonly sourceHash: string;
+  readonly entities: ReadonlyArray<{ readonly kind: string; readonly id: string }>;
+}
+
+export interface ProjectionNotificationOptions {
+  readonly notificationSink?: (notification: JsonRpcNotification) => void;
+  readonly subscribeProjectionChanges?: (
+    repo: DaemonRepoNamespace,
+    listener: (event: ProjectionChangeEvent) => void
+  ) => () => void;
+}
+
+export interface ProjectionNotificationSession {
+  readonly subscriptions: Map<string, () => void>;
+  readonly close: () => Promise<void>;
+}
+
+export function createProjectionNotificationSession(): ProjectionNotificationSession {
+  const subscriptions = new Map<string, () => void>();
+  return {
+    subscriptions,
+    close: async () => {
+      for (const unsubscribe of subscriptions.values()) unsubscribe();
+      subscriptions.clear();
+    }
+  };
+}
+
+export function handleProjectionNotificationSubscription(
+  method: string,
+  repo: DaemonRepoNamespace,
+  options: ProjectionNotificationOptions,
+  subscriptions: Map<string, () => void>
+) {
+  const current = subscriptions.get(repo.repoId);
+  if (method === "repo.notifications.unsubscribe") {
+    current?.();
+    subscriptions.delete(repo.repoId);
+    return successReceipt(method, `unsubscribed from projection changes for ${repo.repoId}`, {
+      subscription: "projection-change/v1"
+    });
+  }
+  if (!options.notificationSink || !options.subscribeProjectionChanges) {
+    return failureReceipt(
+      method,
+      "notifications_unavailable",
+      "Projection notification transport is not configured. Run `ha daemon start`, reconnect through a daemon transport, then retry the subscription."
+    );
+  }
+  current?.();
+  subscriptions.set(repo.repoId, options.subscribeProjectionChanges(repo, (event) => {
+    options.notificationSink?.({
+      jsonrpc: "2.0",
+      method: "repo.projection.changed",
+      params: {
+        repo: { repoId: repo.repoId },
+        event: event as unknown as JsonValue
+      }
+    });
+  }));
+  return successReceipt(method, `subscribed to projection changes for ${repo.repoId}`, {
+    subscription: "projection-change/v1"
+  });
+}

--- a/packages/daemon/src/transport/json-rpc-stream.ts
+++ b/packages/daemon/src/transport/json-rpc-stream.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { Readable, Writable } from "node:stream";
 import type { AcceptedConnectionBinding } from "../protocol/connection-context.ts";
 import type { JsonRpcProtocolServer } from "../protocol/json-rpc-server.ts";
-import type { JsonRpcErrorResponse, JsonRpcId, JsonRpcRequest } from "../protocol/json-rpc-types.ts";
+import type { JsonRpcErrorResponse, JsonRpcId, JsonRpcNotification, JsonRpcRequest } from "../protocol/json-rpc-types.ts";
 import type {
   AcceptedConnectionEvidence,
   DaemonAuthenticationContext,
@@ -41,7 +41,8 @@ export interface JsonRpcStreamOptions {
   readonly acceptedConnectionEvidence?: AcceptedConnectionEvidence;
   readonly createProtocolServer: (
     authContext: DaemonAuthenticationContext,
-    acceptedConnection?: AcceptedConnectionBinding
+    acceptedConnection: AcceptedConnectionBinding | undefined,
+    notificationSink: (notification: JsonRpcNotification) => void
   ) => JsonRpcProtocolServer;
   readonly authenticateFirstFrame?: (
     frame: unknown,
@@ -62,9 +63,10 @@ export function serveJsonRpcStream(options: JsonRpcStreamOptions): DaemonTranspo
   let authContext = options.authContext;
   let server = options.authenticateFirstFrame
     ? undefined
-    : options.createProtocolServer(authContext, acceptedConnection);
+    : options.createProtocolServer(authContext, acceptedConnection, writeFrame);
   let waitingForAuthentication = options.authenticateFirstFrame !== undefined;
   let queue = Promise.resolve();
+  let serverClosed = false;
 
   options.input.on("data", (chunk: Buffer | string) => {
     const batch = reader.push(chunk);
@@ -75,6 +77,7 @@ export function serveJsonRpcStream(options: JsonRpcStreamOptions): DaemonTranspo
     const batch = reader.flush();
     enqueueFrames(batch.frames);
     if (batch.error) failConnection(parseError(batch.error));
+    queue = queue.then(closeProtocolServer);
   });
   options.input.on("error", (error: Error) => failConnection(error));
   options.input.once("close", invalidateGeneration);
@@ -94,6 +97,7 @@ export function serveJsonRpcStream(options: JsonRpcStreamOptions): DaemonTranspo
     close: async () => {
       await queue;
       invalidateGeneration();
+      await closeProtocolServer();
       options.input.destroy();
       options.output.end();
     }
@@ -116,7 +120,7 @@ export function serveJsonRpcStream(options: JsonRpcStreamOptions): DaemonTranspo
         return;
       }
       authContext = result.authContext ?? authContext;
-      server = options.createProtocolServer(authContext, acceptedConnection);
+      server = options.createProtocolServer(authContext, acceptedConnection, writeFrame);
       waitingForAuthentication = false;
       if (!result.forwardFrame) return;
     }
@@ -143,6 +147,13 @@ export function serveJsonRpcStream(options: JsonRpcStreamOptions): DaemonTranspo
     options.onError?.(error);
     writeFrame(streamErrorResponse(null, -32700, error.message));
     options.output.end();
+    void closeProtocolServer();
+  }
+
+  async function closeProtocolServer(): Promise<void> {
+    if (serverClosed) return;
+    serverClosed = true;
+    await server?.close?.();
   }
 
   function writeFrame(frame: unknown): void {

--- a/packages/daemon/src/transport/named-pipe.ts
+++ b/packages/daemon/src/transport/named-pipe.ts
@@ -9,6 +9,7 @@ import type {
   DaemonAuthenticationContext
 } from "./auth-context.ts";
 import { serveJsonRpcStream, type DaemonTransportConnection } from "./json-rpc-stream.ts";
+import type { JsonRpcNotification } from "../protocol/json-rpc-types.ts";
 import { authenticateSshForcedCommandFrame, type AcceptSshForcedCommand } from "./ssh-forced-command.ts";
 import { createNodeSocketAcceptedConnectionEvidenceAdapter } from "./node-socket-peer-credential.ts";
 
@@ -19,7 +20,8 @@ export interface NamedPipeTransportOptions {
   readonly acceptedConnectionEvidenceAdapter?: AcceptedConnectionEvidenceAdapter<net.Socket>;
   readonly createProtocolServer: (
     authContext: DaemonAuthenticationContext,
-    acceptedConnection?: AcceptedConnectionBinding
+    acceptedConnection: AcceptedConnectionBinding | undefined,
+    notificationSink: (notification: JsonRpcNotification) => void
   ) => JsonRpcProtocolServer;
   readonly onConnection?: (connection: DaemonTransportConnection) => void;
   readonly onConnectionClosed?: (connection: DaemonTransportConnection) => void;

--- a/packages/daemon/src/transport/ssh-exec.ts
+++ b/packages/daemon/src/transport/ssh-exec.ts
@@ -1,7 +1,9 @@
 // @slice-activation PLT-Daemon W3 transport adapters exported for daemon composition roots.
 import type { Readable, Writable } from "node:stream";
+import type { AcceptedConnectionBinding } from "../protocol/connection-context.ts";
 import type { DaemonAuthenticationContext } from "./auth-context.ts";
 import { serveJsonRpcStream, type DaemonTransportConnection } from "./json-rpc-stream.ts";
+import type { JsonRpcNotification } from "../protocol/json-rpc-types.ts";
 import type { JsonRpcProtocolServer } from "../protocol/json-rpc-server.ts";
 
 export interface SshExecBridgeOptions {
@@ -9,7 +11,11 @@ export interface SshExecBridgeOptions {
   readonly output?: Writable;
   readonly username?: string;
   readonly host?: string;
-  readonly createProtocolServer: (authContext: DaemonAuthenticationContext) => JsonRpcProtocolServer;
+  readonly createProtocolServer: (
+    authContext: DaemonAuthenticationContext,
+    acceptedConnection: AcceptedConnectionBinding | undefined,
+    notificationSink: (notification: JsonRpcNotification) => void
+  ) => JsonRpcProtocolServer;
 }
 
 export function serveSshExecBridge(options: SshExecBridgeOptions): DaemonTransportConnection {

--- a/packages/daemon/src/transport/ssh-tunnel-token.ts
+++ b/packages/daemon/src/transport/ssh-tunnel-token.ts
@@ -1,8 +1,10 @@
 // @slice-activation PLT-Daemon W3 transport adapters exported for daemon composition roots.
 import { randomBytes, randomUUID } from "node:crypto";
 import type { Readable, Writable } from "node:stream";
+import type { AcceptedConnectionBinding } from "../protocol/connection-context.ts";
 import type { AttachTokenSubject, DaemonAuthenticationContext } from "./auth-context.ts";
 import { serveJsonRpcStream, type DaemonTransportConnection, type TransportAuthenticationResult } from "./json-rpc-stream.ts";
+import type { JsonRpcNotification } from "../protocol/json-rpc-types.ts";
 import type { JsonRpcProtocolServer } from "../protocol/json-rpc-server.ts";
 
 export interface AttachTokenMetadata {
@@ -71,7 +73,11 @@ export interface SshTunnelTokenStreamOptions {
   readonly output: Writable;
   readonly endpoint?: string;
   readonly tokenStore: AttachTokenStore;
-  readonly createProtocolServer: (authContext: DaemonAuthenticationContext) => JsonRpcProtocolServer;
+  readonly createProtocolServer: (
+    authContext: DaemonAuthenticationContext,
+    acceptedConnection: AcceptedConnectionBinding | undefined,
+    notificationSink: (notification: JsonRpcNotification) => void
+  ) => JsonRpcProtocolServer;
 }
 
 export function createInMemoryAttachTokenStore(options: {

--- a/packages/daemon/src/transport/unix-socket.ts
+++ b/packages/daemon/src/transport/unix-socket.ts
@@ -24,6 +24,7 @@ import {
   isSshAuthorityWireBootstrapFrame,
   type AcceptSshForcedCommand
 } from "./ssh-forced-command.ts";
+import type { JsonRpcNotification } from "../protocol/json-rpc-types.ts";
 import type { JsonRpcProtocolServer } from "../protocol/json-rpc-server.ts";
 
 export interface UnixSocketTransportOptions {
@@ -32,7 +33,8 @@ export interface UnixSocketTransportOptions {
   readonly acceptedConnectionEvidenceAdapter?: AcceptedConnectionEvidenceAdapter<net.Socket>;
   readonly createProtocolServer: (
     authContext: DaemonAuthenticationContext,
-    acceptedConnection?: AcceptedConnectionBinding
+    acceptedConnection: AcceptedConnectionBinding | undefined,
+    notificationSink: (notification: JsonRpcNotification) => void
   ) => JsonRpcProtocolServer;
   readonly onConnection?: (connection: DaemonTransportConnection) => void;
   readonly onConnectionClosed?: (connection: DaemonTransportConnection) => void;

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -442,7 +442,7 @@ test("repo.command.run rejects payload rootDir that does not match the repo name
   assert.deepEqual(calls, []);
 });
 
-test("notification subscribe is a no-op socket and respects JSON-RPC notification semantics", async () => {
+test("notification subscribe without an id respects JSON-RPC notification semantics", async () => {
   const server = makeServer();
   await server.handle(readFixture("hello-compatible.json"));
 

--- a/packages/daemon/test/projection-notification-protocol.test.ts
+++ b/packages/daemon/test/projection-notification-protocol.test.ts
@@ -1,0 +1,71 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  makeServer,
+  readFixture,
+  resultReceipt
+} from "./json-rpc-protocol-fixtures.ts";
+
+test("repo notification subscription forwards projection changes and cleans up on disconnect", async () => {
+  const notifications: unknown[] = [];
+  let listener: ((event: unknown) => void) | undefined;
+  let unsubscribeCalls = 0;
+  const server = makeServer({
+    notificationSink: (notification) => notifications.push(notification),
+    subscribeProjectionChanges: (_repo, next) => {
+      listener = next;
+      return () => {
+        unsubscribeCalls += 1;
+        listener = undefined;
+      };
+    }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const subscribed = resultReceipt(await server.handle({
+    jsonrpc: "2.0",
+    id: "subscribe-1",
+    method: "repo.notifications.subscribe",
+    params: { repo: { repoId: "canonical" } }
+  }));
+  assert.equal(subscribed.ok, true);
+  assert.equal(subscribed.details.data.subscription, "projection-change/v1");
+
+  listener?.({
+    schema: "projection-change/v1",
+    sourceHash: "sha256:new",
+    entities: [{ kind: "task", id: "task-a" }]
+  });
+  assert.deepEqual(notifications, [{
+    jsonrpc: "2.0",
+    method: "repo.projection.changed",
+    params: {
+      repo: { repoId: "canonical" },
+      event: {
+        schema: "projection-change/v1",
+        sourceHash: "sha256:new",
+        entities: [{ kind: "task", id: "task-a" }]
+      }
+    }
+  }]);
+
+  const unsubscribed = resultReceipt(await server.handle({
+    jsonrpc: "2.0",
+    id: "unsubscribe-1",
+    method: "repo.notifications.unsubscribe",
+    params: { repo: { repoId: "canonical" } }
+  }));
+  assert.equal(unsubscribed.ok, true);
+  assert.equal(unsubscribeCalls, 1);
+  const resubscribed = resultReceipt(await server.handle({
+    jsonrpc: "2.0",
+    id: "subscribe-2",
+    method: "repo.notifications.subscribe",
+    params: { repo: { repoId: "canonical" } }
+  }));
+  assert.equal(resubscribed.ok, true);
+  await server.close();
+  assert.equal(unsubscribeCalls, 2);
+  assert.equal(listener, undefined);
+});

--- a/packages/daemon/test/projection-notification-transport.test.ts
+++ b/packages/daemon/test/projection-notification-transport.test.ts
@@ -1,0 +1,77 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { createInterface } from "node:readline";
+import { PassThrough, Writable, type Readable } from "node:stream";
+import test from "node:test";
+import { serveJsonRpcStream } from "../src/index.ts";
+
+test("JSON-RPC stream writes asynchronous server notifications and closes subscriptions", async () => {
+  const clientToServer = new PassThrough();
+  const serverToClient = new PassThrough();
+  let notify: ((notification: unknown) => void) | undefined;
+  let closes = 0;
+  const connection = serveJsonRpcStream({
+    input: clientToServer,
+    output: serverToClient,
+    transportKind: "unix-socket",
+    authContext: { transportKind: "unix-socket" },
+    createProtocolServer: (_authContext, _acceptedConnection, notificationSink) => {
+      notify = notificationSink;
+      return {
+        handle: async () => undefined,
+        close: async () => {
+          closes += 1;
+        }
+      };
+    }
+  });
+
+  notify?.({ jsonrpc: "2.0", method: "repo.projection.changed", params: { event: { schema: "projection-change/v1" } } });
+  assert.deepEqual(await readFrame(serverToClient), {
+    jsonrpc: "2.0",
+    method: "repo.projection.changed",
+    params: { event: { schema: "projection-change/v1" } }
+  });
+
+  await connection.close();
+  assert.equal(closes, 1);
+});
+
+test("JSON-RPC stream notification sink does not wait for a slow consumer", async () => {
+  const clientToServer = new PassThrough();
+  const pendingWrites: Array<() => void> = [];
+  const slowOutput = new Writable({
+    highWaterMark: 1,
+    write: (_chunk, _encoding, callback) => {
+      pendingWrites.push(callback);
+    }
+  });
+  let notify: ((notification: unknown) => void) | undefined;
+  const connection = serveJsonRpcStream({
+    input: clientToServer,
+    output: slowOutput,
+    transportKind: "unix-socket",
+    authContext: { transportKind: "unix-socket" },
+    createProtocolServer: (_authContext, _acceptedConnection, notificationSink) => {
+      notify = notificationSink;
+      return { handle: async () => undefined };
+    }
+  });
+
+  for (let index = 0; index < 100; index += 1) {
+    notify?.({ jsonrpc: "2.0", method: "repo.projection.changed", params: { sequence: index } });
+  }
+  assert.equal(pendingWrites.length, 1);
+  assert.ok(slowOutput.writableLength > 1, `expected buffered notifications, saw ${slowOutput.writableLength} bytes`);
+
+  while (pendingWrites.length > 0) pendingWrites.shift()?.();
+  await connection.close();
+});
+
+function readFrame(input: Readable): Promise<unknown> {
+  const lines = createInterface({ input });
+  return new Promise((resolve) => lines.once("line", (line) => {
+    lines.close();
+    resolve(JSON.parse(line));
+  }));
+}

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -96,6 +96,7 @@ export * from "./ports/index.ts";
 export * from "./projection/post-merge-checks.ts";
 export * from "./projection/relation-flow-frontmatter.ts";
 export * from "./projection/relation-graph-projection.ts";
+export type { ProjectionChangeEvent } from "./projection/projection-change-event.ts";
 export {
   auditTaskProvenance,
   queryExecutionProjection,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -96,7 +96,6 @@ export * from "./ports/index.ts";
 export * from "./projection/post-merge-checks.ts";
 export * from "./projection/relation-flow-frontmatter.ts";
 export * from "./projection/relation-graph-projection.ts";
-export type { ProjectionChangeEvent } from "./projection/projection-change-event.ts";
 export {
   auditTaskProvenance,
   queryExecutionProjection,

--- a/packages/kernel/src/projection/projection-change-event.ts
+++ b/packages/kernel/src/projection/projection-change-event.ts
@@ -1,0 +1,51 @@
+import type {
+  DeclaredProjectionDelta,
+  DeclaredSourceManifestRow
+} from "./sqlite-declared-source-manifest.ts";
+import type { ProjectionReadResult } from "./types.ts";
+
+/**
+ * Ephemeral invalidation payload emitted after the derived projection has been
+ * published. It deliberately contains no actor or write-audit fields; those
+ * belong to the runtime event ledger.
+ */
+export interface ProjectionChangeEvent {
+  readonly schema: "projection-change/v1";
+  readonly sourceHash: string;
+  readonly entities: ReadonlyArray<{
+    readonly kind: string;
+    readonly id: string;
+  }>;
+}
+
+export type IncrementalTaskProjectionResult = ProjectionReadResult & (
+  | { readonly mode: "incremental" | "unchanged"; readonly sourceHash: string; readonly change: ProjectionChangeEvent }
+  | { readonly mode: "rebuild"; readonly sourceHash?: undefined; readonly change?: undefined }
+);
+
+export function projectionChange(
+  sourceHash: string,
+  entities: ReadonlyArray<{ readonly kind: string; readonly id: string }>
+): ProjectionChangeEvent {
+  const unique = new Map(entities
+    .filter((entity) => entity.id.length > 0)
+    .map((entity) => [`${entity.kind}\0${entity.id}`, entity] as const));
+  return {
+    schema: "projection-change/v1",
+    sourceHash,
+    entities: [...unique.values()].sort((left, right) =>
+      left.kind.localeCompare(right.kind) || left.id.localeCompare(right.id))
+  };
+}
+
+export function declaredProjectionEntityChanges(
+  previous: ReadonlyArray<Pick<DeclaredSourceManifestRow, "sourcePath" | "sourceKind" | "primaryKey">>,
+  delta: DeclaredProjectionDelta
+): ReadonlyArray<{ readonly kind: string; readonly id: string }> {
+  const previousByPath = new Map(previous.map((row) => [row.sourcePath, row]));
+  return [
+    ...delta.manifest.deleteSourcePaths.map((sourcePath) => previousByPath.get(sourcePath)),
+    ...delta.manifest.upsertRows
+  ].filter((row): row is NonNullable<typeof row> => Boolean(row?.primaryKey))
+    .map((row) => ({ kind: row.sourceKind, id: row.primaryKey }));
+}

--- a/packages/kernel/src/projection/projection-change-publisher.ts
+++ b/packages/kernel/src/projection/projection-change-publisher.ts
@@ -1,0 +1,25 @@
+import type { ProjectionChangeEvent } from "./projection-change-event.ts";
+
+export interface ProjectionChangePublisher {
+  readonly publish: (event: ProjectionChangeEvent) => void;
+  readonly subscribe: (listener: (event: ProjectionChangeEvent) => void) => () => void;
+}
+
+export function createProjectionChangePublisher(): ProjectionChangePublisher {
+  const listeners = new Set<(event: ProjectionChangeEvent) => void>();
+  return {
+    publish: (event) => {
+      for (const listener of listeners) {
+        try {
+          listener(event);
+        } catch {
+          // One connection cannot disrupt publication or other subscribers.
+        }
+      }
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }
+  };
+}

--- a/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
@@ -42,7 +42,12 @@ import {
   hashProjectionLegacyPersonIds,
   readDeclaredProjectionSnapshots
 } from "./projection-source-snapshot.ts";
-import type { DecisionProjectionRow, ProjectionReadResult, TaskProjectionOptions, TaskProjectionRow } from "./types.ts";
+import type { DecisionProjectionRow, TaskProjectionOptions, TaskProjectionRow } from "./types.ts";
+import {
+  declaredProjectionEntityChanges,
+  projectionChange,
+  type IncrementalTaskProjectionResult
+} from "./projection-change-event.ts";
 
 export interface IncrementalProjectionPhase {
   readonly phase: "load-current" | "capture-source" | "derive-affected" | "declared-delta" | "hash-next" | "verify-source" | "source-delta" | "publish";
@@ -53,7 +58,7 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   readonly touchedPaths: ReadonlyArray<string>;
   readonly previousSourceFingerprint?: string;
   readonly onPhase?: (phase: IncrementalProjectionPhase) => void;
-}): ProjectionReadResult & { readonly mode: "incremental" | "rebuild" | "unchanged" } {
+}): IncrementalTaskProjectionResult {
   let phaseStarted = performance.now();
   const recordPhase = (phase: IncrementalProjectionPhase["phase"]): void => {
     const now = performance.now();
@@ -186,7 +191,9 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     return {
       rows: [...existing.rows].sort(compareRows),
       warnings: source.warnings,
-      mode: "unchanged"
+      mode: "unchanged",
+      sourceHash,
+      change: projectionChange(sourceHash, [])
     };
   }
 
@@ -312,7 +319,13 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   return {
     rows: taskChange.rows,
     warnings: source.warnings,
-    mode: "incremental"
+    mode: "incremental",
+    sourceHash,
+    change: projectionChange(sourceHash, [
+      ...[...affected.taskIds].map((id) => ({ kind: "task", id })),
+      ...[...affected.decisionIds].map((id) => ({ kind: "decision", id })),
+      ...declaredProjectionEntityChanges(declaredManifest, declaredDelta)
+    ])
   };
 }
 

--- a/packages/kernel/src/store/daemon-runtime-status.ts
+++ b/packages/kernel/src/store/daemon-runtime-status.ts
@@ -1,0 +1,12 @@
+import type { DaemonRepoRuntimeStatus, DaemonRuntimeStatus } from "./daemon-runtime.ts";
+
+export function toDaemonRuntimeStatus(status: DaemonRepoRuntimeStatus): DaemonRuntimeStatus {
+  return {
+    started: status.started,
+    rootDir: status.rootDir,
+    ...(status.lockPath ? { lockPath: status.lockPath, lockOwnerToken: status.lockOwnerToken } : {}),
+    queue: status.queue,
+    projectionGeneration: status.projectionGeneration,
+    ...(status.lastRecovery ? { lastRecovery: status.lastRecovery } : {})
+  };
+}

--- a/packages/kernel/src/store/daemon-runtime.ts
+++ b/packages/kernel/src/store/daemon-runtime.ts
@@ -43,6 +43,9 @@ import type {
   ExecutionEvidencePage,
   ExecutionEvidencePageQuery
 } from "../projection/sqlite-execution-evidence-reader.ts";
+import type { ProjectionChangeEvent } from "../projection/projection-change-event.ts";
+import { createProjectionChangePublisher } from "../projection/projection-change-publisher.ts";
+import { toDaemonRuntimeStatus } from "./daemon-runtime-status.ts";
 
 const defaultDaemonOperationalActor: OperationalActor = { scope: "operational", kind: "system", id: "daemon-runtime" };
 const defaultLockTtlMs = 60_000;
@@ -104,6 +107,7 @@ export interface HarnessDaemonRuntime {
   }) => WriteCoordinator;
   readonly assertWriteFenceHeld: () => Promise<void>;
   readonly admissionBudget: DaemonAdmissionBudget;
+  readonly subscribeProjectionChanges: (listener: (event: ProjectionChangeEvent) => void) => () => void;
 }
 
 export type DaemonRepoRuntimeState = "attached" | "unavailable" | "detaching" | "detached";
@@ -160,7 +164,8 @@ export function createDaemonRuntime(options: DaemonRuntimeOptions): HarnessDaemo
     queryExecutionEvidencePage: (query) => context.queryExecutionEvidencePage(query),
     createAttributedCoordinator: (input) => context.createAttributedCoordinator(input),
     assertWriteFenceHeld: () => context.assertWriteFenceHeld(),
-    admissionBudget: context.admissionBudget
+    admissionBudget: context.admissionBudget,
+    subscribeProjectionChanges: (listener) => context.subscribeProjectionChanges(listener)
   };
 }
 
@@ -257,6 +262,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
   private readonly queue: DaemonWriteQueue;
   readonly admissionBudget: DaemonAdmissionBudget;
   private readonly options: DaemonRepoRuntimeOptions;
+  private readonly projectionChanges = createProjectionChangePublisher();
   private projectionGeneration: DaemonProjectionGenerationManager;
   private projectionGenerationClosed = false;
   private lock: DaemonGlobalLock | undefined;
@@ -442,6 +448,10 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
     assertDaemonGlobalLockHeld(lock);
   }
 
+  subscribeProjectionChanges(listener: (event: ProjectionChangeEvent) => void): () => void {
+    return this.projectionChanges.subscribe(listener);
+  }
+
   private requireAttached(): { readonly lock: DaemonGlobalLock } {
     if (!this.lock || this.state !== "attached") {
       throw { _tag: "JournalUnavailable", cause: new Error(`daemon repo "${this.repoId}" is not attached`) } satisfies WriteError;
@@ -460,6 +470,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       lockTtlMs: this.lockTtlMs,
       heldGlobalLock: started.lock,
       autoMaterialize: false,
+      onProjectionChange: this.projectionChanges.publish,
       ...(request.sessionId ? { sessionId: request.sessionId } : {}),
       ...(request.commitAuthor ? { commitAuthor: request.commitAuthor } : {})
     };
@@ -548,17 +559,6 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
     if (!this.projectionGenerationClosed) this.projectionGenerationClosed = true;
     return this.projectionGeneration.close();
   }
-}
-
-function toDaemonRuntimeStatus(status: DaemonRepoRuntimeStatus): DaemonRuntimeStatus {
-  return {
-    started: status.started,
-    rootDir: status.rootDir,
-    ...(status.lockPath ? { lockPath: status.lockPath, lockOwnerToken: status.lockOwnerToken } : {}),
-    queue: status.queue,
-    projectionGeneration: status.projectionGeneration,
-    ...(status.lastRecovery ? { lastRecovery: status.lastRecovery } : {})
-  };
 }
 
 function mergeRepoDefaults(repo: DaemonRepoRuntimeOptions, options: MultiRepoDaemonRuntimeOptions): DaemonRepoRuntimeOptions {

--- a/packages/kernel/src/store/write-journal-coordinator.ts
+++ b/packages/kernel/src/store/write-journal-coordinator.ts
@@ -19,8 +19,7 @@ import {
   type HarnessLayoutInput,
   resolveHarnessLayout,
 } from "../layout/index.ts";
-import { updateTaskProjectionIncrementally } from "../projection/sqlite-task-incremental-projection.ts";
-import { hashTaskProjectionRows } from "../projection/sqlite-task-projection.ts";
+import type { ProjectionChangeEvent } from "../projection/projection-change-event.ts";
 import { captureAuthoredProjectionFingerprint } from "../projection/projection-source-baseline.ts";
 import { appendJsonLineDurably, readDurableState, readPayloadRef, writeWatermarkDurably, writeFileDurably } from "./write-journal-durable.ts";
 import { assertCommitPlanAddable, commitTouchedPaths } from "./write-journal-git.ts";
@@ -52,6 +51,7 @@ import { semanticCommitMessage } from "./write-journal-authority-trailer.ts";
 import { recoverJournalIntegrityDomains } from "./write-journal-domain-recovery.ts";
 import { recordsForWriteIntegrityDomain, singleWriteIntegrityDomain } from "./write-integrity-domain.ts";
 import { memoizePublicationVcs } from "./write-journal-publication-vcs.ts";
+import { rebuildProjectionHash } from "./write-journal-projection-publication.ts";
 import type { ApplyMarkerRecord, DeleteAuditRecord, GitCommitAuthor, JournaledWriteCoordinatorOptions, JournalRecoveryOptions, LockConflictRetryOptions, LockTakeoverRecord, OperationalActor, OperationalJournaledWriteCoordinatorOptions, ReadableJournalRecord, WriteWatermark } from "./write-journal-types.ts";
 export type {
   GitCommitAuthor,
@@ -114,7 +114,7 @@ function makeJournaledWriteCoordinatorInternal(
         uniquePendingRecords(state.records, state.applied),
         requestedDomain
       );
-      return flushRecords(reason, rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor, versionControlSystem, attributionEventStore);
+      return flushRecords(reason, rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor, versionControlSystem, attributionEventStore, options.onProjectionChange);
     }, { heldGlobalLock }),
     catch: (cause): WriteError => toJournalError(cause)
   });
@@ -136,7 +136,8 @@ function makeJournaledWriteCoordinatorInternal(
           sessionId,
           commitAuthor,
           versionControlSystem,
-          attributionEventStore
+          attributionEventStore,
+          options.onProjectionChange
         )
       });
     }, { heldGlobalLock }),
@@ -306,7 +307,8 @@ function flushRecords(
   sessionId?: string,
   commitAuthor?: GitCommitAuthor,
   versionControlSystem?: VersionControlSystem,
-  attributionEventStore: AttributionEventStore = makeLocalGitAttributionEventStore()
+  attributionEventStore: AttributionEventStore = makeLocalGitAttributionEventStore(),
+  onProjectionChange?: (event: ProjectionChangeEvent) => void
 ): FlushReport {
   const touchedPaths: string[] = [];
   const committedOpIds: string[] = [];
@@ -379,9 +381,10 @@ function flushRecords(
   if (mutationWillCommit && confirmedAttributionOpIds.size !== eventWrites.length) {
     throw new Error("attribution event durability confirmation failed");
   }
-  const projectionHash = committedOpIds.length > 0
-    ? rebuildProjectionHash(rootDir, rootInput, touchedPaths, previousProjectionSourceFingerprint)
-    : previousWatermark?.projectionHash ?? "no-projection-change";
+  const projectionUpdate = committedOpIds.length > 0
+    ? rebuildProjectionHash(rootDir, rootInput, touchedPaths, previousProjectionSourceFingerprint, plannedRecords.map(({ record }) => record.entityId))
+    : undefined;
+  const projectionHash = projectionUpdate?.hash ?? previousWatermark?.projectionHash ?? "no-projection-change";
   const allCommitted = [...(previousWatermark?.lastCommittedOpIds ?? []), ...committedOpIds];
   const recentCommitted = recentOpIds(allCommitted);
   const watermark = committedOpIds.at(-1);
@@ -401,6 +404,12 @@ function flushRecords(
         lastCommittedOpIds: recentCommitted,
         updatedAt: new Date().toISOString()
       });
+    }
+    try {
+      onProjectionChange?.(projectionUpdate!.event);
+    } catch {
+      // Projection publication and its durable watermark already succeeded.
+      // Ephemeral subscribers must never turn that committed write into a retry.
     }
   }
 
@@ -475,21 +484,6 @@ function readVerifiedPayload(rootDir: string, record: ReadableJournalRecord): Re
     rejectWrite(`payload hash mismatch for op ${record.opId}`, record.entityId);
   }
   return payload;
-}
-
-function rebuildProjectionHash(
-  rootDir: string,
-  rootInput: HarnessLayoutInput,
-  touchedPaths: ReadonlyArray<string>,
-  previousSourceFingerprint: string | undefined
-): string {
-  const layoutOverrides = typeof rootInput === "string" ? undefined : rootInput.layoutOverrides;
-  return hashTaskProjectionRows(updateTaskProjectionIncrementally({
-    rootDir,
-    layoutOverrides,
-    touchedPaths,
-    previousSourceFingerprint
-  }).rows);
 }
 
 function recentOpIds(opIds: ReadonlyArray<string>): ReadonlyArray<string> {

--- a/packages/kernel/src/store/write-journal-projection-publication.ts
+++ b/packages/kernel/src/store/write-journal-projection-publication.ts
@@ -1,0 +1,34 @@
+import type { HarnessLayoutInput } from "../layout/index.ts";
+import type { ProjectionChangeEvent } from "../projection/projection-change-event.ts";
+import { captureAuthoredProjectionFingerprint } from "../projection/projection-source-baseline.ts";
+import { updateTaskProjectionIncrementally } from "../projection/sqlite-task-incremental-projection.ts";
+import { hashTaskProjectionRows } from "../projection/sqlite-task-projection.ts";
+
+export function rebuildProjectionHash(
+  rootDir: string,
+  rootInput: HarnessLayoutInput,
+  touchedPaths: ReadonlyArray<string>,
+  previousSourceFingerprint: string | undefined,
+  entityIds: ReadonlyArray<string>
+): { readonly hash: string; readonly event: ProjectionChangeEvent } {
+  const layoutOverrides = typeof rootInput === "string" ? undefined : rootInput.layoutOverrides;
+  const result = updateTaskProjectionIncrementally({
+    rootDir,
+    layoutOverrides,
+    touchedPaths,
+    previousSourceFingerprint
+  });
+  return {
+    hash: hashTaskProjectionRows(result.rows),
+    event: result.change ?? {
+      schema: "projection-change/v1",
+      sourceHash: captureAuthoredProjectionFingerprint(rootInput),
+      entities: entityIds.map((entityId) => {
+        const separator = entityId.indexOf("/");
+        return separator < 0
+          ? { kind: "entity", id: entityId }
+          : { kind: entityId.slice(0, separator), id: entityId.slice(separator + 1) };
+      })
+    }
+  };
+}

--- a/packages/kernel/src/store/write-journal-types.ts
+++ b/packages/kernel/src/store/write-journal-types.ts
@@ -2,6 +2,7 @@ import type { EntityId, TaskId } from "../domain/index.ts";
 import type { HarnessLayoutOverrides } from "../layout/index.ts";
 import type { VersionControlSystem } from "../ports/version-control-system.ts";
 import type { AttributionEventStore } from "./write-journal-attribution-events.ts";
+import type { ProjectionChangeEvent } from "../projection/projection-change-event.ts";
 import type { WriteOp } from "../ports/write-coordinator.ts";
 import type { ActorAxes, AgentRef, OperationalActor, WriteAttribution } from "../schemas/actor-attribution.ts";
 export type { OperationalActor } from "../schemas/actor-attribution.ts";
@@ -25,6 +26,7 @@ export interface JournaledWriteCoordinatorOptions {
   readonly commitAuthor?: GitCommitAuthor;
   readonly versionControlSystem?: VersionControlSystem;
   readonly attributionEventStore?: AttributionEventStore;
+  readonly onProjectionChange?: (event: ProjectionChangeEvent) => void;
 }
 
 export type JournalRecoveryOptions = Omit<JournaledWriteCoordinatorOptions, "attribution">;

--- a/packages/kernel/test/store/daemon-runtime.test.ts
+++ b/packages/kernel/test/store/daemon-runtime.test.ts
@@ -47,7 +47,6 @@ test("daemon runtime coalesces concurrent evidence reads into one ready repo gen
       projectionSourceFenceFactory: deterministicProjectionSourceFenceFactory
     });
     await runtime.start();
-
     const pages = await Promise.all(Array.from({ length: 100 }, () =>
       runtime.queryExecutionEvidencePage({ limit: 1 })));
 
@@ -76,6 +75,8 @@ test("daemon runtime invalidates only its repo generation after a canonical writ
       projectionSourceFenceFactory: deterministicProjectionSourceFenceFactory
     });
     await runtime.start();
+    const projectionChanges: Array<{ readonly entities: ReadonlyArray<{ readonly kind: string; readonly id: string }> }> = [];
+    const unsubscribe = runtime.subscribeProjectionChanges((event) => projectionChanges.push(event));
 
     await runtime.queryExecutionEvidencePage({ limit: 1 });
     assert.equal(runtime.status().projectionGeneration.validationRuns, 1);
@@ -89,6 +90,10 @@ test("daemon runtime invalidates only its repo generation after a canonical writ
     assert.equal(runtime.status().projectionGeneration.invalidations, 1);
     assert.equal(runtime.status().projectionGeneration.state, "unknown");
     await pendingWrite;
+    assert.deepEqual(projectionChanges.flatMap((event) => event.entities), [
+      { kind: "task", id: "task-generation" }
+    ]);
+    unsubscribe();
 
     await runtime.queryExecutionEvidencePage({ limit: 1 });
     assert.equal(runtime.status().projectionGeneration.validationRuns, 2);

--- a/packages/kernel/test/store/projection-notification-runtime.test.ts
+++ b/packages/kernel/test/store/projection-notification-runtime.test.ts
@@ -1,0 +1,66 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { createDaemonRuntime } from "../../../adapters/local/src/index.ts";
+import { docWrite, withTempStoreAsync } from "./helpers.ts";
+import { daemonAttribution, initAuthoredGit } from "./helpers/daemon-runtime.ts";
+
+const testAttribution = daemonAttribution("person_test", "test", "credential-test");
+
+test("projection subscribers cannot change write outcomes and do not survive daemon restart", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initAuthoredGit(rootDir);
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: false,
+      interactiveMicroBatchMs: 0
+    });
+    await runtime.start();
+
+    const withoutSubscriber = await runtime.enqueueInteractiveWrite({
+      commandId: "cmd-without-projection-subscriber",
+      attribution: testAttribution,
+      ops: [docWrite("op-without-projection-subscriber", "task-no-subscriber", "note.md", "no subscriber")]
+    });
+    let staleSubscriberCalls = 0;
+    runtime.subscribeProjectionChanges(() => {
+      staleSubscriberCalls += 1;
+      throw new Error("disconnected projection subscriber");
+    });
+    const withDisconnectedSubscriber = await runtime.enqueueInteractiveWrite({
+      commandId: "cmd-with-disconnected-projection-subscriber",
+      attribution: testAttribution,
+      ops: [docWrite("op-with-disconnected-projection-subscriber", "task-disconnected-subscriber", "note.md", "disconnected subscriber")]
+    });
+
+    assert.equal(withoutSubscriber.durable, true);
+    assert.equal(withDisconnectedSubscriber.durable, true);
+    assert.equal(staleSubscriberCalls, 1);
+    assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-no-subscriber/note.md"), "utf8"), "no subscriber");
+    assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-disconnected-subscriber/note.md"), "utf8"), "disconnected subscriber");
+    await runtime.stop();
+
+    const restarted = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: false,
+      interactiveMicroBatchMs: 0
+    });
+    await restarted.start();
+    let restartedSubscriberCalls = 0;
+    restarted.subscribeProjectionChanges(() => {
+      restartedSubscriberCalls += 1;
+    });
+    const afterRestart = await restarted.enqueueInteractiveWrite({
+      commandId: "cmd-after-projection-subscriber-restart",
+      attribution: testAttribution,
+      ops: [docWrite("op-after-projection-subscriber-restart", "task-after-restart", "note.md", "after restart")]
+    });
+
+    assert.equal(afterRestart.durable, true);
+    assert.equal(staleSubscriberCalls, 1);
+    assert.equal(restartedSubscriberCalls, 1);
+    await restarted.stop();
+  });
+});

--- a/packages/kernel/test/store/sqlite-incremental-projection.test.ts
+++ b/packages/kernel/test/store/sqlite-incremental-projection.test.ts
@@ -37,6 +37,11 @@ test("first task edit after a full rebuild stays incremental", () => {
     });
 
     assert.equal(result.mode, "incremental");
+    assert.deepEqual(result.change, {
+      schema: "projection-change/v1",
+      sourceHash: result.sourceHash,
+      entities: [{ kind: "task", id: "task-a" }]
+    });
     const fresh = readTaskProjection({ rootDir });
     assert.equal(fresh.warnings.some((warning) => warning.code === "projection_stale"), false);
     assert.equal(fresh.rows.find((row) => row.taskId === "task-a")?.canonicalStatus, "done");
@@ -166,6 +171,10 @@ test("single execution changes update a persisted source manifest without rebuil
     });
 
     assert.equal(result.mode, "incremental");
+    assert.deepEqual(result.change?.entities, [{
+      kind: "execution",
+      id: "exe_00000000000000000000000001"
+    }]);
     const updated = new DatabaseSync(projectionPath, { readOnly: true });
     try {
       assert.equal(updated.prepare("SELECT state FROM execution_projection WHERE execution_id = ?")


### PR DESCRIPTION
# English

## Summary

Revives a dead line: the daemon now publishes projection change notifications over JSON-RPC, so clients can react to ledger changes instead of polling. A complete implementation had been sitting on `codex/projection-notifications` since 2026-07-15 — clean local commit, tests passing, never opened as a PR, never landed, **and with no ledger entry**. It rotted for the same reason as the other dead line recovered tonight: no account, no owner.

This is a prerequisite for the GUI to stop polling, not just an orphaned patch.

## What Changed

- **Kernel**: a projection change event type and a publisher that isolates each subscriber; the daemon runtime exposes the subscription lifecycle and attaches the publisher to the write coordinator.
- **Daemon protocol**: `subscribe`/`unsubscribe` activated from stubs; connection-scoped subscription sessions publish `repo.projection.changed` and are torn down on EOF, explicit close, and error.
- **All five transports wired** — unix-socket, named-pipe, ssh-exec, ssh-tunnel-token, and the shared json-rpc-stream — rather than a partial wiring left undeclared.
- **CLI**: notification sink and repo runtime subscription source threaded through, preserving the accepted-connection and authority wiring from #918/#924.

## Task And Scope

Task `task_01KXVFZHC8BXN3X22DQG0K4RKA`. The 2026-07-15 design was **not** redesigned — this task's contract was to make it hold on today's main. Six files exceeded the complexity gate after the port and were split by responsibility; no threshold, allowlist, gate, or CI file was modified.

## Version Impact

Additive protocol capability. Previously-stubbed `subscribe`/`unsubscribe` methods now function; no existing method changes shape.

## Governance Declaration

Authorization: `task_01KXVFZHC8BXN3X22DQG0K4RKA` and `dec_01KXVM3AN62C0Q5TJ4WQSFB7T1` (accepted tonight — recover valuable dead lines and file the account before dispatching, so an account records a claim rather than a success). This change adds an observation channel only; it does not touch the write road, any gate, or governance surfaces.

## Verification

**The invariant that mattered: a notification must never become part of the write path.** After #921 the daemon is the *sole* canonical writer, so coupling publication into the write transaction would not merely add a failure point — it would amplify into a single point of failure for every write command.

Evidence, verified by mutation rather than read from the report:

| Mutation | Result |
|---|---|
| Remove the per-subscriber `try/catch` only | test stays **green** |
| Remove the coordinator's post-watermark `try/catch` **as well** | test turns **red** |

The first result is not a blind test — it is evidence of genuine redundancy: either layer alone is sufficient, which is what defence in depth means. The second confirms the test can actually detect coupling. Restored byte-identically after each.

The isolation is also structural, not merely defensive: the callback fires *after* `writeWatermarkDurably`, so the write is already durable before any subscriber runs.

- Bad paths covered, not just the happy path: subscriber disconnecting mid-stream, slow consumer (100 notifications delivered under sustained backpressure with the first write callback outstanding — the sink does not wait for drain), and daemon restart (a new runtime does not inherit old subscriptions, and writes stay durable across it).
- Targeted suite: 74 tests, 73 pass, 0 fail, 1 skip (a named-pipe E2E that only runs on Windows).
- `npm run check:local`: 33/33 manifest gates green, affected fast 356/356, affected contract 237/237.

## Review Evidence

The port was the risk here, not the design. The branch's base was four days behind main across a stretch where `packages/cli/src/daemon/` was rewritten three times (#918 ingress, #921 direct-write retirement, #922 parity gate, #924 path CAS). The dispatch said so explicitly, so that heavy rebase conflict would read as expected rather than as something going wrong.

Two things surfaced during closeout and were handled without touching the enforcement surface: six files tripped the complexity gate and were split by responsibility, and a `rebuildProjectionHash` naming contract was restored after being broken by the split. Thresholds and allowlists were left alone.

**CI then caught something `check:local` structurally cannot** — `check-kernel-dead-exports` is one of the 19 CI-only gates. The kernel was exporting `ProjectionChangeEvent` from its barrel with zero non-test consumers, because the daemon declared its own structurally identical copy at the protocol boundary. Three options were put to the implementer with the real constraint attached (an eslint rule forbids the daemon client from importing the kernel barrel, since the GUI dynamically loads that module and the barrel drags in sqlite projection code). Allowlisting was pre-refused: the honest answer to "nobody uses this export" is usually to stop exporting it, not to exempt it.

The implementer chose to remove the barrel export and keep the two types layered — the kernel's is an internal publication event, the daemon's is a wire DTO. That kills the dead export and the cross-layer coupling at once, without widening what the GUI dynamically loads. A kernel-internal shape change should not silently alter the wire contract.

## Residual Risk

1. The Windows named-pipe end-to-end path is **skipped**, not covered — it can only run on Windows. Transport wiring for named-pipe is asserted by unit-level tests only.
2. Full `npm run check:ci` was not run locally; 19 CI-only gates are left to CI.
3. Nothing consumes these notifications yet. The GUI still polls; this only removes the blocker.

## References

- Revived branch `codex/projection-notifications` (`3551c02a`)
- `harness/tasks/task_01KXVFZHC8…/artifacts/REPORT-projection-notifications.md`

---

# 中文

## 概要

复活一条死线:daemon 现在经 JSON-RPC 发布投影变更通知,客户端可以对台账变化做反应式更新,而不必轮询。一份完整实现自 2026-07-15 起躺在 `codex/projection-notifications` 上——本地 commit 干净、测试通过,**从未开 PR、从未落 main、台账里也没有条目**。它腐烂的原因与今晚捡回的另一条死线完全相同:**没有账,就没有主人**。

这不只是一段孤儿补丁,它是 **GUI 摆脱轮询的前置件**。

## 改动内容

- **kernel**:新增投影变更事件类型与 publisher(逐订阅者隔离);daemon runtime 暴露订阅生命周期,并把 publisher 接到写 coordinator。
- **daemon 协议**:`subscribe`/`unsubscribe` 从 stub 激活;连接级订阅 session 发布 `repo.projection.changed`,并在 EOF、显式关闭与错误三种情况下清理。
- **五个 transport 全部接线**——unix-socket、named-pipe、ssh-exec、ssh-tunnel-token 及共用的 json-rpc-stream——而不是部分接线且不声明。
- **CLI**:notification sink 与 repo runtime 订阅源接通,同时保留 #918/#924 的 accepted-connection 与 authority 接线。

## 任务与范围

任务 `task_01KXVFZHC8BXN3X22DQG0K4RKA`。**未重新设计** 2026-07-15 的方案——本任务的契约是让它在今天的 main 上成立。移植后有 6 个文件超出复杂度门,按职责拆分;**未改动任何阈值、allowlist、gate 或 CI 文件**。

## 版本影响

协议能力增量。此前是 stub 的 `subscribe`/`unsubscribe` 现在真正工作;既有方法形状不变。

## 治理声明

授权来源:`task_01KXVFZHC8BXN3X22DQG0K4RKA` 与 `dec_01KXVM3AN62C0Q5TJ4WQSFB7T1`(今晚 accept——捡回有价值的死线,并把"先立账后派活"定为常规,账表示认领而非成功)。本改动只增加一条**观察**通道,不触碰写路、任何门或治理面。

## 验证

**真正要紧的不变量:通知绝不能成为写路的一部分。** #921 之后 daemon 是**唯一** canonical 写者,所以把发布耦合进写事务不只是多一个失败点,而会**放大成所有写命令的单点风险**。

证据由突变测试取得,不是读报告:

| 突变 | 结果 |
|---|---|
| 只移除逐订阅者的 `try/catch` | 测试**仍绿** |
| **同时**移除 coordinator 里 watermark 之后的 `try/catch` | 测试**变红** |

第一条结果**不是**瞎测试,而是真实冗余的证据:任一层单独存在都足够,这正是纵深防御的含义。第二条确认该测试确实能检测出耦合。每次突变后均逐字节还原。

隔离还是结构性的,不只是防御性的:回调发生在 `writeWatermarkDurably` **之后**,写在任何订阅者运行前就已经 durable。

- **坏路径有覆盖,不只 happy path**:订阅者中途断开;慢消费者(在持续背压、首个 write callback 未完成时同步投递 100 条通知,sink 不等 drain);daemon 重启(新 runtime 不继承旧订阅,且跨重启写仍 durable)。
- 定向测试集:74 tests,73 pass,0 fail,1 skip(仅 Windows 可运行的 named-pipe E2E)。
- `npm run check:local`:33/33 manifest gate 全绿,affected fast 356/356,affected contract 237/237。

## 审查证据

本次风险在**移植**而不在设计。分支 base 落后 main 四天,而这几天 `packages/cli/src/daemon/` 一带被连续改了三轮(#918 ingress 收口、#921 直写退役、#922 parity gate、#924 path CAS)。派活时已明说这一点,好让沉重的 rebase 冲突被读成**预期之内**,而不是"出事了"。

收口过程中冒出两件事,均在不碰执法面的前提下处理:6 个文件撞复杂度门,按职责拆分;拆分过程中破坏了 `rebuildProjectionHash` 的命名契约,已恢复。阈值与 allowlist 未动。

**随后 CI 抓到一处 `check:local` 结构上抓不到的问题**——`check-kernel-dead-exports` 属于那 19 个 CI-only 门。kernel 的 barrel 导出了 `ProjectionChangeEvent` 而 kernel 之外零消费者,因为 daemon 在协议边界**自己声明了一个结构完全相同的副本**。CEO 把三条路连同真实约束一并交回实现者定(有 eslint 规则禁止 daemon client 导入 kernel barrel,因为 GUI 会动态加载该模块而 barrel 会带出 sqlite projection 代码)。**加 allowlist 被预先拒绝**:门的用意就是抓"导出了没人用",而"没人用"的诚实回答通常是"那就别导出",不是"豁免它"。

实现者选择撤销 barrel 导出、保留两个类型的分层——kernel 那个是内部发布事件,daemon 那个是 wire DTO。这一刀同时杀掉 dead export 与跨层耦合,且不扩大 GUI 的动态加载依赖。**kernel 内部形状变化不该悄悄改变线上协议契约。**

## 残余风险

1. Windows named-pipe 的端到端路径是 **skip 而非覆盖**——它只能在 Windows 上跑。named-pipe 的 transport 接线目前仅由单元级测试断言。
2. 未在本地跑完整 `npm run check:ci`,19 个 CI 专属门留给 CI。
3. **目前还没有任何消费方**。GUI 仍在轮询;本 PR 只是移除了那块阻塞。

## 关联材料

- 被复活的分支 `codex/projection-notifications`(`3551c02a`)
- `harness/tasks/task_01KXVFZHC8…/artifacts/REPORT-projection-notifications.md`
