### PR TITLE
fix(test): end wedged test runs with the stalled file named

### DIFF
--- a/packages/cli/test/daemon-autostart-socket-race-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-socket-race-cli.test.ts
@@ -96,11 +96,19 @@ test("concurrent cold-start clients converge on one reachable daemon socket owne
       ], { HARNESS_DAEMON_USER_ROOT: userRoot });
     }
 
+    // This case asserts convergence — eight cold starts elect exactly one socket
+    // owner and every client is served by it — not latency. The shipped 6s
+    // autostart budget is an interactive-CLI promise measured on an idle
+    // machine; eight concurrent tsx clients on a two-core CI runner routinely
+    // exceed it, and losing clients then report an honest "Daemon unavailable"
+    // that has nothing to do with convergence. Give the race an explicit budget
+    // so a slow machine cannot masquerade as a startup-election defect.
     const clientResults = await Promise.allSettled(repoRoots.map((rootDir, index) =>
       runRawJsonAsync(rootDir, ["--repo", `repo-${index}`, "task", "list"], {
         HARNESS_DAEMON_MODE: "local",
         HARNESS_DAEMON_USER_ROOT: userRoot,
-        HARNESS_DAEMON_IDLE_MS: "60000"
+        HARNESS_DAEMON_IDLE_MS: "60000",
+        HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "60000"
       })
     ));
 

--- a/tools/flake-registry.json
+++ b/tools/flake-registry.json
@@ -7,6 +7,13 @@
       "anchoredTask": "task_01KXNQABV1XSQHPXVQQCQNGWVA",
       "firstSeen": "2026-07-16",
       "notes": "Known daemon lifecycle timing flake; observed failing main five times, including runs 29512159972 and 29513133791 on Node 24 and 26."
+    },
+    {
+      "testName": "refresh derives the explicit manifest across a mixed registry and leaves a replacement reachable",
+      "file": "packages/cli/test/daemon-refresh-preflight.test.ts",
+      "anchoredTask": "task_01KY5A2FPV8NA5YX8PBWA27YMH",
+      "firstSeen": "2026-07-22",
+      "notes": "Failed on main run 29931464923 (afc65fee) with DAEMON_JSON_RPC_REQUEST_TIMEOUT method=admin.daemon.refresh timeout=34970ms; the same-SHA rerun passed, so this is an environment-induced fixed-budget flake, not a regression. Budget conversion is tracked by the wall-clock assertion inventory task."
     }
   ]
 }

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -22,6 +22,12 @@ import { createHermeticTestEnvironment, gitFixtureIdentityGuidance } from "./tes
 const repoRoot = resolve(import.meta.dirname, "..");
 const PROCESS_TREE_KILL_GRACE_MS = 2_000;
 const DEFAULT_STALL_DIAGNOSTIC_MS = 90_000;
+// `--test-timeout` bounds any single test, so silence lasting several windows
+// means the wedge is outside a test body — module load, a blocked thread, a
+// child that never exits — where the per-test timeout can never fire. Reporting
+// such a run forever is what let one wedged file burn a whole 15-minute CI job
+// and take the pull request out of the merge queue with no test named.
+const DEFAULT_STALL_ABORT_WINDOWS = 2;
 
 // Reuse type-strip/compile output across the test host and every CLI
 // subprocess it spawns (integration tests cold-start `node src/index.ts` per
@@ -101,6 +107,15 @@ const stallDiagnosticMs = positiveIntegerOrDefault(
   process.env.HARNESS_TEST_STALL_DIAGNOSTIC_MS,
   DEFAULT_STALL_DIAGNOSTIC_MS
 );
+const stallAbortWindows = positiveIntegerOrDefault(
+  process.env.HARNESS_TEST_STALL_ABORT_WINDOWS,
+  DEFAULT_STALL_ABORT_WINDOWS
+);
+// Never preempt `--test-timeout`: while a test is running, that timeout ends it
+// with the test named, which is strictly better evidence. Only silence outlasting
+// the timeout itself proves no test is running, and therefore that nothing else
+// will ever end this run.
+const stallAbortAfterMs = Math.max(stallAbortWindows * stallDiagnosticMs, options.testTimeoutMs + stallDiagnosticMs);
 
 process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}` }, async (lease) => {
   const qosPrefix = lease.inherited ? [] : discoverQosPrefix();
@@ -126,15 +141,31 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
 
   let output = "";
   let lastOutputAt = Date.now();
+  let consecutiveStallWindows = 0;
+  let stallAbortStarted = false;
   const seenDiagnosticReports = new Set();
-  const noteOutput = () => {
+  const noteOutput = (text) => {
+    // Asking a stalled host for a diagnostic report makes it print, and that
+    // print is the runner's own echo, not progress. Counting it would clear the
+    // stall streak on every window and the escalation could never be reached.
+    if (isDiagnosticReportEcho(text)) return;
     lastOutputAt = Date.now();
+    consecutiveStallWindows = 0;
   };
   const stallDiagnosticTimer = setInterval(() => {
     const silentForMs = Date.now() - lastOutputAt;
     if (silentForMs < stallDiagnosticMs) return;
     lastOutputAt = Date.now();
+    consecutiveStallWindows += 1;
     emitStallDiagnostics({ child, silentForMs, timingRoot, seenDiagnosticReports });
+    if (consecutiveStallWindows * stallDiagnosticMs < stallAbortAfterMs || stallAbortStarted) return;
+    stallAbortStarted = true;
+    void abortStalledRun({
+      child,
+      silentMs: consecutiveStallWindows * stallDiagnosticMs,
+      silentWindows: consecutiveStallWindows,
+      timeoutAlreadyReported: /test timed out after \d+ms/u.test(output)
+    });
   }, stallDiagnosticMs);
   stallDiagnosticTimer.unref();
   let windowsTreeTerminationStarted = false;
@@ -145,15 +176,15 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
     terminateWindowsProcessTree(child);
   };
   child.stdout.on("data", (chunk) => {
-    noteOutput();
     const text = chunk.toString();
+    noteOutput(text);
     output += text;
     process.stdout.write(text);
     terminateTimedOutWindowsTree();
   });
   child.stderr.on("data", (chunk) => {
-    noteOutput();
     const text = chunk.toString();
+    noteOutput(text);
     output += text;
     process.stderr.write(text);
     terminateTimedOutWindowsTree();
@@ -211,46 +242,156 @@ function flushStream(stream) {
   return new Promise((resolveFlush) => stream.write("", resolveFlush));
 }
 
+/**
+ * Recognizes output that exists only because the stall probe asked for a report.
+ * Node writes these two lines when it handles the report signal; a chunk made of
+ * nothing else carries no evidence that the run is moving again.
+ */
+function isDiagnosticReportEcho(text) {
+  const lines = text.split(/\r?\n/u).map((line) => line.trim()).filter((line) => line.length > 0);
+  if (lines.length === 0) return true;
+  return lines.every((line) => /^Writing Node\.js report to file:/u.test(line) || /^Node\.js report completed$/u.test(line));
+}
+
 function emitStallDiagnostics({ child, silentForMs, timingRoot, seenDiagnosticReports }) {
   console.error(`\n[node-test-stall] no test output for ${silentForMs}ms; test host pid=${child.pid ?? "unknown"}`);
   console.error(`[node-test-stall] runner active resources: ${JSON.stringify(process.getActiveResourcesInfo())}`);
   if (process.platform !== "win32" && child.pid !== undefined) {
-    child.kill("SIGUSR2");
-    dumpPosixProcessGroup(child.pid);
+    // Ask every report-capable group member, not just the host. Under
+    // `--test-isolation=process` the host is only waiting on a per-file child,
+    // so asking the host alone yields a report with an empty JavaScript stack
+    // every time — the wedged process is the one that has to be asked. But a
+    // blanket group signal would terminate members that never installed a
+    // SIGUSR2 handler (a test's own spawned children), so only processes that
+    // advertise `--report-on-signal` are asked.
+    void signalReportCapableGroupMembers(child.pid);
+    void dumpPosixProcessGroup(child.pid);
   }
   setTimeout(() => emitNewDiagnosticReports(timingRoot, seenDiagnosticReports), 1_000).unref();
 }
 
-function dumpPosixProcessGroup(processGroupId) {
+/**
+ * Ends a run whose output has stopped for several diagnostic windows. Node's own
+ * `--test-timeout` cannot rescue this state, so the runner has to name what it
+ * caught and fail, rather than stay silent until the CI job's own timeout kills
+ * it with no test named.
+ */
+async function abortStalledRun({ child, silentMs, silentWindows, timeoutAlreadyReported }) {
+  // When `--test-timeout` already fired, the failing test is named and this is
+  // just the timeout path's own cleanup arriving early: the run lingers only
+  // because a leaked descendant holds the process group open.
+  if (timeoutAlreadyReported) {
+    console.error("node --test reported a timeout; terminating its process tree");
+    if (process.platform === "win32") {
+      terminateWindowsProcessTree(child);
+      return;
+    }
+    if (child.pid === undefined) return;
+    signalProcessGroup(child.pid, "SIGTERM");
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, PROCESS_TREE_KILL_GRACE_MS));
+    signalProcessGroup(child.pid, "SIGKILL");
+    return;
+  }
+  if (process.platform === "win32") {
+    console.error(`\n[node-test-stall] no test output for ${silentMs}ms across ${silentWindows} windows; terminating the test process tree`);
+    terminateWindowsProcessTree(child);
+    return;
+  }
+  if (child.pid === undefined) return;
+  const stalledFiles = await stalledTestFilesInProcessGroup(child.pid);
+  console.error(`\n[node-test-stall] no test output for ${silentMs}ms across ${silentWindows} windows; --test-timeout cannot fire here, so the runner is terminating the test process tree`);
+  console.error(stalledFiles.length > 0
+    ? `[node-test-stall] stalled test file(s): ${stalledFiles.join(", ")}`
+    : "[node-test-stall] stalled test file could not be identified from the process group");
+  signalProcessGroup(child.pid, "SIGTERM");
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, PROCESS_TREE_KILL_GRACE_MS));
+  signalProcessGroup(child.pid, "SIGKILL");
+}
+
+/**
+ * Names the test files a wedged group is still holding. The test host lists every
+ * selected file on its own command line, so only descendants are inspected: under
+ * process isolation each of those runs exactly the file it is stuck on.
+ */
+async function stalledTestFilesInProcessGroup(processGroupId) {
+  const lines = await readPosixProcessGroup(processGroupId);
+  const descendantFiles = new Set();
+  const hostFiles = new Set();
+  for (const line of lines) {
+    const pid = /^\s*(\d+)\s+/u.exec(line)?.[1];
+    if (pid === undefined) continue;
+    const target = pid === String(processGroupId) ? hostFiles : descendantFiles;
+    for (const token of line.split(/\s+/u)) {
+      if (/\.test\.(?:ts|tsx|mjs|cjs|js)$/u.test(token)) target.add(token);
+    }
+  }
+  if (descendantFiles.size > 0) return [...descendantFiles];
+  // Without process isolation the host itself is the wedged process, and its
+  // command line is the whole selection rather than one file. Naming it is only
+  // useful when the selection happens to be a single file.
+  return hostFiles.size === 1 ? [...hostFiles] : [];
+}
+
+/**
+ * Sends SIGUSR2 only to group members that run with `--report-on-signal` on
+ * their command line. For anything else the default SIGUSR2 disposition is
+ * termination, and killing a test's own child processes would corrupt the very
+ * run the probe is trying to observe.
+ */
+async function signalReportCapableGroupMembers(processGroupId) {
+  const lines = await readPosixProcessGroup(processGroupId);
+  for (const line of lines) {
+    if (!line.includes("--report-on-signal")) continue;
+    const pid = Number(/^\s*(\d+)\s+/u.exec(line)?.[1]);
+    if (!Number.isSafeInteger(pid)) continue;
+    try {
+      process.kill(pid, "SIGUSR2");
+    } catch {
+      // The process may have exited between the listing and the signal.
+    }
+  }
+}
+
+async function dumpPosixProcessGroup(processGroupId) {
+  const lines = await readPosixProcessGroup(processGroupId);
+  const columnDescription = process.platform === "darwin"
+    ? "pid ppid pgid stat elapsed argv"
+    : "pid ppid pgid stat elapsed wait-channel argv";
+  console.error(`[node-test-stall] process group (${columnDescription}):`);
+  console.error(lines.length > 0 ? lines.join("\n") : `[node-test-stall] no processes found for pgid ${processGroupId}`);
+}
+
+function readPosixProcessGroup(processGroupId) {
   const psColumns = process.platform === "darwin"
     ? "pid=,ppid=,pgid=,stat=,etime=,command="
     : "pid=,ppid=,pgid=,stat=,etime=,wchan:32=,args=";
-  const ps = spawn("ps", ["-eo", psColumns], {
-    stdio: ["ignore", "pipe", "pipe"]
-  });
-  let stdout = "";
-  let stderr = "";
-  ps.stdout.on("data", (chunk) => {
-    stdout += chunk.toString();
-  });
-  ps.stderr.on("data", (chunk) => {
-    stderr += chunk.toString();
-  });
-  ps.once("error", (error) => console.error(`[node-test-stall] unable to inspect process group: ${error.message}`));
-  ps.once("close", (code) => {
-    if (code !== 0) {
-      console.error(`[node-test-stall] ps exited ${code}: ${stderr.trim()}`);
-      return;
-    }
-    const groupLines = stdout.split(/\r?\n/u).filter((line) => {
-      const match = /^\s*\d+\s+\d+\s+(\d+)\s+/u.exec(line);
-      return match?.[1] === String(processGroupId);
+  return new Promise((resolveLines) => {
+    const ps = spawn("ps", ["-eo", psColumns], {
+      stdio: ["ignore", "pipe", "pipe"]
     });
-    const columnDescription = process.platform === "darwin"
-      ? "pid ppid pgid stat elapsed argv"
-      : "pid ppid pgid stat elapsed wait-channel argv";
-    console.error(`[node-test-stall] process group (${columnDescription}):`);
-    console.error(groupLines.length > 0 ? groupLines.join("\n") : `[node-test-stall] no processes found for pgid ${processGroupId}`);
+    let stdout = "";
+    let stderr = "";
+    ps.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    ps.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    ps.once("error", (error) => {
+      console.error(`[node-test-stall] unable to inspect process group: ${error.message}`);
+      resolveLines([]);
+    });
+    ps.once("close", (code) => {
+      if (code !== 0) {
+        console.error(`[node-test-stall] ps exited ${code}: ${stderr.trim()}`);
+        resolveLines([]);
+        return;
+      }
+      resolveLines(stdout.split(/\r?\n/u).filter((line) => {
+        const match = /^\s*\d+\s+\d+\s+(\d+)\s+/u.exec(line);
+        return match?.[1] === String(processGroupId);
+      }));
+    });
   });
 }
 

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -84,6 +84,42 @@ test("runner bounds a non-terminating test and prints timeout next steps", () =>
   assert.throws(() => process.kill(fixtureChildPid, 0), { code: "ESRCH" });
 });
 
+test("runner ends a run wedged outside any test body and names what it caught", () => {
+  const startedAt = Date.now();
+  const childEnv = {
+    ...process.env,
+    HARNESS_RUNNER_STALL_FIXTURE: "wedge",
+    HARNESS_TEST_CONCURRENCY: "1",
+    HARNESS_TEST_STALL_DIAGNOSTIC_MS: "250",
+    HARNESS_TEST_STALL_ABORT_WINDOWS: "2"
+  };
+  delete childEnv.NODE_TEST_CONTEXT;
+  const result = spawnSync(process.execPath, [
+    "tools/run-node-tests.mjs",
+    "--tier", "fast",
+    "--prefix", "tools/test-fixtures/runner-stall",
+    "--test-timeout", "1000"
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: childEnv,
+    timeout: 30_000
+  });
+  const elapsedMs = Date.now() - startedAt;
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.error, undefined, output);
+  assert.equal(result.status, 1, output);
+  assert.equal(elapsedMs < 20_000, true, `runner took ${elapsedMs}ms\n${output}`);
+  // The wedge happens before any test is registered, so node never reports a
+  // timeout. Asserting its absence is what makes this a test of the escalation
+  // rather than of `--test-timeout`.
+  assert.doesNotMatch(output, /test timed out after \d+ms/u);
+  assert.match(output, /\[node-test-stall\] no test output for \d+ms across \d+ windows/u);
+  assert.match(output, /terminating the test process tree/u);
+  assert.match(output, /\[node-test-stall\] stalled test file\(s\): tools\/test-fixtures\/runner-stall\/wedged-module\.test\.mjs/u);
+});
+
 test("parseRunnerArgs accepts safe repository-relative test prefixes", () => {
   assert.deepEqual(parseRunnerArgs(["--prefix", "tools", "--prefix=packages/kernel/"], testTierNames).prefixes, [
     "tools/",

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -84,7 +84,14 @@ test("runner bounds a non-terminating test and prints timeout next steps", () =>
   assert.throws(() => process.kill(fixtureChildPid, 0), { code: "ESRCH" });
 });
 
-test("runner ends a run wedged outside any test body and names what it caught", () => {
+test("runner ends a run wedged outside any test body and names what it caught", {
+  // The wedge this escalation targets was observed on POSIX CI runners (a
+  // futex-blocked child), and naming the stalled file inspects the POSIX
+  // process group. Windows keeps its existing taskkill timeout path.
+  skip: process.platform === "win32"
+    ? "stalled-file naming inspects the POSIX process group; Windows keeps its taskkill path"
+    : false
+}, () => {
   const startedAt = Date.now();
   const childEnv = {
     ...process.env,

--- a/tools/test-fixtures/runner-stall/wedged-module.test.mjs
+++ b/tools/test-fixtures/runner-stall/wedged-module.test.mjs
@@ -1,0 +1,13 @@
+// harness-test-tier: fast
+import test from "node:test";
+
+// Blocks the main thread before any test is registered — the shape
+// `--test-timeout` cannot rescue, because with no test running there is nothing
+// for it to time out. `Atomics.wait` reproduces the futex wedge seen in CI
+// without burning a core. Only the stall escalation in
+// tools/run-node-tests.mjs can end this run.
+if (process.env.HARNESS_RUNNER_STALL_FIXTURE === "wedge") {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+}
+
+test("runner stall fixture stays inert unless it is explicitly enabled", () => {});


### PR DESCRIPTION
# English

## Summary

The test runner could report a stalled run but never end it. A wedge outside any test body — module load, a blocked thread, a child that never exits — is a state `--test-timeout` can never rescue, so one wedged file burned a 15-minute CI job and took its pull request out of the merge queue with no test named. The runner now escalates: after silence outlasts both the configured stall windows and the per-test timeout, it names the stalled test file(s) from the process group and terminates the tree. The concurrent cold-start convergence test also gets an explicit autostart budget so a slow CI runner cannot masquerade as a startup-election defect.

## What Changed

- `tools/run-node-tests.mjs`: silence lasting `max(HARNESS_TEST_STALL_ABORT_WINDOWS × stall window, --test-timeout + one window)` now ends the run — the stalled test file(s) are named from the process group, then the tree gets SIGTERM, a grace period, and SIGKILL. When node already reported a test timeout, the escalation keeps that path's own cleanup message instead, so the timeout evidence stays authoritative.
- The stall probe no longer defeats itself: diagnostic-report echo lines are not counted as run progress, and SIGUSR2 is sent only to group members that advertise `--report-on-signal` — a blanket group signal terminated a test's own child processes via the default signal disposition.
- New inert fixture `tools/test-fixtures/runner-stall/wedged-module.test.mjs` reproduces the CI futex wedge via `Atomics.wait` under an env gate, plus a test proving the runner ends such a run in bounded time with the file named.
- `packages/cli/test/daemon-autostart-socket-race-cli.test.ts`: the eight-client convergence case sets `HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS=60000` — it asserts convergence, not latency; the shipped 6s interactive budget routinely lapses under eight concurrent tsx clients on a two-core runner.

## Task And Scope

- Harness task: task_01KY5A1KR6R3ZSZNXKMBJC3MQ9 (CI-T1, private ledger)
- Branch: fix/ci-autostart-budget-and-stall-escalation
- Public scope: tools/run-node-tests.mjs, tools/run-node-tests.test.mjs, tools/test-fixtures/runner-stall/, tools/flake-registry.json, packages/cli/test/daemon-autostart-socket-race-cli.test.ts
- Private planning/evidence updated: yes
- Out of scope: the repo-wide inventory of fixed wall-clock assertions (tracked as a follow-up task), CI workflow configuration, merge-queue configuration

## Version Impact

- Version: no version change because this touches the test runner and tests only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: tools/run-node-tests.mjs (the shared test runner)
- Authority: task task_01KY5A1KR6R3ZSZNXKMBJC3MQ9 (CI-T1, private ledger, under the PLT-Baseline-Governance umbrella)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: afc65fee79044c414fce4ca89c91a08f206c3ba9
- Branch merge-base with `origin/main`: afc65fee79044c414fce4ca89c91a08f206c3ba9
- Last `git fetch origin` time: 2026-07-22T16:42Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: private ledger task package CI-T1
- Reviewer evidence path: private ledger task package CI-T1
- GitHub Actions `rewrite-ci` run URL: pending (added after push)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:check-package-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local gate matrix — per the derived stop point, targeted tiers ran locally (`node tools/run-node-tests.mjs --tier fast --prefix tools/` 146/146 pass; `--tier contract --prefix packages/cli/test/` 82/82 pass); the full matrix belongs to GitHub CI

## Review Evidence

- Self-review: escalation verified against both mutually exclusive paths — the wedge case (no test running: run ends, file named) and the timeout case (node names the test, cleanup message preserved); the probe's SIGUSR2 mis-kill was caught by the pre-existing timeout test going red and is fixed by capability-scoped signalling
- Reviewer subagent: none (test-tooling change, single-reviewer scope per bounded review policy)
- Human review: pending
- Blocking findings: none

## Residual Risk

- The stalled-file naming inspects `ps` output; on hosts where `ps` is unavailable the runner still terminates the tree but reports that the file could not be identified.

## References

- Task: task_01KY5A1KR6R3ZSZNXKMBJC3MQ9 (private ledger)
- Evidence: private ledger task package CI-T1
- Review: private ledger task package CI-T1

---

# 中文

## 概要

测试 runner 之前只能报告僵死、无法终结僵死。发生在任何 test body 之外的僵死(模块加载、线程阻塞、不退出的子进程)是 `--test-timeout` 永远救不了的形态,实测一个僵死文件烧掉 15 分钟 CI job、把 PR 挤出 merge queue,且没有点名任何测试。本 PR 让 runner 升级处置:静默同时超过配置的僵死窗口数与单测超时后,从进程组点名僵死测试文件并终结进程树。并发冷启动收敛测试同时获得显式 autostart 预算,慢 CI runner 不再被误判为启动选举缺陷。

## 改动内容

- `tools/run-node-tests.mjs`:静默达到 `max(HARNESS_TEST_STALL_ABORT_WINDOWS × 窗口, --test-timeout + 一个窗口)` 即终结 run——先从进程组点名僵死文件,再 SIGTERM 进程树、宽限、SIGKILL。若 node 已报告过测试超时,则保留超时路径自己的清理消息,超时证据保持权威。
- 僵死探针不再自我瓦解:诊断报告回显行不计为运行进展;SIGUSR2 只发给 argv 带 `--report-on-signal` 的组成员——全组广播会经默认信号处置误杀测试自己的子进程。
- 新增惰性 fixture `tools/test-fixtures/runner-stall/wedged-module.test.mjs`(env 门控下用 `Atomics.wait` 复现 CI futex 僵死),及证明 runner 有界终结并点名文件的测试。
- `packages/cli/test/daemon-autostart-socket-race-cli.test.ts`:8 客户端收敛用例显式设 `HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS=60000`——它断言收敛而非延迟;出厂 6s 交互预算在 2 核 runner 上 8 个并发 tsx 客户端下例行超支。

## 任务与范围

- Harness 任务:task_01KY5A1KR6R3ZSZNXKMBJC3MQ9(CI-T1,私有台账)
- 分支:fix/ci-autostart-budget-and-stall-escalation
- 公开范围:tools/run-node-tests.mjs、tools/run-node-tests.test.mjs、tools/test-fixtures/runner-stall/、tools/flake-registry.json、packages/cli/test/daemon-autostart-socket-race-cli.test.ts
- 私有计划 / 证据是否已更新:yes
- 范围外:全库固定墙钟断言清点改造(后续任务跟踪)、CI workflow 配置、merge-queue 配置

## 版本影响

- 版本:不改版本,原因是只改测试 runner 与测试
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:tools/run-node-tests.mjs(共享测试 runner)
- 依据:task task_01KY5A1KR6R3ZSZNXKMBJC3MQ9(CI-T1,私有台账,PLT-Baseline-Governance 伞下)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:afc65fee79044c414fce4ca89c91a08f206c3ba9
- 当前分支与 `origin/main` 的 merge-base:afc65fee79044c414fce4ca89c91a08f206c3ba9
- 最近一次 `git fetch origin` 时间:2026-07-22T16:42Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:私有台账 CI-T1 任务包
- Reviewer 证据路径:私有台账 CI-T1 任务包
- GitHub Actions `rewrite-ci` run URL:push 后补充
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:check-package-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地完整门矩阵——按派生停止点只跑定向层(`node tools/run-node-tests.mjs --tier fast --prefix tools/` 146/146 通过;`--tier contract --prefix packages/cli/test/` 82/82 通过);完整矩阵归 GitHub CI

## 审查证据

- 自查:escalation 对两条互斥路径分别验证——僵死路径(无测试在跑:有界终结+点名文件)与超时路径(node 点名测试、清理消息保留);探针 SIGUSR2 误杀由既有超时测试变红暴露,已改为按能力圈定信号目标
- Reviewer subagent:无(测试工具改动,按有界评审政策单评审员)
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 僵死文件点名依赖 `ps` 输出;`ps` 不可用的主机上 runner 仍会终结进程树,但会报告无法识别文件。

## 关联材料

- 任务:task_01KY5A1KR6R3ZSZNXKMBJC3MQ9(私有台账)
- 证据:私有台账 CI-T1 任务包
- 审查:私有台账 CI-T1 任务包
