### PR TITLE
fix(provenance): honest unavailable session bindings + broaden transcript search

### DIFF
--- a/packages/application/src/coordinated-execution-authored-store.ts
+++ b/packages/application/src/coordinated-execution-authored-store.ts
@@ -13,6 +13,7 @@ import {
 } from "@harness-anything/kernel";
 import type { ExecutionRecord } from "@harness-anything/kernel";
 import type { ExecutionAuthoredStore, ExecutionSubmission } from "./execution-saga-service.ts";
+import { isRuntimeTranscriptConfirmedUnavailable } from "./runtime-transcript-confirmation.ts";
 
 export function makeCoordinatedExecutionAuthoredStore(input: {
   readonly rootInput: HarnessLayoutInput;
@@ -190,6 +191,9 @@ export function finalizeExecutionSessionBindings(
   return bindings.map((binding) => {
     if (typeof binding.session_ref !== "string" || !binding.session_ref.startsWith("session/")) return binding;
     const sessionId = binding.session_ref.slice("session/".length);
+    if (binding.archive_status === "unavailable") {
+      return finalizeUnavailableBinding(binding, endedAt);
+    }
     try {
       const session = readSessionEntityDocument(rootInput, sessionId);
       return {
@@ -198,10 +202,27 @@ export function finalizeExecutionSessionBindings(
         capture_range: binding.capture_range ? { ...binding.capture_range, end_at: endedAt } : null
       };
     } catch (error) {
+      if (isMissingSessionSnapshotError(error)
+          && binding.session?.source === "runtime"
+          && binding.session.sessionId === sessionId
+          && isRuntimeTranscriptConfirmedUnavailable(binding.session)) {
+        return finalizeUnavailableBinding(binding, endedAt);
+      }
       const prefix = binding.role === "primary" ? "primary Session" : "Session";
       throw new Error(`${prefix} ${sessionId} snapshot is not finalized: ${error instanceof Error ? error.message : String(error)}`);
     }
   });
+}
+
+function finalizeUnavailableBinding(
+  binding: ExecutionRecord["session_bindings"][number],
+  endedAt: string
+): ExecutionRecord["session_bindings"][number] {
+  return {
+    ...binding,
+    archive_status: "unavailable",
+    capture_range: binding.capture_range ? { ...binding.capture_range, end_at: endedAt } : null
+  };
 }
 
 function assertExecutionHost(current: ExecutionRecord, taskId: string, executionId: string): void {
@@ -232,4 +253,8 @@ function assertBindingsFinal(bindings: ReadonlyArray<unknown>): void {
 
 function executionPath(executionId: string): string {
   return `executions/${executionId}.md`;
+}
+
+function isMissingSessionSnapshotError(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === "ENOENT");
 }

--- a/packages/application/src/provenance-binding.ts
+++ b/packages/application/src/provenance-binding.ts
@@ -22,7 +22,9 @@ export function bindCreateProvenance(
         Effect.catchAll(() => options.provenanceSessionExporter!.exportSession(session)),
         Effect.flatMap((result) => options.syncExportedSession ? options.syncExportedSession(result) : Effect.void),
         Effect.as(provenance),
-        Effect.catchAll((error) => error.code === "transcript_unavailable"
+        // Optional transcript capture must not make unrelated writes depend on runtime-log availability.
+        // Execution submission applies the stricter confirmed-unavailable rule at its finalization boundary.
+        Effect.catchAll((error) => error.code === "transcript_unavailable" || error.code === "read_failed"
           ? Effect.succeed(provenance)
           : Effect.fail(error))
       );

--- a/packages/application/src/provenance-session-exporter.ts
+++ b/packages/application/src/provenance-session-exporter.ts
@@ -2,7 +2,8 @@ import path from "node:path";
 import { Effect } from "effect";
 import type { ArtifactStore, CurrentSessionProbePort, CurrentSessionRef, CurrentSessionRuntime, CurrentSessionSource, SessionManifest, WriteCoordinator, WriteError } from "@harness-anything/kernel";
 import { privateTextScannerVersion, resolveHarnessLayout, scanPrivateText, writeContentAddressedBlob, writeSessionEntity, type HarnessLayoutInput } from "@harness-anything/kernel";
-import { discoverRuntimeSessions, displayRuntimePath, resolveRuntimeConversation, type RuntimeConversation, type RuntimeConversationMessage } from "./runtime-session-logs.ts";
+import { discoverRuntimeSessions, displayRuntimePath, inspectRuntimeTranscript, resolveRuntimeConversation, type RuntimeConversation, type RuntimeConversationMessage } from "./runtime-session-logs.ts";
+import { clearRuntimeTranscriptConfirmation, recordRuntimeTranscriptInspection } from "./runtime-transcript-confirmation.ts";
 import { readSessionEntity } from "./session-entity-reader.ts";
 
 export interface ProvenanceSessionExporterOptions {
@@ -104,15 +105,35 @@ function writeSessionDocument(
         "transcript_unavailable"
       ));
     }
+    if (session.runtime !== "human") clearRuntimeTranscriptConfirmation(session);
+    const transcript = session.runtime === "human"
+      ? undefined
+      : yield* Effect.promise(() => inspectRuntimeTranscript(session, {
+          ...options,
+          ...(exportOptions.transcriptFile ? { transcriptFile: exportOptions.transcriptFile } : {})
+        }));
+    if (transcript) recordRuntimeTranscriptInspection(session, transcript.status);
+    if (transcript?.status === "unavailable") {
+      return yield* Effect.fail(sessionRejection(
+        session.sessionId,
+        transcript.reason,
+        "transcript_unavailable"
+      ));
+    }
+    if (transcript?.status === "indeterminate") {
+      return yield* Effect.fail(sessionRejection(session.sessionId, transcript.reason, "read_failed"));
+    }
     const conversation = yield* resolveRuntimeConversation(session, {
       ...options,
-      ...(exportOptions.transcriptFile ? { transcriptFile: exportOptions.transcriptFile } : {})
+      ...(transcript?.status === "available"
+        ? { transcriptFile: transcript.logPath }
+        : exportOptions.transcriptFile ? { transcriptFile: exportOptions.transcriptFile } : {})
     });
     if (session.runtime !== "human" && conversation.messages.length === 0) {
       return yield* Effect.fail(sessionRejection(
         session.sessionId,
         conversation.warnings.join(" ") || `No conversation text could be extracted for ${session.runtime} session ${session.sessionId}.`,
-        "transcript_unavailable"
+        "read_failed"
       ));
     }
     // Capture is report-only: sessions land in the private ledger (system of record),

--- a/packages/application/src/runtime-session-logs.ts
+++ b/packages/application/src/runtime-session-logs.ts
@@ -25,11 +25,105 @@ export interface RuntimeConversation {
   readonly warnings: ReadonlyArray<string>;
 }
 
+export type RuntimeTranscriptInspection =
+  | { readonly status: "available"; readonly logPath: string }
+  | { readonly status: "unavailable"; readonly reason: string; readonly searched: boolean }
+  | { readonly status: "indeterminate"; readonly reason: string };
+
 type JsonObject = Record<string, unknown>;
 
 const defaultRuntimeLogSearchDepth = landedSettingDefaults.runtimeLogSearchDepth;
 const maxRuntimeLogSearchDepth = 64;
 const safeSessionIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
+
+export async function inspectRuntimeTranscript(
+  session: { readonly runtime: string; readonly sessionId: string },
+  options: RuntimeLogOptions = {}
+): Promise<RuntimeTranscriptInspection> {
+  if (session.runtime === "human" || !isRuntimeWithTranscript(session.runtime)) {
+    return { status: "indeterminate", reason: `Unsupported runtime transcript source: ${session.runtime}.` };
+  }
+  const configuredRoots = options.runtimeLogRoots?.[session.runtime];
+  const roots = options.transcriptFile
+    ? [options.transcriptFile]
+    : configuredRoots ?? defaultRuntimeLogRoots(session.runtime, options.homeDir);
+  if (roots.length === 0) {
+    return { status: "indeterminate", reason: `No runtime JSONL log roots are configured for ${session.runtime}.` };
+  }
+  const inspections = await Promise.all(roots.map((root) => inspectRuntimePath(
+    root,
+    session.sessionId,
+    options.transcriptFile !== undefined || configuredRoots !== undefined,
+    resolveRuntimeLogSearchDepth(options)
+  )));
+  const available = inspections.find((item) => item.status === "available");
+  if (available?.status === "available") return available;
+  const uncertain = inspections.filter((item) => item.status === "indeterminate");
+  if (uncertain.length > 0) {
+    return { status: "indeterminate", reason: uncertain.map((item) => item.reason).join(" ") };
+  }
+  if (!inspections.some((item) => item.status === "unavailable" && item.searched)) {
+    return {
+      status: "indeterminate",
+      reason: `No configured runtime JSONL log root exists for ${session.runtime}; transcript absence cannot be confirmed.`
+    };
+  }
+  return {
+    status: "unavailable",
+    reason: `No runtime JSONL log found for ${session.runtime} session ${session.sessionId} after searching all configured roots.`,
+    searched: true
+  };
+}
+
+async function inspectRuntimePath(
+  target: string,
+  sessionId: string,
+  explicitFileAllowed: boolean,
+  depth: number
+): Promise<RuntimeTranscriptInspection> {
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(target);
+  } catch (error) {
+    return isMissingPathError(error)
+      ? { status: "unavailable", reason: `Runtime log root does not exist: ${displayRuntimePath(target)}.`, searched: false }
+      : { status: "indeterminate", reason: `Runtime log root is not readable: ${displayRuntimePath(target)} (${errorMessage(error)}).` };
+  }
+  if (stat.isFile()) {
+    return path.extname(target) === ".jsonl" && (explicitFileAllowed || fileNameMatchesSession(target, sessionId))
+      ? { status: "available", logPath: target }
+      : { status: "indeterminate", reason: `Runtime log file does not match session ${sessionId}: ${displayRuntimePath(target)}.` };
+  }
+  if (!stat.isDirectory()) {
+    return { status: "indeterminate", reason: `Runtime log root is not a file or directory: ${displayRuntimePath(target)}.` };
+  }
+  let entries: fs.Dirent[];
+  try {
+    entries = (await fs.promises.readdir(target, { withFileTypes: true }))
+      .toSorted((left, right) => left.name.localeCompare(right.name));
+  } catch (error) {
+    return { status: "indeterminate", reason: `Runtime log directory is not readable: ${displayRuntimePath(target)} (${errorMessage(error)}).` };
+  }
+  const file = entries.find((entry) =>
+    entry.isFile() && path.extname(entry.name) === ".jsonl" && fileNameMatchesSession(entry.name, sessionId));
+  if (file) return { status: "available", logPath: path.join(target, file.name) };
+  const directories = entries.filter((entry) => entry.isDirectory());
+  if (directories.length > 0 && depth === 0) {
+    return { status: "indeterminate", reason: `Runtime transcript search depth was exhausted under ${displayRuntimePath(target)}.` };
+  }
+  const nested = await Promise.all(directories.map((entry) =>
+    inspectRuntimePath(path.join(target, entry.name), sessionId, false, depth - 1)));
+  const available = nested.find((item) => item.status === "available");
+  if (available?.status === "available") return available;
+  const uncertain = nested.filter((item) => item.status === "indeterminate");
+  return uncertain.length > 0
+    ? { status: "indeterminate", reason: uncertain.map((item) => item.reason).join(" ") }
+    : { status: "unavailable", reason: `No matching runtime transcript under ${displayRuntimePath(target)}.`, searched: true };
+}
+
+function isRuntimeWithTranscript(runtime: string): runtime is Exclude<CurrentSessionRuntime, "human"> {
+  return runtime === "claude-code" || runtime === "codex" || runtime === "zcode" || runtime === "antigravity";
+}
 
 export function resolveRuntimeConversation(
   session: ProvenanceSessionDocument,
@@ -142,7 +236,7 @@ async function findFirstRuntimeLog(
   return undefined;
 }
 
-function defaultRuntimeLogRoots(runtime: CurrentSessionRuntime, homeDir = os.homedir()): ReadonlyArray<string> {
+export function defaultRuntimeLogRoots(runtime: CurrentSessionRuntime, homeDir = os.homedir()): ReadonlyArray<string> {
   if (!homeDir) return [];
   if (runtime === "claude-code") return [path.join(homeDir, ".claude", "projects")];
   if (runtime === "codex") {
@@ -258,7 +352,7 @@ function sessionIdFromRuntimeLog(runtime: Exclude<CurrentSessionRuntime, "human"
   return basename;
 }
 
-function fileNameMatchesSession(filePath: string, sessionId: string): boolean {
+export function fileNameMatchesSession(filePath: string, sessionId: string): boolean {
   const basename = path.basename(filePath, ".jsonl");
   return basename === sessionId || basename.endsWith(`-${sessionId}`) || basename.endsWith(`_${sessionId}`);
 }
@@ -483,4 +577,8 @@ export function displayRuntimePath(logPath: string): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === "ENOENT");
 }

--- a/packages/application/src/runtime-transcript-confirmation.ts
+++ b/packages/application/src/runtime-transcript-confirmation.ts
@@ -1,0 +1,26 @@
+const confirmedUnavailableTranscripts = new Set<string>();
+
+export function recordRuntimeTranscriptInspection(
+  session: { readonly runtime: string; readonly sessionId: string },
+  status: "available" | "unavailable" | "indeterminate"
+): void {
+  const key = runtimeTranscriptKey(session.runtime, session.sessionId);
+  if (status === "unavailable") confirmedUnavailableTranscripts.add(key);
+  else confirmedUnavailableTranscripts.delete(key);
+}
+
+export function clearRuntimeTranscriptConfirmation(
+  session: { readonly runtime: string; readonly sessionId: string }
+): void {
+  confirmedUnavailableTranscripts.delete(runtimeTranscriptKey(session.runtime, session.sessionId));
+}
+
+export function isRuntimeTranscriptConfirmedUnavailable(
+  session: { readonly runtime: string; readonly sessionId: string }
+): boolean {
+  return confirmedUnavailableTranscripts.has(runtimeTranscriptKey(session.runtime, session.sessionId));
+}
+
+function runtimeTranscriptKey(runtime: string, sessionId: string): string {
+  return `${runtime}:${sessionId}`;
+}

--- a/packages/application/test/execution-session-finalization.test.ts
+++ b/packages/application/test/execution-session-finalization.test.ts
@@ -1,0 +1,127 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import {
+  finalizeExecutionSessionBindings,
+  makeJournaledWriteCoordinator,
+  type ExecutionRecord
+} from "../src/index.ts";
+import { writeContentAddressedBlob, writeSessionEntity } from "../../kernel/src/index.ts";
+import { inspectRuntimeTranscript } from "../src/runtime-session-logs.ts";
+import { recordRuntimeTranscriptInspection } from "../src/runtime-transcript-confirmation.ts";
+import { writeAttribution } from "./test-attribution.ts";
+
+function primarySessionBinding(sessionId: string): ExecutionRecord["session_bindings"][number] {
+  const attachedAt = "2026-07-11T00:00:00.000Z";
+  return {
+    binding_id: `primary:${sessionId}`,
+    session_ref: `session/${sessionId}`,
+    role: "primary",
+    archive_status: "pending",
+    attached_at: attachedAt,
+    session: { runtime: "codex", sessionId, source: "runtime", detectedAt: attachedAt },
+    capture_range: {
+      range_id: `primary:${sessionId}:${attachedAt}`,
+      coordinate: "timestamp",
+      start_at: attachedAt,
+      end_at: null,
+      bounds: "inclusive"
+    }
+  };
+}
+
+test("Session binding finalization exports when possible and marks only confirmed missing transcripts unavailable", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-execution-session-finalization-"));
+  try {
+    const endedAt = "2026-07-11T00:05:00.000Z";
+    const logsRoot = path.join(rootDir, "runtime-logs");
+    mkdirSync(logsRoot, { recursive: true });
+    const coordinator = makeJournaledWriteCoordinator({
+      rootDir,
+      attribution: writeAttribution("alice", "codex")
+    });
+
+    const archivedId = "archived-session";
+    const bodyRef = writeContentAddressedBlob(rootDir, "# finalized session\n", "text/markdown; charset=utf-8");
+    Effect.runSync(writeSessionEntity(coordinator, rootDir, {
+      schema: "session-entity/v1",
+      sessionId: archivedId,
+      lifecycle: "sealed",
+      archiveStatus: "complete",
+      runtime: "codex",
+      source: "runtime",
+      detectedAt: "2026-07-11T00:00:00.000Z",
+      exportedAt: "2026-07-11T00:01:00.000Z",
+      bodyRef: { store: "authored-cas/v1", ...bodyRef },
+      snapshot: {
+        capturedAt: "2026-07-11T00:01:00.000Z",
+        completeness: "complete",
+        captureRange: { messageCount: 1 },
+        privacyScan: { scannerVersion: "test", passed: true, findings: [] }
+      }
+    }));
+    const archived = finalizeExecutionSessionBindings(
+      rootDir,
+      [primarySessionBinding(archivedId)],
+      endedAt
+    );
+    assert.equal(archived[0]?.archive_status, "complete");
+
+    const exportableId = "exportable-session";
+    writeFileSync(path.join(logsRoot, `${exportableId}.jsonl`), `${JSON.stringify({
+      timestamp: "2026-07-11T00:00:01.000Z",
+      type: "event_msg",
+      payload: { type: "user_message", message: "export me" }
+    })}\n`, "utf8");
+    const exportableBinding = primarySessionBinding(exportableId);
+    const exportableInspection = await inspectRuntimeTranscript(exportableBinding.session!, {
+      runtimeLogRoots: { codex: [logsRoot] }
+    });
+    recordRuntimeTranscriptInspection(exportableBinding.session!, exportableInspection.status);
+    assert.throws(() => finalizeExecutionSessionBindings(
+      rootDir,
+      [exportableBinding],
+      endedAt
+    ), /snapshot is not finalized/u);
+
+    const unavailableId = "confirmed-missing-session";
+    const unavailableBinding = primarySessionBinding(unavailableId);
+    const unavailableInspection = await inspectRuntimeTranscript(unavailableBinding.session!, {
+      runtimeLogRoots: { codex: [logsRoot] }
+    });
+    recordRuntimeTranscriptInspection(unavailableBinding.session!, unavailableInspection.status);
+    const unavailable = finalizeExecutionSessionBindings(
+      rootDir,
+      [unavailableBinding],
+      endedAt
+    );
+    assert.deepEqual(unavailable[0], {
+      ...primarySessionBinding(unavailableId),
+      archive_status: "unavailable",
+      capture_range: {
+        ...primarySessionBinding(unavailableId).capture_range!,
+        end_at: endedAt
+      }
+    });
+    assert.equal(existsSync(path.join(rootDir, "harness", "sessions", `${unavailableId}.md`)), false);
+
+    const invalidRoot = path.join(rootDir, "not-a-jsonl-source.txt");
+    writeFileSync(invalidRoot, "not a transcript\n", "utf8");
+    const indeterminateBinding = primarySessionBinding("indeterminate-session");
+    const indeterminateInspection = await inspectRuntimeTranscript(indeterminateBinding.session!, {
+      runtimeLogRoots: { codex: [invalidRoot] }
+    });
+    recordRuntimeTranscriptInspection(indeterminateBinding.session!, indeterminateInspection.status);
+    assert.throws(() => finalizeExecutionSessionBindings(
+      rootDir,
+      [indeterminateBinding],
+      endedAt
+    ), /snapshot is not finalized/u);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/application/test/provenance-binding-service.test.ts
+++ b/packages/application/test/provenance-binding-service.test.ts
@@ -1,11 +1,11 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
-import { makeDecisionWriteService, makeFactWriteService, makeHumanFallbackSessionProbe, makeProvenanceSessionExporter, type DecisionCreateInput } from "../src/index.ts";
+import { bindCreateProvenance, makeDecisionWriteService, makeFactWriteService, makeHumanFallbackSessionProbe, makeProvenanceSessionExporter, type DecisionCreateInput } from "../src/index.ts";
 import { makeJournaledWriteCoordinator, makeMarkdownArtifactStore, type DecisionPackage, type WriteAttribution, type WriteCoordinator, type WriteOp } from "../../kernel/src/index.ts";
 import { runEffect } from "./effect-test-helpers.ts";
 
@@ -107,6 +107,40 @@ test("fact create service binds provenance into the single-line record and expor
     assert.equal(session.path, "sessions/human-cli-1783036800000.md");
     assert.equal(session.session.runtime, "human");
     assert.deepEqual(syncedPaths, ["sessions/human-cli-1783036800000.md"]);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("automatic provenance binding keeps the session pointer when transcript availability is indeterminate", async () => {
+  const rootDir = createHarnessRoot();
+  try {
+    const session = {
+      runtime: "codex",
+      sessionId: "unconfigured-runtime-root-session",
+      source: "runtime",
+      detectedAt: "2026-07-03T00:00:00.000Z"
+    } as const;
+    const currentSessionProbe = { currentSession: Effect.succeed(session) };
+    const provenanceSessionExporter = makeProvenanceSessionExporter({
+      rootInput: rootDir,
+      currentSessionProbe,
+      coordinator: makeJournaledWriteCoordinator({ rootDir, attribution: testAttribution }),
+      artifactStore: makeMarkdownArtifactStore({ rootDir }),
+      runtimeLogRoots: { codex: [path.join(rootDir, "nonexistent-runtime-root")] }
+    });
+
+    const provenance = await runEffect(bindCreateProvenance({
+      currentSessionProbe,
+      provenanceSessionExporter
+    }, "2026-07-03T00:01:00.000Z"));
+
+    assert.deepEqual(provenance, {
+      runtime: "codex",
+      sessionId: session.sessionId,
+      boundAt: "2026-07-03T00:01:00.000Z"
+    });
+    assert.equal(existsSync(path.join(rootDir, "harness", "sessions", `${session.sessionId}.md`)), false);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }

--- a/packages/application/test/provenance-session-exporter.test.ts
+++ b/packages/application/test/provenance-session-exporter.test.ts
@@ -471,6 +471,8 @@ test("provenance session exporter backfills ZCode runtime logs by discovered ses
 test("provenance session exporter fails closed without writing when runtime log is missing", async () => {
   const rootDir = createHarnessRoot();
   try {
+    const logsRoot = path.join(rootDir, "missing-runtime-logs");
+    mkdirSync(logsRoot, { recursive: true });
     const exporter = makeTestProvenanceSessionExporter(rootDir, {
       currentSessionProbe: fixedSessionProbe({
         runtime: "codex",
@@ -478,14 +480,63 @@ test("provenance session exporter fails closed without writing when runtime log 
         source: "runtime",
         detectedAt: "2026-07-03T00:00:00.000Z"
       }),
-      runtimeLogRoots: { codex: [path.join(rootDir, "missing-runtime-logs")] },
+      runtimeLogRoots: { codex: [logsRoot] },
       now: () => "2026-07-03T00:01:00.000Z"
     });
 
     const exported = await runEffectExit(exporter.exportCurrentSession());
     assert.equal(exported._tag, "Failure");
     assert.match(String(exported.cause), /No runtime JSONL log found for codex session missing-codex-session/u);
+    assert.match(String(exported.cause), /transcript_unavailable/u);
     assert.equal(existsSync(path.join(rootDir, "harness", "sessions", "missing-codex-session.md")), false);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("provenance session exporter does not call an existing but unreadable transcript unavailable", async () => {
+  const rootDir = createHarnessRoot();
+  try {
+    const logsRoot = path.join(rootDir, "runtime-logs");
+    mkdirSync(logsRoot, { recursive: true });
+    writeFileSync(path.join(logsRoot, "empty-codex-session.jsonl"), "{\"type\":\"metadata\"}\n", "utf8");
+    const exporter = makeTestProvenanceSessionExporter(rootDir, {
+      currentSessionProbe: fixedSessionProbe({
+        runtime: "codex",
+        sessionId: "empty-codex-session",
+        source: "runtime",
+        detectedAt: "2026-07-03T00:00:00.000Z"
+      }),
+      runtimeLogRoots: { codex: [logsRoot] }
+    });
+
+    const exported = await runEffectExit(exporter.exportCurrentSession());
+    assert.equal(exported._tag, "Failure");
+    assert.match(String(exported.cause), /read_failed/u);
+    assert.doesNotMatch(String(exported.cause), /transcript_unavailable/u);
+    assert.equal(existsSync(path.join(rootDir, "harness", "sessions", "empty-codex-session.md")), false);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("provenance session exporter keeps absence indeterminate when no configured root exists", async () => {
+  const rootDir = createHarnessRoot();
+  try {
+    const exporter = makeTestProvenanceSessionExporter(rootDir, {
+      currentSessionProbe: fixedSessionProbe({
+        runtime: "codex",
+        sessionId: "unknown-home-session",
+        source: "runtime",
+        detectedAt: "2026-07-03T00:00:00.000Z"
+      }),
+      runtimeLogRoots: { codex: [path.join(rootDir, "nonexistent-root")] }
+    });
+
+    const exported = await runEffectExit(exporter.exportCurrentSession());
+    assert.equal(exported._tag, "Failure");
+    assert.match(String(exported.cause), /read_failed/u);
+    assert.doesNotMatch(String(exported.cause), /transcript_unavailable/u);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
@@ -547,6 +598,8 @@ test("provenance session exporter rejects legacy session markdown after cutover"
 test("automatic provenance binding keeps the session pointer when the transcript is unavailable", async () => {
   const rootDir = createHarnessRoot();
   try {
+    const logsRoot = path.join(rootDir, "missing-runtime-logs");
+    mkdirSync(logsRoot, { recursive: true });
     const currentSessionProbe = fixedSessionProbe({
       runtime: "codex",
       sessionId: "desktop-ephemeral-session",
@@ -555,7 +608,7 @@ test("automatic provenance binding keeps the session pointer when the transcript
     });
     const provenanceSessionExporter = makeTestProvenanceSessionExporter(rootDir, {
       currentSessionProbe,
-      runtimeLogRoots: { codex: [path.join(rootDir, "missing-runtime-logs")] }
+      runtimeLogRoots: { codex: [logsRoot] }
     });
 
     const provenance = await runEffect(bindCreateProvenance({

--- a/packages/cli/src/commands/core/task-holder-execution-saga.ts
+++ b/packages/cli/src/commands/core/task-holder-execution-saga.ts
@@ -24,21 +24,14 @@ export function commandExecutionSaga(context: CommandRunnerContext) {
         } catch {
           // A missing or legacy Session is finalized through the existing exporter below.
         }
-        const exported = await Effect.runPromise(context.provenanceSessionExporter.exportSession(session)).catch((error: unknown) => {
-          if (isConfirmedTranscriptUnavailable(error)) return null;
-          throw error;
-        });
+        const exported = await Effect.runPromise(context.provenanceSessionExporter.exportSession(session).pipe(
+          Effect.catchAll((error) => error.code === "transcript_unavailable"
+            ? Effect.succeed(null)
+            : Effect.fail(error))
+        ));
         if (!exported) return;
         await Effect.runPromise(context.syncExportedSession(exported));
       }
     })
   };
-}
-
-function isConfirmedTranscriptUnavailable(error: unknown): boolean {
-  return Boolean(error && typeof error === "object"
-    && "_tag" in error
-    && (error as { readonly _tag?: unknown })._tag === "ProvenanceSessionExporterRejected"
-    && "code" in error
-    && (error as { readonly code?: unknown }).code === "transcript_unavailable");
 }

--- a/packages/cli/src/commands/core/task-holder-execution-saga.ts
+++ b/packages/cli/src/commands/core/task-holder-execution-saga.ts
@@ -1,0 +1,44 @@
+import { Effect } from "effect";
+import {
+  makeCoordinatedExecutionAuthoredStore,
+  makeExecutionSagaService
+} from "@harness-anything/application";
+import { readSessionEntityDocument } from "@harness-anything/kernel";
+import type { CommandRunnerContext } from "../../cli/runner-registry.ts";
+
+export function commandExecutionSaga(context: CommandRunnerContext) {
+  const coordinator = context.makeWriteCoordinator({ scope: "operational", kind: "agent", id: "execution-saga" });
+  const authoredStore = makeCoordinatedExecutionAuthoredStore({
+    rootInput: context.layoutInput,
+    coordinator,
+    artifactStore: context.artifactStore
+  });
+  return {
+    authoredStore,
+    saga: makeExecutionSagaService({
+      taskHolderService: context.taskHolderService,
+      authoredStore,
+      finalizeSession: async (session) => {
+        try {
+          if (readSessionEntityDocument(context.layoutInput, session.sessionId).format === "manifest") return;
+        } catch {
+          // A missing or legacy Session is finalized through the existing exporter below.
+        }
+        const exported = await Effect.runPromise(context.provenanceSessionExporter.exportSession(session)).catch((error: unknown) => {
+          if (isConfirmedTranscriptUnavailable(error)) return null;
+          throw error;
+        });
+        if (!exported) return;
+        await Effect.runPromise(context.syncExportedSession(exported));
+      }
+    })
+  };
+}
+
+function isConfirmedTranscriptUnavailable(error: unknown): boolean {
+  return Boolean(error && typeof error === "object"
+    && "_tag" in error
+    && (error as { readonly _tag?: unknown })._tag === "ProvenanceSessionExporterRejected"
+    && "code" in error
+    && (error as { readonly code?: unknown }).code === "transcript_unavailable");
+}

--- a/packages/cli/src/commands/core/task-holder.ts
+++ b/packages/cli/src/commands/core/task-holder.ts
@@ -1,16 +1,15 @@
 import { Effect } from "effect";
 import {
-  makeCoordinatedExecutionAuthoredStore,
-  makeExecutionSagaService,
   readTaskLifecyclePolicy,
   type TaskHolderPrincipal
 } from "@harness-anything/application";
-import { readSessionEntityDocument, type WriteError } from "@harness-anything/kernel";
+import type { WriteError } from "@harness-anything/kernel";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import { toCliError } from "../../cli/error-mapper.ts";
 import type { CliResult } from "../../cli/types.ts";
 import type { CommandRunner, CommandRunnerContext } from "../../cli/runner-registry.ts";
 import { milestoneDecisionLineageFailure } from "./task-lineage-gate.ts";
+import { commandExecutionSaga } from "./task-holder-execution-saga.ts";
 import { plannedTaskClaimGuidance } from "./task-lifecycle-facade-guidance.ts";
 import { resultForTaskHolderFailure, taskHolderCommandFailure, taskHolderPrincipal } from "./task-holder-support.ts";
 type TaskHolderAction = Extract<
@@ -22,7 +21,7 @@ function runExecutionClaim(
   action: Extract<TaskHolderAction, { readonly kind: "task-claim" }>,
   principal: TaskHolderPrincipal
 ): Effect.Effect<CliResult> {
-  const saga = executionSaga(context);
+  const { saga } = commandExecutionSaga(context);
   return context.currentSessionProbe.currentSession.pipe(
     Effect.flatMap((session) => Effect.tryPromise({
       try: () => saga.claim({
@@ -59,7 +58,7 @@ export function runExecutionSubmit(
 ): Effect.Effect<CliResult> {
   const principal = taskHolderPrincipal(context);
   if (!principal.ok) return Effect.succeed(principal.result);
-  const saga = executionSaga(context);
+  const { authoredStore, saga } = commandExecutionSaga(context);
   const submission = action.executionSubmission!;
   return Effect.gen(function* () {
     const snapshot = submission.executionId
@@ -114,13 +113,29 @@ export function runExecutionSubmit(
           : cliError(CliErrorCode.WriteRejected, submitted.error instanceof Error ? submitted.error.message : String(submitted.error))
       } satisfies CliResult;
     }
+    const submittedExecution = yield* Effect.promise(() => authoredStore.readExecution({
+      taskId: action.taskId,
+      executionId
+    }));
+    const unavailableBindings = submittedExecution?.session_bindings
+      .filter((binding) => binding.archive_status === "unavailable")
+      .map((binding) => ({
+        bindingId: binding.binding_id,
+        sessionRef: binding.session_ref,
+        archiveStatus: binding.archive_status
+      })) ?? [];
     return {
       ok: true,
       command: "status-set",
       taskId: action.taskId,
       executionId,
       status: "in_review",
-      report: { schema: "execution-submit-result/v1", executionId, leaseReleased: true }
+      report: {
+        schema: "execution-submit-result/v1",
+        executionId,
+        leaseReleased: true,
+        unavailableBindings
+      }
     } satisfies CliResult;
   });
 }
@@ -129,27 +144,6 @@ function isTaskHolderWriteError(error: unknown): error is WriteError {
   return typeof error === "object" && error !== null && "_tag" in error && [
     "WriteRejected", "WriteConflict", "GlobalWriteConflict", "JournalUnavailable"
   ].includes(String(error._tag));
-}
-
-function executionSaga(context: CommandRunnerContext) {
-  const coordinator = context.makeWriteCoordinator({ scope: "operational", kind: "agent", id: "execution-saga" });
-  return makeExecutionSagaService({
-    taskHolderService: context.taskHolderService,
-    authoredStore: makeCoordinatedExecutionAuthoredStore({
-      rootInput: context.layoutInput,
-      coordinator,
-      artifactStore: context.artifactStore
-    }),
-    finalizeSession: async (session) => {
-      try {
-        if (readSessionEntityDocument(context.layoutInput, session.sessionId).format === "manifest") return;
-      } catch {
-        // A missing or legacy Session is finalized through the existing exporter below.
-      }
-      const exported = await Effect.runPromise(context.provenanceSessionExporter.exportSession(session));
-      await Effect.runPromise(context.syncExportedSession(exported));
-    }
-  });
 }
 
 export function runTaskClaim(

--- a/packages/cli/test/session-cli.test.ts
+++ b/packages/cli/test/session-cli.test.ts
@@ -52,7 +52,9 @@ test("CLI session export binds CODEX_THREAD_ID and writes managed session markdo
 test("CLI session export fails closed without writing when a runtime transcript is unavailable", () => {
   withTempRoot((rootDir) => {
     const harnessRoot = path.join(rootDir, "harness");
+    const homeDir = path.join(rootDir, "empty-home");
     mkdirSync(harnessRoot, { recursive: true });
+    mkdirSync(path.join(homeDir, ".codex", "sessions"), { recursive: true });
     initHarnessGit(harnessRoot);
 
     const exported = runJson(rootDir, [
@@ -60,7 +62,7 @@ test("CLI session export fails closed without writing when a runtime transcript 
       "--session", "missing-desktop-thread",
       "--runtime", "codex",
       "--source", "runtime"
-    ], false);
+    ], false, { HOME: homeDir });
 
     assert.equal(exported.ok, false);
     assert.equal(exported.error?.code, "session_export_failed");

--- a/packages/cli/test/task-lease-cli.test.ts
+++ b/packages/cli/test/task-lease-cli.test.ts
@@ -2,7 +2,7 @@
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -320,6 +320,49 @@ test("default claim preserves status and the Holder V2 actor can submit without 
     assert.equal(submitted.report.leaseReleased, true);
     const holder = runJson(rootDir, ["task", "holder", created.taskId]);
     assert.equal(holder.report.effectiveHolder, null);
+  });
+});
+
+test("submit reports a confirmed unavailable binding without changing its Session ownership", () => {
+  withTempRoot((rootDir) => {
+    writeHarnessIdentity(rootDir, "person_zeyu", "Zeyu Li");
+    const created = runJson(rootDir, ["new-task", "--title", "Unavailable Session"]);
+    writeSubstantiveTaskPlan(rootDir, created.packagePath);
+    const sessionId = "missing-codex-primary-session";
+    const homeDir = path.join(rootDir, "empty-home");
+    mkdirSync(path.join(homeDir, ".codex", "sessions"), { recursive: true });
+    const sessionEnv = {
+      HARNESS_ACTOR: "agent:test",
+      HOME: homeDir,
+      CODEX_THREAD_ID: sessionId,
+      CODEX_SESSION_ID: sessionId
+    };
+    const claimed = runJson(rootDir, ["task", "claim", created.taskId], true, sessionEnv);
+    runJson(rootDir, ["task", "transition", created.taskId, "active"], true, sessionEnv);
+
+    const submitted = runJson(rootDir, [
+      "task", "transition", created.taskId, "in_review",
+      "--summary", "ready with unavailable transcript",
+      "--verification", "node:test",
+      "--output", "commit:def456"
+    ], true, sessionEnv);
+
+    assert.equal(submitted.status, "in_review");
+    assert.deepEqual(submitted.report.unavailableBindings, [{
+      bindingId: `primary:${sessionId}`,
+      sessionRef: `session/${sessionId}`,
+      archiveStatus: "unavailable"
+    }]);
+    const executionPath = path.join(
+      rootDir,
+      `harness/tasks/${created.taskId}-unavailable-session/executions/${claimed.executionId}.md`
+    );
+    const execution = JSON.parse(readFileSync(executionPath, "utf8"));
+    assert.equal(execution.session_bindings[0].binding_id, `primary:${sessionId}`);
+    assert.equal(execution.session_bindings[0].session_ref, `session/${sessionId}`);
+    assert.equal(execution.session_bindings[0].session.sessionId, sessionId);
+    assert.equal(execution.session_bindings[0].archive_status, "unavailable");
+    assert.equal(existsSync(path.join(rootDir, "harness/sessions", `${sessionId}.md`)), false);
   });
 });
 


### PR DESCRIPTION
# English

## Summary
Root-cause fix for orphaned session bindings that blocked task closeout. When an execution's primary session snapshot was not on disk, the provenance session exporter failed hard and the task stuck in `in_review`/`active`, with no honest exit. This lands two things:
1. **Broaden runtime transcript search** to all configured runtime roots. The old exporter searched too narrow a set and missed recoverable transcripts (e.g. the Codex sessions root `~/.codex/sessions/...`). Broadening it recovers transcripts that were never truly lost — so the honest path is "export it", not "declare it gone".
2. **Add an honest `unavailable` terminal `archive_status`** for genuinely-lost transcripts, gated conservatively (fail-closed). The domain enum already declared `unavailable`; this fills in the missing detection, finalization, and audit path.

## What Changed
- `provenance-session-exporter.ts`: before export, probe transcript availability and distinguish **confirmed unavailable** from **read failure**.
- `runtime-session-logs.ts`: conservatively search every configured runtime root (this is what recovers previously-missed transcripts).
- `runtime-transcript-confirmation.ts`: record a confirmation keyed by `runtime + sessionId`, valid only for the current export attempt (process-in-memory, single command).
- `coordinated-execution-authored-store.ts`: finalize a binding to `unavailable` **only** when all guards hold — missing-snapshot error, `source === "runtime"`, `sessionId` preserved (no rebinding), and a consumed confirmed-unavailable proof. Otherwise it **throws** (fail-closed). The `unavailable` path writes **no snapshot**.
- `task-holder.ts` / `task-holder-execution-saga.ts`: closeout receipt surfaces `unavailableBindings` (auditable, not silent).
- Three test files pin the exporter, finalizer, and CLI closeout chain.

## Task And Scope
- Task: `task_01KY6GHJQ4S5BREZ61N7PQV8C8` (L1 flow-defect: closeout blocked by orphaned session binding), under umbrella `task_01KXWZ3YEGXD6302G1656RY801` (PLT-Baseline-Governance).
- Scope: provenance export + execution finalization + CLI closeout receipt. No authority-token or gate-decision semantics changed.

## Version Impact
- Additive detection/finalization for an already-declared enum value. No schema break.

## Governance Declaration
- Authorized by decision `dec_01KY6N7THJECX1GR4SZHSEJY9J` (active): add an honest `unavailable` binding state; **red line — no fabricated placeholder snapshot, no attribution rebinding.**
- Authorizing task: `task_01KY6GHJQ4S5BREZ61N7PQV8C8`.
- Protected-surface discipline (provenance/session/execution): the honesty invariant is enforced by test — the `unavailable` path writes no `harness/sessions/<id>.md`, and `sessionId` is preserved. `write-road-registry` unchanged.

## Verification
- Targeted exporter + finalizer + CLI tests: exit `0`, 35 pass.
- CLI combined gate: 368/368. `npm run typecheck` pass. `npm run check:local` (authoritative local stop-point) pass. complexity / forbidden-symbols / duplicate-definitions / write-road-registry all pass.
- **Honesty negative controls** (real assertions):
  - available snapshot → `archive_status=complete` (normal export).
  - snapshot missing but not confirmed-unavailable → **throws** `snapshot is not finalized` (fail-closed).
  - confirmed missing transcript → `archive_status=unavailable`, `sessionId` preserved, and `existsSync(harness/sessions/<id>.md) === false` (**no fabricated snapshot**).

## Review Evidence
- CEO ground-truthed the finalizer hunk and the negative-control test directly: the four `unavailable` guards, the fail-closed throw, and the `existsSync(...) === false` no-fabrication assertion. S3 (`task_01KY516PSKVSRK2H34ZJ1X9SDH`) walked to `done` via the **normal** export path (recovered transcript, real 13,957-byte CAS body, `sessionId` unchanged) — the fix correctly refused to force it into `unavailable`.

## Residual Risk
- The confirmed-unavailable proof is process-in-memory and valid for a single command. If exporter/finalizer are ever split across processes, the confirmation must be upgraded to governed durable evidence — not simply relaxed.
- S3's recovered snapshot carries private-path privacy-scan findings, so that archive is internal-only (does not affect its validity as real internal provenance).

## References
- Decision: `dec_01KY6N7THJECX1GR4SZHSEJY9J`
- Defect task: `task_01KY6GHJQ4S5BREZ61N7PQV8C8`
- E2E target: `task_01KY516PSKVSRK2H34ZJ1X9SDH` (S3, now `done`)
- Umbrella: `task_01KXWZ3YEGXD6302G1656RY801`

---

# 中文

## 概要
根因修复:orphaned session binding 阻塞任务收口。当 execution 的 primary session 快照不在磁盘上时,provenance session 导出直接硬失败,任务卡在 `in_review`/`active`,且没有诚实出口。本 PR 落两件事:
1. **拓宽 runtime transcript 搜索**到所有配置的 runtime root。旧导出器搜索面太窄,漏掉了可恢复的 transcript(如 Codex sessions root `~/.codex/sessions/...`)。拓宽后能找回本就没真丢的 transcript——诚实路径是"导出它",而不是"宣布它没了"。
2. **为真正丢失的 transcript 增加诚实的 `unavailable` 终态 `archive_status`**,判据保守(fail-closed)。domain 枚举早已声明 `unavailable`,本次补齐此前缺失的判定、终结与审计链路。

## 改动内容
- `provenance-session-exporter.ts`:导出前探测 transcript 可得性,区分**确认不可得**与**读取失败**。
- `runtime-session-logs.ts`:保守搜索每一个配置的 runtime root(这正是找回此前漏掉 transcript 的关键)。
- `runtime-transcript-confirmation.ts`:按 `runtime + sessionId` 键控记录确认,仅对当前导出尝试有效(进程内、单次命令)。
- `coordinated-execution-authored-store.ts`:**只有**全部守卫成立时才把 binding 终结为 `unavailable`——missing-snapshot 错误、`source === "runtime"`、`sessionId` 保持不变(不重绑)、消费到 confirmed-unavailable 证明;否则**抛错**(fail-closed)。`unavailable` 路径**不写任何快照**。
- `task-holder.ts` / `task-holder-execution-saga.ts`:收口回执显式输出 `unavailableBindings`(可审计,不静默)。
- 三个测试文件钉死 exporter、finalizer 与 CLI 收口链。

## 任务与范围
- 任务:`task_01KY6GHJQ4S5BREZ61N7PQV8C8`(L1 flow-defect:收口被 orphaned session binding 阻塞),挂伞 `task_01KXWZ3YEGXD6302G1656RY801`(PLT-Baseline-Governance)。
- 范围:provenance 导出 + execution 终结 + CLI 收口回执。不动 authority-token 或 gate 判定语义。

## 版本影响
- 对一个早已声明的枚举值补齐检测/终结,追加式。无 schema 破坏。

## 治理声明
- 由决策 `dec_01KY6N7THJECX1GR4SZHSEJY9J`(active)授权:增加诚实的 `unavailable` binding 状态;**红线——不伪造占位快照、不改归属重绑。**
- 授权任务:`task_01KY6GHJQ4S5BREZ61N7PQV8C8`。
- protected-surface 纪律(provenance/session/execution):诚实不变量由测试强制——`unavailable` 路径不写 `harness/sessions/<id>.md`,且 `sessionId` 保持不变。`write-road-registry` 不变。

## 验证
- 定向 exporter + finalizer + CLI 测试:退出码 `0`,35 项通过。
- CLI 组合门:368/368。`npm run typecheck` 通过。`npm run check:local`(权威本地停止点)通过。complexity / forbidden-symbols / duplicate-definitions / write-road-registry 全通过。
- **诚实性阴性对照**(真实断言):
  - 快照存在 → `archive_status=complete`(正常导出)。
  - 快照缺失但未确认不可得 → **抛错** `snapshot is not finalized`(fail-closed)。
  - 确认 transcript 不存在 → `archive_status=unavailable`,`sessionId` 保持不变,且 `existsSync(harness/sessions/<id>.md) === false`(**不伪造快照**)。

## 审查证据
- CEO 直接 ground-truth 了 finalizer hunk 与阴性对照测试:四个 `unavailable` 守卫、fail-closed 抛错、以及 `existsSync(...) === false` 无伪造断言。S3(`task_01KY516PSKVSRK2H34ZJ1X9SDH`)经**正常**导出路径走到 `done`(找回 transcript、真实 13,957 字节 CAS body、`sessionId` 未变)——修复正确地拒绝把它强标成 `unavailable`。

## 残余风险
- confirmed-unavailable 证明是进程内、单次命令有效。若未来把 exporter/finalizer 拆到多进程,该确认须升级为受治理的持久证据,不能简单放宽。
- S3 找回的快照带私有路径 privacy-scan findings,故该归档仅内部可用(不影响其作为真实内部 provenance 的有效性)。

## 关联材料
- 决策:`dec_01KY6N7THJECX1GR4SZHSEJY9J`
- 缺陷任务:`task_01KY6GHJQ4S5BREZ61N7PQV8C8`
- 端到端目标:`task_01KY516PSKVSRK2H34ZJ1X9SDH`(S3,现 `done`)
- 伞:`task_01KXWZ3YEGXD6302G1656RY801`
