### PR TITLE
fix(gui): surface newest decision-pool proposals first

### DIFF
--- a/packages/gui/src/renderer/views/DecisionPoolView.tsx
+++ b/packages/gui/src/renderer/views/DecisionPoolView.tsx
@@ -17,7 +17,7 @@ import {
   RiskTierBadge,
   UrgencyBadge,
 } from "../components/badges";
-import { coverageOf, sortDecisionQueue } from "../model/triadic";
+import { coverageOf } from "../model/triadic";
 import { DecisionDetailPanel } from "./genealogy/DecisionDetailPanel";
 import { DecisionProposeForm } from "./DecisionProposeForm";
 import { ClaimList } from "./decisions-verdict";
@@ -29,6 +29,7 @@ import {
   formatActorAxes,
   groupRows,
   relationSummary,
+  sortDecisionPoolRowsByRecency,
   tabForState,
   withinRange,
   type GroupBy,
@@ -222,7 +223,7 @@ export function DecisionPoolView({
   };
 
   const rows = useMemo(() => {
-    return sortDecisionQueue(decisions)
+    return sortDecisionPoolRowsByRecency(decisions)
       .filter((decision) => decision.state === tab)
       .filter((decision) => {
         if (riskFilter === "all") return true;

--- a/packages/gui/src/renderer/views/decision-pool-helpers.ts
+++ b/packages/gui/src/renderer/views/decision-pool-helpers.ts
@@ -19,6 +19,15 @@ export const POOL_TABS: readonly PoolTab[] = [
   "retired",
 ] as const;
 
+/** Decision Pool is a browsing surface: newest proposals stay visible first. */
+export function sortDecisionPoolRowsByRecency(rows: DecisionRow[]): DecisionRow[] {
+  return [...rows].sort((a, b) => {
+    const proposedAt = (b.proposedAt ?? "").localeCompare(a.proposedAt ?? "");
+    if (proposedAt !== 0) return proposedAt;
+    return a.decisionId.localeCompare(b.decisionId);
+  });
+}
+
 export function withinRange(decision: DecisionRow, range: TimeRange): boolean {
   if (range === "all") return true;
   if (!decision.proposedAt) return false;
@@ -168,6 +177,13 @@ export interface MilestoneGroup {
   rows: DecisionRow[];
 }
 
+function newestDecisionPoolProposalTimestamp(rows: DecisionRow[]): string {
+  return rows.reduce(
+    (newest, row) => row.proposedAt && row.proposedAt > newest ? row.proposedAt : newest,
+    "",
+  );
+}
+
 export function groupRows(
   rows: DecisionRow[],
   groupBy: GroupBy,
@@ -201,11 +217,11 @@ export function groupRows(
     }
   }
   return [...buckets.entries()]
-    .sort(([a], [b]) => {
-      // unlinked last
-      if (a === UNLINKED_MILESTONE) return 1;
-      if (b === UNLINKED_MILESTONE) return -1;
-      return a.localeCompare(b);
+    .sort(([aKey, a], [bKey, b]) => {
+      const proposedAt = newestDecisionPoolProposalTimestamp(b.rows)
+        .localeCompare(newestDecisionPoolProposalTimestamp(a.rows));
+      if (proposedAt !== 0) return proposedAt;
+      return aKey.localeCompare(bKey);
     })
     .map(([key, value]) => ({ key, title: value.title, rows: value.rows }));
 }

--- a/packages/gui/test/decision-approval.vitest.ts
+++ b/packages/gui/test/decision-approval.vitest.ts
@@ -411,6 +411,61 @@ describe("server-render smoke · approval + pool", () => {
     // no nested state <select> (dropped)
     expect(html).not.toContain("state: all");
   });
+
+  it("DecisionPoolView shows newly proposed decisions before older higher-risk rows", () => {
+    const html = renderToStaticMarkup(
+      createElement(DecisionPoolView, {
+        decisions: [
+          decision({
+            decisionId: "dec_old",
+            title: "Older high-risk proposal",
+            riskTier: "high",
+            urgency: "high",
+            proposedAt: "2026-07-14T13:39:00.965Z",
+          }),
+          decision({
+            decisionId: "dec_new",
+            title: "New low-risk proposal",
+            riskTier: "low",
+            urgency: "low",
+            proposedAt: "2026-07-21T08:07:07.527Z",
+          }),
+        ],
+        facts,
+        relations: [],
+        tasks: [],
+      }),
+    );
+
+    expect(html.indexOf("dec_new")).toBeLessThan(html.indexOf("dec_old"));
+  });
+
+  it("DecisionPoolView shows a newly proposed unlinked group before older milestone groups", () => {
+    const html = renderToStaticMarkup(
+      createElement(DecisionPoolView, {
+        decisions: [
+          decision({
+            decisionId: "dec_old_linked",
+            proposedAt: "2026-07-14T13:39:00.965Z",
+          }),
+          decision({
+            decisionId: "dec_new_unlinked",
+            proposedAt: "2026-07-21T08:07:07.527Z",
+          }),
+        ],
+        facts,
+        relations: [{
+          from: "decision/dec_old_linked",
+          to: "task/task_leaf",
+          kind: "derives",
+          provenance: "local-document",
+        }],
+        tasks,
+      }),
+    );
+
+    expect(html.indexOf("dec_new_unlinked")).toBeLessThan(html.indexOf("dec_old_linked"));
+  });
 });
 
 describe("dec_01KXARBFDR · propose payload builder (camelCase → snake_case)", () => {


### PR DESCRIPTION
# English

## Summary

Newly proposed decisions were effectively invisible in the GUI Decision Pool: the pool reused the approval queue's risk/urgency ordering (with `proposedAt` ascending as the last tiebreaker), so a fresh low-risk proposal ranked below every older high/medium-risk row; the default milestone grouping additionally pinned the "unlinked" group last, sinking any decision proposed but not yet related to a milestone. Measured against the real canonical projection, a decision proposed on 2026-07-21 ranked 13th/14th behind rows from 2026-07-14. The projection itself was proven complete (459 decision rows, 14 proposed, target present) — this was purely a renderer information-architecture defect.

## What Changed

- `DecisionPoolView.tsx`: the pool now sorts with a pool-specific recency comparator instead of `sortDecisionQueue`; filters and the owner-stripped DTO consumption boundary are unchanged.
- `decision-pool-helpers.ts`: new uniquely named helper `sortDecisionPoolRowsByRecency` (`proposedAt` newest-first, stable by `decisionId`); milestone groups now order by their newest proposal timestamp, removing the hardcoded "unlinked always last" rule.
- `decision-approval.vitest.ts`: two regression tests through the real `DecisionPoolView` render seam — a new proposal must outrank older higher-risk rows, and a new unlinked group must outrank older milestone groups. Both fail against the previous ordering (negative control verified).
- The approval queue, Overview top-N, and relation graph keep `sortDecisionQueue` risk/urgency semantics untouched.

## Verification

- GUI targeted tests: 37/37 pass; GUI production build passes.
- `harness:scan-forbidden-symbols` and `harness:check-duplicate-definitions` gates pass.
- Negative control: reverting the ordering reproduces both "newer row sinks" failures with real rank numbers.

## Task And Scope

- Task: `task_01KY2R4YK3P5W6HM5G35GM8NRJ`. Scope: GUI renderer decision-pool ordering and its component tests only. No write path, schema, daemon, or CLI change.

## Version Impact

No package version bump. Renderer presentation-order change only.

## Governance Declaration

No protected surface touched: no gate tooling, CI/queue configuration, write road, or daemon runtime modified. The pool consumes the same owner-stripped renderer DTOs as before.

## Review Evidence

Worker report with the full evidence chain (real canonical projection measurement, pre-fix comparator ranking, negative-control outputs): `harness/tasks/task_01KY2R4YK3P5W6HM5G35GM8NRJ-gui-proposed/artifacts/worker-report.md` (ledger-side, not in this diff).

## References

- Task package: `harness/tasks/task_01KY2R4YK3P5W6HM5G35GM8NRJ-gui-proposed/`.

## Residual Risk

Vertical grouping keeps name ordering (user-selected grouping semantics, defect was in the default milestone grouping). No Electron manual click-through; component tests cover rendered order.

---

# 中文

## 概要

GUI 决策池里新 propose 的决策几乎不可见:决策池误复用了审批队列的 risk/urgency 排序(`proposedAt` 仅作末位平手项且为**正序**),导致新的低风险提案排在所有旧的高/中风险行之后;默认 milestone 分组又把「未关联」组硬编码沉底,刚提出、尚未 relate 的决策整组垫底。用真实 canonical 投影实测:2026-07-21 新提的决策排第 13/14,前面全是 2026-07-14 的旧行。投影本身证实无缺行(459 行决策、14 条 proposed、目标在内)——纯 renderer 信息架构缺陷。

## 改动内容

- `DecisionPoolView.tsx`:决策池改用池专用的时间倒序比较器,不再用 `sortDecisionQueue`;过滤器与 owner-stripped DTO 消费边界不变。
- `decision-pool-helpers.ts`:新增唯一命名 helper `sortDecisionPoolRowsByRecency`(`proposedAt` 新到旧,按 `decisionId` 稳定);milestone 组按组内最新提议时间排序,删除「未关联永远最后」的硬编码。
- `decision-approval.vitest.ts`:两条走真实 `DecisionPoolView` 渲染缝的回归——新提案须压过旧高风险行;新未关联组须压过旧 milestone 组。两条在旧排序下均失败(阴性对照已验证)。
- 审批队列、Overview top-N、关系图继续沿用 `sortDecisionQueue` 的 risk/urgency 语义,未动。

## 验证

- GUI 定向测试 37/37;GUI production build 通过。
- forbidden-symbols 与 duplicate-definitions 门通过。
- 阴性对照:回滚排序即复现两条「新行沉底」失败,附真实名次数字。

## 任务与范围

- 任务:`task_01KY2R4YK3P5W6HM5G35GM8NRJ`。范围:仅 GUI renderer 决策池排序及其组件测试;不动写路、schema、daemon、CLI。

## 版本影响

无包版本变更;仅 renderer 展示顺序变化。

## 治理声明

未触碰 protected surface:未修改门工具、CI/队列配置、写路或 daemon 运行时。决策池消费的仍是原有 owner-stripped renderer DTO。

## 审查证据

完整证据链(真实 canonical 投影实测、修复前比较器名次、阴性对照输出)见 worker 报告:`harness/tasks/task_01KY2R4YK3P5W6HM5G35GM8NRJ-gui-proposed/artifacts/worker-report.md`(台账侧,不在本 diff 内)。

## 关联材料

- 任务包:`harness/tasks/task_01KY2R4YK3P5W6HM5G35GM8NRJ-gui-proposed/`。

## 残余风险

vertical 分组保持名称排序(用户主动选择的分组语义,缺陷发生在默认 milestone 分组)。未做 Electron 人工点检;组件测试覆盖真实渲染顺序。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Targeted tests green / 定向测试全绿
