### PR TITLE
feat(gui): consume projection notifications and remove the phantom notification protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13227,6 +13227,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
+        "@harness-anything/daemon-client": "0.1.0",
         "@phosphor-icons/react": "^2.1.10",
         "@tanstack/react-query": "^5.101.2",
         "@xterm/addon-fit": "^0.11.0",

--- a/packages/api-contracts/src/daemon-protocol.ts
+++ b/packages/api-contracts/src/daemon-protocol.ts
@@ -2,13 +2,20 @@ export type DaemonClientState = "connecting" | "live" | "stale" | "unknown";
 
 export interface DaemonCapabilities {
   readonly notifications: boolean;
-  readonly retentionGap: boolean;
 }
 
+export interface DaemonRepoDescriptor {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+}
+
+/** Host-side view decoded from the daemon's command-receipt/v2 hello result. */
 export interface HelloResult {
   readonly protocolVersion: number;
   readonly daemonId: string;
   readonly capabilities: DaemonCapabilities;
+  readonly methods: ReadonlyArray<string>;
+  readonly repos: ReadonlyArray<DaemonRepoDescriptor>;
 }
 
 export interface RepoKey {
@@ -16,15 +23,19 @@ export interface RepoKey {
   readonly repoId: string;
 }
 
-export interface RepoEvent {
+export interface ProjectionChangeEvent {
+  readonly schema: "projection-change/v1";
+  readonly sourceHash: string;
+  readonly entities: ReadonlyArray<{ readonly kind: string; readonly id: string }>;
+}
+
+export interface ProjectionChangeNotification {
   readonly repoId: string;
-  readonly seq: number;
-  readonly kind: string;
+  readonly event: ProjectionChangeEvent;
 }
 
 export interface Subscription {
   readonly repoId: string;
-  readonly afterSeq?: number;
   readonly dispose: () => Promise<void>;
 }
 
@@ -32,22 +43,48 @@ export interface Disposable {
   readonly dispose: () => void;
 }
 
+export interface DaemonClientDiagnostic {
+  readonly code: "invalid_notification" | "unknown_notification" | "unsubscribed_notification" | "subscription_failed";
+  readonly message: string;
+  readonly frame?: unknown;
+}
+
+export interface DaemonSuccessReceipt<Data extends Record<string, unknown>> {
+  readonly ok: true;
+  readonly schema: "command-receipt/v2";
+  readonly command: string;
+  readonly details: { readonly data: Data };
+}
+
+export interface DaemonFailureReceipt {
+  readonly ok: false;
+  readonly schema: "command-receipt/v2";
+  readonly command: string;
+  readonly error?: { readonly code: string; readonly hint: string };
+  readonly summary: string;
+  readonly details?: Readonly<Record<string, unknown>>;
+}
+
+export type DaemonReceipt<Data extends Record<string, unknown>> = DaemonSuccessReceipt<Data> | DaemonFailureReceipt;
+
 export interface DaemonMethodMap {
   readonly "protocol.hello": {
-    readonly input: { readonly client: { readonly name: string; readonly version: string } };
-    readonly output: HelloResult;
+    readonly input: { readonly protocolVersion: number; readonly clientName: string; readonly clientVersion: string };
+    readonly output: DaemonReceipt<{
+      readonly protocolVersion: number;
+      readonly daemon: string;
+      readonly capabilities: ReadonlyArray<string>;
+      readonly methods: ReadonlyArray<string>;
+      readonly repos: ReadonlyArray<DaemonRepoDescriptor>;
+    }>;
   };
   readonly "repo.notifications.subscribe": {
-    readonly input: { readonly repoId: string; readonly afterSeq?: number };
-    readonly output: { readonly subscribed: true; readonly headSeq: number };
+    readonly input: { readonly repo: { readonly repoId: string } };
+    readonly output: DaemonReceipt<{ readonly subscription: "projection-change/v1" }>;
   };
   readonly "repo.notifications.unsubscribe": {
-    readonly input: { readonly repoId: string };
-    readonly output: { readonly unsubscribed: true };
-  };
-  readonly "repo.read-full": {
-    readonly input: { readonly repoId: string };
-    readonly output: { readonly headSeq: number };
+    readonly input: { readonly repo: { readonly repoId: string } };
+    readonly output: DaemonReceipt<{ readonly subscription: "projection-change/v1" }>;
   };
 }
 

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -183,8 +183,16 @@ test("SIGKILL of a GUI notification holder closes its socket and restores daemon
     runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: userRoot });
     const endpoint = path.join(rootDir, "gui-kill-idle.sock");
     const daemon = spawnDaemonCli(rootDir, ["daemon", "serve", "--socket", endpoint, "--idle-ms", "1000"]);
-    const readyProbe = await connectSocketWhenReady(endpoint);
-    readyProbe.destroy();
+    // Open the status connection before the holder starts and keep it open. The
+    // daemon arms its idle timer the moment its last connection closes, so a
+    // transient readiness probe would start the countdown and then race it
+    // against the holder's boot (Node startup plus TypeScript module load). On a
+    // loaded machine the holder loses that race, the daemon exits, and the
+    // holder's connect fails with ENOENT. Holding one connection open keeps the
+    // idle timer disarmed until this test deliberately closes it below.
+    const statusSocket = await connectSocketWhenReady(endpoint);
+    const statusClient = new JsonRpcLineClient(statusSocket, statusSocket);
+    await statusClient.request("protocol.hello", { protocolVersion: 1 });
     const clientModuleUrl = new URL("../../daemon-client/src/index.ts", import.meta.url).href;
     const holder = spawn(process.execPath, ["--input-type=module", "--eval", `
       import { JsonLineSocketTransport, PersistentDaemonClient } from ${JSON.stringify(clientModuleUrl)};
@@ -200,9 +208,6 @@ test("SIGKILL of a GUI notification holder closes its socket and restores daemon
     `, endpoint], { stdio: ["ignore", "pipe", "pipe"] });
     try {
       await waitForChildOutput(holder, "GUI_NOTIFICATION_SOCKET_READY");
-      const statusSocket = await connectSocket(endpoint);
-      const statusClient = new JsonRpcLineClient(statusSocket, statusSocket);
-      await statusClient.request("protocol.hello", { protocolVersion: 1 });
       const heldStatus = await statusClient.request("repo.daemon.status", { repo: { repoId: "canonical" } });
       assert.equal(connectionCount(heldStatus), 2, JSON.stringify(heldStatus));
 
@@ -224,6 +229,10 @@ test("SIGKILL of a GUI notification holder closes its socket and restores daemon
       assert.equal(daemon.exitCode, 0);
     } finally {
       if (holder.exitCode === null && holder.signalCode === null) holder.kill("SIGKILL");
+      if (!statusSocket.destroyed) {
+        statusClient.close();
+        statusSocket.destroy();
+      }
       await stopSpawnedDaemon(daemon, endpoint);
       await stopDaemon(rootDir, userRoot);
     }

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import net from "node:net";
 import path from "node:path";
@@ -48,6 +48,35 @@ const expectedCliVersion = readCliPackageVersion();
 test("daemon client defaults to the local daemon", () => {
   assert.equal(readDaemonClientConfig({}).mode, "local");
 });
+
+function connectionCount(receipt: Record<string, unknown>): number | undefined {
+  const details = receipt.details as Record<string, unknown> | undefined;
+  const data = details?.data as Record<string, unknown> | undefined;
+  const connections = data?.connections as Record<string, unknown> | undefined;
+  return typeof connections?.active === "number" ? connections.active : undefined;
+}
+
+function waitForChildOutput(child: ChildProcess, expected: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => reject(new Error(`child output timed out: ${stdout}\n${stderr}`)), 5_000);
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+      if (!stdout.includes(expected)) return;
+      clearTimeout(timer);
+      resolve();
+    });
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    child.once("exit", (code, signal) => {
+      if (stdout.includes(expected)) return;
+      clearTimeout(timer);
+      reject(new Error(`child exited before ready: ${JSON.stringify({ code, signal, stdout, stderr })}`));
+    });
+  });
+}
 
 test("daemon connect relays opaque bytes without creating repository runtime state", { skip: process.platform === "win32" }, async () => {
   await withTempRootAsync(async (rootDir) => {
@@ -140,6 +169,61 @@ test("persistent daemon connection prevents idle exit after a command settles", 
     } finally {
       client.close();
       socket.destroy();
+      await stopSpawnedDaemon(daemon, endpoint);
+      await stopDaemon(rootDir, userRoot);
+    }
+  });
+});
+
+test("SIGKILL of a GUI notification holder closes its socket and restores daemon idle exit", {
+  skip: process.platform === "win32" ? "SIGKILL is unavailable on Windows" : false
+}, async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = defaultDaemonUserRoot(rootDir);
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: userRoot });
+    const endpoint = path.join(rootDir, "gui-kill-idle.sock");
+    const daemon = spawnDaemonCli(rootDir, ["daemon", "serve", "--socket", endpoint, "--idle-ms", "1000"]);
+    const readyProbe = await connectSocketWhenReady(endpoint);
+    readyProbe.destroy();
+    const clientModuleUrl = new URL("../../daemon-client/src/index.ts", import.meta.url).href;
+    const holder = spawn(process.execPath, ["--input-type=module", "--eval", `
+      import { JsonLineSocketTransport, PersistentDaemonClient } from ${JSON.stringify(clientModuleUrl)};
+      const client = new PersistentDaemonClient({
+        endpoint: process.argv[1],
+        transport: new JsonLineSocketTransport(),
+        requestTimeoutMs: 1000,
+        onDiagnostic: (diagnostic) => console.error(diagnostic.message)
+      });
+      await client.subscribe("canonical");
+      console.log("GUI_NOTIFICATION_SOCKET_READY");
+      setInterval(() => undefined, 1000);
+    `, endpoint], { stdio: ["ignore", "pipe", "pipe"] });
+    try {
+      await waitForChildOutput(holder, "GUI_NOTIFICATION_SOCKET_READY");
+      const statusSocket = await connectSocket(endpoint);
+      const statusClient = new JsonRpcLineClient(statusSocket, statusSocket);
+      await statusClient.request("protocol.hello", { protocolVersion: 1 });
+      const heldStatus = await statusClient.request("repo.daemon.status", { repo: { repoId: "canonical" } });
+      assert.equal(connectionCount(heldStatus), 2, JSON.stringify(heldStatus));
+
+      assert.equal(holder.kill("SIGKILL"), true);
+      await new Promise<void>((resolve) => holder.once("exit", () => resolve()));
+      const releasedStatus = await statusClient.request("repo.daemon.status", { repo: { repoId: "canonical" } });
+      // This status probe is the only remaining connection. Once it closes,
+      // the daemon's active count returns to zero and its idle timer starts.
+      assert.equal(connectionCount(releasedStatus), 1, JSON.stringify(releasedStatus));
+      statusClient.close();
+      statusSocket.destroy();
+
+      await pollUntil(
+        () => daemon.exitCode,
+        (exitCode) => exitCode !== null,
+        (candidate, error) => JSON.stringify({ candidate, error: String(error ?? "") }),
+        { timeoutMs: 3_000 }
+      );
+      assert.equal(daemon.exitCode, 0);
+    } finally {
+      if (holder.exitCode === null && holder.signalCode === null) holder.kill("SIGKILL");
       await stopSpawnedDaemon(daemon, endpoint);
       await stopDaemon(rootDir, userRoot);
     }

--- a/packages/daemon-client/src/connection-pool.ts
+++ b/packages/daemon-client/src/connection-pool.ts
@@ -20,7 +20,7 @@ export class ConnectionPool {
     this.#createClient = createClient;
   }
 
-  async acquire(endpoint: string, repoId: string, afterSeq?: number): Promise<PooledRepoConnection> {
+  async acquire(endpoint: string, repoId: string): Promise<PooledRepoConnection> {
     let entry = this.#entries.get(endpoint);
     if (!entry) {
       entry = { client: this.#createClient(endpoint), repos: new Map() };
@@ -31,7 +31,7 @@ export class ConnectionPool {
       repo.refs += 1;
     } else {
       try {
-        repo = { refs: 1, subscription: await entry.client.subscribe(repoId, afterSeq) };
+        repo = { refs: 1, subscription: await entry.client.subscribe(repoId) };
       } catch (error) {
         if (entry.repos.size === 0) {
           this.#entries.delete(endpoint);

--- a/packages/daemon-client/src/persistent-daemon-client.ts
+++ b/packages/daemon-client/src/persistent-daemon-client.ts
@@ -1,14 +1,15 @@
 import type {
+  DaemonClientDiagnostic,
   DaemonClientState,
   DaemonMethod,
   Disposable,
   HelloResult,
   Input,
   Output,
-  RepoEvent,
+  ProjectionChangeNotification,
   Subscription
 } from "../../api-contracts/src/daemon-protocol.ts";
-import { DaemonRpcError, JsonRpcWriter } from "./json-rpc-writer.ts";
+import { JsonRpcWriter } from "./json-rpc-writer.ts";
 import type { JsonRpcConnection, PersistentTransport } from "./transport.ts";
 
 export interface PersistentDaemonClientOptions {
@@ -17,21 +18,21 @@ export interface PersistentDaemonClientOptions {
   readonly clientName?: string;
   readonly clientVersion?: string;
   readonly requestTimeoutMs?: number;
-  readonly pollIntervalMs?: number;
+  readonly helloTimeoutMs?: number;
   readonly reconnectBaseMs?: number;
   readonly reconnectMaxMs?: number;
   readonly jitter?: () => number;
   readonly now?: () => number;
-  readonly readFull: (repoId: string, signal?: AbortSignal) => Promise<{ readonly headSeq: number }>;
+  readonly onDiagnostic?: (diagnostic: DaemonClientDiagnostic) => void;
 }
 
 export class PersistentDaemonClient {
   readonly #options: Required<Pick<PersistentDaemonClientOptions,
-    "clientName" | "clientVersion" | "requestTimeoutMs" | "pollIntervalMs" | "reconnectBaseMs" | "reconnectMaxMs" | "jitter" | "now">>
+    "clientName" | "clientVersion" | "requestTimeoutMs" | "helloTimeoutMs" | "reconnectBaseMs" | "reconnectMaxMs" | "jitter" | "now" | "onDiagnostic">>
     & PersistentDaemonClientOptions;
-  readonly #listeners = new Set<(event: RepoEvent) => void>();
+  readonly #listeners = new Set<(event: ProjectionChangeNotification) => void>();
   readonly #stateListeners = new Set<(state: DaemonClientState) => void>();
-  readonly #subscriptions = new Map<string, { cursor?: number; refs: number }>();
+  readonly #subscriptions = new Map<string, { refs: number }>();
   #connection?: JsonRpcConnection;
   #writer?: JsonRpcWriter;
   #hello?: HelloResult;
@@ -40,7 +41,6 @@ export class PersistentDaemonClient {
   #disposed = false;
   #connectFlight?: Promise<HelloResult>;
   #reconnectTimer?: ReturnType<typeof setTimeout>;
-  #pollTimer?: ReturnType<typeof setTimeout>;
   #reconnectAttempt = 0;
 
   constructor(options: PersistentDaemonClientOptions) {
@@ -48,12 +48,13 @@ export class PersistentDaemonClient {
       ...options,
       clientName: options.clientName ?? "harness-daemon-client",
       clientVersion: options.clientVersion ?? "0.1.0",
-      requestTimeoutMs: options.requestTimeoutMs ?? 10_000,
-      pollIntervalMs: options.pollIntervalMs ?? 10_000,
+      requestTimeoutMs: options.requestTimeoutMs ?? 1_000,
+      helloTimeoutMs: options.helloTimeoutMs ?? options.requestTimeoutMs ?? 1_000,
       reconnectBaseMs: options.reconnectBaseMs ?? 250,
       reconnectMaxMs: options.reconnectMaxMs ?? 10_000,
       jitter: options.jitter ?? Math.random,
-      now: options.now ?? Date.now
+      now: options.now ?? Date.now,
+      onDiagnostic: options.onDiagnostic ?? ((diagnostic) => console.warn(`[daemon-client:${diagnostic.code}] ${diagnostic.message}`))
     };
   }
 
@@ -74,24 +75,28 @@ export class PersistentDaemonClient {
     return writer.request(method, params, { signal, timeoutMs: this.#options.requestTimeoutMs }) as Promise<Output<M>>;
   }
 
-  async subscribe(repoId: string, afterSeq?: number): Promise<Subscription> {
+  async subscribe(repoId: string): Promise<Subscription> {
     const existing = this.#subscriptions.get(repoId);
     if (existing) {
       existing.refs += 1;
       return this.#subscriptionHandle(repoId);
     }
-    this.#subscriptions.set(repoId, { cursor: afterSeq, refs: 1 });
+    this.#subscriptions.set(repoId, { refs: 1 });
     try {
       await this.connect();
-      await this.#synchronize(repoId);
+      await this.#sendSubscription("repo.notifications.subscribe", repoId);
       return this.#subscriptionHandle(repoId);
     } catch (error) {
       this.#subscriptions.delete(repoId);
+      this.#diagnose({
+        code: "subscription_failed",
+        message: `Projection subscription failed for ${repoId}: ${error instanceof Error ? error.message : String(error)}`
+      });
       throw error;
     }
   }
 
-  onEvent(listener: (event: RepoEvent) => void): Disposable {
+  onEvent(listener: (event: ProjectionChangeNotification) => void): Disposable {
     this.#listeners.add(listener);
     return { dispose: () => this.#listeners.delete(listener) };
   }
@@ -113,14 +118,9 @@ export class PersistentDaemonClient {
     if (this.#disposed) return;
     this.#disposed = true;
     clearTimeout(this.#reconnectTimer);
-    clearTimeout(this.#pollTimer);
     const repos = [...this.#subscriptions.keys()];
-    if (this.#hello?.capabilities.notifications && this.#writer) {
-      await Promise.allSettled(repos.map((repoId) => this.#writer!.request(
-        "repo.notifications.unsubscribe",
-        { repoId },
-        { timeoutMs: Math.min(this.#options.requestTimeoutMs, 1_000) }
-      )));
+    if (this.#writer) {
+      await Promise.allSettled(repos.map((repoId) => this.#sendSubscription("repo.notifications.unsubscribe", repoId)));
     }
     this.#subscriptions.clear();
     this.#writer?.disconnect(new Error("daemon client disposed"));
@@ -144,65 +144,38 @@ export class PersistentDaemonClient {
     connection.onFrame((frame) => this.#acceptFrame(frame));
     connection.onClose((error) => this.#handleClose(error));
     const rawHello = await writer.request("protocol.hello", {
-      client: { name: this.#options.clientName, version: this.#options.clientVersion }
-    }, { signal, timeoutMs: this.#options.requestTimeoutMs });
+      protocolVersion: 1,
+      clientName: this.#options.clientName,
+      clientVersion: this.#options.clientVersion
+    }, { signal, timeoutMs: this.#options.helloTimeoutMs });
     const hello = normalizeHello(rawHello);
     this.#hello = hello;
     this.#reconnectAttempt = 0;
-    if (this.#state !== "stale" || this.#subscriptions.size === 0 || !hello.capabilities.notifications) {
-      this.#transition("live");
-    }
-    if (!hello.capabilities.notifications) this.#schedulePoll();
-    return hello;
-  }
-
-  async #synchronize(repoId: string): Promise<void> {
-    const subscription = this.#subscriptions.get(repoId);
-    if (!subscription) return;
-    if (subscription.cursor === undefined) {
-      subscription.cursor = (await this.#options.readFull(repoId)).headSeq;
-    }
-    if (!this.#hello?.capabilities.notifications) return;
-    try {
-      const result = await this.request("repo.notifications.subscribe", {
-        repoId,
-        ...(subscription.cursor === undefined ? {} : { afterSeq: subscription.cursor })
-      });
-      subscription.cursor = result.headSeq;
-      this.#transition("live");
-    } catch (error) {
-      if (!isRetentionGap(error)) throw error;
-      await this.#recoverFromGap(repoId);
-    }
-  }
-
-  async #recoverFromGap(repoId: string): Promise<void> {
-    const subscription = this.#subscriptions.get(repoId);
-    if (!subscription) return;
-    this.#transition("unknown");
-    subscription.cursor = undefined;
-    const snapshot = await this.#options.readFull(repoId);
-    subscription.cursor = snapshot.headSeq;
-    if (this.#hello?.capabilities.notifications) {
-      const result = await this.request("repo.notifications.subscribe", { repoId, afterSeq: snapshot.headSeq });
-      subscription.cursor = result.headSeq;
-    }
     this.#transition("live");
+    return hello;
   }
 
   #acceptFrame(frame: unknown): void {
     try {
       if (this.#writer?.accept(frame) === "response") return;
-      const event = repoEvent(frame);
-      if (!event) return;
-      const subscription = this.#subscriptions.get(event.repoId);
-      if (!subscription) return;
-      if (subscription.cursor !== undefined && event.seq !== subscription.cursor + 1) {
-        void this.#recoverFromGap(event.repoId).catch(() => this.#handleClose());
+      const parsed = projectionNotification(frame);
+      if (parsed.kind === "unknown") {
+        this.#diagnose({ code: "unknown_notification", message: `Unknown daemon notification method ${parsed.method}.`, frame });
         return;
       }
-      subscription.cursor = event.seq;
-      for (const listener of this.#listeners) listener(event);
+      if (parsed.kind === "invalid") {
+        this.#diagnose({ code: "invalid_notification", message: "Invalid repo.projection.changed notification payload.", frame });
+        return;
+      }
+      if (!this.#subscriptions.has(parsed.notification.repoId)) {
+        this.#diagnose({
+          code: "unsubscribed_notification",
+          message: `Projection notification arrived for unsubscribed repo ${parsed.notification.repoId}.`,
+          frame
+        });
+        return;
+      }
+      for (const listener of this.#listeners) listener(parsed.notification);
     } catch (error) {
       this.#handleClose(error instanceof Error ? error : new Error(String(error)));
     }
@@ -228,21 +201,17 @@ export class PersistentDaemonClient {
     const delay = Math.max(0, Math.round(exponential * (0.5 + this.#options.jitter())));
     this.#reconnectTimer = setTimeout(() => {
       void this.connect().then(async () => {
-        for (const repoId of this.#subscriptions.keys()) await this.#synchronize(repoId);
-      }).catch(() => this.#scheduleReconnect());
+        for (const repoId of this.#subscriptions.keys()) {
+          await this.#sendSubscription("repo.notifications.subscribe", repoId);
+        }
+      }).catch((error: unknown) => {
+        this.#diagnose({
+          code: "subscription_failed",
+          message: `Projection reconnect failed: ${error instanceof Error ? error.message : String(error)}`
+        });
+        this.#scheduleReconnect();
+      });
     }, delay);
-  }
-
-  #schedulePoll(): void {
-    clearTimeout(this.#pollTimer);
-    if (this.#disposed || this.#hello?.capabilities.notifications) return;
-    this.#pollTimer = setTimeout(() => {
-      void Promise.all([...this.#subscriptions.keys()].map(async (repoId) => {
-        const snapshot = await this.#options.readFull(repoId);
-        const subscription = this.#subscriptions.get(repoId);
-        if (subscription) subscription.cursor = snapshot.headSeq;
-      })).finally(() => this.#schedulePoll());
-    }, this.#options.pollIntervalMs);
   }
 
   async #release(repoId: string): Promise<void> {
@@ -251,22 +220,33 @@ export class PersistentDaemonClient {
     subscription.refs -= 1;
     if (subscription.refs > 0) return;
     this.#subscriptions.delete(repoId);
-    if (this.#hello?.capabilities.notifications && this.#writer) {
-      await this.request("repo.notifications.unsubscribe", { repoId });
-    }
+    if (this.#writer) await this.#sendSubscription("repo.notifications.unsubscribe", repoId);
   }
 
   #subscriptionHandle(repoId: string): Subscription {
     let disposed = false;
     return {
       repoId,
-      ...(this.#subscriptions.get(repoId)?.cursor === undefined ? {} : { afterSeq: this.#subscriptions.get(repoId)?.cursor }),
       dispose: async () => {
         if (disposed) return;
         disposed = true;
         await this.#release(repoId);
       }
     };
+  }
+
+  async #sendSubscription(
+    method: "repo.notifications.subscribe" | "repo.notifications.unsubscribe",
+    repoId: string
+  ): Promise<void> {
+    const writer = this.#writer;
+    if (!writer) throw new Error("daemon connection is unavailable");
+    const result = await writer.request(method, { repo: { repoId } }, { timeoutMs: this.#options.requestTimeoutMs });
+    requireSuccessfulReceipt(result, method);
+  }
+
+  #diagnose(diagnostic: DaemonClientDiagnostic): void {
+    this.#options.onDiagnostic(diagnostic);
   }
 
   #transition(next: DaemonClientState): void {
@@ -278,31 +258,73 @@ export class PersistentDaemonClient {
 }
 
 function normalizeHello(value: unknown): HelloResult {
-  if (!isProtocolRecord(value)) throw new Error("invalid protocol.hello result");
-  const capabilities = value.capabilities;
-  const capabilitySet = new Set(Array.isArray(capabilities) ? capabilities.filter((item): item is string => typeof item === "string") : []);
-  const capabilityRecord = isProtocolRecord(capabilities) ? capabilities : {};
+  const data = requireSuccessfulReceipt(value, "protocol.hello");
+  const methods = stringArray(data.methods);
+  const repos = Array.isArray(data.repos)
+    ? data.repos.filter((repo): repo is { repoId: string; canonicalRoot: string } =>
+      isProtocolRecord(repo) && typeof repo.repoId === "string" && typeof repo.canonicalRoot === "string")
+    : [];
+  if (typeof data.protocolVersion !== "number" || typeof data.daemon !== "string" || repos.length !== (data.repos as unknown[] | undefined)?.length) {
+    throw new Error("invalid protocol.hello result data");
+  }
   return {
-    protocolVersion: typeof value.protocolVersion === "number" ? value.protocolVersion : 1,
-    daemonId: typeof value.daemonId === "string" ? value.daemonId : "unknown",
-    capabilities: {
-      notifications: capabilityRecord.notifications === true || capabilitySet.has("repo-notifications/v1"),
-      retentionGap: capabilityRecord.retentionGap === true || capabilitySet.has("retention-gap/v1")
+    protocolVersion: data.protocolVersion,
+    daemonId: data.daemon,
+    capabilities: { notifications: methods.includes("repo.notifications.subscribe") },
+    methods,
+    repos
+  };
+}
+
+function requireSuccessfulReceipt(value: unknown, method: string): Record<string, unknown> {
+  if (!isProtocolRecord(value) || value.schema !== "command-receipt/v2" || value.command !== method || typeof value.ok !== "boolean") {
+    throw new Error(`invalid ${method} command receipt`);
+  }
+  if (!value.ok) {
+    const error = isProtocolRecord(value.error) ? value.error : {};
+    const code = typeof error.code === "string" ? error.code : "daemon_request_failed";
+    const hint = typeof error.hint === "string" ? error.hint : typeof value.summary === "string" ? value.summary : method;
+    throw new Error(`${code}: ${hint}`);
+  }
+  const details = isProtocolRecord(value.details) ? value.details : {};
+  if (!isProtocolRecord(details.data)) throw new Error(`invalid ${method} command receipt data`);
+  return details.data;
+}
+
+function projectionNotification(frame: unknown):
+  | { readonly kind: "valid"; readonly notification: ProjectionChangeNotification }
+  | { readonly kind: "invalid" }
+  | { readonly kind: "unknown"; readonly method: string } {
+  if (!isProtocolRecord(frame) || typeof frame.method !== "string") return { kind: "unknown", method: "<missing>" };
+  if (frame.method !== "repo.projection.changed") return { kind: "unknown", method: frame.method };
+  if (!isProtocolRecord(frame.params) || !isProtocolRecord(frame.params.repo) || !isProtocolRecord(frame.params.event)) {
+    return { kind: "invalid" };
+  }
+  const { repo, event } = frame.params;
+  if (typeof repo.repoId !== "string" || event.schema !== "projection-change/v1" || typeof event.sourceHash !== "string"
+    || !Array.isArray(event.entities) || !event.entities.every(isProjectionEntity)) {
+    return { kind: "invalid" };
+  }
+  return {
+    kind: "valid",
+    notification: {
+      repoId: repo.repoId,
+      event: {
+        schema: "projection-change/v1",
+        sourceHash: event.sourceHash,
+        entities: event.entities
+      }
     }
   };
 }
 
-function repoEvent(frame: unknown): RepoEvent | undefined {
-  if (!isProtocolRecord(frame) || frame.method !== "repo.event" || !isProtocolRecord(frame.params)) return undefined;
-  const { repoId, seq, kind } = frame.params;
-  return typeof repoId === "string" && typeof seq === "number" && typeof kind === "string"
-    ? { repoId, seq, kind }
-    : undefined;
+function isProjectionEntity(value: unknown): value is { readonly kind: string; readonly id: string } {
+  return isProtocolRecord(value) && typeof value.kind === "string" && typeof value.id === "string";
 }
 
-function isRetentionGap(error: unknown): boolean {
-  return error instanceof DaemonRpcError
-    && (error.message === "RETENTION_GAP" || (isProtocolRecord(error.data) && error.data.code === "RETENTION_GAP"));
+function stringArray(value: unknown): ReadonlyArray<string> {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) throw new Error("invalid string array");
+  return value;
 }
 
 function isProtocolRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/daemon-client/test/fake-transport.ts
+++ b/packages/daemon-client/test/fake-transport.ts
@@ -45,8 +45,19 @@ export class FakeConnection implements JsonRpcConnection {
     queueMicrotask(() => this.emit({ jsonrpc: "2.0", id, error: { code: -32010, message, data } }));
   }
 
-  notify(repoId: string, seq: number, kind = "invalidate"): void {
-    queueMicrotask(() => this.emit({ jsonrpc: "2.0", method: "repo.event", params: { repoId, seq, kind } }));
+  notify(repoId: string, id: string, kind = "task"): void {
+    queueMicrotask(() => this.emit({
+      jsonrpc: "2.0",
+      method: "repo.projection.changed",
+      params: {
+        repo: { repoId },
+        event: {
+          schema: "projection-change/v1",
+          sourceHash: `sha256:${id}`,
+          entities: [{ kind, id }]
+        }
+      }
+    }));
   }
 
   emit(frame: unknown): void {
@@ -78,10 +89,24 @@ export class FakeTransport implements PersistentTransport {
 
 export function hello(connection: FakeConnection, request: RequestFrame, notifications = true): boolean {
   if (request.method !== "protocol.hello") return false;
-  connection.respond(request.id, {
+  connection.respond(request.id, receipt("protocol.hello", {
     protocolVersion: 1,
-    daemonId: "fixture",
-    capabilities: { notifications, retentionGap: notifications }
-  });
+    daemon: "fixture",
+    capabilities: ["json-rpc-2.0", "command-receipt/v2", "repo-namespace"],
+    methods: notifications ? ["repo.notifications.subscribe", "repo.notifications.unsubscribe"] : [],
+    repos: [{ repoId: "repo-a", canonicalRoot: "/fixture" }]
+  }));
   return true;
+}
+
+export function receipt(command: string, data: Record<string, unknown>): unknown {
+  return {
+    ok: true,
+    schema: "command-receipt/v2",
+    command,
+    action: command,
+    summary: command,
+    details: { data },
+    meta: { generatedAt: "2026-01-01T00:00:00.000Z", compatibility: {} }
+  };
 }

--- a/packages/daemon-client/test/persistent-daemon-client.test.ts
+++ b/packages/daemon-client/test/persistent-daemon-client.test.ts
@@ -1,122 +1,100 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { DaemonClientDiagnostic } from "../../api-contracts/src/index.ts";
 import { ConnectionPool } from "../src/connection-pool.ts";
 import { JsonRpcWriter } from "../src/json-rpc-writer.ts";
 import { PersistentDaemonClient } from "../src/persistent-daemon-client.ts";
 import { createDaemonRegistryResolver } from "../src/registry-discovery.ts";
-import { FakeConnection, FakeTransport, hello, type RequestFrame } from "./fake-transport.ts";
+import { FakeConnection, FakeTransport, hello, receipt } from "./fake-transport.ts";
 
-test("20 concurrent responses and interleaved notifications keep ids and frames", async () => {
-  const queued: Array<{ request: RequestFrame; connection: FakeConnection }> = [];
-  const transport = new FakeTransport((request, connection) => {
-    if (hello(connection, request)) return;
-    if (request.method === "repo.notifications.subscribe") {
-      connection.respond(request.id, { subscribed: true, headSeq: 0 });
-      return;
-    }
-    queued.push({ request, connection });
-  });
-  const client = fixtureClient(transport, async () => ({ headSeq: 0 }));
-  const events: number[] = [];
-  client.onEvent((event) => events.push(event.seq));
-  await client.subscribe("repo-a");
-  const requests = Array.from({ length: 20 }, (_, index) => client.request("repo.read-full", { repoId: `repo-${index}` }));
-  await waitFor(() => queued.length === 20);
-  queued.slice().reverse().forEach(({ request, connection }, index) => {
-    connection.notify("repo-a", index + 1);
-    connection.respond(request.id, { headSeq: Number((request.params as { repoId: string }).repoId.slice(5)) });
-  });
-  const results = await Promise.all(requests);
-  await waitFor(() => events.length === 20);
-  assert.deepEqual(results.map((result) => result.headSeq), Array.from({ length: 20 }, (_, index) => index));
-  assert.deepEqual(events, Array.from({ length: 20 }, (_, index) => index + 1));
-  await client.dispose();
-});
-
-test("state traces cover stale reconnect and retention gap full-read", async () => {
-  let subscribeCalls = 0;
-  let fullReads = 0;
-  const transport = new FakeTransport((request, connection) => {
-    if (hello(connection, request)) return;
-    if (request.method === "repo.notifications.subscribe") {
-      subscribeCalls += 1;
-      if (subscribeCalls === 2) connection.reject(request.id, "RETENTION_GAP", { code: "RETENTION_GAP" });
-      else connection.respond(request.id, { subscribed: true, headSeq: fullReads });
-    } else if (request.method === "repo.notifications.unsubscribe") {
-      connection.respond(request.id, { unsubscribed: true });
-    }
-  });
-  const client = fixtureClient(transport, async () => ({ headSeq: ++fullReads }), { reconnectBaseMs: 1 });
-  const trace = [client.state()];
-  client.onState((state) => trace.push(state));
-  await client.subscribe("repo-a");
-  transport.connections[0]!.disconnect();
-  await waitFor(() => transport.connections.length === 2 && client.state() === "live");
-  assert.deepEqual(trace, ["connecting", "live", "stale", "unknown", "live"]);
-  assert.equal(fullReads, 2);
-  await client.dispose();
-});
-
-test("catch-up reconnect follows connecting to live to stale to live", async () => {
+test("real command-receipt hello and projection notifications interleave with responses", async () => {
   const transport = subscribingTransport();
-  const client = fixtureClient(transport, async () => ({ headSeq: 0 }), { reconnectBaseMs: 1 });
+  const client = fixtureClient(transport);
+  const events: string[] = [];
+  client.onEvent((notification) => events.push(notification.event.entities[0]!.id));
+  const helloResult = await client.connect();
+  assert.equal(helloResult.capabilities.notifications, true);
+  assert.deepEqual(helloResult.repos, [{ repoId: "repo-a", canonicalRoot: "/fixture" }]);
+  await client.subscribe("repo-a");
+
+  const request = client.request("protocol.hello", {
+    protocolVersion: 1,
+    clientName: "test",
+    clientVersion: "1"
+  });
+  transport.connections[0]!.notify("repo-a", "task-1");
+  await request;
+  await waitFor(() => events.length === 1);
+  assert.deepEqual(events, ["task-1"]);
+  await client.dispose();
+});
+
+test("stale connection reconnects and restores repo subscriptions", async () => {
+  const transport = subscribingTransport();
+  const client = fixtureClient(transport, { reconnectBaseMs: 1 });
   const trace = [client.state()];
   client.onState((state) => trace.push(state));
   await client.subscribe("repo-a");
   transport.connections[0]!.disconnect();
-  await waitFor(() => transport.connections.length === 2 && client.state() === "live");
+  await waitFor(() => transport.connections.length === 2 && subscribeCount(transport) === 2);
   assert.deepEqual(trace, ["connecting", "live", "stale", "live"]);
   await client.dispose();
 });
 
-test("sequence gap exposes unknown until full-read completes", async () => {
-  let releaseRead: (() => void) | undefined;
-  let reads = 0;
+test("unknown and malformed notification frames leave diagnostic evidence", async () => {
+  const diagnostics: DaemonClientDiagnostic[] = [];
   const transport = subscribingTransport();
-  const client = fixtureClient(transport, async () => {
-    reads += 1;
-    if (reads > 1) await new Promise<void>((resolve) => { releaseRead = resolve; });
-    return { headSeq: reads === 1 ? 1 : 3 };
+  const client = fixtureClient(transport, { onDiagnostic: (diagnostic) => diagnostics.push(diagnostic) });
+  await client.subscribe("repo-a");
+  transport.connections[0]!.emit({ jsonrpc: "2.0", method: "repo.event", params: {} });
+  transport.connections[0]!.emit({ jsonrpc: "2.0", method: "repo.projection.changed", params: {} });
+  assert.deepEqual(diagnostics.map((diagnostic) => diagnostic.code), ["unknown_notification", "invalid_notification"]);
+  await client.dispose();
+});
+
+test("subscription rejection and timeout are diagnostic and reject for polling fallback", async () => {
+  const diagnostics: DaemonClientDiagnostic[] = [];
+  const unavailable = new FakeTransport((request, connection) => {
+    if (hello(connection, request)) return;
+    if (request.method === "repo.notifications.subscribe") {
+      connection.respond(request.id, {
+        ok: false,
+        schema: "command-receipt/v2",
+        command: request.method,
+        summary: "not configured",
+        error: { code: "notifications_unavailable", hint: "not configured" }
+      });
+    }
   });
-  await client.subscribe("repo-a");
-  transport.connections[0]!.notify("repo-a", 3);
-  await waitFor(() => client.state() === "unknown");
-  assert.equal(client.state(), "unknown");
-  releaseRead?.();
-  await waitFor(() => client.state() === "live");
-  assert.equal(reads, 2);
-  await client.dispose();
+  const rejected = fixtureClient(unavailable, { onDiagnostic: (diagnostic) => diagnostics.push(diagnostic) });
+  await assert.rejects(rejected.subscribe("repo-a"), /notifications_unavailable/u);
+  assert.equal(diagnostics.at(-1)?.code, "subscription_failed");
+  await rejected.dispose();
+
+  const timeout = new FakeTransport((request, connection) => { hello(connection, request); });
+  const timedOut = fixtureClient(timeout, { requestTimeoutMs: 5, onDiagnostic: (diagnostic) => diagnostics.push(diagnostic) });
+  await assert.rejects(timedOut.subscribe("repo-a"), /timed out/u);
+  assert.match(diagnostics.at(-1)?.message ?? "", /timed out/u);
+  await timedOut.dispose();
 });
 
-test("missing notification capability degrades to full-read polling", async () => {
-  let reads = 0;
-  const transport = new FakeTransport((request, connection) => { hello(connection, request, false); });
-  const client = fixtureClient(transport, async () => ({ headSeq: ++reads }), { pollIntervalMs: 2 });
-  await client.subscribe("repo-a");
-  await waitFor(() => reads >= 2);
-  assert.equal(client.state(), "live");
-  assert.equal(transport.connections[0]!.writes.some((frame) => JSON.stringify(frame).includes("notifications.subscribe")), false);
-  await client.dispose();
-});
-
-test("timeout, abort, disconnect and dispose reject pending work deterministically", async () => {
-  const transport = new FakeTransport((request, connection) => { hello(connection, request); });
-  const client = fixtureClient(transport, async () => ({ headSeq: 0 }), { requestTimeoutMs: 5 });
-  await client.connect();
-  await assert.rejects(client.request("repo.read-full", { repoId: "timeout" }), /timed out/u);
+test("abort, disconnect and dispose reject pending hello deterministically", async () => {
+  const transport = new FakeTransport(() => undefined);
+  const client = fixtureClient(transport, { requestTimeoutMs: 100 });
   const controller = new AbortController();
-  const aborted = client.request("repo.read-full", { repoId: "abort" }, controller.signal);
+  const aborted = client.connect(controller.signal);
   controller.abort();
   await assert.rejects(aborted, { name: "AbortError" });
-  const disconnected = client.request("repo.read-full", { repoId: "disconnect" });
-  await waitFor(() => transport.connections[0]!.writes.some((frame) => JSON.stringify(frame).includes("disconnect")));
-  transport.connections[0]!.disconnect(new Error("fixture disconnect"));
-  await assert.rejects(disconnected, /fixture disconnect/u);
-  const started = Date.now();
   await client.dispose();
-  assert.ok(Date.now() - started < 1_000);
-  assert.equal(transport.connections.flatMap((connection) => connection.writes).some((frame) => JSON.stringify(frame).includes("terminate")), false);
+
+  const disconnectedTransport = new FakeTransport(() => undefined);
+  const disconnectedClient = fixtureClient(disconnectedTransport);
+  const disconnected = disconnectedClient.connect();
+  await waitFor(() => disconnectedTransport.connections.length === 1);
+  disconnectedTransport.connections[0]!.disconnect(new Error("fixture disconnect"));
+  await assert.rejects(disconnected, /fixture disconnect/u);
+  await disconnectedClient.dispose();
 });
 
 test("connection pool separates endpoint sockets from repo subscriptions", async () => {
@@ -125,7 +103,7 @@ test("connection pool separates endpoint sockets from repo subscriptions", async
   const pool = new ConnectionPool((endpoint) => {
     const transport = subscribingTransport();
     transports.push(transport);
-    const client = fixtureClient(transport, async () => ({ headSeq: 0 }), { endpoint });
+    const client = fixtureClient(transport, { endpoint });
     created.push(client);
     return client;
   });
@@ -136,14 +114,12 @@ test("connection pool separates endpoint sockets from repo subscriptions", async
   assert.equal(transports[0]!.connections.length, 1);
   assert.deepEqual(pool.snapshot(), [{ endpoint: "unix:/daemon", repos: ["repo-a", "repo-b"] }]);
   await a.dispose();
-  assert.deepEqual(pool.snapshot()[0]?.repos, ["repo-a", "repo-b"]);
   await a2.dispose();
-  assert.deepEqual(pool.snapshot()[0]?.repos, ["repo-b"]);
   await b.dispose();
   assert.deepEqual(pool.snapshot(), []);
 });
 
-test("positive controls detect unknown response ids and invalid state traces", async () => {
+test("positive controls detect unknown response ids and invalid state traces", () => {
   const connection = new FakeConnection(() => undefined);
   const writer = new JsonRpcWriter(connection);
   assert.throws(() => writer.accept({ jsonrpc: "2.0", id: 999, result: {} }), /unknown daemon response id/u);
@@ -167,17 +143,16 @@ test("registry discovery returns endpoint plus repoId and fails closed on unknow
 
 function fixtureClient(
   transport: FakeTransport,
-  readFull: (repoId: string) => Promise<{ headSeq: number }>,
   overrides: Partial<ConstructorParameters<typeof PersistentDaemonClient>[0]> = {}
 ): PersistentDaemonClient {
   return new PersistentDaemonClient({
     endpoint: "unix:/fixture",
     transport,
-    readFull,
     requestTimeoutMs: 100,
     reconnectBaseMs: 2,
     reconnectMaxMs: 5,
     jitter: () => 0,
+    onDiagnostic: () => undefined,
     ...overrides
   });
 }
@@ -185,13 +160,19 @@ function fixtureClient(
 function subscribingTransport(): FakeTransport {
   return new FakeTransport((request, connection) => {
     if (hello(connection, request)) return;
-    if (request.method === "repo.notifications.subscribe") connection.respond(request.id, { subscribed: true, headSeq: 1 });
-    if (request.method === "repo.notifications.unsubscribe") connection.respond(request.id, { unsubscribed: true });
+    if (request.method === "repo.notifications.subscribe" || request.method === "repo.notifications.unsubscribe") {
+      connection.respond(request.id, receipt(request.method, { subscription: "projection-change/v1" }));
+    }
   });
 }
 
+function subscribeCount(transport: FakeTransport): number {
+  return transport.connections.flatMap((connection) => connection.writes)
+    .filter((frame) => (frame as { method?: string }).method === "repo.notifications.subscribe").length;
+}
+
 function assertValidTrace(trace: readonly string[]): void {
-  const allowed = new Set(["connecting>live", "live>stale", "stale>connecting", "live>unknown", "unknown>live"]);
+  const allowed = new Set(["connecting>live", "live>stale", "stale>live"]);
   for (let index = 1; index < trace.length; index += 1) {
     if (!allowed.has(`${trace[index - 1]}>${trace[index]}`)) throw new Error("invalid state transition");
   }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -21,6 +21,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
+    "@harness-anything/daemon-client": "0.1.0",
     "@dnd-kit/core": "^6.3.1",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",

--- a/packages/gui/src/index.ts
+++ b/packages/gui/src/index.ts
@@ -8,6 +8,7 @@ export * from "./distribution/supply-chain-release-readiness.ts";
 export * from "./doc-renderer/sanitize.ts";
 export * from "./main/ipc-handlers.ts";
 export * from "./main/local-composition-root.ts";
+export * from "./main/projection-notifications.ts";
 export * from "./main/security-policy.ts";
 export * from "./main/trust-policy.ts";
 export * from "./main/window-config.ts";

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -4,6 +4,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import type { HarnessLayoutOverrides } from "../../../kernel/src/index.ts";
 import { registerHarnessIpcHandlers } from "./ipc-handlers.ts";
 import { createLocalGuiServiceBridge } from "./local-composition-root.ts";
+import { createLocalGuiProjectionNotifications } from "./projection-notifications.ts";
 import { evaluateNavigationRequest, evaluatePermissionRequest, evaluateWindowOpenRequest } from "./security-policy.ts";
 import { assertDevRendererUrl, createGuiContentSecurityPolicy } from "./window-config.ts";
 
@@ -66,12 +67,17 @@ export async function startGuiApp(): Promise<void> {
   await app.whenReady();
   installContentSecurityPolicy();
   const trustedWebContentsIds = new Set<number>();
-  registerHarnessIpcHandlers(ipcMain, createLocalGuiServiceBridge(resolveGuiProjectRoot(), resolveGuiLayoutOverrides()), {
+  const rootDir = resolveGuiProjectRoot();
+  const projectionNotifications = createLocalGuiProjectionNotifications(rootDir);
+  registerHarnessIpcHandlers(ipcMain, createLocalGuiServiceBridge(rootDir, resolveGuiLayoutOverrides()), {
     isTrustedWebContentsId: (id) => trustedWebContentsIds.has(id),
     rendererUrl: {
       packagedRendererUrl: createLocalPackagedRendererUrl(),
       allowDevRenderer: Boolean(process.env.ELECTRON_RENDERER_URL)
     }
+  }, projectionNotifications.source);
+  app.once("before-quit", () => {
+    void projectionNotifications.dispose();
   });
   createTrustedMainWindow(trustedWebContentsIds);
   app.on("activate", () => {

--- a/packages/gui/src/main/ipc-handlers.ts
+++ b/packages/gui/src/main/ipc-handlers.ts
@@ -1,5 +1,13 @@
 import type { IpcMainInvokeEvent } from "electron";
-import { assertPreloadPayload, preloadAllowlist } from "../preload/allowlist.ts";
+import {
+  HARNESS_PROJECTION_CHANGED_CHANNEL,
+  HARNESS_WATCH_PROJECTION_CHANGES_CHANNEL,
+  assertPreloadPayload,
+  assertProjectionWatchPayload,
+  preloadAllowlist,
+  type ProjectionWatchResult,
+  type RendererProjectionNotification
+} from "../preload/allowlist.ts";
 import type { GuiServiceBridge } from "../api/service-bridge.ts";
 import { evaluateIpcSender, type IpcSenderIdentity, type IpcWebContentsTrustPolicy } from "./security-policy.ts";
 
@@ -10,10 +18,18 @@ export interface HarnessIpcRegistrar {
   ) => void;
 }
 
+export interface HarnessProjectionNotificationSource {
+  readonly watch: (
+    repoId: string,
+    sink: (notification: RendererProjectionNotification) => void
+  ) => Promise<ProjectionWatchResult>;
+}
+
 export function registerHarnessIpcHandlers(
   registrar: HarnessIpcRegistrar,
   bridge: GuiServiceBridge,
-  trustPolicy: IpcWebContentsTrustPolicy
+  trustPolicy: IpcWebContentsTrustPolicy,
+  projectionNotifications?: HarnessProjectionNotificationSource
 ): void {
   assertUniqueHarnessIpcChannels(preloadAllowlist);
   for (const method of preloadAllowlist) {
@@ -21,6 +37,15 @@ export function registerHarnessIpcHandlers(
       assertTrustedIpcSender(event, trustPolicy);
       assertPreloadPayload(method, payload);
       return bridge.invoke(method, payload);
+    });
+  }
+  if (projectionNotifications) {
+    registrar.handle(HARNESS_WATCH_PROJECTION_CHANGES_CHANNEL, async (event, payload) => {
+      assertTrustedIpcSender(event, trustPolicy);
+      assertProjectionWatchPayload(payload);
+      return projectionNotifications.watch(payload.repoId, (notification) => {
+        event.sender.send(HARNESS_PROJECTION_CHANGED_CHANNEL, notification);
+      });
     });
   }
 }

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -23,6 +23,11 @@ interface LocalDaemonTarget {
   readonly registered: boolean;
 }
 
+export interface GuiDaemonNotificationTarget {
+  readonly repoId: string;
+  readonly socketPath: string;
+}
+
 interface HarnessLayoutOverrides {
   readonly authoredRoot?: string;
 }
@@ -66,6 +71,20 @@ export function createLocalGuiServiceBridge(rootDir: string, layoutOverrides?: H
   validateProjectPath(resolvedRootDir, ".");
   const state: GuiDaemonBridgeState = { layoutOverrideDaemonStarted: false };
   return createGuiServiceBridgeForDaemon(async (route, payload) => requestGuiRouteViaDaemon(resolvedRootDir, layoutOverrides, state, route, payload));
+}
+
+export async function resolveGuiDaemonNotificationTarget(rootDir: string): Promise<GuiDaemonNotificationTarget> {
+  const resolvedRootDir = path.resolve(rootDir);
+  validateProjectPath(resolvedRootDir, ".");
+  const daemonClient = await loadDaemonClientModule();
+  const target = daemonClient.resolveLocalDaemonTarget({
+    rootDir: resolvedRootDir,
+    repoIdOverride: process.env.HARNESS_DAEMON_REPO_ID,
+    userRoot: daemonClient.daemonUserRoot(),
+    daemonId: daemonClient.daemonIdFromEnv(),
+    autoRegisterSingleRepo: true
+  });
+  return { repoId: target.repoId, socketPath: target.socketPath };
 }
 
 async function requestGuiRouteViaDaemon(

--- a/packages/gui/src/main/projection-notifications.ts
+++ b/packages/gui/src/main/projection-notifications.ts
@@ -1,0 +1,93 @@
+import type { Disposable, ProjectionChangeNotification, Subscription } from "../../../api-contracts/src/index.ts";
+import { JsonLineSocketTransport, PersistentDaemonClient } from "../../../daemon-client/src/index.ts";
+import type {
+  HarnessProjectionNotificationSource
+} from "./ipc-handlers.ts";
+import type { RendererProjectionNotification } from "../preload/allowlist.ts";
+import { resolveGuiDaemonNotificationTarget } from "./local-composition-root.ts";
+
+const daemonConnectionTimeoutMs = 6_000;
+const projectionSubscriptionTimeoutMs = 1_000;
+
+export interface LocalGuiProjectionNotifications {
+  readonly source: HarnessProjectionNotificationSource;
+  readonly dispose: () => Promise<void>;
+}
+
+export function createLocalGuiProjectionNotifications(rootDir: string): LocalGuiProjectionNotifications {
+  let client: PersistentDaemonClient | undefined;
+  let clientEvents: Disposable | undefined;
+  let clientState: Disposable | undefined;
+  let subscription: Subscription | undefined;
+  let watchedRepoId: string | undefined;
+  let sink: ((notification: RendererProjectionNotification) => void) | undefined;
+
+  const source: HarnessProjectionNotificationSource = {
+    watch: async (repoId, nextSink) => {
+      sink = nextSink;
+      if (subscription && watchedRepoId === repoId) return { mode: "push" };
+      await subscription?.dispose();
+      subscription = undefined;
+      watchedRepoId = repoId;
+      try {
+        const activeClient = await ensureClient();
+        const hello = await activeClient.connect(AbortSignal.timeout(daemonConnectionTimeoutMs));
+        if (!hello.repos.some((repo) => repo.repoId === repoId)) {
+          throw new Error(`repo_not_advertised: daemon hello did not advertise ${repoId}`);
+        }
+        subscription = await activeClient.subscribe(repoId);
+        return { mode: "push" };
+      } catch (error) {
+        const diagnostic = `Projection notifications unavailable for ${repoId}: ${error instanceof Error ? error.message : String(error)}`;
+        traceProjectionDiagnostic(diagnostic);
+        nextSink({ type: "state", mode: "polling", diagnostic });
+        return { mode: "polling", diagnostic };
+      }
+    }
+  };
+
+  return {
+    source,
+    dispose: async () => {
+      sink = undefined;
+      clientEvents?.dispose();
+      clientState?.dispose();
+      await subscription?.dispose();
+      await client?.dispose();
+    }
+  };
+
+  async function ensureClient(): Promise<PersistentDaemonClient> {
+    if (client) return client;
+    const target = await resolveGuiDaemonNotificationTarget(rootDir);
+    client = new PersistentDaemonClient({
+      endpoint: target.socketPath,
+      transport: new JsonLineSocketTransport(),
+      helloTimeoutMs: daemonConnectionTimeoutMs,
+      requestTimeoutMs: projectionSubscriptionTimeoutMs,
+      onDiagnostic: (diagnostic) => {
+        const message = `${diagnostic.code}: ${diagnostic.message}`;
+        traceProjectionDiagnostic(message);
+        sink?.({
+          type: "state",
+          mode: diagnostic.code === "subscription_failed" ? "polling" : "push",
+          diagnostic: message
+        });
+      }
+    });
+    clientEvents = client.onEvent(forwardProjectionChange);
+    clientState = client.onState((state) => {
+      if (state === "stale") sink?.({ type: "state", mode: "polling", diagnostic: "Daemon notification connection became stale." });
+      if (state === "live" && subscription) sink?.({ type: "state", mode: "push" });
+    });
+    return client;
+  }
+
+  function forwardProjectionChange(notification: ProjectionChangeNotification): void {
+    sink?.({ type: "change", repoId: notification.repoId, event: notification.event });
+  }
+}
+
+function traceProjectionDiagnostic(message: string): void {
+  console.warn(`[gui-projection-notifications] ${message}`);
+}

--- a/packages/gui/src/preload/allowlist.ts
+++ b/packages/gui/src/preload/allowlist.ts
@@ -1,6 +1,31 @@
 import type { apiRouteContracts, deferredGuiBridgeContracts, terminalGuiBridgeContracts } from "../api/api-contract-registry.ts";
 
 export const HARNESS_PRELOAD_API = "harness";
+export const HARNESS_PROJECTION_CHANGED_CHANNEL = "harness:projection-changed";
+export const HARNESS_WATCH_PROJECTION_CHANGES_CHANNEL = "harness:watch-projection-changes";
+
+export interface RendererProjectionChange {
+  readonly type: "change";
+  readonly repoId: string;
+  readonly event: {
+    readonly schema: "projection-change/v1";
+    readonly sourceHash: string;
+    readonly entities: ReadonlyArray<{ readonly kind: string; readonly id: string }>;
+  };
+}
+
+export interface RendererProjectionState {
+  readonly type: "state";
+  readonly mode: "push" | "polling";
+  readonly diagnostic?: string;
+}
+
+export type RendererProjectionNotification = RendererProjectionChange | RendererProjectionState;
+
+export interface ProjectionWatchResult {
+  readonly mode: "push" | "polling";
+  readonly diagnostic?: string;
+}
 
 type ShippedPreloadApiMethod = Extract<(typeof apiRouteContracts)[number], { readonly guiBridgeMethod: string }>["guiBridgeMethod"];
 type TerminalPreloadApiMethod = (typeof terminalGuiBridgeContracts)[number]["guiBridgeMethod"];
@@ -165,4 +190,12 @@ export function assertPreloadPayload(method: string, payload: unknown): true {
     throw new Error("Preload payload must be an object or null.");
   }
   return true;
+}
+
+export function assertProjectionWatchPayload(payload: unknown): asserts payload is { readonly repoId: string } {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)
+    || typeof (payload as { readonly repoId?: unknown }).repoId !== "string"
+    || (payload as { readonly repoId: string }).repoId.length === 0) {
+    throw new Error("Projection watch payload requires a non-empty repoId.");
+  }
 }

--- a/packages/gui/src/preload/electron-preload.ts
+++ b/packages/gui/src/preload/electron-preload.ts
@@ -1,10 +1,15 @@
 import { contextBridge, ipcRenderer } from "electron";
 import {
   HARNESS_PRELOAD_API,
+  HARNESS_PROJECTION_CHANGED_CHANNEL,
+  HARNESS_WATCH_PROJECTION_CHANGES_CHANNEL,
   assertPreloadPayload,
+  assertProjectionWatchPayload,
   exposedPreloadApiCapabilities,
   preloadAllowlist,
-  type PreloadApiMethod
+  type PreloadApiMethod,
+  type ProjectionWatchResult,
+  type RendererProjectionNotification
 } from "./allowlist.ts";
 
 const exposedApi = Object.fromEntries(preloadAllowlist.map((method) => [
@@ -17,7 +22,17 @@ const exposedApi = Object.fromEntries(preloadAllowlist.map((method) => [
 
 const exposedHarnessApi = {
   ...exposedApi,
-  capabilities: exposedPreloadApiCapabilities
+  capabilities: exposedPreloadApiCapabilities,
+  watchProjectionChanges: (repoId: string): Promise<ProjectionWatchResult> => {
+    const payload = { repoId };
+    assertProjectionWatchPayload(payload);
+    return ipcRenderer.invoke(HARNESS_WATCH_PROJECTION_CHANGES_CHANNEL, payload) as Promise<ProjectionWatchResult>;
+  },
+  onProjectionChanged: (listener: (notification: RendererProjectionNotification) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, notification: RendererProjectionNotification) => listener(notification);
+    ipcRenderer.on(HARNESS_PROJECTION_CHANGED_CHANNEL, handler);
+    return () => ipcRenderer.removeListener(HARNESS_PROJECTION_CHANGED_CHANNEL, handler);
+  }
 };
 
 contextBridge.exposeInMainWorld(HARNESS_PRELOAD_API, exposedHarnessApi);

--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useProjectionNotifications } from "./projection-notifications.ts";
 import { isGenericStatusWriteTransition, type SnapshotStatus } from "./model/types.ts";
 import { ThemeProvider } from "./theme.tsx";
 import { TaskPreviewDrawer } from "./components/TaskPreviewDrawer.tsx";
@@ -49,6 +50,7 @@ function AppShell() {
     () => resolveActiveRepoId(daemonRepos, selectedRepoId, requestedRepoId),
     [daemonRepos, selectedRepoId, requestedRepoId],
   );
+  useProjectionNotifications(activeRepoId);
 
   // Align selection with resolved active repo once status is known (single-repo
   // path auto-picks the only registered repo — identical to pre-multi-repo UX).

--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -87,6 +87,8 @@ type HarnessBridgeMethod =
 
 type HarnessBridge = Record<HarnessBridgeMethod, (payload?: object | null) => Promise<unknown>> & {
   readonly capabilities?: unknown;
+  readonly watchProjectionChanges?: (repoId: string) => Promise<{ readonly mode: "push" | "polling"; readonly diagnostic?: string }>;
+  readonly onProjectionChanged?: (listener: (notification: import("./projection-notifications.ts").RendererProjectionNotification) => void) => () => void;
 };
 
 declare global {

--- a/packages/gui/src/renderer/projection-notifications.ts
+++ b/packages/gui/src/renderer/projection-notifications.ts
@@ -1,0 +1,97 @@
+import type { Query, QueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { setProjectionPushActive } from "./query-client.ts";
+
+export interface RendererProjectionChange {
+  readonly type: "change";
+  readonly repoId: string;
+  readonly event: {
+    readonly schema: "projection-change/v1";
+    readonly sourceHash: string;
+    readonly entities: ReadonlyArray<{ readonly kind: string; readonly id: string }>;
+  };
+}
+
+export interface RendererProjectionState {
+  readonly type: "state";
+  readonly mode: "push" | "polling";
+  readonly diagnostic?: string;
+}
+
+export type RendererProjectionNotification = RendererProjectionChange | RendererProjectionState;
+
+export function useProjectionNotifications(repoId: string | null): void {
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    if (!repoId) return;
+    const bridge = window.harness;
+    if (!bridge?.watchProjectionChanges || !bridge.onProjectionChanged) {
+      enablePolling(queryClient, "Projection notification bridge is unavailable.");
+      return;
+    }
+    let current = true;
+    const stop = bridge.onProjectionChanged((notification) => {
+      if (!current) return;
+      if (notification.type === "state") {
+        setProjectionMode(queryClient, notification.mode, notification.diagnostic);
+        return;
+      }
+      if (notification.repoId === repoId) applyProjectionChange(queryClient, notification);
+    });
+    void bridge.watchProjectionChanges(repoId).then((result) => {
+      if (current) setProjectionMode(queryClient, result.mode, result.diagnostic);
+    }).catch((error: unknown) => {
+      if (current) enablePolling(queryClient, `Projection subscription failed: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    return () => {
+      current = false;
+      stop();
+    };
+  }, [queryClient, repoId]);
+}
+
+export function applyProjectionChange(queryClient: QueryClient, notification: RendererProjectionChange): void {
+  const entities = notification.event.entities;
+  const predicate = entities.length === 0
+    ? (query: Query) => isRepoQuery(query, notification.repoId)
+    : (query: Query) => entities.some((entity) => entityInvalidatesQuery(entity, query, notification.repoId));
+  void queryClient.invalidateQueries({ predicate });
+}
+
+function setProjectionMode(queryClient: QueryClient, mode: "push" | "polling", diagnostic?: string): void {
+  setProjectionPushActive(mode === "push");
+  if (diagnostic) console.warn(`[renderer-projection-notifications] ${diagnostic}`);
+  void queryClient.invalidateQueries({ queryKey: ["harness"] });
+}
+
+function enablePolling(queryClient: QueryClient, diagnostic: string): void {
+  setProjectionMode(queryClient, "polling", diagnostic);
+}
+
+function entityInvalidatesQuery(
+  entity: { readonly kind: string; readonly id: string },
+  query: Query,
+  repoId: string
+): boolean {
+  if (!isRepoQuery(query, repoId)) return false;
+  const key = query.queryKey;
+  const surface = key[1];
+  if (entity.kind === "task") {
+    return surface === "tasks" && (key[2] === "list" || key.includes(entity.id))
+      || surface === "triadic"
+      || surface === "executions"
+      || surface === "execution-evidence";
+  }
+  if (entity.kind === "decision" || entity.kind === "fact" || entity.kind === "relation") return surface === "triadic";
+  if (entity.kind === "execution" || entity.kind === "evidence") {
+    return surface === "executions" || surface === "execution-evidence";
+  }
+  return true;
+}
+
+function isRepoQuery(query: Query, repoId: string): boolean {
+  const key = query.queryKey;
+  if (key[0] !== "harness") return false;
+  return key.includes(repoId) || key.includes("default");
+}

--- a/packages/gui/src/renderer/query-client.ts
+++ b/packages/gui/src/renderer/query-client.ts
@@ -1,6 +1,15 @@
 import { QueryClient } from "@tanstack/react-query";
 
 export const LEDGER_REFRESH_INTERVAL_MS = 10_000;
+let projectionPushActive = false;
+
+export function setProjectionPushActive(active: boolean): void {
+  projectionPushActive = active;
+}
+
+export function ledgerRefreshInterval(): number | false {
+  return projectionPushActive ? false : LEDGER_REFRESH_INTERVAL_MS;
+}
 
 export function createRendererQueryClient(): QueryClient {
   return new QueryClient({
@@ -8,7 +17,7 @@ export function createRendererQueryClient(): QueryClient {
       queries: {
         retry: 1,
         refetchOnWindowFocus: "always",
-        refetchInterval: LEDGER_REFRESH_INTERVAL_MS,
+        refetchInterval: ledgerRefreshInterval,
         refetchIntervalInBackground: false,
       },
     },

--- a/packages/gui/src/renderer/task-data.ts
+++ b/packages/gui/src/renderer/task-data.ts
@@ -111,7 +111,9 @@ export function useRebuildGovernanceMutation(repoId?: string | null) {
   return useMutation({
     mutationFn: () => harnessClient.rebuildGovernance(repoId ?? undefined),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: taskQueryKeys.all });
+      // Rebuild mode intentionally emits no projection event, so this mutation
+      // is the full-query invalidation fallback for that path.
+      await queryClient.invalidateQueries({ queryKey: ["harness"] });
     }
   });
 }

--- a/packages/gui/test/ipc-handler-registration.test.ts
+++ b/packages/gui/test/ipc-handler-registration.test.ts
@@ -5,6 +5,8 @@ import {
   apiRouteContracts,
   assertUniqueHarnessIpcChannels,
   deferredGuiBridgeContracts,
+  HARNESS_PROJECTION_CHANGED_CHANNEL,
+  HARNESS_WATCH_PROJECTION_CHANGES_CHANNEL,
   preloadAllowlist,
   registerHarnessIpcHandlers,
   shippedPreloadMethods,
@@ -107,3 +109,45 @@ test("main process rejects duplicate IPC handler channels before registration", 
     /Duplicate Harness IPC handler channel: harness:getTasks/u
   );
 });
+
+test("projection subscription sink forwards daemon notifications to the trusted renderer", async () => {
+  type NotificationEvent = {
+    readonly sender: { readonly id: number; readonly send: (channel: string, payload: unknown) => void };
+    readonly senderFrame: { readonly url: string };
+  };
+  const handlers = new Map<string, (event: NotificationEvent, payload: unknown) => Promise<unknown>>();
+  const deliveries: Array<{ readonly channel: string; readonly payload: unknown }> = [];
+  let daemonSink: ((notification: never) => void) | undefined;
+  const event = {
+    ...trustedEvent,
+    sender: {
+      id: 1,
+      send: (channel: string, payload: unknown) => deliveries.push({ channel, payload })
+    }
+  };
+  registerHarnessIpcHandlers(
+    { handle: (channel, listener) => handlers.set(channel, listener as (event: NotificationEvent, payload: unknown) => Promise<unknown>) },
+    { invoke: async () => ({ ok: true }) },
+    { isTrustedWebContentsId: () => true, rendererUrl: { packagedRendererUrl: trustedRendererUrl } },
+    {
+      watch: async (_repoId, sink) => {
+        daemonSink = sink as (notification: never) => void;
+        return { mode: "push" };
+      }
+    }
+  );
+
+  expectChannelRegistered(handlers, HARNESS_WATCH_PROJECTION_CHANGES_CHANNEL);
+  assert.deepEqual(await handlers.get(HARNESS_WATCH_PROJECTION_CHANGES_CHANNEL)?.(event, { repoId: "repo-a" }), { mode: "push" });
+  const notification = {
+    type: "change" as const,
+    repoId: "repo-a",
+    event: { schema: "projection-change/v1" as const, sourceHash: "sha256:new", entities: [{ kind: "task", id: "task-a" }] }
+  };
+  daemonSink?.(notification as never);
+  assert.deepEqual(deliveries, [{ channel: HARNESS_PROJECTION_CHANGED_CHANNEL, payload: notification }]);
+});
+
+function expectChannelRegistered(handlers: ReadonlyMap<string, unknown>, channel: string): void {
+  assert.equal(handlers.has(channel), true, `missing IPC delivery link ${channel}`);
+}

--- a/packages/gui/test/projection-notification-live.test.ts
+++ b/packages/gui/test/projection-notification-live.test.ts
@@ -1,0 +1,87 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { stopDaemon, withTempRootAsync, runRawJson, defaultDaemonUserRoot } from "../../cli/test/helpers/daemon-cli.ts";
+import { createLocalGuiServiceBridge } from "../src/main/local-composition-root.ts";
+import { createLocalGuiProjectionNotifications } from "../src/main/projection-notifications.ts";
+import { applyProjectionChange, type RendererProjectionChange } from "../src/renderer/projection-notifications.ts";
+
+test("real daemon write refreshes an active GUI query without polling", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = defaultDaemonUserRoot(rootDir);
+    const restoreEnv = replaceEnv({
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_USER_ROOT: userRoot,
+      HARNESS_DAEMON_IDLE_MS: "5000"
+    });
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: userRoot });
+    const bridge = createLocalGuiServiceBridge(rootDir);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, refetchInterval: false } } });
+    const queryKey = ["harness", "tasks", "list", "canonical"] as const;
+    const observer = new QueryObserver(queryClient, {
+      queryKey,
+      queryFn: async () => bridge.invoke("getTasks", { repoId: "canonical" }) as Promise<TaskListResult>
+    });
+    const unsubscribeObserver = observer.subscribe(() => undefined);
+    const notifications = createLocalGuiProjectionNotifications(rootDir);
+    try {
+      await observer.refetch();
+      assert.deepEqual(taskIds(observer.getCurrentResult().data), []);
+      const watched = await notifications.source.watch("canonical", (notification) => {
+        if (notification.type === "change") applyProjectionChange(queryClient, notification as RendererProjectionChange);
+      });
+      assert.deepEqual(watched, { mode: "push" });
+
+      const created = runRawJson(rootDir, ["new-task", "--title", "Push Refreshed Task"], {
+        HARNESS_DAEMON_MODE: "local",
+        HARNESS_DAEMON_USER_ROOT: userRoot,
+        HARNESS_DAEMON_IDLE_MS: "5000"
+      });
+      const createdId = receiptTaskId(created);
+      await waitFor(() => taskIds(observer.getCurrentResult().data).includes(createdId));
+      assert.equal(taskIds(observer.getCurrentResult().data).includes(createdId), true);
+    } finally {
+      unsubscribeObserver();
+      await notifications.dispose();
+      queryClient.clear();
+      await stopDaemon(rootDir, userRoot);
+      restoreEnv();
+    }
+  });
+});
+
+interface TaskListResult {
+  readonly ok?: boolean;
+  readonly tasks?: ReadonlyArray<{ readonly taskId?: string }>;
+}
+
+function taskIds(result: TaskListResult | undefined): ReadonlyArray<string> {
+  return result?.tasks?.flatMap((task) => typeof task.taskId === "string" ? [task.taskId] : []) ?? [];
+}
+
+function receiptTaskId(receipt: Record<string, unknown>): string {
+  const details = receipt.details as Record<string, unknown> | undefined;
+  const data = details?.data as Record<string, unknown> | undefined;
+  if (typeof data?.taskId !== "string") throw new Error(`write receipt lacked taskId: ${JSON.stringify(receipt)}`);
+  return data.taskId;
+}
+
+function replaceEnv(values: Readonly<Record<string, string>>): () => void {
+  const previous = new Map(Object.keys(values).map((key) => [key, process.env[key]]));
+  Object.assign(process.env, values);
+  return () => {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("GUI query did not refresh from projection notification");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/packages/gui/test/renderer-app-model.vitest.ts
+++ b/packages/gui/test/renderer-app-model.vitest.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { TaskProjectionRow } from "../../kernel/src/index.ts";
@@ -13,16 +14,24 @@ import { rendererCapabilityModel, rendererNavigation } from "../src/renderer/app
 import {
   LEDGER_REFRESH_INTERVAL_MS,
   createRendererQueryClient,
+  ledgerRefreshInterval,
+  setProjectionPushActive,
 } from "../src/renderer/query-client.ts";
 import { GraphView } from "../src/renderer/views/GraphView.tsx";
+import { applyProjectionChange } from "../src/renderer/projection-notifications.ts";
 
 describe("renderer app model", () => {
   it("refreshes visible ledger queries without polling a hidden window", () => {
     const defaults = createRendererQueryClient().getDefaultOptions().queries;
 
     expect(defaults?.refetchOnWindowFocus).toBe("always");
-    expect(defaults?.refetchInterval).toBe(LEDGER_REFRESH_INTERVAL_MS);
+    expect(defaults?.refetchInterval).toBe(ledgerRefreshInterval);
     expect(defaults?.refetchIntervalInBackground).toBe(false);
+    setProjectionPushActive(false);
+    expect(ledgerRefreshInterval()).toBe(LEDGER_REFRESH_INTERVAL_MS);
+    setProjectionPushActive(true);
+    expect(ledgerRefreshInterval()).toBe(false);
+    setProjectionPushActive(false);
   });
 
   it("keeps the renderer capability model privilege-free", () => {
@@ -159,6 +168,54 @@ describe("renderer app model", () => {
     expect(markup).toContain("No triadic relation data yet");
   });
 });
+
+describe("projection notification invalidation", () => {
+  it("invalidates the changed entity surfaces for only the notified repo", async () => {
+    const client = projectionQueryClient();
+    client.setQueryData(["harness", "tasks", "list", "repo-a"], [{ id: "task-a" }]);
+    client.setQueryData(["harness", "tasks", "detail", "repo-a", "task-a"], { id: "task-a" });
+    client.setQueryData(["harness", "tasks", "detail", "repo-a", "task-b"], { id: "task-b" });
+    client.setQueryData(["harness", "tasks", "list", "repo-b"], [{ id: "task-a" }]);
+    client.setQueryData(["harness", "triadic", "snapshot", "repo-a"], {});
+
+    applyProjectionChange(client, projectionChange("repo-a", [{ kind: "task", id: "task-a" }]));
+    await Promise.resolve();
+
+    expect(queryInvalidated(client, ["harness", "tasks", "list", "repo-a"])).toBe(true);
+    expect(queryInvalidated(client, ["harness", "tasks", "detail", "repo-a", "task-a"])).toBe(true);
+    expect(queryInvalidated(client, ["harness", "tasks", "detail", "repo-a", "task-b"])).toBe(false);
+    expect(queryInvalidated(client, ["harness", "tasks", "list", "repo-b"])).toBe(false);
+    expect(queryInvalidated(client, ["harness", "triadic", "snapshot", "repo-a"])).toBe(true);
+  });
+
+  it("uses repo-wide invalidation when an event has no entity detail", async () => {
+    const client = projectionQueryClient();
+    client.setQueryData(["harness", "catalog", "snapshot", "repo-a"], {});
+    client.setQueryData(["harness", "tasks", "list", "repo-a"], []);
+    client.setQueryData(["harness", "tasks", "list", "repo-b"], []);
+    applyProjectionChange(client, projectionChange("repo-a", []));
+    await Promise.resolve();
+    expect(queryInvalidated(client, ["harness", "catalog", "snapshot", "repo-a"])).toBe(true);
+    expect(queryInvalidated(client, ["harness", "tasks", "list", "repo-a"])).toBe(true);
+    expect(queryInvalidated(client, ["harness", "tasks", "list", "repo-b"])).toBe(false);
+  });
+});
+
+function projectionQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { staleTime: Infinity } } });
+}
+
+function queryInvalidated(client: QueryClient, key: ReadonlyArray<string>): boolean {
+  return client.getQueryState(key)?.isInvalidated ?? false;
+}
+
+function projectionChange(repoId: string, entities: ReadonlyArray<{ readonly kind: string; readonly id: string }>) {
+  return {
+    type: "change" as const,
+    repoId,
+    event: { schema: "projection-change/v1" as const, sourceHash: "sha256:new", entities }
+  };
+}
 
 function taskRow(overrides: Partial<TaskProjectionRow>): TaskProjectionRow {
   return {

--- a/packages/gui/tsconfig.json
+++ b/packages/gui/tsconfig.json
@@ -39,6 +39,9 @@
       "path": "../application"
     },
     {
+      "path": "../daemon-client"
+    },
+    {
       "path": "./tsconfig.renderer.json"
     }
   ]

--- a/packages/vscode-ext/test/workspace-router.test.ts
+++ b/packages/vscode-ext/test/workspace-router.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import type * as vscode from "vscode";
 import { ConnectionPool } from "../../daemon-client/src/connection-pool.ts";
 import { PersistentDaemonClient } from "../../daemon-client/src/persistent-daemon-client.ts";
-import { FakeTransport, hello } from "../../daemon-client/test/fake-transport.ts";
+import { FakeTransport, hello, receipt } from "../../daemon-client/test/fake-transport.ts";
 import { WorkspaceRouter } from "../src/routing/workspace-router.ts";
 
 test("unknown roots fail closed with an explicit action and zero transport requests", async () => {
@@ -82,14 +82,14 @@ test("positive controls detect an extra socket, wrong RepoKey and injected unkno
 });
 
 function client(transport: FakeTransport, endpoint = "unix:/fixture"): PersistentDaemonClient {
-  return new PersistentDaemonClient({ endpoint, transport, readFull: async () => ({ headSeq: 0 }), requestTimeoutMs: 100 });
+  return new PersistentDaemonClient({ endpoint, transport, requestTimeoutMs: 100, onDiagnostic: () => undefined });
 }
 
 function daemonTransport(): FakeTransport {
   return new FakeTransport((request, connection) => {
     if (hello(connection, request)) return;
-    if (request.method === "repo.notifications.subscribe") connection.respond(request.id, { subscribed: true, headSeq: 0 });
-    if (request.method === "repo.notifications.unsubscribe") connection.respond(request.id, { unsubscribed: true });
+    if (request.method === "repo.notifications.subscribe") connection.respond(request.id, receipt(request.method, { subscription: "projection-change/v1" }));
+    if (request.method === "repo.notifications.unsubscribe") connection.respond(request.id, receipt(request.method, { subscription: "projection-change/v1" }));
   });
 }
 


### PR DESCRIPTION
# English

## Summary

The GUI now updates from daemon projection notifications instead of polling every 10 seconds. #926 published those notifications; until now nothing consumed them.

Scoping this uncovered a trap that had to be removed first. `packages/api-contracts/src/daemon-protocol.ts` declared a notification protocol the daemon **does not implement** — `repo.read-full` and `repo.event` had zero implementations anywhere — and `PersistentDaemonClient` was written against it. Because `repo.notifications.subscribe` *does* exist in the method registry, subscribing would have **succeeded**, and then every notification would have been **silently discarded** by an `#acceptFrame` that bare-`return`ed on anything that wasn't `repo.event`. Subscription established, no errors, no updates, ever.

That is the same defect family as #924 (silent drop disguising the real failure) and #922 (declared surface vs actual fields) — and it was sitting directly under the feet of whoever wired the GUI next.

## What Changed

- **Protocol reconciliation**: `api-contracts` now declares what the daemon actually implements. `repo.read-full` and `repo.event` are gone — verified 0 declared / 0 implemented.
- **No more silent discard**: `#acceptFrame` emits a named diagnostic on every drop path — `unknown_notification` (names the method), `invalid_notification` (payload shape), `unsubscribed_notification` (names the repo).
- **Persistent connection + push channel**: a long-lived subscription in the Electron main process, delivered to the renderer through preload, respecting the existing IPC restrictions (`ipcRenderer` only in `electron-preload.ts`, `ipcMain` only in `ipc-handlers.ts`).
- **Renderer**: `refetchInterval` becomes `projectionPushActive ? false : LEDGER_REFRESH_INTERVAL_MS`. Notification `entities` drive targeted `invalidateQueries` through the existing infrastructure.

## Task And Scope

Task `task_01KXW08B94Z98NW6RWGC8KMNP9`. 25 files, +882/−236. No gate, CI configuration, or eslint boundary was relaxed.

## Version Impact

`api-contracts` loses two declared-but-unimplemented methods — nothing could have been calling them successfully. GUI refresh becomes push-driven with polling retained as fallback.

## Governance Declaration

Authorization: `task_01KXW08B94Z98NW6RWGC8KMNP9`, standing fix-on-discovery authority; consumes the channel added by #926. Invariants: **a declared protocol method must be implemented**, and **an undeliverable notification must leave a diagnosable trace rather than vanishing.** Two CEO rulings are recorded under Review Evidence.

## Verification

**Re-run by the reviewer, not read from the report.**

| Check | Result |
|---|---|
| Phantom protocol removed | `repo.read-full` / `repo.event`: **0 declared, 0 implemented** |
| Live end-to-end, no polling | `real daemon write refreshes an active GUI query without polling` — **passes** |
| **Mutation**: sever the delivery chain (`for (const listener …)` → `return`) | live test goes **red** |
| Restored byte-identically | green, `git status` clean |
| **SIGKILL of the GUI notification holder** | `closes its socket and restores daemon idle exit` — **passes** |
| Degrade path is live, not dead code | `setProjectionPushActive(mode === "push")` at `projection-notifications.ts:63`; both states covered by tests |

The mutation matters most here: it proves the live test actually exercises delivery rather than passing for unrelated reasons.

Implementer: root `npm run check:local` exit 0, 34 gates; GUI 336 tests across 26 files.

## Review Evidence

**Two checkpoints were raised and stopped on, both with code-level evidence rather than speculation.**

**Ruling 1 — daemon lifecycle. Approved, but the stated reason was wrong in a way that matters.** The implementer argued a persistent connection would suppress idle-exit. It would — but review of `service-host.ts:151-158` shows `scheduleIdleExit` returns early while `connections.active !== 0` and otherwise does `clearTimeout` plus a fresh timer on every connection settle. With a 10-second poll and a 5-minute idle window, **an open GUI already suppresses idle-exit today**. So this is not a lifecycle change; it makes an already-true emergent behaviour explicit and cheaper.

That reframing moved the risk somewhere the implementer had not named: today a crashed GUI stops polling and the daemon exits after 5 minutes, whereas a persistent connection that is not cleanly closed could pin the daemon open **forever**. An acceptance criterion was added for exactly that — SIGKILL the holder, assert `connections.active` returns to 0 and the idle timer resumes — and it was implemented and passes. It was flagged as "should hold" rather than "verified to hold", and measured instead of reasoned about.

**Ruling 2 — timeout budgets. Approved as proposed**: 6s for connection/handshake, 1s for the subscribe RPC, normal GUI routes unchanged at 200ms, since 200ms is tuned for interactive one-shot calls and subscription is a setup operation. With one binding condition: a subscribe timeout must **degrade to polling, with a diagnosable trace** — never repeat the silent-`return` pattern this PR exists to remove.

Two further checkpoints (retire vs repair `PersistentDaemonClient`; multi-repo subscription) were left with the implementer to decide within the stated invariants; the client was repaired rather than retired, keeping its reconnect/backoff logic.

## Residual Risk

1. `sqlite-task-incremental-projection` emits no change event on `mode: "rebuild"` (`projection-change-event.ts:21-23`), so a full rebuild still relies on the fallback invalidate rather than a targeted one.
2. The degrade path is driven by a single module-level flag; a partially-failed subscription (connected but silently not receiving) would still read as `push` active. The new diagnostics make that observable but nothing yet acts on them automatically.
3. Windows named-pipe transport for the subscription path is not covered here.

## References

- Task `task_01KXW08B94Z98NW6RWGC8KMNP9`, artifact `REPORT-gui-push.md`
- Consumes #926; unblocks the residual "nothing consumes these notifications yet"

---

# 中文

## 概要

GUI 现在由 daemon 的投影变更通知驱动更新,不再每 10 秒轮询。#926 把通知发出来了,在此之前**零消费方**。

摸清范围时挖出一个必须先拆掉的陷阱:`packages/api-contracts/src/daemon-protocol.ts` **声明了一套 daemon 根本没实现的通知协议**——`repo.read-full` 与 `repo.event` 全仓零实现——而 `PersistentDaemonClient` 整个是照它写的。由于 `repo.notifications.subscribe` **确实**在方法注册表里,订阅**会成功**,然后每一条通知都会被 `#acceptFrame` **静默丢弃**(它对任何不是 `repo.event` 的帧裸 `return`)。**订阅已建立、零报错、永远不更新。**

这与 #924(静默丢弃掩盖真实失败)、#922(声明面 vs 实际字段)是同一缺陷族,而且**正埋在下一个接 GUI 的人脚下**。

## 改动内容

- **协议对账**:`api-contracts` 现在只声明 daemon 真正实现的东西。`repo.read-full` 与 `repo.event` 已移除——实测 0 声明 / 0 实现。
- **静默丢弃消失**:`#acceptFrame` 在每条丢弃路径上给出具名诊断——`unknown_notification`(指名方法)、`invalid_notification`(载荷形状)、`unsubscribed_notification`(指名 repo)。
- **持久连接 + 推送通道**:Electron main 进程持有长连订阅,经 preload 投递到 renderer,遵守既有 IPC 限制(`ipcRenderer` 只在 `electron-preload.ts`,`ipcMain` 只在 `ipc-handlers.ts`)。
- **renderer**:`refetchInterval` 变为 `projectionPushActive ? false : LEDGER_REFRESH_INTERVAL_MS`;通知里的 `entities` 经既有基础设施驱动精准 `invalidateQueries`。

## 任务与范围

任务 `task_01KXW08B94Z98NW6RWGC8KMNP9`。25 文件,+882/−236。**未放松任何 gate、CI 配置或 eslint 边界**。

## 版本影响

`api-contracts` 移除两个"声明了但没实现"的方法——**不可能有任何东西曾成功调用它们**。GUI 刷新改为推送驱动,轮询保留为兜底。

## 治理声明

授权来源:`task_01KXW08B94Z98NW6RWGC8KMNP9`,常设「发现即修」授权;消费 #926 建立的通道。不变量:**声明了的协议方法必须被实现**;**无法投递的通知必须留下可诊断痕迹而不是消失**。两条 CEO 裁决见「审查证据」。

## 验证

**由验收者重跑,不是读报告。**

| 检查 | 结果 |
|---|---|
| 幻影协议已移除 | `repo.read-full` / `repo.event`:**0 声明,0 实现** |
| 端到端活体、无轮询 | `real daemon write refreshes an active GUI query without polling` —— **通过** |
| **突变**:切断投递链路(`for (const listener …)` → `return`) | 活体测试**变红** |
| 逐字节还原 | 绿,`git status` 干净 |
| **强杀持有通知的 GUI 进程** | `closes its socket and restores daemon idle exit` —— **通过** |
| 降级路径是活的不是死代码 | `projection-notifications.ts:63` 的 `setProjectionPushActive(mode === "push")`;两种状态均有测试覆盖 |

**其中突变最要紧**:它证明活体测试真的在走投递路径,而不是因为无关原因通过。

实现者:根 `npm run check:local` exit 0,34 个 gate;GUI 26 文件 336 测试。

## 审查证据

**两个 checkpoint 被触发并停下,且都带代码级证据而非推测。**

**裁决一 —— daemon 生命周期。批准,但实现者给的理由错在一个要紧的地方。** 他的依据是"常驻连接会压制 idle-exit"。会,但复核 `service-host.ts:151-158` 后结论更强:`scheduleIdleExit` 在 `connections.active !== 0` 时直接 return,否则每次连接 settle 都 `clearTimeout` + 重设计时器。**10 秒轮询 vs 5 分钟 idle 窗口 → GUI 打开时 idle-exit 今天就已经被压制了。** 所以这不是生命周期变更,只是把一个本就成立的涌现行为变成显式且更省的形式。

这个重述把风险移到了他没点到的地方:今天 GUI 崩了就停止轮询、daemon 5 分钟后正常退出;而**一条没有干净关闭的持久连接可能把 daemon 永远吊住**。为此新增了验收条件——强杀持有者,断言 `connections.active` 回到 0 且 idle 计时器恢复——已实现并通过。该项被明确标为"应该成立"而非"已验证成立",要求**实测而不是推理**。

**裁决二 —— 超时预算。按原案批准**:连接/握手 6 秒、订阅 RPC 1 秒、普通 GUI route 保持 200ms 不变(200ms 是给交互式一次性调用调的,订阅是建立期操作)。附一条硬约束:订阅超时**必须回落到轮询并留下可诊断痕迹**——绝不重复本 PR 正要消除的那个静默 `return` 模式。

另两个 checkpoint(`PersistentDaemonClient` 退役还是修复、多 repo 订阅)在既定不变量内交由实现者定;结论是**修复而非退役**,保留其 reconnect/backoff 逻辑。

## 残余风险

1. `sqlite-task-incremental-projection` 在 `mode: "rebuild"` 时**不发**变更事件(`projection-change-event.ts:21-23`),故全量重建仍依赖兜底失效而非精准失效。
2. 降级由单个模块级标志驱动;**部分失败的订阅(已连接但静默收不到)仍会被读成 push 生效**。新增的诊断让这件事可观测,但目前没有任何东西据此自动动作。
3. 订阅路径的 Windows named-pipe transport 不在本次覆盖内。

## 关联材料

- 任务 `task_01KXW08B94Z98NW6RWGC8KMNP9`,产物 `REPORT-gui-push.md`
- 消费 #926,解除其"目前还没有任何消费方"的残余
