### PR TITLE
feat(gui): reach a remote harness ledger over SSH stdio

### DIFF
--- a/packages/daemon-client/src/index.ts
+++ b/packages/daemon-client/src/index.ts
@@ -4,4 +4,5 @@ export * from "./json-rpc-writer.ts";
 export * from "./net-transport.ts";
 export * from "./persistent-daemon-client.ts";
 export * from "./registry-discovery.ts";
+export * from "./ssh-stdio-transport.ts";
 export * from "./transport.ts";

--- a/packages/daemon-client/src/ssh-stdio-transport.ts
+++ b/packages/daemon-client/src/ssh-stdio-transport.ts
@@ -1,0 +1,129 @@
+import { spawn, type ChildProcessWithoutNullStreams, type SpawnOptionsWithoutStdio } from "node:child_process";
+import type { JsonRpcConnection, PersistentTransport } from "./transport.ts";
+
+export interface SshStdioTransportOptions {
+  readonly host: string;
+  readonly remoteHaPath?: string;
+  readonly spawnProcess?: (
+    command: string,
+    args: ReadonlyArray<string>,
+    options: SpawnOptionsWithoutStdio & { readonly stdio: readonly ["pipe", "pipe", "pipe"] }
+  ) => ChildProcessWithoutNullStreams;
+}
+
+/** JSON-RPC lines over `ssh <host> ha daemon connect --stdio`. */
+export class SshStdioTransport implements PersistentTransport {
+  readonly #options: SshStdioTransportOptions;
+
+  constructor(options: SshStdioTransportOptions) {
+    if (!options.host) throw new Error("SSH stdio transport requires a host alias.");
+    this.#options = options;
+  }
+
+  async open(_endpoint: string, signal?: AbortSignal): Promise<JsonRpcConnection> {
+    if (signal?.aborted) throw new DOMException("The operation was aborted", "AbortError");
+    const child = (this.#options.spawnProcess ?? spawn)(
+      "ssh",
+      sshStdioArgs(this.#options.host, this.#options.remoteHaPath),
+      { stdio: ["pipe", "pipe", "pipe"] }
+    );
+    await waitForSpawn(child, signal);
+    return jsonLineProcessConnection(child);
+  }
+}
+
+export function sshStdioArgs(host: string, remoteHaPath = "ha"): ReadonlyArray<string> {
+  return [host, remoteHaPath, "daemon", "connect", "--stdio"];
+}
+
+function jsonLineProcessConnection(child: ChildProcessWithoutNullStreams): JsonRpcConnection {
+  const frameListeners = new Set<(frame: unknown) => void>();
+  const closeListeners = new Set<(error?: Error) => void>();
+  let stdoutBuffer = "";
+  let stderrBuffer = "";
+  let closed = false;
+
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string | Buffer) => {
+    stdoutBuffer += chunk.toString();
+    for (;;) {
+      const newline = stdoutBuffer.indexOf("\n");
+      if (newline < 0) break;
+      const line = stdoutBuffer.slice(0, newline);
+      stdoutBuffer = stdoutBuffer.slice(newline + 1);
+      if (!line) continue;
+      try {
+        const frame: unknown = JSON.parse(line);
+        for (const listener of frameListeners) listener(frame);
+      } catch (error) {
+        child.kill("SIGTERM");
+        notifyClose(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+  });
+  child.stderr.on("data", (chunk: string | Buffer) => {
+    stderrBuffer = `${stderrBuffer}${chunk.toString()}`.slice(-4_096);
+  });
+  child.once("error", notifyClose);
+  child.once("exit", (code, signal) => {
+    const diagnostic = stderrBuffer.trim();
+    const error = code === 0 || (code === null && signal === "SIGTERM")
+      ? undefined
+      : new Error(`SSH stdio transport exited (${code ?? signal ?? "unknown"})${diagnostic ? `: ${diagnostic}` : ""}`);
+    notifyClose(error);
+  });
+
+  return {
+    write: (frame) => {
+      if (closed || child.stdin.destroyed) throw new Error("SSH stdio transport is closed.");
+      child.stdin.write(`${JSON.stringify(frame)}\n`);
+    },
+    onFrame: (listener) => subscribe(frameListeners, listener),
+    onClose: (listener) => subscribe(closeListeners, listener),
+    close: async () => {
+      if (closed) return;
+      child.stdin.end();
+      child.kill("SIGTERM");
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+    }
+  };
+
+  function notifyClose(error?: Error): void {
+    if (closed) return;
+    closed = true;
+    for (const listener of closeListeners) listener(error);
+  }
+}
+
+function waitForSpawn(child: ChildProcessWithoutNullStreams, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const abort = () => {
+      cleanup();
+      child.kill("SIGTERM");
+      reject(new DOMException("The operation was aborted", "AbortError"));
+    };
+    const spawned = () => {
+      cleanup();
+      resolve();
+    };
+    const failed = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      signal?.removeEventListener("abort", abort);
+      child.off("spawn", spawned);
+      child.off("error", failed);
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+    child.once("spawn", spawned);
+    child.once("error", failed);
+  });
+}
+
+function subscribe<T>(listeners: Set<T>, listener: T): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/packages/daemon-client/test/persistent-daemon-client.test.ts
+++ b/packages/daemon-client/test/persistent-daemon-client.test.ts
@@ -1,11 +1,13 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import test from "node:test";
 import type { DaemonClientDiagnostic } from "../../api-contracts/src/index.ts";
 import { ConnectionPool } from "../src/connection-pool.ts";
 import { JsonRpcWriter } from "../src/json-rpc-writer.ts";
 import { PersistentDaemonClient } from "../src/persistent-daemon-client.ts";
 import { createDaemonRegistryResolver } from "../src/registry-discovery.ts";
+import { SshStdioTransport, sshStdioArgs } from "../src/ssh-stdio-transport.ts";
 import { FakeConnection, FakeTransport, hello, receipt } from "./fake-transport.ts";
 
 test("real command-receipt hello and projection notifications interleave with responses", async () => {
@@ -146,6 +148,35 @@ test("registry discovery fails explicitly when the kernel resolver seam is not i
     () => createDaemonRegistryResolver({ endpoint: "unix:/daemon", userRoot: "/profile" } as never),
     /requires resolveRepoByRoot after PLT-Boundary W1/u
   );
+});
+
+test("ssh stdio transport uses the CLI command shape and carries JSON-RPC lines", async () => {
+  const calls: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> = [];
+  const transport = new SshStdioTransport({
+    host: "remote-alias",
+    remoteHaPath: "/opt/ha",
+    spawnProcess: (command, args, options) => {
+      calls.push({ command, args });
+      return spawn(process.execPath, ["-e", [
+        "process.stdin.setEncoding('utf8');",
+        "let buffer = '';",
+        "process.stdin.on('data', chunk => {",
+        "  buffer += chunk;",
+        "  const newline = buffer.indexOf('\\n');",
+        "  if (newline < 0) return;",
+        "  const request = JSON.parse(buffer.slice(0, newline));",
+        "  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { echoed: request.method } }) + '\\n');",
+        "});"
+      ].join("\n")], options);
+    }
+  });
+  const connection = await transport.open("ssh-stdio:remote-alias");
+  const response = new Promise<unknown>((resolve) => connection.onFrame(resolve));
+  connection.write({ jsonrpc: "2.0", id: 7, method: "repo.tasks.list", params: {} });
+
+  assert.deepEqual(await response, { jsonrpc: "2.0", id: 7, result: { echoed: "repo.tasks.list" } });
+  assert.deepEqual(calls, [{ command: "ssh", args: sshStdioArgs("remote-alias", "/opt/ha") }]);
+  await connection.close();
 });
 
 function fixtureClient(

--- a/packages/gui/src/api/service-bridge.ts
+++ b/packages/gui/src/api/service-bridge.ts
@@ -13,6 +13,7 @@ export { validateGuiRoutePayload } from "./gui-route-payload.ts";
 // not import that kernel barrel because it would reintroduce the sqlite ABI path.
 export interface GuiServiceBridge {
   readonly invoke: (method: string, payload: unknown) => Promise<unknown>;
+  readonly dispose?: () => Promise<void>;
 }
 
 type JsonObject = { readonly [key: string]: JsonValue };

--- a/packages/gui/src/daemon/remote-tunnel.ts
+++ b/packages/gui/src/daemon/remote-tunnel.ts
@@ -5,7 +5,14 @@ import type { TerminalSessionInfo } from "@harness-anything/application/terminal
 export type DaemonTransport =
   | { readonly kind: "local-ipc"; readonly endpoint: string }
   | { readonly kind: "local-loopback"; readonly host: "127.0.0.1"; readonly port: number }
-  | { readonly kind: "ssh-tunnel"; readonly tunnelId: string; readonly localHost: "127.0.0.1"; readonly localPort: number };
+  | { readonly kind: "ssh-tunnel"; readonly tunnelId: string; readonly localHost: "127.0.0.1"; readonly localPort: number }
+  | {
+      readonly kind: "ssh-stdio";
+      readonly host: string;
+      readonly remoteHaPath: string;
+      readonly remoteRoot: string;
+      readonly repoId: string;
+    };
 
 export type TunnelConnectionStatus =
   | "initiating"

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -3,10 +3,10 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { registerHarnessIpcHandlers } from "./ipc-handlers.ts";
 import {
-  createLocalGuiServiceBridge,
+  createGuiServiceBridge,
   type HarnessLayoutOverrides
 } from "./local-composition-root.ts";
-import { createLocalGuiProjectionNotifications } from "./projection-notifications.ts";
+import { createGuiProjectionNotifications } from "./projection-notifications.ts";
 import { evaluateNavigationRequest, evaluatePermissionRequest, evaluateWindowOpenRequest } from "./security-policy.ts";
 import { createGuiContentSecurityPolicy, resolveDevRendererOrigin } from "./window-config.ts";
 
@@ -72,8 +72,9 @@ export async function startGuiApp(): Promise<void> {
   const trustedWebContentsIds = new Set<number>();
   const rootDir = resolveGuiProjectRoot();
   const layoutOverrides = resolveGuiLayoutOverrides();
-  const projectionNotifications = createLocalGuiProjectionNotifications(rootDir, layoutOverrides);
-  registerHarnessIpcHandlers(ipcMain, createLocalGuiServiceBridge(rootDir, layoutOverrides), {
+  const serviceBridge = createGuiServiceBridge(rootDir, layoutOverrides);
+  const projectionNotifications = createGuiProjectionNotifications(rootDir, layoutOverrides);
+  registerHarnessIpcHandlers(ipcMain, serviceBridge, {
     isTrustedWebContentsId: (id) => trustedWebContentsIds.has(id),
     rendererUrl: {
       packagedRendererUrl: createLocalPackagedRendererUrl(),
@@ -83,6 +84,7 @@ export async function startGuiApp(): Promise<void> {
     }
   }, projectionNotifications.source);
   app.once("before-quit", () => {
+    void serviceBridge.dispose?.();
     void projectionNotifications.dispose();
   });
   createTrustedMainWindow(trustedWebContentsIds);

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -2,10 +2,13 @@ import { spawnSync } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { PersistentDaemonClient, type PersistentTransport } from "@harness-anything/daemon-client";
+import { SshStdioTransport } from "../../../daemon-client/src/ssh-stdio-transport.ts";
 import { validateProjectPath } from "../api/local-api.ts";
 import { createGuiServiceBridgeForDaemon } from "../api/service-bridge.ts";
 import type { ApiRouteContract } from "../api/api-contract-registry.ts";
 import type { GuiServiceBridge } from "../api/service-bridge.ts";
+import type { DaemonTransport } from "../daemon/remote-tunnel.ts";
 
 const defaultDaemonAutostartTimeoutMs = 6_000;
 const defaultDaemonIdleExitMs = 5 * 60_000;
@@ -81,9 +84,27 @@ interface LocalDaemonClientModule {
 }
 
 let daemonClientModulePromise: Promise<LocalDaemonClientModule> | undefined;
-let daemonSettingsModulePromise: Promise<{
+interface DaemonSettingsModule {
   readonly readDaemonUserRoot: (env?: NodeJS.ProcessEnv, rootDir?: string, layoutOverrides?: HarnessLayoutOverrides) => string;
-}> | undefined;
+  readonly readDaemonClientConfig: (
+    env?: NodeJS.ProcessEnv,
+    rootDir?: string,
+    modeOverride?: "direct" | "local" | "remote",
+    profileOverride?: "default" | "isolated",
+    layoutOverrides?: HarnessLayoutOverrides
+  ) => {
+    readonly mode: "direct" | "local" | "remote";
+    readonly requestTimeoutMs: number;
+    readonly remote?: {
+      readonly host: string;
+      readonly remoteHaPath: string;
+      readonly remoteRoot: string;
+      readonly repoId: string;
+    };
+  };
+}
+
+let daemonSettingsModulePromise: Promise<DaemonSettingsModule> | undefined;
 
 interface GuiDaemonBridgeState {
   layoutOverrideDaemonStarted: boolean;
@@ -94,6 +115,67 @@ export function createLocalGuiServiceBridge(rootDir: string, layoutOverrides?: H
   validateProjectPath(resolvedRootDir, ".");
   const state: GuiDaemonBridgeState = { layoutOverrideDaemonStarted: false };
   return createGuiServiceBridgeForDaemon(async (route, payload) => requestGuiRouteViaDaemon(resolvedRootDir, layoutOverrides, state, route, payload));
+}
+
+/** Selects the same local/remote daemon mode and SSH config inputs as the CLI. */
+export function createGuiServiceBridge(
+  rootDir: string,
+  layoutOverrides?: HarnessLayoutOverrides,
+  options: {
+    readonly env?: NodeJS.ProcessEnv;
+    readonly createSshTransport?: (transport: Extract<DaemonTransport, { readonly kind: "ssh-stdio" }>) => PersistentTransport;
+  } = {}
+): GuiServiceBridge {
+  const env = options.env ?? process.env;
+  const resolvedRootDir = path.resolve(rootDir);
+  validateProjectPath(resolvedRootDir, ".");
+  let remoteClient: PersistentDaemonClient | undefined;
+  let transportPromise: Promise<DaemonTransport> | undefined;
+  const localState: GuiDaemonBridgeState = { layoutOverrideDaemonStarted: false };
+  const bridge = createGuiServiceBridgeForDaemon(async (route, payload) => {
+    const transport = await (transportPromise ??= resolveGuiDaemonTransport(resolvedRootDir, layoutOverrides, env));
+    if (transport.kind !== "ssh-stdio") {
+      return requestGuiRouteViaDaemon(resolvedRootDir, layoutOverrides, localState, route, payload);
+    }
+    try {
+      remoteClient ??= new PersistentDaemonClient({
+        endpoint: `ssh-stdio:${transport.host}`,
+        transport: options.createSshTransport?.(transport)
+          ?? new SshStdioTransport({ host: transport.host, remoteHaPath: transport.remoteHaPath }),
+        requestTimeoutMs: remoteRequestTimeoutMs(env)
+      });
+      return await remoteClient.request(
+        jsonRpcMethodForGuiRoute(route) as never,
+        jsonRpcParamsForGuiRoute(route, transport.repoId, payload) as never
+      ) as JsonObject;
+    } catch (error) {
+      return {
+        ok: false,
+        error: {
+          code: "daemon_unavailable",
+          hint: `Remote Harness daemon is unavailable through ${transport.host}: ${error instanceof Error ? error.message : String(error)}`
+        }
+      };
+    }
+  });
+  return {
+    invoke: bridge.invoke,
+    dispose: async () => remoteClient?.dispose()
+  };
+}
+
+export async function resolveGuiDaemonTransport(
+  rootDir: string,
+  layoutOverrides?: HarnessLayoutOverrides,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<DaemonTransport> {
+  const daemonSettings = await loadDaemonSettingsModule();
+  const config = daemonSettings.readDaemonClientConfig(env, rootDir, undefined, undefined, layoutOverrides);
+  if (config.mode === "remote") {
+    if (!config.remote) throw new Error("Remote daemon configuration is missing.");
+    return { kind: "ssh-stdio", ...config.remote };
+  }
+  return { kind: "local-ipc", endpoint: "auto" };
 }
 
 export async function resolveGuiDaemonNotificationTarget(
@@ -238,12 +320,8 @@ function daemonClientModuleUrl(): string {
   return new URL("../../../daemon/src/client/local-json-rpc-client.ts", import.meta.url).href;
 }
 
-async function loadDaemonSettingsModule(): Promise<{
-  readonly readDaemonUserRoot: (env?: NodeJS.ProcessEnv, rootDir?: string, layoutOverrides?: HarnessLayoutOverrides) => string;
-}> {
-  daemonSettingsModulePromise ??= import(daemonSettingsModuleUrl()) as Promise<{
-    readonly readDaemonUserRoot: (env?: NodeJS.ProcessEnv, rootDir?: string, layoutOverrides?: HarnessLayoutOverrides) => string;
-  }>;
+async function loadDaemonSettingsModule(): Promise<DaemonSettingsModule> {
+  daemonSettingsModulePromise ??= import(daemonSettingsModuleUrl()) as Promise<DaemonSettingsModule>;
   return daemonSettingsModulePromise;
 }
 
@@ -337,6 +415,10 @@ function positiveIntegerOr(value: string | undefined, fallback: number): number 
   if (!value) return fallback;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function remoteRequestTimeoutMs(env: NodeJS.ProcessEnv): number {
+  return positiveIntegerOr(env.HARNESS_DAEMON_REQUEST_TIMEOUT_MS, 35_000);
 }
 
 function isLocalServiceRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/gui/src/main/projection-notifications.ts
+++ b/packages/gui/src/main/projection-notifications.ts
@@ -1,10 +1,13 @@
 import type { Disposable, ProjectionChangeNotification, Subscription } from "@harness-anything/api-contracts";
-import { JsonLineSocketTransport, PersistentDaemonClient } from "@harness-anything/daemon-client";
+import { JsonLineSocketTransport, PersistentDaemonClient, type PersistentTransport } from "@harness-anything/daemon-client";
+import { SshStdioTransport } from "../../../daemon-client/src/ssh-stdio-transport.ts";
+import type { DaemonTransport } from "../daemon/remote-tunnel.ts";
 import type {
   HarnessProjectionNotificationSource
 } from "./ipc-handlers.ts";
 import type { RendererProjectionNotification } from "../preload/allowlist.ts";
 import {
+  resolveGuiDaemonTransport,
   resolveGuiDaemonNotificationTarget,
   type HarnessLayoutOverrides
 } from "./local-composition-root.ts";
@@ -20,6 +23,29 @@ export interface LocalGuiProjectionNotifications {
 export function createLocalGuiProjectionNotifications(
   rootDir: string,
   layoutOverrides?: HarnessLayoutOverrides
+): LocalGuiProjectionNotifications {
+  return createProjectionNotifications(rootDir, layoutOverrides, true);
+}
+
+export function createGuiProjectionNotifications(
+  rootDir: string,
+  layoutOverrides?: HarnessLayoutOverrides,
+  options: {
+    readonly env?: NodeJS.ProcessEnv;
+    readonly createSshTransport?: (transport: Extract<DaemonTransport, { readonly kind: "ssh-stdio" }>) => PersistentTransport;
+  } = {}
+): LocalGuiProjectionNotifications {
+  return createProjectionNotifications(rootDir, layoutOverrides, false, options);
+}
+
+function createProjectionNotifications(
+  rootDir: string,
+  layoutOverrides: HarnessLayoutOverrides | undefined,
+  forceLocal: boolean,
+  options: {
+    readonly env?: NodeJS.ProcessEnv;
+    readonly createSshTransport?: (transport: Extract<DaemonTransport, { readonly kind: "ssh-stdio" }>) => PersistentTransport;
+  } = {}
 ): LocalGuiProjectionNotifications {
   let client: PersistentDaemonClient | undefined;
   let clientEvents: Disposable | undefined;
@@ -65,10 +91,20 @@ export function createLocalGuiProjectionNotifications(
 
   async function ensureClient(): Promise<PersistentDaemonClient> {
     if (client) return client;
-    const target = await resolveGuiDaemonNotificationTarget(rootDir, layoutOverrides);
+    const selected = forceLocal ? undefined : await resolveGuiDaemonTransport(rootDir, layoutOverrides, options.env);
+    const target = selected?.kind === "ssh-stdio"
+      ? {
+          endpoint: `ssh-stdio:${selected.host}`,
+          transport: options.createSshTransport?.(selected)
+            ?? new SshStdioTransport({ host: selected.host, remoteHaPath: selected.remoteHaPath })
+        }
+      : await resolveGuiDaemonNotificationTarget(rootDir, layoutOverrides).then((local) => ({
+          endpoint: local.socketPath,
+          transport: new JsonLineSocketTransport()
+        }));
     client = new PersistentDaemonClient({
-      endpoint: target.socketPath,
-      transport: new JsonLineSocketTransport(),
+      endpoint: target.endpoint,
+      transport: target.transport,
       helloTimeoutMs: daemonConnectionTimeoutMs,
       requestTimeoutMs: projectionSubscriptionTimeoutMs,
       onDiagnostic: (diagnostic) => {

--- a/packages/gui/test/helpers/daemon-generation-lifecycle.ts
+++ b/packages/gui/test/helpers/daemon-generation-lifecycle.ts
@@ -160,3 +160,44 @@ function isNoSuchProcess(error: unknown): boolean {
     && "code" in error
     && (error as { readonly code?: unknown }).code === "ESRCH";
 }
+
+export function writeTaskIndex(rootDir: string, taskId: string, title: string, status: string, authoredRoot = "harness"): void {
+  writeHarnessConfig(rootDir, authoredRoot);
+  mkdirSync(path.join(rootDir, authoredRoot, "tasks", taskId), { recursive: true });
+  writeFileSync(path.join(rootDir, authoredRoot, "tasks", taskId, "INDEX.md"), [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    `title: ${title}`,
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    `  status: ${status}`,
+    "  ref: ",
+    `  titleSnapshot: ${title}`,
+    "  url: ",
+    "  bindingCreatedAt: 2026-06-12T00:00:00.000Z",
+    "  bindingFingerprint: sha256:test",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "---",
+    ""
+  ].join("\n"), "utf8");
+}
+
+export function writeHarnessConfig(rootDir: string, authoredRoot = "harness"): void {
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  writeFileSync(path.join(rootDir, "harness", "harness.yaml"), [
+    "schema: harness-anything/v1",
+    "name: gui-bridge-test",
+    "layout:",
+    `  authoredRoot: ${authoredRoot}`,
+    "  localRoot: .harness",
+    ""
+  ].join("\n"), "utf8");
+}
+
+export function waitForDaemonIdle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 700));
+}

--- a/packages/gui/test/remote-tunnel.test.ts
+++ b/packages/gui/test/remote-tunnel.test.ts
@@ -31,6 +31,19 @@ test("ssh tunnel transport reuses daemon API route semantics with tunnel auth on
   assert.equal(remote.some((route) => route.id.includes("remote")), false);
 });
 
+test("ssh stdio is a distinct transport and does not inherit tunnel token auth", () => {
+  const remote = bindApiRoutesToDaemonTransport(apiRouteContracts, {
+    kind: "ssh-stdio",
+    host: "kty",
+    remoteHaPath: "ha",
+    remoteRoot: "/srv/harness/team",
+    repoId: "canonical"
+  });
+
+  assert.equal(remote.every((route) => route.transport === "ssh-stdio"), true);
+  assert.equal(remote.some((route) => route.auth === "ssh-tunnel-local-token"), false);
+});
+
 test("remote daemon token bootstrap stores metadata separately from the one-time secret", () => {
   const controller = createRemoteDaemonTunnelController({
     hostProfiles: [hostProfile("host-a")],

--- a/packages/gui/test/service-bridge-remote.test.ts
+++ b/packages/gui/test/service-bridge-remote.test.ts
@@ -1,0 +1,121 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { SshStdioTransport } from "../../daemon-client/src/ssh-stdio-transport.ts";
+import {
+  createGuiProjectionNotifications,
+  createGuiServiceBridge,
+  createLocalGuiServiceBridge
+} from "../src/index.ts";
+import {
+  daemonPidFromStatus,
+  daemonStatusData,
+  readDaemonStatus,
+  stopDaemonProcess,
+  waitForDaemonIdle,
+  withGuiDaemonEnv,
+  writeTaskIndex
+} from "./helpers/daemon-generation-lifecycle.ts";
+
+test("GUI remote selection reads tasks and documents from a second repo over daemon stdio", async () => {
+  const nearRoot = mkdtempSync(path.join(tmpdir(), "ha-gui-near-"));
+  const remoteRoot = mkdtempSync(path.join(tmpdir(), "ha-gui-remote-"));
+  let remoteDaemonPid: number | undefined;
+  try {
+    writeTaskIndex(nearRoot, "task-near", "Near-only task", "planned");
+    writeTaskIndex(remoteRoot, "task-remote", "Remote-only task", "planned");
+
+    const local = await withGuiDaemonEnv(nearRoot, async () => {
+      const bridge = createGuiServiceBridge(nearRoot, undefined, {
+        env: { ...process.env, HARNESS_DAEMON_MODE: "local" }
+      });
+      try {
+        return await bridge.invoke("getTasks", null) as { readonly ok: boolean; readonly tasks?: ReadonlyArray<{ readonly taskId?: string }> };
+      } finally {
+        await bridge.dispose?.();
+      }
+    });
+    assert.deepEqual(local.tasks?.map((task) => task.taskId), ["task-near"]);
+
+    await withGuiDaemonEnv(remoteRoot, async () => {
+      const localRemoteBridge = createLocalGuiServiceBridge(remoteRoot);
+      const warm = await localRemoteBridge.invoke("getTasks", null) as { readonly ok: boolean };
+      assert.equal(warm.ok, true);
+      const status = daemonStatusData(await readDaemonStatus(remoteRoot));
+      const endpoint = status.endpoint;
+      assert.equal(typeof endpoint, "string");
+      remoteDaemonPid = daemonPidFromStatus(status);
+
+      const sshCalls: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> = [];
+      const remoteEnv = {
+        ...process.env,
+        HARNESS_DAEMON_MODE: "remote",
+        HARNESS_DAEMON_SSH_HOST: "fixture-remote",
+        HARNESS_DAEMON_REMOTE_HA: "/opt/ha",
+        HARNESS_DAEMON_REMOTE_ROOT: remoteRoot,
+        HARNESS_DAEMON_REPO_ID: "canonical",
+        HARNESS_DAEMON_REQUEST_TIMEOUT_MS: "5000"
+      };
+      const createEquivalentStdioTransport = (transport: { readonly host: string; readonly remoteHaPath: string }) => new SshStdioTransport({
+        host: transport.host,
+        remoteHaPath: transport.remoteHaPath,
+        spawnProcess: (command, args, options) => {
+          sshCalls.push({ command, args });
+          return spawn(process.execPath, [
+            fileURLToPath(new URL("../../cli/src/index.ts", import.meta.url)),
+            "daemon",
+            "connect",
+            "--stdio",
+            "--socket",
+            endpoint as string
+          ], { ...options, cwd: remoteRoot, env: process.env });
+        }
+      });
+      const remote = createGuiServiceBridge(nearRoot, undefined, {
+        env: remoteEnv,
+        createSshTransport: createEquivalentStdioTransport
+      });
+      try {
+        const tasks = await remote.invoke("getTasks", null) as {
+          readonly ok: boolean;
+          readonly tasks?: ReadonlyArray<{ readonly taskId?: string }>;
+        };
+        const document = await remote.invoke("getTaskDocument", {
+          taskId: "task-remote",
+          path: "INDEX.md"
+        }) as { readonly ok: boolean; readonly body?: string };
+
+        assert.equal(tasks.ok, true, JSON.stringify(tasks));
+        assert.deepEqual(tasks.tasks?.map((task) => task.taskId), ["task-remote"]);
+        assert.equal(tasks.tasks?.some((task) => task.taskId === "task-near"), false);
+        assert.equal(document.ok, true, JSON.stringify(document));
+        assert.match(document.body ?? "", /Remote-only task/u);
+        assert.deepEqual(sshCalls[0], {
+          command: "ssh",
+          args: ["fixture-remote", "/opt/ha", "daemon", "connect", "--stdio"]
+        });
+        const notifications = createGuiProjectionNotifications(nearRoot, undefined, {
+          env: remoteEnv,
+          createSshTransport: createEquivalentStdioTransport
+        });
+        try {
+          assert.deepEqual(await notifications.source.watch("canonical", () => undefined), { mode: "push" });
+        } finally {
+          await notifications.dispose();
+        }
+      } finally {
+        await remote.dispose?.();
+      }
+    }, { idleMs: "5000" });
+  } finally {
+    await stopDaemonProcess(remoteDaemonPid);
+    await waitForDaemonIdle();
+    rmSync(nearRoot, { recursive: true, force: true });
+    rmSync(remoteRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -1,16 +1,11 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import test from "node:test";
-import { SshStdioTransport } from "../../daemon-client/src/ssh-stdio-transport.ts";
 import {
   apiRouteContracts,
-  createGuiProjectionNotifications,
-  createGuiServiceBridge,
   createGuiServiceBridgeForDaemon,
   createLocalGuiServiceBridge,
   getShippedGuiBridgeMethods,
@@ -31,8 +26,11 @@ import {
   initAuthoredGit,
   readDaemonStatus,
   stopDaemonProcess,
+  waitForDaemonIdle,
   withGuiDaemonEnv,
-  writeExecutionEvidence
+  writeExecutionEvidence,
+  writeHarnessConfig,
+  writeTaskIndex
 } from "./helpers/daemon-generation-lifecycle.ts";
 
 test("GUI daemon autostart resolves system Node instead of Electron runtime", () => {
@@ -289,104 +287,6 @@ test("GUI service bridge reaches application service through the daemon client",
   }
 });
 
-test("GUI remote selection reads tasks and documents from a second repo over daemon stdio", async () => {
-  const nearRoot = mkdtempSync(path.join(tmpdir(), "ha-gui-near-"));
-  const remoteRoot = mkdtempSync(path.join(tmpdir(), "ha-gui-remote-"));
-  let remoteDaemonPid: number | undefined;
-  try {
-    writeTaskIndex(nearRoot, "task-near", "Near-only task", "planned");
-    writeTaskIndex(remoteRoot, "task-remote", "Remote-only task", "planned");
-
-    const local = await withGuiDaemonEnv(nearRoot, async () => {
-      const bridge = createGuiServiceBridge(nearRoot, undefined, {
-        env: { ...process.env, HARNESS_DAEMON_MODE: "local" }
-      });
-      try {
-        return await bridge.invoke("getTasks", null) as { readonly ok: boolean; readonly tasks?: ReadonlyArray<{ readonly taskId?: string }> };
-      } finally {
-        await bridge.dispose?.();
-      }
-    });
-    assert.deepEqual(local.tasks?.map((task) => task.taskId), ["task-near"]);
-
-    await withGuiDaemonEnv(remoteRoot, async () => {
-      const localRemoteBridge = createLocalGuiServiceBridge(remoteRoot);
-      const warm = await localRemoteBridge.invoke("getTasks", null) as { readonly ok: boolean };
-      assert.equal(warm.ok, true);
-      const status = daemonStatusData(await readDaemonStatus(remoteRoot));
-      const endpoint = status.endpoint;
-      assert.equal(typeof endpoint, "string");
-      remoteDaemonPid = daemonPidFromStatus(status);
-
-      const sshCalls: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> = [];
-      const remoteEnv = {
-        ...process.env,
-        HARNESS_DAEMON_MODE: "remote",
-        HARNESS_DAEMON_SSH_HOST: "fixture-remote",
-        HARNESS_DAEMON_REMOTE_HA: "/opt/ha",
-        HARNESS_DAEMON_REMOTE_ROOT: remoteRoot,
-        HARNESS_DAEMON_REPO_ID: "canonical",
-        HARNESS_DAEMON_REQUEST_TIMEOUT_MS: "5000"
-      };
-      const createEquivalentStdioTransport = (transport: { readonly host: string; readonly remoteHaPath: string }) => new SshStdioTransport({
-        host: transport.host,
-        remoteHaPath: transport.remoteHaPath,
-        spawnProcess: (command, args, options) => {
-          sshCalls.push({ command, args });
-          return spawn(process.execPath, [
-            fileURLToPath(new URL("../../cli/src/index.ts", import.meta.url)),
-            "daemon",
-            "connect",
-            "--stdio",
-            "--socket",
-            endpoint as string
-          ], { ...options, cwd: remoteRoot, env: process.env });
-        }
-      });
-      const remote = createGuiServiceBridge(nearRoot, undefined, {
-        env: remoteEnv,
-        createSshTransport: createEquivalentStdioTransport
-      });
-      try {
-        const tasks = await remote.invoke("getTasks", null) as {
-          readonly ok: boolean;
-          readonly tasks?: ReadonlyArray<{ readonly taskId?: string }>;
-        };
-        const document = await remote.invoke("getTaskDocument", {
-          taskId: "task-remote",
-          path: "INDEX.md"
-        }) as { readonly ok: boolean; readonly body?: string };
-
-        assert.equal(tasks.ok, true, JSON.stringify(tasks));
-        assert.deepEqual(tasks.tasks?.map((task) => task.taskId), ["task-remote"]);
-        assert.equal(tasks.tasks?.some((task) => task.taskId === "task-near"), false);
-        assert.equal(document.ok, true, JSON.stringify(document));
-        assert.match(document.body ?? "", /Remote-only task/u);
-        assert.deepEqual(sshCalls[0], {
-          command: "ssh",
-          args: ["fixture-remote", "/opt/ha", "daemon", "connect", "--stdio"]
-        });
-        const notifications = createGuiProjectionNotifications(nearRoot, undefined, {
-          env: remoteEnv,
-          createSshTransport: createEquivalentStdioTransport
-        });
-        try {
-          assert.deepEqual(await notifications.source.watch("canonical", () => undefined), { mode: "push" });
-        } finally {
-          await notifications.dispose();
-        }
-      } finally {
-        await remote.dispose?.();
-      }
-    }, { idleMs: "5000" });
-  } finally {
-    await stopDaemonProcess(remoteDaemonPid);
-    await waitForDaemonIdle();
-    rmSync(nearRoot, { recursive: true, force: true });
-    rmSync(remoteRoot, { recursive: true, force: true });
-  }
-});
-
 test("GUI evidence route reuses one daemon generation across an interaction pause", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-gui-evidence-generation-"));
   let daemonPid: number | undefined;
@@ -621,42 +521,7 @@ test("GUI service bridge shipped methods are registry-driven and deferred method
   }
 });
 
-function writeTaskIndex(rootDir: string, taskId: string, title: string, status: string, authoredRoot = "harness"): void {
-  writeHarnessConfig(rootDir, authoredRoot);
-  mkdirSync(path.join(rootDir, authoredRoot, "tasks", taskId), { recursive: true });
-  writeFileSync(path.join(rootDir, authoredRoot, "tasks", taskId, "INDEX.md"), [
-    "---",
-    "schema: task-package/v2",
-    `task_id: ${taskId}`,
-    `title: ${title}`,
-    "lifecycle:",
-    "  bindingSchema: lifecycle-binding/v1",
-    "  engine: local",
-    `  status: ${status}`,
-    "  ref: ",
-    `  titleSnapshot: ${title}`,
-    "  url: ",
-    "  bindingCreatedAt: 2026-06-12T00:00:00.000Z",
-    "  bindingFingerprint: sha256:test",
-    "packageDisposition: active",
-    "vertical: default",
-    "preset: default",
-    "---",
-    ""
-  ].join("\n"), "utf8");
-}
 
-function writeHarnessConfig(rootDir: string, authoredRoot = "harness"): void {
-  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
-  writeFileSync(path.join(rootDir, "harness", "harness.yaml"), [
-    "schema: harness-anything/v1",
-    "name: gui-bridge-test",
-    "layout:",
-    `  authoredRoot: ${authoredRoot}`,
-    "  localRoot: .harness",
-    ""
-  ].join("\n"), "utf8");
-}
 
 function writeTriadicLedger(rootDir: string): void {
   writeTaskIndex(rootDir, "task-1", "Triadic GUI task", "active");
@@ -783,8 +648,4 @@ function writeTriadicLedger(rootDir: string): void {
     executorSource: "none",
     at: "2026-07-10T01:00:00.000Z"
   })}\n`, "utf8");
-}
-
-function waitForDaemonIdle(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 700));
 }

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -1,11 +1,16 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
+import { SshStdioTransport } from "../../daemon-client/src/ssh-stdio-transport.ts";
 import {
   apiRouteContracts,
+  createGuiProjectionNotifications,
+  createGuiServiceBridge,
   createGuiServiceBridgeForDaemon,
   createLocalGuiServiceBridge,
   getShippedGuiBridgeMethods,
@@ -281,6 +286,104 @@ test("GUI service bridge reaches application service through the daemon client",
   } finally {
     await waitForDaemonIdle();
     rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("GUI remote selection reads tasks and documents from a second repo over daemon stdio", async () => {
+  const nearRoot = mkdtempSync(path.join(tmpdir(), "ha-gui-near-"));
+  const remoteRoot = mkdtempSync(path.join(tmpdir(), "ha-gui-remote-"));
+  let remoteDaemonPid: number | undefined;
+  try {
+    writeTaskIndex(nearRoot, "task-near", "Near-only task", "planned");
+    writeTaskIndex(remoteRoot, "task-remote", "Remote-only task", "planned");
+
+    const local = await withGuiDaemonEnv(nearRoot, async () => {
+      const bridge = createGuiServiceBridge(nearRoot, undefined, {
+        env: { ...process.env, HARNESS_DAEMON_MODE: "local" }
+      });
+      try {
+        return await bridge.invoke("getTasks", null) as { readonly ok: boolean; readonly tasks?: ReadonlyArray<{ readonly taskId?: string }> };
+      } finally {
+        await bridge.dispose?.();
+      }
+    });
+    assert.deepEqual(local.tasks?.map((task) => task.taskId), ["task-near"]);
+
+    await withGuiDaemonEnv(remoteRoot, async () => {
+      const localRemoteBridge = createLocalGuiServiceBridge(remoteRoot);
+      const warm = await localRemoteBridge.invoke("getTasks", null) as { readonly ok: boolean };
+      assert.equal(warm.ok, true);
+      const status = daemonStatusData(await readDaemonStatus(remoteRoot));
+      const endpoint = status.endpoint;
+      assert.equal(typeof endpoint, "string");
+      remoteDaemonPid = daemonPidFromStatus(status);
+
+      const sshCalls: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> = [];
+      const remoteEnv = {
+        ...process.env,
+        HARNESS_DAEMON_MODE: "remote",
+        HARNESS_DAEMON_SSH_HOST: "fixture-remote",
+        HARNESS_DAEMON_REMOTE_HA: "/opt/ha",
+        HARNESS_DAEMON_REMOTE_ROOT: remoteRoot,
+        HARNESS_DAEMON_REPO_ID: "canonical",
+        HARNESS_DAEMON_REQUEST_TIMEOUT_MS: "5000"
+      };
+      const createEquivalentStdioTransport = (transport: { readonly host: string; readonly remoteHaPath: string }) => new SshStdioTransport({
+        host: transport.host,
+        remoteHaPath: transport.remoteHaPath,
+        spawnProcess: (command, args, options) => {
+          sshCalls.push({ command, args });
+          return spawn(process.execPath, [
+            fileURLToPath(new URL("../../cli/src/index.ts", import.meta.url)),
+            "daemon",
+            "connect",
+            "--stdio",
+            "--socket",
+            endpoint as string
+          ], { ...options, cwd: remoteRoot, env: process.env });
+        }
+      });
+      const remote = createGuiServiceBridge(nearRoot, undefined, {
+        env: remoteEnv,
+        createSshTransport: createEquivalentStdioTransport
+      });
+      try {
+        const tasks = await remote.invoke("getTasks", null) as {
+          readonly ok: boolean;
+          readonly tasks?: ReadonlyArray<{ readonly taskId?: string }>;
+        };
+        const document = await remote.invoke("getTaskDocument", {
+          taskId: "task-remote",
+          path: "INDEX.md"
+        }) as { readonly ok: boolean; readonly body?: string };
+
+        assert.equal(tasks.ok, true, JSON.stringify(tasks));
+        assert.deepEqual(tasks.tasks?.map((task) => task.taskId), ["task-remote"]);
+        assert.equal(tasks.tasks?.some((task) => task.taskId === "task-near"), false);
+        assert.equal(document.ok, true, JSON.stringify(document));
+        assert.match(document.body ?? "", /Remote-only task/u);
+        assert.deepEqual(sshCalls[0], {
+          command: "ssh",
+          args: ["fixture-remote", "/opt/ha", "daemon", "connect", "--stdio"]
+        });
+        const notifications = createGuiProjectionNotifications(nearRoot, undefined, {
+          env: remoteEnv,
+          createSshTransport: createEquivalentStdioTransport
+        });
+        try {
+          assert.deepEqual(await notifications.source.watch("canonical", () => undefined), { mode: "push" });
+        } finally {
+          await notifications.dispose();
+        }
+      } finally {
+        await remote.dispose?.();
+      }
+    }, { idleMs: "5000" });
+  } finally {
+    await stopDaemonProcess(remoteDaemonPid);
+    await waitForDaemonIdle();
+    rmSync(nearRoot, { recursive: true, force: true });
+    rmSync(remoteRoot, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
# English

## Summary

Lets the GUI reach a remote harness ledger over the same SSH stdio transport the CLI already uses, so a workstation configured for a remote repository sees that repository's tasks and documents.

## What Changed

- Adds `SshStdioTransport` to `packages/daemon-client`, speaking JSON-RPC lines over `ssh <host> ha daemon connect --stdio`.
- Adds an `ssh-stdio` variant to the GUI `DaemonTransport` union and routes the GUI composition root and projection notifications through it when remote mode is configured.
- The GUI reads the same mode and connection inputs as the CLI, so the two cannot drift apart.

## Task And Scope

Task `task_01KY4YJ97QW1EZACN14BPMXW59`. Scope is deliberately limited to reaching remote data. Per-person task filtering is explicitly out of scope; the GUI already lists every task in the repository, so viewing a whole team's work needs no additional work.

## Version Impact

Additive only. The existing `ssh-tunnel` transport variant is untouched, and local mode behaviour is unchanged.

## Governance Declaration

Authorized by task `task_01KY4YJ97QW1EZACN14BPMXW59`. No CI, gate, branch-protection, or governance surface is modified. No gate was weakened, skipped, or exempted. The GUI continues to go through the daemon for every read and write, so the single-writer and authority-admission constraints still hold; no path reads the remote filesystem directly.

## Verification

- Targeted suites pass: 42 tests for the transport and framing contracts, 16 for the remote command shape and forced-command admission, 14 for local and multi-repo routing.
- Verified live against the real KTY server rather than only in fixtures: launching the GUI with remote configuration caused the Electron main process to spawn `ssh kty-harness ha daemon connect --stdio` as its own child, and the daemon returned `daemon protocol handshake accepted`. The repository owner confirmed the window shows the remote repository's data.
- Local mode regression coverage is included.
- Authoritative gates are the required checks on this pull request.

## Review Evidence

The first implementation round stopped at a checkpoint instead of writing code. It found that the pre-existing `ssh-tunnel` contract models loopback TCP with an attach token, whereas the CLI and the KTY deployment use an SSH stdio pipe under a forced command. Reusing the `ssh-tunnel` name for stdio semantics was rejected, because that is precisely the declared-surface-versus-runtime split this task exists to remove. A separate `ssh-stdio` variant was adopted instead, and the original variant was left byte-identical.

One pre-existing idle-exit timing test failed when run concurrently with a broader file set and passed when run alone; that fluctuation was not counted as a pass.

## Residual Risk

- Connection parameters other than the mode still come only from environment variables, so a configured repository does not yet connect without them. Tracked by task `task_01KY51PRDBHJ81QSVRA08V4CVB`.
- Verified on macOS against a Linux daemon; other client platforms are covered by contract tests rather than live runs.

## References

- Task `task_01KY4YJ97QW1EZACN14BPMXW59`
- Follow-up task `task_01KY51PRDBHJ81QSVRA08V4CVB`
- `harness/context/development/remote-harness-connection.md`

# 中文

## 概要

让 GUI 通过与 CLI 相同的 SSH stdio 传输连上远程 harness 台账，使配置了远程仓库的工作机能看到该仓库的任务与文档。

## 改动内容

- 在 `packages/daemon-client` 中新增 `SshStdioTransport`，通过 `ssh <host> ha daemon connect --stdio` 收发 JSON-RPC 行。
- 在 GUI 的 `DaemonTransport` 联合类型中新增 `ssh-stdio` 变体，并在配置为远程模式时把 GUI 组装根与 projection 通知路由过去。
- GUI 读取与 CLI 完全相同的模式与连接输入，因此两者不会各自漂移。

## 任务与范围

任务 `task_01KY4YJ97QW1EZACN14BPMXW59`。范围刻意限定为「能拿到远程数据」。按人筛选明确不在范围内；GUI 本来就列出该仓库的全部任务，所以「看到团队所有人的工作」不需要额外开发。

## 版本影响

纯增量。既有 `ssh-tunnel` 变体一字未改，本地模式行为不变。

## 治理声明

由任务 `task_01KY4YJ97QW1EZACN14BPMXW59` 授权。未修改任何 CI、gate、分支保护或治理面，没有削弱、跳过或豁免任何门。GUI 的每一次读写仍然经由 daemon，因此单写者与 authority admission 约束继续成立；没有任何路径直接读取远程文件系统。

## 验证

- 定向套件通过：传输与 framing 契约 42 项、远程命令形态与 forced-command admission 16 项、本地与多仓路由 14 项。
- 不止跑了 fixture，还对真实 KTY 服务器做了实测：以远程配置启动 GUI 后，Electron 主进程亲自拉起子进程 `ssh kty-harness ha daemon connect --stdio`，daemon 返回 `daemon protocol handshake accepted`；仓库所有者确认窗口中显示的是远程仓库的数据。
- 包含本地模式回归覆盖。
- 权威门是本 PR 上的 required checks。

## 审查证据

第一轮实现没有直接写代码，而是停在 checkpoint 上报：既有 `ssh-tunnel` 契约建模的是带 attach token 的 loopback TCP，而 CLI 与 KTY 实际使用的是 forced command 下的 SSH stdio 管道。复用 `ssh-tunnel` 这个名字去承载 stdio 语义被驳回——那正是本任务要消除的「声明面与运行时分裂」。最终采用独立的 `ssh-stdio` 变体，原变体保持逐字不变。

另有一个既有的 idle-exit 时序测试在与更大文件集并发运行时失败、单独运行时通过；该次波动未被记为通过。

## 残余风险

- 除模式外的连接参数目前仍只来自环境变量，因此仅配置好的仓库还不能自动连上。由任务 `task_01KY51PRDBHJ81QSVRA08V4CVB` 跟踪。
- 验证是在 macOS 上对 Linux daemon 完成的；其他客户端平台由契约测试覆盖，未做实机运行。

## 关联材料

- 任务 `task_01KY4YJ97QW1EZACN14BPMXW59`
- 后续任务 `task_01KY51PRDBHJ81QSVRA08V4CVB`
- `harness/context/development/remote-harness-connection.md`
