### PR TITLE
fix(daemon): refresh handover criterion converges instead of demanding change

### DIFF
--- a/packages/cli/src/commands/daemon/control.ts
+++ b/packages/cli/src/commands/daemon/control.ts
@@ -9,6 +9,10 @@ import path from "node:path";
 import { readOption } from "../../cli/parse-options.ts";
 import { requestLocalDaemonJsonRpc, resolveLocalDaemonTarget } from "../../daemon/client.ts";
 import type { DaemonLaunchConfiguration } from "../../daemon/daemon-launch-spec.ts";
+import {
+  stopDaemonReplacement,
+  type DaemonReplacementStopRuntime
+} from "./replacement-cleanup.ts";
 
 export type DaemonControlKind = "restart" | "refresh";
 type DaemonRefreshTrigger = "explicit" | "post-merge" | "dist-watcher";
@@ -53,6 +57,7 @@ type DaemonLifecycleStatus = {
   readonly loadedIdentity?: string;
   readonly installedIdentity?: string;
   readonly operationCleared?: true;
+  readonly activeOperationId?: string;
 };
 
 class DaemonRefreshWrongCheckoutError extends Error {
@@ -181,10 +186,10 @@ async function completeDaemonReplacement(
   if (typeof beforeLoadedIdentity !== "string" || typeof operationId !== "string") {
     throw new Error(`${method} accepted receipt did not identify the loaded build and operation`);
   }
-  const handoff = await waitForDaemonControlHandoff(lifecycle, beforePid, timeoutMs);
+  const handoff = await waitForDaemonControlHandoff(lifecycle, beforePid, operationId, timeoutMs);
   if (handoff.kind === "adopt") return handoff.status;
   if (handoff.kind === "reject") {
-    await rejectIncompleteReplacement(lifecycle, handoff.status, beforePid, timeoutMs, kind);
+    await rejectIncompleteReplacement(lifecycle, handoff.status, beforePid, operationId, timeoutMs, kind);
   }
   let replacement: Record<string, unknown>;
   try {
@@ -199,29 +204,85 @@ async function completeDaemonReplacement(
   if (!replacementLifecycle) {
     throw new Error(`daemon ${kind} replacement did not return a reachable started daemon status`);
   }
-  if (!isCompleteReplacement(replacementLifecycle, beforePid)) {
-    await rejectIncompleteReplacement(lifecycle, replacementLifecycle, beforePid, timeoutMs, kind);
+  if (replacementLifecycle.pid === beforePid) {
+    throw new Error(`daemon ${kind} replacement PID did not change: ${String(replacementLifecycle.pid)}; replacement was not signaled`);
   }
-  return replacement;
+  return await waitForStartedReplacement(
+    lifecycle,
+    replacement,
+    replacementLifecycle,
+    beforePid,
+    operationId,
+    timeoutMs,
+    kind
+  );
+}
+
+async function waitForStartedReplacement(
+  lifecycle: DaemonControlLifecycle,
+  initialStatus: Record<string, unknown>,
+  initialLifecycle: DaemonLifecycleStatus,
+  beforePid: number,
+  operationId: string,
+  timeoutMs: number,
+  kind: DaemonControlKind
+): Promise<Record<string, unknown>> {
+  let status = initialStatus;
+  let replacement = initialLifecycle;
+  const pollIntervalMs = 100;
+  const attempts = Math.ceil(timeoutMs / pollIntervalMs) + 1;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (replacement.pid === beforePid) {
+      throw new Error(`daemon ${kind} replacement PID did not change: ${String(replacement.pid)}; replacement was not signaled`);
+    }
+    if (replacementIdentityIsInvalid(replacement)) {
+      await rejectIncompleteReplacement(lifecycle, replacement, beforePid, operationId, timeoutMs, kind);
+    }
+    if (isCompleteReplacement(replacement, beforePid, operationId)) return status;
+    if (attempt + 1 < attempts) {
+      await lifecycle.wait(pollIntervalMs);
+      const observed = await lifecycle.probeStatus(lifecycle.target);
+      const observedLifecycle = observed ? normalizeDaemonLifecycleStatus(observed) : undefined;
+      if (observed && observedLifecycle) {
+        status = observed;
+        replacement = observedLifecycle;
+      }
+      continue;
+    }
+  }
+  if (replacement.activeOperationId && replacement.activeOperationId !== operationId) {
+    throw new Error(
+      `daemon ${kind} replacement remained healthy but another daemon control operation remained active: `
+      + `${replacement.activeOperationId}; replacement was left running`
+    );
+  }
+  return await rejectIncompleteReplacement(lifecycle, replacement, beforePid, operationId, timeoutMs, kind);
 }
 
 async function rejectIncompleteReplacement(
   lifecycle: DaemonControlLifecycle,
   replacement: DaemonLifecycleStatus,
   beforePid: number,
+  operationId: string,
   timeoutMs: number,
   kind: DaemonControlKind
 ): Promise<never> {
-  const failure = incompleteReplacementReason(replacement, beforePid);
+  const failure = incompleteReplacementReason(replacement, beforePid, operationId);
+  if (replacement.pid === beforePid) {
+    throw new Error(`daemon ${kind} replacement ${failure}; replacement was not signaled`);
+  }
+  if (!lifecycle.stopReplacement) {
+    throw new Error(`daemon ${kind} replacement ${failure}; cleanup unavailable; replacement may still be serving`);
+  }
   try {
-    if (!lifecycle.stopReplacement) throw new Error("replacement cleanup is unavailable");
     await lifecycle.stopReplacement(lifecycle.target, replacement.pid, timeoutMs);
   } catch (error) {
     throw new Error(
-      `daemon ${kind} replacement ${failure}; cleanup failed: ${error instanceof Error ? error.message : String(error)}`
+      `daemon ${kind} replacement ${failure}; cleanup failed and replacement may still be serving: `
+      + `${error instanceof Error ? error.message : String(error)}`
     );
   }
-  throw new Error(`daemon ${kind} replacement ${failure}; the rejected replacement was stopped`);
+  throw new Error(`daemon ${kind} replacement ${failure}; rejected replacement was stopped and endpoint remained unowned`);
 }
 
 function defaultDaemonControlLifecycle(input: DaemonControlCommandInput): DaemonControlLifecycle {
@@ -251,7 +312,12 @@ function defaultDaemonControlLifecycle(input: DaemonControlCommandInput): Daemon
       timeoutMs,
       launchConfiguration
     ),
-    stopReplacement: stopDaemonReplacement,
+    stopReplacement: (candidate, pid, timeoutMs) => stopDaemonReplacement(
+      candidate,
+      pid,
+      timeoutMs,
+      defaultDaemonReplacementStopRuntime()
+    ),
     wait: (ms) => new Promise((resolve) => setTimeout(resolve, ms))
   };
 }
@@ -275,10 +341,12 @@ function daemonLaunchSpecUpgradeError(target: LocalDaemonTarget): Error {
 async function waitForDaemonControlHandoff(
   lifecycle: DaemonControlLifecycle,
   beforePid: number,
+  operationId: string,
   timeoutMs: number
 ): Promise<DaemonControlHandoff> {
   const pollIntervalMs = 100;
   const attempts = Math.ceil(timeoutMs / pollIntervalMs) + 1;
+  let pendingReplacement: DaemonLifecycleStatus | undefined;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     const status = await lifecycle.probeStatus(lifecycle.target);
     const ownerAlive = lifecycle.ownerIsAlive(beforePid);
@@ -290,17 +358,27 @@ async function waitForDaemonControlHandoff(
       // that permits the existing autostart primitive to run.
       if (!status) return { kind: "autostart" };
       const observedLifecycle = normalizeDaemonLifecycleStatus(status);
-      if (observedLifecycle && isCompleteReplacement(observedLifecycle, beforePid)) {
+      if (observedLifecycle && isCompleteReplacement(observedLifecycle, beforePid, operationId)) {
         return { kind: "adopt", status };
       }
-      if (observedLifecycle && observedLifecycle.pid !== beforePid) {
+      if (observedLifecycle && observedLifecycle.pid !== beforePid && replacementIdentityIsInvalid(observedLifecycle)) {
         return { kind: "reject", status: observedLifecycle };
       }
+      if (observedLifecycle?.pid !== beforePid) pendingReplacement = observedLifecycle;
       // Reachable old-PID or malformed status is not replacement proof and
       // blocks autostart, avoiding an overlapping service-owner window.
     }
 
     if (attempt + 1 === attempts) {
+      if (pendingReplacement) {
+        if (pendingReplacement.activeOperationId && pendingReplacement.activeOperationId !== operationId) {
+          throw new Error(
+            `another daemon control operation remained active: ${pendingReplacement.activeOperationId}; `
+            + "replacement was left running"
+          );
+        }
+        return { kind: "reject", status: pendingReplacement };
+      }
       if (status) {
         throw new Error(`old daemon endpoint was not released before timeout (pid ${beforePid})`);
       }
@@ -319,31 +397,43 @@ function normalizeDaemonLifecycleStatus(
   if (lifecycle?.started !== true || !isPositivePid(lifecycle.pid)) return undefined;
   if (!isV2) return { schema: "daemon-status/v1", started: true, pid: lifecycle.pid };
   const build = isDaemonControlRecord(lifecycle.build) ? lifecycle.build : {};
+  const activeControl = isDaemonControlRecord(lifecycle.activeControl) ? lifecycle.activeControl : undefined;
   return {
     schema: "daemon-status/v2",
     started: true,
     pid: lifecycle.pid,
     ...(typeof build.loadedIdentity === "string" ? { loadedIdentity: build.loadedIdentity } : {}),
     ...(typeof build.installedIdentity === "string" ? { installedIdentity: build.installedIdentity } : {}),
-    ...(lifecycle.activeControl === null ? { operationCleared: true as const } : {})
+    ...(lifecycle.activeControl === null ? { operationCleared: true as const } : {}),
+    ...(typeof activeControl?.operationId === "string" ? { activeOperationId: activeControl.operationId } : {})
   };
 }
 
 function isCompleteReplacement(
   status: NonNullable<ReturnType<typeof normalizeDaemonLifecycleStatus>>,
-  beforePid: number
+  beforePid: number,
+  operationId: string
 ): boolean {
   if (status.pid === beforePid) return false;
   if (status.schema === "daemon-status/v1") return false;
   return typeof status.loadedIdentity === "string"
     && typeof status.installedIdentity === "string"
     && status.loadedIdentity === status.installedIdentity
-    && status.operationCleared === true;
+    && status.operationCleared === true
+    && status.activeOperationId !== operationId;
+}
+
+function replacementIdentityIsInvalid(status: DaemonLifecycleStatus): boolean {
+  return status.schema === "daemon-status/v1"
+    || typeof status.loadedIdentity !== "string"
+    || typeof status.installedIdentity !== "string"
+    || status.loadedIdentity !== status.installedIdentity;
 }
 
 function incompleteReplacementReason(
   status: NonNullable<ReturnType<typeof normalizeDaemonLifecycleStatus>>,
-  beforePid: number
+  beforePid: number,
+  operationId: string
 ): string {
   if (status.pid === beforePid) return `PID did not change: ${String(status.pid)}`;
   if (status.schema === "daemon-status/v1") return "did not expose daemon-status/v2 replacement criteria";
@@ -353,7 +443,8 @@ function incompleteReplacementReason(
   if (status.loadedIdentity !== status.installedIdentity) {
     return `loaded identity did not converge on the installed identity: loaded=${status.loadedIdentity} installed=${status.installedIdentity}`;
   }
-  if (status.operationCleared !== true) return "did not clear the accepted control operation";
+  if (status.activeOperationId === operationId) return `did not clear the accepted control operation ${operationId}`;
+  if (status.operationCleared !== true) return "did not expose a cleared control operation state";
   return "did not satisfy replacement criteria";
 }
 
@@ -395,23 +486,15 @@ async function startDaemonReplacement(
   return status;
 }
 
-async function stopDaemonReplacement(
-  _target: LocalDaemonTarget,
-  pid: number,
-  timeoutMs: number
-): Promise<void> {
-  try {
-    process.kill(pid, "SIGTERM");
-  } catch (error) {
-    if (isDaemonControlErrorCode(error, "ESRCH")) return;
-    throw error;
-  }
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() <= deadline) {
-    if (!daemonProcessIsAlive(pid)) return;
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-  throw new Error(`replacement process did not exit before timeout (pid ${pid})`);
+function defaultDaemonReplacementStopRuntime(): DaemonReplacementStopRuntime {
+  return {
+    probeStatus: probeExactDaemonStatus,
+    statusPid: (status) => normalizeDaemonLifecycleStatus(status)?.pid,
+    processIsAlive: daemonProcessIsAlive,
+    signal: (pid, signal) => process.kill(pid, signal),
+    wait: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    endpointStabilityMs: 10_500
+  };
 }
 
 function daemonReplacementLaunchConfiguration(value: unknown): DaemonLaunchConfiguration {
@@ -475,10 +558,6 @@ function daemonProcessIsAlive(pid: number): boolean {
   } catch (error) {
     return !(isDaemonControlRecord(error) && error.code === "ESRCH");
   }
-}
-
-function isDaemonControlErrorCode(error: unknown, code: string): boolean {
-  return isDaemonControlRecord(error) && error.code === code;
 }
 
 function isPositivePid(value: unknown): value is number {

--- a/packages/cli/src/commands/daemon/control.ts
+++ b/packages/cli/src/commands/daemon/control.ts
@@ -28,6 +28,7 @@ export interface DaemonControlLifecycle {
     timeoutMs: number,
     launchConfiguration: DaemonLaunchConfiguration
   ) => Promise<Record<string, unknown>>;
+  readonly stopReplacement?: (target: LocalDaemonTarget, pid: number, timeoutMs: number) => Promise<void>;
   readonly wait: (ms: number) => Promise<void>;
 }
 
@@ -42,7 +43,17 @@ export interface DaemonControlCommandInput {
 
 type DaemonControlHandoff =
   | { readonly kind: "adopt"; readonly status: Record<string, unknown> }
+  | { readonly kind: "reject"; readonly status: DaemonLifecycleStatus }
   | { readonly kind: "autostart" };
+
+type DaemonLifecycleStatus = {
+  readonly schema: "daemon-status/v1" | "daemon-status/v2";
+  readonly started: true;
+  readonly pid: number;
+  readonly loadedIdentity?: string;
+  readonly installedIdentity?: string;
+  readonly operationCleared?: true;
+};
 
 class DaemonRefreshWrongCheckoutError extends Error {
   constructor() {
@@ -170,8 +181,11 @@ async function completeDaemonReplacement(
   if (typeof beforeLoadedIdentity !== "string" || typeof operationId !== "string") {
     throw new Error(`${method} accepted receipt did not identify the loaded build and operation`);
   }
-  const handoff = await waitForDaemonControlHandoff(lifecycle, beforePid, beforeLoadedIdentity, operationId, timeoutMs);
+  const handoff = await waitForDaemonControlHandoff(lifecycle, beforePid, timeoutMs);
   if (handoff.kind === "adopt") return handoff.status;
+  if (handoff.kind === "reject") {
+    await rejectIncompleteReplacement(lifecycle, handoff.status, beforePid, timeoutMs, kind);
+  }
   let replacement: Record<string, unknown>;
   try {
     replacement = await lifecycle.startReplacement(lifecycle.target, timeoutMs, launchConfiguration);
@@ -185,13 +199,29 @@ async function completeDaemonReplacement(
   if (!replacementLifecycle) {
     throw new Error(`daemon ${kind} replacement did not return a reachable started daemon status`);
   }
-  if (replacementLifecycle.pid === beforePid) {
-    throw new Error(`daemon ${kind} replacement PID did not change: ${String(replacementLifecycle.pid)}`);
-  }
-  if (!isCompleteReplacement(replacementLifecycle, beforePid, beforeLoadedIdentity, operationId)) {
-    throw new Error(`daemon ${kind} replacement did not satisfy new PID, new loaded identity, and cleared operation criteria`);
+  if (!isCompleteReplacement(replacementLifecycle, beforePid)) {
+    await rejectIncompleteReplacement(lifecycle, replacementLifecycle, beforePid, timeoutMs, kind);
   }
   return replacement;
+}
+
+async function rejectIncompleteReplacement(
+  lifecycle: DaemonControlLifecycle,
+  replacement: DaemonLifecycleStatus,
+  beforePid: number,
+  timeoutMs: number,
+  kind: DaemonControlKind
+): Promise<never> {
+  const failure = incompleteReplacementReason(replacement, beforePid);
+  try {
+    if (!lifecycle.stopReplacement) throw new Error("replacement cleanup is unavailable");
+    await lifecycle.stopReplacement(lifecycle.target, replacement.pid, timeoutMs);
+  } catch (error) {
+    throw new Error(
+      `daemon ${kind} replacement ${failure}; cleanup failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  throw new Error(`daemon ${kind} replacement ${failure}; the rejected replacement was stopped`);
 }
 
 function defaultDaemonControlLifecycle(input: DaemonControlCommandInput): DaemonControlLifecycle {
@@ -221,6 +251,7 @@ function defaultDaemonControlLifecycle(input: DaemonControlCommandInput): Daemon
       timeoutMs,
       launchConfiguration
     ),
+    stopReplacement: stopDaemonReplacement,
     wait: (ms) => new Promise((resolve) => setTimeout(resolve, ms))
   };
 }
@@ -244,8 +275,6 @@ function daemonLaunchSpecUpgradeError(target: LocalDaemonTarget): Error {
 async function waitForDaemonControlHandoff(
   lifecycle: DaemonControlLifecycle,
   beforePid: number,
-  beforeLoadedIdentity: string,
-  operationId: string,
   timeoutMs: number
 ): Promise<DaemonControlHandoff> {
   const pollIntervalMs = 100;
@@ -261,8 +290,11 @@ async function waitForDaemonControlHandoff(
       // that permits the existing autostart primitive to run.
       if (!status) return { kind: "autostart" };
       const observedLifecycle = normalizeDaemonLifecycleStatus(status);
-      if (observedLifecycle && isCompleteReplacement(observedLifecycle, beforePid, beforeLoadedIdentity, operationId)) {
+      if (observedLifecycle && isCompleteReplacement(observedLifecycle, beforePid)) {
         return { kind: "adopt", status };
+      }
+      if (observedLifecycle && observedLifecycle.pid !== beforePid) {
+        return { kind: "reject", status: observedLifecycle };
       }
       // Reachable old-PID or malformed status is not replacement proof and
       // blocks autostart, avoiding an overlapping service-owner window.
@@ -281,39 +313,48 @@ async function waitForDaemonControlHandoff(
 
 function normalizeDaemonLifecycleStatus(
   status: Record<string, unknown>
-): {
-  readonly schema: "daemon-status/v1" | "daemon-status/v2";
-  readonly started: true;
-  readonly pid: number;
-  readonly loadedIdentity?: string;
-  readonly activeOperationId?: string;
-} | undefined {
+): DaemonLifecycleStatus | undefined {
   const isV2 = status.schema === "daemon-status/v2";
   const lifecycle = isV2 ? (isDaemonControlRecord(status.service) ? status.service : undefined) : status.schema === "daemon-status/v1" ? status : undefined;
   if (lifecycle?.started !== true || !isPositivePid(lifecycle.pid)) return undefined;
   if (!isV2) return { schema: "daemon-status/v1", started: true, pid: lifecycle.pid };
   const build = isDaemonControlRecord(lifecycle.build) ? lifecycle.build : {};
-  const activeControl = isDaemonControlRecord(lifecycle.activeControl) ? lifecycle.activeControl : undefined;
   return {
     schema: "daemon-status/v2",
     started: true,
     pid: lifecycle.pid,
     ...(typeof build.loadedIdentity === "string" ? { loadedIdentity: build.loadedIdentity } : {}),
-    ...(typeof activeControl?.operationId === "string" ? { activeOperationId: activeControl.operationId } : {})
+    ...(typeof build.installedIdentity === "string" ? { installedIdentity: build.installedIdentity } : {}),
+    ...(lifecycle.activeControl === null ? { operationCleared: true as const } : {})
   };
 }
 
 function isCompleteReplacement(
   status: NonNullable<ReturnType<typeof normalizeDaemonLifecycleStatus>>,
-  beforePid: number,
-  beforeLoadedIdentity: string,
-  operationId: string
+  beforePid: number
 ): boolean {
   if (status.pid === beforePid) return false;
-  if (status.schema === "daemon-status/v1") return true;
+  if (status.schema === "daemon-status/v1") return false;
   return typeof status.loadedIdentity === "string"
-    && status.loadedIdentity !== beforeLoadedIdentity
-    && status.activeOperationId !== operationId;
+    && typeof status.installedIdentity === "string"
+    && status.loadedIdentity === status.installedIdentity
+    && status.operationCleared === true;
+}
+
+function incompleteReplacementReason(
+  status: NonNullable<ReturnType<typeof normalizeDaemonLifecycleStatus>>,
+  beforePid: number
+): string {
+  if (status.pid === beforePid) return `PID did not change: ${String(status.pid)}`;
+  if (status.schema === "daemon-status/v1") return "did not expose daemon-status/v2 replacement criteria";
+  if (typeof status.loadedIdentity !== "string" || typeof status.installedIdentity !== "string") {
+    return "did not expose loaded and installed identities";
+  }
+  if (status.loadedIdentity !== status.installedIdentity) {
+    return `loaded identity did not converge on the installed identity: loaded=${status.loadedIdentity} installed=${status.installedIdentity}`;
+  }
+  if (status.operationCleared !== true) return "did not clear the accepted control operation";
+  return "did not satisfy replacement criteria";
 }
 
 async function probeExactDaemonStatus(target: LocalDaemonTarget): Promise<Record<string, unknown> | undefined> {
@@ -352,6 +393,25 @@ async function startDaemonReplacement(
   const status = statusFromReceipt(receipt);
   if (!status) throw new Error("replacement status RPC did not return daemon status data");
   return status;
+}
+
+async function stopDaemonReplacement(
+  _target: LocalDaemonTarget,
+  pid: number,
+  timeoutMs: number
+): Promise<void> {
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch (error) {
+    if (isDaemonControlErrorCode(error, "ESRCH")) return;
+    throw error;
+  }
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (!daemonProcessIsAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`replacement process did not exit before timeout (pid ${pid})`);
 }
 
 function daemonReplacementLaunchConfiguration(value: unknown): DaemonLaunchConfiguration {
@@ -415,6 +475,10 @@ function daemonProcessIsAlive(pid: number): boolean {
   } catch (error) {
     return !(isDaemonControlRecord(error) && error.code === "ESRCH");
   }
+}
+
+function isDaemonControlErrorCode(error: unknown, code: string): boolean {
+  return isDaemonControlRecord(error) && error.code === code;
 }
 
 function isPositivePid(value: unknown): value is number {

--- a/packages/cli/src/commands/daemon/replacement-cleanup.ts
+++ b/packages/cli/src/commands/daemon/replacement-cleanup.ts
@@ -1,0 +1,108 @@
+import type { LocalDaemonTarget } from "../../../../daemon/src/index.ts";
+
+export interface DaemonReplacementStopRuntime {
+  readonly probeStatus: (target: LocalDaemonTarget) => Promise<Record<string, unknown> | undefined>;
+  readonly statusPid: (status: Record<string, unknown>) => number | undefined;
+  readonly processIsAlive: (pid: number) => boolean;
+  readonly signal: (pid: number, signal: NodeJS.Signals) => void;
+  readonly wait: (ms: number) => Promise<void>;
+  readonly endpointStabilityMs?: number;
+}
+
+export async function stopDaemonReplacement(
+  target: LocalDaemonTarget,
+  pid: number,
+  timeoutMs: number,
+  runtime: DaemonReplacementStopRuntime
+): Promise<void> {
+  if (!runtime.processIsAlive(pid)) {
+    await verifyEndpointRemainsUnowned(target, runtime);
+    return;
+  }
+  if (!await targetEndpointIsOwnedBy(target, pid, runtime)) {
+    await verifyEndpointRemainsUnowned(target, runtime);
+    return;
+  }
+  try {
+    runtime.signal(pid, "SIGTERM");
+  } catch (error) {
+    if (replacementSignalErrorCode(error) === "ESRCH") {
+      await verifyEndpointRemainsUnowned(target, runtime);
+      return;
+    }
+    throw error;
+  }
+  const pollIntervalMs = 100;
+  const termAttempts = Math.ceil(Math.max(1, Math.floor(timeoutMs / 2)) / pollIntervalMs) + 1;
+  if (!await waitForReplacementExit(pid, termAttempts, pollIntervalMs, runtime)) {
+    if (!await targetEndpointIsOwnedBy(target, pid, runtime)) {
+      await verifyEndpointRemainsUnowned(target, runtime);
+      return;
+    }
+    try {
+      runtime.signal(pid, "SIGKILL");
+    } catch (error) {
+      if (replacementSignalErrorCode(error) !== "ESRCH") throw error;
+    }
+    const killAttempts = Math.ceil(Math.max(1, timeoutMs - Math.floor(timeoutMs / 2)) / pollIntervalMs) + 1;
+    if (!await waitForReplacementExit(pid, killAttempts, pollIntervalMs, runtime)) {
+      throw new Error(`SIGTERM and SIGKILL did not stop replacement pid ${pid}`);
+    }
+  }
+  await verifyEndpointRemainsUnowned(target, runtime);
+}
+
+async function targetEndpointIsOwnedBy(
+  target: LocalDaemonTarget,
+  pid: number,
+  runtime: DaemonReplacementStopRuntime
+): Promise<boolean> {
+  const status = await runtime.probeStatus(target);
+  const observedPid = status ? runtime.statusPid(status) : undefined;
+  if (observedPid === pid) return true;
+  if (!runtime.processIsAlive(pid)) return false;
+  if (observedPid !== undefined) {
+    throw new Error(`target endpoint reports pid ${observedPid}; refusing to signal pid ${pid}`);
+  }
+  throw new Error(`target endpoint does not prove ownership by pid ${pid}; refusing to signal it`);
+}
+
+async function waitForReplacementExit(
+  pid: number,
+  attempts: number,
+  pollIntervalMs: number,
+  runtime: DaemonReplacementStopRuntime
+): Promise<boolean> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (!runtime.processIsAlive(pid)) return true;
+    if (attempt + 1 < attempts) await runtime.wait(pollIntervalMs);
+  }
+  return false;
+}
+
+async function verifyEndpointRemainsUnowned(
+  target: LocalDaemonTarget,
+  runtime: DaemonReplacementStopRuntime
+): Promise<void> {
+  const stabilityMs = runtime.endpointStabilityMs ?? 500;
+  const pollIntervalMs = 100;
+  const attempts = Math.ceil(stabilityMs / pollIntervalMs) + 1;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const status = await runtime.probeStatus(target);
+    if (status) {
+      const observedPid = runtime.statusPid(status);
+      throw new Error(
+        observedPid === undefined
+          ? "target endpoint remained reachable with an unrecognized daemon status"
+          : `target endpoint became reachable again with pid ${observedPid}`
+      );
+    }
+    if (attempt + 1 < attempts) await runtime.wait(pollIntervalMs);
+  }
+}
+
+function replacementSignalErrorCode(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error
+    ? (error as { readonly code?: unknown }).code
+    : undefined;
+}

--- a/packages/cli/test/daemon-control-dispatcher.test.ts
+++ b/packages/cli/test/daemon-control-dispatcher.test.ts
@@ -190,8 +190,109 @@ test("daemon control adopts a v2 replacement already exposed by the service supe
   });
 });
 
-test("daemon control retains v1 top-level status compatibility for supervisor replacement", async () => {
+test("refresh accepts a healthy no-delta replacement converged on the installed identity", async () => {
+  const identity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const lifecycle = {
+    target: controlTarget,
+    probeStatus: async () => undefined,
+    ownerIsAlive: () => false,
+    startReplacement: async () => v2DaemonStatus(84, identity, identity),
+    wait: async () => undefined
+  } satisfies DaemonControlLifecycle;
+
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, [], "refresh");
+
+  assert.equal(exitCode, 0, JSON.stringify(receipt));
+});
+
+test("restart accepts a healthy same-version replacement converged on the installed identity", async () => {
+  const identity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const lifecycle = {
+    target: controlTarget,
+    probeStatus: async () => undefined,
+    ownerIsAlive: () => false,
+    startReplacement: async () => v2DaemonStatus(84, identity, identity),
+    wait: async () => undefined
+  } satisfies DaemonControlLifecycle;
+
+  const { exitCode, receipt } = await runCapturedControl(lifecycle);
+
+  assert.equal(exitCode, 0, JSON.stringify(receipt));
+});
+
+test("refresh accepts a healthy delta replacement loaded from the new installed identity", async () => {
+  const lifecycle = {
+    target: controlTarget,
+    probeStatus: async () => undefined,
+    ownerIsAlive: () => false,
+    startReplacement: async () => v2DaemonStatus(84),
+    wait: async () => undefined
+  } satisfies DaemonControlLifecycle;
+
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, [], "refresh");
+
+  assert.equal(exitCode, 0, JSON.stringify(receipt));
+  const replacement = receipt.replacement as Record<string, unknown>;
+  const service = replacement.service as Record<string, unknown>;
+  const build = service.build as Record<string, unknown>;
+  assert.equal(build.loadedIdentity, "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+  assert.equal(build.loadedIdentity, build.installedIdentity);
+});
+
+test("refresh rejects and cleans up a replacement that loaded an old identity", async () => {
+  const stoppedPids: number[] = [];
+  const lifecycle = {
+    target: controlTarget,
+    probeStatus: async () => undefined,
+    ownerIsAlive: () => false,
+    startReplacement: async () => v2DaemonStatus(
+      84,
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    ),
+    stopReplacement: async (_target: typeof controlTarget, pid: number) => {
+      stoppedPids.push(pid);
+    },
+    wait: async () => undefined
+  } satisfies DaemonControlLifecycle;
+
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, [], "refresh");
+
+  assert.equal(exitCode, 1);
+  assert.deepEqual(stoppedPids, [84]);
+  assert.match(controlErrorHint(receipt), /loaded identity did not converge on the installed identity/u);
+});
+
+test("refresh rejects and cleans up a replacement that retains the accepted operation", async () => {
+  const stoppedPids: number[] = [];
+  const status = v2DaemonStatus(84);
+  (status.service as Record<string, unknown>).activeControl = {
+    operationId: "control-refresh",
+    kind: "refresh",
+    phase: "replacing",
+    requestedAt: "2026-07-20T12:00:00.000Z"
+  };
+  const lifecycle = {
+    target: controlTarget,
+    probeStatus: async () => undefined,
+    ownerIsAlive: () => false,
+    startReplacement: async () => status,
+    stopReplacement: async (_target: typeof controlTarget, pid: number) => {
+      stoppedPids.push(pid);
+    },
+    wait: async () => undefined
+  } satisfies DaemonControlLifecycle;
+
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, [], "refresh");
+
+  assert.equal(exitCode, 1);
+  assert.deepEqual(stoppedPids, [84]);
+  assert.match(controlErrorHint(receipt), /did not clear the accepted control operation/u);
+});
+
+test("daemon control rejects and cleans up v1 supervisor status that cannot prove replacement convergence", async () => {
   let replacementStarts = 0;
+  const stoppedPids: number[] = [];
   const lifecycle = {
     target: controlTarget,
     probeStatus: async () => ({ schema: "daemon-status/v1", started: true, pid: 84 }),
@@ -200,14 +301,18 @@ test("daemon control retains v1 top-level status compatibility for supervisor re
       replacementStarts += 1;
       return v2DaemonStatus(85);
     },
+    stopReplacement: async (_target: typeof controlTarget, pid: number) => {
+      stoppedPids.push(pid);
+    },
     wait: async () => undefined
   } satisfies DaemonControlLifecycle;
 
-  const { exitCode, receipt } = await runCapturedControl(lifecycle);
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, ["--timeout-ms", "100"]);
 
-  assert.equal(exitCode, 0);
+  assert.equal(exitCode, 1);
   assert.equal(replacementStarts, 0);
-  assert.equal((receipt.replacement as Record<string, unknown>).pid, 84);
+  assert.deepEqual(stoppedPids, [84]);
+  assert.match(controlErrorHint(receipt), /did not expose daemon-status\/v2 replacement criteria/u);
 });
 
 test("accepted control does not adopt a reachable new endpoint while the old owner remains alive", async () => {
@@ -447,7 +552,8 @@ test("daemon help exposes logs, restart, refresh, and refresh trigger selection"
 
 async function runCapturedControl(
   daemonControlLifecycle: DaemonControlLifecycle,
-  extraArgs: ReadonlyArray<string> = []
+  extraArgs: ReadonlyArray<string> = [],
+  kind: "restart" | "refresh" = "restart"
 ): Promise<{ readonly exitCode: number; readonly receipt: Record<string, unknown> }> {
   const output: string[] = [];
   const originalLog = console.log;
@@ -456,13 +562,13 @@ async function runCapturedControl(
     const exitCode = await runDaemonProductCommand({
       rootDir: "/repo",
       json: true,
-      args: ["daemon", "restart", ...extraArgs],
+      args: ["daemon", kind, ...extraArgs],
       runServe: async () => undefined,
       requestDaemonControl: async () => ({
         schema: "daemon-control-accepted/v1",
         accepted: true,
-        operationId: "control-restart",
-        kind: "restart",
+        operationId: `control-${kind}`,
+        kind,
         before: {
           pid: 42,
           loadedIdentity: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -487,13 +593,17 @@ function controlErrorHint(receipt: Record<string, unknown>): string {
     : "";
 }
 
-function v2DaemonStatus(pid: number): Record<string, unknown> {
+function v2DaemonStatus(
+  pid: number,
+  loadedIdentity = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  installedIdentity = loadedIdentity
+): Record<string, unknown> {
   return {
     schema: "daemon-status/v2",
     service: {
       started: true,
       pid,
-      build: { loadedIdentity: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+      build: { loadedIdentity, installedIdentity },
       activeControl: null
     }
   };

--- a/packages/cli/test/daemon-control-dispatcher.test.ts
+++ b/packages/cli/test/daemon-control-dispatcher.test.ts
@@ -261,6 +261,7 @@ test("refresh rejects and cleans up a replacement that loaded an old identity", 
   assert.equal(exitCode, 1);
   assert.deepEqual(stoppedPids, [84]);
   assert.match(controlErrorHint(receipt), /loaded identity did not converge on the installed identity/u);
+  assert.match(controlErrorHint(receipt), /stopped and endpoint remained unowned$/u);
 });
 
 test("refresh rejects and cleans up a replacement that retains the accepted operation", async () => {
@@ -274,7 +275,7 @@ test("refresh rejects and cleans up a replacement that retains the accepted oper
   };
   const lifecycle = {
     target: controlTarget,
-    probeStatus: async () => undefined,
+    probeStatus: async () => status,
     ownerIsAlive: () => false,
     startReplacement: async () => status,
     stopReplacement: async (_target: typeof controlTarget, pid: number) => {
@@ -288,6 +289,50 @@ test("refresh rejects and cleans up a replacement that retains the accepted oper
   assert.equal(exitCode, 1);
   assert.deepEqual(stoppedPids, [84]);
   assert.match(controlErrorHint(receipt), /did not clear the accepted control operation/u);
+});
+
+test("refresh reports cleanup unavailable separately from a replacement that was stopped", async () => {
+  const lifecycle = {
+    target: controlTarget,
+    probeStatus: async () => undefined,
+    ownerIsAlive: () => false,
+    startReplacement: async () => v2DaemonStatus(
+      84,
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    ),
+    wait: async () => undefined
+  } satisfies DaemonControlLifecycle;
+
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, [], "refresh");
+
+  assert.equal(exitCode, 1);
+  assert.match(controlErrorHint(receipt), /cleanup unavailable; replacement may still be serving$/u);
+  assert.doesNotMatch(controlErrorHint(receipt), /was stopped/u);
+});
+
+test("refresh reports a SIGTERM timeout cleanup failure as possibly still serving", async () => {
+  const lifecycle = {
+    target: controlTarget,
+    probeStatus: async () => undefined,
+    ownerIsAlive: () => false,
+    startReplacement: async () => v2DaemonStatus(
+      84,
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    ),
+    stopReplacement: async () => {
+      throw new Error("SIGTERM timed out; SIGKILL failed");
+    },
+    wait: async () => undefined
+  } satisfies DaemonControlLifecycle;
+
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, [], "refresh");
+
+  assert.equal(exitCode, 1);
+  assert.match(controlErrorHint(receipt), /cleanup failed and replacement may still be serving: SIGTERM timed out; SIGKILL failed$/u);
+  assert.doesNotMatch(controlErrorHint(receipt), /cleanup unavailable/u);
+  assert.doesNotMatch(controlErrorHint(receipt), /was stopped/u);
 });
 
 test("daemon control rejects and cleans up v1 supervisor status that cannot prove replacement convergence", async () => {
@@ -485,17 +530,22 @@ test("refresh rejects a pre-launch-spec daemon before sending control and leaves
 });
 
 test("daemon control fails when the replacement PID does not change", async () => {
+  const stoppedPids: number[] = [];
   const lifecycle = {
     target: controlTarget,
     probeStatus: async () => undefined,
     ownerIsAlive: () => false,
     startReplacement: async () => v2DaemonStatus(42),
+    stopReplacement: async (_target: typeof controlTarget, pid: number) => {
+      stoppedPids.push(pid);
+    },
     wait: async () => undefined
   } satisfies DaemonControlLifecycle;
 
   const { exitCode, receipt } = await runCapturedControl(lifecycle);
 
   assert.equal(exitCode, 1);
+  assert.deepEqual(stoppedPids, []);
   assert.match(controlErrorHint(receipt), /replacement PID did not change/u);
 });
 
@@ -596,7 +646,8 @@ function controlErrorHint(receipt: Record<string, unknown>): string {
 function v2DaemonStatus(
   pid: number,
   loadedIdentity = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-  installedIdentity = loadedIdentity
+  installedIdentity = loadedIdentity,
+  activeOperationId?: string
 ): Record<string, unknown> {
   return {
     schema: "daemon-status/v2",
@@ -604,7 +655,12 @@ function v2DaemonStatus(
       started: true,
       pid,
       build: { loadedIdentity, installedIdentity },
-      activeControl: null
+      activeControl: activeOperationId ? {
+        operationId: activeOperationId,
+        kind: "refresh",
+        phase: "replacing",
+        requestedAt: "2026-07-20T12:00:00.000Z"
+      } : null
     }
   };
 }

--- a/packages/cli/test/daemon-control-replacement-safety.test.ts
+++ b/packages/cli/test/daemon-control-replacement-safety.test.ts
@@ -1,0 +1,289 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  runDaemonProductCommand,
+  type DaemonControlLifecycle
+} from "../src/commands/daemon/productization.ts";
+import {
+  stopDaemonReplacement,
+  type DaemonReplacementStopRuntime
+} from "../src/commands/daemon/replacement-cleanup.ts";
+
+const controlTarget = {
+  repoId: "canonical",
+  canonicalRoot: "/repo",
+  userRoot: "/user-root",
+  daemonId: "default",
+  socketPath: "/user-root/daemon.sock",
+  legacySocketPath: "/repo/legacy.sock",
+  registered: true
+} as const;
+
+const runningLaunchConfiguration = {
+  execPath: "/usr/bin/node",
+  execArgv: ["--import", "tsx"],
+  entrypoint: "/repo/packages/cli/src/index.ts",
+  args: ["--root", "/repo", "daemon", "serve", "--repo", "canonical", "--socket", controlTarget.socketPath]
+} as const;
+
+test("handoff rejects and cleans up a v2 supervisor replacement loaded from the wrong identity", async () => {
+  const stoppedPids: number[] = [];
+  let replacementStarts = 0;
+  const lifecycle = {
+    target: controlTarget,
+    probeStatus: async () => v2DaemonStatus(
+      84,
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    ),
+    ownerIsAlive: () => false,
+    startReplacement: async () => {
+      replacementStarts += 1;
+      return v2DaemonStatus(85);
+    },
+    stopReplacement: async (_target: typeof controlTarget, pid: number) => {
+      stoppedPids.push(pid);
+    },
+    wait: async () => undefined
+  } satisfies DaemonControlLifecycle;
+
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, [], "refresh");
+
+  assert.equal(exitCode, 1);
+  assert.equal(replacementStarts, 0);
+  assert.deepEqual(stoppedPids, [84]);
+  assert.match(controlErrorHint(receipt), /loaded identity did not converge on the installed identity/u);
+});
+
+test("handoff waits for this operation to clear before adopting the v2 supervisor replacement", async () => {
+  let probes = 0;
+  const lifecycle = {
+    target: controlTarget,
+    probeStatus: async () => {
+      probes += 1;
+      return probes < 3 ? v2DaemonStatus(84, undefined, undefined, "control-refresh") : v2DaemonStatus(84);
+    },
+    ownerIsAlive: () => false,
+    startReplacement: async () => {
+      throw new Error("the supervisor replacement must be adopted");
+    },
+    stopReplacement: async () => {
+      throw new Error("a converging replacement must not be stopped");
+    },
+    wait: async () => undefined
+  } satisfies DaemonControlLifecycle;
+
+  const { exitCode } = await runCapturedControl(lifecycle, ["--timeout-ms", "500"], "refresh");
+
+  assert.equal(exitCode, 0);
+  assert.equal(probes, 3);
+});
+
+test("handoff rejects and cleans up a v2 supervisor replacement that never clears this operation", async () => {
+  let probes = 0;
+  const stoppedPids: number[] = [];
+  const lifecycle = {
+    target: controlTarget,
+    probeStatus: async () => {
+      probes += 1;
+      return v2DaemonStatus(84, undefined, undefined, "control-refresh");
+    },
+    ownerIsAlive: () => false,
+    startReplacement: async () => {
+      throw new Error("an occupied endpoint must not autostart");
+    },
+    stopReplacement: async (_target: typeof controlTarget, pid: number) => {
+      stoppedPids.push(pid);
+    },
+    wait: async () => undefined
+  } satisfies DaemonControlLifecycle;
+
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, ["--timeout-ms", "200"], "refresh");
+
+  assert.equal(exitCode, 1);
+  assert.ok(probes > 1);
+  assert.deepEqual(stoppedPids, [84]);
+  assert.match(controlErrorHint(receipt), /did not clear the accepted control operation control-refresh/u);
+});
+
+test("handoff does not kill a healthy v2 replacement while another operation is active", async () => {
+  let probes = 0;
+  const stoppedPids: number[] = [];
+  const lifecycle = {
+    target: controlTarget,
+    probeStatus: async () => {
+      probes += 1;
+      return v2DaemonStatus(84, undefined, undefined, "control-someone-else");
+    },
+    ownerIsAlive: () => false,
+    startReplacement: async () => {
+      throw new Error("an occupied endpoint must not autostart");
+    },
+    stopReplacement: async (_target: typeof controlTarget, pid: number) => {
+      stoppedPids.push(pid);
+    },
+    wait: async () => undefined
+  } satisfies DaemonControlLifecycle;
+
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, ["--timeout-ms", "200"], "refresh");
+
+  assert.equal(exitCode, 1);
+  assert.ok(probes > 1);
+  assert.deepEqual(stoppedPids, []);
+  assert.match(controlErrorHint(receipt), /another daemon control operation remained active/u);
+  assert.match(controlErrorHint(receipt), /left running/u);
+});
+
+test("replacement cleanup validates target ownership, escalates to SIGKILL, and verifies endpoint quiescence", async () => {
+  const signals: NodeJS.Signals[] = [];
+  let alive = true;
+  const runtime = stopRuntime({
+    probeStatus: async () => alive ? v2DaemonStatus(84) : undefined,
+    processIsAlive: () => alive,
+    signal: (_pid, signal) => {
+      signals.push(signal);
+      if (signal === "SIGKILL") alive = false;
+    }
+  });
+
+  await stopDaemonReplacement(controlTarget, 84, 100, runtime);
+
+  assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
+});
+
+test("replacement cleanup refuses to signal a PID not owned by the target endpoint", async () => {
+  const signals: NodeJS.Signals[] = [];
+  const runtime = stopRuntime({
+    probeStatus: async () => v2DaemonStatus(85),
+    processIsAlive: () => true,
+    signal: (_pid, signal) => signals.push(signal)
+  });
+
+  await assert.rejects(
+    stopDaemonReplacement(controlTarget, 84, 100, runtime),
+    /target endpoint reports pid 85; refusing to signal pid 84/u
+  );
+  assert.deepEqual(signals, []);
+});
+
+test("replacement cleanup revalidates endpoint ownership before SIGKILL after PID reuse", async () => {
+  const signals: NodeJS.Signals[] = [];
+  let ownerPid = 84;
+  const runtime = stopRuntime({
+    probeStatus: async () => v2DaemonStatus(ownerPid),
+    processIsAlive: () => true,
+    signal: (_pid, signal) => {
+      signals.push(signal);
+      if (signal === "SIGTERM") ownerPid = 85;
+    }
+  });
+
+  await assert.rejects(
+    stopDaemonReplacement(controlTarget, 84, 100, runtime),
+    /target endpoint reports pid 85; refusing to signal pid 84/u
+  );
+  assert.deepEqual(signals, ["SIGTERM"]);
+});
+
+test("replacement cleanup detects supervisor resurrection during the endpoint stability window", async () => {
+  const signals: NodeJS.Signals[] = [];
+  let alive = true;
+  let probes = 0;
+  const runtime = stopRuntime({
+    probeStatus: async () => {
+      probes += 1;
+      return probes === 1 ? v2DaemonStatus(84) : v2DaemonStatus(85);
+    },
+    processIsAlive: () => alive,
+    signal: (_pid, signal) => {
+      signals.push(signal);
+      if (signal === "SIGTERM") alive = false;
+    },
+    endpointStabilityMs: 100
+  });
+
+  await assert.rejects(
+    stopDaemonReplacement(controlTarget, 84, 100, runtime),
+    /target endpoint became reachable again with pid 85/u
+  );
+  assert.deepEqual(signals, ["SIGTERM"]);
+});
+
+function stopRuntime(
+  overrides: Pick<DaemonReplacementStopRuntime, "probeStatus" | "processIsAlive" | "signal">
+    & Partial<Pick<DaemonReplacementStopRuntime, "endpointStabilityMs">>
+): DaemonReplacementStopRuntime {
+  return {
+    ...overrides,
+    statusPid: daemonStatusPid,
+    wait: async () => undefined,
+    endpointStabilityMs: overrides.endpointStabilityMs ?? 0
+  };
+}
+
+async function runCapturedControl(
+  daemonControlLifecycle: DaemonControlLifecycle,
+  extraArgs: ReadonlyArray<string>,
+  kind: "restart" | "refresh"
+): Promise<{ readonly exitCode: number; readonly receipt: Record<string, unknown> }> {
+  const output: string[] = [];
+  const originalLog = console.log;
+  console.log = (message?: unknown) => output.push(String(message));
+  try {
+    const exitCode = await runDaemonProductCommand({
+      rootDir: "/repo",
+      json: true,
+      args: ["daemon", kind, ...extraArgs],
+      runServe: async () => undefined,
+      requestDaemonControl: async () => ({
+        schema: "daemon-control-accepted/v1",
+        accepted: true,
+        operationId: `control-${kind}`,
+        kind,
+        before: {
+          pid: 42,
+          loadedIdentity: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          launchConfiguration: runningLaunchConfiguration
+        }
+      }),
+      daemonControlLifecycle
+    });
+    return { exitCode, receipt: JSON.parse(output.at(-1) ?? "") as Record<string, unknown> };
+  } finally {
+    console.log = originalLog;
+  }
+}
+
+function controlErrorHint(receipt: Record<string, unknown>): string {
+  const error = receipt.error;
+  return typeof error === "object" && error !== null && "hint" in error ? String(error.hint) : "";
+}
+
+function daemonStatusPid(status: Record<string, unknown>): number | undefined {
+  const service = status.schema === "daemon-status/v2" ? status.service : status;
+  if (typeof service !== "object" || service === null || !("pid" in service)) return undefined;
+  return typeof service.pid === "number" ? service.pid : undefined;
+}
+
+function v2DaemonStatus(
+  pid: number,
+  loadedIdentity = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  installedIdentity = loadedIdentity,
+  activeOperationId?: string
+): Record<string, unknown> {
+  return {
+    schema: "daemon-status/v2",
+    service: {
+      started: true,
+      pid,
+      build: { loadedIdentity, installedIdentity },
+      activeControl: activeOperationId ? {
+        operationId: activeOperationId,
+        kind: "refresh",
+        phase: "replacing",
+        requestedAt: "2026-07-20T12:00:00.000Z"
+      } : null
+    }
+  };
+}

--- a/packages/cli/test/daemon-refresh-preflight.test.ts
+++ b/packages/cli/test/daemon-refresh-preflight.test.ts
@@ -115,6 +115,8 @@ test("refresh derives the explicit manifest across a mixed registry and leaves a
     const refresh = runRawJsonMaybeFail(fixture.repoRoot, [
       "daemon", "refresh", "--trigger", "post-merge", "--timeout-ms", "10000", "--user-root", userRoot
     ], env);
+    assert.equal(refresh.status, 0, JSON.stringify(refresh.receipt));
+    assert.equal(refresh.receipt.ok, true, JSON.stringify(refresh.receipt));
     const after = await pollUntil(
       () => runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env),
       (status) => status.reachable === true && typeof status.pid === "number" && status.pid !== before.pid,
@@ -123,6 +125,14 @@ test("refresh derives the explicit manifest across a mixed registry and leaves a
     );
     assert.equal(after.reachable, true, JSON.stringify({ refresh, after }));
     assert.notEqual(after.pid, before.pid);
+    const beforeService = before.service as { readonly build: { readonly loadedIdentity: string } };
+    const afterService = after.service as {
+      readonly build: { readonly loadedIdentity: string; readonly installedIdentity: string };
+      readonly activeControl: unknown;
+    };
+    assert.equal(afterService.build.loadedIdentity, afterService.build.installedIdentity);
+    assert.equal(afterService.build.loadedIdentity, beforeService.build.loadedIdentity);
+    assert.equal(afterService.activeControl, null);
     process.kill(after.pid as number, 0);
     console.log(JSON.stringify({ scenario: "derived-manifest-refresh", beforePid: before.pid, afterPid: after.pid, reachable: after.reachable, refresh: refresh.receipt }));
   } finally {


### PR DESCRIPTION
# English

## Summary

W2/L1 of the baseline-governance program, third link of the daemon serial chain: the refresh/restart handover criterion no longer reports false negatives. A healthy replacement was previously rejected with "did not satisfy new PID, new loaded identity, and cleared operation criteria" whenever there was no artifact delta (and on same-version restarts), because the identity subcriterion demanded change (`before !== after`). Every post-merge refresh therefore failed and stacked zombie serves in production. The criterion is now convergence: new PID + `loadedIdentity === installedIdentity` + this operation cleared.

## What Changed

- `packages/cli/src/commands/daemon/control.ts`: replacement completion criterion rewritten from identity-change to identity-convergence; with an artifact delta the convergence form still forces the new identity (strictness preserved). The handover poll adopts a converged external replacement, keeps polling while the replacement carries a different client's operation (instead of instantly rejecting it), and rejects with cleanup only on true non-convergence. A `pid === beforePid` failure reports the original error without triggering cleanup.
- `packages/cli/src/commands/daemon/replacement-cleanup.ts` (new): rejected replacements are stopped safely — the target socket owner is cross-checked before any signal (PID-reuse cannot kill an innocent process), SIGTERM escalates to SIGKILL on timeout, and after exit the endpoint is re-verified for a stability window so a supervisor (launchd KeepAlive) respawn is detected and reported as cleanup failure instead of claimed success. "Stopped", "cleanup unavailable", and "cleanup failed, replacement may still be alive" are distinguishable outcomes.
- Tests: new `daemon-control-replacement-safety.test.ts` (289 lines) covering supervisor respawn, PID reuse refusal, SIGKILL escalation, foreign-operation patience, v2 true negatives on the handoff path, and error-tail disambiguation; dispatcher/preflight suites extended. Positive control: under the old criterion a healthy no-delta replacement demonstrably failed; true negative: a replacement loading a stale identity when a delta exists still fails closed.

## Task And Scope

- Harness task: `task_01KXW9E51ZSHYQBZ18MQBG667A` (W2/L1 serial chain), parent umbrella `task_01KXWZ3YEGXD6302G1656RY801` (PLT-Baseline-Governance), charter `dec_01KXWZ33N9`.
- Branch: `fix/l1-refresh-handover-criteria`
- Public scope: daemon control handover criterion + replacement cleanup + tests.
- Private planning/evidence updated: yes (task package plan/progress/mission/adjudications in private ledger).
- Out of scope: cross-endpoint registry write race (pre-existing, later L1 chain); admission diagnostics and argv family (next L1 chain links).

## Version Impact

- Version: no version change — daemon control correctness fix within existing CLI surface.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: daemon control (refresh/restart handover).
- Authority: baseline-governance charter `dec_01KXWZ33N9`, umbrella L1 wave. No criterion is weakened: all three subcriteria remain enforced; the identity form changes from "changed" to "converged to installed", which is strictly the correct truth-condition and still rejects stale-identity replacements whenever a build delta exists. Cleanup validation is strictly stricter (owner cross-check, respawn detection).
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Follow-up governance task: remaining L1 chain items under the umbrella task.

## Verification

- Base `origin/main` SHA: `a42bf2979924fabbc5521bb46f2180f0ac28949f`
- Branch merge-base with `origin/main`: `a42bf2979924fabbc5521bb46f2180f0ac28949f` (branched from current main; no sync needed)
- Last `git fetch origin` time: 2026-07-20 (this session)
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: task package `task_01KXW9E51ZSHYQBZ18MQBG667A` progress/evidence (private ledger)
- Reviewer evidence path: implementation report `codex-report-l1-refresh-criteria.md` (worker worktree, mirrored into the task package)
- GitHub Actions `rewrite-ci` run URL: this PR's checks
- [x] `npm run check:ci` (all locally runnable manifest-derived jobs green, run by worker after each commit)
- [x] `npm run typecheck` (within check:ci)
- [x] `npm test` (targeted daemon-control suites 30/30; full cli fast tier 306/306 re-run by CEO on the final tree)
- [x] GitHub Actions `rewrite-ci` runs on this PR
- Isolated production-shaped proof: real no-delta refresh in an isolated fixture succeeded (PID 99039 → 99713, `loadedIdentity === installedIdentity`, `activeControl = null`); the live production daemon (pid 28666) was not touched.
- Not run locally: Windows named-pipe hosts and systemd/launchd managers — covered by PR CI environment jobs; launchd respawn behavior covered by injected-supervisor tests.

## Review Evidence

- Self-review: worker report with root-cause forensics (only failing subcriterion was identity-change on a converged healthy replacement), before/after criteria traces, and positive/negative control outputs.
- Reviewer subagent: single-round three-model blind cross-review (Codex native + GLM + Grok, mutually blind) per the umbrella review policy. Adjudicated union: 1 P1 (launchd KeepAlive respawns a rejected replacement, PID-only cleanup claims false success — Codex) and 3 convergent P2 (bare-PID kill without owner verification can hit innocent processes on PID reuse — GLM+Grok; SIGTERM-only cleanup can leave the stacked-serve state the fix claims to eliminate — GLM+Grok; operation-cleared subcriterion ignored the receipt operationId and would kill replacements carrying another client's operation — GLM), plus test/message gaps. All fixed in `4d2e7a98` with dedicated safety tests; re-scan scoped to those findings and verified by CEO in the diff.
- Rejected findings (with reasons): instant-reject race on startup (verified near-zero window: identity is computed before socket bind, activeControl initializes null); worker checkpoint on criteria semantics was escalated and adjudicated by the CEO before implementation.
- Human review: standing authorization (baseline-governance umbrella policy; review-intensity policy per repo owner 2026-07-20).
- Blocking findings: none open.

## Residual Risk

- Cleanup verifies endpoint stability for a bounded window (default ~10.5s aggregate); a supervisor with a longer respawn backoff than the window could still respawn after the receipt — reported as accepted bounded risk in the worker report.
- Pure I/O failures during cleanup are reported distinguishably but cannot be retried automatically; the receipt tells the operator whether a live process may remain.
- Cross-endpoint (same userRoot, different socket) registry write race remains pre-existing, tracked as later L1 chain work.

## References

- Umbrella task plan: `harness/tasks/task_01KXWZ3YEGXD6302G1656RY801-plt-baseline-governance-milestone-root/task_plan.md` (L1 wave row; private ledger)
- Charter: `dec_01KXWZ33N9` (baseline-governance, active)
- Production evidence: post-merge refresh failures + stacked serves after PR #946 and #947 merges (2026-07-20 night, task progress log)
- Prereqs landed: PR #945 (launch-spec v2), PR #947 (registry pointer ordering)

---

# 中文

## 概要

基准治理 W2/L1 串行链第三环：refresh/restart 交接判据不再假阴性。此前只要没有 artifact delta（以及同版本 restart），健康替身就会被 "did not satisfy new PID, new loaded identity, and cleared operation criteria" 误判——identity 子判据错误地要求「变化」（before != after）。于是每次 post-merge refresh 都失败并在生产叠僵尸 serve。判据改为收敛式：新 PID + `loadedIdentity === installedIdentity` + 本次 operation 已清。

## 改动内容

- `packages/cli/src/commands/daemon/control.ts`：完成判据从 identity 变化改为 identity 收敛；有 artifact delta 时收敛式仍强制新 identity（严格性保留）。交接 poll 会 adopt 已收敛的外部替身；替身携带其他客户端 operation 时继续轮询（不再 instant reject 腰斩他人操作）；仅真不收敛才 reject+清理；`pid === beforePid` 失败按原语义报错且不触发清理。
- `packages/cli/src/commands/daemon/replacement-cleanup.ts`（新增）：被拒替身安全停止——发信号前交叉验证 target socket owner（PID 复用不会误杀无辜进程）；SIGTERM 超时升级 SIGKILL；退出后在稳定窗口内复核 endpoint，supervisor（launchd KeepAlive）重生会被识别并如实报 cleanup 失败而非假成功；「已停止」「cleanup 不可用」「可能仍存活」三种终态可区分。
- 测试：新增 `daemon-control-replacement-safety.test.ts`（289 行）覆盖 supervisor 重生、PID 复用拒杀、SIGKILL 升级、他人 operation 耐心等待、handoff 路 v2 真阴性、错误尾部区分；dispatcher/preflight 套件扩充。阳性对照：旧判据下健康无 delta 替身确实失败；真阴性：有 delta 时加载旧 identity 的替身仍 fail closed。

## 任务与范围

- Harness 任务：`task_01KXW9E51ZSHYQBZ18MQBG667A`（W2/L1 串行链），父伞 `task_01KXWZ3YEGXD6302G1656RY801`（PLT-Baseline-Governance），charter `dec_01KXWZ33N9`。
- 分支：`fix/l1-refresh-handover-criteria`
- 公开范围：daemon control 交接判据 + 替身清理 + 测试。
- 私有计划/证据已更新：是（任务包 plan/progress/mission/两次裁决在私有台账）。
- 范围外：跨 endpoint registry 写竞态（既有，L1 链后续）；admission 报真因与 argv 家族（L1 链下两环）。

## 版本影响

- 版本：无版本变更——既有 CLI 面内的 daemon control 正确性修复。
- 发布影响：不发布。

## 治理声明

- 触及 protected surface：是
- 范围：daemon control（refresh/restart 交接）。
- 授权：基准治理 charter `dec_01KXWZ33N9`，伞任务 L1 波次。判据未削弱：三个子判据全部保留；identity 形式从「已变化」改为「收敛到已安装产物」，是严格更正确的真值条件，有 build delta 时仍拒绝旧 identity 替身。清理校验只严不松（owner 交叉验证、重生检测）。
- 机器检查边界：本 PR 仅断言声明存在；真实与充分由 reviewer 判断。
- Break-glass：否
- 后续治理任务：伞任务下 L1 链其余环。

## 验证

- 基线 `origin/main` SHA：`a42bf2979924fabbc5521bb46f2180f0ac28949f`
- 分支与 `origin/main` merge-base：`a42bf2979924fabbc5521bb46f2180f0ac28949f`（自当前 main 分出，无需同步）
- 最近 `git fetch origin`：2026-07-20（本 session）
- 同步方式：无需
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据路径：任务包 `task_01KXW9E51ZSHYQBZ18MQBG667A` progress/evidence（私有台账）
- 评审证据路径：实现报告 `codex-report-l1-refresh-criteria.md`（worker worktree，镜像入任务包）
- GitHub Actions `rewrite-ci` run：见本 PR checks
- [x] `npm run check:ci`（manifest 派生本地可运行 job 全绿，worker 每次 commit 后复跑）
- [x] `npm run typecheck`（含于 check:ci）
- [x] `npm test`（定向 daemon-control 套件 30/30；CEO 在最终树复跑 cli fast tier 306/306）
- [x] GitHub Actions `rewrite-ci` 在本 PR 上运行
- 隔离生产形态证明：隔离 fixture 中真实无 delta refresh 成功（PID 99039 → 99713，`loadedIdentity === installedIdentity`，`activeControl = null`）；生产 daemon（pid 28666）未被操作。
- 未本地跑：Windows named-pipe 与 systemd/launchd 实机——由 PR CI 环境 job 覆盖；launchd 重生行为由注入式 supervisor 测试覆盖。

## 审查证据

- 自评：worker 报告含根因取证（唯一误报子判据 = 已收敛健康替身上的 identity 变化要求）、判据改前/改后轨迹、阳性/真阴性对照输出。
- 评审 subagent：按伞任务政策一轮三模型交叉盲评（Codex 原生 + GLM + Grok 互不透题）。裁决并集：1 P1（launchd KeepAlive 重拉被拒替身、仅按 PID 清理假报成功——Codex）+ 3 条收敛 P2（裸 PID kill 无 owner 校验可误杀——GLM+Grok；SIGTERM-only 清理可留下声称要消灭的叠层态——GLM+Grok；operation-cleared 忽略 receipt operationId 会腰斩他人操作——GLM）+ 测试/消息缺口。全部在 `4d2e7a98` 修复并带专门安全测试；复扫仅限这些 findings，CEO 对 diff 逐条核过。
- 驳回的 findings（附理由）：启动竞态 instant-reject（核实窗口近零：identity 在 socket bind 前算好、activeControl 初始为 null）；worker 对判据语义的 checkpoint 依异议协议上报并在实现前由 CEO 裁决。
- 人工评审：常设授权（基准治理伞政策；评审强度按仓库所有者 2026-07-20 裁定情况自裁）。
- 阻塞 findings：无。

## 残余风险

- 清理的 endpoint 稳定复核窗口有界（默认合计 ~10.5s）；supervisor 重生 backoff 超过窗口仍可能在回执后重生——已在 worker 报告记为接受的有界风险。
- 清理中的纯 I/O 失败可区分上报但不自动重试；回执告知操作者是否可能有存活进程。
- 跨 endpoint（同 userRoot 不同 socket）registry 写竞态为既有缺陷，归 L1 链后续任务。

## 关联材料

- 伞任务 plan：`harness/tasks/task_01KXWZ3YEGXD6302G1656RY801-plt-baseline-governance-milestone-root/task_plan.md`（L1 波次行；私有台账）
- Charter：`dec_01KXWZ33N9`（基准治理，active）
- 生产证据：#946/#947 合并后 post-merge refresh 失败 + 叠层 serve（2026-07-20 夜，任务 progress 记录）
- 已落地前置：PR #945（launch-spec v2）、PR #947（registry pointer 时序）
