### PR TITLE
fix(daemon): persist lifecycle diagnostics so the sole write road cannot fail silently

### DIFF
--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -26,6 +26,9 @@ import {
   type DaemonControlRequest
 } from "./control.ts";
 import type { AuthorityRepoLifecycleController } from "../../daemon/authority-lifecycle.ts";
+import { observeDaemonLifecycle } from "../../daemon/daemon-lifecycle.ts";
+import { makeDaemonLogFileStore } from "../../daemon/daemon-log-file-store.ts";
+import { makeDaemonLogService } from "../../../../application/src/index.ts";
 
 export type { DaemonControlLifecycle } from "./control.ts";
 
@@ -175,6 +178,12 @@ async function statusDaemon(input: DaemonCommandInput): Promise<number> {
   const lockStatus = readDaemonLock(path.join(layout.locksRoot, "global.lock"));
   const rpcStatus = await readReachableDaemonStatus(target);
   const cliRpcStatus = rpcStatus ? daemonStatusForCli(rpcStatus) : undefined;
+  const lifecycle = await observeDaemonLifecycle({
+    userRoot: target.userRoot,
+    repo: { repoId: target.repoId, canonicalRoot: target.canonicalRoot },
+    reachable: Boolean(rpcStatus),
+    logService: makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot: target.userRoot }) })
+  });
   emitDaemonResult("daemon-status", {
     ...lockStatus,
     ...(cliRpcStatus ?? {
@@ -185,7 +194,8 @@ async function statusDaemon(input: DaemonCommandInput): Promise<number> {
       connections: { active: 0, total: 0 }
     }),
     started: cliRpcStatus?.started === true,
-    reachable: Boolean(rpcStatus)
+    reachable: Boolean(rpcStatus),
+    lifecycle
   }, input.json);
   return 0;
 }

--- a/packages/cli/src/daemon/daemon-lifecycle.ts
+++ b/packages/cli/src/daemon/daemon-lifecycle.ts
@@ -1,0 +1,238 @@
+import {
+  decodeDaemonLogEntry,
+  type DaemonLogEntryV1,
+  type DaemonLogService
+} from "../../../application/src/index.ts";
+import { makeDaemonLogFileStore } from "./daemon-log-file-store.ts";
+
+const lifecycleEventSchema = "daemon-lifecycle-event/v1" as const;
+
+interface DaemonLifecycleRunningEvent {
+  readonly schema: typeof lifecycleEventSchema;
+  readonly phase: "running";
+  readonly instanceId: string;
+  readonly pid: number;
+  readonly startedAt: string;
+}
+
+interface DaemonLifecycleTerminalEvent {
+  readonly schema: typeof lifecycleEventSchema;
+  readonly phase: "terminated";
+  readonly instanceId: string;
+  readonly pid: number;
+  readonly startedAt: string;
+  readonly observedAt: string;
+  readonly reason: string;
+  readonly clean: boolean;
+}
+
+type DaemonLifecycleEvent = DaemonLifecycleRunningEvent | DaemonLifecycleTerminalEvent;
+
+export interface DaemonLifecycleProjection {
+  readonly state: "never-started" | "previously-started-untracked" | "running" | "running-unreachable" | "running-untracked" | "cleanly-terminated" | "exited-unexpectedly";
+  readonly previouslyStarted: boolean;
+  readonly reason: string;
+  readonly pid?: number;
+  readonly startedAt?: string;
+  readonly terminalAt?: string;
+}
+
+export interface DaemonLifecycleRepoContext {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+}
+
+export async function recordDaemonStarted(input: {
+  readonly userRoot: string;
+  readonly logService: DaemonLogService;
+  readonly repo: DaemonLifecycleRepoContext;
+  readonly instanceId: string;
+  readonly pid: number;
+  readonly startedAt: string;
+}): Promise<void> {
+  const previous = (await readLifecycleHistory(input.userRoot)).latest;
+  if (previous?.phase === "running" && !daemonLifecycleProcessIsAlive(previous.pid)) {
+    await recordInferredExit({ logService: input.logService, repo: input.repo, state: previous });
+  }
+  const event: DaemonLifecycleRunningEvent = {
+    schema: lifecycleEventSchema,
+    phase: "running",
+    instanceId: input.instanceId,
+    pid: input.pid,
+    startedAt: input.startedAt
+  };
+  await input.logService.append({
+    level: "info",
+    source: "daemon",
+    component: "daemon.lifecycle",
+    event: "daemon.lifecycle.started",
+    message: JSON.stringify(event)
+  }, { repo: input.repo });
+}
+
+export async function recordDaemonTerminated(input: {
+  readonly userRoot: string;
+  readonly logService: DaemonLogService;
+  readonly repo: DaemonLifecycleRepoContext;
+  readonly instanceId: string;
+  readonly pid: number;
+  readonly startedAt: string;
+  readonly reason: string;
+  readonly clean: boolean;
+  readonly message?: string;
+}): Promise<void> {
+  const event: DaemonLifecycleTerminalEvent = {
+    schema: lifecycleEventSchema,
+    phase: "terminated",
+    instanceId: input.instanceId,
+    pid: input.pid,
+    startedAt: input.startedAt,
+    observedAt: new Date().toISOString(),
+    reason: input.reason,
+    clean: input.clean
+  };
+  await input.logService.append({
+    level: input.clean ? "info" : "fatal",
+    source: "daemon",
+    component: "daemon.lifecycle",
+    event: "daemon.lifecycle.terminated",
+    message: JSON.stringify(event),
+    ...(!input.clean ? { errorCode: "DAEMON_UNEXPECTED_EXIT", hint: input.message ?? null } : {})
+  }, { repo: input.repo });
+}
+
+export async function observeDaemonLifecycle(input: {
+  readonly userRoot: string;
+  readonly repo: DaemonLifecycleRepoContext;
+  readonly reachable: boolean;
+  readonly logService: DaemonLogService;
+}): Promise<DaemonLifecycleProjection> {
+  const history = await readLifecycleHistory(input.userRoot);
+  const state = history.latest;
+  if (!state) {
+    if (input.reachable) return { state: "running-untracked", previouslyStarted: true, reason: "legacy-no-lifecycle-record" };
+    return history.hasOperationalHistory
+      ? { state: "previously-started-untracked", previouslyStarted: true, reason: "legacy-operational-history-without-lifecycle" }
+      : { state: "never-started", previouslyStarted: false, reason: "no-lifecycle-record" };
+  }
+  if (state.phase === "terminated") return terminalProjection(state);
+  if (input.reachable) return runningProjection(state, "running", "reachable");
+  if (daemonLifecycleProcessIsAlive(state.pid)) {
+    return runningProjection(state, "running-unreachable", "process-alive-endpoint-unreachable");
+  }
+
+  const terminal = await recordInferredExit({ logService: input.logService, repo: input.repo, state });
+  return terminalProjection(terminal);
+}
+
+async function recordInferredExit(input: {
+  readonly logService: DaemonLogService;
+  readonly repo: DaemonLifecycleRepoContext;
+  readonly state: DaemonLifecycleRunningEvent;
+}): Promise<DaemonLifecycleTerminalEvent> {
+  const terminal: DaemonLifecycleTerminalEvent = {
+    ...input.state,
+    phase: "terminated",
+    observedAt: new Date().toISOString(),
+    reason: "process-disappeared",
+    clean: false
+  };
+  await input.logService.append({
+    level: "fatal",
+    source: "cli",
+    component: "daemon.lifecycle",
+    event: "daemon.lifecycle.exit-inferred",
+    message: JSON.stringify(terminal),
+    errorCode: "DAEMON_PROCESS_DISAPPEARED",
+    hint: `Daemon pid=${input.state.pid} disappeared without recording a terminal reason.`
+  }, { repo: input.repo });
+  return terminal;
+}
+
+async function readLifecycleHistory(userRoot: string): Promise<{
+  readonly latest: DaemonLifecycleEvent | undefined;
+  readonly hasOperationalHistory: boolean;
+}> {
+  const stored = await makeDaemonLogFileStore({ userRoot }).read();
+  const entries = stored.records.flatMap((record) => decodeDaemonOperationalLogEntry(record));
+  return {
+    latest: entries
+      .flatMap((entry) => decodeLifecycleLogEntry(entry))
+    .sort((left, right) => right.entry.sequence - left.entry.sequence)
+      .at(0)?.event,
+    hasOperationalHistory: entries.length > 0
+  };
+}
+
+function decodeDaemonOperationalLogEntry(record: unknown): ReadonlyArray<DaemonLogEntryV1> {
+  try {
+    return [decodeDaemonLogEntry(record)];
+  } catch {
+    return [];
+  }
+}
+
+function decodeLifecycleLogEntry(entry: DaemonLogEntryV1): ReadonlyArray<{
+  readonly entry: DaemonLogEntryV1;
+  readonly event: DaemonLifecycleEvent;
+}> {
+  if (entry.component !== "daemon.lifecycle") return [];
+  try {
+    const event = JSON.parse(entry.message) as unknown;
+    return isDaemonLifecycleEvent(event) ? [{ entry, event }] : [];
+  } catch {
+    return [];
+  }
+}
+
+function isDaemonLifecycleEvent(value: unknown): value is DaemonLifecycleEvent {
+  if (!isDaemonLifecycleEventRecord(value) || value.schema !== lifecycleEventSchema) return false;
+  if (typeof value.instanceId !== "string" || !Number.isSafeInteger(value.pid) || Number(value.pid) <= 0 || typeof value.startedAt !== "string") return false;
+  if (value.phase === "running") return true;
+  return value.phase === "terminated"
+    && typeof value.observedAt === "string"
+    && typeof value.reason === "string"
+    && typeof value.clean === "boolean";
+}
+
+function terminalProjection(state: DaemonLifecycleTerminalEvent): DaemonLifecycleProjection {
+  return {
+    state: state.clean ? "cleanly-terminated" : "exited-unexpectedly",
+    previouslyStarted: true,
+    reason: state.reason,
+    pid: state.pid,
+    startedAt: state.startedAt,
+    terminalAt: state.observedAt
+  };
+}
+
+function runningProjection(
+  state: DaemonLifecycleRunningEvent,
+  lifecycleState: "running" | "running-unreachable",
+  reason: string
+): DaemonLifecycleProjection {
+  return {
+    state: lifecycleState,
+    previouslyStarted: true,
+    reason,
+    pid: state.pid,
+    startedAt: state.startedAt
+  };
+}
+
+function daemonLifecycleProcessIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !daemonLifecycleErrorHasCode(error, "ESRCH");
+  }
+}
+
+function isDaemonLifecycleEventRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function daemonLifecycleErrorHasCode(error: unknown, code: string): boolean {
+  return error instanceof Error && "code" in error && error.code === code;
+}

--- a/packages/cli/src/daemon/service-host.ts
+++ b/packages/cli/src/daemon/service-host.ts
@@ -60,6 +60,10 @@ import { requireAuthoritySubmissionForDispatch } from "./authority-submission-di
 
 export { bindAuthoritySubmissionForDispatch } from "./authority-submission-dispatch.ts";
 
+export type DaemonServiceStopRequest =
+  | { readonly reason: "idle-timeout" }
+  | { readonly reason: "control"; readonly kind: "restart" | "refresh"; readonly operationId: string };
+
 type HarnessDaemonRuntime = ReturnType<CliCompositionAdapterProvider["createDaemonRuntime"]>;
 type MultiRepoHarnessDaemonRuntime = ReturnType<CliCompositionAdapterProvider["createMultiRepoDaemonRuntime"]>;
 type RepoServiceBinding = ReturnType<typeof createRepoServiceBinding>;
@@ -94,7 +98,7 @@ export async function createDaemonServiceHost(
   readonly onConnectionStart: () => void;
   readonly onConnectionSettled: () => void;
   readonly scheduleIdleExit: () => void;
-  readonly waitForStopRequest: () => Promise<void>;
+  readonly waitForStopRequest: () => Promise<DaemonServiceStopRequest>;
   readonly onStop: (handler: () => Promise<void>) => void;
   readonly startRegistryReconcile: (userRoot: string) => void;
   readonly reconcileNow: (userRoot: string) => Promise<void>;
@@ -105,8 +109,8 @@ export async function createDaemonServiceHost(
     ?? makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot }) });
   const stopHandlers: Array<() => Promise<void>> = [];
   const reposById = new Map(repos.map((repo) => [repo.repoId, repo]));
-  let requestStop: (() => void) | undefined;
-  const stopRequested = new Promise<void>((resolve) => {
+  let requestStop: ((request: DaemonServiceStopRequest) => void) | undefined;
+  const stopRequested = new Promise<DaemonServiceStopRequest>((resolve) => {
     requestStop = resolve;
   });
   let idleTimer: ReturnType<typeof setTimeout> | undefined;
@@ -148,7 +152,7 @@ export async function createDaemonServiceHost(
     if (idleMs <= 0 || stopping || connections.active !== 0) return;
     if (idleTimer) clearTimeout(idleTimer);
     idleTimer = setTimeout(() => {
-      requestStop?.();
+      requestStop?.({ reason: "idle-timeout" });
     }, idleMs);
     idleTimer.unref();
   };
@@ -194,7 +198,7 @@ export async function createDaemonServiceHost(
           if (activeControl?.operationId !== operationId) return;
           activeControl = { ...activeControl, phase: "draining" };
           drainTimeoutMs = request.drainTimeoutMs;
-          requestStop?.();
+          requestStop?.({ reason: "control", kind, operationId });
         }
       };
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,6 +31,7 @@ import { createDaemonServiceHost } from "./daemon/service-host.ts";
 import { makeDaemonReservationReconciler } from "./composition/reservation-reconciler.ts";
 import { createProductionAuthorityLifecycle } from "./daemon/production-authority-lifecycle.ts";
 import { makeDaemonLogFileStore } from "./daemon/daemon-log-file-store.ts";
+import { recordDaemonStarted, recordDaemonTerminated } from "./daemon/daemon-lifecycle.ts";
 import { loadAuthorityProductionManifest } from "./daemon/authority-production-state.ts";
 import { runCompoundReceiptExitCommand } from "./daemon/compound-receipt-runner.ts";
 import { runAgentRuntimeCommand } from "./commands/agent-runtime.ts";
@@ -144,6 +145,13 @@ async function runDaemonServe(
   return withDaemonSocketOwnership(endpoint, async () => {
     let runtime: MultiRepoHarnessDaemonRuntime | undefined;
     let serviceHost: Awaited<ReturnType<typeof createDaemonServiceHost>> | undefined;
+    let lifecycleStarted = false;
+    let terminalReason: string | undefined;
+    let terminalClean = false;
+    let terminalMessage: string | undefined;
+    let failure: unknown;
+    const daemonLogService = makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot }) });
+    let lifecycleRepo: DaemonServeRepo | undefined;
     try {
       const requestedAuthorityManifest = readOption(args, "--authority-manifest")
         ?? process.env.HARNESS_AUTHORITY_MANIFEST?.trim();
@@ -151,6 +159,8 @@ async function runDaemonServe(
       const serveRepos = daemonServeRepos(rootDir, layoutOverrides, requestedRepoId, userRoot);
       const authorityManifest = requestedAuthorityManifest ?? authorityManifestFromRegistry(serveRepos);
       const defaultRepoId = defaultDaemonServeRepoId(serveRepos, rootDir, requestedRepoId);
+      lifecycleRepo = serveRepos.find((repo) => repo.repoId === defaultRepoId) ?? serveRepos[0];
+      if (!lifecycleRepo) throw new Error("daemon lifecycle requires at least one registered repository");
       runtime = createMultiRepoDaemonRuntime({
         materializerPollMs: 5_000,
         reservationReconciler: async (rootInput) => {
@@ -171,7 +181,6 @@ async function runDaemonServe(
       }
       const idleMs = parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true });
       const connections: DaemonConnectionStats = { active: 0, total: 0 };
-      const daemonLogService = makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot }) });
       const authorityLifecycle = hooks.authorityLifecycle ?? (authorityManifest
         ? createProductionAuthorityLifecycle({
           manifestPath: authorityManifest,
@@ -206,10 +215,30 @@ async function runDaemonServe(
       serviceHost.onStop(async () => {
         await transport.stop();
       });
+      await recordDaemonStarted({
+        userRoot,
+        logService: daemonLogService,
+        repo: lifecycleRepo,
+        instanceId: serviceHost.daemonId,
+        pid: process.pid,
+        startedAt
+      });
+      lifecycleStarted = true;
       hooks.onStarted?.(daemonStatusCliProjection(serviceHost.status()));
       serviceHost.scheduleIdleExit();
-      await Promise.race([waitForStopSignal(), serviceHost.waitForStopRequest()]);
-    } finally {
+      const trigger = await Promise.race([waitForStopSignal(), serviceHost.waitForStopRequest()]);
+      terminalReason = trigger.reason === "signal"
+        ? `signal:${trigger.signal}`
+        : trigger.reason === "control"
+          ? `control:${trigger.kind}`
+          : "idle-timeout";
+      terminalClean = true;
+    } catch (error) {
+      failure = error;
+      terminalReason = `unexpected-error:${error instanceof Error ? error.name : "unknown"}`;
+      terminalMessage = `Daemon service terminated after an unexpected error: ${error instanceof Error ? `${error.name}: ${error.message}` : String(error)}`;
+    }
+    try {
       let stoppedByHost = false;
       try {
         if (serviceHost) {
@@ -221,7 +250,30 @@ async function runDaemonServe(
       } finally {
         if (!stoppedByHost && serviceHost && runtime) await runtime.stop();
       }
+    } catch (error) {
+      failure ??= error;
+      terminalClean = false;
+      terminalReason = `shutdown-error:${error instanceof Error ? error.name : "unknown"}`;
+      terminalMessage = `Daemon service cleanup failed: ${error instanceof Error ? `${error.name}: ${error.message}` : String(error)}`;
     }
+    if (lifecycleStarted && lifecycleRepo && serviceHost) {
+      try {
+        await recordDaemonTerminated({
+          userRoot,
+          logService: daemonLogService,
+          repo: lifecycleRepo,
+          instanceId: serviceHost.daemonId,
+          pid: process.pid,
+          startedAt,
+          reason: terminalReason ?? "unexpected-error:unknown",
+          clean: terminalClean,
+          ...(terminalMessage ? { message: terminalMessage } : {})
+        });
+      } catch (error) {
+        failure ??= error;
+      }
+    }
+    if (failure !== undefined) throw failure;
   });
 }
 
@@ -277,15 +329,17 @@ function defaultDaemonServeRepoId(repos: ReadonlyArray<DaemonServeRepo>, rootDir
   return matchingRoot?.repoId ?? repos[0]?.repoId ?? requestedRepoId;
 }
 
-async function waitForStopSignal(): Promise<void> {
-  await new Promise<void>((resolve) => {
-    const stop = () => {
-      process.off("SIGINT", stop);
-      process.off("SIGTERM", stop);
-      resolve();
+async function waitForStopSignal(): Promise<{ readonly reason: "signal"; readonly signal: "SIGINT" | "SIGTERM" }> {
+  return new Promise((resolve) => {
+    const stop = (signal: "SIGINT" | "SIGTERM") => {
+      process.off("SIGINT", onSigint);
+      process.off("SIGTERM", onSigterm);
+      resolve({ reason: "signal", signal });
     };
-    process.on("SIGINT", stop);
-    process.on("SIGTERM", stop);
+    const onSigint = () => stop("SIGINT");
+    const onSigterm = () => stop("SIGTERM");
+    process.on("SIGINT", onSigint);
+    process.on("SIGTERM", onSigterm);
   });
 }
 

--- a/packages/cli/test/daemon-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-lifecycle-cli.test.ts
@@ -1,0 +1,157 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { makeDaemonLogService } from "../../application/src/index.ts";
+import { makeDaemonLogFileStore } from "../src/daemon/daemon-log-file-store.ts";
+import {
+  defaultDaemonUserRoot,
+  pollUntil,
+  runDaemonCommand,
+  runRawJson,
+  stopDaemon,
+  withTempRootAsync
+} from "./helpers/daemon-cli.ts";
+
+test("daemon status distinguishes a daemon that has never started", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = initializeFixture(rootDir);
+    const status = daemonStatus(rootDir, userRoot);
+
+    assert.deepEqual(status.lifecycle, {
+      state: "never-started",
+      previouslyStarted: false,
+      reason: "no-lifecycle-record"
+    });
+  });
+});
+
+test("daemon status preserves pre-lifecycle operational history", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = initializeFixture(rootDir);
+    await makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot }) }).append({
+      level: "info",
+      source: "daemon",
+      component: "protocol.json-rpc",
+      event: "repo.command.run",
+      message: "legacy daemon activity"
+    }, { repo: { repoId: "canonical", canonicalRoot: rootDir } });
+
+    assert.deepEqual(daemonStatus(rootDir, userRoot).lifecycle, {
+      state: "previously-started-untracked",
+      previouslyStarted: true,
+      reason: "legacy-operational-history-without-lifecycle"
+    });
+  });
+});
+
+test("daemon records a terminal reason when it receives a stop signal", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = initializeFixture(rootDir);
+    startDaemon(rootDir, userRoot);
+
+    await stopDaemon(rootDir, userRoot);
+    const lifecycle = daemonStatus(rootDir, userRoot).lifecycle as Record<string, unknown>;
+
+    assert.equal(lifecycle.state, "cleanly-terminated");
+    assert.equal(lifecycle.previouslyStarted, true);
+    assert.equal(lifecycle.reason, "signal:SIGTERM");
+    assert.deepEqual(lifecycleEvents(userRoot), ["daemon.lifecycle.started", "daemon.lifecycle.terminated"]);
+  });
+});
+
+test("daemon status persists an inferred terminal reason after an uncatchable exit", {
+  skip: process.platform === "win32" ? "SIGKILL is unavailable on Windows" : false
+}, async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = initializeFixture(rootDir);
+    const pid = startDaemon(rootDir, userRoot);
+    await killDaemon(pid);
+
+    try {
+      const status = daemonStatus(rootDir, userRoot);
+      const lifecycle = status.lifecycle as Record<string, unknown>;
+
+      assert.equal(status.started, false);
+      assert.equal(status.reachable, false);
+      assert.equal(lifecycle.state, "exited-unexpectedly");
+      assert.equal(lifecycle.previouslyStarted, true);
+      assert.equal(lifecycle.reason, "process-disappeared");
+      assert.equal(lifecycleEvents(userRoot).at(-1), "daemon.lifecycle.exit-inferred");
+    } finally {
+      startDaemon(rootDir, userRoot);
+      await stopDaemon(rootDir, userRoot);
+    }
+  });
+});
+
+test("daemon restart preserves an inferred exit before replacing a stale start marker", {
+  skip: process.platform === "win32" ? "SIGKILL is unavailable on Windows" : false
+}, async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = initializeFixture(rootDir);
+    const pid = startDaemon(rootDir, userRoot);
+    await killDaemon(pid);
+
+    try {
+      startDaemon(rootDir, userRoot);
+      assert.deepEqual(lifecycleEvents(userRoot), [
+        "daemon.lifecycle.started",
+        "daemon.lifecycle.exit-inferred",
+        "daemon.lifecycle.started"
+      ]);
+    } finally {
+      await stopDaemon(rootDir, userRoot);
+    }
+  });
+});
+
+function initializeFixture(rootDir: string): string {
+  const userRoot = defaultDaemonUserRoot(rootDir);
+  runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: userRoot });
+  return userRoot;
+}
+
+function startDaemon(rootDir: string, userRoot: string): number {
+  const started = runDaemonCommand(rootDir, ["daemon", "start", "--service", "--json"], {
+    HARNESS_DAEMON_USER_ROOT: userRoot
+  });
+  assert.equal(typeof started.pid, "number");
+  return started.pid as number;
+}
+
+function daemonStatus(rootDir: string, userRoot: string): Record<string, unknown> {
+  return runDaemonCommand(rootDir, ["daemon", "status", "--user-root", userRoot, "--json"], {
+    HARNESS_DAEMON_USER_ROOT: userRoot
+  });
+}
+
+async function killDaemon(pid: number): Promise<void> {
+  process.kill(pid, "SIGKILL");
+  await pollUntil(
+    () => processAlive(pid),
+    (alive) => !alive,
+    (alive, error) => JSON.stringify({ pid, alive, error: String(error ?? "") })
+  );
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function lifecycleEvents(userRoot: string): ReadonlyArray<string> {
+  const logRoot = path.join(userRoot, "logs", "harness-anything");
+  return readdirSync(logRoot)
+    .filter((name) => name.endsWith(".ndjson"))
+    .sort()
+    .flatMap((name) => readFileSync(path.join(logRoot, name), "utf8").split("\n"))
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as { readonly event?: unknown })
+    .flatMap((entry) => typeof entry.event === "string" && entry.event.startsWith("daemon.lifecycle.") ? [entry.event] : []);
+}


### PR DESCRIPTION
# English

## Summary

The daemon exits without a trace. Since #921 retired direct CLI execution it is the *sole* canonical write road, so when it dies every typed write fails with `journal_unavailable` — and the first symptom is always some unrelated command reporting an error that does not name the real cause.

This does not claim to stop the daemon from dying. **The root cause is not located, and this PR says so rather than dressing up a candidate as a conclusion.** What it changes is that death is no longer silent: a controlled shutdown records a terminal reason, an uncatchable death is reconstructed at the next observation point, and `daemon status` can finally tell "never started" apart from "ran and died".

## What Changed

- New service-wide lifecycle events on the existing cross-restart operational log — **no new canonical writer and no second write road**: `daemon.lifecycle.started`, `daemon.lifecycle.terminated` (signal, idle, refresh/restart control, exceptions reaching the serve boundary), and `daemon.lifecycle.exit-inferred`.
- SIGKILL/OOM cannot be self-reported by the killed process, so the next `daemon status` — or the next `daemon start`, **before it overwrites the stale start marker** — persists a `process-disappeared` terminal event.
- `daemon status --json` gains a lifecycle projection: `never-started`, `previously-started-untracked`, `running`, `running-unreachable`, `running-untracked`, `cleanly-terminated`, `exited-unexpectedly`.

## Task And Scope

Task `task_01KXVTKA8J28M75D5R48X8AC4Y`. Diagnosability only. **No auto-restart and no supervisor were introduced** — see Review Evidence for why that was deliberately withheld rather than forgotten.

## Version Impact

Additive. `daemon status --json` gains a lifecycle field; no existing method changes shape. Daemons that ran before this change project as `previously-started-untracked` rather than being misreported as never started.

## Governance Declaration

Authorization: `task_01KXVTKA8J28M75D5R48X8AC4Y`, filed under the standing fix-on-discovery authority after a third live occurrence. Invariant: **the sole canonical write road must not fail silently — a controlled termination records a terminal reason, and an uncatchable death is reconstructed at the next observation point.** No gate semantics, CI configuration, or authority behaviour were changed. The retired direct-write road was neither weakened nor reopened.

## Verification

**Mutation tests were re-run by the reviewer, not read from the report.** A check must be able to fail for the thing it claims to check.

| Mutation | Result |
|---|---|
| Disable the `daemon.lifecycle.terminated` append | **red** — `daemon records a terminal reason when it receives a stop signal` fails; state degrades from `cleanly-terminated` to `exited-unexpectedly` |
| Disable the `daemon.lifecycle.exit-inferred` append | **red** — *two* tests fail: the SIGKILL inference and the restart-preserves-inferred-exit case |
| Both restored byte-identically | 5/5 green, `git status` clean |

The implementer additionally ran the restart-protection test red *before* implementing it (observed `started, started` where `started, exit-inferred, started` was required), which is test-first evidence rather than after-the-fact confirmation.

- `daemon-lifecycle-cli.test.ts`: 5/5.
- Root `npm run check:local`: 33/33 manifest stop gates, 268 affected fast, 74 affected contract.

**A reviewer-side instrument error is worth recording.** The reviewer first ran the suite with a bare `npx tsx --test` and saw 4 of 5 fail, which looked like a broken submission. The repo runs tests through `tools/run-node-tests.mjs`, which injects a hermetic environment and a fixture preload; with those supplied the same suite is 5/5. **The tests were correct and the instrument was wrong** — a negative control before accusing the change.

## Review Evidence

**(a) Root cause: not located, and deliberately not guessed.** Four candidates were named in the dispatch (unhandled rejection, lock contention, parent/session teardown, git hooks). None was promoted to a conclusion. What the evidence *does* support:

- No `shutdown` / `exit` / `signal` / `uncaught` / terminal lifecycle entry exists in the persistent log before any of the three deaths.
- `--idle-ms 0` is ruled out at the source: `scheduleIdleExit` returns immediately when `idleMs <= 0`.
- The `post-merge` hook only calls the runtime refresh helper and has no path that kills the daemon. The third failure proves the hook *exposed* an existing death, not that it caused one.
- The current service instance runs with `PPID=1`, which weakens the parent-shell-teardown explanation — **explicitly noted as unable to prove anything retroactively about the three historical instances**.
- The unhandled-rejection candidate remains **unverified**.

**(b) Should a sole write road be allowed to exit silently? No** — and this was answered before proposing a mechanism, which is what the dispatch required. Supervision and auto-restart were **withheld on purpose**: restart policy, backoff, deployment dependencies and authority-recovery failure policy are a separate surface, and adding a restart loop while the root cause is unknown would mask the very evidence needed to find it. Diagnosability first, supervision only once a death has been observed *with* a terminal reason attached.

**(c) Should status distinguish never-started from died? Yes, and it now does**, with a distinct operator action per state. The `previously-started-untracked` state was not requested and is the better detail: daemons that predate this change must not be misreported as never started, nor have a cause fabricated for them.

## Residual Risk

1. **The original trigger of the three deaths is still unknown.** This PR removes the silence and the ambiguity; it does not claim to have removed the cause. The daemon may well die again — the difference is that the next death should leave a reason behind.
2. SIGKILL/OOM reasons are *inferred* at the next observation point, never written at the moment of death.
3. If the OS reuses the PID before observation, the `kill(pid, 0)` probe may transiently project `running-unreachable`. **Unverified** race.
4. Lifecycle history inherits the existing operational-log retention; long-term audit retention is **unverified**.
5. No auto-restart, external health alerting, or supervisor enforcement — see (b).

## References

- Task `task_01KXVTKA8J28M75D5R48X8AC4Y`, artifact `REPORT-daemon-silent-exit.md`
- Context: #921 (direct-write retirement) made this the sole write road

---

# 中文

## 概要

daemon 会**无声无息地退出**。#921 退役直写路径之后它是**唯一** canonical 写路,所以它一死,所有 typed 写命令全部失败于 `journal_unavailable`——而第一个症状永远是**别的**命令报一个看不出真因的错。

本 PR **不声称能让它不死**。**根因未定位,而且本 PR 如实这么说,没有把候选包装成结论。** 它改变的是:**死亡不再是静默的**——受控终止会记下 terminal reason,不可捕获的死亡会在下一个观察点被补记,而 `daemon status` 终于能区分"从未启动"与"跑过后死了"。

## 改动内容

- 在既有的跨重启 operational log 上新增 service 级 lifecycle 事件——**不新增 canonical writer,不开第二条写路**:`daemon.lifecycle.started`、`daemon.lifecycle.terminated`(signal、idle、refresh/restart 控制、传播到 serve 边界的异常)、`daemon.lifecycle.exit-inferred`。
- SIGKILL/OOM 无法由被杀进程自报,因此由下一次 `daemon status`,或下一次 `daemon start`(**在它覆盖旧 start marker 之前**)持久化 `process-disappeared` terminal event。
- `daemon status --json` 新增 lifecycle 投影:`never-started`、`previously-started-untracked`、`running`、`running-unreachable`、`running-untracked`、`cleanly-terminated`、`exited-unexpectedly`。

## 任务与范围

任务 `task_01KXVTKA8J28M75D5R48X8AC4Y`。**仅诊断性**。**未引入自动重启,未引入 supervisor**——那是**有意保留**而非遗漏,理由见「审查证据」。

## 版本影响

增量。`daemon status --json` 新增 lifecycle 字段;既有方法形状不变。本改动之前跑过的 daemon 会投影为 `previously-started-untracked`,**不会被误报为从未启动**。

## 治理声明

授权来源:`task_01KXVTKA8J28M75D5R48X8AC4Y`,在第三次活体复现后按常设「发现即修」授权立项。不变量:**唯一 canonical 写路不得静默失效——受控终止必须记下 terminal reason,不可捕获的死亡必须在下一观察点被补记。** 未改动任何门的语义、CI 配置或 authority 行为。**已退役的直写路径既未削弱也未重开。**

## 验证

**突变测试由验收者亲自重跑,不是读报告。** 一道门必须能因它所声称检查的那件事而失败。

| 突变 | 结果 |
|---|---|
| 关掉 `daemon.lifecycle.terminated` 的 append | **变红**——`daemon records a terminal reason when it receives a stop signal` 失败,状态由 `cleanly-terminated` 退化为 `exited-unexpectedly` |
| 关掉 `daemon.lifecycle.exit-inferred` 的 append | **变红**——**两条**测试失败:SIGKILL 推断,以及"重启前保留 inferred exit" |
| 两次均逐字节还原 | 5/5 绿,`git status` 干净 |

实现者另有一条:**重启保护的测试是在实现之前先跑红的**(实测序列为 `started, started`,而要求是 `started, exit-inferred, started`),这是 test-first 证据,不是事后追认。

- `daemon-lifecycle-cli.test.ts`:5/5。
- 根 `npm run check:local`:33/33 manifest stop gates、268 affected fast、74 affected contract。

**验收者自己的一次仪器错误值得记下。** 验收者最初用裸 `npx tsx --test` 跑,看到 5 条里红了 4 条,**看起来像是提交有问题**。而本仓的测试是经 `tools/run-node-tests.mjs` 跑的,它会注入 hermetic 环境与 fixture preload;补上这两样后同一套测试 5/5 全绿。**测试是对的,错的是仪器**——在指控改动之前先做阴性对照。

## 审查证据

**(a) 根因:未定位,且有意不猜。** 派活时点了四个候选(未捕获 rejection、锁竞争、父进程/session teardown、git 钩子),**没有任何一个被提升为结论**。证据**能**支撑的是:

- 三次死亡之前,持久日志里**都没有** `shutdown` / `exit` / `signal` / `uncaught` / terminal lifecycle 记录。
- `--idle-ms 0` 在源码层面被排除:`idleMs <= 0` 时 `scheduleIdleExit` 直接返回。
- `post-merge` 钩子只调用 runtime refresh helper,**没有杀 daemon 的路径**。第三次失败只证明钩子**暴露**了既有死亡,不证明它导致死亡。
- 当前 service 实例以 `PPID=1` 运行,削弱了"父 shell teardown"这一解释——**并已显式声明这无法追溯证明三个历史实例**。
- 未捕获 rejection 候选仍为 **unverified**。

**(b) 唯一写路是否允许静默退出?不应该**——而且这是**先回答"该不该"再提机制**,正是派活时的要求。监督与自动重启被**有意保留**:restart policy、退避、部署依赖与 authority recovery 失败策略属于另一个面;更要紧的是,**在根因未知时加重启循环,会掩盖掉找到根因所需的那份证据**。先做可诊断,等到某次死亡**带着 terminal reason** 被观察到之后,再谈监督。

**(c) status 是否该区分从未启动与跑过后死亡?应该,且已落地**,每种状态对应不同的操作者动作。其中 `previously-started-untracked` **不在需求里**,是更好的细节:本改动之前就在跑的 daemon,既不能被误报为从未启动,也不能给它编造一个死因。

## 残余风险

1. **三次死亡的原始触发源仍然未知。** 本 PR 消除的是静默性与状态歧义,**不声称消除了病因**。daemon 很可能还会再死——区别在于下一次死亡应当留下一个理由。
2. SIGKILL/OOM 的 terminal reason 是在下一观察点**推断**的,永远无法在死亡瞬间由进程自己写下。
3. 若操作系统在观察前复用了该 PID,`kill(pid, 0)` 探针可能短暂投影为 `running-unreachable`。该竞态 **unverified**。
4. lifecycle 历史继承既有 operational log 的 retention;长期审计留存策略 **unverified**。
5. 未实现自动重启、外部健康告警或 supervisor 强制安装——理由见 (b)。

## 关联材料

- 任务 `task_01KXVTKA8J28M75D5R48X8AC4Y`,产物 `REPORT-daemon-silent-exit.md`
- 背景:#921(直写退役)使其成为唯一写路
