### PR TITLE
test(ci): decouple fixed wall-clock budget assertions from correctness

### DIFF
--- a/packages/cli/test/daemon-snapshot-integration.test.ts
+++ b/packages/cli/test/daemon-snapshot-integration.test.ts
@@ -2,7 +2,10 @@
 import assert from "node:assert/strict";
 import { readFileSync, rmSync } from "node:fs";
 import test from "node:test";
-import { requestLocalDaemonJsonRpc } from "../../daemon/src/index.ts";
+import {
+  defaultDaemonJsonRpcRequestTimeoutMs,
+  requestLocalDaemonJsonRpc
+} from "../../daemon/src/index.ts";
 import { daemonLaunchSpecPath } from "../src/daemon/daemon-launch-spec.ts";
 import {
   defaultDaemonUserRoot,
@@ -11,14 +14,24 @@ import {
 } from "./helpers/daemon-cli.ts";
 import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
 
-test("daemon upgrade serves the installed snapshot identity and persists its entrypoint", { timeout: 90_000 }, async () => {
+const snapshotTestTimeoutMs = positiveIntegerEnv(
+  "HARNESS_TEST_DAEMON_SNAPSHOT_TIMEOUT_MS",
+  process.env.CI ? 180_000 : 90_000
+);
+const snapshotRequestTimeoutMs = positiveIntegerEnv(
+  "HARNESS_TEST_DAEMON_SNAPSHOT_REQUEST_TIMEOUT_MS",
+  process.env.CI ? 90_000 : defaultDaemonJsonRpcRequestTimeoutMs
+);
+
+test("daemon upgrade serves the installed snapshot identity and persists its entrypoint", { timeout: snapshotTestTimeoutMs }, async () => {
   const fixture = createFixture();
   const userRoot = defaultDaemonUserRoot(fixture.root);
   const env = {
     HARNESS_DAEMON_MODE: "local",
     HARNESS_DAEMON_USER_ROOT: userRoot,
     HARNESS_DAEMON_IDLE_MS: "60000",
-    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000"
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: String(snapshotRequestTimeoutMs)
   };
   try {
     runDaemonCommand(fixture.repoRoot, [
@@ -89,3 +102,8 @@ test("daemon upgrade serves the installed snapshot identity and persists its ent
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
+
+function positiveIntegerEnv(name: string, fallback: number): number {
+  const parsed = Number(process.env[name]);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/packages/daemon/test/local-json-rpc-client.test.ts
+++ b/packages/daemon/test/local-json-rpc-client.test.ts
@@ -149,23 +149,17 @@ test("JSON-RPC requests reject within their deadline when the peer never respond
   const input = new PassThrough();
   const output = new PassThrough();
   const client = new JsonRpcLineClient(input, output);
-  const startedAt = Date.now();
   try {
-    const outcome = await Promise.race([
+    await assert.rejects(
       client.request(
         "repo.command.run",
         {},
         30
-      ).then(
-        () => "resolved",
-        (error: unknown) => error
       ),
-      delay(150).then(() => "outer-timeout")
-    ]);
-
-    assert.notEqual(outcome, "outer-timeout", "request must enforce its own deadline");
-    assert.match(outcome instanceof Error ? outcome.message : "", /DAEMON_JSON_RPC_REQUEST_TIMEOUT.*repo\.command\.run.*30ms/u);
-    assert.ok(Date.now() - startedAt < 150);
+      (error: unknown) => error instanceof DaemonJsonRpcRequestTimeoutError
+        && error.method === "repo.command.run"
+        && error.timeoutMs === 30
+    );
   } finally {
     input.destroy();
     output.destroy();
@@ -427,7 +421,6 @@ test("autostart bounds a never-responding ready probe by the total startup budge
     await closeServer(server);
     rmSync(socketPath, { force: true });
   });
-  const startedAt = Date.now();
 
   await assert.rejects(
     requestLocalDaemonJsonRpcForTarget(
@@ -440,8 +433,6 @@ test("autostart bounds a never-responding ready probe by the total startup budge
     (error: unknown) => !(error instanceof DaemonJsonRpcRequestTimeoutError)
       && /autostart.*1200ms/u.test(error instanceof Error ? error.message : "")
   );
-  const elapsedMs = Date.now() - startedAt;
-  assert.ok(elapsedMs >= 1_000 && elapsedMs < 2_000, `expected total-budget failure near 1200ms; saw ${elapsedMs}ms`);
   assert.ok(helloCalls >= 2, `expected multiple bounded ready probes; saw ${helloCalls}`);
 });
 
@@ -488,7 +479,6 @@ test("autostart bounds an accepted local request when the daemon never responds"
     await closeServer(server);
     rmSync(socketPath, { force: true });
   });
-  const startedAt = Date.now();
 
   await assert.rejects(
     requestLocalDaemonJsonRpcForTarget(
@@ -502,7 +492,6 @@ test("autostart bounds an accepted local request when the daemon never responds"
       && error.method === "repo.command.run"
       && error.timeoutMs <= 40
   );
-  assert.ok(Date.now() - startedAt < 200);
 });
 
 function makeTarget(socketPath: string): LocalDaemonTarget {

--- a/packages/vscode-ext/test/lifecycle.test.ts
+++ b/packages/vscode-ext/test/lifecycle.test.ts
@@ -9,9 +9,7 @@ test("extension disposal is bounded and invokes dispose without terminal termina
     calls.push("dispose");
     await new Promise(() => undefined);
   } });
-  const started = Date.now();
   await disposeExtensionResources(5);
-  assert.ok(Date.now() - started < 100);
   assert.deepEqual(calls, ["dispose"]);
   assert.equal(calls.includes("terminate"), false);
 });


### PR DESCRIPTION
# English

## Summary
Decouple fixed wall-clock budget assertions from correctness across a flaky test family, ending the "fix one red at a time" cycle. On 2-core CI runners, performance has random jitter, so a "finished within X ms" assertion is a probabilistic red that no code change can control (a pure-docs PR #1006 red-flaked two integration shards — negative control that the family's reds are causally unrelated to any diff). These assertions are replaced with **semantic** ones (the timeout fires with the right error type, method, and budget), or made **env-overridable** where wall-clock is a legitimate signal, with production timeout **semantics unchanged**.

## What Changed
- `packages/daemon/test/local-json-rpc-client.test.ts`: drop the 150ms / 1–2s / 200ms elapsed-time windows; assert instead on `DaemonJsonRpcRequestTimeoutError` type, `method`, `timeoutMs` budget, and probe count. The timeout still must fire and carry correct metadata — only the timing race is removed.
- `packages/cli/test/daemon-snapshot-integration.test.ts`: add a **test-only** env override (CI defaults 180s/90s; local stays 90s / production request default). Production default semantics are not changed.
- `packages/vscode-ext/test/lifecycle.test.ts`: drop the `<100ms` window; keep the dispose-return and no-terminal-termination behavior assertions.
- Inventory report: `harness/tasks/task_01KY5A2FPV8NA5YX8PBWA27YMH-ci-t2-env/artifacts/wall-clock-assertion-inventory.md`.

## Task And Scope
- Task: `task_01KY5A2FPV8NA5YX8PBWA27YMH` (CI-T2: fixed wall-clock budget assertion family), under umbrella `task_01KXWZ3YEGXD6302G1656RY801` (PLT-Baseline-Governance).
- Scope: test assertions + test-only env overrides. No production code, no gate config, no CI-workflow change.

## Version Impact
- Test-only. No schema or production-behavior change.

## Governance Declaration
- Authorizing task: `task_01KY5A2FPV8NA5YX8PBWA27YMH`. Consistent with decision `dec_01KXE36A` (perf gate = relative overhead, not absolute ms).
- No protected surface touched: no gate is skipped, weakened, or set to `continue-on-error`; production timeout default **semantics** are unchanged (only test/CI override hooks added).

## Verification
- `npm run check:local`: 34 manifest gates green (76.6s). Affected contract: 197/197. Targeted refactor tests: 17/17. `CI=1` snapshot: 1/1. `write-road-registry` unchanged (delta 0).
- **Honesty negative controls** (the assertions still red on real failure):
  - daemon refresh: injected a stuck drain → real failure `daemon_queue_drain_timeout` (`1 !== 0`), ~26.1s; restored → 4/4 pass.
  - supply-chain: hanging npm → two SIGKILLs, budget-exhausted `1 !== 0`, ~11.1s; restored → 15/15 pass, hanging PID confirmed gone.

## Review Evidence
- CEO ground-truthed the diff: the removed wall-clock windows are replaced by semantic timeout assertions (error type + method + budget), not deleted outright. Negative controls confirm the decoupled tests still fail on genuine non-convergence / hangs.

## Residual Risk
- **Follow-up — deliberately not decoupled (worker dissent, CEO-noted)**: A5–A7 are *true* performance gates where wall-clock latency itself is the only regression signal. A6/A7 already carry env multipliers; A5 (artifact-identity median `<50ms`) has no relative-baseline override yet and was **kept** — deleting it would silently miss latency regressions. A follow-up decision/task should decide A5's relative-baseline scheme per `dec_01KXE36A`.

## References
- Task: `task_01KY5A2FPV8NA5YX8PBWA27YMH`
- Umbrella: `task_01KXWZ3YEGXD6302G1656RY801`
- Related decision: `dec_01KXE36A`

---

# 中文

## 概要
把固定墙钟预算断言与正确性解耦,终结「每红一个改一个」的循环。2 核 CI runner 上性能有随机波动,「X 毫秒内完成」这种断言是概率性红、任何代码改动都控制不了(纯文档 PR #1006 红了两个 integration shard——阴性对照证明这族红与任何 diff 无因果)。这些断言改为**语义**断言(超时以正确的 error 类型、method、预算触发),或在墙钟确实是合理信号处改为 **env 可覆盖**,且生产超时**语义不变**。

## 改动内容
- `packages/daemon/test/local-json-rpc-client.test.ts`:删除 150ms / 1–2s / 200ms 的耗时窗口;改为断言 `DaemonJsonRpcRequestTimeoutError` 类型、`method`、`timeoutMs` 预算与 probe 次数。超时仍必须触发并带正确元数据——只移除计时竞态。
- `packages/cli/test/daemon-snapshot-integration.test.ts`:加**测试专用** env 覆盖(CI 默认 180s/90s;本地仍 90s / 生产 request 默认值)。生产默认语义不变。
- `packages/vscode-ext/test/lifecycle.test.ts`:删除 `<100ms` 窗口;保留 dispose 返回与禁止 terminal termination 的行为断言。
- 清点报告:`harness/tasks/task_01KY5A2FPV8NA5YX8PBWA27YMH-ci-t2-env/artifacts/wall-clock-assertion-inventory.md`。

## 任务与范围
- 任务:`task_01KY5A2FPV8NA5YX8PBWA27YMH`(CI-T2:固定墙钟预算断言族),挂伞 `task_01KXWZ3YEGXD6302G1656RY801`(PLT-Baseline-Governance)。
- 范围:测试断言 + 测试专用 env 覆盖。不动生产代码、gate 配置、CI workflow。

## 版本影响
- 仅测试。无 schema 或生产行为变更。

## 治理声明
- 授权任务:`task_01KY5A2FPV8NA5YX8PBWA27YMH`。与决策 `dec_01KXE36A`(perf gate = 相对开销,非绝对 ms)一致。
- 未触碰 protected surface:未 skip / 削弱任何门,未加 `continue-on-error`;生产超时默认**语义**不变(仅加测试/CI 覆盖口)。

## 验证
- `npm run check:local`:34 个 manifest gate 全绿(76.6s)。受影响 contract:197/197。定向改造测试:17/17。`CI=1` snapshot:1/1。`write-road-registry` 不变(delta 0)。
- **诚实性阴性对照**(改造后仍能在真实失败时红):
  - daemon refresh:注入 stuck drain → 真实失败 `daemon_queue_drain_timeout`(`1 !== 0`),约 26.1s;恢复 → 4/4 通过。
  - supply-chain:hanging npm → 两次 SIGKILL,预算耗尽 `1 !== 0`,约 11.1s;恢复 → 15/15 通过,hanging PID 确认消失。

## 审查证据
- CEO ground-truth diff:被删的墙钟窗口由语义超时断言(error 类型 + method + 预算)替代,而非直接删掉。阴性对照确认解耦后的测试在真实不收敛 / 挂死时仍会红。

## 残余风险
- **后续——刻意不解耦(worker 异议,CEO 已记)**:A5–A7 是*真正*的性能门,墙钟延迟本身是唯一回归信号。A6/A7 已有 env multiplier;A5(artifact-identity 中位 `<50ms`)尚无相对基线覆盖口,故**保留**——删了会静默漏掉延迟回归。后续应立 decision/task,按 `dec_01KXE36A` 定 A5 的相对基线方案。

## 关联材料
- 任务:`task_01KY5A2FPV8NA5YX8PBWA27YMH`
- 伞:`task_01KXWZ3YEGXD6302G1656RY801`
- 关联决策:`dec_01KXE36A`
