### PR TITLE
fix(cli): remove daemon dependency from meta commands and the cold-start exit tail

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,3 +21,20 @@ harness-anything doctor --json
 harness-anything status --json
 harness-anything check --post-merge --json
 ```
+
+## CLI timing diagnostics
+
+Set `HA_TIMING=1` to emit one `ha-cli-timing/v1` record on stderr when the
+process exits. The record separates process startup, module loading, parsing,
+daemon configuration and target resolution, connection, daemon launch plus
+authority readiness, command execution, and any event-loop exit wait. Normal
+command output remains unchanged on stdout.
+
+```bash
+HA_TIMING=1 ha task show task_01ABC --json
+```
+
+Cold daemon startup also prints progress on stderr so an invocation does not
+remain silent while authority readiness is pending. Set `HA_PROGRESS=0` only
+when a caller deliberately suppresses those human-readable progress messages;
+it does not change daemon or authority behavior.

--- a/packages/cli/src/cli/timing.ts
+++ b/packages/cli/src/cli/timing.ts
@@ -1,0 +1,88 @@
+import { performance } from "node:perf_hooks";
+
+export type CliTimingPhase =
+  | "module_load"
+  | "cli_command"
+  | "parse"
+  | "daemon_config"
+  | "daemon_target"
+  | "daemon_connect"
+  | "daemon_launch_authority_ready"
+  | "command_execute"
+  | "process_exit_wait";
+
+interface CliTimingState {
+  readonly processStartMs: number;
+  readonly phasesMs: Partial<Record<CliTimingPhase, number>>;
+  activeResourcesAfterCommand?: ReadonlyArray<string>;
+  activeHandlesAfterCommand?: ReadonlyArray<Record<string, unknown>>;
+}
+
+const state: CliTimingState = {
+  processStartMs: performance.now(),
+  phasesMs: {}
+};
+
+export function startCliTimingPhase(phase: CliTimingPhase): () => void {
+  const startedAt = performance.now();
+  let finished = false;
+  return () => {
+    if (finished) return;
+    finished = true;
+    state.phasesMs[phase] = (state.phasesMs[phase] ?? 0) + performance.now() - startedAt;
+  };
+}
+
+export function emitCliTimingOnExit(exitCode: number): void {
+  if (process.env.HA_TIMING !== "1") return;
+  state.activeResourcesAfterCommand = process.getActiveResourcesInfo();
+  state.activeHandlesAfterCommand = activeHandleSummaries();
+  const finishExitWait = startCliTimingPhase("process_exit_wait");
+  process.once("beforeExit", () => {
+    finishExitWait();
+    emitCliTiming(exitCode);
+  });
+}
+
+function emitCliTiming(exitCode: number): void {
+  const roundedPhases = Object.fromEntries(
+    Object.entries(state.phasesMs).map(([phase, elapsed]) => [phase, round(elapsed)])
+  );
+  console.error(`[ha timing] ${JSON.stringify({
+    schema: "ha-cli-timing/v1",
+    pid: process.pid,
+    exitCode,
+    phasesMs: {
+      process_start: round(state.processStartMs),
+      ...roundedPhases
+    },
+    activeResourcesAfterCommand: state.activeResourcesAfterCommand,
+    activeHandlesAfterCommand: state.activeHandlesAfterCommand,
+    totalMs: round(performance.now())
+  })}`);
+}
+
+function activeHandleSummaries(): ReadonlyArray<Record<string, unknown>> {
+  const getActiveHandles = (process as unknown as { readonly _getActiveHandles?: () => ReadonlyArray<unknown> })._getActiveHandles;
+  if (!getActiveHandles) return [];
+  return getActiveHandles.call(process).map((handle) => {
+    const candidate = handle as {
+      readonly constructor?: { readonly name?: string };
+      readonly fd?: unknown;
+      readonly destroyed?: unknown;
+      readonly readable?: unknown;
+      readonly writable?: unknown;
+    };
+    return {
+      type: candidate.constructor?.name ?? "unknown",
+      ...(typeof candidate.fd === "number" ? { fd: candidate.fd } : {}),
+      ...(typeof candidate.destroyed === "boolean" ? { destroyed: candidate.destroyed } : {}),
+      ...(typeof candidate.readable === "boolean" ? { readable: candidate.readable } : {}),
+      ...(typeof candidate.writable === "boolean" ? { writable: candidate.writable } : {})
+    };
+  });
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -21,6 +21,7 @@ import {
   requestLocalDaemonJsonRpcForTarget,
   resolveLocalDaemonTarget as resolveDaemonTarget,
   type JsonObject,
+  type LocalDaemonAutostartPhase,
   type LocalDaemonTarget
 } from "@harness-anything/daemon";
 import {
@@ -42,6 +43,7 @@ import { resolveManagedSectionPolicy } from "../commands/extensions/managed-sect
 const docSyncHostServices = { resolveManagedSectionPolicy };
 import { readProjectHarnessSettings } from "../commands/settings.ts";
 import { isDeclaredLocalMigrationCommand } from "../composition/local-write-scope.ts";
+import { startCliTimingPhase, type CliTimingPhase } from "../cli/timing.ts";
 
 export {
   daemonIdForRoot,
@@ -175,10 +177,13 @@ export async function runCommandThroughDaemon(
   command: ParsedCommand,
   config?: DaemonClientConfig
 ): Promise<CommandReceipt | CommandFailureReceipt | undefined> {
+  const finishConfig = startCliTimingPhase("daemon_config");
   try {
     config ??= readDaemonClientConfig(process.env, command.rootDir, command.daemonModeOverride, command.daemonProfileOverride, command.layoutOverrides);
   } catch (error) {
     return daemonUnavailableReceipt(command, error);
+  } finally {
+    finishConfig();
   }
   if (config.mode !== "remote" && command.action.kind === "init" && !isInitializedHarness(command)) return undefined;
   if (config.mode !== "remote" && isDeclaredLocalMigrationCommand(command.action)) return undefined;
@@ -188,7 +193,7 @@ export async function runCommandThroughDaemon(
   }
   try {
     return config.mode === "remote" && config.remote
-      ? await runRemoteCommand(command, config.remote)
+      ? await runTimedRemoteCommand(command, config.remote)
       : await runLocalCommand(command, config);
   } catch (error) {
     if (command.action.kind === "materializer-run" && config.mode === "local" && !(error instanceof DaemonJsonRpcResponseError)) {
@@ -205,6 +210,7 @@ export async function runCommandThroughDaemon(
 }
 
 async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfig): Promise<CommandReceipt | CommandFailureReceipt> {
+  const finishTarget = startCliTimingPhase("daemon_target");
   command = commandForCanonicalHarness(command);
   const target = resolveLocalDaemonTarget({
     rootDir: command.rootDir,
@@ -214,55 +220,98 @@ async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfi
     autoRegisterSingleRepo: true,
     layoutOverrides: command.layoutOverrides
   });
-  if (isDocSyncSubmitCommand(command)) {
-    let request: ReturnType<typeof buildDocSyncSubmitRequest>;
-    try {
-      request = buildDocSyncSubmitRequest(
-        { rootDir: command.rootDir, layoutOverrides: command.layoutOverrides },
-        target.repoId,
-        docSyncSubmitPaths(command),
-        commandExecutor(command),
-        docSyncHostServices
-      );
-    } catch (error) {
-      return docSyncSubmitPreviewRejected(error);
+  finishTarget();
+  const timing = daemonTimingObserver();
+  const autostart = daemonAutostartOptions(command, config, timing.observe);
+  try {
+    if (isDocSyncSubmitCommand(command)) {
+      let request: ReturnType<typeof buildDocSyncSubmitRequest>;
+      try {
+        request = buildDocSyncSubmitRequest(
+          { rootDir: command.rootDir, layoutOverrides: command.layoutOverrides },
+          target.repoId,
+          docSyncSubmitPaths(command),
+          commandExecutor(command),
+          docSyncHostServices
+        );
+      } catch (error) {
+        return docSyncSubmitPreviewRejected(error);
+      }
+      const response = await requestLocalDaemonJsonRpcForTarget(target, "repo.doc.sync.submit", request as unknown as JsonObject, 200, autostart);
+      if (isCommandReceipt(response)) return normalizeDocSyncSubmitReceipt(response);
+      throw new Error("repo.doc.sync.submit did not return command-receipt/v2");
     }
-    const response = await requestLocalDaemonJsonRpcForTarget(target, "repo.doc.sync.submit", request as unknown as JsonObject, 200, {
-      entryPath: daemonClientCliEntrypointPath(),
-      idleExitMs: config.idleExitMs,
-      timeoutMs: config.autostartTimeoutMs,
-      layoutOverrides: command.layoutOverrides
-    });
-    if (isCommandReceipt(response)) return normalizeDocSyncSubmitReceipt(response);
-    throw new Error("repo.doc.sync.submit did not return command-receipt/v2");
-  }
-  if (isTaskHolderCommand(command)) {
-    const response = await requestLocalDaemonJsonRpcForTarget(target, taskHolderMethod(command), {
+    if (isTaskHolderCommand(command)) {
+      const response = await requestLocalDaemonJsonRpcForTarget(target, taskHolderMethod(command), {
+        repo: { repoId: target.repoId },
+        payload: taskHolderPayload(command)
+      }, 200, autostart);
+      if (isCommandReceipt(response)) return normalizeTaskHolderReceipt(response, command.action.kind);
+      throw new Error(`${taskHolderMethod(command)} did not return command-receipt/v2`);
+    }
+    const response = await requestLocalDaemonJsonRpcForTarget(target, "repo.command.run", {
       repo: { repoId: target.repoId },
-      payload: taskHolderPayload(command)
-    }, 200, {
-      entryPath: daemonClientCliEntrypointPath(),
-      idleExitMs: config.idleExitMs,
-      timeoutMs: config.autostartTimeoutMs,
-      layoutOverrides: command.layoutOverrides
-    });
-    if (isCommandReceipt(response)) return normalizeTaskHolderReceipt(response, command.action.kind);
-    throw new Error(`${taskHolderMethod(command)} did not return command-receipt/v2`);
+      payload: commandRunPayload(
+        commandForTarget(command, target),
+        Effect.runSync(makeEnvironmentCurrentSessionProbe().currentSession)
+      )
+    }, 200, command.action.kind === "materializer-run" ? undefined : autostart);
+    if (isCommandReceipt(response)) return response as unknown as CommandReceipt | CommandFailureReceipt;
+    throw new Error("daemon command.run did not return command-receipt/v2");
+  } finally {
+    timing.finish();
   }
-  const response = await requestLocalDaemonJsonRpcForTarget(target, "repo.command.run", {
-    repo: { repoId: target.repoId },
-    payload: commandRunPayload(
-      commandForTarget(command, target),
-      Effect.runSync(makeEnvironmentCurrentSessionProbe().currentSession)
-    )
-  }, 200, command.action.kind === "materializer-run" ? undefined : {
+}
+
+function daemonAutostartOptions(
+  command: ParsedCommand,
+  config: DaemonClientConfig,
+  onPhase: (phase: LocalDaemonAutostartPhase) => void
+) {
+  return {
     entryPath: daemonClientCliEntrypointPath(),
     idleExitMs: config.idleExitMs,
     timeoutMs: config.autostartTimeoutMs,
-    layoutOverrides: command.layoutOverrides
-  });
-  if (isCommandReceipt(response)) return response as unknown as CommandReceipt | CommandFailureReceipt;
-  throw new Error("daemon command.run did not return command-receipt/v2");
+    layoutOverrides: command.layoutOverrides,
+    onPhase
+  };
+}
+
+function daemonTimingObserver(): {
+  readonly observe: (event: LocalDaemonAutostartPhase) => void;
+  readonly finish: () => void;
+} {
+  let finishPhase: (() => void) | undefined;
+  let launchReported = false;
+  const transition = (phase?: CliTimingPhase) => {
+    finishPhase?.();
+    finishPhase = phase ? startCliTimingPhase(phase) : undefined;
+  };
+  return {
+    observe: (event) => {
+      if (event === "connect-start") transition("daemon_connect");
+      if (event === "launch-start") {
+        transition("daemon_launch_authority_ready");
+        if (!launchReported && process.env.HA_PROGRESS !== "0") {
+          launchReported = true;
+          console.error("[ha] Starting local daemon; waiting for authority readiness.");
+        }
+      }
+      if (event === "ready") transition();
+      if (event === "request-start") transition("command_execute");
+      if (event === "request-end") transition();
+    },
+    finish: () => transition()
+  };
+}
+
+async function runTimedRemoteCommand(command: ParsedCommand, remote: RemoteDaemonConfig): Promise<CommandReceipt | CommandFailureReceipt> {
+  const finish = startCliTimingPhase("command_execute");
+  try {
+    return await runRemoteCommand(command, remote);
+  } finally {
+    finish();
+  }
 }
 
 async function runRemoteCommand(command: ParsedCommand, remote: RemoteDaemonConfig): Promise<CommandReceipt | CommandFailureReceipt> {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,317 +2,15 @@
 
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { parseArgs } from "./cli/parse-args.ts";
-import { deprecationWarning } from "./cli/command-deprecations.ts";
-import { readOption, stripGlobalOptions } from "./cli/parse-options.ts";
-import { appendParseFailureRuntimeEvent } from "./cli/parse-failure-runtime-event.ts";
-import {
-  checkDaemonServeConfiguration as checkDaemonServeConfigurationRoot,
-  runDaemonServe as runDaemonServeRoot
-} from "@harness-anything/daemon";
-import { runCompoundReceiptExitCommand } from "./receipt/compound-exit-command.ts";
-import { receiptDetailsData, renderReceiptText, toCommandReceipt, type CommandFailureReceipt, type CommandReceipt } from "./cli/receipt.ts";
-import type { CommandRegistryEntry } from "./cli/types.ts";
-import { globalCommandOptions } from "./cli/command-spec/command-groups.ts";
-import { parsePositiveIntegerOr } from "./cli/value-utils.ts";
-import {
-  runDaemonProductCommand,
-  type DaemonServeHooks
-} from "./commands/daemon/productization.ts";
-import { daemonStatusCliProjection } from "./commands/daemon/status-payload.ts";
-import { runDaemonConnect } from "./commands/daemon/connect.ts";
-import { runRegisteredCommandWithCliComposition } from "./composition/command-executor.ts";
-import { daemonIdFromEnv, daemonUserRoot, localUserDaemonEndpoint, runCommandThroughDaemon } from "./daemon/client.ts";
-import {
-  parseDaemonLaunchArgv,
-  preflightDaemonLaunch,
-  resolveCompleteDaemonLaunchSpec,
-  resolveDaemonLaunchSpec,
-  type ParsedDaemonLaunchArgv
-} from "./daemon/daemon-launch-spec.ts";
-import { daemonRuntimeLayoutOverrides } from "./daemon/daemon-serve-launch-options.ts";
-import {
-  createCliProductionAuthorityLifecycle as createProductionAuthorityLifecycle
-} from "./composition/production-authority-lifecycle.ts";
-import { runAgentRuntimeCommand } from "./commands/agent-runtime.ts";
-import { runTaskSubmitFacade } from "./commands/core/task-submit-facade.ts";
-import { runTaskCloseoutFacade, runTaskStartFacade } from "./commands/core/task-lifecycle-facade.ts";
-import { isDeclaredLocalMigrationCommand } from "./composition/local-write-scope.ts";
+import { emitCliTimingOnExit, startCliTimingPhase } from "./cli/timing.ts";
 
-const runRegisteredCommand = runRegisteredCommandWithCliComposition;
-type ParsedCommandRunner = (command: Parameters<typeof runRegisteredCommand>[0]) => Promise<CommandReceipt | CommandFailureReceipt>;
-const cliTestFixtureRunnerSymbol = Symbol.for("harness-anything.cli-test-fixture-runner");
+const finishModuleLoad = startCliTimingPhase("module_load");
+const slowLoadNotice = progressNotice("Loading CLI modules");
+const { main } = await import("./main.ts");
+clearTimeout(slowLoadNotice);
+finishModuleLoad();
 
-export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)): Promise<number> {
-  const compoundExit = await runCompoundReceiptExitCommand(argv);
-  if (compoundExit !== undefined) return compoundExit;
-  const daemonOverrides = stripGlobalOptions(argv);
-  if (daemonOverrides.daemonMode) process.env.HARNESS_DAEMON_MODE = daemonOverrides.daemonMode;
-  if (daemonOverrides.daemonProfile) process.env.HARNESS_DAEMON_PROFILE = daemonOverrides.daemonProfile;
-  const daemonExit = await maybeRunDaemonCommand(argv);
-  if (daemonExit !== undefined) return daemonExit;
-  const agentExit = await maybeRunAgentRuntimeCommand(argv);
-  if (agentExit !== undefined) return agentExit;
-
-  const parsed = parseArgs(argv);
-  if (!parsed.ok) {
-    await appendParseFailureRuntimeEvent(argv, parsed.error);
-    emit(toCommandReceipt({ ok: false, command: "parse", error: parsed.error }), true);
-    return 2;
-  }
-
-  if (parsed.value.deprecatedInvocation) console.error(deprecationWarning(parsed.value.deprecatedInvocation));
-
-  const output = parsed.value.action.kind === "task-submit"
-    ? await runTaskSubmitFacade(parsed.value, runParsedCommand)
-    : parsed.value.action.kind === "task-start"
-      ? await runTaskStartFacade(parsed.value, runParsedCommand)
-      : parsed.value.action.kind === "task-closeout"
-        ? await runTaskCloseoutFacade(parsed.value, runParsedCommand)
-        : await runParsedCommand(parsed.value);
-
-  const receipt = "schema" in output ? output : toCommandReceipt(output);
-  emit(receipt, parsed.value.json);
-  return receipt.ok ? 0 : 1;
-}
-
-async function runParsedCommand(command: Parameters<typeof runRegisteredCommand>[0]): Promise<CommandReceipt | CommandFailureReceipt> {
-  const configuredMode = process.env.HARNESS_DAEMON_MODE;
-  const testFixtureCommandRunner = (globalThis as Record<symbol, unknown>)[cliTestFixtureRunnerSymbol] as ParsedCommandRunner | undefined;
-  if (testFixtureCommandRunner && configuredMode !== "direct" && configuredMode !== "local" && configuredMode !== "remote") {
-    return testFixtureCommandRunner(command);
-  }
-  const daemonOutput = isGithubIssuesReadCommand(command)
-    ? undefined
-    : await runCommandThroughDaemon(command);
-  return daemonOutput ?? toCommandReceipt(await runRegisteredCommand(command, {
-    ...(isDeclaredLocalMigrationCommand(command.action)
-      ? { localCoordinatorScope: "migration" }
-      : process.env.HARNESS_DAEMON_MODE === "direct" && process.env.HARNESS_DIRECT_WRITE_REASON === "recovery"
-        ? { localCoordinatorScope: "recovery" }
-        : {})
-  }));
-}
-
-async function maybeRunAgentRuntimeCommand(argv: ReadonlyArray<string>): Promise<number | undefined> {
-  if (stripGlobalOptions(argv).args[0] !== "agent") return undefined;
-  const outcome = await runAgentRuntimeCommand(argv);
-  emit(outcome.receipt, outcome.json);
-  return outcome.receipt.ok ? 0 : 1;
-}
-
-function isGithubIssuesReadCommand(command: { readonly action: { readonly kind: string } }): boolean {
-  return command.action.kind === "external-snapshot" || command.action.kind === "external-list";
-}
-
-async function maybeRunDaemonCommand(argv: ReadonlyArray<string>): Promise<number | undefined> {
-  const stripped = stripGlobalOptions(argv);
-  if (stripped.args[0] !== "daemon") return undefined;
-  const action = stripped.args[1] ?? "status";
-  const layoutOverrides = stripped.authoredRoot !== undefined || argv.includes("--authored-root")
-    ? { authoredRoot: stripped.authoredRoot ?? "" }
-    : undefined;
-  const daemonArgs = stripped.daemonRepoId ? [...stripped.args, "--repo", stripped.daemonRepoId] : stripped.args;
-  if (action === "connect") return runDaemonConnect(stripped.args, {
-    ...(readOption(argv, "--root") ? { rootDir: stripped.rootDir } : {}),
-    ...(layoutOverrides ? { layoutOverrides } : {})
-  });
-  if (action === "serve") {
-    let launchOptions: ParsedDaemonLaunchArgv;
-    try {
-      launchOptions = parseDaemonLaunchArgv(argv);
-    } catch (error) {
-      console.error(error instanceof Error ? error.message : String(error));
-      return 2;
-    }
-    const serveLayoutOverrides = daemonRuntimeLayoutOverrides(launchOptions.rootDir, launchOptions.authoredRoot);
-    if (daemonArgs.includes("--stdio")) {
-      console.error("daemon serve --stdio is disabled because it creates a competing runtime; start the persistent daemon and use 'ha daemon connect --stdio'.");
-      return 2;
-    }
-    if (daemonArgs.includes("--check")) {
-      checkDaemonServeConfiguration(launchOptions.rootDir, serveLayoutOverrides, daemonArgs.filter((arg) => arg !== "--check"), launchOptions);
-      return 0;
-    }
-    await runDaemonServe(launchOptions.rootDir, serveLayoutOverrides, daemonArgs, {}, launchOptions);
-    return 0;
-  }
-  return runDaemonProductCommand({
-    rootDir: stripped.rootDir,
-    layoutOverrides,
-    json: stripped.json,
-    args: daemonArgs,
-    rawArgs: argv,
-    runServe: runDaemonServe
-  });
-}
-
-function checkDaemonServeConfiguration(
-  rootDir: string,
-  layoutOverrides: { readonly authoredRoot?: string } | undefined,
-  args: ReadonlyArray<string>,
-  launchOptions: ParsedDaemonLaunchArgv
-): void {
-  const userRoot = launchOptions.userRoot ?? daemonUserRoot();
-  checkDaemonServeConfigurationRoot({
-    rootDir,
-    layoutOverrides,
-    userRoot,
-    endpoint: launchOptions.socketPath ?? localUserDaemonEndpoint(userRoot, daemonIdFromEnv()),
-    requestedRepoId: readOption(args, "--repo") ?? process.env.HARNESS_DAEMON_REPO_ID ?? "canonical",
-    ...(launchOptions.authorityManifest ? { requestedAuthorityManifest: launchOptions.authorityManifest } : {})
-  });
-}
-
-async function runDaemonServe(
-  rootDir: string,
-  _layoutOverrides: { readonly authoredRoot?: string } | undefined,
-  args: ReadonlyArray<string>,
-  hooks: DaemonServeHooks = {},
-  parsedLaunchOptions = parseDaemonLaunchArgv(args)
-): Promise<void> {
-  const entrypoint = fileURLToPath(import.meta.url);
-  const requestedUserRoot = parsedLaunchOptions.userRoot ?? daemonUserRoot();
-  const requestedEndpoint = parsedLaunchOptions.socketPath ?? localUserDaemonEndpoint(requestedUserRoot, daemonIdFromEnv());
-  const explicit = {
-    ...(parsedLaunchOptions.authorityManifest ? { authorityManifest: parsedLaunchOptions.authorityManifest } : {}),
-    ...(parsedLaunchOptions.authoredRoot ? { authoredRoot: parsedLaunchOptions.authoredRoot } : {})
-  };
-  const restoredSpec = parsedLaunchOptions.optionsResolved
-    ? resolveCompleteDaemonLaunchSpec(requestedEndpoint, explicit)
-    : resolveDaemonLaunchSpec(requestedUserRoot, requestedEndpoint, explicit);
-  const restoredAuthoredRoot = restoredSpec.options.authoredRoot;
-  const restoredLayoutOverrides = daemonRuntimeLayoutOverrides(rootDir, restoredAuthoredRoot);
-  const restoredLaunchOptions = Object.freeze({
-    ...parsedLaunchOptions,
-    ...restoredSpec.options,
-    socketPath: restoredSpec.endpoint,
-    userRoot: requestedUserRoot
-  });
-  const requestedRepoId = readOption(args, "--repo") ?? process.env.HARNESS_DAEMON_REPO_ID ?? "canonical";
-  const { cliDaemonServiceHostServices } = await import("./composition/daemon-service-host-services.ts");
-  await runDaemonServeRoot({
-    rootDir,
-    ...(restoredAuthoredRoot !== undefined ? { authoredRoot: restoredAuthoredRoot } : {}),
-    layoutOverrides: restoredLayoutOverrides,
-    userRoot: requestedUserRoot,
-    endpoint: restoredSpec.endpoint,
-    requestedRepoId,
-    ...(restoredLaunchOptions.authorityManifest ? { requestedAuthorityManifest: restoredLaunchOptions.authorityManifest } : {}),
-    entrypoint,
-    idleMs: parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true }),
-    preflightReplacement: preflightDaemonLaunch
-  }, cliDaemonServiceHostServices, {
-    persistLaunchConfiguration: (userRoot, configuration, effectiveOptions) => restoredSpec
-      .withEffectiveOptions(effectiveOptions)
-      .persist(userRoot, configuration),
-    createAuthorityLifecycle: createProductionAuthorityLifecycle,
-    projectStartedStatus: daemonStatusCliProjection
-  }, hooks);
-}
-
-function emit(output: CommandReceipt | CommandFailureReceipt, json: boolean): void {
-  if (json) {
-    console.log(JSON.stringify(output));
-    return;
-  }
-
-  if (output.ok) {
-    const data = receiptDetailsData(output);
-    if (output.command === "version") {
-      console.log(`harness-anything ${String(data.version ?? "unknown")}`);
-      return;
-    }
-    if (output.command === "help" && Array.isArray(data.commands)) {
-      console.log(renderHelp(data));
-      return;
-    }
-    console.log(renderReceiptText(output));
-    return;
-  }
-
-  console.error(renderReceiptText(output));
-}
-
-function renderHelp(result: Record<string, unknown>): string {
-  const commands = Array.isArray(result.commands) ? result.commands as ReadonlyArray<CommandRegistryEntry> : [];
-  const report = helpReport(result.report);
-  if (report?.kind === "command" && commands.length === 1) {
-    return renderCommandHelp(commands[0]!);
-  }
-  if (report?.kind === "prefix") {
-    const prefix = Array.isArray(report.prefix) ? report.prefix.join(" ") : "";
-    return [
-      `Usage: harness-anything ${prefix} <subcommand> [options]`,
-      `Alias: ha ${prefix} <subcommand> [options]`,
-      ...renderGlobalOptions(),
-      "",
-      "Commands:",
-      ...commands.map((entry) => `  ${entry.primary} - ${entry.summary}`)
-    ].join("\n");
-  }
-  return [
-    "Usage: harness-anything <kind> [options]",
-    "Alias: ha <kind> [options]",
-    ...renderGlobalOptions(),
-    "",
-    "Commands:",
-    ...commands.map((entry) => `  ${entry.primary} - ${entry.summary}`)
-  ].join("\n");
-}
-
-function renderCommandHelp(command: CommandRegistryEntry): string {
-  const aliases = command.aliases.length > 0 ? ["", "Aliases:", ...command.aliases.map((alias) => `  ${alias}`)] : [];
-  const options = command.options.length > 0 ? ["", "Options:", ...command.options.map((option) => `  ${option.flag.padEnd(18)} ${option.description}`)] : [];
-  const additional = command.kind === "new-task" ? taskCreatePresetHelp() : [];
-  const examples = command.examples.length > 0 ? ["", "Example:", ...command.examples.map((example) => `  ${example}`)] : [];
-  return [
-    `Usage: ${command.primary}`,
-    "",
-    command.summary,
-    ...renderGlobalOptions(),
-    ...aliases,
-    ...options,
-    ...additional,
-    ...examples
-  ].join("\n");
-}
-
-function renderGlobalOptions(): ReadonlyArray<string> {
-  return [
-    "",
-    "Global options:",
-    ...globalCommandOptions.map((option) => `  ${option.flag.padEnd(18)} ${option.description}`)
-  ];
-}
-
-function taskCreatePresetHelp(): ReadonlyArray<string> {
-  return [
-    "",
-    "Recommended presets:",
-    "  standard-task           General implementation or maintenance task; the default starting point.",
-    "  long-running-task       Extended task that needs explicit long-running coordination.",
-    "  module                  Module-scoped task with registered module metadata.",
-    "  subtask-expansion       Plan and fan out a parent task into concrete subtasks.",
-    "  github-issue-repair     Guide an agent from a GitHub issue through an evidence-backed repair.",
-    "  legacy-migration        Legacy task intake or migration planning.",
-    "  create-milestone        Guide creation of a milestone root task and its governed map files.",
-    "  decision-conformance    Work that must prove alignment with recorded decisions.",
-    "  milestone-closeout      Milestone wrap-up checks and evidence collection.",
-    "",
-    "Start here:",
-    "  ha task create --title \"...\" --vertical software/coding --preset <id>",
-    "  ha task create --title \"<name> milestone root\" --vertical software/coding --preset create-milestone --long-running"
-  ];
-}
-
-function helpReport(report: unknown): { readonly kind: "global" | "command" | "prefix"; readonly prefix?: unknown } | undefined {
-  if (!report || typeof report !== "object") return undefined;
-  const candidate = report as { readonly schema?: unknown; readonly kind?: unknown; readonly prefix?: unknown };
-  if (candidate.schema !== "cli-help-report/v1") return undefined;
-  if (candidate.kind !== "global" && candidate.kind !== "command" && candidate.kind !== "prefix") return undefined;
-  return { kind: candidate.kind, prefix: candidate.prefix };
-}
+export { main };
 
 function isCliEntrypoint(): boolean {
   const invokedPath = process.argv[1];
@@ -324,10 +22,21 @@ function isCliEntrypoint(): boolean {
   }
 }
 
+function progressNotice(activity: string): NodeJS.Timeout {
+  const timer = setTimeout(() => {
+    console.error(`[ha] ${activity}; still working after 1s.`);
+  }, 1_000);
+  timer.unref();
+  return timer;
+}
+
 if (isCliEntrypoint()) {
+  const finishCommand = startCliTimingPhase("cli_command");
   const exitCode = await main();
+  finishCommand();
   if (process.env.HARNESS_DAEMON_SERVER_HOST === "1") {
     process.exit(exitCode);
   }
   process.exitCode = exitCode;
+  emitCliTimingOnExit(exitCode);
 }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "./cli/parse-args.ts";
+import { deprecationWarning } from "./cli/command-deprecations.ts";
+import { readOption, stripGlobalOptions } from "./cli/parse-options.ts";
+import { appendParseFailureRuntimeEvent } from "./cli/parse-failure-runtime-event.ts";
+import {
+  checkDaemonServeConfiguration as checkDaemonServeConfigurationRoot,
+  runDaemonServe as runDaemonServeRoot
+} from "@harness-anything/daemon";
+import { runCompoundReceiptExitCommand } from "./receipt/compound-exit-command.ts";
+import { receiptDetailsData, renderReceiptText, toCommandReceipt, type CommandFailureReceipt, type CommandReceipt } from "./cli/receipt.ts";
+import type { CommandRegistryEntry } from "./cli/types.ts";
+import { globalCommandOptions } from "./cli/command-spec/command-groups.ts";
+import { parsePositiveIntegerOr } from "./cli/value-utils.ts";
+import {
+  runDaemonProductCommand,
+  type DaemonServeHooks
+} from "./commands/daemon/productization.ts";
+import { daemonStatusCliProjection } from "./commands/daemon/status-payload.ts";
+import { runDaemonConnect } from "./commands/daemon/connect.ts";
+import { runRegisteredCommandWithCliComposition } from "./composition/command-executor.ts";
+import { daemonIdFromEnv, daemonUserRoot, localUserDaemonEndpoint, runCommandThroughDaemon } from "./daemon/client.ts";
+import {
+  parseDaemonLaunchArgv,
+  preflightDaemonLaunch,
+  resolveCompleteDaemonLaunchSpec,
+  resolveDaemonLaunchSpec,
+  type ParsedDaemonLaunchArgv
+} from "./daemon/daemon-launch-spec.ts";
+import { daemonRuntimeLayoutOverrides } from "./daemon/daemon-serve-launch-options.ts";
+import {
+  createCliProductionAuthorityLifecycle as createProductionAuthorityLifecycle
+} from "./composition/production-authority-lifecycle.ts";
+import { runAgentRuntimeCommand } from "./commands/agent-runtime.ts";
+import { runTaskSubmitFacade } from "./commands/core/task-submit-facade.ts";
+import { runTaskCloseoutFacade, runTaskStartFacade } from "./commands/core/task-lifecycle-facade.ts";
+import { isDeclaredLocalMigrationCommand } from "./composition/local-write-scope.ts";
+import { startCliTimingPhase } from "./cli/timing.ts";
+
+const runRegisteredCommand = runRegisteredCommandWithCliComposition;
+type ParsedCommandRunner = (command: Parameters<typeof runRegisteredCommand>[0]) => Promise<CommandReceipt | CommandFailureReceipt>;
+const cliTestFixtureRunnerSymbol = Symbol.for("harness-anything.cli-test-fixture-runner");
+
+export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)): Promise<number> {
+  const compoundExit = await runCompoundReceiptExitCommand(argv);
+  if (compoundExit !== undefined) return compoundExit;
+  const daemonOverrides = stripGlobalOptions(argv);
+  if (daemonOverrides.daemonMode) process.env.HARNESS_DAEMON_MODE = daemonOverrides.daemonMode;
+  if (daemonOverrides.daemonProfile) process.env.HARNESS_DAEMON_PROFILE = daemonOverrides.daemonProfile;
+  const daemonExit = await maybeRunDaemonCommand(argv);
+  if (daemonExit !== undefined) return daemonExit;
+  const agentExit = await maybeRunAgentRuntimeCommand(argv);
+  if (agentExit !== undefined) return agentExit;
+
+  const finishParse = startCliTimingPhase("parse");
+  const parsed = parseArgs(argv);
+  finishParse();
+  if (!parsed.ok) {
+    await appendParseFailureRuntimeEvent(argv, parsed.error);
+    emit(toCommandReceipt({ ok: false, command: "parse", error: parsed.error }), true);
+    return 2;
+  }
+
+  if (parsed.value.deprecatedInvocation) console.error(deprecationWarning(parsed.value.deprecatedInvocation));
+
+  const output = parsed.value.action.kind === "task-submit"
+    ? await runTaskSubmitFacade(parsed.value, runParsedCommand)
+    : parsed.value.action.kind === "task-start"
+      ? await runTaskStartFacade(parsed.value, runParsedCommand)
+      : parsed.value.action.kind === "task-closeout"
+        ? await runTaskCloseoutFacade(parsed.value, runParsedCommand)
+        : await runParsedCommand(parsed.value);
+
+  const receipt = "schema" in output ? output : toCommandReceipt(output);
+  emit(receipt, parsed.value.json);
+  return receipt.ok ? 0 : 1;
+}
+
+async function runParsedCommand(command: Parameters<typeof runRegisteredCommand>[0]): Promise<CommandReceipt | CommandFailureReceipt> {
+  const configuredMode = process.env.HARNESS_DAEMON_MODE;
+  const testFixtureCommandRunner = (globalThis as Record<symbol, unknown>)[cliTestFixtureRunnerSymbol] as ParsedCommandRunner | undefined;
+  if (testFixtureCommandRunner && configuredMode !== "direct" && configuredMode !== "local" && configuredMode !== "remote") {
+    return runTimedCommand(() => testFixtureCommandRunner(command));
+  }
+  if (isDaemonIndependentCommand(command) || isGithubIssuesReadCommand(command)) {
+    return runLocalRegisteredCommand(command);
+  }
+  const slowDaemonNotice = setTimeout(() => {
+    console.error("[ha] Waiting for daemon readiness or command completion; authority admission remains enforced.");
+  }, 1_000);
+  slowDaemonNotice.unref();
+  let daemonOutput: CommandReceipt | CommandFailureReceipt | undefined;
+  try {
+    daemonOutput = await runCommandThroughDaemon(command);
+  } finally {
+    clearTimeout(slowDaemonNotice);
+  }
+  return daemonOutput ?? runLocalRegisteredCommand(command);
+}
+
+async function runLocalRegisteredCommand(
+  command: Parameters<typeof runRegisteredCommand>[0]
+): Promise<CommandReceipt | CommandFailureReceipt> {
+  return runTimedCommand(async () => toCommandReceipt(await runRegisteredCommand(command, {
+    ...(isDeclaredLocalMigrationCommand(command.action)
+      ? { localCoordinatorScope: "migration" }
+      : process.env.HARNESS_DAEMON_MODE === "direct" && process.env.HARNESS_DIRECT_WRITE_REASON === "recovery"
+        ? { localCoordinatorScope: "recovery" }
+        : {})
+  })));
+}
+
+async function runTimedCommand<T>(run: () => Promise<T>): Promise<T> {
+  const finish = startCliTimingPhase("command_execute");
+  try {
+    return await run();
+  } finally {
+    finish();
+  }
+}
+
+function isDaemonIndependentCommand(command: { readonly action: { readonly kind: string } }): boolean {
+  return command.action.kind === "help"
+    || command.action.kind === "version"
+    || command.action.kind === "entity-list"
+    || command.action.kind === "capabilities"
+    || command.action.kind === "completion";
+}
+
+async function maybeRunAgentRuntimeCommand(argv: ReadonlyArray<string>): Promise<number | undefined> {
+  if (stripGlobalOptions(argv).args[0] !== "agent") return undefined;
+  const outcome = await runAgentRuntimeCommand(argv);
+  emit(outcome.receipt, outcome.json);
+  return outcome.receipt.ok ? 0 : 1;
+}
+
+function isGithubIssuesReadCommand(command: { readonly action: { readonly kind: string } }): boolean {
+  return command.action.kind === "external-snapshot" || command.action.kind === "external-list";
+}
+
+async function maybeRunDaemonCommand(argv: ReadonlyArray<string>): Promise<number | undefined> {
+  const stripped = stripGlobalOptions(argv);
+  if (stripped.args[0] !== "daemon") return undefined;
+  const action = stripped.args[1] ?? "status";
+  const layoutOverrides = stripped.authoredRoot !== undefined || argv.includes("--authored-root")
+    ? { authoredRoot: stripped.authoredRoot ?? "" }
+    : undefined;
+  const daemonArgs = stripped.daemonRepoId ? [...stripped.args, "--repo", stripped.daemonRepoId] : stripped.args;
+  if (action === "connect") return runDaemonConnect(stripped.args, {
+    ...(readOption(argv, "--root") ? { rootDir: stripped.rootDir } : {}),
+    ...(layoutOverrides ? { layoutOverrides } : {})
+  });
+  if (action === "serve") {
+    let launchOptions: ParsedDaemonLaunchArgv;
+    try {
+      launchOptions = parseDaemonLaunchArgv(argv);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      return 2;
+    }
+    const serveLayoutOverrides = daemonRuntimeLayoutOverrides(launchOptions.rootDir, launchOptions.authoredRoot);
+    if (daemonArgs.includes("--stdio")) {
+      console.error("daemon serve --stdio is disabled because it creates a competing runtime; start the persistent daemon and use 'ha daemon connect --stdio'.");
+      return 2;
+    }
+    if (daemonArgs.includes("--check")) {
+      checkDaemonServeConfiguration(launchOptions.rootDir, serveLayoutOverrides, daemonArgs.filter((arg) => arg !== "--check"), launchOptions);
+      return 0;
+    }
+    await runDaemonServe(launchOptions.rootDir, serveLayoutOverrides, daemonArgs, {}, launchOptions);
+    return 0;
+  }
+  return runDaemonProductCommand({
+    rootDir: stripped.rootDir,
+    layoutOverrides,
+    json: stripped.json,
+    args: daemonArgs,
+    rawArgs: argv,
+    runServe: runDaemonServe
+  });
+}
+
+function checkDaemonServeConfiguration(
+  rootDir: string,
+  layoutOverrides: { readonly authoredRoot?: string } | undefined,
+  args: ReadonlyArray<string>,
+  launchOptions: ParsedDaemonLaunchArgv
+): void {
+  const userRoot = launchOptions.userRoot ?? daemonUserRoot();
+  checkDaemonServeConfigurationRoot({
+    rootDir,
+    layoutOverrides,
+    userRoot,
+    endpoint: launchOptions.socketPath ?? localUserDaemonEndpoint(userRoot, daemonIdFromEnv()),
+    requestedRepoId: readOption(args, "--repo") ?? process.env.HARNESS_DAEMON_REPO_ID ?? "canonical",
+    ...(launchOptions.authorityManifest ? { requestedAuthorityManifest: launchOptions.authorityManifest } : {})
+  });
+}
+
+async function runDaemonServe(
+  rootDir: string,
+  _layoutOverrides: { readonly authoredRoot?: string } | undefined,
+  args: ReadonlyArray<string>,
+  hooks: DaemonServeHooks = {},
+  parsedLaunchOptions = parseDaemonLaunchArgv(args)
+): Promise<void> {
+  const entrypoint = fileURLToPath(import.meta.url);
+  const requestedUserRoot = parsedLaunchOptions.userRoot ?? daemonUserRoot();
+  const requestedEndpoint = parsedLaunchOptions.socketPath ?? localUserDaemonEndpoint(requestedUserRoot, daemonIdFromEnv());
+  const explicit = {
+    ...(parsedLaunchOptions.authorityManifest ? { authorityManifest: parsedLaunchOptions.authorityManifest } : {}),
+    ...(parsedLaunchOptions.authoredRoot ? { authoredRoot: parsedLaunchOptions.authoredRoot } : {})
+  };
+  const restoredSpec = parsedLaunchOptions.optionsResolved
+    ? resolveCompleteDaemonLaunchSpec(requestedEndpoint, explicit)
+    : resolveDaemonLaunchSpec(requestedUserRoot, requestedEndpoint, explicit);
+  const restoredAuthoredRoot = restoredSpec.options.authoredRoot;
+  const restoredLayoutOverrides = daemonRuntimeLayoutOverrides(rootDir, restoredAuthoredRoot);
+  const restoredLaunchOptions = Object.freeze({
+    ...parsedLaunchOptions,
+    ...restoredSpec.options,
+    socketPath: restoredSpec.endpoint,
+    userRoot: requestedUserRoot
+  });
+  const requestedRepoId = readOption(args, "--repo") ?? process.env.HARNESS_DAEMON_REPO_ID ?? "canonical";
+  const { cliDaemonServiceHostServices } = await import("./composition/daemon-service-host-services.ts");
+  await runDaemonServeRoot({
+    rootDir,
+    ...(restoredAuthoredRoot !== undefined ? { authoredRoot: restoredAuthoredRoot } : {}),
+    layoutOverrides: restoredLayoutOverrides,
+    userRoot: requestedUserRoot,
+    endpoint: restoredSpec.endpoint,
+    requestedRepoId,
+    ...(restoredLaunchOptions.authorityManifest ? { requestedAuthorityManifest: restoredLaunchOptions.authorityManifest } : {}),
+    entrypoint,
+    idleMs: parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true }),
+    preflightReplacement: preflightDaemonLaunch
+  }, cliDaemonServiceHostServices, {
+    persistLaunchConfiguration: (userRoot, configuration, effectiveOptions) => restoredSpec
+      .withEffectiveOptions(effectiveOptions)
+      .persist(userRoot, configuration),
+    createAuthorityLifecycle: createProductionAuthorityLifecycle,
+    projectStartedStatus: daemonStatusCliProjection
+  }, hooks);
+}
+
+function emit(output: CommandReceipt | CommandFailureReceipt, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(output));
+    return;
+  }
+
+  if (output.ok) {
+    const data = receiptDetailsData(output);
+    if (output.command === "version") {
+      console.log(`harness-anything ${String(data.version ?? "unknown")}`);
+      return;
+    }
+    if (output.command === "help" && Array.isArray(data.commands)) {
+      console.log(renderHelp(data));
+      return;
+    }
+    console.log(renderReceiptText(output));
+    return;
+  }
+
+  console.error(renderReceiptText(output));
+}
+
+function renderHelp(result: Record<string, unknown>): string {
+  const commands = Array.isArray(result.commands) ? result.commands as ReadonlyArray<CommandRegistryEntry> : [];
+  const report = helpReport(result.report);
+  if (report?.kind === "command" && commands.length === 1) {
+    return renderCommandHelp(commands[0]!);
+  }
+  if (report?.kind === "prefix") {
+    const prefix = Array.isArray(report.prefix) ? report.prefix.join(" ") : "";
+    return [
+      `Usage: harness-anything ${prefix} <subcommand> [options]`,
+      `Alias: ha ${prefix} <subcommand> [options]`,
+      ...renderGlobalOptions(),
+      "",
+      "Commands:",
+      ...commands.map((entry) => `  ${entry.primary} - ${entry.summary}`)
+    ].join("\n");
+  }
+  return [
+    "Usage: harness-anything <kind> [options]",
+    "Alias: ha <kind> [options]",
+    ...renderGlobalOptions(),
+    "",
+    "Commands:",
+    ...commands.map((entry) => `  ${entry.primary} - ${entry.summary}`)
+  ].join("\n");
+}
+
+function renderCommandHelp(command: CommandRegistryEntry): string {
+  const aliases = command.aliases.length > 0 ? ["", "Aliases:", ...command.aliases.map((alias) => `  ${alias}`)] : [];
+  const options = command.options.length > 0 ? ["", "Options:", ...command.options.map((option) => `  ${option.flag.padEnd(18)} ${option.description}`)] : [];
+  const additional = command.kind === "new-task" ? taskCreatePresetHelp() : [];
+  const examples = command.examples.length > 0 ? ["", "Example:", ...command.examples.map((example) => `  ${example}`)] : [];
+  return [
+    `Usage: ${command.primary}`,
+    "",
+    command.summary,
+    ...renderGlobalOptions(),
+    ...aliases,
+    ...options,
+    ...additional,
+    ...examples
+  ].join("\n");
+}
+
+function renderGlobalOptions(): ReadonlyArray<string> {
+  return [
+    "",
+    "Global options:",
+    ...globalCommandOptions.map((option) => `  ${option.flag.padEnd(18)} ${option.description}`)
+  ];
+}
+
+function taskCreatePresetHelp(): ReadonlyArray<string> {
+  return [
+    "",
+    "Recommended presets:",
+    "  standard-task           General implementation or maintenance task; the default starting point.",
+    "  long-running-task       Extended task that needs explicit long-running coordination.",
+    "  module                  Module-scoped task with registered module metadata.",
+    "  subtask-expansion       Plan and fan out a parent task into concrete subtasks.",
+    "  github-issue-repair     Guide an agent from a GitHub issue through an evidence-backed repair.",
+    "  legacy-migration        Legacy task intake or migration planning.",
+    "  create-milestone        Guide creation of a milestone root task and its governed map files.",
+    "  decision-conformance    Work that must prove alignment with recorded decisions.",
+    "  milestone-closeout      Milestone wrap-up checks and evidence collection.",
+    "",
+    "Start here:",
+    "  ha task create --title \"...\" --vertical software/coding --preset <id>",
+    "  ha task create --title \"<name> milestone root\" --vertical software/coding --preset create-milestone --long-running"
+  ];
+}
+
+function helpReport(report: unknown): { readonly kind: "global" | "command" | "prefix"; readonly prefix?: unknown } | undefined {
+  if (!report || typeof report !== "object") return undefined;
+  const candidate = report as { readonly schema?: unknown; readonly kind?: unknown; readonly prefix?: unknown };
+  if (candidate.schema !== "cli-help-report/v1") return undefined;
+  if (candidate.kind !== "global" && candidate.kind !== "command" && candidate.kind !== "prefix") return undefined;
+  return { kind: candidate.kind, prefix: candidate.prefix };
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "./cli/parse-args.ts";
 import { deprecationWarning } from "./cli/command-deprecations.ts";
@@ -126,7 +127,8 @@ function isDaemonIndependentCommand(command: { readonly action: { readonly kind:
     || command.action.kind === "version"
     || command.action.kind === "entity-list"
     || command.action.kind === "capabilities"
-    || command.action.kind === "completion";
+    || command.action.kind === "completion"
+    || command.action.kind === "git-diff";
 }
 
 async function maybeRunAgentRuntimeCommand(argv: ReadonlyArray<string>): Promise<number | undefined> {
@@ -206,7 +208,8 @@ async function runDaemonServe(
   hooks: DaemonServeHooks = {},
   parsedLaunchOptions = parseDaemonLaunchArgv(args)
 ): Promise<void> {
-  const entrypoint = fileURLToPath(import.meta.url);
+  const implementationPath = fileURLToPath(import.meta.url);
+  const entrypoint = path.join(path.dirname(implementationPath), `index${path.extname(implementationPath)}`);
   const requestedUserRoot = parsedLaunchOptions.userRoot ?? daemonUserRoot();
   const requestedEndpoint = parsedLaunchOptions.socketPath ?? localUserDaemonEndpoint(requestedUserRoot, daemonIdFromEnv());
   const explicit = {

--- a/packages/cli/test/helpers/daemon-cli.ts
+++ b/packages/cli/test/helpers/daemon-cli.ts
@@ -62,7 +62,7 @@ export function runRawJsonMaybeFail(
 export function stderrWithoutDeprecationWarnings(stderr: string): string {
   return stderr
     .split("\n")
-    .filter((line) => !line.startsWith("Deprecation warning: "))
+    .filter((line) => !line.startsWith("Deprecation warning: ") && !line.startsWith("[ha] ") && !line.startsWith("[ha timing] "))
     .join("\n")
     .trim();
 }

--- a/packages/cli/test/perf/cli-latency-budget.test.ts
+++ b/packages/cli/test/perf/cli-latency-budget.test.ts
@@ -1,0 +1,117 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import test from "node:test";
+import { receiptDataString } from "../helpers/forced-command-daemon.ts";
+import {
+  defaultDaemonUserRoot,
+  runDaemonCommand,
+  runRawJson,
+  stopDaemon,
+  withTempRootAsync
+} from "../helpers/daemon-cli.ts";
+import { cliTestEnv } from "../helpers/cli-test-env.ts";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+const localP95BudgetMs = 1_000;
+const warmWriteP95BudgetMs = 3_000;
+const budgetMultiplier = positiveNumber(process.env.HARNESS_CLI_LATENCY_BUDGET_MULTIPLIER, 2);
+
+test("daemon-independent help stays local and exposes phase timing", () => {
+  const missingUserRoot = path.resolve("/tmp", `ha-cli-help-no-daemon-${process.pid}-${Date.now()}`);
+  const result = spawnSync(process.execPath, [cliEntry, "--help"], {
+    encoding: "utf8",
+    env: cliTestEnv({
+      HA_TIMING: "1",
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_USER_ROOT: missingUserRoot
+    })
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Usage: harness-anything/u);
+  assert.equal(existsSync(missingUserRoot), false, "help must not initialize or connect to a daemon user root");
+  const timing = parseTiming(result.stderr);
+  assert.equal(timing.schema, "ha-cli-timing/v1");
+  assert.equal(typeof timing.phasesMs.process_start, "number");
+  assert.equal(typeof timing.phasesMs.module_load, "number");
+  assert.equal(typeof timing.phasesMs.parse, "number");
+  assert.equal(typeof timing.phasesMs.command_execute, "number");
+  assert.equal(typeof timing.phasesMs.process_exit_wait, "number");
+  assert.equal("daemon_connect" in timing.phasesMs, false);
+  assert.equal("daemon_launch_authority_ready" in timing.phasesMs, false);
+});
+
+test("CLI latency budgets cover local p95 and warm daemon writes", { timeout: 60_000 }, async (t) => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = defaultDaemonUserRoot(rootDir);
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: userRoot });
+    const created = runRawJson(rootDir, ["task", "create", "--title", "Latency Budget Fixture"], {
+      HARNESS_DAEMON_MODE: "fixture",
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    const taskId = receiptDataString(created, "taskId");
+    runDaemonCommand(rootDir, ["daemon", "start", "--service", "--json"], { HARNESS_DAEMON_USER_ROOT: userRoot });
+
+    try {
+      const localSamples = sample(7, () => runCli(rootDir, userRoot, ["--help"]));
+      runRawJson(rootDir, ["task", "progress", "append", taskId, "--text", "warmup"], {
+        HARNESS_DAEMON_MODE: "local",
+        HARNESS_DAEMON_USER_ROOT: userRoot,
+        HARNESS_DAEMON_IDLE_MS: "60000"
+      });
+      const writeSamples = sample(5, (index) => runCli(rootDir, userRoot, [
+        "--json", "task", "progress", "append", taskId, "--text", `latency sample ${index}`
+      ]));
+      const localP95 = percentile95(localSamples);
+      const writeP95 = percentile95(writeSamples);
+      t.diagnostic(JSON.stringify({ localP95, writeP95, budgetMultiplier, localSamples, writeSamples }));
+      assert.equal(localP95 < localP95BudgetMs * budgetMultiplier, true, `local p95 ${localP95.toFixed(1)}ms exceeded budget`);
+      assert.equal(writeP95 < warmWriteP95BudgetMs * budgetMultiplier, true, `warm write p95 ${writeP95.toFixed(1)}ms exceeded budget`);
+    } finally {
+      await stopDaemon(rootDir, userRoot);
+    }
+  });
+});
+
+function runCli(rootDir: string, userRoot: string, args: ReadonlyArray<string>): void {
+  const result = spawnSync(process.execPath, [cliEntry, "--root", rootDir, ...args], {
+    encoding: "utf8",
+    env: cliTestEnv({
+      HARNESS_DAEMON_MODE: "local",
+      HARNESS_DAEMON_USER_ROOT: userRoot,
+      HARNESS_DAEMON_IDLE_MS: "60000",
+      HARNESS_ACTOR: "agent:latency-budget",
+      HARNESS_GIT_AUTHOR_NAME: "Harness Test",
+      HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test"
+    })
+  });
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function sample(count: number, run: (index: number) => void): number[] {
+  return Array.from({ length: count }, (_, index) => {
+    const startedAt = performance.now();
+    run(index);
+    return Math.round((performance.now() - startedAt) * 100) / 100;
+  });
+}
+
+function percentile95(samples: ReadonlyArray<number>): number {
+  const sorted = [...samples].sort((left, right) => left - right);
+  return sorted[Math.ceil(sorted.length * 0.95) - 1]!;
+}
+
+function positiveNumber(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseTiming(stderr: string): { readonly schema: string; readonly phasesMs: Record<string, number> } {
+  const line = stderr.split("\n").find((candidate) => candidate.startsWith("[ha timing] "));
+  assert.ok(line, `missing HA_TIMING output: ${stderr}`);
+  return JSON.parse(line.slice("[ha timing] ".length)) as { schema: string; phasesMs: Record<string, number> };
+}

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -67,7 +67,15 @@ export interface LocalDaemonAutostartOptions {
   readonly execPath?: string;
   readonly execArgv?: ReadonlyArray<string>;
   readonly launchConfiguration?: DaemonLaunchConfiguration;
+  readonly onPhase?: (phase: LocalDaemonAutostartPhase) => void;
 }
+
+export type LocalDaemonAutostartPhase =
+  | "connect-start"
+  | "launch-start"
+  | "ready"
+  | "request-start"
+  | "request-end";
 
 export interface LocalDaemonJsonRpcOptions {
   readonly userRoot?: string;
@@ -338,11 +346,15 @@ export class JsonRpcLineClient {
   private async readResponse(id: number): Promise<JsonRpcResponse> {
     const lines = createInterface({ input: this.input });
     const iterator = lines[Symbol.asyncIterator]();
-    while (true) {
-      const next = await iterator.next();
-      if (next.done) throw new Error(`daemon closed before JSON-RPC response ${id}`);
-      const response = JSON.parse(next.value) as JsonRpcResponse;
-      if (response.id === id) return response;
+    try {
+      while (true) {
+        const next = await iterator.next();
+        if (next.done) throw new Error(`daemon closed before JSON-RPC response ${id}`);
+        const response = JSON.parse(next.value) as JsonRpcResponse;
+        if (response.id === id) return response;
+      }
+    } finally {
+      lines.close();
     }
   }
 }
@@ -359,6 +371,7 @@ async function requestLocalDaemonJsonRpcWithAutostart(
   while (Date.now() <= deadline) {
     let socket: net.Socket;
     try {
+      autostart.onPhase?.("connect-start");
       socket = await connectUnixSocket(target.socketPath, boundedConnectTimeout(connectTimeoutMs, deadline));
     } catch (error) {
       lastError = error;
@@ -366,11 +379,14 @@ async function requestLocalDaemonJsonRpcWithAutostart(
       continue;
     }
     try {
+      autostart.onPhase?.("request-start");
       return await requestWithSocket(socket, method, params);
     } catch (error) {
       if (error instanceof DaemonJsonRpcResponseError) throw error;
       lastError = error;
       await delay(Math.min(100, Math.max(1, deadline - Date.now())));
+    } finally {
+      autostart.onPhase?.("request-end");
     }
   }
   throw lastError ?? new Error("local daemon did not become reachable");
@@ -412,10 +428,12 @@ async function spawnAndWaitForLocalDaemon(
   connectTimeoutMs: number,
   flight: DaemonStartupFlight
 ): Promise<void> {
+  autostart.onPhase?.("launch-start");
   spawnLocalDaemon(target, autostart);
   while (Date.now() <= flight.deadline) {
     try {
       await probeLocalDaemonReady(target.socketPath, boundedConnectTimeout(connectTimeoutMs, flight.deadline));
+      autostart.onPhase?.("ready");
       return;
     } catch (error) {
       flight.lastError = error;
@@ -432,13 +450,22 @@ async function waitForDaemonStartupFlight(socketPath: string, flight: DaemonStar
     if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
     throw flight.lastError ?? new Error("local daemon did not become reachable");
   }
-  return Promise.race([
-    flight.promise,
-    delay(remainingMs).then(() => {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
       if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
-      throw flight.lastError ?? new Error("local daemon did not become reachable");
-    })
-  ]);
+      reject(flight.lastError ?? new Error("local daemon did not become reachable"));
+    }, remainingMs);
+    flight.promise.then(
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
 }
 
 function clearDaemonStartupFlight(socketPath: string, flight: DaemonStartupFlight): void {
@@ -451,7 +478,7 @@ async function probeLocalDaemonReady(socketPath: string, timeoutMs: number): Pro
   try {
     await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion });
   } finally {
-    client.close();
+    socket.destroy();
   }
 }
 
@@ -461,7 +488,7 @@ async function requestWithSocket(socket: net.Socket, method: string, params: Jso
     await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion });
     return await client.request(method, params);
   } finally {
-    client.close();
+    socket.destroy();
   }
 }
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -43,6 +43,7 @@ export {
   spawnLocalDaemon,
   type DaemonLaunchConfiguration,
   type DaemonLaunchConfigurationInput,
+  type LocalDaemonAutostartPhase,
   type LocalDaemonAutostartOptions,
   type LocalDaemonJsonRpcOptions,
   type LocalDaemonTarget

--- a/packages/daemon/test/local-json-rpc-client.test.ts
+++ b/packages/daemon/test/local-json-rpc-client.test.ts
@@ -119,6 +119,43 @@ test("autostart coalesces concurrent requests to one spawn per socket path", asy
   assert.deepEqual(results[0], { ok: true, method: "repo.tasks.list" });
 });
 
+test("autostart reports connect, launch, readiness, and request phases", async (t) => {
+  if (process.platform === "win32") return;
+  const socketPath = uniqueSocketPath("ha-daemon-autostart-phases");
+  const target = makeTarget(socketPath);
+  const phases: string[] = [];
+  const timeoutResourcesBefore = process.getActiveResourcesInfo().filter((resource) => resource === "Timeout").length;
+  let server: net.Server | undefined;
+  const restoreSpawn = replaceSpawnLocalDaemonForTest(() => {
+    setTimeout(() => {
+      void startJsonRpcServer(socketPath).then((started) => {
+        server = started;
+      });
+    }, 50);
+  });
+  t.after(async () => {
+    restoreSpawn();
+    await closeServer(server);
+    rmSync(socketPath, { force: true });
+  });
+
+  const result = await requestLocalDaemonJsonRpcForTarget(
+    target,
+    "repo.tasks.list",
+    {},
+    20,
+    { entryPath: "/unused", timeoutMs: 1_000, onPhase: (phase) => phases.push(phase) }
+  );
+
+  assert.deepEqual(result, { ok: true, method: "repo.tasks.list" });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(phases.filter((phase) => phase === "launch-start").length, 1);
+  assert.deepEqual(phases.slice(-3), ["connect-start", "request-start", "request-end"]);
+  assert.equal(phases.indexOf("launch-start") < phases.indexOf("ready"), true);
+  const timeoutResourcesAfter = process.getActiveResourcesInfo().filter((resource) => resource === "Timeout").length;
+  assert.equal(timeoutResourcesAfter <= timeoutResourcesBefore, true, "settled startup flight must cancel its deadline timer");
+});
+
 test("autostart clears failed single-flight so a later request can spawn again", async (t) => {
   if (process.platform === "win32") return;
   const socketPath = uniqueSocketPath("ha-daemon-singleflight-retry");

--- a/tools/check-cli-help-contract.mjs
+++ b/tools/check-cli-help-contract.mjs
@@ -1,18 +1,21 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const registryPath = "packages/cli/src/cli/command-registry.ts";
 const commandSpecDirPath = "packages/cli/src/cli/command-spec";
 const receiptPath = "packages/cli/src/cli/receipt.ts";
-const entrypointPath = "packages/cli/src/index.ts";
+const entrypointPaths = ["packages/cli/src/index.ts", "packages/cli/src/main.ts"];
 const defaultMinimumCommands = 20;
 
 export function findCliHelpContractViolations(rootDir = process.cwd(), options = {}) {
   const minimumCommands = options.minimumCommands ?? defaultMinimumCommands;
   const registrySource = readFileSync(path.join(rootDir, registryPath), "utf8");
   const receiptSource = readFileSync(path.join(rootDir, receiptPath), "utf8");
-  const entrypointSource = readFileSync(path.join(rootDir, entrypointPath), "utf8");
+  const entrypointSource = entrypointPaths
+    .filter((entrypointPath) => existsSync(path.join(rootDir, entrypointPath)))
+    .map((entrypointPath) => readFileSync(path.join(rootDir, entrypointPath), "utf8"))
+    .join("\n");
   const specSources = readdirSync(path.join(rootDir, commandSpecDirPath))
     .filter((name) => name.startsWith("command-spec-") && name.endsWith(".ts"))
     .sort()

--- a/tools/check-cli-structure.mjs
+++ b/tools/check-cli-structure.mjs
@@ -107,7 +107,8 @@ function checkCliCommandDescriptorization() {
   const parserRegistry = readSource("packages/cli/src/cli/parser-registry.ts");
   const runnerRegistryPath = "packages/cli/src/cli/runner-registry.ts";
   const runnerRegistry = existsSync(path.join(root, runnerRegistryPath)) ? readSource(runnerRegistryPath) : "";
-  const cliEntrypoint = readSource("packages/cli/src/index.ts");
+  const cliEntrypointPaths = existingFiles(["packages/cli/src/index.ts", "packages/cli/src/main.ts"]);
+  const cliEntrypoint = cliEntrypointPaths.map(readSource).join("\n");
   const lifecycleExecutorPath = "packages/cli/src/commands/lifecycle.ts";
   const lifecycleExecutor = existsSync(path.join(root, lifecycleExecutorPath)) ? readSource(lifecycleExecutorPath) : "";
 
@@ -162,10 +163,10 @@ function checkCliCommandDescriptorization() {
     violations.push("packages/cli/src/cli/runner-registry.ts: runner registry must not use string runner ids");
   }
   if (!/\brunRegisteredCommand\b/u.test(cliEntrypoint)) {
-    violations.push("packages/cli/src/index.ts: entrypoint must dispatch through runRegisteredCommand");
+    violations.push("packages/cli/src/{index,main}.ts: entrypoint must dispatch through runRegisteredCommand");
   }
   if (/\bif\s*\(\s*runnerId\s*===/u.test(cliEntrypoint)) {
-    violations.push("packages/cli/src/index.ts: entrypoint must not hand-dispatch runner ids");
+    violations.push("packages/cli/src/{index,main}.ts: entrypoint must not hand-dispatch runner ids");
   }
   if (/\bfunction\s+runCommand\b/u.test(lifecycleExecutor)) {
     violations.push("packages/cli/src/commands/lifecycle.ts: lifecycle.ts must not contain catch-all runCommand dispatcher");

--- a/tools/integration-test-shards.mjs
+++ b/tools/integration-test-shards.mjs
@@ -70,6 +70,7 @@ export const integrationTestFileWeightsMs = Object.freeze({
   "packages/cli/test/preset-script-imports-cli.test.ts": 20400,
   "packages/cli/test/preset-script-staging-boundary.test.ts": 25400,
   "packages/cli/test/preset-uninstall-safety-cli.test.ts": 28900,
+  "packages/cli/test/perf/cli-latency-budget.test.ts": 16500,
   "packages/cli/test/progress-evidence-cli.test.ts": 700.0,
   "packages/cli/test/preset-subtask-expansion-cli.test.ts": 17807.0,
   "packages/cli/test/projection-freshness-cli.test.ts": 1723.3,


### PR DESCRIPTION
# English

## Summary

`ha --help` could take 7+ seconds cold (user-reported 15s) and every cold CLI invocation dragged a ~5s silent tail. Measurement (not guessing) found two mechanisms: (1) in-process meta commands — help, version, entity-list, capabilities, completion — were routed through the daemon auto-launch path, paying daemon discovery/launch/authority-ready for output that needs none of it; (2) the daemon startup single-flight used `Promise.race(flight, delay(deadline))` and never cleared the deadline timer after the flight settled, so the Node process stayed alive ~5s after the command finished. This PR fixes both, adds per-phase CLI timing observability, and locks latency budgets in as regression tests.

## What Changed

- `packages/cli/src/index.ts` → lightweight bootstrap + `packages/cli/src/main.ts`: meta commands execute fully in-process (no daemon user-root read/create/connect); module loads >1s and daemon waits >1s emit progress lines instead of silent hangs.
- `packages/cli/src/cli/timing.ts` (new): `ha-cli-timing/v1` stderr records under `HA_TIMING=1` — process start, module load, parse, daemon config/target/connect, launch+authority-ready, command execution, process exit wait, plus active-resource dump. `HA_PROGRESS=0` silences progress. Documented in the CLI README.
- `packages/daemon/src/client/local-json-rpc-client.ts` / daemon index: low-cost lifecycle phase callback exposed; readline/socket closed after the response; settled startup flight clears its deadline timer (the 5s tail).
- Regression tests: `cli-latency-budget.test.ts` real-subprocess p95 budgets (local 1s, warm write 3s, 2× runner multiplier via `HARNESS_CLI_LATENCY_BUDGET_MULTIPLIER`); orphan-timer negative regression in `local-json-rpc-client.test.ts`.
- `tools/check-cli-structure.mjs` / `check-cli-help-contract.mjs` follow the bootstrap/main split (both files checked, no constraint removed); `tools/integration-test-shards.mjs` registers the new ~16.5s perf test's weight.

## Measured Impact

- `help`, daemon missing, cold: 7.18s → 0.64–0.79s (p95 0.791s); dist entry 0.68s.
- Cold `task show`: 6.67s → 2.52s; `process_exit_wait` 5014.94ms → 0.06ms (phase evidence).
- Warm write p95 1.451s (< 3s budget); under a deliberate 4-CPU-hog load help p95 1.047s.

## Task And Scope

- Task: `task_01KY2RRNGJSS990A56DWR7MZVE`. Scope: CLI entry/dispatch, daemon client liveness/timing, latency regression tests, and the two CLI static checkers. Authority recovery algorithms untouched (owned by `task_01KY2R5RREQ5DBGT7B4R09NWMB`); no authority readiness check or write admission is skipped.

## Version Impact

No package version bump. Behavior: meta commands no longer touch the daemon; cold invocations no longer hold a dead 5s timer; new opt-in stderr diagnostics.

## Governance Declaration

`tools/check-cli-structure.mjs`, `tools/check-cli-help-contract.mjs`, and `tools/integration-test-shards.mjs` are gate/runner tooling. Authority: ledger task `task_01KY2RRNGJSS990A56DWR7MZVE` (CEO-adjudicated high-priority CLI latency line, 2026-07-22). The checkers keep equivalent constraints across the entry split — nothing was loosened; the shard registry only adds the new test's scheduling weight.

## Verification

- daemon fast tier 41/41 (red/green control: reverting the timer cleanup fails exactly `settled startup flight must cancel its deadline timer`); cli perf integration 2/2; cli contract 75/75; tools fast 144/144; CLI build + `--noEmit` + eslint + structure/help/direct-writer checkers + `git diff --check` all exit 0.
- Negative controls: daemon-independent help succeeds with a nonexistent `HARNESS_DAEMON_USER_ROOT` and creates nothing; timing writes stderr only, stdout unchanged.

## Review Evidence

Worker report with the full measurement matrix and phase transcripts: `harness/tasks/task_01KY2RRNGJSS990A56DWR7MZVE-cli/artifacts/worker-report.md` (ledger-side, not in this diff).

## Residual Risk

Under sustained 4-CPU saturation help p95 is 1.047s (nominal budget 1s; low-load p95 0.791s) — further import-graph splitting was not justified by the data. Remote-SSH daemon and Windows named-pipe timing presentation not exercised on real hosts (unit/contract coverage passes).

## References

- Task package: `harness/tasks/task_01KY2RRNGJSS990A56DWR7MZVE-cli/`.

---

# 中文

## 概要

`ha --help` 冷态可达 7 秒以上(用户实测 15 秒),且所有冷调用带约 5 秒静默尾挂。用测量(非拍脑袋)坐实两个机制:(1) help、version、entity-list、capabilities、completion 这些进程内元命令被统一路由进 daemon 自动拉起路径,为完全不需要 daemon 的输出付出 discovery/launch/authority-ready 的全部代价;(2) daemon startup single-flight 用 `Promise.race(flight, delay(deadline))`,flight 成功后 deadline timer 不清理,命令 1–2 秒完成后 Node 进程再白等约 5 秒。本 PR 修复两者,新增 CLI 分阶段耗时可观测性,并把延迟预算固化为回归测试。

## 改动内容

- `packages/cli/src/index.ts` 改轻量 bootstrap + 新 `main.ts`:元命令全程进程内执行(不读/建/连 daemon user root);模块加载超 1 秒、daemon 等待超 1 秒输出进度提示,不再静默挂。
- 新增 `timing.ts`:`HA_TIMING=1` 输出 `ha-cli-timing/v1` stderr 记录——进程启动/模块加载/parse/daemon 配置·连接/launch+authority-ready/命令执行/退出等待+活跃资源清单;`HA_PROGRESS=0` 关进度;已写入 CLI README。
- `local-json-rpc-client.ts` 等:暴露低成本 lifecycle phase 回调;响应完成后关 readline/socket;settled flight 清理 deadline timer(5 秒尾挂根因)。
- 回归:`cli-latency-budget.test.ts` 真实子进程 p95 预算(本地 1s、warm 写 3s,默认 2 倍 runner 系数,可用 `HARNESS_CLI_LATENCY_BUDGET_MULTIPLIER` 调);orphan timer 负向回归。
- `tools/check-cli-{structure,help-contract}.mjs` 随入口拆分同查两文件(约束等价,无移除);`tools/integration-test-shards.mjs` 登记新 perf 测试(约 16.5s)调度权重。

## 实测效果

- `help` 无 daemon 冷态:7.18s → 0.64–0.79s(p95 0.791s);dist 入口 0.68s。
- 冷 `task show`:6.67s → 2.52s;`process_exit_wait` 5014.94ms → 0.06ms(阶段证据)。
- warm 写 p95 1.451s(<3s 预算);故意 4 核饱和下 help p95 1.047s。

## 任务与范围

- 任务:`task_01KY2RRNGJSS990A56DWR7MZVE`。范围:CLI 入口/分发、daemon client 活性与计时、延迟回归测试、两条 CLI 静态 checker。authority 恢复算法未动(归 `task_01KY2R5RREQ5DBGT7B4R09NWMB`);未跳过任何 authority 就绪检查或写 admission。

## 版本影响

无包版本变更。行为:元命令不再触碰 daemon;冷调用不再拖 5 秒死 timer;新增可选 stderr 诊断。

## 治理声明

`tools/check-cli-structure.mjs`、`tools/check-cli-help-contract.mjs`、`tools/integration-test-shards.mjs` 属门/runner 工具。授权依据:台账任务 `task_01KY2RRNGJSS990A56DWR7MZVE`(泽宇 2026-07-22 亲裁高优先级 CLI 延迟线)。checker 在入口拆分后保持等价约束——无任何放宽;shard 登记仅新增测试调度权重。

## 验证

- daemon fast 41/41(红绿对照:撤回 timer 清理恰好挂 `settled startup flight must cancel its deadline timer`);cli perf integration 2/2;cli contract 75/75;tools fast 144/144;CLI build、`--noEmit`、eslint、structure/help/direct-writer checker、`git diff --check` 全 exit 0。
- 阴性对照:daemon-independent help 在不存在的 `HARNESS_DAEMON_USER_ROOT` 下成功且不创建目录;timing 只写 stderr,stdout 不变。

## 审查证据

worker 报告含完整测量矩阵与阶段输出:`harness/tasks/task_01KY2RRNGJSS990A56DWR7MZVE-cli/artifacts/worker-report.md`(台账侧,不在本 diff 内)。

## 残余风险

持续 4 核饱和下 help p95 1.047s(名义预算 1s;低负载 0.791s)——数据不支持进一步拆 import 图。远程 SSH daemon 与 Windows named-pipe 的计时呈现未实机验证(单元/contract 覆盖通过)。

## 关联材料

- 任务包:`harness/tasks/task_01KY2RRNGJSS990A56DWR7MZVE-cli/`。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Targeted tests green / 定向测试全绿
- [x] Protected-surface change declared with decision authority / protected surface 改动已带决策授权申报
