### PR TITLE
feat(daemon): S1.1 — four-axis identity schema and durable generation record

### DIFF
--- a/packages/api-contracts/package.json
+++ b/packages/api-contracts/package.json
@@ -8,7 +8,6 @@
     ".": "./src/index.ts",
     "./api-contract-registry": "./src/api-contract-registry.ts",
     "./api-contract-types": "./src/api-contract-types.ts",
-    "./daemon-generation": "./src/daemon-generation.ts",
     "./daemon-protocol": "./src/daemon-protocol.ts",
     "./renderer-safe-state": "./src/renderer-safe-state.ts"
   },

--- a/packages/api-contracts/package.json
+++ b/packages/api-contracts/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./api-contract-registry": "./src/api-contract-registry.ts",
     "./api-contract-types": "./src/api-contract-types.ts",
+    "./daemon-generation": "./src/daemon-generation.ts",
     "./daemon-protocol": "./src/daemon-protocol.ts",
     "./renderer-safe-state": "./src/renderer-safe-state.ts"
   },

--- a/packages/api-contracts/src/daemon-generation.ts
+++ b/packages/api-contracts/src/daemon-generation.ts
@@ -1,0 +1,72 @@
+export type MachineId = string & { readonly __brand: "machine-id" };
+export type DaemonGeneration = number & { readonly __brand: "daemon-generation" };
+export type RuntimeRegistrationId = string & { readonly __brand: "runtime-registration-id" };
+export type ConnectionId = string & { readonly __brand: "connection-id" };
+export type LeaseGeneration = number & { readonly __brand: "lease-generation" };
+
+export interface DaemonGenerationAxesV1 {
+  readonly machineId?: MachineId;
+  readonly daemonGeneration?: DaemonGeneration;
+  readonly runtimeRegistrationId?: RuntimeRegistrationId;
+  readonly connectionId?: ConnectionId;
+}
+
+export interface DaemonTerminalGenerationAxesV1 extends DaemonGenerationAxesV1 {
+  /** Reserved for S4. S1 does not generate or enforce this value. */
+  readonly leaseGeneration?: LeaseGeneration;
+}
+
+export class DaemonGenerationAxesContractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DaemonGenerationAxesContractError";
+  }
+}
+
+/** Decode an additive projection from a containing JSON object. Unrelated keys are left untouched. */
+export function decodeDaemonGenerationAxesV1(value: unknown): DaemonGenerationAxesV1 {
+  const record = object(value);
+  const machineId = optionalIdentifier(record.machineId, "machineId");
+  const daemonGeneration = optionalPositiveSafeInteger(record.daemonGeneration, "daemonGeneration");
+  const runtimeRegistrationId = optionalIdentifier(record.runtimeRegistrationId, "runtimeRegistrationId");
+  const connectionId = optionalIdentifier(record.connectionId, "connectionId");
+  return {
+    ...(machineId !== undefined ? { machineId: machineId as MachineId } : {}),
+    ...(daemonGeneration !== undefined ? { daemonGeneration: daemonGeneration as DaemonGeneration } : {}),
+    ...(runtimeRegistrationId !== undefined ? { runtimeRegistrationId: runtimeRegistrationId as RuntimeRegistrationId } : {}),
+    ...(connectionId !== undefined ? { connectionId: connectionId as ConnectionId } : {})
+  };
+}
+
+export function decodeDaemonTerminalGenerationAxesV1(value: unknown): DaemonTerminalGenerationAxesV1 {
+  const record = object(value);
+  const axes = decodeDaemonGenerationAxesV1(record);
+  const leaseGeneration = optionalPositiveSafeInteger(record.leaseGeneration, "leaseGeneration");
+  return {
+    ...axes,
+    ...(leaseGeneration !== undefined ? { leaseGeneration: leaseGeneration as LeaseGeneration } : {})
+  };
+}
+
+function object(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new DaemonGenerationAxesContractError("daemon generation axes must be an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function optionalIdentifier(value: unknown, field: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new DaemonGenerationAxesContractError(`${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalPositiveSafeInteger(value: unknown, field: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1) {
+    throw new DaemonGenerationAxesContractError(`${field} must be a positive safe integer`);
+  }
+  return value;
+}

--- a/packages/api-contracts/src/daemon-generation.ts
+++ b/packages/api-contracts/src/daemon-generation.ts
@@ -1,3 +1,4 @@
+// @slice-activation PLT-Boundary S1 daemon generation axes exported for daemon and client consumers.
 export type MachineId = string & { readonly __brand: "machine-id" };
 export type DaemonGeneration = number & { readonly __brand: "daemon-generation" };
 export type RuntimeRegistrationId = string & { readonly __brand: "runtime-registration-id" };

--- a/packages/api-contracts/src/daemon-registry.ts
+++ b/packages/api-contracts/src/daemon-registry.ts
@@ -8,6 +8,13 @@ export interface DaemonRegistryRepo {
   readonly state: DaemonRepoState;
   readonly registeredAt: string;
   readonly authorityManifestPath?: string;
+  readonly runtimeRegistrationId?: string;
+  readonly daemonGeneration?: number;
+}
+
+export interface DaemonRegistryGenerationProjectionV1 {
+  readonly machineId?: string;
+  readonly daemonGeneration?: number;
 }
 
 export interface DaemonRegistryLookupOptions {

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./api-contract-registry.ts";
 export * from "./daemon-protocol.ts";
 export * from "./daemon-registry.ts";
+export * from "./daemon-generation.ts";
 export * from "./renderer-safe-state.ts";

--- a/packages/api-contracts/test/daemon-generation-contract.test.ts
+++ b/packages/api-contracts/test/daemon-generation-contract.test.ts
@@ -1,0 +1,34 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  decodeDaemonGenerationAxesV1,
+  decodeDaemonTerminalGenerationAxesV1
+} from "../src/index.ts";
+
+test("daemon generation axes codec accepts omitted, partial, and full projections", () => {
+  assert.deepEqual(decodeDaemonGenerationAxesV1({}), {});
+  assert.deepEqual(decodeDaemonGenerationAxesV1({ daemonGeneration: 7 }), { daemonGeneration: 7 });
+  assert.deepEqual(decodeDaemonGenerationAxesV1({
+    machineId: "machine-installation-a",
+    daemonGeneration: 8,
+    runtimeRegistrationId: "runtime-registration-a",
+    connectionId: "connection-a"
+  }), {
+    machineId: "machine-installation-a",
+    daemonGeneration: 8,
+    runtimeRegistrationId: "runtime-registration-a",
+    connectionId: "connection-a"
+  });
+  assert.deepEqual(decodeDaemonTerminalGenerationAxesV1({ leaseGeneration: 2 }), { leaseGeneration: 2 });
+});
+
+test("daemon generation axes codec rejects invalid identifiers and counters", () => {
+  for (const value of [
+    { machineId: "" },
+    { runtimeRegistrationId: "  " },
+    { daemonGeneration: 0 },
+    { daemonGeneration: 1.5 },
+    { leaseGeneration: Number.MAX_SAFE_INTEGER + 1 }
+  ]) assert.throws(() => decodeDaemonTerminalGenerationAxesV1(value));
+});

--- a/packages/application/src/daemon-status-contract.ts
+++ b/packages/application/src/daemon-status-contract.ts
@@ -1,6 +1,7 @@
 // @slice-activation PLT-Boundary W1 exposes this module through the package root API.
 export interface DaemonStatusRequestV2 {
   readonly repo: { readonly repoId: string };
+  readonly includeGenerationAxes?: true;
 }
 
 export interface DaemonQueueStatus {
@@ -44,6 +45,8 @@ export interface DaemonActiveControlStatus {
   readonly phase: "accepted" | "draining" | "building" | "replacing" | "failed";
   readonly requestedAt: string;
   readonly failure?: Pick<DaemonControlErrorV1, "code" | "hint">;
+  readonly machineId?: string;
+  readonly daemonGeneration?: number;
 }
 
 export interface DaemonBuildStatus {
@@ -69,6 +72,8 @@ export interface DaemonRepoStatus {
   readonly lastError: string | null;
   readonly lastMaterializerError: string | null;
   readonly lastReconcileError: DaemonReconcileErrorStatus | null;
+  readonly runtimeRegistrationId?: string;
+  readonly daemonGeneration?: number;
 }
 
 export interface DaemonStatusResultV2 {
@@ -89,6 +94,7 @@ export interface DaemonStatusResultV2 {
   readonly lastReconcileError: DaemonReconcileErrorStatus | null;
   readonly lastRecovery: unknown;
   readonly projectionGeneration: unknown;
+  readonly connectionId?: string;
   readonly service: {
     readonly daemonId: string;
     readonly pid: number;
@@ -106,6 +112,8 @@ export interface DaemonStatusResultV2 {
     readonly lastReconcileAt: string | null;
     readonly lastReconcileError: DaemonReconcileErrorStatus | null;
     readonly activeControl: DaemonActiveControlStatus | null;
+    readonly machineId?: string;
+    readonly daemonGeneration?: number;
   };
   readonly requestedRepo: DaemonRepoStatus;
   readonly repos: ReadonlyArray<DaemonRepoStatus>;
@@ -125,11 +133,15 @@ export class DaemonStatusContractError extends Error {
 export function decodeDaemonStatusRequestV2(value: unknown): DaemonStatusRequestV2 {
   try {
     const request = object(value, "request");
-    keys(request, ["repo"], "request");
+    keys(request, ["repo", "includeGenerationAxes"], "request", ["includeGenerationAxes"]);
     const repo = object(request.repo, "request.repo");
     keys(repo, ["repoId"], "request.repo");
     string(repo.repoId, "request.repo.repoId");
-    return { repo: { repoId: repo.repoId as string } };
+    if (request.includeGenerationAxes !== undefined) literal(request.includeGenerationAxes, true, "request.includeGenerationAxes");
+    return {
+      repo: { repoId: repo.repoId as string },
+      ...(request.includeGenerationAxes === true ? { includeGenerationAxes: true as const } : {})
+    };
   } catch (error) {
     if (error instanceof DaemonStatusContractError) {
       throw new DaemonStatusContractError("invalid_daemon_status_request", error.message);
@@ -142,8 +154,8 @@ export function decodeDaemonStatusResultV2(value: unknown): DaemonStatusResultV2
   const result = object(value, "result");
   keys(result, [
     "schema", "daemonId", "pid", "started", "rootDir", "repoId", "endpoint", "version", "protocolVersion", "queue", "queueDepth",
-    "connections", "lastReconcileAt", "lastReconcileError", "lastRecovery", "projectionGeneration", "service", "requestedRepo", "repos"
-  ], "result");
+    "connections", "lastReconcileAt", "lastReconcileError", "lastRecovery", "projectionGeneration", "service", "requestedRepo", "repos", "connectionId"
+  ], "result", ["connectionId"]);
   literal(result.schema, "daemon-status/v2", "result.schema");
   for (const field of ["daemonId", "rootDir", "repoId", "endpoint", "version"] as const) string(result[field], `result.${field}`);
   nonNegativeStatusInteger(result.pid, "result.pid");
@@ -154,6 +166,7 @@ export function decodeDaemonStatusResultV2(value: unknown): DaemonStatusResultV2
   connections(result.connections, "result.connections");
   nullableTimestamp(result.lastReconcileAt, "result.lastReconcileAt");
   nullableReconcileError(result.lastReconcileError, "result.lastReconcileError");
+  if (result.connectionId !== undefined) string(result.connectionId, "result.connectionId");
   service(result.service);
   repo(result.requestedRepo, "result.requestedRepo");
   if (!Array.isArray(result.repos)) invalidStatusShape("result.repos must be an array");
@@ -169,8 +182,8 @@ function service(value: unknown): void {
   const record = object(value, "result.service");
   keys(record, [
     "daemonId", "pid", "endpoint", "userRoot", "started", "startedAt", "uptimeMs", "build", "queue", "connections", "repoCount",
-    "attachedCount", "unavailableCount", "lastReconcileAt", "lastReconcileError", "activeControl"
-  ], "result.service");
+    "attachedCount", "unavailableCount", "lastReconcileAt", "lastReconcileError", "activeControl", "machineId", "daemonGeneration"
+  ], "result.service", ["machineId", "daemonGeneration"]);
   for (const field of ["daemonId", "endpoint", "userRoot"] as const) string(record[field], `result.service.${field}`);
   nonNegativeStatusInteger(record.pid, "result.service.pid");
   boolean(record.started, "result.service.started");
@@ -187,11 +200,13 @@ function service(value: unknown): void {
   nullableTimestamp(record.lastReconcileAt, "result.service.lastReconcileAt");
   nullableReconcileError(record.lastReconcileError, "result.service.lastReconcileError");
   if (record.activeControl !== null) activeControl(record.activeControl);
+  if (record.machineId !== undefined) string(record.machineId, "result.service.machineId");
+  if (record.daemonGeneration !== undefined) positiveStatusInteger(record.daemonGeneration, "result.service.daemonGeneration");
 }
 
 function repo(value: unknown, label: string): void {
   const record = object(value, label);
-  keys(record, ["repoId", "canonicalRoot", "displayName", "state", "lock", "queue", "lastRecovery", "projectionGeneration", "lastError", "lastMaterializerError", "lastReconcileError"], label, ["displayName"]);
+  keys(record, ["repoId", "canonicalRoot", "displayName", "state", "lock", "queue", "lastRecovery", "projectionGeneration", "lastError", "lastMaterializerError", "lastReconcileError", "runtimeRegistrationId", "daemonGeneration"], label, ["displayName", "runtimeRegistrationId", "daemonGeneration"]);
   string(record.repoId, `${label}.repoId`);
   string(record.canonicalRoot, `${label}.canonicalRoot`);
   if (record.displayName !== undefined) string(record.displayName, `${label}.displayName`);
@@ -204,6 +219,8 @@ function repo(value: unknown, label: string): void {
   nullableString(record.lastError, `${label}.lastError`);
   nullableString(record.lastMaterializerError, `${label}.lastMaterializerError`);
   nullableReconcileError(record.lastReconcileError, `${label}.lastReconcileError`);
+  if (record.runtimeRegistrationId !== undefined) string(record.runtimeRegistrationId, `${label}.runtimeRegistrationId`);
+  if (record.daemonGeneration !== undefined) positiveStatusInteger(record.daemonGeneration, `${label}.daemonGeneration`);
 }
 
 function queue(value: unknown, label: string): void {
@@ -238,11 +255,13 @@ function connections(value: unknown, label: string): void {
 
 function activeControl(value: unknown): void {
   const record = object(value, "result.service.activeControl");
-  keys(record, ["operationId", "kind", "phase", "requestedAt", "failure"], "result.service.activeControl");
+  keys(record, ["operationId", "kind", "phase", "requestedAt", "failure", "machineId", "daemonGeneration"], "result.service.activeControl", ["failure", "machineId", "daemonGeneration"]);
   string(record.operationId, "result.service.activeControl.operationId");
   oneOf(record.kind, ["restart", "refresh"], "result.service.activeControl.kind");
   oneOf(record.phase, ["accepted", "draining", "building", "replacing", "failed"], "result.service.activeControl.phase");
   timestamp(record.requestedAt, "result.service.activeControl.requestedAt");
+  if (record.machineId !== undefined) string(record.machineId, "result.service.activeControl.machineId");
+  if (record.daemonGeneration !== undefined) positiveStatusInteger(record.daemonGeneration, "result.service.activeControl.daemonGeneration");
   if (record.failure !== undefined) {
     const failure = object(record.failure, "result.service.activeControl.failure");
     keys(failure, ["code", "hint"], "result.service.activeControl.failure");
@@ -277,7 +296,8 @@ function string(value: unknown, label: string): asserts value is string { if (ty
 function nullableString(value: unknown, label: string): void { if (value !== null && typeof value !== "string") invalidStatusShape(`${label} must be null or a string`); }
 function boolean(value: unknown, label: string): void { if (typeof value !== "boolean") invalidStatusShape(`${label} must be a boolean`); }
 function nonNegativeStatusInteger(value: unknown, label: string): void { if (!Number.isInteger(value) || Number(value) < 0) invalidStatusShape(`${label} must be a non-negative integer`); }
-function literal(value: unknown, expected: string | number, label: string): void { if (value !== expected) invalidStatusShape(`${label} must be ${String(expected)}`); }
+function positiveStatusInteger(value: unknown, label: string): void { if (!Number.isSafeInteger(value) || Number(value) < 1) invalidStatusShape(`${label} must be a positive safe integer`); }
+function literal(value: unknown, expected: string | number | boolean, label: string): void { if (value !== expected) invalidStatusShape(`${label} must be ${String(expected)}`); }
 function oneOf(value: unknown, expected: ReadonlyArray<string>, label: string): void { if (typeof value !== "string" || !expected.includes(value)) invalidStatusShape(`${label} is unsupported`); }
 function timestamp(value: unknown, label: string): void { if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) invalidStatusShape(`${label} must be an ISO timestamp`); }
 function nullableTimestamp(value: unknown, label: string): void { if (value !== null) timestamp(value, label); }
@@ -305,7 +325,10 @@ function projectRepo(repo: DaemonRepoStatus): DaemonRendererRepoStatus {
 }
 
 export interface DaemonStatusService {
-  readonly getStatus: (context?: { readonly repo: { readonly repoId: string; readonly canonicalRoot: string } }) =>
+  readonly getStatus: (context?: {
+    readonly repo: { readonly repoId: string; readonly canonicalRoot: string };
+    readonly includeGenerationAxes?: true;
+  }) =>
     DaemonStatusResultV2 | Promise<DaemonStatusResultV2>;
 }
 
@@ -316,6 +339,8 @@ export interface DaemonControlRequestV1 {
   readonly reason: string;
   readonly drainTimeoutMs: number;
   readonly trigger?: DaemonRefreshTrigger;
+  readonly daemonGeneration?: number;
+  readonly connectionId?: string;
 }
 
 export interface DaemonControlAcceptedV1 {
@@ -325,11 +350,15 @@ export interface DaemonControlAcceptedV1 {
   readonly kind: DaemonControlKind;
   readonly scope: "service";
   readonly requestedAt: string;
+  readonly machineId?: string;
+  readonly daemonGeneration?: number;
+  readonly connectionId?: string;
   readonly before: {
     readonly pid: number;
     readonly loadedIdentity: string;
     readonly repoCount: number;
     readonly queueDepth: number;
+    readonly daemonGeneration?: number;
   };
 }
 
@@ -341,6 +370,7 @@ export interface DaemonControlErrorV1 {
     | "daemon_queue_drain_timeout"
     | "daemon_refresh_wrong_checkout"
     | "daemon_refresh_build_failed"
+    | "daemon_control_generation_mismatch"
     | "daemon_restart_failed";
   readonly hint: string;
   readonly operationId: string | null;

--- a/packages/application/src/receipt/v2-types.ts
+++ b/packages/application/src/receipt/v2-types.ts
@@ -84,7 +84,6 @@ export interface CompoundOperationReceiptV2 extends ReceiptIdentityV2 {
   readonly connectionId?: string;
   /** Reserved for S4; S1 neither generates nor enforces this value. */
   readonly leaseGeneration?: number;
-  readonly errorCode?: string;
 }
 
 export interface OpenedCompoundWaiterV2 {
@@ -118,7 +117,6 @@ export interface CompoundTerminalJournalEntry {
   readonly connectionId?: string;
   /** Reserved for S4; S1 neither generates nor enforces this value. */
   readonly leaseGeneration?: number;
-  readonly errorCode?: string;
 }
 
 export type CompoundTerminalJournalDraft = Omit<CompoundTerminalJournalEntry, "terminalLSN" | "receiptSequence">;

--- a/packages/application/src/receipt/v2-types.ts
+++ b/packages/application/src/receipt/v2-types.ts
@@ -78,6 +78,13 @@ export interface CompoundOperationReceiptV2 extends ReceiptIdentityV2 {
   readonly currentLease: CurrentLeaseState;
   readonly sequence: number;
   readonly updatedAt: string;
+  readonly machineId?: string;
+  readonly daemonGeneration?: number;
+  readonly runtimeRegistrationId?: string;
+  readonly connectionId?: string;
+  /** Reserved for S4; S1 neither generates nor enforces this value. */
+  readonly leaseGeneration?: number;
+  readonly errorCode?: string;
 }
 
 export interface OpenedCompoundWaiterV2 {
@@ -105,6 +112,13 @@ export interface CompoundTerminalJournalEntry {
   readonly preparedSequence?: number;
   readonly preparedReceiptDigest?: string;
   readonly reason?: string;
+  readonly machineId?: string;
+  readonly daemonGeneration?: number;
+  readonly runtimeRegistrationId?: string;
+  readonly connectionId?: string;
+  /** Reserved for S4; S1 neither generates nor enforces this value. */
+  readonly leaseGeneration?: number;
+  readonly errorCode?: string;
 }
 
 export type CompoundTerminalJournalDraft = Omit<CompoundTerminalJournalEntry, "terminalLSN" | "receiptSequence">;

--- a/packages/application/src/receipt/validation-v2.ts
+++ b/packages/application/src/receipt/validation-v2.ts
@@ -18,7 +18,10 @@ export function isCompoundOperationReceiptV2(value: unknown): value is CompoundO
     || !exactKeys(value, [
       "schema", "workspaceId", "viewId", "opId", "waiterId", "resultTokenDigest", "phase",
       "delivery", "pinReleaseEligible", "currentLease", "sequence", "updatedAt"
-    ], ["authority", "origin", "originPin", "terminalLSN", "acknowledgement"])
+    ], [
+      "authority", "origin", "originPin", "terminalLSN", "acknowledgement",
+      "machineId", "daemonGeneration", "runtimeRegistrationId", "connectionId", "leaseGeneration", "errorCode"
+    ])
     || value.schema !== compoundReceiptV2Schema
     || !requiredStringsV2(value, ["workspaceId", "viewId", "opId", "waiterId", "resultTokenDigest", "updatedAt"])
     || !hexDigest(value.resultTokenDigest)
@@ -26,7 +29,8 @@ export function isCompoundOperationReceiptV2(value: unknown): value is CompoundO
     || !includes(deliveryStates, value.delivery)
     || !includes(leaseStates, value.currentLease)
     || typeof value.pinReleaseEligible !== "boolean"
-    || !uintReceiptV2(value.sequence)) return false;
+    || !uintReceiptV2(value.sequence)
+    || !validTerminalGenerationAxesV2(value)) return false;
   if (value.authority !== undefined && !validAuthorityV2(value.authority, value)) return false;
   if (value.origin !== undefined && !validOriginV2(value.origin, value)) return false;
   if (value.originPin !== undefined && !validOriginPin(value.originPin, value.origin)) return false;
@@ -179,4 +183,14 @@ function exactKeys(
 
 function stringArrayV2(value: unknown): boolean {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string" && entry.length > 0);
+}
+
+function validTerminalGenerationAxesV2(value: Record<string, unknown>): boolean {
+  for (const field of ["machineId", "runtimeRegistrationId", "connectionId", "errorCode"] as const) {
+    if (value[field] !== undefined && (typeof value[field] !== "string" || value[field].length === 0)) return false;
+  }
+  for (const field of ["daemonGeneration", "leaseGeneration"] as const) {
+    if (value[field] !== undefined && (!uintReceiptV2(value[field]) || Number(value[field]) < 1)) return false;
+  }
+  return true;
 }

--- a/packages/application/src/receipt/validation-v2.ts
+++ b/packages/application/src/receipt/validation-v2.ts
@@ -20,7 +20,7 @@ export function isCompoundOperationReceiptV2(value: unknown): value is CompoundO
       "delivery", "pinReleaseEligible", "currentLease", "sequence", "updatedAt"
     ], [
       "authority", "origin", "originPin", "terminalLSN", "acknowledgement",
-      "machineId", "daemonGeneration", "runtimeRegistrationId", "connectionId", "leaseGeneration", "errorCode"
+      "machineId", "daemonGeneration", "runtimeRegistrationId", "connectionId", "leaseGeneration"
     ])
     || value.schema !== compoundReceiptV2Schema
     || !requiredStringsV2(value, ["workspaceId", "viewId", "opId", "waiterId", "resultTokenDigest", "updatedAt"])
@@ -186,7 +186,7 @@ function stringArrayV2(value: unknown): boolean {
 }
 
 function validTerminalGenerationAxesV2(value: Record<string, unknown>): boolean {
-  for (const field of ["machineId", "runtimeRegistrationId", "connectionId", "errorCode"] as const) {
+  for (const field of ["machineId", "runtimeRegistrationId", "connectionId"] as const) {
     if (value[field] !== undefined && (typeof value[field] !== "string" || value[field].length === 0)) return false;
   }
   for (const field of ["daemonGeneration", "leaseGeneration"] as const) {

--- a/packages/application/test/daemon-generation-receipt-v2.test.ts
+++ b/packages/application/test/daemon-generation-receipt-v2.test.ts
@@ -29,8 +29,7 @@ test("compound receipt v2 accepts omitted, partial, and full generation projecti
     daemonGeneration: 2,
     runtimeRegistrationId: "runtime-a",
     connectionId: "connection-a",
-    leaseGeneration: 1,
-    errorCode: "DAEMON_GENERATION_FENCED"
+    leaseGeneration: 1
   })), true);
   assert.equal(isCompoundOperationReceiptV2(pending({ daemonGeneration: 0 })), false);
 });

--- a/packages/application/test/daemon-generation-receipt-v2.test.ts
+++ b/packages/application/test/daemon-generation-receipt-v2.test.ts
@@ -1,0 +1,44 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isCompoundOperationReceiptV2, type CompoundOperationReceiptV2 } from "../src/index.ts";
+
+function pending(overrides: Partial<CompoundOperationReceiptV2> = {}): CompoundOperationReceiptV2 {
+  return {
+    schema: "compound-operation-receipt/v2",
+    workspaceId: "workspace-a",
+    viewId: "view-a",
+    opId: "op-a",
+    waiterId: "waiter-a",
+    resultTokenDigest: "a".repeat(64),
+    phase: "PENDING",
+    delivery: "PENDING",
+    pinReleaseEligible: false,
+    currentLease: "NOT_REQUESTED",
+    sequence: 0,
+    updatedAt: "2026-07-21T00:00:00.000Z",
+    ...overrides
+  };
+}
+
+test("compound receipt v2 accepts omitted, partial, and full generation projections", () => {
+  assert.equal(isCompoundOperationReceiptV2(pending()), true);
+  assert.equal(isCompoundOperationReceiptV2(pending({ daemonGeneration: 2 })), true);
+  assert.equal(isCompoundOperationReceiptV2(pending({
+    machineId: "machine-installation-a",
+    daemonGeneration: 2,
+    runtimeRegistrationId: "runtime-a",
+    connectionId: "connection-a",
+    leaseGeneration: 1,
+    errorCode: "DAEMON_GENERATION_FENCED"
+  })), true);
+  assert.equal(isCompoundOperationReceiptV2(pending({ daemonGeneration: 0 })), false);
+});
+
+test("legacy compound receipt JSON remains byte-identical through decode and encode", () => {
+  const before = Buffer.from(`${JSON.stringify(pending())}\n`);
+  const decoded = JSON.parse(before.toString("utf8"));
+  assert.equal(isCompoundOperationReceiptV2(decoded), true);
+  const after = Buffer.from(`${JSON.stringify(decoded)}\n`);
+  assert.equal(after.equals(before), true, "legacy compound receipt bytes drifted");
+});

--- a/packages/cli/src/daemon/daemon-launch-spec.ts
+++ b/packages/cli/src/daemon/daemon-launch-spec.ts
@@ -49,6 +49,8 @@ interface PersistedDaemonLaunchSpec {
   readonly schema: typeof daemonLaunchSpecSchema;
   readonly endpoint: string;
   readonly launchConfiguration: DaemonLaunchConfiguration;
+  readonly machineId?: string;
+  readonly daemonGeneration?: number;
 }
 
 interface LegacyPersistedDaemonLaunchSpec {
@@ -153,7 +155,9 @@ function writeDaemonLaunchResolution(
     const document: PersistedDaemonLaunchSpec = {
       schema: daemonLaunchSpecSchema,
       endpoint,
-      launchConfiguration: cloneDaemonLaunchConfiguration(launchConfiguration)
+      launchConfiguration: cloneDaemonLaunchConfiguration(launchConfiguration),
+      ...(launchConfiguration.machineId !== undefined ? { machineId: launchConfiguration.machineId } : {}),
+      ...(launchConfiguration.daemonGeneration !== undefined ? { daemonGeneration: launchConfiguration.daemonGeneration } : {})
     };
     // Owner-only mode. The spec contains paths, never credentials or key material.
     writeFileSync(temporary, `${JSON.stringify(document, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
@@ -210,7 +214,10 @@ export function readPersistedDaemonLaunchSpec(
     throw incompatibleDaemonLaunchSpecError(source, "endpoint-mismatch");
   }
   if (isLegacyPersistedDaemonLaunchSpec(decoded)) return cloneDaemonLaunchOptions(decoded.options);
-  if (decoded.schema !== daemonLaunchSpecSchema || !isDaemonLaunchConfiguration(decoded.launchConfiguration)) {
+  if (decoded.schema !== daemonLaunchSpecSchema || !isDaemonLaunchConfiguration(decoded.launchConfiguration)
+    || !optionalNonEmptyString(decoded.machineId) || !optionalPositiveSafeInteger(decoded.daemonGeneration)
+    || (decoded.machineId !== undefined && decoded.machineId !== decoded.launchConfiguration.machineId)
+    || (decoded.daemonGeneration !== undefined && decoded.daemonGeneration !== decoded.launchConfiguration.daemonGeneration)) {
     throw incompatibleDaemonLaunchSpecError(source, "invalid-document");
   }
   const configuration = cloneDaemonLaunchConfiguration(decoded.launchConfiguration);
@@ -321,7 +328,9 @@ function isDaemonLaunchConfiguration(value: unknown): value is DaemonLaunchConfi
     && typeof value.entrypoint === "string"
     && value.entrypoint.length > 0
     && Array.isArray(value.args)
-    && value.args.every((arg) => typeof arg === "string");
+    && value.args.every((arg) => typeof arg === "string")
+    && optionalNonEmptyString(value.machineId)
+    && optionalPositiveSafeInteger(value.daemonGeneration);
 }
 
 function isLegacyPersistedDaemonLaunchSpec(
@@ -384,8 +393,18 @@ function cloneDaemonLaunchConfiguration(configuration: DaemonLaunchConfiguration
     execPath: configuration.execPath,
     execArgv: [...configuration.execArgv],
     entrypoint: configuration.entrypoint,
-    args: [...configuration.args]
+    args: [...configuration.args],
+    ...(configuration.machineId !== undefined ? { machineId: configuration.machineId } : {}),
+    ...(configuration.daemonGeneration !== undefined ? { daemonGeneration: configuration.daemonGeneration } : {})
   };
+}
+
+function optionalNonEmptyString(value: unknown): boolean {
+  return value === undefined || (typeof value === "string" && value.length > 0);
+}
+
+function optionalPositiveSafeInteger(value: unknown): boolean {
+  return value === undefined || (typeof value === "number" && Number.isSafeInteger(value) && value >= 1);
 }
 
 function isRecordValue(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/test/daemon-cold-start-launch-spec.test.ts
+++ b/packages/cli/test/daemon-cold-start-launch-spec.test.ts
@@ -56,12 +56,22 @@ test("service cold start restores, overrides, and diagnoses the persisted launch
     );
     const persistedLaunchSpec = JSON.parse(readFileSync(daemonLaunchSpecPath(userRoot, endpoint), "utf8")) as {
       readonly endpoint: string;
-      readonly launchConfiguration: { readonly args: ReadonlyArray<string> };
+      readonly launchConfiguration: {
+        readonly execPath: string;
+        readonly execArgv: ReadonlyArray<string>;
+        readonly entrypoint: string;
+        readonly args: ReadonlyArray<string>;
+      };
     };
     assert.equal(persistedLaunchSpec.endpoint, endpoint);
     assert.equal(optionValue(persistedLaunchSpec.launchConfiguration.args, "--authority-manifest"), fixture.manifestPath);
     const runningLaunchSpec = await readRunningLaunchSpec(fixture.repoRoot, userRoot);
-    assert.deepEqual(persistedLaunchSpec.launchConfiguration, runningLaunchSpec);
+    assert.deepEqual({
+      execPath: persistedLaunchSpec.launchConfiguration.execPath,
+      execArgv: persistedLaunchSpec.launchConfiguration.execArgv,
+      entrypoint: persistedLaunchSpec.launchConfiguration.entrypoint,
+      args: persistedLaunchSpec.launchConfiguration.args
+    }, runningLaunchSpec);
     assert.equal(runningLaunchSpec.args.includes(daemonLaunchOptionsResolvedFlag), true);
 
     mkdirSync(classicRoot, { recursive: true });
@@ -112,6 +122,28 @@ test("service cold start restores, overrides, and diagnoses the persisted launch
       }
     );
     assert.equal(optionValue(launchSpecArgs(autostartedSpec), "--authority-manifest"), fixture.manifestPath);
+    const legacyRpcData = launchSpecData(autostartedSpec);
+    const expectedLegacyRpc = Buffer.from(JSON.stringify({
+      execPath: legacyRpcData.execPath,
+      execArgv: legacyRpcData.execArgv,
+      entrypoint: legacyRpcData.entrypoint,
+      args: legacyRpcData.args
+    }));
+    assert.equal(
+      Buffer.from(JSON.stringify(legacyRpcData)).equals(expectedLegacyRpc),
+      true,
+      "legacy launch-spec RPC producer bytes drifted"
+    );
+    const capableSpec = await requestLocalDaemonJsonRpc(
+      fixture.repoRoot,
+      "admin.daemon.launch-spec",
+      { includeGenerationAxes: true },
+      1_000,
+      { userRoot, allowLegacySocket: false }
+    );
+    const capableData = launchSpecData(capableSpec);
+    assert.equal(typeof capableData.machineId, "string");
+    assert.equal(typeof capableData.daemonGeneration, "number");
     assert.match(readFileSync(daemonLaunchSpecPath(userRoot, endpoint), "utf8"), new RegExp(escapeRegExp(fixture.manifestPath), "u"));
     await stopDaemon(fixture.repoRoot, userRoot);
 
@@ -476,6 +508,12 @@ async function readRunningLaunchSpec(
     entrypoint: data.entrypoint as string,
     args: data.args as ReadonlyArray<string>
   };
+}
+
+function launchSpecData(receipt: Record<string, unknown>): Record<string, unknown> {
+  const details = receipt.details as { readonly data?: unknown };
+  assert.equal(isRecord(details.data), true, JSON.stringify(receipt));
+  return details.data as Record<string, unknown>;
 }
 
 function optionValue(args: ReadonlyArray<string>, option: string): string | undefined {

--- a/packages/cli/test/daemon-launch-spec.test.ts
+++ b/packages/cli/test/daemon-launch-spec.test.ts
@@ -40,6 +40,35 @@ test("persisted daemon launch spec round-trips the RPC launch configuration stru
   }
 });
 
+test("legacy launch persistence remains byte-identical and generation projections round-trip", () => {
+  const legacyRoot = mkdtempSync(path.join(tmpdir(), "ha-daemon-launch-bytes-"));
+  const projectedRoot = mkdtempSync(path.join(tmpdir(), "ha-daemon-launch-axes-"));
+  try {
+    resolveDaemonLaunchSpec(legacyRoot, endpoint, persisted).persist(legacyRoot, persistedConfiguration);
+    const expectedLegacy = Buffer.from(`${JSON.stringify({
+      schema: "daemon-launch-spec/v3",
+      endpoint,
+      launchConfiguration: persistedConfiguration
+    }, null, 2)}\n`);
+    const actualLegacy = readFileSync(daemonLaunchSpecPath(legacyRoot, endpoint));
+    assert.equal(actualLegacy.equals(expectedLegacy), true, "legacy launch spec bytes drifted");
+
+    const projected = {
+      ...persistedConfiguration,
+      machineId: "machine-installation-a",
+      daemonGeneration: 7
+    };
+    resolveDaemonLaunchSpec(projectedRoot, endpoint, persisted).persist(projectedRoot, projected);
+    assert.deepEqual(readPersistedDaemonLaunchSpec(projectedRoot, endpoint), projected);
+    const document = JSON.parse(readFileSync(daemonLaunchSpecPath(projectedRoot, endpoint), "utf8")) as Record<string, unknown>;
+    assert.equal(document.machineId, projected.machineId);
+    assert.equal(document.daemonGeneration, projected.daemonGeneration);
+  } finally {
+    rmSync(legacyRoot, { recursive: true, force: true });
+    rmSync(projectedRoot, { recursive: true, force: true });
+  }
+});
+
 test("cold start restores the omitted authority manifest and authored root from structured fields", () => {
   const restored = resolveRestoredLaunchOptions(persisted, {});
   assert.deepEqual(restored, persisted);

--- a/packages/daemon/src/client/daemon-launch-configuration.ts
+++ b/packages/daemon/src/client/daemon-launch-configuration.ts
@@ -1,0 +1,80 @@
+import path from "node:path";
+import type { LocalDaemonTarget } from "./local-json-rpc-client.ts";
+
+export const daemonLaunchOptionsResolvedFlag = "--launch-options-resolved";
+
+export interface DaemonLaunchConfiguration {
+  readonly execPath: string;
+  readonly execArgv: ReadonlyArray<string>;
+  readonly entrypoint: string;
+  readonly args: ReadonlyArray<string>;
+  readonly machineId?: string;
+  readonly daemonGeneration?: number;
+}
+
+export interface DaemonLaunchConfigurationInput {
+  readonly target: Pick<LocalDaemonTarget, "canonicalRoot" | "repoId" | "socketPath" | "userRoot">;
+  readonly entrypoint: string;
+  readonly idleExitMs: number;
+  readonly execPath?: string;
+  readonly execArgv?: ReadonlyArray<string>;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly authoredRoot?: string;
+  readonly authorityManifest?: string;
+  readonly launchOptionsResolved?: boolean;
+  readonly machineId?: string;
+  readonly daemonGeneration?: number;
+}
+
+export function createDaemonLaunchConfiguration(
+  input: DaemonLaunchConfigurationInput
+): DaemonLaunchConfiguration {
+  const environmentAuthorityManifest = nonEmptyEnvironmentValue(input.env?.HARNESS_AUTHORITY_MANIFEST)
+    ?? (input.env === undefined ? nonEmptyEnvironmentValue(process.env.HARNESS_AUTHORITY_MANIFEST) : undefined);
+  const environmentAuthoredRoot = nonEmptyEnvironmentValue(input.env?.HARNESS_AUTHORED_ROOT)
+    ?? (input.env === undefined ? nonEmptyEnvironmentValue(process.env.HARNESS_AUTHORED_ROOT) : undefined);
+  const authorityManifest = input.authorityManifest
+    ?? (environmentAuthorityManifest ? path.resolve(environmentAuthorityManifest) : undefined);
+  const authoredRoot = input.authoredRoot
+    ?? (environmentAuthoredRoot ? path.resolve(input.target.canonicalRoot, environmentAuthoredRoot) : undefined);
+  return {
+    execPath: input.execPath ?? process.execPath,
+    execArgv: [...(input.execArgv ?? process.execArgv)],
+    entrypoint: input.entrypoint,
+    args: [
+      "--root", input.target.canonicalRoot,
+      ...(authoredRoot !== undefined ? ["--authored-root", authoredRoot] : []),
+      "daemon", "serve",
+      "--repo", input.target.repoId,
+      "--socket", input.target.socketPath,
+      "--user-root", input.target.userRoot,
+      "--idle-ms", String(input.idleExitMs),
+      ...(authorityManifest !== undefined ? ["--authority-manifest", authorityManifest] : []),
+      ...(input.launchOptionsResolved ? [daemonLaunchOptionsResolvedFlag] : [])
+    ],
+    ...(input.machineId !== undefined ? { machineId: input.machineId } : {}),
+    ...(input.daemonGeneration !== undefined ? { daemonGeneration: input.daemonGeneration } : {})
+  };
+}
+
+/** Legacy RPC/control projection is exactly the original four-key launch contract. */
+export function projectDaemonLaunchConfiguration(
+  configuration: DaemonLaunchConfiguration,
+  includeGenerationAxes = false
+): DaemonLaunchConfiguration {
+  return {
+    execPath: configuration.execPath,
+    execArgv: [...configuration.execArgv],
+    entrypoint: configuration.entrypoint,
+    args: [...configuration.args],
+    ...(includeGenerationAxes && configuration.machineId !== undefined
+      ? { machineId: configuration.machineId } : {}),
+    ...(includeGenerationAxes && configuration.daemonGeneration !== undefined
+      ? { daemonGeneration: configuration.daemonGeneration } : {})
+  };
+}
+
+function nonEmptyEnvironmentValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -306,6 +306,23 @@ export function createDaemonLaunchConfiguration(
   };
 }
 
+/** Legacy RPC/control projection is exactly the original four-key launch contract. */
+export function projectDaemonLaunchConfiguration(
+  configuration: DaemonLaunchConfiguration,
+  includeGenerationAxes = false
+): DaemonLaunchConfiguration {
+  return {
+    execPath: configuration.execPath,
+    execArgv: [...configuration.execArgv],
+    entrypoint: configuration.entrypoint,
+    args: [...configuration.args],
+    ...(includeGenerationAxes && configuration.machineId !== undefined
+      ? { machineId: configuration.machineId } : {}),
+    ...(includeGenerationAxes && configuration.daemonGeneration !== undefined
+      ? { daemonGeneration: configuration.daemonGeneration } : {})
+  };
+}
+
 export function daemonServerHostEnvironment(
   base: NodeJS.ProcessEnv,
   target: Pick<LocalDaemonTarget, "userRoot" | "daemonId">

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -49,6 +49,8 @@ export interface DaemonLaunchConfiguration {
   readonly execArgv: ReadonlyArray<string>;
   readonly entrypoint: string;
   readonly args: ReadonlyArray<string>;
+  readonly machineId?: string;
+  readonly daemonGeneration?: number;
 }
 
 export interface DaemonLaunchConfigurationInput {
@@ -61,6 +63,8 @@ export interface DaemonLaunchConfigurationInput {
   readonly authoredRoot?: string;
   readonly authorityManifest?: string;
   readonly launchOptionsResolved?: boolean;
+  readonly machineId?: string;
+  readonly daemonGeneration?: number;
 }
 
 interface HarnessLayoutOverrides {
@@ -296,7 +300,9 @@ export function createDaemonLaunchConfiguration(
       "--idle-ms", String(input.idleExitMs),
       ...(authorityManifest !== undefined ? ["--authority-manifest", authorityManifest] : []),
       ...(input.launchOptionsResolved ? [daemonLaunchOptionsResolvedFlag] : [])
-    ]
+    ],
+    ...(input.machineId !== undefined ? { machineId: input.machineId } : {}),
+    ...(input.daemonGeneration !== undefined ? { daemonGeneration: input.daemonGeneration } : {})
   };
 }
 

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -19,10 +19,21 @@ import { type JsonObject, type JsonRpcRequest, type JsonRpcResponse } from "../p
 import { encodeJsonLineFrame } from "../transport/frame-codec.ts";
 import { defaultNamedPipePath } from "../transport/named-pipe.ts";
 import { defaultUnixSocketPath, type UnixSocketPathOptions } from "../transport/unix-socket.ts";
+import {
+  createDaemonLaunchConfiguration,
+  type DaemonLaunchConfiguration
+} from "./daemon-launch-configuration.ts";
+
+export {
+  createDaemonLaunchConfiguration,
+  daemonLaunchOptionsResolvedFlag,
+  projectDaemonLaunchConfiguration,
+  type DaemonLaunchConfiguration,
+  type DaemonLaunchConfigurationInput
+} from "./daemon-launch-configuration.ts";
 
 export const defaultDaemonAutostartTimeoutMs = 6_000;
 export const defaultDaemonIdleExitMs = 750;
-export const daemonLaunchOptionsResolvedFlag = "--launch-options-resolved";
 
 export class DaemonJsonRpcResponseError extends Error {
   readonly code: number;
@@ -42,29 +53,6 @@ export interface LocalDaemonTarget {
   readonly socketPath: string;
   readonly legacySocketPath: string;
   readonly registered: boolean;
-}
-
-export interface DaemonLaunchConfiguration {
-  readonly execPath: string;
-  readonly execArgv: ReadonlyArray<string>;
-  readonly entrypoint: string;
-  readonly args: ReadonlyArray<string>;
-  readonly machineId?: string;
-  readonly daemonGeneration?: number;
-}
-
-export interface DaemonLaunchConfigurationInput {
-  readonly target: Pick<LocalDaemonTarget, "canonicalRoot" | "repoId" | "socketPath" | "userRoot">;
-  readonly entrypoint: string;
-  readonly idleExitMs: number;
-  readonly execPath?: string;
-  readonly execArgv?: ReadonlyArray<string>;
-  readonly env?: NodeJS.ProcessEnv;
-  readonly authoredRoot?: string;
-  readonly authorityManifest?: string;
-  readonly launchOptionsResolved?: boolean;
-  readonly machineId?: string;
-  readonly daemonGeneration?: number;
 }
 
 interface HarnessLayoutOverrides {
@@ -275,54 +263,6 @@ export function spawnLocalDaemon(target: LocalDaemonTarget, options: LocalDaemon
   spawnLocalDaemonImplementation(target, options);
 }
 
-export function createDaemonLaunchConfiguration(
-  input: DaemonLaunchConfigurationInput
-): DaemonLaunchConfiguration {
-  const environmentAuthorityManifest = nonEmptyEnvironmentValue(input.env?.HARNESS_AUTHORITY_MANIFEST)
-    ?? (input.env === undefined ? nonEmptyEnvironmentValue(process.env.HARNESS_AUTHORITY_MANIFEST) : undefined);
-  const environmentAuthoredRoot = nonEmptyEnvironmentValue(input.env?.HARNESS_AUTHORED_ROOT)
-    ?? (input.env === undefined ? nonEmptyEnvironmentValue(process.env.HARNESS_AUTHORED_ROOT) : undefined);
-  const authorityManifest = input.authorityManifest
-    ?? (environmentAuthorityManifest ? path.resolve(environmentAuthorityManifest) : undefined);
-  const authoredRoot = input.authoredRoot
-    ?? (environmentAuthoredRoot ? path.resolve(input.target.canonicalRoot, environmentAuthoredRoot) : undefined);
-  return {
-    execPath: input.execPath ?? process.execPath,
-    execArgv: [...(input.execArgv ?? process.execArgv)],
-    entrypoint: input.entrypoint,
-    args: [
-      "--root", input.target.canonicalRoot,
-      ...(authoredRoot !== undefined ? ["--authored-root", authoredRoot] : []),
-      "daemon", "serve",
-      "--repo", input.target.repoId,
-      "--socket", input.target.socketPath,
-      "--user-root", input.target.userRoot,
-      "--idle-ms", String(input.idleExitMs),
-      ...(authorityManifest !== undefined ? ["--authority-manifest", authorityManifest] : []),
-      ...(input.launchOptionsResolved ? [daemonLaunchOptionsResolvedFlag] : [])
-    ],
-    ...(input.machineId !== undefined ? { machineId: input.machineId } : {}),
-    ...(input.daemonGeneration !== undefined ? { daemonGeneration: input.daemonGeneration } : {})
-  };
-}
-
-/** Legacy RPC/control projection is exactly the original four-key launch contract. */
-export function projectDaemonLaunchConfiguration(
-  configuration: DaemonLaunchConfiguration,
-  includeGenerationAxes = false
-): DaemonLaunchConfiguration {
-  return {
-    execPath: configuration.execPath,
-    execArgv: [...configuration.execArgv],
-    entrypoint: configuration.entrypoint,
-    args: [...configuration.args],
-    ...(includeGenerationAxes && configuration.machineId !== undefined
-      ? { machineId: configuration.machineId } : {}),
-    ...(includeGenerationAxes && configuration.daemonGeneration !== undefined
-      ? { daemonGeneration: configuration.daemonGeneration } : {})
-  };
-}
-
 export function daemonServerHostEnvironment(
   base: NodeJS.ProcessEnv,
   target: Pick<LocalDaemonTarget, "userRoot" | "daemonId">
@@ -366,11 +306,6 @@ function spawnLocalDaemonProcess(target: LocalDaemonTarget, options: LocalDaemon
     env: daemonServerHostEnvironment(options.env ?? process.env, target)
   });
   child.unref();
-}
-
-function nonEmptyEnvironmentValue(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
 }
 
 export class JsonRpcLineClient {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -36,6 +36,7 @@ export {
   localUserDaemonEndpoint,
   localUserDaemonSocketPath,
   createDaemonLaunchConfiguration,
+  projectDaemonLaunchConfiguration,
   requestLocalDaemonJsonRpc,
   requestLocalDaemonJsonRpcForTarget,
   resolveLocalDaemonTarget,

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -60,6 +60,7 @@ export * from "./runtime/canonical-harness-root.ts";
 export * from "./runtime/canonical-root.ts";
 export * from "./runtime/registry-reconciler.ts";
 export * from "./lifecycle/daemon-lifecycle.ts";
+export * from "./lifecycle/daemon-generation.ts";
 export * from "./lifecycle/daemon-log-file-store.ts";
 export * from "./lifecycle/compound-receipt-composition.ts";
 export * from "./lifecycle/compound-receipt-runner.ts";

--- a/packages/daemon/src/lifecycle/daemon-control-service.ts
+++ b/packages/daemon/src/lifecycle/daemon-control-service.ts
@@ -7,7 +7,10 @@ import {
   type DaemonControlService,
   type DaemonStatusResultV2
 } from "@harness-anything/application";
-import type { DaemonLaunchConfiguration } from "../client/local-json-rpc-client.ts";
+import {
+  projectDaemonLaunchConfiguration,
+  type DaemonLaunchConfiguration
+} from "../client/local-json-rpc-client.ts";
 
 export type { DaemonLaunchConfiguration } from "../client/local-json-rpc-client.ts";
 
@@ -75,7 +78,7 @@ export function createDaemonControlService<
             loadedIdentity: before.service.build.loadedIdentity,
             repoCount: before.service.repoCount,
             queueDepth: before.service.queue.depth,
-            launchConfiguration: input.launchConfiguration,
+            launchConfiguration: projectDaemonLaunchConfiguration(input.launchConfiguration, generationCapability),
             ...(generationCapability && input.launchConfiguration.daemonGeneration !== undefined
               ? { daemonGeneration: input.launchConfiguration.daemonGeneration } : {})
           }

--- a/packages/daemon/src/lifecycle/daemon-control-service.ts
+++ b/packages/daemon/src/lifecycle/daemon-control-service.ts
@@ -49,7 +49,16 @@ export function createDaemonControlService<
       const before = input.status();
       const operationId = `control_${randomUUID()}`;
       const requestedAt = new Date().toISOString();
-      input.setActiveControl({ operationId, kind, phase: "accepted", requestedAt });
+      const generationCapability = request.daemonGeneration !== undefined || request.connectionId !== undefined;
+      const generationAxes = generationCapability
+        && input.launchConfiguration.machineId !== undefined
+        && input.launchConfiguration.daemonGeneration !== undefined
+        ? {
+            machineId: input.launchConfiguration.machineId,
+            daemonGeneration: input.launchConfiguration.daemonGeneration
+          }
+        : {};
+      input.setActiveControl({ operationId, kind, phase: "accepted", requestedAt, ...generationAxes });
       return {
         ok: true,
         accepted: {
@@ -59,17 +68,21 @@ export function createDaemonControlService<
           kind,
           scope: "service",
           requestedAt,
+          ...generationAxes,
+          ...(request.connectionId !== undefined ? { connectionId: request.connectionId } : {}),
           before: {
             pid: before.service.pid,
             loadedIdentity: before.service.build.loadedIdentity,
             repoCount: before.service.repoCount,
             queueDepth: before.service.queue.depth,
-            launchConfiguration: input.launchConfiguration
+            launchConfiguration: input.launchConfiguration,
+            ...(generationCapability && input.launchConfiguration.daemonGeneration !== undefined
+              ? { daemonGeneration: input.launchConfiguration.daemonGeneration } : {})
           }
         },
         afterResponse: () => {
           if (input.activeControl()?.operationId !== operationId) return;
-          input.setActiveControl({ operationId, kind, phase: "draining", requestedAt });
+          input.setActiveControl({ operationId, kind, phase: "draining", requestedAt, ...generationAxes });
           input.setDrainTimeout(request.drainTimeoutMs);
           input.requestStop({ reason: "control", kind, operationId });
         }

--- a/packages/daemon/src/lifecycle/daemon-generation.ts
+++ b/packages/daemon/src/lifecycle/daemon-generation.ts
@@ -34,7 +34,11 @@ export function daemonGenerationRecordPath(userRoot: string, endpointIdentity: s
 }
 
 /** Installation-scoped identity. Different userRoot values intentionally receive different identities. */
-export function readOrCreateDaemonMachineId(installationRoot: string): string {
+export function readOrCreateDaemonMachineId(
+  installationRoot: string,
+  platform: NodeJS.Platform = process.platform
+): string {
+  assertDurableGenerationPlatform(platform);
   const directory = path.resolve(installationRoot);
   const target = daemonMachineIdPath(directory);
   mkdirSync(directory, { recursive: true, mode: 0o700 });
@@ -71,7 +75,9 @@ export function publishNextDaemonGeneration(input: {
   readonly machineId: string;
   readonly daemonInstanceId: string;
   readonly now?: () => Date;
+  readonly platform?: NodeJS.Platform;
 }): DaemonGenerationRecordV1 {
+  assertDurableGenerationPlatform(input.platform ?? process.platform);
   assertNonEmpty(input.endpointIdentity, "endpointIdentity");
   assertNonEmpty(input.machineId, "machineId");
   assertNonEmpty(input.daemonInstanceId, "daemonInstanceId");
@@ -135,12 +141,19 @@ function isDaemonGenerationRecord(value: unknown): value is DaemonGenerationReco
 }
 
 function fsyncDirectory(directory: string): void {
-  if (process.platform === "win32") return;
   const descriptor = openSync(directory, "r");
   try {
     fsyncSync(descriptor);
   } finally {
     closeSync(descriptor);
+  }
+}
+
+function assertDurableGenerationPlatform(platform: NodeJS.Platform): void {
+  if (platform === "win32") {
+    throw new Error(
+      "DAEMON_GENERATION_DURABILITY_UNSUPPORTED: Windows daemon generation publication is disabled until a crash-durable directory replacement primitive is available."
+    );
   }
 }
 

--- a/packages/daemon/src/lifecycle/daemon-generation.ts
+++ b/packages/daemon/src/lifecycle/daemon-generation.ts
@@ -14,6 +14,7 @@ import {
 import path from "node:path";
 
 export const daemonGenerationRecordSchema = "daemon-generation-record/v1" as const;
+export const daemonGenerationDurabilityUnsupportedCode = "DAEMON_GENERATION_DURABILITY_UNSUPPORTED" as const;
 
 export interface DaemonGenerationRecordV1 {
   readonly schema: typeof daemonGenerationRecordSchema;
@@ -24,6 +25,15 @@ export interface DaemonGenerationRecordV1 {
   readonly publishedAt: string;
 }
 
+export type DaemonGenerationServePreparation = {
+  readonly mode: "generation";
+  readonly machineId: string;
+  readonly daemonGeneration: number;
+} | {
+  readonly mode: "legacy";
+  readonly diagnostic: typeof daemonGenerationDurabilityUnsupportedCode;
+};
+
 export function daemonMachineIdPath(installationRoot: string): string {
   return path.join(path.resolve(installationRoot), "machine-id");
 }
@@ -31,6 +41,32 @@ export function daemonMachineIdPath(installationRoot: string): string {
 export function daemonGenerationRecordPath(userRoot: string, endpointIdentity: string): string {
   const endpointHash = createHash("sha256").update(endpointIdentity).digest("hex");
   return path.join(path.resolve(userRoot), `daemon-generation.${endpointHash}.json`);
+}
+
+/** Default daemon startup remains legacy-compatible where durable generation publication is unavailable. */
+export function prepareDaemonGenerationForServe(input: {
+  readonly userRoot: string;
+  readonly endpointIdentity: string;
+  readonly daemonInstanceId: string;
+  readonly platform?: NodeJS.Platform;
+}): DaemonGenerationServePreparation {
+  const platform = input.platform ?? process.platform;
+  if (platform === "win32") {
+    return { mode: "legacy", diagnostic: daemonGenerationDurabilityUnsupportedCode };
+  }
+  const machineId = readOrCreateDaemonMachineId(input.userRoot, platform);
+  const generationRecord = publishNextDaemonGeneration({
+    userRoot: input.userRoot,
+    endpointIdentity: input.endpointIdentity,
+    machineId,
+    daemonInstanceId: input.daemonInstanceId,
+    platform
+  });
+  return {
+    mode: "generation",
+    machineId,
+    daemonGeneration: generationRecord.daemonGeneration
+  };
 }
 
 /** Installation-scoped identity. Different userRoot values intentionally receive different identities. */
@@ -152,7 +188,7 @@ function fsyncDirectory(directory: string): void {
 function assertDurableGenerationPlatform(platform: NodeJS.Platform): void {
   if (platform === "win32") {
     throw new Error(
-      "DAEMON_GENERATION_DURABILITY_UNSUPPORTED: Windows daemon generation publication is disabled until a crash-durable directory replacement primitive is available."
+      `${daemonGenerationDurabilityUnsupportedCode}: Windows daemon generation publication is disabled until a crash-durable directory replacement primitive is available.`
     );
   }
 }

--- a/packages/daemon/src/lifecycle/daemon-generation.ts
+++ b/packages/daemon/src/lifecycle/daemon-generation.ts
@@ -1,0 +1,157 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  linkSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import path from "node:path";
+
+export const daemonGenerationRecordSchema = "daemon-generation-record/v1" as const;
+
+export interface DaemonGenerationRecordV1 {
+  readonly schema: typeof daemonGenerationRecordSchema;
+  readonly machineId: string;
+  readonly endpointIdentity: string;
+  readonly daemonGeneration: number;
+  readonly daemonInstanceId: string;
+  readonly publishedAt: string;
+}
+
+export function daemonMachineIdPath(installationRoot: string): string {
+  return path.join(path.resolve(installationRoot), "machine-id");
+}
+
+export function daemonGenerationRecordPath(userRoot: string, endpointIdentity: string): string {
+  const endpointHash = createHash("sha256").update(endpointIdentity).digest("hex");
+  return path.join(path.resolve(userRoot), `daemon-generation.${endpointHash}.json`);
+}
+
+/** Installation-scoped identity. Different userRoot values intentionally receive different identities. */
+export function readOrCreateDaemonMachineId(installationRoot: string): string {
+  const directory = path.resolve(installationRoot);
+  const target = daemonMachineIdPath(directory);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  if (existsSync(target)) return readMachineId(target);
+
+  const temporary = `${target}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(temporary, "wx", 0o600);
+    writeFileSync(descriptor, `${randomUUID()}\n`, "utf8");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    try {
+      linkSync(temporary, target);
+    } catch (error) {
+      if (!isAlreadyExists(error)) throw error;
+    }
+    fsyncDirectory(directory);
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+    rmSync(temporary, { force: true });
+  }
+  return readMachineId(target);
+}
+
+/**
+ * Publish the next generation after the caller has acquired the endpoint owner fence.
+ * The owner serialization is what makes read + replace strictly monotonic.
+ */
+export function publishNextDaemonGeneration(input: {
+  readonly userRoot: string;
+  readonly endpointIdentity: string;
+  readonly machineId: string;
+  readonly daemonInstanceId: string;
+  readonly now?: () => Date;
+}): DaemonGenerationRecordV1 {
+  assertNonEmpty(input.endpointIdentity, "endpointIdentity");
+  assertNonEmpty(input.machineId, "machineId");
+  assertNonEmpty(input.daemonInstanceId, "daemonInstanceId");
+  const directory = path.resolve(input.userRoot);
+  const target = daemonGenerationRecordPath(directory, input.endpointIdentity);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const current = existsSync(target) ? readDaemonGenerationRecord(target) : undefined;
+  if (current && (current.machineId !== input.machineId || current.endpointIdentity !== input.endpointIdentity)) {
+    throw new Error("daemon generation record identity mismatch");
+  }
+  if (current?.daemonGeneration === Number.MAX_SAFE_INTEGER) {
+    throw new Error("daemon generation space exhausted");
+  }
+  const record: DaemonGenerationRecordV1 = {
+    schema: daemonGenerationRecordSchema,
+    machineId: input.machineId,
+    endpointIdentity: input.endpointIdentity,
+    daemonGeneration: (current?.daemonGeneration ?? 0) + 1,
+    daemonInstanceId: input.daemonInstanceId,
+    publishedAt: (input.now ?? (() => new Date()))().toISOString()
+  };
+  const temporary = `${target}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(temporary, "wx", 0o600);
+    writeFileSync(descriptor, `${JSON.stringify(record)}\n`, "utf8");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    renameSync(temporary, target);
+    fsyncDirectory(directory);
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+    rmSync(temporary, { force: true });
+  }
+  return record;
+}
+
+export function readDaemonGenerationRecord(source: string): DaemonGenerationRecordV1 {
+  const parsed: unknown = JSON.parse(readFileSync(source, "utf8"));
+  if (!isDaemonGenerationRecord(parsed)) throw new Error(`invalid daemon generation record: ${source}`);
+  return parsed;
+}
+
+function readMachineId(source: string): string {
+  const machineId = readFileSync(source, "utf8").trim();
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(machineId)) {
+    throw new Error(`invalid daemon machine identity: ${source}`);
+  }
+  return machineId;
+}
+
+function isDaemonGenerationRecord(value: unknown): value is DaemonGenerationRecordV1 {
+  if (!record(value) || Object.keys(value).length !== 6) return false;
+  return value.schema === daemonGenerationRecordSchema
+    && typeof value.machineId === "string" && value.machineId.length > 0
+    && typeof value.endpointIdentity === "string" && value.endpointIdentity.length > 0
+    && typeof value.daemonGeneration === "number" && Number.isSafeInteger(value.daemonGeneration) && value.daemonGeneration >= 1
+    && typeof value.daemonInstanceId === "string" && value.daemonInstanceId.length > 0
+    && typeof value.publishedAt === "string" && Number.isFinite(Date.parse(value.publishedAt));
+}
+
+function fsyncDirectory(directory: string): void {
+  if (process.platform === "win32") return;
+  const descriptor = openSync(directory, "r");
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "EEXIST";
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertNonEmpty(value: string, field: string): void {
+  if (value.length === 0) throw new Error(`${field} must be non-empty`);
+}

--- a/packages/daemon/src/lifecycle/daemon-generation.ts
+++ b/packages/daemon/src/lifecycle/daemon-generation.ts
@@ -131,7 +131,7 @@ function readMachineId(source: string): string {
 }
 
 function isDaemonGenerationRecord(value: unknown): value is DaemonGenerationRecordV1 {
-  if (!record(value) || Object.keys(value).length !== 6) return false;
+  if (!isJsonRecord(value) || Object.keys(value).length !== 6) return false;
   return value.schema === daemonGenerationRecordSchema
     && typeof value.machineId === "string" && value.machineId.length > 0
     && typeof value.endpointIdentity === "string" && value.endpointIdentity.length > 0
@@ -161,7 +161,7 @@ function isAlreadyExists(error: unknown): boolean {
   return error instanceof Error && "code" in error && error.code === "EEXIST";
 }
 
-function record(value: unknown): value is Record<string, unknown> {
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 

--- a/packages/daemon/src/lifecycle/durable-compound-receipt-store.ts
+++ b/packages/daemon/src/lifecycle/durable-compound-receipt-store.ts
@@ -126,7 +126,7 @@ function isState(value: unknown): value is DurableCompoundReceiptStateV2 {
       "pinReleaseEligible", "receiptSequence", "recordedAt"
     ], [
       "preparedSequence", "preparedReceiptDigest", "reason", "machineId", "daemonGeneration",
-      "runtimeRegistrationId", "connectionId", "leaseGeneration", "errorCode"
+      "runtimeRegistrationId", "connectionId", "leaseGeneration"
     ])
       || entry.schema !== compoundTerminalJournalSchema || !uint(entry.terminalLSN)
       || entry.terminalLSN <= priorLSN || !uint(entry.receiptSequence)
@@ -219,7 +219,7 @@ function strings(value: Record<string, unknown>, keys: ReadonlyArray<string>): b
 }
 
 function validTerminalGenerationAxes(value: Record<string, unknown>): boolean {
-  for (const field of ["machineId", "runtimeRegistrationId", "connectionId", "errorCode"] as const) {
+  for (const field of ["machineId", "runtimeRegistrationId", "connectionId"] as const) {
     if (value[field] !== undefined && (typeof value[field] !== "string" || value[field].length === 0)) return false;
   }
   for (const field of ["daemonGeneration", "leaseGeneration"] as const) {

--- a/packages/daemon/src/lifecycle/durable-compound-receipt-store.ts
+++ b/packages/daemon/src/lifecycle/durable-compound-receipt-store.ts
@@ -124,12 +124,16 @@ function isState(value: unknown): value is DurableCompoundReceiptStateV2 {
     if (!record(entry) || !exactKeys(entry, [
       "schema", "terminalLSN", "workspaceId", "viewId", "opId", "waiterId", "kind",
       "pinReleaseEligible", "receiptSequence", "recordedAt"
-    ], ["preparedSequence", "preparedReceiptDigest", "reason"])
+    ], [
+      "preparedSequence", "preparedReceiptDigest", "reason", "machineId", "daemonGeneration",
+      "runtimeRegistrationId", "connectionId", "leaseGeneration", "errorCode"
+    ])
       || entry.schema !== compoundTerminalJournalSchema || !uint(entry.terminalLSN)
       || entry.terminalLSN <= priorLSN || !uint(entry.receiptSequence)
       || entry.pinReleaseEligible !== true
       || !strings(entry, ["workspaceId", "viewId", "opId", "waiterId", "recordedAt"])
-      || (entry.kind !== "ACK_COMMITTED" && entry.kind !== "DETACHED")) return false;
+      || (entry.kind !== "ACK_COMMITTED" && entry.kind !== "DETACHED")
+      || !validTerminalGenerationAxes(entry)) return false;
     if (entry.kind === "ACK_COMMITTED") {
       if (!uint(entry.preparedSequence) || typeof entry.preparedReceiptDigest !== "string"
         || !/^[a-f0-9]{64}$/u.test(entry.preparedReceiptDigest) || entry.reason !== undefined) return false;
@@ -212,4 +216,14 @@ function exactKeys(
 
 function strings(value: Record<string, unknown>, keys: ReadonlyArray<string>): boolean {
   return keys.every((key) => typeof value[key] === "string" && (value[key] as string).length > 0);
+}
+
+function validTerminalGenerationAxes(value: Record<string, unknown>): boolean {
+  for (const field of ["machineId", "runtimeRegistrationId", "connectionId", "errorCode"] as const) {
+    if (value[field] !== undefined && (typeof value[field] !== "string" || value[field].length === 0)) return false;
+  }
+  for (const field of ["daemonGeneration", "leaseGeneration"] as const) {
+    if (value[field] !== undefined && (!uint(value[field]) || Number(value[field]) < 1)) return false;
+  }
+  return true;
 }

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -26,7 +26,7 @@ import { createDaemonLocalTransport, withDaemonSocketOwnership } from "../transp
 import { makeDaemonLogFileStore } from "./daemon-log-file-store.ts";
 import { makeDaemonReservationReconciler } from "./reservation-reconciler.ts";
 import { recordDaemonStarted, recordDaemonTerminated } from "./daemon-lifecycle.ts";
-import { publishNextDaemonGeneration, readOrCreateDaemonMachineId } from "./daemon-generation.ts";
+import { prepareDaemonGenerationForServe } from "./daemon-generation.ts";
 
 export type DaemonServeRepo = DaemonRepoNamespace & Pick<DaemonRegistryRepo, "displayName" | "authorityManifestPath">;
 
@@ -46,6 +46,7 @@ export interface DaemonServeInput {
   readonly entrypoint: string;
   readonly idleMs: number;
   readonly preflightReplacement: (configuration: DaemonLaunchConfiguration) => Promise<void>;
+  readonly platform?: NodeJS.Platform;
 }
 
 export async function runDaemonServe<
@@ -70,13 +71,28 @@ export async function runDaemonServe<
   const startedAt = new Date().toISOString();
 
   return withDaemonSocketOwnership(endpoint, async () => {
-    const machineId = readOrCreateDaemonMachineId(userRoot);
-    const generationRecord = publishNextDaemonGeneration({
+    const daemonLogService = makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot }) });
+    const generation = prepareDaemonGenerationForServe({
       userRoot,
       endpointIdentity: endpoint,
-      machineId,
-      daemonInstanceId: `ha-${process.pid}`
+      daemonInstanceId: `ha-${process.pid}`,
+      ...(input.platform ? { platform: input.platform } : {})
     });
+    if (generation.mode === "legacy") {
+      try {
+        await daemonLogService.append({
+          level: "warn",
+          source: "daemon",
+          component: "daemon.generation",
+          event: "daemon.generation.legacy-mode",
+          message: "Durable daemon generation publication is unavailable; continuing with legacy daemon semantics.",
+          errorCode: generation.diagnostic,
+          hint: "Generation-aware status, control, and terminal receipt fencing remain unavailable on this platform."
+        }, { repo: lifecycleRepo });
+      } catch {
+        // Operational diagnostics must not block legacy-compatible daemon startup.
+      }
+    }
     const launchConfiguration = createDaemonLaunchConfiguration({
       target: { canonicalRoot: rootDir, repoId: defaultRepoId, socketPath: endpoint, userRoot },
       entrypoint: input.entrypoint,
@@ -84,8 +100,10 @@ export async function runDaemonServe<
       ...(input.authoredRoot !== undefined ? { authoredRoot: input.authoredRoot } : {}),
       ...(authorityManifest ? { authorityManifest } : {}),
       launchOptionsResolved: true,
-      machineId,
-      daemonGeneration: generationRecord.daemonGeneration
+      ...(generation.mode === "generation" ? {
+        machineId: generation.machineId,
+        daemonGeneration: generation.daemonGeneration
+      } : {})
     });
     let runtime: ReturnType<typeof createMultiRepoDaemonRuntime> | undefined;
     let serviceHost: Awaited<ReturnType<typeof createDaemonServiceHost<Command, Result, Identity, PresentedControlError>>> | undefined;
@@ -94,7 +112,6 @@ export async function runDaemonServe<
     let terminalClean = false;
     let terminalMessage: string | undefined;
     let failure: unknown;
-    const daemonLogService = makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot }) });
     try {
       runtime = createMultiRepoDaemonRuntime({
         materializerPollMs: 5_000,
@@ -138,8 +155,10 @@ export async function runDaemonServe<
           startedAt,
           launchConfiguration,
           preflightReplacement: input.preflightReplacement,
-          machineId,
-          daemonGeneration: generationRecord.daemonGeneration
+          ...(generation.mode === "generation" ? {
+            machineId: generation.machineId,
+            daemonGeneration: generation.daemonGeneration
+          } : {})
         },
         serviceHostServices,
         authorityLifecycle,

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -26,6 +26,7 @@ import { createDaemonLocalTransport, withDaemonSocketOwnership } from "../transp
 import { makeDaemonLogFileStore } from "./daemon-log-file-store.ts";
 import { makeDaemonReservationReconciler } from "./reservation-reconciler.ts";
 import { recordDaemonStarted, recordDaemonTerminated } from "./daemon-lifecycle.ts";
+import { publishNextDaemonGeneration, readOrCreateDaemonMachineId } from "./daemon-generation.ts";
 
 export type DaemonServeRepo = DaemonRepoNamespace & Pick<DaemonRegistryRepo, "displayName" | "authorityManifestPath">;
 
@@ -65,18 +66,27 @@ export async function runDaemonServe<
 ): Promise<void> {
   const { rootDir, layoutOverrides, userRoot, endpoint } = input;
   const { serveRepos, authorityManifest, defaultRepoId, lifecycleRepo } = resolveDaemonServeConfiguration(input);
-  const launchConfiguration = createDaemonLaunchConfiguration({
-    target: { canonicalRoot: rootDir, repoId: defaultRepoId, socketPath: endpoint, userRoot },
-    entrypoint: input.entrypoint,
-    idleExitMs: input.idleMs,
-    ...(input.authoredRoot !== undefined ? { authoredRoot: input.authoredRoot } : {}),
-    ...(authorityManifest ? { authorityManifest } : {}),
-    launchOptionsResolved: true
-  });
   const loadedBuild = calculateDaemonArtifactIdentity(input.entrypoint);
   const startedAt = new Date().toISOString();
 
   return withDaemonSocketOwnership(endpoint, async () => {
+    const machineId = readOrCreateDaemonMachineId(userRoot);
+    const generationRecord = publishNextDaemonGeneration({
+      userRoot,
+      endpointIdentity: endpoint,
+      machineId,
+      daemonInstanceId: `ha-${process.pid}`
+    });
+    const launchConfiguration = createDaemonLaunchConfiguration({
+      target: { canonicalRoot: rootDir, repoId: defaultRepoId, socketPath: endpoint, userRoot },
+      entrypoint: input.entrypoint,
+      idleExitMs: input.idleMs,
+      ...(input.authoredRoot !== undefined ? { authoredRoot: input.authoredRoot } : {}),
+      ...(authorityManifest ? { authorityManifest } : {}),
+      launchOptionsResolved: true,
+      machineId,
+      daemonGeneration: generationRecord.daemonGeneration
+    });
     let runtime: ReturnType<typeof createMultiRepoDaemonRuntime> | undefined;
     let serviceHost: Awaited<ReturnType<typeof createDaemonServiceHost<Command, Result, Identity, PresentedControlError>>> | undefined;
     let lifecycleStarted = false;
@@ -127,7 +137,9 @@ export async function runDaemonServe<
           loadedIdentity: loadedBuild.identity,
           startedAt,
           launchConfiguration,
-          preflightReplacement: input.preflightReplacement
+          preflightReplacement: input.preflightReplacement,
+          machineId,
+          daemonGeneration: generationRecord.daemonGeneration
         },
         serviceHostServices,
         authorityLifecycle,

--- a/packages/daemon/src/protocol/daemon-control-request.ts
+++ b/packages/daemon/src/protocol/daemon-control-request.ts
@@ -20,11 +20,11 @@ export function daemonControlRequest(
   }
   if (payload.daemonGeneration !== undefined
     && (!Number.isSafeInteger(payload.daemonGeneration) || Number(payload.daemonGeneration) < 1)) {
-    return { ok: false, code: "daemon_control_unavailable", hint: `${method} requires payload.daemonGeneration to be a positive safe integer.` };
+    return { ok: false, code: "daemon_control_unavailable", hint: `${method} requires payload.daemonGeneration to be a positive safe integer. Read the current value from \`ha daemon status --json --include-generation-axes\`, or omit the field to use legacy control.` };
   }
   if (payload.connectionId !== undefined
     && (typeof payload.connectionId !== "string" || payload.connectionId.length === 0)) {
-    return { ok: false, code: "daemon_control_unavailable", hint: `${method} requires payload.connectionId to be a non-empty string.` };
+    return { ok: false, code: "daemon_control_unavailable", hint: `${method} requires payload.connectionId to be a non-empty string. Reuse the connectionId from your accepted connection, or omit the field to use legacy control.` };
   }
   return {
     ok: true,

--- a/packages/daemon/src/protocol/daemon-control-request.ts
+++ b/packages/daemon/src/protocol/daemon-control-request.ts
@@ -18,12 +18,22 @@ export function daemonControlRequest(
     && payload.trigger !== "dist-watcher") {
     return { ok: false, code: "daemon_control_unavailable", hint: `${method} requires payload.trigger explicit|post-merge|dist-watcher. Retry with \`ha daemon refresh --trigger explicit\`.` };
   }
+  if (payload.daemonGeneration !== undefined
+    && (!Number.isSafeInteger(payload.daemonGeneration) || Number(payload.daemonGeneration) < 1)) {
+    return { ok: false, code: "daemon_control_unavailable", hint: `${method} requires payload.daemonGeneration to be a positive safe integer.` };
+  }
+  if (payload.connectionId !== undefined
+    && (typeof payload.connectionId !== "string" || payload.connectionId.length === 0)) {
+    return { ok: false, code: "daemon_control_unavailable", hint: `${method} requires payload.connectionId to be a non-empty string.` };
+  }
   return {
     ok: true,
     value: {
       reason: payload.reason,
       drainTimeoutMs: Number(payload.drainTimeoutMs),
-      ...(method === "admin.daemon.refresh" ? { trigger: payload.trigger as DaemonControlRequestV1["trigger"] } : {})
+      ...(method === "admin.daemon.refresh" ? { trigger: payload.trigger as DaemonControlRequestV1["trigger"] } : {}),
+      ...(payload.daemonGeneration !== undefined ? { daemonGeneration: Number(payload.daemonGeneration) } : {}),
+      ...(payload.connectionId !== undefined ? { connectionId: payload.connectionId as string } : {})
     }
   };
 }

--- a/packages/daemon/src/protocol/daemon-status-validation.ts
+++ b/packages/daemon/src/protocol/daemon-status-validation.ts
@@ -2,13 +2,14 @@ import {
   decodeDaemonStatusRequestV2,
   decodeDaemonStatusResultV2
 } from "@harness-anything/application";
+import type { DaemonStatusRequestV2 } from "@harness-anything/application";
 import type { JsonObject } from "./json-rpc-types.ts";
 
 import { failureReceipt } from "./receipt-envelope.ts";
 
 /** Runtime codecs used by the JSON-RPC handler before it emits a success receipt. */
-export function validateDaemonStatusRequest(params: JsonObject): void {
-  decodeDaemonStatusRequestV2(params);
+export function validateDaemonStatusRequest(params: JsonObject): DaemonStatusRequestV2 {
+  return decodeDaemonStatusRequestV2(params);
 }
 
 export function validateDaemonStatusResult(status: unknown): JsonObject {

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -351,8 +351,14 @@ async function callServiceMethod(
       return failureReceipt(contract.method, "daemon_status_service_unavailable", "Daemon status service is not configured.");
     }
     try {
-      validateDaemonStatusRequest(params);
-      const status = validateDaemonStatusResult(await services.DaemonStatusService.getStatus(repo ? { repo } : undefined));
+      const request = validateDaemonStatusRequest(params);
+      const produced = await services.DaemonStatusService.getStatus(repo ? {
+        repo,
+        ...(request.includeGenerationAxes ? { includeGenerationAxes: true as const } : {})
+      } : undefined);
+      const status = validateDaemonStatusResult(request.includeGenerationAxes && options.acceptedConnection
+        ? { ...produced, connectionId: options.acceptedConnection.connectionId }
+        : produced);
       return successReceipt(contract.method, "read daemon status", status);
     } catch (error) {
       return daemonStatusValidationFailure(contract.method, error);

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -85,7 +85,7 @@ export interface DaemonServiceHost {
   readonly DaemonLogService?: DaemonLogService;
   readonly DaemonControlService?: DaemonControlService;
   readonly DaemonLaunchSpecService?: {
-    readonly getLaunchSpec: () => JsonObject | Promise<JsonObject>;
+    readonly getLaunchSpec: (capability?: { readonly includeGenerationAxes?: true }) => JsonObject | Promise<JsonObject>;
   };
   readonly CliCommandService?: {
     readonly runCommand: (payload?: JsonObject, context?: {
@@ -495,7 +495,13 @@ async function handleAdminMethod(
     if (!options.services.DaemonLaunchSpecService) {
       return failureReceipt(contract.method, "daemon_launch_spec_unavailable", "The running daemon predates the launch-spec protocol and cannot describe a safe replacement configuration. Leave it running until you can manually restart with `ha daemon stop && ha daemon start --service --authority-manifest <path>`.");
     }
-    return successReceipt(contract.method, "read daemon launch specification", await options.services.DaemonLaunchSpecService.getLaunchSpec());
+    return successReceipt(
+      contract.method,
+      "read daemon launch specification",
+      await options.services.DaemonLaunchSpecService.getLaunchSpec(params.includeGenerationAxes === true
+        ? { includeGenerationAxes: true }
+        : undefined)
+    );
   }
   if (contract.method === "admin.daemon.restart" || contract.method === "admin.daemon.refresh") {
     if (!options.services.DaemonControlService) {

--- a/packages/daemon/src/service/service-host.ts
+++ b/packages/daemon/src/service/service-host.ts
@@ -10,7 +10,7 @@ import { createPtyTerminalSessionService } from "../terminal/pty-host.ts";
 import type { AcceptedConnectionBinding } from "../protocol/connection-context.ts";
 import type { AuthorityWireIngressHandler } from "../transport/authority-wire-ingress.ts";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
-import type { JsonRpcNotification } from "../protocol/json-rpc-types.ts";
+import type { JsonObject, JsonRpcNotification } from "../protocol/json-rpc-types.ts";
 import type { DaemonRepoAvailabilityFailure, DaemonRepoNamespace } from "../protocol/json-rpc-server.ts";
 import type { AuthorityRepoComponent, AuthorityRepoLifecycleController } from "../authority/authority-lifecycle.ts";
 import type { AuthenticatedActor, IdentityAdminSnapshot, IdentityProvider, PersonRegistry } from "../identity/types.ts";
@@ -39,6 +39,7 @@ import { createDaemonReconcileState, reconcileDaemonRepoRegistry, type DaemonRec
 import { createAuthorityWireIngressHandler } from "../authority/authority-wire-service.ts";
 import { requireAuthoritySubmissionForDispatch } from "../authority/authority-submission-dispatch.ts";
 import { daemonStatusPayload, type DaemonConnectionStats } from "./status-payload.ts";
+import { projectDaemonLaunchConfiguration } from "../client/local-json-rpc-client.ts";
 
 export type DaemonServiceStopRequest =
   | { readonly reason: "idle-timeout" }
@@ -487,16 +488,10 @@ function createRepoServiceBinding<
       ...(statusOptions?.controlService ? { DaemonControlService: statusOptions.controlService } : {}),
       ...(statusOptions?.build?.launchConfiguration ? {
         DaemonLaunchSpecService: {
-          getLaunchSpec: () => ({
-            execPath: statusOptions.build!.launchConfiguration!.execPath,
-            execArgv: [...statusOptions.build!.launchConfiguration!.execArgv],
-            entrypoint: statusOptions.build!.launchConfiguration!.entrypoint,
-            args: [...statusOptions.build!.launchConfiguration!.args],
-            ...(statusOptions.build!.launchConfiguration!.machineId !== undefined
-              ? { machineId: statusOptions.build!.launchConfiguration!.machineId } : {}),
-            ...(statusOptions.build!.launchConfiguration!.daemonGeneration !== undefined
-              ? { daemonGeneration: statusOptions.build!.launchConfiguration!.daemonGeneration } : {})
-          })
+          getLaunchSpec: (capability) => projectDaemonLaunchConfiguration(
+            statusOptions.build!.launchConfiguration!,
+            capability?.includeGenerationAxes === true
+          ) as unknown as JsonObject
         }
       } : {}),
       CliCommandService: daemonCommandService,

--- a/packages/daemon/src/service/service-host.ts
+++ b/packages/daemon/src/service/service-host.ts
@@ -82,6 +82,8 @@ export async function createDaemonServiceHost<
     readonly startedAt: string;
     readonly launchConfiguration: DaemonLaunchConfiguration;
     readonly preflightReplacement: (configuration: DaemonLaunchConfiguration) => Promise<void>;
+    readonly machineId?: string;
+    readonly daemonGeneration?: number;
   },
   hostServices: DaemonServiceHostServices<Command, Result, AuthenticatedActor, HarnessDaemonRuntime, Identity, PresentedControlError>,
   authorityLifecycle?: AuthorityRepoLifecycleController,
@@ -343,7 +345,7 @@ export async function createDaemonServiceHost<
     }, reconcileState);
   }
 
-  function serviceStatus(repoId: string): DaemonStatusResultV2 {
+  function serviceStatus(repoId: string, includeGenerationAxes = false): DaemonStatusResultV2 {
     const target = reposById.get(repoId) ?? defaultRepoBinding().repo;
     return daemonStatusPayload({
       daemonId,
@@ -358,7 +360,11 @@ export async function createDaemonServiceHost<
       activeControl,
       runtimeStatus: runtime.status(),
       connections,
-      reconcileStatus: reconcileState
+      reconcileStatus: reconcileState,
+      ...(build.machineId !== undefined && build.daemonGeneration !== undefined ? {
+        generationAxes: { machineId: build.machineId, daemonGeneration: build.daemonGeneration }
+      } : {}),
+      ...(includeGenerationAxes ? { includeGenerationAxes: true as const } : {})
     });
   }
 }
@@ -388,6 +394,8 @@ function createRepoServiceBinding<
       readonly loadedIdentity: string;
       readonly startedAt: string;
       readonly launchConfiguration?: DaemonLaunchConfiguration;
+      readonly machineId?: string;
+      readonly daemonGeneration?: number;
     };
     readonly controlService?: DaemonControlService;
     readonly daemonLogService?: DaemonLogService;
@@ -465,6 +473,13 @@ function createRepoServiceBinding<
             activeControl: statusOptions?.activeControl?.() ?? null,
             runtimeStatus: managerRuntime.status(),
             connections: statusOptions?.connections ?? { active: 0, total: 0 },
+            ...(statusOptions?.build?.machineId !== undefined && statusOptions.build.daemonGeneration !== undefined ? {
+              generationAxes: {
+                machineId: statusOptions.build.machineId,
+                daemonGeneration: statusOptions.build.daemonGeneration
+              }
+            } : {}),
+            ...(context?.includeGenerationAxes ? { includeGenerationAxes: true as const } : {}),
             ...(statusOptions?.reconcileStatus ? { reconcileStatus: statusOptions.reconcileStatus } : {})
           });
         }
@@ -476,7 +491,11 @@ function createRepoServiceBinding<
             execPath: statusOptions.build!.launchConfiguration!.execPath,
             execArgv: [...statusOptions.build!.launchConfiguration!.execArgv],
             entrypoint: statusOptions.build!.launchConfiguration!.entrypoint,
-            args: [...statusOptions.build!.launchConfiguration!.args]
+            args: [...statusOptions.build!.launchConfiguration!.args],
+            ...(statusOptions.build!.launchConfiguration!.machineId !== undefined
+              ? { machineId: statusOptions.build!.launchConfiguration!.machineId } : {}),
+            ...(statusOptions.build!.launchConfiguration!.daemonGeneration !== undefined
+              ? { daemonGeneration: statusOptions.build!.launchConfiguration!.daemonGeneration } : {})
           })
         }
       } : {}),

--- a/packages/daemon/src/service/status-payload.ts
+++ b/packages/daemon/src/service/status-payload.ts
@@ -131,7 +131,7 @@ export function daemonStatusPayload(input: {
       unavailableCount: repos.filter((repo) => repo.state === "unavailable").length,
       lastReconcileAt: input.reconcileStatus?.lastReconcileAt ?? null,
       lastReconcileError: reconcileErrorPayload(input.reconcileStatus?.lastReconcileError ?? null),
-      activeControl: input.activeControl,
+      activeControl: projectActiveControl(input.activeControl, input.includeGenerationAxes === true),
       ...(input.includeGenerationAxes && input.generationAxes ? {
         machineId: input.generationAxes.machineId,
         daemonGeneration: input.generationAxes.daemonGeneration
@@ -140,6 +140,16 @@ export function daemonStatusPayload(input: {
     requestedRepo: selectedRepo,
     repos
   };
+}
+
+function projectActiveControl(
+  activeControl: DaemonActiveControlStatus | null,
+  includeGenerationAxes: boolean
+): DaemonActiveControlStatus | null {
+  if (!activeControl || includeGenerationAxes
+    || (activeControl.machineId === undefined && activeControl.daemonGeneration === undefined)) return activeControl;
+  const { machineId: _machineId, daemonGeneration: _daemonGeneration, ...legacy } = activeControl;
+  return legacy;
 }
 
 function repoStatus(

--- a/packages/daemon/src/service/status-payload.ts
+++ b/packages/daemon/src/service/status-payload.ts
@@ -32,6 +32,8 @@ export interface DaemonStatusRuntimeRepo {
   readonly lastError?: string;
   readonly lastMaterializerError?: string;
   readonly projectionGeneration?: unknown;
+  readonly runtimeRegistrationId?: string;
+  readonly daemonGeneration?: number;
 }
 
 const emptyDaemonQueue = { interactive: 0, normal: 0, background: 0, maintenance: 0, running: false } as const;
@@ -67,10 +69,12 @@ export function daemonStatusPayload(input: {
     readonly repos?: ReadonlyArray<DaemonStatusRuntimeRepo>;
   };
   readonly connections: DaemonConnectionStats;
+  readonly generationAxes?: { readonly machineId: string; readonly daemonGeneration: number };
+  readonly includeGenerationAxes?: true;
   readonly reconcileStatus?: Pick<DaemonReconcileState, "lastReconcileAt" | "lastReconcileError" | "repoErrors">;
 }): DaemonStatusResultV2 {
   const runtimeRepos = input.runtimeStatus.repos ?? [];
-  const repos = runtimeRepos.map((repo) => repoStatus(repo, input.reconcileStatus));
+  const repos = runtimeRepos.map((repo) => repoStatus(repo, input.reconcileStatus, input));
   const selectedRepo = repos.find((repo) => repo.repoId === input.repoId) ?? repoStatus({
     repoId: input.repoId,
     canonicalRoot: input.rootDir,
@@ -79,7 +83,7 @@ export function daemonStatusPayload(input: {
     lockOwnerToken: input.runtimeStatus.lockOwnerToken,
     queue: input.runtimeStatus.queue ?? emptyDaemonQueue,
     lastRecovery: input.runtimeStatus.lastRecovery
-  }, input.reconcileStatus);
+  }, input.reconcileStatus, input);
   const aggregateQueue = aggregateQueues(repos.length > 0 ? repos.map((repo) => repo.queue) : [selectedRepo.queue]);
   const installedIdentity = input.readInstalledIdentity();
   return {
@@ -127,7 +131,11 @@ export function daemonStatusPayload(input: {
       unavailableCount: repos.filter((repo) => repo.state === "unavailable").length,
       lastReconcileAt: input.reconcileStatus?.lastReconcileAt ?? null,
       lastReconcileError: reconcileErrorPayload(input.reconcileStatus?.lastReconcileError ?? null),
-      activeControl: input.activeControl
+      activeControl: input.activeControl,
+      ...(input.includeGenerationAxes && input.generationAxes ? {
+        machineId: input.generationAxes.machineId,
+        daemonGeneration: input.generationAxes.daemonGeneration
+      } : {})
     },
     requestedRepo: selectedRepo,
     repos
@@ -136,7 +144,11 @@ export function daemonStatusPayload(input: {
 
 function repoStatus(
   repo: DaemonStatusRuntimeRepo,
-  reconcileStatus: Pick<DaemonReconcileState, "lastReconcileAt" | "lastReconcileError" | "repoErrors"> | undefined
+  reconcileStatus: Pick<DaemonReconcileState, "lastReconcileAt" | "lastReconcileError" | "repoErrors"> | undefined,
+  projection: {
+    readonly includeGenerationAxes?: true;
+    readonly generationAxes?: { readonly daemonGeneration: number };
+  }
 ): DaemonRepoStatus {
   const state = repo.state === "attached" || repo.state === "unavailable" || repo.state === "detaching" || repo.state === "detached"
     ? repo.state
@@ -152,7 +164,11 @@ function repoStatus(
     projectionGeneration: toStatusJsonValue(repo.projectionGeneration ?? null),
     lastError: repo.lastError ?? null,
     lastMaterializerError: repo.lastMaterializerError ?? null,
-    lastReconcileError: reconcileErrorPayload(reconcileStatus?.repoErrors.get(repo.repoId) ?? null)
+    lastReconcileError: reconcileErrorPayload(reconcileStatus?.repoErrors.get(repo.repoId) ?? null),
+    ...(projection.includeGenerationAxes && repo.runtimeRegistrationId !== undefined
+      ? { runtimeRegistrationId: repo.runtimeRegistrationId } : {}),
+    ...(projection.includeGenerationAxes && (repo.daemonGeneration ?? projection.generationAxes?.daemonGeneration) !== undefined
+      ? { daemonGeneration: (repo.daemonGeneration ?? projection.generationAxes?.daemonGeneration)! } : {})
   };
 }
 

--- a/packages/daemon/test/daemon-generation.test.ts
+++ b/packages/daemon/test/daemon-generation.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   daemonGenerationRecordPath,
   daemonMachineIdPath,
+  prepareDaemonGenerationForServe,
   publishNextDaemonGeneration,
   readOrCreateDaemonMachineId
 } from "../src/index.ts";
@@ -105,6 +106,29 @@ test("Windows fails closed before publishing machine identity or daemon generati
       /DAEMON_GENERATION_DURABILITY_UNSUPPORTED/u
     );
     assert.equal(existsSync(generationPath), false);
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("Windows daemon startup degrades to legacy generation mode without throwing or publishing", () => {
+  const userRoot = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-start-win32-"));
+  try {
+    let preparation: ReturnType<typeof prepareDaemonGenerationForServe> | undefined;
+    assert.doesNotThrow(() => {
+      preparation = prepareDaemonGenerationForServe({
+        userRoot,
+        endpointIdentity: "pipe:daemon",
+        daemonInstanceId: "daemon-a",
+        platform: "win32"
+      });
+    });
+    assert.deepEqual(preparation, {
+      mode: "legacy",
+      diagnostic: "DAEMON_GENERATION_DURABILITY_UNSUPPORTED"
+    });
+    assert.equal(existsSync(daemonMachineIdPath(userRoot)), false);
+    assert.equal(existsSync(daemonGenerationRecordPath(userRoot, "pipe:daemon")), false);
   } finally {
     rmSync(userRoot, { recursive: true, force: true });
   }

--- a/packages/daemon/test/daemon-generation.test.ts
+++ b/packages/daemon/test/daemon-generation.test.ts
@@ -1,0 +1,85 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  daemonGenerationRecordPath,
+  daemonMachineIdPath,
+  publishNextDaemonGeneration,
+  readOrCreateDaemonMachineId
+} from "../src/index.ts";
+
+test("machine identity is stable within one installation root and isolated across roots", () => {
+  const parent = mkdtempSync(path.join(os.tmpdir(), "ha-machine-id-"));
+  try {
+    const firstRoot = path.join(parent, "first");
+    const secondRoot = path.join(parent, "second");
+    const first = readOrCreateDaemonMachineId(firstRoot);
+    assert.equal(readOrCreateDaemonMachineId(firstRoot), first);
+    assert.notEqual(readOrCreateDaemonMachineId(secondRoot), first);
+    assert.equal(readFileSync(daemonMachineIdPath(firstRoot), "utf8"), `${first}\n`);
+    if (process.platform !== "win32") assert.equal(statSync(daemonMachineIdPath(firstRoot)).mode & 0o777, 0o600);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("generation publication is durable, endpoint-scoped, and strictly increasing", () => {
+  const userRoot = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-generation-"));
+  try {
+    const machineId = readOrCreateDaemonMachineId(userRoot);
+    const first = publishNextDaemonGeneration({
+      userRoot,
+      endpointIdentity: "/tmp/a.sock",
+      machineId,
+      daemonInstanceId: "daemon-a",
+      now: () => new Date("2026-07-21T00:00:00.000Z")
+    });
+    const second = publishNextDaemonGeneration({
+      userRoot,
+      endpointIdentity: "/tmp/a.sock",
+      machineId,
+      daemonInstanceId: "daemon-b",
+      now: () => new Date("2026-07-21T00:00:01.000Z")
+    });
+    const independent = publishNextDaemonGeneration({
+      userRoot,
+      endpointIdentity: "/tmp/b.sock",
+      machineId,
+      daemonInstanceId: "daemon-c"
+    });
+    assert.equal(first.daemonGeneration, 1);
+    assert.equal(second.daemonGeneration, 2);
+    assert.equal(independent.daemonGeneration, 1);
+    assert.deepEqual(JSON.parse(readFileSync(daemonGenerationRecordPath(userRoot, "/tmp/a.sock"), "utf8")), second);
+    if (process.platform !== "win32") {
+      assert.equal(statSync(daemonGenerationRecordPath(userRoot, "/tmp/a.sock")).mode & 0o777, 0o600);
+    }
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("generation publication fails closed on corrupt or exhausted state", () => {
+  const userRoot = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-generation-corrupt-"));
+  const endpointIdentity = "/tmp/a.sock";
+  try {
+    const machineId = readOrCreateDaemonMachineId(userRoot);
+    const target = daemonGenerationRecordPath(userRoot, endpointIdentity);
+    writeFileSync(target, "{}\n", "utf8");
+    assert.throws(() => publishNextDaemonGeneration({ userRoot, endpointIdentity, machineId, daemonInstanceId: "daemon" }), /invalid daemon generation record/u);
+    writeFileSync(target, `${JSON.stringify({
+      schema: "daemon-generation-record/v1",
+      machineId,
+      endpointIdentity,
+      daemonGeneration: Number.MAX_SAFE_INTEGER,
+      daemonInstanceId: "daemon",
+      publishedAt: "2026-07-21T00:00:00.000Z"
+    })}\n`, "utf8");
+    assert.throws(() => publishNextDaemonGeneration({ userRoot, endpointIdentity, machineId, daemonInstanceId: "daemon" }), /space exhausted/u);
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/daemon/test/daemon-generation.test.ts
+++ b/packages/daemon/test/daemon-generation.test.ts
@@ -12,7 +12,9 @@ import {
   readOrCreateDaemonMachineId
 } from "../src/index.ts";
 
-test("machine identity is stable within one installation root and isolated across roots", () => {
+test("machine identity is stable within one installation root and isolated across roots", {
+  skip: process.platform === "win32" ? "durable generation publication is unsupported on Windows" : false
+}, () => {
   const parent = mkdtempSync(path.join(os.tmpdir(), "ha-machine-id-"));
   try {
     const firstRoot = path.join(parent, "first");
@@ -27,7 +29,9 @@ test("machine identity is stable within one installation root and isolated acros
   }
 });
 
-test("generation publication is durable, endpoint-scoped, and strictly increasing", () => {
+test("generation publication is durable, endpoint-scoped, and strictly increasing", {
+  skip: process.platform === "win32" ? "durable generation publication is unsupported on Windows" : false
+}, () => {
   const userRoot = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-generation-"));
   try {
     const machineId = readOrCreateDaemonMachineId(userRoot);
@@ -63,7 +67,9 @@ test("generation publication is durable, endpoint-scoped, and strictly increasin
   }
 });
 
-test("generation publication fails closed on corrupt or exhausted state", () => {
+test("generation publication fails closed on corrupt or exhausted state", {
+  skip: process.platform === "win32" ? "durable generation publication is unsupported on Windows" : false
+}, () => {
   const userRoot = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-generation-corrupt-"));
   const endpointIdentity = "/tmp/a.sock";
   try {

--- a/packages/daemon/test/daemon-generation.test.ts
+++ b/packages/daemon/test/daemon-generation.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -79,6 +79,32 @@ test("generation publication fails closed on corrupt or exhausted state", () => 
       publishedAt: "2026-07-21T00:00:00.000Z"
     })}\n`, "utf8");
     assert.throws(() => publishNextDaemonGeneration({ userRoot, endpointIdentity, machineId, daemonInstanceId: "daemon" }), /space exhausted/u);
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("Windows fails closed before publishing machine identity or daemon generation", () => {
+  const userRoot = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-generation-win32-"));
+  const machinePath = daemonMachineIdPath(userRoot);
+  const generationPath = daemonGenerationRecordPath(userRoot, "pipe:daemon");
+  try {
+    assert.throws(
+      () => readOrCreateDaemonMachineId(userRoot, "win32"),
+      /DAEMON_GENERATION_DURABILITY_UNSUPPORTED/u
+    );
+    assert.equal(existsSync(machinePath), false);
+    assert.throws(
+      () => publishNextDaemonGeneration({
+        userRoot,
+        endpointIdentity: "pipe:daemon",
+        machineId: "machine-a",
+        daemonInstanceId: "daemon-a",
+        platform: "win32"
+      }),
+      /DAEMON_GENERATION_DURABILITY_UNSUPPORTED/u
+    );
+    assert.equal(existsSync(generationPath), false);
   } finally {
     rmSync(userRoot, { recursive: true, force: true });
   }

--- a/packages/daemon/test/daemon-launch-projection.test.ts
+++ b/packages/daemon/test/daemon-launch-projection.test.ts
@@ -1,0 +1,134 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { DaemonActiveControlStatus, DaemonStatusResultV2 } from "../../application/src/index.ts";
+import { createDaemonControlService, type DaemonLaunchConfiguration } from "../src/index.ts";
+
+const launchConfiguration: DaemonLaunchConfiguration = {
+  execPath: "/current/node",
+  execArgv: ["--enable-source-maps"],
+  entrypoint: "/current/ha.js",
+  args: ["daemon", "serve"],
+  machineId: "machine-installation-a",
+  daemonGeneration: 5
+};
+
+test("control producer keeps legacy launch configuration bytes and gates generation axes", async () => {
+  const legacy = await control().requestControl("restart", {
+    reason: "legacy client",
+    drainTimeoutMs: 5_000
+  });
+  assert.equal(legacy.ok, true);
+  if (!legacy.ok) return;
+  const legacyBefore = legacy.accepted.before as unknown as Record<string, unknown>;
+  const actual = Buffer.from(JSON.stringify(legacyBefore.launchConfiguration));
+  const expected = Buffer.from(JSON.stringify({
+    execPath: launchConfiguration.execPath,
+    execArgv: launchConfiguration.execArgv,
+    entrypoint: launchConfiguration.entrypoint,
+    args: launchConfiguration.args
+  }));
+  assert.equal(actual.equals(expected), true, "legacy control producer leaked launch generation axes");
+  assert.equal("daemonGeneration" in legacy.accepted, false);
+
+  const capable = await control().requestControl("restart", {
+    reason: "generation-aware client",
+    drainTimeoutMs: 5_000,
+    daemonGeneration: 5
+  });
+  assert.equal(capable.ok, true);
+  if (!capable.ok) return;
+  const capableBefore = capable.accepted.before as unknown as Record<string, unknown>;
+  const capableLaunch = capableBefore.launchConfiguration as Record<string, unknown>;
+  assert.equal(capable.accepted.daemonGeneration, 5);
+  assert.equal(capableLaunch.machineId, "machine-installation-a");
+  assert.equal(capableLaunch.daemonGeneration, 5);
+});
+
+function control() {
+  let active: DaemonActiveControlStatus | null = null;
+  return createDaemonControlService({
+    launchConfiguration,
+    preflightReplacement: async () => undefined,
+    status: statusFixture,
+    activeControl: () => active,
+    setActiveControl: (value) => { active = value; },
+    setDrainTimeout: () => undefined,
+    requestStop: () => undefined
+  }, {
+    present: (error) => ({ code: error.code, hint: error.code })
+  });
+}
+
+function statusFixture(): DaemonStatusResultV2 {
+  return {
+    schema: "daemon-status/v2",
+    daemonId: "daemon-a",
+    pid: 41,
+    started: true,
+    rootDir: "/repo",
+    repoId: "canonical",
+    endpoint: "/tmp/daemon.sock",
+    version: "0.1.0",
+    protocolVersion: 1,
+    queue: queue(),
+    queueDepth: 0,
+    connections: { active: 1, total: 1 },
+    lastReconcileAt: null,
+    lastReconcileError: null,
+    lastRecovery: null,
+    projectionGeneration: null,
+    service: {
+      daemonId: "daemon-a",
+      pid: 41,
+      endpoint: "/tmp/daemon.sock",
+      userRoot: "/user",
+      started: true,
+      startedAt: "2026-07-21T00:00:00.000Z",
+      uptimeMs: 1,
+      build: {
+        version: "0.1.0",
+        loadedIdentity: "sha256:a",
+        installedIdentity: "sha256:a",
+        identitySource: "installed-artifact-set",
+        stale: false
+      },
+      queue: queue(),
+      connections: { active: 1, total: 1 },
+      repoCount: 1,
+      attachedCount: 1,
+      unavailableCount: 0,
+      lastReconcileAt: null,
+      lastReconcileError: null,
+      activeControl: null
+    },
+    requestedRepo: repo(),
+    repos: [repo()]
+  };
+}
+
+function queue() {
+  return {
+    interactive: 0,
+    normal: 0,
+    background: 0,
+    maintenance: 0,
+    running: false,
+    depth: 0
+  };
+}
+
+function repo() {
+  return {
+    repoId: "canonical",
+    canonicalRoot: "/repo",
+    state: "attached" as const,
+    lock: { path: null, ownerToken: null },
+    queue: queue(),
+    lastRecovery: null,
+    projectionGeneration: null,
+    lastError: null,
+    lastMaterializerError: null,
+    lastReconcileError: null
+  };
+}

--- a/packages/daemon/test/daemon-status-contract.test.ts
+++ b/packages/daemon/test/daemon-status-contract.test.ts
@@ -240,3 +240,54 @@ test("daemon status generation capability preserves legacy bytes and validates t
   };
   assert.doesNotThrow(() => decodeDaemonStatusResultV2(full));
 });
+
+test("generation-aware control remains byte-identical for a legacy status request", () => {
+  const common = {
+    daemonId: "daemon-test",
+    rootDir: "/repo/alpha",
+    repoId: "alpha",
+    endpoint: "/user/daemon.sock",
+    userRoot: "/user",
+    startedAt: "2999-01-01T00:00:00.000Z",
+    loadedIdentity: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    version: "0.1.0-test",
+    readInstalledIdentity: () => "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    runtimeStatus: {
+      started: true,
+      repos: [{
+        repoId: "alpha",
+        canonicalRoot: "/repo/alpha",
+        state: "attached",
+        queue: { interactive: 0, normal: 0, background: 0, maintenance: 0, running: false }
+      }]
+    },
+    connections: { active: 1, total: 1 }
+  } as const;
+  const legacyControl = {
+    operationId: "control-a",
+    kind: "refresh",
+    phase: "accepted",
+    requestedAt: "2026-07-21T00:00:00.000Z"
+  } as const;
+  const expected = Buffer.from(JSON.stringify(daemonStatusPayload({
+    ...common,
+    activeControl: legacyControl
+  })));
+  const actual = Buffer.from(JSON.stringify(daemonStatusPayload({
+    ...common,
+    activeControl: {
+      ...legacyControl,
+      machineId: "machine-installation-a",
+      daemonGeneration: 4
+    }
+  })));
+  assert.equal(actual.equals(expected), true, "legacy status producer leaked control generation axes");
+
+  const capable = daemonStatusPayload({
+    ...common,
+    activeControl: { ...legacyControl, machineId: "machine-installation-a", daemonGeneration: 4 },
+    generationAxes: { machineId: "machine-installation-a", daemonGeneration: 4 },
+    includeGenerationAxes: true
+  });
+  assert.equal(capable.service.activeControl?.daemonGeneration, 4);
+});

--- a/packages/daemon/test/daemon-status-contract.test.ts
+++ b/packages/daemon/test/daemon-status-contract.test.ts
@@ -199,3 +199,44 @@ test("daemon status v2 schema fixtures prove request and result boundaries", () 
     assert.throws(() => decode(JSON.parse(readFileSync(path.join(fixtureRoot, fixture, "invalid.json"), "utf8"))), fixture);
   }
 });
+
+test("daemon status generation capability preserves legacy bytes and validates the full projection", () => {
+  const fixturePath = path.resolve("packages/daemon/fixtures/api-schemas/daemon.status-result__v2/valid.json");
+  const legacy = JSON.parse(readFileSync(fixturePath, "utf8")) as DaemonStatusResultV2;
+  const before = Buffer.from(JSON.stringify(legacy));
+  assert.doesNotThrow(() => decodeDaemonStatusResultV2(legacy));
+  const after = Buffer.from(JSON.stringify(legacy));
+  assert.equal(after.equals(before), true, "legacy daemon status fixture bytes drifted");
+
+  assert.deepEqual(decodeDaemonStatusRequestV2({ repo: { repoId: "canonical" } }), {
+    repo: { repoId: "canonical" }
+  });
+  assert.deepEqual(decodeDaemonStatusRequestV2({
+    repo: { repoId: "canonical" },
+    includeGenerationAxes: true
+  }), {
+    repo: { repoId: "canonical" },
+    includeGenerationAxes: true
+  });
+  assert.throws(() => decodeDaemonStatusRequestV2({
+    repo: { repoId: "canonical" },
+    includeGenerationAxes: false
+  }));
+
+  const full: DaemonStatusResultV2 = {
+    ...legacy,
+    connectionId: "connection-a",
+    service: {
+      ...legacy.service,
+      machineId: "machine-installation-a",
+      daemonGeneration: 3
+    },
+    requestedRepo: {
+      ...legacy.requestedRepo,
+      runtimeRegistrationId: "runtime-a",
+      daemonGeneration: 3
+    },
+    repos: legacy.repos.map((repo) => ({ ...repo, daemonGeneration: 3 }))
+  };
+  assert.doesNotThrow(() => decodeDaemonStatusResultV2(full));
+});

--- a/packages/kernel/src/local/local-layout-file-system.ts
+++ b/packages/kernel/src/local/local-layout-file-system.ts
@@ -70,7 +70,7 @@ export const localRuntimeStateFileSystem = {
     try {
       descriptor = openSync(inputPath, "wx");
     } catch (error) {
-      if (isExclusiveCreateConflict(error)) return false;
+      if (isExclusiveCreateConflict(error, inputPath)) return false;
       throw error;
     }
     try {
@@ -89,6 +89,23 @@ export const localRuntimeStateFileSystem = {
   writeText: (inputPath: string, value: string) => writeFileSync(inputPath, value, "utf8")
 };
 
-function isExclusiveCreateConflict(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
+export function isExclusiveCreateConflict(
+  error: unknown,
+  inputPath: string,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  const code = nodeErrorCode(error);
+  return code === "EEXIST" || (platform === "win32" && code === "EPERM" && existsSync(inputPath));
+}
+
+export function isConcurrentRenameLoss(
+  error: unknown,
+  sourcePath: string,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  return platform === "win32" && nodeErrorCode(error) === "EPERM" && !existsSync(sourcePath);
+}
+
+function nodeErrorCode(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
 }

--- a/packages/kernel/src/local/task-holder-state.ts
+++ b/packages/kernel/src/local/task-holder-state.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import { hostname } from "node:os";
 import path from "node:path";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
-import { localRuntimeStateFileSystem } from "./local-layout-file-system.ts";
+import { isConcurrentRenameLoss, localRuntimeStateFileSystem } from "./local-layout-file-system.ts";
 import { listExecutionLeaseRefs } from "./task-holder-state-source.ts";
 import { hashExecutionLeaseToken, leaseDurationMs, renewExecutionLeaseCredential, requireExecutionCredential,
   sameExecutionLeaseActor, sameTaskHolderPrincipal } from "./execution-lease-credential.ts";
@@ -511,7 +511,7 @@ function recoverAbandonedTaskHolderMutationLock(lockPath: string): void {
     localRuntimeStateFileSystem.rename(lockPath, quarantinePath);
     localRuntimeStateFileSystem.remove(quarantinePath);
   } catch (error) {
-    if (!isMissingFileError(error)) throw error;
+    if (!isMissingFileError(error) && !isConcurrentRenameLoss(error, lockPath)) throw error;
   }
 }
 

--- a/packages/kernel/test/local-runtime-state-file-system.test.ts
+++ b/packages/kernel/test/local-runtime-state-file-system.test.ts
@@ -1,0 +1,32 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  isConcurrentRenameLoss,
+  isExclusiveCreateConflict
+} from "../src/local/local-layout-file-system.ts";
+
+test("Windows classifies only observed EPERM path races as runtime-state contention", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "ha-runtime-state-race-"));
+  const existing = path.join(root, "existing.lock");
+  const missing = path.join(root, "missing.lock");
+  writeFileSync(existing, "holder", "utf8");
+  try {
+    const eperm = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+    const exists = Object.assign(new Error("already exists"), { code: "EEXIST" });
+
+    assert.equal(isExclusiveCreateConflict(eperm, existing, "win32"), true);
+    assert.equal(isExclusiveCreateConflict(eperm, missing, "win32"), false);
+    assert.equal(isExclusiveCreateConflict(eperm, existing, "linux"), false);
+    assert.equal(isExclusiveCreateConflict(exists, missing, "linux"), true);
+
+    assert.equal(isConcurrentRenameLoss(eperm, missing, "win32"), true);
+    assert.equal(isConcurrentRenameLoss(eperm, existing, "win32"), false);
+    assert.equal(isConcurrentRenameLoss(eperm, missing, "linux"), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -1203,6 +1203,98 @@
         "ref": "task_01KXW7ZNZ2218R9SWYPGVMAFN3",
         "reason": "Daemon-owned terminal session persistence; stores local terminal lifecycle state outside canonical authored entity truth."
       }
+    ],
+    "daemonGenerationRecord": [
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#closeSync@1",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#closeSync@2",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#closeSync@3",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#closeSync@4",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#closeSync@5",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#fsyncSync@1",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#fsyncSync@2",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#fsyncSync@3",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#mkdirSync@1",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#mkdirSync@2",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#openSync@1",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#openSync@2",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#openSync@3",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#renameSync@1",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#rmSync@1",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#rmSync@2",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#writeFileSync@1",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      },
+      {
+        "value": "packages/daemon/src/lifecycle/daemon-generation.ts#writeFileSync@2",
+        "ref": "task_01KXZTWY17ZVH5FWRCRV86J16C",
+        "reason": "S1 daemon generation/machine-id operational record publication: daemon-owned durable identity files outside authored truth; exclusive-create + fsync + rename discipline, registered in write-road registry."
+      }
     ]
   }
 }

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -11,12 +11,13 @@
     "dec_01KXF661DNF187S0WZEE04KHF8",
     "dec_01KXN3ZDDNPVZ6ADH62R69MTCN",
     "dec_01KXMZZ92BY0KJW1482WMBRF1K",
+    "task_01KXZTWY17ZVH5FWRCRV86J16C",
     "ADR-0022"
   ],
   "rowCountReconciliation": {
     "phase1FunctionalRows": 26,
-    "registryRows": 58,
-    "difference": "One phase 1 feature row is retired. Six additional rows split mixed write functions and infrastructure: module canonical/view, script declared writes/produces, worktree code/binding, task-holder runtime state, one WriteCoordinator runtime substrate row, and the Fact-to-Execution administrative migration road. Three hosted typed-authority rows keep Execution, execution-scoped Review, and human Consent records RPC-only. Two further ADR-0028 P4 rows register the attributed doc_sync_submit coordinator road and the preset script staging-mirror ingest road. One ADR-0028 P5 row registers the coordinator-owned immutable attribution event trail. One parallel authority-attribution-event/v2 sibling row registers canonical-byte append, read-after-write, recovery, retention, backup, integrity, and materializer coverage under dec_01KXNB6RYNBD9SJBCXGWTDRP8A. One dedicated T4 administrative migration row registers the attributed, confirmed-plan, key-only retirement of historical ownership fields. One ADR-0029 TW-01 row registers the authority replication submission road (attributed-coordinator entry over forced-command SSH). One ADR-0029 TW-02 row registers the compound receipt durable store (client-side crash-recovery receipt records, fsync + atomic rename). One ADR-0029 TW-03 row registers the broker local-view native applier (crash-safe transparent view materialization). One ADR-0029 TW-04 row registers the platform semantic-probe scratch writes (temporary qualification probes, created and removed inside one probe run). One ADR-0029 TW-06 row registers the authority fence enrollment anchor and durability boundary stores. One authority key-material row registers fd-secure private material in repository-external service state as non-SoT state under dec_01KXN3ZDDNPVZ6ADH62R69MTCN; repository, harness, CAS, and backup roots remain forbidden. One authority lifecycle row registers restart-replayed per-repo operations, replica changes, bindings, and namespaces under daemon service state. One daemon transport row registers the socket owner-lock lifecycle state (task_01KXD0A37NN8ZQEJ2ENG5K313V): ephemeral single-instance mutex outside SoT, not entity data. One daemon operational-log row registers the repository-external append, rotation, and retention store under dec_01KXMZZ92BY0KJW1482WMBRF1K. One identity bootstrap row registers the user-profile people roster boundary (XD-1/XD-2). Two GUI decision rows register proposal and judgment transitions through the authenticated daemon IPC write road (dec_01KXDR0A9AR1Z57Q3M1JEDMBVR). One preset-guidance row records create-milestone agent writes beneath the configured repository-relative milestones root. One GUI daemon-restart row registers the Settings System admin.daemon.restart IPC write road. Two W-A2 rows register the daemon-owned durable agent-runtime session store and authenticated daemon RPC spawn/attach control road. Two W-C1 backend rows register daemon-owned terminal registry persistence and detach/confirmed-terminate RPC control. One daemon service-launch row registers the endpoint-keyed structured launch-option spec (atomic owner-only 0600 rewrite in daemon user root) enabling flagless cold-start restoration of --authority-manifest and --authored-root under baseline-governance task_01KXX5515PKE4NSHGHJDX3DKW0."
+    "registryRows": 60,
+    "difference": "One phase 1 feature row is retired. Six additional rows split mixed write functions and infrastructure: module canonical/view, script declared writes/produces, worktree code/binding, task-holder runtime state, one WriteCoordinator runtime substrate row, and the Fact-to-Execution administrative migration road. Three hosted typed-authority rows keep Execution, execution-scoped Review, and human Consent records RPC-only. Two further ADR-0028 P4 rows register the attributed doc_sync_submit coordinator road and the preset script staging-mirror ingest road. One ADR-0028 P5 row registers the coordinator-owned immutable attribution event trail. One parallel authority-attribution-event/v2 sibling row registers canonical-byte append, read-after-write, recovery, retention, backup, integrity, and materializer coverage under dec_01KXNB6RYNBD9SJBCXGWTDRP8A. One dedicated T4 administrative migration row registers the attributed, confirmed-plan, key-only retirement of historical ownership fields. One ADR-0029 TW-01 row registers the authority replication submission road (attributed-coordinator entry over forced-command SSH). One ADR-0029 TW-02 row registers the compound receipt durable store (client-side crash-recovery receipt records, fsync + atomic rename). One ADR-0029 TW-03 row registers the broker local-view native applier (crash-safe transparent view materialization). One ADR-0029 TW-04 row registers the platform semantic-probe scratch writes (temporary qualification probes, created and removed inside one probe run). One ADR-0029 TW-06 row registers the authority fence enrollment anchor and durability boundary stores. One authority key-material row registers fd-secure private material in repository-external service state as non-SoT state under dec_01KXN3ZDDNPVZ6ADH62R69MTCN; repository, harness, CAS, and backup roots remain forbidden. One authority lifecycle row registers restart-replayed per-repo operations, replica changes, bindings, and namespaces under daemon service state. One daemon transport row registers the socket owner-lock lifecycle state (task_01KXD0A37NN8ZQEJ2ENG5K313V): ephemeral single-instance mutex outside SoT, not entity data. One daemon operational-log row registers the repository-external append, rotation, and retention store under dec_01KXMZZ92BY0KJW1482WMBRF1K. One identity bootstrap row registers the user-profile people roster boundary (XD-1/XD-2). Two GUI decision rows register proposal and judgment transitions through the authenticated daemon IPC write road (dec_01KXDR0A9AR1Z57Q3M1JEDMBVR). One preset-guidance row records create-milestone agent writes beneath the configured repository-relative milestones root. One GUI daemon-restart row registers the Settings System admin.daemon.restart IPC write road. Two W-A2 rows register the daemon-owned durable agent-runtime session store and authenticated daemon RPC spawn/attach control road. Two W-C1 backend rows register daemon-owned terminal registry persistence and detach/confirmed-terminate RPC control. One daemon service-launch row registers the endpoint-keyed structured launch-option spec (atomic owner-only 0600 rewrite in daemon user root) enabling flagless cold-start restoration of --authority-manifest and --authored-root under baseline-governance task_01KXX5515PKE4NSHGHJDX3DKW0. Two PLT-Boundary S1 rows register the installation-scoped machine identity and endpoint-scoped daemon generation operational records under task_01KXZTWY17ZVH5FWRCRV86J16C."
   },
   "rows": [
     {
@@ -1737,6 +1738,60 @@
         "packages/daemon/src/lifecycle/daemon-log-file-store.ts:67"
       ],
       "freshness": "append-jsonl-daily-rotate-retain-14d-10-segments"
+    },
+    {
+      "id": "daemon.machine-identity.installation-record",
+      "sourceInventoryRows": [
+        26
+      ],
+      "road": "D",
+      "bearing": "daemon-operational-identity",
+      "leaseRequired": false,
+      "owner": "daemon installation root",
+      "purpose": "Publish one installation-scoped machine identity beneath userRoot for daemon generation fencing; different installation roots intentionally have different identities.",
+      "channel": {
+        "pathClass": "runtime-local-durable",
+        "zoneClass": "non-sot-operational-state"
+      },
+      "entry": [
+        "daemon"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/daemon/src/lifecycle/daemon-generation.ts"
+        }
+      ],
+      "evidence": [
+        "packages/daemon/src/lifecycle/daemon-generation.ts:37"
+      ],
+      "freshness": "exclusive-create-file-fsync-link-publication-directory-fsync"
+    },
+    {
+      "id": "daemon.generation.operational-record",
+      "sourceInventoryRows": [
+        26
+      ],
+      "road": "D",
+      "bearing": "daemon-operational-generation",
+      "leaseRequired": false,
+      "owner": "daemon endpoint owner",
+      "purpose": "Publish the next endpoint-scoped daemon generation beneath userRoot after endpoint-owner serialization so later fence enforcement can reject stale terminal writers.",
+      "channel": {
+        "pathClass": "runtime-local-durable",
+        "zoneClass": "non-sot-operational-state"
+      },
+      "entry": [
+        "daemon"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/daemon/src/lifecycle/daemon-generation.ts"
+        }
+      ],
+      "evidence": [
+        "packages/daemon/src/lifecycle/daemon-generation.ts:72"
+      ],
+      "freshness": "endpoint-owner-serialized-increment-file-fsync-atomic-rename-directory-fsync"
     },
     {
       "id": "daemon.service-launch-spec.persist",


### PR DESCRIPTION
# English

## Summary

S1 batch 1 (S1.1): introduce the daemon four-axis identity schema — `machineId` / `daemonGeneration` / `runtimeRegistrationId` / `connectionId` (+ `leaseGeneration` reserved for S4) — with a durable daemon-generation operational record, and additively reserve optional fields across registry, launch-spec, status, control, and terminal receipt schemas. No enforcement in this batch; legacy request paths remain byte-for-byte identical (real-producer `Buffer.equals` goldens).

## What Changed

- New machine identity file (`<installationRoot>/machine-id`, exclusive-create + fsync) and daemon generation operational record (`daemon-generation.<sha256(endpoint)>.json`, fsync-then-rename publication; strictly monotonic per `(machineId, endpointIdentity)`). The record — not registry/launch-spec/status — is the generation authority; other surfaces carry optional projections only.
- Optional four-axis fields added to registry DTO, launch-spec envelope, status payload, control op, and compound/terminal receipt schemas. Producers use conditional spread; generation axes are emitted only under an explicit request capability (`includeGenerationAxes`).
- `leaseGeneration` is reserved in terminal receipt/journal only — neither generated nor validated (semantics belong to S4).
- Windows fails closed with `DAEMON_GENERATION_DURABILITY_UNSUPPORTED` (no crash-durable directory replacement primitive there yet) instead of silently claiming durability.
- Adversarial-review fixes (`bc590c8b`): legacy status projection strips generation keys from `activeControl`; launch RPC/control receipts default to the original four launch keys with capability-gated axes; out-of-scope `errorCode` field removed from receipt types/validators/journal codec.

## Task And Scope

- Task: PLT-Boundary S-wave S1 `task_01KXZTWY17ZVH5FWRCRV86J16C`; design doc `artifacts/s1-schema-design.md` passed CEO semantic acceptance with four recorded rulings (CLI launch-spec minimal additive edit authorized; receipt forward-only v2; machineId per installation root; leaseGeneration narrow reserve).
- Scope: schema + record only. Enforcement (old-generation terminal-write fencing) and disease-family A/B/C negative tests land in later S1 batches per the design's batch table.

## Version Impact

Additive-only on W6 frozen faces; default/legacy behavior byte-identical (golden verified). Receipt fields are forward-only v2 additive per ruling — rollback to older binaries after generation-aware receipts are durably written requires the documented migration safety check (design doc rollback section).

## Governance Declaration

No new mutating route or spawn surface; the two new operational files (machine-id, generation record) are daemon-owned operational state outside authored truth, registered in `tools/write-road-registry.json`. No gate logic or threshold change. Authority: S-wave decisions `dec_01KXZTSDZR2JQ9BB4M63FXTCBC` / `dec_01KXZTT8FBSC6SMN0BV8B5R8J4` under the PLT-Baseline-Governance umbrella; four implementation rulings recorded in task progress.

## Verification

- typecheck exit 0; api-contracts 5/5; application contract 185/185; daemon contract 87/87; CLI fast 320/320; CLI integration shard 4 84/84.
- Real-producer `Buffer.equals` goldens: launch-spec, status, receipt legacy bytes unchanged; new "generation-aware control client → legacy status client" golden proves no nested-key leak.
- Codec tests cover omitted / partial / full optional field combinations.

## Review Evidence

Adversarial review round (fresh black-box Codex session) produced 4 findings (3×P1, P2): legacy status leaked capability-only fields via `activeControl`; legacy launch-spec/control default output drifted; Windows directory-fsync skip broke the durability claim; `errorCode` exceeded declared scope. All confirmed by CEO ground-truth at cited lines and fixed in `bc590c8b`; re-scan verified capability-gated projection, four-key legacy default, win32 fail-closed, and zero `errorCode` occurrences. A worker dissent earlier in the round (status/receipt codec ownership vs mission red line) was verified and resolved by CEO ruling (minimal additive edits to application leaf codecs authorized).

## Residual Risk

- Windows daemon generation publication is fail-closed until a crash-durable replacement primitive is added (follow-up in S1 batch table).
- Generation fields are carried but not yet enforced; the fence lands in the next S1 batches — until then old-generation writes are not rejected (status quo unchanged).
- Forward-only receipt state: rollback procedure documented in design doc; not automated.

## References

- Design: `harness/tasks/task_01KXZTWY17*/artifacts/s1-schema-design.md`; missions `mission-s1-round1.md` / `mission-s1-round2.md`
- Authority: `dec_01KXZTSDZR2JQ9BB4M63FXTCBC`, `dec_01KXZTT8FBSC6SMN0BV8B5R8J4`; handoff `tmp/handoff-s-wave-runtime-semantics-to-boundary-ceo.md`
- Research: `harness/context/research/2026-07-20-direction-and-multica-adoption/60-foundation-delta.md` (S1)

---

# 中文

## 概要

S1 第一批(S1.1):引入 daemon 四轴身份 schema——`machineId` / `daemonGeneration` / `runtimeRegistrationId` / `connectionId`(+ 为 S4 预留的 `leaseGeneration`)——含 durable daemon-generation operational record,并在 registry、launch-spec、status、control、terminal receipt 各 schema 上 additive 预留 optional 字段。本批不做 enforcement;legacy 请求路径逐字节不变(真实 producer 的 `Buffer.equals` golden)。

## 改动内容

- 新增 machine identity 文件(`<installationRoot>/machine-id`,exclusive-create + fsync)与 daemon generation operational record(`daemon-generation.<sha256(endpoint)>.json`,fsync-后-rename 发布;按 `(machineId, endpointIdentity)` 严格递增)。record 是 generation 权威——registry/launch-spec/status 只携带 optional 投影。
- registry DTO、launch-spec envelope、status payload、control op、compound/terminal receipt schema 增加 optional 四轴字段;producer 条件 spread,generation 轴只在显式 request capability(`includeGenerationAxes`)下输出。
- `leaseGeneration` 仅在 terminal receipt/journal 预留,不生成不校验(语义归 S4)。
- Windows 以 `DAEMON_GENERATION_DURABILITY_UNSUPPORTED` fail closed(该平台暂无 crash-durable 目录替换原语),不静默宣称 durable。
- 对抗评审修复(`bc590c8b`):legacy status 投影剥离 `activeControl` 内代际字段;launch RPC/control receipt 缺省只输出原四个 launch keys,轴字段走 capability;越界的 `errorCode` 字段从 receipt 类型/validator/journal codec 全部移除。

## 任务与范围

- 任务:PLT-Boundary S-wave S1 `task_01KXZTWY17ZVH5FWRCRV86J16C`;设计文档 `artifacts/s1-schema-design.md` 已过 CEO 语义验收,四项裁决落台账(授权 CLI launch-spec 最小 additive 修改;receipt forward-only v2;machineId 按 installation root 隔离;leaseGeneration 窄预留)。
- 范围:仅 schema 与 record。enforcement(旧代际终态写 fence)与病族 A/B/C 负向测试按设计分批表在后续 S1 批落地。

## 版本影响

W6 冻结面 additive only;缺省/legacy 行为逐字节相同(golden 验证)。receipt 字段按裁决为 forward-only v2 additive——写入 generation-aware receipt 后回滚旧 binary 需按设计文档 rollback 节的 migration 安全检查执行。

## 治理声明

无新增 mutating 路由/spawn 面;两个新 operational 文件(machine-id、generation record)为 daemon-owned operational 态、不入 authored truth,已登记 `tools/write-road-registry.json`。无 gate 逻辑或阈值变化。授权来源:S-wave 决策 `dec_01KXZTSDZR2JQ9BB4M63FXTCBC` / `dec_01KXZTT8FBSC6SMN0BV8B5R8J4`(挂 PLT-Baseline-Governance 伞);四项实现裁决已记 task progress。

## 验证

- typecheck exit 0;api-contracts 5/5;application contract 185/185;daemon contract 87/87;CLI fast 320/320;CLI integration shard 4 84/84。
- 真实 producer `Buffer.equals` golden:launch-spec/status/receipt legacy 字节不变;新增「generation-aware control client → legacy status client」golden 证明无 nested-key 泄漏。
- codec 测试覆盖 omitted / partial / full 三组 optional 组合。

## 审查证据

对抗评审一轮(fresh 黑盒 Codex session)产出 4 条 findings(3×P1+P2):legacy status 经 `activeControl` 泄漏 capability-only 字段;legacy launch-spec/control 缺省输出漂移;Windows 跳过目录 fsync 使 durable 声明不成立;`errorCode` 越界。CEO 在引用行逐条 ground-truth 全部成立,`bc590c8b` 全部修复;复扫验证 capability 投影、四 key legacy 缺省、win32 fail-closed、errorCode 归零。本轮早前 worker 异议(status/receipt codec 所有权 vs mission 红线)经核实成立,CEO 裁决授权对 application 叶级 codec 做最小 additive 修改。

## 残余风险

- Windows generation 发布 fail-closed,待补 crash-durable 替换原语(S1 分批表后续批)。
- 代际字段已携带但未 enforcement;fence 在后续 S1 批落地——在此之前旧代际写不被拒(与现状一致)。
- forward-only receipt 态:回滚流程写在设计文档,未自动化。

## 关联材料

- 设计:`harness/tasks/task_01KXZTWY17*/artifacts/s1-schema-design.md`;mission `mission-s1-round1.md` / `mission-s1-round2.md`
- 授权:`dec_01KXZTSDZR2JQ9BB4M63FXTCBC`、`dec_01KXZTT8FBSC6SMN0BV8B5R8J4`;handoff `tmp/handoff-s-wave-runtime-semantics-to-boundary-ceo.md`
- 研究:`harness/context/research/2026-07-20-direction-and-multica-adoption/60-foundation-delta.md`(S1 节)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
