### PR TITLE
test: consolidate CLI subprocess env into one authority and gate it

### DIFF
--- a/packages/cli/test/actor-attribution-cli.test.ts
+++ b/packages/cli/test/actor-attribution-cli.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./helpers/authority-command-adapter-v2.ts";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
@@ -625,11 +626,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_DAEMON_MODE: "fixture",
-        ...env
-      }
+      env: cliTestEnv({ HARNESS_DAEMON_MODE: "fixture", ...env })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/anchor-backfill-cli.test.ts
+++ b/packages/cli/test/anchor-backfill-cli.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -185,14 +186,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_DAEMON_MODE: "fixture",
-        CLAUDE_SESSION_ID: "",
-        CLAUDE_CODE_SESSION_ID: "",
-        CODEX_THREAD_ID: "",
-        CODEX_SESSION_ID: ""
-      }
+      env: cliTestEnv({ HARNESS_DAEMON_MODE: "fixture" })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/architecture-script-cli.test.ts
+++ b/packages/cli/test/architecture-script-cli.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { architectureSourceDigest } from "../src/commands/extensions/assets/software-coding/architecture/contracts/architecture-runtime.mjs";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -392,12 +393,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_ACTOR: "agent:architecture-script-test",
-        HARNESS_GIT_AUTHOR_NAME: "Harness Test",
-        HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test"
-      }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:architecture-script-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test" })
     });
     const parsed = JSON.parse(output) as Record<string, any>;
     if (expectSuccess) assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/attribution-diff-cli.test.ts
+++ b/packages/cli/test/attribution-diff-cli.test.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
@@ -130,12 +131,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
       maxBuffer: 256 * 1024 * 1024,
-      env: {
-        ...process.env,
-        HARNESS_ACTOR: "agent:attribution-diff-test",
-        HARNESS_DAEMON_MODE: "fixture",
-        ...env
-      }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:attribution-diff-test", HARNESS_DAEMON_MODE: "fixture", ...env })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/check-governance-cli.test.ts
+++ b/packages/cli/test/check-governance-cli.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import test from "node:test";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -657,7 +658,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_ACTOR: "agent:check-governance-test" }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:check-governance-test" })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/completion-cli.test.ts
+++ b/packages/cli/test/completion-cli.test.ts
@@ -7,9 +7,10 @@ import { commandRegistry } from "../src/cli/command-registry.ts";
 import { generateShellCompletion } from "../src/cli/completion/index.ts";
 import { deriveShellCompletionModel } from "../src/cli/completion/model.ts";
 import type { CommandRegistryEntry } from "../src/cli/types.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = fileURLToPath(new URL("../src/index.ts", import.meta.url));
-const directEnv = { ...process.env, HARNESS_DAEMON_MODE: "fixture" };
+const directEnv = cliTestEnv({ HARNESS_DAEMON_MODE: "fixture" });
 
 test("completion scripts track command registry fixture changes", () => {
   const baseline = [fixtureEntry({

--- a/packages/cli/test/conflict-preflight-cli.test.ts
+++ b/packages/cli/test/conflict-preflight-cli.test.ts
@@ -10,6 +10,7 @@ import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { runtimeEventPolicyForAction } from "../src/cli/command-event-policy.ts";
 import { commandDescriptors } from "../src/cli/command-registry.ts";
 import { requiresConflictMarkerPreflight } from "../src/cli/runner-registry.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -284,14 +285,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, env: NodeJS.Proce
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_DAEMON_MODE: "fixture",
-        HARNESS_ACTOR: "agent:conflict-preflight-test",
-        HARNESS_GIT_AUTHOR_NAME: "Harness Test",
-        HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
-        ...env
-      }
+      env: cliTestEnv({ HARNESS_DAEMON_MODE: "fixture", HARNESS_ACTOR: "agent:conflict-preflight-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test", ...env })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/daemon-command-errors.test.ts
+++ b/packages/cli/test/daemon-command-errors.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import test from "node:test";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -25,7 +26,7 @@ function runDaemonFailure(args: ReadonlyArray<string>): {
 } {
   const result = spawnSync(process.execPath, [cliEntry, "--json", ...args], {
     encoding: "utf8",
-    env: { ...process.env, HARNESS_DAEMON_MODE: "fixture" }
+    env: cliTestEnv({ HARNESS_DAEMON_MODE: "fixture" })
   });
   assert.equal(result.stderr, "");
   return {

--- a/packages/cli/test/daemon-execution-claim-cli.test.ts
+++ b/packages/cli/test/daemon-execution-claim-cli.test.ts
@@ -26,27 +26,13 @@ test("daemon-backed Execution claim upgrades Holder V1 and preserves the caller 
     });
     const taskId = receiptDataString(created, "taskId");
 
-    const legacyClaim = runRawJson(rootDir, ["task", "claim", taskId], {
-      HARNESS_DAEMON_MODE: "local",
-      HARNESS_DAEMON_IDLE_MS: "10000",
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: "",
-      CODEX_SESSION_ID: ""
-    });
+    const legacyClaim = runRawJson(rootDir, ["task", "claim", taskId], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "10000" });
     assert.equal(legacyClaim.ok, true, JSON.stringify(legacyClaim));
     assert.equal((((legacyClaim.details as Record<string, unknown>).data as Record<string, unknown>).report as {
       readonly holder?: { readonly schema?: string };
     }).holder?.schema, "task-holder/v1");
 
-    const claimed = runRawJson(rootDir, ["task", "claim", taskId, "--execution"], {
-      HARNESS_DAEMON_MODE: "local",
-      HARNESS_DAEMON_IDLE_MS: "10000",
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: "claiming-codex-session",
-      CODEX_SESSION_ID: "claiming-codex-session"
-    });
+    const claimed = runRawJson(rootDir, ["task", "claim", taskId, "--execution"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "10000", CODEX_THREAD_ID: "claiming-codex-session", CODEX_SESSION_ID: "claiming-codex-session" });
 
     assert.equal(claimed.ok, true, JSON.stringify(claimed));
     const executionId = receiptDataString(claimed, "executionId");
@@ -56,27 +42,12 @@ test("daemon-backed Execution claim upgrades Holder V1 and preserves the caller 
     });
     assert.match(String(claimReport.leaseToken), /^[0-9a-f]{64}$/u, JSON.stringify(claimed));
 
-    const otherHolder = runRawJsonMaybeFail(rootDir, ["task", "claim", taskId, "--execution"], {
-      HARNESS_DAEMON_MODE: "local",
-      HARNESS_DAEMON_IDLE_MS: "10000",
-      HARNESS_ACTOR: "agent:other-worker",
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: "other-worker-session",
-      CODEX_SESSION_ID: "other-worker-session"
-    });
+    const otherHolder = runRawJsonMaybeFail(rootDir, ["task", "claim", taskId, "--execution"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "10000", HARNESS_ACTOR: "agent:other-worker", CODEX_THREAD_ID: "other-worker-session", CODEX_SESSION_ID: "other-worker-session" });
     assert.equal(otherHolder.status, 1);
     assert.equal(otherHolder.receipt.ok, false, JSON.stringify(otherHolder.receipt));
     assert.match(String((otherHolder.receipt.error as { readonly hint?: string } | undefined)?.hint), /current holder principal=person_execution, executor=agent:daemon-cli-test/u);
 
-    const renewed = runRawJson(rootDir, ["task", "claim", taskId, "--execution"], {
-      HARNESS_DAEMON_MODE: "local",
-      HARNESS_DAEMON_IDLE_MS: "10000",
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: "claiming-codex-session",
-      CODEX_SESSION_ID: "claiming-codex-session"
-    });
+    const renewed = runRawJson(rootDir, ["task", "claim", taskId, "--execution"], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "10000", CODEX_THREAD_ID: "claiming-codex-session", CODEX_SESSION_ID: "claiming-codex-session" });
     assert.equal(receiptDataString(renewed, "executionId"), executionId);
     const renewedReport = (((renewed.details as Record<string, unknown>).data as Record<string, unknown>).report as {
       readonly leaseToken?: unknown;
@@ -118,14 +89,7 @@ test("daemon-backed Execution claim upgrades Holder V1 and preserves the caller 
     const holderData = (holder.details as { readonly data?: { readonly holder?: { readonly schema?: string } } } | undefined)?.data;
     assert.equal(holderData?.holder?.schema, "task-holder/v2");
 
-    const released = runRawJson(rootDir, ["task", "release", taskId], {
-      HARNESS_DAEMON_MODE: "local",
-      HARNESS_DAEMON_IDLE_MS: "10000",
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: "claiming-codex-session",
-      CODEX_SESSION_ID: "claiming-codex-session"
-    });
+    const released = runRawJson(rootDir, ["task", "release", taskId], { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "10000", CODEX_THREAD_ID: "claiming-codex-session", CODEX_SESSION_ID: "claiming-codex-session" });
     assert.equal(released.ok, true, JSON.stringify(released));
 
     const releasedHolder = runRawJson(rootDir, ["task", "holder", taskId], {
@@ -168,14 +132,7 @@ test("daemon-backed Execution submit materializes a newly exported Session befor
       JSON.stringify({ timestamp: "2026-07-15T00:00:01.000Z", type: "event_msg", payload: { type: "user_message", message: "submit on the first attempt" } }),
       JSON.stringify({ timestamp: "2026-07-15T00:00:02.000Z", type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "ready" }] } })
     ].join("\n"), "utf8");
-    const daemonSessionEnv = {
-      HARNESS_DAEMON_MODE: "local",
-      HARNESS_DAEMON_IDLE_MS: "10000",
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: sessionId,
-      CODEX_SESSION_ID: sessionId
-    };
+    const daemonSessionEnv = { HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_IDLE_MS: "10000", CODEX_THREAD_ID: sessionId, CODEX_SESSION_ID: sessionId };
     const claimed = runRawJson(rootDir, ["task", "claim", taskId, "--execution"], daemonSessionEnv);
     const claimReport = (((claimed.details as Record<string, unknown>).data as Record<string, unknown>).report as {
       readonly leaseToken?: unknown;

--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -9,6 +9,7 @@ import test from "node:test";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { writeJsonAtomically } from "./helpers/atomic-fixtures.ts";
 import { pollUntil } from "./helpers/poll-until.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 import { stderrWithoutDeprecationWarnings, stopDaemon } from "./helpers/daemon-cli.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
@@ -436,8 +437,7 @@ function runDaemonCommand(rootDir: string, args: ReadonlyArray<string>, env: Rea
 }
 
 function daemonTestEnv(rootDir: string, env: Readonly<Record<string, string>>): NodeJS.ProcessEnv {
-  return {
-    ...process.env,
+  return cliTestEnv({
     HOME: path.join(rootDir, ".home"),
     GIT_CONFIG_GLOBAL: "/dev/null",
     GIT_CONFIG_SYSTEM: "/dev/null",
@@ -449,14 +449,8 @@ function daemonTestEnv(rootDir: string, env: Readonly<Record<string, string>>): 
     GIT_COMMITTER_NAME: "Harness Test",
     GIT_COMMITTER_EMAIL: "harness@example.test",
     HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user"),
-    CLAUDE_SESSION_ID: "",
-    CLAUDE_CODE_SESSION_ID: "",
-    CODEX_THREAD_ID: "",
-    CODEX_SESSION_ID: "",
-    ZCODE_SESSION_ID: "",
-    ANTIGRAVITY_SESSION_ID: "",
     ...env
-  };
+  });
 }
 
 async function assertTaskIndexContains(rootDir: string, taskId: string, slug: string, title: string): Promise<void> {

--- a/packages/cli/test/decision-cli.test.ts
+++ b/packages/cli/test/decision-cli.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -625,17 +626,7 @@ function runJson(
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...cliArgs], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_ACTOR: "agent:test",
-        ANTIGRAVITY_SESSION_ID: "",
-        CLAUDE_CODE_SESSION_ID: "",
-        CLAUDE_SESSION_ID: "",
-        CODEX_SESSION_ID: "",
-        CODEX_THREAD_ID: "",
-        ZCODE_SESSION_ID: "",
-        ...envOverrides
-      }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:test", ...envOverrides })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/decision-content-pin-cli.test.ts
+++ b/packages/cli/test/decision-content-pin-cli.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { readUnionAttributionEvents } from "../../kernel/src/index.ts";
 import { ensureTestHarnessIdentity, initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -151,12 +152,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, a
   const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...cliArgs], {
     encoding: "utf8",
     windowsHide: true,
-    env: {
-      ...process.env,
-      HARNESS_ACTOR: "agent:test",
-      HARNESS_DAEMON_MODE: "fixture",
-      HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user")
-    }
+    env: cliTestEnv({ HARNESS_ACTOR: "agent:test", HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user") })
   });
   const parsed = JSON.parse(output) as Record<string, any>;
   assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/decision-policy-conformance-cli.test.ts
+++ b/packages/cli/test/decision-policy-conformance-cli.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -101,7 +102,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...cliArgs], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_ACTOR: "agent:test" }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:test" })
     });
     const parsed = unwrapCommandReceipt(JSON.parse(output) as Record<string, any>);
     if (expectSuccess) assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/decision-task-metadata-cli.test.ts
+++ b/packages/cli/test/decision-task-metadata-cli.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -207,15 +208,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        ANTIGRAVITY_SESSION_ID: "",
-        CLAUDE_CODE_SESSION_ID: "",
-        CLAUDE_SESSION_ID: "",
-        CODEX_SESSION_ID: "",
-        CODEX_THREAD_ID: "",
-        ZCODE_SESSION_ID: ""
-      }
+      env: cliTestEnv()
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/direct-mode-fail-close.test.ts
+++ b/packages/cli/test/direct-mode-fail-close.test.ts
@@ -5,20 +5,20 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { runRawJson, runRawJsonMaybeFail, withTempRoot } from "./helpers/daemon-cli.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 test("initialized ledgers fail closed when an ordinary caller requests a direct canonical write", () => {
   withTempRoot((rootDir) => {
     execFileSync(process.execPath, [path.resolve("packages/cli/src/index.ts"), "--root", rootDir, "--json", "init"], {
       encoding: "utf8",
-      env: {
-        ...process.env,
+      env: cliTestEnv({
         HARNESS_DAEMON_MODE: "direct",
         HARNESS_DAEMON_USER_ROOT: `${rootDir}/.daemon-user`,
         HARNESS_BOOTSTRAP_MACHINE_IDENTITY: "1",
         HARNESS_ACTOR: "agent:direct-mode-contract",
         HARNESS_GIT_AUTHOR_NAME: "Harness Test",
         HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test"
-      }
+      })
     });
     const initialHead = canonicalHead(rootDir);
     const failed = runRawJsonMaybeFail(rootDir, ["new-task", "--title", "Must Use Daemon"], {
@@ -47,7 +47,7 @@ test("architecture help parse failure does not create a direct operational write
   withTempRoot((rootDir) => {
     const result = spawnSync(process.execPath, [path.resolve("packages/cli/src/index.ts"), "--root", rootDir, "architecture", "--help"], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: `${rootDir}/.daemon-user` }
+      env: cliTestEnv({ HARNESS_DAEMON_MODE: "direct", HARNESS_DAEMON_USER_ROOT: `${rootDir}/.daemon-user` })
     });
 
     assert.equal(result.status, 2);

--- a/packages/cli/test/distill-cli.test.ts
+++ b/packages/cli/test/distill-cli.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -125,15 +126,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        ANTIGRAVITY_SESSION_ID: "",
-        CLAUDE_CODE_SESSION_ID: "",
-        CLAUDE_SESSION_ID: "",
-        CODEX_SESSION_ID: "",
-        CODEX_THREAD_ID: "",
-        ZCODE_SESSION_ID: ""
-      }
+      env: cliTestEnv()
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/doc-sync-cli.test.ts
+++ b/packages/cli/test/doc-sync-cli.test.ts
@@ -9,6 +9,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { pollUntil, stopDaemon } from "./helpers/daemon-cli.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const repoRoot = path.resolve(fileURLToPath(new URL("../../..", import.meta.url)));
@@ -209,16 +210,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_ACTOR: "agent:doc-sync-cli-test",
-        HARNESS_GIT_AUTHOR_NAME: "Harness Test",
-        HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
-        HARNESS_DAEMON_MODE: daemonMode,
-        HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user"),
-        HARNESS_DAEMON_IDLE_MS: "250",
-        GIT_CONFIG_GLOBAL: "/dev/null"
-      }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:doc-sync-cli-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test", HARNESS_DAEMON_MODE: daemonMode, HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user"), HARNESS_DAEMON_IDLE_MS: "250", GIT_CONFIG_GLOBAL: "/dev/null" })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/dry-run-preview-cli.test.ts
+++ b/packages/cli/test/dry-run-preview-cli.test.ts
@@ -10,6 +10,7 @@ import { commandDryRunPreviewRequiredByKind } from "../src/cli/receipt-contracts
 import { dryRunPreviewContractViolation } from "../src/cli/dry-run-preview.ts";
 import type { ParsedCommand } from "../src/cli/types.ts";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -57,13 +58,7 @@ test("decision propose dry-run previews both chosen and both rejected entries", 
       "--dry-run"
     ], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_ACTOR: "agent:test",
-        HARNESS_DAEMON_MODE: "fixture",
-        HARNESS_GIT_AUTHOR_NAME: "Harness Test",
-        HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test"
-      }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:test", HARNESS_DAEMON_MODE: "fixture", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test" })
     });
     const receipt = JSON.parse(stdout) as Record<string, any>;
     const preview = receipt.details.report.preview;

--- a/packages/cli/test/extension-cli.test.ts
+++ b/packages/cli/test/extension-cli.test.ts
@@ -6,6 +6,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const catalogFixture = "packages/kernel/fixtures/schemas/template-catalog/valid.json";
@@ -347,15 +348,7 @@ function runJson(args: ReadonlyArray<string>, expectSuccess = true): Record<stri
 function runRootJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_SESSION_ID: "",
-      CODEX_THREAD_ID: "",
-      ZCODE_SESSION_ID: "",
-      ANTIGRAVITY_SESSION_ID: ""
-    }
+    env: cliTestEnv()
   });
   return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
 }

--- a/packages/cli/test/fact-cli.test.ts
+++ b/packages/cli/test/fact-cli.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -221,16 +222,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_ACTOR: "agent:test",
-        ANTIGRAVITY_SESSION_ID: "",
-        CLAUDE_CODE_SESSION_ID: "",
-        CLAUDE_SESSION_ID: "",
-        CODEX_SESSION_ID: "",
-        CODEX_THREAD_ID: "",
-        ZCODE_SESSION_ID: ""
-      }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:test" })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/fact-execution-migration-cli.test.ts
+++ b/packages/cli/test/fact-execution-migration-cli.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import test from "node:test";
 import { deriveRelationId, formatRelationFlowRecord, parseFactFlowRecords, type EntityRelationRecord } from "../../kernel/src/index.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -177,7 +178,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--actor", "agent:fixture", "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user") }
+      env: cliTestEnv({ HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user") })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/graph-cli.test.ts
+++ b/packages/cli/test/graph-cli.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { deriveRelationId } from "../../kernel/src/index.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -154,7 +155,7 @@ function writeDecision(rootDir: string, decisionId: string, relations: ReadonlyA
 function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: process.env
+    env: cliTestEnv()
   });
   return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
 }

--- a/packages/cli/test/gui-cli.test.ts
+++ b/packages/cli/test/gui-cli.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { isTrustedGuiWorkspaceRoot } from "../src/commands/core/gui.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const npmBin = process.platform === "win32" ? "npm.cmd" : "npm";
@@ -147,7 +148,7 @@ function runJson(
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...env },
+      env: cliTestEnv({ ...env }),
       cwd
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);

--- a/packages/cli/test/helpers/cli-test-env.test.ts
+++ b/packages/cli/test/helpers/cli-test-env.test.ts
@@ -1,0 +1,18 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { blankedCliTestEnvKeys, cliTestEnv } from "./cli-test-env.ts";
+
+test("cliTestEnv blanks every inherited agent session input", () => {
+  const inheritedEnv = Object.fromEntries(blankedCliTestEnvKeys.map((key) => [key, "developer-machine-value"]));
+  const env = cliTestEnv({}, inheritedEnv);
+
+  for (const key of blankedCliTestEnvKeys) assert.equal(env[key], "");
+});
+
+test("cliTestEnv applies explicit test overrides after isolation", () => {
+  const [key] = blankedCliTestEnvKeys;
+  const env = cliTestEnv({ [key]: "fixture-value" }, { [key]: "developer-machine-value" });
+
+  assert.equal(env[key], "fixture-value");
+});

--- a/packages/cli/test/helpers/cli-test-env.ts
+++ b/packages/cli/test/helpers/cli-test-env.ts
@@ -1,0 +1,20 @@
+export const blankedCliTestEnvKeys = [
+  "HARNESS_AUTHORITY_MANIFEST",
+  "CLAUDE_SESSION_ID",
+  "CLAUDE_CODE_SESSION_ID",
+  "CODEX_THREAD_ID",
+  "CODEX_SESSION_ID",
+  "ZCODE_SESSION_ID",
+  "ANTIGRAVITY_SESSION_ID"
+] as const;
+
+export function cliTestEnv(
+  overrides: Readonly<NodeJS.ProcessEnv> = {},
+  inheritedEnv: Readonly<NodeJS.ProcessEnv> = process.env
+): NodeJS.ProcessEnv {
+  return {
+    ...inheritedEnv,
+    ...Object.fromEntries(blankedCliTestEnvKeys.map((key) => [key, ""])),
+    ...overrides
+  };
+}

--- a/packages/cli/test/helpers/daemon-cli.ts
+++ b/packages/cli/test/helpers/daemon-cli.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { localUserDaemonEndpoint } from "../../../daemon/src/index.ts";
+import { cliTestEnv } from "./cli-test-env.ts";
 import { ensureTestHarnessIdentity } from "./git-fixtures.ts";
 import { delay, pollUntil } from "./poll-until.ts";
 
@@ -196,8 +197,7 @@ function waitBeforeRemoveRetry(ms: number): void {
 
 function daemonTestEnv(rootDir: string, env: Readonly<Record<string, string>>): NodeJS.ProcessEnv {
   const homeDir = path.join(rootDir, ".home");
-  return {
-    ...process.env,
+  return cliTestEnv({
     HOME: homeDir,
     USERPROFILE: homeDir,
     GIT_CONFIG_GLOBAL: "/dev/null",
@@ -205,15 +205,8 @@ function daemonTestEnv(rootDir: string, env: Readonly<Record<string, string>>): 
     HARNESS_GIT_AUTHOR_NAME: "Harness Test",
     HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
     HARNESS_DAEMON_USER_ROOT: defaultDaemonUserRoot(rootDir),
-    HARNESS_AUTHORITY_MANIFEST: "",
-    CLAUDE_SESSION_ID: "",
-    CLAUDE_CODE_SESSION_ID: "",
-    CODEX_THREAD_ID: "",
-    CODEX_SESSION_ID: "",
-    ZCODE_SESSION_ID: "",
-    ANTIGRAVITY_SESSION_ID: "",
     ...env
-  };
+  });
 }
 
 function isRetriableRemoveError(error: unknown): boolean {

--- a/packages/cli/test/helpers/daemon-transport.ts
+++ b/packages/cli/test/helpers/daemon-transport.ts
@@ -8,18 +8,13 @@ import {
   defaultDaemonUserRoot,
   pollUntil
 } from "./daemon-cli.ts";
+import { cliTestEnv } from "./cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
 export function spawnDaemonCli(rootDir: string, args: ReadonlyArray<string>) {
   return spawn(process.execPath, [cliEntry, "--root", rootDir, ...args], {
-    env: {
-      ...process.env,
-      HOME: path.join(rootDir, ".home"),
-      GIT_CONFIG_GLOBAL: "/dev/null",
-      HARNESS_DAEMON_MODE: "fixture",
-      HARNESS_DAEMON_USER_ROOT: defaultDaemonUserRoot(rootDir)
-    },
+    env: cliTestEnv({ HOME: path.join(rootDir, ".home"), GIT_CONFIG_GLOBAL: "/dev/null", HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: defaultDaemonUserRoot(rootDir) }),
     stdio: ["pipe", "pipe", "pipe"]
   });
 }

--- a/packages/cli/test/helpers/local-lifecycle-fixtures.ts
+++ b/packages/cli/test/helpers/local-lifecycle-fixtures.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { unwrapCommandReceipt } from "./receipt.ts";
+import { cliTestEnv } from "./cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
@@ -144,7 +145,7 @@ export function runJson(rootDir: string, args: ReadonlyArray<string>, expectSucc
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...env }
+      env: cliTestEnv({ ...env })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/helpers/preset-script-fixtures.ts
+++ b/packages/cli/test/helpers/preset-script-fixtures.ts
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { unwrapCommandReceipt } from "./receipt.ts";
+import { cliTestEnv } from "./cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -12,12 +13,7 @@ export function runJson(rootDir: string, args: ReadonlyArray<string>, expectSucc
   try {
     const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...cliArgs], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_ACTOR: "agent:preset-script-test",
-        HARNESS_GIT_AUTHOR_NAME: "Harness Test",
-        HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test"
-      }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:preset-script-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test" })
     });
     const parsed = JSON.parse(output) as Record<string, any>;
     if (expectSuccess) assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/helpers/task-document-gates-fixtures.ts
+++ b/packages/cli/test/helpers/task-document-gates-fixtures.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { initializeNestedHarnessRepo } from "./git-fixtures.ts";
 import { unwrapCommandReceipt } from "./receipt.ts";
+import { cliTestEnv } from "./cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const testActorEnv = { HARNESS_ACTOR: "agent:test" };
@@ -187,7 +188,7 @@ export function runJson(rootDir: string, args: ReadonlyArray<string>, expectSucc
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_SKIP_NPM_INSTALL: "1", ...testActorEnv, ...env },
+      env: cliTestEnv({ HARNESS_SKIP_NPM_INSTALL: "1", ...testActorEnv, ...env }),
       stdio: ["ignore", "pipe", "pipe"]
     });
     const result = JSON.parse(stdout) as Record<string, any>;

--- a/packages/cli/test/init-cli.test.ts
+++ b/packages/cli/test/init-cli.test.ts
@@ -7,17 +7,10 @@ import { resolveHarnessLayout } from "../../kernel/src/index.ts";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
-const noAgentRuntimeEnv = {
-  CLAUDE_SESSION_ID: "",
-  CLAUDE_CODE_SESSION_ID: "",
-  CODEX_SESSION_ID: "",
-  CODEX_THREAD_ID: "",
-  ZCODE_SESSION_ID: "",
-  ANTIGRAVITY_SESSION_ID: ""
-};
 
 test("CLI init defaults harness project name from the target root basename", () => {
   withTempRoot((rootDir) => {
@@ -324,7 +317,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, env?: NodeJS.Proc
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...noAgentRuntimeEnv, ...(env ?? {}) }
+      env: cliTestEnv({ ...(env ?? {}) })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/migration-adopt-cli.test.ts
+++ b/packages/cli/test/migration-adopt-cli.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
@@ -589,7 +590,7 @@ function runJson(
   try {
     const output = execFileSync(process.execPath, command, {
       encoding: "utf8",
-      env: { ...process.env, ...env }
+      env: cliTestEnv({ ...env })
     });
     const parsed = JSON.parse(output);
     if (expectSuccess) assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/new-task-cli.test.ts
+++ b/packages/cli/test/new-task-cli.test.ts
@@ -8,17 +8,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
-const noAgentRuntimeEnv = {
-  CLAUDE_SESSION_ID: "",
-  CLAUDE_CODE_SESSION_ID: "",
-  CODEX_SESSION_ID: "",
-  CODEX_THREAD_ID: "",
-  ZCODE_SESSION_ID: "",
-  ANTIGRAVITY_SESSION_ID: ""
-};
 const testActorEnv = { HARNESS_ACTOR: "agent:new-task-cli-test" } as const;
 
 test("CLI init dogfoods coding vertical defaults for new tasks", () => {
@@ -29,7 +22,7 @@ test("CLI init dogfoods coding vertical defaults for new tasks", () => {
     assert.equal(existsSync(path.join(rootDir, "harness/adr")), true);
     assert.equal(existsSync(path.join(rootDir, "harness/milestones")), true);
 
-    const result = runJson(rootDir, ["new-task", "--title", "Dogfood Task"], true, noAgentRuntimeEnv);
+    const result = runJson(rootDir, ["new-task", "--title", "Dogfood Task"], true, {});
     const taskId = assertGeneratedTaskId(result.taskId);
     const index = readFileSync(path.join(rootDir, `harness/tasks/${taskId}-dogfood-task/INDEX.md`), "utf8");
     const contract = JSON.parse(readFileSync(path.join(rootDir, `harness/tasks/${taskId}-dogfood-task/task-contract.json`), "utf8"));
@@ -83,7 +76,7 @@ test("CLI reference-task preset materializes localized references on demand", ()
         "reference-task",
         "--locale",
         testCase.locale
-      ], true, noAgentRuntimeEnv);
+      ], true, {});
       const referencesPath = path.join(rootDir, result.packagePath, "references", "INDEX.md");
 
       assert.equal(result.generated.includes("references/INDEX.md"), true);
@@ -105,7 +98,7 @@ test("CLI task readers keep existing references directories compatible", () => {
       "software/coding",
       "--preset",
       "standard-task"
-    ], true, noAgentRuntimeEnv);
+    ], true, {});
     const legacyReferencePath = path.join(rootDir, created.packagePath, "references", "legacy-input.md");
     mkdirSync(path.dirname(legacyReferencePath), { recursive: true });
     writeFileSync(legacyReferencePath, "# Legacy input\n", "utf8");
@@ -134,7 +127,7 @@ test("CLI check reads a created task contract without the mutable preset registr
       "software/coding",
       "--preset",
       "standard-task"
-    ], true, noAgentRuntimeEnv);
+    ], true, {});
     writeSubstantiveTaskPlan(rootDir, String(created.packagePath));
 
     const overrideDir = path.join(rootDir, ".harness", "presets", "standard-task");
@@ -150,9 +143,9 @@ test("CLI check reads a created task contract without the mutable preset registr
 test("CLI task contract migration is dry-run safe, idempotent, and queues ambiguous tasks", () => {
   withTempRoot((rootDir) => {
     runJson(rootDir, ["init"]);
-    const migratable = runJson(rootDir, ["task", "create", "--title", "Legacy Explicit", "--vertical", "software/coding", "--preset", "standard-task"] , true, noAgentRuntimeEnv);
-    const ambiguous = runJson(rootDir, ["task", "create", "--title", "Legacy Ambiguous", "--vertical", "software/coding", "--preset", "standard-task"], true, noAgentRuntimeEnv);
-    const unverified = runJson(rootDir, ["task", "create", "--title", "Legacy Unverified", "--vertical", "software/coding", "--preset", "standard-task"], true, noAgentRuntimeEnv);
+    const migratable = runJson(rootDir, ["task", "create", "--title", "Legacy Explicit", "--vertical", "software/coding", "--preset", "standard-task"] , true, {});
+    const ambiguous = runJson(rootDir, ["task", "create", "--title", "Legacy Ambiguous", "--vertical", "software/coding", "--preset", "standard-task"], true, {});
+    const unverified = runJson(rootDir, ["task", "create", "--title", "Legacy Unverified", "--vertical", "software/coding", "--preset", "standard-task"], true, {});
     const migratableContract = path.join(rootDir, migratable.packagePath, "task-contract.json");
     const ambiguousContract = path.join(rootDir, ambiguous.packagePath, "task-contract.json");
     const unverifiedContract = path.join(rootDir, unverified.packagePath, "task-contract.json");
@@ -207,7 +200,7 @@ test("CLI task contract migration uses source Git history plus actual scaffold e
     runJson(rootDir, ["init"]);
     const created = runJson(rootDir, [
       "task", "create", "--title", "Historical Contract", "--vertical", "software/coding", "--preset", "standard-task"
-    ], true, noAgentRuntimeEnv);
+    ], true, {});
     const contractPath = path.join(rootDir, created.packagePath, "task-contract.json");
     rmSync(contractPath, { force: true });
     writeSubstantiveTaskPlan(rootDir, String(created.packagePath));
@@ -223,7 +216,7 @@ test("CLI task contract migration uses source Git history plus actual scaffold e
 
 test("CLI creates a local task with generated identity, provenance, and stable JSON output", () => {
   withTempRoot((rootDir) => {
-    const result = runJson(rootDir, ["new-task", "--title", "Task One"], true, noAgentRuntimeEnv);
+    const result = runJson(rootDir, ["new-task", "--title", "Task One"], true, {});
     const taskId = assertGeneratedTaskId(result.taskId);
     const index = readFileSync(path.join(rootDir, `harness/tasks/${taskId}-task-one/INDEX.md`), "utf8");
 
@@ -243,7 +236,7 @@ test("CLI creates a local task with generated identity, provenance, and stable J
 
 test("CLI task create persists work kind and priority metadata", () => {
   withTempRoot((rootDir) => {
-    const result = runJson(rootDir, ["task", "create", "--title", "Metadata Task", "--kind", "feat", "--risk-tier", "high", "--urgency", "low"], true, noAgentRuntimeEnv);
+    const result = runJson(rootDir, ["task", "create", "--title", "Metadata Task", "--kind", "feat", "--risk-tier", "high", "--urgency", "low"], true, {});
     const taskId = assertGeneratedTaskId(result.taskId);
     const index = readFileSync(path.join(rootDir, `harness/tasks/${taskId}-metadata-task/INDEX.md`), "utf8");
 
@@ -269,7 +262,6 @@ test("CLI task create keeps runtime provenance without fabricating a missing tra
       "--preset",
       "standard-task"
     ], true, {
-      ...noAgentRuntimeEnv,
       CODEX_THREAD_ID: sessionId,
       HOME: path.join(rootDir, "home")
     });
@@ -314,12 +306,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_DAEMON_MODE: "fixture",
-        ...testActorEnv,
-        ...env
-      }
+      env: cliTestEnv({ HARNESS_DAEMON_MODE: "fixture", ...testActorEnv, ...env })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
@@ -333,11 +320,7 @@ function runText(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_DAEMON_MODE: "fixture",
-        ...testActorEnv
-      },
+      env: cliTestEnv({ HARNESS_DAEMON_MODE: "fixture", ...testActorEnv }),
       stdio: ["ignore", "pipe", "pipe"]
     });
     return stdout;

--- a/packages/cli/test/package-surface.test.ts
+++ b/packages/cli/test/package-surface.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { loadPresetDocument } from "../src/commands/extensions/preset-document-loader.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const architectureRotRoot = path.resolve("packages/cli/src/commands/extensions/assets/software-coding/presets/architecture-rot-audit");
@@ -486,13 +487,7 @@ function assertPresetScriptImportsStayInsidePackage(presetRoot: string, command:
 function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      HARNESS_ACTOR: "agent:package-surface-test",
-      HARNESS_DAEMON_MODE: "fixture",
-      HARNESS_GIT_AUTHOR_NAME: "Harness Test",
-      HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test"
-    }
+    env: cliTestEnv({ HARNESS_ACTOR: "agent:package-surface-test", HARNESS_DAEMON_MODE: "fixture", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test" })
   });
   return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
 }

--- a/packages/cli/test/post-merge-check-cli.test.ts
+++ b/packages/cli/test/post-merge-check-cli.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { deriveRelationId, formatRelationFlowRecord, sha256Text, type EntityRelationRecord } from "../../kernel/src/index.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -376,7 +377,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_SKIP_NPM_INSTALL: "1", ...env },
+      env: cliTestEnv({ HARNESS_SKIP_NPM_INSTALL: "1", ...env }),
       stdio: ["ignore", "pipe", "pipe"]
     });
     const result = JSON.parse(stdout) as Record<string, any>;

--- a/packages/cli/test/preset-create-milestone-cli.test.ts
+++ b/packages/cli/test/preset-create-milestone-cli.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const presetId = "create-milestone";
@@ -61,14 +62,7 @@ test("CLI create-milestone exposes v3 agent guidance without script entrypoints"
 function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
   const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      HARNESS_ACTOR: "agent:create-milestone-guidance-test",
-      HARNESS_GIT_AUTHOR_NAME: "Harness Test",
-      HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
-      HARNESS_DAEMON_MODE: "fixture",
-      HARNESS_USER_HOME: path.join(rootDir, ".empty-user-home")
-    }
+    env: cliTestEnv({ HARNESS_ACTOR: "agent:create-milestone-guidance-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test", HARNESS_DAEMON_MODE: "fixture", HARNESS_USER_HOME: path.join(rootDir, ".empty-user-home") })
   });
   const parsed = JSON.parse(output) as Record<string, any>;
   assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/preset-create-milestone-render-html-cli.test.ts
+++ b/packages/cli/test/preset-create-milestone-render-html-cli.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const presetId = "create-milestone";
@@ -36,14 +37,7 @@ test("CLI create-milestone guidance does not expose retired scaffold, render, or
 function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
   const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      HARNESS_ACTOR: "agent:create-milestone-render-guidance-test",
-      HARNESS_GIT_AUTHOR_NAME: "Harness Test",
-      HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
-      HARNESS_DAEMON_MODE: "fixture",
-      HARNESS_USER_HOME: path.join(rootDir, ".empty-user-home")
-    }
+    env: cliTestEnv({ HARNESS_ACTOR: "agent:create-milestone-render-guidance-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test", HARNESS_DAEMON_MODE: "fixture", HARNESS_USER_HOME: path.join(rootDir, ".empty-user-home") })
   });
   const parsed = JSON.parse(output) as Record<string, any>;
   assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/preset-document-cli.test.ts
+++ b/packages/cli/test/preset-document-cli.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const bundledPresetIndexPath = path.resolve("packages/cli/src/commands/extensions/assets/software-coding/presets/index.json");
@@ -43,7 +44,7 @@ test("CLI preset list text prints one semantic row per bundled preset", () => {
   withTempRoot((rootDir) => {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "preset", "list"], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_DAEMON_MODE: "fixture" }
+      env: cliTestEnv({ HARNESS_DAEMON_MODE: "fixture" })
     });
     const rows = stdout.trim().split("\n");
     const bundledPresetIndex = JSON.parse(readFileSync(bundledPresetIndexPath, "utf8")) as { readonly presets: ReadonlyArray<string> };
@@ -87,7 +88,7 @@ test("CLI preset summaries warn and fall back to title when PRESET.md is missing
 function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: { ...process.env, HARNESS_DAEMON_MODE: "fixture" }
+    env: cliTestEnv({ HARNESS_DAEMON_MODE: "fixture" })
   });
   return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
 }

--- a/packages/cli/test/preset-github-issue-repair-cli.test.ts
+++ b/packages/cli/test/preset-github-issue-repair-cli.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const presetRoot = path.resolve(
@@ -56,14 +57,7 @@ test("CLI github issue repair preset exposes agent guidance without a script run
 function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
   const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      HARNESS_ACTOR: "agent:github-issue-repair-test",
-      HARNESS_GIT_AUTHOR_NAME: "Harness Test",
-      HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
-      HARNESS_DAEMON_MODE: "fixture",
-      HARNESS_USER_HOME: path.join(rootDir, ".empty-user-home")
-    }
+    env: cliTestEnv({ HARNESS_ACTOR: "agent:github-issue-repair-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test", HARNESS_DAEMON_MODE: "fixture", HARNESS_USER_HOME: path.join(rootDir, ".empty-user-home") })
   });
   const parsed = JSON.parse(output) as Record<string, any>;
   assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/preset-milestone-closeout-cli.test.ts
+++ b/packages/cli/test/preset-milestone-closeout-cli.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const presetId = "milestone-closeout";
@@ -59,14 +60,7 @@ test("CLI milestone-closeout exposes v3 agent guidance without a machine-verdict
 function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
   const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      HARNESS_ACTOR: "agent:milestone-closeout-guidance-test",
-      HARNESS_GIT_AUTHOR_NAME: "Harness Test",
-      HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
-      HARNESS_DAEMON_MODE: "fixture",
-      HARNESS_USER_HOME: path.join(rootDir, ".empty-user-home")
-    }
+    env: cliTestEnv({ HARNESS_ACTOR: "agent:milestone-closeout-guidance-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test", HARNESS_DAEMON_MODE: "fixture", HARNESS_USER_HOME: path.join(rootDir, ".empty-user-home") })
   });
   const parsed = JSON.parse(output) as Record<string, any>;
   assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/preset-module-cli.test.ts
+++ b/packages/cli/test/preset-module-cli.test.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const bundledPresetIndexPath = path.resolve("packages/cli/src/commands/extensions/assets/software-coding/presets/index.json");
@@ -493,7 +494,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_ACTOR: "agent:harness-test", HARNESS_DAEMON_MODE: "fixture", ...env }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:harness-test", HARNESS_DAEMON_MODE: "fixture", ...env })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/preset-script-imports-cli.test.ts
+++ b/packages/cli/test/preset-script-imports-cli.test.ts
@@ -9,6 +9,7 @@ import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { PRESET_POLICY_SCHEMA_CREATE_MILESTONE } from "../src/commands/extensions/preset-policy.ts";
 import { executeScript } from "../src/commands/extensions/script-executor.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -479,7 +480,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_ACTOR: "agent:test" }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:test" })
     });
     const parsed = JSON.parse(output) as Record<string, any>;
     if (expectSuccess) assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/preset-script-staging-boundary.test.ts
+++ b/packages/cli/test/preset-script-staging-boundary.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { discoverScriptEntries } from "../src/commands/extensions/script.ts";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -338,13 +339,7 @@ function runJson(
   try {
     const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_ACTOR: "agent:preset-script-staging-test",
-        HARNESS_GIT_AUTHOR_NAME: "Harness Test",
-        HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
-        ...extraEnvironment
-      }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:preset-script-staging-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test", ...extraEnvironment })
     });
     const parsed = JSON.parse(output) as Record<string, any>;
     if (expectSuccess) assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/preset-subtask-expansion-cli.test.ts
+++ b/packages/cli/test/preset-subtask-expansion-cli.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const presetId = "subtask-expansion";
@@ -59,14 +60,7 @@ test("CLI subtask-expansion exposes v3 agent guidance without a script runtime",
 function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
   const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      HARNESS_ACTOR: "agent:subtask-expansion-guidance-test",
-      HARNESS_GIT_AUTHOR_NAME: "Harness Test",
-      HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
-      HARNESS_DAEMON_MODE: "fixture",
-      HARNESS_USER_HOME: path.join(rootDir, ".empty-user-home")
-    }
+    env: cliTestEnv({ HARNESS_ACTOR: "agent:subtask-expansion-guidance-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test", HARNESS_DAEMON_MODE: "fixture", HARNESS_USER_HOME: path.join(rootDir, ".empty-user-home") })
   });
   const parsed = JSON.parse(output) as Record<string, any>;
   assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/preset-uninstall-safety-cli.test.ts
+++ b/packages/cli/test/preset-uninstall-safety-cli.test.ts
@@ -8,16 +8,9 @@ import test from "node:test";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
-const noAgentRuntimeEnv = {
-  CLAUDE_SESSION_ID: "",
-  CLAUDE_CODE_SESSION_ID: "",
-  CODEX_SESSION_ID: "",
-  CODEX_THREAD_ID: "",
-  ZCODE_SESSION_ID: "",
-  ANTIGRAVITY_SESSION_ID: ""
-};
 
 test("preset uninstall dry-run emits impact without deleting and declarative active tasks allow apply", () => {
   withFixture("template-content", (fixture) => {
@@ -115,7 +108,6 @@ function withFixture(kind: "process-action" | "template-content", fn: (fixture: 
   const version = "3.4.5";
   const sourceDir = path.join(rootDir, "source-preset");
   const env = {
-    ...noAgentRuntimeEnv,
     HARNESS_DAEMON_MODE: "fixture",
     HARNESS_USER_HOME: userHome,
     HARNESS_ACTOR: "agent:preset-uninstall-test"
@@ -229,7 +221,7 @@ function runJson(
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...env }
+      env: cliTestEnv({ ...env })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/preset-user-root-cli.test.ts
+++ b/packages/cli/test/preset-user-root-cli.test.ts
@@ -6,6 +6,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -160,7 +161,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...env }
+      env: cliTestEnv({ ...env })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/production-authority-canonical-ingress/wave2-parity.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/wave2-parity.ts
@@ -3,6 +3,7 @@ import { readFileSync, rmSync } from "node:fs";
 import path from "node:path";
 import { parseDecisionDocument } from "../../../kernel/src/index.ts";
 import { runRawJsonMaybeFail } from "../helpers/daemon-cli.ts";
+import { cliTestEnv } from "../helpers/cli-test-env.ts";
 import { createFixture, type ProductionCanonicalIngressFixture } from "./fixture.ts";
 
 export function verifyWave2CanonicalParity(
@@ -10,7 +11,7 @@ export function verifyWave2CanonicalParity(
   daemonEnv: NodeJS.ProcessEnv
 ): void {
   const directFixture = createFixture();
-  const directEnv = { ...daemonEnv, HARNESS_DAEMON_MODE: "fixture", HARNESS_AUTHORITY_MANIFEST: "" };
+  const directEnv = cliTestEnv({ ...daemonEnv, HARNESS_DAEMON_MODE: "fixture" });
   const failures: Error[] = [];
   const check = (assertion: () => void): void => {
     try { assertion(); } catch (error) { failures.push(error instanceof Error ? error : new Error(String(error))); }

--- a/packages/cli/test/progress-evidence-cli.test.ts
+++ b/packages/cli/test/progress-evidence-cli.test.ts
@@ -6,6 +6,7 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
@@ -37,7 +38,7 @@ function assertGeneratedTaskId(value: unknown): string {
 function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: { ...process.env, HARNESS_ACTOR: "agent:test" }
+    env: cliTestEnv({ HARNESS_ACTOR: "agent:test" })
   });
   return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
 }

--- a/packages/cli/test/projection-freshness-cli.test.ts
+++ b/packages/cli/test/projection-freshness-cli.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -93,7 +94,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: process.env
+      env: cliTestEnv()
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/projection-readers-cli.test.ts
+++ b/packages/cli/test/projection-readers-cli.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { writeContentAddressedBlob } from "../../kernel/src/index.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskId = "task_01J00000000000000000000000";
@@ -173,16 +174,7 @@ function writeTask(rootDir: string, id: string, status: string): void {
 function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      HARNESS_ACTOR: "agent:test",
-      ANTIGRAVITY_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CLAUDE_SESSION_ID: "",
-      CODEX_SESSION_ID: "",
-      CODEX_THREAD_ID: "",
-      ZCODE_SESSION_ID: ""
-    }
+    env: cliTestEnv({ HARNESS_ACTOR: "agent:test" })
   });
   return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
 }

--- a/packages/cli/test/retired-attribution-field-migration-cli.test.ts
+++ b/packages/cli/test/retired-attribution-field-migration-cli.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { cleanupRetiredAttributionFields } from "../../kernel/src/index.ts";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -138,7 +139,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--actor", "agent:fixture", "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user") }
+      env: cliTestEnv({ HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user") })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/runtime-event-cli.test.ts
+++ b/packages/cli/test/runtime-event-cli.test.ts
@@ -14,16 +14,9 @@ import type { ParsedCommand } from "../src/cli/types.ts";
 import { runRegisteredCommandWithCliComposition } from "../src/composition/command-executor.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
-const cleanRuntimeEnv = {
-  CLAUDE_CODE_SESSION_ID: "",
-  CLAUDE_SESSION_ID: "",
-  CODEX_SESSION_ID: "",
-  CODEX_THREAD_ID: "",
-  ZCODE_SESSION_ID: "",
-  ANTIGRAVITY_SESSION_ID: ""
-} as const;
 
 test("automatic runtime event failure warns without reversing a successful command receipt", async () => {
   const command = {
@@ -69,10 +62,7 @@ test("automatic runtime event failure warns without reversing a successful comma
 test("CLI authored write commands append a current-session result event", () => {
   withTempRoot((rootDir) => {
     const sessionId = "codex-w2-command-event";
-    const created = runJson(rootDir, ["task", "create", "--title", "Evented Task"], true, {
-      CODEX_SESSION_ID: sessionId,
-      CODEX_THREAD_ID: ""
-    });
+    const created = runJson(rootDir, ["task", "create", "--title", "Evented Task"], true, { CODEX_SESSION_ID: sessionId });
     const ledgerPath = path.join(rootDir, ".harness/generated/runtime-events", `${sessionId}.jsonl`);
     const events = readJsonl(ledgerPath);
 
@@ -139,10 +129,7 @@ test("deprecated grammar tags the existing auto command event instead of adding 
     initGitRoot(rootDir);
     const sessionId = "codex-deprecated-grammar-tag";
     const taskId = "task_01KWY3Z4VEVP6FNT28ZFA809GW";
-    const result = runJson(rootDir, ["task", "status", "set", taskId, "done"], false, {
-      CODEX_SESSION_ID: sessionId,
-      CODEX_THREAD_ID: ""
-    });
+    const result = runJson(rootDir, ["task", "status", "set", taskId, "done"], false, { CODEX_SESSION_ID: sessionId });
     const events = readJsonl(path.join(rootDir, ".harness/generated/runtime-events", `${sessionId}.jsonl`));
 
     assert.equal(result.ok, false);
@@ -158,10 +145,7 @@ test("CLI failed command results append failed command events", () => {
     initGitRoot(rootDir);
     const sessionId = "codex-w2-command-failure";
     const taskId = "task_01KWY3Z4VEVP6FNT28ZFA809GW";
-    const result = runJson(rootDir, ["task", "transition", taskId, "done"], false, {
-      CODEX_SESSION_ID: sessionId,
-      CODEX_THREAD_ID: ""
-    });
+    const result = runJson(rootDir, ["task", "transition", taskId, "done"], false, { CODEX_SESSION_ID: sessionId });
     const ledgerPath = path.join(rootDir, ".harness/generated/runtime-events", `${sessionId}.jsonl`);
     const events = readJsonl(ledgerPath);
 
@@ -180,11 +164,7 @@ test("CLI task transition runtime event records dual-axis actor", () => {
     const created = runJson(rootDir, ["new-task", "--title", "Transition Actor Task"]);
     writeSubstantiveTaskPlan(rootDir, String(created.packagePath));
     const sessionId = "codex-transition-actor";
-    const transitioned = runJson(rootDir, ["task", "transition", created.taskId, "active"], true, {
-      CODEX_SESSION_ID: sessionId,
-      CODEX_THREAD_ID: "",
-      HARNESS_ACTOR: "agent:codex-cli"
-    });
+    const transitioned = runJson(rootDir, ["task", "transition", created.taskId, "active"], true, { CODEX_SESSION_ID: sessionId, HARNESS_ACTOR: "agent:codex-cli" });
     const ledgerPath = path.join(rootDir, ".harness/generated/runtime-events", `${sessionId}.jsonl`);
     const events = readJsonl(ledgerPath);
 
@@ -203,11 +183,7 @@ test("CLI entity write fails closed before runtime event append when principal c
   withTempRoot((rootDir) => {
     writeFileSync(path.join(rootDir, "harness/harness.yaml"), "schema: harness-anything/v1\nsettings:\n", "utf8");
     const sessionId = "codex-runtime-event-missing-actor";
-    const output = runJsonWithStderr(rootDir, ["new-task", "--title", "Missing Actor Event"], {
-      CODEX_SESSION_ID: sessionId,
-      CODEX_THREAD_ID: "",
-      HARNESS_DAEMON_MODE: "fixture"
-    }, 1);
+    const output = runJsonWithStderr(rootDir, ["new-task", "--title", "Missing Actor Event"], { CODEX_SESSION_ID: sessionId, HARNESS_DAEMON_MODE: "fixture" }, 1);
     const ledgerPath = path.join(rootDir, ".harness/generated/runtime-events", `${sessionId}.jsonl`);
 
     assert.equal(output.result.ok, false);
@@ -225,15 +201,7 @@ test("CLI parse failures preserve the receipt without opening a canonical diagno
       "--question", "Which option?",
       "--chosen", "Chosen option",
       "--rejected", '{"badfield":"do-not-store"}'
-    ], {
-      CODEX_SESSION_ID: sessionId,
-      CODEX_THREAD_ID: "",
-      HARNESS_ACTOR: "",
-      HARNESS_GIT_AUTHOR_NAME: "",
-      HARNESS_GIT_AUTHOR_EMAIL: "",
-      GIT_AUTHOR_NAME: "",
-      GIT_AUTHOR_EMAIL: ""
-    }, 2);
+    ], { CODEX_SESSION_ID: sessionId, HARNESS_ACTOR: "", HARNESS_GIT_AUTHOR_NAME: "", HARNESS_GIT_AUTHOR_EMAIL: "", GIT_AUTHOR_NAME: "", GIT_AUTHOR_EMAIL: "" }, 2);
     const ledgerPath = path.join(rootDir, ".harness/generated/runtime-events", `${sessionId}.jsonl`);
 
     assert.equal(output.result.ok, false);
@@ -377,15 +345,7 @@ async function withTempRootAsync<T>(fn: (rootDir: string) => Promise<T>): Promis
 function bootstrapRuntimeEventRoot(rootDir: string): void {
   execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", "init"], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      ...cleanRuntimeEnv,
-      HARNESS_ACTOR: "agent:harness-test",
-      HARNESS_GIT_AUTHOR_NAME: "Harness Tester",
-      HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test",
-      HARNESS_DAEMON_MODE: "local",
-      HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user")
-    }
+    env: cliTestEnv({ HARNESS_ACTOR: "agent:harness-test", HARNESS_GIT_AUTHOR_NAME: "Harness Tester", HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test", HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user") })
   });
   const configPath = path.join(rootDir, "harness/harness.yaml");
   writeFileSync(configPath, readFileSync(configPath, "utf8").replace(
@@ -427,16 +387,7 @@ function runJson(
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        ...cleanRuntimeEnv,
-        HARNESS_ACTOR: "agent:harness-test",
-        HARNESS_GIT_AUTHOR_NAME: "Harness Tester",
-        HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test",
-        HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user"),
-        HARNESS_DAEMON_IDLE_MS: "250",
-        ...env
-      }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:harness-test", HARNESS_GIT_AUTHOR_NAME: "Harness Tester", HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test", HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user"), HARNESS_DAEMON_IDLE_MS: "250", ...env })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
@@ -462,14 +413,7 @@ function runJsonWithStderr(
 ): { readonly result: Record<string, any>; readonly stderr: string } {
   const child = spawnSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      ...cleanRuntimeEnv,
-      HARNESS_ACTOR: "agent:harness-test",
-      HARNESS_GIT_AUTHOR_NAME: "Harness Tester",
-      HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test",
-      ...env
-    }
+    env: cliTestEnv({ HARNESS_ACTOR: "agent:harness-test", HARNESS_GIT_AUTHOR_NAME: "Harness Tester", HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test", ...env })
   });
   assert.equal(child.status, expectedStatus);
   return {
@@ -481,16 +425,6 @@ function runJsonWithStderr(
 function runRaw(rootDir: string, args: ReadonlyArray<string>) {
   return spawnSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      ...cleanRuntimeEnv,
-      HARNESS_ACTOR: "agent:harness-test",
-      HARNESS_GIT_AUTHOR_NAME: "Harness Tester",
-      HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test",
-      HARNESS_DAEMON_MODE: "local",
-      HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user"),
-      HARNESS_DAEMON_IDLE_MS: "250",
-      CODEX_SESSION_ID: "codex-deprecation-warning"
-    }
+    env: cliTestEnv({ HARNESS_ACTOR: "agent:harness-test", HARNESS_GIT_AUTHOR_NAME: "Harness Tester", HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test", HARNESS_DAEMON_MODE: "local", HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user"), HARNESS_DAEMON_IDLE_MS: "250", CODEX_SESSION_ID: "codex-deprecation-warning" })
   });
 }

--- a/packages/cli/test/script-host-boundary.test.ts
+++ b/packages/cli/test/script-host-boundary.test.ts
@@ -10,6 +10,7 @@ import { trustedScriptRepositoryContext } from "../src/commands/extensions/scrip
 import { resolveDeclaredReadScopes, resolveDeclaredWriteScopes } from "../src/commands/extensions/script-scope.ts";
 import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -561,7 +562,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_ACTOR: "agent:script-host-boundary-test" }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:script-host-boundary-test" })
     });
     const parsed = JSON.parse(output) as Record<string, any>;
     if (expectSuccess) assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/script-package-read-boundary.test.ts
+++ b/packages/cli/test/script-package-read-boundary.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -79,7 +80,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const output = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_ACTOR: "agent:test" }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:test" })
     });
     const parsed = unwrapCommandReceipt(JSON.parse(output) as Record<string, any>);
     if (expectSuccess) assert.equal(parsed.ok, true, output);

--- a/packages/cli/test/session-cli.test.ts
+++ b/packages/cli/test/session-cli.test.ts
@@ -9,16 +9,9 @@ import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { writeContentAddressedBlob } from "../../kernel/src/index.ts";
 import { readSessionEntity } from "../../application/src/index.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
-const cleanRuntimeEnv = {
-  CLAUDE_CODE_SESSION_ID: "",
-  CLAUDE_SESSION_ID: "",
-  CODEX_SESSION_ID: "",
-  CODEX_THREAD_ID: "",
-  ZCODE_SESSION_ID: "",
-  ANTIGRAVITY_SESSION_ID: ""
-} as const;
 const testActorEnv = { HARNESS_ACTOR: "agent:session-cli-test" } as const;
 
 test("CLI session export binds CODEX_THREAD_ID and writes managed session markdown through the journal", () => {
@@ -317,7 +310,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...cleanRuntimeEnv, ...testActorEnv, ...env }
+      env: cliTestEnv({ ...testActorEnv, ...env })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/settings-cli.test.ts
+++ b/packages/cli/test/settings-cli.test.ts
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -492,14 +493,7 @@ function runJson(
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HARNESS_ACTOR: "agent:settings-test",
-        HARNESS_GIT_AUTHOR_NAME: "Settings Tester",
-        HARNESS_GIT_AUTHOR_EMAIL: "settings@example.test",
-        HARNESS_DAEMON_MODE: "fixture",
-        ...extraEnv
-      }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:settings-test", HARNESS_GIT_AUTHOR_NAME: "Settings Tester", HARNESS_GIT_AUTHOR_EMAIL: "settings@example.test", HARNESS_DAEMON_MODE: "fixture", ...extraEnv })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/submit-lifecycle-cli.test.ts
+++ b/packages/cli/test/submit-lifecycle-cli.test.ts
@@ -9,15 +9,7 @@ import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
 
-const noRuntimeSession = {
-  HARNESS_ACTOR: "agent:test",
-  CLAUDE_SESSION_ID: "",
-  CLAUDE_CODE_SESSION_ID: "",
-  CODEX_THREAD_ID: "",
-  CODEX_SESSION_ID: "",
-  ZCODE_SESSION_ID: "",
-  ANTIGRAVITY_SESSION_ID: ""
-} as const;
+const noRuntimeSession = { HARNESS_ACTOR: "agent:test" } as const;
 
 test("in_review without an Execution submission fails closed", () => {
   withTempRoot((rootDir) => {

--- a/packages/cli/test/task-lease-cli.test.ts
+++ b/packages/cli/test/task-lease-cli.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
@@ -239,13 +240,7 @@ test("default claim preserves status and the Holder V2 actor can submit without 
     writeHarnessIdentity(rootDir, "person_zeyu", "Zeyu Li");
     const created = runJson(rootDir, ["new-task", "--title", "Execution Saga"]);
     writeSubstantiveTaskPlan(rootDir, created.packagePath);
-    const claimed = runJson(rootDir, ["task", "claim", created.taskId], true, {
-      HARNESS_ACTOR: "agent:test",
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: "codex-primary-session",
-      CODEX_SESSION_ID: "codex-primary-session"
-    });
+    const claimed = runJson(rootDir, ["task", "claim", created.taskId], true, { HARNESS_ACTOR: "agent:test", CODEX_THREAD_ID: "codex-primary-session", CODEX_SESSION_ID: "codex-primary-session" });
 
     assert.match(claimed.executionId, /^exe_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u);
     assert.match(claimed.report.leaseToken, /^[0-9a-f]{64}$/u);
@@ -268,32 +263,14 @@ test("default claim preserves status and the Holder V2 actor can submit without 
     const indexPath = path.join(rootDir, `harness/tasks/${created.taskId}-execution-saga/INDEX.md`);
     assert.match(readFileSync(indexPath, "utf8"), /^  status: planned$/mu);
 
-    const activated = runJson(rootDir, ["task", "transition", created.taskId, "active"], true, {
-      HARNESS_ACTOR: "agent:test",
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: "codex-primary-session",
-      CODEX_SESSION_ID: "codex-primary-session"
-    });
+    const activated = runJson(rootDir, ["task", "transition", created.taskId, "active"], true, { HARNESS_ACTOR: "agent:test", CODEX_THREAD_ID: "codex-primary-session", CODEX_SESSION_ID: "codex-primary-session" });
     assert.equal(activated.status, "active");
 
-    const otherHolder = runJson(rootDir, ["task", "claim", created.taskId], false, {
-      HARNESS_ACTOR: "agent:other-worker",
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: "other-worker-session",
-      CODEX_SESSION_ID: "other-worker-session"
-    });
+    const otherHolder = runJson(rootDir, ["task", "claim", created.taskId], false, { HARNESS_ACTOR: "agent:other-worker", CODEX_THREAD_ID: "other-worker-session", CODEX_SESSION_ID: "other-worker-session" });
     assert.equal(otherHolder.ok, false);
     assert.equal(otherHolder.report.code, "execution_lease_collision");
 
-    const renewed = runJson(rootDir, ["task", "claim", created.taskId], true, {
-      HARNESS_ACTOR: "agent:test",
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: "codex-primary-session",
-      CODEX_SESSION_ID: "codex-primary-session"
-    });
+    const renewed = runJson(rootDir, ["task", "claim", created.taskId], true, { HARNESS_ACTOR: "agent:test", CODEX_THREAD_ID: "codex-primary-session", CODEX_SESSION_ID: "codex-primary-session" });
     assert.equal(renewed.executionId, claimed.executionId);
     assert.notEqual(renewed.report.leaseToken, claimed.report.leaseToken);
     const renewedLeaseLedgerBody = readFileSync(path.join(
@@ -308,13 +285,7 @@ test("default claim preserves status and the Holder V2 actor can submit without 
       "task", "transition", created.taskId, "in_review",
       "--lease-token", claimed.report.leaseToken,
       "--summary", "stale credential must be rejected"
-    ], false, {
-      HARNESS_ACTOR: "agent:test",
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: "codex-primary-session",
-      CODEX_SESSION_ID: "codex-primary-session"
-    });
+    ], false, { HARNESS_ACTOR: "agent:test", CODEX_THREAD_ID: "codex-primary-session", CODEX_SESSION_ID: "codex-primary-session" });
     assert.equal(staleToken.ok, false);
     assert.match(staleToken.error.hint, /requires an active lease/u);
 
@@ -339,14 +310,7 @@ test("default claim preserves status and the Holder V2 actor can submit without 
       "--summary", "ready for review",
       "--verification", "node:test",
       "--output", "commit:abc123"
-    ], true, {
-      HARNESS_ACTOR: "agent:test",
-      HOME: homeDir,
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: "codex-primary-session",
-      CODEX_SESSION_ID: "codex-primary-session"
-    });
+    ], true, { HARNESS_ACTOR: "agent:test", HOME: homeDir, CODEX_THREAD_ID: "codex-primary-session", CODEX_SESSION_ID: "codex-primary-session" });
 
     assert.equal(submitted.status, "in_review");
     assert.equal(submitted.report.leaseReleased, true);
@@ -531,20 +495,13 @@ function writePeopleRoster(rootDir: string, personId: string, displayName: strin
 
 function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true, env: Readonly<Record<string, string>> = {}): Record<string, any> {
   try {
-    const childEnv = {
-      ...process.env,
+    const childEnv = cliTestEnv({
       HARNESS_ACTOR: "agent:harness-test",
       HARNESS_GIT_AUTHOR_NAME: "Harness Tester",
       HARNESS_GIT_AUTHOR_EMAIL: "tester@example.test",
       HARNESS_DAEMON_MODE: "fixture",
-      CLAUDE_SESSION_ID: "",
-      CLAUDE_CODE_SESSION_ID: "",
-      CODEX_THREAD_ID: "",
-      CODEX_SESSION_ID: "",
-      ZCODE_SESSION_ID: "",
-      ANTIGRAVITY_SESSION_ID: "",
       ...env
-    };
+    });
     delete childEnv.HARNESS_TASK_LEASE_ENFORCEMENT;
     delete childEnv.HARNESS_TASK_LEASE_TTL_MS;
     if (env.HARNESS_TASK_LEASE_ENFORCEMENT !== undefined) {

--- a/packages/cli/test/task-show-relation-list-cli.test.ts
+++ b/packages/cli/test/task-show-relation-list-cli.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -186,7 +187,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: process.env
+      env: cliTestEnv()
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/task-transition-sweep-cli.test.ts
+++ b/packages/cli/test/task-transition-sweep-cli.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
@@ -160,7 +161,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, HARNESS_ACTOR: "agent:harness-test", ...env }
+      env: cliTestEnv({ HARNESS_ACTOR: "agent:harness-test", ...env })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
@@ -210,15 +211,7 @@ function approveExecution(rootDir: string, taskId: string, executionId: string):
 }
 
 function actorEnv(id: string): Record<string, string> {
-  return {
-    HARNESS_ACTOR: `agent:${id}`,
-    CLAUDE_SESSION_ID: "",
-    CLAUDE_CODE_SESSION_ID: "",
-    CODEX_THREAD_ID: "",
-    CODEX_SESSION_ID: "",
-    ZCODE_SESSION_ID: "",
-    ANTIGRAVITY_SESSION_ID: ""
-  };
+  return { HARNESS_ACTOR: `agent:${id}` };
 }
 
 function writeFact(rootDir: string, taskPath: string): void {

--- a/packages/cli/test/worktree-cli.test.ts
+++ b/packages/cli/test/worktree-cli.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskId = "task_01KWY3Z4VEVP6FNT28ZFA809GW";
@@ -38,14 +39,7 @@ test("worktree create writes a task binding and status reports active", () => {
 
 test("worktree create fails closed without explicit or runtime namespace", () => {
   withGitHarnessRoot((rootDir) => {
-    const result = runJson(rootDir, ["worktree", "create", "--task", taskId, "--base", "HEAD"], false, {
-      CLAUDE_CODE_SESSION_ID: "",
-      CLAUDE_SESSION_ID: "",
-      CODEX_SESSION_ID: "",
-      CODEX_THREAD_ID: "",
-      ZCODE_SESSION_ID: "",
-      ANTIGRAVITY_SESSION_ID: ""
-    });
+    const result = runJson(rootDir, ["worktree", "create", "--task", taskId, "--base", "HEAD"], false, {});
 
     assert.equal(result.ok, false);
     assert.equal(result.error.code, "invalid_worktree_namespace");
@@ -96,7 +90,7 @@ function runJson(
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...env }
+      env: cliTestEnv({ ...env })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/tools/check-cli-test-env.mjs
+++ b/tools/check-cli-test-env.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+import { blankedCliTestEnvKeys } from "../packages/cli/test/helpers/cli-test-env.ts";
+
+const defaultRepoRoot = path.resolve(import.meta.dirname, "..");
+const childProcessCalls = new Set(["execFileSync", "execSync", "spawnSync", "spawn", "execFile", "exec", "fork"]);
+const sourceFilePattern = /\.(?:c|m)?js$|\.tsx?$/u;
+
+export function checkCliTestEnv(repoRoot = defaultRepoRoot) {
+  const violations = [];
+  for (const filePath of cliTestSourceFiles(repoRoot)) {
+    const relativePath = path.relative(repoRoot, filePath).split(path.sep).join("/");
+    if (relativePath.endsWith("/helpers/cli-test-env.ts")) continue;
+    const source = readFileSync(filePath, "utf8");
+    const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true);
+    const cliEntryBindings = findCliEntryBindings(sourceFile);
+    visit(sourceFile, (node) => {
+      if (ts.isCallExpression(node)) {
+        const callName = node.expression.getText(sourceFile).split(".").at(-1);
+        if (childProcessCalls.has(callName) && node.arguments.some((argument) => referencesCliEntry(argument, sourceFile, cliEntryBindings))) {
+          const options = node.arguments.find(ts.isObjectLiteralExpression);
+          const envProperty = options?.properties.find((property) =>
+            ts.isPropertyAssignment(property) && property.name.getText(sourceFile) === "env"
+          );
+          if (envProperty !== undefined && containsProcessEnv(envProperty.initializer, sourceFile)) {
+            violations.push(violation(relativePath, sourceFile, envProperty, "CLI subprocess env reads process.env directly; use cliTestEnv(...)"));
+          }
+        }
+      }
+      if (ts.isPropertyAssignment(node) && blankedCliTestEnvKeys.includes(propertyName(node.name, sourceFile))) {
+        if (ts.isStringLiteral(node.initializer) && node.initializer.text === "") {
+          violations.push(violation(relativePath, sourceFile, node, "inline session blank duplicates cliTestEnv authority"));
+        }
+      }
+    });
+  }
+  return violations.sort((left, right) => left.path.localeCompare(right.path) || left.line - right.line);
+}
+
+export function formatCliTestEnvReport(violations) {
+  if (violations.length === 0) return "CLI test env check passed: all discovered CLI subprocess env sites use the shared authority.";
+  return [
+    "CLI test env check failed.",
+    ...violations.map((entry) => `- ${entry.path}:${entry.line}: ${entry.message}`)
+  ].join("\n");
+}
+
+export function main(repoRoot = defaultRepoRoot) {
+  const violations = checkCliTestEnv(repoRoot);
+  console.log(formatCliTestEnvReport(violations));
+  return violations.length === 0 ? 0 : 1;
+}
+
+function cliTestSourceFiles(repoRoot) {
+  const packagesRoot = path.join(repoRoot, "packages");
+  if (!existsSync(packagesRoot)) return [];
+  const files = [];
+  for (const packageEntry of readdirSync(packagesRoot, { withFileTypes: true })) {
+    if (!packageEntry.isDirectory()) continue;
+    collectSourceFiles(path.join(packagesRoot, packageEntry.name, "test"), files);
+  }
+  return files.sort();
+}
+
+function collectSourceFiles(directory, files) {
+  if (!existsSync(directory)) return;
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const target = path.join(directory, entry.name);
+    if (entry.isDirectory()) collectSourceFiles(target, files);
+    else if (sourceFilePattern.test(entry.name)) files.push(target);
+  }
+}
+
+function visit(node, inspect) {
+  inspect(node);
+  ts.forEachChild(node, (child) => visit(child, inspect));
+}
+
+function containsProcessEnv(node, sourceFile) {
+  let found = false;
+  visit(node, (child) => {
+    if (ts.isPropertyAccessExpression(child) && child.getText(sourceFile) === "process.env") found = true;
+  });
+  return found;
+}
+
+function findCliEntryBindings(sourceFile) {
+  const bindings = new Set(["cliEntry"]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    visit(sourceFile, (node) => {
+      if (!ts.isVariableDeclaration(node) || !ts.isIdentifier(node.name) || node.initializer === undefined) return;
+      if (referencesCliEntry(node.initializer, sourceFile, bindings) && !bindings.has(node.name.text)) {
+        bindings.add(node.name.text);
+        changed = true;
+      }
+    });
+  }
+  return bindings;
+}
+
+function referencesCliEntry(node, sourceFile, bindings) {
+  let found = false;
+  visit(node, (child) => {
+    if (ts.isIdentifier(child) && bindings.has(child.text)) found = true;
+    if (ts.isStringLiteral(child) && /(?:packages\/cli\/src|\.\.\/src)\/index\.ts$/u.test(child.text)) found = true;
+  });
+  return found;
+}
+
+function propertyName(name, sourceFile) {
+  return ts.isIdentifier(name) || ts.isStringLiteral(name) ? name.text : name.getText(sourceFile);
+}
+
+function violation(pathname, sourceFile, node, message) {
+  return { path: pathname, line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1, message };
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = main();
+}

--- a/tools/check-cli-test-env.test.mjs
+++ b/tools/check-cli-test-env.test.mjs
@@ -1,0 +1,68 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { checkCliTestEnv, formatCliTestEnvReport } from "./check-cli-test-env.mjs";
+
+test("shared CLI test env construction passes", () => {
+  withFixture((rootDir) => {
+    writeTest(rootDir, "good.test.ts", `
+      execFileSync(process.execPath, [cliEntry, "--json"], { env: cliTestEnv({ HARNESS_ACTOR: "agent:test" }) });
+    `);
+
+    assert.deepEqual(checkCliTestEnv(rootDir), []);
+  });
+});
+
+test("direct process env construction turns the check red", () => {
+  withFixture((rootDir) => {
+    writeTest(rootDir, "leak.test.ts", `
+      execFileSync(process.execPath, [cliEntry, "--json"], { env: { ...process.env, HARNESS_ACTOR: "agent:test" } });
+    `);
+
+    const violations = checkCliTestEnv(rootDir);
+
+    assert.equal(violations.length, 1);
+    assert.match(formatCliTestEnvReport(violations), /use cliTestEnv/u);
+  });
+});
+
+test("inline blanking turns the check red", () => {
+  withFixture((rootDir) => {
+    writeTest(rootDir, "drift.test.ts", `
+      const env = { CODEX_SESSION_ID: "" };
+    `);
+
+    const violations = checkCliTestEnv(rootDir);
+
+    assert.equal(violations.length, 1);
+    assert.match(formatCliTestEnvReport(violations), /duplicates cliTestEnv authority/u);
+  });
+});
+
+test("non-CLI subprocess process env construction remains outside this gate", () => {
+  withFixture((rootDir) => {
+    writeTest(rootDir, "git.test.ts", `
+      execFileSync("git", ["status"], { env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" } });
+    `);
+
+    assert.deepEqual(checkCliTestEnv(rootDir), []);
+  });
+});
+
+function writeTest(rootDir, filename, source) {
+  const testDir = path.join(rootDir, "packages", "cli", "test");
+  mkdirSync(testDir, { recursive: true });
+  writeFileSync(path.join(testDir, filename), source, "utf8");
+}
+
+function withFixture(run) {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-cli-test-env-check-"));
+  try {
+    run(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}

--- a/tools/run-local-check.mjs
+++ b/tools/run-local-check.mjs
@@ -76,7 +76,10 @@ export function buildSteps(full, changedFiles = []) {
     const invocation = npmCliInvocation(args);
     return [label, invocation.command, invocation.args];
   };
-  const steps = [["ghost task packages", process.execPath, ["tools/check-ghost-task-packages.mjs"]]];
+  const steps = [
+    ["ghost task packages", process.execPath, ["tools/check-ghost-task-packages.mjs"]],
+    ["CLI test env isolation", process.execPath, ["tools/check-cli-test-env.mjs"]]
+  ];
   steps.push(npmStep("incremental typecheck", ["run", "typecheck"]));
   steps.push(["manifest local stop gates", process.execPath, ["tools/run-local-gates-check.mjs"]]);
   const lintFiles = changedFiles.filter((file) => LINTABLE_EXTENSION.test(file) && existsSync(path.join(repoRoot, file)));

--- a/tools/run-local-check.test.mjs
+++ b/tools/run-local-check.test.mjs
@@ -38,6 +38,7 @@ test("light steps contain incremental typecheck, changed lint, and affected test
   const steps = buildSteps(false, ["tools/run-local-check.mjs", "docs-release/readme.md"]);
   assert.deepEqual(steps.map(([label]) => label), [
     "ghost task packages",
+    "CLI test env isolation",
     "incremental typecheck",
     "manifest local stop gates",
     "changed-file lint",
@@ -55,6 +56,7 @@ test("manual full tier appends integration, GUI E2E, and manifest gates", () => 
   assert.ok(labels.includes("GUI E2E"));
   assert.ok(labels.includes("manifest local stop gates"));
   assert.ok(labels.includes("ghost task packages"));
+  assert.ok(labels.includes("CLI test env isolation"));
 });
 
 test("local steps apply the shared QoS prefix", () => {


### PR DESCRIPTION
# English

## Summary

Test helpers passed the whole ambient environment into CLI subprocesses, so the invoking agent's session id reached the CLI under test. Any code path doing session provenance export then tried to read *that agent's real transcript* — a file that happens to exist on the author's machine and nowhere else. **Those tests were testing the developer's laptop.**

The reported symptom was two sibling helpers disagreeing. An AST sweep found the real shape: **43 CLI-launching sites blanked nothing**, 12 blanked inline, `noAgentRuntimeEnv` was defined **twice**, and one site blanked **4 of 6** — drift had already happened. This replaces all 45+ declarations with one authority and adds a gate so site 44 cannot land silently.

## What Changed

- `packages/cli/test/helpers/cli-test-env.ts`: the single authority — `blankedCliTestEnvKeys` plus `cliTestEnv(overrides, inheritedEnv)`.
- All 43 unblanked sites, the 12 inline ones, both duplicate `noAgentRuntimeEnv` definitions, and the 4-of-6 partial site now consume it. **Net −107 lines**: this is consolidation, not copy-paste.
- `tools/check-cli-test-env.mjs`: an AST gate flagging (a) a CLI subprocess env derived from `process.env`, and (b) an inline session blank duplicating the authority. It **imports `blankedCliTestEnvKeys` from the authority** rather than restating the list — the gate cannot drift from what it enforces.
- Registered in `tools/run-local-check.mjs`, so it runs at the existing stop point.

## Task And Scope

Task `task_01KXVTM8ZCQZ48R699XH6E9ZW0`, scope widened by `dec_01KXVV9TR10ERMYNSQ90WAZFKA` after the sweep tripped the task's `>5` checkpoint. Test surface only; `packages/cli/src/daemon/**` was an exclusion zone (concurrent worker) and is untouched.

## Version Impact

Test infrastructure only. No production code, API, schema, or gate semantics changed. One additional local check step.

## Governance Declaration

Authorization: `task_01KXVTM8ZCQZ48R699XH6E9ZW0` and `dec_01KXVV9TR10ERMYNSQ90WAZFKA` (accepted — full migration plus a mechanical gate, with allowlisting of existing sites pre-refused). Invariant: **a test launching the CLI must not inherit ambient agent session state, and the blanked-key list must exist in exactly one place.** No CI configuration, gate manifest, or authority behaviour was modified.

## Verification

**Re-run by the reviewer, not read from the report.**

| Check | Result |
|---|---|
| Gate on clean tree | exit 0 |
| **Positive control** — reviewer planted a violating test file | exit **1**, naming `packages/cli/test/ceo-planted-violation.test.ts:7` and pointing at `cliTestEnv(...)` |
| Violation removed | exit 0, tree clean |
| **Authority mutation** — drop the blanking spread from `cliTestEnv` | **red**: `actual: 'developer-machine-value'` vs `expected: ''` |
| Restored byte-identically | green, `git status` clean |

**The acceptance criterion was environment-independence, so it was tested directly:**

| Run | Result |
|---|---|
| Poison session ids injected (`CLAUDE_SESSION_ID` etc. set to values with no transcript on disk) | 6/6 pass |
| Hermetic `HOME`, no session ids at all | 6/6 pass |

**Negative control**: `completion-facade-cli.test.ts` genuinely routes through the migrated path — it imports `runJson` from `task-document-gates-fixtures.ts`, which now calls `cliTestEnv(...)` at line 191, the exact site that leaked (previously `...process.env` at 186-188). Identical results across the two environments are therefore meaningful rather than vacuous.

Implementer's evidence: regular vs hermetic CLI integration 597/597 identical; `npm run check:local` green; **no test turned red as a result of the migration.**

## Review Evidence

**The checkpoint firing was the point, not a failure.** The task contract said to stop and report if the sweep found more than five sites. It found 43, and the worker stopped without writing code — which is what turned a two-file patch into a correctly-scoped migration.

**Why narrowing was rejected.** Fixing the two reported helpers would leave 41 sites and, worse, leave the 4-of-6 partial site in place. A partially-blanked site is the most dangerous kind: **it reads as protected, so a reviewer scanning it concludes the case is handled.**

**Why allowlisting was pre-refused.** A gate whose allowlist is sized to let the existing population through enforces nothing. The honest answer to "there are too many existing sites" is to migrate them; this migration is mechanical and homogeneous, so there is no technical obstacle to hide behind. If a site had genuinely resisted mechanical migration that was a checkpoint for the reviewer to rule on, not grounds for a self-granted exemption.

**Why the gate is not optional.** Without it, site 44 lands next week unnoticed. This repository already learned that the hard way: a written reminder about a different hazard was recorded on 2026-07-11 and violated four times in one night by its own author. Knowing is not doing.

## Residual Risk

1. **Two lists still exist, one layer up.** `packages/application/src/current-session-probe.ts` enumerates the same six session variables that the test authority blanks. They agree today — verified — but nothing enforces that. Adding a seventh agent runtime to the probe without updating the authority reintroduces exactly this defect. **Found during review, not by the sweep; filed as follow-up rather than expanded into this PR**, because deriving the test list from the production one is a cross-package dependency question that deserves its own check (compare #926, where an eslint boundary made the obvious import illegal).
2. 30 non-`cliEntry` subprocess sites (git and purpose-built Node children) were classified as out of scope. Reviewed and accepted, but **not exhaustively verified**.
3. The gate matches direct call sites; env flowing through an arbitrary cross-file wrapper, or a CLI subprocess that supplies no explicit `env`, is not covered.

## References

- Task `task_01KXVTM8ZCQZ48R699XH6E9ZW0`, artifact `REPORT-env-isolation.md`
- Decision `dec_01KXVV9TR10ERMYNSQ90WAZFKA`
- Origin: diagnosed while landing #925

---

# 中文

## 概要

测试 helper 把**整个环境**原样透传给 CLI 子进程,于是调用方 agent 的 session id 进入了被测 CLI。任何做 session provenance 导出的路径于是去读**那个 agent 的真实 transcript**——一个恰好只存在于作者机器上的文件。**那些测试实际在测开发者的笔记本。**

工单报的症状是"两个同类 helper 不一致"。AST sweep 照出真实形态:**43 处 CLI 启动点什么都没清**,12 处内联清空,`noAgentRuntimeEnv` 被**定义了两次**,还有一处只清了 **4/6**——**漂移早已发生**。本 PR 把 45+ 处声明收敛成一份权威,并加一道门,让第 44 处无法悄悄落地。

## 改动内容

- `packages/cli/test/helpers/cli-test-env.ts`:唯一权威——`blankedCliTestEnvKeys` 与 `cliTestEnv(overrides, inheritedEnv)`。
- 43 处未清空 + 12 处内联 + 两份重复的 `noAgentRuntimeEnv` + 1 处 4/6 部分清空,**全部改为消费它**。**净 −107 行**:这是收敛,不是复制粘贴。
- `tools/check-cli-test-env.mjs`:AST 门,拦截 (a) 由 `process.env` 派生的 CLI 子进程 env,(b) 重复权威的内联 session 清空。它**从权威 import `blankedCliTestEnvKeys`** 而非重述清单——**门本身不会与它执法的对象漂移**。
- 注册进 `tools/run-local-check.mjs`,落在既有停止点上。

## 任务与范围

任务 `task_01KXVTM8ZCQZ48R699XH6E9ZW0`,范围经 `dec_01KXVV9TR10ERMYNSQ90WAZFKA` 扩大——sweep 触发了任务契约的 `>5` checkpoint。仅测试面;`packages/cli/src/daemon/**` 是并行 worker 的禁区,零改动。

## 版本影响

仅测试基础设施。未改动生产代码、API、schema 或任何门的语义。新增一个本地检查步骤。

## 治理声明

授权来源:`task_01KXVTM8ZCQZ48R699XH6E9ZW0` 与 `dec_01KXVV9TR10ERMYNSQ90WAZFKA`(已 accept——全量迁移 + 机械门,**预先拒绝**以 allowlist 豁免存量)。不变量:**启动 CLI 的测试不得继承环境里的 agent session 状态,且被清空的键清单只能存在于一处。** 未改动 CI 配置、gate manifest 或 authority 行为。

## 验证

**由验收者重跑,不是读报告。**

| 检查 | 结果 |
|---|---|
| 干净树上跑门 | exit 0 |
| **阳性对照**——验收者植入一个违规测试文件 | exit **1**,指名 `packages/cli/test/ceo-planted-violation.test.ts:7` 并指向 `cliTestEnv(...)` |
| 移除违规文件 | exit 0,工作树干净 |
| **权威突变**——拆掉 `cliTestEnv` 里的清空 spread | **变红**:`actual: 'developer-machine-value'` vs `expected: ''` |
| 逐字节还原 | 绿,`git status` 干净 |

**本任务的验收判据就是"与环境无关",因此直接测它:**

| 运行 | 结果 |
|---|---|
| 注入毒化 session id(`CLAUDE_SESSION_ID` 等设为磁盘上无对应 transcript 的值) | 6/6 通过 |
| hermetic `HOME`,完全没有 session id | 6/6 通过 |

**阴性对照**:`completion-facade-cli.test.ts` 确实走迁移后的路径——它从 `task-document-gates-fixtures.ts` import `runJson`,而后者现在在第 191 行调用 `cliTestEnv(...)`,**正是当初泄漏的那个位置**(原为 186-188 行的 `...process.env`)。因此两种环境结果一致是**有意义的**,不是空转。

实现者证据:常规 vs hermetic CLI integration 597/597 一致;`npm run check:local` 绿;**迁移未导致任何测试变红。**

## 审查证据

**checkpoint 被触发正是它的用处,不是失败。** 任务契约写明 sweep 若发现 >5 处就停下上报。他发现 43 处,**没写一行代码就停了**——正是这一停,把一个两文件补丁变成了一次范围正确的迁移。

**为什么拒绝收窄。** 只修报告里那两个 helper,会留下 41 处,更糟的是会留下那处 4/6 的部分清空。**部分清空是最危险的一类:它读起来像防住了,复核者扫过去就会判定"这里已处理"。**

**为什么预先拒绝 allowlist。** 一道 allowlist 大到刚好放过现有人口的门,什么都没执法。"存量太多"的诚实回答是**把存量迁完**;而此处迁移机械同构,没有可以躲在后面的技术障碍。若真有站点无法机械迁移,那是**留给验收者裁的 checkpoint**,不是自行豁免的理由。

**为什么门不可省。** 没有它,第 44 处下周落地且无人察觉。这个仓刚为此付过学费:2026-07-11 写下的一条针对**另一个**坑的提醒,在一个晚上被**写它的人本人违反了四次**。**知道 ≠ 做到。**

## 残余风险

1. **仍有两份清单,在更上一层。** `packages/application/src/current-session-probe.ts` 枚举了测试权威所清空的**同样六个** session 变量。两者今天一致(已核),但**没有任何机制维持**。往 probe 里加第七个 agent runtime 而不改权威,就会原样重现本缺陷。**这是复核时发现的,不是 sweep 发现的;作为后续单独立项而非塞进本 PR**——让测试清单从生产清单派生涉及跨包依赖,值得单独判(参考 #926:一条 eslint 边界规则让"显而易见的 import"非法)。
2. 30 处非 `cliEntry` 子进程站点(git 及专用 Node 子进程)判为范围外。已复核采纳,但**未穷尽验证**。
3. 门匹配的是直接调用点;env 经任意跨文件 wrapper 流转、或 CLI 子进程未显式提供 `env` 的情形,**不在覆盖内**。

## 关联材料

- 任务 `task_01KXVTM8ZCQZ48R699XH6E9ZW0`,产物 `REPORT-env-isolation.md`
- 决策 `dec_01KXVV9TR10ERMYNSQ90WAZFKA`
- 起源:落 #925 时诊断出
