### PR TITLE
fix(governance): resolve S3 unknown write roads (task-review→single-entry, governance-rebuild→parity-debt)

### DIFF
--- a/S3-UNKNOWN-RESOLUTION-REPORT.md
+++ b/S3-UNKNOWN-RESOLUTION-REPORT.md
@@ -1,0 +1,66 @@
+# S3 Unknown Resolution Report
+
+## 最终 realization
+
+依据 `dec_01KY79W8F8R22PB6RRV760V7NY`，两条 `unknown` 按各自真实语义分别收口：
+
+### `task-review`：`single-entry`
+
+CLI `packages/cli/src/commands/core/task-gates.ts#runTaskGatesCommand` 是该写路唯一真实 materializing ingress。
+
+API/GUI 的 `reviewTask` 经 `packages/application/src/local-controller-service.ts#makeLocalControllerService` 调用 `startTaskReview`；后者只返回 `execution_submission_required`，不写入或 materialize review 写路。`tools/write-road-discovery.mjs` 现在同时核验：
+
+- controller 的精确调用集合；
+- `startTaskReview` guard 的精确调用集合；
+- `execution_submission_required` 错误码。
+
+三项都匹配时，API/GUI request-guard 才不作为 authored 写 surface 进入 intent-compiler criterion，使其按 `no-authored-ingress-surfaces` 规则对本写路结构性 not-applicable。任一实现漂移都会失败闭合，重新暴露 API/GUI surface 并要求归属。
+
+### `governance-rebuild`：`parity-debt`
+
+API/GUI surface 保留在 discovery 与 registry 中，因为它确实是条件 materializer：
+
+- CLI `packages/cli/src/commands/governance.ts#runGovernanceRebuild` 无条件执行完整重建，另外写 `Harness-Ledger.md`，archive 模式还会写归档。
+- API/GUI `rebuildGovernance` 经 `queryTaskProjection` / `readTaskProjection` 条件性进入 `packages/kernel/src/projection/sqlite-task-projection.ts#rebuildTaskProjection`，只 materialize SQLite projection。
+
+两种 ingress 对同一 projection materialization 意图存在真实语义分歧，因此登记为 `parity-debt`：
+
+- compiler refs：`runGovernanceRebuild` 与 `rebuildTaskProjection`；
+- owner：`governance.projection.rebuild`；
+- sunset：`2026-10-31`；
+- reason：要求 owner 在 sunset 前收敛语义，或明确保留该分歧。
+
+## 改动文件
+
+- `tools/write-road-discovery.mjs`
+  - 增加 `task-review` request-guard 的失败闭合源码识别。
+- `tools/check-write-road-registry.test.mjs`
+  - 增加合规 `parity-debt` 正向用例。
+  - 增加 request-guard not-applicable 正向用例。
+  - 增加 guard 开始 materialize 时重新发现 surface 的负向用例。
+- `tools/write-road-registry.json`
+  - `task-review` 改为 `single-entry`，只保留 CLI surface。
+  - 从 task lifecycle 写路 row 移除非 materializing 的 `tasks.review` / `reviewTask`。
+  - `governance-rebuild` 改为 `parity-debt`，保留 CLI/API/GUI surfaces。
+- `S3-UNKNOWN-RESOLUTION-REPORT.md`
+  - 记录最终裁决、实现、门证据与风险。
+
+`packages/**` 未修改。
+
+## 门证据
+
+最终提交前的 fresh 结果：
+
+- `node tools/check-write-road-registry.mjs`：通过；criterion 为 `unified=6 parity-debt=4 single-surface-debt=20 single-entry=41 unknown=0`。
+- `node --test tools/check-write-road-registry.test.mjs`：19/19 通过。
+- `node tools/check-cli-daemon-parity.mjs`：通过；覆盖 26 个 live typed write commands。
+- `node tools/check-file-complexity.mjs`：通过。
+- `npm run lint -- --no-fix`：通过。
+- `npm run test:contract`：完成且无失败。
+- `git diff --check`：通过。
+
+## 残余风险
+
+- request-guard discovery 有意对实现形状敏感。无语义变化的调用重构也可能让门变红；这是失败闭合复核信号，不是运行时风险。
+- `governance-rebuild` 的 parity debt 仍是显式治理债：CLI 与 API/GUI 的触发条件、工件范围不同，需 owner 在 `2026-10-31` 前收敛或正式保留差异。
+- 本任务不改变 API 命名、HTTP method 或 `packages/**` 实现，也不臆造新的 materializer。

--- a/tools/check-write-road-registry.test.mjs
+++ b/tools/check-write-road-registry.test.mjs
@@ -34,6 +34,17 @@ test("write-road registry rejects unified entry compilers that point to differen
   }
 });
 
+test("write-road registry accepts a compliant parity-debt item", () => {
+  const root = makeFixtureRoot();
+  try {
+    writeFixture(root, { parity: "parity-debt" });
+    const result = runChecker(root);
+    assert.equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("write-road registry rejects an authored surface without a criterion item", () => {
   const root = makeFixtureRoot();
   try {
@@ -233,6 +244,30 @@ test("write-road registry rejects an unregistered task write API policy", () => 
   }
 });
 
+test("write-road registry treats a verified task review request guard as non-materializing ingress", () => {
+  const root = makeFixtureRoot();
+  try {
+    writeFixture(root, { taskReviewRequestGuard: true });
+    const result = runChecker(root);
+    assert.equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("write-road registry fails closed when the task review request guard starts materializing", () => {
+  const root = makeFixtureRoot();
+  try {
+    writeFixture(root, { taskReviewRequestGuard: true, materializingTaskReviewGuard: true });
+    const result = runChecker(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /mutating API route tasks\.review/u);
+    assert.match(result.stderr, /mutating GUI bridge method reviewTask/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("write-road registry rejects an unregistered preset script output scope", () => {
   const root = makeFixtureRoot();
   try {
@@ -286,9 +321,11 @@ function writeFixture(root, overrides = {}) {
   ]);
   const taskCliPolicies = ["{ actionKind: 'registered-action' }"];
   if (overrides.extraTaskCliAction) taskCliPolicies.push(`{ actionKind: '${overrides.extraTaskCliAction}' }`);
-  const taskApiPolicies = ["single-surface-debt", "single-entry"].includes(overrides.parity)
+  const taskApiPolicies = ["single-surface-debt", "single-entry"].includes(overrides.parity) && !overrides.taskReviewRequestGuard
     ? []
-    : ["{ id: 'registered.route', method: 'POST', guiBridgeMethod: 'registeredBridge' }"];
+    : overrides.taskReviewRequestGuard
+      ? ["{ id: 'tasks.review', method: 'POST', serviceMethod: 'reviewTask', guiBridgeMethod: 'reviewTask' }"]
+      : ["{ id: 'registered.route', method: 'POST', guiBridgeMethod: 'registeredBridge' }"];
   if (overrides.extraTaskApiRoute) taskApiPolicies.push(overrides.extraTaskApiRoute);
   writeLines(root, "packages/application/src/task-write-route-policy.ts", [
     `export const taskWriteCliRoutePolicies = [${taskCliPolicies.join(", ")}] as const;`,
@@ -303,6 +340,35 @@ function writeFixture(root, overrides = {}) {
   writeLines(root, "packages/api-contracts/src/api-contract-registry.ts", [
     `export const apiRouteContracts = [${apiRoutes.join(", ")}] as const;`
   ]);
+  if (overrides.taskReviewRequestGuard) {
+    writeLines(root, "packages/application/src/local-controller-service.ts", [
+      "declare const Effect: { runPromise(value: unknown): unknown; map(fn: unknown): unknown };",
+      "declare const lifecycleOrchestrator: { startTaskReview(payload: unknown): { pipe(...args: unknown[]): unknown } };",
+      "declare function validateLocalControllerTaskId(taskId: unknown): void;",
+      "declare function toLocalControllerResult(value: unknown): unknown;",
+      "export function makeLocalControllerService() {",
+      "  return {",
+      "    reviewTask: async (payload: { taskId: string }) => {",
+      "      validateLocalControllerTaskId(payload.taskId);",
+      "      return Effect.runPromise(lifecycleOrchestrator.startTaskReview(payload).pipe(Effect.map(toLocalControllerResult)));",
+      "    }",
+      "  };",
+      "}"
+    ]);
+    writeLines(root, "packages/application/src/task-lifecycle-orchestrator.ts", [
+      "declare const Effect: { succeed(value: unknown): unknown };",
+      "declare function taskFailure(taskId: string, code: string, hint: string): unknown;",
+      ...(overrides.materializingTaskReviewGuard ? ["declare function materializeReview(): void;"] : []),
+      "export function makeTaskLifecycleOrchestrator() {",
+      "  return {",
+      "    startTaskReview: (payload: { taskId: string }) => {",
+      ...(overrides.materializingTaskReviewGuard ? ["      materializeReview();"] : []),
+      "      return Effect.succeed(taskFailure(payload.taskId, 'execution_submission_required', 'Submit an execution first.'));",
+      "    }",
+      "  };",
+      "}"
+    ]);
+  }
   writeFileSync(path.join(root, "packages/cli/src/commands/extensions/assets/software-coding/presets/fixture/preset.json"), JSON.stringify({
     schema: "preset-manifest/v2",
     id: "fixture",
@@ -322,7 +388,7 @@ function writeFixture(root, overrides = {}) {
 }
 
 function makeRegistry(overrides = {}) {
-  const parity = overrides.parity ?? "unified";
+  const parity = overrides.taskReviewRequestGuard ? "single-entry" : overrides.parity ?? "unified";
   const surfaces = {
     cliActions: ["registered-action"],
     apiRoutes: ["single-surface-debt", "single-entry"].includes(parity) ? [] : ["registered.route"],
@@ -336,14 +402,14 @@ function makeRegistry(overrides = {}) {
         { entry: "direct", ref: "packages/application/src/fixture.ts#compileRegisteredIntent" },
         {
           entry: "daemon",
-          ref: overrides.splitIntentCompiler || parity === "single-surface-debt"
+          ref: overrides.splitIntentCompiler || ["parity-debt", "single-surface-debt"].includes(parity)
             ? "packages/application/src/fixture.ts#compileRegisteredIntentSeparately"
             : "packages/application/src/fixture.ts#compileRegisteredIntent"
         }
       ];
   const dispositionFields = overrides.omitDispositionFields
     ? {}
-    : parity === "single-surface-debt"
+    : ["parity-debt", "single-surface-debt"].includes(parity)
       ? { owner: "fixture.covered", sunset: "2026-10-31" }
       : parity === "single-entry"
         ? { reviewWhen: "Return to unknown when any second authored ingress surface is registered." }

--- a/tools/write-road-discovery.mjs
+++ b/tools/write-road-discovery.mjs
@@ -12,6 +12,8 @@ import { fsWriteApis } from "./fs-write-apis.mjs";
 import { discoverWorkspaceSourceRoots } from "./workspace-packages.mjs";
 
 const mutatingHttpMethods = new Set(["POST", "PUT", "DELETE"]);
+const taskReviewControllerCalls = new Set(["map", "pipe", "runPromise", "startTaskReview", "validateLocalControllerTaskId"]);
+const taskReviewGuardCalls = new Set(["succeed", "taskFailure"]);
 const root = process.cwd();
 const sourceRoots = [...discoverWorkspaceSourceRoots(root), "tools"];
 
@@ -113,6 +115,7 @@ function discoverDaemonCliActions() {
 
 function discoverApiRoutes() {
   const out = [];
+  const taskReviewIsRequestGuard = discoverTaskReviewRequestGuard();
   for (const [rel, arrayName] of [
     ["packages/api-contracts/src/api-contract-registry.ts", "apiRouteContracts"],
     ["packages/application/src/task-write-route-policy.ts", "taskWriteApiRoutePolicies"]
@@ -121,8 +124,10 @@ function discoverApiRoutes() {
     for (const element of objectElementsInArray(sourceFile, arrayName)) {
       const id = stringProperty(element, "id");
       const method = stringProperty(element, "method");
+      const serviceMethod = stringProperty(element, "serviceMethod");
       const guiBridgeMethod = stringProperty(element, "guiBridgeMethod");
       if (id && method && mutatingHttpMethods.has(method)) {
+        if (serviceMethod === "reviewTask" && taskReviewIsRequestGuard) continue;
         out.push(discovery("api-route", rel, element, sourceFile, `mutating API route ${id}`, { apiRoute: id }));
         if (guiBridgeMethod) {
           out.push(discovery("gui-bridge-method", rel, element, sourceFile, `mutating GUI bridge method ${guiBridgeMethod}`, { guiBridgeMethod }));
@@ -131,6 +136,50 @@ function discoverApiRoutes() {
     }
   }
   return uniqueDiscoveries(out);
+}
+
+function discoverTaskReviewRequestGuard() {
+  const controllerRel = "packages/application/src/local-controller-service.ts";
+  const lifecycleRel = "packages/application/src/task-lifecycle-orchestrator.ts";
+  if (![controllerRel, lifecycleRel].every((rel) => existsSync(path.join(root, rel)))) return false;
+  const controllerBody = propertyImplementationBody(parseSource(controllerRel), "reviewTask");
+  const guardBody = propertyImplementationBody(parseSource(lifecycleRel), "startTaskReview");
+  return controllerBody !== undefined &&
+    guardBody !== undefined &&
+    setsEqual(calledNamesIn(controllerBody), taskReviewControllerCalls) &&
+    setsEqual(calledNamesIn(guardBody), taskReviewGuardCalls) &&
+    stringLiteralsInNode(guardBody).includes("execution_submission_required");
+}
+
+function propertyImplementationBody(sourceFile, propertyName) {
+  let body;
+  visit(sourceFile, (node) => {
+    if (!ts.isPropertyAssignment(node) || propertyNameText(node.name) !== propertyName) return;
+    const implementation = unwrapExpression(node.initializer);
+    if (ts.isArrowFunction(implementation) || ts.isFunctionExpression(implementation)) body = implementation.body;
+  });
+  return body;
+}
+
+function calledNamesIn(node) {
+  const calls = new Set();
+  visit(node, (child) => {
+    if (ts.isCallExpression(child)) calls.add(calledIdentifier(child.expression));
+  });
+  calls.delete("");
+  return calls;
+}
+
+function stringLiteralsInNode(node) {
+  const literals = [];
+  visit(node, (child) => {
+    if (ts.isStringLiteralLike(child)) literals.push(child.text);
+  });
+  return literals;
+}
+
+function setsEqual(left, right) {
+  return left.size === right.size && [...left].every((value) => right.has(value));
 }
 
 function objectElementsInArray(sourceFile, arrayName) {

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -223,16 +223,16 @@
           "surfaces": {
             "cliActions": [
               "task-review"
-            ],
-            "apiRoutes": [
-              "tasks.review"
-            ],
-            "guiBridgeMethods": [
-              "reviewTask"
             ]
           },
-          "parity": "unknown",
-          "reason": "CLI packages/cli/src/commands/core/task-gates.ts#runTaskGatesCommand reaches packages/application/src/task-lifecycle-orchestrator.ts#reviewTask, but API/GUI packages/application/src/local-controller-service.ts#makeLocalControllerService routes reviewTask to startTaskReview, which returns execution_submission_required without a materializer; the five dispositions do not express an existing second ingress with no materializer, so task.lifecycle.transition owner must decide that shape."
+          "parity": "single-entry",
+          "compilers": [
+            {
+              "entry": "current-authored-ingress",
+              "ref": "packages/cli/src/commands/core/task-gates.ts#runTaskGatesCommand"
+            }
+          ],
+          "reviewWhen": "Return this item to unknown when any second materializing authored ingress surface is registered for this intent."
         },
         {
           "selector": "task-review-execution",
@@ -346,12 +346,10 @@
         "task-review-execution"
       ],
       "apiRoutes": [
-        "tasks.status.set",
-        "tasks.review"
+        "tasks.status.set"
       ],
       "guiBridgeMethods": [
-        "setTaskStatus",
-        "reviewTask"
+        "setTaskStatus"
       ],
       "callsiteFiles": [
         "packages/adapters/local/src/task-writes.ts"
@@ -2593,8 +2591,20 @@
               "rebuildGovernance"
             ]
           },
-          "parity": "unknown",
-          "reason": "CLI packages/cli/src/commands/governance.ts#runGovernanceRebuild rebuilds and writes projection artifacts, but API/GUI packages/application/src/local-controller-service.ts#makeLocalControllerService implements rebuildGovernance as queryTaskProjection with no rebuild materializer; the five dispositions do not express an existing second ingress with no materializer, so governance.projection.rebuild owner must decide that shape."
+          "parity": "parity-debt",
+          "compilers": [
+            {
+              "entry": "direct",
+              "ref": "packages/cli/src/commands/governance.ts#runGovernanceRebuild"
+            },
+            {
+              "entry": "api-gui",
+              "ref": "packages/kernel/src/projection/sqlite-task-projection.ts#rebuildTaskProjection"
+            }
+          ],
+          "owner": "governance.projection.rebuild",
+          "sunset": "2026-10-31",
+          "reason": "CLI runGovernanceRebuild unconditionally performs the complete rebuild and also writes generated governance views plus an optional archive; API/GUI reaches rebuildTaskProjection only conditionally through queryTaskProjection/readTaskProjection and materializes only the SQLite projection. The owner must converge these ingress semantics or explicitly preserve the divergence before sunset."
         },
         {
           "selector": "materializer-run",


### PR DESCRIPTION
# English

## Summary

Resolve the two long-standing `parity: "unknown"` intent-compiler rows in `tools/write-road-registry.json` by classifying each per its true (verified) semantics, retiring both `unknown` entries. `unknown` count goes 2 → 0.

## What Changed

- **`task-review` → `single-entry`.** CLI `runTaskGatesCommand` is the only real materializing ingress. The API/GUI `reviewTask` routes to `startTaskReview`, which only returns `execution_submission_required` (a request-guard, not a materializer). `tools/write-road-discovery.mjs` now excludes that API/GUI surface **only when a fail-closed check confirms the request-guard shape** (exact controller call-set + exact guard call-set + the `execution_submission_required` literal). Any drift re-exposes the surface and demands classification.
- **`governance-rebuild` → `parity-debt`.** Ground-truth corrected an earlier premise: the API/GUI `rebuildGovernance` **is** a conditional materializer — via `queryTaskProjection`/`readTaskProjection` it reaches `rebuildTaskProjection` and materializes the SQLite projection when the cache is missing/corrupt/stale. It diverges from CLI's unconditional full rebuild (which also writes `Harness-Ledger.md` + optional archive), so it is honest `parity-debt` with two materializer refs, owner, and a sunset.
- Scope is `tools/` only (registry + discovery + tests). No `packages/**` changes; no invented materializer.

## Task And Scope

PLT-Boundary S3 intent-compiler ledger criterion (`task_01KXZTYFZ0MNM0BWQT9Y9ZF4CC`), under the PLT-Baseline-Governance umbrella (`task_01KXWZ3YEGXD6302G1656RY801`). Files: `tools/write-road-registry.json`, `tools/write-road-discovery.mjs`, `tools/check-write-road-registry.test.mjs`.

## Version Impact

None. Registry classification + discovery/test changes only; no API surface, schema, or runtime behavior change.

## Governance Declaration

- `dec_01KY79W8F8R22PB6RRV760V7NY` (active) — governance-rebuild classified `parity-debt`; task-review stays not-applicable/single-entry. Narrows/corrects `dec_01KY76ZNHR79V7NAD6FQFSBJPX`.
- `dec_01KY76ZNHR79V7NAD6FQFSBJPX` (active) — Option A: request-guard/query surfaces classified honestly, no invented materializer (Option B rejected).
- Fact `F-R170E21A` — CEO ground-truthed premise falsification (governance-rebuild is a conditional materializer).
- No protected surface touched (`tools/` only).

## Verification

- `node tools/check-write-road-registry.mjs`: passed; `unified=6 parity-debt=4 single-surface-debt=20 single-entry=41 unknown=0`.
- `node --test tools/check-write-road-registry.test.mjs`: 19/19, including a positive parity-debt case, a positive request-guard-not-applicable case, and a **negative case proving re-discovery when the guard starts materializing**.
- `node tools/check-cli-daemon-parity.mjs`: passed (26 live typed write commands).
- Re-verified green after rebase onto latest `origin/main`.

## Review Evidence

CEO semantic + architecture acceptance (not delegated): the Codex worker first hit a dissent checkpoint and falsified the governance-rebuild premise; CEO verified the call chain line-by-line (`sqlite-task-projection.ts:161/91`) before re-tasking. The fail-closed discovery exclusion was read and confirmed to use exact-set matching (`setsEqual`), so it re-exposes the surface on any drift rather than creating a permanent hole; the negative test encodes this.

## Residual Risk

- The request-guard discovery is intentionally shape-sensitive; a semantically-neutral refactor of `reviewTask`/`startTaskReview` can turn the gate red. This is a fail-closed review signal, not a runtime risk.
- `governance-rebuild` remains explicit governance debt: CLI and API/GUI differ in trigger condition and artifact scope. Owner must converge or explicitly preserve the divergence before sunset `2026-10-31`.

## References

- Umbrella: `task_01KXWZ3YEGXD6302G1656RY801` (PLT-Baseline-Governance)
- Task: `task_01KXZTYFZ0MNM0BWQT9Y9ZF4CC` (S3 intent-compiler ledger criterion)
- Decisions: `dec_01KY79W8F8R22PB6RRV760V7NY`, `dec_01KY76ZNHR79V7NAD6FQFSBJPX`

---

# 中文

## 概要

把 `tools/write-road-registry.json` 里长期停留的两条 `parity: "unknown"` intent-compiler 行,按各自的**真实(已核实)语义**分别归类,退役两条 `unknown`。`unknown` 计数 2 → 0。

## 改动内容

- **`task-review` → `single-entry`。** CLI `runTaskGatesCommand` 是唯一真实 materializing 入口。API/GUI 的 `reviewTask` 路由到 `startTaskReview`,后者只返回 `execution_submission_required`(请求闸门,非 materializer)。`tools/write-road-discovery.mjs` 现在**仅当失败闭合校验确认请求闸门形状时**才排除该 API/GUI surface(精确 controller 调用集 + 精确 guard 调用集 + `execution_submission_required` 字面量)。任一漂移都会重新暴露该 surface 并要求归属。
- **`governance-rebuild` → `parity-debt`。** ground-truth 更正了此前一个前提:API/GUI 的 `rebuildGovernance` **确是**条件 materializer——经 `queryTaskProjection`/`readTaskProjection` 到达 `rebuildTaskProjection`,在缓存缺失/损坏/陈旧时重建 SQLite projection。它与 CLI 的无条件完整重建(还写 `Harness-Ledger.md` + 可选归档)存在真实分歧,故诚实登记为 `parity-debt`,含两个 materializer ref、owner 与 sunset。
- 范围仅 `tools/`(registry + discovery + tests)。不改 `packages/**`;不臆造 materializer。

## 任务与范围

PLT-Boundary S3 intent-compiler 台账判据(`task_01KXZTYFZ0MNM0BWQT9Y9ZF4CC`),隶属 PLT-Baseline-Governance 协调伞(`task_01KXWZ3YEGXD6302G1656RY801`)。文件:`tools/write-road-registry.json`、`tools/write-road-discovery.mjs`、`tools/check-write-road-registry.test.mjs`。

## 版本影响

无。仅 registry 分类 + discovery/test 改动;无 API surface、schema 或运行时行为变化。

## 治理声明

- `dec_01KY79W8F8R22PB6RRV760V7NY`(active)——governance-rebuild 判 `parity-debt`;task-review 维持 not-applicable/single-entry。narrows/更正 `dec_01KY76ZNHR79V7NAD6FQFSBJPX`。
- `dec_01KY76ZNHR79V7NAD6FQFSBJPX`(active)——Option A:request-guard/query surface 按真实语义诚实分类,不臆造 materializer(Option B 已拒)。
- Fact `F-R170E21A`——CEO 亲验前提证伪(governance-rebuild 是条件 materializer)。
- 未触碰 protected surface(仅 `tools/`)。

## 验证

- `node tools/check-write-road-registry.mjs`:通过;`unified=6 parity-debt=4 single-surface-debt=20 single-entry=41 unknown=0`。
- `node --test tools/check-write-road-registry.test.mjs`:19/19,含 parity-debt 正向用例、request-guard not-applicable 正向用例、以及**「guard 开始 materialize 时重新发现 surface」的负向用例**。
- `node tools/check-cli-daemon-parity.mjs`:通过(26 个 live typed write commands)。
- rebase 到最新 `origin/main` 后复验仍绿。

## 审查证据

CEO 语义 + 架构验收(不下放):Codex worker 先在异议 checkpoint 证伪了 governance-rebuild 前提;CEO 逐行核实调用链(`sqlite-task-projection.ts:161/91`)后再委派实现。失败闭合的 discovery 排除已读并确认用精确集合匹配(`setsEqual`),故任一漂移都会重新暴露 surface 而非留永久漏洞;负向测试对此做了编码。

## 残余风险

- 请求闸门 discovery 有意对形状敏感;对 `reviewTask`/`startTaskReview` 的语义中性重构也可能让门变红。这是失败闭合复核信号,不是运行时风险。
- `governance-rebuild` 仍是显式治理债:CLI 与 API/GUI 在触发条件与工件范围上不同。owner 须在 sunset `2026-10-31` 前收敛或明确保留分歧。

## 关联材料

- 协调伞:`task_01KXWZ3YEGXD6302G1656RY801`(PLT-Baseline-Governance)
- 任务:`task_01KXZTYFZ0MNM0BWQT9Y9ZF4CC`(S3 intent-compiler 台账判据)
- 决策:`dec_01KY79W8F8R22PB6RRV760V7NY`、`dec_01KY76ZNHR79V7NAD6FQFSBJPX`

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body with canonical sections / 双语正文含 canonical 章节
- [x] Governance references in Governance Declaration / 治理引用置于治理声明段
- [x] Gates green (registry unknown=0, test 19/19, parity 26) / 门禁绿
- [x] Scope tools/ only, no packages/** / 范围仅 tools/,不动 packages/**
