### PR TITLE
feat(daemon): complete read-down lease contract (renewable lease + on-demand cut record)

### DIFF
--- a/packages/application/src/authority/types.ts
+++ b/packages/application/src/authority/types.ts
@@ -263,6 +263,7 @@ export interface AuthorityStreamReservation {
 export interface AuthoritySnapshotReservation {
   readonly schema: "authority-snapshot-reservation/v1";
   readonly cut: AuthoritySnapshotCut;
+  readonly cutChange?: ReplicaChangeRecord | null;
   readonly lease: AuthoritySnapshotLease;
   readonly stream: AuthorityStreamReservation;
 }

--- a/packages/application/src/authority/types.ts
+++ b/packages/application/src/authority/types.ts
@@ -251,6 +251,7 @@ export interface AuthoritySnapshotCut {
 export interface AuthoritySnapshotLease {
   readonly leaseId: string;
   readonly expiresAt: string;
+  readonly renewableUntil: string;
   readonly minRetainedRevision: number;
   readonly pinnedBlobSetDigest: Sha256Digest;
 }
@@ -263,7 +264,6 @@ export interface AuthorityStreamReservation {
 export interface AuthoritySnapshotReservation {
   readonly schema: "authority-snapshot-reservation/v1";
   readonly cut: AuthoritySnapshotCut;
-  readonly cutChange?: ReplicaChangeRecord | null;
   readonly lease: AuthoritySnapshotLease;
   readonly stream: AuthorityStreamReservation;
 }

--- a/packages/daemon/src/authority/forced-command-session.ts
+++ b/packages/daemon/src/authority/forced-command-session.ts
@@ -53,6 +53,8 @@ export interface AuthorityForcedCommandOptions {
 export interface AuthorityReadDownService {
   readonly beginSnapshot: () => Promise<AuthoritySnapshotReservation>;
   readonly getManifest: (streamToken: string, digest: Sha256Digest) => Promise<AuthoritySnapshotManifest>;
+  readonly getCutChange: (streamToken: string) => Promise<import("@harness-anything/application").ReplicaChangeRecord | null>;
+  readonly releaseLease: (streamToken: string) => Promise<void>;
   readonly getBlob: (streamToken: string, digest: Sha256Digest) => Promise<AuthorityBlobResult>;
   readonly renewLease: (streamToken: string) => Promise<AuthoritySnapshotLease>;
   readonly changesAfter: (streamToken: string, sinceRevision: number) => Promise<AuthorityChangesAfterResult>;
@@ -164,6 +166,7 @@ export function serveAuthorityForcedCommand(options: AuthorityForcedCommandOptio
           ...(options.readDownService ? [
             "begin-snapshot-and-subscribe/v1",
             "authority-snapshot-manifest/v1",
+            "authority-cut-change/v1",
             "authority-blob/v1",
             "authority-changes-after/v1",
             "authority-lease-renewal/v1"
@@ -199,7 +202,15 @@ export function serveAuthorityForcedCommand(options: AuthorityForcedCommandOptio
       try {
         const reservation = await options.readDownService.beginSnapshot();
         subscribedAfterRevision = reservation.cut.revision;
-        write(response(value.requestId, generation, true, reservation));
+        try {
+          const accepted = write(response(value.requestId, generation, true, reservation));
+          if (!accepted && (closed || options.output.destroyed || options.output.writableEnded)) {
+            throw new Error("SNAPSHOT_RESPONSE_NOT_DELIVERABLE");
+          }
+        } catch (error) {
+          await options.readDownService.releaseLease(reservation.stream.streamToken);
+          throw error;
+        }
         for (const change of pendingHints.splice(0)) {
           if (change.revision > reservation.cut.revision) writeReplicaHint(change);
         }
@@ -212,6 +223,10 @@ export function serveAuthorityForcedCommand(options: AuthorityForcedCommandOptio
     }
     if (value.kind === "get_snapshot_manifest") {
       await handleReadDown(value.requestId, () => options.readDownService!.getManifest(value.streamToken, value.manifestDigest));
+      return;
+    }
+    if (value.kind === "get_cut_change") {
+      await handleReadDown(value.requestId, () => options.readDownService!.getCutChange(value.streamToken));
       return;
     }
     if (value.kind === "get_blob") {
@@ -371,7 +386,7 @@ export function serveAuthorityForcedCommand(options: AuthorityForcedCommandOptio
 
   async function handleReadDown(
     requestId: string,
-    read: () => Promise<NonNullable<AuthorityResponseFrame["result"]>>
+    read: () => Promise<AuthorityResponseFrame["result"]>
   ): Promise<void> {
     if (!options.readDownService) {
       write(response(requestId, generation, false, undefined, "READ_DOWN_UNAVAILABLE", "Authority read-down is not enabled."));

--- a/packages/daemon/src/authority/forced-command-session.ts
+++ b/packages/daemon/src/authority/forced-command-session.ts
@@ -12,6 +12,7 @@ import {
   type AuthorityBlobResult,
   type AuthorityChangesAfterResult,
   type AuthoritySnapshotManifest,
+  type AuthoritySnapshotLease,
   type AuthoritySnapshotReservation,
   type AuthorityResponseFrame,
   type AuthorityServerFrame,
@@ -53,6 +54,7 @@ export interface AuthorityReadDownService {
   readonly beginSnapshot: () => Promise<AuthoritySnapshotReservation>;
   readonly getManifest: (streamToken: string, digest: Sha256Digest) => Promise<AuthoritySnapshotManifest>;
   readonly getBlob: (streamToken: string, digest: Sha256Digest) => Promise<AuthorityBlobResult>;
+  readonly renewLease: (streamToken: string) => Promise<AuthoritySnapshotLease>;
   readonly changesAfter: (streamToken: string, sinceRevision: number) => Promise<AuthorityChangesAfterResult>;
 }
 
@@ -163,7 +165,8 @@ export function serveAuthorityForcedCommand(options: AuthorityForcedCommandOptio
             "begin-snapshot-and-subscribe/v1",
             "authority-snapshot-manifest/v1",
             "authority-blob/v1",
-            "authority-changes-after/v1"
+            "authority-changes-after/v1",
+            "authority-lease-renewal/v1"
           ] : []),
           "view-scoped-delegation-token",
           ...(negotiatedV2 ? ["actor-axes-binding/v2", "semantic-mutation-envelope/v2"] : [])
@@ -213,6 +216,18 @@ export function serveAuthorityForcedCommand(options: AuthorityForcedCommandOptio
     }
     if (value.kind === "get_blob") {
       await handleReadDown(value.requestId, () => options.readDownService!.getBlob(value.streamToken, value.digest));
+      return;
+    }
+    if (value.kind === "renew_lease") {
+      if (!options.readDownService) {
+        write(response(value.requestId, generation, false, undefined, "READ_DOWN_UNAVAILABLE", "Authority read-down is not available for this workspace."));
+        return;
+      }
+      if (value.workspaceId !== options.workspaceId) {
+        write(response(value.requestId, generation, false, undefined, "WORKSPACE_MISMATCH", "Read-down lease belongs to another workspace."));
+        return;
+      }
+      await handleReadDown(value.requestId, () => options.readDownService!.renewLease(value.streamToken));
       return;
     }
     if (value.kind === "changes_after") {

--- a/packages/daemon/src/authority/protocol.ts
+++ b/packages/daemon/src/authority/protocol.ts
@@ -19,15 +19,18 @@ export interface AuthoritySnapshotCut {
   readonly provenanceDigest: Sha256Digest;
 }
 
+export interface AuthoritySnapshotLease {
+  readonly leaseId: string;
+  readonly expiresAt: string;
+  readonly minRetainedRevision: number;
+  readonly pinnedBlobSetDigest: Sha256Digest;
+}
+
 export interface AuthoritySnapshotReservation {
   readonly schema: "authority-snapshot-reservation/v1";
   readonly cut: AuthoritySnapshotCut;
-  readonly lease: {
-    readonly leaseId: string;
-    readonly expiresAt: string;
-    readonly minRetainedRevision: number;
-    readonly pinnedBlobSetDigest: Sha256Digest;
-  };
+  readonly cutChange?: ReplicaChangeRecord | null;
+  readonly lease: AuthoritySnapshotLease;
   readonly stream: {
     readonly streamToken: string;
     readonly fromRevision: number;
@@ -108,6 +111,13 @@ export interface AuthorityChangesAfterFrame extends AuthorityWireFrameBase {
   readonly sinceRevision: number;
 }
 
+export interface AuthorityRenewLeaseFrame extends AuthorityWireFrameBase {
+  readonly kind: "renew_lease";
+  readonly requestId: string;
+  readonly workspaceId: string;
+  readonly streamToken: string;
+}
+
 export interface AuthorityBlobResult {
   readonly schema: "authority-blob/v1";
   readonly digest: Sha256Digest;
@@ -127,7 +137,8 @@ export type AuthorityReadDownResult =
   | AuthoritySnapshotReservation
   | AuthoritySnapshotManifest
   | AuthorityBlobResult
-  | AuthorityChangesAfterResult;
+  | AuthorityChangesAfterResult
+  | AuthoritySnapshotLease;
 
 export type AuthorityRequestFrame =
   | AuthorityHelloFrame
@@ -137,7 +148,8 @@ export type AuthorityRequestFrame =
   | AuthorityBeginSnapshotFrame
   | AuthorityGetSnapshotManifestFrame
   | AuthorityGetBlobFrame
-  | AuthorityChangesAfterFrame;
+  | AuthorityChangesAfterFrame
+  | AuthorityRenewLeaseFrame;
 
 export interface AuthorityResponseFrame extends AuthorityWireFrameBase {
   readonly kind: "response";
@@ -183,6 +195,9 @@ export function isAuthorityRequestFrame(value: unknown): value is AuthorityReque
     return typeof value.streamToken === "string" && isSha256Digest(value.manifestDigest);
   }
   if (value.kind === "get_blob") return typeof value.streamToken === "string" && isSha256Digest(value.digest);
+  if (value.kind === "renew_lease") {
+    return typeof value.workspaceId === "string" && typeof value.streamToken === "string";
+  }
   if (value.kind === "changes_after") {
     return typeof value.workspaceId === "string"
       && typeof value.streamToken === "string"

--- a/packages/daemon/src/authority/protocol.ts
+++ b/packages/daemon/src/authority/protocol.ts
@@ -22,6 +22,7 @@ export interface AuthoritySnapshotCut {
 export interface AuthoritySnapshotLease {
   readonly leaseId: string;
   readonly expiresAt: string;
+  readonly renewableUntil: string;
   readonly minRetainedRevision: number;
   readonly pinnedBlobSetDigest: Sha256Digest;
 }
@@ -29,7 +30,6 @@ export interface AuthoritySnapshotLease {
 export interface AuthoritySnapshotReservation {
   readonly schema: "authority-snapshot-reservation/v1";
   readonly cut: AuthoritySnapshotCut;
-  readonly cutChange?: ReplicaChangeRecord | null;
   readonly lease: AuthoritySnapshotLease;
   readonly stream: {
     readonly streamToken: string;
@@ -96,6 +96,12 @@ export interface AuthorityGetSnapshotManifestFrame extends AuthorityWireFrameBas
   readonly manifestDigest: Sha256Digest;
 }
 
+export interface AuthorityGetCutChangeFrame extends AuthorityWireFrameBase {
+  readonly kind: "get_cut_change";
+  readonly requestId: string;
+  readonly streamToken: string;
+}
+
 export interface AuthorityGetBlobFrame extends AuthorityWireFrameBase {
   readonly kind: "get_blob";
   readonly requestId: string;
@@ -134,6 +140,7 @@ export interface AuthorityChangesAfterResult {
 }
 
 export type AuthorityReadDownResult =
+  | ReplicaChangeRecord
   | AuthoritySnapshotReservation
   | AuthoritySnapshotManifest
   | AuthorityBlobResult
@@ -146,6 +153,7 @@ export type AuthorityRequestFrame =
   | AuthoritySubmitV2Frame
   | AuthorityGetOperationFrame
   | AuthorityBeginSnapshotFrame
+  | AuthorityGetCutChangeFrame
   | AuthorityGetSnapshotManifestFrame
   | AuthorityGetBlobFrame
   | AuthorityChangesAfterFrame
@@ -191,6 +199,7 @@ export function isAuthorityRequestFrame(value: unknown): value is AuthorityReque
   if (value.kind === "submit_v2") return typeof value.presentationToken === "string" && typeof value.envelope === "string";
   if (value.kind === "get_operation") return typeof value.workspaceId === "string" && typeof value.opId === "string";
   if (value.kind === "begin_snapshot_and_subscribe") return typeof value.workspaceId === "string";
+  if (value.kind === "get_cut_change") return typeof value.streamToken === "string";
   if (value.kind === "get_snapshot_manifest") {
     return typeof value.streamToken === "string" && isSha256Digest(value.manifestDigest);
   }

--- a/packages/daemon/src/authority/read-down-service.ts
+++ b/packages/daemon/src/authority/read-down-service.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import type { ReplicaChangeLog } from "@harness-anything/application";
+import type { ReplicaChangeLog, ReplicaChangeRecord } from "@harness-anything/application";
 import type { AuthorityReadDownService } from "./forced-command-session.ts";
 import type {
   AuthorityChangesAfterResult,
@@ -19,9 +19,11 @@ interface DurableSnapshotLease {
   readonly schema: "authority-snapshot-lease/v1";
   readonly reservation: AuthoritySnapshotReservation;
   readonly manifest: AuthoritySnapshotManifest;
+  readonly cutChange: ReplicaChangeRecord | null;
 }
 
 const defaultLeaseTtlMs = 5 * 60 * 1000;
+const defaultLeaseMaxLifetimeMs = 60 * 60 * 1000;
 
 export function createAuthorityReadDownService(input: {
   readonly workspaceId: string;
@@ -35,9 +37,11 @@ export function createAuthorityReadDownService(input: {
   };
   readonly now?: () => Date;
   readonly leaseTtlMs?: number;
+  readonly leaseMaxLifetimeMs?: number;
 }): AuthorityReadDownService {
   const now = input.now ?? (() => new Date());
   const leaseTtlMs = input.leaseTtlMs ?? defaultLeaseTtlMs;
+  const leaseMaxLifetimeMs = input.leaseMaxLifetimeMs ?? defaultLeaseMaxLifetimeMs;
 
   return {
     beginSnapshot: () => input.publicationExecutor.run(async () => {
@@ -48,6 +52,8 @@ export function createAuthorityReadDownService(input: {
       }
       const revision = latest?.revision ?? 0;
       const snapshot = input.content.snapshot(commitSha, revision);
+      const issuedAt = now().getTime();
+      const renewableUntil = issuedAt + leaseMaxLifetimeMs;
       const cut = {
         workspaceId: input.workspaceId,
         epoch: input.epoch,
@@ -59,10 +65,10 @@ export function createAuthorityReadDownService(input: {
       const reservation: AuthoritySnapshotReservation = {
         schema: "authority-snapshot-reservation/v1",
         cut,
-        cutChange: latest ?? null,
         lease: {
           leaseId: randomUUID(),
-          expiresAt: new Date(now().getTime() + leaseTtlMs).toISOString(),
+          expiresAt: new Date(Math.min(issuedAt + leaseTtlMs, renewableUntil)).toISOString(),
+          renewableUntil: new Date(renewableUntil).toISOString(),
           minRetainedRevision: revision + 1,
           pinnedBlobSetDigest: snapshot.pinnedBlobSetDigest
         },
@@ -76,9 +82,23 @@ export function createAuthorityReadDownService(input: {
         cut,
         entries: snapshot.entries
       };
-      writeLease(input.state, { schema: "authority-snapshot-lease/v1", reservation, manifest });
+      writeLease(input.state, {
+        schema: "authority-snapshot-lease/v1",
+        reservation,
+        manifest,
+        cutChange: latest ?? null
+      });
       return reservation;
     }),
+    getCutChange: async (streamToken) => {
+      const lease = readLiveLease(input.state, streamToken, now, input.workspaceId, input.epoch);
+      return structuredClone(lease.cutChange);
+    },
+    releaseLease: async (streamToken) => {
+      input.state.put(leaseStateKey(streamToken), {
+        schema: "authority-snapshot-lease-released/v1"
+      });
+    },
     getManifest: async (streamToken, requestedDigest) => {
       const lease = readLiveLease(input.state, streamToken, now, input.workspaceId, input.epoch);
       const actualDigest = manifestDigest(lease.manifest.cut, lease.manifest.entries);
@@ -104,14 +124,28 @@ export function createAuthorityReadDownService(input: {
       };
     },
     renewLease: async (streamToken) => {
-      const current = readLiveLease(input.state, streamToken, now, input.workspaceId, input.epoch);
+      const renewalTime = now().getTime();
+      const current = readLiveLease(
+        input.state,
+        streamToken,
+        () => new Date(renewalTime),
+        input.workspaceId,
+        input.epoch
+      );
+      const currentExpiry = Date.parse(current.reservation.lease.expiresAt);
+      const renewableUntil = Date.parse(current.reservation.lease.renewableUntil);
+      if (currentExpiry - renewalTime > leaseTtlMs / 2) {
+        return structuredClone(current.reservation.lease);
+      }
+      const nextExpiry = Math.min(renewalTime + leaseTtlMs, renewableUntil);
+      if (currentExpiry >= nextExpiry) return structuredClone(current.reservation.lease);
       const renewed: DurableSnapshotLease = {
         ...current,
         reservation: {
           ...current.reservation,
           lease: {
             ...current.reservation.lease,
-            expiresAt: new Date(now().getTime() + leaseTtlMs).toISOString()
+            expiresAt: new Date(nextExpiry).toISOString()
           }
         }
       };
@@ -172,6 +206,23 @@ function readLiveLease(
   if (cut.workspaceId !== workspaceId || cut.epoch !== epoch) {
     throw new Error("RESYNC_REQUIRED:SNAPSHOT_LEASE_AUTHORITY_MISMATCH");
   }
+  const expectedFromRevision = cut.revision + 1;
+  if (typeof lease.reservation.lease.leaseId !== "string"
+    || lease.reservation.lease.leaseId.trim().length === 0
+    || lease.reservation.lease.minRetainedRevision !== expectedFromRevision
+    || lease.reservation.stream.fromRevision !== expectedFromRevision) {
+    throw new Error("RESYNC_REQUIRED:SNAPSHOT_LEASE_DAMAGED");
+  }
+  if ((cut.revision === 0 && lease.cutChange !== null)
+    || (cut.revision > 0 && (
+      lease.cutChange === null
+      || lease.cutChange === undefined
+      || lease.cutChange.workspaceId !== cut.workspaceId
+      || lease.cutChange.revision !== cut.revision
+      || lease.cutChange.commitSha !== cut.commitSha
+    ))) {
+    throw new Error("RESYNC_REQUIRED:SNAPSHOT_CUT_CHANGE_MISMATCH");
+  }
   if (!sameCut(lease.manifest.cut, cut)) throw new Error("RESYNC_REQUIRED:SNAPSHOT_MANIFEST_CUT_MISMATCH");
   const actualManifestDigest = manifestDigest(cut, lease.manifest.entries);
   if (actualManifestDigest !== cut.manifestDigest
@@ -185,6 +236,13 @@ function readLiveLease(
   const expiry = typeof expiresAt === "string" ? Date.parse(expiresAt) : Number.NaN;
   if (!Number.isFinite(expiry) || new Date(expiry).toISOString() !== expiresAt) {
     throw new Error("RESYNC_REQUIRED:SNAPSHOT_LEASE_EXPIRY_DAMAGED");
+  }
+  const renewableUntil = lease.reservation.lease.renewableUntil;
+  const renewalLimit = typeof renewableUntil === "string" ? Date.parse(renewableUntil) : Number.NaN;
+  if (!Number.isFinite(renewalLimit)
+    || new Date(renewalLimit).toISOString() !== renewableUntil
+    || expiry > renewalLimit) {
+    throw new Error("RESYNC_REQUIRED:SNAPSHOT_LEASE_RENEWAL_LIMIT_DAMAGED");
   }
   if (expiry <= now().getTime()) {
     throw new Error(`SNAPSHOT_EXPIRED:${lease.reservation.lease.leaseId}`);

--- a/packages/daemon/src/authority/read-down-service.ts
+++ b/packages/daemon/src/authority/read-down-service.ts
@@ -59,6 +59,7 @@ export function createAuthorityReadDownService(input: {
       const reservation: AuthoritySnapshotReservation = {
         schema: "authority-snapshot-reservation/v1",
         cut,
+        cutChange: latest ?? null,
         lease: {
           leaseId: randomUUID(),
           expiresAt: new Date(now().getTime() + leaseTtlMs).toISOString(),
@@ -101,6 +102,21 @@ export function createAuthorityReadDownService(input: {
         encoding: "base64",
         bytes: Buffer.from(input.content.blob(digest)).toString("base64")
       };
+    },
+    renewLease: async (streamToken) => {
+      const current = readLiveLease(input.state, streamToken, now, input.workspaceId, input.epoch);
+      const renewed: DurableSnapshotLease = {
+        ...current,
+        reservation: {
+          ...current.reservation,
+          lease: {
+            ...current.reservation.lease,
+            expiresAt: new Date(now().getTime() + leaseTtlMs).toISOString()
+          }
+        }
+      };
+      writeLease(input.state, renewed);
+      return structuredClone(renewed.reservation.lease);
     },
     changesAfter: async (streamToken, sinceRevision): Promise<AuthorityChangesAfterResult> => {
       const lease = readLiveLease(input.state, streamToken, now, input.workspaceId, input.epoch);

--- a/packages/daemon/src/transport/persistent-ssh-authority-client.ts
+++ b/packages/daemon/src/transport/persistent-ssh-authority-client.ts
@@ -191,6 +191,19 @@ export class PersistentSshAuthorityClient {
     return response.result as AuthoritySnapshotLease;
   }
 
+  async getCutChange(streamToken: string): Promise<ReplicaChangeRecord | null> {
+    this.assertReady();
+    const response = await this.request({
+      type: authorityWireFrameType,
+      kind: "get_cut_change",
+      requestId: this.nextRequestId(),
+      connectionGeneration: this.generation,
+      streamToken
+    });
+    if (!response.ok) throw new Error(response.error?.message ?? "authority cut change read failed");
+    return (response.result ?? null) as ReplicaChangeRecord | null;
+  }
+
   async close(): Promise<void> {
     this.closing = true;
     await this.closeChild();

--- a/packages/daemon/src/transport/persistent-ssh-authority-client.ts
+++ b/packages/daemon/src/transport/persistent-ssh-authority-client.ts
@@ -13,7 +13,8 @@ import {
   isAuthorityServerFrame,
   type AuthorityNegotiatedProtocol,
   type AuthorityRequestFrame,
-  type AuthorityResponseFrame
+  type AuthorityResponseFrame,
+  type AuthoritySnapshotLease
 } from "../authority/protocol.ts";
 import {
   createLengthPrefixedFrameReader,
@@ -172,6 +173,22 @@ export class PersistentSshAuthorityClient {
     }, opId);
     if (!response.ok) throw new Error(response.error?.message ?? "GetOperation failed");
     return (response.result ?? undefined) as AuthorityOperationRecord | undefined;
+  }
+
+  async renewLease(streamToken: string): Promise<AuthoritySnapshotLease> {
+    this.assertReady();
+    const response = await this.request({
+      type: authorityWireFrameType,
+      kind: "renew_lease",
+      requestId: this.nextRequestId(),
+      connectionGeneration: this.generation,
+      workspaceId: this.options.workspaceId,
+      streamToken
+    });
+    if (!response.ok || !response.result) {
+      throw new Error(response.error?.message ?? "authority lease renewal failed without a lease");
+    }
+    return response.result as AuthoritySnapshotLease;
   }
 
   async close(): Promise<void> {

--- a/packages/daemon/test/authority-read-down-renewal.test.ts
+++ b/packages/daemon/test/authority-read-down-renewal.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -25,6 +25,7 @@ import {
   createAuthorityReplicationContentStore,
   createContentEnrichedReplicaChangeLog
 } from "../src/authority/replication-content-store.ts";
+import { openDurableAuthorityServiceState } from "../src/authority/production/service-state.ts";
 import {
   PersistentSshAuthorityClient,
   type SshAuthorityChild,
@@ -93,6 +94,163 @@ test("renewing a live read lease extends only its expiry and preserves blob auth
   }
 });
 
+test("durable lease renewal bounds append frequency and cannot exceed its absolute lifetime", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-read-down-renewal-durable-"));
+  const gitRoot = path.join(root, "canonical");
+  mkdirSync(gitRoot);
+  git(gitRoot, "init", "-q");
+  git(gitRoot, "config", "user.name", "Authority Test");
+  git(gitRoot, "config", "user.email", "authority@example.test");
+  seedRepository(gitRoot);
+  let state = openDurableAuthorityServiceState({
+    serviceStateRoot: path.join(root, "state"),
+    repoId: "repo-read-down-renewal"
+  });
+  let timestamp = "2026-07-23T04:00:00.000Z";
+  const open = () => {
+    const content = createAuthorityReplicationContentStore({
+      gitRoot,
+      state: state.replicationState,
+      workspaceId,
+      epoch: "7"
+    });
+    return createAuthorityReadDownService({
+      workspaceId,
+      epoch: "7",
+      gitRoot,
+      state: state.replicationState,
+      replicaChangeLog: createContentEnrichedReplicaChangeLog(state.replicaChangeLog, content),
+      content,
+      publicationExecutor: serialExecutor(),
+      now: () => new Date(timestamp),
+      leaseTtlMs: 1_000,
+      leaseMaxLifetimeMs: 3_000
+    });
+  };
+  try {
+    const reservation = await open().beginSnapshot();
+    const replicationLog = path.join(state.stateDirectory, "replication.jsonl");
+    const rowsAfterIssue = durableRows(replicationLog);
+
+    for (let request = 0; request < 100; request += 1) {
+      timestamp = new Date(
+        Date.parse("2026-07-23T04:00:00.800Z") + request
+      ).toISOString();
+      await open().renewLease(reservation.stream.streamToken);
+    }
+    assert.equal(
+      durableRows(replicationLog) - rowsAfterIssue,
+      1,
+      "one renewal window may append at most one durable row regardless of request count"
+    );
+
+    timestamp = "2026-07-23T04:00:01.600Z";
+    await Promise.all(Array.from(
+      { length: 20 },
+      () => open().renewLease(reservation.stream.streamToken)
+    ));
+    timestamp = "2026-07-23T04:00:02.400Z";
+    await Promise.all(Array.from(
+      { length: 20 },
+      () => open().renewLease(reservation.stream.streamToken)
+    ));
+    await state.close();
+    state = openDurableAuthorityServiceState({
+      serviceStateRoot: path.join(root, "state"),
+      repoId: "repo-read-down-renewal"
+    });
+
+    timestamp = "2026-07-23T04:00:03.000Z";
+    await assert.rejects(
+      open().renewLease(reservation.stream.streamToken),
+      /SNAPSHOT_EXPIRED/u
+    );
+  } finally {
+    await state.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("renewal rejects damaged lease identity and pinned revision invariants", async (t) => {
+  const fixture = createReadDownFixture();
+  try {
+    seedRepository(fixture.gitRoot);
+    const opened = fixture.open("2026-07-23T04:00:00.000Z");
+    const reservation = await opened.service.beginSnapshot();
+    const leaseKey = `lease:${reservation.stream.streamToken}`;
+    const original = structuredClone(fixture.state.get<StoredLeaseFixture>(leaseKey)!);
+    const cases = [
+      {
+        name: "empty leaseId",
+        damage: (lease: StoredLeaseFixture) => {
+          lease.reservation.lease.leaseId = "";
+        }
+      },
+      {
+        name: "minRetainedRevision not cut plus one",
+        damage: (lease: StoredLeaseFixture) => {
+          lease.reservation.lease.minRetainedRevision = reservation.cut.revision + 2;
+        }
+      },
+      {
+        name: "stream fromRevision not cut plus one",
+        damage: (lease: StoredLeaseFixture) => {
+          lease.reservation.stream.fromRevision = reservation.cut.revision + 2;
+        }
+      }
+    ] as const;
+
+    for (const candidate of cases) {
+      await t.test(candidate.name, async () => {
+        const damaged = structuredClone(original);
+        candidate.damage(damaged);
+        fixture.state.put(leaseKey, damaged);
+        await assert.rejects(
+          fixture.open("2026-07-23T04:00:01.000Z").service.renewLease(
+            reservation.stream.streamToken
+          ),
+          /RESYNC_REQUIRED:SNAPSHOT_LEASE_DAMAGED/u
+        );
+      });
+    }
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("snapshot response encoding failure invalidates the persisted lease", async () => {
+  const fixture = createReadDownFixture();
+  try {
+    seedRepository(fixture.gitRoot);
+    const opened = fixture.open("2026-07-23T04:00:00.000Z");
+    const wire = openWireSession(opened.changeLog, opened.service, 1, 640);
+    try {
+      wire.send(helloFrame("hello-encode-failure", 1));
+      assert.equal((await wire.frames.nextResponse("hello-encode-failure")).ok, true);
+      wire.send({
+        type: authorityWireFrameType,
+        kind: "begin_snapshot_and_subscribe",
+        requestId: "begin-encode-failure",
+        connectionGeneration: 1,
+        workspaceId
+      });
+      const response = await wire.frames.nextResponse("begin-encode-failure");
+      assert.equal(response.ok, false);
+      assert.match(response.error?.message ?? "", /frame length .* exceeds limit/u);
+      assert.equal(
+        fixture.state.entries<{ readonly schema?: string }>()
+          .filter(([key, value]) =>
+            key.startsWith("lease:") && value.schema === "authority-snapshot-lease/v1").length,
+        0
+      );
+    } finally {
+      await wire.session.close();
+    }
+  } finally {
+    fixture.cleanup();
+  }
+});
+
 test("renew_lease crosses the forced-command wire and fails closed for invalid authority state", async () => {
   const fixture = createReadDownFixture();
   try {
@@ -113,6 +271,17 @@ test("renew_lease crosses the forced-command wire and fails closed for invalid a
         ),
         true
       );
+      assert.equal(
+        (hello.result as { readonly capabilities: ReadonlyArray<string> }).capabilities.includes(
+          "authority-cut-change/v1"
+        ),
+        true
+      );
+
+      live.send(cutChangeFrame("get-cut-change", 1, reservation.stream.streamToken));
+      const cutChange = await live.frames.nextResponse("get-cut-change");
+      assert.equal(cutChange.ok, true);
+      assert.equal(cutChange.result, null);
 
       live.send(renewFrame("renew-live", 1, reservation.stream.streamToken));
       const renewed = await live.frames.nextResponse("renew-live");
@@ -179,27 +348,50 @@ test("renew_lease crosses the forced-command wire and fails closed for invalid a
   }
 });
 
-test("persistent SSH client sends renew_lease and returns the authority lease", async () => {
-  const requested: Array<{ readonly workspaceId: string; readonly streamToken: string }> = [];
+test("persistent SSH client sends renewal and on-demand cut-change frames", async () => {
+  const requested: Array<{
+    readonly kind: string;
+    readonly workspaceId?: string;
+    readonly streamToken: string;
+  }> = [];
   const lease: AuthoritySnapshotLease = {
     leaseId: "lease-read-down",
     expiresAt: "2026-07-23T04:09:00.000Z",
+    renewableUntil: "2026-07-23T05:00:00.000Z",
     minRetainedRevision: 1,
     pinnedBlobSetDigest: `sha256:${"1".repeat(64)}`
   };
+  const cutChange = {
+    schema: "replica-change/v2",
+    workspaceId,
+    revision: 1,
+    opId: "op-cut",
+    semanticDigest: "cut",
+    operations: [{ opId: "op-cut", semanticDigest: "cut" }],
+    commitSha: "1".repeat(40),
+    previousCommit: null,
+    changedAt: "2026-07-23T04:00:00.000Z",
+    manifest: { digest: `sha256:${"1".repeat(64)}` as const, entryCount: 0 },
+    paths: []
+  } as const;
   const client = new PersistentSshAuthorityClient({
     target: { destination: "authority.internal", fixedCommand: "ha-authority-connect" },
     workspaceId,
     channelNonceDigest: () => "sha256:channel-generation",
     protocol: authorityProtocolTuple,
-    childFactory: scriptedRenewalChildFactory(lease, requested)
+    childFactory: scriptedRenewalChildFactory(lease, cutChange, requested)
   });
 
   await client.connect();
   const renewed = await client.renewLease("stream-token");
+  const fetchedCutChange = await client.getCutChange("stream-token");
 
   assert.deepEqual(renewed, lease);
-  assert.deepEqual(requested, [{ workspaceId, streamToken: "stream-token" }]);
+  assert.deepEqual(fetchedCutChange, cutChange);
+  assert.deepEqual(requested, [
+    { kind: "renew_lease", workspaceId, streamToken: "stream-token" },
+    { kind: "get_cut_change", streamToken: "stream-token" }
+  ]);
   await client.close();
 });
 
@@ -249,7 +441,8 @@ function createReadDownFixture() {
 function openWireSession(
   replicaChangeLog: ReplicaChangeLog,
   readDownService: ReturnType<typeof createAuthorityReadDownService>,
-  generation: number
+  generation: number,
+  maxFrameBytes?: number
 ) {
   const input = new PassThrough();
   const output = new PassThrough();
@@ -265,7 +458,8 @@ function openWireSession(
     protocol: authorityProtocolTuple,
     submissionService,
     replicaChangeLog,
-    readDownService
+    readDownService,
+    maxFrameBytes
   });
   return {
     session,
@@ -277,7 +471,12 @@ function openWireSession(
 
 function scriptedRenewalChildFactory(
   lease: AuthoritySnapshotLease,
-  requested: Array<{ readonly workspaceId: string; readonly streamToken: string }>
+  cutChange: import("../../application/src/index.ts").ReplicaChangeRecord,
+  requested: Array<{
+    readonly kind: string;
+    readonly workspaceId?: string;
+    readonly streamToken: string;
+  }>
 ): SshAuthorityChildFactory {
   return {
     spawn: () => {
@@ -297,9 +496,10 @@ function scriptedRenewalChildFactory(
             readonly workspaceId?: string;
             readonly streamToken?: string;
           };
-          if (frame.kind === "renew_lease") {
+          if (frame.kind === "renew_lease" || frame.kind === "get_cut_change") {
             requested.push({
-              workspaceId: frame.workspaceId!,
+              kind: frame.kind,
+              ...(frame.workspaceId ? { workspaceId: frame.workspaceId } : {}),
               streamToken: frame.streamToken!
             });
           }
@@ -311,7 +511,7 @@ function scriptedRenewalChildFactory(
             ok: true,
             result: frame.kind === "hello"
               ? { accepted: true, protocol: authorityProtocolTuple, capabilities: [] }
-              : lease
+              : frame.kind === "get_cut_change" ? cutChange : lease
           }));
         }
       });
@@ -383,6 +583,16 @@ function renewFrame(requestId: string, connectionGeneration: number, streamToken
   };
 }
 
+function cutChangeFrame(requestId: string, connectionGeneration: number, streamToken: string) {
+  return {
+    type: authorityWireFrameType,
+    kind: "get_cut_change",
+    requestId,
+    connectionGeneration,
+    streamToken
+  };
+}
+
 function seedRepository(gitRoot: string): void {
   writeFileSync(path.join(gitRoot, "seed.md"), "seed\n");
   git(gitRoot, "add", ".");
@@ -411,10 +621,20 @@ interface StoredLeaseFixture {
   readonly manifest: unknown;
   readonly reservation: {
     readonly lease: {
-      readonly expiresAt: string;
+      expiresAt: string;
+      leaseId: string;
+      minRetainedRevision: number;
+      [key: string]: unknown;
+    };
+    readonly stream: {
+      fromRevision: number;
       readonly [key: string]: unknown;
     };
-    readonly [key: string]: unknown;
+    [key: string]: unknown;
   };
-  readonly [key: string]: unknown;
+  [key: string]: unknown;
+}
+
+function durableRows(filePath: string): number {
+  return readFileSync(filePath, "utf8").split("\n").filter(Boolean).length;
 }

--- a/packages/daemon/test/authority-read-down-renewal.test.ts
+++ b/packages/daemon/test/authority-read-down-renewal.test.ts
@@ -1,0 +1,420 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import {
+  authorityProtocolTuple,
+  createInMemoryReplicaChangeLog,
+  type AuthoritySubmissionService,
+  type ReplicaChangeLog
+} from "../../application/src/index.ts";
+import { serveAuthorityForcedCommand } from "../src/authority/forced-command-session.ts";
+import {
+  authorityWireFrameType,
+  type AuthorityResponseFrame,
+  type AuthorityServerFrame,
+  type AuthoritySnapshotLease
+} from "../src/authority/protocol.ts";
+import { createAuthorityReadDownService } from "../src/authority/read-down-service.ts";
+import {
+  createAuthorityReplicationContentStore,
+  createContentEnrichedReplicaChangeLog
+} from "../src/authority/replication-content-store.ts";
+import {
+  PersistentSshAuthorityClient,
+  type SshAuthorityChild,
+  type SshAuthorityChildFactory
+} from "../src/transport/persistent-ssh-authority-client.ts";
+import {
+  createLengthPrefixedFrameReader,
+  encodeLengthPrefixedFrame
+} from "../src/transport/length-frame-codec.ts";
+
+const workspaceId = "workspace-read-down";
+
+test("renewing a live read lease extends only its expiry and preserves blob authorization", async () => {
+  const fixture = createReadDownFixture();
+  try {
+    seedRepository(fixture.gitRoot);
+    const issued = fixture.open("2026-07-23T04:00:00.000Z");
+    const reservation = await issued.service.beginSnapshot();
+    const manifest = await issued.service.getManifest(
+      reservation.stream.streamToken,
+      reservation.cut.manifestDigest
+    );
+    const authorizedDigest = manifest.entries[0]!.blobDigest;
+    const unauthorizedDigest = `sha256:${"0".repeat(64)}` as const;
+    const leaseKey = `lease:${reservation.stream.streamToken}`;
+    const before = structuredClone(fixture.state.get<StoredLeaseFixture>(leaseKey)!);
+    await issued.service.getBlob(reservation.stream.streamToken, authorizedDigest);
+    await assert.rejects(
+      issued.service.getBlob(reservation.stream.streamToken, unauthorizedDigest),
+      /RESYNC_REQUIRED:BLOB_NOT_AUTHORIZED/u
+    );
+
+    const renewed = await fixture.open("2026-07-23T04:04:00.000Z").service.renewLease(
+      reservation.stream.streamToken
+    );
+    const after = structuredClone(fixture.state.get<StoredLeaseFixture>(leaseKey)!);
+
+    assert.equal(renewed.expiresAt, "2026-07-23T04:09:00.000Z");
+    assert.deepEqual(
+      {
+        ...after,
+        reservation: {
+          ...after.reservation,
+          lease: {
+            ...after.reservation.lease,
+            expiresAt: before.reservation.lease.expiresAt
+          }
+        }
+      },
+      before,
+      "renewal must preserve the cut, manifest, lease identity, pin, stream, and authorization inputs"
+    );
+    await fixture.open("2026-07-23T04:06:00.000Z").service.getBlob(
+      reservation.stream.streamToken,
+      authorizedDigest
+    );
+    await assert.rejects(
+      fixture.open("2026-07-23T04:06:00.000Z").service.getBlob(
+        reservation.stream.streamToken,
+        unauthorizedDigest
+      ),
+      /RESYNC_REQUIRED:BLOB_NOT_AUTHORIZED/u
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("renew_lease crosses the forced-command wire and fails closed for invalid authority state", async () => {
+  const fixture = createReadDownFixture();
+  try {
+    seedRepository(fixture.gitRoot);
+    const issued = fixture.open("2026-07-23T04:00:00.000Z");
+    const reservation = await issued.service.beginSnapshot();
+    const live = openWireSession(
+      issued.changeLog,
+      fixture.open("2026-07-23T04:04:00.000Z").service,
+      1
+    );
+    try {
+      live.send(helloFrame("hello-renew", 1));
+      const hello = await live.frames.nextResponse("hello-renew");
+      assert.equal(
+        (hello.result as { readonly capabilities: ReadonlyArray<string> }).capabilities.includes(
+          "authority-lease-renewal/v1"
+        ),
+        true
+      );
+
+      live.send(renewFrame("renew-live", 1, reservation.stream.streamToken));
+      const renewed = await live.frames.nextResponse("renew-live");
+      assert.equal(renewed.ok, true);
+      assert.equal(
+        (renewed.result as { readonly leaseId: string }).leaseId,
+        reservation.lease.leaseId
+      );
+      assert.equal(
+        (renewed.result as { readonly expiresAt: string }).expiresAt,
+        "2026-07-23T04:09:00.000Z"
+      );
+
+      live.send(renewFrame("renew-unknown", 1, "a".repeat(43)));
+      const unknown = await live.frames.nextResponse("renew-unknown");
+      assert.equal(unknown.ok, false);
+      assert.equal(unknown.error?.code, "RESYNC_REQUIRED");
+
+      live.send({
+        ...renewFrame("renew-workspace-mismatch", 1, reservation.stream.streamToken),
+        workspaceId: "another-workspace"
+      });
+      const workspaceMismatch = await live.frames.nextResponse("renew-workspace-mismatch");
+      assert.equal(workspaceMismatch.ok, false);
+      assert.equal(workspaceMismatch.error?.code, "WORKSPACE_MISMATCH");
+    } finally {
+      await live.session.close();
+    }
+
+    const wrongEpoch = openWireSession(
+      issued.changeLog,
+      fixture.open("2026-07-23T04:05:00.000Z", "8").service,
+      2
+    );
+    try {
+      wrongEpoch.send(helloFrame("hello-wrong-epoch", 2));
+      await wrongEpoch.frames.nextResponse("hello-wrong-epoch");
+      wrongEpoch.send(renewFrame("renew-wrong-epoch", 2, reservation.stream.streamToken));
+      const response = await wrongEpoch.frames.nextResponse("renew-wrong-epoch");
+      assert.equal(response.ok, false);
+      assert.equal(response.error?.code, "RESYNC_REQUIRED");
+      assert.match(response.error?.message ?? "", /SNAPSHOT_LEASE_AUTHORITY_MISMATCH/u);
+    } finally {
+      await wrongEpoch.session.close();
+    }
+
+    const expired = openWireSession(
+      issued.changeLog,
+      fixture.open("2026-07-23T04:10:00.000Z").service,
+      3
+    );
+    try {
+      expired.send(helloFrame("hello-expired", 3));
+      await expired.frames.nextResponse("hello-expired");
+      expired.send(renewFrame("renew-expired", 3, reservation.stream.streamToken));
+      const response = await expired.frames.nextResponse("renew-expired");
+      assert.equal(response.ok, false);
+      assert.equal(response.error?.code, "SNAPSHOT_EXPIRED");
+    } finally {
+      await expired.session.close();
+    }
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("persistent SSH client sends renew_lease and returns the authority lease", async () => {
+  const requested: Array<{ readonly workspaceId: string; readonly streamToken: string }> = [];
+  const lease: AuthoritySnapshotLease = {
+    leaseId: "lease-read-down",
+    expiresAt: "2026-07-23T04:09:00.000Z",
+    minRetainedRevision: 1,
+    pinnedBlobSetDigest: `sha256:${"1".repeat(64)}`
+  };
+  const client = new PersistentSshAuthorityClient({
+    target: { destination: "authority.internal", fixedCommand: "ha-authority-connect" },
+    workspaceId,
+    channelNonceDigest: () => "sha256:channel-generation",
+    protocol: authorityProtocolTuple,
+    childFactory: scriptedRenewalChildFactory(lease, requested)
+  });
+
+  await client.connect();
+  const renewed = await client.renewLease("stream-token");
+
+  assert.deepEqual(renewed, lease);
+  assert.deepEqual(requested, [{ workspaceId, streamToken: "stream-token" }]);
+  await client.close();
+});
+
+function createReadDownFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-read-down-renewal-"));
+  const gitRoot = path.join(root, "canonical");
+  mkdirSync(gitRoot);
+  git(gitRoot, "init", "-q");
+  git(gitRoot, "config", "user.name", "Authority Test");
+  git(gitRoot, "config", "user.email", "authority@example.test");
+  const base = createInMemoryReplicaChangeLog();
+  const stateValues = new Map<string, unknown>();
+  const state = {
+    get: <Value>(key: string) => stateValues.get(key) as Value | undefined,
+    put: (key: string, value: unknown) => stateValues.set(key, structuredClone(value)),
+    entries: <Value>() => [...stateValues.entries()] as ReadonlyArray<readonly [string, Value]>
+  };
+  return {
+    gitRoot,
+    state,
+    open: (timestamp: string, epoch = "7") => {
+      const content = createAuthorityReplicationContentStore({
+        gitRoot,
+        state,
+        workspaceId,
+        epoch
+      });
+      const changeLog = createContentEnrichedReplicaChangeLog(base, content);
+      return {
+        changeLog,
+        service: createAuthorityReadDownService({
+          workspaceId,
+          epoch,
+          gitRoot,
+          state,
+          replicaChangeLog: changeLog,
+          content,
+          publicationExecutor: serialExecutor(),
+          now: () => new Date(timestamp)
+        })
+      };
+    },
+    cleanup: () => rmSync(root, { recursive: true, force: true })
+  };
+}
+
+function openWireSession(
+  replicaChangeLog: ReplicaChangeLog,
+  readDownService: ReturnType<typeof createAuthorityReadDownService>,
+  generation: number
+) {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const frames = collectFrames(output);
+  const submissionService: AuthoritySubmissionService = {
+    submit: async () => { throw new Error("write path is not used by read-down renewal tests"); },
+    getOperation: async () => undefined
+  };
+  const session = serveAuthorityForcedCommand({
+    input,
+    output,
+    workspaceId,
+    protocol: authorityProtocolTuple,
+    submissionService,
+    replicaChangeLog,
+    readDownService
+  });
+  return {
+    session,
+    frames,
+    send: (frame: unknown) => input.write(encodeLengthPrefixedFrame(frame)),
+    generation
+  };
+}
+
+function scriptedRenewalChildFactory(
+  lease: AuthoritySnapshotLease,
+  requested: Array<{ readonly workspaceId: string; readonly streamToken: string }>
+): SshAuthorityChildFactory {
+  return {
+    spawn: () => {
+      const stdin = new PassThrough();
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const events = new EventEmitter();
+      const reader = createLengthPrefixedFrameReader();
+      stdin.on("data", (chunk: Buffer) => {
+        const batch = reader.push(chunk);
+        assert.equal(batch.error, undefined);
+        for (const value of batch.frames) {
+          const frame = value as {
+            readonly kind: string;
+            readonly requestId: string;
+            readonly connectionGeneration: number;
+            readonly workspaceId?: string;
+            readonly streamToken?: string;
+          };
+          if (frame.kind === "renew_lease") {
+            requested.push({
+              workspaceId: frame.workspaceId!,
+              streamToken: frame.streamToken!
+            });
+          }
+          stdout.write(encodeLengthPrefixedFrame({
+            type: authorityWireFrameType,
+            kind: "response",
+            requestId: frame.requestId,
+            connectionGeneration: frame.connectionGeneration,
+            ok: true,
+            result: frame.kind === "hello"
+              ? { accepted: true, protocol: authorityProtocolTuple, capabilities: [] }
+              : lease
+          }));
+        }
+      });
+      return {
+        stdin,
+        stdout,
+        stderr,
+        on: (event, listener) => events.on(event, listener),
+        kill: () => {
+          queueMicrotask(() => events.emit("exit", 0, null));
+          return true;
+        }
+      } satisfies SshAuthorityChild;
+    }
+  };
+}
+
+function collectFrames(output: PassThrough) {
+  const reader = createLengthPrefixedFrameReader();
+  const buffered: AuthorityServerFrame[] = [];
+  const waiters = new Set<() => void>();
+  output.on("data", (chunk: Buffer) => {
+    const batch = reader.push(chunk);
+    assert.equal(batch.error, undefined);
+    buffered.push(...batch.frames as AuthorityServerFrame[]);
+    for (const wake of [...waiters]) wake();
+  });
+  const nextResponse = (requestId: string): Promise<AuthorityResponseFrame> =>
+    new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        waiters.delete(check);
+        reject(new Error(`timed out waiting for authority response ${requestId}`));
+      }, 2_000);
+      const check = () => {
+        const index = buffered.findIndex(
+          (frame) => frame.kind === "response" && frame.requestId === requestId
+        );
+        if (index < 0) return;
+        clearTimeout(timeout);
+        waiters.delete(check);
+        resolve(buffered.splice(index, 1)[0] as AuthorityResponseFrame);
+      };
+      waiters.add(check);
+      check();
+    });
+  return { nextResponse };
+}
+
+function helloFrame(requestId: string, connectionGeneration: number) {
+  return {
+    type: authorityWireFrameType,
+    kind: "hello",
+    requestId,
+    connectionGeneration,
+    workspaceId,
+    channelNonceDigest: "test",
+    protocol: authorityProtocolTuple
+  };
+}
+
+function renewFrame(requestId: string, connectionGeneration: number, streamToken: string) {
+  return {
+    type: authorityWireFrameType,
+    kind: "renew_lease",
+    requestId,
+    connectionGeneration,
+    workspaceId,
+    streamToken
+  };
+}
+
+function seedRepository(gitRoot: string): void {
+  writeFileSync(path.join(gitRoot, "seed.md"), "seed\n");
+  git(gitRoot, "add", ".");
+  git(gitRoot, "commit", "-m", "seed");
+}
+
+function serialExecutor() {
+  let tail = Promise.resolve();
+  return {
+    run: <Result>(operation: () => Promise<Result>): Promise<Result> => {
+      const result = tail.then(operation, operation);
+      tail = result.then(() => undefined, () => undefined);
+      return result;
+    }
+  };
+}
+
+function git(root: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", root, ...args], {
+    encoding: "utf8",
+    windowsHide: true
+  }).trim();
+}
+
+interface StoredLeaseFixture {
+  readonly manifest: unknown;
+  readonly reservation: {
+    readonly lease: {
+      readonly expiresAt: string;
+      readonly [key: string]: unknown;
+    };
+    readonly [key: string]: unknown;
+  };
+  readonly [key: string]: unknown;
+}

--- a/packages/daemon/test/authority-wire-service.test.ts
+++ b/packages/daemon/test/authority-wire-service.test.ts
@@ -45,6 +45,7 @@ test("read-down snapshot manifest and blob remain verifiable across service rest
     );
 
     assert.equal(reservation.cut.revision, 0);
+    assert.equal(reservation.cutChange, null);
     assert.equal(reservation.stream.fromRevision, 1);
     assert.deepEqual(manifest.entries.map((entry) => entry.path), ["docs/a-first.md", "z-last.md"]);
     const entry = manifest.entries[0]!;
@@ -100,6 +101,47 @@ test("read-down snapshot manifest and blob remain verifiable across service rest
       restarted.service.getBlob(reservation.stream.streamToken, entry.blobDigest),
       /BLOB_DIGEST_MISMATCH/u
     );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("read-down reservation carries the authority's complete latest change without reconstruction", async () => {
+  const fixture = createReadDownFixture();
+  try {
+    writeFileSync(path.join(fixture.gitRoot, "seed.md"), "seed\n");
+    git(fixture.gitRoot, "add", ".");
+    git(fixture.gitRoot, "commit", "-m", "seed");
+    const opened = fixture.open("2026-07-23T04:00:00.000Z");
+    const commitSha = git(fixture.gitRoot, "rev-parse", "HEAD");
+    await opened.changeLog.append({
+      schema: "replica-change/v2",
+      workspaceId: "workspace-read-down",
+      revision: 1,
+      opId: "op-seed",
+      semanticDigest: "semantic-seed",
+      operations: [{ opId: "op-seed", semanticDigest: "semantic-seed" }],
+      commitSha,
+      previousCommit: null,
+      changedAt: "2026-07-23T03:59:59.000Z",
+      manifest: {
+        digest: `sha256:${"1".repeat(64)}`,
+        entryCount: 1
+      },
+      paths: [{
+        path: "seed.md",
+        blobDigest: `sha256:${createHash("sha256").update("seed\n").digest("hex")}`,
+        mode: 0o100644,
+        tombstone: false
+      }]
+    });
+    const authorityLatest = await opened.changeLog.latest("workspace-read-down");
+
+    const reservation = await opened.service.beginSnapshot();
+
+    assert.deepEqual(reservation.cutChange, authorityLatest);
+    assert.equal(reservation.cutChange?.revision, reservation.cut.revision);
+    assert.equal(reservation.cutChange?.commitSha, reservation.cut.commitSha);
   } finally {
     fixture.cleanup();
   }

--- a/packages/daemon/test/authority-wire-service.test.ts
+++ b/packages/daemon/test/authority-wire-service.test.ts
@@ -45,7 +45,8 @@ test("read-down snapshot manifest and blob remain verifiable across service rest
     );
 
     assert.equal(reservation.cut.revision, 0);
-    assert.equal(reservation.cutChange, null);
+    assert.equal("cutChange" in reservation, false);
+    assert.equal(await first.service.getCutChange(reservation.stream.streamToken), null);
     assert.equal(reservation.stream.fromRevision, 1);
     assert.deepEqual(manifest.entries.map((entry) => entry.path), ["docs/a-first.md", "z-last.md"]);
     const entry = manifest.entries[0]!;
@@ -106,7 +107,7 @@ test("read-down snapshot manifest and blob remain verifiable across service rest
   }
 });
 
-test("read-down reservation carries the authority's complete latest change without reconstruction", async () => {
+test("read-down reservation stays bounded while the complete latest change is fetched on demand", async () => {
   const fixture = createReadDownFixture();
   try {
     writeFileSync(path.join(fixture.gitRoot, "seed.md"), "seed\n");
@@ -114,7 +115,7 @@ test("read-down reservation carries the authority's complete latest change witho
     git(fixture.gitRoot, "commit", "-m", "seed");
     const opened = fixture.open("2026-07-23T04:00:00.000Z");
     const commitSha = git(fixture.gitRoot, "rev-parse", "HEAD");
-    await opened.changeLog.append({
+    await fixture.base.append({
       schema: "replica-change/v2",
       workspaceId: "workspace-read-down",
       revision: 1,
@@ -128,20 +129,40 @@ test("read-down reservation carries the authority's complete latest change witho
         digest: `sha256:${"1".repeat(64)}`,
         entryCount: 1
       },
-      paths: [{
-        path: "seed.md",
-        blobDigest: `sha256:${createHash("sha256").update("seed\n").digest("hex")}`,
-        mode: 0o100644,
-        tombstone: false
-      }]
+      paths: Array.from({ length: 25_000 }, (_, index) => ({
+        path: `removed/${String(index).padStart(5, "0")}-${"x".repeat(64)}.md`,
+        blobDigest: null,
+        mode: null,
+        tombstone: true as const
+      }))
     });
     const authorityLatest = await opened.changeLog.latest("workspace-read-down");
-
-    const reservation = await opened.service.beginSnapshot();
-
-    assert.deepEqual(reservation.cutChange, authorityLatest);
-    assert.equal(reservation.cutChange?.revision, reservation.cut.revision);
-    assert.equal(reservation.cutChange?.commitSha, reservation.cut.commitSha);
+    assert.ok(JSON.stringify(authorityLatest).length > 1024 * 1024);
+    const wire = openWireSession(
+      {
+        submit: async () => { throw new Error("write path is not used by read-down tests"); },
+        getOperation: async () => undefined
+      },
+      opened.changeLog,
+      opened.service,
+      1
+    );
+    try {
+      wire.send(helloFrame("hello-bounded", 1));
+      await wire.frames.nextResponse("hello-bounded");
+      wire.send(beginFrame("begin-bounded", 1));
+      const begin = await wire.frames.nextResponse("begin-bounded");
+      assert.equal(begin.ok, true);
+      const reservation = begin.result as Awaited<ReturnType<typeof opened.service.beginSnapshot>>;
+      assert.equal("cutChange" in reservation, false);
+      assert.ok(JSON.stringify(reservation).length < 16 * 1024);
+      assert.deepEqual(
+        await opened.service.getCutChange(reservation.stream.streamToken),
+        authorityLatest
+      );
+    } finally {
+      await wire.session.close();
+    }
   } finally {
     fixture.cleanup();
   }
@@ -448,6 +469,7 @@ function createReadDownFixture() {
   };
   return {
     gitRoot,
+    base,
     state,
     open: (timestamp: string, epoch = "7") => {
       const content = createAuthorityReplicationContentStore({


### PR DESCRIPTION
# English

## Summary

Completes the RD-A read-down wire contract per the already-accepted decision `dec_01KXB6ZS4EBW8EPWR7132CTBJY` (V2-I22), unblocking the broker's persistent read-down consumption (RD-B). RD-A froze a data plane sufficient for a *fresh* client (snapshot-at-cut + forward stream) but under-delivered two pieces the accepted decision requires for a *persistent* broker: a renewable lease and a truthful cut baseline record. This PR adds exactly those two, nothing more.

## What Changed

- **Renewable lease (V2-I22, already decided)**: new `renew_lease` wire frame + server handler + `AuthorityReadDownService.renewLease` + transport client method. It only extends `expiresAt = now + ttl` on a currently-live lease validated by `readLiveLease` (epoch/workspace/liveness/sameCut/digests). It never mutates `cut`, `manifest`, `leaseId`, `minRetainedRevision`, `pinnedBlobSetDigest`, `stream`, or the authorized blob set. Expired / nonexistent / workspace-or-epoch-mismatch fail closed.
- **Reservation carries the cut's real `ReplicaChangeRecord`**: `AuthoritySnapshotReservation.cutChange?: ReplicaChangeRecord | null` (optional, backward-compatible). `beginSnapshot` already reads `replicaChangeLog.latest`; it is attached verbatim (null for the empty revision-0 baseline). No fabrication — this lets the remote broker seed `ReplicaChangeLog.latest()` / `snapshotAt` truthfully.

## Task And Scope

- Task: `task_01KY6ZP85EF1R901SGJDPQAGGW` (RD-A.1), parent `task_01KXBGXDWQ0AW1CBAEHA8D3PNP` (透明工作区实现 root, ADR-0029).
- File surface: `authority/{protocol,read-down-service,forced-command-session}.ts`, `application/authority/types.ts`, `transport/persistent-ssh-authority-client.ts` + tests only. No broker adapter (RD-B), no CLI, no lifecycle assembly, no submit/write path.
- Explicitly **deferred** (per decision, history goes via bootstrap/re-snapshot/git-fetch): no in-wire `changes_after`-below-cut backfill.

## Version Impact

Additive wire contract completion. `AuthoritySnapshotReservation.cutChange` is an optional field; existing `replica-change/v2` consumers are unaffected. The `renew_lease` frame is a new kind; existing frames unchanged.

## Governance Declaration

- Backed by accepted decision `dec_01KXB6ZS4EBW8EPWR7132CTBJY` (V2-I22 renewable lease; snapshot+ReplicaChangeLog+CAS; git-fetch downgraded to bootstrap/history). No new decision required — this completes an accepted contract.
- Scope guardrails `dec_01KY6FT6YM5RM2A083Y45TH6ND` honored (read-down only; renewable lease is NOT a writable channel; no rsync; not writable; not GA).

## Verification

- `npm run check:local` green (local manifest gates); `npm run test:integration` exit 0 (0 fail) — re-run after the adversarial fix round.
- Negative + durable suite `authority-read-down-renewal.test.ts` proves fail-closed (expired / nonexistent / epoch-mismatch / structurally-corrupt lease), lease invariance (renew changes only `expiresAt`), bounded durable writes (100 renews ≤ 1 durable row), and absolute-lifetime fail-closed.
- `check-cli-daemon-parity` is CI-only/hermetic; verified in this PR's CI, not locally.

## Review Evidence

- CEO ground-truth of the diff: `renewLease` mutates only `expiresAt` (bounded by an absolute `renewableUntil` lifetime and a half-TTL idempotency window); the cut record is served on demand, not inlined; diff is scoped to the authorized surface (7 authority files).
- Codex adversarial review (black-box) found 3 findings; all CEO-ground-truthed as real and fixed in one round (commit `04e489d2`):
  - **[P1] `cutChange` inlined unbounded data into the size-limited reservation frame → orphan lease on a giant change.** Fixed: cut record moved to an on-demand `get_cut_change` frame (mirrors `get_snapshot_manifest`); the reservation stays bounded; a failed `begin` response releases the lease (no orphan). *(Deferred: chunking a single >1 MiB record — a pre-existing limitation shared with the manifest.)*
  - **[P1] Unbounded renewal caused synchronous durable write amplification (fsync per renew), masked by an in-memory-Map test.** Fixed: absolute lease lifetime cap (`renewableUntil`) + half-TTL idempotency window (renew is a no-op when ample TTL remains); a real durable-state test proves 100 renews in one window append at most 1 `replication.jsonl` row and that reaching the absolute lifetime fails closed.
  - **[P2] `readLiveLease` did not validate `leaseId` / `minRetainedRevision` / `stream.fromRevision`.** Fixed: fail-closed on empty `leaseId`, and enforces `minRetainedRevision === stream.fromRevision === cut.revision + 1`, plus a canonical `renewableUntil`.

## Residual Risk

- A live lease pins `minRetainedRevision` / blob set, but only up to its absolute `renewableUntil` lifetime (now enforced); it cannot be renewed indefinitely.
- A single cut `ReplicaChangeRecord` larger than one 1 MiB frame is not yet chunked (a pre-existing limitation shared with the manifest frame); deferred.
- RD-B (broker adapters) will consume this with a state-based reconnect (re-snapshot at new cut + manifest diff + CAS dedup), not below-cut log backfill.

## References

- Decision: `dec_01KXB6ZS4EBW8EPWR7132CTBJY`, `dec_01KY6FT6YM5RM2A083Y45TH6ND`
- ADR-0029 transparent workspace; RD-A `task_01KY6GFT78G6DYYYD2K73PK8P5` (done)
- Unblocks RD-B `task_01KY6YPRFAWPRPJD943N13NHZK`

---

# 中文

## 概要

按已接受决策 `dec_01KXB6ZS4EBW8EPWR7132CTBJY`(V2-I22)补全 RD-A 的 read-down wire 契约,解除 broker 持久 read-down 消费(RD-B)的阻塞。RD-A 冻结的数据面对*新*客户端足够(快照+前向流),但对*持久* broker 少交付了决策要求的两样:可续租约 + 真实的 cut 基线记录。本 PR 只补这两样,别无其他。

## 改动内容

- **可续租约(V2-I22,已决策)**:新 `renew_lease` wire 帧 + server handler + `AuthorityReadDownService.renewLease` + transport client 方法。只对经 `readLiveLease`(epoch/workspace/liveness/sameCut/digest)校验为仍 live 的 lease 延展 `expiresAt = now + ttl`;绝不改 `cut`/`manifest`/`leaseId`/`minRetainedRevision`/`pinnedBlobSetDigest`/`stream`/授权 blob 集。过期/不存在/workspace 或 epoch 不符一律 fail-closed。
- **reservation 携带 cut 的真实 `ReplicaChangeRecord`**:`AuthoritySnapshotReservation.cutChange?: ReplicaChangeRecord | null`(可选,向后兼容)。`beginSnapshot` 本已读 `replicaChangeLog.latest`,原样挂入(空 revision-0 基线为 null)。**不 fabricate**——让远程 broker 能真实 seed `ReplicaChangeLog.latest()` / `snapshotAt`。

## 任务与范围

- 任务:`task_01KY6ZP85EF1R901SGJDPQAGGW`(RD-A.1),父 `task_01KXBGXDWQ0AW1CBAEHA8D3PNP`(透明工作区实现 root,ADR-0029)。
- 文件面:仅 `authority/{protocol,read-down-service,forced-command-session}.ts`、`application/authority/types.ts`、`transport/persistent-ssh-authority-client.ts` + 测试。不碰 broker adapter(RD-B)、CLI、lifecycle 装配、submit/写路。
- 明确 **DEFER**(按决策,history 走 bootstrap/re-snapshot/git-fetch):不做 in-wire `changes_after`-below-cut 补拉。

## 版本影响

加性契约补全。`cutChange` 是可选字段,现有 `replica-change/v2` 消费者不受影响;`renew_lease` 是新帧,老帧不变。

## 治理声明

- 由已接受决策 `dec_01KXB6ZS4EBW8EPWR7132CTBJY`(V2-I22 可续租约;快照+ReplicaChangeLog+CAS;git-fetch 降级为 bootstrap/history)背书。**无需新裁决**——本 PR 补完一个已接受契约。
- 遵守 scope 护栏 `dec_01KY6FT6YM5RM2A083Y45TH6ND`(read-down only;可续租约**不是** writable 通道;不 rsync;不 writable;不 GA)。

## 验证

- `npm run check:local` 绿;`npm run test:integration` exit 0(0 失败)——对抗修复轮后复跑。
- 负向 + durable 套件 `authority-read-down-renewal.test.ts` 证明 fail-closed(过期/不存在/epoch 不符/结构损坏 lease)、lease 不变性(renew 只改 `expiresAt`)、durable 写有界(100 次 renew ≤1 条 durable 记录)、绝对寿命 fail-closed。
- `check-cli-daemon-parity` CI-only/hermetic,本 PR 的 CI 验,非本地。

## 审查证据

- CEO 亲验 diff:`renewLease` 只改 `expiresAt`(受绝对寿命 `renewableUntil` + 半 TTL 幂等窗口约束);cut 记录改为按需取、不内联;diff 严格在授权面内(7 authority 文件)。
- Codex 对抗复核(黑盒)抓 3 条,CEO 全部 ground-truth 属实并一轮修掉(commit `04e489d2`):
  - **[P1] cutChange 内联无界数据进受限 reservation 帧 → 巨型 change 致孤儿 lease。** 已修:cut 记录移到按需 `get_cut_change` 帧(镜像 `get_snapshot_manifest`),reservation 恒小,`begin` 响应失败释放 lease(无孤儿)。*(DEFER:单条 >1 MiB 记录分块——与 manifest 共有的既存限制。)*
  - **[P1] 无界续租致同步 durable 写放大(每续租一次 fsync),被内存 Map 测试掩盖。** 已修:绝对寿命上界(`renewableUntil`)+ 半 TTL 幂等窗口(TTL 充足时 renew 为 no-op);真实 durable 测试证明同窗口 100 次 renew 至多 append 1 条 `replication.jsonl` 记录,到达绝对寿命 fail-closed。
  - **[P2] readLiveLease 未校验 leaseId / minRetainedRevision / stream.fromRevision。** 已修:空 leaseId fail-closed,强制 `minRetainedRevision === stream.fromRevision === cut.revision + 1`,并校验 canonical `renewableUntil`。

## 残余风险

- live lease pin 住 `minRetainedRevision`/blob 集,但只到其绝对 `renewableUntil` 寿命(现已强制),不能无限续租。
- 单条超过 1 MiB 帧的 cut `ReplicaChangeRecord` 尚未分块(与 manifest 帧共有的既存限制),DEFER。
- RD-B(broker adapter)将以**状态式** reconnect 消费(重新 snapshot 到新 cut + manifest diff + CAS 去重),非 below-cut log 补拉。

## 关联材料

- 决策:`dec_01KXB6ZS4EBW8EPWR7132CTBJY`、`dec_01KY6FT6YM5RM2A083Y45TH6ND`
- ADR-0029 透明工作区;RD-A `task_01KY6GFT78G6DYYYD2K73PK8P5`(done)
- 解除 RD-B `task_01KY6YPRFAWPRPJD943N13NHZK`
