### PR TITLE
fix(daemon): flagless cold start via persisted launch spec

### DIFF
--- a/packages/cli/src/daemon/daemon-launch-spec.ts
+++ b/packages/cli/src/daemon/daemon-launch-spec.ts
@@ -52,6 +52,12 @@ interface PersistedDaemonLaunchSpec {
   readonly launchConfiguration: DaemonLaunchConfiguration;
 }
 
+interface LegacyPersistedDaemonLaunchSpec {
+  readonly schema: "daemon-launch-spec/v2";
+  readonly endpoint: string;
+  readonly options: DaemonLaunchOptions;
+}
+
 export class DaemonLaunchResolution {
   readonly #endpoint: string;
   readonly #options: DaemonLaunchOptions;
@@ -65,8 +71,17 @@ export class DaemonLaunchResolution {
 
   static restore(userRoot: string, endpoint: string, explicit: DaemonLaunchOptions): DaemonLaunchResolution {
     const endpointIdentity = daemonLaunchEndpointIdentity(endpoint);
-    const persisted = readPersistedDaemonLaunchSpec(userRoot, endpointIdentity);
-    const persistedOptions = persisted ? daemonLaunchOptionsFromConfiguration(persisted) : undefined;
+    let persistedOptions: DaemonLaunchOptions | undefined;
+    try {
+      const persisted = readPersistedDaemonLaunchSpec(userRoot, endpointIdentity);
+      persistedOptions = persisted && isDaemonLaunchConfiguration(persisted)
+        ? daemonLaunchOptionsFromConfiguration(persisted)
+        : persisted;
+    } catch (error) {
+      // A complete explicit authority configuration is sufficient to rebuild durable state. Do not
+      // let an obsolete or damaged cache prevent that recovery path; a successful start rewrites v3.
+      if (explicit.authorityManifest === undefined) throw error;
+    }
     return new DaemonLaunchResolution(endpointIdentity, resolveRestoredLaunchOptions(persistedOptions, explicit));
   }
 
@@ -182,29 +197,30 @@ export function parseDaemonLaunchArgv(
 export function readPersistedDaemonLaunchSpec(
   userRoot: string,
   endpoint: string
-): DaemonLaunchConfiguration | undefined {
+): DaemonLaunchConfiguration | DaemonLaunchOptions | undefined {
   const endpointIdentity = daemonLaunchEndpointIdentity(endpoint);
   const source = daemonLaunchSpecPath(userRoot, endpointIdentity);
   if (!existsSync(source)) return undefined;
   let decoded: unknown;
   try {
     decoded = JSON.parse(readFileSync(source, "utf8"));
-  } catch (error) {
-    throw incompatibleDaemonLaunchSpecError(source, error);
+  } catch {
+    throw incompatibleDaemonLaunchSpecError(source, "invalid-json");
   }
-  if (!isRecordValue(decoded)
-    || decoded.schema !== daemonLaunchSpecSchema
-    || decoded.endpoint !== endpointIdentity
-    || !isDaemonLaunchConfiguration(decoded.launchConfiguration)) {
-    throw incompatibleDaemonLaunchSpecError(source);
+  if (!isRecordValue(decoded) || decoded.endpoint !== endpointIdentity) {
+    throw incompatibleDaemonLaunchSpecError(source, "endpoint-mismatch");
+  }
+  if (isLegacyPersistedDaemonLaunchSpec(decoded)) return cloneDaemonLaunchOptions(decoded.options);
+  if (decoded.schema !== daemonLaunchSpecSchema || !isDaemonLaunchConfiguration(decoded.launchConfiguration)) {
+    throw incompatibleDaemonLaunchSpecError(source, "invalid-document");
   }
   const configuration = cloneDaemonLaunchConfiguration(decoded.launchConfiguration);
   try {
     assertDaemonLaunchConfigurationForEndpoint(configuration, endpointIdentity);
-  } catch (error) {
-    throw incompatibleDaemonLaunchSpecError(source, error);
+    return configuration;
+  } catch {
+    throw incompatibleDaemonLaunchSpecError(source, "invalid-launch-configuration");
   }
-  return configuration;
 }
 
 export function resolveRestoredLaunchOptions(
@@ -309,10 +325,26 @@ function isDaemonLaunchConfiguration(value: unknown): value is DaemonLaunchConfi
     && value.args.every((arg) => typeof arg === "string");
 }
 
-function incompatibleDaemonLaunchSpecError(source: string, cause?: unknown): Error {
-  const detail = cause instanceof Error ? ` (${cause.message})` : "";
+function isLegacyPersistedDaemonLaunchSpec(
+  value: Record<string, unknown>
+): value is Record<string, unknown> & LegacyPersistedDaemonLaunchSpec {
+  return value.schema === "daemon-launch-spec/v2" && isDaemonLaunchOptions(value.options);
+}
+
+function isDaemonLaunchOptions(value: unknown): value is DaemonLaunchOptions {
+  if (!isRecordValue(value)) return false;
+  const authorityManifest = value.authorityManifest;
+  const authoredRoot = value.authoredRoot;
+  return (authorityManifest === undefined || (typeof authorityManifest === "string" && path.isAbsolute(authorityManifest)))
+    && (authoredRoot === undefined || (typeof authoredRoot === "string" && path.isAbsolute(authoredRoot)));
+}
+
+function incompatibleDaemonLaunchSpecError(
+  source: string,
+  category: "invalid-json" | "invalid-document" | "endpoint-mismatch" | "invalid-launch-configuration"
+): Error {
   return new Error(
-    `DAEMON_LAUNCH_SPEC_INCOMPATIBLE: persisted daemon launch specification at ${source} is not compatible with this CLI${detail}. `
+    `DAEMON_LAUNCH_SPEC_INCOMPATIBLE: persisted daemon launch specification at ${source} is not compatible with this CLI (${category}). `
     + "Remove that file and rebuild it with: ha daemon start --service --user-root <user-root> --authority-manifest <path>"
   );
 }

--- a/packages/cli/src/daemon/daemon-launch-spec.ts
+++ b/packages/cli/src/daemon/daemon-launch-spec.ts
@@ -11,7 +11,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 
-export const daemonLaunchSpecSchema = "daemon-launch-spec/v2";
+export const daemonLaunchSpecSchema = "daemon-launch-spec/v3";
 export const daemonLaunchOptionsResolvedFlag = "--launch-options-resolved";
 
 export class DaemonLaunchPreflightError extends Error {
@@ -49,7 +49,7 @@ export interface ParsedDaemonLaunchArgv extends DaemonLaunchOptions {
 interface PersistedDaemonLaunchSpec {
   readonly schema: typeof daemonLaunchSpecSchema;
   readonly endpoint: string;
-  readonly options: DaemonLaunchOptions;
+  readonly launchConfiguration: DaemonLaunchConfiguration;
 }
 
 export class DaemonLaunchResolution {
@@ -66,7 +66,8 @@ export class DaemonLaunchResolution {
   static restore(userRoot: string, endpoint: string, explicit: DaemonLaunchOptions): DaemonLaunchResolution {
     const endpointIdentity = daemonLaunchEndpointIdentity(endpoint);
     const persisted = readPersistedDaemonLaunchSpec(userRoot, endpointIdentity);
-    return new DaemonLaunchResolution(endpointIdentity, resolveRestoredLaunchOptions(persisted, explicit));
+    const persistedOptions = persisted ? daemonLaunchOptionsFromConfiguration(persisted) : undefined;
+    return new DaemonLaunchResolution(endpointIdentity, resolveRestoredLaunchOptions(persistedOptions, explicit));
   }
 
   static complete(endpoint: string, options: DaemonLaunchOptions): DaemonLaunchResolution {
@@ -85,8 +86,12 @@ export class DaemonLaunchResolution {
     return new DaemonLaunchResolution(this.#endpoint, options);
   }
 
-  persist(userRoot: string): void {
-    writeDaemonLaunchResolution(userRoot, this.#endpoint, this.#options);
+  persist(userRoot: string, launchConfiguration: DaemonLaunchConfiguration): void {
+    const configurationOptions = daemonLaunchOptionsFromConfiguration(launchConfiguration);
+    if (!sameDaemonLaunchOptions(configurationOptions, this.#options)) {
+      throw new Error("daemon launch configuration does not match its resolved launch options");
+    }
+    writeDaemonLaunchResolution(userRoot, this.#endpoint, launchConfiguration);
   }
 }
 
@@ -121,15 +126,20 @@ export function resolveCompleteDaemonLaunchSpec(
   return DaemonLaunchResolution.complete(endpoint, options);
 }
 
-function writeDaemonLaunchResolution(userRoot: string, endpoint: string, options: DaemonLaunchOptions): void {
+function writeDaemonLaunchResolution(
+  userRoot: string,
+  endpoint: string,
+  launchConfiguration: DaemonLaunchConfiguration
+): void {
   const target = daemonLaunchSpecPath(userRoot, endpoint);
   const temporary = `${target}.${process.pid}.${Date.now()}.tmp`;
+  assertDaemonLaunchConfigurationForEndpoint(launchConfiguration, endpoint);
   mkdirSync(path.dirname(target), { recursive: true });
   try {
     const document: PersistedDaemonLaunchSpec = {
       schema: daemonLaunchSpecSchema,
       endpoint,
-      options: cloneDaemonLaunchOptions(options)
+      launchConfiguration: cloneDaemonLaunchConfiguration(launchConfiguration)
     };
     // Owner-only mode. The spec contains paths, never credentials or key material.
     writeFileSync(temporary, `${JSON.stringify(document, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
@@ -172,23 +182,29 @@ export function parseDaemonLaunchArgv(
 export function readPersistedDaemonLaunchSpec(
   userRoot: string,
   endpoint: string
-): DaemonLaunchOptions | undefined {
+): DaemonLaunchConfiguration | undefined {
   const endpointIdentity = daemonLaunchEndpointIdentity(endpoint);
   const source = daemonLaunchSpecPath(userRoot, endpointIdentity);
   if (!existsSync(source)) return undefined;
   let decoded: unknown;
   try {
     decoded = JSON.parse(readFileSync(source, "utf8"));
-  } catch {
-    return undefined;
+  } catch (error) {
+    throw incompatibleDaemonLaunchSpecError(source, error);
   }
   if (!isRecordValue(decoded)
     || decoded.schema !== daemonLaunchSpecSchema
     || decoded.endpoint !== endpointIdentity
-    || !isDaemonLaunchOptions(decoded.options)) {
-    return undefined;
+    || !isDaemonLaunchConfiguration(decoded.launchConfiguration)) {
+    throw incompatibleDaemonLaunchSpecError(source);
   }
-  return cloneDaemonLaunchOptions(decoded.options);
+  const configuration = cloneDaemonLaunchConfiguration(decoded.launchConfiguration);
+  try {
+    assertDaemonLaunchConfigurationForEndpoint(configuration, endpointIdentity);
+  } catch (error) {
+    throw incompatibleDaemonLaunchSpecError(source, error);
+  }
+  return configuration;
 }
 
 export function resolveRestoredLaunchOptions(
@@ -263,12 +279,42 @@ function assertValidDaemonLaunchOptions(options: DaemonLaunchOptions): void {
   }
 }
 
-function isDaemonLaunchOptions(value: unknown): value is DaemonLaunchOptions {
-  if (!isRecordValue(value)) return false;
-  const authorityManifest = value.authorityManifest;
-  const authoredRoot = value.authoredRoot;
-  return (authorityManifest === undefined || (typeof authorityManifest === "string" && path.isAbsolute(authorityManifest)))
-    && (authoredRoot === undefined || (typeof authoredRoot === "string" && path.isAbsolute(authoredRoot)));
+function daemonLaunchOptionsFromConfiguration(configuration: DaemonLaunchConfiguration): DaemonLaunchOptions {
+  const parsed = parseDaemonLaunchArgv(configuration.args);
+  return {
+    ...(parsed.authorityManifest !== undefined ? { authorityManifest: parsed.authorityManifest } : {}),
+    ...(parsed.authoredRoot !== undefined ? { authoredRoot: parsed.authoredRoot } : {})
+  };
+}
+
+function assertDaemonLaunchConfigurationForEndpoint(
+  configuration: DaemonLaunchConfiguration,
+  endpoint: string
+): void {
+  const parsed = parseDaemonLaunchArgv(configuration.args);
+  if (parsed.socketPath !== daemonLaunchEndpointIdentity(endpoint)) {
+    throw new Error("persisted launch configuration endpoint does not match its launch spec owner");
+  }
+}
+
+function isDaemonLaunchConfiguration(value: unknown): value is DaemonLaunchConfiguration {
+  return isRecordValue(value)
+    && typeof value.execPath === "string"
+    && value.execPath.length > 0
+    && Array.isArray(value.execArgv)
+    && value.execArgv.every((arg) => typeof arg === "string")
+    && typeof value.entrypoint === "string"
+    && value.entrypoint.length > 0
+    && Array.isArray(value.args)
+    && value.args.every((arg) => typeof arg === "string");
+}
+
+function incompatibleDaemonLaunchSpecError(source: string, cause?: unknown): Error {
+  const detail = cause instanceof Error ? ` (${cause.message})` : "";
+  return new Error(
+    `DAEMON_LAUNCH_SPEC_INCOMPATIBLE: persisted daemon launch specification at ${source} is not compatible with this CLI${detail}. `
+    + "Remove that file and rebuild it with: ha daemon start --service --user-root <user-root> --authority-manifest <path>"
+  );
 }
 
 function validatedDaemonPathOption(argv: ReadonlyArray<string>, name: string, rejectFlagPrefix: boolean): string | undefined {
@@ -295,6 +341,19 @@ function cloneDaemonLaunchOptions(options: DaemonLaunchOptions): DaemonLaunchOpt
   return {
     ...(options.authorityManifest !== undefined ? { authorityManifest: options.authorityManifest } : {}),
     ...(options.authoredRoot !== undefined ? { authoredRoot: options.authoredRoot } : {})
+  };
+}
+
+function sameDaemonLaunchOptions(left: DaemonLaunchOptions, right: DaemonLaunchOptions): boolean {
+  return left.authorityManifest === right.authorityManifest && left.authoredRoot === right.authoredRoot;
+}
+
+function cloneDaemonLaunchConfiguration(configuration: DaemonLaunchConfiguration): DaemonLaunchConfiguration {
+  return {
+    execPath: configuration.execPath,
+    execArgv: [...configuration.execArgv],
+    entrypoint: configuration.entrypoint,
+    args: [...configuration.args]
   };
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -282,7 +282,7 @@ async function runDaemonServe(
       if (restoredLaunchOptions.authorityManifest) {
         persistAuthorityManifestPointer(restoredLaunchOptions.authorityManifest, userRoot);
       }
-      completeSpec.persist(userRoot);
+      completeSpec.persist(userRoot, launchConfiguration);
       serviceHost.startRegistryReconcile(userRoot);
       await recordDaemonStarted({
         userRoot,

--- a/packages/cli/test/daemon-cold-start-launch-spec.test.ts
+++ b/packages/cli/test/daemon-cold-start-launch-spec.test.ts
@@ -72,6 +72,29 @@ test("service cold start restores, overrides, and diagnoses the persisted launch
     ], env);
     await stopDaemon(fixture.repoRoot, userRoot);
 
+    writeFileSync(daemonLaunchSpecPath(userRoot, endpoint), JSON.stringify({
+      schema: "daemon-launch-spec/v2",
+      endpoint,
+      options: { authorityManifest: fixture.manifestPath }
+    }), "utf8");
+    const migratedFromV2 = runDaemonCommand(
+      fixture.repoRoot,
+      ["daemon", "start", "--service", "--json"],
+      env
+    );
+    assert.equal(migratedFromV2.started, true, JSON.stringify(migratedFromV2));
+    assert.equal(
+      optionValue((await readRunningLaunchSpec(fixture.repoRoot, userRoot)).args, "--authority-manifest"),
+      fixture.manifestPath
+    );
+    const migratedDocument = JSON.parse(readFileSync(daemonLaunchSpecPath(userRoot, endpoint), "utf8")) as {
+      readonly schema?: string;
+      readonly launchConfiguration?: unknown;
+    };
+    assert.equal(migratedDocument.schema, "daemon-launch-spec/v3");
+    assert.equal(typeof migratedDocument.launchConfiguration, "object");
+    await stopDaemon(fixture.repoRoot, userRoot);
+
     const autostartedSpec = await requestLocalDaemonJsonRpc(
       fixture.repoRoot,
       "admin.daemon.launch-spec",
@@ -128,13 +151,23 @@ test("service cold start restores, overrides, and diagnoses the persisted launch
     await stopDaemon(fixture.repoRoot, userRoot);
 
     copyFileSync(fixture.manifestPath, replacementManifest);
+    const damagedPrivateFragment = `${fixture.manifestPath}-damaged-private-fragment`;
+    writeFileSync(
+      daemonLaunchSpecPath(userRoot, endpoint),
+      `{"schema":"daemon-launch-spec/v3","authorityManifest":"${damagedPrivateFragment}",BROKEN}`,
+      "utf8"
+    );
     const overridden = runDaemonCommand(fixture.repoRoot, [
-      "daemon", "start", "--service", "--authority-manifest", replacementManifest, "--json"
+      "daemon", "start", "--service", "--user-root", userRoot,
+      "--authority-manifest", replacementManifest, "--authored-root", fixture.authoredRoot, "--json"
     ], env);
     assert.equal(overridden.started, true, JSON.stringify(overridden));
     const overriddenSpec = await readRunningLaunchSpec(fixture.repoRoot, userRoot);
     assert.equal(optionValue(overriddenSpec.args, "--authority-manifest"), replacementManifest);
-    assert.match(readFileSync(daemonLaunchSpecPath(userRoot, endpoint), "utf8"), new RegExp(escapeRegExp(replacementManifest), "u"));
+    const rewrittenSpec = readFileSync(daemonLaunchSpecPath(userRoot, endpoint), "utf8");
+    assert.match(rewrittenSpec, /"schema": "daemon-launch-spec\/v3"/u);
+    assert.match(rewrittenSpec, new RegExp(escapeRegExp(replacementManifest), "u"));
+    assert.doesNotMatch(rewrittenSpec, new RegExp(escapeRegExp(damagedPrivateFragment), "u"));
     await stopDaemon(fixture.repoRoot, userRoot);
   } finally {
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);

--- a/packages/cli/test/daemon-cold-start-launch-spec.test.ts
+++ b/packages/cli/test/daemon-cold-start-launch-spec.test.ts
@@ -56,11 +56,13 @@ test("service cold start restores, overrides, and diagnoses the persisted launch
     );
     const persistedLaunchSpec = JSON.parse(readFileSync(daemonLaunchSpecPath(userRoot, endpoint), "utf8")) as {
       readonly endpoint: string;
-      readonly options: { readonly authorityManifest?: string };
+      readonly launchConfiguration: { readonly args: ReadonlyArray<string> };
     };
     assert.equal(persistedLaunchSpec.endpoint, endpoint);
-    assert.equal(persistedLaunchSpec.options.authorityManifest, fixture.manifestPath);
-    assert.equal((await readRunningLaunchSpec(fixture.repoRoot, userRoot)).args.includes(daemonLaunchOptionsResolvedFlag), true);
+    assert.equal(optionValue(persistedLaunchSpec.launchConfiguration.args, "--authority-manifest"), fixture.manifestPath);
+    const runningLaunchSpec = await readRunningLaunchSpec(fixture.repoRoot, userRoot);
+    assert.deepEqual(persistedLaunchSpec.launchConfiguration, runningLaunchSpec);
+    assert.equal(runningLaunchSpec.args.includes(daemonLaunchOptionsResolvedFlag), true);
 
     mkdirSync(classicRoot, { recursive: true });
     initializeHarness({ rootDir: classicRoot }, false, "Classic");
@@ -300,10 +302,10 @@ test("relative launch paths retain their original cwd meaning across a service c
     await stopDaemon(fixture.repoRoot, userRoot);
 
     const persisted = JSON.parse(readFileSync(daemonLaunchSpecPath(userRoot, endpoint), "utf8")) as {
-      readonly options: { readonly authorityManifest?: string; readonly authoredRoot?: string };
+      readonly launchConfiguration: { readonly args: ReadonlyArray<string> };
     };
-    assert.equal(persisted.options.authorityManifest, fixture.manifestPath);
-    assert.equal(persisted.options.authoredRoot, fixture.authoredRoot);
+    assert.equal(optionValue(persisted.launchConfiguration.args, "--authority-manifest"), fixture.manifestPath);
+    assert.equal(optionValue(persisted.launchConfiguration.args, "--authored-root"), fixture.authoredRoot);
 
     const restored = runDaemonJsonFromCwd(cwdB, path.relative(cwdB, fixture.repoRoot), ["daemon", "start", "--service"], env);
     assert.equal(restored.ok, true, JSON.stringify(restored));
@@ -360,7 +362,12 @@ test("daemon serve and start reject malformed launch path boundaries without per
 async function readRunningLaunchSpec(
   rootDir: string,
   userRoot: string
-): Promise<{ readonly args: ReadonlyArray<string> }> {
+): Promise<{
+  readonly execPath: string;
+  readonly execArgv: ReadonlyArray<string>;
+  readonly entrypoint: string;
+  readonly args: ReadonlyArray<string>;
+}> {
   const receipt = await requestLocalDaemonJsonRpc(rootDir, "admin.daemon.launch-spec", {}, 1_000, {
     userRoot,
     allowLegacySocket: false
@@ -368,8 +375,16 @@ async function readRunningLaunchSpec(
   const details = receipt.details as { readonly data?: unknown };
   assert.equal(isRecord(details.data), true, JSON.stringify(receipt));
   const data = details.data as Record<string, unknown>;
+  assert.equal(typeof data.execPath, "string", JSON.stringify(receipt));
+  assert.equal(Array.isArray(data.execArgv), true, JSON.stringify(receipt));
+  assert.equal(typeof data.entrypoint, "string", JSON.stringify(receipt));
   assert.equal(Array.isArray(data.args), true, JSON.stringify(receipt));
-  return { args: data.args as ReadonlyArray<string> };
+  return {
+    execPath: data.execPath as string,
+    execArgv: data.execArgv as ReadonlyArray<string>,
+    entrypoint: data.entrypoint as string,
+    args: data.args as ReadonlyArray<string>
+  };
 }
 
 function optionValue(args: ReadonlyArray<string>, option: string): string | undefined {

--- a/packages/cli/test/daemon-launch-spec.test.ts
+++ b/packages/cli/test/daemon-launch-spec.test.ts
@@ -68,25 +68,41 @@ test("no persisted spec and no explicit values leaves restored options absent (f
   assert.deepEqual(resolveRestoredLaunchOptions(undefined, {}), {});
 });
 
-test("unpublished or malformed persisted formats fail closed with a rebuild command", () => {
+test("a validated v2 launch spec remains a compatible cold-start source", () => {
   const userRoot = mkdtempSync(path.join(tmpdir(), "ha-daemon-launch-spec-"));
   try {
     writeFileSync(daemonLaunchSpecPath(userRoot, endpoint), JSON.stringify({
-      schema: "daemon-launch-spec/v1",
-      launchConfiguration: { args: ["--authority-manifest", "/old/manifest.json"] }
-    }), "utf8");
-    assert.throws(
-      () => readPersistedDaemonLaunchSpec(userRoot, endpoint),
-      /DAEMON_LAUNCH_SPEC_INCOMPATIBLE.*ha daemon start --service --user-root <user-root> --authority-manifest <path>/u
-    );
-    writeFileSync(daemonLaunchSpecPath(userRoot, endpoint), JSON.stringify({
       schema: "daemon-launch-spec/v2",
       endpoint,
-      options: { authorityManifest: "relative/authority.json" }
+      options: persisted
     }), "utf8");
+    assert.deepEqual(resolveDaemonLaunchSpec(userRoot, endpoint, {}).options, persisted);
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("malformed persisted formats fail closed with a rebuild command without exposing JSON content", () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-daemon-launch-spec-"));
+  const privateFragment = `${persisted.authorityManifest}-private-fragment`;
+  try {
+    writeFileSync(
+      daemonLaunchSpecPath(userRoot, endpoint),
+      `{"schema":"daemon-launch-spec/v3","authorityManifest":"${privateFragment}",BROKEN}`,
+      "utf8"
+    );
     assert.throws(
       () => resolveDaemonLaunchSpec(userRoot, endpoint, {}),
-      /DAEMON_LAUNCH_SPEC_INCOMPATIBLE/u
+      (error: unknown) => {
+        assert.equal(error instanceof Error, true);
+        const message = (error as Error).message;
+        assert.match(
+          message,
+          /DAEMON_LAUNCH_SPEC_INCOMPATIBLE.*invalid-json.*ha daemon start --service --user-root <user-root> --authority-manifest <path>/u
+        );
+        assert.equal(message.includes(privateFragment), false);
+        return true;
+      }
     );
   } finally {
     rmSync(userRoot, { recursive: true, force: true });

--- a/packages/cli/test/daemon-launch-spec.test.ts
+++ b/packages/cli/test/daemon-launch-spec.test.ts
@@ -12,6 +12,7 @@ import {
   resolveCompleteDaemonLaunchSpec,
   resolveDaemonLaunchSpec,
   resolveRestoredLaunchOptions,
+  type DaemonLaunchConfiguration,
   type DaemonLaunchOptions
 } from "../src/daemon/daemon-launch-spec.ts";
 
@@ -21,17 +22,18 @@ const persisted: DaemonLaunchOptions = {
   authorityManifest: path.join(fixtureRoot, "old", "manifest.json"),
   authoredRoot: path.join(fixtureRoot, "old", "authored")
 };
+const persistedConfiguration = launchConfiguration(endpoint, persisted);
 
-test("persisted daemon launch options round-trip as structured owner-private state", () => {
+test("persisted daemon launch spec round-trips the RPC launch configuration structure privately", () => {
   const userRoot = mkdtempSync(path.join(tmpdir(), "ha-daemon-launch-spec-"));
   try {
-    resolveDaemonLaunchSpec(userRoot, endpoint, persisted).persist(userRoot);
-    assert.deepEqual(readPersistedDaemonLaunchSpec(userRoot, endpoint), persisted);
+    resolveDaemonLaunchSpec(userRoot, endpoint, persisted).persist(userRoot, persistedConfiguration);
+    assert.deepEqual(readPersistedDaemonLaunchSpec(userRoot, endpoint), persistedConfiguration);
     const specPath = daemonLaunchSpecPath(userRoot, endpoint);
     const document = JSON.parse(readFileSync(specPath, "utf8")) as Record<string, unknown>;
-    assert.equal(document.schema, "daemon-launch-spec/v2");
-    assert.deepEqual(document.options, persisted);
-    assert.equal("launchConfiguration" in document, false);
+    assert.equal(document.schema, "daemon-launch-spec/v3");
+    assert.deepEqual(document.launchConfiguration, persistedConfiguration);
+    assert.equal("options" in document, false);
     if (process.platform !== "win32") assert.equal(statSync(specPath).mode & 0o777, 0o600);
   } finally {
     rmSync(userRoot, { recursive: true, force: true });
@@ -66,21 +68,26 @@ test("no persisted spec and no explicit values leaves restored options absent (f
   assert.deepEqual(resolveRestoredLaunchOptions(undefined, {}), {});
 });
 
-test("unpublished or malformed persisted formats are ignored and fail closed as missing options", () => {
+test("unpublished or malformed persisted formats fail closed with a rebuild command", () => {
   const userRoot = mkdtempSync(path.join(tmpdir(), "ha-daemon-launch-spec-"));
   try {
     writeFileSync(daemonLaunchSpecPath(userRoot, endpoint), JSON.stringify({
       schema: "daemon-launch-spec/v1",
       launchConfiguration: { args: ["--authority-manifest", "/old/manifest.json"] }
     }), "utf8");
-    assert.equal(readPersistedDaemonLaunchSpec(userRoot, endpoint), undefined);
+    assert.throws(
+      () => readPersistedDaemonLaunchSpec(userRoot, endpoint),
+      /DAEMON_LAUNCH_SPEC_INCOMPATIBLE.*ha daemon start --service --user-root <user-root> --authority-manifest <path>/u
+    );
     writeFileSync(daemonLaunchSpecPath(userRoot, endpoint), JSON.stringify({
       schema: "daemon-launch-spec/v2",
       endpoint,
       options: { authorityManifest: "relative/authority.json" }
     }), "utf8");
-    assert.equal(readPersistedDaemonLaunchSpec(userRoot, endpoint), undefined);
-    assert.deepEqual(resolveDaemonLaunchSpec(userRoot, endpoint, {}).options, {});
+    assert.throws(
+      () => resolveDaemonLaunchSpec(userRoot, endpoint, {}),
+      /DAEMON_LAUNCH_SPEC_INCOMPATIBLE/u
+    );
   } finally {
     rmSync(userRoot, { recursive: true, force: true });
   }
@@ -105,29 +112,28 @@ test("different explicit sockets cannot read or replace each other's launch opti
     const firstEndpoint = path.join(userRoot, "a.sock");
     const secondEndpoint = path.join(userRoot, "b.sock");
     const otherManifest = path.join(userRoot, "other", "manifest.json");
-    resolveDaemonLaunchSpec(userRoot, firstEndpoint, persisted).persist(userRoot);
+    const firstConfiguration = launchConfiguration(firstEndpoint, persisted);
+    resolveDaemonLaunchSpec(userRoot, firstEndpoint, persisted).persist(userRoot, firstConfiguration);
     resolveDaemonLaunchSpec(userRoot, secondEndpoint, {
       authorityManifest: otherManifest
-    }).persist(userRoot);
-    assert.deepEqual(readPersistedDaemonLaunchSpec(userRoot, firstEndpoint), persisted);
-    assert.deepEqual(readPersistedDaemonLaunchSpec(userRoot, secondEndpoint), {
-      authorityManifest: otherManifest
-    });
+    }).persist(userRoot, launchConfiguration(secondEndpoint, { authorityManifest: otherManifest }));
+    assert.deepEqual(readPersistedDaemonLaunchSpec(userRoot, firstEndpoint), firstConfiguration);
+    assert.deepEqual(
+      readPersistedDaemonLaunchSpec(userRoot, secondEndpoint),
+      launchConfiguration(secondEndpoint, { authorityManifest: otherManifest })
+    );
   } finally {
     rmSync(userRoot, { recursive: true, force: true });
   }
 });
 
-test("structured restore ignores malformed positional and single-dash tokens in legacy argv fields", () => {
+test("structured restore derives inherited options from the shared launch configuration", () => {
   const userRoot = mkdtempSync(path.join(tmpdir(), "ha-daemon-launch-spec-"));
   try {
     writeFileSync(daemonLaunchSpecPath(userRoot, endpoint), JSON.stringify({
-      schema: "daemon-launch-spec/v2",
+      schema: "daemon-launch-spec/v3",
       endpoint,
-      options: persisted,
-      launchConfiguration: {
-        args: ["--authored-root", "daemon", "serve", "--authority-manifest", "-x"]
-      }
+      launchConfiguration: persistedConfiguration
     }), "utf8");
     assert.deepEqual(resolveDaemonLaunchSpec(userRoot, endpoint, {}).options, persisted);
   } finally {
@@ -138,10 +144,10 @@ test("structured restore ignores malformed positional and single-dash tokens in 
 test("foreground and autostart omission resolve before persistence and cannot overwrite a complete spec", () => {
   const userRoot = mkdtempSync(path.join(tmpdir(), "ha-daemon-launch-spec-"));
   try {
-    resolveDaemonLaunchSpec(userRoot, endpoint, persisted).persist(userRoot);
-    resolveDaemonLaunchSpec(userRoot, endpoint, {}).persist(userRoot);
-    resolveDaemonLaunchSpec(userRoot, endpoint, {}).persist(userRoot);
-    assert.deepEqual(readPersistedDaemonLaunchSpec(userRoot, endpoint), persisted);
+    resolveDaemonLaunchSpec(userRoot, endpoint, persisted).persist(userRoot, persistedConfiguration);
+    resolveDaemonLaunchSpec(userRoot, endpoint, {}).persist(userRoot, persistedConfiguration);
+    resolveDaemonLaunchSpec(userRoot, endpoint, {}).persist(userRoot, persistedConfiguration);
+    assert.deepEqual(readPersistedDaemonLaunchSpec(userRoot, endpoint), persistedConfiguration);
   } finally {
     rmSync(userRoot, { recursive: true, force: true });
   }
@@ -184,16 +190,41 @@ test("launch argv parsing canonicalizes recoverable paths and validates known op
 test("an opaque immutable resolution persists its captured snapshot without rereading durable state", () => {
   const userRoot = mkdtempSync(path.join(tmpdir(), "ha-daemon-launch-spec-"));
   try {
-    resolveCompleteDaemonLaunchSpec(endpoint, persisted).persist(userRoot);
+    resolveCompleteDaemonLaunchSpec(endpoint, persisted).persist(userRoot, persistedConfiguration);
     const captured = resolveDaemonLaunchSpec(userRoot, endpoint, {});
+    const otherConfiguration = launchConfiguration(endpoint, {
+      authorityManifest: path.join(fixtureRoot, "other", "manifest.json")
+    });
     resolveCompleteDaemonLaunchSpec(endpoint, {
       authorityManifest: path.join(fixtureRoot, "other", "manifest.json")
-    }).persist(userRoot);
-    captured.persist(userRoot);
-    assert.deepEqual(readPersistedDaemonLaunchSpec(userRoot, endpoint), persisted);
+    }).persist(userRoot, otherConfiguration);
+    captured.persist(userRoot, persistedConfiguration);
+    assert.deepEqual(readPersistedDaemonLaunchSpec(userRoot, endpoint), persistedConfiguration);
     assert.equal(Object.isFrozen(captured.options), true);
     assert.equal("persist" in { ...captured }, false);
   } finally {
     rmSync(userRoot, { recursive: true, force: true });
   }
 });
+
+function launchConfiguration(
+  ownedEndpoint: string,
+  options: DaemonLaunchOptions
+): DaemonLaunchConfiguration {
+  return {
+    execPath: "/current/node",
+    execArgv: ["--enable-source-maps"],
+    entrypoint: "/current/ha.js",
+    args: [
+      "--root", fixtureRoot,
+      ...(options.authoredRoot !== undefined ? ["--authored-root", options.authoredRoot] : []),
+      "daemon", "serve",
+      "--repo", "canonical",
+      "--socket", ownedEndpoint,
+      "--user-root", fixtureRoot,
+      ...(options.authorityManifest !== undefined
+        ? ["--authority-manifest", options.authorityManifest]
+        : [])
+    ]
+  };
+}


### PR DESCRIPTION
# English

## Summary

Make `ha daemon start --service` work flaglessly after a daemon death: persist the daemon launch spec (as the same `DaemonLaunchConfiguration` structure the refresh RPC uses — no second flag-inheritance list), restore omitted flags from the persisted spec on bare cold start, and surface the real crash cause instead of a reachability timeout. This is the root cure for the "daemon dies, bare restart fails with journal_unavailable while the real cause (missing --authority-manifest) is invisible" incident.

## What Changed

- Persisted daemon launch spec unified with the refresh RPC payload: both use `DaemonLaunchConfiguration`; the durable spec is written atomically (0600) into the resolved userRoot after every successful start. No parallel list of "which flags to inherit" exists.
- Bare `ha daemon start --service` restores omitted flags from the persisted spec; explicitly provided flags override and become the new persisted spec.
- Cold start reuses the existing preflight true-cause mechanism: replacement/new daemon crash causes (e.g. AUTHORITY_MANIFEST_REGISTRY_INCOMPLETE) appear in the start error.
- With no persisted spec and missing required flags, the error names what is missing and gives a complete placeholder command; no private paths persist anywhere outside the spec file itself.
- Schema upgraded to daemon-launch-spec/v3 with compatibility (adversarial-review P1 fix): validated legacy v2 specs participate in recovery; a stale or corrupt spec never blocks a start whose explicit authority configuration is complete — the spec is atomically rewritten as v3 after a successful start; fail-closed `DAEMON_LAUNCH_SPEC_INCOMPATIBLE` only when the spec is unusable AND explicit configuration is incomplete.
- Spec parse failures report only stable categories (invalid-json / invalid-document / endpoint-mismatch / invalid-launch-configuration) and never echo the raw JSON parser message, which on modern Node can embed file fragments containing the private manifest path (adversarial-review P2 fix).
- Regression tests: v2 bare-start recovery + v3 rewrite; complete-explicit-config crossing a corrupt spec with atomic rewrite; corrupt-JSON error text contains no file content; incompatible-spec fail-closed guidance.

## Task And Scope

- Harness task: task_01KXWKV5C6KCP4AC9S31M0WMHN (L1 chain, under PLT-Baseline-Governance umbrella task_01KXWZ3YEGXD6302G1656RY801)
- Branch: fix/daemon-cold-start-v2
- Public scope: packages/cli daemon launch-spec module, service entrypoint wiring, launch-spec tests
- Private planning/evidence updated: yes
- Out of scope: daemon refresh convergence semantics (#954 preserved unchanged); control.ts / control-convergence.ts untouched; protocol method-registry untouched

## Version Impact

- Version: no version change because this ships within the current unreleased line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: daemon launch/authority startup path (launch spec persistence and recovery)
- Authority: decision dec_01KXW78YDHVNA133RFPWC1K3RS (root-cause governance, active); task task_01KXWKV5C6KCP4AC9S31M0WMHN
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: fb5750784806f86b8f9aef77be23e0991bd29899
- Branch merge-base with `origin/main`: fb5750784806f86b8f9aef77be23e0991bd29899
- Last `git fetch origin` time: 2026-07-20 (rebase immediately before fix round)
- Sync method: rebase
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package artifacts (mission, adjudication)
- Reviewer evidence path: task package review artifacts
- GitHub Actions `rewrite-ci` run URL: pending (this PR's checks)
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] targeted tests: launch-spec suites 20/20 post-fix; cold-start + control/convergence touched surface 54/54 post-rebase
- [x] targeted structure gates: check-file-complexity, check-duplicate-definitions
- Not run: full local `check:ci` and `npm test` matrix — retired to GitHub CI per standing workflow ruling; this PR's CI run is the authoritative gate

## Review Evidence

- Self-review: worker fresh verification recorded per round
- Reviewer subagent: codex adversarial review; 2 findings confirmed (P1 v2→v3 upgrade lockout, P2 parser-message path leakage) and fixed in ec4d3ffd with regression tests
- Human review: CEO semantic acceptance against the task plan's five invariants (persist-on-success, bare-start recovery, single shared structure, true-cause preflight, actionable missing-flag guidance)
- Blocking findings: none open

## Residual Risk

- v2 compatibility reading remains until fleets rewrite specs as v3 on their next successful start; the legacy reader is validation-gated and can be retired in a later cleanup.

## References

- Task: task_01KXWKV5C6KCP4AC9S31M0WMHN
- Evidence: task package artifacts (mission-cold-start-rebase, worker reports)
- Review: adversarial review round; fixes in ec4d3ffd

---

# 中文

## 概要

让 `ha daemon start --service` 在 daemon 死后零 flag 可用:launch spec 持久化(与 refresh RPC 共用同一 `DaemonLaunchConfiguration` 结构,不存在第二份 flag 继承清单),裸冷启动从落盘 spec 恢复省略项,启动失败报真实崩因而非可达性超时。根治「daemon 死后裸重启报 journal_unavailable、真因(缺 --authority-manifest)完全不可见」事故。

## 改动内容

- 落盘 launch spec 与 refresh RPC payload 统一:同用 `DaemonLaunchConfiguration`;每次成功启动后以解析后的 userRoot 原子落盘(0600)。不存在并行的「哪些 flag 该继承」清单。
- 裸 `ha daemon start --service` 从落盘 spec 恢复省略 flag;显式 flag 覆盖并成为新落盘值。
- 冷启动复用既有 preflight 真因机制:替身/新 daemon 崩因(如 AUTHORITY_MANIFEST_REGISTRY_INCOMPLETE)出现在 start 错误里。
- 无落盘 spec 且缺必要 flag 时,错误指名缺什么并给完整占位命令;私有路径不落任何 spec 文件之外的持久化产物。
- Schema 升 v3 带兼容(对抗评审 P1 修复):合法 v2 spec 经校验后参与恢复;显式 authority 配置完整时,旧/坏 spec 一律不阻断启动,成功后原子重写为 v3;只有「spec 不可用且显式配置不完整」才 fail-closed 报 `DAEMON_LAUNCH_SPEC_INCOMPATIBLE`。
- Spec 解析失败只报稳定类别(invalid-json / invalid-document / endpoint-mismatch / invalid-launch-configuration),不透传 JSON parser 原文——现代 Node 的解析错误可能携带含私有 manifest 路径的文件片段(对抗评审 P2 修复)。
- 回归测试:v2 裸启动恢复+v3 重写;显式完整配置跨过坏 spec 并原子重写;坏 JSON 错误文本不含文件内容;不兼容 spec 的 fail-closed 指引。

## 任务与范围

- Harness 任务:task_01KXWKV5C6KCP4AC9S31M0WMHN(L1 链,隶属 PLT-Baseline-Governance 伞 task_01KXWZ3YEGXD6302G1656RY801)
- 分支:fix/daemon-cold-start-v2
- 公开范围:packages/cli daemon launch-spec 模块、service 入口接线、launch-spec 测试
- 私有计划 / 证据是否已更新:yes
- 范围外:daemon refresh 收敛语义(#954 原样保留);control.ts / control-convergence.ts 未动;protocol method-registry 未动

## 版本影响

- 版本:不改版本,原因是仍在当前未发布线内
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:daemon launch/authority 启动路径(launch spec 持久化与恢复)
- 依据:decision dec_01KXW78YDHVNA133RFPWC1K3RS(根因治理,active);task task_01KXWKV5C6KCP4AC9S31M0WMHN
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- `origin/main` 基准 SHA:fb5750784806f86b8f9aef77be23e0991bd29899
- 当前分支与 `origin/main` 的 merge-base:fb5750784806f86b8f9aef77be23e0991bd29899
- 最近一次 `git fetch origin` 时间:2026-07-20(修复轮前即时 rebase)
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 artifacts(mission、裁决)
- Reviewer 证据路径:任务包 review artifacts
- GitHub Actions `rewrite-ci` run URL:待本 PR checks 产生
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] 触面测试:launch-spec 套件修复后 20/20;冷启动+control/convergence 触面 rebase 后 54/54
- [x] 定向结构门:check-file-complexity、check-duplicate-definitions
- 未运行:本地全量 `check:ci` 与 `npm test` 矩阵——按常设裁决已退役至 GitHub CI,本 PR 的 CI run 为权威门

## 审查证据

- 自查:worker 每轮 fresh 核验
- Reviewer subagent:codex 对抗评审;2 条确认(P1 v2→v3 升级锁死、P2 parser 文本泄漏私有路径)已在 ec4d3ffd 修复并带回归测试
- 人工审查:CEO 按任务计划五条不变量做语义验收(成功即落盘/裸启动恢复/单一共享结构/preflight 真因/缺 flag 可执行指引)
- 阻塞发现:无

## 残余风险

- v2 兼容读取保留至各机在下次成功启动时重写为 v3;legacy 读取器带校验门,后续清理任务可退役。

## 关联材料

- 任务:task_01KXWKV5C6KCP4AC9S31M0WMHN
- 证据:任务包 artifacts(mission-cold-start-rebase、worker 报告)
- 审查:对抗评审轮,修复在 ec4d3ffd

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
