### PR TITLE
fix(cli): retry contested daemon upgrade handoffs with bounded evidence

### DIFF
--- a/packages/cli/src/commands/daemon/control-handoff.ts
+++ b/packages/cli/src/commands/daemon/control-handoff.ts
@@ -1,0 +1,91 @@
+import type { LocalDaemonTarget } from "@harness-anything/daemon";
+import {
+  daemonControlFailure,
+  isCompleteReplacement,
+  normalizeDaemonLifecycleStatus,
+  replacementIdentityIsInvalid,
+  type DaemonGenerationConvergenceExpectation,
+  type DaemonLifecycleStatus
+} from "./control-convergence.ts";
+
+export type DaemonControlHandoff =
+  | { readonly kind: "adopt"; readonly status: Record<string, unknown> }
+  | { readonly kind: "reject"; readonly status: DaemonLifecycleStatus }
+  | { readonly kind: "autostart" };
+
+interface DaemonControlHandoffLifecycle {
+  readonly target: LocalDaemonTarget;
+  readonly probeStatus: (
+    target: LocalDaemonTarget,
+    capability?: { readonly includeGenerationAxes: true }
+  ) => Promise<Record<string, unknown> | undefined>;
+  readonly ownerIsAlive: (pid: number) => boolean;
+  readonly wait: (ms: number) => Promise<void>;
+}
+
+export async function waitForDaemonControlHandoff(
+  lifecycle: DaemonControlHandoffLifecycle,
+  beforePid: number,
+  operationId: string,
+  timeoutMs: number,
+  expectedIdentity: string | undefined,
+  expectedGeneration: DaemonGenerationConvergenceExpectation | undefined
+): Promise<DaemonControlHandoff> {
+  const pollIntervalMs = 100;
+  const attempts = Math.ceil(timeoutMs / pollIntervalMs) + 1;
+  let pendingReplacement: DaemonLifecycleStatus | undefined;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const status = await lifecycle.probeStatus(
+      lifecycle.target,
+      expectedGeneration ? { includeGenerationAxes: true } : undefined
+    );
+    const ownerAlive = lifecycle.ownerIsAlive(beforePid);
+    const controlFailure = daemonControlFailure(status, operationId);
+    if (controlFailure) throw new Error(controlFailure);
+
+    // One service process owns each OS-user + userRoot pair. While the old
+    // owner lives, neither a reachable endpoint nor autostart can prove a safe handoff.
+    if (!ownerAlive) {
+      // Once the owner is dead, an absent exact endpoint is the only state
+      // that permits the existing autostart primitive to run.
+      if (!status) return { kind: "autostart" };
+      const observedLifecycle = normalizeDaemonLifecycleStatus(status);
+      if (observedLifecycle && isCompleteReplacement(observedLifecycle, beforePid, operationId, expectedIdentity, expectedGeneration)) {
+        return { kind: "adopt", status };
+      }
+      if (observedLifecycle && observedLifecycle.pid !== beforePid && replacementIdentityIsInvalid(observedLifecycle, expectedIdentity)) {
+        return { kind: "reject", status: observedLifecycle };
+      }
+      if (observedLifecycle?.pid !== beforePid) pendingReplacement = observedLifecycle;
+      // Reachable old-PID or malformed status is not replacement proof and
+      // blocks autostart, avoiding an overlapping service-owner window.
+    }
+
+    if (attempt + 1 === attempts) {
+      if (pendingReplacement) {
+        if (pendingReplacement.activeOperationId && pendingReplacement.activeOperationId !== operationId) {
+          throw new Error(
+            `another daemon control operation remained active: ${pendingReplacement.activeOperationId}; `
+            + "replacement was left running"
+          );
+        }
+        return { kind: "reject", status: pendingReplacement };
+      }
+      if (status) {
+        for (let finalAttempt = 0; finalAttempt < 5; finalAttempt += 1) {
+          await lifecycle.wait(pollIntervalMs);
+          const finalStatus = await lifecycle.probeStatus(
+            lifecycle.target,
+            expectedGeneration ? { includeGenerationAxes: true } : undefined
+          );
+          const finalControlFailure = daemonControlFailure(finalStatus, operationId);
+          if (finalControlFailure) throw new Error(finalControlFailure);
+        }
+        throw new Error(`old daemon endpoint was not released before timeout (pid ${beforePid})`);
+      }
+      throw new Error(`old daemon owner did not exit after releasing its endpoint (pid ${beforePid})`);
+    }
+    await lifecycle.wait(pollIntervalMs);
+  }
+  throw new Error(`daemon control handoff exhausted without a safe decision (pid ${beforePid})`);
+}

--- a/packages/cli/src/commands/daemon/control-replacement.ts
+++ b/packages/cli/src/commands/daemon/control-replacement.ts
@@ -1,0 +1,366 @@
+import type { LocalDaemonTarget } from "@harness-anything/daemon";
+import type { DaemonLaunchConfiguration } from "../../daemon/daemon-launch-spec.ts";
+import {
+  incompleteReplacementReason,
+  isCompleteReplacement,
+  normalizeDaemonLifecycleStatus,
+  replacementIdentityIsInvalid,
+  type DaemonGenerationConvergenceExpectation,
+  type DaemonLifecycleStatus
+} from "./control-convergence.ts";
+import { waitForDaemonControlHandoff } from "./control-handoff.ts";
+import { daemonRecoveryCommand, rollbackDaemonReplacement } from "./snapshot-rollback.ts";
+
+export interface DaemonControlLifecycle {
+  readonly target: LocalDaemonTarget;
+  readonly probeGenerationStatus?: (target: LocalDaemonTarget) => Promise<Record<string, unknown> | undefined>;
+  readonly probeStatus: (
+    target: LocalDaemonTarget,
+    capability?: { readonly includeGenerationAxes: true }
+  ) => Promise<Record<string, unknown> | undefined>;
+  readonly ownerIsAlive: (pid: number) => boolean;
+  readonly prepareReplacement?: (target: LocalDaemonTarget) => Promise<DaemonLaunchConfiguration>;
+  readonly startReplacement: (
+    target: LocalDaemonTarget,
+    timeoutMs: number,
+    launchConfiguration: DaemonLaunchConfiguration,
+    capability?: { readonly includeGenerationAxes: true }
+  ) => Promise<Record<string, unknown>>;
+  readonly stopReplacement?: (target: LocalDaemonTarget, pid: number, timeoutMs: number) => Promise<void>;
+  readonly wait: (ms: number) => Promise<void>;
+}
+
+export interface DaemonControlRecoveryGuidance {
+  readonly retryCommand: string;
+  readonly occupiedEndpoint: string;
+}
+
+interface HandoffRecoveryAttempt {
+  readonly attempt: number;
+  readonly occupantPid: number;
+  readonly loadedIdentity: string;
+  readonly expectedSnapshotIdentity: string;
+  readonly disposition: "stopped-and-retrying" | "stopped-retry-exhausted" | "stopped-successor-detected" | "cleanup-failed";
+  readonly cleanupFailure?: string;
+  readonly successorPid?: number;
+}
+
+interface CompleteDaemonReplacementInput {
+  readonly lifecycle: DaemonControlLifecycle;
+  readonly beforePid: unknown;
+  readonly beforeLoadedIdentity: unknown;
+  readonly operationId: unknown;
+  readonly timeoutMs: number;
+  readonly kind: "restart" | "refresh";
+  readonly method: "admin.daemon.restart" | "admin.daemon.refresh";
+  readonly launchConfiguration: DaemonLaunchConfiguration;
+  readonly expectedIdentity: string | undefined;
+  readonly expectedGeneration: DaemonGenerationConvergenceExpectation | undefined;
+  readonly rollbackLaunchConfiguration?: DaemonLaunchConfiguration;
+  readonly upgradeRecovery?: DaemonControlRecoveryGuidance;
+}
+
+interface StartedReplacementResult {
+  readonly kind: "complete" | "wrong-snapshot-occupant";
+  readonly status: Record<string, unknown>;
+  readonly lifecycle: DaemonLifecycleStatus;
+}
+
+const upgradeHandoffMaxAttempts = 3;
+
+export async function completeDaemonReplacement(
+  input: CompleteDaemonReplacementInput
+): Promise<Record<string, unknown>> {
+  if (!isPositivePid(input.beforePid)) {
+    throw new Error(`${input.method} accepted receipt did not identify the running daemon PID`);
+  }
+  if (typeof input.beforeLoadedIdentity !== "string" || typeof input.operationId !== "string") {
+    throw new Error(`${input.method} accepted receipt did not identify the loaded build and operation`);
+  }
+  const attempts: HandoffRecoveryAttempt[] = [];
+  const maxAttempts = input.upgradeRecovery ? upgradeHandoffMaxAttempts : 1;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const result = await attemptDaemonReplacement(input, input.beforePid, input.beforeLoadedIdentity, input.operationId);
+    if (result.kind === "complete") {
+      return withHandoffRecovery(result.status, input.upgradeRecovery, attempt, attempts);
+    }
+    await stopWrongSnapshotOccupant(input, result.lifecycle, input.operationId, attempt, maxAttempts, attempts);
+  }
+  throw new Error("daemon replacement retry loop exhausted without a terminal result");
+}
+
+async function attemptDaemonReplacement(
+  input: CompleteDaemonReplacementInput,
+  beforePid: number,
+  beforeLoadedIdentity: string,
+  operationId: string
+): Promise<StartedReplacementResult> {
+  const handoff = await waitForDaemonControlHandoff(
+    input.lifecycle, beforePid, operationId, input.timeoutMs, input.expectedIdentity, input.expectedGeneration
+  );
+  if (handoff.kind === "adopt") {
+    const lifecycle = normalizeDaemonLifecycleStatus(handoff.status);
+    if (!lifecycle) throw new Error(`daemon ${input.kind} adopted replacement returned an invalid status`);
+    return { kind: "complete", status: handoff.status, lifecycle };
+  }
+  if (handoff.kind === "reject") {
+    if (isWrongSnapshotOccupant(handoff.status, input.expectedIdentity, operationId, input.upgradeRecovery)) {
+      return { kind: "wrong-snapshot-occupant", status: lifecycleStatusRecord(handoff.status), lifecycle: handoff.status };
+    }
+    await rejectIncompleteReplacement(input, handoff.status, beforePid, operationId);
+  }
+  let replacement: Record<string, unknown>;
+  try {
+    replacement = await input.lifecycle.startReplacement(
+      input.lifecycle.target,
+      input.timeoutMs,
+      input.launchConfiguration,
+      input.expectedGeneration ? { includeGenerationAxes: true } : undefined
+    );
+  } catch (error) {
+    return await failOrRollback(input, error, beforePid, beforeLoadedIdentity, operationId, true);
+  }
+  try {
+    const replacementLifecycle = normalizeDaemonLifecycleStatus(replacement);
+    if (!replacementLifecycle) {
+      throw new Error(`daemon ${input.kind} replacement did not return a reachable started daemon status`);
+    }
+    if (replacementLifecycle.pid === beforePid) {
+      throw new Error(`daemon ${input.kind} replacement PID did not change: ${String(replacementLifecycle.pid)}; replacement was not signaled`);
+    }
+    return await waitForStartedReplacement(input, replacement, replacementLifecycle, beforePid, operationId);
+  } catch (error) {
+    return await failOrRollback(input, error, beforePid, beforeLoadedIdentity, operationId, false);
+  }
+}
+
+async function waitForStartedReplacement(
+  input: CompleteDaemonReplacementInput,
+  initialStatus: Record<string, unknown>,
+  initialLifecycle: DaemonLifecycleStatus,
+  beforePid: number,
+  operationId: string
+): Promise<StartedReplacementResult> {
+  let status = initialStatus;
+  let replacement = initialLifecycle;
+  const pollIntervalMs = 100;
+  const attempts = Math.ceil(input.timeoutMs / pollIntervalMs) + 1;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (replacement.pid === beforePid) {
+      throw new Error(`daemon ${input.kind} replacement PID did not change: ${String(replacement.pid)}; replacement was not signaled`);
+    }
+    if (replacementIdentityIsInvalid(replacement, input.expectedIdentity)) {
+      await rejectIncompleteReplacement(input, replacement, beforePid, operationId);
+    }
+    if (isCompleteReplacement(replacement, beforePid, operationId, input.expectedIdentity, input.expectedGeneration)) {
+      return { kind: "complete", status, lifecycle: replacement };
+    }
+    if (attempt + 1 < attempts) {
+      await input.lifecycle.wait(pollIntervalMs);
+      const observed = await input.lifecycle.probeStatus(
+        input.lifecycle.target,
+        input.expectedGeneration ? { includeGenerationAxes: true } : undefined
+      );
+      const observedLifecycle = observed ? normalizeDaemonLifecycleStatus(observed) : undefined;
+      if (observed && observedLifecycle) {
+        status = observed;
+        replacement = observedLifecycle;
+      }
+    }
+  }
+  if (replacement.activeOperationId && replacement.activeOperationId !== operationId) {
+    throw new Error(
+      `daemon ${input.kind} replacement remained healthy but another daemon control operation remained active: `
+      + `${replacement.activeOperationId}; replacement was left running`
+    );
+  }
+  return await rejectIncompleteReplacement(input, replacement, beforePid, operationId);
+}
+
+async function stopWrongSnapshotOccupant(
+  input: CompleteDaemonReplacementInput,
+  occupant: DaemonLifecycleStatus,
+  operationId: string,
+  attempt: number,
+  maxAttempts: number,
+  attempts: HandoffRecoveryAttempt[]
+): Promise<void> {
+  const expectedIdentity = input.expectedIdentity!;
+  const base = {
+    attempt,
+    occupantPid: occupant.pid,
+    loadedIdentity: occupant.loadedIdentity!,
+    expectedSnapshotIdentity: expectedIdentity
+  } as const;
+  if (!input.lifecycle.stopReplacement) {
+    attempts.push({ ...base, disposition: "cleanup-failed", cleanupFailure: "cleanup unavailable" });
+    throw recoveryError(
+      `daemon upgrade found a wrong-identity endpoint owner; cleanup unavailable; replacement may still be serving. ${input.upgradeRecovery!.occupiedEndpoint}`,
+      maxAttempts,
+      attempt,
+      attempts
+    );
+  }
+  try {
+    await input.lifecycle.stopReplacement(input.lifecycle.target, occupant.pid, input.timeoutMs);
+  } catch (error) {
+    const failure = daemonReplacementErrorMessage(error);
+    const successor = await probeWrongSnapshotSuccessor(input, occupant, operationId);
+    if (successor) {
+      attempts.push({
+        ...base,
+        disposition: "stopped-successor-detected",
+        cleanupFailure: failure,
+        successorPid: successor.pid
+      });
+      if (attempt < maxAttempts) return;
+      throw recoveryError(
+        `DAEMON_UPGRADE_HANDOFF_RETRIES_EXHAUSTED: stopping pid ${occupant.pid} exposed another wrong-identity endpoint owner pid ${successor.pid}. ${input.upgradeRecovery!.occupiedEndpoint}`,
+        maxAttempts,
+        attempt,
+        attempts
+      );
+    }
+    attempts.push({ ...base, disposition: "cleanup-failed", cleanupFailure: failure });
+    throw recoveryError(
+      `daemon upgrade found a wrong-identity endpoint owner; cleanup failed and replacement may still be serving: ${failure}. ${input.upgradeRecovery!.occupiedEndpoint}`,
+      maxAttempts,
+      attempt,
+      attempts
+    );
+  }
+  const exhausted = attempt === maxAttempts;
+  attempts.push({ ...base, disposition: exhausted ? "stopped-retry-exhausted" : "stopped-and-retrying" });
+  if (exhausted) {
+    throw recoveryError(
+      `DAEMON_UPGRADE_HANDOFF_RETRIES_EXHAUSTED: stopped ${maxAttempts} wrong-identity endpoint owners; endpoint remained unowned. Retry exactly with: ${input.upgradeRecovery!.retryCommand}`,
+      maxAttempts,
+      attempt,
+      attempts
+    );
+  }
+}
+
+async function rejectIncompleteReplacement(
+  input: CompleteDaemonReplacementInput,
+  replacement: DaemonLifecycleStatus,
+  beforePid: number,
+  operationId: string
+): Promise<never> {
+  const failure = incompleteReplacementReason(
+    replacement, beforePid, operationId, input.expectedIdentity, input.expectedGeneration
+  );
+  if (replacement.pid === beforePid) {
+    throw new Error(`daemon ${input.kind} replacement ${failure}; replacement was not signaled`);
+  }
+  if (!input.lifecycle.stopReplacement) {
+    throw new Error(`daemon ${input.kind} replacement ${failure}; cleanup unavailable; replacement may still be serving`);
+  }
+  try {
+    await input.lifecycle.stopReplacement(input.lifecycle.target, replacement.pid, input.timeoutMs);
+  } catch (error) {
+    throw new Error(
+      `daemon ${input.kind} replacement ${failure}; cleanup failed and replacement may still be serving: ${daemonReplacementErrorMessage(error)}`
+    );
+  }
+  throw new Error(`daemon ${input.kind} replacement ${failure}; rejected replacement was stopped and endpoint remained unowned`);
+}
+
+async function failOrRollback(
+  input: CompleteDaemonReplacementInput,
+  error: unknown,
+  beforePid: number,
+  beforeLoadedIdentity: string,
+  operationId: string,
+  wrapReplacementStartFailure: boolean
+): Promise<never> {
+  const failure = wrapReplacementStartFailure
+    ? new Error(
+        `DAEMON_${input.kind.toUpperCase()}_REPLACEMENT_FAILED_AFTER_HANDOFF: ${daemonReplacementErrorMessage(error)}. `
+        + `Restore the daemon with: ${daemonRecoveryCommand(input.rollbackLaunchConfiguration ?? input.launchConfiguration)}`
+      )
+    : error;
+  if (!input.rollbackLaunchConfiguration) throw failure;
+  return await rollbackDaemonReplacement({
+    lifecycle: input.lifecycle,
+    replacementFailure: failure,
+    beforePid,
+    beforeLoadedIdentity,
+    operationId,
+    timeoutMs: input.timeoutMs,
+    kind: input.kind,
+    launchConfiguration: input.rollbackLaunchConfiguration,
+    expectedGeneration: input.expectedGeneration
+  });
+}
+
+async function probeWrongSnapshotSuccessor(
+  input: CompleteDaemonReplacementInput,
+  occupant: DaemonLifecycleStatus,
+  operationId: string
+): Promise<DaemonLifecycleStatus | undefined> {
+  const status = await input.lifecycle.probeStatus(
+    input.lifecycle.target,
+    input.expectedGeneration ? { includeGenerationAxes: true } : undefined
+  );
+  const successor = status ? normalizeDaemonLifecycleStatus(status) : undefined;
+  return successor
+    && successor.pid !== occupant.pid
+    && isWrongSnapshotOccupant(successor, input.expectedIdentity, operationId, input.upgradeRecovery)
+    ? successor
+    : undefined;
+}
+
+function isWrongSnapshotOccupant(
+  status: DaemonLifecycleStatus,
+  expectedIdentity: string | undefined,
+  operationId: string,
+  recovery: DaemonControlRecoveryGuidance | undefined
+): boolean {
+  return recovery !== undefined
+    && status.schema === "daemon-status/v2"
+    && typeof status.loadedIdentity === "string"
+    && typeof expectedIdentity === "string"
+    && status.loadedIdentity !== expectedIdentity
+    && (status.activeOperationId === undefined || status.activeOperationId === operationId);
+}
+
+function withHandoffRecovery(
+  status: Record<string, unknown>,
+  recovery: DaemonControlRecoveryGuidance | undefined,
+  attemptsUsed: number,
+  attempts: ReadonlyArray<HandoffRecoveryAttempt>
+): Record<string, unknown> {
+  if (!recovery) return status;
+  return {
+    ...status,
+    handoffRecovery: {
+      maxAttempts: upgradeHandoffMaxAttempts,
+      attemptsUsed,
+      retryCount: attempts.length,
+      attempts
+    }
+  };
+}
+
+function recoveryError(
+  message: string,
+  maxAttempts: number,
+  attemptsUsed: number,
+  attempts: ReadonlyArray<HandoffRecoveryAttempt>
+): Error {
+  const evidence = { maxAttempts, attemptsUsed, retryCount: attempts.length, attempts };
+  return new Error(`${message}. Handoff recovery evidence: ${JSON.stringify(evidence)}`);
+}
+
+function lifecycleStatusRecord(status: DaemonLifecycleStatus): Record<string, unknown> {
+  return { ...status };
+}
+
+function daemonReplacementErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isPositivePid(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}

--- a/packages/cli/src/commands/daemon/control.ts
+++ b/packages/cli/src/commands/daemon/control.ts
@@ -15,23 +15,18 @@ import {
   type DaemonReplacementStopRuntime
 } from "./replacement-cleanup.ts";
 import {
-  daemonControlFailure,
-  incompleteReplacementReason,
-  isCompleteReplacement,
   normalizeDaemonLifecycleStatus,
-  replacementIdentityIsInvalid,
-  type DaemonGenerationConvergenceExpectation,
-  type DaemonLifecycleStatus
 } from "./control-convergence.ts";
+import {
+  completeDaemonReplacement,
+  type DaemonControlLifecycle,
+  type DaemonControlRecoveryGuidance
+} from "./control-replacement.ts";
 import {
   acceptedGenerationExpectation,
   generationExpectationFromCapabilityStatus
 } from "./control-generation-capability.ts";
-import {
-  daemonRecoveryCommand,
-  quoteDaemonRecoveryArgument,
-  rollbackDaemonReplacement
-} from "./snapshot-rollback.ts";
+import { quoteDaemonRecoveryArgument } from "./snapshot-rollback.ts";
 
 export type DaemonControlKind = "restart" | "refresh";
 type DaemonRefreshTrigger = "explicit" | "post-merge" | "dist-watcher";
@@ -41,24 +36,7 @@ export interface DaemonControlRequest {
   readonly params: JsonObject;
 }
 
-export interface DaemonControlLifecycle {
-  readonly target: LocalDaemonTarget;
-  readonly probeGenerationStatus?: (target: LocalDaemonTarget) => Promise<Record<string, unknown> | undefined>;
-  readonly probeStatus: (
-    target: LocalDaemonTarget,
-    capability?: { readonly includeGenerationAxes: true }
-  ) => Promise<Record<string, unknown> | undefined>;
-  readonly ownerIsAlive: (pid: number) => boolean;
-  readonly prepareReplacement?: (target: LocalDaemonTarget) => Promise<DaemonLaunchConfiguration>;
-  readonly startReplacement: (
-    target: LocalDaemonTarget,
-    timeoutMs: number,
-    launchConfiguration: DaemonLaunchConfiguration,
-    capability?: { readonly includeGenerationAxes: true }
-  ) => Promise<Record<string, unknown>>;
-  readonly stopReplacement?: (target: LocalDaemonTarget, pid: number, timeoutMs: number) => Promise<void>;
-  readonly wait: (ms: number) => Promise<void>;
-}
+export type { DaemonControlLifecycle } from "./control-replacement.ts";
 
 export interface DaemonControlCommandInput {
   readonly rootDir: string;
@@ -71,11 +49,6 @@ export interface DaemonControlCommandInput {
   readonly platform?: NodeJS.Platform;
   readonly replacementEntrypoint?: string;
 }
-
-type DaemonControlHandoff =
-  | { readonly kind: "adopt"; readonly status: Record<string, unknown> }
-  | { readonly kind: "reject"; readonly status: DaemonLifecycleStatus }
-  | { readonly kind: "autostart" };
 
 class DaemonRefreshWrongCheckoutError extends Error {
   constructor() {
@@ -139,19 +112,24 @@ export async function runDaemonControl(
   const expectedIdentity = kind === "refresh"
     ? preparedExpectedIdentity ?? calculateInstalledIdentity(input, launchConfiguration.entrypoint)
     : undefined;
-  const replacement = await completeDaemonReplacement(
+  const replacement = await completeDaemonReplacement({
     lifecycle,
-    before.pid,
-    before.loadedIdentity,
-    receipt.operationId,
-    drainTimeoutMs,
+    beforePid: before.pid,
+    beforeLoadedIdentity: before.loadedIdentity,
+    operationId: receipt.operationId,
+    timeoutMs: drainTimeoutMs,
     kind,
     method,
     launchConfiguration,
     expectedIdentity,
     expectedGeneration,
-    input.replacementEntrypoint ? preparedRunningLaunchConfiguration : undefined
-  );
+    ...(input.replacementEntrypoint && preparedRunningLaunchConfiguration
+      ? {
+          rollbackLaunchConfiguration: preparedRunningLaunchConfiguration,
+          upgradeRecovery: daemonControlRecoveryGuidance(input.args, lifecycle.target.userRoot)
+        }
+      : {})
+  });
   const { schema: controlSchema, ...controlResult } = receipt;
   return {
     ...controlResult,
@@ -205,151 +183,6 @@ function validateAcceptedControlReceipt(
     || receipt.operationId.length === 0) {
     throw new Error(`${method} did not return daemon-control-accepted/v1`);
   }
-}
-
-async function completeDaemonReplacement(
-  lifecycle: DaemonControlLifecycle,
-  beforePid: unknown,
-  beforeLoadedIdentity: unknown,
-  operationId: unknown,
-  timeoutMs: number,
-  kind: DaemonControlKind,
-  method: DaemonControlRequest["method"],
-  launchConfiguration: DaemonLaunchConfiguration,
-  expectedIdentity: string | undefined,
-  expectedGeneration: DaemonGenerationConvergenceExpectation | undefined,
-  rollbackLaunchConfiguration?: DaemonLaunchConfiguration
-): Promise<Record<string, unknown>> {
-  if (!isPositivePid(beforePid)) {
-    throw new Error(`${method} accepted receipt did not identify the running daemon PID`);
-  }
-  if (typeof beforeLoadedIdentity !== "string" || typeof operationId !== "string") {
-    throw new Error(`${method} accepted receipt did not identify the loaded build and operation`);
-  }
-  const handoff = await waitForDaemonControlHandoff(lifecycle, beforePid, operationId, timeoutMs, expectedIdentity, expectedGeneration);
-  if (handoff.kind === "adopt") return handoff.status;
-  if (handoff.kind === "reject") {
-    await rejectIncompleteReplacement(lifecycle, handoff.status, beforePid, operationId, timeoutMs, kind, expectedIdentity, expectedGeneration);
-  }
-  let replacement: Record<string, unknown>;
-  try {
-    replacement = await lifecycle.startReplacement(
-      lifecycle.target,
-      timeoutMs,
-      launchConfiguration,
-      expectedGeneration ? { includeGenerationAxes: true } : undefined
-    );
-  } catch (error) {
-    const failure = new Error(
-      `DAEMON_${kind.toUpperCase()}_REPLACEMENT_FAILED_AFTER_HANDOFF: ${error instanceof Error ? error.message : String(error)}. `
-      + `Restore the daemon with: ${daemonRecoveryCommand(rollbackLaunchConfiguration ?? launchConfiguration)}`
-    );
-    if (!rollbackLaunchConfiguration) throw failure;
-    return await rollbackDaemonReplacement({
-      lifecycle, replacementFailure: failure, beforePid, beforeLoadedIdentity, operationId,
-      timeoutMs, kind, launchConfiguration: rollbackLaunchConfiguration, expectedGeneration
-    });
-  }
-  try {
-    const replacementLifecycle = normalizeDaemonLifecycleStatus(replacement);
-    if (!replacementLifecycle) {
-      throw new Error(`daemon ${kind} replacement did not return a reachable started daemon status`);
-    }
-    if (replacementLifecycle.pid === beforePid) {
-      throw new Error(`daemon ${kind} replacement PID did not change: ${String(replacementLifecycle.pid)}; replacement was not signaled`);
-    }
-    return await waitForStartedReplacement(
-      lifecycle,
-      replacement,
-      replacementLifecycle,
-      beforePid,
-      operationId,
-      timeoutMs,
-      kind,
-      expectedIdentity,
-      expectedGeneration
-    );
-  } catch (error) {
-    if (!rollbackLaunchConfiguration) throw error;
-    return await rollbackDaemonReplacement({
-      lifecycle, replacementFailure: error, beforePid, beforeLoadedIdentity, operationId,
-      timeoutMs, kind, launchConfiguration: rollbackLaunchConfiguration, expectedGeneration
-    });
-  }
-}
-
-async function waitForStartedReplacement(
-  lifecycle: DaemonControlLifecycle,
-  initialStatus: Record<string, unknown>,
-  initialLifecycle: DaemonLifecycleStatus,
-  beforePid: number,
-  operationId: string,
-  timeoutMs: number,
-  kind: DaemonControlKind,
-  expectedIdentity: string | undefined,
-  expectedGeneration: DaemonGenerationConvergenceExpectation | undefined
-): Promise<Record<string, unknown>> {
-  let status = initialStatus;
-  let replacement = initialLifecycle;
-  const pollIntervalMs = 100;
-  const attempts = Math.ceil(timeoutMs / pollIntervalMs) + 1;
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    if (replacement.pid === beforePid) {
-      throw new Error(`daemon ${kind} replacement PID did not change: ${String(replacement.pid)}; replacement was not signaled`);
-    }
-    if (replacementIdentityIsInvalid(replacement, expectedIdentity)) {
-      await rejectIncompleteReplacement(lifecycle, replacement, beforePid, operationId, timeoutMs, kind, expectedIdentity, expectedGeneration);
-    }
-    if (isCompleteReplacement(replacement, beforePid, operationId, expectedIdentity, expectedGeneration)) return status;
-    if (attempt + 1 < attempts) {
-      await lifecycle.wait(pollIntervalMs);
-      const observed = await lifecycle.probeStatus(
-        lifecycle.target,
-        expectedGeneration ? { includeGenerationAxes: true } : undefined
-      );
-      const observedLifecycle = observed ? normalizeDaemonLifecycleStatus(observed) : undefined;
-      if (observed && observedLifecycle) {
-        status = observed;
-        replacement = observedLifecycle;
-      }
-      continue;
-    }
-  }
-  if (replacement.activeOperationId && replacement.activeOperationId !== operationId) {
-    throw new Error(
-      `daemon ${kind} replacement remained healthy but another daemon control operation remained active: `
-      + `${replacement.activeOperationId}; replacement was left running`
-    );
-  }
-  return await rejectIncompleteReplacement(lifecycle, replacement, beforePid, operationId, timeoutMs, kind, expectedIdentity, expectedGeneration);
-}
-
-async function rejectIncompleteReplacement(
-  lifecycle: DaemonControlLifecycle,
-  replacement: DaemonLifecycleStatus,
-  beforePid: number,
-  operationId: string,
-  timeoutMs: number,
-  kind: DaemonControlKind,
-  expectedIdentity: string | undefined,
-  expectedGeneration: DaemonGenerationConvergenceExpectation | undefined
-): Promise<never> {
-  const failure = incompleteReplacementReason(replacement, beforePid, operationId, expectedIdentity, expectedGeneration);
-  if (replacement.pid === beforePid) {
-    throw new Error(`daemon ${kind} replacement ${failure}; replacement was not signaled`);
-  }
-  if (!lifecycle.stopReplacement) {
-    throw new Error(`daemon ${kind} replacement ${failure}; cleanup unavailable; replacement may still be serving`);
-  }
-  try {
-    await lifecycle.stopReplacement(lifecycle.target, replacement.pid, timeoutMs);
-  } catch (error) {
-    throw new Error(
-      `daemon ${kind} replacement ${failure}; cleanup failed and replacement may still be serving: `
-      + `${error instanceof Error ? error.message : String(error)}`
-    );
-  }
-  throw new Error(`daemon ${kind} replacement ${failure}; rejected replacement was stopped and endpoint remained unowned`);
 }
 
 function defaultDaemonControlLifecycle(input: DaemonControlCommandInput): DaemonControlLifecycle {
@@ -414,73 +247,6 @@ function daemonLaunchSpecUpgradeError(target: LocalDaemonTarget): Error {
   );
 }
 
-async function waitForDaemonControlHandoff(
-  lifecycle: DaemonControlLifecycle,
-  beforePid: number,
-  operationId: string,
-  timeoutMs: number,
-  expectedIdentity: string | undefined,
-  expectedGeneration: DaemonGenerationConvergenceExpectation | undefined
-): Promise<DaemonControlHandoff> {
-  const pollIntervalMs = 100;
-  const attempts = Math.ceil(timeoutMs / pollIntervalMs) + 1;
-  let pendingReplacement: DaemonLifecycleStatus | undefined;
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    const status = await lifecycle.probeStatus(
-      lifecycle.target,
-      expectedGeneration ? { includeGenerationAxes: true } : undefined
-    );
-    const ownerAlive = lifecycle.ownerIsAlive(beforePid);
-    const controlFailure = daemonControlFailure(status, operationId);
-    if (controlFailure) throw new Error(controlFailure);
-
-    // One service process owns each OS-user + userRoot pair. While the old
-    // owner lives, neither a reachable endpoint nor autostart can prove a safe handoff.
-    if (!ownerAlive) {
-      // Once the owner is dead, an absent exact endpoint is the only state
-      // that permits the existing autostart primitive to run.
-      if (!status) return { kind: "autostart" };
-      const observedLifecycle = normalizeDaemonLifecycleStatus(status);
-      if (observedLifecycle && isCompleteReplacement(observedLifecycle, beforePid, operationId, expectedIdentity, expectedGeneration)) {
-        return { kind: "adopt", status };
-      }
-      if (observedLifecycle && observedLifecycle.pid !== beforePid && replacementIdentityIsInvalid(observedLifecycle, expectedIdentity)) {
-        return { kind: "reject", status: observedLifecycle };
-      }
-      if (observedLifecycle?.pid !== beforePid) pendingReplacement = observedLifecycle;
-      // Reachable old-PID or malformed status is not replacement proof and
-      // blocks autostart, avoiding an overlapping service-owner window.
-    }
-
-    if (attempt + 1 === attempts) {
-      if (pendingReplacement) {
-        if (pendingReplacement.activeOperationId && pendingReplacement.activeOperationId !== operationId) {
-          throw new Error(
-            `another daemon control operation remained active: ${pendingReplacement.activeOperationId}; `
-            + "replacement was left running"
-          );
-        }
-        return { kind: "reject", status: pendingReplacement };
-      }
-      if (status) {
-        for (let finalAttempt = 0; finalAttempt < 5; finalAttempt += 1) {
-          await lifecycle.wait(pollIntervalMs);
-          const finalStatus = await lifecycle.probeStatus(
-            lifecycle.target,
-            expectedGeneration ? { includeGenerationAxes: true } : undefined
-          );
-          const finalControlFailure = daemonControlFailure(finalStatus, operationId);
-          if (finalControlFailure) throw new Error(finalControlFailure);
-        }
-        throw new Error(`old daemon endpoint was not released before timeout (pid ${beforePid})`);
-      }
-      throw new Error(`old daemon owner did not exit after releasing its endpoint (pid ${beforePid})`);
-    }
-    await lifecycle.wait(pollIntervalMs);
-  }
-  throw new Error(`daemon control handoff exhausted without a safe decision (pid ${beforePid})`);
-}
-
 async function probeExactDaemonStatus(
   target: LocalDaemonTarget,
   capability?: { readonly includeGenerationAxes: true }
@@ -521,6 +287,28 @@ async function startDaemonReplacement(
   const status = statusFromReceipt(receipt);
   if (!status) throw new Error("replacement status RPC did not return daemon status data");
   return status;
+}
+
+function daemonControlRecoveryGuidance(
+  args: ReadonlyArray<string>,
+  userRoot: string
+): DaemonControlRecoveryGuidance {
+  const retryCommand = ["ha", ...args].map(quoteDaemonRecoveryArgument).join(" ");
+  const customEndpoint = readOption(args, "--socket");
+  if (customEndpoint) {
+    return {
+      retryCommand,
+      occupiedEndpoint: `ha daemon stop does not target custom endpoint ${quoteDaemonRecoveryArgument(customEndpoint)}; `
+        + `stop that endpoint owner explicitly, then retry exactly with: ${retryCommand}`
+    };
+  }
+  const stop = ["ha", "daemon", "stop", "--user-root", userRoot]
+    .map(quoteDaemonRecoveryArgument)
+    .join(" ");
+  return {
+    retryCommand,
+    occupiedEndpoint: `Stop the endpoint owner and retry exactly with: ${stop} && ${retryCommand}`
+  };
 }
 
 function defaultDaemonReplacementStopRuntime(): DaemonReplacementStopRuntime {
@@ -584,10 +372,6 @@ function daemonProcessIsAlive(pid: number): boolean {
   } catch (error) {
     return !(isDaemonControlRecord(error) && error.code === "ESRCH");
   }
-}
-
-function isPositivePid(value: unknown): value is number {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
 
 function isDaemonControlRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/commands/daemon/snapshot-rollback.ts
+++ b/packages/cli/src/commands/daemon/snapshot-rollback.ts
@@ -4,7 +4,8 @@ import {
   normalizeDaemonLifecycleStatus,
   type DaemonGenerationConvergenceExpectation
 } from "./control-convergence.ts";
-import type { DaemonControlKind, DaemonControlLifecycle } from "./control.ts";
+import type { DaemonControlKind } from "./control.ts";
+import type { DaemonControlLifecycle } from "./control-replacement.ts";
 
 export async function rollbackDaemonReplacement(input: {
   readonly lifecycle: DaemonControlLifecycle;

--- a/packages/cli/test/daemon-snapshot-upgrade.test.ts
+++ b/packages/cli/test/daemon-snapshot-upgrade.test.ts
@@ -100,19 +100,181 @@ test("daemon upgrade rolls back to the previous snapshot when new snapshot healt
   assert.match(controlErrorHint(receipt), /previous snapshot restored and authority converged/u);
 });
 
+test("daemon upgrade stops a wrong-snapshot handoff occupant and retries with bounded evidence", async () => {
+  const activeOwners = new Set<number>([59096]);
+  const starts: string[] = [];
+  const stoppedPids: number[] = [];
+  let maximumOwners = activeOwners.size;
+  let probe = 0;
+  const snapshotEntrypoint = "/snapshots/stable-2026-07-22/dist/cli/src/index.js";
+  const { exitCode, receipt } = await runCapturedUpgrade({
+    target: controlTarget,
+    prepareReplacement: async () => runningLaunchConfiguration,
+    probeStatus: async () => {
+      probe += 1;
+      if (probe === 1) return v2DaemonStatus(59096, oldIdentity);
+      return undefined;
+    },
+    ownerIsAlive: () => false,
+    startReplacement: async (_target, _timeoutMs, launchConfiguration) => {
+      assert.equal(activeOwners.size, 0, "the competing owner must exit before snapshot startup");
+      starts.push(launchConfiguration.entrypoint);
+      activeOwners.add(84);
+      maximumOwners = Math.max(maximumOwners, activeOwners.size);
+      return v2DaemonStatus(84);
+    },
+    stopReplacement: async (_target, pid) => {
+      assert.deepEqual([...activeOwners], [pid]);
+      activeOwners.delete(pid);
+      stoppedPids.push(pid);
+    },
+    wait: async () => undefined
+  }, snapshotEntrypoint, undefined, ["--version", "stable-2026-07-22"]);
+
+  assert.equal(exitCode, 0, JSON.stringify(receipt));
+  assert.equal(maximumOwners, 1, "handoff must retain the single-owner invariant");
+  assert.deepEqual(stoppedPids, [59096]);
+  assert.deepEqual(starts, [snapshotEntrypoint]);
+  const replacement = receipt.replacement as {
+    readonly handoffRecovery: {
+      readonly maxAttempts: number;
+      readonly attemptsUsed: number;
+      readonly retryCount: number;
+      readonly attempts: ReadonlyArray<Record<string, unknown>>;
+    };
+  };
+  assert.deepEqual(replacement.handoffRecovery, {
+    maxAttempts: 3,
+    attemptsUsed: 2,
+    retryCount: 1,
+    attempts: [{
+      attempt: 1,
+      occupantPid: 59096,
+      loadedIdentity: oldIdentity,
+      expectedSnapshotIdentity: newIdentity,
+      disposition: "stopped-and-retrying"
+    }]
+  });
+});
+
+test("daemon upgrade retries when cleanup proves a new wrong-snapshot successor took the endpoint", async () => {
+  const probeStatuses = [
+    v2DaemonStatus(59095, oldIdentity),
+    v2DaemonStatus(59096, oldIdentity),
+    v2DaemonStatus(59096, oldIdentity),
+    undefined
+  ];
+  const stoppedPids: number[] = [];
+  const { exitCode, receipt } = await runCapturedUpgrade({
+    target: controlTarget,
+    prepareReplacement: async () => runningLaunchConfiguration,
+    probeStatus: async () => probeStatuses.shift(),
+    ownerIsAlive: () => false,
+    startReplacement: async () => v2DaemonStatus(84),
+    stopReplacement: async (_target, pid) => {
+      stoppedPids.push(pid);
+      if (pid === 59095) throw new Error("target endpoint became reachable again with pid 59096");
+    },
+    wait: async () => undefined
+  }, "/snapshots/stable-2026-07-22/dist/cli/src/index.js");
+
+  assert.equal(exitCode, 0, JSON.stringify(receipt));
+  assert.deepEqual(stoppedPids, [59095, 59096]);
+  const recovery = ((receipt.replacement as Record<string, unknown>).handoffRecovery) as {
+    readonly attemptsUsed: number;
+    readonly retryCount: number;
+    readonly attempts: ReadonlyArray<Record<string, unknown>>;
+  };
+  assert.equal(recovery.attemptsUsed, 3);
+  assert.equal(recovery.retryCount, 2);
+  assert.deepEqual(recovery.attempts[0], {
+    attempt: 1,
+    occupantPid: 59095,
+    loadedIdentity: oldIdentity,
+    expectedSnapshotIdentity: newIdentity,
+    disposition: "stopped-successor-detected",
+    cleanupFailure: "target endpoint became reachable again with pid 59096",
+    successorPid: 59096
+  });
+});
+
+test("daemon upgrade exhausts wrong-snapshot retries fail-closed with every disposition in the receipt", async () => {
+  const occupantPids = [59096, 59097, 59098];
+  let probe = 0;
+  const stoppedPids: number[] = [];
+  const { exitCode, receipt } = await runCapturedUpgrade({
+    target: controlTarget,
+    prepareReplacement: async () => runningLaunchConfiguration,
+    probeStatus: async () => v2DaemonStatus(occupantPids[probe++]!, oldIdentity),
+    ownerIsAlive: () => false,
+    startReplacement: async () => {
+      throw new Error("an occupied endpoint must not start the snapshot replacement");
+    },
+    stopReplacement: async (_target, pid) => { stoppedPids.push(pid); },
+    wait: async () => undefined
+  }, "/snapshots/stable-2026-07-22/dist/cli/src/index.js", undefined, [
+    "--version", "stable-2026-07-22"
+  ]);
+
+  assert.equal(exitCode, 1);
+  assert.deepEqual(stoppedPids, occupantPids);
+  const hint = controlErrorHint(receipt);
+  assert.match(hint, /DAEMON_UPGRADE_HANDOFF_RETRIES_EXHAUSTED/u);
+  assert.match(hint, /Retry exactly with: ha daemon upgrade --timeout-ms 100 --version stable-2026-07-22/u);
+  const evidenceMatch = /Handoff recovery evidence: (\{.+\})$/u.exec(hint);
+  assert.ok(evidenceMatch);
+  assert.deepEqual(JSON.parse(evidenceMatch[1]!) as Record<string, unknown>, {
+    maxAttempts: 3,
+    attemptsUsed: 3,
+    retryCount: 3,
+    attempts: occupantPids.map((occupantPid, index) => ({
+      attempt: index + 1,
+      occupantPid,
+      loadedIdentity: oldIdentity,
+      expectedSnapshotIdentity: newIdentity,
+      disposition: index === 2 ? "stopped-retry-exhausted" : "stopped-and-retrying"
+    }))
+  });
+});
+
+test("daemon upgrade custom-socket failure does not claim the default stop command is precise", async () => {
+  const customEndpoint = "/tmp/custom daemon.sock";
+  const { exitCode, receipt } = await runCapturedUpgrade({
+    target: { ...controlTarget, socketPath: customEndpoint },
+    prepareReplacement: async () => runningLaunchConfiguration,
+    probeStatus: async () => v2DaemonStatus(59096, oldIdentity),
+    ownerIsAlive: () => false,
+    startReplacement: async () => {
+      throw new Error("an occupied endpoint must not start the snapshot replacement");
+    },
+    stopReplacement: async () => { throw new Error("endpoint owner did not exit"); },
+    wait: async () => undefined
+  }, "/snapshots/stable-2026-07-22/dist/cli/src/index.js", undefined, [
+    "--version", "stable-2026-07-22", "--socket", customEndpoint
+  ]);
+
+  const hint = controlErrorHint(receipt);
+  assert.equal(exitCode, 1);
+  assert.doesNotMatch(hint, /ha daemon stop --user-root/u);
+  assert.match(hint, /ha daemon stop does not target custom endpoint '\/tmp\/custom daemon\.sock'/u);
+  assert.match(hint, /retry exactly with: ha daemon upgrade .* --socket '\/tmp\/custom daemon\.sock'/u);
+});
+
 const oldIdentity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
 async function runCapturedUpgrade(
   daemonControlLifecycle: DaemonControlLifecycle,
   snapshotEntrypoint: string,
-  requestDaemonControl: () => Promise<Record<string, unknown>> = async () => ({
+  requestDaemonControl: (() => Promise<Record<string, unknown>>) | undefined = undefined,
+  extraArgs: ReadonlyArray<string> = []
+): Promise<{ readonly exitCode: number; readonly receipt: Record<string, unknown> }> {
+  requestDaemonControl ??= async () => ({
     schema: "daemon-control-accepted/v1",
     accepted: true,
     operationId: "control-refresh",
     kind: "refresh",
     before: { pid: 42, loadedIdentity: oldIdentity, launchConfiguration: runningLaunchConfiguration }
-  })
-): Promise<{ readonly exitCode: number; readonly receipt: Record<string, unknown> }> {
+  });
   const output: string[] = [];
   const originalLog = console.log;
   console.log = (message?: unknown) => output.push(String(message));
@@ -120,7 +282,7 @@ async function runCapturedUpgrade(
     const exitCode = await runDaemonProductCommand({
       rootDir: "/repo",
       json: true,
-      args: ["daemon", "upgrade", "--timeout-ms", "100"],
+      args: ["daemon", "upgrade", "--timeout-ms", "100", ...extraArgs],
       runServe: async () => undefined,
       requestDaemonControl,
       daemonControlLifecycle,


### PR DESCRIPTION
# English

## Summary

Fix the daemon upgrade handoff race by making `ha daemon upgrade` tolerate preemption inside its own switch window: when a wrong-identity occupant (spawned from a stale launch spec by on-demand autostart) grabs the endpoint after drain, upgrade now stops that occupant and retries the handoff with a bounded budget, recording every attempt in the receipt. The autostart hot path is untouched — this deliberately reverses an earlier lock-based approach per decision dec_01KY48SQCTQEKKFTT7WY9PX4Z2 (tolerate in the affected command instead of synchronizing the shared hot path).

## What Changed

- `ha daemon upgrade` detects a wrong-snapshot endpoint occupant during handoff, stops it, and retries up to 3 attempts; every attempt is recorded in the receipt with occupant pid, loaded identity, expected snapshot identity, and disposition (stopped-and-retrying / stopped-retry-exhausted / stopped-successor-detected / cleanup-failed).
- Retry exhaustion and cleanup failure keep the existing fail-closed terminal state and diagnostics; no force-kill default was added; generation fence, single-owner, drain-timeout-keeps-old-owner and rollback semantics are preserved.
- Non-upgrade control paths (refresh/restart) keep a single attempt — behavior identical to main.
- Custom-socket honesty fix: when upgrade runs against `--socket <endpoint>`, the failure receipt no longer claims the default `ha daemon stop` command precisely recovers that endpoint.
- `control.ts` slimmed by extracting `control-handoff.ts` (safe-handoff decision) and `control-replacement.ts` (bounded retry + evidence); autostart/daemon-client code has zero diff against main.

## Task And Scope

- Harness task: task_01KY3PP3V2V8J59BERCR11PYNF
- Branch: fix/upgrade-race-narrow
- Public scope: packages/cli daemon control command internals and upgrade tests only.
- Private planning/evidence updated: yes (narrowing decision, worker report, negative controls)
- Out of scope: on-demand autostart / daemon client hot path (zero diff, hard constraint of the governing decision); any cross-process synchronization primitive.

## Version Impact

- Version: no version change because this changes CLI command internals with no published artifact impact.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable (production daemon control command internals; no CI/gate/branch-protection surface changed)
- Authority: decision dec_01KY48SQCTQEKKFTT7WY9PX4Z2 (narrowed approach, standing policy) and task task_01KY3PP3V2V8J59BERCR11PYNF.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 23271953cde2b1fa89868a980f4de4629538c589
- Branch merge-base with `origin/main`: 23271953cde2b1fa89868a980f4de4629538c589
- Last `git fetch origin` time: 2026-07-22 14:45 (+0800)
- Sync method: none needed (branched from current main)
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness/tasks/task_01KY3PP3V2V8J59BERCR11PYNF-daemon-upgrade-endpoint/artifacts/
- Reviewer evidence path: artifacts/narrowing-decision.md and artifacts/worker-report.md
- GitHub Actions `rewrite-ci` run URL: pending (added by CI on this PR)
- [x] targeted suites: upgrade/handoff 15/15, daemon CLI suites 138/138; typecheck and targeted ESLint green
- [x] hot-path zero-diff proof: `git diff origin/main -- packages/daemon/src/client` is empty (verified by reviewer)
- [x] negative control: daemon-autostart-socket-race-cli.test.ts run on both main and this branch, 4/4 green on each (worker's check:local red confirmed as flake)
- [x] Linux full-gate precheck (remote-ci, exclusive run): 349s, no wedge, only the registered `:50` server false-red; identical profile to main baseline
- Full gate set delegated to the `rewrite-ci` required checks on this PR.

## Review Evidence

- Self-review: CEO read the new handoff/replacement modules, verified the bounded-retry budget is upgrade-only (`upgradeRecovery ? 3 : 1`), fail-closed exhaustion, and receipt disposition trail.
- Reviewer subagent: prior lock-based branch went through a codex review round whose two P2 findings (PID-reuse wedge, custom-socket recovery honesty) informed this design; the surviving custom-socket fix is carried here.
- Human review: CEO semantic acceptance against dec_01KY48SQCTQEKKFTT7WY9PX4Z2 (command-internal tolerance, hot path untouched).
- Blocking findings: none outstanding.

## Residual Risk

- If a stale launch spec keeps resurrecting occupants faster than 3 bounded retries, upgrade still fails closed with the full disposition trail; the receipt then points at the real cause instead of a generic endpoint error.
- The retired lock-based branch (5 local commits, never pushed) is kept locally for reference only.

## References

- Task: task_01KY3PP3V2V8J59BERCR11PYNF
- Evidence: harness/tasks/task_01KY3PP3V2V8J59BERCR11PYNF-daemon-upgrade-endpoint/artifacts/narrowing-decision.md
- Review: harness/tasks/task_01KY3PP3V2V8J59BERCR11PYNF-daemon-upgrade-endpoint/artifacts/worker-report.md

---

# 中文

## 概要

修复 daemon upgrade 换班竞态,方式是让 `ha daemon upgrade` 在自己的切换窗内容错:drain 后若 endpoint 被身份不符的占用者(按需自动拉起用旧 launch spec 复活的进程)抢占,upgrade 停掉该占用者并**有界重试**,每次尝试都记入回执。autostart 热路径零改动——这是对早前锁方案的刻意反转,依据决策 dec_01KY48SQCTQEKKFTT7WY9PX4Z2(在受影响命令内部容错,而非在共享热路径上加同步)。

## 改动内容

- `ha daemon upgrade` 在换班中检出错误快照的 endpoint 占用者后停掉它并重试,上限 3 次;每次尝试的占用者 pid、loaded identity、期望快照 identity 与处置(stopped-and-retrying / stopped-retry-exhausted / stopped-successor-detected / cleanup-failed)全部记入回执。
- 重试耗尽与 cleanup 失败保持既有 fail-closed 终态与诊断;未新增默认强杀;generation fence、单 owner、drain 超时保旧 owner 与 rollback 语义全保留。
- 非 upgrade 控制路径(refresh/restart)仍是单次尝试,行为与 main 一致。
- 自定义 socket 诚实性修复:对 `--socket <endpoint>` 升级失败时,回执不再谎称默认 `ha daemon stop` 命令能精确恢复该端点。
- `control.ts` 拆出 `control-handoff.ts`(安全换班判定)与 `control-replacement.ts`(有界重试+证据);autostart/daemon client 代码相对 main 零 diff。

## 任务与范围

- Harness 任务: task_01KY3PP3V2V8J59BERCR11PYNF
- 分支: fix/upgrade-race-narrow
- 公开范围: 仅 packages/cli 的 daemon control 命令内部与升级测试。
- 私有规划/证据已更新: 是(收窄决策、worker 报告、阴性对照)
- 范围外: 按需自动拉起/daemon client 热路径(零 diff,治理决策硬约束);任何跨进程同步原语。

## 版本影响

- 版本: 无版本变更,仅 CLI 命令内部改动,不影响发布产物。
- 发布影响: 不发布

## 治理声明

- 触碰受保护面: 否
- 受保护面范围: 不适用(生产 daemon control 命令内部;未改 CI/门/分支保护面)
- 授权依据: 决策 dec_01KY48SQCTQEKKFTT7WY9PX4Z2(收窄方案,常设政策)与任务 task_01KY3PP3V2V8J59BERCR11PYNF。
- 机器检查边界: 本 PR 仅断言声明存在;声明是否为真且充分由评审者判断。
- Break-glass: 否
- Break-glass 原因: 不适用
- Break-glass 范围: 不适用
- 后续治理任务: 不适用

## 验证

- 基线 `origin/main` SHA: 23271953cde2b1fa89868a980f4de4629538c589
- 分支与 `origin/main` 的 merge-base: 23271953cde2b1fa89868a980f4de4629538c589
- 最近 `git fetch origin` 时间: 2026-07-22 14:45 (+0800)
- 同步方式: 不需要(基于当前 main 建分支)
- 公开 diff 命令: `git diff origin/main...HEAD`
- 私有证据 commit/路径: harness/tasks/task_01KY3PP3V2V8J59BERCR11PYNF-daemon-upgrade-endpoint/artifacts/
- 评审证据路径: artifacts/narrowing-decision.md 与 artifacts/worker-report.md
- GitHub Actions `rewrite-ci` 运行 URL: 待本 PR CI 生成
- [x] 定向套件:upgrade/handoff 15/15、daemon CLI 套件 138/138;typecheck 与定向 ESLint 绿
- [x] 热路径零 diff 自证:`git diff origin/main -- packages/daemon/src/client` 为空(评审者亲验)
- [x] 阴性对照:daemon-autostart-socket-race-cli.test.ts 在 main 与本分支各 4/4 绿(worker 的 check:local 红确认为 flake)
- [x] Linux 全量预检(remote-ci,独占执行):349 秒无僵死,唯一红为已登记的 `:50` 服务器假红;与 main 基线形态一致
- 全量门集交由本 PR 的 `rewrite-ci` required checks 承担。

## 审查证据

- 自审: CEO 通读新 handoff/replacement 模块,核验重试预算仅限 upgrade(`upgradeRecovery ? 3 : 1`)、耗尽 fail-closed、回执处置轨迹。
- Reviewer subagent: 前一版锁方案经过一轮 codex 评审,其两条 P2(PID 复用卡死、自定义 socket 恢复诚实性)反哺了本设计;存活的 socket 修复随本 PR 落地。
- 人工评审: CEO 依 dec_01KY48SQCTQEKKFTT7WY9PX4Z2 做语义验收(命令内容错、热路径零改动)。
- 阻塞发现: 无未决项。

## 残余风险

- 若旧 launch spec 使占用者复活快于 3 次有界重试,upgrade 仍 fail-closed 并附完整处置轨迹,回执直指真因而非泛化端点错误。
- 被废弃的锁方案分支(本地 5 commits,从未 push)仅留作参考。

## 关联材料

- 任务: task_01KY3PP3V2V8J59BERCR11PYNF
- 证据: harness/tasks/task_01KY3PP3V2V8J59BERCR11PYNF-daemon-upgrade-endpoint/artifacts/narrowing-decision.md
- 评审: harness/tasks/task_01KY3PP3V2V8J59BERCR11PYNF-daemon-upgrade-endpoint/artifacts/worker-report.md
