### PR TITLE
ci: notify on a red main without touching enforcement

### DIFF
--- a/.github/workflows/main-red-notify.yml
+++ b/.github/workflows/main-red-notify.yml
@@ -1,0 +1,119 @@
+name: main-red-notify
+
+on:
+  workflow_run:
+    workflows: ["rewrite-ci"]
+    branches: [main]
+    types: [completed]
+
+permissions:
+  actions: read
+  issues: write
+
+concurrency:
+  group: main-red-notify
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Open, update, or resolve the main-red advisory issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'main-red';
+            const title = '[CI] rewrite-ci is red on main';
+            const run = context.payload.workflow_run;
+            const { owner, repo } = context.repo;
+            const clean = (value) => String(value).replace(/[\r\n]+/g, ' ').trim();
+            const shaMarker = `<!-- main-red-sha:${clean(run.head_sha)} -->`;
+            const runMarker = `<!-- main-red-run:${clean(run.id)} -->`;
+            const recordedRunId = (issue) => {
+              const match = (issue.body || '').match(/<!-- main-red-run:(\d+) -->/);
+              return match ? Number(match[1]) : null;
+            };
+            const isStale = (issue) => {
+              const recorded = recordedRunId(issue);
+              return recorded !== null && recorded > Number(run.id);
+            };
+            const listed = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: label,
+              per_page: 100
+            });
+            const openIssues = listed.filter((issue) => !issue.pull_request);
+
+            if (run.conclusion === 'success') {
+              const comment = `rewrite-ci is green again on main for \`${clean(run.head_sha)}\`: ${clean(run.html_url)}. Closing this advisory issue.`;
+              const eligibleIssues = openIssues.filter((issue) => !isStale(issue));
+              for (const issue of eligibleIssues) {
+                await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body: comment });
+                await github.rest.issues.update({ owner, repo, issue_number: issue.number, state: 'closed', state_reason: 'completed' });
+              }
+              core.info(`Resolved ${eligibleIssues.length} open ${label} issue(s); ignored ${openIssues.length - eligibleIssues.length} newer failure(s).`);
+              return;
+            }
+
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner,
+              repo,
+              run_id: run.id,
+              filter: 'latest',
+              per_page: 100
+            });
+            const failedJobs = [...new Set(jobs.filter((job) => job.conclusion === 'failure').map((job) => clean(job.name)).filter(Boolean))];
+            const jobLines = failedJobs.length > 0
+              ? failedJobs.map((name) => `- ${name}`)
+              : ['- Unable to identify a failed job from the run API.'];
+            const body = [
+              '<!-- main-red-notification -->',
+              runMarker,
+              shaMarker,
+              '## rewrite-ci is red on main',
+              '',
+              `- Run: ${clean(run.html_url)}`,
+              `- Head SHA: \`${clean(run.head_sha)}\``,
+              '- Failed jobs:',
+              ...jobLines,
+              '',
+              'This issue is advisory only. It does not change required checks, branch protection, or merge enforcement.'
+            ].join('\n');
+            const current = openIssues[0];
+
+            if (!current) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({ owner, repo, name: label, color: 'b60205', description: 'rewrite-ci is red on main' });
+              }
+              const created = await github.rest.issues.create({ owner, repo, title, body, labels: [label] });
+              core.info(`Opened ${created.data.html_url}.`);
+              return;
+            }
+
+            if (isStale(current)) {
+              core.info(`Issue #${current.number} records a newer workflow run; stale failure ${run.id} ignored.`);
+              return;
+            }
+
+            if ((current.body || '').includes(shaMarker) && recordedRunId(current) === Number(run.id)) {
+              core.info(`Issue #${current.number} already records ${run.head_sha}; no duplicate created.`);
+              return;
+            }
+
+            if (!(current.body || '').includes(shaMarker)) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: current.number,
+                body: `rewrite-ci failed again on main: ${clean(run.html_url)} (\`${clean(run.head_sha)}\`). Updating the advisory issue.`
+              });
+            }
+            await github.rest.issues.update({ owner, repo, issue_number: current.number, title, body });
+            core.info(`Updated issue #${current.number}.`);

--- a/tools/main-red-notify.mjs
+++ b/tools/main-red-notify.mjs
@@ -1,0 +1,57 @@
+const notificationMarker = "<!-- main-red-notification -->";
+
+function cleanInline(value) {
+  return String(value).replace(/[\r\n]+/gu, " ").trim();
+}
+
+export const mainRedLabel = "main-red";
+export const mainRedIssueTitle = "[CI] rewrite-ci is red on main";
+
+export function mainRedShaMarker(headSha) {
+  return `<!-- main-red-sha:${cleanInline(headSha)} -->`;
+}
+
+export function mainRedRunMarker(runId) {
+  return `<!-- main-red-run:${cleanInline(runId)} -->`;
+}
+
+export function readMainRedRunId(issue) {
+  const match = typeof issue.body === "string" ? issue.body.match(/<!-- main-red-run:(\d+) -->/u) : null;
+  return match === null ? null : Number(match[1]);
+}
+
+export function buildMainRedIssueBody({ runId, runUrl, headSha, failedJobs }) {
+  const jobs = [...new Set(failedJobs.map(cleanInline).filter(Boolean))];
+  const jobLines = jobs.length > 0 ? jobs.map((name) => `- ${name}`) : ["- Unable to identify a failed job from the run API."];
+  return [
+    notificationMarker,
+    mainRedRunMarker(runId),
+    mainRedShaMarker(headSha),
+    "## rewrite-ci is red on main",
+    "",
+    `- Run: ${cleanInline(runUrl)}`,
+    `- Head SHA: \`${cleanInline(headSha)}\``,
+    "- Failed jobs:",
+    ...jobLines,
+    "",
+    "This issue is advisory only. It does not change required checks, branch protection, or merge enforcement."
+  ].join("\n");
+}
+
+export function buildMainRedRecoveryComment({ runUrl, headSha }) {
+  return `rewrite-ci is green again on main for \`${cleanInline(headSha)}\`: ${cleanInline(runUrl)}. Closing this advisory issue.`;
+}
+
+export function selectOpenMainRedIssues(issues) {
+  return issues.filter((issue) => issue.state === "open" && issue.pull_request === undefined &&
+    issue.labels.some((label) => (typeof label === "string" ? label : label.name) === mainRedLabel));
+}
+
+export function isIssueForHeadSha(issue, headSha) {
+  return typeof issue.body === "string" && issue.body.includes(mainRedShaMarker(headSha));
+}
+
+export function isStaleMainRedRun(issue, runId) {
+  const recordedRunId = readMainRedRunId(issue);
+  return recordedRunId !== null && recordedRunId > Number(runId);
+}

--- a/tools/main-red-notify.test.mjs
+++ b/tools/main-red-notify.test.mjs
@@ -1,0 +1,203 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  buildMainRedIssueBody,
+  buildMainRedRecoveryComment,
+  isIssueForHeadSha,
+  isStaleMainRedRun,
+  mainRedIssueTitle,
+  mainRedLabel,
+  readMainRedRunId,
+  selectOpenMainRedIssues
+} from "./main-red-notify.mjs";
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+function extractWorkflowScript() {
+  const workflow = readFileSync(new URL("../.github/workflows/main-red-notify.yml", import.meta.url), "utf8");
+  const lines = workflow.split("\n");
+  const marker = lines.findIndex((line) => line.trim() === "script: |");
+  assert.notEqual(marker, -1, "workflow must contain a github-script block");
+  return lines.slice(marker + 1).filter((line) => line.startsWith("            ")).map((line) => line.slice(12)).join("\n");
+}
+
+function workflowHarness({ conclusion, runId, headSha, openIssues = [], jobs = [] }) {
+  const calls = { comments: [], creates: [], labels: [], updates: [] };
+  const listForRepo = () => {};
+  const listJobsForWorkflowRun = () => {};
+  const github = {
+    paginate: async (endpoint) => endpoint === listForRepo ? openIssues : jobs,
+    rest: {
+      actions: { listJobsForWorkflowRun },
+      issues: {
+        listForRepo,
+        getLabel: async () => ({ data: { name: "main-red" } }),
+        createLabel: async (input) => { calls.labels.push(input); },
+        create: async (input) => {
+          calls.creates.push(input);
+          return { data: { html_url: "https://github.com/example/repo/issues/1" } };
+        },
+        createComment: async (input) => { calls.comments.push(input); },
+        update: async (input) => { calls.updates.push(input); }
+      }
+    }
+  };
+  const context = {
+    repo: { owner: "example", repo: "repo" },
+    payload: {
+      workflow_run: {
+        conclusion,
+        head_sha: headSha,
+        html_url: `https://github.com/example/repo/actions/runs/${runId}`,
+        id: runId
+      }
+    }
+  };
+  const core = { info: () => {} };
+  return {
+    calls,
+    run: async () => new AsyncFunction("github", "context", "core", extractWorkflowScript())(github, context, core)
+  };
+}
+
+test("failure issue content carries the run, failed jobs, SHA, and advisory boundary", () => {
+  const body = buildMainRedIssueBody({
+    runId: 42,
+    runUrl: "https://github.com/example/repo/actions/runs/42",
+    headSha: "abc123",
+    failedJobs: ["full-check (24)", "full-check (26)", "full-check (24)"]
+  });
+
+  assert.equal(mainRedLabel, "main-red");
+  assert.equal(mainRedIssueTitle, "[CI] rewrite-ci is red on main");
+  assert.match(body, /main-red-sha:abc123/u);
+  assert.match(body, /main-red-run:42/u);
+  assert.match(body, /actions\/runs\/42/u);
+  assert.equal(body.match(/full-check \(24\)/gu)?.length, 1);
+  assert.match(body, /full-check \(26\)/u);
+  assert.match(body, /advisory only/u);
+  assert.equal(isIssueForHeadSha({ body }, "abc123"), true);
+  assert.equal(isIssueForHeadSha({ body }, "def456"), false);
+  assert.equal(readMainRedRunId({ body }), 42);
+  assert.equal(isStaleMainRedRun({ body }, 41), true);
+  assert.equal(isStaleMainRedRun({ body }, 43), false);
+});
+
+test("legacy notification issues without a run marker remain eligible for recovery", () => {
+  const issue = { body: "<!-- main-red-notification -->" };
+  assert.equal(readMainRedRunId(issue), null);
+  assert.equal(isStaleMainRedRun(issue, 43), false);
+});
+
+test("open notification selection excludes pull requests, closed issues, and other labels", () => {
+  const issues = selectOpenMainRedIssues([
+    { number: 1, state: "open", labels: [{ name: "main-red" }] },
+    { number: 2, state: "closed", labels: [{ name: "main-red" }] },
+    { number: 3, state: "open", labels: ["main-red"], pull_request: { url: "https://example.test" } },
+    { number: 4, state: "open", labels: [{ name: "other" }] }
+  ]);
+
+  assert.deepEqual(issues.map((issue) => issue.number), [1]);
+});
+
+test("recovery comment identifies the successful run and head SHA", () => {
+  assert.equal(
+    buildMainRedRecoveryComment({ runUrl: "https://github.com/example/repo/actions/runs/43", headSha: "def456" }),
+    "rewrite-ci is green again on main for `def456`: https://github.com/example/repo/actions/runs/43. Closing this advisory issue."
+  );
+});
+
+test("workflow stays notify-only and uses the declared minimal permissions", () => {
+  const workflow = readFileSync(new URL("../.github/workflows/main-red-notify.yml", import.meta.url), "utf8");
+
+  assert.match(workflow, /workflow_run:/u);
+  assert.match(workflow, /workflows: \["rewrite-ci"\]/u);
+  assert.match(workflow, /branches: \[main\]/u);
+  assert.match(workflow, /types: \[completed\]/u);
+  assert.match(workflow, /permissions:\n  actions: read\n  issues: write/u);
+  assert.doesNotMatch(workflow, /pull_request:|continue-on-error|statuses\.create|checks\.create|merge-queue|\.mergify/u);
+  assert.doesNotMatch(workflow, /actions\/checkout/u);
+  assert.doesNotThrow(() => new AsyncFunction("github", "context", "core", extractWorkflowScript()));
+});
+
+test("workflow failure path creates the locally tested issue content", async () => {
+  const harness = workflowHarness({
+    conclusion: "failure",
+    runId: 42,
+    headSha: "abc123",
+    jobs: [
+      { name: "full-check (24)", conclusion: "failure" },
+      { name: "full-check (26)", conclusion: "success" }
+    ]
+  });
+  await harness.run();
+
+  assert.equal(harness.calls.creates.length, 1);
+  assert.equal(harness.calls.creates[0].title, mainRedIssueTitle);
+  assert.deepEqual(harness.calls.creates[0].labels, [mainRedLabel]);
+  assert.equal(harness.calls.creates[0].body, buildMainRedIssueBody({
+    runId: 42,
+    runUrl: "https://github.com/example/repo/actions/runs/42",
+    headSha: "abc123",
+    failedJobs: ["full-check (24)"]
+  }));
+});
+
+test("workflow does not duplicate the same run and ignores stale completions", async () => {
+  const currentBody = buildMainRedIssueBody({
+    runId: 42,
+    runUrl: "https://github.com/example/repo/actions/runs/42",
+    headSha: "abc123",
+    failedJobs: ["full-check (24)"]
+  });
+  const duplicate = workflowHarness({
+    conclusion: "failure",
+    runId: 42,
+    headSha: "abc123",
+    openIssues: [{ number: 1, body: currentBody }],
+    jobs: [{ name: "full-check (24)", conclusion: "failure" }]
+  });
+  await duplicate.run();
+  assert.deepEqual(duplicate.calls.creates, []);
+  assert.deepEqual(duplicate.calls.updates, []);
+
+  const staleSuccess = workflowHarness({
+    conclusion: "success",
+    runId: 41,
+    headSha: "older",
+    openIssues: [{ number: 1, body: currentBody }]
+  });
+  await staleSuccess.run();
+  assert.deepEqual(staleSuccess.calls.comments, []);
+  assert.deepEqual(staleSuccess.calls.updates, []);
+});
+
+test("workflow closes an open advisory issue after a newer green run", async () => {
+  const failureBody = buildMainRedIssueBody({
+    runId: 42,
+    runUrl: "https://github.com/example/repo/actions/runs/42",
+    headSha: "abc123",
+    failedJobs: ["full-check (24)"]
+  });
+  const harness = workflowHarness({
+    conclusion: "success",
+    runId: 43,
+    headSha: "def456",
+    openIssues: [{ number: 1, body: failureBody }]
+  });
+  await harness.run();
+
+  assert.equal(harness.calls.comments[0].body, buildMainRedRecoveryComment({
+    runUrl: "https://github.com/example/repo/actions/runs/43",
+    headSha: "def456"
+  }));
+  assert.deepEqual(harness.calls.updates[0], {
+    owner: "example",
+    repo: "repo",
+    issue_number: 1,
+    state: "closed",
+    state_reason: "completed"
+  });
+});

--- a/tools/main-watch.mjs
+++ b/tools/main-watch.mjs
@@ -13,6 +13,7 @@ const registryEntryFields = Object.freeze(["testName", "file", "anchoredTask", "
 const execFileAsync = promisify(execFile);
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const registryPath = path.join(repoRoot, "tools/flake-registry.json");
+const transientErrorPattern = /(?:\bEOF\b|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|ENETUNREACH|EPIPE|connection (?:reset|refused|failed)|network is unreachable|temporary failure|TLS handshake timeout|remote end hung up|unexpected end of JSON input|HTTP (?:502|503|504)|status code (?:502|503|504))/iu;
 
 function nonEmptyString(value) {
   return typeof value === "string" && value.trim().length > 0;
@@ -99,10 +100,41 @@ function result(code, classification, runUrl = "-", failingTests = []) {
   return { code, classification, runUrl, failingTests };
 }
 
-async function classifyCompletedRun(run, registry, github) {
+function errorText(error) {
+  if (!(error instanceof Error)) return String(error);
+  const details = [error.message, error.cause, error.code, error.stderr, error.stdout];
+  return details.filter((value) => value !== undefined && value !== null).map(String).join("\n");
+}
+
+export function isTransientGithubError(error) {
+  return transientErrorPattern.test(errorText(error));
+}
+
+const defaultSleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+export async function retryTransientGithubCall(operation, {
+  attempts = 5,
+  baseDelayMs = 250,
+  sleep = defaultSleep
+} = {}) {
+  if (!Number.isInteger(attempts) || attempts < 1) throw new Error("retry attempts must be a positive integer");
+  if (!Number.isFinite(baseDelayMs) || baseDelayMs < 0) throw new Error("retry base delay must be non-negative");
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!isTransientGithubError(error) || attempt === attempts) throw error;
+      await sleep(baseDelayMs * (2 ** (attempt - 1)));
+    }
+  }
+  throw new Error("unreachable retry state");
+}
+
+async function classifyCompletedRun(run, registry, github, retryOptions) {
   if (run.conclusion === "success") return result(0, "green", run.url);
   if (run.conclusion === "cancelled") {
-    const newerRuns = await github.listNewerMainRuns();
+    const newerRuns = await retryTransientGithubCall(() => github.listNewerMainRuns(), retryOptions);
     const supersedingRun = newerRuns.find((candidate) => candidate.createdAt > run.createdAt);
     return {
       ...result(50, "superseded", run.url),
@@ -111,15 +143,13 @@ async function classifyCompletedRun(run, registry, github) {
   }
   if (run.conclusion !== "failure") return result(40, "unavailable", run.url);
 
-  const parsedLogs = parseFailedLogs(await github.readFailedLogs(run.databaseId));
+  const parsedLogs = parseFailedLogs(await retryTransientGithubCall(() => github.readFailedLogs(run.databaseId), retryOptions));
   const { failingTests } = parsedLogs;
   const registeredNames = new Set(registry.entries.map((entry) => entry.testName));
   const allRegistered = !parsedLogs.hasUnparsedFailedJob && failingTests.length > 0 &&
     failingTests.every((testName) => registeredNames.has(testName));
   return result(allRegistered ? 20 : 30, allRegistered ? "flake" : "regression", run.url, failingTests);
 }
-
-const defaultSleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
 export async function watchMain({
   commitSha,
@@ -129,16 +159,20 @@ export async function watchMain({
   timeoutMs = 5_400_000,
   dryRun = false,
   now = Date.now,
-  sleep = defaultSleep
+  sleep = defaultSleep,
+  retryAttempts = 5,
+  retryBaseDelayMs = 250,
+  retrySleep = defaultSleep
 }) {
   const startedAt = now();
   let lastRun;
 
   while (true) {
-    const runs = await github.listRuns(commitSha);
+    const retryOptions = { attempts: retryAttempts, baseDelayMs: retryBaseDelayMs, sleep: retrySleep };
+    const runs = await retryTransientGithubCall(() => github.listRuns(commitSha), retryOptions);
     lastRun = runs.find((candidate) => candidate.event === "push" && candidate.headSha === commitSha);
     if (lastRun?.status === "completed") {
-      return classifyCompletedRun(lastRun, registry, github);
+      return classifyCompletedRun(lastRun, registry, github, retryOptions);
     }
     if (dryRun) {
       return result(40, lastRun ? "pending" : "run-missing", lastRun?.url);

--- a/tools/main-watch.test.mjs
+++ b/tools/main-watch.test.mjs
@@ -5,7 +5,14 @@ import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync 
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { formatResultLine, parseMainWatchArgs, resolveCommitSha, watchMain } from "./main-watch.mjs";
+import {
+  formatResultLine,
+  isTransientGithubError,
+  parseMainWatchArgs,
+  resolveCommitSha,
+  retryTransientGithubCall,
+  watchMain
+} from "./main-watch.mjs";
 
 const knownFlake = "daemon start service status and stop expose productized status contract";
 const failedLog = readFileSync(
@@ -180,6 +187,85 @@ test("a missing run is polled until timeout and exits unavailable", async () => 
     runUrl: "-",
     failingTests: []
   });
+});
+
+test("transient GitHub failures use bounded exponential retry before succeeding", async () => {
+  let calls = 0;
+  const delays = [];
+  const value = await retryTransientGithubCall(async () => {
+    calls += 1;
+    if (calls < 3) throw new Error("gh: failed to reach api.github.com: EOF");
+    return "ok";
+  }, {
+    attempts: 5,
+    baseDelayMs: 10,
+    sleep: async (delay) => { delays.push(delay); }
+  });
+
+  assert.equal(value, "ok");
+  assert.equal(calls, 3);
+  assert.deepEqual(delays, [10, 20]);
+});
+
+test("transient GitHub failures are rethrown only after five attempts", async () => {
+  let calls = 0;
+  await assert.rejects(
+    retryTransientGithubCall(async () => {
+      calls += 1;
+      const error = new Error("request failed");
+      error.code = "ECONNRESET";
+      throw error;
+    }, { attempts: 5, baseDelayMs: 0, sleep: async () => {} }),
+    /request failed/u
+  );
+  assert.equal(calls, 5);
+});
+
+test("non-transient GitHub failures are not retried", async () => {
+  let calls = 0;
+  await assert.rejects(
+    retryTransientGithubCall(async () => {
+      calls += 1;
+      throw new Error("HTTP 401: Bad credentials");
+    }, { sleep: async () => assert.fail("non-transient failures must not sleep") }),
+    /Bad credentials/u
+  );
+  assert.equal(calls, 1);
+  assert.equal(isTransientGithubError(new SyntaxError("Unexpected end of JSON input")), true);
+  assert.equal(isTransientGithubError(new Error("HTTP 401: Bad credentials")), false);
+});
+
+test("watchMain retries a transient list-runs error without changing the green result contract", async () => {
+  let calls = 0;
+  const result = await watchMain({
+    commitSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+    registry: { entries: [] },
+    retryBaseDelayMs: 0,
+    retrySleep: async () => {},
+    github: {
+      listRuns: async () => {
+        calls += 1;
+        if (calls === 1) throw new Error("connection failed: EOF");
+        return [{
+          databaseId: 1,
+          event: "push",
+          headSha: "37d234863f1bb06b7fa33e511d1558bc1394dc77",
+          status: "completed",
+          conclusion: "success",
+          url: "https://github.com/example/repo/actions/runs/1"
+        }];
+      }
+    }
+  });
+
+  assert.equal(calls, 2);
+  assert.deepEqual(result, {
+    code: 0,
+    classification: "green",
+    runUrl: "https://github.com/example/repo/actions/runs/1",
+    failingTests: []
+  });
+  assert.equal(formatResultLine(result), "RESULT: 0 green https://github.com/example/repo/actions/runs/1 -");
 });
 
 test("the CLI prints a machine-readable flake result and exits 20", { skip: process.platform === "win32" }, (t) => {


### PR DESCRIPTION
# English

## Summary

A red `full-check` on main has gone unnoticed twice, because it is not a required PR check and attaching the main-watch sentinel relied on operator memory. This adds a notify-only mechanism: when `rewrite-ci` completes on main with a failure, a workflow opens (or updates) a labeled advisory issue naming the run, head SHA, and failed jobs, and closes it when main goes green again. The main-watch CLI sentinel also stops dying on transient network errors. Nothing about enforcement changes: no required checks, no branch protection, no merge-queue behavior.

## What Changed

- New `.github/workflows/main-red-notify.yml`: `workflow_run` listener on `rewrite-ci`/main; failure → open or update the single `main-red` advisory issue (idempotent via run/SHA markers, stale-run guard); success → comment and close. Minimal permissions (`actions: read`, `issues: write`), 5-minute timeout, advisory-only wording in the issue body.
- New `tools/main-red-notify.mjs` + tests: the issue-body construction logic extracted so it is unit-testable.
- `tools/main-watch.mjs`: transient API errors (EOF, connection resets) now retry boundedly with backoff instead of exiting 40 on the first hiccup (observed three consecutive sentinel deaths in one night from local network jitter); exit-code semantics and the `RESULT:` line contract are unchanged.

## Task And Scope

- Harness task: task_01KY5A3E926RA1DXK445G5D3M6 (CI-T3, private ledger); decision dec_01KY5QGNH0SHJDZ88Q9HGMF6RX
- Branch: codex/ci-t3-main-red-notify
- Public scope: .github/workflows/main-red-notify.yml, tools/main-red-notify.mjs, tools/main-red-notify.test.mjs, tools/main-watch.mjs, tools/main-watch.test.mjs
- Private planning/evidence updated: yes
- Out of scope: required-check set, branch protection, .mergify.yml, any existing workflow job (a separate decision governs any future required-check promotion)

## Version Impact

- Version: no version change because only CI notification and a watch tool changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: .github/workflows/ (new notify-only workflow file), tools/main-watch.mjs
- Authority: decision dec_01KY5QGNH0SHJDZ88Q9HGMF6RX; task task_01KY5A3E926RA1DXK445G5D3M6
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 6020fdab71c5274ac3f39e64498b4e2d4346c1f6
- Branch merge-base with `origin/main`: 6020fdab71c5274ac3f39e64498b4e2d4346c1f6
- Last `git fetch origin` time: 2026-07-22T21:21Z
- Sync method: rebase
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: private ledger CI-T3 task package
- Reviewer evidence path: private ledger CI-T3 task package
- GitHub Actions `rewrite-ci` run URL: pending (added after push)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:check-package-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local gate matrix — per the derived stop point, targeted tests ran locally (23/23 across the new notify and hardened main-watch tests, YAML parse, ESLint, complexity, diff check); the workflow itself cannot execute locally — its first main run after merge is the usage proof; the full matrix belongs to GitHub CI

## Review Evidence

- Self-review (CEO, workflow face reviewed line by line): notify-only confirmed — the workflow produces no check on PRs and cannot block anything; permissions minimal; idempotency and stale-run guards present; advisory wording embedded in the issue body
- Reviewer subagent: none (bounded review policy; CEO reviewed the protected face directly)
- Human review: pending
- Blocking findings: none

## Residual Risk

- The workflow end-to-end path is unverified until the first main run after merge; the unit-tested body builder and YAML validation cover the local half.

## References

- Task: task_01KY5A3E926RA1DXK445G5D3M6 (private ledger)
- Evidence: private ledger CI-T3 task package
- Review: private ledger CI-T3 task package

---

# 中文

## 概要

main 的 `full-check` 红两次无人发现:它不是 PR 必需检查,而 main-watch 哨兵的挂载靠操作者记忆。本 PR 加 notify-only 机制:`rewrite-ci` 在 main 上以 failure 完成时,workflow 自动开(或更新)带标签的 advisory issue,点名 run、head SHA 与失败 job;main 转绿自动评论并关闭。main-watch CLI 哨兵同时不再因瞬时网络错误退哨。执法面零变化:不动 required check、分支保护与 merge queue 行为。

## 改动内容

- 新增 `.github/workflows/main-red-notify.yml`:`workflow_run` 监听 main 上的 `rewrite-ci`;failure → 开或更新唯一的 `main-red` advisory issue(run/SHA 标记幂等 + stale-run 守卫);success → 评论并关闭。最小权限(`actions: read`、`issues: write`)、5 分钟超时、issue 正文内嵌 advisory-only 声明。
- 新增 `tools/main-red-notify.mjs` 及测试:issue 正文构造逻辑抽出可单测。
- `tools/main-watch.mjs`:瞬时 API 错误(EOF、连接重置)改为有界退避重试而非首错即 exit 40(实测一晚三次因本机网络毛刺退哨);退出码语义与 `RESULT:` 行契约不变。

## 任务与范围

- Harness 任务:task_01KY5A3E926RA1DXK445G5D3M6(CI-T3,私有台账);决策 dec_01KY5QGNH0SHJDZ88Q9HGMF6RX
- 分支:codex/ci-t3-main-red-notify
- 公开范围:.github/workflows/main-red-notify.yml、tools/main-red-notify.mjs、tools/main-red-notify.test.mjs、tools/main-watch.mjs、tools/main-watch.test.mjs
- 私有计划 / 证据是否已更新:yes
- 范围外:required check 集、分支保护、.mergify.yml、任何既有 workflow job(未来 required 升级由另一决策裁)

## 版本影响

- 版本:不改版本,原因是只改 CI 通知与 watch 工具
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:.github/workflows/(新增 notify-only workflow 文件)、tools/main-watch.mjs
- 依据:决策 dec_01KY5QGNH0SHJDZ88Q9HGMF6RX;任务 task_01KY5A3E926RA1DXK445G5D3M6
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:6020fdab71c5274ac3f39e64498b4e2d4346c1f6
- 当前分支与 `origin/main` 的 merge-base:6020fdab71c5274ac3f39e64498b4e2d4346c1f6
- 最近一次 `git fetch origin` 时间:2026-07-22T21:21Z
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:私有台账 CI-T3 任务包
- Reviewer 证据路径:私有台账 CI-T3 任务包
- GitHub Actions `rewrite-ci` run URL:push 后补充
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:check-package-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地完整门矩阵——按派生停止点只跑定向层(新 notify 与加固 main-watch 测试 23/23、YAML 解析、ESLint、复杂度、diff check);workflow 本体无法本地执行——合并后首个 main run 即使用证明;完整矩阵归 GitHub CI

## 审查证据

- 自查(CEO 逐行亲验 workflow 面):确认 notify-only——不在 PR 上产生任何 check、无法阻塞任何东西;权限最小;幂等与 stale-run 守卫在位;issue 正文内嵌 advisory 声明
- Reviewer subagent:无(有界评审政策;protected 面由 CEO 直接评审)
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- workflow 端到端路径在合并后首个 main run 前未验;本地可测半边(正文构造单测+YAML 校验)已覆盖。

## 关联材料

- 任务:task_01KY5A3E926RA1DXK445G5D3M6(私有台账)
- 证据:私有台账 CI-T3 任务包
- 审查:私有台账 CI-T3 任务包
