### PR TITLE
fix(application): admit body-only decision amends at the production ingress

### DIFF
--- a/packages/application/src/authority/task-decision-module-decision-mutations-v2.ts
+++ b/packages/application/src/authority/task-decision-module-decision-mutations-v2.ts
@@ -42,7 +42,10 @@ export async function compileDecisionAmendV2(
   const current = decodeIngressDecision(parseDecisionDocument(snapshot.body).decision);
   if (current.decision_id !== next.decision_id) throw admission("DECISION_ID_MISMATCH");
   const changed = changedFields(current, next);
-  if (changed.length === 0 || changed.some((field) => field !== "contentPins" && decisionFieldContracts[field].mutability !== "amendable")
+  // body-only amend 合法:正文不是 DecisionPackage 结构字段,changed 为空但 payload.body 承载改写。
+  const bodyOnlyAmend = changed.length === 0 && payload.body !== undefined;
+  if ((changed.length === 0 && !bodyOnlyAmend)
+    || changed.some((field) => field !== "contentPins" && decisionFieldContracts[field].mutability !== "amendable")
     || (changed.includes("contentPins") && !validContentPinAppend(current, next))) {
     throw admission("DECISION_AMEND_FIELD_INVALID");
   }

--- a/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
+++ b/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
@@ -264,6 +264,27 @@ test("all decision actions compile exact decision mutations; relation also creat
   }
 });
 
+test("body-only decision amend compiles while a no-op amend without body stays rejected", async () => {
+  const active = decisionPackage("dec_W3", "active");
+  const activeSnapshot = snapshot(decisionDocument(active));
+  const decisionRef = ref("decision", "decision/dec_W3");
+  const state = authorityState(new Map([[key(decisionRef), base("decision-v2")]]), new Map([[decisionPath(), activeSnapshot]]));
+  const compiler = makeTaskDecisionModuleSemanticCompilerV2({ state });
+
+  const bodyOnly = await compiler.compile(envelope(
+    { schema: "decision.amend/v1", decision: active, body: "## Rationale\n\nRewritten prose after propose." } as const,
+    [present(decisionRef, "decision-v2")],
+    [cas(decisionPath(), activeSnapshot)]
+  ));
+  assert.equal(bodyOnly.operation.kind, "decision_amend");
+
+  await assert.rejects(compiler.compile(envelope(
+    { schema: "decision.amend/v1", decision: active } as const,
+    [present(decisionRef, "decision-v2")],
+    [cas(decisionPath(), activeSnapshot)]
+  )), (error: Error) => /DECISION_AMEND_FIELD_INVALID/u.test(error.message));
+});
+
 test("module register/unregister/step compile canonical modules.json snapshots", async () => {
   const module = moduleRecord();
   const moduleRef = ref("module", "module/kernel");


### PR DESCRIPTION
# English

## Summary

PR #981 opened the typed `ha decision amend --body/--body-file` road at the CLI, but the production daemon ingress still rejected it: a body-only amend changes no structured `DecisionPackage` field, so `compileDecisionAmendV2` saw `changedFields() === []` and threw `DECISION_AMEND_FIELD_INVALID`. Discovered by CEO usage acceptance on the first real body amend after #981 merged — the declared surface accepted what the runtime refused, the exact defect family this task exists to close.

## What Changed

`packages/application/src/authority/task-decision-module-decision-mutations-v2.ts`: a body-only amend (`changed.length === 0 && payload.body !== undefined`) is now admitted; the compiler already threads `payload.body` into the operation and snapshot CAS, so no other change is needed. A no-op amend (no field change, no body) is still rejected with the same error, and non-amendable field changes remain rejected.

## Task And Scope

- Task: `task_01KY297QCMY1K3TFPFHQB0S4QA` (decision body unwritable after propose) — the daemon-ingress leg of the same defect.
- Scope: one admission predicate in the V2 semantic compiler + regression tests. No schema, mutation-registry, or storage-plan change.

## Version Impact

No package version bump. No wire or schema change: `DecisionAmendPayloadV2.body` already existed and was already carried by the operation envelope.

## Governance Declaration

No governance-controlled surfaces are modified. Admission strictness is preserved: the no-op amend negative control stays rejected; `chosen`/`rejected` append-only and frontmatter machine-exclusivity are untouched (enforced upstream of this predicate and re-asserted by #981's CLI tests).

## Verification

- `packages/application/test/task-decision-module-semantic-compiler-v2.test.ts` → 12/12 pass, including the new "body-only decision amend compiles while a no-op amend without body stays rejected".
- `packages/application/test/task-decision-module-authority-positive-v2.test.ts` → 2/2 pass.
- `npm run typecheck` clean; targeted eslint clean.

## Review Evidence

Negative control in the new test: same envelope without `body` still rejects with `DECISION_AMEND_FIELD_INVALID`. Live production evidence: before this fix, `ha decision amend dec_01KY1VCN49X4RJWGVCDASWFEAQ --body-file …` failed with `authority_ingress_rejected hint=DECISION_AMEND_FIELD_INVALID`; the CEO session will re-run the same real amend after merge as usage acceptance.

## Residual Risk

Body bytes ride the existing operation envelope and snapshot CAS; no new persistence path. The broader ingress-exclusion family (declared-but-unwired commands) remains tracked separately.

## References

- Task package: `harness/tasks/task_01KY297QCMY1K3TFPFHQB0S4QA-decision/`
- Companion: PR #981 (CLI leg of the same fix).

---

# 中文

## 概要

PR #981 在 CLI 打通了 typed `ha decision amend --body/--body-file`,但生产 daemon ingress 仍然拒收:body-only amend 不改任何 `DecisionPackage` 结构字段,`compileDecisionAmendV2` 看到 `changedFields() === []` 就抛 `DECISION_AMEND_FIELD_INVALID`。CEO 在 #981 合并后第一次真实补写决策正文的使用性验收当场撞出——声明面接受、运行时拒绝,正是本任务要根治的缺陷族。

## 改动内容

`packages/application/src/authority/task-decision-module-decision-mutations-v2.ts`:放行 body-only amend(`changed.length === 0 && payload.body !== undefined`);编译器本就把 `payload.body` 织进 operation 与快照 CAS,无需其他改动。无字段变化且无 body 的空转 amend 仍以同错误拒绝,不可 amend 字段的改动仍被拒。

## 任务与范围

- 任务:`task_01KY297QCMY1K3TFPFHQB0S4QA`——同一缺陷的 daemon ingress 腿。
- 范围:V2 语义编译器一处准入判定 + 回归测试。无 schema、mutation registry、storage plan 变更。

## 版本影响

无包版本变更。无 wire/schema 变化:`DecisionAmendPayloadV2.body` 本就存在且已被 operation envelope 承载。

## 治理声明

未修改治理管控面。准入严格度保持:空转 amend 阴性对照仍被拒;`chosen`/`rejected` append-only 与 frontmatter 机器独占未动(在本判定上游执法,并由 #981 的 CLI 测试再断言)。

## 验证

- `task-decision-module-semantic-compiler-v2.test.ts` 12/12 通过,含新增「body-only amend 可编译、无 body 空转 amend 仍被拒」。
- `task-decision-module-authority-positive-v2.test.ts` 2/2 通过。
- `npm run typecheck` 与定向 eslint 干净。

## 审查证据

新测试内置阴性对照:同一 envelope 去掉 `body` 仍以 `DECISION_AMEND_FIELD_INVALID` 拒绝。生产实证:修复前 `ha decision amend dec_01KY1VCN49X4RJWGVCDASWFEAQ --body-file …` 报 `authority_ingress_rejected hint=DECISION_AMEND_FIELD_INVALID`;合并后 CEO 会话将复跑同一真实 amend 作为使用性验收。

## 残余风险

body 字节走既有 operation envelope 与快照 CAS,无新持久化路径。更广的 ingress 排除族(声明面有、运行时无)另行跟踪。

## 关联材料

- 任务包:`harness/tasks/task_01KY297QCMY1K3TFPFHQB0S4QA-decision/`
- 伴生:PR #981(同一修复的 CLI 腿)。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Targeted tests green / 定向测试全绿
- [x] No governance surface touched / 未触碰治理面
