### PR TITLE
fix(cli): task closeout dry-run honors its receipt contract and claim receipts stop being silent

### DIFF
--- a/packages/cli/src/cli/command-spec/command-spec-core.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-core.ts
@@ -139,7 +139,7 @@ export const coreCommandSpecs = defineCommandSpecs([
     "parse": parseCoreTaskArgs,
     "run": runTaskLifecycleCommand,
     "receiptContract": {
-      "data": ["taskId", "report"],
+      "data": ["taskId", "status", "report"],
       "optionalData": { "executionId": "Only emitted when a work claim opens a Holder V2 Execution round." },
       "paths": []
     },
@@ -158,7 +158,11 @@ export const coreCommandSpecs = defineCommandSpecs([
     "run": rejectDaemonTaskLifecycleFacade,
     "receiptContract": {
       "data": ["taskId", "executionId", "status", "report"],
-      "paths": []
+      "paths": [],
+      "dryRun": {
+        "data": ["taskId", "report"],
+        "paths": []
+      }
     },
     "eventPolicy": {
       "conflictMarkerPreflight": false,
@@ -238,7 +242,11 @@ export const coreCommandSpecs = defineCommandSpecs([
     "run": rejectDaemonTaskLifecycleFacade,
     "receiptContract": {
       "data": ["taskId", "executionId", "status", "report"],
-      "paths": []
+      "paths": [],
+      "dryRun": {
+        "data": ["taskId", "report"],
+        "paths": []
+      }
     },
     "eventPolicy": {
       "conflictMarkerPreflight": false,

--- a/packages/cli/src/cli/command-spec/types.ts
+++ b/packages/cli/src/cli/command-spec/types.ts
@@ -26,6 +26,7 @@ export interface CommandReceiptContract {
   readonly paths: ReadonlyArray<string>;
   readonly optionalData?: Readonly<Record<string, string>>;
   readonly optionalPaths?: Readonly<Record<string, string>>;
+  readonly dryRun?: Omit<CommandReceiptContract, "dryRun">;
 }
 
 export interface CommandEventPolicySpec {

--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -219,8 +219,12 @@ function setPath(paths: Record<string, string>, key: string, value: unknown): vo
 }
 
 function validateReceiptContract(receipt: LegacyCommandReceipt): string | undefined {
-  const contract: CommandReceiptContract | undefined = commandReceiptContractsByKind[receipt.command as keyof typeof commandReceiptContractsByKind];
-  if (!contract) return `missing receipt contract for command ${receipt.command}`;
+  const declaredContract: CommandReceiptContract | undefined = commandReceiptContractsByKind[receipt.command as keyof typeof commandReceiptContractsByKind];
+  if (!declaredContract) return `missing receipt contract for command ${receipt.command}`;
+  const report = receipt.data?.report;
+  const dryRun = report !== null && typeof report === "object" && !Array.isArray(report)
+    && (report as { readonly dryRun?: unknown }).dryRun === true;
+  const contract = dryRun && declaredContract.dryRun ? declaredContract.dryRun : declaredContract;
   const allowedData: ReadonlySet<string> = new Set([...contract.data, ...Object.keys(contract.optionalData ?? {})]);
   const allowedPaths: ReadonlySet<string> = new Set([...contract.paths, ...Object.keys(contract.optionalPaths ?? {})]);
   const dataKeys = Object.keys(receipt.data ?? {});

--- a/packages/cli/src/commands/core/task-holder.ts
+++ b/packages/cli/src/commands/core/task-holder.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect";
 import {
   makeCoordinatedExecutionAuthoredStore,
   makeExecutionSagaService,
+  readTaskLifecyclePolicy,
   type TaskHolderPrincipal
 } from "@harness-anything/application";
 import { readSessionEntityDocument, type WriteError } from "@harness-anything/kernel";
@@ -10,6 +11,7 @@ import { toCliError } from "../../cli/error-mapper.ts";
 import type { CliResult } from "../../cli/types.ts";
 import type { CommandRunner, CommandRunnerContext } from "../../cli/runner-registry.ts";
 import { milestoneDecisionLineageFailure } from "./task-lineage-gate.ts";
+import { plannedTaskClaimGuidance } from "./task-lifecycle-facade-guidance.ts";
 import { resultForTaskHolderFailure, taskHolderCommandFailure, taskHolderPrincipal } from "./task-holder-support.ts";
 type TaskHolderAction = Extract<
   Parameters<CommandRunner>[1]["action"],
@@ -157,24 +159,32 @@ export function runTaskClaim(
   return Effect.gen(function* () {
     const principal = taskHolderPrincipal(context);
     if (!principal.ok) return principal.result;
-    if (action.execution || action.executionId) return yield* runExecutionClaim(context, action, principal.value);
+    const policy = yield* readTaskLifecyclePolicy(context.artifactStore, action.taskId);
     const session = yield* context.currentSessionProbe.currentSession;
-    if (session.runtime !== "human") return yield* runExecutionClaim(context, action, principal.value);
-    return yield* Effect.tryPromise({
-      try: () => context.taskHolderService.claim({ taskId: action.taskId, principal: principal.value, ttlMs: action.ttlMs }),
-      catch: taskHolderCommandFailure
-    }).pipe(Effect.match({
-      onFailure: (result): CliResult => resultForTaskHolderFailure("task-claim", action.taskId, result),
-      onSuccess: (result): CliResult => ({
-        ok: true,
-        command: "task-claim",
-        taskId: action.taskId,
-        report: {
-          schema: "task-holder-claim-result/v1",
-          ...result
-        }
-      })
-    }));
+    const claimed = action.execution || action.executionId || session.runtime !== "human"
+      ? yield* runExecutionClaim(context, action, principal.value)
+      : yield* Effect.tryPromise({
+        try: () => context.taskHolderService.claim({ taskId: action.taskId, principal: principal.value, ttlMs: action.ttlMs }),
+        catch: taskHolderCommandFailure
+      }).pipe(Effect.match({
+        onFailure: (result): CliResult => resultForTaskHolderFailure("task-claim", action.taskId, result),
+        onSuccess: (result): CliResult => ({
+          ok: true,
+          command: "task-claim",
+          taskId: action.taskId,
+          report: {
+            schema: "task-holder-claim-result/v1",
+            ...result
+          }
+        })
+      }));
+    if (!claimed.ok || policy?.status === null || policy?.status === undefined) return claimed;
+    const guidance = policy.status === "planned" ? plannedTaskClaimGuidance(action.taskId) : undefined;
+    return {
+      ...claimed,
+      status: policy.status,
+      ...(guidance ? { warnings: [...(claimed.warnings ?? []), guidance] } : {})
+    };
   });
 }
 

--- a/packages/cli/src/commands/core/task-lifecycle-facade-guidance.ts
+++ b/packages/cli/src/commands/core/task-lifecycle-facade-guidance.ts
@@ -1,6 +1,23 @@
 import type { CommandFailureReceipt, CommandReceipt } from "../../cli/receipt.ts";
 import type { ParsedCommand } from "../../cli/types.ts";
 
+export interface PlannedTaskClaimGuidance {
+  readonly severity: "warning";
+  readonly code: "task_still_planned";
+  readonly message: string;
+  readonly nextCommand: string;
+}
+
+export function plannedTaskClaimGuidance(taskId: string): PlannedTaskClaimGuidance {
+  const nextCommand = joinLifecycleCommand("ha", "task", "start", taskId);
+  return {
+    severity: "warning",
+    code: "task_still_planned",
+    message: `Task ${taskId} remains planned after claim; move it to active before writing facts or closing out.`,
+    nextCommand
+  };
+}
+
 export function guidedLifecycleFacadeFailure(
   failure: CommandFailureReceipt,
   completedSteps: ReadonlyArray<CommandReceipt>,

--- a/packages/cli/src/commands/core/task-lifecycle-facade.ts
+++ b/packages/cli/src/commands/core/task-lifecycle-facade.ts
@@ -140,6 +140,7 @@ function dryRun(
     taskId: command.action.taskId,
     report: {
       schema: `${command.action.kind}-dry-run/v1`,
+      dryRun: true,
       ...extra,
       steps: steps.map((step) => step.action.kind)
     }

--- a/packages/cli/test/receipt-contracts.test.ts
+++ b/packages/cli/test/receipt-contracts.test.ts
@@ -65,6 +65,25 @@ test("command receipts fail closed on missing declared success data", () => {
   }
 });
 
+test("task closeout dry-run uses its declared receipt variant while real closeout stays strict", () => {
+  const dryRun = toCommandReceipt({
+    ok: true,
+    command: "task-closeout",
+    taskId: "task_1",
+    report: { schema: "task-closeout-dry-run/v1", dryRun: true }
+  });
+  assert.equal(dryRun.ok, true, JSON.stringify(dryRun));
+
+  const realCloseout = toCommandReceipt({
+    ok: true,
+    command: "task-closeout",
+    taskId: "task_1",
+    report: { schema: "task-closeout-result/v1" }
+  });
+  assert.equal(realCloseout.ok, false);
+  if (!realCloseout.ok) assert.match(realCloseout.error?.hint ?? "", /data\.executionId, data\.status/u);
+});
+
 test("command receipts fail closed on missing declared paths", () => {
   const receipt = toCommandReceipt({
     ok: true,

--- a/packages/cli/test/task-lease-cli.test.ts
+++ b/packages/cli/test/task-lease-cli.test.ts
@@ -106,6 +106,10 @@ test("task claim defaults to a 24 hour lease when no TTL setting is present", ()
     const claimed = runJson(rootDir, ["task", "claim", created.taskId]);
 
     assert.equal(leaseDurationMs(claimed.report), 86_400_000);
+    assert.equal(claimed.status, "planned");
+    const guidance = claimed.warnings.find((warning: Record<string, unknown>) => warning.code === "task_still_planned");
+    assert.match(String(guidance?.message), /remains planned after claim.+before writing facts or closing out/iu);
+    assert.equal(guidance?.nextCommand, `ha task start ${created.taskId}`);
   });
 });
 

--- a/packages/cli/test/task-lifecycle-facade-cli.test.ts
+++ b/packages/cli/test/task-lifecycle-facade-cli.test.ts
@@ -62,6 +62,28 @@ test("approved closeout without consent is rejected before any lifecycle write",
   });
 });
 
+test("closeout dry-run satisfies its receipt contract without inventing execution state", () => {
+  withTempRoot((rootDir) => {
+    const fixture = prepareActiveTask(rootDir, "Dry Run Contract");
+    const packet = writeCloseoutPacket(rootDir);
+    const taskRoot = path.join(rootDir, fixture.packagePath);
+    const indexBefore = readFileSync(path.join(taskRoot, "INDEX.md"), "utf8");
+
+    const previewed = runJson(rootDir, ["task", "closeout", fixture.taskId, "--from-file", packet, "--dry-run"], true, fixture.env);
+
+    assert.equal(previewed.ok, true);
+    assert.equal(previewed.command, "task-closeout");
+    assert.equal(previewed.taskId, fixture.taskId);
+    assert.equal(previewed.executionId, undefined);
+    assert.equal(previewed.status, undefined);
+    assert.equal(previewed.report.schema, "task-closeout-dry-run/v1");
+    assert.equal(previewed.report.dryRun, true);
+    assert.equal(previewed.report.preview.schema, "command-dry-run-preview/v1");
+    assert.deepEqual(previewed.report.steps, ["status-set", "task-review-execution", "task-code-doc-reconcile", "task-complete"]);
+    assert.equal(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), indexBefore);
+  });
+});
+
 test("closeout held by another worker recommends waiting or contacting the holder, never claim", () => {
   withTempRoot((leaseRoot) => {
     const fixture = prepareActiveTask(leaseRoot, "Lost Lease");


### PR DESCRIPTION
# English

## Summary

`ha task closeout --dry-run` violated its own command receipt contract (`command_receipt_contract_mismatch`: missing `data.executionId`/`data.status`), so the heaviest closeout command could not be previewed at all. Separately, a successful `ha task claim` receipt stayed silent about the task still being `planned`, steering holders into a dead zone that only surfaced as a different error at closeout time. Both are workflow defects observed in production on 2026-07-21.

## What Changed

- `CommandReceiptContract` gains an explicit `dryRun` variant type; the receipt validator selects it only when the command declares one and the success report carries `dryRun: true`. No validation is skipped or loosened.
- `task-closeout` keeps its strict real-execution contract (`taskId/executionId/status/report`) and declares a `taskId/report` dry-run variant; `task-start --dry-run` had the same disease and receives the same variant.
- The closeout facade dry-run report now explicitly records `dryRun: true` as the auditable selector.
- `task claim` reads the actual lifecycle status after claiming, reports it in the receipt (now a required contract field, so future regressions fail closed), and when the task is still `planned` attaches a `task_still_planned` warning with a copyable `ha task start <task-id>` next command, reusing the existing lifecycle guidance renderer. The state machine itself is untouched.

## Task And Scope

- Task: `task_01KY2DCC006N6HQ8GMKTCMDHYJ` (task closeout dry-run receipt breach + claim/start semantics).
- Scope: CLI receipt contracts, closeout/start facade dry-run reports, claim receipt guidance, and regression tests. No state-machine change, no harness ledger change, no CI/gate authority change.

## Version Impact

No package version bump. Additive receipt fields (`data.status` on claim, `dryRun` flag in dry-run reports) and a new warning; no breaking CLI surface change.

## Governance Declaration

No governance-controlled surfaces are modified. The task-lifecycle state machine (planned→active advancement) is intentionally unchanged; only receipt honesty and contract/dry-run reconciliation changed. No CI workflow, gate manifest, or branch-protection change.

## Verification

- `HARNESS_CLI_TEST_FIXTURE_PRELOAD=1 node --test packages/cli/test/receipt-contracts.test.ts` → 19/19 pass (re-run independently by the CEO session).
- `NODE_OPTIONS="--import=$PWD/tools/cli-test-fixture-register.mjs" HARNESS_CLI_TEST_FIXTURE_PRELOAD=1 node --test packages/cli/test/task-lifecycle-facade-cli.test.ts` → 6/6 pass, including "closeout dry-run satisfies its receipt contract without inventing execution state".
- Same runner injection for `packages/cli/test/task-lease-cli.test.ts` → 16/16 pass.
- `npx tsc -p packages/cli/tsconfig.build.json --noEmit` and targeted eslint over all touched files → clean.

## Review Evidence

Negative controls executed and restored: (1) removing the dry-run contract variant reproduces the exact production error (`command_receipt_contract_mismatch` … missed declared fields: `data.executionId`, `data.status`); (2) reverting the claim status/guidance decoration fails the new claim assertions. Worker report with full runner transcripts: `harness/tasks/task_01KY2DCC006N6HQ8GMKTCMDHYJ-task-closeout-dry-run-claim-start/artifacts/worker-report-closeout.md` (ledger-side, not in this diff).

## Residual Risk

The variant selector depends on the facade honestly reporting `dryRun: true`; commands that declare no variant are unaffected. Full gate matrix runs in CI, not locally, per repository stop-point policy.

## References

- Task package: `harness/tasks/task_01KY2DCC006N6HQ8GMKTCMDHYJ-task-closeout-dry-run-claim-start/`
- Related defect family: declaration surface vs runtime reconciliation (same family as PR #975).

---

# 中文

## 概要

`ha task closeout --dry-run` 违反它自己声明的回执契约（`command_receipt_contract_mismatch`：缺 `data.executionId`/`data.status`），最重的收口命令完全无法预演。另外 `ha task claim` 成功回执对"任务仍在 `planned`"零提示，把持有者引向死区，直到收口阶段才以另一个错误暴露。两处均为 2026-07-21 生产实测的流转缺陷。

## 改动内容

- `CommandReceiptContract` 增加显式 `dryRun` 变体类型；回执校验器仅在命令声明了变体、且成功 report 带 `dryRun: true` 时选择它。没有任何校验被跳过或放松。
- `task-closeout` 真实执行契约保持严格（`taskId/executionId/status/report`），并声明 `taskId/report` 的 dry-run 变体；`task-start --dry-run` 同病同修。
- closeout facade 的 dry-run report 显式写入 `dryRun: true`，作为可审计的变体选择判据。
- `task claim` 成功后读取并回执实际生命周期状态（该字段进契约必填，未来回归会 fail closed）；状态仍为 `planned` 时附 `task_still_planned` 警告与可复制的 `ha task start <task-id>`，复用既有 guidance 机制。状态机本身未动。

## 任务与范围

- 任务：`task_01KY2DCC006N6HQ8GMKTCMDHYJ`。
- 范围：CLI 回执契约、closeout/start facade 的 dry-run report、claim 回执提示与回归测试。不改状态机、不动 harness 台账、不碰 CI/gate 权威面。

## 版本影响

无包版本变更。回执新增字段与警告均为增量；无破坏性 CLI 面变化。

## 治理声明

未修改治理管控面。任务生命周期状态机（planned→active 推进条件）刻意不动，只改回执诚实度与契约对账。无 CI workflow、gate manifest、分支保护改动。

## 验证

- `receipt-contracts.test.ts` 19/19 通过（CEO 会话独立复跑）。
- `task-lifecycle-facade-cli.test.ts` 6/6 通过，含"closeout dry-run 满足自己的回执契约且不伪造执行状态"。
- `task-lease-cli.test.ts` 16/16 通过。
- 定向 `tsc --noEmit` 与 eslint 全部干净。

## 审查证据

阴性对照均已执行并恢复：(1) 撤掉 dry-run 契约变体可复现与生产完全同码同字段的报错；(2) 回滚 claim 状态/提示装饰后新断言失败。完整 runner 输出见台账报告 `harness/tasks/task_01KY2DCC006N6HQ8GMKTCMDHYJ-task-closeout-dry-run-claim-start/artifacts/worker-report-closeout.md`（不在本 diff 内）。

## 残余风险

变体选择依赖 facade 诚实上报 `dryRun: true`；未声明变体的命令行为不变。完整门矩阵按仓库停止点纪律留给 CI。

## 关联材料

- 任务包：`harness/tasks/task_01KY2DCC006N6HQ8GMKTCMDHYJ-task-closeout-dry-run-claim-start/`
- 同族缺陷：声明面与运行时互不对账（与 PR #975 同族）。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Targeted tests green / 定向测试全绿
- [x] No governance surface touched / 未触碰治理面
