### PR TITLE
perf(ci): real shard weights + drift alarm; perf-class tests to nightly (dec_01KXZ2WZMB)

### DIFF
--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -1,0 +1,23 @@
+name: nightly-integration
+
+on:
+  schedule:
+    - cron: "43 18 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-integration
+  cancel-in-progress: false
+
+jobs:
+  production-authority-perf-matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Run startup performance and canonical ingress matrices
+        run: npm run test:nightly

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:fast": "node tools/run-node-tests.mjs --tier fast",
     "test:contract": "node tools/run-node-tests.mjs --tier contract",
     "test:integration": "node tools/run-node-tests.mjs --tier integration",
+    "test:nightly": "node tools/run-node-tests.mjs --tier nightly --concurrency 1",
     "test:list": "node tools/run-node-tests.mjs --list",
     "quickstart:demo": "npm -w @harness-anything/cli run build && node scripts/quickstart-demo.mjs",
     "quickstart:demo:fail-closed": "npm -w @harness-anything/cli run build && node scripts/quickstart-demo.mjs --break-step fact-record",

--- a/packages/cli/test/production-authority-canonical-ingress-tracer.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress-tracer.test.ts
@@ -1,0 +1,77 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { createGitCanonicalPublicationInspector } from "../src/daemon/authority-publication-evidence.ts";
+import {
+  defaultDaemonUserRoot,
+  pollUntil,
+  runDaemonCommand,
+  runRawJsonMaybeFail,
+  stopDaemon
+} from "./helpers/daemon-cli.ts";
+import {
+  createFixture,
+  latestAuthorityOperation
+} from "./production-authority-canonical-ingress/fixture.ts";
+
+test("PR canonical ingress tracer starts the real daemon and publishes one full-chain task write", { timeout: 60_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const env = {
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    CODEX_THREAD_ID: "canonical-ingress-pr-tracer"
+  };
+  try {
+    const registered = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical", "--canonical-root", fixture.repoRoot,
+      "--user-root", userRoot, "--no-link", "--json"
+    ], env);
+    assert.equal(registered.ok, true, JSON.stringify(registered));
+    try {
+      runDaemonCommand(fixture.repoRoot, [
+        "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+      ], env);
+    } catch {
+      // Keep observing the detached production service when startup outlives
+      // the CLI command's fixed reachability wait.
+    }
+    const status = await pollUntil(
+      () => runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env),
+      (value) => value.reachable === true,
+      (value, error) => JSON.stringify({ value, error: String(error ?? "") }),
+      { timeoutMs: 20_000 }
+    );
+    assert.equal(status.repoCount, 1, JSON.stringify(status));
+
+    const appended = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4",
+      "--text", "PR canonical ingress tracer"
+    ], env);
+    assert.equal(appended.status, 0, JSON.stringify(appended.receipt));
+    assert.equal(appended.receipt.ok, true, JSON.stringify(appended.receipt));
+    assert.match(readFileSync(path.join(
+      fixture.authoredRoot,
+      "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/progress.md"
+    ), "utf8"), /PR canonical ingress tracer/u);
+
+    const operation = latestAuthorityOperation(fixture.serviceRoot);
+    assert.equal(operation.state, "COMMITTED", JSON.stringify(operation));
+    assert.equal(operation.receipt?.tag, "COMMITTED", JSON.stringify(operation));
+    assert.equal(typeof operation.opId, "string", JSON.stringify(operation));
+    const publication = await createGitCanonicalPublicationInspector(fixture.authoredRoot)
+      .findPublicationForOperation(operation.opId!);
+    assert.equal(publication.commitSha, operation.commitSha);
+    assert.equal(publication.physicalChanges.some((change) => change.path ===
+      "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/progress.md"), true);
+    assert.equal(publication.physicalChanges.some((change) => change.path.startsWith("attribution-events/")), true);
+  } finally {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -1,4 +1,5 @@
-// harness-test-tier: integration
+// harness-test-tier: nightly
+// harness-test-tier-decision: dec_01KXZ2WZMB8YS18F549K8BMM7H
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";

--- a/packages/cli/test/production-authority-startup-performance.test.ts
+++ b/packages/cli/test/production-authority-startup-performance.test.ts
@@ -1,4 +1,5 @@
-// harness-test-tier: integration
+// harness-test-tier: nightly
+// harness-test-tier-decision: dec_01KXZ2WZMB8YS18F549K8BMM7H
 import assert from "node:assert/strict";
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import path from "node:path";

--- a/tools/check-integration-test-shards.mjs
+++ b/tools/check-integration-test-shards.mjs
@@ -7,6 +7,8 @@ import {
   integrationShardCount,
   integrationShardSummaries,
   integrationTestFileWeightsMs,
+  nightlyTestFileWeightsMs,
+  validateNightlyTestWeights,
   validateIntegrationTestShards
 } from "./integration-test-shards.mjs";
 import {
@@ -24,6 +26,7 @@ const deletionAllowlistRelativePath = "tools/gate-allowlists/check-integration-t
 export function checkIntegrationTestShards({
   repoRoot = defaultRepoRoot,
   weightOverrides = integrationTestFileWeightsMs,
+  nightlyWeightOverrides,
   previousTestCount,
   baselineRef,
   workflowText = readFileSync(workflowPath, "utf8"),
@@ -33,8 +36,12 @@ export function checkIntegrationTestShards({
   const testFiles = discoverTestFiles(repoRoot);
   const testTierManifest = discoverTestTierManifest(repoRoot);
   const integrationFiles = testTierManifest.integration;
+  const nightlyFiles = testTierManifest.nightly;
   const manifestValidation = validateManifest(testFiles, testTierManifest);
   const shardValidation = validateIntegrationTestShards(integrationFiles, weightOverrides);
+  const resolvedNightlyWeights = nightlyWeightOverrides
+    ?? (repoRoot === defaultRepoRoot ? nightlyTestFileWeightsMs : {});
+  const nightlyWeightValidation = validateNightlyTestWeights(nightlyFiles, resolvedNightlyWeights);
   const workflowValidation = validateIntegrationShardWorkflowMatrix(workflowText, integrationShardCount);
   const gateValidation = validateIntegrationShardRequiredContexts(gateManifestText, integrationShardCount);
   const baseline = previousTestCount === undefined
@@ -46,6 +53,7 @@ export function checkIntegrationTestShards({
     repoRoot,
     testFiles,
     integrationFiles,
+    nightlyFiles,
     baseline,
     delta,
     currentText: deletionAllowlistText
@@ -56,6 +64,7 @@ export function checkIntegrationTestShards({
   const errors = [
     ...manifestValidation.errors,
     ...shardValidation.errors,
+    ...nightlyWeightValidation.errors,
     ...workflowValidation.errors,
     ...gateValidation.errors,
     ...ratchetErrors
@@ -66,11 +75,13 @@ export function checkIntegrationTestShards({
     errors,
     derivedFiles: integrationFiles,
     executionFiles: integrationFiles,
+    nightlyFiles,
     summaries: integrationShardSummaries(integrationFiles, weightOverrides),
     currentCount: integrationFiles.length,
     previousCount: resolvedPreviousCount,
     delta,
     deletedFiles: deletionValidation.deletedFiles,
+    movedToNightlyFiles: deletionValidation.movedToNightlyFiles,
     confirmedDeletions: deletionValidation.confirmedDeletions,
     workflowShards: workflowValidation.shards,
     requiredContexts: gateValidation.contexts
@@ -180,7 +191,7 @@ function parseLegacyTierArray(source, tier, nextTier) {
   return JSON.parse(segment.slice(arrayStart, arrayEnd + 1));
 }
 
-function validateIntentionalTestDeletions({ repoRoot, testFiles, integrationFiles, baseline, delta, currentText }) {
+function validateIntentionalTestDeletions({ repoRoot, testFiles, integrationFiles, nightlyFiles, baseline, delta, currentText }) {
   const current = parseDeletionAllowlist(
     currentText ?? readDeletionAllowlist(repoRoot),
     deletionAllowlistRelativePath
@@ -193,9 +204,13 @@ function validateIntentionalTestDeletions({ repoRoot, testFiles, integrationFile
   const newlyConfirmed = current.paths.filter((file) => !previousPaths.has(file));
   const previousIntegration = new Set(baseline.files ?? []);
   const currentIntegration = new Set(integrationFiles);
+  const currentNightly = new Set(nightlyFiles);
+  const movedToNightlyFiles = baseline.files === null
+    ? []
+    : [...previousIntegration].filter((file) => !currentIntegration.has(file) && currentNightly.has(file)).sort();
   const deletedFiles = baseline.files === null
     ? []
-    : [...previousIntegration].filter((file) => !currentIntegration.has(file)).sort();
+    : [...previousIntegration].filter((file) => !currentIntegration.has(file) && !currentNightly.has(file)).sort();
   const deletedSet = new Set(deletedFiles);
   const confirmedDeletions = deletedFiles.filter((file) => newlyConfirmed.includes(file));
 
@@ -204,6 +219,12 @@ function validateIntentionalTestDeletions({ repoRoot, testFiles, integrationFile
   }
   for (const file of newlyConfirmed) {
     if (!deletedSet.has(file)) errors.push(`new intentional test deletion confirmation does not match a baseline deletion: ${file}`);
+  }
+  for (const file of movedToNightlyFiles) {
+    const source = readFileSync(path.join(repoRoot, file), "utf8");
+    if (!/^\/\/ harness-test-tier-decision: (?:ADR-\d{4}|dec_[A-Za-z0-9_]+|task_[A-Z0-9]+)$/mu.test(source)) {
+      errors.push(`integration test moved to nightly without a decision reference: ${file}`);
+    }
   }
 
   if (delta < 0) {
@@ -217,7 +238,7 @@ function validateIntentionalTestDeletions({ repoRoot, testFiles, integrationFile
     }
   }
 
-  return { errors, deletedFiles, confirmedDeletions };
+  return { errors, deletedFiles, movedToNightlyFiles, confirmedDeletions };
 }
 
 function readDeletionAllowlist(repoRoot) {
@@ -335,7 +356,7 @@ function main() {
   const delta = result.delta === null ? "unavailable" : result.delta;
   console.log(`integration shard check passed: current=${result.currentCount} previous=${previous} delta=${delta} shards=${result.summaries.length} workflowShards=[${result.workflowShards.join(", ")}] requiredContexts=[${result.requiredContexts.join(", ")}]`);
   for (const summary of result.summaries) {
-    console.log(`shard ${summary.id}: files=${summary.files} estimatedMs=${summary.estimatedMs.toFixed(1)}`);
+    console.log(`shard ${summary.id}: files=${summary.files} estimatedMs=${summary.estimatedMs.toFixed(1)} workMs=${summary.estimatedWorkMs.toFixed(1)}`);
   }
 }
 

--- a/tools/check-integration-test-shards.test.mjs
+++ b/tools/check-integration-test-shards.test.mjs
@@ -72,6 +72,52 @@ test("default shard assignment is deterministic across discovery order", () => {
   assert.deepEqual(forward, reverse);
 });
 
+test("moving an integration test to nightly does not count as deleting coverage", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-integration-to-nightly-"));
+  try {
+    const testRoot = path.join(root, "tools");
+    mkdirSync(testRoot, { recursive: true });
+    for (let index = 1; index <= 7; index += 1) {
+      writeFileSync(path.join(testRoot, `fixture-${index}.test.mjs`), "// harness-test-tier: integration\n", "utf8");
+    }
+    writeDeletionAllowlist(root);
+    git(root, ["init", "-q"]);
+    git(root, ["config", "user.name", "Harness Test"]);
+    git(root, ["config", "user.email", "harness@example.test"]);
+    git(root, ["add", "tools"]);
+    git(root, ["commit", "-qm", "register integration tests"]);
+
+    writeFileSync(path.join(testRoot, "fixture-7.test.mjs"), "// harness-test-tier: nightly\n", "utf8");
+    const unapproved = checkIntegrationTestShards({
+      repoRoot: root,
+      weightOverrides: {},
+      nightlyWeightOverrides: {},
+      deletionAllowlistText: deletionAllowlistText()
+    });
+    assert.equal(unapproved.ok, false);
+    assert.match(unapproved.errors.join("\n"), /moved to nightly without a decision reference/u);
+
+    writeFileSync(path.join(testRoot, "fixture-7.test.mjs"), [
+      "// harness-test-tier: nightly",
+      "// harness-test-tier-decision: dec_TEST_NIGHTLY_MOVE",
+      ""
+    ].join("\n"), "utf8");
+    const after = checkIntegrationTestShards({
+      repoRoot: root,
+      weightOverrides: {},
+      nightlyWeightOverrides: {},
+      deletionAllowlistText: deletionAllowlistText()
+    });
+    assert.equal(after.ok, true, after.errors.join("\n"));
+    assert.equal(after.currentCount, 6);
+    assert.deepEqual(after.deletedFiles, []);
+    assert.deepEqual(after.movedToNightlyFiles, ["tools/fixture-7.test.mjs"]);
+    assert.deepEqual(after.nightlyFiles, ["tools/fixture-7.test.mjs"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("integration shard validation rejects duplicate inputs and stale weight overrides", () => {
   const result = validateIntegrationTestShards(
     ["tools/a.test.mjs", "tools/a.test.mjs"],

--- a/tools/integration-test-shards.mjs
+++ b/tools/integration-test-shards.mjs
@@ -5,6 +5,18 @@ const repoRoot = path.resolve(import.meta.dirname, "..");
 export const integrationShardIds = loadEnforcementConstant(repoRoot, "ci-integration-shard-sequence");
 export const integrationShardCount = integrationShardIds.length;
 export const defaultIntegrationTestWeightMs = 1000;
+// The same successful run showed 2.465x aggregate file-test time versus shard
+// wall time. Round to a stable scheduler estimate instead of pretending the
+// concurrent Node runner is serial.
+export const observedCiIntegrationParallelism = 2.5;
+
+// File-level timings extracted from successful rewrite-ci run 29720318100.
+// Nightly tests are not sharded, but keeping their observed cost registered
+// makes tier moves and future drift visible instead of falling back to 1000ms.
+export const nightlyTestFileWeightsMs = Object.freeze({
+  "packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts": 186900,
+  "packages/cli/test/production-authority-startup-performance.test.ts": 25900
+});
 
 // Optional balancing overrides. New tests need no entry: they receive the
 // deterministic default weight and are placed into the lightest shard.
@@ -12,55 +24,67 @@ export const integrationTestFileWeightsMs = Object.freeze({
   "packages/adapters/multica/test/multica-readonly-adopt.test.ts": 782.5,
   "packages/application/test/local-controller-service.test.ts": 507.0,
   "packages/application/test/execution-saga.test.ts": 1200.0,
-  "packages/cli/test/actor-attribution-cli.test.ts": 3640.4,
-  "packages/cli/test/anchor-backfill-cli.test.ts": 16962.1,
+  "packages/cli/test/actor-attribution-cli.test.ts": 21000,
+  "packages/cli/test/anchor-backfill-cli.test.ts": 36500,
+  "packages/cli/test/architecture-script-cli.test.ts": 91400,
   "packages/cli/test/attribution-diff-cli.test.ts": 4299.9,
-  "packages/cli/test/check-governance-cli.test.ts": 37788.5,
+  "packages/cli/test/check-governance-cli.test.ts": 93300,
+  "packages/cli/test/completion-facade-cli.test.ts": 98700,
   "packages/cli/test/conflict-preflight-cli.test.ts": 4766.7,
-  "packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts": 15469.7,
-  "packages/cli/test/daemon-thin-client-cli.test.ts": 38159.7,
-  "packages/cli/test/decision-cli.test.ts": 15299.0,
-  "packages/cli/test/decision-coverage-cli.test.ts": 26753.8,
-  "packages/cli/test/decision-task-metadata-cli.test.ts": 13473.5,
+  "packages/cli/test/daemon-cold-start-launch-spec.test.ts": 38200,
+  "packages/cli/test/daemon-execution-claim-cli.test.ts": 35400,
+  "packages/cli/test/daemon-lifecycle-cli.test.ts": 43200,
+  "packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts": 69400,
+  "packages/cli/test/daemon-refresh-preflight.test.ts": 35700,
+  "packages/cli/test/daemon-thin-client-cli.test.ts": 161000,
+  "packages/cli/test/daemon-thin-client-registry-cli.test.ts": 47500,
+  "packages/cli/test/decision-cli.test.ts": 62800,
+  "packages/cli/test/decision-content-pin-cli.test.ts": 22500,
+  "packages/cli/test/decision-coverage-cli.test.ts": 98200,
+  "packages/cli/test/decision-task-metadata-cli.test.ts": 27800,
   "packages/cli/test/diagnostics-cli.test.ts": 551.7,
   "packages/cli/test/distill-cli.test.ts": 5975.6,
   "packages/cli/test/doc-sync-cli.test.ts": 4214.7,
   "packages/cli/test/doctor-cli.test.ts": 3606.3,
-  "packages/cli/test/extension-cli.test.ts": 7000.4,
-  "packages/cli/test/fact-cli.test.ts": 11411.7,
+  "packages/cli/test/extension-cli.test.ts": 64200,
+  "packages/cli/test/fact-cli.test.ts": 31800,
   "packages/cli/test/graph-cli.test.ts": 2433.0,
   "packages/cli/test/gui-cli.test.ts": 1187.3,
   "packages/cli/test/init-cli.test.ts": 6346.2,
-  "packages/cli/test/local-lifecycle-cli.test.ts": 52850.8,
+  "packages/cli/test/local-lifecycle-cli.test.ts": 149800,
   "packages/cli/test/local-lifecycle-crlf-cli.test.ts": 3951.3,
-  "packages/cli/test/migration-adopt-cli.test.ts": 21829.1,
-  "packages/cli/test/new-task-cli.test.ts": 5417.7,
+  "packages/cli/test/materializer-recovery-cli.test.ts": 40800,
+  "packages/cli/test/migration-adopt-cli.test.ts": 75600,
+  "packages/cli/test/new-task-cli.test.ts": 52200,
   "packages/cli/test/p16-command-parity-cli.test.ts": 10596.6,
-  "packages/cli/test/post-merge-check-cli.test.ts": 13476.9,
+  "packages/cli/test/post-merge-check-cli.test.ts": 47500,
+  "packages/cli/test/production-authority-canonical-ingress-tracer.test.ts": 6800,
   "packages/cli/test/preset-create-milestone-cli.test.ts": 4114.3,
   "packages/cli/test/preset-create-milestone-render-html-cli.test.ts": 3185.5,
   "packages/cli/test/preset-github-issue-repair-cli.test.ts": 2819.6,
   "packages/cli/test/preset-milestone-closeout-cli.test.ts": 2414.0,
-  "packages/cli/test/preset-module-cli.test.ts": 22821.6,
+  "packages/cli/test/preset-module-cli.test.ts": 64200,
   "packages/cli/test/preset-user-root-cli.test.ts": 3000.0,
-  "packages/cli/test/preset-script-cli.test.ts": 21150.1,
-  "packages/cli/test/preset-script-imports-cli.test.ts": 1132.0,
+  "packages/cli/test/preset-script-cli.test.ts": 43800,
+  "packages/cli/test/preset-script-imports-cli.test.ts": 20400,
+  "packages/cli/test/preset-script-staging-boundary.test.ts": 25400,
+  "packages/cli/test/preset-uninstall-safety-cli.test.ts": 28900,
   "packages/cli/test/progress-evidence-cli.test.ts": 700.0,
   "packages/cli/test/preset-subtask-expansion-cli.test.ts": 17807.0,
   "packages/cli/test/projection-freshness-cli.test.ts": 1723.3,
-  "packages/cli/test/runtime-event-cli.test.ts": 5222.8,
+  "packages/cli/test/runtime-event-cli.test.ts": 36100,
   "packages/cli/test/self-host-git-boundary-cli.test.ts": 777.2,
   "packages/cli/test/session-cli.test.ts": 3130.5,
-  "packages/cli/test/submit-lifecycle-cli.test.ts": 7202.5,
-  "packages/cli/test/settings-cli.test.ts": 20342.2,
-  "packages/cli/test/task-archive-distill-cli.test.ts": 15682.0,
-  "packages/cli/test/task-delete-disposition-cli.test.ts": 15148.2,
-  "packages/cli/test/task-document-gates-cli.test.ts": 10050.9,
-  "packages/cli/test/task-lease-cli.test.ts": 2210.6,
+  "packages/cli/test/submit-lifecycle-cli.test.ts": 29500,
+  "packages/cli/test/settings-cli.test.ts": 55900,
+  "packages/cli/test/task-archive-distill-cli.test.ts": 29100,
+  "packages/cli/test/task-delete-disposition-cli.test.ts": 37000,
+  "packages/cli/test/task-document-gates-cli.test.ts": 114100,
+  "packages/cli/test/task-lease-cli.test.ts": 73400,
   "packages/cli/test/task-list-cli.test.ts": 4079.4,
-  "packages/cli/test/task-show-relation-list-cli.test.ts": 9469.7,
-  "packages/cli/test/task-transition-sweep-cli.test.ts": 24335.2,
-  "packages/cli/test/task-tree-cli.test.ts": 10262.2,
+  "packages/cli/test/task-show-relation-list-cli.test.ts": 24100,
+  "packages/cli/test/task-transition-sweep-cli.test.ts": 20500,
+  "packages/cli/test/task-tree-cli.test.ts": 29900,
   "packages/cli/test/worktree-cli.test.ts": 2230.1,
   "packages/cli/test/write-lock-retry-cli.test.ts": 3640.9,
   "packages/daemon/test/transport-integration.test.ts": 413.2,
@@ -87,7 +111,7 @@ export const integrationTestFileWeightsMs = Object.freeze({
   "tools/check-import-boundaries.test.mjs": 1230.7,
   "tools/check-kernel-dead-exports.test.mjs": 1909.3,
   "tools/check-runtime-release-readiness.test.mjs": 1003.8,
-  "tools/check-supply-chain.test.mjs": 8797.4,
+  "tools/check-supply-chain.test.mjs": 29200,
   "tools/graph-panorama.test.mjs": 455.6,
   "tools/quickstart-demo.test.mjs": 5488.9,
   "tools/relation-weathering-spike.test.mjs": 182.9
@@ -131,10 +155,14 @@ export function integrationShardSummaries(manifestFiles, weightOverrides = integ
   return assignIntegrationTestShards(manifestFiles, weightOverrides).map((shard) => ({
     id: shard.id,
     files: shard.files.length,
+    estimatedWorkMs: shard.files.reduce(
+      (sum, file) => sum + (weightOverrides[file] ?? defaultIntegrationTestWeightMs),
+      0
+    ),
     estimatedMs: shard.files.reduce(
       (sum, file) => sum + (weightOverrides[file] ?? defaultIntegrationTestWeightMs),
       0
-    )
+    ) / observedCiIntegrationParallelism
   }));
 }
 
@@ -155,4 +183,14 @@ export function validateIntegrationTestShards(manifestFiles, weightOverrides = i
   if (shards.some((shard) => shard.files.length === 0)) errors.push("derived integration shard is empty");
 
   return { ok: errors.length === 0, errors, shards };
+}
+
+export function validateNightlyTestWeights(manifestFiles, weightOverrides = nightlyTestFileWeightsMs) {
+  const errors = [];
+  const manifestSet = new Set(manifestFiles);
+  for (const [file, weight] of Object.entries(weightOverrides)) {
+    if (!manifestSet.has(file)) errors.push(`nightly weight references non-nightly file: ${file}`);
+    if (!Number.isFinite(weight) || weight <= 0) errors.push(`nightly file has invalid weight: ${file}`);
+  }
+  return { ok: errors.length === 0, errors };
 }

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { resolve } from "node:path";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path, { resolve } from "node:path";
 import { selectIntegrationShardFiles } from "./integration-test-shards.mjs";
+import { formatTestWeightDriftWarnings, parseJunitTestFileDurations } from "./test-weight-drift.mjs";
 import { discoverQosPrefix, prefixCommand, withLocalHeavySlot } from "./local-resource-governance.mjs";
 import {
   collectSlowTests,
@@ -13,7 +16,7 @@ import {
   resolveTestConcurrency,
   selectTestFiles
 } from "./node-test-runner-lib.mjs";
-import { discoverTestTierManifest, testTierNames } from "./test-tier-manifest.mjs";
+import { defaultTestTierNames, discoverTestTierManifest, testTierNames } from "./test-tier-manifest.mjs";
 import { createHermeticTestEnvironment, gitFixtureIdentityGuidance } from "./test-process-environment.mjs";
 
 const repoRoot = resolve(import.meta.dirname, "..");
@@ -39,11 +42,14 @@ try {
 const testTierManifest = discoverTestTierManifest(repoRoot);
 const testFiles = Object.values(testTierManifest).flat().sort();
 const selection = selectTestFiles(testFiles, testTierManifest, options.tier);
+if (options.tier === "all") {
+  selection.files = defaultTestTierNames.flatMap((tier) => testTierManifest[tier]).sort();
+}
 
 // Default CLI integration subprocesses preload a test-only fixture composition.
 // Daemon-focused tests opt into HARNESS_DAEMON_MODE=local with isolated roots;
 // no test re-enables the retired direct product writer.
-if (options.tier === "integration" || options.tier === "all") {
+if (options.tier === "integration" || options.tier === "nightly" || options.tier === "all") {
   const fixturePreload = `--import=${resolve(repoRoot, "tools/cli-test-fixture-register.mjs")}`;
   process.env.HARNESS_CLI_TEST_FIXTURE_PRELOAD = "1";
   process.env.NODE_OPTIONS = [process.env.NODE_OPTIONS, fixturePreload].filter(Boolean).join(" ");
@@ -84,11 +90,17 @@ const concurrency = resolveTestConcurrency({
 const concurrencyArgs =
   concurrency && Number.isInteger(concurrency) && concurrency > 0 ? [`--test-concurrency=${concurrency}`] : [];
 const timeoutArgs = [`--test-timeout=${options.testTimeoutMs}`];
+const timingRoot = mkdtempSync(path.join(tmpdir(), "ha-test-timings-"));
+const timingPath = path.join(timingRoot, "results.xml");
 
 process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}` }, async (lease) => {
   const qosPrefix = lease.inherited ? [] : discoverQosPrefix();
   const invocation = prefixCommand(qosPrefix, process.execPath, [
     "--test",
+    "--test-reporter=spec",
+    "--test-reporter-destination=stdout",
+    "--test-reporter=junit",
+    `--test-reporter-destination=${timingPath}`,
     ...concurrencyArgs,
     ...timeoutArgs,
     ...selection.files
@@ -116,10 +128,19 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
     child.once("error", (error) => {
       console.error(error.message);
       testEnvironment.cleanup();
+      rmSync(timingRoot, { recursive: true, force: true });
       resolveExitCode(1);
     });
     child.once("close", (code, signal) => {
       testEnvironment.cleanup();
+      try {
+        const measured = parseJunitTestFileDurations(readFileSync(timingPath, "utf8"), repoRoot);
+        for (const warning of formatTestWeightDriftWarnings(measured)) console.warn(warning);
+      } catch (error) {
+        console.warn(`Unable to inspect test weight drift: ${error instanceof Error ? error.message : String(error)}`);
+      } finally {
+        rmSync(timingRoot, { recursive: true, force: true });
+      }
       if (signal !== null) {
         console.error(`node --test terminated by signal ${signal}`);
         resolveExitCode(1);

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -4,7 +4,7 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import test from "node:test";
 import { collectSlowTests, DEFAULT_TEST_TIMEOUT_MS, filterTestFilesByPrefixes, formatSlowTestSummary, parseCompletedTestLine, parseRunnerArgs, resolveTestConcurrency, selectTestFiles, validateManifest } from "./node-test-runner-lib.mjs";
-import { deriveTestTierManifest, discoverTestTierManifest, parseTestTierMarker, testTierNames } from "./test-tier-manifest.mjs";
+import { defaultTestTierNames, deriveTestTierManifest, discoverTestTierManifest, parseTestTierMarker, testTierNames } from "./test-tier-manifest.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
@@ -153,7 +153,8 @@ test("inline test tier markers derive the manifest", () => {
   assert.deepEqual(manifest, {
     fast: ["fast.test.ts"],
     contract: ["contract.test.ts"],
-    integration: ["new.test.ts"]
+    integration: ["new.test.ts"],
+    nightly: []
   });
 });
 
@@ -185,6 +186,25 @@ test("integration discovery equals the files executed by the CI runner", () => {
   });
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(result.stdout.trim().split(/\r?\n/u), manifest.integration);
+});
+
+test("nightly tests run only when explicitly selected", () => {
+  const manifest = discoverTestTierManifest(repoRoot);
+  const nightly = spawnSync(process.execPath, ["tools/run-node-tests.mjs", "--tier", "nightly", "--list"], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+  assert.equal(nightly.status, 0, nightly.stderr);
+  assert.deepEqual(nightly.stdout.trim().split(/\r?\n/u), manifest.nightly);
+
+  const defaultRun = spawnSync(process.execPath, ["tools/run-node-tests.mjs", "--list"], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+  assert.equal(defaultRun.status, 0, defaultRun.stderr);
+  const expected = defaultTestTierNames.flatMap((tier) => manifest[tier]).sort();
+  assert.deepEqual(defaultRun.stdout.trim().split(/\r?\n/u), expected);
+  assert.equal(expected.some((file) => manifest.nightly.includes(file)), false);
 });
 
 test("selectTestFiles returns sorted tier files from the derived repository manifest", () => {

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -5,7 +5,8 @@ const testFilePattern = /\.(test|spec)\.(?:mjs|js|ts)$/u;
 const ignoredDirectoryNames = new Set(["node_modules", "dist", "out", "coverage", ".git"]);
 const markerPattern = /^\s*\/\/\s*harness-test-tier:\s*(\S+)\s*$/u;
 
-export const testTierNames = Object.freeze(["fast", "contract", "integration"]);
+export const testTierNames = Object.freeze(["fast", "contract", "integration", "nightly"]);
+export const defaultTestTierNames = Object.freeze(["fast", "contract", "integration"]);
 
 export function parseTestTierMarker(source, file = "test file") {
   const lines = source.split(/\r?\n/u);

--- a/tools/test-weight-drift.mjs
+++ b/tools/test-weight-drift.mjs
@@ -1,0 +1,61 @@
+import path from "node:path";
+import {
+  defaultIntegrationTestWeightMs,
+  integrationTestFileWeightsMs,
+  nightlyTestFileWeightsMs
+} from "./integration-test-shards.mjs";
+
+const significantDriftRatio = 2;
+const significantDriftOverageMs = 5000;
+
+export function parseJunitTestFileDurations(xml, repoRoot) {
+  const durations = new Map();
+  for (const match of xml.matchAll(/<testcase\b[^>]*\btime="([0-9.]+)"[^>]*\bfile="([^"]+)"[^>]*\/>/gu)) {
+    const absoluteFile = decodeXmlAttribute(match[2]);
+    const relativeFile = path.relative(repoRoot, absoluteFile).split(path.sep).join("/");
+    if (relativeFile === ".." || relativeFile.startsWith("../")) continue;
+    const durationMs = Number(match[1]) * 1000;
+    durations.set(relativeFile, (durations.get(relativeFile) ?? 0) + durationMs);
+  }
+  return durations;
+}
+
+export function findTestWeightDrift(measuredDurations, {
+  integrationWeights = integrationTestFileWeightsMs,
+  nightlyWeights = nightlyTestFileWeightsMs,
+  defaultWeightMs = defaultIntegrationTestWeightMs,
+  ratio = significantDriftRatio,
+  minimumOverageMs = significantDriftOverageMs
+} = {}) {
+  const warnings = [];
+  for (const [file, measuredMs] of measuredDurations) {
+    const registered = integrationWeights[file] ?? nightlyWeights[file];
+    const weightMs = registered ?? defaultWeightMs;
+    if (measuredMs < weightMs * ratio || measuredMs - weightMs < minimumOverageMs) continue;
+    warnings.push({
+      file,
+      measuredMs,
+      weightMs,
+      source: registered === undefined ? "default" : "registered"
+    });
+  }
+  return warnings.sort((left, right) => right.measuredMs / right.weightMs - left.measuredMs / left.weightMs);
+}
+
+export function formatTestWeightDriftWarnings(measuredDurations, options) {
+  return findTestWeightDrift(measuredDurations, options).map((warning) => {
+    const message = `test weight drift: measured=${warning.measuredMs.toFixed(0)}ms weight=${warning.weightMs.toFixed(0)}ms source=${warning.source}; refresh tools/integration-test-shards.mjs`;
+    return process.env.CI
+      ? `::warning file=${warning.file}::${message}`
+      : `WARNING ${warning.file}: ${message}`;
+  });
+}
+
+function decodeXmlAttribute(value) {
+  return value
+    .replaceAll("&quot;", "\"")
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}

--- a/tools/test-weight-drift.test.mjs
+++ b/tools/test-weight-drift.test.mjs
@@ -1,0 +1,37 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { findTestWeightDrift, parseJunitTestFileDurations } from "./test-weight-drift.mjs";
+
+test("JUnit file timings are grouped under POSIX repository paths", () => {
+  const measured = parseJunitTestFileDurations([
+    "<testsuites>",
+    '  <testcase name="one" time="4.5" file="/repo/packages/cli/test/heavy.test.ts"/>',
+    '  <testcase name="two" time="2" file="/repo/packages/cli/test/heavy.test.ts"/>',
+    "</testsuites>"
+  ].join("\n"), "/repo");
+  assert.deepEqual([...measured], [["packages/cli/test/heavy.test.ts", 6500]]);
+});
+
+test("weight drift warns for stale registered and default weights only after a material overage", () => {
+  const warnings = findTestWeightDrift(new Map([
+    ["packages/registered.test.ts", 21_000],
+    ["packages/default.test.ts", 7_000],
+    ["packages/noise.test.ts", 5_500]
+  ]), {
+    integrationWeights: { "packages/registered.test.ts": 10_000 },
+    nightlyWeights: {},
+    defaultWeightMs: 1000
+  });
+  assert.deepEqual(warnings, [{
+    file: "packages/default.test.ts",
+    measuredMs: 7000,
+    weightMs: 1000,
+    source: "default"
+  }, {
+    file: "packages/registered.test.ts",
+    measuredMs: 21_000,
+    weightMs: 10_000,
+    source: "registered"
+  }]);
+});


### PR DESCRIPTION
# English

## Summary

Execute decision `dec_01KXZ2WZMB8YS18F549K8BMM7H`: make integration shard weights reflect measured CI durations (with a drift alarm against stale defaults), and move Perf/Soak-class tests out of the PR gate into a nightly workflow, keeping a real full-chain tracer in the PR gate.

## What Changed

- `tools/integration-test-shards.mjs`: register measured weights for heavy files (previously defaulted to 1000ms while e.g. canonical-ingress actually runs ~164s and dominated shard 6 at 54.8%).
- `tools/test-weight-drift.mjs` (+tests): alarm when a file's measured duration significantly exceeds its registered weight, so the table cannot silently rot again.
- `.github/workflows/nightly-integration.yml`: scheduled + manually dispatchable job running the full startup-performance and canonical-ingress matrices; failures are ordinary red (no continue-on-error); not a required check.
- `production-authority-startup-performance.test.ts` and the full `canonical-ingress` matrix retagged `harness-test-tier: nightly`, each annotated with the authorizing decision id.
- New `canonical-ingress-tracer.test.ts` stays in the PR integration tier: starts the real daemon and publishes one full-chain task write (60s budget), so PR-gate semantic coverage keeps a genuine end-to-end path.
- `tools/run-node-tests.mjs` / tier manifest: nightly tier wiring and coverage-migration checks.

## Task And Scope

Task `task_01KXZ2YTSYBDHEM685FF38G4AB`, decision `dec_01KXZ2WZMB8YS18F549K8BMM7H` (accepted 2026-07-20, approved by Zeyu). Motivated by the CI-duration diagnosis: six shard gate-time sum 18.4min, slowest shard ~5min pinned by mis-weighted heavy tests.

## Version Impact

None (test scheduling, tooling, and workflow only).

## Governance Declaration

Authorized by decision `dec_01KXZ2WZMB8YS18F549K8BMM7H` and task `task_01KXZ2YTSYBDHEM685FF38G4AB`. Gate-composition change executed strictly within the decision's chosen scope: no gate weakened beyond the authorized tier moves, PR gate keeps a real daemon full-chain tracer, nightly red is treated like main red, required-checks list untouched.

## Verification

Targeted tests green (shard tooling tests, weight-drift tests, tracer run); shard validation and lint pass. Expected effect (slowest shard 5min → 3-4min) verified on this PR's own CI run.

## Review Evidence

Codex review round: no actionable findings ("nightly tier, workflow, shard-weight updates, drift warnings, and coverage-migration checks are internally consistent"). CEO semantic acceptance performed against the decision item-by-item (nightly job shape, tier annotations carrying the decision id, tracer exercising the real daemon chain).

## Residual Risk

Nightly matrix reliability now carries the deep coverage; first scheduled run should be observed and any red routed per the post-merge red protocol.

## References

- Decision: `dec_01KXZ2WZMB8YS18F549K8BMM7H`
- Task: `task_01KXZ2YTSYBDHEM685FF38G4AB`
- Diagnosis context: CI-duration investigation 2026-07-20

---

# 中文

## 概要

执行决策 `dec_01KXZ2WZMB8YS18F549K8BMM7H`：integration 分片权重接入 CI 实测耗时（并加陈旧默认权重的漂移告警）；Perf/Soak 类测试移出 PR 门进 nightly workflow，PR 门保留真实全链 tracer。

## 改动内容

- `tools/integration-test-shards.mjs`：为重型文件登记实测权重（此前默认 1000ms，而 canonical-ingress 实测 ~164s、占 shard 6 的 54.8%）。
- `tools/test-weight-drift.mjs`（含测试）：文件实测显著超过登记权重时告警，防止权重表再次静默老化。
- `.github/workflows/nightly-integration.yml`：定时 + 可手动触发，跑 startup-performance 与 canonical-ingress 完整矩阵；失败正常变红（无 continue-on-error）；不进 required。
- `startup-performance` 与完整 `canonical-ingress` 矩阵改标 `harness-test-tier: nightly`，均注明授权决策 id。
- 新增 `canonical-ingress-tracer.test.ts` 留在 PR integration 层：真实起 daemon 并完成一次全链任务写（60s 预算），PR 门语义覆盖保有真端到端路径。
- `tools/run-node-tests.mjs` / tier manifest：nightly 层接线与覆盖迁移检查。

## 任务与范围

任务 `task_01KXZ2YTSYBDHEM685FF38G4AB`，决策 `dec_01KXZ2WZMB8YS18F549K8BMM7H`（2026-07-20 accept，泽宇批准）。动机=CI 耗时诊断：六片 gate 总和 18.4min，最慢片 ~5min 被误权重的重型测试钉死。

## 版本影响

无（仅测试调度、工具与 workflow）。

## 治理声明

授权自决策 `dec_01KXZ2WZMB8YS18F549K8BMM7H` 与任务 `task_01KXZ2YTSYBDHEM685FF38G4AB`。gate 组成改动严格限定在决策 chosen 面内：除授权的层级迁移外未削任何门，PR 门保留真实 daemon 全链 tracer，nightly 红视同 main 红，required checks 清单未动。

## 验证

定向测试绿（分片工具测试、漂移告警测试、tracer 运行）；分片校验与 lint 通过。预期效果（最慢片 5min → 3-4min）以本 PR 自身 CI run 验证。

## 审查证据

Codex 评审一轮：无实质 finding（"nightly 层、workflow、权重更新、漂移告警与覆盖迁移检查内部一致"）。CEO 按决策逐条语义验收（nightly job 形态、tier 注记携带决策 id、tracer 真实走 daemon 全链）。

## 残余风险

深覆盖现由 nightly 矩阵承担；首次定时运行需观察，红了按 post-merge 红处置协议路由。

## 关联材料

- 决策：`dec_01KXZ2WZMB8YS18F549K8BMM7H`
- 任务：`task_01KXZ2YTSYBDHEM685FF38G4AB`
- 诊断上下文：2026-07-20 CI 耗时调查

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body / 双语正文
- [x] Governance declaration / 治理声明
- [x] Task linkage / 任务关联
