### PR TITLE
feat(settings): project-level daemon.userRoot pinning

### DIFF
--- a/packages/cli/src/commands/agent-runtime.ts
+++ b/packages/cli/src/commands/agent-runtime.ts
@@ -8,7 +8,12 @@ import { readOption, stripGlobalOptions } from "../cli/parse-options.ts";
 import { daemonClientCliEntrypointPath, readDaemonClientConfig } from "../daemon/client.ts";
 
 type Receipt = CommandReceipt | CommandFailureReceipt;
-type AgentRuntimeRequester = (method: string, payload: JsonObject | undefined, rootDir: string) => Promise<Receipt>;
+type AgentRuntimeRequester = (
+  method: string,
+  payload: JsonObject | undefined,
+  rootDir: string,
+  layoutOverrides?: { readonly authoredRoot?: string }
+) => Promise<Receipt>;
 
 export async function runAgentRuntimeCommand(
   argv: ReadonlyArray<string>,
@@ -53,11 +58,17 @@ export async function runAgentRuntimeCommand(
   } else {
     return { receipt: failure("agent", "unknown_agent_command", agentHelp()), json: stripped.json };
   }
-  return { receipt: await request(method, payload, stripped.rootDir), json: stripped.json };
+  const layoutOverrides = stripped.authoredRoot ? { authoredRoot: stripped.authoredRoot } : undefined;
+  return { receipt: await request(method, payload, stripped.rootDir, layoutOverrides), json: stripped.json };
 }
 
-async function requestAgentRuntimeDaemon(method: string, payload: JsonObject | undefined, rootDir: string): Promise<Receipt> {
-  const config = readDaemonClientConfig(process.env, rootDir);
+async function requestAgentRuntimeDaemon(
+  method: string,
+  payload: JsonObject | undefined,
+  rootDir: string,
+  layoutOverrides?: { readonly authoredRoot?: string }
+): Promise<Receipt> {
+  const config = readDaemonClientConfig(process.env, rootDir, undefined, undefined, layoutOverrides);
   if (config.mode !== "local") return failure("agent", "agent_runtime_requires_local_daemon", "Agent runtime commands require the local daemon; omit HARNESS_DAEMON_MODE=direct or remote.");
   const target = resolveLocalDaemonTarget({
     rootDir,
@@ -71,7 +82,8 @@ async function requestAgentRuntimeDaemon(method: string, payload: JsonObject | u
   }, 200, {
     entryPath: daemonClientCliEntrypointPath(),
     idleExitMs: config.idleExitMs,
-    timeoutMs: config.autostartTimeoutMs
+    timeoutMs: config.autostartTimeoutMs,
+    layoutOverrides
   });
   if (isReceipt(response)) return response;
   return failure("agent", "agent_runtime_response_invalid", `${method} did not return command-receipt/v2.`);

--- a/packages/cli/src/commands/daemon/connect.ts
+++ b/packages/cli/src/commands/daemon/connect.ts
@@ -27,6 +27,7 @@ export async function runDaemonConnect(
     readonly env?: NodeJS.ProcessEnv;
     readonly platform?: NodeJS.Platform;
     readonly rootDir?: string;
+    readonly layoutOverrides?: { readonly authoredRoot?: string };
     readonly streams?: DaemonConnectStreams;
     readonly verifySshdContext?: () => boolean;
   } = {}
@@ -54,7 +55,7 @@ export async function runDaemonConnect(
     streams.error.write(`${error instanceof Error ? error.message : String(error)}\n`);
     return 2;
   }
-  const userRoot = readOption(args, "--user-root") ?? readDaemonUserRoot(env, options.rootDir ?? process.cwd());
+  const userRoot = readOption(args, "--user-root") ?? readDaemonUserRoot(env, options.rootDir ?? process.cwd(), options.layoutOverrides);
   const endpoint = readOption(args, "--socket")
     ?? localUserDaemonEndpoint(userRoot, daemonIdFromEnv(env), options.platform ?? process.platform);
   const streamProtocol: DaemonConnectStreamProtocol = args.includes("--authority-wire")

--- a/packages/cli/src/commands/daemon/connect.ts
+++ b/packages/cli/src/commands/daemon/connect.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import type { Readable, Writable } from "node:stream";
 import {
   daemonIdFromEnv,
-  daemonUserRoot,
   encodeJsonLineFrame,
   localUserDaemonEndpoint,
   sshAuthorityWireBootstrapFrame,
@@ -11,6 +10,7 @@ import {
   type SshForcedCommandBootstrapInput
 } from "@harness-anything/daemon";
 import { readOption } from "../../cli/parse-options.ts";
+import { readDaemonUserRoot } from "../../daemon/client.ts";
 import { verifyCurrentProcessHasPrivilegedSshdAncestor } from "./sshd-witness.ts";
 
 export interface DaemonConnectStreams {
@@ -54,7 +54,7 @@ export async function runDaemonConnect(
     streams.error.write(`${error instanceof Error ? error.message : String(error)}\n`);
     return 2;
   }
-  const userRoot = readOption(args, "--user-root") ?? daemonUserRoot(env);
+  const userRoot = readOption(args, "--user-root") ?? readDaemonUserRoot(env, options.rootDir ?? process.cwd());
   const endpoint = readOption(args, "--socket")
     ?? localUserDaemonEndpoint(userRoot, daemonIdFromEnv(env), options.platform ?? process.platform);
   const streamProtocol: DaemonConnectStreamProtocol = args.includes("--authority-wire")

--- a/packages/cli/src/commands/daemon/control.ts
+++ b/packages/cli/src/commands/daemon/control.ts
@@ -290,6 +290,7 @@ function defaultDaemonControlLifecycle(input: DaemonControlCommandInput): Daemon
     rootDir: input.rootDir,
     repoIdOverride: readOption(input.args, "--repo") ?? process.env.HARNESS_DAEMON_REPO_ID,
     userRoot: daemonUserRootOption(input.args),
+    layoutOverrides: input.layoutOverrides,
     autoRegisterSingleRepo: false
   });
   const socketPath = readOption(input.args, "--socket");

--- a/packages/cli/src/commands/daemon/control.ts
+++ b/packages/cli/src/commands/daemon/control.ts
@@ -91,7 +91,7 @@ export async function runDaemonControl(
     control.params,
     5_000,
     {
-      userRoot: daemonUserRootOption(input.args),
+      userRoot: lifecycle.target.userRoot,
       socketPath: readOption(input.args, "--socket"),
       allowLegacySocket: false
     }

--- a/packages/cli/src/commands/daemon/logs.ts
+++ b/packages/cli/src/commands/daemon/logs.ts
@@ -13,6 +13,7 @@ export async function runDaemonLogsCommand(input: DaemonCommandInput): Promise<n
   const target = resolveLocalDaemonTarget({
     rootDir: input.rootDir,
     repoIdOverride: readOption(input.args, "--repo") ?? process.env.HARNESS_DAEMON_REPO_ID,
+    layoutOverrides: input.layoutOverrides,
     autoRegisterSingleRepo: false
   });
   const levels = readOption(input.args, "--levels")?.split(",").filter((value): value is DaemonLogLevel => value.length > 0);

--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -76,7 +76,7 @@ export async function runDaemonProductCommand(input: DaemonCommandInput): Promis
     if (action === "refresh") return await controlDaemon(input, "refresh");
     if (action === "bootstrap-server") return await bootstrapServer(input);
     if (action === "install-templates") return installTemplates(input);
-    if (action === "repo") return runDaemonRepoCommand({ rootDir: input.rootDir, args: input.args, json: input.json });
+    if (action === "repo") return runDaemonRepoCommand({ rootDir: input.rootDir, layoutOverrides: input.layoutOverrides, args: input.args, json: input.json });
     emitDaemonError(
       CliErrorCode.UnknownCommand,
       `Unknown daemon command: ${action}. Run 'ha daemon --help' to inspect valid daemon subcommands.`,
@@ -104,6 +104,7 @@ async function startDaemon(input: DaemonCommandInput): Promise<number> {
     rootDir: launchOptions.rootDir,
     repoIdOverride: daemonRepoIdOverride(input.args),
     userRoot: launchOptions.userRoot,
+    layoutOverrides,
     autoRegisterSingleRepo: true
   });
   const socketPath = launchOptions.socketPath ?? target.socketPath;
@@ -152,6 +153,7 @@ async function statusDaemon(input: DaemonCommandInput): Promise<number> {
   const target = resolveLocalDaemonTarget({
     rootDir: input.rootDir,
     repoIdOverride: daemonRepoIdOverride(input.args),
+    layoutOverrides: input.layoutOverrides,
     autoRegisterSingleRepo: false
   });
   const layout = resolveHarnessLayout(createHarnessRuntimeContext(target.canonicalRoot, input.layoutOverrides));
@@ -185,6 +187,7 @@ async function stopDaemon(input: DaemonCommandInput): Promise<number> {
   const target = resolveLocalDaemonTarget({
     rootDir: input.rootDir,
     repoIdOverride: daemonRepoIdOverride(input.args),
+    layoutOverrides: input.layoutOverrides,
     autoRegisterSingleRepo: false
   });
   const layout = resolveHarnessLayout(createHarnessRuntimeContext(target.canonicalRoot, input.layoutOverrides));

--- a/packages/cli/src/commands/daemon/repo-registry.ts
+++ b/packages/cli/src/commands/daemon/repo-registry.ts
@@ -4,9 +4,9 @@ import {
   unregisterDaemonRepo,
   type DaemonRegistryRepo
 } from "@harness-anything/kernel";
-import { daemonUserRootForRepo } from "@harness-anything/daemon";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import { readOption } from "../../cli/parse-options.ts";
+import { readDaemonUserRoot } from "../../daemon/client.ts";
 
 export interface DaemonRepoCommandInput {
   readonly rootDir: string;
@@ -20,7 +20,7 @@ export function runDaemonRepoCommand(input: DaemonRepoCommandInput): number {
     console.log(renderDaemonRepoHelp());
     return 0;
   }
-  const userRoot = readOption(input.args, "--user-root") ?? daemonUserRootForRepo(input.rootDir, process.env);
+  const userRoot = readOption(input.args, "--user-root") ?? readDaemonUserRoot(process.env, input.rootDir);
   const options = {
     userRoot,
     createConvenienceLinks: !input.args.includes("--no-link")

--- a/packages/cli/src/commands/daemon/repo-registry.ts
+++ b/packages/cli/src/commands/daemon/repo-registry.ts
@@ -10,6 +10,7 @@ import { readDaemonUserRoot } from "../../daemon/client.ts";
 
 export interface DaemonRepoCommandInput {
   readonly rootDir: string;
+  readonly layoutOverrides?: { readonly authoredRoot?: string };
   readonly args: ReadonlyArray<string>;
   readonly json: boolean;
 }
@@ -20,7 +21,7 @@ export function runDaemonRepoCommand(input: DaemonRepoCommandInput): number {
     console.log(renderDaemonRepoHelp());
     return 0;
   }
-  const userRoot = readOption(input.args, "--user-root") ?? readDaemonUserRoot(process.env, input.rootDir);
+  const userRoot = readOption(input.args, "--user-root") ?? readDaemonUserRoot(process.env, input.rootDir, input.layoutOverrides);
   const options = {
     userRoot,
     createConvenienceLinks: !input.args.includes("--no-link")

--- a/packages/cli/src/commands/settings.ts
+++ b/packages/cli/src/commands/settings.ts
@@ -18,6 +18,10 @@ export interface ProjectHarnessTaskSettings {
   readonly leaseTtlMs?: number;
 }
 
+export interface ProjectHarnessDaemonSettings {
+  readonly userRoot: string;
+}
+
 export interface ProjectHarnessSettings {
   readonly present: boolean;
   readonly locale?: HarnessLocale;
@@ -25,6 +29,7 @@ export interface ProjectHarnessSettings {
   readonly defaultPreset?: string;
   readonly defaultProfile?: string;
   readonly identity?: ProjectHarnessIdentity;
+  readonly daemon?: ProjectHarnessDaemonSettings;
   readonly tasks: ProjectHarnessTaskSettings;
   readonly customVerticalsEnabled: boolean;
 }
@@ -214,6 +219,7 @@ function parseSettingsDocument(body: string): { readonly present: boolean; reado
       defaultPreset: fromSettings.defaultPreset ?? decoded.presets?.default,
       defaultProfile: fromSettings.defaultProfile,
       identity: fromSettings.identity,
+      daemon: fromSettings.daemon,
       tasks: fromSettings.tasks,
       customVerticals: fromSettings.customVerticals
     };
@@ -232,6 +238,7 @@ function parseYamlSettings(body: string): { readonly present: boolean; readonly 
   let inSettings = false;
   let inCustomVerticals = false;
   let inIdentity = false;
+  let inDaemon = false;
   let inTasks = false;
   let foundSettings = false;
 
@@ -244,6 +251,7 @@ function parseYamlSettings(body: string): { readonly present: boolean; readonly 
       inSettings = topLevel[1] === "settings";
       inCustomVerticals = false;
       inIdentity = false;
+      inDaemon = false;
       inTasks = false;
       foundSettings ||= inSettings;
       if (inSettings && topLevel[2]?.trim()) {
@@ -261,6 +269,7 @@ function parseYamlSettings(body: string): { readonly present: boolean; readonly 
       const value = rawValue.trim();
       inCustomVerticals = key === "customVerticals";
       inIdentity = key === "identity";
+      inDaemon = key === "daemon";
       inTasks = key === "tasks";
       if (inCustomVerticals) {
         if (value) throw new Error("settings.customVerticals must be a mapping.");
@@ -270,6 +279,11 @@ function parseYamlSettings(body: string): { readonly present: boolean; readonly 
       if (inIdentity) {
         if (value) throw new Error("settings.identity must be a mapping.");
         settings.identity = {};
+        continue;
+      }
+      if (inDaemon) {
+        if (value) throw new Error("settings.daemon must be a mapping.");
+        settings.daemon = {};
         continue;
       }
       if (inTasks) {
@@ -298,6 +312,14 @@ function parseYamlSettings(body: string): { readonly present: boolean; readonly 
       const value = rawValue.trim();
       if (!value) throw new Error(`settings.identity.${key} must be a scalar value.`);
       settings.identity = { ...(isRecord(settings.identity) ? settings.identity : {}), [key]: unquoteScalar(value) };
+      continue;
+    }
+    if (inDaemon && customNested) {
+      const [, key, rawValue = ""] = customNested;
+      if (key !== "userRoot") throw new Error(`Unknown settings.daemon key: ${key}`);
+      const value = rawValue.trim();
+      if (!value) throw new Error("settings.daemon.userRoot must be a scalar value.");
+      settings.daemon = { userRoot: unquoteScalar(value) };
       continue;
     }
     if (inTasks && customNested) {
@@ -333,6 +355,8 @@ function validateSettings(command: string, raw: RawSettings): SettingsResult {
   if (!defaultProfile.ok) return invalid(command, defaultProfile.message);
   const identity = validateIdentity(command, raw.identity);
   if (!identity.ok) return identity;
+  const daemon = validateDaemon(command, raw.daemon);
+  if (!daemon.ok) return daemon;
   const tasks = raw.tasks;
   let leaseTtlMs: number | undefined;
   if (tasks !== undefined) {
@@ -371,6 +395,7 @@ function validateSettings(command: string, raw: RawSettings): SettingsResult {
       defaultPreset: normalizeDefaultSentinel(defaultPreset.value),
       defaultProfile: normalizeDefaultSentinel(defaultProfile.value),
       ...(identity.value ? { identity: identity.value } : {}),
+      ...(daemon.value ? { daemon: daemon.value } : {}),
       tasks: {
         leaseEnforcement: isRecord(tasks) && tasks.leaseEnforcement === true,
         ...(leaseTtlMs !== undefined ? { leaseTtlMs } : {})
@@ -378,6 +403,24 @@ function validateSettings(command: string, raw: RawSettings): SettingsResult {
       customVerticalsEnabled: isRecord(customVerticals) ? customVerticals.enabled === true : false
     }
   };
+}
+
+function validateDaemon(command: string, value: unknown):
+  | { readonly ok: true; readonly value?: ProjectHarnessDaemonSettings }
+  | Extract<SettingsResult, { readonly ok: false }> {
+  if (value === undefined) return { ok: true };
+  if (!isRecord(value)) return invalid(command, "settings.daemon must be a mapping.");
+  const keys = Object.keys(value);
+  if (keys.length !== 1 || keys[0] !== "userRoot") {
+    return invalid(command, "settings.daemon supports only userRoot.");
+  }
+  if (typeof value.userRoot !== "string" || !value.userRoot.trim() || value.userRoot.includes("\0")) {
+    return invalid(command, "settings.daemon.userRoot must be a non-empty path scalar.");
+  }
+  if (value.userRoot.startsWith("~") && value.userRoot !== "~" && !/^~[\\/]/u.test(value.userRoot)) {
+    return invalid(command, "settings.daemon.userRoot supports only ~ or ~/... home-relative paths.");
+  }
+  return { ok: true, value: { userRoot: value.userRoot.trim() } };
 }
 
 function validateIdentity(command: string, value: unknown):

--- a/packages/cli/src/commands/settings.ts
+++ b/packages/cli/src/commands/settings.ts
@@ -64,11 +64,13 @@ const SETTINGS_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9]*$/u;
 const SETTINGS_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9/_@.-]*$/u;
 const DEFAULT_TASK_LEASE_TTL_MS = 24 * 60 * 60 * 1_000;
 
-export function readProjectHarnessSettings(rootInput: HarnessLayoutInput, command = "settings"): SettingsResult {
+export function readProjectHarnessSettings(
+  rootInput: HarnessLayoutInput,
+  command = "settings",
+  options: { readonly preferAuthoredRootConfig?: boolean } = {}
+): SettingsResult {
   const layout = resolveHarnessLayout(rootInput);
-  const authoredRootOverridden = typeof rootInput !== "string"
-    && rootInput.layoutOverrides?.authoredRoot !== undefined;
-  const configPath = authoredRootOverridden
+  const configPath = options.preferAuthoredRootConfig
     ? path.join(layout.authoredRoot, "harness.yaml")
     : layout.configPath ?? path.join(layout.authoredRoot, "harness.yaml");
   if (!existsSync(configPath)) return { ok: true, settings: EMPTY_SETTINGS };

--- a/packages/cli/src/commands/settings.ts
+++ b/packages/cli/src/commands/settings.ts
@@ -66,7 +66,11 @@ const DEFAULT_TASK_LEASE_TTL_MS = 24 * 60 * 60 * 1_000;
 
 export function readProjectHarnessSettings(rootInput: HarnessLayoutInput, command = "settings"): SettingsResult {
   const layout = resolveHarnessLayout(rootInput);
-  const configPath = layout.configPath ?? path.join(layout.authoredRoot, "harness.yaml");
+  const authoredRootOverridden = typeof rootInput !== "string"
+    && rootInput.layoutOverrides?.authoredRoot !== undefined;
+  const configPath = authoredRootOverridden
+    ? path.join(layout.authoredRoot, "harness.yaml")
+    : layout.configPath ?? path.join(layout.authoredRoot, "harness.yaml");
   if (!existsSync(configPath)) return { ok: true, settings: EMPTY_SETTINGS };
 
   try {

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -132,7 +132,8 @@ function resolveDaemonUserRoot(
 function readProjectDaemonSettings(rootDir: string, layoutOverrides?: HarnessLayoutOverrides) {
   const settings = readProjectHarnessSettings(
     createHarnessRuntimeContext(rootDir, layoutOverrides),
-    "daemon-client-mode"
+    "daemon-client-mode",
+    { preferAuthoredRootConfig: layoutOverrides?.authoredRoot !== undefined }
   );
   if (!settings.ok) {
     const hint = settings.result.error?.hint ?? "Project daemon settings are invalid.";

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -25,7 +25,8 @@ import {
 import {
   createHarnessRuntimeContext,
   resolveHarnessLayout,
-  type CurrentSessionRef
+  type CurrentSessionRef,
+  type HarnessLayoutOverrides
 } from "@harness-anything/kernel";
 import { CliErrorCode, cliError } from "../cli/error-codes.ts";
 import type { CommandFailureReceipt, CommandReceipt } from "../cli/receipt.ts";
@@ -80,17 +81,18 @@ export function readDaemonClientConfig(
   env: NodeJS.ProcessEnv = process.env,
   rootDir = process.cwd(),
   modeOverride?: DaemonClientMode,
-  profileOverride?: "default" | "isolated"
+  profileOverride?: "default" | "isolated",
+  layoutOverrides?: HarnessLayoutOverrides
 ): DaemonClientConfig {
   env = {
     ...env,
     ...(modeOverride ? { HARNESS_DAEMON_MODE: modeOverride } : {}),
     ...(profileOverride ? { HARNESS_DAEMON_PROFILE: profileOverride } : {})
   };
-  const projectSettings = readProjectDaemonSettings(rootDir);
+  const projectSettings = readProjectDaemonSettings(rootDir, layoutOverrides);
   const projectMode = projectSettings?.identity?.mode;
   const mode = readMode(env.HARNESS_DAEMON_MODE ?? projectMode);
-  const userRoot = resolveDaemonUserRoot(env, rootDir, projectSettings);
+  const userRoot = resolveDaemonUserRoot(env, rootDir, projectSettings, layoutOverrides);
   const directWriteReason = readDirectWriteReason(env.HARNESS_DIRECT_WRITE_REASON);
   return {
     mode,
@@ -106,18 +108,20 @@ export function readDaemonClientConfig(
 
 export function readDaemonUserRoot(
   env: NodeJS.ProcessEnv = process.env,
-  rootDir = process.cwd()
+  rootDir = process.cwd(),
+  layoutOverrides?: HarnessLayoutOverrides
 ): string {
-  return resolveDaemonUserRoot(env, rootDir, readProjectDaemonSettings(rootDir));
+  return resolveDaemonUserRoot(env, rootDir, readProjectDaemonSettings(rootDir, layoutOverrides), layoutOverrides);
 }
 
 function resolveDaemonUserRoot(
   env: NodeJS.ProcessEnv,
   rootDir: string,
-  projectSettings: ReturnType<typeof readProjectDaemonSettings>
+  projectSettings: ReturnType<typeof readProjectDaemonSettings>,
+  layoutOverrides?: HarnessLayoutOverrides
 ): string {
   const projectUserRoot = projectSettings?.daemon?.userRoot;
-  const projectRoot = resolveHarnessLayout(rootDir).rootDir;
+  const projectRoot = resolveHarnessLayout(createHarnessRuntimeContext(rootDir, layoutOverrides)).rootDir;
   return daemonUserRootForRepo(
     projectRoot,
     env,
@@ -125,13 +129,17 @@ function resolveDaemonUserRoot(
   );
 }
 
-function readProjectDaemonSettings(rootDir: string) {
-  try {
-    const settings = readProjectHarnessSettings(rootDir, "daemon-client-mode");
-    return settings.ok ? settings.settings : undefined;
-  } catch {
+function readProjectDaemonSettings(rootDir: string, layoutOverrides?: HarnessLayoutOverrides) {
+  const settings = readProjectHarnessSettings(
+    createHarnessRuntimeContext(rootDir, layoutOverrides),
+    "daemon-client-mode"
+  );
+  if (!settings.ok) {
+    const hint = settings.result.error?.hint ?? "Project daemon settings are invalid.";
+    if (/\bsettings\.daemon\b/u.test(hint)) throw new Error(hint);
     return undefined;
   }
+  return settings.settings;
 }
 
 function resolveProjectDaemonUserRoot(rootDir: string, configured: string, env: NodeJS.ProcessEnv): string {
@@ -149,11 +157,12 @@ export function resolveLocalDaemonTarget(input: {
   readonly daemonId?: string;
   readonly autoRegisterSingleRepo?: boolean;
   readonly env?: NodeJS.ProcessEnv;
+  readonly layoutOverrides?: HarnessLayoutOverrides;
 }): LocalDaemonTarget {
   const env = input.env ?? process.env;
   return resolveDaemonTarget({
     ...input,
-    userRoot: input.userRoot ?? readDaemonUserRoot(env, input.rootDir),
+    userRoot: input.userRoot ?? readDaemonUserRoot(env, input.rootDir, input.layoutOverrides),
     env
   });
 }
@@ -162,7 +171,11 @@ export async function runCommandThroughDaemon(
   command: ParsedCommand,
   config?: DaemonClientConfig
 ): Promise<CommandReceipt | CommandFailureReceipt | undefined> {
-  config ??= readDaemonClientConfig(process.env, command.rootDir, command.daemonModeOverride, command.daemonProfileOverride);
+  try {
+    config ??= readDaemonClientConfig(process.env, command.rootDir, command.daemonModeOverride, command.daemonProfileOverride, command.layoutOverrides);
+  } catch (error) {
+    return daemonUnavailableReceipt(command, error);
+  }
   if (config.mode !== "remote" && command.action.kind === "init" && !isInitializedHarness(command)) return undefined;
   if (config.mode !== "remote" && isDeclaredLocalMigrationCommand(command.action)) return undefined;
   if (config.mode === "direct") {
@@ -194,7 +207,8 @@ async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfi
     repoIdOverride: command.daemonRepoId,
     userRoot: config.userRoot,
     daemonId: config.daemonId,
-    autoRegisterSingleRepo: true
+    autoRegisterSingleRepo: true,
+    layoutOverrides: command.layoutOverrides
   });
   if (isDocSyncSubmitCommand(command)) {
     let request: ReturnType<typeof buildDocSyncSubmitRequest>;

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Effect } from "effect";
@@ -17,7 +18,7 @@ import {
   JsonRpcLineClient,
   currentDaemonProtocolVersion,
   requestLocalDaemonJsonRpcForTarget,
-  resolveLocalDaemonTarget,
+  resolveLocalDaemonTarget as resolveDaemonTarget,
   type JsonObject,
   type LocalDaemonTarget
 } from "@harness-anything/daemon";
@@ -47,7 +48,7 @@ export {
   localUserDaemonEndpoint,
   localUserDaemonSocketPath,
   requestLocalDaemonJsonRpc,
-  resolveLocalDaemonTarget,
+  requestLocalDaemonJsonRpcForTarget,
   type LocalDaemonTarget
 } from "@harness-anything/daemon";
 
@@ -86,9 +87,10 @@ export function readDaemonClientConfig(
     ...(modeOverride ? { HARNESS_DAEMON_MODE: modeOverride } : {}),
     ...(profileOverride ? { HARNESS_DAEMON_PROFILE: profileOverride } : {})
   };
-  const projectMode = readProjectDaemonMode(rootDir);
+  const projectSettings = readProjectDaemonSettings(rootDir);
+  const projectMode = projectSettings?.identity?.mode;
   const mode = readMode(env.HARNESS_DAEMON_MODE ?? projectMode);
-  const userRoot = daemonUserRootForRepo(rootDir, env);
+  const userRoot = resolveDaemonUserRoot(env, rootDir, projectSettings);
   const directWriteReason = readDirectWriteReason(env.HARNESS_DIRECT_WRITE_REASON);
   return {
     mode,
@@ -102,13 +104,58 @@ export function readDaemonClientConfig(
   };
 }
 
-function readProjectDaemonMode(rootDir: string): "local" | "remote" | undefined {
+export function readDaemonUserRoot(
+  env: NodeJS.ProcessEnv = process.env,
+  rootDir = process.cwd()
+): string {
+  return resolveDaemonUserRoot(env, rootDir, readProjectDaemonSettings(rootDir));
+}
+
+function resolveDaemonUserRoot(
+  env: NodeJS.ProcessEnv,
+  rootDir: string,
+  projectSettings: ReturnType<typeof readProjectDaemonSettings>
+): string {
+  const projectUserRoot = projectSettings?.daemon?.userRoot;
+  const projectRoot = resolveHarnessLayout(rootDir).rootDir;
+  return daemonUserRootForRepo(
+    projectRoot,
+    env,
+    projectUserRoot ? resolveProjectDaemonUserRoot(projectRoot, projectUserRoot, env) : undefined
+  );
+}
+
+function readProjectDaemonSettings(rootDir: string) {
   try {
     const settings = readProjectHarnessSettings(rootDir, "daemon-client-mode");
-    return settings.ok ? settings.settings.identity?.mode : undefined;
+    return settings.ok ? settings.settings : undefined;
   } catch {
     return undefined;
   }
+}
+
+function resolveProjectDaemonUserRoot(rootDir: string, configured: string, env: NodeJS.ProcessEnv): string {
+  if (configured === "~" || /^~[\\/]/u.test(configured)) {
+    const home = typeof env.HOME === "string" && env.HOME.trim() ? env.HOME.trim() : os.homedir();
+    return path.resolve(home, configured.slice(1).replace(/^[\\/]+/u, ""));
+  }
+  return path.resolve(rootDir, configured);
+}
+
+export function resolveLocalDaemonTarget(input: {
+  readonly rootDir: string;
+  readonly repoIdOverride?: string;
+  readonly userRoot?: string;
+  readonly daemonId?: string;
+  readonly autoRegisterSingleRepo?: boolean;
+  readonly env?: NodeJS.ProcessEnv;
+}): LocalDaemonTarget {
+  const env = input.env ?? process.env;
+  return resolveDaemonTarget({
+    ...input,
+    userRoot: input.userRoot ?? readDaemonUserRoot(env, input.rootDir),
+    env
+  });
 }
 
 export async function runCommandThroughDaemon(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -127,7 +127,8 @@ async function maybeRunDaemonCommand(argv: ReadonlyArray<string>): Promise<numbe
     : undefined;
   const daemonArgs = stripped.daemonRepoId ? [...stripped.args, "--repo", stripped.daemonRepoId] : stripped.args;
   if (action === "connect") return runDaemonConnect(stripped.args, {
-    ...(readOption(argv, "--root") ? { rootDir: stripped.rootDir } : {})
+    ...(readOption(argv, "--root") ? { rootDir: stripped.rootDir } : {}),
+    ...(layoutOverrides ? { layoutOverrides } : {})
   });
   if (action === "serve") {
     let launchOptions: ParsedDaemonLaunchArgv;

--- a/packages/cli/test/daemon-user-root-settings.test.ts
+++ b/packages/cli/test/daemon-user-root-settings.test.ts
@@ -114,6 +114,38 @@ test("settings daemon userRoot validates path-shaped scalar input", () => {
     assert.equal(result.ok, false);
     if (result.ok) return;
     assert.match(result.result.error?.hint ?? "", /supports only ~ or ~\//u);
+    assert.throws(
+      () => readDaemonClientConfig(cleanDaemonEnv({ HOME: path.join(rootDir, "home") }), rootDir),
+      /settings\.daemon\.userRoot supports only ~ or ~\//u
+    );
+  });
+});
+
+test("daemon user root reads settings through an authored-root override", () => {
+  withTempRoot((rootDir) => {
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  daemon:",
+      "    userRoot: state/default-daemon",
+      ""
+    ]);
+    const authoredRoot = "authority/config";
+    const authoredRootPath = path.join(rootDir, authoredRoot);
+    mkdirSync(authoredRootPath, { recursive: true });
+    writeFileSync(path.join(authoredRootPath, "harness.yaml"), [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  daemon:",
+      "    userRoot: state/authority-daemon",
+      ""
+    ].join("\n"), "utf8");
+
+    const env = cleanDaemonEnv({ HOME: path.join(rootDir, "home") });
+    const layoutOverrides = { authoredRoot };
+    const expected = path.join(rootDir, "state/authority-daemon");
+    assert.equal(readDaemonClientConfig(env, rootDir, undefined, undefined, layoutOverrides).userRoot, expected);
+    assert.equal(resolveLocalDaemonTarget({ rootDir, env, layoutOverrides }).userRoot, expected);
   });
 });
 

--- a/packages/cli/test/daemon-user-root-settings.test.ts
+++ b/packages/cli/test/daemon-user-root-settings.test.ts
@@ -1,0 +1,141 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os, { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { localUserDaemonEndpoint } from "@harness-anything/daemon";
+import { readProjectHarnessSettings } from "../src/commands/settings.ts";
+import { readDaemonClientConfig, resolveLocalDaemonTarget } from "../src/daemon/client.ts";
+
+test("project daemon user root resolves once for config, registry target, socket, and autostart", () => {
+  withTempRoot((rootDir) => {
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  identity:",
+      "    mode: local",
+      "    personId: person_test",
+      "  daemon:",
+      "    userRoot: state/daemon",
+      "  tasks:",
+      "    leaseEnforcement: true",
+      ""
+    ]);
+
+    const env = cleanDaemonEnv({ HOME: path.join(rootDir, "home") });
+    const expected = path.resolve(rootDir, "state/daemon");
+    const config = readDaemonClientConfig(env, rootDir);
+    const target = resolveLocalDaemonTarget({ rootDir, env, autoRegisterSingleRepo: false });
+    const settings = readProjectHarnessSettings(rootDir);
+
+    assert.equal(settings.ok, true);
+    if (!settings.ok) return;
+    assert.deepEqual(settings.settings.daemon, { userRoot: "state/daemon" });
+    assert.equal(settings.settings.identity?.personId, "person_test");
+    assert.equal(settings.settings.tasks.leaseEnforcement, true);
+    assert.equal(config.userRoot, expected);
+    assert.equal(target.userRoot, expected);
+    assert.equal(target.socketPath, localUserDaemonEndpoint(expected, config.daemonId));
+
+    const nestedRoot = path.join(rootDir, "workspace/nested");
+    mkdirSync(nestedRoot, { recursive: true });
+    assert.equal(readDaemonClientConfig(env, nestedRoot).userRoot, expected);
+  });
+});
+
+test("daemon user root precedence preserves defaults and isolated profile", () => {
+  withTempRoot((rootDir) => {
+    const home = path.join(rootDir, "home");
+    const baseEnv = cleanDaemonEnv({ HOME: home });
+    assert.equal(readDaemonClientConfig(baseEnv, rootDir).userRoot, path.resolve(home, ".harness"));
+    assert.equal(
+      readDaemonClientConfig({ ...baseEnv, HARNESS_DAEMON_PROFILE: "isolated" }, rootDir).userRoot,
+      path.resolve(rootDir, ".harness/daemon-profile")
+    );
+
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  daemon:",
+      "    userRoot: project-daemon",
+      ""
+    ]);
+    assert.equal(
+      readDaemonClientConfig({ ...baseEnv, HARNESS_DAEMON_PROFILE: "isolated" }, rootDir).userRoot,
+      path.resolve(rootDir, "project-daemon")
+    );
+    assert.equal(
+      readDaemonClientConfig({
+        ...baseEnv,
+        HARNESS_DAEMON_PROFILE: "isolated",
+        HARNESS_DAEMON_USER_ROOT: path.join(rootDir, "operations-override")
+      }, rootDir).userRoot,
+      path.resolve(rootDir, "operations-override")
+    );
+  });
+});
+
+test("project daemon user root expands home and accepts absolute paths", () => {
+  withTempRoot((rootDir) => {
+    const home = path.join(rootDir, "configured-home");
+    const env = cleanDaemonEnv({ HOME: home });
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  daemon:",
+      "    userRoot: ~/.harness-project",
+      ""
+    ]);
+    assert.equal(readDaemonClientConfig(env, rootDir).userRoot, path.resolve(home, ".harness-project"));
+
+    const absolute = path.join(rootDir, "absolute-daemon");
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  daemon:",
+      `    userRoot: ${absolute}`,
+      ""
+    ]);
+    assert.equal(readDaemonClientConfig(env, rootDir).userRoot, path.resolve(absolute));
+  });
+});
+
+test("settings daemon userRoot validates path-shaped scalar input", () => {
+  withTempRoot((rootDir) => {
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  daemon:",
+      "    userRoot: ~another-user/daemon",
+      ""
+    ]);
+    const result = readProjectHarnessSettings(rootDir);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.result.error?.hint ?? "", /supports only ~ or ~\//u);
+  });
+});
+
+function withTempRoot(run: (rootDir: string) => void): void {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-daemon-settings-"));
+  try {
+    run(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function writeHarnessConfig(rootDir: string, lines: ReadonlyArray<string>): void {
+  const harnessDir = path.join(rootDir, "harness");
+  mkdirSync(harnessDir, { recursive: true });
+  writeFileSync(path.join(harnessDir, "harness.yaml"), lines.join("\n"), "utf8");
+}
+
+function cleanDaemonEnv(overrides: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    HOME: os.homedir(),
+    ...overrides
+  };
+}

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -117,9 +117,14 @@ export function daemonUserRoot(env: NodeJS.ProcessEnv = process.env): string {
   return path.resolve(readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_USER_ROOT") ?? path.join(home, ".harness"));
 }
 
-export function daemonUserRootForRepo(rootDir: string, env: NodeJS.ProcessEnv = process.env): string {
+export function daemonUserRootForRepo(
+  rootDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+  projectUserRoot?: string
+): string {
   const explicit = readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_USER_ROOT");
   if (explicit) return path.resolve(explicit);
+  if (projectUserRoot) return path.resolve(projectUserRoot);
   const profile = readNonEmptyDaemonEnv(env, "HARNESS_DAEMON_PROFILE") ?? "default";
   if (profile === "default") return daemonUserRoot(env);
   if (profile === "isolated") return path.resolve(rootDir, ".harness", "daemon-profile");

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -68,8 +68,9 @@ export async function startGuiApp(): Promise<void> {
   installContentSecurityPolicy();
   const trustedWebContentsIds = new Set<number>();
   const rootDir = resolveGuiProjectRoot();
-  const projectionNotifications = createLocalGuiProjectionNotifications(rootDir);
-  registerHarnessIpcHandlers(ipcMain, createLocalGuiServiceBridge(rootDir, resolveGuiLayoutOverrides()), {
+  const layoutOverrides = resolveGuiLayoutOverrides();
+  const projectionNotifications = createLocalGuiProjectionNotifications(rootDir, layoutOverrides);
+  registerHarnessIpcHandlers(ipcMain, createLocalGuiServiceBridge(rootDir, layoutOverrides), {
     isTrustedWebContentsId: (id) => trustedWebContentsIds.has(id),
     rendererUrl: {
       packagedRendererUrl: createLocalPackagedRendererUrl(),

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -1,9 +1,11 @@
 import { app, BrowserWindow, ipcMain, session } from "electron";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import type { HarnessLayoutOverrides } from "@harness-anything/kernel";
 import { registerHarnessIpcHandlers } from "./ipc-handlers.ts";
-import { createLocalGuiServiceBridge } from "./local-composition-root.ts";
+import {
+  createLocalGuiServiceBridge,
+  type HarnessLayoutOverrides
+} from "./local-composition-root.ts";
 import { createLocalGuiProjectionNotifications } from "./projection-notifications.ts";
 import { evaluateNavigationRequest, evaluatePermissionRequest, evaluateWindowOpenRequest } from "./security-policy.ts";
 import { assertDevRendererUrl, createGuiContentSecurityPolicy } from "./window-config.ts";

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -28,7 +28,7 @@ export interface GuiDaemonNotificationTarget {
   readonly socketPath: string;
 }
 
-interface HarnessLayoutOverrides {
+export interface HarnessLayoutOverrides {
   readonly authoredRoot?: string;
 }
 

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -41,6 +41,7 @@ interface LocalDaemonClientModule {
     readonly daemonId?: string;
     readonly autoRegisterSingleRepo?: boolean;
     readonly env?: NodeJS.ProcessEnv;
+    readonly layoutOverrides?: HarnessLayoutOverrides;
   }) => LocalDaemonTarget;
   readonly requestLocalDaemonJsonRpcForTarget: (
     target: LocalDaemonTarget,
@@ -61,7 +62,7 @@ interface LocalDaemonClientModule {
 
 let daemonClientModulePromise: Promise<LocalDaemonClientModule> | undefined;
 let daemonSettingsModulePromise: Promise<{
-  readonly readDaemonUserRoot: (env?: NodeJS.ProcessEnv, rootDir?: string) => string;
+  readonly readDaemonUserRoot: (env?: NodeJS.ProcessEnv, rootDir?: string, layoutOverrides?: HarnessLayoutOverrides) => string;
 }> | undefined;
 
 interface GuiDaemonBridgeState {
@@ -75,17 +76,21 @@ export function createLocalGuiServiceBridge(rootDir: string, layoutOverrides?: H
   return createGuiServiceBridgeForDaemon(async (route, payload) => requestGuiRouteViaDaemon(resolvedRootDir, layoutOverrides, state, route, payload));
 }
 
-export async function resolveGuiDaemonNotificationTarget(rootDir: string): Promise<GuiDaemonNotificationTarget> {
+export async function resolveGuiDaemonNotificationTarget(
+  rootDir: string,
+  layoutOverrides?: HarnessLayoutOverrides
+): Promise<GuiDaemonNotificationTarget> {
   const resolvedRootDir = path.resolve(rootDir);
   validateProjectPath(resolvedRootDir, ".");
   const [daemonClient, daemonSettings] = await Promise.all([loadDaemonClientModule(), loadDaemonSettingsModule()]);
-  const userRoot = daemonSettings.readDaemonUserRoot(process.env, resolvedRootDir);
+  const userRoot = daemonSettings.readDaemonUserRoot(process.env, resolvedRootDir, layoutOverrides);
   const target = daemonClient.resolveLocalDaemonTarget({
     rootDir: resolvedRootDir,
     repoIdOverride: process.env.HARNESS_DAEMON_REPO_ID,
     userRoot,
     daemonId: daemonClient.daemonIdFromEnv(),
-    autoRegisterSingleRepo: true
+    autoRegisterSingleRepo: true,
+    layoutOverrides
   });
   return { repoId: target.repoId, socketPath: target.socketPath };
 }
@@ -99,14 +104,15 @@ async function requestGuiRouteViaDaemon(
 ): Promise<JsonObject> {
   try {
     const [daemonClient, daemonSettings] = await Promise.all([loadDaemonClientModule(), loadDaemonSettingsModule()]);
-    const userRoot = daemonSettings.readDaemonUserRoot(process.env, rootDir);
+    const userRoot = daemonSettings.readDaemonUserRoot(process.env, rootDir, layoutOverrides);
     const daemonId = daemonClient.daemonIdFromEnv();
     const target = daemonClient.resolveLocalDaemonTarget({
       rootDir,
       repoIdOverride: process.env.HARNESS_DAEMON_REPO_ID,
       userRoot,
       daemonId,
-      autoRegisterSingleRepo: true
+      autoRegisterSingleRepo: true,
+      layoutOverrides
     });
     const customLayout = hasLayoutOverride(layoutOverrides);
     if (customLayout && !state.layoutOverrideDaemonStarted && await daemonAlreadyRunning(daemonClient, target)) {
@@ -206,10 +212,10 @@ function daemonClientModuleUrl(): string {
 }
 
 async function loadDaemonSettingsModule(): Promise<{
-  readonly readDaemonUserRoot: (env?: NodeJS.ProcessEnv, rootDir?: string) => string;
+  readonly readDaemonUserRoot: (env?: NodeJS.ProcessEnv, rootDir?: string, layoutOverrides?: HarnessLayoutOverrides) => string;
 }> {
   daemonSettingsModulePromise ??= import(daemonSettingsModuleUrl()) as Promise<{
-    readonly readDaemonUserRoot: (env?: NodeJS.ProcessEnv, rootDir?: string) => string;
+    readonly readDaemonUserRoot: (env?: NodeJS.ProcessEnv, rootDir?: string, layoutOverrides?: HarnessLayoutOverrides) => string;
   }>;
   return daemonSettingsModulePromise;
 }

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { validateProjectPath } from "../api/local-api.ts";
 import { createGuiServiceBridgeForDaemon } from "../api/service-bridge.ts";
 import type { ApiRouteContract } from "../api/api-contract-registry.ts";
@@ -33,7 +33,6 @@ interface HarnessLayoutOverrides {
 }
 
 interface LocalDaemonClientModule {
-  readonly daemonUserRoot: (env?: NodeJS.ProcessEnv) => string;
   readonly daemonIdFromEnv: (env?: NodeJS.ProcessEnv) => string;
   readonly resolveLocalDaemonTarget: (input: {
     readonly rootDir: string;
@@ -61,6 +60,9 @@ interface LocalDaemonClientModule {
 }
 
 let daemonClientModulePromise: Promise<LocalDaemonClientModule> | undefined;
+let daemonSettingsModulePromise: Promise<{
+  readonly readDaemonUserRoot: (env?: NodeJS.ProcessEnv, rootDir?: string) => string;
+}> | undefined;
 
 interface GuiDaemonBridgeState {
   layoutOverrideDaemonStarted: boolean;
@@ -76,11 +78,12 @@ export function createLocalGuiServiceBridge(rootDir: string, layoutOverrides?: H
 export async function resolveGuiDaemonNotificationTarget(rootDir: string): Promise<GuiDaemonNotificationTarget> {
   const resolvedRootDir = path.resolve(rootDir);
   validateProjectPath(resolvedRootDir, ".");
-  const daemonClient = await loadDaemonClientModule();
+  const [daemonClient, daemonSettings] = await Promise.all([loadDaemonClientModule(), loadDaemonSettingsModule()]);
+  const userRoot = daemonSettings.readDaemonUserRoot(process.env, resolvedRootDir);
   const target = daemonClient.resolveLocalDaemonTarget({
     rootDir: resolvedRootDir,
     repoIdOverride: process.env.HARNESS_DAEMON_REPO_ID,
-    userRoot: daemonClient.daemonUserRoot(),
+    userRoot,
     daemonId: daemonClient.daemonIdFromEnv(),
     autoRegisterSingleRepo: true
   });
@@ -95,8 +98,8 @@ async function requestGuiRouteViaDaemon(
   payload: unknown
 ): Promise<JsonObject> {
   try {
-    const daemonClient = await loadDaemonClientModule();
-    const userRoot = daemonClient.daemonUserRoot();
+    const [daemonClient, daemonSettings] = await Promise.all([loadDaemonClientModule(), loadDaemonSettingsModule()]);
+    const userRoot = daemonSettings.readDaemonUserRoot(process.env, rootDir);
     const daemonId = daemonClient.daemonIdFromEnv();
     const target = daemonClient.resolveLocalDaemonTarget({
       rootDir,
@@ -200,6 +203,27 @@ async function loadDaemonClientModule(): Promise<LocalDaemonClientModule> {
 
 function daemonClientModuleUrl(): string {
   return new URL("../../../daemon/src/client/local-json-rpc-client.ts", import.meta.url).href;
+}
+
+async function loadDaemonSettingsModule(): Promise<{
+  readonly readDaemonUserRoot: (env?: NodeJS.ProcessEnv, rootDir?: string) => string;
+}> {
+  daemonSettingsModulePromise ??= import(daemonSettingsModuleUrl()) as Promise<{
+    readonly readDaemonUserRoot: (env?: NodeJS.ProcessEnv, rootDir?: string) => string;
+  }>;
+  return daemonSettingsModulePromise;
+}
+
+function daemonSettingsModuleUrl(): string {
+  const resourcesPath = electronResourcesPath();
+  const candidates = [
+    ...(resourcesPath ? [path.join(resourcesPath, "app/packages/cli/dist/cli/src/daemon/client.js")] : []),
+    fileURLToPath(new URL("../../../cli/src/daemon/client.ts", import.meta.url)),
+    fileURLToPath(new URL("../../../cli/dist/cli/src/daemon/client.js", import.meta.url))
+  ];
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (!found) throw new Error(`Harness daemon client module not found; checked ${candidates.join(", ")}`);
+  return pathToFileURL(realpathSync(found)).href;
 }
 
 function cliEntrypointPath(): string {

--- a/packages/gui/src/main/projection-notifications.ts
+++ b/packages/gui/src/main/projection-notifications.ts
@@ -1,11 +1,13 @@
 import type { Disposable, ProjectionChangeNotification, Subscription } from "@harness-anything/api-contracts";
 import { JsonLineSocketTransport, PersistentDaemonClient } from "@harness-anything/daemon-client";
-import type { HarnessLayoutOverrides } from "@harness-anything/kernel";
 import type {
   HarnessProjectionNotificationSource
 } from "./ipc-handlers.ts";
 import type { RendererProjectionNotification } from "../preload/allowlist.ts";
-import { resolveGuiDaemonNotificationTarget } from "./local-composition-root.ts";
+import {
+  resolveGuiDaemonNotificationTarget,
+  type HarnessLayoutOverrides
+} from "./local-composition-root.ts";
 
 const daemonConnectionTimeoutMs = 6_000;
 const projectionSubscriptionTimeoutMs = 1_000;

--- a/packages/gui/src/main/projection-notifications.ts
+++ b/packages/gui/src/main/projection-notifications.ts
@@ -1,5 +1,6 @@
 import type { Disposable, ProjectionChangeNotification, Subscription } from "@harness-anything/api-contracts";
 import { JsonLineSocketTransport, PersistentDaemonClient } from "@harness-anything/daemon-client";
+import type { HarnessLayoutOverrides } from "@harness-anything/kernel";
 import type {
   HarnessProjectionNotificationSource
 } from "./ipc-handlers.ts";
@@ -14,7 +15,10 @@ export interface LocalGuiProjectionNotifications {
   readonly dispose: () => Promise<void>;
 }
 
-export function createLocalGuiProjectionNotifications(rootDir: string): LocalGuiProjectionNotifications {
+export function createLocalGuiProjectionNotifications(
+  rootDir: string,
+  layoutOverrides?: HarnessLayoutOverrides
+): LocalGuiProjectionNotifications {
   let client: PersistentDaemonClient | undefined;
   let clientEvents: Disposable | undefined;
   let clientState: Disposable | undefined;
@@ -59,7 +63,7 @@ export function createLocalGuiProjectionNotifications(rootDir: string): LocalGui
 
   async function ensureClient(): Promise<PersistentDaemonClient> {
     if (client) return client;
-    const target = await resolveGuiDaemonNotificationTarget(rootDir);
+    const target = await resolveGuiDaemonNotificationTarget(rootDir, layoutOverrides);
     client = new PersistentDaemonClient({
       endpoint: target.socketPath,
       transport: new JsonLineSocketTransport(),

--- a/packages/gui/test/daemon-user-root-settings.test.ts
+++ b/packages/gui/test/daemon-user-root-settings.test.ts
@@ -1,0 +1,59 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createLocalGuiServiceBridge } from "../src/index.ts";
+import { withGuiDaemonEnv } from "./helpers/daemon-generation-lifecycle.ts";
+
+test("GUI daemon bridge honors the project daemon user root", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-settings-daemon-"));
+  const authoredRoot = path.join(rootDir, "harness");
+  const configuredUserRoot = path.join(rootDir, "project-daemon");
+  try {
+    mkdirSync(path.join(authoredRoot, "tasks", "task-1"), { recursive: true });
+    writeFileSync(path.join(authoredRoot, "harness.yaml"), [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  daemon:",
+      "    userRoot: project-daemon",
+      ""
+    ].join("\n"), "utf8");
+    writeFileSync(path.join(authoredRoot, "tasks", "task-1", "INDEX.md"), [
+      "---",
+      "schema: task-package/v2",
+      "task_id: task-1",
+      "title: Task One",
+      "lifecycle:",
+      "  bindingSchema: lifecycle-binding/v1",
+      "  engine: local",
+      "  status: planned",
+      "  ref: ",
+      "  titleSnapshot: Task One",
+      "  url: ",
+      "  bindingCreatedAt: 2026-06-12T00:00:00.000Z",
+      "  bindingFingerprint: sha256:test",
+      "packageDisposition: active",
+      "vertical: default",
+      "preset: default",
+      "---",
+      ""
+    ].join("\n"), "utf8");
+
+    const list = await withGuiDaemonEnv(rootDir, async () => {
+      return createLocalGuiServiceBridge(rootDir).invoke("getTasks", null) as Promise<{
+        readonly ok: boolean;
+        readonly tasks: readonly unknown[];
+      }>;
+    }, { userRoot: false });
+
+    assert.equal(list.ok, true);
+    assert.equal(list.tasks.length, 1);
+    assert.equal(existsSync(path.join(configuredUserRoot, "registry.json")), true);
+    assert.equal(existsSync(path.join(rootDir, ".harness", "registry.json")), false);
+  } finally {
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/gui/test/daemon-user-root-settings.test.ts
+++ b/packages/gui/test/daemon-user-root-settings.test.ts
@@ -1,17 +1,26 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { createLocalGuiServiceBridge } from "../src/index.ts";
 import { withGuiDaemonEnv } from "./helpers/daemon-generation-lifecycle.ts";
 
-test("GUI daemon bridge honors the project daemon user root", async () => {
+test("GUI daemon bridge honors daemon user root from an authored-root override", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-settings-daemon-"));
-  const authoredRoot = path.join(rootDir, "harness");
+  const authoredRootOverride = "authority/config";
+  const authoredRoot = path.join(rootDir, authoredRootOverride);
   const configuredUserRoot = path.join(rootDir, "project-daemon");
   try {
+    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+    writeFileSync(path.join(rootDir, "harness", "harness.yaml"), [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  daemon:",
+      "    userRoot: default-daemon",
+      ""
+    ].join("\n"), "utf8");
     mkdirSync(path.join(authoredRoot, "tasks", "task-1"), { recursive: true });
     writeFileSync(path.join(authoredRoot, "harness.yaml"), [
       "schema: harness-anything/v1",
@@ -42,7 +51,7 @@ test("GUI daemon bridge honors the project daemon user root", async () => {
     ].join("\n"), "utf8");
 
     const list = await withGuiDaemonEnv(rootDir, async () => {
-      return createLocalGuiServiceBridge(rootDir).invoke("getTasks", null) as Promise<{
+      return createLocalGuiServiceBridge(rootDir, { authoredRoot: authoredRootOverride }).invoke("getTasks", null) as Promise<{
         readonly ok: boolean;
         readonly tasks: readonly unknown[];
       }>;
@@ -50,8 +59,14 @@ test("GUI daemon bridge honors the project daemon user root", async () => {
 
     assert.equal(list.ok, true);
     assert.equal(list.tasks.length, 1);
-    assert.equal(existsSync(path.join(configuredUserRoot, "registry.json")), true);
-    assert.equal(existsSync(path.join(rootDir, ".harness", "registry.json")), false);
+    assert.equal(
+      readdirSync(configuredUserRoot).some((name) => name.startsWith("daemon-launch-spec.")),
+      true
+    );
+    assert.equal(
+      readdirSync(path.join(rootDir, ".harness")).some((name) => name.startsWith("daemon-launch-spec.")),
+      false
+    );
   } finally {
     await new Promise((resolve) => setTimeout(resolve, 700));
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/gui/test/helpers/daemon-generation-lifecycle.ts
+++ b/packages/gui/test/helpers/daemon-generation-lifecycle.ts
@@ -12,12 +12,16 @@ import {
 export async function withGuiDaemonEnv<T>(
   rootDir: string,
   run: () => Promise<T>,
-  options: { readonly idleMs?: string } = {}
+  options: { readonly idleMs?: string; readonly userRoot?: string | false } = {}
 ): Promise<T> {
   const previousUserRoot = process.env.HARNESS_DAEMON_USER_ROOT;
   const previousIdleMs = process.env.HARNESS_DAEMON_IDLE_MS;
   const previousAutostartTimeout = process.env.HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS;
-  process.env.HARNESS_DAEMON_USER_ROOT = path.join(rootDir, "user-daemon");
+  if (options.userRoot === false) {
+    delete process.env.HARNESS_DAEMON_USER_ROOT;
+  } else {
+    process.env.HARNESS_DAEMON_USER_ROOT = options.userRoot ?? path.join(rootDir, "user-daemon");
+  }
   process.env.HARNESS_DAEMON_IDLE_MS = options.idleMs ?? "250";
   // Cold daemon spawn on a loaded CI runner regularly exceeds the 6s
   // interactive default; the hermetic tests care about correctness, not

--- a/tools/package-boundary-violations.json
+++ b/tools/package-boundary-violations.json
@@ -1,6 +1,6 @@
 {
   "schema": "harness-anything/package-boundary-violations/v1",
-  "total": 12,
+  "total": 11,
   "violations": [
     { "file": "packages/gui/src/api/gui-route-payload.ts", "source": "gui", "target": "application", "count": 1 },
     { "file": "packages/gui/src/api/renderer-dto.ts", "source": "gui", "target": "application", "count": 1 },
@@ -10,7 +10,6 @@
     { "file": "packages/gui/src/api/view-model.ts", "source": "gui", "target": "kernel", "count": 1 },
     { "file": "packages/gui/src/daemon/remote-tunnel.ts", "source": "gui", "target": "application", "count": 1 },
     { "file": "packages/gui/src/index.ts", "source": "gui", "target": "application", "count": 1 },
-    { "file": "packages/gui/src/main/electron-main.ts", "source": "gui", "target": "kernel", "count": 1 },
     { "file": "packages/gui/src/terminal/session-registry.ts", "source": "gui", "target": "application", "count": 2 }
   ]
 }


### PR DESCRIPTION
# English

## Summary

Add project-level `settings.daemon.userRoot`: a repository can pin its own daemon user root in project settings, and every daemon client path (CLI commands, connect, control, repo-registry, GUI) resolves to it automatically — no env vars, no flags in daily use.

## What Changed

- `settings.ts`: parse, validate, and round-trip the new `daemon.userRoot` field (sibling of `identity`).
- Daemon client: unified precedence `HARNESS_DAEMON_USER_ROOT` env > `settings.daemon.userRoot` > `HARNESS_DAEMON_PROFILE` default; `~` expansion and repo-relative path resolution; socket/registry/autostart all derive from the same resolved root.
- `connect.ts`, `control.ts`, `repo-registry.ts`: these previously reached the default root directly, bypassing settings; now they share the same resolver so control RPCs, registry commands, and lifecycle targets cannot fork onto different roots.
- GUI composition root: gains a settings-aware resolver so GUI requests, notifications, and autostart use the same root as the CLI.
- New regression tests (CLI + GUI): precedence, default/isolated profiles untouched, relative paths, `~`, settings round-trip, GUI autostart.

## Task And Scope

Task `task_01KXYS8X3DD9618TFC2ABQ9FDD`. First consumer: harness-anything itself — prerequisite for splitting the production-authority daemon onto a dedicated user root so `~/.harness` returns to the default multi-repo daemon (fixes `repo_unavailable` for ordinary projects like DRG).

## Version Impact

Minor (new settings field, backward compatible; undeclared repos behave exactly as before).

## Governance Declaration

Authorized by task `task_01KXYS8X3DD9618TFC2ABQ9FDD` (settings.daemon.userRoot pinning). Daemon client resolution surface: additive branch only; env escape hatch and `isolated` profile semantics preserved. The `tools/package-boundary-violations.json` change is a ratchet-down only (baseline 12 -> 11, removing a gui->kernel edge) under the W1 boundary contract; no gate weakened, no CI/gate authority changes.

## Verification

Locally green: typecheck, new CLI/GUI regression tests 5/5, plus multiple full local integration shard passes earlier in the session. Full matrix delegated to GitHub CI per CEO ruling (local full gate retired 2026-07-20).

## Review Evidence

CEO semantic review of the touch list (each out-of-plan file — connect/control/repo-registry/GUI — is a previously root-forking call site; unifying them is the point of the feature). Single-reviewer round runs in parallel with CI.

## Residual Risk

The daemon-split migration itself (moving harness-anything to `~/.harness-production`) is a separate maintenance-window operation, deliberately not part of this PR.

## References

- Task: `task_01KXYS8X3DD9618TFC2ABQ9FDD`
- Motivating incident: production-authority daemon occupying `~/.harness` causes `repo_unavailable` for unregistered-in-manifest projects; `AUTHORITY_MANIFEST_REGISTRY_INCOMPLETE` on mixed cold start

---

# 中文

## 概要

新增项目级 `settings.daemon.userRoot`：仓库可在项目 settings 里钉定自己的 daemon user root，所有 daemon client 路径（CLI 命令、connect、control、repo-registry、GUI）自动解析到该 root——日常零 env、零 flag。

## 改动内容

- `settings.ts`：新字段 `daemon.userRoot` 的解析、校验与 round-trip（与 `identity` 平级）。
- daemon client：统一优先级 `HARNESS_DAEMON_USER_ROOT` env > `settings.daemon.userRoot` > `HARNESS_DAEMON_PROFILE` 默认；支持 `~` 展开与相对仓根路径；socket/registry/autostart 全部从同一解析结果派生。
- `connect.ts`、`control.ts`、`repo-registry.ts`：原先直取默认 root、绕过 settings；现共用同一 resolver，控制 RPC、registry 命令与生命周期 target 不会分叉到不同 root。
- GUI composition root：新增 settings-aware resolver，GUI 请求、通知与 autostart 与 CLI 同根。
- 新增 CLI + GUI 回归测试：优先级、default/isolated 不受影响、相对路径、`~`、settings 保留、GUI autostart。

## 任务与范围

任务 `task_01KXYS8X3DD9618TFC2ABQ9FDD`。第一消费者 = harness-anything 自身——是"生产政体 daemon 搬去专属 user root、`~/.harness` 归还公共 multi-repo daemon"拆分方案的前置（根治 DRG 等普通项目的 `repo_unavailable`）。

## 版本影响

Minor（新增 settings 字段，向后兼容；未声明的仓行为完全不变）。

## 治理声明

授权任务 `task_01KXYS8X3DD9618TFC2ABQ9FDD`（settings.daemon.userRoot 钉定）。daemon client 解析面：只加分支不改默认；env 逃生舱与 `isolated` profile 语义保持。`tools/package-boundary-violations.json` 仅为 ratchet 反向收紧（baseline 12 -> 11，消除一条 gui->kernel 边），属 W1 边界契约下的只紧不松；无削门、无 CI/gate 权威面改动。

## 验证

本地已绿：typecheck、新增 CLI/GUI 回归测试 5/5，此前会话中多轮 integration 分片全绿。完整矩阵按 CEO 裁定（2026-07-20 本地全量门退役）交 GitHub CI。

## 审查证据

CEO 已对触面清单做语义验收（计划外文件 connect/control/repo-registry/GUI 各自都是原先分叉取默认 root 的位点，统一它们正是本 feature 的目的）。单评审员评审与 CI 并行。

## 残余风险

daemon 拆分迁移本身（harness-anything 搬 `~/.harness-production`）是独立的维护窗操作，刻意不在本 PR 内。

## 关联材料

- 任务：`task_01KXYS8X3DD9618TFC2ABQ9FDD`
- 动机事故：production-authority daemon 占据 `~/.harness` 导致 manifest 外项目 `repo_unavailable`；混住 registry 冷启动抛 `AUTHORITY_MANIFEST_REGISTRY_INCOMPLETE`

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body / 双语正文
- [x] Governance declaration / 治理声明
- [x] Task linkage / 任务关联

