### PR TITLE
fix(deps): bump fast-uri to 3.1.4 for GHSA-v2hh-gcrm-f6hx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6153,9 +6153,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
# English

## Summary

GitHub advisory GHSA-v2hh-gcrm-f6hx (high severity, "fast-uri vulnerable to host confusion via literal backslash authority delimiter") was published upstream after tonight's merges and turned the `check-supply-chain` gate red on main's full-check run — an ecosystem event, not a code regression. This PR bumps the transitive dependency `fast-uri` 3.1.3 → 3.1.4 (semver-patch, via ajv → app-builder-lib → electron-builder in the GUI workspace) to the fixed release.

## What Changed

- `package-lock.json` only: fast-uri 3.1.3 → 3.1.4 (3 lines).

## Task And Scope

- Task: `task_01KY3E2GVTB2DQ2SHSPA89ZM82`. Scope: one transitive dependency pin in the lockfile.

## Version Impact

No package version bump. No dependency added or removed; no license tuple change (same package, patch release).

## Governance Declaration

`package-lock.json` is a protected path. Authority: ledger task `task_01KY3E2GVTB2DQ2SHSPA89ZM82` (upstream advisory GHSA-v2hh-gcrm-f6hx fix-forward under the post-merge red triage protocol). Same-package semver-patch pin; no dependency added or removed, no license tuple change, no gate modified.

## Verification

- `npm audit --audit-level=high`: 0 vulnerabilities after the bump.
- `npm run harness:check-supply-chain` (with repo credentials): "Supply chain check passed with CycloneDX SBOM and release/license gates."
- `npm ls fast-uri`: 3.1.4 everywhere (deduped).

## Review Evidence

Main-run failure evidence: run 29868746033 attempt 2, `check-supply-chain failed` citing GHSA-v2hh-gcrm-f6hx.

## Residual Risk

None beyond normal patch-release risk; fast-uri is exercised only through the electron-builder tool chain.

## References

- Advisory: GHSA-v2hh-gcrm-f6hx.

---

# 中文

## 概要

GitHub 安全公告 GHSA-v2hh-gcrm-f6hx(高危,fast-uri 反斜杠 authority 分隔符宿主混淆)在今晚合并之后由上游发布,导致 main 全量 run 的 `check-supply-chain` 门变红——这是生态事件,不是代码回归。本 PR 把传递依赖 `fast-uri` 3.1.3 → 3.1.4(semver patch,经 GUI workspace 的 ajv → app-builder-lib → electron-builder 链)升到修复版。

## 改动内容

- 仅 `package-lock.json`:fast-uri 3.1.3 → 3.1.4(3 行)。

## 任务与范围

- 任务:`task_01KY3E2GVTB2DQ2SHSPA89ZM82`。范围:锁文件中一个传递依赖钉版。

## 版本影响

无包版本变更;未增删依赖;许可证元组不变(同包 patch 版)。

## 治理声明

`package-lock.json` 属 protected 路径。授权依据:台账任务 `task_01KY3E2GVTB2DQ2SHSPA89ZM82`(上游公告 GHSA-v2hh-gcrm-f6hx 的 post-merge 红处置 fix-forward)。同包 semver patch 钉版;未增删依赖、许可证元组不变、未改任何门。

## 验证

- 升级后 `npm audit --audit-level=high`:0 漏洞。
- `npm run harness:check-supply-chain`(带仓库凭证):SBOM 与 release/license 门通过。
- `npm ls fast-uri`:全树 3.1.4(deduped)。

## 审查证据

main run 29868746033 attempt 2 的 `check-supply-chain failed` 原文引 GHSA-v2hh-gcrm-f6hx。

## 残余风险

patch 版常规风险之外无;fast-uri 仅经 electron-builder 工具链使用。

## 关联材料

- 公告:GHSA-v2hh-gcrm-f6hx。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Targeted tests green / 定向测试全绿
