### PR TITLE
feat(daemon): immutable version snapshots and graceful upgrade

### DIFF
--- a/packages/cli/src/commands/daemon/command-types.ts
+++ b/packages/cli/src/commands/daemon/command-types.ts
@@ -1,6 +1,7 @@
 import type { DaemonServeHooks } from "@harness-anything/daemon";
 import type { ParsedDaemonLaunchArgv } from "../../daemon/daemon-launch-spec.ts";
 import type { DaemonControlLifecycle, DaemonControlRequest } from "./control.ts";
+import type { DaemonSnapshotInstallInput, InstalledDaemonSnapshot } from "./snapshot.ts";
 
 export interface DaemonCommandInput {
   readonly rootDir: string;
@@ -18,6 +19,8 @@ export interface DaemonCommandInput {
   ) => Promise<void>;
   readonly requestDaemonControl?: (request: DaemonControlRequest) => Promise<Record<string, unknown>>;
   readonly daemonControlLifecycle?: DaemonControlLifecycle;
+  readonly installDaemonSnapshot?: (input: DaemonSnapshotInstallInput) => InstalledDaemonSnapshot;
+  readonly daemonSourceEntrypoint?: () => string;
 }
 
 export type { DaemonServeHooks } from "@harness-anything/daemon";

--- a/packages/cli/src/commands/daemon/control.ts
+++ b/packages/cli/src/commands/daemon/control.ts
@@ -27,6 +27,11 @@ import {
   acceptedGenerationExpectation,
   generationExpectationFromCapabilityStatus
 } from "./control-generation-capability.ts";
+import {
+  daemonRecoveryCommand,
+  quoteDaemonRecoveryArgument,
+  rollbackDaemonReplacement
+} from "./snapshot-rollback.ts";
 
 export type DaemonControlKind = "restart" | "refresh";
 type DaemonRefreshTrigger = "explicit" | "post-merge" | "dist-watcher";
@@ -64,6 +69,7 @@ export interface DaemonControlCommandInput {
   readonly daemonEntryPath: () => string;
   readonly calculateInstalledIdentity?: (entrypoint: string) => string;
   readonly platform?: NodeJS.Platform;
+  readonly replacementEntrypoint?: string;
 }
 
 type DaemonControlHandoff =
@@ -114,9 +120,12 @@ export async function runDaemonControl(
       ...(probedGeneration ? { daemonGeneration: probedGeneration.daemonGeneration } : {})
     }
   };
-  const preparedLaunchConfiguration = kind === "refresh"
+  const preparedRunningLaunchConfiguration = kind === "refresh"
     ? await lifecycle.prepareReplacement?.(lifecycle.target)
     : undefined;
+  const preparedLaunchConfiguration = preparedRunningLaunchConfiguration && input.replacementEntrypoint
+    ? { ...preparedRunningLaunchConfiguration, entrypoint: input.replacementEntrypoint }
+    : preparedRunningLaunchConfiguration;
   const preparedExpectedIdentity = preparedLaunchConfiguration
     ? calculateInstalledIdentity(input, preparedLaunchConfiguration.entrypoint)
     : undefined;
@@ -140,7 +149,8 @@ export async function runDaemonControl(
     method,
     launchConfiguration,
     expectedIdentity,
-    expectedGeneration
+    expectedGeneration,
+    input.replacementEntrypoint ? preparedRunningLaunchConfiguration : undefined
   );
   const { schema: controlSchema, ...controlResult } = receipt;
   return {
@@ -207,7 +217,8 @@ async function completeDaemonReplacement(
   method: DaemonControlRequest["method"],
   launchConfiguration: DaemonLaunchConfiguration,
   expectedIdentity: string | undefined,
-  expectedGeneration: DaemonGenerationConvergenceExpectation | undefined
+  expectedGeneration: DaemonGenerationConvergenceExpectation | undefined,
+  rollbackLaunchConfiguration?: DaemonLaunchConfiguration
 ): Promise<Record<string, unknown>> {
   if (!isPositivePid(beforePid)) {
     throw new Error(`${method} accepted receipt did not identify the running daemon PID`);
@@ -229,29 +240,42 @@ async function completeDaemonReplacement(
       expectedGeneration ? { includeGenerationAxes: true } : undefined
     );
   } catch (error) {
-    throw new Error(
+    const failure = new Error(
       `DAEMON_${kind.toUpperCase()}_REPLACEMENT_FAILED_AFTER_HANDOFF: ${error instanceof Error ? error.message : String(error)}. `
-      + `Restore the daemon with: ${daemonRecoveryCommand(launchConfiguration)}`
+      + `Restore the daemon with: ${daemonRecoveryCommand(rollbackLaunchConfiguration ?? launchConfiguration)}`
     );
+    if (!rollbackLaunchConfiguration) throw failure;
+    return await rollbackDaemonReplacement({
+      lifecycle, replacementFailure: failure, beforePid, beforeLoadedIdentity, operationId,
+      timeoutMs, kind, launchConfiguration: rollbackLaunchConfiguration, expectedGeneration
+    });
   }
-  const replacementLifecycle = normalizeDaemonLifecycleStatus(replacement);
-  if (!replacementLifecycle) {
-    throw new Error(`daemon ${kind} replacement did not return a reachable started daemon status`);
+  try {
+    const replacementLifecycle = normalizeDaemonLifecycleStatus(replacement);
+    if (!replacementLifecycle) {
+      throw new Error(`daemon ${kind} replacement did not return a reachable started daemon status`);
+    }
+    if (replacementLifecycle.pid === beforePid) {
+      throw new Error(`daemon ${kind} replacement PID did not change: ${String(replacementLifecycle.pid)}; replacement was not signaled`);
+    }
+    return await waitForStartedReplacement(
+      lifecycle,
+      replacement,
+      replacementLifecycle,
+      beforePid,
+      operationId,
+      timeoutMs,
+      kind,
+      expectedIdentity,
+      expectedGeneration
+    );
+  } catch (error) {
+    if (!rollbackLaunchConfiguration) throw error;
+    return await rollbackDaemonReplacement({
+      lifecycle, replacementFailure: error, beforePid, beforeLoadedIdentity, operationId,
+      timeoutMs, kind, launchConfiguration: rollbackLaunchConfiguration, expectedGeneration
+    });
   }
-  if (replacementLifecycle.pid === beforePid) {
-    throw new Error(`daemon ${kind} replacement PID did not change: ${String(replacementLifecycle.pid)}; replacement was not signaled`);
-  }
-  return await waitForStartedReplacement(
-    lifecycle,
-    replacement,
-    replacementLifecycle,
-    beforePid,
-    operationId,
-    timeoutMs,
-    kind,
-    expectedIdentity,
-    expectedGeneration
-  );
 }
 
 async function waitForStartedReplacement(
@@ -526,17 +550,6 @@ function daemonReplacementLaunchConfiguration(value: unknown): DaemonLaunchConfi
     entrypoint: value.entrypoint,
     args: value.args
   };
-}
-
-function daemonRecoveryCommand(configuration: DaemonLaunchConfiguration): string {
-  return [configuration.execPath, ...configuration.execArgv, configuration.entrypoint, ...configuration.args]
-    .map(quoteDaemonRecoveryArgument)
-    .join(" ");
-}
-
-function quoteDaemonRecoveryArgument(value: string): string {
-  if (/^[A-Za-z0-9_./:@%+=,-]+$/u.test(value)) return value;
-  return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
 function statusFromReceipt(receipt: Record<string, unknown>): Record<string, unknown> | undefined {

--- a/packages/cli/src/commands/daemon/help.ts
+++ b/packages/cli/src/commands/daemon/help.ts
@@ -37,12 +37,17 @@ export const daemonCapabilityOperations = [
     "refresh",
     "ha daemon refresh --json",
     "Request a service-wide daemon refresh and wait for the replacement daemon."
+  ),
+  daemonCapabilityOperation(
+    "upgrade",
+    "ha daemon upgrade --json",
+    "Install a versioned daemon snapshot and gracefully switch the service to it."
   )
 ] as const;
 
 export function renderDaemonHelp(): string {
   return [
-    "Usage: harness-anything daemon <start|status|logs|stop|restart|refresh|connect|repo|bootstrap-server|install-templates> [options]",
+    "Usage: harness-anything daemon <start|status|logs|stop|restart|refresh|upgrade|snapshot|connect|repo|bootstrap-server|install-templates> [options]",
     "Alias: ha daemon <subcommand> [options]",
     "",
     daemonGroup.summary,
@@ -68,6 +73,10 @@ export function renderDaemonHelp(): string {
     "                               Classify the refresh caller (default: explicit).",
     "    --timeout-ms <ms>          Set the aggregate queue drain timeout (100-120000).",
     "    --reason <text>            Record the operator or automation reason.",
+    "  upgrade [options]            Install a snapshot, drain, switch, start, and verify authority convergence.",
+    "  snapshot install [options]   Install an immutable daemon artifact snapshot without switching.",
+    "    --ref <git-ref>            Build a specific Git ref (default: current checkout).",
+    "    --version <version>        Override the snapshot directory version.",
     "  connect --stdio              Relay stdin/stdout to an already-running daemon.",
     "  repo <subcommand>            Register, list, or unregister daemon repositories.",
     "  bootstrap-server             Initialize a canonical team server repository.",

--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -33,6 +33,7 @@ import { makeDaemonLogService } from "@harness-anything/application";
 import { prepareDaemonServiceLaunch } from "../../daemon/daemon-service-launch.ts";
 import { parseDaemonLaunchArgv } from "../../daemon/daemon-launch-spec.ts";
 import type { DaemonCommandInput } from "./command-types.ts";
+import { installSnapshotCommand, upgradeDaemonSnapshot } from "./snapshot-command.ts";
 
 export type { DaemonControlLifecycle } from "./control.ts";
 export type { DaemonCommandInput, DaemonServeHooks } from "./command-types.ts";
@@ -78,6 +79,14 @@ export async function runDaemonProductCommand(input: DaemonCommandInput): Promis
     if (action === "stop") return await stopDaemon(input);
     if (action === "restart") return await controlDaemon(input, "restart");
     if (action === "refresh") return await controlDaemon(input, "refresh");
+    if (action === "upgrade") {
+      emitDaemonResult("daemon-upgrade", await upgradeDaemonSnapshot(input, productizationCliEntrypointPath), input.json);
+      return 0;
+    }
+    if (action === "snapshot") {
+      emitDaemonResult("daemon-snapshot-install", installSnapshotCommand(input, productizationCliEntrypointPath), input.json);
+      return 0;
+    }
     if (action === "bootstrap-server") return await bootstrapServer(input);
     if (action === "install-templates") return installTemplates(input);
     if (action === "repo") return runDaemonRepoCommand({ rootDir: input.rootDir, layoutOverrides: input.layoutOverrides, args: input.args, json: input.json });
@@ -515,7 +524,7 @@ function emitDaemonResult(command: string, result: Record<string, unknown>, json
     return;
   }
   const parts = [`ok`, `command=${command}`];
-  for (const key of ["started", "reachable", "mode", "queueDepth", "version", "protocolVersion", "pid", "rootDir", "repoId", "endpoint", "drained", "stopped", "accepted", "operationId", "kind", "reportPath", "outputDir"] as const) {
+  for (const key of ["started", "reachable", "mode", "queueDepth", "version", "protocolVersion", "pid", "rootDir", "repoId", "endpoint", "drained", "stopped", "accepted", "operationId", "kind", "reportPath", "outputDir", "installed", "snapshotDir", "entrypoint", "manifestPath"] as const) {
     if (result[key] !== undefined) parts.push(`${key}=${JSON.stringify(result[key])}`);
   }
   if (typeof result.lockPath === "string") parts.push(`lock=${result.lockPath}`);

--- a/packages/cli/src/commands/daemon/snapshot-command.ts
+++ b/packages/cli/src/commands/daemon/snapshot-command.ts
@@ -1,0 +1,57 @@
+import path from "node:path";
+import { daemonUserRoot } from "@harness-anything/daemon";
+import { readOption } from "../../cli/parse-options.ts";
+import type { DaemonCommandInput } from "./command-types.ts";
+import { runDaemonControl } from "./control.ts";
+import { installDaemonSnapshot, type InstalledDaemonSnapshot } from "./snapshot.ts";
+
+export function installSnapshotCommand(
+  input: DaemonCommandInput,
+  sourceEntrypoint: () => string
+): Record<string, unknown> {
+  const subcommand = input.args[2] ?? "install";
+  if (subcommand !== "install") throw new Error("Use ha daemon snapshot install [--ref <git-ref>] [--version <version>].");
+  return snapshotResult(installSnapshotForCommand(input, sourceEntrypoint));
+}
+
+export async function upgradeDaemonSnapshot(
+  input: DaemonCommandInput,
+  sourceEntrypoint: () => string
+): Promise<Record<string, unknown>> {
+  const snapshot = installSnapshotForCommand(input, sourceEntrypoint);
+  const result = await runDaemonControl({
+    ...input,
+    daemonEntryPath: sourceEntrypoint,
+    replacementEntrypoint: snapshot.entrypoint
+  }, "refresh");
+  return { snapshot: snapshotResult(snapshot), ...result };
+}
+
+function installSnapshotForCommand(
+  input: DaemonCommandInput,
+  sourceEntrypoint: () => string
+): InstalledDaemonSnapshot {
+  const installer = input.installDaemonSnapshot ?? installDaemonSnapshot;
+  const ref = readOption(input.args, "--ref");
+  const version = readOption(input.args, "--version");
+  return installer({
+    sourceEntrypoint: (input.daemonSourceEntrypoint ?? sourceEntrypoint)(),
+    userRoot: path.resolve(readDaemonUserRootOption(input.args) ?? daemonUserRoot()),
+    ...(ref ? { ref } : {}),
+    ...(version ? { version } : {})
+  });
+}
+
+function snapshotResult(snapshot: InstalledDaemonSnapshot): Record<string, unknown> {
+  return {
+    installed: snapshot.installed,
+    snapshotDir: snapshot.snapshotDir,
+    entrypoint: snapshot.entrypoint,
+    manifestPath: snapshot.manifestPath,
+    manifest: snapshot.manifest
+  };
+}
+
+function readDaemonUserRootOption(args: ReadonlyArray<string>): string | undefined {
+  return readOption(args, "--user-root") ?? process.env.HARNESS_DAEMON_USER_ROOT;
+}

--- a/packages/cli/src/commands/daemon/snapshot-command.ts
+++ b/packages/cli/src/commands/daemon/snapshot-command.ts
@@ -11,7 +11,7 @@ export function installSnapshotCommand(
 ): Record<string, unknown> {
   const subcommand = input.args[2] ?? "install";
   if (subcommand !== "install") throw new Error("Use ha daemon snapshot install [--ref <git-ref>] [--version <version>].");
-  return snapshotResult(installSnapshotForCommand(input, sourceEntrypoint));
+  return daemonSnapshotResult(installSnapshotForCommand(input, sourceEntrypoint));
 }
 
 export async function upgradeDaemonSnapshot(
@@ -24,7 +24,7 @@ export async function upgradeDaemonSnapshot(
     daemonEntryPath: sourceEntrypoint,
     replacementEntrypoint: snapshot.entrypoint
   }, "refresh");
-  return { snapshot: snapshotResult(snapshot), ...result };
+  return { snapshot: daemonSnapshotResult(snapshot), ...result };
 }
 
 function installSnapshotForCommand(
@@ -36,13 +36,13 @@ function installSnapshotForCommand(
   const version = readOption(input.args, "--version");
   return installer({
     sourceEntrypoint: (input.daemonSourceEntrypoint ?? sourceEntrypoint)(),
-    userRoot: path.resolve(readDaemonUserRootOption(input.args) ?? daemonUserRoot()),
+    userRoot: path.resolve(readSnapshotUserRootOption(input.args) ?? daemonUserRoot()),
     ...(ref ? { ref } : {}),
     ...(version ? { version } : {})
   });
 }
 
-function snapshotResult(snapshot: InstalledDaemonSnapshot): Record<string, unknown> {
+function daemonSnapshotResult(snapshot: InstalledDaemonSnapshot): Record<string, unknown> {
   return {
     installed: snapshot.installed,
     snapshotDir: snapshot.snapshotDir,
@@ -52,6 +52,6 @@ function snapshotResult(snapshot: InstalledDaemonSnapshot): Record<string, unkno
   };
 }
 
-function readDaemonUserRootOption(args: ReadonlyArray<string>): string | undefined {
+function readSnapshotUserRootOption(args: ReadonlyArray<string>): string | undefined {
   return readOption(args, "--user-root") ?? process.env.HARNESS_DAEMON_USER_ROOT;
 }

--- a/packages/cli/src/commands/daemon/snapshot-rollback.ts
+++ b/packages/cli/src/commands/daemon/snapshot-rollback.ts
@@ -23,7 +23,7 @@ export async function rollbackDaemonReplacement(input: {
   );
   if (occupied) {
     throw new Error(
-      `${errorMessage(input.replacementFailure)}; previous snapshot rollback was not started because the endpoint is still owned`
+      `${rollbackErrorMessage(input.replacementFailure)}; previous snapshot rollback was not started because the endpoint is still owned`
     );
   }
   try {
@@ -46,11 +46,11 @@ export async function rollbackDaemonReplacement(input: {
     }
   } catch (rollbackError) {
     throw new Error(
-      `${errorMessage(input.replacementFailure)}; previous snapshot rollback failed: ${errorMessage(rollbackError)}. `
+      `${rollbackErrorMessage(input.replacementFailure)}; previous snapshot rollback failed: ${rollbackErrorMessage(rollbackError)}. `
       + `Restore the daemon with: ${daemonRecoveryCommand(input.launchConfiguration)}`
     );
   }
-  throw new Error(`${errorMessage(input.replacementFailure)}; previous snapshot restored and authority converged`);
+  throw new Error(`${rollbackErrorMessage(input.replacementFailure)}; previous snapshot restored and authority converged`);
 }
 
 export function daemonRecoveryCommand(configuration: DaemonLaunchConfiguration): string {
@@ -64,6 +64,6 @@ export function quoteDaemonRecoveryArgument(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
-function errorMessage(error: unknown): string {
+function rollbackErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }

--- a/packages/cli/src/commands/daemon/snapshot-rollback.ts
+++ b/packages/cli/src/commands/daemon/snapshot-rollback.ts
@@ -1,0 +1,69 @@
+import type { DaemonLaunchConfiguration } from "../../daemon/daemon-launch-spec.ts";
+import {
+  isCompleteReplacement,
+  normalizeDaemonLifecycleStatus,
+  type DaemonGenerationConvergenceExpectation
+} from "./control-convergence.ts";
+import type { DaemonControlKind, DaemonControlLifecycle } from "./control.ts";
+
+export async function rollbackDaemonReplacement(input: {
+  readonly lifecycle: DaemonControlLifecycle;
+  readonly replacementFailure: unknown;
+  readonly beforePid: number;
+  readonly beforeLoadedIdentity: string;
+  readonly operationId: string;
+  readonly timeoutMs: number;
+  readonly kind: DaemonControlKind;
+  readonly launchConfiguration: DaemonLaunchConfiguration;
+  readonly expectedGeneration: DaemonGenerationConvergenceExpectation | undefined;
+}): Promise<never> {
+  const occupied = await input.lifecycle.probeStatus(
+    input.lifecycle.target,
+    input.expectedGeneration ? { includeGenerationAxes: true } : undefined
+  );
+  if (occupied) {
+    throw new Error(
+      `${errorMessage(input.replacementFailure)}; previous snapshot rollback was not started because the endpoint is still owned`
+    );
+  }
+  try {
+    const restored = await input.lifecycle.startReplacement(
+      input.lifecycle.target,
+      input.timeoutMs,
+      input.launchConfiguration,
+      input.expectedGeneration ? { includeGenerationAxes: true } : undefined
+    );
+    const restoredLifecycle = normalizeDaemonLifecycleStatus(restored);
+    if (!restoredLifecycle
+      || !isCompleteReplacement(
+        restoredLifecycle,
+        input.beforePid,
+        input.operationId,
+        input.beforeLoadedIdentity,
+        input.expectedGeneration
+      )) {
+      throw new Error("restored daemon did not converge on the previous snapshot and authority generation");
+    }
+  } catch (rollbackError) {
+    throw new Error(
+      `${errorMessage(input.replacementFailure)}; previous snapshot rollback failed: ${errorMessage(rollbackError)}. `
+      + `Restore the daemon with: ${daemonRecoveryCommand(input.launchConfiguration)}`
+    );
+  }
+  throw new Error(`${errorMessage(input.replacementFailure)}; previous snapshot restored and authority converged`);
+}
+
+export function daemonRecoveryCommand(configuration: DaemonLaunchConfiguration): string {
+  return [configuration.execPath, ...configuration.execArgv, configuration.entrypoint, ...configuration.args]
+    .map(quoteDaemonRecoveryArgument)
+    .join(" ");
+}
+
+export function quoteDaemonRecoveryArgument(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/u.test(value)) return value;
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/cli/src/commands/daemon/snapshot.ts
+++ b/packages/cli/src/commands/daemon/snapshot.ts
@@ -1,0 +1,323 @@
+import { execFileSync } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { calculateDaemonArtifactIdentity } from "@harness-anything/daemon";
+
+export const daemonSnapshotManifestSchema = "daemon-snapshot-manifest/v1";
+
+export interface DaemonSnapshotManifest {
+  readonly schema: typeof daemonSnapshotManifestSchema;
+  readonly version: string;
+  readonly sourceRef: string;
+  readonly sourceCommit: string;
+  readonly sourceDirty: boolean;
+  readonly sourceFingerprint: string;
+  readonly builtAt: string;
+  readonly entrypoint: string;
+  readonly contentFingerprint: string;
+  readonly artifactFileCount: number;
+  readonly runtimePackages: ReadonlyArray<string>;
+}
+
+export interface InstalledDaemonSnapshot {
+  readonly snapshotDir: string;
+  readonly entrypoint: string;
+  readonly manifestPath: string;
+  readonly manifest: DaemonSnapshotManifest;
+  readonly installed: boolean;
+}
+
+export interface DaemonSnapshotInstallInput {
+  readonly sourceEntrypoint: string;
+  readonly userRoot: string;
+  readonly ref?: string;
+  readonly version?: string;
+  readonly now?: () => Date;
+}
+
+const workspaceRuntimePackages = [
+  "packages/cli",
+  "packages/kernel",
+  "packages/application",
+  "packages/api-contracts",
+  "packages/daemon",
+  "packages/adapters/github-issues",
+  "packages/adapters/local",
+  "packages/adapters/multica"
+] as const;
+
+export function installDaemonSnapshot(input: DaemonSnapshotInstallInput): InstalledDaemonSnapshot {
+  const source = resolveSnapshotSource(input.sourceEntrypoint);
+  const sourceRef = input.ref ?? "HEAD";
+  if (source.kind === "installed" && input.ref !== undefined && input.ref !== "HEAD") {
+    throw new Error("--ref requires a Git source checkout; an installed npm CLI can snapshot only its current release.");
+  }
+  const sourceCommit = source.kind === "repository"
+    ? gitOutput(source.root, ["rev-parse", `${sourceRef}^{commit}`])
+    : installedSourceCommit(source.distRoot);
+  const sourceDirty = source.kind === "repository" && input.ref === undefined
+    ? gitOutput(source.root, ["status", "--porcelain"]).length > 0
+    : false;
+  const sourceFingerprint = sourceDirty
+    ? calculateDaemonArtifactIdentity(input.sourceEntrypoint).identity
+    : sourceCommit;
+  const version = validatedSnapshotVersion(input.version ?? defaultSnapshotVersion(sourceCommit, sourceDirty, sourceFingerprint));
+  const snapshotsRoot = path.join(path.resolve(input.userRoot), "daemon-snapshots");
+  const snapshotDir = path.join(snapshotsRoot, version);
+  const manifestPath = path.join(snapshotDir, "manifest.json");
+  const existing = readExistingManifest(manifestPath);
+  if (existing) {
+    if (existing.sourceCommit !== sourceCommit
+      || existing.sourceDirty !== sourceDirty
+      || existing.sourceFingerprint !== sourceFingerprint) {
+      throw new Error(`daemon snapshot version already belongs to different source bytes: ${version}`);
+    }
+    const entrypoint = path.join(snapshotDir, ...existing.entrypoint.split("/"));
+    const identity = calculateDaemonArtifactIdentity(entrypoint);
+    if (identity.identity !== existing.contentFingerprint) {
+      throw new Error(`daemon snapshot content fingerprint mismatch: ${snapshotDir}`);
+    }
+    return { snapshotDir, entrypoint, manifestPath, manifest: existing, installed: false };
+  }
+
+  mkdirSync(snapshotsRoot, { recursive: true });
+  const staging = mkdtempSync(path.join(snapshotsRoot, `.${version}.`));
+  let buildRoot: string | undefined;
+  try {
+    const build: { readonly distRoot: string; readonly buildRoot?: string } = source.kind === "repository"
+      ? buildRepositoryRef(source.root, sourceRef, input.ref === undefined)
+      : { distRoot: source.distRoot };
+    buildRoot = build.buildRoot;
+    cpSync(build.distRoot, path.join(staging, "dist"), { recursive: true, errorOnExist: true });
+    const runtimePackages = copyRuntimeDependencyClosure(source.dependencyRoot, staging);
+    const entrypoint = path.join(staging, "dist", "cli", "src", "index.js");
+    if (!existsSync(entrypoint)) throw new Error(`built daemon entrypoint is missing: ${entrypoint}`);
+    const identity = calculateDaemonArtifactIdentity(entrypoint);
+    const manifest: DaemonSnapshotManifest = {
+      schema: daemonSnapshotManifestSchema,
+      version,
+      sourceRef,
+      sourceCommit,
+      sourceDirty,
+      sourceFingerprint,
+      builtAt: (input.now ?? (() => new Date()))().toISOString(),
+      entrypoint: "dist/cli/src/index.js",
+      contentFingerprint: identity.identity,
+      artifactFileCount: identity.fileCount,
+      runtimePackages
+    };
+    writeFileSync(path.join(staging, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    renameSync(staging, snapshotDir);
+    return {
+      snapshotDir,
+      entrypoint: path.join(snapshotDir, "dist", "cli", "src", "index.js"),
+      manifestPath,
+      manifest,
+      installed: true
+    };
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+    if (buildRoot) removeBuildWorktree(source, buildRoot);
+  }
+}
+
+type SnapshotSource =
+  | { readonly kind: "repository"; readonly root: string; readonly dependencyRoot: string }
+  | { readonly kind: "installed"; readonly distRoot: string; readonly dependencyRoot: string };
+
+function resolveSnapshotSource(sourceEntrypoint: string): SnapshotSource {
+  const resolved = realpathSync(sourceEntrypoint);
+  let current = path.dirname(resolved);
+  while (true) {
+    if (existsSync(path.join(current, ".git")) && existsSync(path.join(current, "packages", "cli", "tsconfig.build.json"))) {
+      return { kind: "repository", root: current, dependencyRoot: current };
+    }
+    if (path.basename(current) === "dist") {
+      const packageRoot = path.dirname(current);
+      return { kind: "installed", distRoot: current, dependencyRoot: packageRoot };
+    }
+    const parent = path.dirname(current);
+    if (parent === current) throw new Error(`cannot resolve daemon snapshot source from ${sourceEntrypoint}`);
+    current = parent;
+  }
+}
+
+function buildRepositoryRef(
+  repositoryRoot: string,
+  sourceRef: string,
+  useCurrentCheckout: boolean
+): { readonly distRoot: string; readonly buildRoot?: string } {
+  if (useCurrentCheckout) {
+    execFileSync("npm", ["run", "build", "-w", "@harness-anything/cli"], {
+      cwd: repositoryRoot,
+      stdio: ["ignore", "ignore", "inherit"],
+      windowsHide: true
+    });
+    return { distRoot: path.join(repositoryRoot, "packages", "cli", "dist") };
+  }
+  const buildRoot = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-snapshot-build-"));
+  rmSync(buildRoot, { recursive: true, force: true });
+  try {
+    execFileSync("git", ["-c", "core.hooksPath=/dev/null", "worktree", "add", "--detach", buildRoot, sourceRef], {
+      cwd: repositoryRoot,
+      stdio: "ignore",
+      windowsHide: true
+    });
+    symlinkSync(path.join(repositoryRoot, "node_modules"), path.join(buildRoot, "node_modules"), "dir");
+    execFileSync("npm", ["run", "build", "-w", "@harness-anything/cli"], {
+      cwd: buildRoot,
+      stdio: ["ignore", "ignore", "inherit"],
+      windowsHide: true
+    });
+    return { distRoot: path.join(buildRoot, "packages", "cli", "dist"), buildRoot };
+  } catch (error) {
+    removeRepositoryBuildWorktree(repositoryRoot, buildRoot);
+    throw error;
+  }
+}
+
+function removeBuildWorktree(source: SnapshotSource, buildRoot: string): void {
+  if (source.kind !== "repository") return;
+  removeRepositoryBuildWorktree(source.root, buildRoot);
+}
+
+function removeRepositoryBuildWorktree(repositoryRoot: string, buildRoot: string): void {
+  try {
+    execFileSync("git", ["worktree", "remove", "--force", buildRoot], {
+      cwd: repositoryRoot,
+      stdio: "ignore",
+      windowsHide: true
+    });
+  } catch {
+    rmSync(buildRoot, { recursive: true, force: true });
+    try {
+      execFileSync("git", ["worktree", "prune"], { cwd: repositoryRoot, stdio: "ignore", windowsHide: true });
+    } catch {
+      // The primary install error is more useful than best-effort worktree cleanup failure.
+    }
+  }
+}
+
+function copyRuntimeDependencyClosure(dependencyRoot: string, staging: string): ReadonlyArray<string> {
+  const packageNames = new Set<string>();
+  const pending = externalWorkspaceDependencies(dependencyRoot).map((name) => ({ name, optional: false }));
+  while (pending.length > 0) {
+    const { name: packageName, optional } = pending.pop()!;
+    if (packageNames.has(packageName) || packageName.startsWith("@harness-anything/")) continue;
+    let packageDir: string;
+    try {
+      packageDir = resolveDependencyPackage(dependencyRoot, packageName);
+    } catch (error) {
+      if (optional) continue;
+      throw error;
+    }
+    packageNames.add(packageName);
+    const packageJson = JSON.parse(readFileSync(path.join(packageDir, "package.json"), "utf8")) as {
+      readonly dependencies?: Record<string, string>;
+      readonly optionalDependencies?: Record<string, string>;
+    };
+    pending.push(
+      ...Object.keys(packageJson.dependencies ?? {}).map((name) => ({ name, optional: false })),
+      ...Object.keys(packageJson.optionalDependencies ?? {}).map((name) => ({ name, optional: true }))
+    );
+  }
+  for (const packageName of [...packageNames].sort()) {
+    const source = resolveDependencyPackage(dependencyRoot, packageName);
+    const destination = path.join(staging, "node_modules", ...packageName.split("/"));
+    mkdirSync(path.dirname(destination), { recursive: true });
+    cpSync(source, destination, { recursive: true, dereference: true, errorOnExist: true });
+  }
+  return [...packageNames].sort();
+}
+
+function externalWorkspaceDependencies(repositoryRoot: string): string[] {
+  const dependencies = new Set<string>();
+  const installedPackagePath = path.join(repositoryRoot, "package.json");
+  if (existsSync(installedPackagePath) && !existsSync(path.join(repositoryRoot, "packages"))) {
+    addPackageDependencies(installedPackagePath, dependencies);
+  }
+  for (const relativeRoot of workspaceRuntimePackages) {
+    const packagePath = path.join(repositoryRoot, ...relativeRoot.split("/"), "package.json");
+    if (!existsSync(packagePath)) continue;
+    addPackageDependencies(packagePath, dependencies);
+  }
+  dependencies.add("node-pty");
+  return [...dependencies];
+}
+
+function addPackageDependencies(packagePath: string, dependencies: Set<string>): void {
+  const packageJson = JSON.parse(readFileSync(packagePath, "utf8")) as {
+    readonly dependencies?: Record<string, string>;
+    readonly optionalDependencies?: Record<string, string>;
+  };
+  for (const name of [...Object.keys(packageJson.dependencies ?? {}), ...Object.keys(packageJson.optionalDependencies ?? {})]) {
+    if (!name.startsWith("@harness-anything/")) dependencies.add(name);
+  }
+}
+
+function resolveDependencyPackage(dependencyRoot: string, packageName: string): string {
+  let current = dependencyRoot;
+  while (true) {
+    const candidate = path.join(current, "node_modules", ...packageName.split("/"));
+    if (existsSync(path.join(candidate, "package.json"))) {
+      return lstatSync(candidate).isSymbolicLink() ? realpathSync(candidate) : candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) throw new Error(`runtime dependency is not installed: ${packageName}`);
+    current = parent;
+  }
+}
+
+function readExistingManifest(manifestPath: string): DaemonSnapshotManifest | undefined {
+  if (!existsSync(manifestPath)) return undefined;
+  const value = JSON.parse(readFileSync(manifestPath, "utf8")) as Partial<DaemonSnapshotManifest>;
+  if (value.schema !== daemonSnapshotManifestSchema
+    || typeof value.version !== "string"
+    || typeof value.sourceRef !== "string"
+    || typeof value.sourceCommit !== "string"
+    || typeof value.sourceDirty !== "boolean"
+    || typeof value.sourceFingerprint !== "string"
+    || typeof value.builtAt !== "string"
+    || typeof value.entrypoint !== "string"
+    || typeof value.contentFingerprint !== "string"
+    || typeof value.artifactFileCount !== "number"
+    || !Array.isArray(value.runtimePackages)
+    || !value.runtimePackages.every((entry) => typeof entry === "string")) {
+    throw new Error(`invalid daemon snapshot manifest: ${manifestPath}`);
+  }
+  return value as DaemonSnapshotManifest;
+}
+
+function installedSourceCommit(distRoot: string): string {
+  return calculateDaemonArtifactIdentity(path.join(distRoot, "cli", "src", "index.js"))
+    .identity
+    .replace("sha256:", "");
+}
+
+function defaultSnapshotVersion(sourceCommit: string, dirty: boolean, sourceFingerprint: string): string {
+  return `${sourceCommit.slice(0, 12)}${dirty ? `-dirty-${sourceFingerprint.replace("sha256:", "").slice(0, 12)}` : ""}`;
+}
+
+function validatedSnapshotVersion(value: string): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(value)) {
+    throw new Error("snapshot version must use 1-128 letters, digits, dots, underscores, or hyphens");
+  }
+  return value;
+}
+
+function gitOutput(cwd: string, args: ReadonlyArray<string>): string {
+  return execFileSync("git", [...args], { cwd, encoding: "utf8", windowsHide: true }).trim();
+}

--- a/packages/cli/src/commands/daemon/snapshot.ts
+++ b/packages/cli/src/commands/daemon/snapshot.ts
@@ -66,10 +66,10 @@ export function installDaemonSnapshot(input: DaemonSnapshotInstallInput): Instal
     throw new Error("--ref requires a Git source checkout; an installed npm CLI can snapshot only its current release.");
   }
   const sourceCommit = source.kind === "repository"
-    ? gitOutput(source.root, ["rev-parse", `${sourceRef}^{commit}`])
+    ? snapshotGitOutput(source.root, ["rev-parse", `${sourceRef}^{commit}`])
     : installedSourceCommit(source.distRoot);
   const sourceDirty = source.kind === "repository" && input.ref === undefined
-    ? gitOutput(source.root, ["status", "--porcelain"]).length > 0
+    ? snapshotGitOutput(source.root, ["status", "--porcelain"]).length > 0
     : false;
   const sourceFingerprint = sourceDirty
     ? calculateDaemonArtifactIdentity(input.sourceEntrypoint).identity
@@ -318,6 +318,6 @@ function validatedSnapshotVersion(value: string): string {
   return value;
 }
 
-function gitOutput(cwd: string, args: ReadonlyArray<string>): string {
+function snapshotGitOutput(cwd: string, args: ReadonlyArray<string>): string {
   return execFileSync("git", [...args], { cwd, encoding: "utf8", windowsHide: true }).trim();
 }

--- a/packages/cli/test/daemon-control-dispatcher.test.ts
+++ b/packages/cli/test/daemon-control-dispatcher.test.ts
@@ -624,6 +624,8 @@ test("daemon help exposes logs, restart, refresh, and refresh trigger selection"
   assert.match(help, /restart/u);
   assert.match(help, /refresh/u);
   assert.match(help, /explicit\|post-merge\|dist-watcher/u);
+  assert.match(help, /snapshot install/u);
+  assert.match(help, /upgrade/u);
 });
 
 async function runCapturedControl(

--- a/packages/cli/test/daemon-snapshot-integration.test.ts
+++ b/packages/cli/test/daemon-snapshot-integration.test.ts
@@ -1,0 +1,78 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { readFileSync, rmSync } from "node:fs";
+import test from "node:test";
+import { requestLocalDaemonJsonRpc } from "../../daemon/src/index.ts";
+import {
+  defaultDaemonUserRoot,
+  runDaemonCommand,
+  stopDaemon
+} from "./helpers/daemon-cli.ts";
+import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
+
+test("daemon upgrade serves the installed snapshot identity and persists its entrypoint", { timeout: 90_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const env = {
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"
+  };
+  try {
+    runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical",
+      "--canonical-root", fixture.repoRoot, "--user-root", userRoot, "--no-link", "--json"
+    ], env);
+    const started = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+    ], env);
+    const upgrade = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "upgrade", "--version", "integration-snapshot",
+      "--timeout-ms", "20000", "--user-root", userRoot, "--json"
+    ], env);
+    const snapshot = upgrade.snapshot as {
+      readonly entrypoint: string;
+      readonly manifestPath: string;
+      readonly manifest: { readonly contentFingerprint: string };
+    };
+    const replacement = upgrade.replacement as {
+      readonly pid: number;
+      readonly service: {
+        readonly build: { readonly loadedIdentity: string; readonly installedIdentity: string };
+        readonly activeControl: unknown;
+      };
+    };
+
+    assert.notEqual(replacement.pid, started.pid);
+    assert.equal(replacement.service.build.loadedIdentity, snapshot.manifest.contentFingerprint);
+    assert.equal(replacement.service.build.installedIdentity, snapshot.manifest.contentFingerprint);
+    assert.equal(replacement.service.activeControl, null);
+    assert.equal(
+      (JSON.parse(readFileSync(snapshot.manifestPath, "utf8")) as { contentFingerprint: string }).contentFingerprint,
+      snapshot.manifest.contentFingerprint
+    );
+
+    const launchReceipt = await requestLocalDaemonJsonRpc(
+      fixture.repoRoot,
+      "admin.daemon.launch-spec",
+      {},
+      1_000,
+      { userRoot, allowLegacySocket: false }
+    );
+    const launchDetails = launchReceipt.details as Record<string, unknown>;
+    const launchSpec = launchDetails.data as { readonly entrypoint?: unknown };
+    assert.equal(launchSpec.entrypoint, snapshot.entrypoint);
+    process.kill(replacement.pid, 0);
+    console.log(JSON.stringify({
+      scenario: "snapshot-upgrade",
+      beforePid: started.pid,
+      afterPid: replacement.pid,
+      entrypoint: snapshot.entrypoint,
+      fingerprint: snapshot.manifest.contentFingerprint
+    }));
+  } finally {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/test/daemon-snapshot-upgrade.test.ts
+++ b/packages/cli/test/daemon-snapshot-upgrade.test.ts
@@ -1,0 +1,172 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import {
+  runDaemonProductCommand,
+  type DaemonControlLifecycle
+} from "../src/commands/daemon/productization.ts";
+
+const controlTarget = {
+  repoId: "canonical",
+  canonicalRoot: "/repo",
+  userRoot: "/user-root",
+  daemonId: "default",
+  socketPath: "/user-root/daemon.sock",
+  legacySocketPath: "/repo/legacy.sock",
+  registered: true
+} as const;
+
+const runningLaunchConfiguration = {
+  execPath: "/usr/bin/node",
+  execArgv: ["--import", "tsx"],
+  entrypoint: "/snapshots/release-1/dist/cli/src/index.js",
+  args: ["--root", "/repo", "daemon", "serve", "--socket", "/user-root/daemon.sock"]
+} as const;
+
+test("daemon upgrade switches to the installed snapshot only after drain handoff", async () => {
+  const starts: string[] = [];
+  const snapshotEntrypoint = "/user-root/daemon-snapshots/release-2/dist/cli/src/index.js";
+  const { exitCode, receipt } = await runCapturedUpgrade({
+    target: controlTarget,
+    prepareReplacement: async () => runningLaunchConfiguration,
+    probeStatus: async () => undefined,
+    ownerIsAlive: () => false,
+    startReplacement: async (_target, _timeoutMs, launchConfiguration) => {
+      starts.push(launchConfiguration.entrypoint);
+      return v2DaemonStatus(84);
+    },
+    wait: async () => undefined
+  }, snapshotEntrypoint);
+
+  assert.equal(exitCode, 0, JSON.stringify(receipt));
+  assert.deepEqual(starts, [snapshotEntrypoint]);
+  const snapshot = receipt.snapshot as Record<string, unknown>;
+  assert.equal(snapshot.entrypoint, snapshotEntrypoint);
+  assert.equal(snapshot.installed, true);
+});
+
+test("daemon upgrade drain timeout leaves the old daemon serving and does not switch launch configuration", async () => {
+  let replacementStarts = 0;
+  let oldOwnerAlive = true;
+  const { exitCode, receipt } = await runCapturedUpgrade({
+    target: controlTarget,
+    prepareReplacement: async () => runningLaunchConfiguration,
+    probeStatus: async () => v2DaemonStatus(42, oldIdentity),
+    ownerIsAlive: () => oldOwnerAlive,
+    startReplacement: async () => {
+      replacementStarts += 1;
+      return v2DaemonStatus(84);
+    },
+    wait: async () => undefined
+  }, "/snapshots/release-timeout/dist/cli/src/index.js", async () => {
+    oldOwnerAlive = true;
+    throw new Error("daemon_queue_drain_timeout: in-flight journal write retained");
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(replacementStarts, 0);
+  assert.equal(oldOwnerAlive, true);
+  assert.match(controlErrorHint(receipt), /daemon_queue_drain_timeout/u);
+});
+
+test("daemon upgrade rolls back to the previous snapshot when new snapshot health verification fails", async () => {
+  const starts: string[] = [];
+  const stoppedPids: number[] = [];
+  const snapshotEntrypoint = "/snapshots/release-bad/dist/cli/src/index.js";
+  let endpointProbe = 0;
+  const { exitCode, receipt } = await runCapturedUpgrade({
+    target: controlTarget,
+    prepareReplacement: async () => runningLaunchConfiguration,
+    probeStatus: async () => {
+      endpointProbe += 1;
+      return undefined;
+    },
+    ownerIsAlive: () => false,
+    startReplacement: async (_target, _timeoutMs, launchConfiguration) => {
+      starts.push(launchConfiguration.entrypoint);
+      return launchConfiguration.entrypoint === snapshotEntrypoint
+        ? v2DaemonStatus(84, oldIdentity)
+        : v2DaemonStatus(85, oldIdentity);
+    },
+    stopReplacement: async (_target, pid) => { stoppedPids.push(pid); },
+    wait: async () => undefined
+  }, snapshotEntrypoint);
+
+  assert.equal(exitCode, 1);
+  assert.deepEqual(starts, [snapshotEntrypoint, runningLaunchConfiguration.entrypoint]);
+  assert.deepEqual(stoppedPids, [84]);
+  assert.ok(endpointProbe >= 2);
+  assert.match(controlErrorHint(receipt), /previous snapshot restored and authority converged/u);
+});
+
+const oldIdentity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+async function runCapturedUpgrade(
+  daemonControlLifecycle: DaemonControlLifecycle,
+  snapshotEntrypoint: string,
+  requestDaemonControl: () => Promise<Record<string, unknown>> = async () => ({
+    schema: "daemon-control-accepted/v1",
+    accepted: true,
+    operationId: "control-refresh",
+    kind: "refresh",
+    before: { pid: 42, loadedIdentity: oldIdentity, launchConfiguration: runningLaunchConfiguration }
+  })
+): Promise<{ readonly exitCode: number; readonly receipt: Record<string, unknown> }> {
+  const output: string[] = [];
+  const originalLog = console.log;
+  console.log = (message?: unknown) => output.push(String(message));
+  try {
+    const exitCode = await runDaemonProductCommand({
+      rootDir: "/repo",
+      json: true,
+      args: ["daemon", "upgrade", "--timeout-ms", "100"],
+      runServe: async () => undefined,
+      requestDaemonControl,
+      daemonControlLifecycle,
+      installDaemonSnapshot: () => ({
+        installed: true,
+        snapshotDir: path.dirname(path.dirname(path.dirname(path.dirname(snapshotEntrypoint)))),
+        entrypoint: snapshotEntrypoint,
+        manifestPath: "/snapshots/manifest.json",
+        manifest: {
+          schema: "daemon-snapshot-manifest/v1",
+          version: "test",
+          sourceRef: "HEAD",
+          sourceCommit: "a".repeat(40),
+          sourceDirty: false,
+          sourceFingerprint: "a".repeat(40),
+          builtAt: "2026-07-22T00:00:00.000Z",
+          entrypoint: "dist/cli/src/index.js",
+          contentFingerprint: "sha256:" + "b".repeat(64),
+          artifactFileCount: 1,
+          runtimePackages: []
+        }
+      }),
+      daemonSourceEntrypoint: () => "/repo/packages/cli/src/index.ts",
+      calculateInstalledIdentity: () => "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    });
+    return { exitCode, receipt: JSON.parse(output.at(-1) ?? "") as Record<string, unknown> };
+  } finally {
+    console.log = originalLog;
+  }
+}
+
+function controlErrorHint(receipt: Record<string, unknown>): string {
+  const error = receipt.error;
+  return typeof error === "object" && error !== null && "hint" in error ? String(error.hint) : "";
+}
+
+function v2DaemonStatus(pid: number, loadedIdentity = newIdentity): Record<string, unknown> {
+  return {
+    schema: "daemon-status/v2",
+    service: {
+      started: true,
+      pid,
+      build: { loadedIdentity, installedIdentity: loadedIdentity },
+      activeControl: null
+    }
+  };
+}
+
+const newIdentity = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";

--- a/packages/cli/test/daemon-snapshot.test.ts
+++ b/packages/cli/test/daemon-snapshot.test.ts
@@ -1,0 +1,55 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { calculateDaemonArtifactIdentity } from "@harness-anything/daemon";
+import { installDaemonSnapshot } from "../src/commands/daemon/snapshot.ts";
+
+test("daemon snapshot installation is idempotent and remains independent from mutable dist", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-daemon-snapshot-test-"));
+  const packageRoot = path.join(root, "package");
+  const sourceEntrypoint = path.join(packageRoot, "dist", "cli", "src", "index.js");
+  const userRoot = path.join(root, "user");
+  mkdirSync(path.dirname(sourceEntrypoint), { recursive: true });
+  writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ name: "harness-anything", dependencies: {} }));
+  writeFileSync(sourceEntrypoint, "export const daemonVersion = 'snapshot-v1';\n");
+  const nodePtyRoot = path.join(packageRoot, "node_modules", "node-pty");
+  mkdirSync(nodePtyRoot, { recursive: true });
+  writeFileSync(path.join(nodePtyRoot, "package.json"), JSON.stringify({
+    name: "node-pty",
+    version: "1.0.0",
+    optionalDependencies: { "node-pty-unavailable-platform": "1.0.0" }
+  }));
+  writeFileSync(path.join(nodePtyRoot, "index.js"), "module.exports = {};\n");
+
+  try {
+    const first = installDaemonSnapshot({
+      sourceEntrypoint,
+      userRoot,
+      version: "release-1",
+      now: () => new Date("2026-07-22T01:02:03.000Z")
+    });
+    const second = installDaemonSnapshot({ sourceEntrypoint, userRoot, version: "release-1" });
+
+    assert.equal(first.installed, true);
+    assert.equal(second.installed, false);
+    assert.equal(second.snapshotDir, first.snapshotDir);
+    assert.deepEqual(second.manifest, first.manifest);
+    assert.equal(first.manifest.builtAt, "2026-07-22T01:02:03.000Z");
+    assert.equal(calculateDaemonArtifactIdentity(first.entrypoint).identity, first.manifest.contentFingerprint);
+
+    writeFileSync(sourceEntrypoint, "export const daemonVersion = 'mutable-dist-v2';\n");
+    assert.match(readFileSync(first.entrypoint, "utf8"), /snapshot-v1/u);
+    assert.doesNotMatch(readFileSync(first.entrypoint, "utf8"), /mutable-dist-v2/u);
+    assert.equal(calculateDaemonArtifactIdentity(first.entrypoint).identity, first.manifest.contentFingerprint);
+    assert.equal(readFileSync(first.manifestPath, "utf8").endsWith("\n"), true);
+    assert.throws(
+      () => installDaemonSnapshot({ sourceEntrypoint, userRoot, version: "release-1" }),
+      /snapshot version already belongs to different source bytes/u
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/test/doctor-cli.test.ts
+++ b/packages/cli/test/doctor-cli.test.ts
@@ -158,7 +158,8 @@ test("CLI capabilities exposes daemon onboarding operations", () => {
       "logs",
       "stop",
       "restart",
-      "refresh"
+      "refresh",
+      "upgrade"
     ]);
     assert.equal(daemon.report.ops[0]?.command, "ha daemon repo register --root .");
   });

--- a/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
+++ b/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
@@ -8,7 +8,7 @@
     "packages/cli/src/commands/core/decision-relate.ts": "22b3eff78b8115c6c97e870d0218b6f779064dca",
     "packages/cli/src/commands/core/decision-relation-record.ts": "b802dcbb858030d86d40e2b928750afd7150d239",
     "packages/cli/src/commands/core/task-lifecycle.ts": "ca002e96498531aef065647cabe7ed6279caa54e",
-    "packages/cli/src/commands/daemon/productization.ts": "0b2633e856c6be5aa42d3bac727c0b287c2b4033",
+    "packages/cli/src/commands/daemon/productization.ts": "065603c6a5945073b65a1006f88753b5be8b8890",
     "packages/cli/src/commands/preset-task.ts": "e425389b163993d17ce37c11c60ab088e2d46258",
     "packages/cli/src/commands/settings.ts": "640579058ad11b952ed8212d4de6e7835e2d670e",
     "packages/cli/src/composition/adapter-registry.ts": "8c0be49785f847e0e26e8f0c1a5e661f5c5d17df"

--- a/packages/cli/test/snapshots/capabilities-command-kinds.json
+++ b/packages/cli/test/snapshots/capabilities-command-kinds.json
@@ -25,7 +25,8 @@
     "daemon-restart",
     "daemon-start",
     "daemon-status",
-    "daemon-stop"
+    "daemon-stop",
+    "daemon-upgrade"
   ],
   "decision": [
     "decision-amend",

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -640,6 +640,56 @@
     ],
     "freshGateRegistry": [
       {
+        "value": "packages/cli/src/commands/daemon/snapshot.ts#mkdirSync@1",
+        "ref": "task_01KY2WBYH520GMVJK5K76SH1WJ",
+        "reason": "Decision-authorized repository-external daemon snapshot install registered as daemon.snapshot.install; creates the non-SoT immutable runtime artifact root."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/snapshot.ts#cpSync@1",
+        "ref": "task_01KY2WBYH520GMVJK5K76SH1WJ",
+        "reason": "Decision-authorized repository-external daemon snapshot install registered as daemon.snapshot.install; copies built runtime bytes into isolated staging."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/snapshot.ts#writeFileSync@1",
+        "ref": "task_01KY2WBYH520GMVJK5K76SH1WJ",
+        "reason": "Decision-authorized repository-external daemon snapshot install registered as daemon.snapshot.install; records the source and content fingerprint manifest."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/snapshot.ts#renameSync@1",
+        "ref": "task_01KY2WBYH520GMVJK5K76SH1WJ",
+        "reason": "Decision-authorized repository-external daemon snapshot install registered as daemon.snapshot.install; atomically publishes staged immutable runtime bytes."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/snapshot.ts#rmSync@1",
+        "ref": "task_01KY2WBYH520GMVJK5K76SH1WJ",
+        "reason": "Decision-authorized daemon.snapshot.install cleanup removes only its repository-external unpublished staging directory."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/snapshot.ts#rmSync@2",
+        "ref": "task_01KY2WBYH520GMVJK5K76SH1WJ",
+        "reason": "Decision-authorized daemon.snapshot.install prepares its isolated temporary Git worktree path before Git owns it."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/snapshot.ts#symlinkSync@1",
+        "ref": "task_01KY2WBYH520GMVJK5K76SH1WJ",
+        "reason": "Decision-authorized daemon.snapshot.install links existing dependencies only inside its isolated temporary Git worktree for an explicit-ref build."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/snapshot.ts#rmSync@3",
+        "ref": "task_01KY2WBYH520GMVJK5K76SH1WJ",
+        "reason": "Decision-authorized daemon.snapshot.install fallback cleanup removes only its isolated temporary Git worktree after Git cleanup fails."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/snapshot.ts#mkdirSync@2",
+        "ref": "task_01KY2WBYH520GMVJK5K76SH1WJ",
+        "reason": "Decision-authorized repository-external daemon snapshot install registered as daemon.snapshot.install; creates runtime dependency parent directories in staging."
+      },
+      {
+        "value": "packages/cli/src/commands/daemon/snapshot.ts#cpSync@2",
+        "ref": "task_01KY2WBYH520GMVJK5K76SH1WJ",
+        "reason": "Decision-authorized repository-external daemon snapshot install registered as daemon.snapshot.install; copies the runtime dependency closure into staging."
+      },
+      {
         "value": "packages/cli/src/commands/core/worktree.ts#mkdirSync@1",
         "ref": "task_01KWY3Z4VEVP6FNT28ZFA809GW",
         "reason": "C11 generated worktree binding registry write; stores rebuildable local .harness/generated binding state, not authored task truth."

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -12,12 +12,14 @@
     "dec_01KXN3ZDDNPVZ6ADH62R69MTCN",
     "dec_01KXMZZ92BY0KJW1482WMBRF1K",
     "task_01KXZTWY17ZVH5FWRCRV86J16C",
+    "task_01KY2WBYH520GMVJK5K76SH1WJ",
+    "dec_01KY2PJRGWXEJDH3E622553HZK",
     "ADR-0022"
   ],
   "rowCountReconciliation": {
     "phase1FunctionalRows": 26,
-    "registryRows": 61,
-    "difference": "One phase 1 feature row is retired. Six additional rows split mixed write functions and infrastructure: module canonical/view, script declared writes/produces, worktree code/binding, task-holder runtime state, one WriteCoordinator runtime substrate row, and the Fact-to-Execution administrative migration road. Three hosted typed-authority rows keep Execution, execution-scoped Review, and human Consent records RPC-only. Two further ADR-0028 P4 rows register the attributed doc_sync_submit coordinator road and the preset script staging-mirror ingest road. One ADR-0028 P5 row registers the coordinator-owned immutable attribution event trail. One parallel authority-attribution-event/v2 sibling row registers canonical-byte append, read-after-write, recovery, retention, backup, integrity, and materializer coverage under dec_01KXNB6RYNBD9SJBCXGWTDRP8A. One dedicated T4 administrative migration row registers the attributed, confirmed-plan, key-only retirement of historical ownership fields. One ADR-0029 TW-01 row registers the authority replication submission road (attributed-coordinator entry over forced-command SSH). One ADR-0029 TW-02 row registers the compound receipt durable store (client-side crash-recovery receipt records, fsync + atomic rename). One ADR-0029 TW-03 row registers the broker local-view native applier (crash-safe transparent view materialization). One ADR-0029 TW-04 row registers the platform semantic-probe scratch writes (temporary qualification probes, created and removed inside one probe run). One ADR-0029 TW-06 row registers the authority fence enrollment anchor and durability boundary stores. One authority key-material row registers fd-secure private material in repository-external service state as non-SoT state under dec_01KXN3ZDDNPVZ6ADH62R69MTCN; repository, harness, CAS, and backup roots remain forbidden. One authority lifecycle row registers restart-replayed per-repo operations, replica changes, bindings, and namespaces under daemon service state. One daemon transport row registers the socket owner-lock lifecycle state (task_01KXD0A37NN8ZQEJ2ENG5K313V): ephemeral single-instance mutex outside SoT, not entity data. One daemon operational-log row registers the repository-external append, rotation, and retention store under dec_01KXMZZ92BY0KJW1482WMBRF1K. One identity bootstrap row registers the user-profile people roster boundary (XD-1/XD-2). Two GUI decision rows register proposal and judgment transitions through the authenticated daemon IPC write road (dec_01KXDR0A9AR1Z57Q3M1JEDMBVR). One preset-guidance row records create-milestone agent writes beneath the configured repository-relative milestones root. One GUI daemon-restart row registers the Settings System admin.daemon.restart IPC write road. Two W-A2 rows register the daemon-owned durable agent-runtime session store and authenticated daemon RPC spawn/attach control road. Two W-C1 backend rows register daemon-owned terminal registry persistence and detach/confirmed-terminate RPC control. One daemon service-launch row registers the endpoint-keyed structured launch-option spec (atomic owner-only 0600 rewrite in daemon user root) enabling flagless cold-start restoration of --authority-manifest and --authored-root under baseline-governance task_01KXX5515PKE4NSHGHJDX3DKW0. Three PLT-Boundary S1 rows register the installation-scoped machine identity, endpoint-scoped daemon generation, and periodic runtime-registration projection operational records under task_01KXZTWY17ZVH5FWRCRV86J16C."
+    "registryRows": 62,
+    "difference": "One phase 1 feature row is retired. Six additional rows split mixed write functions and infrastructure: module canonical/view, script declared writes/produces, worktree code/binding, task-holder runtime state, one WriteCoordinator runtime substrate row, and the Fact-to-Execution administrative migration road. Three hosted typed-authority rows keep Execution, execution-scoped Review, and human Consent records RPC-only. Two further ADR-0028 P4 rows register the attributed doc_sync_submit coordinator road and the preset script staging-mirror ingest road. One ADR-0028 P5 row registers the coordinator-owned immutable attribution event trail. One parallel authority-attribution-event/v2 sibling row registers canonical-byte append, read-after-write, recovery, retention, backup, integrity, and materializer coverage under dec_01KXNB6RYNBD9SJBCXGWTDRP8A. One dedicated T4 administrative migration row registers the attributed, confirmed-plan, key-only retirement of historical ownership fields. One ADR-0029 TW-01 row registers the authority replication submission road (attributed-coordinator entry over forced-command SSH). One ADR-0029 TW-02 row registers the compound receipt durable store (client-side crash-recovery receipt records, fsync + atomic rename). One ADR-0029 TW-03 row registers the broker local-view native applier (crash-safe transparent view materialization). One ADR-0029 TW-04 row registers the platform semantic-probe scratch writes (temporary qualification probes, created and removed inside one probe run). One ADR-0029 TW-06 row registers the authority fence enrollment anchor and durability boundary stores. One authority key-material row registers fd-secure private material in repository-external service state as non-SoT state under dec_01KXN3ZDDNPVZ6ADH62R69MTCN; repository, harness, CAS, and backup roots remain forbidden. One authority lifecycle row registers restart-replayed per-repo operations, replica changes, bindings, and namespaces under daemon service state. One daemon transport row registers the socket owner-lock lifecycle state (task_01KXD0A37NN8ZQEJ2ENG5K313V): ephemeral single-instance mutex outside SoT, not entity data. One daemon operational-log row registers the repository-external append, rotation, and retention store under dec_01KXMZZ92BY0KJW1482WMBRF1K. One identity bootstrap row registers the user-profile people roster boundary (XD-1/XD-2). Two GUI decision rows register proposal and judgment transitions through the authenticated daemon IPC write road (dec_01KXDR0A9AR1Z57Q3M1JEDMBVR). One preset-guidance row records create-milestone agent writes beneath the configured repository-relative milestones root. One GUI daemon-restart row registers the Settings System admin.daemon.restart IPC write road. Two W-A2 rows register the daemon-owned durable agent-runtime session store and authenticated daemon RPC spawn/attach control road. Two W-C1 backend rows register daemon-owned terminal registry persistence and detach/confirmed-terminate RPC control. One daemon service-launch row registers the endpoint-keyed structured launch-option spec (atomic owner-only 0600 rewrite in daemon user root) enabling flagless cold-start restoration of --authority-manifest and --authored-root under baseline-governance task_01KXX5515PKE4NSHGHJDX3DKW0. Three PLT-Boundary S1 rows register the installation-scoped machine identity, endpoint-scoped daemon generation, and periodic runtime-registration projection operational records under task_01KXZTWY17ZVH5FWRCRV86J16C. One daemon snapshot-install row registers repository-external immutable runtime artifacts and temporary build worktree lifecycle under task_01KY2WBYH520GMVJK5K76SH1WJ and dec_01KY2PJRGWXEJDH3E622553HZK."
   },
   "rows": [
     {
@@ -1861,6 +1863,37 @@
         "packages/kernel/src/daemon/registry.ts:85"
       ],
       "freshness": "post-listen-authority-pointer-then-endpoint-sha256-keyed-structured-options-atomic-temp-rename-owner-only-0600-rewrite"
+    },
+    {
+      "id": "daemon.snapshot.install",
+      "sourceInventoryRows": [
+        26
+      ],
+      "road": "D",
+      "bearing": "daemon-snapshot-install",
+      "leaseRequired": false,
+      "owner": "daemon snapshot installer",
+      "purpose": "Build and install a versioned daemon runtime snapshot beneath the repository-external user root, including an isolated temporary Git worktree for explicit refs; these immutable runtime artifacts and cleanup paths are not authored SoT.",
+      "channel": {
+        "pathClass": "runtime-local-durable",
+        "zoneClass": "non-sot-installed-artifact"
+      },
+      "entry": [
+        "daemon-snapshot-install",
+        "daemon-upgrade"
+      ],
+      "directWrites": [
+        {
+          "file": "packages/cli/src/commands/daemon/snapshot.ts"
+        }
+      ],
+      "evidence": [
+        "packages/cli/src/commands/daemon/snapshot.ts:62",
+        "packages/cli/src/commands/daemon/snapshot.ts:96",
+        "packages/cli/src/commands/daemon/snapshot.ts:158",
+        "packages/cli/src/commands/daemon/snapshot.ts:214"
+      ],
+      "freshness": "content-and-source-fingerprinted-version-directory-staged-then-atomic-rename-no-overwrite-with-best-effort-temporary-worktree-cleanup"
     },
     {
       "id": "daemon.agent-runtime.session-store",


### PR DESCRIPTION
# English

## Summary

The accepted daemon run-model decision rules that the repo daemon runs a pinned stable snapshot decoupled from the in-development `dist`, and that version switches happen only through a graceful restart path. This PR delivers both deliverables: immutable versioned daemon snapshots with a manifest, and a product-grade `ha daemon upgrade` that prepares a snapshot, drains the incumbent through the existing refresh RPC, starts the replacement from the snapshot entrypoint, and verifies identity/authority convergence — with fail-closed rollback.

## What Changed

- `ha daemon snapshot install [--ref <ref>] [--version <v>]`: atomically installs `dist` plus the non-workspace runtime dependency closure into `<userRoot>/daemon-snapshots/<version>/`, writing a `daemon-snapshot-manifest/v1` (source ref/commit, dirty-source fingerprint, build time, content fingerprint, artifact count, dependency closure). Same version + same source verifies the installed fingerprint and returns `installed:false`; same version + different source refuses to overwrite. `--ref` builds in a temporary detached worktree with repo hooks disabled, cleaned up on success or failure.
- `ha daemon upgrade`: snapshot prepare → drain via the existing refresh RPC → replacement started from the snapshot entrypoint → convergence checks reusing the established criteria (PID change, loaded/installed identity == manifest fingerprint, no active operation, authority generation). Drain/RPC failure before replacement leaves launch configuration and the old owner untouched.
- Rollback: if the new snapshot fails to start or converge, the old launch configuration is restarted only after the endpoint is released; rollback is only reported complete when the old artifact identity and authority generation converge. If the endpoint is still occupied it fails closed — no dual owner is ever created.
- Tests: 39/39 targeted (launch-spec, control dispatcher, snapshot, upgrade); 14/14 full related integration group including a real end-to-end upgrade (PID 6566 → 26947, launch-spec pointing at the snapshot entrypoint, fingerprints converged) and a real stuck-drain negative control (`daemon_queue_drain_timeout`, old owner and in-flight ledger preserved).

## Task And Scope

- Task: `task_01KY2WBYH520GMVJK5K76SH1WJ`, derived from decision `dec_01KY2PJRGWXEJDH3E622553HZK` (CH2 snapshot pinning + CH4 deliverable "graceful restart script productization").
- Scope: CLI daemon snapshot/upgrade commands and control-path entrypoint plumbing. Generation fence, recovery semantics, and drain semantics untouched.

## Version Impact

No package version bump. New command surface `ha daemon snapshot install` / `ha daemon upgrade`; existing `ha daemon refresh` behavior unchanged (dispatcher regressions pass).

## Governance Declaration

Daemon lifecycle control is a production-critical surface. Authority: accepted decision `dec_01KY2PJRGWXEJDH3E622553HZK` — "the repo daemon runs a pinned stable snapshot and version switches go only through the graceful restart path" — whose deliverables 2 and 4 map exactly to this change; ledger task `task_01KY2WBYH520GMVJK5K76SH1WJ`. The upgrade path reuses the existing refresh RPC and its convergence criteria rather than introducing a parallel control road; no gate or manifest is modified.

## Verification

- Targeted: 39/39; related integration group 14/14 (72.4s), including real upgrade and stuck-drain scenarios with transcripts in the worker report.
- `--ref` product smoke: snapshot of HEAD installed with `sourceDirty=false` and verified fingerprint.
- TypeScript, ESLint, file-complexity, CLI structure and help-contract checkers pass.

## Review Evidence

Worker report with full runner transcripts, the real PID-handoff evidence, and the drain-timeout negative control: `harness/tasks/task_01KY2WBYH520GMVJK5K76SH1WJ-daemon-2-4/artifacts/worker-report.md` (ledger-side, not in this diff).

## Residual Risk

Snapshot GC/retention is not implemented (snapshots accumulate under the user root until manually removed). The upgrade path has not yet been exercised against the production政体 daemon — that switch is deliberately left for an operator-initiated run.

## References

- Decision: `dec_01KY2PJRGWXEJDH3E622553HZK`; task package: `harness/tasks/task_01KY2WBYH520GMVJK5K76SH1WJ-daemon-2-4/`.

---

# 中文

## 概要

已 accept 的 daemon 运行模型决策裁定:本仓 daemon 跑与开发 `dist` 解耦的钉住稳定快照,版本切换只经优雅重启路径。本 PR 交付两个落地件:带 manifest 的不可变版本化 daemon 快照,以及产品级 `ha daemon upgrade`——准备快照→经既有 refresh RPC drain 现役→以快照 entrypoint 启动 replacement→验证 identity/authority 收敛,失败 fail-closed 回滚。

## 改动内容

- `ha daemon snapshot install [--ref <ref>] [--version <v>]`:把 `dist` 与非 workspace 运行时依赖闭包原子安装到 `<userRoot>/daemon-snapshots/<version>/`,写 `daemon-snapshot-manifest/v1`(源 ref/commit、dirty 源码指纹、构建时间、内容指纹、artifact 数、依赖闭包)。同版本同源校验指纹返回 `installed:false`;同版本异源拒绝覆盖;`--ref` 用临时 detached worktree 构建(禁 hook,成败都清理)。
- `ha daemon upgrade`:快照准备→既有 refresh RPC drain→快照 entrypoint 启动 replacement→复用既有收敛判据(PID 变化、loaded/installed identity==manifest 指纹、无 active operation、authority generation)。drain/RPC 在 replacement 之前失败则不动 launch configuration、不启新进程。
- 回滚:新快照启动或收敛失败,仅在 endpoint 已释放后重启旧 launch configuration;旧 artifact identity 与 authority generation 双收敛才报告回滚完成;endpoint 仍占用则 fail closed,绝不制造双 owner。
- 测试:定向 39/39;相关完整集成组 14/14,含真实端到端升级(PID 6566→26947,launch-spec 指向快照 entrypoint,指纹收敛)与真实卡 drain 阴性对照(`daemon_queue_drain_timeout`,旧 owner 与在途账保留)。

## 任务与范围

- 任务:`task_01KY2WBYH520GMVJK5K76SH1WJ`,由决策 `dec_01KY2PJRGWXEJDH3E622553HZK`(CH2 快照钉住+CH4 落地件「优雅重启脚本产品化」)派生。
- 范围:CLI daemon snapshot/upgrade 命令与 control 路 entrypoint 接线。generation fence、恢复语义、drain 语义未动。

## 版本影响

无包版本变更。新增命令面 `ha daemon snapshot install` / `ha daemon upgrade`;既有 `ha daemon refresh` 行为不变(dispatcher 回归通过)。

## 治理声明

daemon 生命周期控制属生产关键面。授权依据:已 accept 决策 `dec_01KY2PJRGWXEJDH3E622553HZK`(「daemon 跑钉住稳定快照、切版本只经优雅重启路径」),其落地件 2、4 即本改动;台账任务 `task_01KY2WBYH520GMVJK5K76SH1WJ`。升级路复用既有 refresh RPC 与收敛判据而非另起平行控制路;未修改任何 gate 或 manifest。

## 验证

- 定向 39/39;相关集成组 14/14(72.4s),含真实升级与卡 drain 场景,输出原文见 worker 报告。
- `--ref` 产品烟测:HEAD 快照安装,`sourceDirty=false`,指纹校验通过。
- TypeScript、ESLint、复杂度门、CLI structure 与 help-contract checker 通过。

## 审查证据

worker 报告含完整 runner 输出、真实 PID 换班证据与 drain 超时阴性对照:`harness/tasks/task_01KY2WBYH520GMVJK5K76SH1WJ-daemon-2-4/artifacts/worker-report.md`(台账侧,不在本 diff 内)。

## 残余风险

快照 GC/保留策略未实现(快照在 user root 下累积,需手动清理)。升级路径尚未对生产政体 daemon 实操——该切换刻意留给操作者手动发起。

## 关联材料

- 决策:`dec_01KY2PJRGWXEJDH3E622553HZK`;任务包:`harness/tasks/task_01KY2WBYH520GMVJK5K76SH1WJ-daemon-2-4/`。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Targeted tests green / 定向测试全绿
- [x] Protected-surface change declared with decision authority / protected surface 改动已带决策授权申报
