### PR TITLE
fix(test): detect wedged isolation children

### DIFF
--- a/tools/node-test-runner-lib.mjs
+++ b/tools/node-test-runner-lib.mjs
@@ -6,6 +6,34 @@ export const testFilePattern = /\.(test|spec)\.(?:mjs|js|ts)$/u;
 export const ignoredDirectoryNames = new Set(["node_modules", "dist", "out", "coverage", ".git"]);
 export const DEFAULT_TEST_TIMEOUT_MS = 180_000;
 
+export function parsePosixProcessGroupLine(line, platform = process.platform) {
+  const match = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(.+)$/u.exec(line);
+  if (match === null) return null;
+  const [, pidText, ppidText, pgidText, , , tail] = match;
+  if (platform === "darwin") {
+    return { pid: Number(pidText), ppid: Number(ppidText), pgid: Number(pgidText), waitChannel: null, command: tail.trim() };
+  }
+  const waitMatch = /^(\S+)\s+(.+)$/u.exec(tail);
+  if (waitMatch === null) return null;
+  return {
+    pid: Number(pidText),
+    ppid: Number(ppidText),
+    pgid: Number(pgidText),
+    waitChannel: waitMatch[1],
+    command: waitMatch[2].trim()
+  };
+}
+
+export function hasIsolationWedgeSignature(member) {
+  return /^futex(?:_|$)/u.test(member.waitChannel ?? "") || member.command.startsWith("ha-node-test-wedge ");
+}
+
+export function testFilesFromProcessCommand(command, repoRoot) {
+  return command.split(/\s+/u)
+    .map((token) => token.startsWith(`${repoRoot}/`) ? token.slice(repoRoot.length + 1) : token)
+    .filter((token) => /\.test\.(?:ts|tsx|mjs|cjs|js)$/u.test(token));
+}
+
 export function parseRunnerArgs(args, tierNames) {
   const options = {
     tier: "all",

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -12,9 +12,12 @@ import {
   filterTestFilesByPrefixes,
   formatSlowTestSummary,
   formatTestTimeoutGuidance,
+  hasIsolationWedgeSignature,
+  parsePosixProcessGroupLine,
   parseRunnerArgs,
   resolveTestConcurrency,
-  selectTestFiles
+  selectTestFiles,
+  testFilesFromProcessCommand
 } from "./node-test-runner-lib.mjs";
 import { defaultTestTierNames, discoverTestTierManifest, testTierNames } from "./test-tier-manifest.mjs";
 import { createHermeticTestEnvironment, gitFixtureIdentityGuidance } from "./test-process-environment.mjs";
@@ -116,6 +119,12 @@ const stallAbortWindows = positiveIntegerOrDefault(
 // the timeout itself proves no test is running, and therefore that nothing else
 // will ever end this run.
 const stallAbortAfterMs = Math.max(stallAbortWindows * stallDiagnosticMs, options.testTimeoutMs + stallDiagnosticMs);
+// A process that remains in the runtime's futex wait channel across several
+// probes is stronger evidence than global silence: it identifies the isolated
+// file that is stuck in NodePlatform shutdown even while sibling files keep
+// printing. This path does not preempt ordinary quiet tests; only the strong
+// per-process signature can use the shorter multi-window bound.
+const isolationWedgeAfterMs = stallAbortWindows * stallDiagnosticMs;
 
 process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}` }, async (lease) => {
   const qosPrefix = lease.inherited ? [] : discoverQosPrefix();
@@ -143,6 +152,8 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
   let lastOutputAt = Date.now();
   let consecutiveStallWindows = 0;
   let stallAbortStarted = false;
+  let processGroupInspectionStarted = false;
+  const isolationWedgeObservations = new Map();
   const seenDiagnosticReports = new Set();
   const noteOutput = (text) => {
     // Asking a stalled host for a diagnostic report makes it print, and that
@@ -152,16 +163,41 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
     lastOutputAt = Date.now();
     consecutiveStallWindows = 0;
   };
+  const startStallAbort = (input) => {
+    if (stallAbortStarted) return;
+    stallAbortStarted = true;
+    void abortStalledRun({ child, ...input });
+  };
+  const inspectIsolationChildren = async () => {
+    if (process.platform === "win32" || child.pid === undefined || processGroupInspectionStarted || stallAbortStarted) return;
+    processGroupInspectionStarted = true;
+    try {
+      const wedge = await detectWedgedIsolationChildren({
+        processGroupId: child.pid,
+        observations: isolationWedgeObservations,
+        wedgeAfterMs: isolationWedgeAfterMs
+      });
+      if (wedge === null) return;
+      startStallAbort({
+        silentMs: wedge.wedgedForMs,
+        silentWindows: Math.max(1, Math.ceil(wedge.wedgedForMs / stallDiagnosticMs)),
+        timeoutAlreadyReported: /test timed out after \d+ms/u.test(output),
+        isolationChildPid: wedge.pid,
+        stalledFiles: wedge.files
+      });
+    } finally {
+      processGroupInspectionStarted = false;
+    }
+  };
   const stallDiagnosticTimer = setInterval(() => {
+    void inspectIsolationChildren();
     const silentForMs = Date.now() - lastOutputAt;
     if (silentForMs < stallDiagnosticMs) return;
     lastOutputAt = Date.now();
     consecutiveStallWindows += 1;
     emitStallDiagnostics({ child, silentForMs, timingRoot, seenDiagnosticReports });
-    if (consecutiveStallWindows * stallDiagnosticMs < stallAbortAfterMs || stallAbortStarted) return;
-    stallAbortStarted = true;
-    void abortStalledRun({
-      child,
+    if (consecutiveStallWindows * stallDiagnosticMs < stallAbortAfterMs) return;
+    startStallAbort({
       silentMs: consecutiveStallWindows * stallDiagnosticMs,
       silentWindows: consecutiveStallWindows,
       timeoutAlreadyReported: /test timed out after \d+ms/u.test(output)
@@ -276,7 +312,7 @@ function emitStallDiagnostics({ child, silentForMs, timingRoot, seenDiagnosticRe
  * caught and fail, rather than stay silent until the CI job's own timeout kills
  * it with no test named.
  */
-async function abortStalledRun({ child, silentMs, silentWindows, timeoutAlreadyReported }) {
+async function abortStalledRun({ child, silentMs, silentWindows, timeoutAlreadyReported, isolationChildPid, stalledFiles }) {
   // When `--test-timeout` already fired, the failing test is named and this is
   // just the timeout path's own cleanup arriving early: the run lingers only
   // because a leaked descendant holds the process group open.
@@ -298,10 +334,13 @@ async function abortStalledRun({ child, silentMs, silentWindows, timeoutAlreadyR
     return;
   }
   if (child.pid === undefined) return;
-  const stalledFiles = await stalledTestFilesInProcessGroup(child.pid);
-  console.error(`\n[node-test-stall] no test output for ${silentMs}ms across ${silentWindows} windows; --test-timeout cannot fire here, so the runner is terminating the test process tree`);
-  console.error(stalledFiles.length > 0
-    ? `[node-test-stall] stalled test file(s): ${stalledFiles.join(", ")}`
+  const namedFiles = stalledFiles ?? await stalledTestFilesInProcessGroup(child.pid);
+  const reason = isolationChildPid === undefined
+    ? `no test output for ${silentMs}ms across ${silentWindows} windows`
+    : `isolation child pid=${isolationChildPid} remained wedged for ${silentMs}ms across ${silentWindows} windows`;
+  console.error(`\n[node-test-stall] ${reason}; --test-timeout cannot fire here, so the runner is terminating the test process tree`);
+  console.error(namedFiles.length > 0
+    ? `[node-test-stall] stalled test file(s): ${namedFiles.join(", ")}`
     : "[node-test-stall] stalled test file could not be identified from the process group");
   signalProcessGroup(child.pid, "SIGTERM");
   await new Promise((resolveDelay) => setTimeout(resolveDelay, PROCESS_TREE_KILL_GRACE_MS));
@@ -318,12 +357,10 @@ async function stalledTestFilesInProcessGroup(processGroupId) {
   const descendantFiles = new Set();
   const hostFiles = new Set();
   for (const line of lines) {
-    const pid = /^\s*(\d+)\s+/u.exec(line)?.[1];
-    if (pid === undefined) continue;
-    const target = pid === String(processGroupId) ? hostFiles : descendantFiles;
-    for (const token of line.split(/\s+/u)) {
-      if (/\.test\.(?:ts|tsx|mjs|cjs|js)$/u.test(token)) target.add(token);
-    }
+    const member = parsePosixProcessGroupLine(line);
+    if (member === null) continue;
+    const target = member.pid === processGroupId ? hostFiles : descendantFiles;
+    for (const file of testFilesFromProcessCommand(member.command, repoRoot)) target.add(file);
   }
   if (descendantFiles.size > 0) return [...descendantFiles];
   // Without process isolation the host itself is the wedged process, and its
@@ -331,6 +368,42 @@ async function stalledTestFilesInProcessGroup(processGroupId) {
   // useful when the selection happens to be a single file.
   return hostFiles.size === 1 ? [...hostFiles] : [];
 }
+
+/**
+ * Tracks process-isolated test children independently of aggregate reporter
+ * output. Linux exposes the NodePlatform deadlock as `futex_do_wait`; fixture
+ * processes use an explicit title so the same state machine is testable on
+ * macOS, whose `ps` does not expose a useful wait channel.
+ */
+async function detectWedgedIsolationChildren({ processGroupId, observations, wedgeAfterMs }) {
+  const now = Date.now();
+  const liveCandidates = new Set();
+  const wedged = [];
+  for (const line of await readPosixProcessGroup(processGroupId)) {
+    const member = parsePosixProcessGroupLine(line);
+    if (member === null || member.pid === processGroupId || !hasIsolationWedgeSignature(member)) continue;
+    const files = testFilesFromProcessCommand(member.command, repoRoot);
+    if (files.length === 0) continue;
+    liveCandidates.add(member.pid);
+    const fileKey = files.join("\0");
+    const previous = observations.get(member.pid);
+    const firstSeenAt = previous?.fileKey === fileKey ? previous.firstSeenAt : now;
+    observations.set(member.pid, { fileKey, firstSeenAt });
+    if (now - firstSeenAt >= wedgeAfterMs) {
+      wedged.push({ pid: member.pid, files, wedgedForMs: now - firstSeenAt });
+    }
+  }
+  for (const pid of observations.keys()) {
+    if (!liveCandidates.has(pid)) observations.delete(pid);
+  }
+  if (wedged.length === 0) return null;
+  return {
+    pid: wedged[0].pid,
+    files: [...new Set(wedged.flatMap((entry) => entry.files))],
+    wedgedForMs: Math.max(...wedged.map((entry) => entry.wedgedForMs))
+  };
+}
+
 
 /**
  * Sends SIGUSR2 only to group members that run with `--report-on-signal` on

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -4,7 +4,7 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import test from "node:test";
 import { pathToFileURL } from "node:url";
-import { collectSlowTests, DEFAULT_TEST_TIMEOUT_MS, filterTestFilesByPrefixes, formatSlowTestSummary, parseCompletedTestLine, parseRunnerArgs, resolveTestConcurrency, selectTestFiles, validateManifest } from "./node-test-runner-lib.mjs";
+import { collectSlowTests, DEFAULT_TEST_TIMEOUT_MS, filterTestFilesByPrefixes, formatSlowTestSummary, hasIsolationWedgeSignature, parseCompletedTestLine, parsePosixProcessGroupLine, parseRunnerArgs, resolveTestConcurrency, selectTestFiles, testFilesFromProcessCommand, validateManifest } from "./node-test-runner-lib.mjs";
 import { defaultTestTierNames, deriveTestTierManifest, discoverTestTierManifest, parseTestTierMarker, testTierNames } from "./test-tier-manifest.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
@@ -122,9 +122,112 @@ test("runner ends a run wedged outside any test body and names what it caught", 
   // timeout. Asserting its absence is what makes this a test of the escalation
   // rather than of `--test-timeout`.
   assert.doesNotMatch(output, /test timed out after \d+ms/u);
-  assert.match(output, /\[node-test-stall\] no test output for \d+ms across \d+ windows/u);
+  assert.match(output, /\[node-test-stall\] isolation child pid=\d+ remained wedged/u);
   assert.match(output, /terminating the test process tree/u);
   assert.match(output, /\[node-test-stall\] stalled test file\(s\): tools\/test-fixtures\/runner-stall\/wedged-module\.test\.mjs/u);
+});
+
+test("runner detects a wedged isolation child while another file keeps producing output", {
+  skip: process.platform === "win32"
+    ? "per-child wedge detection inspects the POSIX process group"
+    : false
+}, () => {
+  const startedAt = Date.now();
+  const childEnv = {
+    ...process.env,
+    HARNESS_RUNNER_STALL_FIXTURE: "chatter",
+    HARNESS_TEST_CONCURRENCY: "2",
+    HARNESS_TEST_STALL_DIAGNOSTIC_MS: "250",
+    HARNESS_TEST_STALL_ABORT_WINDOWS: "2"
+  };
+  delete childEnv.NODE_TEST_CONTEXT;
+  const result = spawnSync(process.execPath, [
+    "tools/run-node-tests.mjs",
+    "--tier", "fast",
+    "--prefix", "tools/test-fixtures/runner-stall",
+    "--test-timeout", "1000"
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: childEnv,
+    timeout: 15_000
+  });
+  const elapsedMs = Date.now() - startedAt;
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.error, undefined, output);
+  assert.equal(result.status, 1, output);
+  assert.equal(elapsedMs < 5_000, true, `runner took ${elapsedMs}ms\n${output}`);
+  assert.match(output, /runner chatter \d+/u);
+  assert.match(output, /\[node-test-stall\] isolation child pid=\d+ remained wedged/u);
+  assert.match(output, /\[node-test-stall\] stalled test file\(s\): tools\/test-fixtures\/runner-stall\/wedged-module\.test\.mjs/u);
+});
+
+test("runner preserves a real test failure without classifying it as a wedge", () => {
+  const startedAt = Date.now();
+  const childEnv = {
+    ...process.env,
+    HARNESS_RUNNER_STALL_FIXTURE: "failing-only",
+    HARNESS_TEST_CONCURRENCY: "1",
+    HARNESS_TEST_STALL_DIAGNOSTIC_MS: "250",
+    HARNESS_TEST_STALL_ABORT_WINDOWS: "2"
+  };
+  delete childEnv.NODE_TEST_CONTEXT;
+  const result = spawnSync(process.execPath, [
+    "tools/run-node-tests.mjs",
+    "--tier", "fast",
+    "--prefix", "tools/test-fixtures/runner-stall",
+    "--test-timeout", "1000"
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: childEnv,
+    timeout: 10_000
+  });
+  const elapsedMs = Date.now() - startedAt;
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.error, undefined, output);
+  assert.equal(result.status, 1, output);
+  assert.equal(elapsedMs < 5_000, true, `runner took ${elapsedMs}ms\n${output}`);
+  assert.match(output, /✖ runner failing-wedge probe exposes a real failure before shutdown/u);
+  assert.match(output, /intentional real failure before shutdown wedge/u);
+  assert.doesNotMatch(output, /isolation child pid=\d+ remained wedged/u);
+});
+
+test("runner treats a real failure hidden by a shutdown wedge as a named wedge failure", {
+  skip: process.platform === "win32"
+    ? "per-child wedge detection inspects the POSIX process group"
+    : false
+}, () => {
+  const startedAt = Date.now();
+  const childEnv = {
+    ...process.env,
+    HARNESS_RUNNER_STALL_FIXTURE: "failing-wedge",
+    HARNESS_TEST_CONCURRENCY: "1",
+    HARNESS_TEST_STALL_DIAGNOSTIC_MS: "250",
+    HARNESS_TEST_STALL_ABORT_WINDOWS: "2"
+  };
+  delete childEnv.NODE_TEST_CONTEXT;
+  const result = spawnSync(process.execPath, [
+    "tools/run-node-tests.mjs",
+    "--tier", "fast",
+    "--prefix", "tools/test-fixtures/runner-stall",
+    "--test-timeout", "1000"
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: childEnv,
+    timeout: 10_000
+  });
+  const elapsedMs = Date.now() - startedAt;
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.error, undefined, output);
+  assert.equal(result.status, 1, output);
+  assert.equal(elapsedMs < 5_000, true, `runner took ${elapsedMs}ms\n${output}`);
+  assert.match(output, /\[node-test-stall\] isolation child pid=\d+ remained wedged/u);
+  assert.match(output, /\[node-test-stall\] stalled test file\(s\): tools\/test-fixtures\/runner-stall\/failing-then-wedge\.test\.mjs/u);
 });
 
 test("parseRunnerArgs accepts safe repository-relative test prefixes", () => {
@@ -133,6 +236,28 @@ test("parseRunnerArgs accepts safe repository-relative test prefixes", () => {
     "packages/kernel/"
   ]);
   assert.throws(() => parseRunnerArgs(["--prefix", "../outside"], testTierNames), /repository-relative/u);
+});
+
+test("Linux process snapshots distinguish a futex-wedged isolation child", () => {
+  const member = parsePosixProcessGroupLine(
+    " 8774 2519 2519 Sl 06:11 futex_do_wait /opt/node/bin/node --test-isolation=process tools/graph-panorama.test.mjs",
+    "linux"
+  );
+  assert.deepEqual(member, {
+    pid: 8774,
+    ppid: 2519,
+    pgid: 2519,
+    waitChannel: "futex_do_wait",
+    command: "/opt/node/bin/node --test-isolation=process tools/graph-panorama.test.mjs"
+  });
+  assert.equal(hasIsolationWedgeSignature(member), true);
+  assert.deepEqual(testFilesFromProcessCommand(member.command, repoRoot), ["tools/graph-panorama.test.mjs"]);
+
+  const healthy = parsePosixProcessGroupLine(
+    " 8775 2519 2519 Sl 00:01 ep_poll /opt/node/bin/node --test-isolation=process tools/healthy.test.mjs",
+    "linux"
+  );
+  assert.equal(hasIsolationWedgeSignature(healthy), false);
 });
 
 test("parseRunnerArgs accepts integration shards only for the integration tier", () => {

--- a/tools/test-fixtures/runner-stall/chatter.test.mjs
+++ b/tools/test-fixtures/runner-stall/chatter.test.mjs
@@ -1,0 +1,11 @@
+// harness-test-tier: fast
+import test from "node:test";
+
+if (process.env.HARNESS_RUNNER_STALL_FIXTURE === "chatter") {
+  for (let index = 0; index < 30; index += 1) {
+    console.log(`runner chatter ${index + 1}`);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+test("runner chatter fixture stays inert unless it is explicitly enabled", () => {});

--- a/tools/test-fixtures/runner-stall/failing-then-wedge.test.mjs
+++ b/tools/test-fixtures/runner-stall/failing-then-wedge.test.mjs
@@ -1,0 +1,17 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+
+if (process.env.HARNESS_RUNNER_STALL_FIXTURE === "failing-wedge") {
+  after(() => {
+    process.title = "ha-node-test-wedge tools/test-fixtures/runner-stall/failing-then-wedge.test.mjs";
+    const signal = new Int32Array(new SharedArrayBuffer(4));
+    Atomics.wait(signal, 0, 0);
+  });
+}
+
+test("runner failing-wedge probe exposes a real failure before shutdown", () => {
+  if (["failing-only", "failing-wedge"].includes(process.env.HARNESS_RUNNER_STALL_FIXTURE)) {
+    assert.fail("intentional real failure before shutdown wedge");
+  }
+});

--- a/tools/test-fixtures/runner-stall/wedged-module.test.mjs
+++ b/tools/test-fixtures/runner-stall/wedged-module.test.mjs
@@ -6,7 +6,8 @@ import test from "node:test";
 // for it to time out. `Atomics.wait` reproduces the futex wedge seen in CI
 // without burning a core. Only the stall escalation in
 // tools/run-node-tests.mjs can end this run.
-if (process.env.HARNESS_RUNNER_STALL_FIXTURE === "wedge") {
+if (["chatter", "wedge"].includes(process.env.HARNESS_RUNNER_STALL_FIXTURE)) {
+  process.title = "ha-node-test-wedge tools/test-fixtures/runner-stall/wedged-module.test.mjs";
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
 }
 


### PR DESCRIPTION
# English

## Summary

Detect a wedged `--test-isolation=process` child even when other files still emit
output, so a Node shutdown-deadlock ([#54918](https://github.com/nodejs/node/issues/54918))
becomes a fast, named, bounded failure instead of a 20+ minute silent CI hang.

## What Changed

- `tools/run-node-tests.mjs`: track each isolated child by PID / test file /
  consecutive silent window; name and terminate a child on a sustained `futex*`
  wait-channel signature, reusing the existing SIGTERM → grace → SIGKILL
  fail-closed path.
- `tools/node-test-runner-lib.mjs`: parse the POSIX process-group snapshot and
  distinguish a `futex*` wait channel from ordinary `ep_poll`.
- `tools/run-node-tests.test.mjs` + fixtures (`chatter.test.mjs`,
  `failing-then-wedge.test.mjs`): four controls pinning the behaviour.

No retry, no skip, no timeout widening, no workflow change.

## Task And Scope

Task `task_01KY67C6ESF9ADB196Y01FN3YK` (under PLT-Baseline-Governance umbrella).
Scope limited to the test runner and its fixtures; `.github/workflows/*` untouched.

## Version Impact

None. Test-infrastructure only; no shipped package behaviour changes.

## Governance Declaration

Protected surface (`tools/run-node-tests.mjs`, `tools/node-test-runner-lib.mjs`)
changed under decision `dec_01KY6BAN1EJACTAGS0ZH91E2KG` (accepted), which chose
runner-side per-child bounded detection and rejected both blind auto-retry
(unsafe: a real failure is swallowed by the shutdown wedge) and a Node upgrade
(#54918 unfixed on 24/25/26). No break-glass.

## Verification

Node 24 controls: chatter+wedge 2.94s named; permanent wedge 3.15s named; real
failure 0.45s visible and not classified as a wedge; fail-then-wedge 2.90s named.
Targeted gate 164 pass / 0 fail. `git diff --check` clean; workflow diff empty.
Native-ABI integration tests and the full CI matrix left to GitHub CI.

## Review Evidence

CEO verified the commit is scoped to six `tools/` files, confirmed Node #54918 is
an open confirmed-bug, and independently reproduced the real-failure-swallowed-by-wedge
result (parent received only `TAP version 13`).

## Residual Risk

Fast detection relies on Linux `ps` exposing the `futex*` wait channel; other
deadlock shapes and non-Linux fall back to the existing global-silence guard.
Auto-recovery (durable per-file verdict) deferred pending a flush-timing probe.

## References

- Node upstream bug: https://github.com/nodejs/node/issues/54918
- Decision: dec_01KY6BAN1EJACTAGS0ZH91E2KG
- Task: task_01KY67C6ESF9ADB196Y01FN3YK

---

# 中文

## 概要

即使其它文件仍在输出,也能检测到 `--test-isolation=process` 下被 wedge 的子进程,使
Node 退出期死锁([#54918](https://github.com/nodejs/node/issues/54918))从 CI 上
20+ 分钟静默挂起变成秒级、命名、有界的失败。

## 改动内容

- `tools/run-node-tests.mjs`:按 PID / 测试文件 / 连续静默窗口跟踪每个隔离子进程;在
  持续 `futex*` wait-channel 签名下命名并终止该子进程,复用既有 SIGTERM → grace →
  SIGKILL fail-closed 路径。
- `tools/node-test-runner-lib.mjs`:解析 POSIX process-group 快照,区分 `futex*` 与
  普通 `ep_poll`。
- `tools/run-node-tests.test.mjs` + fixture(`chatter.test.mjs`、
  `failing-then-wedge.test.mjs`):四个对照钉死行为。

无重试、无 skip、不放宽超时、不改 workflow。

## 任务与范围

任务 `task_01KY67C6ESF9ADB196Y01FN3YK`(PLT-Baseline-Governance 伞下)。范围限于测试
runner 及其 fixture;`.github/workflows/*` 未动。

## 版本影响

无。仅测试基础设施;不改任何已发布包行为。

## 治理声明

受保护面(`tools/run-node-tests.mjs`、`tools/node-test-runner-lib.mjs`)的改动依据
已 accept 的决策 `dec_01KY6BAN1EJACTAGS0ZH91E2KG`:选择 runner 侧 per-child 有界检测,
否决盲目自动重试(不安全:真失败会被退出期 wedge 吞没)与升级 Node(#54918 在 24/25/26
均未修)。无 break-glass。

## 验证

Node 24 对照:chatter+wedge 2.94s 命名;永久 wedge 3.15s 命名;真失败 0.45s 可见且不判
为 wedge;fail-then-wedge 2.90s 命名。定向门 164 pass / 0 fail。`git diff --check` 干净;
workflow diff 为空。原生 ABI 集成测试与完整 CI 矩阵交给 GitHub CI。

## 审查证据

CEO 验证 commit 仅含六个 `tools/` 文件、确认 Node #54918 为 OPEN confirmed-bug、并独立
复现"真失败被 wedge 吞没"(父进程只收到 `TAP version 13`)。

## 残余风险

快速检测依赖 Linux `ps` 暴露 `futex*` wait channel;其它死锁形态与非 Linux 回落到既有
全局静默 guard。自动恢复(durable 逐文件判决)推迟,待 flush 时序探针后再议。

## 关联材料

- Node 上游 bug:https://github.com/nodejs/node/issues/54918
- 决策:dec_01KY6BAN1EJACTAGS0ZH91E2KG
- 任务:task_01KY67C6ESF9ADB196Y01FN3YK
