### PR TITLE
fix(hooks): rebuild kernel declarations before post-merge cli build

### DIFF
--- a/tools/post-merge-runtime-refresh.mjs
+++ b/tools/post-merge-runtime-refresh.mjs
@@ -76,6 +76,11 @@ export function executePostMergeRuntimeRefresh(input) {
     wrapped("git-hook-dependency-sync", "npm", ["ci"]);
   }
   if (input.plan.buildCli) {
+    // kernel dist/index.d.ts is a git-ignored declaration artifact that the CLI
+    // build resolves through the package "types" condition; it must be
+    // regenerated first or a changed kernel public surface fails every
+    // downstream tsc build against stale declarations.
+    wrapped("git-hook-kernel-decls", "npx", ["tsc", "-p", "packages/kernel/tsconfig.json"]);
     wrapped("git-hook-cli-build", "npm", ["run", "build", "-w", "@harness-anything/cli"]);
   }
   if (input.plan.buildGui) {


### PR DESCRIPTION
# English

## Summary

Post-merge runtime refresh failed on canonical main after the W1 boundary merge: the CLI build resolves `@harness-anything/kernel` types through the git-ignored `packages/kernel/dist/index.d.ts`, which nothing in the hook chain regenerates. A changed kernel public surface breaks every downstream tsc build against stale declarations.

## What Changed

`tools/post-merge-runtime-refresh.mjs`: regenerate kernel declarations (`tsc -p packages/kernel/tsconfig.json`) as a wrapped hook step immediately before the CLI build.

## Task And Scope

Operational fix under umbrella `task_01KXWZ3YEGXD6302G1656RY801` (PLT-Baseline-Governance); production incident 2026-07-20: post-merge deploy of PR #950 blocked by `TS2724 AttributionProjectionRow` against a stale kernel d.ts.

## Version Impact

None (git-hook tooling only).

## Governance Declaration

Authorized by umbrella task `task_01KXWZ3YEGXD6302G1656RY801` / charter `dec_01KXWZ33N9`. Write surface unchanged: the new step runs inside the existing `run-with-local-resources.mjs` wrapper; write-road registry check passes.

## Verification

Reproduced the failure (CLI build red against stale d.ts), regenerated declarations, CLI build green; `node tools/check-write-road-registry.mjs` passes.

## Review Evidence

CEO-authored one-line hook fix; verified by direct reproduction before/after. Low risk, docs-tier review per situational review policy.

## Residual Risk

Related but separate: daemon build identity misses TypeScript artifact changes (`sha256:7265e1f7…` constant across merges) — confirmed defect, tracked for its own task.

## References

- Umbrella: `task_01KXWZ3YEGXD6302G1656RY801` / charter `dec_01KXWZ33N9`
- Incident context: PR #950 deploy

---

# 中文

## 概要

W1 边界合并后 canonical main 的 post-merge runtime refresh 失败：CLI build 经包 `types` 条件解析到 git-ignored 的 `packages/kernel/dist/index.d.ts`，而 hook 链没有任何步骤重新生成它。kernel 公共面一变，所有下游 tsc build 都撞陈旧 declaration。

## 改动内容

`tools/post-merge-runtime-refresh.mjs`：在 CLI build 之前增加一步 wrapped hook（`tsc -p packages/kernel/tsconfig.json`）重新生成 kernel declaration。

## 任务与范围

伞任务 `task_01KXWZ3YEGXD6302G1656RY801`（PLT-Baseline-Governance）下的运维修复；生产事故 2026-07-20：PR #950 的 post-merge 部署被 `TS2724 AttributionProjectionRow`（陈旧 kernel d.ts）卡住。

## 版本影响

无（仅 git-hook 工具）。

## 治理声明

授权自伞任务 `task_01KXWZ3YEGXD6302G1656RY801` / charter `dec_01KXWZ33N9`。写面未变：新步骤在既有 `run-with-local-resources.mjs` 包装器内执行；write-road registry 检查通过。

## 验证

先复现失败（CLI build 对陈旧 d.ts 红）、重生成 declaration 后 CLI build 绿；`node tools/check-write-road-registry.mjs` 通过。

## 审查证据

CEO 亲写的一行 hook 修复；改前/改后直接复现验证。低风险，按情境评审策略走文档级评审。

## 残余风险

相关但独立：daemon build identity 计算漏掉 TypeScript 产物变化（`sha256:7265e1f7…` 跨合并不变）——已确认缺陷，另立任务跟踪。

## 关联材料

- 伞任务：`task_01KXWZ3YEGXD6302G1656RY801` / charter `dec_01KXWZ33N9`
- 事故上下文：PR #950 部署

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body / 双语正文
- [x] Governance declaration / 治理声明
- [x] Task linkage / 任务关联
