### PR TITLE
fix(test): bound and instrument the shard(4) wedge

### DIFF
--- a/tools/check-import-boundaries.test.mjs
+++ b/tools/check-import-boundaries.test.mjs
@@ -9,6 +9,7 @@ import test from "node:test";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const checkerPath = path.join(repoRoot, "tools/check-import-boundaries.mjs");
+const CHECKER_TIMEOUT_MS = 30_000;
 
 test("import boundary check rejects application imports from adapters", () => {
   const root = makeFixtureRoot();
@@ -550,12 +551,20 @@ function writeLocalAdapter(root) {
 }
 
 function runChecker(cwd, options = {}) {
-  return spawnSync(process.execPath, [checkerPath], {
+  const result = spawnSync(process.execPath, [checkerPath], {
     cwd,
     encoding: "utf8",
+    timeout: CHECKER_TIMEOUT_MS,
+    killSignal: "SIGKILL",
     env: {
       ...process.env,
       ...(options.env ?? {})
     }
   });
+  if (result.error?.code === "ETIMEDOUT") {
+    throw new Error(`node tools/check-import-boundaries.mjs timed out after ${CHECKER_TIMEOUT_MS}ms`);
+  }
+  if (result.error) throw new Error(`node tools/check-import-boundaries.mjs failed to start: ${result.error.message}`);
+  if (result.signal !== null) throw new Error(`node tools/check-import-boundaries.mjs terminated by signal ${result.signal}`);
+  return result;
 }

--- a/tools/check-supply-chain.mjs
+++ b/tools/check-supply-chain.mjs
@@ -9,6 +9,11 @@ import {
 const root = process.cwd();
 const errors = [];
 const policy = harnessSupplyChainReleaseReadiness;
+const DEFAULT_COMMAND_TIMEOUT_MS = 60_000;
+const commandTimeoutMs = shorterPositiveTimeout(
+  process.env.HARNESS_SUPPLY_CHAIN_COMMAND_TIMEOUT_MS,
+  DEFAULT_COMMAND_TIMEOUT_MS
+);
 const manifestGateRunner = "node tools/run-manifest-gates.mjs";
 const gateManifest = existsSync(path.join(root, "tools/gate-manifest.json"))
   ? readJson("tools/gate-manifest.json")
@@ -36,9 +41,23 @@ function run(command) {
   const result = spawnSync(binary, args, {
     cwd: root,
     encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: commandTimeoutMs,
+    killSignal: "SIGKILL"
   });
 
+  if (result.error?.code === "ETIMEDOUT") {
+    record(`${command} timed out after ${commandTimeoutMs}ms`);
+    return "";
+  }
+  if (result.error) {
+    record(`${command} failed to start: ${result.error.message}`);
+    return "";
+  }
+  if (result.signal !== null) {
+    record(`${command} terminated by signal ${result.signal}`);
+    return "";
+  }
   if (result.status !== 0) {
     const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
     record(`${command} failed${output ? `:\n${output}` : ""}`);
@@ -46,6 +65,13 @@ function run(command) {
   }
 
   return result.stdout;
+}
+
+function shorterPositiveTimeout(value, fallback) {
+  if (value === undefined || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return fallback;
+  return Math.min(parsed, fallback);
 }
 
 const policyValidation = validateSupplyChainReleaseReadiness(policy);

--- a/tools/check-supply-chain.test.mjs
+++ b/tools/check-supply-chain.test.mjs
@@ -8,6 +8,7 @@ import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 const scriptPath = path.resolve(import.meta.dirname, "check-supply-chain.mjs");
+const CHECK_PROCESS_TIMEOUT_MS = 90_000;
 
 test("supply-chain check accepts the expected release gate contract", async () => {
   await withFixtureRepo((root) => {
@@ -227,15 +228,17 @@ test("supply-chain check invokes npm instead of reading fixture output from env"
   await withFixtureRepo((root) => {
     writeValidSupplyChainFixture(root);
 
-    const result = spawnSync(process.execPath, [scriptPath], {
+    const result = requireCompletedSpawn(spawnSync(process.execPath, [scriptPath], {
       cwd: root,
       encoding: "utf8",
+      timeout: CHECK_PROCESS_TIMEOUT_MS,
+      killSignal: "SIGKILL",
       env: {
         ...process.env,
         PATH: "/nonexistent",
         HARNESS_SUPPLY_CHAIN_FIXTURE_OUTPUT_DIR: path.join(root, ".supply-chain-command-output")
       }
-    });
+    }), "node tools/check-supply-chain.mjs", CHECK_PROCESS_TIMEOUT_MS);
 
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /npm audit --audit-level=high failed/u);
@@ -255,15 +258,45 @@ test("supply-chain check rejects Dependabot directory under wrong ecosystem", as
   });
 });
 
-function runCheck(root) {
-  return spawnSync(process.execPath, [scriptPath], {
+test("supply-chain check reports a bounded npm command timeout", async (t) => {
+  await withFixtureRepo((root) => {
+    writeValidSupplyChainFixture(root, { hangNpmCommand: "sbom --sbom-format=cyclonedx --sbom-type=application" });
+    const startedAt = Date.now();
+
+    const result = runCheck(root, {
+      env: { HARNESS_SUPPLY_CHAIN_COMMAND_TIMEOUT_MS: "2000" },
+      timeoutMs: 10_000
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /npm sbom --sbom-format=cyclonedx --sbom-type=application timed out after 2000ms/u);
+    assert.doesNotMatch(result.stderr, /npm audit .* timed out/u);
+    assert.equal(elapsedMs < 9_000, true, `bounded supply-chain check took ${elapsedMs}ms\n${result.stderr}`);
+    t.diagnostic(`timeout control completed in ${elapsedMs}ms: ${result.stderr.trim()}`);
+  });
+});
+
+function runCheck(root, options = {}) {
+  const timeoutMs = options.timeoutMs ?? CHECK_PROCESS_TIMEOUT_MS;
+  return requireCompletedSpawn(spawnSync(process.execPath, [scriptPath], {
     cwd: root,
     encoding: "utf8",
+    timeout: timeoutMs,
+    killSignal: "SIGKILL",
     env: {
       ...process.env,
+      ...(options.env ?? {}),
       PATH: `${path.join(root, ".mock-bin")}${path.delimiter}${process.env.PATH ?? ""}`
     }
-  });
+  }), "node tools/check-supply-chain.mjs", timeoutMs);
+}
+
+function requireCompletedSpawn(result, command, timeoutMs) {
+  if (result.error?.code === "ETIMEDOUT") throw new Error(`${command} timed out after ${timeoutMs}ms`);
+  if (result.error) throw new Error(`${command} failed to start: ${result.error.message}`);
+  if (result.signal !== null) throw new Error(`${command} terminated by signal ${result.signal}`);
+  return result;
 }
 
 async function withFixtureRepo(fn) {
@@ -356,7 +389,7 @@ function writeValidSupplyChainFixture(root, options = {}) {
   writeFile(root, ".github/workflows/rewrite-ci.yml", options.workflowBody ?? validWorkflow());
   writeFile(root, "README.md", validReadme());
   writeFile(root, "docs-release/release-posture.md", options.supplyDocBody ?? validSupplyDoc());
-  writeMockNpm(root, options.sbomMutator);
+  writeMockNpm(root, options.sbomMutator, options.hangNpmCommand);
 }
 
 function validReadme() {
@@ -406,7 +439,7 @@ function validWorkflow() {
   ].join("\n");
 }
 
-function writeMockNpm(root, sbomMutator) {
+function writeMockNpm(root, sbomMutator, hangNpmCommand) {
   const mockPath = path.join(root, ".mock-bin/npm");
   const sbomValue = validSbom();
   sbomMutator?.(sbomValue);
@@ -414,6 +447,7 @@ function writeMockNpm(root, sbomMutator) {
   writeFile(root, ".mock-bin/npm", [
     "#!/usr/bin/env node",
     "const args = process.argv.slice(2).join(' ');",
+    `if (args === ${JSON.stringify(hangNpmCommand)}) { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0); }`,
     "if (args === 'audit --audit-level=high' || args === 'audit --omit=dev --audit-level=high') {",
     "  console.log('found 0 vulnerabilities');",
     "  process.exit(0);",

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path, { resolve } from "node:path";
 import { selectIntegrationShardFiles } from "./integration-test-shards.mjs";
@@ -21,6 +21,7 @@ import { createHermeticTestEnvironment, gitFixtureIdentityGuidance } from "./tes
 
 const repoRoot = resolve(import.meta.dirname, "..");
 const PROCESS_TREE_KILL_GRACE_MS = 2_000;
+const DEFAULT_STALL_DIAGNOSTIC_MS = 90_000;
 
 // Reuse type-strip/compile output across the test host and every CLI
 // subprocess it spawns (integration tests cold-start `node src/index.ts` per
@@ -93,6 +94,13 @@ const concurrencyArgs =
 const timeoutArgs = [`--test-timeout=${options.testTimeoutMs}`];
 const timingRoot = mkdtempSync(path.join(tmpdir(), "ha-test-timings-"));
 const timingPath = path.join(timingRoot, "results.xml");
+const diagnosticReportArgs = process.platform === "win32"
+  ? []
+  : ["--report-on-signal", "--report-signal=SIGUSR2", `--report-directory=${timingRoot}`];
+const stallDiagnosticMs = positiveIntegerOrDefault(
+  process.env.HARNESS_TEST_STALL_DIAGNOSTIC_MS,
+  DEFAULT_STALL_DIAGNOSTIC_MS
+);
 
 process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}` }, async (lease) => {
   const qosPrefix = lease.inherited ? [] : discoverQosPrefix();
@@ -102,6 +110,7 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
     "--test-reporter-destination=stdout",
     "--test-reporter=junit",
     `--test-reporter-destination=${timingPath}`,
+    ...diagnosticReportArgs,
     "--test-force-exit",
     ...concurrencyArgs,
     ...timeoutArgs,
@@ -116,6 +125,18 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
   });
 
   let output = "";
+  let lastOutputAt = Date.now();
+  const seenDiagnosticReports = new Set();
+  const noteOutput = () => {
+    lastOutputAt = Date.now();
+  };
+  const stallDiagnosticTimer = setInterval(() => {
+    const silentForMs = Date.now() - lastOutputAt;
+    if (silentForMs < stallDiagnosticMs) return;
+    lastOutputAt = Date.now();
+    emitStallDiagnostics({ child, silentForMs, timingRoot, seenDiagnosticReports });
+  }, stallDiagnosticMs);
+  stallDiagnosticTimer.unref();
   let windowsTreeTerminationStarted = false;
   const terminateTimedOutWindowsTree = () => {
     if (process.platform !== "win32" || windowsTreeTerminationStarted || !/test timed out after \d+ms/u.test(output)) return;
@@ -124,12 +145,14 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
     terminateWindowsProcessTree(child);
   };
   child.stdout.on("data", (chunk) => {
+    noteOutput();
     const text = chunk.toString();
     output += text;
     process.stdout.write(text);
     terminateTimedOutWindowsTree();
   });
   child.stderr.on("data", (chunk) => {
+    noteOutput();
     const text = chunk.toString();
     output += text;
     process.stderr.write(text);
@@ -138,12 +161,15 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
 
   return new Promise((resolveExitCode) => {
     child.once("error", (error) => {
+      clearInterval(stallDiagnosticTimer);
       console.error(error.message);
       testEnvironment.cleanup();
       rmSync(timingRoot, { recursive: true, force: true });
       resolveExitCode(1);
     });
     child.once("close", async (code, signal) => {
+      clearInterval(stallDiagnosticTimer);
+      emitNewDiagnosticReports(timingRoot, seenDiagnosticReports);
       const leakedDescendants = await terminateLingeringPosixProcessGroup(child.pid);
       testEnvironment.cleanup();
       try {
@@ -169,6 +195,88 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
     });
   });
 });
+
+function positiveIntegerOrDefault(value, fallback) {
+  if (value === undefined || value === "") return fallback;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function emitStallDiagnostics({ child, silentForMs, timingRoot, seenDiagnosticReports }) {
+  console.error(`\n[node-test-stall] no test output for ${silentForMs}ms; test host pid=${child.pid ?? "unknown"}`);
+  console.error(`[node-test-stall] runner active resources: ${JSON.stringify(process.getActiveResourcesInfo())}`);
+  if (process.platform !== "win32" && child.pid !== undefined) {
+    child.kill("SIGUSR2");
+    dumpPosixProcessGroup(child.pid);
+  }
+  setTimeout(() => emitNewDiagnosticReports(timingRoot, seenDiagnosticReports), 1_000).unref();
+}
+
+function dumpPosixProcessGroup(processGroupId) {
+  const psColumns = process.platform === "darwin"
+    ? "pid=,ppid=,pgid=,stat=,etime=,command="
+    : "pid=,ppid=,pgid=,stat=,etime=,wchan:32=,args=";
+  const ps = spawn("ps", ["-eo", psColumns], {
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  let stdout = "";
+  let stderr = "";
+  ps.stdout.on("data", (chunk) => {
+    stdout += chunk.toString();
+  });
+  ps.stderr.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+  ps.once("error", (error) => console.error(`[node-test-stall] unable to inspect process group: ${error.message}`));
+  ps.once("close", (code) => {
+    if (code !== 0) {
+      console.error(`[node-test-stall] ps exited ${code}: ${stderr.trim()}`);
+      return;
+    }
+    const groupLines = stdout.split(/\r?\n/u).filter((line) => {
+      const match = /^\s*\d+\s+\d+\s+(\d+)\s+/u.exec(line);
+      return match?.[1] === String(processGroupId);
+    });
+    const columnDescription = process.platform === "darwin"
+      ? "pid ppid pgid stat elapsed argv"
+      : "pid ppid pgid stat elapsed wait-channel argv";
+    console.error(`[node-test-stall] process group (${columnDescription}):`);
+    console.error(groupLines.length > 0 ? groupLines.join("\n") : `[node-test-stall] no processes found for pgid ${processGroupId}`);
+  });
+}
+
+function emitNewDiagnosticReports(timingRoot, seenDiagnosticReports) {
+  let reportNames;
+  try {
+    reportNames = readdirSync(timingRoot).filter((name) => /^report\..+\.json$/u.test(name));
+  } catch {
+    return;
+  }
+  for (const reportName of reportNames) {
+    if (seenDiagnosticReports.has(reportName)) continue;
+    seenDiagnosticReports.add(reportName);
+    try {
+      const report = JSON.parse(readFileSync(path.join(timingRoot, reportName), "utf8"));
+      const activeLibuv = Array.isArray(report.libuv)
+        ? report.libuv.filter((handle) => handle?.is_active || handle?.is_referenced)
+          .map((handle) => ({
+            type: handle.type,
+            isActive: handle.is_active,
+            isReferenced: handle.is_referenced,
+            pid: handle.pid,
+            fd: handle.fd,
+            signal: handle.signal,
+            firesInMsFromNow: handle.firesInMsFromNow
+          }))
+        : [];
+      console.error(`[node-test-stall] diagnostic report ${reportName}`);
+      console.error(`[node-test-stall] javascript stack: ${report.javascriptStack?.message ?? "unavailable"}`);
+      console.error(`[node-test-stall] active libuv handles: ${JSON.stringify(activeLibuv)}`);
+    } catch (error) {
+      console.error(`[node-test-stall] unable to read ${reportName}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}
 
 function terminateWindowsProcessTree(child) {
   if (child.pid === undefined) return;

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -40,7 +40,8 @@ test("runner bounds a non-terminating test and prints timeout next steps", () =>
   const childEnv = {
     ...process.env,
     HARNESS_RUNNER_TIMEOUT_FIXTURE: "child",
-    HARNESS_TEST_CONCURRENCY: "1"
+    HARNESS_TEST_CONCURRENCY: "1",
+    HARNESS_TEST_STALL_DIAGNOSTIC_MS: "250"
   };
   delete childEnv.NODE_TEST_CONTEXT;
   const result = spawnSync(process.execPath, [
@@ -67,6 +68,9 @@ test("runner bounds a non-terminating test and prints timeout next steps", () =>
   assert.match(output, /HARNESS_DAEMON_PROFILE=isolated/u);
   assert.match(output, /--test-timeout=1000/u);
   assert.match(output, /terminating its process tree/u);
+  assert.match(output, /\[node-test-stall\] no test output for \d+ms/u);
+  assert.match(output, /\[node-test-stall\] runner active resources:/u);
+  assert.match(output, /\[node-test-stall\] process group \(pid ppid pgid stat elapsed (?:wait-channel )?argv\):/u);
   const fixtureChildPid = Number(output.match(/runner timeout fixture child pid: (\d+)/u)?.[1]);
   assert.equal(Number.isSafeInteger(fixtureChildPid), true, output);
   assert.throws(() => process.kill(fixtureChildPid, 0), { code: "ESRCH" });

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -70,7 +70,14 @@ test("runner bounds a non-terminating test and prints timeout next steps", () =>
   assert.match(output, /terminating its process tree/u);
   assert.match(output, /\[node-test-stall\] no test output for \d+ms/u);
   assert.match(output, /\[node-test-stall\] runner active resources:/u);
-  assert.match(output, /\[node-test-stall\] process group \(pid ppid pgid stat elapsed (?:wait-channel )?argv\):/u);
+  // The process-group dump is POSIX-only; Windows keeps its existing taskkill
+  // path and prints no `ps` output, so asserting it there would fail closed on
+  // a platform the probe deliberately leaves alone.
+  if (process.platform === "win32") {
+    assert.doesNotMatch(output, /\[node-test-stall\] process group/u);
+  } else {
+    assert.match(output, /\[node-test-stall\] process group \(pid ppid pgid stat elapsed (?:wait-channel )?argv\):/u);
+  }
   const fixtureChildPid = Number(output.match(/runner timeout fixture child pid: (\d+)/u)?.[1]);
   assert.equal(Number.isSafeInteger(fixtureChildPid), true, output);
   assert.throws(() => process.kill(fixtureChildPid, 0), { code: "ESRCH" });


### PR DESCRIPTION
# English

## Summary

`integration-shard (4)` has wedged repeatedly on PR CI: the run goes completely silent mid-suite and is killed by the job-level `timeout-minutes: 15`. PR #971 added that timeout and post-run process-group cleanup, but the wedge kept recurring after it merged — because it aimed at a different target.

The decisive observation: the wedged attempt printed **185 `✔`** while the passing rerun of the same job printed **219**. Thirty-four cases never ran. The process stopped **mid-suite**; it did not hang while finishing.

**This PR does not claim to have eliminated the trigger.** The failing runner VM is gone and its log did not retain the fields needed to identify the leaf command. What this PR does is remove the two conditions that made the wedge both possible and undiagnosable:

1. It **bounds** the unbounded synchronous waits that the failure mechanism points at, so a hang becomes a named failure instead of silence.
2. It **instruments** the runner, so if a stall still happens, the log identifies the process, its argv, and what it is waiting on.

## What Changed

**Mechanism.** Both test files left unfinished by the wedge call `spawnSync` with no deadline, and `check-supply-chain` nests `test worker -> check-supply-chain.mjs -> npm`. A synchronous syscall blocks that worker's JavaScript event loop, so `node:test` cannot advance its own per-test timeout inside that worker, and `--test-force-exit` only applies once the host has the worker's result. That single mechanism accounts for the full symptom set: no progress, no exit, no timeout, no TAP summary.

- `tools/check-supply-chain.mjs` — the spawned command gets an explicit deadline with `SIGKILL`. A timeout is recorded as a named check failure stating which command exceeded what bound. `HARNESS_SUPPLY_CHAIN_COMMAND_TIMEOUT_MS` may only **shorten** the default, never extend it.
- `tools/check-supply-chain.test.mjs`, `tools/check-import-boundaries.test.mjs` — the three checker spawns get deadlines; timeout, spawn failure, and signal termination each raise a distinct readable error instead of returning an ambiguous empty result.
- `tools/run-node-tests.mjs` — a stall probe. After a configurable window with no test output it prints the runner's active resources, the test process group (`pid/ppid/pgid/state/elapsed/argv`, plus wait channel on Linux), and a Node diagnostic report of the test host's JavaScript stack and active libuv handles. It sends `SIGUSR2` to the host pid only, never broadcasts to the group. **It does not change the exit code, retry anything, or adjust any timeout.** Windows keeps its existing behavior.
- `tools/run-node-tests.test.mjs` — the existing intentional-hang self-test now also asserts the stall diagnostics appear.

**Not done, with reasons.** A static gate banning deadline-free `spawnSync` was considered and declined: the repo has many existing direct `spawnSync` call sites, a blanket ban becomes a migration rather than a gate, and the synchronous call is not the defect — the missing deadline is. The suggested path is a shared bounded-spawn helper first, then a ban on direct use. Separately, `terminateLingeringPosixProcessGroup` runs from `child.once("close")`, so it cannot fire when the host itself dies; a correct fix needs signal forwarding, `SIGKILL` escalation, exit-code and PGID-reuse handling, and Windows/lease coordination. Both are recorded for follow-up rather than folded in here.

## Task And Scope

- Harness task: `task_01KY284MZV4KXJP6RV06E3NTN1`
- Branch: `fix/shard4-wedge-rootcause`
- Public scope: `tools/`
- Private planning/evidence updated: yes
- Out of scope: the static gate and the host-death cleanup gap described above; any change to gate verdicts, test coverage, or shard composition

## Version Impact

- Version: no version change because this only touches test tooling
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable. The task authorized CI/gate changes, but the final diff touches only `tools/` test tooling — no workflow file, no shard derivation, no gate verdict.
- Authority: `task_01KY284MZV4KXJP6RV06E3NTN1` — the task explicitly authorizes eliminating or instrumenting the hang, and explicitly withholds authority to relax any gate, reduce coverage, or move tests out of a shard.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `a21c83319bcaaca1a3e2d573ffcd9a027cad3bb8`
- Branch merge-base with `origin/main`: `a21c83319bcaaca1a3e2d573ffcd9a027cad3bb8`
- Last `git fetch origin` time: 2026-07-21, immediately before opening this PR
- Sync method: none needed — the branch base is already the current `origin/main`
- Public diff command: `git diff main...fix/shard4-wedge-rootcause`
- Private evidence commit/path: harness task package `task_01KY284MZV4KXJP6RV06E3NTN1` (`facts.md`, `artifacts/codex-shard4-report.md`)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- Not run: local full gate matrix — per the 2026-07-20 ruling the authoritative full gate is GitHub CI. The change surface is test tooling, so these targeted gates were run instead, all exit 0:

```
node tools/run-node-tests.mjs --tier integration --shard 4   -> tests 221 / pass 220 / fail 0 / skipped 1
node --test tools/check-supply-chain.test.mjs                -> tests 13 / pass 13 / fail 0
node --test tools/run-node-tests.test.mjs                    -> tests 20 / pass 20 / fail 0
npx eslint <the five changed files>                          -> clean
node tools/check-write-road-registry.mjs                     -> 61 rows, 497 write surfaces, passed
node tools/scan-forbidden-symbols.mjs                        -> delta 0, passed
node tools/check-private-boundary.mjs                        -> delta 0, passed
git diff --check main...HEAD                                 -> clean
```

The write-road registry gate matters here specifically because this PR adds a `spawn` call site; it discovered the surface and still passed.

Negative control — a fixture whose npm command hangs, with the bound compressed to 2000ms. Reproduced independently by the reviewer, not only by the implementer:

```
✔ supply-chain check reports a bounded npm command timeout (2488.191ms)
ℹ timeout control completed in 2479ms: Supply chain check failed:
- npm sbom --sbom-format=cyclonedx --sbom-type=application timed out after 2000ms
ℹ tests 13
ℹ pass 13
ℹ fail 0
```

The control also asserts `doesNotMatch(/npm audit .* timed out/)`, so it proves only the hung command is bounded rather than everything failing at once, and asserts wall-clock under 9s, so it proves the bound actually fired.

## Review Evidence

- Self-review: full diff read line by line. The stall probe was checked for blast radius specifically — `unref()`ed timer, signal to the host pid only, no exit-code path, Windows untouched.
- Reviewer subagent: implementation by a Codex worker in an isolated worktree; verification by the CEO, who re-ran the negative control independently rather than trusting the pasted output.
- Human review: pending
- Blocking findings: none. Two non-blocking items were raised by the implementer and accepted as separate lines (static gate, host-death cleanup).

## Residual Risk

- **The trigger is not eliminated.** If the wedge recurs, the diagnostics should name the leaf; do not report this as "shard 4 is fixed".
- The stall probe may emit one diagnostic on a legitimately slow single file, because the spec reporter buffers output per test file. It changes no verdict.
- The Linux `wchan`/argv branch is exercised on ubuntu-24.04 fields but was authored on macOS; the macOS branch is covered by the self-test.
- `killSignal: "SIGKILL"` reaches the direct child; a wedged grandchild may still outlive it. This is strictly better than an unbounded wait, not a complete process-tree kill.

## References

- Task: `task_01KY284MZV4KXJP6RV06E3NTN1`
- Evidence: harness task package `facts.md`; `artifacts/codex-shard4-report.md`
- Review: prior attempt `5df13c86` (PR #971) — this PR explains why that one did not converge

---

# 中文

## 概要

`integration-shard (4)` 在 PR CI 上反复卡死：跑到中途完全静默，直到 job 级 `timeout-minutes: 15` 把它杀掉。PR #971 加了这个超时和跑完后的进程组清理，但合并后仍然复发——因为它打的是另一个靶子。

决定性观察：卡死那次只打印了 **185 个 `✔`**，同一 job 成功的重跑打印了 **219 个**。34 个用例根本没跑。进程是**跑到一半停住**，不是收尾时挂住。

**本 PR 不声称消除了 trigger。** 出故障的 runner VM 已销毁，其日志没有保留区分叶子命令所需的字段。本 PR 做的是消除让卡死既可能发生、又不可诊断的两个条件：

1. **界起来**——把失败机制指向的那些无界同步等待界住，使挂起变成有名字的失败而不是静默。
2. **插桩**——若仍然发生静默，日志能指出是哪个进程、它的 argv、以及它在等什么。

## 改动内容

**机制。** 卡死时未完成的两个测试文件都在调用无 deadline 的 `spawnSync`，且 `check-supply-chain` 是 `test worker -> check-supply-chain.mjs -> npm` 的嵌套同步链。同步系统调用阻塞该 worker 的 JavaScript event loop，因此 `node:test` 无法在该 worker 内推进自己的 per-test timeout，而 `--test-force-exit` 只在 host 拿到 worker 结果之后才生效。这一个机制能解释完整的症状组合：不推进、不退出、不超时、无 TAP summary。

- `tools/check-supply-chain.mjs`——被 spawn 的命令获得显式 deadline 并配 `SIGKILL`。超时被记为一条有名字的检查失败，说明哪个命令超过了什么界。`HARNESS_SUPPLY_CHAIN_COMMAND_TIMEOUT_MS` 只能**缩短**默认值，不能延长。
- `tools/check-supply-chain.test.mjs`、`tools/check-import-boundaries.test.mjs`——三处 checker spawn 加 deadline；超时、启动失败、被信号终止各自抛出可读且互相区分的错误，而不是返回语义含糊的空结果。
- `tools/run-node-tests.mjs`——静默探针。在可配置的无输出窗口后，打印 runner 的 active resources、测试进程组（`pid/ppid/pgid/state/elapsed/argv`，Linux 上另加 wait channel），以及 test host 的 Node diagnostic report（JavaScript stack 与 active libuv handles）。只向 host pid 发 `SIGUSR2`，不向进程组广播。**不改退出码、不 retry、不调整任何 timeout。** Windows 保持既有行为。
- `tools/run-node-tests.test.mjs`——既有的 intentional-hang 自测新增断言，要求静默诊断确实出现。

**没做的事及理由。** 评估过加一道静态门禁止无 deadline 的 `spawnSync`，结论是不做：全仓已有大量直接 `spawnSync` 调用点，一刀切会从"设门"变成"存量迁移"，而且同步调用本身不是缺陷，缺 deadline 才是。建议路径是先统一 bounded-spawn helper，再禁止直接使用。另外 `terminateLingeringPosixProcessGroup` 挂在 `child.once("close")` 上，host 自己死亡时它根本不会触发；正确修复需要设计信号转发、`SIGKILL` 升级、退出码与 PGID 复用处理、以及 Windows/lease 协作。两项都记录为后续独立线，不并入本轮。

## 任务与范围

- Harness 任务：`task_01KY284MZV4KXJP6RV06E3NTN1`
- 分支：`fix/shard4-wedge-rootcause`
- 公开范围：`tools/`
- 私有计划 / 证据是否已更新：yes
- 范围外：上述静态门与 host-death 清理缺口；任何对 gate 判定口径、测试覆盖或分片构成的改动

## 版本影响

- 版本：不改版本，原因是本次只触碰测试工具链
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用。任务本身授权了 CI/gate 改动，但最终 diff 只触碰 `tools/` 测试工具——没有 workflow 文件、没有分片派生、没有 gate 判定。
- 依据：`task_01KY284MZV4KXJP6RV06E3NTN1`——该任务明确授权"消除挂起或使其可诊断"，并明确不授权放宽任何门、降低覆盖、或把测试移出分片。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`a21c83319bcaaca1a3e2d573ffcd9a027cad3bb8`
- 当前分支与 `origin/main` 的 merge-base：`a21c83319bcaaca1a3e2d573ffcd9a027cad3bb8`
- 最近一次 `git fetch origin` 时间：2026-07-21，开 PR 前
- 同步方式：不需要——分支基线已是当前 `origin/main`
- 公开 diff 命令：`git diff main...fix/shard4-wedge-rootcause`
- 私有证据 commit/path：harness 任务包 `task_01KY284MZV4KXJP6RV06E3NTN1`（`facts.md`、`artifacts/codex-shard4-report.md`）
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待本 PR 触发
- 未运行：本地全量门矩阵——按 2026-07-20 裁定，权威完整门在 GitHub CI。本次改动面是测试工具链，因此改跑下列定向门，全部 exit 0：

```
node tools/run-node-tests.mjs --tier integration --shard 4   -> tests 221 / pass 220 / fail 0 / skipped 1
node --test tools/check-supply-chain.test.mjs                -> tests 13 / pass 13 / fail 0
node --test tools/run-node-tests.test.mjs                    -> tests 20 / pass 20 / fail 0
npx eslint <五个改动文件>                                     -> clean
node tools/check-write-road-registry.mjs                     -> 61 rows, 497 write surfaces, passed
node tools/scan-forbidden-symbols.mjs                        -> delta 0, passed
node tools/check-private-boundary.mjs                        -> delta 0, passed
git diff --check main...HEAD                                 -> clean
```

write-road registry 这道门在本 PR 尤其相关，因为本次新增了一处 `spawn` 调用点；它发现了该写面并仍然通过。

阴性对照——构造一个 npm 命令必然挂起的 fixture，并把界压到 2000ms。由复核方独立复跑，不只采信实现方粘贴的输出：

```
✔ supply-chain check reports a bounded npm command timeout (2488.191ms)
ℹ timeout control completed in 2479ms: Supply chain check failed:
- npm sbom --sbom-format=cyclonedx --sbom-type=application timed out after 2000ms
ℹ tests 13
ℹ pass 13
ℹ fail 0
```

该对照同时断言 `doesNotMatch(/npm audit .* timed out/)`，因此证明只有挂起的那条命令被界住，而不是所有命令一起失败；并断言墙钟小于 9 秒，因此证明界确实生效了。

## 审查证据

- 自查：逐行通读完整 diff。特别核了静默探针的牵连面——timer 已 `unref()`、信号只发给 host pid、不经过退出码路径、Windows 分支未动。
- Reviewer subagent：由 Codex worker 在独立 worktree 实现；CEO 复核，并独立重跑阴性对照而非采信粘贴输出。
- 人工审查：待进行
- 阻塞发现：无。实现方提出两项非阻塞事项，已接受为独立线（静态门、host-death 清理）。

## 残余风险

- **trigger 未被消除。** 若卡死复发，诊断应能指出叶子；不要把本 PR 汇报为「shard 4 已修好」。
- 静默探针可能在一个合法但很慢的单文件上输出一次诊断，因为 spec reporter 按测试文件缓冲输出。它不改变任何判定。
- Linux 的 `wchan`/argv 分支使用 ubuntu-24.04 支持的字段，但在 macOS 上编写；macOS 分支由自测实际覆盖。
- `killSignal: "SIGKILL"` 只作用于直接子进程；挂死的孙进程仍可能存活。这严格优于无界等待，但不是完整的进程树终止。

## 关联材料

- 任务：`task_01KY284MZV4KXJP6RV06E3NTN1`
- 证据：harness 任务包 `facts.md`；`artifacts/codex-shard4-report.md`
- 审查：上一轮尝试 `5df13c86`（PR #971）——本 PR 说明了它为何没有收敛

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过双语检查。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled. / 治理声明已填。
- [x] No private harness files are included. / 不包含私有 harness 文件（diff 仅 `tools/`）。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本描述不含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明范围。
- [x] Private planning/evidence updates are recorded when applicable. / 已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证（含未跑项与原因）。
- [x] CI results are linked or explained. / CI 结果已说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / 无 open findings。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式：队列无其他 PR 时单 PR 直合；合并后删远端分支、同步 main、清理 worktree。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 不计划 admin bypass。
