### PR TITLE
fix(cli): keep the execute bit on built bin targets

### DIFF
--- a/packages/cli/scripts/copy-assets.mjs
+++ b/packages/cli/scripts/copy-assets.mjs
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import "./rewrite-workspace-imports.mjs";
@@ -21,4 +21,20 @@ for (const { source, target } of copies) {
   }
   mkdirSync(path.dirname(target), { recursive: true });
   cpSync(source, target, { recursive: true });
+}
+
+// `tsc` emits the CLI entry with the default 0644, and `node_modules/.bin/ha`
+// is a symlink straight to it, so every re-emit leaves `ha` unexecutable until
+// the next install relinks it. Restore the bit here, derived from the declared
+// `bin` map rather than a hardcoded path, so adding a bin cannot silently miss
+// this step.
+for (const target of declaredBinTargets()) {
+  if (!existsSync(target)) throw new Error(`declared bin target is missing after build: ${target}`);
+  chmodSync(target, 0o755);
+}
+
+function declaredBinTargets() {
+  const manifest = JSON.parse(readFileSync(path.join(packageRoot, "package.json"), "utf8"));
+  const bin = typeof manifest.bin === "string" ? { [manifest.name]: manifest.bin } : manifest.bin ?? {};
+  return [...new Set(Object.values(bin))].map((relative) => path.join(packageRoot, relative));
 }

--- a/tools/smoke-cli-package.mjs
+++ b/tools/smoke-cli-package.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -100,6 +100,8 @@ export function buildCliPackageArtifact(root, options = {}) {
   const exec = options.execFileSync ?? execFileSync;
   const exists = options.existsSync ?? existsSync;
   const remove = options.rmSync ?? rmSync;
+  const stat = options.statSync ?? statSync;
+  const platform = options.platform ?? process.platform;
   const distPath = path.join(root, "packages/cli/dist");
   remove(distPath, { recursive: true, force: true });
   exec("npm", ["run", "build", "--workspace", "@harness-anything/cli"], {
@@ -113,6 +115,12 @@ export function buildCliPackageArtifact(root, options = {}) {
   const binPath = path.join(root, "packages/cli/dist/cli/src/index.js");
   if (!exists(binPath)) {
     throw new Error(`explicit CLI package build did not produce ${binPath}`);
+  }
+  // `node_modules/.bin/ha` symlinks straight to this file, so a build that
+  // emits it without the execute bit leaves `ha` unusable until the next
+  // install relinks it. Invoking it through `node` below would not notice.
+  if (platform !== "win32" && (stat(binPath).mode & 0o111) === 0) {
+    throw new Error(`clean CLI package build produced a non-executable bin: ${binPath}`);
   }
   const stdout = exec(process.execPath, [binPath, "--json", "version"], {
     cwd: root,

--- a/tools/smoke-cli-package.test.mjs
+++ b/tools/smoke-cli-package.test.mjs
@@ -16,6 +16,7 @@ test("CLI package smoke explicitly builds the CLI artifact even when npm lifecyc
       }
     },
     existsSync: () => true,
+    statSync: () => ({ mode: 0o100755 }),
     rmSync: (...args) => removals.push(args)
   });
 
@@ -46,10 +47,34 @@ test("CLI package smoke rejects a clean build whose bin cannot execute", () => {
         ? JSON.stringify({ ok: false, schema: "command-receipt/v2", command: "version" })
         : undefined,
       existsSync: () => true,
+      statSync: () => ({ mode: 0o100755 }),
       rmSync: () => undefined
     }),
     /clean CLI package build produced an unusable bin/u
   );
+});
+
+test("CLI package smoke rejects a clean build whose bin lost its execute bit", () => {
+  assert.throws(
+    () => buildCliPackageArtifact("/repo", {
+      execFileSync: () => JSON.stringify({ ok: true, schema: "command-receipt/v2", command: "version" }),
+      existsSync: () => true,
+      statSync: () => ({ mode: 0o100644 }),
+      rmSync: () => undefined,
+      platform: "linux"
+    }),
+    new RegExp(`clean CLI package build produced a non-executable bin: ${escapeRegExp(path.join("/repo", "packages/cli/dist/cli/src/index.js"))}`, "u")
+  );
+});
+
+test("CLI package smoke does not require an execute bit on Windows", () => {
+  assert.doesNotThrow(() => buildCliPackageArtifact("/repo", {
+    execFileSync: () => JSON.stringify({ ok: true, schema: "command-receipt/v2", command: "version" }),
+    existsSync: () => true,
+    statSync: () => ({ mode: 0o100644 }),
+    rmSync: () => undefined,
+    platform: "win32"
+  }));
 });
 
 function escapeRegExp(value) {


### PR DESCRIPTION
# English

## Summary

After `npm run build`, `ha` fails with `permission denied`.

`tsc` emits `packages/cli/dist/cli/src/index.js` with the default `0644`, nothing in the build chain restores the execute bit, and `node_modules/.bin/ha` is a symlink straight to that file rather than a wrapper script. npm sets the bit when it links the bin at install time and never revisits it, so every rebuild that re-emits the entry leaves `ha` unusable until someone runs `chmod +x` or reinstalls.

It reads as intermittent because incremental builds often skip the re-emit — it only bites when the entry is actually rewritten.

## What Changed

- `packages/cli/scripts/copy-assets.mjs` — already the last step of the package build, now also `chmod 0755` on every target declared in the package `bin` map. The target list is **derived from the manifest**, not hardcoded, so adding a bin cannot silently miss this step; a declared target that is missing after the build now throws rather than passing silently.
- `tools/smoke-cli-package.mjs` — after the clean rebuild, `buildCliPackageArtifact` asserts the entry carries an execute bit on POSIX. This is where the gap was: the existing check invoked the entry as `node <binPath>`, which succeeds regardless of the file mode, so no gate could see the defect.
- `tools/smoke-cli-package.test.mjs` — two new cases: a `0644` build is rejected on POSIX, and Windows is explicitly exempt because the mode bit is meaningless there.

## Task And Scope

- Harness task: `task_01KY285J0FFV19GT4GH15PRYB2`
- Branch: `fix/cli-bin-exec-bit`
- Public scope: `packages/cli/scripts`, `tools`
- Private planning/evidence updated: yes
- Out of scope: whether the published npm tarball preserves the mode — the task flags that as a separate question to answer before assuming this is only a local DX issue

## Version Impact

- Version: no version change because this fixes the build of an existing package
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KY285J0FFV19GT4GH15PRYB2`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `a21c83319bcaaca1a3e2d573ffcd9a027cad3bb8`
- Branch merge-base with `origin/main`: `a21c83319bcaaca1a3e2d573ffcd9a027cad3bb8`
- Last `git fetch origin` time: 2026-07-21, immediately before opening this PR
- Sync method: none needed — the branch base is already the current `origin/main`
- Public diff command: `git diff main...fix/cli-bin-exec-bit`
- Private evidence commit/path: harness task package `task_01KY285J0FFV19GT4GH15PRYB2` (`facts.md`)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- Not run: local full gate matrix — per the 2026-07-20 ruling the authoritative full gate is GitHub CI. `npm run harness:smoke-cli-package` was also not run locally because it packs and installs the tarball over the network; CI runs it.

The defect was reproduced first, then fixed, then re-verified with the same command:

```
# before, on main
rm packages/cli/dist/cli/src/index.js
touch packages/cli/src/index.ts
npm run build -w @harness-anything/cli
ls -l packages/cli/dist/cli/src/index.js   ->  -rw-r--r--     (ha: permission denied)

# after, on this branch, identical commands
ls -l packages/cli/dist/cli/src/index.js   ->  -rwxr-xr-x
```

Targeted gates, all exit 0:

```
node --test tools/smoke-cli-package.test.mjs   -> tests 5 / pass 5 / fail 0
npx eslint <the three changed files>           -> clean
git diff --check                               -> clean
```

## Review Evidence

- Self-review: full diff read. The reproduction was run on `main` first so the fix has a real before/after, not just a passing test.
- Reviewer subagent: none — the diff is small and the exact change was known before writing it, so delegating would have cost more than doing it.
- Human review: pending
- Blocking findings: none

## Residual Risk

- The new smoke assertion only covers the built tree. Whether `npm pack` preserves the mode into the published tarball is untested here and is tracked on the task as an open question.
- `chmod` is a no-op concern on Windows; the assertion is skipped there rather than adapted, so Windows regressions in bin packaging would not be caught by this gate.

## References

- Task: `task_01KY285J0FFV19GT4GH15PRYB2`
- Evidence: harness task package `facts.md`
- Review: not applicable — no prior attempt at this defect

---

# 中文

## 概要

`npm run build` 之后，`ha` 报 `permission denied`。

`tsc` 以默认 `0644` emit `packages/cli/dist/cli/src/index.js`，构建链里没有任何一步把可执行位加回去，而 `node_modules/.bin/ha` 是**直接指向该文件的 symlink**，不是 wrapper 脚本。npm 只在 install 链接 bin 时设置一次该位，之后不再过问；因此每次重新 emit 入口的构建都会让 `ha` 不可用，直到有人 `chmod +x` 或重新安装。

它表现为间歇性，是因为增量构建常常跳过重新 emit——只有真正重写入口时才咬人。

## 改动内容

- `packages/cli/scripts/copy-assets.mjs`——它本就是包构建的最后一步，现在对包 `bin` map 里声明的每个目标做 `chmod 0755`。目标清单**从 manifest 派生**而非硬编码，因此新增一个 bin 不可能悄悄漏掉这一步；构建后声明的目标若不存在，现在会抛错而不是静默通过。
- `tools/smoke-cli-package.mjs`——干净重建之后，`buildCliPackageArtifact` 在 POSIX 上断言入口带可执行位。缺口正在这里：既有检查是以 `node <binPath>` 方式调用入口的，而这种调用方式**无论文件 mode 如何都会成功**，所以没有任何一道门看得见这个缺陷。
- `tools/smoke-cli-package.test.mjs`——新增两个用例：POSIX 上 `0644` 的构建被拒；Windows 明确豁免，因为 mode 位在那里没有意义。

## 任务与范围

- Harness 任务：`task_01KY285J0FFV19GT4GH15PRYB2`
- 分支：`fix/cli-bin-exec-bit`
- 公开范围：`packages/cli/scripts`、`tools`
- 私有计划 / 证据是否已更新：yes
- 范围外：发布出去的 npm tarball 是否保留 mode——任务里把这一条标为需要单独回答的问题，在回答之前不能假定这只是本机 DX 问题

## 版本影响

- 版本：不改版本，原因是本次修的是既有包的构建
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KY285J0FFV19GT4GH15PRYB2`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`a21c83319bcaaca1a3e2d573ffcd9a027cad3bb8`
- 当前分支与 `origin/main` 的 merge-base：`a21c83319bcaaca1a3e2d573ffcd9a027cad3bb8`
- 最近一次 `git fetch origin` 时间：2026-07-21，开 PR 前
- 同步方式：不需要——分支基线已是当前 `origin/main`
- 公开 diff 命令：`git diff main...fix/cli-bin-exec-bit`
- 私有证据 commit/path：harness 任务包 `task_01KY285J0FFV19GT4GH15PRYB2`（`facts.md`）
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待本 PR 触发
- 未运行：本地全量门矩阵——按 2026-07-20 裁定，权威完整门在 GitHub CI。`npm run harness:smoke-cli-package` 本地也未跑，因为它要打包并联网安装 tarball；由 CI 跑。

先复现缺陷，再修，再用同一条命令复验：

```
# 修之前，在 main 上
rm packages/cli/dist/cli/src/index.js
touch packages/cli/src/index.ts
npm run build -w @harness-anything/cli
ls -l packages/cli/dist/cli/src/index.js   ->  -rw-r--r--     （ha: permission denied）

# 修之后，在本分支上，命令完全相同
ls -l packages/cli/dist/cli/src/index.js   ->  -rwxr-xr-x
```

定向门，全部 exit 0：

```
node --test tools/smoke-cli-package.test.mjs   -> tests 5 / pass 5 / fail 0
npx eslint <三个改动文件>                       -> clean
git diff --check                               -> clean
```

## 审查证据

- 自查：通读完整 diff。复现先在 `main` 上跑过，因此这个修复有真实的前后对照，而不只是一个通过的测试。
- Reviewer subagent：无——diff 很小且动手前就知道确切改动，委托的总成本高于自己做。
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 新增的 smoke 断言只覆盖构建产物树。`npm pack` 是否把 mode 保留进发布 tarball，本 PR 未测，已作为待答问题记在任务上。
- Windows 上 `chmod` 无意义，该断言在那里是跳过而非改写，因此 Windows 的 bin 打包回归不会被这道门抓到。

## 关联材料

- 任务：`task_01KY285J0FFV19GT4GH15PRYB2`
- 证据：harness 任务包 `facts.md`
- 审查：不适用——此缺陷此前没有尝试记录

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过双语检查。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled. / 治理声明已填。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本描述不含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明范围。
- [x] Private planning/evidence updates are recorded when applicable. / 已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证（含未跑项与原因）。
- [x] CI results are linked or explained. / CI 结果已说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / 无 open findings。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式：与 PR #976 并行入队（文件面不重叠）；合并后删远端分支、同步 main、清理 worktree。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 不计划 admin bypass。
