### PR TITLE
fix(daemon): keep recovery alive and checkpoint scans incrementally

### DIFF
--- a/packages/cli/test/production-authority-event-recovery.test.ts
+++ b/packages/cli/test/production-authority-event-recovery.test.ts
@@ -1,10 +1,11 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 import type {
   AuthorityCommittedReceipt,
   AuthorityOperationRegistry,
@@ -406,7 +407,9 @@ test("incremental recovery advances its watermark only after an absent indetermi
         list: async () => [durable],
         put: async (next) => {
           if (next.state === "REJECTED") {
-            assert.equal(existsSync(watermarkPath), false, "watermark must not precede terminalization");
+            const checkpoint = JSON.parse(readFileSync(watermarkPath, "utf8")) as Record<string, unknown>;
+            assert.equal(checkpoint.schema, "authority-recovery-watermark/v2");
+            assert.equal(checkpoint.phase, "partial", "complete watermark must not precede terminalization");
             terminalized = true;
           }
           durable = next;
@@ -466,7 +469,57 @@ test("recovery watermark falls back on missing or corrupt state and then scans o
   }
 });
 
-test("recovery watermark never advances past an unresolved indexed operation", async () => {
+test("SIGKILL during a scan resumes from the last fully checkpointed commit", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-authority-recovery-kill-resume-"));
+  const watermarkPath = path.join(root, "recovery-watermark.json");
+  const readyPath = path.join(root, "checkpoint-ready");
+  const fixturePath = path.resolve("packages/daemon/test/fixtures/recovery-watermark-kill-target.ts");
+  const child = spawn(process.execPath, [fixturePath, watermarkPath, readyPath], { stdio: "inherit" });
+  try {
+    const deadline = Date.now() + 10_000;
+    while (!existsSync(readyPath) && Date.now() < deadline) await delay(10);
+    assert.equal(existsSync(readyPath), true, "fixture did not persist its incremental checkpoint");
+    child.kill("SIGKILL");
+    await new Promise<void>((resolve, reject) => {
+      child.once("exit", (_code, signal) => signal === "SIGKILL"
+        ? resolve()
+        : reject(new Error(`expected SIGKILL, received ${signal ?? "clean exit"}`)));
+      child.once("error", reject);
+    });
+    const partial = JSON.parse(readFileSync(watermarkPath, "utf8")) as Record<string, unknown>;
+    assert.equal(partial.schema, "authority-recovery-watermark/v2");
+    assert.equal(partial.phase, "partial");
+    assert.equal(partial.commitSha, "a".repeat(40));
+
+    const scanInputs: Array<string | undefined> = [];
+    await recoverPendingProductionEvents({
+      workspaceId: "workspace-production",
+      operationRegistry: {
+        get: async () => undefined,
+        list: async () => [],
+        put: async () => undefined
+      },
+      replicaChangeLog: {} as import("../../application/src/index.ts").ReplicaChangeLog,
+      eventLog: {} as ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>,
+      publicationInspector: {
+        scanFirstParentOperationAnchors: async ({ exclusiveCommit }: { readonly exclusiveCommit?: string }) => {
+          scanInputs.push(exclusiveCommit);
+          return { headCommit: "b".repeat(40), scannedCommitCount: 1, anchors: [] };
+        }
+      } as ReturnType<typeof createGitCanonicalPublicationInspector>,
+      recover: async () => { throw new Error("no pending operation should recover"); },
+      watermarkPath
+    });
+
+    assert.deepEqual(scanInputs, ["a".repeat(40)]);
+    assert.equal(JSON.parse(readFileSync(watermarkPath, "utf8")).commitSha, "b".repeat(40));
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("recovery watermark remains partial while an indexed operation is unresolved", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-authority-recovery-unsettled-"));
   const watermarkPath = path.join(root, "recovery-watermark.json");
   const record: AuthorityStoredOperationRecord = {
@@ -501,7 +554,10 @@ test("recovery watermark never advances past an unresolved indexed operation", a
       recover: async () => { throw new Error("unanchored operation must not recover"); },
       watermarkPath
     });
-    assert.equal(existsSync(watermarkPath), false);
+    const checkpoint = JSON.parse(readFileSync(watermarkPath, "utf8")) as Record<string, unknown>;
+    assert.equal(checkpoint.schema, "authority-recovery-watermark/v2");
+    assert.equal(checkpoint.phase, "partial");
+    assert.equal(checkpoint.commitSha, "b".repeat(40));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -541,8 +597,15 @@ test("first-parent scanner rejects a watermark that exists only on a side branch
       inspector.scanFirstParentOperationAnchors({ exclusiveCommit: "f".repeat(40), interestedOpIds: new Set() }),
       (error: unknown) => error instanceof AuthorityRecoveryWatermarkInvalidError
     );
-    const valid = await inspector.scanFirstParentOperationAnchors({ exclusiveCommit: base, interestedOpIds: new Set() });
+    const progressCommits: string[] = [];
+    const valid = await inspector.scanFirstParentOperationAnchors({
+      exclusiveCommit: base,
+      interestedOpIds: new Set(),
+      progressBatchSize: 1,
+      onProgress: async (progress) => { progressCommits.push(progress.commitSha); }
+    });
     assert.equal(valid.scannedCommitCount, 1);
+    assert.deepEqual(progressCommits, [valid.headCommit]);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/daemon/src/authority/authority-lifecycle.ts
+++ b/packages/daemon/src/authority/authority-lifecycle.ts
@@ -161,6 +161,8 @@ export interface AuthorityRepoLifecycleController {
   readonly stopAll: (reason: AuthorityRepoStopReason) => Promise<void>;
   readonly component: (repoId: string) => AuthorityRepoComponent | undefined;
   readonly unavailableReason: (repoId: string) => string | undefined;
+  /** Background authority work that must keep an on-demand daemon alive. */
+  readonly hasActiveWork?: () => boolean;
 }
 
 export type AuthorityRepoStartResult =

--- a/packages/daemon/src/authority/production/production-authority-lifecycle.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle.ts
@@ -109,7 +109,7 @@ export function createProductionAuthorityLifecycle(input: {
   const materials = new Map<string, RepoProductionMaterial>();
   const publicationObservers = new Map<string, Parameters<AuthorityRepoLifecycleHooks["start"]>[0]["inspectPublication"]>();
   const hooks = createProductionAuthorityRepoLifecycleHooks({ materials });
-  return createAuthorityRepoLifecycleController({
+  const controller = createAuthorityRepoLifecycleController({
     hooks,
     serviceStateRoot: manifest.serviceStateRoot,
     resolveCompositionData: async (repo, state, runtime) => {
@@ -270,6 +270,10 @@ export function createProductionAuthorityLifecycle(input: {
       };
     }
   });
+  return {
+    ...controller,
+    hasActiveWork: () => [...materials.values()].some((material) => material.recovery.status === "recovering")
+  };
 
   function createProductionAuthorityRepoLifecycleHooks(options: {
     readonly materials: ReadonlyMap<string, RepoProductionMaterial>;

--- a/packages/daemon/src/authority/production/publication-evidence.ts
+++ b/packages/daemon/src/authority/production/publication-evidence.ts
@@ -41,6 +41,8 @@ export interface GitCanonicalPublicationInspector extends CanonicalPublicationIn
   readonly scanFirstParentOperationAnchors: (input: {
     readonly exclusiveCommit?: string;
     readonly interestedOpIds: ReadonlySet<string>;
+    readonly progressBatchSize?: number;
+    readonly onProgress?: (progress: FirstParentOperationAnchorScanProgress) => Promise<void>;
   }) => Promise<FirstParentOperationAnchorScan>;
 }
 
@@ -52,6 +54,13 @@ export interface FirstParentOperationAnchor {
 
 export interface FirstParentOperationAnchorScan {
   readonly headCommit: string | null;
+  readonly scannedCommitCount: number;
+  readonly anchors: ReadonlyArray<FirstParentOperationAnchor>;
+}
+
+export interface FirstParentOperationAnchorScanProgress {
+  /** The newest commit in a fully inspected, oldest-to-newest scan batch. */
+  readonly commitSha: string;
   readonly scannedCommitCount: number;
   readonly anchors: ReadonlyArray<FirstParentOperationAnchor>;
 }
@@ -140,6 +149,8 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
   const scanFirstParentOperationAnchors = async (input: {
     readonly exclusiveCommit?: string;
     readonly interestedOpIds: ReadonlySet<string>;
+    readonly progressBatchSize?: number;
+    readonly onProgress?: (progress: FirstParentOperationAnchorScanProgress) => Promise<void>;
   }): Promise<FirstParentOperationAnchorScan> => {
     const headCommit = await currentHead();
     if (!headCommit) return { headCommit: null, scannedCommitCount: 0, anchors: [] };
@@ -173,16 +184,33 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
         throw new AuthorityRecoveryWatermarkInvalidError(recoveryWatermark);
       }
     }
-    const anchors: FirstParentOperationAnchor[] = [];
-    for (const commitSha of commits) {
-      const parents = (await publicationGitTextAsync(rootDir, "rev-list", "--parents", "-n", "1", commitSha)).split(" ").slice(1);
-      if (parents.length !== 2) continue;
-      const sessionSubject = await publicationGitTextAsync(rootDir, "show", "-s", "--format=%s", parents[1]!);
-      const opIds = commitSubjectOpIds(sessionSubject);
-      if (!opIds.some((opId) => input.interestedOpIds.has(opId))) continue;
-      anchors.push({ commitSha, previousCommit: parents[0]!, opIds });
+    const progressBatchSize = input.progressBatchSize ?? 128;
+    if (!Number.isInteger(progressBatchSize) || progressBatchSize <= 0) {
+      throw new Error("AUTHORITY_RECOVERY_PROGRESS_BATCH_SIZE_INVALID");
     }
-    return { headCommit, scannedCommitCount: commits.length, anchors };
+    const anchors: FirstParentOperationAnchor[] = [];
+    let batchAnchors: FirstParentOperationAnchor[] = [];
+    let scannedCommitCount = 0;
+    // A watermark may advance only from the old boundary toward HEAD. Scanning
+    // oldest-to-newest makes every reported commit a complete prefix.
+    for (const commitSha of [...commits].reverse()) {
+      const parents = (await publicationGitTextAsync(rootDir, "rev-list", "--parents", "-n", "1", commitSha)).split(" ").slice(1);
+      if (parents.length === 2) {
+        const sessionSubject = await publicationGitTextAsync(rootDir, "show", "-s", "--format=%s", parents[1]!);
+        const opIds = commitSubjectOpIds(sessionSubject);
+        if (opIds.some((opId) => input.interestedOpIds.has(opId))) {
+          const anchor = { commitSha, previousCommit: parents[0]!, opIds };
+          anchors.push(anchor);
+          batchAnchors.push(anchor);
+        }
+      }
+      scannedCommitCount += 1;
+      if (input.onProgress && (scannedCommitCount % progressBatchSize === 0 || scannedCommitCount === commits.length)) {
+        await input.onProgress({ commitSha, scannedCommitCount, anchors: batchAnchors });
+        batchAnchors = [];
+      }
+    }
+    return { headCommit, scannedCommitCount, anchors };
   };
   const inspectPublication = async (
     expectedPreviousHead: string | null,

--- a/packages/daemon/src/authority/production/recovery.ts
+++ b/packages/daemon/src/authority/production/recovery.ts
@@ -1,7 +1,7 @@
 // @slice-activation PLT-Boundary W2 exports daemon-owned production authority recovery to CLI composition consumers.
 import { closeSync, fsyncSync, openSync, readFileSync, renameSync, writeSync } from "node:fs";
 import path from "node:path";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type {
   AuthorityCommittedReceipt,
   AuthorityGenerationFence,
@@ -41,30 +41,68 @@ async function recoverIncrementally(input: ProductionRecoveryInput, watermarkPat
   const records = await input.operationRegistry.list(input.workspaceId);
   const pending = records.filter(isRecoverablePendingRecord);
   const interestedOpIds = new Set(pending.map((record) => record.opId));
-  const storedWatermark = readRecoveryWatermark(watermarkPath, input.workspaceId);
-  let scan;
-  try {
-    scan = await input.publicationInspector.scanFirstParentOperationAnchors({
-      ...(storedWatermark ? { exclusiveCommit: storedWatermark } : {}),
-      interestedOpIds
+  const interestedOpIdsDigest = recoveryInterestDigest(interestedOpIds);
+  const storedCheckpoint = readRecoveryWatermark(watermarkPath, input.workspaceId);
+  const resumePartial = storedCheckpoint?.phase === "partial"
+    && storedCheckpoint.interestedOpIdsDigest === interestedOpIdsDigest;
+  const baseCommitSha = storedCheckpoint?.phase === "partial"
+    ? storedCheckpoint.baseCommitSha
+    : storedCheckpoint?.commitSha;
+  const preferredCommitSha = resumePartial ? storedCheckpoint.commitSha : baseCommitSha;
+  const attempts = [...new Set([preferredCommitSha, baseCommitSha, undefined])];
+  let scan: Awaited<ReturnType<GitCanonicalPublicationInspector["scanFirstParentOperationAnchors"]>> | undefined;
+  let retainedAnchors: ReadonlyArray<RecoveryWatermarkAnchor> = [];
+  let retainedBaseCommitSha: string | undefined;
+  for (const exclusiveCommit of attempts) {
+    const priorAnchors = resumePartial && exclusiveCommit === preferredCommitSha
+      ? storedCheckpoint.anchors
+      : [];
+    const progressAnchors = [...priorAnchors];
+    const attemptBaseCommitSha = exclusiveCommit === undefined ? undefined : baseCommitSha;
+    try {
+      scan = await input.publicationInspector.scanFirstParentOperationAnchors({
+        ...(exclusiveCommit ? { exclusiveCommit } : {}),
+        interestedOpIds,
+        onProgress: async (progress) => {
+          progressAnchors.push(...progress.anchors);
+          await persistPartialRecoveryWatermark(input, watermarkPath, {
+            commitSha: progress.commitSha,
+            ...(attemptBaseCommitSha ? { baseCommitSha: attemptBaseCommitSha } : {}),
+            interestedOpIdsDigest,
+            anchors: progressAnchors
+          });
+        }
+      });
+      retainedAnchors = priorAnchors;
+      retainedBaseCommitSha = attemptBaseCommitSha;
+      break;
+    } catch (error) {
+      if (!(error instanceof AuthorityRecoveryWatermarkInvalidError)) throw error;
+    }
+  }
+  if (!scan) throw new Error("AUTHORITY_RECOVERY_SCAN_UNAVAILABLE");
+  const allAnchors = [...retainedAnchors, ...scan.anchors];
+  if (scan.headCommit) {
+    await persistPartialRecoveryWatermark(input, watermarkPath, {
+      commitSha: scan.headCommit,
+      ...(retainedBaseCommitSha ? { baseCommitSha: retainedBaseCommitSha } : {}),
+      interestedOpIdsDigest,
+      anchors: allAnchors
     });
-  } catch (error) {
-    if (!(error instanceof AuthorityRecoveryWatermarkInvalidError)) throw error;
-    scan = await input.publicationInspector.scanFirstParentOperationAnchors({ interestedOpIds });
   }
   const anchorsByOpId = new Map<string, typeof scan.anchors>();
-  for (const anchor of scan.anchors) {
+  for (const anchor of allAnchors) {
     for (const opId of anchor.opIds) {
       if (!interestedOpIds.has(opId)) continue;
       const known = anchorsByOpId.get(opId) ?? [];
       anchorsByOpId.set(opId, [...known, anchor]);
     }
   }
-  const scanOrder = new Map(scan.anchors.map((anchor, index) => [anchor.commitSha, index]));
+  const scanOrder = new Map(allAnchors.map((anchor, index) => [anchor.commitSha, index]));
   const ordered = [...pending].sort((left, right) => {
     const leftIndex = scanOrder.get(anchorsByOpId.get(left.opId)?.[0]?.commitSha ?? "") ?? -1;
     const rightIndex = scanOrder.get(anchorsByOpId.get(right.opId)?.[0]?.commitSha ?? "") ?? -1;
-    return rightIndex - leftIndex || left.opId.localeCompare(right.opId);
+    return leftIndex - rightIndex || left.opId.localeCompare(right.opId);
   });
   for (const record of ordered) {
     const anchors = anchorsByOpId.get(record.opId) ?? [];
@@ -102,7 +140,7 @@ async function recoverIncrementally(input: ProductionRecoveryInput, watermarkPat
       opId: "authority-recovery-watermark"
     }, async () => {
       await assertRecoveryGeneration(input, { workspaceId: input.workspaceId, opId: "authority-recovery-watermark" });
-      writeRecoveryWatermark(watermarkPath, input.workspaceId, headCommit);
+      writeCompleteRecoveryWatermark(watermarkPath, input.workspaceId, headCommit);
     });
   }
 }
@@ -226,27 +264,108 @@ function isUnsettledV2Record(record: AuthorityStoredOperationRecord): boolean {
     && record.state !== "RETRYABLE_NOT_COMMITTED";
 }
 
-function readRecoveryWatermark(filePath: string, workspaceId: string): string | undefined {
+interface RecoveryWatermarkAnchor {
+  readonly commitSha: string;
+  readonly previousCommit: string;
+  readonly opIds: ReadonlyArray<string>;
+}
+
+type RecoveryWatermark =
+  | { readonly phase: "complete"; readonly commitSha: string }
+  | {
+    readonly phase: "partial";
+    readonly commitSha: string;
+    readonly baseCommitSha?: string;
+    readonly interestedOpIdsDigest: string;
+    readonly anchors: ReadonlyArray<RecoveryWatermarkAnchor>;
+  };
+
+function readRecoveryWatermark(filePath: string, workspaceId: string): RecoveryWatermark | undefined {
   try {
     const parsed = JSON.parse(readFileSync(filePath, "utf8")) as Record<string, unknown>;
-    return parsed.schema === "authority-recovery-watermark/v1"
+    if (parsed.schema === "authority-recovery-watermark/v1"
       && parsed.workspaceId === workspaceId
       && typeof parsed.commitSha === "string"
-      && /^[a-f0-9]{40}$/u.test(parsed.commitSha)
-      ? parsed.commitSha
-      : undefined;
+      && isCommitSha(parsed.commitSha)) {
+      return { phase: "complete", commitSha: parsed.commitSha };
+    }
+    if (parsed.schema !== "authority-recovery-watermark/v2"
+      || parsed.workspaceId !== workspaceId
+      || parsed.phase !== "partial"
+      || typeof parsed.commitSha !== "string"
+      || !isCommitSha(parsed.commitSha)
+      || (parsed.baseCommitSha !== undefined && (typeof parsed.baseCommitSha !== "string" || !isCommitSha(parsed.baseCommitSha)))
+      || typeof parsed.interestedOpIdsDigest !== "string"
+      || !/^[a-f0-9]{64}$/u.test(parsed.interestedOpIdsDigest)
+      || !Array.isArray(parsed.anchors)) return undefined;
+    const anchors = parsed.anchors.map(parseRecoveryWatermarkAnchor);
+    if (anchors.some((anchor) => !anchor)) return undefined;
+    return {
+      phase: "partial",
+      commitSha: parsed.commitSha,
+      ...(typeof parsed.baseCommitSha === "string" ? { baseCommitSha: parsed.baseCommitSha } : {}),
+      interestedOpIdsDigest: parsed.interestedOpIdsDigest,
+      anchors: anchors as RecoveryWatermarkAnchor[]
+    };
   } catch {
     return undefined;
   }
 }
 
-function writeRecoveryWatermark(filePath: string, workspaceId: string, commitSha: string): void {
-  const body = `${JSON.stringify({
+function parseRecoveryWatermarkAnchor(value: unknown): RecoveryWatermarkAnchor | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const anchor = value as Record<string, unknown>;
+  return typeof anchor.commitSha === "string"
+    && isCommitSha(anchor.commitSha)
+    && typeof anchor.previousCommit === "string"
+    && isCommitSha(anchor.previousCommit)
+    && Array.isArray(anchor.opIds)
+    && anchor.opIds.every((opId) => typeof opId === "string")
+    ? {
+      commitSha: anchor.commitSha,
+      previousCommit: anchor.previousCommit,
+      opIds: anchor.opIds as string[]
+    }
+    : undefined;
+}
+
+function isCommitSha(value: string): boolean {
+  return /^[a-f0-9]{40}$/u.test(value);
+}
+
+function recoveryInterestDigest(opIds: ReadonlySet<string>): string {
+  return createHash("sha256").update([...opIds].sort().join("\0")).digest("hex");
+}
+
+function persistPartialRecoveryWatermark(
+  input: ProductionRecoveryInput,
+  filePath: string,
+  watermark: Omit<Extract<RecoveryWatermark, { readonly phase: "partial" }>, "phase">
+): Promise<void> {
+  return runTerminalRecovery(input, {
+    workspaceId: input.workspaceId,
+    opId: "authority-recovery-watermark"
+  }, async () => {
+    await assertRecoveryGeneration(input, { workspaceId: input.workspaceId, opId: "authority-recovery-watermark" });
+    writeRecoveryWatermark(filePath, {
+      schema: "authority-recovery-watermark/v2",
+      phase: "partial",
+      workspaceId: input.workspaceId,
+      ...watermark
+    });
+  });
+}
+
+function writeCompleteRecoveryWatermark(filePath: string, workspaceId: string, commitSha: string): void {
+  writeRecoveryWatermark(filePath, {
     schema: "authority-recovery-watermark/v1",
     workspaceId,
-    commitSha,
-    scannedAt: new Date().toISOString()
-  })}\n`;
+    commitSha
+  });
+}
+
+function writeRecoveryWatermark(filePath: string, watermark: Record<string, unknown>): void {
+  const body = `${JSON.stringify({ ...watermark, scannedAt: new Date().toISOString() })}\n`;
   const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
   const file = openSync(temporaryPath, "wx", 0o600);
   try {

--- a/packages/daemon/src/service/idle-exit-scheduler.ts
+++ b/packages/daemon/src/service/idle-exit-scheduler.ts
@@ -4,15 +4,15 @@ export function createDaemonIdleExitScheduler(input: {
   readonly activeConnections: () => number;
   readonly hasActiveWork: () => boolean;
   readonly requestIdleStop: () => void;
-}): { readonly schedule: () => void; readonly cancel: () => void } {
+}): { readonly schedule: () => void; readonly disarm: () => void } {
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const cancel = () => {
+  const disarm = () => {
     if (timer) clearTimeout(timer);
     timer = undefined;
   };
   const schedule = () => {
     if (input.idleMs <= 0 || input.isStopping() || input.activeConnections() !== 0) return;
-    cancel();
+    disarm();
     timer = setTimeout(() => {
       timer = undefined;
       if (input.hasActiveWork()) {
@@ -23,5 +23,5 @@ export function createDaemonIdleExitScheduler(input: {
     }, input.idleMs);
     timer.unref();
   };
-  return { schedule, cancel };
+  return { schedule, disarm };
 }

--- a/packages/daemon/src/service/idle-exit-scheduler.ts
+++ b/packages/daemon/src/service/idle-exit-scheduler.ts
@@ -1,0 +1,27 @@
+export function createDaemonIdleExitScheduler(input: {
+  readonly idleMs: number;
+  readonly isStopping: () => boolean;
+  readonly activeConnections: () => number;
+  readonly hasActiveWork: () => boolean;
+  readonly requestIdleStop: () => void;
+}): { readonly schedule: () => void; readonly cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const cancel = () => {
+    if (timer) clearTimeout(timer);
+    timer = undefined;
+  };
+  const schedule = () => {
+    if (input.idleMs <= 0 || input.isStopping() || input.activeConnections() !== 0) return;
+    cancel();
+    timer = setTimeout(() => {
+      timer = undefined;
+      if (input.hasActiveWork()) {
+        schedule();
+        return;
+      }
+      input.requestIdleStop();
+    }, input.idleMs);
+    timer.unref();
+  };
+  return { schedule, cancel };
+}

--- a/packages/daemon/src/service/service-host.ts
+++ b/packages/daemon/src/service/service-host.ts
@@ -135,7 +135,7 @@ export async function createDaemonServiceHost<
   const stop = async () => {
     if (stopping) return;
     stopping = true;
-    idleExit.cancel();
+    idleExit.disarm();
     if (reconcileTimer) clearInterval(reconcileTimer);
     try {
       await drainDaemonRuntime({
@@ -167,7 +167,7 @@ export async function createDaemonServiceHost<
       if (activeControl) {
         throw new Error(`DAEMON_DRAINING_ADMISSION_CLOSED: daemon ${activeControl.kind} operation ${activeControl.operationId} is draining. Run \`ha daemon status --json\` and wait for it to complete or report its timeout before retrying.`);
       }
-      idleExit.cancel();
+      idleExit.disarm();
     },
     onCommandSettled: scheduleIdleExit
   };
@@ -247,7 +247,7 @@ export async function createDaemonServiceHost<
     }),
     status: () => serviceStatus(defaultRepoBinding().repo.repoId),
     requestControl: controlService.requestControl,
-    onConnectionStart: idleExit.cancel,
+    onConnectionStart: idleExit.disarm,
     onConnectionSettled: scheduleIdleExit,
     scheduleIdleExit,
     waitForStopRequest: () => stopRequested,

--- a/packages/daemon/src/service/service-host.ts
+++ b/packages/daemon/src/service/service-host.ts
@@ -41,6 +41,7 @@ import { createAuthorityWireIngressHandler } from "../authority/authority-wire-s
 import { requireAuthoritySubmissionForDispatch } from "../authority/authority-submission-dispatch.ts";
 import { daemonStatusPayload, type DaemonConnectionStats } from "./status-payload.ts";
 import { projectDaemonLaunchConfiguration } from "../client/local-json-rpc-client.ts";
+import { createDaemonIdleExitScheduler } from "./idle-exit-scheduler.ts";
 
 export type DaemonServiceStopRequest =
   | { readonly reason: "idle-timeout" }
@@ -119,16 +120,22 @@ export async function createDaemonServiceHost<
   const stopRequested = new Promise<DaemonServiceStopRequest>((resolve) => {
     requestStop = resolve;
   });
-  let idleTimer: ReturnType<typeof setTimeout> | undefined;
   let reconcileTimer: ReturnType<typeof setInterval> | undefined;
   let reconciling = false;
   let stopping = false;
   let drainTimeoutMs: number | undefined;
   let activeControl: DaemonActiveControlStatus | null = null;
+  const idleExit = createDaemonIdleExitScheduler({
+    idleMs,
+    isStopping: () => stopping,
+    activeConnections: () => connections.active,
+    hasActiveWork: () => authorityLifecycle?.hasActiveWork?.() ?? false,
+    requestIdleStop: () => requestStop?.({ reason: "idle-timeout" })
+  });
   const stop = async () => {
     if (stopping) return;
     stopping = true;
-    if (idleTimer) clearTimeout(idleTimer);
+    idleExit.cancel();
     if (reconcileTimer) clearInterval(reconcileTimer);
     try {
       await drainDaemonRuntime({
@@ -154,20 +161,13 @@ export async function createDaemonServiceHost<
       await handler();
     }
   };
-  const scheduleIdleExit = () => {
-    if (idleMs <= 0 || stopping || connections.active !== 0) return;
-    if (idleTimer) clearTimeout(idleTimer);
-    idleTimer = setTimeout(() => {
-      requestStop?.({ reason: "idle-timeout" });
-    }, idleMs);
-    idleTimer.unref();
-  };
+  const scheduleIdleExit = idleExit.schedule;
   const commandOptions = {
     onCommandStart: () => {
       if (activeControl) {
         throw new Error(`DAEMON_DRAINING_ADMISSION_CLOSED: daemon ${activeControl.kind} operation ${activeControl.operationId} is draining. Run \`ha daemon status --json\` and wait for it to complete or report its timeout before retrying.`);
       }
-      if (idleTimer) clearTimeout(idleTimer);
+      idleExit.cancel();
     },
     onCommandSettled: scheduleIdleExit
   };
@@ -247,10 +247,7 @@ export async function createDaemonServiceHost<
     }),
     status: () => serviceStatus(defaultRepoBinding().repo.repoId),
     requestControl: controlService.requestControl,
-    onConnectionStart: () => {
-      if (idleTimer) clearTimeout(idleTimer);
-      idleTimer = undefined;
-    },
+    onConnectionStart: idleExit.cancel,
     onConnectionSettled: scheduleIdleExit,
     scheduleIdleExit,
     waitForStopRequest: () => stopRequested,

--- a/packages/daemon/test/fixtures/recovery-watermark-kill-target.ts
+++ b/packages/daemon/test/fixtures/recovery-watermark-kill-target.ts
@@ -1,0 +1,45 @@
+import { writeFileSync } from "node:fs";
+import { recoverPendingProductionEvents } from "../../src/authority/production/recovery.ts";
+import type { GitCanonicalPublicationInspector } from "../../src/authority/production/publication-evidence.ts";
+
+const [watermarkPath, readyPath] = process.argv.slice(2);
+if (!watermarkPath || !readyPath) throw new Error("recovery watermark kill fixture requires watermark and ready paths");
+let generationFenceHeld = false;
+
+const keepAlive = setInterval(() => undefined, 1_000);
+await recoverPendingProductionEvents({
+  workspaceId: "workspace-production",
+  operationRegistry: {
+    get: async () => undefined,
+    list: async () => [],
+    put: async () => undefined
+  },
+  replicaChangeLog: {} as never,
+  eventLog: {} as never,
+  publicationInspector: {
+    scanFirstParentOperationAnchors: async ({ onProgress }) => {
+      await onProgress?.({
+        commitSha: "a".repeat(40),
+        scannedCommitCount: 128,
+        anchors: []
+      });
+      writeFileSync(readyPath, "ready\n");
+      await new Promise<never>(() => undefined);
+    }
+  } as GitCanonicalPublicationInspector,
+  recover: async () => { throw new Error("fixture has no pending operations"); },
+  generationFence: {
+    assertHeld: async () => {
+      if (!generationFenceHeld) throw new Error("incremental watermark write escaped its generation fence");
+    },
+    runExclusive: async (_stage, _identity, operation) => {
+      generationFenceHeld = true;
+      try {
+        return await operation();
+      } finally {
+        generationFenceHeld = false;
+      }
+    }
+  },
+  watermarkPath
+}).finally(() => clearInterval(keepAlive));

--- a/packages/daemon/test/idle-exit-scheduler.test.ts
+++ b/packages/daemon/test/idle-exit-scheduler.test.ts
@@ -24,6 +24,6 @@ test("background authority recovery keeps an idle daemon alive until recovery se
     while (idleStops === 0 && Date.now() < deadline) await delay(5);
     assert.equal(idleStops, 1);
   } finally {
-    scheduler.cancel();
+    scheduler.disarm();
   }
 });

--- a/packages/daemon/test/idle-exit-scheduler.test.ts
+++ b/packages/daemon/test/idle-exit-scheduler.test.ts
@@ -1,0 +1,29 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { createDaemonIdleExitScheduler } from "../src/service/idle-exit-scheduler.ts";
+
+test("background authority recovery keeps an idle daemon alive until recovery settles", async () => {
+  let recovering = true;
+  let idleStops = 0;
+  const scheduler = createDaemonIdleExitScheduler({
+    idleMs: 25,
+    isStopping: () => false,
+    activeConnections: () => 0,
+    hasActiveWork: () => recovering,
+    requestIdleStop: () => { idleStops += 1; }
+  });
+  try {
+    scheduler.schedule();
+    await delay(90);
+    assert.equal(idleStops, 0);
+
+    recovering = false;
+    const deadline = Date.now() + 250;
+    while (idleStops === 0 && Date.now() < deadline) await delay(5);
+    assert.equal(idleStops, 1);
+  } finally {
+    scheduler.cancel();
+  }
+});


### PR DESCRIPTION
# English

## Summary

Two liveness defects turned authority recovery into a Sisyphus loop on on-demand daemons: (1) the idle timeout (~35s) evicted the daemon while background authority recovery (a full first-parent history scan taking >35s) was still running; (2) the recovery watermark was only persisted after the scan completed, so a mid-scan death restarted from zero. Together they made the write path report `AUTHORITY_RECOVERY_IN_PROGRESS` forever. This PR makes recovery count as active work for the idle scheduler and checkpoints the scan incrementally.

## What Changed

- `idle-exit-scheduler.ts` (new): extracted idle timer; when the timer fires and `hasActiveWork()` is true, a new idle window is re-armed instead of requesting `idle-timeout`. `service-host.ts` feeds connections, commands, and authority background liveness into it.
- `authority-lifecycle.ts` / `production-authority-lifecycle.ts`: lifecycle exposes an optional read-only `hasActiveWork()`; production reports active while any repo's recovery is `recovering`.
- `publication-evidence.ts`: the first-parent scan now walks oldest-to-newest and reports safe commit boundaries with each batch's anchors every 128 full commits (trailing partial batch included).
- `recovery.ts`: new `authority-recovery-watermark/v2` partial checkpoint — commit boundary, accumulated anchors, previous complete watermark, and pending-op-set digest persisted atomically (fsync+rename, one file, no half-watermark). Restart resumes from the partial only when the digest matches; otherwise falls back to the last complete watermark, then to a full scan. All writes stay inside the `runTerminalRecovery` + `assertRecoveryGeneration` generation fence; the v2 partial is replaced by the existing v1 complete form only after every op reaches a terminal state.
- Tests: real two-process SIGKILL resume test (child hangs after its first fenced checkpoint, parent kills it, restart proves the scan continues from the checkpoint) plus idle-keepalive regression (daemon survives ~3.6 idle windows during recovery, exits normally afterwards).

## Task And Scope

- Task: `task_01KY2R5RREQ5DBGT7B4R09NWMB`, derived from decision `dec_01KY2PJRGWXEJDH3E622553HZK` (CH3, deliverable 4: "keepalive during recovery; incremental recovery watermark").
- Scope: daemon idle/liveness scheduling and recovery checkpoint persistence. Deferred-op handling, fail-closed branches, and terminal-recovery semantics are untouched.

## Version Impact

No package version bump. Runtime behavior: on-demand daemons no longer die mid-recovery, and interrupted recoveries resume instead of rescanning from zero.

## Governance Declaration

This changes daemon production-authority recovery persistence, a production write-road surface. Authority: decision `dec_01KY2PJRGWXEJDH3E622553HZK` (accepted), whose deliverable 4 mandates exactly these two fixes; ledger task `task_01KY2R5RREQ5DBGT7B4R09NWMB` tracks the work. The S1 generation-fence semantics (#966/#970/#973/#982) are preserved — every watermark write remains inside the fence; no gate or manifest is modified.

## Verification

- Targeted regressions: `production-authority-event-recovery` + `idle-exit-scheduler` → 11/11; `authority-lifecycle-seam` → 13/13 (repo runner fixture preload + `--test-force-exit`).
- `tsc -b` daemon+cli, eslint on touched files, file-complexity gate, import-boundary gate (`current=16 previous=16 delta=0`), `git diff --check` all pass.

## Review Evidence

Worker report with full mechanism notes, runner transcripts, and both negative controls (removing keepalive → eviction at first idle window; removing incremental checkpoint → `ENOENT recovery-watermark.json` after SIGKILL): `harness/tasks/task_01KY2R5RREQ5DBGT7B4R09NWMB-daemon-idle/artifacts/worker-report.md` (ledger-side, not in this diff).

## Residual Risk

Checkpoint batch size is fixed at 128 commits (durability vs rescan-bound tradeoff, no new config surface). Partial checkpoint JSON grows with the current round's pending-op anchors only. No production-scale fsync-throughput measurement yet; Windows atomic-write branch semantics unchanged but not exercised on real Windows SIGKILL.

## References

- Decision: `dec_01KY2PJRGWXEJDH3E622553HZK`; task package: `harness/tasks/task_01KY2R5RREQ5DBGT7B4R09NWMB-daemon-idle/`.

---

# 中文

## 概要

两个活性缺陷把按需 daemon 的 authority 恢复变成西西弗斯循环:(1) idle 超时(~35 秒)在后台恢复(全历史首父扫描,>35 秒)完成前清退进程;(2) 恢复水位线只在整扫结束后落盘,中途死亡=下次从零再扫。两者叠加让写路永久报 `AUTHORITY_RECOVERY_IN_PROGRESS`。本 PR 让恢复计入 idle 活跃工作,并把扫描改为增量 checkpoint。

## 改动内容

- `idle-exit-scheduler.ts`(新):抽出 idle 计时器;到点时若 `hasActiveWork()` 为真则续一个 idle 窗口,否则才请求 `idle-timeout`。`service-host.ts` 把连接、命令与 authority 后台活性统一接入。
- `authority-lifecycle.ts` / `production-authority-lifecycle.ts`:lifecycle 暴露可选只读 `hasActiveWork()`;production 以任一仓库 recovery=`recovering` 记为活跃。
- `publication-evidence.ts`:首父扫描改为 oldest-to-newest,每 128 个完整 commit(尾批不足也回调)报告安全 commit 边界与该批 anchors。
- `recovery.ts`:新增 `authority-recovery-watermark/v2` partial checkpoint——commit 边界、累计 anchors、上一完整水位线、pending-op 集合 digest 单文件原子落盘(fsync+rename,无半格水位)。重启仅在 digest 一致时续用 partial,失配回退上一完整水位线,再退全扫。全部写入留在 `runTerminalRecovery` + `assertRecoveryGeneration` 的 generation fence 内;所有 op terminal 后才把 v2 partial 替换为既有 v1 complete。
- 测试:真实双进程 SIGKILL 续扫(子进程首个 fenced checkpoint 后挂起,父进程 kill,重启断言从 checkpoint 续扫)+ idle 续命回归(恢复期跨过约 3.6 个 idle 窗口不退出,恢复结束后正常退出)。

## 任务与范围

- 任务:`task_01KY2R5RREQ5DBGT7B4R09NWMB`,由决策 `dec_01KY2PJRGWXEJDH3E622553HZK`(CH3/落地件 4:恢复期续命+水位线增量落盘)派生。
- 范围:daemon idle/活性调度与恢复 checkpoint 持久化。deferred op、fail-closed、terminal recovery 语义未动。

## 版本影响

无包版本变更。运行时行为:按需 daemon 不再死于恢复中途;被打断的恢复续扫而非从零重扫。

## 治理声明

本 PR 改动 daemon 生产 authority 恢复持久化,属生产写路面。授权依据:已 accept 的决策 `dec_01KY2PJRGWXEJDH3E622553HZK`,其落地件 4 明确要求这两项修复;台账任务 `task_01KY2R5RREQ5DBGT7B4R09NWMB` 跟踪本工作。S1 generation fence 语义(#966/#970/#973/#982)完整保留——所有水位线写入都在围栏内;未修改任何 gate 或 manifest。

## 验证

- 定向回归:`production-authority-event-recovery` + `idle-exit-scheduler` 11/11;`authority-lifecycle-seam` 13/13(仓库 runner fixture preload + `--test-force-exit`)。
- `tsc -b` daemon+cli、改动文件 eslint、file-complexity 门、import-boundary 门(`current=16 previous=16 delta=0`)、`git diff --check` 全过。

## 审查证据

worker 报告含完整机制说明、runner 输出与两条阴性对照(去续命→首个 idle 窗口即清退;去增量落盘→SIGKILL 后 `ENOENT recovery-watermark.json`):`harness/tasks/task_01KY2R5RREQ5DBGT7B4R09NWMB-daemon-idle/artifacts/worker-report.md`(台账侧,不在本 diff 内)。

## 残余风险

checkpoint 批大小固定 128 commits(耐久 fsync 频率与重扫上限的折中,未新增配置面)。partial JSON 只随本轮 pending anchors 增长。未做生产规模 fsync 吞吐测量;Windows 原子写分支语义未动但未在真机 SIGKILL 验证。

## 关联材料

- 决策:`dec_01KY2PJRGWXEJDH3E622553HZK`;任务包:`harness/tasks/task_01KY2R5RREQ5DBGT7B4R09NWMB-daemon-idle/`。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Targeted tests green / 定向测试全绿
- [x] Protected-surface change declared with decision authority / protected surface 改动已带决策授权申报
