### PR TITLE
feat(daemon): resolve the remote connection from project and personal settings

### DIFF
--- a/packages/cli/src/commands/project-settings-identity.ts
+++ b/packages/cli/src/commands/project-settings-identity.ts
@@ -6,9 +6,28 @@ export interface ProjectHarnessIdentity {
   readonly displayName?: string;
 }
 
-export interface ProjectHarnessDaemonSettings {
-  readonly userRoot: string;
+/**
+ * Shared connection coordinates for the remote daemon. These describe the
+ * ledger repository, not the operator: every member of one project points at
+ * the same remote root and repo id, so the project file owns them. The host
+ * entry is the default `~/.ssh/config` alias the project publishes; an
+ * operator whose alias differs overrides it from personal settings instead of
+ * editing the shared file.
+ */
+export interface ProjectHarnessDaemonRemoteSettings {
+  readonly host?: string;
+  readonly root?: string;
+  readonly repoId?: string;
+  readonly haPath?: string;
 }
+
+export interface ProjectHarnessDaemonSettings {
+  readonly userRoot?: string;
+  readonly remote?: ProjectHarnessDaemonRemoteSettings;
+}
+
+const DAEMON_REMOTE_HOST_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._@-]*$/u;
+const DAEMON_REMOTE_REPO_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9/_@.-]*$/u;
 
 type Validation<Value> = { readonly ok: true; readonly value?: Value } | { readonly ok: false; readonly message: string };
 
@@ -16,14 +35,71 @@ export function validateDaemonSettings(value: unknown): Validation<ProjectHarnes
   if (value === undefined) return { ok: true };
   if (!isIdentitySettingsRecord(value)) return { ok: false, message: "settings.daemon must be a mapping." };
   const keys = Object.keys(value);
-  if (keys.length !== 1 || keys[0] !== "userRoot") return { ok: false, message: "settings.daemon supports only userRoot." };
-  if (typeof value.userRoot !== "string" || !value.userRoot.trim() || value.userRoot.includes("\0")) {
-    return { ok: false, message: "settings.daemon.userRoot must be a non-empty path scalar." };
+  if (keys.length === 0 || keys.some((key) => key !== "userRoot" && key !== "remote")) {
+    return { ok: false, message: "settings.daemon supports only userRoot and remote." };
   }
-  if (value.userRoot.startsWith("~") && value.userRoot !== "~" && !/^~[\\/]/u.test(value.userRoot)) {
-    return { ok: false, message: "settings.daemon.userRoot supports only ~ or ~/... home-relative paths." };
+  let userRoot: string | undefined;
+  if (value.userRoot !== undefined) {
+    if (typeof value.userRoot !== "string" || !value.userRoot.trim() || value.userRoot.includes("\0")) {
+      return { ok: false, message: "settings.daemon.userRoot must be a non-empty path scalar." };
+    }
+    if (value.userRoot.startsWith("~") && value.userRoot !== "~" && !/^~[\\/]/u.test(value.userRoot)) {
+      return { ok: false, message: "settings.daemon.userRoot supports only ~ or ~/... home-relative paths." };
+    }
+    userRoot = value.userRoot.trim();
   }
-  return { ok: true, value: { userRoot: value.userRoot.trim() } };
+  const remote = validateDaemonRemoteSettings(value.remote, "settings.daemon.remote");
+  if (!remote.ok) return remote;
+  return {
+    ok: true,
+    value: {
+      ...(userRoot === undefined ? {} : { userRoot }),
+      ...(remote.value === undefined ? {} : { remote: remote.value })
+    }
+  };
+}
+
+/**
+ * Validates one remote connection mapping. The same shape is accepted from the
+ * shared project file and from personal settings, so both layers reject the
+ * same malformed input with the same wording; the caller supplies the label so
+ * the message names the file the operator has to fix.
+ */
+export function validateDaemonRemoteSettings(value: unknown, label: string): Validation<ProjectHarnessDaemonRemoteSettings> {
+  if (value === undefined) return { ok: true };
+  if (!isIdentitySettingsRecord(value)) return { ok: false, message: `${label} must be a mapping.` };
+  const keys = Object.keys(value);
+  if (keys.length === 0) return { ok: false, message: `${label} must declare at least one of host, root, repoId, or haPath.` };
+  const unknown = keys.find((key) => key !== "host" && key !== "root" && key !== "repoId" && key !== "haPath");
+  if (unknown !== undefined) return { ok: false, message: `${label} supports only host, root, repoId, and haPath.` };
+
+  if (value.host !== undefined && (typeof value.host !== "string" || !DAEMON_REMOTE_HOST_PATTERN.test(value.host.trim()))) {
+    return { ok: false, message: `${label}.host must be an ssh destination or ~/.ssh/config alias.` };
+  }
+  if (value.root !== undefined) {
+    if (typeof value.root !== "string" || !value.root.trim() || value.root.includes("\0")) {
+      return { ok: false, message: `${label}.root must be a non-empty path scalar.` };
+    }
+    if (!value.root.trim().startsWith("/")) {
+      return { ok: false, message: `${label}.root must be an absolute path on the remote host.` };
+    }
+  }
+  if (value.repoId !== undefined && (typeof value.repoId !== "string" || !DAEMON_REMOTE_REPO_ID_PATTERN.test(value.repoId.trim()))) {
+    return { ok: false, message: `${label}.repoId must be a non-empty identifier.` };
+  }
+  if (value.haPath !== undefined && (typeof value.haPath !== "string" || !value.haPath.trim() || value.haPath.includes("\0"))) {
+    return { ok: false, message: `${label}.haPath must be a non-empty path scalar.` };
+  }
+
+  return {
+    ok: true,
+    value: {
+      ...(typeof value.host === "string" ? { host: value.host.trim() } : {}),
+      ...(typeof value.root === "string" ? { root: value.root.trim() } : {}),
+      ...(typeof value.repoId === "string" ? { repoId: value.repoId.trim() } : {}),
+      ...(typeof value.haPath === "string" ? { haPath: value.haPath.trim() } : {})
+    }
+  };
 }
 
 export function validateIdentitySettings(value: unknown): Validation<ProjectHarnessIdentity> {

--- a/packages/cli/src/commands/settings-document.ts
+++ b/packages/cli/src/commands/settings-document.ts
@@ -1,0 +1,252 @@
+/**
+ * Reads one harness settings document into a raw mapping. Parsing is
+ * deliberately separate from validation: this layer only decides what the file
+ * says, and every semantic rule about those values lives in the settings
+ * module that consumes it.
+ */
+import type { DaemonRuntimePolicyValues } from "@harness-anything/daemon";
+
+export type RawSettings = Record<string, unknown>;
+
+const SETTINGS_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9]*$/u;
+
+export function parseSettingsDocument(body: string): { readonly present: boolean; readonly settings: RawSettings } {
+  const trimmed = body.trimStart();
+  if (trimmed.startsWith("{")) {
+    const decoded = JSON.parse(body) as { readonly settings?: RawSettings; readonly project?: { readonly locale?: unknown }; readonly vertical?: { readonly default?: unknown }; readonly presets?: { readonly default?: unknown } };
+    const fromSettings = decoded.settings ?? {};
+    const merged = {
+      locale: fromSettings.locale ?? decoded.project?.locale,
+      defaultVertical: fromSettings.defaultVertical ?? decoded.vertical?.default,
+      defaultPreset: fromSettings.defaultPreset ?? decoded.presets?.default,
+      defaultProfile: fromSettings.defaultProfile,
+      identity: fromSettings.identity,
+      daemon: fromSettings.daemon,
+      daemonRuntime: fromSettings.daemonRuntime,
+      tasks: fromSettings.tasks,
+      execution: fromSettings.execution,
+      adapters: fromSettings.adapters,
+      customVerticals: fromSettings.customVerticals
+    };
+    return {
+      present: Boolean(decoded.settings || decoded.project?.locale || decoded.vertical?.default || decoded.presets?.default),
+      settings: merged
+    };
+  }
+
+  return parseYamlSettings(body);
+}
+
+function parseYamlSettings(body: string): { readonly present: boolean; readonly settings: RawSettings } {
+  const lines = body.split(/\r?\n/u);
+  const settings: Record<string, unknown> = {};
+  let inSettings = false;
+  let inCustomVerticals = false;
+  let inIdentity = false;
+  let inDaemon = false;
+  let inDaemonRemote = false;
+  let inTasks = false;
+  let inDaemonRuntime = false;
+  let inExecution = false;
+  let inAdapters = false;
+  let inMultica = false;
+  let foundSettings = false;
+
+  for (const rawLine of lines) {
+    const withoutComment = rawLine.replace(/\s+#.*$/u, "");
+    if (!withoutComment.trim()) continue;
+
+    const topLevel = /^([A-Za-z][A-Za-z0-9]*):(?:\s*(.*))?$/u.exec(withoutComment);
+    if (topLevel) {
+      inSettings = topLevel[1] === "settings";
+      inCustomVerticals = false;
+      inIdentity = false;
+      inDaemon = false;
+      inDaemonRemote = false;
+      inTasks = false;
+      inDaemonRuntime = false;
+      inExecution = false;
+      inAdapters = false;
+      inMultica = false;
+      foundSettings ||= inSettings;
+      if (inSettings && topLevel[2]?.trim()) {
+        throw new Error("settings must be a mapping.");
+      }
+      continue;
+    }
+
+    if (!inSettings) continue;
+
+    const nested = /^  ([A-Za-z][A-Za-z0-9]*):(?:\s*(.*))?$/u.exec(withoutComment);
+    if (nested) {
+      const [, key, rawValue = ""] = nested;
+      if (!SETTINGS_KEY_PATTERN.test(key)) throw new Error(`Invalid settings key: ${key}`);
+      const value = rawValue.trim();
+      inCustomVerticals = key === "customVerticals";
+      inIdentity = key === "identity";
+      inDaemon = key === "daemon";
+      inDaemonRemote = false;
+      inTasks = key === "tasks";
+      inDaemonRuntime = key === "daemonRuntime";
+      inExecution = key === "execution";
+      inAdapters = key === "adapters";
+      inMultica = false;
+      if (inCustomVerticals) {
+        if (value) throw new Error("settings.customVerticals must be a mapping.");
+        settings.customVerticals = {};
+        continue;
+      }
+      if (inIdentity) {
+        if (value) throw new Error("settings.identity must be a mapping.");
+        settings.identity = {};
+        continue;
+      }
+      if (inDaemon) {
+        if (value) throw new Error("settings.daemon must be a mapping.");
+        settings.daemon = {};
+        continue;
+      }
+      if (inTasks) {
+        if (value) throw new Error("settings.tasks must be a mapping.");
+        settings.tasks = {};
+        continue;
+      }
+      if (inDaemonRuntime) {
+        if (value) throw new Error("settings.daemonRuntime must be a mapping.");
+        settings.daemonRuntime = {};
+        continue;
+      }
+      if (inExecution) {
+        if (value) throw new Error("settings.execution must be a mapping.");
+        settings.execution = {};
+        continue;
+      }
+      if (inAdapters) {
+        if (value) throw new Error("settings.adapters must be a mapping.");
+        settings.adapters = {};
+        continue;
+      }
+      if (!isKnownSettingsScalar(key)) throw new Error(`Unknown settings key: ${key}`);
+      if (!value) throw new Error(`settings.${key} must be a scalar value.`);
+      settings[key] = unquoteScalar(value);
+      continue;
+    }
+
+    const customNested = /^    ([A-Za-z][A-Za-z0-9]*):(?:\s*(.*))?$/u.exec(withoutComment);
+    if (inCustomVerticals && customNested) {
+      const [, key, rawValue = ""] = customNested;
+      if (key !== "enabled") throw new Error(`Unknown settings.customVerticals key: ${key}`);
+      const value = rawValue.trim();
+      if (value !== "true" && value !== "false") throw new Error("settings.customVerticals.enabled must be true or false.");
+      settings.customVerticals = { enabled: value === "true" };
+      continue;
+    }
+    if (inIdentity && customNested) {
+      const [, key, rawValue = ""] = customNested;
+      if (key !== "mode" && key !== "personId" && key !== "displayName") throw new Error(`Unknown settings.identity key: ${key}`);
+      const value = rawValue.trim();
+      if (!value) throw new Error(`settings.identity.${key} must be a scalar value.`);
+      settings.identity = { ...(isRecord(settings.identity) ? settings.identity : {}), [key]: unquoteScalar(value) };
+      continue;
+    }
+    if (inDaemon && customNested) {
+      const [, key, rawValue = ""] = customNested;
+      if (key !== "userRoot" && key !== "remote") throw new Error(`Unknown settings.daemon key: ${key}`);
+      const value = rawValue.trim();
+      inDaemonRemote = key === "remote";
+      const priorDaemon = isRecord(settings.daemon) ? settings.daemon : {};
+      if (inDaemonRemote) {
+        if (value) throw new Error("settings.daemon.remote must be a mapping.");
+        settings.daemon = { ...priorDaemon, remote: {} };
+        continue;
+      }
+      if (!value) throw new Error("settings.daemon.userRoot must be a scalar value.");
+      settings.daemon = { ...priorDaemon, userRoot: unquoteScalar(value) };
+      continue;
+    }
+    if (inTasks && customNested) {
+      const [, key, rawValue = ""] = customNested;
+      if (key !== "leaseEnforcement" && key !== "leaseTtlMs") throw new Error(`Unknown settings.tasks key: ${key}`);
+      const value = rawValue.trim();
+      if (!value) throw new Error(`settings.tasks.${key} must be a scalar value.`);
+      if (key === "leaseEnforcement") {
+        if (value !== "true" && value !== "false") throw new Error("settings.tasks.leaseEnforcement must be true or false.");
+        settings.tasks = { ...(isRecord(settings.tasks) ? settings.tasks : {}), leaseEnforcement: value === "true" };
+      } else {
+        settings.tasks = { ...(isRecord(settings.tasks) ? settings.tasks : {}), leaseTtlMs: unquoteScalar(value) };
+      }
+      continue;
+    }
+    if (inExecution && customNested) {
+      const [, key, rawValue = ""] = customNested;
+      if (key !== "consentTtlMs") throw new Error(`Unknown settings.execution key: ${key}`);
+      const value = rawValue.trim();
+      if (!value) throw new Error("settings.execution.consentTtlMs must be a scalar value.");
+      settings.execution = { consentTtlMs: unquoteScalar(value) };
+      continue;
+    }
+    if (inDaemonRuntime && customNested) {
+      const [, key, rawValue = ""] = customNested;
+      if (!daemonRuntimeKeys.includes(key as keyof DaemonRuntimePolicyValues)) throw new Error(`Unknown settings.daemonRuntime key: ${key}`);
+      const value = rawValue.trim();
+      if (!value) throw new Error(`settings.daemonRuntime.${key} must be a scalar value.`);
+      settings.daemonRuntime = { ...(isRecord(settings.daemonRuntime) ? settings.daemonRuntime : {}), [key]: unquoteScalar(value) };
+      continue;
+    }
+    if (inAdapters && customNested) {
+      const [, key, rawValue = ""] = customNested;
+      if (key !== "multica") throw new Error(`Unknown settings.adapters key: ${key}`);
+      if (rawValue.trim()) throw new Error("settings.adapters.multica must be a mapping.");
+      settings.adapters = { multica: {} };
+      inMultica = true;
+      continue;
+    }
+
+    const deepNested = /^      ([A-Za-z][A-Za-z0-9]*):(?:\s*(.*))?$/u.exec(withoutComment);
+    if (inDaemon && inDaemonRemote && deepNested) {
+      const [, key, rawValue = ""] = deepNested;
+      if (key !== "host" && key !== "root" && key !== "repoId" && key !== "haPath") {
+        throw new Error(`Unknown settings.daemon.remote key: ${key}`);
+      }
+      const value = rawValue.trim();
+      if (!value) throw new Error(`settings.daemon.remote.${key} must be a scalar value.`);
+      const priorDaemon = isRecord(settings.daemon) ? settings.daemon : {};
+      const priorRemote = isRecord(priorDaemon.remote) ? priorDaemon.remote : {};
+      settings.daemon = { ...priorDaemon, remote: { ...priorRemote, [key]: unquoteScalar(value) } };
+      continue;
+    }
+    if (inAdapters && inMultica && deepNested) {
+      const [, key, rawValue = ""] = deepNested;
+      if (key !== "staleTtlMs") throw new Error(`Unknown settings.adapters.multica key: ${key}`);
+      const value = rawValue.trim();
+      if (!value) throw new Error("settings.adapters.multica.staleTtlMs must be a scalar value.");
+      settings.adapters = { multica: { staleTtlMs: unquoteScalar(value) } };
+      continue;
+    }
+
+    throw new Error(`Unsupported settings YAML line: ${withoutComment.trim()}`);
+  }
+
+  return { present: foundSettings, settings };
+}
+
+export const daemonRuntimeKeys = [
+  "writeLockTtlMs", "interactiveMicroBatchMs", "maxInteractiveOpsPerCommit",
+  "materializerPollMs", "materializerMaxBranchesPerBatch",
+  "projectionReconcileIntervalMs", "registryReconcileIntervalMs"
+] as const satisfies ReadonlyArray<keyof DaemonRuntimePolicyValues>;
+
+function isKnownSettingsScalar(key: string): boolean {
+  return key === "locale" || key === "defaultVertical" || key === "defaultPreset" || key === "defaultProfile";
+}
+
+function unquoteScalar(value: string): string {
+  if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/cli/src/commands/settings.ts
+++ b/packages/cli/src/commands/settings.ts
@@ -4,6 +4,12 @@ import type { HarnessLayoutInput } from "@harness-anything/kernel";
 import type { DaemonRuntimePolicyValues } from "@harness-anything/daemon";
 import { resolveHarnessLayout } from "@harness-anything/kernel";
 import { cliError, CliErrorCode } from "../cli/error-codes.ts";
+import {
+  daemonRuntimeKeys,
+  isRecord,
+  parseSettingsDocument,
+  type RawSettings
+} from "./settings-document.ts";
 import type { CliResult } from "../cli/types.ts";
 import {
   validateAdapterSettings,
@@ -11,7 +17,14 @@ import {
   type ProjectHarnessAdapterSettings,
   type ProjectHarnessExecutionSettings
 } from "./project-policy-values.ts";
-import { validateDaemonSettings, validateIdentitySettings, type ProjectHarnessDaemonSettings, type ProjectHarnessIdentity } from "./project-settings-identity.ts";
+import {
+  validateDaemonRemoteSettings,
+  validateDaemonSettings,
+  validateIdentitySettings,
+  type ProjectHarnessDaemonRemoteSettings,
+  type ProjectHarnessDaemonSettings,
+  type ProjectHarnessIdentity
+} from "./project-settings-identity.ts";
 
 export type HarnessLocale = "zh-CN" | "en-US";
 
@@ -38,6 +51,7 @@ export interface ProjectHarnessSettings {
 export interface UserHarnessSettings {
   readonly present: boolean;
   readonly customVerticalsDevMode: boolean;
+  readonly daemonRemote?: ProjectHarnessDaemonRemoteSettings;
 }
 
 type SettingsResult =
@@ -47,8 +61,6 @@ type SettingsResult =
 type UserSettingsResult =
   | { readonly ok: true; readonly settings: UserHarnessSettings }
   | { readonly ok: false; readonly result: CliResult };
-
-type RawSettings = Record<string, unknown>;
 
 const EMPTY_SETTINGS: ProjectHarnessSettings = {
   present: false,
@@ -61,7 +73,6 @@ const EMPTY_USER_SETTINGS: UserHarnessSettings = {
   customVerticalsDevMode: false
 };
 
-const SETTINGS_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9]*$/u;
 const SETTINGS_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9/_@.-]*$/u;
 const DEFAULT_TASK_LEASE_TTL_MS = 24 * 60 * 60 * 1_000;
 
@@ -97,22 +108,27 @@ export function readUserHarnessSettings(rootInput: HarnessLayoutInput, command =
     const raw = JSON.parse(readFileSync(configPath, "utf8")) as unknown;
     if (
       !isRecord(raw) ||
-      !hasExactKeys(raw, ["devMode", "schema"]) ||
+      !hasKnownKeys(raw, ["daemon", "devMode", "schema"]) ||
       raw.schema !== "user-settings/v1" ||
-      !isRecord(raw.devMode) ||
-      !hasExactKeys(raw.devMode, ["customVerticals"]) ||
-      typeof raw.devMode.customVerticals !== "boolean"
+      (raw.devMode !== undefined && (
+        !isRecord(raw.devMode) ||
+        !hasExactKeys(raw.devMode, ["customVerticals"]) ||
+        typeof raw.devMode.customVerticals !== "boolean"
+      ))
     ) {
       return {
         ok: false,
         result: userSettingsError(command, ".harness/user-settings.json must match user-settings/v1 with devMode.customVerticals boolean.")
       };
     }
+    const daemonRemote = readUserDaemonRemote(raw.daemon);
+    if (!daemonRemote.ok) return { ok: false, result: userSettingsError(command, daemonRemote.message) };
     return {
       ok: true,
       settings: {
         present: true,
-        customVerticalsDevMode: raw.devMode.customVerticals
+        customVerticalsDevMode: isRecord(raw.devMode) && raw.devMode.customVerticals === true,
+        ...(daemonRemote.value === undefined ? {} : { daemonRemote: daemonRemote.value })
       }
     };
   } catch (error) {
@@ -215,204 +231,6 @@ export function settingsIssue(result: Extract<SettingsResult, { readonly ok: fal
   };
 }
 
-function parseSettingsDocument(body: string): { readonly present: boolean; readonly settings: RawSettings } {
-  const trimmed = body.trimStart();
-  if (trimmed.startsWith("{")) {
-    const decoded = JSON.parse(body) as { readonly settings?: RawSettings; readonly project?: { readonly locale?: unknown }; readonly vertical?: { readonly default?: unknown }; readonly presets?: { readonly default?: unknown } };
-    const fromSettings = decoded.settings ?? {};
-    const merged = {
-      locale: fromSettings.locale ?? decoded.project?.locale,
-      defaultVertical: fromSettings.defaultVertical ?? decoded.vertical?.default,
-      defaultPreset: fromSettings.defaultPreset ?? decoded.presets?.default,
-      defaultProfile: fromSettings.defaultProfile,
-      identity: fromSettings.identity,
-      daemon: fromSettings.daemon,
-      daemonRuntime: fromSettings.daemonRuntime,
-      tasks: fromSettings.tasks,
-      execution: fromSettings.execution,
-      adapters: fromSettings.adapters,
-      customVerticals: fromSettings.customVerticals
-    };
-    return {
-      present: Boolean(decoded.settings || decoded.project?.locale || decoded.vertical?.default || decoded.presets?.default),
-      settings: merged
-    };
-  }
-
-  return parseYamlSettings(body);
-}
-
-function parseYamlSettings(body: string): { readonly present: boolean; readonly settings: RawSettings } {
-  const lines = body.split(/\r?\n/u);
-  const settings: Record<string, unknown> = {};
-  let inSettings = false;
-  let inCustomVerticals = false;
-  let inIdentity = false;
-  let inDaemon = false;
-  let inTasks = false;
-  let inDaemonRuntime = false;
-  let inExecution = false;
-  let inAdapters = false;
-  let inMultica = false;
-  let foundSettings = false;
-
-  for (const rawLine of lines) {
-    const withoutComment = rawLine.replace(/\s+#.*$/u, "");
-    if (!withoutComment.trim()) continue;
-
-    const topLevel = /^([A-Za-z][A-Za-z0-9]*):(?:\s*(.*))?$/u.exec(withoutComment);
-    if (topLevel) {
-      inSettings = topLevel[1] === "settings";
-      inCustomVerticals = false;
-      inIdentity = false;
-      inDaemon = false;
-      inTasks = false;
-      inDaemonRuntime = false;
-      inExecution = false;
-      inAdapters = false;
-      inMultica = false;
-      foundSettings ||= inSettings;
-      if (inSettings && topLevel[2]?.trim()) {
-        throw new Error("settings must be a mapping.");
-      }
-      continue;
-    }
-
-    if (!inSettings) continue;
-
-    const nested = /^  ([A-Za-z][A-Za-z0-9]*):(?:\s*(.*))?$/u.exec(withoutComment);
-    if (nested) {
-      const [, key, rawValue = ""] = nested;
-      if (!SETTINGS_KEY_PATTERN.test(key)) throw new Error(`Invalid settings key: ${key}`);
-      const value = rawValue.trim();
-      inCustomVerticals = key === "customVerticals";
-      inIdentity = key === "identity";
-      inDaemon = key === "daemon";
-      inTasks = key === "tasks";
-      inDaemonRuntime = key === "daemonRuntime";
-      inExecution = key === "execution";
-      inAdapters = key === "adapters";
-      inMultica = false;
-      if (inCustomVerticals) {
-        if (value) throw new Error("settings.customVerticals must be a mapping.");
-        settings.customVerticals = {};
-        continue;
-      }
-      if (inIdentity) {
-        if (value) throw new Error("settings.identity must be a mapping.");
-        settings.identity = {};
-        continue;
-      }
-      if (inDaemon) {
-        if (value) throw new Error("settings.daemon must be a mapping.");
-        settings.daemon = {};
-        continue;
-      }
-      if (inTasks) {
-        if (value) throw new Error("settings.tasks must be a mapping.");
-        settings.tasks = {};
-        continue;
-      }
-      if (inDaemonRuntime) {
-        if (value) throw new Error("settings.daemonRuntime must be a mapping.");
-        settings.daemonRuntime = {};
-        continue;
-      }
-      if (inExecution) {
-        if (value) throw new Error("settings.execution must be a mapping.");
-        settings.execution = {};
-        continue;
-      }
-      if (inAdapters) {
-        if (value) throw new Error("settings.adapters must be a mapping.");
-        settings.adapters = {};
-        continue;
-      }
-      if (!isKnownSettingsScalar(key)) throw new Error(`Unknown settings key: ${key}`);
-      if (!value) throw new Error(`settings.${key} must be a scalar value.`);
-      settings[key] = unquoteScalar(value);
-      continue;
-    }
-
-    const customNested = /^    ([A-Za-z][A-Za-z0-9]*):(?:\s*(.*))?$/u.exec(withoutComment);
-    if (inCustomVerticals && customNested) {
-      const [, key, rawValue = ""] = customNested;
-      if (key !== "enabled") throw new Error(`Unknown settings.customVerticals key: ${key}`);
-      const value = rawValue.trim();
-      if (value !== "true" && value !== "false") throw new Error("settings.customVerticals.enabled must be true or false.");
-      settings.customVerticals = { enabled: value === "true" };
-      continue;
-    }
-    if (inIdentity && customNested) {
-      const [, key, rawValue = ""] = customNested;
-      if (key !== "mode" && key !== "personId" && key !== "displayName") throw new Error(`Unknown settings.identity key: ${key}`);
-      const value = rawValue.trim();
-      if (!value) throw new Error(`settings.identity.${key} must be a scalar value.`);
-      settings.identity = { ...(isRecord(settings.identity) ? settings.identity : {}), [key]: unquoteScalar(value) };
-      continue;
-    }
-    if (inDaemon && customNested) {
-      const [, key, rawValue = ""] = customNested;
-      if (key !== "userRoot") throw new Error(`Unknown settings.daemon key: ${key}`);
-      const value = rawValue.trim();
-      if (!value) throw new Error("settings.daemon.userRoot must be a scalar value.");
-      settings.daemon = { userRoot: unquoteScalar(value) };
-      continue;
-    }
-    if (inTasks && customNested) {
-      const [, key, rawValue = ""] = customNested;
-      if (key !== "leaseEnforcement" && key !== "leaseTtlMs") throw new Error(`Unknown settings.tasks key: ${key}`);
-      const value = rawValue.trim();
-      if (!value) throw new Error(`settings.tasks.${key} must be a scalar value.`);
-      if (key === "leaseEnforcement") {
-        if (value !== "true" && value !== "false") throw new Error("settings.tasks.leaseEnforcement must be true or false.");
-        settings.tasks = { ...(isRecord(settings.tasks) ? settings.tasks : {}), leaseEnforcement: value === "true" };
-      } else {
-        settings.tasks = { ...(isRecord(settings.tasks) ? settings.tasks : {}), leaseTtlMs: unquoteScalar(value) };
-      }
-      continue;
-    }
-    if (inExecution && customNested) {
-      const [, key, rawValue = ""] = customNested;
-      if (key !== "consentTtlMs") throw new Error(`Unknown settings.execution key: ${key}`);
-      const value = rawValue.trim();
-      if (!value) throw new Error("settings.execution.consentTtlMs must be a scalar value.");
-      settings.execution = { consentTtlMs: unquoteScalar(value) };
-      continue;
-    }
-    if (inDaemonRuntime && customNested) {
-      const [, key, rawValue = ""] = customNested;
-      if (!daemonRuntimeKeys.includes(key as keyof DaemonRuntimePolicyValues)) throw new Error(`Unknown settings.daemonRuntime key: ${key}`);
-      const value = rawValue.trim();
-      if (!value) throw new Error(`settings.daemonRuntime.${key} must be a scalar value.`);
-      settings.daemonRuntime = { ...(isRecord(settings.daemonRuntime) ? settings.daemonRuntime : {}), [key]: unquoteScalar(value) };
-      continue;
-    }
-    if (inAdapters && customNested) {
-      const [, key, rawValue = ""] = customNested;
-      if (key !== "multica") throw new Error(`Unknown settings.adapters key: ${key}`);
-      if (rawValue.trim()) throw new Error("settings.adapters.multica must be a mapping.");
-      settings.adapters = { multica: {} };
-      inMultica = true;
-      continue;
-    }
-
-    const adapterNested = /^      ([A-Za-z][A-Za-z0-9]*):(?:\s*(.*))?$/u.exec(withoutComment);
-    if (inAdapters && inMultica && adapterNested) {
-      const [, key, rawValue = ""] = adapterNested;
-      if (key !== "staleTtlMs") throw new Error(`Unknown settings.adapters.multica key: ${key}`);
-      const value = rawValue.trim();
-      if (!value) throw new Error("settings.adapters.multica.staleTtlMs must be a scalar value.");
-      settings.adapters = { multica: { staleTtlMs: unquoteScalar(value) } };
-      continue;
-    }
-
-    throw new Error(`Unsupported settings YAML line: ${withoutComment.trim()}`);
-  }
-
-  return { present: foundSettings, settings };
-}
-
 function validateSettings(command: string, raw: RawSettings): SettingsResult {
   const locale = raw.locale;
   if (locale !== undefined && locale !== "zh-CN" && locale !== "en-US") {
@@ -489,12 +307,6 @@ function validateSettings(command: string, raw: RawSettings): SettingsResult {
   };
 }
 
-const daemonRuntimeKeys = [
-  "writeLockTtlMs", "interactiveMicroBatchMs", "maxInteractiveOpsPerCommit",
-  "materializerPollMs", "materializerMaxBranchesPerBatch",
-  "projectionReconcileIntervalMs", "registryReconcileIntervalMs"
-] as const satisfies ReadonlyArray<keyof DaemonRuntimePolicyValues>;
-
 function validateDaemonRuntime(value: unknown):
   | { readonly ok: true; readonly value?: DaemonRuntimePolicyValues }
   | { readonly ok: false; readonly message: string } {
@@ -540,10 +352,6 @@ function userSettingsError(command: string, hint: string): CliResult {
   };
 }
 
-function isKnownSettingsScalar(key: string): boolean {
-  return key === "locale" || key === "defaultVertical" || key === "defaultPreset" || key === "defaultProfile";
-}
-
 function parseLeaseEnforcementEnv(value: string | undefined): boolean | undefined {
   switch (value?.trim().toLowerCase()) {
     case "1":
@@ -574,17 +382,26 @@ function hasExactKeys(value: Record<string, unknown>, expected: ReadonlyArray<st
   return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
 }
 
+function hasKnownKeys(value: Record<string, unknown>, allowed: ReadonlyArray<string>): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+/**
+ * Personal settings carry only the operator-specific half of the remote
+ * connection; the shared project file owns the rest. Unknown keys fail closed
+ * here for the same reason they do in the project file: a typo that silently
+ * resolves to the default would send writes at the wrong ledger.
+ */
+function readUserDaemonRemote(
+  value: unknown
+): { readonly ok: true; readonly value?: ProjectHarnessDaemonRemoteSettings } | { readonly ok: false; readonly message: string } {
+  if (value === undefined) return { ok: true };
+  if (!isRecord(value) || !hasExactKeys(value, ["remote"])) {
+    return { ok: false, message: ".harness/user-settings.json daemon supports only remote." };
+  }
+  return validateDaemonRemoteSettings(value.remote, ".harness/user-settings.json daemon.remote");
+}
+
 function normalizeDefaultSentinel(value: string | undefined): string | undefined {
   return value === "default" ? undefined : value;
-}
-
-function unquoteScalar(value: string): string {
-  if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
-    return value.slice(1, -1);
-  }
-  return value;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -43,6 +43,7 @@ import { resolveManagedSectionPolicy } from "../commands/extensions/managed-sect
 
 const docSyncHostServices = { resolveManagedSectionPolicy };
 import { readProjectHarnessSettings } from "../commands/settings.ts";
+import { readRemoteConfig, remoteDaemonSshArgs, remoteDaemonUnavailableHint, type RemoteDaemonConfig } from "./remote-config.ts";
 import { isDeclaredLocalMigrationCommand } from "../composition/local-write-scope.ts";
 import { startCliTimingPhase, type CliTimingPhase } from "../cli/timing.ts";
 
@@ -59,6 +60,12 @@ export {
   type LocalDaemonTarget
 } from "@harness-anything/daemon";
 
+export {
+  remoteDaemonSshArgs,
+  remoteDaemonUnavailableHint,
+  type RemoteDaemonConfig
+} from "./remote-config.ts";
+
 export type DaemonClientMode = "direct" | "local" | "remote";
 
 export interface DaemonClientConfig {
@@ -71,13 +78,6 @@ export interface DaemonClientConfig {
   readonly daemonId: string;
   readonly directWriteReason?: "recovery";
   readonly remote?: RemoteDaemonConfig;
-}
-
-export interface RemoteDaemonConfig {
-  readonly host: string;
-  readonly remoteHaPath: string;
-  readonly remoteRoot: string;
-  readonly repoId: string;
 }
 
 type TaskHolderParsedCommand = ParsedCommand & {
@@ -110,7 +110,7 @@ export function readDaemonClientConfig(
     userRoot,
     daemonId: daemonIdFromEnv(env),
     ...(directWriteReason ? { directWriteReason } : {}),
-    ...(mode === "remote" ? { remote: readRemoteConfig(env) } : {})
+    ...(mode === "remote" ? { remote: readRemoteConfig(env, rootDir, projectSettings, layoutOverrides) } : {})
   };
 }
 
@@ -454,14 +454,6 @@ function isInitializedHarness(command: ParsedCommand): boolean {
   }
 }
 
-export function remoteDaemonSshArgs(remote: RemoteDaemonConfig): ReadonlyArray<string> {
-  return [remote.host, remote.remoteHaPath, "daemon", "connect", "--stdio"];
-}
-
-export function remoteDaemonUnavailableHint(remote: RemoteDaemonConfig): string {
-  return `Remote daemon unavailable. Start the persistent daemon on ${remote.host} with '${remote.remoteHaPath} daemon start --service' and verify '${remote.remoteHaPath} daemon status'.`;
-}
-
 function commandForTarget(command: ParsedCommand, target: LocalDaemonTarget): ParsedCommand {
   return path.resolve(command.rootDir) === path.resolve(target.canonicalRoot)
     ? command
@@ -482,21 +474,6 @@ export function daemonClientCliEntrypointPath(moduleUrl: string | URL = import.m
     throw new Error(`unsupported daemon client module extension: ${extension || "<none>"}`);
   }
   return fileURLToPath(new URL(`../index${extension}`, clientUrl));
-}
-
-function readRemoteConfig(env: NodeJS.ProcessEnv): RemoteDaemonConfig {
-  return {
-    host: requiredEnv(env, "HARNESS_DAEMON_SSH_HOST"),
-    remoteHaPath: env.HARNESS_DAEMON_REMOTE_HA ?? "ha",
-    remoteRoot: requiredEnv(env, "HARNESS_DAEMON_REMOTE_ROOT"),
-    repoId: env.HARNESS_DAEMON_REPO_ID ?? "canonical"
-  };
-}
-
-function requiredEnv(env: NodeJS.ProcessEnv, name: string): string {
-  const value = env[name];
-  if (typeof value === "string" && value.length > 0) return value;
-  throw new Error(`${name} is required when HARNESS_DAEMON_MODE=remote`);
 }
 
 function isCommandReceipt(value: JsonObject): boolean {

--- a/packages/cli/src/daemon/remote-config.ts
+++ b/packages/cli/src/daemon/remote-config.ts
@@ -1,0 +1,75 @@
+import { createHarnessRuntimeContext, type HarnessLayoutOverrides } from "@harness-anything/kernel";
+import type { ProjectHarnessDaemonRemoteSettings } from "../commands/project-settings-identity.ts";
+import { readUserHarnessSettings, type ProjectHarnessSettings } from "../commands/settings.ts";
+
+export interface RemoteDaemonConfig {
+  readonly host: string;
+  readonly remoteHaPath: string;
+  readonly remoteRoot: string;
+  readonly repoId: string;
+}
+
+/**
+ * Resolves the remote connection from three layers so a configured checkout
+ * needs no exported environment at all: the environment stays the operational
+ * override, personal settings carry what differs per operator (their own
+ * ~/.ssh/config alias), and the shared project file carries what the whole
+ * team points at. Every layer is optional; only the resolved result has to be
+ * complete.
+ */
+export function readRemoteConfig(
+  env: NodeJS.ProcessEnv,
+  rootDir: string,
+  projectSettings: ProjectHarnessSettings | undefined,
+  layoutOverrides?: HarnessLayoutOverrides
+): RemoteDaemonConfig {
+  const shared = projectSettings?.daemon?.remote;
+  const personal = readUserDaemonRemoteSettings(rootDir, layoutOverrides);
+  return {
+    host: requiredRemoteSetting(
+      [env.HARNESS_DAEMON_SSH_HOST, personal?.host, shared?.host],
+      "HARNESS_DAEMON_SSH_HOST",
+      "host"
+    ),
+    remoteHaPath: firstConfigured([env.HARNESS_DAEMON_REMOTE_HA, personal?.haPath, shared?.haPath]) ?? "ha",
+    remoteRoot: requiredRemoteSetting(
+      [env.HARNESS_DAEMON_REMOTE_ROOT, personal?.root, shared?.root],
+      "HARNESS_DAEMON_REMOTE_ROOT",
+      "root"
+    ),
+    repoId: firstConfigured([env.HARNESS_DAEMON_REPO_ID, personal?.repoId, shared?.repoId]) ?? "canonical"
+  };
+}
+
+export function remoteDaemonSshArgs(remote: RemoteDaemonConfig): ReadonlyArray<string> {
+  return [remote.host, remote.remoteHaPath, "daemon", "connect", "--stdio"];
+}
+
+export function remoteDaemonUnavailableHint(remote: RemoteDaemonConfig): string {
+  return `Remote daemon unavailable. Start the persistent daemon on ${remote.host} with '${remote.remoteHaPath} daemon start --service' and verify '${remote.remoteHaPath} daemon status'.`;
+}
+
+function readUserDaemonRemoteSettings(
+  rootDir: string,
+  layoutOverrides?: HarnessLayoutOverrides
+): ProjectHarnessDaemonRemoteSettings | undefined {
+  const settings = readUserHarnessSettings(createHarnessRuntimeContext(rootDir, layoutOverrides), "daemon-client-mode");
+  if (!settings.ok) throw new Error(settings.result.error?.hint ?? "Personal daemon settings are invalid.");
+  return settings.settings.daemonRemote;
+}
+
+function firstConfigured(candidates: ReadonlyArray<string | undefined>): string | undefined {
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) return candidate.trim();
+  }
+  return undefined;
+}
+
+function requiredRemoteSetting(candidates: ReadonlyArray<string | undefined>, envName: string, field: string): string {
+  const value = firstConfigured(candidates);
+  if (value !== undefined) return value;
+  throw new Error(
+    `Remote daemon ${field} is not configured. Set settings.daemon.remote.${field} in harness/harness.yaml, ` +
+    `daemon.remote.${field} in .harness/user-settings.json, or export ${envName}.`
+  );
+}

--- a/packages/cli/test/daemon-remote-config-settings.test.ts
+++ b/packages/cli/test/daemon-remote-config-settings.test.ts
@@ -1,0 +1,205 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os, { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { readDaemonClientConfig, remoteDaemonSshArgs } from "../src/daemon/client.ts";
+
+test("a configured checkout resolves the whole remote connection without any environment", () => {
+  withTempRoot((rootDir) => {
+    writeSharedConfig(rootDir);
+
+    const config = readDaemonClientConfig(cleanDaemonEnv({ HOME: path.join(rootDir, "home") }), rootDir);
+
+    assert.equal(config.mode, "remote");
+    assert.deepEqual(config.remote, {
+      host: "kty-harness",
+      remoteHaPath: "/opt/harness/bin/ha",
+      remoteRoot: "/srv/harness-repos/kty-harness",
+      repoId: "kty-harness"
+    });
+    assert.deepEqual(
+      config.remote ? [...remoteDaemonSshArgs(config.remote)] : [],
+      ["kty-harness", "/opt/harness/bin/ha", "daemon", "connect", "--stdio"]
+    );
+  });
+});
+
+test("personal ssh aliases differ per operator while the shared ledger coordinates stay identical", () => {
+  withTempRoot((firstRoot) => {
+    withTempRoot((secondRoot) => {
+      writeSharedConfig(firstRoot);
+      writeSharedConfig(secondRoot);
+      writeUserSettings(firstRoot, { schema: "user-settings/v1", daemon: { remote: { host: "kty-lan" } } });
+      writeUserSettings(secondRoot, { schema: "user-settings/v1", daemon: { remote: { host: "kty-via-jump" } } });
+
+      const first = readDaemonClientConfig(cleanDaemonEnv({ HOME: path.join(firstRoot, "home") }), firstRoot);
+      const second = readDaemonClientConfig(cleanDaemonEnv({ HOME: path.join(secondRoot, "home") }), secondRoot);
+
+      assert.equal(first.remote?.host, "kty-lan");
+      assert.equal(second.remote?.host, "kty-via-jump");
+      assert.equal(first.remote?.remoteRoot, second.remote?.remoteRoot);
+      assert.equal(first.remote?.repoId, second.remote?.repoId);
+    });
+  });
+});
+
+test("remote settings resolve environment over personal settings over the shared project file", () => {
+  withTempRoot((rootDir) => {
+    writeSharedConfig(rootDir);
+    const env = cleanDaemonEnv({ HOME: path.join(rootDir, "home") });
+
+    assert.equal(readDaemonClientConfig(env, rootDir).remote?.host, "kty-harness");
+
+    writeUserSettings(rootDir, {
+      schema: "user-settings/v1",
+      daemon: { remote: { host: "kty-personal", repoId: "kty-scratch" } }
+    });
+    const personal = readDaemonClientConfig(env, rootDir);
+    assert.equal(personal.remote?.host, "kty-personal");
+    assert.equal(personal.remote?.repoId, "kty-scratch");
+    assert.equal(personal.remote?.remoteRoot, "/srv/harness-repos/kty-harness");
+
+    const overridden = readDaemonClientConfig({ ...env, HARNESS_DAEMON_SSH_HOST: "kty-operations" }, rootDir);
+    assert.equal(overridden.remote?.host, "kty-operations");
+  });
+});
+
+test("personal settings predating the remote block keep working and stay optional", () => {
+  withTempRoot((rootDir) => {
+    writeSharedConfig(rootDir);
+    writeUserSettings(rootDir, { schema: "user-settings/v1", devMode: { customVerticals: true } });
+
+    const config = readDaemonClientConfig(cleanDaemonEnv({ HOME: path.join(rootDir, "home") }), rootDir);
+
+    assert.equal(config.remote?.host, "kty-harness");
+    assert.equal(config.remote?.repoId, "kty-harness");
+  });
+});
+
+test("an incomplete remote connection names every layer that can supply the missing value", () => {
+  withTempRoot((rootDir) => {
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  identity:",
+      "    mode: remote",
+      "  daemon:",
+      "    remote:",
+      "      root: /srv/harness-repos/kty-harness",
+      ""
+    ]);
+
+    assert.throws(
+      () => readDaemonClientConfig(cleanDaemonEnv({ HOME: path.join(rootDir, "home") }), rootDir),
+      /settings\.daemon\.remote\.host.*\.harness\/user-settings\.json.*HARNESS_DAEMON_SSH_HOST/su
+    );
+  });
+});
+
+test("malformed remote settings fail closed in both the shared file and personal settings", () => {
+  withTempRoot((rootDir) => {
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  identity:",
+      "    mode: remote",
+      "  daemon:",
+      "    remote:",
+      "      host: kty-harness",
+      "      root: harness-repos/kty-harness",
+      ""
+    ]);
+    const env = cleanDaemonEnv({ HOME: path.join(rootDir, "home") });
+    assert.throws(() => readDaemonClientConfig(env, rootDir), /must be an absolute path on the remote host/u);
+
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  identity:",
+      "    mode: remote",
+      "  daemon:",
+      "    remote:",
+      "      hostname: kty-harness",
+      ""
+    ]);
+    assert.throws(() => readDaemonClientConfig(env, rootDir), /Unknown settings\.daemon\.remote key: hostname/u);
+
+    writeSharedConfig(rootDir);
+    writeUserSettings(rootDir, { schema: "user-settings/v1", daemon: { remote: { host: "kty harness" } } });
+    assert.throws(() => readDaemonClientConfig(env, rootDir), /user-settings\.json daemon\.remote\.host/u);
+
+    writeUserSettings(rootDir, { schema: "user-settings/v1", daemon: { sshHost: "kty-harness" } });
+    assert.throws(() => readDaemonClientConfig(env, rootDir), /user-settings\.json daemon supports only remote/u);
+  });
+});
+
+test("the shared file keeps carrying userRoot alongside the remote block", () => {
+  withTempRoot((rootDir) => {
+    writeHarnessConfig(rootDir, [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  identity:",
+      "    mode: remote",
+      "  daemon:",
+      "    userRoot: state/daemon",
+      "    remote:",
+      "      host: kty-harness",
+      "      root: /srv/harness-repos/kty-harness",
+      ""
+    ]);
+
+    const config = readDaemonClientConfig(cleanDaemonEnv({ HOME: path.join(rootDir, "home") }), rootDir);
+
+    assert.equal(config.userRoot, path.resolve(rootDir, "state/daemon"));
+    assert.equal(config.remote?.host, "kty-harness");
+    assert.equal(config.remote?.repoId, "canonical");
+    assert.equal(config.remote?.remoteHaPath, "ha");
+  });
+});
+
+function withTempRoot(run: (rootDir: string) => void): void {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-daemon-remote-"));
+  try {
+    run(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function writeSharedConfig(rootDir: string): void {
+  writeHarnessConfig(rootDir, [
+    "schema: harness-anything/v1",
+    "settings:",
+    "  identity:",
+    "    mode: remote",
+    "  daemon:",
+    "    remote:",
+    "      host: kty-harness",
+    "      root: /srv/harness-repos/kty-harness",
+    "      repoId: kty-harness",
+    "      haPath: /opt/harness/bin/ha",
+    ""
+  ]);
+}
+
+function writeHarnessConfig(rootDir: string, lines: ReadonlyArray<string>): void {
+  const harnessDir = path.join(rootDir, "harness");
+  mkdirSync(harnessDir, { recursive: true });
+  writeFileSync(path.join(harnessDir, "harness.yaml"), lines.join("\n"), "utf8");
+}
+
+function writeUserSettings(rootDir: string, value: Record<string, unknown>): void {
+  const filePath = path.join(rootDir, ".harness/user-settings.json");
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(value, null, 2), "utf8");
+}
+
+function cleanDaemonEnv(overrides: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    HOME: os.homedir(),
+    ...overrides
+  };
+}

--- a/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
+++ b/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
@@ -10,7 +10,7 @@
     "packages/cli/src/commands/core/task-lifecycle.ts": "ca002e96498531aef065647cabe7ed6279caa54e",
     "packages/cli/src/commands/daemon/productization.ts": "97eba53a9fb0b7b4baac466f0a4b0e27e1fdac8f",
     "packages/cli/src/commands/preset-task.ts": "e425389b163993d17ce37c11c60ab088e2d46258",
-    "packages/cli/src/commands/settings.ts": "6c26e1c986826d25ead64266ef2d893b87617b40",
+    "packages/cli/src/commands/settings.ts": "dcc83b0f0775494d4f6d7326aaa7285d5f67b619",
     "packages/cli/src/composition/adapter-registry.ts": "8c0be49785f847e0e26e8f0c1a5e661f5c5d17df"
   },
   "adapterE2E": {


### PR DESCRIPTION
# English

## Summary

A checkout configured for a remote ledger still needed four exported environment variables before any
command reached that ledger, so "configured" and "usable" were two different states and every operator
had to remember the exports. This splits the remote connection across the layers that actually own each
half — the shared project file carries what the whole team points at, personal settings carry what
differs per machine — so a configured checkout works with no environment at all.

## What Changed

- `harness/harness.yaml` accepts `settings.daemon.remote` (`host`, `root`, `repoId`, `haPath`) beside the
  existing `userRoot`. This is the shared half: one remote root and repo id for everyone, plus the ssh
  alias the project publishes as its default.
- `.harness/user-settings.json` (gitignored) accepts `daemon.remote`. This is the personal half: an
  operator whose `~/.ssh/config` alias differs overrides just that, without touching the shared file, so
  several people share one remote ledger repository without colliding.
- Resolution order is environment, then personal, then shared. The environment stays an operational
  override rather than the daily path, and an incomplete connection now names all three sources instead
  of only the environment variable.
- Both layers fail closed on unknown keys, a non-absolute remote root, or a host that is not a plausible
  ssh destination — a typo that silently fell back to a default would aim writes at the wrong ledger.
- `settings.ts` and `daemon/client.ts` crossed the 600-line ceiling, so the settings document parser and
  the remote resolver move into `settings-document.ts` and `daemon/remote-config.ts`.
- Refreshed the batch5a blob id for `settings.ts`. The behavioural half of that golden is unchanged,
  which is the evidence this edit is behaviour-preserving for the probed surface.

## Task And Scope

- Harness task: `task_01KY51PRDBHJ81QSVRA08V4CVB`
- Branch: `feat/remote-config-yaml`
- Public scope: CLI settings and daemon client configuration resolution
- Private planning/evidence updated: yes
- Out of scope: GUI remote transport (landed separately in #1001); credential storage of any kind — this
  carries ssh host aliases only, never keys or passphrases

## Version Impact

- Version: no version change because this is an additive configuration surface on an unreleased CLI
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KY51PRDBHJ81QSVRA08V4CVB`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is
  true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `851ab3ae97a84317571a76dce50a784dd2a603b9`
- Branch merge-base with `origin/main`: `851ab3ae97a84317571a76dce50a784dd2a603b9`
- Last `git fetch origin` time: 2026-07-22, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff 851ab3ae...feat/remote-config-yaml`
- Private evidence commit/path: `harness/tasks/task_01KY51PRDBHJ81QSVRA08V4CVB-harness-yaml/`
- Reviewer evidence path: `packages/cli/test/daemon-remote-config-settings.test.ts`
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `npm run typecheck`
- [x] `node tools/run-node-tests.mjs --tier fast --prefix=packages/cli/test/` — 353 tests, 353 pass, 0 fail
- [x] `node tools/check-file-complexity.mjs`
- [x] `node tools/check-duplicate-definitions.mjs`
- [x] `node tools/check-write-road-registry.mjs`
- [x] `npx eslint` on every changed file
- [x] Live use proof: in a directory containing only `harness/harness.yaml` and
      `.harness/user-settings.json`, with no connection environment set, `ha task list --json` returned
      the six KTY remote tasks. A deliberately wrong personal alias changed the failure message to name
      that alias, proving the personal layer is consulted end to end and not merely unit-tested.
- Not run: the full gate matrix — that is CI's job.

## Review Evidence

- Self-review: yes
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- The remote root is validated as an absolute path but not proven to exist; a wrong-but-absolute path
  still fails at connect time rather than at config time.
- Personal settings may override `root` and `repoId`, not only `host`. That is deliberate — it lets an
  operator point at a scratch remote root — but it also means a stale personal file can silently
  redirect an otherwise correct shared configuration.

## References

- Task: `task_01KY51PRDBHJ81QSVRA08V4CVB`
- Evidence: `harness/context/development/remote-harness-connection.md` section 5
- Review: pending

---

# 中文

## 概要

一个已经配好远程台账的仓库，此前仍然要先 export 四个环境变量，命令才真的走到远程——也就是说"配好了"
和"能用"是两个状态，每个人都得记住那几行 export。本 PR 按"这个值到底归谁"把远程连接参数拆到相应的层：
共享的项目文件放全队共同指向的东西，个人文件放每台机器不一样的东西。配好之后，不设任何环境变量即可直接用。

## 改动内容

- `harness/harness.yaml` 新增 `settings.daemon.remote`（`host` / `root` / `repoId` / `haPath`），与既有
  `userRoot` 并列。这是共享的一半：全队同一个远程根与 repoId，外加项目公布的默认 ssh 别名。
- `.harness/user-settings.json`（gitignored）新增 `daemon.remote`。这是个人的一半：`~/.ssh/config` 里别名
  不同的人只覆盖这一项，不动共享文件——于是多人共用同一个远程台账仓时互不冲突。
- 优先级为 环境变量 > 个人配置 > 共享配置。环境变量退回它本来的位置（运维临时覆盖），不再是日常接入方式；
  连接参数缺失时报错会同时点名三个来源，而不是只提环境变量。
- 两层都对未知键、非绝对路径的远程根、不像 ssh 目标的 host 直接拒收：一个静默退回默认值的笔误，
  会把写入打到错误的台账上。
- `settings.ts` 与 `daemon/client.ts` 双双越过 600 行上限，因此把设置文档解析与远程解析分别拆到
  `settings-document.ts` 与 `daemon/remote-config.ts`。
- 刷新了 `settings.ts` 在 batch5a 的 blob id。该 golden 的行为断言部分未变，这正是本次改动对被探测面
  行为保持不变的证据。

## 任务与范围

- Harness 任务：`task_01KY51PRDBHJ81QSVRA08V4CVB`
- 分支：`feat/remote-config-yaml`
- 公共范围：CLI 设置与 daemon 客户端的配置解析
- 私有计划/证据已更新：是
- 不在范围内：GUI 远程传输（已在 #1001 单独落地）；任何形式的凭证存放——本改动只承载 ssh host 别名，
  绝不承载密钥或口令

## 版本影响

- 版本：不变，这是未发布 CLI 上的增量配置面
- 发布影响：不发布

## 治理声明

- 是否触及受保护面：否
- 受保护面范围：不适用
- 授权：`task_01KY51PRDBHJ81QSVRA08V4CVB`
- 机器检查边界：本 PR 仅断言声明存在；是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`851ab3ae97a84317571a76dce50a784dd2a603b9`
- 与 `origin/main` 的 merge-base：`851ab3ae97a84317571a76dce50a784dd2a603b9`
- 最近一次 `git fetch origin`：2026-07-22，开 PR 前
- 同步方式：无需同步
- 公共 diff 命令：`git diff 851ab3ae...feat/remote-config-yaml`
- 私有证据路径：`harness/tasks/task_01KY51PRDBHJ81QSVRA08V4CVB-harness-yaml/`
- 评审证据路径：`packages/cli/test/daemon-remote-config-settings.test.ts`
- GitHub Actions `rewrite-ci` 运行链接：本 PR 上待跑
- [x] `npm run typecheck`
- [x] `node tools/run-node-tests.mjs --tier fast --prefix=packages/cli/test/` —— 353 项，353 通过，0 失败
- [x] `node tools/check-file-complexity.mjs`
- [x] `node tools/check-duplicate-definitions.mjs`
- [x] `node tools/check-write-road-registry.mjs`
- [x] 对全部改动文件跑 `npx eslint`
- [x] 使用证明：在一个只有 `harness/harness.yaml` 与 `.harness/user-settings.json`、不设任何连接环境变量的
      目录里，`ha task list --json` 取回了 KTY 远程的 6 条任务。把个人别名故意写错后，报错消息随之改为
      点名那个错别名——证明个人层是端到端真的被读取，而不只是单测里成立。
- 未运行：完整门矩阵——那是 CI 的活。

## 审查证据

- 自审：是
- 评审子代理：无
- 人工评审：待进行
- 阻塞发现：无

## 残余风险

- 远程根只校验了"是绝对路径"，没有校验它存在；一个绝对但写错的路径仍然要到连接时才失败，而不是配置时。
- 个人配置可以覆盖 `root` 与 `repoId`，不只是 `host`。这是刻意的（便于指向一个临时的远程根），
  但也意味着一份过期的个人文件能悄悄把本来正确的共享配置改道。

## 关联材料

- 任务：`task_01KY51PRDBHJ81QSVRA08V4CVB`
- 证据：`harness/context/development/remote-harness-connection.md` 第 5 节
- 评审：待进行
