### PR TITLE
fix(daemon): include workspace TypeScript in build identity; enforce expected identity on refresh

### DIFF
--- a/packages/cli/src/commands/daemon/control-convergence.ts
+++ b/packages/cli/src/commands/daemon/control-convergence.ts
@@ -1,0 +1,103 @@
+export type DaemonLifecycleStatus = {
+  readonly schema: "daemon-status/v1" | "daemon-status/v2";
+  readonly started: true;
+  readonly pid: number;
+  readonly loadedIdentity?: string;
+  readonly installedIdentity?: string;
+  readonly operationCleared?: true;
+  readonly activeOperationId?: string;
+};
+
+export function daemonControlFailure(
+  status: Record<string, unknown> | undefined,
+  operationId: string
+): string | undefined {
+  if (!status || status.schema !== "daemon-status/v2") return undefined;
+  const service = isRecord(status.service) ? status.service : undefined;
+  const activeControl = isRecord(service?.activeControl) ? service.activeControl : undefined;
+  const failure = isRecord(activeControl?.failure) ? activeControl.failure : undefined;
+  if (activeControl?.operationId !== operationId
+    || activeControl.phase !== "failed"
+    || typeof failure?.hint !== "string") return undefined;
+  return typeof failure.code === "string"
+    ? `${failure.code}: ${failure.hint}`
+    : failure.hint;
+}
+
+export function normalizeDaemonLifecycleStatus(
+  status: Record<string, unknown>
+): DaemonLifecycleStatus | undefined {
+  const isV2 = status.schema === "daemon-status/v2";
+  const lifecycle = isV2
+    ? (isRecord(status.service) ? status.service : undefined)
+    : status.schema === "daemon-status/v1" ? status : undefined;
+  if (lifecycle?.started !== true || !isPositivePid(lifecycle.pid)) return undefined;
+  if (!isV2) return { schema: "daemon-status/v1", started: true, pid: lifecycle.pid };
+  const build = isRecord(lifecycle.build) ? lifecycle.build : {};
+  const activeControl = isRecord(lifecycle.activeControl) ? lifecycle.activeControl : undefined;
+  return {
+    schema: "daemon-status/v2",
+    started: true,
+    pid: lifecycle.pid,
+    ...(typeof build.loadedIdentity === "string" ? { loadedIdentity: build.loadedIdentity } : {}),
+    ...(typeof build.installedIdentity === "string" ? { installedIdentity: build.installedIdentity } : {}),
+    ...(lifecycle.activeControl === null ? { operationCleared: true as const } : {}),
+    ...(typeof activeControl?.operationId === "string" ? { activeOperationId: activeControl.operationId } : {})
+  };
+}
+
+export function isCompleteReplacement(
+  status: DaemonLifecycleStatus,
+  beforePid: number,
+  operationId: string,
+  expectedIdentity: string | undefined
+): boolean {
+  if (status.pid === beforePid || status.schema === "daemon-status/v1") return false;
+  return typeof status.loadedIdentity === "string"
+    && typeof status.installedIdentity === "string"
+    && status.loadedIdentity === status.installedIdentity
+    && (expectedIdentity === undefined || status.loadedIdentity === expectedIdentity)
+    && status.operationCleared === true
+    && status.activeOperationId !== operationId;
+}
+
+export function replacementIdentityIsInvalid(
+  status: DaemonLifecycleStatus,
+  expectedIdentity: string | undefined
+): boolean {
+  return status.schema === "daemon-status/v1"
+    || typeof status.loadedIdentity !== "string"
+    || typeof status.installedIdentity !== "string"
+    || status.loadedIdentity !== status.installedIdentity
+    || (expectedIdentity !== undefined && status.loadedIdentity !== expectedIdentity);
+}
+
+export function incompleteReplacementReason(
+  status: DaemonLifecycleStatus,
+  beforePid: number,
+  operationId: string,
+  expectedIdentity: string | undefined
+): string {
+  if (status.pid === beforePid) return `PID did not change: ${String(status.pid)}`;
+  if (status.schema === "daemon-status/v1") return "did not expose daemon-status/v2 replacement criteria";
+  if (typeof status.loadedIdentity !== "string" || typeof status.installedIdentity !== "string") {
+    return "did not expose loaded and installed identities";
+  }
+  if (status.loadedIdentity !== status.installedIdentity) {
+    return `loaded identity did not converge on the installed identity: loaded=${status.loadedIdentity} installed=${status.installedIdentity}`;
+  }
+  if (expectedIdentity !== undefined && status.loadedIdentity !== expectedIdentity) {
+    return `loaded identity did not match the replacement identity calculated before handoff: loaded=${status.loadedIdentity} expected=${expectedIdentity}`;
+  }
+  if (status.activeOperationId === operationId) return `did not clear the accepted control operation ${operationId}`;
+  if (status.operationCleared !== true) return "did not expose a cleared control operation state";
+  return "did not satisfy replacement criteria";
+}
+
+function isPositivePid(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/cli/src/commands/daemon/control-convergence.ts
+++ b/packages/cli/src/commands/daemon/control-convergence.ts
@@ -13,9 +13,9 @@ export function daemonControlFailure(
   operationId: string
 ): string | undefined {
   if (!status || status.schema !== "daemon-status/v2") return undefined;
-  const service = isRecord(status.service) ? status.service : undefined;
-  const activeControl = isRecord(service?.activeControl) ? service.activeControl : undefined;
-  const failure = isRecord(activeControl?.failure) ? activeControl.failure : undefined;
+  const service = isDaemonLifecycleRecord(status.service) ? status.service : undefined;
+  const activeControl = isDaemonLifecycleRecord(service?.activeControl) ? service.activeControl : undefined;
+  const failure = isDaemonLifecycleRecord(activeControl?.failure) ? activeControl.failure : undefined;
   if (activeControl?.operationId !== operationId
     || activeControl.phase !== "failed"
     || typeof failure?.hint !== "string") return undefined;
@@ -29,12 +29,12 @@ export function normalizeDaemonLifecycleStatus(
 ): DaemonLifecycleStatus | undefined {
   const isV2 = status.schema === "daemon-status/v2";
   const lifecycle = isV2
-    ? (isRecord(status.service) ? status.service : undefined)
+    ? (isDaemonLifecycleRecord(status.service) ? status.service : undefined)
     : status.schema === "daemon-status/v1" ? status : undefined;
-  if (lifecycle?.started !== true || !isPositivePid(lifecycle.pid)) return undefined;
+  if (lifecycle?.started !== true || !isDaemonLifecyclePositivePid(lifecycle.pid)) return undefined;
   if (!isV2) return { schema: "daemon-status/v1", started: true, pid: lifecycle.pid };
-  const build = isRecord(lifecycle.build) ? lifecycle.build : {};
-  const activeControl = isRecord(lifecycle.activeControl) ? lifecycle.activeControl : undefined;
+  const build = isDaemonLifecycleRecord(lifecycle.build) ? lifecycle.build : {};
+  const activeControl = isDaemonLifecycleRecord(lifecycle.activeControl) ? lifecycle.activeControl : undefined;
   return {
     schema: "daemon-status/v2",
     started: true,
@@ -94,10 +94,10 @@ export function incompleteReplacementReason(
   return "did not satisfy replacement criteria";
 }
 
-function isPositivePid(value: unknown): value is number {
+function isDaemonLifecyclePositivePid(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isDaemonLifecycleRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/cli/src/commands/daemon/control.ts
+++ b/packages/cli/src/commands/daemon/control.ts
@@ -14,6 +14,14 @@ import {
   stopDaemonReplacement,
   type DaemonReplacementStopRuntime
 } from "./replacement-cleanup.ts";
+import {
+  daemonControlFailure,
+  incompleteReplacementReason,
+  isCompleteReplacement,
+  normalizeDaemonLifecycleStatus,
+  replacementIdentityIsInvalid,
+  type DaemonLifecycleStatus
+} from "./control-convergence.ts";
 
 export type DaemonControlKind = "restart" | "refresh";
 type DaemonRefreshTrigger = "explicit" | "post-merge" | "dist-watcher";
@@ -51,16 +59,6 @@ type DaemonControlHandoff =
   | { readonly kind: "adopt"; readonly status: Record<string, unknown> }
   | { readonly kind: "reject"; readonly status: DaemonLifecycleStatus }
   | { readonly kind: "autostart" };
-
-type DaemonLifecycleStatus = {
-  readonly schema: "daemon-status/v1" | "daemon-status/v2";
-  readonly started: true;
-  readonly pid: number;
-  readonly loadedIdentity?: string;
-  readonly installedIdentity?: string;
-  readonly operationCleared?: true;
-  readonly activeOperationId?: string;
-};
 
 class DaemonRefreshWrongCheckoutError extends Error {
   constructor() {
@@ -416,85 +414,6 @@ async function waitForDaemonControlHandoff(
     await lifecycle.wait(pollIntervalMs);
   }
   throw new Error(`daemon control handoff exhausted without a safe decision (pid ${beforePid})`);
-}
-
-function daemonControlFailure(status: Record<string, unknown> | undefined, operationId: string): string | undefined {
-  if (!status || status.schema !== "daemon-status/v2") return undefined;
-  const service = isDaemonControlRecord(status.service) ? status.service : undefined;
-  const activeControl = isDaemonControlRecord(service?.activeControl) ? service.activeControl : undefined;
-  const failure = isDaemonControlRecord(activeControl?.failure) ? activeControl.failure : undefined;
-  if (activeControl?.operationId !== operationId
-    || activeControl.phase !== "failed"
-    || typeof failure?.hint !== "string") return undefined;
-  return typeof failure.code === "string"
-    ? `${failure.code}: ${failure.hint}`
-    : failure.hint;
-}
-
-function normalizeDaemonLifecycleStatus(
-  status: Record<string, unknown>
-): DaemonLifecycleStatus | undefined {
-  const isV2 = status.schema === "daemon-status/v2";
-  const lifecycle = isV2 ? (isDaemonControlRecord(status.service) ? status.service : undefined) : status.schema === "daemon-status/v1" ? status : undefined;
-  if (lifecycle?.started !== true || !isPositivePid(lifecycle.pid)) return undefined;
-  if (!isV2) return { schema: "daemon-status/v1", started: true, pid: lifecycle.pid };
-  const build = isDaemonControlRecord(lifecycle.build) ? lifecycle.build : {};
-  const activeControl = isDaemonControlRecord(lifecycle.activeControl) ? lifecycle.activeControl : undefined;
-  return {
-    schema: "daemon-status/v2",
-    started: true,
-    pid: lifecycle.pid,
-    ...(typeof build.loadedIdentity === "string" ? { loadedIdentity: build.loadedIdentity } : {}),
-    ...(typeof build.installedIdentity === "string" ? { installedIdentity: build.installedIdentity } : {}),
-    ...(lifecycle.activeControl === null ? { operationCleared: true as const } : {}),
-    ...(typeof activeControl?.operationId === "string" ? { activeOperationId: activeControl.operationId } : {})
-  };
-}
-
-function isCompleteReplacement(
-  status: NonNullable<ReturnType<typeof normalizeDaemonLifecycleStatus>>,
-  beforePid: number,
-  operationId: string,
-  expectedIdentity: string | undefined
-): boolean {
-  if (status.pid === beforePid) return false;
-  if (status.schema === "daemon-status/v1") return false;
-  return typeof status.loadedIdentity === "string"
-    && typeof status.installedIdentity === "string"
-    && status.loadedIdentity === status.installedIdentity
-    && (expectedIdentity === undefined || status.loadedIdentity === expectedIdentity)
-    && status.operationCleared === true
-    && status.activeOperationId !== operationId;
-}
-
-function replacementIdentityIsInvalid(status: DaemonLifecycleStatus, expectedIdentity: string | undefined): boolean {
-  return status.schema === "daemon-status/v1"
-    || typeof status.loadedIdentity !== "string"
-    || typeof status.installedIdentity !== "string"
-    || status.loadedIdentity !== status.installedIdentity
-    || (expectedIdentity !== undefined && status.loadedIdentity !== expectedIdentity);
-}
-
-function incompleteReplacementReason(
-  status: NonNullable<ReturnType<typeof normalizeDaemonLifecycleStatus>>,
-  beforePid: number,
-  operationId: string,
-  expectedIdentity: string | undefined
-): string {
-  if (status.pid === beforePid) return `PID did not change: ${String(status.pid)}`;
-  if (status.schema === "daemon-status/v1") return "did not expose daemon-status/v2 replacement criteria";
-  if (typeof status.loadedIdentity !== "string" || typeof status.installedIdentity !== "string") {
-    return "did not expose loaded and installed identities";
-  }
-  if (status.loadedIdentity !== status.installedIdentity) {
-    return `loaded identity did not converge on the installed identity: loaded=${status.loadedIdentity} installed=${status.installedIdentity}`;
-  }
-  if (expectedIdentity !== undefined && status.loadedIdentity !== expectedIdentity) {
-    return `loaded identity did not match the replacement identity calculated before handoff: loaded=${status.loadedIdentity} expected=${expectedIdentity}`;
-  }
-  if (status.activeOperationId === operationId) return `did not clear the accepted control operation ${operationId}`;
-  if (status.operationCleared !== true) return "did not expose a cleared control operation state";
-  return "did not satisfy replacement criteria";
 }
 
 async function probeExactDaemonStatus(target: LocalDaemonTarget): Promise<Record<string, unknown> | undefined> {

--- a/packages/cli/src/commands/daemon/control.ts
+++ b/packages/cli/src/commands/daemon/control.ts
@@ -1,4 +1,5 @@
 import {
+  calculateDaemonArtifactIdentity,
   requestLocalDaemonJsonRpcForTarget,
   type JsonObject,
   type LocalDaemonTarget
@@ -43,6 +44,7 @@ export interface DaemonControlCommandInput {
   readonly requestDaemonControl?: (request: DaemonControlRequest) => Promise<Record<string, unknown>>;
   readonly daemonControlLifecycle?: DaemonControlLifecycle;
   readonly daemonEntryPath: () => string;
+  readonly calculateInstalledIdentity?: (entrypoint: string) => string;
 }
 
 type DaemonControlHandoff =
@@ -99,12 +101,18 @@ export async function runDaemonControl(
   const preparedLaunchConfiguration = kind === "refresh"
     ? await lifecycle.prepareReplacement?.(lifecycle.target)
     : undefined;
+  const preparedExpectedIdentity = preparedLaunchConfiguration
+    ? calculateInstalledIdentity(input, preparedLaunchConfiguration.entrypoint)
+    : undefined;
   const rpcReceipt = await request({ method, params });
   const receipt = controlPayloadFromRpcReceipt(rpcReceipt, method);
   validateAcceptedControlReceipt(receipt, method, kind);
   const before = isDaemonControlRecord(receipt.before) ? receipt.before : {};
   const launchConfiguration = preparedLaunchConfiguration
     ?? daemonReplacementLaunchConfiguration(before.launchConfiguration);
+  const expectedIdentity = kind === "refresh"
+    ? preparedExpectedIdentity ?? calculateInstalledIdentity(input, launchConfiguration.entrypoint)
+    : undefined;
   const replacement = await completeDaemonReplacement(
     lifecycle,
     before.pid,
@@ -113,7 +121,8 @@ export async function runDaemonControl(
     drainTimeoutMs,
     kind,
     method,
-    launchConfiguration
+    launchConfiguration,
+    expectedIdentity
   );
   const { schema: controlSchema, ...controlResult } = receipt;
   return {
@@ -178,7 +187,8 @@ async function completeDaemonReplacement(
   timeoutMs: number,
   kind: DaemonControlKind,
   method: DaemonControlRequest["method"],
-  launchConfiguration: DaemonLaunchConfiguration
+  launchConfiguration: DaemonLaunchConfiguration,
+  expectedIdentity: string | undefined
 ): Promise<Record<string, unknown>> {
   if (!isPositivePid(beforePid)) {
     throw new Error(`${method} accepted receipt did not identify the running daemon PID`);
@@ -186,10 +196,10 @@ async function completeDaemonReplacement(
   if (typeof beforeLoadedIdentity !== "string" || typeof operationId !== "string") {
     throw new Error(`${method} accepted receipt did not identify the loaded build and operation`);
   }
-  const handoff = await waitForDaemonControlHandoff(lifecycle, beforePid, operationId, timeoutMs);
+  const handoff = await waitForDaemonControlHandoff(lifecycle, beforePid, operationId, timeoutMs, expectedIdentity);
   if (handoff.kind === "adopt") return handoff.status;
   if (handoff.kind === "reject") {
-    await rejectIncompleteReplacement(lifecycle, handoff.status, beforePid, operationId, timeoutMs, kind);
+    await rejectIncompleteReplacement(lifecycle, handoff.status, beforePid, operationId, timeoutMs, kind, expectedIdentity);
   }
   let replacement: Record<string, unknown>;
   try {
@@ -214,7 +224,8 @@ async function completeDaemonReplacement(
     beforePid,
     operationId,
     timeoutMs,
-    kind
+    kind,
+    expectedIdentity
   );
 }
 
@@ -225,7 +236,8 @@ async function waitForStartedReplacement(
   beforePid: number,
   operationId: string,
   timeoutMs: number,
-  kind: DaemonControlKind
+  kind: DaemonControlKind,
+  expectedIdentity: string | undefined
 ): Promise<Record<string, unknown>> {
   let status = initialStatus;
   let replacement = initialLifecycle;
@@ -235,10 +247,10 @@ async function waitForStartedReplacement(
     if (replacement.pid === beforePid) {
       throw new Error(`daemon ${kind} replacement PID did not change: ${String(replacement.pid)}; replacement was not signaled`);
     }
-    if (replacementIdentityIsInvalid(replacement)) {
-      await rejectIncompleteReplacement(lifecycle, replacement, beforePid, operationId, timeoutMs, kind);
+    if (replacementIdentityIsInvalid(replacement, expectedIdentity)) {
+      await rejectIncompleteReplacement(lifecycle, replacement, beforePid, operationId, timeoutMs, kind, expectedIdentity);
     }
-    if (isCompleteReplacement(replacement, beforePid, operationId)) return status;
+    if (isCompleteReplacement(replacement, beforePid, operationId, expectedIdentity)) return status;
     if (attempt + 1 < attempts) {
       await lifecycle.wait(pollIntervalMs);
       const observed = await lifecycle.probeStatus(lifecycle.target);
@@ -256,7 +268,7 @@ async function waitForStartedReplacement(
       + `${replacement.activeOperationId}; replacement was left running`
     );
   }
-  return await rejectIncompleteReplacement(lifecycle, replacement, beforePid, operationId, timeoutMs, kind);
+  return await rejectIncompleteReplacement(lifecycle, replacement, beforePid, operationId, timeoutMs, kind, expectedIdentity);
 }
 
 async function rejectIncompleteReplacement(
@@ -265,9 +277,10 @@ async function rejectIncompleteReplacement(
   beforePid: number,
   operationId: string,
   timeoutMs: number,
-  kind: DaemonControlKind
+  kind: DaemonControlKind,
+  expectedIdentity: string | undefined
 ): Promise<never> {
-  const failure = incompleteReplacementReason(replacement, beforePid, operationId);
+  const failure = incompleteReplacementReason(replacement, beforePid, operationId, expectedIdentity);
   if (replacement.pid === beforePid) {
     throw new Error(`daemon ${kind} replacement ${failure}; replacement was not signaled`);
   }
@@ -300,12 +313,13 @@ function defaultDaemonControlLifecycle(input: DaemonControlCommandInput): Daemon
     probeStatus: probeExactDaemonStatus,
     ownerIsAlive: daemonProcessIsAlive,
     prepareReplacement: async (candidate) => {
+      let receipt: Record<string, unknown>;
       try {
-        const receipt = await requestLocalDaemonJsonRpcForTarget(candidate, "admin.daemon.launch-spec", {}, 1_000);
-        return daemonReplacementLaunchConfiguration(statusFromReceipt(receipt));
+        receipt = await requestLocalDaemonJsonRpcForTarget(candidate, "admin.daemon.launch-spec", {}, 1_000);
       } catch {
         throw daemonLaunchSpecUpgradeError(candidate);
       }
+      return daemonReplacementLaunchConfiguration(statusFromReceipt(receipt));
     },
     startReplacement: (candidate, timeoutMs, launchConfiguration) => startDaemonReplacement(
       candidate,
@@ -321,6 +335,11 @@ function defaultDaemonControlLifecycle(input: DaemonControlCommandInput): Daemon
     ),
     wait: (ms) => new Promise((resolve) => setTimeout(resolve, ms))
   };
+}
+
+function calculateInstalledIdentity(input: DaemonControlCommandInput, entrypoint: string): string {
+  return input.calculateInstalledIdentity?.(entrypoint)
+    ?? calculateDaemonArtifactIdentity(entrypoint).identity;
 }
 
 function daemonLaunchSpecUpgradeError(target: LocalDaemonTarget): Error {
@@ -343,7 +362,8 @@ async function waitForDaemonControlHandoff(
   lifecycle: DaemonControlLifecycle,
   beforePid: number,
   operationId: string,
-  timeoutMs: number
+  timeoutMs: number,
+  expectedIdentity: string | undefined
 ): Promise<DaemonControlHandoff> {
   const pollIntervalMs = 100;
   const attempts = Math.ceil(timeoutMs / pollIntervalMs) + 1;
@@ -361,10 +381,10 @@ async function waitForDaemonControlHandoff(
       // that permits the existing autostart primitive to run.
       if (!status) return { kind: "autostart" };
       const observedLifecycle = normalizeDaemonLifecycleStatus(status);
-      if (observedLifecycle && isCompleteReplacement(observedLifecycle, beforePid, operationId)) {
+      if (observedLifecycle && isCompleteReplacement(observedLifecycle, beforePid, operationId, expectedIdentity)) {
         return { kind: "adopt", status };
       }
-      if (observedLifecycle && observedLifecycle.pid !== beforePid && replacementIdentityIsInvalid(observedLifecycle)) {
+      if (observedLifecycle && observedLifecycle.pid !== beforePid && replacementIdentityIsInvalid(observedLifecycle, expectedIdentity)) {
         return { kind: "reject", status: observedLifecycle };
       }
       if (observedLifecycle?.pid !== beforePid) pendingReplacement = observedLifecycle;
@@ -434,28 +454,32 @@ function normalizeDaemonLifecycleStatus(
 function isCompleteReplacement(
   status: NonNullable<ReturnType<typeof normalizeDaemonLifecycleStatus>>,
   beforePid: number,
-  operationId: string
+  operationId: string,
+  expectedIdentity: string | undefined
 ): boolean {
   if (status.pid === beforePid) return false;
   if (status.schema === "daemon-status/v1") return false;
   return typeof status.loadedIdentity === "string"
     && typeof status.installedIdentity === "string"
     && status.loadedIdentity === status.installedIdentity
+    && (expectedIdentity === undefined || status.loadedIdentity === expectedIdentity)
     && status.operationCleared === true
     && status.activeOperationId !== operationId;
 }
 
-function replacementIdentityIsInvalid(status: DaemonLifecycleStatus): boolean {
+function replacementIdentityIsInvalid(status: DaemonLifecycleStatus, expectedIdentity: string | undefined): boolean {
   return status.schema === "daemon-status/v1"
     || typeof status.loadedIdentity !== "string"
     || typeof status.installedIdentity !== "string"
-    || status.loadedIdentity !== status.installedIdentity;
+    || status.loadedIdentity !== status.installedIdentity
+    || (expectedIdentity !== undefined && status.loadedIdentity !== expectedIdentity);
 }
 
 function incompleteReplacementReason(
   status: NonNullable<ReturnType<typeof normalizeDaemonLifecycleStatus>>,
   beforePid: number,
-  operationId: string
+  operationId: string,
+  expectedIdentity: string | undefined
 ): string {
   if (status.pid === beforePid) return `PID did not change: ${String(status.pid)}`;
   if (status.schema === "daemon-status/v1") return "did not expose daemon-status/v2 replacement criteria";
@@ -464,6 +488,9 @@ function incompleteReplacementReason(
   }
   if (status.loadedIdentity !== status.installedIdentity) {
     return `loaded identity did not converge on the installed identity: loaded=${status.loadedIdentity} installed=${status.installedIdentity}`;
+  }
+  if (expectedIdentity !== undefined && status.loadedIdentity !== expectedIdentity) {
+    return `loaded identity did not match the replacement identity calculated before handoff: loaded=${status.loadedIdentity} expected=${expectedIdentity}`;
   }
   if (status.activeOperationId === operationId) return `did not clear the accepted control operation ${operationId}`;
   if (status.operationCleared !== true) return "did not expose a cleared control operation state";

--- a/packages/cli/test/daemon-control-dispatcher.test.ts
+++ b/packages/cli/test/daemon-control-dispatcher.test.ts
@@ -98,7 +98,8 @@ test("daemon dispatcher routes restart and every refresh trigger through canonic
             return v2DaemonStatus(84);
           },
           wait: async () => undefined
-        }
+        },
+        calculateInstalledIdentity: () => "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
       });
 
       assert.equal(exitCode, 0);
@@ -200,7 +201,7 @@ test("refresh accepts a healthy no-delta replacement converged on the installed 
     wait: async () => undefined
   } satisfies DaemonControlLifecycle;
 
-  const { exitCode, receipt } = await runCapturedControl(lifecycle, [], "refresh");
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, [], "refresh", identity);
 
   assert.equal(exitCode, 0, JSON.stringify(receipt));
 });
@@ -220,16 +221,18 @@ test("restart accepts a healthy same-version replacement converged on the instal
   assert.equal(exitCode, 0, JSON.stringify(receipt));
 });
 
-test("refresh accepts a healthy delta replacement loaded from the new installed identity", async () => {
+test("refresh accepts a new expected identity when the old daemon reported a legacy identity", async () => {
+  const expectedIdentity = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
   const lifecycle = {
     target: controlTarget,
     probeStatus: async () => undefined,
     ownerIsAlive: () => false,
+    prepareReplacement: async () => runningLaunchConfiguration,
     startReplacement: async () => v2DaemonStatus(84),
     wait: async () => undefined
   } satisfies DaemonControlLifecycle;
 
-  const { exitCode, receipt } = await runCapturedControl(lifecycle, [], "refresh");
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, [], "refresh", expectedIdentity);
 
   assert.equal(exitCode, 0, JSON.stringify(receipt));
   const replacement = receipt.replacement as Record<string, unknown>;
@@ -237,6 +240,29 @@ test("refresh accepts a healthy delta replacement loaded from the new installed 
   const build = service.build as Record<string, unknown>;
   assert.equal(build.loadedIdentity, "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
   assert.equal(build.loadedIdentity, build.installedIdentity);
+});
+
+test("refresh rejects a self-consistent replacement that did not load the expected new identity", async () => {
+  const staleIdentity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const expectedIdentity = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+  const stoppedPids: number[] = [];
+  const lifecycle = {
+    target: controlTarget,
+    probeStatus: async () => undefined,
+    ownerIsAlive: () => false,
+    prepareReplacement: async () => runningLaunchConfiguration,
+    startReplacement: async () => v2DaemonStatus(84, staleIdentity, staleIdentity),
+    stopReplacement: async (_target: typeof controlTarget, pid: number) => {
+      stoppedPids.push(pid);
+    },
+    wait: async () => undefined
+  } satisfies DaemonControlLifecycle;
+
+  const { exitCode, receipt } = await runCapturedControl(lifecycle, [], "refresh", expectedIdentity);
+
+  assert.equal(exitCode, 1);
+  assert.deepEqual(stoppedPids, [84]);
+  assert.match(controlErrorHint(receipt), /did not match the replacement identity calculated before handoff/u);
 });
 
 test("refresh rejects and cleans up a replacement that loaded an old identity", async () => {
@@ -603,7 +629,8 @@ test("daemon help exposes logs, restart, refresh, and refresh trigger selection"
 async function runCapturedControl(
   daemonControlLifecycle: DaemonControlLifecycle,
   extraArgs: ReadonlyArray<string> = [],
-  kind: "restart" | "refresh" = "restart"
+  kind: "restart" | "refresh" = "restart",
+  expectedIdentity = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 ): Promise<{ readonly exitCode: number; readonly receipt: Record<string, unknown> }> {
   const output: string[] = [];
   const originalLog = console.log;
@@ -625,7 +652,8 @@ async function runCapturedControl(
           launchConfiguration: runningLaunchConfiguration
         }
       }),
-      daemonControlLifecycle
+      daemonControlLifecycle,
+      calculateInstalledIdentity: () => expectedIdentity
     });
     return {
       exitCode,

--- a/packages/cli/test/daemon-control-replacement-safety.test.ts
+++ b/packages/cli/test/daemon-control-replacement-safety.test.ts
@@ -247,7 +247,8 @@ async function runCapturedControl(
           launchConfiguration: runningLaunchConfiguration
         }
       }),
-      daemonControlLifecycle
+      daemonControlLifecycle,
+      calculateInstalledIdentity: () => "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     });
     return { exitCode, receipt: JSON.parse(output.at(-1) ?? "") as Record<string, unknown> };
   } finally {

--- a/packages/daemon/src/protocol/daemon-artifact-identity.ts
+++ b/packages/daemon/src/protocol/daemon-artifact-identity.ts
@@ -1,6 +1,6 @@
 // @slice-activation PLT-Boundary W1 exposes this module through the package root API.
 import { createHash } from "node:crypto";
-import { readFileSync, readdirSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import path from "node:path";
 
 export interface DaemonArtifactIdentity {
@@ -10,13 +10,26 @@ export interface DaemonArtifactIdentity {
   readonly elapsedMs: number;
 }
 
-const includedExtensions = new Set([".js", ".json", ".mjs", ".cjs"]);
+const compiledArtifactExtensions = new Set([".js", ".json", ".mjs", ".cjs"]);
+const sourceArtifactExtensions = new Set([...compiledArtifactExtensions, ".ts", ".mts", ".cts", ".tsx"]);
+const sourcePackageRoots = [
+  "packages/cli/src",
+  "packages/kernel/src",
+  "packages/application/src",
+  "packages/api-contracts/src",
+  "packages/daemon/src",
+  "packages/adapters/github-issues/src",
+  "packages/adapters/local/src",
+  "packages/adapters/multica/src"
+] as const;
+const identityDomain = Buffer.from("harness-anything/daemon-artifact-identity/v2\0", "utf8");
 
 export function calculateDaemonArtifactIdentity(entrypoint: string): DaemonArtifactIdentity {
   const started = process.hrtime.bigint();
   const artifactRoot = resolveDaemonArtifactRoot(entrypoint);
-  const files = artifactFiles(artifactRoot);
+  const files = artifactFiles(entrypoint, artifactRoot);
   const digest = createHash("sha256");
+  digest.update(identityDomain);
   for (const relativePath of files) {
     const pathBytes = Buffer.from(relativePath, "utf8");
     const content = readFileSync(path.join(artifactRoot, ...relativePath.split("/")));
@@ -41,15 +54,34 @@ export function resolveDaemonArtifactRoot(entrypoint: string): string {
   let current = path.dirname(resolvedEntrypoint);
   while (true) {
     if (path.basename(current) === "dist") return current;
+    if (isCliSourceRoot(current)) return path.dirname(path.dirname(path.dirname(current)));
     const parent = path.dirname(current);
     if (parent === current) return path.dirname(resolvedEntrypoint);
     current = parent;
   }
 }
 
-function artifactFiles(root: string): ReadonlyArray<string> {
+function artifactFiles(entrypoint: string, root: string): ReadonlyArray<string> {
+  const resolvedEntrypoint = realpathSync(entrypoint);
+  if (isCliSourceEntrypoint(resolvedEntrypoint, root)) {
+    return filesBelowRoots(root, sourcePackageRoots, sourceArtifactExtensions);
+  }
+  const extensions = sourceArtifactExtensions.has(path.extname(resolvedEntrypoint))
+    && !compiledArtifactExtensions.has(path.extname(resolvedEntrypoint))
+    ? sourceArtifactExtensions
+    : compiledArtifactExtensions;
+  return filesBelowRoots(root, ["."], extensions);
+}
+
+function filesBelowRoots(
+  root: string,
+  relativeRoots: ReadonlyArray<string>,
+  extensions: ReadonlySet<string>
+): ReadonlyArray<string> {
   const files: string[] = [];
-  const pending = [root];
+  const pending = relativeRoots
+    .map((relativeRoot) => path.join(root, ...relativeRoot.split("/")))
+    .filter((candidate) => existsDirectory(candidate));
   while (pending.length > 0) {
     const directory = pending.pop()!;
     for (const entry of readdirSync(directory, { withFileTypes: true })) {
@@ -59,10 +91,26 @@ function artifactFiles(root: string): ReadonlyArray<string> {
         pending.push(absolutePath);
         continue;
       }
-      if (!entry.isFile() || !includedExtensions.has(path.extname(entry.name))) continue;
+      if (!entry.isFile()
+        || !extensions.has(path.extname(entry.name))
+        || entry.name.endsWith(".d.ts")) continue;
       files.push(path.relative(root, absolutePath).split(path.sep).join("/"));
     }
   }
   files.sort((left, right) => Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8")));
   return files;
+}
+
+function isCliSourceEntrypoint(entrypoint: string, artifactRoot: string): boolean {
+  return path.dirname(entrypoint) === path.join(artifactRoot, "packages", "cli", "src");
+}
+
+function isCliSourceRoot(candidate: string): boolean {
+  return path.basename(candidate) === "src"
+    && path.basename(path.dirname(candidate)) === "cli"
+    && path.basename(path.dirname(path.dirname(candidate))) === "packages";
+}
+
+function existsDirectory(candidate: string): boolean {
+  return existsSync(candidate);
 }

--- a/packages/daemon/test/daemon-status-contract.test.ts
+++ b/packages/daemon/test/daemon-status-contract.test.ts
@@ -38,6 +38,33 @@ test("daemon artifact identity is deterministic over the adjudicated regular-fil
   }
 });
 
+test("source daemon artifact identity covers CLI build inputs and remains deterministic", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-source-artifact-"));
+  try {
+    const entrypoint = path.join(root, "packages", "cli", "src", "index.ts");
+    const daemonSource = path.join(root, "packages", "daemon", "src", "index.ts");
+    mkdirSync(path.dirname(entrypoint), { recursive: true });
+    mkdirSync(path.dirname(daemonSource), { recursive: true });
+    writeFileSync(entrypoint, "export const cli = true;\n");
+    writeFileSync(daemonSource, "export const daemon = 1;\n");
+    writeFileSync(path.join(path.dirname(daemonSource), "types.d.ts"), "export type Ignored = true;\n");
+
+    const first = calculateDaemonArtifactIdentity(entrypoint);
+    const unchanged = calculateDaemonArtifactIdentity(entrypoint);
+    assert.equal(first.artifactRoot, realpathSync(root));
+    assert.equal(first.fileCount, 2);
+    assert.equal(unchanged.identity, first.identity);
+
+    writeFileSync(entrypoint, "export const cli = false;\n");
+    assert.notEqual(calculateDaemonArtifactIdentity(entrypoint).identity, first.identity);
+    writeFileSync(entrypoint, "export const cli = true;\n");
+    writeFileSync(daemonSource, "export const daemon = 2;\n");
+    assert.notEqual(calculateDaemonArtifactIdentity(entrypoint).identity, first.identity);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("representative installed artifact identity is stable with a sub-50ms median calculation", (t) => {
   const root = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-installed-artifact-"));
   try {


### PR DESCRIPTION
# English

## Summary

Fix the daemon build-identity computation that kept `sha256:7265e1f7…` constant across five merges containing CLI/daemon source changes: the source-mode artifact enumeration only globbed `.js/.json/.mjs/.cjs` and missed every workspace TypeScript file, degrading the #948 handoff convergence criterion (`loadedIdentity === installedIdentity` was vacuously true).

## What Changed

- `packages/daemon/src/protocol/daemon-artifact-identity.ts`: source mode now digests the CLI-build workspace `src` sets (8 workspaces); dist mode keeps covering the full `dist` runtime artifact set. No timestamps, PIDs, or absolute-path noise in the digest.
- `packages/cli/src/commands/daemon/control.ts`: refresh convergence additionally requires `loadedIdentity === pre-handoff expectedIdentity` (computed before the handoff), on top of all existing conditions (new PID, loaded==installed, operation cleared).
- Backward compatible: old fingerprints in existing state do not wedge refresh; no launch-spec/status schema changes.
- Regression tests: source change → fingerprint change; no change → stable; dispatcher/replacement-safety/status-contract coverage.

Evidence: recomputing with the fixed algorithm distinguishes #948 (`ff720e60…`) from #949 (`a33948cc…`) where the old algorithm produced the identical `7265e1f7…` (45 files) for both.

## Task And Scope

Task `task_01KXZ6J74CX0G4CKA3YQ68B0Q0`; forensic side-quest of the L1 owner-exit task confirmed the defect. Scope: identity enumeration + refresh convergence wiring only.

## Version Impact

Patch. No schema changes.

## Governance Declaration

Authorized by task `task_01KXZ6J74CX0G4CKA3YQ68B0Q0` under umbrella `task_01KXWZ3YEGXD6302G1656RY801` / charter `dec_01KXWZ33N9`. Protected daemon-lifecycle criterion strengthened only, never relaxed. Write-road registry unchanged (no new write surface).

## Verification

Targeted tests green: identity tests (35/35, hermetic git config), refresh isolation integration (4/4), typecheck, ESLint on touched files. Full matrix on this PR's CI. Production acceptance: the next post-merge refresh after this lands must show a changed installedIdentity.

## Review Evidence

Independent Codex review round: no findings ("consistently expands source artifact identity coverage and enforces the precomputed refresh identity during replacement convergence"). CEO semantic acceptance: criterion strictly stronger, backward-compatibility path tested.

## Residual Risk

First deploy after merge is the real-world proof point (fingerprint must change); observed as part of the merge closeout.

## References

- Umbrella: `task_01KXWZ3YEGXD6302G1656RY801` / charter `dec_01KXWZ33N9`
- Origin forensics: L1 owner-exit task `task_01KXYBMJRG6NY22FRT00ABP6S0` (PR #950)

---

# 中文

## 概要

修复 daemon build identity 计算：`sha256:7265e1f7…` 跨五次含 CLI/daemon 源码变更的合并保持不变——源码模式产物枚举只收 `.js/.json/.mjs/.cjs`，漏掉了全部 workspace TypeScript 文件，使 #948 交接收敛判据（`loadedIdentity === installedIdentity`）退化为恒真。

## 改动内容

- `packages/daemon/src/protocol/daemon-artifact-identity.ts`：源码模式改为摘要 CLI build 涉及的 8 个 workspace `src` 集合；dist 模式继续覆盖完整 `dist` 运行产物集。摘要不含时间戳、PID、绝对路径噪声。
- `packages/cli/src/commands/daemon/control.ts`：refresh 收敛新增 `loadedIdentity === 交接前 expectedIdentity` 条件，叠加在全部既有条件（新 PID、loaded==installed、operation cleared）之上。
- 前后兼容：既有状态里的旧指纹不会卡死 refresh；未改 launch-spec/status schema。
- 回归测试：源变→指纹变；不变→稳定；dispatcher/replacement-safety/status-contract 覆盖。

证据：用修复后算法重算，#948（`ff720e60…`）与 #949（`a33948cc…`）立即区分，旧算法两者同为 `7265e1f7…`（45 文件）。

## 任务与范围

任务 `task_01KXZ6J74CX0G4CKA3YQ68B0Q0`；缺陷由 L1 owner-exit 任务的取证副线确认。范围仅限 identity 枚举 + refresh 收敛接线。

## 版本影响

Patch。无 schema 变化。

## 治理声明

授权自任务 `task_01KXZ6J74CX0G4CKA3YQ68B0Q0`（伞任务 `task_01KXWZ3YEGXD6302G1656RY801` / charter `dec_01KXWZ33N9`）。protected daemon 生命周期判据只强化不放松。write-road registry 无变化（无新增写面）。

## 验证

定向测试绿：identity 测试（35/35，hermetic git 配置）、refresh 隔离集成（4/4）、typecheck、触面 ESLint。全量矩阵由本 PR CI 判。生产验收：合并后下一次 post-merge refresh 必须观察到 installedIdentity 变化。

## 审查证据

独立 Codex 评审一轮：无 finding。CEO 语义验收：判据严格更强、兼容路径有测试。

## 残余风险

合并后首次部署是真实世界验证点（指纹必须变化）；作为合并收尾的一部分观察记录。

## 关联材料

- 伞任务：`task_01KXWZ3YEGXD6302G1656RY801` / charter `dec_01KXWZ33N9`
- 取证来源：L1 owner-exit 任务 `task_01KXYBMJRG6NY22FRT00ABP6S0`（PR #950）

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body / 双语正文
- [x] Governance declaration / 治理声明
- [x] Task linkage / 任务关联
