### PR TITLE
fix(gui): make the terminal dock usable — reachable confirm, right dock, global entry, resize

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -33,7 +33,7 @@ import { useNavigationHistory } from "./navigation/useNavigationHistory.ts";
 import type { EntityFacet } from "./navigation/navigationHistory.ts";
 import { buildEntityIndex, type EntityHit } from "./model/entitySearch.ts";
 import { CommandPalette } from "./components/CommandPalette.tsx";
-import { TerminalDock } from "./components/terminal/TerminalDock.tsx";
+import { TerminalDock, type DockPosition } from "./components/terminal/TerminalDock.tsx";
 import { t, useI18n } from "./i18n/index.tsx";
 
 const RECENT_LIMIT = 12;
@@ -195,6 +195,9 @@ function AppShell() {
   // Cmd+K 命令面板开态;Cmd+K / Ctrl+K 全局切换,面板内 Esc / Cmd+K 关闭。
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [terminalOpen, setTerminalOpen] = useState(false);
+  // Dock 默认底部;右侧停靠时 ViewSwitch 与 dock 横向并排。位置在同一会话内保持。
+  const [terminalDockPosition, setTerminalDockPosition] = useState<DockPosition>("bottom");
+  const terminalDockRight = terminalOpen && terminalDockPosition === "right";
   // 最近焦点实体队列(用户在面板/画布/详情之间跳过哪些 navRef)。first = 最新。
   const [recentRefs, setRecentRefs] = useState<string[]>([]);
 
@@ -490,6 +493,8 @@ function AppShell() {
         openProject={openProject}
         goto={goto}
         inboxCount={inboxCount}
+        terminalOpen={terminalOpen}
+        onToggleTerminal={() => setTerminalOpen((open) => !open)}
       />
 
       <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
@@ -500,7 +505,7 @@ function AppShell() {
           onBack={back}
           onForward={forward}
         />
-        <div className="flex min-h-0 min-w-0 flex-1 flex-row overflow-hidden">
+        <div className={`flex min-h-0 min-w-0 flex-1 overflow-hidden ${terminalDockRight ? "flex-row" : "flex-col"}`}>
           <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             <ViewSwitch
               view={location.view}
@@ -544,12 +549,14 @@ function AppShell() {
               onOpenApproval={openApproval}
             />
           </div>
+          <TerminalDock
+            open={terminalOpen}
+            projectId={projectId}
+            onToggle={() => setTerminalOpen((open) => !open)}
+            position={terminalDockPosition}
+            onPositionChange={setTerminalDockPosition}
+          />
         </div>
-        <TerminalDock
-          open={terminalOpen}
-          projectId={projectId}
-          onToggle={() => setTerminalOpen((open) => !open)}
-        />
       </main>
       <TaskPreviewDrawer
         task={previewTask}

--- a/packages/gui/src/renderer/components/AppSidebar.tsx
+++ b/packages/gui/src/renderer/components/AppSidebar.tsx
@@ -2,6 +2,7 @@ import {
   FolderSimple,
   CaretUpDown,
   CloudSlash,
+  TerminalWindow,
   WarningCircle,
 } from "@phosphor-icons/react";
 import type { Project, TaskRow } from "../model/types.ts";
@@ -38,6 +39,10 @@ interface AppSidebarProps {
   openProject: (repoId: string) => void;
   goto: (v: ViewId) => void;
   inboxCount: number;
+  /** Whether the global terminal dock is currently expanded. */
+  terminalOpen: boolean;
+  /** Toggle the global terminal dock open/closed. */
+  onToggleTerminal: () => void;
 }
 
 export function AppSidebar({
@@ -56,6 +61,8 @@ export function AppSidebar({
   openProject,
   goto,
   inboxCount,
+  terminalOpen,
+  onToggleTerminal,
 }: AppSidebarProps) {
   return (
     <aside className="flex max-h-[42dvh] w-full shrink-0 flex-col overflow-y-auto border-b border-border bg-surface md:max-h-none md:w-64 md:overflow-visible md:border-r md:border-b-0">
@@ -195,6 +202,32 @@ export function AppSidebar({
             label={item.label}
           />
         ))}
+      </nav>
+
+      <div className="px-3 pt-3 pb-1 font-mono text-[12px] uppercase tracking-wide text-text-faint">
+        {t("components.appSidebar.tools")}
+      </div>
+      <nav className="flex gap-1 overflow-x-auto px-2 pb-2 md:flex-col md:gap-0.5 md:overflow-visible md:pb-0">
+        <button
+          type="button"
+          onClick={onToggleTerminal}
+          title={terminalOpen ? t("terminal.dock.close") : t("terminal.dock.open")}
+          aria-pressed={terminalOpen}
+          data-testid="sidebar-terminal-toggle"
+          className={`flex min-w-0 items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[15px] leading-snug ${
+            terminalOpen
+              ? "bg-surface-raised text-text"
+              : "text-text-muted hover:bg-surface-raised/60 hover:text-text"
+          }`}
+        >
+          <span className="shrink-0 text-base">
+            <TerminalWindow weight="duotone" />
+          </span>
+          <span className="min-w-0 truncate">{t("terminal.dock.title")}</span>
+          <span className="ml-auto shrink-0 font-mono text-[10px] text-text-faint">
+            {t("terminal.dock.shortcut")}
+          </span>
+        </button>
       </nav>
 
       <div className="mt-auto hidden border-t border-border px-3 py-2.5 md:block">

--- a/packages/gui/src/renderer/components/terminal/TerminalDock.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalDock.tsx
@@ -1,4 +1,4 @@
-import { CaretUp, List, Plus, TerminalWindow, X } from "@phosphor-icons/react";
+import { CaretUp, List, Plus, Rows, SidebarSimple, TerminalWindow, X } from "@phosphor-icons/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { t } from "../../i18n/index.tsx";
 import type { TerminalSessionInfo } from "../../terminal-api-client.ts";
@@ -15,10 +15,17 @@ import {
   type TerminalTabState
 } from "./terminal-tab-state.ts";
 
+/** Where the terminal dock attaches within the main content area. */
+export type DockPosition = "bottom" | "right";
+
 export interface TerminalDockProps {
   readonly open: boolean;
   readonly projectId: string;
   readonly onToggle: () => void;
+  /** Current dock attachment side. */
+  readonly position: DockPosition;
+  /** Called when the user requests a different attachment side via the header toggle. */
+  readonly onPositionChange: (position: DockPosition) => void;
 }
 
 let tabSeq = 0;
@@ -27,7 +34,7 @@ function nextTabId(): string {
   return `term-tab-${tabSeq}-${Date.now().toString(36)}`;
 }
 
-export function TerminalDock({ open, projectId, onToggle }: TerminalDockProps) {
+export function TerminalDock({ open, projectId, onToggle, position, onPositionChange }: TerminalDockProps) {
   const [tabState, setTabState] = useState<TerminalTabState>(() => emptyTerminalTabState());
   const [managerOpen, setManagerOpen] = useState(false);
   const [managerRefresh, setManagerRefresh] = useState(0);
@@ -71,11 +78,22 @@ export function TerminalDock({ open, projectId, onToggle }: TerminalDockProps) {
     setManagerRefresh((value) => value + 1);
   }, []);
 
+  // Closed dock always collapses to the bottom thin bar regardless of position,
+  // so the border follows the *visual* attachment: bottom bar → border-t, open
+  // right panel → border-l.
+  const borderSide = open && position === "right" ? "border-l" : "border-t";
+  const sizeClasses = open
+    ? position === "right"
+      ? "w-96 min-w-48"
+      : "h-80 min-h-48"
+    : "h-9";
+
   return (
     <section
-      className={`relative shrink-0 border-t border-border bg-surface ${
-        open ? "flex h-80 min-h-48 flex-col" : "h-9"
-      }`}
+      className={`relative shrink-0 ${borderSide} border-border bg-surface ${
+        open ? "flex flex-col" : ""
+      } ${sizeClasses}`}
+      data-dock-position={position}
     >
       <div className="flex h-9 shrink-0 items-center gap-1 px-2">
         <button
@@ -145,6 +163,17 @@ export function TerminalDock({ open, projectId, onToggle }: TerminalDockProps) {
               onClick={() => setManagerOpen((value) => !value)}
             >
               <List size={14} />
+            </button>
+
+            <button
+              type="button"
+              className="grid size-7 place-items-center rounded-md text-text-faint hover:bg-surface-raised hover:text-text"
+              aria-label={position === "bottom" ? t("terminal.dock.dockRight") : t("terminal.dock.dockBottom")}
+              title={position === "bottom" ? t("terminal.dock.dockRight") : t("terminal.dock.dockBottom")}
+              aria-pressed={position === "right"}
+              onClick={() => onPositionChange(position === "bottom" ? "right" : "bottom")}
+            >
+              {position === "bottom" ? <SidebarSimple size={14} /> : <Rows size={14} />}
             </button>
 
             <span className="font-mono text-[10px] text-text-faint">{t("terminal.dock.shortcut")}</span>

--- a/packages/gui/src/renderer/components/terminal/TerminalDock.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalDock.tsx
@@ -14,9 +14,9 @@ import {
   removeTerminalTab,
   type TerminalTabState
 } from "./terminal-tab-state.ts";
+import { useDockResize, type DockPosition } from "./dock-resize.ts";
 
-/** Where the terminal dock attaches within the main content area. */
-export type DockPosition = "bottom" | "right";
+export type { DockPosition };
 
 export interface TerminalDockProps {
   readonly open: boolean;
@@ -78,32 +78,64 @@ export function TerminalDock({ open, projectId, onToggle, position, onPositionCh
     setManagerRefresh((value) => value + 1);
   }, []);
 
+  const resize = useDockResize(position);
+
   // Closed dock always collapses to the bottom thin bar regardless of position,
   // so the border follows the *visual* attachment: bottom bar → border-t, open
   // right panel → border-l.
-  const borderSide = open && position === "right" ? "border-l" : "border-t";
-  const sizeClasses = open
-    ? position === "right"
-      ? "w-96 min-w-48"
-      : "h-80 min-h-48"
-    : "h-9";
+  const dockedRight = open && position === "right";
+  const borderSide = dockedRight ? "border-l" : "border-t";
+  // Size is inline (not a Tailwind class) because the user can drag it.
+  const sizeStyle = open
+    ? dockedRight
+      ? { width: `${resize.width}px` }
+      : { height: `${resize.height}px` }
+    : undefined;
 
   return (
     <section
       className={`relative shrink-0 ${borderSide} border-border bg-surface ${
-        open ? "flex flex-col" : ""
-      } ${sizeClasses}`}
+        open ? "flex flex-col" : "h-9"
+      }`}
+      style={sizeStyle}
       data-dock-position={position}
     >
-      <div className="flex h-9 shrink-0 items-center gap-1 px-2">
+      {open && (
+        <div
+          role="separator"
+          tabIndex={0}
+          aria-orientation={dockedRight ? "vertical" : "horizontal"}
+          aria-label={dockedRight ? t("terminal.dock.resizeWidth") : t("terminal.dock.resizeHeight")}
+          title={dockedRight ? t("terminal.dock.resizeWidth") : t("terminal.dock.resizeHeight")}
+          data-testid="terminal-dock-resize-handle"
+          className={`absolute z-20 touch-none hover:bg-accent/40 focus-visible:bg-accent/60 focus-visible:outline-none ${
+            resize.resizing ? "bg-accent/50" : ""
+          } ${
+            dockedRight
+              ? "inset-y-0 -left-1 w-2 cursor-col-resize"
+              : "inset-x-0 -top-1 h-2 cursor-row-resize"
+          }`}
+          onPointerDown={resize.onHandlePointerDown}
+          onPointerMove={resize.onHandlePointerMove}
+          onPointerUp={resize.onHandlePointerUp}
+          onPointerCancel={resize.onHandlePointerUp}
+          onKeyDown={resize.onHandleKeyDown}
+        />
+      )}
+
+      {/* Opaque + stacked above the pane: long unwrapped terminal output must
+          never paint over these controls and swallow their clicks. */}
+      <div className="relative z-10 flex h-9 shrink-0 items-center gap-1 overflow-hidden bg-surface px-2">
         <button
           type="button"
-          className="flex h-7 items-center gap-2 rounded-md px-2 text-xs font-medium text-text-muted hover:bg-surface-raised hover:text-text"
+          className="flex h-7 shrink-0 items-center gap-2 rounded-md px-2 text-xs font-medium text-text-muted hover:bg-surface-raised hover:text-text"
           aria-expanded={open}
+          aria-label={t("terminal.dock.title")}
           onClick={onToggle}
         >
           <TerminalWindow size={15} weight="bold" />
-          <span>{t("terminal.dock.title")}</span>
+          {/* The narrow right dock needs every pixel for the tabs and controls. */}
+          {!dockedRight && <span>{t("terminal.dock.title")}</span>}
           {!open && <CaretUp size={12} />}
         </button>
 
@@ -143,7 +175,7 @@ export function TerminalDock({ open, projectId, onToggle, position, onPositionCh
               })}
               <button
                 type="button"
-                className="grid size-7 place-items-center rounded-md text-text-faint hover:bg-surface-raised hover:text-text"
+                className="grid size-7 shrink-0 place-items-center rounded-md text-text-faint hover:bg-surface-raised hover:text-text"
                 aria-label={t("terminal.dock.newTab")}
                 title={t("terminal.dock.newTab")}
                 onClick={spawnTab}
@@ -154,7 +186,7 @@ export function TerminalDock({ open, projectId, onToggle, position, onPositionCh
 
             <button
               type="button"
-              className={`grid size-7 place-items-center rounded-md hover:bg-surface-raised hover:text-text ${
+              className={`grid size-7 shrink-0 place-items-center rounded-md hover:bg-surface-raised hover:text-text ${
                 managerOpen ? "bg-surface-raised text-text" : "text-text-faint"
               }`}
               aria-label={t("terminal.dock.sessions")}
@@ -167,7 +199,7 @@ export function TerminalDock({ open, projectId, onToggle, position, onPositionCh
 
             <button
               type="button"
-              className="grid size-7 place-items-center rounded-md text-text-faint hover:bg-surface-raised hover:text-text"
+              className="grid size-7 shrink-0 place-items-center rounded-md text-text-faint hover:bg-surface-raised hover:text-text"
               aria-label={position === "bottom" ? t("terminal.dock.dockRight") : t("terminal.dock.dockBottom")}
               title={position === "bottom" ? t("terminal.dock.dockRight") : t("terminal.dock.dockBottom")}
               aria-pressed={position === "right"}
@@ -176,10 +208,14 @@ export function TerminalDock({ open, projectId, onToggle, position, onPositionCh
               {position === "bottom" ? <SidebarSimple size={14} /> : <Rows size={14} />}
             </button>
 
-            <span className="font-mono text-[10px] text-text-faint">{t("terminal.dock.shortcut")}</span>
+            {/* Sidebar already surfaces the shortcut; at the right dock the width
+                is better spent on controls that are otherwise squeezed away. */}
+            {!dockedRight && (
+              <span className="shrink-0 font-mono text-[10px] text-text-faint">{t("terminal.dock.shortcut")}</span>
+            )}
             <button
               type="button"
-              className="grid size-7 place-items-center rounded-md text-text-faint hover:bg-surface-raised hover:text-text"
+              className="grid size-7 shrink-0 place-items-center rounded-md text-text-faint hover:bg-surface-raised hover:text-text"
               aria-label={t("terminal.dock.close")}
               title={t("terminal.dock.close")}
               onClick={onToggle}

--- a/packages/gui/src/renderer/components/terminal/TerminalPane.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPane.tsx
@@ -198,7 +198,10 @@ export function TerminalPane({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-[#1d1d20]">
-      <div className="flex h-7 shrink-0 items-center gap-2 border-b border-white/10 px-3 font-mono text-[11px] text-white/55">
+      {/* overflow-hidden is load-bearing: this bar is a fixed h-7, and an
+          arbitrarily long backend error would otherwise spill out of it and
+          paint over the dock header, blocking those controls. */}
+      <div className="flex h-7 shrink-0 items-center gap-2 overflow-hidden border-b border-white/10 px-3 font-mono text-[11px] text-white/55">
         {state.kind === "connecting" && t("terminal.pane.connecting")}
         {(state.kind === "active" || state.kind === "exited") && (
           <>
@@ -226,7 +229,11 @@ export function TerminalPane({
             )}
           </>
         )}
-        {state.kind === "error" && t("terminal.pane.connectionFailed", { error: state.error })}
+        {state.kind === "error" && (
+          <span className="min-w-0 truncate" title={t("terminal.pane.connectionFailed", { error: state.error })}>
+            {t("terminal.pane.connectionFailed", { error: state.error })}
+          </span>
+        )}
       </div>
       {degradation && state.kind === "active" && (
         <div className="shrink-0 border-b border-white/10 bg-amber-950/40 px-3 py-1 text-[10px] text-amber-200/90" title={degradation}>

--- a/packages/gui/src/renderer/components/terminal/TerminalSessionManager.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalSessionManager.tsx
@@ -95,11 +95,11 @@ export function TerminalSessionManager({
 
   return (
     <div
-      className="absolute inset-x-0 bottom-9 z-20 mx-2 mb-1 max-h-64 overflow-hidden rounded-md border border-border bg-surface-raised shadow-lg"
+      className="absolute inset-x-0 bottom-9 z-20 mx-2 mb-1 flex max-h-64 flex-col overflow-hidden rounded-md border border-border bg-surface-raised shadow-lg"
       role="dialog"
       aria-label={t("terminal.manager.title")}
     >
-      <div className="flex h-8 items-center gap-2 border-b border-border px-2">
+      <div className="flex h-8 shrink-0 items-center gap-2 border-b border-border px-2">
         <span className="text-xs font-medium text-text">{t("terminal.manager.title")}</span>
         <span className="font-mono text-[10px] text-text-faint">{t("terminal.manager.subtitle")}</span>
         <button
@@ -122,7 +122,7 @@ export function TerminalSessionManager({
         </button>
       </div>
 
-      <div className="max-h-48 overflow-y-auto p-2">
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-2">
         <button
           type="button"
           className="mb-2 flex w-full items-center gap-2 rounded-md border border-dashed border-border px-2 py-1.5 text-left text-xs text-text-muted hover:border-accent hover:bg-surface hover:text-text"
@@ -212,11 +212,11 @@ export function TerminalSessionManager({
       </div>
 
       {actionError && (
-        <div className="border-t border-border px-2 py-1.5 text-[11px] text-danger">{actionError}</div>
+        <div className="shrink-0 border-t border-border px-2 py-1.5 text-[11px] text-danger">{actionError}</div>
       )}
 
       {confirm.kind === "confirm-terminate" && (
-        <div className="border-t border-border bg-surface px-3 py-2">
+        <div className="shrink-0 border-t border-border bg-surface px-3 py-2">
           <p className="text-[12px] text-text">
             {t("terminal.manager.terminateConfirm", { name: confirm.session.name })}
           </p>

--- a/packages/gui/src/renderer/components/terminal/dock-resize.ts
+++ b/packages/gui/src/renderer/components/terminal/dock-resize.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
+
+/** Where the terminal dock attaches within the main content area. */
+export type DockPosition = "bottom" | "right";
+
+/** Defaults match the sizes the dock shipped with before it became resizable. */
+export const DOCK_DEFAULT_HEIGHT = 320;
+export const DOCK_DEFAULT_WIDTH = 384;
+
+/** Floors keep the dock usable; it must never collapse into an unreadable sliver. */
+export const DOCK_MIN_HEIGHT = 120;
+export const DOCK_MIN_WIDTH = 240;
+
+/**
+ * Ceilings reserve room for the rest of the shell so a drag can never swallow
+ * the primary view (or push it under the sidebar).
+ */
+export const DOCK_RESERVE_HEIGHT = 160;
+export const DOCK_RESERVE_WIDTH = 360;
+
+/** Keyboard resize step, so the handle is operable without a pointer. */
+export const DOCK_KEYBOARD_STEP = 16;
+
+export function clampDockHeight(height: number, viewportHeight: number): number {
+  const ceiling = Math.max(DOCK_MIN_HEIGHT, viewportHeight - DOCK_RESERVE_HEIGHT);
+  return Math.round(Math.min(Math.max(height, DOCK_MIN_HEIGHT), ceiling));
+}
+
+export function clampDockWidth(width: number, viewportWidth: number): number {
+  const ceiling = Math.max(DOCK_MIN_WIDTH, viewportWidth - DOCK_RESERVE_WIDTH);
+  return Math.round(Math.min(Math.max(width, DOCK_MIN_WIDTH), ceiling));
+}
+
+interface DragOrigin {
+  readonly pointerId: number;
+  readonly startX: number;
+  readonly startY: number;
+  readonly startHeight: number;
+  readonly startWidth: number;
+}
+
+export interface DockResize {
+  /** Current dock height in px (used when docked at the bottom). */
+  readonly height: number;
+  /** Current dock width in px (used when docked at the right). */
+  readonly width: number;
+  /** True while a drag is in flight, so the dock can suppress transitions. */
+  readonly resizing: boolean;
+  readonly onHandlePointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+  readonly onHandlePointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
+  readonly onHandlePointerUp: (event: ReactPointerEvent<HTMLElement>) => void;
+  readonly onHandleKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => void;
+}
+
+function viewportHeight(): number {
+  return typeof window === "undefined" ? DOCK_DEFAULT_HEIGHT + DOCK_RESERVE_HEIGHT : window.innerHeight;
+}
+
+function viewportWidth(): number {
+  return typeof window === "undefined" ? DOCK_DEFAULT_WIDTH + DOCK_RESERVE_WIDTH : window.innerWidth;
+}
+
+/**
+ * Drag-to-resize for the terminal dock. The handle sits on the dock's leading
+ * edge, so dragging *toward* the viewport centre grows it: at the bottom that
+ * is upward (smaller clientY), at the right that is leftward (smaller clientX).
+ * Each position keeps its own size, so flipping sides restores what you set.
+ */
+export function useDockResize(position: DockPosition): DockResize {
+  const [height, setHeight] = useState(DOCK_DEFAULT_HEIGHT);
+  const [width, setWidth] = useState(DOCK_DEFAULT_WIDTH);
+  const [resizing, setResizing] = useState(false);
+  const dragRef = useRef<DragOrigin | null>(null);
+
+  // A shrinking window must not leave the dock larger than its ceiling.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const reclamp = () => {
+      setHeight((current) => clampDockHeight(current, window.innerHeight));
+      setWidth((current) => clampDockWidth(current, window.innerWidth));
+    };
+    window.addEventListener("resize", reclamp);
+    return () => window.removeEventListener("resize", reclamp);
+  }, []);
+
+  const onHandlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      event.preventDefault();
+      dragRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        startHeight: height,
+        startWidth: width
+      };
+      setResizing(true);
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [height, width]
+  );
+
+  const onHandlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      if (position === "bottom") {
+        setHeight(clampDockHeight(drag.startHeight + (drag.startY - event.clientY), viewportHeight()));
+      } else {
+        setWidth(clampDockWidth(drag.startWidth + (drag.startX - event.clientX), viewportWidth()));
+      }
+    },
+    [position]
+  );
+
+  const onHandlePointerUp = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    dragRef.current = null;
+    setResizing(false);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  }, []);
+
+  const onHandleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLElement>) => {
+      const grow = event.key === (position === "bottom" ? "ArrowUp" : "ArrowLeft");
+      const shrink = event.key === (position === "bottom" ? "ArrowDown" : "ArrowRight");
+      if (!grow && !shrink) return;
+      event.preventDefault();
+      const delta = grow ? DOCK_KEYBOARD_STEP : -DOCK_KEYBOARD_STEP;
+      if (position === "bottom") {
+        setHeight((current) => clampDockHeight(current + delta, viewportHeight()));
+      } else {
+        setWidth((current) => clampDockWidth(current + delta, viewportWidth()));
+      }
+    },
+    [position]
+  );
+
+  return { height, width, resizing, onHandlePointerDown, onHandlePointerMove, onHandlePointerUp, onHandleKeyDown };
+}

--- a/packages/gui/src/renderer/i18n/locales/en-US/components.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/components.json
@@ -37,6 +37,7 @@
   "components.appSidebar.repoUnavailableHint": "This repository is not attached; switch is blocked until the daemon attaches it.",
   "components.appSidebar.v2PreviewAfterLoggingYourAccountYou": "V2 preview: After logging in with your account, you can synchronize multiple devices and access projects remotely.",
   "components.appSidebar.workspace": "Workspace",
+  "components.appSidebar.tools": "Tools",
   "components.badges.active": "Active",
   "components.badges.agnosticNoCaching": "Unknown · uncached",
   "components.badges.blocked": "Blocked",

--- a/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
@@ -8,6 +8,8 @@
   "terminal.dock.sessions": "Sessions",
   "terminal.dock.dockBottom": "Dock to bottom",
   "terminal.dock.dockRight": "Dock to right",
+  "terminal.dock.resizeHeight": "Drag to resize terminal height (or use ↑ ↓)",
+  "terminal.dock.resizeWidth": "Drag to resize terminal width (or use ← →)",
   "terminal.dock.empty": "No terminal tabs open.",
   "terminal.pane.connecting": "Starting shell…",
   "terminal.pane.cwd": "Working directory: {cwd}",

--- a/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
@@ -6,6 +6,8 @@
   "terminal.dock.newTab": "New terminal",
   "terminal.dock.closeTab": "Close tab",
   "terminal.dock.sessions": "Sessions",
+  "terminal.dock.dockBottom": "Dock to bottom",
+  "terminal.dock.dockRight": "Dock to right",
   "terminal.dock.empty": "No terminal tabs open.",
   "terminal.pane.connecting": "Starting shell…",
   "terminal.pane.cwd": "Working directory: {cwd}",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/components.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/components.json
@@ -37,6 +37,7 @@
   "components.appSidebar.repoUnavailableHint": "该仓库尚未挂载；daemon 挂载前不可切换。",
   "components.appSidebar.v2PreviewAfterLoggingYourAccountYou": "V2 预览：账号登录后可多设备同步、远程访问项目",
   "components.appSidebar.workspace": "工作区",
+  "components.appSidebar.tools": "工具",
   "components.badges.active": "进行中",
   "components.badges.agnosticNoCaching": "不可知 · 无缓存",
   "components.badges.blocked": "已阻塞",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
@@ -8,6 +8,8 @@
   "terminal.dock.sessions": "会话",
   "terminal.dock.dockBottom": "停靠到底部",
   "terminal.dock.dockRight": "停靠到右侧",
+  "terminal.dock.resizeHeight": "拖动调整终端高度（方向键 ↑ ↓ 也可调整）",
+  "terminal.dock.resizeWidth": "拖动调整终端宽度（方向键 ← → 也可调整）",
   "terminal.dock.empty": "当前没有打开的终端标签。",
   "terminal.pane.connecting": "正在启动 Shell…",
   "terminal.pane.cwd": "工作目录：{cwd}",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
@@ -6,6 +6,8 @@
   "terminal.dock.newTab": "新建终端",
   "terminal.dock.closeTab": "关闭标签",
   "terminal.dock.sessions": "会话",
+  "terminal.dock.dockBottom": "停靠到底部",
+  "terminal.dock.dockRight": "停靠到右侧",
   "terminal.dock.empty": "当前没有打开的终端标签。",
   "terminal.pane.connecting": "正在启动 Shell…",
   "terminal.pane.cwd": "工作目录：{cwd}",

--- a/packages/gui/test/terminal-dock.vitest.ts
+++ b/packages/gui/test/terminal-dock.vitest.ts
@@ -4,6 +4,17 @@ import { renderToString } from "react-dom/server";
 import { createElement } from "react";
 import { TerminalSessionManager } from "../src/renderer/components/terminal/TerminalSessionManager.tsx";
 import { TerminalDock } from "../src/renderer/components/terminal/TerminalDock.tsx";
+import { TerminalPane } from "../src/renderer/components/terminal/TerminalPane.tsx";
+import {
+  clampDockHeight,
+  clampDockWidth,
+  DOCK_DEFAULT_HEIGHT,
+  DOCK_DEFAULT_WIDTH,
+  DOCK_MIN_HEIGHT,
+  DOCK_MIN_WIDTH,
+  DOCK_RESERVE_HEIGHT,
+  DOCK_RESERVE_WIDTH,
+} from "../src/renderer/components/terminal/dock-resize.ts";
 import { AppSidebar } from "../src/renderer/components/AppSidebar.tsx";
 import type { Project, TaskRow } from "../src/renderer/model/types.ts";
 import type { ViewId } from "../src/renderer/shell-config.tsx";
@@ -34,7 +45,7 @@ describe("defect 1 — terminate confirm bar is not clipped", () => {
 });
 
 describe("defect 2 — dock supports bottom and right positions", () => {
-  it("renders bottom position with horizontal height and top border", () => {
+  it("renders bottom position with a draggable height and top border", () => {
     const html = renderToString(
       createElement(TerminalDock, {
         open: true,
@@ -46,12 +57,13 @@ describe("defect 2 — dock supports bottom and right positions", () => {
     );
     expect(html).toContain('data-dock-position="bottom"');
     expect(html).toContain("border-t");
-    expect(html).toContain("h-80");
+    // Size is inline because it is drag-resizable; it must be the height axis.
+    expect(html).toContain(`height:${DOCK_DEFAULT_HEIGHT}px`);
     expect(html).not.toContain("border-l");
-    expect(html).not.toContain("w-96");
+    expect(html).not.toContain("width:");
   });
 
-  it("renders right position with fixed width and left border", () => {
+  it("renders right position with a draggable width and left border", () => {
     const html = renderToString(
       createElement(TerminalDock, {
         open: true,
@@ -63,8 +75,8 @@ describe("defect 2 — dock supports bottom and right positions", () => {
     );
     expect(html).toContain('data-dock-position="right"');
     expect(html).toContain("border-l");
-    expect(html).toContain("w-96");
-    expect(html).not.toContain("h-80");
+    expect(html).toContain(`width:${DOCK_DEFAULT_WIDTH}px`);
+    expect(html).not.toContain("height:");
   });
 
   it("shows the dock-right toggle control when at bottom", () => {
@@ -105,8 +117,93 @@ describe("defect 2 — dock supports bottom and right positions", () => {
     );
     expect(html).toContain("h-9");
     expect(html).toContain("border-t");
-    expect(html).not.toContain("w-96");
+    expect(html).not.toContain("width:");
     expect(html).not.toContain("border-l");
+  });
+});
+
+describe("defect 4 — dock is drag-resizable", () => {
+  const dockHtml = (position: "bottom" | "right", open = true) =>
+    renderToString(
+      createElement(TerminalDock, {
+        open,
+        projectId: "p",
+        onToggle: noop,
+        position,
+        onPositionChange: noop,
+      }),
+    );
+
+  it("exposes a row-resize handle on the top edge when docked at the bottom", () => {
+    const html = dockHtml("bottom");
+    expect(html).toContain('data-testid="terminal-dock-resize-handle"');
+    expect(html).toContain("cursor-row-resize");
+    expect(html).toContain('aria-orientation="horizontal"');
+  });
+
+  it("exposes a col-resize handle on the left edge when docked at the right", () => {
+    const html = dockHtml("right");
+    expect(html).toContain('data-testid="terminal-dock-resize-handle"');
+    expect(html).toContain("cursor-col-resize");
+    expect(html).toContain('aria-orientation="vertical"');
+  });
+
+  it("is keyboard reachable so resizing does not require a pointer", () => {
+    expect(dockHtml("bottom")).toContain('role="separator"');
+    expect(dockHtml("bottom")).toContain('tabindex="0"');
+  });
+
+  it("hides the handle when the dock is collapsed", () => {
+    expect(dockHtml("bottom", false)).not.toContain('data-testid="terminal-dock-resize-handle"');
+  });
+
+  it("clamps height between the floor and a ceiling that reserves the main view", () => {
+    expect(clampDockHeight(10, 1000)).toBe(DOCK_MIN_HEIGHT);
+    expect(clampDockHeight(400, 1000)).toBe(400);
+    // Ceiling = viewport - reserve, so the primary view can never be swallowed.
+    expect(clampDockHeight(99_999, 1000)).toBe(1000 - DOCK_RESERVE_HEIGHT);
+    // A viewport smaller than the reserve still yields a usable floor.
+    expect(clampDockHeight(500, 100)).toBe(DOCK_MIN_HEIGHT);
+  });
+
+  it("clamps width between the floor and a ceiling that reserves the sidebar", () => {
+    expect(clampDockWidth(10, 2000)).toBe(DOCK_MIN_WIDTH);
+    expect(clampDockWidth(600, 2000)).toBe(600);
+    expect(clampDockWidth(99_999, 2000)).toBe(2000 - DOCK_RESERVE_WIDTH);
+    expect(clampDockWidth(900, 200)).toBe(DOCK_MIN_WIDTH);
+  });
+});
+
+describe("defect 5 — narrow right dock must not squeeze controls out of reach", () => {
+  it("keeps every header control shrink-proof and drops the redundant shortcut hint", () => {
+    const right = renderToString(
+      createElement(TerminalDock, {
+        open: true,
+        projectId: "p",
+        onToggle: noop,
+        position: "right",
+        onPositionChange: noop,
+      }),
+    );
+    // At w-96 the flex row previously compressed these below their hit area.
+    expect(right).toContain("size-7 shrink-0");
+    // The sidebar entry already shows Ctrl+`; repeating it here stole the width.
+    expect(right).not.toContain("Ctrl+`");
+    // Header paints above the pane so terminal output cannot cover the buttons.
+    expect(right).toContain("relative z-10 flex h-9 shrink-0 items-center gap-1 overflow-hidden bg-surface");
+  });
+
+  it("still shows the shortcut hint at the roomier bottom dock", () => {
+    const bottom = renderToString(
+      createElement(TerminalDock, {
+        open: true,
+        projectId: "p",
+        onToggle: noop,
+        position: "bottom",
+        onPositionChange: noop,
+      }),
+    );
+    expect(bottom).toContain("Ctrl+`");
   });
 });
 
@@ -155,5 +252,14 @@ describe("defect 3 — global terminal toggle in sidebar", () => {
     );
     expect(html).toContain('aria-pressed="true"');
     expect(html).toContain("Close terminal");
+  });
+});
+
+describe("defect 5 — pane status bar must not spill over the dock header", () => {
+  it("clips its fixed-height status bar so long backend errors cannot escape it", () => {
+    const html = renderToString(createElement(TerminalPane, { projectId: "p" }));
+    // The bar is a fixed h-7; without overflow-hidden a long daemon error wraps
+    // out of the box and paints over the dock controls above it.
+    expect(html).toContain("h-7 shrink-0 items-center gap-2 overflow-hidden");
   });
 });

--- a/packages/gui/test/terminal-dock.vitest.ts
+++ b/packages/gui/test/terminal-dock.vitest.ts
@@ -1,0 +1,159 @@
+// harness-test-tier: fast
+import { describe, it, expect } from "vitest";
+import { renderToString } from "react-dom/server";
+import { createElement } from "react";
+import { TerminalSessionManager } from "../src/renderer/components/terminal/TerminalSessionManager.tsx";
+import { TerminalDock } from "../src/renderer/components/terminal/TerminalDock.tsx";
+import { AppSidebar } from "../src/renderer/components/AppSidebar.tsx";
+import type { Project, TaskRow } from "../src/renderer/model/types.ts";
+import type { ViewId } from "../src/renderer/shell-config.tsx";
+
+// Defect-level DOM smoke: assert the three terminal-dock usability fixes hold
+// at the rendered markup level (structure + presence), complementing the
+// CSS/layout reasoning in the component source.
+
+const noop = () => {};
+
+describe("defect 1 — terminate confirm bar is not clipped", () => {
+  it("renders the manager panel as a flex column so the confirm bar stays visible", () => {
+    const html = renderToString(
+      createElement(TerminalSessionManager, {
+        open: true,
+        projectId: "p",
+        onClose: noop,
+        onAttach: noop,
+        onSpawn: noop,
+      }),
+    );
+    // Outer panel must be flex-col (was a plain block with overflow-hidden that
+    // clipped the confirm sibling). The list must flex+min-h-0 so it shrinks to
+    // leave room for the confirm bar instead of pushing it below max-h-64.
+    expect(html).toContain("flex max-h-64 flex-col");
+    expect(html).toContain("flex min-h-0 flex-1 flex-col overflow-y-auto");
+  });
+});
+
+describe("defect 2 — dock supports bottom and right positions", () => {
+  it("renders bottom position with horizontal height and top border", () => {
+    const html = renderToString(
+      createElement(TerminalDock, {
+        open: true,
+        projectId: "p",
+        onToggle: noop,
+        position: "bottom",
+        onPositionChange: noop,
+      }),
+    );
+    expect(html).toContain('data-dock-position="bottom"');
+    expect(html).toContain("border-t");
+    expect(html).toContain("h-80");
+    expect(html).not.toContain("border-l");
+    expect(html).not.toContain("w-96");
+  });
+
+  it("renders right position with fixed width and left border", () => {
+    const html = renderToString(
+      createElement(TerminalDock, {
+        open: true,
+        projectId: "p",
+        onToggle: noop,
+        position: "right",
+        onPositionChange: noop,
+      }),
+    );
+    expect(html).toContain('data-dock-position="right"');
+    expect(html).toContain("border-l");
+    expect(html).toContain("w-96");
+    expect(html).not.toContain("h-80");
+  });
+
+  it("shows the dock-right toggle control when at bottom", () => {
+    const html = renderToString(
+      createElement(TerminalDock, {
+        open: true,
+        projectId: "p",
+        onToggle: noop,
+        position: "bottom",
+        onPositionChange: noop,
+      }),
+    );
+    expect(html).toContain("Dock to right");
+  });
+
+  it("shows the dock-bottom toggle control when at right", () => {
+    const html = renderToString(
+      createElement(TerminalDock, {
+        open: true,
+        projectId: "p",
+        onToggle: noop,
+        position: "right",
+        onPositionChange: noop,
+      }),
+    );
+    expect(html).toContain("Dock to bottom");
+  });
+
+  it("collapses to the bottom thin bar when closed regardless of position", () => {
+    const html = renderToString(
+      createElement(TerminalDock, {
+        open: false,
+        projectId: "p",
+        onToggle: noop,
+        position: "right",
+        onPositionChange: noop,
+      }),
+    );
+    expect(html).toContain("h-9");
+    expect(html).toContain("border-t");
+    expect(html).not.toContain("w-96");
+    expect(html).not.toContain("border-l");
+  });
+});
+
+describe("defect 3 — global terminal toggle in sidebar", () => {
+  const baseProject: Project = {
+    id: "p",
+    name: "Demo",
+    path: "/demo",
+    preset: "local",
+    engines: ["local"],
+    watermarkAt: "2026-01-01",
+  };
+
+  const commonProps = {
+    view: "overview" as ViewId,
+    selected: null as TaskRow | null,
+    tasksQuery: { isSuccess: true, isError: false, fetchStatus: "idle", status: "success" } as never,
+    projectTasks: [] as TaskRow[],
+    activeCount: 0,
+    project: baseProject,
+    projects: [baseProject],
+    projectId: "p",
+    tasks: [] as TaskRow[],
+    projectSwitcherOpen: false,
+    onProjectSwitcherToggle: noop,
+    onManageAll: noop,
+    openProject: noop,
+    goto: noop,
+    inboxCount: 0,
+  };
+
+  it("renders a terminal toggle button with the shortcut hint visible at a glance", () => {
+    const html = renderToString(
+      createElement(AppSidebar, { ...commonProps, terminalOpen: false, onToggleTerminal: noop }),
+    );
+    expect(html).toContain('data-testid="sidebar-terminal-toggle"');
+    expect(html).toContain('aria-pressed="false"');
+    expect(html).toContain("Open terminal");
+    // The Ctrl+` shortcut is surfaced right on the sidebar entry, not buried.
+    expect(html).toContain("Ctrl+`");
+  });
+
+  it("reflects the open state with aria-pressed and close tooltip", () => {
+    const html = renderToString(
+      createElement(AppSidebar, { ...commonProps, terminalOpen: true, onToggleTerminal: noop }),
+    );
+    expect(html).toContain('aria-pressed="true"');
+    expect(html).toContain("Close terminal");
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -24,5 +24,6 @@ export const guiVitestManifest = [
   "packages/gui/test/relation-visual.vitest.ts",
   "packages/gui/test/entity-status-filter.vitest.ts",
   "packages/gui/test/overview-selectors.vitest.ts",
-  "packages/gui/test/first-usable.vitest.ts"
+  "packages/gui/test/first-usable.vitest.ts",
+  "packages/gui/test/terminal-dock.vitest.ts"
 ];


### PR DESCRIPTION
# English

## Summary

Makes the GUI terminal dock actually usable. Five defects found by dogfooding the running app: the terminate confirmation had no reachable buttons, the dock could only attach to the bottom, its entry point looked decision-page-only, it could not be resized at all, and long backend output painted over the header controls and swallowed their clicks.

## What Changed

- **Terminate confirmation was unreachable.** `TerminalSessionManager` was a plain block with `max-h-64 overflow-hidden`; with several sessions the list filled that box and the confirm bar (appended as a sibling after the scroll list) got clipped to its first text line. The panel is now a flex column and the confirm/error bars are `shrink-0`, so the buttons cannot be clipped away.
- **Dock could only attach to the bottom.** Added a `bottom | right` dock position with a header toggle. At the right the dock becomes a side column and the main view narrows beside it; bottom remains the default and each side remembers its own size.
- **Global entry was not discoverable.** The dock was already mounted globally with a `Ctrl+`` ` shortcut, but the collapsed state was a 36px text strip, so it read as decision-page-only. Added a Tools section to the sidebar with a terminal toggle that shows state and the shortcut.
- **Dock could not be resized.** Size was hardcoded (`h-80` / `w-96`). Added drag-to-resize on the dock's leading edge — top edge at the bottom, left edge at the right — with pointer capture, min/max clamping that reserves room for the main view and sidebar, arrow-key support for keyboard users, and a re-clamp on window resize.
- **Terminal output covered the header controls.** `TerminalPane`'s status bar is a fixed `h-7`, and the error branch rendered an arbitrarily long backend message with no truncation. The text overflowed that box and painted over the dock header, intercepting clicks on the buttons underneath. The bar now clips, the error truncates with a full-text tooltip, and the header is opaque and stacked above the pane. Header controls are also `shrink-0` so the narrow right dock cannot squeeze them below their hit area.

## Task And Scope

- Harness task: `task_01KY40GYCB19DKDM5PXVHGKK9X`
- Branch: `fix/terminal-dock-usability`
- Public scope: `packages/gui/**` renderer components, GUI locales, GUI vitest, plus one line in `tools/gui-test-manifest.mjs` to register the new test file.
- Private planning/evidence updated: yes
- Out of scope: terminal session process management (`packages/gui/src/terminal/**` session registry and boundary), the `terminal-api-client.ts` protocol, backend/daemon/CLI, and CI or gate configuration. None of these were touched.

## Version Impact

- Version: no version change because this is a GUI behaviour fix with no package surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gui-test-manifest.mjs` — one entry appended to `guiVitestManifest` so the new `packages/gui/test/terminal-dock.vitest.ts` runs in the GUI lane. No gate logic, threshold, allowlist policy, or skip condition was modified.
- Authority: `task_01KY40GYCB19DKDM5PXVHGKK9X`. Registering a newly added test in the manifest is the declared way to bring a test under the `test-gui` gate; this adds coverage rather than relaxing it.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `23271953cde2b1fa89868a980f4de4629538c589`
- Branch merge-base with `origin/main`: `23271953cde2b1fa89868a980f4de4629538c589`
- Last `git fetch origin` time: 2026-07-22, immediately before opening this PR
- Sync method: none needed — branch is 2 ahead, 0 behind
- Public diff command: `git diff 23271953cde2b1fa89868a980f4de4629538c589..HEAD`
- Private evidence commit/path: recorded in the harness task package for `task_01KY40GYCB19DKDM5PXVHGKK9X`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: populated by the checks tab once CI runs on this PR
- [x] `npm run check:stop-point` — green: 355 tests across 27 GUI test files, GUI locale coverage 1181 keys aligned across `en-US` / `zh-CN`, 35 complete manifest gates green
- [x] `npm run test:gui`
- [x] `npm run typecheck`
- [ ] `npm ci`
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:check-package-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: the unchecked commands above were not run locally. Per the standing decision that the local full gate is retired in favour of GitHub CI, the local stop point is the working stop condition and CI is the authoritative gate. The 20 broader gates CI still owns include `lint`, `test-fast`, `test-contract`, `test-integration`, `gui-package-build`, `check-package-boundaries`, `check-supply-chain`, `pr-body-lint`, and `pr-governance-lint`.

## Review Evidence

- Self-review: full diff read line by line against the reported defects, including the delegated worker's commit. Scope confirmed limited to the stated surface.
- Reviewer subagent: the first commit was produced by a delegated frontend worker; the second was authored directly after reviewing that work.
- Human review: reviewed hands-on in a dev build of this branch and approved.
- Blocking findings: none.

## Residual Risk

- Defect 1 (terminate confirmation) could not be exercised end to end in the review worktree: that root is not registered with the user daemon registry, so no terminal session could start there. It is covered by rendered-markup assertions on the layout that caused the clipping, not by a live terminate.
- Resize coverage is structural — handle presence, orientation, keyboard reachability, and the clamp arithmetic including degenerate viewports. A real pointer drag is not simulated, so drag feel was validated manually rather than by test.
- The dock position and size live in React state for the session only; they are intentionally not persisted to settings.

## References

- Task: `task_01KY40GYCB19DKDM5PXVHGKK9X`
- Evidence: harness task package for the task above
- Review: same task package

---

# 中文

## 概要

修复 GUI 内嵌终端 dock 的可用性。五个缺陷均来自真实使用:终止确认没有可点的按钮、dock 只能停靠底部、入口看起来像只有决策页才有、尺寸完全不能调,以及后端长报错会画到 header 上把按钮的点击吞掉。

## 改动内容

- **终止确认按钮点不到。** `TerminalSessionManager` 外层是带 `max-h-64 overflow-hidden` 的普通块;会话一多,滚动列表撑满该盒子,而确认栏是列表之后追加的 sibling,于是被裁到只剩第一行文字。现在面板改为 flex 纵向布局,确认栏与错误栏均为 `shrink-0`,按钮不会再被裁掉。
- **只能停靠底部。** 新增 `bottom | right` 停靠位置与 header 切换控件。右侧停靠时 dock 成为侧栏、主视图在其左侧收窄;底部仍是默认,两个方向各自记住自己的尺寸。
- **全局入口不可发现。** dock 本来就是全局挂载并注册了 `Ctrl+`` ` 快捷键,但收起态只是一条 36px 的文字细栏,于是被误读成只有决策页能开。侧边栏新增「工具」分区,放入带状态与快捷键提示的终端开关。
- **尺寸不能调。** 尺寸原本写死(`h-80` / `w-96`)。新增沿 dock 前缘拖拽调整 —— 底部拖上边缘、右侧拖左边缘 —— 带指针捕获、为主视图与侧边栏预留空间的上下限钳制、供键盘用户使用的方向键支持,以及窗口尺寸变化时的重新钳制。
- **终端输出盖住 header 控件。** `TerminalPane` 的状态栏是固定 `h-7`,而报错分支渲染的后端信息任意长且未截断。文字溢出该盒子后画到 dock header 上,拦掉了下方按钮的点击。现在状态栏裁剪、错误文字截断并以 tooltip 提供全文、header 不透明且层叠在 pane 之上。header 控件同时加上 `shrink-0`,使窄的右侧 dock 不会把它们压到小于可点区域。

## 任务与范围

- Harness 任务：`task_01KY40GYCB19DKDM5PXVHGKK9X`
- 分支：`fix/terminal-dock-usability`
- 公开范围：`packages/gui/**` 渲染层组件、GUI locale、GUI vitest,以及 `tools/gui-test-manifest.mjs` 中用于注册新测试文件的一行。
- 私有计划 / 证据是否已更新：yes
- 范围外：终端会话进程管理(`packages/gui/src/terminal/**` 的 session registry 与 boundary)、`terminal-api-client.ts` 协议、后端 / daemon / CLI,以及 CI 与 gate 配置。以上均未触碰。

## 版本影响

- 版本：不改版本,原因是本次仅为 GUI 行为修复,未改动任何包对外表面。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/gui-test-manifest.mjs` —— 向 `guiVitestManifest` 追加一条,使新增的 `packages/gui/test/terminal-dock.vitest.ts` 进入 GUI lane 执行。未修改任何门逻辑、阈值、allowlist 策略或跳过条件。
- 依据：`task_01KY40GYCB19DKDM5PXVHGKK9X`。把新增测试登记进 manifest 正是让该测试受 `test-gui` 门约束的既定方式,属于扩大覆盖而非放松门禁。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分,由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`23271953cde2b1fa89868a980f4de4629538c589`
- 当前分支与 `origin/main` 的 merge-base：`23271953cde2b1fa89868a980f4de4629538c589`
- 最近一次 `git fetch origin` 时间：2026-07-22,开 PR 前刚执行
- 同步方式：不需要 —— 分支领先 2、落后 0
- 公开 diff 命令：`git diff 23271953cde2b1fa89868a980f4de4629538c589..HEAD`
- 私有证据 commit/path：记录在 `task_01KY40GYCB19DKDM5PXVHGKK9X` 的任务包中
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：CI 在本 PR 上运行后由 checks 页填充
- [x] `npm run check:stop-point` —— 绿：27 个 GUI 测试文件共 355 条测试通过,GUI locale 覆盖 1181 键在 `en-US` / `zh-CN` 对齐,35 个完整 manifest 门全绿
- [x] `npm run test:gui`
- [x] `npm run typecheck`
- [ ] `npm ci`
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:check-package-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：上方未勾选的命令本地未执行。按「本地全量门退役、完整门交给 GitHub CI」这条既有裁决,本地停止点是工作停止条件,CI 才是权威门。CI 仍独占的 20 个更广门包括 `lint`、`test-fast`、`test-contract`、`test-integration`、`gui-package-build`、`check-package-boundaries`、`check-supply-chain`、`pr-body-lint`、`pr-governance-lint`。

## 审查证据

- 自查：对照所报缺陷逐行通读完整 diff,含受委托 worker 的那个 commit,确认改动范围限于声明的表面。
- Reviewer subagent：第一个 commit 由受委托的前端 worker 产出；第二个 commit 在复核该工作后直接编写。
- 人工审查：在本分支的 dev 构建中亲自上手复核并认可。
- 阻塞发现：无。

## 残余风险

- 缺陷 1(终止确认)未能在复核用的 worktree 中端到端验证：该 root 未登记进 user daemon registry,因此那里起不了终端会话。目前由针对造成裁剪的布局所做的渲染标记断言覆盖,而非一次真实终止。
- resize 的覆盖是结构性的 —— 手柄存在性、方向、键盘可达性,以及含退化视口在内的钳制算术。未模拟真实指针拖拽,拖拽手感为人工验证而非测试验证。
- dock 的停靠位置与尺寸仅存活于本会话的 React state,有意不持久化到设置。

## 关联材料

- 任务：`task_01KY40GYCB19DKDM5PXVHGKK9X`
- 证据：上述任务的 harness 任务包
- 审查：同一任务包
