### PR TITLE
feat(test): load-adaptive shard-level parallelism for local runs

### DIFF
--- a/tools/run-ci-equivalent.mjs
+++ b/tools/run-ci-equivalent.mjs
@@ -15,10 +15,12 @@
 //   npm run check:ci                      跑全部可本地执行的 job
 //   npm run check:ci -- --job boundaries  只跑指定 job(可重复)
 //   npm run check:ci -- --json             额外吐一份机器可读回执(贴进 PR / worker 报告)
+//   HARNESS_SHARD_PARALLELISM=2 npm run check:ci  显式控制本地 integration shard fan-out
 //
 // 回执是产物,不是断言:每个 job 的真实 exit code 都在里面。CEO 会重跑并比对数字。
 
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
+import { availableParallelism } from "node:os";
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -26,8 +28,15 @@ import {
   getEnforcementConstant,
   resolveEnforcementConstant
 } from "./enforcement-constants.mjs";
-import { discoverQosPrefix, prefixCommand, withLocalHeavySlot } from "./local-resource-governance.mjs";
+import {
+  discoverQosPrefix,
+  prefixCommand,
+  resolveLocalSlotCount,
+  withLocalHeavySlot
+} from "./local-resource-governance.mjs";
 import { clearIncrementalArtifacts } from "./clear-incremental-artifacts.mjs";
+import { resolveTestConcurrency } from "./node-test-runner-lib.mjs";
+import { mapWithConcurrency, resolveShardParallelism } from "./shard-parallelism.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const manifestPath = path.join(root, "tools/gate-manifest.json");
@@ -124,18 +133,62 @@ export function buildCiJobInvocation(qosPrefix, args) {
   return prefixCommand(qosPrefix, process.execPath, args);
 }
 
-function runJob(job, shard, { qosPrefix, env }) {
-  clearIncrementalArtifacts(root);
-  const args = ["tools/run-manifest-gates.mjs", "--workflow-job", job, "--exclude", "mergify-queue-metadata-edit-noop"];
-  if (shard !== undefined) args.push("--shard", String(shard));
-  const invocation = buildCiJobInvocation(qosPrefix, args);
-  const started = Date.now();
-  const result = spawnSync(invocation.command, invocation.args, { cwd: root, stdio: "inherit", env });
-  return {
-    job: shard === undefined ? job : `${job} (${shard})`,
-    exitCode: result.status ?? 1,
-    seconds: Math.round((Date.now() - started) / 1000)
-  };
+async function runJob(job, shard) {
+  const label = shard === undefined ? job : `${job}:${shard}`;
+  return withLocalHeavySlot({ label: `check:ci:${label}` }, async (lease) => {
+    const qosPrefix = discoverQosPrefix();
+    const args = ["tools/run-manifest-gates.mjs", "--workflow-job", job, "--exclude", "mergify-queue-metadata-edit-noop"];
+    if (shard !== undefined) args.push("--shard", String(shard));
+    const invocation = buildCiJobInvocation(qosPrefix, args);
+    const started = Date.now();
+    const exitCode = await runChild(invocation, lease.childEnv);
+    return {
+      job: shard === undefined ? job : `${job} (${shard})`,
+      exitCode,
+      seconds: Math.round((Date.now() - started) / 1000)
+    };
+  });
+}
+
+function runChild(invocation, env) {
+  return new Promise((resolveExitCode) => {
+    const child = spawn(invocation.command, invocation.args, { cwd: root, stdio: "inherit", env });
+    let settled = false;
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      console.error(`[check:ci] ${error.message}`);
+      resolveExitCode(1);
+    });
+    child.once("close", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      if (signal !== null) console.error(`[check:ci] job terminated by signal ${signal}`);
+      resolveExitCode(signal === null ? (code ?? 1) : 1);
+    });
+  });
+}
+
+export async function runCiPlan(plan, shardParallelism, run = runJob, beforeBatch = () => clearIncrementalArtifacts(root)) {
+  const receipts = [];
+  for (let index = 0; index < plan.length;) {
+    const [job] = plan[index];
+    if (job !== INTEGRATION_SHARD_JOB) {
+      await beforeBatch();
+      receipts.push(await run(...plan[index]));
+      index += 1;
+      continue;
+    }
+
+    const shardBatch = [];
+    while (index < plan.length && plan[index][0] === INTEGRATION_SHARD_JOB) {
+      shardBatch.push(plan[index]);
+      index += 1;
+    }
+    await beforeBatch();
+    receipts.push(...await mapWithConcurrency(shardBatch, shardParallelism, ([shardJob, shard]) => run(shardJob, shard)));
+  }
+  return receipts;
 }
 
 function parseArgs(argv) {
@@ -152,40 +205,56 @@ function parseArgs(argv) {
 }
 
 async function main() {
-  await withLocalHeavySlot({ label: "check:ci" }, async (lease) => {
-    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-    const shardDeclaration = getEnforcementConstant(manifest, "ci-integration-shard-sequence");
-    const workflowPath = path.join(root, shardDeclaration.authority.path);
-    const workflowText = readFileSync(workflowPath, "utf8");
-    const { wanted, receiptPath } = parseArgs(process.argv.slice(2));
-    const { derived, plan, skipped } = buildCiPlan(manifest, workflowText, wanted);
-    const missingCredentials = NEEDS_GITHUB.filter((name) => !process.env[name]);
-    if (missingCredentials.length > 0) {
-      console.error(
-        `\n[check:ci] ${missingCredentials.join(" and ")} not set. The boundaries job reads GitHub's live\n` +
-        `           branch rules (check-github-required-contexts) and will fail for environmental\n` +
-        `           reasons, not code reasons. Set them first:\n\n` +
-        `             export GITHUB_REPOSITORY=<owner>/<name>\n` +
-        `             export GITHUB_TOKEN=$(gh auth token)\n`
-      );
-    }
-
-    const qosPrefix = discoverQosPrefix();
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const shardDeclaration = getEnforcementConstant(manifest, "ci-integration-shard-sequence");
+  const workflowPath = path.join(root, shardDeclaration.authority.path);
+  const workflowText = readFileSync(workflowPath, "utf8");
+  const { wanted, receiptPath } = parseArgs(process.argv.slice(2));
+  const { derived, plan, skipped } = buildCiPlan(manifest, workflowText, wanted);
+  const missingCredentials = NEEDS_GITHUB.filter((name) => !process.env[name]);
+  if (missingCredentials.length > 0) {
     console.error(
-      `\n[check:ci] ${plan.length} runs derived from tools/gate-manifest.json and ${path.relative(root, workflowPath)} ` +
-      `(${[...derived].map(([job, gates]) => `${job}:${gates.length}`).join(" ")}); ` +
-      `QoS=${qosPrefix.join(" ") || "none"}; slot=${path.basename(lease.slotPath)}\n`
+      `\n[check:ci] ${missingCredentials.join(" and ")} not set. The boundaries job reads GitHub's live\n` +
+      `           branch rules (check-github-required-contexts) and will fail for environmental\n` +
+      `           reasons, not code reasons. Set them first:\n\n` +
+      `             export GITHUB_REPOSITORY=<owner>/<name>\n` +
+      `             export GITHUB_TOKEN=$(gh auth token)\n`
     );
-    const receipts = [];
-    for (const [job, shard] of plan) receipts.push(runJob(job, shard, { qosPrefix, env: lease.childEnv }));
+  }
 
-    console.error(formatSummary(receipts, skipped));
-    if (receiptPath !== null) {
-      writeFileSync(receiptPath, `${JSON.stringify(createReceipt(receipts, skipped), null, 2)}\n`);
-      console.error(`  receipt → ${receiptPath}\n`);
-    }
-    process.exitCode = receipts.some((receipt) => receipt.exitCode !== 0) ? 1 : 0;
+  const localSlots = resolveLocalSlotCount(process.env.HARNESS_LOCAL_SLOTS);
+  const cpuCount = availableParallelism();
+  const resolvedTestConcurrency = resolveTestConcurrency({
+    flagConcurrency: undefined,
+    envConcurrency: process.env.HARNESS_TEST_CONCURRENCY,
+    isCi: Boolean(process.env.CI)
   });
+  const perShardConcurrency = resolvedTestConcurrency ?? cpuCount;
+  const shardCount = plan.filter(([job]) => job === INTEGRATION_SHARD_JOB).length;
+  const shardResolution = shardCount === 0
+    ? { parallelism: 1, source: "not-selected", requested: 0, freeCores: 0, perShardConcurrency }
+    : resolveShardParallelism({
+      shardCount,
+      localSlots,
+      perShardConcurrency,
+      cpuCount
+    });
+  const qosPrefix = discoverQosPrefix();
+  console.error(
+    `\n[check:ci] ${plan.length} runs derived from tools/gate-manifest.json and ${path.relative(root, workflowPath)} ` +
+    `(${[...derived].map(([job, gates]) => `${job}:${gates.length}`).join(" ")}); ` +
+    `QoS=${qosPrefix.join(" ") || "none"}; slots=${localSlots}; ` +
+    `shard-parallelism=${shardResolution.parallelism} (${shardResolution.source}, requested=${shardResolution.requested}, ` +
+    `free-cores=${shardResolution.freeCores}, per-shard=${shardResolution.perShardConcurrency})\n`
+  );
+  const receipts = await runCiPlan(plan, shardResolution.parallelism);
+
+  console.error(formatSummary(receipts, skipped));
+  if (receiptPath !== null) {
+    writeFileSync(receiptPath, `${JSON.stringify(createReceipt(receipts, skipped), null, 2)}\n`);
+    console.error(`  receipt → ${receiptPath}\n`);
+  }
+  process.exitCode = receipts.some((receipt) => receipt.exitCode !== 0) ? 1 : 0;
 }
 
 if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/tools/run-ci-equivalent.test.mjs
+++ b/tools/run-ci-equivalent.test.mjs
@@ -1,5 +1,9 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import {
   LOCAL_EQUIVALENCE_NOTICE,
@@ -7,8 +11,10 @@ import {
   buildCiPlan,
   createReceipt,
   formatSummary,
-  parseIntegrationShardMatrix
+  parseIntegrationShardMatrix,
+  runCiPlan
 } from "./run-ci-equivalent.mjs";
+import { resolveShardParallelism } from "./shard-parallelism.mjs";
 
 test("check:ci applies the shared QoS prefix to each manifest job", () => {
   assert.deepEqual(buildCiJobInvocation(["taskpolicy", "-c", "utility"], ["tools/run-manifest-gates.mjs"]), {
@@ -69,6 +75,76 @@ test("skipped jobs are visible in the final summary and JSON receipt", () => {
   assert.match(summary, /ALL GREEN \(locally runnable jobs only; 1 skipped\)/u);
   assert.match(summary, /本地绿 ≠ 完整 CI 等价/u);
 });
+
+test("explicit shard parallelism wins over load adaptation but keeps slot and CPU safety caps", () => {
+  assert.deepEqual(resolveShardParallelism({
+    raw: "2", shardCount: 6, localSlots: 3, perShardConcurrency: 2, cpuCount: 12, loadOne: 11
+  }), {
+    parallelism: 2,
+    source: "explicit",
+    requested: 2,
+    freeCores: 1,
+    cpuCap: 6,
+    localSlots: 3,
+    perShardConcurrency: 2
+  });
+  assert.equal(resolveShardParallelism({
+    raw: "9", shardCount: 6, localSlots: 3, perShardConcurrency: 4, cpuCount: 8, loadOne: 0
+  }).parallelism, 2);
+  assert.throws(() => resolveShardParallelism({
+    raw: "many", shardCount: 2, localSlots: 3, perShardConcurrency: 2, cpuCount: 8, loadOne: 0
+  }), /HARNESS_SHARD_PARALLELISM must be a positive integer/u);
+});
+
+test("adaptive shard parallelism derives from free cores and never exceeds the machine slot budget", () => {
+  assert.equal(resolveShardParallelism({
+    shardCount: 6, localSlots: 3, perShardConcurrency: 2, cpuCount: 12, loadOne: 4
+  }).parallelism, 3);
+  assert.equal(resolveShardParallelism({
+    shardCount: 6, localSlots: 3, perShardConcurrency: 2, cpuCount: 12, loadOne: 11
+  }).parallelism, 1);
+});
+
+test("parallelism two overlaps two shard child processes and preserves a failing exit code", async (context) => {
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-shard-parallelism-"));
+  context.after(() => rmSync(fixtureRoot, { recursive: true, force: true }));
+  const plan = [["integration-shard", 1], ["integration-shard", 2]];
+  const resolution = resolveShardParallelism({
+    raw: "2", shardCount: 2, localSlots: 3, perShardConcurrency: 2, cpuCount: 8, loadOne: 7
+  });
+  const receipts = await runCiPlan(
+    plan,
+    resolution.parallelism,
+    (_job, shard) => runFixtureShard(fixtureRoot, shard),
+    () => {}
+  );
+
+  assert.equal(resolution.source, "explicit");
+  assert.equal(resolution.parallelism, 2);
+  assert.deepEqual(receipts.map(({ job, exitCode }) => ({ job, exitCode })), [
+    { job: "integration-shard (1)", exitCode: 0 },
+    { job: "integration-shard (2)", exitCode: 7 }
+  ]);
+  assert.equal(createReceipt(receipts, []).ok, false);
+});
+
+function runFixtureShard(root, shard) {
+  const peer = shard === 1 ? 2 : 1;
+  const expectedExitCode = shard === 2 ? 7 : 0;
+  const started = Date.now();
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [
+      path.join(import.meta.dirname, "test-fixtures/shard-parallelism/worker.mjs"),
+      root, String(shard), String(peer), String(expectedExitCode)
+    ], { stdio: "ignore" });
+    child.once("error", () => resolve({ job: `integration-shard (${shard})`, exitCode: 1, seconds: 0 }));
+    child.once("close", (code) => resolve({
+      job: `integration-shard (${shard})`,
+      exitCode: code ?? 1,
+      seconds: Math.round((Date.now() - started) / 1000)
+    }));
+  });
+}
 
 function makeManifest() {
   return {

--- a/tools/shard-parallelism.mjs
+++ b/tools/shard-parallelism.mjs
@@ -1,0 +1,72 @@
+import { availableParallelism, loadavg } from "node:os";
+
+export const SHARD_PARALLELISM_ENV = "HARNESS_SHARD_PARALLELISM";
+
+export function resolveShardParallelism({
+  raw = process.env[SHARD_PARALLELISM_ENV],
+  shardCount,
+  localSlots,
+  perShardConcurrency,
+  cpuCount = availableParallelism(),
+  loadOne = loadavg()[0]
+}) {
+  assertPositiveInteger(shardCount, "shard count");
+  assertPositiveInteger(localSlots, "local slot count");
+  assertPositiveInteger(perShardConcurrency, "per-shard concurrency");
+  assertPositiveInteger(cpuCount, "CPU count");
+
+  const normalizedLoad = Number.isFinite(loadOne) && loadOne >= 0 ? loadOne : cpuCount;
+  const freeCores = Math.max(1, Math.floor(cpuCount - normalizedLoad));
+  const adaptive = Math.max(1, Math.floor(freeCores / perShardConcurrency));
+  const explicit = parseExplicitParallelism(raw);
+  const requested = explicit ?? adaptive;
+  const cpuCap = Math.max(1, Math.floor(cpuCount / perShardConcurrency));
+  const parallelism = Math.min(requested, shardCount, localSlots, cpuCap);
+
+  return {
+    parallelism,
+    source: explicit === null ? "adaptive" : "explicit",
+    requested,
+    freeCores,
+    cpuCap,
+    localSlots,
+    perShardConcurrency
+  };
+}
+
+export async function mapWithConcurrency(items, concurrency, worker) {
+  assertPositiveInteger(concurrency, "shard parallelism");
+  if (items.length === 0) return [];
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  async function runNext() {
+    for (;;) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index], index);
+    }
+  }
+
+  await Promise.all(Array.from(
+    { length: Math.min(concurrency, items.length) },
+    () => runNext()
+  ));
+  return results;
+}
+
+function parseExplicitParallelism(raw) {
+  if (raw === undefined || raw === "") return null;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${SHARD_PARALLELISM_ENV} must be a positive integer; received ${JSON.stringify(raw)}`);
+  }
+  return parsed;
+}
+
+function assertPositiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+}

--- a/tools/test-fixtures/shard-parallelism/worker.mjs
+++ b/tools/test-fixtures/shard-parallelism/worker.mjs
@@ -1,0 +1,15 @@
+import { existsSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const [root, id, peerId, rawExitCode] = process.argv.slice(2);
+if (!root || !id || !peerId || rawExitCode === undefined) process.exit(2);
+
+writeFileSync(path.join(root, `started-${id}`), "", { flag: "wx" });
+const deadline = Date.now() + 2_000;
+while (!existsSync(path.join(root, `started-${peerId}`)) && Date.now() < deadline) {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (!existsSync(path.join(root, `started-${peerId}`))) process.exit(9);
+
+await new Promise((resolve) => setTimeout(resolve, 50));
+process.exitCode = Number(rawExitCode);


### PR DESCRIPTION
# English

## Summary

Add a load-adaptive shard-level parallelism knob for local test runs. The six integration shards previously always ran strictly serially in local full-matrix runs (20+ minutes); they can now run concurrently under an explicit `HARNESS_SHARD_PARALLELISM` setting or a load-derived default, cutting a deliberate local full run to a fraction while respecting the machine-wide QoS slot discipline.

## What Changed

- New `tools/shard-parallelism.mjs`: explicit `HARNESS_SHARD_PARALLELISM` wins; otherwise the degree derives from `loadavg`/available cores; always bounded by shard count, machine-wide slot count, and a CPU oversell cap computed against the resolved per-shard `HARNESS_TEST_CONCURRENCY` (whose semantics are unchanged).
- `tools/run-ci-equivalent.mjs`: only the integration-shard batch parallelizes; all other jobs stay serial. Each shard acquires its own machine-wide QoS slot instead of sharing the parent's single slot. Receipt ordering is stable; any non-zero shard still reds the aggregate.
- Targeted test proves parallelism=2 with two real child processes at a barrier, and preserves exit-code contract (0/7) and failure aggregation.

## Task And Scope

- Task: `task_01KY1K8BMQAC2VPER33PCVM8D5` under PLT-Baseline-Governance (charter in task progress, Zeyu 2026-07-21). Does not change the worker stop-point ruling: targeted tests remain the norm; the full matrix belongs to CI. This knob serves deliberate local full runs.
- Machine-wide 3-slot QoS semaphore (dec_01KXFEMG) is respected — per-shard slot acquisition goes through the existing mechanism.

## Version Impact

Local tooling only; no production package code, no CI behavior change (CI already parallelizes shards at the job level).

## Governance Declaration

No gate logic or threshold change; no new write surface. Runner receipt/exit-code contract unchanged (verified by tests). Authority: task `task_01KY1K8BMQAC2VPER33PCVM8D5` under the umbrella.

## Verification

- typecheck exit 0; runner suite 36/36 (CEO re-ran the run-ci-equivalent suite: 8/8); explicit parallelism=2 targeted proof 1/1.
- changed-file ESLint, file-complexity, enforcement-constant audit all exit 0.
- Per the narrowed stop-point ruling, no full local matrix was run — the full gate is CI's job on this PR.

## Review Evidence

Small local-tooling diff (4 files, +277/−45) with a real-process barrier test; CEO verified the knob precedence, load-adaptive bound, slot acquisition, and failure aggregation at source. PR-bot findings will be ground-truthed on the PR.

## Residual Risk

- Load-derived defaults are heuristic (loadavg snapshot); explicit env always wins for deterministic runs.
- Oversell cap depends on the resolved per-shard concurrency; changing that default later should revisit the cap factor.

## References

- Task ledger: `harness/tasks/task_01KY1K8BMQ*/`; predecessor: PR #971 (shard-4 wedge fix)

---

# 中文

## 概要

为本地测试新增负载自适应的 shard 级并行旋钮。此前本地全量跑六个 integration shard 严格串行(20+ 分钟);现在可经显式 `HARNESS_SHARD_PARALLELISM` 或负载推导的默认值并行执行,刻意的本地全量跑时间大幅缩短,同时尊重全机 QoS 槽位纪律。

## 改动内容

- 新增 `tools/shard-parallelism.mjs`:显式 `HARNESS_SHARD_PARALLELISM` 优先;未设置时按 `loadavg`/可用核推导;始终受 shard 数、全机槽位数、以及按单 shard `HARNESS_TEST_CONCURRENCY` 解析值计算的 CPU 超卖上限约束(单 shard 并发语义不变)。
- `tools/run-ci-equivalent.mjs`:仅 integration-shard batch 并行,其余 job 保持串行;每个 shard 独立获取全机 QoS 槽位,不再共享父级单槽。Receipt 顺序稳定;任一 shard 非零仍使总结果为红。
- 定向测试用两个真实子进程在 barrier 处证明并行度 2 生效,并保留退出码契约(0/7)与失败聚合。

## 任务与范围

- 任务:`task_01KY1K8BMQAC2VPER33PCVM8D5`(挂 PLT-Baseline-Governance 伞;charter 见任务 progress,泽宇 2026-07-21)。不改变 worker 停止点裁决:定向测试仍是常态,全量矩阵归 CI;此旋钮服务于刻意的本地全量场景。
- 尊重全机 3 槽 QoS 信号量(dec_01KXFEMG)——每 shard 槽位获取走既有机制。

## 版本影响

仅本地工具;不改生产包代码,不改 CI 行为(CI 侧 shard 本就 job 级并行)。

## 治理声明

无 gate 逻辑或阈值变化;无新写面。runner receipt/退出码契约不变(测试验证)。授权来源:伞下任务 `task_01KY1K8BMQAC2VPER33PCVM8D5`。

## 验证

- typecheck exit 0;runner 套件 36/36(CEO 复跑 run-ci-equivalent 套件 8/8);显式并行度 2 定向证明 1/1。
- changed-file ESLint、file-complexity、enforcement-constant audit 均 exit 0。
- 按收窄的停止点裁决,未跑全量本地矩阵——完整门由本 PR 的 CI 验证。

## 审查证据

小型本地工具 diff(4 文件,+277/−45),含真实子进程 barrier 测试;CEO 源码核验旋钮优先级、负载自适应上限、槽位获取与失败聚合。PR bot findings 在 PR 上逐条 ground-truth。

## 残余风险

- 负载推导默认值是启发式(loadavg 快照);要确定性就显式设 env。
- 超卖上限依赖单 shard 并发解析值;未来改该默认需回看上限系数。

## 关联材料

- 任务台账:`harness/tasks/task_01KY1K8BMQ*/`;前置:PR #971(shard-4 卡死修复)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
