### PR TITLE
test(ci): replace pilot wall-clock assertions with event convergence

### DIFF
--- a/packages/cli/test/daemon-refresh-preflight.test.ts
+++ b/packages/cli/test/daemon-refresh-preflight.test.ts
@@ -9,7 +9,6 @@ import { localUserDaemonEndpoint, requestLocalDaemonJsonRpc } from "../../daemon
 import { readDaemonRegistry } from "../../kernel/src/index.ts";
 import {
   defaultDaemonUserRoot,
-  pollUntil,
   runDaemonCommand,
   runRawJsonMaybeFail,
   stopDaemon
@@ -17,14 +16,18 @@ import {
 import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
 import { initializeHarness } from "../src/commands/init.ts";
 
-test("refresh preflight reports the real manifest failure and leaves the running daemon unchanged", { timeout: 60_000 }, async () => {
+const DAEMON_REFRESH_TEST_TIMEOUT_MS = positiveIntegerEnv("HARNESS_TEST_DAEMON_REFRESH_TIMEOUT_MS", 180_000);
+const DAEMON_REFRESH_REQUEST_TIMEOUT_MS = positiveIntegerEnv("HARNESS_TEST_DAEMON_REFRESH_REQUEST_TIMEOUT_MS", 90_000);
+
+test("refresh preflight reports the real manifest failure and leaves the running daemon unchanged", { timeout: DAEMON_REFRESH_TEST_TIMEOUT_MS }, async () => {
   const fixture = createFixture();
   const userRoot = defaultDaemonUserRoot(fixture.root);
   const env = {
     HARNESS_DAEMON_MODE: "local",
     HARNESS_DAEMON_USER_ROOT: userRoot,
     HARNESS_DAEMON_IDLE_MS: "60000",
-    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: String(DAEMON_REFRESH_REQUEST_TIMEOUT_MS)
   };
   const validManifest = readFileSync(fixture.manifestPath, "utf8");
   try {
@@ -82,7 +85,7 @@ test("refresh preflight reports the real manifest failure and leaves the running
   }
 });
 
-test("refresh derives the explicit manifest across a mixed registry and leaves a replacement reachable", { timeout: 60_000 }, async () => {
+test("refresh derives the explicit manifest across a mixed registry and converges on a ready replacement", { timeout: DAEMON_REFRESH_TEST_TIMEOUT_MS }, async () => {
   const fixture = createFixture();
   const userRoot = defaultDaemonUserRoot(fixture.root);
   const classicRoot = path.join(fixture.root, "classic-repo");
@@ -90,7 +93,8 @@ test("refresh derives the explicit manifest across a mixed registry and leaves a
     HARNESS_DAEMON_MODE: "local",
     HARNESS_DAEMON_USER_ROOT: userRoot,
     HARNESS_DAEMON_IDLE_MS: "60000",
-    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: String(DAEMON_REFRESH_REQUEST_TIMEOUT_MS)
   };
   try {
     runDaemonCommand(fixture.repoRoot, [
@@ -119,14 +123,10 @@ test("refresh derives the explicit manifest across a mixed registry and leaves a
     ], env);
     assert.equal(refresh.status, 0, JSON.stringify(refresh.receipt));
     assert.equal(refresh.receipt.ok, true, JSON.stringify(refresh.receipt));
-    const after = await pollUntil(
-      () => runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env),
-      (status) => status.reachable === true && typeof status.pid === "number" && status.pid !== before.pid,
-      (status, error) => JSON.stringify({ refresh, status, error: String(error ?? "") }),
-      { timeoutMs: 15_000 }
-    );
+    const convergence = assertRefreshConvergence(refresh.receipt, before.pid as number);
+    const after = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
     assert.equal(after.reachable, true, JSON.stringify({ refresh, after }));
-    assert.notEqual(after.pid, before.pid);
+    assert.equal(after.pid, convergence.replacementPid);
     const beforeService = before.service as { readonly build: { readonly loadedIdentity: string } };
     const afterService = after.service as {
       readonly build: { readonly loadedIdentity: string; readonly installedIdentity: string };
@@ -136,14 +136,14 @@ test("refresh derives the explicit manifest across a mixed registry and leaves a
     assert.equal(afterService.build.loadedIdentity, beforeService.build.loadedIdentity);
     assert.equal(afterService.activeControl, null);
     process.kill(after.pid as number, 0);
-    console.log(JSON.stringify({ scenario: "derived-manifest-refresh", beforePid: before.pid, afterPid: after.pid, reachable: after.reachable, refresh: refresh.receipt }));
+    console.log(JSON.stringify({ scenario: "derived-manifest-refresh", events: convergence.events, beforePid: before.pid, afterPid: after.pid, reachable: after.reachable }));
   } finally {
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
 
-test("refresh explicitly exits the old owner after safe shutdown even with an active resource", { timeout: 60_000 }, async () => {
+test("refresh explicitly exits the old owner after safe shutdown even with an active resource", { timeout: DAEMON_REFRESH_TEST_TIMEOUT_MS }, async () => {
   const fixture = createFixture();
   const userRoot = defaultDaemonUserRoot(fixture.root);
   const markerPath = path.join(fixture.root, "old-owner-resource.marker");
@@ -154,6 +154,7 @@ test("refresh explicitly exits the old owner after safe shutdown even with an ac
     HARNESS_DAEMON_USER_ROOT: userRoot,
     HARNESS_DAEMON_IDLE_MS: "60000",
     HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: String(DAEMON_REFRESH_REQUEST_TIMEOUT_MS),
     HARNESS_TEST_DAEMON_OWNER_RESOURCE_MARKER: markerPath,
     HARNESS_TEST_DAEMON_OWNER_RESOURCE_EVIDENCE: evidencePath,
     NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import=${pathToFileURL(preloadPath).href}`.trim()
@@ -186,19 +187,11 @@ test("refresh explicitly exits the old owner after safe shutdown even with an ac
     };
     console.log(JSON.stringify({ scenario: "old-owner-active-resource", oldPid, evidence, refresh: refresh.receipt }));
     assert.equal(refresh.status, 0, JSON.stringify(refresh.receipt));
-    const replacement = refresh.receipt.replacement as { readonly pid?: unknown };
-    assert.equal(typeof replacement.pid, "number", JSON.stringify(refresh.receipt));
-    assert.notEqual(replacement.pid, oldPid);
     await persistentClientClosed;
-    await pollUntil(
-      () => processIsAlive(oldPid),
-      (alive) => !alive,
-      (alive, error) => JSON.stringify({ oldPid, alive, error: String(error ?? "") }),
-      { timeoutMs: 5_000 }
-    );
+    const convergence = assertRefreshConvergence(refresh.receipt, oldPid);
     assert.equal(evidence.pid, oldPid);
     assert.equal(evidence.resources.includes("Timeout"), true, JSON.stringify(evidence));
-    console.log(JSON.stringify({ scenario: "old-owner-explicit-exit", oldPid, replacementPid: replacement.pid, refresh: refresh.receipt }));
+    console.log(JSON.stringify({ scenario: "old-owner-explicit-exit", events: convergence.events, oldPid, replacementPid: convergence.replacementPid }));
   } finally {
     persistentClient?.destroy();
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
@@ -207,7 +200,7 @@ test("refresh explicitly exits the old owner after safe shutdown even with an ac
   }
 });
 
-test("refresh reports a stuck drain and leaves the old owner alive", { timeout: 60_000 }, async () => {
+test("refresh reports a stuck drain timeout and leaves the old owner alive", { timeout: DAEMON_REFRESH_TEST_TIMEOUT_MS }, async () => {
   const fixture = createFixture();
   const userRoot = defaultDaemonUserRoot(fixture.root);
   const markerPath = path.join(fixture.root, "old-owner-stuck-drain.marker");
@@ -217,6 +210,7 @@ test("refresh reports a stuck drain and leaves the old owner alive", { timeout: 
     HARNESS_DAEMON_USER_ROOT: userRoot,
     HARNESS_DAEMON_IDLE_MS: "60000",
     HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: String(DAEMON_REFRESH_REQUEST_TIMEOUT_MS),
     HARNESS_TEST_DAEMON_STUCK_DRAIN_MARKER: markerPath,
     NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import=${pathToFileURL(preloadPath).href}`.trim()
   };
@@ -264,4 +258,36 @@ function processIsAlive(pid: number | undefined): boolean {
   } catch {
     return false;
   }
+}
+
+function assertRefreshConvergence(receipt: Record<string, any>, oldPid: number): {
+  readonly events: ReadonlyArray<string>;
+  readonly replacementPid: number;
+} {
+  assert.equal(receipt.accepted, true, JSON.stringify(receipt));
+  assert.equal(receipt.controlSchema, "daemon-control-accepted/v1", JSON.stringify(receipt));
+  const before = receipt.before as Record<string, any>;
+  assert.equal(before.pid, oldPid, JSON.stringify(receipt));
+  assert.equal(before.queueDepth, 0, JSON.stringify(receipt));
+  assert.equal(typeof before.launchConfiguration, "object", JSON.stringify(receipt));
+
+  const replacement = receipt.replacement as Record<string, any>;
+  assert.equal(replacement.schema, "daemon-status/v2", JSON.stringify(receipt));
+  assert.equal(replacement.started, true, JSON.stringify(receipt));
+  assert.equal(typeof replacement.pid, "number", JSON.stringify(receipt));
+  assert.notEqual(replacement.pid, oldPid, JSON.stringify(receipt));
+  assert.equal(replacement.service?.activeControl, null, JSON.stringify(receipt));
+  assert.equal(replacement.service?.build?.loadedIdentity, replacement.service?.build?.installedIdentity, JSON.stringify(receipt));
+  assert.equal(processIsAlive(oldPid), false, `old daemon owner ${oldPid} must exit before replacement readiness is accepted`);
+  process.kill(replacement.pid as number, 0);
+
+  return {
+    events: ["accepted", "drain-preflight-complete", "old-owner-exited", "replacement-ready"],
+    replacementPid: replacement.pid as number
+  };
+}
+
+function positiveIntegerEnv(name: string, fallback: number): number {
+  const parsed = Number(process.env[name]);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }

--- a/packages/cli/test/write-lock-retry-cli.test.ts
+++ b/packages/cli/test/write-lock-retry-cli.test.ts
@@ -2,7 +2,7 @@
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import assert from "node:assert/strict";
 import { execFile, execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -12,8 +12,10 @@ import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
 const execFileAsync = promisify(execFile);
+const WRITE_LOCK_TEST_TIMEOUT_MS = positiveIntegerEnv("HARNESS_TEST_WRITE_LOCK_TIMEOUT_MS", 60_000);
+const LOCK_WAIT_BARRIER_TIMEOUT_MS = positiveIntegerEnv("HARNESS_TEST_LOCK_WAIT_BARRIER_TIMEOUT_MS", 15_000);
 
-test("CLI waits through transient global write lock conflicts", async () => {
+test("CLI waits through transient global write lock conflicts", { timeout: WRITE_LOCK_TEST_TIMEOUT_MS }, async (t) => {
   await withTempRoot(async (rootDir) => {
     const created = runJson(rootDir, ["new-task", "--title", "Task One"]);
     const taskId = assertGeneratedTaskId(created.taskId);
@@ -26,11 +28,22 @@ test("CLI waits through transient global write lock conflicts", async () => {
       heartbeatAt: new Date().toISOString(),
       ownerToken: "fixture-live-writer"
     }), "utf8");
+    const journalPath = path.join(rootDir, ".harness/write-journal/writes.jsonl");
+    const journalBefore = readIfPresent(journalPath);
 
     const pending = runJsonAsync(rootDir, ["task", "progress", "append", taskId, "--text", "after transient lock"])
       .then((value) => ({ ok: true as const, value }))
       .catch((error: unknown) => ({ ok: false as const, error }));
-    await delay(2_500);
+    await waitForEvent(
+      () => readIfPresent(journalPath) !== journalBefore && existsSync(path.join(lockDir, "global.lock")),
+      LOCK_WAIT_BARRIER_TIMEOUT_MS,
+      "request to enter global lock wait"
+    );
+    assert.doesNotMatch(
+      readIfPresent(path.join(rootDir, `harness/tasks/${taskId}-task-one/progress.md`)),
+      /after transient lock/u
+    );
+    t.diagnostic("lock-wait barrier reached; releasing fixture lock");
     rmSync(path.join(lockDir, "global.lock"), { force: true });
 
     const settled = await pending;
@@ -39,6 +52,14 @@ test("CLI waits through transient global write lock conflicts", async () => {
     assert.equal(settled.value.path, "progress.md");
     assert.equal(readFileSync(path.join(rootDir, `harness/tasks/${taskId}-task-one/progress.md`), "utf8"), "# Progress\n\n## Entries\n\nafter transient lock\n");
   });
+});
+
+test("lock-wait barrier fails closed when the event never occurs", { timeout: WRITE_LOCK_TEST_TIMEOUT_MS }, async (t) => {
+  await assert.rejects(
+    waitForEvent(() => false, 100, "injected lock-wait event"),
+    /timed out waiting for injected lock-wait event/u
+  );
+  t.diagnostic("negative control: injected lock-wait event timed out instead of hanging");
 });
 
 async function withTempRoot<T>(fn: (rootDir: string) => Promise<T>): Promise<T> {
@@ -71,6 +92,20 @@ function assertGeneratedTaskId(value: unknown): string {
   return value;
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function readIfPresent(file: string): string {
+  return existsSync(file) ? readFileSync(file, "utf8") : "";
+}
+
+async function waitForEvent(predicate: () => boolean, timeoutMs: number, description: string): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for ${description} after ${timeoutMs}ms`);
+}
+
+function positiveIntegerEnv(name: string, fallback: number): number {
+  const parsed = Number(process.env[name]);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }

--- a/tools/check-supply-chain.mjs
+++ b/tools/check-supply-chain.mjs
@@ -10,9 +10,25 @@ const root = process.cwd();
 const errors = [];
 const policy = harnessSupplyChainReleaseReadiness;
 const DEFAULT_COMMAND_TIMEOUT_MS = 60_000;
-const commandTimeoutMs = shorterPositiveTimeout(
+const MAX_COMMAND_TIMEOUT_MS = 180_000;
+const DEFAULT_NETWORK_BUDGET_MS = 180_000;
+const MAX_NETWORK_BUDGET_MS = 300_000;
+const DEFAULT_NETWORK_ATTEMPTS = 2;
+const MAX_NETWORK_ATTEMPTS = 3;
+const commandTimeoutMs = boundedPositiveInteger(
   process.env.HARNESS_SUPPLY_CHAIN_COMMAND_TIMEOUT_MS,
-  DEFAULT_COMMAND_TIMEOUT_MS
+  DEFAULT_COMMAND_TIMEOUT_MS,
+  MAX_COMMAND_TIMEOUT_MS
+);
+const networkBudgetMs = boundedPositiveInteger(
+  process.env.HARNESS_SUPPLY_CHAIN_NETWORK_BUDGET_MS,
+  DEFAULT_NETWORK_BUDGET_MS,
+  MAX_NETWORK_BUDGET_MS
+);
+const networkAttempts = boundedPositiveInteger(
+  process.env.HARNESS_SUPPLY_CHAIN_NETWORK_ATTEMPTS,
+  DEFAULT_NETWORK_ATTEMPTS,
+  MAX_NETWORK_ATTEMPTS
 );
 const manifestGateRunner = "node tools/run-manifest-gates.mjs";
 const gateManifest = existsSync(path.join(root, "tools/gate-manifest.json"))
@@ -36,42 +52,61 @@ function requireIncludes(file, text, description = text) {
   if (!body.includes(normalizeText(text))) record(`${file} must mention ${description}`);
 }
 
-function run(command) {
+function runNetworkCommand(command, phase, networkStartedAt) {
   const [binary, ...args] = command.split(" ");
-  const result = spawnSync(binary, args, {
-    cwd: root,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-    timeout: commandTimeoutMs,
-    killSignal: "SIGKILL"
-  });
+  for (let attempt = 1; attempt <= networkAttempts; attempt += 1) {
+    const remainingMs = networkBudgetMs - (Date.now() - networkStartedAt);
+    if (remainingMs <= 0) {
+      record(`[phase=${phase}] ${command} exhausted the ${networkBudgetMs}ms network budget before attempt ${attempt}`);
+      return "";
+    }
+    const attemptTimeoutMs = Math.min(commandTimeoutMs, remainingMs);
+    const result = spawnSync(binary, args, {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: attemptTimeoutMs,
+      killSignal: "SIGKILL",
+      detached: process.platform !== "win32"
+    });
+    const receipt = `phase=${phase} attempt=${attempt}/${networkAttempts} timeoutMs=${attemptTimeoutMs}`;
 
-  if (result.error?.code === "ETIMEDOUT") {
-    record(`${command} timed out after ${commandTimeoutMs}ms`);
-    return "";
-  }
-  if (result.error) {
-    record(`${command} failed to start: ${result.error.message}`);
-    return "";
-  }
-  if (result.signal !== null) {
-    record(`${command} terminated by signal ${result.signal}`);
-    return "";
-  }
-  if (result.status !== 0) {
-    const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
-    record(`${command} failed${output ? `:\n${output}` : ""}`);
-    return "";
-  }
+    if (result.error?.code === "ETIMEDOUT") {
+      const processReceipt = result.pid === undefined
+        ? "processGroup=unknown"
+        : `processGroup=${result.pid}`;
+      if (attempt < networkAttempts && Date.now() - networkStartedAt < networkBudgetMs) {
+        console.error(`[supply-chain] ${receipt} status=timeout-retry ${processReceipt} termination=SIGKILL`);
+        continue;
+      }
+      record(`[${receipt}] ${command} timed out; ${processReceipt} termination=SIGKILL`);
+      return "";
+    }
+    if (result.error) {
+      record(`[${receipt}] ${command} failed to start: ${result.error.message}`);
+      return "";
+    }
+    if (result.signal !== null) {
+      record(`[${receipt}] ${command} terminated by signal ${result.signal}`);
+      return "";
+    }
+    if (result.status !== 0) {
+      const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+      record(`[${receipt}] ${command} failed${output ? `:\n${output}` : ""}`);
+      return "";
+    }
 
-  return result.stdout;
+    console.log(`[supply-chain] ${receipt} status=completed`);
+    return result.stdout;
+  }
+  return "";
 }
 
-function shorterPositiveTimeout(value, fallback) {
+function boundedPositiveInteger(value, fallback, maximum) {
   if (value === undefined || value === "") return fallback;
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) return fallback;
-  return Math.min(parsed, fallback);
+  return Math.min(parsed, maximum);
 }
 
 const policyValidation = validateSupplyChainReleaseReadiness(policy);
@@ -84,12 +119,18 @@ validatePackageLock();
 validateDependabot();
 validateDocsAndWorkflow();
 
-for (const command of policy.auditCommands) {
-  run(command.command);
-}
+// Local release-contract failures are complete evidence on their own. Keep the
+// network-dependent npm lane isolated so a local fixture or metadata failure
+// never waits on registry availability.
+if (errors.length === 0) {
+  const networkStartedAt = Date.now();
+  for (const [index, command] of policy.auditCommands.entries()) {
+    runNetworkCommand(command.command, `audit-${index + 1}`, networkStartedAt);
+  }
 
-const sbomOutput = run(policy.sbom.generationCommand);
-if (sbomOutput) validateSbom(sbomOutput);
+  const sbomOutput = runNetworkCommand(policy.sbom.generationCommand, "sbom", networkStartedAt);
+  if (sbomOutput) validateSbom(sbomOutput);
+}
 
 if (errors.length > 0) {
   console.error("Supply chain check failed:");

--- a/tools/check-supply-chain.test.mjs
+++ b/tools/check-supply-chain.test.mjs
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -18,6 +18,20 @@ test("supply-chain check accepts the expected release gate contract", async () =
 
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /Supply chain check passed/u);
+    assert.match(result.stdout, /phase=sbom .*status=completed/u);
+  });
+});
+
+test("supply-chain check accepts an explicitly wider fail-closed command timeout", async () => {
+  await withFixtureRepo((root) => {
+    writeValidSupplyChainFixture(root);
+
+    const result = runCheck(root, {
+      env: { HARNESS_SUPPLY_CHAIN_COMMAND_TIMEOUT_MS: "120000" }
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /phase=audit-1 .*timeoutMs=120000 .*status=completed/u);
   });
 });
 
@@ -258,22 +272,46 @@ test("supply-chain check rejects Dependabot directory under wrong ecosystem", as
   });
 });
 
-test("supply-chain check reports a bounded npm command timeout", async (t) => {
+test("supply-chain check isolates local contract failures from npm commands", async () => {
   await withFixtureRepo((root) => {
-    writeValidSupplyChainFixture(root, { hangNpmCommand: "sbom --sbom-format=cyclonedx --sbom-type=application" });
-    const startedAt = Date.now();
-
-    const result = runCheck(root, {
-      env: { HARNESS_SUPPLY_CHAIN_COMMAND_TIMEOUT_MS: "2000" },
-      timeoutMs: 10_000
+    const invocationLogPath = path.join(root, "npm-invocations.log");
+    writeValidSupplyChainFixture(root, {
+      dependabotBody: validDependabot().replace('package-ecosystem: "npm"', 'package-ecosystem: "github-actions"'),
+      invocationLogPath
     });
-    const elapsedMs = Date.now() - startedAt;
+
+    const result = runCheck(root);
 
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /npm sbom --sbom-format=cyclonedx --sbom-type=application timed out after 2000ms/u);
-    assert.doesNotMatch(result.stderr, /npm audit .* timed out/u);
-    assert.equal(elapsedMs < 9_000, true, `bounded supply-chain check took ${elapsedMs}ms\n${result.stderr}`);
-    t.diagnostic(`timeout control completed in ${elapsedMs}ms: ${result.stderr.trim()}`);
+    assert.match(result.stderr, /must cover npm directory/u);
+    assert.equal(existsSync(invocationLogPath), false, "local contract failure must not enter the npm network phase");
+  });
+});
+
+test("supply-chain check reports a bounded npm command timeout", async (t) => {
+  await withFixtureRepo((root) => {
+    const hangPidPath = path.join(root, "hanging-npm.pid");
+    writeValidSupplyChainFixture(root, {
+      hangNpmCommand: "sbom --sbom-format=cyclonedx --sbom-type=application",
+      hangPidPath
+    });
+
+    const result = runCheck(root, {
+      env: {
+        HARNESS_SUPPLY_CHAIN_COMMAND_TIMEOUT_MS: "5000",
+        HARNESS_SUPPLY_CHAIN_NETWORK_BUDGET_MS: "11000"
+      },
+      timeoutMs: 20_000
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /phase=sbom attempt=2\/2 .*timed out/u);
+    assert.match(result.stderr, /termination=SIGKILL/u);
+    assert.doesNotMatch(result.stderr, /phase=audit-.*timed out/u);
+    const hangingPid = Number(readFileSync(hangPidPath, "utf8"));
+    assert.equal(processGroupExists(hangingPid), false, `hanging npm process group ${hangingPid} must be gone`);
+    t.diagnostic(`timeout receipt: ${result.stderr.trim()}`);
+    t.diagnostic(`process group gone: ${hangingPid}`);
   });
 });
 
@@ -389,7 +427,7 @@ function writeValidSupplyChainFixture(root, options = {}) {
   writeFile(root, ".github/workflows/rewrite-ci.yml", options.workflowBody ?? validWorkflow());
   writeFile(root, "README.md", validReadme());
   writeFile(root, "docs-release/release-posture.md", options.supplyDocBody ?? validSupplyDoc());
-  writeMockNpm(root, options.sbomMutator, options.hangNpmCommand);
+  writeMockNpm(root, options);
 }
 
 function validReadme() {
@@ -439,15 +477,20 @@ function validWorkflow() {
   ].join("\n");
 }
 
-function writeMockNpm(root, sbomMutator, hangNpmCommand) {
+function writeMockNpm(root, options) {
   const mockPath = path.join(root, ".mock-bin/npm");
   const sbomValue = validSbom();
-  sbomMutator?.(sbomValue);
+  options.sbomMutator?.(sbomValue);
   const sbom = JSON.stringify(sbomValue);
   writeFile(root, ".mock-bin/npm", [
     "#!/usr/bin/env node",
+    "const { appendFileSync, writeFileSync } = require('node:fs');",
     "const args = process.argv.slice(2).join(' ');",
-    `if (args === ${JSON.stringify(hangNpmCommand)}) { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0); }`,
+    ...(options.invocationLogPath ? [`appendFileSync(${JSON.stringify(options.invocationLogPath)}, args + '\\n');`] : []),
+    `if (args === ${JSON.stringify(options.hangNpmCommand)}) {`,
+    ...(options.hangPidPath ? [`  writeFileSync(${JSON.stringify(options.hangPidPath)}, String(process.pid));`] : []),
+    "  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);",
+    "}",
     "if (args === 'audit --audit-level=high' || args === 'audit --omit=dev --audit-level=high') {",
     "  console.log('found 0 vulnerabilities');",
     "  process.exit(0);",
@@ -460,6 +503,23 @@ function writeMockNpm(root, sbomMutator, hangNpmCommand) {
     "process.exit(1);"
   ].join("\n"));
   chmodSync(mockPath, 0o755);
+}
+
+function processGroupExists(pid) {
+  if (process.platform === "win32") {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function validSbom() {


### PR DESCRIPTION
# English

## Summary

Three representative CI tests stopped asserting wall-clock budgets as correctness. This is the pilot batch of the event-convergence doctrine adopted for the repo-wide family of 125 fixed wall-clock assertion anchors (inventoried under the governing task): correctness is judged by event/state convergence, each async chain keeps exactly one outer, configurable, fail-closed hang budget, and network subprocesses get bounded retries with phase reporting. Each conversion ships a positive control and a negative control proving the fail-closed budget still fires when the awaited event never happens.

## What Changed

- `packages/cli/test/daemon-refresh-preflight.test.ts`: refresh correctness now follows the event sequence accepted → drain/preflight complete → old-owner exited → replacement ready, instead of racing a 35s RPC budget on a loaded runner; the outer test budget defaults to 180s and is overridable via `HARNESS_TEST_DAEMON_REFRESH_TIMEOUT_MS`. Negative control: a stuck drain reports `daemon_queue_drain_timeout` and leaves the old owner alive.
- `tools/check-supply-chain.mjs` + test: local contract failures no longer launch network npm commands; networked commands (audit/SBOM) retry boundedly within the outer budget and report their phase; `HARNESS_SUPPLY_CHAIN_COMMAND_TIMEOUT_MS` may now widen the per-command timeout explicitly in CI but stays fail-closed under a 180s hard cap. The hang-fixture negative control (kill via SIGKILL, process group gone) is preserved; the flaky "bounded npm command timeout" case no longer asserts host elapsed time.
- `packages/cli/test/write-lock-retry-cli.test.ts`: the fixed 2.5s bare sleep before releasing the contended lock is replaced by a lock-wait barrier derived from journal observation; negative control proves the barrier fails closed instead of hanging.
- No production defaults, daemon production code, or CI workflow configuration changed.

## Task And Scope

- Harness task: task_01KY5A2FPV8NA5YX8PBWA27YMH (CI-T2, private ledger); decision dec_01KY5FHQT3HWVZXBE44870TR6Z
- Branch: codex/ci-t2-pilot
- Public scope: packages/cli/test/daemon-refresh-preflight.test.ts, packages/cli/test/write-lock-retry-cli.test.ts, tools/check-supply-chain.mjs, tools/check-supply-chain.test.mjs
- Private planning/evidence updated: yes
- Out of scope: the remaining ~120 anchors (later batches), production timeout defaults (D01–D03, decision-gated), CI workflow configuration

## Version Impact

- Version: no version change because only tests and a check tool changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: tools/check-supply-chain.mjs (supply-chain gate tool)
- Authority: decision dec_01KY5FHQT3HWVZXBE44870TR6Z; task task_01KY5A2FPV8NA5YX8PBWA27YMH
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: f57493386141397295cd52511f5ca48c1d48120a
- Branch merge-base with `origin/main`: f57493386141397295cd52511f5ca48c1d48120a
- Last `git fetch origin` time: 2026-07-22T19:02Z
- Sync method: rebase
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: private ledger CI-T2 task package
- Reviewer evidence path: private ledger CI-T2 task package
- GitHub Actions `rewrite-ci` run URL: pending (added after push)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:check-package-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: itemized remainder — `npm run check:local` ran the 34-gate manifest with affected contract tests 305/305 pass; targeted tiers 641/641 (packages/cli) and 61/61 (tools) pass; the full matrix belongs to GitHub CI

## Review Evidence

- Self-review: each conversion carries a positive control (normal convergence green) and a negative control (event never fires → the fail-closed budget reds, no hang); production defaults grep-verified untouched
- Reviewer subagent: none (bounded review policy; changes are test/tool-side with negative controls as invariant evidence)
- Human review: pending
- Blocking findings: none

## Residual Risk

- The remaining anchors of the family stay budget-sensitive until later batches land; known flaky members are registered in tools/flake-registry.json.

## References

- Task: task_01KY5A2FPV8NA5YX8PBWA27YMH (private ledger)
- Evidence: private ledger CI-T2 task package (wall-clock-assertion-inventory.md)
- Review: private ledger CI-T2 task package

---

# 中文

## 概要

三条代表性 CI 测试不再把墙钟预算当正确性断言。这是全库 125 个固定墙钟断言锚点(清点在治理任务台账内)所采纳「事件收敛制」的试点批:正确性由事件/状态收敛判定;每条异步链只保留一个外层、可配置、fail-closed 的挂死预算;联网子进程在外层预算内有界重试并报告 phase。每条改造都带阳性对照与阴性对照(所等事件永不发生时,兜底预算必须红)。

## 改动内容

- `packages/cli/test/daemon-refresh-preflight.test.ts`:refresh 正确性改为事件序 accepted → drain/preflight 完成 → 旧 owner 退出 → 替身就绪,不再与高负载 runner 上的 35s RPC 预算赛跑;外层测试兜底默认 180s,`HARNESS_TEST_DAEMON_REFRESH_TIMEOUT_MS` 可覆盖。阴性对照:卡死的 drain 报 `daemon_queue_drain_timeout` 且旧 owner 保持存活。
- `tools/check-supply-chain.mjs` 及测试:本地契约失败不再启动联网 npm 命令;联网命令(audit/SBOM)在外层预算内有界重试并报 phase;`HARNESS_SUPPLY_CHAIN_COMMAND_TIMEOUT_MS` 现可在 CI 显式放宽单命令超时,但受 180s 硬上限约束、保持 fail-closed;挂死 fixture 阴性对照(SIGKILL、进程组消失)保留;屡红的「bounded npm command timeout」用例不再断言宿主耗时。
- `packages/cli/test/write-lock-retry-cli.test.ts`:释放争用锁前的固定 2.5s 裸等待改为由 journal 观测派生的 lock-wait barrier;阴性对照证明 barrier 失败时收口而非挂死。
- 不动生产默认、daemon 生产代码与 CI workflow 配置。

## 任务与范围

- Harness 任务:task_01KY5A2FPV8NA5YX8PBWA27YMH(CI-T2,私有台账);决策 dec_01KY5FHQT3HWVZXBE44870TR6Z
- 分支:codex/ci-t2-pilot
- 公开范围:packages/cli/test/daemon-refresh-preflight.test.ts、packages/cli/test/write-lock-retry-cli.test.ts、tools/check-supply-chain.mjs、tools/check-supply-chain.test.mjs
- 私有计划 / 证据是否已更新:yes
- 范围外:族内其余约 120 个锚点(后续批次)、生产超时默认值(D01-D03,须另行 decision)、CI workflow 配置

## 版本影响

- 版本:不改版本,原因是只改测试与检查工具
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:tools/check-supply-chain.mjs(供应链门工具)
- 依据:决策 dec_01KY5FHQT3HWVZXBE44870TR6Z;任务 task_01KY5A2FPV8NA5YX8PBWA27YMH
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:f57493386141397295cd52511f5ca48c1d48120a
- 当前分支与 `origin/main` 的 merge-base:f57493386141397295cd52511f5ca48c1d48120a
- 最近一次 `git fetch origin` 时间:2026-07-22T19:02Z
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:私有台账 CI-T2 任务包
- Reviewer 证据路径:私有台账 CI-T2 任务包
- GitHub Actions `rewrite-ci` run URL:push 后补充
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:check-package-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:其余逐项——`npm run check:local` 已跑 34 门 manifest、受影响契约测试 305/305;定向层 641/641(packages/cli)与 61/61(tools)通过;完整矩阵归 GitHub CI

## 审查证据

- 自查:每条改造带阳性对照(正常收敛绿)与阴性对照(事件永不发生→兜底预算红、不挂死);grep 验证生产默认未动
- Reviewer subagent:无(有界评审政策;测试/工具面改动,阴性对照即不变量证据)
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 族内其余锚点在后续批次落地前仍预算敏感;已知 flaky 成员登记于 tools/flake-registry.json。

## 关联材料

- 任务:task_01KY5A2FPV8NA5YX8PBWA27YMH(私有台账)
- 证据:私有台账 CI-T2 任务包(wall-clock-assertion-inventory.md)
- 审查:私有台账 CI-T2 任务包
