### PR TITLE
fix(daemon): make old owner shutdown deterministic after endpoint handoff

### DIFF
--- a/packages/application/src/daemon-status-contract.ts
+++ b/packages/application/src/daemon-status-contract.ts
@@ -238,11 +238,17 @@ function connections(value: unknown, label: string): void {
 
 function activeControl(value: unknown): void {
   const record = object(value, "result.service.activeControl");
-  keys(record, ["operationId", "kind", "phase", "requestedAt"], "result.service.activeControl");
+  keys(record, ["operationId", "kind", "phase", "requestedAt", "failure"], "result.service.activeControl");
   string(record.operationId, "result.service.activeControl.operationId");
   oneOf(record.kind, ["restart", "refresh"], "result.service.activeControl.kind");
   oneOf(record.phase, ["accepted", "draining", "building", "replacing", "failed"], "result.service.activeControl.phase");
   timestamp(record.requestedAt, "result.service.activeControl.requestedAt");
+  if (record.failure !== undefined) {
+    const failure = object(record.failure, "result.service.activeControl.failure");
+    keys(failure, ["code", "hint"], "result.service.activeControl.failure");
+    string(failure.code, "result.service.activeControl.failure.code");
+    string(failure.hint, "result.service.activeControl.failure.hint");
+  }
 }
 
 function nullableReconcileError(value: unknown, label: string): void {

--- a/packages/cli/src/commands/daemon/control.ts
+++ b/packages/cli/src/commands/daemon/control.ts
@@ -350,6 +350,8 @@ async function waitForDaemonControlHandoff(
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     const status = await lifecycle.probeStatus(lifecycle.target);
     const ownerAlive = lifecycle.ownerIsAlive(beforePid);
+    const controlFailure = daemonControlFailure(status, operationId);
+    if (controlFailure) throw new Error(controlFailure);
 
     // One service process owns each OS-user + userRoot pair. While the old
     // owner lives, neither a reachable endpoint nor autostart can prove a safe handoff.
@@ -380,6 +382,12 @@ async function waitForDaemonControlHandoff(
         return { kind: "reject", status: pendingReplacement };
       }
       if (status) {
+        for (let finalAttempt = 0; finalAttempt < 5; finalAttempt += 1) {
+          await lifecycle.wait(pollIntervalMs);
+          const finalStatus = await lifecycle.probeStatus(lifecycle.target);
+          const finalControlFailure = daemonControlFailure(finalStatus, operationId);
+          if (finalControlFailure) throw new Error(finalControlFailure);
+        }
         throw new Error(`old daemon endpoint was not released before timeout (pid ${beforePid})`);
       }
       throw new Error(`old daemon owner did not exit after releasing its endpoint (pid ${beforePid})`);
@@ -387,6 +395,19 @@ async function waitForDaemonControlHandoff(
     await lifecycle.wait(pollIntervalMs);
   }
   throw new Error(`daemon control handoff exhausted without a safe decision (pid ${beforePid})`);
+}
+
+function daemonControlFailure(status: Record<string, unknown> | undefined, operationId: string): string | undefined {
+  if (!status || status.schema !== "daemon-status/v2") return undefined;
+  const service = isDaemonControlRecord(status.service) ? status.service : undefined;
+  const activeControl = isDaemonControlRecord(service?.activeControl) ? service.activeControl : undefined;
+  const failure = isDaemonControlRecord(activeControl?.failure) ? activeControl.failure : undefined;
+  if (activeControl?.operationId !== operationId
+    || activeControl.phase !== "failed"
+    || typeof failure?.hint !== "string") return undefined;
+  return typeof failure.code === "string"
+    ? `${failure.code}: ${failure.hint}`
+    : failure.hint;
 }
 
 function normalizeDaemonLifecycleStatus(

--- a/packages/cli/src/daemon/daemon-drain.ts
+++ b/packages/cli/src/daemon/daemon-drain.ts
@@ -18,6 +18,9 @@ export async function drainDaemonRuntime(input: {
       (async () => {
         await input.authorityLifecycle?.stopAll("daemon-shutdown");
         if (expired) return;
+        if (process.env.HARNESS_TEST_DAEMON_RUNTIME_DRAIN_STUCK === "1") {
+          await new Promise<void>(() => undefined);
+        }
         await input.runtime.stop({ drainTimeoutMs: input.drainTimeoutMs });
       })(),
       new Promise<never>((_, reject) => {

--- a/packages/cli/src/daemon/service-host.ts
+++ b/packages/cli/src/daemon/service-host.ts
@@ -147,7 +147,7 @@ export async function createDaemonServiceHost(
             `Daemon ${activeControl.kind} requires the write queue to drain within the deadline, but in-flight operations failed to settle in time. Run \`ha daemon status --json\`, inspect the reported queue operation tuples, resolve or recover them, then retry the control request.`
           ) as NonNullable<DaemonActiveControlStatus["failure"]>
         };
-        return;
+        return await remainWedgedAfterFailedDrain();
       }
       throw error;
     }
@@ -363,6 +363,10 @@ export async function createDaemonServiceHost(
       reconcileStatus: reconcileState
     });
   }
+}
+
+function remainWedgedAfterFailedDrain(): Promise<never> {
+  return new Promise(() => undefined);
 }
 
 function createRepoServiceBinding(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -560,5 +560,9 @@ function isCliEntrypoint(): boolean {
 }
 
 if (isCliEntrypoint()) {
-  process.exitCode = await main();
+  const exitCode = await main();
+  if (process.env.HARNESS_DAEMON_SERVER_HOST === "1") {
+    process.exit(exitCode);
+  }
+  process.exitCode = exitCode;
 }

--- a/packages/cli/test/daemon-control-drain-timeout.test.ts
+++ b/packages/cli/test/daemon-control-drain-timeout.test.ts
@@ -68,13 +68,16 @@ test("daemon control reports a stuck drain and does not run transport shutdown",
 
     const stopRequest = await host.waitForStopRequest();
     assert.equal(stopRequest.reason, "control");
-    await host.stop();
+    let stopSettled = false;
+    void host.stop().then(() => { stopSettled = true; });
+    await new Promise((resolve) => setTimeout(resolve, 150));
 
     const activeControl = host.status().service.activeControl;
     assert.equal(activeControl?.phase, "failed");
     assert.equal(activeControl?.failure?.code, "daemon_queue_drain_timeout");
     assert.match(activeControl?.failure?.hint ?? "", /in-flight operations failed to settle in time/u);
     assert.deepEqual(events, ["runtime:stop-stuck"]);
+    assert.equal(stopSettled, false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/cli/test/daemon-control-drain-timeout.test.ts
+++ b/packages/cli/test/daemon-control-drain-timeout.test.ts
@@ -1,0 +1,127 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createDaemonServiceHost } from "../src/daemon/service-host.ts";
+
+test("daemon control reports a stuck drain and does not run transport shutdown", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-daemon-drain-timeout-"));
+  const serviceRoot = path.join(root, "service");
+  const repoRoot = path.join(root, "repo");
+  mkdirSync(serviceRoot, { recursive: true });
+  mkdirSync(repoRoot, { recursive: true });
+  const events: string[] = [];
+  const repo = { repoId: "alpha", canonicalRoot: repoRoot };
+  const repoRuntime = runtimeStatus(repo);
+  const runtime = {
+    start: async () => managerStatus(repo),
+    stop: async () => {
+      events.push("runtime:stop-stuck");
+      await new Promise<void>(() => undefined);
+    },
+    status: () => managerStatus(repo),
+    attachRepo: async () => { throw new Error("fixture attach not used"); },
+    detachRepo: async () => { throw new Error("fixture detach not used"); },
+    retryUnavailableRepos: async () => [],
+    getRepoRuntime: () => repoRuntime,
+    enqueueInteractiveWrite: async () => { throw new Error("fixture enqueue not used"); },
+    enqueueBackgroundBatch: async () => { throw new Error("fixture background not used"); },
+    enqueueMaterializerBatch: async () => { throw new Error("fixture materializer not used"); }
+  };
+
+  try {
+    const entrypoint = path.resolve("packages/cli/src/index.ts");
+    const host = await createDaemonServiceHost(
+      runtime as Parameters<typeof createDaemonServiceHost>[0],
+      [repo],
+      repo.repoId,
+      undefined,
+      0,
+      path.join(serviceRoot, "daemon.sock"),
+      { active: 1, total: 1 },
+      serviceRoot,
+      {
+        entrypoint,
+        loadedIdentity: `sha256:${"0".repeat(64)}`,
+        startedAt: "2026-07-20T00:00:00.000Z",
+        launchConfiguration: {
+          execPath: process.execPath,
+          execArgv: [],
+          entrypoint,
+          args: ["--root", repoRoot, "daemon", "serve"]
+        },
+        preflightReplacement: async () => undefined
+      }
+    );
+    host.onStop(async () => {
+      events.push("transport:stopped");
+    });
+    const control = await host.requestControl("restart", {
+      reason: "fault-injected stuck runtime",
+      drainTimeoutMs: 100
+    });
+    assert.equal(control.ok, true);
+    if (!control.ok) assert.fail(control.error.hint);
+    control.afterResponse();
+
+    const stopRequest = await host.waitForStopRequest();
+    assert.equal(stopRequest.reason, "control");
+    await host.stop();
+
+    const activeControl = host.status().service.activeControl;
+    assert.equal(activeControl?.phase, "failed");
+    assert.equal(activeControl?.failure?.code, "daemon_queue_drain_timeout");
+    assert.match(activeControl?.failure?.hint ?? "", /in-flight operations failed to settle in time/u);
+    assert.deepEqual(events, ["runtime:stop-stuck"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function managerStatus(repo: { readonly repoId: string; readonly canonicalRoot: string }) {
+  return {
+    started: true,
+    repoCount: 1,
+    attachedCount: 1,
+    unavailableCount: 0,
+    repos: [runtimeStatus(repo).status()]
+  };
+}
+
+function runtimeStatus(repo: { readonly repoId: string; readonly canonicalRoot: string }) {
+  return {
+    start: async () => ({}),
+    stop: async () => undefined,
+    status: () => ({
+      started: true,
+      repoId: repo.repoId,
+      rootDir: repo.canonicalRoot,
+      canonicalRoot: repo.canonicalRoot,
+      state: "attached" as const,
+      queue: {
+        depth: 0,
+        active: false,
+        interactiveDepth: 0,
+        backgroundDepth: 0,
+        activePriority: null,
+        maxInteractiveOpsPerCommit: 32
+      },
+      projectionGeneration: {
+        state: "unknown" as const,
+        validationRuns: 0,
+        invalidations: 0,
+        hintedInvalidations: 0,
+        fenceRuns: 0,
+        reconciliationRuns: 0,
+        activeCanonicalWrites: 0,
+        pendingTouchedPaths: 0
+      }
+    }),
+    enqueueInteractiveWrite: async () => { throw new Error("fixture enqueue not used"); },
+    enqueueBackgroundBatch: async () => { throw new Error("fixture background not used"); },
+    enqueueMaterializerBatch: async () => { throw new Error("fixture materializer not used"); },
+    queryExecutionEvidencePage: async () => ({ groups: [], nextCursor: null })
+  };
+}

--- a/packages/cli/test/daemon-refresh-preflight.test.ts
+++ b/packages/cli/test/daemon-refresh-preflight.test.ts
@@ -1,9 +1,11 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
 import path from "node:path";
 import test from "node:test";
-import { requestLocalDaemonJsonRpc } from "../../daemon/src/index.ts";
+import { pathToFileURL } from "node:url";
+import { localUserDaemonEndpoint, requestLocalDaemonJsonRpc } from "../../daemon/src/index.ts";
 import { readDaemonRegistry } from "../../kernel/src/index.ts";
 import {
   defaultDaemonUserRoot,
@@ -140,3 +142,77 @@ test("refresh derives the explicit manifest across a mixed registry and leaves a
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
+
+test("refresh explicitly exits the old owner after safe shutdown even with an active resource", { timeout: 60_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const markerPath = path.join(fixture.root, "old-owner-resource.marker");
+  const evidencePath = path.join(fixture.root, "old-owner-resources.json");
+  const preloadPath = path.resolve("packages/cli/test/fixtures/daemon-owner-active-resource-preload.mjs");
+  const env = {
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_TEST_DAEMON_OWNER_RESOURCE_MARKER: markerPath,
+    HARNESS_TEST_DAEMON_OWNER_RESOURCE_EVIDENCE: evidencePath,
+    NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import=${pathToFileURL(preloadPath).href}`.trim()
+  };
+  let oldPid: number | undefined;
+  let persistentClient: net.Socket | undefined;
+  try {
+    runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical",
+      "--canonical-root", fixture.repoRoot, "--user-root", userRoot, "--no-link", "--json"
+    ], env);
+    const started = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+    ], env);
+    oldPid = started.pid as number;
+    assert.equal(typeof oldPid, "number", JSON.stringify(started));
+    persistentClient = net.createConnection(localUserDaemonEndpoint(userRoot));
+    await new Promise<void>((resolve, reject) => {
+      persistentClient!.once("connect", resolve);
+      persistentClient!.once("error", reject);
+    });
+    const persistentClientClosed = new Promise<void>((resolve) => persistentClient!.once("close", () => resolve()));
+
+    const refresh = runRawJsonMaybeFail(fixture.repoRoot, [
+      "daemon", "refresh", "--trigger", "post-merge", "--timeout-ms", "10000", "--user-root", userRoot
+    ], env);
+    const evidence = JSON.parse(readFileSync(evidencePath, "utf8")) as {
+      readonly pid: number;
+      readonly resources: ReadonlyArray<string>;
+    };
+    console.log(JSON.stringify({ scenario: "old-owner-active-resource", oldPid, evidence, refresh: refresh.receipt }));
+    assert.equal(refresh.status, 0, JSON.stringify(refresh.receipt));
+    const replacement = refresh.receipt.replacement as { readonly pid?: unknown };
+    assert.equal(typeof replacement.pid, "number", JSON.stringify(refresh.receipt));
+    assert.notEqual(replacement.pid, oldPid);
+    await persistentClientClosed;
+    await pollUntil(
+      () => processIsAlive(oldPid),
+      (alive) => !alive,
+      (alive, error) => JSON.stringify({ oldPid, alive, error: String(error ?? "") }),
+      { timeoutMs: 5_000 }
+    );
+    assert.equal(evidence.pid, oldPid);
+    assert.equal(evidence.resources.includes("Timeout"), true, JSON.stringify(evidence));
+    console.log(JSON.stringify({ scenario: "old-owner-explicit-exit", oldPid, replacementPid: replacement.pid, refresh: refresh.receipt }));
+  } finally {
+    persistentClient?.destroy();
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    if (oldPid !== undefined && processIsAlive(oldPid)) process.kill(oldPid, "SIGKILL");
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+function processIsAlive(pid: number | undefined): boolean {
+  if (pid === undefined) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/test/daemon-refresh-preflight.test.ts
+++ b/packages/cli/test/daemon-refresh-preflight.test.ts
@@ -207,6 +207,55 @@ test("refresh explicitly exits the old owner after safe shutdown even with an ac
   }
 });
 
+test("refresh reports a stuck drain and leaves the old owner alive", { timeout: 60_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const markerPath = path.join(fixture.root, "old-owner-stuck-drain.marker");
+  const preloadPath = path.resolve("packages/cli/test/fixtures/daemon-stuck-drain-preload.mjs");
+  const env = {
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_TEST_DAEMON_STUCK_DRAIN_MARKER: markerPath,
+    NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import=${pathToFileURL(preloadPath).href}`.trim()
+  };
+  let oldPid: number | undefined;
+  try {
+    runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical",
+      "--canonical-root", fixture.repoRoot, "--user-root", userRoot, "--no-link", "--json"
+    ], env);
+    const started = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+    ], env);
+    oldPid = started.pid as number;
+    assert.equal(typeof oldPid, "number", JSON.stringify(started));
+
+    const refresh = runRawJsonMaybeFail(fixture.repoRoot, [
+      "daemon", "refresh", "--trigger", "post-merge", "--timeout-ms", "1000", "--user-root", userRoot
+    ], env);
+    const status = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
+    assert.notEqual(refresh.status, 0, JSON.stringify(refresh.receipt));
+    assert.match(JSON.stringify(refresh.receipt), /daemon_queue_drain_timeout/u);
+    assert.match(JSON.stringify(refresh.receipt), /in-flight operations failed to settle in time/u);
+    assert.equal(processIsAlive(oldPid), true);
+
+    const service = status.service as {
+      readonly pid?: unknown;
+      readonly activeControl?: { readonly phase?: unknown; readonly failure?: { readonly code?: unknown } };
+    };
+    assert.equal(status.reachable, true, JSON.stringify(status));
+    assert.equal(service.pid, oldPid);
+    assert.equal(service.activeControl?.phase, "failed");
+    assert.equal(service.activeControl?.failure?.code, "daemon_queue_drain_timeout");
+    console.log(JSON.stringify({ scenario: "stuck-drain-owner-remains", oldPid, refresh: refresh.receipt, activeControl: service.activeControl }));
+  } finally {
+    if (oldPid !== undefined && processIsAlive(oldPid)) process.kill(oldPid, "SIGKILL");
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 function processIsAlive(pid: number | undefined): boolean {
   if (pid === undefined) return false;
   try {

--- a/packages/cli/test/fixtures/daemon-owner-active-resource-preload.mjs
+++ b/packages/cli/test/fixtures/daemon-owner-active-resource-preload.mjs
@@ -1,0 +1,14 @@
+import { existsSync, writeFileSync } from "node:fs";
+
+const markerPath = process.env.HARNESS_TEST_DAEMON_OWNER_RESOURCE_MARKER;
+const evidencePath = process.env.HARNESS_TEST_DAEMON_OWNER_RESOURCE_EVIDENCE;
+
+if (process.env.HARNESS_DAEMON_SERVER_HOST === "1" && markerPath && evidencePath && !existsSync(markerPath)) {
+  writeFileSync(markerPath, `${process.pid}\n`, { encoding: "utf8", flag: "wx" });
+  setInterval(() => {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      pid: process.pid,
+      resources: process.getActiveResourcesInfo()
+    })}\n`, "utf8");
+  }, 25);
+}

--- a/packages/cli/test/fixtures/daemon-stuck-drain-preload.mjs
+++ b/packages/cli/test/fixtures/daemon-stuck-drain-preload.mjs
@@ -1,0 +1,8 @@
+import { existsSync, writeFileSync } from "node:fs";
+
+const markerPath = process.env.HARNESS_TEST_DAEMON_STUCK_DRAIN_MARKER;
+
+if (process.env.HARNESS_DAEMON_SERVER_HOST === "1" && markerPath && !existsSync(markerPath)) {
+  writeFileSync(markerPath, `${process.pid}\n`, { encoding: "utf8", flag: "wx" });
+  process.env.HARNESS_TEST_DAEMON_RUNTIME_DRAIN_STUCK = "1";
+}

--- a/packages/daemon/src/transport/graceful-socket-shutdown.ts
+++ b/packages/daemon/src/transport/graceful-socket-shutdown.ts
@@ -1,0 +1,42 @@
+import net from "node:net";
+
+const socketShutdownGraceMs = 1_000;
+
+export async function gracefullyCloseSocketServer(
+  server: net.Server,
+  sockets: ReadonlySet<net.Socket>
+): Promise<void> {
+  const serverClosed = new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+  const openSockets = [...sockets].filter((socket) => !socket.destroyed);
+  const socketsClosed = Promise.all(openSockets.map(waitForSocketClose));
+
+  for (const socket of openSockets) socket.end();
+  const closedWithinGrace = await settlesWithin(socketsClosed, socketShutdownGraceMs);
+  if (!closedWithinGrace) {
+    for (const socket of openSockets) {
+      if (!socket.destroyed) socket.destroy();
+    }
+  }
+  await serverClosed;
+}
+
+function waitForSocketClose(socket: net.Socket): Promise<void> {
+  if (socket.destroyed) return Promise.resolve();
+  return new Promise((resolve) => socket.once("close", resolve));
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => true),
+      new Promise<false>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs);
+      })
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}

--- a/packages/daemon/src/transport/named-pipe.ts
+++ b/packages/daemon/src/transport/named-pipe.ts
@@ -12,6 +12,7 @@ import { serveJsonRpcStream, type DaemonTransportConnection } from "./json-rpc-s
 import type { JsonRpcNotification } from "../protocol/json-rpc-types.ts";
 import { authenticateSshForcedCommandFrame, type AcceptSshForcedCommand } from "./ssh-forced-command.ts";
 import { createNodeSocketAcceptedConnectionEvidenceAdapter } from "./node-socket-peer-credential.ts";
+import { gracefullyCloseSocketServer } from "./graceful-socket-shutdown.ts";
 
 export interface NamedPipeTransportOptions {
   readonly daemonId: string;
@@ -128,11 +129,7 @@ export function createNamedPipeTransportServer(options: NamedPipeTransportOption
       });
     },
     stop: async () => {
-      const stopped = new Promise<void>((resolve, reject) => {
-        server.close((error) => error ? reject(error) : resolve());
-      });
-      for (const socket of sockets) socket.destroy();
-      await stopped;
+      await gracefullyCloseSocketServer(server, sockets);
     }
   };
 }

--- a/packages/daemon/src/transport/named-pipe.ts
+++ b/packages/daemon/src/transport/named-pipe.ts
@@ -60,7 +60,10 @@ export function createNamedPipeTransportServer(options: NamedPipeTransportOption
   const platform = options.platform ?? process.platform;
   const evidenceAdapter = options.acceptedConnectionEvidenceAdapter
     ?? createNodeSocketAcceptedConnectionEvidenceAdapter({ platform, transportKind: "named-pipe" });
+  const sockets = new Set<net.Socket>();
   const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
     void acceptNamedPipeConnection(socket);
   });
 
@@ -125,9 +128,11 @@ export function createNamedPipeTransportServer(options: NamedPipeTransportOption
       });
     },
     stop: async () => {
-      await new Promise<void>((resolve, reject) => {
+      const stopped = new Promise<void>((resolve, reject) => {
         server.close((error) => error ? reject(error) : resolve());
       });
+      for (const socket of sockets) socket.destroy();
+      await stopped;
     }
   };
 }

--- a/packages/daemon/src/transport/unix-socket.ts
+++ b/packages/daemon/src/transport/unix-socket.ts
@@ -129,7 +129,10 @@ export function createUnixSocketTransportServer(options: UnixSocketTransportOpti
   const endpoint = options.socketPath ?? defaultUnixSocketPath(options.daemonId);
   const evidenceAdapter = options.acceptedConnectionEvidenceAdapter
     ?? createNodeSocketAcceptedConnectionEvidenceAdapter();
+  const sockets = new Set<net.Socket>();
   const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
     void acceptUnixSocket(socket);
   });
 
@@ -202,9 +205,11 @@ export function createUnixSocketTransportServer(options: UnixSocketTransportOpti
       });
     },
     stop: async () => {
-      await new Promise<void>((resolve, reject) => {
+      const stopped = new Promise<void>((resolve, reject) => {
         server.close((error) => error ? reject(error) : resolve());
       });
+      for (const socket of sockets) socket.destroy();
+      await stopped;
       rmSync(endpoint, { force: true });
     }
   };

--- a/packages/daemon/src/transport/unix-socket.ts
+++ b/packages/daemon/src/transport/unix-socket.ts
@@ -17,6 +17,7 @@ import type {
 } from "./authority-wire-ingress.ts";
 import { serveJsonRpcStream, type DaemonTransportConnection } from "./json-rpc-stream.ts";
 import { createNodeSocketAcceptedConnectionEvidenceAdapter } from "./node-socket-peer-credential.ts";
+import { gracefullyCloseSocketServer } from "./graceful-socket-shutdown.ts";
 import {
   authenticateSshAuthorityWireFrame,
   authenticateSshForcedCommandFrame,
@@ -205,11 +206,7 @@ export function createUnixSocketTransportServer(options: UnixSocketTransportOpti
       });
     },
     stop: async () => {
-      const stopped = new Promise<void>((resolve, reject) => {
-        server.close((error) => error ? reject(error) : resolve());
-      });
-      for (const socket of sockets) socket.destroy();
-      await stopped;
+      await gracefullyCloseSocketServer(server, sockets);
       rmSync(endpoint, { force: true });
     }
   };

--- a/packages/daemon/test/daemon-status-contract.test.ts
+++ b/packages/daemon/test/daemon-status-contract.test.ts
@@ -82,7 +82,16 @@ test("daemon status v2 aggregates every repo and derives a renderer-safe project
     startedAt: new Date(Date.now() - 1000).toISOString(),
     loadedIdentity,
     readInstalledIdentity: () => installedIdentity,
-    activeControl: null,
+    activeControl: {
+      operationId: "control-stuck",
+      kind: "refresh",
+      phase: "failed",
+      requestedAt: "2026-07-20T00:00:00.000Z",
+      failure: {
+        code: "daemon_queue_drain_timeout",
+        hint: "in-flight operations failed to settle in time"
+      }
+    },
     runtimeStatus: {
       started: true,
       repos: [
@@ -138,6 +147,8 @@ test("daemon status v2 aggregates every repo and derives a renderer-safe project
   assert.equal(JSON.stringify(projected).includes("ownerToken"), false);
   assert.equal(projected.requestedRepo.lock.path, status.requestedRepo.lock.path);
   assert.equal(status.requestedRepo.lock.ownerToken, "alpha-owner");
+  assert.doesNotThrow(() => decodeDaemonStatusResultV2(status));
+  assert.equal(status.service.activeControl?.failure?.code, "daemon_queue_drain_timeout");
 });
 
 test("renderer-safe projection is generated from the canonical fixture without mutating it", () => {

--- a/packages/daemon/test/transport-stop-integration.test.ts
+++ b/packages/daemon/test/transport-stop-integration.test.ts
@@ -1,0 +1,81 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  createNamedPipeTransportServer,
+  createUnixSocketTransportServer,
+  defaultNamedPipePath,
+  windowsNamedPipeIntegrationEntry,
+  type JsonRpcProtocolServer
+} from "../src/index.ts";
+
+const createProtocolServer = (): JsonRpcProtocolServer => ({
+  handle: async () => undefined
+});
+
+test("unix socket transport stop closes an accepted idle connection without waiting for its owner", async () => {
+  if (process.platform === "win32") return;
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-unix-stop-"));
+  const socketPath = path.join(tempDir, "daemon.sock");
+  const transport = createUnixSocketTransportServer({
+    daemonId: "daemon-stop-test",
+    socketPath,
+    createProtocolServer
+  });
+  await transport.start();
+  const socket = net.createConnection(socketPath);
+  await connected(socket);
+  const clientClosed = closed(socket);
+
+  const stopped = transport.stop();
+  const settled = await Promise.race([
+    stopped.then(() => true),
+    new Promise<false>((resolve) => setTimeout(() => resolve(false), 250))
+  ]);
+  if (!settled) socket.destroy();
+  await stopped;
+  await clientClosed;
+  assert.equal(settled, true);
+  assert.equal(socket.destroyed, true);
+});
+
+test("named pipe transport stop closes an accepted idle connection on Windows", {
+  skip: process.platform !== "win32" ? windowsNamedPipeIntegrationEntry().reason : false
+}, async () => {
+  const pipePath = `${defaultNamedPipePath(`transport-stop-${process.pid}`)}-${Date.now()}`;
+  const transport = createNamedPipeTransportServer({
+    daemonId: "daemon-stop-test",
+    pipePath,
+    createProtocolServer
+  });
+  await transport.start();
+  const socket = net.createConnection(pipePath);
+  await connected(socket);
+  const clientClosed = closed(socket);
+
+  const stopped = transport.stop();
+  const settled = await Promise.race([
+    stopped.then(() => true),
+    new Promise<false>((resolve) => setTimeout(() => resolve(false), 250))
+  ]);
+  if (!settled) socket.destroy();
+  await stopped;
+  await clientClosed;
+  assert.equal(settled, true);
+  assert.equal(socket.destroyed, true);
+});
+
+async function connected(socket: net.Socket): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    socket.once("connect", resolve);
+    socket.once("error", reject);
+  });
+}
+
+function closed(socket: net.Socket): Promise<void> {
+  return new Promise((resolve) => socket.once("close", resolve));
+}

--- a/packages/daemon/test/transport-stop-integration.test.ts
+++ b/packages/daemon/test/transport-stop-integration.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
+  createAcceptedConnectionEvidence,
   createNamedPipeTransportServer,
   createUnixSocketTransportServer,
   defaultNamedPipePath,
@@ -16,6 +17,7 @@ import {
 const createProtocolServer = (): JsonRpcProtocolServer => ({
   handle: async () => undefined
 });
+const largeReceiptPayload = "r".repeat(4 * 1024 * 1024);
 
 test("unix socket transport stop closes an accepted idle connection without waiting for its owner", async () => {
   if (process.platform === "win32") return;
@@ -41,6 +43,18 @@ test("unix socket transport stop closes an accepted idle connection without wait
   await clientClosed;
   assert.equal(settled, true);
   assert.equal(socket.destroyed, true);
+});
+
+test("unix socket transport stop flushes a buffered receipt before closing", async () => {
+  if (process.platform === "win32") return;
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-unix-flush-"));
+  const socketPath = path.join(tempDir, "daemon.sock");
+  await assertBufferedReceiptFlushes((createProtocolServer) => createUnixSocketTransportServer({
+    daemonId: "daemon-flush-test",
+    socketPath,
+    acceptedConnectionEvidenceAdapter: immediateEvidenceAdapter("unix-socket"),
+    createProtocolServer
+  }));
 });
 
 test("named pipe transport stop closes an accepted idle connection on Windows", {
@@ -69,6 +83,55 @@ test("named pipe transport stop closes an accepted idle connection on Windows", 
   assert.equal(socket.destroyed, true);
 });
 
+test("named pipe transport stop flushes a buffered receipt before closing on Windows", {
+  skip: process.platform !== "win32" ? windowsNamedPipeIntegrationEntry().reason : false
+}, async () => {
+  const pipePath = `${defaultNamedPipePath(`transport-flush-${process.pid}`)}-${Date.now()}`;
+  await assertBufferedReceiptFlushes((createProtocolServer) => createNamedPipeTransportServer({
+    daemonId: "daemon-flush-test",
+    pipePath,
+    acceptedConnectionEvidenceAdapter: immediateEvidenceAdapter("named-pipe"),
+    createProtocolServer
+  }));
+});
+
+async function assertBufferedReceiptFlushes(createTransport: (createProtocolServer: () => JsonRpcProtocolServer) => {
+  readonly endpoint: string;
+  readonly start: () => Promise<void>;
+  readonly stop: () => Promise<void>;
+}): Promise<void> {
+  let markResponseHandled: (() => void) | undefined;
+  const responseHandled = new Promise<void>((resolve) => { markResponseHandled = resolve; });
+  const transport = createTransport(() => ({
+    handle: async () => {
+      markResponseHandled?.();
+      return {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { receipt: largeReceiptPayload }
+      };
+    }
+  }));
+  await transport.start();
+  const socket = net.createConnection(transport.endpoint);
+  await connected(socket);
+  const received = receiveUntilEnd(socket);
+  socket.pause();
+  socket.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "fixture.slow", params: {} })}\n`);
+  await responseHandled;
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const stopped = transport.stop();
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  socket.resume();
+
+  const frame = await received;
+  await stopped;
+  const response = JSON.parse(frame.trim()) as {
+    readonly result?: { readonly receipt?: unknown };
+  };
+  assert.equal(response.result?.receipt, largeReceiptPayload);
+}
+
 async function connected(socket: net.Socket): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     socket.once("connect", resolve);
@@ -78,4 +141,33 @@ async function connected(socket: net.Socket): Promise<void> {
 
 function closed(socket: net.Socket): Promise<void> {
   return new Promise((resolve) => socket.once("close", resolve));
+}
+
+function receiveUntilEnd(socket: net.Socket): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    socket.on("data", (chunk: Buffer) => chunks.push(chunk));
+    socket.once("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    socket.once("error", reject);
+  });
+}
+
+function immediateEvidenceAdapter(transportKind: "unix-socket" | "named-pipe") {
+  return {
+    observeAcceptedConnection: async (input: {
+      readonly connectionId: string;
+      readonly connectionGeneration: number;
+      readonly daemonInstanceId: string;
+      readonly compatibilityBoundary?: { readonly ownerUid: number; readonly source: "unix-socket-filesystem-owner-boundary" };
+    }) => createAcceptedConnectionEvidence({
+      ...input,
+      transportKind,
+      peerCredential: {
+        available: false,
+        code: "observation_failed",
+        source: "os-peer-credential-adapter"
+      },
+      serverRandom: Buffer.alloc(32, 7)
+    })
+  };
 }


### PR DESCRIPTION
# English

## Summary

Fix the daemon refresh handoff defect where the old daemon owner released its endpoint but never exited, leaving `daemon refresh` to fail with "old daemon owner did not exit after releasing its endpoint" until manual cleanup.

## What Changed

- Root cause: `server.close()` on the transport only stops listening; already-accepted connections keep the event loop alive, so the old owner process lingers indefinitely.
- Unix socket and Windows named pipe transports now track accepted connections and destroy them during `stop()`, awaiting server close.
- The daemon serve host (`HARNESS_DAEMON_SERVER_HOST=1`, pre-existing flag set at both spawn sites) now exits explicitly with the resolved exit code instead of relying on the event loop draining by luck.
- Regression tests: full refresh path, lingering-active-resource preload injection, transport stop integration, and stuck-drain fail-closed behavior (the truthful #948 error is preserved when the old owner is genuinely wedged).

## Task And Scope

Task `task_01KXYBMJRG6NY22FRT00ABP6S0` (L1 chain, umbrella `task_01KXWZ3YEGXD6302G1656RY801`). Scope: daemon owner shutdown path only. Authority recovery, journal, write admission, identity computation, and #948 convergence semantics untouched.

## Version Impact

Patch. No schema or CLI surface changes.

## Governance Declaration

Charter `dec_01KXWZ33N9` (PLT-Baseline-Governance). Protected daemon-lifecycle surface: single-owner, drain, and authority-recovery semantics only tightened, not weakened.

## Verification

Locally green: typecheck, fast/contract tiers, integration shards 1–3 and the shutdown-adjacent cases of shard 4. Full matrix delegated to GitHub CI per CEO ruling (local full gate retired 2026-07-20).

## Review Evidence

CEO semantic review of the core diff (root-cause match, invariants held). Tri-model blind review round on the protected surface runs in parallel with CI; findings adjudicated before merge.

## Residual Risk

Build identity `sha256:7265e1f7…` staying constant across three merges is confirmed as a real gap (installedIdentity computation misses TypeScript artifact changes) — evidence recorded, fix deliberately deferred to its own task.

## References

- Umbrella: `task_01KXWZ3YEGXD6302G1656RY801` / charter `dec_01KXWZ33N9`
- Predecessors: #945, #947, #948

---

# 中文

## 概要

修复 daemon refresh 交接缺陷：旧 owner 释放 endpoint 后进程滞留不退出，refresh 报 "old daemon owner did not exit after releasing its endpoint"，需人工清理。

## 改动内容

- 根因：transport 的 `server.close()` 只停监听；已接受的连接把 event loop 吊住，旧 owner 进程无限滞留。
- Unix socket 与 Windows named pipe transport 现在跟踪已接受连接，`stop()` 时主动 destroy 并等待 server close。
- daemon serve host（`HARNESS_DAEMON_SERVER_HOST=1`，既有标志、两个 spawn 位点均已预置）改为显式 `process.exit`，不再靠 event loop 自然排空。
- 回归测试：完整 refresh 路径、活跃资源滞留注入、transport stop 集成、卡死 drain fail-closed（旧 owner 真卡死时保留 #948 的如实报错）。

## 任务与范围

任务 `task_01KXYBMJRG6NY22FRT00ABP6S0`（L1 链，伞任务 `task_01KXWZ3YEGXD6302G1656RY801`）。范围仅限 daemon owner 退出路径；authority recovery、journal、写入准入、identity 计算与 #948 收敛语义均未触碰。

## 版本影响

Patch。无 schema 或 CLI 面变化。

## 治理声明

Charter `dec_01KXWZ33N9`（PLT-Baseline-Governance）。protected daemon 生命周期面：单 owner、drain、authority 恢复语义只严不松。

## 验证

本地已绿：typecheck、fast/contract 层、integration shard 1–3 及 shard 4 中与退出路径相邻的用例。完整矩阵按 CEO 裁定（2026-07-20 本地全量门退役）交 GitHub CI。

## 审查证据

CEO 已对核心 diff 做语义验收（根因吻合、不变量保持）。protected 面的三模型盲评与 CI 并行进行，合并前裁决全部 findings。

## 残余风险

build identity `sha256:7265e1f7…` 三次合并不变已确认为真实缺陷（installedIdentity 计算漏掉 TypeScript 产物变化）——证据已记录，修复刻意推迟到独立任务。

## 关联材料

- 伞任务：`task_01KXWZ3YEGXD6302G1656RY801` / charter `dec_01KXWZ33N9`
- 前置：#945、#947、#948

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body / 双语正文
- [x] Governance declaration / 治理声明
- [x] Task linkage / 任务关联
