### PR TITLE
fix(daemon): persist authority registry pointer only after socket ownership

### DIFF
--- a/packages/cli/src/daemon/authority-manifest-registry.ts
+++ b/packages/cli/src/daemon/authority-manifest-registry.ts
@@ -1,0 +1,80 @@
+import { realpathSync } from "node:fs";
+import path from "node:path";
+import {
+  readDaemonRegistry,
+  registerDaemonRepo,
+  type DaemonRegistryRepo
+} from "../../../kernel/src/index.ts";
+import { loadAuthorityProductionManifest } from "./authority-production-state.ts";
+
+export type AuthorityManifestRegistryRepo = Pick<
+  DaemonRegistryRepo,
+  "repoId" | "canonicalRoot" | "displayName" | "authorityManifestPath"
+>;
+
+export function authorityManifestServeRepos(
+  manifestPath: string,
+  userRoot: string
+): ReadonlyArray<AuthorityManifestRegistryRepo> {
+  const manifest = loadAuthorityProductionManifest(manifestPath);
+  const canonicalManifestPath = realpathSync(manifestPath);
+  const registered = readDaemonRegistry({ userRoot }).repos;
+  const projected: Array<AuthorityManifestRegistryRepo & { state: DaemonRegistryRepo["state"] }> = registered.map((repo) => ({
+    repoId: repo.repoId,
+    canonicalRoot: repo.canonicalRoot,
+    displayName: repo.displayName,
+    state: repo.state,
+    ...(repo.authorityManifestPath ? { authorityManifestPath: repo.authorityManifestPath } : {})
+  }));
+  for (const manifestRepo of manifest.repos) {
+    const canonicalRoot = realpathSync(manifestRepo.canonicalRoot);
+    const existingByRoot = projected.find((repo) => canonicalRegistryRoot(repo.canonicalRoot) === canonicalRoot);
+    if (existingByRoot) {
+      if (existingByRoot.repoId !== manifestRepo.repoId) {
+        throw new Error(`canonical root is already registered as repoId "${existingByRoot.repoId}"`);
+      }
+      const index = projected.indexOf(existingByRoot);
+      projected[index] = {
+        ...existingByRoot,
+        displayName: path.basename(canonicalRoot),
+        state: "enabled",
+        authorityManifestPath: canonicalManifestPath
+      };
+      continue;
+    }
+    const conflictingRepo = projected.find((repo) => repo.repoId === manifestRepo.repoId);
+    if (conflictingRepo) {
+      throw new Error(`repoId "${manifestRepo.repoId}" is already registered for ${conflictingRepo.canonicalRoot}`);
+    }
+    projected.push({
+      repoId: manifestRepo.repoId,
+      canonicalRoot,
+      displayName: path.basename(canonicalRoot),
+      state: "enabled",
+      authorityManifestPath: canonicalManifestPath
+    });
+  }
+  return projected
+    .filter((repo) => repo.state === "enabled")
+    .map(({ state: _state, ...repo }) => repo);
+}
+
+export function persistAuthorityManifestPointer(manifestPath: string, userRoot: string): void {
+  const manifest = loadAuthorityProductionManifest(manifestPath);
+  for (const repo of manifest.repos) {
+    registerDaemonRepo({
+      userRoot,
+      repoId: repo.repoId,
+      canonicalRoot: repo.canonicalRoot,
+      authorityManifestPath: manifestPath
+    });
+  }
+}
+
+function canonicalRegistryRoot(rootDir: string): string {
+  try {
+    return realpathSync(rootDir);
+  } catch {
+    return rootDir;
+  }
+}

--- a/packages/cli/src/daemon/authority-manifest-registry.ts
+++ b/packages/cli/src/daemon/authority-manifest-registry.ts
@@ -1,8 +1,8 @@
-import { realpathSync } from "node:fs";
-import path from "node:path";
 import {
+  projectDaemonRepoRegistration,
   readDaemonRegistry,
   registerDaemonRepo,
+  type DaemonRegistry,
   type DaemonRegistryRepo
 } from "../../../kernel/src/index.ts";
 import { loadAuthorityProductionManifest } from "./authority-production-state.ts";
@@ -16,51 +16,13 @@ export function authorityManifestServeRepos(
   manifestPath: string,
   userRoot: string
 ): ReadonlyArray<AuthorityManifestRegistryRepo> {
-  const manifest = loadAuthorityProductionManifest(manifestPath);
-  const canonicalManifestPath = realpathSync(manifestPath);
-  const registered = readDaemonRegistry({ userRoot }).repos;
-  const projected: Array<AuthorityManifestRegistryRepo & { state: DaemonRegistryRepo["state"] }> = registered.map((repo) => ({
-    repoId: repo.repoId,
-    canonicalRoot: repo.canonicalRoot,
-    displayName: repo.displayName,
-    state: repo.state,
-    ...(repo.authorityManifestPath ? { authorityManifestPath: repo.authorityManifestPath } : {})
-  }));
-  for (const manifestRepo of manifest.repos) {
-    const canonicalRoot = realpathSync(manifestRepo.canonicalRoot);
-    const existingByRoot = projected.find((repo) => canonicalRegistryRoot(repo.canonicalRoot) === canonicalRoot);
-    if (existingByRoot) {
-      if (existingByRoot.repoId !== manifestRepo.repoId) {
-        throw new Error(`canonical root is already registered as repoId "${existingByRoot.repoId}"`);
-      }
-      const index = projected.indexOf(existingByRoot);
-      projected[index] = {
-        ...existingByRoot,
-        displayName: path.basename(canonicalRoot),
-        state: "enabled",
-        authorityManifestPath: canonicalManifestPath
-      };
-      continue;
-    }
-    const conflictingRepo = projected.find((repo) => repo.repoId === manifestRepo.repoId);
-    if (conflictingRepo) {
-      throw new Error(`repoId "${manifestRepo.repoId}" is already registered for ${conflictingRepo.canonicalRoot}`);
-    }
-    projected.push({
-      repoId: manifestRepo.repoId,
-      canonicalRoot,
-      displayName: path.basename(canonicalRoot),
-      state: "enabled",
-      authorityManifestPath: canonicalManifestPath
-    });
-  }
-  return projected
+  return projectAuthorityManifestRegistry(manifestPath, userRoot).registry.repos
     .filter((repo) => repo.state === "enabled")
     .map(({ state: _state, ...repo }) => repo);
 }
 
 export function persistAuthorityManifestPointer(manifestPath: string, userRoot: string): void {
-  const manifest = loadAuthorityProductionManifest(manifestPath);
+  const { manifest } = projectAuthorityManifestRegistry(manifestPath, userRoot);
   for (const repo of manifest.repos) {
     registerDaemonRepo({
       userRoot,
@@ -71,10 +33,19 @@ export function persistAuthorityManifestPointer(manifestPath: string, userRoot: 
   }
 }
 
-function canonicalRegistryRoot(rootDir: string): string {
-  try {
-    return realpathSync(rootDir);
-  } catch {
-    return rootDir;
+function projectAuthorityManifestRegistry(manifestPath: string, userRoot: string): {
+  readonly manifest: ReturnType<typeof loadAuthorityProductionManifest>;
+  readonly registry: DaemonRegistry;
+} {
+  const manifest = loadAuthorityProductionManifest(manifestPath);
+  let registry = readDaemonRegistry({ userRoot });
+  for (const repo of manifest.repos) {
+    registry = projectDaemonRepoRegistration(registry, {
+      userRoot,
+      repoId: repo.repoId,
+      canonicalRoot: repo.canonicalRoot,
+      authorityManifestPath: manifestPath
+    }).registry;
   }
+  return { manifest, registry };
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,6 @@ import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   readDaemonRegistry,
-  registerDaemonRepo,
   type DaemonRegistryRepo
 } from "../../kernel/src/index.ts";
 import { makeDaemonLogService } from "../../application/src/index.ts";
@@ -44,6 +43,10 @@ import { createProductionAuthorityLifecycle } from "./daemon/production-authorit
 import { makeDaemonLogFileStore } from "./daemon/daemon-log-file-store.ts";
 import { recordDaemonStarted, recordDaemonTerminated } from "./daemon/daemon-lifecycle.ts";
 import { loadAuthorityProductionManifest } from "./daemon/authority-production-state.ts";
+import {
+  authorityManifestServeRepos,
+  persistAuthorityManifestPointer
+} from "./daemon/authority-manifest-registry.ts";
 import { runCompoundReceiptExitCommand } from "./daemon/compound-receipt-runner.ts";
 import { runAgentRuntimeCommand } from "./commands/agent-runtime.ts";
 import { runTaskSubmitFacade } from "./commands/core/task-submit-facade.ts";
@@ -181,7 +184,7 @@ async function runDaemonServe(
     socketPath: restoredSpec.endpoint,
     userRoot: requestedUserRoot
   });
-  const configuration = resolveDaemonServeConfiguration(rootDir, restoredLayoutOverrides, args, true, restoredLaunchOptions);
+  const configuration = resolveDaemonServeConfiguration(rootDir, restoredLayoutOverrides, args, restoredLaunchOptions);
   const { userRoot, endpoint, serveRepos, authorityManifest, defaultRepoId, lifecycleRepo } = configuration;
   const completeSpec = restoredSpec.withEffectiveOptions({
     ...(authorityManifest ? { authorityManifest } : {}),
@@ -250,7 +253,6 @@ async function runDaemonServe(
         launchConfiguration,
         preflightReplacement: preflightDaemonLaunch
       }, authorityLifecycle, daemonLogService);
-      serviceHost.startRegistryReconcile(userRoot);
       const transport = createDaemonLocalTransport({
         daemonId: serviceHost.daemonId,
         endpoint,
@@ -268,10 +270,14 @@ async function runDaemonServe(
         }
       });
       await transport.start();
-      completeSpec.persist(userRoot);
       serviceHost.onStop(async () => {
         await transport.stop();
       });
+      if (restoredLaunchOptions.authorityManifest) {
+        persistAuthorityManifestPointer(restoredLaunchOptions.authorityManifest, userRoot);
+      }
+      completeSpec.persist(userRoot);
+      serviceHost.startRegistryReconcile(userRoot);
       await recordDaemonStarted({
         userRoot,
         logService: daemonLogService,
@@ -340,14 +346,13 @@ function checkDaemonServeConfiguration(
   args: ReadonlyArray<string>,
   launchOptions: ParsedDaemonLaunchArgv
 ): void {
-  resolveDaemonServeConfiguration(rootDir, layoutOverrides, args, false, launchOptions);
+  resolveDaemonServeConfiguration(rootDir, layoutOverrides, args, launchOptions);
 }
 
 function resolveDaemonServeConfiguration(
   rootDir: string,
   layoutOverrides: { readonly authoredRoot?: string } | undefined,
   args: ReadonlyArray<string>,
-  persistExplicitManifest: boolean,
   launchOptions: ParsedDaemonLaunchArgv
 ): {
   readonly userRoot: string;
@@ -361,11 +366,9 @@ function resolveDaemonServeConfiguration(
   const userRoot = launchOptions.userRoot ?? daemonUserRoot();
   const endpoint = launchOptions.socketPath ?? localUserDaemonEndpoint(userRoot, daemonIdFromEnv());
   const requestedAuthorityManifest = launchOptions.authorityManifest;
-  if (requestedAuthorityManifest) {
-    loadAuthorityProductionManifest(requestedAuthorityManifest);
-    if (persistExplicitManifest) persistAuthorityManifestPointer(requestedAuthorityManifest, userRoot);
-  }
-  const serveRepos = daemonServeRepos(rootDir, layoutOverrides, requestedRepoId, userRoot);
+  const serveRepos = requestedAuthorityManifest
+    ? authorityManifestServeRepos(requestedAuthorityManifest, userRoot)
+    : daemonServeRepos(rootDir, layoutOverrides, requestedRepoId, userRoot);
   const authorityManifest = requestedAuthorityManifest ?? authorityManifestFromRegistry(serveRepos);
   if (authorityManifest) loadAuthorityProductionManifest(authorityManifest);
   const defaultRepoId = defaultDaemonServeRepoId(serveRepos, rootDir, requestedRepoId);
@@ -401,18 +404,6 @@ function daemonServeRepos(
     canonicalRoot: rootDir,
     displayName: layoutOverrides?.authoredRoot ?? requestedRepoId
   }];
-}
-
-function persistAuthorityManifestPointer(manifestPath: string, userRoot: string): void {
-  const manifest = loadAuthorityProductionManifest(manifestPath);
-  for (const repo of manifest.repos) {
-    registerDaemonRepo({
-      userRoot,
-      repoId: repo.repoId,
-      canonicalRoot: repo.canonicalRoot,
-      authorityManifestPath: manifestPath
-    });
-  }
 }
 
 export function authorityManifestFromRegistry(repos: ReadonlyArray<DaemonServeRepo>): string | undefined {

--- a/packages/cli/test/authority-manifest-registry.test.ts
+++ b/packages/cli/test/authority-manifest-registry.test.ts
@@ -1,0 +1,161 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import {
+  readDaemonRegistry,
+  registerDaemonRepo,
+  unregisterDaemonRepo
+} from "../../kernel/src/index.ts";
+import {
+  authorityManifestServeRepos,
+  persistAuthorityManifestPointer
+} from "../src/daemon/authority-manifest-registry.ts";
+import { initializeHarness } from "../src/commands/init.ts";
+import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
+
+test("authority manifest projection rejects a root registered under another repoId without writing", () => {
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "user-root");
+  try {
+    registerDaemonRepo({
+      userRoot,
+      repoId: "existing",
+      canonicalRoot: fixture.repoRoot,
+      createConvenienceLinks: false
+    });
+    const before = readDaemonRegistry({ userRoot });
+
+    assert.throws(
+      () => authorityManifestServeRepos(fixture.manifestPath, userRoot),
+      /canonical root is already registered as repoId "existing"/u
+    );
+    assert.deepEqual(readDaemonRegistry({ userRoot }), before);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("authority manifest projection re-enables a disabled matching root without writing", () => {
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "user-root");
+  try {
+    registerDaemonRepo({
+      userRoot,
+      repoId: "canonical",
+      canonicalRoot: fixture.repoRoot,
+      createConvenienceLinks: false
+    });
+    unregisterDaemonRepo("canonical", { userRoot, createConvenienceLinks: false });
+    const before = readDaemonRegistry({ userRoot });
+
+    const projected = authorityManifestServeRepos(fixture.manifestPath, userRoot);
+
+    assert.deepEqual(projected.map((repo) => repo.repoId), ["canonical"]);
+    assert.equal(projected[0]?.canonicalRoot, realpathSync.native(fixture.repoRoot));
+    assert.equal(projected[0]?.authorityManifestPath, realpathSync.native(fixture.manifestPath));
+    assert.deepEqual(readDaemonRegistry({ userRoot }), before);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("authority manifest projection canonicalizes a harness subdirectory to the registered root", () => {
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "user-root");
+  try {
+    registerDaemonRepo({
+      userRoot,
+      repoId: "canonical",
+      canonicalRoot: fixture.repoRoot,
+      createConvenienceLinks: false
+    });
+    const nestedRoot = path.join(fixture.authoredRoot, "tasks");
+    rewriteManifest(fixture.manifestPath, (manifest) => {
+      manifest.repos[0].canonicalRoot = nestedRoot;
+    });
+
+    const projected = authorityManifestServeRepos(fixture.manifestPath, userRoot);
+
+    assert.deepEqual(projected.map((repo) => repo.repoId), ["canonical"]);
+    assert.equal(projected[0]?.canonicalRoot, realpathSync.native(fixture.repoRoot));
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("authority manifest projection rejects an invalid explicit repoId before writing", () => {
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "user-root");
+  try {
+    rewriteManifest(fixture.manifestPath, (manifest) => {
+      manifest.repos[0].repoId = "Canonical";
+    });
+    const before = readDaemonRegistry({ userRoot });
+
+    assert.throws(
+      () => authorityManifestServeRepos(fixture.manifestPath, userRoot),
+      /repoId must use lowercase letters/u
+    );
+    assert.deepEqual(readDaemonRegistry({ userRoot }), before);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("authority manifest projection uses daemon registry ordering", () => {
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "user-root");
+  const zetaRoot = path.join(fixture.root, "zeta-repo");
+  try {
+    mkdirSync(zetaRoot);
+    initializeHarness({ rootDir: zetaRoot }, false, "Zeta");
+    registerDaemonRepo({
+      userRoot,
+      repoId: "zeta",
+      canonicalRoot: zetaRoot,
+      createConvenienceLinks: false
+    });
+
+    assert.deepEqual(
+      authorityManifestServeRepos(fixture.manifestPath, userRoot).map((repo) => repo.repoId),
+      ["canonical", "zeta"]
+    );
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("authority manifest persistence validates every repo before its first registry write", () => {
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "user-root");
+  try {
+    rewriteManifest(fixture.manifestPath, (manifest) => {
+      manifest.repos.push({
+        ...manifest.repos[0],
+        repoId: "Invalid",
+        canonicalRoot: fixture.auxiliaryRoot
+      });
+    });
+    const before = readDaemonRegistry({ userRoot });
+
+    assert.throws(
+      () => persistAuthorityManifestPointer(fixture.manifestPath, userRoot),
+      /repoId must use lowercase letters/u
+    );
+    assert.deepEqual(readDaemonRegistry({ userRoot }), before);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+interface MutableManifest {
+  repos: Array<Record<string, unknown>>;
+}
+
+function rewriteManifest(manifestPath: string, mutate: (manifest: MutableManifest) => void): void {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as MutableManifest;
+  mutate(manifest);
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}

--- a/packages/cli/test/authority-manifest-registry.test.ts
+++ b/packages/cli/test/authority-manifest-registry.test.ts
@@ -1,4 +1,4 @@
-// harness-test-tier: fast
+// harness-test-tier: integration
 import assert from "node:assert/strict";
 import { mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";

--- a/packages/cli/test/daemon-cold-start-launch-spec.test.ts
+++ b/packages/cli/test/daemon-cold-start-launch-spec.test.ts
@@ -1,9 +1,11 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { execFile, execFileSync, spawn, spawnSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
 import path from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 import { localUserDaemonEndpoint, requestLocalDaemonJsonRpc } from "../../daemon/src/index.ts";
 import { readDaemonRegistry, registerDaemonRepo } from "../../kernel/src/index.ts";
 import { initializeHarness } from "../src/commands/init.ts";
@@ -21,6 +23,8 @@ import {
 } from "./helpers/daemon-cli.ts";
 import { cliTestEnv } from "./helpers/cli-test-env.ts";
 import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
+
+const execFileAsync = promisify(execFile);
 
 test("service cold start restores, overrides, and diagnoses the persisted launch spec", { timeout: 90_000 }, async () => {
   const fixture = createFixture();
@@ -44,7 +48,18 @@ test("service cold start restores, overrides, and diagnoses the persisted launch
     ], env);
     assert.equal(first.started, true, JSON.stringify(first));
     assert.equal(typeof first.pid, "number", JSON.stringify(first));
-    assert.match(readFileSync(daemonLaunchSpecPath(userRoot, endpoint), "utf8"), new RegExp(escapeRegExp(fixture.manifestPath), "u"));
+    assert.equal(first.endpoint, endpoint, JSON.stringify(first));
+    assert.equal(first.daemonId, `ha-${String(first.pid)}`, JSON.stringify(first));
+    assert.equal(
+      readDaemonRegistry({ userRoot }).repos.find((repo) => repo.repoId === "canonical")?.authorityManifestPath,
+      fixture.manifestPath
+    );
+    const persistedLaunchSpec = JSON.parse(readFileSync(daemonLaunchSpecPath(userRoot, endpoint), "utf8")) as {
+      readonly endpoint: string;
+      readonly options: { readonly authorityManifest?: string };
+    };
+    assert.equal(persistedLaunchSpec.endpoint, endpoint);
+    assert.equal(persistedLaunchSpec.options.authorityManifest, fixture.manifestPath);
     assert.equal((await readRunningLaunchSpec(fixture.repoRoot, userRoot)).args.includes(daemonLaunchOptionsResolvedFlag), true);
 
     mkdirSync(classicRoot, { recursive: true });
@@ -175,6 +190,43 @@ test("service cold start without a required manifest reports the preflight cause
     assert.doesNotMatch(failure, /did not become reachable/u);
   } finally {
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("occupied daemon socket does not persist a new authority manifest registry pointer", async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const endpoint = localUserDaemonEndpoint(userRoot);
+  const owner = net.createServer();
+  try {
+    mkdirSync(userRoot, { recursive: true });
+    await new Promise<void>((resolve, reject) => {
+      owner.once("error", reject);
+      owner.listen(endpoint, () => resolve());
+    });
+    writeFileSync(`${endpoint}.owner`, JSON.stringify({
+      schema: "daemon-socket-owner/v1",
+      pid: process.pid,
+      ownerToken: "occupied-socket-test-owner"
+    }));
+
+    await assert.rejects(execFileAsync(process.execPath, [
+      path.resolve("packages/cli/src/index.ts"),
+      "--root", fixture.repoRoot,
+      "daemon", "serve",
+      "--repo", "canonical",
+      "--socket", endpoint,
+      "--user-root", userRoot,
+      "--authority-manifest", fixture.manifestPath
+    ], { encoding: "utf8", env: cliTestEnv({ HARNESS_DAEMON_USER_ROOT: userRoot }) }), /already owned/u);
+
+    assert.equal(
+      readDaemonRegistry({ userRoot }).repos.find((repo) => repo.repoId === "canonical")?.authorityManifestPath,
+      undefined
+    );
+  } finally {
+    await new Promise<void>((resolve) => owner.close(() => resolve()));
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });

--- a/packages/cli/test/daemon-cold-start-launch-spec.test.ts
+++ b/packages/cli/test/daemon-cold-start-launch-spec.test.ts
@@ -201,6 +201,7 @@ test("occupied daemon socket does not persist a new authority manifest registry 
   const owner = net.createServer();
   try {
     mkdirSync(userRoot, { recursive: true });
+    const registryBefore = readDaemonRegistry({ userRoot });
     await new Promise<void>((resolve, reject) => {
       owner.once("error", reject);
       owner.listen(endpoint, () => resolve());
@@ -221,12 +222,38 @@ test("occupied daemon socket does not persist a new authority manifest registry 
       "--authority-manifest", fixture.manifestPath
     ], { encoding: "utf8", env: cliTestEnv({ HARNESS_DAEMON_USER_ROOT: userRoot }) }), /already owned/u);
 
-    assert.equal(
-      readDaemonRegistry({ userRoot }).repos.find((repo) => repo.repoId === "canonical")?.authorityManifestPath,
-      undefined
-    );
+    assert.deepEqual(readDaemonRegistry({ userRoot }), registryBefore);
   } finally {
     await new Promise<void>((resolve) => owner.close(() => resolve()));
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("transport bind failure after socket ownership does not persist any registry change", {
+  skip: process.platform === "win32",
+  timeout: 30_000
+}, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const endpoint = localUserDaemonEndpoint(userRoot);
+  try {
+    mkdirSync(userRoot, { recursive: true });
+    mkdirSync(endpoint);
+    const registryBefore = readDaemonRegistry({ userRoot });
+
+    await assert.rejects(execFileAsync(process.execPath, [
+      path.resolve("packages/cli/src/index.ts"),
+      "--root", fixture.repoRoot,
+      "daemon", "serve",
+      "--repo", "canonical",
+      "--socket", endpoint,
+      "--user-root", userRoot,
+      "--authority-manifest", fixture.manifestPath
+    ], { encoding: "utf8", env: cliTestEnv({ HARNESS_DAEMON_USER_ROOT: userRoot }) }), /EISDIR|Path is a directory/u);
+
+    assert.deepEqual(readDaemonRegistry({ userRoot }), registryBefore);
+    assert.equal(existsSync(`${endpoint}.owner`), false);
+  } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });

--- a/packages/kernel/src/daemon/registry.ts
+++ b/packages/kernel/src/daemon/registry.ts
@@ -60,6 +60,12 @@ export interface DaemonRegistryMutationResult {
   readonly warnings: ReadonlyArray<string>;
 }
 
+export interface DaemonRegistryRegistrationProjection {
+  readonly registry: DaemonRegistry;
+  readonly repo: DaemonRegistryRepo;
+  readonly changed: boolean;
+}
+
 export function daemonRegistryPaths(options: DaemonRegistryOptions = {}): DaemonRegistryPaths {
   const userRoot = path.resolve(options.userRoot ?? path.join(os.homedir(), ".harness"));
   return {
@@ -79,11 +85,20 @@ export function readDaemonRegistry(options: DaemonRegistryOptions = {}): DaemonR
 export function registerDaemonRepo(input: DaemonRegistryRegisterInput): DaemonRegistryMutationResult {
   const paths = daemonRegistryPaths(input);
   const registry = readDaemonRegistry(input);
+  const projected = projectDaemonRepoRegistration(registry, input);
+  if (projected.changed) writeDaemonRegistry(projected.registry, input);
+  const warnings = syncConvenienceLink(projected.repo, input);
+  return { ...projected, registryPath: paths.registryPath, warnings };
+}
+
+export function projectDaemonRepoRegistration(
+  registry: DaemonRegistry,
+  input: DaemonRegistryRegisterInput
+): DaemonRegistryRegistrationProjection {
   const canonicalRoot = canonicalHarnessRoot(input.canonicalRoot);
   const displayName = input.displayName ?? path.basename(canonicalRoot);
   const explicitRepoId = input.repoId ? normalizeExplicitRepoId(input.repoId) : undefined;
   const existingByRoot = registry.repos.find((repo) => repo.canonicalRoot === canonicalRoot);
-  const warnings: Array<string> = [];
 
   if (existingByRoot) {
     if (explicitRepoId && existingByRoot.repoId !== explicitRepoId) {
@@ -97,9 +112,7 @@ export function registerDaemonRepo(input: DaemonRegistryRegisterInput): DaemonRe
     };
     const next = replaceRepo(registry, repo);
     const changed = !daemonRepoEquals(existingByRoot, repo);
-    if (changed) writeDaemonRegistry(next, input);
-    warnings.push(...syncConvenienceLink(repo, input));
-    return { registry: next, repo, registryPath: paths.registryPath, changed, warnings };
+    return { registry: next, repo, changed };
   }
 
   const repoId = explicitRepoId ?? generateRepoId(displayName, canonicalRoot, registry.repos);
@@ -117,9 +130,7 @@ export function registerDaemonRepo(input: DaemonRegistryRegisterInput): DaemonRe
     ...(input.authorityManifestPath ? { authorityManifestPath: canonicalAuthorityManifestPath(input.authorityManifestPath) } : {})
   };
   const next = sortDaemonRegistry({ schema: daemonRegistrySchema, repos: [...registry.repos, repo] });
-  writeDaemonRegistry(next, input);
-  warnings.push(...syncConvenienceLink(repo, input));
-  return { registry: next, repo, registryPath: paths.registryPath, changed: true, warnings };
+  return { registry: next, repo, changed: true };
 }
 
 export function unregisterDaemonRepo(repoId: string, options: DaemonRegistryOptions = {}): DaemonRegistryMutationResult {

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -163,12 +163,16 @@ export { daemonAdmissionBytes } from "./daemon/admission-budget.ts";
 export type { DaemonAdmissionBudget } from "./daemon/admission-budget.ts";
 export { writeCoordinatedPayload, writeCoordinatedTaskDocuments } from "./write-coordination/write-helpers.ts";
 export {
+  projectDaemonRepoRegistration,
   readDaemonRegistry,
   resolveDaemonRepoByRoot,
   registerDaemonRepo,
   unregisterDaemonRepo
 } from "./daemon/registry.ts";
-export type { DaemonRegistry, DaemonRegistryRepo } from "./daemon/registry.ts";
+export type {
+  DaemonRegistry,
+  DaemonRegistryRepo
+} from "./daemon/registry.ts";
 export {
   TaskClaimCollisionError,
   ExecutionLeaseCollisionError,

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -195,6 +195,7 @@ const publicRuntimeSurface = [
   "preflightPresetManifest",
   "priorityTiers",
   "privateTextScannerVersion",
+  "projectDaemonRepoRegistration",
   "queryConsentsBySourceStrength",
   "queryDecisionProjection",
   "queryExecutionEvidencePage",

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -1742,7 +1742,7 @@
       "bearing": "daemon-service-launch",
       "leaseRequired": false,
       "owner": "daemon endpoint owner",
-      "purpose": "Persist one opaque endpoint-isolated resolution of canonical authority-manifest and authored-root options after common-path restoration for safe service, foreground, and autostart cold starts.",
+      "purpose": "After the daemon owns and listens on its endpoint, persist the authority-manifest registry pointer and one opaque endpoint-isolated resolution of canonical authority-manifest and authored-root options for safe service, foreground, and autostart cold starts.",
       "channel": {
         "pathClass": "runtime-local-durable",
         "zoneClass": "non-sot-service-state"
@@ -1753,13 +1753,19 @@
       "directWrites": [
         {
           "file": "packages/cli/src/daemon/daemon-launch-spec.ts"
+        },
+        {
+          "file": "packages/kernel/src/daemon/registry.ts"
         }
       ],
       "evidence": [
+        "packages/cli/src/index.ts:272",
+        "packages/cli/src/daemon/authority-manifest-registry.ts:62",
         "packages/cli/src/daemon/daemon-launch-spec.ts:87",
-        "packages/cli/src/daemon/daemon-launch-spec.ts:134"
+        "packages/cli/src/daemon/daemon-launch-spec.ts:134",
+        "packages/kernel/src/daemon/registry.ts:85"
       ],
-      "freshness": "endpoint-sha256-keyed-structured-options-atomic-temp-rename-owner-only-0600-rewrite"
+      "freshness": "post-listen-authority-pointer-then-endpoint-sha256-keyed-structured-options-atomic-temp-rename-owner-only-0600-rewrite"
     },
     {
       "id": "daemon.agent-runtime.session-store",


### PR DESCRIPTION
# English

## Summary

W2/L1 of the baseline-governance program: the authority-manifest registry pointer is now persisted only after the daemon actually owns and listens on its socket. Previously the pointer was written during configuration resolution — before bind — so a failed startup (occupied socket, bind error, preflight rejection) could leave a durable pointer referencing a process that never became the owner (ordering defect anchored at `eb6a4841`).

## What Changed

- `packages/cli/src/index.ts` (daemon serve path): pointer persistence moved from configuration-resolution time to after `transport.start()` succeeds; launch-spec persist and registry reconcile follow in the same post-listen sequence. Service, foreground, and autostart all funnel through this common path.
- `packages/cli/src/daemon/authority-manifest-registry.ts` (new): serve configuration now computes its repo set from an in-memory projection of the manifest against the registry instead of writing the registry early. The projection reuses the kernel's own registration logic, so validation, canonicalization, and ordering cannot diverge from the disk write path.
- `packages/kernel/src/daemon/registry.ts`: extracted `projectDaemonRepoRegistration` — the pure projection previously embedded in `registerDaemonRepo` (same `canonicalHarnessRoot` canonicalization, repoId validation, `sortDaemonRegistry` ordering). `registerDaemonRepo` now composes it, and `persistAuthorityManifestPointer` runs the full projection as pre-validation before the first write, so predictable failures cannot leave partial multi-repo pointer writes.
- Tests: new `authority-manifest-registry.test.ts` projection unit suite (conflicting repoId, disabled same-root, subdirectory roots, invalid repoId); cold-start integration additions — occupied-socket and transport-bind-failure paths assert the entire registry is deep-equal to its pre-start state, plus a positive control proving the old ordering did leak a pointer.
- `tools/write-road-registry.json`: registry row updated to declare the post-listen pointer write (declaration, not exemption).

## Task And Scope

- Harness task: `task_01KXXJS60W7TN2ZEV1XD0D10ZP` (W2/L1), parent umbrella `task_01KXWZ3YEGXD6302G1656RY801` (PLT-Baseline-Governance), charter `dec_01KXWZ33N9`.
- Branch: `fix/l1-registry-pointer-ordering`
- Public scope: daemon serve startup ordering, kernel registry projection extraction, tests, write-road registry row.
- Private planning/evidence updated: yes (task package plan/progress/mission in private ledger).
- Out of scope: authority write-path semantics; cross-endpoint registry write race (pre-existing, later L1 chain task); refresh false-negative and admission diagnostics (next L1 chain tasks).

## Version Impact

- Version: no version change — daemon startup ordering fix within existing CLI surface, no published interface change.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: daemon control + authority launch path.
- Authority: baseline-governance charter `dec_01KXWZ33N9`, umbrella L1 wave (write-road serial chain). No gate, preflight, admission, or single-owner check is weakened; validation now happens earlier (pre-listen projection), strictly stricter-or-equal.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Follow-up governance task: remaining L1 chain items under the umbrella task (refresh false-negative, admission diagnostics, cross-endpoint registry race).

## Verification

- Base `origin/main` SHA: `39d474dcbfa9b93b4c68d300f1da7925f2202766`
- Branch merge-base with `origin/main`: `39d474dcbfa9b93b4c68d300f1da7925f2202766` (branched from current main; no sync needed)
- Last `git fetch origin` time: 2026-07-20 (this session)
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: task package `task_01KXXJS60W7TN2ZEV1XD0D10ZP` progress/evidence (private ledger)
- Reviewer evidence path: implementation report `codex-report-l1-registry-pointer.md` (worker worktree, mirrored into the task package)
- GitHub Actions `rewrite-ci` run URL: this PR's checks
- [x] `npm run check:ci` (all locally runnable manifest-derived workflows green; run by worker after each commit)
- [x] `npm run typecheck` (within check:ci)
- [x] `npm test` (cold-start integration 6/6 plus new projection unit suite via `tools/run-node-tests.mjs`)
- [x] GitHub Actions `rewrite-ci` runs on this PR
- Positive control: under the pre-fix ordering the occupied-socket scenario demonstrably persisted a pointer; after the fix the same scenario leaves the registry byte-identical.
- Not run locally: real Windows named-pipe hosts and systemd/launchd service managers — covered by PR CI environment jobs.

## Review Evidence

- Self-review: worker report with before/after startup-sequence traces for service/foreground/autostart and positive-control outputs.
- Reviewer subagent: single-round three-model blind cross-review (Codex native review + GLM + Grok, mutually blind) per the umbrella review policy. Adjudicated union: 4 confirmed P2 — projection canonicalization diverging from kernel `canonicalHarnessRoot` (3/3 convergent; could wedge cold start permanently on subdirectory roots), non-atomic multi-repo pointer persistence leaving partial orphans (2/3), projection ordering drift vs `sortDaemonRegistry` changing default-repo selection, and positive-control test gaps. All four fixed in `b8f16452` by extracting the kernel projection as the single source of truth; re-scan scoped to those findings.
- Rejected findings (with reasons): persist crash window between pointer and launch-spec writes (self-heals from registry on restart), `realpathSync` vs `.native` mix (no key-path string comparison), cross-endpoint registry write race (pre-existing, tracked as later L1 chain work).
- Human review: standing authorization (baseline-governance umbrella policy confirmed by repo owner).
- Blocking findings: none open.

## Residual Risk

- After pre-validation, only genuine I/O failures (disk EACCES, TOCTOU races) can interrupt the multi-repo persist loop mid-way; the window is accepted and documented in the worker report.
- A hard kill between listen and the persist steps leaves a daemon that briefly listened but wrote no pointer — strictly safer than the previous inverse, and the next cold start self-heals from the registry.
- Windows named-pipe equivalent failure injection not exercised on real hardware; CI's windows job covers the portable code paths.

## References

- Umbrella task plan: `harness/tasks/task_01KXWZ3YEGXD6302G1656RY801-plt-baseline-governance-milestone-root/task_plan.md` (L1 wave row; private ledger)
- Charter: `dec_01KXWZ33N9` (baseline-governance, active)
- Ordering-defect anchor: commit `eb6a4841` (restore post-boundary authority write path)
- Prereq landed before this wave: PR #945 (daemon launch-spec v2 cold start), PR #946 (L0 gate closure)

---

# 中文

## 概要

基准治理 W2/L1：authority-manifest registry pointer 现在只在 daemon 真正取得 socket ownership 并 listen 成功之后才落盘。此前 pointer 在配置解析期（bind 之前）就写入，启动失败（socket 被占/bind 失败/preflight 拒绝）会留下指向从未成为 owner 的进程的持久 pointer（时序缺陷锚 `eb6a4841`）。

## 改动内容

- `packages/cli/src/index.ts`（daemon serve 路）：pointer 持久化从配置解析期移到 `transport.start()` 成功之后；launch-spec 持久化与 registry reconcile 同在 post-listen 序列。service/foreground/autostart 三路汇入同一公共路径。
- `packages/cli/src/daemon/authority-manifest-registry.ts`（新增）：serve 配置改用 manifest 对 registry 的内存投影计算 repo 集，不再提前写 registry。投影复用 kernel 自身的注册逻辑，校验/规范化/排序不可能与磁盘写路径漂移。
- `packages/kernel/src/daemon/registry.ts`：抽出纯投影 `projectDaemonRepoRegistration`（同一 `canonicalHarnessRoot` 规范化、repoId 校验、`sortDaemonRegistry` 排序）；`registerDaemonRepo` 组合调用之；`persistAuthorityManifestPointer` 在第一笔写之前跑全量投影做预校验，可预见失败不再留下部分多 repo pointer。
- 测试：新增 `authority-manifest-registry.test.ts` 投影单测（repoId 冲突/disabled 同根/子目录根/非法 repoId）；冷启动集成新增 occupied-socket 与 transport bind 失败路径断言全 registry 与启动前 deep-equal；阳性对照证明旧序确实泄漏 pointer。
- `tools/write-road-registry.json`：更新声明行覆盖 post-listen pointer 写（补声明，非豁免）。

## 任务与范围

- Harness 任务：`task_01KXXJS60W7TN2ZEV1XD0D10ZP`（W2/L1），父伞 `task_01KXWZ3YEGXD6302G1656RY801`（PLT-Baseline-Governance），charter `dec_01KXWZ33N9`。
- 分支：`fix/l1-registry-pointer-ordering`
- 公开范围：daemon serve 启动时序、kernel registry 投影抽取、测试、write-road registry 声明行。
- 私有计划/证据已更新：是（任务包 plan/progress/mission 在私有台账）。
- 范围外：authority 写路语义；跨 endpoint registry 写竞态（既有缺陷，L1 链后续任务）；refresh 假阴性与 admission 报真因（L1 链下两项）。

## 版本影响

- 版本：无版本变更——既有 CLI 面内的 daemon 启动时序修复，无发布接口变化。
- 发布影响：不发布。

## 治理声明

- 触及 protected surface：是
- 范围：daemon control + authority launch 路径。
- 授权：基准治理 charter `dec_01KXWZ33N9`，伞任务 L1 波次（写路串行链）。未削弱任何 gate/preflight/admission/单 owner 校验；校验反而前移到 pre-listen 投影，只严不松。
- 机器检查边界：本 PR 仅断言声明存在；声明是否真实充分由 reviewer 判断。
- Break-glass：否
- 后续治理任务：伞任务下 L1 链其余项（refresh 假阴性、admission 报真因、跨 endpoint 竞态）。

## 验证

- 基线 `origin/main` SHA：`39d474dcbfa9b93b4c68d300f1da7925f2202766`
- 分支与 `origin/main` merge-base：`39d474dcbfa9b93b4c68d300f1da7925f2202766`（自当前 main 分出，无需同步）
- 最近 `git fetch origin`：2026-07-20（本 session）
- 同步方式：无需
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据路径：任务包 `task_01KXXJS60W7TN2ZEV1XD0D10ZP` progress/evidence（私有台账）
- 评审证据路径：实现报告 `codex-report-l1-registry-pointer.md`（worker worktree，镜像入任务包）
- GitHub Actions `rewrite-ci` run：见本 PR checks
- [x] `npm run check:ci`（manifest 派生的本地可运行 workflow 全绿；worker 每次 commit 后复跑）
- [x] `npm run typecheck`（含于 check:ci）
- [x] `npm test`（冷启动集成 6/6 + 新投影单测，经 `tools/run-node-tests.mjs`）
- [x] GitHub Actions `rewrite-ci` 在本 PR 上运行
- 阳性对照：修复前时序下 occupied-socket 场景确实持久化了 pointer；修复后同场景 registry 与启动前逐字节一致。
- 未本地跑：真实 Windows named-pipe 主机与 systemd/launchd——由 PR CI 环境 job 覆盖。

## 审查证据

- 自评：worker 报告含 service/foreground/autostart 三路改前/改后时序取证与阳性对照输出。
- 评审 subagent：按伞任务评审政策执行一轮三模型交叉盲评（Codex 原生 review + GLM + Grok 互不透题）。裁决并集：4 条 confirmed P2——投影规范化与 kernel `canonicalHarnessRoot` 漂移（3/3 收敛；子目录根可致冷启动永久卡死）、多 repo persist 非原子留部分 orphan（2/3）、投影排序漂移改变默认 repo 选择、阳性对照测试缺口。四条全部在 `b8f16452` 以抽取 kernel 投影为唯一权威修复；复扫仅限这些 findings。
- 驳回的 findings（附理由）：pointer 与 launch-spec 双写间隙崩溃窗口（重启自 registry 自愈）、`realpathSync` 与 `.native` 混用（无关键路径字符串比较）、跨 endpoint registry 写竞态（既有缺陷，L1 链后续任务跟踪）。
- 人工评审：常设授权（基准治理伞政策，仓库所有者已确认）。
- 阻塞 findings：无。

## 残余风险

- 预校验后，只有真实 I/O 失败（磁盘 EACCES、TOCTOU）能中断多 repo persist 循环；窗口已接受并记录于 worker 报告。
- listen 与 persist 之间硬杀会留下「曾短暂 listen 但未写 pointer」的状态——严格安全于旧的反向情形，下次冷启动自 registry 自愈。
- Windows named-pipe 等价失败注入未实机验证；CI windows job 覆盖可移植代码路径。

## 关联材料

- 伞任务 plan：`harness/tasks/task_01KXWZ3YEGXD6302G1656RY801-plt-baseline-governance-milestone-root/task_plan.md`（L1 波次行；私有台账）
- Charter：`dec_01KXWZ33N9`（基准治理，active）
- 时序缺陷锚：commit `eb6a4841`（restore post-boundary authority write path）
- 本波次前置：PR #945（daemon launch-spec v2 冷启动）、PR #946（L0 gate 闭包）
