### PR TITLE
test(tools): detect ghost task packages in the ledger

### DIFF
--- a/tools/check-ghost-task-packages.mjs
+++ b/tools/check-ghost-task-packages.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const defaultRepoRoot = path.resolve(import.meta.dirname, "..");
+const taskPackagePattern = /^(task_[0-9A-HJKMNP-TV-Z]{26})(?:-|$)/u;
+
+export function checkGhostTaskPackages(repoRoot = defaultRepoRoot) {
+  const tasksRoot = path.join(repoRoot, "harness", "tasks");
+  if (!existsSync(tasksRoot)) {
+    return { skipped: true, scanned: 0, missingIndexes: [], duplicateTaskIds: [] };
+  }
+
+  const packages = readdirSync(tasksRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const match = taskPackagePattern.exec(entry.name);
+      return match?.[1] === undefined
+        ? null
+        : {
+            taskId: match[1],
+            relativePath: path.posix.join("harness", "tasks", entry.name),
+            hasIndex: existsSync(path.join(tasksRoot, entry.name, "INDEX.md"))
+          };
+    })
+    .filter((entry) => entry !== null)
+    .sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+
+  const byTaskId = new Map();
+  for (const taskPackage of packages) {
+    const group = byTaskId.get(taskPackage.taskId) ?? [];
+    group.push(taskPackage.relativePath);
+    byTaskId.set(taskPackage.taskId, group);
+  }
+
+  return {
+    skipped: false,
+    scanned: packages.length,
+    missingIndexes: packages
+      .filter((taskPackage) => !taskPackage.hasIndex)
+      .map((taskPackage) => taskPackage.relativePath),
+    duplicateTaskIds: [...byTaskId.entries()]
+      .filter(([, directories]) => directories.length > 1)
+      .map(([taskId, directories]) => ({ taskId, directories }))
+      .sort((left, right) => left.taskId.localeCompare(right.taskId))
+  };
+}
+
+export function formatGhostTaskPackageReport(result) {
+  if (result.skipped) return "Ghost task package check: harness/tasks not present; skipping.";
+  if (result.missingIndexes.length === 0 && result.duplicateTaskIds.length === 0) {
+    return `Ghost task package check passed: ${result.scanned} task package(s), 0 missing INDEX.md, 0 duplicate task IDs.`;
+  }
+
+  const lines = ["Ghost task package check failed."];
+  for (const directory of result.missingIndexes) {
+    lines.push(`- missing INDEX.md: ${directory}`);
+  }
+  for (const duplicate of result.duplicateTaskIds) {
+    lines.push(`- duplicate ${duplicate.taskId}: ${duplicate.directories.join(", ")}`);
+  }
+  return lines.join("\n");
+}
+
+export function main(repoRoot = defaultRepoRoot) {
+  const result = checkGhostTaskPackages(repoRoot);
+  console.log(formatGhostTaskPackageReport(result));
+  return result.missingIndexes.length === 0 && result.duplicateTaskIds.length === 0 ? 0 : 1;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = main();
+}

--- a/tools/check-ghost-task-packages.test.mjs
+++ b/tools/check-ghost-task-packages.test.mjs
@@ -1,0 +1,89 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { checkGhostTaskPackages, formatGhostTaskPackageReport } from "./check-ghost-task-packages.mjs";
+
+const taskId = "task_01KXVMJ093BMM53KXPPMS8CRNP";
+
+test("canonical task packages pass", () => {
+  withFixture((rootDir) => {
+    writeCanonicalPackage(rootDir, `${taskId}-authority`);
+
+    assert.deepEqual(checkGhostTaskPackages(rootDir), {
+      skipped: false,
+      scanned: 1,
+      missingIndexes: [],
+      duplicateTaskIds: []
+    });
+  });
+});
+
+test("missing harness skips cleanly", () => {
+  withFixture((rootDir) => {
+    const result = checkGhostTaskPackages(rootDir);
+
+    assert.deepEqual(result, {
+      skipped: true,
+      scanned: 0,
+      missingIndexes: [],
+      duplicateTaskIds: []
+    });
+    assert.match(formatGhostTaskPackageReport(result), /harness\/tasks not present; skipping/u);
+  });
+});
+
+test("duplicate task id identifies the canonical and ghost directories", () => {
+  withFixture((rootDir) => {
+    writeCanonicalPackage(rootDir, `${taskId}-authority`);
+    mkdirSync(path.join(rootDir, "harness", "tasks", `${taskId}-ghost-packages`));
+
+    const result = checkGhostTaskPackages(rootDir);
+    const report = formatGhostTaskPackageReport(result);
+
+    assert.equal(result.skipped, false);
+    assert.deepEqual(result.missingIndexes, [
+      `harness/tasks/${taskId}-ghost-packages`
+    ]);
+    assert.deepEqual(result.duplicateTaskIds, [{
+      taskId,
+      directories: [
+        `harness/tasks/${taskId}-authority`,
+        `harness/tasks/${taskId}-ghost-packages`
+      ]
+    }]);
+    assert.match(report, new RegExp(taskId, "u"));
+    assert.match(report, /task_01KXVMJ093BMM53KXPPMS8CRNP-authority/u);
+    assert.match(report, /task_01KXVMJ093BMM53KXPPMS8CRNP-ghost-packages/u);
+  });
+});
+
+test("removing the canonical INDEX.md turns the check red", () => {
+  withFixture((rootDir) => {
+    const packageName = `${taskId}-authority`;
+    writeCanonicalPackage(rootDir, packageName);
+    unlinkSync(path.join(rootDir, "harness", "tasks", packageName, "INDEX.md"));
+
+    const result = checkGhostTaskPackages(rootDir);
+
+    assert.deepEqual(result.missingIndexes, [`harness/tasks/${packageName}`]);
+  });
+});
+
+function writeCanonicalPackage(rootDir, packageName) {
+  const packageDir = path.join(rootDir, "harness", "tasks", packageName);
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(path.join(packageDir, "INDEX.md"), "# Task\n", "utf8");
+  writeFileSync(path.join(packageDir, "task-contract.json"), "{}\n", "utf8");
+}
+
+function withFixture(run) {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-ghost-task-packages-"));
+  try {
+    run(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}

--- a/tools/run-local-check.mjs
+++ b/tools/run-local-check.mjs
@@ -76,7 +76,8 @@ export function buildSteps(full, changedFiles = []) {
     const invocation = npmCliInvocation(args);
     return [label, invocation.command, invocation.args];
   };
-  const steps = [npmStep("incremental typecheck", ["run", "typecheck"])];
+  const steps = [["ghost task packages", process.execPath, ["tools/check-ghost-task-packages.mjs"]]];
+  steps.push(npmStep("incremental typecheck", ["run", "typecheck"]));
   steps.push(["manifest local stop gates", process.execPath, ["tools/run-local-gates-check.mjs"]]);
   const lintFiles = changedFiles.filter((file) => LINTABLE_EXTENSION.test(file) && existsSync(path.join(repoRoot, file)));
   if (lintFiles.length > 0) {

--- a/tools/run-local-check.test.mjs
+++ b/tools/run-local-check.test.mjs
@@ -37,6 +37,7 @@ test("affected test prefixes derive package, nested adapter, and tools scopes", 
 test("light steps contain incremental typecheck, changed lint, and affected tests only", () => {
   const steps = buildSteps(false, ["tools/run-local-check.mjs", "docs-release/readme.md"]);
   assert.deepEqual(steps.map(([label]) => label), [
+    "ghost task packages",
     "incremental typecheck",
     "manifest local stop gates",
     "changed-file lint",
@@ -53,6 +54,7 @@ test("manual full tier appends integration, GUI E2E, and manifest gates", () => 
   assert.ok(labels.includes("integration tests"));
   assert.ok(labels.includes("GUI E2E"));
   assert.ok(labels.includes("manifest local stop gates"));
+  assert.ok(labels.includes("ghost task packages"));
 });
 
 test("local steps apply the shared QoS prefix", () => {


### PR DESCRIPTION
# English

## Summary

Detects ghost task packages: directories under `harness/tasks/` that carry a task id but no `INDEX.md`, and any task id owning more than one directory. A ghost package is silent — both directories exist, both are committed, nothing errors, and nobody can tell which one holds the real plan.

The cause is not carelessness. A package directory is `<task_id>-<slug>`, and the slug is derived from the title by a heuristic no caller can predict. The task filed for this very defect is the live proof: the title was Chinese, and `task create` produced `task_01KXVMJ093BMM53KXPPMS8CRNP-authority` — the slug is the single English word in the title. Other observed shapes include branch-derived slugs with a hash suffix and plainly truncated ones (`…-review-co` where canonical is `…-review-complete-agent`). Composing that path by hand is not "usually right, occasionally wrong" — it approaches never right.

## What Changed

- `tools/check-ghost-task-packages.mjs`: scans `harness/tasks/`, reporting directories missing `INDEX.md` and task ids owning multiple directories, naming the id and every directory involved.
- Registered as a step in `tools/run-local-check.mjs`, so it runs at the existing stop point rather than as a script nobody calls.
- Skips cleanly when `harness/tasks` is absent.

## Task And Scope

Task `task_01KXVMJ093BMM53KXPPMS8CRNP`. Detection only. **No CLI surface was added** — that was an explicit constraint, because the most natural fix (a command that answers "where is this task's canonical directory?") runs against the adjudicated CLI-surface-simplification programme and is not the CEO's call to make alone.

## Version Impact

No API or schema change. One additional local check step.

## Governance Declaration

Authorization: `task_01KXVMJ093BMM53KXPPMS8CRNP`, filed under the standing fix-on-discovery authority after a full-ledger measurement found live instances. Invariant: **a task's documents live in exactly one directory, and it must be the one the authority resolves for that task id.** This adds detection only; it changes no gate semantics, no CI configuration, and no authority behaviour.

## Verification

**Negative control run by the reviewer against the real ledger, not a fixture.**

| State | Result |
|---|---|
| Real ledger as-is | 775 packages scanned, 0 missing `INDEX.md`, 0 duplicate ids |
| One ghost directory planted | names `harness/tasks/task_01KXVMJ093BMM53KXPPMS8CRNP-ceo-planted-ghost` as missing `INDEX.md`, **and** reports the duplicate id listing both directories |

The planted directory was removed afterwards; the ledger is back to 775/0/0.

The 775-clean baseline is itself a result: the same measurement earlier tonight found **6 ghost packages and 5 duplicate task ids**, two of which predated tonight. Those were consolidated by hand before this check existed.

## Review Evidence

The reason this needed a mechanical check rather than a note is that **the note already existed and did not work.** This exact hazard was written down on 2026-07-11 ("never compose the slug yourself; `ls` first"). It was still violated four times in one night by the author of that note. Knowing is not doing; only something that turns red changes behaviour.

**Honest statement of coverage, because a bounded check that reads as full protection is worse than none.** `harness/` is git-ignored in the public repository (`git ls-files harness/` returns 0 files), so this can never run in CI — CI has no ledger to scan. It is a `check:local` step, and workers run `check:local` inside worktrees, where `harness/` does not exist and the check correctly skips. **In practice it only does work when `check:local` runs in the canonical root**, which is not the common case.

So this catches the defect on the machine where the damage happens, but it is not yet on the critical path. The stronger chokepoint would be the ledger repository's own commit path, which every ghost must pass through; that is a separate design question and is deliberately not decided here.

## Residual Risk

1. Coverage is bounded as described above — real, but not a chokepoint. Do not read a green `check:local` in a worktree as evidence of no ghosts.
2. Detection only: it reports ghosts, it does not prevent creating them or merge them back.
3. The root cause — an unpredictable canonical path with no supported way to ask for it — is untouched, and is blocked on a ruling about CLI surface.

## References

- Task `task_01KXVMJ093BMM53KXPPMS8CRNP`, artifacts `REPORT-ghost-packages.md`

---

# 中文

## 概要

检测幽灵任务包:`harness/tasks/` 下带 task id 却没有 `INDEX.md` 的目录,以及同一个 task id 拥有多个目录的情况。幽灵包是**安静的**——两个目录都在、都进了 git、什么都不报错,而没有人能判断真实计划在哪一边。

成因不是不小心。任务包目录是 `<task_id>-<slug>`,而 slug 由标题经一套调用者无法预测的启发式派生。**为这个缺陷立的任务本身就是活体证明**:标题是中文,`task create` 生成的却是 `task_01KXVMJ093BMM53KXPPMS8CRNP-authority`——slug 取了标题里唯一那个英文单词。其它已观察形态还有按分支名派生带 hash 后缀的,以及被直接截断的(`…-review-co`,canonical 是 `…-review-complete-agent`)。手工拼这个路径不是"通常对、偶尔错",而是**接近永远不对**。

## 改动内容

- `tools/check-ghost-task-packages.mjs`:扫描 `harness/tasks/`,报告缺 `INDEX.md` 的目录与拥有多个目录的 task id,**指名** id 及涉及的每一个目录。
- 注册进 `tools/run-local-check.mjs` 作为一个步骤,让它落在既有停止点上,而不是变成一个没人调用的脚本。
- `harness/tasks` 不存在时干净跳过。

## 任务与范围

任务 `task_01KXVMJ093BMM53KXPPMS8CRNP`。**仅检测**。**未新增任何 CLI 命令面**——这是明确约束:最自然的修法(一条"这个任务的 canonical 目录在哪"的命令)与泽宇亲裁的 CLI 命令面精简项目方向相反,不由 CEO 独断。

## 版本影响

无 API 或 schema 变更。新增一个本地检查步骤。

## 治理声明

授权来源:`task_01KXVMJ093BMM53KXPPMS8CRNP`,在全库实测发现活体实例后按常设的"发现即修"授权立项。不变量:**一个任务的文档只能存在于一个目录,且该目录必须是 authority 为这个 task id 解析出来的那个。** 本改动只增加检测,不改动任何门的语义、CI 配置或 authority 行为。

## 验证

**验收者对真实台账跑的阴性对照,不是 fixture。**

| 状态 | 结果 |
|---|---|
| 真实台账原样 | 扫描 775 个包,0 个缺 `INDEX.md`,0 个重复 id |
| 人为植入一个幽灵目录 | 指名 `harness/tasks/task_01KXVMJ093BMM53KXPPMS8CRNP-ceo-planted-ghost` 缺 `INDEX.md`,**并**报出重复 id 且列出两个目录 |

植入目录事后已删除,台账回到 775/0/0。

775 全清这个基线本身也是结果:**今晚早些时候同一测量找到 6 个幽灵包与 5 组重复 task id,其中 2 组早于今晚**。那些是在本检查存在之前手工合并归位的。

## 审查证据

**之所以需要机械检查而不是一条提醒,是因为那条提醒早就存在,而且没用。** 这个坑在 2026-07-11 就被写下过("目录名绝不能自己拼 slug,写前必 ls")。写下它的人在一个晚上又违反了四次。**知道 ≠ 做到;只有会变红的东西才改变行为。**

**覆盖范围的诚实声明——一个有边界却读起来像全覆盖的检查,比没有检查更坏。** `harness/` 在公开仓被 git 忽略(`git ls-files harness/` 返回 0 个文件),所以它**永远不可能在 CI 里跑**——CI 根本没有台账可扫。它是一个 `check:local` 步骤,而 worker 都在 worktree 里跑 `check:local`,那里没有 `harness/`,检查会(正确地)跳过。**实际上只有在 canonical 根跑 `check:local` 时它才真正工作**,而那并不是常态。

所以它能在"损坏实际发生的那台机器上"抓到问题,但**还不在关键路径上**。更强的 chokepoint 是台账仓自己的提交路径——每个幽灵都必须经过那里;那是另一个设计问题,本 PR 有意不裁。

## 残余风险

1. 覆盖范围如上所述有边界:是真的,但不是 chokepoint。**不要**把 worktree 里绿的 `check:local` 读成"没有幽灵"。
2. 只检测:它报告幽灵,不阻止产生,也不负责合并归位。
3. 根因——canonical 路径不可预测且没有受支持的方式去问它——**未触碰**,卡在 CLI 命令面的裁决上。

## 关联材料

- 任务 `task_01KXVMJ093BMM53KXPPMS8CRNP`,产物 `REPORT-ghost-packages.md`
