### PR TITLE
fix(cli): resolve slugged script artifact scope

### DIFF
--- a/packages/cli/src/daemon/production-authority-script-ingest.ts
+++ b/packages/cli/src/daemon/production-authority-script-ingest.ts
@@ -5,6 +5,7 @@ import {
   encodeCanonicalCbor,
   normalizeRelativeDocumentPath,
   sha256Text,
+  taskPackagePath,
   type CanonicalCborValue,
   type RegistryMutationPlanInput,
   type WriteOp
@@ -34,6 +35,11 @@ interface ScriptScopePayload {
   readonly writes: ReadonlyArray<ScriptScopeWrite>;
 }
 
+interface ScriptTaskArtifactScope {
+  readonly packagePath: string;
+  readonly artifactsPrefix: string;
+}
+
 export function productionScriptIngestAttemptIntent(
   command: ParsedCommand,
   operation: WriteOp,
@@ -41,7 +47,8 @@ export function productionScriptIngestAttemptIntent(
 ): CanonicalAttemptIntent {
   const taskId = scriptTaskId(command);
   if (operation.kind !== "script_ingest") throw new Error("AUTHORITY_SCRIPT_SCOPE_OPERATION_REQUIRED");
-  const writes = scriptScopeWrites(operation.payload, taskId, authoredRoot);
+  const scope = scriptTaskArtifactScope(taskId, authoredRoot);
+  const writes = scriptScopeWrites(operation.payload, scope, authoredRoot);
   assertScriptRunEntityId(operation.entityId);
   const payload: ScriptScopePayload = {
     schema: payloadSchema,
@@ -67,10 +74,11 @@ export function makeProductionScriptIngestSemanticCompiler(authoredRoot: string)
   return {
     compile: async (envelope) => {
       const payload = decodeScriptScopeEnvelope(envelope);
-      const writes = scriptScopeWrites({ writes: payload.writes }, payload.taskId, authoredRoot);
+      const scope = scriptTaskArtifactScope(payload.taskId, authoredRoot);
+      const writes = scriptScopeWrites({ writes: payload.writes }, scope, authoredRoot);
       assertScriptRunEntityId(payload.entityId);
       return {
-        mutationPlan: scriptScopeMutationPlan(payload.taskId, writes),
+        mutationPlan: scriptScopeMutationPlan(payload.taskId, scope, writes),
         operation: {
           opId: "authority-overrides-this",
           entityId: payload.entityId as WriteOp["entityId"],
@@ -101,7 +109,20 @@ function scriptTaskId(command: ParsedCommand): string {
   return taskId;
 }
 
-function scriptScopeWrites(payload: unknown, taskId: string, authoredRoot: string): ReadonlyArray<ScriptScopeWrite> {
+function scriptTaskArtifactScope(taskId: string, authoredRoot: string): ScriptTaskArtifactScope {
+  const rootDir = path.dirname(authoredRoot);
+  const packagePath = normalizeRelativeDocumentPath(path.relative(authoredRoot, taskPackagePath({
+    rootDir,
+    layoutOverrides: { authoredRoot: path.relative(rootDir, authoredRoot) }
+  }, taskId)).split(path.sep).join("/"));
+  return { packagePath, artifactsPrefix: `${packagePath}/artifacts/` };
+}
+
+function scriptScopeWrites(
+  payload: unknown,
+  scope: ScriptTaskArtifactScope,
+  authoredRoot: string
+): ReadonlyArray<ScriptScopeWrite> {
   if (!payload || typeof payload !== "object" || !Array.isArray((payload as { readonly writes?: unknown }).writes)) {
     throw new Error("AUTHORITY_SCRIPT_SCOPE_PAYLOAD_INVALID");
   }
@@ -113,8 +134,7 @@ function scriptScopeWrites(payload: unknown, taskId: string, authoredRoot: strin
       throw new Error("AUTHORITY_SCRIPT_SCOPE_WRITE_INVALID");
     }
     const normalized = normalizeRelativeDocumentPath(row.path);
-    const expectedPrefix = `tasks/${taskId}/artifacts/`;
-    if (!normalized.startsWith(expectedPrefix) || normalized.length === expectedPrefix.length) {
+    if (!normalized.startsWith(scope.artifactsPrefix) || normalized.length === scope.artifactsPrefix.length) {
       throw new Error(`AUTHORITY_SCRIPT_SCOPE_PATH_DENIED:${normalized}`);
     }
     const absolute = path.join(authoredRoot, normalized);
@@ -131,10 +151,14 @@ function scriptScopeWrites(payload: unknown, taskId: string, authoredRoot: strin
   return writes;
 }
 
-function scriptScopeMutationPlan(taskId: string, writes: ReadonlyArray<ScriptScopeWrite>): RegistryMutationPlanInput {
+function scriptScopeMutationPlan(
+  taskId: string,
+  scope: ScriptTaskArtifactScope,
+  writes: ReadonlyArray<ScriptScopeWrite>
+): RegistryMutationPlanInput {
   const contexts = writes.map((write) => ({
-    packagePath: `tasks/${taskId}`,
-    documentPath: write.path.slice(`tasks/${taskId}/`.length)
+    packagePath: scope.packagePath,
+    documentPath: write.path.slice(`${scope.packagePath}/`.length)
   }));
   return {
     registryVersion: 1,

--- a/packages/cli/test/production-authority-canonical-ingress/fixture.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/fixture.ts
@@ -32,6 +32,11 @@ export function createFixture() {
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"));
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6"), { recursive: true });
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6"));
+  mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG9-script-scope"), { recursive: true });
+  writeFileSync(
+    path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG9-script-scope/INDEX.md"),
+    taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG9")
+  );
   for (const taskId of [
     "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK0", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK1",
     "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK2", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK3",
@@ -231,7 +236,10 @@ export function installProductionArtifactPreset(repoRoot: string): void {
           capability: "task-artifacts",
           version: "1",
           target: { taskFrom: "current-task" },
-          artifacts: [{ id: "production-scaffold", schema: "production-scaffold/v1", mediaTypes: ["text/markdown"], cardinality: "one", required: true }]
+          artifacts: [
+            { id: "production-scaffold", schema: "production-scaffold/v1", mediaTypes: ["text/markdown"], cardinality: "one", required: true },
+            { id: "evidence", schema: "production-evidence/v1", mediaTypes: ["application/json"], cardinality: "one", required: true }
+          ]
         }],
         sideEffects: []
       }
@@ -244,8 +252,10 @@ export function installProductionArtifactPreset(repoRoot: string): void {
     'const context = JSON.parse(readFileSync(process.env.HARNESS_PRESET_CONTEXT, "utf8"));',
     'const writer = context.capabilities.writes["task-artifacts"][0];',
     'const output = writer.artifacts["production-scaffold"].representations[0].path;',
+    'const evidence = writer.artifacts.evidence.representations[0].path;',
     'writeFileSync(output, `# Production scaffold\\n\\nTask: ${context.run.taskId}\\n`, "utf8");',
-    'writeFileSync(context.result.path, JSON.stringify({ schema: "script-result/v1", ok: true, produced: ["production-scaffold"] }), "utf8");',
+    'writeFileSync(evidence, JSON.stringify({ schema: "production-evidence/v1", ok: true }), "utf8");',
+    'writeFileSync(context.result.path, JSON.stringify({ schema: "script-result/v1", ok: true, produced: ["production-scaffold", "evidence"] }), "utf8");',
     ''
   ].join("\n"));
 }

--- a/packages/cli/test/production-authority-canonical-ingress/preset-ingress.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/preset-ingress.ts
@@ -28,7 +28,7 @@ export function verifyProductionPresetIngress(
   const scriptOperationCount = authorityOperationRecords(fixture.serviceRoot).length;
   const scriptRun = runRawJsonMaybeFail(fixture.repoRoot, [
     "script", "run", "preset:production-artifact-scaffold:scaffold",
-    "--task", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6"
+    "--task", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG9"
   ], env);
   assert.equal(scriptRun.status, 0, JSON.stringify(scriptRun.receipt));
   assert.equal(scriptRun.receipt.ok, true, JSON.stringify(scriptRun.receipt));
@@ -36,6 +36,10 @@ export function verifyProductionPresetIngress(
     "script run must submit its declared artifact batch through one canonical operation");
   assert.equal(readFileSync(path.join(
     fixture.authoredRoot,
-    "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6/artifacts/production-scaffold.md"
-  ), "utf8"), "# Production scaffold\n\nTask: task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6\n");
+    "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG9-script-scope/artifacts/production-scaffold.md"
+  ), "utf8"), "# Production scaffold\n\nTask: task_01KXQ4WTA7Q4XJ5GDDRS1YXNG9\n");
+  assert.equal(existsSync(path.join(
+    fixture.authoredRoot,
+    "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG9-script-scope/artifacts/.machine-evidence.registry.json"
+  )), true);
 }

--- a/packages/cli/test/production-authority-script-ingest.test.ts
+++ b/packages/cli/test/production-authority-script-ingest.test.ts
@@ -43,6 +43,31 @@ test("production script ingest admits one task-artifact batch as one semantic do
   }
 });
 
+test("production script ingest admits the runtime batch for a slugged task package", () => {
+  const authoredRoot = mkdtempSync(path.join(tmpdir(), "ha-script-ingest-"));
+  try {
+    const packageName = `${taskId}-architecture-rot-audit`;
+    mkdirSync(path.join(authoredRoot, "tasks", packageName), { recursive: true });
+    writeFileSync(path.join(authoredRoot, "tasks", packageName, "INDEX.md"), [
+      "---",
+      `task_id: ${taskId}`,
+      "---",
+      "# Architecture rot audit",
+      ""
+    ].join("\n"));
+    const registryPath = `tasks/${packageName}/artifacts/.machine-evidence.registry.json`;
+    const intent = productionScriptIngestAttemptIntent(command, operation([{
+      path: registryPath,
+      body: "{}\n",
+      baseBlobSha256: null
+    }]), authoredRoot);
+
+    assert.deepEqual(intent.portablePaths, [registryPath]);
+  } finally {
+    rmSync(authoredRoot, { recursive: true, force: true });
+  }
+});
+
 test("production script ingest fails closed outside the bound task artifact scope and on stale CAS", () => {
   const authoredRoot = mkdtempSync(path.join(tmpdir(), "ha-script-ingest-"));
   try {

--- a/packages/cli/test/production-authority-script-scope-ingress.test.ts
+++ b/packages/cli/test/production-authority-script-scope-ingress.test.ts
@@ -1,0 +1,54 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { rmSync } from "node:fs";
+import test from "node:test";
+import {
+  defaultDaemonUserRoot,
+  pollUntil,
+  runDaemonCommand,
+  stopDaemon
+} from "./helpers/daemon-cli.ts";
+import {
+  createFixture,
+  installProductionArtifactPreset
+} from "./production-authority-canonical-ingress/fixture.ts";
+import { verifyProductionPresetIngress } from "./production-authority-canonical-ingress/preset-ingress.ts";
+
+test("production script ingress admits runtime evidence for a slugged task package", { timeout: 60_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const env = {
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"
+  };
+  try {
+    installProductionArtifactPreset(fixture.repoRoot);
+    const registered = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical", "--canonical-root", fixture.repoRoot,
+      "--user-root", userRoot, "--no-link", "--json"
+    ], env);
+    assert.equal(registered.ok, true, JSON.stringify(registered));
+    try {
+      runDaemonCommand(fixture.repoRoot, [
+        "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+      ], env);
+    } catch {
+      // Observe the detached service when startup outlives the command reachability wait.
+    }
+    const status = await pollUntil(
+      () => runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env),
+      (candidate) => candidate.reachable === true,
+      (candidate, error) => JSON.stringify({ candidate, error: error instanceof Error ? error.message : String(error ?? "") }),
+      { timeoutMs: 20_000 }
+    );
+    assert.equal(status.repoCount, 1, JSON.stringify(status));
+
+    verifyProductionPresetIngress(fixture, env);
+  } finally {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
# English

## Summary

Preset scripts could not complete a real write on the production daemon path. `ha script run <id> --task <task-id>` failed with `AUTHORITY_SCRIPT_SCOPE_PATH_DENIED` on the runtime's own bookkeeping file — even though that file sits squarely inside the task's `artifacts/` directory, exactly where script writes are supposed to go.

Root cause: the authority's script-scope admission hardcoded the task package path as `tasks/${taskId}/artifacts/` in three places, while real task package directories are slug-suffixed (`tasks/<taskId>-<slug>/`). The runtime writes to the real, slugged directory; admission approved only the slugless ghost. Every path was therefore denied. This is the same "hand-assembled task path becomes a ghost directory" mistake already documented for humans — committed inside the authority layer.

It is also one of the enumeration's declaration-drift pairings: the set of paths the runtime writes and the set admission approves were maintained separately and only ever agreed by luck — in this case, never.

## What Changed

One commit. The three hardcoded `tasks/${taskId}` sites in `production-authority-script-ingest.ts` are replaced by a scope derived from the kernel's slug-aware `taskPackagePath()` — the same resolver the runtime itself uses. Admission prefix, envelope compilation, and the mutation plan now all derive from that single source; there is no second list to drift.

## Task And Scope

Task `task_01KXTVPMV3BTSDQPJJCAXDA8ZT` (decision anchor `dec_01KXTVNPSM57P9MYS53YA2XQ2N`, active). Phase 1 of this line — the road itself (`AUTHORITY_TYPED_COMMAND_UNSUPPORTED`) — was already fixed by #917/#918; this PR closes the remaining admission gap found by live production retest. Scope is one authority module plus tests; the daemon control surface, tools, and kernel index were deliberately untouched (parallel lines in flight).

## Version Impact

Behavioral fix on the production daemon path only: preset script writes into slugged task packages are now admitted. Direct mode is byte-identical (asserted by test). No schema, wire, or CLI surface changes. Fail-closed behavior outside the task's artifact scope is preserved and covered by a negative test.

## Governance Declaration

Authorization: task `task_01KXTVPMV3BTSDQPJJCAXDA8ZT` under `dec_01KXTVNPSM57P9MYS53YA2XQ2N` (active), and root-cause program `dec_01KXW78YDHVNA133RFPWC1K3RS` (active) — this is an instance of prohibition #1: a list derivable from an authoritative resolver must not be handwritten. Invariant: **the paths admission approves must derive from the same resolver that produces the paths the runtime writes.** No gate weakened; the denial outside scope remains fail-closed. No CI configuration, workflow, or branch protection modified.

## Verification

Re-run by the reviewer, not read from the report:

| Check | Result |
|---|---|
| Live repro before fix (production daemon, real write) | `AUTHORITY_SCRIPT_SCOPE_PATH_DENIED:tasks/<slugged>/artifacts/.machine-evidence.registry.json` |
| Targeted tests on fixed code (hermetic env) | 4/4 green, including slugged-package admission and fail-closed negative |
| **Mutation**: restore the old hardcoded module, rerun the same tests | exit 1, 5 failures — the fix is what flips them |
| Restore fix | green again; worktree clean |
| Implementer's full gate run | root `check:local` exit 0, 34 gates |

## Review Evidence

The dispatch itself was nearly wasted: this line's task still sat `planned`, but ground-truthing before dispatch showed phase 1 had already merged (#917/#918) — a merged-but-never-closed-out line. Instead of re-dispatching the stale mission, the CEO re-tested the live production path, found the remaining one-layer failure, and dispatched against that precise repro. The worker was given an explicit escape hatch — if the denial turned out to be deliberate design (dotfile exclusion), stop and report rather than open a hole — and correctly judged it an omission, with the originating hardcode identified by line.

## Residual Risk

1. The live production path retest with the fixed binary can only happen post-merge (the running daemon serves merged code). The same path is covered pre-merge by the ingress test that drives the production route in-process.
2. `script list` inventory names differ between preset layers (one candidate id used in the repro did not exist); unrelated to admission, noted for the diagnosability queue.
3. Task `task_01KXTVPMV3BTSDQPJJCAXDA8ZT` closeout (including #917/#918 attribution) follows after merge.

## References

- Task `task_01KXTVPMV3BTSDQPJJCAXDA8ZT`; decisions `dec_01KXTVNPSM57P9MYS53YA2XQ2N`, `dec_01KXW78YDHVNA133RFPWC1K3RS`
- Report `tmp/orch/preset-ingress/REPORT-preset-ingress.md`; prior phase #917, #918

---

# 中文

## 概要

preset 脚本在生产 daemon 路上**真写走不通**:`ha script run <id> --task <task-id>` 失败于 `AUTHORITY_SCRIPT_SCOPE_PATH_DENIED`,被拒的是 runtime 自己的记账文件——而它明明就在任务包 `artifacts/` 目录里,正是脚本写入的合法落点。

根因:authority 的 script-scope 准入在三处**硬编码**了 `tasks/${taskId}/artifacts/`,而真实任务包目录带 slug 后缀(`tasks/<taskId>-<slug>/`)。runtime 写进真实带 slug 的目录,准入却只批那个不带 slug 的幽灵目录——于是所有路径必拒。这正是台账里早已记给人类的「手工拼任务包路径必成幽灵目录」坑,**这次是 authority 层代码自己犯的**。

它同时是枚举中声明漂移类的一个配对:runtime 实际写的路径集与准入批准的路径集分处两地、各自维护,只靠恰好一致——本例中从未一致过。

## 改动内容

一个 commit。`production-authority-script-ingest.ts` 三处硬编码全部替换为从 kernel 的 slug-aware `taskPackagePath()` **派生**的 scope——与 runtime 同一个解析器。准入前缀、envelope 编译、mutation plan 三者同源,**不存在第二份可漂移的清单**。

## 任务与范围

任务 `task_01KXTVPMV3BTSDQPJJCAXDA8ZT`(决策锚 `dec_01KXTVNPSM57P9MYS53YA2XQ2N`,active)。本线阶段 1(整条路不存在,`AUTHORITY_TYPED_COMMAND_UNSUPPORTED`)已由 #917/#918 修复;本 PR 收掉生产实测发现的剩余准入缺口。范围为一个 authority 模块加测试;daemon control 面、tools、kernel index 刻意未碰(并行线在飞)。

## 版本影响

仅生产 daemon 路的行为修复:preset 脚本对带 slug 任务包的写入现在可被准入。direct 模式字节不变(有测试断言)。无 schema/wire/CLI 面变化。任务 artifact scope 之外的拒绝(fail-closed)原样保留并有阴性测试覆盖。

## 治理声明

授权来源:任务 `task_01KXTVPMV3BTSDQPJJCAXDA8ZT`(决策 `dec_01KXTVNPSM57P9MYS53YA2XQ2N`,active)+ 根因治理 `dec_01KXW78YDHVNA133RFPWC1K3RS`(active)——本例即禁令一的实例:能从权威解析器推出的清单不许手写。不变量:**准入批准的路径必须与 runtime 产生写路径用同一个解析器派生。** 未削弱任何门;scope 外拒绝保持 fail-closed。未改动 CI 配置、workflow 或分支保护。

## 验证

由验收者重跑,不采信报告:

| 检查 | 结果 |
|---|---|
| 修复前生产实测(daemon 路真写) | `AUTHORITY_SCRIPT_SCOPE_PATH_DENIED:tasks/<带slug>/artifacts/.machine-evidence.registry.json` |
| 修复后定向测试(hermetic 环境) | 4/4 绿,含带 slug 任务包准入与 fail-closed 阴性 |
| **突变**:还原旧硬编码模块重跑同一组测试 | exit 1,5 处失败——红绿翻转由本修复决定 |
| 还原修复 | 复绿;工作树干净 |
| 实现者全门 | 根 `check:local` exit 0,34 门 |

## 审查证据

这次派工差点白派:该线任务还挂着 `planned`,但派发前 ground-truth 发现阶段 1 早已合入(#917/#918)——**合并未销账**。CEO 没有照旧 mission 重派,而是先对生产路真实重测,找到剩余那一层的精确复现再派。给实现者留了明确的判定分支:若该拒绝是刻意设计(dotfile 排除)则停下上报、不许硬开洞;实现者正确判定为遗漏,并按行号指认了硬编码源头。

## 残余风险

1. 修复后二进制的生产路复测只能在合并后做(现役 daemon 服务的是已合并代码);合并前由进程内驱动生产路由的 ingress 测试覆盖同一路径。
2. `script list` 清单在不同 preset 层间命名不一致(复现时一个候选 id 不存在);与准入无关,记入可诊断性队列。
3. 任务 `task_01KXTVPMV3BTSDQPJJCAXDA8ZT` 的收口(含 #917/#918 归账)在合并后进行。

## 关联材料

- 任务 `task_01KXTVPMV3BTSDQPJJCAXDA8ZT`;决策 `dec_01KXTVNPSM57P9MYS53YA2XQ2N`、`dec_01KXW78YDHVNA133RFPWC1K3RS`
- 报告 `tmp/orch/preset-ingress/REPORT-preset-ingress.md`;前序阶段 #917、#918
