### PR TITLE
fix(ci): shard-4 wedge — daemon test child-process leak cleanup + bounded job timeouts

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   metadata-source-proof:
     if: github.event_name == 'pull_request'
+    timeout-minutes: 5
     permissions:
       statuses: read
     runs-on: ubuntu-latest
@@ -61,6 +62,7 @@ jobs:
 
   pr-body-lint:
     if: github.event_name == 'pull_request'
+    timeout-minutes: 15
     needs: metadata-source-proof
     runs-on: ubuntu-latest
     steps:
@@ -87,6 +89,7 @@ jobs:
 
   full-check:
     if: github.event_name != 'pull_request'
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -109,6 +112,7 @@ jobs:
 
   typecheck:
     if: github.event_name == 'pull_request'
+    timeout-minutes: 15
     needs: metadata-source-proof
     runs-on: ubuntu-latest
     strategy:
@@ -133,6 +137,7 @@ jobs:
 
   fast-contract:
     if: github.event_name == 'pull_request'
+    timeout-minutes: 15
     needs: metadata-source-proof
     runs-on: ubuntu-latest
     steps:
@@ -155,6 +160,7 @@ jobs:
 
   integration-shard:
     if: github.event_name == 'pull_request'
+    timeout-minutes: 15
     needs: metadata-source-proof
     name: integration-shard (${{ matrix.shard }})
     runs-on: ubuntu-latest
@@ -180,6 +186,7 @@ jobs:
 
   boundaries:
     if: github.event_name == 'pull_request'
+    timeout-minutes: 15
     needs: metadata-source-proof
     permissions:
       contents: read
@@ -206,6 +213,7 @@ jobs:
 
   package-policy:
     if: github.event_name == 'pull_request'
+    timeout-minutes: 15
     needs: metadata-source-proof
     runs-on: ubuntu-latest
     steps:
@@ -226,6 +234,7 @@ jobs:
 
   supply-chain:
     if: github.event_name == 'pull_request'
+    timeout-minutes: 15
     needs: metadata-source-proof
     runs-on: ubuntu-latest
     steps:
@@ -246,6 +255,7 @@ jobs:
 
   gui-build:
     if: github.event_name == 'pull_request'
+    timeout-minutes: 15
     needs: metadata-source-proof
     runs-on: ubuntu-latest
     steps:
@@ -282,6 +292,7 @@ jobs:
         run: node tools/run-manifest-gates.mjs --workflow-job gui-build --exclude mergify-queue-metadata-edit-noop
   node26-compatibility:
     if: github.event_name == 'pull_request'
+    timeout-minutes: 15
     needs: metadata-source-proof
     runs-on: ubuntu-latest
     steps:
@@ -304,6 +315,7 @@ jobs:
 
   windows-local-check:
     if: github.event_name == 'pull_request'
+    timeout-minutes: 30
     needs: metadata-source-proof
     runs-on: windows-latest
     steps:
@@ -330,6 +342,7 @@ jobs:
 
   source-validation-proof:
     if: github.event_name == 'pull_request' && needs.metadata-source-proof.outputs.reuse_source != 'true'
+    timeout-minutes: 5
     needs:
       - metadata-source-proof
       - pr-body-lint

--- a/packages/cli/test/daemon-cold-start-launch-spec.test.ts
+++ b/packages/cli/test/daemon-cold-start-launch-spec.test.ts
@@ -319,11 +319,15 @@ test("registry-inferred authority cold start preserves disabled manifest reposit
   }
 });
 
-test("occupied daemon socket does not persist a new authority manifest registry pointer", async () => {
+test("occupied daemon socket does not persist a new authority manifest registry pointer", { timeout: 30_000 }, async () => {
   const fixture = createFixture();
   const userRoot = defaultDaemonUserRoot(fixture.root);
   const endpoint = localUserDaemonEndpoint(userRoot);
-  const owner = net.createServer();
+  const ownerSockets = new Set<net.Socket>();
+  const owner = net.createServer((socket) => {
+    ownerSockets.add(socket);
+    socket.once("close", () => ownerSockets.delete(socket));
+  });
   try {
     mkdirSync(userRoot, { recursive: true });
     const registryBefore = readDaemonRegistry({ userRoot });
@@ -345,11 +349,17 @@ test("occupied daemon socket does not persist a new authority manifest registry 
       "--socket", endpoint,
       "--user-root", userRoot,
       "--authority-manifest", fixture.manifestPath
-    ], { encoding: "utf8", env: cliTestEnv({ HARNESS_DAEMON_USER_ROOT: userRoot }) }), /already owned/u);
+    ], {
+      encoding: "utf8",
+      env: cliTestEnv({ HARNESS_DAEMON_USER_ROOT: userRoot }),
+      timeout: 10_000,
+      killSignal: "SIGKILL"
+    }), /already owned/u);
 
     assert.deepEqual(readDaemonRegistry({ userRoot }), registryBefore);
   } finally {
-    await new Promise<void>((resolve) => owner.close(() => resolve()));
+    for (const socket of ownerSockets) socket.destroy();
+    if (owner.listening) await new Promise<void>((resolve) => owner.close(() => resolve()));
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
@@ -374,7 +384,12 @@ test("transport bind failure after socket ownership does not persist any registr
       "--socket", endpoint,
       "--user-root", userRoot,
       "--authority-manifest", fixture.manifestPath
-    ], { encoding: "utf8", env: cliTestEnv({ HARNESS_DAEMON_USER_ROOT: userRoot }) }), /EISDIR|Path is a directory/u);
+    ], {
+      encoding: "utf8",
+      env: cliTestEnv({ HARNESS_DAEMON_USER_ROOT: userRoot }),
+      timeout: 10_000,
+      killSignal: "SIGKILL"
+    }), /EISDIR|Path is a directory/u);
 
     assert.deepEqual(readDaemonRegistry({ userRoot }), registryBefore);
     assert.equal(existsSync(`${endpoint}.owner`), false);

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -20,6 +20,7 @@ import { defaultTestTierNames, discoverTestTierManifest, testTierNames } from ".
 import { createHermeticTestEnvironment, gitFixtureIdentityGuidance } from "./test-process-environment.mjs";
 
 const repoRoot = resolve(import.meta.dirname, "..");
+const PROCESS_TREE_KILL_GRACE_MS = 2_000;
 
 // Reuse type-strip/compile output across the test host and every CLI
 // subprocess it spawns (integration tests cold-start `node src/index.ts` per
@@ -101,6 +102,7 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
     "--test-reporter-destination=stdout",
     "--test-reporter=junit",
     `--test-reporter-destination=${timingPath}`,
+    "--test-force-exit",
     ...concurrencyArgs,
     ...timeoutArgs,
     ...selection.files
@@ -109,19 +111,29 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
   const child = spawn(invocation.command, invocation.args, {
     cwd: repoRoot,
     stdio: ["inherit", "pipe", "pipe"],
-    env: testEnvironment.env
+    env: testEnvironment.env,
+    detached: process.platform !== "win32"
   });
 
   let output = "";
+  let windowsTreeTerminationStarted = false;
+  const terminateTimedOutWindowsTree = () => {
+    if (process.platform !== "win32" || windowsTreeTerminationStarted || !/test timed out after \d+ms/u.test(output)) return;
+    windowsTreeTerminationStarted = true;
+    console.error("node --test reported a timeout; terminating its process tree");
+    terminateWindowsProcessTree(child);
+  };
   child.stdout.on("data", (chunk) => {
     const text = chunk.toString();
     output += text;
     process.stdout.write(text);
+    terminateTimedOutWindowsTree();
   });
   child.stderr.on("data", (chunk) => {
     const text = chunk.toString();
     output += text;
     process.stderr.write(text);
+    terminateTimedOutWindowsTree();
   });
 
   return new Promise((resolveExitCode) => {
@@ -131,7 +143,8 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
       rmSync(timingRoot, { recursive: true, force: true });
       resolveExitCode(1);
     });
-    child.once("close", (code, signal) => {
+    child.once("close", async (code, signal) => {
+      const leakedDescendants = await terminateLingeringPosixProcessGroup(child.pid);
       testEnvironment.cleanup();
       try {
         const measured = parseJunitTestFileDurations(readFileSync(timingPath, "utf8"), repoRoot);
@@ -143,10 +156,8 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
       }
       if (signal !== null) {
         console.error(`node --test terminated by signal ${signal}`);
-        resolveExitCode(1);
-        return;
       }
-      if (code !== 0) {
+      if (code !== 0 || signal !== null) {
         const timeoutGuidance = formatTestTimeoutGuidance(output, options.testTimeoutMs);
         if (timeoutGuidance !== null) console.error(`\n${timeoutGuidance}`);
         const guidance = gitFixtureIdentityGuidance(output);
@@ -154,7 +165,31 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
       }
       const slowTests = collectSlowTests(output, options.slowThresholdMs);
       console.log(formatSlowTestSummary(slowTests, options.slowThresholdMs, options.slowLimit));
-      resolveExitCode(code ?? 1);
+      resolveExitCode(signal === null && !leakedDescendants ? (code ?? 1) : 1);
     });
   });
 });
+
+function terminateWindowsProcessTree(child) {
+  if (child.pid === undefined) return;
+  const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+  killer.once("error", () => child.kill("SIGKILL"));
+}
+
+async function terminateLingeringPosixProcessGroup(pid) {
+  if (process.platform === "win32" || pid === undefined || !signalProcessGroup(pid, "SIGTERM")) return false;
+  console.error("node --test completed with lingering descendants; terminating its process tree");
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, PROCESS_TREE_KILL_GRACE_MS));
+  signalProcessGroup(pid, "SIGKILL");
+  return true;
+}
+
+function signalProcessGroup(pid, signal) {
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+    return false;
+  }
+}

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -39,7 +39,7 @@ test("runner bounds a non-terminating test and prints timeout next steps", () =>
   const startedAt = Date.now();
   const childEnv = {
     ...process.env,
-    HARNESS_RUNNER_TIMEOUT_FIXTURE: "hang",
+    HARNESS_RUNNER_TIMEOUT_FIXTURE: "child",
     HARNESS_TEST_CONCURRENCY: "1"
   };
   delete childEnv.NODE_TEST_CONTEXT;
@@ -66,6 +66,10 @@ test("runner bounds a non-terminating test and prints timeout next steps", () =>
   assert.match(output, /ps -axo pid,ppid,etime,command/u);
   assert.match(output, /HARNESS_DAEMON_PROFILE=isolated/u);
   assert.match(output, /--test-timeout=1000/u);
+  assert.match(output, /terminating its process tree/u);
+  const fixtureChildPid = Number(output.match(/runner timeout fixture child pid: (\d+)/u)?.[1]);
+  assert.equal(Number.isSafeInteger(fixtureChildPid), true, output);
+  assert.throws(() => process.kill(fixtureChildPid, 0), { code: "ESRCH" });
 });
 
 test("parseRunnerArgs accepts safe repository-relative test prefixes", () => {

--- a/tools/test-fixtures/runner-timeout/intentional-hang.test.mjs
+++ b/tools/test-fixtures/runner-timeout/intentional-hang.test.mjs
@@ -1,7 +1,19 @@
 // harness-test-tier: fast
 import test from "node:test";
+import { spawn } from "node:child_process";
 
 test("runner timeout fixture becomes intentionally non-terminating", async () => {
-  if (process.env.HARNESS_RUNNER_TIMEOUT_FIXTURE !== "hang") return;
+  if (process.env.HARNESS_RUNNER_TIMEOUT_FIXTURE === "child") {
+    const child = spawn(process.execPath, [
+      "--input-type=module",
+      "--eval",
+      "process.on('SIGTERM', () => {}); setInterval(() => {}, 60_000)"
+    ], {
+      stdio: "ignore"
+    });
+    console.log(`runner timeout fixture child pid: ${child.pid}`);
+  } else if (process.env.HARNESS_RUNNER_TIMEOUT_FIXTURE !== "hang") {
+    return;
+  }
   await new Promise(() => {});
 });


### PR DESCRIPTION
# English

## Summary

Fix the recurring integration-shard (4) CI wedge (four hangs in two days, 90+ minutes each) with a two-layer defense: root-cause cleanup of daemon test child-process leaks, and bounded job timeouts so any future hang becomes a fast visible red instead of a silent multi-hour stall.

## What Changed

- Root cause: the occupied-daemon-socket test never closed accepted server sockets, so `server.close()` waited forever on live connections, and its spawned daemon child had no time bound. The test now tracks and destroys accepted sockets and bounds the child at 10 seconds with `SIGKILL`; the original registry-atomicity assertions are unchanged.
- Runner hardening (`tools/run-node-tests.mjs`): Node `--test-force-exit`; POSIX runs test processes in their own process group and terminates lingering descendants — reporting failure (exit 1) when leftovers were found, never masking a leak as green; Windows uses `taskkill /T /F` on timeout.
- Regression test: a real grandchild process that ignores `SIGTERM`; before the fix the outer runner hung to its 15s harness timeout, after the fix it exits 1 in ~3.2s with the grandchild PID verified gone.
- CI guard: all 13 `rewrite-ci.yml` jobs get `timeout-minutes` sized from observed durations (short jobs 5, regular/shard jobs 15, Windows 30, full-check 45).

## Task And Scope

- Task: `task_01KY1CQA34Q9752WQBSM4WWV8V` under the PLT-Baseline-Governance umbrella; authority: decision `dec_01KY1CND7V8HN8AG31968J57GW` (accepted), which explicitly authorizes the CI-config edit as a protected-surface change.
- Evidence chain in the task ledger: run 29783759724 attempt 1 log shows the 180s test failure followed by a 90-minute runner hang with orphan daemon processes at cancel; a live recurrence on PR #970 (run 29796025336) is recorded in task progress.

## Version Impact

Test/tooling/CI-config only; no production package code changed.

## Governance Declaration

Protected surface (CI workflow) touched under an accepted decision (`dec_01KY1CND7V8HN8AG31968J57GW`). Strengthening only: no check removed, no threshold loosened; timeouts convert unbounded hangs into bounded failures; the runner reports leaked descendants as failure rather than green. No gate logic changed.

## Verification

- Targeted occupied-socket/bind tests: 2/2, exit 0 (880/900 ms — previously the wedge site).
- Runner regression suite: 20/20, exit 0, including the SIGTERM-ignoring grandchild case (~3.2s bounded failure, PID verified gone).
- typecheck exit 0; post-commit full `check:ci` locally: all 13 runnable jobs exit 0, shard 4 in 206s.
- CEO verified at source: 13 timeout-minutes entries, `--test-force-exit`, process-group cleanup, and the leak-means-red exit path.

## Review Evidence

Small strengthening-only diff (5 files, +92/−13) under an accepted decision; CEO line-verified the four claims (socket destroy, bounded child, leak-red runner path, CI timeouts). PR-bot findings will be ground-truthed on the PR per standing practice.

## Residual Risk

- Timeout values are sized ~3x observed p95; a legitimately slower future job would need its bound raised explicitly (visible, declared change).
- The Windows cleanup path relies on `taskkill` semantics covered by platform CI.

## References

- Decision: `dec_01KY1CND7V8HN8AG31968J57GW`; task ledger `harness/tasks/task_01KY1CQA34*/`
- Wedge evidence: run 29783759724 attempt 1; recurrence on PR #970 run 29796025336

---

# 中文

## 概要

修复连续复发的 integration-shard (4) CI 卡死(两天四次,每次挂 90+ 分钟),双层防御:根因层清理 daemon 测试子进程泄漏;护栏层给 CI job 加有界超时,未来任何挂起变成快速可见的红,而不是静默吊数小时。

## 改动内容

- 根因:occupied-daemon-socket 测试从未关闭已接受的 server socket,`server.close()` 因活动连接无限等待,拉起的 daemon 子进程也无时间约束。现在跟踪并销毁已接受 socket,子进程 10 秒 `SIGKILL` 收束;原 registry 原子性断言未改。
- Runner 加固(`tools/run-node-tests.mjs`):Node `--test-force-exit`;POSIX 用独立进程组并清理残留后代——发现残留即报失败(exit 1),绝不把泄漏装绿;Windows 超时用 `taskkill /T /F` 清进程树。
- 回归测试:真实的、忽略 `SIGTERM` 的孙进程;修复前外层 runner 挂到 15 秒 harness 超时,修复后约 3.2 秒 exit 1,并验证孙进程 PID 已消失。
- CI 护栏:`rewrite-ci.yml` 全部 13 个 job 按观测时长设 `timeout-minutes`(短 job 5、常规/shard 15、Windows 30、full-check 45)。

## 任务与范围

- 任务:`task_01KY1CQA34Q9752WQBSM4WWV8V`(挂 PLT-Baseline-Governance 伞);授权:决策 `dec_01KY1CND7V8HN8AG31968J57GW`(已 accept),显式授权本次 protected surface 的 CI 配置修改。
- 证据链在任务台账:run 29783759724 attempt-1 日志显示 180 秒测试失败后 runner 挂 90 分钟、cancel 时清出孤儿 daemon 进程;PR #970(run 29796025336)的现挂复发也已记录。

## 版本影响

仅测试/工具/CI 配置;不改任何生产包代码。

## 治理声明

在已 accept 决策(`dec_01KY1CND7V8HN8AG31968J57GW`)授权下触碰 protected surface(CI workflow)。只加严:无 check 移除、无阈值放宽;超时把无界挂起变为有界失败;runner 把泄漏后代报为失败而非绿。无 gate 逻辑变化。

## 验证

- 定向 occupied-socket/bind 测试:2/2,exit 0(880/900 ms——此前的卡死位点)。
- Runner 回归套件:20/20,exit 0,含忽略 SIGTERM 的孙进程用例(约 3.2 秒有界失败,PID 验证消失)。
- typecheck exit 0;提交后本地全量 `check:ci`:13 个可运行 job 全部 exit 0,shard 4 用时 206 秒。
- CEO 源码逐项核验:13 处 timeout-minutes、`--test-force-exit`、进程组清理、泄漏即红的退出路径。

## 审查证据

小型只加严 diff(5 文件,+92/−13),有已 accept 决策授权;CEO 逐行核验四项声明(socket 销毁、子进程限时、泄漏即红、CI 超时)。PR bot findings 按惯例在 PR 上逐条 ground-truth。

## 残余风险

- 超时值按观测 p95 的约 3 倍设定;未来某 job 合理变慢需显式上调(可见、有声明的变更)。
- Windows 清理路径依赖 `taskkill` 语义,由平台 CI 覆盖。

## 关联材料

- 决策:`dec_01KY1CND7V8HN8AG31968J57GW`;任务台账 `harness/tasks/task_01KY1CQA34*/`
- 卡死证据:run 29783759724 attempt-1;PR #970 run 29796025336 复发

🤖 Generated with [Claude Code](https://claude.com/claude-code)
