### PR TITLE
fix(ci): flush node test list output before exit

### DIFF
--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -38,7 +38,7 @@ try {
   options = parseRunnerArgs(process.argv.slice(2), testTierNames);
 } catch (error) {
   console.error(error.message);
-  process.exit(2);
+  await exitAfterStreamFlush(2);
 }
 
 const testTierManifest = discoverTestTierManifest(repoRoot);
@@ -61,7 +61,7 @@ if (selection.errors.length > 0) {
   for (const error of selection.errors) {
     console.error(error);
   }
-  process.exit(1);
+  await exitAfterStreamFlush(1);
 }
 
 if (options.shard !== undefined) {
@@ -71,14 +71,14 @@ selection.files = filterTestFilesByPrefixes(selection.files, options.prefixes);
 
 if (selection.files.length === 0) {
   console.log(`No node test files found for tier ${options.tier}.`);
-  process.exit(0);
+  await exitAfterStreamFlush(0);
 }
 
 if (options.list) {
   for (const file of selection.files) {
     console.log(file);
   }
-  process.exit(0);
+  await exitAfterStreamFlush(0);
 }
 
 // Cap process fan-out so full runs don't exhaust memory on developer laptops.
@@ -200,6 +200,15 @@ function positiveIntegerOrDefault(value, fallback) {
   if (value === undefined || value === "") return fallback;
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+async function exitAfterStreamFlush(code) {
+  await Promise.all([flushStream(process.stdout), flushStream(process.stderr)]);
+  process.exit(code);
+}
+
+function flushStream(stream) {
+  return new Promise((resolveFlush) => stream.write("", resolveFlush));
 }
 
 function emitStallDiagnostics({ child, silentForMs, timingRoot, seenDiagnosticReports }) {

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 import { collectSlowTests, DEFAULT_TEST_TIMEOUT_MS, filterTestFilesByPrefixes, formatSlowTestSummary, parseCompletedTestLine, parseRunnerArgs, resolveTestConcurrency, selectTestFiles, validateManifest } from "./node-test-runner-lib.mjs";
 import { defaultTestTierNames, deriveTestTierManifest, discoverTestTierManifest, parseTestTierMarker, testTierNames } from "./test-tier-manifest.mjs";
 
@@ -209,7 +210,7 @@ test("list output survives stdout backpressure", () => {
     ...process.env,
     NODE_OPTIONS: [
       process.env.NODE_OPTIONS,
-      `--import=${path.join(repoRoot, "tools/test-fixtures/delayed-stdout.mjs")}`
+      `--import=${pathToFileURL(path.join(repoRoot, "tools/test-fixtures/delayed-stdout.mjs")).href}`
     ].filter(Boolean).join(" ")
   };
   delete childEnv.NODE_TEST_CONTEXT;

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -203,6 +203,26 @@ test("integration discovery equals the files executed by the CI runner", () => {
   assert.deepEqual(result.stdout.trim().split(/\r?\n/u), manifest.integration);
 });
 
+test("list output survives stdout backpressure", () => {
+  const manifest = discoverTestTierManifest(repoRoot);
+  const childEnv = {
+    ...process.env,
+    NODE_OPTIONS: [
+      process.env.NODE_OPTIONS,
+      `--import=${path.join(repoRoot, "tools/test-fixtures/delayed-stdout.mjs")}`
+    ].filter(Boolean).join(" ")
+  };
+  delete childEnv.NODE_TEST_CONTEXT;
+  const result = spawnSync(process.execPath, ["tools/run-node-tests.mjs", "--tier", "integration", "--list"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: childEnv
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.stdout.trim().split(/\r?\n/u), manifest.integration);
+});
+
 test("nightly tests run only when explicitly selected", () => {
   const manifest = discoverTestTierManifest(repoRoot);
   const nightly = spawnSync(process.execPath, ["tools/run-node-tests.mjs", "--tier", "nightly", "--list"], {

--- a/tools/test-fixtures/delayed-stdout.mjs
+++ b/tools/test-fixtures/delayed-stdout.mjs
@@ -1,0 +1,6 @@
+const originalWrite = process.stdout.write.bind(process.stdout);
+
+process.stdout.write = (chunk, encoding, callback) => {
+  setTimeout(() => originalWrite(chunk, encoding, callback), 10);
+  return false;
+};


### PR DESCRIPTION
# English

## Summary

`main`'s `full-check` has been red on `tools/run-node-tests.test.mjs` for four of the last seven runs, and nobody noticed: `full-check` runs only on push-to-main (`if: github.event_name != 'pull_request'`), so it is not a required PR gate. Pull requests stayed green while main stayed red.

The failing assertion compared discovered test files against the files the CI runner executes, and the discovered list was missing a **continuous tail** — six `packages/kernel/test/store/*` files followed by every `tools/*.test.mjs`.

The cause is not shard fan-out and not derived machine capacity. `--list` writes each file with `console.log` and then calls `process.exit` immediately, and **a forced exit does not drain stdout's queued asynchronous writes**. When stdout is a pipe and the host is busy, only a prefix of the sorted list ever reaches the reader — which is exactly why identical code alternates green and red, and why the earlier `nightly tests run only when explicitly selected` failure lived in the same file on the same mechanism.

## What Changed

- `tools/run-node-tests.mjs` — a new `exitAfterStreamFlush()` awaits the queued `stdout` and `stderr` writes before exiting. It is applied to all four early-exit paths (argument error, manifest error, empty selection, `--list`), and each path keeps its original exit code. No tier, shard, prefix, concurrency, or coverage semantics changed.
- `tools/run-node-tests.test.mjs` — the two existing strict deep-equal assertions are untouched. A new end-to-end regression proves the list is not "exit 0 with truncated content".
- `tools/test-fixtures/delayed-stdout.mjs` — new fixture that delays stdout writes, turning a load-dependent race into a deterministic reproduction.

`tools/integration-test-shards.mjs` and `.github/workflows/rewrite-ci.yml` are unchanged. The relationship between the `full-check` and `integration-shard` job parameters did not need to change.

**A hypothesis was refuted along the way, and that matters for anyone reading the history.** The investigation started from "shard count is derived from measured machine capacity, so different runners produce different unions". That is wrong: `--list` returns before `resolveTestConcurrency`, before the local slot acquisition, and before the runner starts, and the failing child commands never passed `--shard`. `f8c6096e`, `89a55936`, `7431265d` and the #974 merge changed local fan-out and capacity budgeting — they raised the probability of hitting the race by adding host load, but they did not change discovery semantics.

## Task And Scope

- Harness task: `task_01KY2DNND29HD5DJ67QN7X988G`
- Branch: `fix/main-fullcheck-shard-discovery`
- Public scope: `tools/`
- Private planning/evidence updated: yes
- Out of scope: the governance question of whether `full-check` should be a required PR gate. This PR fixes the red; it does not change what made the red invisible.

## Version Impact

- Version: no version change because this only touches test tooling
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable. The task authorized CI/gate changes, but the final diff touches only `tools/` — no workflow file, no shard derivation, no gate verdict, no assertion loosened.
- Authority: `task_01KY2DNND29HD5DJ67QN7X988G` — the task explicitly authorizes fixing the runner and its tests, and explicitly withholds authority to relax the assertions, reduce coverage, or make `full-check` non-blocking.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `40992f460ac1f958148ab44af129758e9532734c`
- Branch merge-base with `origin/main`: `40992f460ac1f958148ab44af129758e9532734c`
- Last `git fetch origin` time: 2026-07-21, immediately before opening this PR
- Sync method: none needed — the branch base is already the current `origin/main`
- Public diff command: `git diff main...fix/main-fullcheck-shard-discovery`
- Private evidence commit/path: harness task package `task_01KY2DNND29HD5DJ67QN7X988G` (`facts.md`, `artifacts/codex-mainred-report.md`)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- Not run: local full gate matrix — per the 2026-07-20 ruling the authoritative full gate is GitHub CI. The change surface is test tooling, so targeted gates were run instead.

**Negative control, reproduced independently by the reviewer rather than trusting the implementer's output.** The implementation was reverted while keeping the new test, so the test faces the unfixed runner:

```
# fixed
✔ list output survives stdout backpressure (135.118208ms)
ℹ tests 21 / pass 21 / fail 0

# git checkout main -- tools/run-node-tests.mjs   (test kept, impl reverted)
✖ list output survives stdout backpressure (104.282959ms)
ℹ tests 21 / pass 20 / fail 1
```

Against the unfixed runner the assertion sees an empty list while the process still reports exit 0 — the defect stated precisely.

Other targeted gates, all exit 0:

```
node --test tools/run-node-tests.test.mjs                      -> tests 21 / pass 21 / fail 0
CI=true HARNESS_TEST_CONCURRENCY=3 node@24 --test-concurrency=3 -> tests 21 / pass 21 / fail 0
npx eslint <the three changed files>                            -> clean
node tools/check-write-road-registry.mjs                        -> 61 rows, 497 write surfaces, passed
node tools/scan-forbidden-symbols.mjs                           -> delta 0, passed
node tools/check-private-boundary.mjs                           -> delta 0, passed
git diff --check main...HEAD                                    -> clean
```

## Review Evidence

- Self-review: full diff read. `stream.write("", callback)` is the drain point; the callback fires only after previously queued writes complete, and every early-exit path keeps its exit code.
- Reviewer subagent: implementation by a Codex worker in an isolated worktree. The worker used its dissent channel to refute the CEO's stated hypothesis with evidence, and was right to.
- Human review: pending
- Blocking findings: none

## Residual Risk

- The backpressure fixture is a deterministic simulation of stdout write timing, not a byte-level emulation of a Linux kernel pipe. It covers the same exit mechanism that caused the CI truncation.
- This branch has not run on a real GitHub-hosted ubuntu-24.04 runner yet; **the merge is only proven once main's next `full-check` turns green**, and that will be checked rather than assumed.
- `full-check` remains a non-required PR gate, so a future main-only red would again be silent. That is a separate governance question, deliberately not decided here.

## References

- Task: `task_01KY2DNND29HD5DJ67QN7X988G`
- Evidence: harness task package `facts.md`; `artifacts/codex-mainred-report.md`
- Review: red main runs `29805434375`, `29806744240`, `29826658079`, `29832104158`

---

# 中文

## 概要

`main` 的 `full-check` 在最近 7 次 run 里有 4 次红在 `tools/run-node-tests.test.mjs`，而没有人发现：`full-check` 只在 push-to-main 触发（`if: github.event_name != 'pull_request'`），不是 PR 的必需门。PR 一路绿，main 一路红。

失败的断言比较"发现到的测试文件"与"CI runner 实际执行的文件"，而发现到的列表缺了**连续的尾段**——6 个 `packages/kernel/test/store/*` 加**全部** `tools/*.test.mjs`。

真因不是分片扇出，也不是派生的机器容量。`--list` 用 `console.log` 逐个写文件，然后立即调用 `process.exit`，而**强制退出不会排干 stdout 已排队的异步写**。当 stdout 接管道且主机繁忙时，只有已排序列表的一个前缀能到达读端——这精确解释了为什么同一份代码会时绿时红，也解释了早先那次 `nightly tests run only when explicitly selected` 为什么红在同一个文件、同一个机制上。

## 改动内容

- `tools/run-node-tests.mjs`——新增 `exitAfterStreamFlush()`，退出前等待 `stdout` 与 `stderr` 已排队的写入完成。四个早退路径（参数错误、manifest 错误、空 selection、`--list`）全部走它，各自保留原退出码。tier、shard、prefix、并发与覆盖口径均未改变。
- `tools/run-node-tests.test.mjs`——原有两个严格深相等断言原样保留。新增一个端到端回归，证明列表不是"exit 0 但内容被截断"。
- `tools/test-fixtures/delayed-stdout.mjs`——新 fixture，延迟 stdout 写入，把依赖负载的竞态变成确定性复现。

`tools/integration-test-shards.mjs` 与 `.github/workflows/rewrite-ci.yml` 未改；`full-check` 与 `integration-shard` 的分片参数关系不需要改变。

**过程中有一个假设被证伪，这一点对以后翻历史的人有用。** 调查起点是"分片数由实测机器容量派生，因此不同 runner 得到不同并集"。这是错的：`--list` 在 `resolveTestConcurrency` 之前、在获取本地 slot 之前、在 runner 启动之前就返回了，而失败的 child 命令根本没传 `--shard`。`f8c6096e`、`89a55936`、`7431265d` 与 #974 的合并改的是本地扇出与容量预算——它们通过增加主机压力**提高了撞上竞态的概率**，但没有改变 discovery 语义。

## 任务与范围

- Harness 任务：`task_01KY2DNND29HD5DJ67QN7X988G`
- 分支：`fix/main-fullcheck-shard-discovery`
- 公开范围：`tools/`
- 私有计划 / 证据是否已更新：yes
- 范围外：`full-check` 该不该成为 PR 必需门这个治理问题。本 PR 修的是那道红，不改变"是什么让这道红隐形"。

## 版本影响

- 版本：不改版本，原因是本次只触碰测试工具链
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用。任务授权了 CI/gate 改动，但最终 diff 只触碰 `tools/`——无 workflow 文件、无分片派生、无 gate 判定、无断言放宽。
- 依据：`task_01KY2DNND29HD5DJ67QN7X988G`——该任务明确授权修 runner 与其测试，并明确不授权放宽断言、降低覆盖、或让 `full-check` 变成非阻塞。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`40992f460ac1f958148ab44af129758e9532734c`
- 当前分支与 `origin/main` 的 merge-base：`40992f460ac1f958148ab44af129758e9532734c`
- 最近一次 `git fetch origin` 时间：2026-07-21，开 PR 前
- 同步方式：不需要——分支基线已是当前 `origin/main`
- 公开 diff 命令：`git diff main...fix/main-fullcheck-shard-discovery`
- 私有证据 commit/path：harness 任务包 `task_01KY2DNND29HD5DJ67QN7X988G`（`facts.md`、`artifacts/codex-mainred-report.md`）
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待本 PR 触发
- 未运行：本地全量门矩阵——按 2026-07-20 裁定，权威完整门在 GitHub CI。本次改动面是测试工具链，因此改跑定向门。

**阴性对照，由复核方独立复跑，而非采信实现方粘贴的输出。** 做法是只回滚实现、保留新测试，让测试面对未修的 runner：

```
# 已修
✔ list output survives stdout backpressure (135.118208ms)
ℹ tests 21 / pass 21 / fail 0

# git checkout main -- tools/run-node-tests.mjs   （保留测试，回滚实现）
✖ list output survives stdout backpressure (104.282959ms)
ℹ tests 21 / pass 20 / fail 1
```

面对未修的 runner，断言看到的是**空列表**，而进程仍然报 exit 0——正是本缺陷的精确表述。

其余定向门，全部 exit 0：

```
node --test tools/run-node-tests.test.mjs                      -> tests 21 / pass 21 / fail 0
CI=true HARNESS_TEST_CONCURRENCY=3 node@24 --test-concurrency=3 -> tests 21 / pass 21 / fail 0
npx eslint <三个改动文件>                                        -> clean
node tools/check-write-road-registry.mjs                        -> 61 rows, 497 write surfaces, passed
node tools/scan-forbidden-symbols.mjs                           -> delta 0, passed
node tools/check-private-boundary.mjs                           -> delta 0, passed
git diff --check main...HEAD                                    -> clean
```

## 审查证据

- 自查：通读完整 diff。`stream.write("", callback)` 是排干点，回调只在此前已排队的写入完成后触发；四个早退路径各自保留原退出码。
- Reviewer subagent：由 Codex worker 在独立 worktree 实现。该 worker 用异议通道**带证据推翻了 CEO 给出的假设**，并且它是对的。
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 背压 fixture 是对 stdout 写入时序的确定性模拟，不是 Linux kernel pipe 的逐字节仿真；它覆盖的是导致 CI 截断的同一个退出机制。
- 本分支尚未在真实 GitHub-hosted ubuntu-24.04 runner 上跑过；**只有 main 的下一次 `full-check` 转绿才算证明**，这一条会去查而不是假定。
- `full-check` 仍然不是 PR 必需门，因此将来再出现只在 main 上的红，依然是静默的。那是另一个治理问题，本 PR 刻意不裁。

## 关联材料

- 任务：`task_01KY2DNND29HD5DJ67QN7X988G`
- 证据：harness 任务包 `facts.md`；`artifacts/codex-mainred-report.md`
- 审查：红的 main run `29805434375`、`29806744240`、`29826658079`、`29832104158`

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过双语检查。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled. / 治理声明已填。
- [x] No private harness files are included. / 不包含私有 harness 文件（diff 仅 `tools/`）。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本描述不含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明范围。
- [x] Private planning/evidence updates are recorded when applicable. / 已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证（含未跑项与原因）。
- [x] CI results are linked or explained. / CI 结果已说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / 无 open findings。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式：队列无其他 PR 时单 PR 直合；合并后删远端分支、同步 main、清理 worktree，并盯下一次 main `full-check` 转绿。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 不计划 admin bypass。
