### PR TITLE
fix(cli): resolve the ledger root from git worktrees

### DIFF
--- a/packages/cli/src/cli/command-spec/command-groups.ts
+++ b/packages/cli/src/cli/command-spec/command-groups.ts
@@ -7,6 +7,7 @@ export interface CommandGroupDefinition {
 }
 
 export const globalCommandOptions = [
+  { flag: "--root DIR", description: "Use DIR as the harness repository root." },
   { flag: "--json", description: "Emit machine-readable JSON." }
 ] as const satisfies ReadonlyArray<CommandOptionDefinition>;
 

--- a/packages/cli/src/cli/parse-args.ts
+++ b/packages/cli/src/cli/parse-args.ts
@@ -8,21 +8,28 @@ import type { CliResult, ParsedCommand } from "./types.ts";
 import { withDeprecatedInvocation } from "./command-deprecations.ts";
 
 export function parseArgs(argv: ReadonlyArray<string>): { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] } {
-  const { rootDir, authoredRoot, daemonRepoId, actor, daemonMode, daemonProfile, json, args: rawArgs } = stripGlobalOptions(argv);
+  const { rootDir, rootResolutionSource, authoredRoot, daemonRepoId, actor, daemonMode, daemonProfile, json, args: rawArgs } = stripGlobalOptions(argv);
   const jsonInput = applyJsonInputLayer(rawArgs, process.cwd());
   if (!jsonInput.ok) return { ok: false, error: jsonInput.error };
   const args = jsonInput.args;
   const layoutOverrides = authoredRoot ? { authoredRoot } : undefined;
 
   const help = parseHelpRequest(args, rootDir, json, layoutOverrides);
-  if (help) return attachDeprecation(attachDaemonOverrides(attachActor(attachDaemonRepoId(help, daemonRepoId), actor), daemonMode, daemonProfile), args);
+  if (help) return attachRootResolutionSource(attachDeprecation(attachDaemonOverrides(attachActor(attachDaemonRepoId(help, daemonRepoId), actor), daemonMode, daemonProfile), args), rootResolutionSource);
 
   const parsed = parseRegisteredCommand(args, rootDir, json, jsonInput.input);
-  if (parsed) return attachDeprecation(attachDaemonOverrides(attachActor(attachDaemonRepoId(attachLayoutOverrides(parsed, layoutOverrides), daemonRepoId), actor), daemonMode, daemonProfile), args);
+  if (parsed) return attachRootResolutionSource(attachDeprecation(attachDaemonOverrides(attachActor(attachDaemonRepoId(attachLayoutOverrides(parsed, layoutOverrides), daemonRepoId), actor), daemonMode, daemonProfile), args), rootResolutionSource);
   return {
     ok: false,
     error: cliError(CliErrorCode.UnknownCommand, unknownCommandHint(args))
   };
+}
+
+function attachRootResolutionSource(
+  parsed: { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] },
+  rootResolutionSource: NonNullable<ParsedCommand["rootResolutionSource"]>
+): typeof parsed {
+  return parsed.ok ? { ok: true, value: { ...parsed.value, rootResolutionSource } } : parsed;
 }
 
 function attachDeprecation(

--- a/packages/cli/src/cli/parse-options.ts
+++ b/packages/cli/src/cli/parse-options.ts
@@ -3,6 +3,7 @@ import type { CliResult } from "./types.ts";
 
 export interface GlobalParseOptions {
   readonly rootDir: string;
+  readonly rootResolutionSource: "explicit-override" | "local-cwd";
   readonly authoredRoot?: string;
   readonly daemonRepoId?: string;
   readonly actor?: string;
@@ -13,7 +14,9 @@ export interface GlobalParseOptions {
 }
 
 export function stripGlobalOptions(argv: ReadonlyArray<string>, cwd = process.cwd()): GlobalParseOptions {
-  const rootDir = readOption(argv, "--root") ?? cwd;
+  const explicitRoot = readOption(argv, "--root");
+  const rootDir = explicitRoot ?? cwd;
+  const rootResolutionSource = explicitRoot === undefined ? "local-cwd" : "explicit-override";
   const authoredRoot = readOption(argv, "--authored-root") ?? readNonEmptyProcessEnv("HARNESS_AUTHORED_ROOT");
   const daemonRepoId = readOption(argv, "--repo") ?? readNonEmptyProcessEnv("HARNESS_DAEMON_REPO_ID");
   const actor = readOption(argv, "--actor");
@@ -36,7 +39,7 @@ export function stripGlobalOptions(argv: ReadonlyArray<string>, cwd = process.cw
       && arg !== "--daemon-profile"
       && previous !== "--daemon-profile";
   });
-  return { rootDir, authoredRoot, daemonRepoId, actor, daemonMode, daemonProfile, json, args };
+  return { rootDir, rootResolutionSource, authoredRoot, daemonRepoId, actor, daemonMode, daemonProfile, json, args };
 }
 
 function readDaemonMode(value: string | undefined): GlobalParseOptions["daemonMode"] {

--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -77,6 +77,11 @@ export function renderReceiptText(receipt: CommandReceiptEnvelope): string {
   if (receipt.command === "preset list") return renderPresetListText(receipt);
   const data = receiptDetailsData(receipt);
   const parts = [`ok`, `command=${formatToken(receipt.command)}`];
+  const rootResolution = receiptRootResolution(receipt.details?.rootResolution);
+  if (rootResolution) {
+    parts.push(`root=${formatToken(rootResolution.root)}`);
+    parts.push(`rootSource=${formatToken(rootResolution.source)}`);
+  }
   const taskId = typeof data.taskId === "string" ? data.taskId : receipt.entity?.kind === "task" ? receipt.entity.id : undefined;
   if (typeof taskId === "string") parts.push(`task=${formatToken(taskId)}`);
   const status = typeof data.status === "string" ? data.status : undefined;
@@ -96,6 +101,14 @@ export function renderReceiptText(receipt: CommandReceiptEnvelope): string {
   if (mode) parts.push(`mode=${formatToken(mode.mode)}`, `package=${formatToken(mode.packageName)}`);
   parts.push(`summary=${formatToken(receipt.summary)}`);
   return parts.join(" ");
+}
+
+function receiptRootResolution(value: unknown): { readonly root: string; readonly source: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const candidate = value as { readonly root?: unknown; readonly source?: unknown };
+  return typeof candidate.root === "string" && typeof candidate.source === "string"
+    ? { root: candidate.root, source: candidate.source }
+    : undefined;
 }
 
 function renderCompletionText(receipt: CommandReceipt): string {

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -209,6 +209,7 @@ export interface CommandHelpOption {
 
 export interface ParsedCommand {
   readonly rootDir: string;
+  readonly rootResolutionSource?: "explicit-override" | "local-cwd";
   readonly layoutOverrides?: HarnessLayoutOverrides;
   readonly daemonRepoId?: string;
   readonly actor?: string;

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -13,6 +13,7 @@ import {
   daemonIdFromEnv,
   daemonUserRootForRepo,
   DaemonJsonRpcRequestTimeoutError,
+  DaemonRepoRootResolutionError,
   DaemonJsonRpcResponseError,
   defaultDaemonAutostartTimeoutMs,
   defaultDaemonIdleExitMs,
@@ -48,6 +49,13 @@ import { readRemoteConfig, remoteDaemonSshArgs, remoteDaemonUnavailableHint, typ
 import { isDeclaredLocalMigrationCommand } from "../composition/local-write-scope.ts";
 import { startCliTimingPhase, type CliTimingPhase } from "../cli/timing.ts";
 import { daemonRequestTimeoutReceipt } from "./request-outcome.ts";
+import {
+  CliRootResolutionError,
+  commandForRootResolution,
+  resolveCommandRoot,
+  rootResolutionUnavailableHint,
+  withRootResolution
+} from "./root-resolution.ts";
 
 export {
   daemonIdForRoot,
@@ -184,7 +192,8 @@ export async function runCommandThroughDaemon(
 ): Promise<CommandReceipt | CommandFailureReceipt | undefined> {
   const finishConfig = startCliTimingPhase("daemon_config");
   try {
-    config ??= readDaemonClientConfig(process.env, command.rootDir, command.daemonModeOverride, command.daemonProfileOverride, command.layoutOverrides);
+    const configRoot = resolveCommandRoot(command).root;
+    config ??= readDaemonClientConfig(process.env, configRoot, command.daemonModeOverride, command.daemonProfileOverride, command.layoutOverrides);
   } catch (error) {
     return daemonUnavailableReceipt(command, error);
   } finally {
@@ -219,15 +228,27 @@ export async function runCommandThroughDaemon(
 
 async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfig): Promise<CommandReceipt | CommandFailureReceipt> {
   const finishTarget = startCliTimingPhase("daemon_target");
-  command = commandForCanonicalHarness(command);
-  const target = resolveLocalDaemonTarget({
-    rootDir: command.rootDir,
-    repoIdOverride: command.daemonRepoId,
-    userRoot: config.userRoot,
-    daemonId: config.daemonId,
-    autoRegisterSingleRepo: true,
-    layoutOverrides: command.layoutOverrides
-  });
+  let rootResolution = resolveCommandRoot(command);
+  command = commandForRootResolution(command, rootResolution);
+  let target: LocalDaemonTarget;
+  try {
+    target = resolveLocalDaemonTarget({
+      rootDir: command.rootDir,
+      repoIdOverride: command.daemonRepoId,
+      userRoot: config.userRoot,
+      daemonId: config.daemonId,
+      autoRegisterSingleRepo: true,
+      layoutOverrides: command.layoutOverrides
+    });
+  } catch (error) {
+    if (error instanceof DaemonRepoRootResolutionError) throw new CliRootResolutionError(rootResolution, error);
+    throw error;
+  }
+  rootResolution = {
+    ...rootResolution,
+    root: target.canonicalRoot,
+    ...(command.daemonRepoId ? { source: "explicit-override" as const } : {})
+  };
   finishTarget();
   const timing = daemonTimingObserver();
   const autostart = daemonAutostartOptions(command, config, timing.observe);
@@ -243,10 +264,10 @@ async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfi
           docSyncHostServices
         );
       } catch (error) {
-        return docSyncSubmitPreviewRejected(error);
+        return withRootResolution(docSyncSubmitPreviewRejected(error), rootResolution);
       }
       const response = await requestLocalDaemonJsonRpcForTarget(target, "repo.doc.sync.submit", request as unknown as JsonObject, 200, autostart);
-      if (isCommandReceipt(response)) return normalizeDocSyncSubmitReceipt(response);
+      if (isCommandReceipt(response)) return withRootResolution(normalizeDocSyncSubmitReceipt(response), rootResolution);
       throw new Error("repo.doc.sync.submit did not return command-receipt/v2");
     }
     if (isTaskHolderCommand(command)) {
@@ -254,7 +275,7 @@ async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfi
         repo: { repoId: target.repoId },
         payload: taskHolderPayload(command)
       }, 200, autostart);
-      if (isCommandReceipt(response)) return normalizeTaskHolderReceipt(response, command.action.kind);
+      if (isCommandReceipt(response)) return withRootResolution(normalizeTaskHolderReceipt(response, command.action.kind), rootResolution);
       throw new Error(`${taskHolderMethod(command)} did not return command-receipt/v2`);
     }
     const response = await requestLocalDaemonJsonRpcForTarget(target, "repo.command.run", {
@@ -264,7 +285,7 @@ async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfi
         Effect.runSync(makeEnvironmentCurrentSessionProbe().currentSession)
       )
     }, 200, command.action.kind === "materializer-run" ? undefined : autostart);
-    if (isCommandReceipt(response)) return response as unknown as CommandReceipt | CommandFailureReceipt;
+    if (isCommandReceipt(response)) return withRootResolution(response as unknown as CommandReceipt | CommandFailureReceipt, rootResolution);
     throw new Error("daemon command.run did not return command-receipt/v2");
   } finally {
     timing.finish();
@@ -378,7 +399,9 @@ async function runWithLineClient(
 }
 
 function daemonUnavailableReceipt(command: ParsedCommand, error: unknown, remote?: RemoteDaemonConfig): CommandFailureReceipt {
-  const unavailableHint = remote
+  const unavailableHint = error instanceof CliRootResolutionError
+    ? rootResolutionUnavailableHint(error.resolution)
+    : remote
     ? remoteDaemonUnavailableHint(remote)
     : `Daemon unavailable. Start the daemon with 'ha daemon start --service' or check 'ha daemon status'. If the daemon is stuck and this write must be recovered locally, run '${directRecoveryCommandLine()}'.`;
   const receipt = toCommandReceipt({
@@ -386,7 +409,9 @@ function daemonUnavailableReceipt(command: ParsedCommand, error: unknown, remote
     command: receiptCommandKind(command.action),
     error: cliError(
       CliErrorCode.JournalUnavailable,
-      `${unavailableHint} Cause: ${error instanceof Error ? error.message : String(error)}`
+      error instanceof CliRootResolutionError
+        ? unavailableHint
+        : `${unavailableHint} Cause: ${error instanceof Error ? error.message : String(error)}`
     )
   });
   if (receipt.ok) throw new Error("daemon unavailable receipt unexpectedly succeeded");
@@ -465,13 +490,6 @@ function commandForTarget(command: ParsedCommand, target: LocalDaemonTarget): Pa
     : { ...command, rootDir: target.canonicalRoot };
 }
 
-function commandForCanonicalHarness(command: ParsedCommand): ParsedCommand {
-  const canonicalRoot = resolveCanonicalHarnessRoot(createHarnessRuntimeContext(command.rootDir, command.layoutOverrides));
-  return path.resolve(command.rootDir) === path.resolve(canonicalRoot)
-    ? command
-    : { ...command, rootDir: canonicalRoot };
-}
-
 export function daemonClientCliEntrypointPath(moduleUrl: string | URL = import.meta.url): string {
   const clientUrl = new URL(moduleUrl);
   const extension = path.posix.extname(clientUrl.pathname);
@@ -511,7 +529,7 @@ function taskHolderPayload(command: TaskHolderParsedCommand): JsonObject {
 
 export function commandRunPayload(command: ParsedCommand, session?: CurrentSessionRef): JsonObject {
   const executor = taskHolderExecutorPayload(command);
-  const { actor: _localActorFlag, ...transportCommand } = command;
+  const { actor: _localActorFlag, rootResolutionSource: _localRootResolutionSource, ...transportCommand } = command;
   return {
     command: transportCommand as unknown as JsonObject,
     ...(executor !== undefined ? { executor } : {}),

--- a/packages/cli/src/daemon/root-resolution.ts
+++ b/packages/cli/src/daemon/root-resolution.ts
@@ -1,0 +1,58 @@
+import path from "node:path";
+import type { CommandFailureReceipt, CommandReceipt } from "../cli/receipt.ts";
+import type { ParsedCommand } from "../cli/types.ts";
+import { resolveCanonicalHarnessRoot } from "@harness-anything/daemon";
+import { createHarnessRuntimeContext } from "@harness-anything/kernel";
+
+export interface CliRootResolution {
+  readonly requestedRoot: string;
+  readonly root: string;
+  readonly source: "explicit-override" | "local-cwd" | "git-common-dir";
+}
+
+export class CliRootResolutionError extends Error {
+  readonly resolution: CliRootResolution;
+
+  constructor(resolution: CliRootResolution, cause: unknown) {
+    super("could not resolve a registered harness repo root", { cause });
+    this.name = "CliRootResolutionError";
+    this.resolution = resolution;
+  }
+}
+
+export function resolveCommandRoot(command: ParsedCommand): CliRootResolution {
+  const requestedRoot = path.resolve(command.rootDir);
+  const root = resolveCanonicalHarnessRoot(createHarnessRuntimeContext(requestedRoot, command.layoutOverrides));
+  const source = command.rootResolutionSource === "explicit-override"
+    ? "explicit-override"
+    : path.resolve(root) === requestedRoot ? "local-cwd" : "git-common-dir";
+  return { requestedRoot, root, source };
+}
+
+export function commandForRootResolution(command: ParsedCommand, resolution: CliRootResolution): ParsedCommand {
+  return path.resolve(command.rootDir) === path.resolve(resolution.root)
+    ? command
+    : { ...command, rootDir: resolution.root };
+}
+
+export function rootResolutionUnavailableHint(resolution: CliRootResolution): string {
+  if (resolution.source === "git-common-dir") {
+    return `Could not resolve a registered harness repo root: git common-dir candidate ${JSON.stringify(resolution.root)} is not registered. Pass --root <canonical-root>, or register that candidate with 'ha daemon repo register --repo-id <id> --root ${quoteRootArgument(resolution.root)}'.`;
+  }
+  const origin = resolution.source === "explicit-override" ? "the explicit --root override" : "the current directory";
+  return `Could not resolve a registered harness repo root from ${origin} ${JSON.stringify(resolution.requestedRoot)}. Pass --root <canonical-root>, or register it with 'ha daemon repo register --repo-id <id> --root ${quoteRootArgument(resolution.requestedRoot)}'.`;
+}
+
+export function withRootResolution<T extends CommandReceipt | CommandFailureReceipt>(receipt: T, resolution: CliRootResolution): T {
+  return {
+    ...receipt,
+    details: {
+      ...(receipt.details ?? {}),
+      rootResolution: { root: resolution.root, source: resolution.source }
+    }
+  };
+}
+
+function quoteRootArgument(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'"'"'`)}'`;
+}

--- a/packages/cli/test/snapshots/global-help.txt
+++ b/packages/cli/test/snapshots/global-help.txt
@@ -2,6 +2,7 @@ Usage: harness-anything <kind> [options]
 Alias: ha <kind> [options]
 
 Global options:
+  --root DIR         Use DIR as the harness repository root.
   --json             Emit machine-readable JSON.
 
 Commands:

--- a/packages/cli/test/worktree-root-resolution-cli.test.ts
+++ b/packages/cli/test/worktree-root-resolution-cli.test.ts
@@ -1,0 +1,234 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { localUserDaemonEndpoint } from "../../daemon/src/index.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
+import { initializeNestedHarnessRepo } from "./helpers/git-fixtures.ts";
+import { runDaemonCommand, runRawJson, stopDaemon } from "./helpers/daemon-cli.ts";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+
+test("worktree commands derive a registered canonical root from git common-dir", async () => {
+  const fixture = createWorktreeFixture("registered", true, true);
+  try {
+    const created = runRawJson(fixture.canonicalRoot, ["task", "create", "--title", "Worktree Root"]);
+    const taskId = receiptData(created).taskId;
+    assert.equal(typeof taskId, "string");
+
+    const shown = runFrom(fixture.worktreeRoot, ["--json", "task", "show", String(taskId)], fixture.env);
+
+    assert.equal(shown.status, 0);
+    assert.equal(shown.receipt.ok, true);
+    assert.deepEqual(receiptRootResolution(shown.receipt), {
+      root: realpathSync.native(fixture.canonicalRoot),
+      source: "git-common-dir"
+    });
+    const text = spawnSync(process.execPath, [cliEntry, "task", "show", String(taskId)], {
+      cwd: fixture.worktreeRoot,
+      encoding: "utf8",
+      env: fixture.env
+    });
+    assert.equal(text.status, 0);
+    assert.match(text.stdout, /root=.*canonical rootSource=git-common-dir/iu);
+  } finally {
+    await cleanupFixture(fixture);
+  }
+});
+
+test("explicit root override wins over a registered git common-dir candidate", async () => {
+  const fixture = createWorktreeFixture("explicit");
+  const explicitRoot = path.join(fixture.containerRoot, "explicit-root");
+  mkdirSync(explicitRoot, { recursive: true });
+  try {
+    initializeNestedHarnessRepo(explicitRoot);
+    registerRepo(explicitRoot, fixture.userRoot, "explicit", fixture.env);
+
+    const listed = runFrom(fixture.worktreeRoot, ["--root", explicitRoot, "--json", "task", "list"], fixture.env);
+
+    assert.equal(listed.status, 0);
+    assert.deepEqual(receiptRootResolution(listed.receipt), {
+      root: realpathSync.native(explicitRoot),
+      source: "explicit-override"
+    });
+    const local = runFrom(explicitRoot, ["--json", "task", "list"], fixture.env);
+    assert.equal(local.status, 0);
+    assert.deepEqual(receiptRootResolution(local.receipt), {
+      root: realpathSync.native(explicitRoot),
+      source: "local-cwd"
+    });
+  } finally {
+    await stopDaemon(explicitRoot, fixture.userRoot);
+    await cleanupFixture(fixture);
+  }
+});
+
+test("git common-dir parent is rejected when it is not a registered repo root", async () => {
+  const fixture = createWorktreeFixture("unregistered", false);
+  const registeredRoot = path.join(fixture.containerRoot, "registered-root");
+  mkdirSync(registeredRoot, { recursive: true });
+  try {
+    initializeNestedHarnessRepo(registeredRoot);
+    registerRepo(registeredRoot, fixture.userRoot, "registered", fixture.env);
+
+    const failed = runFrom(fixture.worktreeRoot, ["--json", "task", "list"], fixture.env);
+
+    assert.notEqual(failed.status, 0);
+    assert.equal(failed.receipt.error?.code, "journal_unavailable");
+    assert.match(String(failed.receipt.error?.hint), /could not resolve a registered harness repo root/iu);
+    assert.match(String(failed.receipt.error?.hint), /git common-dir candidate .* is not registered/iu);
+    assert.doesNotMatch(String(failed.receipt.error?.hint), /Start the daemon|recovery escape hatch/iu);
+  } finally {
+    await stopDaemon(registeredRoot, fixture.userRoot);
+    await cleanupFixture(fixture);
+  }
+});
+
+test("non-git cwd keeps the unregistered-root failure path", async () => {
+  const containerRoot = mkdtempSync(path.join(tmpdir(), "ha-non-git-root-"));
+  const registeredRoot = path.join(containerRoot, "registered-root");
+  const outsiderRoot = path.join(containerRoot, "outsider");
+  const userRoot = path.join(containerRoot, "user-daemon");
+  const env = daemonEnv(containerRoot, userRoot);
+  mkdirSync(registeredRoot, { recursive: true });
+  mkdirSync(outsiderRoot, { recursive: true });
+  try {
+    runRawJson(registeredRoot, ["init"], env);
+
+    const failed = runFrom(outsiderRoot, ["--json", "task", "list"], env);
+
+    assert.notEqual(failed.status, 0);
+    assert.equal(failed.receipt.error?.code, "journal_unavailable");
+    assert.match(String(failed.receipt.error?.hint), /could not resolve a registered harness repo root/iu);
+    assert.doesNotMatch(String(failed.receipt.error?.hint), /git common-dir candidate/iu);
+  } finally {
+    await stopDaemon(registeredRoot, userRoot);
+    rmSync(containerRoot, { recursive: true, force: true });
+  }
+});
+
+test("resolved roots retain the daemon-unavailable recovery hint for real connection failures", async () => {
+  if (process.platform === "win32") return;
+  const containerRoot = mkdtempSync(path.join(tmpdir(), "ha-daemon-unavailable-root-"));
+  const canonicalRoot = path.join(containerRoot, "canonical");
+  const userRoot = path.join(containerRoot, "user-daemon");
+  const env = daemonEnv(containerRoot, userRoot);
+  mkdirSync(canonicalRoot, { recursive: true });
+  initializeNestedHarnessRepo(canonicalRoot);
+  registerRepo(canonicalRoot, userRoot, "canonical", env);
+  const endpoint = localUserDaemonEndpoint(userRoot);
+  try {
+    mkdirSync(endpoint, { recursive: true });
+    const failed = runFrom(canonicalRoot, ["--root", canonicalRoot, "--json", "task", "list"], {
+      ...env,
+      HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "30"
+    });
+
+    assert.notEqual(failed.status, 0);
+    assert.equal(failed.receipt.error?.code, "journal_unavailable");
+    assert.match(String(failed.receipt.error?.hint), /Daemon unavailable/iu);
+    assert.match(String(failed.receipt.error?.hint), /HARNESS_DIRECT_WRITE_REASON=recovery/iu);
+  } finally {
+    rmSync(endpoint, { recursive: true, force: true });
+    rmSync(`${endpoint}.owner`, { force: true });
+    rmSync(containerRoot, { recursive: true, force: true });
+  }
+});
+
+interface WorktreeFixture {
+  readonly containerRoot: string;
+  readonly canonicalRoot: string;
+  readonly worktreeRoot: string;
+  readonly userRoot: string;
+  readonly env: NodeJS.ProcessEnv;
+}
+
+function createWorktreeFixture(name: string, registerCanonical = true, useProjectDaemonRoot = false): WorktreeFixture {
+  const containerRoot = mkdtempSync(path.join(tmpdir(), `ha-worktree-root-${name}-`));
+  const canonicalRoot = path.join(containerRoot, "canonical");
+  const worktreeRoot = path.join(containerRoot, "worktree");
+  const userRoot = path.join(containerRoot, "user-daemon");
+  const env = daemonEnv(containerRoot, useProjectDaemonRoot ? undefined : userRoot);
+  mkdirSync(canonicalRoot, { recursive: true });
+  runGit(canonicalRoot, "init");
+  writeFileSync(path.join(canonicalRoot, ".gitignore"), "/harness/\n/.harness/\n", "utf8");
+  runGit(canonicalRoot, "add", ".gitignore");
+  runGit(canonicalRoot, "commit", "-m", "seed worktree fixture");
+  initializeNestedHarnessRepo(canonicalRoot);
+  if (useProjectDaemonRoot) writeProjectDaemonRoot(canonicalRoot, "../user-daemon");
+  if (registerCanonical) registerRepo(canonicalRoot, userRoot, "canonical", env);
+  runGit(canonicalRoot, "worktree", "add", "--detach", worktreeRoot);
+  return { containerRoot, canonicalRoot, worktreeRoot, userRoot, env };
+}
+
+async function cleanupFixture(fixture: WorktreeFixture): Promise<void> {
+  await stopDaemon(fixture.canonicalRoot, fixture.userRoot);
+  rmSync(fixture.containerRoot, { recursive: true, force: true });
+}
+
+function registerRepo(rootDir: string, userRoot: string, repoId: string, env: NodeJS.ProcessEnv): void {
+  runDaemonCommand(rootDir, [
+    "daemon", "repo", "register", "--repo-id", repoId, "--root", rootDir,
+    "--user-root", userRoot, "--no-link", "--json"
+  ], env as Record<string, string>);
+}
+
+function runFrom(cwd: string, args: ReadonlyArray<string>, env: NodeJS.ProcessEnv): {
+  readonly status: number | null;
+  readonly receipt: Record<string, any>;
+} {
+  const result = spawnSync(process.execPath, [cliEntry, ...args], {
+    cwd,
+    encoding: "utf8",
+    env
+  });
+  return {
+    status: result.status,
+    receipt: JSON.parse(result.stdout || "{}") as Record<string, any>
+  };
+}
+
+function receiptData(receipt: Record<string, any>): Record<string, any> {
+  return receipt.details?.data ?? {};
+}
+
+function receiptRootResolution(receipt: Record<string, any>): unknown {
+  return receipt.details?.rootResolution;
+}
+
+function daemonEnv(homeRoot: string, userRoot?: string): NodeJS.ProcessEnv {
+  return cliTestEnv({
+    HOME: path.join(homeRoot, ".home"),
+    USERPROFILE: path.join(homeRoot, ".home"),
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    HARNESS_ACTOR: "agent:worktree-root-test",
+    HARNESS_GIT_AUTHOR_NAME: "Harness Test",
+    HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
+    ...(userRoot ? { HARNESS_DAEMON_USER_ROOT: userRoot } : {}),
+    HA_PROGRESS: "0"
+  });
+}
+
+function writeProjectDaemonRoot(rootDir: string, userRoot: string): void {
+  const configPath = path.join(rootDir, "harness", "harness.yaml");
+  writeFileSync(configPath, `${readFileSync(configPath, "utf8")}  daemon:\n    userRoot: ${userRoot}\n`, "utf8");
+}
+
+function runGit(rootDir: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+      GIT_AUTHOR_NAME: "Harness Test",
+      GIT_AUTHOR_EMAIL: "harness-test@example.invalid",
+      GIT_COMMITTER_NAME: "Harness Test",
+      GIT_COMMITTER_EMAIL: "harness-test@example.invalid"
+    }
+  }).trim();
+}

--- a/packages/cli/test/worktree-root-resolution-cli.test.ts
+++ b/packages/cli/test/worktree-root-resolution-cli.test.ts
@@ -21,7 +21,7 @@ test("worktree commands derive a registered canonical root from git common-dir",
 
     const shown = runFrom(fixture.worktreeRoot, ["--json", "task", "show", String(taskId)], fixture.env);
 
-    assert.equal(shown.status, 0);
+    assert.equal(shown.status, 0, shown.diagnostic);
     assert.equal(shown.receipt.ok, true);
     assert.deepEqual(receiptRootResolution(shown.receipt), {
       root: realpathSync.native(fixture.canonicalRoot),
@@ -32,7 +32,7 @@ test("worktree commands derive a registered canonical root from git common-dir",
       encoding: "utf8",
       env: fixture.env
     });
-    assert.equal(text.status, 0);
+    assert.equal(text.status, 0, formatChildResult(text));
     assert.match(text.stdout, /root=.*canonical rootSource=git-common-dir/iu);
   } finally {
     await cleanupFixture(fixture);
@@ -49,13 +49,13 @@ test("explicit root override wins over a registered git common-dir candidate", a
 
     const listed = runFrom(fixture.worktreeRoot, ["--root", explicitRoot, "--json", "task", "list"], fixture.env);
 
-    assert.equal(listed.status, 0);
+    assert.equal(listed.status, 0, listed.diagnostic);
     assert.deepEqual(receiptRootResolution(listed.receipt), {
       root: realpathSync.native(explicitRoot),
       source: "explicit-override"
     });
     const local = runFrom(explicitRoot, ["--json", "task", "list"], fixture.env);
-    assert.equal(local.status, 0);
+    assert.equal(local.status, 0, local.diagnostic);
     assert.deepEqual(receiptRootResolution(local.receipt), {
       root: realpathSync.native(explicitRoot),
       source: "local-cwd"
@@ -76,7 +76,7 @@ test("git common-dir parent is rejected when it is not a registered repo root", 
 
     const failed = runFrom(fixture.worktreeRoot, ["--json", "task", "list"], fixture.env);
 
-    assert.notEqual(failed.status, 0);
+    assert.notEqual(failed.status, 0, failed.diagnostic);
     assert.equal(failed.receipt.error?.code, "journal_unavailable");
     assert.match(String(failed.receipt.error?.hint), /could not resolve a registered harness repo root/iu);
     assert.match(String(failed.receipt.error?.hint), /git common-dir candidate .* is not registered/iu);
@@ -100,7 +100,7 @@ test("non-git cwd keeps the unregistered-root failure path", async () => {
 
     const failed = runFrom(outsiderRoot, ["--json", "task", "list"], env);
 
-    assert.notEqual(failed.status, 0);
+    assert.notEqual(failed.status, 0, failed.diagnostic);
     assert.equal(failed.receipt.error?.code, "journal_unavailable");
     assert.match(String(failed.receipt.error?.hint), /could not resolve a registered harness repo root/iu);
     assert.doesNotMatch(String(failed.receipt.error?.hint), /git common-dir candidate/iu);
@@ -127,7 +127,7 @@ test("resolved roots retain the daemon-unavailable recovery hint for real connec
       HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "30"
     });
 
-    assert.notEqual(failed.status, 0);
+    assert.notEqual(failed.status, 0, failed.diagnostic);
     assert.equal(failed.receipt.error?.code, "journal_unavailable");
     assert.match(String(failed.receipt.error?.hint), /Daemon unavailable/iu);
     assert.match(String(failed.receipt.error?.hint), /HARNESS_DIRECT_WRITE_REASON=recovery/iu);
@@ -179,16 +179,40 @@ function registerRepo(rootDir: string, userRoot: string, repoId: string, env: No
 function runFrom(cwd: string, args: ReadonlyArray<string>, env: NodeJS.ProcessEnv): {
   readonly status: number | null;
   readonly receipt: Record<string, any>;
+  readonly diagnostic: string;
 } {
   const result = spawnSync(process.execPath, [cliEntry, ...args], {
     cwd,
     encoding: "utf8",
     env
   });
+  const diagnostic = formatChildResult(result);
+  let receipt: Record<string, any>;
+  try {
+    receipt = JSON.parse(result.stdout || "{}") as Record<string, any>;
+  } catch (error) {
+    throw new Error(`CLI stdout was not JSON.\n${diagnostic}`, { cause: error });
+  }
   return {
     status: result.status,
-    receipt: JSON.parse(result.stdout || "{}") as Record<string, any>
+    receipt,
+    diagnostic
   };
+}
+
+function formatChildResult(result: {
+  readonly status: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly error?: Error;
+}): string {
+  return [
+    `status=${String(result.status)} signal=${String(result.signal)}`,
+    `stdout:\n${result.stdout || "<empty>"}`,
+    `stderr:\n${result.stderr || "<empty>"}`,
+    ...(result.error ? [`spawn error:\n${result.error.stack ?? result.error.message}`] : [])
+  ].join("\n");
 }
 
 function receiptData(receipt: Record<string, any>): Record<string, any> {
@@ -205,9 +229,11 @@ function daemonEnv(homeRoot: string, userRoot?: string): NodeJS.ProcessEnv {
     USERPROFILE: path.join(homeRoot, ".home"),
     GIT_CONFIG_GLOBAL: "/dev/null",
     GIT_CONFIG_SYSTEM: "/dev/null",
+    HARNESS_CLI_TEST_FIXTURE_PRELOAD: "",
     HARNESS_ACTOR: "agent:worktree-root-test",
     HARNESS_GIT_AUTHOR_NAME: "Harness Test",
     HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test",
+    NODE_OPTIONS: "",
     ...(userRoot ? { HARNESS_DAEMON_USER_ROOT: userRoot } : {}),
     HA_PROGRESS: "0"
   });
@@ -219,16 +245,18 @@ function writeProjectDaemonRoot(rootDir: string, userRoot: string): void {
 }
 
 function runGit(rootDir: string, ...args: ReadonlyArray<string>): string {
-  return execFileSync("git", ["-C", rootDir, ...args], {
+  return execFileSync("git", [
+    "-c", "user.name=Harness Test",
+    "-c", "user.email=harness-test@example.invalid",
+    "-c", "init.defaultBranch=main",
+    "-C", rootDir,
+    ...args
+  ], {
     encoding: "utf8",
     env: {
       ...process.env,
       GIT_CONFIG_GLOBAL: "/dev/null",
-      GIT_CONFIG_SYSTEM: "/dev/null",
-      GIT_AUTHOR_NAME: "Harness Test",
-      GIT_AUTHOR_EMAIL: "harness-test@example.invalid",
-      GIT_COMMITTER_NAME: "Harness Test",
-      GIT_COMMITTER_EMAIL: "harness-test@example.invalid"
+      GIT_CONFIG_SYSTEM: "/dev/null"
     }
   }).trim();
 }

--- a/packages/daemon/src/client/daemon-repo-root-resolution-error.ts
+++ b/packages/daemon/src/client/daemon-repo-root-resolution-error.ts
@@ -1,0 +1,9 @@
+export class DaemonRepoRootResolutionError extends Error {
+  readonly rootDir: string;
+
+  constructor(rootDir: string) {
+    super(`current root is not registered with the user daemon registry. Run: ha daemon repo register --repo-id <id> --root ${JSON.stringify(rootDir)}`);
+    this.name = "DaemonRepoRootResolutionError";
+    this.rootDir = rootDir;
+  }
+}

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -19,6 +19,7 @@ import {
   createDaemonLaunchConfiguration,
   type DaemonLaunchConfiguration
 } from "./daemon-launch-configuration.ts";
+import { DaemonRepoRootResolutionError } from "./daemon-repo-root-resolution-error.ts";
 import { daemonSocketConnectError } from "./daemon-socket-namespace.ts";
 import {
   DaemonJsonRpcRequestTimeoutError,
@@ -227,7 +228,7 @@ export function resolveLocalDaemonTarget(input: {
     });
   }
 
-  throw new Error(`current root is not registered with the user daemon registry. Run: ha daemon repo register --repo-id <id> --root ${JSON.stringify(path.resolve(input.rootDir))}`);
+  throw new DaemonRepoRootResolutionError(path.resolve(input.rootDir));
 }
 
 export async function requestLocalDaemonJsonRpc(

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -50,6 +50,7 @@ export {
   type LocalDaemonJsonRpcOptions,
   type LocalDaemonTarget
 } from "./client/local-json-rpc-client.ts";
+export { DaemonRepoRootResolutionError } from "./client/daemon-repo-root-resolution-error.ts";
 export * from "./authority/index.ts";
 export * from "./authority/authority-command-submission.ts";
 export * from "./authority/authority-cutover-command.ts";


### PR DESCRIPTION
# English

## Summary

Running `ha` from a git worktree silently failed to find the harness ledger: the ledger lives only at the canonical repository root, and root resolution stopped at the current working directory. Workers in worktrees either got a misleading "daemon unavailable" shape or had to discover the undocumented `--root` flag by trial. Root resolution now falls back to the git common directory, so a worktree reaches its canonical ledger with no flag, while explicit overrides keep priority and non-git directories keep their existing behavior.

## What Changed

- New `packages/cli/src/daemon/root-resolution.ts`: root priority is explicit override (`--root`/env) > local cwd ledger > git common-dir fallback; the receipt names which source resolved the root.
- Root-resolution failure is now typed distinctly from real daemon unreachability (`daemon-repo-root-resolution-error`), so the recovery hint no longer points at the daemon when the problem is the missing ledger root.
- `--root DIR` is documented in global help.
- Negative tests cover unregistered git candidates and non-git directories; `packages/cli/test/worktree-root-resolution-cli.test.ts` exercises the packaged CLI from a real worktree.
- No configuration fields added (per the governing decision), no principal/write-semantics/projection changes.

## Task And Scope

- Harness task: task_01KY58NV71Y2EE0924X8B7TWRE (private ledger), decision dec_01KY58M0P81S55M5MDTHXNZDRE
- Branch: fix/worktree-git-root
- Public scope: packages/cli/src/cli/*, packages/cli/src/daemon/client.ts, packages/cli/src/daemon/root-resolution.ts, packages/daemon/src/*, CLI tests and help snapshot
- Private planning/evidence updated: yes
- Out of scope: configuration schema, daemon protocol, projection/write semantics

## Version Impact

- Version: no version change because this is a CLI resolution fix within the existing surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: packages/cli/src/daemon/client.ts (daemon client root resolution)
- Authority: decision dec_01KY58M0P81S55M5MDTHXNZDRE; task task_01KY58NV71Y2EE0924X8B7TWRE
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: e5404c681ba38b8a9d92098a159c7bc5c45bf716
- Branch merge-base with `origin/main`: afc65fee79044c414fce4ca89c91a08f206c3ba9
- Last `git fetch origin` time: 2026-07-22T17:49Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: private ledger task package (worktree root)
- Reviewer evidence path: private ledger task package (worktree root)
- GitHub Actions `rewrite-ci` run URL: pending (added after push)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:check-package-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local gate matrix — per the derived stop point, targeted tests ran locally (204/204 pass, 33/33 static local gates, ESLint and diff check pass, packaged CLI verified from a real worktree); the full matrix belongs to GitHub CI

## Review Evidence

- Self-review: root priority order verified (explicit override > local cwd > git fallback); root-resolution failure and daemon unreachability confirmed as distinct receipt shapes; negative controls for unregistered git candidates and non-git directories
- Reviewer subagent: none (bounded review policy; CI is the authority gate)
- Human review: pending
- Blocking findings: none

## Residual Risk

- Full CI matrix not run locally; GitHub CI is the deciding gate.

## References

- Task: task_01KY58NV71Y2EE0924X8B7TWRE (private ledger)
- Evidence: private ledger task package
- Review: private ledger task package

---

# 中文

## 概要

在 git worktree 里跑 `ha` 会静默找不到台账:台账只在 canonical 仓库根,而 root 解析止步于当前目录。worktree 里的 worker 要么撞上误导性的「daemon 不可达」,要么只能靠试错发现无文档的 `--root`。现在 root 解析回退到 git common directory,worktree 无 flag 即达 canonical 台账;显式覆盖仍保持最高优先,非 git 目录行为不变。

## 改动内容

- 新增 `packages/cli/src/daemon/root-resolution.ts`:优先级=显式覆盖(`--root`/env)> 本地 cwd 台账 > git common-dir 回退;回执标明 root 来源。
- root 解析失败与真正 daemon 不可达分型(`daemon-repo-root-resolution-error`),缺台账根时恢复提示不再指向 daemon。
- `--root DIR` 进入全局 help。
- 阴性测试覆盖未注册 git 候选与非 git 目录;`worktree-root-resolution-cli.test.ts` 用打包 CLI 在真实 worktree 验证。
- 按治理决策不新增配置字段;不动 principal/写语义/projection。

## 任务与范围

- Harness 任务:task_01KY58NV71Y2EE0924X8B7TWRE(私有台账),决策 dec_01KY58M0P81S55M5MDTHXNZDRE
- 分支:fix/worktree-git-root
- 公开范围:packages/cli/src/cli/*、packages/cli/src/daemon/client.ts、packages/cli/src/daemon/root-resolution.ts、packages/daemon/src/*、CLI 测试与 help 快照
- 私有计划 / 证据是否已更新:yes
- 范围外:配置 schema、daemon 协议、projection/写语义

## 版本影响

- 版本:不改版本,原因是既有面内的 CLI 解析修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:packages/cli/src/daemon/client.ts(daemon 客户端 root 解析)
- 依据:决策 dec_01KY58M0P81S55M5MDTHXNZDRE;任务 task_01KY58NV71Y2EE0924X8B7TWRE
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:e5404c681ba38b8a9d92098a159c7bc5c45bf716
- 当前分支与 `origin/main` 的 merge-base:afc65fee79044c414fce4ca89c91a08f206c3ba9
- 最近一次 `git fetch origin` 时间:2026-07-22T17:49Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:私有台账任务包(worktree root)
- Reviewer 证据路径:私有台账任务包(worktree root)
- GitHub Actions `rewrite-ci` run URL:push 后补充
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:check-package-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地完整门矩阵——按派生停止点只跑定向层(定向测试 204/204、静态 local gates 33/33、ESLint 与 diff check 通过、真实 worktree 打包 CLI 验证);完整矩阵归 GitHub CI

## 审查证据

- 自查:root 优先级(显式覆盖 > 本地 cwd > git 回退)已验;root 解析失败与 daemon 不可达为不同回执形态;未注册 git 候选与非 git 目录有阴性对照
- Reviewer subagent:无(有界评审政策;CI 为权威门)
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 本地未跑完整 CI 矩阵;GitHub CI 为裁决门。

## 关联材料

- 任务:task_01KY58NV71Y2EE0924X8B7TWRE(私有台账)
- 证据:私有台账任务包
- 审查:私有台账任务包
