### PR TITLE
fix(tools): remove the post-merge automatic daemon refresh trigger

### DIFF
--- a/tools/git-hooks/post-merge
+++ b/tools/git-hooks/post-merge
@@ -4,8 +4,8 @@ set -eu
 # Installed by pointing git at this directory:
 #   git config core.hooksPath tools/git-hooks   (or: npm run hooks:install)
 #
-# Keeps local build artifacts and the canonical main Daemon runtime fresh after
-# merges. Runtime installation/restart guards live in the testable Node helper.
+# Keeps local CLI and GUI build artifacts fresh after merges. Canonical main
+# also installs the rebuilt CLI; Daemon lifecycle changes remain explicit.
 
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
@@ -15,7 +15,7 @@ if [ -z "$previous_head" ]; then
   previous_head=$(git rev-parse --verify HEAD^ 2>/dev/null || true)
 fi
 if [ -z "$previous_head" ]; then
-  echo "post-merge: no previous commit is available; skipping runtime refresh."
+  echo "post-merge: no previous commit is available; skipping runtime build."
   exit 0
 fi
 

--- a/tools/git-hooks/post-merge.test.mjs
+++ b/tools/git-hooks/post-merge.test.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 
 const hookPath = fileURLToPath(new URL("./post-merge", import.meta.url));
 
-test("post-merge delegates the observed commit range to the runtime refresh helper", () => {
+test("post-merge delegates the observed commit range to the runtime build helper", () => {
   const root = mkdtempSync(path.join(os.tmpdir(), "ha-post-merge-hook-"));
   try {
     run("git", ["init", "-q"], root);

--- a/tools/post-merge-runtime-refresh.mjs
+++ b/tools/post-merge-runtime-refresh.mjs
@@ -44,26 +44,17 @@ export function planPostMergeRuntimeRefresh(input) {
     rootBuildFiles.has(file) || guiBuildFiles.has(file) || guiBuildPrefixes.some((prefix) => file.startsWith(prefix))
   );
   const onCanonicalMain = input.branch === "main";
-  const daemon = daemonStatusView(input.daemonStatus);
-  const daemonMatchesCanonicalRoot = daemon.canonicalRoot === input.repoRoot;
 
   return {
     buildCli,
     buildGui,
     installCli: buildCli && onCanonicalMain,
-    refreshDaemon: buildCli
-      && onCanonicalMain
-      && daemonMatchesCanonicalRoot
-      && daemon.started === true
-      && daemon.reachable === true
-      && typeof daemon.pid === "number",
     syncDependencies: input.changedPaths.some(isPackageManifest)
   };
 }
 
 export function executePostMergeRuntimeRefresh(input) {
   const cliEntry = path.join(input.repoRoot, "packages/cli/dist/cli/src/index.js");
-  const daemonTarget = input.daemonTarget ?? resolvePostMergeDaemonTarget(input.repoRoot, input.env ?? {});
   const wrapped = (label, command, args) => input.run(process.execPath, [
     "tools/run-with-local-resources.mjs",
     "--label",
@@ -91,37 +82,6 @@ export function executePostMergeRuntimeRefresh(input) {
     input.run(process.execPath, [cliEntry, "--json", "version"], { print: false });
     input.run("npm", ["install", "-g", "./packages/cli"]);
   }
-  if (!input.plan.refreshDaemon) return;
-
-  const before = daemonStatusView(input.daemonStatus);
-  const control = parseJsonObject(input.run(process.execPath, [
-    cliEntry,
-    ...postMergeDaemonCommandArgs(daemonTarget, "refresh"),
-    "--trigger",
-    "post-merge",
-    "--timeout-ms",
-    "30000",
-    "--reason",
-    "post-merge runtime build installed",
-    "--json"
-  ], { print: false }), "post-merge: refresh control returned invalid JSON");
-  const accepted = acceptedRefreshControl(control, before);
-  const status = waitForRefreshedDaemon({
-    cliEntry,
-    daemonTarget,
-    input,
-    before: {
-      ...before,
-      pid: accepted.beforePid,
-      loadedIdentity: accepted.beforeLoadedIdentity ?? before.loadedIdentity
-    }
-  });
-  assertRefreshedDaemon(status, {
-    ...before,
-    pid: accepted.beforePid,
-    loadedIdentity: accepted.beforeLoadedIdentity ?? before.loadedIdentity
-  }, input.repoRoot);
-  input.run(process.execPath, [cliEntry, "--root", input.repoRoot, "task", "list", "--limit", "1"]);
 }
 
 export function runPostMergeRuntimeRefresh(input) {
@@ -133,170 +93,14 @@ export function runPostMergeRuntimeRefresh(input) {
     input.currentHead,
     "--"
   ], { print: false }).split(/\r?\n/u).filter(Boolean);
-  const initialPlan = planPostMergeRuntimeRefresh({ branch, changedPaths, repoRoot: input.repoRoot });
-  const daemonTarget = resolvePostMergeDaemonTarget(input.repoRoot, input.env);
-  let daemonStatus;
-  if (branch === "main" && initialPlan.buildCli) {
-    try {
-      daemonStatus = JSON.parse(input.run("ha", [
-        ...postMergeDaemonCommandArgs(daemonTarget, "status"),
-        "--json"
-      ], { print: false }));
-    } catch (error) {
-      input.log?.(`post-merge: unable to read the existing Daemon status; it will not be restarted: ${error instanceof Error ? error.message : String(error)}`);
-      daemonStatus = undefined;
-    }
-  }
-  const plan = planPostMergeRuntimeRefresh({ branch, changedPaths, daemonStatus, repoRoot: input.repoRoot });
-  input.log?.(`post-merge: plan dependency-sync=${plan.syncDependencies} cli-build=${plan.buildCli} gui-build=${plan.buildGui} install-cli=${plan.installCli} refresh-daemon=${plan.refreshDaemon}`);
+  const plan = planPostMergeRuntimeRefresh({ branch, changedPaths });
+  input.log?.(`post-merge: plan dependency-sync=${plan.syncDependencies} cli-build=${plan.buildCli} gui-build=${plan.buildGui} install-cli=${plan.installCli}`);
   executePostMergeRuntimeRefresh({
-    daemonStatus,
-    daemonTarget,
     plan,
     repoRoot: input.repoRoot,
     run: input.run
   });
   return plan;
-}
-
-export function resolvePostMergeDaemonTarget(repoRoot, env = process.env) {
-  const userRoot = nonEmptyEnvironmentOption(env?.HARNESS_DAEMON_USER_ROOT);
-  const repoId = nonEmptyEnvironmentOption(env?.HARNESS_DAEMON_REPO_ID);
-  return Object.freeze({ repoRoot, userRoot, repoId });
-}
-
-function postMergeDaemonCommandArgs(target, action) {
-  return [
-    "--root", target.repoRoot,
-    ...(target.repoId ? ["--repo", target.repoId] : []),
-    "daemon", action,
-    ...(target.userRoot ? ["--user-root", target.userRoot] : [])
-  ];
-}
-
-function nonEmptyEnvironmentOption(value) {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
-}
-
-function acceptedRefreshControl(control, before) {
-  if (control.ok !== true
-    || control.accepted !== true
-    || control.kind !== "refresh"
-    || typeof control.operationId !== "string"
-    || control.operationId.length === 0) {
-    throw new Error("post-merge: refresh request was rejected or returned an invalid control receipt");
-  }
-  const controlBefore = isRecord(control.before) ? control.before : {};
-  const beforePid = typeof controlBefore.pid === "number" ? controlBefore.pid : before.pid;
-  const beforeLoadedIdentity = typeof controlBefore.loadedIdentity === "string"
-    ? controlBefore.loadedIdentity
-    : before.loadedIdentity;
-  if (typeof beforePid !== "number") {
-    throw new Error("post-merge: refresh control receipt did not identify the running daemon PID");
-  }
-  if (typeof before.pid === "number" && beforePid !== before.pid) {
-    throw new Error(`post-merge: refresh control targeted unexpected daemon PID: ${String(beforePid)}`);
-  }
-  if (before.loadedIdentity && beforeLoadedIdentity !== before.loadedIdentity) {
-    throw new Error(`post-merge: refresh control targeted unexpected build identity: ${String(beforeLoadedIdentity)}`);
-  }
-  return { beforePid, beforeLoadedIdentity };
-}
-
-function waitForRefreshedDaemon({ cliEntry, daemonTarget, input, before }) {
-  const attempts = input.statusPollAttempts ?? 300;
-  const wait = input.wait ?? waitSynchronously;
-  let lastStatus;
-  let lastError;
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    try {
-      lastStatus = parseJsonObject(input.run(process.execPath, [
-        cliEntry,
-        ...postMergeDaemonCommandArgs(daemonTarget, "status"),
-        "--json"
-      ], { print: false }), "post-merge: daemon status returned invalid JSON");
-      if (isRefreshedDaemon(lastStatus, before, input.repoRoot)) return lastStatus;
-    } catch (error) {
-      lastError = error;
-    }
-    if (attempt + 1 < attempts) wait(100);
-  }
-  if (lastStatus) return lastStatus;
-  throw new Error(`post-merge: refreshed daemon is not reachable${lastError instanceof Error ? `: ${lastError.message}` : ""}`);
-}
-
-function isRefreshedDaemon(status, before, repoRoot) {
-  const current = daemonStatusView(status);
-  return current.reachable === true
-    && current.started === true
-    && current.canonicalRoot === repoRoot
-    && typeof current.pid === "number"
-    && current.pid !== before.pid
-    && typeof current.loadedIdentity === "string"
-    && current.loadedIdentity !== before.loadedIdentity
-    && current.loadedIdentity === current.installedIdentity
-    && current.stale === false
-    && current.queueDepth === 0;
-}
-
-function assertRefreshedDaemon(status, before, repoRoot) {
-  const current = daemonStatusView(status);
-  if (current.reachable !== true || current.started !== true) {
-    throw new Error("post-merge: refreshed daemon is not reachable");
-  }
-  if (current.canonicalRoot !== repoRoot) {
-    throw new Error(`post-merge: refreshed daemon root mismatch: ${String(current.canonicalRoot)}`);
-  }
-  if (current.pid === before.pid) {
-    throw new Error(`post-merge: daemon PID did not change: ${String(current.pid)}`);
-  }
-  if (current.loadedIdentity === before.loadedIdentity) {
-    throw new Error(`post-merge: daemon build identity did not change: ${String(current.loadedIdentity)}`);
-  }
-  if (!current.loadedIdentity || current.loadedIdentity !== current.installedIdentity || current.stale !== false) {
-    throw new Error(`post-merge: refreshed daemon did not load the installed build identity: loaded=${String(current.loadedIdentity)} installed=${String(current.installedIdentity)}`);
-  }
-  if (current.queueDepth !== 0) {
-    throw new Error(`post-merge: refreshed daemon queue is not empty: ${String(current.queueDepth)}`);
-  }
-}
-
-function daemonStatusView(status) {
-  const source = isRecord(status) ? status : {};
-  const service = isRecord(source.service) ? source.service : {};
-  const requestedRepo = isRecord(source.requestedRepo) ? source.requestedRepo : {};
-  const build = isRecord(service.build) ? service.build : {};
-  const queue = isRecord(service.queue) ? service.queue : {};
-  return {
-    started: source.started === true || service.started === true,
-    reachable: source.reachable === true,
-    pid: typeof service.pid === "number" ? service.pid : source.pid,
-    canonicalRoot: typeof requestedRepo.canonicalRoot === "string" ? requestedRepo.canonicalRoot : source.rootDir,
-    queueDepth: typeof queue.depth === "number" ? queue.depth : source.queueDepth,
-    loadedIdentity: typeof build.loadedIdentity === "string" ? build.loadedIdentity : undefined,
-    installedIdentity: typeof build.installedIdentity === "string" ? build.installedIdentity : undefined,
-    stale: typeof build.stale === "boolean" ? build.stale : undefined
-  };
-}
-
-function parseJsonObject(value, errorMessage) {
-  let parsed;
-  try {
-    parsed = JSON.parse(value);
-  } catch {
-    throw new Error(errorMessage);
-  }
-  if (!isRecord(parsed)) throw new Error(errorMessage);
-  return parsed;
-}
-
-function isRecord(value) {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function waitSynchronously(ms) {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
 export function createPostMergeCommandRunner(repoRoot) {

--- a/tools/post-merge-runtime-refresh.test.mjs
+++ b/tools/post-merge-runtime-refresh.test.mjs
@@ -7,145 +7,74 @@ import {
   runPostMergeRuntimeRefresh
 } from "./post-merge-runtime-refresh.mjs";
 
-test("feature worktree merges never install or restart the shared runtime", () => {
+test("feature worktree merges build without installing the shared runtime", () => {
   const plan = planPostMergeRuntimeRefresh({
     branch: "codex/example",
-    changedPaths: ["packages/daemon/src/index.ts"],
-    daemonStatus: {
-      started: true,
-      reachable: true,
-      pid: 42,
-      rootDir: "/repo"
-    },
-    repoRoot: "/repo/.worktrees/example"
+    changedPaths: ["packages/daemon/src/index.ts"]
   });
 
-  assert.equal(plan.buildCli, true);
-  assert.equal(plan.installCli, false);
-  assert.equal(plan.refreshDaemon, false);
+  assert.deepEqual(plan, {
+    buildCli: true,
+    buildGui: false,
+    installCli: false,
+    syncDependencies: false
+  });
 });
 
-test("canonical main installs daemon-only changes without starting a stopped daemon", () => {
+test("canonical main installs daemon-only changes without scheduling daemon control", () => {
   const plan = planPostMergeRuntimeRefresh({
     branch: "main",
-    changedPaths: ["packages/daemon/src/protocol/method-registry.ts"],
-    daemonStatus: {
-      started: false,
-      reachable: false,
-      rootDir: "/repo"
-    },
-    repoRoot: "/repo"
+    changedPaths: ["packages/daemon/src/protocol/method-registry.ts"]
   });
 
   assert.deepEqual(plan, {
     buildCli: true,
     buildGui: false,
     installCli: true,
-    refreshDaemon: false,
     syncDependencies: false
   });
 });
 
-test("canonical main does not restart when the old daemon PID is unknown", () => {
+test("test-only changes do not rebuild or install the runtime", () => {
   const plan = planPostMergeRuntimeRefresh({
     branch: "main",
-    changedPaths: ["packages/daemon/src/index.ts"],
-    daemonStatus: { started: true, reachable: true, rootDir: "/repo" },
-    repoRoot: "/repo"
+    changedPaths: ["packages/daemon/test/json-rpc-protocol.test.ts"]
   });
 
-  assert.equal(plan.installCli, true);
-  assert.equal(plan.refreshDaemon, false);
-});
-
-test("test-only changes do not rebuild or restart the installed runtime", () => {
-  const plan = planPostMergeRuntimeRefresh({
-    branch: "main",
-    changedPaths: ["packages/daemon/test/json-rpc-protocol.test.ts"],
-    daemonStatus: { started: true, reachable: true, pid: 42, rootDir: "/repo" },
-    repoRoot: "/repo"
+  assert.deepEqual(plan, {
+    buildCli: false,
+    buildGui: false,
+    installCli: false,
+    syncDependencies: false
   });
-
-  assert.equal(plan.buildCli, false);
-  assert.equal(plan.buildGui, false);
-  assert.equal(plan.installCli, false);
-  assert.equal(plan.refreshDaemon, false);
 });
 
 test("lockfile changes synchronize dependencies before rebuilding both workspaces", () => {
   const plan = planPostMergeRuntimeRefresh({
     branch: "main",
-    changedPaths: ["package-lock.json"],
-    daemonStatus: { started: false, reachable: false },
-    repoRoot: "/repo"
+    changedPaths: ["package-lock.json"]
   });
 
-  assert.equal(plan.syncDependencies, true);
-  assert.equal(plan.buildCli, true);
-  assert.equal(plan.buildGui, true);
-  assert.equal(plan.installCli, true);
-  assert.equal(plan.refreshDaemon, false);
+  assert.deepEqual(plan, {
+    buildCli: true,
+    buildGui: true,
+    installCli: true,
+    syncDependencies: true
+  });
 });
 
-test("canonical refresh completes every build and install before requesting canonical control", () => {
+test("post-merge execution preserves dependency, CLI, GUI, and install ordering", () => {
   const calls = [];
   const run = (command, args) => {
     calls.push([command, ...args]);
-    if (args.includes("refresh")) {
-      return JSON.stringify({
-        ok: true,
-        schema: "daemon-command/v1",
-        command: "daemon-refresh",
-        accepted: true,
-        operationId: "control-refresh",
-        kind: "refresh",
-        before: {
-          pid: 42,
-          loadedIdentity: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        }
-      });
-    }
-    if (args.includes("status")) {
-      return JSON.stringify({
-        ok: true,
-        started: true,
-        reachable: true,
-        pid: 84,
-        queueDepth: 0,
-        rootDir: "/repo",
-        service: {
-          pid: 84,
-          queue: { depth: 0 },
-          build: {
-            loadedIdentity: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            installedIdentity: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            stale: false
-          }
-        },
-        requestedRepo: { canonicalRoot: "/repo" }
-      });
-    }
     return "";
   };
 
   executePostMergeRuntimeRefresh({
-    daemonStatus: {
-      started: true,
-      reachable: true,
-      pid: 42,
-      rootDir: "/repo",
-      service: {
-        pid: 42,
-        build: {
-          loadedIdentity: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        }
-      }
-    },
     plan: {
       buildCli: true,
       buildGui: true,
       installCli: true,
-      refreshDaemon: true,
       syncDependencies: true
     },
     repoRoot: "/repo",
@@ -153,20 +82,19 @@ test("canonical refresh completes every build and install before requesting cano
   });
 
   const rendered = calls.map((call) => call.join(" "));
-  const refreshIndex = rendered.findIndex((call) => call.includes("daemon refresh"));
-  assert.ok(rendered.findIndex((call) => call.includes("npm ci")) < refreshIndex);
-  assert.ok(rendered.findIndex((call) => call.includes("@harness-anything/cli")) < refreshIndex);
-  assert.ok(rendered.findIndex((call) => call.includes("@harness-anything/gui")) < refreshIndex);
-  assert.ok(rendered.findIndex((call) => call.includes("npm install -g")) < refreshIndex);
-  assert.ok(refreshIndex >= 0);
-  assert.ok(rendered[refreshIndex].includes("--trigger post-merge"));
-  assert.equal(rendered.some((call) => call.includes("daemon stop")), false);
-  assert.equal(rendered.some((call) => call.includes("daemon start")), false);
-  assert.ok(rendered.some((call) => call.includes("daemon status --json")));
-  assert.ok(rendered.some((call) => call.includes("task list --limit 1")));
+  const dependencyIndex = rendered.findIndex((call) => call.includes("npm ci"));
+  const kernelIndex = rendered.findIndex((call) => call.includes("packages/kernel/tsconfig.json"));
+  const cliIndex = rendered.findIndex((call) => call.includes("@harness-anything/cli"));
+  const guiIndex = rendered.findIndex((call) => call.includes("@harness-anything/gui"));
+  const installIndex = rendered.findIndex((call) => call.includes("npm install -g"));
+  assert.ok(dependencyIndex < kernelIndex);
+  assert.ok(kernelIndex < cliIndex);
+  assert.ok(cliIndex < guiIndex);
+  assert.ok(guiIndex < installIndex);
+  assert.equal(rendered.some((call) => /daemon (?:status|refresh|stop|start)/u.test(call)), false);
 });
 
-test("build failure leaves the running daemon untouched", () => {
+test("build failure stops later build and install work", () => {
   const calls = [];
   const run = (command, args) => {
     calls.push([command, ...args].join(" "));
@@ -175,210 +103,45 @@ test("build failure leaves the running daemon untouched", () => {
   };
 
   assert.throws(() => executePostMergeRuntimeRefresh({
-    daemonStatus: { started: true, reachable: true, pid: 42, rootDir: "/repo" },
     plan: {
       buildCli: true,
-      buildGui: false,
+      buildGui: true,
       installCli: true,
-      refreshDaemon: true,
       syncDependencies: false
     },
     repoRoot: "/repo",
     run
   }), /build failed/u);
 
-  assert.equal(calls.some((call) => call.includes("daemon refresh")), false);
+  assert.equal(calls.some((call) => call.includes("@harness-anything/gui")), false);
+  assert.equal(calls.some((call) => call.includes("npm install -g")), false);
 });
 
-test("RPC rejection leaves post-merge verification untouched", () => {
-  const calls = [];
-  const run = (command, args) => {
-    calls.push([command, ...args].join(" "));
-    if (args.includes("refresh")) {
-      return JSON.stringify({ ok: false, schema: "daemon-command/v1", command: "daemon-refresh" });
-    }
-    return "";
-  };
-
-  assert.throws(() => executePostMergeRuntimeRefresh({
-    daemonStatus: { started: true, reachable: true, pid: 42, rootDir: "/repo" },
-    plan: {
-      buildCli: false,
-      buildGui: false,
-      installCli: false,
-      refreshDaemon: true,
-      syncDependencies: false
-    },
-    repoRoot: "/repo",
-    run
-  }), /refresh request was rejected/u);
-
-  assert.equal(calls.some((call) => call.includes("daemon status")), false);
-});
-
-test("refresh verification rejects an unchanged daemon PID", () => {
-  assert.throws(() => executePostMergeRuntimeRefresh({
-    daemonStatus: {
-      started: true,
-      reachable: true,
-      pid: 42,
-      rootDir: "/repo",
-      service: {
-        pid: 42,
-        build: {
-          loadedIdentity: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        }
-      }
-    },
-    plan: {
-      buildCli: false,
-      buildGui: false,
-      installCli: false,
-      refreshDaemon: true,
-      syncDependencies: false
-    },
-    repoRoot: "/repo",
-    statusPollAttempts: 1,
-    run: (_command, args) => args.includes("refresh")
-      ? JSON.stringify({
-        ok: true,
-        accepted: true,
-        operationId: "control-refresh",
-        kind: "refresh",
-        before: {
-          pid: 42,
-          loadedIdentity: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        }
-      })
-      : JSON.stringify({
-        started: true,
-        reachable: true,
-        service: {
-          pid: 42,
-          queue: { depth: 0 },
-          build: {
-            loadedIdentity: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            installedIdentity: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            stale: false
-          }
-        },
-        requestedRepo: { canonicalRoot: "/repo" }
-      })
-  }), /PID did not change/u);
-});
-
-test("refresh verification rejects an unchanged loaded build identity", () => {
-  const identity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-  assert.throws(() => executePostMergeRuntimeRefresh({
-    daemonStatus: {
-      started: true,
-      reachable: true,
-      pid: 42,
-      rootDir: "/repo",
-      service: { pid: 42, build: { loadedIdentity: identity } }
-    },
-    plan: {
-      buildCli: false,
-      buildGui: false,
-      installCli: false,
-      refreshDaemon: true,
-      syncDependencies: false
-    },
-    repoRoot: "/repo",
-    statusPollAttempts: 1,
-    run: (_command, args) => args.includes("refresh")
-      ? JSON.stringify({
-        ok: true,
-        accepted: true,
-        operationId: "control-refresh",
-        kind: "refresh",
-        before: { pid: 42, loadedIdentity: identity }
-      })
-      : JSON.stringify({
-        started: true,
-        reachable: true,
-        service: {
-          pid: 84,
-          queue: { depth: 0 },
-          build: { loadedIdentity: identity, installedIdentity: identity, stale: false }
-        },
-        requestedRepo: { canonicalRoot: "/repo" }
-      })
-  }), /build identity did not change/u);
-});
-
-test("post-merge discovery refreshes a running canonical daemon for daemon-only changes", () => {
+test("post-merge discovery builds and installs without issuing daemon commands", () => {
   const calls = [];
   const run = (command, args) => {
     calls.push([command, ...args]);
     if (command === "git" && args[0] === "branch") return "main\n";
     if (command === "git" && args[0] === "diff") return "packages/daemon/src/index.ts\n";
-    if (command === "ha") {
-      return JSON.stringify({
-        started: true,
-        reachable: true,
-        pid: 42,
-        rootDir: "/repo",
-        service: {
-          pid: 42,
-          build: {
-            loadedIdentity: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-          }
-        }
-      });
-    }
-    if (args.includes("refresh")) {
-      return JSON.stringify({
-        ok: true,
-        accepted: true,
-        operationId: "control-refresh",
-        kind: "refresh",
-        before: {
-          pid: 42,
-          loadedIdentity: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        }
-      });
-    }
-    if (args.includes("status")) {
-      return JSON.stringify({
-        started: true,
-        reachable: true,
-        pid: 84,
-        queueDepth: 0,
-        rootDir: "/repo",
-        service: {
-          pid: 84,
-          queue: { depth: 0 },
-          build: {
-            loadedIdentity: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            installedIdentity: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            stale: false
-          }
-        },
-        requestedRepo: { canonicalRoot: "/repo" }
-      });
-    }
     return "";
   };
 
-  runPostMergeRuntimeRefresh({
+  const plan = runPostMergeRuntimeRefresh({
     currentHead: "new",
-    env: {
-      HARNESS_DAEMON_REPO_ID: "canonical",
-      HARNESS_DAEMON_USER_ROOT: "/state/user"
-    },
     previousHead: "old",
     repoRoot: "/repo",
     run
   });
 
   const rendered = calls.map((call) => call.join(" "));
+  assert.deepEqual(plan, {
+    buildCli: true,
+    buildGui: false,
+    installCli: true,
+    syncDependencies: false
+  });
   assert.ok(rendered.some((call) => call === "git diff --name-only old new --"));
-  assert.ok(rendered.some((call) => call.includes("daemon refresh") && call.includes("--trigger post-merge")));
-  const daemonCommands = rendered.filter((call) => /daemon (?:status|refresh)/u.test(call));
-  assert.ok(daemonCommands.length >= 3, JSON.stringify(daemonCommands));
-  assert.equal(daemonCommands.every((call) => call.includes("--repo canonical")), true, JSON.stringify(daemonCommands));
-  assert.equal(daemonCommands.every((call) => call.includes("--user-root /state/user")), true, JSON.stringify(daemonCommands));
-  assert.equal(rendered.some((call) => call.includes("daemon stop")), false);
-  assert.equal(rendered.some((call) => call.includes("daemon start")), false);
+  assert.ok(rendered.some((call) => call.includes("@harness-anything/cli")));
+  assert.ok(rendered.some((call) => call.includes("npm install -g")));
+  assert.equal(rendered.some((call) => /daemon (?:status|refresh|stop|start)/u.test(call)), false);
 });


### PR DESCRIPTION
# English

## Summary

Every merge into canonical main used to auto-refresh the live daemon (`post-merge` hook → `refreshDaemon`), hot-swapping the resident process at an uncontrolled moment. That automatic, high-frequency, uncontrolled handoff is the manufactured trigger behind the recurring generation/handoff failure family ("post-merge refresh kills the incumbent and fails to raise a replacement"). This PR removes the trigger; builds stay.

## What Changed

- `tools/post-merge-runtime-refresh.mjs`: the `refreshDaemon` plan flag, daemon status preflight, refresh RPC, replacement polling/verification, and post-refresh probe are removed (−489 lines net). Dependency sync, kernel declarations, CLI build, GUI build, and canonical-main CLI install keep their exact order.
- `tools/git-hooks/post-merge` + tests: hook delegates the same commit range to the runtime build helper; comments now state that daemon lifecycle transitions must be explicit.
- `tools/post-merge-runtime-refresh.test.mjs`: expectations updated — the plan never contains a refresh item, and discovery issues no daemon status/refresh/stop/start commands.
- The explicit `ha daemon refresh` command surface is untouched (21/21 dispatcher/control regression tests pass unchanged).

## Task And Scope

- Task: `task_01KY2PQ5AY0C3ENEE536TMEV9B`, derived from decision `dec_01KY2PJRGWXEJDH3E622553HZK` (CH2).
- Scope: post-merge hook tooling and its tests only. No daemon runtime code, no CLI source, no post-commit hook, no gate-manifest change.

## Version Impact

No package version bump. Developer-workflow behavior change only: merges no longer hot-swap the daemon; version switches go through the explicit graceful-restart path.

## Governance Declaration

`tools/git-hooks/post-merge` is a protected surface under the `check-local-load-governance` gate (`requiresGovernanceEvidence: true`). Authority: decision `dec_01KY2PJRGWXEJDH3E622553HZK` ("daemon runs a pinned stable snapshot and may deliberately trail main; the automatic freshness default is explicitly overturned"), which derives task `task_01KY2PQ5AY0C3ENEE536TMEV9B` for exactly this removal. The gate itself and its manifest row are not modified.

## Verification

- `HARNESS_CLI_TEST_FIXTURE_PRELOAD=1 node --test tools/git-hooks/post-merge.test.mjs` → 1/1 pass.
- `… node --test tools/post-merge-runtime-refresh.test.mjs` → 7/7 pass, including "post-merge discovery builds and installs without issuing daemon commands".
- Explicit-refresh regression (`daemon-control-dispatcher` suite) → 21/21 pass, proving the retained `ha daemon refresh` command is intact.

## Review Evidence

Worker report with full runner transcripts and the negative control (restoring the trigger reproduces the old plan expectations): `harness/tasks/task_01KY2PQ5AY0C3ENEE536TMEV9B-post-merge-daemon-refresh-build/artifacts/worker-report.md` (ledger-side, not in this diff).

## Residual Risk

Developers must now consciously switch daemon versions via the graceful-restart path; a stale daemon is the intended steady state, not drift — the overturned default is recorded in the decision to prevent well-meaning reinstatement.

## References

- Decision: `dec_01KY2PJRGWXEJDH3E622553HZK`; task package: `harness/tasks/task_01KY2PQ5AY0C3ENEE536TMEV9B-post-merge-daemon-refresh-build/`.

---

# 中文

## 概要

过去每次合入 canonical main 都会自动刷新现役 daemon(`post-merge` hook → `refreshDaemon`),在不受控时刻热替换常驻进程。这种自动、高频、不受控的换班正是 generation/交接故障族反复复发的人造触发器("post-merge refresh 杀现役拉不起替身")。本 PR 移除该触发器;构建保留。

## 改动内容

- `tools/post-merge-runtime-refresh.mjs`:删除 `refreshDaemon` plan 标志、daemon status 预检、refresh RPC、replacement 轮询/校验与 post-refresh 探针(净删 489 行)。依赖同步、kernel declarations、CLI build、GUI build、canonical-main CLI install 的顺序原样保留。
- `tools/git-hooks/post-merge` 与测试:hook 以同一 commit range 委派 runtime build helper;注释明确 daemon 生命周期转换必须显式触发。
- `tools/post-merge-runtime-refresh.test.mjs`:期望更新——plan 永不含 refresh 项,discovery 不发出任何 daemon status/refresh/stop/start 命令。
- 显式 `ha daemon refresh` 命令面未动(dispatcher/control 回归 21/21 通过)。

## 任务与范围

- 任务:`task_01KY2PQ5AY0C3ENEE536TMEV9B`,由决策 `dec_01KY2PJRGWXEJDH3E622553HZK`(CH2)派生。
- 范围:仅 post-merge hook 工具链及其测试。不动 daemon 运行时、CLI 源码、post-commit hook、gate-manifest。

## 版本影响

无包版本变更。仅开发工作流行为变化:合并不再热替换 daemon;版本切换走显式优雅重启路径。

## 治理声明

`tools/git-hooks/post-merge` 是 `check-local-load-governance` 门下的 protected surface(`requiresGovernanceEvidence: true`)。授权依据:决策 `dec_01KY2PJRGWXEJDH3E622553HZK`("daemon 应跑钉住的稳定快照、可故意落后于 main;自动保鲜默认被显式推翻"),其 CH2 派生任务 `task_01KY2PQ5AY0C3ENEE536TMEV9B` 即本次移除。门本身与其 manifest 行未修改。

## 验证

- `post-merge.test.mjs` 1/1 通过。
- `post-merge-runtime-refresh.test.mjs` 7/7 通过,含「post-merge discovery 只构建安装、不发出 daemon 命令」。
- 显式 refresh 回归(dispatcher/control 套件)21/21 通过,证明保留的 `ha daemon refresh` 命令完好。

## 审查证据

worker 报告含完整 runner 输出与阴性对照(恢复触发器则旧 plan 期望复现):`harness/tasks/task_01KY2PQ5AY0C3ENEE536TMEV9B-post-merge-daemon-refresh-build/artifacts/worker-report.md`(不在本 diff 内)。

## 残余风险

开发者此后须经优雅重启路径有意识地切换 daemon 版本;daemon 陈旧是设计后的常态而非漂移——被推翻的旧默认已记录在决策中,防止未来被"好心"改回。

## 关联材料

- 决策:`dec_01KY2PJRGWXEJDH3E622553HZK`;任务包:`harness/tasks/task_01KY2PQ5AY0C3ENEE536TMEV9B-post-merge-daemon-refresh-build/`。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Targeted tests green / 定向测试全绿
- [x] Protected-surface change declared with decision authority / protected surface 改动已带决策授权申报
