### PR TITLE
fix(daemon): truthful admission rejections — oversized batch is not retryable

### DIFF
--- a/packages/application/src/authority/admission.ts
+++ b/packages/application/src/authority/admission.ts
@@ -26,7 +26,9 @@ export async function runWithAuthorityAdmission(input: {
       ? admission.error.reason
       : "Shared daemon admission failed. Run 'ha daemon status --json', wait for current writes to settle, then retry the exact command.";
     return {
-      tag: "RETRYABLE_NOT_COMMITTED",
+      tag: admission.error._tag === "WriteRejected" && admission.error.retryable === false
+        ? "REJECTED"
+        : "RETRYABLE_NOT_COMMITTED",
       workspaceId: input.identity.workspaceId,
       opId: input.identity.opId,
       semanticDigest: input.semanticDigest,

--- a/packages/application/test/authority-daemon-admission.test.ts
+++ b/packages/application/test/authority-daemon-admission.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { DaemonAdmissionBudget } from "@harness-anything/kernel";
+import { runWithAuthorityAdmission } from "../src/authority/admission.ts";
+
+const identity = { workspaceId: "workspace-admission", opId: "op-admission" };
+
+test("authority forced-command reports temporary capacity pressure as retryable", async () => {
+  let temporarilyFull = true;
+  const budget: DaemonAdmissionBudget = {
+    reserve: () => temporarilyFull
+      ? {
+        ok: false,
+        error: {
+          _tag: "WriteRejected",
+          code: "admission_overloaded",
+          reason: "Shared daemon admission budget is full. Run 'ha daemon status --json', wait for current writes to settle, then retry the exact command.",
+          retryable: true
+        }
+      }
+      : { ok: true, reservation: { release: () => undefined } },
+    snapshot: () => ({
+      limits: { maxOperations: 2, maxBytes: 200, reservedOperationsPerPlane: 0, reservedBytesPerPlane: 0 },
+      used: { operations: 0, bytes: 0, authorityOperations: 0, authorityBytes: 0, jsonRpcOperations: 0, jsonRpcBytes: 0 },
+      rejected: { authority: temporarilyFull ? 1 : 0, "json-rpc": 0 }
+    })
+  };
+
+  const receipt = await runWithAuthorityAdmission({
+    budget,
+    identity,
+    semanticDigest: "digest-temporary",
+    bytes: 100,
+    work: () => Promise.reject(new Error("rejected work must not run"))
+  });
+
+  assert.deepEqual(receipt, {
+    tag: "RETRYABLE_NOT_COMMITTED",
+    workspaceId: identity.workspaceId,
+    opId: identity.opId,
+    semanticDigest: "digest-temporary",
+    reason: "Shared daemon admission budget is full. Run 'ha daemon status --json', wait for current writes to settle, then retry the exact command."
+  });
+  temporarilyFull = false;
+  const retried = await runWithAuthorityAdmission({
+    budget,
+    identity,
+    semanticDigest: "digest-temporary",
+    bytes: 100,
+    work: async () => ({
+      tag: "REJECTED",
+      workspaceId: identity.workspaceId,
+      opId: identity.opId,
+      semanticDigest: "digest-temporary",
+      reason: "fixture reached work"
+    })
+  });
+  assert.equal(retried.reason, "fixture reached work");
+});
+
+test("authority forced-command reports a permanently oversized payload as non-retryable", async () => {
+  const budget: DaemonAdmissionBudget = {
+    reserve: () => ({
+      ok: false,
+      error: {
+        _tag: "WriteRejected",
+        code: "admission_payload_exceeds_limit",
+        reason: "Shared daemon admission payload exceeds the per-request limit (operations: requested 1, limit 1; bytes: requested 101, limit 100). Split the batch or reduce the payload, then submit each smaller request.",
+        retryable: false
+      }
+    }),
+    snapshot: () => ({
+      limits: { maxOperations: 2, maxBytes: 200, reservedOperationsPerPlane: 1, reservedBytesPerPlane: 100 },
+      used: { operations: 0, bytes: 0, authorityOperations: 0, authorityBytes: 0, jsonRpcOperations: 0, jsonRpcBytes: 0 },
+      rejected: { authority: 2, "json-rpc": 0 }
+    })
+  };
+  const expected = {
+    tag: "REJECTED",
+    workspaceId: identity.workspaceId,
+    opId: identity.opId,
+    semanticDigest: "digest-oversized",
+    reason: "Shared daemon admission payload exceeds the per-request limit (operations: requested 1, limit 1; bytes: requested 101, limit 100). Split the batch or reduce the payload, then submit each smaller request."
+  } as const;
+  const request = () => runWithAuthorityAdmission({
+    budget,
+    identity,
+    semanticDigest: "digest-oversized",
+    bytes: 101,
+    work: () => Promise.reject(new Error("oversized work must not run"))
+  });
+
+  assert.deepEqual(await request(), expected);
+  assert.deepEqual(await request(), expected);
+});

--- a/packages/application/test/authority-daemon-admission.test.ts
+++ b/packages/application/test/authority-daemon-admission.test.ts
@@ -1,3 +1,4 @@
+// harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { DaemonAdmissionBudget } from "@harness-anything/kernel";

--- a/packages/cli/src/cli/error-codes.ts
+++ b/packages/cli/src/cli/error-codes.ts
@@ -237,7 +237,7 @@ export interface CliErrorCodeDefinition {
 
 export const cliErrorCodeRegistry = {
   [CliErrorCode.AdmissionOverloaded]: { category: "domain", defaultHint: "Shared daemon admission failed because the op/byte budget is full. Run `ha daemon status --json`, wait for admitted writes to settle, then retry the exact command." },
-  [CliErrorCode.AdmissionPayloadExceedsLimit]: { category: "domain", defaultHint: "Shared daemon admission payload exceeds its permanent per-request limit. Split the batch or reduce the payload, then submit each smaller request." },
+  [CliErrorCode.AdmissionPayloadExceedsLimit]: { category: "domain", defaultHint: "Shared daemon admission rejected this request because its operations or bytes exceed the protected per-request limit. Split it into multiple calls or pass a smaller `--evidence` value, then rerun the original command." },
   [CliErrorCode.ArchivedHardDeleteForbidden]: { category: "domain", defaultHint: "Archived tasks cannot be hard deleted." },
   [CliErrorCode.ArtifactReadFailed]: { category: "domain", defaultHint: "Artifact read failed." },
   [CliErrorCode.ArtifactWriteRejected]: { category: "domain", defaultHint: "Artifact write was rejected." },

--- a/packages/cli/src/cli/error-codes.ts
+++ b/packages/cli/src/cli/error-codes.ts
@@ -1,5 +1,6 @@
 export const CliErrorCode = {
   AdmissionOverloaded: "admission_overloaded",
+  AdmissionPayloadExceedsLimit: "admission_payload_exceeds_limit",
   ArchivedHardDeleteForbidden: "archived_hard_delete_forbidden",
   ArtifactReadFailed: "artifact_read_failed",
   ArtifactWriteRejected: "artifact_write_rejected",
@@ -188,6 +189,7 @@ export type CliErrorCategory = "parse" | "command" | "domain" | "settings" | "ex
 export type CliErrorFamily = "kernel-mapped" | "command-local";
 
 export const cliKernelMappedErrorCodes = new Set<CliErrorCode>([
+  CliErrorCode.AdmissionPayloadExceedsLimit,
   CliErrorCode.ArchivedHardDeleteForbidden,
   CliErrorCode.ArtifactReadFailed,
   CliErrorCode.ArtifactWriteRejected,
@@ -235,6 +237,7 @@ export interface CliErrorCodeDefinition {
 
 export const cliErrorCodeRegistry = {
   [CliErrorCode.AdmissionOverloaded]: { category: "domain", defaultHint: "Shared daemon admission failed because the op/byte budget is full. Run `ha daemon status --json`, wait for admitted writes to settle, then retry the exact command." },
+  [CliErrorCode.AdmissionPayloadExceedsLimit]: { category: "domain", defaultHint: "Shared daemon admission payload exceeds its permanent per-request limit. Split the batch or reduce the payload, then submit each smaller request." },
   [CliErrorCode.ArchivedHardDeleteForbidden]: { category: "domain", defaultHint: "Archived tasks cannot be hard deleted." },
   [CliErrorCode.ArtifactReadFailed]: { category: "domain", defaultHint: "Artifact read failed." },
   [CliErrorCode.ArtifactWriteRejected]: { category: "domain", defaultHint: "Artifact write was rejected." },

--- a/packages/cli/test/receipt-contracts.test.ts
+++ b/packages/cli/test/receipt-contracts.test.ts
@@ -174,6 +174,27 @@ test("task lease write rejection preserves its specific CLI error code and hint"
   });
 });
 
+test("CLI failure receipt preserves the permanent admission payload classification", () => {
+  const receipt = toCommandReceipt({
+    ok: false,
+    command: "progress-append",
+    error: toCliError({
+      _tag: "WriteRejected",
+      code: "admission_payload_exceeds_limit",
+      reason: "Requested bytes exceed the permanent admission limit. Split the batch.",
+      retryable: false
+    })
+  });
+
+  assert.equal(receipt.ok, false);
+  if (receipt.ok) return;
+  assert.deepEqual(receipt.error, {
+    code: "admission_payload_exceeds_limit",
+    hint: "Requested bytes exceed the permanent admission limit. Split the batch."
+  });
+  assert.match(renderReceiptText(receipt), /code=admission_payload_exceeds_limit/u);
+});
+
 test("command receipts accept explicitly optional declared data when present", () => {
   const receipt = toCommandReceipt({
     ok: true,

--- a/packages/kernel/src/daemon/admission-budget.ts
+++ b/packages/kernel/src/daemon/admission-budget.ts
@@ -39,7 +39,7 @@ export interface DaemonAdmissionBudget {
   readonly snapshot: () => DaemonAdmissionBudgetSnapshot;
 }
 
-const overloadError: WriteError = Object.freeze({
+const capacityExceededError: WriteError = Object.freeze({
   _tag: "WriteRejected" as const,
   code: "admission_overloaded",
   reason: "Shared daemon admission budget is full. Run 'ha daemon status --json', wait for current writes to settle, then retry the exact command.",
@@ -62,6 +62,15 @@ export function createDaemonAdmissionBudget(limits: DaemonAdmissionBudgetLimits)
     reserve: (input) => {
       assertNonNegativeInteger(input.operations, "operations");
       assertNonNegativeInteger(input.bytes, "bytes");
+      const operationLimit = limits.maxOperations - limits.reservedOperationsPerPlane;
+      const byteLimit = limits.maxBytes - limits.reservedBytesPerPlane;
+      if (input.operations > operationLimit || input.bytes > byteLimit) {
+        rejected[input.plane] += 1;
+        return {
+          ok: false,
+          error: payloadExceedsLimitError(input.operations, operationLimit, input.bytes, byteLimit)
+        };
+      }
       const otherOperations = input.plane === "authority" ? used.jsonRpcOperations : used.authorityOperations;
       const otherBytes = input.plane === "authority" ? used.jsonRpcBytes : used.authorityBytes;
       const protectedOperations = Math.max(0, limits.reservedOperationsPerPlane - otherOperations);
@@ -70,7 +79,7 @@ export function createDaemonAdmissionBudget(limits: DaemonAdmissionBudgetLimits)
       const exceedsBytes = used.bytes + input.bytes > limits.maxBytes - protectedBytes;
       if (exceedsOperations || exceedsBytes) {
         rejected[input.plane] += 1;
-        return { ok: false, error: overloadError };
+        return { ok: false, error: capacityExceededError };
       }
 
       used.operations += input.operations;
@@ -103,6 +112,15 @@ export function createDaemonAdmissionBudget(limits: DaemonAdmissionBudgetLimits)
       };
     },
     snapshot: () => ({ limits: { ...limits }, used: { ...used }, rejected: { ...rejected } })
+  };
+}
+
+function payloadExceedsLimitError(operations: number, operationLimit: number, bytes: number, byteLimit: number): WriteError {
+  return {
+    _tag: "WriteRejected",
+    code: "admission_payload_exceeds_limit",
+    reason: `Shared daemon admission payload exceeds the per-request limit (operations: requested ${operations}, limit ${operationLimit}; bytes: requested ${bytes}, limit ${byteLimit}). Split the batch or reduce the payload, then submit each smaller request.`,
+    retryable: false
   };
 }
 

--- a/packages/kernel/test/daemon/admission-budget.test.ts
+++ b/packages/kernel/test/daemon/admission-budget.test.ts
@@ -42,8 +42,49 @@ test("shared admission budget bounds 32 clients per plane without starving the p
         else {
           assert.equal(result.error._tag, "WriteRejected");
           assert.equal(result.error._tag === "WriteRejected" ? result.error.code : undefined, "admission_overloaded");
+          assert.equal(result.error._tag === "WriteRejected" ? result.error.retryable : undefined, true);
         }
       }
     }
+  }
+});
+
+test("admission distinguishes temporary capacity pressure from a payload that can never fit", () => {
+  for (const plane of ["authority", "json-rpc"] as const) {
+    const budget = createDaemonAdmissionBudget({
+      maxOperations: 4,
+      maxBytes: 400,
+      reservedOperationsPerPlane: 1,
+      reservedBytesPerPlane: 100
+    });
+    const held = budget.reserve({ plane, operations: 3, bytes: 300 });
+    assert.equal(held.ok, true);
+
+    const temporarilyFull = budget.reserve({ plane, operations: 1, bytes: 100 });
+    assert.deepEqual(temporarilyFull, {
+      ok: false,
+      error: {
+        _tag: "WriteRejected",
+        code: "admission_overloaded",
+        reason: "Shared daemon admission budget is full. Run 'ha daemon status --json', wait for current writes to settle, then retry the exact command.",
+        retryable: true
+      }
+    });
+    if (held.ok) held.reservation.release();
+    const retriedAfterRelease = budget.reserve({ plane, operations: 1, bytes: 100 });
+    assert.equal(retriedAfterRelease.ok, true);
+    if (retriedAfterRelease.ok) retriedAfterRelease.reservation.release();
+
+    const oversized = {
+      ok: false,
+      error: {
+        _tag: "WriteRejected",
+        code: "admission_payload_exceeds_limit",
+        reason: "Shared daemon admission payload exceeds the per-request limit (operations: requested 4, limit 3; bytes: requested 301, limit 300). Split the batch or reduce the payload, then submit each smaller request.",
+        retryable: false
+      }
+    };
+    assert.deepEqual(budget.reserve({ plane, operations: 4, bytes: 301 }), oversized);
+    assert.deepEqual(budget.reserve({ plane, operations: 4, bytes: 301 }), oversized);
   }
 });

--- a/packages/kernel/test/store/daemon-runtime-admission.test.ts
+++ b/packages/kernel/test/store/daemon-runtime-admission.test.ts
@@ -1,0 +1,88 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDaemonRuntime } from "../../../adapters/local/src/index.ts";
+import { docWrite, withTempStoreAsync } from "./helpers.ts";
+import { daemonAttribution } from "./helpers/daemon-runtime.ts";
+
+const admissionAttribution = daemonAttribution("person_admission", "agent_admission", "credential-admission");
+
+test("JSON-RPC queue retries temporary admission pressure after the reservation is released", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: false,
+      interactiveMicroBatchMs: 100,
+      admissionMaxOperations: 1,
+      admissionMaxBytes: 1_000_000,
+      admissionReservedOperationsPerPlane: 0,
+      admissionReservedBytesPerPlane: 0
+    });
+    await runtime.start();
+    const first = runtime.enqueueInteractiveWrite({
+      commandId: "cmd-held",
+      attribution: admissionAttribution,
+      ops: [docWrite("op-held", "task-held", "note.md", "held")]
+    });
+    await assert.rejects(
+      runtime.enqueueInteractiveWrite({
+        commandId: "cmd-temporarily-full",
+        attribution: admissionAttribution,
+        ops: [docWrite("op-temporarily-full", "task-temporarily-full", "note.md", "temporary")]
+      }),
+      temporaryCapacityError
+    );
+    await first;
+    await runtime.enqueueInteractiveWrite({
+      commandId: "cmd-retried",
+      attribution: admissionAttribution,
+      ops: [docWrite("op-retried", "task-retried", "note.md", "retried")]
+    });
+    await runtime.stop();
+  });
+});
+
+test("JSON-RPC queue keeps rejecting an oversized batch as non-retryable", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: false,
+      admissionMaxOperations: 1,
+      admissionMaxBytes: 1_000_000,
+      admissionReservedOperationsPerPlane: 0,
+      admissionReservedBytesPerPlane: 0
+    });
+    await runtime.start();
+    const request = () => runtime.enqueueInteractiveWrite({
+      commandId: "cmd-oversized",
+      attribution: admissionAttribution,
+      ops: [
+        docWrite("op-oversized-1", "task-oversized-1", "note.md", "one"),
+        docWrite("op-oversized-2", "task-oversized-2", "note.md", "two")
+      ]
+    });
+    await assert.rejects(request(), oversizedPayloadError);
+    await assert.rejects(request(), oversizedPayloadError);
+    await runtime.stop();
+  });
+});
+
+function temporaryCapacityError(error: unknown): boolean {
+  assert.deepEqual(error, {
+    _tag: "WriteRejected",
+    code: "admission_overloaded",
+    reason: "Shared daemon admission budget is full. Run 'ha daemon status --json', wait for current writes to settle, then retry the exact command.",
+    retryable: true
+  });
+  return true;
+}
+
+function oversizedPayloadError(error: unknown): boolean {
+  assert.equal(typeof error, "object");
+  assert.equal(error !== null && "_tag" in error ? error._tag : undefined, "WriteRejected");
+  assert.equal(error !== null && "code" in error ? error.code : undefined, "admission_payload_exceeds_limit");
+  assert.equal(error !== null && "retryable" in error ? error.retryable : undefined, false);
+  assert.match(error !== null && "reason" in error ? String(error.reason) : "", /operations: requested 2, limit 1/u);
+  assert.match(error !== null && "reason" in error ? String(error.reason) : "", /Split the batch or reduce the payload/u);
+  return true;
+}

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -397,6 +397,7 @@
         }
       ],
       "evidence": [
+        "packages/kernel/src/daemon/admission-budget.ts:62",
         "packages/kernel/src/write-coordination/write-helpers.ts:20",
         "packages/kernel/src/store/write-journal-durable.ts:109",
         "packages/kernel/src/store/write-journal-locks.ts:125"
@@ -1488,6 +1489,7 @@
         "packages/application/src/authority/service.ts"
       ],
       "evidence": [
+        "packages/application/src/authority/admission.ts:23",
         "packages/application/src/authority/service.ts:86",
         "packages/daemon/src/authority/forced-command-session.ts:1"
       ],


### PR DESCRIPTION
# English

## Summary

Fix the daemon admission budget's always-true lie: a single batch whose payload exceeds the absolute admission limit used to get the same retryable "budget is full … retry" rejection as a temporarily-full budget, sending callers into a retry loop that can never succeed. Rejections are now classified truthfully.

## What Changed

- `packages/kernel/src/daemon/admission-budget.ts`: `reserve` now distinguishes `capacity-exceeded-now` (`admission_overloaded`, retryable, keeps the wait-and-retry guidance) from `payload-exceeds-limit` (`admission_payload_exceeds_limit`, non-retryable; reason reports requested vs per-batch limits for operations/bytes and instructs to split or shrink the batch). Admission math (`protectedOperations/Bytes`, aggregate accounting) unchanged — the existing rejection set is only subdivided, never widened or narrowed.
- `packages/application/src/authority/admission.ts`: authority plane maps the permanent class to the existing `REJECTED` receipt tag (no receipt-contract change); the retryable class keeps `RETRYABLE_NOT_COMMITTED`.
- CLI error boundary: `admission_payload_exceeds_limit` registered in `CliErrorCode` and its registry so the machine-readable permanent-vs-retryable distinction survives to the public surface instead of degrading to generic `write_rejected` (review finding, fixed with end-to-end receipt/text assertions).
- Regression tests with red-control: temporarily-full → retry succeeds after release; oversized batch → truthful non-retryable rejection on both planes (authority forced-command and JSON-RPC share the aggregate budget, asserted consistent).

## Task And Scope

Task `task_01KXWQ3PATP9ZSGT4GB4948RHN` (L1 chain, umbrella `task_01KXWZ3YEGXD6302G1656RY801`). Scope: rejection semantics only; no file moves (serial with Boundary W2), no admission-policy change.

## Version Impact

Patch (new CLI error code is additive).

## Governance Declaration

Authorized by task `task_01KXWQ3PATP9ZSGT4GB4948RHN` under charter `dec_01KXWZ33N9`. Write-admission surface: rejection classification made truthful only; no gate weakened. Aligned with the CLI diagnosability contract `dec_01KXV0BEVX` (what was rejected / why / what to do next). Write-road registry rows added for the touched surfaces.

## Verification

Targeted tests 27/27 green including red-control (reverting the fix makes the new tests fail precisely); typecheck, `check-cli-error-codes`, write-road registry, file-complexity, duplicate-definitions all green locally. Full matrix on this PR's CI.

## Review Evidence

Single-reviewer round (Codex): one P2 confirmed — permanent error code was being downgraded at the CLI boundary — fixed in the bounded fix round with end-to-end assertions. CEO semantic acceptance: existing `REJECTED` tag reused, receipt contract untouched (checkpoint honored).

## Residual Risk

None known; oversized-batch behavior is now covered by regression on both planes.

## References

- Umbrella: `task_01KXWZ3YEGXD6302G1656RY801` / charter `dec_01KXWZ33N9`
- Diagnosability contract: `dec_01KXV0BEVX`

---

# 中文

## 概要

修复 daemon 准入预算的恒真谎言：单批 payload 超过准入绝对上限时，此前返回与"预算暂满"相同的 retryable"预算满请重试"文案，把调用方引进永不成功的重试循环。拒绝现按真实语义分类。

## 改动内容

- `packages/kernel/src/daemon/admission-budget.ts`：`reserve` 区分 `capacity-exceeded-now`（`admission_overloaded`，可重试，保留等待重试指引）与 `payload-exceeds-limit`（`admission_payload_exceeds_limit`，不可重试；reason 报告 operations/bytes 的请求值与单批上限，并指引拆批/缩小）。准入公式与聚合占用判断未动——只细分既有拒绝集合，不放宽不收紧。
- `packages/application/src/authority/admission.ts`：authority 面把永久类映射到既有 `REJECTED` receipt tag（不改 receipt 契约）；可重试类保持 `RETRYABLE_NOT_COMMITTED`。
- CLI 错误边界：`admission_payload_exceeds_limit` 注册进 `CliErrorCode` 与 registry，机器可读的永久/可重试区分保留到公共面，不再降级为泛化 `write_rejected`（评审 finding，已修并带端到端断言）。
- 回归测试含 red 对照：暂满→释放后重试成功；单批超限→双面（authority forced-command 与 JSON-RPC 共享聚合预算）一致的如实非重试拒绝。

## 任务与范围

任务 `task_01KXWQ3PATP9ZSGT4GB4948RHN`（L1 链，伞任务 `task_01KXWZ3YEGXD6302G1656RY801`）。范围仅限拒绝语义；不挪文件（与 Boundary W2 串行）、不改准入政策。

## 版本影响

Patch（新 CLI error code 为增量）。

## 治理声明

授权自任务 `task_01KXWQ3PATP9ZSGT4GB4948RHN`（charter `dec_01KXWZ33N9`）。写入准入面：仅把拒绝分类做真实，无削门。对齐 CLI 可诊断性契约 `dec_01KXV0BEVX`（拒了什么/为什么/怎么办）。触面已补 write-road registry 行。

## 验证

定向测试 27/27 绿含 red 对照（撤回修复则新测试准确失败）；typecheck、`check-cli-error-codes`、write-road registry、file-complexity、duplicate-definitions 本地全绿。全量矩阵由本 PR CI 判。

## 审查证据

单评审员一轮（Codex）：1 条 P2 成立——永久 error code 在 CLI 边界被降级——已在同轮修复并带端到端断言。CEO 语义验收：复用既有 `REJECTED` tag，receipt 契约未动（checkpoint 守住）。

## 残余风险

无已知；超限单批行为已被双面回归覆盖。

## 关联材料

- 伞任务：`task_01KXWZ3YEGXD6302G1656RY801` / charter `dec_01KXWZ33N9`
- 可诊断性契约：`dec_01KXV0BEVX`

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body / 双语正文
- [x] Governance declaration / 治理声明
- [x] Task linkage / 任务关联
