### PR TITLE
feat(daemon): S1.0 torn-tail repair + S1.4 kill-9 disease integration with intent-record fencing

### DIFF
--- a/packages/application/src/authority/intent-record-persistence.ts
+++ b/packages/application/src/authority/intent-record-persistence.ts
@@ -1,0 +1,28 @@
+import type { AuthorityGenerationFence, DaemonGenerationWriteRejectionV1 } from "./types.ts";
+import { isDaemonGenerationFenced } from "./generation-fence-enforcement.ts";
+
+type GenerationIntentRejection = Error & {
+  readonly code: "DAEMON_GENERATION_FENCED";
+  readonly context: DaemonGenerationWriteRejectionV1;
+};
+
+export async function persistAuthorityIntentWhileGenerationCurrent(input: {
+  readonly generationFence?: AuthorityGenerationFence;
+  readonly identity: { readonly workspaceId: string; readonly opId: string };
+  readonly persist: () => Promise<void>;
+}): Promise<GenerationIntentRejection | undefined> {
+  try {
+    if (!input.generationFence) {
+      await input.persist();
+      return undefined;
+    }
+    await input.generationFence.runExclusive("before-prepare", input.identity, async () => {
+      await input.generationFence!.assertHeld("before-prepare", input.identity);
+      await input.persist();
+    });
+    return undefined;
+  } catch (error) {
+    if (!isDaemonGenerationFenced(error)) throw error;
+    return error;
+  }
+}

--- a/packages/application/src/authority/service.ts
+++ b/packages/application/src/authority/service.ts
@@ -45,6 +45,7 @@ import {
   validateLegacyTokenEnvelopeClaims
 } from "./legacy-admission.ts";
 import { createAuthorityOperationRecordPersistence } from "./operation-record-persistence.ts";
+import { persistAuthorityIntentWhileGenerationCurrent } from "./intent-record-persistence.ts";
 import { canonicalAuthorityRequestDigest, runWithAuthorityAdmission } from "./admission.ts";
 import {
   authorityPublicationBatchSize,
@@ -64,7 +65,6 @@ import {
 import { batchReceipts, indeterminate, rejected, retryable, terminal } from "./receipt-builders.ts";
 import type { AuthoritySubmissionServiceOptions } from "./service-options.ts";
 export type { AuthoritySubmissionServiceOptions, AuthoritySubmissionV2Options } from "./service-options.ts";
-
 export function createAuthoritySubmissionService(options: AuthoritySubmissionServiceOptions): AuthoritySubmissionService {
   const writableEntityRegistry = options.v2
     ? createWritableEntityRegistry(options.v2.entityRegistrations)
@@ -177,7 +177,12 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
       if (known.receipt) return terminal(known.receipt);
       return terminal(indeterminate(identity, semanticDigest, `operation remains ${known.state}`));
     }
-    await put(identity, semanticDigest, "RECEIVED", undefined, undefined, undefined, canonicalRequestEnvelope);
+    const intentRejection = await persistAuthorityIntentWhileGenerationCurrent({
+      generationFence: options.generationFenceWitness,
+      identity,
+      persist: () => put(identity, semanticDigest, "RECEIVED", undefined, undefined, undefined, canonicalRequestEnvelope)
+    });
+    if (intentRejection) return terminal(generationFencedReceipt(identity, semanticDigest, intentRejection));
     let computedIntegrity: AuthorityOperationIntegrity | undefined;
     try {
       if (!sameProtocolSchemaTupleV2(envelope.schemaTuple, v2.schemaTuple)) {
@@ -274,7 +279,12 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
       if (known.receipt) return terminal(known.receipt);
       return terminal(indeterminate(envelope, semanticDigest, `operation remains ${known.state}`));
     }
-    await put(envelope, semanticDigest, "RECEIVED");
+    const intentRejection = await persistAuthorityIntentWhileGenerationCurrent({
+      generationFence: options.generationFenceWitness,
+      identity: envelope,
+      persist: () => put(envelope, semanticDigest, "RECEIVED")
+    });
+    if (intentRejection) return terminal(generationFencedReceipt(envelope, semanticDigest, intentRejection));
     if (options.v2 && (envelope.operation.kind === "doc_sync_submit" || envelope.operation.kind === "script_ingest")) {
       return terminal(await persistTerminal(
         envelope,
@@ -360,24 +370,26 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
     }
 
     const candidates: PreparedAuthoritySubmission[] = [];
-    for (const entry of prepared) {
-      try {
-        await Effect.runPromise(entry.coordinator.enqueue(entry.operation));
-        await put(entry, entry.semanticDigest, "PREPARED", undefined, undefined, entry.authorityIntegrity, entry.canonicalRequestEnvelope);
-        candidates.push(entry);
-      } catch (error) {
-        receipts.set(entry, await persistTerminal(
-          entry,
-          entry.semanticDigest,
-          "REJECTED",
-          rejected(entry, entry.semanticDigest, `ADMISSION_REJECTED:${describe(error)}`)
-        ));
-      }
-    }
-    if (candidates.length === 0) return batchReceipts(admissions, receipts);
-
     let canonicalFlushCommitted = false;
     const publishWhileGenerationCurrent = async (): Promise<ReadonlyArray<AuthorityOperationReceipt>> => {
+      for (const entry of prepared) {
+        try {
+          await options.generationFenceWitness?.assertHeld("before-prepare", entry);
+          await Effect.runPromise(entry.coordinator.enqueue(entry.operation));
+          await options.generationFenceWitness?.assertHeld("before-prepare", entry);
+          await put(entry, entry.semanticDigest, "PREPARED", undefined, undefined, entry.authorityIntegrity, entry.canonicalRequestEnvelope);
+          candidates.push(entry);
+        } catch (error) {
+          if (isDaemonGenerationFenced(error)) throw error;
+          receipts.set(entry, await persistTerminal(
+            entry,
+            entry.semanticDigest,
+            "REJECTED",
+            rejected(entry, entry.semanticDigest, `ADMISSION_REJECTED:${describe(error)}`)
+          ));
+        }
+      }
+      if (candidates.length === 0) return batchReceipts(admissions, receipts);
       try {
       await options.generationFenceWitness?.assertHeld("before-canonical-publish", candidates[0]);
       const flush = await Effect.runPromise(candidates[0]!.coordinator.flush("explicit"));
@@ -516,13 +528,14 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
       return options.generationFenceWitness
         ? await options.generationFenceWitness.runExclusive(
           "before-canonical-publish",
-          candidates[0],
+          prepared[0],
           publishWhileGenerationCurrent
         )
         : await publishWhileGenerationCurrent();
     } catch (error) {
       if (!isDaemonGenerationFenced(error)) throw error;
-      for (const entry of candidates) {
+      for (const entry of prepared) {
+        if (receipts.has(entry)) continue;
         receipts.set(entry, canonicalFlushCommitted
           ? generationFencedIndeterminateReceipt(entry, entry.semanticDigest, error)
           : generationFencedReceipt(entry, entry.semanticDigest, error));

--- a/packages/cli/test/daemon-generation-disease-integration.test.ts
+++ b/packages/cli/test/daemon-generation-disease-integration.test.ts
@@ -1,0 +1,239 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { fork, type ChildProcess } from "node:child_process";
+import { readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createCompoundReceiptServiceV2 } from "../../application/src/index.ts";
+import {
+  createDurableCompoundReceiptStoreV2,
+  daemonGenerationFencedCode,
+  localUserDaemonEndpoint,
+  requestLocalDaemonJsonRpc
+} from "../../daemon/src/index.ts";
+import {
+  defaultDaemonUserRoot,
+  pollUntil,
+  runDaemonCommand,
+  stopDaemon
+} from "./helpers/daemon-cli.ts";
+import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
+
+test("kill -9 replacement fences stale terminal residue across launch status control and receipt", {
+  skip: process.platform === "win32" ? "SIGKILL and durable generation publication are unavailable on Windows" : false,
+  timeout: 60_000
+}, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const endpointIdentity = localUserDaemonEndpoint(userRoot);
+  const receiptDirectory = path.join(fixture.root, "disease-receipts");
+  const children: ChildProcess[] = [];
+  const env = {
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"
+  };
+  try {
+    const registered = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register",
+      "--repo-id", "canonical",
+      "--canonical-root", fixture.repoRoot,
+      "--user-root", userRoot,
+      "--no-link",
+      "--json"
+    ], env);
+    assert.equal(registered.ok, true, JSON.stringify(registered));
+    const started = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "start", "--service",
+      "--authority-manifest", fixture.manifestPath,
+      "--json"
+    ], env);
+    assert.equal(started.started, true, JSON.stringify(started));
+    assert.equal(typeof started.pid, "number", JSON.stringify(started));
+
+    const firstLaunch = await requestLocalDaemonJsonRpc(
+      fixture.repoRoot,
+      "admin.daemon.launch-spec",
+      { includeGenerationAxes: true },
+      1_000,
+      { userRoot, allowLegacySocket: false }
+    );
+    const firstLaunchData = diseaseReceiptData(firstLaunch);
+    const machineId = String(firstLaunchData.machineId ?? "");
+    const firstGeneration = Number(firstLaunchData.daemonGeneration);
+    assert.notEqual(machineId, "", JSON.stringify(firstLaunch));
+    assert.equal(Number.isSafeInteger(firstGeneration), true, JSON.stringify(firstLaunch));
+
+    const firstStatus = await requestLocalDaemonJsonRpc(
+      fixture.repoRoot,
+      "repo.daemon.status",
+      { repo: { repoId: "canonical" }, includeGenerationAxes: true },
+      1_000,
+      { userRoot, allowLegacySocket: false }
+    );
+    const firstStatusData = diseaseReceiptData(firstStatus);
+    const firstService = firstStatusData.service as Record<string, unknown>;
+    assert.equal(firstService.machineId, machineId, JSON.stringify(firstStatus));
+    assert.equal(firstService.daemonGeneration, firstGeneration, JSON.stringify(firstStatus));
+    assert.equal(typeof firstStatusData.connectionId, "string", JSON.stringify(firstStatus));
+
+    const receiptService = createCompoundReceiptServiceV2({
+      store: createDurableCompoundReceiptStoreV2({ directory: receiptDirectory }),
+      createWaiterId: () => "waiter-disease-integration",
+      createResultToken: () => Buffer.alloc(32, 0x64).toString("base64url")
+    });
+    const opened = await receiptService.openWaiter({
+      workspaceId: "workspace-disease-integration",
+      viewId: "view-disease-integration",
+      opId: "op-disease-integration"
+    });
+    const stale = startDiseaseReceiptRacer(children, [
+      "old",
+      userRoot,
+      endpointIdentity,
+      machineId,
+      String(firstGeneration),
+      receiptDirectory,
+      encodeDiseaseIdentity(opened.identity)
+    ]);
+    assert.equal((await awaitDiseaseChildMessage(stale)).type, "validated");
+
+    process.kill(started.pid as number, "SIGKILL");
+    await killDiseaseDaemonAndWait(started.pid as number);
+    const replacementStart = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "start", "--service",
+      "--authority-manifest", fixture.manifestPath,
+      "--json"
+    ], env);
+    assert.equal(replacementStart.started, true, JSON.stringify(replacementStart));
+    assert.notEqual(replacementStart.pid, started.pid, JSON.stringify(replacementStart));
+
+    const replacementLaunch = await requestLocalDaemonJsonRpc(
+      fixture.repoRoot,
+      "admin.daemon.launch-spec",
+      { includeGenerationAxes: true },
+      1_000,
+      { userRoot, allowLegacySocket: false }
+    );
+    const replacementLaunchData = diseaseReceiptData(replacementLaunch);
+    const replacementGeneration = Number(replacementLaunchData.daemonGeneration);
+    assert.equal(replacementLaunchData.machineId, machineId, JSON.stringify(replacementLaunch));
+    assert.equal(replacementGeneration > firstGeneration, true, JSON.stringify(replacementLaunch));
+
+    const replacementStatus = await requestLocalDaemonJsonRpc(
+      fixture.repoRoot,
+      "repo.daemon.status",
+      { repo: { repoId: "canonical" }, includeGenerationAxes: true },
+      1_000,
+      { userRoot, allowLegacySocket: false }
+    );
+    const replacementStatusData = diseaseReceiptData(replacementStatus);
+    const replacementService = replacementStatusData.service as Record<string, unknown>;
+    assert.equal(replacementService.daemonGeneration, replacementGeneration, JSON.stringify(replacementStatus));
+    assert.notEqual(replacementStatusData.connectionId, firstStatusData.connectionId, JSON.stringify(replacementStatus));
+
+    const staleControl = await requestLocalDaemonJsonRpc(
+      fixture.repoRoot,
+      "admin.daemon.restart",
+      {
+        payload: {
+          reason: "prove stale generation control rejection",
+          drainTimeoutMs: 5_000,
+          daemonGeneration: firstGeneration,
+          connectionId: firstStatusData.connectionId
+        }
+      },
+      1_000,
+      { userRoot, allowLegacySocket: false }
+    );
+    assert.equal(staleControl.ok, false, JSON.stringify(staleControl));
+    assert.equal((staleControl.error as Record<string, unknown>).code, "daemon_control_generation_mismatch");
+
+    const current = startDiseaseReceiptRacer(children, [
+      "current",
+      userRoot,
+      endpointIdentity,
+      machineId,
+      String(replacementGeneration),
+      receiptDirectory,
+      encodeDiseaseIdentity(opened.identity)
+    ]);
+    const committed = await awaitDiseaseChildMessage(current);
+    assert.equal(committed.type, "committed", JSON.stringify(committed));
+    const terminalReceipt = committed.receipt as Record<string, unknown>;
+    assert.equal(terminalReceipt.daemonGeneration, replacementGeneration, JSON.stringify(committed));
+    assert.equal(terminalReceipt.delivery, "DETACHED", JSON.stringify(committed));
+    const statePath = path.join(receiptDirectory, "compound-receipt-broker-state-v2.json");
+    const currentBytes = readFileSync(statePath);
+
+    stale.send("release");
+    const rejected = await awaitDiseaseChildMessage(stale);
+    assert.equal(rejected.type, "error", JSON.stringify(rejected));
+    assert.equal(rejected.code, daemonGenerationFencedCode, JSON.stringify(rejected));
+    assert.equal((rejected.context as Record<string, unknown>).schema, "daemon-generation-write-rejection/v1");
+    assert.equal(readFileSync(statePath).equals(currentBytes), true, "stale terminal attempt changed replacement receipt bytes");
+  } finally {
+    for (const child of children) {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    }
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+function diseaseReceiptData(receipt: Record<string, unknown>): Record<string, unknown> {
+  const details = receipt.details as Record<string, unknown> | undefined;
+  const data = details?.data as Record<string, unknown> | undefined;
+  assert.ok(data, JSON.stringify(receipt));
+  return data;
+}
+
+function startDiseaseReceiptRacer(children: ChildProcess[], args: ReadonlyArray<string>): ChildProcess {
+  const child = fork(fileURLToPath(new URL("../../daemon/test/fixtures/generation-terminal-racer.ts", import.meta.url)), [...args], {
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+    execArgv: process.execArgv.filter((argument) => argument !== "--test-force-exit")
+  });
+  children.push(child);
+  return child;
+}
+
+function awaitDiseaseChildMessage(child: ChildProcess): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const onMessage = (message: unknown) => {
+      cleanup();
+      resolve(message as Record<string, unknown>);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(`disease racer exited before response: code=${code};signal=${signal}`));
+    };
+    const cleanup = () => {
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+    };
+    child.once("message", onMessage);
+    child.once("exit", onExit);
+  });
+}
+
+function encodeDiseaseIdentity(identity: unknown): string {
+  return Buffer.from(JSON.stringify(identity), "utf8").toString("base64url");
+}
+
+async function killDiseaseDaemonAndWait(pid: number): Promise<void> {
+  await pollUntil(
+    () => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    (alive) => !alive,
+    (alive, error) => JSON.stringify({ pid, alive, error: String(error ?? "") }),
+    { timeoutMs: 8_000 }
+  );
+}

--- a/packages/daemon/src/fence/durability.ts
+++ b/packages/daemon/src/fence/durability.ts
@@ -1,3 +1,4 @@
+import { constants } from "node:fs";
 import { mkdir, open, readFile } from "node:fs/promises";
 import path from "node:path";
 import type { AuthorityFenceWitness } from "@harness-anything/application";
@@ -150,7 +151,8 @@ async function appendDurabilityRecord(
   }
   const directory = path.dirname(ledgerPath);
   await mkdir(directory, { recursive: true, mode: 0o700 });
-  const handle = await open(ledgerPath, "a+", 0o600);
+  // Windows 上 append 模式句柄不允许 ftruncate(EPERM),所以用读写模式打开并显式按偏移写尾。
+  const handle = await open(ledgerPath, constants.O_RDWR | constants.O_CREAT, 0o600);
   try {
     const scan = scanSingleAuthorityDurabilityLedger(await handle.readFile());
     if (scan.repairRequired) {
@@ -158,7 +160,7 @@ async function appendDurabilityRecord(
       await handle.sync();
       await fsyncSingleAuthorityDurabilityDirectory(directory);
     }
-    await handle.writeFile(`${JSON.stringify(record)}\n`, "utf8");
+    await handle.write(`${JSON.stringify(record)}\n`, scan.validByteLength, "utf8");
     await handle.sync();
   } finally {
     await handle.close();

--- a/packages/daemon/src/fence/durability.ts
+++ b/packages/daemon/src/fence/durability.ts
@@ -11,6 +11,14 @@ export type DurabilityAuditStage =
   | "ORIGIN_RESULT_DURABLE"
   | "BACKUP_HOOK_RECORDED";
 
+const durabilityAuditStages = new Set<DurabilityAuditStage>([
+  "CANONICAL_OBJECTS_FSYNCED",
+  "CANONICAL_REF_FSYNCED",
+  "OPERATION_INDEX_FSYNCED",
+  "ORIGIN_RESULT_DURABLE",
+  "BACKUP_HOOK_RECORDED"
+]);
+
 export interface SingleAuthorityDurabilityAuditRecord {
   readonly schema: "single-authority-durability-audit/v1";
   readonly profile: typeof singleAuthorityBoundedRpoProfile;
@@ -123,33 +131,108 @@ export async function runSingleAuthorityBoundedRpoCommit(
 export async function readSingleAuthorityDurabilityLedger(
   ledgerPath: string
 ): Promise<ReadonlyArray<SingleAuthorityDurabilityAuditRecord>> {
-  let body: string;
+  let body: Buffer;
   try {
-    body = await readFile(ledgerPath, "utf8");
+    body = await readFile(ledgerPath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
     throw error;
   }
-  const completeBody = body.endsWith("\n") ? body : body.slice(0, body.lastIndexOf("\n") + 1);
-  return completeBody
-    .split("\n")
-    .filter((line) => line !== "")
-    .map((line) => JSON.parse(line) as SingleAuthorityDurabilityAuditRecord);
+  return scanSingleAuthorityDurabilityLedger(body).records;
 }
 
 async function appendDurabilityRecord(
   ledgerPath: string,
   record: SingleAuthorityDurabilityAuditRecord
 ): Promise<void> {
+  if (!isSingleAuthorityDurabilityAuditRecord(record)) {
+    throw new Error("invalid single-authority durability audit record");
+  }
   const directory = path.dirname(ledgerPath);
   await mkdir(directory, { recursive: true, mode: 0o700 });
-  const handle = await open(ledgerPath, "a", 0o600);
+  const handle = await open(ledgerPath, "a+", 0o600);
   try {
+    const scan = scanSingleAuthorityDurabilityLedger(await handle.readFile());
+    if (scan.repairRequired) {
+      await handle.truncate(scan.validByteLength);
+      await handle.sync();
+      await fsyncSingleAuthorityDurabilityDirectory(directory);
+    }
     await handle.writeFile(`${JSON.stringify(record)}\n`, "utf8");
     await handle.sync();
   } finally {
     await handle.close();
   }
+  await fsyncSingleAuthorityDurabilityDirectory(directory);
+}
+
+interface SingleAuthorityDurabilityLedgerScan {
+  readonly records: ReadonlyArray<SingleAuthorityDurabilityAuditRecord>;
+  readonly validByteLength: number;
+  readonly repairRequired: boolean;
+}
+
+function scanSingleAuthorityDurabilityLedger(body: Buffer): SingleAuthorityDurabilityLedgerScan {
+  const lines: Array<{ readonly start: number; readonly end: number; readonly terminated: boolean }> = [];
+  let start = 0;
+  for (let offset = 0; offset < body.byteLength; offset += 1) {
+    if (body[offset] !== 0x0a) continue;
+    lines.push({ start, end: offset, terminated: true });
+    start = offset + 1;
+  }
+  if (start < body.byteLength) lines.push({ start, end: body.byteLength, terminated: false });
+  const lastNonEmpty = lines.findLastIndex(({ start: lineStart, end }) => end > lineStart);
+  const records: SingleAuthorityDurabilityAuditRecord[] = [];
+  let validByteLength = 0;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    if (line.end === line.start) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body.subarray(line.start, line.end).toString("utf8"));
+    } catch (error) {
+      if (index === lastNonEmpty) return { records, validByteLength, repairRequired: true };
+      throw new Error(`invalid single-authority durability ledger record at byte ${line.start}`, { cause: error });
+    }
+    if (!isSingleAuthorityDurabilityAuditRecord(parsed)) {
+      if (index === lastNonEmpty) return { records, validByteLength, repairRequired: true };
+      throw new Error(`invalid single-authority durability ledger schema at byte ${line.start}`);
+    }
+    if (!line.terminated) return { records, validByteLength, repairRequired: true };
+    records.push(parsed);
+    validByteLength = line.end + 1;
+  }
+  return { records, validByteLength: body.byteLength, repairRequired: false };
+}
+
+function isSingleAuthorityDurabilityAuditRecord(value: unknown): value is SingleAuthorityDurabilityAuditRecord {
+  if (!isDurabilityLedgerJsonRecord(value)) return false;
+  const keys = Object.keys(value);
+  const recordKeys = new Set([
+    "schema",
+    "profile",
+    "commitSha",
+    "completedStages",
+    "backupWatermark",
+    "backupBoundSatisfied"
+  ]);
+  if (keys.length !== recordKeys.size || !keys.every((key) => recordKeys.has(key))) return false;
+  return value.schema === "single-authority-durability-audit/v1"
+    && value.profile === singleAuthorityBoundedRpoProfile
+    && typeof value.commitSha === "string" && value.commitSha.length > 0
+    && Array.isArray(value.completedStages)
+    && value.completedStages.every((stage) => typeof stage === "string"
+      && durabilityAuditStages.has(stage as DurabilityAuditStage))
+    && new Set(value.completedStages).size === value.completedStages.length
+    && typeof value.backupWatermark === "string" && value.backupWatermark.length > 0
+    && typeof value.backupBoundSatisfied === "boolean";
+}
+
+function isDurabilityLedgerJsonRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function fsyncSingleAuthorityDurabilityDirectory(directory: string): Promise<void> {
   if (process.platform === "win32") return;
   const directoryHandle = await open(directory, "r");
   try {

--- a/packages/daemon/test/daemon-generation-intent-fence.test.ts
+++ b/packages/daemon/test/daemon-generation-intent-fence.test.ts
@@ -1,0 +1,111 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  authorityProtocolTuple,
+  createAuthoritySubmissionService,
+  createInMemoryAuthorityOperationRegistry,
+  createInMemoryReplicaChangeLog,
+  type AuthorityOperationEnvelope
+} from "@harness-anything/application";
+import {
+  createDaemonGenerationAuthorityFence,
+  createDaemonGenerationWitness,
+  daemonGenerationFencedCode,
+  publishNextDaemonGeneration,
+  readOrCreateDaemonMachineId
+} from "../src/index.ts";
+
+const intentFencePosixOnly = process.platform === "win32"
+  ? "durable generation publication is unsupported on Windows"
+  : false;
+
+test("replacement between the admission check and RECEIVED persistence leaves no stale intent", {
+  skip: intentFencePosixOnly
+}, async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "ha-generation-received-race-"));
+  try {
+    const endpointIdentity = path.join(root, "daemon.sock");
+    const machineId = readOrCreateDaemonMachineId(root);
+    const first = publishNextDaemonGeneration({
+      userRoot: root,
+      endpointIdentity,
+      machineId,
+      daemonInstanceId: "daemon-before-received"
+    });
+    const generationFence = createDaemonGenerationAuthorityFence({
+      authorityFence: { assertHeld: async () => undefined },
+      generationWitness: createDaemonGenerationWitness({
+        userRoot: root,
+        endpointIdentity,
+        machineId,
+        daemonGeneration: first.daemonGeneration
+      }),
+      workspaceId: "workspace-received-race",
+      repo: { repoId: "repo-received-race", canonicalRoot: root },
+      connectionId: "connection-received-race"
+    });
+    const memory = createInMemoryAuthorityOperationRegistry();
+    let replacementPublished = false;
+    const service = createAuthoritySubmissionService({
+      workspaceId: "workspace-received-race",
+      coordinatorFactory: {
+        create: () => { throw new Error("stale admission must not construct a coordinator"); }
+      },
+      tokenVerifier: { verify: async () => { throw new Error("stale admission must not verify a token"); } },
+      operationRegistry: {
+        list: memory.list,
+        put: memory.put,
+        get: async (workspaceId, opId) => {
+          const known = await memory.get(workspaceId, opId);
+          if (!replacementPublished) {
+            replacementPublished = true;
+            publishNextDaemonGeneration({
+              userRoot: root,
+              endpointIdentity,
+              machineId,
+              daemonInstanceId: "daemon-after-received-check"
+            });
+          }
+          return known;
+        }
+      },
+      replicaChangeLog: createInMemoryReplicaChangeLog(),
+      publicationInspector: {
+        currentHead: async () => null,
+        inspectPublishedHead: async () => { throw new Error("stale admission must not inspect publication"); }
+      },
+      fenceWitness: { assertHeld: async () => undefined },
+      generationFenceWitness: generationFence
+    });
+
+    const receipt = await service.submit(receivedRaceEnvelope());
+
+    assert.equal(receipt.tag, "RETRYABLE_NOT_COMMITTED");
+    assert.equal(receipt.tag === "RETRYABLE_NOT_COMMITTED" ? receipt.errorCode : undefined, daemonGenerationFencedCode);
+    assert.deepEqual(await memory.list("workspace-received-race"), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function receivedRaceEnvelope(): AuthorityOperationEnvelope {
+  return {
+    workspaceId: "workspace-received-race",
+    opId: "op-received-race",
+    claimedDigest: "a".repeat(64),
+    command: "task.progress.append",
+    operation: {
+      opId: "op-received-race",
+      entityId: "task/task_RECEIVED_RACE",
+      kind: "progress_append",
+      payload: { path: "progress.md", append: "stale\n" }
+    },
+    delegationToken: "stale-token",
+    channelNonceDigest: "b".repeat(64),
+    protocol: authorityProtocolTuple
+  };
+}

--- a/packages/daemon/test/daemon-generation-write-fence.test.ts
+++ b/packages/daemon/test/daemon-generation-write-fence.test.ts
@@ -397,9 +397,7 @@ test("generation exclusion spans canonical flush through the corresponding termi
     get: memory.get,
     list: memory.list,
     put: async (record: Parameters<typeof memory.put>[0]) => {
-      if (record.state === "PUBLISHED" || record.state === "INDEXED" || record.state === "COMMITTED") {
-        assert.equal(generationLockDepth > 0, true, `${record.state} escaped the generation exclusion`);
-      }
+      assert.equal(generationLockDepth > 0, true, `${record.state} escaped the generation exclusion`);
       await memory.put(record);
     }
   };

--- a/packages/daemon/test/fence-durability.test.ts
+++ b/packages/daemon/test/fence-durability.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -69,6 +69,101 @@ test("bounded-RPO commit audits every fsync boundary and withholds COMMITTED whe
   }
 });
 
+test("durability reader accepts only a continuous schema-valid prefix and tolerates one torn tail", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "ha-durability-tail-read-"));
+  try {
+    const valid = `${JSON.stringify(durabilityRecord("commit-valid"))}\n`;
+    for (const [name, tail] of [
+      ["partial", '{"schema":"single-authority'],
+      ["malformed-newline", "{not-json}\n"],
+      ["schema-invalid-newline", `${JSON.stringify({ schema: "not-an-audit-record" })}\n`]
+    ] as const) {
+      const ledgerPath = path.join(root, `${name}.jsonl`);
+      await writeFile(ledgerPath, `${valid}${tail}`, "utf8");
+      assert.deepEqual(
+        (await readSingleAuthorityDurabilityLedger(ledgerPath)).map(({ commitSha }) => commitSha),
+        ["commit-valid"]
+      );
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("durability reader fails closed on a malformed or schema-invalid middle record", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "ha-durability-middle-"));
+  try {
+    const first = `${JSON.stringify(durabilityRecord("commit-first"))}\n`;
+    const last = `${JSON.stringify(durabilityRecord("commit-last"))}\n`;
+    for (const [name, middle] of [
+      ["malformed", "{not-json}\n"],
+      ["schema-invalid", `${JSON.stringify({ arbitrary: "parseable-json" })}\n`]
+    ] as const) {
+      const ledgerPath = path.join(root, `${name}.jsonl`);
+      await writeFile(ledgerPath, `${first}${middle}${last}`, "utf8");
+      await assert.rejects(
+        readSingleAuthorityDurabilityLedger(ledgerPath),
+        /invalid single-authority durability ledger/u
+      );
+      const before = await readFile(ledgerPath);
+      await assert.rejects(
+        new SingleAuthorityDurabilityLedger(ledgerPath).append(durabilityRecord("must-not-append")),
+        /invalid single-authority durability ledger/u
+      );
+      assert.equal((await readFile(ledgerPath)).equals(before), true, "fail-closed append changed a corrupt ledger");
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("append repairs a torn final record before writing the next durable record", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "ha-durability-tail-repair-"));
+  try {
+    for (const [name, tail] of [
+      ["partial", '{"schema":"single-authority'],
+      ["malformed-newline", "{not-json}\n"]
+    ] as const) {
+      const ledgerPath = path.join(root, `${name}.jsonl`);
+      await writeFile(
+        ledgerPath,
+        `${JSON.stringify(durabilityRecord("commit-before"))}\n${tail}`,
+        "utf8"
+      );
+      const ledger = new SingleAuthorityDurabilityLedger(ledgerPath);
+      await ledger.append(durabilityRecord("commit-after"));
+      assert.deepEqual(
+        (await readSingleAuthorityDurabilityLedger(ledgerPath)).map(({ commitSha }) => commitSha),
+        ["commit-before", "commit-after"]
+      );
+      assert.equal((await readFile(ledgerPath, "utf8")).includes("not-json"), false);
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("append rejects parseable JSON that is not a durability audit record", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "ha-durability-schema-"));
+  try {
+    const ledger = new SingleAuthorityDurabilityLedger(path.join(root, "durability.jsonl"));
+    for (const invalid of [
+      { arbitrary: "parseable-json" },
+      { ...durabilityRecord("bad-stage"), completedStages: ["NOT_FSYNCED"] },
+      { ...durabilityRecord("bad-bound"), backupBoundSatisfied: "true" },
+      { ...durabilityRecord("extra-key"), ungoverned: true }
+    ]) {
+      await assert.rejects(
+        ledger.append(invalid as never),
+        /invalid single-authority durability audit record/u
+      );
+    }
+    assert.deepEqual(await readSingleAuthorityDurabilityLedger(ledger.path), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("kill -9 and restart preserves every fsynced durability audit record", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "ha-durability-kill-"));
   const ledgerPath = path.join(root, "durability.jsonl");
@@ -76,13 +171,14 @@ test("kill -9 and restart preserves every fsynced durability audit record", asyn
   const childScript = `
     const { SingleAuthorityDurabilityLedger } = await import(process.argv[1]);
     const ledger = new SingleAuthorityDurabilityLedger(process.argv[2]);
-    for (let index = 0; index < 200; index += 1) {
+    const round = process.argv[3];
+    for (let index = 0; index < 10000; index += 1) {
       await ledger.append({
         schema: "single-authority-durability-audit/v1",
         profile: "SINGLE_AUTHORITY_BOUNDED_RPO",
-        commitSha: "commit-" + index,
+        commitSha: "round-" + round + "-commit-" + index,
         completedStages: ["CANONICAL_OBJECTS_FSYNCED", "CANONICAL_REF_FSYNCED", "OPERATION_INDEX_FSYNCED", "ORIGIN_RESULT_DURABLE", "BACKUP_HOOK_RECORDED"],
-        backupWatermark: "watermark-" + index,
+        backupWatermark: "round-" + round + "-watermark-" + index,
         backupBoundSatisfied: true
       });
       process.stdout.write(String(index) + "\\n");
@@ -90,60 +186,74 @@ test("kill -9 and restart preserves every fsynced durability audit record", asyn
   `;
   const childEnv = { ...process.env, FORCE_COLOR: "0" };
   delete childEnv.NO_COLOR;
-  const child = spawn(process.execPath, ["--input-type=module", "--eval", childScript, moduleUrl, ledgerPath], {
-    stdio: ["ignore", "pipe", "pipe"],
-    env: childEnv
-  });
-  let acknowledged = -1;
-  let buffered = "";
+  let activeChild: ReturnType<typeof spawn> | undefined;
   try {
-    await new Promise<void>((resolve, reject) => {
-      child.once("error", reject);
-      child.stderr?.on("data", (chunk) => reject(new Error(String(chunk))));
-      child.once("exit", (code, signal) => {
-        if (acknowledged < 24) reject(new Error(`durability child exited before acknowledgement 24 (code=${code}, signal=${signal})`));
+    for (let round = 0; round < 6; round += 1) {
+      const child = spawn(
+        process.execPath,
+        ["--input-type=module", "--eval", childScript, moduleUrl, ledgerPath, String(round)],
+        { stdio: ["ignore", "pipe", "pipe"], env: childEnv }
+      );
+      activeChild = child;
+      let acknowledged = -1;
+      let buffered = "";
+      await new Promise<void>((resolve, reject) => {
+        child.once("error", reject);
+        child.stderr?.on("data", (chunk) => reject(new Error(String(chunk))));
+        child.once("exit", (code, signal) => {
+          if (acknowledged < 24) reject(new Error(`durability child exited before acknowledgement 24 (code=${code}, signal=${signal})`));
+        });
+        child.stdout?.on("data", (chunk) => {
+          buffered += String(chunk);
+          const lines = buffered.split("\n");
+          buffered = lines.pop() ?? "";
+          for (const line of lines) {
+            if (line !== "") acknowledged = Number.parseInt(line, 10);
+          }
+          if (acknowledged >= 24) resolve();
+        });
       });
-      child.stdout?.on("data", (chunk) => {
-        buffered += String(chunk);
-        const lines = buffered.split("\n");
-        buffered = lines.pop() ?? "";
-        for (const line of lines) {
-          if (line !== "") acknowledged = Number.parseInt(line, 10);
-        }
-        if (acknowledged >= 24) resolve();
-      });
-    });
-    const exited = once(child, "exit");
-    assert.equal(child.kill("SIGKILL"), true);
-    await exited;
+      const exited = once(child, "exit");
+      assert.equal(child.kill("SIGKILL"), true);
+      await exited;
+      activeChild = undefined;
 
-    const afterCrash = await readSingleAuthorityDurabilityLedger(ledgerPath);
-    assert.equal(acknowledged >= 24, true);
-    for (let index = 0; index <= acknowledged; index += 1) {
-      assert.equal(afterCrash.some((record) => record.commitSha === `commit-${index}`), true, `lost fsynced commit-${index}`);
+      const afterCrash = await readSingleAuthorityDurabilityLedger(ledgerPath);
+      for (let index = 0; index <= acknowledged; index += 1) {
+        assert.equal(
+          afterCrash.some((record) => record.commitSha === `round-${round}-commit-${index}`),
+          true,
+          `lost fsynced round-${round}-commit-${index}`
+        );
+      }
+      await new SingleAuthorityDurabilityLedger(ledgerPath).append(durabilityRecord(`round-${round}-restart`));
     }
 
     const restarted = new SingleAuthorityDurabilityLedger(ledgerPath);
-    await restarted.append({
-      schema: "single-authority-durability-audit/v1",
-      profile: "SINGLE_AUTHORITY_BOUNDED_RPO",
-      commitSha: "commit-after-restart",
-      completedStages: [
-        "CANONICAL_OBJECTS_FSYNCED",
-        "CANONICAL_REF_FSYNCED",
-        "OPERATION_INDEX_FSYNCED",
-        "ORIGIN_RESULT_DURABLE",
-        "BACKUP_HOOK_RECORDED"
-      ],
-      backupWatermark: "watermark-after-restart",
-      backupBoundSatisfied: true
-    });
+    await restarted.append(durabilityRecord("commit-after-restart"));
     assert.equal(
       (await readSingleAuthorityDurabilityLedger(ledgerPath)).at(-1)?.commitSha,
       "commit-after-restart"
     );
   } finally {
-    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    if (activeChild?.exitCode === null && activeChild.signalCode === null) activeChild.kill("SIGKILL");
     await rm(root, { recursive: true, force: true });
   }
 });
+
+function durabilityRecord(commitSha: string) {
+  return {
+    schema: "single-authority-durability-audit/v1" as const,
+    profile: "SINGLE_AUTHORITY_BOUNDED_RPO" as const,
+    commitSha,
+    completedStages: [
+      "CANONICAL_OBJECTS_FSYNCED",
+      "CANONICAL_REF_FSYNCED",
+      "OPERATION_INDEX_FSYNCED",
+      "ORIGIN_RESULT_DURABLE",
+      "BACKUP_HOOK_RECORDED"
+    ] as const,
+    backupWatermark: `watermark-${commitSha}`,
+    backupBoundSatisfied: true
+  };
+}


### PR DESCRIPTION
# English

## Summary

S1.0 + S1.4 of the daemon generation-fence line: repair torn tails in the single-authority durability ledger, prove the full kill-9 → replacement → stale-terminal-attempt disease flow through real entrypoints, and pull intent-record persistence (RECEIVED/PREPARED/batch enqueue) inside the same cross-process generation exclusion that already fences terminal writes — closing the S1.3 review's registered leftover.

## What Changed

- **S1.0 torn-tail** (`packages/daemon/src/fence/durability.ts`): the reader returns only the continuous, newline-terminated, schema-valid prefix from the start of the ledger; only the final non-empty physical record may be torn, malformed middle records fail closed. Append scans first inside the same serial writer, truncates a torn tail to the last valid byte boundary, fsyncs file and directory, then appends and fsyncs again. `SingleAuthorityDurabilityAuditRecord` moves from a type cast to exact-key runtime validation.
- **S1.4 disease integration** (`packages/cli/test/daemon-generation-disease-integration.test.ts`): a real detached daemon is SIGKILLed, a real replacement launches, and the A/B/C evidence chain is asserted through launch/status/control/receipt: machineId stable, generation strictly increases, connection replaced; a control RPC carrying the old generation/connection gets `daemon_control_generation_mismatch`; a stale terminal writer loses the compound-terminal CAS with `DAEMON_GENERATION_FENCED` and the receipt bytes are proven unchanged via `Buffer.equals`.
- **Intent-record fencing** (`packages/application/src/authority/intent-record-persistence.ts`, `service.ts`): RECEIVED persistence re-asserts the generation inside `before-prepare` exclusion; enqueue and PREPARED move inside the existing `before-canonical-publish` critical section, so one lock now spans enqueue → PREPARED → canonical flush → terminal persistence. No new lock or intent LSN is introduced; legacy/Windows capability posture is unchanged.

## Task And Scope

- Task: `task_01KXZTWY17ZVH5FWRCRV86J16C` (PLT-Boundary S1 daemon generation fence), slices S1.0 and S1.4 per the design's PR split table; intent fencing was moved into S1.4 scope by the S1.3 adjudication.
- Scope: daemon fence durability, application authority intent persistence, daemon/CLI tests. No gate authority change.

## Version Impact

No package version bump. No schema or wire-format change: the durability ledger bytes, generation record, and receipt formats are unchanged; only validation strictness and lock coverage changed.

## Governance Declaration

No governance-controlled surfaces are modified. The fence continues to enforce at the resource level established by S1.3; sticky staleness semantics are preserved (a process that observes its own staleness writes zero further durable bytes).

## Verification

- `fence-durability + generation-write-fence + intent-fence + terminal-sequence` suite: 16/16 pass (CEO session independently re-ran fence-durability + intent-fence: 7/7).
- Authority producer / V1+V2 admission regressions: 19/19 pass.
- Real-daemon disease integration: 1/1 pass (~8s, real SIGKILL, re-run independently by the CEO session).
- `npm run typecheck`, targeted eslint, file-complexity, duplicate-definitions, write-road registry, package-boundary, write-coordinator boundary, bypass-write boundary: all exit 0.

## Review Evidence

Negative controls in the worker report: middle-record corruption leaves the ledger byte-identical (`Buffer.equals`) and both read and append reject; arbitrary parseable JSON cannot impersonate an audit record; six SIGKILL/restart rounds preserve every stdout-confirmed committed record; a deterministic race publishes the replacement between the admission check and RECEIVED and asserts `DAEMON_GENERATION_FENCED` with an empty registry; every registry put across RECEIVED→COMMITTED asserts lock depth > 0. Full transcripts: `harness/tasks/task_01KXZTWY17ZVH5FWRCRV86J16C-plt-boundary-s1-daemon-generation-fence/artifacts/worker-report-s10-s14.md` (ledger-side, not in this diff).

## Residual Risk

Windows keeps the S1.1/S1.2 posture (legacy serve degrades, explicit generation capability fails closed; real-SIGKILL tests skip on Windows). The ledger's serial-writer guarantee is per-instance; multiple writer processes on one path would need a cross-process CAS design. Cross-runner flake conclusions rest with GitHub CI re-runs.

## References

- Task package: `harness/tasks/task_01KXZTWY17ZVH5FWRCRV86J16C-plt-boundary-s1-daemon-generation-fence/`
- Predecessors: PR #966 (S1.1), #970 (S1.2), #973 (S1.3).

---

# 中文

## 概要

代际围栏线的 S1.0 + S1.4：修复 single-authority durability ledger 的 torn tail，用真实入口证明 kill-9 → replacement → 旧代际终态写入尝试的完整病灶流程，并把 intent 记录持久化（RECEIVED/PREPARED/batch enqueue）拉进已围住终态写入的同一跨进程代际排他区——收掉 S1.3 评审登记的遗留项。

## 改动内容

- **S1.0 torn-tail**（`packages/daemon/src/fence/durability.ts`）：reader 只返回从文件头开始连续、newline 终止、schema 合法的 prefix；只容忍最后一个非空物理 record 损坏，中段损坏 fail closed。append 在同一 serial writer 内先扫描，遇 torn tail 截断到最后有效 byte boundary、fsync 文件与目录，再写入并再次 fsync。`SingleAuthorityDurabilityAuditRecord` 从类型 cast 改为 exact-key 运行时校验。
- **S1.4 disease integration**（`packages/cli/test/daemon-generation-disease-integration.test.ts`）：真实 detached daemon 被 SIGKILL、真实 replacement 启动，A/B/C 证据链经 launch/status/control/receipt 断言：machineId 不变、generation 严格递增、connection 更换；携旧代际/连接的 control RPC 得 `daemon_control_generation_mismatch`；旧代际终态写入者在 compound-terminal CAS 落败得 `DAEMON_GENERATION_FENCED`，receipt 字节以 `Buffer.equals` 证明未被覆盖。
- **intent 记录围栏**（`packages/application/src/authority/intent-record-persistence.ts`、`service.ts`）：RECEIVED 持久化在 `before-prepare` 排他区内重新断言代际；enqueue 与 PREPARED 移入既有 `before-canonical-publish` 临界区，一把锁覆盖 enqueue → PREPARED → canonical flush → 终态持久化。不新增锁或 intent LSN；legacy/Windows 能力姿态不变。

## 任务与范围

- 任务：`task_01KXZTWY17ZVH5FWRCRV86J16C`（PLT-Boundary S1 代际围栏），按设计文档 PR 切分表的 S1.0 与 S1.4；intent 围栏由 S1.3 评审裁定移入 S1.4 范围。
- 范围：daemon fence durability、application authority intent 持久化、daemon/CLI 测试。不改 gate 权威面。

## 版本影响

无包版本变更。无 schema 或 wire 格式变更：ledger 字节、generation record、receipt 格式均不变；只有校验严格度与锁覆盖范围变化。

## 治理声明

未修改治理管控面。围栏继续在 S1.3 确立的 resource 层执法；sticky staleness 语义保持（进程一旦观测到自己 stale，不再产生任何 durable 字节）。

## 验证

- fence-durability + generation-write-fence + intent-fence + terminal-sequence 套件 16/16 通过（CEO 会话独立复跑 fence-durability + intent-fence：7/7）。
- authority producer / V1+V2 admission 回归 19/19 通过。
- 真实 daemon disease integration 1/1 通过（约 8 秒，真实 SIGKILL，CEO 会话独立复跑）。
- `npm run typecheck`、定向 eslint、file-complexity、duplicate-definitions、write-road registry、package boundary、write-coordinator boundary、bypass-write boundary 全部 exit 0。

## 审查证据

worker 报告中的阴性对照：中段损坏时 ledger 字节零变化（`Buffer.equals`）且读写均拒绝；任意 parseable JSON 不能冒充 audit record；6 轮 SIGKILL/restart 保留每条 stdout 确认的 commit；确定性竞态在 admission 校验与 RECEIVED 之间发布 replacement 并断言 `DAEMON_GENERATION_FENCED` 且 registry 为空；RECEIVED→COMMITTED 的每次 registry put 断言锁深度 > 0。完整输出见台账报告 `harness/tasks/task_01KXZTWY17ZVH5FWRCRV86J16C-plt-boundary-s1-daemon-generation-fence/artifacts/worker-report-s10-s14.md`（不在本 diff 内）。

## 残余风险

Windows 保持 S1.1/S1.2 姿态（legacy serve 降级、显式 generation capability fail closed；真实 SIGKILL 测试在 Windows skip）。ledger 的 serial-writer 保证是单实例级；未来若多个 writer 进程指向同一路径需另设计跨进程 CAS。跨 runner flake 结论由 GitHub CI 重跑确认。

## 关联材料

- 任务包：`harness/tasks/task_01KXZTWY17ZVH5FWRCRV86J16C-plt-boundary-s1-daemon-generation-fence/`
- 前序：PR #966（S1.1）、#970（S1.2）、#973（S1.3）。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Targeted tests green / 定向测试全绿
- [x] No governance surface touched / 未触碰治理面
