### PR TITLE
docs(preset): stop advertising the retired progress template

### DIFF
--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/docs-task/PRESET.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/docs-task/PRESET.md
@@ -1,6 +1,6 @@
 ---
 schema: preset-document/v1
-description: Create the planning, progress, review, evidence, and closeout package for design, documentation, or chore work that produces no code commit.
+description: Create the planning, facts, and closeout scaffold for design, documentation, or chore work that produces no code commit.
 whenToUse: Use for pure design, documentation, research, or chore tasks whose deliverable is a document or decision rather than code, so completion is gated on a real closeout and an approved review instead of CI or code-doc reconciliation.
 ---
 

--- a/packages/cli/src/commands/extensions/assets/software-coding/presets/standard-task/PRESET.md
+++ b/packages/cli/src/commands/extensions/assets/software-coding/presets/standard-task/PRESET.md
@@ -1,6 +1,6 @@
 ---
 schema: preset-document/v1
-description: Create the standard planning, progress, review, evidence, and closeout package for general software work.
+description: Create the standard planning, facts, and closeout scaffold for general software work.
 whenToUse: Use for ordinary implementation, maintenance, refactoring, documentation, or test work when no narrower preset fits.
 ---
 

--- a/packages/cli/test/package-surface.test.ts
+++ b/packages/cli/test/package-surface.test.ts
@@ -174,6 +174,13 @@ test("bundled software coding assets have consistent template and process-preset
     assert.deepEqual(document.warnings, [], `${presetId} must ship valid PRESET.md frontmatter`);
     assert.equal(document.frontmatter?.schema, "preset-document/v1", presetId);
     assert.equal((document.frontmatter?.description.length ?? 0) > 0, true, presetId);
+    if (presetId === "standard-task" || presetId === "docs-task") {
+      assert.doesNotMatch(
+        document.frontmatter?.description ?? "",
+        /\b(?:progress|review)\b/u,
+        `${presetId} description must not advertise retired progress.md or review.md scaffold files`
+      );
+    }
     assert.deepEqual(
       Object.keys(document.frontmatter?.entrypoints ?? {}).sort(),
       Object.keys(manifest.entrypoints ?? {}).sort(),


### PR DESCRIPTION
# English

## Summary

The coding presets stopped generating a `progress.md` scaffold in an earlier change (25bf8652), but two preset documents still promised the retired template to users, and nothing guarded against the stale claim coming back. This lands the honest residue of the approved template removal: corrected preset descriptions and a regression test pinning the generated-file list.

## What Changed

- `packages/cli/src/commands/extensions/assets/software-coding/presets/standard-task/PRESET.md` and `docs-task/PRESET.md`: removed the outdated claim that the scaffold generates progress/review templates.
- `packages/cli/test/package-surface.test.ts`: asserts the two presets no longer advertise retired template files.
- The historical `progress@1` catalog entry is deliberately kept so existing task contracts keep validating; the progress append data path is untouched (proven by a live create + append walkthrough).

## Task And Scope

- Harness task: task_01KY5KNWZS98ERK8H4YYC15W93 (private ledger)
- Branch: codex/progress-md-removal
- Public scope: two PRESET.md assets, packages/cli/test/package-surface.test.ts
- Private planning/evidence updated: yes
- Out of scope: existing task packages (all 776 untouched), progress append machinery, preset catalog history

## Version Impact

- Version: no version change because only preset descriptions and a test changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task task_01KY5KNWZS98ERK8H4YYC15W93 (approved template removal)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 1b52813d32a7be0d4eadfbc10bce860e53353e7a
- Branch merge-base with `origin/main`: 1b52813d32a7be0d4eadfbc10bce860e53353e7a
- Last `git fetch origin` time: 2026-07-22T19:35Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: private ledger task package
- Reviewer evidence path: private ledger task package
- GitHub Actions `rewrite-ci` run URL: pending (added after push)
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:check-package-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: itemized remainder — `npm run check:local` ran the 34-gate manifest (affected fast 354/354, contract 82/82); targeted integration 641/641; usage proof: a live `ha task create` generates no progress.md and `progress append` still succeeds; the full matrix belongs to GitHub CI

## Review Evidence

- Self-review: premise verified against main before implementing — the scaffold removal itself already landed as 25bf8652, so this PR carries only the residual stale descriptions and the guard test
- Reviewer subagent: none (docs + one test)
- Human review: pending
- Blocking findings: none

## Residual Risk

- None beyond normal: data path proven live; retired template list is now pinned by test.

## References

- Task: task_01KY5KNWZS98ERK8H4YYC15W93 (private ledger)
- Evidence: private ledger task package
- Review: private ledger task package

---

# 中文

## 概要

coding preset 在更早的变更(25bf8652)中已停止生成 `progress.md` 脚手架,但两个 preset 文档仍向用户宣称会生成该已退役模板,且没有任何守卫防止过时声明回潮。本 PR 落地已批准的模板删除的诚实残量:修正 preset 描述并加回归测试钉住生成文件清单。

## 改动内容

- `standard-task/PRESET.md` 与 `docs-task/PRESET.md`:删除「会生成 progress/review 模板」的过时声明。
- `packages/cli/test/package-surface.test.ts`:断言两个 preset 不再宣传已退役模板文件。
- 历史 `progress@1` catalog 条目刻意保留,维持存量 task-contract 校验;progress append 数据通道未动(create+append 实测走通)。

## 任务与范围

- Harness 任务:task_01KY5KNWZS98ERK8H4YYC15W93(私有台账)
- 分支:codex/progress-md-removal
- 公开范围:两个 PRESET.md 资产、packages/cli/test/package-surface.test.ts
- 私有计划 / 证据是否已更新:yes
- 范围外:存量任务包(776 个全不动)、progress append 机制、preset catalog 历史

## 版本影响

- 版本:不改版本,原因是只改 preset 描述与一个测试
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 task_01KY5KNWZS98ERK8H4YYC15W93(已批准的模板删除)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:1b52813d32a7be0d4eadfbc10bce860e53353e7a
- 当前分支与 `origin/main` 的 merge-base:1b52813d32a7be0d4eadfbc10bce860e53353e7a
- 最近一次 `git fetch origin` 时间:2026-07-22T19:35Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:私有台账任务包
- Reviewer 证据路径:私有台账任务包
- GitHub Actions `rewrite-ci` run URL:push 后补充
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:check-package-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:其余逐项——`npm run check:local` 已跑 34 门 manifest(affected fast 354/354、contract 82/82);定向 integration 641/641;使用证明:实测 `ha task create` 不再生成 progress.md 且 `progress append` 成功;完整矩阵归 GitHub CI

## 审查证据

- 自查:实现前先对 main 证伪前提——scaffold 删除本体已由 25bf8652 落地,本 PR 只携带残留过时描述与守卫测试
- Reviewer subagent:无(文档+单测试)
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 无超出常规:数据通道实测走通;退役模板清单已被测试钉住。

## 关联材料

- 任务:task_01KY5KNWZS98ERK8H4YYC15W93(私有台账)
- 证据:私有台账任务包
- 审查:私有台账任务包
