### PR TITLE
fix: canonicalize attribution source cache order

### DIFF
--- a/packages/kernel/src/projection/sqlite-projection-source-cache.ts
+++ b/packages/kernel/src/projection/sqlite-projection-source-cache.ts
@@ -125,7 +125,7 @@ export function captureProjectionSourceCacheSnapshot(
   const previousMetadata = new Map(previousSnapshot?.metadata.map((row) => [row.cacheKind, row]) ?? []);
   return projectionSourceCacheSnapshot({
     files: [
-      ...attributionFiles,
+      ...attributionFiles.sort(compareCachePaths),
       ...taskFiles.sort(compareCachePaths)
     ],
     watches: [

--- a/packages/kernel/test/store/attribution-union-projection.test.ts
+++ b/packages/kernel/test/store/attribution-union-projection.test.ts
@@ -23,6 +23,7 @@ import {
   materializeAttributionProjectionFromEvents,
   readAttributionProjection
 } from "../../src/projection/sqlite-attribution-projection.ts";
+import { readProjectionSourceCacheSnapshot } from "../../src/projection/sqlite-projection-source-cache.ts";
 import { queryTaskProjectionRows, runSqlite } from "../../src/projection/sqlite-projection-store.ts";
 import { readTaskProjection, rebuildTaskProjection } from "../../src/projection/sqlite-task-projection.ts";
 import {
@@ -112,6 +113,30 @@ test("union event headers and mutation join rebuild identically after SQLite del
     assert.equal(existsSync(projectionPath), false);
     rebuildTaskProjection({ rootDir });
     assert.deepEqual(readAttributionProjection(rootDir), before);
+  });
+});
+
+test("mixed V1 and V2 attribution source cache hashes survive persistence", () => {
+  withTempStore((rootDir) => {
+    const eventsRoot = path.join(rootDir, "harness/attribution-events");
+    mkdirSync(eventsRoot, { recursive: true });
+    writeFileSync(path.join(eventsRoot, "legacy-op.jsonl"), `${JSON.stringify(v1Event())}\n`, "utf8");
+    makeLocalAuthorityAttributionEventV2Log(rootDir).ensure(
+      v2Event([mutation("fact", "fact/task_T/F-1", "create")])
+    );
+
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const persisted = readProjectionSourceCacheSnapshot(projectionPath);
+    const db = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      assert.equal(
+        db.prepare("SELECT value FROM projection_meta WHERE key = 'sourceCacheHash'").get()?.value,
+        persisted.hash
+      );
+    } finally {
+      db.close();
+    }
   });
 });
 


### PR DESCRIPTION
# English

## Summary

Fix the permanent `projection_tampered` hard-fail: the attribution source-cache kind hash was computed over differently-ordered inputs on the write path versus the read path, so the recorded hash could never be reproduced and `ha check` failed on every run even immediately after `ha governance rebuild --apply`.

## What Changed

- `packages/kernel/src/projection/sqlite-projection-source-cache.ts`: sort `attributionFiles` by canonical cache path before snapshotting, matching the read-side ordering (the task-side files were already sorted; the attribution side was left in `relativePath` collection order, which diverges once V1 and V2 attribution layouts are mixed).
- `packages/kernel/test/store/attribution-union-projection.test.ts`: new regression test asserting that a persisted snapshot over mixed V1+V2 attribution events recomputes to an identical hash.

## Task And Scope

- Harness task: task_01KXW8JR40D7EPEC5YR9GA59Y8
- Branch: fix/projection-tamper
- Public scope: packages/kernel projection source-cache ordering + regression test
- Private planning/evidence updated: yes (diagnosis recorded as fact/task_01KXW8JR40D7EPEC5YR9GA59Y8/F-ADZ1WPKM)
- Out of scope: pre-existing check failures (`dangling_entity_ref`, `relation_endpoint_unknown`, `execution_submission_required`) — unrelated legacy issues, intentionally untouched; tamper detection itself is not weakened.

## Version Impact

- Version: no version change because this is an internal projection-cache correctness fix with no public surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_01KXW8JR40D7EPEC5YR9GA59Y8 (diagnosis fact F-ADZ1WPKM)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 7df9af9cc39362265166e5836158dd3d4a220e9c
- Branch merge-base with `origin/main`: 7df9af9cc39362265166e5836158dd3d4a220e9c (rebased)
- Last `git fetch origin` time: 2026-07-19 (this session)
- Sync method: rebase
- Public diff command: `git diff origin/main...fix/projection-tamper`
- Private evidence commit/path: fact/task_01KXW8JR40D7EPEC5YR9GA59Y8/F-ADZ1WPKM
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending (will be attached by CI on this PR)
- [x] `git diff --check`
- [x] repo test runner on touched package: 32 tests, 32 pass, 0 fail (pre-rebase worktree)
- [x] ESLint on touched files
- Not run: full `npm run typecheck` in the worktree (worktree `node_modules` drift produced known-false `@types/node` errors; rewrite-ci on this PR is the authoritative gate), remaining checklist items delegated to `rewrite-ci`.

Acceptance evidence (pre-rebase worktree run):
- `ha governance rebuild --apply` → ok, 793 rows, zero warnings
- `ha check --profile private-harness` → `projection_tampered`: **0** (previously permanent); remaining pre-existing hard-fails unchanged (`dangling_entity_ref`: 1, `relation_endpoint_unknown`: 1, `execution_submission_required`: 5)

## Review Evidence

- Self-review: worker self-review plus coordinator (session CEO) verification of the diff and the refutation of the initial body-hash diagnosis
- Reviewer subagent: independent worker (Codex) produced the fix from an adversarial brief that explicitly invited refuting the coordinator's diagnosis — and did refute the mechanism (ordering mismatch, not body hashing) with a regression test as ground truth
- Human review: pending on this PR
- Blocking findings: none

## Residual Risk

Ordering canonicalization only affects hash reproducibility; if any consumer depended on the previous non-deterministic ordering (none found), it would surface as a test failure in `rewrite-ci`.

## References

- Task: task_01KXW8JR40D7EPEC5YR9GA59Y8
- Evidence: fact/task_01KXW8JR40D7EPEC5YR9GA59Y8/F-ADZ1WPKM (diagnosis); regression test packages/kernel/test/store/attribution-union-projection.test.ts
- Review: adversarial worker brief with refutation mandate; coordinator diff verification

---

# 中文

## 概要

修复永久性 `projection_tampered` hard-fail:attribution source-cache 的 kind hash 在写入路径与读取路径上对**不同顺序**的输入计算,导致存储的 hash 永不可复现 —— 即使刚跑完 `ha governance rebuild --apply`,下一条 `ha check` 也立刻判负。

## 改动内容

- `packages/kernel/src/projection/sqlite-projection-source-cache.ts`:快照前对 `attributionFiles` 按 canonical cache path 排序,与读取侧口径一致(task 侧本已排序;attribution 侧此前保持 `relativePath` 收集序,V1 与 V2 attribution 布局混合后两种顺序分叉)。
- `packages/kernel/test/store/attribution-union-projection.test.ts`:新增回归测试,断言混合 V1+V2 attribution 事件持久化后 hash 可重算相等。

## 任务与范围

- Harness 任务:task_01KXW8JR40D7EPEC5YR9GA59Y8
- 分支:fix/projection-tamper
- 公开范围:packages/kernel 投影 source-cache 排序 + 回归测试
- 私有规划/证据已更新:是(诊断已记录为 fact/task_01KXW8JR40D7EPEC5YR9GA59Y8/F-ADZ1WPKM)
- 范围之外:既有 check 失败(`dangling_entity_ref`、`relation_endpoint_unknown`、`execution_submission_required`)为无关遗留问题,刻意不触碰;tamper 检测本身未被削弱。

## 版本影响

- 版本:无版本变更,因为这是内部投影缓存正确性修复,无公开面变化。
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:不适用
- 授权:task_01KXW8JR40D7EPEC5YR9GA59Y8(诊断 fact F-ADZ1WPKM)
- 机器检查边界:本 PR 仅断言声明存在;声明是否真实、充分由评审者判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- 基线 `origin/main` SHA:7df9af9cc39362265166e5836158dd3d4a220e9c
- 分支与 `origin/main` 的 merge-base:7df9af9cc39362265166e5836158dd3d4a220e9c(已 rebase)
- 最近 `git fetch origin` 时间:2026-07-19(本次会话)
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...fix/projection-tamper`
- 私有证据 commit/路径:fact/task_01KXW8JR40D7EPEC5YR9GA59Y8/F-ADZ1WPKM
- 评审证据路径:见评审证据节
- GitHub Actions `rewrite-ci` 运行 URL:待本 PR CI 附上
- [x] `git diff --check`
- [x] 仓库 runner 跑触碰包测试:32 tests,32 pass,0 fail(rebase 前 worktree)
- [x] 触碰文件 ESLint
- 未运行:worktree 内完整 `npm run typecheck`(worktree `node_modules` 漂移产生已知假红 `@types/node` 错误;以本 PR 的 rewrite-ci 为权威门),其余清单项交由 `rewrite-ci`。

验收证据(rebase 前 worktree 实测):
- `ha governance rebuild --apply` → ok,793 行,零警告
- `ha check --profile private-harness` → `projection_tampered`:**0**(此前永久存在);其余既有 hard-fail 不变(`dangling_entity_ref`:1、`relation_endpoint_unknown`:1、`execution_submission_required`:5)

## 审查证据

- 自评:worker 自评 + coordinator(会话 CEO)对 diff 的核验,以及对初始「body 参与哈希」诊断的证伪确认
- 评审 subagent:独立 worker(Codex)按明确允许证伪 coordinator 诊断的对抗式简报产出修复 —— 并确实证伪了机制(是排序失配,不是 body 哈希),以回归测试为 ground truth
- 人工评审:待本 PR
- 阻塞性发现:无

## 残余风险

排序 canonical 化只影响 hash 可复现性;若有消费者依赖此前的非确定性顺序(未发现),会在 `rewrite-ci` 中以测试失败形式暴露。

## 关联材料

- 任务:task_01KXW8JR40D7EPEC5YR9GA59Y8
- 证据:fact/task_01KXW8JR40D7EPEC5YR9GA59Y8/F-ADZ1WPKM(诊断);回归测试 packages/kernel/test/store/attribution-union-projection.test.ts
- 审查:允许证伪的对抗式 worker 简报;coordinator diff 核验
