### PR TITLE
fix(doc-sync): task_plan template is the baseline, addenda are free

### DIFF
--- a/packages/application/src/doc-sync.ts
+++ b/packages/application/src/doc-sync.ts
@@ -300,11 +300,15 @@ function managedSectionFailure(
   if (baseBody === candidateBody) return null;
   if (!filePath.endsWith(".md")) return null;
   if (!policy) return `SEMANTIC_DIFF_REQUIRED: no section permission declaration for ${filePath}`;
+  const effectivePolicy: SemanticDiffDocumentPolicy = {
+    ...policy,
+    undeclaredSections: policy.undeclaredSections ?? "reject"
+  };
   try {
     assertManagedSemanticRegions(
       { documents: [{ path: filePath, body: baseBody }] },
       { documents: [{ path: filePath, body: candidateBody }] },
-      { documentPolicies: [policy] }
+      { documentPolicies: [effectivePolicy] }
     );
     return null;
   } catch (error) {

--- a/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
+++ b/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
@@ -140,6 +140,32 @@ test("managed heading regions fail closed on undeclared, duplicate, machine-writ
   ), /SEMANTIC_DIFF_REQUIRED:forbidden section changed/u);
 });
 
+test("host-prose policies allow undeclared sections without weakening their declared skeleton", () => {
+  const taskId = "task_T";
+  const documentPath = `tasks/${taskId}-folder/task_plan.md`;
+  const index = { path: `tasks/${taskId}-folder/INDEX.md`, body: taskIndex(taskId, "active") };
+  const policy = {
+    ...freeProsePolicy(documentPath, "## Goal"),
+    undeclaredSections: "allow" as const
+  };
+
+  assert.doesNotThrow(() => compileManagedCandidateTreeV2({
+    documents: [index, { path: documentPath, body: managedBody("Plan", "## Goal", "Old") }]
+  }, {
+    documents: [index, {
+      path: documentPath,
+      body: `${managedBody("Plan", "## Goal", "Old")}\n## Review Addendum\n\nNew context.\n`
+    }]
+  }, [policy], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]));
+
+  assert.throws(() => compileManagedCandidateTreeV2({
+    documents: [index, { path: documentPath, body: managedBody("Plan", "## Goal", "Old") }]
+  }, {
+    documents: [index, { path: documentPath, body: managedBody("Plan", "## Purpose", "Old") }]
+  }, [policy], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]),
+  /SEMANTIC_DIFF_AMBIGUOUS:section identity changed/u);
+});
+
 test("all task actions compile to one exact package-hosted StoragePlan", async () => {
   const taskId = "task_T";
   const taskRef = ref("task", `task/${taskId}`);

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -19,6 +19,7 @@ import { readProjectHarnessSettings, settingsIssue, type ProjectHarnessSettings 
 import { bundledTaskDocumentPlaceholderPolicy } from "./core/task-document-placeholders.ts";
 import { discoverScriptEntries } from "./extensions/script.ts";
 import { runScriptHost } from "./extensions/script-host.ts";
+import { undeclaredSectionsForTaskDocument } from "./extensions/managed-section-policy.ts";
 import { validateInReviewExecutionConsistency } from "./task-execution-consistency.ts";
 
 const FORCE_STATUS_AUDIT_MARKER = "FORCE_STATUS_SET_AUDIT";
@@ -443,15 +444,17 @@ function validateMetadataDrivenTaskPackage(
       continue;
     }
     const permissions = new Map(liveDocument.sectionPermissions.map((permission) => [permission.anchor, permission]));
-    for (const section of markdownHeadingSections(body)) {
-      if (permissions.has(section.anchor)) continue;
-      issues.push(profileIssue(
-        "metadata-template",
-        "metadata_section_permission_missing",
-        "hard-fail",
-        `${relativeDocumentPath} contains undeclared section ${section.anchor}.`,
-        "Declare the heading in the selected template sectionPermissions before canonical writes are allowed."
-      ));
+    if (undeclaredSectionsForTaskDocument(liveDocument.sectionPermissions) === "reject") {
+      for (const section of markdownHeadingSections(body)) {
+        if (permissions.has(section.anchor)) continue;
+        issues.push(profileIssue(
+          "metadata-template",
+          "metadata_section_permission_missing",
+          "hard-fail",
+          `${relativeDocumentPath} contains undeclared section ${section.anchor}.`,
+          "Declare the heading in the selected template sectionPermissions before canonical writes are allowed."
+        ));
+      }
     }
     for (const permission of liveDocument.sectionPermissions) {
       if (permission.writeMode !== "forbidden") continue;

--- a/packages/cli/src/commands/extensions/managed-section-policy.ts
+++ b/packages/cli/src/commands/extensions/managed-section-policy.ts
@@ -39,7 +39,7 @@ export function resolveManagedSectionPolicy(
     const declaration = materialized.ok
       ? materialized.documents.find((document) => document.materializeAs === taskMatch[2])
       : undefined;
-    if (declaration) return { path: normalized, sections: declaration.sectionPermissions };
+    if (declaration) return taskDocumentPolicy(normalized, declaration.sectionPermissions);
   }
   const documentAbsolutePath = path.join(layout.authoredRoot, normalized);
   if (!existsSync(documentAbsolutePath)) return null;
@@ -47,8 +47,30 @@ export function resolveManagedSectionPolicy(
   const headings = markdownHeadingSections(documentBody).map((section) => section.anchor);
   const matches = (bundledTemplateCatalog("software/coding")?.documents ?? [])
     .filter((document) => document.materializeAs === taskMatch[2])
-    .filter((document) => headings.every((heading) => document.sectionPermissions.some((permission) => permission.anchor === heading)))
+    .filter((document) => undeclaredSectionsForTaskDocument(document.sectionPermissions) === "allow"
+      ? document.sectionPermissions.every((permission) => headings.includes(permission.anchor))
+      : headings.every((heading) => document.sectionPermissions.some((permission) => permission.anchor === heading)))
     .sort((left, right) => left.sectionPermissions.length - right.sectionPermissions.length || left.id.localeCompare(right.id));
   if (!matches[0] || (matches[1] && matches[1].sectionPermissions.length === matches[0].sectionPermissions.length)) return null;
-  return { path: normalized, sections: matches[0].sectionPermissions };
+  return taskDocumentPolicy(normalized, matches[0].sectionPermissions);
+}
+
+export function undeclaredSectionsForTaskDocument(
+  sections: SemanticDiffDocumentPolicy["sections"]
+): "allow" | "reject" {
+  return sections.length > 0 && sections.every((section) =>
+    section.writeMode === "free-prose" && section.semanticClass === "host-prose-only")
+    ? "allow"
+    : "reject";
+}
+
+function taskDocumentPolicy(
+  documentPath: string,
+  sections: SemanticDiffDocumentPolicy["sections"]
+): SemanticDiffDocumentPolicy {
+  return {
+    path: documentPath,
+    sections,
+    undeclaredSections: undeclaredSectionsForTaskDocument(sections)
+  };
 }

--- a/packages/cli/test/check-governance-cli.test.ts
+++ b/packages/cli/test/check-governance-cli.test.ts
@@ -82,6 +82,13 @@ test("CLI metadata check validates software coding preset task documents", () =>
     assert.equal(result.report.summary.hardFailCount, 0);
     assert.equal(result.warnings.some((warning: Record<string, unknown>) => warning.code === "visual_map_missing"), false);
     assert.equal(readFileSync(path.join(rootDir, created.packagePath, "task_plan.md"), "utf8").includes("Task Contract: harness-task v1"), true);
+
+    const taskPlanPath = path.join(rootDir, created.packagePath, "task_plan.md");
+    writeFileSync(taskPlanPath, `${readFileSync(taskPlanPath, "utf8")}\n## Review Addendum\n\nNew context.\n`, "utf8");
+    const withAddendum = runJson(rootDir, ["check", "--profile", "target-project", "--strict"]);
+    assert.equal(withAddendum.ok, true);
+    assert.equal(withAddendum.warnings.some((warning: Record<string, unknown>) =>
+      warning.code === "metadata_section_permission_missing" && warning.message.includes("task_plan.md")), false);
   });
 });
 

--- a/packages/cli/test/doc-sync-service.test.ts
+++ b/packages/cli/test/doc-sync-service.test.ts
@@ -115,6 +115,61 @@ test("doc sync submit accepts pure task prose and commits with hermetic author",
   });
 });
 
+test("doc sync submit accepts undeclared sections in task host prose", async () => {
+  await withHarnessFixture(async ({ rootDir, harnessRoot, taskId }) => {
+    const service = makeDocSyncService({ rootDir, coordinator: attributedCoordinator(rootDir) });
+    const base = planBody("Original prose.");
+    const next = `${base}\n## 2026-07-21 Review Addendum\n\nNewly discovered requirement.\n`;
+    const result = await service.submit(submitRequest({
+      baseLedgerSha: git(harnessRoot, "rev-parse", "HEAD"),
+      intentId: "intent-task-plan-addendum",
+      changes: [inlineChange(`tasks/${taskId}/task_plan.md`, base, next)]
+    }));
+
+    assert.equal(result.ok, true, JSON.stringify(result));
+    assert.match(readFileSync(path.join(harnessRoot, "tasks", taskId, "task_plan.md"), "utf8"), /Review Addendum/u);
+  });
+});
+
+test("doc sync rejects renamed task host-prose skeleton sections", async () => {
+  await withHarnessFixture(async ({ rootDir, harnessRoot, taskId }) => {
+    const base = planBody("Original prose.");
+    const validation = validateDocSyncSubmitRequest({
+      rootInput: rootDir,
+      request: submitRequest({
+        baseLedgerSha: git(harnessRoot, "rev-parse", "HEAD"),
+        intentId: "intent-task-plan-renamed-skeleton",
+        changes: [inlineChange(`tasks/${taskId}/task_plan.md`, base, base.replace("## Goal", "## Purpose"))]
+      })
+    });
+
+    assert.equal(validation.ok, false);
+    assert.match(validation.unresolvedTouches[0]?.reason ?? "", /SEMANTIC_DIFF_AMBIGUOUS:section identity changed/u);
+  });
+});
+
+test("doc sync keeps decision documents strict about undeclared sections", async () => {
+  await withHarnessFixture(async ({ rootDir, harnessRoot }) => {
+    const decisionPath = "decisions/decision-dec_TEST/decision.md";
+    const decisionBase = "# Decision\n\n## Rationale\n\nOriginal rationale.\n";
+    mkdirSync(path.join(harnessRoot, "decisions", "decision-dec_TEST"), { recursive: true });
+    writeFileSync(path.join(harnessRoot, decisionPath), decisionBase, "utf8");
+    git(harnessRoot, "add", decisionPath);
+    gitCommit(harnessRoot, "seed canonical decision");
+    const validation = validateDocSyncSubmitRequest({
+      rootInput: rootDir,
+      request: submitRequest({
+        baseLedgerSha: git(harnessRoot, "rev-parse", "HEAD"),
+        intentId: "intent-decision-addendum",
+        changes: [inlineChange(decisionPath, decisionBase, `${decisionBase}\n## Addendum\n\nUndeclared.\n`)]
+      })
+    });
+
+    assert.equal(validation.ok, false);
+    assert.match(validation.unresolvedTouches[0]?.reason ?? "", /SEMANTIC_DIFF_REQUIRED:undeclared section/u);
+  });
+});
+
 test("doc sync candidate tree compiles prose plus hosted facts and relation in one save", async () => {
   await withHarnessFixture(async ({ rootDir, harnessRoot, taskRoot, taskId }) => {
     writeFileSync(path.join(taskRoot, "facts.md"), factsBody(""), "utf8");
@@ -255,7 +310,7 @@ test("doc sync submit rejects disguised prose edits to task fact records", async
   });
 });
 
-test("doc sync rejects undeclared, machine-written, forbidden, and non-heading module regions before apply", async () => {
+test("doc sync allows task host-prose additions but rejects machine-written, forbidden, and non-heading module regions", async () => {
   await withHarnessFixture(async ({ rootDir, harnessRoot, taskRoot, taskId }) => {
     const progressBase = progressBody("Original log.");
     const reviewBase = reviewBody("pending");
@@ -282,7 +337,7 @@ test("doc sync rejects undeclared, machine-written, forbidden, and non-heading m
 
     assert.equal(validation.ok, false);
     const reasons = validation.unresolvedTouches.map((touch) => touch.reason).join("\n");
-    assert.match(reasons, /SEMANTIC_DIFF_REQUIRED:undeclared section/u);
+    assert.doesNotMatch(reasons, /task_plan\.md.*undeclared section/u);
     assert.match(reasons, /SEMANTIC_DIFF_REQUIRED:machine-written section requires typed command/u);
     assert.match(reasons, /SEMANTIC_DIFF_REQUIRED:forbidden section changed/u);
     assert.match(reasons, /modules\.json has no registered markdown heading region/u);

--- a/packages/kernel/src/entity/managed-semantic-diff.ts
+++ b/packages/kernel/src/entity/managed-semantic-diff.ts
@@ -88,12 +88,15 @@ function changedRegions(
     assertUniqueHeadings(baseBody, filePath);
     assertUniqueHeadings(candidateBody, filePath);
     const declared = new Map(policy!.sections.map((section) => [section.anchor, section]));
+    const allowsUndeclaredSections = policy!.undeclaredSections === "allow";
     const actualAnchors = new Set([
       ...markdownHeadingSections(baseBody).map((section) => section.anchor),
       ...markdownHeadingSections(candidateBody).map((section) => section.anchor)
     ]);
     for (const anchor of actualAnchors) {
-      if (!declared.has(anchor)) semanticDiffError("SEMANTIC_DIFF_REQUIRED", `undeclared section ${anchor} in ${filePath}`);
+      if (!allowsUndeclaredSections && !declared.has(anchor)) {
+        semanticDiffError("SEMANTIC_DIFF_REQUIRED", `undeclared section ${anchor} in ${filePath}`);
+      }
     }
     for (const section of policy!.sections) {
       const baseHas = hasHeading(baseBody, section.anchor);
@@ -119,7 +122,8 @@ function changedRegions(
         candidateSection
       });
     }
-    if (maskDeclaredSections(baseBody, policy!.sections) !== maskDeclaredSections(candidateBody, policy!.sections)) {
+    if (!allowsUndeclaredSections
+      && maskDeclaredSections(baseBody, policy!.sections) !== maskDeclaredSections(candidateBody, policy!.sections)) {
       semanticDiffError("SEMANTIC_DIFF_REQUIRED", `bytes outside declared sections changed: ${filePath}`);
     }
   }

--- a/packages/kernel/src/entity/registry-contract.ts
+++ b/packages/kernel/src/entity/registry-contract.ts
@@ -75,6 +75,7 @@ export interface SemanticDiffSectionPolicy {
 export interface SemanticDiffDocumentPolicy {
   readonly path: string;
   readonly sections: ReadonlyArray<SemanticDiffSectionPolicy>;
+  readonly undeclaredSections?: "allow" | "reject";
 }
 
 export interface SemanticDiffCandidateDocument {


### PR DESCRIPTION
# English

## Summary

Task plan documents are free-form prose. Experts extend them during review — adding an addendum section anchored to a decision is normal practice, not a violation. Today those addenda were rejected by doc sync as `SEMANTIC_DIFF_REQUIRED:undeclared section`, leaving the file permanently unsyncable.

This PR implements `dec_01KY20K4F9X39KEZXRJV8C65BE`: **the template is the baseline and stays fixed; anything beyond the baseline may be appended freely.**

## What Changed

- `SemanticDiffDocumentPolicy` gains an optional `undeclaredSections?: "allow" | "reject"`. It is **undefined by default**, so every existing document keeps its current strict behavior.
- `managed-semantic-diff.ts` skips the undeclared-section check and the bytes-outside-declared-sections check only when the policy says `allow`. The `section identity changed` check is untouched, so deleting or renaming a baseline section still raises.
- A task document resolves to `allow` only when **all** of its declared sections are `free-prose` + `host-prose-only`. Documents with any machine-written, forbidden, or entity-bearing section stay strict — this covers `decision.md` and `facts.md` without hardcoding paths.
- `doc-sync.ts` and `check.ts` are updated together so the two parallel checks cannot diverge in verdict.

## Task And Scope

- Harness task: `task_01KY1YT4C0FM2WY8DV78CVGB9W`
- Branch: `fix/task-plan-free-sections`
- Public scope: `packages/kernel`, `packages/application`, `packages/cli`
- Private planning/evidence updated: yes
- Out of scope: editing existing baseline section content (unchanged free-prose + submit flow); daemon restart to pick up the new behavior

## Version Impact

- Version: no version change because this is a behavior fix inside existing packages
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KY20K4F9X39KEZXRJV8C65BE` (state: active) — "task_plan: the template is the baseline and stays fixed, everything beyond it may be appended freely"
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `cf273c0bba3219e557e4facd225a704c991c908c`
- Branch merge-base with `origin/main`: `cf273c0bba3219e557e4facd225a704c991c908c`
- Last `git fetch origin` time: 2026-07-21, immediately before rebase
- Sync method: rebase
- Public diff command: `git diff-tree -r --no-commit-id 7fd3b3e8161f4a0bb7e34eb3b3c9a92b925c51d5`
- Private evidence commit/path: `harness/tasks/task_01KY1YT4C0FM2WY8DV78CVGB9W-ecs/facts.md`
- Reviewer evidence path: `harness/context/research/2026-07-21-ecs-vs-three-primitive-kernel/`
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- Not run: local full gate — per the 2026-07-20 ruling the authoritative full gate lives in GitHub CI; the implementing worker ran the 13 locally runnable `check:ci`-derived jobs green before rebase.

Behavior verified directly against the built artifacts (not only unit tests):

- Policy for a real `task_plan.md` resolves to `undeclaredSections = allow` with 8 sections.
- Appending a section outside the template: **passes**.
- Deleting the baseline `## Goal` section: **still raises** `SEMANTIC_DIFF_AMBIGUOUS:section identity changed`.

## Review Evidence

- Self-review: full diff read; the four regression boundaries were re-checked by directly invoking the built resolver and asserter rather than trusting the test summary.
- Reviewer subagent: implementation by Codex worker; verification by CEO.
- Human review: pending
- Blocking findings: none

## Residual Risk

- The running daemon serves the code it loaded at startup, so the new behavior only takes effect after the daemon is restarted post-merge. This was observed during verification: the daemon (started 17:42) kept rejecting addenda while the freshly built artifacts accepted them.
- Two side findings were recorded as facts and are **not** fixed here: the build leaves `dist/cli/src/index.js` without its executable bit (breaking `ha` until `chmod +x`), and `HARNESS_DAEMON_MODE=direct` is retired, so read-only commands can no longer bypass a stale daemon to verify new code.

## References

- Task: `task_01KY1YT4C0FM2WY8DV78CVGB9W`
- Evidence: `harness/tasks/task_01KY1YT4C0FM2WY8DV78CVGB9W-ecs/facts.md`; `harness/context/research/2026-07-21-ecs-vs-three-primitive-kernel/`
- Review: `dec_01KY20K4F9X39KEZXRJV8C65BE` (active); superseded first draft `dec_01KY20F4A5BRFPNGRGM3363KMA`

---

# 中文

## 概要

task plan 是自由填写的文档。专家在评审过程中扩充它——追加一个锚定决策的补充段落——是正常实践，不是违规。但目前这类追加会被 doc sync 判为 `SEMANTIC_DIFF_REQUIRED:undeclared section`，导致该文件永久无法同步。

本 PR 实现 `dec_01KY20K4F9X39KEZXRJV8C65BE`：**template 是基准，动不得；基准之外，自由追加。**

## 改动内容

- `SemanticDiffDocumentPolicy` 增加可选字段 `undeclaredSections?: "allow" | "reject"`，**默认 undefined**，所有既有文档行为保持严格不变。
- `managed-semantic-diff.ts` 仅在 policy 为 `allow` 时跳过「未声明段落」与「声明段落外字节」两项检查。`section identity changed` 检查**未改动**，因此删除或改名基准段落仍然报警。
- 一份 task 文档只有在其**全部**声明段落都是 `free-prose` + `host-prose-only` 时才解析为 `allow`；含任何 machine-written、forbidden 或 entity-bearing 段落的文档保持严格——这样无需硬编码路径即可覆盖 `decision.md` 与 `facts.md`。
- `doc-sync.ts` 与 `check.ts` 同步修改，避免两处并行检查口径分裂。

## 任务与范围

- Harness 任务：`task_01KY1YT4C0FM2WY8DV78CVGB9W`
- 分支：`fix/task-plan-free-sections`
- 公开范围：`packages/kernel`、`packages/application`、`packages/cli`
- 私有计划/证据已更新：是
- 不在范围内：基准段落内容的正常编辑（仍走既有 free-prose + submit 流程）；让新行为生效所需的 daemon 重启

## 版本影响

- 版本：无变更，因为这是既有包内的行为修复
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：`dec_01KY20K4F9X39KEZXRJV8C65BE`（state: active）——「task_plan：template 是基准动不得，基准之外自由追加」
- 机器检查边界：本 PR 只断言声明存在；声明是否属实与充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`cf273c0bba3219e557e4facd225a704c991c908c`
- 分支与 `origin/main` 的 merge-base：`cf273c0bba3219e557e4facd225a704c991c908c`
- 最近一次 `git fetch origin` 时间：2026-07-21，rebase 前
- 同步方式：rebase
- 公开 diff 命令：`git diff-tree -r --no-commit-id 7fd3b3e8161f4a0bb7e34eb3b3c9a92b925c51d5`
- 私有证据 commit/路径：`harness/tasks/task_01KY1YT4C0FM2WY8DV78CVGB9W-ecs/facts.md`
- 评审证据路径：`harness/context/research/2026-07-21-ecs-vs-three-primitive-kernel/`
- GitHub Actions `rewrite-ci` 运行 URL：待本 PR 触发
- 未运行项：本地全量门——按 2026-07-20 裁定，权威完整门在 GitHub CI；实现方在 rebase 前跑过 `check:ci` 派生的 13 个本地可运行 job，全绿。

行为已直接对构建产物验证（不只依赖单测）：

- 真实 `task_plan.md` 的 policy 解析为 `undeclaredSections = allow`，8 个 sections。
- 追加 template 之外的段落：**通过**。
- 删除基准段落 `## Goal`：**仍报警** `SEMANTIC_DIFF_AMBIGUOUS:section identity changed`。

## 审查证据

- 自审：通读完整 diff；四条回归边界通过直接调用构建后的解析器与断言器复验，而非采信测试摘要。
- 评审子代理：实现由 Codex worker 完成，验证由 CEO 执行。
- 人工评审：待进行
- 阻塞性发现：无

## 残余风险

- 运行中的 daemon 服务的是其启动时加载的代码，因此新行为需在合并后重启 daemon 才生效。此现象在验证过程中实测到：daemon（17:42 启动）仍在拦截追加段落，而新构建产物已放行。
- 另有两项副产品发现已记为 fact，**本 PR 不修**：构建后 `dist/cli/src/index.js` 丢失可执行位（导致 `ha` 不可用直到 `chmod +x`）；`HARNESS_DAEMON_MODE=direct` 已退役，只读命令无法再绕过陈旧 daemon 验证新代码。

## 关联材料

- 任务：`task_01KY1YT4C0FM2WY8DV78CVGB9W`
- 证据：`harness/tasks/task_01KY1YT4C0FM2WY8DV78CVGB9W-ecs/facts.md`；`harness/context/research/2026-07-21-ecs-vs-three-primitive-kernel/`
- 评审：`dec_01KY20K4F9X39KEZXRJV8C65BE`（active）；被取代的初版 `dec_01KY20F4A5BRFPNGRGM3363KMA`

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过双语检查。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled. / 治理声明已填（本 PR 未触碰 protected surface，仍列出授权决策）。
- [x] No private harness files are included. / 不包含私有 harness 文件（diff 仅 `packages/`）。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本描述不含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明范围。
- [x] Private planning/evidence updates are recorded when applicable. / 已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证（含未跑项与原因）。
- [x] CI results are linked or explained. / CI 结果已说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / 无 open findings。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式：单 PR 直合（队列无其他 PR 时 `gh pr merge --merge`）；合并后删远端分支、同步 main、重启 daemon 使新行为生效。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 不计划 admin bypass。
