### PR TITLE
refactor: derive test session-var blanking from the production probe

### DIFF
--- a/packages/cli/test/helpers/cli-test-env.test.ts
+++ b/packages/cli/test/helpers/cli-test-env.test.ts
@@ -1,13 +1,21 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import { defaultRuntimeSessionEnvCandidates } from "../../../application/src/index.ts";
 import { blankedCliTestEnvKeys, cliTestEnv } from "./cli-test-env.ts";
 
-test("cliTestEnv blanks every inherited agent session input", () => {
-  const inheritedEnv = Object.fromEntries(blankedCliTestEnvKeys.map((key) => [key, "developer-machine-value"]));
+test("cliTestEnv blanks exactly the production session inputs and test authority manifest", () => {
+  const productionSessionEnvKeys = defaultRuntimeSessionEnvCandidates.flatMap(({ keys }) => keys);
+  const expectedBlankedKeys = [...new Set(["HARNESS_AUTHORITY_MANIFEST", ...productionSessionEnvKeys])].sort();
+  const inheritedEnv = {
+    UNRELATED_TEST_ENV: "preserved-value",
+    ...Object.fromEntries(expectedBlankedKeys.map((key) => [key, "developer-machine-value"]))
+  };
   const env = cliTestEnv({}, inheritedEnv);
+  const actuallyBlankedKeys = Object.keys(inheritedEnv).filter((key) => env[key] === "").sort();
 
-  for (const key of blankedCliTestEnvKeys) assert.equal(env[key], "");
+  assert.deepEqual(actuallyBlankedKeys, expectedBlankedKeys);
+  assert.equal(env.UNRELATED_TEST_ENV, "preserved-value");
 });
 
 test("cliTestEnv applies explicit test overrides after isolation", () => {

--- a/packages/cli/test/helpers/cli-test-env.ts
+++ b/packages/cli/test/helpers/cli-test-env.ts
@@ -1,11 +1,10 @@
+import { defaultRuntimeSessionEnvCandidates } from "../../../application/src/index.ts";
+
+const runtimeSessionEnvKeys = defaultRuntimeSessionEnvCandidates.flatMap(({ keys }) => keys);
+
 export const blankedCliTestEnvKeys = [
   "HARNESS_AUTHORITY_MANIFEST",
-  "CLAUDE_SESSION_ID",
-  "CLAUDE_CODE_SESSION_ID",
-  "CODEX_THREAD_ID",
-  "CODEX_SESSION_ID",
-  "ZCODE_SESSION_ID",
-  "ANTIGRAVITY_SESSION_ID"
+  ...runtimeSessionEnvKeys
 ] as const;
 
 export function cliTestEnv(


### PR DESCRIPTION
# English

## Summary

PR #931 collapsed 45+ restatements of the agent session-variable list into one test authority. Review found the duplication had simply moved up a layer: `packages/application/src/current-session-probe.ts` (the production reader) and `cli-test-env.ts` (the test blanker) each enumerated the same six variables, agreeing only because nobody had touched them.

The test list is now **derived** from the production list. Adding a seventh agent runtime to the probe propagates automatically — the defect is no longer detected, it is **structurally impossible**.

## What Changed

`cli-test-env.ts` imports `defaultRuntimeSessionEnvCandidates` from the application barrel and flattens it; `HARNESS_AUTHORITY_MANIFEST` remains an explicit test-only addition. Two files, +16/−9. No production behaviour touched: `current-session-probe` reads the same variables in the same order.

## Task And Scope

Task `task_01KXVZWMV5EVFMN3DZERKY4C8A`. Follow-up to #931 residual risk item 1.

## Version Impact

Test infrastructure only. No API, schema, or gate semantics changed. `defaultRuntimeSessionEnvCandidates` was already exported via `public-exports.ts`, so no new export surface was created.

## Governance Declaration

Authorization: `task_01KXVZWMV5EVFMN3DZERKY4C8A`, under the standing fix-on-discovery authority; continues `dec_01KXVV9TR10ERMYNSQ90WAZFKA`. Invariant: **the set of session variables blanked in tests must equal the set production reads, by construction rather than by agreement.** No CI configuration, gate manifest, or authority behaviour modified.

## Verification

**The task contract contained a contradiction, and the implementer stopped rather than papering over it.** It demanded both (a) true derivation and (b) "adding a variable to production must turn a test red". Those are mutually exclusive: under real derivation the variable propagates automatically, so nothing *can* go red — making it red would require re-introducing the second declaration being eliminated.

The reviewer's criterion was wrong, not the implementation. It had been written for the divergence-gate alternative and stated as if universal. **The mutation target is the derivation mechanism, not the list contents.** Corrected and re-run by the reviewer:

| Mutation | Expected | Result |
|---|---|---|
| Add a 7th runtime to **production only**, touch nothing else | propagates, **observably** | `in derived key set: true`; a planted `CEO_FUTURE_AGENT_SESSION_ID=leaked-value` came back `""` |
| Replace the derivation with a hardcoded list missing one key | **red** | `cliTestEnv blanks exactly the production session inputs and test authority manifest` fails |
| Both restored | green | 2/2, `git status` clean |

The forward case deliberately asserts *observable propagation* rather than "tests still pass" — the latter is indistinguishable from nothing having happened. The reverse case is the protection that remains: it catches a future change that reverts derivation back to restatement.

#931's `check-cli-test-env` gate still passes on this branch. Implementer: root `npm run check:local` exit 0, 270/270 affected fast tests.

## Review Evidence

Fixing this by adding a divergence check was available and was rejected. **Eliminating a class of defect beats gating it**: after derivation, "the two lists drift" is not something that gets caught — it cannot occur. A gate would have preserved the duplication and added a second thing to maintain.

The implementer also verified two things that de-risked the change and were reported rather than assumed: `defaultRuntimeSessionEnvCandidates` was *already* exported through the application barrel (so no new export surface), and no third production declaration of these variables exists. The reviewer had flagged a possible eslint module-boundary obstacle by analogy with #926; it does not apply — that rule is kernel-specific, and `packages/cli/src/index.ts:10` already imports from application.

## Residual Risk

1. Derivation covers the *key names*. If production later changes how it *reads* them (precedence, prefix matching, a non-env source), the test helper's blanking model could diverge again in a way this equality assertion would not catch.
2. `HARNESS_AUTHORITY_MANIFEST` remains an explicit test-only entry by design — it is not a session variable. It is asserted as a deliberate addition, not derived, so it stays a small hand-maintained surface.

## References

- Task `task_01KXVZWMV5EVFMN3DZERKY4C8A`, artifact `REPORT-session-var-derive.md`
- Follows #931 (residual risk 1); decision `dec_01KXVV9TR10ERMYNSQ90WAZFKA`

---

# 中文

## 概要

PR #931 把 45+ 处重述的 agent session 变量清单收敛成一份测试权威。复核发现重复只是**上移了一层**:生产读取方 `packages/application/src/current-session-probe.ts` 与测试清空方 `cli-test-env.ts` **各自枚举同样六个变量**,一致仅仅因为没人动过。

现在测试清单**派生自**生产清单。往 probe 加第七个 agent runtime 会自动流过去——这个缺陷不再是"能被检测到",而是**结构上不可能发生**。

## 改动内容

`cli-test-env.ts` 从 application barrel 导入 `defaultRuntimeSessionEnvCandidates` 并展平;`HARNESS_AUTHORITY_MANIFEST` 仍作为测试独有项显式保留。两个文件,+16/−9。**生产行为零改动**:`current-session-probe` 读取的变量与顺序一个字未变。

## 任务与范围

任务 `task_01KXVZWMV5EVFMN3DZERKY4C8A`,#931 残余风险第 1 条的后续。

## 版本影响

仅测试基础设施。无 API/schema/门语义变更。`defaultRuntimeSessionEnvCandidates` **本就**已通过 `public-exports.ts` 导出,**未新增任何导出面**。

## 治理声明

授权来源:`task_01KXVZWMV5EVFMN3DZERKY4C8A`,按常设「发现即修」授权;延续 `dec_01KXVV9TR10ERMYNSQ90WAZFKA`。不变量:**测试清空的 session 变量集合必须等于生产读取的集合,靠构造成立而非靠人为一致。** 未改动 CI 配置、gate manifest 或 authority 行为。

## 验证

**任务契约里有一处矛盾,实现者停下上报而没有硬凑。** 契约同时要求 (a) 真派生 与 (b)「生产加变量必须让测试变红」。**两者互斥**:真派生下变量自动流过去,**没有东西可以变红**;要让它红就必须重新引入正在消除的第二份声明。

**错的是验收者的判据,不是实现。** 那条判据是为「分歧门」备选方案写的,却被当成普适条件。**突变对象是派生机制,不是清单内容。** 更正后由验收者重跑:

| 突变 | 期望 | 结果 |
|---|---|---|
| **只**给生产加第七个 runtime,其余不动 | 自动流过去,且**可观测** | `in derived key set: true`;植入的 `CEO_FUTURE_AGENT_SESSION_ID=leaked-value` 返回 `""` |
| 把派生换成漏掉一个 key 的硬编码清单 | **变红** | `cliTestEnv blanks exactly the production session inputs and test authority manifest` 失败 |
| 两次还原 | 绿 | 2/2,`git status` 干净 |

正向刻意断言**可观测的传播**而不是"测试还是绿"——后者与"什么都没发生"无法区分。反向才是真正留下的保护:它抓的是**未来有人把派生改回重述**。

#931 的 `check-cli-test-env` 门在本分支仍通过。实现者:根 `npm run check:local` exit 0,affected fast 270/270。

## 审查证据

"加一道分歧门"这条路是可选的,**被拒绝**。**消除一整类缺陷强于为它加门**:派生之后"两份清单漂移"不是能被抓到,而是**不可能发生**;而门会把重复保留下来,并且多一样要维护的东西。

实现者另外验证了两件降低风险的事(是查出来上报的,不是假设):`defaultRuntimeSessionEnvCandidates` **本就**已通过 application barrel 导出(故无新增导出面),且**不存在第三份生产声明**。验收者曾类比 #926 提示可能有 eslint 边界阻碍——**不适用**,那条规则是 kernel 专属的,而 `packages/cli/src/index.ts:10` 早已从 application 导入。

## 残余风险

1. 派生覆盖的是**键名**。若生产日后改变**读取方式**(优先级、前缀匹配、非环境变量来源),测试侧的清空模型仍可能以这条等价断言抓不到的方式发散。
2. `HARNESS_AUTHORITY_MANIFEST` 按设计仍是显式的测试独有项——它不是 session 变量,是被断言的有意添加而非派生,因此保留了一小块手工维护面。

## 关联材料

- 任务 `task_01KXVZWMV5EVFMN3DZERKY4C8A`,产物 `REPORT-session-var-derive.md`
- 承接 #931(残余风险 1);决策 `dec_01KXVV9TR10ERMYNSQ90WAZFKA`
