### PR TITLE
feat(tools): derive local capacity from a declared interactive core reservation

### DIFF
--- a/packages/cli/src/commands/extensions/assets/software-coding/extension-contract.lock.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/extension-contract.lock.json
@@ -2,8 +2,8 @@
   "schema": "extension-contract-lock/v1",
   "catalog": {
     "id": "software-coding-core",
-    "version": "1.3.2",
-    "digest": "sha256:e27e01f2f29dd402cac09530c2714b6bb1bce7879bcc770f5077145e6fba4d18"
+    "version": "1.4.0",
+    "digest": "sha256:9de17a7f169e9e4df2ecbecd4e69a52cfa5ed3774a79a043d50e13d16cdae39c"
   },
   "presets": [
     { "id": "standard-task", "version": "2.0.0", "digest": "sha256:82510a9275a49a88fb7b4a00809123f3703a0b277e0c04da64baf4cbdad4447c" },

--- a/packages/cli/src/commands/extensions/assets/software-coding/template-catalog.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/template-catalog.json
@@ -3,7 +3,7 @@
   "package": {
     "id": "software-coding-core",
     "title": "Software Coding Core Templates",
-    "version": "1.3.2",
+    "version": "1.4.0",
     "owner": "harness-anything",
     "locales": [
       "zh-CN",

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/task.plan/en-US.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/task.plan/en-US.md
@@ -36,6 +36,6 @@ If this task is not a CI/gate/governance task but requires modifying CI/gate aut
 
 ## Verification
 
-- **Stop point = `npm run check:ci` green + a local commit.** It derives *every* job CI runs on a pull request from `tools/gate-manifest.json` and runs them all. Do not hand-copy a list of gates here: lists rot (`check:local` is only a fast-tier subset, and the `boundaries` job alone carries 35 gates), whereas this command grows with the manifest. Paste the `--json <path>` receipt into this section verbatim rather than writing "all green" — a receipt is an artifact, an assertion is not.
+- **Stop point = targeted tests for the surface you touched, green, plus a local commit. The full gate matrix is GitHub CI's job, not this machine's.** Name the specific test files or `--tier` selection this task's surface requires, and paste the real runner output rather than writing "all green" — output is an artifact, an assertion is not. Do not run the whole local matrix serially to feel safe: one machine running every job in sequence is strictly slower than CI running them in parallel, and it blocks every other worker on the same machine behind the shared slot budget. `npm run check:ci` remains available for deliberately reproducing a CI failure locally; it is not the stop point.
 - List any review and human acceptance conditions this task additionally requires.
 - Per `dec_mrg3z1we/CH4`, Facts are explicit `0..N` promotions, not a review or completion quantity gate; verify delivery through Execution outputs, review, closeout, and the applicable completion gates.

--- a/packages/cli/src/commands/extensions/assets/software-coding/templates/task.plan/zh-CN.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/templates/task.plan/zh-CN.md
@@ -36,6 +36,6 @@ Task Contract: harness-task v1
 
 ## Verification
 
-- **停止点 = `npm run check:ci` 全绿 + 本地 commit。** 它从 `tools/gate-manifest.json` 派生出 CI 在 pull_request 上跑的**全部** job 并逐个执行——不要在这里手抄一张门的清单：清单会腐烂（`check:local` 只是 fast tier 子集，光 `boundaries` 一个 job 就 35 道门），而这条命令会跟着 manifest 自动长。把 `--json <path>` 回执原样贴进本节，别只写「全绿」——回执是产物，断言不是。
+- **停止点 = 本次改动面的定向测试全绿 + 本地 commit。完整门矩阵是 GitHub CI 的活，不是这台机器的活。** 点名本任务改动面需要的具体测试文件或 `--tier` 选择，并把 runner 的真实输出贴进本节，别只写「全绿」——输出是产物，断言不是。不要为了求安心在本机串行跑全量：一台机器顺序跑完所有 job 严格慢于 CI 并行跑，而且会占住全机槽预算、把同机其他 worker 全堵在后面。`npm run check:ci` 仍然保留，用于**刻意在本地复现某个 CI 失败**，它不是停止点。
 - 列出本任务额外需要的 review 与人工验收条件。
 - 依据 `dec_mrg3z1we/CH4`，Fact 是 `0..N` 的显式晋升，不是 review 或 completion 的数量门；交付通过 Execution outputs、review、closeout 与适用的 completion gates 验证。

--- a/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
+++ b/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
@@ -327,7 +327,7 @@
       },
       "settingsPreset": {
         "byteLength": 7278,
-        "sha256": "2bc224d63461f63d2f6ce647ae697d48c410de754aa241d3b277de0bba43c148"
+        "sha256": "fc00a87c397bff86ed49a7a2c1f2d1393560d1364ed5b4ccfffd665636d820be"
       },
       "settingsFailure": {
         "byteLength": 79,

--- a/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
+++ b/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
@@ -15,81 +15,305 @@
   },
   "adapterE2E": {
     "generic": {
-      "envelope": { "byteLength": 919, "sha256": "cc68c260a6ad3c434d4ec32febf14a8eb41a097da635dafea9b5bc551f37f240" },
-      "receipt": { "byteLength": 504, "sha256": "a17c9eff4a77a74d997ef11d4298382ba4cd85ee43aff60b8459f2b111bdc913" }
+      "envelope": {
+        "byteLength": 919,
+        "sha256": "cc68c260a6ad3c434d4ec32febf14a8eb41a097da635dafea9b5bc551f37f240"
+      },
+      "receipt": {
+        "byteLength": 504,
+        "sha256": "a17c9eff4a77a74d997ef11d4298382ba4cd85ee43aff60b8459f2b111bdc913"
+      }
     },
     "taskClaim": {
-      "envelope": { "byteLength": 1912, "sha256": "aaa618d11cd1805e081c0f503c6efe8ff20b2269ca415f9ad0e5180fefa8ea37" },
-      "receipt": { "byteLength": 1368, "sha256": "4fd7d4dc44cd68d0b08c5458fad2e8859e670b69d3a37ade8979cc4e6f203d42" }
+      "envelope": {
+        "byteLength": 1912,
+        "sha256": "aaa618d11cd1805e081c0f503c6efe8ff20b2269ca415f9ad0e5180fefa8ea37"
+      },
+      "receipt": {
+        "byteLength": 1368,
+        "sha256": "4fd7d4dc44cd68d0b08c5458fad2e8859e670b69d3a37ade8979cc4e6f203d42"
+      }
     },
     "observedWrite": {
-      "envelope": { "byteLength": 1589, "sha256": "2376a1b604025f8691ed09b5045c9703b7e481d64e3c6e566cf2cf39d3501811" },
-      "receipt": { "byteLength": 595, "sha256": "c734a98664aeabaaf5500950cf55dc912deb3799e715814442cd5f1fa3f0985a" }
+      "envelope": {
+        "byteLength": 1589,
+        "sha256": "2376a1b604025f8691ed09b5045c9703b7e481d64e3c6e566cf2cf39d3501811"
+      },
+      "receipt": {
+        "byteLength": 595,
+        "sha256": "c734a98664aeabaaf5500950cf55dc912deb3799e715814442cd5f1fa3f0985a"
+      }
     },
     "decisionTransition": {
-      "envelope": { "byteLength": 1949, "sha256": "d7107a5274371776aceaae4e53551248e37143708b4490eb630775534510648f" },
-      "receipt": { "byteLength": 779, "sha256": "b019e2eeb0e383dc3fc656311535aa64235b72b10183126db009ea23c23e1ed2" }
+      "envelope": {
+        "byteLength": 1949,
+        "sha256": "d7107a5274371776aceaae4e53551248e37143708b4490eb630775534510648f"
+      },
+      "receipt": {
+        "byteLength": 779,
+        "sha256": "b019e2eeb0e383dc3fc656311535aa64235b72b10183126db009ea23c23e1ed2"
+      }
     }
   },
   "hostServices": {
     "ingressAdapters": {
-      "generic": { "status": "typed-v2", "adapter": "generic" },
-      "decisionTransition": { "status": "typed-v2", "adapter": "decision-transition" },
-      "taskClaim": { "status": "typed-v2", "adapter": "task-claim" },
-      "observedWrite": { "status": "typed-v2", "adapter": "observed-write" }
+      "generic": {
+        "status": "typed-v2",
+        "adapter": "generic"
+      },
+      "decisionTransition": {
+        "status": "typed-v2",
+        "adapter": "decision-transition"
+      },
+      "taskClaim": {
+        "status": "typed-v2",
+        "adapter": "task-claim"
+      },
+      "observedWrite": {
+        "status": "typed-v2",
+        "adapter": "observed-write"
+      }
     },
     "normalizer": {
       "success": {
-        "kind": "decision-propose", "decisionId": "dec_GOLDEN", "proposedAt": "2026-07-20T00:00:00.000Z",
-        "title": "Golden decision", "question": "Keep bytes?",
-        "chosen": [{ "id": "CH9", "text": "Yes" }],
-        "rejected": [{ "id": "RJ9", "text": "No", "why_not": "Breaks parity" }],
-        "claim": "Bytes stay stable", "claims": [{ "id": "C9", "text": "Bytes stay stable" }],
-        "claimLoadBearing": true, "fulfillments": [], "riskTier": "medium", "urgency": "high",
-        "modules": [], "productLines": [], "evidenceRelations": [], "dryRun": false
+        "kind": "decision-propose",
+        "decisionId": "dec_GOLDEN",
+        "proposedAt": "2026-07-20T00:00:00.000Z",
+        "title": "Golden decision",
+        "question": "Keep bytes?",
+        "chosen": [
+          {
+            "id": "CH9",
+            "text": "Yes"
+          }
+        ],
+        "rejected": [
+          {
+            "id": "RJ9",
+            "text": "No",
+            "why_not": "Breaks parity"
+          }
+        ],
+        "claim": "Bytes stay stable",
+        "claims": [
+          {
+            "id": "C9",
+            "text": "Bytes stay stable"
+          }
+        ],
+        "claimLoadBearing": true,
+        "fulfillments": [],
+        "riskTier": "medium",
+        "urgency": "high",
+        "modules": [],
+        "productLines": [],
+        "evidenceRelations": [],
+        "dryRun": false
       },
       "defaults": {
-        "kind": "decision-propose", "decisionId": "dec_GOLDEN", "proposedAt": "2026-07-20T00:00:00.000Z",
-        "title": "Golden decision", "question": "Keep bytes?",
-        "chosen": [{ "text": "Yes", "id": "CH1" }],
-        "rejected": [{ "text": "No", "why_not": "Breaks parity", "id": "RJ1" }],
-        "claim": "Bytes stay stable", "claims": [{ "text": "Bytes stay stable", "id": "C1" }],
-        "claimLoadBearing": true, "fulfillments": [], "riskTier": "medium", "urgency": "high",
-        "modules": [], "productLines": [], "evidenceRelations": [], "dryRun": false
+        "kind": "decision-propose",
+        "decisionId": "dec_GOLDEN",
+        "proposedAt": "2026-07-20T00:00:00.000Z",
+        "title": "Golden decision",
+        "question": "Keep bytes?",
+        "chosen": [
+          {
+            "text": "Yes",
+            "id": "CH1"
+          }
+        ],
+        "rejected": [
+          {
+            "text": "No",
+            "why_not": "Breaks parity",
+            "id": "RJ1"
+          }
+        ],
+        "claim": "Bytes stay stable",
+        "claims": [
+          {
+            "text": "Bytes stay stable",
+            "id": "C1"
+          }
+        ],
+        "claimLoadBearing": true,
+        "fulfillments": [],
+        "riskTier": "medium",
+        "urgency": "high",
+        "modules": [],
+        "productLines": [],
+        "evidenceRelations": [],
+        "dryRun": false
       },
       "duplicateRecovery": {
-        "kind": "decision-propose", "decisionId": "dec_GOLDEN", "proposedAt": "2026-07-20T00:00:00.000Z",
-        "title": "Golden decision", "question": "Keep bytes?",
-        "chosen": [{ "id": "CH1", "text": "One" }, { "id": "CH2", "text": "Two" }],
-        "rejected": [{ "text": "No", "why_not": "Breaks parity", "id": "RJ1" }],
-        "claim": "Bytes stay stable", "claims": [{ "text": "Bytes stay stable", "id": "C1" }],
-        "claimLoadBearing": true, "fulfillments": [], "riskTier": "medium", "urgency": "high",
-        "modules": [], "productLines": [], "evidenceRelations": [], "dryRun": false
+        "kind": "decision-propose",
+        "decisionId": "dec_GOLDEN",
+        "proposedAt": "2026-07-20T00:00:00.000Z",
+        "title": "Golden decision",
+        "question": "Keep bytes?",
+        "chosen": [
+          {
+            "id": "CH1",
+            "text": "One"
+          },
+          {
+            "id": "CH2",
+            "text": "Two"
+          }
+        ],
+        "rejected": [
+          {
+            "text": "No",
+            "why_not": "Breaks parity",
+            "id": "RJ1"
+          }
+        ],
+        "claim": "Bytes stay stable",
+        "claims": [
+          {
+            "text": "Bytes stay stable",
+            "id": "C1"
+          }
+        ],
+        "claimLoadBearing": true,
+        "fulfillments": [],
+        "riskTier": "medium",
+        "urgency": "high",
+        "modules": [],
+        "productLines": [],
+        "evidenceRelations": [],
+        "dryRun": false
       }
     },
     "materializer": {
-      "success": { "ok": true, "value": { "ok": true, "decision": {
-        "schema": "decision-package/v1", "decision_id": "dec_GOLDEN", "title": "Golden decision", "state": "proposed",
-        "riskTier": "medium", "urgency": "high", "vertical": "software/coding", "preset": "architecture-decision",
-        "applies_to": { "modules": [], "productLines": [] }, "proposedAt": "2026-07-20T00:00:00.000Z",
-        "question": "Keep bytes?", "chosen": [{ "id": "CH9", "text": "Yes" }],
-        "rejected": [{ "id": "RJ9", "text": "No", "why_not": "Breaks parity" }],
-        "claims": [{ "id": "C9", "text": "Bytes stay stable" }], "relations": []
-      } } },
-      "defaults": { "ok": true, "value": { "ok": true, "decision": {
-        "schema": "decision-package/v1", "decision_id": "dec_GOLDEN", "title": "Golden decision", "state": "proposed",
-        "riskTier": "medium", "urgency": "high", "vertical": "software/coding", "preset": "architecture-decision",
-        "applies_to": { "modules": [], "productLines": [] }, "proposedAt": "2026-07-20T00:00:00.000Z",
-        "question": "Keep bytes?", "chosen": [{ "id": "CH1", "text": "Yes" }],
-        "rejected": [{ "id": "RJ1", "text": "No", "why_not": "Breaks parity" }],
-        "claims": [{ "id": "C1", "text": "Bytes stay stable" }], "relations": []
-      } } },
-      "failure": { "ok": true, "value": { "ok": false, "code": "invalid_decision_evidence_relation", "reason": "decision evidence relation source anchor does not exist: MISSING" } }
+      "success": {
+        "ok": true,
+        "value": {
+          "ok": true,
+          "decision": {
+            "schema": "decision-package/v1",
+            "decision_id": "dec_GOLDEN",
+            "title": "Golden decision",
+            "state": "proposed",
+            "riskTier": "medium",
+            "urgency": "high",
+            "vertical": "software/coding",
+            "preset": "architecture-decision",
+            "applies_to": {
+              "modules": [],
+              "productLines": []
+            },
+            "proposedAt": "2026-07-20T00:00:00.000Z",
+            "question": "Keep bytes?",
+            "chosen": [
+              {
+                "id": "CH9",
+                "text": "Yes"
+              }
+            ],
+            "rejected": [
+              {
+                "id": "RJ9",
+                "text": "No",
+                "why_not": "Breaks parity"
+              }
+            ],
+            "claims": [
+              {
+                "id": "C9",
+                "text": "Bytes stay stable"
+              }
+            ],
+            "relations": []
+          }
+        }
+      },
+      "defaults": {
+        "ok": true,
+        "value": {
+          "ok": true,
+          "decision": {
+            "schema": "decision-package/v1",
+            "decision_id": "dec_GOLDEN",
+            "title": "Golden decision",
+            "state": "proposed",
+            "riskTier": "medium",
+            "urgency": "high",
+            "vertical": "software/coding",
+            "preset": "architecture-decision",
+            "applies_to": {
+              "modules": [],
+              "productLines": []
+            },
+            "proposedAt": "2026-07-20T00:00:00.000Z",
+            "question": "Keep bytes?",
+            "chosen": [
+              {
+                "id": "CH1",
+                "text": "Yes"
+              }
+            ],
+            "rejected": [
+              {
+                "id": "RJ1",
+                "text": "No",
+                "why_not": "Breaks parity"
+              }
+            ],
+            "claims": [
+              {
+                "id": "C1",
+                "text": "Bytes stay stable"
+              }
+            ],
+            "relations": []
+          }
+        }
+      },
+      "failure": {
+        "ok": true,
+        "value": {
+          "ok": false,
+          "code": "invalid_decision_evidence_relation",
+          "reason": "decision evidence relation source anchor does not exist: MISSING"
+        }
+      }
     },
     "identity": {
-      "success": { "ok": true, "value": { "mode": "local", "people": ["person_golden"], "providerId": "transport-derived/v1", "adminPeople": [{ "personId": "person_golden", "primaryEmail": "golden@example.test" }] } },
-      "defaults": { "ok": true, "value": { "mode": "local", "people": [], "providerId": null, "adminPeople": [] } },
-      "failure": { "ok": true, "value": { "mode": "remote", "people": [], "providerId": null, "adminPeople": [] } }
+      "success": {
+        "ok": true,
+        "value": {
+          "mode": "local",
+          "people": [
+            "person_golden"
+          ],
+          "providerId": "transport-derived/v1",
+          "adminPeople": [
+            {
+              "personId": "person_golden",
+              "primaryEmail": "golden@example.test"
+            }
+          ]
+        }
+      },
+      "defaults": {
+        "ok": true,
+        "value": {
+          "mode": "local",
+          "people": [],
+          "providerId": null,
+          "adminPeople": []
+        }
+      },
+      "failure": {
+        "ok": true,
+        "value": {
+          "mode": "remote",
+          "people": [],
+          "providerId": null,
+          "adminPeople": []
+        }
+      }
     },
     "forceStatusAudit": {
       "success": "FORCE_STATUS_SET_AUDIT: forced terminal status=completed; reason=golden reason; recordedAt=2026-07-20T00:00:00.000Z",
@@ -97,9 +321,18 @@
       "edge": "FORCE_STATUS_SET_AUDIT: forced terminal status=; reason=; recordedAt=2026-07-20T00:00:00.000Z"
     },
     "taskCreateWrites": {
-      "adapterDefault": { "byteLength": 1468, "sha256": "196bf0ad812a4b626e197556bb0413b8a5185a9505ffe5afd5f6ab312090e957" },
-      "settingsPreset": { "byteLength": 7076, "sha256": "2bd4a4a4732084f3576a9bd2abb9a6383f36a4127afba583e74c9ad359aada79" },
-      "settingsFailure": { "byteLength": 79, "sha256": "be9d4989c69f9ffc90dd734fcc56801a0a0cd5caa35d27a895a8a83c172bc3d4" }
+      "adapterDefault": {
+        "byteLength": 1468,
+        "sha256": "196bf0ad812a4b626e197556bb0413b8a5185a9505ffe5afd5f6ab312090e957"
+      },
+      "settingsPreset": {
+        "byteLength": 7278,
+        "sha256": "2bc224d63461f63d2f6ce647ae697d48c410de754aa241d3b277de0bba43c148"
+      },
+      "settingsFailure": {
+        "byteLength": 79,
+        "sha256": "be9d4989c69f9ffc90dd734fcc56801a0a0cd5caa35d27a895a8a83c172bc3d4"
+      }
     }
   }
 }

--- a/tools/local-resource-governance.mjs
+++ b/tools/local-resource-governance.mjs
@@ -18,6 +18,14 @@ import path from "node:path";
 // 这样一台机器上所有 harness 进程对容量的判断天然一致，不会各算各的。
 export const DEFAULT_INTERACTIVE_CORE_RESERVATION = 4;
 export const DEFAULT_LOCAL_TEST_CONCURRENCY = 2;
+
+// 一个「并发测试文件」不等于一个核:集成测试会自己 spawn daemon 与 CLI 子进程。
+// 2026-07-21 在 M3 Max(16 核/128 GB)上对完整 check:ci 做 A/B 实测:
+//   3 路 shard → shard 阶段墙钟 625s,进程时间合计 1774s,单 shard 均值 295s
+//   6 路 shard → shard 阶段墙钟 618s,进程时间合计 3012s,单 shard 均值 502s
+// 并行翻倍只换来 1% 墙钟,机器时间却多花 70% —— 说明 3 路时吞吐已经到顶,再加只是把
+// 同样的吞吐切得更碎,还会挤掉同机其他 worker。反推出的系数≈每个并发测试文件 2 个核。
+export const DEFAULT_CORES_PER_TEST_PROCESS = 2;
 export const INTERACTIVE_CORE_RESERVATION_ENV = "HARNESS_INTERACTIVE_CORE_RESERVATION";
 export const LOCAL_SLOT_ROOT = path.join(homedir(), ".harness", "locks", "local-heavy-v1");
 
@@ -53,7 +61,11 @@ const INITIALIZATION_GRACE_MS = 30_000;
 
 export function resolveLocalSlotCount(
   raw = process.env.HARNESS_LOCAL_SLOTS,
-  { cpuCount, reservationRaw, perSlotCores = DEFAULT_LOCAL_TEST_CONCURRENCY } = {}
+  {
+    cpuCount,
+    reservationRaw,
+    perSlotCores = DEFAULT_LOCAL_TEST_CONCURRENCY * DEFAULT_CORES_PER_TEST_PROCESS
+  } = {}
 ) {
   if (raw !== undefined && raw !== "") {
     const parsed = Number(raw);

--- a/tools/local-resource-governance.mjs
+++ b/tools/local-resource-governance.mjs
@@ -11,12 +11,39 @@ import {
   statSync,
   writeFileSync
 } from "node:fs";
-import { homedir, hostname } from "node:os";
+import { availableParallelism, homedir, hostname } from "node:os";
 import path from "node:path";
 
-export const DEFAULT_LOCAL_SLOTS = 3;
+// 本机治理的第一性参数是「留给人的核心数」，不是槽数。槽数、shard 并行度都从它派生，
+// 这样一台机器上所有 harness 进程对容量的判断天然一致，不会各算各的。
+export const DEFAULT_INTERACTIVE_CORE_RESERVATION = 4;
 export const DEFAULT_LOCAL_TEST_CONCURRENCY = 2;
+export const INTERACTIVE_CORE_RESERVATION_ENV = "HARNESS_INTERACTIVE_CORE_RESERVATION";
 export const LOCAL_SLOT_ROOT = path.join(homedir(), ".harness", "locks", "local-heavy-v1");
+
+export function resolveInteractiveCoreReservation(
+  raw = process.env[INTERACTIVE_CORE_RESERVATION_ENV]
+) {
+  if (raw === undefined || raw === "") return DEFAULT_INTERACTIVE_CORE_RESERVATION;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(
+      `${INTERACTIVE_CORE_RESERVATION_ENV} must be a non-negative integer; received ${JSON.stringify(raw)}`
+    );
+  }
+  return parsed;
+}
+
+export function resolveLocalCoreBudget({
+  raw = process.env[INTERACTIVE_CORE_RESERVATION_ENV],
+  cpuCount = availableParallelism()
+} = {}) {
+  if (!Number.isSafeInteger(cpuCount) || cpuCount <= 0) {
+    throw new Error("CPU count must be a positive integer");
+  }
+  const reserved = resolveInteractiveCoreReservation(raw);
+  return { cpuCount, reserved, usableCores: Math.max(1, cpuCount - reserved) };
+}
 
 const OWNER_FILE = "owner.json";
 const REAPER_DIR = ".reaper";
@@ -24,13 +51,22 @@ const SLOT_PATH_ENV = "HARNESS_LOCAL_SLOT_PATH";
 const SLOT_TOKEN_ENV = "HARNESS_LOCAL_SLOT_TOKEN";
 const INITIALIZATION_GRACE_MS = 30_000;
 
-export function resolveLocalSlotCount(raw = process.env.HARNESS_LOCAL_SLOTS) {
-  if (raw === undefined || raw === "") return DEFAULT_LOCAL_SLOTS;
-  const parsed = Number(raw);
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error(`HARNESS_LOCAL_SLOTS must be a positive integer; received ${JSON.stringify(raw)}`);
+export function resolveLocalSlotCount(
+  raw = process.env.HARNESS_LOCAL_SLOTS,
+  { cpuCount, reservationRaw, perSlotCores = DEFAULT_LOCAL_TEST_CONCURRENCY } = {}
+) {
+  if (raw !== undefined && raw !== "") {
+    const parsed = Number(raw);
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+      throw new Error(`HARNESS_LOCAL_SLOTS must be a positive integer; received ${JSON.stringify(raw)}`);
+    }
+    return parsed;
   }
-  return parsed;
+  const { usableCores } = resolveLocalCoreBudget({
+    ...(reservationRaw === undefined ? {} : { raw: reservationRaw }),
+    ...(cpuCount === undefined ? {} : { cpuCount })
+  });
+  return Math.max(1, Math.floor(usableCores / perSlotCores));
 }
 
 export function selectQosPrefix({ platform, hasTaskpolicy, hasNice }) {

--- a/tools/local-resource-governance.test.mjs
+++ b/tools/local-resource-governance.test.mjs
@@ -8,20 +8,39 @@ import test from "node:test";
 import { pathToFileURL } from "node:url";
 import {
   acquireLocalHeavySlot,
-  DEFAULT_LOCAL_SLOTS,
+  DEFAULT_INTERACTIVE_CORE_RESERVATION,
   discoverQosPrefix,
   LOCAL_SLOT_ROOT,
   processStartFingerprint,
   prefixCommand,
+  resolveLocalCoreBudget,
   resolveLocalSlotCount,
   selectQosPrefix
 } from "./local-resource-governance.mjs";
 
-test("local slot capacity defaults to three and rejects invalid overrides", () => {
-  assert.equal(DEFAULT_LOCAL_SLOTS, 3);
+// 这些解析器的默认参数会读进程 env(生产行为正确),所以测试一律显式传 raw:""(= 未设置),
+// 否则本机开发者 shell 里存着 HARNESS_LOCAL_SLOTS 就会看到假红,而 CI 里没有该变量照样绿。
+test("the interactive core reservation is the first-class knob and the rest of the machine is spendable", () => {
+  assert.equal(DEFAULT_INTERACTIVE_CORE_RESERVATION, 4);
+  assert.deepEqual(resolveLocalCoreBudget({ cpuCount: 16, raw: "" }), {
+    cpuCount: 16, reserved: 4, usableCores: 12
+  });
+  assert.deepEqual(resolveLocalCoreBudget({ cpuCount: 16, raw: "10" }), {
+    cpuCount: 16, reserved: 10, usableCores: 6
+  });
+  assert.equal(
+    resolveLocalCoreBudget({ cpuCount: 2, raw: "8" }).usableCores,
+    1,
+    "an over-large reservation still leaves one usable core instead of deadlocking"
+  );
+  assert.throws(() => resolveLocalCoreBudget({ cpuCount: 16, raw: "-1" }), /non-negative integer/u);
+});
+
+test("local slot capacity derives from the core budget and rejects invalid overrides", () => {
   assert.equal(LOCAL_SLOT_ROOT, path.join(homedir(), ".harness", "locks", "local-heavy-v1"));
-  assert.equal(resolveLocalSlotCount(undefined), 3);
-  assert.equal(resolveLocalSlotCount("2"), 2);
+  assert.equal(resolveLocalSlotCount("", { cpuCount: 16, reservationRaw: "4" }), 6);
+  assert.equal(resolveLocalSlotCount("", { cpuCount: 8, reservationRaw: "4" }), 2);
+  assert.equal(resolveLocalSlotCount("2", { cpuCount: 16 }), 2);
   assert.throws(() => resolveLocalSlotCount("0"), /positive integer/u);
   assert.throws(() => resolveLocalSlotCount("many"), /positive integer/u);
 });

--- a/tools/local-resource-governance.test.mjs
+++ b/tools/local-resource-governance.test.mjs
@@ -38,8 +38,8 @@ test("the interactive core reservation is the first-class knob and the rest of t
 
 test("local slot capacity derives from the core budget and rejects invalid overrides", () => {
   assert.equal(LOCAL_SLOT_ROOT, path.join(homedir(), ".harness", "locks", "local-heavy-v1"));
-  assert.equal(resolveLocalSlotCount("", { cpuCount: 16, reservationRaw: "4" }), 6);
-  assert.equal(resolveLocalSlotCount("", { cpuCount: 8, reservationRaw: "4" }), 2);
+  assert.equal(resolveLocalSlotCount("", { cpuCount: 16, reservationRaw: "4" }), 3);
+  assert.equal(resolveLocalSlotCount("", { cpuCount: 8, reservationRaw: "4" }), 1);
   assert.equal(resolveLocalSlotCount("2", { cpuCount: 16 }), 2);
   assert.throws(() => resolveLocalSlotCount("0"), /positive integer/u);
   assert.throws(() => resolveLocalSlotCount("many"), /positive integer/u);

--- a/tools/run-ci-equivalent.mjs
+++ b/tools/run-ci-equivalent.mjs
@@ -15,7 +15,11 @@
 //   npm run check:ci                      跑全部可本地执行的 job
 //   npm run check:ci -- --job boundaries  只跑指定 job(可重复)
 //   npm run check:ci -- --json             额外吐一份机器可读回执(贴进 PR / worker 报告)
-//   HARNESS_SHARD_PARALLELISM=2 npm run check:ci  显式控制本地 integration shard fan-out
+//   HARNESS_SHARD_PARALLELISM=2 npm run check:ci  显式收窄本地 integration shard fan-out
+//
+// 本机资源治理的第一性参数是「留给人的核心数」:HARNESS_INTERACTIVE_CORE_RESERVATION
+// (默认 4)。它之外的核心都可以被 harness 花掉,槽数与 shard 并行度都由它派生;
+// 想让本机跑得更满就调小它,想把机器还给自己就调大它。QoS 负责动态让路,预算负责封顶。
 //
 // 回执是产物,不是断言:每个 job 的真实 exit code 都在里面。CEO 会重跑并比对数字。
 
@@ -31,6 +35,7 @@ import {
 import {
   discoverQosPrefix,
   prefixCommand,
+  resolveLocalCoreBudget,
   resolveLocalSlotCount,
   withLocalHeavySlot
 } from "./local-resource-governance.mjs";
@@ -231,8 +236,16 @@ async function main() {
   });
   const perShardConcurrency = resolvedTestConcurrency ?? cpuCount;
   const shardCount = plan.filter(([job]) => job === INTEGRATION_SHARD_JOB).length;
+  const coreBudget = resolveLocalCoreBudget({ cpuCount });
   const shardResolution = shardCount === 0
-    ? { parallelism: 1, source: "not-selected", requested: 0, freeCores: 0, perShardConcurrency }
+    ? {
+      parallelism: 1,
+      source: "not-selected",
+      requested: 0,
+      usableCores: coreBudget.usableCores,
+      reservedCores: coreBudget.reserved,
+      perShardConcurrency
+    }
     : resolveShardParallelism({
       shardCount,
       localSlots,
@@ -244,8 +257,9 @@ async function main() {
     `\n[check:ci] ${plan.length} runs derived from tools/gate-manifest.json and ${path.relative(root, workflowPath)} ` +
     `(${[...derived].map(([job, gates]) => `${job}:${gates.length}`).join(" ")}); ` +
     `QoS=${qosPrefix.join(" ") || "none"}; slots=${localSlots}; ` +
+    `cores=${cpuCount} (reserved=${shardResolution.reservedCores}, usable=${shardResolution.usableCores}); ` +
     `shard-parallelism=${shardResolution.parallelism} (${shardResolution.source}, requested=${shardResolution.requested}, ` +
-    `free-cores=${shardResolution.freeCores}, per-shard=${shardResolution.perShardConcurrency})\n`
+    `per-shard=${shardResolution.perShardConcurrency})\n`
   );
   const receipts = await runCiPlan(plan, shardResolution.parallelism);
 

--- a/tools/run-ci-equivalent.test.mjs
+++ b/tools/run-ci-equivalent.test.mjs
@@ -76,33 +76,45 @@ test("skipped jobs are visible in the final summary and JSON receipt", () => {
   assert.match(summary, /本地绿 ≠ 完整 CI 等价/u);
 });
 
-test("explicit shard parallelism wins over load adaptation but keeps slot and CPU safety caps", () => {
+test("explicit shard parallelism narrows fan-out but can never spend the interactive core reservation", () => {
   assert.deepEqual(resolveShardParallelism({
-    raw: "2", shardCount: 6, localSlots: 3, perShardConcurrency: 2, cpuCount: 12, loadOne: 11
+    raw: "2", shardCount: 6, localSlots: 6, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "4"
   }), {
     parallelism: 2,
     source: "explicit",
     requested: 2,
-    freeCores: 1,
-    cpuCap: 6,
-    localSlots: 3,
+    usableCores: 12,
+    reservedCores: 4,
+    coreCap: 6,
+    localSlots: 6,
     perShardConcurrency: 2
   });
   assert.equal(resolveShardParallelism({
-    raw: "9", shardCount: 6, localSlots: 3, perShardConcurrency: 4, cpuCount: 8, loadOne: 0
-  }).parallelism, 2);
+    raw: "99", shardCount: 6, localSlots: 6, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "4"
+  }).parallelism, 6);
   assert.throws(() => resolveShardParallelism({
-    raw: "many", shardCount: 2, localSlots: 3, perShardConcurrency: 2, cpuCount: 8, loadOne: 0
+    raw: "many", shardCount: 2, localSlots: 3, perShardConcurrency: 2, cpuCount: 8, reservationRaw: ""
   }), /HARNESS_SHARD_PARALLELISM must be a positive integer/u);
 });
 
-test("adaptive shard parallelism derives from free cores and never exceeds the machine slot budget", () => {
+test("default shard parallelism spends the whole core budget and shrinks as the reservation grows", () => {
   assert.equal(resolveShardParallelism({
-    shardCount: 6, localSlots: 3, perShardConcurrency: 2, cpuCount: 12, loadOne: 4
-  }).parallelism, 3);
+    raw: "", shardCount: 6, localSlots: 6, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "4"
+  }).parallelism, 6);
   assert.equal(resolveShardParallelism({
-    shardCount: 6, localSlots: 3, perShardConcurrency: 2, cpuCount: 12, loadOne: 11
-  }).parallelism, 1);
+    raw: "", shardCount: 6, localSlots: 6, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "12"
+  }).parallelism, 2);
+  assert.equal(resolveShardParallelism({
+    raw: "", shardCount: 6, localSlots: 2, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "0"
+  }).parallelism, 2, "an explicit slot budget still bounds fan-out");
+});
+
+test("machine load never shrinks the declared core budget", () => {
+  const busy = resolveShardParallelism({
+    raw: "", shardCount: 6, localSlots: 6, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "4"
+  });
+  assert.equal(busy.source, "core-budget");
+  assert.equal(busy.parallelism, 6, "self-inflicted load must not self-throttle the runner");
 });
 
 test("parallelism two overlaps two shard child processes and preserves a failing exit code", async (context) => {
@@ -110,7 +122,7 @@ test("parallelism two overlaps two shard child processes and preserves a failing
   context.after(() => rmSync(fixtureRoot, { recursive: true, force: true }));
   const plan = [["integration-shard", 1], ["integration-shard", 2]];
   const resolution = resolveShardParallelism({
-    raw: "2", shardCount: 2, localSlots: 3, perShardConcurrency: 2, cpuCount: 8, loadOne: 7
+    raw: "2", shardCount: 2, localSlots: 3, perShardConcurrency: 2, cpuCount: 8, reservationRaw: ""
   });
   const receipts = await runCiPlan(
     plan,

--- a/tools/run-ci-equivalent.test.mjs
+++ b/tools/run-ci-equivalent.test.mjs
@@ -78,20 +78,20 @@ test("skipped jobs are visible in the final summary and JSON receipt", () => {
 
 test("explicit shard parallelism narrows fan-out but can never spend the interactive core reservation", () => {
   assert.deepEqual(resolveShardParallelism({
-    raw: "2", shardCount: 6, localSlots: 6, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "4"
+    raw: "2", shardCount: 6, localSlots: 3, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "4"
   }), {
     parallelism: 2,
     source: "explicit",
     requested: 2,
     usableCores: 12,
     reservedCores: 4,
-    coreCap: 6,
-    localSlots: 6,
+    coreCap: 3,
+    localSlots: 3,
     perShardConcurrency: 2
   });
   assert.equal(resolveShardParallelism({
-    raw: "99", shardCount: 6, localSlots: 6, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "4"
-  }).parallelism, 6);
+    raw: "99", shardCount: 6, localSlots: 3, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "4"
+  }).parallelism, 3);
   assert.throws(() => resolveShardParallelism({
     raw: "many", shardCount: 2, localSlots: 3, perShardConcurrency: 2, cpuCount: 8, reservationRaw: ""
   }), /HARNESS_SHARD_PARALLELISM must be a positive integer/u);
@@ -99,11 +99,11 @@ test("explicit shard parallelism narrows fan-out but can never spend the interac
 
 test("default shard parallelism spends the whole core budget and shrinks as the reservation grows", () => {
   assert.equal(resolveShardParallelism({
-    raw: "", shardCount: 6, localSlots: 6, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "4"
-  }).parallelism, 6);
+    raw: "", shardCount: 6, localSlots: 3, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "4"
+  }).parallelism, 3);
   assert.equal(resolveShardParallelism({
-    raw: "", shardCount: 6, localSlots: 6, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "12"
-  }).parallelism, 2);
+    raw: "", shardCount: 6, localSlots: 3, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "12"
+  }).parallelism, 1);
   assert.equal(resolveShardParallelism({
     raw: "", shardCount: 6, localSlots: 2, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "0"
   }).parallelism, 2, "an explicit slot budget still bounds fan-out");
@@ -111,10 +111,10 @@ test("default shard parallelism spends the whole core budget and shrinks as the 
 
 test("machine load never shrinks the declared core budget", () => {
   const busy = resolveShardParallelism({
-    raw: "", shardCount: 6, localSlots: 6, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "4"
+    raw: "", shardCount: 6, localSlots: 3, perShardConcurrency: 2, cpuCount: 16, reservationRaw: "4"
   });
   assert.equal(busy.source, "core-budget");
-  assert.equal(busy.parallelism, 6, "self-inflicted load must not self-throttle the runner");
+  assert.equal(busy.parallelism, 3, "self-inflicted load must not self-throttle the runner");
 });
 
 test("parallelism two overlaps two shard child processes and preserves a failing exit code", async (context) => {
@@ -122,7 +122,7 @@ test("parallelism two overlaps two shard child processes and preserves a failing
   context.after(() => rmSync(fixtureRoot, { recursive: true, force: true }));
   const plan = [["integration-shard", 1], ["integration-shard", 2]];
   const resolution = resolveShardParallelism({
-    raw: "2", shardCount: 2, localSlots: 3, perShardConcurrency: 2, cpuCount: 8, reservationRaw: ""
+    raw: "2", shardCount: 2, localSlots: 3, perShardConcurrency: 2, cpuCount: 16, reservationRaw: ""
   });
   const receipts = await runCiPlan(
     plan,

--- a/tools/shard-parallelism.mjs
+++ b/tools/shard-parallelism.mjs
@@ -1,12 +1,17 @@
 import { availableParallelism } from "node:os";
 
-import { resolveLocalCoreBudget } from "./local-resource-governance.mjs";
+import {
+  DEFAULT_CORES_PER_TEST_PROCESS,
+  resolveLocalCoreBudget
+} from "./local-resource-governance.mjs";
 
 export const SHARD_PARALLELISM_ENV = "HARNESS_SHARD_PARALLELISM";
 
-// 并行度按「可用核心预算 ÷ 每 shard 并发」算，不看 loadavg。loadavg 分不清负载是用户的
-// 还是我们自己的，一旦把自己的负载算进去就会自我节流(实测 requested 5 掉到 3)；
-// 真正的动态让路交给 QoS(taskpolicy -c utility)，静态预算只负责封顶要多少。
+// 并行度 = 可用核心预算 ÷ (每 shard 并发 × 每个测试文件实测占用的核心数)，不看 loadavg。
+// loadavg 分不清负载是用户的还是我们自己的，一旦把自己的负载算进去就会自我节流
+// (实测 requested 5 掉到 3)；动态让路交给 QoS(taskpolicy -c utility)，静态预算只封顶。
+// 系数来自实测而非估算，理由见 DEFAULT_CORES_PER_TEST_PROCESS：把 fan-out 从 3 拉到 6
+// 只买到 1% 墙钟却多花 70% 机器时间，说明超过预算继续加并行是纯负和。
 export function resolveShardParallelism({
   raw = process.env[SHARD_PARALLELISM_ENV],
   shardCount,
@@ -24,7 +29,8 @@ export function resolveShardParallelism({
     cpuCount,
     ...(reservationRaw === undefined ? {} : { raw: reservationRaw })
   });
-  const coreCap = Math.max(1, Math.floor(budget.usableCores / perShardConcurrency));
+  const coresPerShard = perShardConcurrency * DEFAULT_CORES_PER_TEST_PROCESS;
+  const coreCap = Math.max(1, Math.floor(budget.usableCores / coresPerShard));
   const explicit = parseExplicitParallelism(raw);
   const requested = explicit ?? coreCap;
   const parallelism = Math.min(requested, shardCount, localSlots, coreCap);

--- a/tools/shard-parallelism.mjs
+++ b/tools/shard-parallelism.mjs
@@ -1,34 +1,41 @@
-import { availableParallelism, loadavg } from "node:os";
+import { availableParallelism } from "node:os";
+
+import { resolveLocalCoreBudget } from "./local-resource-governance.mjs";
 
 export const SHARD_PARALLELISM_ENV = "HARNESS_SHARD_PARALLELISM";
 
+// 并行度按「可用核心预算 ÷ 每 shard 并发」算，不看 loadavg。loadavg 分不清负载是用户的
+// 还是我们自己的，一旦把自己的负载算进去就会自我节流(实测 requested 5 掉到 3)；
+// 真正的动态让路交给 QoS(taskpolicy -c utility)，静态预算只负责封顶要多少。
 export function resolveShardParallelism({
   raw = process.env[SHARD_PARALLELISM_ENV],
   shardCount,
   localSlots,
   perShardConcurrency,
   cpuCount = availableParallelism(),
-  loadOne = loadavg()[0]
+  reservationRaw
 }) {
   assertPositiveInteger(shardCount, "shard count");
   assertPositiveInteger(localSlots, "local slot count");
   assertPositiveInteger(perShardConcurrency, "per-shard concurrency");
   assertPositiveInteger(cpuCount, "CPU count");
 
-  const normalizedLoad = Number.isFinite(loadOne) && loadOne >= 0 ? loadOne : cpuCount;
-  const freeCores = Math.max(1, Math.floor(cpuCount - normalizedLoad));
-  const adaptive = Math.max(1, Math.floor(freeCores / perShardConcurrency));
+  const budget = resolveLocalCoreBudget({
+    cpuCount,
+    ...(reservationRaw === undefined ? {} : { raw: reservationRaw })
+  });
+  const coreCap = Math.max(1, Math.floor(budget.usableCores / perShardConcurrency));
   const explicit = parseExplicitParallelism(raw);
-  const requested = explicit ?? adaptive;
-  const cpuCap = Math.max(1, Math.floor(cpuCount / perShardConcurrency));
-  const parallelism = Math.min(requested, shardCount, localSlots, cpuCap);
+  const requested = explicit ?? coreCap;
+  const parallelism = Math.min(requested, shardCount, localSlots, coreCap);
 
   return {
     parallelism,
-    source: explicit === null ? "adaptive" : "explicit",
+    source: explicit === null ? "core-budget" : "explicit",
     requested,
-    freeCores,
-    cpuCap,
+    usableCores: budget.usableCores,
+    reservedCores: budget.reserved,
+    coreCap,
     localSlots,
     perShardConcurrency
   };


### PR DESCRIPTION
# English

## Summary

Local capacity governance gets one first-class parameter — **how many cores stay reserved for
the human at the keyboard** — and the numbers that used to be hardcoded are now derived from it
against a *measured* per-test core cost. A full A/B of local `check:ci` refuted the assumption
that motivated this work, and the refutation is encoded in the code rather than lost in chat.

## What Changed

- `HARNESS_INTERACTIVE_CORE_RESERVATION` (default `4`) declares the reservation;
  `usableCores = max(1, cpuCount - reserved)`. Slot count and integration-shard fan-out derive
  from it, so one machine's harness processes all compute the same capacity.
- `DEFAULT_CORES_PER_TEST_PROCESS = 2`, measured rather than estimated. A concurrent test file
  is not one core: integration tests spawn daemon and CLI children. Fan-out is therefore
  `usableCores / (perShardConcurrency × coresPerTestProcess)` — 3 on a 16-core machine with the
  default reservation, 6 on a 32-core one, 4 if the reservation is dropped to zero.
- The loadavg adaptation is deleted. `loadavg` cannot separate the user's load from the runner's
  own, so the runner throttled itself the moment it got busy (measured: `requested=5` collapsing
  to `3`), and on this machine most of the load is other agents' processes anyway. Dynamic
  yielding belongs to QoS (`taskpolicy -c utility` / `nice`); the static budget only caps intent.
- `HARNESS_SHARD_PARALLELISM` can now only narrow fan-out within the budget. One safety property,
  one knob: to spend more of the machine, lower the reservation.
- The `task.plan` template's stop point no longer tells workers to run `npm run check:ci` green.
  That line contradicted the 2026-07-20 ruling that retired the local full gate, and a task
  package contract beats a dispatch prompt — which is why workers kept serially running the full
  matrix despite being told not to. Stop point is now targeted tests for the touched surface.
- Catalog version `1.3.2` → `1.4.0` with a refreshed lock digest, because template bodies are
  versioned contract content. The parent-differential golden fixture is re-captured through its
  own `HARNESS_CAPTURE_BATCH5A_GOLDEN=1` path; only `taskCreateWrites.settingsPreset` moved and
  all eleven pinned implementation blobs are untouched, which is the evidence that generated
  bytes changed while implementation behavior did not.

## Task And Scope

- Harness task: `task_01KY21Y551DZFTFZ7620PQYGDF`
- Branch: `feat/local-core-budget`
- Public scope: local runner capacity policy, plan-template stop point, catalog version
- Private planning/evidence updated: yes
- Out of scope: CI workflow definitions, required contexts, job timeouts, semaphore semantics

## Version Impact

- Version: template catalog `1.3.2` -> `1.4.0`; no npm package version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `extension-contract.lock.json` catalog version and digest; the
  parent-differential golden fixture
- Authority: `dec_01KY21PQNY59FQTY3A3YE950BQ` (active), which narrows
  `dec_01KXFEMGFNT0QF5PTXVDGQGZ76`; anchored to `fact/task_01KY21Y551DZFTFZ7620PQYGDF/F-VX1J9K5Y`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether
  it is true and sufficient.
- Break-glass: no
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: `1941a8eb`
- Sync method: branched from `origin/main`, no rebase needed
- Public diff command: `git diff 1941a8eb..HEAD`
- `npm run harness:check-local-load-governance` — 48/48, run twice: once clean, once under a
  deliberately hostile environment (`HARNESS_LOCAL_SLOTS=3 HARNESS_SHARD_PARALLELISM=3
  HARNESS_INTERACTIVE_CORE_RESERVATION=9`). The hostile run exists because the first version of
  these tests read ambient env through default parameters and went red inside `check:ci` while
  passing standalone — the exact "green locally, red in CI" shape, inverted.
- `check-catalog-schema`, `check-error-next-steps`, `check-duplicate-definitions`,
  `check-package-policy`, `check-implementation-contracts` — all pass
- `packages/cli/test/production-authority-host-services/golden.test.ts` — 2/2
- `npm run typecheck`, `npx eslint tools/*.mjs` — clean
- A/B receipts committed under the task's `artifacts/`
- Not run: full local `check:ci` as a stop point — deliberately, per the ruling this PR encodes.
  The full matrix is GitHub CI's job.

## Review Evidence

- Self-review: measurement-first; the original hypothesis (more fan-out is faster) was refuted
  by the A/B and the code now encodes the refutation.
- Human review: pending
- Blocking findings: none outstanding

## Residual Risk

- `DEFAULT_CORES_PER_TEST_PROCESS` is calibrated on one machine class (Apple M3 Max, 16 cores).
  It is a declared constant with its measurement written next to it, so a different machine that
  disagrees can be re-measured and the constant revised — but it has not been validated on Linux
  CI-class hardware.
- Raising fan-out increases daemon-contention flakes. `materializer-recovery-cli` failed once
  under six-way parallelism and passed 6/6 in isolation; the calibrated default keeps fan-out at
  the previous level on this machine, so exposure is unchanged, but the risk is real if someone
  lowers the reservation aggressively.

## References

- Task: `task_01KY21Y551DZFTFZ7620PQYGDF`
- Evidence: `fact/task_01KY21Y551DZFTFZ7620PQYGDF/F-VX1J9K5Y`
- Decision: `dec_01KY21PQNY59FQTY3A3YE950BQ`

---

# 中文

## 概要

本机容量治理收敛到一个第一性参数——**给键盘前的人留几个核心**——原先写死的数字全部由它派生,
且派生系数来自**实测**而非估算。一次完整的本地 `check:ci` A/B 实测**证伪了发起这项工作的假设**,
而这个证伪被写进了代码,不是留在聊天里。

## 改动内容

- `HARNESS_INTERACTIVE_CORE_RESERVATION`(默认 `4`)声明保留量,
  `usableCores = max(1, cpuCount - reserved)`。槽数与 integration shard 并行度都由它派生,
  同一台机器上所有 harness 进程算出的容量因此天然一致。
- `DEFAULT_CORES_PER_TEST_PROCESS = 2`,来自实测而非估算。一个并发测试文件**不等于一个核**:
  集成测试会自己 spawn daemon 与 CLI 子进程。并行度因此是
  `usableCores ÷ (每 shard 并发 × 每测试文件核数)`——16 核默认保留下 = 3,32 核 = 6,
  保留量调到 0 则 = 4。
- 删除 loadavg 自适应。loadavg **分不清负载是用户的还是 runner 自己的**,一忙起来就自我节流
  (实测 `requested=5` 掉到 `3`),而且本机负载大头本来就是别的 agent 的进程。动态让路属于
  QoS(`taskpolicy -c utility` / `nice`),静态预算只负责封顶意图。
- `HARNESS_SHARD_PARALLELISM` 现在只能在预算内收窄。一个安全属性一个旋钮:想让机器跑得更满,
  就调小保留数。
- `task.plan` 模板的停止点不再要求 worker 跑绿 `npm run check:ci`。这句话与 2026-07-20
  「本地全量退役」的裁决冲突,而**任务包契约压过派活 prompt**——这正是 worker 明明被告知别跑
  却反复串行跑全量的原因。停止点改为「改动面的定向测试」。
- Catalog 版本 `1.3.2` → `1.4.0` 并刷新 lock digest,因为模板正文属于版本化契约内容。
  parent-differential golden fixture 经其自带的 `HARNESS_CAPTURE_BATCH5A_GOLDEN=1` 通道重生成;
  逐字比对确认**只有 `taskCreateWrites.settingsPreset` 变化**,11 个被钉住的实现文件 blob 一个未动
  ——这就是「生成字节变了而实现行为没变」的证据。

## 任务与范围

- Harness 任务:`task_01KY21Y551DZFTFZ7620PQYGDF`
- 分支:`feat/local-core-budget`
- 公共范围:本机 runner 容量策略、plan 模板停止点、catalog 版本
- 私有计划/证据已更新:是
- 范围外:CI workflow 定义、required contexts、job 超时、信号量语义

## 版本影响

- 版本:模板 catalog `1.3.2` -> `1.4.0`;npm 包版本不变
- 发布影响:不发布

## 治理声明

- 触碰 protected surface:是
- 范围:`extension-contract.lock.json` 的 catalog 版本与 digest;parent-differential golden fixture
- 授权:`dec_01KY21PQNY59FQTY3A3YE950BQ`(active),收窄 `dec_01KXFEMGFNT0QF5PTXVDGQGZ76`;
  锚定 `fact/task_01KY21Y551DZFTFZ7620PQYGDF/F-VX1J9K5Y`
- 机器校验边界:本 PR 只断言声明存在;声明是否属实与充分由评审者判断。
- Break-glass:否
- 后续治理任务:无

## 验证

- 基线 `origin/main` SHA:`1941a8eb`
- 同步方式:直接从 `origin/main` 开分支,无需 rebase
- 公共 diff 命令:`git diff 1941a8eb..HEAD`
- `npm run harness:check-local-load-governance` —— 48/48,跑了两次:一次干净环境,一次**故意的敌意环境**
  (`HARNESS_LOCAL_SLOTS=3 HARNESS_SHARD_PARALLELISM=3 HARNESS_INTERACTIVE_CORE_RESERVATION=9`)。
  之所以要敌意环境:这些测试的第一版通过默认参数读了环境变量,单独跑绿、在 `check:ci` 里却红——
  正是「本地绿 CI 红」的镜像形态。
- `check-catalog-schema`、`check-error-next-steps`、`check-duplicate-definitions`、
  `check-package-policy`、`check-implementation-contracts` —— 全部通过
- `packages/cli/test/production-authority-host-services/golden.test.ts` —— 2/2
- `npm run typecheck`、`npx eslint tools/*.mjs` —— 干净
- A/B 回执已落任务包 `artifacts/`
- 未跑:把本地完整 `check:ci` 当停止点——**刻意不跑**,依据正是本 PR 编码的那条裁决。完整矩阵是 CI 的活。

## 审查证据

- 自评审:先测量后下结论;原假设(并行越高越快)被 A/B 证伪,代码现在编码的是这个证伪。
- 人工评审:待办
- 阻塞发现:无

## 残余风险

- `DEFAULT_CORES_PER_TEST_PROCESS` 只在一类机器上标定过(Apple M3 Max,16 核)。它是一个把测量写在
  旁边的显式常量,换机器不符可以重测并修订——但尚未在 Linux CI 级硬件上验证。
- 提高 fan-out 会增加 daemon 争用型 flake。`materializer-recovery-cli` 在 6 路并行下红过一次,
  隔离跑 6/6 绿;校准后的默认值在本机把 fan-out 保持在原水平,所以暴露面没变,但若有人激进调小保留量,
  这个风险是真的。

## 关联材料

- 任务:`task_01KY21Y551DZFTFZ7620PQYGDF`
- 证据:`fact/task_01KY21Y551DZFTFZ7620PQYGDF/F-VX1J9K5Y`
- 决策:`dec_01KY21PQNY59FQTY3A3YE950BQ`
