### PR TITLE
fix(ci): supply-chain 对瞬时 registry 错误重试,不再因 npm 503 硬红

### DIFF
--- a/tools/check-supply-chain.mjs
+++ b/tools/check-supply-chain.mjs
@@ -52,6 +52,18 @@ function requireIncludes(file, text, description = text) {
   if (!body.includes(normalizeText(text))) record(`${file} must mention ${description}`);
 }
 
+// A transient npm registry / transport failure (5xx, rate limit, connection
+// reset, DNS, socket hang up) must be retried inside the network budget rather
+// than hard-failing this required gate on a registry blip. Real `npm audit`
+// findings (actual advisories) never contain these transport tokens, so this
+// predicate cannot mistake a genuine vulnerability report for a transient error.
+export function isTransientRegistryError(output) {
+  if (typeof output !== "string" || output === "") return false;
+  return /\b(50[0234]|429)\b|service unavailable|bad gateway|gateway time-?out|too many requests|audit endpoint returned an error|econnreset|etimedout|eai_again|enotfound|socket hang ?up|network (?:error|timeout)|request to https?:\/\/\S*registry\S* failed/iu.test(
+    output
+  );
+}
+
 function runNetworkCommand(command, phase, networkStartedAt) {
   const [binary, ...args] = command.split(" ");
   for (let attempt = 1; attempt <= networkAttempts; attempt += 1) {
@@ -92,6 +104,16 @@ function runNetworkCommand(command, phase, networkStartedAt) {
     }
     if (result.status !== 0) {
       const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+      if (
+        attempt < networkAttempts &&
+        Date.now() - networkStartedAt < networkBudgetMs &&
+        isTransientRegistryError(output)
+      ) {
+        console.error(
+          `[supply-chain] ${receipt} status=registry-error-retry: ${output.split("\n", 1)[0]}`
+        );
+        continue;
+      }
       record(`[${receipt}] ${command} failed${output ? `:\n${output}` : ""}`);
       return "";
     }

--- a/tools/check-supply-chain.test.mjs
+++ b/tools/check-supply-chain.test.mjs
@@ -43,6 +43,42 @@ test("supply-chain check accepts an explicitly wider fail-closed command timeout
   });
 });
 
+test("supply-chain check retries a transient registry error and passes within budget", async () => {
+  await withFixtureRepo((root) => {
+    const counterPath = path.join(root, "audit-attempts.count");
+    writeValidSupplyChainFixture(root, {
+      flakyNpmCommand: "audit --omit=dev --audit-level=high",
+      flakyCounterPath: counterPath,
+      flakyFailCount: 1
+    });
+
+    const result = runCheck(root);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Supply chain check passed/u);
+    assert.match(result.stderr, /status=registry-error-retry/u);
+    assert.equal(Number(readFileSync(counterPath, "utf8")), 2, "a transient 503 must be retried once");
+  });
+});
+
+test("supply-chain check does not retry a real audit finding and fails closed", async () => {
+  await withFixtureRepo((root) => {
+    const counterPath = path.join(root, "audit-attempts.count");
+    writeValidSupplyChainFixture(root, {
+      flakyNpmCommand: "audit --omit=dev --audit-level=high",
+      flakyCounterPath: counterPath,
+      flakyFailCount: 99,
+      flakyFailMessage: "found 3 high severity vulnerabilities in 1200 scanned packages"
+    });
+
+    const result = runCheck(root);
+
+    assert.notEqual(result.status, 0);
+    assert.doesNotMatch(result.stderr, /status=registry-error-retry/u);
+    assert.equal(Number(readFileSync(counterPath, "utf8")), 1, "a real finding must fail closed without retry");
+  });
+});
+
 test("supply-chain check rejects non-CLI publishable packages", async () => {
   await withFixtureRepo((root) => {
     writeValidSupplyChainFixture(root, {
@@ -492,13 +528,23 @@ function writeMockNpm(root, options) {
   const sbom = JSON.stringify(sbomValue);
   writeFile(root, ".mock-bin/npm", [
     "#!/usr/bin/env node",
-    "const { appendFileSync, writeFileSync } = require('node:fs');",
+    "const { appendFileSync, readFileSync, writeFileSync } = require('node:fs');",
     "const args = process.argv.slice(2).join(' ');",
     ...(options.invocationLogPath ? [`appendFileSync(${JSON.stringify(options.invocationLogPath)}, args + '\\n');`] : []),
     `if (args === ${JSON.stringify(options.hangNpmCommand)}) {`,
     ...(options.hangPidPath ? [`  writeFileSync(${JSON.stringify(options.hangPidPath)}, String(process.pid));`] : []),
     "  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);",
     "}",
+    ...(options.flakyNpmCommand ? [
+      `if (args === ${JSON.stringify(options.flakyNpmCommand)}) {`,
+      `  let n = 0; try { n = Number(readFileSync(${JSON.stringify(options.flakyCounterPath)}, 'utf8')) || 0; } catch {}`,
+      `  writeFileSync(${JSON.stringify(options.flakyCounterPath)}, String(n + 1));`,
+      `  if (n < ${options.flakyFailCount ?? 1}) {`,
+      `    console.error(${JSON.stringify(options.flakyFailMessage ?? "npm warn audit 503 Service Unavailable - POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk - Service Unavailable\nnpm error audit endpoint returned an error")});`,
+      "    process.exit(1);",
+      "  }",
+      "}"
+    ] : []),
     "if (args === 'audit --audit-level=high' || args === 'audit --omit=dev --audit-level=high') {",
     "  console.log('found 0 vulnerabilities');",
     "  process.exit(0);",


### PR DESCRIPTION
# English

## Summary

Make the supply-chain gate resilient to transient npm registry errors. `runNetworkCommand` only retried on `ETIMEDOUT`; when `npm audit`/`npm sbom` hit a transient registry error (503/5xx/429/ECONNRESET/socket hang up) they exit non-zero and were hard-failed with no retry — a single registry blip reds a required gate. Observed live: `phase=audit-2` `npm audit` returned `503 Service Unavailable` and failed the run after 13.2s.

## What Changed

- `tools/check-supply-chain.mjs`: added `isTransientRegistryError(output)` (matches transport-layer tokens: 5xx/429, Service Unavailable, ECONNRESET/ETIMEDOUT/EAI_AGAIN/ENOTFOUND, socket hang up, "audit endpoint returned an error", failed registry request). On a non-zero exit whose output matches, retry within the existing network budget instead of hard-failing. A real `npm audit` finding never contains these tokens, so a genuine vulnerability report can never be mistaken for a transient error.
- `tools/check-supply-chain.test.mjs`: extended the mock npm with a fail-then-succeed mode and added two regressions — a transient 503 is retried once and passes; a real finding fails closed with no retry.

## Task And Scope

- Branch: `fix/ci-supply-chain-registry-retry`
- Public scope: supply-chain check network retry only.
- Private planning/evidence updated: not applicable (separate CI-stability defect surfaced during wedge-class work).
- Out of scope: concurrency cap (PR #1062), fast-contract sharding (held).

## Version Impact

- Version: no version change; CI check behavior only.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: no (`tools/check-supply-chain.mjs` logic; does not change CI topology, gate manifest, mergify, or branch protection).
- Authority: CI-stability defect (transient npm registry 503 hard-failing a required gate); no ADR/decision change to the gate contract.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: `1d921c9a`
- Sync method: branched from latest main
- Public diff command: `git diff main..HEAD`
- [x] `git diff --check`
- [x] Targeted tests: `tools/check-supply-chain.test.mjs` (17/17, incl. transient-retry and real-finding-fails-closed), eslint clean.
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate).
- Not run, and why: full local `check:stop-point` deferred to CI; change is isolated to the supply-chain network-retry path with direct unit coverage.

## Review Evidence

- Self-review: retry predicate matches only transport tokens; negative test proves a real audit finding is not retried and fails closed — no risk of swallowing a genuine vulnerability.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- If the registry is persistently down (both attempts fail), the gate still reds — intended (a persistent outage should surface, not be masked). Retry count stays at the existing 2 attempts; can be raised if blips exceed one retry.

## References

- Related: PR #1062 (concurrency cap), merge `1d921c9a` (topology + supply-chain timeout fix).

---

# 中文

## 概要

让 supply-chain 门对瞬时 npm registry 错误有韧性。`runNetworkCommand` 只在 `ETIMEDOUT` 时重试;`npm audit`/`npm sbom` 遇到瞬时 registry 错误(503/5xx/429/ECONNRESET/socket hang up)会以非零退出,直接被判硬失败、不重试——一个 registry blip 就把必需门弄红。实测:`phase=audit-2` 的 `npm audit` 返回 `503 Service Unavailable`,13.2s 硬红。

## 改动内容

- `tools/check-supply-chain.mjs`:新增 `isTransientRegistryError(output)`(按传输层 token 匹配:5xx/429、Service Unavailable、ECONNRESET/ETIMEDOUT/EAI_AGAIN/ENOTFOUND、socket hang up、"audit endpoint returned an error"、registry 请求失败)。非零退出且输出匹配时,在既有网络预算内重试而非硬失败。真实 `npm audit` 漏洞报告绝不含这些 token,所以真发现绝不会被误当瞬时错误。
- `tools/check-supply-chain.test.mjs`:给 mock npm 加"先失败后成功"模式,新增两个回归——瞬时 503 重试一次后通过;真发现 fail-closed 且不重试。

## 任务与范围

- 分支:`fix/ci-supply-chain-registry-retry`
- 公开范围:仅 supply-chain 检查的网络重试。
- 私有计划 / 证据是否已更新:不适用(wedge 类工作中浮现的独立 CI 稳定性缺陷)。
- 范围外:并发上限(PR #1062)、fast-contract 分片(已 hold)。

## 版本影响

- 版本:不改版本,仅 CI 检查行为。
- 发布影响:不发布。

## 治理声明

- 是否触碰 protected surface:no(`tools/check-supply-chain.mjs` 逻辑;不改 CI 拓扑 / gate manifest / mergify / 分支保护)。
- 依据:CI 稳定性缺陷(瞬时 npm registry 503 弄红必需门);不改门契约的 ADR/decision。
- 机器检查边界:本 PR 只声明该段存在;是否真实充分由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:`1d921c9a`
- 同步方式:从最新 main 切出
- 公开 diff 命令:`git diff main..HEAD`
- [x] `git diff --check`
- [x] 定向测试:`tools/check-supply-chain.test.mjs`(17/17,含瞬时重试与真发现 fail-closed),eslint 干净。
- [ ] GitHub Actions `rewrite-ci` 通过(权威全量门)。
- 未跑项及原因:完整本地 `check:stop-point` 推迟到 CI;改动隔离在 supply-chain 网络重试路径,有直接单测覆盖。

## 审查证据

- 自查:重试判据只匹配传输层 token;负向测试证明真 audit 发现不重试、fail-closed——无吞掉真漏洞的风险。
- 人工审查:待。
- 阻塞发现:无。

## 残余风险

- 若 registry 持续宕机(两次都失败),门仍会红——这是刻意的(持续故障应暴露而非掩盖)。重试次数保持既有 2 次;若 blip 超过一次重试可再调高。

## 关联材料

- 关联:PR #1062(并发上限)、merge `1d921c9a`(topology + supply-chain 超时修复)。
