### PR TITLE
fix: stop the contracts permission probe inheriting the test preload

### DIFF
--- a/packages/cli/test/package-surface.test.ts
+++ b/packages/cli/test/package-surface.test.ts
@@ -247,13 +247,23 @@ test("architecture contracts are single-authority, portable, and route the scaff
     "verified evidence rule must reference an allowed lifecycle status"
   );
   assert.deepEqual(contract.validateArchitectureManifest(manifest), { ok: true, value: manifest, issues: [] });
+  // This probe narrows filesystem access to the contracts directory on purpose,
+  // so that loading the contracts proves they are self-contained. The
+  // integration tier's runner injects a fixture preload into NODE_OPTIONS for
+  // every child process; that file lives outside the permitted directory, so an
+  // inherited environment makes the probe fail on the preload rather than
+  // measuring the contracts at all. Strip the runner's instrumentation so this
+  // asserts the vertical's portability and nothing else.
+  const permissionProbeEnv = { ...process.env };
+  delete permissionProbeEnv.NODE_OPTIONS;
+  delete permissionProbeEnv.HARNESS_CLI_TEST_FIXTURE_PRELOAD;
   const permissionProbe = execFileSync(process.execPath, [
     "--permission",
     `--allow-fs-read=${path.dirname(contractPath)}`,
     "--input-type=module",
     "--eval",
     `import { architectureManifestJsonSchema, architectureModelContract } from ${JSON.stringify(pathToFileURL(contractPath).href)}; process.stdout.write(architectureManifestJsonSchema().$id + "\\n" + architectureModelContract().id);`
-  ], { encoding: "utf8" });
+  ], { encoding: "utf8", env: permissionProbeEnv });
   assert.equal(permissionProbe, `${generatedSchema.$id}\n${modelContract.id}`, "vertical actions can load both contracts without node_modules access");
   for (const metadataKey of new Set([
     ...modelContract.elements.requiredMetadataKeys,


### PR DESCRIPTION
# English

## Summary

`architecture contracts are single-authority, portable, and route the scaffold` has been failing on **main** across three consecutive unrelated commits (`9843d15b`, `17dfc64c`, `a998b950`), always in about 1.2s. It is deterministic, not a flake.

The test runs a subprocess with `node --permission --allow-fs-read=<contracts dir>`, deliberately narrowing filesystem access so that successfully loading the contracts proves they are self-contained. The integration tier's runner injects a fixture preload into `NODE_OPTIONS` for **every** child process (`tools/run-node-tests.mjs:47-49`). That file lives outside the permitted directory, so under `--tier all` the probe died on the preload with `ERR_ACCESS_DENIED` before it ever reached the contracts.

**The probe was measuring the runner's instrumentation instead of the thing it exists to measure.**

## Why This Stayed Invisible

`full-check` runs `--tier all` and is **not a required check**. Every pull request therefore stayed green while main was red. A standing red on main is worse than an intermittent one: it trains everyone to read main's red as normal, which is precisely how a real regression gets waved through later.

## What Changed

One commit. The probe's environment is copied and `NODE_OPTIONS` / `HARNESS_CLI_TEST_FIXTURE_PRELOAD` are removed before spawning, so it asserts the vertical's portability and nothing else. No gate was weakened; the probe's permission narrowing is unchanged and still enforced.

## Task And Scope

Task `task_01KXWBD37ZY6NGYD1W45XG5TMG`. Scope is one test file, one spawn site. **The runner's global injection is deliberately left alone** — changing where the preload is injected would touch every integration test at once, and this PR exists to clear a standing red, not to redesign test instrumentation. The general pattern is recorded as residual risk below rather than fixed here.

## Version Impact

None. No production code, public surface, CLI behaviour, or on-disk format changes; the diff is confined to a test's subprocess environment. `full-check` on main should return to green.

## Governance Declaration

Authorization: task `task_01KXWBD37ZY6NGYD1W45XG5TMG`, standing fix-on-discovery authority. Invariant: **a probe that deliberately restricts its environment must not inherit the harness's test instrumentation.** No CI configuration, workflow, or branch protection was modified.

## Verification

**A controlled pair, both halves run in the same environment.**

| Check | Result |
|---|---|
| **Negative control**: unfixed code, preload injected as `--tier all` injects it | **red** — `ERR_ACCESS_DENIED`, `resource: tools/cli-test-fixture-register.mjs` |
| **Positive**: fixed code, identical environment | **green**, 888ms |
| Reproduction platform | **Node 26.4.0 locally**, versus 26.5.0 on the runner |

**A hypothesis discarded on the evidence:** the runner is on Node 26.5.0 and this machine on 26.4.0, so the first read was that a Node upgrade had changed permission-model behaviour. **The negative control reproduces on 26.4.0, so the Node version is irrelevant** — the trigger is the preload alone. Had the version story gone unchecked, the fix would have been aimed at a runner upgrade that had nothing to do with it.

## Review Evidence

The failure was found by reading main's own CI history while investigating an unrelated pull request, not by anyone reporting it — which is the point of the finding. It had been red on main since at least `9843d15b` and nobody was blocked by it, because the job that catches it is not required.

The diagnosis was taken to ground truth before any code was written: the `ERR_ACCESS_DENIED` payload names its `resource` outright (`tools/cli-test-fixture-register.mjs`), so the denied read was identified from the log rather than inferred from the symptom. The premature Node-version attribution had already been recorded as a fact against the task and was **corrected in the ledger** once the negative control disproved it, rather than quietly dropped.

## Residual Risk

1. This fixes the probe, not the pattern. **Any** other test spawning a child with a restricted environment inherits the same `NODE_OPTIONS` and will fail the same way; the runner injects it globally and nothing warns at the spawn site.
2. `full-check` remains non-required, so the next standing red on main will again be invisible from the pull request view. That is a separate call and is not made here.

## References

- Task `task_01KXWBD37ZY6NGYD1W45XG5TMG`
- Injection site `tools/run-node-tests.mjs:47-49`; probe `packages/cli/test/package-surface.test.ts:250`

---

# 中文

## 概要

`architecture contracts are single-authority, portable, and route the scaffold` 已在 **main** 上连续三个互不相关的提交(`9843d15b`、`17dfc64c`、`a998b950`)失败,耗时恒定约 1.2s。**这是确定性失败,不是 flake。**

该测试用 `node --permission --allow-fs-read=<contracts 目录>` 起子进程,**刻意**把文件系统访问收窄——能成功加载 contracts 才证明它是自包含的。而 integration tier 的 runner 会把 fixture preload 注入 `NODE_OPTIONS`,对**每一个**子进程生效(`tools/run-node-tests.mjs:47-49`)。该文件在允许目录之外,于是在 `--tier all` 下,探针在加载 preload 时就死于 `ERR_ACCESS_DENIED`,**根本没走到 contracts**。

**探针量的是 runner 的仪器,不是它本该量的东西。**

## 为什么一直没被看见

`full-check` 跑的是 `--tier all`,而它**不是必需门**。于是每个 PR 都绿,main 一直红。**常驻红比偶发红更坏**:它训练所有人把 main 的红当作正常——真正的回归日后就是这样被放行的。

## 改动内容

一个 commit。复制探针的环境并在 spawn 前删掉 `NODE_OPTIONS` / `HARNESS_CLI_TEST_FIXTURE_PRELOAD`,使它只断言该 vertical 的可移植性。**未削弱任何门**:探针的权限收窄原样保留并继续生效。

## 任务与范围

任务 `task_01KXWBD37ZY6NGYD1W45XG5TMG`。范围为一个测试文件、一个 spawn 处。**runner 的全局注入刻意不动**——改注入位置会一次性波及所有 integration 测试;本 PR 的目的是清掉一条常驻红,不是重新设计测试仪器。**通用模式作为残余风险如实记下,而不是在这里顺手改掉。**

## 版本影响

无。未改动生产代码、公共面、CLI 行为或落盘格式,diff 仅限于一个测试子进程的环境。预期 main 上的 `full-check` 恢复绿。

## 治理声明

授权来源:任务 `task_01KXWBD37ZY6NGYD1W45XG5TMG`,常设「发现即修」。不变量:**刻意限制自身环境的探针,不得继承 harness 的测试仪器。** 未改动 CI 配置、workflow 或分支保护。

## 验证

**一组对照,两侧在同一环境下各跑一次。**

| 检查 | 结果 |
|---|---|
| **阴性对照**:未修代码 + 按 `--tier all` 的方式注入 preload | **红** —— `ERR_ACCESS_DENIED`,`resource: tools/cli-test-fixture-register.mjs` |
| **阳性**:已修代码,环境完全相同 | **绿**,888ms |
| 复现平台 | **本机 Node 26.4.0**,runner 为 26.5.0 |

**一个被证据推翻的假设**:runner 是 Node 26.5.0、本机是 26.4.0,最初的判断是「Node 升级改了 permission model 行为」。**但阴性对照在 26.4.0 上就复现了,说明 Node 版本无关**——触发条件只是 preload 本身。若不做这一步对照,修复会被瞄向一次与此事毫无关系的 runner 升级。

## 审查证据

这条失败是在排查另一个不相干的 PR 时**顺手翻 main 自己的 CI 历史**发现的,**没有任何人报过它**——而这恰恰是本次发现的意义所在:它至少从 `9843d15b` 起就红着,却没有卡住任何人,因为抓到它的那个 job 不是必需门。

诊断在动手写代码之前先落到 ground truth:`ERR_ACCESS_DENIED` 的载荷**直接指名了 `resource`**(`tools/cli-test-fixture-register.mjs`),因此被拒的那次读是**从日志里读出来的,不是从症状推出来的**。此前那条过早归因到 Node 版本的记录已作为 fact 落在任务上,在阴性对照推翻它之后**在台账里做了更正**,而不是悄悄抹掉。

## 残余风险

1. 本 PR 修的是**这个探针**,不是**这个模式**。任何其他「起受限环境子进程」的测试都会继承同一个 `NODE_OPTIONS`,并以同样方式失败;runner 是全局注入的,而 spawn 处没有任何提示。
2. `full-check` 仍非必需门,因此下一次 main 常驻红,从 PR 视角依然不可见。**那是另一个裁决,本 PR 不做。**

## 关联材料

- 任务 `task_01KXWBD37ZY6NGYD1W45XG5TMG`
- 注入点 `tools/run-node-tests.mjs:47-49`;探针 `packages/cli/test/package-surface.test.ts:250`
