### PR TITLE
fix(cli): route archive distill writes operationally

### DIFF
--- a/packages/cli/src/cli/runner-registry.ts
+++ b/packages/cli/src/cli/runner-registry.ts
@@ -34,6 +34,7 @@ export interface CommandRunnerContext {
   readonly runtimeEventLedgerService: RuntimeEventLedgerService;
   readonly makeWriteCoordinator: (actor: OperationalActor) => WriteCoordinator;
   readonly makeMigrationWriteCoordinator: (actor: OperationalActor, evidenceRef: string) => WriteCoordinator;
+  readonly makeOperationalWriteCoordinator: (actor: OperationalActor) => WriteCoordinator;
   readonly actorAttribution: () => CliActorAttribution;
   readonly taskHolderPrincipal: () => TaskHolderPrincipal;
   readonly decisionWriteService: DecisionWriteService;
@@ -116,6 +117,7 @@ export function runRegisteredCommand(
   syncExportedSession: (result: ProvenanceSessionExportResult) => Effect.Effect<void, ProvenanceSessionExporterRejected>,
   makeWriteCoordinator: (actor: OperationalActor) => WriteCoordinator,
   makeMigrationWriteCoordinator: (actor: OperationalActor, evidenceRef: string) => WriteCoordinator,
+  makeOperationalWriteCoordinator: (actor: OperationalActor) => WriteCoordinator,
   actorAttribution: () => CliActorAttribution,
   taskHolderPrincipal: () => TaskHolderPrincipal,
   makeDecisionWriteService: () => DecisionWriteService,
@@ -171,6 +173,7 @@ export function runRegisteredCommand(
     syncExportedSession,
     makeWriteCoordinator,
     makeMigrationWriteCoordinator,
+    makeOperationalWriteCoordinator,
     actorAttribution,
     taskHolderPrincipal,
     get decisionWriteService() {

--- a/packages/cli/src/commands/core/distill.ts
+++ b/packages/cli/src/commands/core/distill.ts
@@ -59,7 +59,7 @@ export function writeDistillCandidate(
   };
   const outputPath = path.join(layout.generatedRoot, "distill", action.taskId, `${candidateId}.json`);
   const relativeOutputPath = toPortablePath(path.relative(layout.rootDir, outputPath));
-  return writeCoordinatedPayload(context.makeWriteCoordinator({ scope: "operational", kind: "agent", id: "distill-candidate" }), {
+  return writeCoordinatedPayload(context.makeOperationalWriteCoordinator({ scope: "operational", kind: "agent", id: "distill-candidate" }), {
     entityId: moduleEntityId("distill-candidate"),
     kind: "machine_artifact_write",
     opIdPrefix: `distill-candidate-${candidateId}`,

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -211,7 +211,7 @@ export async function runRegisteredCommandWithCliComposition(
         syncExportedSession
       })
     }, boundAt)
-  }), enforceTaskLease(), makeTaskHolder, getTaskHolderPrincipal), makeArtifactStore, getCurrentSessionProbe, makeSessionExporter, syncExportedSession, makeWriteCoordinator, makeMigrationWriteCoordinator, getActorAttribution, getTaskHolderPrincipal, () => {
+  }), enforceTaskLease(), makeTaskHolder, getTaskHolderPrincipal), makeArtifactStore, getCurrentSessionProbe, makeSessionExporter, syncExportedSession, makeWriteCoordinator, makeMigrationWriteCoordinator, makeOperationalWriteCoordinator, getActorAttribution, getTaskHolderPrincipal, () => {
     const attribution = getActorAttribution().writeAttribution;
     const repin = command.action.kind === "decision-repin" ? command.action : undefined;
     return makeDecisionWriteService({

--- a/packages/cli/test/production-authority-observed-write-path-cas.test.ts
+++ b/packages/cli/test/production-authority-observed-write-path-cas.test.ts
@@ -95,6 +95,31 @@ test("observed-write attempt compilation fails explicitly when required path CAS
   }
 });
 
+test("task archive observed-write intent requires the selected task entity", () => {
+  const fixture = createPathCasFixture();
+  try {
+    const command = {
+      action: { kind: "task-archive", taskId: fixture.sourceTaskId, reason: "archive regression" }
+    } as unknown as ParsedCommand;
+    const matchingOperation = {
+      opId: "archive-entity-match",
+      entityId: taskEntityId(fixture.sourceTaskId),
+      kind: "package_archive",
+      payload: { path: "INDEX.md", body: fixture.body }
+    } satisfies WriteOp;
+
+    const intent = productionObservedWriteAttemptIntent(command, matchingOperation, fixture.authoredRoot);
+    assert.equal(intent.physicalEntityId, taskEntityId(fixture.sourceTaskId));
+
+    assert.throws(() => productionObservedWriteAttemptIntent(command, {
+      ...matchingOperation,
+      entityId: "module/distill-candidate"
+    }, fixture.authoredRoot), /AUTHORITY_TASK_ARCHIVE_OPERATION_MISMATCH/u);
+  } finally {
+    rmSync(fixture.rootDir, { recursive: true, force: true });
+  }
+});
+
 function createPathCasFixture() {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-observed-path-cas-"));
   const authoredRoot = path.join(rootDir, "harness");

--- a/packages/cli/test/task-archive-distill-cli.test.ts
+++ b/packages/cli/test/task-archive-distill-cli.test.ts
@@ -5,7 +5,10 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { deriveRelationId, formatRelationFlowRecord, type EntityRelationRecord } from "../../kernel/src/index.ts";
+import { Effect } from "effect";
+import { deriveRelationId, formatRelationFlowRecord, type EntityRelationRecord, type WriteCoordinator, type WriteOp } from "../../kernel/src/index.ts";
+import type { CommandRunnerContext } from "../src/cli/runner-registry.ts";
+import { writeDistillCandidate } from "../src/commands/core/distill.ts";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
@@ -87,6 +90,33 @@ test("CLI task archive writes runtime distill artifacts through the canonical re
   });
 });
 
+test("task archive distill candidate uses the operational coordinator", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-archive-distill-routing-"));
+  try {
+    const inputPath = "archive-source.md";
+    writeFileSync(path.join(rootDir, inputPath), "Archive evidence.\n", "utf8");
+    const repoOperations: WriteOp[] = [];
+    const operationalOperations: WriteOp[] = [];
+    const context = {
+      layoutInput: { rootDir },
+      makeWriteCoordinator: () => captureCoordinator(repoOperations),
+      makeOperationalWriteCoordinator: () => captureCoordinator(operationalOperations)
+    } as unknown as CommandRunnerContext;
+
+    const result = Effect.runSync(writeDistillCandidate(context, {
+      taskId: "task_01KXWBD37ZY6NGYD1W45XG5TMG",
+      inputPath
+    }, "ha task archive"));
+
+    assert.equal(result.ok, true);
+    assert.equal(repoOperations.length, 0);
+    assert.equal(operationalOperations.length, 1);
+    assert.equal(operationalOperations[0]?.entityId, "module/distill-candidate");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("CLI task archive fails closed when a task-owned relation endpoint is unresolved", () => {
   withTempRoot((rootDir) => {
     const created = runJson(rootDir, ["new-task", "--title", "Unresolved Fact Archive"]);
@@ -158,6 +188,17 @@ function relationRecord(source: string, target: string): EntityRelationRecord {
     origin: "declared",
     rationale: "Archive reference guard fixture",
     state: "active"
+  };
+}
+
+function captureCoordinator(operations: WriteOp[]): WriteCoordinator {
+  return {
+    enqueue: (operation) => Effect.sync(() => {
+      operations.push(operation);
+      return { opId: operation.opId, entityId: operation.entityId, accepted: true as const };
+    }),
+    flush: (reason) => Effect.succeed({ reason, opCount: operations.length, committed: false }),
+    recover: Effect.succeed({ replayedOps: 0 })
   };
 }
 


### PR DESCRIPTION
# English

## Summary

Fix `ha task archive` rejection on the production daemon authority path (`AUTHORITY_TASK_ARCHIVE_OPERATION_MISMATCH`) by routing the archive distill-candidate write through the operational coordinator instead of the repo authority coordinator.

## What Changed

- `distill.ts`: distill-candidate write now uses `makeOperationalWriteCoordinator` (machine artifact belongs on the operational path) instead of `makeWriteCoordinator`.
- `runner-registry.ts` / `command-executor.ts`: thread `makeOperationalWriteCoordinator` through the command runner context.
- Tests: authority observed-write-path-cas + task-archive-distill CLI tests extended (9/9 pass).

## Task And Scope

- Harness task: baseline-governance umbrella `task_01KXWZ3YEGXD6302G1656RY801`
- Branch: fix/task-archive-authority-entityid
- Public scope: packages/cli archive + distill write routing
- Private planning/evidence updated: not applicable
- Out of scope: the `--dry-run` true-barrier gap

## Version Impact

- Version: no version change because this is an internal write-path routing fix, no public API change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: production authority write path (`packages/cli/src/daemon/` coordinator routing)
- Authority: baseline-governance charter `dec_01KXWZ33N9VQP4SN0F5WBGE7M1`; ADR-0016 write-coordinator scope boundary
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: `--dry-run` barrier gap

## Verification

- Base `origin/main` SHA: 8a5c14d3f91474046f9ab02aec539d1a0c6a9d3d
- Branch merge-base with `origin/main`: 8a5c14d3f91474046f9ab02aec539d1a0c6a9d3d
- `npm run check:local` exit 0; related tests 9/9.

## Review Evidence

- CEO semantic + architecture review: read the full diff; gate defense at `production-authority-observed-write-intents.ts:217` is untouched — the fix removes illegitimate machine-artifact traffic from the authority path, it does not weaken the mismatch check.
- Codex worker corrected the CEO's initial root-cause hypothesis (entityId was correct; the real defect was distill-candidate mis-routing) with code evidence.

## Residual Risk

- `ha task archive --dry-run` does not currently enforce a true dry-run barrier (writes may still occur); tracked as follow-up.
- The 3 already-fixed tasks (#938/#778/#807 closeout) require lease claims before archiving; they can be archived once this lands.

## References

- Root-cause map: `packages/cli/src/daemon/production-authority-observed-write-intents.ts:214-218`
- Baseline-governance charter: `dec_01KXWZ33N9VQP4SN0F5WBGE7M1`
- ADR-0016 write-coordinator scope boundary

---

# 中文

## 概要

修复 `ha task archive` 在生产 daemon authority 写路径被 `AUTHORITY_TASK_ARCHIVE_OPERATION_MISMATCH` 拒收的缺陷：把 archive 的 distill-candidate 写入从 repo authority 协调器改走 operational 协调器。

## 改动内容

- `distill.ts`：distill-candidate 写入改用 `makeOperationalWriteCoordinator`（机器产物本该走 operational 路径），不再走 `makeWriteCoordinator`。
- `runner-registry.ts` / `command-executor.ts`：把 `makeOperationalWriteCoordinator` 穿进命令 runner context。
- 测试：authority observed-write-path-cas + task-archive-distill CLI 测试扩展（9/9 通过）。

## 任务与范围

- Harness task：基准治理伞 `task_01KXWZ3YEGXD6302G1656RY801`
- 分支：fix/task-archive-authority-entityid
- 公共范围：packages/cli archive + distill 写路由
- 私有规划/证据更新：不适用
- 范围外：`--dry-run` 真 barrier 缺口

## 版本影响

- 版本：无变更，内部写路径路由修复，无公共 API 变化
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：是
- Protected surface 范围：生产 authority 写路径（`packages/cli/src/daemon/` 协调器路由）
- 授权：基准治理 charter `dec_01KXWZ33N9VQP4SN0F5WBGE7M1`；ADR-0016 写协调器 scope 边界
- 机器检查边界：本 PR 仅断言声明存在；是否真实充分由复核者判定。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：`--dry-run` barrier 缺口

## 验证

- Base `origin/main` SHA：8a5c14d3f91474046f9ab02aec539d1a0c6a9d3d
- 分支与 `origin/main` 的 merge-base：8a5c14d3f91474046f9ab02aec539d1a0c6a9d3d
- `npm run check:local` 退出 0；相关测试 9/9。

## 审查证据

- CEO 语义+架构复核：通读 diff；`production-authority-observed-write-intents.ts:217` 的 gate 防御未动——修复移除的是 authority 路径上的非法机器产物流量，不是放宽 mismatch 校验。
- Codex worker 用代码证据纠正了 CEO 最初的根因假设（entityId 本是对的；真缺陷是 distill-candidate 错误路由）。

## 残余风险

- `ha task archive --dry-run` 当前不是真 barrier（写入可能仍发生）；另立后续。
- 3 个 already-fixed 任务（#938/#778/#807 销账）archive 前需先 claim lease；此 PR 合入后可 archive。

## 关联材料

- 根因地图：`packages/cli/src/daemon/production-authority-observed-write-intents.ts:214-218`
- 基准治理 charter：`dec_01KXWZ33N9VQP4SN0F5WBGE7M1`
- ADR-0016 写协调器 scope 边界

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body / 双语正文
- [x] Governance declaration / 治理声明
- [x] Tests pass / 测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)